### PR TITLE
executor_linux: Remove unreachable PATH= code

### DIFF
--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -833,13 +833,7 @@ func lookupTaskBin(command *ExecCommand) (string, error) {
 		return "", fmt.Errorf("file %s not found under path %s", bin, taskDir)
 	}
 
-	// Find the PATH
 	path := "/usr/local/bin:/usr/bin:/bin"
-	for _, e := range command.Env {
-		if strings.HasPrefix("PATH=", e) {
-			path = e[5:]
-		}
-	}
 
 	return lookPathIn(path, taskDir, bin)
 }

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -810,50 +810,36 @@ func cmdMounts(mounts []*drivers.MountConfig) []*lconfigs.Mount {
 	return r
 }
 
-// lookupTaskBin finds the file `bin` in taskDir/local, taskDir in that order, then performs
-// a PATH search inside taskDir. It returns an absolute path. See also executor.lookupBin
+// lookupTaskBin finds the command.Cmd in taskDir/local, taskDir in that order,
+// then performs a PATH search inside taskDir. It returns an absolute path.
 func lookupTaskBin(command *ExecCommand) (string, error) {
-	taskDir := command.TaskDir
-	bin := command.Cmd
-
-	// Check in the local directory
-	localDir := filepath.Join(taskDir, allocdir.TaskLocal)
-	local := filepath.Join(localDir, bin)
-	if _, err := os.Stat(local); err == nil {
-		return local, nil
+	dirs := []string{
+		filepath.Join(command.TaskDir, allocdir.TaskLocal),
+		command.TaskDir,
 	}
 
-	// Check at the root of the task's directory
-	root := filepath.Join(taskDir, bin)
-	if _, err := os.Stat(root); err == nil {
-		return root, nil
-	}
-
-	if strings.Contains(bin, "/") {
-		return "", fmt.Errorf("file %s not found under path %s", bin, taskDir)
-	}
-
-	path := "/usr/local/bin:/usr/bin:/bin"
-
-	return lookPathIn(path, taskDir, bin)
-}
-
-// lookPathIn looks for a file with PATH inside the directory root. Like exec.LookPath
-func lookPathIn(path string, root string, bin string) (string, error) {
-	// exec.LookPath(file string)
-	for _, dir := range filepath.SplitList(path) {
-		if dir == "" {
-			// match unix shell behavior, empty path element == .
-			dir = "."
+	envPath := "/usr/local/bin:/usr/bin:/bin"
+	for _, e := range command.Env {
+		if strings.HasPrefix(e, "PATH=") {
+			envPath = e[5:]
 		}
-		path := filepath.Join(root, dir, bin)
+	}
+
+	for _, dir := range filepath.SplitList(envPath) {
+		dirs = append(dirs, filepath.Join(command.TaskDir, dir))
+	}
+
+	for _, dir := range dirs {
+		path := filepath.Join(dir, command.Cmd)
 		f, err := os.Stat(path)
 		if err != nil {
 			continue
 		}
+
 		if m := f.Mode(); !m.IsDir() {
 			return path, nil
 		}
 	}
-	return "", fmt.Errorf("file %s not found under path %s", bin, root)
+
+	return "", fmt.Errorf("file %s not found under path %s", command.Cmd, command.TaskDir)
 }

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -306,92 +306,41 @@ func TestUniversalExecutor_LookupTaskBin(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	cases := []struct {
-		name             string
-		cmd              string
-		env              string
-		shouldErr        bool
-		writeTaskDirPath string
-	}{
-		{
-			name:             "reference to a binary that exists in taskdir root",
-			cmd:              "some-root-bin",
-			writeTaskDirPath: "/some-root-bin",
-		},
-		{
-			name:      "reference to a binary that doesn't exist in taskdir root",
-			cmd:       "some-root-bin",
-			shouldErr: true,
-		},
-		{
-			name:             "absolute reference to a binary that exists in taskdir",
-			cmd:              "/abs/some-bin",
-			writeTaskDirPath: "/abs/some-bin",
-		},
-		{
-			name:      "absolute reference to a binary that doesn't exist in taskdir",
-			cmd:       "/abs/some-bin",
-			shouldErr: true,
-		},
-		{
-			name:             "relative reference to a binary that exists in taskdir/bin",
-			cmd:              "some-bin",
-			writeTaskDirPath: "/bin/some-bin",
-		},
-		{
-			name:             "relative reference to a binary that exists in taskdir/usr/bin",
-			cmd:              "some-bin",
-			writeTaskDirPath: "/usr/bin/some-bin",
-		},
-		{
-			name:             "relative reference to a binary that exists in taskdir/usr/local/bin",
-			cmd:              "some-bin",
-			writeTaskDirPath: "/usr/local/bin/some-bin",
-		},
-		{
-			name:             "relative reference to a binary that exists in PATH-defined dir",
-			cmd:              "some-bin",
-			env:              "PATH=/usr/local/bin:/bar",
-			writeTaskDirPath: "/bar/some-bin",
-		},
-		{
-			name:      "relative reference to a binary that doesn't exist",
-			cmd:       "some-bin",
-			shouldErr: true,
-		},
-	}
+	// Create a temp dir
+	tmpDir, err := ioutil.TempDir("", "")
+	require.Nil(err)
+	defer os.Remove(tmpDir)
 
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			taskDir, err := ioutil.TempDir("", "taskdir")
-			require.Nil(err)
-			defer os.Remove(taskDir)
+	// Create the command
+	cmd := &ExecCommand{Env: []string{"PATH=/bin"}, TaskDir: tmpDir}
 
-			cmd := &ExecCommand{
-				Cmd:     c.cmd,
-				Env:     []string{c.env},
-				TaskDir: taskDir,
-			}
+	// Make a foo subdir
+	os.MkdirAll(filepath.Join(tmpDir, "foo"), 0700)
 
-			if c.shouldErr {
-				_, err := lookupTaskBin(cmd)
-				require.Error(err)
-				return
-			}
+	// Write a file under foo
+	filePath := filepath.Join(tmpDir, "foo", "tmp.txt")
+	err = ioutil.WriteFile(filePath, []byte{1, 2}, os.ModeAppend)
+	require.NoError(err)
 
-			dir := filepath.Dir(c.writeTaskDirPath)
-			err = os.MkdirAll(filepath.Join(taskDir, dir), 0700)
-			require.Nil(err)
+	// Lookout with an absolute path to the binary
+	cmd.Cmd = "/foo/tmp.txt"
+	_, err = lookupTaskBin(cmd)
+	require.NoError(err)
 
-			binPath := filepath.Join(taskDir, c.writeTaskDirPath)
-			err = ioutil.WriteFile(binPath, []byte{1, 2}, os.ModeAppend)
-			require.NoError(err)
+	// Write a file under local subdir
+	os.MkdirAll(filepath.Join(tmpDir, "local"), 0700)
+	filePath2 := filepath.Join(tmpDir, "local", "tmp.txt")
+	ioutil.WriteFile(filePath2, []byte{1, 2}, os.ModeAppend)
 
-			actual, err := lookupTaskBin(cmd)
-			require.NoError(err)
-			require.Equal(filepath.Join(taskDir, c.writeTaskDirPath), actual)
-		})
-	}
+	// Lookup with file name, should find the one we wrote above
+	cmd.Cmd = "tmp.txt"
+	_, err = lookupTaskBin(cmd)
+	require.NoError(err)
+
+	// Lookup a host absolute path
+	cmd.Cmd = "/bin/sh"
+	_, err = lookupTaskBin(cmd)
+	require.Error(err)
 }
 
 // Exec Launch looks for the binary only inside the chroot


### PR DESCRIPTION
This was found via an updated golangci-lint, which noted that the HasPrefix invocation was backwards.

This is split into two commits on purpose:

The first commit removes the untested code that tries to find a given command.Cmd in a path defined in the command.Env as `PATH=`. I think the thinking here is that you could make a relative reference to a binary that lives in a directory that's in a user-defined `PATH` env var. However, the code that looks for a `PATH=` entry in command.Env is backwards; the prefix needs to be the second arg, not the first. That means this code never would have worked the way it was intended.

The second commit fixes this functionality, adding tests to back it up.

I'm fine with either commit being approved.