### PR TITLE
Fix HCLv2 parser discrepancies

### DIFF
--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -1400,6 +1400,12 @@ func TestParse(t *testing.T) {
 								"b":   true,
 								"val": 5,
 								"f":   .1,
+
+								"check": []map[string]interface{}{
+									{"foo": []map[string]interface{}{
+										{"query": "some_query"},
+									}},
+								},
 							},
 							Enabled: boolToPtr(false),
 						},

--- a/jobspec/test-fixtures/tg-scaling-policy.hcl
+++ b/jobspec/test-fixtures/tg-scaling-policy.hcl
@@ -10,6 +10,10 @@ job "elastic" {
         b   = true
         val = 5
         f   = 0.1
+
+        check "foo" {
+          query = "some_query"
+        }
       }
     }
   }

--- a/jobspec2/parse_map.go
+++ b/jobspec2/parse_map.go
@@ -197,9 +197,6 @@ func smallestNumber(b *big.Float) interface{} {
 		return v
 	}
 
-	if v, acc := b.Float64(); acc == big.Exact || acc == big.Above {
-		return v
-	}
-
-	return b
+	v, _ := b.Float64()
+	return v
 }

--- a/jobspec2/parse_map.go
+++ b/jobspec2/parse_map.go
@@ -188,7 +188,6 @@ func isCollectionOfMaps(t cty.Type) bool {
 }
 
 func smallestNumber(b *big.Float) interface{} {
-
 	if v, acc := b.Int64(); acc == big.Exact {
 		// check if it fits in int
 		if int64(int(v)) == v {

--- a/jobspec2/parse_test.go
+++ b/jobspec2/parse_test.go
@@ -38,6 +38,23 @@ func TestEquivalentToHCL1(t *testing.T) {
 	}
 }
 
+func TestEquivalentToHCL1_ComplexConfig(t *testing.T) {
+	name := "./test-fixtures/config-compatibility.hcl"
+	f, err := os.Open(name)
+	require.NoError(t, err)
+	defer f.Close()
+
+	job1, err := jobspec.Parse(f)
+	require.NoError(t, err)
+
+	f.Seek(0, 0)
+
+	job2, err := Parse(name, f)
+	require.NoError(t, err)
+
+	require.Equal(t, job1, job2)
+}
+
 func TestParse_VarsAndFunctions(t *testing.T) {
 	hcl := `
 job "example" {

--- a/jobspec2/test-fixtures/config-compatibility.hcl
+++ b/jobspec2/test-fixtures/config-compatibility.hcl
@@ -1,0 +1,78 @@
+job "example" {
+  group "group" {
+    task "task" {
+      config {
+        ## arbitrary structures to compare HCLv1 and HCLv2
+        ## HCLv2 must parse the same way HCLv1 parser does
+
+
+        # primitive attrs
+        attr_string    = "b"
+        attr_int       = 3
+        attr_large_int = 21474836470
+        attr_float     = 3.2
+
+        # lists attrs
+        attr_list_string = ["a", "b"]
+        attr_list_int    = [1, 2, 4]
+        attr_list_float  = [1.2, 2.3, 4.2]
+        attr_list_hetro  = [1, "a", 3.4, { "k" = "v" }]
+        attr_list_empty  = []
+
+        # map attrs
+        attr_map       = { "KEY" = "VAL", "KEY2" = "VAL2" }
+        attr_map_empty = {}
+
+        # simple blocks
+        block1 {
+          k    = "b"
+          key2 = "v2"
+        }
+        labeled_block "label1" {
+          k = "b"
+        }
+        multi_labeled_block "label1" "label2" "label3" {
+          k = "b"
+        }
+
+        # repeated block
+        repeated_block_type {
+          a = 2
+        }
+        repeated_block_type {
+          b = 3
+        }
+
+        # repeated blocks with labels
+        label_repeated "l1" {
+          a = 1
+        }
+        label_repeated "l1" {
+          a = 2
+        }
+        label_repeated "l2" "l21" {
+          a = 3
+        }
+        label_repeated "l2" "l21" "l23" {
+          a = 4
+        }
+        label_repeated "l3" {
+          a = 5
+        }
+
+        # nested blocks
+        outer_block "l1" {
+          level = 1
+          inner_block "l2" {
+            level = 2
+            most_inner "l3" {
+              level = 3
+
+              inner_map = { "K" = "V" }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix HCLv2 special handling of `map[string]interface{}` that appears in Task driver config and scaling policies.  Here, the HCLv2 parser needs to parse the tree the exact way as HCLv1 to maintain compatibility.

This PR fixes three classes of discrepancies:

First, floats are interpretted as float64 and never as big.Float

Second, in HCLv1, attributes assigned to map are interpreted as single map slices, so
```
# in HCL
map_attr = { "K" = "V" }

# parsed as
{"map_attr": [{"K": "V"}]}
```

Lastly, when blocks are repeated with labels, so
```
# in HCL
check "foo" {
  query = "query1"
}

check "bar" {
  query = "query2"
}

# parsed as
{
  "check": [
    {"foo": [{"query": "query1"}]},
    {"bar": [{"query": "query2"}]}
  ]
}
```

I've added tests first, so reviewer can see the failures initially in https://app.circleci.com/pipelines/github/hashicorp/nomad/12682/workflows/ec51a08c-b8fb-4ef3-ba5c-bd760e7b2740/jobs/112600 but it's passing at the end in https://app.circleci.com/pipelines/github/hashicorp/nomad/12683/workflows/7373db22-4e3c-46bd-996a-703f679eedc8/jobs/112616

Fixes https://github.com/hashicorp/nomad/issues/9170