### PR TITLE
docs: template behavior warnings

### DIFF
--- a/website/pages/docs/job-specification/template.mdx
+++ b/website/pages/docs/job-specification/template.mdx
@@ -68,6 +68,10 @@ README][ct]. Since Nomad v0.6.0, templates can be read as environment variables.
 
 - `env` `(bool: false)` - Specifies the template should be read back in as
   environment variables for the task. ([See below](#environment-variables))
+  Note that if `noop` mode is used for the `change_mode`, the task will not be
+  restarted and the environment variables wwon't be changed in the task. If
+  you set `env = true`, then the `change_mode` should be one of `restart` or
+  `signal`.
 
 - `left_delimiter` `(string: "{{")` - Specifies the left delimiter to use in the
   template. The default is "{{" for some templates, it may be easier to use a
@@ -347,6 +351,18 @@ raw key/value data. This secret was set using
   }
 ```
 
+Note that if the name of a secret includes the `-` character, you must access
+it by index. This secret was set using `vault kv put secret/app
+db-password=somepassword`.
+
+```hcl
+  template {
+    data = <<EOF
+      DB_PASSWORD = "{{with secret "secret/app"}}{{index .Data "db-password"}}{{end}}"
+    EOF
+  }
+```
+
 ### Vault KV API v2
 
 Under Vault KV API v2, paths start with `secret/data/`, and the response returns
@@ -365,6 +381,18 @@ Notice the addition of `data` in both the path and the field accessor string.
 Additionally, when using the Vault v2 API, the Vault policies applied to your
 Nomad jobs will need to grant permissions to `read` under `secret/data/...`
 rather than `secret/...`.
+
+Similar to KV API v1, if the name of a secret includes the `-` character, you
+must access it by index. This secret was set using `vault kv put secret/app
+db-password=somepassword`.
+
+```hcl
+  template {
+    data = <<EOF
+      DB_PASSWORD = "{{with secret "secret/data/app"}}{{index .Data.data "db-password"}}{{end}}"
+    EOF
+  }
+```
 
 ## Client Configuration
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/8703 and https://github.com/hashicorp/nomad/issues/6099

* vault secrets named with `-` characters cannot be read by `consul-template` due to limitations in golang's template rendering engine.
* environment variables are not modified in running tasks if `change_mode.noop` is set.

Preview link https://nomad-qb01ses7r.vercel.app/docs/job-specification/template