### PR TITLE
docs: Moe unquoting of HCL block attributes

### DIFF
--- a/website/pages/docs/configuration/client.mdx
+++ b/website/pages/docs/configuration/client.mdx
@@ -459,9 +459,9 @@ client {
   node_class    = "prod"
 
   meta {
-    "owner" = "ops"
-    "cached_binaries" = "redis,apache,nginx,jq,cypress,nodejs"
-    "rack" = "rack-12-1"
+    owner           = "ops"
+    cached_binaries = "redis,apache,nginx,jq,cypress,nodejs"
+    rack            = "rack-12-1"
   }
 }
 ```

--- a/website/pages/docs/job-specification/env.mdx
+++ b/website/pages/docs/job-specification/env.mdx
@@ -48,8 +48,6 @@ is preserved.
 env {
   key   = 1.4
   key   = "1.4"
-  "key" = 1.4
-  "key" = "1.4"
 
   key = true
   key = "1"

--- a/website/pages/docs/job-specification/group.mdx
+++ b/website/pages/docs/job-specification/group.mdx
@@ -148,7 +148,7 @@ This example show arbitrary user-defined metadata on the group:
 ```hcl
 group "example" {
   meta {
-    "my-key" = "my-value"
+    my-key = "my-value"
   }
 }
 ```

--- a/website/pages/docs/job-specification/hcl2/index.mdx
+++ b/website/pages/docs/job-specification/hcl2/index.mdx
@@ -109,7 +109,7 @@ meta {
 ```
 
 Additionally, block attributes must be [HCL2 valid identifiers](https://github.com/hashicorp/hcl/blob/v2.8.0/hclsyntax/spec.md#identifiers).
-Loosely speaking, identifiers may only contain letters, numbers, underscore `_`,
+Generally, identifiers may only contain letters, numbers, underscore `_`,
 or a dash `-`, and start with a letter. Notable,
 [`meta`](https://www.nomadproject.io/docs/job-specification/meta), and
 [`env`](https://www.nomadproject.io/docs/job-specification/env) keys may not

--- a/website/pages/docs/job-specification/hcl2/index.mdx
+++ b/website/pages/docs/job-specification/hcl2/index.mdx
@@ -108,6 +108,13 @@ meta {
 }
 ```
 
+Additionally, block attributes must be [HCL2 valid identifiers](https://github.com/hashicorp/hcl/blob/v2.8.0/hclsyntax/spec.md#identifiers).
+Loosely speaking, identifiers may only contain letters, numbers, underscore `_`,
+or a dash `-`, and start with a letter. Notable,
+[`meta`](https://www.nomadproject.io/docs/job-specification/meta), and
+[`env`](https://www.nomadproject.io/docs/job-specification/env) keys may not
+contain other symbols (e.g. `.`, `#`).
+
 ### Multiline "here doc" strings
 
 Nomad supports multi-line string literals in the so-called "heredoc" style, inspired by Unix shell languages:

--- a/website/pages/docs/job-specification/hcl2/variables.mdx
+++ b/website/pages/docs/job-specification/hcl2/variables.mdx
@@ -158,7 +158,6 @@ maintainers, use comments.
 Once a variable is declared in your configuration, you can set it:
 
 - Individually, with the `-var foo=bar` command line option.
-- In variable definitions files specified on the command line (with `-var-file=input.vars`).
 - As environment variables, for example: `NOMAD_VAR_foo=bar`
 
 The following sections describe these options in more detail.
@@ -178,6 +177,9 @@ If you plan to assign variables via the command line, we strongly recommend that
 you at least set a default type instead of using empty blocks; this helps the
 HCL parser understand what is being set. Otherwise, the interpreter will assume
 that any variable set on the command line is a string.
+
+<!---
+# TODO (hcl2): Renable for 1.0.1 by reverting the comment out commit
 
 ### Variable Definitions Files
 
@@ -209,6 +211,7 @@ corresponding to variable names:
   "labels": ["testing", "internal"],
 }
 ```
+--->
 
 ### Environment Variables
 
@@ -268,7 +271,7 @@ Nomad loads variables in the following order, with later sources taking
 precedence over earlier ones:
 
 - Environment variables (lowest priority)
-- Any `-var` and `-var-file` options on the command line, in the order they are
+- Any `-var` options on the command line, in the order they are
   provided. (highest priority)
 
 If the same variable is assigned multiple values using different mechanisms,
@@ -297,4 +300,3 @@ this behavior optional :
 |            var.foo              | error, "foo needs to be set" |      null        |        xy        |
 | `NOMAD_VAR_foo=yz`<br />var.foo |              yz              |        yz        |        yz        |
 |  `-var foo=yz`<br />var.foo     |              yz              |        yz        |        yz        |
-

--- a/website/pages/docs/job-specification/job.mdx
+++ b/website/pages/docs/job-specification/job.mdx
@@ -30,7 +30,7 @@ job "docs" {
   }
 
   meta {
-    "my-key" = "my-value"
+    my-key = "my-value"
   }
 
   parameterized {

--- a/website/pages/docs/job-specification/meta.mdx
+++ b/website/pages/docs/job-specification/meta.mdx
@@ -64,8 +64,6 @@ meta {
   key = "true"
   key = true
 
-  "key" = true
-
   key = 1.4
   key = "1.4"
 }

--- a/website/pages/docs/runtime/interpolation.mdx
+++ b/website/pages/docs/runtime/interpolation.mdx
@@ -47,8 +47,8 @@ task "docs" {
   # Environment variables are interpreted and can contain both runtime and
   # node attributes. These environment variables are passed into the task.
   env {
-    "DC"      = "Running on datacenter ${node.datacenter}"
-    "VERSION" = "Version ${NOMAD_META_VERSION}"
+    DC      = "Running on datacenter ${node.datacenter}"
+    VERSION = "Version ${NOMAD_META_VERSION}"
   }
 
   # Meta keys are also interpretable.


### PR DESCRIPTION
Tweak the docs for some HCL2 changes: update remaining examples that still quoted `env`/`meta` keys, remove `var-file` reference (until https://github.com/hashicorp/nomad/pull/9592 ships), and note that env/meta keys need to be valid identifiers.