### PR TITLE
csi: alloc status -verbose should query volume request 'source'

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -785,7 +785,7 @@ FOUND:
 	hostVolumesOutput = append(hostVolumesOutput, "ID|Read Only")
 	if verbose {
 		csiVolumesOutput = append(csiVolumesOutput,
-			"ID|Plugin|Provider|Schedulable|Read Only|Mount Options")
+			"Name|ID|Plugin|Provider|Schedulable|Read Only|Mount Options")
 	} else {
 		csiVolumesOutput = append(csiVolumesOutput, "ID|Read Only")
 	}
@@ -800,15 +800,16 @@ FOUND:
 			if verbose {
 				// there's an extra API call per volume here so we toggle it
 				// off with the -verbose flag
-				vol, _, err := client.CSIVolumes().Info(volReq.Name, nil)
+				vol, _, err := client.CSIVolumes().Info(volReq.Source, nil)
 				if err != nil {
 					c.Ui.Error(fmt.Sprintf("Error retrieving volume info for %q: %s",
 						volReq.Name, err))
 					continue
 				}
 				csiVolumesOutput = append(csiVolumesOutput,
-					fmt.Sprintf("%s|%s|%s|%v|%v|%s",
+					fmt.Sprintf("%s|%s|%s|%s|%v|%v|%s",
 						volReq.Name,
+						vol.ID,
 						vol.PluginID,
 						vol.Provider,
 						vol.Schedulable,

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -491,7 +491,7 @@ func TestAllocStatusCommand_CSIVolumes(t *testing.T) {
 		vol0: {
 			Name:   vol0,
 			Type:   structs.VolumeTypeCSI,
-			Source: "/tmp/vol0",
+			Source: vol0,
 		},
 	}
 	job.TaskGroups[0].Tasks[0].VolumeMounts = []*structs.VolumeMount{


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9297

The `nomad alloc status -verbose` command returns a 404 from CSI volumes
because the volume mount block in the task points back to the
`job.group.volume` block. So using the `Name` field to query is the "name" as
seen in the jobspec, and not the name of the volume that we need for querying.

Show both the job-specific name and the volume ID in the resulting output,
which clarifies the difference between the two fields and is more consistent
with the web UI.