### PR TITLE
CSI: fix transaction handling in state store

### DIFF
--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -116,16 +116,19 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 		queryOpts: &args.QueryOptions,
 		queryMeta: &reply.QueryMeta,
 		run: func(ws memdb.WatchSet, state *state.StateStore) error {
+			snap, err := state.Snapshot()
+			if err != nil {
+				return err
+			}
 			// Query all volumes
-			var err error
 			var iter memdb.ResultIterator
 
 			if args.NodeID != "" {
-				iter, err = state.CSIVolumesByNodeID(ws, args.NodeID)
+				iter, err = snap.CSIVolumesByNodeID(ws, args.NodeID)
 			} else if args.PluginID != "" {
-				iter, err = state.CSIVolumesByPluginID(ws, ns, args.PluginID)
+				iter, err = snap.CSIVolumesByPluginID(ws, ns, args.PluginID)
 			} else {
-				iter, err = state.CSIVolumesByNamespace(ws, ns)
+				iter, err = snap.CSIVolumesByNamespace(ws, ns)
 			}
 
 			if err != nil {
@@ -140,21 +143,23 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 				if raw == nil {
 					break
 				}
-
 				vol := raw.(*structs.CSIVolume)
-				vol, err := state.CSIVolumeDenormalizePlugins(ws, vol.Copy())
-				if err != nil {
-					return err
-				}
 
-				// Remove (possibly again) by PluginID to handle passing both NodeID and PluginID
+				// Remove (possibly again) by PluginID to handle passing both
+				// NodeID and PluginID
 				if args.PluginID != "" && args.PluginID != vol.PluginID {
 					continue
 				}
 
-				// Remove by Namespace, since CSIVolumesByNodeID hasn't used the Namespace yet
+				// Remove by Namespace, since CSIVolumesByNodeID hasn't used
+				// the Namespace yet
 				if vol.Namespace != ns {
 					continue
+				}
+
+				vol, err := snap.CSIVolumeDenormalizePlugins(ws, vol.Copy())
+				if err != nil {
+					return err
 				}
 
 				vs = append(vs, vol.Stub())
@@ -195,12 +200,17 @@ func (v *CSIVolume) Get(args *structs.CSIVolumeGetRequest, reply *structs.CSIVol
 		queryOpts: &args.QueryOptions,
 		queryMeta: &reply.QueryMeta,
 		run: func(ws memdb.WatchSet, state *state.StateStore) error {
-			vol, err := state.CSIVolumeByID(ws, ns, args.ID)
+			snap, err := state.Snapshot()
+			if err != nil {
+				return err
+			}
+
+			vol, err := snap.CSIVolumeByID(ws, ns, args.ID)
 			if err != nil {
 				return err
 			}
 			if vol != nil {
-				vol, err = state.CSIVolumeDenormalize(ws, vol)
+				vol, err = snap.CSIVolumeDenormalize(ws, vol)
 			}
 			if err != nil {
 				return err
@@ -870,7 +880,12 @@ func (v *CSIPlugin) Get(args *structs.CSIPluginGetRequest, reply *structs.CSIPlu
 		queryOpts: &args.QueryOptions,
 		queryMeta: &reply.QueryMeta,
 		run: func(ws memdb.WatchSet, state *state.StateStore) error {
-			plug, err := state.CSIPluginByID(ws, args.ID)
+			snap, err := state.Snapshot()
+			if err != nil {
+				return err
+			}
+
+			plug, err := snap.CSIPluginByID(ws, args.ID)
 			if err != nil {
 				return err
 			}
@@ -880,7 +895,7 @@ func (v *CSIPlugin) Get(args *structs.CSIPluginGetRequest, reply *structs.CSIPlu
 			}
 
 			if withAllocs {
-				plug, err = state.CSIPluginDenormalize(ws, plug.Copy())
+				plug, err = snap.CSIPluginDenormalize(ws, plug.Copy())
 				if err != nil {
 					return err
 				}

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -224,9 +224,8 @@ func (v *CSIVolume) Get(args *structs.CSIVolumeGetRequest, reply *structs.CSIVol
 
 func (v *CSIVolume) pluginValidateVolume(req *structs.CSIVolumeRegisterRequest, vol *structs.CSIVolume) (*structs.CSIPlugin, error) {
 	state := v.srv.fsm.State()
-	ws := memdb.NewWatchSet()
 
-	plugin, err := state.CSIPluginByID(ws, vol.PluginID)
+	plugin, err := state.CSIPluginByID(nil, vol.PluginID)
 	if err != nil {
 		return nil, err
 	}
@@ -491,9 +490,7 @@ func (v *CSIVolume) controllerPublishVolume(req *structs.CSIVolumeClaimRequest, 
 
 func (v *CSIVolume) volAndPluginLookup(namespace, volID string) (*structs.CSIPlugin, *structs.CSIVolume, error) {
 	state := v.srv.fsm.State()
-	ws := memdb.NewWatchSet()
-
-	vol, err := state.CSIVolumeByID(ws, namespace, volID)
+	vol, err := state.CSIVolumeByID(nil, namespace, volID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -507,7 +504,7 @@ func (v *CSIVolume) volAndPluginLookup(namespace, volID string) (*structs.CSIPlu
 	// note: we do this same lookup in CSIVolumeByID but then throw
 	// away the pointer to the plugin rather than attaching it to
 	// the volume so we have to do it again here.
-	plug, err := state.CSIPluginByID(ws, vol.PluginID)
+	plug, err := state.CSIPluginByID(nil, vol.PluginID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1826,22 +1826,20 @@ func (s *StateStore) JobsByIDPrefix(ws memdb.WatchSet, namespace, id string) (me
 func (s *StateStore) JobVersionsByID(ws memdb.WatchSet, namespace, id string) ([]*structs.Job, error) {
 	txn := s.db.ReadTxn()
 
-	return s.jobVersionByID(txn, &ws, namespace, id)
+	return s.jobVersionByID(txn, ws, namespace, id)
 }
 
 // jobVersionByID is the underlying implementation for retrieving all tracked
 // versions of a job and is called under an existing transaction. A watch set
 // can optionally be passed in to add the job histories to the watch set.
-func (s *StateStore) jobVersionByID(txn *txn, ws *memdb.WatchSet, namespace, id string) ([]*structs.Job, error) {
+func (s *StateStore) jobVersionByID(txn *txn, ws memdb.WatchSet, namespace, id string) ([]*structs.Job, error) {
 	// Get all the historic jobs for this ID
 	iter, err := txn.Get("job_version", "id_prefix", namespace, id)
 	if err != nil {
 		return nil, err
 	}
 
-	if ws != nil {
-		ws.Add(iter.WatchCh())
-	}
+	ws.Add(iter.WatchCh())
 
 	var all []*structs.Job
 	for {
@@ -1884,9 +1882,7 @@ func (s *StateStore) jobByIDAndVersionImpl(ws memdb.WatchSet, namespace, id stri
 		return nil, err
 	}
 
-	if ws != nil {
-		ws.Add(watchCh)
-	}
+	ws.Add(watchCh)
 
 	if existing != nil {
 		job := existing.(*structs.Job)
@@ -2122,9 +2118,8 @@ func (s *StateStore) CSIVolumeByID(ws memdb.WatchSet, namespace, id string) (*st
 	if err != nil {
 		return nil, fmt.Errorf("volume lookup failed: %s %v", id, err)
 	}
-	if ws != nil {
-		ws.Add(watchCh)
-	}
+
+	ws.Add(watchCh)
 
 	if obj == nil {
 		return nil, nil
@@ -2170,6 +2165,7 @@ func (s *StateStore) CSIVolumesByIDPrefix(ws memdb.WatchSet, namespace, volumeID
 	}
 
 	ws.Add(iter.WatchCh())
+
 	return iter, nil
 }
 
@@ -2210,6 +2206,7 @@ func (s *StateStore) CSIVolumesByNodeID(ws memdb.WatchSet, nodeID string) (memdb
 		}
 		iter.Add(raw)
 	}
+
 	ws.Add(iter.WatchCh())
 
 	return iter, nil
@@ -2223,6 +2220,7 @@ func (s *StateStore) CSIVolumesByNamespace(ws memdb.WatchSet, namespace string) 
 	if err != nil {
 		return nil, fmt.Errorf("volume lookup failed: %v", err)
 	}
+
 	ws.Add(iter.WatchCh())
 
 	return iter, nil
@@ -2519,9 +2517,8 @@ func (s *StateStore) CSIPluginByIDTxn(txn Txn, ws memdb.WatchSet, id string) (*s
 	if err != nil {
 		return nil, fmt.Errorf("csi_plugin lookup failed: %s %v", id, err)
 	}
-	if ws != nil {
-		ws.Add(watchCh)
-	}
+
+	ws.Add(watchCh)
 
 	if obj != nil {
 		return obj.(*structs.CSIPlugin), nil
@@ -3358,9 +3355,9 @@ func (s *StateStore) allocByIDImpl(txn Txn, ws memdb.WatchSet, id string) (*stru
 	if err != nil {
 		return nil, fmt.Errorf("alloc lookup failed: %v", err)
 	}
-	if ws != nil {
-		ws.Add(watchCh)
-	}
+
+	ws.Add(watchCh)
+
 	if raw == nil {
 		return nil, nil
 	}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2427,7 +2427,9 @@ func (s *StateStore) CSIVolumeDenormalize(ws memdb.WatchSet, vol *structs.CSIVol
 
 // CSIVolumeDenormalizeTxn populates a CSIVolume with allocations
 func (s *StateStore) CSIVolumeDenormalizeTxn(txn Txn, ws memdb.WatchSet, vol *structs.CSIVolume) (*structs.CSIVolume, error) {
-
+	if vol == nil {
+		return nil, nil
+	}
 	for id := range vol.ReadAllocs {
 		a, err := s.allocByIDImpl(txn, ws, id)
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9371 and possibly https://github.com/hashicorp/nomad/issues/9248 and https://github.com/hashicorp/nomad/issues/8034

When making updates to CSI plugins and volumes, the state store methods that have open write transactions were querying the state store using the same methods used by the CSI RPC endpoint, but these methods create their own top-level read transactions. During concurrent plugin updates (as happens when a plugin job is stopped), this can cause write skew in the plugin counts. This bug hasn't yet been identified as the root cause of any volume query bug, but it seems likely.

Best reviewed commit-by-commit.