### PR TITLE
Change exec URLs to use job’s namespace/region

### DIFF
--- a/ui/app/utils/generate-exec-url.js
+++ b/ui/app/utils/generate-exec-url.js
@@ -1,7 +1,18 @@
 import { get } from '@ember/object';
 
 export default function generateExecUrl(router, { job, taskGroup, task, allocation }) {
-  const queryParams = router.currentRoute.queryParams;
+  const queryParams = {};
+
+  const namespace = get(job, 'namespace.name');
+  const region = get(job, 'region');
+
+  if (namespace) {
+    queryParams.namespace = namespace;
+  }
+
+  if (region) {
+    queryParams.region = region;
+  }
 
   if (task) {
     const queryParamsOptions = {

--- a/ui/tests/unit/utils/generate-exec-url-test.js
+++ b/ui/tests/unit/utils/generate-exec-url-test.js
@@ -96,14 +96,15 @@ module('Unit | Utility | generate-exec-url', function(hooks) {
     );
   });
 
-  test('it includes query parameters from the current route', function(assert) {
-    this.router.currentRoute.queryParams = {
-      namespace: 'a-namespace',
-      region: 'a-region',
-    };
-
+  test('it includes job namespace and region when they exist', function(assert) {
     generateExecUrl(this.router, {
-      job: { plainId: 'job-name' },
+      job: {
+        namespace: {
+          name: 'a-namespace',
+        },
+        plainId: 'job-name',
+        region: 'a-region',
+      },
       allocation: { shortId: 'id', taskGroup: { name: 'task-group-name', tasks: [0, 1] } },
     });
 


### PR DESCRIPTION
This closes #9966. It was looking at the query parameters
for the namespace and region, but allocation (and task!)
routes don’t have a namespace query parameter. Since the URL
generator requires the job for all calls, it makes sense to
extract the namespace and region from the job instead.