### PR TITLE
jobspec: add support for headers in artifact stanza

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ IMPROVEMENTS:
  * driver/docker: Upgrade pause container and detect architecture [[GH-8957](https://github.com/hashicorp/nomad/pull/8957)]
  * driver/docker: Support pinning tasks to specific CPUs with `cpuset_cpus` option. [[GH-8291](https://github.com/hashicorp/nomad/pull/8291)]
  * jobspec: Lowered minimum CPU allowed from 10 to 1. [[GH-8996](https://github.com/hashicorp/nomad/issues/8996)]
+ * jobspec: Added support for `headers` option in `artifact` stanza [[GH-9306](https://github.com/hashicorp/nomad/issues/9306)]
 
 __BACKWARDS INCOMPATIBILITIES:__
  * core: null characters are prohibited in region, datacenter, job name/ID, task group name, and task name [[GH-9020](https://github.com/hashicorp/nomad/issues/9020)]

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -726,6 +726,7 @@ func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {
 type TaskArtifact struct {
 	GetterSource  *string           `mapstructure:"source" hcl:"source,optional"`
 	GetterOptions map[string]string `mapstructure:"options" hcl:"options,block"`
+	GetterHeaders map[string]string `mapstructure:"headers" hcl:"headers,block"`
 	GetterMode    *string           `mapstructure:"mode" hcl:"mode,optional"`
 	RelativeDest  *string           `mapstructure:"destination" hcl:"destination,optional"`
 }
@@ -737,6 +738,12 @@ func (a *TaskArtifact) Canonicalize() {
 	if a.GetterSource == nil {
 		// Shouldn't be possible, but we don't want to panic
 		a.GetterSource = stringToPtr("")
+	}
+	if len(a.GetterOptions) == 0 {
+		a.GetterOptions = nil
+	}
+	if len(a.GetterHeaders) == 0 {
+		a.GetterHeaders = nil
 	}
 	if a.RelativeDest == nil {
 		switch *a.GetterMode {

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -356,16 +356,16 @@ func TestTask_AddAffinity(t *testing.T) {
 func TestTask_Artifact(t *testing.T) {
 	t.Parallel()
 	a := TaskArtifact{
-		GetterSource: stringToPtr("http://localhost/foo.txt"),
-		GetterMode:   stringToPtr("file"),
+		GetterSource:  stringToPtr("http://localhost/foo.txt"),
+		GetterMode:    stringToPtr("file"),
+		GetterHeaders: make(map[string]string),
+		GetterOptions: make(map[string]string),
 	}
 	a.Canonicalize()
-	if *a.GetterMode != "file" {
-		t.Errorf("expected file but found %q", *a.GetterMode)
-	}
-	if filepath.ToSlash(*a.RelativeDest) != "local/foo.txt" {
-		t.Errorf("expected local/foo.txt but found %q", *a.RelativeDest)
-	}
+	require.Equal(t, "file", *a.GetterMode)
+	require.Equal(t, "local/foo.txt", filepath.ToSlash(*a.RelativeDest))
+	require.Nil(t, a.GetterOptions)
+	require.Nil(t, a.GetterHeaders)
 }
 
 func TestTask_VolumeMount(t *testing.T) {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1103,7 +1103,8 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 		for k, ta := range apiTask.Artifacts {
 			structsTask.Artifacts[k] = &structs.TaskArtifact{
 				GetterSource:  *ta.GetterSource,
-				GetterOptions: ta.GetterOptions,
+				GetterOptions: helper.CopyMapStringString(ta.GetterOptions),
+				GetterHeaders: helper.CopyMapStringString(ta.GetterHeaders),
 				GetterMode:    *ta.GetterMode,
 				RelativeDest:  *ta.RelativeDest,
 			}

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -2628,12 +2628,11 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						},
 						Artifacts: []*api.TaskArtifact{
 							{
-								GetterSource: helper.StringToPtr("source"),
-								GetterOptions: map[string]string{
-									"a": "b",
-								},
-								GetterMode:   helper.StringToPtr("dir"),
-								RelativeDest: helper.StringToPtr("dest"),
+								GetterSource:  helper.StringToPtr("source"),
+								GetterOptions: map[string]string{"a": "b"},
+								GetterHeaders: map[string]string{"User-Agent": "nomad"},
+								GetterMode:    helper.StringToPtr("dir"),
+								RelativeDest:  helper.StringToPtr("dest"),
 							},
 						},
 						DispatchPayload: &api.DispatchPayloadConfig{
@@ -2752,12 +2751,11 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						},
 						Artifacts: []*structs.TaskArtifact{
 							{
-								GetterSource: "source",
-								GetterOptions: map[string]string{
-									"a": "b",
-								},
-								GetterMode:   "dir",
-								RelativeDest: "dest",
+								GetterSource:  "source",
+								GetterOptions: map[string]string{"a": "b"},
+								GetterHeaders: map[string]string{"User-Agent": "nomad"},
+								GetterMode:    "dir",
+								RelativeDest:  "dest",
 							},
 						},
 						DispatchPayload: &structs.DispatchPayloadConfig{

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -4056,6 +4056,9 @@ func TestTaskDiff(t *testing.T) {
 						GetterOptions: map[string]string{
 							"bar": "baz",
 						},
+						GetterHeaders: map[string]string{
+							"User": "user1",
+						},
 						GetterMode:   "dir",
 						RelativeDest: "bar",
 					},
@@ -4075,6 +4078,10 @@ func TestTaskDiff(t *testing.T) {
 						GetterOptions: map[string]string{
 							"bam": "baz",
 						},
+						GetterHeaders: map[string]string{
+							"User":       "user2",
+							"User-Agent": "nomad",
+						},
 						GetterMode:   "file",
 						RelativeDest: "bam",
 					},
@@ -4087,6 +4094,18 @@ func TestTaskDiff(t *testing.T) {
 						Type: DiffTypeAdded,
 						Name: "Artifact",
 						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeAdded,
+								Name: "GetterHeaders[User-Agent]",
+								Old:  "",
+								New:  "nomad",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "GetterHeaders[User]",
+								Old:  "",
+								New:  "user2",
+							},
 							{
 								Type: DiffTypeAdded,
 								Name: "GetterMode",
@@ -4117,6 +4136,12 @@ func TestTaskDiff(t *testing.T) {
 						Type: DiffTypeDeleted,
 						Name: "Artifact",
 						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeDeleted,
+								Name: "GetterHeaders[User]",
+								Old:  "user1",
+								New:  "",
+							},
 							{
 								Type: DiffTypeDeleted,
 								Name: "GetterMode",

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash"
 	"hash/crc32"
 	"math"
 	"net"
@@ -7866,6 +7867,10 @@ type TaskArtifact struct {
 	// go-getter.
 	GetterOptions map[string]string
 
+	// GetterHeaders are headers to use when downloading the artifact using
+	// go-getter.
+	GetterHeaders map[string]string
+
 	// GetterMode is the go-getter.ClientMode for fetching resources.
 	// Defaults to "any" but can be set to "file" or "dir".
 	GetterMode string
@@ -7879,40 +7884,48 @@ func (ta *TaskArtifact) Copy() *TaskArtifact {
 	if ta == nil {
 		return nil
 	}
-	nta := new(TaskArtifact)
-	*nta = *ta
-	nta.GetterOptions = helper.CopyMapStringString(ta.GetterOptions)
-	return nta
+	return &TaskArtifact{
+		GetterSource:  ta.GetterSource,
+		GetterOptions: helper.CopyMapStringString(ta.GetterOptions),
+		GetterHeaders: helper.CopyMapStringString(ta.GetterHeaders),
+		GetterMode:    ta.GetterMode,
+		RelativeDest:  ta.RelativeDest,
+	}
 }
 
 func (ta *TaskArtifact) GoString() string {
 	return fmt.Sprintf("%+v", ta)
 }
 
-// Hash creates a unique identifier for a TaskArtifact as the same GetterSource
-// may be specified multiple times with different destinations.
-func (ta *TaskArtifact) Hash() string {
-	hash, err := blake2b.New256(nil)
-	if err != nil {
-		panic(err)
-	}
-
-	hash.Write([]byte(ta.GetterSource))
-
-	// Must iterate over keys in a consistent order
-	keys := make([]string, 0, len(ta.GetterOptions))
-	for k := range ta.GetterOptions {
+// hashStringMap appends a deterministic hash of m onto h.
+func hashStringMap(h hash.Hash, m map[string]string) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		hash.Write([]byte(k))
-		hash.Write([]byte(ta.GetterOptions[k]))
+		h.Write([]byte(k))
+		h.Write([]byte(m[k]))
+	}
+}
+
+// Hash creates a unique identifier for a TaskArtifact as the same GetterSource
+// may be specified multiple times with different destinations.
+func (ta *TaskArtifact) Hash() string {
+	h, err := blake2b.New256(nil)
+	if err != nil {
+		panic(err)
 	}
 
-	hash.Write([]byte(ta.GetterMode))
-	hash.Write([]byte(ta.RelativeDest))
-	return base64.RawStdEncoding.EncodeToString(hash.Sum(nil))
+	h.Write([]byte(ta.GetterSource))
+
+	hashStringMap(h, ta.GetterOptions)
+	hashStringMap(h, ta.GetterHeaders)
+
+	h.Write([]byte(ta.GetterMode))
+	h.Write([]byte(ta.RelativeDest))
+	return base64.RawStdEncoding.EncodeToString(h.Sum(nil))
 }
 
 // PathEscapesAllocDir returns if the given path escapes the allocation

--- a/vendor/github.com/hashicorp/nomad/api/tasks.go
+++ b/vendor/github.com/hashicorp/nomad/api/tasks.go
@@ -726,6 +726,7 @@ func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {
 type TaskArtifact struct {
 	GetterSource  *string           `mapstructure:"source" hcl:"source,optional"`
 	GetterOptions map[string]string `mapstructure:"options" hcl:"options,block"`
+	GetterHeaders map[string]string `mapstructure:"headers" hcl:"headers,block"`
 	GetterMode    *string           `mapstructure:"mode" hcl:"mode,optional"`
 	RelativeDest  *string           `mapstructure:"destination" hcl:"destination,optional"`
 }
@@ -737,6 +738,12 @@ func (a *TaskArtifact) Canonicalize() {
 	if a.GetterSource == nil {
 		// Shouldn't be possible, but we don't want to panic
 		a.GetterSource = stringToPtr("")
+	}
+	if len(a.GetterOptions) == 0 {
+		a.GetterOptions = nil
+	}
+	if len(a.GetterHeaders) == 0 {
+		a.GetterHeaders = nil
 	}
 	if a.RelativeDest == nil {
 		switch *a.GetterMode {

--- a/website/pages/docs/job-specification/artifact.mdx
+++ b/website/pages/docs/job-specification/artifact.mdx
@@ -54,7 +54,11 @@ automatically unarchived before the starting the task.
 - `options` `(map<string|string>: nil)` - Specifies configuration parameters to
   fetch the artifact. The key-value pairs map directly to parameters appended to
   the supplied `source` URL. Please see the [`go-getter`
-  documentation][go-getter] for a complete list of options and examples
+  documentation][go-getter] for a complete list of options and examples.
+
+- `headers` `(map<string|string>: nil)` - Specifies HTTP headers to set when
+  fetching the artifact using `http` or `https` protocol. Please see the
+  [`go-getter` headers documentation][go-getter-headers] for more information.
 
 - `source` `(string: <required>)` - Specifies the URL of the artifact to download.
   See [`go-getter`][go-getter] for details.
@@ -73,6 +77,20 @@ directory].
 ```hcl
 artifact {
   source = "https://example.com/file.txt"
+}
+```
+
+To set HTTP headers in the request for the source the optional `headers` field
+can be configured.
+
+```hcl
+artifact {
+  source = "https://example.com/file.txt"
+
+  headers {
+    User-Agent    = "nomad-[${NOMAD_JOB_ID}]-[${NOMAD_GROUP_NAME}]-[${NOMAD_TASK_NAME}]"
+    X-Nomad-Alloc = "${NOMAD_ALLOC_ID}"
+  }
 }
 ```
 
@@ -186,6 +204,7 @@ artifact {
 ```
 
 [go-getter]: https://github.com/hashicorp/go-getter 'HashiCorp go-getter Library'
+[go-getter-headers]: https://github.com/hashicorp/go-getter#headers 'HashiCorp go-getter Headers'
 [minio]: https://www.minio.io/
 [s3-bucket-addr]: http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro 'Amazon S3 Bucket Addressing'
 [s3-region-endpoints]: http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region 'Amazon S3 Region Endpoints'


### PR DESCRIPTION
This PR adds the ability to set HTTP headers when downloading
an artifact from an `http` or `https` resource.

The implementation in `go-getter` is such that a new `HTTPGetter`
must be created for each artifact that sets headers (as opposed
to conveniently setting headers per-request). This PR maintains
the memoization of the default Getter objects, creating new ones
only for artifacts where headers are set.

Closes #9306