### PR TITLE
docs: check_restart is broken for group networks

### DIFF
--- a/website/pages/docs/job-specification/check_restart.mdx
+++ b/website/pages/docs/job-specification/check_restart.mdx
@@ -16,6 +16,10 @@ description: |-
   ]}
 />
 
+~> The `check_restart` stanza in Nomad is only supported for task networks,
+   *not* group networks. Please follow [#9176][gh-9176] to be notified when
+   this is fixed.
+
 As of Nomad 0.7 the `check_restart` stanza instructs Nomad when to restart
 tasks with unhealthy service checks. When a health check in Consul has been
 unhealthy for the `limit` specified in a `check_restart` stanza, it is
@@ -137,5 +141,6 @@ and not be restarted again. See the [`restart` stanza][restart_stanza] for
 details.
 
 [check_stanza]: /docs/job-specification/service#check-parameters 'check stanza'
+[gh-9176]: https://github.com/hashicorp/nomad/issues/9176
 [restart_stanza]: /docs/job-specification/restart 'restart stanza'
 [service_stanza]: /docs/job-specification/service 'service stanza'


### PR DESCRIPTION
Add a warning about check_restart being limited to task networks and
link to the relevant issue: #9176.

![image](https://user-images.githubusercontent.com/113362/100770990-bba0b980-33b2-11eb-83d3-04a4c340cafb.png)
