### PR TITLE
cni: use correct interface for netStatus

### DIFF
--- a/client/allocrunner/networking_cni.go
+++ b/client/allocrunner/networking_cni.go
@@ -112,7 +112,9 @@ func (c *cniNetworkConfigurator) Setup(ctx context.Context, alloc *structs.Alloc
 	if len(res.Interfaces) > 0 {
 		iface, name := func(r *cni.CNIResult) (*cni.Config, string) {
 			for i := range r.Interfaces {
-				return r.Interfaces[i], i
+				if r.Interfaces[i].Sandbox != "" {
+					return r.Interfaces[i], i
+				}
 			}
 			return nil, ""
 		}(res)


### PR DESCRIPTION
CNI plugins can return multiple interfaces, eg the bridge plugin. (See https://github.com/containernetworking/plugins/blob/8aad9739d8383de465293d5da346a61ff3131449/plugins/main/bridge/bridge.go#L415)

At the moment a random interface is returned, this PR returns the one with the sandbox.