### PR TITLE
website: update downloads page to beta3

### DIFF
--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -15,7 +15,7 @@ export default function DownloadsPage({ releaseData }) {
         prerelease={{
           type: 'Beta',
           name: 'v1.0.0',
-          version: '1.0.0-beta2'
+          version: '1.0.0-beta3'
         }}
       />
     </div>


### PR DESCRIPTION
`stable-website` branch needs to be updated as well with this change, and it is currently lagging `master`