### PR TITLE
lifecycle: successful prestart tasks should not fail deployments

### DIFF
--- a/client/allochealth/tracker.go
+++ b/client/allochealth/tracker.go
@@ -285,7 +285,7 @@ func (t *Tracker) watchTaskEvents() {
 			}
 
 			// One of the tasks has failed so we can exit watching
-			if state.Failed || !state.FinishedAt.IsZero() {
+			if state.Failed || (!state.FinishedAt.IsZero() && t.lifecycleTasks[taskName] != structs.TaskLifecycleHookPrestart) {
 				t.setTaskHealth(false, true)
 				return
 			}


### PR DESCRIPTION
In 492d62d we prevented poststop tasks from contributing to allocation health
status, which fixed a bug where poststop tasks would prevent a deployment from
ever being marked successful. The patch introduced a regression where prestart
tasks that complete are causing the allocation to be marked unhealthy. This
changeset restores the previous behavior for prestart tasks.

Note to reviewers: you can [compare to the original line](https://github.com/hashicorp/nomad/pull/9548/files#diff-22c7aef46df110dd1b35c5ef1f7a090779ac2c9c1b8a0cd8d8137ff6deb6fe3bL281).