### PR TITLE
Use dominant-baseline instead of alignment-baseline to get firefox support

### DIFF
--- a/ui/app/styles/charts/topo-viz-node.scss
+++ b/ui/app/styles/charts/topo-viz-node.scss
@@ -55,7 +55,7 @@
 
     .label {
       text-anchor: middle;
-      alignment-baseline: central;
+      dominant-baseline: central;
       font-weight: $weight-normal;
       fill: $grey;
       pointer-events: none;
@@ -68,7 +68,7 @@
 
     text {
       text-anchor: middle;
-      alignment-baseline: central;
+      dominant-baseline: central;
     }
   }
 


### PR DESCRIPTION
Before:
<img width="562" alt="Labels are top-aligned to their parent elements" src="https://user-images.githubusercontent.com/174740/105877155-84b2e280-5fb4-11eb-8a86-2865295aa48e.png">


After:
<img width="551" alt="Labels are center aligned to their parent elements" src="https://user-images.githubusercontent.com/174740/105877186-8c728700-5fb4-11eb-8d2b-68cdb4e68884.png">

