### PR TITLE
Added Enterprise Badges in Docs

### DIFF
--- a/website/pages/api-docs/quotas.mdx
+++ b/website/pages/api-docs/quotas.mdx
@@ -9,8 +9,10 @@ description: The /quota endpoints are used to query for and interact with quotas
 
 The `/quota` endpoints are used to query for and interact with quotas.
 
-~> **Enterprise Only!** This API endpoint and functionality only exists in
+<EnterpriseAlert>
+This API endpoint and functionality only exists in
 Nomad Enterprise. This is not present in the open source version of Nomad.
+</EnterpriseAlert>
 
 ## List Quota Specifications
 

--- a/website/pages/api-docs/recommendations.mdx
+++ b/website/pages/api-docs/recommendations.mdx
@@ -12,8 +12,10 @@ description: >-
 The `/recommendation` endpoints are used to query and interact with Dynamic
 Application Sizing recommendations.
 
-~> **Enterprise Only!** This API endpoint and functionality only exists in
+<EnterpriseAlert>
+This API endpoint and functionality only exists in
 Nomad Enterprise. This is not present in the open source version of Nomad.
+</EnterpriseAlert>
 
 ## List Recommendations
 

--- a/website/pages/api-docs/sentinel-policies.mdx
+++ b/website/pages/api-docs/sentinel-policies.mdx
@@ -14,8 +14,10 @@ For more details about Sentinel policies, please see the [Sentinel Policy Guide]
 
 Sentinel endpoints are only available when ACLs are enabled. For more details about ACLs, please see the [ACL Guide](https://learn.hashicorp.com/collections/nomad/access-control).
 
-~> **Enterprise Only!** This API endpoint and functionality only exists in
+<EnterpriseAlert>
+This API endpoint and functionality only exists in
 Nomad Enterprise. This is not present in the open source version of Nomad.
+</EnterpriseAlert>
 
 ## List Policies
 

--- a/website/pages/docs/autoscaling/index.mdx
+++ b/website/pages/docs/autoscaling/index.mdx
@@ -40,8 +40,10 @@ cluster.
 
 ## Dynamic Application Sizing
 
-~> **Enterprise Only!** This functionality only exists in Nomad Autoscaler
+<EnterpriseAlert>
+This functionality only exists in Nomad Autoscaler
 Enterprise. This is not present in the open source version of Nomad Autoscaler.
+</EnterpriseAlert>
 
 Dynamic Application Sizing enables organizations to optimize the resource
 consumption of applications using sizing recommendations from Nomad. It evaluates,

--- a/website/pages/docs/autoscaling/plugins/strategy.mdx
+++ b/website/pages/docs/autoscaling/plugins/strategy.mdx
@@ -47,8 +47,10 @@ check {
 
 ## Dynamic Application Sizing Average Strategy Plugin
 
-~> **Enterprise Only!** This functionality only exists in Nomad Autoscaler
+<EnterpriseAlert>
+This functionality only exists in Nomad Autoscaler
 Enterprise. This is not present in the open source version of Nomad Autoscaler.
+</EnterpriseAlert>
 
 The `app-sizing-avg` plugin calculates the average value seen across the dataset.
 The plugin applies an exponential weight decay to data, in order to give
@@ -78,8 +80,10 @@ check "avg" {
 
 ## Dynamic Application Sizing Max Strategy Plugin
 
-~> **Enterprise Only!** This functionality only exists in Nomad Autoscaler
+<EnterpriseAlert>
+This functionality only exists in Nomad Autoscaler
 Enterprise. This is not present in the open source version of Nomad Autoscaler.
+</EnterpriseAlert>
 
 The `app-sizing-max` plugin calculates the maximum value seen for the target
 resource within the available dataset. This plugin is ideally suited for memory
@@ -107,8 +111,10 @@ check "max" {
 
 ## Dynamic Application Sizing Percentile Strategy Plugin
 
-~> **Enterprise Only!** This functionality only exists in Nomad Autoscaler
+<EnterpriseAlert>
+This functionality only exists in Nomad Autoscaler
 Enterprise. This is not present in the open source version of Nomad Autoscaler.
+</EnterpriseAlert>
 
 The `app-sizing-percentile` plugin calculates its result based on a desired
 percentile value from the dataset.

--- a/website/pages/docs/autoscaling/plugins/target.mdx
+++ b/website/pages/docs/autoscaling/plugins/target.mdx
@@ -62,8 +62,10 @@ check "example-check" {
 
 ## Dynamic Application Sizing Nomad Task Target
 
-~> **Enterprise Only!** This functionality only exists in Nomad Autoscaler
+<EnterpriseAlert>
+This functionality only exists in Nomad Autoscaler
 Enterprise. This is not present in the open source version of Nomad Autoscaler.
+</EnterpriseAlert>
 
 The `app-sizing-nomad` target plugin reports on the current task resource value
 as well as submits recommendations to Nomad via the [recommendations API endpoint][nomad_recommendations_api]

--- a/website/pages/docs/autoscaling/policy.mdx
+++ b/website/pages/docs/autoscaling/policy.mdx
@@ -98,8 +98,10 @@ policy {
 
 ## Task (DAS) `policy` Options
 
-~> **Enterprise Only!** This functionality only exists in Nomad Autoscaler
+<EnterpriseAlert>
+This functionality only exists in Nomad Autoscaler
 Enterprise. This is not present in the open source version of Nomad Autoscaler.
+</EnterpriseAlert>
 
 The following options are available when using the Nomad Autoscaler Enterprise
 to perform Dynamic Application Sizing recommendations for task resources. When

--- a/website/pages/docs/integrations/vault-integration.mdx
+++ b/website/pages/docs/integrations/vault-integration.mdx
@@ -343,6 +343,7 @@ You can see examples of `v1` and `v2` syntax in the
 [template documentation][vault-kv-templates].
 
 ## Enterprise Configuration
+<EnterpriseAlert />
 
 Nomad Enterprise 0.12.2 introduced the ability for jobs to use multiple Vault Namespaces.
 There are a few configuration settings to consider when using this functionality.

--- a/website/pages/docs/job-specification/multiregion.mdx
+++ b/website/pages/docs/job-specification/multiregion.mdx
@@ -11,8 +11,7 @@ description: |-
 
 <Placement groups={[['job', 'multiregion']]} />
 
-~> **Enterprise Only!** This functionality only exists in Nomad
-Enterprise. This is not present in the open source version of Nomad.
+<EnterpriseAlert />
 
 The `multiregion` stanza specifies that a job will be deployed to multiple
 [federated regions]. If omitted, the job will be deployed to a single region


### PR DESCRIPTION
Fixes #9529 . Added Enterprise Badges in these [files](https://github.com/hashicorp/nomad/search?l=Markdown&q=%2A%2AEnterprise+Only%21%2A%2A+This+functionality+only+exists+in) using the reference from [here](https://github.com/hashicorp/nomad/tree/master/website#enterprise-alert) .