### PR TITLE
Docs cleanup

### DIFF
--- a/website/pages/api-docs/jobs.mdx
+++ b/website/pages/api-docs/jobs.mdx
@@ -115,15 +115,12 @@ The table below shows this endpoint's support for
 - `JobModifyIndex` `(int: 0)` - Specifies the `JobModifyIndex` to enforce the
   current job is at.
 
+- `PolicyOverride` `(bool: false)` - If set, any soft mandatory Sentinel
+  policies will be overridden. This allows a job to be registered when it would
+  be denied by policy.
+
 - `PreserveCounts` `(bool: false)` - If set, existing task group counts are
   preserved, over those specified in the new job spec.
-
-- `PolicyOverride` `(bool: false)` - If set, any soft mandatory Sentinel policies
-  will be overridden. This allows a job to be registered when it would be denied
-  by policy.
-
-- `PreserveCounts` `(bool: false)` - If set, the existing task group counts will
-  be preserved when updating a job.
 
 ### Sample Payload
 

--- a/website/pages/docs/configuration/client.mdx
+++ b/website/pages/docs/configuration/client.mdx
@@ -21,15 +21,6 @@ client {
 }
 ```
 
-## Plugin Options
-
-Nomad 0.9 now supports pluggable drivers. Operators should use the new
-[plugin][plugin-stanza] syntax to modify driver configuration. To find the
-plugin options supported by each individual Nomad driver, please see the
-[drivers documentation](/docs/drivers). The pre-0.9 `client.options`
-stanza will be supported in 0.9 for backward compatibility (except for the `lxc`
-driver) but will be removed in a future release.
-
 ## `client` Parameters
 
 - `alloc_dir` `(string: "[data_dir]/alloc")` - Specifies the directory to use
@@ -188,8 +179,8 @@ the full list.
 
 ### `options` Parameters
 
-~> Note: client configuration options for drivers will soon be deprecated. See
-the [plugin stanza][plugin-stanza] documentation for more information.
+~> Note: In Nomad 0.9 client configuration options for drivers were deprecated.
+   See the [plugin stanza][plugin-stanza] documentation for more information.
 
 The following is not an exhaustive list of options for only the Nomad
 client. To find the options supported by each individual Nomad driver, please

--- a/website/pages/docs/operations/nomad-agent.mdx
+++ b/website/pages/docs/operations/nomad-agent.mdx
@@ -142,6 +142,8 @@ Nomad servers should be run with the lowest possible permissions. They need
 access to their own data directory and the ability to bind to their ports. You
 should create a `nomad` user with the minimal set of required privileges.
 
-Nomad clients must be run as `root` due to the OS isolation mechanisms that
-require root privileges. The Nomad client's data directory should be owned by
-`root` with filesystem permissions set to `0700`.
+Nomad clients should be run as `root` due to the OS isolation mechanisms that
+require root privileges. While it is possible to run Nomad as an unprivileged
+user, careful testing must be done to ensure the task drivers and features
+you use function as expected. The Nomad client's data directory should be
+owned by `root` with filesystem permissions set to `0700`.


### PR DESCRIPTION
Each commit has a small docs change:

- remove duplicate PreserveCounts entry
- remove old client.options migration note
  - There's no reason to give the `client.options` to `plugins` migration top billing on the client configuration page. Remove and and clarify the more appropriately placed note down below.
- mention client can be non-root; I want to strike a balance here:
  - On the one hand there are use cases (raw_exec or Docker only) where running Nomad clients as an unprivileged user is *preferable.*
  - On the other hand running Nomad clients as root is our main and best tested environment. So I want to leave that a strong recommendation.