### PR TITLE
buf: use comment ignores

### DIFF
--- a/drivers/shared/executor/proto/executor.pb.go
+++ b/drivers/shared/executor/proto/executor.pb.go
@@ -918,6 +918,7 @@ type ExecutorClient interface {
 	Stats(ctx context.Context, in *StatsRequest, opts ...grpc.CallOption) (Executor_StatsClient, error)
 	Signal(ctx context.Context, in *SignalRequest, opts ...grpc.CallOption) (*SignalResponse, error)
 	Exec(ctx context.Context, in *ExecRequest, opts ...grpc.CallOption) (*ExecResponse, error)
+	// buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
 	ExecStreaming(ctx context.Context, opts ...grpc.CallOption) (Executor_ExecStreamingClient, error)
 }
 
@@ -1065,6 +1066,7 @@ type ExecutorServer interface {
 	Stats(*StatsRequest, Executor_StatsServer) error
 	Signal(context.Context, *SignalRequest) (*SignalResponse, error)
 	Exec(context.Context, *ExecRequest) (*ExecResponse, error)
+	// buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
 	ExecStreaming(Executor_ExecStreamingServer) error
 }
 

--- a/drivers/shared/executor/proto/executor.proto
+++ b/drivers/shared/executor/proto/executor.proto
@@ -14,7 +14,17 @@ service Executor {
     rpc Stats(StatsRequest) returns (stream StatsResponse) {}
     rpc Signal(SignalRequest) returns (SignalResponse) {}
     rpc Exec(ExecRequest) returns (ExecResponse) {}
-    rpc ExecStreaming(stream hashicorp.nomad.plugins.drivers.proto.ExecTaskStreamingRequest) returns (stream hashicorp.nomad.plugins.drivers.proto.ExecTaskStreamingResponse) {}
+
+    // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+    rpc ExecStreaming(
+      stream
+      // buf:lint:ignore RPC_REQUEST_STANDARD_NAME
+      hashicorp.nomad.plugins.drivers.proto.ExecTaskStreamingRequest)
+    returns (
+      stream
+      // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+      hashicorp.nomad.plugins.drivers.proto.ExecTaskStreamingResponse
+    ) {}
 }
 
 message LaunchRequest {

--- a/plugins/base/proto/base.pb.go
+++ b/plugins/base/proto/base.pb.go
@@ -335,9 +335,11 @@ func (m *NomadConfig) GetDriver() *NomadDriverConfig {
 type NomadDriverConfig struct {
 	// ClientMaxPort is the upper range of the ports that the client uses for
 	// communicating with plugin subsystems over loopback
+	// buf:lint:ignore FIELD_LOWER_SNAKE_CASE
 	ClientMaxPort uint32 `protobuf:"varint,1,opt,name=ClientMaxPort,proto3" json:"ClientMaxPort,omitempty"`
 	// ClientMinPort is the lower range of the ports that the client uses for
 	// communicating with plugin subsystems over loopback
+	// buf:lint:ignore FIELD_LOWER_SNAKE_CASE
 	ClientMinPort        uint32   `protobuf:"varint,2,opt,name=ClientMinPort,proto3" json:"ClientMinPort,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/plugins/base/proto/base.proto
+++ b/plugins/base/proto/base.proto
@@ -76,12 +76,14 @@ message NomadConfig {
 // driver plugins
 message NomadDriverConfig {
     // ClientMaxPort is the upper range of the ports that the client uses for
-	// communicating with plugin subsystems over loopback
-	uint32 ClientMaxPort = 1;
+    // communicating with plugin subsystems over loopback
+    // buf:lint:ignore FIELD_LOWER_SNAKE_CASE
+    uint32 ClientMaxPort = 1;
 
-	// ClientMinPort is the lower range of the ports that the client uses for
-	// communicating with plugin subsystems over loopback
-	uint32 ClientMinPort = 2;
+    // ClientMinPort is the lower range of the ports that the client uses for
+    // communicating with plugin subsystems over loopback
+    // buf:lint:ignore FIELD_LOWER_SNAKE_CASE
+    uint32 ClientMinPort = 2;
 }
 
 // SetConfigResponse is used to respond to setting the configuration

--- a/plugins/device/proto/device.pb.go
+++ b/plugins/device/proto/device.pb.go
@@ -184,6 +184,7 @@ func (m *DeviceGroup) GetAttributes() map[string]*proto1.Attribute {
 type DetectedDevice struct {
 	// ID is the ID of the device. This ID is used during allocation and must be
 	// stable across restarts of the device driver.
+	// buf:lint:ignore FIELD_LOWER_SNAKE_CASE
 	ID string `protobuf:"bytes,1,opt,name=ID,proto3" json:"ID,omitempty"`
 	// Health of the device.
 	Healthy bool `protobuf:"varint,2,opt,name=healthy,proto3" json:"healthy,omitempty"`

--- a/plugins/device/proto/device.proto
+++ b/plugins/device/proto/device.proto
@@ -58,6 +58,7 @@ message DeviceGroup {
 message DetectedDevice {
   // ID is the ID of the device. This ID is used during allocation and must be
   // stable across restarts of the device driver.
+  // buf:lint:ignore FIELD_LOWER_SNAKE_CASE
   string ID = 1;
 
   // Health of the device.

--- a/plugins/drivers/proto/driver.pb.go
+++ b/plugins/drivers/proto/driver.pb.go
@@ -2606,6 +2606,7 @@ type LinuxResources struct {
 	// CpusetMems constrains the allowed set of memory nodes. Default: "" (not specified)
 	CpusetMems string `protobuf:"bytes,7,opt,name=cpuset_mems,json=cpusetMems,proto3" json:"cpuset_mems,omitempty"`
 	// PercentTicks is a compatibility option for docker and should not be used
+	// buf:lint:ignore FIELD_LOWER_SNAKE_CASE
 	PercentTicks         float64  `protobuf:"fixed64,8,opt,name=PercentTicks,proto3" json:"PercentTicks,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -3887,6 +3888,7 @@ type DriverClient interface {
 	ExecTask(ctx context.Context, in *ExecTaskRequest, opts ...grpc.CallOption) (*ExecTaskResponse, error)
 	// ExecTaskStreaming executes a command inside the tasks execution context
 	// and streams back results
+	// buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
 	ExecTaskStreaming(ctx context.Context, opts ...grpc.CallOption) (Driver_ExecTaskStreamingClient, error)
 	// CreateNetwork is implemented when the driver needs to create the network
 	// namespace instead of allowing the Nomad client to do.
@@ -4186,6 +4188,7 @@ type DriverServer interface {
 	ExecTask(context.Context, *ExecTaskRequest) (*ExecTaskResponse, error)
 	// ExecTaskStreaming executes a command inside the tasks execution context
 	// and streams back results
+	// buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
 	ExecTaskStreaming(Driver_ExecTaskStreamingServer) error
 	// CreateNetwork is implemented when the driver needs to create the network
 	// namespace instead of allowing the Nomad client to do.

--- a/plugins/drivers/proto/driver.proto
+++ b/plugins/drivers/proto/driver.proto
@@ -60,7 +60,9 @@ service Driver {
 
     // TaskEvents starts a streaming RPC where all task events emitted by the
     // driver are streamed to the caller.
-    rpc TaskEvents(TaskEventsRequest) returns (stream DriverTaskEvent) {}
+    rpc TaskEvents(TaskEventsRequest) returns (stream
+      // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+      DriverTaskEvent) {}
 
     // The following RPCs are only implemented if the driver sets the
     // corresponding capability.
@@ -73,6 +75,7 @@ service Driver {
 
     // ExecTaskStreaming executes a command inside the tasks execution context
     // and streams back results
+    // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
     rpc ExecTaskStreaming(stream ExecTaskStreamingRequest) returns (stream ExecTaskStreamingResponse) {}
 
     // CreateNetwork is implemented when the driver needs to create the network
@@ -371,6 +374,7 @@ message DriverCapabilities {
     bool must_create_network = 5;
 
     enum MountConfigs {
+        // buf:lint:ignore ENUM_NO_ALLOW_ALIAS
         option allow_alias = true;
         UNKNOWN_MOUNTS = 0; // treated as ANY_MOUNTS for backwards compatibility
         ANY_MOUNTS = 0;
@@ -525,6 +529,7 @@ message LinuxResources {
     // CpusetMems constrains the allowed set of memory nodes. Default: "" (not specified)
     string cpuset_mems = 7;
     // PercentTicks is a compatibility option for docker and should not be used
+    // buf:lint:ignore FIELD_LOWER_SNAKE_CASE
     double PercentTicks = 8;
 }
 

--- a/plugins/shared/hclspec/hcl_spec.proto
+++ b/plugins/shared/hclspec/hcl_spec.proto
@@ -60,6 +60,7 @@ message Spec {
   oneof block {
     Object object = 1;
     Array array = 2;
+    // buf:lint:ignore FIELD_LOWER_SNAKE_CASE
     Attr Attr = 3;
     Block block_value = 4;
     BlockAttrs block_attrs = 5;

--- a/tools/buf/buf.yaml
+++ b/tools/buf/buf.yaml
@@ -7,9 +7,8 @@ build:
 lint:
   use:
     - DEFAULT
+  allow_comment_ignores: true
   ignore_only:
-    ENUM_NO_ALLOW_ALIAS:
-      - plugins/drivers/proto/driver.proto
     ENUM_VALUE_PREFIX:
       - plugins/base/proto/base.proto
       - plugins/drivers/proto/driver.proto
@@ -27,11 +26,6 @@ lint:
       - plugins/shared/structs/proto/attribute.proto
       - plugins/shared/structs/proto/recoverable_error.proto
       - plugins/shared/structs/proto/stats.proto
-    FIELD_LOWER_SNAKE_CASE:
-      - plugins/base/proto/base.proto
-      - plugins/device/proto/device.proto
-      - plugins/drivers/proto/driver.proto
-      - plugins/shared/hclspec/hcl_spec.proto
     PACKAGE_VERSION_SUFFIX:
       - client/logmon/proto/logmon.proto
       - drivers/docker/docklog/proto/docker_logger.proto
@@ -43,14 +37,6 @@ lint:
       - plugins/shared/structs/proto/attribute.proto
       - plugins/shared/structs/proto/recoverable_error.proto
       - plugins/shared/structs/proto/stats.proto
-    RPC_REQUEST_RESPONSE_UNIQUE:
-      - drivers/shared/executor/proto/executor.proto
-      - plugins/drivers/proto/driver.proto
-    RPC_REQUEST_STANDARD_NAME:
-      - drivers/shared/executor/proto/executor.proto
-    RPC_RESPONSE_STANDARD_NAME:
-      - drivers/shared/executor/proto/executor.proto
-      - plugins/drivers/proto/driver.proto
     SERVICE_SUFFIX:
       - client/logmon/proto/logmon.proto
       - drivers/docker/docklog/proto/docker_logger.proto


### PR DESCRIPTION
Use targetted ignore comments for the cases where we are bound by
backward compatibility.

I've left some file based linters, especially when the file is riddled
with linter voilations (e.g. enum names), or if it's a property of the
file (e.g. package and file names).

I encountered an odd behavior related to RPC_REQUEST_RESPONSE_UNIQUE and
RPC_REQUEST_STANDARD_NAME.  Apparently, if they target a `stream` type,
we must separate them into separate lines so that the ignore comment
targets the type specifically.

This is the follow up of https://github.com/hashicorp/nomad/pull/9414#discussion_r527870340 .