### PR TITLE
docs: Remove network_speed client config field

### DIFF
--- a/website/pages/docs/configuration/client.mdx
+++ b/website/pages/docs/configuration/client.mdx
@@ -65,11 +65,6 @@ driver) but will be removed in a future release.
   [`"fingerprint.network.disallow_link_local"`](#fingerprint-network-disallow_link_local)
   configuration value.
 
-- `network_speed` `(int: 0)` - Specifies an override for the network link speed.
-  This value, if set, overrides any detected or defaulted link speed. Most
-  clients can determine their speed automatically, and thus in most cases this
-  should be left unset.
-
 - `cpu_total_compute` `(int: 0)` - Specifies an override for the total CPU
   compute. This value should be set to `# Cores * Core MHz`. For example, a
   quad-core running at 2 GHz would have a total compute of 8000 (4 \* 2000). Most


### PR DESCRIPTION
This field is deprecated and should not be used.

Closes #9385 