### PR TITLE
csi/ui: show Node Only for volumes when controllers aren't required

### DIFF
--- a/ui/app/templates/csi/plugins/index.hbs
+++ b/ui/app/templates/csi/plugins/index.hbs
@@ -47,10 +47,10 @@
                   ({{row.model.controllersHealthy}}/{{row.model.controllersExpected}})
                 {{else}}
                   {{#if (gt row.model.controllersExpected 0)}}
-                  {{if (gt row.model.controllersHealthy 0) "Healthy" "Unhealthy"}}
-                  ({{row.model.controllersHealthy}}/{{row.model.controllersExpected}})
+                    {{if (gt row.model.controllersHealthy 0) "Healthy" "Unhealthy"}}
+                    ({{row.model.controllersHealthy}}/{{row.model.controllersExpected}})
                   {{else}}
-                  <em class="is-faded">Node Only</em>
+                    <em class="is-faded">Node Only</em>
                   {{/if}}
                 {{/if}}
               </td>

--- a/ui/app/templates/csi/plugins/index.hbs
+++ b/ui/app/templates/csi/plugins/index.hbs
@@ -46,7 +46,12 @@
                   {{if (gt row.model.controllersHealthy 0) "Healthy" "Unhealthy"}}
                   ({{row.model.controllersHealthy}}/{{row.model.controllersExpected}})
                 {{else}}
+                  {{#if (gt row.model.controllersExpected 0)}}
+                  {{if (gt row.model.controllersHealthy 0) "Healthy" "Unhealthy"}}
+                  ({{row.model.controllersHealthy}}/{{row.model.controllersExpected}})
+                  {{else}}
                   <em class="is-faded">Node Only</em>
+                  {{/if}}
                 {{/if}}
               </td>
               <td data-test-plugin-node-health>

--- a/ui/app/templates/csi/volumes/index.hbs
+++ b/ui/app/templates/csi/volumes/index.hbs
@@ -50,10 +50,10 @@
                   ({{row.model.controllersHealthy}}/{{row.model.controllersExpected}})
                 {{else}}
                   {{#if (gt row.model.controllersExpected 0)}}
-                  {{if (gt row.model.controllersHealthy 0) "Healthy" "Unhealthy"}}
-                  ({{row.model.controllersHealthy}}/{{row.model.controllersExpected}})
+                    {{if (gt row.model.controllersHealthy 0) "Healthy" "Unhealthy"}}
+                    ({{row.model.controllersHealthy}}/{{row.model.controllersExpected}})
                   {{else}}
-                  <em class="is-faded">Node Only</em>
+                    <em class="is-faded">Node Only</em>
                   {{/if}}
                 {{/if}}
               </td>

--- a/ui/app/templates/csi/volumes/index.hbs
+++ b/ui/app/templates/csi/volumes/index.hbs
@@ -45,8 +45,17 @@
               </td>
               <td data-test-volume-schedulable>{{if row.model.schedulable "Schedulable" "Unschedulable"}}</td>
               <td data-test-volume-controller-health>
-                {{if (gt row.model.controllersHealthy 0) "Healthy" "Unhealthy"}}
-                ({{row.model.controllersHealthy}}/{{row.model.controllersExpected}})
+                {{#if row.model.controllerRequired}}
+                  {{if (gt row.model.controllersHealthy 0) "Healthy" "Unhealthy"}}
+                  ({{row.model.controllersHealthy}}/{{row.model.controllersExpected}})
+                {{else}}
+                  {{#if (gt row.model.controllersExpected 0)}}
+                  {{if (gt row.model.controllersHealthy 0) "Healthy" "Unhealthy"}}
+                  ({{row.model.controllersHealthy}}/{{row.model.controllersExpected}})
+                  {{else}}
+                  <em class="is-faded">Node Only</em>
+                  {{/if}}
+                {{/if}}
               </td>
               <td data-test-volume-node-health>
                 {{if (gt row.model.nodesHealthy 0) "Healthy" "Unhealthy"}}

--- a/ui/tests/acceptance/volumes-list-test.js
+++ b/ui/tests/acceptance/volumes-list-test.js
@@ -69,17 +69,19 @@ module('Acceptance | volumes list', function(hooks) {
 
     const volumeRow = VolumesList.volumes.objectAt(0);
 
-    const controllerHealthStr = volume.controllersHealthy > 0 ?
-      `Healthy (${volume.controllersHealthy}/${volume.controllersExpected})` :
-      volume.controllerRequired ?
-        'Unhealthy (${volume.controllersHealthy}/${volume.controllersExpected})' :
-        'Node Only';
+    let controllerHealthStr = 'Node Only';
+    if (volume.controllerRequired || volume.controllersExpected > 0) {
+      const healthy = volume.controllersHealthy;
+      const expected = volume.controllersExpected;
+      const isHealthy = healthy > 0;
+      controllerHealthStr = `${isHealthy ? 'Healthy' : 'Unhealthy'} (${healthy}/${expected})`;
+    }
 
     const nodeHealthStr = volume.nodesHealthy > 0 ? 'Healthy' : 'Unhealthy';
 
     assert.equal(volumeRow.name, volume.id);
     assert.equal(volumeRow.schedulable, volume.schedulable ? 'Schedulable' : 'Unschedulable');
-    assert.equal(volumeRow.controllerHealth, `${controllerHealthStr}`);
+    assert.equal(volumeRow.controllerHealth, controllerHealthStr);
     assert.equal(
       volumeRow.nodeHealth,
       `${nodeHealthStr} (${volume.nodesHealthy}/${volume.nodesExpected})`

--- a/ui/tests/acceptance/volumes-list-test.js
+++ b/ui/tests/acceptance/volumes-list-test.js
@@ -69,15 +69,17 @@ module('Acceptance | volumes list', function(hooks) {
 
     const volumeRow = VolumesList.volumes.objectAt(0);
 
-    const controllerHealthStr = volume.controllersHealthy > 0 ? 'Healthy' : 'Unhealthy';
+    const controllerHealthStr = volume.controllersHealthy > 0 ?
+      `Healthy (${volume.controllersHealthy}/${volume.controllersExpected})` :
+      volume.controllerRequired ?
+        'Unhealthy (${volume.controllersHealthy}/${volume.controllersExpected})' :
+        'Node Only';
+
     const nodeHealthStr = volume.nodesHealthy > 0 ? 'Healthy' : 'Unhealthy';
 
     assert.equal(volumeRow.name, volume.id);
     assert.equal(volumeRow.schedulable, volume.schedulable ? 'Schedulable' : 'Unschedulable');
-    assert.equal(
-      volumeRow.controllerHealth,
-      `${controllerHealthStr} (${volume.controllersHealthy}/${volume.controllersExpected})`
-    );
+    assert.equal(volumeRow.controllerHealth, `${controllerHealthStr}`);
     assert.equal(
       volumeRow.nodeHealth,
       `${nodeHealthStr} (${volume.nodesHealthy}/${volume.nodesExpected})`


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9252

Plugin health for controllers should show "Node Only" in the UI only when both
conditions are true: controllers are not required, and no controllers have
registered themselves (0 expected controllers). This accounts for "monolith"
plugins which might register as both controllers and nodes but not necessarily have 
`ControllerRequired = true` because they don't implement the Controller RPC 
endpoints we need (this requirement was added in https://github.com/hashicorp/nomad/pull/7844)

This changeset includes the following fixes:

* Update the Plugins tab of the UI so that monolith plugins don't show "Node
  Only" once they've registered.
* Add the missing "Node Only" logic to the Volumes tab of the UI.