### PR TITLE
Properly detect unloaded dynamic modules on RHEL derivates. Fixes #9776

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ IMPROVEMENTS:
 BUG FIXES:
  * client: Fixed a bug where non-`docker` tasks with network isolation were restarted on client restart. [[GH-9757](https://github.com/hashicorp/nomad/issues/9757)]
  * client: Fixed a bug where clients configured with `cpu_total_compute` did not update the `cpu.totalcompute` node attribute. [[GH-9532](https://github.com/hashicorp/nomad/issues/9532)]
+ * client: Fixed an fingerprinter issue detecting bridge kernel module on RHEL [[GH-9776](https://github.com/hashicorp/nomad/issues/9776)]
  * core: Fixed a bug where an in place update dropped an allocations shared allocated resources [[GH-9736](https://github.com/hashicorp/nomad/issues/9736)]
  * consul: Fixed a bug where updating a task to include services would not work [[GH-9707](https://github.com/hashicorp/nomad/issues/9707)]
  * consul: Fixed alloc address mode port advertisement to use the mapped `to` port value [[GH-9730](https://github.com/hashicorp/nomad/issues/9730)]

--- a/client/fingerprint/bridge_linux.go
+++ b/client/fingerprint/bridge_linux.go
@@ -16,7 +16,7 @@ const bridgeKernelModuleName = "bridge"
 const (
 	dynamicModuleRe = `%s\s+.*$`
 	builtinModuleRe = `.+/%s.ko$`
-	dependsModuleRe = `.+/%s.ko:.*$`
+	dependsModuleRe = `.+/%s.ko(\.xz)?:.*$`
 )
 
 func (f *BridgeFingerprint) Fingerprint(req *FingerprintRequest, resp *FingerprintResponse) error {

--- a/client/fingerprint/bridge_linux_test.go
+++ b/client/fingerprint/bridge_linux_test.go
@@ -67,6 +67,8 @@ kernel/net/bridge/bridge.ko: kernel/net/802/stp.ko kernel/net/llc/llc.ko
 kernel/net/bridge/br_netfilter.ko: kernel/net/bridge/bridge.ko kernel/net/802/stp.ko kernel/net/llc/llc.ko
 kernel/net/appletalk/appletalk.ko: kernel/net/802/psnap.ko kernel/net/llc/llc.ko
 kernel/net/x25/x25.ko:
+# Dummy module to test RHEL modules.dep format
+kernel/net/bridge/bridgeRHEL.ko.xz: kernel/net/802/stp.ko.xz kernel/net/llc/llc.ko.xz
 `
 )
 
@@ -115,6 +117,9 @@ func TestBridgeFingerprint_search(t *testing.T) {
 			defer cleanupFile(t, file)
 
 			err := f.searchFile("bridge", file, f.regexp(dependsModuleRe, "bridge"))
+			require.NoError(t, err)
+
+			err = f.searchFile("bridgeRHEL", file, f.regexp(dependsModuleRe, "bridgeRHEL"))
 			require.NoError(t, err)
 		})
 


### PR DESCRIPTION
The modules.dep file on RHEL includes .xz for compressed kernel modules.