### PR TITLE
Update input variables usage docs

### DIFF
--- a/website/pages/docs/job-specification/hcl2.mdx
+++ b/website/pages/docs/job-specification/hcl2.mdx
@@ -58,7 +58,7 @@ within expressions as `vars.<NAME>`. You can set the variable in the CLI by
 passing `-var <NAME>=<VALUE>`.
 
 For example, to repurpose the job spec to target different environments (e.g.
-staging vs production), you can use `vars.environment` in the job spec, and pass
+staging vs production), you can use `var.environment` in the job spec, and pass
 `--var environment=production`.
 
 ## Backward Compatibilities


### PR DESCRIPTION
I'm assuming this was just a typo. Using `vars.` did not work for me when referencing an input variable