### PR TITLE
docs/help: -no-color does not apply to alloc logs content

### DIFF
--- a/command/alloc_logs.go
+++ b/command/alloc_logs.go
@@ -55,7 +55,12 @@ Logs Specific Options:
 
   -c
     Sets the tail location in number of bytes relative to the end of the logs.
-  `
+
+  Note that the -no-color option applies to Nomad's own output. If the task's
+  logs include terminal escape sequences for color codes, Nomad will not
+  remove them.
+`
+
 	return strings.TrimSpace(helpText)
 }
 

--- a/website/pages/docs/commands/alloc/logs.mdx
+++ b/website/pages/docs/commands/alloc/logs.mdx
@@ -48,6 +48,10 @@ the given job will be chosen.
 - `-c`: Sets the tail location in number of bytes relative to the end of the
   logs.
 
+Note that the `-no-color` option applies to Nomad's own output. If the task's
+logs include terminal escape sequences for color codes, Nomad will not remove
+them.
+
 ## Examples
 
 ```shell-session


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9182

The `nomad alloc logs` command does not remove terminal escape sequences for
color from the log outputs of a task. Clarify that the standard `-no-color`
flag, which does apply to Nomad's error responses from `nomad alloc logs`,
does not apply to the log output.