### PR TITLE
nomad operator debug - add pprof duration / csi details

### DIFF
--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -61,7 +61,8 @@ Usage: nomad operator debug [options]
   If ACLs are enabled, this command will require a token with the 'node:read'
   capability to run. In order to collect information, the token will also
   require the 'agent:read' and 'operator:read' capabilities, as well as the
-  'list-jobs' capability for all namespaces.
+  'list-jobs' capability for all namespaces. To collect pprof profiles the
+  token will also require 'agent:write', or enable_debug configuration set to true.
 
 General Options:
 

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -566,7 +566,6 @@ func (c *OperatorDebugCommand) collectAgentHosts(client *api.Client) {
 	for _, n := range c.serverIDs {
 		c.collectAgentHost("server", n, client)
 	}
-
 }
 
 // collectAgentHost gets the agent host data
@@ -604,7 +603,6 @@ func (c *OperatorDebugCommand) collectPprofs(client *api.Client) {
 	for _, n := range c.serverIDs {
 		c.collectPprof("server", n, client)
 	}
-
 }
 
 // collectPprof captures pprof data for the node
@@ -758,6 +756,9 @@ func (c *OperatorDebugCommand) collectNomad(dir string, client *api.Client) erro
 	} else {
 		c.writeBytes(dir, "metrics.json", metricBytes)
 	}
+
+	metrics, _, err := client.Operator().MetricsSummary(qo)
+	c.writeJSON(dir, "metrics.json", metrics, err)
 
 	return nil
 }

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -634,20 +634,23 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client)
 			c.Ui.Warn(fmt.Sprintf("Pprof retrieval requires agent:write ACL or enable_debug=true.  See https://www.nomadproject.io/api-docs/agent#agent-runtime-profiles for more information."))
 			return // only exit on 403
 		}
+	} else {
+		c.writeBytes(path, "profile.prof", bs)
 	}
-	c.writeBytes(path, "profile.prof", bs)
 
 	bs, err = client.Agent().Trace(opts, nil)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("%s: Failed to retrieve pprof trace.prof, err: %v", path, err))
+	} else {
+		c.writeBytes(path, "trace.prof", bs)
 	}
-	c.writeBytes(path, "trace.prof", bs)
 
 	bs, err = client.Agent().Lookup("goroutine", opts, nil)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("%s: Failed to retrieve pprof goroutine.prof, err: %v", path, err))
+	} else {
+		c.writeBytes(path, "goroutine.prof", bs)
 	}
-	c.writeBytes(path, "goroutine.prof", bs)
 
 	// Gather goroutine text output - debug type 1
 	// debug type 1 writes the legacy text format for human readable output
@@ -655,8 +658,9 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client)
 	bs, err = client.Agent().Lookup("goroutine", opts, nil)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("%s: Failed to retrieve pprof goroutine-debug1.txt, err: %v", path, err))
+	} else {
+		c.writeBytes(path, "goroutine-debug1.txt", bs)
 	}
-	c.writeBytes(path, "goroutine-debug1.txt", bs)
 
 	// Gather goroutine text output - debug type 2
 	// When printing the "goroutine" profile, debug=2 means to print the goroutine
@@ -665,8 +669,9 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client)
 	bs, err = client.Agent().Lookup("goroutine", opts, nil)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("%s: Failed to retrieve pprof goroutine-debug2.txt, err: %v", path, err))
+	} else {
+		c.writeBytes(path, "goroutine-debug2.txt", bs)
 	}
-	c.writeBytes(path, "goroutine-debug2.txt", bs)
 }
 
 // collectPeriodic runs for duration, capturing the cluster state every interval. It flushes and stops

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -579,6 +579,16 @@ func (c *OperatorDebugCommand) collectAgentHost(path, id string, client *api.Cli
 		host, err = client.Agent().Host("", id, nil)
 	}
 
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("%s/%s: Failed to retrieve agent host data, err: %v", path, id, err))
+
+		if strings.Contains(err.Error(), structs.ErrPermissionDenied.Error()) {
+			// Drop a hint to help the operator resolve the error
+			c.Ui.Warn(fmt.Sprintf("Agent host retrieval requires agent:read ACL or enable_debug=true.  See https://www.nomadproject.io/api-docs/agent#host for more information."))
+		}
+		return // exit on any error
+	}
+
 	path = filepath.Join(path, id)
 	c.mkdir(path)
 
@@ -614,51 +624,50 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client)
 	}
 
 	bs, err := client.Agent().CPUProfile(opts, nil)
-	if err == nil {
-		c.writeBytes(path, "profile.prof", bs)
-	} else {
+	if err != nil {
 		c.Ui.Error(fmt.Sprintf("%s: Failed to retrieve pprof profile.prof, err: %v", path, err))
+
+		if strings.Contains(err.Error(), structs.ErrPermissionDenied.Error()) {
+			// All Profiles require the same permissions, so we only need to see
+			// one permission failure before we bail.
+			// But lets first drop a hint to help the operator resolve the error
+
+			c.Ui.Warn(fmt.Sprintf("Pprof retrieval requires agent:write ACL or enable_debug=true.  See https://www.nomadproject.io/api-docs/agent#agent-runtime-profiles for more information."))
+			return // only exit on 403
+		}
 	}
+	c.writeBytes(path, "profile.prof", bs)
 
 	bs, err = client.Agent().Trace(opts, nil)
-	if err == nil {
-		c.writeBytes(path, "trace.prof", bs)
-	} else {
+	if err != nil {
 		c.Ui.Error(fmt.Sprintf("%s: Failed to retrieve pprof trace.prof, err: %v", path, err))
 	}
+	c.writeBytes(path, "trace.prof", bs)
 
 	bs, err = client.Agent().Lookup("goroutine", opts, nil)
-	if err == nil {
-		c.writeBytes(path, "goroutine.prof", bs)
-	} else {
+	if err != nil {
 		c.Ui.Error(fmt.Sprintf("%s: Failed to retrieve pprof goroutine.prof, err: %v", path, err))
 	}
+	c.writeBytes(path, "goroutine.prof", bs)
 
 	// Gather goroutine text output - debug type 1
 	// debug type 1 writes the legacy text format for human readable output
 	opts.Debug = 1
 	bs, err = client.Agent().Lookup("goroutine", opts, nil)
-	if err == nil {
-		c.writeBytes(path, "goroutine-debug1.txt", bs)
-	} else {
+	if err != nil {
 		c.Ui.Error(fmt.Sprintf("%s: Failed to retrieve pprof goroutine-debug1.txt, err: %v", path, err))
 	}
+	c.writeBytes(path, "goroutine-debug1.txt", bs)
 
 	// Gather goroutine text output - debug type 2
 	// When printing the "goroutine" profile, debug=2 means to print the goroutine
 	// stacks in the same form that a Go program uses when dying due to an unrecovered panic.
 	opts.Debug = 2
 	bs, err = client.Agent().Lookup("goroutine", opts, nil)
-	if err == nil {
-		c.writeBytes(path, "goroutine-debug2.txt", bs)
-	} else {
+	if err != nil {
 		c.Ui.Error(fmt.Sprintf("%s: Failed to retrieve pprof goroutine-debug2.txt, err: %v", path, err))
 	}
-
-	// Only need to cover this once, but lets drop a helpful hint for 403 permission denied
-	if err != nil && strings.Contains(err.Error(), "403 (Permission denied)") {
-		c.Ui.Error(fmt.Sprintf("Pprof retrieval requires agent:write ACL or enable_debug=true.  See https://www.nomadproject.io/api-docs/agent#agent-runtime-profiles for more information."))
-	}
+	c.writeBytes(path, "goroutine-debug2.txt", bs)
 }
 
 // collectPeriodic runs for duration, capturing the cluster state every interval. It flushes and stops
@@ -733,8 +742,16 @@ func (c *OperatorDebugCommand) collectNomad(dir string, client *api.Client) erro
 	ps, _, err := client.CSIPlugins().List(qo)
 	c.writeJSON(dir, "plugins.json", ps, err)
 
-	vs, _, err := client.CSIVolumes().List(qo)
-	c.writeJSON(dir, "volumes.json", vs, err)
+	// Loop over each plugin - /v1/plugin/csi/:plugin_id
+	for _, p := range ps {
+		csiPlugin, _, err := client.CSIPlugins().Info(p.ID, qo)
+		csiPluginFileName := fmt.Sprintf("csi-plugin-id-%s", p.ID)
+		c.writeJSON(dir, csiPluginFileName, csiPlugin, err)
+	}
+
+	// CSI Volumes - /v1/volumes?type=csi
+	csiVolumes, _, err := client.CSIVolumes().List(qo)
+	c.writeJSON(dir, "csi-volumes.json", csiVolumes, err)
 
 	if metricBytes, err := client.Operator().Metrics(qo); err != nil {
 		c.writeError(dir, "metrics.json", err)

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -811,10 +811,13 @@ func (c *OperatorDebugCommand) collectVault(dir, vault string) error {
 
 // writeBytes writes a file to the archive, recording it in the manifest
 func (c *OperatorDebugCommand) writeBytes(dir, file string, data []byte) error {
-	relativePath := filepath.Join(dir, file)
+	// Replace invalid characters in filename
+	filename := helper.CleanFilename(file, "_")
+
+	relativePath := filepath.Join(dir, filename)
 	c.manifest = append(c.manifest, relativePath)
 	dirPath := filepath.Join(c.collectDir, dir)
-	filePath := filepath.Join(dirPath, file)
+	filePath := filepath.Join(dirPath, filename)
 
 	// Ensure parent directories exist
 	err := os.MkdirAll(dirPath, os.ModePerm)

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -737,13 +737,14 @@ func (c *OperatorDebugCommand) collectNomad(dir string, client *api.Client) erro
 	ns, _, err := client.Nodes().List(qo)
 	c.writeJSON(dir, "nodes.json", ns, err)
 
+	// CSI Plugins - /v1/plugins?type=csi
 	ps, _, err := client.CSIPlugins().List(qo)
 	c.writeJSON(dir, "plugins.json", ps, err)
 
-	// Loop over each plugin - /v1/plugin/csi/:plugin_id
+	// CSI Plugin details - /v1/plugin/csi/:plugin_id
 	for _, p := range ps {
 		csiPlugin, _, err := client.CSIPlugins().Info(p.ID, qo)
-		csiPluginFileName := fmt.Sprintf("csi-plugin-id-%s", p.ID)
+		csiPluginFileName := fmt.Sprintf("csi-plugin-id-%s.json", p.ID)
 		c.writeJSON(dir, csiPluginFileName, csiPlugin, err)
 	}
 
@@ -751,10 +752,11 @@ func (c *OperatorDebugCommand) collectNomad(dir string, client *api.Client) erro
 	csiVolumes, _, err := client.CSIVolumes().List(qo)
 	c.writeJSON(dir, "csi-volumes.json", csiVolumes, err)
 
-	if metricBytes, err := client.Operator().Metrics(qo); err != nil {
-		c.writeError(dir, "metrics.json", err)
-	} else {
-		c.writeBytes(dir, "metrics.json", metricBytes)
+	// Loop over each volume - /v1/volumes/csi/:volume-id
+	for _, v := range csiVolumes {
+		csiVolume, _, err := client.CSIVolumes().Info(v.ID, qo)
+		csiFileName := fmt.Sprintf("csi-volume-id-%s.json", v.ID)
+		c.writeJSON(dir, csiFileName, csiVolume, err)
 	}
 
 	metrics, _, err := client.Operator().MetricsSummary(qo)

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -822,7 +822,6 @@ func (c *OperatorDebugCommand) writeBytes(dir, file string, data []byte) error {
 	// Ensure parent directories exist
 	err := os.MkdirAll(dirPath, os.ModePerm)
 	if err != nil {
-		// Display error immediately -- may not see this if files aren't written
 		c.Ui.Error(fmt.Sprintf("failed to create parent directories of \"%s\": %s", dirPath, err.Error()))
 		return err
 	}
@@ -830,14 +829,17 @@ func (c *OperatorDebugCommand) writeBytes(dir, file string, data []byte) error {
 	// Create the file
 	fh, err := os.Create(filePath)
 	if err != nil {
-		// Display error immediately -- may not see this if files aren't written
 		c.Ui.Error(fmt.Sprintf("failed to create file \"%s\": %s", filePath, err.Error()))
 		return err
 	}
 	defer fh.Close()
 
 	_, err = fh.Write(data)
-	return err
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to write data to file \"%s\", err: %v", filePath, err.Error()))
+		return err
+	}
+	return nil
 }
 
 // writeJSON writes JSON responses from the Nomad API calls to the archive

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -109,10 +109,13 @@ func TestDebug_NodeClass(t *testing.T) {
 	// Debug on client - node class = "clienta"
 	code := cmd.Run([]string{"-address", url, "-duration", "250ms", "-server-id", "all", "-node-id", "all", "-node-class", "clienta", "-max-nodes", "2"})
 
-	assert.Equal(t, 0, code) // take note of failed return code, but continue to allow buffer content checks
+	assert.Equal(t, 0, code)
 	require.Empty(t, ui.ErrorWriter.String(), "errorwriter should be empty")
 	require.Contains(t, ui.OutputWriter.String(), "Starting debugger")
+	require.Contains(t, ui.OutputWriter.String(), "Max node count reached (2)")
 	require.Contains(t, ui.OutputWriter.String(), "Node Class: clienta")
+	require.Contains(t, ui.OutputWriter.String(), "Created debug archive")
+
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()
 }

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -50,7 +50,6 @@ func TestDebug_NodeClass(t *testing.T) {
 	// Setup Client 1 (nodeclass = clienta)
 	agentConfFunc1 := func(c *agent.Config) {
 		c.Region = "global"
-		c.EnableDebug = true
 		c.Server.Enabled = false
 		c.Client.NodeClass = "clienta"
 		c.Client.Enabled = true
@@ -69,7 +68,6 @@ func TestDebug_NodeClass(t *testing.T) {
 	// Setup Client 2 (nodeclass = clientb)
 	agentConfFunc2 := func(c *agent.Config) {
 		c.Region = "global"
-		c.EnableDebug = true
 		c.Server.Enabled = false
 		c.Client.NodeClass = "clientb"
 		c.Client.Enabled = true
@@ -88,7 +86,6 @@ func TestDebug_NodeClass(t *testing.T) {
 	// Setup Client 3 (nodeclass = clienta)
 	agentConfFunc3 := func(c *agent.Config) {
 		c.Server.Enabled = false
-		c.EnableDebug = false
 		c.Client.NodeClass = "clienta"
 		c.Client.Servers = []string{srvRPCAddr}
 	}

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -21,6 +21,16 @@ var validUUID = regexp.MustCompile(`(?i)^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f
 // by sequences containing a dot followed by a one or more non-dot characters.
 var validInterpVarKey = regexp.MustCompile(`^[^.]+(\.[^.]+)*$`)
 
+// invalidFilename is the minimum set of characters which must be removed or
+// replaced to produce a valid filename
+var invalidFilename = regexp.MustCompile(`[/\\<>:"|?*]`)
+
+// invalidFilenameNonASCII = invalidFilename plus all non-ASCII characters
+var invalidFilenameNonASCII = regexp.MustCompile(`[[:^ascii:]/\\<>:"|?*]`)
+
+// invalidFilenameStrict = invalidFilename plus additional punctuation
+var invalidFilenameStrict = regexp.MustCompile(`[/\\<>:"|?*$()+=[\];#@~,&']`)
+
 // IsUUID returns true if the given string is a valid UUID.
 func IsUUID(str string) bool {
 	const uuidLen = 36
@@ -392,6 +402,24 @@ func CleanEnvVar(s string, r byte) string {
 		}
 	}
 	return string(b)
+}
+
+// CleanFilename replaces invalid characters in filename
+func CleanFilename(filename string, replace string) string {
+	clean := invalidFilename.ReplaceAllLiteralString(filename, replace)
+	return clean
+}
+
+// CleanFilenameASCIIOnly replaces invalid and non-ASCII characters in filename
+func CleanFilenameASCIIOnly(filename string, replace string) string {
+	clean := invalidFilenameNonASCII.ReplaceAllLiteralString(filename, replace)
+	return clean
+}
+
+// CleanFilenameStrict replaces invalid and punctuation characters in filename
+func CleanFilenameStrict(filename string, replace string) string {
+	clean := invalidFilenameStrict.ReplaceAllLiteralString(filename, replace)
+	return clean
 }
 
 func CheckHCLKeys(node ast.Node, valid []string) error {

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -202,6 +202,79 @@ func BenchmarkCleanEnvVar(b *testing.B) {
 	}
 }
 
+type testCase struct {
+	input    string
+	expected string
+}
+
+func commonCleanFilenameCases() (cases []testCase) {
+	// Common set of test cases for all 3 TestCleanFilenameX functions
+	cases = []testCase{
+		{"asdf", "asdf"},
+		{"ASDF", "ASDF"},
+		{"0sdf", "0sdf"},
+		{"asd0", "asd0"},
+		{"_asd", "_asd"},
+		{"-asd", "-asd"},
+		{"asd.fgh", "asd.fgh"},
+		{"Linux/Forbidden", "Linux_Forbidden"},
+		{"Windows<>:\"/\\|?*Forbidden", "Windows_________Forbidden"},
+		{`Windows<>:"/\|?*Forbidden_StringLiteral`, "Windows_________Forbidden_StringLiteral"},
+	}
+	return cases
+}
+
+func TestCleanFilename(t *testing.T) {
+	cases := append(
+		[]testCase{
+			{"A\U0001f4a9Z", "A💩Z"}, // CleanFilename allows unicode
+			{"A💩Z", "A💩Z"},
+			{"A~!@#$%^&*()_+-={}[]|\\;:'\"<,>?/Z", "A~!@#$%^&_()_+-={}[]__;_'__,___Z"},
+		}, commonCleanFilenameCases()...)
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			output := CleanFilename(c.input, "_")
+			failMsg := fmt.Sprintf("CleanFilename(%q, '_') -> %q != %q", c.input, output, c.expected)
+			require.Equal(t, c.expected, output, failMsg)
+		})
+	}
+}
+
+func TestCleanFilenameASCIIOnly(t *testing.T) {
+	ASCIIOnlyCases := append(
+		[]testCase{
+			{"A\U0001f4a9Z", "A_Z"}, // CleanFilenameASCIIOnly does not allow unicode
+			{"A💩Z", "A_Z"},
+			{"A~!@#$%^&*()_+-={}[]|\\;:'\"<,>?/Z", "A~!@#$%^&_()_+-={}[]__;_'__,___Z"},
+		}, commonCleanFilenameCases()...)
+
+	for i, c := range ASCIIOnlyCases {
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			output := CleanFilenameASCIIOnly(c.input, "_")
+			failMsg := fmt.Sprintf("CleanFilenameASCIIOnly(%q, '_') -> %q != %q", c.input, output, c.expected)
+			require.Equal(t, c.expected, output, failMsg)
+		})
+	}
+}
+
+func TestCleanFilenameStrict(t *testing.T) {
+	strictCases := append(
+		[]testCase{
+			{"A\U0001f4a9Z", "A💩Z"}, // CleanFilenameStrict allows unicode
+			{"A💩Z", "A💩Z"},
+			{"A~!@#$%^&*()_+-={}[]|\\;:'\"<,>?/Z", "A_!___%^______-_{}_____________Z"},
+		}, commonCleanFilenameCases()...)
+
+	for i, c := range strictCases {
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			output := CleanFilenameStrict(c.input, "_")
+			failMsg := fmt.Sprintf("CleanFilenameStrict(%q, '_') -> %q != %q", c.input, output, c.expected)
+			require.Equal(t, c.expected, output, failMsg)
+		})
+	}
+}
+
 func TestCheckNamespaceScope(t *testing.T) {
 	cases := []struct {
 		desc      string

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -168,7 +168,7 @@ func TestCopyMapSliceInterface(t *testing.T) {
 	require.False(t, reflect.DeepEqual(m, c))
 }
 
-func TestClearEnvVar(t *testing.T) {
+func TestCleanEnvVar(t *testing.T) {
 	type testCase struct {
 		input    string
 		expected string


### PR DESCRIPTION
- Adds `pprof-duration` to allow pprof capture over timeframe longer than 1 second
- Extends CSI support to iterate over plugins and volumes for more detail (fixes #9262)

From the helpText:
```
  -pprof-duration=<duration>
    Duration for pprof collection. Defaults to 1s.
```
