### PR TITLE
Wrong device plugin fingerprint error being logged

### DIFF
--- a/client/devicemanager/instance.go
+++ b/client/devicemanager/instance.go
@@ -373,7 +373,7 @@ START:
 				goto START
 			}
 
-			i.logger.Error("fingerprinting returned an error", "error", err)
+			i.logger.Error("fingerprinting returned an error", "error", fresp.Error)
 			i.handleFingerprintError()
 			return
 		}


### PR DESCRIPTION
We started noticing log lines like:

```
2020-12-29T20:02:55.284Z [ERROR] client.device_mgr: fingerprinting returned an error: plugin=fly-volume error=<nil>
```

when our device plugin stopped. That's not very helpful. Looking at the code, it appeared that the error being logged was unrelated to the problem.

This should log the correct error (the fingerprint response error)