### PR TITLE
Refactor alloc exec command

### DIFF
--- a/command/alloc_exec.go
+++ b/command/alloc_exec.go
@@ -206,7 +206,9 @@ func (l *AllocExecCommand) Run(args []string) int {
 
 	if !stdinOpt {
 		l.Stdin = bytes.NewReader(nil)
-	} else if l.Stdin == nil {
+	}
+
+	if l.Stdin == nil {
 		l.Stdin = os.Stdin
 	}
 

--- a/command/alloc_exec.go
+++ b/command/alloc_exec.go
@@ -114,7 +114,7 @@ func (l *AllocExecCommand) Run(args []string) int {
 		return 1
 	}
 
-	args := flags.Args()
+	args = flags.Args()
 
 	if len(args) < 1 {
 		if job {

--- a/command/alloc_exec.go
+++ b/command/alloc_exec.go
@@ -99,15 +99,14 @@ func (l *AllocExecCommand) AutocompleteArgs() complete.Predictor {
 func (l *AllocExecCommand) Name() string { return "alloc exec" }
 
 func (l *AllocExecCommand) Run(args []string) int {
+	var job, stdinOpt, ttyOpt bool
+	var task, escapeChar string
+
 	flags := l.Meta.FlagSet(l.Name(), FlagSetClient)
 	flags.Usage = func() { l.Ui.Output(l.Help()) }
-
-	var job, stdinOpt, ttyOpt bool
 	flags.BoolVar(&job, "job", false, "")
 	flags.BoolVar(&stdinOpt, "i", true, "")
 	flags.BoolVar(&ttyOpt, "t", isTty(), "")
-
-	var escapeChar, task string
 	flags.StringVar(&escapeChar, "e", "~", "")
 	flags.StringVar(&task, "task", "", "")
 
@@ -115,9 +114,9 @@ func (l *AllocExecCommand) Run(args []string) int {
 		return 1
 	}
 
-	positionalArgs := flags.Args()
+	args := flags.Args()
 
-	if len(positionalArgs) < 1 {
+	if len(args) < 1 {
 		if job {
 			l.Ui.Error("A job ID is required")
 		} else {
@@ -127,7 +126,7 @@ func (l *AllocExecCommand) Run(args []string) int {
 		return 1
 	}
 
-	jobOrAllocID := positionalArgs[0]
+	jobOrAllocID := args[0]
 	if len(jobOrAllocID) == 1 {
 		if job {
 			l.Ui.Error("Job ID must contain at least two characters")
@@ -137,7 +136,7 @@ func (l *AllocExecCommand) Run(args []string) int {
 		return 1
 	}
 
-	if len(positionalArgs) < 2 {
+	if len(args) < 2 {
 		l.Ui.Error("A command is required")
 		l.Ui.Error(commandErrorText(l))
 		return 1
@@ -221,7 +220,7 @@ func (l *AllocExecCommand) Run(args []string) int {
 		l.Stderr = os.Stderr
 	}
 
-	code, err := l.execImpl(client, alloc, task, ttyOpt, positionalArgs[1:], escapeChar, l.Stdin, l.Stdout, l.Stderr)
+	code, err := l.execImpl(client, alloc, task, ttyOpt, args[1:], escapeChar, l.Stdin, l.Stdout, l.Stderr)
 	if err != nil {
 		l.Ui.Error(fmt.Sprintf("failed to exec into task: %v", err))
 		return 1

--- a/command/alloc_exec_test.go
+++ b/command/alloc_exec_test.go
@@ -30,39 +30,54 @@ func TestAllocExecCommand_Fails(t *testing.T) {
 		expectedError string
 	}{
 		{
-			"misuse",
-			[]string{"bad"},
-			commandErrorText(&AllocExecCommand{}),
+			"alloc id missing",
+			[]string{},
+			`An allocation ID is required`,
 		},
 		{
-			"connection failure",
-			[]string{"-address=nope", "26470238-5CF2-438F-8772-DC67CFB0705C", "/bin/bash"},
-			"Error querying allocation",
+			"alloc id too short",
+			[]string{"-address=" + url, "2", "/bin/bash"},
+			`Alloc ID must contain at least two characters`,
 		},
 		{
-			"not found alloc",
+			"alloc not found",
 			[]string{"-address=" + url, "26470238-5CF2-438F-8772-DC67CFB0705C", "/bin/bash"},
-			"No allocation(s) with prefix or id",
+			`No allocation(s) with prefix or id "26470238-5CF2-438F-8772-DC67CFB0705C"`,
 		},
 		{
-			"not found job",
+			"alloc not found with odd-length prefix",
+			[]string{"-address=" + url, "26470238-5CF", "/bin/bash"},
+			`No allocation(s) with prefix or id "26470238-5CF"`,
+		},
+		{
+			"job id missing",
+			[]string{"-job"},
+			`A job ID is required`,
+		},
+		{
+			"job id too short",
+			[]string{"-address=" + url, "-job", "2", "/bin/bash"},
+			`Job ID must contain at least two characters`,
+		},
+		{
+			"job not found",
 			[]string{"-address=" + url, "-job", "example", "/bin/bash"},
 			`job "example" doesn't exist`,
 		},
 		{
-			"too short allocis",
-			[]string{"-address=" + url, "2", "/bin/bash"},
-			"Alloc ID must contain at least two characters",
-		},
-		{
-			"missing command",
+			"command missing",
 			[]string{"-address=" + url, "26470238-5CF2-438F-8772-DC67CFB0705C"},
-			"A command is required",
+			`A command is required`,
 		},
 		{
-			"long escaped char",
-			[]string{"-address=" + url, "-e", "long_escape", "26470238-5CF2-438F-8772-DC67CFB0705C", "/bin/bash"},
-			"a single character",
+			"connection failure",
+			[]string{"-address=nope", "26470238-5CF2-438F-8772-DC67CFB0705C", "/bin/bash"},
+			`Error querying allocation`,
+		},
+		{
+			"escape char too long",
+			[]string{"-address=" + url, "-e", "es", "26470238-5CF2-438F-8772-DC67CFB0705C", "/bin/bash"},
+			`-e requires 'none' or a single character`,
 		},
 	}
 

--- a/command/alloc_exec_test.go
+++ b/command/alloc_exec_test.go
@@ -55,11 +55,6 @@ func TestAllocExecCommand_Fails(t *testing.T) {
 			`A job ID is required`,
 		},
 		{
-			"job id too short",
-			[]string{"-address=" + url, "-job", "2", "/bin/bash"},
-			`Job ID must contain at least two characters`,
-		},
-		{
 			"job not found",
 			[]string{"-address=" + url, "-job", "example", "/bin/bash"},
 			`job "example" doesn't exist`,

--- a/command/alloc_fs.go
+++ b/command/alloc_fs.go
@@ -409,5 +409,5 @@ func getRandomJobAllocID(client *api.Client, jobID string) (string, error) {
 		return "", err
 	}
 
-	return alloc.ID, err
+	return alloc.ID, nil
 }

--- a/command/alloc_fs.go
+++ b/command/alloc_fs.go
@@ -164,12 +164,11 @@ func (f *AllocFSCommand) Run(args []string) int {
 	// If -job is specified, use random allocation, otherwise use provided allocation
 	allocID := args[0]
 	if job {
-		alloc, err := getRandomJobAlloc(client, args[0])
+		allocID, err = getRandomJobAllocID(client, args[0])
 		if err != nil {
 			f.Ui.Error(fmt.Sprintf("Error fetching allocations: %v", err))
 			return 1
 		}
-		allocID = alloc.ID
 	}
 
 	// Truncate the id unless full length is requested
@@ -402,4 +401,9 @@ func getRandomJobAlloc(client *api.Client, jobID string) (*api.AllocationListStu
 	alloc := runningAllocs[r.Intn(len(runningAllocs))]
 
 	return alloc, err
+}
+
+func getRandomJobAllocID(client *api.Client, jobID string) (string, error) {
+	alloc, err := getRandomJobAlloc(client, jobID)
+	return alloc.ID, err
 }

--- a/command/alloc_fs.go
+++ b/command/alloc_fs.go
@@ -164,11 +164,12 @@ func (f *AllocFSCommand) Run(args []string) int {
 	// If -job is specified, use random allocation, otherwise use provided allocation
 	allocID := args[0]
 	if job {
-		allocID, err = getRandomJobAlloc(client, args[0])
+		alloc, err := getRandomJobAlloc(client, args[0])
 		if err != nil {
 			f.Ui.Error(fmt.Sprintf("Error fetching allocations: %v", err))
 			return 1
 		}
+		allocID = alloc.ID
 	}
 
 	// Truncate the id unless full length is requested
@@ -376,15 +377,15 @@ func (f *AllocFSCommand) followFile(client *api.Client, alloc *api.Allocation,
 	return r, nil
 }
 
-// Get Random Allocation ID from a known jobID. Prefer to use a running allocation,
+// Get Random Allocation from a known jobID. Prefer to use a running allocation,
 // but use a dead allocation if no running allocations are found
-func getRandomJobAlloc(client *api.Client, jobID string) (string, error) {
+func getRandomJobAlloc(client *api.Client, jobID string) (*api.AllocationListStub, error) {
 	var runningAllocs []*api.AllocationListStub
 	allocs, _, err := client.Jobs().Allocations(jobID, false, nil)
 
 	// Check that the job actually has allocations
 	if len(allocs) == 0 {
-		return "", fmt.Errorf("job %q doesn't exist or it has no allocations", jobID)
+		return nil, fmt.Errorf("job %q doesn't exist or it has no allocations", jobID)
 	}
 
 	for _, v := range allocs {
@@ -398,6 +399,7 @@ func getRandomJobAlloc(client *api.Client, jobID string) (string, error) {
 	}
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	allocID := runningAllocs[r.Intn(len(runningAllocs))].ID
-	return allocID, err
+	alloc := runningAllocs[r.Intn(len(runningAllocs))]
+
+	return alloc, err
 }

--- a/command/alloc_fs.go
+++ b/command/alloc_fs.go
@@ -405,5 +405,9 @@ func getRandomJobAlloc(client *api.Client, jobID string) (*api.AllocationListStu
 
 func getRandomJobAllocID(client *api.Client, jobID string) (string, error) {
 	alloc, err := getRandomJobAlloc(client, jobID)
+	if err != nil {
+		return "", err
+	}
+
 	return alloc.ID, err
 }

--- a/command/alloc_logs.go
+++ b/command/alloc_logs.go
@@ -144,7 +144,7 @@ func (l *AllocLogsCommand) Run(args []string) int {
 	// If -job is specified, use random allocation, otherwise use provided allocation
 	allocID := args[0]
 	if job {
-		allocID, err = getRandomJobAlloc(client, args[0])
+		allocID, err = getRandomJobAllocID(client, args[0])
 		if err != nil {
 			l.Ui.Error(fmt.Sprintf("Error fetching allocations: %v", err))
 			return 1


### PR DESCRIPTION
While looking into `alloc exec`, I found there were some improvements that could be made to the code for readability, as well as correctness, so as a low-priority thing I did a rewrite.

This re-arranges the alloc exec Run implementation to have validation hoisted as high as possible, ~which allows for returning a better error message when `-job` is given with a too-short job ID, as well as a more correct error message in that case.~ <- this was removed as the full job name is required.