### PR TITLE
Add and enable depgaurd linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,11 @@ linters-settings:
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
+  depguard:
+    # disallow packages from being used
+    list-type: blacklist
+    packages:
+      - github.com/hashicorp/consul/command/flags
 
 issues:
   exclude:
@@ -74,6 +79,7 @@ linters:
     - unconvert
     - gofmt
     - gosimple
+    - depguard
     # Stretch Goal
     #- maligned
   fast: false


### PR DESCRIPTION
As suggested, enable `depgaurd` and enable it on a package recently removed that should never be invited back (`github.com/hashicorp/consul/command/flags`).