### PR TITLE
UI: Change ember-cli-babel to include external helpers

### DIFF
--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -23,6 +23,7 @@ module.exports = function(defaults) {
       ],
     },
     'ember-cli-babel': {
+      includeExternalHelpers: true,
       includePolyfill: isProd,
     },
     hinting: isTest,


### PR DESCRIPTION
This is an experiment thanks to a tip from @maxfierke on
the Ember Discord:
https://discord.com/channels/480462759797063690/486548111221719040/785857236546748446