### PR TITLE
UI: Show the nomad agent version of the agent the UI is served from

### DIFF
--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -29,6 +29,20 @@ export default class SystemService extends Service {
   }
 
   @computed
+  get agent() {
+    const token = this.token;
+    return PromiseObject.create({
+      promise: token
+        .authorizedRawRequest(`/${namespace}/agent/self`)
+        .then(jsonWithDefault({}))
+        .then(agent => {
+          agent.version = agent.member?.Tags?.build || 'Unknown';
+          return agent;
+        }),
+    });
+  }
+
+  @computed
   get defaultRegion() {
     const token = this.token;
     return PromiseObject.create({

--- a/ui/app/styles/components/gutter.scss
+++ b/ui/app/styles/components/gutter.scss
@@ -1,4 +1,6 @@
 .gutter {
+  display: flex;
+  flex-direction: column;
   height: 100%;
   border-right: 1px solid $grey-blue;
   overflow: hidden;
@@ -55,6 +57,13 @@
 
   .menu {
     z-index: $z-gutter;
+  }
+
+  .gutter-footer {
+    text-align: center;
+    border-top: 1px solid lighten($grey-blue, 10%);
+    padding: 0.5em 0;
+    margin-top: auto;
   }
 }
 

--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -84,6 +84,9 @@
         <li><LinkTo @route="topology" @activeClass="is-active" data-test-gutter-link="topology">Topology</LinkTo></li>
       </ul>
     </aside>
+    <footer class="gutter-footer">
+      <span class="is-faded">v{{this.system.agent.version}}</span>
+    </footer>
   </div>
 </div>
 <div data-test-page-content class="page-column is-right">

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -323,6 +323,12 @@ export default function() {
     };
   });
 
+  this.get('/agent/self', function({ agents }) {
+    return {
+      member: this.serialize(agents.first()),
+    };
+  });
+
   this.get('/agent/monitor', function({ agents, nodes }, { queryParams }) {
     const serverId = queryParams.server_id;
     const clientId = queryParams.client_id;

--- a/ui/tests/acceptance/regions-test.js
+++ b/ui/tests/acceptance/regions-test.js
@@ -152,7 +152,7 @@ module('Acceptance | regions (many)', function(hooks) {
     );
   });
 
-  test('when the region is not the default region, all api requests include the region query param', async function(assert) {
+  test('when the region is not the default region, all api requests other than the agent/self request include the region query param', async function(assert) {
     window.localStorage.removeItem('nomadTokenSecret');
     const region = server.db.regions[1].id;
 
@@ -178,7 +178,11 @@ module('Acceptance | regions (many)', function(hooks) {
     );
 
     appRequests.forEach(req => {
-      assert.ok(req.url.includes(`region=${region}`), req.url);
+      if (req.url === '/v1/agent/self') {
+        assert.notOk(req.url.includes('region='), `(no region) ${req.url}`);
+      } else {
+        assert.ok(req.url.includes(`region=${region}`), req.url);
+      }
     });
   });
 });


### PR DESCRIPTION
Closes: #8389 

Slipping this one in. It would be nice to avoid making an additional request for this considering we have to fetch members to get the default region anyway, but I think this is the only guaranteed way to get the actual version in the event that servers are running different versions.

![image](https://user-images.githubusercontent.com/174740/97142081-3a079d00-171d-11eb-908c-9ff1e78a20fa.png)
