### PR TITLE
document some hcl2 quarks

### DIFF
--- a/website/pages/docs/job-specification/hcl2/expressions.mdx
+++ b/website/pages/docs/job-specification/hcl2/expressions.mdx
@@ -16,10 +16,10 @@ The simplest expressions are just literal values, like `"hello"` or `5`, but
 HCL also allows more complex expressions such as arithmetic, conditional
 evaluation, and a number of built-in functions.
 
-Expressions can be used in a number of places in HCL, but some contexts limit
-which expression constructs are allowed, such as requiring a literal value of a
-particular type or forbidding. Each language feature's documentation describes
-any restrictions it places on expressions.
+Expressions can be used in a number of places in HCL, particularly as attribute
+values. Attribute value expressions must adhere to the attribute type. Block
+labels must be string literals without any interpolation. Each language
+feature's documentation describes any restrictions it places on expressions.
 
 The rest of this page describes all of the features of Nomad's
 expression syntax.
@@ -272,7 +272,7 @@ job "example" {
   # ...
   service {
     port = "lb" # can use expressions here
-  
+
     dynamic "check" {
       for_each = local.check_paths
 

--- a/website/pages/docs/job-specification/hcl2/index.mdx
+++ b/website/pages/docs/job-specification/hcl2/index.mdx
@@ -66,7 +66,7 @@ task "example" {
 - _Blocks_ are containers for other content and usually represent the
   configuration of some kind of object, like a task. Blocks have a
   _block type,_ can have zero or more _labels,_ and have a _body_ that contains
-  any number of arguments and nested blocks.
+  any number of arguments and nested blocks. Block labels must be string literals.
 - _Arguments_ assign a value to a name. They appear within blocks.
 - _Expressions_ represent a value, either literally or by referencing and
   combining other values. They appear as values for arguments, or within other
@@ -126,3 +126,9 @@ hello
 HCL2 trims the whitespace preceding the delimiter in the last line.  So in the
 above example, `data` is read as `"hello\n  world\n  "` in HCL1, but `"hello\n
 world\n"` (note lack of trailing whitespace) in HCL2.
+
+### Decimals
+
+Nomad 0.12 and earlier accepted small decimal values without a leading zero
+(e.g. `.3`, `.59`, `.9`). In such case, Nomad 1.0 requires a leading zero (e.g.
+`0.3`, `0.59`, `0.9`).


### PR DESCRIPTION
Mainly note that block labels need to be string literals, and that decimals without a leading significant digits aren't acceptable anymore (e.g. `.9` are required to be `0.9`).

Dynamic blocks can be used here, but feels too much of a hack, or a hammer to highlight it here, specially given the error reporting and debugging isn't so straightforward. I'd advocate internally for relaxing the restriction and allowing expressions in block labels instead.

Related to https://github.com/hashicorp/nomad/issues/9522 .
