### PR TITLE
UI: Fix job recommendation test flakiness

### DIFF
--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -105,11 +105,9 @@ module('Acceptance | job detail (with namespaces)', function(hooks) {
       type: 'service',
       status: 'running',
       namespaceId: server.db.namespaces[1].name,
-      createRecommendations: true,
     });
     server.createList('job', 3, {
       namespaceId: server.db.namespaces[0].name,
-      createRecommendations: true,
     });
 
     managementToken = server.create('token');
@@ -213,6 +211,14 @@ module('Acceptance | job detail (with namespaces)', function(hooks) {
 
   test('resource recommendations show when they exist and can be expanded, collapsed, and processed', async function(assert) {
     server.create('feature', { name: 'Dynamic Application Sizing' });
+
+    job = server.create('job', {
+      type: 'service',
+      status: 'running',
+      namespaceId: server.db.namespaces[1].name,
+      groupsCount: 3,
+      createRecommendations: true,
+    });
 
     window.localStorage.nomadTokenSecret = managementToken.secretId;
     await JobDetail.visit({ id: job.id, namespace: server.db.namespaces[1].name });


### PR DESCRIPTION
This is meant to fix the flaky test failure seen [here](https://app.circleci.com/pipelines/github/hashicorp/nomad/13672/workflows/5a38de22-ca06-4deb-adeb-6eab375a749f/jobs/124184). There are two changes:

* constructing a job specifically for the recommendations test that has more task groups and therefore a vanishingly small (0.0001%) likelihood that no recommendations will be created
* calculating the number of task groups with recommendations instead of assuming that the group count would always equal the recommendation summary count, which was false in 1% of cases