### PR TITLE
docs: add potential lifecycle values

### DIFF
--- a/website/pages/docs/job-specification/lifecycle.mdx
+++ b/website/pages/docs/job-specification/lifecycle.mdx
@@ -58,7 +58,13 @@ job "docs" {
 ## `lifecycle` Parameters
 
 - `hook` `(string: "prestart")` - Specifies when a task should be run within
-  the lifecycle of a group. Currently only Prestart Hooks are supported.
+  the lifecycle of a group. The potential values are:
+  
+  - "prestart" - Runs prior to starting the main task.
+
+  - "poststart" - Runs after starting the main task.
+
+  - "poststop" - Runs after all other tasks have finished.
 
 - `sidecar` `(bool: false)` - Controls whether or not a task is ephemeral or
   long-lived within the task group. If a lifecycle task is ephemeral (`sidecar = false`), the task will not be restarted after it completes successfully. If a


### PR DESCRIPTION
I found these were missing in the docs after the mention of PostStop in the 1.0 release; I've used the same markdown style for the listing of values as f.e. present on https://www.nomadproject.io/docs/job-specification/update#health_check