### PR TITLE
Don't prepend https to docker cred helper stdin

### DIFF
--- a/drivers/docker/driver_linux_test.go
+++ b/drivers/docker/driver_linux_test.go
@@ -42,7 +42,7 @@ func TestDockerDriver_authFromHelper(t *testing.T) {
 	}
 	content, err := ioutil.ReadFile(filepath.Join(dir, "helper-get.out"))
 	require.NoError(t, err)
-	require.Equal(t, []byte("https://registry.local:5000"), content)
+	require.Equal(t, "https://registry.local:5000", string(content))
 }
 
 func TestDockerDriver_PidsLimit(t *testing.T) {

--- a/drivers/docker/driver_linux_test.go
+++ b/drivers/docker/driver_linux_test.go
@@ -42,7 +42,7 @@ func TestDockerDriver_authFromHelper(t *testing.T) {
 	}
 	content, err := ioutil.ReadFile(filepath.Join(dir, "helper-get.out"))
 	require.NoError(t, err)
-	require.Equal(t, "https://registry.local:5000", string(content))
+	require.Equal(t, "registry.local:5000", string(content))
 }
 
 func TestDockerDriver_PidsLimit(t *testing.T) {

--- a/drivers/docker/utils.go
+++ b/drivers/docker/utils.go
@@ -153,10 +153,7 @@ func authFromHelper(helperName string) authBackend {
 			return nil, err
 		}
 
-		// Ensure that the HTTPs prefix exists
-		repoAddr := fmt.Sprintf("https://%s", repoInfo.Index.Name)
-
-		cmd.Stdin = strings.NewReader(repoAddr)
+		cmd.Stdin = strings.NewReader(repoInfo.Index.Name)
 		output, err := cmd.Output()
 		if err != nil {
 			switch err.(type) {


### PR DESCRIPTION
Fixes: #8316

Some credential helpers, like the ECR helper, will strip the protocol if
given. Others, like the linux "pass" helper, do not.