### PR TITLE
Remove Namespace field from JobScaleRequest

### DIFF
--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -495,7 +495,6 @@ func (s *HTTPServer) jobScaleAction(resp http.ResponseWriter, req *http.Request,
 		return nil, CodedError(400, err.Error())
 	}
 
-	namespace := args.Target[structs.ScalingTargetNamespace]
 	targetJob := args.Target[structs.ScalingTargetJob]
 	if targetJob != "" && targetJob != jobName {
 		return nil, CodedError(400, "job ID in payload did not match URL")
@@ -503,7 +502,6 @@ func (s *HTTPServer) jobScaleAction(resp http.ResponseWriter, req *http.Request,
 
 	scaleReq := structs.JobScaleRequest{
 		JobID:          jobName,
-		Namespace:      namespace,
 		Target:         args.Target,
 		Count:          args.Count,
 		PolicyOverride: args.PolicyOverride,

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -693,13 +693,12 @@ type JobPlanRequest struct {
 // JobScaleRequest is used for the Job.Scale endpoint to scale one of the
 // scaling targets in a job
 type JobScaleRequest struct {
-	Namespace string
-	JobID     string
-	Target    map[string]string
-	Count     *int64
-	Message   string
-	Error     bool
-	Meta      map[string]interface{}
+	JobID   string
+	Target  map[string]string
+	Count   *int64
+	Message string
+	Error   bool
+	Meta    map[string]interface{}
 	// PolicyOverride is set when the user is attempting to override any policies
 	PolicyOverride bool
 	WriteRequest


### PR DESCRIPTION
Having the `Namespace` as a top-level field causes the RPC decoding process to use it as the request namespace. Since we are not using this field, the namepsace would be set to an empty string when going from a client to a server, causing the request to fail with a `404` when looking for the job:

```
job "webapp" not found
```