### PR TITLE
docs: update plan API documentation

### DIFF
--- a/website/pages/api-docs/jobs.mdx
+++ b/website/pages/api-docs/jobs.mdx
@@ -1483,7 +1483,9 @@ The table below shows this endpoint's support for
 
 ```json
 {
-  "Job": "...",
+  "Job": {
+    // ...
+  },
   "Diff": true,
   "PolicyOverride": false
 }


### PR DESCRIPTION
The current documentation implies that job JSON is submitted as a string (`...`) but this is not the case (if you do this you will receive a 400)

Changed the text to match the convention in 'update job' wherein the job is correctly illustrated as an object literal