### PR TITLE
e2e: CSI test should detect un-deregisterable volumes

### DIFF
--- a/e2e/csi/csi.go
+++ b/e2e/csi/csi.go
@@ -3,17 +3,23 @@ package csi
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
-	"github.com/hashicorp/hcl"
-	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/e2e/e2eutil"
-	"github.com/hashicorp/nomad/e2e/framework"
-	"github.com/hashicorp/nomad/helper"
-	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/nomad/api"
+	e2e "github.com/hashicorp/nomad/e2e/e2eutil"
+	"github.com/hashicorp/nomad/e2e/framework"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/testutil"
 )
 
 type CSIVolumesTest struct {
@@ -34,6 +40,11 @@ func init() {
 	})
 }
 
+const ns = ""
+
+var pluginWait = &e2e.WaitConfig{Interval: 5 * time.Second, Retries: 24} // 2min
+var reapWait = &e2e.WaitConfig{Interval: 5 * time.Second, Retries: 36}   // 3min
+
 func (tc *CSIVolumesTest) BeforeAll(f *framework.F) {
 	t := f.T()
 
@@ -49,8 +60,8 @@ func (tc *CSIVolumesTest) BeforeAll(f *framework.F) {
 
 	// Ensure cluster has leader and at least two client
 	// nodes in a ready state before running tests
-	e2eutil.WaitForLeader(t, tc.Nomad())
-	e2eutil.WaitForNodesReady(t, tc.Nomad(), 2)
+	e2e.WaitForLeader(t, tc.Nomad())
+	e2e.WaitForNodesReady(t, tc.Nomad(), 2)
 }
 
 // TestEBSVolumeClaim launches AWS EBS plugins and registers an EBS volume
@@ -62,84 +73,91 @@ func (tc *CSIVolumesTest) TestEBSVolumeClaim(f *framework.F) {
 	require := require.New(t)
 	nomadClient := tc.Nomad()
 	uuid := uuid.Generate()
+	pluginID := "aws-ebs0"
 
 	// deploy the controller plugin job
 	controllerJobID := "aws-ebs-plugin-controller-" + uuid[0:8]
+	f.NoError(e2e.Register(controllerJobID, "csi/input/plugin-aws-ebs-controller.nomad"))
 	tc.pluginJobIDs = append(tc.pluginJobIDs, controllerJobID)
-	e2eutil.RegisterAndWaitForAllocs(t, nomadClient,
-		"csi/input/plugin-aws-ebs-controller.nomad", controllerJobID, "")
+	expected := []string{"running", "running"}
+	f.NoError(
+		e2e.WaitForAllocStatusExpected(controllerJobID, ns, expected),
+		"job should be running")
 
 	// deploy the node plugins job
 	nodesJobID := "aws-ebs-plugin-nodes-" + uuid[0:8]
+	f.NoError(e2e.Register(nodesJobID, "csi/input/plugin-aws-ebs-nodes.nomad"))
 	tc.pluginJobIDs = append(tc.pluginJobIDs, nodesJobID)
-	e2eutil.RegisterAndWaitForAllocs(t, nomadClient,
-		"csi/input/plugin-aws-ebs-nodes.nomad", nodesJobID, "")
 
-	// wait for plugin to become healthy
-	require.Eventuallyf(func() bool {
-		plugin, _, err := nomadClient.CSIPlugins().Info("aws-ebs0", nil)
-		if err != nil {
-			return false
-		}
-		if plugin.ControllersHealthy < 2 || plugin.NodesHealthy < 2 {
-			return false
-		}
-		return true
-		// TODO(tgross): cut down this time after fixing
-		// https://github.com/hashicorp/nomad/issues/7296
-	}, 90*time.Second, 5*time.Second, "aws-ebs0 plugins did not become healthy")
+	f.NoError(e2e.WaitForAllocStatusComparison(
+		func() ([]string, error) { return e2e.AllocStatuses(nodesJobID, ns) },
+		func(got []string) bool {
+			for _, status := range got {
+				if status != "running" {
+					return false
+				}
+			}
+			return true
+		}, nil,
+	))
+
+	f.NoError(waitForPluginStatusControllerCount(pluginID, 2, pluginWait),
+		"aws-ebs0 controller plugins did not become healthy")
+	f.NoError(waitForPluginStatusMinNodeCount(pluginID, 2, pluginWait),
+		"aws-ebs0 node plugins did not become healthy")
 
 	// register a volume
+	// TODO: we don't have a unique ID threaded thru the jobspec yet
 	volID := "ebs-vol0"
-	vol, err := parseVolumeFile("csi/input/volume-ebs.hcl")
-	require.NoError(err)
-	_, err = nomadClient.CSIVolumes().Register(vol, nil)
+	err := volumeRegister(volID, "csi/input/volume-ebs.hcl")
 	require.NoError(err)
 	tc.volumeIDs = append(tc.volumeIDs, volID)
 
 	// deploy a job that writes to the volume
 	writeJobID := "write-ebs-" + uuid[0:8]
-	tc.testJobIDs = append(tc.testJobIDs, writeJobID)
-	writeAllocs := e2eutil.RegisterAndWaitForAllocs(t, nomadClient,
-		"csi/input/use-ebs-volume.nomad", writeJobID, "")
-	writeAllocID := writeAllocs[0].ID
-	tc.testJobIDs = append(tc.testJobIDs, writeJobID) // ensure failed tests clean up
-	e2eutil.WaitForAllocRunning(t, nomadClient, writeAllocID)
+	f.NoError(e2e.Register(writeJobID, "csi/input/use-ebs-volume.nomad"))
+	f.NoError(
+		e2e.WaitForAllocStatusExpected(writeJobID, ns, []string{"running"}),
+		"job should be running")
+
+	allocs, err := e2e.AllocsForJob(writeJobID, ns)
+	f.NoError(err, "could not get allocs for write job")
+	f.Len(allocs, 1, "could not get allocs for write job")
+	writeAllocID := allocs[0]["ID"]
 
 	// read data from volume and assert the writer wrote a file to it
-	writeAlloc, _, err := nomadClient.Allocations().Info(writeAllocID, nil)
-	require.NoError(err)
-	expectedPath := "/local/test/" + writeAllocID
-	_, err = readFile(nomadClient, writeAlloc, expectedPath)
+	expectedPath := "/task/test/" + writeAllocID
+	_, err = readFile(nomadClient, writeAllocID, expectedPath)
 	require.NoError(err)
 
 	// Shutdown (and purge) the writer so we can run a reader.
 	// we could mount the EBS volume with multi-attach, but we
 	// want this test to exercise the unpublish workflow.
-	// this runs the equivalent of 'nomad job stop -purge'
-	nomadClient.Jobs().Deregister(writeJobID, true, nil)
-	// instead of waiting for the alloc to stop, wait for the volume claim gc run
-	require.Eventuallyf(func() bool {
-		vol, _, err := nomadClient.CSIVolumes().Info(volID, nil)
-		if err != nil {
-			return false
-		}
-		return len(vol.WriteAllocs) == 0
-	}, 90*time.Second, 5*time.Second, "write-ebs alloc claim was not released")
+	_, err = e2e.Command("nomad", "job", "stop", "-purge", writeJobID)
+	require.NoError(err)
+
+	// wait for the volume unpublish workflow to complete
+	require.NoError(waitForVolumeClaimRelease(volID, reapWait),
+		"write-ebs alloc claim was not released")
 
 	// deploy a job so we can read from the volume
 	readJobID := "read-ebs-" + uuid[0:8]
-	tc.testJobIDs = append(tc.testJobIDs, readJobID)
-	readAllocs := e2eutil.RegisterAndWaitForAllocs(t, nomadClient,
-		"csi/input/use-ebs-volume.nomad", readJobID, "")
-	readAllocID := readAllocs[0].ID
-	e2eutil.WaitForAllocRunning(t, nomadClient, readAllocID)
+	tc.testJobIDs = append(tc.testJobIDs, readJobID) // ensure failed tests clean up
+	f.NoError(e2e.Register(readJobID, "csi/input/use-ebs-volume.nomad"))
+	f.NoError(
+		e2e.WaitForAllocStatusExpected(readJobID, ns, []string{"running"}),
+		"job should be running")
 
-	// read data from volume and assert the writer wrote a file to it
-	readAlloc, _, err := nomadClient.Allocations().Info(readAllocID, nil)
+	allocs, err = e2e.AllocsForJob(readJobID, ns)
+	f.NoError(err, "could not get allocs for read job")
+	f.Len(allocs, 1, "could not get allocs for read job")
+	readAllocID := allocs[0]["ID"]
+
+	// read data from volume and assert we can read the file the writer wrote
+	expectedPath = "/task/test/" + readAllocID
+	_, err = readFile(nomadClient, readAllocID, expectedPath)
 	require.NoError(err)
-	_, err = readFile(nomadClient, readAlloc, expectedPath)
-	require.NoError(err)
+
 }
 
 // TestEFSVolumeClaim launches AWS EFS plugins and registers an EFS volume
@@ -151,106 +169,190 @@ func (tc *CSIVolumesTest) TestEFSVolumeClaim(f *framework.F) {
 	require := require.New(t)
 	nomadClient := tc.Nomad()
 	uuid := uuid.Generate()
+	pluginID := "aws-efs0"
 
 	// deploy the node plugins job (no need for a controller for EFS)
 	nodesJobID := "aws-efs-plugin-nodes-" + uuid[0:8]
+	f.NoError(e2e.Register(nodesJobID, "csi/input/plugin-aws-efs-nodes.nomad"))
 	tc.pluginJobIDs = append(tc.pluginJobIDs, nodesJobID)
-	e2eutil.RegisterAndWaitForAllocs(t, nomadClient,
-		"csi/input/plugin-aws-efs-nodes.nomad", nodesJobID, "")
 
-	// wait for plugin to become healthy
-	require.Eventuallyf(func() bool {
-		plugin, _, err := nomadClient.CSIPlugins().Info("aws-efs0", nil)
-		if err != nil {
-			return false
-		}
-		if plugin.NodesHealthy < 2 {
-			return false
-		}
-		return true
-		// TODO(tgross): cut down this time after fixing
-		// https://github.com/hashicorp/nomad/issues/7296
-	}, 90*time.Second, 5*time.Second, "aws-efs0 plugins did not become healthy")
+	f.NoError(e2e.WaitForAllocStatusComparison(
+		func() ([]string, error) { return e2e.AllocStatuses(nodesJobID, ns) },
+		func(got []string) bool {
+			for _, status := range got {
+				if status != "running" {
+					return false
+				}
+			}
+			return true
+		}, nil,
+	))
+
+	f.NoError(waitForPluginStatusMinNodeCount(pluginID, 2, pluginWait),
+		"aws-efs0 node plugins did not become healthy")
 
 	// register a volume
 	volID := "efs-vol0"
-	vol, err := parseVolumeFile("csi/input/volume-efs.hcl")
-	require.NoError(err)
-	_, err = nomadClient.CSIVolumes().Register(vol, nil)
+	err := volumeRegister(volID, "csi/input/volume-efs.hcl")
 	require.NoError(err)
 	tc.volumeIDs = append(tc.volumeIDs, volID)
 
 	// deploy a job that writes to the volume
 	writeJobID := "write-efs-" + uuid[0:8]
-	writeAllocs := e2eutil.RegisterAndWaitForAllocs(t, nomadClient,
-		"csi/input/use-efs-volume-write.nomad", writeJobID, "")
-	writeAllocID := writeAllocs[0].ID
 	tc.testJobIDs = append(tc.testJobIDs, writeJobID) // ensure failed tests clean up
-	e2eutil.WaitForAllocRunning(t, nomadClient, writeAllocID)
+	f.NoError(e2e.Register(writeJobID, "csi/input/use-efs-volume-write.nomad"))
+	f.NoError(
+		e2e.WaitForAllocStatusExpected(writeJobID, ns, []string{"running"}),
+		"job should be running")
+
+	allocs, err := e2e.AllocsForJob(writeJobID, ns)
+	f.NoError(err, "could not get allocs for write job")
+	f.Len(allocs, 1, "could not get allocs for write job")
+	writeAllocID := allocs[0]["ID"]
 
 	// read data from volume and assert the writer wrote a file to it
-	writeAlloc, _, err := nomadClient.Allocations().Info(writeAllocID, nil)
-	require.NoError(err)
-	expectedPath := "/local/test/" + writeAllocID
-	_, err = readFile(nomadClient, writeAlloc, expectedPath)
+	expectedPath := "/task/test/" + writeAllocID
+	_, err = readFile(nomadClient, writeAllocID, expectedPath)
 	require.NoError(err)
 
 	// Shutdown the writer so we can run a reader.
 	// although EFS should support multiple readers, the plugin
 	// does not.
-	// this runs the equivalent of 'nomad job stop'
-	nomadClient.Jobs().Deregister(writeJobID, false, nil)
-	// instead of waiting for the alloc to stop, wait for the volume claim gc run
-	require.Eventuallyf(func() bool {
-		vol, _, err := nomadClient.CSIVolumes().Info(volID, nil)
-		if err != nil {
-			return false
-		}
-		return len(vol.WriteAllocs) == 0
-	}, 90*time.Second, 5*time.Second, "write-efs alloc claim was not released")
+	_, err = e2e.Command("nomad", "job", "stop", writeJobID)
+	require.NoError(err)
 
-	// deploy a job that reads from the volume.
+	// wait for the volume unpublish workflow to complete
+	require.NoError(waitForVolumeClaimRelease(volID, reapWait),
+		"write-efs alloc claim was not released")
+
+	// deploy a job that reads from the volume
 	readJobID := "read-efs-" + uuid[0:8]
-	tc.testJobIDs = append(tc.testJobIDs, readJobID)
-	readAllocs := e2eutil.RegisterAndWaitForAllocs(t, nomadClient,
-		"csi/input/use-efs-volume-read.nomad", readJobID, "")
-	e2eutil.WaitForAllocRunning(t, nomadClient, readAllocs[0].ID)
+	tc.testJobIDs = append(tc.testJobIDs, readJobID) // ensure failed tests clean up
+	f.NoError(e2e.Register(readJobID, "csi/input/use-efs-volume-read.nomad"))
+	f.NoError(
+		e2e.WaitForAllocStatusExpected(readJobID, ns, []string{"running"}),
+		"job should be running")
+
+	allocs, err = e2e.AllocsForJob(readJobID, ns)
+	f.NoError(err, "could not get allocs for read job")
+	f.Len(allocs, 1, "could not get allocs for read job")
+	readAllocID := allocs[0]["ID"]
 
 	// read data from volume and assert the writer wrote a file to it
-	readAlloc, _, err := nomadClient.Allocations().Info(readAllocs[0].ID, nil)
 	require.NoError(err)
-	_, err = readFile(nomadClient, readAlloc, expectedPath)
+	_, err = readFile(nomadClient, readAllocID, expectedPath)
 	require.NoError(err)
 }
 
 func (tc *CSIVolumesTest) AfterEach(f *framework.F) {
-	nomadClient := tc.Nomad()
-	jobs := nomadClient.Jobs()
+
 	// Stop all jobs in test
 	for _, id := range tc.testJobIDs {
-		jobs.Deregister(id, true, nil)
+		out, err := e2e.Command("nomad", "job", "stop", "-purge", id)
+		f.Assert().NoError(err, out)
 	}
+	tc.testJobIDs = []string{}
+
 	// Deregister all volumes in test
 	for _, id := range tc.volumeIDs {
-		nomadClient.CSIVolumes().Deregister(id, true, nil)
+		// make sure all the test jobs have finished unpublishing claims
+		err := waitForVolumeClaimRelease(id, reapWait)
+		f.Assert().NoError(err, "volume claims were not released")
+
+		out, err := e2e.Command("nomad", "volume", "deregister", id)
+		if err != nil {
+			fmt.Println("could not deregister volume, dumping allocation logs")
+			f.Assert().NoError(tc.dumpLogs())
+		}
+		f.Assert().NoError(err, out)
 	}
+	tc.volumeIDs = []string{}
+
 	// Deregister all plugin jobs in test
 	for _, id := range tc.pluginJobIDs {
-		jobs.Deregister(id, true, nil)
+		out, err := e2e.Command("nomad", "job", "stop", "-purge", id)
+		f.Assert().NoError(err, out)
 	}
+	tc.pluginJobIDs = []string{}
 
 	// Garbage collect
-	nomadClient.System().GarbageCollect()
+	out, err := e2e.Command("nomad", "system", "gc")
+	f.Assert().NoError(err, out)
+}
+
+// waitForVolumeClaimRelease makes sure we don't try to re-claim a volume
+// that's in the process of being unpublished. we can't just wait for allocs
+// to stop, but need to wait for their claims to be released
+func waitForVolumeClaimRelease(volID string, wc *e2e.WaitConfig) error {
+	var out string
+	var err error
+	testutil.WaitForResultRetries(wc.Retries, func() (bool, error) {
+		time.Sleep(wc.Interval)
+		out, err = e2e.Command("nomad", "volume", "status", volID)
+		if err != nil {
+			return false, err
+		}
+		section, err := e2e.GetSection(out, "Allocations")
+		if err != nil {
+			return false, err
+		}
+		return strings.Contains(section, "No allocations placed"), nil
+	}, func(e error) {
+		if e == nil {
+			err = nil
+		}
+		err = fmt.Errorf("alloc claim was not released: %v\n%s", e, out)
+	})
+	return err
+}
+
+func (tc *CSIVolumesTest) dumpLogs() error {
+
+	for _, id := range tc.pluginJobIDs {
+		allocs, err := e2e.AllocsForJob(id, ns)
+		if err != nil {
+			return fmt.Errorf("could not find allocs for plugin: %v", err)
+		}
+		for _, alloc := range allocs {
+			allocID := alloc["ID"]
+			out, err := e2e.AllocLogs(allocID, e2e.LogsStdErr)
+			if err != nil {
+				return fmt.Errorf("could not get logs for alloc: %v\n%s", err, out)
+			}
+			_, isCI := os.LookupEnv("CI")
+			if isCI {
+				fmt.Println("--------------------------------------")
+				fmt.Println("allocation logs:", allocID)
+				fmt.Println(out)
+				continue
+			}
+			f, err := os.Create(allocID + ".log")
+			if err != nil {
+				return fmt.Errorf("could not create log file: %v", err)
+			}
+			defer f.Close()
+			_, err = f.WriteString(out)
+			if err != nil {
+				return fmt.Errorf("could not write to log file: %v", err)
+			}
+			fmt.Printf("nomad alloc logs written to %s.log\n", allocID)
+		}
+	}
+	return nil
 }
 
 // TODO(tgross): replace this w/ AllocFS().Stat() after
 // https://github.com/hashicorp/nomad/issues/7365 is fixed
-func readFile(client *api.Client, alloc *api.Allocation, path string) (bytes.Buffer, error) {
+func readFile(client *api.Client, allocID string, path string) (bytes.Buffer, error) {
+	var stdout, stderr bytes.Buffer
+	alloc, _, err := client.Allocations().Info(allocID, nil)
+	if err != nil {
+		return stdout, err
+	}
 	ctx, cancelFn := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelFn()
 
-	var stdout, stderr bytes.Buffer
-	_, err := client.Allocations().Exec(ctx,
+	_, err = client.Allocations().Exec(ctx,
 		alloc, "task", false,
 		[]string{"cat", path},
 		os.Stdin, &stdout, &stderr,
@@ -258,33 +360,109 @@ func readFile(client *api.Client, alloc *api.Allocation, path string) (bytes.Buf
 	return stdout, err
 }
 
-// TODO(tgross): this is taken from `nomad volume register` but
-// it would be nice if we could expose this with a ParseFile as
-// we do for api.Job.
-func parseVolumeFile(filepath string) (*api.CSIVolume, error) {
+func waitForPluginStatusMinNodeCount(pluginID string, minCount int, wc *e2e.WaitConfig) error {
 
-	rawInput, err := ioutil.ReadFile(filepath)
+	return waitForPluginStatusCompare(pluginID, func(out string) (bool, error) {
+		expected, err := e2e.GetField(out, "Nodes Expected")
+		if err != nil {
+			return false, err
+		}
+		expectedCount, err := strconv.Atoi(strings.TrimSpace(expected))
+		if err != nil {
+			return false, err
+		}
+		if expectedCount < minCount {
+			return false, fmt.Errorf(
+				"expected Nodes Expected >= %d, got %q", minCount, expected)
+		}
+		healthy, err := e2e.GetField(out, "Nodes Healthy")
+		if err != nil {
+			return false, err
+		}
+		if healthy != expected {
+			return false, fmt.Errorf(
+				"expected Nodes Healthy >= %d, got %q", minCount, healthy)
+		}
+		return true, nil
+	}, wc)
+}
+
+func waitForPluginStatusControllerCount(pluginID string, count int, wc *e2e.WaitConfig) error {
+
+	return waitForPluginStatusCompare(pluginID, func(out string) (bool, error) {
+
+		expected, err := e2e.GetField(out, "Controllers Expected")
+		if err != nil {
+			return false, err
+		}
+		expectedCount, err := strconv.Atoi(strings.TrimSpace(expected))
+		if err != nil {
+			return false, err
+		}
+		if expectedCount != count {
+			return false, fmt.Errorf(
+				"expected Controllers Expected = %d, got %d", count, expectedCount)
+		}
+		healthy, err := e2e.GetField(out, "Controllers Healthy")
+		if err != nil {
+			return false, err
+		}
+		healthyCount, err := strconv.Atoi(strings.TrimSpace(healthy))
+		if err != nil {
+			return false, err
+		}
+		if healthyCount != count {
+			return false, fmt.Errorf(
+				"expected Controllers Healthy = %d, got %d", count, healthyCount)
+		}
+		return true, nil
+
+	}, wc)
+}
+
+func waitForPluginStatusCompare(pluginID string, compare func(got string) (bool, error), wc *e2e.WaitConfig) error {
+	var err error
+	testutil.WaitForResultRetries(wc.Retries, func() (bool, error) {
+		time.Sleep(wc.Interval)
+		out, err := e2e.Command("nomad", "plugin", "status", pluginID)
+		if err != nil {
+			return false, err
+		}
+		return compare(out)
+	}, func(e error) {
+		err = fmt.Errorf("plugin status check failed: %v", e)
+	})
+	return err
+}
+
+// VolumeRegister registers a jobspec from a file but with a unique ID.
+// The caller is responsible for recording that ID for later cleanup.
+func volumeRegister(volID, volFilePath string) error {
+
+	cmd := exec.Command("nomad", "volume", "register", "-")
+	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return nil, err
-	}
-	ast, err := hcl.Parse(string(rawInput))
-	if err != nil {
-		return nil, err
+		return fmt.Errorf("could not open stdin?: %w", err)
 	}
 
-	output := &api.CSIVolume{}
-	err = hcl.DecodeObject(output, ast)
+	content, err := ioutil.ReadFile(volFilePath)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("could not open vol file: %w", err)
 	}
 
-	// api.CSIVolume doesn't have the type field, it's used only for
-	// dispatch in parseVolumeType
-	helper.RemoveEqualFold(&output.ExtraKeysHCL, "type")
-	err = helper.UnusedKeys(output)
-	if err != nil {
-		return nil, err
-	}
+	// hack off the first line to replace with our unique ID
+	var re = regexp.MustCompile(`(?m)^id ".*"`)
+	volspec := re.ReplaceAllString(string(content),
+		fmt.Sprintf("id = \"%s\"", volID))
 
-	return output, nil
+	go func() {
+		defer stdin.Close()
+		io.WriteString(stdin, volspec)
+	}()
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("could not register vol: %w\n%v", err, string(out))
+	}
+	return nil
 }

--- a/e2e/csi/input/use-ebs-volume.nomad
+++ b/e2e/csi/input/use-ebs-volume.nomad
@@ -19,7 +19,7 @@ job "use-ebs-volume" {
       config {
         image   = "busybox:1"
         command = "/bin/sh"
-        args    = ["-c", "touch /local/test/${NOMAD_ALLOC_ID}; sleep 3600"]
+        args    = ["-c", "echo 'ok' > ${NOMAD_TASK_DIR}/test/${NOMAD_ALLOC_ID}; sleep 3600"]
       }
 
       volume_mount {

--- a/e2e/csi/input/use-efs-volume-write.nomad
+++ b/e2e/csi/input/use-efs-volume-write.nomad
@@ -19,7 +19,7 @@ job "use-efs-volume" {
       config {
         image   = "busybox:1"
         command = "/bin/sh"
-        args    = ["-c", "touch /local/test/${NOMAD_ALLOC_ID}; sleep 3600"]
+        args    = ["-c", "echo 'ok' > ${NOMAD_TASK_DIR}/test/${NOMAD_ALLOC_ID}; sleep 3600"]
       }
 
       volume_mount {

--- a/e2e/e2eutil/allocs.go
+++ b/e2e/e2eutil/allocs.go
@@ -170,6 +170,22 @@ func AllocStatusesRescheduled(jobID, ns string) ([]string, error) {
 	return statuses, nil
 }
 
+type LogStream int
+
+const (
+	LogsStdErr LogStream = iota
+	LogsStdOut
+)
+
+func AllocLogs(allocID string, logStream LogStream) (string, error) {
+	cmd := []string{"nomad", "alloc", "logs"}
+	if logStream == LogsStdErr {
+		cmd = append(cmd, "-stderr")
+	}
+	cmd = append(cmd, allocID)
+	return Command(cmd[0], cmd[1:]...)
+}
+
 // AllocExec is a convenience wrapper that runs 'nomad alloc exec' with the
 // passed execCmd via '/bin/sh -c', retrying if the task isn't ready
 func AllocExec(allocID, taskID, execCmd, ns string, wc *WaitConfig) (string, error) {

--- a/e2e/e2eutil/job.go
+++ b/e2e/e2eutil/job.go
@@ -24,7 +24,7 @@ func Register(jobID, jobFilePath string) error {
 	}
 
 	// hack off the first line to replace with our unique ID
-	var re = regexp.MustCompile(`^job "\w+" \{`)
+	var re = regexp.MustCompile(`(?m)^job ".*" \{`)
 	jobspec := re.ReplaceAllString(string(content),
 		fmt.Sprintf("job \"%s\" {", jobID))
 


### PR DESCRIPTION
Assert that deregistering a volume works without errors following a volume
reap. This has been an area where we've been hit by bugs and the existing
tests don't cover it. (And it seems very difficult to make happen in unit testing.)

Includes:
* Use CLI helpers where feasible to exercise CSI command line.
* Dump plugin allocation logs on deregistration failures for debugging purposes.