### PR TITLE
csi: Return error when deleting node

### DIFF
--- a/nomad/structs/csi_test.go
+++ b/nomad/structs/csi_test.go
@@ -213,3 +213,183 @@ func TestCSIPluginCleanup(t *testing.T) {
 	require.Equal(t, 0, len(plug.Controllers))
 	require.Equal(t, 0, len(plug.Nodes))
 }
+
+func TestDeleteNodeForType_Controller(t *testing.T) {
+	info := &CSIInfo{
+		PluginID:                 "foo",
+		AllocID:                  "a0",
+		Healthy:                  true,
+		Provider:                 "foo-provider",
+		RequiresControllerPlugin: true,
+		RequiresTopologies:       false,
+		ControllerInfo:           &CSIControllerInfo{},
+	}
+
+	plug := NewCSIPlugin("foo", 1000)
+
+	plug.Controllers["n0"] = info
+	plug.ControllersHealthy = 1
+
+	err := plug.DeleteNodeForType("n0", CSIPluginTypeController)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, plug.ControllersHealthy)
+	require.Equal(t, 0, len(plug.Controllers))
+}
+
+func TestDeleteNodeForType_NilController(t *testing.T) {
+	plug := NewCSIPlugin("foo", 1000)
+
+	plug.Controllers["n0"] = nil
+	plug.ControllersHealthy = 1
+
+	err := plug.DeleteNodeForType("n0", CSIPluginTypeController)
+	require.Error(t, err)
+	require.Equal(t, 1, len(plug.Controllers))
+
+	_, ok := plug.Controllers["foo"]
+	require.False(t, ok)
+}
+
+func TestDeleteNodeForType_Node(t *testing.T) {
+	info := &CSIInfo{
+		PluginID:                 "foo",
+		AllocID:                  "a0",
+		Healthy:                  true,
+		Provider:                 "foo-provider",
+		RequiresControllerPlugin: true,
+		RequiresTopologies:       false,
+		NodeInfo:                 &CSINodeInfo{},
+	}
+
+	plug := NewCSIPlugin("foo", 1000)
+
+	plug.Nodes["n0"] = info
+	plug.NodesHealthy = 1
+
+	err := plug.DeleteNodeForType("n0", CSIPluginTypeNode)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, plug.NodesHealthy)
+	require.Equal(t, 0, len(plug.Nodes))
+}
+
+func TestDeleteNodeForType_NilNode(t *testing.T) {
+	plug := NewCSIPlugin("foo", 1000)
+
+	plug.Nodes["n0"] = nil
+	plug.NodesHealthy = 1
+
+	err := plug.DeleteNodeForType("n0", CSIPluginTypeNode)
+	require.Error(t, err)
+	require.Equal(t, 1, len(plug.Nodes))
+
+	_, ok := plug.Nodes["foo"]
+	require.False(t, ok)
+}
+
+func TestDeleteNodeForType_Monolith(t *testing.T) {
+	controllerInfo := &CSIInfo{
+		PluginID:                 "foo",
+		AllocID:                  "a0",
+		Healthy:                  true,
+		Provider:                 "foo-provider",
+		RequiresControllerPlugin: true,
+		RequiresTopologies:       false,
+		ControllerInfo:           &CSIControllerInfo{},
+	}
+
+	nodeInfo := &CSIInfo{
+		PluginID:                 "foo",
+		AllocID:                  "a0",
+		Healthy:                  true,
+		Provider:                 "foo-provider",
+		RequiresControllerPlugin: true,
+		RequiresTopologies:       false,
+		NodeInfo:                 &CSINodeInfo{},
+	}
+
+	plug := NewCSIPlugin("foo", 1000)
+
+	plug.Controllers["n0"] = controllerInfo
+	plug.ControllersHealthy = 1
+
+	plug.Nodes["n0"] = nodeInfo
+	plug.NodesHealthy = 1
+
+	err := plug.DeleteNodeForType("n0", CSIPluginTypeMonolith)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, len(plug.Controllers))
+	require.Equal(t, 0, len(plug.Nodes))
+
+	_, ok := plug.Nodes["foo"]
+	require.False(t, ok)
+
+	_, ok = plug.Controllers["foo"]
+	require.False(t, ok)
+}
+
+func TestDeleteNodeForType_Monolith_NilController(t *testing.T) {
+	plug := NewCSIPlugin("foo", 1000)
+
+	plug.Controllers["n0"] = nil
+	plug.ControllersHealthy = 1
+
+	nodeInfo := &CSIInfo{
+		PluginID:                 "foo",
+		AllocID:                  "a0",
+		Healthy:                  true,
+		Provider:                 "foo-provider",
+		RequiresControllerPlugin: true,
+		RequiresTopologies:       false,
+		NodeInfo:                 &CSINodeInfo{},
+	}
+
+	plug.Nodes["n0"] = nodeInfo
+	plug.NodesHealthy = 1
+
+	err := plug.DeleteNodeForType("n0", CSIPluginTypeMonolith)
+	require.Error(t, err)
+
+	require.Equal(t, 1, len(plug.Controllers))
+	require.Equal(t, 0, len(plug.Nodes))
+
+	_, ok := plug.Nodes["foo"]
+	require.False(t, ok)
+
+	_, ok = plug.Controllers["foo"]
+	require.False(t, ok)
+}
+
+func TestDeleteNodeForType_Monolith_NilNode(t *testing.T) {
+	plug := NewCSIPlugin("foo", 1000)
+
+	plug.Nodes["n0"] = nil
+	plug.NodesHealthy = 1
+
+	controllerInfo := &CSIInfo{
+		PluginID:                 "foo",
+		AllocID:                  "a0",
+		Healthy:                  true,
+		Provider:                 "foo-provider",
+		RequiresControllerPlugin: true,
+		RequiresTopologies:       false,
+		ControllerInfo:           &CSIControllerInfo{},
+	}
+
+	plug.Controllers["n0"] = controllerInfo
+	plug.ControllersHealthy = 1
+
+	err := plug.DeleteNodeForType("n0", CSIPluginTypeMonolith)
+	require.Error(t, err)
+
+	require.Equal(t, 0, len(plug.Controllers))
+	require.Equal(t, 1, len(plug.Nodes))
+
+	_, ok := plug.Nodes["foo"]
+	require.False(t, ok)
+
+	_, ok = plug.Controllers["foo"]
+	require.False(t, ok)
+}

--- a/nomad/structs/csi_test.go
+++ b/nomad/structs/csi_test.go
@@ -204,7 +204,9 @@ func TestCSIPluginCleanup(t *testing.T) {
 	require.Equal(t, 1, plug.ControllersHealthy)
 	require.Equal(t, 1, plug.NodesHealthy)
 
-	plug.DeleteNode("n0")
+	err := plug.DeleteNode("n0")
+	require.NoError(t, err)
+
 	require.Equal(t, 0, plug.ControllersHealthy)
 	require.Equal(t, 0, plug.NodesHealthy)
 


### PR DESCRIPTION
The error that this would have returned would only have been returned if
the lookup in a map did not fail and the value that the map returned was
nil, ~which I think is not possible~ the map keys are pointers, so they can be!

In this change we'll properly return the error in the
CSIPluginTypeMonolith case (which is the type given in DeleteNode()),
and also actually return the error when the given ID is not found.

This was found via errcheck.

Note: ~Since I don't think it was possible for this to have ever actually returned an error before,~ I wonder if the behavior when trying to delete a node where one of the controller or node is not found should actually return an error, and if so, if it should only do so for one and not the other. In other words, if you want to delete a node and there's no controller found, should it still proceed to try deleting the node from the map?