### PR TITLE
artifact/template: make destination path absolute inside taskdir

### DIFF
--- a/e2e/consultemplate/input/templating.nomad
+++ b/e2e/consultemplate/input/templating.nomad
@@ -24,7 +24,7 @@ job "templating" {
 server {{ .Name }} {{ .Address }}:{{ .Port }}{{ end }}
 EOT
 
-        destination = "local/services.conf"
+        destination = "${NOMAD_TASK_DIR}/services.conf"
         change_mode = "noop"
       }
 
@@ -35,7 +35,7 @@ key: {{ key "consultemplatetest" }}
 job: {{ env "NOMAD_JOB_NAME" }}
 EOT
 
-        destination = "local/kv.yml"
+        destination = "${NOMAD_TASK_DIR}/kv.yml"
         change_mode = "restart"
       }
 
@@ -63,7 +63,7 @@ EOT
 server {{ .Name }} {{ .Address }}:{{ .Port }}{{ end }}
 EOT
 
-        destination = "local/services.conf"
+        destination = "${NOMAD_TASK_DIR}/services.conf"
         change_mode = "noop"
       }
 
@@ -73,7 +73,7 @@ EOT
 key: {{ key "consultemplatetest" }}
 job: {{ env "NOMAD_JOB_NAME" }}
 EOT
-        destination = "local/kv.yml"
+        destination = "${NOMAD_TASK_DIR}/kv.yml"
         change_mode = "restart"
       }
 

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -514,21 +514,16 @@ func CheckNamespaceScope(provided string, requested []string) []string {
 	return nil
 }
 
-// GetPathInSandbox returns a cleaned path inside the sandbox directory
-// (typically this will be the allocation directory). Relative paths will be
-// joined to the sandbox directory. Returns an error if the path escapes the
-// sandbox directory.
-func GetPathInSandbox(sandboxDir, path string) (string, error) {
-	if !filepath.IsAbs(path) {
-		path = filepath.Join(sandboxDir, path)
-	}
-	path = filepath.Clean(path)
+// PathEscapesSandbox returns whether previously cleaned path inside the
+// sandbox directory (typically this will be the allocation directory)
+// escapes.
+func PathEscapesSandbox(sandboxDir, path string) bool {
 	rel, err := filepath.Rel(sandboxDir, path)
 	if err != nil {
-		return path, err
+		return true
 	}
 	if strings.HasPrefix(rel, "..") {
-		return path, fmt.Errorf("%q escapes sandbox directory", path)
+		return true
 	}
-	return path, nil
+	return false
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9148

Prior to Nomad 0.12.5, you could use `${NOMAD_SECRETS_DIR}/mysecret.txt` as
the `artifact.destination` and `template.destination` because we would always
append the destination to the task working directory. In the recent security
patch we treated the `destination` absolute path as valid if it didn't escape
the working directory, but this breaks backwards compatibility and
interpolation of `destination` fields.

This changeset partially reverts the behavior so that we always append the
destination, but we also perform the escape check on that new destination
after interpolation so the security hole is closed.