### PR TITLE
docs: note that 1.0.2 is unreleased

### DIFF
--- a/website/pages/docs/upgrade/upgrade-specific.mdx
+++ b/website/pages/docs/upgrade/upgrade-specific.mdx
@@ -14,7 +14,7 @@ upgrade. However, specific versions of Nomad may have more details provided for
 their upgrades as a result of new features or changed behavior. This page is
 used to document those details separately from the standard upgrade flow.
 
-## Nomad 1.0.2
+## Nomad 1.0.2 (Unreleased)
 
 #### Dynamic secrets trigger template changes on client restart
 


### PR DESCRIPTION
We accidently deployed 1.0.2 upgrade notes before 1.0.2 is released. Obviously we don't want to confuse people about what the latest version of Nomad is, but I feel like pre-publishing upgrade notes might be useful for users to be aware of chanes ahead of time (similar to the `Unreleased` section of the changelog). So instead of removing the unreleased 1.0.2 notes, I marked them the same as the changelog.

Not a big deal, so if there are any concerns I'm more than happy to just remove the unreleased version's notes from the website until release day.