### PR TITLE
investigating where to ignore poststop task in alloc health tracker

### DIFF
--- a/client/allochealth/tracker.go
+++ b/client/allochealth/tracker.go
@@ -66,8 +66,8 @@ type Tracker struct {
 	// not needed
 	allocStopped chan struct{}
 
-	// lifecycleTasks is a set of tasks with lifecycle hook set and may
-	// terminate without affecting alloc health
+	// lifecycleTasks is a map of ephemeral tasks and their lifecycle hooks.
+	// These tasks may terminate without affecting alloc health
 	lifecycleTasks map[string]string
 
 	// l is used to lock shared fields listed below
@@ -290,7 +290,6 @@ func (t *Tracker) watchTaskEvents() {
 				return
 			}
 
-			// Ignore poststop since it will be pending until the main job exists
 			if state.State == structs.TaskStatePending {
 				latestStartTime = time.Time{}
 				break

--- a/client/allochealth/tracker_test.go
+++ b/client/allochealth/tracker_test.go
@@ -89,6 +89,46 @@ func TestTracker_Checks_Healthy(t *testing.T) {
 	}
 }
 
+func TestTracker_Checks_PendingPostStop_Healthy(t *testing.T) {
+	t.Parallel()
+
+	alloc := mock.LifecycleAlloc()
+	alloc.Job.TaskGroups[0].Migrate.MinHealthyTime = 1 // let's speed things up
+
+	// Synthesize running alloc and tasks
+	alloc.ClientStatus = structs.AllocClientStatusRunning
+	alloc.TaskStates = map[string]*structs.TaskState{
+		"web": {
+			State:     structs.TaskStateRunning,
+			StartedAt: time.Now(),
+		},
+		"post": {
+			State: structs.TaskStatePending,
+		},
+	}
+
+	logger := testlog.HCLogger(t)
+	b := cstructs.NewAllocBroadcaster(logger)
+	defer b.Close()
+
+	consul := consul.NewMockConsulServiceClient(t, logger)
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+
+	checkInterval := 10 * time.Millisecond
+	tracker := NewTracker(ctx, logger, alloc, b.Listen(), consul,
+		time.Millisecond, true)
+	tracker.checkLookupInterval = checkInterval
+	tracker.Start()
+
+	select {
+	case <-time.After(4 * checkInterval):
+		require.Fail(t, "timed out while waiting for health")
+	case h := <-tracker.HealthyCh():
+		require.True(t, h)
+	}
+}
+
 func TestTracker_Checks_Unhealthy(t *testing.T) {
 	t.Parallel()
 

--- a/client/allochealth/tracker_test.go
+++ b/client/allochealth/tracker_test.go
@@ -92,7 +92,7 @@ func TestTracker_Checks_Healthy(t *testing.T) {
 func TestTracker_Checks_PendingPostStop_Healthy(t *testing.T) {
 	t.Parallel()
 
-	alloc := mock.LifecycleAlloc()
+	alloc := mock.LifecycleAllocWithPoststopDeploy()
 	alloc.Job.TaskGroups[0].Migrate.MinHealthyTime = 1 // let's speed things up
 
 	// Synthesize running alloc and tasks

--- a/client/allocrunner/task_hook_coordinator_test.go
+++ b/client/allocrunner/task_hook_coordinator_test.go
@@ -35,7 +35,11 @@ func TestTaskHookCoordinator_PrestartRunsBeforeMain(t *testing.T) {
 
 	mainTask := tasks[0]
 	sideTask := tasks[1]
-	initTask := tasks[2]
+	initTask := tasks[3]
+
+	require.Equal(t, "web", mainTask.Name)
+	require.Equal(t, "side", sideTask.Name)
+	require.Equal(t, "init", initTask.Name)
 
 	coord := newTaskHookCoordinator(logger, tasks)
 	initCh := coord.startConditionForTask(initTask)
@@ -55,7 +59,11 @@ func TestTaskHookCoordinator_MainRunsAfterPrestart(t *testing.T) {
 
 	mainTask := tasks[0]
 	sideTask := tasks[1]
-	initTask := tasks[2]
+	initTask := tasks[3]
+
+	require.Equal(t, "web", mainTask.Name)
+	require.Equal(t, "side", sideTask.Name)
+	require.Equal(t, "init", initTask.Name)
 
 	coord := newTaskHookCoordinator(logger, tasks)
 	initCh := coord.startConditionForTask(initTask)
@@ -189,7 +197,11 @@ func TestTaskHookCoordinator_SidecarNeverStarts(t *testing.T) {
 
 	mainTask := tasks[0]
 	sideTask := tasks[1]
-	initTask := tasks[2]
+	initTask := tasks[3]
+
+	require.Equal(t, "web", mainTask.Name)
+	require.Equal(t, "side", sideTask.Name)
+	require.Equal(t, "init", initTask.Name)
 
 	coord := newTaskHookCoordinator(logger, tasks)
 	initCh := coord.startConditionForTask(initTask)
@@ -234,8 +246,14 @@ func TestTaskHookCoordinator_PoststartStartsAfterMain(t *testing.T) {
 	sideTask := tasks[1]
 	postTask := tasks[2]
 
+	require.Equal(t, "web", mainTask.Name)
+	require.Equal(t, "side", sideTask.Name)
+	require.Equal(t, "post", postTask.Name)
+	require.Equal(t, structs.TaskLifecycleHookPoststop, postTask.Lifecycle.Hook)
+
 	// Make the the third task a poststart hook
 	postTask.Lifecycle.Hook = structs.TaskLifecycleHookPoststart
+	require.Equal(t, structs.TaskLifecycleHookPoststart, postTask.Lifecycle.Hook)
 
 	coord := newTaskHookCoordinator(logger, tasks)
 	postCh := coord.startConditionForTask(postTask)

--- a/client/allocrunner/task_hook_coordinator_test.go
+++ b/client/allocrunner/task_hook_coordinator_test.go
@@ -35,11 +35,7 @@ func TestTaskHookCoordinator_PrestartRunsBeforeMain(t *testing.T) {
 
 	mainTask := tasks[0]
 	sideTask := tasks[1]
-	initTask := tasks[3]
-
-	require.Equal(t, "web", mainTask.Name)
-	require.Equal(t, "side", sideTask.Name)
-	require.Equal(t, "init", initTask.Name)
+	initTask := tasks[2]
 
 	coord := newTaskHookCoordinator(logger, tasks)
 	initCh := coord.startConditionForTask(initTask)
@@ -59,11 +55,7 @@ func TestTaskHookCoordinator_MainRunsAfterPrestart(t *testing.T) {
 
 	mainTask := tasks[0]
 	sideTask := tasks[1]
-	initTask := tasks[3]
-
-	require.Equal(t, "web", mainTask.Name)
-	require.Equal(t, "side", sideTask.Name)
-	require.Equal(t, "init", initTask.Name)
+	initTask := tasks[2]
 
 	coord := newTaskHookCoordinator(logger, tasks)
 	initCh := coord.startConditionForTask(initTask)
@@ -197,11 +189,7 @@ func TestTaskHookCoordinator_SidecarNeverStarts(t *testing.T) {
 
 	mainTask := tasks[0]
 	sideTask := tasks[1]
-	initTask := tasks[3]
-
-	require.Equal(t, "web", mainTask.Name)
-	require.Equal(t, "side", sideTask.Name)
-	require.Equal(t, "init", initTask.Name)
+	initTask := tasks[2]
 
 	coord := newTaskHookCoordinator(logger, tasks)
 	initCh := coord.startConditionForTask(initTask)
@@ -246,14 +234,8 @@ func TestTaskHookCoordinator_PoststartStartsAfterMain(t *testing.T) {
 	sideTask := tasks[1]
 	postTask := tasks[2]
 
-	require.Equal(t, "web", mainTask.Name)
-	require.Equal(t, "side", sideTask.Name)
-	require.Equal(t, "post", postTask.Name)
-	require.Equal(t, structs.TaskLifecycleHookPoststop, postTask.Lifecycle.Hook)
-
 	// Make the the third task a poststart hook
 	postTask.Lifecycle.Hook = structs.TaskLifecycleHookPoststart
-	require.Equal(t, structs.TaskLifecycleHookPoststart, postTask.Lifecycle.Hook)
 
 	coord := newTaskHookCoordinator(logger, tasks)
 	postCh := coord.startConditionForTask(postTask)

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -395,6 +395,158 @@ func LifecycleJob() *structs.Job {
 		},
 		TaskGroups: []*structs.TaskGroup{
 			{
+				Name:  "web",
+				Count: 1,
+				RestartPolicy: &structs.RestartPolicy{
+					Attempts: 0,
+					Interval: 10 * time.Minute,
+					Delay:    1 * time.Minute,
+					Mode:     structs.RestartPolicyModeFail,
+				},
+				Tasks: []*structs.Task{
+					{
+						Name:   "web",
+						Driver: "mock_driver",
+						Config: map[string]interface{}{
+							"run_for": "1s",
+						},
+						LogConfig: structs.DefaultLogConfig(),
+						Resources: &structs.Resources{
+							CPU:      1000,
+							MemoryMB: 256,
+						},
+					},
+					{
+						Name:   "side",
+						Driver: "mock_driver",
+						Config: map[string]interface{}{
+							"run_for": "1s",
+						},
+						Lifecycle: &structs.TaskLifecycleConfig{
+							Hook:    structs.TaskLifecycleHookPrestart,
+							Sidecar: true,
+						},
+						LogConfig: structs.DefaultLogConfig(),
+						Resources: &structs.Resources{
+							CPU:      1000,
+							MemoryMB: 256,
+						},
+					},
+					{
+						Name:   "init",
+						Driver: "mock_driver",
+						Config: map[string]interface{}{
+							"run_for": "1s",
+						},
+						Lifecycle: &structs.TaskLifecycleConfig{
+							Hook:    structs.TaskLifecycleHookPrestart,
+							Sidecar: false,
+						},
+						LogConfig: structs.DefaultLogConfig(),
+						Resources: &structs.Resources{
+							CPU:      1000,
+							MemoryMB: 256,
+						},
+					},
+				},
+			},
+		},
+		Meta: map[string]string{
+			"owner": "armon",
+		},
+		Status:         structs.JobStatusPending,
+		Version:        0,
+		CreateIndex:    42,
+		ModifyIndex:    99,
+		JobModifyIndex: 99,
+	}
+	job.Canonicalize()
+	return job
+}
+
+func LifecycleAlloc() *structs.Allocation {
+	alloc := &structs.Allocation{
+		ID:        uuid.Generate(),
+		EvalID:    uuid.Generate(),
+		NodeID:    "12345678-abcd-efab-cdef-123456789abc",
+		Namespace: structs.DefaultNamespace,
+		TaskGroup: "web",
+
+		// TODO Remove once clientv2 gets merged
+		Resources: &structs.Resources{
+			CPU:      500,
+			MemoryMB: 256,
+		},
+		TaskResources: map[string]*structs.Resources{
+			"web": {
+				CPU:      1000,
+				MemoryMB: 256,
+			},
+			"init": {
+				CPU:      1000,
+				MemoryMB: 256,
+			},
+			"side": {
+				CPU:      1000,
+				MemoryMB: 256,
+			},
+		},
+
+		AllocatedResources: &structs.AllocatedResources{
+			Tasks: map[string]*structs.AllocatedTaskResources{
+				"web": {
+					Cpu: structs.AllocatedCpuResources{
+						CpuShares: 1000,
+					},
+					Memory: structs.AllocatedMemoryResources{
+						MemoryMB: 256,
+					},
+				},
+				"init": {
+					Cpu: structs.AllocatedCpuResources{
+						CpuShares: 1000,
+					},
+					Memory: structs.AllocatedMemoryResources{
+						MemoryMB: 256,
+					},
+				},
+				"side": {
+					Cpu: structs.AllocatedCpuResources{
+						CpuShares: 1000,
+					},
+					Memory: structs.AllocatedMemoryResources{
+						MemoryMB: 256,
+					},
+				},
+			},
+		},
+		Job:           LifecycleJob(),
+		DesiredStatus: structs.AllocDesiredStatusRun,
+		ClientStatus:  structs.AllocClientStatusPending,
+	}
+	alloc.JobID = alloc.Job.ID
+	return alloc
+}
+
+func LifecycleJobWithPoststopDeploy() *structs.Job {
+	job := &structs.Job{
+		Region:      "global",
+		ID:          fmt.Sprintf("mock-service-%s", uuid.Generate()),
+		Name:        "my-job",
+		Namespace:   structs.DefaultNamespace,
+		Type:        structs.JobTypeBatch,
+		Priority:    50,
+		AllAtOnce:   false,
+		Datacenters: []string{"dc1"},
+		Constraints: []*structs.Constraint{
+			{
+				LTarget: "${attr.kernel.name}",
+				RTarget: "linux",
+				Operand: "=",
+			},
+		},
+		TaskGroups: []*structs.TaskGroup{
+			{
 				Name:    "web",
 				Count:   1,
 				Migrate: structs.DefaultMigrateStrategy(),
@@ -480,7 +632,7 @@ func LifecycleJob() *structs.Job {
 	return job
 }
 
-func LifecycleAlloc() *structs.Allocation {
+func LifecycleAllocWithPoststopDeploy() *structs.Allocation {
 	alloc := &structs.Allocation{
 		ID:        uuid.Generate(),
 		EvalID:    uuid.Generate(),
@@ -548,7 +700,7 @@ func LifecycleAlloc() *structs.Allocation {
 				},
 			},
 		},
-		Job:           LifecycleJob(),
+		Job:           LifecycleJobWithPoststopDeploy(),
 		DesiredStatus: structs.AllocDesiredStatusRun,
 		ClientStatus:  structs.AllocClientStatusPending,
 	}

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -395,8 +395,9 @@ func LifecycleJob() *structs.Job {
 		},
 		TaskGroups: []*structs.TaskGroup{
 			{
-				Name:  "web",
-				Count: 1,
+				Name:    "web",
+				Count:   1,
+				Migrate: structs.DefaultMigrateStrategy(),
 				RestartPolicy: &structs.RestartPolicy{
 					Attempts: 0,
 					Interval: 10 * time.Minute,
@@ -425,6 +426,21 @@ func LifecycleJob() *structs.Job {
 						Lifecycle: &structs.TaskLifecycleConfig{
 							Hook:    structs.TaskLifecycleHookPrestart,
 							Sidecar: true,
+						},
+						LogConfig: structs.DefaultLogConfig(),
+						Resources: &structs.Resources{
+							CPU:      1000,
+							MemoryMB: 256,
+						},
+					},
+					{
+						Name:   "post",
+						Driver: "mock_driver",
+						Config: map[string]interface{}{
+							"run_for": "1s",
+						},
+						Lifecycle: &structs.TaskLifecycleConfig{
+							Hook: structs.TaskLifecycleHookPoststop,
 						},
 						LogConfig: structs.DefaultLogConfig(),
 						Resources: &structs.Resources{
@@ -490,6 +506,10 @@ func LifecycleAlloc() *structs.Allocation {
 				CPU:      1000,
 				MemoryMB: 256,
 			},
+			"post": {
+				CPU:      1000,
+				MemoryMB: 256,
+			},
 		},
 
 		AllocatedResources: &structs.AllocatedResources{
@@ -511,6 +531,14 @@ func LifecycleAlloc() *structs.Allocation {
 					},
 				},
 				"side": {
+					Cpu: structs.AllocatedCpuResources{
+						CpuShares: 1000,
+					},
+					Memory: structs.AllocatedMemoryResources{
+						MemoryMB: 256,
+					},
+				},
+				"post": {
 					Cpu: structs.AllocatedCpuResources{
 						CpuShares: 1000,
 					},


### PR DESCRIPTION
Ignores poststop jobs pending state when calculating the lastest start time for an allocation

resolves #9361 