### PR TITLE
e2e: fix destination of templates in VaultSecrets test

### DIFF
--- a/e2e/vaultsecrets/input/secrets.nomad
+++ b/e2e/vaultsecrets/input/secrets.nomad
@@ -33,7 +33,7 @@ job "secrets" {
 {{ end }}
 EOT
 
-        destination = "${NOMAD_SECRETS_DIR}/certificate.crt"
+        destination = "secrets/certificate.crt"
         change_mode = "noop"
       }
 
@@ -42,7 +42,7 @@ EOT
 SOME_SECRET={{ with secret "secrets-TESTID/data/myapp" }}{{- .Data.data.key -}}{{end}}
 EOT
 
-        destination = "${NOMAD_SECRETS_DIR}/access.key"
+        destination = "secrets/access.key"
       }
 
       resources {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9144

The `$NOMAD_SECRETS_DIR` environment variable is rendered as `/secrets`, which
if used as a `template.destination` prior to the recent security patch would unintentionally 
escape the file sandbox and get dropped in a directory named `/secrets` where the Nomad 
client binary was running. The `VaultSecrets` test was accidentally relying on this
behavior and that causes the test to fail.

---

This is an easy mistake to make, and makes me worry whether we have a lot of this
behavior "in the wild" and what we could do to improve the UX.

Addendum: in 0.12.5 it doesn't _actually_ escape the file sandbox, but it fails the check in
0.12.6 as though it does. So there may be a bug in the patch 😦 (Going to spin that out to a new issue)