### PR TITLE
website: require Node v14

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.mirror.hashicorp.services/node:10.16.3-alpine
+FROM docker.mirror.hashicorp.services/node:14.15.0-alpine
 RUN apk add --update --no-cache git make g++ automake autoconf libtool nasm libpng-dev
 
 COPY ./package.json /website/package.json

--- a/website/Makefile
+++ b/website/Makefile
@@ -38,8 +38,6 @@ build-image:
 # Use this if you have run `build-image` to use the locally built image
 # rather than our CI-generated image to test dependency changes.
 website-local:
-	@echo "==> Downloading latest Docker image..."
-	@docker pull hashicorp/nomad-website
 	@echo "==> Starting website in Docker..."
 	@docker run \
 		--interactive \

--- a/website/README.md
+++ b/website/README.md
@@ -48,7 +48,7 @@ The docker image is pre-built with all the website dependencies installed, which
 
 ### With Node
 
-If your local development environment has a supported version (v10.0.0+) of [node installed](https://nodejs.org/en/) you can run:
+If your local development environment has a supported version (v14.5.0+) of [node installed](https://nodejs.org/en/) you can run:
 
 - `npm install`
 - `npm start`
@@ -145,6 +145,7 @@ $ curl ...
 
 </Tab>
 </Tabs>
+
 
 Contined normal markdown content
 ````


### PR DESCRIPTION
Start using Node.js 14.5.0, the most recent active LTS.

The docs now require String.prototype.matchAll, that's part of ES2020
support, and is not available on Node.js 10.x as seen in https://node.green/#ES2020 .