### PR TITLE
don't prefix json logging (fixes #9489)

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -618,6 +618,15 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
+	// GH-9489: Reset UI to prevent prefixed json output
+	if config.LogJson {
+		c.Ui = &cli.BasicUi{
+			Reader:      os.Stdin,
+			Writer:      os.Stdout,
+			ErrorWriter: os.Stderr,
+		}
+	}
+
 	// Setup the log outputs
 	logFilter, logGate, logOutput := SetupLoggers(c.Ui, config)
 	c.logFilter = logFilter

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -618,7 +618,7 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	// GH-9489: Reset UI to prevent prefixed json output
+	// reset UI to prevent prefixed json output
 	if config.LogJson {
 		c.Ui = &cli.BasicUi{
 			Reader:      os.Stdin,


### PR DESCRIPTION
This fixes the extra spaces at the beginning of json logging (#9489).

However I'm not a 100% happy with the current solution. Ideally we would switch the UI to `logging.HcLogUI` after reading the config. But to initialize one we need a logger, which needs a UI. Classic Catch-22.