### PR TITLE
csi/api: populate ReadAllocs/WriteAllocs fields

### DIFF
--- a/ui/app/serializers/volume.js
+++ b/ui/app/serializers/volume.js
@@ -23,17 +23,16 @@ export default class VolumeSerializer extends ApplicationSerializer {
     hash.ID = JSON.stringify([`csi/${hash.ID}`, hash.NamespaceID || 'default']);
     hash.PluginID = `csi/${hash.PluginID}`;
 
-    // Convert hash-based allocation embeds to lists
+    // Populate read/write allocation lists from aggregate allocation list
     const readAllocs = hash.ReadAllocs || {};
     const writeAllocs = hash.WriteAllocs || {};
-    const bindIDToAlloc = hash => id => {
-      const alloc = hash[id];
-      alloc.ID = id;
+    const bindIDToAlloc = allocList => id => {
+      const alloc = allocList.find(a => a.ID === id);
       return alloc;
     };
 
-    hash.ReadAllocations = Object.keys(readAllocs).map(bindIDToAlloc(readAllocs));
-    hash.WriteAllocations = Object.keys(writeAllocs).map(bindIDToAlloc(writeAllocs));
+    hash.ReadAllocations = Object.keys(readAllocs).map(bindIDToAlloc(hash.Allocations));
+    hash.WriteAllocations = Object.keys(writeAllocs).map(bindIDToAlloc(hash.Allocations));
 
     const normalizedHash = super.normalize(typeHash, hash);
     return this.extractEmbeddedRecords(this, this.store, typeHash, normalizedHash);

--- a/ui/app/serializers/volume.js
+++ b/ui/app/serializers/volume.js
@@ -26,13 +26,22 @@ export default class VolumeSerializer extends ApplicationSerializer {
     // Populate read/write allocation lists from aggregate allocation list
     const readAllocs = hash.ReadAllocs || {};
     const writeAllocs = hash.WriteAllocs || {};
-    const bindIDToAlloc = allocList => id => {
-      const alloc = allocList.find(a => a.ID === id);
-      return alloc;
-    };
 
-    hash.ReadAllocations = Object.keys(readAllocs).map(bindIDToAlloc(hash.Allocations));
-    hash.WriteAllocations = Object.keys(writeAllocs).map(bindIDToAlloc(hash.Allocations));
+    hash.ReadAllocations = [];
+    hash.WriteAllocations = [];
+
+    if (hash.Allocations) {
+      hash.Allocations.forEach(function(alloc) {
+        const id = alloc.ID;
+        if (id in readAllocs) {
+          hash.ReadAllocations.push(alloc);
+        }
+        if (id in writeAllocs) {
+          hash.WriteAllocations.push(alloc);
+        }
+      });
+      delete hash.Allocations;
+    }
 
     const normalizedHash = super.normalize(typeHash, hash);
     return this.extractEmbeddedRecords(this, this.store, typeHash, normalizedHash);

--- a/ui/mirage/models/csi-volume.js
+++ b/ui/mirage/models/csi-volume.js
@@ -4,4 +4,5 @@ export default Model.extend({
   plugin: belongsTo('csi-plugin'),
   writeAllocs: hasMany('allocation'),
   readAllocs: hasMany('allocation'),
+  allocations: hasMany('allocation'),
 });

--- a/ui/mirage/serializers/csi-volume.js
+++ b/ui/mirage/serializers/csi-volume.js
@@ -9,7 +9,7 @@ const groupBy = (list, attr) => {
 
 export default ApplicationSerializer.extend({
   embed: true,
-  include: ['writeAllocs', 'readAllocs'],
+  include: ['writeAllocs', 'readAllocs', 'allocations'],
 
   serialize() {
     var json = ApplicationSerializer.prototype.serialize.apply(this, arguments);

--- a/ui/tests/acceptance/volume-detail-test.js
+++ b/ui/tests/acceptance/volume-detail-test.js
@@ -9,11 +9,13 @@ import VolumeDetail from 'nomad-ui/tests/pages/storage/volumes/detail';
 
 const assignWriteAlloc = (volume, alloc) => {
   volume.writeAllocs.add(alloc);
+  volume.allocations.add(alloc);
   volume.save();
 };
 
 const assignReadAlloc = (volume, alloc) => {
   volume.readAllocs.add(alloc);
+  volume.allocations.add(alloc);
   volume.save();
 };
 

--- a/ui/tests/acceptance/volumes-list-test.js
+++ b/ui/tests/acceptance/volumes-list-test.js
@@ -9,11 +9,13 @@ import Layout from 'nomad-ui/tests/pages/layout';
 
 const assignWriteAlloc = (volume, alloc) => {
   volume.writeAllocs.add(alloc);
+  volume.allocations.add(alloc);
   volume.save();
 };
 
 const assignReadAlloc = (volume, alloc) => {
   volume.readAllocs.add(alloc);
+  volume.allocations.add(alloc);
   volume.save();
 };
 

--- a/ui/tests/unit/serializers/volume-test.js
+++ b/ui/tests/unit/serializers/volume-test.js
@@ -173,30 +173,38 @@ module('Unit | Serializer | Volume', function(hooks) {
         NodesExpected: 2,
         CreateIndex: 1,
         ModifyIndex: 38,
-        WriteAllocs: {
-          'alloc-id-1': {
+        Allocations: [
+          {
+            ID: 'alloc-id-1',
             TaskGroup: 'foobar',
             CreateTime: +REF_DATE * 1000000,
             ModifyTime: +REF_DATE * 1000000,
             JobID: 'the-job',
             Namespace: 'namespace-2',
           },
-          'alloc-id-2': {
+          {
+            ID: 'alloc-id-2',
             TaskGroup: 'write-here',
             CreateTime: +REF_DATE * 1000000,
             ModifyTime: +REF_DATE * 1000000,
             JobID: 'the-job',
             Namespace: 'namespace-2',
           },
-        },
-        ReadAllocs: {
-          'alloc-id-3': {
+          {
+            ID: 'alloc-id-3',
             TaskGroup: 'look-if-you-must',
             CreateTime: +REF_DATE * 1000000,
             ModifyTime: +REF_DATE * 1000000,
             JobID: 'the-job',
             Namespace: 'namespace-2',
           },
+        ],
+        WriteAllocs: {
+          'alloc-id-1': null,
+          'alloc-id-2': null,
+        },
+        ReadAllocs: {
+          'alloc-id-3': null,
         },
       },
       out: {

--- a/website/pages/api-docs/volumes.mdx
+++ b/website/pages/api-docs/volumes.mdx
@@ -230,6 +230,10 @@ $ curl \
       "ModifyTime": 1495747371794276400
     }
   ],
+  "ReadAllocs": {
+    "a8198d79-cfdb-6593-a999-1e9adabcba2e": null
+  },
+  "WriteAllocs": {},
   "Schedulable": true,
   "PluginID": "plugin-id1",
   "Provider": "ebs",


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9215

The API is missing values for `ReadAllocs` and `WriteAllocs` fields, resulting
in allocation claims not being populated in the web UI. These fields mirror
the fields in `nomad/structs.CSIVolume`. Returning a separate list of stubs
for read and write would be ideal, but this can't be done without either
bloating the API response with repeated full `Allocation` data, or causing a
panic in previous versions of the CLI.

The `nomad/structs` fields are persisted with nil values and are populated
during RPC, so we'll do the same in the HTTP API and populate the `ReadAllocs`
and `WriteAllocs` fields with a map of allocation IDs, but with null
values. The web UI will then create its `ReadAllocations` and
`WriteAllocations` fields by mapping from those IDs to the values in
`Allocations`, instead of flattening the map into a list.

---

I've tested this out via the web UI and verified `nomad volume status`, `nomad alloc status`, and `nomad node status` aren't broken, including with a v0.12.8 version of the command line.