### PR TITLE
Allow client.cpu_total_compute to override attr.cpu.totalcompute

### DIFF
--- a/client/fingerprint/cpu.go
+++ b/client/fingerprint/cpu.go
@@ -39,11 +39,6 @@ func (f *CPUFingerprint) Fingerprint(req *FingerprintRequest, resp *FingerprintR
 		f.logger.Warn("failed initializing stats collector", "error", err)
 	}
 
-	if cfg.CpuCompute != 0 {
-		setResourcesCPU(cfg.CpuCompute)
-		return nil
-	}
-
 	if modelName := stats.CPUModelName(); modelName != "" {
 		resp.AddAttribute("cpu.modelname", modelName)
 	}

--- a/client/fingerprint/cpu_test.go
+++ b/client/fingerprint/cpu_test.go
@@ -1,6 +1,7 @@
 package fingerprint
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/nomad/client/config"
@@ -101,6 +102,9 @@ func TestCPUFingerprint_OverrideCompute(t *testing.T) {
 		}
 		if response.NodeResources.Cpu.CpuShares != int64(cfg.CpuCompute) {
 			t.Fatalf("expected override cpu of %d but found %d", cfg.CpuCompute, response.NodeResources.Cpu.CpuShares)
+		}
+		if response.Attributes["cpu.totalcompute"] != strconv.Itoa(cfg.CpuCompute) {
+			t.Fatalf("expected override cpu.totalcompute of %d but found %s", cfg.CpuCompute, response.Attributes["cpu.totalcompute"])
 		}
 	}
 }

--- a/client/fingerprint/env_aws.go
+++ b/client/fingerprint/env_aws.go
@@ -187,6 +187,8 @@ func (f *EnvAWSFingerprint) Fingerprint(request *FingerprintRequest, response *F
 				nodeResources = new(structs.NodeResources)
 			}
 			nodeResources.Cpu = structs.NodeCpuResources{CpuShares: int64(ticks)}
+		} else {
+			response.AddAttribute("cpu.totalcompute", fmt.Sprintf("%d", request.Config.CpuCompute))
 		}
 	} else {
 		f.logger.Warn("failed to find the cpu specification for this instance type")

--- a/client/fingerprint/env_aws_test.go
+++ b/client/fingerprint/env_aws_test.go
@@ -241,7 +241,7 @@ func TestCPUFingerprint_AWS_OverrideCompute(t *testing.T) {
 	require.True(t, response.Detected)
 	require.Equal(t, "2200", response.Attributes["cpu.frequency"])
 	require.Equal(t, "8", response.Attributes["cpu.numcores"])
-	require.NotContains(t, response.Attributes, "cpu.totalcompute")
+	require.Equal(t, "99999", response.Attributes["cpu.totalcompute"])
 	require.Nil(t, response.Resources)          // defaults in cpu fingerprinter
 	require.Zero(t, response.NodeResources.Cpu) // defaults in cpu fingerprinter
 }


### PR DESCRIPTION
The [documentation](https://www.nomadproject.io/docs/runtime/interpolation#interpreted_node_vars) states that `${attr.cpu.totalcompute}` may be overridden by `client.cpu_total_compute`.  The actual behaviour was that `attr.cpu.totalcompute` was unset when `cpu_total_compute` was used.

I think either the feature should operate how the documentation says, or the documentation should be updated.  I opted for changing the feature, as I think it would be useful.