### PR TITLE
scheduler: add tests and fix for detected host_network and to port field changes

### DIFF
--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -534,16 +534,26 @@ func networkUpdated(netA, netB []*structs.NetworkResource) bool {
 	return false
 }
 
-// networkPortMap takes a network resource and returns a map of port labels to
-// values. The value for dynamic ports is disregarded even if it is set. This
+// networkPortMap takes a network resource and returns a AllocatedPorts.
+// The value for dynamic ports is disregarded even if it is set. This
 // makes this function suitable for comparing two network resources for changes.
-func networkPortMap(n *structs.NetworkResource) map[string]int {
-	m := make(map[string]int, len(n.DynamicPorts)+len(n.ReservedPorts))
+func networkPortMap(n *structs.NetworkResource) structs.AllocatedPorts {
+	var m structs.AllocatedPorts
 	for _, p := range n.ReservedPorts {
-		m[p.Label] = p.Value
+		m = append(m, structs.AllocatedPortMapping{
+			Label:  p.Label,
+			Value:  p.Value,
+			To:     p.To,
+			HostIP: p.HostNetwork,
+		})
 	}
 	for _, p := range n.DynamicPorts {
-		m[p.Label] = -1
+		m = append(m, structs.AllocatedPortMapping{
+			Label:  p.Label,
+			Value:  -1,
+			To:     p.To,
+			HostIP: p.HostNetwork,
+		})
 	}
 	return m
 }

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -762,6 +762,63 @@ func TestTasksUpdated_connectServiceUpdated(t *testing.T) {
 	})
 }
 
+func TestNetworkUpdated(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		a       []*structs.NetworkResource
+		b       []*structs.NetworkResource
+		updated bool
+	}{
+		{
+			name: "mode updated",
+			a: []*structs.NetworkResource{
+				{Mode: "host"},
+			},
+			b: []*structs.NetworkResource{
+				{Mode: "bridge"},
+			},
+			updated: true,
+		},
+		{
+			name: "host_network updated",
+			a: []*structs.NetworkResource{
+				{DynamicPorts: []structs.Port{
+					{Label: "http", To: 8080},
+				}},
+			},
+			b: []*structs.NetworkResource{
+				{DynamicPorts: []structs.Port{
+					{Label: "http", To: 8080, HostNetwork: "public"},
+				}},
+			},
+			updated: true,
+		},
+		{
+			name: "port.To updated",
+			a: []*structs.NetworkResource{
+				{DynamicPorts: []structs.Port{
+					{Label: "http", To: 8080},
+				}},
+			},
+			b: []*structs.NetworkResource{
+				{DynamicPorts: []structs.Port{
+					{Label: "http", To: 8088},
+				}},
+			},
+			updated: true,
+		},
+	}
+
+	for i := range cases {
+		c := cases[i]
+		t.Run(c.name, func(tc *testing.T) {
+			tc.Parallel()
+			require.Equal(tc, c.updated, networkUpdated(c.a, c.b), "unexpected network updated result")
+		})
+	}
+}
+
 func TestEvictAndPlace_LimitLessThanAllocs(t *testing.T) {
 	_, ctx := testContext(t)
 	allocs := []allocTuple{


### PR DESCRIPTION
This PR changes the scheduler to detect if a `to` or `host_network` field is updated.

fixes #9728