### PR TITLE
E2E: CSI driver provisioning

### DIFF
--- a/e2e/csi/csi.go
+++ b/e2e/csi/csi.go
@@ -42,7 +42,7 @@ func init() {
 
 const ns = ""
 
-var pluginWait = &e2e.WaitConfig{Interval: 5 * time.Second, Retries: 24} // 2min
+var pluginWait = &e2e.WaitConfig{Interval: 5 * time.Second, Retries: 36} // 3min
 var reapWait = &e2e.WaitConfig{Interval: 5 * time.Second, Retries: 36}   // 3min
 
 func (tc *CSIVolumesTest) BeforeAll(f *framework.F) {

--- a/e2e/csi/input/plugin-aws-ebs-controller.nomad
+++ b/e2e/csi/input/plugin-aws-ebs-controller.nomad
@@ -22,7 +22,7 @@ job "plugin-aws-ebs-controller" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-ebs-csi-driver:v0.6.0"
+        image = "amazon/aws-ebs-csi-driver:v0.7.1"
 
         args = [
           "controller",

--- a/e2e/csi/input/plugin-aws-ebs-nodes.nomad
+++ b/e2e/csi/input/plugin-aws-ebs-nodes.nomad
@@ -19,7 +19,7 @@ job "plugin-aws-ebs-nodes" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-ebs-csi-driver:v0.6.0"
+        image = "amazon/aws-ebs-csi-driver:v0.7.1"
 
         args = [
           "node",


### PR DESCRIPTION
* Wait longer for plugins to become healthy. Plugins are Docker containers, and as such sometimes we get delays in startup due to pulling from the registry and this is a source of test flakiness. Give the plugins a little longer to start up.
* Version bump for AWS EBS plugins