### PR TITLE
UI: Add logged Faker seed when none is set in tests

### DIFF
--- a/ui/mirage/faker.js
+++ b/ui/mirage/faker.js
@@ -11,6 +11,10 @@ if (config.environment !== 'test' || searchIncludesSeed) {
   } else {
     faker.seed(1);
   }
+} else if (config.environment === 'test') {
+  const randomSeed = faker.random.number();
+  console.log(`No seed specified with faker-seed query parameter, seeding Faker with ${randomSeed}`);
+  faker.seed(randomSeed);
 }
 
 export default faker;


### PR DESCRIPTION
This will hopefully make it easier to reproduce test failures
that happen intermittently, especially in CI.

It shows up in a somewhat strange place in the [CircleCI logs](https://app.circleci.com/pipelines/github/hashicorp/nomad/12536/workflows/1309c73f-c4c5-4222-a32e-803c2ca50c4f/jobs/110577) but maybe it’s fine?

```
ok 1 Chrome 86.0 - [1322 ms] - Acceptance | allocation detail: it passes an accessibility audit
    ---
        browser log: |
            LOG: No seed specified with faker-seed query parameter, seeding Faker with 13497
```