### PR TITLE
dist: place systemd unit options correctly

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -32,6 +32,9 @@ under `/etc/systemd/system/nomad.service`.
 
 You can control Nomad with `systemctl start|stop|restart nomad`.
 
+The `system/nomad.service` unit file is compatible with systemd v230
+or higher.
+
 ## Upstart
 
 On systems using upstart the basic upstart file under

--- a/dist/systemd/nomad.service
+++ b/dist/systemd/nomad.service
@@ -3,6 +3,8 @@ Description=Nomad
 Documentation=https://nomadproject.io/docs/
 Wants=network-online.target
 After=network-online.target
+StartLimitIntervalSec=10
+StartLimitBurst=3
 
 # When using Nomad with Consul it is not necessary to start Consul first. These
 # lines start Consul before Nomad as an optimization to avoid Nomad logging
@@ -19,8 +21,6 @@ LimitNOFILE=65536
 LimitNPROC=infinity
 Restart=on-failure
 RestartSec=2
-StartLimitBurst=3
-StartLimitIntervalSec=10
 TasksMax=infinity
 OOMScoreAdjust=-1000
 

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/nomad.service
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/nomad.service
@@ -3,6 +3,7 @@ Description=Nomad Agent
 Requires=network-online.target
 After=network-online.target
 StartLimitIntervalSec=10
+StartLimitBurst=3
 
 [Service]
 ExecReload=/bin/kill -HUP $MAINPID
@@ -14,7 +15,6 @@ LimitNPROC=infinity
 TasksMax=infinity
 Restart=on-failure
 RestartSec=2
-StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/terraform/shared/config/nomad.service
+++ b/terraform/shared/config/nomad.service
@@ -3,6 +3,8 @@ Description=Nomad
 Documentation=https://nomadproject.io/docs/
 Wants=network-online.target
 After=network-online.target
+StartLimitIntervalSec=10
+StartLimitBurst=3
 
 # If you are running Consul, please uncomment following Wants/After configs.
 # Assuming your Consul service unit name is "consul"
@@ -18,8 +20,6 @@ LimitNOFILE=infinity
 LimitNPROC=infinity
 Restart=on-failure
 RestartSec=2
-StartLimitBurst=3
-StartLimitIntervalSec=10
 TasksMax=infinity
 
 [Install]


### PR DESCRIPTION
This PR places `StartLimitIntervalSec` and `StartLimitBurst` in the
`Unit` section of systemd unit files, rather than the `Service` section.

https://www.freedesktop.org/software/systemd/man/systemd.unit.html

Fixes #10065