### PR TITLE
UI: Add exchange of one-time token on application load

### DIFF
--- a/ui/app/adapters/token.js
+++ b/ui/app/adapters/token.js
@@ -21,7 +21,8 @@ export default class TokenAdapter extends ApplicationAdapter {
     return this.ajax(`${this.buildURL()}/token/onetime/exchange`, 'POST', {
       data: {
         OneTimeSecret: oneTimeToken,
-      }}).then(token => {
+      },
+    }).then(({ Token: token }) => {
       const store = this.store;
       store.pushPayload('token', {
         tokens: [token],

--- a/ui/app/adapters/token.js
+++ b/ui/app/adapters/token.js
@@ -16,4 +16,18 @@ export default class TokenAdapter extends ApplicationAdapter {
       return store.peekRecord('token', store.normalize('token', token).data.id);
     });
   }
+
+  exchangeOneTimeToken(oneTimeToken) {
+    return this.ajax(`${this.buildURL()}/token/onetime/exchange`, 'POST', {
+      data: {
+        OneTimeSecret: oneTimeToken,
+      }}).then(token => {
+      const store = this.store;
+      store.pushPayload('token', {
+        tokens: [token],
+      });
+
+      return store.peekRecord('token', store.normalize('token', token).data.id);
+    });
+  }
 }

--- a/ui/app/adapters/token.js
+++ b/ui/app/adapters/token.js
@@ -1,5 +1,6 @@
 import { inject as service } from '@ember/service';
 import { default as ApplicationAdapter, namespace } from './application';
+import OTTExchangeError from '../utils/ott-exchange-error';
 
 export default class TokenAdapter extends ApplicationAdapter {
   @service store;
@@ -29,6 +30,8 @@ export default class TokenAdapter extends ApplicationAdapter {
       });
 
       return store.peekRecord('token', store.normalize('token', token).data.id);
+    }).catch(() => {
+      throw new OTTExchangeError();
     });
   }
 }

--- a/ui/app/adapters/token.js
+++ b/ui/app/adapters/token.js
@@ -20,7 +20,7 @@ export default class TokenAdapter extends ApplicationAdapter {
   exchangeOneTimeToken(oneTimeToken) {
     return this.ajax(`${this.buildURL()}/token/onetime/exchange`, 'POST', {
       data: {
-        OneTimeSecret: oneTimeToken,
+        OneTimeSecretID: oneTimeToken,
       },
     }).then(({ Token: token }) => {
       const store = this.store;

--- a/ui/app/controllers/application.js
+++ b/ui/app/controllers/application.js
@@ -7,6 +7,7 @@ import { computed } from '@ember/object';
 import Ember from 'ember';
 import codesForError from '../utils/codes-for-error';
 import NoLeaderError from '../utils/no-leader-error';
+import OTTExchangeError from '../utils/ott-exchange-error';
 import classic from 'ember-classic-decorator';
 
 @classic
@@ -53,6 +54,12 @@ export default class ApplicationController extends Controller {
   get isNoLeader() {
     const error = this.error;
     return error instanceof NoLeaderError;
+  }
+
+  @computed('error')
+  get isOTTExchange() {
+    const error = this.error;
+    return error instanceof OTTExchangeError;
   }
 
   @observes('error')

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -30,16 +30,16 @@ export default class ApplicationRoute extends Route {
     let exchangeOneTimeToken;
 
     if (transition.to.queryParams.ott) {
-      exchangeOneTimeToken = this.get('token.exchangeOneTimeToken')
-        .perform(transition.to.queryParams.ott)
-        .catch(() => {
-          this.controllerFor('application').set('error', new OTTExchangeError());
-        });
+      exchangeOneTimeToken = this.get('token').exchangeOneTimeToken(transition.to.queryParams.ott);
     } else {
       exchangeOneTimeToken = Promise.resolve(true);
     }
 
-    await exchangeOneTimeToken;
+    try {
+      await exchangeOneTimeToken;
+    } catch (e) {
+      this.controllerFor('application').set('error', new OTTExchangeError());
+    }
 
     const fetchSelfTokenAndPolicies = this.get('token.fetchSelfTokenAndPolicies')
       .perform()

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -4,6 +4,7 @@ import Route from '@ember/routing/route';
 import { AbortError } from '@ember-data/adapter/error';
 import RSVP from 'rsvp';
 import { action } from '@ember/object';
+import OTTExchangeError from '../utils/ott-exchange-error';
 import classic from 'ember-classic-decorator';
 
 @classic
@@ -31,7 +32,9 @@ export default class ApplicationRoute extends Route {
     if (transition.to.queryParams.ott) {
       exchangeOneTimeToken = this.get('token.exchangeOneTimeToken')
         .perform(transition.to.queryParams.ott)
-        .catch();
+        .catch(() => {
+          this.controllerFor('application').set('error', new OTTExchangeError());
+        });
     } else {
       exchangeOneTimeToken = Promise.resolve(true);
     }

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -4,7 +4,6 @@ import Route from '@ember/routing/route';
 import { AbortError } from '@ember-data/adapter/error';
 import RSVP from 'rsvp';
 import { action } from '@ember/object';
-import OTTExchangeError from '../utils/ott-exchange-error';
 import classic from 'ember-classic-decorator';
 
 @classic
@@ -38,7 +37,7 @@ export default class ApplicationRoute extends Route {
     try {
       await exchangeOneTimeToken;
     } catch (e) {
-      this.controllerFor('application').set('error', new OTTExchangeError());
+      this.controllerFor('application').set('error', e);
     }
 
     const fetchSelfTokenAndPolicies = this.get('token.fetchSelfTokenAndPolicies')

--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -42,6 +42,14 @@ export default class TokenService extends Service {
   })
   fetchSelfToken;
 
+  @task(function*(oneTimeToken) {
+    const TokenAdapter = getOwner(this).lookup('adapter:token');
+
+    const token = yield TokenAdapter.exchangeOneTimeToken(oneTimeToken);
+    this.secret = token.secret;
+  })
+  exchangeOneTimeToken;
+
   @computed('secret', 'fetchSelfToken.lastSuccessful.value')
   get selfToken() {
     if (this.secret) return this.get('fetchSelfToken.lastSuccessful.value');

--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -42,13 +42,12 @@ export default class TokenService extends Service {
   })
   fetchSelfToken;
 
-  @task(function*(oneTimeToken) {
+  async exchangeOneTimeToken(oneTimeToken) {
     const TokenAdapter = getOwner(this).lookup('adapter:token');
 
-    const token = yield TokenAdapter.exchangeOneTimeToken(oneTimeToken);
+    const token = await TokenAdapter.exchangeOneTimeToken(oneTimeToken);
     this.secret = token.secret;
-  })
-  exchangeOneTimeToken;
+  }
 
   @computed('secret', 'fetchSelfToken.lastSuccessful.value')
   get selfToken() {

--- a/ui/app/styles/components/empty-message.scss
+++ b/ui/app/styles/components/empty-message.scss
@@ -22,4 +22,20 @@
   &.is-hollow {
     background: transparent;
   }
+
+  .terminal-container {
+    display: flex;
+    justify-content: center;
+    margin-top: 1.25rem;
+  }
+
+  .terminal {
+    background: $grey-lighter;
+    border-radius: 2px;
+    padding: 0.75rem 1rem;
+
+    .prompt {
+      color: $ui-gray-500;
+    }
+  }
 }

--- a/ui/app/styles/components/empty-message.scss
+++ b/ui/app/styles/components/empty-message.scss
@@ -35,7 +35,7 @@
     padding: 0.75rem 1rem;
 
     .prompt {
-      color: $ui-gray-500;
+      color: $grey;
     }
   }
 }

--- a/ui/app/styles/components/empty-message.scss
+++ b/ui/app/styles/components/empty-message.scss
@@ -17,6 +17,10 @@
     strong {
       color: $grey;
     }
+
+    &:not(:last-child) {
+      margin-bottom: 1rem;
+    }
   }
 
   &.is-hollow {

--- a/ui/app/styles/components/empty-message.scss
+++ b/ui/app/styles/components/empty-message.scss
@@ -31,7 +31,7 @@
 
   .terminal {
     background: $grey-lighter;
-    border-radius: 2px;
+    border-radius: $radius;
     padding: 0.75rem 1rem;
 
     .prompt {

--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -10,6 +10,11 @@
         <p data-test-error-message class="subtitle">
           The cluster has no leader. <a href="https://www.nomadproject.io/guides/outage.html"> Read about Outage Recovery.</a>
         </p>
+      {{else if this.isOTTExchange}}
+        <h1 data-test-error-title class="title is-spaced">Token Exchange Error</h1>
+        <p data-test-error-message class="subtitle">
+          Failed to exchange the one-time token. FIXME
+        </p>
       {{else if this.is500}}
         <h1 data-test-error-title class="title is-spaced">Server Error</h1>
         <p data-test-error-message class="subtitle">A server error prevented data from being sent to the client.</p>

--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -13,7 +13,7 @@
       {{else if this.isOTTExchange}}
         <h1 data-test-error-title class="title is-spaced">Token Exchange Error</h1>
         <p data-test-error-message class="subtitle">
-          Failed to exchange the one-time token. FIXME
+          Failed to exchange the one-time token.
         </p>
       {{else if this.is500}}
         <h1 data-test-error-title class="title is-spaced">Server Error</h1>

--- a/ui/app/templates/components/forbidden-message.hbs
+++ b/ui/app/templates/components/forbidden-message.hbs
@@ -17,12 +17,12 @@
         requisite
       {{/if}}
       permission to view this.
-      <br>
-      <br>
-      If you have an ACL token configured for the CLI, authenticate with:
-      <div class='terminal-container'>
-        <pre class='terminal'><span class='prompt'>$</span> nomad ui -authenticate</pre>
-      </div>
     {{/if}}
+  </p>
+  <p class="empty-message-body">
+    If you have an ACL token configured for the CLI, authenticate with:
+    <div class='terminal-container'>
+      <pre class='terminal'><span class='prompt'>$</span> nomad ui -authenticate</pre>
+    </div>
   </p>
 </div>

--- a/ui/app/templates/components/forbidden-message.hbs
+++ b/ui/app/templates/components/forbidden-message.hbs
@@ -17,6 +17,12 @@
         requisite
       {{/if}}
       permission to view this.
+      <br>
+      <br>
+      If you have an ACL token configured for the CLI, authenticate with:
+      <div class='terminal-container'>
+        <pre class='terminal'><span class='prompt'>$</span> nomad ui -authenticate</pre>
+      </div>
     {{/if}}
   </p>
 </div>

--- a/ui/app/utils/ott-exchange-error.js
+++ b/ui/app/utils/ott-exchange-error.js
@@ -1,0 +1,3 @@
+export default class OTTExchangeError extends Error {
+  message = 'Failed to exchange the one-time token.';
+}

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -391,7 +391,9 @@ export default function() {
 
     // Return the token if it exists
     if (tokenForSecret) {
-      return this.serialize(tokenForSecret);
+      return {
+        Token: this.serialize(tokenForSecret),
+      };
     }
 
     // Forbidden error if it doesn't
@@ -436,7 +438,7 @@ export default function() {
       return {
         License: {
           Features: records.models.mapBy('name'),
-        }
+        },
       };
     }
 

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -384,6 +384,20 @@ export default function() {
     return new Response(403, {}, null);
   });
 
+  this.post('/acl/token/onetime/exchange', function({ tokens }, { requestBody }) {
+    const { OneTimeSecret } = JSON.parse(requestBody);
+
+    const tokenForSecret = tokens.findBy({ oneTimeSecret: OneTimeSecret });
+
+    // Return the token if it exists
+    if (tokenForSecret) {
+      return this.serialize(tokenForSecret);
+    }
+
+    // Forbidden error if it doesn't
+    return new Response(403, {}, null);
+  });
+
   this.get('/acl/policy/:id', function({ policies, tokens }, req) {
     const policy = policies.find(req.params.id);
     const secret = req.requestHeaders['X-Nomad-Token'];

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -385,9 +385,9 @@ export default function() {
   });
 
   this.post('/acl/token/onetime/exchange', function({ tokens }, { requestBody }) {
-    const { OneTimeSecret } = JSON.parse(requestBody);
+    const { OneTimeSecretID } = JSON.parse(requestBody);
 
-    const tokenForSecret = tokens.findBy({ oneTimeSecret: OneTimeSecret });
+    const tokenForSecret = tokens.findBy({ oneTimeSecret: OneTimeSecretID });
 
     // Return the token if it exists
     if (tokenForSecret) {

--- a/ui/mirage/factories/token.js
+++ b/ui/mirage/factories/token.js
@@ -11,6 +11,8 @@ export default Factory.extend({
   global: () => faker.random.boolean(),
   type: i => (i === 0 ? 'management' : 'client'),
 
+  oneTimeSecret: () => faker.random.uuid(),
+
   afterCreate(token, server) {
     const policyIds = Array(faker.random.number({ min: 1, max: 5 }))
       .fill(0)

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -164,6 +164,15 @@ module('Acceptance | tokens', function(hooks) {
     assert.equal(requests.filter(req => req.url === '/v1/namespaces').length, 3);
   });
 
+  test('when the ott query parameter is present upon application load it’s exchanged for a token', async function(assert) {
+    const { oneTimeSecret, secretId } = managementToken;
+
+    await JobDetail.visit({ id: job.id, ott: oneTimeSecret });
+
+    await Tokens.visit();
+    assert.equal(window.localStorage.nomadTokenSecret, secretId, 'Token secret was set');
+  });
+
   function getHeader({ requestHeaders }, name) {
     // Headers are case-insensitive, but object property look up is not
     return (

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -169,8 +169,8 @@ module('Acceptance | tokens', function(hooks) {
     const { oneTimeSecret, secretId } = managementToken;
 
     await JobDetail.visit({ id: job.id, ott: oneTimeSecret });
-
     await Tokens.visit();
+
     assert.equal(window.localStorage.nomadTokenSecret, secretId, 'Token secret was set');
   });
 

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -7,6 +7,7 @@ import Tokens from 'nomad-ui/tests/pages/settings/tokens';
 import Jobs from 'nomad-ui/tests/pages/jobs/list';
 import JobDetail from 'nomad-ui/tests/pages/jobs/detail';
 import ClientDetail from 'nomad-ui/tests/pages/clients/detail';
+import Layout from 'nomad-ui/tests/pages/layout';
 
 let job;
 let node;
@@ -171,6 +172,14 @@ module('Acceptance | tokens', function(hooks) {
 
     await Tokens.visit();
     assert.equal(window.localStorage.nomadTokenSecret, secretId, 'Token secret was set');
+  });
+
+  test('when the ott exchange fails an error is shown', async function(assert) {
+    await visit('/?ott=fake');
+
+    assert.ok(Layout.error.isPresent, 'An error is shown');
+    assert.equal(Layout.error.title, 'Token Exchange Error');
+    assert.equal(Layout.error.message, 'Failed to exchange the one-time token. FIXME');
   });
 
   function getHeader({ requestHeaders }, name) {

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -1,4 +1,4 @@
-import { find } from '@ember/test-helpers';
+import { find, visit } from '@ember/test-helpers';
 import { module, skip, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -177,7 +177,7 @@ module('Acceptance | tokens', function(hooks) {
   test('when the ott exchange fails an error is shown', async function(assert) {
     await visit('/?ott=fake');
 
-    assert.ok(Layout.error.isPresent, 'An error is shown');
+    assert.ok(Layout.error.isPresent);
     assert.equal(Layout.error.title, 'Token Exchange Error');
     assert.equal(Layout.error.message, 'Failed to exchange the one-time token.');
   });

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -179,7 +179,7 @@ module('Acceptance | tokens', function(hooks) {
 
     assert.ok(Layout.error.isPresent, 'An error is shown');
     assert.equal(Layout.error.title, 'Token Exchange Error');
-    assert.equal(Layout.error.message, 'Failed to exchange the one-time token. FIXME');
+    assert.equal(Layout.error.message, 'Failed to exchange the one-time token.');
   });
 
   function getHeader({ requestHeaders }, name) {

--- a/ui/tests/pages/layout.js
+++ b/ui/tests/pages/layout.js
@@ -93,4 +93,10 @@ export default create({
   breadcrumbFor(id) {
     return this.breadcrumbs.toArray().find(crumb => crumb.id === id);
   },
+
+  error: {
+    isPresent: isPresent('[data-test-error]'),
+    title: text('[data-test-error-title]'),
+    message: text('[data-test-error-message]'),
+  },
 });


### PR DESCRIPTION
This adds UI support for receiving the one-time token passed via query parameter, as in #10134
and related PRs, and exchanging it for its corresponding secret ID. When this works, it’s mostly
invisible, as seen here when used with `nomad ui -authenticate`, where the OTT is briefly onscreen:

![authenticate](https://user-images.githubusercontent.com/43280/113087124-95e0c100-91a8-11eb-822d-c2573c62a10e.gif)

You can also see the amended message when authentication fails suggesting to `-authenticate`.

When it fails, it shows a whole-page error:

<img width="1019" alt="failed" src="https://user-images.githubusercontent.com/43280/113087212-c58fc900-91a8-11eb-8aae-e8ba9d700da3.png">

Unfortunately, I was unable to produce the desired UX of having the OTT be erased from the URL
after processing, so I’m submitting this for review with that sad caveat. This will only be seen when
jumping directly with an identifier (`nomad ui -authenticate jobname`), as `nomad ui -authenticate`
forwards to `/ui/?ott=…` which then forwards to `/ui/jobs` after the exchange is complete, but it’s
undesirable regardless. I’ll continue trying to find a way to cleanly and reliably remove it.

![leftover](https://user-images.githubusercontent.com/43280/113087487-52d31d80-91a9-11eb-83c9-6b769c5f6d11.gif)


The whole-page error currently has this minimal text:

> Failed to exchange the one-time token.

This is an edge case where I can’t actually imagine what would produce it, but the error doesn’t
really help you if it does happen… I’m open to suggestions for something better!