### PR TITLE
cni: bump CNI plugins version to v0.9.0

### DIFF
--- a/e2e/terraform/packer/ubuntu-bionic-amd64/setup.sh
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/setup.sh
@@ -108,7 +108,7 @@ sudo apt-get install -y openjdk-8-jdk
 echo "Installing CNI plugins"
 sudo mkdir -p /opt/cni/bin
 wget -q -O - \
-     https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz \
+     https://github.com/containernetworking/plugins/releases/download/v0.9.0/cni-plugins-linux-amd64-v0.9.0.tgz \
     | sudo tar -C /opt/cni/bin -xz
 
 echo "Installing Podman"

--- a/website/content/docs/drivers/external/containerd.mdx
+++ b/website/content/docs/drivers/external/containerd.mdx
@@ -253,7 +253,7 @@ before you can use `bridge` networks.
 **Instructions for installing CNI plugins.**
 
 ```hcl
- $ curl -L -o cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz
+ $ curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/releases/download/v0.9.0/cni-plugins-linux-$( [ $(uname -m) = aarch64 ] && echo arm64 || echo amd64)"-v0.9.0.tgz
  $ sudo mkdir -p /opt/cni/bin
  $ sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
 ```

--- a/website/content/docs/integrations/consul-connect.mdx
+++ b/website/content/docs/integrations/consul-connect.mdx
@@ -116,7 +116,7 @@ must have CNI plugins installed.
 The following commands install CNI plugins:
 
 ```shell-session
-$ curl -L -o cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz
+$ curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/releases/download/v0.9.0/cni-plugins-linux-$( [ $(uname -m) = aarch64 ] && echo arm64 || echo amd64)"-v0.9.0.tgz
 $ sudo mkdir -p /opt/cni/bin
 $ sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
 ```


### PR DESCRIPTION
https://github.com/containernetworking/plugins/releases/tag/v0.9.0

Also make the copy-paste install instructions work with arm64 for a better OOTB experience (AWS Graviton, Pi 4's). (Is there a better way to do this? I like the architecture tabs Docker uses at the bottom of https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository but that seems hard). 