### PR TITLE
in Job.Scale, ensure that new count is within [min,max] configured in  scaling policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ BUG FIXES:
  * consul/connect: Fixed a bug where in-place upgrade of Nomad client running Connect enabled jobs would panic [[GH-9738](https://github.com/hashicorp/nomad/issues/9738)]
  * template: Fixed multiple issues in template src/dest and artifact dest interpolation [[GH-9671](https://github.com/hashicorp/nomad/issues/9671)]
  * template: Fixed a bug where dynamic secrets did not trigger the template `change_mode` after a client restart. [[GH-9636](https://github.com/hashicorp/nomad/issues/9636)]
+ * scaling: Fixed a bug where job scaling endpoint did not enforce scaling policy min/max [[GH-9761](https://github.com/hashicorp/nomad/issues/9761)]
  * server: Fixed a bug where new servers may bootstrap prematurely when configured with `bootstrap_expect = 0`.
 
 ## 1.0.1 (December 16, 2020)

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -53,7 +53,7 @@ func testJobWithScalingPolicy() *Job {
 	job.TaskGroups[0].Scaling = &ScalingPolicy{
 		Policy:  map[string]interface{}{},
 		Min:     int64ToPtr(1),
-		Max:     int64ToPtr(1),
+		Max:     int64ToPtr(5),
 		Enabled: boolToPtr(true),
 	}
 	return job

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1043,11 +1043,11 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 		if found.Scaling != nil {
 			if *args.Count < found.Scaling.Min {
 				return structs.NewErrRPCCoded(400,
-					fmt.Sprintf("new scaling count cannot be less than the scaling policy minimum"))
+					"new scaling count cannot be less than the scaling policy minimum")
 			}
 			if found.Scaling.Max < *args.Count {
 				return structs.NewErrRPCCoded(400,
-					fmt.Sprintf("new scaling count cannot be greater than the scaling policy maximum"))
+					"new scaling count cannot be greater than the scaling policy maximum")
 			}
 		}
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1039,6 +1039,18 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	prevCount := found.Count
 	if args.Count != nil {
 
+		// if there is a scaling policy, check that the new count is within bounds
+		if found.Scaling != nil {
+			if *args.Count < found.Scaling.Min {
+				return structs.NewErrRPCCoded(400,
+					fmt.Sprintf("new scaling count cannot be less than the scaling policy minimum"))
+			}
+			if found.Scaling.Max < *args.Count {
+				return structs.NewErrRPCCoded(400,
+					fmt.Sprintf("new scaling count cannot be greater than the scaling policy maximum"))
+			}
+		}
+
 		// Lookup the latest deployment, to see whether this scaling event should be blocked
 		d, err := snap.LatestDeploymentByJobID(ws, namespace, args.JobID)
 		if err != nil {

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1043,11 +1043,13 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 		if found.Scaling != nil {
 			if *args.Count < found.Scaling.Min {
 				return structs.NewErrRPCCoded(400,
-					"new scaling count cannot be less than the scaling policy minimum")
+					fmt.Sprintf("group count was less than scaling policy minimum: %d < %d",
+						*args.Count, found.Scaling.Min))
 			}
 			if found.Scaling.Max < *args.Count {
 				return structs.NewErrRPCCoded(400,
-					"new scaling count cannot be greater than the scaling policy maximum")
+					fmt.Sprintf("group count was greater than scaling policy maximum: %d > %d",
+						*args.Count, found.Scaling.Max))
 			}
 		}
 

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -6731,7 +6731,7 @@ func TestJobEndpoint_Scale_OutOfBounds(t *testing.T) {
 			structs.ScalingTargetGroup: job.TaskGroups[0].Name,
 		},
 		Count:          helper.Int64ToPtr(pol.Max + 1),
-		Message:        "too high",
+		Message:        "out of bounds",
 		PolicyOverride: false,
 		WriteRequest: structs.WriteRequest{
 			Region:    "global",
@@ -6740,13 +6740,12 @@ func TestJobEndpoint_Scale_OutOfBounds(t *testing.T) {
 	}
 	err = msgpackrpc.CallWithCodec(codec, "Job.Scale", scale, &resp)
 	require.Error(err)
-	require.Contains(err.Error(), "cannot be greater than")
+	require.Contains(err.Error(), "group count was greater than scaling policy maximum: 11 > 10")
 
-	scale.Count = helper.Int64ToPtr(pol.Min - 1)
-	scale.Message = "too low"
+	scale.Count = helper.Int64ToPtr(2)
 	err = msgpackrpc.CallWithCodec(codec, "Job.Scale", scale, &resp)
 	require.Error(err)
-	require.Contains(err.Error(), "cannot be less than")
+	require.Contains(err.Error(), "group count was less than scaling policy minimum: 2 < 3")
 }
 
 func TestJobEndpoint_Scale_NoEval(t *testing.T) {


### PR DESCRIPTION
the `Job.Scale` endpoint did not enforce min/max from the group scaling policy. this PR addresses that with a simple check. unit tested the RPC; I had to make a small tweak to one of the `api` scaling tests because it was previously (incorrectly) scaling outside of bounds.

resolves #9758