### PR TITLE
UI: Quietly ignore orphaned allocs in the topo viz

### DIFF
--- a/ui/app/components/topo-viz.js
+++ b/ui/app/components/topo-viz.js
@@ -98,8 +98,9 @@ export default class TopoViz extends Component {
     allocations.forEach(allocation => {
       const nodeId = allocation.belongsTo('node').id();
       const nodeContainer = nodeIndex[nodeId];
-      if (!nodeContainer)
-        throw new Error(`Node ${nodeId} for alloc ${allocation.id} not in index.`);
+
+      // Ignore orphaned allocations
+      if (!nodeContainer) return;
 
       const allocationContainer = this.dataForAllocation(allocation, nodeContainer);
       nodeContainer.allocations.push(allocationContainer);

--- a/ui/tests/unit/components/topo-viz-test.js
+++ b/ui/tests/unit/components/topo-viz-test.js
@@ -174,6 +174,24 @@ module('Unit | Component | TopoViz', function(hooks) {
     assert.equal(topoViz.topology.datacenters[0].nodes[0].allocations[0].cpuPercent, 0.5);
     assert.equal(topoViz.topology.datacenters[0].nodes[0].allocations[0].memoryPercent, 0.1);
   });
+
+  test('allocations that reference nonexistent nodes are ignored', async function(assert) {
+    const nodes = [{ datacenter: 'dc1', id: 'node0', resources: {} }];
+
+    const allocations = [
+      alloc({ nodeId: 'node0', jobId: 'job0', taskGroupName: 'group' }),
+      alloc({ nodeId: 'node404', jobId: 'job1', taskGroupName: 'group' }),
+    ];
+
+    const topoViz = this.createComponent({ nodes, allocations });
+
+    topoViz.buildTopology();
+
+    assert.deepEqual(topoViz.topology.datacenters[0].nodes.mapBy('node'), [nodes[0]]);
+    assert.deepEqual(topoViz.topology.datacenters[0].nodes[0].allocations.mapBy('allocation'), [
+      allocations[0],
+    ]);
+  });
 });
 
 function alloc(props) {


### PR DESCRIPTION
Fixes #9658 

Conveniently, we were already detecting this case—just handling it in a less than ideal way.

Nomad will reference and surface allocations with no nodes until a GC event clears them. Draining and removing a node should consistently get a cluster into this state.

Since the topo viz only shows running and starting allocations on nodes, omitting these orphaned allocations has no impact on the feature.