### PR TITLE
Fix typo in batch processing use case

### DIFF
--- a/website/pages/intro/use-cases.mdx
+++ b/website/pages/intro/use-cases.mdx
@@ -52,8 +52,8 @@ easier to adopt the paradigm.
 
 As data science and analytics teams grow in size and complexity, they increasingly
 benefit from highly performant and scalable tools that can run batch workloads with
-minimal operational overhead. Nomad can natively run batch jobs and  [parameterized](https://www.hashicorp.com/blog/replacing-queues-with-nomad-dispatch) jobs. 
-workloads. Nomad's architecture enables easy scalability and an optimistically
+minimal operational overhead. Nomad can natively run batch jobs and [parameterized](https://www.hashicorp.com/blog/replacing-queues-with-nomad-dispatch) jobs. 
+Nomad's architecture enables easy scalability and an optimistically
 concurrent scheduling strategy that can yield [thousands of container deployments per
 second](https://www.hashicorp.com/c1m). Alternatives are overly complex and limited
 in terms of their scheduling throughput, scalability, and multi-cloud capabilities.


### PR DESCRIPTION
I believe there’s a typo where “workloads” was changed to “jobs” but the original word wasn’t removed. Or maybe it’s the other way around. But currently there is an orphaned one-word sentence.