### PR TITLE
UI: Add namespace and task states query params to the topology route

### DIFF
--- a/ui/app/routes/topology.js
+++ b/ui/app/routes/topology.js
@@ -20,7 +20,11 @@ export default class TopologyRoute extends Route.extend(WithForbiddenState) {
   model() {
     return RSVP.hash({
       jobs: this.store.findAll('job'),
-      allocations: this.store.query('allocation', { resources: true }),
+      allocations: this.store.query('allocation', {
+        resources: true,
+        task_states: false,
+        namespace: '*',
+      }),
       nodes: this.store.query('node', { resources: true }),
     }).catch(notifyForbidden(this));
   }


### PR DESCRIPTION
Adding `namespace=*` will bring in allocations from all namespaces instead of only the default one.
Adding `task_states=false` will remove the task states properties from the allocations response which significantly reduces the size of the response.