### PR TITLE
docs: v1.0.0-beta2 released!

### DIFF
--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -12,6 +12,11 @@ export default function DownloadsPage({ releaseData }) {
         version={VERSION}
         releaseData={releaseData}
         community="/resources"
+        prerelease={{
+          type: 'Beta',
+          name: 'v1.0.0',
+          version: '1.0.0-beta2'
+        }}
       />
     </div>
   )


### PR DESCRIPTION
Calling it "Beta" despite being "beta2" since "beta1" was never published.