### PR TITLE
validate connect block allowed only within group.service (fixes #9450)

### DIFF
--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1088,6 +1088,12 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 					}
 				}
 			}
+
+			// Task services can't have a connect block. We still convert it so that
+			// we can later return a validation error.
+			if service.Connect != nil {
+				structsTask.Services[i].Connect = ApiConsulConnectToStructs(service.Connect)
+			}
 		}
 	}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6922,7 +6922,7 @@ func validateServices(t *Task, tgNetworks Networks) error {
 			}
 		}
 
-		// GH-9450: connect block is only allowed on group level
+		// connect block is only allowed on group level
 		if service.Connect != nil {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("service %q cannot have \"connect\" block, only services defined in a \"group\" block can", service.Name))
 		}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6922,6 +6922,11 @@ func validateServices(t *Task, tgNetworks Networks) error {
 			}
 		}
 
+		// GH-9450: connect block is only allowed on group level
+		if service.Connect != nil {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("service %q cannot have \"connect\" block, only services defined in a \"group\" block can", service.Name))
+		}
+
 		// Ensure that check names are unique and have valid ports
 		knownChecks := make(map[string]struct{})
 		for _, check := range service.Checks {

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1933,6 +1933,13 @@ func TestTask_Validate_Service_Check_AddressMode(t *testing.T) {
 			},
 			ErrContains: `invalid: check requires a port but neither check nor service`,
 		},
+		{
+			Service: &Service{
+				Name:    "conect-block-on-task-level",
+				Connect: &ConsulConnect{SidecarService: &ConsulSidecarService{}},
+			},
+			ErrContains: `cannot have "connect" block`,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This adds the missing validation mentioned in #9450 for a connect block to be allowed only in a group service. 