### PR TITLE
UI: Fix deployment failure error handling

### DIFF
--- a/ui/app/components/job-page/parts/latest-deployment.js
+++ b/ui/app/components/job-page/parts/latest-deployment.js
@@ -29,15 +29,9 @@ export default class LatestDeployment extends Component {
     try {
       yield this.get('job.latestDeployment.content').fail();
     } catch (err) {
-      let message = messageFromAdapterError(err);
-
-      if (err instanceof ForbiddenError) {
-        message = 'Your ACL token does not grant permission to fail deployments.';
-      }
-
       this.handleError({
         title: 'Could Not Fail Deployment',
-        description: message,
+        description: messageFromAdapterError(err, 'fail deployments'),
       });
     }
   })


### PR DESCRIPTION
This is a supplement to #9831 to incorporate the extracted
missing-permissions error handling from #9909.

It fixes [this failure](https://app.circleci.com/pipelines/github/hashicorp/nomad/14728/workflows/4c147dca-fd1e-4de7-86aa-90ded7aabad2/jobs/137137) on the main branch! 😳