### PR TITLE
build binaries with UI enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,7 +391,21 @@ jobs:
       - run: source ${BASH_ENV} && make deps
       - run: brew install protobuf
       - run: PATH="$GOPATH/bin:${HOME}/goinstall/go/bin:$PATH" make generate-structs
-      - run: source ${BASH_ENV} && make pkg/darwin_amd64.zip
+      - run: ./scripts/vagrant-linux-unpriv-ui.sh
+      - run:
+          name: prepare ui
+          command: |
+            export PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
+            source ${BASH_ENV}
+            . ~/.nvm/nvm.sh
+            cd ui && yarn install --frozen-lockfile && cd ..
+            JOBS=2 make ember-dist static-assets
+      - run:
+          name: build binaries
+          command: |
+            source ${BASH_ENV}
+            export GO_TAGS="ui $(grep 'GO_TAGS ?=' ./GNUmakefile | cut -d= -f2)"
+            make pkg/darwin_amd64.zip
       - store_artifacts:
           path: pkg/darwin_amd64.zip
           destination: /builds/nomad_darwin_amd64.zip
@@ -403,7 +417,20 @@ jobs:
       - run: make deps
       - install-buf
       - run: sudo -E PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" make generate-structs
-      - run: make pkg/windows_amd64.zip pkg/linux_amd64.zip
+      - run: ./scripts/vagrant-linux-unpriv-ui.sh
+      - run:
+          name: prepare ui
+          command: |
+            export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
+            export PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
+            . ~/.nvm/nvm.sh
+            cd ui && yarn install --frozen-lockfile && cd ..
+            JOBS=2 make ember-dist static-assets
+      - run:
+          name: build binaries
+          command: |
+            export GO_TAGS="ui $(grep 'GO_TAGS ?=' ./GNUmakefile | cut -d= -f2)"
+            make pkg/windows_amd64.zip pkg/linux_amd64.zip
       - store_artifacts:
           path: pkg/windows_amd64.zip
           destination: /builds/nomad_windows_amd64.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,15 +391,38 @@ jobs:
       - run: source ${BASH_ENV} && make deps
       - run: brew install protobuf
       - run: PATH="$GOPATH/bin:${HOME}/goinstall/go/bin:$PATH" make generate-structs
-      - run: ./scripts/vagrant-linux-unpriv-ui.sh
+
+      - run:
+          name: prepare ui cache
+          command: git log -n 1 --pretty=format:%H ui > /tmp/ui-sha
+
+      - restore_cache:
+          name: restore compiled ui assets
+          keys:
+          - v1-binary-ui-assets-darwin-{{ checksum "/tmp/ui-sha" }}
       - run:
           name: prepare ui
           command: |
+            if [[ -f ~/caches/ui-assets/bindata_assetfs.go ]]; then
+              cp ~/caches/ui-assets/bindata_assetfs.go ./command/agent/bindata_assetfs.go
+              exit 0
+            fi
+
+            ./scripts/vagrant-linux-unpriv-ui.sh
+
             export PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
             source ${BASH_ENV}
             . ~/.nvm/nvm.sh
             cd ui && yarn install --frozen-lockfile && cd ..
             JOBS=2 make ember-dist static-assets
+
+            mkdir -p ~/caches/ui-assets
+            cp ./command/agent/bindata_assetfs.go ~/caches/ui-assets/bindata_assetfs.go
+      - save_cache:
+          name: save compiled ui assets
+          key: v1-binary-ui-assets-darwin-{{ checksum "/tmp/ui-sha" }}
+          paths:
+          - ~/caches/ui-assets
       - run:
           name: build binaries
           command: |
@@ -417,26 +440,50 @@ jobs:
       - run: make deps
       - install-buf
       - run: sudo -E PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" make generate-structs
-      - run: ./scripts/vagrant-linux-unpriv-ui.sh
+
+      - run:
+          name: prepare ui cache
+          command: git log -n 1 --pretty=format:%H ui > /tmp/ui-sha
+
+      - restore_cache:
+          name: restore compiled ui assets
+          keys:
+          - v1-binary-ui-assets-linux-{{ checksum "/tmp/ui-sha" }}
       - run:
           name: prepare ui
           command: |
+            if [[ -f /tmp/ui-assets/bindata_assetfs.go ]]; then
+              cp /tmp/ui-assets/bindata_assetfs.go ./command/agent/bindata_assetfs.go
+              exit 0
+            fi
+
+            ./scripts/vagrant-linux-unpriv-ui.sh
+
             export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
             export PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
             . ~/.nvm/nvm.sh
             cd ui && yarn install --frozen-lockfile && cd ..
             JOBS=2 make ember-dist static-assets
+
+            mkdir -p /tmp/ui-assets
+            cp ./command/agent/bindata_assetfs.go /tmp/ui-assets/bindata_assetfs.go
+
+      - save_cache:
+          name: save compiled ui assets
+          key: v1-binary-ui-assets-linux-{{ checksum "/tmp/ui-sha" }}
+          paths:
+          - /tmp/ui-assets
       - run:
           name: build binaries
           command: |
             export GO_TAGS="ui $(grep 'GO_TAGS ?=' ./GNUmakefile | cut -d= -f2)"
             make pkg/windows_amd64.zip pkg/linux_amd64.zip
       - store_artifacts:
-          path: pkg/windows_amd64.zip
-          destination: /builds/nomad_windows_amd64.zip
+          path: pkg
+          destination: /builds
       - store_artifacts:
-          path: pkg/linux_amd64.zip
-          destination: /builds/nomad_linux_amd64.zip
+          path: /tmp/ui-assets
+          destination: /ui-assets
   algolia_index:
     docker:
       - image: docker.mirror.hashicorp.services/node:12

--- a/scripts/vagrant-linux-unpriv-ui.sh
+++ b/scripts/vagrant-linux-unpriv-ui.sh
@@ -4,7 +4,7 @@
 curl -sSL --fail -o- https://raw.githubusercontent.com/creationix/nvm/v0.36.0/install.sh | bash
 
 # This enables NVM without a logout/login
-export NVM_DIR="/home/vagrant/.nvm"
+export NVM_DIR="${HOME}/.nvm"
 # shellcheck source=/dev/null
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
 


### PR DESCRIPTION
Have the build-binary bundle the UI by default.  This eases getting "alpha pre-releases" out for support without compiling locally, and engineer's experience with e2e test clusters.