### PR TITLE
UI: Remove logo spin for prefers-reduced-motion

### DIFF
--- a/ui/app/styles/components/loading-spinner.scss
+++ b/ui/app/styles/components/loading-spinner.scss
@@ -43,6 +43,12 @@ $darker-side: darken($lighter-side, 15%);
     animation: cube-spin $duration forwards infinite;
   }
 
+  @media (prefers-reduced-motion) {
+    .cube {
+      animation-iteration-count: 0;
+    }
+  }
+
   &.paused {
     .cube,
     .side-4,


### PR DESCRIPTION
Spinning is one of the triggers mentioned on [this page](https://webkit.org/blog/7551/responsive-design-for-motion/
). Thanks to @fivetanley for mentioning that this exists.

Here’s a GIF showing it working, though the looping is confusing 😐

![reduced-motion-logo](https://user-images.githubusercontent.com/43280/96601570-c5190b00-12b7-11eb-9dd0-015b01e78af9.gif)
