### PR TITLE
Add missing comma in help-text example.

### DIFF
--- a/command/event.go
+++ b/command/event.go
@@ -28,7 +28,7 @@ Usage: nomad event <subcommand> [options] [args]
       $ cat sink.json
       {
         "ID": "my-sink",
-        "Type": "webhook"
+        "Type": "webhook",
         "Address": "http://127.0.0.1:8080",
         "Topics": {
           "*": ["*"]


### PR DESCRIPTION
@krishicks, I spotted this while playing with command.