### PR TITLE
docs: update brige network subnet docs

### DIFF
--- a/website/pages/docs/configuration/client.mdx
+++ b/website/pages/docs/configuration/client.mdx
@@ -144,7 +144,7 @@ driver) but will be removed in a future release.
   created by nomad for allocations running with bridge networking mode on the
   client.
 
-- `bridge_network_subnet` `(string: "172.26.66.0/23")` - Specifies the subnet
+- `bridge_network_subnet` `(string: "172.26.64.0/20")` - Specifies the subnet
   which the client will use to allocate IP addresses from.
 
 - `template` <code>([Template](#template-parameters): nil)</code> - Specifies


### PR DESCRIPTION
Update the default value for `client.bridge_network_subnet` in docs
to match the new value from 99742f2665. Was `172.26.66.0/23`, is
now `172.26.64.0/20`.

Fixes #9316