### PR TITLE
ar/groupservice: remove drivernetwork

### DIFF
--- a/client/allocrunner/groupservice_hook.go
+++ b/client/allocrunner/groupservice_hook.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/nomad/client/taskenv"
 	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/hashicorp/nomad/plugins/drivers"
 )
 
 type networkStatusGetter interface {
@@ -177,22 +176,6 @@ func (h *groupServiceHook) Postrun() error {
 	return nil
 }
 
-func (h *groupServiceHook) driverNet() *drivers.DriverNetwork {
-	if len(h.networks) == 0 {
-		return nil
-	}
-
-	//TODO(schmichael) only support one network for now
-	net := h.networks[0]
-	//TODO(schmichael) there's probably a better way than hacking driver network
-	return &drivers.DriverNetwork{
-		AutoAdvertise: true,
-		IP:            net.IP,
-		// Copy PortLabels from group network
-		PortMap: net.PortLabels(),
-	}
-}
-
 // deregister services from Consul.
 func (h *groupServiceHook) deregister() {
 	if len(h.services) > 0 {
@@ -221,7 +204,6 @@ func (h *groupServiceHook) getWorkloadServices() *agentconsul.WorkloadServices {
 		Group:         h.group,
 		Restarter:     h.restarter,
 		Services:      interpolatedServices,
-		DriverNetwork: h.driverNet(),
 		Networks:      h.networks,
 		NetworkStatus: netStatus,
 		Ports:         h.ports,

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -1476,10 +1476,24 @@ func getAddress(addrMode, portLabel string, networks structs.Networks, driverNet
 		mapping, ok := ports.Get(portLabel)
 		if !ok {
 			ip, port := networks.Port(portLabel)
-			if ip == "" && port <= 0 {
+			if ip != "" && port > 0 {
+				return ip, port, nil
+			}
+
+			// If port isn't a label, try to parse it as a literal port number
+			port, err := strconv.Atoi(portLabel)
+			if err != nil {
+				// Don't include Atoi error message as user likely
+				// never intended it to be a numeric and it creates a
+				// confusing error message
 				return "", 0, fmt.Errorf("invalid port %q: port label not found", portLabel)
 			}
-			return ip, port, nil
+			if port <= 0 {
+				return "", 0, fmt.Errorf("invalid port: %q: port must be >0", portLabel)
+			}
+
+			// A number was given which will use the Consul agent's address and the given port
+			return "", port, nil
 		}
 		return mapping.HostIP, mapping.Value, nil
 

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -1476,7 +1476,7 @@ func getAddress(addrMode, portLabel string, networks structs.Networks, driverNet
 		mapping, ok := ports.Get(portLabel)
 		if !ok {
 			ip, port := networks.Port(portLabel)
-			if ip != "" && port > 0 {
+			if port > 0 {
 				return ip, port, nil
 			}
 
@@ -1493,6 +1493,7 @@ func getAddress(addrMode, portLabel string, networks structs.Networks, driverNet
 			}
 
 			// A number was given which will use the Consul agent's address and the given port
+			// Returning a blank string as an address will use the Consul agent's address
 			return "", port, nil
 		}
 		return mapping.HostIP, mapping.Value, nil


### PR DESCRIPTION
Fixes a bug introduced in #9095 where the wrong port was used in service registration. This is because group services initially passed the port to the service watcher through use of a DriverNetwork. #9095 switch to using newer apis/interfaces that weren't previously available at the time, but didn't remove this initial functionality causing the wrong port number to be used on registration. 

fixes #9221 