### PR TITLE
log_rotate_max_files docs request 29569

### DIFF
--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -255,8 +255,8 @@ testing.
   value such as 30s.
 
 - `log_rotate_max_files` `(int: 0)` - Specifies the maximum number of older log
-  file archives to keep. If 0 no files are ever deleted. The number of log files
-  is greater than the log_rotate_max_files by 1.
+  file archives to keep. If 0 no files are ever deleted. Please note the number
+  of log files will be 1 greater than the log_rotate_max_files value.
 
 - `name` `(string: [hostname])` - Specifies the name of the local node. This
   value is used to identify individual agents. When specified on a server, the

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -255,7 +255,8 @@ testing.
   value such as 30s.
 
 - `log_rotate_max_files` `(int: 0)` - Specifies the maximum number of older log
-  file archives to keep. If 0 no files are ever deleted.
+  file archives to keep. If 0 no files are ever deleted. The number of log files
+  is greater than the log_rotate_max_files by 1.
 
 - `name` `(string: [hostname])` - Specifies the name of the local node. This
   value is used to identify individual agents. When specified on a server, the

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -254,9 +254,11 @@ testing.
   log should be written to before it needs to be rotated. Must be a duration
   value such as 30s.
 
-- `log_rotate_max_files` `(int: 0)` - Specifies the maximum number of older log
-  file archives to keep. If 0 no files are ever deleted. Please note the number
-  of log files will be 1 greater than the log_rotate_max_files value.
+- `log_rotate_max_files` `(int: 0)` - Specifies the maximum number of older
+  log file archives to keep, not including the log file currently being
+  written. If set to 0 no files are ever deleted. Note that the total number
+  of log files, for each of `stderr` and `stdout`, will be 1 greater than the
+  `log_rotate_max_files` value.
 
 - `name` `(string: [hostname])` - Specifies the name of the local node. This
   value is used to identify individual agents. When specified on a server, the


### PR DESCRIPTION
clarify some confusion for customers who observe +1 log file compared to the set `log_rotate_max_files` value