### PR TITLE
UI: Add DAS summary table filtering

### DIFF
--- a/ui/app/controllers/optimize.js
+++ b/ui/app/controllers/optimize.js
@@ -179,6 +179,20 @@ export default class OptimizeController extends Controller {
   @action
   setFacetQueryParam(queryParam, selection) {
     this[queryParam] = serialize(selection);
+    this.ensureActiveSummaryIsNotExcluded();
+  }
+
+  @action
+  ensureActiveSummaryIsNotExcluded() {
+    scheduleOnce('actions', () => {
+      if (!this.filteredSummaries.includes(this.activeRecommendationSummary)) {
+        const firstFilteredSummary = this.filteredSummaries.objectAt(0);
+
+        if (firstFilteredSummary) {
+          this.transitionToSummary(firstFilteredSummary);
+        }
+      }
+    });
   }
 }
 

--- a/ui/app/controllers/optimize.js
+++ b/ui/app/controllers/optimize.js
@@ -1,10 +1,149 @@
+/* eslint-disable ember/no-incorrect-calls-with-inline-anonymous-functions */
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { inject as controller } from '@ember/controller';
+import { scheduleOnce } from '@ember/runloop';
 import { task } from 'ember-concurrency';
+import intersection from 'lodash.intersection';
+import { serialize, deserializedQueryParam as selection } from 'nomad-ui/utils/qp-serialize';
 
 export default class OptimizeController extends Controller {
   @controller('optimize/summary') summaryController;
+
+  queryParams = [
+    // {
+    //   currentPage: 'page',
+    // },
+    // {
+    //   searchTerm: 'search',
+    // },
+    // {
+    //   sortProperty: 'sort',
+    // },
+    // {
+    //   sortDescending: 'desc',
+    // },
+    {
+      qpType: 'type',
+    },
+    {
+      qpStatus: 'status',
+    },
+    {
+      qpDatacenter: 'dc',
+    },
+    {
+      qpPrefix: 'prefix',
+    },
+  ];
+
+  @tracked qpType = '';
+  @tracked qpStatus = '';
+  @tracked qpDatacenter = '';
+  @tracked qpPrefix = '';
+
+  @selection('qpType') selectionType;
+  @selection('qpStatus') selectionStatus;
+  @selection('qpDatacenter') selectionDatacenter;
+  @selection('qpPrefix') selectionPrefix;
+
+  optionsType = [
+    { key: 'service', label: 'Service' },
+    { key: 'system', label: 'System' },
+  ];
+
+  optionsStatus = [
+    { key: 'pending', label: 'Pending' },
+    { key: 'running', label: 'Running' },
+    { key: 'dead', label: 'Dead' },
+  ];
+
+  get optionsDatacenter() {
+    const flatten = (acc, val) => acc.concat(val);
+    const allDatacenters = new Set(this.model.mapBy('job.datacenters').reduce(flatten, []));
+
+    // Remove any invalid datacenters from the query param/selection
+    const availableDatacenters = Array.from(allDatacenters).compact();
+    scheduleOnce('actions', () => {
+      // eslint-disable-next-line ember/no-side-effects
+      this.qpDatacenter = serialize(intersection(availableDatacenters, this.selectionDatacenter));
+    });
+
+    return availableDatacenters.sort().map(dc => ({ key: dc, label: dc }));
+  }
+
+  get optionsPrefix() {
+    // A prefix is defined as the start of a job name up to the first - or .
+    // ex: mktg-analytics -> mktg, ds.supermodel.classifier -> ds
+    const hasPrefix = /.[-._]/;
+
+    // Collect and count all the prefixes
+    const allNames = this.model.mapBy('job.name');
+    const nameHistogram = allNames.reduce((hist, name) => {
+      if (hasPrefix.test(name)) {
+        const prefix = name.match(/(.+?)[-._]/)[1];
+        hist[prefix] = hist[prefix] ? hist[prefix] + 1 : 1;
+      }
+      return hist;
+    }, {});
+
+    // Convert to an array
+    const nameTable = Object.keys(nameHistogram).map(key => ({
+      prefix: key,
+      count: nameHistogram[key],
+    }));
+
+    // Only consider prefixes that match more than one name
+    const prefixes = nameTable.filter(name => name.count > 1);
+
+    // Remove any invalid prefixes from the query param/selection
+    const availablePrefixes = prefixes.mapBy('prefix');
+    scheduleOnce('actions', () => {
+      // eslint-disable-next-line ember/no-side-effects
+      this.qpPrefix = serialize(intersection(availablePrefixes, this.selectionPrefix));
+    });
+
+    // Sort, format, and include the count in the label
+    return prefixes.sortBy('prefix').map(name => ({
+      key: name.prefix,
+      label: `${name.prefix} (${name.count})`,
+    }));
+  }
+
+  get filteredSummaries() {
+    const {
+      selectionType: types,
+      selectionStatus: statuses,
+      selectionDatacenter: datacenters,
+      selectionPrefix: prefixes,
+    } = this;
+
+    // A summary’s job must match ALL filter facets, but it can match ANY selection within a facet
+    // Always return early to prevent unnecessary facet predicates.
+    return this.model.filter(summary => {
+      const job = summary.get('job');
+
+      if (types.length && !types.includes(job.get('displayType'))) {
+        return false;
+      }
+
+      if (statuses.length && !statuses.includes(job.get('status'))) {
+        return false;
+      }
+
+      if (datacenters.length && !job.get('datacenters').find(dc => datacenters.includes(dc))) {
+        return false;
+      }
+
+      const name = job.get('name');
+      if (prefixes.length && !prefixes.find(prefix => name.startsWith(prefix))) {
+        return false;
+      }
+
+      return true;
+    });
+  }
 
   get activeRecommendationSummary() {
     return this.summaryController.model;
@@ -29,5 +168,10 @@ export default class OptimizeController extends Controller {
     this.transitionToRoute('optimize.summary', summary.slug, {
       queryParams: { jobNamespace: summary.jobNamespace },
     });
+  }
+
+  @action
+  setFacetQueryParam(queryParam, selection) {
+    this[queryParam] = serialize(selection);
   }
 }

--- a/ui/app/controllers/optimize.js
+++ b/ui/app/controllers/optimize.js
@@ -183,6 +183,15 @@ export default class OptimizeController extends Controller {
   }
 
   @action
+  transitionToFirstSummary() {
+    const firstFilteredSummary = this.filteredSummaries.objectAt(0);
+
+    if (firstFilteredSummary) {
+      this.transitionToSummary(firstFilteredSummary);
+    }
+  }
+
+  @action
   ensureActiveSummaryIsNotExcluded() {
     scheduleOnce('actions', () => {
       if (!this.filteredSummaries.includes(this.activeRecommendationSummary)) {
@@ -190,6 +199,8 @@ export default class OptimizeController extends Controller {
 
         if (firstFilteredSummary) {
           this.transitionToSummary(firstFilteredSummary);
+        } else {
+          this.transitionToRoute('optimize');
         }
       }
     });

--- a/ui/app/controllers/optimize.js
+++ b/ui/app/controllers/optimize.js
@@ -13,16 +13,7 @@ export default class OptimizeController extends Controller {
 
   queryParams = [
     // {
-    //   currentPage: 'page',
-    // },
-    // {
     //   searchTerm: 'search',
-    // },
-    // {
-    //   sortProperty: 'sort',
-    // },
-    // {
-    //   sortDescending: 'desc',
     // },
     {
       qpType: 'type',

--- a/ui/app/controllers/optimize.js
+++ b/ui/app/controllers/optimize.js
@@ -183,15 +183,6 @@ export default class OptimizeController extends Controller {
   }
 
   @action
-  transitionToFirstSummary() {
-    const firstFilteredSummary = this.filteredSummaries.objectAt(0);
-
-    if (firstFilteredSummary) {
-      this.transitionToSummary(firstFilteredSummary);
-    }
-  }
-
-  @action
   ensureActiveSummaryIsNotExcluded() {
     scheduleOnce('actions', () => {
       if (!this.filteredSummaries.includes(this.activeRecommendationSummary)) {

--- a/ui/app/controllers/optimize.js
+++ b/ui/app/controllers/optimize.js
@@ -158,8 +158,8 @@ export default class OptimizeController extends Controller {
   // This is a task because the accordion uses timeouts for animation
   // eslint-disable-next-line require-yield
   @(task(function*() {
-    const currentSummaryIndex = this.model.indexOf(this.activeRecommendationSummary);
-    const nextSummary = this.model.objectAt(currentSummaryIndex + 1);
+    const currentSummaryIndex = this.filteredSummaries.indexOf(this.activeRecommendationSummary);
+    const nextSummary = this.filteredSummaries.objectAt(currentSummaryIndex + 1);
 
     if (nextSummary) {
       this.transitionToSummary(nextSummary);

--- a/ui/app/models/recommendation-summary.js
+++ b/ui/app/models/recommendation-summary.js
@@ -47,6 +47,6 @@ export default class RecommendationSummary extends Model {
   }
 
   get slug() {
-    return `${this.jobId}/${this.taskGroupName}`;
+    return `${get(this, 'job.name')}/${this.taskGroupName}`;
   }
 }

--- a/ui/app/routes/optimize/index.js
+++ b/ui/app/routes/optimize/index.js
@@ -1,8 +1,9 @@
 import Route from '@ember/routing/route';
 
 export default class OptimizeIndexRoute extends Route {
-  async redirect() {
-    const summaries = this.modelFor('optimize');
+  async activate() {
+    // This runs late in the loading lifecycle to ensure .filteredSummaries is populated
+    const summaries = this.controllerFor('optimize').filteredSummaries;
 
     if (summaries.length) {
       const firstSummary = summaries.objectAt(0);

--- a/ui/app/templates/optimize.hbs
+++ b/ui/app/templates/optimize.hbs
@@ -4,11 +4,10 @@
       <div class="toolbar">
         <div class="toolbar-item">
           {{#if @model}}
-            {{!-- <SearchBox
-              data-test-jobs-search
+            <SearchBox
+              data-test-recommendation-summaries-search
               @searchTerm={{mut this.searchTerm}}
-              @onChange={{action this.resetPagination}}
-              @placeholder="Search jobs..." /> --}}
+              @placeholder="Search recommendations..." />
           {{/if}}
         </div>
         <div class="toolbar-item is-right-aligned is-mobile-full-width">

--- a/ui/app/templates/optimize.hbs
+++ b/ui/app/templates/optimize.hbs
@@ -7,7 +7,7 @@
             <SearchBox
               data-test-recommendation-summaries-search
               @searchTerm={{mut this.searchTerm}}
-              @placeholder="Search recommendations..." />
+              @placeholder="Search {{this.model.length}} {{pluralize "recommendation" this.model.length}}..." />
           {{/if}}
         </div>
         <div class="toolbar-item is-right-aligned is-mobile-full-width">

--- a/ui/app/templates/optimize.hbs
+++ b/ui/app/templates/optimize.hbs
@@ -1,10 +1,50 @@
 <PageLayout>
   <section class="section">
     {{#if @model}}
+      <div class="toolbar">
+        <div class="toolbar-item">
+          {{#if @model}}
+            {{!-- <SearchBox
+              data-test-jobs-search
+              @searchTerm={{mut this.searchTerm}}
+              @onChange={{action this.resetPagination}}
+              @placeholder="Search jobs..." /> --}}
+          {{/if}}
+        </div>
+        <div class="toolbar-item is-right-aligned is-mobile-full-width">
+          <div class="button-bar">
+            <MultiSelectDropdown
+              data-test-type-facet
+              @label="Type"
+              @options={{this.optionsType}}
+              @selection={{this.selectionType}}
+              @onSelect={{action this.setFacetQueryParam "qpType"}} />
+            <MultiSelectDropdown
+              data-test-status-facet
+              @label="Status"
+              @options={{this.optionsStatus}}
+              @selection={{this.selectionStatus}}
+              @onSelect={{action this.setFacetQueryParam "qpStatus"}} />
+            <MultiSelectDropdown
+              data-test-datacenter-facet
+              @label="Datacenter"
+              @options={{this.optionsDatacenter}}
+              @selection={{this.selectionDatacenter}}
+              @onSelect={{action this.setFacetQueryParam "qpDatacenter"}} />
+            <MultiSelectDropdown
+              data-test-prefix-facet
+              @label="Prefix"
+              @options={{this.optionsPrefix}}
+              @selection={{this.selectionPrefix}}
+              @onSelect={{action this.setFacetQueryParam "qpPrefix"}} />
+          </div>
+        </div>
+      </div>
+
       {{outlet}}
 
       <ListTable
-        @source={{this.model}} as |t|>
+        @source={{this.filteredSummaries}} as |t|>
         <t.head>
           <th>Job</th>
           <th>Recommended At</th>

--- a/ui/app/templates/optimize.hbs
+++ b/ui/app/templates/optimize.hbs
@@ -40,35 +40,44 @@
         </div>
       </div>
 
-      {{outlet}}
+      {{#if this.filteredSummaries}}
+        {{outlet}}
 
-      <ListTable
-        @source={{this.filteredSummaries}} as |t|>
-        <t.head>
-          <th>Job</th>
-          <th>Recommended At</th>
-          <th># Allocs</th>
-          <th>CPU</th>
-          <th>Mem</th>
-          <th>Agg. CPU</th>
-          <th>Agg. Mem</th>
-        </t.head>
-        <t.body as |row|>
-          {{#if row.model.isProcessed}}
-            <Das::RecommendationRow
-              class="is-disabled"
-              @summary={{row.model}}
-            />
-          {{else}}
-            <Das::RecommendationRow
-              class="is-interactive {{if (eq row.model this.activeRecommendationSummary) 'is-active'}}"
-              @summary={{row.model}}
-              {{on "click" (fn this.transitionToSummary row.model)}}
-            />
-          {{/if}}
+        <ListTable
+          @source={{this.filteredSummaries}} as |t|>
+          <t.head>
+            <th>Job</th>
+            <th>Recommended At</th>
+            <th># Allocs</th>
+            <th>CPU</th>
+            <th>Mem</th>
+            <th>Agg. CPU</th>
+            <th>Agg. Mem</th>
+          </t.head>
+          <t.body as |row|>
+            {{#if row.model.isProcessed}}
+              <Das::RecommendationRow
+                class="is-disabled"
+                @summary={{row.model}}
+              />
+            {{else}}
+              <Das::RecommendationRow
+                class="is-interactive {{if (eq row.model this.activeRecommendationSummary) 'is-active'}}"
+                @summary={{row.model}}
+                {{on "click" (fn this.transitionToSummary row.model)}}
+              />
+            {{/if}}
 
-        </t.body>
-      </ListTable>
+          </t.body>
+        </ListTable>
+      {{else}}
+        <div class="empty-message" data-test-empty-recommendations>
+          <h3 class="empty-message-headline" data-test-empty-recommendations-headline>No Matches</h3>
+          <p class="empty-message-body">
+            No recommendations match your current filter selection.
+          </p>
+        </div>
+      {{/if}}
     {{else}}
       <div class="empty-message" data-test-empty-recommendations>
         <h3 class="empty-message-headline" data-test-empty-recommendations-headline>No Recommendations</h3>

--- a/ui/app/templates/optimize.hbs
+++ b/ui/app/templates/optimize.hbs
@@ -6,6 +6,7 @@
           {{#if @model}}
             <SearchBox
               data-test-recommendation-summaries-search
+              @onChange={{this.ensureActiveSummaryIsNotExcluded}}
               @searchTerm={{mut this.searchTerm}}
               @placeholder="Search {{this.model.length}} {{pluralize "recommendation" this.model.length}}..." />
           {{/if}}

--- a/ui/tests/acceptance/optimize-test.js
+++ b/ui/tests/acceptance/optimize-test.js
@@ -351,7 +351,7 @@ module('Acceptance | optimize', function(hooks) {
   });
 });
 
-module('Acceptance | optimize facets', function(hooks) {
+module('Acceptance | optimize search and facets', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -364,6 +364,29 @@ module('Acceptance | optimize facets', function(hooks) {
 
     window.localStorage.clear();
     window.localStorage.nomadTokenSecret = managementToken.secretId;
+  });
+
+  test('search field narrows summary table results', async function(assert) {
+    server.createList('job', 1, {
+      name: 'oooooo',
+      createRecommendations: true,
+      groupsCount: 2,
+      groupTaskCount: 4,
+    });
+
+    server.createList('job', 1, {
+      name: 'pppppp',
+      createRecommendations: true,
+      groupsCount: 2,
+      groupTaskCount: 4,
+    });
+
+    await Optimize.visit();
+
+    await Optimize.search.fillIn('ooo');
+
+    assert.equal(Optimize.recommendationSummaries.length, 2);
+    assert.ok(Optimize.recommendationSummaries[0].slug.startsWith('oooooo'));
   });
 
   test('the optimize page has appropriate faceted search options', async function(assert) {

--- a/ui/tests/acceptance/optimize-test.js
+++ b/ui/tests/acceptance/optimize-test.js
@@ -366,7 +366,7 @@ module('Acceptance | optimize search and facets', function(hooks) {
     window.localStorage.nomadTokenSecret = managementToken.secretId;
   });
 
-  test('search field narrows summary table results', async function(assert) {
+  test('search field narrows summary table results and displays a no matches message when there are none', async function(assert) {
     server.createList('job', 1, {
       name: 'oooooo',
       createRecommendations: true,
@@ -389,6 +389,12 @@ module('Acceptance | optimize search and facets', function(hooks) {
 
     assert.equal(Optimize.recommendationSummaries.length, 2);
     assert.ok(Optimize.recommendationSummaries[0].slug.startsWith('oooooo'));
+
+    await Optimize.search.fillIn('qqq');
+
+    assert.notOk(Optimize.card.isPresent);
+    assert.ok(Optimize.empty.isPresent);
+    assert.equal(Optimize.empty.headline, 'No Matches');
   });
 
   test('the optimize page has appropriate faceted search options', async function(assert) {

--- a/ui/tests/acceptance/optimize-test.js
+++ b/ui/tests/acceptance/optimize-test.js
@@ -367,7 +367,7 @@ module('Acceptance | optimize search and facets', function(hooks) {
   });
 
   test('search field narrows summary table results, changes the active summary if it no longer matches, and displays a no matches message when there are none', async function(assert) {
-    server.createList('job', 1, {
+    server.create('job', {
       name: 'zzzzzz',
       createRecommendations: true,
       groupsCount: 1,
@@ -378,14 +378,14 @@ module('Acceptance | optimize search and facets', function(hooks) {
     const futureSubmitTime = (Date.now() + 10000) * 1000000;
     server.db.recommendations.update({ submitTime: futureSubmitTime });
 
-    server.createList('job', 1, {
+    server.create('job', {
       name: 'oooooo',
       createRecommendations: true,
       groupsCount: 2,
       groupTaskCount: 4,
     });
 
-    server.createList('job', 1, {
+    server.create('job', {
       name: 'pppppp',
       createRecommendations: true,
       groupsCount: 2,
@@ -415,21 +415,21 @@ module('Acceptance | optimize search and facets', function(hooks) {
   });
 
   test('processing a summary moves to the next one in the sorted list', async function(assert) {
-    server.createList('job', 1, {
+    server.create('job', {
       name: 'ooo111',
       createRecommendations: true,
       groupsCount: 1,
       groupTaskCount: 4,
     });
 
-    server.createList('job', 1, {
+    server.create('job', {
       name: 'pppppp',
       createRecommendations: true,
       groupsCount: 1,
       groupTaskCount: 4,
     });
 
-    server.createList('job', 1, {
+    server.create('job', {
       name: 'ooo222',
       createRecommendations: true,
       groupsCount: 1,

--- a/ui/tests/acceptance/optimize-test.js
+++ b/ui/tests/acceptance/optimize-test.js
@@ -383,6 +383,8 @@ module('Acceptance | optimize search and facets', function(hooks) {
 
     await Optimize.visit();
 
+    assert.equal(Optimize.search.placeholder, `Search ${Optimize.recommendationSummaries.length} recommendations...`);
+
     await Optimize.search.fillIn('ooo');
 
     assert.equal(Optimize.recommendationSummaries.length, 2);

--- a/ui/tests/acceptance/optimize-test.js
+++ b/ui/tests/acceptance/optimize-test.js
@@ -351,6 +351,244 @@ module('Acceptance | optimize', function(hooks) {
   });
 });
 
+module('Acceptance | optimize facets', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    server.create('node');
+
+    server.createList('namespace', 2);
+
+    managementToken = server.create('token');
+
+    window.localStorage.clear();
+    window.localStorage.nomadTokenSecret = managementToken.secretId;
+  });
+
+  test('the optimize page has appropriate faceted search options', async function(assert) {
+    server.createList('job', 4, {
+      status: 'running',
+      createRecommendations: true,
+      childrenCount: 0,
+    });
+
+    await Optimize.visit();
+
+    assert.ok(Optimize.facets.type.isPresent, 'Type facet found');
+    assert.ok(Optimize.facets.status.isPresent, 'Status facet found');
+    assert.ok(Optimize.facets.datacenter.isPresent, 'Datacenter facet found');
+    assert.ok(Optimize.facets.prefix.isPresent, 'Prefix facet found');
+  });
+
+  testFacet('Type', {
+    facet: Optimize.facets.type,
+    paramName: 'type',
+    expectedOptions: ['Service', 'System'],
+    async beforeEach() {
+      server.createList('job', 2, {
+        type: 'service',
+        createRecommendations: true,
+        groupsCount: 1,
+        groupTaskCount: 2,
+      });
+
+      server.createList('job', 2, {
+        type: 'system',
+        createRecommendations: true,
+        groupsCount: 1,
+        groupTaskCount: 2,
+      });
+      await Optimize.visit();
+    },
+    filter(taskGroup, selection) {
+      let displayType = taskGroup.job.type;
+      return selection.includes(displayType);
+    },
+  });
+
+  testFacet('Status', {
+    facet: Optimize.facets.status,
+    paramName: 'status',
+    expectedOptions: ['Pending', 'Running', 'Dead'],
+    async beforeEach() {
+      server.createList('job', 2, {
+        status: 'pending',
+        createRecommendations: true,
+        groupsCount: 1,
+        groupTaskCount: 2,
+        childrenCount: 0,
+      });
+      server.createList('job', 2, {
+        status: 'running',
+        createRecommendations: true,
+        groupsCount: 1,
+        groupTaskCount: 2,
+        childrenCount: 0,
+      });
+      server.createList('job', 2, { status: 'dead', createRecommendations: true, childrenCount: 0 });
+      await Optimize.visit();
+    },
+    filter: (taskGroup, selection) => selection.includes(taskGroup.job.status),
+  });
+
+  testFacet('Datacenter', {
+    facet: Optimize.facets.datacenter,
+    paramName: 'dc',
+    expectedOptions(jobs) {
+      const allDatacenters = new Set(
+        jobs.mapBy('datacenters').reduce((acc, val) => acc.concat(val), [])
+      );
+      return Array.from(allDatacenters).sort();
+    },
+    async beforeEach() {
+      server.create('job', {
+        datacenters: ['pdx', 'lax'],
+        createRecommendations: true,
+        groupsCount: 1,
+        groupTaskCount: 2,
+        childrenCount: 0,
+      });
+      server.create('job', {
+        datacenters: ['pdx', 'ord'],
+        createRecommendations: true,
+        groupsCount: 1,
+        groupTaskCount: 2,
+        childrenCount: 0,
+      });
+      server.create('job', {
+        datacenters: ['lax', 'jfk'],
+        createRecommendations: true,
+        groupsCount: 1,
+        groupTaskCount: 2,
+        childrenCount: 0,
+      });
+      server.create('job', {
+        datacenters: ['jfk', 'dfw'],
+        createRecommendations: true,
+        groupsCount: 1,
+        groupTaskCount: 2,
+        childrenCount: 0,
+      });
+      server.create('job', { datacenters: ['pdx'], createRecommendations: true, childrenCount: 0 });
+      await Optimize.visit();
+    },
+    filter: (taskGroup, selection) => taskGroup.job.datacenters.find(dc => selection.includes(dc)),
+  });
+
+  testFacet('Prefix', {
+    facet: Optimize.facets.prefix,
+    paramName: 'prefix',
+    expectedOptions: ['hashi (3)', 'nmd (2)', 'pre (2)'],
+    async beforeEach() {
+      [
+        'pre-one',
+        'hashi_one',
+        'nmd.one',
+        'one-alone',
+        'pre_two',
+        'hashi.two',
+        'hashi-three',
+        'nmd_two',
+        'noprefix',
+      ].forEach(name => {
+        server.create('job', {
+          name,
+          createRecommendations: true,
+          createAllocations: true,
+          groupsCount: 1,
+          groupTaskCount: 2,
+          childrenCount: 0,
+        });
+      });
+      await Optimize.visit();
+    },
+    filter: (taskGroup, selection) => selection.find(prefix => taskGroup.job.name.startsWith(prefix)),
+  });
+
+  function testFacet(label, { facet, paramName, beforeEach, filter, expectedOptions }) {
+    test(`the ${label} facet has the correct options`, async function(assert) {
+      await beforeEach();
+      await facet.toggle();
+
+      let expectation;
+      if (typeof expectedOptions === 'function') {
+        expectation = expectedOptions(server.db.jobs);
+      } else {
+        expectation = expectedOptions;
+      }
+
+      assert.deepEqual(
+        facet.options.map(option => option.label.trim()),
+        expectation,
+        'Options for facet are as expected'
+      );
+    });
+
+    test(`the ${label} facet filters the recommendation summaries by ${label}`, async function(assert) {
+      let option;
+
+      await beforeEach();
+      await facet.toggle();
+
+      option = facet.options.objectAt(0);
+      await option.toggle();
+
+      const selection = [option.key];
+
+      const sortedRecommendations = server.db.recommendations
+        .sortBy('submitTime').reverse();
+
+      const recommendationTaskGroups = server.schema.tasks.find(sortedRecommendations.mapBy('taskId').uniq()).models.mapBy('taskGroup').uniqBy('id').filter(group => filter(group, selection));
+
+      Optimize.recommendationSummaries.forEach((summary, index) => {
+        const group = recommendationTaskGroups[index];
+        assert.equal(summary.slug, `${group.job.name} / ${group.name}`);
+      });
+    });
+
+    test(`selecting multiple options in the ${label} facet results in a broader search`, async function(assert) {
+      const selection = [];
+
+      await beforeEach();
+      await facet.toggle();
+
+      const option1 = facet.options.objectAt(0);
+      const option2 = facet.options.objectAt(1);
+      await option1.toggle();
+      selection.push(option1.key);
+      await option2.toggle();
+      selection.push(option2.key);
+
+      const sortedRecommendations = server.db.recommendations
+        .sortBy('submitTime').reverse();
+
+      const recommendationTaskGroups = server.schema.tasks.find(sortedRecommendations.mapBy('taskId').uniq()).models.mapBy('taskGroup').uniqBy('id').filter(group => filter(group, selection));
+
+      Optimize.recommendationSummaries.forEach((summary, index) => {
+        const group = recommendationTaskGroups[index];
+        assert.equal(summary.slug, `${group.job.name} / ${group.name}`);
+      });
+    });
+
+    test(`selecting options in the ${label} facet updates the ${paramName} query param`, async function(assert) {
+      const selection = [];
+
+      await beforeEach();
+      await facet.toggle();
+
+      const option1 = facet.options.objectAt(0);
+      const option2 = facet.options.objectAt(1);
+      await option1.toggle();
+      selection.push(option1.key);
+      await option2.toggle();
+      selection.push(option2.key);
+
+      assert.ok(currentURL().includes(encodeURIComponent(JSON.stringify(selection))));
+    });
+  }
+});
+
 function formattedMemDiff(memDiff) {
   const absMemDiff = Math.abs(memDiff);
   const negativeSign = memDiff < 0 ? '-' : '';

--- a/ui/tests/acceptance/optimize-test.js
+++ b/ui/tests/acceptance/optimize-test.js
@@ -411,6 +411,7 @@ module('Acceptance | optimize search and facets', function(hooks) {
     assert.notOk(Optimize.card.isPresent);
     assert.ok(Optimize.empty.isPresent);
     assert.equal(Optimize.empty.headline, 'No Matches');
+    assert.equal(currentURL(), '/optimize?search=qqq');
   });
 
   test('processing a summary moves to the next one in the sorted list', async function(assert) {

--- a/ui/tests/pages/optimize.js
+++ b/ui/tests/pages/optimize.js
@@ -29,6 +29,13 @@ export default create({
     placeholder: attribute('placeholder'),
   },
 
+  facets: {
+    type: facet('[data-test-type-facet]'),
+    status: facet('[data-test-status-facet]'),
+    datacenter: facet('[data-test-datacenter-facet]'),
+    prefix: facet('[data-test-prefix-facet]'),
+  },
+
   card: recommendationCard,
 
   recommendationSummaries: collection('[data-test-recommendation-summary-row]', {
@@ -60,12 +67,5 @@ export default create({
   applicationError: {
     isPresent: isPresent('[data-test-error]'),
     title: text('[data-test-error-title]'),
-  },
-
-  facets: {
-    type: facet('[data-test-type-facet]'),
-    status: facet('[data-test-status-facet]'),
-    datacenter: facet('[data-test-datacenter-facet]'),
-    prefix: facet('[data-test-prefix-facet]'),
   },
 });

--- a/ui/tests/pages/optimize.js
+++ b/ui/tests/pages/optimize.js
@@ -10,6 +10,7 @@ import {
 } from 'ember-cli-page-object';
 
 import recommendationCard from 'nomad-ui/tests/pages/components/recommendation-card';
+import facet from 'nomad-ui/tests/pages/components/facet';
 
 export default create({
   visit: visitable('/optimize'),
@@ -54,5 +55,12 @@ export default create({
   applicationError: {
     isPresent: isPresent('[data-test-error]'),
     title: text('[data-test-error-title]'),
+  },
+
+  facets: {
+    type: facet('[data-test-type-facet]'),
+    status: facet('[data-test-status-facet]'),
+    datacenter: facet('[data-test-datacenter-facet]'),
+    prefix: facet('[data-test-prefix-facet]'),
   },
 });

--- a/ui/tests/pages/optimize.js
+++ b/ui/tests/pages/optimize.js
@@ -24,6 +24,10 @@ export default create({
     return this.breadcrumbs.toArray().find(crumb => crumb.id === id);
   },
 
+  search: {
+    scope: '[data-test-recommendation-summaries-search] input',
+  },
+
   card: recommendationCard,
 
   recommendationSummaries: collection('[data-test-recommendation-summary-row]', {

--- a/ui/tests/pages/optimize.js
+++ b/ui/tests/pages/optimize.js
@@ -26,6 +26,7 @@ export default create({
 
   search: {
     scope: '[data-test-recommendation-summaries-search] input',
+    placeholder: attribute('placeholder'),
   },
 
   card: recommendationCard,


### PR DESCRIPTION
This adds text and facet filtering to the DAS summary table. It’s mostly a combination
of facet code taken from `controller:jobs/index`, search adapted from the global
search control, and tests.

The only search is fuzzy matching against the recommendation summary slug; the other
strings of task names and namespaces didn’t seem applicable to me, but it wouldn’t
be difficult to add anything else desirable.

Some design decisions:
* if changing the filter causes the currently-active summary to be excluded, the active card (and subroute) updates to the first summary in the filtered collection
* if the filter causes the collection to become empty, it navigates to `/optimize?…`