### PR TITLE
implement alloc runner task restart hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 
+ * consul: Fixed a bug where failing tasks with group services would only cause the allocation to restart once instead of respecting the `restart` field. [[GH-9869](https://github.com/hashicorp/nomad/issues/9869)]
  * consul/connect: Fixed a bug where gateway proxy connection default timeout not set [[GH-9851](https://github.com/hashicorp/nomad/pull/9851)]
  * consul/connect: Fixed a bug preventing more than one connect gateway per Nomad client [[GH-9849](https://github.com/hashicorp/nomad/pull/9849)]
  * scheduler: Fixed a bug where shared ports were not persisted during inplace updates for service jobs. [[GH-9830](https://github.com/hashicorp/nomad/issues/9830)]
@@ -16,7 +17,7 @@ IMPROVEMENTS:
  * consul/connect: Interpolate the connect, service meta, and service canary meta blocks with the task environment [[GH-9586](https://github.com/hashicorp/nomad/pull/9586)]
  * consul/connect: enable configuring custom gateway task [[GH-9639](https://github.com/hashicorp/nomad/pull/9639)]
  * cli: Added JSON/go template formatting to agent-info command. [[GH-9788](https://github.com/hashicorp/nomad/pull/9788)]
- 
+
 
 BUG FIXES:
  * client: Fixed a bug where non-`docker` tasks with network isolation were restarted on client restart. [[GH-9757](https://github.com/hashicorp/nomad/issues/9757)]

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -1138,6 +1138,9 @@ func (ar *allocRunner) Restart(ctx context.Context, event *structs.TaskEvent, fa
 	var err *multierror.Error
 	var errMutex sync.Mutex
 
+	// run alloc task restart hooks
+	ar.taskRestartHooks()
+
 	go func() {
 		var wg sync.WaitGroup
 		defer close(waitCh)
@@ -1169,6 +1172,9 @@ func (ar *allocRunner) Restart(ctx context.Context, event *structs.TaskEvent, fa
 // Returns any errors in a concatenated form.
 func (ar *allocRunner) RestartAll(taskEvent *structs.TaskEvent) error {
 	var err *multierror.Error
+
+	// run alloc task restart hooks
+	ar.taskRestartHooks()
 
 	for tn := range ar.tasks {
 		rerr := ar.RestartTask(tn, taskEvent.Copy())

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -360,3 +360,28 @@ func (ar *allocRunner) shutdownHooks() {
 		}
 	}
 }
+
+func (ar *allocRunner) taskRestartHooks() {
+	for _, hook := range ar.runnerHooks {
+		re, ok := hook.(interfaces.RunnerTaskRestartHook)
+		if !ok {
+			continue
+		}
+
+		name := re.Name()
+		var start time.Time
+		if ar.logger.IsTrace() {
+			start = time.Now()
+			ar.logger.Trace("running alloc task restart hook",
+				"name", name, "start", start)
+		}
+
+		re.PreTaskRestart()
+
+		if ar.logger.IsTrace() {
+			end := time.Now()
+			ar.logger.Trace("finished alloc task restart hook",
+				"name", name, "end", end, "duration", end.Sub(start))
+		}
+	}
+}

--- a/client/allocrunner/interfaces/runner_lifecycle.go
+++ b/client/allocrunner/interfaces/runner_lifecycle.go
@@ -55,6 +55,14 @@ type RunnerUpdateRequest struct {
 	Alloc *structs.Allocation
 }
 
+// RunnerTaskRestartHooks are executed just before the allocation runner is
+// going to restart all tasks.
+type RunnerTaskRestartHook interface {
+	RunnerHook
+
+	PreTaskRestart() error
+}
+
 // ShutdownHook may be implemented by AllocRunner or TaskRunner hooks and will
 // be called when the agent process is being shutdown gracefully.
 type ShutdownHook interface {

--- a/e2e/consul/check_restart.go
+++ b/e2e/consul/check_restart.go
@@ -1,0 +1,106 @@
+package consul
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	e2e "github.com/hashicorp/nomad/e2e/e2eutil"
+	"github.com/hashicorp/nomad/e2e/framework"
+	"github.com/hashicorp/nomad/helper/uuid"
+)
+
+const ns = ""
+
+type CheckRestartE2ETest struct {
+	framework.TC
+	jobIds []string
+}
+
+func (tc *CheckRestartE2ETest) BeforeAll(f *framework.F) {
+	e2e.WaitForLeader(f.T(), tc.Nomad())
+	e2e.WaitForNodesReady(f.T(), tc.Nomad(), 1)
+}
+
+func (tc *CheckRestartE2ETest) AfterEach(f *framework.F) {
+	if os.Getenv("NOMAD_TEST_SKIPCLEANUP") == "1" {
+		return
+	}
+
+	for _, id := range tc.jobIds {
+		_, err := e2e.Command("nomad", "job", "stop", "-purge", id)
+		f.Assert().NoError(err)
+	}
+	tc.jobIds = []string{}
+	_, err := e2e.Command("nomad", "system", "gc")
+	f.Assert().NoError(err)
+}
+
+// TestGroupCheckRestart runs a job with a group service that will never
+// become healthy. Both tasks should be restarted up to the 'restart' limit.
+func (tc *CheckRestartE2ETest) TestGroupCheckRestart(f *framework.F) {
+
+	jobID := "test-group-check-restart-" + uuid.Short()
+	f.NoError(e2e.Register(jobID, "consul/input/checks_group_restart.nomad"))
+	tc.jobIds = append(tc.jobIds, jobID)
+
+	var allocID string
+
+	f.NoError(
+		e2e.WaitForAllocStatusComparison(
+			func() ([]string, error) { return e2e.AllocStatuses(jobID, ns) },
+			func(got []string) bool { return reflect.DeepEqual(got, []string{"failed"}) },
+			&e2e.WaitConfig{Interval: time.Second * 10, Retries: 30},
+		))
+
+	expected := "Exceeded allowed attempts 2 in interval 5m0s and mode is \"fail\""
+
+	out, err := e2e.Command("nomad", "alloc", "status", allocID)
+	f.NoError(err, "could not get allocation status")
+	f.Contains(out, expected,
+		fmt.Errorf("expected '%s', got\n%v", expected, out))
+
+	re := regexp.MustCompile(`Total Restarts += (.*)\n`)
+	match := re.FindAllStringSubmatch(out, -1)
+	for _, m := range match {
+		f.Equal("2", strings.TrimSpace(m[1]),
+			fmt.Errorf("expected exactly 2 restarts for both tasks, got:\n%v", out))
+	}
+}
+
+// TestTaskCheckRestart runs a job with a task service that will never become
+// healthy. Only the failed task should be restarted up to the 'restart'
+// limit.
+func (tc *CheckRestartE2ETest) TestTaskCheckRestart(f *framework.F) {
+
+	jobID := "test-task-check-restart-" + uuid.Short()
+	f.NoError(e2e.Register(jobID, "consul/input/checks_task_restart.nomad"))
+	tc.jobIds = append(tc.jobIds, jobID)
+
+	var allocID string
+
+	f.NoError(
+		e2e.WaitForAllocStatusComparison(
+			func() ([]string, error) { return e2e.AllocStatuses(jobID, ns) },
+			func(got []string) bool { return reflect.DeepEqual(got, []string{"failed"}) },
+			&e2e.WaitConfig{Interval: time.Second * 10, Retries: 30},
+		))
+
+	expected := "Exceeded allowed attempts 2 in interval 5m0s and mode is \"fail\""
+
+	out, err := e2e.Command("nomad", "alloc", "status", allocID)
+	f.NoError(err, "could not get allocation status")
+	f.Contains(out, expected,
+		fmt.Errorf("expected '%s', got\n%v", expected, out))
+
+	re := regexp.MustCompile(`Total Restarts += (.*)\n`)
+	match := re.FindAllStringSubmatch(out, -1)
+	f.Equal("2", strings.TrimSpace(match[0][1]),
+		fmt.Errorf("expected exactly 2 restarts for failed task, got:\n%v", out))
+
+	f.Equal("0", strings.TrimSpace(match[1][1]),
+		fmt.Errorf("expected exactly no restarts for healthy task, got:\n%v", out))
+}

--- a/e2e/consul/consul.go
+++ b/e2e/consul/consul.go
@@ -35,6 +35,7 @@ func init() {
 		Cases: []framework.TestCase{
 			new(ConsulE2ETest),
 			new(ScriptChecksE2ETest),
+			new(CheckRestartE2ETest),
 		},
 	})
 }

--- a/e2e/consul/input/checks_group_restart.nomad
+++ b/e2e/consul/input/checks_group_restart.nomad
@@ -1,0 +1,64 @@
+job "group_check_restart" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "group_check_restart" {
+    network {
+      mode = "bridge"
+    }
+
+    restart {
+      attempts = 2
+      delay    = "1s"
+      interval = "5m"
+      mode     = "fail"
+    }
+
+    service {
+      name = "group-service-1"
+      port = "9003"
+
+      # this check should always time out and so the service
+      # should not be marked healthy, resulting in the tasks
+      # getting restarted
+      check {
+        name     = "always-dead"
+        type     = "script"
+        task     = "fail"
+        interval = "2s"
+        timeout  = "1s"
+        command  = "sleep"
+        args     = ["10"]
+
+        check_restart {
+          limit           = 2
+          grace           = "5s"
+          ignore_warnings = false
+        }
+      }
+    }
+
+    task "fail" {
+      driver = "raw_exec"
+
+      config {
+        command = "bash"
+        args    = ["-c", "sleep 15000"]
+      }
+    }
+
+    task "ok" {
+      driver = "raw_exec"
+
+      config {
+        command = "bash"
+        args    = ["-c", "sleep 15000"]
+      }
+    }
+  }
+}

--- a/e2e/consul/input/checks_task_restart.nomad
+++ b/e2e/consul/input/checks_task_restart.nomad
@@ -1,0 +1,63 @@
+job "task_check" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "task_check" {
+    count = 1
+
+    restart {
+      attempts = 2
+      delay    = "1s"
+      interval = "5m"
+      mode     = "fail"
+    }
+
+    task "fail" {
+
+      service {
+        name = "task-service-1"
+
+        # this check should always time out and so the service
+        # should not be marked healthy
+        check {
+          name     = "always-dead"
+          type     = "script"
+          interval = "2s"
+          timeout  = "1s"
+          command  = "sleep"
+          args     = ["10"]
+
+          check_restart {
+            limit           = 2
+            grace           = "5s"
+            ignore_warnings = false
+          }
+
+        }
+      }
+
+      driver = "raw_exec"
+
+      config {
+        command = "bash"
+        args    = ["-c", "sleep 15000"]
+      }
+    }
+
+
+    task "ok" {
+      driver = "raw_exec"
+
+      config {
+        command = "bash"
+        args    = ["-c", "sleep 15000"]
+      }
+    }
+
+  }
+}

--- a/website/content/docs/job-specification/check_restart.mdx
+++ b/website/content/docs/job-specification/check_restart.mdx
@@ -16,10 +16,6 @@ description: |-
   ]}
 />
 
-~> The `check_restart` stanza in Nomad is only supported for task networks,
-_not_ group networks. Please follow [#9176][gh-9176] to be notified when
-this is fixed.
-
 As of Nomad 0.7 the `check_restart` stanza instructs Nomad when to restart
 tasks with unhealthy service checks. When a health check in Consul has been
 unhealthy for the `limit` specified in a `check_restart` stanza, it is


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9176

Most allocation hooks don't need to know when a single task within the
allocation is restarted. The check watcher for group services triggers the
alloc runner to restart all tasks, but the alloc runner's `Restart` method
doesn't trigger any of the alloc hooks, including the group service hook. The
result is that after the first time a check triggers a restart, we'll never
restart the tasks of an allocation again.

This commit adds a `RunnerTaskRestartHook` interface so that alloc runner
hooks can act if a task within the alloc is restarted. The only implementation
is in the group service hook, which will force a re-registration of the
alloc's services and fix check restarts.