### PR TITLE
fix: docs/job-specification change mounts to mount

### DIFF
--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -245,13 +245,11 @@ task "task" {
 
   config {
     image = "redis:6.0"
-    mounts = [
-      {
-        type   = "bind"
-        source = "local"
-        target = "/etc/redis.d"
-      }
-    ]
+    mount {
+      type   = "bind"
+      source = "local"
+      target = "/etc/redis.d"
+    }
   }
 
   template {


### PR DESCRIPTION
Since [mounts](https://www.nomadproject.io/docs/drivers/docker#mounts) is deprecated,
switch to newer `mount` in `task.config` for `docker` driver.