### PR TITLE
Update group.mdx

### DIFF
--- a/website/pages/docs/job-specification/group.mdx
+++ b/website/pages/docs/job-specification/group.mdx
@@ -72,7 +72,7 @@ job "docs" {
   stopping a group's tasks. The delay occurs between Consul deregistration
   and sending each task a shutdown signal. Ideally, services would fail
   healthchecks once they receive a shutdown signal. Alternatively
-  `shutdown_delay` may be set to give in flight requests time to complete
+  `shutdown_delay` may be set to give in-flight requests time to complete
   before shutting down. A group level `shutdown_delay` will run regardless
   if there are any defined group services. In addition, tasks may have their
   own [`shutdown_delay`](/docs/job-specification/task#shutdown_delay)


### PR DESCRIPTION
Typo
I also note (in a number of places but this page has one) a newline in the wrong place: https://www.nomadproject.io/docs/job-specification/group#stop-after-client-disconnect 

group does not have<br />`stop_after_client_disconnect`, ...

on my Chrome latest browser rendered on a MBP.  This does not show in the GH preview pane.