### PR TITLE
Allow setting of headers in api client

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -615,6 +615,8 @@ func (r *request) toHTTP() (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header = r.header
+
 	// Optionally configure HTTP basic authentication
 	if r.url.User != nil {
 		username := r.url.User.Username()
@@ -624,7 +626,6 @@ func (r *request) toHTTP() (*http.Request, error) {
 		req.SetBasicAuth(r.config.HttpAuth.Username, r.config.HttpAuth.Password)
 	}
 
-	req.Header = r.header
 	req.Header.Add("Accept-Encoding", "gzip")
 	if r.token != "" {
 		req.Header.Set("X-Nomad-Token", r.token)

--- a/api/api.go
+++ b/api/api.go
@@ -156,7 +156,7 @@ type Config struct {
 	// TLSConfig is ignored if HttpClient is set.
 	TLSConfig *TLSConfig
 
-	Header http.Header
+	Headers http.Header
 }
 
 // ClientConfig copies the configuration with a new client address, region, and
@@ -677,8 +677,8 @@ func (c *Client) newRequest(method, path string) (*request, error) {
 		}
 	}
 
-	if c.config.Header != nil {
-		r.header = c.config.Header
+	if c.config.Headers != nil {
+		r.header = c.config.Headers
 	}
 
 	return r, nil

--- a/api/api.go
+++ b/api/api.go
@@ -677,7 +677,9 @@ func (c *Client) newRequest(method, path string) (*request, error) {
 		}
 	}
 
-	r.header = c.config.Header
+	if c.config.Header != nil {
+		r.header = c.config.Header
+	}
 
 	return r, nil
 }

--- a/api/api.go
+++ b/api/api.go
@@ -156,7 +156,7 @@ type Config struct {
 	// TLSConfig is ignored if HttpClient is set.
 	TLSConfig *TLSConfig
 
-	Headers http.Header
+	Header http.Header
 }
 
 // ClientConfig copies the configuration with a new client address, region, and
@@ -676,7 +676,7 @@ func (c *Client) newRequest(method, path string) (*request, error) {
 		}
 	}
 
-	r.header = c.config.Headers
+	r.header = c.config.Header
 
 	return r, nil
 }

--- a/api/api.go
+++ b/api/api.go
@@ -156,7 +156,7 @@ type Config struct {
 	// TLSConfig is ignored if HttpClient is set.
 	TLSConfig *TLSConfig
 
-	Headers map[string]string
+	Headers http.Header
 }
 
 // ClientConfig copies the configuration with a new client address, region, and
@@ -676,9 +676,7 @@ func (c *Client) newRequest(method, path string) (*request, error) {
 		}
 	}
 
-	for key, value := range c.config.Headers {
-		r.header.Set(key, value)
-	}
+	r.header = c.config.Headers
 
 	return r, nil
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -344,7 +344,7 @@ func TestParseWriteMeta(t *testing.T) {
 func TestClientHeader(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t, func(c *Config) {
-		c.Headers = http.Header{
+		c.Header = http.Header{
 			"Hello": []string{"World"},
 		}
 	}, nil)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -344,8 +344,8 @@ func TestParseWriteMeta(t *testing.T) {
 func TestClientHeader(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t, func(c *Config) {
-		c.Headers = map[string]string{
-			"Hello": "World",
+		c.Headers = http.Header{
+			"Hello": []string{"World"},
 		}
 	}, nil)
 	defer s.Stop()

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -344,7 +344,7 @@ func TestParseWriteMeta(t *testing.T) {
 func TestClientHeader(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t, func(c *Config) {
-		c.Header = http.Header{
+		c.Headers = http.Header{
 			"Hello": []string{"World"},
 		}
 	}, nil)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -341,6 +341,22 @@ func TestParseWriteMeta(t *testing.T) {
 	}
 }
 
+func TestClientHeader(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t, func(c *Config) {
+		c.Headers = map[string]string{
+			"Hello": "World",
+		}
+	}, nil)
+	defer s.Stop()
+
+	r, _ := c.newRequest("GET", "/v1/jobs")
+
+	if r.header.Get("Hello") != "World" {
+		t.Fatalf("bad: %v", r.header)
+	}
+}
+
 func TestQueryString(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t, nil, nil)

--- a/vendor/github.com/hashicorp/nomad/api/api.go
+++ b/vendor/github.com/hashicorp/nomad/api/api.go
@@ -156,7 +156,7 @@ type Config struct {
 	// TLSConfig is ignored if HttpClient is set.
 	TLSConfig *TLSConfig
 
-	Header http.Header
+	Headers http.Header
 }
 
 // ClientConfig copies the configuration with a new client address, region, and
@@ -677,8 +677,8 @@ func (c *Client) newRequest(method, path string) (*request, error) {
 		}
 	}
 
-	if c.config.Header != nil {
-		r.header = c.config.Header
+	if c.config.Headers != nil {
+		r.header = c.config.Headers
 	}
 
 	return r, nil

--- a/vendor/github.com/hashicorp/nomad/api/api.go
+++ b/vendor/github.com/hashicorp/nomad/api/api.go
@@ -155,6 +155,8 @@ type Config struct {
 	//
 	// TLSConfig is ignored if HttpClient is set.
 	TLSConfig *TLSConfig
+
+	Header http.Header
 }
 
 // ClientConfig copies the configuration with a new client address, region, and
@@ -527,6 +529,7 @@ type request struct {
 	body   io.Reader
 	obj    interface{}
 	ctx    context.Context
+	header http.Header
 }
 
 // setQueryOptions is used to annotate the request with
@@ -612,6 +615,8 @@ func (r *request) toHTTP() (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header = r.header
+
 	// Optionally configure HTTP basic authentication
 	if r.url.User != nil {
 		username := r.url.User.Username()
@@ -649,6 +654,7 @@ func (c *Client) newRequest(method, path string) (*request, error) {
 			Path:    u.Path,
 			RawPath: u.RawPath,
 		},
+		header: make(http.Header),
 		params: make(map[string][]string),
 	}
 	if c.config.Region != "" {
@@ -669,6 +675,10 @@ func (c *Client) newRequest(method, path string) (*request, error) {
 		for _, value := range values {
 			r.params.Add(key, value)
 		}
+	}
+
+	if c.config.Header != nil {
+		r.header = c.config.Header
 	}
 
 	return r, nil


### PR DESCRIPTION
👋 I've got Nomad behind a proxy that requires setting headers to authentication.

This allows you to configure the client with headers that will be passed on every request. 