### PR TITLE
Version update for demo Vagrant: Ubuntu 20.04, Nomad 1.0.1, Consul 1.9.0

### DIFF
--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -69,7 +69,7 @@ nomad -autocomplete-install
 SCRIPT
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "bento/ubuntu-20.04" # 18.04 LTS
+  config.vm.box = "bento/ubuntu-18.04" # 18.04 LTS
   config.vm.hostname = "nomad"
   config.vm.provision "shell", inline: $script, privileged: false
 

--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -25,7 +25,7 @@ sudo docker --version
 sudo apt-get install unzip curl vim -y
 
 echo "Installing Nomad..."
-NOMAD_VERSION=0.12.1
+NOMAD_VERSION=1.0.1
 cd /tmp/
 curl -sSL https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip -o nomad.zip
 unzip nomad.zip
@@ -35,7 +35,7 @@ sudo chmod a+w /etc/nomad.d
 
 
 echo "Installing Consul..."
-CONSUL_VERSION=1.7.2
+CONSUL_VERSION=1.9.0
 curl -sSL https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip > consul.zip
 unzip /tmp/consul.zip
 sudo install consul /usr/bin/consul
@@ -69,7 +69,7 @@ nomad -autocomplete-install
 SCRIPT
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "bento/ubuntu-18.04" # 18.04 LTS
+  config.vm.box = "bento/ubuntu-20.04" # 18.04 LTS
   config.vm.hostname = "nomad"
   config.vm.provision "shell", inline: $script, privileged: false
 


### PR DESCRIPTION
Vagrant was using Ubuntu 18.04 as base; update to use 20.04

Also updated Nomad and Consul versions to the latest