### PR TITLE
Custom message when job file is HCL2 incompatible

### DIFF
--- a/command/helpers.go
+++ b/command/helpers.go
@@ -458,7 +458,14 @@ func (j *JobGetter) ApiJobWithArgs(jpath string, vars []string, varfiles []strin
 			ArgVars: vars,
 			AllowFS: true,
 		})
+
+		if err != nil {
+			if _, merr := jobspec.Parse(&buf); merr == nil {
+				return nil, fmt.Errorf("Failed to parse using HCL 2. Use the HCL 1 parser with `nomad run -hcl1`, or address the following issues:\n%v", err)
+			}
+		}
 	}
+
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing job file from %s:\n%v", jpath, err)
 	}


### PR DESCRIPTION
Use a custom message when the job file is a valid HCL1 but no longer
valid under HCL 2 syntax.

A sample error:

```
$ nomad job run /tmp/example.nomad
Error getting job struct: Failed to parse using HCL 2. Use the HCL 1 parser with `nomad run -hcl1`, or address the following issues:
example.nomad:20,5-6: Invalid argument name; Argument names must not be quoted.
```