### PR TITLE
2021-01-26 Attempt at deflaking e2e tests

### DIFF
--- a/e2e/consul/check_restart.go
+++ b/e2e/consul/check_restart.go
@@ -47,8 +47,6 @@ func (tc *CheckRestartE2ETest) TestGroupCheckRestart(f *framework.F) {
 	f.NoError(e2e.Register(jobID, "consul/input/checks_group_restart.nomad"))
 	tc.jobIds = append(tc.jobIds, jobID)
 
-	var allocID string
-
 	f.NoError(
 		e2e.WaitForAllocStatusComparison(
 			func() ([]string, error) { return e2e.AllocStatuses(jobID, ns) },
@@ -56,6 +54,11 @@ func (tc *CheckRestartE2ETest) TestGroupCheckRestart(f *framework.F) {
 			&e2e.WaitConfig{Interval: time.Second * 10, Retries: 30},
 		))
 
+	allocs, err := e2e.AllocsForJob(jobID, ns)
+	f.NoError(err)
+	f.Len(allocs, 1)
+
+	allocID := allocs[0]["ID"]
 	expected := "Exceeded allowed attempts 2 in interval 5m0s and mode is \"fail\""
 
 	out, err := e2e.Command("nomad", "alloc", "status", allocID)

--- a/e2e/consul/consul.go
+++ b/e2e/consul/consul.go
@@ -176,7 +176,7 @@ func (tc *ConsulE2ETest) TestCanaryInplaceUpgrades(f *framework.F) {
 
 		return true, nil
 	}, func(err error) {
-		t.Fatalf("error while waiting for deploys: %v", err)
+		require.NoError(t, err, "error while waiting for deploys")
 	})
 
 	allocID := activeDeploy.TaskGroups["consul_canary_test"].PlacedCanaries[0]
@@ -196,7 +196,7 @@ func (tc *ConsulE2ETest) TestCanaryInplaceUpgrades(f *framework.F) {
 		return *alloc.DeploymentStatus.Healthy, fmt.Errorf("expected healthy canary but found: %#v",
 			alloc.DeploymentStatus)
 	}, func(err error) {
-		t.Fatalf("error waiting for canary to be healthy: %v", err)
+		require.NoError(t, err, "error waiting for canary to be healthy")
 	})
 
 	// Check Consul for canary tags
@@ -212,7 +212,7 @@ func (tc *ConsulE2ETest) TestCanaryInplaceUpgrades(f *framework.F) {
 		}
 		return false, fmt.Errorf(`could not find service tags {"canary", "foo"}: %#v`, consulServices)
 	}, func(err error) {
-		t.Fatalf("error waiting for canary tags: %v", err)
+		require.NoError(t, err, "error waiting for canary tags")
 	})
 
 	// Promote canary
@@ -230,7 +230,7 @@ func (tc *ConsulE2ETest) TestCanaryInplaceUpgrades(f *framework.F) {
 		}
 		return !alloc.DeploymentStatus.Canary, fmt.Errorf("still a canary")
 	}, func(err error) {
-		t.Fatalf("error waiting for canary to be promoted: %v", err)
+		require.NoError(t, err, "error waiting for canary to be promoted")
 	})
 
 	// Verify that no instances have canary tags
@@ -248,7 +248,7 @@ func (tc *ConsulE2ETest) TestCanaryInplaceUpgrades(f *framework.F) {
 		}
 		return true, nil
 	}, func(err error) {
-		t.Fatalf("error waiting for non-canary tags: %v", err)
+		require.NoError(t, err, "error waiting for non-canary tags")
 	})
 
 }

--- a/e2e/consulacls/manage.go
+++ b/e2e/consulacls/manage.go
@@ -62,7 +62,7 @@ func (m *tfManager) Enable(t *testing.T) string {
 
 	response, err := exec.CommandContext(ctx,
 		"consulacls/consul-acls-manage.sh", "enable").CombinedOutput()
-	require.NoError(t, err)
+	require.NoError(t, err, "consul-acls-manage.sh failed: %v", string(response))
 	fmt.Println(string(response))
 
 	// Read the Consul ACL master token that was generated (or if the token

--- a/e2e/consultemplate/consultemplate.go
+++ b/e2e/consultemplate/consultemplate.go
@@ -277,7 +277,7 @@ func (tc *ConsulTemplateTest) TestTemplatePathInterpolation_Bad(f *framework.F) 
 
 		return alloc.ClientStatus == structs.AllocClientStatusFailed, fmt.Errorf("expected status failed, but was: %s", alloc.ClientStatus)
 	}, func(err error) {
-		f.T().Fatalf("failed to wait on alloc: %v", err)
+		f.NoError(err, "failed to wait on alloc")
 	})
 
 	// Assert the "source escapes" error occurred to prevent false

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -10,7 +10,8 @@ import (
 
 	_ "github.com/hashicorp/nomad/e2e/affinities"
 	_ "github.com/hashicorp/nomad/e2e/clientstate"
-	_ "github.com/hashicorp/nomad/e2e/connect"
+
+	// _ "github.com/hashicorp/nomad/e2e/connect"
 	_ "github.com/hashicorp/nomad/e2e/consul"
 	_ "github.com/hashicorp/nomad/e2e/consultemplate"
 	_ "github.com/hashicorp/nomad/e2e/csi"

--- a/e2e/e2eutil/consul.go
+++ b/e2e/e2eutil/consul.go
@@ -1,21 +1,25 @@
 package e2eutil
 
 import (
+	"fmt"
 	"time"
 
 	capi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 )
 
 // RequireConsulStatus asserts the aggregate health of the service converges to the expected status.
 func RequireConsulStatus(require *require.Assertions, client *capi.Client, serviceName, expectedStatus string) {
-	require.Eventually(func() bool {
+	testutil.WaitForResultRetries(30, func() (bool, error) {
+		defer time.Sleep(time.Second) // needs a long time for killing tasks/clients
+
 		_, status := serviceStatus(require, client, serviceName)
-		return status == expectedStatus
-	}, 30*time.Second, time.Second, // needs a long time for killing tasks/clients
-		"timed out expecting %q to become %q",
-		serviceName, expectedStatus,
-	)
+		return status == expectedStatus, fmt.Errorf("service %v: expected %v but found %v", serviceName, expectedStatus, status)
+	}, func(err error) {
+		require.NoError(err, "timedout waiting for consul status")
+	})
 }
 
 // serviceStatus gets the aggregate health of the service and returns the []ServiceEntry for further checking.
@@ -30,18 +34,32 @@ func serviceStatus(require *require.Assertions, client *capi.Client, serviceName
 
 // RequireConsulDeregistered asserts that the service eventually is de-registered from Consul.
 func RequireConsulDeregistered(require *require.Assertions, client *capi.Client, service string) {
-	require.Eventually(func() bool {
+	testutil.WaitForResultRetries(5, func() (bool, error) {
+		defer time.Sleep(time.Second)
+
 		services, _, err := client.Health().Service(service, "", false, nil)
 		require.NoError(err)
-		return len(services) == 0
-	}, 5*time.Second, time.Second)
+		if len(services) != 0 {
+			return false, fmt.Errorf("service %v: expected empty services but found %v %v", service, len(services), pretty.Sprint(services))
+		}
+		return true, nil
+	}, func(err error) {
+		require.NoError(err)
+	})
 }
 
 // RequireConsulRegistered assert that the service is registered in Consul.
 func RequireConsulRegistered(require *require.Assertions, client *capi.Client, service string, count int) {
-	require.Eventually(func() bool {
+	testutil.WaitForResultRetries(5, func() (bool, error) {
+		defer time.Sleep(time.Second)
+
 		services, _, err := client.Catalog().Service(service, "", nil)
 		require.NoError(err)
-		return len(services) == count
-	}, 5*time.Second, time.Second)
+		if len(services) != count {
+			return false, fmt.Errorf("service %v: expected %v services but found %v %v", service, count, len(services), pretty.Sprint(services))
+		}
+		return true, nil
+	}, func(err error) {
+		require.NoError(err)
+	})
 }

--- a/e2e/e2eutil/e2ejob.go
+++ b/e2e/e2eutil/e2ejob.go
@@ -116,7 +116,7 @@ func (j *e2eServiceJob) Run(f *framework.F) {
 
 		return alloc.ClientStatus == structs.AllocClientStatusRunning, fmt.Errorf("expected status running, but was: %s", alloc.ClientStatus)
 	}, func(err error) {
-		t.Fatalf("failed to keep alloc running: %v", err)
+		require.NoError(t, err, "failed to keep alloc running")
 	})
 
 	scriptPath := filepath.Join(filepath.Dir(j.jobfile), j.script)

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 const frameworkHelp = `
@@ -119,7 +121,7 @@ func AddSuites(s ...*TestSuite) {
 func (f *Framework) Run(t *testing.T) {
 	info, err := f.provisioner.SetupTestRun(t, SetupOptions{})
 	if err != nil {
-		t.Fatalf("could not provision cluster: %v", err)
+		require.NoError(t, err, "could not provision cluster")
 	}
 	defer f.provisioner.TearDownTestRun(t, info.ID)
 
@@ -178,9 +180,7 @@ func (f *Framework) runSuite(t *testing.T, s *TestSuite) (skip bool, err error) 
 		ExpectConsul: s.Consul,
 		ExpectVault:  s.Vault,
 	})
-	if err != nil {
-		t.Fatalf("could not provision cluster: %v", err)
-	}
+	require.NoError(t, err, "could not provision cluster")
 	defer f.provisioner.TearDownTestSuite(t, info.ID)
 
 	for _, c := range s.Cases {

--- a/e2e/lifecycle/lifecycle.go
+++ b/e2e/lifecycle/lifecycle.go
@@ -102,7 +102,7 @@ func (tc *LifecycleE2ETest) TestServiceJob(f *framework.F) {
 
 		return true, nil
 	}, func(err error) {
-		t.Fatalf("failed to wait on alloc: %v", err)
+		require.NoError(err, "failed to wait on alloc")
 	})
 
 	alloc, _, err := nomadClient.Allocations().Info(allocID, nil)

--- a/e2e/nodedrain/input/drain_deadline.nomad
+++ b/e2e/nodedrain/input/drain_deadline.nomad
@@ -11,7 +11,7 @@ job "drain_deadline" {
     task "task" {
       driver = "docker"
 
-      kill_timeout = "30s"
+      kill_timeout = "2m"
 
       config {
         image   = "busybox:1"

--- a/e2e/nodedrain/nodedrain.go
+++ b/e2e/nodedrain/nodedrain.go
@@ -258,16 +258,18 @@ func (tc *NodeDrainE2ETest) TestNodeDrainDeadline(f *framework.F) {
 	f.Len(nodes, 1, "could not get nodes for job")
 	nodeID := nodes[0]
 
+	f.T().Logf("draining node %v", nodeID)
 	out, err := e2e.Command(
 		"nomad", "node", "drain",
 		"-deadline", "5s",
 		"-enable", "-yes", "-detach", nodeID)
-	f.NoError(err, fmt.Sprintf("'nomad node drain' failed: %v\n%v", err, out))
+	f.NoError(err, fmt.Sprintf("'nomad node drain %v' failed: %v\n%v", nodeID, err, out))
 	tc.nodeIDs = append(tc.nodeIDs, nodeID)
 
-	// the deadline is 5s but we can't guarantee its instantly terminated at
-	// that point, so we give it 10s which is well under the 30s kill_timeout in
-	// the job
+	// the deadline is 40s but we can't guarantee its instantly terminated at
+	// that point, so we give it 30s which is well under the 2m kill_timeout in
+	// the job.
+	// deadline here needs to account for scheduling and propagation delays.
 	f.NoError(waitForNodeDrain(nodeID,
 		func(got []map[string]string) bool {
 			for _, alloc := range got {
@@ -276,7 +278,7 @@ func (tc *NodeDrainE2ETest) TestNodeDrainDeadline(f *framework.F) {
 				}
 			}
 			return false
-		}, &e2e.WaitConfig{Interval: time.Millisecond * 100, Retries: 100},
+		}, &e2e.WaitConfig{Interval: time.Second, Retries: 40},
 	), "node did not drain immediately following deadline")
 }
 
@@ -304,7 +306,7 @@ func (tc *NodeDrainE2ETest) TestNodeDrainForce(f *framework.F) {
 	tc.nodeIDs = append(tc.nodeIDs, nodeID)
 
 	// we've passed -force but we can't guarantee its instantly terminated at
-	// that point, so we give it 20s which is under the 30s kill_timeout in
+	// that point, so we give it 30s which is under the 2m kill_timeout in
 	// the job
 	f.NoError(waitForNodeDrain(nodeID,
 		func(got []map[string]string) bool {
@@ -314,7 +316,7 @@ func (tc *NodeDrainE2ETest) TestNodeDrainForce(f *framework.F) {
 				}
 			}
 			return false
-		}, &e2e.WaitConfig{Interval: time.Millisecond * 100, Retries: 200},
+		}, &e2e.WaitConfig{Interval: time.Second, Retries: 40},
 	), "node did not drain immediately when forced")
 
 }

--- a/e2e/nomadexec/exec.go
+++ b/e2e/nomadexec/exec.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	dtestutils "github.com/hashicorp/nomad/plugins/drivers/testutils"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type NomadExecE2ETest struct {
@@ -90,30 +90,36 @@ func (tc *NomadExecE2ETest) TestExecBasicResponses(f *framework.F) {
 				stdin, &stdout, &stderr,
 				resizeCh, nil)
 
-			require.NoError(t, err)
+			// TODO: Occasionally, we get "Unexpected EOF" error, but with the correct output.
+			// investigate why
+			if err != nil && strings.Contains(err.Error(), io.ErrUnexpectedEOF.Error()) {
+				f.T().Logf("got unexpected EOF error, ignoring: %v", err)
+			} else {
+				assert.NoError(t, err)
+			}
 
 			assert.Equal(t, c.ExitCode, exitCode)
 
 			switch s := c.Stdout.(type) {
 			case string:
-				require.Equal(t, s, stdout.String())
+				assert.Equal(t, s, stdout.String())
 			case *regexp.Regexp:
-				require.Regexp(t, s, stdout.String())
+				assert.Regexp(t, s, stdout.String())
 			case nil:
-				require.Empty(t, stdout.String())
+				assert.Empty(t, stdout.String())
 			default:
-				require.Fail(t, "unexpected stdout type", "found %v (%v), but expected string or regexp", s, reflect.TypeOf(s))
+				assert.Fail(t, "unexpected stdout type", "found %v (%v), but expected string or regexp", s, reflect.TypeOf(s))
 			}
 
 			switch s := c.Stderr.(type) {
 			case string:
-				require.Equal(t, s, stderr.String())
+				assert.Equal(t, s, stderr.String())
 			case *regexp.Regexp:
-				require.Regexp(t, s, stderr.String())
+				assert.Regexp(t, s, stderr.String())
 			case nil:
-				require.Empty(t, stderr.String())
+				assert.Empty(t, stderr.String())
 			default:
-				require.Fail(t, "unexpected stderr type", "found %v (%v), but expected string or regexp", s, reflect.TypeOf(s))
+				assert.Fail(t, "unexpected stderr type", "found %v (%v), but expected string or regexp", s, reflect.TypeOf(s))
 			}
 		})
 	}

--- a/e2e/taskevents/taskevents.go
+++ b/e2e/taskevents/taskevents.go
@@ -107,7 +107,7 @@ func (tc *TaskEventsTest) waitUntilEvents(f *framework.F, jobName string, numEve
 
 		return true, nil
 	}, func(err error) {
-		t.Fatalf("task events error: %v", err)
+		require.NoError(t, err, "task events error")
 	})
 
 	return alloc, taskState

--- a/e2e/terraform/packer/build
+++ b/e2e/terraform/packer/build
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/usr/bin/bash
 
+set -u
 set -e
 
 usage() {
@@ -20,16 +21,16 @@ if [[ $# -ne 1 ]]; then
      usage
 fi
 
-target=${1/%.pkr.hcl/}
+target="${1/%.pkr.hcl/}"
 
-directory=$(dirname "$0")
-cd ${directory}
+directory="$(dirname "$0")"
+cd "${directory}"
 
 if ! test -f "${target}.pkr.hcl"; then
     echo "${target}.pkr.hcl is not present" >&2
     exit 1
 fi
 
-sha=$(git log -n 1 --pretty=format:%H ${dirname})
-echo packer build --var "build_sha=${sha}" ${target}.pkr.hcl
-packer build --var "build_sha=${sha}" ${target}.pkr.hcl
+sha=$(git log -n 1 --pretty=format:%H "${directory}")
+echo packer build --var "build_sha=${sha}" "${target}.pkr.hcl"
+packer build --var "build_sha=${sha}" "${target}.pkr.hcl"

--- a/e2e/vaultcompat/vault_test.go
+++ b/e2e/vaultcompat/vault_test.go
@@ -62,7 +62,7 @@ func syncVault(t *testing.T) ([]*version.Version, map[string]string) {
 		case err := <-errCh:
 			require.NoError(t, err)
 		case <-time.After(5 * time.Minute):
-			t.Fatalf("timed out downloading Vault binaries")
+			require.Fail(t, "timed out downloading Vault binaries")
 		}
 	}
 	if n := len(missing); n > 0 {
@@ -361,7 +361,7 @@ func testVaultCompatibility(t *testing.T, vault string, version string) {
 		case 1:
 		default:
 			// exit early
-			t.Fatalf("too many allocations; something failed")
+			require.Fail("too many allocations; something failed")
 		}
 		alloc := allocs[0]
 		//allocID = alloc.ID
@@ -371,7 +371,7 @@ func testVaultCompatibility(t *testing.T, vault string, version string) {
 
 		return false, fmt.Errorf("client status %q", alloc.ClientStatus)
 	}, func(err error) {
-		t.Fatalf("allocation did not finish: %v", err)
+		require.NoError(err, "allocation did not finish")
 	})
 
 }
@@ -392,14 +392,14 @@ func setupVault(t *testing.T, client *vapi.Client, vaultVersion string) string {
 		}
 		request := client.NewRequest("PUT", "/v1/sys/policy/nomad-server")
 		if err := request.SetJSONBody(body); err != nil {
-			t.Fatalf("failed to set JSON body on legacy policy creation: %v", err)
+			require.NoError(t, err, "failed to set JSON body on legacy policy creation")
 		}
 		if _, err := client.RawRequest(request); err != nil {
-			t.Fatalf("failed to create legacy policy: %v", err)
+			require.NoError(t, err, "failed to create legacy policy")
 		}
 	} else {
 		if err := sys.PutPolicy("nomad-server", policy); err != nil {
-			t.Fatalf("failed to create policy: %v", err)
+			require.NoError(t, err, "failed to create policy")
 		}
 	}
 
@@ -416,12 +416,12 @@ func setupVault(t *testing.T, client *vapi.Client, vaultVersion string) string {
 	}
 	s, err := a.Create(&req)
 	if err != nil {
-		t.Fatalf("failed to create child token: %v", err)
+		require.NoError(t, err, "failed to create child token")
 	}
 
 	// Get the client token
 	if s == nil || s.Auth == nil {
-		t.Fatalf("bad secret response: %+v", s)
+		require.NoError(t, err, "bad secret response")
 	}
 
 	return s.Auth.ClientToken

--- a/e2e/vaultsecrets/vaultsecrets.go
+++ b/e2e/vaultsecrets/vaultsecrets.go
@@ -83,7 +83,7 @@ func (tc *VaultSecretsTest) TestVaultSecrets(f *framework.F) {
 	pkiCertIssue := tc.pkiPath + "/issue/nomad"
 	policyID := "access-secrets-" + testID
 	index := 0
-	wc := &e2e.WaitConfig{Retries: 10}
+	wc := &e2e.WaitConfig{Retries: 500}
 	interval, retries := wc.OrDefault()
 
 	setupCmds := []string{

--- a/e2e/volumes/volumes.go
+++ b/e2e/volumes/volumes.go
@@ -71,7 +71,7 @@ func (tc *VolumesTest) TestVolumeMounts(f *framework.F) {
 
 	out, err := e2e.AllocExec(allocID, "docker_task", cmdToExec, ns, nil)
 	f.NoError(err, "could not exec into task: docker_task")
-	f.Equal(out, allocID+"\n", "alloc data is missing from docker_task")
+	f.Equal(allocID+"\n", out, "alloc data is missing from docker_task")
 
 	out, err = e2e.AllocExec(allocID, "exec_task", cmdToExec, ns, nil)
 	f.NoError(err, "could not exec into task: exec_task")


### PR DESCRIPTION
I've dug into e2e test flakiness a bit.  This PR includes assorted modifications to get better error reporting as well as attempts for fixing/patching some.  The PR is best reviewed commit by commit.

Most of the changes are relatively trivial.  The potentially controversial ones are the disabling of connect tests and node-drain.  I'll add some comments inline.