### PR TITLE
Tweak early return website workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -575,6 +575,8 @@ workflows:
           goarch: "386"
           filters: *backend_test_branches_filter
   website:
+    when:
+      equal: [ "https://github.com/hashicorp/nomad", << pipeline.project.git_url >> ]
     jobs:
       - website-docker-image:
           context: static-sites

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,9 +167,8 @@ jobs:
     shell: /usr/bin/env bash -euo pipefail -c
     steps:
       - checkout
-      - setup_remote_docker
       - run:
-          name: Build Docker Image if Necessary
+          name: Skip building if nothing changed
           command: |
             # There is an edge case that would cause an issue here - if dependencies are updated to an exact copy
             # of a previous version, for example if packge-lock.json is reverted, we need to manually push the new
@@ -177,17 +176,28 @@ jobs:
             # Ignore job if running an enterprise build
             IMAGE_TAG=$(cat website/Dockerfile website/package-lock.json | sha256sum | awk '{print $1;}')
             echo "Using $IMAGE_TAG"
+
             if  [ "$CIRCLE_REPOSITORY_URL" != "git@github.com:hashicorp/nomad.git" ]; then
               echo "Not Nomad OSS Repo, not building website docker image"
+              circleci-agent step halt
             elif curl https://hub.docker.com/v2/repositories/hashicorp/nomad-website/tags/$IMAGE_TAG -fsL > /dev/null; then
-                echo "Dependencies have not changed, not building a new website docker image."
-            else
-                cd website/
-                docker build -t hashicorp/nomad-website:$IMAGE_TAG .
-                docker tag hashicorp/nomad-website:$IMAGE_TAG hashicorp/nomad-website:latest
-                docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS
-                docker push hashicorp/nomad-website
+              echo "Dependencies have not changed, not building a new website docker image."
+              circleci-agent step halt
             fi
+
+      - setup_remote_docker
+      - run:
+          name: Build Docker Image
+          command: |
+            IMAGE_TAG=$(cat website/Dockerfile website/package-lock.json | sha256sum | awk '{print $1;}')
+            echo "Using $IMAGE_TAG"
+
+            cd website/
+            docker build -t hashicorp/nomad-website:$IMAGE_TAG .
+            docker tag hashicorp/nomad-website:$IMAGE_TAG hashicorp/nomad-website:latest
+            docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS
+            docker push hashicorp/nomad-website
+
   test-windows:
     executor: go-windows
 


### PR DESCRIPTION
Makes two changes to CI steps:

1. Halt the website-docker-image job early if no changes are detected. We
halt early before spinning up the remote docker engine, as the remote
docker engine step can add some delay (seconds to minutes) and is more
likely to suffer circleci instability.

This relies on https://circleci.com/docs/2.0/configuration-reference/#ending-a-job-from-within-a-step .


2. Add a CircleCI conditional to avoid running website worklows on forks. This eliminates starting the job in the first place!

The second relies on Config 2.1 option that wasn't available to us before: https://circleci.com/docs/2.0/pipeline-variables/#conditional-workflows .