### PR TITLE
api/testutil: Use fast fingerprint timeout in dev mode tests

### DIFF
--- a/api/internal/testutil/server.go
+++ b/api/internal/testutil/server.go
@@ -175,11 +175,7 @@ func NewTestServer(t testing.T, cb ServerConfigCallback) *TestServer {
 		cb(nomadConfig)
 	}
 
-	args := []string{"agent", "-config", configFile.Name()}
-
 	if nomadConfig.DevMode {
-		args = append(args, "-dev")
-
 		if nomadConfig.Client.Options == nil {
 			nomadConfig.Client.Options = map[string]string{}
 		}
@@ -204,6 +200,11 @@ func NewTestServer(t testing.T, cb ServerConfigCallback) *TestServer {
 	stderr := io.Writer(os.Stderr)
 	if nomadConfig.Stderr != nil {
 		stderr = nomadConfig.Stderr
+	}
+
+	args := []string{"agent", "-config", configFile.Name()}
+	if nomadConfig.DevMode {
+		args = append(args, "-dev")
 	}
 
 	// Start the server


### PR DESCRIPTION
The [AWS](https://github.com/hashicorp/nomad/blob/master/client/fingerprint/env_aws.go#L25) and [GCE](https://github.com/hashicorp/nomad/blob/master/client/fingerprint/env_gce.go#L29) fingerprinters have 2-second timeouts by default.

This makes startup time for the `nomad` binary in dev-mode in non-AWS/GCE environments longer, as the the server will not have started until these fingerprint timeouts are hit.

In the case of running tests locally, these 2-second timeouts make any test that starts a dev-mode server very likely to time out. (CI is configured with a much longer default test timeout.)

There already is functionality in place for using a much shorter timeout via the client configuration option `test.tighten_network_timeouts`. This defaults to `true` when creating a test client: https://github.com/hashicorp/nomad/blob/master/client/testing.go#L31

With this change, any time a test server is started in dev mode, it behaves more like the above `TestClient`, which is appropriate because a dev-mode server is also a client.

I chose to use the literal string rather than reference the `fingerprint` package as I wasn't sure it was reasonable to bring that package into the `api` package.