### PR TITLE
Upgrade links to guides

### DIFF
--- a/website/pages/docs/install/quickstart.mdx
+++ b/website/pages/docs/install/quickstart.mdx
@@ -12,16 +12,14 @@ environment.
 
 These installations are designed to get you started with Nomad easily and should
 be used only for experimentation purposes. If you are looking to install Nomad
-in production, please refer to our [Production Installation](/docs/install/production) guide here.
+in production, please refer to the [Production Installation](/docs/install/production) guide here.
 
 <Tabs>
 <Tab heading="Interactive Online Environment">
 
-Experiment with Nomad in your browser via the Katacoda interactive learning platform.
+Experiment with Nomad in your browser via Learn guides containing embedded Katacoda interactive learning environments.
 
-- [Introduction to Nomad](https://www.katacoda.com/hashicorp/scenarios/nomad-introduction)
-
-- [Nomad Playground](https://katacoda.com/hashicorp/scenarios/playground)
+- [Interactive Labs](https://learn.hashicorp.com/collections/nomad/interactive)
 
 </Tab>
 <Tab heading="Create a Cloud Lab">
@@ -58,7 +56,7 @@ Vagrant is a tool for building and managing virtual machine environments.
 these [instructions](https://www.vagrantup.com/docs/installation/). You will
 also need a virtualization tool, such as [VirtualBox][].
 
-You can download a Vagrantfile which will start a small Nomad cluster. First
+You can download a Vagrantfile which can start a small Nomad cluster. First
 create a new directory for your Vagrant environment.
 
 ```shell-session
@@ -84,7 +82,7 @@ you must create the virtual machine with the `vagrant up` command.
 $ vagrant up
 ```
 
-This will take a few minutes as the base Ubuntu box must be downloaded
+This takes a few minutes as the base Ubuntu box must be downloaded
 and provisioned with both Docker and Nomad. Once this completes, you should
 see this output.
 


### PR DESCRIPTION
Fixes #9535 - Katacoda guides are all embedded into Learn guides now, so no direct links.

Small drive-by style fixes.
