### PR TITLE
command: remove -namespace from help options when not applicable

### DIFF
--- a/command/acl_bootstrap.go
+++ b/command/acl_bootstrap.go
@@ -20,7 +20,7 @@ Usage: nomad acl bootstrap [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/acl_policy_apply.go
+++ b/command/acl_policy_apply.go
@@ -23,7 +23,7 @@ Usage: nomad acl policy apply [options] <name> <path>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Apply Options:
 

--- a/command/acl_policy_delete.go
+++ b/command/acl_policy_delete.go
@@ -19,7 +19,7 @@ Usage: nomad acl policy delete <name>
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 
 	return strings.TrimSpace(helpText)
 }

--- a/command/acl_policy_info.go
+++ b/command/acl_policy_info.go
@@ -19,7 +19,7 @@ Usage: nomad acl policy info <name>
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 
 	return strings.TrimSpace(helpText)
 }

--- a/command/acl_policy_list.go
+++ b/command/acl_policy_list.go
@@ -20,7 +20,7 @@ Usage: nomad acl policy list
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 List Options:
 

--- a/command/acl_token_create.go
+++ b/command/acl_token_create.go
@@ -20,7 +20,7 @@ Usage: nomad acl token create [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Create Options:
 

--- a/command/acl_token_delete.go
+++ b/command/acl_token_delete.go
@@ -19,7 +19,7 @@ Usage: nomad acl token delete <token_accessor_id>
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 
 	return strings.TrimSpace(helpText)
 }

--- a/command/acl_token_info.go
+++ b/command/acl_token_info.go
@@ -19,7 +19,7 @@ Usage: nomad acl token info <token_accessor_id>
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 
 	return strings.TrimSpace(helpText)
 }

--- a/command/acl_token_list.go
+++ b/command/acl_token_list.go
@@ -20,7 +20,7 @@ Usage: nomad acl token list
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 List Options:
 

--- a/command/acl_token_self.go
+++ b/command/acl_token_self.go
@@ -19,7 +19,7 @@ Usage: nomad acl token self
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 
 	return strings.TrimSpace(helpText)
 }

--- a/command/acl_token_update.go
+++ b/command/acl_token_update.go
@@ -19,7 +19,7 @@ Usage: nomad acl token update <token_accessor_id>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Update Options:
 

--- a/command/agent_info.go
+++ b/command/agent_info.go
@@ -20,7 +20,7 @@ Usage: nomad agent-info [options]
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 	return strings.TrimSpace(helpText)
 }
 

--- a/command/agent_monitor.go
+++ b/command/agent_monitor.go
@@ -29,7 +29,7 @@ Usage: nomad monitor [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Monitor Specific Options:
 

--- a/command/alloc_exec.go
+++ b/command/alloc_exec.go
@@ -34,7 +34,7 @@ Usage: nomad alloc exec [options] <allocation> <command>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Exec Specific Options:
 

--- a/command/alloc_fs.go
+++ b/command/alloc_fs.go
@@ -42,7 +42,7 @@ Alias: nomad fs
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 FS Specific Options:
 

--- a/command/alloc_logs.go
+++ b/command/alloc_logs.go
@@ -28,7 +28,7 @@ Alias: nomad logs
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Logs Specific Options:
 

--- a/command/alloc_restart.go
+++ b/command/alloc_restart.go
@@ -23,7 +23,7 @@ Usage: nomad alloc restart [options] <allocation> <task>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Restart Specific Options:
 

--- a/command/alloc_signal.go
+++ b/command/alloc_signal.go
@@ -23,7 +23,7 @@ Usage: nomad alloc signal [options] <signal> <allocation> <task>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Signal Specific Options:
 

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -31,7 +31,7 @@ Usage: nomad alloc status [options] <allocation>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Alloc Status Options:
 

--- a/command/alloc_stop.go
+++ b/command/alloc_stop.go
@@ -24,7 +24,7 @@ Alias: nomad stop
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Stop Specific Options:
 

--- a/command/check.go
+++ b/command/check.go
@@ -29,7 +29,7 @@ Usage: nomad check [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Agent Check Options:
 

--- a/command/deployment_fail.go
+++ b/command/deployment_fail.go
@@ -23,7 +23,7 @@ Usage: nomad deployment fail [options] <deployment id>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Fail Options:
 

--- a/command/deployment_list.go
+++ b/command/deployment_list.go
@@ -20,7 +20,7 @@ Usage: nomad deployment list [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 List Options:
 

--- a/command/deployment_pause.go
+++ b/command/deployment_pause.go
@@ -21,7 +21,7 @@ Usage: nomad deployment pause [options] <deployment id>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Pause Options:
 

--- a/command/deployment_promote.go
+++ b/command/deployment_promote.go
@@ -28,7 +28,7 @@ Usage: nomad deployment promote [options] <deployment id>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Promote Options:
 

--- a/command/deployment_resume.go
+++ b/command/deployment_resume.go
@@ -21,7 +21,7 @@ Usage: nomad deployment resume [options] <deployment id>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Resume Options:
 

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -24,7 +24,7 @@ Usage: nomad deployment status [options] <deployment id>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Status Options:
 

--- a/command/deployment_unblock.go
+++ b/command/deployment_unblock.go
@@ -21,7 +21,7 @@ Usage: nomad deployment unblock [options] <deployment id>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Unblock Options:
 

--- a/command/eval_status.go
+++ b/command/eval_status.go
@@ -25,7 +25,7 @@ Usage: nomad eval status [options] <evaluation>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Eval Status Options:
 

--- a/command/event_sink_deregister.go
+++ b/command/event_sink_deregister.go
@@ -16,7 +16,7 @@ Usage: nomad event sink deregister <event sink id>
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault)
 
 	return helpText
 }

--- a/command/event_sink_list.go
+++ b/command/event_sink_list.go
@@ -20,7 +20,7 @@ Usage: nomad event sink list
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault)
 
 	return helpText
 }

--- a/command/event_sink_register.go
+++ b/command/event_sink_register.go
@@ -25,7 +25,7 @@ Usage: nomad event sink register <path>
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault)
 
 	return helpText
 }

--- a/command/job_deployments.go
+++ b/command/job_deployments.go
@@ -21,7 +21,7 @@ Usage: nomad job deployments [options] <job>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Deployments Options:
 
@@ -38,7 +38,7 @@ Deployments Options:
     Display full information.
 
   -all
-    Display all deployments matching the job ID, including those 
+    Display all deployments matching the job ID, including those
     from an older instance of the job.
 `
 	return strings.TrimSpace(helpText)

--- a/command/job_dispatch.go
+++ b/command/job_dispatch.go
@@ -30,7 +30,7 @@ Usage: nomad job dispatch [options] <parameterized job> [input source]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Dispatch Options:
 

--- a/command/job_eval.go
+++ b/command/job_eval.go
@@ -24,7 +24,7 @@ Usage: nomad job eval [options] <job_id>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Eval Options:
 

--- a/command/job_history.go
+++ b/command/job_history.go
@@ -28,7 +28,7 @@ Usage: nomad job history [options] <job>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 History Options:
 

--- a/command/job_inspect.go
+++ b/command/job_inspect.go
@@ -22,7 +22,7 @@ Alias: nomad inspect
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Inspect Options:
 

--- a/command/job_periodic_force.go
+++ b/command/job_periodic_force.go
@@ -22,7 +22,7 @@ Usage: nomad job periodic force <job id>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Periodic Force Options:
 

--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -65,7 +65,7 @@ Alias: nomad plan
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Plan Options:
 

--- a/command/job_promote.go
+++ b/command/job_promote.go
@@ -29,7 +29,7 @@ Usage: nomad job promote [options] <job id>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Promote Options:
 

--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -23,7 +23,7 @@ Usage: nomad job revert [options] <job> <version>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Revert Options:
 
@@ -36,8 +36,8 @@ Revert Options:
    The Consul token used to verify that the caller has access to the Service
    Identity policies associated in the targeted version of the job.
 
-  -vault-token 
-   The Vault token used to verify that the caller has access to the Vault 
+  -vault-token
+   The Vault token used to verify that the caller has access to the Vault
    policies in the targeted version of the job.
 
   -verbose

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -63,7 +63,7 @@ Alias: nomad run
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Run Options:
 

--- a/command/job_scale.go
+++ b/command/job_scale.go
@@ -34,7 +34,7 @@ Usage: nomad job scale [options] <job> [<group>] <count>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Scale Options:
 

--- a/command/job_scaling_events.go
+++ b/command/job_scaling_events.go
@@ -29,7 +29,7 @@ Usage: nomad job scaling-events [options] <args>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Scaling-Events Options:
 

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -35,7 +35,7 @@ Usage: nomad status [options] <job>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Status Options:
 

--- a/command/job_stop.go
+++ b/command/job_stop.go
@@ -26,7 +26,7 @@ Alias: nomad stop
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Stop Options:
 

--- a/command/license_get.go
+++ b/command/license_get.go
@@ -15,7 +15,7 @@ Usage: nomad license get [options]
 Gets a new license in Servers and Clients
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 
 	return helpText
 }

--- a/command/license_put.go
+++ b/command/license_put.go
@@ -25,7 +25,7 @@ Puts a new license in Servers and Clients
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Install a new license from a file:
 

--- a/command/meta.go
+++ b/command/meta.go
@@ -161,8 +161,16 @@ func (m *Meta) Colorize() *colorstring.Colorize {
 	}
 }
 
+type usageOptsFlags uint8
+
+const (
+	usageOptsDefault     usageOptsFlags = 0
+	usageOptsNoNamespace                = 1 << iota
+)
+
 // generalOptionsUsage returns the help string for the global options.
-func generalOptionsUsage() string {
+func generalOptionsUsage(usageOpts usageOptsFlags) string {
+
 	helpText := `
   -address=<addr>
     The address of the Nomad server.
@@ -173,14 +181,21 @@ func generalOptionsUsage() string {
     The region of the Nomad servers to forward commands to.
     Overrides the NOMAD_REGION environment variable if set.
     Defaults to the Agent's local region.
+`
 
+	namespaceText := `
   -namespace=<namespace>
     The target namespace for queries and actions bound to a namespace.
     Overrides the NOMAD_NAMESPACE environment variable if set.
     If set to '*', job and alloc subcommands query all namespaces authorized
     to user.
     Defaults to the "default" namespace.
+`
 
+	// note: that although very few commands use color explicitly, all of them
+	// return red-colored text on error so we don't want to make this
+	// configurable
+	remainingText := `
   -no-color
     Disables colored command output. Alternatively, NOMAD_CLI_NO_COLOR may be
     set.
@@ -218,6 +233,12 @@ func generalOptionsUsage() string {
     The SecretID of an ACL token to use to authenticate API requests with.
     Overrides the NOMAD_TOKEN environment variable if set.
 `
+
+	if usageOpts&usageOptsNoNamespace == 0 {
+		helpText = helpText + namespaceText
+	}
+
+	helpText = helpText + remainingText
 	return strings.TrimSpace(helpText)
 }
 

--- a/command/metrics.go
+++ b/command/metrics.go
@@ -19,7 +19,7 @@ Usage: nomad operator metrics [options]
 Get Nomad metrics
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Metrics Specific Options
 

--- a/command/namespace_apply.go
+++ b/command/namespace_apply.go
@@ -22,7 +22,7 @@ Usage: nomad namespace apply [options] <namespace>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Apply Options:
 

--- a/command/namespace_delete.go
+++ b/command/namespace_delete.go
@@ -19,7 +19,7 @@ Usage: nomad namespace delete [options] <namespace>
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 
 	return strings.TrimSpace(helpText)
 }

--- a/command/namespace_inspect.go
+++ b/command/namespace_inspect.go
@@ -19,7 +19,7 @@ Usage: nomad namespace inspect [options] <namespace>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Inspect Options:
 

--- a/command/namespace_list.go
+++ b/command/namespace_list.go
@@ -21,7 +21,7 @@ Usage: nomad namespace list [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 List Options:
 

--- a/command/namespace_status.go
+++ b/command/namespace_status.go
@@ -20,7 +20,7 @@ Usage: nomad namespace status [options] <namespace>
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 
 	return strings.TrimSpace(helpText)
 }

--- a/command/node_config.go
+++ b/command/node_config.go
@@ -24,7 +24,7 @@ Usage: nomad node config [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Client Config Options:
 

--- a/command/node_drain.go
+++ b/command/node_drain.go
@@ -31,7 +31,7 @@ Usage: nomad node drain [options] <node>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Node Drain Options:
 

--- a/command/node_eligibility.go
+++ b/command/node_eligibility.go
@@ -25,7 +25,7 @@ Usage: nomad node eligibility [options] <node>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Node Eligibility Options:
 

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -51,7 +51,7 @@ Usage: nomad node status [options] <node>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Node Status Options:
 

--- a/command/operator_autopilot_get.go
+++ b/command/operator_autopilot_get.go
@@ -66,7 +66,7 @@ Usage: nomad operator autopilot get-config [options]
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 
 	return strings.TrimSpace(helpText)
 }

--- a/command/operator_autopilot_set.go
+++ b/command/operator_autopilot_set.go
@@ -112,7 +112,7 @@ Usage: nomad operator autopilot set-config [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Set Config Options:
 

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -57,7 +57,7 @@ Usage: nomad operator debug [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Debug Options:
 

--- a/command/operator_keyring.go
+++ b/command/operator_keyring.go
@@ -33,7 +33,7 @@ Usage: nomad operator keyring [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Keyring Options:
 

--- a/command/operator_raft_list.go
+++ b/command/operator_raft_list.go
@@ -21,7 +21,7 @@ Usage: nomad operator raft list-peers [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 List Peers Options:
 

--- a/command/operator_raft_remove.go
+++ b/command/operator_raft_remove.go
@@ -27,7 +27,7 @@ Usage: nomad operator raft remove-peer [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Remove Peer Options:
 

--- a/command/operator_snapshot_restore.go
+++ b/command/operator_snapshot_restore.go
@@ -34,7 +34,7 @@ Usage: nomad operator snapshot restore [options] <file>
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 	return strings.TrimSpace(helpText)
 }
 

--- a/command/operator_snapshot_save.go
+++ b/command/operator_snapshot_save.go
@@ -41,7 +41,7 @@ Usage: nomad operator snapshot save [options] <file>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Snapshot Save Options:
 

--- a/command/plugin_status.go
+++ b/command/plugin_status.go
@@ -26,7 +26,7 @@ Usage nomad plugin status [options] <plugin>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Status Options:
 

--- a/command/quota_apply.go
+++ b/command/quota_apply.go
@@ -31,7 +31,7 @@ Usage: nomad quota apply [options] <input>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Apply Options:
 

--- a/command/quota_delete.go
+++ b/command/quota_delete.go
@@ -19,7 +19,7 @@ Usage: nomad quota delete [options] <quota>
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault)
 
 	return strings.TrimSpace(helpText)
 }

--- a/command/quota_inspect.go
+++ b/command/quota_inspect.go
@@ -26,7 +26,7 @@ Usage: nomad quota inspect [options] <quota>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Inspect Options:
 

--- a/command/quota_list.go
+++ b/command/quota_list.go
@@ -21,7 +21,7 @@ Usage: nomad quota list [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 List Options:
 

--- a/command/quota_status.go
+++ b/command/quota_status.go
@@ -23,7 +23,7 @@ Usage: nomad quota status [options] <quota>
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault)
 
 	return strings.TrimSpace(helpText)
 }

--- a/command/recommendation_apply.go
+++ b/command/recommendation_apply.go
@@ -27,7 +27,7 @@ Usage: nomad recommendation apply [options] <recommendation_ids>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Recommendation Apply Options:
 

--- a/command/recommendation_dismiss.go
+++ b/command/recommendation_dismiss.go
@@ -48,7 +48,7 @@ Usage: nomad recommendation dismiss [options] <recommendation_ids>
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault)
 	return strings.TrimSpace(helpText)
 }
 

--- a/command/recommendation_info.go
+++ b/command/recommendation_info.go
@@ -26,7 +26,7 @@ Usage: nomad recommendation info [options] <recommendation_id>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Recommendation Info Options:
 

--- a/command/recommendation_list.go
+++ b/command/recommendation_list.go
@@ -27,7 +27,7 @@ Usage: nomad recommendation list [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Recommendation List Options:
 

--- a/command/scaling_policy_info.go
+++ b/command/scaling_policy_info.go
@@ -25,7 +25,7 @@ Usage: nomad scaling policy info [options] <policy_id>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Policy Info Options:
 

--- a/command/scaling_policy_list.go
+++ b/command/scaling_policy_list.go
@@ -27,7 +27,7 @@ Usage: nomad scaling policy list [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Policy Info Options:
 

--- a/command/sentinel_apply.go
+++ b/command/sentinel_apply.go
@@ -24,7 +24,7 @@ Usage: nomad sentinel apply [options] <name> <file>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Apply Options:
 

--- a/command/sentinel_delete.go
+++ b/command/sentinel_delete.go
@@ -19,7 +19,7 @@ Usage: nomad sentinel delete [options] <name>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/sentinel_list.go
+++ b/command/sentinel_list.go
@@ -19,7 +19,7 @@ Usage: nomad sentinel list [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/sentinel_read.go
+++ b/command/sentinel_read.go
@@ -19,7 +19,7 @@ Usage: nomad sentinel read [options] <name>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Read Options:
 

--- a/command/server_force_leave.go
+++ b/command/server_force_leave.go
@@ -22,7 +22,7 @@ Usage: nomad server force-leave [options] <node>
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 	return strings.TrimSpace(helpText)
 }
 

--- a/command/server_join.go
+++ b/command/server_join.go
@@ -23,7 +23,7 @@ Usage: nomad server join [options] <addr> [<addr>...]
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 	return strings.TrimSpace(helpText)
 }
 

--- a/command/server_members.go
+++ b/command/server_members.go
@@ -25,7 +25,7 @@ Usage: nomad server members [options]
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
 Server Members Options:
 

--- a/command/status.go
+++ b/command/status.go
@@ -26,7 +26,7 @@ Usage: nomad status [options] <identifier>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Status Options:
 

--- a/command/system_gc.go
+++ b/command/system_gc.go
@@ -19,7 +19,7 @@ Usage: nomad system gc [options]
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 	return strings.TrimSpace(helpText)
 }
 

--- a/command/system_reconcile_summaries.go
+++ b/command/system_reconcile_summaries.go
@@ -19,7 +19,7 @@ Usage: nomad system reconcile summaries [options]
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 	return strings.TrimSpace(helpText)
 }
 

--- a/command/ui.go
+++ b/command/ui.go
@@ -29,7 +29,7 @@ object. Supported identifiers are jobs, allocations and nodes.
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 
 	return strings.TrimSpace(helpText)
 }

--- a/command/volume_deregister.go
+++ b/command/volume_deregister.go
@@ -20,7 +20,7 @@ Usage: nomad volume deregister [options] <id>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Volume Deregister Options:
 

--- a/command/volume_detach.go
+++ b/command/volume_detach.go
@@ -20,7 +20,7 @@ Usage: nomad volume detach [options] <vol id> <node id>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/volume_register.go
+++ b/command/volume_register.go
@@ -27,7 +27,7 @@ Usage: nomad volume register [options] <input>
 
 General Options:
 
-  ` + generalOptionsUsage()
+  ` + generalOptionsUsage(usageOptsDefault)
 
 	return strings.TrimSpace(helpText)
 }

--- a/command/volume_status.go
+++ b/command/volume_status.go
@@ -26,7 +26,7 @@ Usage: nomad volume status [options] <id>
 
 General Options:
 
-  ` + generalOptionsUsage() + `
+  ` + generalOptionsUsage(usageOptsDefault) + `
 
 Status Options:
 


### PR DESCRIPTION
Half of the fix for https://github.com/hashicorp/nomad/issues/9295. A second PR will come with the website docs update.

Add a bitflag for `commands/meta.go`'s `generalOptionsUsage` function so that we can remove sections of the general options help text that aren't applicable to that command. (I originally was going to include removing the `-no-color` flag as well, but that turns out to be needed everywhere to handle coloring errors red.)

---


Example without `-namespace`:

<details><summary>nomad node drain</summary>

```
$ nomad node drain -help
Usage: nomad node drain [options] <node>

  Toggles node draining on a specified node. It is required
  that either -enable or -disable is specified, but not both.
  The -self flag is useful to drain the local node.

General Options:

  -address=<addr>
    The address of the Nomad server.
    Overrides the NOMAD_ADDR environment variable if set.
    Default = http://127.0.0.1:4646

  -region=<region>
    The region of the Nomad servers to forward commands to.
    Overrides the NOMAD_REGION environment variable if set.
    Defaults to the Agent's local region.

  -no-color
    Disables colored command output. Alternatively, NOMAD_CLI_NO_COLOR may be
    set.

  -ca-cert=<path>
    Path to a PEM encoded CA cert file to use to verify the
    Nomad server SSL certificate.  Overrides the NOMAD_CACERT
    environment variable if set.

  -ca-path=<path>
    Path to a directory of PEM encoded CA cert files to verify
    the Nomad server SSL certificate. If both -ca-cert and
    -ca-path are specified, -ca-cert is used. Overrides the
    NOMAD_CAPATH environment variable if set.

  -client-cert=<path>
    Path to a PEM encoded client certificate for TLS authentication
    to the Nomad server. Must also specify -client-key. Overrides
    the NOMAD_CLIENT_CERT environment variable if set.

  -client-key=<path>
    Path to an unencrypted PEM encoded private key matching the
    client certificate from -client-cert. Overrides the
    NOMAD_CLIENT_KEY environment variable if set.

  -tls-server-name=<value>
    The server name to use as the SNI host when connecting via
    TLS. Overrides the NOMAD_TLS_SERVER_NAME environment variable if set.

  -tls-skip-verify
    Do not verify TLS certificate. This is highly not recommended. Verification
    will also be skipped if NOMAD_SKIP_VERIFY is set.

  -token
    The SecretID of an ACL token to use to authenticate API requests with.
    Overrides the NOMAD_TOKEN environment variable if set.

Node Drain Options:

  -disable
    Disable draining for the specified node.

  -enable
    Enable draining for the specified node.

  -deadline <duration>
    Set the deadline by which all allocations must be moved off the node.
    Remaining allocations after the deadline are forced removed from the node.
    If unspecified, a default deadline of one hour is applied.

  -detach
    Return immediately instead of entering monitor mode.

  -monitor
    Enter monitor mode directly without modifying the drain status.

  -force
    Force remove allocations off the node immediately.

  -no-deadline
    No deadline allows the allocations to drain off the node without being force
    stopped after a certain deadline.

  -ignore-system
    Ignore system allows the drain to complete without stopping system job
    allocations. By default system jobs are stopped last.

  -keep-ineligible
    Keep ineligible will maintain the node's scheduling ineligibility even if
    the drain is being disabled. This is useful when an existing drain is being
    cancelled but additional scheduling on the node is not desired.

  -self
    Set the drain status of the local node.

  -yes
    Automatic yes to prompts.
```

</details>


Example with `-namespace`: 


<details><summary>nomad job plan</summary>

```
$ nomad job plan -help
Usage: nomad job plan [options] <path>
Alias: nomad plan

  Plan invokes a dry-run of the scheduler to determine the effects of submitting
  either a new or updated version of a job. The plan will not result in any
  changes to the cluster but gives insight into whether the job could be run
  successfully and how it would affect existing allocations.

  If the supplied path is "-", the jobfile is read from stdin. Otherwise
  it is read from the file at the supplied path or downloaded and
  read from URL specified.

  A job modify index is returned with the plan. This value can be used when
  submitting the job using "nomad run -check-index", which will check that the job
  was not modified between the plan and run command before invoking the
  scheduler. This ensures the job has not been modified since the plan.
  Multiregion jobs do not return a job modify index.

  A structured diff between the local and remote job is displayed to
  give insight into what the scheduler will attempt to do and why.

  If the job has specified the region, the -region flag and NOMAD_REGION
  environment variable are overridden and the job's region is used.

  Plan will return one of the following exit codes:
    * 0: No allocations created or destroyed.
    * 1: Allocations created or destroyed.
    * 255: Error determining plan results.

General Options:

  -address=<addr>
    The address of the Nomad server.
    Overrides the NOMAD_ADDR environment variable if set.
    Default = http://127.0.0.1:4646

  -region=<region>
    The region of the Nomad servers to forward commands to.
    Overrides the NOMAD_REGION environment variable if set.
    Defaults to the Agent's local region.

  -namespace=<namespace>
    The target namespace for queries and actions bound to a namespace.
    Overrides the NOMAD_NAMESPACE environment variable if set.
    If set to '*', job and alloc subcommands query all namespaces authorized
    to user.
    Defaults to the "default" namespace.

  -no-color
    Disables colored command output. Alternatively, NOMAD_CLI_NO_COLOR may be
    set.

  -ca-cert=<path>
    Path to a PEM encoded CA cert file to use to verify the
    Nomad server SSL certificate.  Overrides the NOMAD_CACERT
    environment variable if set.

  -ca-path=<path>
    Path to a directory of PEM encoded CA cert files to verify
    the Nomad server SSL certificate. If both -ca-cert and
    -ca-path are specified, -ca-cert is used. Overrides the
    NOMAD_CAPATH environment variable if set.

  -client-cert=<path>
    Path to a PEM encoded client certificate for TLS authentication
    to the Nomad server. Must also specify -client-key. Overrides
    the NOMAD_CLIENT_CERT environment variable if set.

  -client-key=<path>
    Path to an unencrypted PEM encoded private key matching the
    client certificate from -client-cert. Overrides the
    NOMAD_CLIENT_KEY environment variable if set.

  -tls-server-name=<value>
    The server name to use as the SNI host when connecting via
    TLS. Overrides the NOMAD_TLS_SERVER_NAME environment variable if set.

  -tls-skip-verify
    Do not verify TLS certificate. This is highly not recommended. Verification
    will also be skipped if NOMAD_SKIP_VERIFY is set.

  -token
    The SecretID of an ACL token to use to authenticate API requests with.
    Overrides the NOMAD_TOKEN environment variable if set.

Plan Options:

  -diff
    Determines whether the diff between the remote job and planned job is shown.
    Defaults to true.

  -hcl1
    Parses the job file as HCLv1.

  -policy-override
    Sets the flag to force override any soft mandatory Sentinel policies.

  -var 'key=value'
    Variable for template, can be used multiple times.

  -var-file=path
    Path to HCL2 file containing user variables.

  -verbose
    Increase diff verbosity.
```

</details>