### PR TITLE
interpolate maps in dynamic blocks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/hashicorp/go-version v1.2.1-0.20191009193637-2046c9d0f0b0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hashicorp/hcl v1.0.1-0.20201016140508-a07e7d50bbee
-	github.com/hashicorp/hcl/v2 v2.7.1-0.20201020204811-68a97f93bb48
+	github.com/hashicorp/hcl/v2 v2.7.1-0.20210129140708-3000d85e32a9
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/memberlist v0.2.2
 	github.com/hashicorp/net-rpc-msgpackrpc v0.0.0-20151116020338-a14192a58a69

--- a/go.sum
+++ b/go.sum
@@ -411,8 +411,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.1-0.20201016140508-a07e7d50bbee h1:8B4HqvMUtYSjsGkYjiQGStc9pXffY2J+Z2SPQAj+wMY=
 github.com/hashicorp/hcl v1.0.1-0.20201016140508-a07e7d50bbee/go.mod h1:gwlu9+/P9MmKtYrMsHeFRZPXj2CTPm11TDnMeaRHS7g=
-github.com/hashicorp/hcl/v2 v2.7.1-0.20201020204811-68a97f93bb48 h1:iaau0VStfX9CgOlpbceawI94uVEM3sliqnjpHSVQqUo=
-github.com/hashicorp/hcl/v2 v2.7.1-0.20201020204811-68a97f93bb48/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
+github.com/hashicorp/hcl/v2 v2.7.1-0.20210129140708-3000d85e32a9 h1:5s4yY6Efzd33dTozKsEe6PeqPPN1jhXb8ijCBZllS1c=
+github.com/hashicorp/hcl/v2 v2.7.1-0.20210129140708-3000d85e32a9/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/hil v0.0.0-20160711231837-1e86c6b523c5/go.mod h1:KHvg/R2/dPtaePb16oW4qIyzkMxXOL38xjRN64adsts=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/jobspec2/parse_test.go
+++ b/jobspec2/parse_test.go
@@ -280,17 +280,38 @@ func TestParseDynamic(t *testing.T) {
 	hcl := `
 job "example" {
 
-dynamic "group" {
-  for_each = ["groupA", "groupB", "groupC"]
-  labels   = [group.value]
+  dynamic "group" {
+    for_each = [
+      { name = "groupA", idx = 1 },
+      { name = "groupB", idx = 2 },
+      { name = "groupC", idx = 3 },
+    ]
+    labels   = [group.value.name]
 
-  content {
-    task "simple" {
-      driver = "raw_exec"
+    content {
+      count = group.value.idx
 
+      service {
+        port = group.value.name
+      }
+
+      task "simple" {
+        driver  = "raw_exec"
+        config {
+          command = group.value.name
+        }
+        meta {
+          VERSION = group.value.idx
+        }
+        env {
+          ID = format("id:%s", group.value.idx)
+        }
+        resources {
+          cpu = group.value.idx
+        }
+      }
     }
   }
-}
 }
 `
 	out, err := ParseWithConfig(&ParseConfig{
@@ -305,6 +326,13 @@ dynamic "group" {
 	require.Equal(t, "groupA", *out.TaskGroups[0].Name)
 	require.Equal(t, "groupB", *out.TaskGroups[1].Name)
 	require.Equal(t, "groupC", *out.TaskGroups[2].Name)
+	require.Equal(t, 1, *out.TaskGroups[0].Tasks[0].Resources.CPU)
+	require.Equal(t, "groupA", out.TaskGroups[0].Services[0].PortLabel)
+
+	// interpolation inside maps
+	require.Equal(t, "groupA", out.TaskGroups[0].Tasks[0].Config["command"])
+	require.Equal(t, "1", out.TaskGroups[0].Tasks[0].Meta["VERSION"])
+	require.Equal(t, "id:1", out.TaskGroups[0].Tasks[0].Env["ID"])
 }
 
 func TestParse_InvalidScalingSyntax(t *testing.T) {

--- a/jobspec2/parse_test.go
+++ b/jobspec2/parse_test.go
@@ -333,6 +333,8 @@ job "example" {
 	require.Equal(t, "groupA", out.TaskGroups[0].Tasks[0].Config["command"])
 	require.Equal(t, "1", out.TaskGroups[0].Tasks[0].Meta["VERSION"])
 	require.Equal(t, "id:1", out.TaskGroups[0].Tasks[0].Env["ID"])
+	require.Equal(t, "id:2", out.TaskGroups[1].Tasks[0].Env["ID"])
+	require.Equal(t, "3", out.TaskGroups[2].Tasks[0].Meta["VERSION"])
 }
 
 func TestParse_InvalidScalingSyntax(t *testing.T) {

--- a/vendor/github.com/hashicorp/hcl/v2/ext/dynblock/expand_body.go
+++ b/vendor/github.com/hashicorp/hcl/v2/ext/dynblock/expand_body.go
@@ -251,10 +251,12 @@ func (b *expandBody) expandChild(child hcl.Body, i *iteration) hcl.Body {
 }
 
 func (b *expandBody) JustAttributes() (hcl.Attributes, hcl.Diagnostics) {
-	// blocks aren't allowed in JustAttributes mode and this body can
-	// only produce blocks, so we'll just pass straight through to our
-	// underlying body here.
-	return b.original.JustAttributes()
+	// TODO: the original comment in upstream says that blocks aren't allowed
+	// here, but we pass them in when dynamic blocks include
+	// map[string]interface{}
+	attrs, diags := b.original.JustAttributes()
+	attrs = b.prepareAttributes(attrs)
+	return attrs, diags
 }
 
 func (b *expandBody) MissingItemRange() hcl.Range {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -470,7 +470,7 @@ github.com/hashicorp/hcl/hcl/token
 github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hashicorp/hcl/v2 v2.7.1-0.20201020204811-68a97f93bb48
+# github.com/hashicorp/hcl/v2 v2.7.1-0.20210129140708-3000d85e32a9
 ## explicit
 github.com/hashicorp/hcl/v2
 github.com/hashicorp/hcl/v2/ext/customdecode


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9871

This changeset includes both a test and a dependency update for a patch that fixes map interpolation inside `dynamic` blocks. This dependency update is from the off-release HCL2 version as described https://github.com/hashicorp/nomad/issues/9918