### PR TITLE
UI: Show allocation associations in the topo viz more often (and fix a bug)

### DIFF
--- a/ui/app/components/topo-viz.js
+++ b/ui/app/components/topo-viz.js
@@ -238,6 +238,13 @@ export default class TopoViz extends Component {
   }
 
   @action
+  resizeEdges() {
+    if (this.activeEdges.length > 0) {
+      this.computedActiveEdges();
+    }
+  }
+
+  @action
   computedActiveEdges() {
     // Wait a render cycle
     run.next(() => {

--- a/ui/app/components/topo-viz.js
+++ b/ui/app/components/topo-viz.js
@@ -220,8 +220,8 @@ export default class TopoViz extends Component {
         });
       }
 
-      // Only show the lines if the selected allocations are sparse (low count relative to the client count).
-      if (newAllocations.length < this.args.nodes.length * 0.75) {
+      // Only show the lines if the selected allocations are sparse (low count relative to the client count or low count generally).
+      if (newAllocations.length < 10 || newAllocations.length < this.args.nodes.length * 0.75) {
         this.computedActiveEdges();
       } else {
         this.activeEdges = [];

--- a/ui/app/templates/components/topo-viz.hbs
+++ b/ui/app/templates/components/topo-viz.hbs
@@ -45,7 +45,7 @@
   </div>
 
   {{#if this.activeAllocation}}
-    <svg data-test-allocation-associations class="chart topo-viz-edges" {{window-resize this.computedActiveEdges}}>
+    <svg data-test-allocation-associations class="chart topo-viz-edges" {{window-resize this.resizeEdges}}>
       <g transform="translate({{this.edgeOffset.x}},{{this.edgeOffset.y}})">
         {{#each this.activeEdges as |edge|}}
           <path data-test-allocation-association class="edge" d={{edge}} />

--- a/ui/tests/integration/components/topo-viz-test.js
+++ b/ui/tests/integration/components/topo-viz-test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+import { triggerEvent } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { componentA11yAudit } from 'nomad-ui/tests/helpers/a11y-audit';
@@ -144,6 +145,10 @@ module('Integration | Component | TopoViz', function(hooks) {
     assert.ok(TopoViz.allocationAssociationsArePresent);
     assert.equal(TopoViz.allocationAssociations.length, selectedAllocations.length * 2);
 
+    // Lines get redrawn when the window resizes; make sure the lines persist.
+    await triggerEvent(window, 'resize');
+    assert.equal(TopoViz.allocationAssociations.length, selectedAllocations.length * 2);
+
     await TopoViz.datacenters[0].nodes[0].memoryRects[0].select();
     assert.notOk(TopoViz.allocationAssociationsArePresent);
   });
@@ -166,6 +171,10 @@ module('Integration | Component | TopoViz', function(hooks) {
     assert.notOk(TopoViz.allocationAssociationsArePresent);
 
     await TopoViz.datacenters[0].nodes[0].memoryRects[0].select();
+    assert.equal(TopoViz.allocationAssociations.length, 0);
+
+    // Lines get redrawn when the window resizes; make sure that doesn't make the lines show up again
+    await triggerEvent(window, 'resize');
     assert.equal(TopoViz.allocationAssociations.length, 0);
   });
 

--- a/ui/tests/integration/components/topo-viz-test.js
+++ b/ui/tests/integration/components/topo-viz-test.js
@@ -157,8 +157,17 @@ module('Integration | Component | TopoViz', function(hooks) {
     this.setProperties({
       nodes: [node('dc1', 'node0', 1000, 500), node('dc1', 'node1', 1000, 500)],
       allocations: [
+        // There need to be at least 10 sibling allocations to trigger this behavior
         alloc('node0', 'job1', 'group', 100, 100),
         alloc('node0', 'job1', 'group', 100, 100),
+        alloc('node0', 'job1', 'group', 100, 100),
+        alloc('node0', 'job1', 'group', 100, 100),
+        alloc('node0', 'job1', 'group', 100, 100),
+        alloc('node0', 'job1', 'group', 100, 100),
+        alloc('node1', 'job1', 'group', 100, 100),
+        alloc('node1', 'job1', 'group', 100, 100),
+        alloc('node1', 'job1', 'group', 100, 100),
+        alloc('node1', 'job1', 'group', 100, 100),
         alloc('node1', 'job1', 'group', 100, 100),
         alloc('node1', 'job1', 'group', 100, 100),
         alloc('node0', 'job1', 'groupTwo', 100, 100),


### PR DESCRIPTION
Closes #9769 

This fixes the bug reported in the above issue and hopefully also clears up some of the confusing behavior.

**Bug**
When allocation associations aren't supposed to be drawn, resizing the window will cause them to be drawn anyway.

**Confusion**
Sometimes allocation associations aren't supposed to be drawn but it's not clear when or why.

The motive behind this behavior is the lines can become more overwhelming than they are helpful for densely placed allocs on large clusters. The lines are supposed to help get a sense of spread, but when it's just spaghetti, it's not solving that anymore.

I think this motive is still valid, but the logic behind it is admittedly naive. Before this pr, the logic was `allocCount < nodeCount * 0.75` And as you can see in the issue, this means three allocs on a three node cluster don't get lines. Having lines in this scenario isn't at all overwhelming, so I adjusted the logic. 

Now lines will always be drawn if the sibling alloc count is <10.