### PR TITLE
UI: Fix the raw 'blue' in recommendation cards to use '$blue'

### DIFF
--- a/ui/app/styles/components/recommendation-card.scss
+++ b/ui/app/styles/components/recommendation-card.scss
@@ -166,7 +166,7 @@
     }
 
     tr.active {
-      color: blue;
+      color: $blue;
       font-weight: bold;
 
       // When there’s only one task, it doesn’t need highlighting


### PR DESCRIPTION
I noticed this while poking around.

**Before**
<img width="1182" alt="Recommendation card with the active task in CSS blue" src="https://user-images.githubusercontent.com/174740/97921298-98311300-1d0f-11eb-85d8-a23ebf668288.png">


**After**
![Recommendation card with the active task in the correct blue](https://user-images.githubusercontent.com/174740/97921346-ab43e300-1d0f-11eb-9fc5-98b4dc3ce9cb.png)
