### PR TITLE
Persist shared allocated ports for inplace update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.0.3 (Unreleased)
 
+BUG FIXES:
+
+ * scheduler: Fixed a bug where shared ports were not persisted during inplace updates for service jobs. [[GH-9830](https://github.com/hashicorp/nomad/issues/9830)]
+
 ## 1.0.2 (January 14, 2020)
 
 IMPROVEMENTS:

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -1014,7 +1014,7 @@ func genericAllocUpdateFn(ctx Context, stack Stack, evalID string) allocUpdateTy
 			},
 		}
 
-		// Since this is an inplace update, we should copy network
+		// Since this is an inplace update, we should copy network and port
 		// information from the original alloc. This is similar to how
 		// we copy network info for task level networks above.
 		//
@@ -1022,6 +1022,7 @@ func genericAllocUpdateFn(ctx Context, stack Stack, evalID string) allocUpdateTy
 		// Nomad v0.8 or earlier.
 		if existing.AllocatedResources != nil {
 			newAlloc.AllocatedResources.Shared.Networks = existing.AllocatedResources.Shared.Networks
+			newAlloc.AllocatedResources.Shared.Ports = existing.AllocatedResources.Shared.Ports
 		}
 
 		// Use metrics from existing alloc for in place upgrade

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/nomad/helper"
@@ -943,8 +942,6 @@ func TestInplaceUpdate_AllocatedResources(t *testing.T) {
 	alloc.TaskResources = map[string]*structs.Resources{"web": alloc.Resources}
 	require.NoError(t, state.UpsertJobSummary(1000, mock.JobSummary(alloc.JobID)))
 	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc}))
-
-	spew.Dump(job)
 
 	// Update TG to add a new service (inplace)
 	tg := job.TaskGroups[0]

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/nomad/helper"
@@ -942,6 +943,8 @@ func TestInplaceUpdate_AllocatedResources(t *testing.T) {
 	alloc.TaskResources = map[string]*structs.Resources{"web": alloc.Resources}
 	require.NoError(t, state.UpsertJobSummary(1000, mock.JobSummary(alloc.JobID)))
 	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc}))
+
+	spew.Dump(job)
 
 	// Update TG to add a new service (inplace)
 	tg := job.TaskGroups[0]


### PR DESCRIPTION
Ports were not copied over when performing inplace updates in the
generic scheduler

Fixes #9808 