### PR TITLE
Use Dockerhub Mirror.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -551,9 +551,7 @@ jobs:
           make deps
         name: Install golang dependencies
     - run:
-        command: |
-          # Pull from mirror and retag with bare tag.
-          docker pull docker.mirror.hashicorp.services/hashicorpnomad/busybox-windows:server2016-0.1
+        command: docker pull docker.mirror.hashicorp.services/hashicorpnomad/busybox-windows:server2016-0.1
         name: Pre-download docker test image
     - run:
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -554,7 +554,6 @@ jobs:
         command: |
           # Pull from mirror and retag with bare tag.
           docker pull docker.mirror.hashicorp.services/hashicorpnomad/busybox-windows:server2016-0.1
-          docker tag docker.mirror.hashicorp.services/hashicorpnomad/busybox-windows:server2016-0.1 hashicorpnomad/busybox-windows:server2016-0.1q
         name: Pre-download docker test image
     - run:
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -551,7 +551,10 @@ jobs:
           make deps
         name: Install golang dependencies
     - run:
-        command: docker pull hashicorpnomad/busybox-windows:server2016-0.1
+        command: |
+          # Pull from mirror and retag with bare tag.
+          docker pull docker.mirror.hashicorp.services/hashicorpnomad/busybox-windows:server2016-0.1
+          docker tag docker.mirror.hashicorp.services/hashicorpnomad/busybox-windows:server2016-0.1 hashicorpnomad/busybox-windows:server2016-0.1q
         name: Pre-download docker test image
     - run:
         command: |
@@ -703,7 +706,7 @@ jobs:
     docker:
     - environment:
         JOBS: 2
-      image: circleci/node:10-browsers
+      image: docker.mirror.hashicorp.services/circleci/node:10-browsers
     steps:
     - checkout
     - restore_cache:
@@ -732,7 +735,7 @@ jobs:
         path: /tmp/test-reports
   lint-go:
     docker:
-    - image: golang:1.15.1
+    - image: docker.mirror.hashicorp.services/golang:1.15.1
     working_directory: /go/src/github.com/hashicorp/nomad
     steps:
     - checkout
@@ -767,7 +770,7 @@ jobs:
     - PAGER: cat
   website-docker-image:
     docker:
-    - image: circleci/buildpack-deps
+    - image: docker.mirror.hashicorp.services/circleci/buildpack-deps
     shell: /usr/bin/env bash -euo pipefail -c
     steps:
     - checkout
@@ -912,7 +915,7 @@ jobs:
         path: /tmp/test-reports
   test-devices:
     docker:
-    - image: golang:1.15.1
+    - image: docker.mirror.hashicorp.services/golang:1.15.1
     working_directory: /go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
@@ -1050,7 +1053,7 @@ jobs:
     - PAGER: cat
   algolia_index:
     docker:
-    - image: node:12
+    - image: docker.mirror.hashicorp.services/node:12
     steps:
     - checkout
     - run:
@@ -1184,7 +1187,7 @@ jobs:
         path: /tmp/test-reports
   build-binaries:
     docker:
-    - image: golang:1.15.1
+    - image: docker.mirror.hashicorp.services/golang:1.15.1
     working_directory: /go/src/github.com/hashicorp/nomad
     environment:
     - GIT_PAGER: cat
@@ -1218,7 +1221,7 @@ jobs:
         path: pkg/linux_amd64.zip
   test-e2e:
     docker:
-    - image: golang:1.15.1
+    - image: docker.mirror.hashicorp.services/golang:1.15.1
     working_directory: /go/src/github.com/hashicorp/nomad
     steps:
     - checkout

--- a/.circleci/config/config.yml
+++ b/.circleci/config/config.yml
@@ -24,7 +24,7 @@ executors:
   go:
     working_directory: /go/src/github.com/hashicorp/nomad
     docker:
-      - image: golang:1.15.1
+      - image: docker.mirror.hashicorp.services/golang:1.15.1
     environment:
       <<: *common_envs
       GOPATH: /go

--- a/.circleci/config/jobs/algolia_index.yml
+++ b/.circleci/config/jobs/algolia_index.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: node:12
+  - image: docker.mirror.hashicorp.services/node:12
 steps:
   - checkout
   - run:

--- a/.circleci/config/jobs/test-ui.yml
+++ b/.circleci/config/jobs/test-ui.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/node:10-browsers
+  - image: docker.mirror.hashicorp.services/circleci/node:10-browsers
     environment:
       # See https://git.io/vdao3 for details.
       JOBS: 2

--- a/.circleci/config/jobs/test-windows.yml
+++ b/.circleci/config/jobs/test-windows.yml
@@ -25,7 +25,6 @@ steps:
       command: |
         # Pull from mirror and retag with bare tag.
         docker pull docker.mirror.hashicorp.services/hashicorpnomad/busybox-windows:server2016-0.1
-        docker tag docker.mirror.hashicorp.services/hashicorpnomad/busybox-windows:server2016-0.1 hashicorpnomad/busybox-windows:server2016-0.1q
   - run:
       name: Build nomad
       command: | 

--- a/.circleci/config/jobs/test-windows.yml
+++ b/.circleci/config/jobs/test-windows.yml
@@ -22,7 +22,10 @@ steps:
         make deps
   - run:
       name: Pre-download docker test image
-      command: docker pull hashicorpnomad/busybox-windows:server2016-0.1
+      command: |
+        # Pull from mirror and retag with bare tag.
+        docker pull docker.mirror.hashicorp.services/hashicorpnomad/busybox-windows:server2016-0.1
+        docker tag docker.mirror.hashicorp.services/hashicorpnomad/busybox-windows:server2016-0.1 hashicorpnomad/busybox-windows:server2016-0.1q
   - run:
       name: Build nomad
       command: | 

--- a/.circleci/config/jobs/test-windows.yml
+++ b/.circleci/config/jobs/test-windows.yml
@@ -22,9 +22,7 @@ steps:
         make deps
   - run:
       name: Pre-download docker test image
-      command: |
-        # Pull from mirror and retag with bare tag.
-        docker pull docker.mirror.hashicorp.services/hashicorpnomad/busybox-windows:server2016-0.1
+      command: docker pull docker.mirror.hashicorp.services/hashicorpnomad/busybox-windows:server2016-0.1
   - run:
       name: Build nomad
       command: | 

--- a/.circleci/config/jobs/website-docker-image.yml
+++ b/.circleci/config/jobs/website-docker-image.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: circleci/buildpack-deps
+  - image: docker.mirror.hashicorp.services/circleci/buildpack-deps
 shell: /usr/bin/env bash -euo pipefail -c
 steps:
   - checkout

--- a/drivers/docker/docklog/docker_logger_test.go
+++ b/drivers/docker/docklog/docker_logger_test.go
@@ -17,13 +17,20 @@ import (
 )
 
 func testContainerDetails() (image string, imageName string, imageTag string) {
+	name := "busybox"
+	tag := "1"
+
 	if runtime.GOOS == "windows" {
-		return "hashicorpnomad/busybox-windows:server2016-0.1",
-			"hashicorpnomad/busybox-windows",
-			"server2016-0.1"
+		name = "hashicorpnomad/busybox-windows"
+		tag = "server2016-0.1"
 	}
 
-	return "busybox:1", "busybox", "1"
+	if testutil.IsCI() {
+		// In CI, use HashiCorp Mirror to avoid DockerHub rate limiting
+		name = "docker.mirror.hashicorp.services/" + name
+	}
+
+	return name + ":" + tag, name, tag
 }
 
 func TestDockerLogger_Success(t *testing.T) {

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -333,7 +333,7 @@ func TestDockerDriver_Start_StoppedContainer(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		imageID, err = d.Impl().(*Driver).loadImage(task, &taskCfg, client)
 	} else {
-		image, lErr := client.InspectImage("hashicorpnomad/busybox-windows:server2016-0.1")
+		image, lErr := client.InspectImage(taskCfg.Image)
 		err = lErr
 		if image != nil {
 			imageID = image.ID

--- a/drivers/docker/driver_windows_test.go
+++ b/drivers/docker/driver_windows_test.go
@@ -6,12 +6,18 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/client/allocdir"
+	tu "github.com/hashicorp/nomad/testutil"
 )
 
 func newTaskConfig(variant string, command []string) TaskConfig {
 	// busyboxImageID is an id of an image containing nanoserver windows and
 	// a busybox exe.
 	busyboxImageID := "hashicorpnomad/busybox-windows:server2016-0.1"
+
+	if tu.IsCI() {
+		// In CI, use HashiCorp Mirror to avoid DockerHub rate limiting
+		busyboxImageID = "docker.mirror.hashicorp.services/" + busyboxImageID
+	}
 
 	return TaskConfig{
 		Image:            busyboxImageID,

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.16.3-alpine
+FROM docker.mirror.hashicorp.services/node:10.16.3-alpine
 RUN apk add --update --no-cache git make g++ automake autoconf libtool nasm libpng-dev
 
 COPY ./package.json /website/package.json


### PR DESCRIPTION
Dockerhub is going to rate limit unauthenticated pulls.

Use our HashiCorp internal mirror for builds run through CircleCI.