### PR TITLE
docs: update ingress gateway runnable demo

### DIFF
--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -287,7 +287,7 @@ job "ingress-demo" {
 
     service {
       name = "uuid-api"
-      port = "${NOMAD_PORT_api}"
+      port = "api"
 
       connect {
         native = true
@@ -298,7 +298,7 @@ job "ingress-demo" {
       driver = "docker"
 
       config {
-        image        = "hashicorpnomad/uuid-api:v3"
+        image        = "hashicorpnomad/uuid-api:v5"
         network_mode = "host"
       }
 


### PR DESCRIPTION
Using the environment variable stopped working here a while back,
should be using the port label. Also upgrade to uuid-api:v5 which
supports linux/arm64.