### PR TITLE
Update golang version table

### DIFF
--- a/contributing/golang.md
+++ b/contributing/golang.md
@@ -12,7 +12,15 @@ version.
 
 | Nomad Version | Go Version |
 |:-------------:|:----------:|
-| 0.11          | 1.14       |
+| 1.0           | 1.15.5     |
+| 0.12.2        | 1.14.7     |
+| 0.12.1        | 1.14.6     |
+| 0.12.0        | 1.14.4     |
+| 0.11.4        | 1.14.6     |
+| 0.11.3        | 1.14.3     |
+| 0.11.0        | 1.14.1     |
+| 0.10.4        | 1.12.16    |
+| 0.10.2        | 1.12.13    |
 | 0.10          | 1.12       |
 | 0.9           | 1.11       |
 
@@ -22,7 +30,7 @@ The
 [`update_golang_version.sh`](https://github.com/hashicorp/nomad/blob/master/scripts/update_golang_version.sh)
 script is used to update the Go version for all build tools.
 
-The [Changelog](https://github.com/hashicorp/nomad/blob/v0.10.2/CHANGELOG.md)
+The [Changelog](https://github.com/hashicorp/nomad/blob/master/CHANGELOG.md)
 will note when the Go version has changed in the Improvements section:
 
 ```

--- a/scripts/update_golang_version.sh
+++ b/scripts/update_golang_version.sh
@@ -3,7 +3,7 @@
 if [ -z "$1" ]; then
     echo "usage: $0 GO_VERSION"
     echo ""
-    echo "For example: $0 1.14.3"
+    echo "For example: $0 1.15.5"
     exit 1
 fi
 


### PR DESCRIPTION
Updated Nomad / Go version table to include 1.0.  0.12 was missing altogether, so I also added the interim versions to provide a more complete picture of what we shipped.

Also a small tweak to `update_golang_version.sh` help text.