### PR TITLE
UI: Change cache prefix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,13 +254,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-deps-{{ checksum "ui/yarn.lock" }}
-            - v2-deps-
+            - v3-deps-{{ checksum "ui/yarn.lock" }}
+            - v3-deps-
       - run:
           name: yarn install
           command: cd ui && yarn install
       - save_cache:
-          key: v2-deps-{{ checksum "ui/yarn.lock" }}
+          key: v3-deps-{{ checksum "ui/yarn.lock" }}
           paths:
             - ./ui/node_modules
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,6 @@ jobs:
       - restore_cache:
           keys:
             - v3-deps-{{ checksum "ui/yarn.lock" }}
-            - v3-deps-
       - run:
           name: yarn install
           command: cd ui && yarn install


### PR DESCRIPTION
Builds on the main branch have been failing, perhaps due to
a corrupt cache.