### PR TITLE
Persisted shared ports during inplace update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
  * client: Fixed a bug where clients configured with `cpu_total_compute` did not update the `cpu.totalcompute` node attribute. [[GH-9532](https://github.com/hashicorp/nomad/issues/9532)]
+ * core: Fixed a bug where an in place update dropped an allocations shared allocated resources [[GH-9736](https://github.com/hashicorp/nomad/issues/9736)]
  * consul: Fixed a bug where updating a task to include services would not work [[GH-9707](https://github.com/hashicorp/nomad/issues/9707)]
  * consul: Fixed alloc address mode port advertisement to use the mapped `to` port value [[GH-9730](https://github.com/hashicorp/nomad/issues/9730)]
  * consul/connect: Fixed a bug where absent ingress envoy proxy configuration could panic client [[GH-9669](https://github.com/hashicorp/nomad/issues/9669)]

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -728,7 +728,9 @@ func inplaceUpdate(ctx Context, eval *structs.Evaluation, job *structs.Job,
 			Tasks:          option.TaskResources,
 			TaskLifecycles: option.TaskLifecycles,
 			Shared: structs.AllocatedSharedResources{
-				DiskMB: int64(update.TaskGroup.EphemeralDisk.SizeMB),
+				DiskMB:   int64(update.TaskGroup.EphemeralDisk.SizeMB),
+				Ports:    update.Alloc.AllocatedResources.Shared.Ports,
+				Networks: update.Alloc.AllocatedResources.Shared.Networks.Copy(),
 			},
 		}
 		newAlloc.Metrics = ctx.Metrics()


### PR DESCRIPTION
Ensure that allocation AllocatedResources Shared Ports are not dropped during inplace updates.

When performing in place updates, the scheduler creates a shallow copy of the allocation and updates a few fields. It's not immediately clear to me why we do a shallow copy instead of something like `allocation.Copy()`. The AllocatedSharedResources Ports were not copied over causing issues after the plan was applied.

As a side effect, removing or updating a task group service stanza, resulting in an inplace update would error and prevent a service from being registered or deregistered during an inplace update.  This issue was reported in  https://github.com/hashicorp/nomad/issues/9360 

This error was displayed in the logs like so:
```
    2021-01-06T12:49:47.127-0500 [ERROR] client.alloc_runner: error running update hooks: alloc_id=13ff640d-7426-4763-1be1-427a3594dec3 error="1 error occurred:
        * update hook "group_services" failed: error getting address for check "service: \"example-service\" check": invalid port "api": port label not found
"
```

fixes #9360
fixes #9735