### PR TITLE
Update Cinder CSI example docs

### DIFF
--- a/demo/csi/cinder-csi-plugin/cinder-csi-plugin.hcl
+++ b/demo/csi/cinder-csi-plugin/cinder-csi-plugin.hcl
@@ -33,10 +33,10 @@ EOF
 
         args = [
           "/bin/cinder-csi-plugin",
+          "-v=4",
           "--endpoint=unix:///csi/csi.sock",
           "--cloud-config=/etc/config/cloud.conf",
           "--nodeid=${node.unique.name}",
-          "--cluster=${NOMAD_DC}"
         ]
         privileged = true
       }
@@ -72,6 +72,7 @@ EOF
 
         args = [
           "/bin/cinder-csi-plugin",
+          "-v=4",
           "--endpoint=unix:///csi/csi.sock",
           "--cloud-config=/etc/config/cloud.conf",
           "--nodeid=${node.unique.name}",

--- a/demo/csi/cinder-csi-plugin/example_volume.hcl
+++ b/demo/csi/cinder-csi-plugin/example_volume.hcl
@@ -3,7 +3,7 @@ id              = "testvol"
 name            = "test_volume"
 external_id     = "56as4da-as524d-asd9-asd8-asdasd52555"
 access_mode     = "single-node-writer"
-attachment_mode = "block-device"
+attachment_mode = "file-system"
 plugin_id       = "cinder-csi"
 mount_options {
   fs_type = "ext4"


### PR DESCRIPTION
- Add verbose logging to CSI Driver example
- Update the `attachment_mode` in the example volume registration to be `file-system`