### PR TITLE
recs cli: fixed bad composition

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -655,17 +655,23 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 		},
 		"recommendation apply": func() (cli.Command, error) {
 			return &RecommendationApplyCommand{
-				Meta: meta,
+				RecommendationAutocompleteCommand: RecommendationAutocompleteCommand{
+					Meta: meta,
+				},
 			}, nil
 		},
 		"recommendation dismiss": func() (cli.Command, error) {
 			return &RecommendationDismissCommand{
-				Meta: meta,
+				RecommendationAutocompleteCommand: RecommendationAutocompleteCommand{
+					Meta: meta,
+				},
 			}, nil
 		},
 		"recommendation info": func() (cli.Command, error) {
 			return &RecommendationInfoCommand{
-				Meta: meta,
+				RecommendationAutocompleteCommand: RecommendationAutocompleteCommand{
+					Meta: meta,
+				},
 			}, nil
 		},
 		"recommendation list": func() (cli.Command, error) {

--- a/command/recommendation_apply.go
+++ b/command/recommendation_apply.go
@@ -15,7 +15,6 @@ var _ cli.Command = &RecommendationApplyCommand{}
 
 // RecommendationApplyCommand implements cli.Command.
 type RecommendationApplyCommand struct {
-	Meta
 	RecommendationAutocompleteCommand
 }
 

--- a/command/recommendation_apply_test.go
+++ b/command/recommendation_apply_test.go
@@ -33,7 +33,13 @@ func TestRecommendationApplyCommand_Run(t *testing.T) {
 	})
 
 	ui := cli.NewMockUi()
-	cmd := &RecommendationApplyCommand{Meta: Meta{Ui: ui}}
+	cmd := &RecommendationApplyCommand{
+		RecommendationAutocompleteCommand: RecommendationAutocompleteCommand{
+			Meta: Meta{
+				Ui: ui,
+			},
+		},
+	}
 
 	// Register a test job to write a recommendation against.
 	testJob := testJob("recommendation_apply")
@@ -86,10 +92,17 @@ func TestRecommendationApplyCommand_Run(t *testing.T) {
 }
 
 func TestRecommendationApplyCommand_AutocompleteArgs(t *testing.T) {
-	srv, client, url := testServer(t, true, nil)
+	srv, client, url := testServer(t, false, nil)
 	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
-	cmd := RecommendationApplyCommand{Meta: Meta{Ui: ui, flagAddress: url}}
-	testRecommendationAutocompleteCommand(t, client, srv, ui, &cmd.RecommendationAutocompleteCommand)
+	cmd := RecommendationApplyCommand{
+		RecommendationAutocompleteCommand: RecommendationAutocompleteCommand{
+			Meta: Meta{
+				Ui:          ui,
+				flagAddress: url,
+			},
+		},
+	}
+	testRecommendationAutocompleteCommand(t, client, srv, &cmd.RecommendationAutocompleteCommand)
 }

--- a/command/recommendation_dismiss.go
+++ b/command/recommendation_dismiss.go
@@ -36,7 +36,6 @@ func (r *RecommendationAutocompleteCommand) AutocompleteArgs() complete.Predicto
 
 // RecommendationDismissCommand implements cli.Command.
 type RecommendationDismissCommand struct {
-	Meta
 	RecommendationAutocompleteCommand
 }
 

--- a/command/recommendation_info.go
+++ b/command/recommendation_info.go
@@ -14,7 +14,6 @@ var _ cli.Command = &RecommendationInfoCommand{}
 
 // RecommendationInfoCommand implements cli.Command.
 type RecommendationInfoCommand struct {
-	Meta
 	RecommendationAutocompleteCommand
 }
 

--- a/command/recommendation_info_test.go
+++ b/command/recommendation_info_test.go
@@ -33,7 +33,11 @@ func TestRecommendationInfoCommand_Run(t *testing.T) {
 	})
 
 	ui := cli.NewMockUi()
-	cmd := &RecommendationInfoCommand{Meta: Meta{Ui: ui}}
+	cmd := &RecommendationInfoCommand{
+		RecommendationAutocompleteCommand: RecommendationAutocompleteCommand{
+			Meta: Meta{Ui: ui},
+		},
+	}
 
 	// Perform an initial call, which should return a not found error.
 	code := cmd.Run([]string{"-address=" + url, "2c13f001-f5b6-ce36-03a5-e37afe160df5"})
@@ -84,10 +88,17 @@ func TestRecommendationInfoCommand_Run(t *testing.T) {
 }
 
 func TestRecommendationInfoCommand_AutocompleteArgs(t *testing.T) {
-	srv, client, url := testServer(t, true, nil)
+	srv, client, url := testServer(t, false, nil)
 	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
-	cmd := RecommendationInfoCommand{Meta: Meta{Ui: ui, flagAddress: url}}
-	testRecommendationAutocompleteCommand(t, client, srv, ui, &cmd.RecommendationAutocompleteCommand)
+	cmd := RecommendationInfoCommand{
+		RecommendationAutocompleteCommand: RecommendationAutocompleteCommand{
+			Meta: Meta{
+				Ui:          ui,
+				flagAddress: url,
+			},
+		},
+	}
+	testRecommendationAutocompleteCommand(t, client, srv, &cmd.RecommendationAutocompleteCommand)
 }


### PR DESCRIPTION
i got the composition wrong 😞 so that `meta` was duplicated, and downstream code was using the wrong one
new approach is not as pretty, but still better than repeating this across all three (so far) commands