### PR TITLE
docs: add missing command documentation

### DIFF
--- a/command/metrics.go
+++ b/command/metrics.go
@@ -17,6 +17,7 @@ func (c *OperatorMetricsCommand) Help() string {
 Usage: nomad operator metrics [options]
 
 Get Nomad metrics
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -159,6 +159,7 @@ export default [
           'debug',
           'keygen',
           'keyring',
+          'metrics',
           'raft-list-peers',
           'raft-remove-peer',
           'snapshot-agent',

--- a/website/pages/docs/commands/operator/keyring.mdx
+++ b/website/pages/docs/commands/operator/keyring.mdx
@@ -36,6 +36,10 @@ nomad operator keyring [options]
 Only one actionable argument may be specified per run, including `-list`,
 `-install`, `-remove`, and `-use`.
 
+## General Options
+
+@include 'general_options_no_namespace.mdx'
+
 The list of available flags are:
 
 - `-list` - List all keys currently in use within the cluster.

--- a/website/pages/docs/commands/operator/metrics.mdx
+++ b/website/pages/docs/commands/operator/metrics.mdx
@@ -1,0 +1,96 @@
+---
+layout: docs
+page_title: 'Commands: operator metrics'
+sidebar_title: metrics
+---
+
+# Command: operator metrics
+
+The `operator metrics` command queries the [metrics API endpoint](/api-docs/metrics).
+
+## Usage
+
+```plaintext
+nomad operator metrics [options]
+```
+
+## General Options
+
+@include 'general_options_no_namespace.mdx'
+
+Metrics Specific Options
+
+  -pretty
+    Pretty prints the JSON output
+
+  -format <format>
+    Specify output format (prometheus)
+
+  -json
+    Output the allocation in its JSON format.
+
+  -t
+    Format and display allocation using a Go template.
+
+## Output
+
+The output of `nomad operator metrics` is a JSON representation of the
+[metrics API endpoint](/api-docs/metrics).
+
+```shell-session
+$ nomad operator metrics -pretty
+{
+  "Counters": [
+    {
+      "Count": 11,
+      "Labels": {},
+      "Max": 1.0,
+      "Mean": 1.0,
+      "Min": 1.0,
+      "Name": "nomad.nomad.rpc.query",
+      "Stddev": 0.0,
+      "Sum": 11.0
+    }
+  ],
+  "Gauges": [
+    {
+      "Labels": {
+        "node_id": "cd7c3e0c-0174-29dd-17ba-ea4609e0fd1f",
+        "datacenter": "dc1"
+      },
+      "Name": "nomad.client.allocations.blocked",
+      "Value": 0.0
+    },
+    {
+      "Labels": {
+        "datacenter": "dc1",
+        "node_id": "cd7c3e0c-0174-29dd-17ba-ea4609e0fd1f"
+      },
+      "Name": "nomad.client.allocations.migrating",
+      "Value": 0.0
+    }
+  ],
+  "Samples": [
+    {
+      "Count": 20,
+      "Labels": {},
+      "Max": 0.03544100001454353,
+      "Mean": 0.023678050097078084,
+      "Min": 0.00956599973142147,
+      "Name": "nomad.memberlist.gossip",
+      "Stddev": 0.005445327799243976,
+      "Sum": 0.4735610019415617
+    },
+    {
+      "Count": 1,
+      "Labels": {},
+      "Max": 0.0964059978723526,
+      "Mean": 0.0964059978723526,
+      "Min": 0.0964059978723526,
+      "Name": "nomad.nomad.client.update_status",
+      "Stddev": 0.0,
+      "Sum": 0.0964059978723526
+    }
+  ]
+}
+```

--- a/website/pages/docs/commands/operator/metrics.mdx
+++ b/website/pages/docs/commands/operator/metrics.mdx
@@ -18,19 +18,12 @@ nomad operator metrics [options]
 
 @include 'general_options_no_namespace.mdx'
 
-Metrics Specific Options
+## Metrics Specific Options
 
-  -pretty
-    Pretty prints the JSON output
-
-  -format <format>
-    Specify output format (prometheus)
-
-  -json
-    Output the allocation in its JSON format.
-
-  -t
-    Format and display allocation using a Go template.
+- `-pretty`: Pretty prints the JSON output
+- `-format <format>`: Specify output format (`prometheus`)
+- `-json`: Output the allocation in its JSON format.
+- `-t`: Format and display allocation using a Go template.
 
 ## Output
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9404 and https://github.com/hashicorp/nomad/issues/9403

* `nomad operator keyring` was missing the general options section
* `nomad operator metrics` was missing a page in the docs entirely