### PR TITLE
e2e: move dnsmasq config into dnsmasq service unit

### DIFF
--- a/e2e/terraform/compute.tf
+++ b/e2e/terraform/compute.tf
@@ -7,8 +7,6 @@ resource "aws_instance" "server" {
   iam_instance_profile   = data.aws_iam_instance_profile.nomad_e2e_cluster.name
   availability_zone      = var.availability_zone
 
-  user_data = file("${path.root}/userdata/ubuntu-bionic.sh")
-
   # Instance tags
   tags = {
     Name           = "${local.random_name}-server-${count.index}"
@@ -26,8 +24,6 @@ resource "aws_instance" "client_ubuntu_bionic_amd64" {
   count                  = var.client_count_ubuntu_bionic_amd64
   iam_instance_profile   = data.aws_iam_instance_profile.nomad_e2e_cluster.name
   availability_zone      = var.availability_zone
-
-  user_data = file("${path.root}/userdata/ubuntu-bionic.sh")
 
   # Instance tags
   tags = {

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/dnsconfig.sh
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/dnsconfig.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
-# Tasks in the Linux userdata can't be executed during AMI builds because they
-# rely on instance-specific data, but they only need to be executed once per
-# instance and not on every provisioning of Nomad
+set -e
+
+# These tasks can't be executed during AMI builds because they rely on
+# instance-specific data.
 
 # Add hostname to /etc/hosts
-echo "127.0.0.1 $(hostname)" | sudo tee --append /etc/hosts
+echo "127.0.0.1 $(hostname)" | tee --append /etc/hosts
+
+# this script should run after docker.service but we can't guarantee
+# it's created docker0 yet, so wait to make sure
+while :
+do
+    ip link | grep -q docker0 && break
+    sleep 1
+done
 
 # Use dnsmasq first and then docker bridge network for DNS resolution
 DOCKER_BRIDGE_IP_ADDRESS=$(/usr/local/bin/sockaddr eval 'GetInterfaceIP "docker0"')
@@ -12,7 +21,7 @@ cat <<EOF > /tmp/resolv.conf
 nameserver 127.0.0.1
 nameserver $DOCKER_BRIDGE_IP_ADDRESS
 EOF
-sudo mv /tmp/resolv.conf /etc/resolv.conf
+cp /tmp/resolv.conf /etc/resolv.conf
 
 # need to get the interface for dnsmasq config so that we can
 # accomodate both "predictable" and old-style interface names
@@ -28,7 +37,7 @@ interface=$IFACE
 listen-address=127.0.0.1
 server=/consul/127.0.0.1#8600
 EOF
-sudo mv /tmp/dnsmasq /etc/dnsmasq.d/default
+cp /tmp/dnsmasq /etc/dnsmasq.d/default
 
 # need to get the AWS DNS address from the VPC...
 # this is pretty hacky but will work for any typical case
@@ -36,7 +45,6 @@ MAC=$(curl -s --fail http://169.254.169.254/latest/meta-data/mac)
 CIDR_BLOCK=$(curl -s --fail "http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-block")
 VPC_DNS_ROOT=$(echo "$CIDR_BLOCK" | cut -d'.' -f1-3)
 echo "nameserver ${VPC_DNS_ROOT}.2" > /tmp/dnsmasq-resolv.conf
-sudo mv /tmp/dnsmasq-resolv.conf /var/run/dnsmasq/resolv.conf
+cp /tmp/dnsmasq-resolv.conf /var/run/dnsmasq/resolv.conf
 
-sudo systemctl restart dnsmasq
-sudo systemctl restart docker
+/usr/sbin/dnsmasq --test

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/dnsconfig.sh
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/dnsconfig.sh
@@ -9,9 +9,8 @@ echo "127.0.0.1 $(hostname)" | tee --append /etc/hosts
 
 # this script should run after docker.service but we can't guarantee
 # it's created docker0 yet, so wait to make sure
-while :
+while ! (ip link | grep -q docker0)
 do
-    ip link | grep -q docker0 && break
     sleep 1
 done
 

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/dnsmasq.service
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/dnsmasq.service
@@ -1,0 +1,37 @@
+[Unit]
+Description=dnsmasq - A lightweight DHCP and caching DNS server
+Requires=network.target
+Wants=nss-lookup.target
+Before=nss-lookup.target
+After=network.target
+After=docker.service
+
+[Service]
+Type=forking
+PIDFile=/run/dnsmasq/dnsmasq.pid
+
+# Configure our hosts and resolver file with info from the host,
+# then test the resulting config file before starting
+ExecStartPre=/usr/local/bin/dnsconfig.sh
+
+# (from upstream)
+# We run dnsmasq via the /etc/init.d/dnsmasq script which acts as a
+# wrapper picking up extra configuration files and then execs dnsmasq
+# itself, when called with the "systemd-exec" function.
+ExecStart=/etc/init.d/dnsmasq systemd-exec
+
+# (from upstream)
+# The systemd-*-resolvconf functions configure (and deconfigure)
+# resolvconf to work with the dnsmasq DNS server. They're called like
+# this to get correct error handling (ie don't start-resolvconf if the
+# dnsmasq daemon fails to start.
+ExecStartPost=/etc/init.d/dnsmasq systemd-start-resolvconf
+
+# We need to tell docker to pick up the changes
+ExecStartPost=systemctl restart docker
+
+ExecStop=/etc/init.d/dnsmasq systemd-stop-resolvconf
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/setup.sh
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/setup.sh
@@ -146,7 +146,10 @@ sudo chown root:root /etc/dnsmasq.d/default
 echo 'nameserver 8.8.8.8' > /tmp/resolv.conf
 sudo mv /tmp/resolv.conf /etc/resolv.conf
 
-sudo systemctl restart dnsmasq
+sudo mv /tmp/linux/dnsmasq.service /etc/systemd/system/dnsmasq.service
+sudo mv /tmp/linux/dnsconfig.sh /usr/local/bin/dnsconfig.sh
+sudo chmod +x /usr/local/bin/dnsconfig.sh
+sudo systemctl daemon-reload
 
 echo "Updating boot parameters"
 


### PR DESCRIPTION
Our dnsmasq configuration needs host-specific data that we can't configure in
the AMI build. But configuring this in userdata leads to a race between
userdata execution, docker.service startup, and dnsmasq.service startup. So
rather than letting dnsmasq come up with incorrect configuration and then
modifying it after the fact, do the configuration in the service's prestart,
and have it kick off a Docker restart when we're done.

I've built a test AMI with this and it seems to solve the recent provisioning issue.
Will kick off a re-build on CI and then the nightly E2E when that's done.