### PR TITLE
UI: Change test audit comparison to use static seed

### DIFF
--- a/.github/workflows/ember-test-audit.yml
+++ b/.github/workflows/ember-test-audit.yml
@@ -25,6 +25,7 @@ jobs:
           node-version: '10.x'
       - run: yarn --frozen-lockfile
       - run: mkdir -p /tmp/test-reports
+      - run: gsed -i "s/faker\.random\.number()/1919/" mirage/faker.js
       - run: npx ember-test-audit 3 --json --output ../base-audit.json
       - name: Upload result
         uses: actions/upload-artifact@v2
@@ -42,6 +43,7 @@ jobs:
           node-version: '10.x'
       - run: yarn --frozen-lockfile
       - run: mkdir -p /tmp/test-reports
+      - run: gsed -i "s/faker\.random\.number()/1919/" mirage/faker.js
       - run: npx ember-test-audit 3 --json --output ../pr-audit.json
       - name: Upload result
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ember-test-audit.yml
+++ b/.github/workflows/ember-test-audit.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: '10.x'
       - run: yarn --frozen-lockfile
       - run: mkdir -p /tmp/test-reports
-      - run: gsed -i "s/faker\.random\.number()/1919/" mirage/faker.js
+      - run: sed -i "s/faker\.random\.number()/1919/" mirage/faker.js
       - run: npx ember-test-audit 3 --json --output ../base-audit.json
       - name: Upload result
         uses: actions/upload-artifact@v2
@@ -43,7 +43,7 @@ jobs:
           node-version: '10.x'
       - run: yarn --frozen-lockfile
       - run: mkdir -p /tmp/test-reports
-      - run: gsed -i "s/faker\.random\.number()/1919/" mirage/faker.js
+      - run: sed -i "s/faker\.random\.number()/1919/" mirage/faker.js
       - run: npx ember-test-audit 3 --json --output ../pr-audit.json
       - name: Upload result
         uses: actions/upload-artifact@v2

--- a/ui/tests/acceptance/optimize-test.js
+++ b/ui/tests/acceptance/optimize-test.js
@@ -23,7 +23,7 @@ function getLatestRecommendationSubmitTimeForJob(job) {
   return Math.max(...recommendations.mapBy('submitTime'));
 }
 
-module('Acceptance | optimize', function(hooks) {
+module('Acceptance | optimize!', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 


### PR DESCRIPTION
I’m trying this out to see if it makes the test times less
variable. 🤔