### PR TITLE
docs: remove remaining references to network_speed config

### DIFF
--- a/website/content/docs/commands/agent.mdx
+++ b/website/content/docs/commands/agent.mdx
@@ -113,9 +113,6 @@ via CLI arguments. The `agent` command accepts the following arguments:
 - `-network-interface=<interface>`: Equivalent to the Client
   [network_interface] config option.
 
-- `-network-speed=<MBits>`: Equivalent to the Client
-  [network_speed] config option.
-
 - `-node=<name>`: Equivalent to the [name] config option.
 
 - `-node-class=<class>`: Equivalent to the Client [node_class]
@@ -204,7 +201,6 @@ via CLI arguments. The `agent` command accepts the following arguments:
 [meta]: /docs/configuration/client#meta
 [name]: /docs/configuration#name
 [network_interface]: /docs/configuration/client#network_interface
-[network_speed]: /docs/configuration/client#network_speed
 [node_class]: /docs/configuration/client#node_class
 [nomad agent]: /docs/install/production/nomad-agent
 [plugin_dir]: /docs/configuration#plugin_dir

--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -441,7 +441,6 @@ the values below are for illustrative purposes only.
 ```hcl
 client {
   enabled       = true
-  network_speed = 500
   node_class    = "prod"
 
   meta {

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -60,7 +60,6 @@ server {
 
 client {
   enabled       = true
-  network_speed = 10
 }
 
 plugin "raw_exec" {


### PR DESCRIPTION
Follow-up to https://github.com/hashicorp/nomad/pull/9685, as noted by @nh2 in https://github.com/hashicorp/nomad/issues/9385#issuecomment-759154171