### PR TITLE
events: API event stream client should the index flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,9 @@ __BACKWARDS INCOMPATIBILITIES:__
 BUG FIXES:
 
  * agent (Enterprise): Fixed a bug where audit logging caused websocket and streaming http endpoints to fail [[GH-9319](https://github.com/hashicorp/nomad/issues/9319)]
- * api: Fixed a bug where AllocatedResources contained increasingly duplicated ports [[GH-9368](https://github.com/hashicorp/nomad/issues/9368)]
+ * api: Fixed a bug where the event stream client didn't pass the index query parameters [[GH-9419](https://github.com/hashicorp/nomad/issues/9419)]
  * core: Fixed a bug where ACL handling prevented cross-namespace allocation listing [[GH-9278](https://github.com/hashicorp/nomad/issues/9278)]
+ * core: Fixed a bug where AllocatedResources contained increasingly duplicated ports [[GH-9368](https://github.com/hashicorp/nomad/issues/9368)]
  * core: Fixed a bug where scaling policy filtering would ignore type query if job query was present [[GH-9312](https://github.com/hashicorp/nomad/issues/9312)]
  * core: Fixed a bug where a request to scale a job would fail if the job was not in the default namespace. [[GH-9296](https://github.com/hashicorp/nomad/pull/9296)]
  * core: Fixed a bug where blocking queries would not include the query's maximum wait time when calculating whether it was safe to retry. [[GH-8921](https://github.com/hashicorp/nomad/issues/8921)]

--- a/api/event_stream.go
+++ b/api/event_stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -141,6 +142,10 @@ func (e *EventStream) Stream(ctx context.Context, topics map[Topic][]string, ind
 		return nil, err
 	}
 	q = q.WithContext(ctx)
+	if q.Params == nil {
+		q.Params = map[string]string{}
+	}
+	q.Params["index"] = strconv.FormatUint(index, 10)
 	r.setQueryOptions(q)
 
 	// Build topic query params

--- a/vendor/github.com/hashicorp/nomad/api/event_stream.go
+++ b/vendor/github.com/hashicorp/nomad/api/event_stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -141,6 +142,10 @@ func (e *EventStream) Stream(ctx context.Context, topics map[Topic][]string, ind
 		return nil, err
 	}
 	q = q.WithContext(ctx)
+	if q.Params == nil {
+		q.Params = map[string]string{}
+	}
+	q.Params["index"] = strconv.FormatUint(index, 10)
 	r.setQueryOptions(q)
 
 	// Build topic query params


### PR DESCRIPTION
Stream() method on the Event API client was neglecting to pass the `index` argument.

i added this as an e2e test, my first one. feedback appreciated.