### PR TITLE
e2e: set default version for dev cluster

### DIFF
--- a/e2e/terraform/Makefile
+++ b/e2e/terraform/Makefile
@@ -3,12 +3,14 @@ PKG_PATH = $(shell pwd)/../../pkg/linux_amd64/nomad
 
 dev-cluster:
 	terraform apply -auto-approve \
-		-var="nomad_sha=$(NOMAD_SHA)"
+		-var="nomad_sha=$(NOMAD_SHA)" \
+		-var="nomad_version="
 	terraform output environment
 
 dev-cluster-from-local:
 	terraform apply -auto-approve \
-		-var="nomad_local_binary=$(PKG_PATH)"
+		-var="nomad_local_binary=$(PKG_PATH)" \
+		-var="nomad_version="
 	terraform output environment
 
 clean:
@@ -21,7 +23,8 @@ full-cluster:
 
 plan-dev-cluster:
 	terraform plan \
-		-var="nomad_sha=$(NOMAD_SHA)"
+		-var="nomad_sha=$(NOMAD_SHA)" \
+		-var="nomad_version="
 
 plan-full-cluster:
 	terraform plan \

--- a/e2e/terraform/terraform.tfvars
+++ b/e2e/terraform/terraform.tfvars
@@ -9,6 +9,10 @@ nomad_enterprise                 = false
 vault                            = true
 volumes                          = false
 
+# default version for deployment
+nomad_version = "0.12.7"
+
 # Example overrides:
+# nomad_sha = "38e23b62a7700c96f4898be777543869499fea0a"
 # nomad_local_binary = "../../pkg/linux_amd/nomad"
 # nomad_local_binary_client_windows_2016_amd64 = ["../../pkg/windows_amd64/nomad.exe"]


### PR DESCRIPTION
Improve the DX for deploying a dev cluster by making it obvious that there's a default to change.