### PR TITLE
Display class in client details

### DIFF
--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -146,6 +146,12 @@
         <span class="term">Datacenter</span>
         {{this.model.datacenter}}
       </span>
+      {{#if this.model.nodeClass}}
+        <span class="pair" data-test-node-class>
+          <span class="term">Class</span>
+          {{this.model.nodeClass}}
+        </span>
+      {{/if}}
       <span class="pair" data-test-driver-health>
         <span class="term">Drivers</span>
         {{#if this.model.unhealthyDrivers.length}}


### PR DESCRIPTION
Display node class in client detail at /ui/clients/{client-id}

also fixes https://github.com/hashicorp/nomad/issues/8547