### PR TITLE
docs: clarify default behavior of docker userns_mode

### DIFF
--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -283,8 +283,9 @@ config {
   to be configured to allow privileged containers.
 
 - `userns_mode` - (Optional) `host` or not set (default). Set to `host` to use
-  the host's user namespace when user namespace remapping is enabled on the
-  docker daemon.
+  the host's user namespace (effectively disabling user namespacing) when user
+  namespace remapping is enabled on the docker daemon. This field has no
+  effect if the docker daemon does not have user namespace remapping enabled.
 
 - `volumes` - (Optional) A list of `host_path:container_path` strings to bind
   host paths to container paths. Mounting host paths outside of the [allocation


### PR DESCRIPTION
Following a conversation with @louievandyke I realized the documentation for `userns_mode` is somewhat unclear. The Docker [documentation](https://docs.docker.com/engine/security/userns-remap/#disable-namespace-remapping-for-a-container) refers to "disabling user namespaces". Although this isn't strictly accurate as the host namespace still exists, adding it to the our docs can help make the translation between our driver and Docker's behavior more clear.