### PR TITLE
Add "compute/zone" to Azure fingerprinting

### DIFF
--- a/client/fingerprint/env_azure.go
+++ b/client/fingerprint/env_azure.go
@@ -143,6 +143,7 @@ func (f *EnvAzureFingerprint) Fingerprint(request *FingerprintRequest, response 
 		"resource-group": {unique: false, path: "compute/resourceGroupName"},
 		"scale-set":      {unique: false, path: "compute/vmScaleSetName"},
 		"vm-size":        {unique: false, path: "compute/vmSize"},
+		"zone":           {unique: false, path: "compute/zone"},
 		"local-ipv4":     {unique: true, path: "network/interface/0/ipv4/ipAddress/0/privateIpAddress"},
 		"public-ipv4":    {unique: true, path: "network/interface/0/ipv4/ipAddress/0/publicIpAddress"},
 		"local-ipv6":     {unique: true, path: "network/interface/0/ipv6/ipAddress/0/privateIpAddress"},


### PR DESCRIPTION
Nomad 1.0.0 features Azure fingerprinting, however it is missing 1 important metadata field `compute/zone`.
When a VM is part of a scaling set it is populated (non-empty) in the response from Azure metadata service.

With AWS we can do the following in the job def to spread allocs across AZs equally:
```
    spread {
      attribute = "${attr.platform.aws.placement.availability-zone}"
      weight = 100
    }
```

By adding 1 line to the code we can do the same on Azure:
```
    spread {
      attribute = "${attr.platform.azure.zone}"
      weight = 100
    }
```

Not adding `compute/zone` to the tests because it is empty when a VM is not a part of VMSS.

<img width="555" alt="Screenshot 2020-11-26 at 14 01 11" src="https://user-images.githubusercontent.com/2220941/100348775-11124a80-2ff0-11eb-94e2-1ae2fe10b21b.png">
