### PR TITLE
consul/connect: always set gateway proxy default timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 
+ * consul/connect: Fixed a bug where gateway proxy connection default timeout not set [[GH-9851](https://github.com/hashicorp/nomad/pull/9851)]
  * scheduler: Fixed a bug where shared ports were not persisted during inplace updates for service jobs. [[GH-9830](https://github.com/hashicorp/nomad/issues/9830)]
 
 ## 1.0.2 (January 14, 2020)

--- a/api/services.go
+++ b/api/services.go
@@ -335,6 +335,8 @@ type ConsulGatewayBindAddress struct {
 }
 
 var (
+	// defaultConnectTimeout is the default amount of time a connect gateway will
+	// wait for a response from an upstream service (same as consul)
 	defaultGatewayConnectTimeout = 5 * time.Second
 )
 

--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -12,6 +12,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// defaultConnectTimeout is the default amount of time a connect gateway will
+	// wait for a response from an upstream service (same as consul)
+	defaultConnectTimeout = 5 * time.Second
+)
+
 var (
 	// connectSidecarResources returns the set of resources used by default for
 	// the Consul Connect sidecar task
@@ -322,6 +328,11 @@ func gatewayProxyForBridge(gateway *structs.ConsulGateway) *structs.ConsulGatewa
 	if gateway.Proxy != nil {
 		proxy.ConnectTimeout = gateway.Proxy.ConnectTimeout
 		proxy.Config = gateway.Proxy.Config
+	}
+
+	// set default connect timeout if not set
+	if proxy.ConnectTimeout == nil {
+		proxy.ConnectTimeout = helper.TimeToPtr(defaultConnectTimeout)
 	}
 
 	// magically set the fields where Nomad knows what to do

--- a/nomad/job_endpoint_hook_connect_test.go
+++ b/nomad/job_endpoint_hook_connect_test.go
@@ -492,6 +492,7 @@ func TestJobEndpointConnect_gatewayProxyForBridge(t *testing.T) {
 			},
 		})
 		require.Equal(t, &structs.ConsulGatewayProxy{
+			ConnectTimeout:                  helper.TimeToPtr(defaultConnectTimeout),
 			EnvoyGatewayNoDefaultBind:       true,
 			EnvoyGatewayBindTaggedAddresses: false,
 			EnvoyGatewayBindAddresses: map[string]*structs.ConsulGatewayBindAddress{

--- a/vendor/github.com/hashicorp/nomad/api/services.go
+++ b/vendor/github.com/hashicorp/nomad/api/services.go
@@ -335,6 +335,8 @@ type ConsulGatewayBindAddress struct {
 }
 
 var (
+	// defaultConnectTimeout is the default amount of time a connect gateway will
+	// wait for a response from an upstream service (same as consul)
 	defaultGatewayConnectTimeout = 5 * time.Second
 )
 


### PR DESCRIPTION
If the connect.proxy stanza is left unset, the connection timeout
value is not set but is assumed to be, and may cause a non-fatal NPE
on job submission.