### PR TITLE
docs: Add quota removal step to namespace apply

### DIFF
--- a/command/quota_init.go
+++ b/command/quota_init.go
@@ -106,22 +106,30 @@ func (c *QuotaInitCommand) Run(args []string) int {
 
 var defaultHclQuotaSpec = strings.TrimSpace(`
 name = "default-quota"
-description = "Unlimited default"
+description = "Limit the shared default namespace"
 
+# Create a limit for the global region. Additional limits may
+# be specified in-order to limit other regions.
 limit {
     region = "global"
-    region_limit {}
+    region_limit {
+        cpu = 2500
+        memory = 1000
+    }
 }
 `)
 
 var defaultJsonQuotaSpec = strings.TrimSpace(`
 {
 	"Name": "default-quota",
-	"Description": "Unlimited quota",
+	"Description": "Limit the shared default namespace",
 	"Limits": [
 		{
 			"Region": "global",
-			"RegionLimit": {}
+			"RegionLimit": {
+				"CPU": 2500,
+				"MemoryMB": 1000
+			}
 		}
 	]
 }

--- a/command/quota_init.go
+++ b/command/quota_init.go
@@ -106,30 +106,22 @@ func (c *QuotaInitCommand) Run(args []string) int {
 
 var defaultHclQuotaSpec = strings.TrimSpace(`
 name = "default-quota"
-description = "Limit the shared default namespace"
+description = "Unlimited default"
 
-# Create a limit for the global region. Additional limits may
-# be specified in-order to limit other regions.
 limit {
     region = "global"
-    region_limit {
-        cpu = 2500
-        memory = 1000
-    }
+    region_limit {}
 }
 `)
 
 var defaultJsonQuotaSpec = strings.TrimSpace(`
 {
 	"Name": "default-quota",
-	"Description": "Limit the shared default namespace",
+	"Description": "Unlimited quota",
 	"Limits": [
 		{
 			"Region": "global",
-			"RegionLimit": {
-				"CPU": 2500,
-				"MemoryMB": 1000
-			}
+			"RegionLimit": {}
 		}
 	]
 }

--- a/website/pages/docs/commands/namespace/apply.mdx
+++ b/website/pages/docs/commands/namespace/apply.mdx
@@ -36,27 +36,15 @@ If ACLs are enabled, this command requires a management ACL token.
 
 ## Examples
 
-Create a namespace with a quota
+Create a namespace with a quota:
 
 ```shell-session
 $ nomad namespace apply -description "Prod API servers" -quota prod api-prod
 Successfully applied namespace "api-prod"!
 ```
 
-Remove a quota from a namespace
-
-Quotas cannot be removed from a namespace once they have been applied, only replaced. To effectively remove a quota, create and apply an unlimited quota.
+Remove a quota from a namespace:
 
 ```shell-session
-$ nomad quota init
-Example quota specification written to spec.hcl
-$ cat spec.hcl
-name = "default-quota"
-description = "Unlimited default"
-
-limit {
-    region = "global"
-    region_limit {}
-}
-$ nomad quota apply spec.hcl
-$ nomad namespace apply -quota default-quota api-prod
+$ nomad namespace apply -quota= api-prod
+```

--- a/website/pages/docs/commands/namespace/apply.mdx
+++ b/website/pages/docs/commands/namespace/apply.mdx
@@ -42,3 +42,21 @@ Create a namespace with a quota
 $ nomad namespace apply -description "Prod API servers" -quota prod api-prod
 Successfully applied namespace "api-prod"!
 ```
+
+Remove a quota from a namespace
+
+Quotas cannot be removed from a namespace once they have been applied, only replaced. To effectively remove a quota, create and apply an unlimited quota.
+
+```shell-session
+$ nomad quota init
+Example quota specification written to spec.hcl
+$ cat spec.hcl
+name = "default-quota"
+description = "Unlimited default"
+
+limit {
+    region = "global"
+    region_limit {}
+}
+$ nomad quota apply spec.hcl
+$ nomad namespace apply -quota default-quota api-prod


### PR DESCRIPTION
This updates `quota init` to provide an unlimited quota by default, which is then referenced in the docs for how to remove a quota. The [Learn docs](https://learn.hashicorp.com/tutorials/nomad/quotas) would be out of date with this change, but maybe should also be updated to include similar quota removal steps.