### PR TITLE
Example CSI configuration for AWS EBS and EFS

### DIFF
--- a/demo/csi/aws/README.md
+++ b/demo/csi/aws/README.md
@@ -1,0 +1,11 @@
+# AWS CSI Plugins
+
+Configurations are provided here for [Elastic Block Store](https://aws.amazon.com/ebs/) and [Elastic Filesystem](https://aws.amazon.com/efs/) CSI drivers for use on [Amazon Web Services](https://aws.amazon.com).
+
+## Elastic Block Store
+
+EBS provides virtual block disks. Disks are tied to an availability zone, and aside from [io1/io2 multi-attach](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volumes-multi.html), which requires special filesystems to use in read-write mode, may only be used by a single node at a time.
+
+## Elastic File Store
+
+EFS provides a shared network filesystem over NFSv4. An EFS filesystem may be used within an AWS region, not just an availability zone, and can be accessed in read-write mode by multiple nodes at once.

--- a/demo/csi/aws/ebs/README.md
+++ b/demo/csi/aws/ebs/README.md
@@ -1,0 +1,64 @@
+# AWS EBS CSI Plugin
+
+The configuration here is for the [AWS Elastic Block Store](https://aws.amazon.com/ebs/) CSI driver.
+
+## Requirements
+
+The example plugin jobs use [templates](https://www.nomadproject.io/docs/job-specification/template) rendered with secrets obtained from the [Vault AWS Secrets Engine](https://www.vaultproject.io/docs/secrets/aws) to obtain the credentials necessary to control EBS volumes.
+Additionally this directory contains some sample Vault and AWS IAM (via [Terraform](https://www.terraform.io)) configuration that may be useful as a starting point for setting up Vault to provide credentials for these jobs.
+
+### Docker Privileged Mode
+
+The EBS node task requires that [`privileged = true`](https://www.nomadproject.io/docs/drivers/docker#privileged) be set in order to mount/unmount filesystems on the node.
+
+### EC2 Instance Metadata Service.
+
+The driver also requires access to the [EC2 Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
+If you have blocked access to this from docker tasks running in bridge (default) or NAT mode, which is a good idea for security, you may run the task in host networking mode by setting [`network_mode = host`](https://www.nomadproject.io/docs/drivers/docker#network_mode)
+
+## Container Arguments
+ 
+Refer to the official plugin [README](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/README.md).
+
+- `controller`
+ 
+  - Run the driver in controller mode.
+
+- `node`
+
+  - Run the driver in node mode.
+
+- `--endpoint=unix:///csi/csi.sock`
+
+  - This option must match the `mount_dir` specified in the `csi_plugin` stanza for the task.
+
+- --logtostderr
+
+  - Logs are written to standard error instead of to files.
+
+- --v=5
+
+  - Sets the klog logging "V" level to 5.
+
+## Deployment
+
+### Plugins
+
+```bash
+export NOMAD_ADDR=https://nomad.example.com:4646
+export NOMAD_TOKEN=34534-3sdf3-szfdsafsdf3423-zxdfsd3
+nomad job run plugin-aws-ebs-controller.hcl
+nomad job run plugin-aws-ebs-nodes.hcl
+```
+
+### Volume Registration
+
+```bash
+export NOMAD_ADDR=https://nomad.example.com:4646
+export NOMAD_TOKEN=34534-3sdf3-szfdsafsdf3423-zxdfsd3
+nomad volume register example-volume.hcl
+```
+
+## EBS CSI Driver Source
+
+- https://github.com/kubernetes-sigs/aws-ebs-csi-driver

--- a/demo/csi/aws/ebs/example-disk.tf
+++ b/demo/csi/aws/ebs/example-disk.tf
@@ -1,0 +1,30 @@
+data "aws_kms_alias" "ebs" {
+  name = "alias/aws/ebs"
+}
+
+resource "aws_ebs_volume" "mytestebsvol" {
+  availability_zone = "us-east-1a"
+  size              = 1
+ 
+  encrypted         = true
+  kms_key_id        = data.aws_kms_alias.ebs.target_key_arn
+    
+  tags = {
+    Name = "my-test-ebs-volume"
+  }
+}
+
+output "mytestebsvol" {
+    value = <<__EOF__
+# terraform output mytestebsvol >example-volume.hcl
+# nomad volume register example-folume.hcl
+
+type = "csi"
+id = "mytestebsvol"
+name = "my-test-ebs-volume"
+external_id = "${aws_ebs_volume.mytestebsvol.id}"
+access_mode = "single-node-writer"
+attachment_mode = "file-system"
+plugin_id = "aws-ebs"
+__EOF__
+}

--- a/demo/csi/aws/ebs/example-volume.hcl
+++ b/demo/csi/aws/ebs/example-volume.hcl
@@ -1,0 +1,10 @@
+# terraform output mytestebsvol >example-volume.hcl
+# nomad volume register example-volume.hcl
+
+type = "csi"
+id = "mytestebsvol"
+name = "my-test-ebs-volume"
+external_id = "vol-04a08b15c16d23e42"
+access_mode = "single-node-writer"
+attachment_mode = "file-system"
+plugin_id = "aws-ebs"

--- a/demo/csi/aws/ebs/iam-ebs-csi.tf
+++ b/demo/csi/aws/ebs/iam-ebs-csi.tf
@@ -1,0 +1,42 @@
+data "aws_iam_policy_document" "ebs_csi_policy_doc" {
+  statement {
+    effect  = "Allow"
+    actions = [
+       # Permissions needed by the EBS CSI driver
+
+      "ec2:AttachVolume",
+      "ec2:CreateSnapshot",
+      "ec2:CreateTags",
+      "ec2:CreateVolume",
+      "ec2:DeleteSnapshot",
+      "ec2:DeleteTags",
+      "ec2:DeleteVolume",
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeInstances",
+      "ec2:DescribeSnapshots",
+      "ec2:DescribeTags",
+      "ec2:DescribeVolumes",
+      "ec2:DescribeVolumesModifications",
+      "ec2:DetachVolume",
+      "ec2:ModifyVolume"
+    ]
+
+    resources = [ "*" ]
+  }
+}
+
+resource "aws_iam_policy" "ebs_csi_policy" {
+  name        = "EBS-CSI"
+  path        = "/"
+  description = "Policy for EBS CSI Driver"
+
+  policy = data.aws_iam_policy_document.ebs_csi_policy_doc.json
+}
+
+# Give the permissions to Vault so that it can give them to users
+# it creates.
+
+resource "aws_iam_group_policy_attachment" "vault_ebs_cli" {
+  group      = aws_iam_group.vault_group.name
+  policy_arn = aws_iam_policy.ebs_csi_policy.arn
+}

--- a/demo/csi/aws/ebs/plugin-aws-ebs-controller.nomad
+++ b/demo/csi/aws/ebs/plugin-aws-ebs-controller.nomad
@@ -1,0 +1,59 @@
+job "plugin-aws-ebs-controller" { 
+  datacenters = ["dc1"]
+
+  group "controller" {
+    ephemeral_disk {
+      size = "128"
+    }
+
+    task "plugin" {
+      driver = "docker"
+
+      config {
+        image = "amazon/aws-ebs-csi-driver:v0.7.0"
+
+	args = [ 
+          "controller",
+          "--endpoint=unix://csi/csi.sock",
+          "--logtostderr",
+          "--v=5"
+        ]
+
+        # If you have blocked access to the EC2 Metadata Service for
+        # tasks running in the default "bridge" mode (advisable),
+        # allow access by running in host mode.
+
+        network_mode = "host"
+      }
+
+      csi_plugin {
+        id        = "aws-ebs"
+        type      = "controller"
+        mount_dir = "/csi"
+      }
+
+      resources {
+        cpu    = 100
+        memory = 32
+      }
+
+      vault {
+        policies = ["ebs-csi"]
+
+        change_mode = "restart"
+      }
+
+      template {
+        data = <<__EOF__
+{{ with secret "aws/creds/ebs-csi" -}}
+AWS_ACCESS_KEY_ID="{{.Data.access_key}}"
+AWS_SECRET_ACCESS_KEY="{{.Data.secret_key}}"
+{{ end }}
+__EOF__
+
+        destination = "secrets/file.env"
+        env         = true
+      }
+    }
+  }
+}

--- a/demo/csi/aws/ebs/plugin-aws-ebs-nodes.nomad
+++ b/demo/csi/aws/ebs/plugin-aws-ebs-nodes.nomad
@@ -1,0 +1,66 @@
+job "plugin-aws-ebs-nodes" { 
+  datacenters = ["dc1"]
+
+  type = "system"
+
+  group "nodes" {
+    ephemeral_disk {
+      size = "128"
+    }
+
+    task "plugin" {
+      driver = "docker"
+
+      config {
+        image = "amazon/aws-ebs-csi-driver:v0.7.0"
+
+	args = [ 
+          "node",
+          "--endpoint=unix://csi/csi.sock",
+          "--logtostderr",
+          "--v=5"
+        ]
+
+        # If you have blocked access to the EC2 Metadata Service for
+        # tasks running in the default "bridge" mode (advisable),
+        # allow access by running in host mode.
+
+        network_mode = "host"
+
+        # node plugins must run as privileged jobs because they
+        # mount disks to the host
+
+        privileged = true
+      }
+
+      csi_plugin {
+        id        = "aws-ebs"
+        type      = "node"
+        mount_dir = "/csi"
+      }
+
+      resources {
+        cpu    = 100
+        memory = 32
+      }
+
+      vault {
+        policies = ["ebs-csi"]
+
+        change_mode = "restart"
+      }
+
+      template {
+        data = <<__EOF__
+{{ with secret "aws/creds/ebs-csi" -}}
+AWS_ACCESS_KEY_ID="{{.Data.access_key}}"
+AWS_SECRET_ACCESS_KEY="{{.Data.secret_key}}"
+{{ end }}
+__EOF__
+
+        destination = "secrets/file.env"
+        env         = true
+      }
+    }
+  }
+}

--- a/demo/csi/aws/ebs/vault-ebs-csi-policy.hcl
+++ b/demo/csi/aws/ebs/vault-ebs-csi-policy.hcl
@@ -1,0 +1,4 @@
+path "aws/creds/ebs-csi"
+{
+  capabilities = ["read"]
+}

--- a/demo/csi/aws/ebs/vault-example-setup.sh
+++ b/demo/csi/aws/ebs/vault-example-setup.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Vault AWS Secrets Engine
+
+vault secrets enable -path=aws aws
+vault write aws/config/root \
+    access_key=A...NA \
+    secret_key=123XYZ \
+    region=us-east-1
+
+# Permissions needed by the EBS CSI driver
+
+vault write aws/roles/ebs-csi credential_type=iam_user \
+   policy_arns="arn:aws:iam::481516234200:policy/EBS-CSI" \
+   permissions_boundary_arn="arn:aws:iam::481516234200:policy/VaultGrantedBoundary"
+
+# A policy to access AWS credentials for the driver
+vault policy write ebs-csi ebs-csi.hcl

--- a/demo/csi/aws/efs/README.md
+++ b/demo/csi/aws/efs/README.md
@@ -1,0 +1,54 @@
+# AWS EFS CSI Plugin
+
+The configuration here is for the [AWS Elastic Filesystem](https://aws.amazon.com/efs/) CSI driver. This driver only needs to run on nodes, there is no controller required.
+
+## Requirements
+
+### Docker Privileged Mode
+
+The EFS node task requires that [`privileged = true`](https://www.nomadproject.io/docs/drivers/docker#privileged) be set in order to mount/unmount filesystems on the node.
+
+### EC2 Instance Metadata Service.
+
+The driver also requires access to the [EC2 Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
+If you have blocked access to this from docker tasks running in bridge (default) or NAT mode, which is a good idea for security, you may run the task in host networking mode by setting [`network_mode = host`](https://www.nomadproject.io/docs/drivers/docker#network_mode)
+
+## Container Arguments
+ 
+Refer to the official plugin [README](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/README.md).
+ 
+- `--endpoint=unix:///csi/csi.sock`
+
+  - This option must match the `mount_dir` specified in the `csi_plugin` stanza for the task.
+
+- `--logtostderr`
+
+  - Logs are written to standard error instead of to files.
+
+- `--v=5`
+
+  - Sets the klog logging "V" level to 5.
+
+## Deployment
+
+### Plugin
+
+```bash
+export NOMAD_ADDR=https://nomad.example.com:4646
+export NOMAD_TOKEN=34534-3sdf3-szfdsafsdf3423-zxdfsd3
+nomad job run plugin-aws-efs-nodes.hcl
+```
+
+### Volume Registration
+
+Note that it is possible to use the root of the filesystem or a subdirectory, and it is perfectly fine to have different volumes using overlapping subtrees (eg `/`, `/foo`, and `/foo/bar`), or even to have multiple volumes use the same path.
+
+```bash
+export NOMAD_ADDR=https://nomad.example.com:4646
+export NOMAD_TOKEN=34534-3sdf3-szfdsafsdf3423-zxdfsd3
+nomad volume register example-volume.hcl
+```
+
+## EFS CSI Driver Source
+
+- https://github.com/kubernetes-sigs/aws-efs-csi-driver

--- a/demo/csi/aws/efs/example-volume.hcl
+++ b/demo/csi/aws/efs/example-volume.hcl
@@ -1,0 +1,10 @@
+# terraform output mytestefsvol >example-volume.hcl
+# nomad volume register example-volume.hcl
+
+type = "csi"
+id = "mytestefsvol"
+name = "my-test-efs-volume"
+external_id = "fs-1a2b3c4d:/some/path"
+access_mode = "multi-node-multi-writer"
+attachment_mode = "file-system"
+plugin_id = "aws-efs"

--- a/demo/csi/aws/efs/example.tf
+++ b/demo/csi/aws/efs/example.tf
@@ -1,0 +1,42 @@
+data "aws_kms_alias" "elasticfilesystem" {
+  name = "alias/aws/elasticfilesystem"
+}
+
+resource "aws_efs_file_system" "mytestefsvol" {
+  creation_token = "1eab7a71-2457-49b0-a56b-3519b21009a8"
+
+  encrypted = true
+  kms_key_id = data.aws_kms_alias.elasticfilesystem.target_key_arn
+
+  #lifecycle_policy {
+  #  transition_to_ia = AFTER_90_DAYS
+  #}
+
+  tags = {
+    Name = "my-test-efs-volume"
+  }
+}
+
+resource "aws_efs_mount_target" "mytestefsvol_mount" {
+  file_system_id = aws_efs_file_system.mytestefsvol.id
+  subnet_id      = aws_subnet.mysubnet.id
+  ip_address     = ...
+  security_groups = [
+    ...
+  ]
+}
+
+output "mytestefsvol" {
+    value = <<__EOF__
+# terraform output mytestefsvol >example-volume.hcl
+# nomad volume register example-volume.hcl
+
+type = "csi"
+id = "mytestefsvol"
+name = "my-test-efs-volume"
+external_id = "${aws_ebs_volume.mytestefsvol.id}:/some/path"
+access_mode = "multi-node-multi-writer"
+attachment_mode = "file-system"
+plugin_id = "aws-efs"
+__EOF__
+}

--- a/demo/csi/aws/efs/plugin-aws-efs-nodes.nomad
+++ b/demo/csi/aws/efs/plugin-aws-efs-nodes.nomad
@@ -1,0 +1,54 @@
+job "plugin-aws-efs-nodes" { 
+  datacenters = ["dc1"]
+
+  # Curently amd64 only, arm64 hopefully coming soon.
+  # Follow https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/111
+  constraint {
+     attribute = "${attr.cpu.arch}"
+     value     = "amd64"
+  }
+
+  type = "system"
+
+  group "nodes" {
+    ephemeral_disk {
+      size = "128"
+    }
+
+    task "plugin" {
+      driver = "docker"
+
+      config {
+        image = "amazon/aws-efs-csi-driver:v1.0.0"
+
+	args = [ 
+          "--endpoint=unix://csi/csi.sock",
+          "--logtostderr",
+          "--v=5"
+        ]
+
+	# If you have blocked access to the EC2 Metadata Service for
+	# tasks running in the default "bridge" mode (advisable),
+	# allow access by running in host mode.
+
+        network_mode = "host"
+
+        # node plugins must run as privileged jobs because they
+        # mount disks to the host
+
+        privileged = true
+      }
+
+      csi_plugin {
+        id        = "aws-efs"
+        type      = "node"
+        mount_dir = "/csi"
+      }
+
+      resources {
+        cpu    = 100
+        memory = 32
+      }
+    }
+  }
+}


### PR DESCRIPTION
I am contributing these additional CSI example files for AWS EBS and CSI in the hope that it will help others.

The online documentation does have some EBS content, but this example includes some more details, like getting AWS credentials from Vault, and using Terraform to create a disk and automatically create the volume registration file.

There are no EFS examples out there as far as I know.

Thanks!