### PR TITLE
circleci: Allow expanding Makefile in enterpise

### DIFF
--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -27,3 +27,11 @@ help:
 .PHONY: ci-verify
 ci-verify:
 	@$(CIRCLECI) config validate config.yml
+
+MKFILE_PATH := $(lastword $(filter %Makefile,$(MAKEFILE_LIST)))
+CURRENT_DIR := $(dir $(realpath $(MKFILE_PATH)))
+CURRENT_DIR := $(CURRENT_DIR:/=)
+
+ifneq ($(wildcard $(CURRENT_DIR)/*.mk),)
+	include $(CURRENT_DIR)/*.mk
+endif

--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -33,5 +33,5 @@ CURRENT_DIR := $(dir $(realpath $(MKFILE_PATH)))
 CURRENT_DIR := $(CURRENT_DIR:/=)
 
 ifneq ($(wildcard $(CURRENT_DIR)/*.mk),)
-	include $(CURRENT_DIR)/*.mk
+include $(CURRENT_DIR)/*.mk
 endif


### PR DESCRIPTION
OSS no longer needs the multi-file config Makefile content, so it was removed. However, enterprise does benefit from having that around. We can allow enterprise to expand on OSS' CircleCI Makefile by adding an include directive in OSS. This will allow the Makefile to be the same on both OSS and Enterprise, so merge conflicts cannot occur.
