### PR TITLE
[Website] Bump HSM version

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1799,9 +1799,9 @@
       "integrity": "sha512-a2eWgjLwGAC2LjUHE7Xt6sRGGjyTWfrc4N+qVxsyZw4eE0EiNhMIKDYHWjmtb+tGh8r8j+ca3tSjsuOUePVPUw=="
     },
     "@hashicorp/react-hashi-stack-menu": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-1.0.7.tgz",
-      "integrity": "sha512-WcPD9T2WjjuAlUmCNG3ed6zmroKC0T9LDf5ocL/IWTI5TSnqtjmlC63066v1YCPytG1B/QMkarFP9SYZUrIJrQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-1.0.8.tgz",
+      "integrity": "sha512-qKNkYguud3rmZQczIaPLYzhuaOahyRulV0KIxKo4TCjfHEzXJfbXaKi8uq1GJw2wAMOl0tV3brMTC0z1S3uTEw==",
       "requires": {
         "@hashicorp/react-inline-svg": "^1.0.2",
         "slugify": "1.3.4"

--- a/website/package.json
+++ b/website/package.json
@@ -16,7 +16,7 @@
     "@hashicorp/react-docs-page": "6.3.1",
     "@hashicorp/react-docs-sidenav": "5.2.1",
     "@hashicorp/react-global-styles": "4.6.1",
-    "@hashicorp/react-hashi-stack-menu": "^1.0.7",
+    "@hashicorp/react-hashi-stack-menu": "^1.0.8",
     "@hashicorp/react-head": "1.1.4",
     "@hashicorp/react-hero": "3.1.9",
     "@hashicorp/react-image": "3.0.1",


### PR DESCRIPTION
Bumps `<HashiStackMenu />` version for design tweaks

[🔍 Preview Link](https://nomad-git-jmbump-hsm-version-108.hashicorp.vercel.app/)