### PR TITLE
hclfmt digitalocean demo to pass linting

### DIFF
--- a/demo/csi/digitalocean/volume-job.nomad
+++ b/demo/csi/digitalocean/volume-job.nomad
@@ -29,7 +29,7 @@ job "example" {
 
         network {
           mbits = 14
-          port  "db"  {}
+          port "db" {}
         }
       }
     }


### PR DESCRIPTION
The demo that got merged didn't get `hclfmt` checked because it was on a `docs-*` branch.