### PR TITLE
use concrete type helper instead of interface surfing

### DIFF
--- a/e2e/events/events.go
+++ b/e2e/events/events.go
@@ -156,24 +156,21 @@ func (tc *EventsTest) TestBlockedEvalEvents(f *framework.F) {
 	// ensure there is a deployment promotion event
 	testutil.WaitForResult(func() (bool, error) {
 		for _, e := range evalEvents {
-			evalRaw, ok := e.Payload["Eval"].(map[string]interface{})
-			if !ok {
-				return false, fmt.Errorf("type assertion on eval")
+			eval, err := e.Evaluation()
+			if err != nil {
+				return false, fmt.Errorf("event was not an evaluation")
 			}
 
-			ftg, ok := evalRaw["FailedTGAllocs"].(map[string]interface{})
+			ftg := eval.FailedTGAllocs
+
+			tg, ok := ftg["one"]
 			if !ok {
 				continue
 			}
 
-			tg, ok := ftg["one"].(map[string]interface{})
-			if !ok {
-				continue
-			}
-			mem := tg["DimensionExhausted"].(map[string]interface{})["memory"]
+			mem := tg.DimensionExhausted["memory"]
 			require.NotNil(t, mem, "memory dimension was nil")
-			memInt := int(mem.(float64))
-			require.Greater(t, memInt, 0, "memory dimension was zero")
+			require.Greater(t, mem, 0, "memory dimension was zero")
 			return true, nil
 
 		}

--- a/e2e/events/events.go
+++ b/e2e/events/events.go
@@ -158,7 +158,7 @@ func (tc *EventsTest) TestBlockedEvalEvents(f *framework.F) {
 		for _, e := range evalEvents {
 			eval, err := e.Evaluation()
 			if err != nil {
-				return false, fmt.Errorf("event was not an evaluation")
+				return false, fmt.Errorf("event was not an evaluation %w", err)
 			}
 
 			ftg := eval.FailedTGAllocs


### PR DESCRIPTION
`Eval` changed to `Evaluation` in 1.0.0, but there is also an easier way to get a concrete type out of an event now.