### PR TITLE
Fix for Java fingerprinter on macOS

### DIFF
--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -223,6 +223,16 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 			return fp
 		}
 	}
+	if runtime.GOOS == "darwin" {
+		_, err := checkForMacJVM()
+		// return no error, as it isn't an error to not find java, it just means we
+		// can't use it.
+
+		fp.Health = drivers.HealthStateUndetected
+		fp.HealthDescription = ""
+		d.logger.Trace("macOS jvm not found", "error", err)
+		return fp
+	}
 
 	version, runtime, vm, err := javaVersionInfo()
 	if err != nil {

--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -225,13 +225,15 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	}
 	if runtime.GOOS == "darwin" {
 		_, err := checkForMacJVM()
-		// return no error, as it isn't an error to not find java, it just means we
-		// can't use it.
+		if err != nil {
+			// return no error, as it isn't an error to not find java, it just means we
+			// can't use it.
 
-		fp.Health = drivers.HealthStateUndetected
-		fp.HealthDescription = ""
-		d.logger.Trace("macOS jvm not found", "error", err)
-		return fp
+			fp.Health = drivers.HealthStateUndetected
+			fp.HealthDescription = ""
+			d.logger.Trace("macOS jvm not found", "error", err)
+			return fp
+		}
 	}
 
 	version, runtime, vm, err := javaVersionInfo()

--- a/drivers/java/utils.go
+++ b/drivers/java/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	rt "runtime"
 	"strings"
 )
 
@@ -28,7 +29,7 @@ func checkForMacJVM() (ok bool, err error) {
 func javaVersionInfo() (version, runtime, vm string, err error) {
 	var out bytes.Buffer
 
-	if runtime.GOOS == "darwin" {
+	if rt.GOOS == "darwin" {
 		_, err = checkForMacJVM()
 		if err != nil {
 			err = fmt.Errorf("failed to check java version: %v", err)

--- a/drivers/java/utils.go
+++ b/drivers/java/utils.go
@@ -9,10 +9,29 @@ import (
 )
 
 var javaVersionCommand = []string{"java", "-version"}
+var macOSJavaTestCommand = "/usr/libexec/java_home"
+
+func checkForMacJVM() (ok bool, err error) {
+	// test for java differently because of the shim application
+	var out bytes.Buffer
+	cmd := exec.Command(macOSJavaTestCommand)
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err = cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("failed check for macOS jvm: %v, out: %v", err, strings.Replace(strings.Replace(out.String(), "\n", " ", -1), `"`, `\"`, -1))
+		return false, err
+	}
+	return true, nil
+}
 
 func javaVersionInfo() (version, runtime, vm string, err error) {
 	var out bytes.Buffer
-
+	_, err = checkForMacJVM()
+	if err != nil {
+		err = fmt.Errorf("failed to check java version: %v", err)
+		return
+	}
 	cmd := exec.Command(javaVersionCommand[0], javaVersionCommand[1:]...)
 	cmd.Stdout = &out
 	cmd.Stderr = &out

--- a/drivers/java/utils.go
+++ b/drivers/java/utils.go
@@ -27,11 +27,15 @@ func checkForMacJVM() (ok bool, err error) {
 
 func javaVersionInfo() (version, runtime, vm string, err error) {
 	var out bytes.Buffer
-	_, err = checkForMacJVM()
-	if err != nil {
-		err = fmt.Errorf("failed to check java version: %v", err)
-		return
+
+	if runtime.GOOS == "darwin" {
+		_, err = checkForMacJVM()
+		if err != nil {
+			err = fmt.Errorf("failed to check java version: %v", err)
+			return
+		}
 	}
+
 	cmd := exec.Command(javaVersionCommand[0], javaVersionCommand[1:]...)
 	cmd.Stdout = &out
 	cmd.Stderr = &out


### PR DESCRIPTION
Fixes #7865

Found that `/usr/libexec/java_home` will provide information about whether or not a JVM is installed and not stimulate the "Install a JVM" popup window that running the shim commands do.  

