### PR TITLE
e2e infrastructure tweaks

### DIFF
--- a/e2e/terraform/.terraform.lock.hcl
+++ b/e2e/terraform/.terraform.lock.hcl
@@ -19,6 +19,23 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.0.0"
+  hashes = [
+    "h1:6S7hqjmUnoAZ5D/0F1VlJZKSJsUIBh7Ro0tLjGpKO0g=",
+    "zh:07949780dd6a1d43e7b46950f6e6976581d9724102cb5388d3411a1b6f476bde",
+    "zh:0a4f4636ff93f0644affa8474465dd8c9252946437ad025b28fc9f6603534a24",
+    "zh:0dd7e05a974c649950d1a21d7015d3753324ae52ebdd1744b144bc409ca4b3e8",
+    "zh:2b881032b9aa9d227ac712f614056d050bcdcc67df0dc79e2b2cb76a197059ad",
+    "zh:38feb4787b4570335459ca75a55389df1a7570bdca8cdf5df4c2876afe3c14b4",
+    "zh:40f7e0aaef3b1f4c2ca2bb1189e3fe9af8c296da129423986d1d99ccc8cfb86c",
+    "zh:56b361f64f0f0df5c4f958ae2f0e6f8ba192f35b720b9d3ae1be068fabcf73d9",
+    "zh:5fadb5880cd31c2105f635ded92b9b16f918c1dd989627a4ce62c04939223909",
+    "zh:61fa0be9c14c8c4109cfb7be8d54a80c56d35dbae49d3231cddb59831e7e5a4d",
+    "zh:853774bf97fbc4a784d5af5a4ca0090848430781ae6cfc586adeb48f7c44af79",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.0.0"
   hashes = [

--- a/e2e/terraform/README.md
+++ b/e2e/terraform/README.md
@@ -73,7 +73,7 @@ If you want to bootstrap Nomad ACLs, include `-var 'nomad_acls=true'`.
 
 The `profile` field selects from a set of configuration files for Nomad,
 Consul, and Vault by uploading the files found in `./config/<profile>`. The
-profiles are as follows:
+standard profiles are as follows:
 
 * `full-cluster`: This profile is used for nightly E2E testing. It assumes at
   least 3 servers and includes a unique config for each Nomad client.
@@ -81,10 +81,10 @@ profiles are as follows:
   set of clients. It assumes at least 3 servers but uses the one config for
   all the Linux Nomad clients and one config for all the Windows Nomad
   clients.
-* `custom`: This profile is used for one-off developer testing of more complex
-  interactions between features. You can build your own custom profile by
-  writing config files to the `./config/custom` directory, which are protected
-  by `.gitignore`
+
+You may create additional profiles for testing more complex interactions between features.
+You can build your own custom profile by writing config files to the
+`./config/<custom name>` directory.
 
 For each profile, application (Nomad, Consul, Vault), and agent type
 (`server`, `client_linux`, or `client_windows`), the agent gets the following

--- a/e2e/terraform/compute.tf
+++ b/e2e/terraform/compute.tf
@@ -58,6 +58,15 @@ resource "aws_instance" "client_windows_2016_amd64" {
   }
 }
 
+data "external" "packer_sha" {
+  program = ["/bin/sh", "-c", <<EOT
+sha=$(git log -n 1 --pretty=format:%H packer)
+echo "{\"sha\":\"$${sha}\"}"
+EOT
+]
+
+}
+
 data "aws_ami" "ubuntu_bionic_amd64" {
   most_recent = true
   owners      = ["self"]
@@ -70,6 +79,11 @@ data "aws_ami" "ubuntu_bionic_amd64" {
   filter {
     name   = "tag:OS"
     values = ["Ubuntu"]
+  }
+
+  filter {
+    name   = "tag:BuilderSha"
+    values = [data.external.packer_sha.result["sha"]]
   }
 }
 
@@ -85,5 +99,10 @@ data "aws_ami" "windows_2016_amd64" {
   filter {
     name   = "tag:OS"
     values = ["Windows2016"]
+  }
+
+  filter {
+    name   = "tag:BuilderSha"
+    values = [data.external.packer_sha.result["sha"]]
   }
 }

--- a/e2e/terraform/compute.tf
+++ b/e2e/terraform/compute.tf
@@ -1,3 +1,7 @@
+locals {
+  ami_prefix = "nomad-e2e-v2"
+}
+
 resource "aws_instance" "server" {
   ami                    = data.aws_ami.ubuntu_bionic_amd64.image_id
   instance_type          = var.instance_type
@@ -60,7 +64,7 @@ data "aws_ami" "ubuntu_bionic_amd64" {
 
   filter {
     name   = "name"
-    values = ["nomad-e2e-ubuntu-bionic-amd64-*"]
+    values = ["${local.ami_prefix}-ubuntu-bionic-amd64-*"]
   }
 
   filter {
@@ -75,7 +79,7 @@ data "aws_ami" "windows_2016_amd64" {
 
   filter {
     name   = "name"
-    values = ["nomad-e2e-windows-2016-amd64-*"]
+    values = ["${local.ami_prefix}-windows-2016-amd64-*"]
   }
 
   filter {

--- a/e2e/terraform/packer/README.md
+++ b/e2e/terraform/packer/README.md
@@ -17,10 +17,10 @@ $ packer --version
 1.6.4
 
 # build Ubuntu Bionic AMI
-$ packer build ubuntu-bionic-amd64.pkr.hcl
+$ ./build ubuntu-bionic-amd64
 
 # build Windows AMI
-$ packer build windows-2016-amd64.pkr.hcl
+$ ./build windows-2016-amd64
 ```
 
 ## Debugging Packer Builds

--- a/e2e/terraform/packer/build
+++ b/e2e/terraform/packer/build
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -e
+
+usage() {
+    cat <<EOF
+Usage: build <target>
+
+Build an AMI for the target configuration
+
+Examples
+  build ubuntu-bionic-amd64
+
+EOF
+
+    exit 2
+}
+
+if [[ $# -ne 1 ]]; then
+     usage
+fi
+
+target=${1/%.pkr.hcl/}
+
+directory=$(dirname "$0")
+cd ${directory}
+
+if ! test -f "${target}.pkr.hcl"; then
+    echo "${target}.pkr.hcl is not present" >&2
+    exit 1
+fi
+
+sha=$(git log -n 1 --pretty=format:%H ${dirname})
+echo packer build --var "build_sha=${sha}" ${target}.pkr.hcl
+packer build --var "build_sha=${sha}" ${target}.pkr.hcl

--- a/e2e/terraform/packer/ubuntu-bionic-amd64.pkr.hcl
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64.pkr.hcl
@@ -1,10 +1,11 @@
 locals {
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
   distro    = "ubuntu-bionic-18.04-amd64-server-*"
+  version   = "v2"
 }
 
 source "amazon-ebs" "latest_ubuntu_bionic" {
-  ami_name             = "nomad-e2e-ubuntu-bionic-amd64-${local.timestamp}"
+  ami_name             = "nomad-e2e-${local.version}-ubuntu-bionic-amd64-${local.timestamp}"
   iam_instance_profile = "packer_build" // defined in nomad-e2e repo
   instance_type        = "t2.medium"
   region               = "us-east-1"

--- a/e2e/terraform/packer/ubuntu-bionic-amd64.pkr.hcl
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64.pkr.hcl
@@ -36,11 +36,6 @@ build {
     source      = "./ubuntu-bionic-amd64"
   }
 
-  provisioner "file" {
-    destination = "/tmp/config"
-    source      = "../config"
-  }
-
   // cloud-init modifies the apt sources, so we need to wait
   // before running our setup
   provisioner "shell-local" {

--- a/e2e/terraform/packer/ubuntu-bionic-amd64.pkr.hcl
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64.pkr.hcl
@@ -1,3 +1,8 @@
+variable "build_sha" {
+  type        = string
+  description = "the revision of the packer scripts building this image"
+}
+
 locals {
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
   distro    = "ubuntu-bionic-18.04-amd64-server-*"
@@ -24,8 +29,9 @@ source "amazon-ebs" "latest_ubuntu_bionic" {
   }
 
   tags = {
-    OS      = "Ubuntu"
-    Version = "Bionic"
+    OS         = "Ubuntu"
+    Version    = "Bionic"
+    BuilderSha = var.build_sha
   }
 }
 

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/setup.sh
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/setup.sh
@@ -77,7 +77,6 @@ mkdir_for_root $NOMAD_PLUGIN_DIR
 sudo mv /tmp/linux/nomad.service /etc/systemd/system/nomad.service
 
 echo "Install Nomad"
-sudo mv /tmp/config /opt/
 sudo mv /tmp/linux/provision.sh /opt/provision.sh
 sudo chmod +x /opt/provision.sh
 /opt/provision.sh --nomad_version $NOMADVERSION --nostart

--- a/e2e/terraform/packer/windows-2016-amd64.pkr.hcl
+++ b/e2e/terraform/packer/windows-2016-amd64.pkr.hcl
@@ -38,11 +38,6 @@ build {
   }
 
   provisioner "file" {
-    destination = "/opt"
-    source      = "../config"
-  }
-
-  provisioner "file" {
     destination = "/opt/provision.ps1"
     source      = "./windows-2016-amd64/provision.ps1"
   }

--- a/e2e/terraform/packer/windows-2016-amd64.pkr.hcl
+++ b/e2e/terraform/packer/windows-2016-amd64.pkr.hcl
@@ -1,3 +1,8 @@
+variable "build_sha" {
+  type        = string
+  description = "the revision of the packer scripts building this image"
+}
+
 locals {
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
   version   = "v2"
@@ -23,7 +28,8 @@ source "amazon-ebs" "latest_windows_2016" {
   }
 
   tags = {
-    OS = "Windows2016"
+    OS         = "Windows2016"
+    BuilderSha = var.build_sha
   }
 }
 

--- a/e2e/terraform/packer/windows-2016-amd64.pkr.hcl
+++ b/e2e/terraform/packer/windows-2016-amd64.pkr.hcl
@@ -1,7 +1,10 @@
-locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+locals {
+  timestamp = regex_replace(timestamp(), "[- TZ:]", "")
+  version   = "v2"
+}
 
 source "amazon-ebs" "latest_windows_2016" {
-  ami_name       = "nomad-e2e-windows-2016-amd64-${local.timestamp}"
+  ami_name       = "nomad-e2e-${local.version}-windows-2016-amd64-${local.timestamp}"
   communicator   = "ssh"
   instance_type  = "t2.medium"
   region         = "us-east-1"


### PR DESCRIPTION
This PR makes two ergonomics changes, meant to get e2e builds more reproducible and ease changes.

### AMI Management

First, we pin the server AMIs to the commits associated with the build.  No more using the latest AMI a developer build in a test branch, or accidentally using a stale AMI because we forgot to build one!  Packer is to tag the AMI images with the commit sha used to generate the image, and then Terraform would look up only the AMIs associated with that sha. To minimize churn, we use the SHA associated with the latest Packer configurations, rather than SHA of all.

This has few benefits: reproducibility and avoiding accidental AMI changes and contamination of changes across branches. Also, the change is a stepping stone to an e2e pipeline that builds new AMIs automatically if Packer files changed.

The downside is that new AMIs will be generated even for irrelevant changes (e.g. spelling, commits), but I suspect that's OK. Also, an engineer will be forced to build the AMI whenever they change Packer files while iterating on e2e scripts; this hasn't been an issue for me yet, and I'll be open for iterating on that later if it proves to be an issue.

### Config Files and Packer

Second, this PR moves e2e config hcl management to Terraform instead of Packer. Currently, the config files live in `./terraform/config`, but they are baked into the servers by Packer and changes are ignored.  This current behavior surprised me, as I spent a bit of time debugging why my config changes weren't applied.  Having Terraform manage them would ease engineer's iteration.  Also, make Packer management more consistent (Packer only works `e2e/terraform/packer`), and easing the logic for AMI change detection.

The config directory is very small (100KB), and having it as an upload step adds negligible time to `terraform apply`.