### PR TITLE
Website StackMenu updates for 1/14

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1787,9 +1787,9 @@
       "integrity": "sha512-a2eWgjLwGAC2LjUHE7Xt6sRGGjyTWfrc4N+qVxsyZw4eE0EiNhMIKDYHWjmtb+tGh8r8j+ca3tSjsuOUePVPUw=="
     },
     "@hashicorp/react-hashi-stack-menu": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-1.0.11.tgz",
-      "integrity": "sha512-d98ijPKl8qEIz2pNh6FxEgb9Kn2R7K3KylhF+GqhNy/+hFLXvlnS+nPv9CLcxfrhjpNyUslTtwfmpUati1/CCw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-1.1.0.tgz",
+      "integrity": "sha512-WPrMJT64V5y6JPVajCQduAXKTz1ij8OXCOKdvavjhoSpteuA+/xWuQZyeNQaUWnsKCXnNydbBUzuCb2or03vsA==",
       "requires": {
         "@hashicorp/react-inline-svg": "^1.0.2",
         "slugify": "1.3.4"

--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
     "@hashicorp/react-call-to-action": "1.0.3",
     "@hashicorp/react-content": "6.2.0",
     "@hashicorp/react-docs-page": "10.4.0",
-    "@hashicorp/react-hashi-stack-menu": "^1.0.11",
+    "@hashicorp/react-hashi-stack-menu": "^1.1.0",
     "@hashicorp/react-hero": "4.1.0",
     "@hashicorp/react-image": "3.0.3",
     "@hashicorp/react-inline-svg": "5.0.0",


### PR DESCRIPTION
A small version bump to the HashiStackMenu (formally known as the MegaNav) for 1/14 updates.

