### PR TITLE
e2e: remove deprecated terraform syntax

### DIFF
--- a/e2e/terraform/.terraform.lock.hcl
+++ b/e2e/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "3.22.0"
   hashes = [
     "h1:8aWXjFcmEi64P0TMHOCQXWws+/SmvJQrNvHlzdktKOM=",
+    "h1:f/Tz8zv1Zb78ZaiyJkQ0MGIViZwbYrLuQk3kojPM91c=",
     "zh:4a9a66caf1964cdd3b61fb3ebb0da417195a5529cb8e496f266b0778335d11c8",
     "zh:514f2f006ae68db715d86781673faf9483292deab235c7402ff306e0e92ea11a",
     "zh:5277b61109fddb9011728f6650ef01a639a0590aeffe34ed7de7ba10d0c31803",
@@ -22,6 +23,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version = "2.0.0"
   hashes = [
     "h1:EC6eh7avwx1rF56h3RZcxgEp/14ihi7Sk/4J3Hn4nIE=",
+    "h1:pO1ANXtOCRfecKsY9Hn4UsXoPBLv6LFiDIEiS1MZ09E=",
     "zh:34ce8b79493ace8333d094752b579ccc907fa9392a2c1d6933a6c95d0786d3f1",
     "zh:5c5a19c4f614a4ffb68bae0b0563f3860115cf7539b8adc21108324cfdc10092",
     "zh:67ddb1ca2cd3e1a8f948302597ceb967f19d2eeb2d125303493667388fe6330e",
@@ -38,6 +40,7 @@ provider "registry.terraform.io/hashicorp/local" {
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.0.0"
   hashes = [
+    "h1:V1tzrSG6t3e7zWvUwRbGbhsWU2Jd/anrJpOl9XM+R/8=",
     "h1:ysHGBhBNkIiJLEpthB/IVCLpA1Qoncp3KbCTFGFZTO0=",
     "zh:05fb7eab469324c97e9b73a61d2ece6f91de4e9b493e573bfeda0f2077bc3a4c",
     "zh:1688aa91885a395c4ae67636d411475d0b831e422e005dcf02eedacaafac3bb4",
@@ -56,6 +59,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version = "3.0.0"
   hashes = [
     "h1:grDzxfnOdFXi90FRIIwP/ZrCzirJ/SfsGBe6cE0Shg4=",
+    "h1:yhHJpb4IfQQfuio7qjUXuUFTU/s+ensuEpm23A+VWz0=",
     "zh:0fcb00ff8b87dcac1b0ee10831e47e0203a6c46aafd76cb140ba2bab81f02c6b",
     "zh:123c984c0e04bad910c421028d18aa2ca4af25a153264aef747521f4e7c36a17",
     "zh:287443bc6fd7fa9a4341dec235589293cbcc6e467a042ae225fd5d161e4e68dc",
@@ -72,6 +76,7 @@ provider "registry.terraform.io/hashicorp/random" {
 provider "registry.terraform.io/hashicorp/template" {
   version = "2.2.0"
   hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
     "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
     "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
     "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
@@ -89,6 +94,7 @@ provider "registry.terraform.io/hashicorp/template" {
 provider "registry.terraform.io/hashicorp/tls" {
   version = "3.0.0"
   hashes = [
+    "h1:AcQGOAD5xa4KE9gYw5g7R6UU8a77Yn/afPvch4N86lQ=",
     "h1:LtCEW5v1E5Eo49+kQOsKHRYf9Hc8ZR0jTpK+mXszPHs=",
     "zh:05eac573a1fe53227bcc6b01daf6ddf0b73456f97f56f316f1b3114a4771e175",
     "zh:09390dad764c76f0fd59cae4dad296e3e39487e06de3a4bc0df73916c6bb2f17",

--- a/e2e/terraform/nomad.tf
+++ b/e2e/terraform/nomad.tf
@@ -25,7 +25,7 @@ module "nomad_server" {
   connection = {
     type        = "ssh"
     user        = "ubuntu"
-    host        = "${aws_instance.server[count.index].public_ip}"
+    host        = aws_instance.server[count.index].public_ip
     port        = 22
     private_key = "${path.root}/keys/${local.random_name}.pem"
   }
@@ -60,7 +60,7 @@ module "nomad_client_ubuntu_bionic_amd64" {
   connection = {
     type        = "ssh"
     user        = "ubuntu"
-    host        = "${aws_instance.client_ubuntu_bionic_amd64[count.index].public_ip}"
+    host        = aws_instance.client_ubuntu_bionic_amd64[count.index].public_ip
     port        = 22
     private_key = "${path.root}/keys/${local.random_name}.pem"
   }
@@ -96,7 +96,7 @@ module "nomad_client_windows_2016_amd64" {
   connection = {
     type        = "ssh"
     user        = "Administrator"
-    host        = "${aws_instance.client_windows_2016_amd64[count.index].public_ip}"
+    host        = aws_instance.client_windows_2016_amd64[count.index].public_ip
     port        = 22
     private_key = "${path.root}/keys/${local.random_name}.pem"
   }

--- a/e2e/terraform/provision-nomad/main.tf
+++ b/e2e/terraform/provision-nomad/main.tf
@@ -109,7 +109,7 @@ resource "null_resource" "upload_custom_configs" {
 
   count = var.profile == "custom" ? 1 : 0
   triggers = {
-    hashes = "${join(",", [for file in local.custom_config_files : filemd5("${local.custom_path}/${file}")])}"
+    hashes = join(",", [for file in local.custom_config_files : filemd5("${local.custom_path}/${file}")])
   }
 
   connection {

--- a/e2e/terraform/terraform.tfvars
+++ b/e2e/terraform/terraform.tfvars
@@ -9,9 +9,9 @@ nomad_enterprise                 = false
 vault                            = true
 volumes                          = false
 
-nomad_version      = "1.0.1"  # default version for deployment
-nomad_sha          = ""       # overrides nomad_version if set
-nomad_local_binary = ""       # overrides nomad_sha and nomad_version if set
+nomad_version      = "1.0.1" # default version for deployment
+nomad_sha          = ""      # overrides nomad_version if set
+nomad_local_binary = ""      # overrides nomad_sha and nomad_version if set
 
 # Example overrides:
 # nomad_sha = "38e23b62a7700c96f4898be777543869499fea0a"


### PR DESCRIPTION
Also bumps patch versions of some TF modules

Ran into this while testing TF0.15, where these warnings will become errors.