### PR TITLE
Add handling for license requests in OSS

### DIFF
--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -314,6 +314,7 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 
 	s.mux.HandleFunc("/v1/search", s.wrap(s.SearchRequest))
 
+	s.mux.HandleFunc("/v1/operator/license", s.wrap(s.LicenseRequest))
 	s.mux.HandleFunc("/v1/operator/raft/", s.wrap(s.OperatorRequest))
 	s.mux.HandleFunc("/v1/operator/autopilot/configuration", s.wrap(s.OperatorAutopilotConfiguration))
 	s.mux.HandleFunc("/v1/operator/autopilot/health", s.wrap(s.OperatorServerHealth))

--- a/command/agent/http_oss.go
+++ b/command/agent/http_oss.go
@@ -16,8 +16,6 @@ func (s *HTTPServer) registerEnterpriseHandlers() {
 	s.mux.HandleFunc("/v1/quota/", s.wrap(s.entOnly))
 	s.mux.HandleFunc("/v1/quota", s.wrap(s.entOnly))
 
-	s.mux.HandleFunc("/v1/operator/license", s.wrap(s.entOnly))
-
 	s.mux.HandleFunc("/v1/recommendation", s.wrap(s.entOnly))
 	s.mux.HandleFunc("/v1/recommendations", s.wrap(s.entOnly))
 	s.mux.HandleFunc("/v1/recommendations/apply", s.wrap(s.entOnly))

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -289,6 +289,17 @@ func (s *HTTPServer) schedulerUpdateConfig(resp http.ResponseWriter, req *http.R
 	return reply, nil
 }
 
+func (s *HTTPServer) LicenseRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	switch req.Method {
+	case "GET":
+		resp.WriteHeader(http.StatusNoContent)
+		return "", nil
+	default:
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+}
+
 func (s *HTTPServer) SnapshotRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	switch req.Method {
 	case "GET":

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -294,6 +294,8 @@ func (s *HTTPServer) LicenseRequest(resp http.ResponseWriter, req *http.Request)
 	case "GET":
 		resp.WriteHeader(http.StatusNoContent)
 		return nil, nil
+	case "PUT":
+		return nil, CodedError(501, ErrEntOnly)
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)
 	}

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -289,19 +289,6 @@ func (s *HTTPServer) schedulerUpdateConfig(resp http.ResponseWriter, req *http.R
 	return reply, nil
 }
 
-func (s *HTTPServer) LicenseRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	switch req.Method {
-	case "GET":
-		resp.WriteHeader(http.StatusNoContent)
-		return nil, nil
-	case "PUT":
-		return nil, CodedError(501, ErrEntOnly)
-	default:
-		return nil, CodedError(405, ErrInvalidMethod)
-	}
-
-}
-
 func (s *HTTPServer) SnapshotRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	switch req.Method {
 	case "GET":

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -293,7 +293,7 @@ func (s *HTTPServer) LicenseRequest(resp http.ResponseWriter, req *http.Request)
 	switch req.Method {
 	case "GET":
 		resp.WriteHeader(http.StatusNoContent)
-		return "", nil
+		return nil, nil
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)
 	}

--- a/command/agent/operator_endpoint_oss.go
+++ b/command/agent/operator_endpoint_oss.go
@@ -1,0 +1,20 @@
+// +build !ent
+
+package agent
+
+import (
+	"net/http"
+)
+
+func (s *HTTPServer) LicenseRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	switch req.Method {
+	case "GET":
+		resp.WriteHeader(http.StatusNoContent)
+		return nil, nil
+	case "PUT":
+		return nil, CodedError(501, ErrEntOnly)
+	default:
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+}


### PR DESCRIPTION
This changes the OSS response for `GET /v1/operator/license` from 501 to 204 to close #9827. It preserves the `1` status code when running `nomad operator license`. Here’s me interacting with it locally:

<img width="608" alt="image" src="https://user-images.githubusercontent.com/43280/107248394-dff2c500-69f7-11eb-8eb5-0b3a6a24640d.png">

This means people won’t see what appears to be an error in their logs for a known situation, as the UI checks this endpoint to decide whether to show enterprise features.