### PR TITLE
lint: Upgrade buf to 0.36.0, latest so far

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -125,7 +125,7 @@ check: ## Lint the source code
 	@misspell -error -source=text website/pages/
 
 	@echo "==> Checking for breaking changes in protos..."
-	@buf check breaking --config tools/buf/buf.yaml --against-config tools/buf/buf.yaml --against .git#tag=$(PROTO_COMPARE_TAG)
+	@buf breaking --config tools/buf/buf.yaml --against-config tools/buf/buf.yaml --against .git#tag=$(PROTO_COMPARE_TAG)
 
 	@echo "==> Check proto files are in-sync..."
 	@$(MAKE) proto

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,7 @@ GOTEST_PKGS=$(shell go list ./... | sed 's/github.com\/hashicorp\/nomad/./' | eg
 endif
 
 # tag corresponding to latest release we maintain backward compatibility with
-PROTO_COMPARE_TAG ?= v1.0.0$(if $(findstring ent,$(GO_TAGS)),+ent,)
+PROTO_COMPARE_TAG ?= v1.0.3$(if $(findstring ent,$(GO_TAGS)),+ent,)
 
 default: help
 

--- a/scripts/vagrant-linux-priv-buf.sh
+++ b/scripts/vagrant-linux-priv-buf.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 # Make sure you grab the latest version
-VERSION=0.30.1
+VERSION=0.36.0
 DOWNLOAD=https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-Linux-x86_64
 
 function install() {


### PR DESCRIPTION
Also, update the compatibility check to 1.0.3, the latest release so far.

Closes https://github.com/hashicorp/nomad/issues/9925