### PR TITLE
consul: add tests for meta/canarymeta interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ BUG FIXES:
  * core: Fixed a bug where blocking queries would not include the query's maximum wait time when calculating whether it was safe to retry. [[GH-8921](https://github.com/hashicorp/nomad/issues/8921)]
  * config (Enterprise): Fixed default enterprise config merging. [[GH-9083](https://github.com/hashicorp/nomad/pull/9083)]
  * consul: Fixed a bug to correctly validate task when using script-checks in group-level services [[GH-8952](https://github.com/hashicorp/nomad/issues/8952)]
+ * consul: Fixed a bug where canary_meta was not being interpolated with environment variables [[GH-9096](https://github.com/hashicorp/nomad/pull/9096)]
  * consul/connect: Fixed a bug to correctly trigger updates on jobspec changes [[GH-9029](https://github.com/hashicorp/nomad/pull/9029)]
  * csi: Fixed a bug where multi-writer volumes were allowed only 1 write claim. [[GH-9040](https://github.com/hashicorp/nomad/issues/9040)]
  * csi: Fixed a bug where `nomad volume detach` would not accept prefixes for the node ID parameter. [[GH-9041](https://github.com/hashicorp/nomad/issues/9041)]

--- a/client/taskenv/services.go
+++ b/client/taskenv/services.go
@@ -57,6 +57,14 @@ func InterpolateServices(taskEnv *TaskEnv, services []*structs.Service) []*struc
 			service.Meta = meta
 		}
 
+		if len(service.CanaryMeta) > 0 {
+			canaryMeta := make(map[string]string, len(service.CanaryMeta))
+			for k, v := range service.CanaryMeta {
+				canaryMeta[k] = taskEnv.ReplaceEnv(v)
+			}
+			service.CanaryMeta = canaryMeta
+		}
+
 		interpolated[i] = service
 	}
 

--- a/client/taskenv/services_test.go
+++ b/client/taskenv/services_test.go
@@ -16,6 +16,12 @@ func TestInterpolateServices(t *testing.T) {
 			Name:      "${name}",
 			PortLabel: "${portlabel}",
 			Tags:      []string{"${tags}"},
+			Meta: map[string]string{
+				"meta-key": "${meta}",
+			},
+			CanaryMeta: map[string]string{
+				"canarymeta-key": "${canarymeta}",
+			},
 			Checks: []*structs.ServiceCheck{
 				{
 					Name:          "${checkname}",
@@ -40,6 +46,8 @@ func TestInterpolateServices(t *testing.T) {
 			"name":         "name",
 			"portlabel":    "portlabel",
 			"tags":         "tags",
+			"meta":         "meta-value",
+			"canarymeta":   "canarymeta-value",
 			"checkname":    "checkname",
 			"checktype":    "checktype",
 			"checkcmd":     "checkcmd",
@@ -62,6 +70,12 @@ func TestInterpolateServices(t *testing.T) {
 			Name:      "name",
 			PortLabel: "portlabel",
 			Tags:      []string{"tags"},
+			Meta: map[string]string{
+				"meta-key": "meta-value",
+			},
+			CanaryMeta: map[string]string{
+				"canarymeta-key": "canarymeta-value",
+			},
 			Checks: []*structs.ServiceCheck{
 				{
 					Name:          "checkname",


### PR DESCRIPTION
Adds onto https://github.com/hashicorp/nomad/pull/9096 for tests, CL, rebase w/ master

