### PR TITLE
e2e: Disable node drain deadline tests

### DIFF
--- a/e2e/consul/consul.go
+++ b/e2e/consul/consul.go
@@ -176,7 +176,7 @@ func (tc *ConsulE2ETest) TestCanaryInplaceUpgrades(f *framework.F) {
 
 		return true, nil
 	}, func(err error) {
-		require.NoError(t, err, "error while waiting for deploys")
+		f.NoError(err, "error while waiting for deploys")
 	})
 
 	allocID := activeDeploy.TaskGroups["consul_canary_test"].PlacedCanaries[0]
@@ -196,7 +196,7 @@ func (tc *ConsulE2ETest) TestCanaryInplaceUpgrades(f *framework.F) {
 		return *alloc.DeploymentStatus.Healthy, fmt.Errorf("expected healthy canary but found: %#v",
 			alloc.DeploymentStatus)
 	}, func(err error) {
-		require.NoError(t, err, "error waiting for canary to be healthy")
+		f.NoError(err, "error waiting for canary to be healthy")
 	})
 
 	// Check Consul for canary tags
@@ -212,7 +212,7 @@ func (tc *ConsulE2ETest) TestCanaryInplaceUpgrades(f *framework.F) {
 		}
 		return false, fmt.Errorf(`could not find service tags {"canary", "foo"}: %#v`, consulServices)
 	}, func(err error) {
-		require.NoError(t, err, "error waiting for canary tags")
+		f.NoError(err, "error waiting for canary tags")
 	})
 
 	// Promote canary

--- a/e2e/nodedrain/nodedrain.go
+++ b/e2e/nodedrain/nodedrain.go
@@ -245,6 +245,7 @@ func (tc *NodeDrainE2ETest) TestNodeDrainIgnoreSystem(f *framework.F) {
 // TestNodeDrainDeadline tests the enforcement of the node drain deadline so
 // that allocations are terminated even if they haven't gracefully exited.
 func (tc *NodeDrainE2ETest) TestNodeDrainDeadline(f *framework.F) {
+	f.T().Skip("The behavior is unclear and test assertions don't capture intent.  Issue 9902")
 
 	jobID := "test-node-drain-" + uuid.Generate()[0:8]
 	f.NoError(e2e.Register(jobID, "nodedrain/input/drain_deadline.nomad"))
@@ -272,6 +273,8 @@ func (tc *NodeDrainE2ETest) TestNodeDrainDeadline(f *framework.F) {
 	// deadline here needs to account for scheduling and propagation delays.
 	f.NoError(waitForNodeDrain(nodeID,
 		func(got []map[string]string) bool {
+			// FIXME: check the drain job alloc specifically. test
+			// may pass if client had another completed alloc
 			for _, alloc := range got {
 				if alloc["Status"] == "complete" {
 					return true
@@ -285,6 +288,7 @@ func (tc *NodeDrainE2ETest) TestNodeDrainDeadline(f *framework.F) {
 // TestNodeDrainDeadline tests the enforcement of the node drain -force flag
 // so that allocations are terminated immediately.
 func (tc *NodeDrainE2ETest) TestNodeDrainForce(f *framework.F) {
+	f.T().Skip("The behavior is unclear and test assertions don't capture intent.  Issue 9902")
 
 	jobID := "test-node-drain-" + uuid.Generate()[0:8]
 	f.NoError(e2e.Register(jobID, "nodedrain/input/drain_deadline.nomad"))
@@ -310,6 +314,8 @@ func (tc *NodeDrainE2ETest) TestNodeDrainForce(f *framework.F) {
 	// the job
 	f.NoError(waitForNodeDrain(nodeID,
 		func(got []map[string]string) bool {
+			// FIXME: check the drain job alloc specifically. test
+			// may pass if client had another completed alloc
 			for _, alloc := range got {
 				if alloc["Status"] == "complete" {
 					return true


### PR DESCRIPTION
Disabling node drain deadlines tests.  They assert that the allocations to be migrated get killed immediate (with `--force`) or after the specified drain deadline.  However, that doesn't seem the case in practice.  Issue #9902 is the placeholder issue to investigate behavior.