### PR TITLE
fix AgentHostRequest panic found in GH-9546

### DIFF
--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -716,36 +716,18 @@ func (s *HTTPServer) AgentHostRequest(resp http.ResponseWriter, req *http.Reques
 	var reply structs.HostDataResponse
 	var rpcErr error
 
-	// serverID is set, find path to make RPC call to server
+	// If serverID is specified, use that to lookup the RPC interface
+	lookupNodeID := nodeID
 	if serverID != "" {
-		// Verify Server() exists before making RPC call
-		server := s.agent.Server()
-		if server == nil {
-			s.agent.logger.Trace("s.agent.Server() is nil -- forwarding Agent.Host RPC through s.agent.Client() instead", "serverID", serverID)
-			// Verify Client() exists
-			client := s.agent.Client()
-			if client == nil {
-				rpcErr = fmt.Errorf("failed to retrieve Client() or Server() for Agent.Host RPC call to serverID: %s", serverID)
-			} else {
-				// Send RPC via local client
-				rpcErr = client.RPC("Agent.Host", &args, &reply)
-			}
-		} else {
-			// Send RPC via local server
-			rpcErr = server.RPC("Agent.Host", &args, &reply)
-		}
-
-		if rpcErr != nil {
-			rpcErr = fmt.Errorf("failed Agent.Host RPC to serverID: %s, err: %w", serverID, rpcErr)
-		}
-		return reply, rpcErr
+		lookupNodeID = serverID
 	}
 
-	// Make the RPC. The RPC endpoint actually forwards the request to the correct
+	// The RPC endpoint actually forwards the request to the correct
 	// agent, but we need to use the correct RPC interface.
-	localClient, remoteClient, localServer := s.rpcHandlerForNode(nodeID)
-	s.agent.logger.Trace("s.rpcHandlerForNode()", "serverID", serverID, "nodeID", nodeID, "localClient", localClient, "remoteClient", remoteClient, "localServer", localServer)
+	localClient, remoteClient, localServer := s.rpcHandlerForNode(lookupNodeID)
+	s.agent.logger.Debug("s.rpcHandlerForNode()", "lookupNodeID", lookupNodeID, "serverID", serverID, "nodeID", nodeID, "localClient", localClient, "remoteClient", remoteClient, "localServer", localServer)
 
+	// Make the RPC call
 	if localClient {
 		rpcErr = s.agent.Client().ClientRPC("Agent.Host", &args, &reply)
 	} else if remoteClient {

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -291,7 +291,7 @@ func TestDebug_ClientToServer(t *testing.T) {
 			addrServer,
 		},
 		{
-			"client1 address - fails with SIGSEGV",
+			"client1 address - verify no SIGSEGV panic",
 			addrClient1,
 		},
 	}

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -95,7 +95,7 @@ func TestDebug_NodeClass(t *testing.T) {
 	srvRPCAddr := srv.GetConfig().AdvertiseAddrs.RPC
 	t.Logf("[TEST] Leader started, srv.GetConfig().AdvertiseAddrs.RPC: %s", srvRPCAddr)
 
-	// Setup Client 1 (nodeclass = clienta)
+	// Setup client 1 (nodeclass = clienta)
 	agentConfFunc1 := func(c *agent.Config) {
 		c.Region = "global"
 		c.Server.Enabled = false
@@ -104,16 +104,16 @@ func TestDebug_NodeClass(t *testing.T) {
 		c.Client.Servers = []string{srvRPCAddr}
 	}
 
-	// Start Client 1
+	// Start client 1
 	client1 := agent.NewTestAgent(t, "client1", agentConfFunc1)
 	defer client1.Shutdown()
 
-	// Wait for the client to connect
+	// Wait for client1 to connect
 	client1NodeID := client1.Agent.Client().NodeID()
 	testutil.WaitForClient(t, srv.Agent.RPC, client1NodeID)
 	t.Logf("[TEST] Client1 ready, id: %s", client1NodeID)
 
-	// Setup Client 2 (nodeclass = clientb)
+	// Setup client 2 (nodeclass = clientb)
 	agentConfFunc2 := func(c *agent.Config) {
 		c.Region = "global"
 		c.Server.Enabled = false
@@ -122,27 +122,27 @@ func TestDebug_NodeClass(t *testing.T) {
 		c.Client.Servers = []string{srvRPCAddr}
 	}
 
-	// Start Client 2
+	// Start client 2
 	client2 := agent.NewTestAgent(t, "client2", agentConfFunc2)
 	defer client2.Shutdown()
 
-	// Wait for the client to connect
+	// Wait for client2 to connect
 	client2NodeID := client2.Agent.Client().NodeID()
 	testutil.WaitForClient(t, srv.Agent.RPC, client2NodeID)
 	t.Logf("[TEST] Client2 ready, id: %s", client2NodeID)
 
-	// Setup Client 3 (nodeclass = clienta)
+	// Setup client 3 (nodeclass = clienta)
 	agentConfFunc3 := func(c *agent.Config) {
 		c.Server.Enabled = false
 		c.Client.NodeClass = "clienta"
 		c.Client.Servers = []string{srvRPCAddr}
 	}
 
-	// Start Client 3
+	// Start client 3
 	client3 := agent.NewTestAgent(t, "client3", agentConfFunc3)
 	defer client3.Shutdown()
 
-	// Wait for the client to connect
+	// Wait for client3 to connect
 	client3NodeID := client3.Agent.Client().NodeID()
 	testutil.WaitForClient(t, srv.Agent.RPC, client3NodeID)
 	t.Logf("[TEST] Client3 ready, id: %s", client3NodeID)
@@ -151,18 +151,58 @@ func TestDebug_NodeClass(t *testing.T) {
 	ui := cli.NewMockUi()
 	cmd := &OperatorDebugCommand{Meta: Meta{Ui: ui}}
 
-	// Debug on client - node class = "clienta"
-	code := cmd.Run([]string{"-address", url, "-duration", "250ms", "-server-id", "all", "-node-id", "all", "-node-class", "clienta", "-max-nodes", "2"})
+	// Setup test cases struct
+	cases := []struct {
+		name            string
+		args            []string
+		expectedCode    int
+		expectedOutputs []string
+		expectedError   string
+	}{
+		{
+			name:         "address=api, node-class=clienta, max-nodes=2",
+			args:         []string{"-address", url, "-duration", "250ms", "-server-id", "all", "-node-id", "all", "-node-class", "clienta", "-max-nodes", "2"},
+			expectedCode: 0,
+			expectedOutputs: []string{
+				"Starting debugger",
+				"Created debug archive",
+				"Max node count reached (2)",
+				"Node Class: clienta",
+			},
+			expectedError: "",
+		},
+		{
+			name:         "address=api, node-class=clientb, max-nodes=2",
+			args:         []string{"-address", url, "-duration", "250ms", "-server-id", "all", "-node-id", "all", "-node-class", "clientb", "-max-nodes", "2"},
+			expectedCode: 0,
+			expectedOutputs: []string{
+				"Starting debugger",
+				"Created debug archive",
+				"Node Class: clientb",
+			},
+			expectedError: "",
+		},
+	}
 
-	assert.Equal(t, 0, code)
-	require.Empty(t, ui.ErrorWriter.String(), "errorwriter should be empty")
-	require.Contains(t, ui.OutputWriter.String(), "Starting debugger")
-	require.Contains(t, ui.OutputWriter.String(), "Max node count reached (2)")
-	require.Contains(t, ui.OutputWriter.String(), "Node Class: clienta")
-	require.Contains(t, ui.OutputWriter.String(), "Created debug archive")
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Run test case
+			code := cmd.Run(c.args)
+			out := ui.OutputWriter.String()
+			outerr := ui.ErrorWriter.String()
 
-	ui.OutputWriter.Reset()
-	ui.ErrorWriter.Reset()
+			// Verify case expectations
+			require.Equalf(t, code, c.expectedCode, "expected exit code %d, got: %d: %s", c.expectedCode, code, outerr)
+			for _, expectedOutput := range c.expectedOutputs {
+				require.Contains(t, out, expectedOutput, "expected output \"%s\", got \"%s\"", expectedOutput, out)
+			}
+			require.Containsf(t, outerr, c.expectedError, "expected error \"%s\", got \"%s\"", c.expectedError, outerr)
+
+			// Reset buffers before next test
+			ui.OutputWriter.Reset()
+			ui.ErrorWriter.Reset()
+		})
+	}
 }
 
 func TestDebugFail_Pprof(t *testing.T) {


### PR DESCRIPTION
When running `nomad operator debug` from a client node, attempts to retrieve Agent.Host from a server member would panic when trying to make the RPC request.  This PR tests both s.agent.Server() and s.agent.Client() to ensure they are valid before making the RPC call.

A test case was added to verify the panic, then verify the fix worked.  Also cleaned up TestDebug_NodeClass test as it was used as the test template.