### PR TITLE
Don't bootstrap when `bootstrap_expect` is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
  * template: Fixed a bug where dynamic secrets did not trigger the template `change_mode` after a client restart. [[GH-9636](https://github.com/hashicorp/nomad/issues/9636)]
+ * server: Fixed a bug where new servers may bootstrap prematurely when configured with `bootstrap_expect = 0`.
 
 ## 1.0.1 (December 16, 2020)
 

--- a/nomad/serf.go
+++ b/nomad/serf.go
@@ -91,6 +91,12 @@ func (s *Server) nodeJoin(me serf.MemberEvent) {
 
 // maybeBootstrap is used to handle bootstrapping when a new server joins
 func (s *Server) maybeBootstrap() {
+
+	// redundant check to ease testing
+	if s.config.BootstrapExpect == 0 {
+		return
+	}
+
 	// Bootstrap can only be done if there are no committed logs, remove our
 	// expectations of bootstrapping. This is slightly cheaper than the full
 	// check that BootstrapCluster will do, so this is a good pre-filter.

--- a/nomad/serf.go
+++ b/nomad/serf.go
@@ -83,7 +83,7 @@ func (s *Server) nodeJoin(me serf.MemberEvent) {
 		s.peerLock.Unlock()
 
 		// If we still expecting to bootstrap, may need to handle this
-		if atomic.LoadInt32(&s.config.Bootstrapped) == 0 {
+		if s.config.BootstrapExpect != 0 && atomic.LoadInt32(&s.config.Bootstrapped) == 0 {
 			s.maybeBootstrap()
 		}
 	}

--- a/nomad/serf_test.go
+++ b/nomad/serf_test.go
@@ -473,7 +473,10 @@ func TestNomad_NonBootstraping_ShouldntBootstap(t *testing.T) {
 		t.Fatalf("expected 1 local peer: %v", err)
 	})
 
-	time.Sleep(500 * time.Millisecond)
+	// as non-bootstrap mode is the initial state, we must wait long enough to assert that
+	// we don't bootstrap even if enough time has elapsed.  Also, explicitly attempt bootstrap.
+	s1.maybeBootstrap()
+	time.Sleep(100 * time.Millisecond)
 
 	bootstrapped := atomic.LoadInt32(&s1.config.Bootstrapped)
 	require.Zero(t, bootstrapped, "expecting non-bootstrapped servers")

--- a/nomad/serf_test.go
+++ b/nomad/serf_test.go
@@ -6,11 +6,13 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/hashicorp/serf/serf"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNomad_JoinPeer(t *testing.T) {
@@ -441,4 +443,42 @@ func TestNomad_BadExpect(t *testing.T) {
 	}, func(err error) {
 		t.Fatalf("should have 0 peers: %v", err)
 	})
+}
+
+// TestNomad_NonBootstraping_ShouldntBootstap asserts that if BootstrapExpect is zero,
+// the server shouldn't bootstrap
+func TestNomad_NonBootstraping_ShouldntBootstap(t *testing.T) {
+	t.Parallel()
+
+	dir := tmpDir(t)
+	defer os.RemoveAll(dir)
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
+		c.BootstrapExpect = 0
+		c.DevMode = false
+		c.DataDir = path.Join(dir, "node")
+	})
+	defer cleanupS1()
+
+	testutil.WaitForResult(func() (bool, error) {
+		s1.peerLock.Lock()
+		p := len(s1.localPeers)
+		s1.peerLock.Unlock()
+		if p != 1 {
+			return false, fmt.Errorf("%d", p)
+		}
+
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("expected 1 local peer: %v", err)
+	})
+
+	time.Sleep(500 * time.Millisecond)
+
+	bootstrapped := atomic.LoadInt32(&s1.config.Bootstrapped)
+	require.Zero(t, bootstrapped, "expecting non-bootstrapped servers")
+
+	p, _ := s1.numPeers()
+	require.Zero(t, p, "number of peers in Raft")
+
 }


### PR DESCRIPTION
When [`bootstrap_expect`](https://www.nomadproject.io/docs/configuration/server#bootstrap_expect) is 0, the Nomad server shouldn't attempt to bootstrap and elect itself as the leader.  This is the behavior of Consul, the previous Nomad behavior, as well as intended behaviod.

The behavior was accidentally changed in https://github.com/hashicorp/nomad/pull/7252/files#diff-adc7208ec155586c7694004df7060da8916517d28041e0660d171d73bfdfee47L86-R86 . Prior to that, Nomad only attempted to bootstrap if BootstrapExpect is non-zero, while the change made it such that bootstrapping is always attempted regardless of bootstrap expect value.

Added a failing test in https://app.circleci.com/pipelines/github/hashicorp/nomad/13931/workflows/4f71cf9d-5617-4ce1-b92c-749cfddf05f2/jobs/127419 .