### PR TITLE
Add NOMAD_HEADERS to cli client

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -241,6 +241,23 @@ func defaultHttpClient() *http.Client {
 	return httpClient
 }
 
+func parseHeaders(headerString string) http.Header {
+	realHeaders := http.Header{}
+	headers := strings.Split(headerString, ";")
+
+	for _, h := range headers {
+		header := strings.Split(strings.TrimSpace(h), ":")
+		if len(header) < 2 {
+			continue
+		}
+		k := strings.TrimSpace(header[0])
+		v := strings.TrimSpace(header[1])
+
+		realHeaders.Add(k, v)
+	}
+	return realHeaders
+}
+
 // DefaultConfig returns a default configuration for the client
 func DefaultConfig() *Config {
 	config := &Config{
@@ -293,6 +310,11 @@ func DefaultConfig() *Config {
 			config.TLSConfig.Insecure = insecure
 		}
 	}
+
+	if v := os.Getenv("NOMAD_HEADERS"); v != "" {
+		config.Headers = parseHeaders(v)
+	}
+
 	if v := os.Getenv("NOMAD_TOKEN"); v != "" {
 		config.SecretID = v
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"context"
@@ -242,20 +243,14 @@ func defaultHttpClient() *http.Client {
 }
 
 func parseHeaders(headerString string) http.Header {
-	realHeaders := http.Header{}
-	headers := strings.Split(headerString, ";")
+	headers := http.Header{}
+	reader := bufio.NewReader(strings.NewReader("GET / HTTP/1.1\r\n" + headerString + "\r\n"))
 
-	for _, h := range headers {
-		header := strings.Split(strings.TrimSpace(h), ":")
-		if len(header) < 2 {
-			continue
-		}
-		k := strings.TrimSpace(header[0])
-		v := strings.TrimSpace(header[1])
-
-		realHeaders.Add(k, v)
+	logReq, err := http.ReadRequest(reader)
+	if err != nil {
+		return headers
 	}
-	return realHeaders
+	return logReq.Header
 }
 
 // DefaultConfig returns a default configuration for the client

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -121,6 +121,13 @@ func TestDefaultConfig_env(t *testing.T) {
 	region := "test"
 	namespace := "dev"
 	token := "foobar"
+	headers := "ABC: 123; EFG: 245; XYZ: 29; XYZ: 30;"
+
+	expectedHeaders := http.Header{}
+	expectedHeaders.Add("ABC", "123")
+	expectedHeaders.Add("EFG", "245")
+	expectedHeaders.Add("XYZ", "29")
+	expectedHeaders.Add("XYZ", "30")
 
 	os.Setenv("NOMAD_ADDR", url)
 	defer os.Setenv("NOMAD_ADDR", "")
@@ -137,10 +144,19 @@ func TestDefaultConfig_env(t *testing.T) {
 	os.Setenv("NOMAD_TOKEN", token)
 	defer os.Setenv("NOMAD_TOKEN", "")
 
+	os.Setenv("NOMAD_HEADERS", headers)
+	defer os.Setenv("NOMAD_TOKEN", "")
+
 	config := DefaultConfig()
 
 	if config.Address != url {
 		t.Errorf("expected %q to be %q", config.Address, url)
+	}
+
+	for k, _ := range expectedHeaders {
+		if config.Headers.Get(k) != expectedHeaders.Get(k) {
+			t.Errorf("expected %q to be %q", config.Headers, expectedHeaders)
+		}
 	}
 
 	if config.Region != region {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -121,7 +121,7 @@ func TestDefaultConfig_env(t *testing.T) {
 	region := "test"
 	namespace := "dev"
 	token := "foobar"
-	headers := "ABC: 123; EFG: 245; XYZ: 29; XYZ: 30;"
+	headers := "ABC: 123\r\nEFG: 245\r\nXYZ: 29\r\nXYZ: 30\r\n"
 
 	expectedHeaders := http.Header{}
 	expectedHeaders.Add("ABC", "123")


### PR DESCRIPTION
We run nomad behind an auth proxy that requires some headers to be set in order to authenticate, before sending the request through to the destination server.

This change allows a user to specify the `NOMAD_HEADERS` environment variable to send alongside their commands.

e.g.
```sh
NOMAD_HEADERS="CF-Access-Client-Id: <Client ID>
CF-Access-Client-Secret: <Client Secret>" nomad job status nginx
```