### PR TITLE
client: improve alloc GC API error messages

### DIFF
--- a/client/alloc_endpoint.go
+++ b/client/alloc_endpoint.go
@@ -62,8 +62,7 @@ func (a *Allocations) GarbageCollect(args *nstructs.AllocSpecificRequest, reply 
 	}
 
 	if !a.c.CollectAllocation(args.AllocID) {
-		// Could not find alloc
-		return nstructs.NewErrUnknownAllocation(args.AllocID)
+		return fmt.Errorf("No such allocation on client or allocation not eligible for GC")
 	}
 
 	return nil

--- a/client/alloc_endpoint.go
+++ b/client/alloc_endpoint.go
@@ -62,7 +62,7 @@ func (a *Allocations) GarbageCollect(args *nstructs.AllocSpecificRequest, reply 
 	}
 
 	if !a.c.CollectAllocation(args.AllocID) {
-		return fmt.Errorf("No such allocation on client or allocation not eligible for GC")
+		return fmt.Errorf("No such allocation on client, or allocation not eligible for GC")
 	}
 
 	return nil

--- a/client/alloc_endpoint_test.go
+++ b/client/alloc_endpoint_test.go
@@ -268,6 +268,8 @@ func TestAllocations_GarbageCollect_ACL(t *testing.T) {
 		"run_for": "20s",
 	}
 
+	noSuchAllocErr := fmt.Errorf("No such allocation on client or allocation not eligible for GC")
+
 	// Wait for client to be running job
 	alloc := testutil.WaitForRunningWithToken(t, server.RPC, job, root.SecretID)[0]
 
@@ -306,7 +308,7 @@ func TestAllocations_GarbageCollect_ACL(t *testing.T) {
 
 		var resp nstructs.GenericResponse
 		err := client.ClientRPC("Allocations.GarbageCollect", &req, &resp)
-		require.True(nstructs.IsErrUnknownAllocation(err))
+		require.Error(err, noSuchAllocErr)
 	}
 
 	// Try request with a management token
@@ -316,7 +318,7 @@ func TestAllocations_GarbageCollect_ACL(t *testing.T) {
 
 		var resp nstructs.GenericResponse
 		err := client.ClientRPC("Allocations.GarbageCollect", &req, &resp)
-		require.True(nstructs.IsErrUnknownAllocation(err))
+		require.Error(err, noSuchAllocErr)
 	}
 }
 

--- a/website/pages/api-docs/client.mdx
+++ b/website/pages/api-docs/client.mdx
@@ -560,7 +560,8 @@ $ curl \
 ## GC Allocation
 
 This endpoint forces a garbage collection of a particular, stopped allocation
-on a node.
+on a node. Note that the allocation will still exist on the server and appear
+in server responses.
 
 | Method | Path                              | Produces           |
 | ------ | --------------------------------- | ------------------ |


### PR DESCRIPTION
The client allocation GC API returns a misleading error message when the
allocation exists but is not yet eligible for GC. Make this clear in the error
response.

Note in the docs that the allocation will still show on the server responses.

Got rabbit-holed a bit by this while working on https://github.com/hashicorp/nomad/issues/9376