### PR TITLE
docs: Enumerate job statuses and types in docs

### DIFF
--- a/website/pages/api-docs/jobs.mdx
+++ b/website/pages/api-docs/jobs.mdx
@@ -547,6 +547,17 @@ $ curl \
 }
 ```
 
+#### Field Reference
+
+- `Status`: The job's current state. It can have one of the following values:
+  - `pending`: The job is currently waiting on scheduling.
+  - `running`: The job has non-terminal allocations.
+  - `dead`: All of the job's allocations and evaluations are terminal.
+- `Type`: The type of job in terms of scheduling. It can have one of the following values:
+  - `service`: Allocations are intended to remain alive.
+  - `batch`: Allocations are intended to exit.
+  - `system`: Each client gets an allocation.
+
 ## List Job Versions
 
 This endpoint reads information about all versions of a job.
@@ -593,9 +604,7 @@ $ curl \
       "Constraints": null,
       "ConsulToken": "",
       "CreateIndex": 44,
-      "Datacenters": [
-        "dc1"
-      ],
+      "Datacenters": ["dc1"],
       "Dispatched": false,
       "ID": "example",
       "JobModifyIndex": 44,
@@ -680,9 +689,7 @@ $ curl \
               "CSIPluginConfig": null,
               "Config": {
                 "image": "redis:3.2",
-                "ports": [
-                  "db"
-                ]
+                "ports": ["db"]
               },
               "Constraints": null,
               "DispatchPayload": null,
@@ -755,7 +762,6 @@ $ curl \
   ]
 }
 ```
-
 
 ```shell-session
 $ curl \


### PR DESCRIPTION
Closes #9398 

This is modeled after the existing [Field Reference](https://www.nomadproject.io/api-docs/allocations#field-reference) seen on the allocations doc page.

This isn't a complete field reference, but statuses and types are the hardest to infer from a response.