### PR TITLE
consul: always include task services hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ IMPROVEMENTS:
  * consul/connect: interpolate the connect, service meta, and service canary meta blocks with the task environment [[GH-9586](https://github.com/hashicorp/nomad/pull/9586)]
 
 BUG FIXES:
+ * consul: Fixed a bug where updating a task to include services would not work [[GH-9707](https://github.com/hashicorp/nomad/issues/9707)]
  * template: Fixed multiple issues in template src/dest and artifact dest interpolation [[GH-9671](https://github.com/hashicorp/nomad/issues/9671)]
  * template: Fixed a bug where dynamic secrets did not trigger the template `change_mode` after a client restart. [[GH-9636](https://github.com/hashicorp/nomad/issues/9636)]
  * server: Fixed a bug where new servers may bootstrap prematurely when configured with `bootstrap_expect = 0`.

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -101,16 +101,15 @@ func (tr *TaskRunner) initHooks() {
 		}))
 	}
 
-	// If there are any services, add the service hook
-	if len(task.Services) != 0 {
-		tr.runnerHooks = append(tr.runnerHooks, newServiceHook(serviceHookConfig{
-			alloc:     tr.Alloc(),
-			task:      tr.Task(),
-			consul:    tr.consulServiceClient,
-			restarter: tr,
-			logger:    hookLogger,
-		}))
-	}
+	// Always add the service hook. A task with no services on initial registration
+	// may be updated to include services, which must be handled with this hook.
+	tr.runnerHooks = append(tr.runnerHooks, newServiceHook(serviceHookConfig{
+		alloc:     tr.Alloc(),
+		task:      tr.Task(),
+		consul:    tr.consulServiceClient,
+		restarter: tr,
+		logger:    hookLogger,
+	}))
 
 	// If this is a Connect sidecar proxy (or a Connect Native) service,
 	// add the sidsHook for requesting a Service Identity token (if ACLs).

--- a/e2e/consul/input/consul_example.nomad
+++ b/e2e/consul/input/consul_example.nomad
@@ -23,7 +23,7 @@ job "consul-example" {
     healthy_deadline = "5m"
   }
 
-  group "cache" {
+  group "group" {
     count = 3
 
     network {
@@ -41,7 +41,7 @@ job "consul-example" {
       size = 300
     }
 
-    task "redis" {
+    task "example" {
       driver = "docker"
 
       config {

--- a/e2e/consul/input/services_empty.nomad
+++ b/e2e/consul/input/services_empty.nomad
@@ -1,0 +1,29 @@
+job "consul-register-on-update" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "echo" {
+
+    task "busybox-nc" {
+      driver = "docker"
+
+      config {
+        image   = "busybox:1"
+        command = "nc"
+        args = [
+          "-ll",
+          "-p",
+          "1234",
+          "-e",
+        "/bin/cat"]
+      }
+
+      # no initial service definition
+    }
+  }
+}

--- a/e2e/consul/input/services_present.nomad
+++ b/e2e/consul/input/services_present.nomad
@@ -1,0 +1,31 @@
+job "consul-register-on-update" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "echo" {
+
+    task "busybox-nc" {
+      driver = "docker"
+
+      config {
+        image   = "busybox:1"
+        command = "nc"
+        args = [
+          "-ll",
+          "-p",
+          "1234",
+          "-e",
+        "/bin/cat"]
+      }
+
+      service {
+        name = "nc-service"
+      }
+    }
+  }
+}

--- a/e2e/consul/script_checks.go
+++ b/e2e/consul/script_checks.go
@@ -32,64 +32,65 @@ func (tc *ScriptChecksE2ETest) BeforeAll(f *framework.F) {
 // and associated script checks. It updates, stops, etc. the job to verify
 // that script checks are re-registered as expected.
 func (tc *ScriptChecksE2ETest) TestGroupScriptCheck(f *framework.F) {
+	r := require.New(f.T())
+
 	nomadClient := tc.Nomad()
-	uuid := uuid.Generate()
-	require := require.New(f.T())
 	consulClient := tc.Consul()
 
-	jobId := "checks_group" + uuid[0:8]
+	jobId := "checks_group" + uuid.Short()
 	tc.jobIds = append(tc.jobIds, jobId)
 
 	// Job run: verify that checks were registered in Consul
 	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(),
 		nomadClient, "consul/input/checks_group.nomad", jobId, "")
-	require.Equal(1, len(allocs))
-	e2eutil.RequireConsulStatus(require, consulClient, "group-service-1", capi.HealthPassing)
-	e2eutil.RequireConsulStatus(require, consulClient, "group-service-2", capi.HealthWarning)
-	e2eutil.RequireConsulStatus(require, consulClient, "group-service-3", capi.HealthCritical)
+	r.Equal(1, len(allocs))
+	e2eutil.RequireConsulStatus(r, consulClient, "group-service-1", capi.HealthPassing)
+	e2eutil.RequireConsulStatus(r, consulClient, "group-service-2", capi.HealthWarning)
+	e2eutil.RequireConsulStatus(r, consulClient, "group-service-3", capi.HealthCritical)
 
 	// Check in warning state becomes healthy after check passes
 	_, _, err := exec(nomadClient, allocs,
 		[]string{"/bin/sh", "-c", "touch /tmp/${NOMAD_ALLOC_ID}-alive-2b"})
-	require.NoError(err)
-	e2eutil.RequireConsulStatus(require, consulClient, "group-service-2", capi.HealthPassing)
+	r.NoError(err)
+	e2eutil.RequireConsulStatus(r, consulClient, "group-service-2", capi.HealthPassing)
 
 	// Job update: verify checks are re-registered in Consul
 	allocs = e2eutil.RegisterAndWaitForAllocs(f.T(),
 		nomadClient, "consul/input/checks_group_update.nomad", jobId, "")
-	require.Equal(1, len(allocs))
-	e2eutil.RequireConsulStatus(require, consulClient, "group-service-1", capi.HealthPassing)
-	e2eutil.RequireConsulStatus(require, consulClient, "group-service-2", capi.HealthPassing)
-	e2eutil.RequireConsulStatus(require, consulClient, "group-service-3", capi.HealthCritical)
+	r.Equal(1, len(allocs))
+	e2eutil.RequireConsulStatus(r, consulClient, "group-service-1", capi.HealthPassing)
+	e2eutil.RequireConsulStatus(r, consulClient, "group-service-2", capi.HealthPassing)
+	e2eutil.RequireConsulStatus(r, consulClient, "group-service-3", capi.HealthCritical)
 
 	// Verify we don't have any linger script checks running on the client
 	out, _, err := exec(nomadClient, allocs, []string{"pgrep", "sleep"})
-	require.NoError(err)
+	r.NoError(err)
 	running := strings.Split(strings.TrimSpace(out.String()), "\n")
-	require.LessOrEqual(len(running), 2) // task itself + 1 check == 2
+	r.LessOrEqual(len(running), 2) // task itself + 1 check == 2
 
 	// Clean job stop: verify that checks were deregistered in Consul
-	nomadClient.Jobs().Deregister(jobId, false, nil) // nomad job stop
-	e2eutil.RequireConsulDeregistered(require, consulClient, "group-service-1")
-	e2eutil.RequireConsulDeregistered(require, consulClient, "group-service-2")
-	e2eutil.RequireConsulDeregistered(require, consulClient, "group-service-3")
+	_, _, err = nomadClient.Jobs().Deregister(jobId, false, nil) // nomad job stop
+	r.NoError(err)
+	e2eutil.RequireConsulDeregistered(r, consulClient, "group-service-1")
+	e2eutil.RequireConsulDeregistered(r, consulClient, "group-service-2")
+	e2eutil.RequireConsulDeregistered(r, consulClient, "group-service-3")
 
 	// Restore for next test
 	allocs = e2eutil.RegisterAndWaitForAllocs(f.T(),
 		nomadClient, "consul/input/checks_group.nomad", jobId, "")
-	require.Equal(2, len(allocs))
-	e2eutil.RequireConsulStatus(require, consulClient, "group-service-1", capi.HealthPassing)
-	e2eutil.RequireConsulStatus(require, consulClient, "group-service-2", capi.HealthWarning)
-	e2eutil.RequireConsulStatus(require, consulClient, "group-service-3", capi.HealthCritical)
+	r.Equal(2, len(allocs))
+	e2eutil.RequireConsulStatus(r, consulClient, "group-service-1", capi.HealthPassing)
+	e2eutil.RequireConsulStatus(r, consulClient, "group-service-2", capi.HealthWarning)
+	e2eutil.RequireConsulStatus(r, consulClient, "group-service-3", capi.HealthCritical)
 
 	// Crash a task: verify that checks become healthy again
 	_, _, err = exec(nomadClient, allocs, []string{"pkill", "sleep"})
 	if err != nil && err.Error() != "plugin is shut down" {
-		require.FailNow("unexpected error: %v", err)
+		r.FailNow("unexpected error: %v", err)
 	}
-	e2eutil.RequireConsulStatus(require, consulClient, "group-service-1", capi.HealthPassing)
-	e2eutil.RequireConsulStatus(require, consulClient, "group-service-2", capi.HealthWarning)
-	e2eutil.RequireConsulStatus(require, consulClient, "group-service-3", capi.HealthCritical)
+	e2eutil.RequireConsulStatus(r, consulClient, "group-service-1", capi.HealthPassing)
+	e2eutil.RequireConsulStatus(r, consulClient, "group-service-2", capi.HealthWarning)
+	e2eutil.RequireConsulStatus(r, consulClient, "group-service-3", capi.HealthCritical)
 
 	// TODO(tgross) ...
 	// Restart client: verify that checks are re-registered
@@ -99,78 +100,82 @@ func (tc *ScriptChecksE2ETest) TestGroupScriptCheck(f *framework.F) {
 // and associated script checks. It updates, stops, etc. the job to verify
 // that script checks are re-registered as expected.
 func (tc *ScriptChecksE2ETest) TestTaskScriptCheck(f *framework.F) {
+	r := require.New(f.T())
+
 	nomadClient := tc.Nomad()
-	uuid := uuid.Generate()
-	require := require.New(f.T())
 	consulClient := tc.Consul()
 
-	jobId := "checks_task" + uuid[0:8]
+	jobId := "checks_task" + uuid.Short()
 	tc.jobIds = append(tc.jobIds, jobId)
 
 	// Job run: verify that checks were registered in Consul
 	allocs := e2eutil.RegisterAndWaitForAllocs(f.T(),
 		nomadClient, "consul/input/checks_task.nomad", jobId, "")
-	require.Equal(1, len(allocs))
-	e2eutil.RequireConsulStatus(require, consulClient, "task-service-1", capi.HealthPassing)
-	e2eutil.RequireConsulStatus(require, consulClient, "task-service-2", capi.HealthWarning)
-	e2eutil.RequireConsulStatus(require, consulClient, "task-service-3", capi.HealthCritical)
+	r.Equal(1, len(allocs))
+	e2eutil.RequireConsulStatus(r, consulClient, "task-service-1", capi.HealthPassing)
+	e2eutil.RequireConsulStatus(r, consulClient, "task-service-2", capi.HealthWarning)
+	e2eutil.RequireConsulStatus(r, consulClient, "task-service-3", capi.HealthCritical)
 
 	// Check in warning state becomes healthy after check passes
 	_, _, err := exec(nomadClient, allocs,
 		[]string{"/bin/sh", "-c", "touch ${NOMAD_TASK_DIR}/alive-2b"})
-	require.NoError(err)
-	e2eutil.RequireConsulStatus(require, consulClient, "task-service-2", capi.HealthPassing)
+	r.NoError(err)
+	e2eutil.RequireConsulStatus(r, consulClient, "task-service-2", capi.HealthPassing)
 
 	// Job update: verify checks are re-registered in Consul
 	allocs = e2eutil.RegisterAndWaitForAllocs(f.T(),
 		nomadClient, "consul/input/checks_task_update.nomad", jobId, "")
-	require.Equal(1, len(allocs))
-	e2eutil.RequireConsulStatus(require, consulClient, "task-service-1", capi.HealthPassing)
-	e2eutil.RequireConsulStatus(require, consulClient, "task-service-2", capi.HealthPassing)
-	e2eutil.RequireConsulStatus(require, consulClient, "task-service-3", capi.HealthCritical)
+	r.Equal(1, len(allocs))
+	e2eutil.RequireConsulStatus(r, consulClient, "task-service-1", capi.HealthPassing)
+	e2eutil.RequireConsulStatus(r, consulClient, "task-service-2", capi.HealthPassing)
+	e2eutil.RequireConsulStatus(r, consulClient, "task-service-3", capi.HealthCritical)
 
 	// Verify we don't have any linger script checks running on the client
 	out, _, err := exec(nomadClient, allocs, []string{"pgrep", "sleep"})
-	require.NoError(err)
+	r.NoError(err)
 	running := strings.Split(strings.TrimSpace(out.String()), "\n")
-	require.LessOrEqual(len(running), 2) // task itself + 1 check == 2
+	r.LessOrEqual(len(running), 2) // task itself + 1 check == 2
 
 	// Clean job stop: verify that checks were deregistered in Consul
-	nomadClient.Jobs().Deregister(jobId, false, nil) // nomad job stop
-	e2eutil.RequireConsulDeregistered(require, consulClient, "task-service-1")
-	e2eutil.RequireConsulDeregistered(require, consulClient, "task-service-2")
-	e2eutil.RequireConsulDeregistered(require, consulClient, "task-service-3")
+	_, _, err = nomadClient.Jobs().Deregister(jobId, false, nil) // nomad job stop
+	r.NoError(err)
+	e2eutil.RequireConsulDeregistered(r, consulClient, "task-service-1")
+	e2eutil.RequireConsulDeregistered(r, consulClient, "task-service-2")
+	e2eutil.RequireConsulDeregistered(r, consulClient, "task-service-3")
 
 	// Restore for next test
 	allocs = e2eutil.RegisterAndWaitForAllocs(f.T(),
 		nomadClient, "consul/input/checks_task.nomad", jobId, "")
-	require.Equal(2, len(allocs))
-	e2eutil.RequireConsulStatus(require, consulClient, "task-service-1", capi.HealthPassing)
-	e2eutil.RequireConsulStatus(require, consulClient, "task-service-2", capi.HealthWarning)
-	e2eutil.RequireConsulStatus(require, consulClient, "task-service-3", capi.HealthCritical)
+	r.Equal(2, len(allocs))
+	e2eutil.RequireConsulStatus(r, consulClient, "task-service-1", capi.HealthPassing)
+	e2eutil.RequireConsulStatus(r, consulClient, "task-service-2", capi.HealthWarning)
+	e2eutil.RequireConsulStatus(r, consulClient, "task-service-3", capi.HealthCritical)
 
 	// Crash a task: verify that checks become healthy again
 	_, _, err = exec(nomadClient, allocs, []string{"pkill", "sleep"})
 	if err != nil && err.Error() != "plugin is shut down" {
-		require.FailNow("unexpected error: %v", err)
+		r.FailNow("unexpected error: %v", err)
 	}
-	e2eutil.RequireConsulStatus(require, consulClient, "task-service-1", capi.HealthPassing)
-	e2eutil.RequireConsulStatus(require, consulClient, "task-service-2", capi.HealthWarning)
-	e2eutil.RequireConsulStatus(require, consulClient, "task-service-3", capi.HealthCritical)
+	e2eutil.RequireConsulStatus(r, consulClient, "task-service-1", capi.HealthPassing)
+	e2eutil.RequireConsulStatus(r, consulClient, "task-service-2", capi.HealthWarning)
+	e2eutil.RequireConsulStatus(r, consulClient, "task-service-3", capi.HealthCritical)
 
 	// TODO(tgross) ...
 	// Restart client: verify that checks are re-registered
 }
 
 func (tc *ScriptChecksE2ETest) AfterEach(f *framework.F) {
+	r := require.New(f.T())
+
 	nomadClient := tc.Nomad()
 	jobs := nomadClient.Jobs()
 	// Stop all jobs in test
 	for _, id := range tc.jobIds {
-		jobs.Deregister(id, true, nil)
+		_, _, err := jobs.Deregister(id, true, nil)
+		r.NoError(err)
 	}
 	// Garbage collect
-	nomadClient.System().GarbageCollect()
+	r.NoError(nomadClient.System().GarbageCollect())
 }
 
 func exec(client *api.Client, allocs []*api.AllocationListStub, command []string) (bytes.Buffer, bytes.Buffer, error) {

--- a/e2e/e2eutil/consul.go
+++ b/e2e/e2eutil/consul.go
@@ -7,10 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// RequireConsulStatus asserts the aggregate health of the service converges to
-// the expected status
-func RequireConsulStatus(require *require.Assertions,
-	client *capi.Client, serviceName, expectedStatus string) {
+// RequireConsulStatus asserts the aggregate health of the service converges to the expected status.
+func RequireConsulStatus(require *require.Assertions, client *capi.Client, serviceName, expectedStatus string) {
 	require.Eventually(func() bool {
 		_, status := serviceStatus(require, client, serviceName)
 		return status == expectedStatus
@@ -20,10 +18,8 @@ func RequireConsulStatus(require *require.Assertions,
 	)
 }
 
-// serviceStatus gets the aggregate health of the service and returns
-// the []ServiceEntry for further checking
-func serviceStatus(require *require.Assertions,
-	client *capi.Client, serviceName string) ([]*capi.ServiceEntry, string) {
+// serviceStatus gets the aggregate health of the service and returns the []ServiceEntry for further checking.
+func serviceStatus(require *require.Assertions, client *capi.Client, serviceName string) ([]*capi.ServiceEntry, string) {
 	services, _, err := client.Health().Service(serviceName, "", false, nil)
 	require.NoError(err, "expected no error for %q, got %v", serviceName, err)
 	if len(services) > 0 {
@@ -32,12 +28,20 @@ func serviceStatus(require *require.Assertions,
 	return nil, "(unknown status)"
 }
 
-// RequireConsulDeregistered asserts that the service eventually is deregistered from Consul
-func RequireConsulDeregistered(require *require.Assertions,
-	client *capi.Client, serviceName string) {
+// RequireConsulDeregistered asserts that the service eventually is de-registered from Consul.
+func RequireConsulDeregistered(require *require.Assertions, client *capi.Client, service string) {
 	require.Eventually(func() bool {
-		services, _, err := client.Health().Service(serviceName, "", false, nil)
-		require.NoError(err, "expected no error for %q, got %v", serviceName, err)
+		services, _, err := client.Health().Service(service, "", false, nil)
+		require.NoError(err)
 		return len(services) == 0
+	}, 5*time.Second, time.Second)
+}
+
+// RequireConsulRegistered assert that the service is registered in Consul.
+func RequireConsulRegistered(require *require.Assertions, client *capi.Client, service string, count int) {
+	require.Eventually(func() bool {
+		services, _, err := client.Catalog().Service(service, "", nil)
+		require.NoError(err)
+		return len(services) == count
 	}, 5*time.Second, time.Second)
 }

--- a/helper/uuid/uuid.go
+++ b/helper/uuid/uuid.go
@@ -1,14 +1,14 @@
 package uuid
 
 import (
-	crand "crypto/rand"
+	"crypto/rand"
 	"fmt"
 )
 
-// Generate is used to generate a random UUID
+// Generate is used to generate a random UUID.
 func Generate() string {
 	buf := make([]byte, 16)
-	if _, err := crand.Read(buf); err != nil {
+	if _, err := rand.Read(buf); err != nil {
 		panic(fmt.Errorf("failed to read random bytes: %v", err))
 	}
 
@@ -18,4 +18,9 @@ func Generate() string {
 		buf[6:8],
 		buf[8:10],
 		buf[10:16])
+}
+
+// Short is used to generate the first 8 characters of a UUID.
+func Short() string {
+	return Generate()[0:8]
 }


### PR DESCRIPTION
Previously, Nomad would optimize out the services task runner
hook for tasks which were initially submitted with no services
defined. This causes a problem when the job is later updated to
include service(s) on that task, which will result in nothing
happening because the hook is not present to handle the service
registration in the .Update.

Instead, always enable the services hook. The group services
alloc runner hook is already always enabled.

Fixes #9707
