### PR TITLE
build: add build target for darwin/arm64

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -53,7 +53,7 @@ endif
 # On MacOS, we only build for MacOS
 ifeq (Darwin,$(THIS_OS))
 ALL_TARGETS += darwin_amd64
-# Copy CGO files for darwin into place
+ALL_TARGETS += darwin_arm64
 endif
 
 # On FreeBSD, we only build for FreeBSD
@@ -67,6 +67,15 @@ endif
 pkg/darwin_amd64/nomad: $(SOURCE_FILES) ## Build Nomad for darwin/amd64
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
 	@CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 \
+		go build \
+		-trimpath \
+		-ldflags $(GO_LDFLAGS) \
+		-tags "$(GO_TAGS)" \
+		-o "$@"
+
+pkg/darwin_arm64/nomad: $(SOURCE_FILES) ## Build Nomad for darwin/arm64
+	@echo "==> Building $@ with tags $(GO_TAGS)..."
+	@CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 \
 		go build \
 		-trimpath \
 		-ldflags $(GO_LDFLAGS) \


### PR DESCRIPTION
Add a build target for Apple Silicon (m1) macs.

Note that Go must have been built with c4f497da6f for
Nomad to work on darwin/arm64 (i.e. wait for go1.16).

Closes #9408