### PR TITLE
Add devices to AllocatedTaskResources

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -468,6 +468,7 @@ type AllocatedTaskResources struct {
 	Cpu      AllocatedCpuResources
 	Memory   AllocatedMemoryResources
 	Networks []*NetworkResource
+	Devices  []*AllocatedDeviceResource
 }
 
 type AllocatedSharedResources struct {
@@ -489,6 +490,13 @@ type AllocatedCpuResources struct {
 
 type AllocatedMemoryResources struct {
 	MemoryMB int64
+}
+
+type AllocatedDeviceResource struct {
+	Vendor    string
+	Type      string
+	Name      string
+	DeviceIDs []string
 }
 
 // AllocIndexSort reverse sorts allocs by CreateIndex.

--- a/go.sum
+++ b/go.sum
@@ -433,7 +433,6 @@ github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea h1:xykPFhrBA
 github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea/go.mod h1:pNv7Wc3ycL6F5oOWn+tPGo2gWD4a5X+yp/ntwdKLjRk=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.8.3/go.mod h1:UpNcs7fFbpKIyZaUuSW6EPiH+eZC7OuyFD+wc1oal+k=
-github.com/hashicorp/serf v0.9.3 h1:AVF6JDQQens6nMHT9OGERBvK0f8rPrAGILnsKLr6lzM=
 github.com/hashicorp/serf v0.9.3/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=
 github.com/hashicorp/serf v0.9.5 h1:EBWvyu9tcRszt3Bxp3KNssBMP1KuHWyO51lz9+786iM=
 github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=

--- a/vendor/github.com/hashicorp/nomad/api/allocations.go
+++ b/vendor/github.com/hashicorp/nomad/api/allocations.go
@@ -468,6 +468,7 @@ type AllocatedTaskResources struct {
 	Cpu      AllocatedCpuResources
 	Memory   AllocatedMemoryResources
 	Networks []*NetworkResource
+	Devices  []*AllocatedDeviceResource
 }
 
 type AllocatedSharedResources struct {
@@ -489,6 +490,13 @@ type AllocatedCpuResources struct {
 
 type AllocatedMemoryResources struct {
 	MemoryMB int64
+}
+
+type AllocatedDeviceResource struct {
+	Vendor    string
+	Type      string
+	Name      string
+	DeviceIDs []string
 }
 
 // AllocIndexSort reverse sorts allocs by CreateIndex.


### PR DESCRIPTION
This PR adds the missing `Devices` field on `AllocatedTaskResources `.

We've been running this in production at fly.io, works as expected 😄 

Fixes #10063 