### PR TITLE
scheduler: only add allocs to network and device trackers if required

### DIFF
--- a/nomad/structs/network.go
+++ b/nomad/structs/network.go
@@ -70,6 +70,9 @@ func (idx *NetworkIndex) getUsedPortsFor(ip string) Bitmap {
 // Release is called when the network index is no longer needed
 // to attempt to re-use some of the memory it has allocated
 func (idx *NetworkIndex) Release() {
+	if idx == nil {
+		return
+	}
 	for _, b := range idx.UsedPorts {
 		bitmapPool.Put(b)
 	}

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"fmt"
 	"math"
+	"sync"
 
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -202,13 +203,17 @@ OUTER:
 		}
 
 		// Index the existing network usage
-		netIdx := structs.NewNetworkIndex()
-		netIdx.SetNode(option.Node)
-		netIdx.AddAllocs(proposed)
+		var netIdx *structs.NetworkIndex
+		initNetIdx := func() {
+			netIdx = structs.NewNetworkIndex()
+			netIdx.SetNode(option.Node)
+			netIdx.AddAllocs(proposed)
+		}
+		var initNetIdxOnce sync.Once
 
 		// Create a device allocator
 		devAllocator := newDeviceAllocator(iter.ctx, option.Node)
-		devAllocator.AddAllocs(proposed)
+		var initDevAllocatorOnce sync.Once
 
 		// Track the affinities of the devices
 		totalDeviceAffinityWeight := 0.0
@@ -241,6 +246,7 @@ OUTER:
 
 		// Check if we need task group network resource
 		if len(iter.taskGroup.Networks) > 0 {
+			initNetIdxOnce.Do(initNetIdx)
 			ask := iter.taskGroup.Networks[0].Copy()
 			offer, err := netIdx.AssignPorts(ask)
 			if err != nil {
@@ -308,6 +314,7 @@ OUTER:
 
 			// Check if we need a network resource
 			if len(task.Resources.Networks) > 0 {
+				initNetIdxOnce.Do(initNetIdx)
 				ask := task.Resources.Networks[0].Copy()
 				offer, err := netIdx.AssignNetwork(ask)
 				if offer == nil {
@@ -356,6 +363,7 @@ OUTER:
 
 			// Check if we need to assign devices
 			for _, req := range task.Resources.Devices {
+				initDevAllocatorOnce.Do(func() { devAllocator.AddAllocs(proposed) })
 				offer, sumAffinities, err := devAllocator.AssignDevice(req)
 				if offer == nil {
 					// If eviction is not enabled, mark this node as exhausted and continue

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -212,7 +212,11 @@ OUTER:
 		var initNetIdxOnce sync.Once
 
 		// Create a device allocator
-		devAllocator := newDeviceAllocator(iter.ctx, option.Node)
+		var devAllocator *deviceAllocator
+		initDevAllocator := func() {
+			devAllocator = newDeviceAllocator(iter.ctx, option.Node)
+			devAllocator.AddAllocs(proposed)
+		}
 		var initDevAllocatorOnce sync.Once
 
 		// Track the affinities of the devices
@@ -363,7 +367,7 @@ OUTER:
 
 			// Check if we need to assign devices
 			for _, req := range task.Resources.Devices {
-				initDevAllocatorOnce.Do(func() { devAllocator.AddAllocs(proposed) })
+				initDevAllocatorOnce.Do(initDevAllocator)
 				offer, sumAffinities, err := devAllocator.AssignDevice(req)
 				if offer == nil {
 					// If eviction is not enabled, mark this node as exhausted and continue


### PR DESCRIPTION
There are two structs used in in scheduling to track usage of networks and devices. While they are only used if an alloc requires a network or device, they always are initialized regardless. In many cases this initialization overhead is minimal. However, in cases where the cardinality of allocs assigned to ranked nodes are high, memory and cpu cycles are wasted accounting the devices and networks used by these allocs if that accounting is never used to rank the node, e.g. the proposed allocation doesn't require a network or device.

This PR moves the initialization to a function that is called by sync.Once when needed. We do call `netIdx.Release()` always so I made sure that accepted a nil receiver without panicing. 