### PR TITLE
demo: CSI example for DigitalOcean block storage

### DIFF
--- a/demo/csi/digitalocean/.gitignore
+++ b/demo/csi/digitalocean/.gitignore
@@ -1,0 +1,1 @@
+terraform.tfvars

--- a/demo/csi/digitalocean/README.md
+++ b/demo/csi/digitalocean/README.md
@@ -1,0 +1,37 @@
+# CSI on DigitalOcean
+
+This is a Terraform demo for deploying CSI volumes on DigitalOcean. It
+asssumes you already have a Nomad cluster running with the Docker task
+driver. You will need a DigitalOcean account and a DigitalOcean API key.
+
+Deploy the demo:
+
+```
+export NOMAD_ADDR=http://${IP_ADDRESS}:4646
+terraform apply -var do_token=${DIGITALOCEAN_TOKEN}
+```
+
+See the volume is registered:
+
+```
+$ nomad volume status nomad-csi
+ID                   = nomad-csi-test
+Name                 = nomad-csi-test
+External ID          = 58c4ef75-25d1-11eb-a381-0a58ac1449b9
+Plugin ID            = digitalocean
+Provider             = dobs.csi.digitalocean.com
+Version              = v2.1.1
+Schedulable          = true
+Controllers Healthy  = 1
+Controllers Expected = 1
+Nodes Healthy        = 1
+Nodes Expected       = 1
+Access Mode          = single-node-writer
+Attachment Mode      = block-device
+Mount Options        = <none>
+Namespace            = default
+
+Allocations
+ID        Node ID   Task Group  Version  Desired  Status   Created  Modified
+8d223dc7  ce46add9  cache       0        run      running  21s ago  3s ago
+```

--- a/demo/csi/digitalocean/main.tf
+++ b/demo/csi/digitalocean/main.tf
@@ -1,0 +1,34 @@
+# Terraform configuration for creating a volume in DigitalOcean and
+# registering it with Nomad
+
+# create the volume
+resource "digitalocean_volume" "test_volume" {
+  region                  = var.region
+  name                    = "csi-test-volume"
+  size                    = 50
+  initial_filesystem_type = "ext4"
+  description             = "a volume for testing Nomad CSI"
+}
+
+# run the plugin job
+resource "nomad_job" "plugin" {
+  jobspec = templatefile("${path.module}/plugin.nomad", { token = var.do_token })
+}
+
+# register the volume with Nomad
+resource "nomad_volume" "test_volume" {
+  volume_id             = var.volume_id
+  name                  = var.volume_id
+  type                  = "csi"
+  plugin_id             = "digitalocean"
+  external_id           = digitalocean_volume.test_volume.id
+  access_mode           = "single-node-writer"
+  attachment_mode       = "block-device"
+  deregister_on_destroy = true
+}
+
+# consume the volume
+resource "nomad_job" "redis" {
+  jobspec    = templatefile("${path.module}/volume-job.nomad", { volume_id = nomad_volume.test_volume.id })
+  depends_on = [nomad_volume.test_volume]
+}

--- a/demo/csi/digitalocean/plugin.nomad
+++ b/demo/csi/digitalocean/plugin.nomad
@@ -1,0 +1,32 @@
+job "digitalocean" {
+
+  datacenters = ["dc1"]
+
+  group "csi" {
+    task "plugin" {
+      driver = "docker"
+
+      config {
+        image = "digitalocean/do-csi-plugin:v2.1.1"
+        args = [
+          "--endpoint=unix://csi/csi.sock",
+          "--token=${token}",
+          "--url=https://api.digitalocean.com/",
+        ]
+
+        privileged = true
+      }
+
+      csi_plugin {
+        id        = "digitalocean"
+        type      = "monolith"
+        mount_dir = "/csi"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 256
+      }
+    }
+  }
+}

--- a/demo/csi/digitalocean/terraform.tf
+++ b/demo/csi/digitalocean/terraform.tf
@@ -1,0 +1,3 @@
+provider "digitalocean" {
+  token = var.do_token
+}

--- a/demo/csi/digitalocean/variables.tf
+++ b/demo/csi/digitalocean/variables.tf
@@ -1,0 +1,11 @@
+variable "do_token" {
+  description = "API key"
+}
+
+variable "region" {
+  default = "nyc1"
+}
+
+variable "volume_id" {
+  default = "nomad-csi-test"
+}

--- a/demo/csi/digitalocean/versions.tf
+++ b/demo/csi/digitalocean/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source = "digitalocean/digitalocean"
+    }
+    nomad = {
+      source = "hashicorp/nomad"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/demo/csi/digitalocean/volume-job.nomad
+++ b/demo/csi/digitalocean/volume-job.nomad
@@ -1,0 +1,37 @@
+job "example" {
+  datacenters = ["dc1"]
+
+  group "cache" {
+    volume "test" {
+      type   = "csi"
+      source = "${volume_id}"
+    }
+
+    task "redis" {
+      driver = "docker"
+
+      config {
+        image = "redis:3.2"
+
+        port_map {
+          db = 6379
+        }
+      }
+
+      volume_mount {
+        volume      = "test"
+        destination = "/test"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 256
+
+        network {
+          mbits = 14
+          port  "db"  {}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a slight rework of an internal testing deployment.