### PR TITLE
docs: add regression warning for GH-9148 to upgrade guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ BUG FIXES:
  * csi: Fixed a bug where `nomad volume detach` would not accept prefixes for the node ID parameter. [[GH-9041](https://github.com/hashicorp/nomad/issues/9041)]
  * driver/docker: Fixed a bug where the default `image_delay` configuration was ignored if the `gc` configuration was not set. [[GH-9101](https://github.com/hashicorp/nomad/issues/9101)]
 
+## 0.12.7 (October 23, 2020)
+
+BUG FIXES:
+ * artifact: Fixed a regression in 0.12.6 where if the artifact `destination` field is an absolute path it is not appended to the task working directory, breaking the use of `NOMAD_SECRETS_DIR` as part of the destination path. [[GH-9148](https://github.com/hashicorp/nomad/issues/9148)]
+ * template: Fixed a regression in 0.12.6 where if the template `destination` field is an absolute path it is not appended to the task working directory, breaking the use of `NOMAD_SECRETS_DIR` as part of the destination path. [[GH-9148](https://github.com/hashicorp/nomad/issues/9148)]
+
 ## 0.12.6 (October 21, 2020)
 
 SECURITY:
@@ -212,6 +218,12 @@ BUG FIXES:
  * ui: The task group detail page no longer makes excessive requests to the allocation and stats endpoints. [[GH-8216](https://github.com/hashicorp/nomad/issues/8216)]
  * ui: Polling endpoints that have yet to be fetched normally works as expected (regression from 0.11.3). [[GH-8207](https://github.com/hashicorp/nomad/issues/8207)]
 
+## 0.11.6 (October 23, 2020)
+
+BUG FIXES:
+ * artifact: _Backport from v0.12.7_ - Fixed a regression in 0.11.5 where if the artifact `destination` field is an absolute path it is not appended to the task working directory, breaking the use of `NOMAD_SECRETS_DIR` as part of the destination path. [[GH-9148](https://github.com/hashicorp/nomad/issues/9148)]
+ * template: _Backport from v0.12.7_ - Fixed a regression in 0.11.5 where if the template `destination` field is an absolute path it is not appended to the task working directory, breaking the use of `NOMAD_SECRETS_DIR` as part of the destination path. [[GH-9148](https://github.com/hashicorp/nomad/issues/9148)]
+
 ## 0.11.5 (October 21, 2020)
 
 SECURITY:
@@ -364,6 +376,11 @@ BUG FIXES:
  * scheduler: Fixed a bug where changes to task group `shutdown_delay` were not persisted or displayed in plan output [[GH-7618](https://github.com/hashicorp/nomad/issues/7618)]
  * ui: Fixed handling of multi-byte unicode characters in allocation log view [[GH-7470](https://github.com/hashicorp/nomad/issues/7470)] [[GH-7551](https://github.com/hashicorp/nomad/pull/7551)]
 
+## 0.10.7 (October 23, 2020)
+
+BUG FIXES:
+ * artifact: _Backport from v0.12.7_ - Fixed a regression in 0.10.6 where if the artifact `destination` field is an absolute path it is not appended to the task working directory, breaking the use of `NOMAD_SECRETS_DIR` as part of the destination path. [[GH-9148](https://github.com/hashicorp/nomad/issues/9148)]
+ * template: _Backport from v0.12.7_ - Fixed a regression in 0.10.6 where if the template `destination` field is an absolute path it is not appended to the task working directory, breaking the use of `NOMAD_SECRETS_DIR` as part of the destination path. [[GH-9148](https://github.com/hashicorp/nomad/issues/9148)]
 
 ## 0.10.6 (October 21, 2020)
 

--- a/website/pages/docs/upgrade/upgrade-specific.mdx
+++ b/website/pages/docs/upgrade/upgrade-specific.mdx
@@ -108,6 +108,12 @@ in handling of job `template` and `artifact` stanzas:
   bypass this validation. The client now interpolates the paths before
   checking if they are in the file sandbox.
 
+~> **Warning:** Due to a [bug][gh-9148] in Nomad v0.12.6, the
+`template.destination` and `artifact.destination` paths do not support
+absolute paths, including the interpolated `NOMAD_SECRETS_DIR`,
+`NOMAD_TASK_DIR`, and `NOMAD_ALLOC_DIR` variables. This bug is fixed in
+v0.12.7. To work around the bug, use a relative path.
+
 ## Nomad 0.12.0
 
 ### `mbits` and Task Network Resource deprecation
@@ -201,6 +207,12 @@ vulnerabilities in handling of job `template` and `artifact` stanzas:
   bypass this validation. The client now interpolates the paths before
   checking if they are in the file sandbox.
 
+~> **Warning:** Due to a [bug][gh-9148] in Nomad v0.11.5, the
+`template.destination` and `artifact.destination` paths do not support
+absolute paths, including the interpolated `NOMAD_SECRETS_DIR`,
+`NOMAD_TASK_DIR`, and `NOMAD_ALLOC_DIR` variables. This bug is fixed in
+v0.11.6. To work around the bug, use a relative path.
+
 ## Nomad 0.11.3
 
 Nomad 0.11.3 fixes a critical bug causing the nomad agent to become
@@ -274,6 +286,12 @@ vulnerabilities in handling of job `template` and `artifact` stanzas:
   do not escape the file sandbox. It was possible to use interpolation to
   bypass this validation. The client now interpolates the paths before
   checking if they are in the file sandbox.
+
+~> **Warning:** Due to a [bug][gh-9148] in Nomad v0.10.6, the
+`template.destination` and `artifact.destination` paths do not support
+absolute paths, including the interpolated `NOMAD_SECRETS_DIR`,
+`NOMAD_TASK_DIR`, and `NOMAD_ALLOC_DIR` variables. This bug is fixed in
+v0.10.7. To work around the bug, use a relative path.
 
 ## Nomad 0.10.4
 
@@ -727,6 +745,7 @@ deleted and then Nomad 0.3.0 can be launched.
 [dst]: /docs/job-specification/periodic#daylight-saving-time
 [gh-6787]: https://github.com/hashicorp/nomad/issues/6787
 [gh-8457]: https://github.com/hashicorp/nomad/issues/8457
+[gh-9148]: https://github.com/hashicorp/nomad/issues/9148
 [hcl2]: https://github.com/hashicorp/hcl2
 [limits]: /docs/configuration#limits
 [lxc]: /docs/drivers/external/lxc


### PR DESCRIPTION
_Pending backport release of 0.12.7, 0.11.6, and 0.10.7 tomorrow_