### PR TITLE
HCL2: Add vault function

### DIFF
--- a/jobspec2/functions.go
+++ b/jobspec2/functions.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-cty-funcs/uuid"
 	"github.com/hashicorp/hcl/v2/ext/tryfunc"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/hashicorp/nomad/jobspec2/vault"
 	ctyyaml "github.com/zclconf/go-cty-yaml"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
@@ -96,6 +97,7 @@ func Functions(basedir string, allowFS bool) map[string]function.Function {
 		"uuidv4":          uuid.V4Func,
 		"uuidv5":          uuid.V5Func,
 		"values":          stdlib.ValuesFunc,
+		"vault":           vault.GenVaultFunc,
 		"yamldecode":      ctyyaml.YAMLDecodeFunc,
 		"yamlencode":      ctyyaml.YAMLEncodeFunc,
 		"zipmap":          stdlib.ZipmapFunc,

--- a/jobspec2/vault/functions.go
+++ b/jobspec2/vault/functions.go
@@ -1,0 +1,70 @@
+package vault
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// GenVaultFunc returns generated vault func
+var GenVaultFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "path",
+			Type: cty.String,
+		},
+		{
+			Name: "key",
+			Type: cty.String,
+		},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		path := args[0].AsString()
+		key := args[1].AsString()
+
+		return vault(path, key)
+	},
+})
+
+func vault(path string, key string) (cty.Value, error) {
+
+	if token := os.Getenv("VAULT_TOKEN"); token == "" {
+		return cty.StringVal(""), errors.New("Must set VAULT_TOKEN env var in order to use vault template function")
+	}
+
+	vaultConfig := vaultapi.DefaultConfig()
+	cli, err := vaultapi.NewClient(vaultConfig)
+	if err != nil {
+		return cty.StringVal(""), fmt.Errorf("Error getting Vault client: %s", err)
+	}
+	secret, err := cli.Logical().Read(path)
+	if err != nil {
+		return cty.StringVal(""), fmt.Errorf("Error reading vault secret: %s", err)
+	}
+	if secret == nil {
+		return cty.StringVal(""), errors.New("Vault Secret does not exist at the given path")
+	}
+
+	data, ok := secret.Data["data"]
+	if !ok {
+		// maybe ths is v1, not v2 kv store
+		value, ok := secret.Data[key]
+		if ok {
+			return cty.StringVal(value.(string)), nil
+		}
+
+		// neither v1 nor v2 proudced a valid value
+		return cty.StringVal(""), fmt.Errorf("Vault data was empty at the given path. Warnings: %s", strings.Join(secret.Warnings, "; "))
+	}
+
+	if val, ok := data.(map[string]interface{})[key]; ok {
+		return cty.StringVal(val.(string)), nil
+	}
+	return cty.StringVal(""), errors.New("Vault path does not contain the requested key")
+}

--- a/jobspec2/vault/functions.go
+++ b/jobspec2/vault/functions.go
@@ -53,13 +53,13 @@ func vault(path string, key string) (cty.Value, error) {
 
 	data, ok := secret.Data["data"]
 	if !ok {
-		// maybe ths is v1, not v2 kv store
+		// maybe this is v1, not v2 kv store
 		value, ok := secret.Data[key]
 		if ok {
 			return cty.StringVal(value.(string)), nil
 		}
 
-		// neither v1 nor v2 proudced a valid value
+		// neither v1 nor v2 produced a valid value
 		return cty.StringVal(""), fmt.Errorf("Vault data was empty at the given path. Warnings: %s", strings.Join(secret.Warnings, "; "))
 	}
 


### PR DESCRIPTION
This adds the vault function into hcl2 configuration based on the Packer implementation.

PR https://github.com/hashicorp/nomad/pull/9298 recently added hcl2 functions for the job file with a link to the packer function documentation. 
Adding the vault function would greatly improve the workflow to not rely on external templating tools.
This PR gives the possibility to define something like:
```
variable "env" {
  default = "dev"
}

locals {
  config = yamldecode( file( var.env ))
  mysecret =  "${ try( local.config["mysecret"], vault("secret/path" "my_secret")) }"
}

job "myservice" {
  group "service_group" {
    task "service_task" {
      env {
        SECRET_VAR = local.mysecret
  ...
```