### PR TITLE
core: optimize AllocsFit to minimize calculation

### DIFF
--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -677,9 +677,49 @@ func evaluateNodePlan(snap *state.StateSnapshot, plan *structs.Plan, nodeID stri
 	proposed := structs.RemoveAllocs(existingAlloc, remove)
 	proposed = append(proposed, plan.NodeAllocation[nodeID]...)
 
+	// Only check devices and networks if the job being planned uses them
+	// since simply removing allocs can never cause invalid device or port
+	// allocations.
+	checkDev, checkNet := containsDeviceNet(plan.Job)
+
 	// Check if these allocations fit
-	fit, reason, _, err := structs.AllocsFit(node, proposed, nil, true)
+	fit, reason, _, err := structs.AllocsFit(node, proposed, checkDev, checkNet)
 	return fit, reason, err
+}
+
+// containsDeviceNet requires true if a job contains any devices or networks.
+func containsDeviceNet(job *structs.Job) (containsDev, containsNet bool) {
+	for _, tg := range job.TaskGroups {
+		if len(tg.Networks) > 0 {
+			for _, net := range tg.Networks {
+				if net.Mode != "none" {
+					containsNet = true
+					break
+				}
+			}
+		}
+
+		for _, task := range tg.Tasks {
+			if containsDev && containsNet {
+				// Found both, return early
+				return containsDev, containsNet
+			}
+
+			if task.Resources == nil {
+				continue
+			}
+
+			if len(task.Resources.Devices) > 0 {
+				containsDev = true
+			}
+
+			if len(task.Resources.Networks) > 0 {
+				containsNet = true
+			}
+		}
+	}
+
+	return containsDev, containsNet
 }
 
 func max(a, b uint64) uint64 {

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -95,11 +95,18 @@ func FilterTerminalAllocs(allocs []*Allocation) ([]*Allocation, map[string]*Allo
 }
 
 // AllocsFit checks if a given set of allocations will fit on a node.
-// The netIdx can optionally be provided if its already been computed.
-// If the netIdx is provided, it is assumed that the client has already
-// ensured there are no collisions. If checkDevices is set to true, we check if
-// there is a device oversubscription.
-func AllocsFit(node *Node, allocs []*Allocation, netIdx *NetworkIndex, checkDevices bool) (bool, string, *ComparableResources, error) {
+//
+// This func is shared between the binpack iterator and plan applier. During
+// binpack iteration network and device collisions are detected prior to
+// calling this func. During plan applying this func must check devices and
+// networks again to ensure there are still no collisions, but these checks may
+// be skipped if no allocs use devices or networks.
+//
+// If the netIdx is nil, it is assumed that the client has already
+// ensured there are no collisions.
+// If checkDevices is set to true, we check if there is a device
+// oversubscription.
+func AllocsFit(node *Node, allocs []*Allocation, checkDev, checkNet bool) (bool, string, *ComparableResources, error) {
 	// Compute the allocs' utilization from zero
 	used := new(ComparableResources)
 
@@ -121,25 +128,20 @@ func AllocsFit(node *Node, allocs []*Allocation, netIdx *NetworkIndex, checkDevi
 		return false, dimension, used, nil
 	}
 
-	// Create the network index if missing
-	if netIdx == nil {
-		netIdx = NewNetworkIndex()
-		defer netIdx.Release()
-		if netIdx.SetNode(node) || netIdx.AddAllocs(allocs) {
-			return false, "reserved port collision", used, nil
-		}
-	}
-
-	// Check if the network is overcommitted
-	if netIdx.Overcommitted() {
-		return false, "bandwidth exceeded", used, nil
-	}
-
 	// Check devices
-	if checkDevices {
+	if checkDev {
 		accounter := NewDeviceAccounter(node)
 		if accounter.AddAllocs(allocs) {
 			return false, "device oversubscribed", used, nil
+		}
+	}
+
+	// Create the network index if missing and needs checking
+	if checkNet {
+		netIdx := NewNetworkIndex()
+		defer netIdx.Release()
+		if netIdx.SetNode(node) || netIdx.AddAllocs(allocs) {
+			return false, "reserved port collision", used, nil
 		}
 	}
 

--- a/nomad/structs/network.go
+++ b/nomad/structs/network.go
@@ -45,9 +45,7 @@ type NetworkIndex struct {
 func NewNetworkIndex() *NetworkIndex {
 	return &NetworkIndex{
 		AvailAddresses: make(map[string][]NodeNetworkAddress),
-		AvailBandwidth: make(map[string]int),
 		UsedPorts:      make(map[string]Bitmap),
-		UsedBandwidth:  make(map[string]int),
 	}
 }
 
@@ -75,18 +73,6 @@ func (idx *NetworkIndex) Release() {
 	}
 }
 
-// Overcommitted checks if the network is overcommitted
-func (idx *NetworkIndex) Overcommitted() bool {
-	// TODO remove since bandwidth is deprecated
-	/*for device, used := range idx.UsedBandwidth {
-		avail := idx.AvailBandwidth[device]
-		if used > avail {
-			return true
-		}
-	}*/
-	return false
-}
-
 // SetNode is used to setup the available network resources. Returns
 // true if there is a collision
 func (idx *NetworkIndex) SetNode(node *Node) (collide bool) {
@@ -109,7 +95,6 @@ func (idx *NetworkIndex) SetNode(node *Node) (collide bool) {
 	for _, n := range networks {
 		if n.Device != "" {
 			idx.AvailNetworks = append(idx.AvailNetworks, n)
-			idx.AvailBandwidth[n.Device] = n.MBits
 		}
 	}
 
@@ -211,8 +196,6 @@ func (idx *NetworkIndex) AddReserved(n *NetworkResource) (collide bool) {
 		}
 	}
 
-	// Add the bandwidth
-	idx.UsedBandwidth[n.Device] += n.MBits
 	return
 }
 

--- a/nomad/structs/network_test.go
+++ b/nomad/structs/network_test.go
@@ -9,49 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNetworkIndex_Overcommitted(t *testing.T) {
-	t.Skip()
-	idx := NewNetworkIndex()
-
-	// Consume some network
-	reserved := &NetworkResource{
-		Device:        "eth0",
-		IP:            "192.168.0.100",
-		MBits:         505,
-		ReservedPorts: []Port{{"one", 8000, 0, ""}, {"two", 9000, 0, ""}},
-	}
-	collide := idx.AddReserved(reserved)
-	if collide {
-		t.Fatalf("bad")
-	}
-	if !idx.Overcommitted() {
-		t.Fatalf("have no resources")
-	}
-
-	// Add resources
-	n := &Node{
-		NodeResources: &NodeResources{
-			Networks: []*NetworkResource{
-				{
-					Device: "eth0",
-					CIDR:   "192.168.0.100/32",
-					MBits:  1000,
-				},
-			},
-		},
-	}
-	idx.SetNode(n)
-	if idx.Overcommitted() {
-		t.Fatalf("have resources")
-	}
-
-	// Double up our usage
-	idx.AddReserved(reserved)
-	if !idx.Overcommitted() {
-		t.Fatalf("should be overcommitted")
-	}
-}
-
 func TestNetworkIndex_SetNode(t *testing.T) {
 	idx := NewNetworkIndex()
 	n := &Node{

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -417,8 +417,10 @@ OUTER:
 		// Add the resources we are trying to fit
 		proposed = append(proposed, &structs.Allocation{AllocatedResources: total})
 
-		// Check if these allocations fit, if they do not, simply skip this node
-		fit, dim, util, _ := structs.AllocsFit(option.Node, proposed, netIdx, false)
+		// Check if these allocations fit, skipping network and device
+		// checks as they're done elsewhere. If they do not, simply
+		// skip this node.
+		fit, dim, util, _ := structs.AllocsFit(option.Node, proposed, false, false)
 		netIdx.Release()
 		if !fit {
 			// Skip the node if evictions are not enabled


### PR DESCRIPTION
AllocsFit is called from the plan applier and binpacking iterator to
ensure planned/proposed allocs fit on a node. While it always compares
mem/cpu resources, it does not always need to check devices and
networks.

- Plan Applier

  - Before this change the plan applier would *always* check devices and
    networks for collisions.

  - After this change the plan applier will only checks devices and
    networks for collisions if the plan's job contains devices and
    networks. There's no possibility of a collision if there are no new
    device or network reservations.

- Binpack Iterator

  - Before this change the binpack iterator would never check ports
    or devices because those feasibility checks are handled elsewhere.
    Bandwidth was checked but hardcoded to pass since Nomad 0.12.

  - The behavior has not changed, but the code is much cleaner. Before a
    network index would be passed to AllocsFit, but only its bandwidth
    would be checked. Since bandwidth is deprecated, this check was a
    noop. All of that code is removed so it no longer appears that
    AllocsFit is checking for network collisions when it does not.

## TODO

- [ ] Tests!
- [ ] NetworkIndex usage could probably still be improved.