### PR TITLE
update tree tool to pass lint-go

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/nomad/tools
 go 1.14
 
 require (
-	github.com/a8m/tree v0.0.0-20181222104329-6a0b80129de4
+	github.com/a8m/tree v0.0.0-20201019170308-9f4249a434f8
 	github.com/aws/aws-sdk-go v1.35.5
 	github.com/client9/misspell v0.3.4
 	github.com/elazarl/go-bindata-assetfs v1.0.1

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/nomad/tools
 
-go 1.14
+go 1.15
 
 require (
 	github.com/a8m/tree v0.0.0-20201019170308-9f4249a434f8

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -7,6 +7,8 @@ github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmU
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/a8m/tree v0.0.0-20181222104329-6a0b80129de4 h1:mK1/QgFPU4osbhjJ26B1w738kjQHaGJcon8uCLMS8fk=
 github.com/a8m/tree v0.0.0-20181222104329-6a0b80129de4/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
+github.com/a8m/tree v0.0.0-20201019170308-9f4249a434f8 h1:CkFIJJAKEbZbM2tKmCqt/v9ivgpikjPu5lnDsk8huLE=
+github.com/a8m/tree v0.0.0-20201019170308-9f4249a434f8/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
Upstream pushed a commit onto the untagged 0.0.0, which breaks our check for no diffs in the go.mod/go.sum files.