### PR TITLE
UI: Move breadcrumbs objects into shared layout object

### DIFF
--- a/ui/tests/acceptance/client-detail-test.js
+++ b/ui/tests/acceptance/client-detail-test.js
@@ -9,6 +9,7 @@ import moment from 'moment';
 import ClientDetail from 'nomad-ui/tests/pages/clients/detail';
 import Clients from 'nomad-ui/tests/pages/clients/list';
 import Jobs from 'nomad-ui/tests/pages/jobs/list';
+import Layout from 'nomad-ui/tests/pages/layout';
 
 let node;
 let managementToken;
@@ -53,16 +54,16 @@ module('Acceptance | client detail', function(hooks) {
     assert.equal(document.title, `Client ${node.name} - Nomad`);
 
     assert.equal(
-      ClientDetail.breadcrumbFor('clients.index').text,
+      Layout.breadcrumbFor('clients.index').text,
       'Clients',
       'First breadcrumb says clients'
     );
     assert.equal(
-      ClientDetail.breadcrumbFor('clients.client').text,
+      Layout.breadcrumbFor('clients.client').text,
       node.id.split('-')[0],
       'Second breadcrumb says the node short id'
     );
-    await ClientDetail.breadcrumbFor('clients.index').visit();
+    await Layout.breadcrumbFor('clients.index').visit();
     assert.equal(currentURL(), '/clients', 'First breadcrumb links back to clients');
   });
 

--- a/ui/tests/acceptance/client-monitor-test.js
+++ b/ui/tests/acceptance/client-monitor-test.js
@@ -5,6 +5,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import ClientMonitor from 'nomad-ui/tests/pages/clients/monitor';
+import Layout from 'nomad-ui/tests/pages/layout';
 
 let node;
 let managementToken;
@@ -34,10 +35,10 @@ module('Acceptance | client monitor', function(hooks) {
   test('/clients/:id/monitor should have a breadcrumb trail linking back to clients', async function(assert) {
     await ClientMonitor.visit({ id: node.id });
 
-    assert.equal(ClientMonitor.breadcrumbFor('clients.index').text, 'Clients');
-    assert.equal(ClientMonitor.breadcrumbFor('clients.client').text, node.id.split('-')[0]);
+    assert.equal(Layout.breadcrumbFor('clients.index').text, 'Clients');
+    assert.equal(Layout.breadcrumbFor('clients.client').text, node.id.split('-')[0]);
 
-    await ClientMonitor.breadcrumbFor('clients.index').visit();
+    await Layout.breadcrumbFor('clients.index').visit();
     assert.equal(currentURL(), '/clients');
   });
 

--- a/ui/tests/acceptance/optimize-test.js
+++ b/ui/tests/acceptance/optimize-test.js
@@ -7,7 +7,7 @@ import Response from 'ember-cli-mirage/response';
 import moment from 'moment';
 
 import Optimize from 'nomad-ui/tests/pages/optimize';
-import PageLayout from 'nomad-ui/tests/pages/layout';
+import Layout from 'nomad-ui/tests/pages/layout';
 import JobsList from 'nomad-ui/tests/pages/jobs/list';
 
 let managementToken, clientToken;
@@ -68,7 +68,7 @@ module('Acceptance | optimize', function(hooks) {
     const currentTaskGroup = this.job1.taskGroups.models[0];
     const nextTaskGroup = this.job2.taskGroups.models[0];
 
-    assert.equal(PageLayout.breadcrumbFor('optimize').text, 'Recommendations');
+    assert.equal(Layout.breadcrumbFor('optimize').text, 'Recommendations');
 
     assert.equal(
       Optimize.recommendationSummaries[0].slug,
@@ -76,7 +76,7 @@ module('Acceptance | optimize', function(hooks) {
     );
 
     assert.equal(
-      PageLayout.breadcrumbFor('optimize.summary').text,
+      Layout.breadcrumbFor('optimize.summary').text,
       `${this.job1.name} / ${currentTaskGroup.name}`
     );
 
@@ -342,7 +342,7 @@ module('Acceptance | optimize', function(hooks) {
     await Optimize.visit();
 
     assert.equal(currentURL(), '/jobs');
-    assert.ok(PageLayout.gutter.optimize.isHidden);
+    assert.ok(Layout.gutter.optimize.isHidden);
   });
 
   test('it reloads partially-loaded jobs', async function(assert) {

--- a/ui/tests/acceptance/optimize-test.js
+++ b/ui/tests/acceptance/optimize-test.js
@@ -68,7 +68,7 @@ module('Acceptance | optimize', function(hooks) {
     const currentTaskGroup = this.job1.taskGroups.models[0];
     const nextTaskGroup = this.job2.taskGroups.models[0];
 
-    assert.equal(Optimize.breadcrumbFor('optimize').text, 'Recommendations');
+    assert.equal(PageLayout.breadcrumbFor('optimize').text, 'Recommendations');
 
     assert.equal(
       Optimize.recommendationSummaries[0].slug,
@@ -76,7 +76,7 @@ module('Acceptance | optimize', function(hooks) {
     );
 
     assert.equal(
-      Optimize.breadcrumbFor('optimize.summary').text,
+      PageLayout.breadcrumbFor('optimize.summary').text,
       `${this.job1.name} / ${currentTaskGroup.name}`
     );
 

--- a/ui/tests/acceptance/plugin-detail-test.js
+++ b/ui/tests/acceptance/plugin-detail-test.js
@@ -6,6 +6,7 @@ import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import moment from 'moment';
 import { formatBytes } from 'nomad-ui/helpers/format-bytes';
 import PluginDetail from 'nomad-ui/tests/pages/storage/plugins/detail';
+import Layout from 'nomad-ui/tests/pages/layout';
 
 module('Acceptance | plugin detail', function(hooks) {
   setupApplicationTest(hooks);
@@ -26,9 +27,9 @@ module('Acceptance | plugin detail', function(hooks) {
   test('/csi/plugins/:id should have a breadcrumb trail linking back to Plugins and Storage', async function(assert) {
     await PluginDetail.visit({ id: plugin.id });
 
-    assert.equal(PluginDetail.breadcrumbFor('csi.index').text, 'Storage');
-    assert.equal(PluginDetail.breadcrumbFor('csi.plugins').text, 'Plugins');
-    assert.equal(PluginDetail.breadcrumbFor('csi.plugins.plugin').text, plugin.id);
+    assert.equal(Layout.breadcrumbFor('csi.index').text, 'Storage');
+    assert.equal(Layout.breadcrumbFor('csi.plugins').text, 'Plugins');
+    assert.equal(Layout.breadcrumbFor('csi.plugins.plugin').text, plugin.id);
   });
 
   test('/csi/plugins/:id should show the plugin name in the title', async function(assert) {

--- a/ui/tests/acceptance/regions-test.js
+++ b/ui/tests/acceptance/regions-test.js
@@ -6,7 +6,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import JobsList from 'nomad-ui/tests/pages/jobs/list';
 import ClientsList from 'nomad-ui/tests/pages/clients/list';
-import PageLayout from 'nomad-ui/tests/pages/layout';
+import Layout from 'nomad-ui/tests/pages/layout';
 import Allocation from 'nomad-ui/tests/pages/allocations/detail';
 
 module('Acceptance | regions (only one)', function(hooks) {
@@ -29,7 +29,7 @@ module('Acceptance | regions (only one)', function(hooks) {
 
     await JobsList.visit();
 
-    assert.notOk(PageLayout.navbar.regionSwitcher.isPresent, 'No region switcher');
+    assert.notOk(Layout.navbar.regionSwitcher.isPresent, 'No region switcher');
     assert.equal(document.title, 'Jobs - Nomad');
   });
 
@@ -38,7 +38,7 @@ module('Acceptance | regions (only one)', function(hooks) {
 
     await JobsList.visit();
 
-    assert.notOk(PageLayout.navbar.regionSwitcher.isPresent, 'No region switcher');
+    assert.notOk(Layout.navbar.regionSwitcher.isPresent, 'No region switcher');
   });
 
   test('pages do not include the region query param', async function(assert) {
@@ -60,8 +60,8 @@ module('Acceptance | regions (only one)', function(hooks) {
 
     await JobsList.visit();
     await JobsList.jobs.objectAt(0).clickRow();
-    await PageLayout.gutter.visitClients();
-    await PageLayout.gutter.visitServers();
+    await Layout.gutter.visitClients();
+    await Layout.gutter.visitServers();
     server.pretender.handledRequests.forEach(req => {
       assert.notOk(req.url.includes('region='), req.url);
     });
@@ -84,7 +84,7 @@ module('Acceptance | regions (many)', function(hooks) {
   test('the region switcher is rendered in the nav bar and the region is in the page title', async function(assert) {
     await JobsList.visit();
 
-    assert.ok(PageLayout.navbar.regionSwitcher.isPresent, 'Region switcher is shown');
+    assert.ok(Layout.navbar.regionSwitcher.isPresent, 'Region switcher is shown');
     assert.equal(document.title, 'Jobs - global - Nomad');
   });
 
@@ -159,11 +159,13 @@ module('Acceptance | regions (many)', function(hooks) {
     await JobsList.visit({ region });
 
     await JobsList.jobs.objectAt(0).clickRow();
-    await PageLayout.gutter.visitClients();
-    await PageLayout.gutter.visitServers();
+    await Layout.gutter.visitClients();
+    await Layout.gutter.visitServers();
     const [
-      , // License request
-      , // Token/policies request
+      ,
+      ,
+      // License request
+      // Token/policies request
       regionsRequest,
       defaultRegionRequest,
       ...appRequests

--- a/ui/tests/acceptance/search-test.js
+++ b/ui/tests/acceptance/search-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { currentURL, triggerEvent, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import PageLayout from 'nomad-ui/tests/pages/layout';
+import Layout from 'nomad-ui/tests/pages/layout';
 import JobsList from 'nomad-ui/tests/pages/jobs/list';
 import { selectSearch } from 'ember-power-select/test-support';
 import sinon from 'sinon';
@@ -36,9 +36,9 @@ module('Acceptance | search', function(hooks) {
     let presearchJobsRequestCount = getRequestCount(server, '/v1/jobs');
     let presearchNodesRequestCount = getRequestCount(server, '/v1/nodes');
 
-    await selectSearch(PageLayout.navbar.search.scope, 'xy');
+    await selectSearch(Layout.navbar.search.scope, 'xy');
 
-    PageLayout.navbar.search.as(search => {
+    Layout.navbar.search.as(search => {
       assert.equal(search.groups.length, 2);
 
       search.groups[0].as(jobs => {
@@ -66,18 +66,18 @@ module('Acceptance | search', function(hooks) {
       'a nodes request should happen when not in the clients hierarchy'
     );
 
-    await PageLayout.navbar.search.groups[0].options[0].click();
+    await Layout.navbar.search.groups[0].options[0].click();
     assert.equal(currentURL(), '/jobs/xyz');
 
-    await selectSearch(PageLayout.navbar.search.scope, otherNode.id.substr(0, 3));
+    await selectSearch(Layout.navbar.search.scope, otherNode.id.substr(0, 3));
 
-    await PageLayout.navbar.search.groups[1].options[0].click();
+    await Layout.navbar.search.groups[1].options[0].click();
     assert.equal(currentURL(), `/clients/${otherNode.id}`);
 
     presearchJobsRequestCount = getRequestCount(server, '/v1/jobs');
     presearchNodesRequestCount = getRequestCount(server, '/v1/nodes');
 
-    await selectSearch(PageLayout.navbar.search.scope, 'zzzzzzzzzzz');
+    await selectSearch(Layout.navbar.search.scope, 'zzzzzzzzzzz');
 
     assert.equal(
       getRequestCount(server, '/v1/jobs'),
@@ -92,7 +92,7 @@ module('Acceptance | search', function(hooks) {
 
     clock.tick(COLLECTION_CACHE_DURATION * 2);
 
-    await selectSearch(PageLayout.navbar.search.scope, otherNode.id.substr(0, 3));
+    await selectSearch(Layout.navbar.search.scope, otherNode.id.substr(0, 3));
 
     assert.equal(
       getRequestCount(server, '/v1/jobs'),
@@ -112,9 +112,9 @@ module('Acceptance | search', function(hooks) {
 
     await visit('/');
 
-    await selectSearch(PageLayout.navbar.search.scope, 'trae');
+    await selectSearch(Layout.navbar.search.scope, 'trae');
 
-    PageLayout.navbar.search.as(search => {
+    Layout.navbar.search.as(search => {
       search.groups[0].as(jobs => {
         assert.equal(jobs.options[0].text, 'traefik');
         assert.equal(jobs.options[0].formattedText, '*trae*fik');
@@ -124,18 +124,18 @@ module('Acceptance | search', function(hooks) {
       });
     });
 
-    await selectSearch(PageLayout.navbar.search.scope, 'ra');
+    await selectSearch(Layout.navbar.search.scope, 'ra');
 
-    PageLayout.navbar.search.as(search => {
+    Layout.navbar.search.as(search => {
       search.groups[0].as(jobs => {
         assert.equal(jobs.options[0].formattedText, 't*ra*efik');
         assert.equal(jobs.options[1].formattedText, 't*ra*cking');
       });
     });
 
-    await selectSearch(PageLayout.navbar.search.scope, 'sensor');
+    await selectSearch(Layout.navbar.search.scope, 'sensor');
 
-    PageLayout.navbar.search.as(search => {
+    Layout.navbar.search.as(search => {
       search.groups[0].as(jobs => {
         assert.equal(jobs.options[0].formattedText, '*s*mtp-*sensor*');
       });
@@ -151,9 +151,9 @@ module('Acceptance | search', function(hooks) {
 
     await visit('/');
 
-    await selectSearch(PageLayout.navbar.search.scope, 'job');
+    await selectSearch(Layout.navbar.search.scope, 'job');
 
-    PageLayout.navbar.search.as(search => {
+    Layout.navbar.search.as(search => {
       search.groups[0].as(jobs => {
         assert.equal(jobs.name, 'Jobs (showing 10 of 15)');
         assert.equal(jobs.options.length, 10);
@@ -166,13 +166,15 @@ module('Acceptance | search', function(hooks) {
 
     const idPrefix = nodeToMatchById.id.substr(0, 5);
 
-    const nodeToMatchByName = server.create('node', { name: `node-name-with-id-piece-${idPrefix}`});
+    const nodeToMatchByName = server.create('node', {
+      name: `node-name-with-id-piece-${idPrefix}`,
+    });
 
     await visit('/');
 
-    await selectSearch(PageLayout.navbar.search.scope, idPrefix);
+    await selectSearch(Layout.navbar.search.scope, idPrefix);
 
-    PageLayout.navbar.search.as(search => {
+    Layout.navbar.search.as(search => {
       search.groups[1].as(clients => {
         assert.equal(clients.options[0].text, nodeToMatchById.name);
         assert.equal(clients.options[1].text, nodeToMatchByName.name);
@@ -183,23 +185,23 @@ module('Acceptance | search', function(hooks) {
   test('clicking the search field starts search immediately', async function(assert) {
     await visit('/');
 
-    assert.notOk(PageLayout.navbar.search.field.isPresent);
+    assert.notOk(Layout.navbar.search.field.isPresent);
 
-    await PageLayout.navbar.search.click();
+    await Layout.navbar.search.click();
 
-    assert.ok(PageLayout.navbar.search.field.isPresent);
+    assert.ok(Layout.navbar.search.field.isPresent);
   });
 
   test('pressing slash starts a search', async function(assert) {
     await visit('/');
 
-    assert.notOk(PageLayout.navbar.search.field.isPresent);
+    assert.notOk(Layout.navbar.search.field.isPresent);
 
     await triggerEvent('.page-layout', 'keydown', {
       keyCode: 191, // slash
     });
 
-    assert.ok(PageLayout.navbar.search.field.isPresent);
+    assert.ok(Layout.navbar.search.field.isPresent);
   });
 
   test('pressing slash when an input element is focused does not start a search', async function(assert) {
@@ -208,11 +210,11 @@ module('Acceptance | search', function(hooks) {
 
     await visit('/');
 
-    assert.notOk(PageLayout.navbar.search.field.isPresent);
+    assert.notOk(Layout.navbar.search.field.isPresent);
 
     await JobsList.search.click();
     await JobsList.search.keydown({ keyCode: 191 });
 
-    assert.notOk(PageLayout.navbar.search.field.isPresent);
+    assert.notOk(Layout.navbar.search.field.isPresent);
   });
 });

--- a/ui/tests/acceptance/server-monitor-test.js
+++ b/ui/tests/acceptance/server-monitor-test.js
@@ -5,6 +5,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import ServerMonitor from 'nomad-ui/tests/pages/servers/monitor';
+import Layout from 'nomad-ui/tests/pages/layout';
 
 let agent;
 let managementToken;
@@ -33,10 +34,10 @@ module('Acceptance | server monitor', function(hooks) {
   test('/servers/:id/monitor should have a breadcrumb trail linking back to servers', async function(assert) {
     await ServerMonitor.visit({ name: agent.name });
 
-    assert.equal(ServerMonitor.breadcrumbFor('servers.index').text, 'Servers');
-    assert.equal(ServerMonitor.breadcrumbFor('servers.server').text, agent.name);
+    assert.equal(Layout.breadcrumbFor('servers.index').text, 'Servers');
+    assert.equal(Layout.breadcrumbFor('servers.server').text, agent.name);
 
-    await ServerMonitor.breadcrumbFor('servers.index').visit();
+    await Layout.breadcrumbFor('servers.index').visit();
     assert.equal(currentURL(), '/servers');
   });
 

--- a/ui/tests/acceptance/task-detail-test.js
+++ b/ui/tests/acceptance/task-detail-test.js
@@ -4,6 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import Task from 'nomad-ui/tests/pages/allocations/task/detail';
+import Layout from 'nomad-ui/tests/pages/layout';
 import moment from 'moment';
 
 let allocation;
@@ -57,37 +58,37 @@ module('Acceptance | task detail', function(hooks) {
 
     const shortId = allocation.id.split('-')[0];
 
-    assert.equal(Task.breadcrumbFor('jobs.index').text, 'Jobs', 'Jobs is the first breadcrumb');
+    assert.equal(Layout.breadcrumbFor('jobs.index').text, 'Jobs', 'Jobs is the first breadcrumb');
     assert.equal(
-      Task.breadcrumbFor('jobs.job.index').text,
+      Layout.breadcrumbFor('jobs.job.index').text,
       job.name,
       'Job is the second breadcrumb'
     );
     assert.equal(
-      Task.breadcrumbFor('jobs.job.task-group').text,
+      Layout.breadcrumbFor('jobs.job.task-group').text,
       taskGroup,
       'Task Group is the third breadcrumb'
     );
     assert.equal(
-      Task.breadcrumbFor('allocations.allocation').text,
+      Layout.breadcrumbFor('allocations.allocation').text,
       shortId,
       'Allocation short id is the fourth breadcrumb'
     );
     assert.equal(
-      Task.breadcrumbFor('allocations.allocation.task').text,
+      Layout.breadcrumbFor('allocations.allocation.task').text,
       task.name,
       'Task name is the fifth breadcrumb'
     );
 
-    await Task.breadcrumbFor('jobs.index').visit();
+    await Layout.breadcrumbFor('jobs.index').visit();
     assert.equal(currentURL(), '/jobs', 'Jobs breadcrumb links correctly');
 
     await Task.visit({ id: allocation.id, name: task.name });
-    await Task.breadcrumbFor('jobs.job.index').visit();
+    await Layout.breadcrumbFor('jobs.job.index').visit();
     assert.equal(currentURL(), `/jobs/${job.id}`, 'Job breadcrumb links correctly');
 
     await Task.visit({ id: allocation.id, name: task.name });
-    await Task.breadcrumbFor('jobs.job.task-group').visit();
+    await Layout.breadcrumbFor('jobs.job.task-group').visit();
     assert.equal(
       currentURL(),
       `/jobs/${job.id}/${taskGroup}`,
@@ -95,7 +96,7 @@ module('Acceptance | task detail', function(hooks) {
     );
 
     await Task.visit({ id: allocation.id, name: task.name });
-    await Task.breadcrumbFor('allocations.allocation').visit();
+    await Layout.breadcrumbFor('allocations.allocation').visit();
     assert.equal(
       currentURL(),
       `/allocations/${allocation.id}`,
@@ -280,7 +281,7 @@ module('Acceptance | task detail (different namespace)', function(hooks) {
     const { jobId, taskGroup } = allocation;
     const job = server.db.jobs.find(jobId);
 
-    await Task.breadcrumbFor('jobs.index').visit();
+    await Layout.breadcrumbFor('jobs.index').visit();
     assert.equal(
       currentURL(),
       '/jobs?namespace=other-namespace',
@@ -288,7 +289,7 @@ module('Acceptance | task detail (different namespace)', function(hooks) {
     );
 
     await Task.visit({ id: allocation.id, name: task.name });
-    await Task.breadcrumbFor('jobs.job.index').visit();
+    await Layout.breadcrumbFor('jobs.job.index').visit();
     assert.equal(
       currentURL(),
       `/jobs/${job.id}?namespace=other-namespace`,
@@ -296,7 +297,7 @@ module('Acceptance | task detail (different namespace)', function(hooks) {
     );
 
     await Task.visit({ id: allocation.id, name: task.name });
-    await Task.breadcrumbFor('jobs.job.task-group').visit();
+    await Layout.breadcrumbFor('jobs.job.task-group').visit();
     assert.equal(
       currentURL(),
       `/jobs/${job.id}/${taskGroup}?namespace=other-namespace`,
@@ -304,7 +305,7 @@ module('Acceptance | task detail (different namespace)', function(hooks) {
     );
 
     await Task.visit({ id: allocation.id, name: task.name });
-    await Task.breadcrumbFor('allocations.allocation').visit();
+    await Layout.breadcrumbFor('allocations.allocation').visit();
     assert.equal(
       currentURL(),
       `/allocations/${allocation.id}`,

--- a/ui/tests/acceptance/task-group-detail-test.js
+++ b/ui/tests/acceptance/task-group-detail-test.js
@@ -5,6 +5,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import { formatBytes } from 'nomad-ui/helpers/format-bytes';
 import TaskGroup from 'nomad-ui/tests/pages/jobs/job/task-group';
+import Layout from 'nomad-ui/tests/pages/layout';
 import pageSizeSelect from './behaviors/page-size-select';
 import moment from 'moment';
 
@@ -103,14 +104,14 @@ module('Acceptance | task group detail', function(hooks) {
   test('/jobs/:id/:task-group should have breadcrumbs for job and jobs', async function(assert) {
     await TaskGroup.visit({ id: job.id, name: taskGroup.name });
 
-    assert.equal(TaskGroup.breadcrumbFor('jobs.index').text, 'Jobs', 'First breadcrumb says jobs');
+    assert.equal(Layout.breadcrumbFor('jobs.index').text, 'Jobs', 'First breadcrumb says jobs');
     assert.equal(
-      TaskGroup.breadcrumbFor('jobs.job.index').text,
+      Layout.breadcrumbFor('jobs.job.index').text,
       job.name,
       'Second breadcrumb says the job name'
     );
     assert.equal(
-      TaskGroup.breadcrumbFor('jobs.job.task-group').text,
+      Layout.breadcrumbFor('jobs.job.task-group').text,
       taskGroup.name,
       'Third breadcrumb says the job name'
     );
@@ -119,14 +120,14 @@ module('Acceptance | task group detail', function(hooks) {
   test('/jobs/:id/:task-group first breadcrumb should link to jobs', async function(assert) {
     await TaskGroup.visit({ id: job.id, name: taskGroup.name });
 
-    await TaskGroup.breadcrumbFor('jobs.index').visit();
+    await Layout.breadcrumbFor('jobs.index').visit();
     assert.equal(currentURL(), '/jobs', 'First breadcrumb links back to jobs');
   });
 
   test('/jobs/:id/:task-group second breadcrumb should link to the job for the task group', async function(assert) {
     await TaskGroup.visit({ id: job.id, name: taskGroup.name });
 
-    await TaskGroup.breadcrumbFor('jobs.job.index').visit();
+    await Layout.breadcrumbFor('jobs.job.index').visit();
     assert.equal(
       currentURL(),
       `/jobs/${job.id}`,

--- a/ui/tests/acceptance/volume-detail-test.js
+++ b/ui/tests/acceptance/volume-detail-test.js
@@ -6,6 +6,7 @@ import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import moment from 'moment';
 import { formatBytes } from 'nomad-ui/helpers/format-bytes';
 import VolumeDetail from 'nomad-ui/tests/pages/storage/volumes/detail';
+import Layout from 'nomad-ui/tests/pages/layout';
 
 const assignWriteAlloc = (volume, alloc) => {
   volume.writeAllocs.add(alloc);
@@ -39,9 +40,9 @@ module('Acceptance | volume detail', function(hooks) {
   test('/csi/volumes/:id should have a breadcrumb trail linking back to Volumes and Storage', async function(assert) {
     await VolumeDetail.visit({ id: volume.id });
 
-    assert.equal(VolumeDetail.breadcrumbFor('csi.index').text, 'Storage');
-    assert.equal(VolumeDetail.breadcrumbFor('csi.volumes').text, 'Volumes');
-    assert.equal(VolumeDetail.breadcrumbFor('csi.volumes.volume').text, volume.name);
+    assert.equal(Layout.breadcrumbFor('csi.index').text, 'Storage');
+    assert.equal(Layout.breadcrumbFor('csi.volumes').text, 'Volumes');
+    assert.equal(Layout.breadcrumbFor('csi.volumes.volume').text, volume.name);
   });
 
   test('/csi/volumes/:id should show the volume name in the title', async function(assert) {

--- a/ui/tests/pages/allocations/task/detail.js
+++ b/ui/tests/pages/allocations/task/detail.js
@@ -32,16 +32,6 @@ export default create({
     scope: '[data-test-exec-button]',
   },
 
-  breadcrumbs: collection('[data-test-breadcrumb]', {
-    id: attribute('data-test-breadcrumb'),
-    text: text(),
-    visit: clickable(),
-  }),
-
-  breadcrumbFor(id) {
-    return this.breadcrumbs.toArray().find(crumb => crumb.id === id);
-  },
-
   resourceCharts: collection('[data-test-primary-metric]', {
     name: text('[data-test-primary-metric-title]'),
     chartClass: attribute('class', '[data-test-percentage-chart] progress'),

--- a/ui/tests/pages/clients/detail.js
+++ b/ui/tests/pages/clients/detail.js
@@ -17,16 +17,6 @@ import toggle from 'nomad-ui/tests/pages/components/toggle';
 export default create({
   visit: visitable('/clients/:id'),
 
-  breadcrumbs: collection('[data-test-breadcrumb]', {
-    id: attribute('data-test-breadcrumb'),
-    text: text(),
-    visit: clickable(),
-  }),
-
-  breadcrumbFor(id) {
-    return this.breadcrumbs.toArray().find(crumb => crumb.id === id);
-  },
-
   title: text('[data-test-title]'),
   clientId: text('[data-test-node-id]'),
 

--- a/ui/tests/pages/clients/monitor.js
+++ b/ui/tests/pages/clients/monitor.js
@@ -1,27 +1,9 @@
-import {
-  create,
-  attribute,
-  clickable,
-  collection,
-  isPresent,
-  text,
-  visitable,
-} from 'ember-cli-page-object';
+import { create, clickable, isPresent, text, visitable } from 'ember-cli-page-object';
 import { run } from '@ember/runloop';
 import { selectOpen, selectOpenChoose } from '../../utils/ember-power-select-extensions';
 
 export default create({
   visit: visitable('/clients/:id/monitor'),
-
-  breadcrumbs: collection('[data-test-breadcrumb]', {
-    id: attribute('data-test-breadcrumb'),
-    text: text(),
-    visit: clickable(),
-  }),
-
-  breadcrumbFor(id) {
-    return this.breadcrumbs.toArray().find(crumb => crumb.id === id);
-  },
 
   logsArePresent: isPresent('[data-test-log-box]'),
 

--- a/ui/tests/pages/jobs/job/task-group.js
+++ b/ui/tests/pages/jobs/job/task-group.js
@@ -1,5 +1,4 @@
 import {
-  attribute,
   clickable,
   create,
   collection,
@@ -28,16 +27,6 @@ export default create({
   cpu: text('[data-test-task-group-cpu]'),
   mem: text('[data-test-task-group-mem]'),
   disk: text('[data-test-task-group-disk]'),
-
-  breadcrumbs: collection('[data-test-breadcrumb]', {
-    id: attribute('data-test-breadcrumb'),
-    text: text(),
-    visit: clickable(),
-  }),
-
-  breadcrumbFor(id) {
-    return this.breadcrumbs.toArray().find(crumb => crumb.id === id);
-  },
 
   ...allocations(),
 

--- a/ui/tests/pages/layout.js
+++ b/ui/tests/pages/layout.js
@@ -1,4 +1,12 @@
-import { create, clickable, collection, hasClass, isPresent, text } from 'ember-cli-page-object';
+import {
+  attribute,
+  create,
+  clickable,
+  collection,
+  hasClass,
+  isPresent,
+  text,
+} from 'ember-cli-page-object';
 
 export default create({
   navbar: {
@@ -23,23 +31,28 @@ export default create({
         resetScope: true,
         name: text('.ember-power-select-group-name'),
 
-        options: collection('.ember-power-select-option', create({
-          label: text(),
+        options: collection(
+          '.ember-power-select-option',
+          create({
+            label: text(),
 
-          substrings: collection('[data-test-match-substring]', {
-            isHighlighted: hasClass('highlighted'),
-          }),
+            substrings: collection('[data-test-match-substring]', {
+              isHighlighted: hasClass('highlighted'),
+            }),
 
-          get formattedText() {
-            return this.substrings.map(string => {
-              if (string.isHighlighted) {
-                return `*${string.text}*`;
-              } else {
-                return string.text;
-              }
-            }).join('');
-          }
-        })),
+            get formattedText() {
+              return this.substrings
+                .map(string => {
+                  if (string.isHighlighted) {
+                    return `*${string.text}*`;
+                  } else {
+                    return string.text;
+                  }
+                })
+                .join('');
+            },
+          })
+        ),
       }),
 
       field: {
@@ -69,5 +82,15 @@ export default create({
     visitClients: clickable('[data-test-gutter-link="clients"]'),
     visitServers: clickable('[data-test-gutter-link="servers"]'),
     visitStorage: clickable('[data-test-gutter-link="storage"]'),
+  },
+
+  breadcrumbs: collection('[data-test-breadcrumb]', {
+    id: attribute('data-test-breadcrumb'),
+    text: text(),
+    visit: clickable(),
+  }),
+
+  breadcrumbFor(id) {
+    return this.breadcrumbs.toArray().find(crumb => crumb.id === id);
   },
 });

--- a/ui/tests/pages/optimize.js
+++ b/ui/tests/pages/optimize.js
@@ -16,15 +16,6 @@ import toggle from 'nomad-ui/tests/pages/components/toggle';
 export default create({
   visit: visitable('/optimize'),
 
-  breadcrumbs: collection('[data-test-breadcrumb]', {
-    id: attribute('data-test-breadcrumb'),
-    text: text(),
-  }),
-
-  breadcrumbFor(id) {
-    return this.breadcrumbs.toArray().find(crumb => crumb.id === id);
-  },
-
   search: {
     scope: '[data-test-recommendation-summaries-search] input',
     placeholder: attribute('placeholder'),

--- a/ui/tests/pages/servers/monitor.js
+++ b/ui/tests/pages/servers/monitor.js
@@ -1,27 +1,9 @@
-import {
-  create,
-  attribute,
-  clickable,
-  collection,
-  isPresent,
-  text,
-  visitable,
-} from 'ember-cli-page-object';
+import { create, clickable, isPresent, text, visitable } from 'ember-cli-page-object';
 import { run } from '@ember/runloop';
 import { selectOpen, selectOpenChoose } from '../../utils/ember-power-select-extensions';
 
 export default create({
   visit: visitable('/servers/:name/monitor'),
-
-  breadcrumbs: collection('[data-test-breadcrumb]', {
-    id: attribute('data-test-breadcrumb'),
-    text: text(),
-    visit: clickable(),
-  }),
-
-  breadcrumbFor(id) {
-    return this.breadcrumbs.toArray().find(crumb => crumb.id === id);
-  },
 
   logsArePresent: isPresent('[data-test-log-box]'),
 

--- a/ui/tests/pages/storage/plugins/detail.js
+++ b/ui/tests/pages/storage/plugins/detail.js
@@ -1,12 +1,4 @@
-import {
-  attribute,
-  clickable,
-  collection,
-  create,
-  isPresent,
-  text,
-  visitable,
-} from 'ember-cli-page-object';
+import { clickable, create, isPresent, text, visitable } from 'ember-cli-page-object';
 
 import allocations from 'nomad-ui/tests/pages/components/allocations';
 
@@ -22,16 +14,6 @@ export default create({
 
   controllerAvailabilityIsPresent: isPresent('[data-test-plugin-controller-availability]'),
   nodeAvailabilityIsPresent: isPresent('[data-test-plugin-node-availability]'),
-
-  breadcrumbs: collection('[data-test-breadcrumb]', {
-    id: attribute('data-test-breadcrumb'),
-    text: text(),
-    visit: clickable(),
-  }),
-
-  breadcrumbFor(id) {
-    return this.breadcrumbs.toArray().find(crumb => crumb.id === id);
-  },
 
   ...allocations('[data-test-controller-allocation]', 'controllerAllocations'),
   ...allocations('[data-test-node-allocation]', 'nodeAllocations'),

--- a/ui/tests/pages/storage/volumes/detail.js
+++ b/ui/tests/pages/storage/volumes/detail.js
@@ -1,12 +1,4 @@
-import {
-  attribute,
-  clickable,
-  collection,
-  create,
-  isPresent,
-  text,
-  visitable,
-} from 'ember-cli-page-object';
+import { create, isPresent, text, visitable } from 'ember-cli-page-object';
 
 import allocations from 'nomad-ui/tests/pages/components/allocations';
 
@@ -20,16 +12,6 @@ export default create({
   externalId: text('[data-test-volume-external-id]'),
   hasNamespace: isPresent('[data-test-volume-namespace]'),
   namespace: text('[data-test-volume-namespace]'),
-
-  breadcrumbs: collection('[data-test-breadcrumb]', {
-    id: attribute('data-test-breadcrumb'),
-    text: text(),
-    visit: clickable(),
-  }),
-
-  breadcrumbFor(id) {
-    return this.breadcrumbs.toArray().find(crumb => crumb.id === id);
-  },
 
   ...allocations('[data-test-read-allocation]', 'readAllocations'),
   ...allocations('[data-test-write-allocation]', 'writeAllocations'),


### PR DESCRIPTION
Various page objects had `breadcrumbs` and `breadcrumbFor` within them, this
moves those to the existing `Layout` page object that contains shared page objects.

`Layout` is sometimes imported as `PageLayout`; I chose the former for tests that
didn’t have it imported already. I could easily change them all to the same thing if
that seems desirable 🤓