### PR TITLE
UI: Fix allocation count in CSI volumes table

### DIFF
--- a/ui/app/models/volume.js
+++ b/ui/app/models/volume.js
@@ -18,6 +18,14 @@ export default class Volume extends Model {
     return [...this.writeAllocations.toArray(), ...this.readAllocations.toArray()];
   }
 
+  @attr('number') currentWriters;
+  @attr('number') currentReaders;
+
+  @computed('currentWriters', 'currentReaders')
+  get allocationCount() {
+    return this.currentWriters + this.currentReaders;
+  }
+
   @attr('string') externalId;
   @attr() topologies;
   @attr('string') accessMode;

--- a/ui/app/templates/csi/volumes/index.hbs
+++ b/ui/app/templates/csi/volumes/index.hbs
@@ -62,7 +62,7 @@
                 ({{row.model.nodesHealthy}}/{{row.model.nodesExpected}})
               </td>
               <td data-test-volume-provider>{{row.model.provider}}</td>
-              <td data-test-volume-allocations>{{row.model.allocations.length}}</td>
+              <td data-test-volume-allocations>{{row.model.allocationCount}}</td>
             </tr>
           </t.body>
         </ListTable>

--- a/ui/mirage/serializers/csi-volume.js
+++ b/ui/mirage/serializers/csi-volume.js
@@ -23,7 +23,10 @@ export default ApplicationSerializer.extend({
 });
 
 function serializeVolumeFromArray(volume) {
+  volume.CurrentWriters = volume.WriteAllocs.length;
   delete volume.WriteAllocs;
+
+  volume.CurrentReaders = volume.ReadAllocs.length;
   delete volume.ReadAllocs;
 }
 

--- a/ui/mirage/serializers/csi-volume.js
+++ b/ui/mirage/serializers/csi-volume.js
@@ -13,9 +13,7 @@ export default ApplicationSerializer.extend({
 
   serialize() {
     var json = ApplicationSerializer.prototype.serialize.apply(this, arguments);
-    if (json instanceof Array) {
-      json.forEach(serializeVolume);
-    } else {
+    if (!json instanceof Array) {
       serializeVolume(json);
     }
     return json;

--- a/ui/mirage/serializers/csi-volume.js
+++ b/ui/mirage/serializers/csi-volume.js
@@ -13,12 +13,19 @@ export default ApplicationSerializer.extend({
 
   serialize() {
     var json = ApplicationSerializer.prototype.serialize.apply(this, arguments);
-    if (!json instanceof Array) {
+    if (json instanceof Array) {
+      json.forEach(serializeVolumeFromArray);
+    } else {
       serializeVolume(json);
     }
     return json;
   },
 });
+
+function serializeVolumeFromArray(volume) {
+  delete volume.WriteAllocs;
+  delete volume.ReadAllocs;
+}
 
 function serializeVolume(volume) {
   volume.WriteAllocs = groupBy(volume.WriteAllocs, 'ID');


### PR DESCRIPTION
As detailed in #9495, the collection query `GET /v1/volumes?type=csi` doesn’t return `ReadAllocs` and `WriteAllocs`, so the `# Allocs` cell was always showing `0` upon first load because it was derived from the lengths of those arrays. This uses the heretofore-ignored `CurrentReaders` and `CurrentWriters` values to calculate the total instead.

The single-resource query `GET /v1/volume/csi%2F:id` doesn’t return `CurrentReaders` and `CurrentWriters` but you can see here that the missing values don’t cause the already-fetched ones to be deleted.

![csi-alloc-count](https://user-images.githubusercontent.com/43280/101086619-c146fc80-3576-11eb-8401-ca7d719a336e.gif)

Thanks to @apollo13 for reporting this in #9495 and to @tgross for the API logs and suggestion.