### PR TITLE
e2e: provide precedence for version variables

### DIFF
--- a/e2e/terraform/Makefile
+++ b/e2e/terraform/Makefile
@@ -3,14 +3,12 @@ PKG_PATH = $(shell pwd)/../../pkg/linux_amd64/nomad
 
 dev-cluster:
 	terraform apply -auto-approve \
-		-var="nomad_sha=$(NOMAD_SHA)" \
-		-var="nomad_version="
+		-var="nomad_sha=$(NOMAD_SHA)"
 	terraform output environment
 
 dev-cluster-from-local:
 	terraform apply -auto-approve \
-		-var="nomad_local_binary=$(PKG_PATH)" \
-		-var="nomad_version="
+		-var="nomad_local_binary=$(PKG_PATH)"
 	terraform output environment
 
 clean:
@@ -18,15 +16,14 @@ clean:
 
 full-cluster:
 	terraform apply -auto-approve \
-		-var="nomad_sha=$(NOMAD_SHA)" \
-		-var-file=terraform.full.tfvars
+		-var-file=terraform.full.tfvars \
+		-var="nomad_sha=$(NOMAD_SHA)"
 
 plan-dev-cluster:
 	terraform plan \
-		-var="nomad_sha=$(NOMAD_SHA)" \
-		-var="nomad_version="
+		-var="nomad_sha=$(NOMAD_SHA)"
 
 plan-full-cluster:
 	terraform plan \
-		-var="nomad_sha=$(NOMAD_SHA)" \
-		-var-file=terraform.full.tfvars
+		-var-file=terraform.full.tfvars \
+		-var="nomad_sha=$(NOMAD_SHA)"

--- a/e2e/terraform/README.md
+++ b/e2e/terraform/README.md
@@ -32,7 +32,7 @@ Run Terraform apply to deploy the infrastructure:
 
 ```sh
 cd e2e/terraform/
-terraform apply -var=nomad_sha=abcedf
+terraform apply
 ```
 
 > Note: You will likely see "Connection refused" or "Permission denied" errors
@@ -49,12 +49,13 @@ You'll need to pass one of the following variables in either your
 
 * `nomad_local_binary`: provision this specific local binary of Nomad. This is
   a path to a Nomad binary on your own host. Ex. `nomad_local_binary =
-  "/home/me/nomad"`.
+  "/home/me/nomad"`. This setting overrides `nomad_sha` or `nomad_version`.
 * `nomad_sha`: provision this specific sha from S3. This is a Nomad binary
   identified by its full commit SHA that's stored in a shared s3 bucket that
   Nomad team developers can access. That commit SHA can be from any branch
   that's pushed to remote. Ex. `nomad_sha =
-  "0b6b475e7da77fed25727ea9f01f155a58481b6c"`
+  "0b6b475e7da77fed25727ea9f01f155a58481b6c"`. This setting overrides
+  `nomad_version`.
 * `nomad_version`: provision this version from
   [releases.hashicorp.com](https://releases.hashicorp.com/nomad). Ex. `nomad_version
   = "0.10.2+ent"`

--- a/e2e/terraform/provision-nomad/main.tf
+++ b/e2e/terraform/provision-nomad/main.tf
@@ -50,11 +50,11 @@ data "template_file" "provision_script" {
 }
 
 data "template_file" "arg_nomad_sha" {
-  template = var.nomad_sha != "" ? " ${local._arg}nomad_sha ${var.nomad_sha}" : ""
+  template = var.nomad_sha != "" && var.nomad_local_binary == "" ? " ${local._arg}nomad_sha ${var.nomad_sha}" : ""
 }
 
 data "template_file" "arg_nomad_version" {
-  template = var.nomad_version != "" ? " ${local._arg}nomad_version ${var.nomad_version}" : ""
+  template = var.nomad_version != "" && var.nomad_sha == "" && var.nomad_local_binary == "" ? " ${local._arg}nomad_version ${var.nomad_version}" : ""
 }
 
 data "template_file" "arg_nomad_binary" {

--- a/e2e/terraform/terraform.full.tfvars
+++ b/e2e/terraform/terraform.full.tfvars
@@ -8,3 +8,8 @@ nomad_enterprise                 = true
 nomad_acls                       = true
 vault                            = true
 volumes                          = true
+
+# required to avoid picking up defaults from terraform.tfvars file
+nomad_version      = "" # default version for deployment
+nomad_sha          = "" # overrides nomad_version if set
+nomad_local_binary = "" # overrides nomad_sha and nomad_version if set

--- a/e2e/terraform/terraform.tfvars
+++ b/e2e/terraform/terraform.tfvars
@@ -9,8 +9,9 @@ nomad_enterprise                 = false
 vault                            = true
 volumes                          = false
 
-# default version for deployment
-nomad_version = "0.12.7"
+nomad_version      = "0.12.7" # default version for deployment
+nomad_sha          = ""       # overrides nomad_version if set
+nomad_local_binary = ""       # overrides nomad_sha and nomad_version if set
 
 # Example overrides:
 # nomad_sha = "38e23b62a7700c96f4898be777543869499fea0a"


### PR DESCRIPTION
The `nomad_sha`, `nomad_version`, and `nomad_local_binary` variables for the
Nomad provisioning module assumed that only one would be set. By having the
override each other with an explicit precedence, it makes it easier to avoid
problems with Terraform's implicit variables behavior.

Set the expected default values in the `terraform.full.tfvars` to avoid
shadowing by any future changes to the `terraform.tfvars` file.

Update the Makefile to put the `-var` and `-var-file` in the correct order.