### PR TITLE
Add missing sink.Cancel() in fsm

### DIFF
--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1894,6 +1894,7 @@ func (s *nomadSnapshot) Persist(sink raft.SnapshotSink) error {
 		return err
 	}
 	if err := s.persistNamespaces(sink, encoder); err != nil {
+		sink.Cancel()
 		return err
 	}
 	if err := s.persistEnterpriseTables(sink, encoder); err != nil {


### PR DESCRIPTION
As it says on the tin. This looks like it was missed when the namespace persistence was added.