### PR TITLE
prevent double job status update

### DIFF
--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1345,9 +1345,8 @@ func apiConnectGatewayProxyToStructs(in *api.ConsulGatewayProxy) *structs.Consul
 		return nil
 	}
 
-	var bindAddresses map[string]*structs.ConsulGatewayBindAddress
+	bindAddresses := make(map[string]*structs.ConsulGatewayBindAddress)
 	if in.EnvoyGatewayBindAddresses != nil {
-		bindAddresses = make(map[string]*structs.ConsulGatewayBindAddress)
 		for k, v := range in.EnvoyGatewayBindAddresses {
 			bindAddresses[k] = &structs.ConsulGatewayBindAddress{
 				Address: v.Address,

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/hashicorp/nomad/e2e/nodedrain"
 	_ "github.com/hashicorp/nomad/e2e/nomad09upgrade"
 	_ "github.com/hashicorp/nomad/e2e/nomadexec"
+	_ "github.com/hashicorp/nomad/e2e/periodic"
 	_ "github.com/hashicorp/nomad/e2e/podman"
 	_ "github.com/hashicorp/nomad/e2e/quotas"
 	_ "github.com/hashicorp/nomad/e2e/rescheduling"

--- a/e2e/periodic/input/simple.nomad
+++ b/e2e/periodic/input/simple.nomad
@@ -1,0 +1,21 @@
+job "test" {
+  datacenters = ["dc1"]
+  type        = "batch"
+
+  periodic {
+    cron             = "* * * * *"
+    prohibit_overlap = true
+  }
+
+  group "group" {
+    task "task" {
+      driver = "docker"
+
+      config {
+        image   = "alpine:latest"
+        command = "ls"
+      }
+    }
+  }
+}
+

--- a/e2e/periodic/input/simple.nomad
+++ b/e2e/periodic/input/simple.nomad
@@ -1,6 +1,12 @@
-job "test" {
+job "periodic" {
   datacenters = ["dc1"]
   type        = "batch"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
 
   periodic {
     cron             = "* * * * *"
@@ -12,8 +18,9 @@ job "test" {
       driver = "docker"
 
       config {
-        image   = "alpine:latest"
-        command = "ls"
+        image   = "busybox:1"
+        command = "/bin/sh"
+        args    = ["-c", "sleep 5"]
       }
     }
   }

--- a/e2e/periodic/periodic.go
+++ b/e2e/periodic/periodic.go
@@ -1,0 +1,52 @@
+package periodic
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/nomad/e2e/e2eutil"
+	"github.com/hashicorp/nomad/e2e/framework"
+	"github.com/hashicorp/nomad/helper/uuid"
+)
+
+type PeriodicTest struct {
+	framework.TC
+	jobIDs []string
+}
+
+func init() {
+	framework.AddSuites(&framework.TestSuite{
+		Component:   "Periodic",
+		CanRunLocal: true,
+		Cases: []framework.TestCase{
+			new(PeriodicTest),
+		},
+	})
+}
+
+func (tc *PeriodicTest) BeforeAll(f *framework.F) {
+	e2eutil.WaitForLeader(f.T(), tc.Nomad())
+}
+
+func (tc *PeriodicTest) AfterEach(f *framework.F) {
+	nomadClient := tc.Nomad()
+	j := nomadClient.Jobs()
+
+	for _, id := range tc.jobIDs {
+		j.Deregister(id, true, nil)
+	}
+	_, err := e2eutil.Command("nomad", "system", "gc")
+	f.NoError(err)
+}
+
+func (tc *PeriodicTest) TestPeriodicDispatch_Basic(f *framework.F) {
+	t := f.T()
+
+	nomadClient := tc.Nomad()
+
+	uuid := uuid.Generate()
+	jobID := fmt.Sprintf("deployment-%s", uuid[0:8])
+	tc.jobIDs = append(tc.jobIDs, jobID)
+
+	// register job
+	e2eutil.RegisterAndWaitForAllocs(t, nomadClient, "periodic/input/simple.nomad", jobID, "")
+}

--- a/e2e/terraform/Makefile
+++ b/e2e/terraform/Makefile
@@ -1,6 +1,9 @@
 NOMAD_SHA ?= $(shell git rev-parse HEAD)
 PKG_PATH = $(shell pwd)/../../pkg/linux_amd64/nomad
 
+# The version of nomad that gets deployed depends on an order of precedence
+# linked below
+# https://github.com/hashicorp/nomad/blob/master/e2e/terraform/README.md#nomad-version
 dev-cluster:
 	terraform apply -auto-approve \
 		-var="nomad_sha=$(NOMAD_SHA)"

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -3439,9 +3439,7 @@ func TestFSM_EventBroker_JobRegisterFSMEvents(t *testing.T) {
 		Eval: eval,
 	}
 	buf, err := structs.Encode(structs.JobRegisterRequestType, req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 
 	resp := fsm.Apply(makeLog(buf))
 	require.Nil(t, resp)
@@ -3479,5 +3477,5 @@ func TestFSM_EventBroker_JobRegisterFSMEvents(t *testing.T) {
 	}
 
 	require.Len(t, events, 1)
-	require.Equal(t, events[0].Type, structs.TypeJobRegistered)
+	require.Equal(t, structs.TypeJobRegistered, events[0].Type)
 }

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -2,6 +2,7 @@ package nomad
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -3421,4 +3422,62 @@ func TestFSM_ACLEvents(t *testing.T) {
 			tc.eventfn(t, events)
 		})
 	}
+}
+
+// TestFSM_EventBroker_JobRegisterFSMEvents asserts that only a single job
+// register event is emitted when registering a job
+func TestFSM_EventBroker_JobRegisterFSMEvents(t *testing.T) {
+	t.Parallel()
+	fsm := testFSM(t)
+
+	job := mock.Job()
+	eval := mock.Eval()
+	eval.JobID = job.ID
+
+	req := structs.JobRegisterRequest{
+		Job:  job,
+		Eval: eval,
+	}
+	buf, err := structs.Encode(structs.JobRegisterRequestType, req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	resp := fsm.Apply(makeLog(buf))
+	require.Nil(t, resp)
+
+	broker, err := fsm.State().EventBroker()
+	require.NoError(t, err)
+
+	subReq := &stream.SubscribeRequest{
+		Topics: map[structs.Topic][]string{
+			structs.TopicJob: {"*"},
+		},
+	}
+
+	sub, err := broker.Subscribe(subReq)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(500*time.Millisecond))
+	defer cancel()
+
+	// consume the queue
+	var events []structs.Event
+	for {
+		out, err := sub.Next(ctx)
+		if len(out.Events) == 0 {
+			break
+		}
+
+		// consume the queue until the deadline has exceeded or until we've
+		// received more events than  expected
+		if err == context.DeadlineExceeded || len(events) > 1 {
+			break
+		}
+
+		events = append(events, out.Events...)
+	}
+
+	require.Len(t, events, 1)
+	require.Equal(t, events[0].Type, structs.TypeJobRegistered)
 }

--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -345,7 +345,7 @@ func gatewayProxyForBridge(gateway *structs.ConsulGateway) *structs.ConsulGatewa
 
 func gatewayBindAddresses(ingress *structs.ConsulIngressConfigEntry) map[string]*structs.ConsulGatewayBindAddress {
 	if ingress == nil || len(ingress.Listeners) == 0 {
-		return nil
+		return make(map[string]*structs.ConsulGatewayBindAddress)
 	}
 
 	addresses := make(map[string]*structs.ConsulGatewayBindAddress)

--- a/nomad/job_endpoint_hook_connect_test.go
+++ b/nomad/job_endpoint_hook_connect_test.go
@@ -412,12 +412,12 @@ func TestJobEndpointConnect_gatewayProxyIsDefault(t *testing.T) {
 func TestJobEndpointConnect_gatewayBindAddresses(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		result := gatewayBindAddresses(nil)
-		require.Nil(t, result)
+		require.Empty(t, result)
 	})
 
 	t.Run("no listeners", func(t *testing.T) {
 		result := gatewayBindAddresses(&structs.ConsulIngressConfigEntry{Listeners: nil})
-		require.Nil(t, result)
+		require.Empty(t, result)
 	})
 
 	t.Run("simple", func(t *testing.T) {

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -875,7 +875,8 @@ func ConnectIngressGatewayJob(mode string, inject bool) *structs.Job {
 		Connect: &structs.ConsulConnect{
 			Gateway: &structs.ConsulGateway{
 				Proxy: &structs.ConsulGatewayProxy{
-					ConnectTimeout: helper.TimeToPtr(3 * time.Second),
+					ConnectTimeout:            helper.TimeToPtr(3 * time.Second),
+					EnvoyGatewayBindAddresses: make(map[string]*structs.ConsulGatewayBindAddress),
 				},
 				Ingress: &structs.ConsulIngressConfigEntry{
 					Listeners: []*structs.ConsulIngressListener{{

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4427,9 +4427,6 @@ func (s *StateStore) setJobStatus(index uint64, txn *txn,
 
 	// Capture the current status so we can check if there is a change
 	oldStatus := job.Status
-	if index == job.CreateIndex {
-		oldStatus = ""
-	}
 	newStatus := forceStatus
 
 	// If forceStatus is not set, compute the jobs status.

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4412,6 +4412,7 @@ func (s *StateStore) setJobStatuses(index uint64, txn *txn,
 		if err := s.setJobStatus(index, txn, existing.(*structs.Job), evalDelete, forceStatus); err != nil {
 			return err
 		}
+
 	}
 
 	return nil
@@ -4427,6 +4428,7 @@ func (s *StateStore) setJobStatus(index uint64, txn *txn,
 
 	// Capture the current status so we can check if there is a change
 	oldStatus := job.Status
+	firstPass := index == job.CreateIndex
 	newStatus := forceStatus
 
 	// If forceStatus is not set, compute the jobs status.
@@ -4440,8 +4442,25 @@ func (s *StateStore) setJobStatus(index uint64, txn *txn,
 
 	// Fast-path if nothing has changed.
 	if oldStatus == newStatus {
+		updated := job.Copy()
+		updated.ModifyIndex = index
+		if err := txn.Insert("jobs", updated); err != nil {
+			return fmt.Errorf("job insert failed: %v", err)
+		}
+		if err := txn.Insert("index", &IndexEntry{"jobs", index}); err != nil {
+			return fmt.Errorf("index update failed: %v", err)
+		}
+		if err := s.setJobSummary(txn, job, index, oldStatus, newStatus, firstPass); err != nil {
+			return err
+		}
+		// initialize job summary
+		// initialize / update job summary
 		return nil
 	}
+
+	// TODO (drew)
+	// not inserting the job again with modify index/status
+	// prevents job stability test pass
 
 	// Copy and update the existing job
 	updated := job.Copy()
@@ -4457,64 +4476,72 @@ func (s *StateStore) setJobStatus(index uint64, txn *txn,
 	}
 
 	// Update the children summary
-	if updated.ParentID != "" {
-		// Try to update the summary of the parent job summary
-		summaryRaw, err := txn.First("job_summary", "id", updated.Namespace, updated.ParentID)
-		if err != nil {
-			return fmt.Errorf("unable to retrieve summary for parent job: %v", err)
-		}
+	if err := s.setJobSummary(txn, updated, index, oldStatus, newStatus, firstPass); err != nil {
+		return fmt.Errorf("job summary update failed %w", err)
+	}
+	return nil
+}
 
-		// Only continue if the summary exists. It could not exist if the parent
-		// job was removed
-		if summaryRaw != nil {
-			existing := summaryRaw.(*structs.JobSummary)
-			pSummary := existing.Copy()
-			if pSummary.Children == nil {
-				pSummary.Children = new(structs.JobChildrenSummary)
-			}
-
-			// Determine the transition and update the correct fields
-			children := pSummary.Children
-
-			// Decrement old status
-			if oldStatus != "" {
-				switch oldStatus {
-				case structs.JobStatusPending:
-					children.Pending--
-				case structs.JobStatusRunning:
-					children.Running--
-				case structs.JobStatusDead:
-					children.Dead--
-				default:
-					return fmt.Errorf("unknown old job status %q", oldStatus)
-				}
-			}
-
-			// Increment new status
-			switch newStatus {
-			case structs.JobStatusPending:
-				children.Pending++
-			case structs.JobStatusRunning:
-				children.Running++
-			case structs.JobStatusDead:
-				children.Dead++
-			default:
-				return fmt.Errorf("unknown new job status %q", newStatus)
-			}
-
-			// Update the index
-			pSummary.ModifyIndex = index
-
-			// Insert the summary
-			if err := txn.Insert("job_summary", pSummary); err != nil {
-				return fmt.Errorf("job summary insert failed: %v", err)
-			}
-			if err := txn.Insert("index", &IndexEntry{"job_summary", index}); err != nil {
-				return fmt.Errorf("index update failed: %v", err)
-			}
-		}
+func (s *StateStore) setJobSummary(txn *txn, updated *structs.Job, index uint64, oldStatus, newStatus string, firstPass bool) error {
+	if updated.ParentID == "" {
+		return nil
 	}
 
+	// Try to update the summary of the parent job summary
+	summaryRaw, err := txn.First("job_summary", "id", updated.Namespace, updated.ParentID)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve summary for parent job: %v", err)
+	}
+
+	// Only continue if the summary exists. It could not exist if the parent
+	// job was removed
+	if summaryRaw != nil {
+		existing := summaryRaw.(*structs.JobSummary)
+		pSummary := existing.Copy()
+		if pSummary.Children == nil {
+			pSummary.Children = new(structs.JobChildrenSummary)
+		}
+
+		// Determine the transition and update the correct fields
+		children := pSummary.Children
+
+		// Decrement old status
+		if !firstPass {
+			switch oldStatus {
+			case structs.JobStatusPending:
+				children.Pending--
+			case structs.JobStatusRunning:
+				children.Running--
+			case structs.JobStatusDead:
+				children.Dead--
+			default:
+				return fmt.Errorf("unknown old job status %q", oldStatus)
+			}
+		}
+
+		// Increment new status
+		switch newStatus {
+		case structs.JobStatusPending:
+			children.Pending++
+		case structs.JobStatusRunning:
+			children.Running++
+		case structs.JobStatusDead:
+			children.Dead++
+		default:
+			return fmt.Errorf("unknown new job status %q", newStatus)
+		}
+
+		// Update the index
+		pSummary.ModifyIndex = index
+
+		// Insert the summary
+		if err := txn.Insert("job_summary", pSummary); err != nil {
+			return fmt.Errorf("job summary insert failed: %v", err)
+		}
+		if err := txn.Insert("index", &IndexEntry{"job_summary", index}); err != nil {
+			return fmt.Errorf("index update failed: %v", err)
+		}
+	}
 	return nil
 }
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4440,27 +4440,14 @@ func (s *StateStore) setJobStatus(index uint64, txn *txn,
 		}
 	}
 
-	// Fast-path if nothing has changed.
+	// Fast-path if the job has changed.
+	// Still update the job summary if necessary.
 	if oldStatus == newStatus {
-		updated := job.Copy()
-		updated.ModifyIndex = index
-		if err := txn.Insert("jobs", updated); err != nil {
-			return fmt.Errorf("job insert failed: %v", err)
-		}
-		if err := txn.Insert("index", &IndexEntry{"jobs", index}); err != nil {
-			return fmt.Errorf("index update failed: %v", err)
-		}
 		if err := s.setJobSummary(txn, job, index, oldStatus, newStatus, firstPass); err != nil {
 			return err
 		}
-		// initialize job summary
-		// initialize / update job summary
 		return nil
 	}
-
-	// TODO (drew)
-	// not inserting the job again with modify index/status
-	// prevents job stability test pass
 
 	// Copy and update the existing job
 	updated := job.Copy()

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -6855,16 +6855,10 @@ func TestStateStore_UpdateJobStability(t *testing.T) {
 
 	// Check that the job was updated properly
 	ws := memdb.NewWatchSet()
-	jout, _ := state.JobByIDAndVersion(ws, job.Namespace, job.ID, 0)
-	if err != nil {
-		t.Fatalf("bad: %v", err)
-	}
-	if jout == nil {
-		t.Fatalf("bad: %#v", jout)
-	}
-	if !jout.Stable {
-		t.Fatalf("job not marked stable %#v", jout)
-	}
+	jout, err := state.JobByIDAndVersion(ws, job.Namespace, job.ID, 0)
+	require.NoError(t, err)
+	require.NotNil(t, jout)
+	require.True(t, jout.Stable, "job not marked as stable")
 
 	// Update the stability to false
 	err = state.UpdateJobStability(3, job.Namespace, job.ID, 0, false)
@@ -6873,16 +6867,10 @@ func TestStateStore_UpdateJobStability(t *testing.T) {
 	}
 
 	// Check that the job was updated properly
-	jout, _ = state.JobByIDAndVersion(ws, job.Namespace, job.ID, 0)
-	if err != nil {
-		t.Fatalf("bad: %v", err)
-	}
-	if jout == nil {
-		t.Fatalf("bad: %#v", jout)
-	}
-	if jout.Stable {
-		t.Fatalf("job marked stable %#v", jout)
-	}
+	jout, err = state.JobByIDAndVersion(ws, job.Namespace, job.ID, 0)
+	require.NoError(t, err)
+	require.NotNil(t, jout)
+	require.False(t, jout.Stable)
 }
 
 // Test that nonexistent deployment can't be promoted

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -6839,19 +6839,13 @@ func TestStateStore_UpdateJobStability(t *testing.T) {
 
 	// Insert a job twice to get two versions
 	job := mock.Job()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, job); err != nil {
-		t.Fatalf("bad: %v", err)
-	}
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1, job))
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 2, job); err != nil {
-		t.Fatalf("bad: %v", err)
-	}
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 2, job.Copy()))
 
 	// Update the stability to true
 	err := state.UpdateJobStability(3, job.Namespace, job.ID, 0, true)
-	if err != nil {
-		t.Fatalf("bad: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Check that the job was updated properly
 	ws := memdb.NewWatchSet()

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -1352,12 +1352,9 @@ func (p *ConsulGatewayProxy) Copy() *ConsulGatewayProxy {
 		return nil
 	}
 
-	var bindAddresses map[string]*ConsulGatewayBindAddress
-	if p.EnvoyGatewayBindAddresses != nil {
-		bindAddresses = make(map[string]*ConsulGatewayBindAddress, len(p.EnvoyGatewayBindAddresses))
-		for k, v := range p.EnvoyGatewayBindAddresses {
-			bindAddresses[k] = v.Copy()
-		}
+	bindAddresses := make(map[string]*ConsulGatewayBindAddress, len(p.EnvoyGatewayBindAddresses))
+	for k, v := range p.EnvoyGatewayBindAddresses {
+		bindAddresses[k] = v.Copy()
 	}
 
 	return &ConsulGatewayProxy{

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -1352,9 +1352,12 @@ func (p *ConsulGatewayProxy) Copy() *ConsulGatewayProxy {
 		return nil
 	}
 
-	bindAddresses := make(map[string]*ConsulGatewayBindAddress, len(p.EnvoyGatewayBindAddresses))
-	for k, v := range p.EnvoyGatewayBindAddresses {
-		bindAddresses[k] = v.Copy()
+	var bindAddresses map[string]*ConsulGatewayBindAddress
+	if p.EnvoyGatewayBindAddresses != nil {
+		bindAddresses = make(map[string]*ConsulGatewayBindAddress, len(p.EnvoyGatewayBindAddresses))
+		for k, v := range p.EnvoyGatewayBindAddresses {
+			bindAddresses[k] = v.Copy()
+		}
 	}
 
 	return &ConsulGatewayProxy{

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -299,7 +299,7 @@ func TestConsulConnect_GatewayProxy_CopyEquals(t *testing.T) {
 	c := &ConsulGatewayProxy{
 		ConnectTimeout:                  helper.TimeToPtr(1 * time.Second),
 		EnvoyGatewayBindTaggedAddresses: false,
-		EnvoyGatewayBindAddresses:       nil,
+		EnvoyGatewayBindAddresses:       make(map[string]*ConsulGatewayBindAddress),
 	}
 
 	require.NoError(t, c.Validate())

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -293,6 +293,23 @@ func TestConsulConnect_CopyEquals(t *testing.T) {
 	require.False(t, c.Equals(o))
 }
 
+func TestConsulConnect_GatewayProxy_CopyEquals(t *testing.T) {
+	t.Parallel()
+
+	c := &ConsulGatewayProxy{
+		ConnectTimeout:                  helper.TimeToPtr(1 * time.Second),
+		EnvoyGatewayBindTaggedAddresses: false,
+		EnvoyGatewayBindAddresses:       nil,
+	}
+
+	require.NoError(t, c.Validate())
+
+	// Copies should be equivalent
+	o := c.Copy()
+	require.Equal(t, c, o)
+	require.True(t, c.Equals(o))
+}
+
 func TestSidecarTask_MergeIntoTask(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
#8435 introduced atomic eval insertion when registering/de-registering jobs.

This change removes a now obsolete guard which checked if the index was 
equal to the job.CreateIndex, which would empty the status. 

Now that the job regisration eval insertion is atomic with the registration 
this check is no longer necessary to set the job statuses correctly

fixes https://github.com/hashicorp/nomad/issues/8692