### PR TITLE
lifecycle: update e2e test for service job with new docker signal #8932

### DIFF
--- a/e2e/lifecycle/inputs/service.nomad
+++ b/e2e/lifecycle/inputs/service.nomad
@@ -120,7 +120,7 @@ if [ ! -f ${NOMAD_ALLOC_DIR}/poststart-started ]; then exit 15; fi
 touch ${NOMAD_ALLOC_DIR}/main-checked
 
 echo trap
-trap cleanup SIGINT
+trap cleanup SIGTERM
 
 echo sleep
 while true


### PR DESCRIPTION
To test the lifecycle `poststop` hook for service jobs, we need to confirm that poststop will run after the main task is stopped with `nomad job stop` or `nomad alloc signal`. This signal is determined by the task driver, which in the Docker case was recently switched from SIGINT to SIGTERM re: #8932 & #8933. 