### PR TITLE
docs: add metrics and API docs to RPC contributors checklist

### DIFF
--- a/contributing/checklist-rpc-endpoint.md
+++ b/contributing/checklist-rpc-endpoint.md
@@ -36,3 +36,5 @@ Prefer adding a new message to changing any existing RPC messages.
 ## Docs
 
 * [ ] Changelog
+* [ ] [Metrics](https://www.nomadproject.io/docs/operations/metrics#server-metrics)
+* [ ] [API docs](https://www.nomadproject.io/api-docs) for RPCs with an HTTP endpoint, include ACLs, params, and example response body.


### PR DESCRIPTION
Adds notes to our contributor checklist to make sure we keep the new table in https://github.com/hashicorp/nomad/pull/9694 up to date.