### PR TITLE
consul: Refactor parts of UpdateWorkload

### DIFF
--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -1028,17 +1028,14 @@ func (c *ServiceClient) UpdateWorkload(old, newWorkload *WorkloadServices) error
 	regs := new(ServiceRegistrations)
 	regs.Services = make(map[string]*ServiceRegistration, len(newWorkload.Services))
 
-	existingIDs := make(map[string]*structs.Service, len(old.Services))
-	for _, s := range old.Services {
-		existingIDs[MakeAllocServiceID(old.AllocID, old.Name(), s)] = s
-	}
 	newIDs := make(map[string]*structs.Service, len(newWorkload.Services))
 	for _, s := range newWorkload.Services {
 		newIDs[MakeAllocServiceID(newWorkload.AllocID, newWorkload.Name(), s)] = s
 	}
 
-	// Loop over existing Service IDs to see if they have been removed
-	for existingID, existingSvc := range existingIDs {
+	// Loop over existing Services to see if they have been removed
+	for _, existingSvc := range old.Services {
+		existingID := MakeAllocServiceID(old.AllocID, old.Name(), existingSvc)
 		newSvc, ok := newIDs[existingID]
 
 		if !ok {

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -917,8 +917,8 @@ func (c *ServiceClient) serviceRegs(ops *operations, service *structs.Service, w
 	if err != nil {
 		return nil, err
 	}
-	for id, registration := range checkRegs {
-		sreg.checkIDs[id] = struct{}{}
+	for _, registration := range checkRegs {
+		sreg.checkIDs[registration.ID] = struct{}{}
 		ops.regChecks = append(ops.regChecks, registration)
 	}
 
@@ -927,9 +927,9 @@ func (c *ServiceClient) serviceRegs(ops *operations, service *structs.Service, w
 
 // checkRegs creates check registrations for the given service
 func (c *ServiceClient) checkRegs(serviceID string, service *structs.Service,
-	workload *WorkloadServices) (map[string]*api.AgentCheckRegistration, error) {
+	workload *WorkloadServices) ([]*api.AgentCheckRegistration, error) {
 
-	registrations := make(map[string]*api.AgentCheckRegistration, len(service.Checks))
+	registrations := make([]*api.AgentCheckRegistration, 0, len(service.Checks))
 	for _, check := range service.Checks {
 		ip := ""
 		port := 0
@@ -959,7 +959,7 @@ func (c *ServiceClient) checkRegs(serviceID string, service *structs.Service,
 			return nil, fmt.Errorf("failed to add check %q: %v", check.Name, err)
 		}
 
-		registrations[checkID] = registration
+		registrations = append(registrations, registration)
 	}
 
 	return registrations, nil
@@ -1079,8 +1079,8 @@ func (c *ServiceClient) UpdateWorkload(old, newWorkload *WorkloadServices) error
 				return err
 			}
 
-			for id, registration := range checkRegs {
-				sreg.checkIDs[id] = struct{}{}
+			for _, registration := range checkRegs {
+				sreg.checkIDs[registration.ID] = struct{}{}
 				ops.regChecks = append(ops.regChecks, registration)
 			}
 

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -931,8 +931,8 @@ func (c *ServiceClient) checkRegs(serviceID string, service *structs.Service,
 
 	registrations := make([]*api.AgentCheckRegistration, 0, len(service.Checks))
 	for _, check := range service.Checks {
-		ip := ""
-		port := 0
+		var ip string
+		var port int
 
 		if check.Type != structs.ServiceCheckScript {
 			portLabel := check.PortLabel

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -928,13 +928,7 @@ func (c *ServiceClient) serviceRegs(ops *operations, service *structs.Service, w
 func (c *ServiceClient) checkRegs(ops *operations, serviceID string, service *structs.Service,
 	workload *WorkloadServices) ([]string, error) {
 
-	// Fast path
-	numChecks := len(service.Checks)
-	if numChecks == 0 {
-		return nil, nil
-	}
-
-	checkIDs := make([]string, 0, numChecks)
+	checkIDs := make([]string, 0, len(service.Checks))
 	for _, check := range service.Checks {
 		checkID := MakeCheckID(serviceID, check)
 		checkIDs = append(checkIDs, checkID)

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -1127,8 +1127,7 @@ func (c *ServiceClient) UpdateWorkload(old, newWorkload *WorkloadServices) error
 
 	// Start watching checks. Done after service registrations are built
 	// since an error building them could leak watches.
-	for _, service := range newIDs {
-		serviceID := MakeAllocServiceID(newWorkload.AllocID, newWorkload.Name(), service)
+	for serviceID, service := range newIDs {
 		for _, check := range service.Checks {
 			if check.TriggersRestarts() {
 				checkID := MakeCheckID(serviceID, check)


### PR DESCRIPTION
While reading this code during debugging I felt there was room for improvement.

This removes modification of `ops` in methods that `UpdateWorkload` calls, keeping them local to `UpdateWorkload`. It also includes some rewrites of `checkRegs` for clarity.

I find things like this in particular make reasoning about the code easier:

```diff
- checkIDs, err := c.checkRegs(ops, id, service, workload)
+ checkRegs, err := c.checkRegs(id, service, workload)
```

`c.checkRegs` just returns `checkRegs` rather than `checkIDs`.