### PR TITLE
ar: isolate network actions performed by client

### DIFF
--- a/client/allocrunner/network_manager_linux.go
+++ b/client/allocrunner/network_manager_linux.go
@@ -152,9 +152,17 @@ func newNetworkConfigurator(log hclog.Logger, alloc *structs.Allocation, config 
 
 	switch {
 	case netMode == "bridge":
-		return newBridgeNetworkConfigurator(log, config.BridgeNetworkName, config.BridgeNetworkAllocSubnet, config.CNIPath, ignorePortMappingHostIP)
+		c, err := newBridgeNetworkConfigurator(log, config.BridgeNetworkName, config.BridgeNetworkAllocSubnet, config.CNIPath, ignorePortMappingHostIP)
+		if err != nil {
+			return nil, err
+		}
+		return &synchronizedNetworkConfigurator{c}, nil
 	case strings.HasPrefix(netMode, "cni/"):
-		return newCNINetworkConfigurator(log, config.CNIPath, config.CNIInterfacePrefix, config.CNIConfigDir, netMode[4:], ignorePortMappingHostIP)
+		c, err := newCNINetworkConfigurator(log, config.CNIPath, config.CNIInterfacePrefix, config.CNIConfigDir, netMode[4:], ignorePortMappingHostIP)
+		if err != nil {
+			return nil, err
+		}
+		return &synchronizedNetworkConfigurator{c}, nil
 	default:
 		return &hostNetworkConfigurator{}, nil
 	}


### PR DESCRIPTION
This PR adds a global mutex for network hook operations which invoke iptables. This is to isolate these and avoid race conditions related toconcurrent iptables read then write operations.

fixes #8838 