### PR TITLE
consul/connect: interpolate connect block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.0.1 (Unreleased)
 
 IMPROVEMENTS:
- * consul/connect: interpolate connect block [[GH-9586](https://github.com/hashicorp/nomad/pull/9586)]
+ * consul/connect: interpolate the connect, service meta, and service canary meta blocks with the task environment [[GH-9586](https://github.com/hashicorp/nomad/pull/9586)]
 
 ## 1.0.0 (December 8, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.1 (Unreleased)
+
+IMPROVEMENTS:
+ * consul/connect: interpolate connect block [[GH-9586](https://github.com/hashicorp/nomad/pull/9586)]
+
 ## 1.0.0 (December 8, 2020)
 
 FEATURES:

--- a/client/taskenv/services.go
+++ b/client/taskenv/services.go
@@ -16,8 +16,8 @@ func InterpolateServices(taskEnv *TaskEnv, services []*structs.Service) []*struc
 	interpolated := make([]*structs.Service, len(services))
 
 	for i, origService := range services {
-		// Create a copy as we need to reinterpolate every time the
-		// environment changes
+		// Create a copy as we need to re-interpolate every time the
+		// environment changes.
 		service := origService.Copy()
 
 		for _, check := range service.Checks {
@@ -31,42 +31,174 @@ func InterpolateServices(taskEnv *TaskEnv, services []*structs.Service) []*struc
 			check.InitialStatus = taskEnv.ReplaceEnv(check.InitialStatus)
 			check.Method = taskEnv.ReplaceEnv(check.Method)
 			check.GRPCService = taskEnv.ReplaceEnv(check.GRPCService)
-			if len(check.Header) > 0 {
-				header := make(map[string][]string, len(check.Header))
-				for k, vs := range check.Header {
-					newVals := make([]string, len(vs))
-					for i, v := range vs {
-						newVals[i] = taskEnv.ReplaceEnv(v)
-					}
-					header[taskEnv.ReplaceEnv(k)] = newVals
-				}
-				check.Header = header
-			}
+			check.Header = interpolateMapStringSliceString(taskEnv, check.Header)
 		}
 
 		service.Name = taskEnv.ReplaceEnv(service.Name)
 		service.PortLabel = taskEnv.ReplaceEnv(service.PortLabel)
 		service.Tags = taskEnv.ParseAndReplace(service.Tags)
 		service.CanaryTags = taskEnv.ParseAndReplace(service.CanaryTags)
-
-		if len(service.Meta) > 0 {
-			meta := make(map[string]string, len(service.Meta))
-			for k, v := range service.Meta {
-				meta[k] = taskEnv.ReplaceEnv(v)
-			}
-			service.Meta = meta
-		}
-
-		if len(service.CanaryMeta) > 0 {
-			canaryMeta := make(map[string]string, len(service.CanaryMeta))
-			for k, v := range service.CanaryMeta {
-				canaryMeta[k] = taskEnv.ReplaceEnv(v)
-			}
-			service.CanaryMeta = canaryMeta
-		}
+		service.Meta = interpolateMapStringString(taskEnv, service.Meta)
+		service.CanaryMeta = interpolateMapStringString(taskEnv, service.CanaryMeta)
+		service.Connect = interpolateConnect(taskEnv, service.Connect)
 
 		interpolated[i] = service
 	}
 
 	return interpolated
+}
+
+func interpolateMapStringSliceString(taskEnv *TaskEnv, orig map[string][]string) map[string][]string {
+	if len(orig) == 0 {
+		return nil
+	}
+
+	m := make(map[string][]string, len(orig))
+	for k, vs := range orig {
+		m[taskEnv.ReplaceEnv(k)] = taskEnv.ParseAndReplace(vs)
+	}
+	return m
+}
+
+func interpolateMapStringString(taskEnv *TaskEnv, orig map[string]string) map[string]string {
+	if len(orig) == 0 {
+		return nil
+	}
+
+	m := make(map[string]string, len(orig))
+	for k, v := range orig {
+		m[taskEnv.ReplaceEnv(k)] = taskEnv.ReplaceEnv(v)
+	}
+	return m
+}
+
+func interpolateMapStringInterface(taskEnv *TaskEnv, orig map[string]interface{}) map[string]interface{} {
+	if len(orig) == 0 {
+		return nil
+	}
+
+	m := make(map[string]interface{}, len(orig))
+	for k, v := range orig {
+		m[taskEnv.ReplaceEnv(k)] = v
+	}
+	return m
+}
+
+func interpolateConnect(taskEnv *TaskEnv, orig *structs.ConsulConnect) *structs.ConsulConnect {
+	if orig == nil {
+		return nil
+	}
+
+	// make one copy and interpolate in-place on that
+	modified := orig.Copy()
+	interpolateConnectSidecarService(taskEnv, modified.SidecarService)
+	interpolateConnectSidecarTask(taskEnv, modified.SidecarTask)
+	if modified.Gateway != nil {
+		interpolateConnectGatewayProxy(taskEnv, modified.Gateway.Proxy)
+		interpolateConnectGatewayIngress(taskEnv, modified.Gateway.Ingress)
+	}
+	return modified
+}
+
+func interpolateConnectGatewayProxy(taskEnv *TaskEnv, proxy *structs.ConsulGatewayProxy) {
+	if proxy == nil {
+		return
+	}
+
+	m := make(map[string]*structs.ConsulGatewayBindAddress, len(proxy.EnvoyGatewayBindAddresses))
+	for k, v := range proxy.EnvoyGatewayBindAddresses {
+		m[taskEnv.ReplaceEnv(k)] = &structs.ConsulGatewayBindAddress{
+			Address: taskEnv.ReplaceEnv(v.Address),
+			Port:    v.Port,
+		}
+	}
+
+	proxy.EnvoyGatewayBindAddresses = m
+	proxy.Config = interpolateMapStringInterface(taskEnv, proxy.Config)
+}
+
+func interpolateConnectGatewayIngress(taskEnv *TaskEnv, ingress *structs.ConsulIngressConfigEntry) {
+	if ingress == nil {
+		return
+	}
+
+	for _, listener := range ingress.Listeners {
+		listener.Protocol = taskEnv.ReplaceEnv(listener.Protocol)
+		for _, service := range listener.Services {
+			service.Name = taskEnv.ReplaceEnv(service.Name)
+			service.Hosts = taskEnv.ParseAndReplace(service.Hosts)
+		}
+	}
+}
+
+func interpolateConnectSidecarService(taskEnv *TaskEnv, sidecar *structs.ConsulSidecarService) {
+	if sidecar == nil {
+		return
+	}
+
+	sidecar.Port = taskEnv.ReplaceEnv(sidecar.Port)
+	sidecar.Tags = taskEnv.ParseAndReplace(sidecar.Tags)
+	if sidecar.Proxy != nil {
+		sidecar.Proxy.LocalServiceAddress = taskEnv.ReplaceEnv(sidecar.Proxy.LocalServiceAddress)
+		if sidecar.Proxy.Expose != nil {
+			for i := 0; i < len(sidecar.Proxy.Expose.Paths); i++ {
+				sidecar.Proxy.Expose.Paths[i].Protocol = taskEnv.ReplaceEnv(sidecar.Proxy.Expose.Paths[i].Protocol)
+				sidecar.Proxy.Expose.Paths[i].ListenerPort = taskEnv.ReplaceEnv(sidecar.Proxy.Expose.Paths[i].ListenerPort)
+				sidecar.Proxy.Expose.Paths[i].Path = taskEnv.ReplaceEnv(sidecar.Proxy.Expose.Paths[i].Path)
+			}
+		}
+		for i := 0; i < len(sidecar.Proxy.Upstreams); i++ {
+			sidecar.Proxy.Upstreams[i].Datacenter = taskEnv.ReplaceEnv(sidecar.Proxy.Upstreams[i].Datacenter)
+			sidecar.Proxy.Upstreams[i].DestinationName = taskEnv.ReplaceEnv(sidecar.Proxy.Upstreams[i].DestinationName)
+		}
+		sidecar.Proxy.Config = interpolateMapStringInterface(taskEnv, sidecar.Proxy.Config)
+	}
+}
+
+func interpolateConnectSidecarTask(taskEnv *TaskEnv, task *structs.SidecarTask) {
+	if task == nil {
+		return
+	}
+
+	task.Driver = taskEnv.ReplaceEnv(task.Driver)
+	task.Config = interpolateMapStringInterface(taskEnv, task.Config)
+	task.Env = interpolateMapStringString(taskEnv, task.Env)
+	task.KillSignal = taskEnv.ReplaceEnv(task.KillSignal)
+	task.Meta = interpolateMapStringString(taskEnv, task.Meta)
+	interpolateTaskResources(taskEnv, task.Resources)
+	task.User = taskEnv.ReplaceEnv(task.User)
+}
+
+func interpolateTaskResources(taskEnv *TaskEnv, resources *structs.Resources) {
+	if resources == nil {
+		return
+	}
+
+	for i := 0; i < len(resources.Devices); i++ {
+		resources.Devices[i].Name = taskEnv.ReplaceEnv(resources.Devices[i].Name)
+		// do not interpolate constraints & affinities
+	}
+
+	for i := 0; i < len(resources.Networks); i++ {
+		resources.Networks[i].CIDR = taskEnv.ReplaceEnv(resources.Networks[i].CIDR)
+		resources.Networks[i].Device = taskEnv.ReplaceEnv(resources.Networks[i].Device)
+		resources.Networks[i].IP = taskEnv.ReplaceEnv(resources.Networks[i].IP)
+		resources.Networks[i].Mode = taskEnv.ReplaceEnv(resources.Networks[i].Mode)
+
+		if resources.Networks[i].DNS != nil {
+			resources.Networks[i].DNS.Options = taskEnv.ParseAndReplace(resources.Networks[i].DNS.Options)
+			resources.Networks[i].DNS.Searches = taskEnv.ParseAndReplace(resources.Networks[i].DNS.Searches)
+			resources.Networks[i].DNS.Servers = taskEnv.ParseAndReplace(resources.Networks[i].DNS.Servers)
+		}
+
+		for p := 0; p < len(resources.Networks[i].DynamicPorts); p++ {
+			resources.Networks[i].DynamicPorts[p].HostNetwork = taskEnv.ReplaceEnv(resources.Networks[i].DynamicPorts[p].HostNetwork)
+			resources.Networks[i].DynamicPorts[p].Label = taskEnv.ReplaceEnv(resources.Networks[i].DynamicPorts[p].Label)
+		}
+
+		for p := 0; p < len(resources.Networks[i].ReservedPorts); p++ {
+			resources.Networks[i].ReservedPorts[p].HostNetwork = taskEnv.ReplaceEnv(resources.Networks[i].ReservedPorts[p].HostNetwork)
+			resources.Networks[i].ReservedPorts[p].Label = taskEnv.ReplaceEnv(resources.Networks[i].ReservedPorts[p].Label)
+		}
+	}
 }

--- a/client/taskenv/services.go
+++ b/client/taskenv/services.go
@@ -40,7 +40,7 @@ func InterpolateServices(taskEnv *TaskEnv, services []*structs.Service) []*struc
 		service.CanaryTags = taskEnv.ParseAndReplace(service.CanaryTags)
 		service.Meta = interpolateMapStringString(taskEnv, service.Meta)
 		service.CanaryMeta = interpolateMapStringString(taskEnv, service.CanaryMeta)
-		service.Connect = interpolateConnect(taskEnv, service.Connect)
+		interpolateConnect(taskEnv, service.Connect)
 
 		interpolated[i] = service
 	}
@@ -84,20 +84,17 @@ func interpolateMapStringInterface(taskEnv *TaskEnv, orig map[string]interface{}
 	return m
 }
 
-func interpolateConnect(taskEnv *TaskEnv, orig *structs.ConsulConnect) *structs.ConsulConnect {
-	if orig == nil {
-		return nil
+func interpolateConnect(taskEnv *TaskEnv, connect *structs.ConsulConnect) {
+	if connect == nil {
+		return
 	}
 
-	// make one copy and interpolate in-place on that
-	modified := orig.Copy()
-	interpolateConnectSidecarService(taskEnv, modified.SidecarService)
-	interpolateConnectSidecarTask(taskEnv, modified.SidecarTask)
-	if modified.Gateway != nil {
-		interpolateConnectGatewayProxy(taskEnv, modified.Gateway.Proxy)
-		interpolateConnectGatewayIngress(taskEnv, modified.Gateway.Ingress)
+	interpolateConnectSidecarService(taskEnv, connect.SidecarService)
+	interpolateConnectSidecarTask(taskEnv, connect.SidecarTask)
+	if connect.Gateway != nil {
+		interpolateConnectGatewayProxy(taskEnv, connect.Gateway.Proxy)
+		interpolateConnectGatewayIngress(taskEnv, connect.Gateway.Ingress)
 	}
-	return modified
 }
 
 func interpolateConnectGatewayProxy(taskEnv *TaskEnv, proxy *structs.ConsulGatewayProxy) {

--- a/client/taskenv/services_test.go
+++ b/client/taskenv/services_test.go
@@ -307,7 +307,7 @@ func TestInterpolate_interpolateConnect(t *testing.T) {
 		},
 	}
 
-	result := interpolateConnect(env, connect)
+	interpolateConnect(env, connect)
 
 	require.Equal(t, &structs.ConsulConnect{
 		Native: false,
@@ -412,5 +412,5 @@ func TestInterpolate_interpolateConnect(t *testing.T) {
 				}},
 			},
 		},
-	}, result)
+	}, connect)
 }

--- a/client/taskenv/services_test.go
+++ b/client/taskenv/services_test.go
@@ -2,7 +2,9 @@ package taskenv
 
 import (
 	"testing"
+	"time"
 
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/stretchr/testify/require"
 )
@@ -11,6 +13,7 @@ import (
 // and check fields are properly interpolated.
 func TestInterpolateServices(t *testing.T) {
 	t.Parallel()
+
 	services := []*structs.Service{
 		{
 			Name:      "${name}",
@@ -96,4 +99,318 @@ func TestInterpolateServices(t *testing.T) {
 	}
 
 	require.Equal(t, exp, interpolated)
+}
+
+var testEnv = NewTaskEnv(
+	map[string]string{"foo": "bar", "baz": "blah"},
+	nil,
+	nil,
+)
+
+func TestInterpolate_interpolateMapStringSliceString(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		require.Nil(t, interpolateMapStringSliceString(testEnv, nil))
+	})
+
+	t.Run("not nil", func(t *testing.T) {
+		require.Equal(t, map[string][]string{
+			"a":   {"b"},
+			"bar": {"blah", "c"},
+		}, interpolateMapStringSliceString(testEnv, map[string][]string{
+			"a":      {"b"},
+			"${foo}": {"${baz}", "c"},
+		}))
+	})
+}
+
+func TestInterpolate_interpolateMapStringString(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		require.Nil(t, interpolateMapStringString(testEnv, nil))
+	})
+
+	t.Run("not nil", func(t *testing.T) {
+		require.Equal(t, map[string]string{
+			"a":   "b",
+			"bar": "blah",
+		}, interpolateMapStringString(testEnv, map[string]string{
+			"a":      "b",
+			"${foo}": "${baz}",
+		}))
+	})
+}
+
+func TestInterpolate_interpolateMapStringInterface(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		require.Nil(t, interpolateMapStringInterface(testEnv, nil))
+	})
+
+	t.Run("not nil", func(t *testing.T) {
+		require.Equal(t, map[string]interface{}{
+			"a":   1,
+			"bar": 2,
+		}, interpolateMapStringInterface(testEnv, map[string]interface{}{
+			"a":      1,
+			"${foo}": 2,
+		}))
+	})
+}
+
+func TestInterpolate_interpolateConnect(t *testing.T) {
+	t.Parallel()
+
+	env := NewTaskEnv(map[string]string{
+		"tag1":         "_tag1",
+		"port1":        "12345",
+		"address1":     "1.2.3.4",
+		"destination1": "_dest1",
+		"datacenter1":  "_datacenter1",
+		"path1":        "_path1",
+		"protocol1":    "_protocol1",
+		"port2":        "_port2",
+		"config1":      "_config1",
+		"driver1":      "_driver1",
+		"user1":        "_user1",
+		"config2":      "_config2",
+		"env1":         "_env1",
+		"env2":         "_env2",
+		"mode1":        "_mode1",
+		"device1":      "_device1",
+		"cidr1":        "10.0.0.0/64",
+		"ip1":          "1.1.1.1",
+		"server1":      "10.0.0.1",
+		"search1":      "10.0.0.2",
+		"option1":      "10.0.0.3",
+		"port3":        "_port3",
+		"network1":     "_network1",
+		"port4":        "_port4",
+		"network2":     "_network2",
+		"resource1":    "_resource1",
+		"meta1":        "_meta1",
+		"meta2":        "_meta2",
+		"signal1":      "_signal1",
+		"bind1":        "_bind1",
+		"address2":     "10.0.0.4",
+		"config3":      "_config3",
+		"protocol2":    "_protocol2",
+		"service1":     "_service1",
+		"host1":        "_host1",
+	}, nil, nil)
+
+	connect := &structs.ConsulConnect{
+		Native: false,
+		SidecarService: &structs.ConsulSidecarService{
+			Tags: []string{"${tag1}", "tag2"},
+			Port: "${port1}",
+			Proxy: &structs.ConsulProxy{
+				LocalServiceAddress: "${address1}",
+				LocalServicePort:    10000,
+				Upstreams: []structs.ConsulUpstream{{
+					DestinationName: "${destination1}",
+					Datacenter:      "${datacenter1}",
+					LocalBindPort:   10001,
+				}},
+				Expose: &structs.ConsulExposeConfig{
+					Paths: []structs.ConsulExposePath{{
+						Path:          "${path1}",
+						Protocol:      "${protocol1}",
+						ListenerPort:  "${port2}",
+						LocalPathPort: 10002,
+					}},
+				},
+				Config: map[string]interface{}{
+					"${config1}": 1,
+				},
+			},
+		},
+		SidecarTask: &structs.SidecarTask{
+			Name:   "name", // not interpolated by taskenv
+			Driver: "${driver1}",
+			User:   "${user1}",
+			Config: map[string]interface{}{"${config2}": 2},
+			Env:    map[string]string{"${env1}": "${env2}"},
+			Resources: &structs.Resources{
+				CPU:      1,
+				MemoryMB: 2,
+				DiskMB:   3,
+				IOPS:     4,
+				Networks: structs.Networks{{
+					Mode:   "${mode1}",
+					Device: "${device1}",
+					CIDR:   "${cidr1}",
+					IP:     "${ip1}",
+					MBits:  1,
+					DNS: &structs.DNSConfig{
+						Servers:  []string{"${server1}"},
+						Searches: []string{"${search1}"},
+						Options:  []string{"${option1}"},
+					},
+					ReservedPorts: []structs.Port{{
+						Label:       "${port3}",
+						Value:       9000,
+						To:          9000,
+						HostNetwork: "${network1}",
+					}},
+					DynamicPorts: []structs.Port{{
+						Label:       "${port4}",
+						Value:       9001,
+						To:          9001,
+						HostNetwork: "${network2}",
+					}},
+				}},
+				Devices: structs.ResourceDevices{{
+					Name: "${resource1}",
+				}},
+			},
+			Meta:        map[string]string{"${meta1}": "${meta2}"},
+			KillTimeout: helper.TimeToPtr(1 * time.Second),
+			LogConfig: &structs.LogConfig{
+				MaxFiles:      1,
+				MaxFileSizeMB: 2,
+			},
+			ShutdownDelay: helper.TimeToPtr(2 * time.Second),
+			KillSignal:    "${signal1}",
+		},
+		Gateway: &structs.ConsulGateway{
+			Proxy: &structs.ConsulGatewayProxy{
+				ConnectTimeout:                  helper.TimeToPtr(3 * time.Second),
+				EnvoyGatewayBindTaggedAddresses: true,
+				EnvoyGatewayBindAddresses: map[string]*structs.ConsulGatewayBindAddress{
+					"${bind1}": {
+						Address: "${address2}",
+						Port:    8000,
+					},
+				},
+				EnvoyGatewayNoDefaultBind: true,
+				Config: map[string]interface{}{
+					"${config3}": 4,
+				},
+			},
+			Ingress: &structs.ConsulIngressConfigEntry{
+				TLS: &structs.ConsulGatewayTLSConfig{
+					Enabled: true,
+				},
+				Listeners: []*structs.ConsulIngressListener{{
+					Protocol: "${protocol2}",
+					Port:     8001,
+					Services: []*structs.ConsulIngressService{{
+						Name:  "${service1}",
+						Hosts: []string{"${host1}", "host2"},
+					}},
+				}},
+			},
+		},
+	}
+
+	result := interpolateConnect(env, connect)
+
+	require.Equal(t, &structs.ConsulConnect{
+		Native: false,
+		SidecarService: &structs.ConsulSidecarService{
+			Tags: []string{"_tag1", "tag2"},
+			Port: "12345",
+			Proxy: &structs.ConsulProxy{
+				LocalServiceAddress: "1.2.3.4",
+				LocalServicePort:    10000,
+				Upstreams: []structs.ConsulUpstream{{
+					DestinationName: "_dest1",
+					Datacenter:      "_datacenter1",
+					LocalBindPort:   10001,
+				}},
+				Expose: &structs.ConsulExposeConfig{
+					Paths: []structs.ConsulExposePath{{
+						Path:          "_path1",
+						Protocol:      "_protocol1",
+						ListenerPort:  "_port2",
+						LocalPathPort: 10002,
+					}},
+				},
+				Config: map[string]interface{}{
+					"_config1": 1,
+				},
+			},
+		},
+		SidecarTask: &structs.SidecarTask{
+			Name:   "name", // not interpolated by InterpolateServices
+			Driver: "_driver1",
+			User:   "_user1",
+			Config: map[string]interface{}{"_config2": 2},
+			Env:    map[string]string{"_env1": "_env2"},
+			Resources: &structs.Resources{
+				CPU:      1,
+				MemoryMB: 2,
+				DiskMB:   3,
+				IOPS:     4,
+				Networks: structs.Networks{{
+					Mode:   "_mode1",
+					Device: "_device1",
+					CIDR:   "10.0.0.0/64",
+					IP:     "1.1.1.1",
+					MBits:  1,
+					DNS: &structs.DNSConfig{
+						Servers:  []string{"10.0.0.1"},
+						Searches: []string{"10.0.0.2"},
+						Options:  []string{"10.0.0.3"},
+					},
+					ReservedPorts: []structs.Port{{
+						Label:       "_port3",
+						Value:       9000,
+						To:          9000,
+						HostNetwork: "_network1",
+					}},
+					DynamicPorts: []structs.Port{{
+						Label:       "_port4",
+						Value:       9001,
+						To:          9001,
+						HostNetwork: "_network2",
+					}},
+				}},
+				Devices: structs.ResourceDevices{{
+					Name: "_resource1",
+				}},
+			},
+			Meta:        map[string]string{"_meta1": "_meta2"},
+			KillTimeout: helper.TimeToPtr(1 * time.Second),
+			LogConfig: &structs.LogConfig{
+				MaxFiles:      1,
+				MaxFileSizeMB: 2,
+			},
+			ShutdownDelay: helper.TimeToPtr(2 * time.Second),
+			KillSignal:    "_signal1",
+		},
+		Gateway: &structs.ConsulGateway{
+			Proxy: &structs.ConsulGatewayProxy{
+				ConnectTimeout:                  helper.TimeToPtr(3 * time.Second),
+				EnvoyGatewayBindTaggedAddresses: true,
+				EnvoyGatewayBindAddresses: map[string]*structs.ConsulGatewayBindAddress{
+					"_bind1": {
+						Address: "10.0.0.4",
+						Port:    8000,
+					},
+				},
+				EnvoyGatewayNoDefaultBind: true,
+				Config: map[string]interface{}{
+					"_config3": 4,
+				},
+			},
+			Ingress: &structs.ConsulIngressConfigEntry{
+				TLS: &structs.ConsulGatewayTLSConfig{
+					Enabled: true,
+				},
+				Listeners: []*structs.ConsulIngressListener{{
+					Protocol: "_protocol2",
+					Port:     8001,
+					Services: []*structs.ConsulIngressService{{
+						Name:  "_service1",
+						Hosts: []string{"_host1", "host2"},
+					}},
+				}},
+			},
+		},
+	}, result)
 }

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -1212,6 +1212,7 @@ func TestJobEndpoint_Register_Dispatched(t *testing.T) {
 	// Create the register request with a job with 'Dispatch' set to true
 	job := mock.Job()
 	job.Dispatched = true
+	job.ParameterizedJob = &structs.ParameterizedJobConfig{}
 	req := &structs.JobRegisterRequest{
 		Job: job,
 		WriteRequest: structs.WriteRequest{


### PR DESCRIPTION
This PR enables job submitters to use interpolation in the connect
block of jobs making use of consul connect. Before, only the name of
the connect service would be interpolated, and only for a few select
identifiers related to the job itself (#6853). Now, all connect fields
can be interpolated using the full spectrum of runtime parameters.

Note that the service name is interpolated at job-submission time,
and cannot make use of values known only at runtime.

Fixes #7221