### PR TITLE
Add support for external getter

### DIFF
--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -65,7 +65,7 @@ func (tr *TaskRunner) initHooks() {
 		newLogMonHook(tr, hookLogger),
 		newDispatchHook(alloc, hookLogger),
 		newVolumeHook(tr, hookLogger),
-		newArtifactHook(tr, hookLogger),
+		newArtifactHook(tr, tr.clientConfig.ExternalGetterCommand, hookLogger),
 		newStatsHook(tr, tr.clientConfig.StatsCollectionInterval, hookLogger),
 		newDeviceHook(tr.devicemanager, hookLogger),
 	}

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -265,6 +265,11 @@ type Config struct {
 	//
 	// This configuration is only considered if no host networks are defined.
 	BindWildcardDefaultHostNetwork bool
+
+	// ExternalGetterCommand configures an external tool uesd to retrieve artifacts.
+	// If not such command is defined (as is default), Nomad falls back and uses its
+	// internal version of go-getter.
+	ExternalGetterCommand string
 }
 
 type ClientTemplateConfig struct {
@@ -318,11 +323,12 @@ func DefaultConfig() *Config {
 			FunctionDenylist: []string{"plugin"},
 			DisableSandbox:   false,
 		},
-		RPCHoldTimeout:     5 * time.Second,
-		CNIPath:            "/opt/cni/bin",
-		CNIConfigDir:       "/opt/cni/config",
-		CNIInterfacePrefix: "eth",
-		HostNetworks:       map[string]*structs.ClientHostNetworkConfig{},
+		RPCHoldTimeout:        5 * time.Second,
+		CNIPath:               "/opt/cni/bin",
+		CNIConfigDir:          "/opt/cni/config",
+		CNIInterfacePrefix:    "eth",
+		HostNetworks:          map[string]*structs.ClientHostNetworkConfig{},
+		ExternalGetterCommand: "",
 	}
 }
 


### PR DESCRIPTION
Nomad has an internal library to acquire artifacts. Sometimes custom behavior/logic to acquire such artifacts is required (e.g. due to custom backends or auth schemes). Today all these need to implemented in the Nomad (or dependency) code base which does not scale well. This adds a way to leverage an external application to implement this getter functionality. This allows clean implementations of custom behaviors without polluting the Nomad code base.

I am still working on some minor aspects of this, but would appreciate any and all feedback on the overall idea as well as the implementation approach and the tests so far.