### PR TITLE
UI: Change node id search to prefix-only

### DIFF
--- a/ui/app/components/global-search/control.js
+++ b/ui/app/components/global-search/control.js
@@ -26,7 +26,11 @@ export default class GlobalSearchControl extends Component {
       dataSource: this,
     });
 
-    this.nodeSearch = NodeSearch.create({
+    this.nodeNameSearch = NodeNameSearch.create({
+      dataSource: this,
+    });
+
+    this.nodeIdSearch = NodeIdSearch.create({
       dataSource: this,
     });
   }
@@ -62,7 +66,9 @@ export default class GlobalSearchControl extends Component {
       set(this, 'nodes', nodes.toArray());
 
       const jobResults = this.jobSearch.listSearched.slice(0, MAXIMUM_RESULTS);
-      const nodeResults = this.nodeSearch.listSearched.slice(0, MAXIMUM_RESULTS);
+
+      const mergedNodeListSearched = this.nodeNameSearch.listSearched.concat(this.nodeIdSearch.listSearched).uniq();
+      const nodeResults = mergedNodeListSearched.slice(0, MAXIMUM_RESULTS);
 
       return [
         {
@@ -70,7 +76,7 @@ export default class GlobalSearchControl extends Component {
           options: jobResults,
         },
         {
-          groupName: resultsGroupLabel('Clients', nodeResults, this.nodeSearch.listSearched),
+          groupName: resultsGroupLabel('Clients', nodeResults, mergedNodeListSearched),
           options: nodeResults,
         },
       ];
@@ -161,12 +167,11 @@ class JobSearch extends EmberObject.extend(Searchable) {
   fuzzySearchEnabled = true;
   includeFuzzySearchMatches = true;
 }
-
 @classic
-class NodeSearch extends EmberObject.extend(Searchable) {
+class NodeNameSearch extends EmberObject.extend(Searchable) {
   @computed
   get searchProps() {
-    return ['id', 'name'];
+    return ['name'];
   }
 
   @computed
@@ -179,6 +184,23 @@ class NodeSearch extends EmberObject.extend(Searchable) {
 
   fuzzySearchEnabled = true;
   includeFuzzySearchMatches = true;
+}
+
+@classic
+class NodeIdSearch extends EmberObject.extend(Searchable) {
+  @computed
+  get regexSearchProps() {
+    return ['id'];
+  }
+
+  @alias('dataSource.nodes') listToSearch;
+  @computed('dataSource.searchString')
+  get searchTerm() {
+    return `^${this.get('dataSource.searchString')}`;
+  }
+
+  exactMatchEnabled = false;
+  regexEnabled = true;
 }
 
 function resultsGroupLabel(type, renderedResults, allResults) {

--- a/ui/app/components/global-search/control.js
+++ b/ui/app/components/global-search/control.js
@@ -67,7 +67,7 @@ export default class GlobalSearchControl extends Component {
 
       const jobResults = this.jobSearch.listSearched.slice(0, MAXIMUM_RESULTS);
 
-      const mergedNodeListSearched = this.nodeNameSearch.listSearched.concat(this.nodeIdSearch.listSearched).uniq();
+      const mergedNodeListSearched = this.nodeIdSearch.listSearched.concat(this.nodeNameSearch.listSearched).uniq();
       const nodeResults = mergedNodeListSearched.slice(0, MAXIMUM_RESULTS);
 
       return [

--- a/ui/tests/acceptance/search-test.js
+++ b/ui/tests/acceptance/search-test.js
@@ -20,7 +20,7 @@ module('Acceptance | search', function(hooks) {
 
   test('search searches jobs and nodes with route- and time-based caching and navigates to chosen items', async function(assert) {
     server.create('node', { name: 'xyz' });
-    const otherNode = server.create('node', { name: 'aaa' });
+    const otherNode = server.create('node', { name: 'ghi' });
 
     server.create('job', { id: 'vwxyz', namespaceId: 'default' });
     server.create('job', { id: 'xyz', name: 'xyz job', namespace: 'default' });

--- a/ui/tests/acceptance/search-test.js
+++ b/ui/tests/acceptance/search-test.js
@@ -161,6 +161,25 @@ module('Acceptance | search', function(hooks) {
     });
   });
 
+  test('node id prefix matches take priority over node name matches', async function(assert) {
+    const nodeToMatchById = server.create('node', { name: 'xyz' });
+
+    const idPrefix = nodeToMatchById.id.substr(0, 5);
+
+    const nodeToMatchByName = server.create('node', { name: `node-name-with-id-piece-${idPrefix}`});
+
+    await visit('/');
+
+    await selectSearch(PageLayout.navbar.search.scope, idPrefix);
+
+    PageLayout.navbar.search.as(search => {
+      search.groups[1].as(clients => {
+        assert.equal(clients.options[0].text, nodeToMatchById.name);
+        assert.equal(clients.options[1].text, nodeToMatchByName.name);
+      });
+    });
+  });
+
   test('clicking the search field starts search immediately', async function(assert) {
     await visit('/');
 


### PR DESCRIPTION
This test has been periodically failing, like [here](https://app.circleci.com/pipelines/github/hashicorp/nomad/12879/workflows/40c0445c-b244-4a04-a5a3-d9685b656c94/jobs/114751/tests).

This test has sometimes been failing because the first node contains
the beginning of the `otherNode` id somewhere within its id. It seems
less useful to match within the node, so this changes id search to
only match at the beginning of the id.