### PR TITLE
Legacy executors are executors after all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ BUG FIXES:
  * config (Enterprise): Fixed default enterprise config merging. [[GH-9083](https://github.com/hashicorp/nomad/pull/9083)]
  * client: Fixed an issue with the Java fingerprinter on macOS causing pop-up notifications when no JVM installed. [[GH-9225](https://github.com/hashicorp/nomad/pull/9225)] 
  * client: Fixed an fingerprinter issue detecting bridge kernel module [[GH-9299](https://github.com/hashicorp/nomad/pull/9299)]
+ * client: Fixed an in-place upgrade bug, where a Nomad client may fail to manage tasks that were started with pre-0.9 Nomad client. [[GH-9304](https://github.com/hashicorp/nomad/pull/9304)]
  * consul: Fixed a bug to correctly validate task when using script-checks in group-level services [[GH-8952](https://github.com/hashicorp/nomad/issues/8952)]
  * consul: Fixed a bug where canary_meta was not being interpolated with environment variables [[GH-9096](https://github.com/hashicorp/nomad/pull/9096)]
  * consul/connect: Fixed a bug to correctly trigger updates on jobspec changes [[GH-9029](https://github.com/hashicorp/nomad/pull/9029)]

--- a/drivers/shared/executor/legacy_executor_wrapper.go
+++ b/drivers/shared/executor/legacy_executor_wrapper.go
@@ -36,6 +36,9 @@ type legacyExecutorWrapper struct {
 	logger hclog.Logger
 }
 
+// validate that legacyExecutorWrapper is an executor
+var _ Executor = (*legacyExecutorWrapper)(nil)
+
 func (l *legacyExecutorWrapper) Launch(launchCmd *ExecCommand) (*ProcessState, error) {
 	return nil, fmt.Errorf("operation not supported for legacy exec wrapper")
 }
@@ -131,6 +134,11 @@ func (l *legacyExecutorWrapper) Signal(s os.Signal) error {
 
 func (l *legacyExecutorWrapper) Exec(deadline time.Time, cmd string, args []string) ([]byte, int, error) {
 	return l.client.Exec(deadline, cmd, args)
+}
+
+func (l *legacyExecutorWrapper) ExecStreaming(ctx context.Context, cmd []string, tty bool,
+	stream drivers.ExecTaskStream) error {
+	return fmt.Errorf("operation not supported for legacy exec wrapper")
 }
 
 type pre09ExecutorRPC struct {


### PR DESCRIPTION
This fixes a bug where pre-0.9 executors fail to recover after an
upgrade.

The bug is that legacyExecutorWrappers didn't get updated with
ExecStreaming function, and thus failed to implement the Executor
function. Sadly, this meant that all recovery attempts fail, as the
runtime check in
https://github.com/hashicorp/nomad/blob/b312aacbc961dfd976b6a402d22d80b45176a962/drivers/shared/executor/utils.go#L103-L110
.

### Impact

The bug affects all versions since 0.9.2: if a client upgrades from pre-0.9 to 0.9.2 or later; then all exec based tasks (i.e. exec, raw_exec, java, qemu) will fail to recover, will be leaked, and then nomad will start another task.  The leaked pre-0.9 task will run un-interrupted and unmanaged until the client dies or it's killed manually.