### PR TITLE
e2e: reduce risk of flaky Ubuntu AMI build

### DIFF
--- a/e2e/terraform/packer/packer-ubuntu-bionic-amd64.json
+++ b/e2e/terraform/packer/packer-ubuntu-bionic-amd64.json
@@ -38,6 +38,10 @@
       "destination": "/tmp/config"
     },
     {
+      "type": "shell-local",
+      "inline": ["sleep 30"]
+    },
+    {
       "type": "shell",
       "script": "./ubuntu-bionic-amd64/setup.sh"
     }


### PR DESCRIPTION
The base Ubuntu AMI modifies apt sources during cloud-init. But the Packer
build can potentially start the setup script before that work is done,
resulting in errors trying to install base system dependencies like
`dnsmasq`. Delay the setup long enough to lose the race with cloud-init.

This is a mildly hacky fix but these builds are automated (running weekly), so
adding 30s to the build costs us a lot less than the time it would take to try
to fix how cloud-init is working for us.