### PR TITLE
UI: Update lingering instances of the old warning icon in stories

### DIFF
--- a/ui/stories/components/gutter-menu.stories.js
+++ b/ui/stories/components/gutter-menu.stories.js
@@ -139,7 +139,7 @@ export let IconItems = () => {
 
               <p class="menu-label">Features</p>
               <ul class="menu-list">
-                <li><a href="javascript:;">{{x-icon "warning"}} Feature One</a></li>
+                <li><a href="javascript:;">{{x-icon "alert-triangle"}} Feature One</a></li>
                 <li><a href="javascript:;">{{x-icon "media-pause"}} Feature Two</a></li>
               </ul>
             </aside>
@@ -172,7 +172,7 @@ export let TaggedItems = () => {
 
               <p class="menu-label">Features</p>
               <ul class="menu-list">
-                <li><a href="javascript:;">{{x-icon "warning"}} Feature One</a></li>
+                <li><a href="javascript:;">{{x-icon "alert-triangle"}} Feature One</a></li>
                 <li><a href="javascript:;">{{x-icon "media-pause"}} Feature Two <span class="tag is-small is-warning">3</span></a></li>
               </ul>
             </aside>

--- a/ui/stories/components/table.stories.js
+++ b/ui/stories/components/table.stories.js
@@ -446,7 +446,7 @@ export let CellIcons = () => {
             <tr>
               <td class="is-narrow">
                 {{#if (lt row.model.growth 0)}}
-                  {{x-icon "warning" class="is-warning"}}
+                  {{x-icon "alert-triangle" class="is-warning"}}
                 {{/if}}
               </td>
               <td>{{row.model.rank}}</td>


### PR DESCRIPTION
I missed these when I removed the warning icon. Note to self: grep the stories directory as well as app and tests.