### PR TITLE
build: set linux build tag on CNI networking

### DIFF
--- a/client/allocrunner/networking_cni.go
+++ b/client/allocrunner/networking_cni.go
@@ -1,3 +1,7 @@
+// For now CNI is supported only on Linux.
+//
+//+build linux
+
 package allocrunner
 
 import (


### PR DESCRIPTION
CNI network configuration is currently only supported on Linux.
For now, add the linux build tag so that the deadcode linter does
not trip over unused CNI stuff on macOS.