### PR TITLE
Clean up Task Validation tests

### DIFF
--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -5925,9 +5925,9 @@ func requireMultierrorNotContaining(t *testing.T, err error, unexpected ...strin
 	require.True(t, ok)
 
 	var found []string
-	for _, unex := range unexpected {
-		if strings.Contains(mErr.Error(), unex) {
-			found = append(found, unex)
+	for _, e := range unexpected {
+		if strings.Contains(mErr.Error(), e) {
+			found = append(found, e)
 		}
 	}
 
@@ -5941,10 +5941,10 @@ func requireMultierrorContaining(t *testing.T, err error, expected ...string) {
 	require.True(t, ok)
 
 	var found []string
-	for _, ex := range expected {
+	for _, e := range expected {
 		for _, actual := range mErr.Errors {
-			if strings.Contains(actual.Error(), ex) {
-				found = append(found, ex)
+			if strings.Contains(actual.Error(), e) {
+				found = append(found, e)
 				break
 			}
 		}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -20,7 +20,7 @@ import (
 func TestJob_Validate(t *testing.T) {
 	j := &Job{}
 	err := j.Validate()
-	requireMultierrorContaining(t, err,
+	requireErrors(t, err,
 		"datacenters",
 		"job ID",
 		"job name",
@@ -83,7 +83,7 @@ func TestJob_Validate(t *testing.T) {
 		},
 	}
 	err = j.Validate()
-	requireMultierrorContaining(t, err,
+	requireErrors(t, err,
 		"2 redefines 'web' from group 1",
 		"group 3 missing name",
 		"Task group web validation failed",
@@ -116,7 +116,7 @@ func TestJob_ValidateScaling(t *testing.T) {
 	p.Max = 0
 	p.Min = 10
 	err := job.Validate()
-	requireMultierrorContaining(t, err,
+	requireErrors(t, err,
 		"task group count must not be less than minimum count in scaling policy",
 		"task group count must not be greater than maximum count in scaling policy",
 	)
@@ -914,7 +914,7 @@ func TestTaskGroup_Validate(t *testing.T) {
 		},
 	}
 	err := tg.Validate(j)
-	requireMultierrorContaining(t, err,
+	requireErrors(t, err,
 		"group name",
 		"count can't be negative",
 		"Missing tasks",
@@ -996,7 +996,7 @@ func TestTaskGroup_Validate(t *testing.T) {
 	}
 
 	err = tg.Validate(j)
-	requireMultierrorContaining(t, err,
+	requireErrors(t, err,
 		"should have an ephemeral disk object",
 		"2 redefines 'web' from task 1",
 		"Task 3 missing name",
@@ -1304,7 +1304,7 @@ func TestTask_Validate(t *testing.T) {
 	task := &Task{}
 	ephemeralDisk := DefaultEphemeralDisk()
 	err := task.Validate(ephemeralDisk, JobTypeBatch, nil, nil)
-	requireMultierrorContaining(t, err,
+	requireErrors(t, err,
 		"task name",
 		"task driver",
 		"task resources",
@@ -1339,7 +1339,7 @@ func TestTask_Validate(t *testing.T) {
 		})
 
 	err = task.Validate(ephemeralDisk, JobTypeBatch, nil, nil)
-	requireMultierrorContaining(t, err,
+	requireErrors(t, err,
 		"task level: distinct_hosts",
 		"task level: distinct_property",
 	)
@@ -2458,7 +2458,7 @@ func TestUpdateStrategy_Validate(t *testing.T) {
 	}
 
 	err := u.Validate()
-	requireMultierrorContaining(t, err,
+	requireErrors(t, err,
 		"Invalid health check given",
 		"Max parallel can not be less than zero",
 		"Canary count can not be less than zero",
@@ -5918,7 +5918,7 @@ func TestTaskGroup_validateScriptChecksInGroupServices(t *testing.T) {
 	})
 }
 
-func requireMultierrorContaining(t *testing.T, err error, expected ...string) {
+func requireErrors(t *testing.T, err error, expected ...string) {
 	t.Helper()
 	require.Error(t, err)
 	mErr, ok := err.(*multierror.Error)

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -20,31 +20,16 @@ import (
 func TestJob_Validate(t *testing.T) {
 	j := &Job{}
 	err := j.Validate()
-	mErr := err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "job region") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[1].Error(), "job ID") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[2].Error(), "job name") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[3].Error(), "namespace") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[4].Error(), "job type") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[5].Error(), "priority") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[6].Error(), "datacenters") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[7].Error(), "task groups") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err,
+		"datacenters",
+		"job ID",
+		"job name",
+		"job region",
+		"job type",
+		"namespace",
+		"priority",
+		"task groups",
+	)
 
 	j = &Job{
 		Type: "invalid-job-type",
@@ -61,10 +46,7 @@ func TestJob_Validate(t *testing.T) {
 		},
 	}
 	err = j.Validate()
-	mErr = err.(*multierror.Error)
-	if !strings.Contains(mErr.Error(), "Periodic") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err, "Periodic")
 
 	j = &Job{
 		Region:      "global",
@@ -101,26 +83,17 @@ func TestJob_Validate(t *testing.T) {
 		},
 	}
 	err = j.Validate()
-	mErr = err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "2 redefines 'web' from group 1") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[1].Error(), "group 3 missing name") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[2].Error(), "Task group web validation failed") {
-		t.Fatalf("err: %s", err)
-	}
-
+	requireMultierrorContaining(t, err,
+		"2 redefines 'web' from group 1",
+		"group 3 missing name",
+		"Task group web validation failed",
+	)
 	// test for empty datacenters
 	j = &Job{
 		Datacenters: []string{""},
 	}
 	err = j.Validate()
-	mErr = err.(*multierror.Error)
-	if !strings.Contains(mErr.Error(), "datacenter must be non-empty string") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err, "datacenter must be non-empty string")
 }
 
 func TestJob_ValidateScaling(t *testing.T) {
@@ -143,31 +116,28 @@ func TestJob_ValidateScaling(t *testing.T) {
 	p.Max = 0
 	p.Min = 10
 	err := job.Validate()
-	require.Error(err)
-	mErr := err.(*multierror.Error)
-	require.Len(mErr.Errors, 1)
-	require.Contains(mErr.Errors[0].Error(), "task group count must not be less than minimum count in scaling policy")
-	require.Contains(mErr.Errors[0].Error(), "task group count must not be greater than maximum count in scaling policy")
+	requireMultierrorContaining(t, err,
+		"task group count must not be less than minimum count in scaling policy",
+		"task group count must not be greater than maximum count in scaling policy",
+	)
 
 	// count <= max
 	p.Max = 0
 	p.Min = 5
 	job.TaskGroups[0].Count = 5
 	err = job.Validate()
-	require.Error(err)
-	mErr = err.(*multierror.Error)
-	require.Len(mErr.Errors, 1)
-	require.Contains(mErr.Errors[0].Error(), "task group count must not be greater than maximum count in scaling policy")
+	requireMultierrorContaining(t, err,
+		"task group count must not be greater than maximum count in scaling policy",
+	)
 
 	// min <= count
 	job.TaskGroups[0].Count = 0
 	p.Min = 5
 	p.Max = 5
 	err = job.Validate()
-	require.Error(err)
-	mErr = err.(*multierror.Error)
-	require.Len(mErr.Errors, 1)
-	require.Contains(mErr.Errors[0].Error(), "task group count must not be less than minimum count in scaling policy")
+	requireMultierrorContaining(t, err,
+		"task group count must not be less than minimum count in scaling policy",
+	)
 }
 
 func TestJob_ValidateNullChar(t *testing.T) {
@@ -263,9 +233,8 @@ func TestJob_Warnings(t *testing.T) {
 			if warnings == nil {
 				if len(c.Expected) == 0 {
 					return
-				} else {
-					t.Fatal("Got no warnings when they were expected")
 				}
+				t.Fatal("Got no warnings when they were expected")
 			}
 
 			a := warnings.Error()
@@ -945,16 +914,11 @@ func TestTaskGroup_Validate(t *testing.T) {
 		},
 	}
 	err := tg.Validate(j)
-	mErr := err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "group name") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[1].Error(), "count can't be negative") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[2].Error(), "Missing tasks") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err,
+		"group name",
+		"count can't be negative",
+		"Missing tasks",
+	)
 
 	tg = &TaskGroup{
 		Tasks: []*Task{
@@ -1032,22 +996,13 @@ func TestTaskGroup_Validate(t *testing.T) {
 	}
 
 	err = tg.Validate(j)
-	mErr = err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "should have an ephemeral disk object") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[1].Error(), "2 redefines 'web' from task 1") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[2].Error(), "Task 3 missing name") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[3].Error(), "Only one task may be marked as leader") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[4].Error(), "Task web validation failed") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err,
+		"should have an ephemeral disk object",
+		"2 redefines 'web' from task 1",
+		"Task 3 missing name",
+		"Only one task may be marked as leader",
+		"Task web validation failed",
+	)
 
 	tg = &TaskGroup{
 		Name:  "web",
@@ -1059,9 +1014,7 @@ func TestTaskGroup_Validate(t *testing.T) {
 	}
 	j.Type = JobTypeBatch
 	err = tg.Validate(j)
-	if !strings.Contains(err.Error(), "does not allow update block") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err, "does not allow update block")
 
 	tg = &TaskGroup{
 		Count: -1,
@@ -1351,23 +1304,15 @@ func TestTask_Validate(t *testing.T) {
 	task := &Task{}
 	ephemeralDisk := DefaultEphemeralDisk()
 	err := task.Validate(ephemeralDisk, JobTypeBatch, nil, nil)
-	mErr := err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "task name") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[1].Error(), "task driver") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[2].Error(), "task resources") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err,
+		"task name",
+		"task driver",
+		"task resources",
+	)
 
 	task = &Task{Name: "web/foo"}
 	err = task.Validate(ephemeralDisk, JobTypeBatch, nil, nil)
-	mErr = err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "slashes") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err, "slashes")
 
 	task = &Task{
 		Name:   "web",
@@ -1394,13 +1339,10 @@ func TestTask_Validate(t *testing.T) {
 		})
 
 	err = task.Validate(ephemeralDisk, JobTypeBatch, nil, nil)
-	mErr = err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "task level: distinct_hosts") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[1].Error(), "task level: distinct_property") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err,
+		"task level: distinct_hosts",
+		"task level: distinct_property",
+	)
 }
 
 func TestTask_Validate_Resources(t *testing.T) {
@@ -2115,10 +2057,7 @@ func TestTask_Validate_LogConfig(t *testing.T) {
 	}
 
 	err := task.Validate(ephemeralDisk, JobTypeService, nil, nil)
-	mErr := err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[3].Error(), "log storage") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err, "log storage")
 }
 
 func TestLogConfig_Equals(t *testing.T) {
@@ -2155,13 +2094,15 @@ func TestLogConfig_Equals(t *testing.T) {
 
 func TestTask_Validate_CSIPluginConfig(t *testing.T) {
 	table := []struct {
-		name        string
-		pc          *TaskCSIPluginConfig
-		expectedErr string
+		name          string
+		pc            *TaskCSIPluginConfig
+		expectedErr   string
+		unexpectedErr string
 	}{
 		{
-			name: "no errors when not specified",
-			pc:   nil,
+			name:          "no errors when not specified",
+			pc:            nil,
+			unexpectedErr: "CSIPluginConfig",
 		},
 		{
 			name:        "requires non-empty plugin id",
@@ -2188,15 +2129,10 @@ func TestTask_Validate_CSIPluginConfig(t *testing.T) {
 			}
 
 			err := task.Validate(ephemeralDisk, JobTypeService, nil, nil)
-			mErr := err.(*multierror.Error)
 			if tt.expectedErr != "" {
-				if !strings.Contains(mErr.Errors[4].Error(), tt.expectedErr) {
-					t.Fatalf("err: %s", err)
-				}
-			} else {
-				if len(mErr.Errors) != 4 {
-					t.Fatalf("unexpected err: %s", mErr.Errors[4])
-				}
+				requireMultierrorContaining(t, err, tt.expectedErr)
+			} else if tt.unexpectedErr != "" {
+				requireMultierrorNotContaining(t, err, tt.unexpectedErr)
 			}
 		})
 	}
@@ -2353,10 +2289,7 @@ func TestTemplate_Validate(t *testing.T) {
 func TestConstraint_Validate(t *testing.T) {
 	c := &Constraint{}
 	err := c.Validate()
-	mErr := err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "Missing constraint operand") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err, "Missing constraint operand")
 
 	c = &Constraint{
 		LTarget: "$attr.kernel.name",
@@ -2370,25 +2303,18 @@ func TestConstraint_Validate(t *testing.T) {
 	c.Operand = ConstraintRegex
 	c.RTarget = "(foo"
 	err = c.Validate()
-	mErr = err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "missing closing") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err, "missing closing")
 
 	// Perform version validation
 	c.Operand = ConstraintVersion
 	c.RTarget = "~> foo"
 	err = c.Validate()
-	mErr = err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "Malformed constraint") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err, "Malformed constraint")
 
 	// Perform semver validation
 	c.Operand = ConstraintSemver
 	err = c.Validate()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "Malformed constraint")
+	requireMultierrorContaining(t, err, "Malformed constraint")
 
 	c.RTarget = ">= 0.6.1"
 	require.NoError(t, c.Validate())
@@ -2397,17 +2323,11 @@ func TestConstraint_Validate(t *testing.T) {
 	c.Operand = ConstraintDistinctProperty
 	c.RTarget = "0"
 	err = c.Validate()
-	mErr = err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "count of 1 or greater") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err, "count of 1 or greater")
 
 	c.RTarget = "-1"
 	err = c.Validate()
-	mErr = err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "to uint64") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err, "to uint64")
 
 	// Perform distinct_hosts validation
 	c.Operand = ConstraintDistinctHosts
@@ -2422,10 +2342,7 @@ func TestConstraint_Validate(t *testing.T) {
 	for _, o := range []string{ConstraintSetContains, ConstraintSetContainsAll, ConstraintSetContainsAny} {
 		c.Operand = o
 		err = c.Validate()
-		mErr = err.(*multierror.Error)
-		if !strings.Contains(mErr.Errors[0].Error(), "requires an RTarget") {
-			t.Fatalf("err: %s", err)
-		}
+		requireMultierrorContaining(t, err, "requires an RTarget")
 	}
 
 	// Perform LTarget validation
@@ -2433,18 +2350,12 @@ func TestConstraint_Validate(t *testing.T) {
 	c.RTarget = "foo"
 	c.LTarget = ""
 	err = c.Validate()
-	mErr = err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "No LTarget") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err, "No LTarget")
 
 	// Perform constraint type validation
 	c.Operand = "foo"
 	err = c.Validate()
-	mErr = err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "Unknown constraint type") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err, "Unknown constraint type")
 }
 
 func TestAffinity_Validate(t *testing.T) {
@@ -2547,31 +2458,16 @@ func TestUpdateStrategy_Validate(t *testing.T) {
 	}
 
 	err := u.Validate()
-	mErr := err.(*multierror.Error)
-	if !strings.Contains(mErr.Errors[0].Error(), "Invalid health check given") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[1].Error(), "Max parallel can not be less than zero") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[2].Error(), "Canary count can not be less than zero") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[3].Error(), "Minimum healthy time may not be less than zero") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[4].Error(), "Healthy deadline must be greater than zero") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[5].Error(), "Progress deadline must be zero or greater") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[6].Error(), "Minimum healthy time must be less than healthy deadline") {
-		t.Fatalf("err: %s", err)
-	}
-	if !strings.Contains(mErr.Errors[7].Error(), "Healthy deadline must be less than progress deadline") {
-		t.Fatalf("err: %s", err)
-	}
+	requireMultierrorContaining(t, err,
+		"Invalid health check given",
+		"Max parallel can not be less than zero",
+		"Canary count can not be less than zero",
+		"Minimum healthy time may not be less than zero",
+		"Healthy deadline must be greater than zero",
+		"Progress deadline must be zero or greater",
+		"Minimum healthy time must be less than healthy deadline",
+		"Healthy deadline must be less than progress deadline",
+	)
 }
 
 func TestResource_NetIndex(t *testing.T) {
@@ -5099,10 +4995,7 @@ func TestScalingPolicy_Validate(t *testing.T) {
 			err := c.input.Validate()
 
 			if len(c.expectedErr) > 0 {
-				require.Error(err)
-				mErr := err.(*multierror.Error)
-				require.Len(mErr.Errors, 1)
-				require.Contains(mErr.Errors[0].Error(), c.expectedErr)
+				requireMultierrorContaining(t, err, c.expectedErr)
 			} else {
 				require.NoError(err)
 			}
@@ -6023,4 +5916,31 @@ func TestTaskGroup_validateScriptChecksInGroupServices(t *testing.T) {
 		mErrOK := tgOK.validateScriptChecksInGroupServices()
 		require.Nil(t, mErrOK)
 	})
+}
+
+func requireMultierrorNotContaining(t *testing.T, err error, unexpected ...string) {
+	t.Helper()
+	require.Error(t, err)
+	mErr, ok := err.(*multierror.Error)
+	require.True(t, ok)
+
+	var found []string
+	for _, unex := range unexpected {
+		if strings.Contains(mErr.Error(), unex) {
+			found = append(found, unex)
+		}
+	}
+
+	require.Empty(t, found, "found unexpected error(s): %v", found)
+}
+
+func requireMultierrorContaining(t *testing.T, err error, expected ...string) {
+	t.Helper()
+	require.Error(t, err)
+	mErr, ok := err.(*multierror.Error)
+	require.True(t, ok)
+
+	for _, ex := range expected {
+		require.Contains(t, mErr.Error(), ex)
+	}
 }

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -46,7 +46,7 @@ func TestJob_Validate(t *testing.T) {
 		},
 	}
 	err = j.Validate()
-	requireMultierrorContaining(t, err, "Periodic")
+	require.Error(t, err, "Periodic")
 
 	j = &Job{
 		Region:      "global",
@@ -93,7 +93,7 @@ func TestJob_Validate(t *testing.T) {
 		Datacenters: []string{""},
 	}
 	err = j.Validate()
-	requireMultierrorContaining(t, err, "datacenter must be non-empty string")
+	require.Error(t, err, "datacenter must be non-empty string")
 }
 
 func TestJob_ValidateScaling(t *testing.T) {
@@ -126,7 +126,7 @@ func TestJob_ValidateScaling(t *testing.T) {
 	p.Min = 5
 	job.TaskGroups[0].Count = 5
 	err = job.Validate()
-	requireMultierrorContaining(t, err,
+	require.Error(err,
 		"task group count must not be greater than maximum count in scaling policy",
 	)
 
@@ -135,7 +135,7 @@ func TestJob_ValidateScaling(t *testing.T) {
 	p.Min = 5
 	p.Max = 5
 	err = job.Validate()
-	requireMultierrorContaining(t, err,
+	require.Error(err,
 		"task group count must not be less than minimum count in scaling policy",
 	)
 }
@@ -1014,7 +1014,7 @@ func TestTaskGroup_Validate(t *testing.T) {
 	}
 	j.Type = JobTypeBatch
 	err = tg.Validate(j)
-	requireMultierrorContaining(t, err, "does not allow update block")
+	require.Error(t, err, "does not allow update block")
 
 	tg = &TaskGroup{
 		Count: -1,
@@ -1312,7 +1312,7 @@ func TestTask_Validate(t *testing.T) {
 
 	task = &Task{Name: "web/foo"}
 	err = task.Validate(ephemeralDisk, JobTypeBatch, nil, nil)
-	requireMultierrorContaining(t, err, "slashes")
+	require.Error(t, err, "slashes")
 
 	task = &Task{
 		Name:   "web",
@@ -2057,7 +2057,7 @@ func TestTask_Validate_LogConfig(t *testing.T) {
 	}
 
 	err := task.Validate(ephemeralDisk, JobTypeService, nil, nil)
-	requireMultierrorContaining(t, err, "log storage")
+	require.Error(t, err, "log storage")
 }
 
 func TestLogConfig_Equals(t *testing.T) {
@@ -2289,7 +2289,7 @@ func TestTemplate_Validate(t *testing.T) {
 func TestConstraint_Validate(t *testing.T) {
 	c := &Constraint{}
 	err := c.Validate()
-	requireMultierrorContaining(t, err, "Missing constraint operand")
+	require.Error(t, err, "Missing constraint operand")
 
 	c = &Constraint{
 		LTarget: "$attr.kernel.name",
@@ -2303,18 +2303,18 @@ func TestConstraint_Validate(t *testing.T) {
 	c.Operand = ConstraintRegex
 	c.RTarget = "(foo"
 	err = c.Validate()
-	requireMultierrorContaining(t, err, "missing closing")
+	require.Error(t, err, "missing closing")
 
 	// Perform version validation
 	c.Operand = ConstraintVersion
 	c.RTarget = "~> foo"
 	err = c.Validate()
-	requireMultierrorContaining(t, err, "Malformed constraint")
+	require.Error(t, err, "Malformed constraint")
 
 	// Perform semver validation
 	c.Operand = ConstraintSemver
 	err = c.Validate()
-	requireMultierrorContaining(t, err, "Malformed constraint")
+	require.Error(t, err, "Malformed constraint")
 
 	c.RTarget = ">= 0.6.1"
 	require.NoError(t, c.Validate())
@@ -2323,11 +2323,11 @@ func TestConstraint_Validate(t *testing.T) {
 	c.Operand = ConstraintDistinctProperty
 	c.RTarget = "0"
 	err = c.Validate()
-	requireMultierrorContaining(t, err, "count of 1 or greater")
+	require.Error(t, err, "count of 1 or greater")
 
 	c.RTarget = "-1"
 	err = c.Validate()
-	requireMultierrorContaining(t, err, "to uint64")
+	require.Error(t, err, "to uint64")
 
 	// Perform distinct_hosts validation
 	c.Operand = ConstraintDistinctHosts
@@ -2342,7 +2342,7 @@ func TestConstraint_Validate(t *testing.T) {
 	for _, o := range []string{ConstraintSetContains, ConstraintSetContainsAll, ConstraintSetContainsAny} {
 		c.Operand = o
 		err = c.Validate()
-		requireMultierrorContaining(t, err, "requires an RTarget")
+		require.Error(t, err, "requires an RTarget")
 	}
 
 	// Perform LTarget validation
@@ -2350,12 +2350,12 @@ func TestConstraint_Validate(t *testing.T) {
 	c.RTarget = "foo"
 	c.LTarget = ""
 	err = c.Validate()
-	requireMultierrorContaining(t, err, "No LTarget")
+	require.Error(t, err, "No LTarget")
 
 	// Perform constraint type validation
 	c.Operand = "foo"
 	err = c.Validate()
-	requireMultierrorContaining(t, err, "Unknown constraint type")
+	require.Error(t, err, "Unknown constraint type")
 }
 
 func TestAffinity_Validate(t *testing.T) {
@@ -4995,7 +4995,7 @@ func TestScalingPolicy_Validate(t *testing.T) {
 			err := c.input.Validate()
 
 			if len(c.expectedErr) > 0 {
-				requireMultierrorContaining(t, err, c.expectedErr)
+				require.Error(err, c.expectedErr)
 			} else {
 				require.NoError(err)
 			}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -5931,7 +5931,7 @@ func requireMultierrorNotContaining(t *testing.T, err error, unexpected ...strin
 		}
 	}
 
-	require.Empty(t, found, "found unexpected error(s): %v", found)
+	require.Empty(t, found, "found unexpected error(s)")
 }
 
 func requireMultierrorContaining(t *testing.T, err error, expected ...string) {

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -2121,18 +2121,18 @@ func TestTask_Validate_CSIPluginConfig(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
-			task := &Task{
-				CSIPluginConfig: tt.pc,
-			}
+			task := testJob().TaskGroups[0].Tasks[0]
+			task.CSIPluginConfig = tt.pc
 			ephemeralDisk := &EphemeralDisk{
-				SizeMB: 1,
+				SizeMB: 100,
 			}
 
 			err := task.Validate(ephemeralDisk, JobTypeService, nil, nil)
 			if tt.expectedErr != "" {
-				requireMultierrorContaining(t, err, tt.expectedErr)
-			} else if tt.unexpectedErr != "" {
-				requireMultierrorNotContaining(t, err, tt.unexpectedErr)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedErr)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -5916,22 +5916,6 @@ func TestTaskGroup_validateScriptChecksInGroupServices(t *testing.T) {
 		mErrOK := tgOK.validateScriptChecksInGroupServices()
 		require.Nil(t, mErrOK)
 	})
-}
-
-func requireMultierrorNotContaining(t *testing.T, err error, unexpected ...string) {
-	t.Helper()
-	require.Error(t, err)
-	mErr, ok := err.(*multierror.Error)
-	require.True(t, ok)
-
-	var found []string
-	for _, e := range unexpected {
-		if strings.Contains(mErr.Error(), e) {
-			found = append(found, e)
-		}
-	}
-
-	require.Empty(t, found, "found unexpected error(s)")
 }
 
 func requireMultierrorContaining(t *testing.T, err error, expected ...string) {

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -5940,7 +5940,15 @@ func requireMultierrorContaining(t *testing.T, err error, expected ...string) {
 	mErr, ok := err.(*multierror.Error)
 	require.True(t, ok)
 
+	var found []string
 	for _, ex := range expected {
-		require.Contains(t, mErr.Error(), ex)
+		for _, actual := range mErr.Errors {
+			if strings.Contains(actual.Error(), ex) {
+				found = append(found, ex)
+				break
+			}
+		}
 	}
+
+	require.Equal(t, expected, found)
 }


### PR DESCRIPTION
Fixes: #6844

This adds two helpers to structs_test:
* `requireMultierrorContaining`
* `requireMultierrorNotContaining`

These helpers remove the tight coupling of the expected error count and ordering in the tests.