### PR TITLE
recommendations CLI: autocomplete support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ IMPROVEMENTS:
  * api: Added ?resources=true query parameter to /v1/nodes and /v1/allocations to include resource allocations in listings. [[GH-9055](https://github.com/hashicorp/nomad/issues/9055)]
  * api: Added ?task_states=false query parameter to /v1/allocations to remove TaskStates from listings. Defaults to being included as before. [[GH-9055](https://github.com/hashicorp/nomad/issues/9055)]
  * build: Updated to Go 1.15.4. [[GH-9305](https://github.com/hashicorp/nomad/issues/9305)]
+ * cli: Added autocompletion for `recommendation` commands [[GH-9317](https://github.com/hashicorp/nomad/issues/9317)]
  * cli: Added `scale` and `scaling-events` subcommands to the `job` command. [[GH-9023](https://github.com/hashicorp/nomad/pull/9023)]
  * cli: Added `scaling` command for interaction with the scaling API endpoint. [[GH-9025](https://github.com/hashicorp/nomad/pull/9025)]
  * client: Batch state store writes to reduce disk IO. [[GH-9093](https://github.com/hashicorp/nomad/issues/9093)]

--- a/api/contexts/contexts.go
+++ b/api/contexts/contexts.go
@@ -4,14 +4,15 @@ package contexts
 type Context string
 
 const (
-	Allocs      Context = "allocs"
-	Deployments Context = "deployment"
-	Evals       Context = "evals"
-	Jobs        Context = "jobs"
-	Nodes       Context = "nodes"
-	Namespaces  Context = "namespaces"
-	Quotas      Context = "quotas"
-	Plugins     Context = "plugins"
-	Volumes     Context = "volumes"
-	All         Context = "all"
+	Allocs          Context = "allocs"
+	Deployments     Context = "deployment"
+	Evals           Context = "evals"
+	Jobs            Context = "jobs"
+	Nodes           Context = "nodes"
+	Namespaces      Context = "namespaces"
+	Quotas          Context = "quotas"
+	Recommendations Context = "recommendations"
+	Plugins         Context = "plugins"
+	Volumes         Context = "volumes"
+	All             Context = "all"
 )

--- a/command/recommendation_apply.go
+++ b/command/recommendation_apply.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/api/contexts"
+
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
 )
@@ -58,6 +60,21 @@ func (r *RecommendationApplyCommand) AutocompleteFlags() complete.Flags {
 			"-policy-override": complete.PredictNothing,
 			"-verbose":         complete.PredictNothing,
 		})
+}
+
+func (r *RecommendationApplyCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFunc(func(a complete.Args) []string {
+		client, err := r.Meta.Client()
+		if err != nil {
+			return nil
+		}
+
+		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Recommendations, nil)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Recommendations]
+	})
 }
 
 // Name returns the name of this command.

--- a/command/recommendation_apply.go
+++ b/command/recommendation_apply.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/api/contexts"
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
@@ -17,6 +16,7 @@ var _ cli.Command = &RecommendationApplyCommand{}
 // RecommendationApplyCommand implements cli.Command.
 type RecommendationApplyCommand struct {
 	Meta
+	RecommendationAutocompleteCommand
 }
 
 // Help satisfies the cli.Command Help function.
@@ -60,21 +60,6 @@ func (r *RecommendationApplyCommand) AutocompleteFlags() complete.Flags {
 			"-policy-override": complete.PredictNothing,
 			"-verbose":         complete.PredictNothing,
 		})
-}
-
-func (r *RecommendationApplyCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictFunc(func(a complete.Args) []string {
-		client, err := r.Meta.Client()
-		if err != nil {
-			return nil
-		}
-
-		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Recommendations, nil)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Recommendations]
-	})
 }
 
 // Name returns the name of this command.

--- a/command/recommendation_apply_test.go
+++ b/command/recommendation_apply_test.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/testutil"
-	"github.com/mitchellh/cli"
-	"github.com/posener/complete"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRecommendationApplyCommand_Run(t *testing.T) {
@@ -87,44 +86,10 @@ func TestRecommendationApplyCommand_Run(t *testing.T) {
 }
 
 func TestRecommendationApplyCommand_AutocompleteArgs(t *testing.T) {
-	assert := assert.New(t)
-	t.Parallel()
-
 	srv, client, url := testServer(t, true, nil)
 	defer srv.Shutdown()
 
-	// Register a test job to write a recommendation against.
 	ui := cli.NewMockUi()
-	testJob := testJob("recommendation_list")
-	regResp, _, err := client.Jobs().Register(testJob, nil)
-	require.NoError(t, err)
-	registerCode := waitForSuccess(ui, client, fullId, t, regResp.EvalID)
-	require.Equal(t, 0, registerCode)
-
-	// Write a recommendation.
-	rec := &api.Recommendation{
-		JobID:    *testJob.ID,
-		Group:    *testJob.TaskGroups[0].Name,
-		Task:     testJob.TaskGroups[0].Tasks[0].Name,
-		Resource: "CPU",
-		Value:    1050,
-		Meta:     map[string]interface{}{"test-meta-entry": "test-meta-value"},
-		Stats:    map[string]float64{"p13": 1.13},
-	}
-	rec, _, err = client.Recommendations().Upsert(rec, nil)
-	if srv.Enterprise {
-		require.NoError(t, err)
-	} else {
-		require.Error(t, err, "Nomad Enterprise only endpoint")
-		return
-	}
-
-	cmd := &RecommendationApplyCommand{Meta: Meta{Ui: ui, flagAddress: url}}
-	prefix := rec.ID[:5]
-	args := complete.Args{Last: prefix}
-	predictor := cmd.AutocompleteArgs()
-
-	res := predictor.Predict(args)
-	assert.Equal(1, len(res))
-	assert.Equal(rec.ID, res[0])
+	cmd := RecommendationApplyCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+	testRecommendationAutocompleteCommand(t, client, srv, ui, &cmd.RecommendationAutocompleteCommand)
 }

--- a/command/recommendation_dismiss.go
+++ b/command/recommendation_dismiss.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
+
+	"github.com/hashicorp/nomad/api/contexts"
 )
 
 // Ensure RecommendationDismissCommand satisfies the cli.Command interface.
@@ -37,6 +39,21 @@ func (r *RecommendationDismissCommand) Synopsis() string {
 func (r *RecommendationDismissCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(r.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{})
+}
+
+func (r *RecommendationDismissCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFunc(func(a complete.Args) []string {
+		client, err := r.Meta.Client()
+		if err != nil {
+			return nil
+		}
+
+		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Recommendations, nil)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Recommendations]
+	})
 }
 
 // Name returns the name of this command.

--- a/command/recommendation_dismiss_test.go
+++ b/command/recommendation_dismiss_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
@@ -84,15 +85,21 @@ func TestRecommendationDismissCommand_Run(t *testing.T) {
 }
 
 func TestRecommendationDismissCommand_AutocompleteArgs(t *testing.T) {
-	assert := assert.New(t)
-	t.Parallel()
-
 	srv, client, url := testServer(t, true, nil)
 	defer srv.Shutdown()
 
-	// Register a test job to write a recommendation against.
 	ui := cli.NewMockUi()
-	testJob := testJob("recommendation_list")
+	cmd := &RecommendationDismissCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	testRecommendationAutocompleteCommand(t, client, srv, ui, &cmd.RecommendationAutocompleteCommand)
+}
+
+func testRecommendationAutocompleteCommand(t *testing.T, client *api.Client, srv *agent.TestAgent, ui *cli.MockUi, cmd *RecommendationAutocompleteCommand) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	// Register a test job to write a recommendation against.
+	testJob := testJob("recommendation_autocomplete")
 	regResp, _, err := client.Jobs().Register(testJob, nil)
 	require.NoError(t, err)
 	registerCode := waitForSuccess(ui, client, fullId, t, regResp.EvalID)
@@ -116,7 +123,6 @@ func TestRecommendationDismissCommand_AutocompleteArgs(t *testing.T) {
 		return
 	}
 
-	cmd := &RecommendationDismissCommand{Meta: Meta{Ui: ui, flagAddress: url}}
 	prefix := rec.ID[:5]
 	args := complete.Args{Last: prefix}
 	predictor := cmd.AutocompleteArgs()

--- a/command/recommendation_dismiss_test.go
+++ b/command/recommendation_dismiss_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,4 +81,47 @@ func TestRecommendationDismissCommand_Run(t *testing.T) {
 	recInfo, _, err := client.Recommendations().Info(recResp.ID, nil)
 	require.Error(err, "not found")
 	require.Nil(recInfo)
+}
+
+func TestRecommendationDismissCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, client, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	// Register a test job to write a recommendation against.
+	ui := cli.NewMockUi()
+	testJob := testJob("recommendation_list")
+	regResp, _, err := client.Jobs().Register(testJob, nil)
+	require.NoError(t, err)
+	registerCode := waitForSuccess(ui, client, fullId, t, regResp.EvalID)
+	require.Equal(t, 0, registerCode)
+
+	// Write a recommendation.
+	rec := &api.Recommendation{
+		JobID:    *testJob.ID,
+		Group:    *testJob.TaskGroups[0].Name,
+		Task:     testJob.TaskGroups[0].Tasks[0].Name,
+		Resource: "CPU",
+		Value:    1050,
+		Meta:     map[string]interface{}{"test-meta-entry": "test-meta-value"},
+		Stats:    map[string]float64{"p13": 1.13},
+	}
+	rec, _, err = client.Recommendations().Upsert(rec, nil)
+	if srv.Enterprise {
+		require.NoError(t, err)
+	} else {
+		require.Error(t, err, "Nomad Enterprise only endpoint")
+		return
+	}
+
+	cmd := &RecommendationDismissCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+	prefix := rec.ID[:5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(rec.ID, res[0])
 }

--- a/command/recommendation_info.go
+++ b/command/recommendation_info.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
+
+	"github.com/hashicorp/nomad/api/contexts"
 )
 
 // Ensure RecommendationInfoCommand satisfies the cli.Command interface.
@@ -50,6 +52,21 @@ func (r *RecommendationInfoCommand) AutocompleteFlags() complete.Flags {
 			"-json": complete.PredictNothing,
 			"-t":    complete.PredictAnything,
 		})
+}
+
+func (r *RecommendationInfoCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFunc(func(a complete.Args) []string {
+		client, err := r.Meta.Client()
+		if err != nil {
+			return nil
+		}
+
+		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Recommendations, nil)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Recommendations]
+	})
 }
 
 // Name returns the name of this command.

--- a/command/recommendation_info.go
+++ b/command/recommendation_info.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
-
-	"github.com/hashicorp/nomad/api/contexts"
 )
 
 // Ensure RecommendationInfoCommand satisfies the cli.Command interface.
@@ -17,6 +15,7 @@ var _ cli.Command = &RecommendationInfoCommand{}
 // RecommendationInfoCommand implements cli.Command.
 type RecommendationInfoCommand struct {
 	Meta
+	RecommendationAutocompleteCommand
 }
 
 // Help satisfies the cli.Command Help function.
@@ -52,21 +51,6 @@ func (r *RecommendationInfoCommand) AutocompleteFlags() complete.Flags {
 			"-json": complete.PredictNothing,
 			"-t":    complete.PredictAnything,
 		})
-}
-
-func (r *RecommendationInfoCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictFunc(func(a complete.Args) []string {
-		client, err := r.Meta.Client()
-		if err != nil {
-			return nil
-		}
-
-		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Recommendations, nil)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Recommendations]
-	})
 }
 
 // Name returns the name of this command.

--- a/command/recommendation_info_test.go
+++ b/command/recommendation_info_test.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/testutil"
-	"github.com/mitchellh/cli"
-	"github.com/posener/complete"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRecommendationInfoCommand_Run(t *testing.T) {
@@ -85,44 +84,10 @@ func TestRecommendationInfoCommand_Run(t *testing.T) {
 }
 
 func TestRecommendationInfoCommand_AutocompleteArgs(t *testing.T) {
-	assert := assert.New(t)
-	t.Parallel()
-
 	srv, client, url := testServer(t, true, nil)
 	defer srv.Shutdown()
 
-	// Register a test job to write a recommendation against.
 	ui := cli.NewMockUi()
-	testJob := testJob("recommendation_list")
-	regResp, _, err := client.Jobs().Register(testJob, nil)
-	require.NoError(t, err)
-	registerCode := waitForSuccess(ui, client, fullId, t, regResp.EvalID)
-	require.Equal(t, 0, registerCode)
-
-	// Write a recommendation.
-	rec := &api.Recommendation{
-		JobID:    *testJob.ID,
-		Group:    *testJob.TaskGroups[0].Name,
-		Task:     testJob.TaskGroups[0].Tasks[0].Name,
-		Resource: "CPU",
-		Value:    1050,
-		Meta:     map[string]interface{}{"test-meta-entry": "test-meta-value"},
-		Stats:    map[string]float64{"p13": 1.13},
-	}
-	rec, _, err = client.Recommendations().Upsert(rec, nil)
-	if srv.Enterprise {
-		require.NoError(t, err)
-	} else {
-		require.Error(t, err, "Nomad Enterprise only endpoint")
-		return
-	}
-
-	cmd := &RecommendationInfoCommand{Meta: Meta{Ui: ui, flagAddress: url}}
-	prefix := rec.ID[:5]
-	args := complete.Args{Last: prefix}
-	predictor := cmd.AutocompleteArgs()
-
-	res := predictor.Predict(args)
-	assert.Equal(1, len(res))
-	assert.Equal(rec.ID, res[0])
+	cmd := RecommendationInfoCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+	testRecommendationAutocompleteCommand(t, client, srv, ui, &cmd.RecommendationAutocompleteCommand)
 }

--- a/command/recommendation_info_test.go
+++ b/command/recommendation_info_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,4 +82,47 @@ func TestRecommendationInfoCommand_Run(t *testing.T) {
 		require.Contains(out, "1.13")
 		require.Contains(out, recResp.ID)
 	}
+}
+
+func TestRecommendationInfoCommand_AutocompleteArgs(t *testing.T) {
+	assert := assert.New(t)
+	t.Parallel()
+
+	srv, client, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	// Register a test job to write a recommendation against.
+	ui := cli.NewMockUi()
+	testJob := testJob("recommendation_list")
+	regResp, _, err := client.Jobs().Register(testJob, nil)
+	require.NoError(t, err)
+	registerCode := waitForSuccess(ui, client, fullId, t, regResp.EvalID)
+	require.Equal(t, 0, registerCode)
+
+	// Write a recommendation.
+	rec := &api.Recommendation{
+		JobID:    *testJob.ID,
+		Group:    *testJob.TaskGroups[0].Name,
+		Task:     testJob.TaskGroups[0].Tasks[0].Name,
+		Resource: "CPU",
+		Value:    1050,
+		Meta:     map[string]interface{}{"test-meta-entry": "test-meta-value"},
+		Stats:    map[string]float64{"p13": 1.13},
+	}
+	rec, _, err = client.Recommendations().Upsert(rec, nil)
+	if srv.Enterprise {
+		require.NoError(t, err)
+	} else {
+		require.Error(t, err, "Nomad Enterprise only endpoint")
+		return
+	}
+
+	cmd := &RecommendationInfoCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+	prefix := rec.ID[:5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	assert.Equal(1, len(res))
+	assert.Equal(rec.ID, res[0])
 }

--- a/command/recommendation_list_test.go
+++ b/command/recommendation_list_test.go
@@ -1,15 +1,14 @@
 package command
 
 import (
-	"fmt"
 	"sort"
 	"testing"
 
-	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/testutil"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/nomad/api"
 )
 
 func TestRecommendationListCommand_Run(t *testing.T) {
@@ -17,21 +16,6 @@ func TestRecommendationListCommand_Run(t *testing.T) {
 	t.Parallel()
 	srv, client, url := testServer(t, true, nil)
 	defer srv.Shutdown()
-	testutil.WaitForResult(func() (bool, error) {
-		nodes, _, err := client.Nodes().List(nil)
-		if err != nil {
-			return false, err
-		}
-		if len(nodes) == 0 {
-			return false, fmt.Errorf("missing node")
-		}
-		if _, ok := nodes[0].Drivers["mock_driver"]; !ok {
-			return false, fmt.Errorf("mock_driver not ready")
-		}
-		return true, nil
-	}, func(err error) {
-		t.Fatalf("err: %s", err)
-	})
 
 	ui := cli.NewMockUi()
 	cmd := &RecommendationListCommand{Meta: Meta{Ui: ui}}
@@ -89,7 +73,7 @@ func TestRecommendationListCommand_Run(t *testing.T) {
 	}
 }
 
-func TestRecommendationList_Sort(t *testing.T) {
+func TestRecommendationListCommand_Sort(t *testing.T) {
 	testCases := []struct {
 		inputRecommendationList []*api.Recommendation
 		expectedOutputList      []*api.Recommendation

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -193,16 +193,17 @@ var (
 type Context string
 
 const (
-	Allocs      Context = "allocs"
-	Deployments Context = "deployment"
-	Evals       Context = "evals"
-	Jobs        Context = "jobs"
-	Nodes       Context = "nodes"
-	Namespaces  Context = "namespaces"
-	Quotas      Context = "quotas"
-	All         Context = "all"
-	Plugins     Context = "plugins"
-	Volumes     Context = "volumes"
+	Allocs          Context = "allocs"
+	Deployments     Context = "deployment"
+	Evals           Context = "evals"
+	Jobs            Context = "jobs"
+	Nodes           Context = "nodes"
+	Namespaces      Context = "namespaces"
+	Quotas          Context = "quotas"
+	Recommendations Context = "recommendations"
+	All             Context = "all"
+	Plugins         Context = "plugins"
+	Volumes         Context = "volumes"
 )
 
 // NamespacedID is a tuple of an ID and a namespace

--- a/vendor/github.com/hashicorp/nomad/api/contexts/contexts.go
+++ b/vendor/github.com/hashicorp/nomad/api/contexts/contexts.go
@@ -4,14 +4,15 @@ package contexts
 type Context string
 
 const (
-	Allocs      Context = "allocs"
-	Deployments Context = "deployment"
-	Evals       Context = "evals"
-	Jobs        Context = "jobs"
-	Nodes       Context = "nodes"
-	Namespaces  Context = "namespaces"
-	Quotas      Context = "quotas"
-	Plugins     Context = "plugins"
-	Volumes     Context = "volumes"
-	All         Context = "all"
+	Allocs          Context = "allocs"
+	Deployments     Context = "deployment"
+	Evals           Context = "evals"
+	Jobs            Context = "jobs"
+	Nodes           Context = "nodes"
+	Namespaces      Context = "namespaces"
+	Quotas          Context = "quotas"
+	Recommendations Context = "recommendations"
+	Plugins         Context = "plugins"
+	Volumes         Context = "volumes"
+	All             Context = "all"
 )


### PR DESCRIPTION
relies on and provides structure for `/v1/search` support in Enterprise, which will be merged next

the autocomplete support is redundant across all of the supported commands: `apply`, `dismiss`, and `info`, and I just copied it between them. this seems a little gross, but it's the same pattern used in the `nomad job` commands and `nomad deployment` commands (where it is repeated 6 times)

**update**: refactored to reduce redundancy in autocomplete code. 🤷 