### PR TITLE
makefile: Re-scope VERBOSE=true, update build warnings

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,10 +22,6 @@ PROTO_COMPARE_TAG ?= v1.0.0$(if $(findstring ent,$(GO_TAGS)),+ent,)
 
 default: help
 
-ifeq (,$(findstring $(THIS_OS),Darwin Linux FreeBSD Windows MSYS_NT))
-$(error Building Nomad is currently only supported on Darwin and Linux; not $(THIS_OS))
-endif
-
 ifeq ($(CI),true)
 	$(info Running in a CI environment, verbose mode is disabled)
 else
@@ -53,11 +49,16 @@ ifeq (FreeBSD,$(THIS_OS))
 ALL_TARGETS = freebsd_amd64
 endif
 
+SUPPORTED_OSES = Darwin Linux FreeBSD Windows MSYS_NT
+
 # include per-user customization after all variables are defined
 -include GNUMakefile.local
 
 pkg/%/nomad: GO_OUT ?= $@
 pkg/%/nomad: ## Build Nomad for GOOS_GOARCH, e.g. pkg/linux_amd64/nomad
+ifeq (,$(findstring $(THIS_OS),$(SUPPORTED_OSES)))
+	$(warning WARNING: Building Nomad is only supported on $(SUPPORTED_OSES); not $(THIS_OS))
+endif
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
 	@CGO_ENABLED=1 \
 		GOOS=$(firstword $(subst _, ,$*)) \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -35,8 +35,7 @@ else
 	VERBOSE="true"
 endif
 
-
-ALL_TARGETS += linux_386 \
+ALL_TARGETS = linux_386 \
 	linux_amd64 \
 	linux_arm \
 	linux_arm64 \
@@ -45,20 +44,16 @@ ALL_TARGETS += linux_386 \
 
 endif
 
-# On s390x architecture, we only build for s390x
 ifeq (s390x,$(THIS_ARCH))
 ALL_TARGETS = linux_s390x
 endif
 
-# On MacOS, we only build for MacOS
 ifeq (Darwin,$(THIS_OS))
-ALL_TARGETS += darwin_amd64
-ALL_TARGETS += darwin_arm64
+ALL_TARGETS = darwin_amd64 darwin_arm64
 endif
 
-# On FreeBSD, we only build for FreeBSD
 ifeq (FreeBSD,$(THIS_OS))
-ALL_TARGETS += freebsd_amd64
+ALL_TARGETS = freebsd_amd64
 endif
 
 # include per-user customization after all variables are defined

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -26,22 +26,19 @@ ifeq (,$(findstring $(THIS_OS),Darwin Linux FreeBSD Windows MSYS_NT))
 $(error Building Nomad is currently only supported on Darwin and Linux; not $(THIS_OS))
 endif
 
-# On Linux we build for Linux and Windows
-ifeq (Linux,$(THIS_OS))
-
 ifeq ($(CI),true)
 	$(info Running in a CI environment, verbose mode is disabled)
 else
 	VERBOSE="true"
 endif
 
+ifeq (Linux,$(THIS_OS))
 ALL_TARGETS = linux_386 \
 	linux_amd64 \
 	linux_arm \
 	linux_arm64 \
 	windows_386 \
 	windows_amd64
-
 endif
 
 ifeq (s390x,$(THIS_ARCH))


### PR DESCRIPTION
Warn about unsupported OS rather than error

Also:

* Only print the warning when trying to build Nomad
* Print correct list of supported OSes

---
Re-scope VERBOSE=true

Previously this was only set when the OS was Linux; this was added in
805ade7d3.

I'm not sure who would actually see the verbose output, given it doesn't run in CI and is only used in the test-nomad, test-nomad-module, e2e-test, and integration-test targets. :shrug: 

---
Set 'only' ALL_TARGETS rather than append

This is functionally no different than before, but it's more correct.