### PR TITLE
docs: move agent lifecycle doc under Operations heading

### DIFF
--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -14,7 +14,6 @@ export default [
         category: 'production',
         content: [
           'requirements',
-          'nomad-agent',
           {
             title: 'Reference Architecture',
             href:
@@ -283,6 +282,7 @@ export default [
   {
     category: 'operations',
     content: [
+      'nomad-agent',
       'telemetry',
       'metrics',
       {

--- a/website/pages/docs/operations/index.mdx
+++ b/website/pages/docs/operations/index.mdx
@@ -12,6 +12,7 @@ learn more, choose an item from the sidebar, or choose one of the options
 below:
 
 
+- [Operating Nomad Agents](/docs/operations/nomad-agent)
 - [Telemetry Overview](/docs/operations/telemetry)
 - [Metrics](/docs/operations/metrics)
 - [Cluster Management](https://learn.hashicorp.com/collections/nomad/manage-clusters)

--- a/website/pages/docs/operations/nomad-agent.mdx
+++ b/website/pages/docs/operations/nomad-agent.mdx
@@ -1,13 +1,13 @@
 ---
 layout: docs
 page_title: Nomad Agent
-sidebar_title: Set Server & Client Nodes
+sidebar_title: Operating Nomad Agents
 description: |-
   The Nomad agent is a long running process which can be used either in
   a client or server mode.
 ---
 
-# Setting Nodes with Nomad Agent
+# Operating Nomad Agents
 
 The Nomad agent is a long running process which runs on every machine that
 is part of the Nomad cluster. The behavior of the agent depends on if it is

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -810,10 +810,16 @@ module.exports = [
     destination: '/docs/operations/telemetry',
     permanent: true,
   },
-
   {
     source: '/docs/telemetry/metrics',
     destination: '/docs/operations/metrics',
+    permanent: true,
+  },
+
+  // Moved installing agent under operations as ope
+  {
+    source: '/docs/install/production/nomad-agent',
+    destination: '/docs/operations/nomad-agent',
     permanent: true,
   },
 


### PR DESCRIPTION
As suggested in https://github.com/hashicorp/nomad/pull/9395#issuecomment-730547191

Website preview: https://nomad-edohxyewc.vercel.app/docs/operations/nomad-agent