### PR TITLE
address interpolation of artifact and template src/dest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ IMPROVEMENTS:
  * consul/connect: interpolate the connect, service meta, and service canary meta blocks with the task environment [[GH-9586](https://github.com/hashicorp/nomad/pull/9586)]
 
 BUG FIXES:
+ * template: Fixed multiple issues in template src/dest and artifact dest interpolation [[GH-9671](https://github.com/hashicorp/nomad/issues/9671)]
  * template: Fixed a bug where dynamic secrets did not trigger the template `change_mode` after a client restart. [[GH-9636](https://github.com/hashicorp/nomad/issues/9636)]
  * server: Fixed a bug where new servers may bootstrap prematurely when configured with `bootstrap_expect = 0`.
 

--- a/client/allocrunner/taskrunner/artifact_hook.go
+++ b/client/allocrunner/taskrunner/artifact_hook.go
@@ -52,7 +52,8 @@ func (h *artifactHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 
 		h.logger.Debug("downloading artifact", "artifact", artifact.GetterSource)
 		//XXX add ctx to GetArtifact to allow cancelling long downloads
-		if err := getter.GetArtifact(req.TaskEnv, artifact, req.TaskDir.Dir); err != nil {
+		if err := getter.GetArtifact(req.TaskEnv, artifact); err != nil {
+
 			wrapped := structs.NewRecoverableError(
 				fmt.Errorf("failed to download artifact %q: %v", artifact.GetterSource, err),
 				true,

--- a/client/allocrunner/taskrunner/artifact_hook_test.go
+++ b/client/allocrunner/taskrunner/artifact_hook_test.go
@@ -94,7 +94,7 @@ func TestTaskRunner_ArtifactHook_PartialDone(t *testing.T) {
 	}()
 
 	req := &interfaces.TaskPrestartRequest{
-		TaskEnv: taskenv.NewEmptyTaskEnv(),
+		TaskEnv: taskenv.NewTaskEnv(nil, nil, nil, nil, destdir, ""),
 		TaskDir: &allocdir.TaskDir{Dir: destdir},
 		Task: &structs.Task{
 			Artifacts: []*structs.TaskArtifact{

--- a/client/allocrunner/taskrunner/envoy_version_hook_test.go
+++ b/client/allocrunner/taskrunner/envoy_version_hook_test.go
@@ -17,10 +17,10 @@ import (
 )
 
 var (
-	taskEnvDefault = taskenv.NewTaskEnv(nil, nil, map[string]string{
+	taskEnvDefault = taskenv.NewTaskEnv(nil, nil, nil, map[string]string{
 		"meta.connect.sidecar_image": envoy.ImageFormat,
 		"meta.connect.gateway_image": envoy.ImageFormat,
-	})
+	}, "", "")
 )
 
 func TestEnvoyVersionHook_semver(t *testing.T) {
@@ -140,7 +140,9 @@ func TestEnvoyVersionHook_interpolateImage(t *testing.T) {
 		}
 		hook.interpolateImage(task, taskenv.NewTaskEnv(map[string]string{
 			"MY_ENVOY": "my/envoy",
-		}, nil, nil))
+		}, map[string]string{
+			"MY_ENVOY": "my/envoy",
+		}, nil, nil, "", ""))
 		require.Equal(t, "my/envoy", task.Config["image"])
 	})
 

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -1616,9 +1616,6 @@ func TestTaskTemplateManager_Escapes(t *testing.T) {
 		Name   string
 		Config func() *TaskTemplateManagerConfig
 
-		// Set to skip a test; remove once bugs are fixed
-		Skip bool
-
 		// Expected paths to be returned if Err is nil
 		SourcePath string
 		DestPath   string
@@ -1740,7 +1737,6 @@ func TestTaskTemplateManager_Escapes(t *testing.T) {
 		//      joining of the task dir onto the destination seems like
 		//      a bug. https://github.com/hashicorp/nomad/issues/9389
 		{
-			Skip: true,
 			Name: "RawExecOk",
 			Config: func() *TaskTemplateManagerConfig {
 				return &TaskTemplateManagerConfig{
@@ -1798,9 +1794,6 @@ func TestTaskTemplateManager_Escapes(t *testing.T) {
 	for i := range cases {
 		tc := cases[i]
 		t.Run(tc.Name, func(t *testing.T) {
-			if tc.Skip {
-				t.Skip("FIXME: Skipping broken test")
-			}
 			config := tc.Config()
 			mapping, err := parseTemplateConfigs(config)
 			if tc.Err == nil {

--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -135,15 +136,31 @@ type TaskEnv struct {
 
 	// envList is a memoized list created by List()
 	envList []string
+
+	// EnvMap is the map of environment variables with client-specific
+	// task directories
+	// See https://github.com/hashicorp/nomad/pull/9671
+	EnvMapClient map[string]string
+
+	// clientTaskDir is the absolute path to the task root directory on the host
+	// <alloc_dir>/<task>
+	clientTaskDir string
+
+	// clientSharedAllocDir is the path to shared alloc directory on the host
+	// <alloc_dir>/alloc/
+	clientSharedAllocDir string
 }
 
 // NewTaskEnv creates a new task environment with the given environment, device
 // environment and node attribute maps.
-func NewTaskEnv(env, deviceEnv, node map[string]string) *TaskEnv {
+func NewTaskEnv(env, envClient, deviceEnv, node map[string]string, clientTaskDir, clientAllocDir string) *TaskEnv {
 	return &TaskEnv{
-		NodeAttrs: node,
-		deviceEnv: deviceEnv,
-		EnvMap:    env,
+		NodeAttrs:            node,
+		deviceEnv:            deviceEnv,
+		EnvMap:               env,
+		EnvMapClient:         envClient,
+		clientTaskDir:        clientTaskDir,
+		clientSharedAllocDir: clientAllocDir,
 	}
 }
 
@@ -290,6 +307,53 @@ func (t *TaskEnv) ReplaceEnv(arg string) string {
 	return hargs.ReplaceEnv(arg, t.EnvMap, t.NodeAttrs)
 }
 
+// replaceEnvClient takes an arg and replaces all occurrences of client-specific
+// environment variables and Nomad variables.  If the variable is found in the
+// passed map it is replaced, otherwise the original string is returned.
+// The difference from ReplaceEnv client is potentially different values for
+// the following variables:
+// * NOMAD_ALLOC_DIR
+// * NOMAD_TASK_DIR
+// * NOMAD_SECRETS_DIR
+// and anything that was interpolated using them.
+//
+// See https://github.com/hashicorp/nomad/pull/9671
+func (t *TaskEnv) replaceEnvClient(arg string) string {
+	return hargs.ReplaceEnv(arg, t.EnvMapClient, t.NodeAttrs)
+}
+
+// checkEscape returns true if the absolute path testPath escapes both the
+// task directory and shared allocation directory specified in the
+// directory path fields of this TaskEnv
+func (t *TaskEnv) checkEscape(testPath string) bool {
+	for _, p := range []string{t.clientTaskDir, t.clientSharedAllocDir} {
+		if p != "" && !helper.PathEscapesSandbox(p, testPath) {
+			return false
+		}
+	}
+	return true
+}
+
+// ClientPath interpolates the argument as a path, using the
+// environment variables with client-relative directories. The
+// result is an absolute path on the client filesystem.
+//
+// If the interpolated result is a relative path, it is made absolute
+// wrt to the task working directory.
+// If joinEscape, an interpolated path that escapes will be joined with the
+// task dir.
+// The result is checked to see whether it (still) escapes both the task working
+// directory and the shared allocation directory.
+func (t *TaskEnv) ClientPath(rawPath string, joinEscape bool) (string, bool) {
+	path := t.replaceEnvClient(rawPath)
+	if !filepath.IsAbs(path) || (t.checkEscape(path) && joinEscape) {
+		path = filepath.Join(t.clientTaskDir, path)
+	}
+	path = filepath.Clean(path)
+	escapes := t.checkEscape(path)
+	return path, escapes
+}
+
 // Builder is used to build task environment's and is safe for concurrent use.
 type Builder struct {
 	// envvars are custom set environment variables
@@ -315,6 +379,18 @@ type Builder struct {
 
 	// secretsDir from task's perspective; eg /secrets
 	secretsDir string
+
+	// clientSharedAllocDir is the shared alloc dir from the client's perspective; eg, <alloc_dir>/<alloc_id>/alloc
+	clientSharedAllocDir string
+
+	// clientTaskRoot is the task working directory from the client's perspective; eg <alloc_dir>/<alloc_id>/<task>
+	clientTaskRoot string
+
+	// clientTaskLocalDir is the local dir from the client's perspective; eg <client_task_root>/local
+	clientTaskLocalDir string
+
+	// clientTaskSecretsDir is the secrets dir from the client's perspective; eg <client_task_root>/secrets
+	clientTaskSecretsDir string
 
 	cpuLimit         int64
 	memLimit         int64
@@ -381,24 +457,23 @@ func NewEmptyBuilder() *Builder {
 	}
 }
 
-// Build must be called after all the tasks environment values have been set.
-func (b *Builder) Build() *TaskEnv {
-	nodeAttrs := make(map[string]string)
+// buildEnv returns the environment variables and device environment
+// variables with respect to the task directories passed in the arguments.
+func (b *Builder) buildEnv(allocDir, localDir, secretsDir string,
+	nodeAttrs map[string]string) (map[string]string, map[string]string) {
+
 	envMap := make(map[string]string)
 	var deviceEnvs map[string]string
 
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-
 	// Add the directories
-	if b.allocDir != "" {
-		envMap[AllocDir] = b.allocDir
+	if allocDir != "" {
+		envMap[AllocDir] = allocDir
 	}
-	if b.localDir != "" {
-		envMap[TaskLocalDir] = b.localDir
+	if localDir != "" {
+		envMap[TaskLocalDir] = localDir
 	}
-	if b.secretsDir != "" {
-		envMap[SecretsDir] = b.secretsDir
+	if secretsDir != "" {
+		envMap[SecretsDir] = secretsDir
 	}
 
 	// Add the resource limits
@@ -442,9 +517,6 @@ func (b *Builder) Build() *TaskEnv {
 	}
 	if b.region != "" {
 		envMap[Region] = b.region
-
-		// Copy region over to node attrs
-		nodeAttrs[nodeRegionKey] = b.region
 	}
 
 	// Build the network related env vars
@@ -471,11 +543,6 @@ func (b *Builder) Build() *TaskEnv {
 	// Copy task meta
 	for k, v := range b.taskMeta {
 		envMap[k] = v
-	}
-
-	// Copy node attributes
-	for k, v := range b.nodeAttrs {
-		nodeAttrs[k] = v
 	}
 
 	// Interpolate and add environment variables
@@ -522,7 +589,29 @@ func (b *Builder) Build() *TaskEnv {
 		cleanedEnv[cleanedK] = v
 	}
 
-	return NewTaskEnv(cleanedEnv, deviceEnvs, nodeAttrs)
+	return cleanedEnv, deviceEnvs
+}
+
+// Build must be called after all the tasks environment values have been set.
+func (b *Builder) Build() *TaskEnv {
+	nodeAttrs := make(map[string]string)
+
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if b.region != "" {
+		// Copy region over to node attrs
+		nodeAttrs[nodeRegionKey] = b.region
+	}
+	// Copy node attributes
+	for k, v := range b.nodeAttrs {
+		nodeAttrs[k] = v
+	}
+
+	envMap, deviceEnvs := b.buildEnv(b.allocDir, b.localDir, b.secretsDir, nodeAttrs)
+	envMapClient, _ := b.buildEnv(b.clientSharedAllocDir, b.clientTaskLocalDir, b.clientTaskSecretsDir, nodeAttrs)
+
+	return NewTaskEnv(envMap, envMapClient, deviceEnvs, nodeAttrs, b.clientTaskRoot, b.clientSharedAllocDir)
 }
 
 // Update task updates the environment based on a new alloc and task.
@@ -722,6 +811,34 @@ func (b *Builder) SetAllocDir(dir string) *Builder {
 func (b *Builder) SetTaskLocalDir(dir string) *Builder {
 	b.mu.Lock()
 	b.localDir = dir
+	b.mu.Unlock()
+	return b
+}
+
+func (b *Builder) SetClientSharedAllocDir(dir string) *Builder {
+	b.mu.Lock()
+	b.clientSharedAllocDir = dir
+	b.mu.Unlock()
+	return b
+}
+
+func (b *Builder) SetClientTaskRoot(dir string) *Builder {
+	b.mu.Lock()
+	b.clientTaskRoot = dir
+	b.mu.Unlock()
+	return b
+}
+
+func (b *Builder) SetClientTaskLocalDir(dir string) *Builder {
+	b.mu.Lock()
+	b.clientTaskLocalDir = dir
+	b.mu.Unlock()
+	return b
+}
+
+func (b *Builder) SetClientTaskSecretsDir(dir string) *Builder {
+	b.mu.Lock()
+	b.clientTaskSecretsDir = dir
 	b.mu.Unlock()
 	return b
 }

--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -339,7 +339,6 @@ func (t *TaskEnv) checkEscape(testPath string) bool {
 // result is an absolute path on the client filesystem.
 //
 // If the interpolated result is a relative path, it is made absolute
-// wrt to the task working directory.
 // If joinEscape, an interpolated path that escapes will be joined with the
 // task dir.
 // The result is checked to see whether it (still) escapes both the task working

--- a/client/taskenv/services_test.go
+++ b/client/taskenv/services_test.go
@@ -103,9 +103,8 @@ func TestInterpolateServices(t *testing.T) {
 
 var testEnv = NewTaskEnv(
 	map[string]string{"foo": "bar", "baz": "blah"},
-	nil,
-	nil,
-)
+	map[string]string{"foo": "bar", "baz": "blah"},
+	nil, nil, "", "")
 
 func TestInterpolate_interpolateMapStringSliceString(t *testing.T) {
 	t.Parallel()
@@ -164,7 +163,7 @@ func TestInterpolate_interpolateMapStringInterface(t *testing.T) {
 func TestInterpolate_interpolateConnect(t *testing.T) {
 	t.Parallel()
 
-	env := NewTaskEnv(map[string]string{
+	e := map[string]string{
 		"tag1":         "_tag1",
 		"port1":        "12345",
 		"address1":     "1.2.3.4",
@@ -200,7 +199,8 @@ func TestInterpolate_interpolateConnect(t *testing.T) {
 		"protocol2":    "_protocol2",
 		"service1":     "_service1",
 		"host1":        "_host1",
-	}, nil, nil)
+	}
+	env := NewTaskEnv(e, e, nil, nil, "", "")
 
 	connect := &structs.ConsulConnect{
 		Native: false,

--- a/e2e/consultemplate/input/template_paths.nomad
+++ b/e2e/consultemplate/input/template_paths.nomad
@@ -28,6 +28,13 @@ job "template-paths" {
         destination = "${NOMAD_SECRETS_DIR}/foo/dst"
       }
 
+      template {
+        destination = "${NOMAD_ALLOC_DIR}/shared.txt"
+        data        = <<EOH
+Data shared between all task in alloc dir.
+EOH
+      }
+
       resources {
         cpu    = 128
         memory = 64

--- a/e2e/consultemplate/input/template_paths.nomad
+++ b/e2e/consultemplate/input/template_paths.nomad
@@ -1,6 +1,10 @@
 job "template-paths" {
   datacenters = ["dc1", "dc2"]
 
+  meta {
+    ARTIFACT_DEST_DIR = "local/foo/src"
+  }
+
   constraint {
     attribute = "${attr.kernel.name}"
     value     = "linux"
@@ -20,7 +24,7 @@ job "template-paths" {
 
       artifact {
         source      = "https://google.com"
-        destination = "local/foo/src"
+        destination = "${NOMAD_META_ARTIFACT_DEST_DIR}"
       }
 
       template {

--- a/e2e/consultemplate/input/template_shared_alloc.nomad
+++ b/e2e/consultemplate/input/template_shared_alloc.nomad
@@ -1,0 +1,114 @@
+job "template-shared-alloc" {
+  datacenters = ["dc1", "dc2"]
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "template-paths" {
+
+    task "raw_exec" {
+      driver = "raw_exec"
+      config {
+        command = "/bin/sh"
+        args    = ["-c", "sleep 300"]
+      }
+
+      lifecycle {
+        hook    = "prestart"
+        sidecar = true
+      }
+
+      artifact {
+        source      = "https://google.com"
+        destination = "../alloc/google1.html"
+      }
+
+      template {
+        destination = "${NOMAD_ALLOC_DIR}/${NOMAD_TASK_NAME}.env"
+        data        = <<EOH
+{{env "NOMAD_ALLOC_DIR"}}
+EOH
+      }
+
+      template {
+        destination = "${NOMAD_ALLOC_DIR}/hello-from-raw.env"
+        data        = <<EOH
+HELLO_FROM={{env "NOMAD_TASK_NAME"}}
+EOH
+        env         = true
+      }
+
+      resources {
+        cpu    = 128
+        memory = 64
+      }
+
+    }
+
+    task "docker" {
+      driver = "docker"
+      config {
+        image   = "busybox:1"
+        command = "/bin/sh"
+        args    = ["-c", "sleep 300"]
+      }
+
+      artifact {
+        source      = "https://google.com"
+        destination = "../alloc/google2.html"
+      }
+
+      template {
+        destination = "${NOMAD_ALLOC_DIR}/${NOMAD_TASK_NAME}.env"
+        data        = <<EOH
+{{env "NOMAD_ALLOC_DIR"}}
+EOH
+      }
+
+      template {
+        source      = "${NOMAD_ALLOC_DIR}/hello-from-raw.env"
+        destination = "${NOMAD_LOCAL_DIR}/hello-from-raw.env"
+        env         = true
+      }
+
+      resources {
+        cpu    = 128
+        memory = 64
+      }
+    }
+
+    task "exec" {
+      driver = "exec"
+      config {
+        command = "/bin/sh"
+        args    = ["-c", "sleep 300"]
+      }
+
+      artifact {
+        source      = "https://google.com"
+        destination = "${NOMAD_ALLOC_DIR}/google3.html"
+      }
+
+      template {
+        destination = "${NOMAD_ALLOC_DIR}/${NOMAD_TASK_NAME}.env"
+        data        = <<EOH
+{{env "NOMAD_ALLOC_DIR"}}
+EOH
+      }
+
+      template {
+        source      = "${NOMAD_ALLOC_DIR}/hello-from-raw.env"
+        destination = "${NOMAD_LOCAL_DIR}/hello-from-raw.env"
+        env         = true
+      }
+
+      resources {
+        cpu    = 128
+        memory = 64
+      }
+    }
+
+  }
+}

--- a/plugins/drivers/testutils/testing.go
+++ b/plugins/drivers/testutils/testing.go
@@ -250,6 +250,12 @@ func (d *MockDriver) ExecTaskStreaming(ctx context.Context, taskID string, execO
 
 // SetEnvvars sets path and host env vars depending on the FS isolation used.
 func SetEnvvars(envBuilder *taskenv.Builder, fsi drivers.FSIsolation, taskDir *allocdir.TaskDir, conf *config.Config) {
+
+	envBuilder.SetClientTaskRoot(taskDir.Dir)
+	envBuilder.SetClientSharedAllocDir(taskDir.SharedAllocDir)
+	envBuilder.SetClientTaskLocalDir(taskDir.LocalDir)
+	envBuilder.SetClientTaskSecretsDir(taskDir.SecretsDir)
+
 	// Set driver-specific environment variables
 	switch fsi {
 	case drivers.FSIsolationNone:


### PR DESCRIPTION
refactored #9668 for (imho) better abstraction

Resolves #9610 
Resolves #9389 
Resolves #6929

The main change is to use client-specific absolute paths in the environment maps for interpolating `source` for `template` and `destination` for `template` and `artifact`.

Because of this, it required adjusting the sandbox-escape checks to allow shared alloc dir, in addition to task working dir.

The result is that we should now support source and destination paths of the following forms:
* well-known interpolated paths: `${NOMAD_ALLOC_DIR}`, `${NOMAD_SECRETS_DIR}`, `${NOMAD_TASK_DIR}`
* task-dir relative paths: `local`, `secrets`, `../alloc`

The new [e2e test](https://github.com/hashicorp/nomad/pull/9668/files#diff-f806af7529cc10075671623ecd284693609d4014a3245fa05c34691feeac265a) shows the capability that we're targeting.