### PR TITLE
e2e enables audit log on full-cluster

### DIFF
--- a/e2e/terraform/config/full-cluster/nomad/base.hcl
+++ b/e2e/terraform/config/full-cluster/nomad/base.hcl
@@ -10,6 +10,10 @@ consul {
   address = "127.0.0.1:8500"
 }
 
+audit {
+  enabled = true
+}
+
 telemetry {
   collection_interval        = "1s"
   disable_hostname           = true


### PR DESCRIPTION
Enables audit logging for full-cluster clients and servers, the full-cluster profile [specifies `nomad_enterprise = true`](https://github.com/hashicorp/nomad/blob/master/e2e/terraform/terraform.full.tfvars) so enabling audit logging will ensure that all http requests go through the auditing process