### PR TITLE
drivers/docker: support mapping multiple host ports to the same container port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ BUG FIXES:
  * consul: Fixed a bug where failing tasks with group services would only cause the allocation to restart once instead of respecting the `restart` field. [[GH-9869](https://github.com/hashicorp/nomad/issues/9869)]
  * consul/connect: Fixed a bug where gateway proxy connection default timeout not set [[GH-9851](https://github.com/hashicorp/nomad/pull/9851)]
  * consul/connect: Fixed a bug preventing more than one connect gateway per Nomad client [[GH-9849](https://github.com/hashicorp/nomad/pull/9849)]
+ * drivers/docker: Fixed a bug preventing multiple ports to be mapped to the same container port [[GH-9951](https://github.com/hashicorp/nomad/issues/9951)]
  * scheduler: Fixed a bug where shared ports were not persisted during inplace updates for service jobs. [[GH-9830](https://github.com/hashicorp/nomad/issues/9830)]
  * scheduler: Fixed a bug where job statuses and summaries where duplicated and miscalculated when registering a job. [[GH-9768](https://github.com/hashicorp/nomad/issues/9768)]
   * scheduler (Enterprise): Fixed a bug where the deprecated network `mbits` field was being considered as part of quota enforcement. [[GH-9920](https://github.com/hashicorp/nomad/issues/9920)]

--- a/drivers/docker/driver_default.go
+++ b/drivers/docker/driver_default.go
@@ -7,8 +7,8 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 )
 
-func getPortBinding(ip string, port string) []docker.PortBinding {
-	return []docker.PortBinding{{HostIP: ip, HostPort: port}}
+func getPortBinding(ip string, port string) docker.PortBinding {
+	return docker.PortBinding{HostIP: ip, HostPort: port}
 }
 
 func tweakCapabilities(basics, adds, drops []string) ([]string, error) {

--- a/drivers/docker/driver_windows.go
+++ b/drivers/docker/driver_windows.go
@@ -3,8 +3,8 @@ package docker
 import docker "github.com/fsouza/go-dockerclient"
 
 //Currently Windows containers don't support host ip in port binding.
-func getPortBinding(ip string, port string) []docker.PortBinding {
-	return []docker.PortBinding{{HostIP: "", HostPort: port}}
+func getPortBinding(ip string, port string) docker.PortBinding {
+	return docker.PortBinding{HostIP: "", HostPort: port}
 }
 
 func tweakCapabilities(basics, adds, drops []string) ([]string, error) {

--- a/drivers/docker/ports_test.go
+++ b/drivers/docker/ports_test.go
@@ -1,0 +1,19 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/nomad/helper/testlog"
+)
+
+func TestPublishedPorts_add(t *testing.T) {
+	p := newPublishedPorts(testlog.HCLogger(t))
+	p.add("label", "10.0.0.1", 1234, 80)
+	p.add("label", "10.0.0.1", 5678, 80)
+	for _, bindings := range p.publishedPorts {
+		require.Len(t, bindings, 2)
+	}
+	require.Len(t, p.exposedPorts, 2)
+}


### PR DESCRIPTION
The docker driver native port mapping logic would overwrite ports with the same container port. This wouldn't allow multiple ports to be mapped to the came container port.

This PR fixes this issue by correctly appending to the published port map instead of overwriting.

fixes #8284