### PR TITLE
UI: Remove support for IE11

### DIFF
--- a/ui/config/targets.js
+++ b/ui/config/targets.js
@@ -2,13 +2,6 @@
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };

--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -17,6 +17,7 @@ module.exports = function(defaults) {
       modes: ['javascript'],
     },
     babel: {
+      include: ['proposal-optional-chaining'],
       plugins: [
         '@babel/plugin-proposal-object-rest-spread',
         require.resolve('ember-auto-import/babel-plugin'),


### PR DESCRIPTION
This changes the Babel compilation targets to exclude IE, which results in significant payload size savings.

Thanks to @pichfl for [this](https://github.com/ember-cli/ember-cli/issues/9290#issuecomment-672734338) solution to an Uglify problem.