### PR TITLE
fix duplication of ports in `AllocatedResources`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ __BACKWARDS INCOMPATIBILITIES:__
 BUG FIXES:
 
  * agent (Enterprise): Fixed a bug where audit logging caused websocket and streaming http endpoints to fail [[GH-9319](https://github.com/hashicorp/nomad/issues/9319)]
+ * api: Fixed a bug where AllocatedResources contained increasingly duplicated ports [[GH-9368](https://github.com/hashicorp/nomad/issues/9368)]
  * core: Fixed a bug where ACL handling prevented cross-namespace allocation listing [[GH-9278](https://github.com/hashicorp/nomad/issues/9278)]
  * core: Fixed a bug where scaling policy filtering would ignore type query if job query was present [[GH-9312](https://github.com/hashicorp/nomad/issues/9312)]
  * core: Fixed a bug where a request to scale a job would fail if the job was not in the default namespace. [[GH-9296](https://github.com/hashicorp/nomad/pull/9296)]

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -127,6 +127,7 @@ func (s *HTTPServer) allocGet(allocID string, resp http.ResponseWriter, req *htt
 	alloc.SetEventDisplayMessages()
 
 	// Handle 0.12 ports upgrade path
+	alloc = alloc.Copy()
 	alloc.AllocatedResources.Canonicalize()
 
 	return alloc, nil


### PR DESCRIPTION
#9367 suggests that the canonicalization of `structs.Allocation.AllocatedResources` is mutating the memdb object, causing the number of ports to grow on every call

there are a few solutions here: 
* rewrite canonicalize to avoid this; this allows the field to exist and attempts consistency, which is presumably what we wanted to avoid
* mutate a copy

documenting test in the first commit:
https://app.circleci.com/pipelines/github/hashicorp/nomad/13195/workflows/63c91dd0-ea6e-440e-b080-50b68b680dbc/jobs/118749

copy-based fix in the second commit:
https://app.circleci.com/pipelines/github/hashicorp/nomad/13196/workflows/c857a136-5584-4d3f-ad10-6684bc7f9c68/jobs/118744