### PR TITLE
Add extra Docker labels ( job name, task and task group name)

### DIFF
--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -980,7 +980,11 @@ func (tr *TaskRunner) buildTaskConfig() *drivers.TaskConfig {
 		ID:            fmt.Sprintf("%s/%s/%s", alloc.ID, task.Name, invocationid),
 		Name:          task.Name,
 		JobName:       alloc.Job.Name,
+		JobID:         alloc.Job.ID,
 		TaskGroupName: alloc.TaskGroup,
+		Namespace:     alloc.Namespace,
+		NodeName:      alloc.NodeName,
+		NodeID:        alloc.NodeID,
 		Resources: &drivers.Resources{
 			NomadResources: taskResources,
 			LinuxResources: &drivers.LinuxResources{

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -612,6 +612,7 @@ type DriverConfig struct {
 	DisableLogCollection          bool          `codec:"disable_log_collection"`
 	PullActivityTimeout           string        `codec:"pull_activity_timeout"`
 	pullActivityTimeoutDuration   time.Duration `codec:"-"`
+	ExtraLabels                   []string      `codec:"extra_labels"`
 
 	AllowRuntimesList []string            `codec:"allow_runtimes"`
 	allowRuntimes     map[string]struct{} `codec:"-"`

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -203,6 +203,9 @@ var (
 			"ca":   hclspec.NewAttr("ca", "string", false),
 		})),
 
+		// extra docker labels, globs supported
+		"extra_labels": hclspec.NewAttr("extra_labels", "list(string)", false),
+
 		// garbage collection options
 		// default needed for both if the gc {...} block is not set and
 		// if the default fields are missing

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1127,25 +1127,25 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 
 	//optional labels, as configured in plugin configuration
 	for _, configurationExtraLabel := range d.config.ExtraLabels {
-		if glob.Glob(configurationExtraLabel, strings.Split(dockerLabelJobName, ".")[3]) {
+		if glob.Glob(configurationExtraLabel, "job_name") {
 			labels[dockerLabelJobName] = task.JobName
 		}
-		if glob.Glob(configurationExtraLabel, strings.Split(dockerLabelJobID, ".")[3]) {
+		if glob.Glob(configurationExtraLabel, "job_id") {
 			labels[dockerLabelJobID] = task.JobID
 		}
-		if glob.Glob(configurationExtraLabel, strings.Split(dockerLabelTaskGroupName, ".")[3]) {
+		if glob.Glob(configurationExtraLabel, "task_group_name") {
 			labels[dockerLabelTaskGroupName] = task.TaskGroupName
 		}
-		if glob.Glob(configurationExtraLabel, strings.Split(dockerLabelTaskName, ".")[3]) {
+		if glob.Glob(configurationExtraLabel, "task_name") {
 			labels[dockerLabelTaskName] = task.Name
 		}
-		if glob.Glob(configurationExtraLabel, strings.Split(dockerLabelNamespace, ".")[3]) {
+		if glob.Glob(configurationExtraLabel, "namespace") {
 			labels[dockerLabelNamespace] = task.Namespace
 		}
-		if glob.Glob(configurationExtraLabel, strings.Split(dockerLabelNodeName, ".")[3]) {
+		if glob.Glob(configurationExtraLabel, "node_name") {
 			labels[dockerLabelNodeName] = task.NodeName
 		}
-		if glob.Glob(configurationExtraLabel, strings.Split(dockerLabelNodeID, ".")[3]) {
+		if glob.Glob(configurationExtraLabel, "node_id") {
 			labels[dockerLabelNodeID] = task.NodeID
 		}
 	}

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -70,7 +70,10 @@ var (
 )
 
 const (
-	dockerLabelAllocID = "com.hashicorp.nomad.alloc_id"
+	dockerLabelAllocID       = "com.hashicorp.nomad.alloc_id"
+	dockerLabelJobName       = "com.hashicorp.nomad.job_name"
+	dockerLabelTaskGroupName = "com.hashicorp.nomad.task_group_name"
+	dockerLabelTaskName      = "com.hashicorp.nomad.task_name"
 )
 
 type Driver struct {
@@ -1115,6 +1118,10 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		labels[k] = v
 	}
 	labels[dockerLabelAllocID] = task.AllocID
+	labels[dockerLabelJobName] = task.JobName
+	labels[dockerLabelTaskGroupName] = task.TaskGroupName
+	labels[dockerLabelTaskName] = task.Name
+
 	config.Labels = labels
 	logger.Debug("applied labels on the container", "labels", config.Labels)
 

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -1065,11 +1065,8 @@ func TestDockerDriver_CreateContainerConfig_Labels(t *testing.T) {
 	expectedLabels := map[string]string{
 		// user provided labels
 		"user_label": "user_value",
-		// default labels
+		// default label
 		"com.hashicorp.nomad.alloc_id":        task.AllocID,
-		"com.hashicorp.nomad.job_name":        task.JobName,
-		"com.hashicorp.nomad.task_group_name": task.TaskGroupName,
-		"com.hashicorp.nomad.task_name":       task.Name,
 	}
 
 	require.Equal(t, expectedLabels, c.Config.Labels)

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -799,8 +799,8 @@ func TestDockerDriver_Labels(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// expect to see 1 additional standard labels
-	require.Equal(t, len(cfg.Labels)+1, len(container.Config.Labels))
+	// expect to see 4 additional standard labels (allocID, jobName, TaskGroupName and TaskName)
+	require.Equal(t, len(cfg.Labels)+4, len(container.Config.Labels))
 	for k, v := range cfg.Labels {
 		require.Equal(t, v, container.Config.Labels[k])
 	}
@@ -1066,7 +1066,10 @@ func TestDockerDriver_CreateContainerConfig_Labels(t *testing.T) {
 		// user provided labels
 		"user_label": "user_value",
 		// default labels
-		"com.hashicorp.nomad.alloc_id": task.AllocID,
+		"com.hashicorp.nomad.alloc_id":        task.AllocID,
+		"com.hashicorp.nomad.job_name":        task.JobName,
+		"com.hashicorp.nomad.task_group_name": task.TaskGroupName,
+		"com.hashicorp.nomad.task_name":       task.Name,
 	}
 
 	require.Equal(t, expectedLabels, c.Config.Labels)

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -799,8 +799,8 @@ func TestDockerDriver_Labels(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// expect to see 4 additional standard labels (allocID, jobName, TaskGroupName and TaskName)
-	require.Equal(t, len(cfg.Labels)+4, len(container.Config.Labels))
+	// expect to see 1 additional standard labels (allocID)
+	require.Equal(t, len(cfg.Labels)+1, len(container.Config.Labels))
 	for k, v := range cfg.Labels {
 		require.Equal(t, v, container.Config.Labels[k])
 	}

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -1066,7 +1066,7 @@ func TestDockerDriver_CreateContainerConfig_Labels(t *testing.T) {
 		// user provided labels
 		"user_label": "user_value",
 		// default label
-		"com.hashicorp.nomad.alloc_id":        task.AllocID,
+		"com.hashicorp.nomad.alloc_id": task.AllocID,
 	}
 
 	require.Equal(t, expectedLabels, c.Config.Labels)

--- a/plugins/drivers/driver.go
+++ b/plugins/drivers/driver.go
@@ -237,8 +237,12 @@ func (c *DNSConfig) Copy() *DNSConfig {
 type TaskConfig struct {
 	ID               string
 	JobName          string
+	JobID            string
 	TaskGroupName    string
 	Name             string
+	Namespace        string
+	NodeName         string
+	NodeID           string
 	Env              map[string]string
 	DeviceEnv        map[string]string
 	Resources        *Resources

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -870,7 +870,7 @@ plugin "docker" {
 
 - `extra_labels` - Extra labels to add to Docker containers. 
    Available options are `job_name`, `job_id`, `task_group_name`, `task_name`,
-   `namespace`, `node_name`, `node_id`. Globs are supported ( e.g. `task*`)
+   `namespace`, `node_name`, `node_id`. Globs are supported (e.g. `task*`)
 
 - `gc` stanza:
 

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -774,6 +774,8 @@ plugin "docker" {
       ca   = "/etc/nomad/nomad.cert"
     }
 
+    extra_labels = ["job_name", "job_id", "task_group_name", "task_name", "namespace", "node_name", "node_id"]
+
     gc {
       image       = true
       image_delay = "3m"
@@ -865,6 +867,10 @@ plugin "docker" {
   disable Nomad logs collection of Docker tasks. If you don't rely on nomad log
   capabilities and exclusively use host based log aggregation, you may consider
   this option to disable nomad log collection overhead.
+
+- `extra_labels` - Extra labels to add to Docker containers. 
+   Available options are `job_name`, `job_id`, `task_group_name`, `task_name`,
+   `namespace`, `node_name`, `node_id`. Globs are supported ( e.g. `task*`)
 
 - `gc` stanza:
 


### PR DESCRIPTION
As discussed in #4781 , having those extra labels is needed for log shipping, cAdvisor, etc.