### PR TITLE
WIP: better interpolation support for template and artifact source/destination

### DIFF
--- a/client/allocrunner/taskrunner/getter/getter_test.go
+++ b/client/allocrunner/taskrunner/getter/getter_test.go
@@ -95,7 +95,7 @@ func TestGetArtifact_Headers(t *testing.T) {
 
 	// Download the artifact.
 	taskEnv := new(upperReplacer)
-	err = GetArtifact(taskEnv, artifact, taskDir)
+	err = GetArtifact(taskEnv, taskEnv, artifact, taskDir, "")
 	require.NoError(t, err)
 
 	// Verify artifact exists.
@@ -129,7 +129,7 @@ func TestGetArtifact_FileAndChecksum(t *testing.T) {
 	}
 
 	// Download the artifact
-	if err := GetArtifact(noopTaskEnv, artifact, taskDir); err != nil {
+	if err := GetArtifact(noopTaskEnv, noopTaskEnv, artifact, taskDir, ""); err != nil {
 		t.Fatalf("GetArtifact failed: %v", err)
 	}
 
@@ -163,7 +163,7 @@ func TestGetArtifact_File_RelativeDest(t *testing.T) {
 	}
 
 	// Download the artifact
-	if err := GetArtifact(noopTaskEnv, artifact, taskDir); err != nil {
+	if err := GetArtifact(noopTaskEnv, noopTaskEnv, artifact, taskDir, ""); err != nil {
 		t.Fatalf("GetArtifact failed: %v", err)
 	}
 
@@ -197,7 +197,7 @@ func TestGetArtifact_File_EscapeDest(t *testing.T) {
 	}
 
 	// attempt to download the artifact
-	err = GetArtifact(noopTaskEnv, artifact, taskDir)
+	err = GetArtifact(noopTaskEnv, noopTaskEnv, artifact, taskDir, "")
 	if err == nil || !strings.Contains(err.Error(), "escapes") {
 		t.Fatalf("expected GetArtifact to disallow sandbox escape: %v", err)
 	}
@@ -247,7 +247,7 @@ func TestGetArtifact_InvalidChecksum(t *testing.T) {
 	}
 
 	// Download the artifact and expect an error
-	if err := GetArtifact(noopTaskEnv, artifact, taskDir); err == nil {
+	if err := GetArtifact(noopTaskEnv, noopTaskEnv, artifact, taskDir, ""); err == nil {
 		t.Fatalf("GetArtifact should have failed")
 	}
 }
@@ -312,7 +312,7 @@ func TestGetArtifact_Archive(t *testing.T) {
 		},
 	}
 
-	if err := GetArtifact(noopTaskEnv, artifact, taskDir); err != nil {
+	if err := GetArtifact(noopTaskEnv, noopTaskEnv, artifact, taskDir, ""); err != nil {
 		t.Fatalf("GetArtifact failed: %v", err)
 	}
 
@@ -345,7 +345,7 @@ func TestGetArtifact_Setuid(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, GetArtifact(noopTaskEnv, artifact, taskDir))
+	require.NoError(t, GetArtifact(noopTaskEnv, noopTaskEnv, artifact, taskDir, ""))
 
 	var expected map[string]int
 

--- a/client/allocrunner/taskrunner/task_dir_hook.go
+++ b/client/allocrunner/taskrunner/task_dir_hook.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	log "github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	cconfig "github.com/hashicorp/nomad/client/config"
@@ -76,6 +77,11 @@ func (h *taskDirHook) Prestart(ctx context.Context, req *interfaces.TaskPrestart
 
 // setEnvvars sets path and host env vars depending on the FS isolation used.
 func setEnvvars(envBuilder *taskenv.Builder, fsi drivers.FSIsolation, taskDir *allocdir.TaskDir, conf *cconfig.Config) {
+
+	envBuilder.SetClientAllocDir(taskDir.SharedAllocDir)
+	envBuilder.SetClientTaskLocalDir(taskDir.LocalDir)
+	envBuilder.SetClientSecretDir(taskDir.SecretsDir)
+
 	// Set driver-specific environment variables
 	switch fsi {
 	case drivers.FSIsolationNone:
@@ -93,11 +99,10 @@ func setEnvvars(envBuilder *taskenv.Builder, fsi drivers.FSIsolation, taskDir *a
 	// Set the host environment variables for non-image based drivers
 	if fsi != drivers.FSIsolationImage {
 		// COMPAT(1.0) using inclusive language, blacklist is kept for backward compatibility.
-		denylist := conf.ReadAlternativeDefault(
+		filter := strings.Split(conf.ReadAlternativeDefault(
 			[]string{"env.denylist", "env.blacklist"},
 			cconfig.DefaultEnvDenylist,
-		)
-		filter := strings.Split(denylist, ",")
+		), ",")
 		envBuilder.SetHostEnvvars(filter)
 	}
 }

--- a/client/allocrunner/taskrunner/template_hook.go
+++ b/client/allocrunner/taskrunner/template_hook.go
@@ -52,6 +52,9 @@ type templateHook struct {
 
 	// taskDir is the task directory
 	taskDir string
+
+	// shared alloc dir is the shared task alloc dir
+	sharedAllocDir string
 }
 
 func newTemplateHook(config *templateHookConfig) *templateHook {
@@ -77,6 +80,7 @@ func (h *templateHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 
 	// Store the current Vault token and the task directory
 	h.taskDir = req.TaskDir.Dir
+	h.sharedAllocDir = req.TaskDir.SharedAllocDir
 	h.vaultToken = req.VaultToken
 
 	// Set vault namespace if specified
@@ -109,6 +113,7 @@ func (h *templateHook) newManager() (unblock chan struct{}, err error) {
 		VaultToken:           h.vaultToken,
 		VaultNamespace:       h.vaultNamespace,
 		TaskDir:              h.taskDir,
+		SharedAllocDir:       h.sharedAllocDir,
 		EnvBuilder:           h.config.envBuilder,
 		MaxTemplateEventRate: template.DefaultMaxTemplateEventRate,
 	})

--- a/e2e/consultemplate/consultemplate.go
+++ b/e2e/consultemplate/consultemplate.go
@@ -245,12 +245,7 @@ func (tc *ConsulTemplateTest) TestTemplatePathInterpolation_Ok(f *framework.F) {
 			return len(out) > 0
 		}, nil), "expected file to have contents")
 
-	f.NoError(waitForTemplateRender(allocID, "task/alloc/shared.txt",
-		func(out string) bool {
-			return len(out) > 0
-		}, nil), "expected task-alloc-dir file to have contents")
-
-	f.NoError(waitForTemplateRender(allocID, "shared.txt",
+	f.NoError(waitForTemplateRender(allocID, "alloc/shared.txt",
 		func(out string) bool {
 			return len(out) > 0
 		}, nil), "expected shared-alloc-dir file to have contents")
@@ -295,6 +290,65 @@ func (tc *ConsulTemplateTest) TestTemplatePathInterpolation_Bad(f *framework.F) 
 		}
 	}
 	f.True(found, "alloc failed but NOT due to expected source path escape error")
+}
+
+// TestTemplatePathInterpolation_SharedAlloc asserts that NOMAD_ALLOC_DIR
+// is supported as a destination for artifact and template blocks, and
+// that it is properly interpolated for task drivers with varying
+// filesystem isolation
+func (tc *ConsulTemplateTest) TestTemplatePathInterpolation_SharedAllocDir(f *framework.F) {
+	jobID := "template-shared-alloc-" + uuid.Generate()[:8]
+	tc.jobIDs = append(tc.jobIDs, jobID)
+
+	allocStubs := e2eutil.RegisterAndWaitForAllocs(
+		f.T(), tc.Nomad(), "consultemplate/input/template_shared_alloc.nomad", jobID, "")
+	f.Len(allocStubs, 1)
+	allocID := allocStubs[0].ID
+
+	e2eutil.WaitForAllocRunning(f.T(), tc.Nomad(), allocID)
+
+	for _, task := range []string{"raw_exec", "docker", "exec"} {
+		f.NoError(waitForTaskFile(allocID, task, "${NOMAD_ALLOC_DIR}/raw_exec.env",
+			func(out string) bool {
+				return len(out) > 0 && strings.TrimSpace(out) != "/alloc"
+			}, nil), "expected raw_exec.env to not be '/alloc'")
+
+		f.NoError(waitForTaskFile(allocID, task, "${NOMAD_ALLOC_DIR}/exec.env",
+			func(out string) bool {
+				return strings.TrimSpace(out) == "/alloc"
+			}, nil), "expected shared exec.env to contain '/alloc'")
+
+		f.NoError(waitForTaskFile(allocID, task, "${NOMAD_ALLOC_DIR}/docker.env",
+			func(out string) bool {
+				return strings.TrimSpace(out) == "/alloc"
+			}, nil), "expected shared docker.env to contain '/alloc'")
+
+		for _, a := range []string{"google1.html", "google2.html", "google3.html"} {
+			f.NoError(waitForTaskFile(allocID, task, "${NOMAD_ALLOC_DIR}/"+a,
+				func(out string) bool {
+					return len(out) > 0
+				}, nil), "expected artifact in alloc dir")
+		}
+	}
+}
+
+func waitForTaskFile(allocID, task, path string, test func(out string) bool, wc *e2e.WaitConfig) error {
+	var err error
+	var out string
+	interval, retries := wc.OrDefault()
+
+	testutil.WaitForResultRetries(retries, func() (bool, error) {
+		time.Sleep(interval)
+		out, err = e2e.Command("nomad", "alloc", "exec", "-task", task, allocID, "sh", "-c", "cat "+path)
+		if err != nil {
+			return false, fmt.Errorf("could not cat file %q from task %q in allocation %q: %v",
+				path, task, allocID, err)
+		}
+		return test(out), nil
+	}, func(e error) {
+		err = fmt.Errorf("test for file content failed: got %#v\nerror: %v", out, e)
+	})
+	return err
 }
 
 // waitForTemplateRender is a helper that grabs a file via alloc fs

--- a/e2e/consultemplate/consultemplate.go
+++ b/e2e/consultemplate/consultemplate.go
@@ -244,6 +244,16 @@ func (tc *ConsulTemplateTest) TestTemplatePathInterpolation_Ok(f *framework.F) {
 		func(out string) bool {
 			return len(out) > 0
 		}, nil), "expected file to have contents")
+
+	f.NoError(waitForTemplateRender(allocID, "task/alloc/shared.txt",
+		func(out string) bool {
+			return len(out) > 0
+		}, nil), "expected task-alloc-dir file to have contents")
+
+	f.NoError(waitForTemplateRender(allocID, "shared.txt",
+		func(out string) bool {
+			return len(out) > 0
+		}, nil), "expected shared-alloc-dir file to have contents")
 }
 
 // TestTemplatePathInterpolation_Bad asserts that template.source paths are not

--- a/e2e/consultemplate/input/template_paths.nomad
+++ b/e2e/consultemplate/input/template_paths.nomad
@@ -28,6 +28,13 @@ job "template-paths" {
         destination = "${NOMAD_SECRETS_DIR}/foo/dst"
       }
 
+      template {
+        destination = "${NOMAD_ALLOC_DIR}/shared.txt"
+        data        = <<EOH
+Data shared between all task in alloc dir.
+EOH
+      }
+
       resources {
         cpu    = 128
         memory = 64

--- a/e2e/consultemplate/input/template_shared_alloc.nomad
+++ b/e2e/consultemplate/input/template_shared_alloc.nomad
@@ -1,0 +1,89 @@
+job "template-shared-alloc" {
+  datacenters = ["dc1", "dc2"]
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "template-paths" {
+
+    task "raw_exec" {
+      driver = "raw_exec"
+      config {
+        command = "/bin/sh"
+        args    = ["-c", "sleep 300"]
+      }
+
+      artifact {
+        source      = "https://google.com"
+        destination = "../alloc/google1.html"
+      }
+
+      template {
+        destination = "${NOMAD_ALLOC_DIR}/${NOMAD_TASK_NAME}.env"
+        data        = <<EOH
+{{env "NOMAD_ALLOC_DIR"}}
+EOH
+      }
+
+      resources {
+        cpu    = 128
+        memory = 64
+      }
+
+    }
+
+    task "docker" {
+      driver = "docker"
+      config {
+        image   = "busybox:1"
+        command = "/bin/sh"
+        args    = ["-c", "sleep 300"]
+      }
+
+      artifact {
+        source      = "https://google.com"
+        destination = "../alloc/google2.html"
+      }
+
+      template {
+        destination = "${NOMAD_ALLOC_DIR}/${NOMAD_TASK_NAME}.env"
+        data        = <<EOH
+{{env "NOMAD_ALLOC_DIR"}}
+EOH
+      }
+
+      resources {
+        cpu    = 128
+        memory = 64
+      }
+    }
+
+    task "exec" {
+      driver = "exec"
+      config {
+        command = "/bin/sh"
+        args    = ["-c", "sleep 300"]
+      }
+
+      artifact {
+        source      = "https://google.com"
+        destination = "${NOMAD_ALLOC_DIR}/google3.html"
+      }
+
+      template {
+        destination = "${NOMAD_ALLOC_DIR}/${NOMAD_TASK_NAME}.env"
+        data        = <<EOH
+{{env "NOMAD_ALLOC_DIR"}}
+EOH
+      }
+
+      resources {
+        cpu    = 128
+        memory = 64
+      }
+    }
+
+  }
+}

--- a/plugins/drivers/testutils/testing.go
+++ b/plugins/drivers/testutils/testing.go
@@ -250,6 +250,11 @@ func (d *MockDriver) ExecTaskStreaming(ctx context.Context, taskID string, execO
 
 // SetEnvvars sets path and host env vars depending on the FS isolation used.
 func SetEnvvars(envBuilder *taskenv.Builder, fsi drivers.FSIsolation, taskDir *allocdir.TaskDir, conf *config.Config) {
+
+	envBuilder.SetClientAllocDir(taskDir.SharedAllocDir)
+	envBuilder.SetClientTaskLocalDir(taskDir.LocalDir)
+	envBuilder.SetClientSecretDir(taskDir.SecretsDir)
+
 	// Set driver-specific environment variables
 	switch fsi {
 	case drivers.FSIsolationNone:


### PR DESCRIPTION

This is the first draft to address #9610 and #9389 and #6929. I wanted to get early feedback on the general approach.

*UPDATE: I've refactored this in #9671 with (imho) better abstraction*

The main change is to use client-specific absolute paths in the environment maps for interpolating `source` for `template` and `destination` for `template` and `artifact`.

Because of this, it required adjusting the sandbox-escape checks to allow shared alloc dir, in addition to task working dir

The result is that we should now support destination paths of the following forms: 
* well-known interpolated paths: `${NOMAD_ALLOC_DIR}`, `${NOMAD_SECRETS_DIR}`, `${NOMAD_TASK_DIR}`
* task-dir relative paths: `local`, `secrets`, `../alloc`

I'm in the process of adding new tests. The new [e2e test](https://github.com/hashicorp/nomad/pull/9668/files#diff-f806af7529cc10075671623ecd284693609d4014a3245fa05c34691feeac265a) shows the capability that we're targeting.

Also need to fix the failing test. And I need to read through pre-hook and make sure that I haven't broken anything in there wrt to pre-hooks and the task env.