### PR TITLE
docs: describe required ACLs for all commands

### DIFF
--- a/command/acl_policy_apply.go
+++ b/command/acl_policy_apply.go
@@ -21,6 +21,8 @@ Usage: nomad acl policy apply [options] <name> <path>
   Apply is used to create or update an ACL policy. The policy is
   sourced from <path> or from stdin if path is "-".
 
+  This command requires a management ACL token.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/acl_policy_delete.go
+++ b/command/acl_policy_delete.go
@@ -17,6 +17,8 @@ Usage: nomad acl policy delete <name>
 
   Delete is used to delete an existing ACL policy.
 
+  This command requires a management ACL token.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)

--- a/command/acl_policy_info.go
+++ b/command/acl_policy_info.go
@@ -17,6 +17,9 @@ Usage: nomad acl policy info <name>
 
   Info is used to fetch information on an existing ACL policy.
 
+  This command requires a management ACL token or a token that has the
+  associated policy.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)

--- a/command/acl_policy_list.go
+++ b/command/acl_policy_list.go
@@ -18,6 +18,9 @@ Usage: nomad acl policy list
 
   List is used to list available ACL policies.
 
+  This command requires a management ACL token to view all policies. A
+  non-management token can query its own policies.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/agent_info.go
+++ b/command/agent_info.go
@@ -18,6 +18,9 @@ Usage: nomad agent-info [options]
 
   Display status information about the local agent.
 
+  When ACLs are enabled, this command requires a token with the 'agent:read'
+  capability.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)

--- a/command/agent_monitor.go
+++ b/command/agent_monitor.go
@@ -27,6 +27,9 @@ Usage: nomad monitor [options]
   example your agent may only be logging at INFO level, but with the monitor
   command you can set -log-level DEBUG
 
+  When ACLs are enabled, this command requires a token with the 'agent:read'
+  capability.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/alloc_exec.go
+++ b/command/alloc_exec.go
@@ -32,6 +32,12 @@ Usage: nomad alloc exec [options] <allocation> <command>
 
   Run command inside the environment of the given allocation and task.
 
+  When ACLs are enabled, this command requires a token with the 'alloc-exec',
+  'read-job', and 'list-jobs' capabilities for the allocation's namespace. If
+  the task driver does not have file system isolation (as with 'raw_exec'),
+  this command requires the 'alloc-node-exec', 'read-job', and 'list-jobs'
+  capabilities for the allocation's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/alloc_fs.go
+++ b/command/alloc_fs.go
@@ -36,9 +36,12 @@ func (f *AllocFSCommand) Help() string {
 Usage: nomad alloc fs [options] <allocation> <path>
 Alias: nomad fs
 
-  fs displays either the contents of an allocation directory for the passed allocation,
-  or displays the file at the given path. The path is relative to the root of the alloc
-  dir and defaults to root if unspecified.
+  fs displays either the contents of an allocation directory for the passed
+  allocation, or displays the file at the given path. The path is relative to
+  the root of the alloc dir and defaults to root if unspecified.
+
+  When ACLs are enabled, this command requires a token with the 'read-fs',
+  'read-job', and 'list-jobs' capabilities for the allocation's namespace.
 
 General Options:
 

--- a/command/alloc_logs.go
+++ b/command/alloc_logs.go
@@ -26,6 +26,9 @@ Alias: nomad logs
 
   Streams the stdout/stderr of the given allocation and task.
 
+  When ACLs are enabled, this command requires a token with the 'read-logs',
+  'read-job', and 'list-jobs' capabilities for the allocation's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/alloc_restart.go
+++ b/command/alloc_restart.go
@@ -17,9 +17,13 @@ func (a *AllocRestartCommand) Help() string {
 	helpText := `
 Usage: nomad alloc restart [options] <allocation> <task>
 
-  restart an existing allocation. This command is used to restart a specific alloc
+  Restart an existing allocation. This command is used to restart a specific alloc
   and its tasks. If no task is provided then all of the allocation's tasks will
   be restarted.
+
+  When ACLs are enabled, this command requires a token with the
+  'alloc-lifecycle', 'read-job', and 'list-jobs' capabilities for the
+  allocation's namespace.
 
 General Options:
 

--- a/command/alloc_signal.go
+++ b/command/alloc_signal.go
@@ -21,6 +21,10 @@ Usage: nomad alloc signal [options] <signal> <allocation> <task>
   and its subtasks. If no task is provided then all of the allocations subtasks
   will receive the signal.
 
+  When ACLs are enabled, this command requires a token with the
+  'alloc-lifecycle', 'read-job', and 'list-jobs' capabilities for the
+  allocation's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -29,6 +29,9 @@ Usage: nomad alloc status [options] <allocation>
   status, metadata, and verbose failure messages reported by internal
   subsystems.
 
+  When ACLs are enabled, this command requires a token with the 'read-job' and
+  'list-jobs' capabilities for the allocation's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/alloc_stop.go
+++ b/command/alloc_stop.go
@@ -16,11 +16,15 @@ func (a *AllocStopCommand) Help() string {
 Usage: nomad alloc stop [options] <allocation>
 Alias: nomad stop
 
-  stop an existing allocation. This command is used to signal a specific alloc
+  Stop an existing allocation. This command is used to signal a specific alloc
   to shut down. When the allocation has been shut down, it will then be
   rescheduled. An interactive monitoring session will display log lines as the
   allocation completes shutting down. It is safe to exit the monitor early with
   ctrl-c.
+
+  When ACLs are enabled, this command requires a token with the
+  'alloc-lifecycle', 'read-job', and 'list-jobs' capabilities for the
+  allocation's namespace.
 
 General Options:
 

--- a/command/deployment_fail.go
+++ b/command/deployment_fail.go
@@ -21,6 +21,9 @@ Usage: nomad deployment fail [options] <deployment id>
   if the job is configured to auto revert, the job will attempt to roll back to a
   stable version.
 
+  When ACLs are enabled, this command requires a token with the 'submit-job'
+  and 'read-job' capabilities for the deployment's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/deployment_list.go
+++ b/command/deployment_list.go
@@ -18,6 +18,9 @@ Usage: nomad deployment list [options]
 
   List is used to list the set of deployments tracked by Nomad.
 
+  When ACLs are enabled, this command requires a token with the 'read-job'
+  capability for the deployment's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/deployment_pause.go
+++ b/command/deployment_pause.go
@@ -19,6 +19,9 @@ Usage: nomad deployment pause [options] <deployment id>
   Pause is used to pause a deployment. Pausing a deployment will pause the
   placement of new allocations as part of rolling deployment.
 
+  When ACLs are enabled, this command requires a token with the 'submit-job'
+  and 'read-job' capabilities for the deployment's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/deployment_promote.go
+++ b/command/deployment_promote.go
@@ -26,6 +26,9 @@ Usage: nomad deployment promote [options] <deployment id>
   the job can be failed forward by submitting a new version or failed backwards by
   reverting to an older version using the "nomad job revert" command.
 
+  When ACLs are enabled, this command requires a token with the 'submit-job'
+  and 'read-job' capabilities for the deployment's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/deployment_resume.go
+++ b/command/deployment_resume.go
@@ -19,6 +19,9 @@ Usage: nomad deployment resume [options] <deployment id>
   Resume is used to unpause a paused deployment. Resuming a deployment will
   resume the placement of new allocations as part of rolling deployment.
 
+  When ACLs are enabled, this command requires a token with the 'submit-job'
+  and 'read-job' capabilities for the deployment's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -22,6 +22,9 @@ Usage: nomad deployment status [options] <deployment id>
   Status is used to display the status of a deployment. The status will display
   the number of desired changes as well as the currently applied changes.
 
+  When ACLs are enabled, this command requires a token with the 'read-job'
+  capability for the deployment's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/deployment_unblock.go
+++ b/command/deployment_unblock.go
@@ -19,6 +19,9 @@ Usage: nomad deployment unblock [options] <deployment id>
   Unblock is used to unblock a multiregion deployment that's waiting for
   peer region deployments to complete.
 
+  When ACLs are enabled, this command requires a token with the 'submit-job'
+  and 'read-job' capabilities for the deployment's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/event_sink_deregister.go
+++ b/command/event_sink_deregister.go
@@ -12,7 +12,9 @@ func (c *EventSinkDeregisterCommand) Help() string {
 	helpText := `
 Usage: nomad event sink deregister <event sink id>
 
-   Deregister is used to deregister a registered event sink.
+  Deregister is used to deregister a registered event sink.
+
+  When ACLs are enabled, this command requires a management token.
 
 General Options:
 

--- a/command/event_sink_list.go
+++ b/command/event_sink_list.go
@@ -16,7 +16,10 @@ func (c *EventSinkListCommand) Help() string {
 	helpText := `
 Usage: nomad event sink list
 
-    List is used to list event sinks that have been registered.
+  List is used to list event sinks that have been registered.
+
+  When ACLs are enabled, this command requires a token with the
+  'operator:read' capability.
 
 General Options:
 

--- a/command/event_sink_register.go
+++ b/command/event_sink_register.go
@@ -20,8 +20,10 @@ func (c *EventSinkRegisterCommand) Help() string {
 	helpText := `
 Usage: nomad event sink register <path>
 
-   Register is used to register a new event sink. The event sink is
-   sourced from <path> or from stdin if path is "-".
+  Register is used to register a new event sink. The event sink is
+  sourced from <path> or from stdin if path is "-".
+
+  When ACLs are enabled, this command requires a management token.
 
 General Options:
 

--- a/command/job_deployments.go
+++ b/command/job_deployments.go
@@ -19,6 +19,9 @@ Usage: nomad job deployments [options] <job>
 
   Deployments is used to display the deployments for a particular job.
 
+  When ACLs are enabled, this command requires a token with the 'read-job' and
+  'list-jobs' capabilities for the job's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/job_dispatch.go
+++ b/command/job_dispatch.go
@@ -28,6 +28,9 @@ Usage: nomad job dispatch [options] <parameterized job> [input source]
   triggered evaluation will be monitored. This can be disabled by supplying the
   detach flag.
 
+  When ACLs are enabled, this command requires a token with the 'dispatch-job'
+  capability for the job's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/job_eval.go
+++ b/command/job_eval.go
@@ -18,9 +18,13 @@ func (c *JobEvalCommand) Help() string {
 	helpText := `
 Usage: nomad job eval [options] <job_id>
 
-  Force an evaluation of the provided job ID. Forcing an evaluation will trigger the scheduler
-  to re-evaluate the job. The force flags allow operators to force the scheduler to create
-  new allocations under certain scenarios.
+  Force an evaluation of the provided job ID. Forcing an evaluation will
+  trigger the scheduler to re-evaluate the job. The force flags allow
+  operators to force the scheduler to create new allocations under certain
+  scenarios.
+
+  When ACLs are enabled, this command requires a token with the 'submit-job'
+  capability for the job's namespace.
 
 General Options:
 

--- a/command/job_history.go
+++ b/command/job_history.go
@@ -26,6 +26,9 @@ Usage: nomad job history [options] <job>
   the changes that occurred to the job as well as deciding job versions to revert
   to.
 
+  When ACLs are enabled, this command requires a token with the 'read-job' and
+  'list-jobs' capabilities for the job's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/job_inspect.go
+++ b/command/job_inspect.go
@@ -20,6 +20,9 @@ Alias: nomad inspect
 
   Inspect is used to see the specification of a submitted job.
 
+  When ACLs are enabled, this command requires a token with the 'read-job' and
+  'list-jobs' capabilities for the job's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/job_periodic_force.go
+++ b/command/job_periodic_force.go
@@ -20,6 +20,9 @@ Usage: nomad job periodic force <job id>
   This is used to immediately run a periodic job, even if it violates the job's
   prohibit_overlap setting.
 
+  When ACLs are enabled, this command requires a token with the 'submit-job'
+  and 'list-jobs' capabilities for the job's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -63,6 +63,9 @@ Alias: nomad plan
     * 1: Allocations created or destroyed.
     * 255: Error determining plan results.
 
+  When ACLs are enabled, this command requires a token with the 'submit-job'
+  capability for the job's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/job_promote.go
+++ b/command/job_promote.go
@@ -27,6 +27,9 @@ Usage: nomad job promote [options] <job id>
   a new version or failed backwards by reverting to an older version using the
   "nomad job revert" command.
 
+  When ACLs are enabled, this command requires a token with the 'submit-job',
+  'list-jobs', and 'read-job' capabilities for the job's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -21,6 +21,9 @@ Usage: nomad job revert [options] <job> <version>
   Revert is used to revert a job to a prior version of the job. The available
   versions to revert to can be found using "nomad job history" command.
 
+  When ACLs are enabled, this command requires a token with the 'submit-job'
+  and 'list-jobs' capabilities for the job's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -61,6 +61,12 @@ Alias: nomad run
   precedence, going from highest to lowest: the -vault-token flag, the
   $VAULT_TOKEN environment variable and finally the value in the job file.
 
+  When ACLs are enabled, this command requires a token with the 'submit-job'
+  capability for the job's namespace. Jobs that mount CSI volumes require a
+  token with the 'csi-mount-volume' capability for the volume's
+  namespace. Jobs that mount host volumes require a token with the
+  'host_volume' capability for that volume.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/job_scale.go
+++ b/command/job_scale.go
@@ -32,6 +32,9 @@ Usage: nomad job scale [options] <job> [<group>] <count>
   onto nodes. The monitor will end once job placement is done. It
   is safe to exit the monitor early using ctrl+c.
 
+  When ACLs are enabled, this command requires a token with the 'scale-job'
+  capability for the job's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/job_scaling_events.go
+++ b/command/job_scaling_events.go
@@ -27,6 +27,9 @@ Usage: nomad job scaling-events [options] <args>
 
   List the scaling events for the specified job.
 
+  When ACLs are enabled, this command requires a token with the
+  'read-job-scaling' capability for the job's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -33,6 +33,9 @@ Usage: nomad status [options] <job>
   Display status information about a job. If no job ID is given, a list of all
   known jobs will be displayed.
 
+  When ACLs are enabled, this command requires a token with the 'read-job' and
+  'list-jobs' capabilities for the job's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/job_stop.go
+++ b/command/job_stop.go
@@ -18,11 +18,14 @@ func (c *JobStopCommand) Help() string {
 Usage: nomad job stop [options] <job>
 Alias: nomad stop
 
-  Stop an existing job. This command is used to signal allocations
-  to shut down for the given job ID. Upon successful deregistration,
-  an interactive monitor session will start to display log lines as
-  the job unwinds its allocations and completes shutting down. It
-  is safe to exit the monitor early using ctrl+c.
+  Stop an existing job. This command is used to signal allocations to shut
+  down for the given job ID. Upon successful deregistration, an interactive
+  monitor session will start to display log lines as the job unwinds its
+  allocations and completes shutting down. It is safe to exit the monitor
+  early using ctrl+c.
+
+  When ACLs are enabled, this command requires a token with the 'submit-job',
+  'read-job', and 'list-jobs' capabilities for the job's namespace.
 
 General Options:
 

--- a/command/job_validate.go
+++ b/command/job_validate.go
@@ -29,6 +29,9 @@ Alias: nomad validate
   it is read from the file at the supplied path or downloaded and
   read from URL specified.
 
+  When ACLs are enabled, this command requires a token with the 'read-job'
+  capability for the job's namespace.
+
 Validate Options:
 
   -hcl1

--- a/command/license_get.go
+++ b/command/license_get.go
@@ -12,7 +12,11 @@ func (c *LicenseGetCommand) Help() string {
 	helpText := `
 Usage: nomad license get [options]
 
-Gets a new license in Servers and Clients
+  Gets a new license in Servers and Clients
+
+  When ACLs are enabled, this command requires a token with the
+  'operator:read' capability.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)

--- a/command/license_put.go
+++ b/command/license_put.go
@@ -21,7 +21,10 @@ func (c *LicensePutCommand) Help() string {
 	helpText := `
 Usage: nomad license put [options]
 
-Puts a new license in Servers and Clients
+  Puts a new license in Servers and Clients
+
+  When ACLs are enabled, this command requires a token with the
+  'operator:write' capability.
 
 General Options:
 

--- a/command/namespace_apply.go
+++ b/command/namespace_apply.go
@@ -20,6 +20,8 @@ Usage: nomad namespace apply [options] <namespace>
   Apply is used to create or update a namespace. It takes the namespace name to
   create or update as its only argument.
 
+  If ACLs are enabled, this command requires a management ACL token.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/namespace_delete.go
+++ b/command/namespace_delete.go
@@ -17,6 +17,8 @@ Usage: nomad namespace delete [options] <namespace>
 
   Delete is used to remove a namespace.
 
+  If ACLs are enabled, this command requires a management ACL token.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)

--- a/command/namespace_inspect.go
+++ b/command/namespace_inspect.go
@@ -17,6 +17,9 @@ Usage: nomad namespace inspect [options] <namespace>
 
   Inspect is used to view raw information about a particular namespace.
 
+  If ACLs are enabled, this command requires a management ACL token or a token
+  that has a capability associated with the namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/namespace_list.go
+++ b/command/namespace_list.go
@@ -19,6 +19,10 @@ Usage: nomad namespace list [options]
 
   List is used to list available namespaces.
 
+  If ACLs are enabled, this command requires a management ACL token to view
+  all namespaces. A non-management token can be used to list namespaces for
+  which it has an associated capability.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/namespace_status.go
+++ b/command/namespace_status.go
@@ -18,6 +18,9 @@ Usage: nomad namespace status [options] <namespace>
 
   Status is used to view the status of a particular namespace.
 
+  If ACLs are enabled, this command requires a management ACL token or a token
+  that has a capability associated with the namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)

--- a/command/node_config.go
+++ b/command/node_config.go
@@ -29,16 +29,21 @@ General Options:
 Client Config Options:
 
   -servers
-    List the known server addresses of the client node. Client
-    nodes do not participate in the gossip pool, and instead
-    register with these servers periodically over the network.
+    List the known server addresses of the client node. Client nodes do not
+    participate in the gossip pool, and instead register with these servers
+    periodically over the network.
+
+    If ACLs are enabled, this option requires a token with the 'agent:read'
+    capability.
 
   -update-servers
-    Updates the client's server list using the provided
-    arguments. Multiple server addresses may be passed using
-    multiple arguments. IMPORTANT: When updating the servers
-    list, you must specify ALL of the server nodes you wish
-    to configure. The set is updated atomically.
+    Updates the client's server list using the provided arguments. Multiple
+    server addresses may be passed using multiple arguments. IMPORTANT: When
+    updating the servers list, you must specify ALL of the server nodes you
+    wish to configure. The set is updated atomically.
+
+    If ACLs are enabled, this option requires a token with the 'agent:write'
+    capability.
 
     Example:
       $ nomad node config -update-servers foo:4647 bar:4647

--- a/command/node_drain.go
+++ b/command/node_drain.go
@@ -25,9 +25,12 @@ func (c *NodeDrainCommand) Help() string {
 	helpText := `
 Usage: nomad node drain [options] <node>
 
-  Toggles node draining on a specified node. It is required
-  that either -enable or -disable is specified, but not both.
-  The -self flag is useful to drain the local node.
+  Toggles node draining on a specified node. It is required that either
+  -enable or -disable is specified, but not both.  The -self flag is useful to
+  drain the local node.
+
+  If ACLs are enabled, this option requires a token with the 'node:write'
+  capability.
 
 General Options:
 

--- a/command/node_eligibility.go
+++ b/command/node_eligibility.go
@@ -23,6 +23,9 @@ Usage: nomad node eligibility [options] <node>
   It is required that either -enable or -disable is specified, but not both.
   The -self flag is useful to set the scheduling eligibility of the local node.
 
+  If ACLs are enabled, this option requires a token with the 'node:write'
+  capability.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -49,6 +49,9 @@ Usage: nomad node status [options] <node>
   short-hand list of all nodes will be displayed. The -self flag is useful to
   quickly access the status of the local node.
 
+  If ACLs are enabled, this option requires a token with the 'node:read'
+  capability.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/operator_autopilot_get.go
+++ b/command/operator_autopilot_get.go
@@ -64,6 +64,9 @@ Usage: nomad operator autopilot get-config [options]
 
   Displays the current Autopilot configuration.
 
+  If ACLs are enabled, this command requires a token with the 'operator:read'
+  capability.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)

--- a/command/operator_autopilot_set.go
+++ b/command/operator_autopilot_set.go
@@ -110,6 +110,9 @@ Usage: nomad operator autopilot set-config [options]
 
   Modifies the current Autopilot configuration.
 
+  If ACLs are enabled, this command requires a token with the 'operator:write'
+  capability.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -55,6 +55,11 @@ Usage: nomad operator debug [options]
   Build an archive containing Nomad cluster configuration and state, and Consul and Vault
   status. Include logs and pprof profiles for selected servers and client nodes.
 
+  If ACLs are enabled, this command will require a token with the 'node:read'
+  capability to run. In order to collect information, the token will also
+  require the 'agent:read' and 'operator:read' capabilities, as well as the
+  'list-jobs' capability for all namespaces.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/operator_keyring.go
+++ b/command/operator_keyring.go
@@ -31,6 +31,9 @@ Usage: nomad operator keyring [options]
   are no errors. If any node fails to reply or reports failure, the exit code
   will be 1.
 
+  If ACLs are enabled, this command requires a token with the 'agent:write'
+  capability.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/operator_raft_info.go
+++ b/command/operator_raft_info.go
@@ -17,9 +17,11 @@ func (c *OperatorRaftInfoCommand) Help() string {
 Usage: nomad operator raft _info <path to nomad data dir>
 
   Displays info about the raft logs in the data directory.
-  
+
   This is a low-level debugging tool and not subject to Nomad's usual backward
   compatibility guarantees.
+
+  If ACLs are enabled, this command requires a management token.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/operator_raft_list.go
+++ b/command/operator_raft_list.go
@@ -19,6 +19,8 @@ Usage: nomad operator raft list-peers [options]
 
   Displays the current Raft peer configuration.
 
+  If ACLs are enabled, this command requires a management token.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/operator_raft_logs.go
+++ b/command/operator_raft_logs.go
@@ -22,6 +22,8 @@ Usage: nomad operator raft _logs <path to nomad data dir>
 
   This is a low-level debugging tool and not subject to Nomad's usual backward
   compatibility guarantees.
+
+  If ACLs are enabled, this command requires a management token.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/operator_raft_remove.go
+++ b/command/operator_raft_remove.go
@@ -25,6 +25,8 @@ Usage: nomad operator raft remove-peer [options]
   server-members" command, it is preferable to clean up by simply running "nomad
   server-force-leave" instead of this command.
 
+  If ACLs are enabled, this command requires a management token.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/operator_raft_state.go
+++ b/command/operator_raft_state.go
@@ -23,6 +23,8 @@ Usage: nomad operator raft _state <path to nomad data dir>
   This is a low-level debugging tool and not subject to Nomad's usual backward
   compatibility guarantees.
 
+  If ACLs are enabled, this command requires a management token.
+
 Options:
 
   -last-index=<last_index>

--- a/command/plugin_status.go
+++ b/command/plugin_status.go
@@ -21,8 +21,11 @@ func (c *PluginStatusCommand) Help() string {
 	helpText := `
 Usage nomad plugin status [options] <plugin>
 
-    Display status information about a plugin. If no plugin id is given,
-    a list of all plugins will be displayed.
+  Display status information about a plugin. If no plugin id is given,
+  a list of all plugins will be displayed.
+
+  If ACLs are enabled, this command requires a token with the 'plugin:read'
+  capability.
 
 General Options:
 

--- a/command/quota_apply.go
+++ b/command/quota_apply.go
@@ -29,6 +29,9 @@ Usage: nomad quota apply [options] <input>
   will be read from stdin by specifying "-", otherwise a path to the file is
   expected.
 
+  If ACLs are enabled, this command requires a token with the 'quota:write'
+  capability.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/quota_delete.go
+++ b/command/quota_delete.go
@@ -17,6 +17,9 @@ Usage: nomad quota delete [options] <quota>
 
   Delete is used to delete an existing quota specification.
 
+  If ACLs are enabled, this command requires a token with the 'quota:write'
+  capability.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault)

--- a/command/quota_inspect.go
+++ b/command/quota_inspect.go
@@ -24,6 +24,9 @@ Usage: nomad quota inspect [options] <quota>
 
   Inspect is used to view raw information about a particular quota.
 
+  If ACLs are enabled, this command requires a token with the 'quota:read'
+  capability and access to any namespaces that the quota is applied to.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/quota_list.go
+++ b/command/quota_list.go
@@ -19,6 +19,10 @@ Usage: nomad quota list [options]
 
   List is used to list available quota specifications.
 
+  If ACLs are enabled, this command requires a token with the 'quota:read'
+  capability. Any quotas applied to namespaces that the token does not have
+  access to will be filtered from the results.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/quota_status.go
+++ b/command/quota_status.go
@@ -21,6 +21,9 @@ Usage: nomad quota status [options] <quota>
 
   Status is used to view the status of a particular quota specification.
 
+  If ACLs are enabled, this command requires a token with the 'quota:read'
+  capability and access to any namespaces that the quota is applied to.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault)

--- a/command/recommendation_apply.go
+++ b/command/recommendation_apply.go
@@ -25,6 +25,10 @@ Usage: nomad recommendation apply [options] <recommendation_ids>
 
   Apply one or more Nomad recommendations.
 
+  When ACLs are enabled, this command requires a token with the 'submit-job',
+  'read-job', and 'submit-recommendation' capabilities for the
+  recommendation's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/recommendation_dismiss.go
+++ b/command/recommendation_dismiss.go
@@ -46,6 +46,10 @@ Usage: nomad recommendation dismiss [options] <recommendation_ids>
 
   Dismiss one or more Nomad recommendations.
 
+  When ACLs are enabled, this command requires a token with the 'submit-job',
+  'read-job', and 'submit-recommendation' capabilities for the
+  recommendation's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault)

--- a/command/recommendation_info.go
+++ b/command/recommendation_info.go
@@ -24,6 +24,9 @@ Usage: nomad recommendation info [options] <recommendation_id>
 
   Info is used to read the specified recommendation.
 
+  When ACLs are enabled, this command requires a token with the 'read-job'
+  capability for the recommendation's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/recommendation_list.go
+++ b/command/recommendation_list.go
@@ -25,6 +25,10 @@ Usage: nomad recommendation list [options]
 
   List is used to list the available recommendations.
 
+  When ACLs are enabled, this command requires a token with the 'submit-job',
+  'read-job', and 'submit-recommendation' capabilities for the namespace being
+  queried.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/scaling_policy_info.go
+++ b/command/scaling_policy_info.go
@@ -23,6 +23,9 @@ Usage: nomad scaling policy info [options] <policy_id>
 
   Info is used to read the specified scaling policy.
 
+  If ACLs are enabled, this command requires a token with the 'read-job' and
+  'list-jobs' capabilities for the policy's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/scaling_policy_list.go
+++ b/command/scaling_policy_list.go
@@ -25,6 +25,11 @@ Usage: nomad scaling policy list [options]
 
   List is used to list the currently configured scaling policies.
 
+  If ACLs are enabled, this command requires a token with the 'read-job' and
+  'list-jobs' capabilities for the namespace of all policies. Any namespaces
+  that the token does not have access to will have its policies filtered from
+  the results.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/sentinel_apply.go
+++ b/command/sentinel_apply.go
@@ -22,6 +22,9 @@ Usage: nomad sentinel apply [options] <name> <file>
   The name of the policy and file must be specified. The file will be read
   from stdin by specifying "-".
 
+  Sentinel commands are only available when ACLs are enabled. This command
+  requires a management token.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/sentinel_delete.go
+++ b/command/sentinel_delete.go
@@ -17,6 +17,9 @@ Usage: nomad sentinel delete [options] <name>
 
   Delete is used to delete an existing Sentinel policy.
 
+  Sentinel commands are only available when ACLs are enabled. This command
+  requires a management token.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/sentinel_list.go
+++ b/command/sentinel_list.go
@@ -17,6 +17,9 @@ Usage: nomad sentinel list [options]
 
   List is used to display all the installed Sentinel policies.
 
+  Sentinel commands are only available when ACLs are enabled. This command
+  requires a management token.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/sentinel_read.go
+++ b/command/sentinel_read.go
@@ -17,6 +17,9 @@ Usage: nomad sentinel read [options] <name>
 
   Read is used to inspect a Sentinel policy.
 
+  Sentinel commands are only available when ACLs are enabled. This command
+  requires a management token.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/server_force_leave.go
+++ b/command/server_force_leave.go
@@ -20,6 +20,9 @@ Usage: nomad server force-leave [options] <node>
   Note that if the member is actually still alive, it will
   eventually rejoin the cluster again.
 
+  If ACLs are enabled, this option requires a token with the 'agent:write'
+  capability.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)

--- a/command/server_members.go
+++ b/command/server_members.go
@@ -23,6 +23,9 @@ Usage: nomad server members [options]
   Display a list of the known servers and their status. Only Nomad servers are
   able to service this command.
 
+  If ACLs are enabled, this option requires a token with the 'node:read'
+  capability.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/command/system_gc.go
+++ b/command/system_gc.go
@@ -17,6 +17,8 @@ Usage: nomad system gc [options]
 
   Initializes a garbage collection of jobs, evaluations, allocations, and nodes.
 
+  If ACLs are enabled, this option requires a management token.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)

--- a/command/system_reconcile_summaries.go
+++ b/command/system_reconcile_summaries.go
@@ -17,6 +17,8 @@ Usage: nomad system reconcile summaries [options]
 
   Reconciles the summaries of all registered jobs.
 
+  If ACLs are enabled, this option requires a management token.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)

--- a/command/volume_deregister.go
+++ b/command/volume_deregister.go
@@ -18,6 +18,9 @@ Usage: nomad volume deregister [options] <id>
 
   Remove an unused volume from Nomad.
 
+  When ACLs are enabled, this command requires a token with the
+  'csi-write-volume' capability for the volume's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/volume_detach.go
+++ b/command/volume_detach.go
@@ -18,6 +18,10 @@ Usage: nomad volume detach [options] <vol id> <node id>
 
   Detach a volume from a Nomad client.
 
+  When ACLs are enabled, this command requires a token with the
+  'csi-write-volume' and 'csi-read-volume' capabilities for the volume's
+  namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/command/volume_register.go
+++ b/command/volume_register.go
@@ -25,6 +25,9 @@ Usage: nomad volume register [options] <input>
   If the supplied path is "-" the volume file is read from stdin. Otherwise, it
   is read from the file at the supplied path.
 
+  When ACLs are enabled, this command requires a token with the
+  'csi-write-volume' capability for the volume's namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault)

--- a/command/volume_status.go
+++ b/command/volume_status.go
@@ -24,6 +24,10 @@ Usage: nomad volume status [options] <id>
   Display status information about a CSI volume. If no volume id is given, a
   list of all volumes will be displayed.
 
+  When ACLs are enabled, this command requires a token with the
+  'csi-read-volume' and 'csi-list-volumes' capability for the volume's
+  namespace.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `

--- a/website/pages/docs/commands/acl/policy-apply.mdx
+++ b/website/pages/docs/commands/acl/policy-apply.mdx
@@ -19,6 +19,8 @@ nomad acl policy apply [options] <name> <path>
 The `acl policy apply` command requires two arguments, the policy name and path
 to file. The policy can be read from stdin by setting the path to "-".
 
+This command requires a management ACL token.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/acl/policy-delete.mdx
+++ b/website/pages/docs/commands/acl/policy-delete.mdx
@@ -18,6 +18,8 @@ nomad acl policy delete <policy_name>
 
 The `acl policy delete` command requires the policy name as an argument.
 
+This command requires a management ACL token.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/acl/policy-info.mdx
+++ b/website/pages/docs/commands/acl/policy-info.mdx
@@ -20,6 +20,9 @@ nomad acl policy info <name>
 
 The `acl policy info` command requires the policy name.
 
+This command requires a management ACL token or a token that has the
+associated policy.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/acl/policy-list.mdx
+++ b/website/pages/docs/commands/acl/policy-list.mdx
@@ -16,6 +16,9 @@ The `acl policy list` command is used to list available ACL policies.
 nomad acl policy list
 ```
 
+This command requires a management ACL token to view all policies. A
+non-management token can query its own policies.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/agent-info.mdx
+++ b/website/pages/docs/commands/agent-info.mdx
@@ -18,6 +18,9 @@ is connected to. This is useful for troubleshooting and performance monitoring.
 nomad agent-info [options]
 ```
 
+When ACLs are enabled, this command requires a token with the `agent:read`
+capability.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/alloc/exec.mdx
+++ b/website/pages/docs/commands/alloc/exec.mdx
@@ -28,6 +28,12 @@ allocation is only running a single task, the task name can be omitted.
 Optionally, the `-job` option may be used in which case a random allocation from
 the given job will be chosen.
 
+When ACLs are enabled, this command requires a token with the `alloc-exec`,
+`read-job`, and `list-jobs` capabilities for the allocation's namespace. If
+the task driver does not have file system isolation (as with `raw_exec`),
+this command requires the `alloc-node-exec`, `read-job`, and `list-jobs`
+capabilities for the allocation's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/alloc/fs.mdx
+++ b/website/pages/docs/commands/alloc/fs.mdx
@@ -36,6 +36,9 @@ specified, in which case an allocation is chosen from the given job) and a
 path.  The path is optional and relative to the root of the [allocation working
 directory].
 
+When ACLs are enabled, this command requires a token with the `read-fs`,
+`read-job`, and `list-jobs` capabilities for the allocation's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/alloc/logs.mdx
+++ b/website/pages/docs/commands/alloc/logs.mdx
@@ -23,6 +23,9 @@ allocation is only running a single task, the task name can be omitted.
 Optionally, the `-job` option may be used in which case a random allocation from
 the given job will be chosen.
 
+When ACLs are enabled, this command requires a token with the `read-logs`,
+`read-job`, and `list-jobs` capabilities for the allocation's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/alloc/restart.mdx
+++ b/website/pages/docs/commands/alloc/restart.mdx
@@ -21,6 +21,10 @@ This command accepts a single allocation ID and a task name. The task name must
 be part of the allocation and the task must be currently running. The task name
 is optional and if omitted every task in the allocation will be restarted.
 
+When ACLs are enabled, this command requires a token with the
+`alloc-lifecycle`, `read-job`, and `list-jobs` capabilities for the
+allocation's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/alloc/signal.mdx
+++ b/website/pages/docs/commands/alloc/signal.mdx
@@ -21,6 +21,10 @@ This command accepts a single allocation ID and a task name. The task name must
 be part of the allocation and the task must be currently running. The task name
 is optional and if omitted every task in the allocation will be signaled.
 
+When ACLs are enabled, this command requires a token with the
+`alloc-lifecycle`, `read-job`, and `list-jobs` capabilities for the
+allocation's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/alloc/status.mdx
+++ b/website/pages/docs/commands/alloc/status.mdx
@@ -27,6 +27,9 @@ An allocation ID or prefix must be provided. If there is an exact match, the
 full details of the allocation will be displayed. Otherwise, a list of matching
 allocations and information will be displayed.
 
+When ACLs are enabled, this command requires a token with the `read-job` and
+`list-jobs` capabilities for the allocation's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/alloc/stop.mdx
+++ b/website/pages/docs/commands/alloc/stop.mdx
@@ -26,6 +26,10 @@ Stop will issue a request to stop and reschedule the allocation. An interactive
 monitoring session will display log lines as the allocation completes shutting
 down. It is safe to exit the monitor early with ctrl-c.
 
+When ACLs are enabled, this command requires a token with the
+`alloc-lifecycle`, `read-job`, and `list-jobs` capabilities for the
+allocation's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/deployment/fail.mdx
+++ b/website/pages/docs/commands/deployment/fail.mdx
@@ -22,6 +22,9 @@ nomad deployment fail [options] <deployment id>
 The `deployment fail` command requires a single argument, a deployment ID or
 prefix.
 
+When ACLs are enabled, this command requires a token with the `submit-job`
+and `read-job` capabilities for the deployment's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/deployment/list.mdx
+++ b/website/pages/docs/commands/deployment/list.mdx
@@ -18,6 +18,9 @@ nomad deployment list [options]
 
 The `deployment list` command requires no arguments.
 
+When ACLs are enabled, this command requires a token with the 'read-job'
+capability for the deployment's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/deployment/pause.mdx
+++ b/website/pages/docs/commands/deployment/pause.mdx
@@ -22,6 +22,9 @@ nomad deployment pause [options] <deployment id>
 The `deployment pause` command requires a single argument, a deployment ID or
 prefix.
 
+When ACLs are enabled, this command requires a token with the `submit-job`
+and `read-job` capabilities for the deployment's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/deployment/promote.mdx
+++ b/website/pages/docs/commands/deployment/promote.mdx
@@ -28,6 +28,9 @@ prefix. When run without specifying any groups to promote, the promote command
 promotes all task groups. The group flag can be specified multiple times to
 select particular groups to promote.
 
+When ACLs are enabled, this command requires a token with the `submit-job`
+and `read-job` capabilities for the deployment's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/deployment/resume.mdx
+++ b/website/pages/docs/commands/deployment/resume.mdx
@@ -21,6 +21,9 @@ nomad deployment resume [options] <deployment id>
 The `deployment resume` command requires a single argument, a deployment ID or
 prefix.
 
+When ACLs are enabled, this command requires a token with the `submit-job`
+and `read-job` capabilities for the deployment's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/deployment/status.mdx
+++ b/website/pages/docs/commands/deployment/status.mdx
@@ -21,6 +21,9 @@ nomad deployment status [options] <deployment id>
 The `deployment status` command requires a single argument, a deployment ID or
 prefix.
 
+When ACLs are enabled, this command requires a token with the 'read-job'
+capability for the deployment's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/deployment/unblock.mdx
+++ b/website/pages/docs/commands/deployment/unblock.mdx
@@ -24,6 +24,9 @@ nomad deployment unblock [options] <deployment id>
 The `deployment unblock` command requires a single argument, a deployment ID or
 prefix.
 
+When ACLs are enabled, this command requires a token with the `submit-job`
+and `read-job` capabilities for the deployment's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/event/sink-deregister.mdx
+++ b/website/pages/docs/commands/event/sink-deregister.mdx
@@ -21,6 +21,8 @@ nomad event sink deregister <id>
 The `event sink deregister` command requires a single argument, the event sink
 ID.
 
+When ACLs are enabled, this command requires a management token.
+
 ## General Options
 
 @include 'general_options.mdx'
@@ -33,4 +35,3 @@ Deregister an event sink:
 $ nomad event sink deregister job-webhook
 Successfully deregistered "job-webhook" event sink!
 ```
-

--- a/website/pages/docs/commands/event/sink-list.mdx
+++ b/website/pages/docs/commands/event/sink-list.mdx
@@ -16,6 +16,9 @@ The `event sink list` command is used to list all registered event sinks.
 nomad event sink list
 ```
 
+When ACLs are enabled, this command requires a token with the `operator:read`
+capability.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/event/sink-register.mdx
+++ b/website/pages/docs/commands/event/sink-register.mdx
@@ -22,6 +22,8 @@ The `event sink register` command requires a single argument, a path to a file
 with the JSON configuration for an event sink. "-" can be given as the path to
 provide the configuration via stdin.
 
+When ACLs are enabled, this command requires a management token.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/job/deployments.mdx
+++ b/website/pages/docs/commands/job/deployments.mdx
@@ -20,6 +20,9 @@ nomad job deployments [options] <job>
 The `job deployments` command requires a single argument, the job ID or an ID
 prefix of a job to display the list of deployments for.
 
+When ACLs are enabled, this command requires a token with the `read-job` and
+`list-jobs` capabilities for the job's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/job/dispatch.mdx
+++ b/website/pages/docs/commands/job/dispatch.mdx
@@ -40,6 +40,9 @@ there are job placement issues encountered (unsatisfiable constraints, resource
 exhaustion, etc), then the exit code will be 2. Any other errors, including
 client connection issues or internal errors, are indicated by exit code 1.
 
+When ACLs are enabled, this command requires a token with the `dispatch-job`
+capability for the job's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/job/eval.mdx
+++ b/website/pages/docs/commands/job/eval.mdx
@@ -21,6 +21,9 @@ The `job eval` command requires a single argument, specifying the job ID to
 evaluate. If there is an exact match based on the provided job ID, then the job
 will be evaluated, forcing a scheduler run.
 
+When ACLs are enabled, this command requires a token with the `submit-job`
+capability for the job's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/job/history.mdx
+++ b/website/pages/docs/commands/job/history.mdx
@@ -22,6 +22,9 @@ nomad job history [options] <job>
 The `job history` command requires a single argument, the job ID or an ID prefix
 of a job to display the history for.
 
+When ACLs are enabled, this command requires a token with the `read-job` and
+`list-jobs` capabilities for the job's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/job/inspect.mdx
+++ b/website/pages/docs/commands/job/inspect.mdx
@@ -23,6 +23,9 @@ will retrieve the JSON version of the job. This JSON is valid to be submitted to
 the [Job HTTP API]. This command is useful to inspect what version of a job
 Nomad is running.
 
+When ACLs are enabled, this command requires a token with the `read-job` and
+`list-jobs` capabilities for the job's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/job/periodic-force.mdx
+++ b/website/pages/docs/commands/job/periodic-force.mdx
@@ -27,6 +27,9 @@ monitor and display log information detailing the scheduling decisions and
 placement information for the forced evaluation. The monitor will exit after
 scheduling has finished or failed.
 
+When ACLs are enabled, this command requires a token with the `submit-job`
+and `list-jobs` capabilities for the job's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/job/plan.mdx
+++ b/website/pages/docs/commands/job/plan.mdx
@@ -49,6 +49,9 @@ Plan will return one of the following exit codes:
 - 1: Allocations created or destroyed.
 - 255: Error determining plan results.
 
+When ACLs are enabled, this command requires a token with the `submit-job`
+capability for the job's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/job/promote.mdx
+++ b/website/pages/docs/commands/job/promote.mdx
@@ -28,6 +28,9 @@ prefix. When run without specifying any groups to promote, the promote command
 promotes all task groups. The group flag can be specified multiple times to
 select particular groups to promote.
 
+When ACLs are enabled, this command requires a token with the `submit-job`,
+`list-jobs`, and `read-job` capabilities for the job's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/job/revert.mdx
+++ b/website/pages/docs/commands/job/revert.mdx
@@ -35,6 +35,9 @@ nomad job revert [options] <job> <version>
 The `job revert` command requires two inputs, the job ID and the version of that
 job to revert to.
 
+When ACLs are enabled, this command requires a token with the `submit-job`
+and `list-jobs` capabilities for the job's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/job/run.mdx
+++ b/website/pages/docs/commands/job/run.mdx
@@ -47,6 +47,12 @@ The run command will set the `vault_token` of the job based on the following
 precedence, going from highest to lowest: the `-vault-token` flag, the
 `$VAULT_TOKEN` environment variable and finally the value in the job file.
 
+When ACLs are enabled, this command requires a token with the `submit-job`
+capability for the job's namespace. Jobs that mount CSI volumes require a
+token with the `csi-mount-volume` capability for the volume's namespace. Jobs
+that mount host volumes require a token with the `host_volume` capability for
+that volume.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/job/scale.mdx
+++ b/website/pages/docs/commands/job/scale.mdx
@@ -29,6 +29,9 @@ Scale will issue a request to update the matched job and then invoke an interact
 monitor that exits automatically once the scheduler has processed the request.
 It is safe to exit the monitor early using ctrl+c.
 
+When ACLs are enabled, this command requires a token with the `scale-job`
+capability for the job's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/job/scaling-events.mdx
+++ b/website/pages/docs/commands/job/scaling-events.mdx
@@ -20,6 +20,9 @@ nomad job scaling-events [options] <job>
 The `job scaling-events` command requires a single argument, a submitted job's
 ID, and will output the stored scaling events for the job if there are any.
 
+When ACLs are enabled, this command requires a token with the
+`read-job-scaling` capability for the job's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/job/status.mdx
+++ b/website/pages/docs/commands/job/status.mdx
@@ -27,6 +27,9 @@ shows allocation modification time in addition to create time. When the
 `-verbose` flag is not set, allocation creation and modify times are shown in a
 shortened relative time format like `5m ago`.
 
+When ACLs are enabled, this command requires a token with the `read-job` and
+`list-jobs` capabilities for the job's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/job/stop.mdx
+++ b/website/pages/docs/commands/job/stop.mdx
@@ -28,6 +28,9 @@ Stop will issue a request to deregister the matched job and then invoke an
 interactive monitor that exits automatically once the scheduler has processed
 the request. It is safe to exit the monitor early using ctrl+c.
 
+When ACLs are enabled, this command requires a token with the `submit-job`,
+`read-job`, and `list-jobs` capabilities for the job's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/job/validate.mdx
+++ b/website/pages/docs/commands/job/validate.mdx
@@ -30,6 +30,9 @@ supports `go-getter` syntax.
 On successful validation, exit code 0 will be returned, otherwise an exit code
 of 1 indicates an error.
 
+When ACLs are enabled, this command requires a token with the `read-job`
+capability for the job's namespace.
+
 ## Examples
 
 Validate a job with invalid syntax:

--- a/website/pages/docs/commands/license/get.mdx
+++ b/website/pages/docs/commands/license/get.mdx
@@ -19,6 +19,9 @@ Enterprise.
 nomad license get [options]
 ```
 
+When ACLs are enabled, this command requires a token with the 'operator:read'
+capability.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/license/put.mdx
+++ b/website/pages/docs/commands/license/put.mdx
@@ -19,6 +19,9 @@ Enterprise.
 nomad license put
 ```
 
+When ACLs are enabled, this command requires a token with the 'operator:write'
+capability.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/monitor.mdx
+++ b/website/pages/docs/commands/monitor.mdx
@@ -25,6 +25,9 @@ the agent at a relatively high log level (such as "warn"),
 but still access debug logs and watch the debug logs if necessary.
 The monitor command also allows you to specify a single client node id to follow.
 
+When ACLs are enabled, this command requires a token with the `agent:read`
+capability.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/namespace/apply.mdx
+++ b/website/pages/docs/commands/namespace/apply.mdx
@@ -22,6 +22,8 @@ nomad namespace apply [options] <namespace>
 The `namespace apply` command requires the name of the namespace to be created
 or updated.
 
+If ACLs are enabled, this command requires a management ACL token.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/namespace/delete.mdx
+++ b/website/pages/docs/commands/namespace/delete.mdx
@@ -21,6 +21,8 @@ nomad namespace delete [options] <namespace>
 
 The `namespace delete` command requires the name of the namespace to be deleted.
 
+If ACLs are enabled, this command requires a management ACL token.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/namespace/inspect.mdx
+++ b/website/pages/docs/commands/namespace/inspect.mdx
@@ -21,6 +21,9 @@ namespace.
 nomad namespace inspect [options] <namespace_name>
 ```
 
+If ACLs are enabled, this command requires a management ACL token or a token
+that has a capability associated with the namespace.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/namespace/list.mdx
+++ b/website/pages/docs/commands/namespace/list.mdx
@@ -21,6 +21,10 @@ nomad namespace list [options]
 
 The `namespace list` command requires no arguments.
 
+If ACLs are enabled, this command requires a management ACL token to view all
+namespaces. A non-management token can be used to list namespaces for which it
+has an associated capability.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/namespace/status.mdx
+++ b/website/pages/docs/commands/namespace/status.mdx
@@ -21,6 +21,9 @@ namespace.
 nomad namespace status [options] <namespace_name>
 ```
 
+If ACLs are enabled, this command requires a management ACL token or a token
+that has a capability associated with the namespace.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/node/config.mdx
+++ b/website/pages/docs/commands/node/config.mdx
@@ -32,12 +32,18 @@ description below for specific usage information and requirements.
   the network. The initial value of this list may come from configuration files
   using the [`servers`] configuration option in the client block.
 
+  If ACLs are enabled, this option requires a token with the 'agent:read'
+  capability.
+
 - `-update-servers`: Updates the client's server list using the provided
   arguments. Multiple server addresses may be passed using multiple arguments.
   When updating the servers list, you must specify ALL of the server nodes you
   wish to configure. The set is updated atomically. It is an error to specify
   this flag without any server addresses. If you do _not_ specify a port for each
   server address, the default port `4647` will be used.
+
+  If ACLs are enabled, this option requires a token with the 'agent:write'
+  capability.
 
 ## Examples
 

--- a/website/pages/docs/commands/node/drain.mdx
+++ b/website/pages/docs/commands/node/drain.mdx
@@ -44,6 +44,9 @@ information will be displayed.
 It is also required to pass one of `-enable` or `-disable`, depending on which
 operation is desired.
 
+If ACLs are enabled, this option requires a token with the 'node:write'
+capability.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/node/eligibility.mdx
+++ b/website/pages/docs/commands/node/eligibility.mdx
@@ -40,6 +40,9 @@ nodes and information will be displayed.
 It is also required to pass one of `-enable` or `-disable`, depending on which
 operation is desired.
 
+If ACLs are enabled, this option requires a token with the 'node:write'
+capability.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/node/status.mdx
+++ b/website/pages/docs/commands/node/status.mdx
@@ -28,6 +28,9 @@ including resource usage statistics. Otherwise, a list of matching nodes and
 information will be displayed. If running the command on a Nomad Client, the
 `-self` flag is useful to quickly access the status of the local node.
 
+If ACLs are enabled, this option requires a token with the 'node:read'
+capability.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/operator/autopilot-get-config.mdx
+++ b/website/pages/docs/commands/operator/autopilot-get-config.mdx
@@ -17,6 +17,9 @@ configuration. See the [Autopilot Guide] for more information about Autopilot.
 nomad operator autopilot get-config [options]
 ```
 
+If ACLs are enabled, this command requires a token with the `operator:read`
+capability.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/operator/autopilot-set-config.mdx
+++ b/website/pages/docs/commands/operator/autopilot-set-config.mdx
@@ -17,6 +17,9 @@ configuration. See the [Autopilot Guide] for more information about Autopilot.
 nomad operator autopilot set-config [options]
 ```
 
+If ACLs are enabled, this command requires a token with the `operator:write`
+capability.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/operator/debug.mdx
+++ b/website/pages/docs/commands/operator/debug.mdx
@@ -35,6 +35,11 @@ creates a compressed tar archive in the current directory.
 Consul and Vault status and version information are included if
 configured.
 
+If ACLs are enabled, this command will require a token with the 'node:read'
+capability to run. In order to collect information, the token will also
+require the 'agent:read' and 'operator:read' capabilities, as well as the
+'list-jobs' capability for all namespaces.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/operator/keyring.mdx
+++ b/website/pages/docs/commands/operator/keyring.mdx
@@ -24,6 +24,9 @@ All variations of the `keyring` command return 0 if all nodes reply and there
 are no errors. If any node fails to reply or reports failure, the exit code
 will be 1.
 
+If ACLs are enabled, this command requires a token with the `agent:write`
+capability.
+
 ## Usage
 
 ```plaintext

--- a/website/pages/docs/commands/operator/raft-list-peers.mdx
+++ b/website/pages/docs/commands/operator/raft-list-peers.mdx
@@ -21,6 +21,8 @@ documentation for the [Operator] endpoint.
 nomad operator raft list-peers [options]
 ```
 
+If ACLs are enabled, this command requires a management token.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/operator/raft-remove-peer.mdx
+++ b/website/pages/docs/commands/operator/raft-remove-peer.mdx
@@ -27,6 +27,8 @@ documentation for the [Operator] endpoint.
 nomad operator raft remove-peer [options]
 ```
 
+If ACLs are enabled, this command requires a management token.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/plugin/status.mdx
+++ b/website/pages/docs/commands/plugin/status.mdx
@@ -25,6 +25,9 @@ and information will be displayed.
 If the ID is omitted, the command lists out all of the existing plugins and a few
 of the most useful status fields for each.
 
+If ACLs are enabled, this command requires a token with the `plugin:read`
+capability.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/quota/apply.mdx
+++ b/website/pages/docs/commands/quota/apply.mdx
@@ -22,6 +22,9 @@ nomad quota apply [options] <path>
 The `quota apply` command requires the path to the specification file. The
 specification can be read from stdin by setting the path to "-".
 
+If ACLs are enabled, this command requires a token with the `quota:write`
+capability.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/quota/delete.mdx
+++ b/website/pages/docs/commands/quota/delete.mdx
@@ -21,6 +21,9 @@ nomad quota delete <quota_name>
 
 The `quota delete` command requires the quota specification name as an argument.
 
+If ACLs are enabled, this command requires a token with the `quota:write`
+capability.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/quota/inspect.mdx
+++ b/website/pages/docs/commands/quota/inspect.mdx
@@ -21,6 +21,9 @@ Enterprise.
 nomad quota inspect [options] <quota_name>
 ```
 
+If ACLs are enabled, this command requires a token with the `quota:read`
+capability and access to any namespaces that the quota is applied to.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/quota/list.mdx
+++ b/website/pages/docs/commands/quota/list.mdx
@@ -19,6 +19,10 @@ Enterprise.
 nomad quota list
 ```
 
+If ACLs are enabled, this command requires a token with the `quota:read`
+capability. Any quotas applied to namespaces that the token does not have
+access to will be filtered from the results.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/quota/status.mdx
+++ b/website/pages/docs/commands/quota/status.mdx
@@ -21,6 +21,9 @@ Enterprise.
 nomad quota status [options] <quota_name>
 ```
 
+If ACLs are enabled, this command requires a token with the `quota:read`
+capability and access to any namespaces that the quota is applied to.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/recommendation/apply.mdx
+++ b/website/pages/docs/commands/recommendation/apply.mdx
@@ -23,6 +23,10 @@ The `recommendation apply` command requires at least one recommendation ID to
 be passed to it. Multiple IDs can be passed, with each recommendation ID
 separated from the next by a space.
 
+When ACLs are enabled, this command requires a token with the `submit-job`,
+`read-job`, and `submit-recommendation` capabilities for the recommendation's
+namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/recommendation/dismiss.mdx
+++ b/website/pages/docs/commands/recommendation/dismiss.mdx
@@ -23,6 +23,10 @@ The `recommendation dismiss` command requires at least one recommendation ID
 to be passed to it. Multiple IDs can be passed, with each recommendation ID
 separated from the next by a space.
 
+When ACLs are enabled, this command requires a token with the `submit-job`,
+`read-job`, and `submit-recommendation` capabilities for the recommendation's
+namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/recommendation/info.mdx
+++ b/website/pages/docs/commands/recommendation/info.mdx
@@ -21,6 +21,9 @@ nomad recommendation info [options] <recommendation_id>
 
 The `recommendation info` command requires a single argument, a recommendation ID.
 
+When ACLs are enabled, this command requires a token with the `read-job`
+capability for the recommendation's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/recommendation/list.mdx
+++ b/website/pages/docs/commands/recommendation/list.mdx
@@ -21,6 +21,10 @@ nomad recommendation list [options]
 
 The `recommendation list` command requires no arguments.
 
+When ACLs are enabled, this command requires a token with the `submit-job`,
+`read-job`, and `submit-recommendation` capabilities for the namespace being
+queried.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/scaling/policy-info.mdx
+++ b/website/pages/docs/commands/scaling/policy-info.mdx
@@ -16,6 +16,9 @@ Info is used to return detailed information on the specified scaling policy.
 nomad scaling policy info [options] <policy_id>
 ```
 
+If ACLs are enabled, this command requires a token with the `read-job` and
+`list-jobs` capabilities for the policy's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/scaling/policy-list.mdx
+++ b/website/pages/docs/commands/scaling/policy-list.mdx
@@ -16,6 +16,11 @@ List is used to list all scaling policies stored in Nomad.
 nomad scaling policy list [options]
 ```
 
+If ACLs are enabled, this command requires a token with the `read-job` and
+`list-jobs` capabilities for the namespace of all policies. Any namespaces
+that the token does not have access to will have its policies filtered from
+the results.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/sentinel/apply.mdx
+++ b/website/pages/docs/commands/sentinel/apply.mdx
@@ -25,6 +25,9 @@ The `sentinel apply` command requires two arguments, the policy name and the
 policy file. The policy file can be read from stdin by specifying "-" as the
 file name.
 
+Sentinel commands are only available when ACLs are enabled. This command
+requires a management token.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/sentinel/delete.mdx
+++ b/website/pages/docs/commands/sentinel/delete.mdx
@@ -21,6 +21,9 @@ nomad sentinel delete [options] <Policy Name>
 
 The `sentinel delete` command requires a single argument, the policy name.
 
+Sentinel commands are only available when ACLs are enabled. This command
+requires a management token.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/sentinel/list.mdx
+++ b/website/pages/docs/commands/sentinel/list.mdx
@@ -22,6 +22,9 @@ nomad sentinel list [options]
 
 The `sentinel list` command requires no arguments.
 
+Sentinel commands are only available when ACLs are enabled. This command
+requires a management token.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/sentinel/read.mdx
+++ b/website/pages/docs/commands/sentinel/read.mdx
@@ -21,6 +21,9 @@ nomad sentinel read [options] <Policy Name>
 
 The `sentinel read` command requires a single argument, the policy name.
 
+Sentinel commands are only available when ACLs are enabled. This command
+requires a management token.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/server/force-leave.mdx
+++ b/website/pages/docs/commands/server/force-leave.mdx
@@ -23,6 +23,9 @@ nomad server force-leave [options] <node>
 This command expects only one argument - the node which should be forced
 to enter the "left" state.
 
+If ACLs are enabled, this option requires a token with the `agent:write`
+capability.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/server/members.mdx
+++ b/website/pages/docs/commands/server/members.mdx
@@ -19,6 +19,9 @@ which is only run on server nodes.
 nomad server members [options]
 ```
 
+If ACLs are enabled, this option requires a token with the `node:read`
+capability.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/system/gc.mdx
+++ b/website/pages/docs/commands/system/gc.mdx
@@ -17,6 +17,8 @@ This is an asynchronous operation.
 nomad system gc [options]
 ```
 
+If ACLs are enabled, this option requires a management token.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/system/reconcile-summaries.mdx
+++ b/website/pages/docs/commands/system/reconcile-summaries.mdx
@@ -16,6 +16,8 @@ Reconciles the summaries of all registered jobs.
 nomad system reconcile summaries [options]
 ```
 
+If ACLs are enabled, this option requires a management token.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'

--- a/website/pages/docs/commands/volume/deregister.mdx
+++ b/website/pages/docs/commands/volume/deregister.mdx
@@ -24,6 +24,9 @@ the ID of volume to be deregistered. Deregistration will fail if the
 volume is still in use by an allocation or in the process of being
 unpublished.
 
+When ACLs are enabled, this command requires a token with the
+`csi-write-volume` capability for the volume's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/volume/detach.mdx
+++ b/website/pages/docs/commands/volume/detach.mdx
@@ -25,6 +25,10 @@ Note that you can use a node ID prefix just as you can with other Nomad
 commands, but if the node has been garbage collected, you may need to pass the
 full node ID.
 
+When ACLs are enabled, this command requires a token with the
+`csi-write-volume` and `csi-read-volume` capabilities for the volume's
+namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/volume/register.mdx
+++ b/website/pages/docs/commands/volume/register.mdx
@@ -26,6 +26,9 @@ job will be submitted to Nomad for scheduling. If the supplied path is
 "-", the job file is read from STDIN. Otherwise it is read from the
 file at the supplied path.
 
+When ACLs are enabled, this command requires a token with the
+`csi-write-volume` capability for the volume's namespace.
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/pages/docs/commands/volume/status.mdx
+++ b/website/pages/docs/commands/volume/status.mdx
@@ -25,6 +25,10 @@ and information will be displayed.
 If the ID is omitted, the command lists out all of the existing volumes and a few
 of the most useful status fields for each.
 
+When ACLs are enabled, this command requires a token with the
+`csi-read-volume` and `csi-list-volumes` capability for the volume's
+namespace.
+
 ## General Options
 
 @include 'general_options.mdx'


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/7475

I think some kind of table that maps from ACLs to commands might be useful as well (under the new Operations header), but I wasn't able to make that legible. We can do that in future documentation work.

Website preview: https://nomad-rhxcqvgd6.vercel.app/docs