### PR TITLE
pluginmanager: WaitForFirstFingerprint times out

### DIFF
--- a/client/pluginmanager/group.go
+++ b/client/pluginmanager/group.go
@@ -65,12 +65,12 @@ func (m *PluginGroup) WaitForFirstFingerprint(ctx context.Context) (<-chan struc
 		go func() {
 			defer wg.Done()
 			logger.Debug("waiting on plugin manager initial fingerprint")
-			<-manager.WaitForFirstFingerprint(ctx)
+
 			select {
+			case <-manager.WaitForFirstFingerprint(ctx):
+				logger.Debug("finished plugin manager initial fingerprint")
 			case <-ctx.Done():
 				logger.Warn("timeout waiting for plugin manager to be ready")
-			default:
-				logger.Debug("finished plugin manager initial fingerprint")
 			}
 		}()
 	}

--- a/client/pluginmanager/testing.go
+++ b/client/pluginmanager/testing.go
@@ -1,10 +1,22 @@
 package pluginmanager
 
+import "context"
+
 type MockPluginManager struct {
-	RunF      func()
-	ShutdownF func()
+	RunF                      func()
+	ShutdownF                 func()
+	WaitForFirstFingerprintCh <-chan struct{}
 }
 
 func (m *MockPluginManager) Run()               { m.RunF() }
 func (m *MockPluginManager) Shutdown()          { m.ShutdownF() }
 func (m *MockPluginManager) PluginType() string { return "mock" }
+func (m *MockPluginManager) WaitForFirstFingerprint(ctx context.Context) <-chan struct{} {
+	if m.WaitForFirstFingerprintCh != nil {
+		return m.WaitForFirstFingerprintCh
+	}
+
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}


### PR DESCRIPTION
As pointed out by [@tgross](https://github.com/hashicorp/nomad/pull/9590#discussion_r539534906), prior to this change we would have been blocking until all managers waited for first fingerprint rather than timing out as intended.