### PR TITLE
circleci: Remove GO_TAGS from build-binaries job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,9 +388,6 @@ jobs:
           destination: /builds/nomad_darwin_amd64.zip
   build-binaries:
     executor: go
-    environment:
-      # TODO: add ui tag here
-      GO_TAGS: "codegen_generated"
     steps:
       - checkout
       - run: apt-get update; apt-get install -y sudo unzip zip


### PR DESCRIPTION
These tags default to the same value in GNUMakefile. This will also help
fix a discrepancy between the build-binaries job in OSS and Ent, which will make merging OSS into Ent clean.