### PR TITLE
Adds community USB plugin to documentation site

### DIFF
--- a/website/content/docs/devices/external/index.mdx
+++ b/website/content/docs/devices/external/index.mdx
@@ -11,6 +11,15 @@ If you have authored a device plugin that you believe will be useful to the
 broader Nomad community and you are committed to maintaining the plugin, please
 file a PR to add your plugin to this page.
 
+## Device Plugins
+
+Nomad has a plugin system for defining task drivers. External device driver
+plugins will have the same user experience as built in devices.
+
+Below is a list of community-supported task drivers you can use with Nomad:
+
+- [USB][usb]
+
 ## Authoring Device Plugins
 
 Nomad has a plugin system for defining device drivers. External device plugins
@@ -19,3 +28,4 @@ authoring a device plugin, please refer to the [plugin authoring
 guide][plugin_guide].
 
 [plugin_guide]: /docs/internals/plugins
+[usb]: /docs/devices/external/usb

--- a/website/content/docs/devices/external/usb.mdx
+++ b/website/content/docs/devices/external/usb.mdx
@@ -9,106 +9,50 @@ description: The USB Device Plugin detects and makes USB devices available to ta
 
 Name: `usb`
 
-The `usb` device plugin is used to expose USB devices to Nomad. The USB plugin is not included
-within Nomad and requires downloading and providing on each node.
+The `usb` device plugin is used to expose USB devices to Nomad. The USB plugin
+is not included within Nomad and requires downloading and providing on each
+node.
 
 ## Fingerprinted Attributes
 
-<table>
-  <thead>
-    <tr>
-      <th>Attribute</th>
-      <th>Unit</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <tt>vendor_id</tt>
-      </td>
-      <td>int</td>
-      <td>USB VID in decimal format</td>
-    </tr>
-    <tr>
-      <td>
-        <tt>product_id</tt>
-      </td>
-      <td>int</td>
-      <td>USB PID in decimal format</td>
-    </tr>
-    <tr>
-      <td>
-        <tt>class_id</tt>
-      </td>
-      <td>int</td>
-      <td>USB Class code in decimal format</td>
-    </tr>
-    <tr>
-      <td>
-        <tt>sub_class_id</tt>
-      </td>
-      <td>int</td>
-      <td>USB SubClass code in decimal format</td>
-    </tr>
-    <tr>
-      <td>
-        <tt>protocol_id</tt>
-      </td>
-      <td>int</td>
-      <td>USB Protocol code in decimal format</td>
-    </tr>
-    <tr>
-      <td>
-        <tt>vendor</tt>
-      </td>
-      <td>string</td>
-      <td>Human readable vendor</td>
-    </tr>
-    <tr>
-      <td>
-        <tt>product</tt>
-      </td>
-      <td>string</td>
-      <td>Human readable product</td>
-    </tr>
-    <tr>
-      <td>
-        <tt>description</tt>
-      </td>
-      <td>string</td>
-      <td>Human readable description of the USB device</td>
-    </tr>
-    <tr>
-      <td>
-        <tt>classification</tt>
-      </td>
-      <td>string</td>
-      <td>Human readable classification of the USB device</td>
-    </tr>
-  </tbody>
-</table>
+| Attribute        | Unit   | Description                                     |
+|------------------|--------|-------------------------------------------------|
+| `vendor_id`      | int    | USB VID in decimal format                       |
+| `product_id`     | int    | USB PID in decimal format                       |
+| `class_id`       | int    | USB Class code in decimal format                |
+| `sub_class_id`   | int    | USB SubClass code in decimal format             |
+| `protocol_id`    | int    | USB Protocol code in decimal format             |
+| `vendor`         | string | Human readable vendor                           |
+| `product`        | string | Human readable product                          |
+| `description`    | string | Human readable description of the USB device    |
+| `classification` | string | Human readable classification of the USB device |
 
 ## Runtime Environment
 
 The `usb` device plugin exposes the following environment variables:
 
-- `USB_VISIBLE_DEVICES` - List of USB IDs (from the plugin) available to the task. 
+- `USB_VISIBLE_DEVICES` - List of USB IDs (from the plugin) available to the task.
 
 ## Installation Requirements
 
-In order to use the `usb` device plugin the following prerequisites must be met:
+In order to use the `usb` device plugin the following prerequisites must be
+met:
 
-1. GNU/Linux i368/amd64/armv7/arm64 (Other Architectures and OS may work but have not been tested)
+1. GNU/Linux i368/amd64/armv7/arm64 (Other Architectures and OS may work but
+   have not been tested)
 2. [libusb-1.0](https://github.com/libusb/libusb/wiki) installed
 
 ## Installation
 
-To install the `usb` device plugin you will first need to download the binary for your Nomad client. You can find the
-latest release of these binaries on the [release page](https://gitlab.com/CarbonCollins/nomad-usb-device-plugin/-/releases).
+To install the `usb` device plugin you will first need to download the binary
+for your Nomad client. You can find the latest release of these binaries on
+the [release
+page](https://gitlab.com/CarbonCollins/nomad-usb-device-plugin/-/releases).
 
-This binary needs to be downloaded into the plugins directory of the Nomad node and the plugin stanza then needs to be
-added. A full example of the plugin stanza needed for the `usb` driver can be found under the plugin configuration section.
+This binary needs to be downloaded into the plugins directory of the Nomad
+node and the plugin stanza then needs to be added. A full example of the
+plugin stanza needed for the `usb` driver can be found under the plugin
+configuration section.
 
 ## Plugin Configuration
 
@@ -130,45 +74,58 @@ plugin "usb" {
 
 The `usb` device plugin supports the following configuration in the agent config:
 
-- `enabled` `(bool: true)` - the `usb` driver may be disabled on osts by setting this option to `false` (defaults to `true`).
+- `enabled` `(bool: true)` - the `usb` driver may be disabled on clients by
+  setting this option to `false` (defaults to `true`).
 
-- `included_vendor_ids` (`array<uint16>: []`): An array of VIDs to pass to nomad if found
+- `included_vendor_ids` (`array<uint16>: []`): An array of VIDs to pass to
+  nomad if found
 
-- `excluded_vendor_ids` (`array<uint16>: []`): An array of VIDs to not pass to nomad if found (this takes priority over the include list)
+- `excluded_vendor_ids` (`array<uint16>: []`): An array of VIDs to not pass to
+  nomad if found (this takes priority over the include list)
 
-- `included_product_ids` (`array<uint16>: []`): An array of PIDs to pass to nomad if found
+- `included_product_ids` (`array<uint16>: []`): An array of PIDs to pass to
+  nomad if found
 
-- `excluded_product_ids` (`array<uint16>: []`): An array of PIDs to not pass to nomad if found (this takes priority over the include list)
+- `excluded_product_ids` (`array<uint16>: []`): An array of PIDs to not pass
+  to nomad if found (this takes priority over the include list)
 
-- `fingerprint_period` `(string: "1m")` - The period in which to fingerprint for device changes.
+- `fingerprint_period` `(string: "1m")` - The period in which to fingerprint
+  for device changes.
 
 ## Limitations
 
-Currently the `usb` driver does not automatically provide dev paths for the USB devices into the task, this means in
-containerised applications you will still have to supply the dev path manually e.g. `/dev/ttyUSB0` however this plugin does
-allow containerised tasks to only be deployed on nodes which have specified USB devices connected.
+Currently the `usb` driver does not automatically provide dev paths for the
+USB devices into the task, this means in containerized applications you will
+still have to supply the dev path manually e.g. `/dev/ttyUSB0` however this
+plugin does allow containerized tasks to only be deployed on nodes which have
+specified USB devices connected.
 
 ## Other Information
 
-The `usb` device plugin is currently in beta and thus is not recomended for production use. This will remain the case
-until the current limitations have been solved with the plugin. If you find any issues with the `usb` plugin please raise
-an issue on the plugins [issues page](https://gitlab.com/CarbonCollins/nomad-usb-device-plugin/-/issues/new?issue)
+The `usb` device plugin is currently in beta and thus is not recommended for
+production use. This will remain the case until the current limitations have
+been solved with the plugin. If you find any issues with the `usb` plugin
+please raise an issue on the plugins [issues
+page](https://gitlab.com/CarbonCollins/nomad-usb-device-plugin/-/issues/new?issue)
 
 ### USB Codes
 
-For a full list of availble class, subsclass, and protocol codes you can see the [usb-if-defined-class-codes](https://www.usb.org/defined-class-codes)
-page on the usb
+For a full list of available class, subclass, and protocol codes you can see
+the [usb-if-defined-class-codes](https://www.usb.org/defined-class-codes) page
+on the usb
 
 ### USB Vendors & Products
 
-There are several sources where you can find known vendor and product ids for USB devices. These are independently
-maintained lists from third parties but can be useful as a reference.
+There are several sources where you can find known vendor and product ids for
+USB devices. These are independently maintained lists from third parties but
+can be useful as a reference.
 
 - [linux-usb.org](http://www.linux-usb.org/)
 - [devicehunt.com](https://devicehunt.com/all-usb-vendors)
 
 ### Source Code & Compiled Binaries
 
-The source code for this plugin can be found at [CarbonCollins/nomad-usb-device-plugin](https://gitlab.com/CarbonCollins/nomad-usb-device-plugin).
-You will also find pre built binaries on the [releases page](https://gitlab.com/CarbonCollins/nomad-usb-device-plugin/-/releases).
-
+The source code for this plugin can be found at
+[CarbonCollins/nomad-usb-device-plugin](https://gitlab.com/CarbonCollins/nomad-usb-device-plugin). You
+will also find pre built binaries on the [releases
+page](https://gitlab.com/CarbonCollins/nomad-usb-device-plugin/-/releases).

--- a/website/content/docs/devices/external/usb.mdx
+++ b/website/content/docs/devices/external/usb.mdx
@@ -1,0 +1,174 @@
+---
+layout: docs
+page_title: 'Devices: USB'
+sidebar_title: USB <sup>Beta</sup>
+description: The USB Device Plugin detects and makes USB devices available to tasks
+---
+
+# USB Device Plugin
+
+Name: `usb`
+
+The `usb` device plugin is used to expose USB devices to Nomad. The USB plugin is not included
+within Nomad and requires downloading and providing on each node.
+
+## Fingerprinted Attributes
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute</th>
+      <th>Unit</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <tt>vendor_id</tt>
+      </td>
+      <td>int</td>
+      <td>USB VID in decimal format</td>
+    </tr>
+    <tr>
+      <td>
+        <tt>product_id</tt>
+      </td>
+      <td>int</td>
+      <td>USB PID in decimal format</td>
+    </tr>
+    <tr>
+      <td>
+        <tt>class_id</tt>
+      </td>
+      <td>int</td>
+      <td>USB Class code in decimal format</td>
+    </tr>
+    <tr>
+      <td>
+        <tt>sub_class_id</tt>
+      </td>
+      <td>int</td>
+      <td>USB SubClass code in decimal format</td>
+    </tr>
+    <tr>
+      <td>
+        <tt>protocol_id</tt>
+      </td>
+      <td>int</td>
+      <td>USB Protocol code in decimal format</td>
+    </tr>
+    <tr>
+      <td>
+        <tt>vendor</tt>
+      </td>
+      <td>string</td>
+      <td>Human readable vendor</td>
+    </tr>
+    <tr>
+      <td>
+        <tt>product</tt>
+      </td>
+      <td>string</td>
+      <td>Human readable product</td>
+    </tr>
+    <tr>
+      <td>
+        <tt>description</tt>
+      </td>
+      <td>string</td>
+      <td>Human readable description of the USB device</td>
+    </tr>
+    <tr>
+      <td>
+        <tt>classification</tt>
+      </td>
+      <td>string</td>
+      <td>Human readable classification of the USB device</td>
+    </tr>
+  </tbody>
+</table>
+
+## Runtime Environment
+
+The `usb` device plugin exposes the following environment variables:
+
+- `USB_VISIBLE_DEVICES` - List of USB IDs (from the plugin) available to the task. 
+
+## Installation Requirements
+
+In order to use the `usb` device plugin the following prerequisites must be met:
+
+1. GNU/Linux i368/amd64/armv7/arm64 (Other Architectures and OS may work but have not been tested)
+2. [libusb-1.0](https://github.com/libusb/libusb/wiki) installed
+
+## Installation
+
+To install the `usb` device plugin you will first need to download the binary for your Nomad client. You can find the
+latest release of these binaries on the [release page](https://gitlab.com/CarbonCollins/nomad-usb-device-plugin/-/releases).
+
+This binary needs to be downloaded into the plugins directory of the Nomad node and the plugin stanza then needs to be
+added. A full example of the plugin stanza needed for the `usb` driver can be found under the plugin configuration section.
+
+## Plugin Configuration
+
+```hcl
+plugin "usb" {
+  config {
+    enabled = true
+
+    included_vendor_ids = [0x1CF1, 0x067b]
+    excluded_vendor_ids = []
+
+    included_product_ids = [0x0030, 0x2303]
+    excluded_product_ids = []
+
+    fingerprint_period = "1m"
+  }
+}
+```
+
+The `usb` device plugin supports the following configuration in the agent config:
+
+- `enabled` `(bool: true)` - the `usb` driver may be disabled on osts by setting this option to `false` (defaults to `true`).
+
+- `included_vendor_ids` (`array<uint16>: []`): An array of VIDs to pass to nomad if found
+
+- `excluded_vendor_ids` (`array<uint16>: []`): An array of VIDs to not pass to nomad if found (this takes priority over the include list)
+
+- `included_product_ids` (`array<uint16>: []`): An array of PIDs to pass to nomad if found
+
+- `excluded_product_ids` (`array<uint16>: []`): An array of PIDs to not pass to nomad if found (this takes priority over the include list)
+
+- `fingerprint_period` `(string: "1m")` - The period in which to fingerprint for device changes.
+
+## Limitations
+
+Currently the `usb` driver does not automatically provide dev paths for the USB devices into the task, this means in
+containerised applications you will still have to supply the dev path manually e.g. `/dev/ttyUSB0` however this plugin does
+allow containerised tasks to only be deployed on nodes which have specified USB devices connected.
+
+## Other Information
+
+The `usb` device plugin is currently in beta and thus is not recomended for production use. This will remain the case
+until the current limitations have been solved with the plugin. If you find any issues with the `usb` plugin please raise
+an issue on the plugins [issues page](https://gitlab.com/CarbonCollins/nomad-usb-device-plugin/-/issues/new?issue)
+
+### USB Codes
+
+For a full list of availble class, subsclass, and protocol codes you can see the [usb-if-defined-class-codes](https://www.usb.org/defined-class-codes)
+page on the usb
+
+### USB Vendors & Products
+
+There are several sources where you can find known vendor and product ids for USB devices. These are independently
+maintained lists from third parties but can be useful as a reference.
+
+- [linux-usb.org](http://www.linux-usb.org/)
+- [devicehunt.com](https://devicehunt.com/all-usb-vendors)
+
+### Source Code & Compiled Binaries
+
+The source code for this plugin can be found at [CarbonCollins/nomad-usb-device-plugin](https://gitlab.com/CarbonCollins/nomad-usb-device-plugin).
+You will also find pre built binaries on the [releases page](https://gitlab.com/CarbonCollins/nomad-usb-device-plugin/-/releases).
+

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -397,7 +397,15 @@ export default [
   },
   {
     category: 'devices',
-    content: ['nvidia', 'community'],
+    content: [
+      'nvidia',
+      {
+        category: 'external',
+        content: [
+          'usb'
+        ]
+      }
+    ],
   },
   'schedulers',
   { category: 'runtime', content: ['environment', 'interpolation'] },


### PR DESCRIPTION
Adds a community device plugin page for the [usb device plugin](https://gitlab.com/CarbonCollins/nomad-usb-device-plugin).

I believe I have updated the javascript file that was referenced in #9806 and have updated the device plugin community page to become a sub list of device plugins so others can be added in the future.