### PR TITLE
csi: prevent in-use plugin GC from blocking volume GC

### DIFF
--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -860,7 +860,7 @@ func (c *CoreScheduler) csiPluginGC(eval *structs.Evaluation) error {
 			}}
 		err := c.srv.RPC("CSIPlugin.Delete", req, &structs.CSIPluginDeleteResponse{})
 		if err != nil {
-			if err.Error() == "plugin in use" {
+			if strings.Contains(err.Error(), "plugin in use") {
 				continue
 			}
 			c.logger.Error("failed to GC plugin", "plugin_id", plugin.ID, "error", err)


### PR DESCRIPTION
Fixes an issue noticed in https://github.com/hashicorp/nomad/issues/8949#issuecomment-712118627

During CSI plugin GC, we don't return an error if the volume is in use,
because this is not an error condition. If we were to return an error during a
`nomad system gc`, we would not continue on to GC volumes.

But the check for the specific error message fails if the GC is performed on a
worker rather than on the leader, due to RPC forwarding wrapping the error
message. Use a less specific test so that we don't return an error.