### PR TITLE
e2e: dnsmasq configuration fixes

### DIFF
--- a/e2e/terraform/packer/ubuntu-bionic-amd64/dnsconfig.sh
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/dnsconfig.sh
@@ -4,6 +4,9 @@ set -e
 # These tasks can't be executed during AMI builds because they rely on
 # instance-specific data.
 
+mkdir -p /var/run/dnsmasq
+mkdir -p /etc/dnsmasq.d
+
 # Add hostname to /etc/hosts
 echo "127.0.0.1 $(hostname)" | tee --append /etc/hosts
 

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/dnsmasq.service
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/dnsmasq.service
@@ -28,7 +28,7 @@ ExecStart=/etc/init.d/dnsmasq systemd-exec
 ExecStartPost=/etc/init.d/dnsmasq systemd-start-resolvconf
 
 # We need to tell docker to pick up the changes
-ExecStartPost=systemctl restart docker
+ExecStartPost=/bin/systemctl restart docker
 
 ExecStop=/etc/init.d/dnsmasq systemd-stop-resolvconf
 ExecReload=/bin/kill -HUP $MAINPID

--- a/e2e/terraform/provision-nomad/main.tf
+++ b/e2e/terraform/provision-nomad/main.tf
@@ -34,6 +34,7 @@ resource "null_resource" "provision_nomad" {
   # Run the provisioner as a local-exec'd ssh command as a workaround for
   # Windows remote-exec zero-byte scripts bug:
   # https://github.com/hashicorp/terraform/issues/25634
+  # https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#0150-unreleased
   #
   # The retry behavior and explicit PasswordAuthenticaiton flag here are to
   # workaround a race with the Windows userdata script that installs the


### PR DESCRIPTION
* systemd units require absolute paths
* ensure directory exists for dnsmasq

This should have been caught when I tested https://github.com/hashicorp/nomad/pull/9660, but I can't figure out why it didn't show up there. The resulting failure is intermittent so it's possible that there's a race condition we're winning sometimes in the directory configuration, but sometimes not.

AMI ami-00efbb65a6510a043 has this patch, which I've tested for a full cluster (and inadvertently so has @shoenig b/c I built the AMI without tagging it for testing accidentally).