### PR TITLE
actually honor var files

### DIFF
--- a/command/helpers.go
+++ b/command/helpers.go
@@ -453,10 +453,11 @@ func (j *JobGetter) ApiJobWithArgs(jpath string, vars []string, varfiles []strin
 			return nil, fmt.Errorf("Error reading job file from %s: %v", jpath, err)
 		}
 		jobStruct, err = jobspec2.ParseWithConfig(&jobspec2.ParseConfig{
-			Path:    pathName,
-			Body:    buf.Bytes(),
-			ArgVars: vars,
-			AllowFS: true,
+			Path:     pathName,
+			Body:     buf.Bytes(),
+			ArgVars:  vars,
+			AllowFS:  true,
+			VarFiles: varfiles,
 		})
 
 		if err != nil {


### PR DESCRIPTION
Apparently, we missed passing VarFile argument, so var files were
ignored.

Fixes https://github.com/hashicorp/nomad/issues/9588 