### PR TITLE
add prefix-search and auto-completion for `scaling policy info` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ FEATURES:
  * **Terminating Gateways**: Adds built-in support for running Consul Connect terminating gateways [[GH-9829](https://github.com/hashicorp/nomad/pull/9829)]
 
 IMPROVEMENTS:
+ * cli: Improved `scaling policy` commands with -verbose, auto-completion, and prefix-matching [[GH-9964](https://github.com/hashicorp/nomad/issues/9964)]
  * consul/connect: Made handling of sidecar task container image URLs consistent with the `docker` task driver. [[GH-9580](https://github.com/hashicorp/nomad/issues/9580)]
+
 
 BUG FIXES:
  * consul: Fixed a bug where failing tasks with group services would only cause the allocation to restart once instead of respecting the `restart` field. [[GH-9869](https://github.com/hashicorp/nomad/issues/9869)]

--- a/api/contexts/contexts.go
+++ b/api/contexts/contexts.go
@@ -12,6 +12,7 @@ const (
 	Namespaces      Context = "namespaces"
 	Quotas          Context = "quotas"
 	Recommendations Context = "recommendations"
+	ScalingPolicies Context = "scaling_policy"
 	Plugins         Context = "plugins"
 	Volumes         Context = "volumes"
 	All             Context = "all"

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -115,7 +115,7 @@ func (c *AllocStatusCommand) Run(args []string) int {
 	}
 
 	// If args not specified but output format is specified, format and output the allocations data list
-	if len(args) == 0 && json || len(tmpl) > 0 {
+	if len(args) == 0 && (json || len(tmpl) > 0) {
 		allocs, _, err := client.Allocations().List(nil)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error querying allocations: %v", err))

--- a/command/eval_status.go
+++ b/command/eval_status.go
@@ -106,7 +106,7 @@ func (c *EvalStatusCommand) Run(args []string) int {
 	}
 
 	// If args not specified but output format is specified, format and output the evaluations data list
-	if len(args) == 0 && json || len(tmpl) > 0 {
+	if len(args) == 0 && (json || len(tmpl) > 0) {
 		evals, _, err := client.Evaluations().List(nil)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error querying evaluations: %v", err))

--- a/command/job_inspect.go
+++ b/command/job_inspect.go
@@ -94,7 +94,7 @@ func (c *JobInspectCommand) Run(args []string) int {
 	}
 
 	// If args not specified but output format is specified, format and output the jobs data list
-	if len(args) == 0 && json || len(tmpl) > 0 {
+	if len(args) == 0 && (json || len(tmpl) > 0) {
 		jobs, _, err := client.Jobs().List(nil)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error querying jobs: %v", err))

--- a/command/scaling_policy_info_test.go
+++ b/command/scaling_policy_info_test.go
@@ -35,6 +35,14 @@ func TestScalingPolicyInfoCommand_Run(t *testing.T) {
 	cmd := &ScalingPolicyInfoCommand{Meta: Meta{Ui: ui}}
 
 	// Calling without the policyID should result in an error.
+	if code := cmd.Run([]string{"-address=" + url}); code != 1 {
+		t.Fatalf("expected cmd run exit code 1, got: %d", code)
+	}
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "This command takes one of the following argument conditions") {
+		t.Fatalf("expected argument error within output: %v", out)
+	}
+
+	// Calling with more than one argument should result in an error.
 	if code := cmd.Run([]string{"-address=" + url, "first", "second"}); code != 1 {
 		t.Fatalf("expected cmd run exit code 1, got: %d", code)
 	}
@@ -80,6 +88,14 @@ func TestScalingPolicyInfoCommand_Run(t *testing.T) {
 	}
 
 	if code := cmd.Run([]string{"-address=" + url, policies[0].ID}); code != 0 {
+		t.Fatalf("expected cmd run exit code 0, got: %d", code)
+	}
+	if out := ui.OutputWriter.String(); !strings.Contains(out, "Policy:") {
+		t.Fatalf("expected policy ID within output: %v", out)
+	}
+
+	prefix := policies[0].ID[:2]
+	if code := cmd.Run([]string{"-address=" + url, prefix}); code != 0 {
 		t.Fatalf("expected cmd run exit code 0, got: %d", code)
 	}
 	if out := ui.OutputWriter.String(); !strings.Contains(out, "Policy:") {

--- a/command/scaling_policy_info_test.go
+++ b/command/scaling_policy_info_test.go
@@ -35,10 +35,10 @@ func TestScalingPolicyInfoCommand_Run(t *testing.T) {
 	cmd := &ScalingPolicyInfoCommand{Meta: Meta{Ui: ui}}
 
 	// Calling without the policyID should result in an error.
-	if code := cmd.Run([]string{"-address=" + url}); code != 1 {
+	if code := cmd.Run([]string{"-address=" + url, "first", "second"}); code != 1 {
 		t.Fatalf("expected cmd run exit code 1, got: %d", code)
 	}
-	if out := ui.ErrorWriter.String(); !strings.Contains(out, "This command takes one argument: <policy_id>") {
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "This command takes one of the following argument conditions") {
 		t.Fatalf("expected argument error within output: %v", out)
 	}
 
@@ -46,8 +46,8 @@ func TestScalingPolicyInfoCommand_Run(t *testing.T) {
 	if code := cmd.Run([]string{"-address=" + url, "scaling_policy_info"}); code != 1 {
 		t.Fatalf("expected cmd run exit code 1, got: %d", code)
 	}
-	if out := ui.ErrorWriter.String(); !strings.Contains(out, "404 (policy not found)") {
-		t.Fatalf("expected 404 not found within output: %v", out)
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, `No scaling policies with prefix or id "scaling_policy_inf" found`) {
+		t.Fatalf("expected 'no policies found' within output: %v", out)
 	}
 
 	// Generate a test job.

--- a/nomad/search_endpoint.go
+++ b/nomad/search_endpoint.go
@@ -31,6 +31,7 @@ var (
 		structs.Deployments,
 		structs.Plugins,
 		structs.Volumes,
+		structs.ScalingPolicies,
 		structs.Namespaces,
 	}
 )
@@ -67,6 +68,8 @@ func (s *Search) getMatches(iter memdb.ResultIterator, prefix string) ([]string,
 		case *structs.CSIPlugin:
 			id = t.ID
 		case *structs.CSIVolume:
+			id = t.ID
+		case *structs.ScalingPolicy:
 			id = t.ID
 		case *structs.Namespace:
 			id = t.Name
@@ -106,6 +109,8 @@ func getResourceIter(context structs.Context, aclObj *acl.ACL, namespace, prefix
 		return state.DeploymentsByIDPrefix(ws, namespace, prefix)
 	case structs.Plugins:
 		return state.CSIPluginsByIDPrefix(ws, prefix)
+	case structs.ScalingPolicies:
+		return state.ScalingPoliciesByIDPrefix(ws, namespace, prefix)
 	case structs.Volumes:
 		return state.CSIVolumesByIDPrefix(ws, namespace, prefix)
 	case structs.Namespaces:

--- a/nomad/search_endpoint_oss.go
+++ b/nomad/search_endpoint_oss.go
@@ -102,6 +102,7 @@ func searchContexts(aclObj *acl.ACL, namespace string, context structs.Context) 
 		acl.NamespaceCapabilityListJobs,
 		acl.NamespaceCapabilityReadJob)
 	volRead := allowVolume(aclObj, namespace)
+	policyRead := aclObj.AllowNsOp(namespace, acl.NamespaceCapabilityListScalingPolicies)
 
 	// Filter contexts down to those the ACL grants access to
 	available := make([]structs.Context, 0, len(all))
@@ -109,6 +110,10 @@ func searchContexts(aclObj *acl.ACL, namespace string, context structs.Context) 
 		switch c {
 		case structs.Allocs, structs.Jobs, structs.Evals, structs.Deployments:
 			if jobRead {
+				available = append(available, c)
+			}
+		case structs.ScalingPolicies:
+			if policyRead || jobRead {
 				available = append(available, c)
 			}
 		case structs.Namespaces:

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -201,6 +201,7 @@ const (
 	Namespaces      Context = "namespaces"
 	Quotas          Context = "quotas"
 	Recommendations Context = "recommendations"
+	ScalingPolicies Context = "scaling_policy"
 	All             Context = "all"
 	Plugins         Context = "plugins"
 	Volumes         Context = "volumes"

--- a/vendor/github.com/hashicorp/nomad/api/contexts/contexts.go
+++ b/vendor/github.com/hashicorp/nomad/api/contexts/contexts.go
@@ -12,6 +12,7 @@ const (
 	Namespaces      Context = "namespaces"
 	Quotas          Context = "quotas"
 	Recommendations Context = "recommendations"
+	ScalingPolicies Context = "scaling_policy"
 	Plugins         Context = "plugins"
 	Volumes         Context = "volumes"
 	All             Context = "all"


### PR DESCRIPTION
also, i think there was some bad boolean logic in a few other info-like commands

resolves #9787 