### PR TITLE
UI: Guard against nodes running an old version of the Nomad agent

### DIFF
--- a/ui/app/controllers/topology.js
+++ b/ui/app/controllers/topology.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import { computed, action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 import classic from 'ember-classic-decorator';
 import { reduceToLargestUnit } from 'nomad-ui/helpers/format-bytes';
 
@@ -12,6 +13,8 @@ export default class TopologyControllers extends Controller {
   @service userSettings;
 
   @alias('userSettings.showTopoVizPollingNotice') showPollingNotice;
+
+  @tracked filteredNodes = null;
 
   @computed('model.nodes.@each.datacenter')
   get datacenters() {
@@ -116,5 +119,13 @@ export default class TopologyControllers extends Controller {
   @action
   setNode(node) {
     this.set('activeNode', node);
+  }
+
+  @action
+  handleTopoVizDataError(errors) {
+    const filteredNodesError = errors.findBy('type', 'filtered-nodes');
+    if (filteredNodesError) {
+      this.filteredNodes = filteredNodesError.context;
+    }
   }
 }

--- a/ui/app/templates/topology.hbs
+++ b/ui/app/templates/topology.hbs
@@ -4,6 +4,19 @@
     {{#if this.isForbidden}}
       <ForbiddenMessage />
     {{else}}
+      {{#if this.filteredNodes}}
+        <div class="notification is-warning">
+          <div data-test-filtered-nodes-warning class="columns">
+            <div class="column">
+              <h3 data-test-title class="title is-4">Some Clients Were Filtered</h3>
+              <p data-test-message>{{this.filteredNodes.length}} {{if (eq this.filteredNodes.length 1) "client was" "clients were"}} filtered from the topology visualization. This is most likely due to the {{pluralize "client" this.filteredNodes.length}} running a version of Nomad &lt;0.9.0.</p>
+            </div>
+            <div class="column is-centered is-minimum">
+              <button data-test-dismiss class="button is-warning" onclick={{action (mut this.filteredNodes) null}} type="button">Okay</button>
+            </div>
+          </div>
+        </div>
+      {{/if}}
       <div class="columns">
         <div class="column is-narrow is-400">
           {{#if this.showPollingNotice}}
@@ -217,7 +230,8 @@
             @nodes={{this.model.nodes}}
             @allocations={{this.model.allocations}}
             @onAllocationSelect={{action this.setAllocation}}
-            @onNodeSelect={{action this.setNode}} />
+            @onNodeSelect={{action this.setNode}}
+            @onDataError={{action this.handleTopoVizDataError}}/>
         </div>
       </div>
     {{/if}}

--- a/ui/tests/acceptance/topology-test.js
+++ b/ui/tests/acceptance/topology-test.js
@@ -29,6 +29,7 @@ module('Acceptance | topology', function(hooks) {
 
     await Topology.visit();
     assert.equal(Topology.infoPanelTitle, 'Cluster Details');
+    assert.notOk(Topology.filteredNodesWarning.isPresent);
   });
 
   test('all allocations for all namespaces and all clients are queried on load', async function(assert) {
@@ -73,5 +74,16 @@ module('Acceptance | topology', function(hooks) {
 
     await Topology.viz.datacenters[0].nodes[0].selectNode();
     assert.equal(Topology.infoPanelTitle, 'Client Details');
+  });
+
+  test('when one or more nodes lack the NodeResources property, a warning message is shown', async function(assert) {
+    server.createList('node', 3);
+    server.createList('allocation', 5);
+
+    server.schema.nodes.all().models[0].update({ nodeResources: null });
+
+    await Topology.visit();
+    assert.ok(Topology.filteredNodesWarning.isPresent);
+    assert.ok(Topology.filteredNodesWarning.message.startsWith('1'));
   });
 });

--- a/ui/tests/pages/topology.js
+++ b/ui/tests/pages/topology.js
@@ -1,11 +1,13 @@
 import { create, text, visitable } from 'ember-cli-page-object';
 
 import TopoViz from 'nomad-ui/tests/pages/components/topo-viz';
+import notification from 'nomad-ui/tests/pages/components/notification';
 
 export default create({
   visit: visitable('/topology'),
 
   infoPanelTitle: text('[data-test-info-panel-title]'),
+  filteredNodesWarning: notification('[data-test-filtered-nodes-warning]'),
 
   viz: TopoViz('[data-test-topo-viz]'),
 });


### PR DESCRIPTION
Fixes #9702 

If a cluster has nodes running a version of Nomad <0.9.0, they won't have the requisite `NodeResources` property. Instead of blowing up, now the UI will filter those nodes out of the viz and report the situation to the user.

<img width="1527" alt="Screen Shot 2021-01-05 at 4 17 05 PM" src="https://user-images.githubusercontent.com/174740/103717201-bd453a80-4f79-11eb-91b5-4a2d0053e3aa.png">
