### PR TITLE
docs: podman FSIsolation is image

### DIFF
--- a/website/content/docs/drivers/podman.mdx
+++ b/website/content/docs/drivers/podman.mdx
@@ -42,7 +42,7 @@ The `podman` driver implements the following [capabilities](/docs/internals/plug
 | -------------------- | ----------------------- |
 | `nomad alloc signal` | true                    |
 | `nomad alloc exec`   | false                   |
-| filesystem isolation | none                    |
+| filesystem isolation | image                   |
 | network isolation    | host, group, task, none |
 | volume mounting      | none                    |
 


### PR DESCRIPTION
As of podman 0.2.0 (and https://github.com/hashicorp/nomad-driver-podman/commit/b580f2d1874273bd61640525d54a02e3747c2df4), podman correctly advertises its filesystem isolation as `FSIsolationImage`.

(Noticed this was stale in https://github.com/hashicorp/nomad/issues/9790#issuecomment-759458730)