### PR TITLE
fix the inconsistency handling between infra image and normal task image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.0.3 (Unreleased)
 
+IMPROVEMENTS:
+ * consul/connect: Made handling of sidecar task container image URLs consistent with the `docker` task driver. [[GH-9580](https://github.com/hashicorp/nomad/issues/9580)]
+
 BUG FIXES:
 
  * consul/connect: Fixed a bug where gateway proxy connection default timeout not set [[GH-9851](https://github.com/hashicorp/nomad/pull/9851)]
@@ -16,7 +19,7 @@ IMPROVEMENTS:
  * consul/connect: Interpolate the connect, service meta, and service canary meta blocks with the task environment [[GH-9586](https://github.com/hashicorp/nomad/pull/9586)]
  * consul/connect: enable configuring custom gateway task [[GH-9639](https://github.com/hashicorp/nomad/pull/9639)]
  * cli: Added JSON/go template formatting to agent-info command. [[GH-9788](https://github.com/hashicorp/nomad/pull/9788)]
- 
+
 
 BUG FIXES:
  * client: Fixed a bug where non-`docker` tasks with network isolation were restarted on client restart. [[GH-9757](https://github.com/hashicorp/nomad/issues/9757)]

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -662,10 +662,7 @@ func (d *Driver) SetConfig(c *base.Config) error {
 	}
 
 	d.config = &config
-	// Remove any http
-	if strings.HasPrefix(d.config.InfraImage, "https://") {
-		d.config.InfraImage = strings.Replace(d.config.InfraImage, "https://", "", 1)
-	}
+	d.config.InfraImage = strings.TrimPrefix(d.config.InfraImage, "https://")
 
 	if len(d.config.GC.ImageDelay) > 0 {
 		dur, err := time.ParseDuration(d.config.GC.ImageDelay)

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -662,6 +662,11 @@ func (d *Driver) SetConfig(c *base.Config) error {
 	}
 
 	d.config = &config
+	// Remove any http
+	if strings.HasPrefix(d.config.InfraImage, "https://") {
+		d.config.InfraImage = strings.Replace(d.config.InfraImage, "https://", "", 1)
+	}
+
 	if len(d.config.GC.ImageDelay) > 0 {
 		dur, err := time.ParseDuration(d.config.GC.ImageDelay)
 		if err != nil {

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -251,10 +251,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		return nil, nil, fmt.Errorf("image name required for docker driver")
 	}
 
-	// Remove any http
-	if strings.HasPrefix(driverConfig.Image, "https://") {
-		driverConfig.Image = strings.Replace(driverConfig.Image, "https://", "", 1)
-	}
+	driverConfig.Image = strings.TrimPrefix(driverConfig.Image, "https://")
 
 	handle := drivers.NewTaskHandle(taskHandleVersion)
 	handle.Config = cfg


### PR DESCRIPTION
fix a minor inconsistency in how nomad handles image url for task and infra.

basically a duplication of https://github.com/hashicorp/nomad/blob/2176fbd90a228a6aafba4ff7a9042fc0fc7dcdf0/drivers/docker/driver.go#L253-L256 
