### PR TITLE
Fix a command typo of vault token create

### DIFF
--- a/website/pages/docs/integrations/vault-integration.mdx
+++ b/website/pages/docs/integrations/vault-integration.mdx
@@ -440,7 +440,7 @@ EOF
 To Submit this job a token that has the `access-kv` policy in the Namespace `engineering`
 
 ```shell-session
-$ vault token create -policy access-kv -namespace=engineering -period 72h -oprhan
+$ vault token create -policy access-kv -namespace=engineering -period 72h -orphan
 
 Key                  Value
 ---                  -----


### PR DESCRIPTION
Fix a command typo at `Submitting a job with a Vault Namespace` unit.

It should be 
`vault token create -policy access-kv -namespace=engineering -period 72h -orphan`