### PR TITLE
Events/msgtype cleanup

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -490,7 +490,7 @@ func TestClient_WatchAllocs(t *testing.T) {
 	if err := state.UpsertJobSummary(101, mock.JobSummary(alloc1.JobID)); err != nil {
 		t.Fatal(err)
 	}
-	err := state.UpsertAllocs(102, []*structs.Allocation{alloc1, alloc2})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 102, []*structs.Allocation{alloc1, alloc2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -515,7 +515,7 @@ func TestClient_WatchAllocs(t *testing.T) {
 	// alloc runner.
 	alloc2_2 := alloc2.Copy()
 	alloc2_2.DesiredStatus = structs.AllocDesiredStatusStop
-	if err := state.UpsertAllocs(104, []*structs.Allocation{alloc2_2}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 104, []*structs.Allocation{alloc2_2}); err != nil {
 		t.Fatalf("err upserting stopped alloc: %v", err)
 	}
 
@@ -587,7 +587,7 @@ func TestClient_SaveRestoreState(t *testing.T) {
 	if err := state.UpsertJobSummary(101, mock.JobSummary(alloc1.JobID)); err != nil {
 		t.Fatal(err)
 	}
-	if err := state.UpsertAllocs(102, []*structs.Allocation{alloc1}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 102, []*structs.Allocation{alloc1}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -693,7 +693,7 @@ func TestClient_AddAllocError(t *testing.T) {
 	err = state.UpsertJobSummary(101, mock.JobSummary(alloc1.JobID))
 	require.Nil(err)
 
-	err = state.UpsertAllocs(102, []*structs.Allocation{alloc1})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 102, []*structs.Allocation{alloc1})
 	require.Nil(err)
 
 	// Push this alloc update to the client
@@ -795,7 +795,7 @@ func TestClient_BlockedAllocations(t *testing.T) {
 	}
 
 	state.UpsertJobSummary(99, mock.JobSummary(alloc.JobID))
-	state.UpsertAllocs(100, []*structs.Allocation{alloc})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc})
 
 	// Wait until the client downloads and starts the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -818,7 +818,7 @@ func TestClient_BlockedAllocations(t *testing.T) {
 	alloc2.Job = alloc.Job
 	alloc2.JobID = alloc.JobID
 	alloc2.PreviousAllocation = alloc.ID
-	if err := state.UpsertAllocs(200, []*structs.Allocation{alloc2}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 200, []*structs.Allocation{alloc2}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -839,7 +839,7 @@ func TestClient_BlockedAllocations(t *testing.T) {
 	// Change the desired state of the parent alloc to stop
 	alloc1 := alloc.Copy()
 	alloc1.DesiredStatus = structs.AllocDesiredStatusStop
-	if err := state.UpsertAllocs(300, []*structs.Allocation{alloc1}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 300, []*structs.Allocation{alloc1}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -484,7 +484,7 @@ func TestClient_WatchAllocs(t *testing.T) {
 	alloc2.Job = job
 
 	state := s1.State()
-	if err := state.UpsertJob(100, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.UpsertJobSummary(101, mock.JobSummary(alloc1.JobID)); err != nil {
@@ -581,7 +581,7 @@ func TestClient_SaveRestoreState(t *testing.T) {
 	alloc1.ClientStatus = structs.AllocClientStatusRunning
 
 	state := s1.State()
-	if err := state.UpsertJob(100, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.UpsertJobSummary(101, mock.JobSummary(alloc1.JobID)); err != nil {
@@ -687,7 +687,7 @@ func TestClient_AddAllocError(t *testing.T) {
 	alloc1.TaskResources = nil
 
 	state := s1.State()
-	err := state.UpsertJob(100, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
 	require.Nil(err)
 
 	err = state.UpsertJobSummary(101, mock.JobSummary(alloc1.JobID))

--- a/client/gc_test.go
+++ b/client/gc_test.go
@@ -383,7 +383,7 @@ func TestAllocGarbageCollector_MakeRoomFor_MaxAllocs(t *testing.T) {
 
 	upsertJobFn := func(server *nomad.Server, j *structs.Job) {
 		state := server.State()
-		require.NoError(state.UpsertJob(nextIndex(), j))
+		require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, nextIndex(), j))
 		require.NoError(state.UpsertJobSummary(nextIndex(), mock.JobSummary(j.ID)))
 	}
 

--- a/client/gc_test.go
+++ b/client/gc_test.go
@@ -392,7 +392,7 @@ func TestAllocGarbageCollector_MakeRoomFor_MaxAllocs(t *testing.T) {
 
 	upsertAllocFn := func(server *nomad.Server, a *structs.Allocation) {
 		state := server.State()
-		require.NoError(state.UpsertAllocs(nextIndex(), []*structs.Allocation{a}))
+		require.NoError(state.UpsertAllocs(structs.MsgTypeTestSetup, nextIndex(), []*structs.Allocation{a}))
 	}
 
 	upsertNewAllocFn := func(server *nomad.Server, j *structs.Job) *structs.Allocation {

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -43,8 +43,7 @@ func TestHTTP_AllocsList(t *testing.T) {
 
 		state.UpsertJobSummary(998, mock.JobSummary(alloc1.JobID))
 		state.UpsertJobSummary(999, mock.JobSummary(alloc2.JobID))
-		err := state.UpsertAllocs(1000,
-			[]*structs.Allocation{alloc1, alloc2})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1, alloc2})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -112,8 +111,7 @@ func TestHTTP_AllocsPrefixList(t *testing.T) {
 		if err := state.UpsertJobSummary(999, summary2); err != nil {
 			t.Fatal(err)
 		}
-		if err := state.UpsertAllocs(1000,
-			[]*structs.Allocation{alloc1, alloc2}); err != nil {
+		if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1, alloc2}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -167,8 +165,7 @@ func TestHTTP_AllocQuery(t *testing.T) {
 		if err := state.UpsertJobSummary(999, mock.JobSummary(alloc.JobID)); err != nil {
 			t.Fatal(err)
 		}
-		err := state.UpsertAllocs(1000,
-			[]*structs.Allocation{alloc})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -220,7 +217,7 @@ func TestHTTP_AllocQuery_Payload(t *testing.T) {
 		compressed := snappy.Encode(nil, expected)
 		alloc.Job.Payload = compressed
 
-		err := state.UpsertAllocs(1000, []*structs.Allocation{alloc})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -404,7 +401,7 @@ func TestHTTP_AllocStop(t *testing.T) {
 		require := require.New(t)
 		require.NoError(state.UpsertJobSummary(999, mock.JobSummary(alloc.JobID)))
 
-		require.NoError(state.UpsertAllocs(1000, []*structs.Allocation{alloc}))
+		require.NoError(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc}))
 
 		// Test that the happy path works
 		{
@@ -629,7 +626,7 @@ func TestHTTP_AllocSnapshot_Atomic(t *testing.T) {
 		}
 		alloc.NodeID = s.client.NodeID()
 		state.UpsertJobSummary(998, mock.JobSummary(alloc.JobID))
-		if err := state.UpsertAllocs(1000, []*structs.Allocation{alloc.Copy()}); err != nil {
+		if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc.Copy()}); err != nil {
 			t.Fatalf("error upserting alloc: %v", err)
 		}
 

--- a/command/agent/deployment_endpoint_test.go
+++ b/command/agent/deployment_endpoint_test.go
@@ -109,7 +109,7 @@ func TestHTTP_DeploymentAllocations(t *testing.T) {
 
 		assert.Nil(state.UpsertJob(998, j), "UpsertJob")
 		assert.Nil(state.UpsertDeployment(999, d), "UpsertDeployment")
-		assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a1, a2}), "UpsertAllocs")
+		assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a1, a2}), "UpsertAllocs")
 
 		// Make the HTTP request
 		req, err := http.NewRequest("GET", "/v1/deployment/allocations/"+d.ID, nil)
@@ -261,7 +261,7 @@ func TestHTTP_DeploymentAllocHealth(t *testing.T) {
 		a.DeploymentID = d.ID
 		assert.Nil(state.UpsertJob(998, j), "UpsertJob")
 		assert.Nil(state.UpsertDeployment(999, d), "UpsertDeployment")
-		assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a}), "UpsertAllocs")
+		assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a}), "UpsertAllocs")
 
 		// Create the pause request
 		args := structs.DeploymentAllocHealthRequest{

--- a/command/agent/deployment_endpoint_test.go
+++ b/command/agent/deployment_endpoint_test.go
@@ -107,7 +107,7 @@ func TestHTTP_DeploymentAllocations(t *testing.T) {
 		a2.TaskStates = make(map[string]*structs.TaskState)
 		a2.TaskStates["test"] = taskState2
 
-		assert.Nil(state.UpsertJob(998, j), "UpsertJob")
+		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
 		assert.Nil(state.UpsertDeployment(999, d), "UpsertDeployment")
 		assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a1, a2}), "UpsertAllocs")
 
@@ -174,7 +174,7 @@ func TestHTTP_DeploymentPause(t *testing.T) {
 		j := mock.Job()
 		d := mock.Deployment()
 		d.JobID = j.ID
-		assert.Nil(state.UpsertJob(999, j), "UpsertJob")
+		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
 		assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 		// Create the pause request
@@ -215,7 +215,7 @@ func TestHTTP_DeploymentPromote(t *testing.T) {
 		j := mock.Job()
 		d := mock.Deployment()
 		d.JobID = j.ID
-		assert.Nil(state.UpsertJob(999, j), "UpsertJob")
+		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
 		assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 		// Create the pause request
@@ -259,7 +259,7 @@ func TestHTTP_DeploymentAllocHealth(t *testing.T) {
 		a := mock.Alloc()
 		a.JobID = j.ID
 		a.DeploymentID = d.ID
-		assert.Nil(state.UpsertJob(998, j), "UpsertJob")
+		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
 		assert.Nil(state.UpsertDeployment(999, d), "UpsertDeployment")
 		assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -301,7 +301,7 @@ func TestHTTP_DeploymentFail(t *testing.T) {
 		j := mock.Job()
 		d := mock.Deployment()
 		d.JobID = j.ID
-		assert.Nil(state.UpsertJob(998, j), "UpsertJob")
+		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
 		assert.Nil(state.UpsertDeployment(999, d), "UpsertDeployment")
 
 		// Make the HTTP request

--- a/command/agent/eval_endpoint_test.go
+++ b/command/agent/eval_endpoint_test.go
@@ -16,8 +16,7 @@ func TestHTTP_EvalList(t *testing.T) {
 		state := s.Agent.server.State()
 		eval1 := mock.Eval()
 		eval2 := mock.Eval()
-		err := state.UpsertEvals(1000,
-			[]*structs.Evaluation{eval1, eval2})
+		err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1, eval2})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -63,8 +62,7 @@ func TestHTTP_EvalPrefixList(t *testing.T) {
 		eval1.ID = "aaabbbbb-e8f7-fd38-c855-ab94ceb89706"
 		eval2 := mock.Eval()
 		eval2.ID = "aaabbbbb-e8f7-fd38-c855-ab94ceb89706"
-		err := state.UpsertEvals(1000,
-			[]*structs.Evaluation{eval1, eval2})
+		err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1, eval2})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -160,7 +158,7 @@ func TestHTTP_EvalQuery(t *testing.T) {
 		// Directly manipulate the state
 		state := s.Agent.server.State()
 		eval := mock.Eval()
-		err := state.UpsertEvals(1000, []*structs.Evaluation{eval})
+		err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/command/agent/eval_endpoint_test.go
+++ b/command/agent/eval_endpoint_test.go
@@ -116,8 +116,7 @@ func TestHTTP_EvalAllocations(t *testing.T) {
 		alloc2.EvalID = alloc1.EvalID
 		state.UpsertJobSummary(998, mock.JobSummary(alloc1.JobID))
 		state.UpsertJobSummary(999, mock.JobSummary(alloc2.JobID))
-		err := state.UpsertAllocs(1000,
-			[]*structs.Allocation{alloc1, alloc2})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1, alloc2})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/command/agent/fs_endpoint_test.go
+++ b/command/agent/fs_endpoint_test.go
@@ -63,7 +63,7 @@ func addAllocToClient(agent *TestAgent, alloc *structs.Allocation, wait clientAl
 	// Upsert the allocation
 	state := agent.server.State()
 	require.Nil(state.UpsertJob(999, alloc.Job))
-	require.Nil(state.UpsertAllocs(1003, []*structs.Allocation{alloc}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{alloc}))
 
 	if wait == noWaitClientAlloc {
 		return

--- a/command/agent/fs_endpoint_test.go
+++ b/command/agent/fs_endpoint_test.go
@@ -62,7 +62,7 @@ func addAllocToClient(agent *TestAgent, alloc *structs.Allocation, wait clientAl
 
 	// Upsert the allocation
 	state := agent.server.State()
-	require.Nil(state.UpsertJob(999, alloc.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{alloc}))
 
 	if wait == noWaitClientAlloc {

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -407,7 +407,7 @@ func TestHTTP_JobQuery_Payload(t *testing.T) {
 
 		// Directly manipulate the state
 		state := s.Agent.server.State()
-		if err := state.UpsertJob(1000, job); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
 			t.Fatalf("Failed to upsert job: %v", err)
 		}
 

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -1007,7 +1007,7 @@ func TestHTTP_JobAllocations(t *testing.T) {
 		alloc1.TaskStates = make(map[string]*structs.TaskState)
 		alloc1.TaskStates["test"] = taskState
 		state := s.Agent.server.State()
-		err := state.UpsertAllocs(1000, []*structs.Allocation{alloc1})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/command/agent/node_endpoint_test.go
+++ b/command/agent/node_endpoint_test.go
@@ -139,7 +139,7 @@ func TestHTTP_NodeForceEval(t *testing.T) {
 		if err := state.UpsertJobSummary(999, mock.JobSummary(alloc1.JobID)); err != nil {
 			t.Fatal(err)
 		}
-		err := state.UpsertAllocs(1000, []*structs.Allocation{alloc1})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -199,7 +199,7 @@ func TestHTTP_NodeAllocations(t *testing.T) {
 		alloc1.TaskStates = make(map[string]*structs.TaskState)
 		alloc1.TaskStates["test"] = taskState
 
-		err := state.UpsertAllocs(1000, []*structs.Allocation{alloc1})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -387,7 +387,7 @@ func TestHTTP_NodePurge(t *testing.T) {
 		if err := state.UpsertJobSummary(999, mock.JobSummary(alloc1.JobID)); err != nil {
 			t.Fatal(err)
 		}
-		err := state.UpsertAllocs(1000, []*structs.Allocation{alloc1})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/command/agent/search_endpoint_test.go
+++ b/command/agent/search_endpoint_test.go
@@ -215,7 +215,7 @@ func TestHTTP_Search_Nodes(t *testing.T) {
 	httpTest(t, nil, func(s *TestAgent) {
 		state := s.Agent.server.State()
 		node := mock.Node()
-		err := state.UpsertNode(6000, node)
+		err := state.UpsertNode(structs.MsgTypeTestSetup, node, 6000)
 		assert.Nil(err)
 
 		prefix := node.ID[:len(node.ID)-2]

--- a/command/agent/search_endpoint_test.go
+++ b/command/agent/search_endpoint_test.go
@@ -182,7 +182,7 @@ func TestHTTP_Search_Allocations(t *testing.T) {
 	httpTest(t, nil, func(s *TestAgent) {
 		state := s.Agent.server.State()
 		alloc := mock.Alloc()
-		err := state.UpsertAllocs(7000, []*structs.Allocation{alloc})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 7000, []*structs.Allocation{alloc})
 		assert.Nil(err)
 
 		prefix := alloc.ID[:len(alloc.ID)-2]

--- a/command/agent/search_endpoint_test.go
+++ b/command/agent/search_endpoint_test.go
@@ -31,7 +31,7 @@ func createJobForTest(jobID string, s *TestAgent, t *testing.T) {
 	job.TaskGroups[0].Count = 1
 
 	state := s.Agent.server.State()
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	assert.Nil(err)
 }
 
@@ -147,8 +147,7 @@ func TestHTTP_Search_Evaluation(t *testing.T) {
 		state := s.Agent.server.State()
 		eval1 := mock.Eval()
 		eval2 := mock.Eval()
-		err := state.UpsertEvals(9000,
-			[]*structs.Evaluation{eval1, eval2})
+		err := state.UpsertEvals(structs.MsgTypeTestSetup, 9000, []*structs.Evaluation{eval1, eval2})
 		assert.Nil(err)
 
 		prefix := eval1.ID[:len(eval1.ID)-2]
@@ -307,7 +306,7 @@ func TestHTTP_Search_AllContext(t *testing.T) {
 		state := s.Agent.server.State()
 		eval1 := mock.Eval()
 		eval1.ID = testJobID
-		err := state.UpsertEvals(8000, []*structs.Evaluation{eval1})
+		err := state.UpsertEvals(structs.MsgTypeTestSetup, 8000, []*structs.Evaluation{eval1})
 		assert.Nil(err)
 
 		data := structs.SearchRequest{Prefix: testJobPrefix, Context: structs.All}

--- a/command/agent/search_endpoint_test.go
+++ b/command/agent/search_endpoint_test.go
@@ -214,7 +214,7 @@ func TestHTTP_Search_Nodes(t *testing.T) {
 	httpTest(t, nil, func(s *TestAgent) {
 		state := s.Agent.server.State()
 		node := mock.Node()
-		err := state.UpsertNode(structs.MsgTypeTestSetup, node, 6000)
+		err := state.UpsertNode(structs.MsgTypeTestSetup, 6000, node)
 		assert.Nil(err)
 
 		prefix := node.ID[:len(node.ID)-2]

--- a/command/alloc_exec_test.go
+++ b/command/alloc_exec_test.go
@@ -145,7 +145,7 @@ func TestAllocExecCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake alloc
 	state := srv.Agent.Server().State()
 	a := mock.Alloc()
-	assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a}))
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a}))
 
 	prefix := a.ID[:5]
 	args := complete.Args{Last: prefix}

--- a/command/alloc_fs_test.go
+++ b/command/alloc_fs_test.go
@@ -100,7 +100,7 @@ func TestFSCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake alloc
 	state := srv.Agent.Server().State()
 	a := mock.Alloc()
-	assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a}))
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a}))
 
 	prefix := a.ID[:5]
 	args := complete.Args{Last: prefix}

--- a/command/alloc_logs_test.go
+++ b/command/alloc_logs_test.go
@@ -82,7 +82,7 @@ func TestLogsCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake alloc
 	state := srv.Agent.Server().State()
 	a := mock.Alloc()
-	assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a}))
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a}))
 
 	prefix := a.ID[:5]
 	args := complete.Args{Last: prefix}

--- a/command/alloc_restart_test.go
+++ b/command/alloc_restart_test.go
@@ -163,7 +163,7 @@ func TestAllocRestartCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake alloc
 	state := srv.Agent.Server().State()
 	a := mock.Alloc()
-	assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a}))
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a}))
 
 	prefix := a.ID[:5]
 	args := complete.Args{Last: prefix}

--- a/command/alloc_signal_test.go
+++ b/command/alloc_signal_test.go
@@ -68,7 +68,7 @@ func TestAllocSignalCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake alloc
 	state := srv.Agent.Server().State()
 	a := mock.Alloc()
-	assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a}))
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a}))
 
 	prefix := a.ID[:5]
 	args := complete.Args{All: []string{"signal", prefix}, Last: prefix}

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -138,7 +138,7 @@ func TestAllocStatusCommand_LifecycleInfo(t *testing.T) {
 		"prestart_sidecar": &structs.TaskState{State: "running"},
 	}
 
-	require.Nil(t, state.UpsertAllocs(1000, []*structs.Allocation{a}))
+	require.Nil(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a}))
 
 	if code := cmd.Run([]string{"-address=" + url, a.ID}); code != 0 {
 		t.Fatalf("expected exit 0, got: %d", code)
@@ -286,7 +286,7 @@ func TestAllocStatusCommand_RescheduleInfo(t *testing.T) {
 			},
 		},
 	}
-	require.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a}))
 
 	if code := cmd.Run([]string{"-address=" + url, a.ID}); code != 0 {
 		t.Fatalf("expected exit 0, got: %d", code)
@@ -343,7 +343,7 @@ func TestAllocStatusCommand_ScoreMetrics(t *testing.T) {
 			},
 		},
 	}
-	require.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a}))
 
 	if code := cmd.Run([]string{"-address=" + url, "-verbose", a.ID}); code != 0 {
 		t.Fatalf("expected exit 0, got: %d", code)
@@ -371,7 +371,7 @@ func TestAllocStatusCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake alloc
 	state := srv.Agent.Server().State()
 	a := mock.Alloc()
-	assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a}))
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a}))
 
 	prefix := a.ID[:5]
 	args := complete.Args{Last: prefix}
@@ -437,7 +437,7 @@ func TestAllocStatusCommand_HostVolumes(t *testing.T) {
 	}
 	summary := mock.JobSummary(alloc.JobID)
 	require.NoError(t, state.UpsertJobSummary(1004, summary))
-	require.NoError(t, state.UpsertAllocs(1005, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1005, []*structs.Allocation{alloc}))
 
 	ui := cli.NewMockUi()
 	cmd := &AllocStatusCommand{Meta: Meta{Ui: ui}}
@@ -512,7 +512,7 @@ func TestAllocStatusCommand_CSIVolumes(t *testing.T) {
 	}
 	summary := mock.JobSummary(alloc.JobID)
 	require.NoError(t, state.UpsertJobSummary(1004, summary))
-	require.NoError(t, state.UpsertAllocs(1005, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1005, []*structs.Allocation{alloc}))
 
 	ui := cli.NewMockUi()
 	cmd := &AllocStatusCommand{Meta: Meta{Ui: ui}}

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -466,7 +466,7 @@ func TestAllocStatusCommand_CSIVolumes(t *testing.T) {
 			NodeInfo: &structs.CSINodeInfo{},
 		},
 	}
-	err := state.UpsertNode(1001, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1001)
 	require.NoError(t, err)
 
 	vols := []*structs.CSIVolume{{

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -466,7 +466,7 @@ func TestAllocStatusCommand_CSIVolumes(t *testing.T) {
 			NodeInfo: &structs.CSINodeInfo{},
 		},
 	}
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1001)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 1001, node)
 	require.NoError(t, err)
 
 	vols := []*structs.CSIVolume{{

--- a/command/eval_status_test.go
+++ b/command/eval_status_test.go
@@ -74,7 +74,7 @@ func TestEvalStatusCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake eval
 	state := srv.Agent.Server().State()
 	e := mock.Eval()
-	assert.Nil(state.UpsertEvals(1000, []*structs.Evaluation{e}))
+	assert.Nil(state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{e}))
 
 	prefix := e.ID[:5]
 	args := complete.Args{Last: prefix}

--- a/command/job_deployments_test.go
+++ b/command/job_deployments_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/structs"
+
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
@@ -55,7 +57,7 @@ func TestJobDeploymentsCommand_Run(t *testing.T) {
 	// Create a job without a deployment
 	job := mock.Job()
 	state := srv.Agent.Server().State()
-	assert.Nil(state.UpsertJob(100, job))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 100, job))
 
 	// Should display no match if the job doesn't have deployments
 	if code := cmd.Run([]string{"-address=" + url, job.ID}); code != 0 {
@@ -99,7 +101,7 @@ func TestJobDeploymentsCommand_Run_Latest(t *testing.T) {
 	// Create a job without a deployment
 	job := mock.Job()
 	state := srv.Agent.Server().State()
-	assert.Nil(state.UpsertJob(100, job))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 100, job))
 
 	// Should display no match if the job doesn't have deployments
 	if code := cmd.Run([]string{"-address=" + url, "-latest", job.ID}); code != 0 {
@@ -139,7 +141,7 @@ func TestJobDeploymentsCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}

--- a/command/job_dispatch_test.go
+++ b/command/job_dispatch_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	structs2 "github.com/hashicorp/nomad/nomad/structs"
 	"strings"
 	"testing"
 
@@ -60,7 +61,7 @@ func TestJobDispatchCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(1000, j))
+	assert.Nil(state.UpsertJob(structs2.MsgTypeTestSetup, 1000, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}

--- a/command/job_dispatch_test.go
+++ b/command/job_dispatch_test.go
@@ -1,9 +1,10 @@
 package command
 
 import (
-	structs2 "github.com/hashicorp/nomad/nomad/structs"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/nomad/nomad/structs"
 
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
@@ -61,7 +62,7 @@ func TestJobDispatchCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(structs2.MsgTypeTestSetup, 1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}

--- a/command/job_eval_test.go
+++ b/command/job_eval_test.go
@@ -74,7 +74,7 @@ func TestJobEvalCommand_Run(t *testing.T) {
 
 	// Create a job
 	job := mock.Job()
-	err := state.UpsertJob(11, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 11, job)
 	require.Nil(err)
 
 	job, err = state.JobByID(nil, structs.DefaultNamespace, job.ID)
@@ -115,7 +115,7 @@ func TestJobEvalCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}

--- a/command/job_eval_test.go
+++ b/command/job_eval_test.go
@@ -87,7 +87,7 @@ func TestJobEvalCommand_Run(t *testing.T) {
 	alloc.TaskGroup = job.TaskGroups[0].Name
 	alloc.Namespace = job.Namespace
 	alloc.ClientStatus = structs.AllocClientStatusFailed
-	err = state.UpsertAllocs(12, []*structs.Allocation{alloc})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 12, []*structs.Allocation{alloc})
 	require.Nil(err)
 
 	if code := cmd.Run([]string{"-address=" + url, "-force-reschedule", "-detach", job.ID}); code != 0 {

--- a/command/job_history_test.go
+++ b/command/job_history_test.go
@@ -1,9 +1,10 @@
 package command
 
 import (
-	structs2 "github.com/hashicorp/nomad/nomad/structs"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/nomad/nomad/structs"
 
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
@@ -52,7 +53,7 @@ func TestJobHistoryCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(structs2.MsgTypeTestSetup, 1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}

--- a/command/job_history_test.go
+++ b/command/job_history_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	structs2 "github.com/hashicorp/nomad/nomad/structs"
 	"strings"
 	"testing"
 
@@ -51,7 +52,7 @@ func TestJobHistoryCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(1000, j))
+	assert.Nil(state.UpsertJob(structs2.MsgTypeTestSetup, 1000, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}

--- a/command/job_inspect_test.go
+++ b/command/job_inspect_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
 	"github.com/stretchr/testify/assert"
@@ -71,7 +72,7 @@ func TestInspectCommand_AutocompleteArgs(t *testing.T) {
 
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}

--- a/command/job_periodic_force_test.go
+++ b/command/job_periodic_force_test.go
@@ -49,7 +49,7 @@ func TestJobPeriodicForceCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job, not periodic
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	require.NoError(t, state.UpsertJob(1000, j))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
 
 	predictor := cmd.AutocompleteArgs()
 
@@ -66,7 +66,7 @@ func TestJobPeriodicForceCommand_AutocompleteArgs(t *testing.T) {
 		ProhibitOverlap: true,
 		TimeZone:        "test zone",
 	}
-	require.NoError(t, state.UpsertJob(1000, j2))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, j2))
 
 	res = predictor.Predict(complete.Args{Last: j2.ID[:len(j.ID)-5]})
 	require.Equal(t, []string{j2.ID}, res)

--- a/command/job_promote_test.go
+++ b/command/job_promote_test.go
@@ -1,9 +1,10 @@
 package command
 
 import (
-	structs2 "github.com/hashicorp/nomad/nomad/structs"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/nomad/nomad/structs"
 
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/mitchellh/cli"
@@ -52,7 +53,7 @@ func TestJobPromoteCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(structs2.MsgTypeTestSetup, 1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}

--- a/command/job_promote_test.go
+++ b/command/job_promote_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	structs2 "github.com/hashicorp/nomad/nomad/structs"
 	"strings"
 	"testing"
 
@@ -51,7 +52,7 @@ func TestJobPromoteCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(1000, j))
+	assert.Nil(state.UpsertJob(structs2.MsgTypeTestSetup, 1000, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}

--- a/command/job_revert_test.go
+++ b/command/job_revert_test.go
@@ -1,11 +1,11 @@
 package command
 
 import (
-	structs2 "github.com/hashicorp/nomad/nomad/structs"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/nomad/mock"
+	structs "github.com/hashicorp/nomad/nomad/structs"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
 	"github.com/stretchr/testify/assert"
@@ -52,7 +52,7 @@ func TestJobRevertCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(structs2.MsgTypeTestSetup, 1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}

--- a/command/job_revert_test.go
+++ b/command/job_revert_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	structs2 "github.com/hashicorp/nomad/nomad/structs"
 	"strings"
 	"testing"
 
@@ -51,7 +52,7 @@ func TestJobRevertCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(1000, j))
+	assert.Nil(state.UpsertJob(structs2.MsgTypeTestSetup, 1000, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}

--- a/command/job_status_test.go
+++ b/command/job_status_test.go
@@ -374,7 +374,7 @@ func TestJobStatusCommand_RescheduleEvals(t *testing.T) {
 	a.Metrics = &structs.AllocMetric{}
 	a.DesiredStatus = structs.AllocDesiredStatusRun
 	a.ClientStatus = structs.AllocClientStatusRunning
-	require.Nil(state.UpsertAllocs(1000, []*structs.Allocation{a}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a}))
 
 	// Query jobs with prefix match
 	if code := cmd.Run([]string{"-address=" + url, j.ID}); code != 0 {

--- a/command/job_status_test.go
+++ b/command/job_status_test.go
@@ -254,7 +254,7 @@ func TestJobStatusCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}
@@ -361,11 +361,11 @@ func TestJobStatusCommand_RescheduleEvals(t *testing.T) {
 
 	// Create state store objects for job, alloc and followup eval with a future WaitUntil value
 	j := mock.Job()
-	require.Nil(state.UpsertJob(900, j))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 900, j))
 
 	e := mock.Eval()
 	e.WaitUntil = time.Now().Add(1 * time.Hour)
-	require.Nil(state.UpsertEvals(902, []*structs.Evaluation{e}))
+	require.Nil(state.UpsertEvals(structs.MsgTypeTestSetup, 902, []*structs.Evaluation{e}))
 	a := mock.Alloc()
 	a.Job = j
 	a.JobID = j.ID

--- a/command/job_stop_test.go
+++ b/command/job_stop_test.go
@@ -1,11 +1,11 @@
 package command
 
 import (
-	structs2 "github.com/hashicorp/nomad/nomad/structs"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
 	"github.com/stretchr/testify/assert"
@@ -64,7 +64,7 @@ func TestStopCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(structs2.MsgTypeTestSetup, 1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}

--- a/command/job_stop_test.go
+++ b/command/job_stop_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	structs2 "github.com/hashicorp/nomad/nomad/structs"
 	"strings"
 	"testing"
 
@@ -63,7 +64,7 @@ func TestStopCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(1000, j))
+	assert.Nil(state.UpsertJob(structs2.MsgTypeTestSetup, 1000, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}

--- a/command/status_test.go
+++ b/command/status_test.go
@@ -26,7 +26,7 @@ func TestStatusCommand_Run_JobStatus(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
 
 	// Query to check the job status
 	if code := cmd.Run([]string{"-address=" + url, j.ID}); code != 0 {
@@ -54,8 +54,8 @@ func TestStatusCommand_Run_JobStatus_MultiMatch(t *testing.T) {
 	j := mock.Job()
 	j2 := mock.Job()
 	j2.ID = fmt.Sprintf("%s-more", j.ID)
-	assert.Nil(state.UpsertJob(1000, j))
-	assert.Nil(state.UpsertJob(1001, j2))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1001, j2))
 
 	// Query to check the job status
 	if code := cmd.Run([]string{"-address=" + url, j.ID}); code != 0 {
@@ -81,7 +81,7 @@ func TestStatusCommand_Run_EvalStatus(t *testing.T) {
 	// Create a fake eval
 	state := srv.Agent.Server().State()
 	eval := mock.Eval()
-	assert.Nil(state.UpsertEvals(1000, []*structs.Evaluation{eval}))
+	assert.Nil(state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval}))
 
 	// Query to check the eval status
 	if code := cmd.Run([]string{"-address=" + url, eval.ID}); code != 0 {
@@ -198,7 +198,7 @@ func TestStatusCommand_Run_NoPrefix(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	job := mock.Job()
-	assert.Nil(state.UpsertJob(1000, job))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, job))
 
 	// Query to check status
 	if code := cmd.Run([]string{"-address=" + url}); code != 0 {
@@ -224,7 +224,7 @@ func TestStatusCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	job := mock.Job()
-	assert.Nil(state.UpsertJob(1000, job))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, job))
 
 	prefix := job.ID[:len(job.ID)-5]
 	args := complete.Args{Last: prefix}

--- a/command/status_test.go
+++ b/command/status_test.go
@@ -147,7 +147,7 @@ func TestStatusCommand_Run_AllocStatus(t *testing.T) {
 	// Create a fake alloc
 	state := srv.Agent.Server().State()
 	alloc := mock.Alloc()
-	assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{alloc}))
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc}))
 
 	if code := cmd.Run([]string{"-address=" + url, alloc.ID}); code != 0 {
 		t.Fatalf("expected exit 0, got: %d", code)

--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -494,7 +494,7 @@ func TestAllocEndpoint_GetAlloc_ACL(t *testing.T) {
 			Name: "valid-node-secret",
 			F: func(t *testing.T) {
 				node := mock.Node()
-				assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1005))
+				assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1005, node))
 				get := getReq()
 				get.AuthToken = node.SecretID
 				get.AllocID = alloc.ID

--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -494,7 +494,7 @@ func TestAllocEndpoint_GetAlloc_ACL(t *testing.T) {
 			Name: "valid-node-secret",
 			F: func(t *testing.T) {
 				node := mock.Node()
-				assert.Nil(state.UpsertNode(1005, node))
+				assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1005))
 				get := getReq()
 				get.AuthToken = node.SecretID
 				get.AllocID = alloc.ID

--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -33,7 +33,7 @@ func TestAllocEndpoint_List(t *testing.T) {
 	if err := state.UpsertJobSummary(999, summary); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := state.UpsertAllocs(1000, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -97,7 +97,7 @@ func TestAllocEndpoint_List_Fields(t *testing.T) {
 	state := s1.fsm.State()
 
 	require.NoError(t, state.UpsertJobSummary(999, summary))
-	require.NoError(t, state.UpsertAllocs(1000, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc}))
 
 	cases := []struct {
 		Name   string
@@ -192,7 +192,7 @@ func TestAllocEndpoint_List_ACL(t *testing.T) {
 	state := s1.fsm.State()
 
 	assert.Nil(state.UpsertJobSummary(999, summary), "UpsertJobSummary")
-	assert.Nil(state.UpsertAllocs(1000, allocs), "UpsertAllocs")
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, allocs), "UpsertAllocs")
 
 	stubAllocs := []*structs.AllocListStub{alloc.Stub(nil)}
 	stubAllocs[0].CreateIndex = 1000
@@ -251,7 +251,7 @@ func TestAllocEndpoint_List_Blocking(t *testing.T) {
 	}
 	// Upsert alloc triggers watches
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.UpsertAllocs(2, []*structs.Allocation{alloc}); err != nil {
+		if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 2, []*structs.Allocation{alloc}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -326,7 +326,7 @@ func TestAllocEndpoint_List_AllNamespaces_OSS(t *testing.T) {
 
 	err := state.UpsertJobSummary(999, summary)
 	require.NoError(t, err)
-	err = state.UpsertAllocs(1000, []*structs.Allocation{alloc})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc})
 	require.NoError(t, err)
 
 	t.Run("looking up all allocations", func(t *testing.T) {
@@ -405,7 +405,7 @@ func TestAllocEndpoint_GetAlloc(t *testing.T) {
 	}
 	state := s1.fsm.State()
 	state.UpsertJobSummary(999, mock.JobSummary(alloc.JobID))
-	err := state.UpsertAllocs(1000, []*structs.Allocation{alloc})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -444,7 +444,7 @@ func TestAllocEndpoint_GetAlloc_ACL(t *testing.T) {
 	state := s1.fsm.State()
 
 	assert.Nil(state.UpsertJobSummary(999, summary), "UpsertJobSummary")
-	assert.Nil(state.UpsertAllocs(1000, allocs), "UpsertAllocs")
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, allocs), "UpsertAllocs")
 
 	// Create the namespace policy and tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid",
@@ -555,7 +555,7 @@ func TestAllocEndpoint_GetAlloc_Blocking(t *testing.T) {
 	// First create an unrelated alloc
 	time.AfterFunc(100*time.Millisecond, func() {
 		state.UpsertJobSummary(99, mock.JobSummary(alloc1.JobID))
-		err := state.UpsertAllocs(100, []*structs.Allocation{alloc1})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc1})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -564,7 +564,7 @@ func TestAllocEndpoint_GetAlloc_Blocking(t *testing.T) {
 	// Create the alloc we are watching later
 	time.AfterFunc(200*time.Millisecond, func() {
 		state.UpsertJobSummary(199, mock.JobSummary(alloc2.JobID))
-		err := state.UpsertAllocs(200, []*structs.Allocation{alloc2})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 200, []*structs.Allocation{alloc2})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -609,7 +609,7 @@ func TestAllocEndpoint_GetAllocs(t *testing.T) {
 	state := s1.fsm.State()
 	state.UpsertJobSummary(998, mock.JobSummary(alloc.JobID))
 	state.UpsertJobSummary(999, mock.JobSummary(alloc2.JobID))
-	err := state.UpsertAllocs(1000, []*structs.Allocation{alloc, alloc2})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc, alloc2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -659,7 +659,7 @@ func TestAllocEndpoint_GetAllocs_Blocking(t *testing.T) {
 	// First create an unrelated alloc
 	time.AfterFunc(100*time.Millisecond, func() {
 		state.UpsertJobSummary(99, mock.JobSummary(alloc1.JobID))
-		err := state.UpsertAllocs(100, []*structs.Allocation{alloc1})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc1})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -668,7 +668,7 @@ func TestAllocEndpoint_GetAllocs_Blocking(t *testing.T) {
 	// Create the alloc we are watching later
 	time.AfterFunc(200*time.Millisecond, func() {
 		state.UpsertJobSummary(199, mock.JobSummary(alloc2.JobID))
-		err := state.UpsertAllocs(200, []*structs.Allocation{alloc2})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 200, []*structs.Allocation{alloc2})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -714,7 +714,7 @@ func TestAllocEndpoint_UpdateDesiredTransition(t *testing.T) {
 	state := s1.fsm.State()
 	require.Nil(state.UpsertJobSummary(998, mock.JobSummary(alloc.JobID)))
 	require.Nil(state.UpsertJobSummary(999, mock.JobSummary(alloc2.JobID)))
-	require.Nil(state.UpsertAllocs(1000, []*structs.Allocation{alloc, alloc2}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc, alloc2}))
 
 	t1 := &structs.DesiredTransition{
 		Migrate: helper.BoolToPtr(true),
@@ -798,7 +798,7 @@ func TestAllocEndpoint_Stop_ACL(t *testing.T) {
 	state := s1.fsm.State()
 	require.Nil(state.UpsertJobSummary(998, mock.JobSummary(alloc.JobID)))
 	require.Nil(state.UpsertJobSummary(999, mock.JobSummary(alloc2.JobID)))
-	require.Nil(state.UpsertAllocs(1000, []*structs.Allocation{alloc, alloc2}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc, alloc2}))
 
 	req := &structs.AllocStopRequest{
 		AllocID: alloc.ID,

--- a/nomad/client_alloc_endpoint_test.go
+++ b/nomad/client_alloc_endpoint_test.go
@@ -324,7 +324,7 @@ func TestClientAllocations_GarbageCollect_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(999, a.Job))
+	require.Nil(state.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -382,7 +382,7 @@ func TestClientAllocations_GarbageCollect_Local_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(nstructs.MsgTypeTestSetup, 1010, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
@@ -492,9 +492,9 @@ func TestClientAllocations_GarbageCollect_Remote(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(999, a.Job))
+	require.Nil(state1.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state1.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
-	require.Nil(state2.UpsertJob(999, a.Job))
+	require.Nil(state2.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state2.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -613,7 +613,7 @@ func TestClientAllocations_Stats_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(999, a.Job))
+	require.Nil(state.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -672,7 +672,7 @@ func TestClientAllocations_Stats_Local_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(nstructs.MsgTypeTestSetup, 1010, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
@@ -769,9 +769,9 @@ func TestClientAllocations_Stats_Remote(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(999, a.Job))
+	require.Nil(state1.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state1.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
-	require.Nil(state2.UpsertJob(999, a.Job))
+	require.Nil(state2.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state2.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -853,7 +853,7 @@ func TestClientAllocations_Restart_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(999, a.Job))
+	require.Nil(state.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -967,9 +967,9 @@ func TestClientAllocations_Restart_Remote(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(999, a.Job))
+	require.Nil(state1.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state1.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
-	require.Nil(state2.UpsertJob(999, a.Job))
+	require.Nil(state2.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state2.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -1026,7 +1026,7 @@ func TestClientAllocations_Restart_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(nstructs.MsgTypeTestSetup, 1010, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
@@ -1134,10 +1134,10 @@ func TestAlloc_ExecStreaming(t *testing.T) {
 
 	// Upsert the allocation
 	localState := localServer.State()
-	require.Nil(t, localState.UpsertJob(999, a.Job))
+	require.Nil(t, localState.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(t, localState.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 	remoteState := remoteServer.State()
-	require.Nil(t, remoteState.UpsertJob(999, a.Job))
+	require.Nil(t, remoteState.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(t, remoteState.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation

--- a/nomad/client_alloc_endpoint_test.go
+++ b/nomad/client_alloc_endpoint_test.go
@@ -162,7 +162,7 @@ func TestClientAllocations_GarbageCollectAll_OldNode(t *testing.T) {
 	// Test for an old version error
 	node := mock.Node()
 	node.Attributes["nomad.version"] = "0.7.1"
-	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, node, 1005))
+	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, 1005, node))
 
 	req := &structs.NodeSpecificRequest{
 		NodeID:       node.ID,
@@ -175,7 +175,7 @@ func TestClientAllocations_GarbageCollectAll_OldNode(t *testing.T) {
 
 	// Test for a missing version error
 	delete(node.Attributes, "nomad.version")
-	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, node, 1006))
+	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, 1006, node))
 
 	err = msgpackrpc.CallWithCodec(codec, "ClientAllocations.GarbageCollectAll", req, &resp)
 	require.True(structs.IsErrUnknownNomadVersion(err))
@@ -255,7 +255,7 @@ func TestClientAllocations_GarbageCollect_OldNode(t *testing.T) {
 	// Test for an old version error
 	node := mock.Node()
 	node.Attributes["nomad.version"] = "0.7.1"
-	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, node, 1005))
+	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, 1005, node))
 
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
@@ -275,7 +275,7 @@ func TestClientAllocations_GarbageCollect_OldNode(t *testing.T) {
 
 	// Test for a missing version error
 	delete(node.Attributes, "nomad.version")
-	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, node, 1007))
+	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, 1007, node))
 
 	err = msgpackrpc.CallWithCodec(codec, "ClientAllocations.GarbageCollect", req, &resp)
 	require.True(structs.IsErrUnknownNomadVersion(err), err.Error())
@@ -546,7 +546,7 @@ func TestClientAllocations_Stats_OldNode(t *testing.T) {
 	// Test for an old version error
 	node := mock.Node()
 	node.Attributes["nomad.version"] = "0.7.1"
-	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, node, 1005))
+	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, 1005, node))
 
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
@@ -565,7 +565,7 @@ func TestClientAllocations_Stats_OldNode(t *testing.T) {
 
 	// Test for a missing version error
 	delete(node.Attributes, "nomad.version")
-	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, node, 1007))
+	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, 1007, node))
 
 	err = msgpackrpc.CallWithCodec(codec, "ClientAllocations.Stats", req, &resp)
 	require.True(structs.IsErrUnknownNomadVersion(err), err.Error())

--- a/nomad/client_alloc_endpoint_test.go
+++ b/nomad/client_alloc_endpoint_test.go
@@ -162,7 +162,7 @@ func TestClientAllocations_GarbageCollectAll_OldNode(t *testing.T) {
 	// Test for an old version error
 	node := mock.Node()
 	node.Attributes["nomad.version"] = "0.7.1"
-	require.Nil(state.UpsertNode(1005, node))
+	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, node, 1005))
 
 	req := &structs.NodeSpecificRequest{
 		NodeID:       node.ID,
@@ -175,7 +175,7 @@ func TestClientAllocations_GarbageCollectAll_OldNode(t *testing.T) {
 
 	// Test for a missing version error
 	delete(node.Attributes, "nomad.version")
-	require.Nil(state.UpsertNode(1006, node))
+	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, node, 1006))
 
 	err = msgpackrpc.CallWithCodec(codec, "ClientAllocations.GarbageCollectAll", req, &resp)
 	require.True(structs.IsErrUnknownNomadVersion(err))
@@ -255,7 +255,7 @@ func TestClientAllocations_GarbageCollect_OldNode(t *testing.T) {
 	// Test for an old version error
 	node := mock.Node()
 	node.Attributes["nomad.version"] = "0.7.1"
-	require.Nil(state.UpsertNode(1005, node))
+	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, node, 1005))
 
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
@@ -275,7 +275,7 @@ func TestClientAllocations_GarbageCollect_OldNode(t *testing.T) {
 
 	// Test for a missing version error
 	delete(node.Attributes, "nomad.version")
-	require.Nil(state.UpsertNode(1007, node))
+	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, node, 1007))
 
 	err = msgpackrpc.CallWithCodec(codec, "ClientAllocations.GarbageCollect", req, &resp)
 	require.True(structs.IsErrUnknownNomadVersion(err), err.Error())
@@ -546,7 +546,7 @@ func TestClientAllocations_Stats_OldNode(t *testing.T) {
 	// Test for an old version error
 	node := mock.Node()
 	node.Attributes["nomad.version"] = "0.7.1"
-	require.Nil(state.UpsertNode(1005, node))
+	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, node, 1005))
 
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
@@ -565,7 +565,7 @@ func TestClientAllocations_Stats_OldNode(t *testing.T) {
 
 	// Test for a missing version error
 	delete(node.Attributes, "nomad.version")
-	require.Nil(state.UpsertNode(1007, node))
+	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, node, 1007))
 
 	err = msgpackrpc.CallWithCodec(codec, "ClientAllocations.Stats", req, &resp)
 	require.True(structs.IsErrUnknownNomadVersion(err), err.Error())

--- a/nomad/client_alloc_endpoint_test.go
+++ b/nomad/client_alloc_endpoint_test.go
@@ -259,7 +259,7 @@ func TestClientAllocations_GarbageCollect_OldNode(t *testing.T) {
 
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
-	require.Nil(state.UpsertAllocs(1006, []*structs.Allocation{alloc}))
+	require.Nil(state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1006, []*structs.Allocation{alloc}))
 
 	req := &structs.AllocSpecificRequest{
 		AllocID: alloc.ID,
@@ -325,7 +325,7 @@ func TestClientAllocations_GarbageCollect_Local(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	require.Nil(state.UpsertJob(999, a.Job))
-	require.Nil(state.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -383,7 +383,7 @@ func TestClientAllocations_GarbageCollect_Local_ACL(t *testing.T) {
 	state := s.State()
 	alloc := mock.Alloc()
 	require.NoError(t, state.UpsertJob(1010, alloc.Job))
-	require.NoError(t, state.UpsertAllocs(1011, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
 		Name          string
@@ -493,9 +493,9 @@ func TestClientAllocations_GarbageCollect_Remote(t *testing.T) {
 	state1 := s1.State()
 	state2 := s2.State()
 	require.Nil(state1.UpsertJob(999, a.Job))
-	require.Nil(state1.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state1.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 	require.Nil(state2.UpsertJob(999, a.Job))
-	require.Nil(state2.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state2.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -550,7 +550,7 @@ func TestClientAllocations_Stats_OldNode(t *testing.T) {
 
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
-	require.Nil(state.UpsertAllocs(1006, []*structs.Allocation{alloc}))
+	require.Nil(state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1006, []*structs.Allocation{alloc}))
 
 	req := &structs.AllocSpecificRequest{
 		AllocID: alloc.ID,
@@ -614,7 +614,7 @@ func TestClientAllocations_Stats_Local(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	require.Nil(state.UpsertJob(999, a.Job))
-	require.Nil(state.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -673,7 +673,7 @@ func TestClientAllocations_Stats_Local_ACL(t *testing.T) {
 	state := s.State()
 	alloc := mock.Alloc()
 	require.NoError(t, state.UpsertJob(1010, alloc.Job))
-	require.NoError(t, state.UpsertAllocs(1011, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
 		Name          string
@@ -770,9 +770,9 @@ func TestClientAllocations_Stats_Remote(t *testing.T) {
 	state1 := s1.State()
 	state2 := s2.State()
 	require.Nil(state1.UpsertJob(999, a.Job))
-	require.Nil(state1.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state1.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 	require.Nil(state2.UpsertJob(999, a.Job))
-	require.Nil(state2.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state2.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -854,7 +854,7 @@ func TestClientAllocations_Restart_Local(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	require.Nil(state.UpsertJob(999, a.Job))
-	require.Nil(state.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -968,9 +968,9 @@ func TestClientAllocations_Restart_Remote(t *testing.T) {
 	state1 := s1.State()
 	state2 := s2.State()
 	require.Nil(state1.UpsertJob(999, a.Job))
-	require.Nil(state1.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state1.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 	require.Nil(state2.UpsertJob(999, a.Job))
-	require.Nil(state2.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state2.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -1027,7 +1027,7 @@ func TestClientAllocations_Restart_ACL(t *testing.T) {
 	state := s.State()
 	alloc := mock.Alloc()
 	require.NoError(t, state.UpsertJob(1010, alloc.Job))
-	require.NoError(t, state.UpsertAllocs(1011, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
 		Name          string
@@ -1135,10 +1135,10 @@ func TestAlloc_ExecStreaming(t *testing.T) {
 	// Upsert the allocation
 	localState := localServer.State()
 	require.Nil(t, localState.UpsertJob(999, a.Job))
-	require.Nil(t, localState.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(t, localState.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 	remoteState := remoteServer.State()
 	require.Nil(t, remoteState.UpsertJob(999, a.Job))
-	require.Nil(t, remoteState.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(t, remoteState.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {

--- a/nomad/client_csi_endpoint_test.go
+++ b/nomad/client_csi_endpoint_test.go
@@ -141,11 +141,11 @@ func TestClientCSI_NodeForControllerPlugin(t *testing.T) {
 	node3 := mock.Node()
 	node3.ID = uuid.Generate()
 
-	err := state.UpsertNode(1002, node1)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node1, 1002)
 	require.NoError(t, err)
-	err = state.UpsertNode(1003, node2)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, node2, 1003)
 	require.NoError(t, err)
-	err = state.UpsertNode(1004, node3)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, node3, 1004)
 	require.NoError(t, err)
 
 	ws := memdb.NewWatchSet()
@@ -221,7 +221,7 @@ func setupForward(t *testing.T) (rpc.ClientCodec, func()) {
 	node1.Attributes["nomad.version"] = "0.11.0" // client RPCs not supported on early versions
 	node1.CSIControllerPlugins = plugins
 
-	s1.fsm.state.UpsertNode(1000, node1)
+	s1.fsm.state.UpsertNode(structs.MsgTypeTestSetup, node1, 1000)
 
 	cleanup := func() {
 		cleanupS1()
@@ -270,7 +270,7 @@ func setupLocal(t *testing.T) (rpc.ClientCodec, func()) {
 	node1.Attributes["nomad.version"] = "0.11.0" // client RPCs not supported on early versions
 	node1.CSIControllerPlugins = plugins
 
-	s1.fsm.state.UpsertNode(1000, node1)
+	s1.fsm.state.UpsertNode(structs.MsgTypeTestSetup, node1, 1000)
 
 	cleanup := func() {
 		cleanupS1()

--- a/nomad/client_csi_endpoint_test.go
+++ b/nomad/client_csi_endpoint_test.go
@@ -141,11 +141,11 @@ func TestClientCSI_NodeForControllerPlugin(t *testing.T) {
 	node3 := mock.Node()
 	node3.ID = uuid.Generate()
 
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node1, 1002)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 1002, node1)
 	require.NoError(t, err)
-	err = state.UpsertNode(structs.MsgTypeTestSetup, node2, 1003)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, 1003, node2)
 	require.NoError(t, err)
-	err = state.UpsertNode(structs.MsgTypeTestSetup, node3, 1004)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, 1004, node3)
 	require.NoError(t, err)
 
 	ws := memdb.NewWatchSet()
@@ -221,7 +221,7 @@ func setupForward(t *testing.T) (rpc.ClientCodec, func()) {
 	node1.Attributes["nomad.version"] = "0.11.0" // client RPCs not supported on early versions
 	node1.CSIControllerPlugins = plugins
 
-	s1.fsm.state.UpsertNode(structs.MsgTypeTestSetup, node1, 1000)
+	s1.fsm.state.UpsertNode(structs.MsgTypeTestSetup, 1000, node1)
 
 	cleanup := func() {
 		cleanupS1()
@@ -270,7 +270,7 @@ func setupLocal(t *testing.T) (rpc.ClientCodec, func()) {
 	node1.Attributes["nomad.version"] = "0.11.0" // client RPCs not supported on early versions
 	node1.CSIControllerPlugins = plugins
 
-	s1.fsm.state.UpsertNode(structs.MsgTypeTestSetup, node1, 1000)
+	s1.fsm.state.UpsertNode(structs.MsgTypeTestSetup, 1000, node1)
 
 	cleanup := func() {
 		cleanupS1()

--- a/nomad/client_fs_endpoint_test.go
+++ b/nomad/client_fs_endpoint_test.go
@@ -280,7 +280,7 @@ func TestClientFS_Stat_OldNode(t *testing.T) {
 	// Test for an old version error
 	node := mock.Node()
 	node.Attributes["nomad.version"] = "0.7.1"
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1005))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1005, node))
 
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
@@ -1375,7 +1375,7 @@ func TestClientFS_Logs_OldNode(t *testing.T) {
 	// Test for an old version error
 	node := mock.Node()
 	node.Attributes["nomad.version"] = "0.7.1"
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1005))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1005, node))
 
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID

--- a/nomad/client_fs_endpoint_test.go
+++ b/nomad/client_fs_endpoint_test.go
@@ -280,7 +280,7 @@ func TestClientFS_Stat_OldNode(t *testing.T) {
 	// Test for an old version error
 	node := mock.Node()
 	node.Attributes["nomad.version"] = "0.7.1"
-	require.Nil(state.UpsertNode(1005, node))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1005))
 
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
@@ -1375,7 +1375,7 @@ func TestClientFS_Logs_OldNode(t *testing.T) {
 	// Test for an old version error
 	node := mock.Node()
 	node.Attributes["nomad.version"] = "0.7.1"
-	require.Nil(state.UpsertNode(1005, node))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1005))
 
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID

--- a/nomad/client_fs_endpoint_test.go
+++ b/nomad/client_fs_endpoint_test.go
@@ -64,7 +64,7 @@ func TestClientFS_List_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(999, a.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -124,7 +124,7 @@ func TestClientFS_List_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
@@ -224,9 +224,9 @@ func TestClientFS_List_Remote(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(999, a.Job))
+	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
-	require.Nil(state2.UpsertJob(999, a.Job))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -340,7 +340,7 @@ func TestClientFS_Stat_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(999, a.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -400,7 +400,7 @@ func TestClientFS_Stat_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
@@ -500,9 +500,9 @@ func TestClientFS_Stat_Remote(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(999, a.Job))
+	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
-	require.Nil(state2.UpsertJob(999, a.Job))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -632,7 +632,7 @@ func TestClientFS_Streaming_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
@@ -773,7 +773,7 @@ func TestClientFS_Streaming_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(999, a.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -909,7 +909,7 @@ func TestClientFS_Streaming_Local_Follow(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(999, a.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -1052,9 +1052,9 @@ func TestClientFS_Streaming_Remote_Server(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(999, a.Job))
+	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
-	require.Nil(state2.UpsertJob(999, a.Job))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -1198,7 +1198,7 @@ func TestClientFS_Streaming_Remote_Region(t *testing.T) {
 
 	// Upsert the allocation
 	state2 := s2.State()
-	require.Nil(state2.UpsertJob(999, a.Job))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -1461,7 +1461,7 @@ func TestClientFS_Logs_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
@@ -1602,7 +1602,7 @@ func TestClientFS_Logs_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(999, a.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -1739,7 +1739,7 @@ func TestClientFS_Logs_Local_Follow(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(999, a.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -1883,9 +1883,9 @@ func TestClientFS_Logs_Remote_Server(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(999, a.Job))
+	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
-	require.Nil(state2.UpsertJob(999, a.Job))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -2030,7 +2030,7 @@ func TestClientFS_Logs_Remote_Region(t *testing.T) {
 
 	// Upsert the allocation
 	state2 := s2.State()
-	require.Nil(state2.UpsertJob(999, a.Job))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
 	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation

--- a/nomad/client_fs_endpoint_test.go
+++ b/nomad/client_fs_endpoint_test.go
@@ -65,7 +65,7 @@ func TestClientFS_List_Local(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	require.Nil(state.UpsertJob(999, a.Job))
-	require.Nil(state.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -125,7 +125,7 @@ func TestClientFS_List_ACL(t *testing.T) {
 	state := s.State()
 	alloc := mock.Alloc()
 	require.NoError(t, state.UpsertJob(1010, alloc.Job))
-	require.NoError(t, state.UpsertAllocs(1011, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
 		Name          string
@@ -225,9 +225,9 @@ func TestClientFS_List_Remote(t *testing.T) {
 	state1 := s1.State()
 	state2 := s2.State()
 	require.Nil(state1.UpsertJob(999, a.Job))
-	require.Nil(state1.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 	require.Nil(state2.UpsertJob(999, a.Job))
-	require.Nil(state2.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -284,7 +284,7 @@ func TestClientFS_Stat_OldNode(t *testing.T) {
 
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
-	require.Nil(state.UpsertAllocs(1006, []*structs.Allocation{alloc}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1006, []*structs.Allocation{alloc}))
 
 	req := &cstructs.FsStatRequest{
 		AllocID:      alloc.ID,
@@ -341,7 +341,7 @@ func TestClientFS_Stat_Local(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	require.Nil(state.UpsertJob(999, a.Job))
-	require.Nil(state.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -401,7 +401,7 @@ func TestClientFS_Stat_ACL(t *testing.T) {
 	state := s.State()
 	alloc := mock.Alloc()
 	require.NoError(t, state.UpsertJob(1010, alloc.Job))
-	require.NoError(t, state.UpsertAllocs(1011, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
 		Name          string
@@ -501,9 +501,9 @@ func TestClientFS_Stat_Remote(t *testing.T) {
 	state1 := s1.State()
 	state2 := s2.State()
 	require.Nil(state1.UpsertJob(999, a.Job))
-	require.Nil(state1.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 	require.Nil(state2.UpsertJob(999, a.Job))
-	require.Nil(state2.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -633,7 +633,7 @@ func TestClientFS_Streaming_ACL(t *testing.T) {
 	state := s.State()
 	alloc := mock.Alloc()
 	require.NoError(t, state.UpsertJob(1010, alloc.Job))
-	require.NoError(t, state.UpsertAllocs(1011, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
 		Name          string
@@ -774,7 +774,7 @@ func TestClientFS_Streaming_Local(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	require.Nil(state.UpsertJob(999, a.Job))
-	require.Nil(state.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -910,7 +910,7 @@ func TestClientFS_Streaming_Local_Follow(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	require.Nil(state.UpsertJob(999, a.Job))
-	require.Nil(state.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -1053,9 +1053,9 @@ func TestClientFS_Streaming_Remote_Server(t *testing.T) {
 	state1 := s1.State()
 	state2 := s2.State()
 	require.Nil(state1.UpsertJob(999, a.Job))
-	require.Nil(state1.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 	require.Nil(state2.UpsertJob(999, a.Job))
-	require.Nil(state2.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -1199,7 +1199,7 @@ func TestClientFS_Streaming_Remote_Region(t *testing.T) {
 	// Upsert the allocation
 	state2 := s2.State()
 	require.Nil(state2.UpsertJob(999, a.Job))
-	require.Nil(state2.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -1379,7 +1379,7 @@ func TestClientFS_Logs_OldNode(t *testing.T) {
 
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
-	require.Nil(state.UpsertAllocs(1006, []*structs.Allocation{alloc}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1006, []*structs.Allocation{alloc}))
 
 	req := &cstructs.FsLogsRequest{
 		AllocID:      alloc.ID,
@@ -1462,7 +1462,7 @@ func TestClientFS_Logs_ACL(t *testing.T) {
 	state := s.State()
 	alloc := mock.Alloc()
 	require.NoError(t, state.UpsertJob(1010, alloc.Job))
-	require.NoError(t, state.UpsertAllocs(1011, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
 		Name          string
@@ -1603,7 +1603,7 @@ func TestClientFS_Logs_Local(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	require.Nil(state.UpsertJob(999, a.Job))
-	require.Nil(state.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -1740,7 +1740,7 @@ func TestClientFS_Logs_Local_Follow(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	require.Nil(state.UpsertJob(999, a.Job))
-	require.Nil(state.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -1884,9 +1884,9 @@ func TestClientFS_Logs_Remote_Server(t *testing.T) {
 	state1 := s1.State()
 	state2 := s2.State()
 	require.Nil(state1.UpsertJob(999, a.Job))
-	require.Nil(state1.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 	require.Nil(state2.UpsertJob(999, a.Job))
-	require.Nil(state2.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -2031,7 +2031,7 @@ func TestClientFS_Logs_Remote_Region(t *testing.T) {
 	// Upsert the allocation
 	state2 := s2.State()
 	require.Nil(state2.UpsertJob(999, a.Job))
-	require.Nil(state2.UpsertAllocs(1003, []*structs.Allocation{a}))
+	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {

--- a/nomad/client_stats_endpoint_test.go
+++ b/nomad/client_stats_endpoint_test.go
@@ -155,7 +155,7 @@ func TestClientStats_Stats_OldNode(t *testing.T) {
 	// Test for an old version error
 	node := mock.Node()
 	node.Attributes["nomad.version"] = "0.7.1"
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1005))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1005, node))
 
 	req := &structs.NodeSpecificRequest{
 		NodeID:       node.ID,

--- a/nomad/client_stats_endpoint_test.go
+++ b/nomad/client_stats_endpoint_test.go
@@ -155,7 +155,7 @@ func TestClientStats_Stats_OldNode(t *testing.T) {
 	// Test for an old version error
 	node := mock.Node()
 	node.Attributes["nomad.version"] = "0.7.1"
-	require.Nil(state.UpsertNode(1005, node))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1005))
 
 	req := &structs.NodeSpecificRequest{
 		NodeID:       node.ID,

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -837,7 +837,7 @@ func TestCoreScheduler_NodeGC(t *testing.T) {
 			state := server.fsm.State()
 			node := mock.Node()
 			node.Status = structs.NodeStatusDown
-			err := state.UpsertNode(1000, node)
+			err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -887,7 +887,7 @@ func TestCoreScheduler_NodeGC_TerminalAllocs(t *testing.T) {
 	state := s1.fsm.State()
 	node := mock.Node()
 	node.Status = structs.NodeStatusDown
-	err := state.UpsertNode(1000, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -943,7 +943,7 @@ func TestCoreScheduler_NodeGC_RunningAllocs(t *testing.T) {
 	state := s1.fsm.State()
 	node := mock.Node()
 	node.Status = structs.NodeStatusDown
-	err := state.UpsertNode(1000, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1001,7 +1001,7 @@ func TestCoreScheduler_NodeGC_Force(t *testing.T) {
 	state := s1.fsm.State()
 	node := mock.Node()
 	node.Status = structs.NodeStatusDown
-	err := state.UpsertNode(1000, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2283,7 +2283,7 @@ func TestCoreScheduler_CSIVolumeClaimGC(t *testing.T) {
 		},
 	}
 	index++
-	err := state.UpsertNode(index, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, index)
 	require.NoError(err)
 
 	// Note that for volume writes in this test we need to use the

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -32,7 +32,7 @@ func TestCoreScheduler_EvalGC(t *testing.T) {
 	eval := mock.Eval()
 	eval.Status = structs.EvalStatusFailed
 	state.UpsertJobSummary(999, mock.JobSummary(eval.JobID))
-	err := state.UpsertEvals(1000, []*structs.Evaluation{eval})
+	err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval})
 	require.Nil(err)
 
 	// Insert mock job with rescheduling disabled
@@ -42,7 +42,7 @@ func TestCoreScheduler_EvalGC(t *testing.T) {
 		Attempts: 0,
 		Interval: 0 * time.Second,
 	}
-	err = state.UpsertJob(1001, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1001, job)
 	require.Nil(err)
 
 	// Insert "dead" alloc
@@ -126,21 +126,21 @@ func TestCoreScheduler_EvalGC_ReschedulingAllocs(t *testing.T) {
 	eval := mock.Eval()
 	eval.Status = structs.EvalStatusFailed
 	state.UpsertJobSummary(999, mock.JobSummary(eval.JobID))
-	err := state.UpsertEvals(1000, []*structs.Evaluation{eval})
+	err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval})
 	require.Nil(err)
 
 	// Insert "pending" eval for same job
 	eval2 := mock.Eval()
 	eval2.JobID = eval.JobID
 	state.UpsertJobSummary(999, mock.JobSummary(eval2.JobID))
-	err = state.UpsertEvals(1003, []*structs.Evaluation{eval2})
+	err = state.UpsertEvals(structs.MsgTypeTestSetup, 1003, []*structs.Evaluation{eval2})
 	require.Nil(err)
 
 	// Insert mock job with default reschedule policy of 2 in 10 minutes
 	job := mock.Job()
 	job.ID = eval.JobID
 
-	err = state.UpsertJob(1001, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1001, job)
 	require.Nil(err)
 
 	// Insert failed alloc with an old reschedule attempt, can be GCed
@@ -231,7 +231,7 @@ func TestCoreScheduler_EvalGC_StoppedJob_Reschedulable(t *testing.T) {
 	eval := mock.Eval()
 	eval.Status = structs.EvalStatusFailed
 	state.UpsertJobSummary(999, mock.JobSummary(eval.JobID))
-	err := state.UpsertEvals(1000, []*structs.Evaluation{eval})
+	err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval})
 	require.Nil(err)
 
 	// Insert mock stopped job with default reschedule policy of 2 in 10 minutes
@@ -239,7 +239,7 @@ func TestCoreScheduler_EvalGC_StoppedJob_Reschedulable(t *testing.T) {
 	job.ID = eval.JobID
 	job.Stop = true
 
-	err = state.UpsertJob(1001, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1001, job)
 	require.Nil(err)
 
 	// Insert failed alloc with a recent reschedule attempt
@@ -306,7 +306,7 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.Status = structs.JobStatusDead
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 	eval.Status = structs.EvalStatusComplete
 	eval.Type = structs.JobTypeBatch
 	eval.JobID = job.ID
-	err = state.UpsertEvals(1001, []*structs.Evaluation{eval})
+	err = state.UpsertEvals(structs.MsgTypeTestSetup, 1001, []*structs.Evaluation{eval})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -410,7 +410,7 @@ func TestCoreScheduler_EvalGC_Batch_OldVersion(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.Status = structs.JobStatusDead
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -420,7 +420,7 @@ func TestCoreScheduler_EvalGC_Batch_OldVersion(t *testing.T) {
 	eval.Status = structs.EvalStatusComplete
 	eval.Type = structs.JobTypeBatch
 	eval.JobID = job.ID
-	err = state.UpsertEvals(1001, []*structs.Evaluation{eval})
+	err = state.UpsertEvals(structs.MsgTypeTestSetup, 1001, []*structs.Evaluation{eval})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -539,7 +539,7 @@ func TestCoreScheduler_EvalGC_BatchStopped(t *testing.T) {
 		Attempts: 0,
 		Interval: 0 * time.Second,
 	}
-	err := state.UpsertJob(1001, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1001, job)
 	require.Nil(err)
 
 	// Insert "complete" eval
@@ -547,7 +547,7 @@ func TestCoreScheduler_EvalGC_BatchStopped(t *testing.T) {
 	eval.Status = structs.EvalStatusComplete
 	eval.Type = structs.JobTypeBatch
 	eval.JobID = job.ID
-	err = state.UpsertEvals(1002, []*structs.Evaluation{eval})
+	err = state.UpsertEvals(structs.MsgTypeTestSetup, 1002, []*structs.Evaluation{eval})
 	require.Nil(err)
 
 	// Insert "failed" alloc
@@ -630,7 +630,7 @@ func TestCoreScheduler_EvalGC_Partial(t *testing.T) {
 	eval := mock.Eval()
 	eval.Status = structs.EvalStatusComplete
 	state.UpsertJobSummary(999, mock.JobSummary(eval.JobID))
-	err := state.UpsertEvals(1000, []*structs.Evaluation{eval})
+	err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -675,7 +675,7 @@ func TestCoreScheduler_EvalGC_Partial(t *testing.T) {
 		Attempts: 0,
 		Interval: 0 * time.Second,
 	}
-	err = state.UpsertJob(1001, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1001, job)
 	require.Nil(err)
 
 	// Update the time tables to make this work
@@ -755,7 +755,7 @@ func TestCoreScheduler_EvalGC_Force(t *testing.T) {
 			eval := mock.Eval()
 			eval.Status = structs.EvalStatusFailed
 			state.UpsertJobSummary(999, mock.JobSummary(eval.JobID))
-			err := state.UpsertEvals(1000, []*structs.Evaluation{eval})
+			err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval})
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -767,7 +767,7 @@ func TestCoreScheduler_EvalGC_Force(t *testing.T) {
 				Attempts: 0,
 				Interval: 0 * time.Second,
 			}
-			err = state.UpsertJob(1001, job)
+			err = state.UpsertJob(structs.MsgTypeTestSetup, 1001, job)
 			require.Nil(err)
 
 			// Insert "dead" alloc
@@ -1046,7 +1046,7 @@ func TestCoreScheduler_JobGC_OutstandingEvals(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.Status = structs.JobStatusDead
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1059,7 +1059,7 @@ func TestCoreScheduler_JobGC_OutstandingEvals(t *testing.T) {
 	eval2 := mock.Eval()
 	eval2.JobID = job.ID
 	eval2.Status = structs.EvalStatusPending
-	err = state.UpsertEvals(1001, []*structs.Evaluation{eval, eval2})
+	err = state.UpsertEvals(structs.MsgTypeTestSetup, 1001, []*structs.Evaluation{eval, eval2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1110,7 +1110,7 @@ func TestCoreScheduler_JobGC_OutstandingEvals(t *testing.T) {
 
 	// Update the second eval to be terminal
 	eval2.Status = structs.EvalStatusComplete
-	err = state.UpsertEvals(1003, []*structs.Evaluation{eval2})
+	err = state.UpsertEvals(structs.MsgTypeTestSetup, 1003, []*structs.Evaluation{eval2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1174,7 +1174,7 @@ func TestCoreScheduler_JobGC_OutstandingAllocs(t *testing.T) {
 		Attempts: 0,
 		Interval: 0 * time.Second,
 	}
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1183,7 +1183,7 @@ func TestCoreScheduler_JobGC_OutstandingAllocs(t *testing.T) {
 	eval := mock.Eval()
 	eval.JobID = job.ID
 	eval.Status = structs.EvalStatusComplete
-	err = state.UpsertEvals(1001, []*structs.Evaluation{eval})
+	err = state.UpsertEvals(structs.MsgTypeTestSetup, 1001, []*structs.Evaluation{eval})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1315,7 +1315,7 @@ func TestCoreScheduler_JobGC_OneShot(t *testing.T) {
 	state := s1.fsm.State()
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1329,7 +1329,7 @@ func TestCoreScheduler_JobGC_OneShot(t *testing.T) {
 	eval2.JobID = job.ID
 	eval2.Status = structs.EvalStatusComplete
 
-	err = state.UpsertEvals(1001, []*structs.Evaluation{eval, eval2})
+	err = state.UpsertEvals(structs.MsgTypeTestSetup, 1001, []*structs.Evaluation{eval, eval2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1432,7 +1432,7 @@ func TestCoreScheduler_JobGC_Stopped(t *testing.T) {
 		Attempts: 0,
 		Interval: 0 * time.Second,
 	}
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1446,7 +1446,7 @@ func TestCoreScheduler_JobGC_Stopped(t *testing.T) {
 	eval2.JobID = job.ID
 	eval2.Status = structs.EvalStatusComplete
 
-	err = state.UpsertEvals(1001, []*structs.Evaluation{eval, eval2})
+	err = state.UpsertEvals(structs.MsgTypeTestSetup, 1001, []*structs.Evaluation{eval, eval2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1537,7 +1537,7 @@ func TestCoreScheduler_JobGC_Force(t *testing.T) {
 			job := mock.Job()
 			job.Type = structs.JobTypeBatch
 			job.Status = structs.JobStatusDead
-			err := state.UpsertJob(1000, job)
+			err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -1546,7 +1546,7 @@ func TestCoreScheduler_JobGC_Force(t *testing.T) {
 			eval := mock.Eval()
 			eval.JobID = job.ID
 			eval.Status = structs.EvalStatusComplete
-			err = state.UpsertEvals(1001, []*structs.Evaluation{eval})
+			err = state.UpsertEvals(structs.MsgTypeTestSetup, 1001, []*structs.Evaluation{eval})
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -1605,7 +1605,7 @@ func TestCoreScheduler_JobGC_Parameterized(t *testing.T) {
 	job.ParameterizedJob = &structs.ParameterizedJobConfig{
 		Payload: structs.DispatchPayloadRequired,
 	}
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1637,7 +1637,7 @@ func TestCoreScheduler_JobGC_Parameterized(t *testing.T) {
 	// Mark the job as stopped and try again
 	job2 := job.Copy()
 	job2.Stop = true
-	err = state.UpsertJob(2000, job2)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 2000, job2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1680,7 +1680,7 @@ func TestCoreScheduler_JobGC_Periodic(t *testing.T) {
 	// Insert a parameterized job.
 	state := s1.fsm.State()
 	job := mock.PeriodicJob()
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1712,7 +1712,7 @@ func TestCoreScheduler_JobGC_Periodic(t *testing.T) {
 	// Mark the job as stopped and try again
 	job2 := job.Copy()
 	job2.Stop = true
-	err = state.UpsertJob(2000, job2)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 2000, job2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2318,14 +2318,14 @@ func TestCoreScheduler_CSIVolumeClaimGC(t *testing.T) {
 	index++
 	state.UpsertJobSummary(index, mock.JobSummary(eval.JobID))
 	index++
-	err = state.UpsertEvals(index, []*structs.Evaluation{eval})
+	err = state.UpsertEvals(structs.MsgTypeTestSetup, index, []*structs.Evaluation{eval})
 	require.Nil(err)
 
 	job := mock.Job()
 	job.ID = eval.JobID
 	job.Status = structs.JobStatusRunning
 	index++
-	err = state.UpsertJob(index, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, index, job)
 	require.NoError(err)
 
 	alloc1, alloc2 := mock.Alloc(), mock.Alloc()

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -837,7 +837,7 @@ func TestCoreScheduler_NodeGC(t *testing.T) {
 			state := server.fsm.State()
 			node := mock.Node()
 			node.Status = structs.NodeStatusDown
-			err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+			err := state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -887,7 +887,7 @@ func TestCoreScheduler_NodeGC_TerminalAllocs(t *testing.T) {
 	state := s1.fsm.State()
 	node := mock.Node()
 	node.Status = structs.NodeStatusDown
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -943,7 +943,7 @@ func TestCoreScheduler_NodeGC_RunningAllocs(t *testing.T) {
 	state := s1.fsm.State()
 	node := mock.Node()
 	node.Status = structs.NodeStatusDown
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1001,7 +1001,7 @@ func TestCoreScheduler_NodeGC_Force(t *testing.T) {
 	state := s1.fsm.State()
 	node := mock.Node()
 	node.Status = structs.NodeStatusDown
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2283,7 +2283,7 @@ func TestCoreScheduler_CSIVolumeClaimGC(t *testing.T) {
 		},
 	}
 	index++
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, index)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, index, node)
 	require.NoError(err)
 
 	// Note that for volume writes in this test we need to use the

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -59,7 +59,7 @@ func TestCoreScheduler_EvalGC(t *testing.T) {
 	alloc2.ClientStatus = structs.AllocClientStatusLost
 	alloc2.JobID = eval.JobID
 	alloc2.TaskGroup = job.TaskGroups[0].Name
-	err = state.UpsertAllocs(1001, []*structs.Allocation{alloc, alloc2})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc, alloc2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestCoreScheduler_EvalGC_ReschedulingAllocs(t *testing.T) {
 			},
 		},
 	}
-	err = state.UpsertAllocs(1001, []*structs.Allocation{alloc, alloc2})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc, alloc2})
 	require.Nil(err)
 
 	// Update the time tables to make this work
@@ -258,7 +258,7 @@ func TestCoreScheduler_EvalGC_StoppedJob_Reschedulable(t *testing.T) {
 			},
 		},
 	}
-	err = state.UpsertAllocs(1001, []*structs.Allocation{alloc})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc})
 	require.Nil(err)
 
 	// Update the time tables to make this work
@@ -336,7 +336,7 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 	alloc2.DesiredStatus = structs.AllocDesiredStatusRun
 	alloc2.ClientStatus = structs.AllocClientStatusLost
 
-	err = state.UpsertAllocs(1002, []*structs.Allocation{alloc, alloc2})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc, alloc2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -451,7 +451,7 @@ func TestCoreScheduler_EvalGC_Batch_OldVersion(t *testing.T) {
 	alloc3.DesiredStatus = structs.AllocDesiredStatusRun
 	alloc3.ClientStatus = structs.AllocClientStatusLost
 
-	err = state.UpsertAllocs(1002, []*structs.Allocation{alloc, alloc2, alloc3})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc, alloc2, alloc3})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -565,7 +565,7 @@ func TestCoreScheduler_EvalGC_BatchStopped(t *testing.T) {
 	alloc2.ClientStatus = structs.AllocClientStatusLost
 	alloc2.TaskGroup = job.TaskGroups[0].Name
 
-	err = state.UpsertAllocs(1003, []*structs.Allocation{alloc, alloc2})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{alloc, alloc2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -655,7 +655,7 @@ func TestCoreScheduler_EvalGC_Partial(t *testing.T) {
 	alloc2.DesiredStatus = structs.AllocDesiredStatusRun
 	alloc2.ClientStatus = structs.AllocClientStatusLost
 
-	err = state.UpsertAllocs(1002, []*structs.Allocation{alloc, alloc2})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc, alloc2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -665,7 +665,7 @@ func TestCoreScheduler_EvalGC_Partial(t *testing.T) {
 	alloc3.EvalID = eval.ID
 	alloc3.JobID = job.ID
 	state.UpsertJobSummary(1003, mock.JobSummary(alloc3.JobID))
-	err = state.UpsertAllocs(1004, []*structs.Allocation{alloc3})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1004, []*structs.Allocation{alloc3})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -776,7 +776,7 @@ func TestCoreScheduler_EvalGC_Force(t *testing.T) {
 			alloc.DesiredStatus = structs.AllocDesiredStatusStop
 			alloc.TaskGroup = job.TaskGroups[0].Name
 			state.UpsertJobSummary(1001, mock.JobSummary(alloc.JobID))
-			err = state.UpsertAllocs(1002, []*structs.Allocation{alloc})
+			err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc})
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -896,7 +896,7 @@ func TestCoreScheduler_NodeGC_TerminalAllocs(t *testing.T) {
 	alloc := mock.Alloc()
 	alloc.DesiredStatus = structs.AllocDesiredStatusStop
 	state.UpsertJobSummary(1001, mock.JobSummary(alloc.JobID))
-	if err := state.UpsertAllocs(1002, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -954,7 +954,7 @@ func TestCoreScheduler_NodeGC_RunningAllocs(t *testing.T) {
 	alloc.DesiredStatus = structs.AllocDesiredStatusRun
 	alloc.ClientStatus = structs.AllocClientStatusRunning
 	state.UpsertJobSummary(1001, mock.JobSummary(alloc.JobID))
-	if err := state.UpsertAllocs(1002, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -1203,7 +1203,7 @@ func TestCoreScheduler_JobGC_OutstandingAllocs(t *testing.T) {
 	alloc2.ClientStatus = structs.AllocClientStatusRunning
 	alloc2.TaskGroup = job.TaskGroups[0].Name
 
-	err = state.UpsertAllocs(1002, []*structs.Allocation{alloc, alloc2})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc, alloc2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1254,7 +1254,7 @@ func TestCoreScheduler_JobGC_OutstandingAllocs(t *testing.T) {
 
 	// Update the second alloc to be terminal
 	alloc2.ClientStatus = structs.AllocClientStatusComplete
-	err = state.UpsertAllocs(1003, []*structs.Allocation{alloc2})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{alloc2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1345,7 +1345,7 @@ func TestCoreScheduler_JobGC_OneShot(t *testing.T) {
 	alloc2.EvalID = eval2.ID
 	alloc2.DesiredStatus = structs.AllocDesiredStatusRun
 
-	err = state.UpsertAllocs(1002, []*structs.Allocation{alloc, alloc2})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc, alloc2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1457,7 +1457,7 @@ func TestCoreScheduler_JobGC_Stopped(t *testing.T) {
 	alloc.EvalID = eval.ID
 	alloc.DesiredStatus = structs.AllocDesiredStatusStop
 	alloc.TaskGroup = job.TaskGroups[0].Name
-	err = state.UpsertAllocs(1002, []*structs.Allocation{alloc})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1764,7 +1764,7 @@ func TestCoreScheduler_DeploymentGC(t *testing.T) {
 	a := mock.Alloc()
 	a.JobID = d3.JobID
 	a.DeploymentID = d3.ID
-	assert.Nil(state.UpsertAllocs(1003, []*structs.Allocation{a}), "UpsertAllocs")
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Update the time tables to make this work
 	tt := s1.fsm.TimeTable()
@@ -2348,8 +2348,7 @@ func TestCoreScheduler_CSIVolumeClaimGC(t *testing.T) {
 	index++
 	require.NoError(state.UpsertJobSummary(index, summary))
 	index++
-	require.NoError(state.UpsertAllocs(index,
-		[]*structs.Allocation{alloc1, alloc2}))
+	require.NoError(state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc1, alloc2}))
 
 	// Claim the volume for the alloc
 	req := &structs.CSIVolumeClaimRequest{

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -133,7 +133,7 @@ func TestCSIVolumeEndpoint_Register(t *testing.T) {
 			NodeInfo: &structs.CSINodeInfo{},
 		},
 	}
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node, 1000))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1000, node))
 
 	// Create the volume
 	vols := []*structs.CSIVolume{{
@@ -260,7 +260,7 @@ func TestCSIVolumeEndpoint_Claim(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(structs.MsgTypeTestSetup, node, index)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, index, node)
 	require.NoError(t, err)
 
 	vols := []*structs.CSIVolume{{
@@ -401,7 +401,7 @@ func TestCSIVolumeEndpoint_ClaimWithController(t *testing.T) {
 			NodeInfo: &structs.CSINodeInfo{},
 		},
 	}
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1002)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 1002, node)
 	require.NoError(t, err)
 	vols := []*structs.CSIVolume{{
 		ID:                 id0,
@@ -481,7 +481,7 @@ func TestCSIVolumeEndpoint_Unpublish(t *testing.T) {
 		},
 	}
 	index++
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node, index))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, index, node))
 
 	type tc struct {
 		name           string
@@ -899,7 +899,7 @@ func TestCSI_RPCVolumeAndPluginLookup(t *testing.T) {
 	node.CSINodePlugins = map[string]*structs.CSIInfo{
 		"adam": {PluginID: "adam", Healthy: true},
 	}
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 3)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 3, node)
 	require.NoError(t, err)
 
 	// Create 2 volumes

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -232,7 +232,7 @@ func TestCSIVolumeEndpoint_Claim(t *testing.T) {
 	index++
 	require.NoError(t, state.UpsertJobSummary(index, summary))
 	index++
-	require.NoError(t, state.UpsertAllocs(index, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc}))
 
 	// Create an initial volume claim request; we expect it to fail
 	// because there's no such volume yet.
@@ -312,7 +312,7 @@ func TestCSIVolumeEndpoint_Claim(t *testing.T) {
 	index++
 	require.NoError(t, state.UpsertJobSummary(index, summary))
 	index++
-	require.NoError(t, state.UpsertAllocs(index, []*structs.Allocation{alloc2}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc2}))
 	claimReq.AllocationID = alloc2.ID
 	err = msgpackrpc.CallWithCodec(codec, "CSIVolume.Claim", claimReq, claimResp)
 	require.EqualError(t, err, "volume max claim reached",
@@ -346,7 +346,7 @@ func TestCSIVolumeEndpoint_Claim(t *testing.T) {
 	index++
 	require.NoError(t, state.UpsertJobSummary(index, summary))
 	index++
-	require.NoError(t, state.UpsertAllocs(index, []*structs.Allocation{alloc3}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc3}))
 	claimReq.AllocationID = alloc3.ID
 	err = msgpackrpc.CallWithCodec(codec, "CSIVolume.Claim", claimReq, claimResp)
 	require.NoError(t, err)
@@ -419,7 +419,7 @@ func TestCSIVolumeEndpoint_ClaimWithController(t *testing.T) {
 	alloc.NodeID = node.ID
 	summary := mock.JobSummary(alloc.JobID)
 	require.NoError(t, state.UpsertJobSummary(1004, summary))
-	require.NoError(t, state.UpsertAllocs(1005, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1005, []*structs.Allocation{alloc}))
 
 	// Make the volume claim
 	claimReq := &structs.CSIVolumeClaimRequest{
@@ -529,7 +529,7 @@ func TestCSIVolumeEndpoint_Unpublish(t *testing.T) {
 			alloc.ClientStatus = structs.AllocClientStatusFailed
 
 			index++
-			require.NoError(t, state.UpsertAllocs(index, []*structs.Allocation{alloc}))
+			require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc}))
 
 			// setup: claim the volume for our alloc
 			claim := &structs.CSIVolumeClaim{

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -133,7 +133,7 @@ func TestCSIVolumeEndpoint_Register(t *testing.T) {
 			NodeInfo: &structs.CSINodeInfo{},
 		},
 	}
-	require.NoError(t, state.UpsertNode(1000, node))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node, 1000))
 
 	// Create the volume
 	vols := []*structs.CSIVolume{{
@@ -260,7 +260,7 @@ func TestCSIVolumeEndpoint_Claim(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(index, node)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, node, index)
 	require.NoError(t, err)
 
 	vols := []*structs.CSIVolume{{
@@ -401,7 +401,7 @@ func TestCSIVolumeEndpoint_ClaimWithController(t *testing.T) {
 			NodeInfo: &structs.CSINodeInfo{},
 		},
 	}
-	err := state.UpsertNode(1002, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1002)
 	require.NoError(t, err)
 	vols := []*structs.CSIVolume{{
 		ID:                 id0,
@@ -481,7 +481,7 @@ func TestCSIVolumeEndpoint_Unpublish(t *testing.T) {
 		},
 	}
 	index++
-	require.NoError(t, state.UpsertNode(index, node))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node, index))
 
 	type tc struct {
 		name           string
@@ -899,7 +899,7 @@ func TestCSI_RPCVolumeAndPluginLookup(t *testing.T) {
 	node.CSINodePlugins = map[string]*structs.CSIInfo{
 		"adam": {PluginID: "adam", Healthy: true},
 	}
-	err := state.UpsertNode(3, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 3)
 	require.NoError(t, err)
 
 	// Create 2 volumes

--- a/nomad/deployment_endpoint_test.go
+++ b/nomad/deployment_endpoint_test.go
@@ -29,7 +29,7 @@ func TestDeploymentEndpoint_GetDeployment(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Lookup the deployments
@@ -61,7 +61,7 @@ func TestDeploymentEndpoint_GetDeployment_ACL(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Create the namespace policy and tokens
@@ -118,8 +118,8 @@ func TestDeploymentEndpoint_GetDeployment_Blocking(t *testing.T) {
 	d2 := mock.Deployment()
 	d2.JobID = j2.ID
 
-	assert.Nil(state.UpsertJob(98, j1), "UpsertJob")
-	assert.Nil(state.UpsertJob(99, j2), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 98, j1), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 99, j2), "UpsertJob")
 
 	// Upsert a deployment we are not interested in first.
 	time.AfterFunc(100*time.Millisecond, func() {
@@ -167,7 +167,7 @@ func TestDeploymentEndpoint_Fail(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Mark the deployment as failed
@@ -217,7 +217,7 @@ func TestDeploymentEndpoint_Fail_ACL(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Create the namespace policy and tokens
@@ -294,7 +294,7 @@ func TestDeploymentEndpoint_Fail_Rollback(t *testing.T) {
 	j.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
 	j.TaskGroups[0].Update.MaxParallel = 2
 	j.TaskGroups[0].Update.AutoRevert = true
-	assert.Nil(state.UpsertJob(998, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
 
 	// Create the second job, deployment and alloc
 	j2 := j.Copy()
@@ -311,7 +311,7 @@ func TestDeploymentEndpoint_Fail_Rollback(t *testing.T) {
 	a.JobID = j.ID
 	a.DeploymentID = d.ID
 
-	assert.Nil(state.UpsertJob(999, j2), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j2), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -371,7 +371,7 @@ func TestDeploymentEndpoint_Pause(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Mark the deployment as failed
@@ -414,7 +414,7 @@ func TestDeploymentEndpoint_Pause_ACL(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Create the namespace policy and tokens
@@ -493,7 +493,7 @@ func TestDeploymentEndpoint_Promote(t *testing.T) {
 	}
 
 	state := s1.fsm.State()
-	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -558,7 +558,7 @@ func TestDeploymentEndpoint_Promote_ACL(t *testing.T) {
 	}
 
 	state := s1.fsm.State()
-	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -644,7 +644,7 @@ func TestDeploymentEndpoint_SetAllocHealth(t *testing.T) {
 	a.DeploymentID = d.ID
 
 	state := s1.fsm.State()
-	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -712,7 +712,7 @@ func TestDeploymentEndpoint_SetAllocHealth_ACL(t *testing.T) {
 	a.DeploymentID = d.ID
 
 	state := s1.fsm.State()
-	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -802,7 +802,7 @@ func TestDeploymentEndpoint_SetAllocHealth_Rollback(t *testing.T) {
 	j.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
 	j.TaskGroups[0].Update.MaxParallel = 2
 	j.TaskGroups[0].Update.AutoRevert = true
-	assert.Nil(state.UpsertJob(998, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
 
 	// Create the second job, deployment and alloc
 	j2 := j.Copy()
@@ -818,7 +818,7 @@ func TestDeploymentEndpoint_SetAllocHealth_Rollback(t *testing.T) {
 	a.JobID = j.ID
 	a.DeploymentID = d.ID
 
-	assert.Nil(state.UpsertJob(999, j2), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j2), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -892,7 +892,7 @@ func TestDeploymentEndpoint_SetAllocHealth_NoRollback(t *testing.T) {
 	j.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
 	j.TaskGroups[0].Update.MaxParallel = 2
 	j.TaskGroups[0].Update.AutoRevert = true
-	assert.Nil(state.UpsertJob(998, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
 
 	// Create the second job, deployment and alloc. Job has same spec as original
 	j2 := j.Copy()
@@ -907,7 +907,7 @@ func TestDeploymentEndpoint_SetAllocHealth_NoRollback(t *testing.T) {
 	a.JobID = j.ID
 	a.DeploymentID = d.ID
 
-	assert.Nil(state.UpsertJob(999, j2), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j2), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -976,7 +976,7 @@ func TestDeploymentEndpoint_List(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Lookup the deployments
@@ -1023,7 +1023,7 @@ func TestDeploymentEndpoint_List_ACL(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Create the namespace policy and tokens
@@ -1092,7 +1092,7 @@ func TestDeploymentEndpoint_List_Blocking(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 
-	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
 
 	// Upsert alloc triggers watches
 	time.AfterFunc(100*time.Millisecond, func() {
@@ -1153,7 +1153,7 @@ func TestDeploymentEndpoint_Allocations(t *testing.T) {
 	summary := mock.JobSummary(a.JobID)
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(998, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
 	assert.Nil(state.UpsertJobSummary(999, summary), "UpsertJobSummary")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
@@ -1191,7 +1191,7 @@ func TestDeploymentEndpoint_Allocations_ACL(t *testing.T) {
 	summary := mock.JobSummary(a.JobID)
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(998, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
 	assert.Nil(state.UpsertJobSummary(999, summary), "UpsertJobSummary")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
@@ -1266,7 +1266,7 @@ func TestDeploymentEndpoint_Allocations_Blocking(t *testing.T) {
 	a.DeploymentID = d.ID
 	summary := mock.JobSummary(a.JobID)
 
-	assert.Nil(state.UpsertJob(1, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(2, d), "UpsertDeployment")
 	assert.Nil(state.UpsertJobSummary(3, summary), "UpsertJobSummary")
 

--- a/nomad/deployment_endpoint_test.go
+++ b/nomad/deployment_endpoint_test.go
@@ -313,7 +313,7 @@ func TestDeploymentEndpoint_Fail_Rollback(t *testing.T) {
 
 	assert.Nil(state.UpsertJob(999, j2), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
-	assert.Nil(state.UpsertAllocs(1001, []*structs.Allocation{a}), "UpsertAllocs")
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Mark the deployment as failed
 	req := &structs.DeploymentFailRequest{
@@ -495,7 +495,7 @@ func TestDeploymentEndpoint_Promote(t *testing.T) {
 	state := s1.fsm.State()
 	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
-	assert.Nil(state.UpsertAllocs(1001, []*structs.Allocation{a}), "UpsertAllocs")
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Promote the deployment
 	req := &structs.DeploymentPromoteRequest{
@@ -560,7 +560,7 @@ func TestDeploymentEndpoint_Promote_ACL(t *testing.T) {
 	state := s1.fsm.State()
 	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
-	assert.Nil(state.UpsertAllocs(1001, []*structs.Allocation{a}), "UpsertAllocs")
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Create the namespace policy and tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid",
@@ -646,7 +646,7 @@ func TestDeploymentEndpoint_SetAllocHealth(t *testing.T) {
 	state := s1.fsm.State()
 	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
-	assert.Nil(state.UpsertAllocs(1001, []*structs.Allocation{a}), "UpsertAllocs")
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Set the alloc as healthy
 	req := &structs.DeploymentAllocHealthRequest{
@@ -714,7 +714,7 @@ func TestDeploymentEndpoint_SetAllocHealth_ACL(t *testing.T) {
 	state := s1.fsm.State()
 	assert.Nil(state.UpsertJob(999, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
-	assert.Nil(state.UpsertAllocs(1001, []*structs.Allocation{a}), "UpsertAllocs")
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Create the namespace policy and tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid",
@@ -820,7 +820,7 @@ func TestDeploymentEndpoint_SetAllocHealth_Rollback(t *testing.T) {
 
 	assert.Nil(state.UpsertJob(999, j2), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
-	assert.Nil(state.UpsertAllocs(1001, []*structs.Allocation{a}), "UpsertAllocs")
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Set the alloc as unhealthy
 	req := &structs.DeploymentAllocHealthRequest{
@@ -909,7 +909,7 @@ func TestDeploymentEndpoint_SetAllocHealth_NoRollback(t *testing.T) {
 
 	assert.Nil(state.UpsertJob(999, j2), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
-	assert.Nil(state.UpsertAllocs(1001, []*structs.Allocation{a}), "UpsertAllocs")
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Set the alloc as unhealthy
 	req := &structs.DeploymentAllocHealthRequest{
@@ -1156,7 +1156,7 @@ func TestDeploymentEndpoint_Allocations(t *testing.T) {
 	assert.Nil(state.UpsertJob(998, j), "UpsertJob")
 	assert.Nil(state.UpsertJobSummary(999, summary), "UpsertJobSummary")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
-	assert.Nil(state.UpsertAllocs(1001, []*structs.Allocation{a}), "UpsertAllocs")
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Lookup the allocations
 	get := &structs.DeploymentSpecificRequest{
@@ -1194,7 +1194,7 @@ func TestDeploymentEndpoint_Allocations_ACL(t *testing.T) {
 	assert.Nil(state.UpsertJob(998, j), "UpsertJob")
 	assert.Nil(state.UpsertJobSummary(999, summary), "UpsertJobSummary")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
-	assert.Nil(state.UpsertAllocs(1001, []*structs.Allocation{a}), "UpsertAllocs")
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Create the namespace policy and tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid",
@@ -1272,7 +1272,7 @@ func TestDeploymentEndpoint_Allocations_Blocking(t *testing.T) {
 
 	// Upsert alloc triggers watches
 	time.AfterFunc(100*time.Millisecond, func() {
-		assert.Nil(state.UpsertAllocs(4, []*structs.Allocation{a}), "UpsertAllocs")
+		assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 4, []*structs.Allocation{a}), "UpsertAllocs")
 	})
 
 	req := &structs.DeploymentSpecificRequest{

--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -202,7 +202,7 @@ func TestWatcher_SetAllocHealth_Healthy(t *testing.T) {
 	a.DeploymentID = d.ID
 	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// require that we get a call to UpsertDeploymentAllocHealth
 	matchConfig := &matchDeploymentAllocHealthRequestConfig{
@@ -247,7 +247,7 @@ func TestWatcher_SetAllocHealth_Unhealthy(t *testing.T) {
 	a.DeploymentID = d.ID
 	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// require that we get a call to UpsertDeploymentAllocHealth
 	matchConfig := &matchDeploymentAllocHealthRequestConfig{
@@ -305,7 +305,7 @@ func TestWatcher_SetAllocHealth_Unhealthy_Rollback(t *testing.T) {
 	a.DeploymentID = d.ID
 	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Upsert the job again to get a new version
 	j2 := j.Copy()
@@ -372,7 +372,7 @@ func TestWatcher_SetAllocHealth_Unhealthy_NoRollback(t *testing.T) {
 	a.DeploymentID = d.ID
 	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Upsert the job again to get a new version
 	j2 := j.Copy()
@@ -440,7 +440,7 @@ func TestWatcher_PromoteDeployment_HealthyCanaries(t *testing.T) {
 	a.DeploymentID = d.ID
 	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// require that we get a call to UpsertDeploymentPromotion
 	matchConfig := &matchDeploymentPromoteRequestConfig{
@@ -497,7 +497,7 @@ func TestWatcher_PromoteDeployment_UnhealthyCanaries(t *testing.T) {
 	a.DeploymentID = d.ID
 	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// require that we get a call to UpsertDeploymentPromotion
 	matchConfig := &matchDeploymentPromoteRequestConfig{
@@ -576,7 +576,7 @@ func TestWatcher_AutoPromoteDeployment(t *testing.T) {
 	d.TaskGroups[a.TaskGroup].DesiredCanaries = 2
 	require.NoError(t, m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
 	require.NoError(t, m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
-	require.NoError(t, m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a, b}), "UpsertAllocs")
+	require.NoError(t, m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a, b}), "UpsertAllocs")
 
 	// =============================================================
 	// Support method calls
@@ -880,7 +880,7 @@ func TestDeploymentWatcher_Watch_NoProgressDeadline(t *testing.T) {
 	a.DeploymentID = d.ID
 	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Upsert the job again to get a new version
 	j2 := j.Copy()
@@ -1002,7 +1002,7 @@ func TestDeploymentWatcher_Watch_ProgressDeadline(t *testing.T) {
 	a.DeploymentID = d.ID
 	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// require that we get a call to UpsertDeploymentStatusUpdate
 	c := &matchDeploymentStatusUpdateConfig{
@@ -1097,7 +1097,7 @@ func TestDeploymentWatcher_ProgressCutoff(t *testing.T) {
 
 	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a, a2}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a, a2}), "UpsertAllocs")
 
 	// We may get an update for the desired transition.
 	m1 := matchUpdateAllocDesiredTransitions([]string{d.ID})
@@ -1126,7 +1126,7 @@ func TestDeploymentWatcher_ProgressCutoff(t *testing.T) {
 	// Update the first allocation to be healthy
 	a3 := a.Copy()
 	a3.DeploymentStatus = &structs.AllocDeploymentStatus{Healthy: helper.BoolToPtr(true)}
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a3}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a3}), "UpsertAllocs")
 
 	// Get the updated deployment
 	d2, err := m.state.DeploymentByID(nil, d.ID)
@@ -1145,7 +1145,7 @@ func TestDeploymentWatcher_ProgressCutoff(t *testing.T) {
 	// Update the second allocation to be healthy
 	a4 := a2.Copy()
 	a4.DeploymentStatus = &structs.AllocDeploymentStatus{Healthy: helper.BoolToPtr(true)}
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a4}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a4}), "UpsertAllocs")
 
 	// Get the updated deployment
 	d3, err := m.state.DeploymentByID(nil, d.ID)
@@ -1191,7 +1191,7 @@ func TestDeploymentWatcher_Watch_ProgressDeadline_Canaries(t *testing.T) {
 	a.DeploymentID = d.ID
 	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// require that we will get a createEvaluation call only once. This will
 	// verify that the watcher is batching allocation changes
@@ -1283,7 +1283,7 @@ func TestDeploymentWatcher_PromotedCanary_UpdatedAllocs(t *testing.T) {
 	}
 	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	w.SetEnabled(true, m.state)
 	testutil.WaitForResult(func() (bool, error) { return 1 == watchersCount(w), nil },
@@ -1306,7 +1306,7 @@ func TestDeploymentWatcher_PromotedCanary_UpdatedAllocs(t *testing.T) {
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	// Wait until batch eval period passes before updating another alloc
 	time.Sleep(1 * time.Second)
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a2}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a2}), "UpsertAllocs")
 
 	// Wait for the deployment to cross the deadline
 	dout, err := m.state.DeploymentByID(nil, d.ID)
@@ -1361,7 +1361,7 @@ func TestDeploymentWatcher_Watch_StartWithoutProgressDeadline(t *testing.T) {
 	a.CreateTime = time.Now().UnixNano()
 	a.DeploymentID = d.ID
 
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	d.TaskGroups["web"].ProgressDeadline = 500 * time.Millisecond
 	// Update the deployment with a progress deadline
@@ -1417,7 +1417,7 @@ func TestDeploymentWatcher_RollbackFailed(t *testing.T) {
 	a.DeploymentID = d.ID
 	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
 	// Upsert the job again to get a new version
 	j2 := j.Copy()
@@ -1542,8 +1542,8 @@ func TestWatcher_BatchAllocUpdates(t *testing.T) {
 	require.Nil(m.state.UpsertJob(m.nextIndex(), j2), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d1), "UpsertDeployment")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d2), "UpsertDeployment")
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a1}), "UpsertAllocs")
-	require.Nil(m.state.UpsertAllocs(m.nextIndex(), []*structs.Allocation{a2}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a1}), "UpsertAllocs")
+	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a2}), "UpsertAllocs")
 
 	// require that we will get a createEvaluation call only once and it contains
 	// both deployments. This will verify that the watcher is batching

--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -39,9 +39,9 @@ func TestWatcher_WatchDeployments(t *testing.T) {
 
 	// Create three jobs
 	j1, j2, j3 := mock.Job(), mock.Job(), mock.Job()
-	require.Nil(m.state.UpsertJob(100, j1))
-	require.Nil(m.state.UpsertJob(101, j2))
-	require.Nil(m.state.UpsertJob(102, j3))
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, 100, j1))
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, 101, j2))
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, 102, j3))
 
 	// Create three deployments all running
 	d1, d2, d3 := mock.Deployment(), mock.Deployment(), mock.Deployment()
@@ -154,7 +154,7 @@ func TestWatcher_SetAllocHealth_Unknown(t *testing.T) {
 	j := mock.Job()
 	d := mock.Deployment()
 	d.JobID = j.ID
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// require that we get a call to UpsertDeploymentAllocHealth
@@ -200,7 +200,7 @@ func TestWatcher_SetAllocHealth_Healthy(t *testing.T) {
 	d.JobID = j.ID
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -245,7 +245,7 @@ func TestWatcher_SetAllocHealth_Unhealthy(t *testing.T) {
 	d.JobID = j.ID
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -303,7 +303,7 @@ func TestWatcher_SetAllocHealth_Unhealthy_Rollback(t *testing.T) {
 	d.TaskGroups["web"].AutoRevert = true
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -313,7 +313,7 @@ func TestWatcher_SetAllocHealth_Unhealthy_Rollback(t *testing.T) {
 	// Modify the job to make its specification different
 	j2.Meta["foo"] = "bar"
 
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j2), "UpsertJob2")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j2), "UpsertJob2")
 
 	// require that we get a call to UpsertDeploymentAllocHealth
 	matchConfig := &matchDeploymentAllocHealthRequestConfig{
@@ -370,7 +370,7 @@ func TestWatcher_SetAllocHealth_Unhealthy_NoRollback(t *testing.T) {
 	d.TaskGroups["web"].AutoRevert = true
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -378,7 +378,7 @@ func TestWatcher_SetAllocHealth_Unhealthy_NoRollback(t *testing.T) {
 	j2 := j.Copy()
 	j2.Stable = false
 
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j2), "UpsertJob2")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j2), "UpsertJob2")
 
 	// require that we get a call to UpsertDeploymentAllocHealth
 	matchConfig := &matchDeploymentAllocHealthRequestConfig{
@@ -438,7 +438,7 @@ func TestWatcher_PromoteDeployment_HealthyCanaries(t *testing.T) {
 		Healthy: helper.BoolToPtr(true),
 	}
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -495,7 +495,7 @@ func TestWatcher_PromoteDeployment_UnhealthyCanaries(t *testing.T) {
 	d.TaskGroups[a.TaskGroup].PlacedCanaries = []string{a.ID}
 	d.TaskGroups[a.TaskGroup].DesiredCanaries = 2
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -574,7 +574,7 @@ func TestWatcher_AutoPromoteDeployment(t *testing.T) {
 
 	d.TaskGroups[a.TaskGroup].PlacedCanaries = []string{a.ID, b.ID}
 	d.TaskGroups[a.TaskGroup].DesiredCanaries = 2
-	require.NoError(t, m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.NoError(t, m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.NoError(t, m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.NoError(t, m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a, b}), "UpsertAllocs")
 
@@ -667,7 +667,7 @@ func TestWatcher_PauseDeployment_Pause_Running(t *testing.T) {
 	j := mock.Job()
 	d := mock.Deployment()
 	d.JobID = j.ID
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// require that we get a call to UpsertDeploymentStatusUpdate
@@ -710,7 +710,7 @@ func TestWatcher_PauseDeployment_Pause_Paused(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 	d.Status = structs.DeploymentStatusPaused
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// require that we get a call to UpsertDeploymentStatusUpdate
@@ -750,7 +750,7 @@ func TestWatcher_PauseDeployment_Unpause_Paused(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 	d.Status = structs.DeploymentStatusPaused
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// require that we get a call to UpsertDeploymentStatusUpdate
@@ -790,7 +790,7 @@ func TestWatcher_PauseDeployment_Unpause_Running(t *testing.T) {
 	j := mock.Job()
 	d := mock.Deployment()
 	d.JobID = j.ID
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// require that we get a call to UpsertDeploymentStatusUpdate
@@ -830,7 +830,7 @@ func TestWatcher_FailDeployment_Running(t *testing.T) {
 	j := mock.Job()
 	d := mock.Deployment()
 	d.JobID = j.ID
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// require that we get a call to UpsertDeploymentStatusUpdate
@@ -878,7 +878,7 @@ func TestDeploymentWatcher_Watch_NoProgressDeadline(t *testing.T) {
 	d.TaskGroups["web"].AutoRevert = true
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -887,7 +887,7 @@ func TestDeploymentWatcher_Watch_NoProgressDeadline(t *testing.T) {
 	// Modify the job to make its specification different
 	j2.Meta["foo"] = "bar"
 	j2.Stable = false
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j2), "UpsertJob2")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j2), "UpsertJob2")
 
 	// require that we will get a update allocation call only once. This will
 	// verify that the watcher is batching allocation changes
@@ -1000,7 +1000,7 @@ func TestDeploymentWatcher_Watch_ProgressDeadline(t *testing.T) {
 	a.CreateTime = now.UnixNano()
 	a.ModifyTime = now.UnixNano()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -1095,7 +1095,7 @@ func TestDeploymentWatcher_ProgressCutoff(t *testing.T) {
 	a2.ModifyTime = now.UnixNano()
 	a2.DeploymentID = d.ID
 
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a, a2}), "UpsertAllocs")
 
@@ -1189,7 +1189,7 @@ func TestDeploymentWatcher_Watch_ProgressDeadline_Canaries(t *testing.T) {
 	a.CreateTime = now.UnixNano()
 	a.ModifyTime = now.UnixNano()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -1281,7 +1281,7 @@ func TestDeploymentWatcher_PromotedCanary_UpdatedAllocs(t *testing.T) {
 		Healthy:   helper.BoolToPtr(true),
 		Timestamp: now,
 	}
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -1354,7 +1354,7 @@ func TestDeploymentWatcher_Watch_StartWithoutProgressDeadline(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	a := mock.Alloc()
@@ -1415,7 +1415,7 @@ func TestDeploymentWatcher_RollbackFailed(t *testing.T) {
 	d.TaskGroups["web"].AutoRevert = true
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -1423,7 +1423,7 @@ func TestDeploymentWatcher_RollbackFailed(t *testing.T) {
 	j2 := j.Copy()
 	// Modify the job to make its specification different
 	j2.Stable = false
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j2), "UpsertJob2")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j2), "UpsertJob2")
 
 	// require that we will get a createEvaluation call only once. This will
 	// verify that the watcher is batching allocation changes
@@ -1538,8 +1538,8 @@ func TestWatcher_BatchAllocUpdates(t *testing.T) {
 	a2.JobID = j2.ID
 	a2.DeploymentID = d2.ID
 
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j1), "UpsertJob")
-	require.Nil(m.state.UpsertJob(m.nextIndex(), j2), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j1), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j2), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d1), "UpsertDeployment")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d2), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a1}), "UpsertAllocs")

--- a/nomad/deploymentwatcher/testutil_test.go
+++ b/nomad/deploymentwatcher/testutil_test.go
@@ -89,7 +89,7 @@ func matchUpdateAllocDesiredTransitionReschedule(allocIDs []string) func(update 
 func (m *mockBackend) UpsertJob(job *structs.Job) (uint64, error) {
 	m.Called(job)
 	i := m.nextIndex()
-	return i, m.state.UpsertJob(i, job)
+	return i, m.state.UpsertJob(structs.MsgTypeTestSetup, i, job)
 }
 
 func (m *mockBackend) UpdateDeploymentStatus(u *structs.DeploymentStatusUpdateRequest) (uint64, error) {

--- a/nomad/drainer/draining_node_test.go
+++ b/nomad/drainer/draining_node_test.go
@@ -67,7 +67,7 @@ func TestDrainingNode_Table(t *testing.T) {
 				alloc := mock.BatchAlloc()
 				alloc.NodeID = dn.node.ID
 				require.Nil(t, dn.state.UpsertJob(101, alloc.Job))
-				require.Nil(t, dn.state.UpsertAllocs(102, []*structs.Allocation{alloc}))
+				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, []*structs.Allocation{alloc}))
 			},
 		},
 		{
@@ -79,7 +79,7 @@ func TestDrainingNode_Table(t *testing.T) {
 				alloc := mock.Alloc()
 				alloc.NodeID = dn.node.ID
 				require.Nil(t, dn.state.UpsertJob(101, alloc.Job))
-				require.Nil(t, dn.state.UpsertAllocs(102, []*structs.Allocation{alloc}))
+				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, []*structs.Allocation{alloc}))
 			},
 		},
 		{
@@ -91,7 +91,7 @@ func TestDrainingNode_Table(t *testing.T) {
 				alloc := mock.SystemAlloc()
 				alloc.NodeID = dn.node.ID
 				require.Nil(t, dn.state.UpsertJob(101, alloc.Job))
-				require.Nil(t, dn.state.UpsertAllocs(102, []*structs.Allocation{alloc}))
+				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, []*structs.Allocation{alloc}))
 			},
 		},
 		{
@@ -105,7 +105,7 @@ func TestDrainingNode_Table(t *testing.T) {
 					a.NodeID = dn.node.ID
 					require.Nil(t, dn.state.UpsertJob(101, a.Job))
 				}
-				require.Nil(t, dn.state.UpsertAllocs(102, allocs))
+				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 
 				// StateStore doesn't like inserting new allocs
 				// with a terminal status, so set the status in
@@ -113,7 +113,7 @@ func TestDrainingNode_Table(t *testing.T) {
 				for _, a := range allocs {
 					a.ClientStatus = structs.AllocClientStatusComplete
 				}
-				require.Nil(t, dn.state.UpsertAllocs(103, allocs))
+				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 103, allocs))
 			},
 		},
 		{
@@ -127,11 +127,11 @@ func TestDrainingNode_Table(t *testing.T) {
 					a.NodeID = dn.node.ID
 					require.Nil(t, dn.state.UpsertJob(101, a.Job))
 				}
-				require.Nil(t, dn.state.UpsertAllocs(102, allocs))
+				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 
 				// Set only the service job as terminal
 				allocs[0].ClientStatus = structs.AllocClientStatusComplete
-				require.Nil(t, dn.state.UpsertAllocs(103, allocs))
+				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 103, allocs))
 			},
 		},
 		{
@@ -145,12 +145,12 @@ func TestDrainingNode_Table(t *testing.T) {
 					a.NodeID = dn.node.ID
 					require.Nil(t, dn.state.UpsertJob(101, a.Job))
 				}
-				require.Nil(t, dn.state.UpsertAllocs(102, allocs))
+				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 
 				// Set only the service and batch jobs as terminal
 				allocs[0].ClientStatus = structs.AllocClientStatusComplete
 				allocs[2].ClientStatus = structs.AllocClientStatusComplete
-				require.Nil(t, dn.state.UpsertAllocs(103, allocs))
+				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 103, allocs))
 			},
 		},
 		{
@@ -164,12 +164,12 @@ func TestDrainingNode_Table(t *testing.T) {
 					a.NodeID = dn.node.ID
 					require.Nil(t, dn.state.UpsertJob(101, a.Job))
 				}
-				require.Nil(t, dn.state.UpsertAllocs(102, allocs))
+				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 
 				// Set only the service and batch jobs as terminal
 				allocs[0].ClientStatus = structs.AllocClientStatusComplete
 				allocs[1].ClientStatus = structs.AllocClientStatusComplete
-				require.Nil(t, dn.state.UpsertAllocs(103, allocs))
+				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 103, allocs))
 			},
 		},
 		{
@@ -190,13 +190,13 @@ func TestDrainingNode_Table(t *testing.T) {
 					a.NodeID = dn.node.ID
 					require.Nil(t, dn.state.UpsertJob(101, a.Job))
 				}
-				require.Nil(t, dn.state.UpsertAllocs(102, allocs))
+				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 
 				// Set only the service and batch jobs as terminal
 				allocs[0].ClientStatus = structs.AllocClientStatusComplete
 				allocs[1].ClientStatus = structs.AllocClientStatusComplete
 				allocs[2].ClientStatus = structs.AllocClientStatusComplete
-				require.Nil(t, dn.state.UpsertAllocs(103, allocs))
+				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 103, allocs))
 			},
 		},
 	}

--- a/nomad/drainer/draining_node_test.go
+++ b/nomad/drainer/draining_node_test.go
@@ -23,7 +23,7 @@ func testDrainingNode(t *testing.T) *drainingNode {
 		ForceDeadline: time.Now().Add(time.Hour),
 	}
 
-	require.Nil(t, state.UpsertNode(structs.MsgTypeTestSetup, node, 100))
+	require.Nil(t, state.UpsertNode(structs.MsgTypeTestSetup, 100, node))
 	return NewDrainingNode(node, state)
 }
 

--- a/nomad/drainer/draining_node_test.go
+++ b/nomad/drainer/draining_node_test.go
@@ -66,7 +66,7 @@ func TestDrainingNode_Table(t *testing.T) {
 			setup: func(t *testing.T, dn *drainingNode) {
 				alloc := mock.BatchAlloc()
 				alloc.NodeID = dn.node.ID
-				require.Nil(t, dn.state.UpsertJob(101, alloc.Job))
+				require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, alloc.Job))
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, []*structs.Allocation{alloc}))
 			},
 		},
@@ -78,7 +78,7 @@ func TestDrainingNode_Table(t *testing.T) {
 			setup: func(t *testing.T, dn *drainingNode) {
 				alloc := mock.Alloc()
 				alloc.NodeID = dn.node.ID
-				require.Nil(t, dn.state.UpsertJob(101, alloc.Job))
+				require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, alloc.Job))
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, []*structs.Allocation{alloc}))
 			},
 		},
@@ -90,7 +90,7 @@ func TestDrainingNode_Table(t *testing.T) {
 			setup: func(t *testing.T, dn *drainingNode) {
 				alloc := mock.SystemAlloc()
 				alloc.NodeID = dn.node.ID
-				require.Nil(t, dn.state.UpsertJob(101, alloc.Job))
+				require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, alloc.Job))
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, []*structs.Allocation{alloc}))
 			},
 		},
@@ -103,7 +103,7 @@ func TestDrainingNode_Table(t *testing.T) {
 				allocs := []*structs.Allocation{mock.Alloc(), mock.BatchAlloc(), mock.SystemAlloc()}
 				for _, a := range allocs {
 					a.NodeID = dn.node.ID
-					require.Nil(t, dn.state.UpsertJob(101, a.Job))
+					require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, a.Job))
 				}
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 
@@ -125,7 +125,7 @@ func TestDrainingNode_Table(t *testing.T) {
 				allocs := []*structs.Allocation{mock.Alloc(), mock.BatchAlloc(), mock.SystemAlloc()}
 				for _, a := range allocs {
 					a.NodeID = dn.node.ID
-					require.Nil(t, dn.state.UpsertJob(101, a.Job))
+					require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, a.Job))
 				}
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 
@@ -143,7 +143,7 @@ func TestDrainingNode_Table(t *testing.T) {
 				allocs := []*structs.Allocation{mock.Alloc(), mock.BatchAlloc(), mock.SystemAlloc()}
 				for _, a := range allocs {
 					a.NodeID = dn.node.ID
-					require.Nil(t, dn.state.UpsertJob(101, a.Job))
+					require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, a.Job))
 				}
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 
@@ -162,7 +162,7 @@ func TestDrainingNode_Table(t *testing.T) {
 				allocs := []*structs.Allocation{mock.Alloc(), mock.BatchAlloc(), mock.SystemAlloc()}
 				for _, a := range allocs {
 					a.NodeID = dn.node.ID
-					require.Nil(t, dn.state.UpsertJob(101, a.Job))
+					require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, a.Job))
 				}
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 
@@ -188,7 +188,7 @@ func TestDrainingNode_Table(t *testing.T) {
 				}
 				for _, a := range allocs {
 					a.NodeID = dn.node.ID
-					require.Nil(t, dn.state.UpsertJob(101, a.Job))
+					require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, a.Job))
 				}
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 

--- a/nomad/drainer/draining_node_test.go
+++ b/nomad/drainer/draining_node_test.go
@@ -23,7 +23,7 @@ func testDrainingNode(t *testing.T) *drainingNode {
 		ForceDeadline: time.Now().Add(time.Hour),
 	}
 
-	require.Nil(t, state.UpsertNode(100, node))
+	require.Nil(t, state.UpsertNode(structs.MsgTypeTestSetup, node, 100))
 	return NewDrainingNode(node, state)
 }
 

--- a/nomad/drainer/watch_jobs_test.go
+++ b/nomad/drainer/watch_jobs_test.go
@@ -140,7 +140,7 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 			allocs = append(allocs, a)
 		}
 
-		require.Nil(state.UpsertAllocs(index, allocs))
+		require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, index, allocs))
 		index++
 
 	}
@@ -162,7 +162,7 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 		// create a copy so we can reuse this slice
 		drainedAllocs[i] = a.Copy()
 	}
-	require.Nil(state.UpsertAllocs(index, drainedAllocs))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, index, drainedAllocs))
 	drains.Resp.Respond(index, nil)
 	index++
 
@@ -189,7 +189,7 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 		updates = append(updates, a, replacement)
 		replacements[i] = replacement.Copy()
 	}
-	require.Nil(state.UpsertAllocs(index, updates))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, index, updates))
 	index++
 
 	// The drained allocs stopping cause migrations but no new drains
@@ -203,7 +203,7 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 			Healthy: helper.BoolToPtr(true),
 		}
 	}
-	require.Nil(state.UpsertAllocs(index, replacements))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, index, replacements))
 	index++
 
 	require.NotEmpty(jobWatcher.drainingJobs())
@@ -219,7 +219,7 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 		// create a copy so we can reuse this slice
 		drainedAllocs[i] = a.Copy()
 	}
-	require.Nil(state.UpsertAllocs(index, drainedAllocs))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, index, drainedAllocs))
 	drains.Resp.Respond(index, nil)
 	index++
 
@@ -235,7 +235,7 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 		updates = append(updates, a, replacement)
 		replacements[i] = replacement.Copy()
 	}
-	require.Nil(state.UpsertAllocs(index, updates))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, index, updates))
 	index++
 
 	assertJobWatcherOps(t, jobWatcher, 0, 6)
@@ -246,7 +246,7 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 			Healthy: helper.BoolToPtr(true),
 		}
 	}
-	require.Nil(state.UpsertAllocs(index, replacements))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, index, replacements))
 	index++
 
 	require.NotEmpty(jobWatcher.drainingJobs())
@@ -262,7 +262,7 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 		// create a copy so we can reuse this slice
 		drainedAllocs[i] = a.Copy()
 	}
-	require.Nil(state.UpsertAllocs(index, drainedAllocs))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, index, drainedAllocs))
 	drains.Resp.Respond(index, nil)
 	index++
 
@@ -278,7 +278,7 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 		updates = append(updates, a, replacement)
 		replacements[i] = replacement.Copy()
 	}
-	require.Nil(state.UpsertAllocs(index, updates))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, index, updates))
 	index++
 
 	assertJobWatcherOps(t, jobWatcher, 0, 4)
@@ -289,7 +289,7 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 			Healthy: helper.BoolToPtr(true),
 		}
 	}
-	require.Nil(state.UpsertAllocs(index, replacements))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, index, replacements))
 
 	// No jobs should be left!
 	require.Empty(jobWatcher.drainingJobs())
@@ -585,7 +585,7 @@ func testHandleTaskGroup(t *testing.T, tc handleTaskGroupTestCase) {
 		allocs = append(allocs, a)
 	}
 
-	require.Nil(state.UpsertAllocs(103, allocs))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 103, allocs))
 	snap, err := state.Snapshot()
 	require.Nil(err)
 
@@ -634,7 +634,7 @@ func TestHandleTaskGroup_Migrations(t *testing.T) {
 		}
 		allocs = append(allocs, a)
 	}
-	require.Nil(state.UpsertAllocs(102, allocs))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 
 	snap, err := state.Snapshot()
 	require.Nil(err)
@@ -706,7 +706,7 @@ func TestHandleTaskGroup_GarbageCollectedNode(t *testing.T) {
 
 	// Make the first one be on a GC'd node
 	allocs[0].NodeID = uuid.Generate()
-	require.Nil(state.UpsertAllocs(102, allocs))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 
 	snap, err := state.Snapshot()
 	require.Nil(err)

--- a/nomad/drainer/watch_jobs_test.go
+++ b/nomad/drainer/watch_jobs_test.go
@@ -25,12 +25,12 @@ func testNodes(t *testing.T, state *state.StateStore) (drainingNode, runningNode
 		},
 		ForceDeadline: time.Now().Add(time.Minute),
 	}
-	require.Nil(t, state.UpsertNode(100, n1))
+	require.Nil(t, state.UpsertNode(structs.MsgTypeTestSetup, n1, 100))
 
 	// Create a non-draining node
 	n2 := mock.Node()
 	n2.Name = "running"
-	require.Nil(t, state.UpsertNode(101, n2))
+	require.Nil(t, state.UpsertNode(structs.MsgTypeTestSetup, n2, 101))
 	return n1, n2
 }
 
@@ -611,7 +611,7 @@ func TestHandleTaskGroup_Migrations(t *testing.T) {
 		},
 		ForceDeadline: time.Now().Add(1 * time.Minute),
 	}
-	require.Nil(state.UpsertNode(100, n))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n, 100))
 
 	job := mock.Job()
 	require.Nil(state.UpsertJob(101, job))
@@ -680,7 +680,7 @@ func TestHandleTaskGroup_GarbageCollectedNode(t *testing.T) {
 		},
 		ForceDeadline: time.Now().Add(1 * time.Minute),
 	}
-	require.Nil(state.UpsertNode(100, n))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n, 100))
 
 	job := mock.Job()
 	require.Nil(state.UpsertJob(101, job))

--- a/nomad/drainer/watch_jobs_test.go
+++ b/nomad/drainer/watch_jobs_test.go
@@ -25,12 +25,12 @@ func testNodes(t *testing.T, state *state.StateStore) (drainingNode, runningNode
 		},
 		ForceDeadline: time.Now().Add(time.Minute),
 	}
-	require.Nil(t, state.UpsertNode(structs.MsgTypeTestSetup, n1, 100))
+	require.Nil(t, state.UpsertNode(structs.MsgTypeTestSetup, 100, n1))
 
 	// Create a non-draining node
 	n2 := mock.Node()
 	n2.Name = "running"
-	require.Nil(t, state.UpsertNode(structs.MsgTypeTestSetup, n2, 101))
+	require.Nil(t, state.UpsertNode(structs.MsgTypeTestSetup, 101, n2))
 	return n1, n2
 }
 
@@ -611,7 +611,7 @@ func TestHandleTaskGroup_Migrations(t *testing.T) {
 		},
 		ForceDeadline: time.Now().Add(1 * time.Minute),
 	}
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n, 100))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 100, n))
 
 	job := mock.Job()
 	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 101, job))
@@ -680,7 +680,7 @@ func TestHandleTaskGroup_GarbageCollectedNode(t *testing.T) {
 		},
 		ForceDeadline: time.Now().Add(1 * time.Minute),
 	}
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n, 100))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 100, n))
 
 	job := mock.Job()
 	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 101, job))

--- a/nomad/drainer/watch_jobs_test.go
+++ b/nomad/drainer/watch_jobs_test.go
@@ -128,7 +128,7 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 		jnss[i] = structs.NamespacedID{Namespace: job.Namespace, ID: job.ID}
 		job.TaskGroups[0].Migrate.MaxParallel = 3
 		job.TaskGroups[0].Count = count
-		require.Nil(state.UpsertJob(index, job))
+		require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, index, job))
 		index++
 
 		var allocs []*structs.Allocation
@@ -562,7 +562,7 @@ func testHandleTaskGroup(t *testing.T, tc handleTaskGroupTestCase) {
 	if tc.MaxParallel > 0 {
 		job.TaskGroups[0].Migrate.MaxParallel = tc.MaxParallel
 	}
-	require.Nil(state.UpsertJob(102, job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 102, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -614,7 +614,7 @@ func TestHandleTaskGroup_Migrations(t *testing.T) {
 	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n, 100))
 
 	job := mock.Job()
-	require.Nil(state.UpsertJob(101, job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 101, job))
 
 	// Create 10 done allocs
 	var allocs []*structs.Allocation
@@ -683,7 +683,7 @@ func TestHandleTaskGroup_GarbageCollectedNode(t *testing.T) {
 	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n, 100))
 
 	job := mock.Job()
-	require.Nil(state.UpsertJob(101, job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 101, job))
 
 	// Create 10 done allocs
 	var allocs []*structs.Allocation

--- a/nomad/drainer/watch_nodes_test.go
+++ b/nomad/drainer/watch_nodes_test.go
@@ -126,7 +126,7 @@ func TestNodeDrainWatcher_Remove_Nonexistent(t *testing.T) {
 	require.Equal(n, tracked[n.ID])
 
 	// Delete the node
-	require.Nil(state.DeleteNode(101, []string{n.ID}))
+	require.Nil(state.DeleteNode(structs.MsgTypeTestSetup, 101, []string{n.ID}))
 	testutil.WaitForResult(func() (bool, error) {
 		return len(m.events()) == 2, nil
 	}, func(err error) {

--- a/nomad/drainer/watch_nodes_test.go
+++ b/nomad/drainer/watch_nodes_test.go
@@ -45,8 +45,8 @@ func TestNodeDrainWatcher_AddDraining(t *testing.T) {
 		ForceDeadline: time.Now().Add(time.Hour),
 	}
 
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n1, 100))
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n2, 101))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 100, n1))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 101, n2))
 
 	testutil.WaitForResult(func() (bool, error) {
 		return len(m.events()) == 1, nil
@@ -76,7 +76,7 @@ func TestNodeDrainWatcher_Remove(t *testing.T) {
 	}
 
 	// Wait for it to be tracked
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n, 100))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 100, n))
 	testutil.WaitForResult(func() (bool, error) {
 		return len(m.events()) == 1, nil
 	}, func(err error) {
@@ -114,7 +114,7 @@ func TestNodeDrainWatcher_Remove_Nonexistent(t *testing.T) {
 	}
 
 	// Wait for it to be tracked
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n, 100))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 100, n))
 	testutil.WaitForResult(func() (bool, error) {
 		return len(m.events()) == 1, nil
 	}, func(err error) {
@@ -152,7 +152,7 @@ func TestNodeDrainWatcher_Update(t *testing.T) {
 	}
 
 	// Wait for it to be tracked
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n, 100))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 100, n))
 	testutil.WaitForResult(func() (bool, error) {
 		return len(m.events()) == 1, nil
 	}, func(err error) {

--- a/nomad/drainer/watch_nodes_test.go
+++ b/nomad/drainer/watch_nodes_test.go
@@ -88,7 +88,7 @@ func TestNodeDrainWatcher_Remove(t *testing.T) {
 	require.Equal(n, tracked[n.ID])
 
 	// Change the node to be not draining and wait for it to be untracked
-	require.Nil(state.UpdateNodeDrain(101, n.ID, nil, false, 0, nil))
+	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 101, n.ID, nil, false, 0, nil))
 	testutil.WaitForResult(func() (bool, error) {
 		return len(m.events()) == 2, nil
 	}, func(err error) {
@@ -166,7 +166,7 @@ func TestNodeDrainWatcher_Update(t *testing.T) {
 	// Change the node to have a new spec
 	s2 := n.DrainStrategy.Copy()
 	s2.Deadline += time.Hour
-	require.Nil(state.UpdateNodeDrain(101, n.ID, s2, false, 0, nil))
+	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 101, n.ID, s2, false, 0, nil))
 
 	// Wait for it to be updated
 	testutil.WaitForResult(func() (bool, error) {

--- a/nomad/drainer/watch_nodes_test.go
+++ b/nomad/drainer/watch_nodes_test.go
@@ -45,8 +45,8 @@ func TestNodeDrainWatcher_AddDraining(t *testing.T) {
 		ForceDeadline: time.Now().Add(time.Hour),
 	}
 
-	require.Nil(state.UpsertNode(100, n1))
-	require.Nil(state.UpsertNode(101, n2))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n1, 100))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n2, 101))
 
 	testutil.WaitForResult(func() (bool, error) {
 		return len(m.events()) == 1, nil
@@ -76,7 +76,7 @@ func TestNodeDrainWatcher_Remove(t *testing.T) {
 	}
 
 	// Wait for it to be tracked
-	require.Nil(state.UpsertNode(100, n))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n, 100))
 	testutil.WaitForResult(func() (bool, error) {
 		return len(m.events()) == 1, nil
 	}, func(err error) {
@@ -114,7 +114,7 @@ func TestNodeDrainWatcher_Remove_Nonexistent(t *testing.T) {
 	}
 
 	// Wait for it to be tracked
-	require.Nil(state.UpsertNode(100, n))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n, 100))
 	testutil.WaitForResult(func() (bool, error) {
 		return len(m.events()) == 1, nil
 	}, func(err error) {
@@ -152,7 +152,7 @@ func TestNodeDrainWatcher_Update(t *testing.T) {
 	}
 
 	// Wait for it to be tracked
-	require.Nil(state.UpsertNode(100, n))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n, 100))
 	testutil.WaitForResult(func() (bool, error) {
 		return len(m.events()) == 1, nil
 	}, func(err error) {

--- a/nomad/drainer_int_test.go
+++ b/nomad/drainer_int_test.go
@@ -798,7 +798,7 @@ func TestDrainer_AllTypes_Deadline_GarbageCollectedNode(t *testing.T) {
 		alloc.ClientStatus = structs.AllocClientStatusComplete
 		badAllocs = append(badAllocs, alloc)
 	}
-	require.NoError(state.UpsertAllocs(1, badAllocs))
+	require.NoError(state.UpsertAllocs(structs.MsgTypeTestSetup, 1, badAllocs))
 
 	// Create the second node
 	nodeReg = &structs.NodeRegisterRequest{

--- a/nomad/eval_endpoint_test.go
+++ b/nomad/eval_endpoint_test.go
@@ -866,8 +866,7 @@ func TestEvalEndpoint_Allocations(t *testing.T) {
 	state := s1.fsm.State()
 	state.UpsertJobSummary(998, mock.JobSummary(alloc1.JobID))
 	state.UpsertJobSummary(999, mock.JobSummary(alloc2.JobID))
-	err := state.UpsertAllocs(1000,
-		[]*structs.Allocation{alloc1, alloc2})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1, alloc2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -906,7 +905,7 @@ func TestEvalEndpoint_Allocations_ACL(t *testing.T) {
 	state := s1.fsm.State()
 	assert.Nil(state.UpsertJobSummary(998, mock.JobSummary(alloc1.JobID)))
 	assert.Nil(state.UpsertJobSummary(999, mock.JobSummary(alloc2.JobID)))
-	assert.Nil(state.UpsertAllocs(1000, []*structs.Allocation{alloc1, alloc2}))
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1, alloc2}))
 
 	// Create ACL tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1003, "test-valid",
@@ -971,7 +970,7 @@ func TestEvalEndpoint_Allocations_Blocking(t *testing.T) {
 	// Upsert an unrelated alloc first
 	time.AfterFunc(100*time.Millisecond, func() {
 		state.UpsertJobSummary(99, mock.JobSummary(alloc1.JobID))
-		err := state.UpsertAllocs(100, []*structs.Allocation{alloc1})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc1})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -980,7 +979,7 @@ func TestEvalEndpoint_Allocations_Blocking(t *testing.T) {
 	// Upsert an alloc which will trigger the watch later
 	time.AfterFunc(200*time.Millisecond, func() {
 		state.UpsertJobSummary(199, mock.JobSummary(alloc2.JobID))
-		err := state.UpsertAllocs(200, []*structs.Allocation{alloc2})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 200, []*structs.Allocation{alloc2})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/nomad/eval_endpoint_test.go
+++ b/nomad/eval_endpoint_test.go
@@ -29,7 +29,7 @@ func TestEvalEndpoint_GetEval(t *testing.T) {
 
 	// Create the register request
 	eval1 := mock.Eval()
-	s1.fsm.State().UpsertEvals(1000, []*structs.Evaluation{eval1})
+	s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1})
 
 	// Lookup the eval
 	get := &structs.EvalSpecificRequest{
@@ -73,7 +73,7 @@ func TestEvalEndpoint_GetEval_ACL(t *testing.T) {
 	// Create the register request
 	eval1 := mock.Eval()
 	state := s1.fsm.State()
-	state.UpsertEvals(1000, []*structs.Evaluation{eval1})
+	state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1})
 
 	// Create ACL tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1003, "test-valid",
@@ -137,7 +137,7 @@ func TestEvalEndpoint_GetEval_Blocking(t *testing.T) {
 
 	// First create an unrelated eval
 	time.AfterFunc(100*time.Millisecond, func() {
-		err := state.UpsertEvals(100, []*structs.Evaluation{eval1})
+		err := state.UpsertEvals(structs.MsgTypeTestSetup, 100, []*structs.Evaluation{eval1})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -145,7 +145,7 @@ func TestEvalEndpoint_GetEval_Blocking(t *testing.T) {
 
 	// Upsert the eval we are watching later
 	time.AfterFunc(200*time.Millisecond, func() {
-		err := state.UpsertEvals(200, []*structs.Evaluation{eval2})
+		err := state.UpsertEvals(structs.MsgTypeTestSetup, 200, []*structs.Evaluation{eval2})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -260,9 +260,9 @@ func TestEvalEndpoint_Dequeue_WaitIndex_Snapshot(t *testing.T) {
 	eval1 := mock.Eval()
 	eval2 := mock.Eval()
 	eval2.JobID = eval1.JobID
-	s1.fsm.State().UpsertEvals(1000, []*structs.Evaluation{eval1})
+	s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1})
 	s1.evalBroker.Enqueue(eval1)
-	s1.fsm.State().UpsertEvals(1001, []*structs.Evaluation{eval2})
+	s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 1001, []*structs.Evaluation{eval2})
 
 	// Dequeue the eval
 	get := &structs.EvalDequeueRequest{
@@ -310,7 +310,7 @@ func TestEvalEndpoint_Dequeue_WaitIndex_Eval(t *testing.T) {
 	eval1 := mock.Eval()
 	eval2 := mock.Eval()
 	eval2.JobID = eval1.JobID
-	s1.fsm.State().UpsertEvals(1000, []*structs.Evaluation{eval1})
+	s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1})
 	eval2.ModifyIndex = 1001
 	s1.evalBroker.Enqueue(eval2)
 
@@ -351,7 +351,7 @@ func TestEvalEndpoint_Dequeue_UpdateWaitIndex(t *testing.T) {
 
 	state := s1.fsm.State()
 
-	if err := state.UpsertJob(999, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -359,7 +359,7 @@ func TestEvalEndpoint_Dequeue_UpdateWaitIndex(t *testing.T) {
 	eval.JobID = job.ID
 
 	// Create an eval
-	if err := state.UpsertEvals(1, []*structs.Evaluation{eval}); err != nil {
+	if err := state.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{eval}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -636,7 +636,7 @@ func TestEvalEndpoint_Reap(t *testing.T) {
 
 	// Create the register request
 	eval1 := mock.Eval()
-	s1.fsm.State().UpsertEvals(1000, []*structs.Evaluation{eval1})
+	s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1})
 
 	// Reap the eval
 	get := &structs.EvalDeleteRequest{
@@ -675,7 +675,7 @@ func TestEvalEndpoint_List(t *testing.T) {
 	eval1.ID = "aaaaaaaa-3350-4b4b-d185-0e1992ed43e9"
 	eval2 := mock.Eval()
 	eval2.ID = "aaaabbbb-3350-4b4b-d185-0e1992ed43e9"
-	s1.fsm.State().UpsertEvals(1000, []*structs.Evaluation{eval1, eval2})
+	s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1, eval2})
 
 	// Lookup the eval
 	get := &structs.EvalListRequest{
@@ -733,7 +733,7 @@ func TestEvalEndpoint_List_ACL(t *testing.T) {
 	eval2 := mock.Eval()
 	eval2.ID = "aaaabbbb-3350-4b4b-d185-0e1992ed43e9"
 	state := s1.fsm.State()
-	assert.Nil(state.UpsertEvals(1000, []*structs.Evaluation{eval1, eval2}))
+	assert.Nil(state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1, eval2}))
 
 	// Create ACL tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1003, "test-valid",
@@ -798,7 +798,7 @@ func TestEvalEndpoint_List_Blocking(t *testing.T) {
 
 	// Upsert eval triggers watches
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.UpsertEvals(2, []*structs.Evaluation{eval}); err != nil {
+		if err := state.UpsertEvals(structs.MsgTypeTestSetup, 2, []*structs.Evaluation{eval}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -1067,7 +1067,7 @@ func TestEvalEndpoint_Reblock_NonBlocked(t *testing.T) {
 	s1.evalBroker.Enqueue(eval1)
 
 	// Insert it into the state store
-	if err := s1.fsm.State().UpsertEvals(1000, []*structs.Evaluation{eval1}); err != nil {
+	if err := s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1111,7 +1111,7 @@ func TestEvalEndpoint_Reblock(t *testing.T) {
 	s1.evalBroker.Enqueue(eval1)
 
 	// Insert it into the state store
-	if err := s1.fsm.State().UpsertEvals(1000, []*structs.Evaluation{eval1}); err != nil {
+	if err := s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -339,7 +339,7 @@ func (n *nomadFSM) applyUpsertNode(reqType structs.MessageType, buf []byte, inde
 	// Handle upgrade paths
 	req.Node.Canonicalize()
 
-	if err := n.state.UpsertNodeMsgType(reqType, index, req.Node); err != nil {
+	if err := n.state.UpsertNode(reqType, req.Node, index); err != nil {
 		n.logger.Error("UpsertNode failed", "error", err)
 		return err
 	}

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -339,7 +339,7 @@ func (n *nomadFSM) applyUpsertNode(reqType structs.MessageType, buf []byte, inde
 	// Handle upgrade paths
 	req.Node.Canonicalize()
 
-	if err := n.state.UpsertNode(reqType, req.Node, index); err != nil {
+	if err := n.state.UpsertNode(reqType, index, req.Node); err != nil {
 		n.logger.Error("UpsertNode failed", "error", err)
 		return err
 	}

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -85,7 +85,7 @@ func TestFSM_UpsertNodeEvents(t *testing.T) {
 
 	node := mock.Node()
 
-	err := state.UpsertNode(1000, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -408,7 +408,7 @@ func TestFSM_UpdateNodeDrain_Pre08_Compatibility(t *testing.T) {
 	// Force a node into the state store without eligiblity
 	node := mock.Node()
 	node.SchedulingEligibility = ""
-	require.Nil(fsm.State().UpsertNode(1, node))
+	require.Nil(fsm.State().UpsertNode(structs.MsgTypeTestSetup, node, 1))
 
 	// Do an old style drain
 	req := structs.NodeUpdateDrainRequest{
@@ -1449,7 +1449,7 @@ func TestFSM_UpdateAllocFromClient_Unblock(t *testing.T) {
 	state := fsm.State()
 
 	node := mock.Node()
-	state.UpsertNode(1, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 1)
 
 	// Mark an eval as blocked.
 	eval := mock.Eval()
@@ -2494,12 +2494,12 @@ func TestFSM_SnapshotRestore_Nodes(t *testing.T) {
 	fsm := testFSM(t)
 	state := fsm.State()
 	node1 := mock.Node()
-	state.UpsertNode(1000, node1)
+	state.UpsertNode(structs.MsgTypeTestSetup, node1, 1000)
 
 	// Upgrade this node
 	node2 := mock.Node()
 	node2.SchedulingEligibility = ""
-	state.UpsertNode(1001, node2)
+	state.UpsertNode(structs.MsgTypeTestSetup, node2, 1001)
 
 	// Verify the contents
 	fsm2 := testSnapshotRestore(t, fsm)
@@ -2622,7 +2622,7 @@ func TestFSM_SnapshotRestore_Indexes(t *testing.T) {
 	fsm := testFSM(t)
 	state := fsm.State()
 	node1 := mock.Node()
-	state.UpsertNode(1000, node1)
+	state.UpsertNode(structs.MsgTypeTestSetup, node1, 1000)
 
 	// Verify the contents
 	fsm2 := testSnapshotRestore(t, fsm)
@@ -2891,7 +2891,7 @@ func TestFSM_ReconcileSummaries(t *testing.T) {
 
 	// Add a node
 	node := mock.Node()
-	require.NoError(t, state.UpsertNode(800, node))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node, 800))
 
 	// Make a job so that none of the tasks can be placed
 	job1 := mock.Job()
@@ -2973,7 +2973,7 @@ func TestFSM_ReconcileParentJobSummary(t *testing.T) {
 
 	// Add a node
 	node := mock.Node()
-	state.UpsertNode(800, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 800)
 
 	// Make a parameterized job
 	job1 := mock.BatchJob()

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -85,7 +85,7 @@ func TestFSM_UpsertNodeEvents(t *testing.T) {
 
 	node := mock.Node()
 
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -408,7 +408,7 @@ func TestFSM_UpdateNodeDrain_Pre08_Compatibility(t *testing.T) {
 	// Force a node into the state store without eligiblity
 	node := mock.Node()
 	node.SchedulingEligibility = ""
-	require.Nil(fsm.State().UpsertNode(structs.MsgTypeTestSetup, node, 1))
+	require.Nil(fsm.State().UpsertNode(structs.MsgTypeTestSetup, 1, node))
 
 	// Do an old style drain
 	req := structs.NodeUpdateDrainRequest{
@@ -1449,7 +1449,7 @@ func TestFSM_UpdateAllocFromClient_Unblock(t *testing.T) {
 	state := fsm.State()
 
 	node := mock.Node()
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 1)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1, node)
 
 	// Mark an eval as blocked.
 	eval := mock.Eval()
@@ -2494,12 +2494,12 @@ func TestFSM_SnapshotRestore_Nodes(t *testing.T) {
 	fsm := testFSM(t)
 	state := fsm.State()
 	node1 := mock.Node()
-	state.UpsertNode(structs.MsgTypeTestSetup, node1, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node1)
 
 	// Upgrade this node
 	node2 := mock.Node()
 	node2.SchedulingEligibility = ""
-	state.UpsertNode(structs.MsgTypeTestSetup, node2, 1001)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1001, node2)
 
 	// Verify the contents
 	fsm2 := testSnapshotRestore(t, fsm)
@@ -2622,7 +2622,7 @@ func TestFSM_SnapshotRestore_Indexes(t *testing.T) {
 	fsm := testFSM(t)
 	state := fsm.State()
 	node1 := mock.Node()
-	state.UpsertNode(structs.MsgTypeTestSetup, node1, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node1)
 
 	// Verify the contents
 	fsm2 := testSnapshotRestore(t, fsm)
@@ -2891,7 +2891,7 @@ func TestFSM_ReconcileSummaries(t *testing.T) {
 
 	// Add a node
 	node := mock.Node()
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node, 800))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 800, node))
 
 	// Make a job so that none of the tasks can be placed
 	job1 := mock.Job()
@@ -2973,7 +2973,7 @@ func TestFSM_ReconcileParentJobSummary(t *testing.T) {
 
 	// Add a node
 	node := mock.Node()
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 800)
+	state.UpsertNode(structs.MsgTypeTestSetup, 800, node)
 
 	// Make a parameterized job
 	job1 := mock.BatchJob()

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -1468,7 +1468,7 @@ func TestFSM_UpdateAllocFromClient_Unblock(t *testing.T) {
 	alloc2.NodeID = node.ID
 	state.UpsertJobSummary(8, mock.JobSummary(alloc.JobID))
 	state.UpsertJobSummary(9, mock.JobSummary(alloc2.JobID))
-	state.UpsertAllocs(10, []*structs.Allocation{alloc, alloc2})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 10, []*structs.Allocation{alloc, alloc2})
 
 	clientAlloc := new(structs.Allocation)
 	*clientAlloc = *alloc
@@ -1535,7 +1535,7 @@ func TestFSM_UpdateAllocFromClient(t *testing.T) {
 
 	alloc := mock.Alloc()
 	state.UpsertJobSummary(9, mock.JobSummary(alloc.JobID))
-	state.UpsertAllocs(10, []*structs.Allocation{alloc})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 10, []*structs.Allocation{alloc})
 
 	clientAlloc := new(structs.Allocation)
 	*clientAlloc = *alloc
@@ -1586,7 +1586,7 @@ func TestFSM_UpdateAllocDesiredTransition(t *testing.T) {
 	alloc2.Job = alloc.Job
 	alloc2.JobID = alloc.JobID
 	state.UpsertJobSummary(9, mock.JobSummary(alloc.JobID))
-	state.UpsertAllocs(10, []*structs.Allocation{alloc, alloc2})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 10, []*structs.Allocation{alloc, alloc2})
 
 	t1 := &structs.DesiredTransition{
 		Migrate: helper.BoolToPtr(true),
@@ -1835,7 +1835,7 @@ func TestFSM_ApplyPlanResults(t *testing.T) {
 	alloc2.JobID = job2.ID
 	alloc2.PreemptedByAllocation = alloc.ID
 
-	fsm.State().UpsertAllocs(1, []*structs.Allocation{alloc1, alloc2})
+	fsm.State().UpsertAllocs(structs.MsgTypeTestSetup, 1, []*structs.Allocation{alloc1, alloc2})
 
 	// evals for preempted jobs
 	eval1 := mock.Eval()
@@ -2101,7 +2101,7 @@ func TestFSM_DeploymentPromotion(t *testing.T) {
 		Healthy: helper.BoolToPtr(true),
 	}
 
-	if err := state.UpsertAllocs(3, []*structs.Allocation{c1, c2}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 3, []*structs.Allocation{c1, c2}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2173,7 +2173,7 @@ func TestFSM_DeploymentAllocHealth(t *testing.T) {
 	a1.DeploymentID = d.ID
 	a2 := mock.Alloc()
 	a2.DeploymentID = d.ID
-	if err := state.UpsertAllocs(2, []*structs.Allocation{a1, a2}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 2, []*structs.Allocation{a1, a2}); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -2572,8 +2572,8 @@ func TestFSM_SnapshotRestore_Allocs(t *testing.T) {
 	alloc2 := mock.Alloc()
 	state.UpsertJobSummary(998, mock.JobSummary(alloc1.JobID))
 	state.UpsertJobSummary(999, mock.JobSummary(alloc2.JobID))
-	state.UpsertAllocs(1000, []*structs.Allocation{alloc1})
-	state.UpsertAllocs(1001, []*structs.Allocation{alloc2})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc2})
 
 	// Verify the contents
 	fsm2 := testSnapshotRestore(t, fsm)
@@ -2600,7 +2600,7 @@ func TestFSM_SnapshotRestore_Allocs_Canonicalize(t *testing.T) {
 	alloc.AllocatedResources = nil
 
 	state.UpsertJobSummary(998, mock.JobSummary(alloc.JobID))
-	state.UpsertAllocs(1000, []*structs.Allocation{alloc})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc})
 
 	// Verify the contents
 	fsm2 := testSnapshotRestore(t, fsm)
@@ -2902,7 +2902,7 @@ func TestFSM_ReconcileSummaries(t *testing.T) {
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
 	require.NoError(t, state.UpsertJob(1010, alloc.Job))
-	require.NoError(t, state.UpsertAllocs(1011, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	// Delete the summaries
 	require.NoError(t, state.DeleteJobSummary(1030, job1.Namespace, job1.ID))
@@ -2999,7 +2999,7 @@ func TestFSM_ReconcileParentJobSummary(t *testing.T) {
 	alloc.ClientStatus = structs.AllocClientStatusRunning
 
 	state.UpsertJob(1010, childJob)
-	state.UpsertAllocs(1011, []*structs.Allocation{alloc})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc})
 
 	// Make the summary incorrect in the state store
 	summary, err := state.JobSummaryByID(nil, job1.Namespace, job1.ID)

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -1817,7 +1817,7 @@ func TestFSM_ApplyPlanResults(t *testing.T) {
 
 	eval := mock.Eval()
 	eval.JobID = job.ID
-	fsm.State().UpsertEvals(1, []*structs.Evaluation{eval})
+	fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{eval})
 
 	fsm.State().UpsertJobSummary(1, mock.JobSummary(alloc.JobID))
 
@@ -1908,7 +1908,7 @@ func TestFSM_ApplyPlanResults(t *testing.T) {
 	eval = mock.Eval()
 	eval.JobID = job.ID
 
-	fsm.State().UpsertEvals(2, []*structs.Evaluation{eval})
+	fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 2, []*structs.Evaluation{eval})
 
 	evictAlloc.Job = nil
 	evictAlloc.DesiredStatus = structs.AllocDesiredStatusEvict
@@ -2018,7 +2018,7 @@ func TestFSM_JobStabilityUpdate(t *testing.T) {
 
 	// Upsert a deployment
 	job := mock.Job()
-	if err := state.UpsertJob(1, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, job); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -2063,7 +2063,7 @@ func TestFSM_DeploymentPromotion(t *testing.T) {
 	tg2 := tg1.Copy()
 	tg2.Name = "foo"
 	j.TaskGroups = append(j.TaskGroups, tg2)
-	if err := state.UpsertJob(1, j); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, j); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -2521,9 +2521,9 @@ func TestFSM_SnapshotRestore_Jobs(t *testing.T) {
 	fsm := testFSM(t)
 	state := fsm.State()
 	job1 := mock.Job()
-	state.UpsertJob(1000, job1)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1000, job1)
 	job2 := mock.Job()
-	state.UpsertJob(1001, job2)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1001, job2)
 
 	// Verify the contents
 	ws := memdb.NewWatchSet()
@@ -2545,9 +2545,9 @@ func TestFSM_SnapshotRestore_Evals(t *testing.T) {
 	fsm := testFSM(t)
 	state := fsm.State()
 	eval1 := mock.Eval()
-	state.UpsertEvals(1000, []*structs.Evaluation{eval1})
+	state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1})
 	eval2 := mock.Eval()
-	state.UpsertEvals(1001, []*structs.Evaluation{eval2})
+	state.UpsertEvals(structs.MsgTypeTestSetup, 1001, []*structs.Evaluation{eval2})
 
 	// Verify the contents
 	fsm2 := testSnapshotRestore(t, fsm)
@@ -2701,12 +2701,12 @@ func TestFSM_SnapshotRestore_JobSummary(t *testing.T) {
 	state := fsm.State()
 
 	job1 := mock.Job()
-	state.UpsertJob(1000, job1)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1000, job1)
 	ws := memdb.NewWatchSet()
 	js1, _ := state.JobSummaryByID(ws, job1.Namespace, job1.ID)
 
 	job2 := mock.Job()
-	state.UpsertJob(1001, job2)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1001, job2)
 	js2, _ := state.JobSummaryByID(ws, job2.Namespace, job2.ID)
 
 	// Verify the contents
@@ -2751,10 +2751,10 @@ func TestFSM_SnapshotRestore_JobVersions(t *testing.T) {
 	fsm := testFSM(t)
 	state := fsm.State()
 	job1 := mock.Job()
-	state.UpsertJob(1000, job1)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1000, job1)
 	job2 := mock.Job()
 	job2.ID = job1.ID
-	state.UpsertJob(1001, job2)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1001, job2)
 
 	// Verify the contents
 	ws := memdb.NewWatchSet()
@@ -2785,7 +2785,7 @@ func TestFSM_SnapshotRestore_Deployments(t *testing.T) {
 	d1.JobID = j.ID
 	d2.JobID = j.ID
 
-	state.UpsertJob(999, j)
+	state.UpsertJob(structs.MsgTypeTestSetup, 999, j)
 	state.UpsertDeployment(1000, d1)
 	state.UpsertDeployment(1001, d2)
 
@@ -2896,12 +2896,12 @@ func TestFSM_ReconcileSummaries(t *testing.T) {
 	// Make a job so that none of the tasks can be placed
 	job1 := mock.Job()
 	job1.TaskGroups[0].Tasks[0].Resources.CPU = 5000
-	require.NoError(t, state.UpsertJob(1000, job1))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, job1))
 
 	// make a job which can make partial progress
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
-	require.NoError(t, state.UpsertJob(1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	// Delete the summaries
@@ -2982,7 +2982,7 @@ func TestFSM_ReconcileParentJobSummary(t *testing.T) {
 		Payload: "random",
 	}
 	job1.TaskGroups[0].Count = 1
-	state.UpsertJob(1000, job1)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1000, job1)
 
 	// Make a child job
 	childJob := job1.Copy()
@@ -2998,7 +2998,7 @@ func TestFSM_ReconcileParentJobSummary(t *testing.T) {
 	alloc.JobID = childJob.ID
 	alloc.ClientStatus = structs.AllocClientStatusRunning
 
-	state.UpsertJob(1010, childJob)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1010, childJob)
 	state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc})
 
 	// Make the summary incorrect in the state store

--- a/nomad/heartbeat_test.go
+++ b/nomad/heartbeat_test.go
@@ -22,7 +22,7 @@ func TestHeartbeat_InitializeHeartbeatTimers(t *testing.T) {
 
 	node := mock.Node()
 	state := s1.fsm.State()
-	err := state.UpsertNode(1, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestHeartbeat_InvalidateHeartbeat(t *testing.T) {
 	// Create a node
 	node := mock.Node()
 	state := s1.fsm.State()
-	require.NoError(state.UpsertNode(1, node))
+	require.NoError(state.UpsertNode(structs.MsgTypeTestSetup, node, 1))
 
 	// This should cause a status update
 	s1.invalidateHeartbeat(node.ID)

--- a/nomad/heartbeat_test.go
+++ b/nomad/heartbeat_test.go
@@ -22,7 +22,7 @@ func TestHeartbeat_InitializeHeartbeatTimers(t *testing.T) {
 
 	node := mock.Node()
 	state := s1.fsm.State()
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 1, node)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestHeartbeat_InvalidateHeartbeat(t *testing.T) {
 	// Create a node
 	node := mock.Node()
 	state := s1.fsm.State()
-	require.NoError(state.UpsertNode(structs.MsgTypeTestSetup, node, 1))
+	require.NoError(state.UpsertNode(structs.MsgTypeTestSetup, 1, node))
 
 	// This should cause a status update
 	s1.invalidateHeartbeat(node.ID)

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1704,13 +1704,13 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 		if oldJob.SpecChanged(args.Job) {
 			// Insert the updated Job into the snapshot
 			updatedIndex = oldJob.JobModifyIndex + 1
-			if err := snap.UpsertJob(updatedIndex, args.Job); err != nil {
+			if err := snap.UpsertJob(structs.IgnoreUnknownTypeFlag, updatedIndex, args.Job); err != nil {
 				return err
 			}
 		}
 	} else if oldJob == nil {
 		// Insert the updated Job into the snapshot
-		err := snap.UpsertJob(100, args.Job)
+		err := snap.UpsertJob(structs.IgnoreUnknownTypeFlag, 100, args.Job)
 		if err != nil {
 			return err
 		}
@@ -1733,7 +1733,8 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 		ModifyTime: now,
 	}
 
-	snap.UpsertEvals(100, []*structs.Evaluation{eval})
+	// Ignore eval event creation during snapshot eval creation
+	snap.UpsertEvals(structs.IgnoreUnknownTypeFlag, 100, []*structs.Evaluation{eval})
 
 	// Create an in-memory Planner that returns no errors and stores the
 	// submitted plan and created evals.

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -2528,12 +2528,12 @@ func TestJobEndpoint_Revert_ACL(t *testing.T) {
 
 	// Create the jobs
 	job := mock.Job()
-	err := state.UpsertJob(300, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 300, job)
 	require.Nil(err)
 
 	job2 := job.Copy()
 	job2.Priority = 1
-	err = state.UpsertJob(400, job2)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 400, job2)
 	require.Nil(err)
 
 	// Create revert request and enforcing it be at the current version
@@ -2656,7 +2656,7 @@ func TestJobEndpoint_Stable_ACL(t *testing.T) {
 
 	// Register the job
 	job := mock.Job()
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	require.Nil(err)
 
 	// Create stability request
@@ -2887,7 +2887,7 @@ func TestJobEndpoint_Evaluate_ACL(t *testing.T) {
 
 	// Create the job
 	job := mock.Job()
-	err := state.UpsertJob(300, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 300, job)
 	require.Nil(err)
 
 	// Force a re-evaluation
@@ -3141,7 +3141,7 @@ func TestJobEndpoint_Deregister_ACL(t *testing.T) {
 
 	// Create and register a job
 	job := mock.Job()
-	err := state.UpsertJob(100, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
 	require.Nil(err)
 
 	// Deregister and purge
@@ -3683,8 +3683,8 @@ func TestJobEndpoint_BatchDeregister_ACL(t *testing.T) {
 
 	// Create and register a job
 	job, job2 := mock.Job(), mock.Job()
-	require.Nil(state.UpsertJob(100, job))
-	require.Nil(state.UpsertJob(101, job2))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 100, job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 101, job2))
 
 	// Deregister
 	req := &structs.JobBatchDeregisterRequest{
@@ -3828,7 +3828,7 @@ func TestJobEndpoint_GetJob_ACL(t *testing.T) {
 
 	// Create the job
 	job := mock.Job()
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	require.Nil(err)
 
 	// Lookup the job
@@ -3889,14 +3889,14 @@ func TestJobEndpoint_GetJob_Blocking(t *testing.T) {
 
 	// Upsert a job we are not interested in first.
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.UpsertJob(100, job1); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job1); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
 
 	// Upsert another job later which should trigger the watch.
 	time.AfterFunc(200*time.Millisecond, func() {
-		if err := state.UpsertJob(200, job2); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 200, job2); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -4037,11 +4037,11 @@ func TestJobEndpoint_GetJobVersions_ACL(t *testing.T) {
 	// Create two versions of a job with different priorities
 	job := mock.Job()
 	job.Priority = 88
-	err := state.UpsertJob(10, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 10, job)
 	require.Nil(err)
 
 	job.Priority = 100
-	err = state.UpsertJob(100, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
 	require.Nil(err)
 
 	// Lookup the job
@@ -4206,14 +4206,14 @@ func TestJobEndpoint_GetJobVersions_Blocking(t *testing.T) {
 
 	// Upsert a job we are not interested in first.
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.UpsertJob(100, job1); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job1); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
 
 	// Upsert another job later which should trigger the watch.
 	time.AfterFunc(200*time.Millisecond, func() {
-		if err := state.UpsertJob(200, job2); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 200, job2); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -4244,7 +4244,7 @@ func TestJobEndpoint_GetJobVersions_Blocking(t *testing.T) {
 
 	// Upsert the job again which should trigger the watch.
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.UpsertJob(300, job3); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 300, job3); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -4435,7 +4435,7 @@ func TestJobEndpoint_GetJobSummary_Blocking(t *testing.T) {
 	// Create a job and insert it
 	job1 := mock.Job()
 	time.AfterFunc(200*time.Millisecond, func() {
-		if err := state.UpsertJob(100, job1); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job1); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -4528,7 +4528,7 @@ func TestJobEndpoint_ListJobs(t *testing.T) {
 	// Create the register request
 	job := mock.Job()
 	state := s1.fsm.State()
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4593,7 +4593,7 @@ func TestJobEndpoint_ListJobs_AllNamespaces_OSS(t *testing.T) {
 	// Create the register request
 	job := mock.Job()
 	state := s1.fsm.State()
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4660,7 +4660,7 @@ func TestJobEndpoint_ListJobs_WithACL(t *testing.T) {
 
 	// Create the register request
 	job := mock.Job()
-	err = state.UpsertJob(1000, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	require.Nil(err)
 
 	req := &structs.JobListRequest{
@@ -4718,7 +4718,7 @@ func TestJobEndpoint_ListJobs_Blocking(t *testing.T) {
 
 	// Upsert job triggers watches
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.UpsertJob(100, job); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -4969,8 +4969,7 @@ func TestJobEndpoint_Evaluations(t *testing.T) {
 	eval2 := mock.Eval()
 	eval2.JobID = eval1.JobID
 	state := s1.fsm.State()
-	err := state.UpsertEvals(1000,
-		[]*structs.Evaluation{eval1, eval2})
+	err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1, eval2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5010,8 +5009,7 @@ func TestJobEndpoint_Evaluations_ACL(t *testing.T) {
 	eval1 := mock.Eval()
 	eval2 := mock.Eval()
 	eval2.JobID = eval1.JobID
-	err := state.UpsertEvals(1000,
-		[]*structs.Evaluation{eval1, eval2})
+	err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1, eval2})
 	require.Nil(err)
 
 	// Lookup the jobs
@@ -5073,7 +5071,7 @@ func TestJobEndpoint_Evaluations_Blocking(t *testing.T) {
 
 	// First upsert an unrelated eval
 	time.AfterFunc(100*time.Millisecond, func() {
-		err := state.UpsertEvals(100, []*structs.Evaluation{eval1})
+		err := state.UpsertEvals(structs.MsgTypeTestSetup, 100, []*structs.Evaluation{eval1})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -5081,7 +5079,7 @@ func TestJobEndpoint_Evaluations_Blocking(t *testing.T) {
 
 	// Upsert an eval for the job we are interested in later
 	time.AfterFunc(200*time.Millisecond, func() {
-		err := state.UpsertEvals(200, []*structs.Evaluation{eval2})
+		err := state.UpsertEvals(structs.MsgTypeTestSetup, 200, []*structs.Evaluation{eval2})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -5129,7 +5127,7 @@ func TestJobEndpoint_Deployments(t *testing.T) {
 	d2 := mock.Deployment()
 	d1.JobID = j.ID
 	d2.JobID = j.ID
-	require.Nil(state.UpsertJob(1000, j), "UpsertJob")
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j), "UpsertJob")
 	d1.JobCreateIndex = j.CreateIndex
 	d2.JobCreateIndex = j.CreateIndex
 
@@ -5166,7 +5164,7 @@ func TestJobEndpoint_Deployments_ACL(t *testing.T) {
 	d2 := mock.Deployment()
 	d1.JobID = j.ID
 	d2.JobID = j.ID
-	require.Nil(state.UpsertJob(1000, j), "UpsertJob")
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j), "UpsertJob")
 	d1.JobCreateIndex = j.CreateIndex
 	d2.JobCreateIndex = j.CreateIndex
 	require.Nil(state.UpsertDeployment(1001, d1), "UpsertDeployment")
@@ -5229,7 +5227,7 @@ func TestJobEndpoint_Deployments_Blocking(t *testing.T) {
 	d1 := mock.Deployment()
 	d2 := mock.Deployment()
 	d2.JobID = j.ID
-	require.Nil(state.UpsertJob(50, j), "UpsertJob")
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 50, j), "UpsertJob")
 	d2.JobCreateIndex = j.CreateIndex
 	// First upsert an unrelated eval
 	time.AfterFunc(100*time.Millisecond, func() {
@@ -5279,7 +5277,7 @@ func TestJobEndpoint_LatestDeployment(t *testing.T) {
 	d2.JobID = j.ID
 	d2.CreateIndex = d1.CreateIndex + 100
 	d2.ModifyIndex = d2.CreateIndex + 100
-	require.Nil(state.UpsertJob(1000, j), "UpsertJob")
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j), "UpsertJob")
 	d1.JobCreateIndex = j.CreateIndex
 	d2.JobCreateIndex = j.CreateIndex
 	require.Nil(state.UpsertDeployment(1001, d1), "UpsertDeployment")
@@ -5318,7 +5316,7 @@ func TestJobEndpoint_LatestDeployment_ACL(t *testing.T) {
 	d2.JobID = j.ID
 	d2.CreateIndex = d1.CreateIndex + 100
 	d2.ModifyIndex = d2.CreateIndex + 100
-	require.Nil(state.UpsertJob(1000, j), "UpsertJob")
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j), "UpsertJob")
 	d1.JobCreateIndex = j.CreateIndex
 	d2.JobCreateIndex = j.CreateIndex
 	require.Nil(state.UpsertDeployment(1001, d1), "UpsertDeployment")
@@ -5384,7 +5382,7 @@ func TestJobEndpoint_LatestDeployment_Blocking(t *testing.T) {
 	d1 := mock.Deployment()
 	d2 := mock.Deployment()
 	d2.JobID = j.ID
-	require.Nil(state.UpsertJob(50, j), "UpsertJob")
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 50, j), "UpsertJob")
 	d2.JobCreateIndex = j.CreateIndex
 
 	// First upsert an unrelated eval
@@ -5937,7 +5935,7 @@ func TestJobEndpoint_Dispatch_ACL(t *testing.T) {
 	// Create a parameterized job
 	job := mock.BatchJob()
 	job.ParameterizedJob = &structs.ParameterizedJobConfig{}
-	err := state.UpsertJob(400, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 400, job)
 	require.Nil(err)
 
 	req := &structs.JobDispatchRequest{
@@ -6287,7 +6285,7 @@ func TestJobEndpoint_Scale(t *testing.T) {
 
 	job := mock.Job()
 	originalCount := job.TaskGroups[0].Count
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	require.Nil(err)
 
 	groupName := job.TaskGroups[0].Name
@@ -6344,7 +6342,7 @@ func TestJobEndpoint_Scale_DeploymentBlocking(t *testing.T) {
 	for _, tc := range cases {
 		// create a job with a deployment history
 		job := mock.Job()
-		require.Nil(state.UpsertJob(1000, job), "UpsertJob")
+		require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, job), "UpsertJob")
 		d1 := mock.Deployment()
 		d1.Status = structs.DeploymentStatusCancelled
 		d1.StatusDescription = structs.DeploymentStatusDescriptionNewerJob
@@ -6439,7 +6437,7 @@ func TestJobEndpoint_Scale_InformationalEventsShouldNotBeBlocked(t *testing.T) {
 	for _, tc := range cases {
 		// create a job with a deployment history
 		job := mock.Job()
-		require.Nil(state.UpsertJob(1000, job), "UpsertJob")
+		require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, job), "UpsertJob")
 		d1 := mock.Deployment()
 		d1.Status = structs.DeploymentStatusCancelled
 		d1.StatusDescription = structs.DeploymentStatusDescriptionNewerJob
@@ -6505,7 +6503,7 @@ func TestJobEndpoint_Scale_ACL(t *testing.T) {
 	state := s1.fsm.State()
 
 	job := mock.Job()
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	require.Nil(err)
 
 	scale := &structs.JobScaleRequest{
@@ -6619,7 +6617,7 @@ func TestJobEndpoint_Scale_Invalid(t *testing.T) {
 	require.Contains(err.Error(), "not found")
 
 	// register the job
-	err = state.UpsertJob(1000, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	require.Nil(err)
 
 	scale.Count = helper.Int64ToPtr(10)
@@ -6706,7 +6704,7 @@ func TestJobEndpoint_InvalidCount(t *testing.T) {
 	state := s1.fsm.State()
 
 	job := mock.Job()
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	require.Nil(err)
 
 	scale := &structs.JobScaleRequest{
@@ -6751,7 +6749,7 @@ func TestJobEndpoint_GetScaleStatus(t *testing.T) {
 	require.Nil(resp2.JobScaleStatus)
 
 	// stopped (previous version)
-	require.NoError(state.UpsertJob(1000, jobV1), "UpsertJob")
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 1000, jobV1), "UpsertJob")
 	a0 := mock.Alloc()
 	a0.Job = jobV1
 	a0.Namespace = jobV1.Namespace
@@ -6760,7 +6758,7 @@ func TestJobEndpoint_GetScaleStatus(t *testing.T) {
 	require.NoError(state.UpsertAllocs(structs.MsgTypeTestSetup, 1010, []*structs.Allocation{a0}), "UpsertAllocs")
 
 	jobV2 := jobV1.Copy()
-	require.NoError(state.UpsertJob(1100, jobV2), "UpsertJob")
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 1100, jobV2), "UpsertJob")
 	a1 := mock.Alloc()
 	a1.Job = jobV2
 	a1.Namespace = jobV2.Namespace
@@ -6853,7 +6851,7 @@ func TestJobEndpoint_GetScaleStatus_ACL(t *testing.T) {
 
 	// Create the job
 	job := mock.Job()
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	require.Nil(err)
 
 	// Get the job scale status

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -1771,12 +1771,12 @@ func TestJobEndpoint_Register_SemverConstraint(t *testing.T) {
 	node1 := mock.Node()
 	node1.Attributes["vault.version"] = "1.3.0-beta1+ent"
 	node1.ComputeClass()
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node1, 1))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1, node1))
 
 	node2 := mock.Node()
 	delete(node2.Attributes, "vault.version")
 	node2.ComputeClass()
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node2, 2))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 2, node2))
 
 	// Create the register request
 	req := &structs.JobRegisterRequest{

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -2833,7 +2833,7 @@ func TestJobEndpoint_ForceRescheduleEvaluate(t *testing.T) {
 	alloc.TaskGroup = job.TaskGroups[0].Name
 	alloc.Namespace = job.Namespace
 	alloc.ClientStatus = structs.AllocClientStatusFailed
-	err = s1.State().UpsertAllocs(resp.Index+1, []*structs.Allocation{alloc})
+	err = s1.State().UpsertAllocs(structs.MsgTypeTestSetup, resp.Index+1, []*structs.Allocation{alloc})
 	require.Nil(err)
 
 	// Force a re-evaluation
@@ -4463,7 +4463,7 @@ func TestJobEndpoint_GetJobSummary_Blocking(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.JobID = job1.ID
 		alloc.Job = job1
-		if err := state.UpsertAllocs(200, []*structs.Allocation{alloc}); err != nil {
+		if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 200, []*structs.Allocation{alloc}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -4786,8 +4786,7 @@ func TestJobEndpoint_Allocations(t *testing.T) {
 	state := s1.fsm.State()
 	state.UpsertJobSummary(998, mock.JobSummary(alloc1.JobID))
 	state.UpsertJobSummary(999, mock.JobSummary(alloc2.JobID))
-	err := state.UpsertAllocs(1000,
-		[]*structs.Allocation{alloc1, alloc2})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1, alloc2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4829,8 +4828,7 @@ func TestJobEndpoint_Allocations_ACL(t *testing.T) {
 	alloc2.JobID = alloc1.JobID
 	state.UpsertJobSummary(998, mock.JobSummary(alloc1.JobID))
 	state.UpsertJobSummary(999, mock.JobSummary(alloc2.JobID))
-	err := state.UpsertAllocs(1000,
-		[]*structs.Allocation{alloc1, alloc2})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1, alloc2})
 	require.Nil(err)
 
 	// Look up allocations for that job
@@ -4893,7 +4891,7 @@ func TestJobEndpoint_Allocations_Blocking(t *testing.T) {
 	// First upsert an unrelated alloc
 	time.AfterFunc(100*time.Millisecond, func() {
 		state.UpsertJobSummary(99, mock.JobSummary(alloc1.JobID))
-		err := state.UpsertAllocs(100, []*structs.Allocation{alloc1})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc1})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -4902,7 +4900,7 @@ func TestJobEndpoint_Allocations_Blocking(t *testing.T) {
 	// Upsert an alloc for the job we are interested in later
 	time.AfterFunc(200*time.Millisecond, func() {
 		state.UpsertJobSummary(199, mock.JobSummary(alloc2.JobID))
-		err := state.UpsertAllocs(200, []*structs.Allocation{alloc2})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 200, []*structs.Allocation{alloc2})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -6759,7 +6757,7 @@ func TestJobEndpoint_GetScaleStatus(t *testing.T) {
 	a0.Namespace = jobV1.Namespace
 	a0.JobID = jobV1.ID
 	a0.ClientStatus = structs.AllocClientStatusComplete
-	require.NoError(state.UpsertAllocs(1010, []*structs.Allocation{a0}), "UpsertAllocs")
+	require.NoError(state.UpsertAllocs(structs.MsgTypeTestSetup, 1010, []*structs.Allocation{a0}), "UpsertAllocs")
 
 	jobV2 := jobV1.Copy()
 	require.NoError(state.UpsertJob(1100, jobV2), "UpsertJob")
@@ -6798,7 +6796,7 @@ func TestJobEndpoint_GetScaleStatus(t *testing.T) {
 	a4.JobID = jobV2.ID
 	a4.ClientStatus = structs.AllocClientStatusRunning
 	// upsert allocations
-	require.NoError(state.UpsertAllocs(1110, []*structs.Allocation{a1, a2, a3, a4}), "UpsertAllocs")
+	require.NoError(state.UpsertAllocs(structs.MsgTypeTestSetup, 1110, []*structs.Allocation{a1, a2, a3, a4}), "UpsertAllocs")
 
 	event := &structs.ScalingEvent{
 		Time:    time.Now().Unix(),

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -1771,12 +1771,12 @@ func TestJobEndpoint_Register_SemverConstraint(t *testing.T) {
 	node1 := mock.Node()
 	node1.Attributes["vault.version"] = "1.3.0-beta1+ent"
 	node1.ComputeClass()
-	require.NoError(t, state.UpsertNode(1, node1))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node1, 1))
 
 	node2 := mock.Node()
 	delete(node2.Attributes, "vault.version")
 	node2.ComputeClass()
-	require.NoError(t, state.UpsertNode(2, node2))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node2, 2))
 
 	// Create the register request
 	req := &structs.JobRegisterRequest{

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -584,7 +584,7 @@ func TestClientEndpoint_Register_GetEvals(t *testing.T) {
 	// Register a system job.
 	job := mock.SystemJob()
 	state := s1.fsm.State()
-	if err := state.UpsertJob(1, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -679,7 +679,7 @@ func TestClientEndpoint_UpdateStatus_GetEvals(t *testing.T) {
 	// Register a system job.
 	job := mock.SystemJob()
 	state := s1.fsm.State()
-	if err := state.UpsertJob(1, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -938,7 +938,7 @@ func TestClientEndpoint_UpdateDrain(t *testing.T) {
 
 	// Register a system job
 	job := mock.SystemJob()
-	require.Nil(s1.State().UpsertJob(10, job))
+	require.Nil(s1.State().UpsertJob(structs.MsgTypeTestSetup, 10, job))
 
 	// Update the eligibility and expect evals
 	dereg.DrainStrategy = nil
@@ -1200,7 +1200,7 @@ func TestClientEndpoint_UpdateEligibility(t *testing.T) {
 
 	// Register a system job
 	job := mock.SystemJob()
-	require.Nil(s1.State().UpsertJob(10, job))
+	require.Nil(s1.State().UpsertJob(structs.MsgTypeTestSetup, 10, job))
 
 	// Update the eligibility and expect evals
 	elig.Eligibility = structs.NodeSchedulingEligible
@@ -2103,7 +2103,7 @@ func TestClientEndpoint_UpdateAlloc(t *testing.T) {
 	// Inject mock job
 	job := mock.Job()
 	job.ID = "mytestjob"
-	err := state.UpsertJob(101, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 101, job)
 	require.Nil(err)
 
 	// Inject fake allocations
@@ -2271,7 +2271,7 @@ func TestClientEndpoint_UpdateAlloc_Vault(t *testing.T) {
 	// Inject mock job
 	job := mock.Job()
 	job.ID = alloc.JobID
-	err := state.UpsertJob(101, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 101, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2330,7 +2330,7 @@ func TestClientEndpoint_CreateNodeEvals(t *testing.T) {
 
 	// Inject a fake system job.
 	job := mock.SystemJob()
-	if err := state.UpsertJob(3, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 3, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2762,7 +2762,7 @@ func TestClientEndpoint_ListNodes_Blocking(t *testing.T) {
 				Deadline: 10 * time.Second,
 			},
 		}
-		errCh <- state.UpdateNodeDrain(3, node.ID, s, false, 0, nil)
+		errCh <- state.UpdateNodeDrain(structs.MsgTypeTestSetup, 3, node.ID, s, false, 0, nil)
 	})
 
 	req.MinQueryIndex = 2

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -1485,7 +1485,7 @@ func TestClientEndpoint_GetNode_Blocking(t *testing.T) {
 
 	// Node delete triggers watches
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.DeleteNode(400, []string{node2.ID}); err != nil {
+		if err := state.DeleteNode(structs.MsgTypeTestSetup, 400, []string{node2.ID}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -2814,7 +2814,7 @@ func TestClientEndpoint_ListNodes_Blocking(t *testing.T) {
 
 	// Node delete triggers watches.
 	time.AfterFunc(100*time.Millisecond, func() {
-		errCh <- state.DeleteNode(50, []string{node.ID})
+		errCh <- state.DeleteNode(structs.MsgTypeTestSetup, 50, []string{node.ID})
 	})
 
 	req.MinQueryIndex = 45

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -1536,7 +1536,7 @@ func TestClientEndpoint_GetAllocs(t *testing.T) {
 	alloc.NodeID = node.ID
 	state := s1.fsm.State()
 	state.UpsertJobSummary(99, mock.JobSummary(alloc.JobID))
-	err := state.UpsertAllocs(100, []*structs.Allocation{alloc})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1588,7 +1588,7 @@ func TestClientEndpoint_GetAllocs_ACL_Basic(t *testing.T) {
 	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1), "UpsertNode")
 	assert.Nil(state.UpsertJobSummary(2, mock.JobSummary(allocDefaultNS.JobID)), "UpsertJobSummary")
 	allocs := []*structs.Allocation{allocDefaultNS}
-	assert.Nil(state.UpsertAllocs(5, allocs), "UpsertAllocs")
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 5, allocs), "UpsertAllocs")
 
 	// Create the namespace policy and tokens
 	validDefaultToken := mock.CreatePolicyAndToken(t, state, 1001, "test-default-valid", mock.NodePolicy(acl.PolicyRead)+
@@ -1667,7 +1667,7 @@ func TestClientEndpoint_GetClientAllocs(t *testing.T) {
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
 	state.UpsertJobSummary(99, mock.JobSummary(alloc.JobID))
-	err := state.UpsertAllocs(100, []*structs.Allocation{alloc})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1758,7 +1758,7 @@ func TestClientEndpoint_GetClientAllocs_Blocking(t *testing.T) {
 	state.UpsertJobSummary(99, mock.JobSummary(alloc.JobID))
 	start := time.Now()
 	time.AfterFunc(100*time.Millisecond, func() {
-		err := state.UpsertAllocs(100, []*structs.Allocation{alloc})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1825,7 +1825,7 @@ func TestClientEndpoint_GetClientAllocs_Blocking(t *testing.T) {
 		allocUpdate.ID = alloc.ID
 		allocUpdate.ClientStatus = structs.AllocClientStatusRunning
 		state.UpsertJobSummary(199, mock.JobSummary(allocUpdate.JobID))
-		err := state.UpsertAllocs(200, []*structs.Allocation{allocUpdate})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 200, []*structs.Allocation{allocUpdate})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1879,7 +1879,7 @@ func TestClientEndpoint_GetClientAllocs_Blocking_GC(t *testing.T) {
 	state.UpsertJobSummary(99, mock.JobSummary(alloc1.JobID))
 	start := time.Now()
 	time.AfterFunc(100*time.Millisecond, func() {
-		assert.Nil(state.UpsertAllocs(100, []*structs.Allocation{alloc1, alloc2}))
+		assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc1, alloc2}))
 	})
 
 	// Lookup the allocs in a blocking query
@@ -1958,7 +1958,7 @@ func TestClientEndpoint_GetClientAllocs_WithoutMigrateTokens(t *testing.T) {
 	alloc.DesiredStatus = structs.AllocClientStatusComplete
 	state := s1.fsm.State()
 	state.UpsertJobSummary(99, mock.JobSummary(alloc.JobID))
-	err := state.UpsertAllocs(100, []*structs.Allocation{prevAlloc, alloc})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{prevAlloc, alloc})
 	assert.Nil(err)
 
 	// Lookup the allocs
@@ -2008,7 +2008,7 @@ func TestClientEndpoint_GetAllocs_Blocking(t *testing.T) {
 	state.UpsertJobSummary(99, mock.JobSummary(alloc.JobID))
 	start := time.Now()
 	time.AfterFunc(100*time.Millisecond, func() {
-		err := state.UpsertAllocs(100, []*structs.Allocation{alloc})
+		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -2121,7 +2121,7 @@ func TestClientEndpoint_UpdateAlloc(t *testing.T) {
 	require.Nil(err)
 	alloc2.TaskGroup = job.TaskGroups[0].Name
 
-	err = state.UpsertAllocs(100, []*structs.Allocation{alloc, alloc2})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc, alloc2})
 	require.Nil(err)
 
 	// Attempt updates of more than one alloc for the same job
@@ -2195,7 +2195,7 @@ func TestClientEndpoint_BatchUpdate(t *testing.T) {
 	alloc.NodeID = node.ID
 	state := s1.fsm.State()
 	state.UpsertJobSummary(99, mock.JobSummary(alloc.JobID))
-	err := state.UpsertAllocs(100, []*structs.Allocation{alloc})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2257,7 +2257,7 @@ func TestClientEndpoint_UpdateAlloc_Vault(t *testing.T) {
 	alloc.NodeID = node.ID
 	state := s1.fsm.State()
 	state.UpsertJobSummary(99, mock.JobSummary(alloc.JobID))
-	if err := state.UpsertAllocs(100, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2324,7 +2324,7 @@ func TestClientEndpoint_CreateNodeEvals(t *testing.T) {
 	alloc := mock.Alloc()
 	state := s1.fsm.State()
 	state.UpsertJobSummary(1, mock.JobSummary(alloc.JobID))
-	if err := state.UpsertAllocs(2, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 2, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2416,7 +2416,7 @@ func TestClientEndpoint_Evaluate(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	state.UpsertJobSummary(2, mock.JobSummary(alloc.JobID))
-	err = state.UpsertAllocs(3, []*structs.Allocation{alloc})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 3, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2501,7 +2501,7 @@ func TestClientEndpoint_Evaluate_ACL(t *testing.T) {
 
 	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1), "UpsertNode")
 	assert.Nil(state.UpsertJobSummary(2, mock.JobSummary(alloc.JobID)), "UpsertJobSummary")
-	assert.Nil(state.UpsertAllocs(3, []*structs.Allocation{alloc}), "UpsertAllocs")
+	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 3, []*structs.Allocation{alloc}), "UpsertAllocs")
 
 	// Create the policy and tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid", mock.NodePolicy(acl.PolicyWrite))
@@ -2858,7 +2858,7 @@ func TestClientEndpoint_DeriveVaultToken_Bad(t *testing.T) {
 	alloc := mock.Alloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	tasks := []string{task.Name}
-	if err := state.UpsertAllocs(3, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 3, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2894,7 +2894,7 @@ func TestClientEndpoint_DeriveVaultToken_Bad(t *testing.T) {
 
 	// Update to be running on the node
 	alloc.NodeID = node.ID
-	if err := state.UpsertAllocs(4, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 4, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2908,7 +2908,7 @@ func TestClientEndpoint_DeriveVaultToken_Bad(t *testing.T) {
 
 	// Update to be terminal
 	alloc.DesiredStatus = structs.AllocDesiredStatusStop
-	if err := state.UpsertAllocs(5, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 5, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2951,7 +2951,7 @@ func TestClientEndpoint_DeriveVaultToken(t *testing.T) {
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	tasks := []string{task.Name}
 	task.Vault = &structs.Vault{Policies: []string{"a", "b"}}
-	if err := state.UpsertAllocs(3, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 3, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3044,7 +3044,7 @@ func TestClientEndpoint_DeriveVaultToken_VaultError(t *testing.T) {
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	tasks := []string{task.Name}
 	task.Vault = &structs.Vault{Policies: []string{"a", "b"}}
-	if err := state.UpsertAllocs(3, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 3, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3177,7 +3177,7 @@ func TestClientEndpoint_DeriveSIToken(t *testing.T) {
 	mutateConnectJob(t, alloc.Job) // appends sidecar task
 	sidecarTask := alloc.Job.TaskGroups[0].Tasks[1]
 
-	err = state.UpsertAllocs(3, []*structs.Allocation{alloc})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 3, []*structs.Allocation{alloc})
 	r.NoError(err)
 
 	request := &structs.DeriveSITokenRequest{
@@ -3235,7 +3235,7 @@ func TestClientEndpoint_DeriveSIToken_ConsulError(t *testing.T) {
 	m := NewConsulACLsAPI(mockACLsAPI, s1.logger, nil)
 	s1.consulACLs = m
 
-	err = state.UpsertAllocs(3, []*structs.Allocation{alloc})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 3, []*structs.Allocation{alloc})
 	r.NoError(err)
 
 	request := &structs.DeriveSITokenRequest{

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -267,10 +267,10 @@ func TestClientEndpoint_Deregister_ACL(t *testing.T) {
 	node := mock.Node()
 	node1 := mock.Node()
 	state := s1.fsm.State()
-	if err := state.UpsertNode(1, node); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := state.UpsertNode(2, node1); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, node1, 2); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -978,7 +978,7 @@ func TestClientEndpoint_UpdateDrain_ACL(t *testing.T) {
 	node := mock.Node()
 	state := s1.fsm.State()
 
-	require.Nil(state.UpsertNode(1, node), "UpsertNode")
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1), "UpsertNode")
 
 	// Create the policy and tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid", mock.NodePolicy(acl.PolicyWrite))
@@ -1229,7 +1229,7 @@ func TestClientEndpoint_UpdateEligibility_ACL(t *testing.T) {
 	node := mock.Node()
 	state := s1.fsm.State()
 
-	require.Nil(state.UpsertNode(1, node), "UpsertNode")
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1), "UpsertNode")
 
 	// Create the policy and tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid", mock.NodePolicy(acl.PolicyWrite))
@@ -1353,7 +1353,7 @@ func TestClientEndpoint_GetNode_ACL(t *testing.T) {
 	// Create the node
 	node := mock.Node()
 	state := s1.fsm.State()
-	assert.Nil(state.UpsertNode(1, node), "UpsertNode")
+	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1), "UpsertNode")
 
 	// Create the policy and tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid", mock.NodePolicy(acl.PolicyRead))
@@ -1420,14 +1420,14 @@ func TestClientEndpoint_GetNode_Blocking(t *testing.T) {
 
 	// First create an unrelated node.
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.UpsertNode(100, node1); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, node1, 100); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
 
 	// Upsert the node we are watching later
 	time.AfterFunc(200*time.Millisecond, func() {
-		if err := state.UpsertNode(200, node2); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, node2, 200); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -1461,7 +1461,7 @@ func TestClientEndpoint_GetNode_Blocking(t *testing.T) {
 		nodeUpdate := mock.Node()
 		nodeUpdate.ID = node2.ID
 		nodeUpdate.Status = structs.NodeStatusDown
-		if err := state.UpsertNode(300, nodeUpdate); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, nodeUpdate, 300); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -1585,7 +1585,7 @@ func TestClientEndpoint_GetAllocs_ACL_Basic(t *testing.T) {
 	node := mock.Node()
 	allocDefaultNS.NodeID = node.ID
 	state := s1.fsm.State()
-	assert.Nil(state.UpsertNode(1, node), "UpsertNode")
+	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1), "UpsertNode")
 	assert.Nil(state.UpsertJobSummary(2, mock.JobSummary(allocDefaultNS.JobID)), "UpsertJobSummary")
 	allocs := []*structs.Allocation{allocDefaultNS}
 	assert.Nil(state.UpsertAllocs(5, allocs), "UpsertAllocs")
@@ -1661,7 +1661,7 @@ func TestClientEndpoint_GetClientAllocs(t *testing.T) {
 	// Create the register request
 	node := mock.Node()
 	state := s1.fsm.State()
-	require.Nil(state.UpsertNode(98, node))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 98))
 
 	// Inject fake evaluations
 	alloc := mock.Alloc()
@@ -2411,7 +2411,7 @@ func TestClientEndpoint_Evaluate(t *testing.T) {
 	node := mock.Node()
 	node.ID = alloc.NodeID
 	state := s1.fsm.State()
-	err := state.UpsertNode(1, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2499,7 +2499,7 @@ func TestClientEndpoint_Evaluate_ACL(t *testing.T) {
 	node.ID = alloc.NodeID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertNode(1, node), "UpsertNode")
+	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1), "UpsertNode")
 	assert.Nil(state.UpsertJobSummary(2, mock.JobSummary(alloc.JobID)), "UpsertJobSummary")
 	assert.Nil(state.UpsertAllocs(3, []*structs.Allocation{alloc}), "UpsertAllocs")
 
@@ -2664,7 +2664,7 @@ func TestClientEndpoint_ListNodes_ACL(t *testing.T) {
 	// Create the node
 	node := mock.Node()
 	state := s1.fsm.State()
-	assert.Nil(state.UpsertNode(1, node), "UpsertNode")
+	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1), "UpsertNode")
 
 	// Create the namespace policy and tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid", mock.NodePolicy(acl.PolicyRead))
@@ -2725,7 +2725,7 @@ func TestClientEndpoint_ListNodes_Blocking(t *testing.T) {
 	// Node upsert triggers watches
 	errCh := make(chan error, 1)
 	timer := time.AfterFunc(100*time.Millisecond, func() {
-		errCh <- state.UpsertNode(2, node)
+		errCh <- state.UpsertNode(structs.MsgTypeTestSetup, node, 2)
 	})
 	defer timer.Stop()
 
@@ -2850,7 +2850,7 @@ func TestClientEndpoint_DeriveVaultToken_Bad(t *testing.T) {
 
 	// Create the node
 	node := mock.Node()
-	if err := state.UpsertNode(2, node); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, 2); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2941,7 +2941,7 @@ func TestClientEndpoint_DeriveVaultToken(t *testing.T) {
 
 	// Create the node
 	node := mock.Node()
-	if err := state.UpsertNode(2, node); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, 2); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3034,7 +3034,7 @@ func TestClientEndpoint_DeriveVaultToken_VaultError(t *testing.T) {
 
 	// Create the node
 	node := mock.Node()
-	if err := state.UpsertNode(2, node); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, 2); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3168,7 +3168,7 @@ func TestClientEndpoint_DeriveSIToken(t *testing.T) {
 
 	// Create the node
 	node := mock.Node()
-	err := state.UpsertNode(2, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 2)
 	r.NoError(err)
 
 	// Create an alloc with a typical connect service (sidecar) defined
@@ -3220,7 +3220,7 @@ func TestClientEndpoint_DeriveSIToken_ConsulError(t *testing.T) {
 
 	// Create the node
 	node := mock.Node()
-	err := state.UpsertNode(2, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 2)
 	r.NoError(err)
 
 	// Create an alloc with a typical connect service (sidecar) defined
@@ -3265,7 +3265,7 @@ func TestClientEndpoint_EmitEvents(t *testing.T) {
 
 	// create a node that we can register our event to
 	node := mock.Node()
-	err := state.UpsertNode(2, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 2)
 	require.Nil(err)
 
 	nodeEvent := &structs.NodeEvent{

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -267,10 +267,10 @@ func TestClientEndpoint_Deregister_ACL(t *testing.T) {
 	node := mock.Node()
 	node1 := mock.Node()
 	state := s1.fsm.State()
-	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, 1, node); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := state.UpsertNode(structs.MsgTypeTestSetup, node1, 2); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, 2, node1); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -978,7 +978,7 @@ func TestClientEndpoint_UpdateDrain_ACL(t *testing.T) {
 	node := mock.Node()
 	state := s1.fsm.State()
 
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1), "UpsertNode")
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1, node), "UpsertNode")
 
 	// Create the policy and tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid", mock.NodePolicy(acl.PolicyWrite))
@@ -1229,7 +1229,7 @@ func TestClientEndpoint_UpdateEligibility_ACL(t *testing.T) {
 	node := mock.Node()
 	state := s1.fsm.State()
 
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1), "UpsertNode")
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1, node), "UpsertNode")
 
 	// Create the policy and tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid", mock.NodePolicy(acl.PolicyWrite))
@@ -1353,7 +1353,7 @@ func TestClientEndpoint_GetNode_ACL(t *testing.T) {
 	// Create the node
 	node := mock.Node()
 	state := s1.fsm.State()
-	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1), "UpsertNode")
+	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1, node), "UpsertNode")
 
 	// Create the policy and tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid", mock.NodePolicy(acl.PolicyRead))
@@ -1420,14 +1420,14 @@ func TestClientEndpoint_GetNode_Blocking(t *testing.T) {
 
 	// First create an unrelated node.
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.UpsertNode(structs.MsgTypeTestSetup, node1, 100); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, 100, node1); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
 
 	// Upsert the node we are watching later
 	time.AfterFunc(200*time.Millisecond, func() {
-		if err := state.UpsertNode(structs.MsgTypeTestSetup, node2, 200); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, 200, node2); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -1461,7 +1461,7 @@ func TestClientEndpoint_GetNode_Blocking(t *testing.T) {
 		nodeUpdate := mock.Node()
 		nodeUpdate.ID = node2.ID
 		nodeUpdate.Status = structs.NodeStatusDown
-		if err := state.UpsertNode(structs.MsgTypeTestSetup, nodeUpdate, 300); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, 300, nodeUpdate); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -1585,7 +1585,7 @@ func TestClientEndpoint_GetAllocs_ACL_Basic(t *testing.T) {
 	node := mock.Node()
 	allocDefaultNS.NodeID = node.ID
 	state := s1.fsm.State()
-	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1), "UpsertNode")
+	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1, node), "UpsertNode")
 	assert.Nil(state.UpsertJobSummary(2, mock.JobSummary(allocDefaultNS.JobID)), "UpsertJobSummary")
 	allocs := []*structs.Allocation{allocDefaultNS}
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 5, allocs), "UpsertAllocs")
@@ -1661,7 +1661,7 @@ func TestClientEndpoint_GetClientAllocs(t *testing.T) {
 	// Create the register request
 	node := mock.Node()
 	state := s1.fsm.State()
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 98))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 98, node))
 
 	// Inject fake evaluations
 	alloc := mock.Alloc()
@@ -2411,7 +2411,7 @@ func TestClientEndpoint_Evaluate(t *testing.T) {
 	node := mock.Node()
 	node.ID = alloc.NodeID
 	state := s1.fsm.State()
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 1, node)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2499,7 +2499,7 @@ func TestClientEndpoint_Evaluate_ACL(t *testing.T) {
 	node.ID = alloc.NodeID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1), "UpsertNode")
+	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1, node), "UpsertNode")
 	assert.Nil(state.UpsertJobSummary(2, mock.JobSummary(alloc.JobID)), "UpsertJobSummary")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 3, []*structs.Allocation{alloc}), "UpsertAllocs")
 
@@ -2664,7 +2664,7 @@ func TestClientEndpoint_ListNodes_ACL(t *testing.T) {
 	// Create the node
 	node := mock.Node()
 	state := s1.fsm.State()
-	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1), "UpsertNode")
+	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1, node), "UpsertNode")
 
 	// Create the namespace policy and tokens
 	validToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid", mock.NodePolicy(acl.PolicyRead))
@@ -2725,7 +2725,7 @@ func TestClientEndpoint_ListNodes_Blocking(t *testing.T) {
 	// Node upsert triggers watches
 	errCh := make(chan error, 1)
 	timer := time.AfterFunc(100*time.Millisecond, func() {
-		errCh <- state.UpsertNode(structs.MsgTypeTestSetup, node, 2)
+		errCh <- state.UpsertNode(structs.MsgTypeTestSetup, 2, node)
 	})
 	defer timer.Stop()
 
@@ -2850,7 +2850,7 @@ func TestClientEndpoint_DeriveVaultToken_Bad(t *testing.T) {
 
 	// Create the node
 	node := mock.Node()
-	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, 2); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, 2, node); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2941,7 +2941,7 @@ func TestClientEndpoint_DeriveVaultToken(t *testing.T) {
 
 	// Create the node
 	node := mock.Node()
-	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, 2); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, 2, node); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3034,7 +3034,7 @@ func TestClientEndpoint_DeriveVaultToken_VaultError(t *testing.T) {
 
 	// Create the node
 	node := mock.Node()
-	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, 2); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, 2, node); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3168,7 +3168,7 @@ func TestClientEndpoint_DeriveSIToken(t *testing.T) {
 
 	// Create the node
 	node := mock.Node()
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 2)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 2, node)
 	r.NoError(err)
 
 	// Create an alloc with a typical connect service (sidecar) defined
@@ -3220,7 +3220,7 @@ func TestClientEndpoint_DeriveSIToken_ConsulError(t *testing.T) {
 
 	// Create the node
 	node := mock.Node()
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 2)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 2, node)
 	r.NoError(err)
 
 	// Create an alloc with a typical connect service (sidecar) defined
@@ -3265,7 +3265,7 @@ func TestClientEndpoint_EmitEvents(t *testing.T) {
 
 	// create a node that we can register our event to
 	node := mock.Node()
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 2)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 2, node)
 	require.Nil(err)
 
 	nodeEvent := &structs.NodeEvent{

--- a/nomad/operator_endpoint_test.go
+++ b/nomad/operator_endpoint_test.go
@@ -762,7 +762,7 @@ func generateSnapshot(t *testing.T) (*snapshot.Snapshot, *structs.Job) {
 	err = msgpackrpc.CallWithCodec(codec, "Job.Register", jobReq, &jobResp)
 	require.NoError(t, err)
 
-	err = s.State().UpsertJob(1000, job)
+	err = s.State().UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	require.NoError(t, err)
 
 	snapshot, err := snapshot.New(s.logger, s.raft)

--- a/nomad/periodic_endpoint_test.go
+++ b/nomad/periodic_endpoint_test.go
@@ -26,7 +26,7 @@ func TestPeriodicEndpoint_Force(t *testing.T) {
 	// Create and insert a periodic job.
 	job := mock.PeriodicJob()
 	job.Periodic.ProhibitOverlap = true // Shouldn't affect anything.
-	if err := state.UpsertJob(100, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	s1.periodicDispatcher.Add(job)
@@ -78,7 +78,7 @@ func TestPeriodicEndpoint_Force_ACL(t *testing.T) {
 	// Create and insert a periodic job.
 	job := mock.PeriodicJob()
 	job.Periodic.ProhibitOverlap = true // Shouldn't affect anything.
-	assert.Nil(state.UpsertJob(100, job))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 100, job))
 	err := s1.periodicDispatcher.Add(job)
 	assert.Nil(err)
 
@@ -157,7 +157,7 @@ func TestPeriodicEndpoint_Force_NonPeriodic(t *testing.T) {
 
 	// Create and insert a non-periodic job.
 	job := mock.Job()
-	if err := state.UpsertJob(100, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/nomad/periodic_test.go
+++ b/nomad/periodic_test.go
@@ -658,7 +658,7 @@ func TestPeriodicDispatch_RunningChildren_NoEvals(t *testing.T) {
 	// Insert job.
 	state := s1.fsm.State()
 	job := mock.PeriodicJob()
-	if err := state.UpsertJob(1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
 		t.Fatalf("UpsertJob failed: %v", err)
 	}
 
@@ -682,12 +682,12 @@ func TestPeriodicDispatch_RunningChildren_ActiveEvals(t *testing.T) {
 	// Insert periodic job and child.
 	state := s1.fsm.State()
 	job := mock.PeriodicJob()
-	if err := state.UpsertJob(1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
 		t.Fatalf("UpsertJob failed: %v", err)
 	}
 
 	childjob := deriveChildJob(job)
-	if err := state.UpsertJob(1001, childjob); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1001, childjob); err != nil {
 		t.Fatalf("UpsertJob failed: %v", err)
 	}
 
@@ -695,7 +695,7 @@ func TestPeriodicDispatch_RunningChildren_ActiveEvals(t *testing.T) {
 	eval := mock.Eval()
 	eval.JobID = childjob.ID
 	eval.Status = structs.EvalStatusPending
-	if err := state.UpsertEvals(1002, []*structs.Evaluation{eval}); err != nil {
+	if err := state.UpsertEvals(structs.MsgTypeTestSetup, 1002, []*structs.Evaluation{eval}); err != nil {
 		t.Fatalf("UpsertEvals failed: %v", err)
 	}
 
@@ -719,12 +719,12 @@ func TestPeriodicDispatch_RunningChildren_ActiveAllocs(t *testing.T) {
 	// Insert periodic job and child.
 	state := s1.fsm.State()
 	job := mock.PeriodicJob()
-	if err := state.UpsertJob(1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
 		t.Fatalf("UpsertJob failed: %v", err)
 	}
 
 	childjob := deriveChildJob(job)
-	if err := state.UpsertJob(1001, childjob); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1001, childjob); err != nil {
 		t.Fatalf("UpsertJob failed: %v", err)
 	}
 
@@ -732,7 +732,7 @@ func TestPeriodicDispatch_RunningChildren_ActiveAllocs(t *testing.T) {
 	eval := mock.Eval()
 	eval.JobID = childjob.ID
 	eval.Status = structs.EvalStatusPending
-	if err := state.UpsertEvals(1002, []*structs.Evaluation{eval}); err != nil {
+	if err := state.UpsertEvals(structs.MsgTypeTestSetup, 1002, []*structs.Evaluation{eval}); err != nil {
 		t.Fatalf("UpsertEvals failed: %v", err)
 	}
 

--- a/nomad/periodic_test.go
+++ b/nomad/periodic_test.go
@@ -741,7 +741,7 @@ func TestPeriodicDispatch_RunningChildren_ActiveAllocs(t *testing.T) {
 	alloc.JobID = childjob.ID
 	alloc.EvalID = eval.ID
 	alloc.DesiredStatus = structs.AllocDesiredStatusRun
-	if err := state.UpsertAllocs(1003, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("UpsertAllocs failed: %v", err)
 	}
 

--- a/nomad/plan_apply_pool_test.go
+++ b/nomad/plan_apply_pool_test.go
@@ -11,7 +11,7 @@ func TestEvaluatePool(t *testing.T) {
 	t.Parallel()
 	state := testStateStore(t)
 	node := mock.Node()
-	state.UpsertNode(1000, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	snap, _ := state.Snapshot()
 
 	alloc := mock.Alloc()

--- a/nomad/plan_apply_pool_test.go
+++ b/nomad/plan_apply_pool_test.go
@@ -11,7 +11,7 @@ func TestEvaluatePool(t *testing.T) {
 	t.Parallel()
 	state := testStateStore(t)
 	node := mock.Node()
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	snap, _ := state.Snapshot()
 
 	alloc := mock.Alloc()

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -100,7 +100,7 @@ func TestPlanApply_applyPlan(t *testing.T) {
 	// Create an eval
 	eval := mock.Eval()
 	eval.JobID = alloc.JobID
-	if err := s1.State().UpsertEvals(1, []*structs.Evaluation{eval}); err != nil {
+	if err := s1.State().UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{eval}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -288,7 +288,7 @@ func TestPlanApply_applyPlanWithNormalizedAllocs(t *testing.T) {
 	// Create an eval
 	eval := mock.Eval()
 	eval.JobID = alloc.JobID
-	if err := s1.State().UpsertEvals(1, []*structs.Evaluation{eval}); err != nil {
+	if err := s1.State().UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{eval}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -284,7 +284,7 @@ func TestPlanApply_applyPlanWithNormalizedAllocs(t *testing.T) {
 		PreemptedByAllocation: alloc.ID,
 	}
 	s1.State().UpsertJobSummary(1000, mock.JobSummary(alloc.JobID))
-	s1.State().UpsertAllocs(1100, []*structs.Allocation{stoppedAlloc, preemptedAlloc})
+	s1.State().UpsertAllocs(structs.MsgTypeTestSetup, 1100, []*structs.Allocation{stoppedAlloc, preemptedAlloc})
 	// Create an eval
 	eval := mock.Eval()
 	eval.JobID = alloc.JobID
@@ -485,7 +485,7 @@ func TestPlanApply_EvalPlan_Preemption(t *testing.T) {
 	}
 
 	// Insert a preempted alloc such that the alloc will fit only after preemption
-	state.UpsertAllocs(1001, []*structs.Allocation{preemptedAlloc})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{preemptedAlloc})
 
 	alloc := mock.Alloc()
 	alloc.AllocatedResources = &structs.AllocatedResources{
@@ -775,7 +775,7 @@ func TestPlanApply_EvalNodePlan_NodeFull(t *testing.T) {
 	alloc.AllocatedResources = structs.NodeResourcesToAllocatedResources(node.NodeResources)
 	state.UpsertJobSummary(999, mock.JobSummary(alloc.JobID))
 	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
-	state.UpsertAllocs(1001, []*structs.Allocation{alloc})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc})
 
 	alloc2 := mock.Alloc()
 	alloc2.NodeID = node.ID
@@ -825,7 +825,7 @@ func TestPlanApply_EvalNodePlan_NodeFull_Device(t *testing.T) {
 
 	state.UpsertJobSummary(999, mock.JobSummary(alloc.JobID))
 	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
-	state.UpsertAllocs(1001, []*structs.Allocation{alloc})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc})
 
 	// Alloc2 tries to use the same device
 	alloc2 := mock.Alloc()
@@ -865,7 +865,7 @@ func TestPlanApply_EvalNodePlan_UpdateExisting(t *testing.T) {
 	alloc.NodeID = node.ID
 	alloc.AllocatedResources = structs.NodeResourcesToAllocatedResources(node.NodeResources)
 	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
-	state.UpsertAllocs(1001, []*structs.Allocation{alloc})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc})
 	snap, _ := state.Snapshot()
 
 	plan := &structs.Plan{
@@ -896,7 +896,7 @@ func TestPlanApply_EvalNodePlan_NodeFull_Evict(t *testing.T) {
 	alloc.NodeID = node.ID
 	alloc.AllocatedResources = structs.NodeResourcesToAllocatedResources(node.NodeResources)
 	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
-	state.UpsertAllocs(1001, []*structs.Allocation{alloc})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc})
 	snap, _ := state.Snapshot()
 
 	allocEvict := new(structs.Allocation)
@@ -935,7 +935,7 @@ func TestPlanApply_EvalNodePlan_NodeFull_AllocEvict(t *testing.T) {
 	alloc.DesiredStatus = structs.AllocDesiredStatusEvict
 	alloc.AllocatedResources = structs.NodeResourcesToAllocatedResources(node.NodeResources)
 	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
-	state.UpsertAllocs(1001, []*structs.Allocation{alloc})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc})
 	snap, _ := state.Snapshot()
 
 	alloc2 := mock.Alloc()
@@ -968,7 +968,7 @@ func TestPlanApply_EvalNodePlan_NodeDown_EvictOnly(t *testing.T) {
 	node.ReservedResources = nil
 	node.Status = structs.NodeStatusDown
 	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
-	state.UpsertAllocs(1001, []*structs.Allocation{alloc})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc})
 	snap, _ := state.Snapshot()
 
 	allocEvict := new(structs.Allocation)

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -393,7 +393,7 @@ func TestPlanApply_EvalPlan_Simple(t *testing.T) {
 	t.Parallel()
 	state := testStateStore(t)
 	node := mock.Node()
-	state.UpsertNode(1000, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	snap, _ := state.Snapshot()
 
 	alloc := mock.Alloc()
@@ -455,7 +455,7 @@ func TestPlanApply_EvalPlan_Preemption(t *testing.T) {
 			},
 		},
 	}
-	state.UpsertNode(1000, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 
 	preemptedAlloc := mock.Alloc()
 	preemptedAlloc.NodeID = node.ID
@@ -551,9 +551,9 @@ func TestPlanApply_EvalPlan_Partial(t *testing.T) {
 	t.Parallel()
 	state := testStateStore(t)
 	node := mock.Node()
-	state.UpsertNode(1000, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	node2 := mock.Node()
-	state.UpsertNode(1001, node2)
+	state.UpsertNode(structs.MsgTypeTestSetup, node2, 1001)
 	snap, _ := state.Snapshot()
 
 	alloc := mock.Alloc()
@@ -609,9 +609,9 @@ func TestPlanApply_EvalPlan_Partial_AllAtOnce(t *testing.T) {
 	t.Parallel()
 	state := testStateStore(t)
 	node := mock.Node()
-	state.UpsertNode(1000, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	node2 := mock.Node()
-	state.UpsertNode(1001, node2)
+	state.UpsertNode(structs.MsgTypeTestSetup, node2, 1001)
 	snap, _ := state.Snapshot()
 
 	alloc := mock.Alloc()
@@ -660,7 +660,7 @@ func TestPlanApply_EvalNodePlan_Simple(t *testing.T) {
 	t.Parallel()
 	state := testStateStore(t)
 	node := mock.Node()
-	state.UpsertNode(1000, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	snap, _ := state.Snapshot()
 
 	alloc := mock.Alloc()
@@ -688,7 +688,7 @@ func TestPlanApply_EvalNodePlan_NodeNotReady(t *testing.T) {
 	state := testStateStore(t)
 	node := mock.Node()
 	node.Status = structs.NodeStatusInit
-	state.UpsertNode(1000, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	snap, _ := state.Snapshot()
 
 	alloc := mock.Alloc()
@@ -716,7 +716,7 @@ func TestPlanApply_EvalNodePlan_NodeDrain(t *testing.T) {
 	state := testStateStore(t)
 	node := mock.Node()
 	node.Drain = true
-	state.UpsertNode(1000, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	snap, _ := state.Snapshot()
 
 	alloc := mock.Alloc()
@@ -774,7 +774,7 @@ func TestPlanApply_EvalNodePlan_NodeFull(t *testing.T) {
 	alloc.NodeID = node.ID
 	alloc.AllocatedResources = structs.NodeResourcesToAllocatedResources(node.NodeResources)
 	state.UpsertJobSummary(999, mock.JobSummary(alloc.JobID))
-	state.UpsertNode(1000, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	state.UpsertAllocs(1001, []*structs.Allocation{alloc})
 
 	alloc2 := mock.Alloc()
@@ -824,7 +824,7 @@ func TestPlanApply_EvalNodePlan_NodeFull_Device(t *testing.T) {
 	}
 
 	state.UpsertJobSummary(999, mock.JobSummary(alloc.JobID))
-	state.UpsertNode(1000, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	state.UpsertAllocs(1001, []*structs.Allocation{alloc})
 
 	// Alloc2 tries to use the same device
@@ -864,7 +864,7 @@ func TestPlanApply_EvalNodePlan_UpdateExisting(t *testing.T) {
 	node.Reserved = nil
 	alloc.NodeID = node.ID
 	alloc.AllocatedResources = structs.NodeResourcesToAllocatedResources(node.NodeResources)
-	state.UpsertNode(1000, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	state.UpsertAllocs(1001, []*structs.Allocation{alloc})
 	snap, _ := state.Snapshot()
 
@@ -895,7 +895,7 @@ func TestPlanApply_EvalNodePlan_NodeFull_Evict(t *testing.T) {
 	node.ReservedResources = nil
 	alloc.NodeID = node.ID
 	alloc.AllocatedResources = structs.NodeResourcesToAllocatedResources(node.NodeResources)
-	state.UpsertNode(1000, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	state.UpsertAllocs(1001, []*structs.Allocation{alloc})
 	snap, _ := state.Snapshot()
 
@@ -934,7 +934,7 @@ func TestPlanApply_EvalNodePlan_NodeFull_AllocEvict(t *testing.T) {
 	alloc.NodeID = node.ID
 	alloc.DesiredStatus = structs.AllocDesiredStatusEvict
 	alloc.AllocatedResources = structs.NodeResourcesToAllocatedResources(node.NodeResources)
-	state.UpsertNode(1000, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	state.UpsertAllocs(1001, []*structs.Allocation{alloc})
 	snap, _ := state.Snapshot()
 
@@ -967,7 +967,7 @@ func TestPlanApply_EvalNodePlan_NodeDown_EvictOnly(t *testing.T) {
 	alloc.AllocatedResources = structs.NodeResourcesToAllocatedResources(node.NodeResources)
 	node.ReservedResources = nil
 	node.Status = structs.NodeStatusDown
-	state.UpsertNode(1000, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	state.UpsertAllocs(1001, []*structs.Allocation{alloc})
 	snap, _ := state.Snapshot()
 

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -393,7 +393,7 @@ func TestPlanApply_EvalPlan_Simple(t *testing.T) {
 	t.Parallel()
 	state := testStateStore(t)
 	node := mock.Node()
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	snap, _ := state.Snapshot()
 
 	alloc := mock.Alloc()
@@ -455,7 +455,7 @@ func TestPlanApply_EvalPlan_Preemption(t *testing.T) {
 			},
 		},
 	}
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 
 	preemptedAlloc := mock.Alloc()
 	preemptedAlloc.NodeID = node.ID
@@ -551,9 +551,9 @@ func TestPlanApply_EvalPlan_Partial(t *testing.T) {
 	t.Parallel()
 	state := testStateStore(t)
 	node := mock.Node()
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	node2 := mock.Node()
-	state.UpsertNode(structs.MsgTypeTestSetup, node2, 1001)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1001, node2)
 	snap, _ := state.Snapshot()
 
 	alloc := mock.Alloc()
@@ -609,9 +609,9 @@ func TestPlanApply_EvalPlan_Partial_AllAtOnce(t *testing.T) {
 	t.Parallel()
 	state := testStateStore(t)
 	node := mock.Node()
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	node2 := mock.Node()
-	state.UpsertNode(structs.MsgTypeTestSetup, node2, 1001)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1001, node2)
 	snap, _ := state.Snapshot()
 
 	alloc := mock.Alloc()
@@ -660,7 +660,7 @@ func TestPlanApply_EvalNodePlan_Simple(t *testing.T) {
 	t.Parallel()
 	state := testStateStore(t)
 	node := mock.Node()
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	snap, _ := state.Snapshot()
 
 	alloc := mock.Alloc()
@@ -688,7 +688,7 @@ func TestPlanApply_EvalNodePlan_NodeNotReady(t *testing.T) {
 	state := testStateStore(t)
 	node := mock.Node()
 	node.Status = structs.NodeStatusInit
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	snap, _ := state.Snapshot()
 
 	alloc := mock.Alloc()
@@ -716,7 +716,7 @@ func TestPlanApply_EvalNodePlan_NodeDrain(t *testing.T) {
 	state := testStateStore(t)
 	node := mock.Node()
 	node.Drain = true
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	snap, _ := state.Snapshot()
 
 	alloc := mock.Alloc()
@@ -774,7 +774,7 @@ func TestPlanApply_EvalNodePlan_NodeFull(t *testing.T) {
 	alloc.NodeID = node.ID
 	alloc.AllocatedResources = structs.NodeResourcesToAllocatedResources(node.NodeResources)
 	state.UpsertJobSummary(999, mock.JobSummary(alloc.JobID))
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc})
 
 	alloc2 := mock.Alloc()
@@ -824,7 +824,7 @@ func TestPlanApply_EvalNodePlan_NodeFull_Device(t *testing.T) {
 	}
 
 	state.UpsertJobSummary(999, mock.JobSummary(alloc.JobID))
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc})
 
 	// Alloc2 tries to use the same device
@@ -864,7 +864,7 @@ func TestPlanApply_EvalNodePlan_UpdateExisting(t *testing.T) {
 	node.Reserved = nil
 	alloc.NodeID = node.ID
 	alloc.AllocatedResources = structs.NodeResourcesToAllocatedResources(node.NodeResources)
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc})
 	snap, _ := state.Snapshot()
 
@@ -895,7 +895,7 @@ func TestPlanApply_EvalNodePlan_NodeFull_Evict(t *testing.T) {
 	node.ReservedResources = nil
 	alloc.NodeID = node.ID
 	alloc.AllocatedResources = structs.NodeResourcesToAllocatedResources(node.NodeResources)
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc})
 	snap, _ := state.Snapshot()
 
@@ -934,7 +934,7 @@ func TestPlanApply_EvalNodePlan_NodeFull_AllocEvict(t *testing.T) {
 	alloc.NodeID = node.ID
 	alloc.DesiredStatus = structs.AllocDesiredStatusEvict
 	alloc.AllocatedResources = structs.NodeResourcesToAllocatedResources(node.NodeResources)
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc})
 	snap, _ := state.Snapshot()
 
@@ -967,7 +967,7 @@ func TestPlanApply_EvalNodePlan_NodeDown_EvictOnly(t *testing.T) {
 	alloc.AllocatedResources = structs.NodeResourcesToAllocatedResources(node.NodeResources)
 	node.ReservedResources = nil
 	node.Status = structs.NodeStatusDown
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc})
 	snap, _ := state.Snapshot()
 

--- a/nomad/search_endpoint_test.go
+++ b/nomad/search_endpoint_test.go
@@ -76,7 +76,7 @@ func TestSearch_PrefixSearch_ACL(t *testing.T) {
 	state := s.fsm.State()
 
 	job := registerAndVerifyJob(s, t, jobID, 0)
-	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, mock.Node(), 1001))
+	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1001, mock.Node()))
 
 	req := &structs.SearchRequest{
 		Prefix:  "",
@@ -447,7 +447,7 @@ func TestSearch_PrefixSearch_All_UUID(t *testing.T) {
 	}
 
 	node := mock.Node()
-	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1001); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, 1001, node); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -490,7 +490,7 @@ func TestSearch_PrefixSearch_Node(t *testing.T) {
 	state := s.fsm.State()
 	node := mock.Node()
 
-	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, 100); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, 100, node); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -569,7 +569,7 @@ func TestSearch_PrefixSearch_AllContext(t *testing.T) {
 	state := s.fsm.State()
 	node := mock.Node()
 
-	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, 100); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, 100, node); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/nomad/search_endpoint_test.go
+++ b/nomad/search_endpoint_test.go
@@ -76,7 +76,7 @@ func TestSearch_PrefixSearch_ACL(t *testing.T) {
 	state := s.fsm.State()
 
 	job := registerAndVerifyJob(s, t, jobID, 0)
-	assert.Nil(state.UpsertNode(1001, mock.Node()))
+	assert.Nil(state.UpsertNode(structs.MsgTypeTestSetup, mock.Node(), 1001))
 
 	req := &structs.SearchRequest{
 		Prefix:  "",
@@ -447,7 +447,7 @@ func TestSearch_PrefixSearch_All_UUID(t *testing.T) {
 	}
 
 	node := mock.Node()
-	if err := state.UpsertNode(1001, node); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1001); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -490,7 +490,7 @@ func TestSearch_PrefixSearch_Node(t *testing.T) {
 	state := s.fsm.State()
 	node := mock.Node()
 
-	if err := state.UpsertNode(100, node); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, 100); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -569,7 +569,7 @@ func TestSearch_PrefixSearch_AllContext(t *testing.T) {
 	state := s.fsm.State()
 	node := mock.Node()
 
-	if err := state.UpsertNode(100, node); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, 100); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/nomad/search_endpoint_test.go
+++ b/nomad/search_endpoint_test.go
@@ -22,7 +22,7 @@ func registerAndVerifyJob(s *Server, t *testing.T, prefix string, counter int) *
 	job := mock.Job()
 	job.ID = prefix + strconv.Itoa(counter)
 	state := s.fsm.State()
-	if err := state.UpsertJob(jobIndex, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, jobIndex, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -319,7 +319,7 @@ func TestSearch_PrefixSearch_AllWithJob(t *testing.T) {
 
 	eval1 := mock.Eval()
 	eval1.ID = job.ID
-	s.fsm.State().UpsertEvals(2000, []*structs.Evaluation{eval1})
+	s.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 2000, []*structs.Evaluation{eval1})
 
 	req := &structs.SearchRequest{
 		Prefix:  prefix,
@@ -354,7 +354,7 @@ func TestSearch_PrefixSearch_Evals(t *testing.T) {
 	testutil.WaitForLeader(t, s.RPC)
 
 	eval1 := mock.Eval()
-	s.fsm.State().UpsertEvals(2000, []*structs.Evaluation{eval1})
+	s.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 2000, []*structs.Evaluation{eval1})
 
 	prefix := eval1.ID[:len(eval1.ID)-2]
 
@@ -453,7 +453,7 @@ func TestSearch_PrefixSearch_All_UUID(t *testing.T) {
 
 	eval1 := mock.Eval()
 	eval1.ID = node.ID
-	if err := state.UpsertEvals(1002, []*structs.Evaluation{eval1}); err != nil {
+	if err := state.UpsertEvals(structs.MsgTypeTestSetup, 1002, []*structs.Evaluation{eval1}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -575,7 +575,7 @@ func TestSearch_PrefixSearch_AllContext(t *testing.T) {
 
 	eval1 := mock.Eval()
 	eval1.ID = node.ID
-	if err := state.UpsertEvals(1000, []*structs.Evaluation{eval1}); err != nil {
+	if err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/nomad/search_endpoint_test.go
+++ b/nomad/search_endpoint_test.go
@@ -197,7 +197,7 @@ func TestSearch_PrefixSearch_All_JobWithHyphen(t *testing.T) {
 	if err := state.UpsertJobSummary(999, summary); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := state.UpsertAllocs(1000, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -242,7 +242,7 @@ func TestSearch_PrefixSearch_All_LongJob(t *testing.T) {
 	if err := state.UpsertJobSummary(999, summary); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := state.UpsertAllocs(1000, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -397,7 +397,7 @@ func TestSearch_PrefixSearch_Allocation(t *testing.T) {
 	if err := state.UpsertJobSummary(999, summary); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := state.UpsertAllocs(90, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 90, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -442,7 +442,7 @@ func TestSearch_PrefixSearch_All_UUID(t *testing.T) {
 	if err := state.UpsertJobSummary(999, summary); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := state.UpsertAllocs(1000, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/nomad/state/deployment_events_test.go
+++ b/nomad/state/deployment_events_test.go
@@ -79,7 +79,7 @@ func WaitForEvents(t *testing.T, s *StateStore, index uint64, minEvents int, tim
 		}
 		maxAttempts--
 		if maxAttempts == 0 {
-			require.Fail(t, "reached max attempts waiting for desired event count")
+			require.Failf(t, "reached max attempts waiting for desired event count", "count %d", len(got))
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/nomad/state/events_test.go
+++ b/nomad/state/events_test.go
@@ -244,8 +244,8 @@ func TestGenericEventsFromChanges_UpsertNodeEventsType(t *testing.T) {
 	n1 := mock.Node()
 	n2 := mock.Node()
 
-	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, n1, 10))
-	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, n2, 12))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, 10, n1))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, 12, n2))
 
 	msgType := structs.UpsertNodeEventsType
 	req := &structs.EmitNodeEventsRequest{
@@ -284,7 +284,7 @@ func TestGenericEventsFromChanges_NodeUpdateStatusRequest(t *testing.T) {
 	// setup
 	n1 := mock.Node()
 
-	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, n1, 10))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, 10, n1))
 
 	updated := time.Now()
 	msgType := structs.NodeUpdateStatusRequestType
@@ -409,8 +409,8 @@ func TestGenericEventsFromChanges_BatchNodeUpdateDrainRequestType(t *testing.T) 
 	n1 := mock.Node()
 	n2 := mock.Node()
 
-	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, n1, 10))
-	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, n2, 11))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, 10, n1))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, 11, n2))
 
 	updated := time.Now()
 	msgType := structs.BatchNodeUpdateDrainRequestType
@@ -463,7 +463,7 @@ func TestGenericEventsFromChanges_NodeUpdateEligibilityRequestType(t *testing.T)
 	// setup
 	n1 := mock.Node()
 
-	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, n1, 10))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, 10, n1))
 
 	msgType := structs.NodeUpdateEligibilityRequestType
 

--- a/nomad/state/events_test.go
+++ b/nomad/state/events_test.go
@@ -263,7 +263,7 @@ func TestGenericEventsFromChanges_UpsertNodeEventsType(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, s.UpsertNodeEventsMsgType(msgType, 100, req.NodeEvents))
+	require.NoError(t, s.UpsertNodeEvents(msgType, 100, req.NodeEvents))
 	events := WaitForEvents(t, s, 100, 1, 1*time.Second)
 	require.Len(t, events, 2)
 
@@ -315,7 +315,7 @@ func TestGenericEventsFromChanges_EvalUpdateRequestType(t *testing.T) {
 	// setup
 	e1 := mock.Eval()
 
-	require.NoError(t, s.UpsertEvals(10, []*structs.Evaluation{e1}))
+	require.NoError(t, s.UpsertEvals(structs.MsgTypeTestSetup, 10, []*structs.Evaluation{e1}))
 
 	e2 := mock.Eval()
 	e2.ID = e1.ID
@@ -327,7 +327,7 @@ func TestGenericEventsFromChanges_EvalUpdateRequestType(t *testing.T) {
 		Evals: []*structs.Evaluation{e2},
 	}
 
-	require.NoError(t, s.UpsertEvalsMsgType(msgType, 100, req.Evals))
+	require.NoError(t, s.UpsertEvals(msgType, 100, req.Evals))
 
 	events := WaitForEvents(t, s, 100, 1, 1*time.Second)
 	require.Len(t, events, 1)
@@ -355,13 +355,13 @@ func TestGenericEventsFromChanges_ApplyPlanResultsRequestType(t *testing.T) {
 	alloc.DeploymentID = d.ID
 	alloc2.DeploymentID = d.ID
 
-	require.NoError(t, s.UpsertJob(9, job))
+	require.NoError(t, s.UpsertJob(structs.MsgTypeTestSetup, 9, job))
 
 	eval := mock.Eval()
 	eval.JobID = job.ID
 
 	// Create an eval
-	require.NoError(t, s.UpsertEvals(10, []*structs.Evaluation{eval}))
+	require.NoError(t, s.UpsertEvals(structs.MsgTypeTestSetup, 10, []*structs.Evaluation{eval}))
 
 	msgType := structs.ApplyPlanResultsRequestType
 	req := &structs.ApplyPlanResultsRequest{
@@ -502,7 +502,7 @@ func TestGenericEventsFromChanges_AllocUpdateDesiredTransitionRequestType(t *tes
 
 	alloc := mock.Alloc()
 
-	require.Nil(t, s.UpsertJob(10, alloc.Job))
+	require.Nil(t, s.UpsertJob(structs.MsgTypeTestSetup, 10, alloc.Job))
 	require.Nil(t, s.UpsertAllocs(structs.MsgTypeTestSetup, 11, []*structs.Allocation{alloc}))
 
 	msgType := structs.AllocUpdateDesiredTransitionRequestType

--- a/nomad/state/events_test.go
+++ b/nomad/state/events_test.go
@@ -503,7 +503,7 @@ func TestGenericEventsFromChanges_AllocUpdateDesiredTransitionRequestType(t *tes
 	alloc := mock.Alloc()
 
 	require.Nil(t, s.UpsertJob(10, alloc.Job))
-	require.Nil(t, s.UpsertAllocs(11, []*structs.Allocation{alloc}))
+	require.Nil(t, s.UpsertAllocs(structs.MsgTypeTestSetup, 11, []*structs.Allocation{alloc}))
 
 	msgType := structs.AllocUpdateDesiredTransitionRequestType
 

--- a/nomad/state/events_test.go
+++ b/nomad/state/events_test.go
@@ -244,8 +244,8 @@ func TestGenericEventsFromChanges_UpsertNodeEventsType(t *testing.T) {
 	n1 := mock.Node()
 	n2 := mock.Node()
 
-	require.NoError(t, s.UpsertNode(10, n1))
-	require.NoError(t, s.UpsertNode(12, n2))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, n1, 10))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, n2, 12))
 
 	msgType := structs.UpsertNodeEventsType
 	req := &structs.EmitNodeEventsRequest{
@@ -284,7 +284,7 @@ func TestGenericEventsFromChanges_NodeUpdateStatusRequest(t *testing.T) {
 	// setup
 	n1 := mock.Node()
 
-	require.NoError(t, s.UpsertNode(10, n1))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, n1, 10))
 
 	updated := time.Now()
 	msgType := structs.NodeUpdateStatusRequestType
@@ -409,8 +409,8 @@ func TestGenericEventsFromChanges_BatchNodeUpdateDrainRequestType(t *testing.T) 
 	n1 := mock.Node()
 	n2 := mock.Node()
 
-	require.NoError(t, s.UpsertNode(10, n1))
-	require.NoError(t, s.UpsertNode(11, n2))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, n1, 10))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, n2, 11))
 
 	updated := time.Now()
 	msgType := structs.BatchNodeUpdateDrainRequestType
@@ -463,7 +463,7 @@ func TestGenericEventsFromChanges_NodeUpdateEligibilityRequestType(t *testing.T)
 	// setup
 	n1 := mock.Node()
 
-	require.NoError(t, s.UpsertNode(10, n1))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, n1, 10))
 
 	msgType := structs.NodeUpdateEligibilityRequestType
 

--- a/nomad/state/state_changes.go
+++ b/nomad/state/state_changes.go
@@ -72,6 +72,7 @@ func (c *changeTrackerDB) WriteTxn(idx uint64) *txn {
 		Txn:     c.memdb.Txn(true),
 		Index:   idx,
 		publish: c.publish,
+		msgType: structs.IgnoreUnknownTypeFlag, // The zero value of structs.MessageType is noderegistration.
 	}
 	t.Txn.TrackChanges()
 	return t

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -952,20 +952,7 @@ func (s *StateStore) BatchUpdateNodeDrain(msgType structs.MessageType, index uin
 }
 
 // UpdateNodeDrain is used to update the drain of a node
-func (s *StateStore) UpdateNodeDrainMsgType(msgType structs.MessageType, index uint64, nodeID string,
-	drain *structs.DrainStrategy, markEligible bool, updatedAt int64, event *structs.NodeEvent) error {
-
-	txn := s.db.WriteTxnMsgT(msgType, index)
-	defer txn.Abort()
-	if err := s.updateNodeDrainImpl(txn, index, nodeID, drain, markEligible, updatedAt, event); err != nil {
-		return err
-	}
-	return txn.Commit()
-}
-
-// UpdateNodeDrain is used to update the drain of a node
-func (s *StateStore) UpdateNodeDrain(index uint64, nodeID string,
-	drain *structs.DrainStrategy, markEligible bool, updatedAt int64, event *structs.NodeEvent) error {
+func (s *StateStore) UpdateNodeDrain(msgType structs.MessageType, index uint64, nodeID string, drain *structs.DrainStrategy, markEligible bool, updatedAt int64, event *structs.NodeEvent) error {
 
 	txn := s.db.WriteTxn(index)
 	defer txn.Abort()
@@ -1064,23 +1051,10 @@ func (s *StateStore) UpdateNodeEligibility(msgType structs.MessageType, index ui
 	return txn.Commit()
 }
 
-func (s *StateStore) UpsertNodeEventsMsgType(msgType structs.MessageType, index uint64, nodeEvents map[string][]*structs.NodeEvent) error {
-	txn := s.db.WriteTxnMsgT(msgType, index)
-	defer txn.Abort()
-
-	for nodeID, events := range nodeEvents {
-		if err := s.upsertNodeEvents(index, nodeID, events, txn); err != nil {
-			return err
-		}
-	}
-
-	return txn.Commit()
-}
-
 // UpsertNodeEvents adds the node events to the nodes, rotating events as
 // necessary.
-func (s *StateStore) UpsertNodeEvents(index uint64, nodeEvents map[string][]*structs.NodeEvent) error {
-	txn := s.db.WriteTxn(index)
+func (s *StateStore) UpsertNodeEvents(msgType structs.MessageType, index uint64, nodeEvents map[string][]*structs.NodeEvent) error {
+	txn := s.db.WriteTxnMsgT(msgType, index)
 	defer txn.Abort()
 
 	for nodeID, events := range nodeEvents {
@@ -1469,18 +1443,8 @@ func (s *StateStore) Nodes(ws memdb.WatchSet) (memdb.ResultIterator, error) {
 }
 
 // UpsertJob is used to register a job or update a job definition
-func (s *StateStore) UpsertJob(index uint64, job *structs.Job) error {
+func (s *StateStore) UpsertJob(msgType structs.MessageType, index uint64, job *structs.Job) error {
 	txn := s.db.WriteTxn(index)
-	defer txn.Abort()
-	if err := s.upsertJobImpl(index, job, false, txn); err != nil {
-		return err
-	}
-	return txn.Commit()
-}
-
-// UpsertJob is used to register a job or update a job definition
-func (s *StateStore) UpsertJobMsgType(msgType structs.MessageType, index uint64, job *structs.Job) error {
-	txn := s.db.WriteTxnMsgT(msgType, index)
 	defer txn.Abort()
 	if err := s.upsertJobImpl(index, job, false, txn); err != nil {
 		return err
@@ -2684,19 +2648,7 @@ func (s *StateStore) PeriodicLaunches(ws memdb.WatchSet) (memdb.ResultIterator, 
 }
 
 // UpsertEvals is used to upsert a set of evaluations
-func (s *StateStore) UpsertEvals(index uint64, evals []*structs.Evaluation) error {
-	txn := s.db.WriteTxn(index)
-	defer txn.Abort()
-
-	err := s.UpsertEvalsTxn(index, evals, txn)
-	if err == nil {
-		return txn.Commit()
-	}
-	return err
-}
-
-// UpsertEvals is used to upsert a set of evaluations
-func (s *StateStore) UpsertEvalsMsgType(msgType structs.MessageType, index uint64, evals []*structs.Evaluation) error {
+func (s *StateStore) UpsertEvals(msgType structs.MessageType, index uint64, evals []*structs.Evaluation) error {
 	txn := s.db.WriteTxnMsgT(msgType, index)
 	defer txn.Abort()
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -782,26 +782,11 @@ func (s *StateStore) ScalingEventsByJob(ws memdb.WatchSet, namespace, jobID stri
 	return nil, 0, nil
 }
 
-// UpsertNodeMsgType is used to register a node or update a node definition
-// This is assumed to be triggered by the client, so we retain the value
-// of drain/eligibility which is set by the scheduler.
-// TODO(drew) remove this and update all test callers of UpsertNode to use msgType
-func (s *StateStore) UpsertNodeMsgType(msgType structs.MessageType, index uint64, node *structs.Node) error {
-	txn := s.db.WriteTxnMsgT(msgType, index)
-	defer txn.Abort()
-
-	err := upsertNodeTxn(txn, index, node)
-	if err != nil {
-		return nil
-	}
-	return txn.Commit()
-}
-
 // UpsertNode is used to register a node or update a node definition
 // This is assumed to be triggered by the client, so we retain the value
 // of drain/eligibility which is set by the scheduler.
-func (s *StateStore) UpsertNode(index uint64, node *structs.Node) error {
-	txn := s.db.WriteTxn(index)
+func (s *StateStore) UpsertNode(msgType structs.MessageType, node *structs.Node, index uint64) error {
+	txn := s.db.WriteTxnMsgT(msgType, index)
 	defer txn.Abort()
 
 	err := upsertNodeTxn(txn, index, node)

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -785,7 +785,7 @@ func (s *StateStore) ScalingEventsByJob(ws memdb.WatchSet, namespace, jobID stri
 // UpsertNode is used to register a node or update a node definition
 // This is assumed to be triggered by the client, so we retain the value
 // of drain/eligibility which is set by the scheduler.
-func (s *StateStore) UpsertNode(msgType structs.MessageType, node *structs.Node, index uint64) error {
+func (s *StateStore) UpsertNode(msgType structs.MessageType, index uint64, node *structs.Node) error {
 	txn := s.db.WriteTxnMsgT(msgType, index)
 	defer txn.Abort()
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -849,19 +849,7 @@ func upsertNodeTxn(txn *txn, index uint64, node *structs.Node) error {
 }
 
 // DeleteNode deregisters a batch of nodes
-func (s *StateStore) DeleteNodeMsgType(msgType structs.MessageType, index uint64, nodes []string) error {
-	txn := s.db.WriteTxnMsgT(msgType, index)
-	defer txn.Abort()
-
-	err := deleteNodeTxn(txn, index, nodes)
-	if err != nil {
-		return nil
-	}
-	return txn.Commit()
-}
-
-// DeleteNode deregisters a batch of nodes
-func (s *StateStore) DeleteNode(index uint64, nodes []string) error {
+func (s *StateStore) DeleteNode(msgType structs.MessageType, index uint64, nodes []string) error {
 	txn := s.db.WriteTxn(index)
 	defer txn.Abort()
 
@@ -3139,19 +3127,8 @@ func (s *StateStore) nestedUpdateAllocFromClient(txn *txn, index uint64, alloc *
 
 // UpsertAllocs is used to evict a set of allocations and allocate new ones at
 // the same time.
-func (s *StateStore) UpsertAllocs(index uint64, allocs []*structs.Allocation) error {
+func (s *StateStore) UpsertAllocs(msgType structs.MessageType, index uint64, allocs []*structs.Allocation) error {
 	txn := s.db.WriteTxn(index)
-	defer txn.Abort()
-	if err := s.upsertAllocsImpl(index, allocs, txn); err != nil {
-		return err
-	}
-	return txn.Commit()
-}
-
-// UpsertAllocsMsgType is used to evict a set of allocations and allocate new ones at
-// the same time.
-func (s *StateStore) UpsertAllocsMsgType(msgType structs.MessageType, index uint64, allocs []*structs.Allocation) error {
-	txn := s.db.WriteTxnMsgT(msgType, index)
 	defer txn.Abort()
 	if err := s.upsertAllocsImpl(index, allocs, txn); err != nil {
 		return err

--- a/nomad/state/state_store_events_test.go
+++ b/nomad/state/state_store_events_test.go
@@ -33,7 +33,7 @@ func TestStateStore_Events_OnEvict(t *testing.T) {
 	// force 3 evictions
 	for i := 1; i < 13; i++ {
 		require.NoError(t,
-			s.UpsertNode(structs.NodeRegisterRequestType, mock.Node(), uint64(i)),
+			s.UpsertNode(structs.NodeRegisterRequestType, uint64(i), mock.Node()),
 		)
 	}
 
@@ -107,7 +107,7 @@ func TestStateStore_Events_OnEvict_Missing(t *testing.T) {
 	// Publish 13 events to fill buffer and force 3 evictions
 	for i := 1; i < 13; i++ {
 		require.NoError(t,
-			s.UpsertNode(structs.NodeRegisterRequestType, mock.Node(), uint64(i)),
+			s.UpsertNode(structs.NodeRegisterRequestType, uint64(i), mock.Node()),
 		)
 	}
 

--- a/nomad/state/state_store_events_test.go
+++ b/nomad/state/state_store_events_test.go
@@ -33,7 +33,7 @@ func TestStateStore_Events_OnEvict(t *testing.T) {
 	// force 3 evictions
 	for i := 1; i < 13; i++ {
 		require.NoError(t,
-			s.UpsertNodeMsgType(structs.NodeRegisterRequestType, uint64(i), mock.Node()),
+			s.UpsertNode(structs.NodeRegisterRequestType, mock.Node(), uint64(i)),
 		)
 	}
 
@@ -107,7 +107,7 @@ func TestStateStore_Events_OnEvict_Missing(t *testing.T) {
 	// Publish 13 events to fill buffer and force 3 evictions
 	for i := 1; i < 13; i++ {
 		require.NoError(t,
-			s.UpsertNodeMsgType(structs.NodeRegisterRequestType, uint64(i), mock.Node()),
+			s.UpsertNode(structs.NodeRegisterRequestType, mock.Node(), uint64(i)),
 		)
 	}
 

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -858,7 +858,7 @@ func TestStateStore_DeleteNode_Node(t *testing.T) {
 	require.NotNil(t, out)
 
 	// Delete both nodes in a batch, fires the watch
-	err = state.DeleteNode(1002, []string{node0.ID, node1.ID})
+	err = state.DeleteNode(structs.MsgTypeTestSetup, 1002, []string{node0.ID, node1.ID})
 	require.NoError(t, err)
 	require.True(t, watchFired(ws))
 
@@ -2870,7 +2870,7 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	index++
 	err := state.UpsertNode(structs.MsgTypeTestSetup, node, index)
 	require.NoError(t, err)
-	defer state.DeleteNode(9999, []string{pluginID})
+	defer state.DeleteNode(structs.MsgTypeTestSetup, 9999, []string{pluginID})
 
 	index++
 	err = state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc})

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -106,7 +106,7 @@ func TestStateStore_UpsertPlanResults_AllocationsCreated_Denormalized(t *testing
 	job := alloc.Job
 	alloc.Job = nil
 
-	if err := state.UpsertJob(999, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -114,7 +114,7 @@ func TestStateStore_UpsertPlanResults_AllocationsCreated_Denormalized(t *testing
 	eval.JobID = job.ID
 
 	// Create an eval
-	if err := state.UpsertEvals(1, []*structs.Evaluation{eval}); err != nil {
+	if err := state.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{eval}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -177,19 +177,19 @@ func TestStateStore_UpsertPlanResults_AllocationsDenormalized(t *testing.T) {
 
 	require := require.New(t)
 	require.NoError(state.UpsertAllocs(structs.MsgTypeTestSetup, 900, []*structs.Allocation{stoppedAlloc, preemptedAlloc}))
-	require.NoError(state.UpsertJob(999, job))
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 999, job))
 
 	// modify job and ensure that stopped and preempted alloc point to original Job
 	mJob := job.Copy()
 	mJob.TaskGroups[0].Name = "other"
 
-	require.NoError(state.UpsertJob(1001, mJob))
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 1001, mJob))
 
 	eval := mock.Eval()
 	eval.JobID = job.ID
 
 	// Create an eval
-	require.NoError(state.UpsertEvals(1, []*structs.Evaluation{eval}))
+	require.NoError(state.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{eval}))
 
 	// Create a plan result
 	res := structs.ApplyPlanResultsRequest{
@@ -262,7 +262,7 @@ func TestStateStore_UpsertPlanResults_Deployment(t *testing.T) {
 	alloc.DeploymentID = d.ID
 	alloc2.DeploymentID = d.ID
 
-	if err := state.UpsertJob(999, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -270,7 +270,7 @@ func TestStateStore_UpsertPlanResults_Deployment(t *testing.T) {
 	eval.JobID = job.ID
 
 	// Create an eval
-	if err := state.UpsertEvals(1, []*structs.Evaluation{eval}); err != nil {
+	if err := state.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{eval}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -365,13 +365,13 @@ func TestStateStore_UpsertPlanResults_PreemptedAllocs(t *testing.T) {
 	alloc.Job = nil
 
 	// Insert job
-	err := state.UpsertJob(999, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 999, job)
 	require.NoError(err)
 
 	// Create an eval
 	eval := mock.Eval()
 	eval.JobID = job.ID
-	err = state.UpsertEvals(1, []*structs.Evaluation{eval})
+	err = state.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{eval})
 	require.NoError(err)
 
 	// Insert alloc that will be preempted in the plan
@@ -442,7 +442,7 @@ func TestStateStore_UpsertPlanResults_DeploymentUpdates(t *testing.T) {
 
 	// Create a job that applies to all
 	job := mock.Job()
-	if err := state.UpsertJob(998, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 998, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -458,7 +458,7 @@ func TestStateStore_UpsertPlanResults_DeploymentUpdates(t *testing.T) {
 	eval.JobID = job.ID
 
 	// Create an eval
-	if err := state.UpsertEvals(1, []*structs.Evaluation{eval}); err != nil {
+	if err := state.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{eval}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	alloc := mock.Alloc()
@@ -570,7 +570,7 @@ func TestStateStore_OldDeployment(t *testing.T) {
 	state := testStateStore(t)
 	job := mock.Job()
 	job.ID = "job1"
-	state.UpsertJob(1000, job)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 
 	deploy1 := mock.Deployment()
 	deploy1.JobID = job.ID
@@ -1002,7 +1002,7 @@ func TestStateStore_UpdateNodeDrain_Node(t *testing.T) {
 		Subsystem: structs.NodeEventSubsystemDrain,
 		Timestamp: time.Now(),
 	}
-	require.Nil(state.UpdateNodeDrain(1001, node.ID, expectedDrain, false, 7, event))
+	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 1001, node.ID, expectedDrain, false, 7, event))
 	require.True(watchFired(ws))
 
 	ws = memdb.NewWatchSet()
@@ -1050,7 +1050,7 @@ func TestStateStore_AddSingleNodeEvent(t *testing.T) {
 	nodeEvents := map[string][]*structs.NodeEvent{
 		node.ID: {nodeEvent},
 	}
-	err = state.UpsertNodeEvents(uint64(1001), nodeEvents)
+	err = state.UpsertNodeEvents(structs.MsgTypeTestSetup, uint64(1001), nodeEvents)
 	require.Nil(err)
 
 	require.True(watchFired(ws))
@@ -1096,7 +1096,7 @@ func TestStateStore_NodeEvents_RetentionWindow(t *testing.T) {
 		nodeEvents := map[string][]*structs.NodeEvent{
 			out.ID: {nodeEvent},
 		}
-		err := state.UpsertNodeEvents(uint64(i), nodeEvents)
+		err := state.UpsertNodeEvents(structs.MsgTypeTestSetup, uint64(i), nodeEvents)
 		require.Nil(err)
 
 		require.True(watchFired(ws))
@@ -1138,7 +1138,7 @@ func TestStateStore_UpdateNodeDrain_ResetEligiblity(t *testing.T) {
 		Subsystem: structs.NodeEventSubsystemDrain,
 		Timestamp: time.Now(),
 	}
-	require.Nil(state.UpdateNodeDrain(1001, node.ID, drain, false, 7, event1))
+	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 1001, node.ID, drain, false, 7, event1))
 	require.True(watchFired(ws))
 
 	// Remove the drain
@@ -1147,7 +1147,7 @@ func TestStateStore_UpdateNodeDrain_ResetEligiblity(t *testing.T) {
 		Subsystem: structs.NodeEventSubsystemDrain,
 		Timestamp: time.Now(),
 	}
-	require.Nil(state.UpdateNodeDrain(1002, node.ID, nil, true, 9, event2))
+	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 1002, node.ID, nil, true, 9, event2))
 
 	ws = memdb.NewWatchSet()
 	out, err := state.NodeByID(ws, node.ID)
@@ -1213,7 +1213,7 @@ func TestStateStore_UpdateNodeEligibility(t *testing.T) {
 			Deadline: -1 * time.Second,
 		},
 	}
-	require.Nil(state.UpdateNodeDrain(1002, node.ID, expectedDrain, false, 7, nil))
+	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 1002, node.ID, expectedDrain, false, 7, nil))
 
 	// Try to set the node to eligible
 	err = state.UpdateNodeEligibility(structs.MsgTypeTestSetup, 1003, node.ID, structs.NodeSchedulingEligible, 9, nil)
@@ -1394,7 +1394,7 @@ func TestStateStore_UpsertJob_Job(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	if err := state.UpsertJob(1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if !watchFired(ws) {
@@ -1474,14 +1474,14 @@ func TestStateStore_UpdateUpsertJob_Job(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	if err := state.UpsertJob(1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	job2 := mock.Job()
 	job2.ID = job.ID
 	job2.AllAtOnce = true
-	err = state.UpsertJob(1001, job2)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1001, job2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1579,7 +1579,7 @@ func TestStateStore_UpdateUpsertJob_PeriodicJob(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	if err := state.UpsertJob(1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -1587,21 +1587,21 @@ func TestStateStore_UpdateUpsertJob_PeriodicJob(t *testing.T) {
 	job2 := job.Copy()
 	job2.Periodic = nil
 	job2.ID = fmt.Sprintf("%v/%s-1490635020", job.ID, structs.PeriodicLaunchSuffix)
-	err = state.UpsertJob(1001, job2)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1001, job2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	eval := mock.Eval()
 	eval.JobID = job2.ID
-	err = state.UpsertEvals(1002, []*structs.Evaluation{eval})
+	err = state.UpsertEvals(structs.MsgTypeTestSetup, 1002, []*structs.Evaluation{eval})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	job3 := job.Copy()
 	job3.TaskGroups[0].Tasks[0].Name = "new name"
-	err = state.UpsertJob(1003, job3)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1003, job3)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1630,7 +1630,7 @@ func TestStateStore_UpsertJob_BadNamespace(t *testing.T) {
 	job := mock.Job()
 	job.Namespace = "foo"
 
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	assert.Contains(err.Error(), "nonexistent namespace")
 
 	ws := memdb.NewWatchSet()
@@ -1654,13 +1654,13 @@ func TestStateStore_UpsertJob_ChildJob(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	if err := state.UpsertJob(1000, parent); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, parent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	child := mock.Job()
 	child.ParentID = parent.ID
-	if err := state.UpsertJob(1001, child); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1001, child); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -1702,7 +1702,7 @@ func TestStateStore_UpdateUpsertJob_JobVersion(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	if err := state.UpsertJob(1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -1715,7 +1715,7 @@ func TestStateStore_UpdateUpsertJob_JobVersion(t *testing.T) {
 		finalJob = mock.Job()
 		finalJob.ID = job.ID
 		finalJob.Name = fmt.Sprintf("%d", i)
-		err = state.UpsertJob(uint64(1000+i), finalJob)
+		err = state.UpsertJob(structs.MsgTypeTestSetup, uint64(1000+i), finalJob)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1782,7 +1782,7 @@ func TestStateStore_DeleteJob_Job(t *testing.T) {
 	state := testStateStore(t)
 	job := mock.Job()
 
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1872,7 +1872,7 @@ func TestStateStore_DeleteJobTxn_BatchDeletes(t *testing.T) {
 		stateIndex++
 		job := mock.BatchJob()
 
-		err := state.UpsertJob(stateIndex, job)
+		err := state.UpsertJob(structs.MsgTypeTestSetup, stateIndex, job)
 		require.NoError(t, err)
 
 		jobs[i] = job
@@ -1886,7 +1886,7 @@ func TestStateStore_DeleteJobTxn_BatchDeletes(t *testing.T) {
 				"Version": fmt.Sprintf("%d", vi),
 			}
 
-			require.NoError(t, state.UpsertJob(stateIndex, job))
+			require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, stateIndex, job))
 		}
 	}
 
@@ -1943,7 +1943,7 @@ func TestStateStore_DeleteJob_MultipleVersions(t *testing.T) {
 	ws := memdb.NewWatchSet()
 	_, err := state.JobVersionsByID(ws, job.Namespace, job.ID)
 	assert.Nil(err)
-	assert.Nil(state.UpsertJob(1000, job))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, job))
 	assert.True(watchFired(ws))
 
 	var finalJob *structs.Job
@@ -1951,7 +1951,7 @@ func TestStateStore_DeleteJob_MultipleVersions(t *testing.T) {
 		finalJob = mock.Job()
 		finalJob.ID = job.ID
 		finalJob.Priority = i
-		assert.Nil(state.UpsertJob(uint64(1000+i), finalJob))
+		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, uint64(1000+i), finalJob))
 	}
 
 	assert.Nil(state.DeleteJob(1020, job.Namespace, job.ID))
@@ -1991,14 +1991,14 @@ func TestStateStore_DeleteJob_ChildJob(t *testing.T) {
 	state := testStateStore(t)
 
 	parent := mock.Job()
-	if err := state.UpsertJob(998, parent); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 998, parent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	child := mock.Job()
 	child.ParentID = parent.ID
 
-	if err := state.UpsertJob(999, child); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, child); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2048,7 +2048,7 @@ func TestStateStore_Jobs(t *testing.T) {
 		job := mock.Job()
 		jobs = append(jobs, job)
 
-		err := state.UpsertJob(1000+uint64(i), job)
+		err := state.UpsertJob(structs.MsgTypeTestSetup, 1000+uint64(i), job)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -2090,7 +2090,7 @@ func TestStateStore_JobVersions(t *testing.T) {
 		job := mock.Job()
 		jobs = append(jobs, job)
 
-		err := state.UpsertJob(1000+uint64(i), job)
+		err := state.UpsertJob(structs.MsgTypeTestSetup, 1000+uint64(i), job)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -2129,7 +2129,7 @@ func TestStateStore_JobsByIDPrefix(t *testing.T) {
 	job := mock.Job()
 
 	job.ID = "redis"
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2172,7 +2172,7 @@ func TestStateStore_JobsByIDPrefix(t *testing.T) {
 
 	job = mock.Job()
 	job.ID = "riak"
-	err = state.UpsertJob(1001, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1001, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2216,7 +2216,7 @@ func TestStateStore_JobsByPeriodic(t *testing.T) {
 		job := mock.Job()
 		nonPeriodic = append(nonPeriodic, job)
 
-		err := state.UpsertJob(1000+uint64(i), job)
+		err := state.UpsertJob(structs.MsgTypeTestSetup, 1000+uint64(i), job)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -2226,7 +2226,7 @@ func TestStateStore_JobsByPeriodic(t *testing.T) {
 		job := mock.PeriodicJob()
 		periodic = append(periodic, job)
 
-		err := state.UpsertJob(2000+uint64(i), job)
+		err := state.UpsertJob(structs.MsgTypeTestSetup, 2000+uint64(i), job)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -2289,7 +2289,7 @@ func TestStateStore_JobsByScheduler(t *testing.T) {
 		job := mock.Job()
 		serviceJobs = append(serviceJobs, job)
 
-		err := state.UpsertJob(1000+uint64(i), job)
+		err := state.UpsertJob(structs.MsgTypeTestSetup, 1000+uint64(i), job)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -2300,7 +2300,7 @@ func TestStateStore_JobsByScheduler(t *testing.T) {
 		job.Status = structs.JobStatusRunning
 		sysJobs = append(sysJobs, job)
 
-		err := state.UpsertJob(2000+uint64(i), job)
+		err := state.UpsertJob(structs.MsgTypeTestSetup, 2000+uint64(i), job)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -2367,7 +2367,7 @@ func TestStateStore_JobsByGC(t *testing.T) {
 		}
 		nonGc[job.ID] = struct{}{}
 
-		if err := state.UpsertJob(1000+uint64(i), job); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000+uint64(i), job); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	}
@@ -2377,7 +2377,7 @@ func TestStateStore_JobsByGC(t *testing.T) {
 		job.Type = structs.JobTypeBatch
 		gc[job.ID] = struct{}{}
 
-		if err := state.UpsertJob(2000+uint64(i), job); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 2000+uint64(i), job); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -2385,7 +2385,7 @@ func TestStateStore_JobsByGC(t *testing.T) {
 		eval := mock.Eval()
 		eval.JobID = job.ID
 		eval.Status = structs.EvalStatusComplete
-		if err := state.UpsertEvals(2000+uint64(i+1), []*structs.Evaluation{eval}); err != nil {
+		if err := state.UpsertEvals(structs.MsgTypeTestSetup, 2000+uint64(i+1), []*structs.Evaluation{eval}); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -3536,11 +3536,11 @@ func TestStateStore_CSIPluginJobs(t *testing.T) {
 		Type: structs.CSIPluginTypeNode,
 	}
 
-	err := s.UpsertJob(index, controllerJob)
+	err := s.UpsertJob(structs.MsgTypeTestSetup, index, controllerJob)
 	require.NoError(t, err)
 	index++
 
-	err = s.UpsertJob(index, nodeJob)
+	err = s.UpsertJob(structs.MsgTypeTestSetup, index, nodeJob)
 	require.NoError(t, err)
 	index++
 
@@ -3701,7 +3701,7 @@ func TestStateStore_LatestIndex(t *testing.T) {
 	}
 
 	exp := uint64(2000)
-	if err := state.UpsertJob(exp, mock.Job()); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, exp, mock.Job()); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3755,7 +3755,7 @@ func TestStateStore_UpsertEvals_Eval(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	err := state.UpsertEvals(1000, []*structs.Evaluation{eval})
+	err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -3800,7 +3800,7 @@ func TestStateStore_UpsertEvals_CancelBlocked(t *testing.T) {
 	b2.JobID = j
 	b2.Status = structs.EvalStatusBlocked
 
-	err := state.UpsertEvals(999, []*structs.Evaluation{b1, b2})
+	err := state.UpsertEvals(structs.MsgTypeTestSetup, 999, []*structs.Evaluation{b1, b2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -3820,7 +3820,7 @@ func TestStateStore_UpsertEvals_CancelBlocked(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	if err := state.UpsertEvals(1000, []*structs.Evaluation{eval}); err != nil {
+	if err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3872,7 +3872,7 @@ func TestStateStore_Update_UpsertEvals_Eval(t *testing.T) {
 	state := testStateStore(t)
 	eval := mock.Eval()
 
-	err := state.UpsertEvals(1000, []*structs.Evaluation{eval})
+	err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -3891,7 +3891,7 @@ func TestStateStore_Update_UpsertEvals_Eval(t *testing.T) {
 	eval2 := mock.Eval()
 	eval2.ID = eval.ID
 	eval2.JobID = eval.JobID
-	err = state.UpsertEvals(1001, []*structs.Evaluation{eval2})
+	err = state.UpsertEvals(structs.MsgTypeTestSetup, 1001, []*structs.Evaluation{eval2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -3939,14 +3939,14 @@ func TestStateStore_UpsertEvals_Eval_ChildJob(t *testing.T) {
 	state := testStateStore(t)
 
 	parent := mock.Job()
-	if err := state.UpsertJob(998, parent); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 998, parent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	child := mock.Job()
 	child.ParentID = parent.ID
 
-	if err := state.UpsertJob(999, child); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, child); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3968,7 +3968,7 @@ func TestStateStore_UpsertEvals_Eval_ChildJob(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	err := state.UpsertEvals(1000, []*structs.Evaluation{eval})
+	err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4078,7 +4078,7 @@ func TestStateStore_DeleteEval_Eval(t *testing.T) {
 	state.UpsertJobSummary(901, mock.JobSummary(eval2.JobID))
 	state.UpsertJobSummary(902, mock.JobSummary(alloc1.JobID))
 	state.UpsertJobSummary(903, mock.JobSummary(alloc2.JobID))
-	err := state.UpsertEvals(1000, []*structs.Evaluation{eval1, eval2})
+	err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1, eval2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4163,14 +4163,14 @@ func TestStateStore_DeleteEval_ChildJob(t *testing.T) {
 	state := testStateStore(t)
 
 	parent := mock.Job()
-	if err := state.UpsertJob(998, parent); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 998, parent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	child := mock.Job()
 	child.ParentID = parent.ID
 
-	if err := state.UpsertJob(999, child); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, child); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4179,7 +4179,7 @@ func TestStateStore_DeleteEval_ChildJob(t *testing.T) {
 	alloc1 := mock.Alloc()
 	alloc1.JobID = child.ID
 
-	err := state.UpsertEvals(1000, []*structs.Evaluation{eval1})
+	err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4238,11 +4238,11 @@ func TestStateStore_EvalsByJob(t *testing.T) {
 	eval3 := mock.Eval()
 	evals := []*structs.Evaluation{eval1, eval2}
 
-	err := state.UpsertEvals(1000, evals)
+	err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, evals)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	err = state.UpsertEvals(1001, []*structs.Evaluation{eval3})
+	err = state.UpsertEvals(structs.MsgTypeTestSetup, 1001, []*structs.Evaluation{eval3})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4275,7 +4275,7 @@ func TestStateStore_Evals(t *testing.T) {
 		eval := mock.Eval()
 		evals = append(evals, eval)
 
-		err := state.UpsertEvals(1000+uint64(i), []*structs.Evaluation{eval})
+		err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000+uint64(i), []*structs.Evaluation{eval})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -4331,7 +4331,7 @@ func TestStateStore_EvalsByIDPrefix(t *testing.T) {
 		evals = append(evals, eval)
 	}
 
-	err := state.UpsertEvals(1000, evals)
+	err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, evals)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4415,13 +4415,13 @@ func TestStateStore_UpdateAllocsFromClient(t *testing.T) {
 
 	state := testStateStore(t)
 	parent := mock.Job()
-	if err := state.UpsertJob(998, parent); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 998, parent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	child := mock.Job()
 	child.ParentID = parent.ID
-	if err := state.UpsertJob(999, child); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, child); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4506,10 +4506,10 @@ func TestStateStore_UpdateAllocsFromClient_ChildJob(t *testing.T) {
 	alloc1 := mock.Alloc()
 	alloc2 := mock.Alloc()
 
-	if err := state.UpsertJob(999, alloc1.Job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc1.Job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := state.UpsertJob(999, alloc2.Job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc2.Job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4641,7 +4641,7 @@ func TestStateStore_UpdateMultipleAllocsFromClient(t *testing.T) {
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 
-	if err := state.UpsertJob(999, alloc.Job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc})
@@ -4720,7 +4720,7 @@ func TestStateStore_UpdateAllocsFromClient_Deployment(t *testing.T) {
 	deployment.TaskGroups[alloc.TaskGroup].ProgressDeadline = pdeadline
 	alloc.DeploymentID = deployment.ID
 
-	require.Nil(state.UpsertJob(999, alloc.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job))
 	require.Nil(state.UpsertDeployment(1000, deployment))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc}))
 
@@ -4766,7 +4766,7 @@ func TestStateStore_UpdateAllocsFromClient_DeploymentStateMerges(t *testing.T) {
 		Canary: true,
 	}
 
-	require.Nil(state.UpsertJob(999, alloc.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job))
 	require.Nil(state.UpsertDeployment(1000, deployment))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc}))
 
@@ -4797,7 +4797,7 @@ func TestStateStore_UpsertAlloc_Alloc(t *testing.T) {
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 
-	if err := state.UpsertJob(999, alloc.Job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4880,7 +4880,7 @@ func TestStateStore_UpsertAlloc_Deployment(t *testing.T) {
 	deployment.TaskGroups[alloc.TaskGroup].ProgressDeadline = pdeadline
 	alloc.DeploymentID = deployment.ID
 
-	require.Nil(state.UpsertJob(999, alloc.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job))
 	require.Nil(state.UpsertDeployment(1000, deployment))
 
 	// Create a watch set so we can test that update fires the watch
@@ -4939,14 +4939,14 @@ func TestStateStore_UpsertAlloc_ChildJob(t *testing.T) {
 	state := testStateStore(t)
 
 	parent := mock.Job()
-	if err := state.UpsertJob(998, parent); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 998, parent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	child := mock.Job()
 	child.ParentID = parent.ID
 
-	if err := state.UpsertJob(999, child); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, child); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4998,7 +4998,7 @@ func TestStateStore_UpdateAlloc_Alloc(t *testing.T) {
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 
-	if err := state.UpsertJob(999, alloc.Job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -5100,7 +5100,7 @@ func TestStateStore_UpdateAlloc_Lost(t *testing.T) {
 	alloc := mock.Alloc()
 	alloc.ClientStatus = "foo"
 
-	if err := state.UpsertJob(999, alloc.Job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -5138,7 +5138,7 @@ func TestStateStore_UpdateAlloc_NoJob(t *testing.T) {
 
 	// Upsert a job
 	state.UpsertJobSummary(998, mock.JobSummary(alloc.JobID))
-	if err := state.UpsertJob(999, alloc.Job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -5181,7 +5181,7 @@ func TestStateStore_UpdateAllocDesiredTransition(t *testing.T) {
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 
-	require.Nil(state.UpsertJob(999, alloc.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc}))
 
 	t1 := &structs.DesiredTransition{
@@ -5249,7 +5249,7 @@ func TestStateStore_JobSummary(t *testing.T) {
 
 	// Add a job
 	job := mock.Job()
-	state.UpsertJob(900, job)
+	state.UpsertJob(structs.MsgTypeTestSetup, 900, job)
 
 	// Get the job back
 	ws := memdb.NewWatchSet()
@@ -5331,7 +5331,7 @@ func TestStateStore_JobSummary(t *testing.T) {
 	// Re-register the same job
 	job1 := mock.Job()
 	job1.ID = job.ID
-	state.UpsertJob(1000, job1)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1000, job1)
 	outJob2, _ := state.JobByID(ws, job1.Namespace, job1.ID)
 	if outJob2.CreateIndex != 1000 {
 		t.Fatalf("bad create index: %v", outJob2.CreateIndex)
@@ -5378,7 +5378,7 @@ func TestStateStore_ReconcileJobSummary(t *testing.T) {
 	tg2 := alloc.Job.TaskGroups[0].Copy()
 	tg2.Name = "db"
 	alloc.Job.TaskGroups = append(alloc.Job.TaskGroups, tg2)
-	state.UpsertJob(100, alloc.Job)
+	state.UpsertJob(structs.MsgTypeTestSetup, 100, alloc.Job)
 
 	// Create one more alloc for the db task group
 	alloc2 := mock.Alloc()
@@ -5474,7 +5474,7 @@ func TestStateStore_ReconcileParentJobSummary(t *testing.T) {
 		Payload: "random",
 	}
 	job1.TaskGroups[0].Count = 1
-	state.UpsertJob(100, job1)
+	state.UpsertJob(structs.MsgTypeTestSetup, 100, job1)
 
 	// Make a child job
 	childJob := job1.Copy()
@@ -5496,7 +5496,7 @@ func TestStateStore_ReconcileParentJobSummary(t *testing.T) {
 	alloc2.JobID = childJob.ID
 	alloc2.ClientStatus = structs.AllocClientStatusFailed
 
-	require.Nil(state.UpsertJob(110, childJob))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 110, childJob))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 111, []*structs.Allocation{alloc, alloc2}))
 
 	// Make the summary incorrect in the state store
@@ -5553,7 +5553,7 @@ func TestStateStore_UpdateAlloc_JobNotPresent(t *testing.T) {
 	state := testStateStore(t)
 
 	alloc := mock.Alloc()
-	state.UpsertJob(100, alloc.Job)
+	state.UpsertJob(structs.MsgTypeTestSetup, 100, alloc.Job)
 	state.UpsertAllocs(structs.MsgTypeTestSetup, 200, []*structs.Allocation{alloc})
 
 	// Delete the job
@@ -5569,7 +5569,7 @@ func TestStateStore_UpdateAlloc_JobNotPresent(t *testing.T) {
 	}
 
 	// Re-Register the job
-	state.UpsertJob(500, alloc.Job)
+	state.UpsertJob(structs.MsgTypeTestSetup, 500, alloc.Job)
 
 	// Update the alloc again
 	alloc2 := alloc.Copy()
@@ -5783,7 +5783,7 @@ func TestStateStore_AllocsForRegisteredJob(t *testing.T) {
 
 	job := mock.Job()
 	job.ID = "foo"
-	state.UpsertJob(100, job)
+	state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
 	for i := 0; i < 3; i++ {
 		alloc := mock.Alloc()
 		alloc.Job = job
@@ -5801,7 +5801,7 @@ func TestStateStore_AllocsForRegisteredJob(t *testing.T) {
 	job1 := mock.Job()
 	job1.ID = "foo"
 	job1.CreateIndex = 50
-	state.UpsertJob(300, job1)
+	state.UpsertJob(structs.MsgTypeTestSetup, 300, job1)
 	for i := 0; i < 4; i++ {
 		alloc := mock.Alloc()
 		alloc.Job = job1
@@ -6219,7 +6219,7 @@ func TestStateStore_GetJobStatus_DeadEvalsAndAllocs(t *testing.T) {
 	eval := mock.Eval()
 	eval.JobID = job.ID
 	eval.Status = structs.EvalStatusComplete
-	if err := state.UpsertEvals(1001, []*structs.Evaluation{eval}); err != nil {
+	if err := state.UpsertEvals(structs.MsgTypeTestSetup, 1001, []*structs.Evaluation{eval}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -6327,7 +6327,7 @@ func TestStateStore_SetJobStatus_PendingEval(t *testing.T) {
 	eval := mock.Eval()
 	eval.JobID = job.ID
 	eval.Status = structs.EvalStatusPending
-	if err := state.UpsertEvals(1000, []*structs.Evaluation{eval}); err != nil {
+	if err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -6355,7 +6355,7 @@ func TestStateStore_SetJobStatus_SystemJob(t *testing.T) {
 	eval.JobID = job.ID
 	eval.Type = job.Type
 	eval.Status = structs.EvalStatusComplete
-	if err := state.UpsertEvals(1000, []*structs.Evaluation{eval}); err != nil {
+	if err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -6395,7 +6395,7 @@ func TestStateJobSummary_UpdateJobCount(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	if err := state.UpsertJob(1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -6528,7 +6528,7 @@ func TestJobSummary_UpdateClientStatus(t *testing.T) {
 	alloc3.Job = job
 	alloc3.JobID = job.ID
 
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -6704,7 +6704,7 @@ func TestStateStore_UpsertDeploymentStatusUpdate_Successful(t *testing.T) {
 
 	// Insert a job
 	job := mock.Job()
-	if err := state.UpsertJob(1, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, job); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -6761,11 +6761,11 @@ func TestStateStore_UpdateJobStability(t *testing.T) {
 
 	// Insert a job twice to get two versions
 	job := mock.Job()
-	if err := state.UpsertJob(1, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, job); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
-	if err := state.UpsertJob(2, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 2, job); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -6862,7 +6862,7 @@ func TestStateStore_UpsertDeploymentPromotion_Unhealthy(t *testing.T) {
 
 	// Create a job
 	j := mock.Job()
-	require.Nil(state.UpsertJob(1, j))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1, j))
 
 	// Create a deployment
 	d := mock.Deployment()
@@ -6911,7 +6911,7 @@ func TestStateStore_UpsertDeploymentPromotion_NoCanaries(t *testing.T) {
 
 	// Create a job
 	j := mock.Job()
-	require.Nil(state.UpsertJob(1, j))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1, j))
 
 	// Create a deployment
 	d := mock.Deployment()
@@ -6943,7 +6943,7 @@ func TestStateStore_UpsertDeploymentPromotion_All(t *testing.T) {
 	tg2 := tg1.Copy()
 	tg2.Name = "foo"
 	j.TaskGroups = append(j.TaskGroups, tg2)
-	if err := state.UpsertJob(1, j); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, j); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -7043,7 +7043,7 @@ func TestStateStore_UpsertDeploymentPromotion_Subset(t *testing.T) {
 	tg2 := tg1.Copy()
 	tg2.Name = "foo"
 	j.TaskGroups = append(j.TaskGroups, tg2)
-	require.Nil(state.UpsertJob(1, j))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1, j))
 
 	// Create a deployment
 	d := mock.Deployment()
@@ -7216,7 +7216,7 @@ func TestStateStore_UpsertDeploymentAlloc_Canaries(t *testing.T) {
 
 	// Create a Job
 	job := mock.Job()
-	require.NoError(t, state.UpsertJob(3, job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 3, job))
 
 	// Create alloc with canary status
 	a := mock.Alloc()
@@ -7286,7 +7286,7 @@ func TestStateStore_UpsertDeploymentAlloc_NoCanaries(t *testing.T) {
 
 	// Create a Job
 	job := mock.Job()
-	require.NoError(t, state.UpsertJob(3, job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 3, job))
 
 	// Create alloc with canary status
 	a := mock.Alloc()
@@ -8738,7 +8738,7 @@ func TestStateStore_UpsertJob_UpsertScalingPolicies(t *testing.T) {
 	require.Nil(out)
 
 	var newIndex uint64 = 1000
-	err = state.UpsertJob(newIndex, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, newIndex, job)
 	require.NoError(err)
 	require.True(watchFired(ws), "watch did not fire")
 
@@ -8766,7 +8766,7 @@ func TestStateStore_UpsertJob_PreserveScalingPolicyIDsAndIndex(t *testing.T) {
 	job, policy := mock.JobWithScalingPolicy()
 
 	var newIndex uint64 = 1000
-	err := state.UpsertJob(newIndex, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, newIndex, job)
 	require.NoError(err)
 
 	ws := memdb.NewWatchSet()
@@ -8784,7 +8784,7 @@ func TestStateStore_UpsertJob_PreserveScalingPolicyIDsAndIndex(t *testing.T) {
 	// update the job
 	job.Meta["new-meta"] = "new-value"
 	newIndex += 100
-	err = state.UpsertJob(newIndex, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, newIndex, job)
 	require.NoError(err)
 	require.False(watchFired(ws), "watch should not have fired")
 
@@ -8811,7 +8811,7 @@ func TestStateStore_UpsertJob_UpdateScalingPolicy(t *testing.T) {
 	job, policy := mock.JobWithScalingPolicy()
 
 	var oldIndex uint64 = 1000
-	require.NoError(state.UpsertJob(oldIndex, job))
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, oldIndex, job))
 
 	ws := memdb.NewWatchSet()
 	p1, err := state.ScalingPolicyByTargetAndType(ws, policy.Target, policy.Type)
@@ -8830,7 +8830,7 @@ func TestStateStore_UpsertJob_UpdateScalingPolicy(t *testing.T) {
 	newPolicy := p1.Copy()
 	newPolicy.Policy["new-field"] = "new-value"
 	job.TaskGroups[0].Scaling = newPolicy
-	require.NoError(state.UpsertJob(oldIndex+100, job))
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, oldIndex+100, job))
 	require.True(watchFired(ws), "watch should have fired")
 
 	p2, err := state.ScalingPolicyByTargetAndType(nil, policy.Target, policy.Type)
@@ -8910,7 +8910,7 @@ func TestStateStore_StopJob_DeleteScalingPolicies(t *testing.T) {
 
 	job := mock.Job()
 
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	require.NoError(err)
 
 	policy := mock.ScalingPolicy()
@@ -8931,7 +8931,7 @@ func TestStateStore_StopJob_DeleteScalingPolicies(t *testing.T) {
 	job, err = state.JobByID(nil, job.Namespace, job.ID)
 	require.NoError(err)
 	job.Stop = true
-	err = state.UpsertJob(1200, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1200, job)
 	require.NoError(err)
 
 	// Ensure:
@@ -8965,7 +8965,7 @@ func TestStateStore_UnstopJob_UpsertScalingPolicies(t *testing.T) {
 	require.Nil(list.Next())
 
 	// upsert a stopped job, verify that we don't fire the watcher or add any scaling policies
-	err = state.UpsertJob(1000, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	require.NoError(err)
 	require.False(watchFired(ws))
 	// stopped job should have no scaling policies, watcher doesn't fire
@@ -8979,7 +8979,7 @@ func TestStateStore_UnstopJob_UpsertScalingPolicies(t *testing.T) {
 	require.NoError(err)
 	// Unstop this job, say you'll run it again...
 	job.Stop = false
-	err = state.UpsertJob(1100, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1100, job)
 	require.NoError(err)
 
 	// Ensure the scaling policy was added, watch was fired, index was advanced
@@ -9001,7 +9001,7 @@ func TestStateStore_DeleteJob_DeleteScalingPolicies(t *testing.T) {
 
 	job := mock.Job()
 
-	err := state.UpsertJob(1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	require.NoError(err)
 
 	policy := mock.ScalingPolicy()
@@ -9031,10 +9031,10 @@ func TestStateStore_DeleteJob_DeleteScalingPoliciesPrefixBug(t *testing.T) {
 	state := testStateStore(t)
 
 	job := mock.Job()
-	require.NoError(state.UpsertJob(1000, job))
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 1000, job))
 	job2 := job.Copy()
 	job2.ID = job.ID + "-but-longer"
-	require.NoError(state.UpsertJob(1001, job2))
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 1001, job2))
 
 	policy := mock.ScalingPolicy()
 	policy.Target[structs.ScalingTargetJob] = job.ID
@@ -9069,7 +9069,7 @@ func TestStateStore_DeleteJob_ScalingPolicyIndexNoop(t *testing.T) {
 	prevIndex, err := state.Index("scaling_policy")
 	require.NoError(err)
 
-	err = state.UpsertJob(1000, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 	require.NoError(err)
 
 	newIndex, err := state.Index("scaling_policy")
@@ -9575,7 +9575,7 @@ func TestStateSnapshot_DenormalizeAllocationDiffSlice_AllocDoesNotExist(t *testi
 	require := require.New(t)
 
 	// Insert job
-	err := state.UpsertJob(999, alloc.Job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job)
 	require.NoError(err)
 
 	allocDiffs := []*structs.AllocationDiff{

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -83,7 +83,7 @@ func TestStateStore_Blocking_MinQuery(t *testing.T) {
 	defer cancel()
 
 	time.AfterFunc(5*time.Millisecond, func() {
-		state.UpsertNode(structs.MsgTypeTestSetup, node, 11)
+		state.UpsertNode(structs.MsgTypeTestSetup, 11, node)
 	})
 
 	resp, idx, err := state.BlockingQuery(queryFn, 10, deadlineCtx)
@@ -801,7 +801,7 @@ func TestStateStore_UpsertNode_Node(t *testing.T) {
 	_, err := state.NodeByID(ws, node.ID)
 	require.NoError(err)
 
-	require.NoError(state.UpsertNode(structs.MsgTypeTestSetup, node, 1000))
+	require.NoError(state.UpsertNode(structs.MsgTypeTestSetup, 1000, node))
 	require.True(watchFired(ws))
 
 	ws = memdb.NewWatchSet()
@@ -824,8 +824,8 @@ func TestStateStore_UpsertNode_Node(t *testing.T) {
 	// event
 	down := out.Copy()
 	down.Status = structs.NodeStatusDown
-	require.NoError(state.UpsertNode(structs.MsgTypeTestSetup, down, 1001))
-	require.NoError(state.UpsertNode(structs.MsgTypeTestSetup, out, 1002))
+	require.NoError(state.UpsertNode(structs.MsgTypeTestSetup, 1001, down))
+	require.NoError(state.UpsertNode(structs.MsgTypeTestSetup, 1002, out))
 
 	out, err = state.NodeByID(ws, node.ID)
 	require.NoError(err)
@@ -841,9 +841,9 @@ func TestStateStore_DeleteNode_Node(t *testing.T) {
 	// Create and insert two nodes, which we'll delete
 	node0 := mock.Node()
 	node1 := mock.Node()
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node0, 1000)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 1000, node0)
 	require.NoError(t, err)
-	err = state.UpsertNode(structs.MsgTypeTestSetup, node1, 1001)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, 1001, node1)
 	require.NoError(t, err)
 
 	// Create a watchset so we can test that delete fires the watch
@@ -885,7 +885,7 @@ func TestStateStore_UpdateNodeStatus_Node(t *testing.T) {
 	state := testStateStore(t)
 	node := mock.Node()
 
-	require.NoError(state.UpsertNode(structs.MsgTypeTestSetup, node, 800))
+	require.NoError(state.UpsertNode(structs.MsgTypeTestSetup, 800, node))
 
 	// Create a watchset so we can test that update node status fires the watch
 	ws := memdb.NewWatchSet()
@@ -923,8 +923,8 @@ func TestStateStore_BatchUpdateNodeDrain(t *testing.T) {
 	state := testStateStore(t)
 
 	n1, n2 := mock.Node(), mock.Node()
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n1, 1000))
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n2, 1001))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1000, n1))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1001, n2))
 
 	// Create a watchset so we can test that update node drain fires the watch
 	ws := memdb.NewWatchSet()
@@ -984,7 +984,7 @@ func TestStateStore_UpdateNodeDrain_Node(t *testing.T) {
 	state := testStateStore(t)
 	node := mock.Node()
 
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1000))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1000, node))
 
 	// Create a watchset so we can test that update node drain fires the watch
 	ws := memdb.NewWatchSet()
@@ -1030,7 +1030,7 @@ func TestStateStore_AddSingleNodeEvent(t *testing.T) {
 	node := mock.Node()
 
 	// We create a new node event every time we register a node
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	require.Nil(err)
 
 	require.Equal(1, len(node.Events))
@@ -1073,7 +1073,7 @@ func TestStateStore_NodeEvents_RetentionWindow(t *testing.T) {
 
 	node := mock.Node()
 
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1120,7 +1120,7 @@ func TestStateStore_UpdateNodeDrain_ResetEligiblity(t *testing.T) {
 
 	state := testStateStore(t)
 	node := mock.Node()
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1000))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1000, node))
 
 	// Create a watchset so we can test that update node drain fires the watch
 	ws := memdb.NewWatchSet()
@@ -1172,7 +1172,7 @@ func TestStateStore_UpdateNodeEligibility(t *testing.T) {
 	state := testStateStore(t)
 	node := mock.Node()
 
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1231,7 +1231,7 @@ func TestStateStore_Nodes(t *testing.T) {
 		node := mock.Node()
 		nodes = append(nodes, node)
 
-		err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000+uint64(i))
+		err := state.UpsertNode(structs.MsgTypeTestSetup, 1000+uint64(i), node)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1272,7 +1272,7 @@ func TestStateStore_NodesByIDPrefix(t *testing.T) {
 	node := mock.Node()
 
 	node.ID = "11111111-662e-d0ab-d1c9-3e434af7bdb4"
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1318,7 +1318,7 @@ func TestStateStore_NodesByIDPrefix(t *testing.T) {
 
 	node = mock.Node()
 	node.ID = "11222222-662e-d0ab-d1c9-3e434af7bdb4"
-	err = state.UpsertNode(structs.MsgTypeTestSetup, node, 1001)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, 1001, node)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2868,7 +2868,7 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	}
 
 	index++
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, index)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, index, node)
 	require.NoError(t, err)
 	defer state.DeleteNode(structs.MsgTypeTestSetup, 9999, []string{pluginID})
 
@@ -3039,7 +3039,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 	ns := []*structs.Node{mock.Node(), mock.Node()}
 	for _, n := range ns {
 		index++
-		err := state.UpsertNode(structs.MsgTypeTestSetup, n, index)
+		err := state.UpsertNode(structs.MsgTypeTestSetup, index, n)
 		require.NoError(t, err)
 	}
 
@@ -3059,7 +3059,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 		},
 	}
 	index++
-	err := state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, index, n0)
 	require.NoError(t, err)
 
 	// Fingerprint two running node plugins
@@ -3076,7 +3076,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 			},
 		}
 		index++
-		err = state.UpsertNode(structs.MsgTypeTestSetup, n, index)
+		err = state.UpsertNode(structs.MsgTypeTestSetup, index, n)
 		require.NoError(t, err)
 	}
 
@@ -3119,7 +3119,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 	}
 
 	index++
-	err = state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, index, n0)
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID)
@@ -3137,7 +3137,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 	n1, _ := state.NodeByID(ws, ns[1].ID)
 	n1.CSINodePlugins = map[string]*structs.CSIInfo{}
 	index++
-	err = state.UpsertNode(structs.MsgTypeTestSetup, n1, index)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, index, n1)
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID)
@@ -3151,7 +3151,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 	n0, _ = state.NodeByID(ws, ns[0].ID)
 	n0.CSINodePlugins = map[string]*structs.CSIInfo{}
 	index++
-	err = state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, index, n0)
 	require.NoError(t, err)
 
 	// Nodes plugins should be gone but controllers left
@@ -3175,7 +3175,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, index, n0)
 	require.NoError(t, err)
 
 	// Nodes plugin should be replaced and healthy
@@ -3190,7 +3190,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 	n0, _ = state.NodeByID(ws, ns[0].ID)
 	n0.CSINodePlugins = map[string]*structs.CSIInfo{}
 	index++
-	err = state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, index, n0)
 	require.NoError(t, err)
 
 	// Nodes plugins should be gone but controllers left
@@ -3205,7 +3205,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 	n0, _ = state.NodeByID(ws, ns[0].ID)
 	n0.CSIControllerPlugins = map[string]*structs.CSIInfo{}
 	index++
-	err = state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, index, n0)
 	require.NoError(t, err)
 
 	// Plugin has been removed entirely
@@ -3230,7 +3230,7 @@ func TestStateStore_CSIPluginAllocUpdates(t *testing.T) {
 
 	n := mock.Node()
 	index++
-	err := state.UpsertNode(structs.MsgTypeTestSetup, n, index)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, index, n)
 	require.NoError(t, err)
 
 	// (1) unhealthy fingerprint, then terminal alloc, then healthy node update
@@ -3257,7 +3257,7 @@ func TestStateStore_CSIPluginAllocUpdates(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(structs.MsgTypeTestSetup, n, index)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, index, n)
 	require.NoError(t, err)
 
 	plug, err := state.CSIPluginByID(ws, plugID0)
@@ -3278,7 +3278,7 @@ func TestStateStore_CSIPluginAllocUpdates(t *testing.T) {
 	n.CSINodePlugins[plugID0].Healthy = true
 	n.CSINodePlugins[plugID0].UpdateTime = time.Now()
 	index++
-	err = state.UpsertNode(structs.MsgTypeTestSetup, n, index)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, index, n)
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID0)
@@ -3301,7 +3301,7 @@ func TestStateStore_CSIPluginAllocUpdates(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(structs.MsgTypeTestSetup, n, index)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, index, n)
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID1)
@@ -3348,7 +3348,7 @@ func TestStateStore_CSIPluginAllocUpdates(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(structs.MsgTypeTestSetup, n, index)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, index, n)
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID2)
@@ -3372,7 +3372,7 @@ func TestStateStore_CSIPluginMultiNodeUpdates(t *testing.T) {
 	ns := []*structs.Node{mock.Node(), mock.Node()}
 	for _, n := range ns {
 		index++
-		err = state.UpsertNode(structs.MsgTypeTestSetup, n, index)
+		err = state.UpsertNode(structs.MsgTypeTestSetup, index, n)
 		require.NoError(t, err)
 	}
 
@@ -3397,7 +3397,7 @@ func TestStateStore_CSIPluginMultiNodeUpdates(t *testing.T) {
 			},
 		}
 		index++
-		err = state.UpsertNode(structs.MsgTypeTestSetup, n, index)
+		err = state.UpsertNode(structs.MsgTypeTestSetup, index, n)
 		require.NoError(t, err)
 
 		nAlloc.NodeID = n.ID
@@ -3428,7 +3428,7 @@ func TestStateStore_CSIPluginMultiNodeUpdates(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, index, n0)
 	require.NoError(t, err)
 
 	plug, err := state.CSIPluginByID(ws, plugID)
@@ -3489,7 +3489,7 @@ func TestStateStore_CSIPluginMultiNodeUpdates(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, index, n0)
 	require.NoError(t, err)
 
 	n1.CSIControllerPlugins = map[string]*structs.CSIInfo{
@@ -3507,7 +3507,7 @@ func TestStateStore_CSIPluginMultiNodeUpdates(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(structs.MsgTypeTestSetup, n1, index)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, index, n1)
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID)
@@ -3652,7 +3652,7 @@ func TestStateStore_Indexes(t *testing.T) {
 	state := testStateStore(t)
 	node := mock.Node()
 
-	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -3696,7 +3696,7 @@ func TestStateStore_LatestIndex(t *testing.T) {
 
 	state := testStateStore(t)
 
-	if err := state.UpsertNode(structs.MsgTypeTestSetup, mock.Node(), 1000); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, 1000, mock.Node()); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -5465,7 +5465,7 @@ func TestStateStore_ReconcileParentJobSummary(t *testing.T) {
 
 	// Add a node
 	node := mock.Node()
-	state.UpsertNode(structs.MsgTypeTestSetup, node, 80)
+	state.UpsertNode(structs.MsgTypeTestSetup, 80, node)
 
 	// Make a parameterized job
 	job1 := mock.BatchJob()
@@ -9603,7 +9603,7 @@ func TestStateStore_SnapshotMinIndex_OK(t *testing.T) {
 	require.NoError(t, err)
 
 	node := mock.Node()
-	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, node, index+1))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, index+1, node))
 
 	// Assert SnapshotMinIndex returns immediately if index < latest index
 	ctx, cancel := context.WithTimeout(context.Background(), 0)
@@ -9660,7 +9660,7 @@ func TestStateStore_SnapshotMinIndex_OK(t *testing.T) {
 	}
 
 	node.Name = "hal"
-	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, node, index+2))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, index+2, node))
 
 	select {
 	case err := <-errCh:

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -176,7 +176,7 @@ func TestStateStore_UpsertPlanResults_AllocationsDenormalized(t *testing.T) {
 	}
 
 	require := require.New(t)
-	require.NoError(state.UpsertAllocs(900, []*structs.Allocation{stoppedAlloc, preemptedAlloc}))
+	require.NoError(state.UpsertAllocs(structs.MsgTypeTestSetup, 900, []*structs.Allocation{stoppedAlloc, preemptedAlloc}))
 	require.NoError(state.UpsertJob(999, job))
 
 	// modify job and ensure that stopped and preempted alloc point to original Job
@@ -376,7 +376,7 @@ func TestStateStore_UpsertPlanResults_PreemptedAllocs(t *testing.T) {
 
 	// Insert alloc that will be preempted in the plan
 	preemptedAlloc := mock.Alloc()
-	err = state.UpsertAllocs(2, []*structs.Allocation{preemptedAlloc})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 2, []*structs.Allocation{preemptedAlloc})
 	require.NoError(err)
 
 	minimalPreemptedAlloc := &structs.Allocation{
@@ -2873,7 +2873,7 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	defer state.DeleteNode(9999, []string{pluginID})
 
 	index++
-	err = state.UpsertAllocs(index, []*structs.Allocation{alloc})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc})
 	require.NoError(t, err)
 
 	ns := structs.DefaultNamespace
@@ -2945,7 +2945,7 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	a0 := mock.Alloc()
 	a1 := mock.Alloc()
 	index++
-	err = state.UpsertAllocs(index, []*structs.Allocation{a0, a1})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{a0, a1})
 	require.NoError(t, err)
 
 	// Claims
@@ -3242,7 +3242,7 @@ func TestStateStore_CSIPluginAllocUpdates(t *testing.T) {
 	alloc0.ClientStatus = "running"
 	alloc0.Job.TaskGroups[0].Tasks[0].CSIPluginConfig = &structs.TaskCSIPluginConfig{ID: plugID0}
 	index++
-	err = state.UpsertAllocs(index, []*structs.Allocation{alloc0})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc0})
 	require.NoError(t, err)
 
 	n, _ = state.NodeByID(ws, n.ID)
@@ -3267,7 +3267,7 @@ func TestStateStore_CSIPluginAllocUpdates(t *testing.T) {
 	alloc0.DesiredStatus = "stopped"
 	alloc0.ClientStatus = "complete"
 	index++
-	err = state.UpsertAllocs(index, []*structs.Allocation{alloc0})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc0})
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID0)
@@ -3313,7 +3313,7 @@ func TestStateStore_CSIPluginAllocUpdates(t *testing.T) {
 	alloc1.ClientStatus = "complete"
 	alloc1.Job.TaskGroups[0].Tasks[0].CSIPluginConfig = &structs.TaskCSIPluginConfig{ID: plugID1}
 	index++
-	err = state.UpsertAllocs(index, []*structs.Allocation{alloc1})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc1})
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID1)
@@ -3329,7 +3329,7 @@ func TestStateStore_CSIPluginAllocUpdates(t *testing.T) {
 	alloc2.ClientStatus = "complete"
 	alloc2.Job.TaskGroups[0].Tasks[0].CSIPluginConfig = &structs.TaskCSIPluginConfig{ID: plugID2}
 	index++
-	err = state.UpsertAllocs(index, []*structs.Allocation{alloc2})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc2})
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID2)
@@ -3406,7 +3406,7 @@ func TestStateStore_CSIPluginMultiNodeUpdates(t *testing.T) {
 		nAlloc.Job.TaskGroups[0].Tasks[0].CSIPluginConfig = plugCfg
 
 		index++
-		err = state.UpsertAllocs(index, []*structs.Allocation{nAlloc})
+		err = state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{nAlloc})
 		require.NoError(t, err)
 	}
 
@@ -3446,7 +3446,7 @@ func TestStateStore_CSIPluginMultiNodeUpdates(t *testing.T) {
 	alloc0.Job.TaskGroups[0].Tasks[0].CSIPluginConfig = plugCfg
 
 	index++
-	err = state.UpsertAllocs(index, []*structs.Allocation{alloc0})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc0})
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID)
@@ -3463,7 +3463,7 @@ func TestStateStore_CSIPluginMultiNodeUpdates(t *testing.T) {
 	alloc1.Job.TaskGroups[0].Tasks[0].CSIPluginConfig = plugCfg
 
 	index++
-	err = state.UpsertAllocs(index, []*structs.Allocation{alloc1})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc1})
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID)
@@ -3574,7 +3574,7 @@ func TestStateStore_CSIPluginJobs(t *testing.T) {
 		})
 	}
 
-	err = s.UpsertAllocs(index, as)
+	err = s.UpsertAllocs(structs.MsgTypeTestSetup, index, as)
 	require.NoError(t, err)
 	index++
 
@@ -4083,7 +4083,7 @@ func TestStateStore_DeleteEval_Eval(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	err = state.UpsertAllocs(1001, []*structs.Allocation{alloc1, alloc2})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc1, alloc2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4184,7 +4184,7 @@ func TestStateStore_DeleteEval_ChildJob(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	err = state.UpsertAllocs(1001, []*structs.Allocation{alloc1})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc1})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4429,7 +4429,7 @@ func TestStateStore_UpdateAllocsFromClient(t *testing.T) {
 	alloc.JobID = child.ID
 	alloc.Job = child
 
-	err := state.UpsertAllocs(1000, []*structs.Allocation{alloc})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4513,7 +4513,7 @@ func TestStateStore_UpdateAllocsFromClient_ChildJob(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	err := state.UpsertAllocs(1000, []*structs.Allocation{alloc1, alloc2})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1, alloc2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4644,7 +4644,7 @@ func TestStateStore_UpdateMultipleAllocsFromClient(t *testing.T) {
 	if err := state.UpsertJob(999, alloc.Job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	err := state.UpsertAllocs(1000, []*structs.Allocation{alloc})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4722,7 +4722,7 @@ func TestStateStore_UpdateAllocsFromClient_Deployment(t *testing.T) {
 
 	require.Nil(state.UpsertJob(999, alloc.Job))
 	require.Nil(state.UpsertDeployment(1000, deployment))
-	require.Nil(state.UpsertAllocs(1001, []*structs.Allocation{alloc}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc}))
 
 	healthy := now.Add(time.Second)
 	update := &structs.Allocation{
@@ -4768,7 +4768,7 @@ func TestStateStore_UpdateAllocsFromClient_DeploymentStateMerges(t *testing.T) {
 
 	require.Nil(state.UpsertJob(999, alloc.Job))
 	require.Nil(state.UpsertDeployment(1000, deployment))
-	require.Nil(state.UpsertAllocs(1001, []*structs.Allocation{alloc}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc}))
 
 	update := &structs.Allocation{
 		ID:           alloc.ID,
@@ -4819,7 +4819,7 @@ func TestStateStore_UpsertAlloc_Alloc(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	err := state.UpsertAllocs(1000, []*structs.Allocation{alloc})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4887,7 +4887,7 @@ func TestStateStore_UpsertAlloc_Deployment(t *testing.T) {
 	ws := memdb.NewWatchSet()
 	require.Nil(state.AllocsByDeployment(ws, alloc.DeploymentID))
 
-	err := state.UpsertAllocs(1001, []*structs.Allocation{alloc})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc})
 	require.Nil(err)
 
 	if !watchFired(ws) {
@@ -4927,7 +4927,7 @@ func TestStateStore_UpsertAlloc_No_Job(t *testing.T) {
 	alloc := mock.Alloc()
 	alloc.Job = nil
 
-	err := state.UpsertAllocs(999, []*structs.Allocation{alloc})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 999, []*structs.Allocation{alloc})
 	if err == nil || !strings.Contains(err.Error(), "without a job") {
 		t.Fatalf("expect err: %v", err)
 	}
@@ -4960,7 +4960,7 @@ func TestStateStore_UpsertAlloc_ChildJob(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	err := state.UpsertAllocs(1000, []*structs.Allocation{alloc})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5002,7 +5002,7 @@ func TestStateStore_UpdateAlloc_Alloc(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	err := state.UpsertAllocs(1000, []*structs.Allocation{alloc})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5040,7 +5040,7 @@ func TestStateStore_UpdateAlloc_Alloc(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	err = state.UpsertAllocs(1002, []*structs.Allocation{alloc2})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5104,7 +5104,7 @@ func TestStateStore_UpdateAlloc_Lost(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	err := state.UpsertAllocs(1000, []*structs.Allocation{alloc})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5112,7 +5112,7 @@ func TestStateStore_UpdateAlloc_Lost(t *testing.T) {
 	alloc2 := new(structs.Allocation)
 	*alloc2 = *alloc
 	alloc2.ClientStatus = structs.AllocClientStatusLost
-	if err := state.UpsertAllocs(1001, []*structs.Allocation{alloc2}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc2}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -5142,7 +5142,7 @@ func TestStateStore_UpdateAlloc_NoJob(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	err := state.UpsertAllocs(1000, []*structs.Allocation{alloc})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5154,7 +5154,7 @@ func TestStateStore_UpdateAlloc_NoJob(t *testing.T) {
 	// Update the desired state of the allocation to stop
 	allocCopy := alloc.Copy()
 	allocCopy.DesiredStatus = structs.AllocDesiredStatusStop
-	if err := state.UpsertAllocs(1002, []*structs.Allocation{allocCopy}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{allocCopy}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -5182,7 +5182,7 @@ func TestStateStore_UpdateAllocDesiredTransition(t *testing.T) {
 	alloc := mock.Alloc()
 
 	require.Nil(state.UpsertJob(999, alloc.Job))
-	require.Nil(state.UpsertAllocs(1000, []*structs.Allocation{alloc}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc}))
 
 	t1 := &structs.DesiredTransition{
 		Migrate: helper.BoolToPtr(true),
@@ -5266,7 +5266,7 @@ func TestStateStore_JobSummary(t *testing.T) {
 	alloc := mock.Alloc()
 	alloc.JobID = job.ID
 	alloc.Job = job
-	state.UpsertAllocs(910, []*structs.Allocation{alloc})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 910, []*structs.Allocation{alloc})
 
 	// Update the alloc from client
 	alloc1 := alloc.Copy()
@@ -5283,13 +5283,13 @@ func TestStateStore_JobSummary(t *testing.T) {
 	alloc4 := alloc.Copy()
 	alloc4.ClientStatus = structs.AllocClientStatusPending
 	alloc4.DesiredStatus = structs.AllocDesiredStatusRun
-	state.UpsertAllocs(950, []*structs.Allocation{alloc4})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 950, []*structs.Allocation{alloc4})
 
 	// Again upsert the alloc
 	alloc5 := alloc.Copy()
 	alloc5.ClientStatus = structs.AllocClientStatusPending
 	alloc5.DesiredStatus = structs.AllocDesiredStatusRun
-	state.UpsertAllocs(970, []*structs.Allocation{alloc5})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 970, []*structs.Allocation{alloc5})
 
 	if !watchFired(ws) {
 		t.Fatalf("bad")
@@ -5387,7 +5387,7 @@ func TestStateStore_ReconcileJobSummary(t *testing.T) {
 	alloc2.Job = alloc.Job
 
 	// Upserts the alloc
-	state.UpsertAllocs(110, []*structs.Allocation{alloc, alloc2})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 110, []*structs.Allocation{alloc, alloc2})
 
 	// Change the state of the first alloc to running
 	alloc3 := alloc.Copy()
@@ -5423,7 +5423,7 @@ func TestStateStore_ReconcileJobSummary(t *testing.T) {
 	alloc11 := alloc10.Copy()
 	alloc11.ClientStatus = structs.AllocClientStatusLost
 
-	state.UpsertAllocs(130, []*structs.Allocation{alloc4, alloc6, alloc8, alloc10})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 130, []*structs.Allocation{alloc4, alloc6, alloc8, alloc10})
 
 	state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 150, []*structs.Allocation{alloc5, alloc7, alloc9, alloc11})
 
@@ -5497,7 +5497,7 @@ func TestStateStore_ReconcileParentJobSummary(t *testing.T) {
 	alloc2.ClientStatus = structs.AllocClientStatusFailed
 
 	require.Nil(state.UpsertJob(110, childJob))
-	require.Nil(state.UpsertAllocs(111, []*structs.Allocation{alloc, alloc2}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 111, []*structs.Allocation{alloc, alloc2}))
 
 	// Make the summary incorrect in the state store
 	summary, err := state.JobSummaryByID(nil, job1.Namespace, job1.ID)
@@ -5554,7 +5554,7 @@ func TestStateStore_UpdateAlloc_JobNotPresent(t *testing.T) {
 
 	alloc := mock.Alloc()
 	state.UpsertJob(100, alloc.Job)
-	state.UpsertAllocs(200, []*structs.Allocation{alloc})
+	state.UpsertAllocs(structs.MsgTypeTestSetup, 200, []*structs.Allocation{alloc})
 
 	// Delete the job
 	state.DeleteJob(300, alloc.Namespace, alloc.Job.ID)
@@ -5605,7 +5605,7 @@ func TestStateStore_EvictAlloc_Alloc(t *testing.T) {
 	alloc := mock.Alloc()
 
 	state.UpsertJobSummary(999, mock.JobSummary(alloc.JobID))
-	err := state.UpsertAllocs(1000, []*structs.Allocation{alloc})
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5613,7 +5613,7 @@ func TestStateStore_EvictAlloc_Alloc(t *testing.T) {
 	alloc2 := new(structs.Allocation)
 	*alloc2 = *alloc
 	alloc2.DesiredStatus = structs.AllocDesiredStatusEvict
-	err = state.UpsertAllocs(1001, []*structs.Allocation{alloc2})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc2})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5653,7 +5653,7 @@ func TestStateStore_AllocsByNode(t *testing.T) {
 		state.UpsertJobSummary(uint64(900+idx), mock.JobSummary(alloc.JobID))
 	}
 
-	err := state.UpsertAllocs(1000, allocs)
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, allocs)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5698,7 +5698,7 @@ func TestStateStore_AllocsByNodeTerminal(t *testing.T) {
 		state.UpsertJobSummary(uint64(900+idx), mock.JobSummary(alloc.JobID))
 	}
 
-	err := state.UpsertAllocs(1000, allocs)
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, allocs)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5751,7 +5751,7 @@ func TestStateStore_AllocsByJob(t *testing.T) {
 		state.UpsertJobSummary(uint64(900+i), mock.JobSummary(alloc.JobID))
 	}
 
-	err := state.UpsertAllocs(1000, allocs)
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, allocs)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5790,7 +5790,7 @@ func TestStateStore_AllocsForRegisteredJob(t *testing.T) {
 		alloc.JobID = job.ID
 		allocs = append(allocs, alloc)
 	}
-	if err := state.UpsertAllocs(200, allocs); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 200, allocs); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -5809,7 +5809,7 @@ func TestStateStore_AllocsForRegisteredJob(t *testing.T) {
 		allocs1 = append(allocs1, alloc)
 	}
 
-	if err := state.UpsertAllocs(1000, allocs1); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, allocs1); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -5866,7 +5866,7 @@ func TestStateStore_AllocsByIDPrefix(t *testing.T) {
 		state.UpsertJobSummary(uint64(900+i), mock.JobSummary(alloc.JobID))
 	}
 
-	err := state.UpsertAllocs(1000, allocs)
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, allocs)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5931,7 +5931,7 @@ func TestStateStore_Allocs(t *testing.T) {
 		state.UpsertJobSummary(uint64(900+i), mock.JobSummary(alloc.JobID))
 	}
 
-	err := state.UpsertAllocs(1000, allocs)
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, allocs)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5981,7 +5981,7 @@ func TestStateStore_Allocs_PrevAlloc(t *testing.T) {
 	allocs[1].PreviousAllocation = allocs[0].ID
 	allocs[2].PreviousAllocation = allocs[1].ID
 
-	err := state.UpsertAllocs(1000, allocs)
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, allocs)
 	require.Nil(err)
 
 	ws := memdb.NewWatchSet()
@@ -6010,7 +6010,7 @@ func TestStateStore_Allocs_PrevAlloc(t *testing.T) {
 	// Insert another alloc, verify index of previous alloc also got updated
 	alloc := mock.Alloc()
 	alloc.PreviousAllocation = allocs[0].ID
-	err = state.UpsertAllocs(1001, []*structs.Allocation{alloc})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc})
 	require.Nil(err)
 	alloc0, err := state.AllocByID(nil, allocs[0].ID)
 	require.Nil(err)
@@ -6211,7 +6211,7 @@ func TestStateStore_GetJobStatus_DeadEvalsAndAllocs(t *testing.T) {
 	alloc.JobID = job.ID
 	alloc.DesiredStatus = structs.AllocDesiredStatusStop
 	state.UpsertJobSummary(999, mock.JobSummary(alloc.JobID))
-	if err := state.UpsertAllocs(1000, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -6245,7 +6245,7 @@ func TestStateStore_GetJobStatus_RunningAlloc(t *testing.T) {
 	alloc.JobID = job.ID
 	alloc.DesiredStatus = structs.AllocDesiredStatusRun
 	state.UpsertJobSummary(999, mock.JobSummary(alloc.JobID))
-	if err := state.UpsertAllocs(1000, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -6399,7 +6399,7 @@ func TestStateJobSummary_UpdateJobCount(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := state.UpsertAllocs(1001, []*structs.Allocation{alloc}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -6439,7 +6439,7 @@ func TestStateJobSummary_UpdateJobCount(t *testing.T) {
 	alloc3.Job = job
 	alloc3.JobID = job.ID
 
-	if err := state.UpsertAllocs(1002, []*structs.Allocation{alloc2, alloc3}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc2, alloc3}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -6533,7 +6533,7 @@ func TestJobSummary_UpdateClientStatus(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := state.UpsertAllocs(1001, []*structs.Allocation{alloc, alloc2, alloc3}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc, alloc2, alloc3}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -6578,7 +6578,7 @@ func TestJobSummary_UpdateClientStatus(t *testing.T) {
 	alloc7.Job = alloc.Job
 	alloc7.JobID = alloc.JobID
 
-	if err := state.UpsertAllocs(1003, []*structs.Allocation{alloc7}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{alloc7}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	summary, _ = state.JobSummaryByID(ws, job.Namespace, job.ID)
@@ -6888,7 +6888,7 @@ func TestStateStore_UpsertDeploymentPromotion_Unhealthy(t *testing.T) {
 	c3.DeploymentStatus = &structs.AllocDeploymentStatus{Healthy: helper.BoolToPtr(true)}
 	d.TaskGroups[c3.TaskGroup].PlacedCanaries = append(d.TaskGroups[c3.TaskGroup].PlacedCanaries, c3.ID)
 
-	require.Nil(state.UpsertAllocs(3, []*structs.Allocation{c1, c2, c3}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 3, []*structs.Allocation{c1, c2, c3}))
 
 	// Promote the canaries
 	req := &structs.ApplyDeploymentPromoteRequest{
@@ -6982,7 +6982,7 @@ func TestStateStore_UpsertDeploymentPromotion_All(t *testing.T) {
 		Healthy: helper.BoolToPtr(true),
 	}
 
-	if err := state.UpsertAllocs(3, []*structs.Allocation{c1, c2}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 3, []*structs.Allocation{c1, c2}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -7090,7 +7090,7 @@ func TestStateStore_UpsertDeploymentPromotion_Subset(t *testing.T) {
 		Canary:  true,
 	}
 
-	require.Nil(state.UpsertAllocs(3, []*structs.Allocation{c1, c2, c3}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 3, []*structs.Allocation{c1, c2, c3}))
 
 	// Create an eval
 	e := mock.Eval()
@@ -7226,7 +7226,7 @@ func TestStateStore_UpsertDeploymentAlloc_Canaries(t *testing.T) {
 		Healthy: helper.BoolToPtr(false),
 		Canary:  true,
 	}
-	require.NoError(t, state.UpsertAllocs(4, []*structs.Allocation{a}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 4, []*structs.Allocation{a}))
 
 	// Pull the deployment from state
 	ws := memdb.NewWatchSet()
@@ -7244,7 +7244,7 @@ func TestStateStore_UpsertDeploymentAlloc_Canaries(t *testing.T) {
 		Healthy: helper.BoolToPtr(false),
 		Canary:  false,
 	}
-	require.NoError(t, state.UpsertAllocs(4, []*structs.Allocation{b}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 4, []*structs.Allocation{b}))
 
 	// Pull the deployment from state
 	ws = memdb.NewWatchSet()
@@ -7265,7 +7265,7 @@ func TestStateStore_UpsertDeploymentAlloc_Canaries(t *testing.T) {
 		Healthy: helper.BoolToPtr(false),
 		Canary:  true,
 	}
-	require.NoError(t, state.UpsertAllocs(6, []*structs.Allocation{c}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 6, []*structs.Allocation{c}))
 
 	ws = memdb.NewWatchSet()
 	deploy2, err := state.DeploymentByID(ws, d2.ID)
@@ -7296,7 +7296,7 @@ func TestStateStore_UpsertDeploymentAlloc_NoCanaries(t *testing.T) {
 		Healthy: helper.BoolToPtr(true),
 		Canary:  false,
 	}
-	require.NoError(t, state.UpsertAllocs(4, []*structs.Allocation{a}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 4, []*structs.Allocation{a}))
 
 	// Pull the deployment from state
 	ws := memdb.NewWatchSet()
@@ -7327,7 +7327,7 @@ func TestStateStore_UpsertDeploymentAllocHealth_BadAlloc_MismatchDeployment(t *t
 	// Insert an alloc for a random deployment
 	a := mock.Alloc()
 	a.DeploymentID = d1.ID
-	if err := state.UpsertAllocs(3, []*structs.Allocation{a}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 3, []*structs.Allocation{a}); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -7362,7 +7362,7 @@ func TestStateStore_UpsertDeploymentAllocHealth(t *testing.T) {
 	a1.DeploymentID = d.ID
 	a2 := mock.Alloc()
 	a2.DeploymentID = d.ID
-	if err := state.UpsertAllocs(2, []*structs.Allocation{a1, a2}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 2, []*structs.Allocation{a1, a2}); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -83,7 +83,7 @@ func TestStateStore_Blocking_MinQuery(t *testing.T) {
 	defer cancel()
 
 	time.AfterFunc(5*time.Millisecond, func() {
-		state.UpsertNode(11, node)
+		state.UpsertNode(structs.MsgTypeTestSetup, node, 11)
 	})
 
 	resp, idx, err := state.BlockingQuery(queryFn, 10, deadlineCtx)
@@ -801,7 +801,7 @@ func TestStateStore_UpsertNode_Node(t *testing.T) {
 	_, err := state.NodeByID(ws, node.ID)
 	require.NoError(err)
 
-	require.NoError(state.UpsertNode(1000, node))
+	require.NoError(state.UpsertNode(structs.MsgTypeTestSetup, node, 1000))
 	require.True(watchFired(ws))
 
 	ws = memdb.NewWatchSet()
@@ -824,8 +824,8 @@ func TestStateStore_UpsertNode_Node(t *testing.T) {
 	// event
 	down := out.Copy()
 	down.Status = structs.NodeStatusDown
-	require.NoError(state.UpsertNode(1001, down))
-	require.NoError(state.UpsertNode(1002, out))
+	require.NoError(state.UpsertNode(structs.MsgTypeTestSetup, down, 1001))
+	require.NoError(state.UpsertNode(structs.MsgTypeTestSetup, out, 1002))
 
 	out, err = state.NodeByID(ws, node.ID)
 	require.NoError(err)
@@ -841,9 +841,9 @@ func TestStateStore_DeleteNode_Node(t *testing.T) {
 	// Create and insert two nodes, which we'll delete
 	node0 := mock.Node()
 	node1 := mock.Node()
-	err := state.UpsertNode(1000, node0)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node0, 1000)
 	require.NoError(t, err)
-	err = state.UpsertNode(1001, node1)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, node1, 1001)
 	require.NoError(t, err)
 
 	// Create a watchset so we can test that delete fires the watch
@@ -885,7 +885,7 @@ func TestStateStore_UpdateNodeStatus_Node(t *testing.T) {
 	state := testStateStore(t)
 	node := mock.Node()
 
-	require.NoError(state.UpsertNode(800, node))
+	require.NoError(state.UpsertNode(structs.MsgTypeTestSetup, node, 800))
 
 	// Create a watchset so we can test that update node status fires the watch
 	ws := memdb.NewWatchSet()
@@ -923,8 +923,8 @@ func TestStateStore_BatchUpdateNodeDrain(t *testing.T) {
 	state := testStateStore(t)
 
 	n1, n2 := mock.Node(), mock.Node()
-	require.Nil(state.UpsertNode(1000, n1))
-	require.Nil(state.UpsertNode(1001, n2))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n1, 1000))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, n2, 1001))
 
 	// Create a watchset so we can test that update node drain fires the watch
 	ws := memdb.NewWatchSet()
@@ -984,7 +984,7 @@ func TestStateStore_UpdateNodeDrain_Node(t *testing.T) {
 	state := testStateStore(t)
 	node := mock.Node()
 
-	require.Nil(state.UpsertNode(1000, node))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1000))
 
 	// Create a watchset so we can test that update node drain fires the watch
 	ws := memdb.NewWatchSet()
@@ -1030,7 +1030,7 @@ func TestStateStore_AddSingleNodeEvent(t *testing.T) {
 	node := mock.Node()
 
 	// We create a new node event every time we register a node
-	err := state.UpsertNode(1000, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	require.Nil(err)
 
 	require.Equal(1, len(node.Events))
@@ -1073,7 +1073,7 @@ func TestStateStore_NodeEvents_RetentionWindow(t *testing.T) {
 
 	node := mock.Node()
 
-	err := state.UpsertNode(1000, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1120,7 +1120,7 @@ func TestStateStore_UpdateNodeDrain_ResetEligiblity(t *testing.T) {
 
 	state := testStateStore(t)
 	node := mock.Node()
-	require.Nil(state.UpsertNode(1000, node))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, node, 1000))
 
 	// Create a watchset so we can test that update node drain fires the watch
 	ws := memdb.NewWatchSet()
@@ -1172,7 +1172,7 @@ func TestStateStore_UpdateNodeEligibility(t *testing.T) {
 	state := testStateStore(t)
 	node := mock.Node()
 
-	err := state.UpsertNode(1000, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1231,7 +1231,7 @@ func TestStateStore_Nodes(t *testing.T) {
 		node := mock.Node()
 		nodes = append(nodes, node)
 
-		err := state.UpsertNode(1000+uint64(i), node)
+		err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000+uint64(i))
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1272,7 +1272,7 @@ func TestStateStore_NodesByIDPrefix(t *testing.T) {
 	node := mock.Node()
 
 	node.ID = "11111111-662e-d0ab-d1c9-3e434af7bdb4"
-	err := state.UpsertNode(1000, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1318,7 +1318,7 @@ func TestStateStore_NodesByIDPrefix(t *testing.T) {
 
 	node = mock.Node()
 	node.ID = "11222222-662e-d0ab-d1c9-3e434af7bdb4"
-	err = state.UpsertNode(1001, node)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, node, 1001)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2868,7 +2868,7 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	}
 
 	index++
-	err := state.UpsertNode(index, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, index)
 	require.NoError(t, err)
 	defer state.DeleteNode(9999, []string{pluginID})
 
@@ -3039,7 +3039,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 	ns := []*structs.Node{mock.Node(), mock.Node()}
 	for _, n := range ns {
 		index++
-		err := state.UpsertNode(index, n)
+		err := state.UpsertNode(structs.MsgTypeTestSetup, n, index)
 		require.NoError(t, err)
 	}
 
@@ -3059,7 +3059,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 		},
 	}
 	index++
-	err := state.UpsertNode(index, n0)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
 	require.NoError(t, err)
 
 	// Fingerprint two running node plugins
@@ -3076,7 +3076,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 			},
 		}
 		index++
-		err = state.UpsertNode(index, n)
+		err = state.UpsertNode(structs.MsgTypeTestSetup, n, index)
 		require.NoError(t, err)
 	}
 
@@ -3119,7 +3119,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 	}
 
 	index++
-	err = state.UpsertNode(index, n0)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID)
@@ -3137,7 +3137,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 	n1, _ := state.NodeByID(ws, ns[1].ID)
 	n1.CSINodePlugins = map[string]*structs.CSIInfo{}
 	index++
-	err = state.UpsertNode(index, n1)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, n1, index)
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID)
@@ -3151,7 +3151,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 	n0, _ = state.NodeByID(ws, ns[0].ID)
 	n0.CSINodePlugins = map[string]*structs.CSIInfo{}
 	index++
-	err = state.UpsertNode(index, n0)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
 	require.NoError(t, err)
 
 	// Nodes plugins should be gone but controllers left
@@ -3175,7 +3175,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(index, n0)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
 	require.NoError(t, err)
 
 	// Nodes plugin should be replaced and healthy
@@ -3190,7 +3190,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 	n0, _ = state.NodeByID(ws, ns[0].ID)
 	n0.CSINodePlugins = map[string]*structs.CSIInfo{}
 	index++
-	err = state.UpsertNode(index, n0)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
 	require.NoError(t, err)
 
 	// Nodes plugins should be gone but controllers left
@@ -3205,7 +3205,7 @@ func TestStateStore_CSIPluginNodes(t *testing.T) {
 	n0, _ = state.NodeByID(ws, ns[0].ID)
 	n0.CSIControllerPlugins = map[string]*structs.CSIInfo{}
 	index++
-	err = state.UpsertNode(index, n0)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
 	require.NoError(t, err)
 
 	// Plugin has been removed entirely
@@ -3230,7 +3230,7 @@ func TestStateStore_CSIPluginAllocUpdates(t *testing.T) {
 
 	n := mock.Node()
 	index++
-	err := state.UpsertNode(index, n)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, n, index)
 	require.NoError(t, err)
 
 	// (1) unhealthy fingerprint, then terminal alloc, then healthy node update
@@ -3257,7 +3257,7 @@ func TestStateStore_CSIPluginAllocUpdates(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(index, n)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, n, index)
 	require.NoError(t, err)
 
 	plug, err := state.CSIPluginByID(ws, plugID0)
@@ -3278,7 +3278,7 @@ func TestStateStore_CSIPluginAllocUpdates(t *testing.T) {
 	n.CSINodePlugins[plugID0].Healthy = true
 	n.CSINodePlugins[plugID0].UpdateTime = time.Now()
 	index++
-	err = state.UpsertNode(index, n)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, n, index)
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID0)
@@ -3301,7 +3301,7 @@ func TestStateStore_CSIPluginAllocUpdates(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(index, n)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, n, index)
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID1)
@@ -3348,7 +3348,7 @@ func TestStateStore_CSIPluginAllocUpdates(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(index, n)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, n, index)
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID2)
@@ -3372,7 +3372,7 @@ func TestStateStore_CSIPluginMultiNodeUpdates(t *testing.T) {
 	ns := []*structs.Node{mock.Node(), mock.Node()}
 	for _, n := range ns {
 		index++
-		err = state.UpsertNode(index, n)
+		err = state.UpsertNode(structs.MsgTypeTestSetup, n, index)
 		require.NoError(t, err)
 	}
 
@@ -3397,7 +3397,7 @@ func TestStateStore_CSIPluginMultiNodeUpdates(t *testing.T) {
 			},
 		}
 		index++
-		err = state.UpsertNode(index, n)
+		err = state.UpsertNode(structs.MsgTypeTestSetup, n, index)
 		require.NoError(t, err)
 
 		nAlloc.NodeID = n.ID
@@ -3428,7 +3428,7 @@ func TestStateStore_CSIPluginMultiNodeUpdates(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(index, n0)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
 	require.NoError(t, err)
 
 	plug, err := state.CSIPluginByID(ws, plugID)
@@ -3489,7 +3489,7 @@ func TestStateStore_CSIPluginMultiNodeUpdates(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(index, n0)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, n0, index)
 	require.NoError(t, err)
 
 	n1.CSIControllerPlugins = map[string]*structs.CSIInfo{
@@ -3507,7 +3507,7 @@ func TestStateStore_CSIPluginMultiNodeUpdates(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(index, n1)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, n1, index)
 	require.NoError(t, err)
 
 	plug, err = state.CSIPluginByID(ws, plugID)
@@ -3652,7 +3652,7 @@ func TestStateStore_Indexes(t *testing.T) {
 	state := testStateStore(t)
 	node := mock.Node()
 
-	err := state.UpsertNode(1000, node)
+	err := state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -3696,7 +3696,7 @@ func TestStateStore_LatestIndex(t *testing.T) {
 
 	state := testStateStore(t)
 
-	if err := state.UpsertNode(1000, mock.Node()); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, mock.Node(), 1000); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -5465,7 +5465,7 @@ func TestStateStore_ReconcileParentJobSummary(t *testing.T) {
 
 	// Add a node
 	node := mock.Node()
-	state.UpsertNode(80, node)
+	state.UpsertNode(structs.MsgTypeTestSetup, node, 80)
 
 	// Make a parameterized job
 	job1 := mock.BatchJob()
@@ -9603,7 +9603,7 @@ func TestStateStore_SnapshotMinIndex_OK(t *testing.T) {
 	require.NoError(t, err)
 
 	node := mock.Node()
-	require.NoError(t, s.UpsertNode(index+1, node))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, node, index+1))
 
 	// Assert SnapshotMinIndex returns immediately if index < latest index
 	ctx, cancel := context.WithTimeout(context.Background(), 0)
@@ -9660,7 +9660,7 @@ func TestStateStore_SnapshotMinIndex_OK(t *testing.T) {
 	}
 
 	node.Name = "hal"
-	require.NoError(t, s.UpsertNode(index+2, node))
+	require.NoError(t, s.UpsertNode(structs.MsgTypeTestSetup, node, index+2))
 
 	select {
 	case err := <-errCh:

--- a/nomad/state/testing.go
+++ b/nomad/state/testing.go
@@ -108,7 +108,7 @@ func createTestCSIPlugin(s *StateStore, id string, requiresController bool) func
 	index := uint64(999)
 	for _, n := range ns {
 		index++
-		s.UpsertNode(structs.MsgTypeTestSetup, n, index)
+		s.UpsertNode(structs.MsgTypeTestSetup, index, n)
 	}
 
 	ids := make([]string, len(ns))

--- a/nomad/state/testing.go
+++ b/nomad/state/testing.go
@@ -108,7 +108,7 @@ func createTestCSIPlugin(s *StateStore, id string, requiresController bool) func
 	index := uint64(999)
 	for _, n := range ns {
 		index++
-		s.UpsertNode(index, n)
+		s.UpsertNode(structs.MsgTypeTestSetup, n, index)
 	}
 
 	ids := make([]string, len(ns))

--- a/nomad/state/testing.go
+++ b/nomad/state/testing.go
@@ -119,6 +119,6 @@ func createTestCSIPlugin(s *StateStore, id string, requiresController bool) func
 	// Return cleanup function that deletes the nodes
 	return func() {
 		index++
-		s.DeleteNode(index, ids)
+		s.DeleteNode(structs.MsgTypeTestSetup, index, ids)
 	}
 }

--- a/nomad/system_endpoint_test.go
+++ b/nomad/system_endpoint_test.go
@@ -27,14 +27,14 @@ func TestSystemEndpoint_GarbageCollect(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.Stop = true
-	if err := state.UpsertJob(1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
 		t.Fatalf("UpsertJob() failed: %v", err)
 	}
 
 	eval := mock.Eval()
 	eval.Status = structs.EvalStatusComplete
 	eval.JobID = job.ID
-	if err := state.UpsertEvals(1001, []*structs.Evaluation{eval}); err != nil {
+	if err := state.UpsertEvals(structs.MsgTypeTestSetup, 1001, []*structs.Evaluation{eval}); err != nil {
 		t.Fatalf("UpsertEvals() failed: %v", err)
 	}
 
@@ -122,7 +122,7 @@ func TestSystemEndpoint_ReconcileSummaries(t *testing.T) {
 	state := s1.fsm.State()
 	s1.fsm.State()
 	job := mock.Job()
-	if err := state.UpsertJob(1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
 		t.Fatalf("UpsertJob() failed: %v", err)
 	}
 

--- a/nomad/volumewatcher/interfaces_test.go
+++ b/nomad/volumewatcher/interfaces_test.go
@@ -35,7 +35,7 @@ func testNode(plugin *structs.CSIPlugin, s *state.StateStore) *structs.Node {
 	} else {
 		node.CSIControllerPlugins = map[string]*structs.CSIInfo{}
 	}
-	s.UpsertNode(structs.MsgTypeTestSetup, node, 99)
+	s.UpsertNode(structs.MsgTypeTestSetup, 99, node)
 	return node
 }
 

--- a/nomad/volumewatcher/interfaces_test.go
+++ b/nomad/volumewatcher/interfaces_test.go
@@ -35,7 +35,7 @@ func testNode(plugin *structs.CSIPlugin, s *state.StateStore) *structs.Node {
 	} else {
 		node.CSIControllerPlugins = map[string]*structs.CSIInfo{}
 	}
-	s.UpsertNode(99, node)
+	s.UpsertNode(structs.MsgTypeTestSetup, node, 99)
 	return node
 }
 

--- a/nomad/volumewatcher/volumes_watcher_test.go
+++ b/nomad/volumewatcher/volumes_watcher_test.go
@@ -114,7 +114,7 @@ func TestVolumeWatch_StartStop(t *testing.T) {
 	err := srv.State().UpsertJob(index, alloc1.Job)
 	require.NoError(err)
 	index++
-	err = srv.State().UpsertAllocs(index, []*structs.Allocation{alloc1, alloc2})
+	err = srv.State().UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc1, alloc2})
 	require.NoError(err)
 
 	// register a volume
@@ -160,7 +160,7 @@ func TestVolumeWatch_StartStop(t *testing.T) {
 	// alloc becomes terminal
 	alloc1.ClientStatus = structs.AllocClientStatusComplete
 	index++
-	err = srv.State().UpsertAllocs(index, []*structs.Allocation{alloc1})
+	err = srv.State().UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc1})
 	require.NoError(err)
 	index++
 	claim.State = structs.CSIVolumeClaimStateReadyToFree

--- a/nomad/volumewatcher/volumes_watcher_test.go
+++ b/nomad/volumewatcher/volumes_watcher_test.go
@@ -111,7 +111,7 @@ func TestVolumeWatch_StartStop(t *testing.T) {
 	alloc2.Job = alloc1.Job
 	alloc2.ClientStatus = structs.AllocClientStatusRunning
 	index++
-	err := srv.State().UpsertJob(index, alloc1.Job)
+	err := srv.State().UpsertJob(structs.MsgTypeTestSetup, index, alloc1.Job)
 	require.NoError(err)
 	index++
 	err = srv.State().UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc1, alloc2})

--- a/nomad/worker_test.go
+++ b/nomad/worker_test.go
@@ -297,7 +297,7 @@ func TestWorker_waitForIndex(t *testing.T) {
 	go func() {
 		time.Sleep(10 * time.Millisecond)
 		n := mock.Node()
-		errCh <- s1.fsm.state.UpsertNode(index+1, n)
+		errCh <- s1.fsm.state.UpsertNode(structs.MsgTypeTestSetup, n, index+1)
 	}()
 
 	// Wait for a future index

--- a/nomad/worker_test.go
+++ b/nomad/worker_test.go
@@ -297,7 +297,7 @@ func TestWorker_waitForIndex(t *testing.T) {
 	go func() {
 		time.Sleep(10 * time.Millisecond)
 		n := mock.Node()
-		errCh <- s1.fsm.state.UpsertNode(structs.MsgTypeTestSetup, n, index+1)
+		errCh <- s1.fsm.state.UpsertNode(structs.MsgTypeTestSetup, index+1, n)
 	}()
 
 	// Wait for a future index

--- a/nomad/worker_test.go
+++ b/nomad/worker_test.go
@@ -427,7 +427,7 @@ func TestWorker_SubmitPlanNormalizedAllocations(t *testing.T) {
 
 	stoppedAlloc := mock.Alloc()
 	preemptedAlloc := mock.Alloc()
-	s1.fsm.State().UpsertAllocs(5, []*structs.Allocation{stoppedAlloc, preemptedAlloc})
+	s1.fsm.State().UpsertAllocs(structs.MsgTypeTestSetup, 5, []*structs.Allocation{stoppedAlloc, preemptedAlloc})
 
 	// Create an allocation plan
 	plan := &structs.Plan{

--- a/nomad/worker_test.go
+++ b/nomad/worker_test.go
@@ -100,7 +100,7 @@ func TestWorker_dequeueEvaluation_SerialJobs(t *testing.T) {
 	eval2.JobID = eval1.JobID
 
 	// Insert the evals into the state store
-	if err := s1.fsm.State().UpsertEvals(1000, []*structs.Evaluation{eval1, eval2}); err != nil {
+	if err := s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1, eval2}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -128,7 +128,7 @@ func TestWorker_dequeueEvaluation_SerialJobs(t *testing.T) {
 	}
 
 	// Update the modify index of the first eval
-	if err := s1.fsm.State().UpsertEvals(2000, []*structs.Evaluation{eval1}); err != nil {
+	if err := s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 2000, []*structs.Evaluation{eval1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -355,8 +355,8 @@ func TestWorker_SubmitPlan(t *testing.T) {
 	job := mock.Job()
 	eval1 := mock.Eval()
 	eval1.JobID = job.ID
-	s1.fsm.State().UpsertJob(1000, job)
-	s1.fsm.State().UpsertEvals(1000, []*structs.Evaluation{eval1})
+	s1.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1})
 
 	// Create the register request
 	s1.evalBroker.Enqueue(eval1)
@@ -422,8 +422,8 @@ func TestWorker_SubmitPlanNormalizedAllocations(t *testing.T) {
 	job := mock.Job()
 	eval1 := mock.Eval()
 	eval1.JobID = job.ID
-	s1.fsm.State().UpsertJob(0, job)
-	s1.fsm.State().UpsertEvals(0, []*structs.Evaluation{eval1})
+	s1.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 0, job)
+	s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{eval1})
 
 	stoppedAlloc := mock.Alloc()
 	preemptedAlloc := mock.Alloc()
@@ -472,7 +472,7 @@ func TestWorker_SubmitPlan_MissingNodeRefresh(t *testing.T) {
 
 	// Create the job
 	job := mock.Job()
-	s1.fsm.State().UpsertJob(1000, job)
+	s1.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 1000, job)
 
 	// Create the register request
 	eval1 := mock.Eval()
@@ -640,7 +640,7 @@ func TestWorker_ReblockEval(t *testing.T) {
 	eval1.QueuedAllocations = map[string]int{"cache": 100}
 
 	// Insert it into the state store
-	if err := s1.fsm.State().UpsertEvals(1000, []*structs.Evaluation{eval1}); err != nil {
+	if err := s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/scheduler/context_test.go
+++ b/scheduler/context_test.go
@@ -108,7 +108,7 @@ func TestEvalContext_ProposedAlloc(t *testing.T) {
 	}
 	require.NoError(t, state.UpsertJobSummary(998, mock.JobSummary(alloc1.JobID)))
 	require.NoError(t, state.UpsertJobSummary(999, mock.JobSummary(alloc2.JobID)))
-	require.NoError(t, state.UpsertAllocs(1000, []*structs.Allocation{alloc1, alloc2}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1, alloc2}))
 
 	// Add a planned eviction to alloc1
 	plan := ctx.Plan()
@@ -247,7 +247,7 @@ func TestEvalContext_ProposedAlloc_EvictPreempt(t *testing.T) {
 	require.NoError(t, state.UpsertJobSummary(998, mock.JobSummary(allocEvict.JobID)))
 	require.NoError(t, state.UpsertJobSummary(999, mock.JobSummary(allocPreempt.JobID)))
 	require.NoError(t, state.UpsertJobSummary(999, mock.JobSummary(allocPropose.JobID)))
-	require.NoError(t, state.UpsertAllocs(1000, []*structs.Allocation{allocEvict, allocPreempt, allocPropose}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{allocEvict, allocPreempt, allocPropose}))
 
 	// Plan to evict one alloc and preempt another
 	plan := ctx.Plan()

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -282,7 +282,7 @@ func TestCSIVolumeChecker(t *testing.T) {
 	// Create the plugins in the state store
 	index := uint64(999)
 	for _, node := range nodes {
-		err := state.UpsertNode(structs.MsgTypeTestSetup, node, index)
+		err := state.UpsertNode(structs.MsgTypeTestSetup, index, node)
 		require.NoError(t, err)
 		index++
 	}
@@ -1273,7 +1273,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
 		n.Meta["rack"] = fmt.Sprintf("%d", i)
 
 		// Add to state store
-		if err := state.UpsertNode(structs.MsgTypeTestSetup, n, uint64(100+i)); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, uint64(100+i), n); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 	}
@@ -1451,7 +1451,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 		n.Meta["rack"] = fmt.Sprintf("%d", i)
 
 		// Add to state store
-		if err := state.UpsertNode(structs.MsgTypeTestSetup, n, uint64(100+i)); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, uint64(100+i), n); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 	}
@@ -1655,7 +1655,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_RemoveAndReplace(t *testin
 	nodes[0].Meta["rack"] = "1"
 
 	// Add to state store
-	if err := state.UpsertNode(structs.MsgTypeTestSetup, nodes[0], uint64(100)); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, uint64(100), nodes[0]); err != nil {
 		t.Fatalf("failed to upsert node: %v", err)
 	}
 
@@ -1739,7 +1739,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible(t *testing.T) {
 		n.Meta["rack"] = fmt.Sprintf("%d", i)
 
 		// Add to state store
-		if err := state.UpsertNode(structs.MsgTypeTestSetup, n, uint64(100+i)); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, uint64(100+i), n); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 	}
@@ -1816,7 +1816,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible_Count(t *testin
 		n.Meta["rack"] = fmt.Sprintf("%d", i)
 
 		// Add to state store
-		if err := state.UpsertNode(structs.MsgTypeTestSetup, n, uint64(100+i)); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, uint64(100+i), n); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 	}
@@ -1912,7 +1912,7 @@ func TestDistinctPropertyIterator_TaskGroupDistinctProperty(t *testing.T) {
 		n.Meta["rack"] = fmt.Sprintf("%d", i)
 
 		// Add to state store
-		if err := state.UpsertNode(structs.MsgTypeTestSetup, n, uint64(100+i)); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, uint64(100+i), n); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 	}

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -324,7 +324,7 @@ func TestCSIVolumeChecker(t *testing.T) {
 	summary := mock.JobSummary(alloc.JobID)
 	require.NoError(t, state.UpsertJobSummary(index, summary))
 	index++
-	err = state.UpsertAllocs(index, []*structs.Allocation{alloc})
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc})
 	require.NoError(t, err)
 	index++
 
@@ -1418,7 +1418,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
 			NodeID:    nodes[4].ID,
 		},
 	}
-	if err := state.UpsertAllocs(1000, upserting); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, upserting); err != nil {
 		t.Fatalf("failed to UpsertAllocs: %v", err)
 	}
 
@@ -1625,7 +1625,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 			NodeID:    nodes[1].ID,
 		},
 	}
-	if err := state.UpsertAllocs(1000, upserting); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, upserting); err != nil {
 		t.Fatalf("failed to UpsertAllocs: %v", err)
 	}
 
@@ -1710,7 +1710,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_RemoveAndReplace(t *testin
 			NodeID:    nodes[0].ID,
 		},
 	}
-	if err := state.UpsertAllocs(1000, upserting); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, upserting); err != nil {
 		t.Fatalf("failed to UpsertAllocs: %v", err)
 	}
 
@@ -1787,7 +1787,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible(t *testing.T) {
 			NodeID:    nodes[1].ID,
 		},
 	}
-	if err := state.UpsertAllocs(1000, upserting); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, upserting); err != nil {
 		t.Fatalf("failed to UpsertAllocs: %v", err)
 	}
 
@@ -1882,7 +1882,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible_Count(t *testin
 			NodeID:    nodes[1].ID,
 		},
 	}
-	if err := state.UpsertAllocs(1000, upserting); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, upserting); err != nil {
 		t.Fatalf("failed to UpsertAllocs: %v", err)
 	}
 
@@ -1997,7 +1997,7 @@ func TestDistinctPropertyIterator_TaskGroupDistinctProperty(t *testing.T) {
 			NodeID:    nodes[2].ID,
 		},
 	}
-	if err := state.UpsertAllocs(1000, upserting); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, upserting); err != nil {
 		t.Fatalf("failed to UpsertAllocs: %v", err)
 	}
 

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -318,7 +318,7 @@ func TestCSIVolumeChecker(t *testing.T) {
 			Source: vid2,
 		},
 	}
-	err = state.UpsertJob(index, alloc.Job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, index, alloc.Job)
 	require.NoError(t, err)
 	index++
 	summary := mock.JobSummary(alloc.JobID)

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -282,7 +282,7 @@ func TestCSIVolumeChecker(t *testing.T) {
 	// Create the plugins in the state store
 	index := uint64(999)
 	for _, node := range nodes {
-		err := state.UpsertNode(index, node)
+		err := state.UpsertNode(structs.MsgTypeTestSetup, node, index)
 		require.NoError(t, err)
 		index++
 	}
@@ -1273,7 +1273,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
 		n.Meta["rack"] = fmt.Sprintf("%d", i)
 
 		// Add to state store
-		if err := state.UpsertNode(uint64(100+i), n); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, n, uint64(100+i)); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 	}
@@ -1451,7 +1451,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 		n.Meta["rack"] = fmt.Sprintf("%d", i)
 
 		// Add to state store
-		if err := state.UpsertNode(uint64(100+i), n); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, n, uint64(100+i)); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 	}
@@ -1655,7 +1655,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_RemoveAndReplace(t *testin
 	nodes[0].Meta["rack"] = "1"
 
 	// Add to state store
-	if err := state.UpsertNode(uint64(100), nodes[0]); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, nodes[0], uint64(100)); err != nil {
 		t.Fatalf("failed to upsert node: %v", err)
 	}
 
@@ -1739,7 +1739,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible(t *testing.T) {
 		n.Meta["rack"] = fmt.Sprintf("%d", i)
 
 		// Add to state store
-		if err := state.UpsertNode(uint64(100+i), n); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, n, uint64(100+i)); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 	}
@@ -1816,7 +1816,7 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible_Count(t *testin
 		n.Meta["rack"] = fmt.Sprintf("%d", i)
 
 		// Add to state store
-		if err := state.UpsertNode(uint64(100+i), n); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, n, uint64(100+i)); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 	}
@@ -1912,7 +1912,7 @@ func TestDistinctPropertyIterator_TaskGroupDistinctProperty(t *testing.T) {
 		n.Meta["rack"] = fmt.Sprintf("%d", i)
 
 		// Add to state store
-		if err := state.UpsertNode(uint64(100+i), n); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, n, uint64(100+i)); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 	}

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -28,7 +28,7 @@ func TestServiceSched_JobRegister(t *testing.T) {
 
 	// Create a job
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -40,7 +40,7 @@ func TestServiceSched_JobRegister(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -119,7 +119,7 @@ func TestServiceSched_JobRegister_StickyAllocs(t *testing.T) {
 	// Create a job
 	job := mock.Job()
 	job.TaskGroups[0].EphemeralDisk.Sticky = true
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -130,7 +130,7 @@ func TestServiceSched_JobRegister_StickyAllocs(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	if err := h.Process(NewServiceScheduler, eval); err != nil {
@@ -152,7 +152,7 @@ func TestServiceSched_JobRegister_StickyAllocs(t *testing.T) {
 	// Update the job to force a rolling upgrade
 	updated := job.Copy()
 	updated.TaskGroups[0].Tasks[0].Resources.CPU += 10
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), updated))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), updated))
 
 	// Create a mock evaluation to handle the update
 	eval = &structs.Evaluation{
@@ -163,7 +163,7 @@ func TestServiceSched_JobRegister_StickyAllocs(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 	h1 := NewHarnessWithState(t, h.State)
 	if err := h1.Process(NewServiceScheduler, eval); err != nil {
 		t.Fatalf("err: %v", err)
@@ -211,7 +211,7 @@ func TestServiceSched_JobRegister_DiskConstraints(t *testing.T) {
 	job := mock.Job()
 	job.TaskGroups[0].Count = 2
 	job.TaskGroups[0].EphemeralDisk.SizeMB = 88 * 1024
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -223,7 +223,7 @@ func TestServiceSched_JobRegister_DiskConstraints(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -287,7 +287,7 @@ func TestServiceSched_JobRegister_DistinctHosts(t *testing.T) {
 	job := mock.Job()
 	job.TaskGroups[0].Count = 11
 	job.Constraints = append(job.Constraints, &structs.Constraint{Operand: structs.ConstraintDistinctHosts})
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -299,7 +299,7 @@ func TestServiceSched_JobRegister_DistinctHosts(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -379,7 +379,7 @@ func TestServiceSched_JobRegister_DistinctProperty(t *testing.T) {
 			LTarget: "${meta.rack}",
 			RTarget: "2",
 		})
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -391,7 +391,7 @@ func TestServiceSched_JobRegister_DistinctProperty(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -474,7 +474,7 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup(t *testing.T) {
 
 	job.TaskGroups[1].Name = "tg2"
 	job.TaskGroups[1].Count = 2
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -485,7 +485,7 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -543,7 +543,7 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup_Incr(t *testing.T) 
 			Operand: structs.ConstraintDistinctProperty,
 			LTarget: "${node.unique.id}",
 		})
-	assert.Nil(h.State.UpsertJob(h.NextIndex(), job), "UpsertJob")
+	assert.Nil(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job), "UpsertJob")
 
 	// Create some nodes
 	var nodes []*structs.Node
@@ -568,7 +568,7 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup_Incr(t *testing.T) 
 	// Update the count
 	job2 := job.Copy()
 	job2.TaskGroups[0].Count = 6
-	assert.Nil(h.State.UpsertJob(h.NextIndex(), job2), "UpsertJob")
+	assert.Nil(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2), "UpsertJob")
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -579,7 +579,7 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup_Incr(t *testing.T) 
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	assert.Nil(h.Process(NewServiceScheduler, eval), "Process")
@@ -643,7 +643,7 @@ func TestServiceSched_Spread(t *testing.T) {
 						},
 					},
 				})
-			assert.Nil(h.State.UpsertJob(h.NextIndex(), job), "UpsertJob")
+			assert.Nil(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job), "UpsertJob")
 			// Create some nodes, half in dc2
 			var nodes []*structs.Node
 			nodeMap := make(map[string]*structs.Node)
@@ -666,7 +666,7 @@ func TestServiceSched_Spread(t *testing.T) {
 				JobID:       job.ID,
 				Status:      structs.EvalStatusPending,
 			}
-			require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+			require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 			// Process the evaluation
 			assert.Nil(h.Process(NewServiceScheduler, eval), "Process")
@@ -720,7 +720,7 @@ func TestServiceSched_EvenSpread(t *testing.T) {
 			Attribute: "${node.datacenter}",
 			Weight:    100,
 		})
-	assert.Nil(h.State.UpsertJob(h.NextIndex(), job), "UpsertJob")
+	assert.Nil(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job), "UpsertJob")
 	// Create some nodes, half in dc2
 	var nodes []*structs.Node
 	nodeMap := make(map[string]*structs.Node)
@@ -743,7 +743,7 @@ func TestServiceSched_EvenSpread(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	assert.Nil(h.Process(NewServiceScheduler, eval), "Process")
@@ -791,7 +791,7 @@ func TestServiceSched_JobRegister_Annotate(t *testing.T) {
 
 	// Create a job
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -803,7 +803,7 @@ func TestServiceSched_JobRegister_Annotate(t *testing.T) {
 		AnnotatePlan: true,
 		Status:       structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -871,7 +871,7 @@ func TestServiceSched_JobRegister_CountZero(t *testing.T) {
 	// Create a job and set the task group count to zero.
 	job := mock.Job()
 	job.TaskGroups[0].Count = 0
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -882,7 +882,7 @@ func TestServiceSched_JobRegister_CountZero(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -914,7 +914,7 @@ func TestServiceSched_JobRegister_AllocFail(t *testing.T) {
 	// Create NO nodes
 	// Create a job
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -926,7 +926,7 @@ func TestServiceSched_JobRegister_AllocFail(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -1003,7 +1003,7 @@ func TestServiceSched_JobRegister_CreateBlockedEval(t *testing.T) {
 
 	// Create a jobs
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -1015,7 +1015,7 @@ func TestServiceSched_JobRegister_CreateBlockedEval(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -1103,7 +1103,7 @@ func TestServiceSched_JobRegister_FeasibleAndInfeasibleTG(t *testing.T) {
 	tg2.Name = "web2"
 	tg2.Constraints[1].RTarget = "class_1"
 	job.TaskGroups = append(job.TaskGroups, tg2)
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -1114,7 +1114,7 @@ func TestServiceSched_JobRegister_FeasibleAndInfeasibleTG(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
 	if err != nil {
@@ -1180,7 +1180,7 @@ func TestServiceSched_EvaluateMaxPlanEval(t *testing.T) {
 	// Create a job and set the task group count to zero.
 	job := mock.Job()
 	job.TaskGroups[0].Count = 0
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock blocked evaluation
 	eval := &structs.Evaluation{
@@ -1193,7 +1193,7 @@ func TestServiceSched_EvaluateMaxPlanEval(t *testing.T) {
 	}
 
 	// Insert it into the state store
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -1221,7 +1221,7 @@ func TestServiceSched_Plan_Partial_Progress(t *testing.T) {
 	job := mock.Job()
 	job.TaskGroups[0].Count = 3
 	job.TaskGroups[0].Tasks[0].Resources.CPU = 3600
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -1233,7 +1233,7 @@ func TestServiceSched_Plan_Partial_Progress(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -1284,7 +1284,7 @@ func TestServiceSched_EvaluateBlockedEval(t *testing.T) {
 
 	// Create a job
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock blocked evaluation
 	eval := &structs.Evaluation{
@@ -1297,7 +1297,7 @@ func TestServiceSched_EvaluateBlockedEval(t *testing.T) {
 	}
 
 	// Insert it into the state store
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -1335,7 +1335,7 @@ func TestServiceSched_EvaluateBlockedEval_Finished(t *testing.T) {
 
 	// Create a job and set the task group count to zero.
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock blocked evaluation
 	eval := &structs.Evaluation{
@@ -1348,7 +1348,7 @@ func TestServiceSched_EvaluateBlockedEval_Finished(t *testing.T) {
 	}
 
 	// Insert it into the state store
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -1421,7 +1421,7 @@ func TestServiceSched_JobModify(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -1453,7 +1453,7 @@ func TestServiceSched_JobModify(t *testing.T) {
 
 	// Update the task, such that it cannot be done in-place
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -1464,7 +1464,7 @@ func TestServiceSched_JobModify(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -1525,7 +1525,7 @@ func TestServiceSched_JobModify_IncrCount_NodeLimit(t *testing.T) {
 	job := mock.Job()
 	job.TaskGroups[0].Tasks[0].Resources.CPU = 256
 	job2 := job.Copy()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	alloc := mock.Alloc()
@@ -1539,7 +1539,7 @@ func TestServiceSched_JobModify_IncrCount_NodeLimit(t *testing.T) {
 
 	// Update the job to count 3
 	job2.TaskGroups[0].Count = 3
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -1550,7 +1550,7 @@ func TestServiceSched_JobModify_IncrCount_NodeLimit(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -1618,7 +1618,7 @@ func TestServiceSched_JobModify_CountZero(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -1648,7 +1648,7 @@ func TestServiceSched_JobModify_CountZero(t *testing.T) {
 	job2 := mock.Job()
 	job2.ID = job.ID
 	job2.TaskGroups[0].Count = 0
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -1659,7 +1659,7 @@ func TestServiceSched_JobModify_CountZero(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -1718,7 +1718,7 @@ func TestServiceSched_JobModify_Rolling(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -1744,7 +1744,7 @@ func TestServiceSched_JobModify_Rolling(t *testing.T) {
 
 	// Update the task, such that it cannot be done in-place
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -1755,7 +1755,7 @@ func TestServiceSched_JobModify_Rolling(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -1845,7 +1845,7 @@ func TestServiceSched_JobModify_Rolling_FullNode(t *testing.T) {
 	job := mock.Job()
 	job.TaskGroups[0].Count = 1
 	job.TaskGroups[0].Tasks[0].Resources = request
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	alloc := mock.Alloc()
 	alloc.AllocatedResources = allocated
@@ -1869,7 +1869,7 @@ func TestServiceSched_JobModify_Rolling_FullNode(t *testing.T) {
 
 	// Update the task, such that it cannot be done in-place
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
@@ -1879,7 +1879,7 @@ func TestServiceSched_JobModify_Rolling_FullNode(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -1944,7 +1944,7 @@ func TestServiceSched_JobModify_Canaries(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -1971,7 +1971,7 @@ func TestServiceSched_JobModify_Canaries(t *testing.T) {
 
 	// Update the task, such that it cannot be done in-place
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -1982,7 +1982,7 @@ func TestServiceSched_JobModify_Canaries(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -2070,7 +2070,7 @@ func TestServiceSched_JobModify_InPlace(t *testing.T) {
 	job := mock.Job()
 	d := mock.Deployment()
 	d.JobID = job.ID
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 	require.NoError(t, h.State.UpsertDeployment(h.NextIndex(), d))
 
 	taskName := job.TaskGroups[0].Tasks[0].Name
@@ -2107,7 +2107,7 @@ func TestServiceSched_JobModify_InPlace(t *testing.T) {
 		MinHealthyTime:  10 * time.Second,
 		HealthyDeadline: 10 * time.Minute,
 	}
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -2118,7 +2118,7 @@ func TestServiceSched_JobModify_InPlace(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -2208,7 +2208,7 @@ func TestServiceSched_JobModify_InPlace08(t *testing.T) {
 	// Generate a fake job with 0.8 allocations
 	job := mock.Job()
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create 0.8 alloc
 	alloc := mock.Alloc()
@@ -2222,7 +2222,7 @@ func TestServiceSched_JobModify_InPlace08(t *testing.T) {
 	job2 := job.Copy()
 
 	job2.TaskGroups[0].Tasks[0].Services[0].Tags[0] = "newtag"
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Create a mock evaluation
 	eval := &structs.Evaluation{
@@ -2233,7 +2233,7 @@ func TestServiceSched_JobModify_InPlace08(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -2296,7 +2296,7 @@ func TestServiceSched_JobModify_DistinctProperty(t *testing.T) {
 			Operand: structs.ConstraintDistinctProperty,
 			LTarget: "${meta.rack}",
 		})
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	oldJob := job.Copy()
 	oldJob.JobModifyIndex -= 1
@@ -2323,7 +2323,7 @@ func TestServiceSched_JobModify_DistinctProperty(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -2412,7 +2412,7 @@ func TestServiceSched_JobModify_NodeReschedulePenalty(t *testing.T) {
 	tgName := job.TaskGroups[0].Name
 	now := time.Now()
 
-	require.NoError(h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 2; i++ {
@@ -2443,7 +2443,7 @@ func TestServiceSched_JobModify_NodeReschedulePenalty(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 	require.NoError(h.Process(NewServiceScheduler, eval))
 
 	// Ensure we have one plan
@@ -2479,7 +2479,7 @@ func TestServiceSched_JobModify_NodeReschedulePenalty(t *testing.T) {
 	// Update the job, such that it cannot be done in-place
 	job2 := job.Copy()
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Create and process a mock evaluation
 	eval = &structs.Evaluation{
@@ -2490,7 +2490,7 @@ func TestServiceSched_JobModify_NodeReschedulePenalty(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 	require.NoError(h.Process(NewServiceScheduler, eval))
 
 	// Lookup the new allocations by JobID
@@ -2541,7 +2541,7 @@ func TestServiceSched_JobDeregister_Purged(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -2588,7 +2588,7 @@ func TestServiceSched_JobDeregister_Stopped(t *testing.T) {
 	// Generate a fake job with allocations
 	job := mock.Job()
 	job.Stop = true
-	require.NoError(h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -2615,7 +2615,7 @@ func TestServiceSched_JobDeregister_Stopped(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	require.NoError(h.Process(NewServiceScheduler, eval))
@@ -2709,7 +2709,7 @@ func TestServiceSched_NodeDown(t *testing.T) {
 
 			// Generate a fake job with allocations and an update policy.
 			job := mock.Job()
-			require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+			require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 			alloc := mock.Alloc()
 			alloc.Job = job
@@ -2736,7 +2736,7 @@ func TestServiceSched_NodeDown(t *testing.T) {
 				NodeID:      node.ID,
 				Status:      structs.EvalStatusPending,
 			}
-			require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+			require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 			// Process the evaluation
 			err := h.Process(NewServiceScheduler, eval)
@@ -2807,7 +2807,7 @@ func TestServiceSched_StopAfterClientDisconnect(t *testing.T) {
 			job := mock.Job()
 			job.TaskGroups[0].Count = 1
 			job.TaskGroups[0].StopAfterClientDisconnect = &tc.stop
-			require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+			require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 			// Alloc for the running group
 			alloc := mock.Alloc()
@@ -2838,7 +2838,7 @@ func TestServiceSched_StopAfterClientDisconnect(t *testing.T) {
 				Status:      structs.EvalStatusPending,
 			}}
 			eval := evals[0]
-			require.NoError(t, h.State.UpsertEvals(h.NextIndex(), evals))
+			require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), evals))
 
 			// Process the evaluation
 			err := h.Process(NewServiceScheduler, eval)
@@ -2939,7 +2939,7 @@ func TestServiceSched_NodeUpdate(t *testing.T) {
 
 	// Generate a fake job with allocations and an update policy.
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -2970,7 +2970,7 @@ func TestServiceSched_NodeUpdate(t *testing.T) {
 		NodeID:      node.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -3000,7 +3000,7 @@ func TestServiceSched_NodeDrain(t *testing.T) {
 
 	// Generate a fake job with allocations and an update policy.
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -3024,7 +3024,7 @@ func TestServiceSched_NodeDrain(t *testing.T) {
 		NodeID:      node.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -3077,7 +3077,7 @@ func TestServiceSched_NodeDrain_Down(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -3139,7 +3139,7 @@ func TestServiceSched_NodeDrain_Down(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -3189,7 +3189,7 @@ func TestServiceSched_NodeDrain_Queued_Allocations(t *testing.T) {
 	// Generate a fake job with allocations and an update policy.
 	job := mock.Job()
 	job.TaskGroups[0].Count = 2
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 2; i++ {
@@ -3216,7 +3216,7 @@ func TestServiceSched_NodeDrain_Queued_Allocations(t *testing.T) {
 		NodeID:      node.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -3242,7 +3242,7 @@ func TestServiceSched_RetryLimit(t *testing.T) {
 
 	// Create a job
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -3253,7 +3253,7 @@ func TestServiceSched_RetryLimit(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -3304,7 +3304,7 @@ func TestServiceSched_Reschedule_OnceNow(t *testing.T) {
 	tgName := job.TaskGroups[0].Name
 	now := time.Now()
 
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 2; i++ {
@@ -3334,7 +3334,7 @@ func TestServiceSched_Reschedule_OnceNow(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -3379,7 +3379,7 @@ func TestServiceSched_Reschedule_OnceNow(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err = h.Process(NewServiceScheduler, eval)
@@ -3417,7 +3417,7 @@ func TestServiceSched_Reschedule_Later(t *testing.T) {
 	tgName := job.TaskGroups[0].Name
 	now := time.Now()
 
-	require.NoError(h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 2; i++ {
@@ -3446,7 +3446,7 @@ func TestServiceSched_Reschedule_Later(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -3504,7 +3504,7 @@ func TestServiceSched_Reschedule_MultipleNow(t *testing.T) {
 	tgName := job.TaskGroups[0].Name
 	now := time.Now()
 
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 2; i++ {
@@ -3533,7 +3533,7 @@ func TestServiceSched_Reschedule_MultipleNow(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	expectedNumAllocs := 3
 	expectedNumReschedTrackers := 1
@@ -3604,7 +3604,7 @@ func TestServiceSched_Reschedule_MultipleNow(t *testing.T) {
 			JobID:       job.ID,
 			Status:      structs.EvalStatusPending,
 		}
-		require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+		require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 		expectedNumAllocs += 1
 		expectedNumReschedTrackers += 1
 	}
@@ -3641,7 +3641,7 @@ func TestServiceSched_Reschedule_PruneEvents(t *testing.T) {
 		Delay:         5 * time.Second,
 		Unlimited:     true,
 	}
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 2; i++ {
@@ -3709,7 +3709,7 @@ func TestServiceSched_Reschedule_PruneEvents(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -3773,7 +3773,7 @@ func TestDeployment_FailedAllocs_Reschedule(t *testing.T) {
 				Interval: 15 * time.Minute,
 			}
 			jobIndex := h.NextIndex()
-			require.Nil(h.State.UpsertJob(jobIndex, job))
+			require.Nil(h.State.UpsertJob(structs.MsgTypeTestSetup, jobIndex, job))
 
 			deployment := mock.Deployment()
 			deployment.JobID = job.ID
@@ -3813,7 +3813,7 @@ func TestDeployment_FailedAllocs_Reschedule(t *testing.T) {
 				JobID:       job.ID,
 				Status:      structs.EvalStatusPending,
 			}
-			require.Nil(h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+			require.Nil(h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 			// Process the evaluation
 			require.Nil(h.Process(NewServiceScheduler, eval))
@@ -3849,7 +3849,7 @@ func TestBatchSched_Run_CompleteAlloc(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a complete alloc
 	alloc := mock.Alloc()
@@ -3869,7 +3869,7 @@ func TestBatchSched_Run_CompleteAlloc(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewBatchScheduler, eval)
@@ -3906,7 +3906,7 @@ func TestBatchSched_Run_FailedAlloc(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	tgName := job.TaskGroups[0].Name
 	now := time.Now()
@@ -3932,7 +3932,7 @@ func TestBatchSched_Run_FailedAlloc(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewBatchScheduler, eval)
@@ -3977,7 +3977,7 @@ func TestBatchSched_Run_LostAlloc(t *testing.T) {
 	job.ID = "my-job"
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 3
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Desired = 3
 	// Mark one as lost and then schedule
@@ -4015,7 +4015,7 @@ func TestBatchSched_Run_LostAlloc(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewBatchScheduler, eval)
@@ -4064,7 +4064,7 @@ func TestBatchSched_Run_FailedAllocQueuedAllocations(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	tgName := job.TaskGroups[0].Name
 	now := time.Now()
@@ -4090,7 +4090,7 @@ func TestBatchSched_Run_FailedAllocQueuedAllocations(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewBatchScheduler, eval)
@@ -4121,7 +4121,7 @@ func TestBatchSched_ReRun_SuccessfullyFinishedAlloc(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a successful alloc
 	alloc := mock.Alloc()
@@ -4152,7 +4152,7 @@ func TestBatchSched_ReRun_SuccessfullyFinishedAlloc(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewBatchScheduler, eval)
@@ -4194,7 +4194,7 @@ func TestBatchSched_JobModify_InPlace_Terminal(t *testing.T) {
 	// Generate a fake job with allocations
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -4217,7 +4217,7 @@ func TestBatchSched_JobModify_InPlace_Terminal(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewBatchScheduler, eval)
@@ -4246,7 +4246,7 @@ func TestBatchSched_JobModify_Destructive_Terminal(t *testing.T) {
 	// Generate a fake job with allocations
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -4266,7 +4266,7 @@ func TestBatchSched_JobModify_Destructive_Terminal(t *testing.T) {
 	job2.Type = structs.JobTypeBatch
 	job2.Version++
 	job2.TaskGroups[0].Tasks[0].Env = map[string]string{"foo": "bar"}
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	allocs = nil
 	for i := 0; i < 10; i++ {
@@ -4300,7 +4300,7 @@ func TestBatchSched_JobModify_Destructive_Terminal(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewBatchScheduler, eval)
@@ -4331,7 +4331,7 @@ func TestBatchSched_NodeDrain_Running_OldJob(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a running alloc
 	alloc := mock.Alloc()
@@ -4346,7 +4346,7 @@ func TestBatchSched_NodeDrain_Running_OldJob(t *testing.T) {
 	job2 := job.Copy()
 	job2.TaskGroups[0].Tasks[0].Env = map[string]string{"foo": "bar"}
 	job2.Version++
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -4358,7 +4358,7 @@ func TestBatchSched_NodeDrain_Running_OldJob(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewBatchScheduler, eval)
@@ -4403,7 +4403,7 @@ func TestBatchSched_NodeDrain_Complete(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a complete alloc
 	alloc := mock.Alloc()
@@ -4434,7 +4434,7 @@ func TestBatchSched_NodeDrain_Complete(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewBatchScheduler, eval)
@@ -4464,7 +4464,7 @@ func TestBatchSched_ScaleDown_SameName(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	scoreMetric := &structs.AllocMetric{
 		NodesEvaluated: 10,
@@ -4495,7 +4495,7 @@ func TestBatchSched_ScaleDown_SameName(t *testing.T) {
 	// Update the job's modify index to force an inplace upgrade
 	updatedJob := job.Copy()
 	updatedJob.JobModifyIndex = job.JobModifyIndex + 1
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), updatedJob))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), updatedJob))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -4507,7 +4507,7 @@ func TestBatchSched_ScaleDown_SameName(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewBatchScheduler, eval)
@@ -4616,7 +4616,7 @@ func TestGenericSched_AllocFit(t *testing.T) {
 			// Create a job with sidecar & init tasks
 			job := mock.VariableLifecycleJob(testCase.TaskResources, testCase.MainTaskCount, testCase.InitTaskCount, testCase.SideTaskCount)
 
-			require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+			require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 			// Create a mock evaluation to register the job
 			eval := &structs.Evaluation{
@@ -4627,7 +4627,7 @@ func TestGenericSched_AllocFit(t *testing.T) {
 				JobID:       job.ID,
 				Status:      structs.EvalStatusPending,
 			}
-			require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+			require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 			// Process the evaluation
 			err := h.Process(NewServiceScheduler, eval)
@@ -4664,7 +4664,7 @@ func TestGenericSched_ChainedAlloc(t *testing.T) {
 
 	// Create a job
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -4675,7 +4675,7 @@ func TestGenericSched_ChainedAlloc(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 	// Process the evaluation
 	if err := h.Process(NewServiceScheduler, eval); err != nil {
 		t.Fatalf("err: %v", err)
@@ -4695,7 +4695,7 @@ func TestGenericSched_ChainedAlloc(t *testing.T) {
 	job1.ID = job.ID
 	job1.TaskGroups[0].Tasks[0].Env["foo"] = "bar"
 	job1.TaskGroups[0].Count = 12
-	require.NoError(t, h1.State.UpsertJob(h1.NextIndex(), job1))
+	require.NoError(t, h1.State.UpsertJob(structs.MsgTypeTestSetup, h1.NextIndex(), job1))
 
 	// Create a mock evaluation to update the job
 	eval1 := &structs.Evaluation{
@@ -4706,7 +4706,7 @@ func TestGenericSched_ChainedAlloc(t *testing.T) {
 		JobID:       job1.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval1}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval1}))
 
 	// Process the evaluation
 	if err := h1.Process(NewServiceScheduler, eval1); err != nil {
@@ -4757,7 +4757,7 @@ func TestServiceSched_NodeDrain_Sticky(t *testing.T) {
 	alloc.Job.TaskGroups[0].Count = 1
 	alloc.Job.TaskGroups[0].EphemeralDisk.Sticky = true
 	alloc.DesiredTransition.Migrate = helper.BoolToPtr(true)
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), alloc.Job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), alloc.Job))
 	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create a mock evaluation to deal with drain
@@ -4771,7 +4771,7 @@ func TestServiceSched_NodeDrain_Sticky(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -4812,7 +4812,7 @@ func TestServiceSched_CancelDeployment_Stopped(t *testing.T) {
 	job.JobModifyIndex = job.CreateIndex + 1
 	job.ModifyIndex = job.CreateIndex + 1
 	job.Stop = true
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a deployment
 	d := mock.Deployment()
@@ -4831,7 +4831,7 @@ func TestServiceSched_CancelDeployment_Stopped(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -4883,7 +4883,7 @@ func TestServiceSched_CancelDeployment_NewerJob(t *testing.T) {
 
 	// Generate a fake job
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a deployment for an old version of the job
 	d := mock.Deployment()
@@ -4891,7 +4891,7 @@ func TestServiceSched_CancelDeployment_NewerJob(t *testing.T) {
 	require.NoError(t, h.State.UpsertDeployment(h.NextIndex(), d))
 
 	// Upsert again to bump job version
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to kick the job
 	eval := &structs.Evaluation{
@@ -4903,7 +4903,7 @@ func TestServiceSched_CancelDeployment_NewerJob(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -5235,7 +5235,7 @@ func TestServiceSched_Preemption(t *testing.T) {
 	r1.CPU = 500
 	r1.MemoryMB = 1024
 	r1.Networks = nil
-	require.NoError(h.State.UpsertJob(h.NextIndex(), job1))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job1))
 
 	job2 := mock.Job()
 	job2.TaskGroups[0].Count = 1
@@ -5244,7 +5244,7 @@ func TestServiceSched_Preemption(t *testing.T) {
 	r2.CPU = 350
 	r2.MemoryMB = 512
 	r2.Networks = nil
-	require.NoError(h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Create a mock evaluation to register the jobs
 	eval1 := &structs.Evaluation{
@@ -5264,7 +5264,7 @@ func TestServiceSched_Preemption(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval1, eval2}))
+	require.NoError(h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval1, eval2}))
 
 	expectedPreemptedAllocs := make(map[string]struct{})
 	// Process the two evals for job1 and job2 and make sure they allocated
@@ -5298,7 +5298,7 @@ func TestServiceSched_Preemption(t *testing.T) {
 	r3.CPU = 900
 	r3.MemoryMB = 1700
 	r3.Networks = nil
-	require.NoError(h.State.UpsertJob(h.NextIndex(), job3))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job3))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -5310,7 +5310,7 @@ func TestServiceSched_Preemption(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.NoError(h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -5358,7 +5358,7 @@ func TestServiceSched_Migrate_NonCanary(t *testing.T) {
 		MaxParallel: 1,
 		Canary:      1,
 	}
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	deployment := &structs.Deployment{
 		ID:             uuid.Generate(),
@@ -5395,7 +5395,7 @@ func TestServiceSched_Migrate_NonCanary(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -5431,7 +5431,7 @@ func TestServiceSched_Migrate_CanaryStatus(t *testing.T) {
 		MaxParallel: 1,
 		Canary:      desiredCanaries,
 	}
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	deployment := &structs.Deployment{
 		ID:             uuid.Generate(),
@@ -5464,7 +5464,7 @@ func TestServiceSched_Migrate_CanaryStatus(t *testing.T) {
 	job2 := job.Copy()
 	job2.Stable = false
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Create a mock evaluation
 	eval := &structs.Evaluation{
@@ -5475,7 +5475,7 @@ func TestServiceSched_Migrate_CanaryStatus(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -5529,7 +5529,7 @@ func TestServiceSched_Migrate_CanaryStatus(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{neval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{neval}))
 
 	// Process the evaluation
 	err = h.Process(NewServiceScheduler, eval)
@@ -5594,7 +5594,7 @@ func TestServiceSched_RunningWithNextAllocation(t *testing.T) {
 	job.Stable = true
 	job.TaskGroups[0].Count = totalCount
 	job.TaskGroups[0].Update = nil
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < totalCount+1; i++ {
@@ -5615,7 +5615,7 @@ func TestServiceSched_RunningWithNextAllocation(t *testing.T) {
 	job2 := job.Copy()
 	job2.Version = 1
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Create a mock evaluation
 	eval := &structs.Evaluation{
@@ -5626,7 +5626,7 @@ func TestServiceSched_RunningWithNextAllocation(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -23,7 +23,7 @@ func TestServiceSched_JobRegister(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job
@@ -113,7 +113,7 @@ func TestServiceSched_JobRegister_StickyAllocs(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job
@@ -204,7 +204,7 @@ func TestServiceSched_JobRegister_DiskConstraints(t *testing.T) {
 
 	// Create a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create a job with count 2 and disk as 60GB so that only one allocation
 	// can fit
@@ -279,7 +279,7 @@ func TestServiceSched_JobRegister_DistinctHosts(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job that uses distinct host and has count 1 higher than what is
@@ -366,7 +366,7 @@ func TestServiceSched_JobRegister_DistinctProperty(t *testing.T) {
 			rack = "rack1"
 		}
 		node.Meta["rack"] = rack
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job that uses distinct property and has count higher than what is
@@ -459,7 +459,7 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		node := mock.Node()
 		node.Meta["ssd"] = "true"
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job that uses distinct property only on one task group.
@@ -550,7 +550,7 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup_Incr(t *testing.T) 
 	for i := 0; i < 6; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		assert.Nil(h.State.UpsertNode(h.NextIndex(), node), "UpsertNode")
+		assert.Nil(h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()), "UpsertNode")
 	}
 
 	// Create some allocations
@@ -653,7 +653,7 @@ func TestServiceSched_Spread(t *testing.T) {
 					node.Datacenter = "dc2"
 				}
 				nodes = append(nodes, node)
-				assert.Nil(h.State.UpsertNode(h.NextIndex(), node), "UpsertNode")
+				assert.Nil(h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()), "UpsertNode")
 				nodeMap[node.ID] = node
 			}
 
@@ -730,7 +730,7 @@ func TestServiceSched_EvenSpread(t *testing.T) {
 			node.Datacenter = "dc2"
 		}
 		nodes = append(nodes, node)
-		assert.Nil(h.State.UpsertNode(h.NextIndex(), node), "UpsertNode")
+		assert.Nil(h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()), "UpsertNode")
 		nodeMap[node.ID] = node
 	}
 
@@ -786,7 +786,7 @@ func TestServiceSched_JobRegister_Annotate(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job
@@ -865,7 +865,7 @@ func TestServiceSched_JobRegister_CountZero(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job and set the task group count to zero.
@@ -993,13 +993,13 @@ func TestServiceSched_JobRegister_CreateBlockedEval(t *testing.T) {
 		},
 	}
 	node.ComputeClass()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create an ineligible node
 	node2 := mock.Node()
 	node2.Attributes["kernel.name"] = "windows"
 	node2.ComputeClass()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node2))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node2, h.NextIndex()))
 
 	// Create a jobs
 	job := mock.Job()
@@ -1087,7 +1087,7 @@ func TestServiceSched_JobRegister_FeasibleAndInfeasibleTG(t *testing.T) {
 	node := mock.Node()
 	node.NodeClass = "class_0"
 	require.NoError(t, node.ComputeClass())
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create a job that constrains on a node class
 	job := mock.Job()
@@ -1214,7 +1214,7 @@ func TestServiceSched_Plan_Partial_Progress(t *testing.T) {
 
 	// Create a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create a job with a high resource ask so that all the allocations can't
 	// be placed on a single node.
@@ -1330,7 +1330,7 @@ func TestServiceSched_EvaluateBlockedEval_Finished(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job and set the task group count to zero.
@@ -1416,7 +1416,7 @@ func TestServiceSched_JobModify(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations
@@ -1519,7 +1519,7 @@ func TestServiceSched_JobModify_IncrCount_NodeLimit(t *testing.T) {
 	// Create one node
 	node := mock.Node()
 	node.NodeResources.Cpu.CpuShares = 1000
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Generate a fake job with one allocation
 	job := mock.Job()
@@ -1613,7 +1613,7 @@ func TestServiceSched_JobModify_CountZero(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations
@@ -1713,7 +1713,7 @@ func TestServiceSched_JobModify_Rolling(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations
@@ -1817,7 +1817,7 @@ func TestServiceSched_JobModify_Rolling_FullNode(t *testing.T) {
 	// Create a node and clear the reserved resources
 	node := mock.Node()
 	node.ReservedResources = nil
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create a resource ask that is the same as the resources available on the
 	// node
@@ -1939,7 +1939,7 @@ func TestServiceSched_JobModify_Canaries(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations
@@ -2063,7 +2063,7 @@ func TestServiceSched_JobModify_InPlace(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations and create an older deployment
@@ -2203,7 +2203,7 @@ func TestServiceSched_JobModify_InPlace08(t *testing.T) {
 
 	// Create node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Generate a fake job with 0.8 allocations
 	job := mock.Job()
@@ -2284,7 +2284,7 @@ func TestServiceSched_JobModify_DistinctProperty(t *testing.T) {
 		node := mock.Node()
 		node.Meta["rack"] = fmt.Sprintf("rack%d", i)
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job that uses distinct property and has count higher than what is
@@ -2396,7 +2396,7 @@ func TestServiceSched_JobModify_NodeReschedulePenalty(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations and an update policy.
@@ -2705,7 +2705,7 @@ func TestServiceSched_NodeDown(t *testing.T) {
 			// Register a node
 			node := mock.Node()
 			node.Status = structs.NodeStatusDown
-			require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+			require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 			// Generate a fake job with allocations and an update policy.
 			job := mock.Job()
@@ -2801,7 +2801,7 @@ func TestServiceSched_StopAfterClientDisconnect(t *testing.T) {
 			// Node, which is down
 			node := mock.Node()
 			node.Status = structs.NodeStatusDown
-			require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+			require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 			// Job with allocations and stop_after_client_disconnect
 			job := mock.Job()
@@ -2885,7 +2885,7 @@ func TestServiceSched_StopAfterClientDisconnect(t *testing.T) {
 			if tc.rescheduled {
 				// Register a new node, leave it up, process the followup eval
 				node = mock.Node()
-				require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+				require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 				require.NoError(t, h.Process(NewServiceScheduler, eval))
 
 				as, err := h.State.AllocsByJob(ws, job.Namespace, job.ID, false)
@@ -2935,7 +2935,7 @@ func TestServiceSched_NodeUpdate(t *testing.T) {
 
 	// Register a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Generate a fake job with allocations and an update policy.
 	job := mock.Job()
@@ -2990,12 +2990,12 @@ func TestServiceSched_NodeDrain(t *testing.T) {
 	// Register a draining node
 	node := mock.Node()
 	node.Drain = true
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations and an update policy.
@@ -3073,7 +3073,7 @@ func TestServiceSched_NodeDrain_Down(t *testing.T) {
 	node := mock.Node()
 	node.Drain = true
 	node.Status = structs.NodeStatusDown
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Generate a fake job with allocations
 	job := mock.Job()
@@ -3184,7 +3184,7 @@ func TestServiceSched_NodeDrain_Queued_Allocations(t *testing.T) {
 
 	// Register a draining node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Generate a fake job with allocations and an update policy.
 	job := mock.Job()
@@ -3204,7 +3204,7 @@ func TestServiceSched_NodeDrain_Queued_Allocations(t *testing.T) {
 	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
 
 	node.Drain = true
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -3237,7 +3237,7 @@ func TestServiceSched_RetryLimit(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job
@@ -3288,7 +3288,7 @@ func TestServiceSched_Reschedule_OnceNow(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations and an update policy.
@@ -3400,7 +3400,7 @@ func TestServiceSched_Reschedule_Later(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations and an update policy.
@@ -3488,7 +3488,7 @@ func TestServiceSched_Reschedule_MultipleNow(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	maxRestartAttempts := 3
@@ -3629,7 +3629,7 @@ func TestServiceSched_Reschedule_PruneEvents(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations and an update policy.
@@ -3762,7 +3762,7 @@ func TestDeployment_FailedAllocs_Reschedule(t *testing.T) {
 			for i := 0; i < 10; i++ {
 				node := mock.Node()
 				nodes = append(nodes, node)
-				require.NoError(h.State.UpsertNode(h.NextIndex(), node))
+				require.NoError(h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 			}
 
 			// Generate a fake job with allocations and a reschedule policy.
@@ -3843,7 +3843,7 @@ func TestBatchSched_Run_CompleteAlloc(t *testing.T) {
 
 	// Create a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create a job
 	job := mock.Job()
@@ -3900,7 +3900,7 @@ func TestBatchSched_Run_FailedAlloc(t *testing.T) {
 
 	// Create a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create a job
 	job := mock.Job()
@@ -3970,7 +3970,7 @@ func TestBatchSched_Run_LostAlloc(t *testing.T) {
 
 	// Create a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create a job
 	job := mock.Job()
@@ -4058,7 +4058,7 @@ func TestBatchSched_Run_FailedAllocQueuedAllocations(t *testing.T) {
 
 	node := mock.Node()
 	node.Drain = true
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create a job
 	job := mock.Job()
@@ -4114,8 +4114,8 @@ func TestBatchSched_ReRun_SuccessfullyFinishedAlloc(t *testing.T) {
 	node := mock.Node()
 	node.Drain = true
 	node2 := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node2))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node2, h.NextIndex()))
 
 	// Create a job
 	job := mock.Job()
@@ -4188,7 +4188,7 @@ func TestBatchSched_JobModify_InPlace_Terminal(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations
@@ -4240,7 +4240,7 @@ func TestBatchSched_JobModify_Destructive_Terminal(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations
@@ -4324,8 +4324,8 @@ func TestBatchSched_NodeDrain_Running_OldJob(t *testing.T) {
 	node := mock.Node()
 	node.Drain = true
 	node2 := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node2))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node2, h.NextIndex()))
 
 	// Create a job
 	job := mock.Job()
@@ -4396,8 +4396,8 @@ func TestBatchSched_NodeDrain_Complete(t *testing.T) {
 	node := mock.Node()
 	node.Drain = true
 	node2 := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node2))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node2, h.NextIndex()))
 
 	// Create a job
 	job := mock.Job()
@@ -4458,7 +4458,7 @@ func TestBatchSched_ScaleDown_SameName(t *testing.T) {
 
 	// Create a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create a job
 	job := mock.Job()
@@ -4611,7 +4611,7 @@ func TestGenericSched_AllocFit(t *testing.T) {
 			h := NewHarness(t)
 			node := mock.Node()
 			node.NodeResources.Cpu.CpuShares = testCase.NodeCpu
-			require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+			require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 			// Create a job with sidecar & init tasks
 			job := mock.VariableLifecycleJob(testCase.TaskResources, testCase.MainTaskCount, testCase.InitTaskCount, testCase.SideTaskCount)
@@ -4659,7 +4659,7 @@ func TestGenericSched_ChainedAlloc(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job
@@ -4748,7 +4748,7 @@ func TestServiceSched_NodeDrain_Sticky(t *testing.T) {
 	// Register a draining node
 	node := mock.Node()
 	node.Drain = true
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create an alloc on the draining node
 	alloc := mock.Alloc()
@@ -5225,7 +5225,7 @@ func TestServiceSched_Preemption(t *testing.T) {
 			ReservedHostPorts: "22",
 		},
 	}
-	require.NoError(h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create a couple of jobs and schedule them
 	job1 := mock.Job()
@@ -5349,7 +5349,7 @@ func TestServiceSched_Migrate_NonCanary(t *testing.T) {
 	h := NewHarness(t)
 
 	node1 := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node1))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node1, h.NextIndex()))
 
 	job := mock.Job()
 	job.Stable = true
@@ -5419,7 +5419,7 @@ func TestServiceSched_Migrate_CanaryStatus(t *testing.T) {
 	h := NewHarness(t)
 
 	node1 := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node1))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node1, h.NextIndex()))
 
 	totalCount := 3
 	desiredCanaries := 1
@@ -5515,10 +5515,10 @@ func TestServiceSched_Migrate_CanaryStatus(t *testing.T) {
 	// now, drain node1 and ensure all are migrated to node2
 	node1 = node1.Copy()
 	node1.Status = structs.NodeStatusDown
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node1))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node1, h.NextIndex()))
 
 	node2 := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node2))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node2, h.NextIndex()))
 
 	neval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
@@ -5586,7 +5586,7 @@ func TestServiceSched_RunningWithNextAllocation(t *testing.T) {
 	h := NewHarness(t)
 
 	node1 := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node1))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node1, h.NextIndex()))
 
 	totalCount := 2
 	job := mock.Job()

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -563,7 +563,7 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup_Incr(t *testing.T) 
 		alloc.Name = fmt.Sprintf("my-job.web[%d]", i)
 		allocs = append(allocs, alloc)
 	}
-	assert.Nil(h.State.UpsertAllocs(h.NextIndex(), allocs), "UpsertAllocs")
+	assert.Nil(h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs), "UpsertAllocs")
 
 	// Update the count
 	job2 := job.Copy()
@@ -1432,7 +1432,7 @@ func TestServiceSched_JobModify(t *testing.T) {
 		alloc.Name = fmt.Sprintf("my-job.web[%d]", i)
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Add a few terminal status allocations, these should be ignored
 	var terminal []*structs.Allocation
@@ -1445,7 +1445,7 @@ func TestServiceSched_JobModify(t *testing.T) {
 		alloc.DesiredStatus = structs.AllocDesiredStatusStop
 		terminal = append(terminal, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), terminal))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), terminal))
 
 	// Update the job
 	job2 := mock.Job()
@@ -1535,7 +1535,7 @@ func TestServiceSched_JobModify_IncrCount_NodeLimit(t *testing.T) {
 	alloc.Name = "my-job.web[0]"
 	alloc.AllocatedResources.Tasks["web"].Cpu.CpuShares = 256
 	allocs = append(allocs, alloc)
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Update the job to count 3
 	job2.TaskGroups[0].Count = 3
@@ -1629,7 +1629,7 @@ func TestServiceSched_JobModify_CountZero(t *testing.T) {
 		alloc.Name = structs.AllocName(alloc.JobID, alloc.TaskGroup, uint(i))
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Add a few terminal status allocations, these should be ignored
 	var terminal []*structs.Allocation
@@ -1642,7 +1642,7 @@ func TestServiceSched_JobModify_CountZero(t *testing.T) {
 		alloc.DesiredStatus = structs.AllocDesiredStatusStop
 		terminal = append(terminal, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), terminal))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), terminal))
 
 	// Update the job to be count zero
 	job2 := mock.Job()
@@ -1729,7 +1729,7 @@ func TestServiceSched_JobModify_Rolling(t *testing.T) {
 		alloc.Name = fmt.Sprintf("my-job.web[%d]", i)
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Update the job
 	job2 := mock.Job()
@@ -1853,7 +1853,7 @@ func TestServiceSched_JobModify_Rolling_FullNode(t *testing.T) {
 	alloc.JobID = job.ID
 	alloc.NodeID = node.ID
 	alloc.Name = "my-job.web[0]"
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Update the job to place more versions of the task group, drop the count
 	// and force destructive updates
@@ -1955,7 +1955,7 @@ func TestServiceSched_JobModify_Canaries(t *testing.T) {
 		alloc.Name = fmt.Sprintf("my-job.web[%d]", i)
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Update the job
 	job2 := mock.Job()
@@ -2095,7 +2095,7 @@ func TestServiceSched_JobModify_InPlace(t *testing.T) {
 		alloc.AllocatedResources.Tasks[taskName].Devices = []*structs.AllocatedDeviceResource{&adr}
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Update the job
 	job2 := mock.Job()
@@ -2216,7 +2216,7 @@ func TestServiceSched_JobModify_InPlace08(t *testing.T) {
 	alloc.JobID = job.ID
 	alloc.NodeID = node.ID
 	alloc.AllocatedResources = nil // 0.8 didn't have this
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Update the job inplace
 	job2 := job.Copy()
@@ -2312,7 +2312,7 @@ func TestServiceSched_JobModify_DistinctProperty(t *testing.T) {
 		alloc.Name = fmt.Sprintf("my-job.web[%d]", i)
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -2432,7 +2432,7 @@ func TestServiceSched_JobModify_NodeReschedulePenalty(t *testing.T) {
 	failedAllocID := failedAlloc.ID
 	successAllocID := allocs[0].ID
 
-	require.NoError(h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Create and process a mock evaluation
 	eval := &structs.Evaluation{
@@ -2530,7 +2530,7 @@ func TestServiceSched_JobDeregister_Purged(t *testing.T) {
 	for _, alloc := range allocs {
 		h.State.UpsertJobSummary(h.NextIndex(), mock.JobSummary(alloc.JobID))
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
@@ -2597,7 +2597,7 @@ func TestServiceSched_JobDeregister_Stopped(t *testing.T) {
 		alloc.JobID = job.ID
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Create a summary where the queued allocs are set as we want to assert
 	// they get zeroed out.
@@ -2724,7 +2724,7 @@ func TestServiceSched_NodeDown(t *testing.T) {
 			alloc.DesiredTransition.Migrate = helper.BoolToPtr(tc.migrate)
 
 			allocs := []*structs.Allocation{alloc}
-			require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+			require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 			// Create a mock evaluation to deal with drain
 			eval := &structs.Evaluation{
@@ -2825,7 +2825,7 @@ func TestServiceSched_StopAfterClientDisconnect(t *testing.T) {
 				}}
 			}
 			allocs := []*structs.Allocation{alloc}
-			require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+			require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 			// Create a mock evaluation to deal with drain
 			evals := []*structs.Evaluation{{
@@ -2950,7 +2950,7 @@ func TestServiceSched_NodeUpdate(t *testing.T) {
 		alloc.Name = fmt.Sprintf("my-job.web[%d]", i)
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Mark some allocs as running
 	ws := memdb.NewWatchSet()
@@ -3012,7 +3012,7 @@ func TestServiceSched_NodeDrain(t *testing.T) {
 		alloc.DesiredTransition.Migrate = helper.BoolToPtr(true)
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -3088,7 +3088,7 @@ func TestServiceSched_NodeDrain_Down(t *testing.T) {
 		alloc.Name = fmt.Sprintf("my-job.web[%d]", i)
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Set the desired state of the allocs to stop
 	var stop []*structs.Allocation
@@ -3098,7 +3098,7 @@ func TestServiceSched_NodeDrain_Down(t *testing.T) {
 		newAlloc.DesiredTransition.Migrate = helper.BoolToPtr(true)
 		stop = append(stop, newAlloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), stop))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), stop))
 
 	// Mark some of the allocations as running
 	var running []*structs.Allocation
@@ -3201,7 +3201,7 @@ func TestServiceSched_NodeDrain_Queued_Allocations(t *testing.T) {
 		alloc.DesiredTransition.Migrate = helper.BoolToPtr(true)
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	node.Drain = true
 	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
@@ -3323,7 +3323,7 @@ func TestServiceSched_Reschedule_OnceNow(t *testing.T) {
 	failedAllocID := allocs[1].ID
 	successAllocID := allocs[0].ID
 
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Create a mock evaluation
 	eval := &structs.Evaluation{
@@ -3368,7 +3368,7 @@ func TestServiceSched_Reschedule_OnceNow(t *testing.T) {
 	// Mark this alloc as failed again, should not get rescheduled
 	newAlloc.ClientStatus = structs.AllocClientStatusFailed
 
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{newAlloc}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{newAlloc}))
 
 	// Create another mock evaluation
 	eval = &structs.Evaluation{
@@ -3435,7 +3435,7 @@ func TestServiceSched_Reschedule_Later(t *testing.T) {
 		FinishedAt: now}}
 	failedAllocID := allocs[1].ID
 
-	require.NoError(h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Create a mock evaluation
 	eval := &structs.Evaluation{
@@ -3522,7 +3522,7 @@ func TestServiceSched_Reschedule_MultipleNow(t *testing.T) {
 		StartedAt:  now.Add(-1 * time.Hour),
 		FinishedAt: now.Add(-10 * time.Second)}}
 
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Create a mock evaluation
 	eval := &structs.Evaluation{
@@ -3593,7 +3593,7 @@ func TestServiceSched_Reschedule_MultipleNow(t *testing.T) {
 		failedAllocId = newAlloc.ID
 		failedNodeID = newAlloc.NodeID
 
-		require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{newAlloc}))
+		require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{newAlloc}))
 
 		// Create another mock evaluation
 		eval = &structs.Evaluation{
@@ -3698,7 +3698,7 @@ func TestServiceSched_Reschedule_PruneEvents(t *testing.T) {
 	failedAllocID := allocs[1].ID
 	successAllocID := allocs[0].ID
 
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Create a mock evaluation
 	eval := &structs.Evaluation{
@@ -3802,7 +3802,7 @@ func TestDeployment_FailedAllocs_Reschedule(t *testing.T) {
 				FinishedAt: time.Now().Add(-10 * time.Hour)}}
 			allocs[1].DesiredTransition.Reschedule = helper.BoolToPtr(true)
 
-			require.Nil(h.State.UpsertAllocs(h.NextIndex(), allocs))
+			require.Nil(h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 			// Create a mock evaluation
 			eval := &structs.Evaluation{
@@ -3858,7 +3858,7 @@ func TestBatchSched_Run_CompleteAlloc(t *testing.T) {
 	alloc.NodeID = node.ID
 	alloc.Name = "my-job.web[0]"
 	alloc.ClientStatus = structs.AllocClientStatusComplete
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -3921,7 +3921,7 @@ func TestBatchSched_Run_FailedAlloc(t *testing.T) {
 	alloc.TaskStates = map[string]*structs.TaskState{tgName: {State: "dead",
 		StartedAt:  now.Add(-1 * time.Hour),
 		FinishedAt: now.Add(-10 * time.Second)}}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -4004,7 +4004,7 @@ func TestBatchSched_Run_LostAlloc(t *testing.T) {
 	alloc.DesiredStatus = structs.AllocDesiredStatusStop
 	alloc.ClientStatus = structs.AllocClientStatusComplete
 	allocs = append(allocs, alloc)
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -4079,7 +4079,7 @@ func TestBatchSched_Run_FailedAllocQueuedAllocations(t *testing.T) {
 	alloc.TaskStates = map[string]*structs.TaskState{tgName: {State: "dead",
 		StartedAt:  now.Add(-1 * time.Hour),
 		FinishedAt: now.Add(-10 * time.Second)}}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -4141,7 +4141,7 @@ func TestBatchSched_ReRun_SuccessfullyFinishedAlloc(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create a mock evaluation to rerun the job
 	eval := &structs.Evaluation{
@@ -4206,7 +4206,7 @@ func TestBatchSched_JobModify_InPlace_Terminal(t *testing.T) {
 		alloc.ClientStatus = structs.AllocClientStatusComplete
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Create a mock evaluation to trigger the job
 	eval := &structs.Evaluation{
@@ -4258,7 +4258,7 @@ func TestBatchSched_JobModify_Destructive_Terminal(t *testing.T) {
 		alloc.ClientStatus = structs.AllocClientStatusComplete
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Update the job
 	job2 := mock.Job()
@@ -4289,7 +4289,7 @@ func TestBatchSched_JobModify_Destructive_Terminal(t *testing.T) {
 		}
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -4340,7 +4340,7 @@ func TestBatchSched_NodeDrain_Running_OldJob(t *testing.T) {
 	alloc.NodeID = node.ID
 	alloc.Name = "my-job.web[0]"
 	alloc.ClientStatus = structs.AllocClientStatusRunning
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create an update job
 	job2 := job.Copy()
@@ -4422,7 +4422,7 @@ func TestBatchSched_NodeDrain_Complete(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -4490,7 +4490,7 @@ func TestBatchSched_ScaleDown_SameName(t *testing.T) {
 		alloc.Metrics = scoreMetric
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Update the job's modify index to force an inplace upgrade
 	updatedJob := job.Copy()
@@ -4758,7 +4758,7 @@ func TestServiceSched_NodeDrain_Sticky(t *testing.T) {
 	alloc.Job.TaskGroups[0].EphemeralDisk.Sticky = true
 	alloc.DesiredTransition.Migrate = helper.BoolToPtr(true)
 	require.NoError(t, h.State.UpsertJob(h.NextIndex(), alloc.Job))
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -5384,7 +5384,7 @@ func TestServiceSched_Migrate_NonCanary(t *testing.T) {
 	alloc.DesiredStatus = structs.AllocDesiredStatusRun
 	alloc.ClientStatus = structs.AllocClientStatusRunning
 	alloc.DesiredTransition.Migrate = helper.BoolToPtr(true)
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create a mock evaluation
 	eval := &structs.Evaluation{
@@ -5458,7 +5458,7 @@ func TestServiceSched_Migrate_CanaryStatus(t *testing.T) {
 		alloc.Name = fmt.Sprintf("my-job.web[%d]", i)
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// new update with new task group
 	job2 := job.Copy()
@@ -5609,7 +5609,7 @@ func TestServiceSched_RunningWithNextAllocation(t *testing.T) {
 	// simulate a case where .NextAllocation is set but alloc is still running
 	allocs[2].PreviousAllocation = allocs[0].ID
 	allocs[0].NextAllocation = allocs[2].ID
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// new update with new task group
 	job2 := job.Copy()

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -23,7 +23,7 @@ func TestServiceSched_JobRegister(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job
@@ -113,7 +113,7 @@ func TestServiceSched_JobRegister_StickyAllocs(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job
@@ -204,7 +204,7 @@ func TestServiceSched_JobRegister_DiskConstraints(t *testing.T) {
 
 	// Create a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create a job with count 2 and disk as 60GB so that only one allocation
 	// can fit
@@ -279,7 +279,7 @@ func TestServiceSched_JobRegister_DistinctHosts(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job that uses distinct host and has count 1 higher than what is
@@ -366,7 +366,7 @@ func TestServiceSched_JobRegister_DistinctProperty(t *testing.T) {
 			rack = "rack1"
 		}
 		node.Meta["rack"] = rack
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job that uses distinct property and has count higher than what is
@@ -459,7 +459,7 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		node := mock.Node()
 		node.Meta["ssd"] = "true"
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job that uses distinct property only on one task group.
@@ -550,7 +550,7 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup_Incr(t *testing.T) 
 	for i := 0; i < 6; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		assert.Nil(h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()), "UpsertNode")
+		assert.Nil(h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node), "UpsertNode")
 	}
 
 	// Create some allocations
@@ -653,7 +653,7 @@ func TestServiceSched_Spread(t *testing.T) {
 					node.Datacenter = "dc2"
 				}
 				nodes = append(nodes, node)
-				assert.Nil(h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()), "UpsertNode")
+				assert.Nil(h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node), "UpsertNode")
 				nodeMap[node.ID] = node
 			}
 
@@ -730,7 +730,7 @@ func TestServiceSched_EvenSpread(t *testing.T) {
 			node.Datacenter = "dc2"
 		}
 		nodes = append(nodes, node)
-		assert.Nil(h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()), "UpsertNode")
+		assert.Nil(h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node), "UpsertNode")
 		nodeMap[node.ID] = node
 	}
 
@@ -786,7 +786,7 @@ func TestServiceSched_JobRegister_Annotate(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job
@@ -865,7 +865,7 @@ func TestServiceSched_JobRegister_CountZero(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job and set the task group count to zero.
@@ -993,13 +993,13 @@ func TestServiceSched_JobRegister_CreateBlockedEval(t *testing.T) {
 		},
 	}
 	node.ComputeClass()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create an ineligible node
 	node2 := mock.Node()
 	node2.Attributes["kernel.name"] = "windows"
 	node2.ComputeClass()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node2, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node2))
 
 	// Create a jobs
 	job := mock.Job()
@@ -1087,7 +1087,7 @@ func TestServiceSched_JobRegister_FeasibleAndInfeasibleTG(t *testing.T) {
 	node := mock.Node()
 	node.NodeClass = "class_0"
 	require.NoError(t, node.ComputeClass())
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create a job that constrains on a node class
 	job := mock.Job()
@@ -1214,7 +1214,7 @@ func TestServiceSched_Plan_Partial_Progress(t *testing.T) {
 
 	// Create a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create a job with a high resource ask so that all the allocations can't
 	// be placed on a single node.
@@ -1330,7 +1330,7 @@ func TestServiceSched_EvaluateBlockedEval_Finished(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job and set the task group count to zero.
@@ -1416,7 +1416,7 @@ func TestServiceSched_JobModify(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations
@@ -1519,7 +1519,7 @@ func TestServiceSched_JobModify_IncrCount_NodeLimit(t *testing.T) {
 	// Create one node
 	node := mock.Node()
 	node.NodeResources.Cpu.CpuShares = 1000
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Generate a fake job with one allocation
 	job := mock.Job()
@@ -1613,7 +1613,7 @@ func TestServiceSched_JobModify_CountZero(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations
@@ -1713,7 +1713,7 @@ func TestServiceSched_JobModify_Rolling(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations
@@ -1817,7 +1817,7 @@ func TestServiceSched_JobModify_Rolling_FullNode(t *testing.T) {
 	// Create a node and clear the reserved resources
 	node := mock.Node()
 	node.ReservedResources = nil
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create a resource ask that is the same as the resources available on the
 	// node
@@ -1939,7 +1939,7 @@ func TestServiceSched_JobModify_Canaries(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations
@@ -2063,7 +2063,7 @@ func TestServiceSched_JobModify_InPlace(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations and create an older deployment
@@ -2203,7 +2203,7 @@ func TestServiceSched_JobModify_InPlace08(t *testing.T) {
 
 	// Create node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Generate a fake job with 0.8 allocations
 	job := mock.Job()
@@ -2284,7 +2284,7 @@ func TestServiceSched_JobModify_DistinctProperty(t *testing.T) {
 		node := mock.Node()
 		node.Meta["rack"] = fmt.Sprintf("rack%d", i)
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job that uses distinct property and has count higher than what is
@@ -2396,7 +2396,7 @@ func TestServiceSched_JobModify_NodeReschedulePenalty(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations and an update policy.
@@ -2705,7 +2705,7 @@ func TestServiceSched_NodeDown(t *testing.T) {
 			// Register a node
 			node := mock.Node()
 			node.Status = structs.NodeStatusDown
-			require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+			require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 			// Generate a fake job with allocations and an update policy.
 			job := mock.Job()
@@ -2801,7 +2801,7 @@ func TestServiceSched_StopAfterClientDisconnect(t *testing.T) {
 			// Node, which is down
 			node := mock.Node()
 			node.Status = structs.NodeStatusDown
-			require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+			require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 			// Job with allocations and stop_after_client_disconnect
 			job := mock.Job()
@@ -2885,7 +2885,7 @@ func TestServiceSched_StopAfterClientDisconnect(t *testing.T) {
 			if tc.rescheduled {
 				// Register a new node, leave it up, process the followup eval
 				node = mock.Node()
-				require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+				require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 				require.NoError(t, h.Process(NewServiceScheduler, eval))
 
 				as, err := h.State.AllocsByJob(ws, job.Namespace, job.ID, false)
@@ -2935,7 +2935,7 @@ func TestServiceSched_NodeUpdate(t *testing.T) {
 
 	// Register a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Generate a fake job with allocations and an update policy.
 	job := mock.Job()
@@ -2990,12 +2990,12 @@ func TestServiceSched_NodeDrain(t *testing.T) {
 	// Register a draining node
 	node := mock.Node()
 	node.Drain = true
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations and an update policy.
@@ -3073,7 +3073,7 @@ func TestServiceSched_NodeDrain_Down(t *testing.T) {
 	node := mock.Node()
 	node.Drain = true
 	node.Status = structs.NodeStatusDown
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Generate a fake job with allocations
 	job := mock.Job()
@@ -3184,7 +3184,7 @@ func TestServiceSched_NodeDrain_Queued_Allocations(t *testing.T) {
 
 	// Register a draining node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Generate a fake job with allocations and an update policy.
 	job := mock.Job()
@@ -3204,7 +3204,7 @@ func TestServiceSched_NodeDrain_Queued_Allocations(t *testing.T) {
 	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	node.Drain = true
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -3237,7 +3237,7 @@ func TestServiceSched_RetryLimit(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job
@@ -3288,7 +3288,7 @@ func TestServiceSched_Reschedule_OnceNow(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations and an update policy.
@@ -3400,7 +3400,7 @@ func TestServiceSched_Reschedule_Later(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations and an update policy.
@@ -3488,7 +3488,7 @@ func TestServiceSched_Reschedule_MultipleNow(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	maxRestartAttempts := 3
@@ -3629,7 +3629,7 @@ func TestServiceSched_Reschedule_PruneEvents(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations and an update policy.
@@ -3762,7 +3762,7 @@ func TestDeployment_FailedAllocs_Reschedule(t *testing.T) {
 			for i := 0; i < 10; i++ {
 				node := mock.Node()
 				nodes = append(nodes, node)
-				require.NoError(h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+				require.NoError(h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 			}
 
 			// Generate a fake job with allocations and a reschedule policy.
@@ -3843,7 +3843,7 @@ func TestBatchSched_Run_CompleteAlloc(t *testing.T) {
 
 	// Create a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create a job
 	job := mock.Job()
@@ -3900,7 +3900,7 @@ func TestBatchSched_Run_FailedAlloc(t *testing.T) {
 
 	// Create a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create a job
 	job := mock.Job()
@@ -3970,7 +3970,7 @@ func TestBatchSched_Run_LostAlloc(t *testing.T) {
 
 	// Create a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create a job
 	job := mock.Job()
@@ -4058,7 +4058,7 @@ func TestBatchSched_Run_FailedAllocQueuedAllocations(t *testing.T) {
 
 	node := mock.Node()
 	node.Drain = true
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create a job
 	job := mock.Job()
@@ -4114,8 +4114,8 @@ func TestBatchSched_ReRun_SuccessfullyFinishedAlloc(t *testing.T) {
 	node := mock.Node()
 	node.Drain = true
 	node2 := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node2, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node2))
 
 	// Create a job
 	job := mock.Job()
@@ -4188,7 +4188,7 @@ func TestBatchSched_JobModify_InPlace_Terminal(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations
@@ -4240,7 +4240,7 @@ func TestBatchSched_JobModify_Destructive_Terminal(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations
@@ -4324,8 +4324,8 @@ func TestBatchSched_NodeDrain_Running_OldJob(t *testing.T) {
 	node := mock.Node()
 	node.Drain = true
 	node2 := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node2, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node2))
 
 	// Create a job
 	job := mock.Job()
@@ -4396,8 +4396,8 @@ func TestBatchSched_NodeDrain_Complete(t *testing.T) {
 	node := mock.Node()
 	node.Drain = true
 	node2 := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node2, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node2))
 
 	// Create a job
 	job := mock.Job()
@@ -4458,7 +4458,7 @@ func TestBatchSched_ScaleDown_SameName(t *testing.T) {
 
 	// Create a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create a job
 	job := mock.Job()
@@ -4611,7 +4611,7 @@ func TestGenericSched_AllocFit(t *testing.T) {
 			h := NewHarness(t)
 			node := mock.Node()
 			node.NodeResources.Cpu.CpuShares = testCase.NodeCpu
-			require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+			require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 			// Create a job with sidecar & init tasks
 			job := mock.VariableLifecycleJob(testCase.TaskResources, testCase.MainTaskCount, testCase.InitTaskCount, testCase.SideTaskCount)
@@ -4659,7 +4659,7 @@ func TestGenericSched_ChainedAlloc(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job
@@ -4748,7 +4748,7 @@ func TestServiceSched_NodeDrain_Sticky(t *testing.T) {
 	// Register a draining node
 	node := mock.Node()
 	node.Drain = true
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create an alloc on the draining node
 	alloc := mock.Alloc()
@@ -5225,7 +5225,7 @@ func TestServiceSched_Preemption(t *testing.T) {
 			ReservedHostPorts: "22",
 		},
 	}
-	require.NoError(h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create a couple of jobs and schedule them
 	job1 := mock.Job()
@@ -5349,7 +5349,7 @@ func TestServiceSched_Migrate_NonCanary(t *testing.T) {
 	h := NewHarness(t)
 
 	node1 := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node1, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node1))
 
 	job := mock.Job()
 	job.Stable = true
@@ -5419,7 +5419,7 @@ func TestServiceSched_Migrate_CanaryStatus(t *testing.T) {
 	h := NewHarness(t)
 
 	node1 := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node1, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node1))
 
 	totalCount := 3
 	desiredCanaries := 1
@@ -5515,10 +5515,10 @@ func TestServiceSched_Migrate_CanaryStatus(t *testing.T) {
 	// now, drain node1 and ensure all are migrated to node2
 	node1 = node1.Copy()
 	node1.Status = structs.NodeStatusDown
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node1, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node1))
 
 	node2 := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node2, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node2))
 
 	neval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
@@ -5586,7 +5586,7 @@ func TestServiceSched_RunningWithNextAllocation(t *testing.T) {
 	h := NewHarness(t)
 
 	node1 := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node1, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node1))
 
 	totalCount := 2
 	job := mock.Job()

--- a/scheduler/preemption_test.go
+++ b/scheduler/preemption_test.go
@@ -1337,7 +1337,7 @@ func TestPreemption(t *testing.T) {
 					Node: node,
 				},
 			}
-			state.UpsertNode(1000, node)
+			state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
 			for _, alloc := range tc.currentAllocations {
 				alloc.NodeID = node.ID
 			}

--- a/scheduler/preemption_test.go
+++ b/scheduler/preemption_test.go
@@ -1337,7 +1337,7 @@ func TestPreemption(t *testing.T) {
 					Node: node,
 				},
 			}
-			state.UpsertNode(structs.MsgTypeTestSetup, node, 1000)
+			state.UpsertNode(structs.MsgTypeTestSetup, 1000, node)
 			for _, alloc := range tc.currentAllocations {
 				alloc.NodeID = node.ID
 			}

--- a/scheduler/preemption_test.go
+++ b/scheduler/preemption_test.go
@@ -1342,7 +1342,7 @@ func TestPreemption(t *testing.T) {
 				alloc.NodeID = node.ID
 			}
 			require := require.New(t)
-			err := state.UpsertAllocs(1001, tc.currentAllocations)
+			err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, tc.currentAllocations)
 
 			require.Nil(err)
 			if tc.currentPreemptions != nil {

--- a/scheduler/rank_test.go
+++ b/scheduler/rank_test.go
@@ -673,7 +673,7 @@ func TestBinPackIterator_ExistingAlloc(t *testing.T) {
 	}
 	require.NoError(t, state.UpsertJobSummary(998, mock.JobSummary(alloc1.JobID)))
 	require.NoError(t, state.UpsertJobSummary(999, mock.JobSummary(alloc2.JobID)))
-	require.NoError(t, state.UpsertAllocs(1000, []*structs.Allocation{alloc1, alloc2}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1, alloc2}))
 
 	taskGroup := &structs.TaskGroup{
 		EphemeralDisk: &structs.EphemeralDisk{},
@@ -788,7 +788,7 @@ func TestBinPackIterator_ExistingAlloc_PlannedEvict(t *testing.T) {
 	}
 	require.NoError(t, state.UpsertJobSummary(998, mock.JobSummary(alloc1.JobID)))
 	require.NoError(t, state.UpsertJobSummary(999, mock.JobSummary(alloc2.JobID)))
-	require.NoError(t, state.UpsertAllocs(1000, []*structs.Allocation{alloc1, alloc2}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1, alloc2}))
 
 	// Add a planned eviction to alloc1
 	plan := ctx.Plan()
@@ -1108,7 +1108,7 @@ func TestBinPackIterator_Devices(t *testing.T) {
 				for _, alloc := range c.ExistingAllocs {
 					alloc.NodeID = c.Node.ID
 				}
-				require.NoError(state.UpsertAllocs(1000, c.ExistingAllocs))
+				require.NoError(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, c.ExistingAllocs))
 			}
 
 			static := NewStaticRankIterator(ctx, []*RankedNode{{Node: c.Node}})

--- a/scheduler/spread_test.go
+++ b/scheduler/spread_test.go
@@ -21,7 +21,7 @@ func TestSpreadIterator_SingleAttribute(t *testing.T) {
 	for i, dc := range dcs {
 		node := mock.Node()
 		node.Datacenter = dc
-		if err := state.UpsertNode(structs.MsgTypeTestSetup, node, uint64(100+i)); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, uint64(100+i), node); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 		nodes = append(nodes, &RankedNode{Node: node})
@@ -181,7 +181,7 @@ func TestSpreadIterator_MultipleAttributes(t *testing.T) {
 		node := mock.Node()
 		node.Datacenter = dc
 		node.Meta["rack"] = rack[i]
-		if err := state.UpsertNode(structs.MsgTypeTestSetup, node, uint64(100+i)); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, uint64(100+i), node); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 		nodes = append(nodes, &RankedNode{Node: node})
@@ -280,7 +280,7 @@ func TestSpreadIterator_EvenSpread(t *testing.T) {
 	for i, dc := range dcs {
 		node := mock.Node()
 		node.Datacenter = dc
-		if err := state.UpsertNode(structs.MsgTypeTestSetup, node, uint64(100+i)); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, uint64(100+i), node); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 		nodes = append(nodes, &RankedNode{Node: node})
@@ -416,7 +416,7 @@ func TestSpreadIterator_EvenSpread(t *testing.T) {
 	// Add another node in dc3
 	node := mock.Node()
 	node.Datacenter = "dc3"
-	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, uint64(1111)); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, uint64(1111), node); err != nil {
 		t.Fatalf("failed to upsert node: %v", err)
 	}
 	nodes = append(nodes, &RankedNode{Node: node})
@@ -467,7 +467,7 @@ func TestSpreadIterator_MaxPenalty(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		node := mock.Node()
 		node.Datacenter = "dc3"
-		if err := state.UpsertNode(structs.MsgTypeTestSetup, node, uint64(100+i)); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, uint64(100+i), node); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 		nodes = append(nodes, &RankedNode{Node: node})

--- a/scheduler/spread_test.go
+++ b/scheduler/spread_test.go
@@ -54,7 +54,7 @@ func TestSpreadIterator_SingleAttribute(t *testing.T) {
 		},
 	}
 
-	if err := state.UpsertAllocs(1000, upserting); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, upserting); err != nil {
 		t.Fatalf("failed to UpsertAllocs: %v", err)
 	}
 
@@ -214,7 +214,7 @@ func TestSpreadIterator_MultipleAttributes(t *testing.T) {
 		},
 	}
 
-	if err := state.UpsertAllocs(1000, upserting); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, upserting); err != nil {
 		t.Fatalf("failed to UpsertAllocs: %v", err)
 	}
 

--- a/scheduler/spread_test.go
+++ b/scheduler/spread_test.go
@@ -21,7 +21,7 @@ func TestSpreadIterator_SingleAttribute(t *testing.T) {
 	for i, dc := range dcs {
 		node := mock.Node()
 		node.Datacenter = dc
-		if err := state.UpsertNode(uint64(100+i), node); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, node, uint64(100+i)); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 		nodes = append(nodes, &RankedNode{Node: node})
@@ -181,7 +181,7 @@ func TestSpreadIterator_MultipleAttributes(t *testing.T) {
 		node := mock.Node()
 		node.Datacenter = dc
 		node.Meta["rack"] = rack[i]
-		if err := state.UpsertNode(uint64(100+i), node); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, node, uint64(100+i)); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 		nodes = append(nodes, &RankedNode{Node: node})
@@ -280,7 +280,7 @@ func TestSpreadIterator_EvenSpread(t *testing.T) {
 	for i, dc := range dcs {
 		node := mock.Node()
 		node.Datacenter = dc
-		if err := state.UpsertNode(uint64(100+i), node); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, node, uint64(100+i)); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 		nodes = append(nodes, &RankedNode{Node: node})
@@ -416,7 +416,7 @@ func TestSpreadIterator_EvenSpread(t *testing.T) {
 	// Add another node in dc3
 	node := mock.Node()
 	node.Datacenter = "dc3"
-	if err := state.UpsertNode(uint64(1111), node); err != nil {
+	if err := state.UpsertNode(structs.MsgTypeTestSetup, node, uint64(1111)); err != nil {
 		t.Fatalf("failed to upsert node: %v", err)
 	}
 	nodes = append(nodes, &RankedNode{Node: node})
@@ -467,7 +467,7 @@ func TestSpreadIterator_MaxPenalty(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		node := mock.Node()
 		node.Datacenter = "dc3"
-		if err := state.UpsertNode(uint64(100+i), node); err != nil {
+		if err := state.UpsertNode(structs.MsgTypeTestSetup, node, uint64(100+i)); err != nil {
 			t.Fatalf("failed to upsert node: %v", err)
 		}
 		nodes = append(nodes, &RankedNode{Node: node})

--- a/scheduler/stack_test.go
+++ b/scheduler/stack_test.go
@@ -272,7 +272,7 @@ func TestServiceStack_Select_CSI(t *testing.T) {
 	}}
 
 	// Add the node to the state store to index the healthy plugins and mark the volume "foo" healthy
-	err = state.UpsertNode(1000, zero)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, zero, 1000)
 	require.NoError(t, err)
 
 	// Use the node to build the stack and test

--- a/scheduler/stack_test.go
+++ b/scheduler/stack_test.go
@@ -272,7 +272,7 @@ func TestServiceStack_Select_CSI(t *testing.T) {
 	}}
 
 	// Add the node to the state store to index the healthy plugins and mark the volume "foo" healthy
-	err = state.UpsertNode(structs.MsgTypeTestSetup, zero, 1000)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, 1000, zero)
 	require.NoError(t, err)
 
 	// Use the node to build the stack and test

--- a/scheduler/system_sched_test.go
+++ b/scheduler/system_sched_test.go
@@ -21,7 +21,7 @@ func TestSystemSched_JobRegister(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job
@@ -95,7 +95,7 @@ func TestSystemSched_JobRegister_StickyAllocs(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job
@@ -170,7 +170,7 @@ func TestSystemSched_JobRegister_EphemeralDiskConstraint(t *testing.T) {
 
 	// Create a nodes
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create a job
 	job := mock.SystemJob()
@@ -239,7 +239,7 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 
 	// Create a nodes
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Enable Preemption
 	h.State.SchedulerSetConfig(h.NextIndex(), &structs.SchedulerConfiguration{
@@ -324,7 +324,7 @@ func TestSystemSched_JobRegister_Annotate(t *testing.T) {
 			node.NodeClass = "bar"
 		}
 		node.ComputeClass()
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job constraining on node class
@@ -416,7 +416,7 @@ func TestSystemSched_JobRegister_AddNode(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations
@@ -436,7 +436,7 @@ func TestSystemSched_JobRegister_AddNode(t *testing.T) {
 
 	// Add a new node.
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Create a mock evaluation to deal with the node update
 	eval := &structs.Evaluation{
@@ -538,7 +538,7 @@ func TestSystemSched_JobModify(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations
@@ -640,7 +640,7 @@ func TestSystemSched_JobModify_Rolling(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations
@@ -743,7 +743,7 @@ func TestSystemSched_JobModify_InPlace(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations
@@ -842,7 +842,7 @@ func TestSystemSched_JobDeregister_Purged(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations
@@ -914,7 +914,7 @@ func TestSystemSched_JobDeregister_Stopped(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Generate a fake job with allocations
@@ -986,7 +986,7 @@ func TestSystemSched_NodeDown(t *testing.T) {
 	// Register a down node
 	node := mock.Node()
 	node.Status = structs.NodeStatusDown
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
@@ -1054,7 +1054,7 @@ func TestSystemSched_NodeDrain_Down(t *testing.T) {
 	node := mock.Node()
 	node.Drain = true
 	node.Status = structs.NodeStatusDown
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
@@ -1115,7 +1115,7 @@ func TestSystemSched_NodeDrain(t *testing.T) {
 	// Register a draining node
 	node := mock.Node()
 	node.Drain = true
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
@@ -1181,7 +1181,7 @@ func TestSystemSched_NodeUpdate(t *testing.T) {
 
 	// Register a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
@@ -1227,7 +1227,7 @@ func TestSystemSched_RetryLimit(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job
@@ -1279,7 +1279,7 @@ func TestSystemSched_Queued_With_Constraints(t *testing.T) {
 	// Register a node
 	node := mock.Node()
 	node.Attributes["kernel.name"] = "darwin"
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Generate a system job which can't be placed on the node
 	job := mock.SystemJob()
@@ -1323,13 +1323,13 @@ func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
 	node = mock.Node()
 	node.NodeClass = "Class-A"
 	node.ComputeClass()
-	require.Nil(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.Nil(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	var nodeB *structs.Node
 	nodeB = mock.Node()
 	nodeB.NodeClass = "Class-B"
 	nodeB.ComputeClass()
-	require.Nil(t, h.State.UpsertNode(structs.MsgTypeTestSetup, nodeB, h.NextIndex()))
+	require.Nil(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), nodeB))
 
 	// Make a job with two task groups, each constraint to a node class
 	job := mock.SystemJob()
@@ -1416,7 +1416,7 @@ func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
 	nodeBTwo = mock.Node()
 	nodeBTwo.ComputeClass()
 	nodeBTwo.NodeClass = "Class-B"
-	require.Nil(t, h.State.UpsertNode(structs.MsgTypeTestSetup, nodeBTwo, h.NextIndex()))
+	require.Nil(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), nodeBTwo))
 
 	// Evaluate the new node
 	eval3 := &structs.Evaluation{
@@ -1468,7 +1468,7 @@ func TestSystemSched_ExistingAllocNoNodes(t *testing.T) {
 	// Create a node
 	node = mock.Node()
 	node.ComputeClass()
-	require.Nil(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.Nil(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	// Make a job
 	job := mock.SystemJob()
@@ -1550,7 +1550,7 @@ func TestSystemSched_ConstraintErrors(t *testing.T) {
 		node = mock.Node()
 		node.Meta["tag"] = tag
 		node.ComputeClass()
-		require.Nil(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.Nil(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Mark the last node as ineligible
@@ -1616,7 +1616,7 @@ func TestSystemSched_ChainedAlloc(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a job
@@ -1657,7 +1657,7 @@ func TestSystemSched_ChainedAlloc(t *testing.T) {
 	// Insert two more nodes
 	for i := 0; i < 2; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 	}
 
 	// Create a mock evaluation to update the job
@@ -1712,12 +1712,12 @@ func TestSystemSched_PlanWithDrainedNode(t *testing.T) {
 	node.NodeClass = "green"
 	node.Drain = true
 	node.ComputeClass()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	node2 := mock.Node()
 	node2.NodeClass = "blue"
 	node2.ComputeClass()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node2, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node2))
 
 	// Create a Job with two task groups, each constrained on node class
 	job := mock.SystemJob()
@@ -1802,12 +1802,12 @@ func TestSystemSched_QueuedAllocsMultTG(t *testing.T) {
 	node := mock.Node()
 	node.NodeClass = "green"
 	node.ComputeClass()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 
 	node2 := mock.Node()
 	node2.NodeClass = "blue"
 	node2.ComputeClass()
-	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node2, h.NextIndex()))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node2))
 
 	// Create a Job with two task groups, each constrained on node class
 	job := mock.SystemJob()
@@ -1907,7 +1907,7 @@ func TestSystemSched_Preemption(t *testing.T) {
 				},
 			},
 		}
-		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 		nodes = append(nodes, node)
 	}
 

--- a/scheduler/system_sched_test.go
+++ b/scheduler/system_sched_test.go
@@ -21,7 +21,7 @@ func TestSystemSched_JobRegister(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job
@@ -95,7 +95,7 @@ func TestSystemSched_JobRegister_StickyAllocs(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job
@@ -170,7 +170,7 @@ func TestSystemSched_JobRegister_EphemeralDiskConstraint(t *testing.T) {
 
 	// Create a nodes
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create a job
 	job := mock.SystemJob()
@@ -239,7 +239,7 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 
 	// Create a nodes
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Enable Preemption
 	h.State.SchedulerSetConfig(h.NextIndex(), &structs.SchedulerConfiguration{
@@ -324,7 +324,7 @@ func TestSystemSched_JobRegister_Annotate(t *testing.T) {
 			node.NodeClass = "bar"
 		}
 		node.ComputeClass()
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job constraining on node class
@@ -416,7 +416,7 @@ func TestSystemSched_JobRegister_AddNode(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations
@@ -436,7 +436,7 @@ func TestSystemSched_JobRegister_AddNode(t *testing.T) {
 
 	// Add a new node.
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Create a mock evaluation to deal with the node update
 	eval := &structs.Evaluation{
@@ -538,7 +538,7 @@ func TestSystemSched_JobModify(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations
@@ -640,7 +640,7 @@ func TestSystemSched_JobModify_Rolling(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations
@@ -743,7 +743,7 @@ func TestSystemSched_JobModify_InPlace(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations
@@ -842,7 +842,7 @@ func TestSystemSched_JobDeregister_Purged(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations
@@ -914,7 +914,7 @@ func TestSystemSched_JobDeregister_Stopped(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
 		nodes = append(nodes, node)
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Generate a fake job with allocations
@@ -986,7 +986,7 @@ func TestSystemSched_NodeDown(t *testing.T) {
 	// Register a down node
 	node := mock.Node()
 	node.Status = structs.NodeStatusDown
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
@@ -1054,7 +1054,7 @@ func TestSystemSched_NodeDrain_Down(t *testing.T) {
 	node := mock.Node()
 	node.Drain = true
 	node.Status = structs.NodeStatusDown
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
@@ -1115,7 +1115,7 @@ func TestSystemSched_NodeDrain(t *testing.T) {
 	// Register a draining node
 	node := mock.Node()
 	node.Drain = true
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
@@ -1181,7 +1181,7 @@ func TestSystemSched_NodeUpdate(t *testing.T) {
 
 	// Register a node
 	node := mock.Node()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
@@ -1227,7 +1227,7 @@ func TestSystemSched_RetryLimit(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job
@@ -1279,7 +1279,7 @@ func TestSystemSched_Queued_With_Constraints(t *testing.T) {
 	// Register a node
 	node := mock.Node()
 	node.Attributes["kernel.name"] = "darwin"
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Generate a system job which can't be placed on the node
 	job := mock.SystemJob()
@@ -1323,13 +1323,13 @@ func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
 	node = mock.Node()
 	node.NodeClass = "Class-A"
 	node.ComputeClass()
-	require.Nil(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.Nil(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	var nodeB *structs.Node
 	nodeB = mock.Node()
 	nodeB.NodeClass = "Class-B"
 	nodeB.ComputeClass()
-	require.Nil(t, h.State.UpsertNode(h.NextIndex(), nodeB))
+	require.Nil(t, h.State.UpsertNode(structs.MsgTypeTestSetup, nodeB, h.NextIndex()))
 
 	// Make a job with two task groups, each constraint to a node class
 	job := mock.SystemJob()
@@ -1416,7 +1416,7 @@ func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
 	nodeBTwo = mock.Node()
 	nodeBTwo.ComputeClass()
 	nodeBTwo.NodeClass = "Class-B"
-	require.Nil(t, h.State.UpsertNode(h.NextIndex(), nodeBTwo))
+	require.Nil(t, h.State.UpsertNode(structs.MsgTypeTestSetup, nodeBTwo, h.NextIndex()))
 
 	// Evaluate the new node
 	eval3 := &structs.Evaluation{
@@ -1468,7 +1468,7 @@ func TestSystemSched_ExistingAllocNoNodes(t *testing.T) {
 	// Create a node
 	node = mock.Node()
 	node.ComputeClass()
-	require.Nil(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.Nil(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	// Make a job
 	job := mock.SystemJob()
@@ -1550,7 +1550,7 @@ func TestSystemSched_ConstraintErrors(t *testing.T) {
 		node = mock.Node()
 		node.Meta["tag"] = tag
 		node.ComputeClass()
-		require.Nil(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.Nil(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Mark the last node as ineligible
@@ -1616,7 +1616,7 @@ func TestSystemSched_ChainedAlloc(t *testing.T) {
 	// Create some nodes
 	for i := 0; i < 10; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a job
@@ -1657,7 +1657,7 @@ func TestSystemSched_ChainedAlloc(t *testing.T) {
 	// Insert two more nodes
 	for i := 0; i < 2; i++ {
 		node := mock.Node()
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 	}
 
 	// Create a mock evaluation to update the job
@@ -1712,12 +1712,12 @@ func TestSystemSched_PlanWithDrainedNode(t *testing.T) {
 	node.NodeClass = "green"
 	node.Drain = true
 	node.ComputeClass()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	node2 := mock.Node()
 	node2.NodeClass = "blue"
 	node2.ComputeClass()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node2))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node2, h.NextIndex()))
 
 	// Create a Job with two task groups, each constrained on node class
 	job := mock.SystemJob()
@@ -1802,12 +1802,12 @@ func TestSystemSched_QueuedAllocsMultTG(t *testing.T) {
 	node := mock.Node()
 	node.NodeClass = "green"
 	node.ComputeClass()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 
 	node2 := mock.Node()
 	node2.NodeClass = "blue"
 	node2.ComputeClass()
-	require.NoError(t, h.State.UpsertNode(h.NextIndex(), node2))
+	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node2, h.NextIndex()))
 
 	// Create a Job with two task groups, each constrained on node class
 	job := mock.SystemJob()
@@ -1907,7 +1907,7 @@ func TestSystemSched_Preemption(t *testing.T) {
 				},
 			},
 		}
-		require.NoError(t, h.State.UpsertNode(h.NextIndex(), node))
+		require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, node, h.NextIndex()))
 		nodes = append(nodes, node)
 	}
 

--- a/scheduler/system_sched_test.go
+++ b/scheduler/system_sched_test.go
@@ -26,7 +26,7 @@ func TestSystemSched_JobRegister(t *testing.T) {
 
 	// Create a job
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
@@ -37,7 +37,7 @@ func TestSystemSched_JobRegister(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
@@ -101,7 +101,7 @@ func TestSystemSched_JobRegister_StickyAllocs(t *testing.T) {
 	// Create a job
 	job := mock.SystemJob()
 	job.TaskGroups[0].EphemeralDisk.Sticky = true
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -112,7 +112,7 @@ func TestSystemSched_JobRegister_StickyAllocs(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	if err := h.Process(NewSystemScheduler, eval); err != nil {
@@ -143,7 +143,7 @@ func TestSystemSched_JobRegister_StickyAllocs(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 	h1 := NewHarnessWithState(t, h.State)
 	if err := h1.Process(NewSystemScheduler, eval); err != nil {
 		t.Fatalf("err: %v", err)
@@ -175,13 +175,13 @@ func TestSystemSched_JobRegister_EphemeralDiskConstraint(t *testing.T) {
 	// Create a job
 	job := mock.SystemJob()
 	job.TaskGroups[0].EphemeralDisk.SizeMB = 60 * 1024
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create another job with a lot of disk resource ask so that it doesn't fit
 	// the node
 	job1 := mock.SystemJob()
 	job1.TaskGroups[0].EphemeralDisk.SizeMB = 60 * 1024
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job1))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job1))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -192,7 +192,7 @@ func TestSystemSched_JobRegister_EphemeralDiskConstraint(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	if err := h.Process(NewSystemScheduler, eval); err != nil {
@@ -220,7 +220,7 @@ func TestSystemSched_JobRegister_EphemeralDiskConstraint(t *testing.T) {
 		JobID:       job1.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval1}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval1}))
 
 	// Process the evaluation
 	if err := h1.Process(NewSystemScheduler, eval1); err != nil {
@@ -252,7 +252,7 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 	svcJob := mock.Job()
 	svcJob.TaskGroups[0].Count = 1
 	svcJob.TaskGroups[0].Tasks[0].Resources.CPU = 3600
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), svcJob))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), svcJob))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -263,7 +263,7 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 		JobID:       svcJob.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
 	if err != nil {
@@ -272,7 +272,7 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 
 	// Create a system job
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval1 := &structs.Evaluation{
@@ -283,7 +283,7 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval1}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval1}))
 	// Process the evaluation
 	if err := h.Process(NewSystemScheduler, eval1); err != nil {
 		t.Fatalf("err: %v", err)
@@ -335,7 +335,7 @@ func TestSystemSched_JobRegister_Annotate(t *testing.T) {
 		Operand: "==",
 	}
 	job.Constraints = append(job.Constraints, fooConstraint)
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
@@ -347,7 +347,7 @@ func TestSystemSched_JobRegister_Annotate(t *testing.T) {
 		AnnotatePlan: true,
 		Status:       structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
@@ -421,7 +421,7 @@ func TestSystemSched_JobRegister_AddNode(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -447,7 +447,7 @@ func TestSystemSched_JobRegister_AddNode(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
 	if err != nil {
@@ -504,7 +504,7 @@ func TestSystemSched_JobRegister_AllocFail(t *testing.T) {
 	// Create NO nodes
 	// Create a job
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -515,7 +515,7 @@ func TestSystemSched_JobRegister_AllocFail(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
 	if err != nil {
@@ -543,7 +543,7 @@ func TestSystemSched_JobModify(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -575,7 +575,7 @@ func TestSystemSched_JobModify(t *testing.T) {
 
 	// Update the task, such that it cannot be done in-place
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -586,7 +586,7 @@ func TestSystemSched_JobModify(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
@@ -645,7 +645,7 @@ func TestSystemSched_JobModify_Rolling(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -668,7 +668,7 @@ func TestSystemSched_JobModify_Rolling(t *testing.T) {
 
 	// Update the task, such that it cannot be done in-place
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -679,7 +679,7 @@ func TestSystemSched_JobModify_Rolling(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
 	if err != nil {
@@ -748,7 +748,7 @@ func TestSystemSched_JobModify_InPlace(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -764,7 +764,7 @@ func TestSystemSched_JobModify_InPlace(t *testing.T) {
 	// Update the job
 	job2 := mock.SystemJob()
 	job2.ID = job.ID
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -775,7 +775,7 @@ func TestSystemSched_JobModify_InPlace(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
@@ -871,7 +871,7 @@ func TestSystemSched_JobDeregister_Purged(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
@@ -920,7 +920,7 @@ func TestSystemSched_JobDeregister_Stopped(t *testing.T) {
 	// Generate a fake job with allocations
 	job := mock.SystemJob()
 	job.Stop = true
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -945,7 +945,7 @@ func TestSystemSched_JobDeregister_Stopped(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
@@ -990,7 +990,7 @@ func TestSystemSched_NodeDown(t *testing.T) {
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	alloc := mock.Alloc()
 	alloc.Job = job
@@ -1010,7 +1010,7 @@ func TestSystemSched_NodeDown(t *testing.T) {
 		NodeID:      node.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
@@ -1058,7 +1058,7 @@ func TestSystemSched_NodeDrain_Down(t *testing.T) {
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	alloc := mock.Alloc()
 	alloc.Job = job
@@ -1077,7 +1077,7 @@ func TestSystemSched_NodeDrain_Down(t *testing.T) {
 		NodeID:      node.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewServiceScheduler, eval)
@@ -1119,7 +1119,7 @@ func TestSystemSched_NodeDrain(t *testing.T) {
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	alloc := mock.Alloc()
 	alloc.Job = job
@@ -1139,7 +1139,7 @@ func TestSystemSched_NodeDrain(t *testing.T) {
 		NodeID:      node.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
@@ -1185,7 +1185,7 @@ func TestSystemSched_NodeUpdate(t *testing.T) {
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	alloc := mock.Alloc()
 	alloc.Job = job
@@ -1204,7 +1204,7 @@ func TestSystemSched_NodeUpdate(t *testing.T) {
 		NodeID:      node.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
@@ -1232,7 +1232,7 @@ func TestSystemSched_RetryLimit(t *testing.T) {
 
 	// Create a job
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
@@ -1243,7 +1243,7 @@ func TestSystemSched_RetryLimit(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
@@ -1283,7 +1283,7 @@ func TestSystemSched_Queued_With_Constraints(t *testing.T) {
 
 	// Generate a system job which can't be placed on the node
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to deal
 	eval := &structs.Evaluation{
@@ -1295,7 +1295,7 @@ func TestSystemSched_Queued_With_Constraints(t *testing.T) {
 		NodeID:      node.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
@@ -1354,7 +1354,7 @@ func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
 
 	// Upsert Job
 	job.TaskGroups = []*structs.TaskGroup{tgA, tgB}
-	require.Nil(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Evaluate the job
 	eval := &structs.Evaluation{
@@ -1366,7 +1366,7 @@ func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.Nil(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.Nil(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	require.Nil(t, h.Process(NewSystemScheduler, eval))
 	require.Equal(t, "complete", h.Evals[0].Status)
@@ -1398,7 +1398,7 @@ func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.Nil(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval2}))
+	require.Nil(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval2}))
 	require.Nil(t, h.Process(NewSystemScheduler, eval2))
 	require.Equal(t, "complete", h.Evals[1].Status)
 
@@ -1430,7 +1430,7 @@ func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
 	}
 
 	// Ensure New eval is complete
-	require.Nil(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval3}))
+	require.Nil(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval3}))
 	require.Nil(t, h.Process(NewSystemScheduler, eval3))
 	require.Equal(t, "complete", h.Evals[2].Status)
 
@@ -1472,7 +1472,7 @@ func TestSystemSched_ExistingAllocNoNodes(t *testing.T) {
 
 	// Make a job
 	job := mock.SystemJob()
-	require.Nil(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Evaluate the job
 	eval := &structs.Evaluation{
@@ -1484,7 +1484,7 @@ func TestSystemSched_ExistingAllocNoNodes(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.Nil(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.Nil(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 	require.Nil(t, h.Process(NewSystemScheduler, eval))
 	require.Equal(t, "complete", h.Evals[0].Status)
 
@@ -1508,14 +1508,14 @@ func TestSystemSched_ExistingAllocNoNodes(t *testing.T) {
 		NodeID:      node.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.Nil(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval2}))
+	require.Nil(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval2}))
 	require.Nil(t, h.Process(NewSystemScheduler, eval2))
 	require.Equal(t, "complete", h.Evals[1].Status)
 
 	// Create a new job version, deploy
 	job2 := job.Copy()
 	job2.Meta["version"] = "2"
-	require.Nil(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	// Run evaluation as a plan
 	eval3 := &structs.Evaluation{
@@ -1529,7 +1529,7 @@ func TestSystemSched_ExistingAllocNoNodes(t *testing.T) {
 	}
 
 	// Ensure New eval is complete
-	require.Nil(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval3}))
+	require.Nil(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval3}))
 	require.Nil(t, h.Process(NewSystemScheduler, eval3))
 	require.Equal(t, "complete", h.Evals[2].Status)
 
@@ -1565,7 +1565,7 @@ func TestSystemSched_ConstraintErrors(t *testing.T) {
 			Operand: "=",
 		})
 
-	require.Nil(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Evaluate the job
 	eval := &structs.Evaluation{
@@ -1577,7 +1577,7 @@ func TestSystemSched_ConstraintErrors(t *testing.T) {
 		Status:      structs.EvalStatusPending,
 	}
 
-	require.Nil(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.Nil(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 	require.Nil(t, h.Process(NewSystemScheduler, eval))
 	require.Equal(t, "complete", h.Evals[0].Status)
 
@@ -1621,7 +1621,7 @@ func TestSystemSched_ChainedAlloc(t *testing.T) {
 
 	// Create a job
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -1632,7 +1632,7 @@ func TestSystemSched_ChainedAlloc(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 	// Process the evaluation
 	if err := h.Process(NewSystemScheduler, eval); err != nil {
 		t.Fatalf("err: %v", err)
@@ -1652,7 +1652,7 @@ func TestSystemSched_ChainedAlloc(t *testing.T) {
 	job1.ID = job.ID
 	job1.TaskGroups[0].Tasks[0].Env = make(map[string]string)
 	job1.TaskGroups[0].Tasks[0].Env["foo"] = "bar"
-	require.NoError(t, h1.State.UpsertJob(h1.NextIndex(), job1))
+	require.NoError(t, h1.State.UpsertJob(structs.MsgTypeTestSetup, h1.NextIndex(), job1))
 
 	// Insert two more nodes
 	for i := 0; i < 2; i++ {
@@ -1669,7 +1669,7 @@ func TestSystemSched_ChainedAlloc(t *testing.T) {
 		JobID:       job1.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval1}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval1}))
 	// Process the evaluation
 	if err := h1.Process(NewSystemScheduler, eval1); err != nil {
 		t.Fatalf("err: %v", err)
@@ -1733,7 +1733,7 @@ func TestSystemSched_PlanWithDrainedNode(t *testing.T) {
 	tg2.Name = "web2"
 	tg2.Constraints[0].RTarget = "blue"
 	job.TaskGroups = append(job.TaskGroups, tg2)
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create an allocation on each node
 	alloc := mock.Alloc()
@@ -1762,7 +1762,7 @@ func TestSystemSched_PlanWithDrainedNode(t *testing.T) {
 		NodeID:      node.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
@@ -1823,7 +1823,7 @@ func TestSystemSched_QueuedAllocsMultTG(t *testing.T) {
 	tg2.Name = "web2"
 	tg2.Constraints[0].RTarget = "blue"
 	job.TaskGroups = append(job.TaskGroups, tg2)
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -1835,7 +1835,7 @@ func TestSystemSched_QueuedAllocsMultTG(t *testing.T) {
 		NodeID:      node.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)
@@ -1969,7 +1969,7 @@ func TestSystemSched_Preemption(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job1))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job1))
 
 	job2 := mock.BatchJob()
 	job2.Type = structs.JobTypeBatch
@@ -2012,7 +2012,7 @@ func TestSystemSched_Preemption(t *testing.T) {
 			DiskMB: 5 * 1024,
 		},
 	}
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
 
 	job3 := mock.Job()
 	job3.Type = structs.JobTypeBatch
@@ -2104,7 +2104,7 @@ func TestSystemSched_Preemption(t *testing.T) {
 			DiskMB: 2 * 1024,
 		},
 	}
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job4))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job4))
 	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc4}))
 
 	// Create a system job such that it would need to preempt both allocs to succeed
@@ -2119,7 +2119,7 @@ func TestSystemSched_Preemption(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -2130,7 +2130,7 @@ func TestSystemSched_Preemption(t *testing.T) {
 		JobID:       job.ID,
 		Status:      structs.EvalStatusPending,
 	}
-	require.NoError(t, h.State.UpsertEvals(h.NextIndex(), []*structs.Evaluation{eval}))
+	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 	// Process the evaluation
 	err := h.Process(NewSystemScheduler, eval)

--- a/scheduler/system_sched_test.go
+++ b/scheduler/system_sched_test.go
@@ -432,7 +432,7 @@ func TestSystemSched_JobRegister_AddNode(t *testing.T) {
 		alloc.Name = "my-job.web[0]"
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Add a new node.
 	node := mock.Node()
@@ -554,7 +554,7 @@ func TestSystemSched_JobModify(t *testing.T) {
 		alloc.Name = "my-job.web[0]"
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Add a few terminal status allocations, these should be ignored
 	var terminal []*structs.Allocation
@@ -567,7 +567,7 @@ func TestSystemSched_JobModify(t *testing.T) {
 		alloc.DesiredStatus = structs.AllocDesiredStatusStop
 		terminal = append(terminal, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), terminal))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), terminal))
 
 	// Update the job
 	job2 := mock.SystemJob()
@@ -656,7 +656,7 @@ func TestSystemSched_JobModify_Rolling(t *testing.T) {
 		alloc.Name = "my-job.web[0]"
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Update the job
 	job2 := mock.SystemJob()
@@ -759,7 +759,7 @@ func TestSystemSched_JobModify_InPlace(t *testing.T) {
 		alloc.Name = "my-job.web[0]"
 		allocs = append(allocs, alloc)
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Update the job
 	job2 := mock.SystemJob()
@@ -860,7 +860,7 @@ func TestSystemSched_JobDeregister_Purged(t *testing.T) {
 	for _, alloc := range allocs {
 		require.NoError(t, h.State.UpsertJobSummary(h.NextIndex(), mock.JobSummary(alloc.JobID)))
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
@@ -934,7 +934,7 @@ func TestSystemSched_JobDeregister_Stopped(t *testing.T) {
 	for _, alloc := range allocs {
 		require.NoError(t, h.State.UpsertJobSummary(h.NextIndex(), mock.JobSummary(alloc.JobID)))
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), allocs))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), allocs))
 
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
@@ -998,7 +998,7 @@ func TestSystemSched_NodeDown(t *testing.T) {
 	alloc.NodeID = node.ID
 	alloc.Name = "my-job.web[0]"
 	alloc.DesiredTransition.Migrate = helper.BoolToPtr(true)
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -1065,7 +1065,7 @@ func TestSystemSched_NodeDrain_Down(t *testing.T) {
 	alloc.JobID = job.ID
 	alloc.NodeID = node.ID
 	alloc.Name = "my-job.web[0]"
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create a mock evaluation to deal with the node update
 	eval := &structs.Evaluation{
@@ -1127,7 +1127,7 @@ func TestSystemSched_NodeDrain(t *testing.T) {
 	alloc.NodeID = node.ID
 	alloc.Name = "my-job.web[0]"
 	alloc.DesiredTransition.Migrate = helper.BoolToPtr(true)
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -1192,7 +1192,7 @@ func TestSystemSched_NodeUpdate(t *testing.T) {
 	alloc.JobID = job.ID
 	alloc.NodeID = node.ID
 	alloc.Name = "my-job.web[0]"
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create a mock evaluation to deal
 	eval := &structs.Evaluation{
@@ -1750,7 +1750,7 @@ func TestSystemSched_PlanWithDrainedNode(t *testing.T) {
 	alloc2.NodeID = node2.ID
 	alloc2.Name = "my-job.web2[0]"
 	alloc2.TaskGroup = "web2"
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc, alloc2}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc, alloc2}))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -2057,7 +2057,7 @@ func TestSystemSched_Preemption(t *testing.T) {
 			DiskMB: 5 * 1024,
 		},
 	}
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc1, alloc2, alloc3}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc1, alloc2, alloc3}))
 
 	// Create a high priority job and allocs for it
 	// These allocs should not be preempted
@@ -2105,7 +2105,7 @@ func TestSystemSched_Preemption(t *testing.T) {
 		},
 	}
 	require.NoError(t, h.State.UpsertJob(h.NextIndex(), job4))
-	require.NoError(t, h.State.UpsertAllocs(h.NextIndex(), []*structs.Allocation{alloc4}))
+	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc4}))
 
 	// Create a system job such that it would need to preempt both allocs to succeed
 	job := mock.SystemJob()

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -335,10 +335,10 @@ func TestReadyNodesInDCs(t *testing.T) {
 	node4 := mock.Node()
 	node4.Drain = true
 
-	require.NoError(t, state.UpsertNode(1000, node1))
-	require.NoError(t, state.UpsertNode(1001, node2))
-	require.NoError(t, state.UpsertNode(1002, node3))
-	require.NoError(t, state.UpsertNode(1003, node4))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node1, 1000))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node2, 1001))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node3, 1002))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node4, 1003))
 
 	nodes, dc, err := readyNodesInDCs(state, []string{"dc1", "dc2"})
 	require.NoError(t, err)
@@ -394,10 +394,10 @@ func TestTaintedNodes(t *testing.T) {
 	node3.Status = structs.NodeStatusDown
 	node4 := mock.Node()
 	node4.Drain = true
-	require.NoError(t, state.UpsertNode(1000, node1))
-	require.NoError(t, state.UpsertNode(1001, node2))
-	require.NoError(t, state.UpsertNode(1002, node3))
-	require.NoError(t, state.UpsertNode(1003, node4))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node1, 1000))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node2, 1001))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node3, 1002))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node4, 1003))
 
 	allocs := []*structs.Allocation{
 		{NodeID: node1.ID},
@@ -868,7 +868,7 @@ func TestInplaceUpdate_ChangedTaskGroup(t *testing.T) {
 	job := mock.Job()
 
 	node := mock.Node()
-	require.NoError(t, state.UpsertNode(900, node))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node, 900))
 
 	// Register an alloc
 	alloc := &structs.Allocation{
@@ -923,7 +923,7 @@ func TestInplaceUpdate_NoMatch(t *testing.T) {
 	job := mock.Job()
 
 	node := mock.Node()
-	require.NoError(t, state.UpsertNode(900, node))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node, 900))
 
 	// Register an alloc
 	alloc := &structs.Allocation{
@@ -974,7 +974,7 @@ func TestInplaceUpdate_Success(t *testing.T) {
 	job := mock.Job()
 
 	node := mock.Node()
-	require.NoError(t, state.UpsertNode(900, node))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node, 900))
 
 	// Register an alloc
 	alloc := &structs.Allocation{

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -335,10 +335,10 @@ func TestReadyNodesInDCs(t *testing.T) {
 	node4 := mock.Node()
 	node4.Drain = true
 
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node1, 1000))
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node2, 1001))
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node3, 1002))
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node4, 1003))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1000, node1))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1001, node2))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1002, node3))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1003, node4))
 
 	nodes, dc, err := readyNodesInDCs(state, []string{"dc1", "dc2"})
 	require.NoError(t, err)
@@ -394,10 +394,10 @@ func TestTaintedNodes(t *testing.T) {
 	node3.Status = structs.NodeStatusDown
 	node4 := mock.Node()
 	node4.Drain = true
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node1, 1000))
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node2, 1001))
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node3, 1002))
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node4, 1003))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1000, node1))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1001, node2))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1002, node3))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1003, node4))
 
 	allocs := []*structs.Allocation{
 		{NodeID: node1.ID},
@@ -868,7 +868,7 @@ func TestInplaceUpdate_ChangedTaskGroup(t *testing.T) {
 	job := mock.Job()
 
 	node := mock.Node()
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node, 900))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 900, node))
 
 	// Register an alloc
 	alloc := &structs.Allocation{
@@ -923,7 +923,7 @@ func TestInplaceUpdate_NoMatch(t *testing.T) {
 	job := mock.Job()
 
 	node := mock.Node()
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node, 900))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 900, node))
 
 	// Register an alloc
 	alloc := &structs.Allocation{
@@ -974,7 +974,7 @@ func TestInplaceUpdate_Success(t *testing.T) {
 	job := mock.Job()
 
 	node := mock.Node()
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, node, 900))
+	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 900, node))
 
 	// Register an alloc
 	alloc := &structs.Allocation{

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -895,7 +895,7 @@ func TestInplaceUpdate_ChangedTaskGroup(t *testing.T) {
 	}
 	alloc.TaskResources = map[string]*structs.Resources{"web": alloc.Resources}
 	require.NoError(t, state.UpsertJobSummary(1000, mock.JobSummary(alloc.JobID)))
-	require.NoError(t, state.UpsertAllocs(1001, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc}))
 
 	// Create a new task group that prevents in-place updates.
 	tg := &structs.TaskGroup{}
@@ -950,7 +950,7 @@ func TestInplaceUpdate_NoMatch(t *testing.T) {
 	}
 	alloc.TaskResources = map[string]*structs.Resources{"web": alloc.Resources}
 	require.NoError(t, state.UpsertJobSummary(1000, mock.JobSummary(alloc.JobID)))
-	require.NoError(t, state.UpsertAllocs(1001, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc}))
 
 	// Create a new task group that requires too much resources.
 	tg := &structs.TaskGroup{}
@@ -1001,7 +1001,7 @@ func TestInplaceUpdate_Success(t *testing.T) {
 	}
 	alloc.TaskResources = map[string]*structs.Resources{"web": alloc.Resources}
 	require.NoError(t, state.UpsertJobSummary(999, mock.JobSummary(alloc.JobID)))
-	require.NoError(t, state.UpsertAllocs(1001, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc}))
 
 	// Create a new task group that updates the resources.
 	tg := &structs.TaskGroup{}


### PR DESCRIPTION
#9013 introduced a few new state store methods that were copies of the originals* with a `MsgType` explicitly added. This was mainly due to the sheer volume of test case usage. This PR removes the temporary methods and updates all the test usages to use `structs.MsgTypeTestSetup`

Note to reviewers:
- `nomad/state/state_store.go` removes placholder methods
- `nomad/job_endpoint` uses structs.IgnoreUnknownMsgType as a placeholder for job plan
- `fsm.go` `applyDeregisterNodeBatch` includes a message type to satisfy the used state store methods, delete events are ignored for now
- `_test.go` files were programmatically updated, I personally wouldn't spend much time reviewing every diff in test file

Placeholder state store methods that have been removed:
`UpsertNodeMsgType, DeleteNodeMsgType, UpdateNodeDrainMsgType, UpsertNodeEventsMsgType, UpsertJobMsgType, UpsertEvalsMsgType, UpsertAllocsMsgType`