### PR TITLE
UI: Fix audit workflow action versions

### DIFF
--- a/.github/workflows/ember-test-audit.yml
+++ b/.github/workflows/ember-test-audit.yml
@@ -77,7 +77,7 @@ jobs:
           files: "flakiness-report.md"
       - name: comment PR
         if: steps.check_file.outputs.files_exists == 'true'
-        uses: machine-learning-apps/pr-comment@v1
+        uses: machine-learning-apps/pr-comment@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/ember-test-audit.yml
+++ b/.github/workflows/ember-test-audit.yml
@@ -66,7 +66,7 @@ jobs:
           comparison-identifier: ${{ github.event.pull_request.head.sha }}
           timing-output-path: audit-diff.md
           flakiness-output-path: flakiness-report.md
-      - uses: marocchino/sticky-pull-request-comment@33a6cfb
+      - uses: marocchino/sticky-pull-request-comment@v2.0.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           path: audit-diff.md


### PR DESCRIPTION
This fixes the version reference error seen in [this](https://github.com/hashicorp/nomad/actions/runs/504695096) workflow failure.

I’ve also included an update to the sticky comment action version to address this warning in the above link:

```
marocchino/sticky-pull-request-comment@33a6cfb looks like the shortened version of a commit SHA. Referencing actions by the short SHA will be disabled soon. Please see https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions.
```

We were previously using `33a6cfb` after the maintainer merged [my PR](https://github.com/marocchino/sticky-pull-request-comment/pull/118) to allow the comment to be read from a file, there was no released version with that, but it’s now included in `v2.0.0`.