### PR TITLE
Fix RPC retry logic in nomad client's rpc.go for blocking queries

### DIFF
--- a/client/rpc.go
+++ b/client/rpc.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"net/rpc"
+	"reflect"
 	"strings"
 	"time"
 
@@ -46,6 +47,32 @@ func (c *Client) StreamingRpcHandler(method string) (structs.StreamingRpcHandler
 	return c.streamingRpcs.GetHandler(method)
 }
 
+// Given a type that is or eventually points to a concrete type with an embedded QueryOptions
+// returns the value reference to that options. Otherwise returns reflect.Value{}
+func getEmbeddedQueryOptsValue(arg interface{}) reflect.Value {
+	// Dereference interfaces or pointers for their concrete types
+	maybeOpts := reflect.ValueOf(arg)
+	for maybeOpts.Kind() == reflect.Ptr || maybeOpts.Kind() == reflect.Interface {
+		maybeOpts = maybeOpts.Elem()
+	}
+	return maybeOpts.FieldByName("QueryOptions")
+}
+
+// Given a type that is or eventually points to a concrete type with an embedded QueryOptions
+// returns a copy of that QueryOptions.
+func getEmbeddedQueryOpts(arg interface{}) (structs.QueryOptions, bool) {
+	if maybeOpts := getEmbeddedQueryOptsValue(arg); maybeOpts != (reflect.Value{}) {
+		return maybeOpts.Interface().(structs.QueryOptions), true
+	}
+	return structs.QueryOptions{}, false
+}
+
+// Sets the query options embedded in the concrete type backing the arg
+// will panic if there isn't a query opts in there
+func setEmbeddedQueryOpts(arg interface{}, opts structs.QueryOptions) {
+	getEmbeddedQueryOptsValue(arg).Set(reflect.ValueOf(opts))
+}
+
 // RPC is used to forward an RPC call to a nomad server, or fail if no servers.
 func (c *Client) RPC(method string, args interface{}, reply interface{}) error {
 	// Invoke the RPCHandler if it exists
@@ -53,12 +80,20 @@ func (c *Client) RPC(method string, args interface{}, reply interface{}) error {
 		return c.config.RPCHandler.RPC(method, args, reply)
 	}
 
-	// This is subtle but we start measuring the time on the client side
-	// right at the time of the first request, vs. on the first retry as
-	// is done on the server side inside forward(). This is because the
-	// servers may already be applying the RPCHoldTimeout up there, so by
-	// starting the timer here we won't potentially double up the delay.
-	firstCheck := time.Now()
+	// We will try to automatically retry requests that fail due to things like server unavailability
+	// but instead of retrying forever, lets have a solid upper-bound
+	deadline := time.Now()
+
+	// A reasonable amount of time for leader election. Note when servers forward() our RPC requests
+	// to the leader they may also allow for an RPCHoldTimeout while waiting for leader election.
+	// That's OK, we won't double up because we are using it here not as a sleep but
+	// as a hint to give up
+	deadline = deadline.Add(c.config.RPCHoldTimeout)
+
+	// If its a blocking query, allow the time specified by the request
+	if opts, ok := getEmbeddedQueryOpts(args); ok {
+		deadline = deadline.Add(opts.TimeToBlock())
+	}
 
 TRY:
 	server := c.servers.FindServer()
@@ -68,6 +103,7 @@ TRY:
 
 	// Make the request.
 	rpcErr := c.connPool.RPC(c.Region(), server.Addr, c.RPCMajorVersion(), method, args, reply)
+
 	if rpcErr == nil {
 		c.fireRpcRetryWatcher()
 		return nil
@@ -83,14 +119,40 @@ TRY:
 	// Move off to another server, and see if we can retry.
 	c.rpcLogger.Error("error performing RPC to server", "error", rpcErr, "rpc", method, "server", server.Addr)
 	c.servers.NotifyFailedServer(server)
-	if retry := canRetry(args, rpcErr, firstCheck, c.config.RPCHoldTimeout); !retry {
+
+	if !canRetry(args, rpcErr) {
+		c.rpcLogger.Error("error performing RPC to server which is not safe to automatically retry", "error", rpcErr, "rpc", method, "server", server.Addr)
+		return rpcErr
+	}
+	if time.Now().After(deadline) {
+		// Blocking queries are tricky.  jitters and rpcholdtimes in multiple places can result in our server call taking longer than we wanted it to. For example:
+		// a block time of 5s may easily turn into the server blocking for 10s since it applies its own RPCHoldTime. If the server dies at t=7s we still want to retry
+		// so before we give up on blocking queries make one last attempt for an immediate answer
+		if opts, ok := getEmbeddedQueryOpts(args); ok && opts.TimeToBlock() > 0 {
+			opts.MinQueryIndex = 0
+			opts.MaxQueryTime = 0
+			setEmbeddedQueryOpts(args, opts)
+			return c.RPC(method, args, reply)
+		}
+		c.rpcLogger.Error("error performing RPC to server, deadline exceeded, cannot retry", "error", rpcErr, "rpc", method, "server", server.Addr)
 		return rpcErr
 	}
 
-	// We can wait a bit and retry!
-	jitter := lib.RandomStagger(c.config.RPCHoldTimeout / structs.JitterFraction)
+	// Wait to avoid thundering herd
 	select {
-	case <-time.After(jitter):
+	case <-time.After(lib.RandomStagger(c.config.RPCHoldTimeout / structs.JitterFraction)):
+		// If we are going to retry a blocking query we need to update the time to block so it finishes by our deadline.
+		if opts, ok := getEmbeddedQueryOpts(args); ok && opts.TimeToBlock() > 0 {
+			opts.MaxQueryTime = deadline.Sub(time.Now())
+			// We can get below 0 here on slow computers because we slept for jitter so at least try to get an immediate response
+			if opts.MaxQueryTime <= 0 {
+				opts.MinQueryIndex = 0
+				opts.MaxQueryTime = 0
+			}
+			setEmbeddedQueryOpts(args, opts)
+			return c.RPC(method, args, reply)
+		}
+
 		goto TRY
 	case <-c.shutdownCh:
 	}
@@ -98,7 +160,7 @@ TRY:
 }
 
 // canRetry returns true if the given situation is safe for a retry.
-func canRetry(args interface{}, err error, start time.Time, rpcHoldTimeout time.Duration) bool {
+func canRetry(args interface{}, err error) bool {
 	// No leader errors are always safe to retry since no state could have
 	// been changed.
 	if structs.IsErrNoLeader(err) {
@@ -108,7 +170,7 @@ func canRetry(args interface{}, err error, start time.Time, rpcHoldTimeout time.
 	// Reads are safe to retry for stream errors, such as if a server was
 	// being shut down.
 	info, ok := args.(structs.RPCInfo)
-	if ok && info.IsRead() && lib.IsErrEOF(err) && !info.HasTimedOut(start, rpcHoldTimeout) {
+	if ok && info.IsRead() && lib.IsErrEOF(err) {
 		return true
 	}
 

--- a/nomad/rpc.go
+++ b/nomad/rpc.go
@@ -780,12 +780,7 @@ func (r *rpcHandler) blockingRPC(opts *blockingOptions) error {
 		goto RUN_QUERY
 	}
 
-	// Restrict the max query time, and ensure there is always one
-	if opts.queryOpts.MaxQueryTime > structs.MaxBlockingRPCQueryTime {
-		opts.queryOpts.MaxQueryTime = structs.MaxBlockingRPCQueryTime
-	} else if opts.queryOpts.MaxQueryTime <= 0 {
-		opts.queryOpts.MaxQueryTime = structs.DefaultBlockingRPCQueryTime
-	}
+	opts.queryOpts.MaxQueryTime = opts.queryOpts.TimeToBlock()
 
 	// Apply a small amount of jitter to the request
 	opts.queryOpts.MaxQueryTime += lib.RandomStagger(opts.queryOpts.MaxQueryTime / structs.JitterFraction)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -229,6 +229,11 @@ type RPCInfo interface {
 	AllowStaleRead() bool
 	IsForwarded() bool
 	SetForwarded()
+	TimeToBlock() time.Duration
+	// TimeToBlock sets how long this request can block. The requested time may not be possible,
+	// so Callers should readback TimeToBlock. E.g. you cannot set time to block at all on WriteRequests
+	// and it cannot exceed MaxBlockingRPCQueryTime
+	SetTimeToBlock(t time.Duration)
 }
 
 // InternalRpcInfo allows adding internal RPC metadata to an RPC. This struct
@@ -295,6 +300,10 @@ func (q QueryOptions) TimeToBlock() time.Duration {
 		return DefaultBlockingRPCQueryTime
 	}
 	return q.MaxQueryTime
+}
+
+func (q QueryOptions) SetTimeToBlock(t time.Duration) {
+	q.MaxQueryTime = t
 }
 
 func (q QueryOptions) RequestRegion() string {
@@ -380,6 +389,13 @@ type WriteRequest struct {
 	AuthToken string
 
 	InternalRpcInfo
+}
+
+func (w WriteRequest) TimeToBlock() time.Duration {
+	return 0
+}
+
+func (w WriteRequest) SetTimeToBlock(_ time.Duration) {
 }
 
 func (w WriteRequest) RequestRegion() string {


### PR DESCRIPTION
Overhaul the RPC retry logic with recent learnings about how it can fail. For tons of detail about all the learnings and care we put into this please see https://github.com/hashicorp/nomad/issues/9265

I realize this probably looks scary, so i am also available for a voice chat, and I hope the details in #9265 help.

# Description
[The fix](https://github.com/hashicorp/nomad/pull/8921) which we merged into Nomad for the above issue is a good one - without it retries cannot possibly work, but it does have a flaw.

Consider:
1. A long poll is made with a timeout of 5 minutes
2. A retriable error occurs at the 4 minute mark
3. We make a new request to the server

What you would expect is that the second request, #3, has a timeout of 1 minute. Unfortunately, that is not what happens. The request is made again from the top - with a timeout of 5 minutes just like the first - and so the entire request could take as much as 9 minutes, even though the client asked for 5 minutes.

What is even worse about this is that if another retriable error occurs at the 7 minute mark, the code will not retry because it will realize it has been 7 minutes with a timeout of 5 and so the client will see an EOF. What it should have seen was a timeout at the 5 minute mark instead.

The correct fix for this is clear: step 3 should make a request to the sever with a timeout of 1 minute (the original timeout, minus time elapsed already). However, how to implement that is not so straight forward.

Because the RPC helpers burry the request time in interfaces and re-infer defaults on the server, there is no easy way for the RPC helper to change the request time to reflect the updated elapsed time. 

One way to do that is with reflect. This is an inelegant solution that fixes the bug with a hammer. To fix it correctly, the client needs a way to tell the server the timeout time in a way that is not invisible and type-lost to the RPC function. However the complexity and risk of such a change does not seem appropriate.


# Tested by
The following cases were testing. As a note, we have been using this patch at Cloudflare on thousands of nodes for the past two weeks and have noticed only an improvement

1. Ran this bash script for 8 minutes. It did eventually fail due to "no cluster leader" but everything retried appropriately
```
while :; do sudo docker restart nomad-server-$(($RANDOM % 5)) && sleep  $((5 + $RANDOM % 10)); done^C
```
2. Changed default blocking time and logged how long blocking queries took using the above script. They took 30-40s each, which is expected when you add a default RPCHoldtime of 5s which can be applied twice for blocking queries. This seems sane to me.

3. Added test code to force an EOF error every 10 seconds (separate from above tests) and verified it always retries
