### PR TITLE
template: trigger change_mode for dynamic secrets on restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.2 (Unreleased)
+
+BUG FIXES:
+ * template: Fixed a bug where dynamic secrets did not trigger the template `change_mode` after a client restart. [[GH-9636](https://github.com/hashicorp/nomad/issues/9636)]
+
 ## 1.0.1 (Unreleased)
 
 IMPROVEMENTS:

--- a/client/allocrunner/taskrunner/interfaces/lifecycle.go
+++ b/client/allocrunner/taskrunner/interfaces/lifecycle.go
@@ -16,4 +16,10 @@ type TaskLifecycle interface {
 
 	// Kill a task permanently.
 	Kill(ctx context.Context, event *structs.TaskEvent) error
+
+	// HasHandle returns true if the task runner has a handle to the task
+	// driver, which is useful for distinguishing restored tasks during
+	// prestart hooks. Note: prestart should be idempotent whenever possible
+	// to handle restored tasks safely; use this as an escape hatch.
+	HasHandle() bool
 }

--- a/client/allocrunner/taskrunner/interfaces/lifecycle.go
+++ b/client/allocrunner/taskrunner/interfaces/lifecycle.go
@@ -17,9 +17,11 @@ type TaskLifecycle interface {
 	// Kill a task permanently.
 	Kill(ctx context.Context, event *structs.TaskEvent) error
 
-	// HasHandle returns true if the task runner has a handle to the task
+	// IsRunning returns true if the task runner has a handle to the task
 	// driver, which is useful for distinguishing restored tasks during
-	// prestart hooks. Note: prestart should be idempotent whenever possible
-	// to handle restored tasks safely; use this as an escape hatch.
-	HasHandle() bool
+	// prestart hooks. But note that the driver handle could go away after you
+	// check this, so callers should make sure they're handling that case
+	// safely. Ideally prestart hooks should be idempotnent whenever possible
+	// to handle restored tasks; use this as an escape hatch.
+	IsRunning() bool
 }

--- a/client/allocrunner/taskrunner/interfaces/lifecycle.go
+++ b/client/allocrunner/taskrunner/interfaces/lifecycle.go
@@ -21,7 +21,7 @@ type TaskLifecycle interface {
 	// driver, which is useful for distinguishing restored tasks during
 	// prestart hooks. But note that the driver handle could go away after you
 	// check this, so callers should make sure they're handling that case
-	// safely. Ideally prestart hooks should be idempotnent whenever possible
+	// safely. Ideally prestart hooks should be idempotent whenever possible
 	// to handle restored tasks; use this as an escape hatch.
 	IsRunning() bool
 }

--- a/client/allocrunner/taskrunner/lifecycle.go
+++ b/client/allocrunner/taskrunner/lifecycle.go
@@ -87,6 +87,6 @@ func (tr *TaskRunner) Kill(ctx context.Context, event *structs.TaskEvent) error 
 	return tr.getKillErr()
 }
 
-func (tr *TaskRunner) HasHandle() bool {
+func (tr *TaskRunner) IsRunning() bool {
 	return tr.getDriverHandle() != nil
 }

--- a/client/allocrunner/taskrunner/lifecycle.go
+++ b/client/allocrunner/taskrunner/lifecycle.go
@@ -86,3 +86,7 @@ func (tr *TaskRunner) Kill(ctx context.Context, event *structs.TaskEvent) error 
 
 	return tr.getKillErr()
 }
+
+func (tr *TaskRunner) HasHandle() bool {
+	return tr.getDriverHandle() != nil
+}

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -273,11 +273,22 @@ WAIT:
 				continue
 			}
 
+			dirty := false
 			for _, event := range events {
 				// This template hasn't been rendered
 				if event.LastWouldRender.IsZero() {
 					continue WAIT
 				}
+				if event.WouldRender && event.DidRender {
+					dirty = true
+				}
+			}
+
+			// if there's a driver handle then the task is already running and
+			// that changes how we want to behave on first render
+			if dirty && tm.config.Lifecycle.HasHandle() {
+				handledRenders := make(map[string]time.Time, len(tm.config.Templates))
+				tm.onTemplateRendered(handledRenders, time.Time{})
 			}
 
 			break WAIT

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -286,7 +286,7 @@ WAIT:
 
 			// if there's a driver handle then the task is already running and
 			// that changes how we want to behave on first render
-			if dirty && tm.config.Lifecycle.HasHandle() {
+			if dirty && tm.config.Lifecycle.IsRunning() {
 				handledRenders := make(map[string]time.Time, len(tm.config.Templates))
 				tm.onTemplateRendered(handledRenders, time.Time{})
 			}

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -385,7 +385,7 @@ func (tm *TaskTemplateManager) handleTemplateRerenders(allRenderedTime time.Time
 }
 
 func (tm *TaskTemplateManager) onTemplateRendered(handledRenders map[string]time.Time, allRenderedTime time.Time) {
-	// A template has been rendered, figure out what to do
+
 	var handling []string
 	signals := make(map[string]struct{})
 	restart := false

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -98,6 +98,10 @@ func (m *MockTaskHooks) Kill(ctx context.Context, event *structs.TaskEvent) erro
 	return nil
 }
 
+func (m *MockTaskHooks) HasHandle() bool {
+	return false // TODO
+}
+
 func (m *MockTaskHooks) EmitEvent(event *structs.TaskEvent) {
 	m.Events = append(m.Events, event)
 	select {

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -101,7 +101,7 @@ func (m *MockTaskHooks) Kill(ctx context.Context, event *structs.TaskEvent) erro
 	return nil
 }
 
-func (m *MockTaskHooks) HasHandle() bool {
+func (m *MockTaskHooks) IsRunning() bool {
 	return m.hasHandle
 }
 

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -791,7 +791,7 @@ func TestTaskTemplateManager_FirstRender_Restored(t *testing.T) {
 	// Ensure no unblock
 	select {
 	case <-harness.mockHooks.UnblockCh:
-		t.Fatalf("Task unblock should not have been called")
+		require.Fail("Task unblock should not have been called")
 	case <-time.After(time.Duration(1*testutil.TestMultiplier()) * time.Second):
 	}
 
@@ -804,19 +804,14 @@ func TestTaskTemplateManager_FirstRender_Restored(t *testing.T) {
 	select {
 	case <-harness.mockHooks.UnblockCh:
 	case <-time.After(time.Duration(5*testutil.TestMultiplier()) * time.Second):
-		t.Fatalf("Task unblock should have been called")
+		require.Fail("Task unblock should have been called")
 	}
 
 	// Check the file is there
 	path := filepath.Join(harness.taskDir, file)
 	raw, err := ioutil.ReadFile(path)
-	if err != nil {
-		t.Fatalf("Failed to read rendered template from %q: %v", path, err)
-	}
-
-	if s := string(raw); s != content {
-		t.Fatalf("Unexpected template data; got %q, want %q", s, content)
-	}
+	require.NoError(err, "Failed to read rendered template from %q", path)
+	require.Equal(content, string(raw), "Unexpected template data; got %s, want %q", raw, content)
 
 	// task is now running
 	harness.mockHooks.hasHandle = true
@@ -830,14 +825,14 @@ func TestTaskTemplateManager_FirstRender_Restored(t *testing.T) {
 	select {
 	case <-harness.mockHooks.UnblockCh:
 	case <-time.After(time.Duration(5*testutil.TestMultiplier()) * time.Second):
-		t.Fatalf("Task unblock should have been called")
+		require.Fail("Task unblock should have been called")
 	}
 
 	select {
 	case <-harness.mockHooks.RestartCh:
-		t.Fatalf("should not have restarted: %+v", harness.mockHooks)
+		require.Fail("should not have restarted", harness.mockHooks)
 	case <-harness.mockHooks.SignalCh:
-		t.Fatalf("should not have restarted: %+v", harness.mockHooks)
+		require.Fail("should not have restarted", harness.mockHooks)
 	case <-time.After(time.Duration(1*testutil.TestMultiplier()) * time.Second):
 	}
 
@@ -853,7 +848,7 @@ func TestTaskTemplateManager_FirstRender_Restored(t *testing.T) {
 	select {
 	case <-harness.mockHooks.UnblockCh:
 	case <-time.After(time.Duration(5*testutil.TestMultiplier()) * time.Second):
-		t.Fatalf("Task unblock should have been called")
+		require.Fail("Task unblock should have been called")
 	}
 
 	// Wait for restart
@@ -864,9 +859,9 @@ OUTER:
 		case <-harness.mockHooks.RestartCh:
 			break OUTER
 		case <-harness.mockHooks.SignalCh:
-			t.Fatalf("Signal with restart policy: %+v", harness.mockHooks)
+			require.Fail("Signal with restart policy", harness.mockHooks)
 		case <-timeout:
-			t.Fatalf("Should have received a restart: %+v", harness.mockHooks)
+			require.Fail("Should have received a restart", harness.mockHooks)
 		}
 	}
 }

--- a/website/pages/docs/upgrade/upgrade-specific.mdx
+++ b/website/pages/docs/upgrade/upgrade-specific.mdx
@@ -14,6 +14,27 @@ upgrade. However, specific versions of Nomad may have more details provided for
 their upgrades as a result of new features or changed behavior. This page is
 used to document those details separately from the standard upgrade flow.
 
+## Nomad 1.0.2
+
+#### Dynamic secrets trigger template changes on client restart
+
+Nomad 1.0.2 changed the behavior of template `change_mode` triggers when a
+client node restarts. In Nomad 1.0.1 and earlier, the first rendering of a
+template after a client restart would not trigger the `change_mode`. For
+dynamic secrets such as the Vault PKI secrets engine, this resulted in the
+secret being updated but not restarting or signalling the task. When the
+secret's lease expired at some later time, the task workload might fail
+because of the stale secret. For example, a web server's SSL certificate would
+be expired and browsers would be unable to connect.
+
+In Nomad 1.0.2, when a client node is restarted any task with Vault secrets
+that are generated or have expired will have its `change_mode` triggered. If
+`change_mode = "restart"` this will result in the task being restarted, to
+avoid the task failing unexpectedly at some point in the future. This change
+only impacts tasks using dynamic Vault secrets engines such as [PKI][pki], or
+when secrets are rotated. Secrets that don't change in Vault will not trigger
+a `change_mode` on client restart.
+
 ## Nomad 1.0.1
 
 #### Envoy worker threads
@@ -963,3 +984,4 @@ deleted and then Nomad 0.3.0 can be launched.
 [vault_grace]: /docs/job-specification/template
 [node drain]: https://www.nomadproject.io/docs/upgrade#5-upgrade-clients
 [`template.disable_file_sandbox`]: /docs/configuration/client#template-parameters
+[pki]: https://www.vaultproject.io/docs/secrets/pki


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9491

When a task is restored after a client restart, the template runner will
create a new lease for any dynamic secret (ex. Consul or PKI secrets
engines). But because this lease is being created in the prestart hook, we
don't trigger the `change_mode`.

This changeset uses the the existence of the task handle to detect a
previously running task that's been restored, so that we can trigger the
template `change_mode` if the template is changed, as it will be only with
dynamic secrets.

---

Note to reviewers: because this requires a bit of a refactor of the `onTemplateRendered`  so that it can be used for both first-pass and re-render, this PR is probably best reviewed commit-by-commit. https://github.com/hashicorp/nomad/issues/9491#issuecomment-742060641 and the diagram in the comment that follow it can walk you thru the problem.