### PR TITLE
docs: clarify type constraints for collections in locals

### DIFF
--- a/website/content/docs/job-specification/hcl2/functions/conversion/convert.mdx
+++ b/website/content/docs/job-specification/hcl2/functions/conversion/convert.mdx
@@ -35,18 +35,18 @@ All other values will produce an error.
 false
 > convert(false, string)
 "false"
-> convert(["a", "b", 3], list)
+> convert(["a", "b", 3], list(string))
 [
   "a",
   "b",
   "3",
 ]
-> convert(["c", "b", "b"], set)
+> convert(["c", "b", "b"], set(string))
 [
   "b",
   "c",
 ]
-> convert({"a" = "foo", "b" = true}, map)
+> convert({"a" = "foo", "b" = true}, map(string))
 {
   "a" = "foo"
   "b" = "true"

--- a/website/content/docs/job-specification/hcl2/locals.mdx
+++ b/website/content/docs/job-specification/hcl2/locals.mdx
@@ -12,8 +12,9 @@ description: >-
 Local values assign a name to an expression, that can then be used multiple
 times within a folder.
 
-If [variables](/docs/job-specification/hcl2/variables) are analogous to function arguments then
-_local values_ are comparable to a function's local variables.
+If [variables](/docs/job-specification/hcl2/variables) are analogous to
+function arguments then _local values_ are comparable to a function's local
+variables.
 
 ## Examples
 
@@ -24,6 +25,10 @@ Local values are defined in `locals` blocks:
 locals {
   default_name_prefix = "${var.project_name}-web"
   name_prefix         = "${var.name_prefix != "" ? var.name_prefix : local.default_name_prefix}"
+
+  # unlike variables, locals don't have type constraints, so if you use
+  # functions that take maps but not objects, you may need to convert them
+  number_of_ports = length(convert({"www" = "80"}, map(string)))
 }
 
 # Local values can be interpolated elsewhere using the "local." prefix.


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10024

HCL2 locals don't have type constraints, and the map syntax is interpreted as
an object. So users may need to explictly convert to map for some functions.

The `convert` function documentation was missing the required type constructor
parameter for collections.