### PR TITLE
docs: clarify where variables can be placed with HCLv2.

### DIFF
--- a/website/content/docs/job-specification/hcl2/variables.mdx
+++ b/website/content/docs/job-specification/hcl2/variables.mdx
@@ -12,8 +12,8 @@ description: |-
 Input variables serve as parameters for a Nomad job, allowing aspects of the
 job to be customized without altering the job's own source code.
 
-When you declare variables in the job configuration, you can set
-their values using CLI options and environment variables.
+When you declare variables in the same file as the job specification, you
+can set their values using CLI options and environment variables.
 
 -> **Note:** For brevity, input variables are often referred to as just
 "variables" or "Nomad variables" when it is clear from context what sort of


### PR DESCRIPTION
Attempting to make it clearer variables go into the jobspec file while attempting to use similar terminology.

closes #9842 