### PR TITLE
UI: Change down to highest-priority composite status

### DIFF
--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -102,7 +102,9 @@ export default class Node extends Model {
   // Useful for coloring and sorting nodes
   @computed('isDraining', 'isEligible', 'status')
   get compositeStatus() {
-    if (this.isDraining) {
+    if (this.status === 'down') {
+      return 'down';
+    } else if (this.isDraining) {
       return 'draining';
     } else if (!this.isEligible) {
       return 'ineligible';

--- a/ui/tests/acceptance/client-detail-test.js
+++ b/ui/tests/acceptance/client-detail-test.js
@@ -457,6 +457,7 @@ module('Acceptance | client detail', function(hooks) {
     node = server.create('node', {
       drain: false,
       schedulingEligibility: 'ineligible',
+      status: 'ready',
     });
 
     await ClientDetail.visit({ id: node.id });


### PR DESCRIPTION
As pointed out by @nickethier, if a node was ineligible before
it went down, downness should be displayed, not ineligibility.