### PR TITLE
Fix infinite retry if err is "no leader"

### DIFF
--- a/client/rpc.go
+++ b/client/rpc.go
@@ -83,7 +83,7 @@ TRY:
 	// Move off to another server, and see if we can retry.
 	c.rpcLogger.Error("error performing RPC to server", "error", rpcErr, "rpc", method, "server", server.Addr)
 	c.servers.NotifyFailedServer(server)
-	if retry := canRetry(args, rpcErr, firstCheck, c.config.RPCHoldTimeout); !retry {
+	if hasTimedOut(args, firstCheck, c.config.RPCHoldTimeout) || !canRetry(args, rpcErr) {
 		return rpcErr
 	}
 
@@ -97,8 +97,15 @@ TRY:
 	return rpcErr
 }
 
+func hasTimedOut(args interface{}, start time.Time, rpcHoldTimeout time.Duration) bool {
+	if info, ok := args.(structs.RPCInfo); ok {
+		return info.HasTimedOut(start, rpcHoldTimeout)
+	}
+	return time.Since(start) >= rpcHoldTimeout
+}
+
 // canRetry returns true if the given situation is safe for a retry.
-func canRetry(args interface{}, err error, start time.Time, rpcHoldTimeout time.Duration) bool {
+func canRetry(args interface{}, err error) bool {
 	// No leader errors are always safe to retry since no state could have
 	// been changed.
 	if structs.IsErrNoLeader(err) {
@@ -108,7 +115,7 @@ func canRetry(args interface{}, err error, start time.Time, rpcHoldTimeout time.
 	// Reads are safe to retry for stream errors, such as if a server was
 	// being shut down.
 	info, ok := args.(structs.RPCInfo)
-	if ok && info.IsRead() && lib.IsErrEOF(err) && !info.HasTimedOut(start, rpcHoldTimeout) {
+	if ok && info.IsRead() && lib.IsErrEOF(err) {
 		return true
 	}
 


### PR DESCRIPTION
Moving the timeout calculation to the HasTimedOut method effectively
removed it from the code path where either the args aren't implementing
RPCInfo or if the error is "No cluster leader". This fix brings the
timeout calculation before everything else and works as originally
designed even if the args don't implement the RPCInfo interface.

PR that introduced the bug: https://github.com/hashicorp/nomad/pull/8921