### PR TITLE
cni: prevent NPE if no interface has sandbox field set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ IMPROVEMENTS:
 BUG FIXES:
  * core: Fixed a bug where ACLToken and ACLPolicy changes were ignored by the event stream [[GH-9595](https://github.com/hashicorp/nomad/issues/9595)]
  * core: Fixed a bug to honor HCL2 variables set by environment variables or variable files [[GH-9592](https://github.com/hashicorp/nomad/issues/9592)] [[GH-9623](https://github.com/hashicorp/nomad/issues/9623)]
+ * cni: Fixed a bug where plugins that do not set the interface sandbox value could crash the Nomad client. [[GH-9648](https://github.com/hashicorp/nomad/issues/9648)]
 
 ## 1.0.0 (December 8, 2020)
 

--- a/client/allocrunner/networking_cni.go
+++ b/client/allocrunner/networking_cni.go
@@ -114,13 +114,15 @@ func (c *cniNetworkConfigurator) Setup(ctx context.Context, alloc *structs.Alloc
 	netStatus := new(structs.AllocNetworkStatus)
 
 	if len(res.Interfaces) > 0 {
-		iface, name := func(r *cni.CNIResult) (*cni.Config, string) {
-			for i := range r.Interfaces {
-				if r.Interfaces[i].Sandbox != "" {
-					return r.Interfaces[i], i
+		// find an interface with Sandbox set, or any one of them if no
+		// interface has it set
+		iface, name := func(r *cni.CNIResult) (iface *cni.Config, name string) {
+			for name, iface = range r.Interfaces {
+				if iface.Sandbox != "" {
+					return
 				}
 			}
-			return nil, ""
+			return
 		}(res)
 
 		netStatus.InterfaceName = name


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9647

When we iterate over the interfaces returned from CNI setup, we filter for one
with the `Sandbox` field set. Ensure that if none of the interfaces has that
field set that we still return an available interface.