### PR TITLE
return 405 on non-GET requests to /v1/event/stream (fixes #9526)

### DIFF
--- a/command/agent/event_endpoint.go
+++ b/command/agent/event_endpoint.go
@@ -18,6 +18,10 @@ import (
 )
 
 func (s *HTTPServer) EventStream(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if req.Method != http.MethodGet {
+		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
+	}
+
 	query := req.URL.Query()
 
 	indexStr := query.Get("index")


### PR DESCRIPTION
Not sure if you want to have an additional test for this. I checked and I don't think any other endpoint has. 