### PR TITLE
set EnvVar variables in hcl2 parsing

### DIFF
--- a/command/helpers.go
+++ b/command/helpers.go
@@ -458,6 +458,7 @@ func (j *JobGetter) ApiJobWithArgs(jpath string, vars []string, varfiles []strin
 			ArgVars:  vars,
 			AllowFS:  true,
 			VarFiles: varfiles,
+			Envs:     os.Environ(),
 		})
 
 		if err != nil {

--- a/command/helpers_test.go
+++ b/command/helpers_test.go
@@ -338,16 +338,20 @@ variables {
   var1 = "default-val"
   var2 = "default-val"
   var3 = "default-val"
+  var4 = "default-val"
 }
 
 job "example" {
-  datacenters = ["${var.var1}", "${var.var2}", "${var.var3}"]
+  datacenters = ["${var.var1}", "${var.var2}", "${var.var3}", "${var.var4}"]
 }
 `
 
+	os.Setenv("NOMAD_VAR_var4", "from-envvar")
+	defer os.Unsetenv("NOMAD_VAR_var4")
+
 	cliArgs := []string{`var2=from-cli`}
 	fileVars := `var3 = "from-varfile"`
-	expected := []string{"default-val", "from-cli", "from-varfile"}
+	expected := []string{"default-val", "from-cli", "from-varfile", "from-envvar"}
 
 	hclf, err := ioutil.TempFile("", "hcl")
 	require.NoError(t, err)

--- a/website/pages/docs/job-specification/hcl2/variables.mdx
+++ b/website/pages/docs/job-specification/hcl2/variables.mdx
@@ -153,15 +153,6 @@ documentation about the job, and so it should be written from the perspective
 of the user of the job rather than its maintainer. For commentary for job
 maintainers, use comments.
 
-## Assigning Values to job Variables
-
-Once a variable is declared in your configuration, you can set it:
-
-- Individually, with the `-var foo=bar` command line option.
-- As environment variables, for example: `NOMAD_VAR_foo=bar`
-
-The following sections describe these options in more detail.
-
 ### Variables on the Command Line
 
 To specify individual variables on the command line, use the `-var` option when
@@ -211,7 +202,6 @@ corresponding to variable names:
   "labels": ["testing", "internal"],
 }
 ```
---->
 
 ### Environment Variables
 
@@ -233,6 +223,8 @@ On operating systems where environment variable names are case-sensitive,
 Nomad matches the variable name exactly as given in configuration, and so the
 required environment variable name will usually have a mix of upper and lower
 case letters as in the above example.
+
+--->
 
 ### Complex-typed Values
 
@@ -262,6 +254,7 @@ For readability, and to avoid the need to worry about shell escaping, we
 recommend always setting complex variable values via variable definitions
 files.
 
+<!---
 ### Variable Definition Precedence
 
 The above mechanisms for setting variables can be used together in any
@@ -280,6 +273,8 @@ that the same variable cannot be assigned multiple values within a single source
 
 ~> **Important:** Variables with map and object values behave the same way as
 other variables: the last value found overrides the previous values.
+
+--->
 
 ## A variable value must be known:
 


### PR DESCRIPTION
Another 🤦 case of missing to wire parameters in :( , just the environment variables this time.

Fixes #9622 .