### PR TITLE
Refactor Job.Scale()

### DIFF
--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1128,9 +1128,6 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 
 		reply.EvalID = eval.ID
 		reply.EvalCreateIndex = evalIndex
-	} else {
-		reply.EvalID = ""
-		reply.EvalCreateIndex = 0
 	}
 
 	event := &structs.ScalingEventRequest{

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -967,7 +967,7 @@ func (j *Job) BatchDeregister(args *structs.JobBatchDeregisterRequest, reply *st
 
 // Scale is used to modify one of the scaling targets in the job
 func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterResponse) error {
-	if done, err := j.srv.forward("Job.Scale", args, args, reply); done {
+	if forwarded, err := j.srv.forward("Job.Scale", args, args, reply); forwarded {
 		return err
 	}
 	defer metrics.MeasureSince([]string{"nomad", "job", "scale"}, time.Now())

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1077,9 +1077,6 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 			return structs.NewErrRPCCoded(400, JobScalingBlockedByActiveDeployment)
 		}
 
-		// update the task group count
-		group.Count = int(*args.Count)
-
 		_, jobModifyIndex, err := j.srv.raftApply(
 			structs.JobRegisterRequestType,
 			structs.JobRegisterRequest{

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1014,7 +1014,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	groupName := args.Target[structs.ScalingTargetGroup]
 	var group *structs.TaskGroup
 	for _, tg := range job.TaskGroups {
-		if groupName == tg.Name {
+		if tg.Name == groupName {
 			group = tg
 			break
 		}

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -967,8 +967,7 @@ func (j *Job) BatchDeregister(args *structs.JobBatchDeregisterRequest, reply *st
 
 // Scale is used to modify one of the scaling targets in the job
 func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterResponse) error {
-	// Return early if request is successfully forwarded
-	if forwarded, err := j.srv.forward("Job.Scale", args, args, reply); forwarded {
+	if done, err := j.srv.forward("Job.Scale", args, args, reply); done {
 		return err
 	}
 	defer metrics.MeasureSince([]string{"nomad", "job", "scale"}, time.Now())

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1027,6 +1027,8 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 			fmt.Sprintf("task group %q specified for scaling does not exist in job", groupName))
 	}
 
+	prevCount := int64(group.Count)
+
 	// Handle non- count-based scaling event
 	if args.Count == nil {
 		_, eventIndex, err := j.srv.raftApply(
@@ -1037,7 +1039,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 				TaskGroup: groupName,
 				ScalingEvent: &structs.ScalingEvent{
 					Time:          time.Now().UnixNano(),
-					PreviousCount: int64(group.Count),
+					PreviousCount: prevCount,
 					Message:       args.Message,
 					Error:         args.Error,
 					Meta:          args.Meta,
@@ -1072,7 +1074,6 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	}
 
 	now := time.Now().UnixNano()
-	prevCount := int64(group.Count)
 
 	// Block scaling event if there's an active deployment
 	deployment, err := snap.LatestDeploymentByJobID(ws, namespace, args.JobID)

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1070,14 +1070,17 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	now := time.Now().UnixNano()
 	prevCount := int64(group.Count)
 
-	// Look up the latest deployment, to see whether this scaling event should be blocked
+	// Look up the latest deployment, to see whether this scaling event should be
+	// blocked
 	deployment, err := snap.LatestDeploymentByJobID(ws, namespace, args.JobID)
 	if err != nil {
 		j.logger.Error("unable to lookup latest deployment", "error", err)
 		return err
 	}
-	// explicitly filter deployment by JobCreateIndex to be safe, because LatestDeploymentByJobID doesn't
-	if deployment != nil && deployment.JobCreateIndex == job.CreateIndex && deployment.Active() {
+
+	// Explicitly filter deployment by JobCreateIndex to be safe, because
+	// LatestDeploymentByJobID doesn't
+	if deployment != nil && deployment.Active() && deployment.JobCreateIndex == job.CreateIndex {
 		// attempt to register the scaling event
 		JobScalingBlockedByActiveDeployment := "job scaling blocked due to active deployment"
 		event := &structs.ScalingEventRequest{

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1082,7 +1082,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	// LatestDeploymentByJobID doesn't
 	if deployment != nil && deployment.Active() && deployment.JobCreateIndex == job.CreateIndex {
 		// attempt to register the scaling event
-		JobScalingBlockedByActiveDeployment := "job scaling blocked due to active deployment"
+		msg := "job scaling blocked due to active deployment"
 		event := &structs.ScalingEventRequest{
 			Namespace: job.Namespace,
 			JobID:     job.ID,
@@ -1090,7 +1090,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 			ScalingEvent: &structs.ScalingEvent{
 				Time:          now,
 				PreviousCount: prevCount,
-				Message:       JobScalingBlockedByActiveDeployment,
+				Message:       msg,
 				Error:         true,
 				Meta: map[string]interface{}{
 					"OriginalMessage": args.Message,
@@ -1103,7 +1103,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 			// just log the error, this was a best-effort attempt
 			j.logger.Error("scaling event create failed during block scaling action", "error", err)
 		}
-		return structs.NewErrRPCCoded(400, JobScalingBlockedByActiveDeployment)
+		return structs.NewErrRPCCoded(400, msg)
 	}
 
 	// Commit the job update via Raft, for now we'll do this even if count didn't

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -999,12 +999,14 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	if err != nil {
 		return err
 	}
+
 	ws := memdb.NewWatchSet()
 	job, err := snap.JobByID(ws, namespace, args.JobID)
 	if err != nil {
 		j.logger.Error("unable to lookup job", "error", err)
 		return err
 	}
+
 	if job == nil {
 		return structs.NewErrRPCCoded(404, fmt.Sprintf("job %q not found", args.JobID))
 	}
@@ -1017,6 +1019,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 			break
 		}
 	}
+
 	if group == nil {
 		return structs.NewErrRPCCoded(400,
 			fmt.Sprintf("task group %q specified for scaling does not exist in job", groupName))

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1109,6 +1109,9 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 		return structs.NewErrRPCCoded(400, msg)
 	}
 
+	// Update the job's TaskGroup count
+	group.Count = int(*args.Count)
+
 	// Commit the job update
 	_, jobModifyIndex, err := j.srv.raftApply(
 		structs.JobRegisterRequestType,

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1101,7 +1101,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 
 	// Only create an eval for non-dispatch jobs and if the count was provided
 	// for now, we'll do this even if count didn't change
-	if !job.IsPeriodic() && !job.IsParameterized() && args.Count != nil {
+	if !(job.IsPeriodic() || job.IsParameterized()) && args.Count != nil {
 		eval := &structs.Evaluation{
 			ID:             uuid.Generate(),
 			Namespace:      namespace,

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1128,13 +1128,15 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 			CreateTime:     now,
 			ModifyTime:     now,
 		}
-		update := &structs.EvalUpdateRequest{
-			Evals:        []*structs.Evaluation{eval},
-			WriteRequest: structs.WriteRequest{Region: args.Region},
-		}
 
 		// Commit this evaluation via Raft
-		_, evalIndex, err := j.srv.raftApply(structs.EvalUpdateRequestType, update)
+		_, evalIndex, err := j.srv.raftApply(
+			structs.EvalUpdateRequestType,
+			&structs.EvalUpdateRequest{
+				Evals:        []*structs.Evaluation{eval},
+				WriteRequest: structs.WriteRequest{Region: args.Region},
+			},
+		)
 		if err != nil {
 			j.logger.Error("eval create failed", "error", err, "method", "scale")
 			return err

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1154,7 +1154,9 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	}
 
 	reply.Index = eventIndex
+
 	j.srv.setQueryMeta(&reply.QueryMeta)
+
 	return nil
 }
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1044,7 +1044,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	// for now, we'll do this even if count didn't change
 	prevCount := group.Count
 	if args.Count != nil {
-		// Lookup the latest deployment, to see whether this scaling event should be blocked
+		// Look up the latest deployment, to see whether this scaling event should be blocked
 		d, err := snap.LatestDeploymentByJobID(ws, namespace, args.JobID)
 		if err != nil {
 			j.logger.Error("unable to lookup latest deployment", "error", err)

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1071,13 +1071,13 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	prevCount := int64(group.Count)
 
 	// Look up the latest deployment, to see whether this scaling event should be blocked
-	d, err := snap.LatestDeploymentByJobID(ws, namespace, args.JobID)
+	deployment, err := snap.LatestDeploymentByJobID(ws, namespace, args.JobID)
 	if err != nil {
 		j.logger.Error("unable to lookup latest deployment", "error", err)
 		return err
 	}
 	// explicitly filter deployment by JobCreateIndex to be safe, because LatestDeploymentByJobID doesn't
-	if d != nil && d.JobCreateIndex == job.CreateIndex && d.Active() {
+	if deployment != nil && deployment.JobCreateIndex == job.CreateIndex && deployment.Active() {
 		// attempt to register the scaling event
 		JobScalingBlockedByActiveDeployment := "job scaling blocked due to active deployment"
 		event := &structs.ScalingEventRequest{

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1080,14 +1080,16 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 		// update the task group count
 		group.Count = int(*args.Count)
 
-		registerReq := structs.JobRegisterRequest{
-			Job:            job,
-			EnforceIndex:   true,
-			JobModifyIndex: job.ModifyIndex,
-			PolicyOverride: args.PolicyOverride,
-			WriteRequest:   args.WriteRequest,
-		}
-		_, jobModifyIndex, err := j.srv.raftApply(structs.JobRegisterRequestType, registerReq)
+		_, jobModifyIndex, err := j.srv.raftApply(
+			structs.JobRegisterRequestType,
+			structs.JobRegisterRequest{
+				Job:            job,
+				EnforceIndex:   true,
+				JobModifyIndex: job.ModifyIndex,
+				PolicyOverride: args.PolicyOverride,
+				WriteRequest:   args.WriteRequest,
+			},
+		)
 		if err != nil {
 			j.logger.Error("job register for scale failed", "error", err)
 			return err

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -994,7 +994,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 		return err
 	}
 
-	// Lookup the job
+	// Look up the job
 	snap, err := j.srv.fsm.State().Snapshot()
 	if err != nil {
 		return err

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1077,13 +1077,8 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 			return structs.NewErrRPCCoded(400, JobScalingBlockedByActiveDeployment)
 		}
 
-		truncCount := int(*args.Count)
-		if int64(truncCount) != *args.Count {
-			return structs.NewErrRPCCoded(400,
-				fmt.Sprintf("new scaling count is too large for TaskGroup.Count (int): %v", args.Count))
-		}
 		// update the task group count
-		group.Count = truncCount
+		group.Count = int(*args.Count)
 
 		registerReq := structs.JobRegisterRequest{
 			Job:            job,

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1073,6 +1073,9 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 		}
 	}
 
+	// Update group count
+	group.Count = int(*args.Count)
+
 	now := time.Now().UnixNano()
 
 	// Block scaling event if there's an active deployment
@@ -1109,9 +1112,6 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 		}
 		return structs.NewErrRPCCoded(400, msg)
 	}
-
-	// Update the job's TaskGroup count
-	group.Count = int(*args.Count)
 
 	// Commit the job update
 	_, jobModifyIndex, err := j.srv.raftApply(

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -736,8 +736,16 @@ func (r *JobScaleRequest) Validate() error {
 		return NewErrRPCCoded(400, "scaling action should not contain count if error is true")
 	}
 
-	if r.Count != nil && *r.Count < 0 {
-		return NewErrRPCCoded(400, "scaling action count can't be negative")
+	if r.Count != nil {
+		if *r.Count < 0 {
+			return NewErrRPCCoded(400, "scaling action count can't be negative")
+		}
+
+		truncCount := int(*r.Count)
+		if int64(truncCount) != *r.Count {
+			return NewErrRPCCoded(400,
+				fmt.Sprintf("new scaling count is too large for TaskGroup.Count (int): %v", r.Count))
+		}
 	}
 
 	return nil

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -732,13 +732,13 @@ func (r *JobScaleRequest) Validate() error {
 		return NewErrRPCCoded(400, "missing task group name for scaling action")
 	}
 
-	if r.Error && r.Count != nil {
-		return NewErrRPCCoded(400, "scaling action should not contain count if error is true")
-	}
-
 	if r.Count != nil {
 		if *r.Count < 0 {
 			return NewErrRPCCoded(400, "scaling action count can't be negative")
+		}
+
+		if r.Error {
+			return NewErrRPCCoded(400, "scaling action should not contain count if error is true")
 		}
 
 		truncCount := int(*r.Count)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -715,6 +715,34 @@ type JobScaleRequest struct {
 	WriteRequest
 }
 
+// Validate is used to validate the arguments in the request
+func (r *JobScaleRequest) Validate() error {
+	namespace := r.Target[ScalingTargetNamespace]
+	if namespace != "" && namespace != r.RequestNamespace() {
+		return NewErrRPCCoded(400, "namespace in payload did not match header")
+	}
+
+	jobID := r.Target[ScalingTargetJob]
+	if jobID != "" && jobID != r.JobID {
+		return fmt.Errorf("job ID in payload did not match URL")
+	}
+
+	groupName := r.Target[ScalingTargetGroup]
+	if groupName == "" {
+		return NewErrRPCCoded(400, "missing task group name for scaling action")
+	}
+
+	if r.Error && r.Count != nil {
+		return NewErrRPCCoded(400, "scaling action should not contain count if error is true")
+	}
+
+	if r.Count != nil && *r.Count < 0 {
+		return NewErrRPCCoded(400, "scaling action count can't be negative")
+	}
+
+	return nil
+}
+
 // JobSummaryRequest is used when we just need to get a specific job summary
 type JobSummaryRequest struct {
 	JobID string


### PR DESCRIPTION
I was perusing the git log history and found a recently-modified func could be cleaned up a bit.

The main things here are creating a JobScaleRequest.Validate() to handle some simple validation stuff, and special-casing the nil JobScaleRequest.Count scenario to remove a bunch of `if args.Count != nil` below, which also removes some nested conditionals.