### PR TITLE
Update monitor prefix test

### DIFF
--- a/command/monitor_test.go
+++ b/command/monitor_test.go
@@ -256,6 +256,9 @@ func TestMonitor_MonitorWithPrefix(t *testing.T) {
 
 	// Check the output
 	out := ui.OutputWriter.String()
+	if !strings.Contains(out, "Monitoring evaluation") {
+		t.Fatalf("expected evaluation monitoring output, got: %s", out)
+	}
 	if !strings.Contains(out, resp.EvalID[:8]) {
 		t.Fatalf("missing eval\n\n%s", out)
 	}
@@ -265,6 +268,8 @@ func TestMonitor_MonitorWithPrefix(t *testing.T) {
 	if !strings.Contains(out, "finished with status") {
 		t.Fatalf("missing final status\n\n%s", out)
 	}
+	ui.OutputWriter.Reset()
+	ui.ErrorWriter.Reset()
 
 	// Fail on identifier with too few characters
 	code = mon.monitor(resp.EvalID[:1], true)
@@ -274,14 +279,4 @@ func TestMonitor_MonitorWithPrefix(t *testing.T) {
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "must contain at least two characters.") {
 		t.Fatalf("expected too few characters error, got: %s", out)
 	}
-	ui.ErrorWriter.Reset()
-
-	code = mon.monitor(resp.EvalID[:3], true)
-	if code != 2 {
-		t.Fatalf("expect exit 2, got: %d", code)
-	}
-	if out := ui.OutputWriter.String(); !strings.Contains(out, "Monitoring evaluation") {
-		t.Fatalf("expected evaluation monitoring output, got: %s", out)
-	}
-
 }


### PR DESCRIPTION
Previously, this test would attempt to monitor an eval with a long
prefix, then with a too-short prefix, and finally with a
just-barely-long prefix.

Unfortunately, the last assertion sometimes does not fail its precondition 
correctly (return exit status 2) because of the expectation that there is only a
single matching alloc for the given, just-barely-long, prefix. This is
not always the case as there may be another allocation that matches that
same prefix as can be seen in the reproduction below:

```
    Prefix matched multiple evaluations

ID        Priority  Type   Triggered By   Status
d3202e02  1         batch  queued-allocs  blocked
d3a0d764  1         batch  job-register   complete
```

The fix here is not to make the just-barely-long prefix assertion, as it
isn't strictly necessary.

This is meant to fix e.g. https://app.circleci.com/pipelines/github/hashicorp/nomad/12875/workflows/e47e0ea0-8f54-4f20-aa17-74f29b13e8ab/jobs/114674