### PR TITLE
command: Fix node help error

### DIFF
--- a/command/node.go
+++ b/command/node.go
@@ -27,7 +27,7 @@ Usage: nomad node <subcommand> [options] [args]
 
       $ nomad node eligibility -disable <node-id>
 
-  Mark a node to be drained, allowing batch jobs four hours to finished before
+  Mark a node to be drained, allowing batch jobs four hours to finish before
   forcing them off the node:
 
       $ nomad node drain -enable -deadline 4h <node-id>


### PR DESCRIPTION
Fix a error in the documentation that prints as a result of the "nomad node help" command.