### PR TITLE
Document correct default Nomad port

### DIFF
--- a/website/pages/docs/commands/operator/snapshot-agent.mdx
+++ b/website/pages/docs/commands/operator/snapshot-agent.mdx
@@ -27,7 +27,7 @@ The Config file has the following format (shown populated with default values):
 
 ```hcl
 nomad {
-  address         = "http://127.0.0.1:8500"
+  address         = "http://127.0.0.1:4646"
   token           = ""
   region          = ""
   ca_file         = ""


### PR DESCRIPTION
I noticed that `nomad.address` has a familiar looking port -- consul's! Most likely an accidental stowaway while porting over the snapshot functionality from Consul to Nomad.

PR updates the documentation to use the correct default Nomad API port, 4646.