### PR TITLE
Revert "e2e: fix destination of templates in VaultSecrets test (#9146)"

### DIFF
--- a/e2e/vaultsecrets/input/secrets.nomad
+++ b/e2e/vaultsecrets/input/secrets.nomad
@@ -33,7 +33,7 @@ job "secrets" {
 {{ end }}
 EOT
 
-        destination = "secrets/certificate.crt"
+        destination = "${NOMAD_SECRETS_DIR}/certificate.crt"
         change_mode = "noop"
       }
 
@@ -42,7 +42,7 @@ EOT
 SOME_SECRET={{ with secret "secrets-TESTID/data/myapp" }}{{- .Data.data.key -}}{{end}}
 EOT
 
-        destination = "secrets/access.key"
+        destination = "${NOMAD_SECRETS_DIR}/access.key"
       }
 
       resources {


### PR DESCRIPTION
This reverts commit 8aed53c177aea024d4f24d1fbb4d6e0881f04eab.
The regression was fixed in https://github.com/hashicorp/nomad/pull/9149