### PR TITLE
Send events to EventSinks

### DIFF
--- a/command/agent/event_endpoint.go
+++ b/command/agent/event_endpoint.go
@@ -19,7 +19,7 @@ import (
 
 func (s *HTTPServer) EventSinksRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if req.Method != http.MethodGet {
-		return nil, CodedError(405, ErrInvalidMethod)
+		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
 	}
 
 	args := structs.EventSinkListRequest{}
@@ -42,7 +42,7 @@ func (s *HTTPServer) EventSinksRequest(resp http.ResponseWriter, req *http.Reque
 func (s *HTTPServer) EventSinkSpecificRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	name := strings.TrimPrefix(req.URL.Path, "/v1/event/sink/")
 	if len(name) == 0 {
-		return nil, CodedError(400, "Missing Policy Name")
+		return nil, CodedError(http.StatusBadRequest, "Missing Policy Name")
 	}
 	switch req.Method {
 	case http.MethodGet:

--- a/helper/raftutil/msgtypes.go
+++ b/helper/raftutil/msgtypes.go
@@ -47,6 +47,7 @@ var msgTypeNames = map[structs.MessageType]string{
 	structs.CSIPluginDeleteRequestType:                   "CSIPluginDeleteRequestType",
 	structs.EventSinkUpsertRequestType:                   "EventSinkUpsertRequestType",
 	structs.EventSinkDeleteRequestType:                   "EventSinkDeleteRequestType",
+	structs.BatchEventSinkUpdateProgressType:             "BatchEventSinkUpdateProgressType",
 	structs.NamespaceUpsertRequestType:                   "NamespaceUpsertRequestType",
 	structs.NamespaceDeleteRequestType:                   "NamespaceDeleteRequestType",
 }

--- a/nomad/event_endpoint.go
+++ b/nomad/event_endpoint.go
@@ -105,6 +105,28 @@ func (e *Event) UpsertSink(args *structs.EventSinkUpsertRequest, reply *structs.
 	return nil
 }
 
+func (e *Event) UpdateSinks(args *structs.EventSinkProgressRequest, reply *structs.GenericResponse) error {
+	if done, err := e.srv.forward("Event.UpdateSinks", args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince([]string{"nomad", "event", "update_sinks"}, time.Now())
+
+	if aclObj, err := e.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
+	// Update via Raft
+	_, index, err := e.srv.raftApply(structs.BatchEventSinkUpdateProgressType, args)
+	if err != nil {
+		return err
+	}
+
+	reply.Index = index
+	return nil
+}
+
 // GetSink returns the requested event sink
 func (e *Event) GetSink(args *structs.EventSinkSpecificRequest, reply *structs.EventSinkResponse) error {
 	if done, err := e.srv.forward("Event.GetSink", args, args, reply); done {

--- a/nomad/event_sink_manager.go
+++ b/nomad/event_sink_manager.go
@@ -1,0 +1,437 @@
+package nomad
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/stream"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// ErrEventSinkDeregistered is used to inform the EventSink Manager that a sink
+// has been deleted
+var ErrEventSinkDeregistered error = errors.New("sink deregistered")
+
+// SinkManager manages all of the registered event sinks. It runs each sink as
+// a ManagedSink and starts new sinks when they are registered
+type SinkManager struct {
+	// ctx is the passed in parent context that is used to signal that the
+	// SinkManager should stop
+	ctx context.Context
+
+	// broker is the event broker
+	broker *stream.EventBroker
+
+	// mu synchronizes access to sinkSubscriptions and newSinkWs
+	mu                sync.Mutex
+	sinkSubscriptions map[string]*ManagedSink
+	newSinkWs         memdb.WatchSet
+
+	// stateFn is a function that returns a pointer to the servers state store
+	stateFn func() *state.StateStore
+
+	L hclog.Logger
+}
+
+// NewSinkManager builds a new SinkManager. It also creates ManagedSinks for
+// all EventSinks in the state store
+func NewSinkManager(ctx context.Context, stateFn func() *state.StateStore, L hclog.Logger) (*SinkManager, error) {
+	state := stateFn()
+	if state == nil {
+		return nil, fmt.Errorf("state store was nil")
+	}
+
+	broker, err := state.EventBroker()
+	if err != nil {
+		return nil, err
+	}
+
+	newSinkWs := memdb.NewWatchSet()
+	newSinkWs.Add(state.AbandonCh())
+
+	m := &SinkManager{
+		stateFn:           stateFn,
+		broker:            broker,
+		ctx:               ctx,
+		sinkSubscriptions: make(map[string]*ManagedSink),
+		newSinkWs:         newSinkWs,
+		L:                 L,
+	}
+
+	iter, err := state.EventSinks(newSinkWs)
+	if err != nil {
+		return nil, err
+	}
+	var sinkIDs []string
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		sink := raw.(*structs.EventSink)
+		sinkIDs = append(sinkIDs, sink.ID)
+	}
+
+	for _, id := range sinkIDs {
+		mSink, err := NewManagedSink(ctx, id, stateFn, L)
+		if err != nil {
+			return nil, fmt.Errorf("creating managed sink: %w", err)
+		}
+		m.sinkSubscriptions[id] = mSink
+	}
+
+	return m, nil
+}
+
+func (m *SinkManager) Run() error {
+	errCh := make(chan SinkError)
+	execute := func(id string, ms *ManagedSink) {
+		err := ms.Run()
+		select {
+		case <-m.ctx.Done():
+		case errCh <- SinkError{ID: id, Error: err}:
+		}
+	}
+
+START:
+	for id, ms := range m.sinkSubscriptions {
+		sid, sinkSub := id, ms
+		if !ms.Running() {
+			go execute(sid, sinkSub)
+		}
+	}
+
+	for {
+		select {
+		case <-m.ctx.Done():
+			return m.ctx.Err()
+		case err := <-m.NewSinkWs().WatchCh(m.ctx):
+			if err != nil {
+				return err
+			}
+			// check for new sinks
+			err = m.refreshSinks()
+			if err != nil {
+				return err
+			}
+			goto START
+
+		case sinkErr := <-errCh:
+			if sinkErr.Error == ErrEventSinkDeregistered {
+				m.L.Debug("sink deregistered, removing from manager", "sink", sinkErr.ID)
+				m.removeSink(sinkErr.ID)
+			} else {
+				m.L.Warn("received error from managed event sink", "error", sinkErr.Error.Error())
+			}
+		}
+	}
+
+}
+
+func (m *SinkManager) removeSink(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.sinkSubscriptions, id)
+}
+
+func (m *SinkManager) refreshSinks() error {
+	state := m.stateFn()
+	if state == nil {
+		return fmt.Errorf("unable to fetch state store")
+	}
+
+	newSinkWs := state.NewWatchSet()
+	iter, err := state.EventSinks(newSinkWs)
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		sink := raw.(*structs.EventSink)
+		if _, ok := m.sinkSubscriptions[sink.ID]; !ok {
+			ms, err := NewManagedSink(m.ctx, sink.ID, m.stateFn, m.L)
+			if err != nil {
+				return err
+			}
+			m.sinkSubscriptions[sink.ID] = ms
+		}
+	}
+
+	m.newSinkWs = newSinkWs
+	return nil
+}
+
+// NewSinkWs returns the current newSinkWs used to listen for changes to the
+// event sink table in the state store
+func (m *SinkManager) NewSinkWs() memdb.WatchSet {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.newSinkWs
+}
+
+// ManagedSink maintains a subscription for a given EventSink. It is
+// responsible for resubscribing and consuming the subscription, writing events
+// to the managedsink's SinkWriter
+type ManagedSink struct {
+	// stopCtx is the passed in ctx used to signal that the ManagedSink should
+	// stop running
+	stopCtx context.Context
+
+	// Sink is the state store EventSink
+	Sink *structs.EventSink
+
+	// watchCh is used to watch for updates to the ManagedSink's Sink.
+	watchCh <-chan error
+
+	// doneReset is used to notify that the ManagedSink is done reloading
+	// itself from a subscription or state store change
+	doneReset chan struct{}
+
+	// Subscription is the event stream Subscription
+	Subscription *stream.Subscription
+
+	// LastSuccess is the index of the last successfully sent index
+	LastSuccess uint64
+
+	// SinkWriter is an interface used to send events to their final destination
+	SinkWriter stream.SinkWriter
+
+	// stateFn returns the current server's StateStore
+	stateFn func() *state.StateStore
+
+	// broker is the current server's event broker
+	broker *stream.EventBroker
+
+	// sinkCtx is used to signal that the sink needs to be reloaded
+	sinkCtx context.Context
+
+	// cancelFn cancels sinkCtx
+	cancelFn context.CancelFunc
+
+	// mu coordinates access to running
+	mu sync.Mutex
+
+	// running specifies if the managed sink is running
+	running bool
+
+	l hclog.Logger
+}
+
+// NewManagedSink returns a new ManagedSink for a given sinkID. It queries the
+// state store and subscribes the sink to the state stores event broker
+func NewManagedSink(ctx context.Context, sinkID string, stateFn func() *state.StateStore, L hclog.Logger) (*ManagedSink, error) {
+	state := stateFn()
+	if state == nil {
+		return nil, fmt.Errorf("unable to fetch state store")
+	}
+
+	if L == nil {
+		return nil, fmt.Errorf("logger was nil")
+	}
+
+	ws := state.NewWatchSet()
+	sink, err := state.EventSinkByID(ws, sinkID)
+	if err != nil {
+		return nil, fmt.Errorf("getting sink %s: %w", sinkID, err)
+	}
+
+	// TODO(drew) generate writer based off type
+	writer, err := stream.NewWebhookSink(sink)
+	if err != nil {
+		return nil, fmt.Errorf("generating sink writer for sink %w", err)
+	}
+	broker, err := state.EventBroker()
+	if err != nil {
+		return nil, err
+	}
+
+	sinkCtx, cancel := context.WithCancel(ctx)
+	ms := &ManagedSink{
+		stopCtx:    ctx,
+		Sink:       sink,
+		watchCh:    ws.WatchCh(sinkCtx),
+		doneReset:  make(chan struct{}),
+		SinkWriter: writer,
+		broker:     broker,
+		cancelFn:   cancel,
+		sinkCtx:    sinkCtx,
+		stateFn:    stateFn,
+		l:          L,
+	}
+
+	req := &stream.SubscribeRequest{
+		Topics: ms.Sink.Topics,
+	}
+
+	sub, err := ms.broker.Subscribe(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to subscribe sink %w", err)
+	}
+	ms.Subscription = sub
+
+	return ms, nil
+}
+
+// Run runs until the ManagedSink returns an non reloadable error or until the
+// parent ctx is stopped.
+func (m *ManagedSink) Run() error {
+	m.mu.Lock()
+	if m.running {
+		return fmt.Errorf("managed sink already running")
+	}
+	m.running = true
+	m.mu.Unlock()
+
+	defer func() {
+		m.mu.Lock()
+		m.running = false
+		m.mu.Unlock()
+	}()
+
+	defer m.Subscription.Unsubscribe()
+	exitCh := make(chan struct{})
+	defer close(exitCh)
+
+	// Listen for changes to EventSink. If there is a change cancel our local
+	// context to stop the subscription and reload with new changes.
+	go func() {
+		for {
+			select {
+			case <-exitCh:
+				return
+			case <-m.stopCtx.Done():
+				return
+			case err := <-m.WatchCh():
+				if err != nil {
+					return
+				}
+
+				// Cancel the subscription scoped context
+				m.cancelFn()
+
+				// wait until the reset was done
+				select {
+				case <-m.stopCtx.Done():
+					return
+				case <-m.doneReset:
+				case <-exitCh:
+				}
+			}
+		}
+	}()
+
+LOOP:
+	for {
+		events, err := m.Subscription.Next(m.sinkCtx)
+		if err != nil {
+			// Shutting down, exit gracefully
+			if m.stopCtx.Err() != nil {
+				return m.stopCtx.Err()
+			}
+
+			// Reloadable error, reload and restart
+			if err == stream.ErrSubscriptionClosed || err == context.Canceled {
+				if err := m.Reload(); err != nil {
+					return err
+				}
+				goto LOOP
+			}
+			return err
+		}
+
+		err = m.SinkWriter.Send(m.sinkCtx, &events)
+		if err != nil {
+			if strings.Contains(err.Error(), context.Canceled.Error()) {
+				continue
+			}
+			m.l.Warn("Failed to send event to sink", "sink", m.Sink.ID, "error", err)
+			continue
+		}
+		// Update the last successful index sent
+		atomic.StoreUint64(&m.LastSuccess, events.Index)
+	}
+}
+
+// Reload reloads and resets a ManagedSink.
+func (m *ManagedSink) Reload() error {
+	// Exit if shutting down
+	if err := m.stopCtx.Err(); err != nil {
+		return err
+	}
+
+	// Unsubscribe incase we haven't yet
+	m.Subscription.Unsubscribe()
+
+	// Fetch our updated or changed event sink with a new watchset
+	ws := memdb.NewWatchSet()
+	ws.Add(m.stateFn().AbandonCh())
+	sink, err := m.stateFn().EventSinkByID(ws, m.Sink.ID)
+	if err != nil {
+		return err
+	}
+
+	// Sink has been deleted, stop
+	if sink == nil {
+		return ErrEventSinkDeregistered
+	}
+
+	// Reconfigure the sink writer
+	writer, err := stream.NewWebhookSink(sink)
+	if err != nil {
+		return fmt.Errorf("generating sink writer for sink %w", err)
+	}
+
+	// Reset values we are updating
+	sinkCtx, cancel := context.WithCancel(m.stopCtx)
+	m.sinkCtx = sinkCtx
+	m.cancelFn = cancel
+	m.SinkWriter = writer
+	m.Sink = sink
+	m.watchCh = ws.WatchCh(sinkCtx)
+
+	// Resubscribe
+	req := &stream.SubscribeRequest{
+		Topics: m.Sink.Topics,
+		Index:  atomic.LoadUint64(&m.LastSuccess),
+	}
+
+	sub, err := m.broker.Subscribe(req)
+	if err != nil {
+		return fmt.Errorf("unable to subscribe sink %w", err)
+	}
+	m.Subscription = sub
+
+	// signal we are done reloading
+	m.doneReset <- struct{}{}
+	return nil
+}
+
+// Running specifies if the ManagedSink is currently running
+func (m *ManagedSink) Running() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.running
+}
+
+func (m *ManagedSink) WatchCh() <-chan error {
+	return m.watchCh
+}
+
+type SinkError struct {
+	ID    string
+	Error error
+}

--- a/nomad/event_sink_manager_test.go
+++ b/nomad/event_sink_manager_test.go
@@ -1,0 +1,500 @@
+package nomad
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManager_Run(t *testing.T) {
+	t.Parallel()
+
+	s, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+
+	receivedCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var event structs.Events
+		dec := json.NewDecoder(r.Body)
+		require.NoError(t, dec.Decode(&event))
+		require.Equal(t, "Deployment", string(event.Events[0].Topic))
+
+		receivedCount++
+	}))
+	defer ts.Close()
+
+	s1 := mock.EventSink()
+	s1.Address = ts.URL
+	s2 := mock.EventSink()
+	s2.Address = ts.URL
+
+	require.NoError(t, s.State().UpsertEventSink(1000, s1))
+	require.NoError(t, s.State().UpsertEventSink(1001, s2))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	manager, err := NewSinkManager(ctx, s.State, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	require.Len(t, manager.sinkSubscriptions, 2)
+
+	runStopped := make(chan struct{})
+	go func() {
+		err := manager.Run()
+		require.Error(t, err)
+		require.Equal(t, context.Canceled, err)
+		close(runStopped)
+	}()
+
+	// Publish an event
+	broker, err := s.State().EventBroker()
+	require.NoError(t, err)
+
+	broker.Publish(&structs.Events{Index: 1, Events: []structs.Event{{Topic: "Deployment"}}})
+
+	testutil.WaitForResult(func() (bool, error) {
+		return receivedCount == 2, fmt.Errorf("webhook count not equal to expected want %d, got %d", 2, receivedCount)
+	}, func(err error) {
+		require.Fail(t, err.Error())
+	})
+
+	cancel()
+
+	select {
+	case <-runStopped:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timeout waiting for manager to stop")
+	}
+}
+
+func TestManager_SinkErr(t *testing.T) {
+	t.Parallel()
+
+	s, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+
+	receivedCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var event structs.Events
+		dec := json.NewDecoder(r.Body)
+		require.NoError(t, dec.Decode(&event))
+		require.Equal(t, "Deployment", string(event.Events[0].Topic))
+
+		receivedCount++
+	}))
+	defer ts.Close()
+
+	s1 := mock.EventSink()
+	s1.Address = ts.URL
+	s2 := mock.EventSink()
+	s2.Address = ts.URL
+
+	require.NoError(t, s.State().UpsertEventSink(1000, s1))
+	require.NoError(t, s.State().UpsertEventSink(1001, s2))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	manager, err := NewSinkManager(ctx, s.State, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	require.Len(t, manager.sinkSubscriptions, 2)
+
+	runStopped := make(chan struct{})
+	go func() {
+		err := manager.Run()
+		require.Error(t, err)
+		require.Equal(t, context.Canceled, err)
+		close(runStopped)
+	}()
+
+	// Publish an event
+	broker, err := s.State().EventBroker()
+	require.NoError(t, err)
+
+	broker.Publish(&structs.Events{Index: 1, Events: []structs.Event{{Topic: "Deployment"}}})
+
+	testutil.WaitForResult(func() (bool, error) {
+		return receivedCount == 2, fmt.Errorf("webhook count not equal to expected want %d, got %d", 2, receivedCount)
+	}, func(err error) {
+		require.Fail(t, err.Error())
+	})
+
+	require.NoError(t, s.State().DeleteEventSinks(2000, []string{s1.ID}))
+
+	broker.Publish(&structs.Events{Index: 1, Events: []structs.Event{{Topic: "Deployment"}}})
+
+	time.Sleep(2 * time.Second)
+
+	cancel()
+
+	select {
+	case <-runStopped:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timeout waiting for manager to stop")
+	}
+}
+
+// TestManager_Run_AddNew asserts that adding a new managed sink to the state
+// store notifies the manager and starts the sink while leaving the existing
+// managed sinks running
+func TestManager_Run_AddNew(t *testing.T) {
+	t.Parallel()
+
+	s, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+
+	received := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var event structs.Events
+		dec := json.NewDecoder(r.Body)
+		require.NoError(t, dec.Decode(&event))
+		require.Equal(t, "Deployment", string(event.Events[0].Topic))
+
+		close(received)
+	}))
+	defer ts.Close()
+
+	received2 := make(chan struct{})
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var event structs.Events
+		dec := json.NewDecoder(r.Body)
+		require.NoError(t, dec.Decode(&event))
+		require.Equal(t, "Deployment", string(event.Events[0].Topic))
+
+		close(received2)
+	}))
+	defer ts2.Close()
+
+	s1 := mock.EventSink()
+	s1.Address = ts.URL
+
+	require.NoError(t, s.State().UpsertEventSink(1000, s1))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	manager, err := NewSinkManager(ctx, s.State, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	require.Len(t, manager.sinkSubscriptions, 1)
+
+	runErr := make(chan error)
+	go func() {
+		err := manager.Run()
+		runErr <- err
+	}()
+
+	// Publish an event
+	broker, err := s.State().EventBroker()
+	require.NoError(t, err)
+
+	broker.Publish(&structs.Events{Index: 1, Events: []structs.Event{{Topic: "Deployment"}}})
+
+	select {
+	case <-received:
+		// pass
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timeout waiting for first sink to send event")
+	}
+
+	s2 := mock.EventSink()
+	s2.Address = ts2.URL
+	require.NoError(t, s.State().UpsertEventSink(1001, s2))
+
+	select {
+	case <-received2:
+		// pass
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timeout waiting for first sink to send event")
+	}
+
+	// stop
+	cancel()
+
+	select {
+	case err := <-runErr:
+		require.Error(t, err)
+		require.Equal(t, context.Canceled, err)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timeout waiting for manager to stop")
+	}
+}
+
+func TestManagedSink_Run_Webhook(t *testing.T) {
+	t.Parallel()
+
+	// Setup webhook destination
+	received := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var event structs.Events
+		dec := json.NewDecoder(r.Body)
+		require.NoError(t, dec.Decode(&event))
+		require.Equal(t, "Deployment", string(event.Events[0].Topic))
+
+		close(received)
+	}))
+	defer ts.Close()
+
+	s, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+
+	s1 := mock.EventSink()
+	s1.Address = ts.URL
+	require.NoError(t, s.State().UpsertEventSink(1000, s1))
+
+	ws := memdb.NewWatchSet()
+	_, err := s.State().EventSinkByID(ws, s1.ID)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create sink
+	mSink, err := NewManagedSink(ctx, s1.ID, s.State, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	// Run in background
+	go func() {
+		mSink.Run()
+	}()
+
+	// Publish an event
+	broker, err := s.State().EventBroker()
+	require.NoError(t, err)
+
+	broker.Publish(&structs.Events{Index: 1, Events: []structs.Event{{Topic: "Deployment"}}})
+
+	// Ensure the webhook destination receives event
+	select {
+	case <-received:
+		// pass
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timeout waiting for webhook received")
+	}
+}
+
+func TestManagedSink_Run_Webhook_Update(t *testing.T) {
+	t.Parallel()
+
+	// Setup webhook destination
+	received1 := make(chan int, 3)
+	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var event structs.Events
+		dec := json.NewDecoder(r.Body)
+		require.NoError(t, dec.Decode(&event))
+		require.Equal(t, "Deployment", string(event.Events[0].Topic))
+
+		received1 <- int(event.Index)
+	}))
+	defer ts1.Close()
+
+	received2 := make(chan int, 3)
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var event structs.Events
+		dec := json.NewDecoder(r.Body)
+		require.NoError(t, dec.Decode(&event))
+		require.Equal(t, "Deployment", string(event.Events[0].Topic))
+
+		received2 <- int(event.Index)
+	}))
+	defer ts2.Close()
+
+	s, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	testutil.WaitForLeader(t, s.RPC)
+
+	s1 := mock.EventSink()
+	s1.Address = ts1.URL
+	require.NoError(t, s.State().UpsertEventSink(1000, s1))
+
+	ws := memdb.NewWatchSet()
+	_, err := s.State().EventSinkByID(ws, s1.ID)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mSink, err := NewManagedSink(ctx, s1.ID, s.State, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	go func() {
+		mSink.Run()
+	}()
+
+	broker, err := s.State().EventBroker()
+	require.NoError(t, err)
+
+	broker.Publish(&structs.Events{Index: 1, Events: []structs.Event{{Topic: "Deployment"}}})
+
+	select {
+	case got := <-received1:
+		require.Equal(t, 1, got)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timeout waiting for webhook received")
+	}
+
+	testutil.WaitForResult(func() (bool, error) {
+		ls := atomic.LoadUint64(&mSink.LastSuccess)
+		return int(ls) == 1, fmt.Errorf("expected last success to update")
+	}, func(err error) {
+		require.NoError(t, err)
+	})
+
+	// Update sink to point to new address
+	s1.Address = ts2.URL
+	require.NoError(t, s.State().UpsertEventSink(1001, s1))
+
+	// Wait for the address to propogate
+	testutil.WaitForResult(func() (bool, error) {
+		return mSink.Sink.Address == s1.Address, fmt.Errorf("expected managed sink address to update")
+	}, func(err error) {
+		require.Fail(t, err.Error())
+	})
+
+	// Publish a new event
+	broker.Publish(&structs.Events{Index: 2, Events: []structs.Event{{Topic: "Deployment"}}})
+
+	testutil.WaitForResult(func() (bool, error) {
+		ls := atomic.LoadUint64(&mSink.LastSuccess)
+		return int(ls) == 2, fmt.Errorf("expected last success to update")
+	}, func(err error) {
+		require.NoError(t, err)
+	})
+
+	// We persist last success so
+	select {
+	case got := <-received2:
+		require.Equal(t, 1, got)
+		// pass
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timeout waiting for webhook received")
+	}
+
+	// Point back to original
+	s1.Address = ts1.URL
+	require.NoError(t, s.State().UpsertEventSink(1002, s1))
+
+	testutil.WaitForResult(func() (bool, error) {
+		return mSink.Sink.Address == s1.Address, fmt.Errorf("expected managed sink address to update")
+	}, func(err error) {
+		require.FailNow(t, err.Error())
+	})
+
+	broker.Publish(&structs.Events{Index: 3, Events: []structs.Event{{Topic: "Deployment"}}})
+	select {
+	case got := <-received1:
+		got2 := <-received1
+		//
+		require.Equal(t, 2, got)
+		require.Equal(t, 3, got2)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timeout waiting for webhook received")
+	}
+}
+
+func TestManagedSink_Shutdown(t *testing.T) {
+	t.Parallel()
+
+	s, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+
+	s1 := mock.EventSink()
+	require.NoError(t, s.State().UpsertEventSink(1000, s1))
+
+	ws := memdb.NewWatchSet()
+	_, err := s.State().EventSinkByID(ws, s1.ID)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create sink
+	mSink, err := NewManagedSink(ctx, s1.ID, s.State, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	// Run in background
+	closed := make(chan struct{})
+	go func() {
+		err := mSink.Run()
+		require.Error(t, err)
+		require.Equal(t, context.Canceled, err)
+		close(closed)
+	}()
+
+	// Stop the parent context
+	cancel()
+
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "expected managed sink to stop")
+	}
+}
+
+func TestManagedSink_DeregisterSink(t *testing.T) {
+	t.Parallel()
+
+	s, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+
+	s1 := mock.EventSink()
+	require.NoError(t, s.State().UpsertEventSink(1000, s1))
+
+	ws := memdb.NewWatchSet()
+	_, err := s.State().EventSinkByID(ws, s1.ID)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create sink
+	mSink, err := NewManagedSink(ctx, s1.ID, s.State, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	// Run in background
+	closed := make(chan struct{})
+	go func() {
+		err := mSink.Run()
+		close(closed)
+		require.Error(t, err)
+		require.Equal(t, ErrEventSinkDeregistered, err)
+	}()
+
+	// Stop the parent context
+	require.NoError(t, s.State().DeleteEventSinks(1001, []string{s1.ID}))
+
+	select {
+	case <-closed:
+		// success
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "expected managed sink to stop")
+	}
+}

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -1522,5 +1522,8 @@ func EventSink() *structs.EventSink {
 		ID:      fmt.Sprintf("webhook-sink-%s", uuid.Generate()[0:8]),
 		Type:    structs.SinkWebhook,
 		Address: "http://127.0.0.1/",
+		Topics: map[structs.Topic][]string{
+			structs.TopicAll: {"*"},
+		},
 	}
 }

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -244,6 +244,10 @@ type Server struct {
 	// Nomad router.
 	statsFetcher *StatsFetcher
 
+	// eventSinkManager is used by the leader to send events to configured
+	// event sinks
+	eventSinkManager *SinkManager
+
 	// EnterpriseState is used to fill in state for Pro/Ent builds
 	EnterpriseState
 
@@ -365,6 +369,9 @@ func NewServer(config *Config, consulCatalog consul.CatalogAPI, consulConfigEntr
 
 	// Initialize the stats fetcher that autopilot will use.
 	s.statsFetcher = NewStatsFetcher(s.logger, s.connPool, s.config.Region)
+
+	// Initialize the event sink manager the leader will use
+	s.eventSinkManager = NewSinkManager(s.shutdownCtx, &serverDelegate{s}, s.logger)
 
 	// Setup Consul (more)
 	s.setupConsul(consulConfigEntries, consulACLs)

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -112,6 +112,15 @@ func NewStateStore(config *StateStoreConfig) (*StateStore, error) {
 	return s, nil
 }
 
+// NewWatchSet returns a new memdb.WatchSet that adds the state stores abandonCh
+// as a watcher. This is important in that it will notify when this specific
+// state store is no longer valid, usually due to a new snapshot being loaded
+func (s *StateStore) NewWatchSet() memdb.WatchSet {
+	ws := memdb.NewWatchSet()
+	ws.Add(s.AbandonCh())
+	return ws
+}
+
 func (s *StateStore) EventBroker() (*stream.EventBroker, error) {
 	if s.db.publisher == nil {
 		return nil, fmt.Errorf("EventBroker not configured")

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -9569,6 +9569,30 @@ func TestStateStore_UpsertEventSink(t *testing.T) {
 	require.Equal(t, structs.SinkWebhook, out.Type)
 }
 
+func TestStateStore_BatchUpdateEventSinks(t *testing.T) {
+	t.Parallel()
+
+	state := testStateStore(t)
+	s1 := mock.EventSink()
+	s2 := mock.EventSink()
+
+	require.NoError(t, state.UpsertEventSink(100, s1))
+	require.NoError(t, state.UpsertEventSink(101, s2))
+
+	s1.LatestIndex = uint64(200)
+	s2.LatestIndex = uint64(180)
+
+	require.NoError(t, state.BatchUpdateEventSinks(102, []*structs.EventSink{s1, s2}))
+
+	out, err := state.EventSinkByID(nil, s1.ID)
+	require.NoError(t, err)
+	require.Equal(t, uint64(200), out.LatestIndex)
+
+	out2, err := state.EventSinkByID(nil, s2.ID)
+	require.NoError(t, err)
+	require.Equal(t, uint64(180), out2.LatestIndex)
+}
+
 func TestStateStore_DeleteEventSinks(t *testing.T) {
 	t.Parallel()
 

--- a/nomad/stream/sink.go
+++ b/nomad/stream/sink.go
@@ -1,0 +1,12 @@
+package stream
+
+import (
+	"context"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// SinkWriter is the interface used by a ManagedSink to send events to.
+type SinkWriter interface {
+	Send(ctx context.Context, e *structs.Events) error
+}

--- a/nomad/stream/webhook_sink.go
+++ b/nomad/stream/webhook_sink.go
@@ -1,0 +1,88 @@
+package stream
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+func defaultHttpClient() *http.Client {
+	httpClient := cleanhttp.DefaultClient()
+	transport := httpClient.Transport.(*http.Transport)
+	transport.TLSHandshakeTimeout = 10 * time.Second
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	return httpClient
+}
+
+type WebhookSink struct {
+	client *http.Client
+
+	Address string
+}
+
+func NewWebhookSink(eventSink *structs.EventSink) (*WebhookSink, error) {
+	if eventSink.Address == "" {
+		return nil, fmt.Errorf("invalid address for websink")
+	} else if _, err := url.Parse(eventSink.Address); err != nil {
+		return nil, fmt.Errorf("invalid address '%s' : %v", eventSink.Address, err)
+	}
+
+	httpClient := defaultHttpClient()
+
+	return &WebhookSink{
+		Address: eventSink.Address,
+		client:  httpClient,
+	}, nil
+}
+
+func (ws *WebhookSink) Send(ctx context.Context, e *structs.Events) error {
+	req, err := ws.toRequest(ctx, e)
+	if err != nil {
+		return fmt.Errorf("converting event to request: %w", err)
+	}
+
+	err = ws.doRequest(req)
+	if err != nil {
+		return fmt.Errorf("sending request to webhook %w", err)
+	}
+
+	return nil
+}
+
+func (ws *WebhookSink) doRequest(req *http.Request) error {
+	_, err := ws.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func (ws *WebhookSink) toRequest(ctx context.Context, e *structs.Events) (*http.Request, error) {
+	buf := bytes.NewBuffer(nil)
+	enc := json.NewEncoder(buf)
+	if err := enc.Encode(e); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ws.Address, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	return req, nil
+}

--- a/nomad/stream/webhook_sink_test.go
+++ b/nomad/stream/webhook_sink_test.go
@@ -1,0 +1,55 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+)
+
+var _ SinkWriter = &WebhookSink{}
+
+func TestWebhookSink_Basic(t *testing.T) {
+	received := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var event structs.Events
+		dec := json.NewDecoder(r.Body)
+		require.NoError(t, dec.Decode(&event))
+		require.Equal(t, "Deployment", string(event.Events[0].Topic))
+
+		close(received)
+	}))
+	defer ts.Close()
+
+	sink := mock.EventSink()
+	sink.Address = ts.URL
+
+	webhook, err := NewWebhookSink(sink)
+	require.NoError(t, err)
+
+	e := &structs.Events{
+		Index: 1,
+		Events: []structs.Event{
+			{
+				Topic: "Deployment",
+			},
+		},
+	}
+	webhook.Send(context.Background(), e)
+
+	select {
+	case <-received:
+		// success
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "expected test server to receive webhook")
+	}
+}

--- a/nomad/structs/event.go
+++ b/nomad/structs/event.go
@@ -77,6 +77,11 @@ func (j *EventJson) Copy() *EventJson {
 	return n
 }
 
+type EventSinkProgressRequest struct {
+	Sinks []*EventSink
+	WriteRequest
+}
+
 type EventSinkUpsertRequest struct {
 	Sink *EventSink
 	WriteRequest
@@ -119,6 +124,11 @@ type EventSink struct {
 	Topics map[Topic][]string
 
 	Address string
+
+	// LatestIndex is the latest reported index that was successfully sent.
+	// MangedSinks periodically check in to update the LatestIndex so that a
+	// minimal amount of events are resent when reestablishing an event sink
+	LatestIndex uint64
 
 	CreateIndex uint64
 	ModifyIndex uint64

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -99,6 +99,7 @@ const (
 	CSIPluginDeleteRequestType                   MessageType = 40
 	EventSinkUpsertRequestType                   MessageType = 41
 	EventSinkDeleteRequestType                   MessageType = 42
+	BatchEventSinkUpdateProgressType             MessageType = 43
 
 	// Namespace types were moved from enterprise and therefore start at 64
 	NamespaceUpsertRequestType MessageType = 64


### PR DESCRIPTION
Adds a new SinkManager to control sending events to configured event sinks.

This PR adds a new SinkManager to Nomad Servers. When a server establishes leadership it will run the manager.

A SinkManager is responsible for:
- Establishing and running ManagedSinks
- Starting new ManagedSinks when one is added to the state store
- Periodically Checking in ManagedSink progress to raft

A ManagedSink is responsible for:
- Subscribing to the event broker 
- Sending events from the subscription to a SinkWriter
- Reloading itself when its EventSink is updated in the state store
