### PR TITLE
UI: Add handling for empty state flaky test edge case

### DIFF
--- a/ui/tests/acceptance/topology-test.js
+++ b/ui/tests/acceptance/topology-test.js
@@ -56,8 +56,12 @@ module('Acceptance | topology', function(hooks) {
 
     await Topology.visit();
 
-    await Topology.viz.datacenters[0].nodes[0].memoryRects[0].select();
-    assert.equal(Topology.infoPanelTitle, 'Allocation Details');
+    if (Topology.viz.datacenters[0].nodes[0].isEmpty) {
+      assert.expect(0);
+    } else {
+      await Topology.viz.datacenters[0].nodes[0].memoryRects[0].select();
+      assert.equal(Topology.infoPanelTitle, 'Allocation Details');
+    }
   });
 
   test('when a node is selected, the info panel shows information on the node', async function(assert) {

--- a/ui/tests/pages/components/topo-viz/node.js
+++ b/ui/tests/pages/components/topo-viz/node.js
@@ -33,4 +33,5 @@ export default scope => ({
   }),
 
   emptyMessage: text('[data-test-empty-message]'),
+  isEmpty: hasClass('is-empty'),
 });


### PR DESCRIPTION
This test occasionally fails because the random generation
sometimes produces a node with no allocations, such as [here](https://app.circleci.com/pipelines/github/hashicorp/nomad/12735/workflows/9a407f87-0383-48ee-8e41-7e6e351dce28/jobs/113130/steps).

This is one way to solve it without trying to force the generated
data to always have an allocation.