### PR TITLE
scripts: fail if golang installation fails

### DIFF
--- a/scripts/release/Dockerfile
+++ b/scripts/release/Dockerfile
@@ -2,7 +2,7 @@
 # that mimics Vagrant environment as far as required
 # for building the scripts and running provision scripts
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update; apt-get install -y \
             apt-transport-https \

--- a/scripts/vagrant-linux-priv-go.sh
+++ b/scripts/vagrant-linux-priv-go.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
 
+set -o errexit
+
 function install_go() {
 	local go_version="1.15.5"
-	local download=
+	local download="https://storage.googleapis.com/golang/go${go_version}.linux-amd64.tar.gz"
 
-	download="https://storage.googleapis.com/golang/go${go_version}.linux-amd64.tar.gz"
-
-	if [ -d /usr/local/go ] ; then
+		if go version 2>&1 | grep -q "${go_version}"; then
 		return
 	fi
 
-	curl -sSL --fail -o /tmp/go.tar.gz ${download}
+	# remove previous older version
+	rm -rf /usr/local/go
+
+	# retry downloading on spurious failure
+	curl -sSL --fail -o /tmp/go.tar.gz \
+		--retry 5 --retry-connrefused \
+		"${download}"
 
 	tar -C /tmp -xf /tmp/go.tar.gz
 	sudo mv /tmp/go /usr/local
@@ -18,7 +24,7 @@ function install_go() {
 }
 
 install_go
-	
+
 # Ensure that the GOPATH tree is owned by vagrant:vagrant
 mkdir -p /opt/gopath
 chown -R vagrant:vagrant /opt/gopath


### PR DESCRIPTION
This makes few changes to golang installation scripts: ensure that the script fails if any step fails, retry downloading if the download fails.

Also, update our release docker container image to use 18.04, so it matches our Vagrant box.  We ought to upgrade both to 20.04 but punting on for now that until I can test the Vagrant box.