### PR TITLE
docs: fix HCL2 doc page code block

### DIFF
--- a/website/content/docs/job-specification/hcl2/index.mdx
+++ b/website/content/docs/job-specification/hcl2/index.mdx
@@ -155,7 +155,7 @@ mounts = [
 
 Or better yet, the new [`mount`](/docs/driver/docker#mount) syntax, introduced in Nomad 1.0.1, is more appropriate here:
 
-````hcl
+```hcl
 mount {
   type = "tmpfs"
   tmpf_options {


### PR DESCRIPTION
Before:
<img width="959" alt="Screen Shot 2021-01-13 at 11 12 05 AM" src="https://user-images.githubusercontent.com/775380/104478386-3bb06680-5590-11eb-9518-39918d8df50f.png">

After:
<img width="948" alt="Screen Shot 2021-01-13 at 11 12 23 AM" src="https://user-images.githubusercontent.com/775380/104478411-42d77480-5590-11eb-9ff2-6d7d22cb11a4.png">
