### PR TITLE
Update alert banner to promote Noamd 1.0 announcement

### DIFF
--- a/website/data/alert-banner.js
+++ b/website/data/alert-banner.js
@@ -7,4 +7,7 @@ export default {
   tag: 'ANNOUNCING',
   text:
     'Nomad 0.12 is now generally available, which includes 15+ new features and our breakthrough Multi-Cluster Deployment. Learn more!',
+  // Set the `expirationDate prop with a datetime string (e.g. `2020-01-31T12:00:00-07:00`)
+  // if you'd like the component to stop showing at or after a certain date
+  expirationDate: null,
 }

--- a/website/data/alert-banner.js
+++ b/website/data/alert-banner.js
@@ -2,12 +2,12 @@ export const ALERT_BANNER_ACTIVE = true
 
 // https://github.com/hashicorp/web-components/tree/master/packages/alert-banner
 export default {
-  url:
-    'https://www.hashicorp.com/blog/announcing-general-availability-of-hashicorp-nomad-0-12',
-  tag: 'ANNOUNCING',
+  linkText: 'Register now',
+  url: 'https://www.hashicorp.com/events/webinars/introducing-nomad-1-0',
+  tag: 'ANNOUNCEMENT',
   text:
-    'Nomad 0.12 is now generally available, which includes 15+ new features and our breakthrough Multi-Cluster Deployment. Learn more!',
+    'Join us on Oct 27th for the Nomad 1.0 Product Announcement with Armon Dadgar',
   // Set the `expirationDate prop with a datetime string (e.g. `2020-01-31T12:00:00-07:00`)
   // if you'd like the component to stop showing at or after a certain date
-  expirationDate: null,
+  expirationDate: '2020-10-27T09:00:00-07:00',
 }

--- a/website/data/version.js
+++ b/website/data/version.js
@@ -1,1 +1,1 @@
-export default '0.12.5'
+export default '0.12.6'

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1598,11 +1598,10 @@
       "integrity": "sha512-03qWTvECGrG2Z0cm/w71J/KmSBJrUem1QTdRuGFHLTPGgAdIgI90xWpYWmUjGw7gXrxJ/q1yY2JwbfpHwRrpPg=="
     },
     "@hashicorp/react-alert-banner": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-alert-banner/-/react-alert-banner-3.1.0.tgz",
-      "integrity": "sha512-7Alg7nJ9EKa2mDU5zxutkEcSaiXE7JbSTALMhRFHRrg9P0cHcAkxMdetgQn2GY05dGCu0YoOr96f2nhMmu4hrw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-alert-banner/-/react-alert-banner-4.2.0.tgz",
+      "integrity": "sha512-mLi5caKU41L6ZMqQ/mQN9jrgPESzxIqxoKchmB0TpJqwHnUG46UPokWbQovXgtPnAUrXDyLYU0Sp3gaIsDuI9Q==",
       "requires": {
-        "@hashicorp/react-global-styles": "^4.4.0",
         "js-cookie": "2.2.0",
         "slugify": "1.3.4"
       },

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "author": "HashiCorp",
   "dependencies": {
     "@hashicorp/nextjs-scripts": "13.0.0",
-    "@hashicorp/react-alert-banner": "3.1.0",
+    "@hashicorp/react-alert-banner": "4.2.0",
     "@hashicorp/react-button": "3.0.2",
     "@hashicorp/react-call-to-action": "0.2.1",
     "@hashicorp/react-case-study-slider": "2.1.1",

--- a/website/pages/docs/upgrade/upgrade-specific.mdx
+++ b/website/pages/docs/upgrade/upgrade-specific.mdx
@@ -89,6 +89,24 @@ the time of the upgrade for each node will ensure Connect workloads are properly
 rescheduled onto nodes in such a way that the Nomad Clients, Consul agents, and
 Envoy sidecar tasks maintain compatibility with one another.
 
+## Nomad 0.12.6
+
+### Artifact and Template Paths
+
+Nomad 0.12.6 includes security fixes for privilege escalation vulnerabilities
+in handling of job `template` and `artifact` stanzas:
+
+- The `template.source` and `template.destination` fields are now protected by
+  the file sandbox introduced in 0.9.6. These paths are now restricted to fall
+  inside the task directory by default. An operator can opt-out of this
+  protection with the
+  [`template.disable_file_sandbox`](/docs/configuration/client#template-parameters)
+  field in the client configuration.
+- The paths for `template.source`, `template.destination`, and
+  `artifact.destination` are validated on job submission to ensure the paths
+  do not escape the file sandbox. It was possible to use interpolation to
+  bypass this validation. The client now interpolates the paths before
+  checking if they are in the file sandbox.
 
 ## Nomad 0.12.0
 
@@ -164,6 +182,25 @@ plugin "qemu" {
 }
 ```
 
+## Nomad 0.11.5
+
+### Artifact and Template Paths
+
+Nomad 0.11.5 includes backported security fixes for privilege escalation
+vulnerabilities in handling of job `template` and `artifact` stanzas:
+
+- The `template.source` and `template.destination` fields are now protected by
+  the file sandbox introduced in 0.9.6. These paths are now restricted to fall
+  inside the task directory by default. An operator can opt-out of this
+  protection with the
+  [`template.disable_file_sandbox`](/docs/configuration/client#template-parameters)
+  field in the client configuration.
+- The paths for `template.source`, `template.destination`, and
+  `artifact.destination` are validated on job submission to ensure the paths
+  do not escape the file sandbox. It was possible to use interpolation to
+  bypass this validation. The client now interpolates the paths before
+  checking if they are in the file sandbox.
+
 ## Nomad 0.11.3
 
 Nomad 0.11.3 fixes a critical bug causing the nomad agent to become
@@ -218,6 +255,25 @@ code is available in an external repository,
 it will not be maintained as `rkt` is [no longer being developed
 upstream](https://github.com/rkt/rkt). We encourage all `rkt` users to find a
 new task driver as soon as possible.
+
+## Nomad 0.10.6
+
+### Artifact and Template Paths
+
+Nomad 0.10.6 includes backported security fixes for privilege escalation
+vulnerabilities in handling of job `template` and `artifact` stanzas:
+
+- The `template.source` and `template.destination` fields are now protected by
+  the file sandbox introduced in 0.9.6. These paths are now restricted to fall
+  inside the task directory by default. An operator can opt-out of this
+  protection with the
+  [`template.disable_file_sandbox`](/docs/configuration/client#template-parameters)
+  field in the client configuration.
+- The paths for `template.source`, `template.destination`, and
+  `artifact.destination` are validated on job submission to ensure the paths
+  do not escape the file sandbox. It was possible to use interpolation to
+  bypass this validation. The client now interpolates the paths before
+  checking if they are in the file sandbox.
 
 ## Nomad 0.10.4
 

--- a/website/pages/style.css
+++ b/website/pages/style.css
@@ -4,7 +4,7 @@
 @import '~@hashicorp/react-global-styles/custom-properties/font.css';
 @import '~@hashicorp/react-global-styles/_temporary-to-remove/layout.css';
 @import '~@hashicorp/react-global-styles/_temporary-to-remove/tables.css';
-@import '~@hashicorp/react-alert-banner/dist/style.css';
+@import '~@hashicorp/react-alert-banner/style.css';
 @import '~@hashicorp/nextjs-scripts/prism/style.css';
 
 :root {


### PR DESCRIPTION
_Note_ The commit history here is off as this is branched of off `pruett.alertbanner-exp` in #9156. Once that PR is rebased, I'l rebase this and we should be good to go.

This updates the alert banner content to promote the Nomad 1.0 launch announcement webinar on 10/27.