### PR TITLE
Update HCL2 docs for 1.0.1

### DIFF
--- a/website/pages/docs/drivers/docker.mdx
+++ b/website/pages/docs/drivers/docker.mdx
@@ -327,7 +327,56 @@ config {
 
 - `work_dir` - (Optional) The working directory inside the container.
 
-- `mounts` - (Optional) A list of
+- `mount` - *Since 1.0.1* (Optional) Specify a
+  [mount](https://docs.docker.com/engine/reference/commandline/service_create/#add-bind-mounts-volumes-or-memory-filesystems)
+  to be mounted into the container. Volume, bind, and tmpfs type mounts are supported. May be specified multiple times.
+
+  ```hcl
+  config {
+    # sample volume mount
+    mount {
+      type = "volume"
+      target = "/path/in/container"
+      source = "name-of-volume"
+      readonly = false
+      volume_options {
+        no_copy = false
+        labels {
+          foo = "bar"
+        }
+        driver_config {
+          name = "pxd"
+          options {
+            foo = "bar"
+          }
+        }
+      }
+    }
+
+    # sample bind mount
+    mount {
+      type = "bind"
+      target = "/path/in/container"
+      source = "/path/in/host"
+      readonly = false
+      bind_options {
+        propagation = "rshared"
+      }
+    }
+
+    # sample tmpfs mount
+    mount {
+      type = "tmpfs"
+      target = "/path/in/container"
+      readonly = false
+      tmpfs_options {
+        size = 100000 # size in bytes
+      }
+    }
+  }
+  ```
+
+- `mounts` - (*deprecated*: Replaced by `mount` in 1.0.1) (Optional) A list of
   [mounts](https://docs.docker.com/engine/reference/commandline/service_create/#add-bind-mounts-volumes-or-memory-filesystems)
   to be mounted into the container. Volume, bind, and tmpfs type mounts are supported.
 

--- a/website/pages/docs/job-specification/hcl2/index.mdx
+++ b/website/pages/docs/job-specification/hcl2/index.mdx
@@ -154,7 +154,7 @@ mounts = [
 ]
 ```
 
-Or better yet, the new [`mount`](/docs/driver/docker#mount) syntax is more appropriate here:
+Or better yet, the new [`mount`](/docs/driver/docker#mount) syntax, introduced in Nomad 1.0.1, is more appropriate here:
 
 ````hcl
 mount {

--- a/website/pages/docs/job-specification/hcl2/index.mdx
+++ b/website/pages/docs/job-specification/hcl2/index.mdx
@@ -154,6 +154,17 @@ mounts = [
 ]
 ```
 
+Or better yet, the new [`mount`](/docs/driver/docker#mount) syntax is more appropriate here:
+
+````hcl
+mount {
+  type = "tmpfs"
+  tmpf_options {
+    size = 10000
+  }
+}
+```
+
 ### Multiline "here doc" string
 
 Nomad supports multi-line string literals in the so-called "heredoc" style, inspired by Unix shell languages:

--- a/website/pages/docs/job-specification/hcl2/variables.mdx
+++ b/website/pages/docs/job-specification/hcl2/variables.mdx
@@ -153,6 +153,15 @@ documentation about the job, and so it should be written from the perspective
 of the user of the job rather than its maintainer. For commentary for job
 maintainers, use comments.
 
+## Assigning Values to job Variables
+
+Once a variable is declared in your configuration, you can set it:
+
+- Individually, with the `-var foo=bar` command line option.
+- As environment variables, for example: `NOMAD_VAR_foo=bar`
+
+The following sections describe these options in more detail.
+
 ### Variables on the Command Line
 
 To specify individual variables on the command line, use the `-var` option when
@@ -202,6 +211,7 @@ corresponding to variable names:
   "labels": ["testing", "internal"],
 }
 ```
+--->
 
 ### Environment Variables
 
@@ -223,8 +233,6 @@ On operating systems where environment variable names are case-sensitive,
 Nomad matches the variable name exactly as given in configuration, and so the
 required environment variable name will usually have a mix of upper and lower
 case letters as in the above example.
-
---->
 
 ### Complex-typed Values
 
@@ -254,7 +262,6 @@ For readability, and to avoid the need to worry about shell escaping, we
 recommend always setting complex variable values via variable definitions
 files.
 
-<!---
 ### Variable Definition Precedence
 
 The above mechanisms for setting variables can be used together in any
@@ -273,8 +280,6 @@ that the same variable cannot be assigned multiple values within a single source
 
 ~> **Important:** Variables with map and object values behave the same way as
 other variables: the last value found overrides the previous values.
-
---->
 
 ## A variable value must be known:
 

--- a/website/pages/docs/job-specification/hcl2/variables.mdx
+++ b/website/pages/docs/job-specification/hcl2/variables.mdx
@@ -158,6 +158,7 @@ maintainers, use comments.
 Once a variable is declared in your configuration, you can set it:
 
 - Individually, with the `-var foo=bar` command line option.
+- In variable definitions files specified on the command line (with `-var-file=input.vars`).
 - As environment variables, for example: `NOMAD_VAR_foo=bar`
 
 The following sections describe these options in more detail.
@@ -177,9 +178,6 @@ If you plan to assign variables via the command line, we strongly recommend that
 you at least set a default type instead of using empty blocks; this helps the
 HCL parser understand what is being set. Otherwise, the interpreter will assume
 that any variable set on the command line is a string.
-
-<!---
-# TODO (hcl2): Renable for 1.0.1 by reverting the comment out commit
 
 ### Variable Definitions Files
 
@@ -211,7 +209,6 @@ corresponding to variable names:
   "labels": ["testing", "internal"],
 }
 ```
---->
 
 ### Environment Variables
 
@@ -271,7 +268,7 @@ Nomad loads variables in the following order, with later sources taking
 precedence over earlier ones:
 
 - Environment variables (lowest priority)
-- Any `-var` options on the command line, in the order they are
+- Any `-var` and `-var-file` options on the command line, in the order they are
   provided. (highest priority)
 
 If the same variable is assigned multiple values using different mechanisms,
@@ -300,3 +297,4 @@ this behavior optional :
 |            var.foo              | error, "foo needs to be set" |      null        |        xy        |
 | `NOMAD_VAR_foo=yz`<br />var.foo |              yz              |        yz        |        yz        |
 |  `-var foo=yz`<br />var.foo     |              yz              |        yz        |        yz        |
+


### PR DESCRIPTION
Revert the removal of `-var-file` and variable environment variable setting.  Also, document the new docker `mount` field.