### PR TITLE
docs: fix some markdown escaping errors

### DIFF
--- a/website/pages/docs/commands/job/revert.mdx
+++ b/website/pages/docs/commands/job/revert.mdx
@@ -47,11 +47,11 @@ job to revert to.
 
 - `-consul-token`: If set, the passed Consul token is sent along with the revert
   request to the Nomad servers. This overrides the token found in the
-  \$CONSUL_HTTP_TOKEN environment variable.
+  `$CONSUL_HTTP_TOKEN` environment variable.
 
 - `-vault-token`: If set, the passed Vault token is sent along with the revert
   request to the Nomad servers. This overrides the token found in the
-  \$VAULT_TOKEN environment variable.
+  `$VAULT_TOKEN` environment variable.
 
 - `-verbose`: Show full information.
 

--- a/website/pages/docs/commands/job/run.mdx
+++ b/website/pages/docs/commands/job/run.mdx
@@ -36,7 +36,7 @@ there are job placement issues encountered (unsatisfiable constraints, resource
 exhaustion, etc), then the exit code will be 2. Any other errors, including
 client connection issues or internal errors, are indicated by exit code 1.
 
-If the job has specified the region, the -region flag and `\$NOMAD_REGION`
+If the job has specified the region, the `-region` flag and `$NOMAD_REGION`
 environment variable are overridden and the job's region is used.
 
 The run command will set the `consul_token` of the job based on the following

--- a/website/pages/docs/drivers/external/singularity.mdx
+++ b/website/pages/docs/drivers/external/singularity.mdx
@@ -105,7 +105,7 @@ The `Singularity` driver supports the following configuration in the job spec:
   }
   ```
 
-- `contain` - (Optional) Use minimal `/dev` and empty other directories (e.g. /tmp and \$HOME) instead of sharing filesystems from your host.
+- `contain` - (Optional) Use minimal `/dev` and empty other directories (e.g. `/tmp` and `$HOME`) instead of sharing filesystems from your host.
 
   ```hcl
   config {
@@ -113,7 +113,7 @@ The `Singularity` driver supports the following configuration in the job spec:
   }
   ```
 
-- `workdir` - (Optional) Working directory to be used for `/tmp`, `/var/tmp` and \$HOME (if -c/--contain was also used).
+- `workdir` - (Optional) Working directory to be used for `/tmp`, `/var/tmp` and `$HOME` (if -c/--contain was also used).
 
   ```hcl
   config {

--- a/website/pages/partials/general_options.mdx
+++ b/website/pages/partials/general_options.mdx
@@ -6,8 +6,8 @@
   Agent's local region.
 
 - `-namespace=<namespace>`: The target namespace for queries and actions bound
-  to a namespace. Overrides the NOMAD_NAMESPACE environment variable if set.
-  If set to '\*', job and alloc subcommands query all namespacecs authorized to
+  to a namespace. Overrides the `NOMAD_NAMESPACE` environment variable if set.
+  If set to `'*'`, job and alloc subcommands query all namespacecs authorized to
   user. Defaults to the "default" namespace.
 
 - `-no-color`: Disables colored command output. Alternatively,


### PR DESCRIPTION
Preview links:
* https://nomad-2qc05gu75.vercel.app/docs/commands/job/revert
* https://nomad-2qc05gu75.vercel.app/docs/commands/job/run
* https://nomad-2qc05gu75.vercel.app/docs/drivers/external/singularity