### PR TITLE
volumes: implement plan diff for volume requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,16 @@ IMPROVEMENTS:
  * cli: Improved `scaling policy` commands with -verbose, auto-completion, and prefix-matching [[GH-9964](https://github.com/hashicorp/nomad/issues/9964)]
  * consul/connect: Made handling of sidecar task container image URLs consistent with the `docker` task driver. [[GH-9580](https://github.com/hashicorp/nomad/issues/9580)]
 
-
 BUG FIXES:
  * consul: Fixed a bug where failing tasks with group services would only cause the allocation to restart once instead of respecting the `restart` field. [[GH-9869](https://github.com/hashicorp/nomad/issues/9869)]
  * consul/connect: Fixed a bug where gateway proxy connection default timeout not set [[GH-9851](https://github.com/hashicorp/nomad/pull/9851)]
  * consul/connect: Fixed a bug preventing more than one connect gateway per Nomad client [[GH-9849](https://github.com/hashicorp/nomad/pull/9849)]
  * drivers/docker: Fixed a bug preventing multiple ports to be mapped to the same container port [[GH-9951](https://github.com/hashicorp/nomad/issues/9951)]
+ * driver/qemu: Fixed a bug where network namespaces were not supported for QEMU workloads [[GH-9861](https://github.com/hashicorp/nomad/pull/9861)]
  * scheduler: Fixed a bug where shared ports were not persisted during inplace updates for service jobs. [[GH-9830](https://github.com/hashicorp/nomad/issues/9830)]
  * scheduler: Fixed a bug where job statuses and summaries where duplicated and miscalculated when registering a job. [[GH-9768](https://github.com/hashicorp/nomad/issues/9768)]
-  * scheduler (Enterprise): Fixed a bug where the deprecated network `mbits` field was being considered as part of quota enforcement. [[GH-9920](https://github.com/hashicorp/nomad/issues/9920)]
- * driver/qemu: Fixed a bug where network namespaces were not supported for QEMU workloads [[GH-9861](https://github.com/hashicorp/nomad/pull/9861)]
+ * scheduler (Enterprise): Fixed a bug where the deprecated network `mbits` field was being considered as part of quota enforcement. [[GH-9920](https://github.com/hashicorp/nomad/issues/9920)]
+ * volumes: Fixed a bug where volume diffs were not displayed in the output of `nomad plan`. [[GH-9973](https://github.com/hashicorp/nomad/issues/9973)]
 
 ## 1.0.3 (January 28, 2021)
 

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -3609,6 +3609,145 @@ func TestTaskGroupDiff(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			TestCase: "TaskGroup volumes added",
+			Old:      &TaskGroup{},
+			New: &TaskGroup{
+				Volumes: map[string]*VolumeRequest{
+					"foo": &VolumeRequest{
+						Name:     "foo",
+						Type:     "host",
+						Source:   "foo-src",
+						ReadOnly: true,
+					},
+				},
+			},
+
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeAdded,
+						Name: "Volume",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeAdded,
+								Name: "Name",
+								Old:  "",
+								New:  "foo",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "ReadOnly",
+								Old:  "",
+								New:  "true",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "Source",
+								Old:  "",
+								New:  "foo-src",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "Type",
+								Old:  "",
+								New:  "host",
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			TestCase: "TaskGroup volumes edited",
+			Old: &TaskGroup{
+				Volumes: map[string]*VolumeRequest{
+					"foo": &VolumeRequest{
+						Name:     "foo",
+						Type:     "csi",
+						Source:   "foo-src1",
+						ReadOnly: false,
+						MountOptions: &CSIMountOptions{
+							FSType:     "ext4",
+							MountFlags: []string{"relatime", "rw"},
+						},
+					},
+					"bar": &VolumeRequest{
+						Name:     "bar",
+						Type:     "host",
+						Source:   "bar-src",
+						ReadOnly: true,
+					},
+				},
+			},
+			New: &TaskGroup{
+				Volumes: map[string]*VolumeRequest{
+					"foo": &VolumeRequest{
+						Name:     "foo",
+						Type:     "csi",
+						Source:   "foo-src2",
+						ReadOnly: true,
+						MountOptions: &CSIMountOptions{
+							FSType:     "ext4",
+							MountFlags: []string{"relatime", "rw", "nosuid"},
+						},
+					},
+					"bar": &VolumeRequest{ // untouched
+						Name:     "bar",
+						Type:     "host",
+						Source:   "bar-src",
+						ReadOnly: true,
+					},
+				},
+			},
+
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeEdited,
+						Name: "Volume",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeEdited,
+								Name: "ReadOnly",
+								Old:  "false",
+								New:  "true",
+							},
+							{
+								Type: DiffTypeEdited,
+								Name: "Source",
+								Old:  "foo-src1",
+								New:  "foo-src2",
+							},
+						},
+						Objects: []*ObjectDiff{
+							{
+								Type: DiffTypeEdited,
+								Name: "MountOptions",
+								Objects: []*ObjectDiff{
+									{
+										Type: DiffTypeAdded,
+										Name: "MountFlags",
+										Fields: []*FieldDiff{
+											{
+												Type: DiffTypeAdded,
+												Name: "MountFlags",
+												Old:  "",
+												New:  "nosuid",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9962

The details of host volume and CSI volume requests do not show up in `nomad
plan` outputs, although the updates are detected by the scheduler and result
in an update as expected.