### PR TITLE
Restrict HCL special casing of map[string]interface{} fields

### DIFF
--- a/jobspec2/helper_test.go
+++ b/jobspec2/helper_test.go
@@ -1,0 +1,5 @@
+package jobspec2
+
+func intToPtr(v int) *int {
+	return &v
+}

--- a/jobspec2/parse.go
+++ b/jobspec2/parse.go
@@ -11,11 +11,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/ext/dynblock"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	hcljson "github.com/hashicorp/hcl/v2/json"
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/jobspec2/hclutil"
 )
 
 func Parse(path string, r io.Reader) (*api.Job, error) {
@@ -104,9 +102,7 @@ func decode(c *jobConfig) error {
 		return diags
 	}
 
-	body := hclutil.BlocksAsAttrs(file.Body)
-	body = dynblock.Expand(body, c.EvalContext())
-	diags = c.decodeBody(body)
+	diags = c.decodeBody(file.Body)
 	if diags.HasErrors() {
 		var str strings.Builder
 		for i, diag := range diags {
@@ -117,7 +113,9 @@ func decode(c *jobConfig) error {
 		}
 		return errors.New(str.String())
 	}
-	diags = append(diags, decodeMapInterfaceType(&c, c.EvalContext())...)
+	diags = append(diags, decodeMapInterfaceType(&c.Job, c.EvalContext())...)
+	diags = append(diags, decodeMapInterfaceType(&c.Tasks, c.EvalContext())...)
+	diags = append(diags, decodeMapInterfaceType(&c.Vault, c.EvalContext())...)
 	return nil
 }
 

--- a/jobspec2/parse_job.go
+++ b/jobspec2/parse_job.go
@@ -113,6 +113,10 @@ func normalizeTemplates(templates []*api.Template) {
 	}
 }
 
+func intToPtr(v int) *int {
+	return &v
+}
+
 func int8ToPtr(v int8) *int8 {
 	return &v
 }

--- a/jobspec2/parse_job.go
+++ b/jobspec2/parse_job.go
@@ -113,10 +113,6 @@ func normalizeTemplates(templates []*api.Template) {
 	}
 }
 
-func intToPtr(v int) *int {
-	return &v
-}
-
 func int8ToPtr(v int8) *int8 {
 	return &v
 }

--- a/jobspec2/parse_map.go
+++ b/jobspec2/parse_map.go
@@ -41,6 +41,11 @@ func (w *walker) Map(m reflect.Value) error {
 		return nil
 	}
 
+	// ignore private map fields
+	if !m.CanSet() {
+		return nil
+	}
+
 	for _, k := range m.MapKeys() {
 		v := m.MapIndex(k)
 		if attr, ok := v.Interface().(*hcl.Attribute); ok {


### PR DESCRIPTION
The HCL2 parser needs to apply special parsing tweaks so it can parse
the task config the same way as HCL1. Particularly, it needs to
reinterprets `map[string]interface{}` fields and blocks that appear when
attributes are expected.

This commit restricts the special casing to the Job fields, and ignore
`variables` and `locals` block.