### PR TITLE
docs: clarify connect upgrade procedure

### DIFF
--- a/website/pages/docs/integrations/consul-connect.mdx
+++ b/website/pages/docs/integrations/consul-connect.mdx
@@ -329,6 +329,8 @@ dashes (`-`) are converted to underscores (`_`) in environment variables so
 - The `consul` binary must be present in Nomad's `$PATH` to run the Envoy
   proxy sidecar on client nodes.
 - Consul Connect using network namespaces is only supported on Linux.
+- Prior to Nomad 1.0 and Consul 1.9, the Envoy sidecar proxy may drop and stop
+  accepting connections while the Nomad agent is restarting.
 
 [count-dashboard]: /img/count-dashboard.png
 [gh6120]: https://github.com/hashicorp/nomad/issues/6120

--- a/website/pages/docs/integrations/consul-connect.mdx
+++ b/website/pages/docs/integrations/consul-connect.mdx
@@ -329,8 +329,8 @@ dashes (`-`) are converted to underscores (`_`) in environment variables so
 - The `consul` binary must be present in Nomad's `$PATH` to run the Envoy
   proxy sidecar on client nodes.
 - Consul Connect using network namespaces is only supported on Linux.
-- Prior to Nomad 1.0 and Consul 1.9, the Envoy sidecar proxy may drop and stop
-  accepting connections while the Nomad agent is restarting.
+- Prior to Consul 1.9, the Envoy sidecar proxy will drop and stop accepting
+  connections while the Nomad agent is restarting.
 
 [count-dashboard]: /img/count-dashboard.png
 [gh6120]: https://github.com/hashicorp/nomad/issues/6120

--- a/website/pages/docs/upgrade/upgrade-specific.mdx
+++ b/website/pages/docs/upgrade/upgrade-specific.mdx
@@ -81,7 +81,20 @@ Nomad. The specific configuration values replaced are:
 - Docker driver `docker.caps.whitelist` is replaced with
   `docker.caps.allowlist`.
 
-### Envoy proxy versions
+### Consul Connect
+
+Nomad 1.0's Consul Connect integration works best with Consul 1.9 or later. The
+ideal upgrade path is:
+
+1. Create a new Nomad client image with Nomad 1.0 and Consul 1.9 or later.
+2. Add new hosts based on the image.
+3. [Drain][drain-cli] and shutdown old Nomad client nodes.
+
+While inplace upgrades and older versions of Consul are supported by Nomad 1.0,
+Envoy proxies may drop and stop accepting connections while the Nomad agent is
+restarting. Nomad 1.0 with Consul 1.9 do not have this limitation.
+
+#### Envoy proxy versions
 
 Nomad v1.0.0 changes the behavior around the selection of Envoy version used for
 Connect sidecar proxies. Previously, Nomad always defaulted to Envoy v1.11.2 if
@@ -104,7 +117,7 @@ will ensure Connect workloads are properly rescheduled onto nodes in such a way
 that the Nomad Clients, Consul agents, and Envoy sidecar tasks maintain
 compatibility with one another.
 
-### Envoy worker threads
+#### Envoy worker threads
 
 Nomad v1.0.0 changes the default behavior around the number of worker threads
 created by the Envoy sidecar proxy when using Consul Connect. Previously, the

--- a/website/pages/docs/upgrade/upgrade-specific.mdx
+++ b/website/pages/docs/upgrade/upgrade-specific.mdx
@@ -91,7 +91,7 @@ ideal upgrade path is:
 3. [Drain][drain-cli] and shutdown old Nomad client nodes.
 
 While inplace upgrades and older versions of Consul are supported by Nomad 1.0,
-Envoy proxies may drop and stop accepting connections while the Nomad agent is
+Envoy proxies will drop and stop accepting connections while the Nomad agent is
 restarting. Nomad 1.0 with Consul 1.9 do not have this limitation.
 
 #### Envoy proxy versions


### PR DESCRIPTION
During testing we discovered old versions of Nomad and Consul seemed to
prevent Envoy from accepting new connections while the Nomad agent was
being upgraded.

![image](https://user-images.githubusercontent.com/113362/101090425-7f648900-356b-11eb-9e98-439f22a0b78d.png)
