### PR TITLE
UI: Use the same prefix pattern for both the region switcher and the namespace switcher

### DIFF
--- a/ui/app/styles/components/dropdown.scss
+++ b/ui/app/styles/components/dropdown.scss
@@ -122,6 +122,7 @@
 .ember-power-select-selected-item,
 .dropdown-item {
   text-overflow: ellipsis;
+  overflow: hidden;
   white-space: nowrap;
 }
 

--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -36,6 +36,7 @@
                 @onChange={{action this.gotoJobsForNamespace}}
                 @tagName="div"
                 @class="namespace-switcher"
+                title={{this.system.activeNamespace.name}}
                 as |namespace|>
                 <span class="ember-power-select-prefix">Namespace: </span>{{namespace.name}}
               </PowerSelect>

--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -37,11 +37,7 @@
                 @tagName="div"
                 @class="namespace-switcher"
                 as |namespace|>
-                {{#if (eq namespace.name "default")}}
-                  Default Namespace
-                {{else}}
-                  {{namespace.name}}
-                {{/if}}
+                <span class="ember-power-select-prefix">Namespace: </span>{{namespace.name}}
               </PowerSelect>
             </div>
           </li>

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -130,12 +130,11 @@ module('Acceptance | job detail (with namespaces)', function(hooks) {
   test('when switching namespaces, the app redirects to /jobs with the new namespace', async function(assert) {
     const namespace = server.db.namespaces.find(job.namespaceId);
     const otherNamespace = server.db.namespaces.toArray().find(ns => ns !== namespace).name;
-    const label = otherNamespace === 'default' ? 'Default Namespace' : otherNamespace;
 
     await JobDetail.visit({ id: job.id, namespace: namespace.name });
 
     // TODO: Migrate to Page Objects
-    await selectChoose('[data-test-namespace-switcher]', label);
+    await selectChoose('[data-test-namespace-switcher]', otherNamespace);
     assert.equal(currentURL().split('?')[0], '/jobs', 'Navigated to /jobs');
 
     const jobs = server.db.jobs

--- a/ui/tests/acceptance/namespaces-test.js
+++ b/ui/tests/acceptance/namespaces-test.js
@@ -69,7 +69,7 @@ module('Acceptance | namespaces (enabled)', function(hooks) {
     );
     assert.equal(
       JobsList.namespaceSwitcher.options.objectAt(0).label,
-      'Default Namespace',
+      'Namespace: default',
       'The first namespace is always the default one'
     );
 
@@ -79,7 +79,11 @@ module('Acceptance | namespaces (enabled)', function(hooks) {
       if (index === 0) return;
 
       const namespace = sortedNamespaces[index - 1];
-      assert.equal(option.label, namespace.name, `index ${index}: ${namespace.name}`);
+      assert.equal(
+        option.label,
+        `Namespace: ${namespace.name}`,
+        `index ${index}: ${namespace.name}`
+      );
     });
   });
 


### PR DESCRIPTION
Fixes #9814 

This makes the UI more consistent and also correctly displays the `default` namespace as "default" instead of "Default".

![Region and namespace switcher both labeled by subdued prefixes](https://user-images.githubusercontent.com/174740/105544031-5f219280-5caf-11eb-8ca0-b7db199364d9.png)
