### PR TITLE
structs: canonicalize allocatedtaskresources to populate shared ports

### DIFF
--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -127,7 +127,7 @@ func (s *HTTPServer) allocGet(allocID string, resp http.ResponseWriter, req *htt
 	alloc.SetEventDisplayMessages()
 
 	// Handle 0.12 ports upgrade path
-	alloc.AllocatedResources.Shared.Canonicalize()
+	alloc.AllocatedResources.Canonicalize()
 
 	return alloc, nil
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3391,6 +3391,23 @@ func (a *AllocatedResources) OldTaskResources() map[string]*Resources {
 	return m
 }
 
+func (a *AllocatedResources) Canonicalize() {
+	a.Shared.Canonicalize()
+
+	for _, r := range a.Tasks {
+		for _, nw := range r.Networks {
+			for _, port := range append(nw.DynamicPorts, nw.ReservedPorts...) {
+				a.Shared.Ports = append(a.Shared.Ports, AllocatedPortMapping{
+					Label:  port.Label,
+					Value:  port.Value,
+					To:     port.To,
+					HostIP: nw.IP,
+				})
+			}
+		}
+	}
+}
+
 // AllocatedTaskResources are the set of resources allocated to a task.
 type AllocatedTaskResources struct {
 	Cpu      AllocatedCpuResources


### PR DESCRIPTION
This PR populates the `Ports` fields of the `AllocatedSharedResources` struct with port information from the deprecated task network resources. This should allow allocations to display network information in the UI correctly until the user migrates to the new group network definition syntax.

Fixes #9031 