### PR TITLE
nomad agent-info: Add json/gotemplate formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ IMPROVEMENTS:
  * build: Updated to Go 1.15.6. [[GH-9686](https://github.com/hashicorp/nomad/issues/9686)]
  * client: Improve support for AWS Graviton instances [[GH-7989](https://github.com/hashicorp/nomad/issues/7989)]
  * consul/connect: Interpolate the connect, service meta, and service canary meta blocks with the task environment [[GH-9586](https://github.com/hashicorp/nomad/pull/9586)]
+ * cli: Added JSON/go template formatting to agent-info command. [[GH-9788](https://github.com/hashicorp/nomad/pull/9788)]
 
 BUG FIXES:
  * client: Fixed a bug where non-`docker` tasks with network isolation were restarted on client restart. [[GH-9757](https://github.com/hashicorp/nomad/issues/9757)]

--- a/command/agent_info.go
+++ b/command/agent_info.go
@@ -94,7 +94,7 @@ func (c *AgentInfoCommand) Run(args []string) int {
 	if json || len(tmpl) > 0 {
 		out, err := Format(json, tmpl, info)
 		if err != nil {
-			c.Ui.Error(err.Error())
+			c.Ui.Error(fmt.Sprintf("Error formatting output: %s", err))
 			return 1
 		}
 

--- a/command/agent_info.go
+++ b/command/agent_info.go
@@ -23,7 +23,16 @@ Usage: nomad agent-info [options]
 
 General Options:
 
-  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
+
+Agent Info Options:
+
+  -json
+    Output the node in its JSON format.
+
+-t
+    Format and display node using a Go template.
+`
 	return strings.TrimSpace(helpText)
 }
 
@@ -32,7 +41,11 @@ func (c *AgentInfoCommand) Synopsis() string {
 }
 
 func (c *AgentInfoCommand) AutocompleteFlags() complete.Flags {
-	return c.Meta.AutocompleteFlags(FlagSetClient)
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-json": complete.PredictNothing,
+			"-t":    complete.PredictAnything,
+		})
 }
 
 func (c *AgentInfoCommand) AutocompleteArgs() complete.Predictor {
@@ -42,9 +55,16 @@ func (c *AgentInfoCommand) AutocompleteArgs() complete.Predictor {
 func (c *AgentInfoCommand) Name() string { return "agent-info" }
 
 func (c *AgentInfoCommand) Run(args []string) int {
+	var json bool
+	var tmpl string
+
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.BoolVar(&json, "json", false, "")
+	flags.StringVar(&tmpl, "t", "", "")
+
 	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error parsing flags: %s", err))
 		return 1
 	}
 
@@ -68,6 +88,18 @@ func (c *AgentInfoCommand) Run(args []string) int {
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error querying agent info: %s", err))
 		return 1
+	}
+
+	// If output format is specified, format and output the agent info
+	if json || len(tmpl) > 0 {
+		out, err := Format(json, tmpl, info)
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+
+		c.Ui.Output(out)
+		return 0
 	}
 
 	// Sort and output agent info

--- a/command/agent_info_test.go
+++ b/command/agent_info_test.go
@@ -26,6 +26,40 @@ func TestAgentInfoCommand_Run(t *testing.T) {
 	}
 }
 
+func TestAgentInfoCommand_Run_JSON(t *testing.T) {
+	t.Parallel()
+	srv, _, url := testServer(t, false, nil)
+	defer srv.Shutdown()
+
+	ui := cli.NewMockUi()
+	cmd := &AgentInfoCommand{Meta: Meta{Ui: ui}}
+
+	code := cmd.Run([]string{"-address=" + url, "-json"})
+	if code != 0 {
+		t.Fatalf("expected exit 0, got: %d", code)
+	}
+	if out := ui.OutputWriter.String(); !strings.Contains(out, "\"config\": {") {
+		t.Fatalf("expected config stanza in output json")
+	}
+}
+
+func TestAgentInfoCommand_Run_Gotemplate(t *testing.T) {
+	t.Parallel()
+	srv, _, url := testServer(t, false, nil)
+	defer srv.Shutdown()
+
+	ui := cli.NewMockUi()
+	cmd := &AgentInfoCommand{Meta: Meta{Ui: ui}}
+
+	code := cmd.Run([]string{"-address=" + url, "-t", "{{.Stats.raft}}"})
+	if code != 0 {
+		t.Fatalf("expected exit 0, got: %d", code)
+	}
+	if out := ui.OutputWriter.String(); !strings.Contains(out, "last_log_index") {
+		t.Fatalf("expected raft stats in gotemplate output")
+	}
+}
+
 func TestAgentInfoCommand_Fails(t *testing.T) {
 	t.Parallel()
 	ui := cli.NewMockUi()

--- a/website/content/docs/commands/agent-info.mdx
+++ b/website/content/docs/commands/agent-info.mdx
@@ -25,6 +25,11 @@ capability.
 
 @include 'general_options_no_namespace.mdx'
 
+## Agent Info Options
+
+- `-json` : Output agent info in its JSON format.
+- `-t` : Format and display agent info using a Go template.
+
 ## Output
 
 Depending on the agent queried, information from different subsystems is


### PR DESCRIPTION
Added -json and -t formatting options to `nomad agent-info` CLI command, which provides access to the complete set of data available from the /v1/agent/self API.