### PR TITLE
ci: only read/modify `GO_TAGS` field

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,7 +427,7 @@ jobs:
           name: build binaries
           command: |
             source ${BASH_ENV}
-            export GO_TAGS="ui $(grep 'GO_TAGS ?=' ./GNUmakefile | cut -d= -f2)"
+            export GO_TAGS="ui $(grep -e '^GO_TAGS ?=' ./GNUmakefile | cut -d= -f2)"
             make pkg/darwin_amd64.zip
       - store_artifacts:
           path: pkg/darwin_amd64.zip
@@ -476,7 +476,7 @@ jobs:
       - run:
           name: build binaries
           command: |
-            export GO_TAGS="ui $(grep 'GO_TAGS ?=' ./GNUmakefile | cut -d= -f2)"
+            export GO_TAGS="ui $(grep -e '^GO_TAGS ?=' ./GNUmakefile | cut -d= -f2)"
             make pkg/windows_amd64.zip pkg/linux_amd64.zip
       - store_artifacts:
           path: pkg


### PR DESCRIPTION
Only lookup GO_TAGS variable, and avoid the false positives where GO_TAGS is a variable suffix.

Needed to fix the Enterprise (private fork) build binary jobs.