### PR TITLE
agent: Reduce startup time by 4 seconds

### DIFF
--- a/client/fingerprint_manager.go
+++ b/client/fingerprint_manager.go
@@ -143,7 +143,7 @@ func (fm *FingerprintManager) setupFingerprinters(fingerprints []string) error {
 func (fm *FingerprintManager) runFingerprint(f fingerprint.Fingerprint, name string) {
 	detected, err := fm.fingerprint(name, f)
 	if err != nil {
-		fm.logger.Debug("error periodic fingerprinting", "error", err, "fingerprinter", name)
+		fm.logger.Debug("error fingerprinting", "error", err, "fingerprinter", name)
 		return
 	}
 


### PR DESCRIPTION
The reason `nomad agent` takes so long to start up is because of fingerprinting for AWS and GCE, each of which has a 2 second timeout by default, and because that code was run sequentially.

In the previous implementation, we would attempt to run each fingerprinter once, and then maybe create a goroutine to run the fingerprinter periodically if the fingerprinter was periodic.

Instead, we use that goroutine to run the initial fingerprinting, and either return early or enter a forever loop based on whether the fingerprinter is periodic or not.

This also required a small change to the debug logging. Previously, the initial list of fingerprinters would be given in a single log line:

```
...
    2020-11-18T09:13:13.009-0800 [DEBUG] client.fingerprint_mgr: detected fingerprints: node_attrs=[arch, bridge, cgroup, cpu, host, network, nomad, signal, storage]
...
```

But now they are printed individually as they are discovered:

```
...
    2020-11-18T09:14:54.328-0800 [DEBUG] client.fingerprint_mgr: detected fingerprint: name=cpu
    2020-11-18T09:14:54.329-0800 [DEBUG] client.fingerprint_mgr: detected fingerprint: name=host
    2020-11-18T09:14:54.329-0800 [INFO]  client.fingerprint_mgr.cgroup: cgroups are available
    2020-11-18T09:14:54.329-0800 [DEBUG] client.fingerprint_mgr: detected fingerprint: name=cgroup
...
```