### PR TITLE
release: infer node version

### DIFF
--- a/scripts/release/Dockerfile
+++ b/scripts/release/Dockerfile
@@ -31,13 +31,14 @@ USER vagrant
 
 COPY ./scripts/vagrant-linux-unpriv-ui.sh /tmp/scripts/vagrant-linux-unpriv-ui.sh
 RUN /tmp/scripts/vagrant-linux-unpriv-ui.sh
+# avoid requiring loading nvm.sh by using a well defined path as an lias to the node version
+RUN /bin/bash -c '. ~/.nvm/nvm.sh && ln -s ~/.nvm/versions/node/$(nvm current) ~/.nvm/versions/node/.default'
 
 COPY ./scripts/release/docker-build-all /tmp/scripts/docker-build-all
 
 # Update PATH with GO bin, yarn, and node
-ENV NODE_VERSION=v12.19.0
 ENV GOPATH="/opt/gopath" \
-    PATH="/home/vagrant/.nvm/versions/node/${NODE_VERSION}/bin:/home/vagrant/bin:/opt/gopath/bin:/home/vagrant/.yarn/bin:/home/vagrant/.config/yarn/global/node_modules/.bin:$PATH"
+    PATH="/home/vagrant/.nvm/versions/node/.default/bin:/home/vagrant/bin:/opt/gopath/bin:/home/vagrant/.yarn/bin:/home/vagrant/.config/yarn/global/node_modules/.bin:$PATH"
 
 RUN mkdir -p /opt/gopath/src/github.com/hashicorp/nomad
 RUN mkdir -p /home/vagrant/bin \

--- a/scripts/release/Dockerfile
+++ b/scripts/release/Dockerfile
@@ -31,7 +31,7 @@ USER vagrant
 
 COPY ./scripts/vagrant-linux-unpriv-ui.sh /tmp/scripts/vagrant-linux-unpriv-ui.sh
 RUN /tmp/scripts/vagrant-linux-unpriv-ui.sh
-# avoid requiring loading nvm.sh by using a well defined path as an lias to the node version
+# avoid requiring loading nvm.sh by using a well defined path as an alias to the node version
 RUN /bin/bash -c '. ~/.nvm/nvm.sh && ln -s ~/.nvm/versions/node/$(nvm current) ~/.nvm/versions/node/.default'
 
 COPY ./scripts/release/docker-build-all /tmp/scripts/docker-build-all

--- a/scripts/vagrant-linux-unpriv-ui.sh
+++ b/scripts/vagrant-linux-unpriv-ui.sh
@@ -9,7 +9,7 @@ export NVM_DIR="/home/vagrant/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
 
 # Install Node, Ember CLI, and Phantom for UI development
-# Use exact full version version (e.g. not 12) and update scripts/release/Dockerfile
+# Use exact full version version (e.g. not 12) for reproducibility purposes
 nvm install 12.19.0
 nvm alias default 12.19.0
 npm install -g ember-cli


### PR DESCRIPTION
Avoids setting the node version in the release Dockerfile, by using
an alias.  This allows us to update the node version in one file only.
