### PR TITLE
UI: Line chart decomposed

### DIFF
--- a/ui/app/components/chart-primitives/area.hbs
+++ b/ui/app/components/chart-primitives/area.hbs
@@ -1,0 +1,13 @@
+<defs>
+  <linearGradient x1="0" x2="0" y1="0" y2="1" class="{{this.colorClass}}" id="{{this.fillId}}">
+    <stop class="start" offset="0%" />
+    <stop class="end" offset="100%" />
+  </linearGradient>
+  <clipPath id="{{this.maskId}}">
+    <path class="fill" d="{{this.area}}" />
+  </clipPath>
+</defs>
+<g class="area {{this.colorClass}}" ...attributes>
+  <path class="line" d="{{this.line}}" />
+  <rect class="fill" x="0" y="0" width="{{@width}}" height="{{@height}}" fill="url(#{{this.fillId}})" clip-path="url(#{{this.maskId}})" />
+</g>

--- a/ui/app/components/chart-primitives/area.js
+++ b/ui/app/components/chart-primitives/area.js
@@ -1,0 +1,37 @@
+import Component from '@glimmer/component';
+import { default as d3Shape, area, line } from 'd3-shape';
+import uniquely from 'nomad-ui/utils/properties/uniquely';
+
+export default class ChartPrimitiveArea extends Component {
+  get colorClass() {
+    return this.args.colorClass || `${this.args.colorScale}-${this.args.index}`;
+  }
+
+  @uniquely('area-mask') maskId;
+  @uniquely('area-fill') fillId;
+
+  get line() {
+    const { xScale, yScale, xProp, yProp, curveMethod } = this.args;
+
+    const builder = line()
+      .curve(d3Shape[curveMethod])
+      .defined(d => d[yProp] != null)
+      .x(d => xScale(d[xProp]))
+      .y(d => yScale(d[yProp]));
+
+    return builder(this.args.data);
+  }
+
+  get area() {
+    const { xScale, yScale, xProp, yProp, curveMethod } = this.args;
+
+    const builder = area()
+      .curve(d3Shape[curveMethod])
+      .defined(d => d[yProp] != null)
+      .x(d => xScale(d[xProp]))
+      .y0(yScale(0))
+      .y1(d => yScale(d[yProp]));
+
+    return builder(this.args.data);
+  }
+}

--- a/ui/app/components/chart-primitives/v-annotations.hbs
+++ b/ui/app/components/chart-primitives/v-annotations.hbs
@@ -1,0 +1,17 @@
+<div data-test-annotations class="line-chart-annotations" style={{this.chartAnnotationsStyle}} ...attributes>
+  {{#each this.processed key=@key as |annotation|}}
+    <div data-test-annotation class="chart-annotation {{annotation.iconClass}} {{annotation.staggerClass}}" style={{annotation.style}}>
+      <button
+        type="button"
+        title={{annotation.label}}
+        class="indicator {{if (or
+          (and @key (eq-by @key annotation.annotation this.activeAnnotation))
+          (and (not @key) (eq annotation.annotation this.activeAnnotation))
+        ) "is-active"}}"
+        {{on "click" (fn this.selectAnnotation annotation.annotation)}}>
+        {{x-icon annotation.icon}}
+      </button>
+      <div class="line" />
+    </div>
+  {{/each}}
+</div>

--- a/ui/app/components/chart-primitives/v-annotations.js
+++ b/ui/app/components/chart-primitives/v-annotations.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import { action } from '@ember/object';
+import styleString from 'nomad-ui/utils/properties/glimmer-style-string';
 
 const iconFor = {
   error: 'cancel-circle-fill',
@@ -11,30 +12,6 @@ const iconClassFor = {
   error: 'is-danger',
   info: '',
 };
-
-// TODO: This is what styleStringProperty looks like in the pure decorator world
-function styleString(target, name, descriptor) {
-  if (!descriptor.get) throw new Error('styleString only works on getters');
-  const orig = descriptor.get;
-  descriptor.get = function() {
-    const styles = orig.apply(this);
-
-    let str = '';
-
-    if (styles) {
-      str = Object.keys(styles)
-        .reduce(function(arr, key) {
-          const val = styles[key];
-          arr.push(key + ':' + (typeof val === 'number' ? val.toFixed(2) + 'px' : val));
-          return arr;
-        }, [])
-        .join(';');
-    }
-
-    return htmlSafe(str);
-  };
-  return descriptor;
-}
 
 export default class ChartPrimitiveVAnnotations extends Component {
   @styleString

--- a/ui/app/components/chart-primitives/v-annotations.js
+++ b/ui/app/components/chart-primitives/v-annotations.js
@@ -1,0 +1,85 @@
+import Component from '@glimmer/component';
+import { htmlSafe } from '@ember/template';
+import { action } from '@ember/object';
+
+const iconFor = {
+  error: 'cancel-circle-fill',
+  info: 'info-circle-fill',
+};
+
+const iconClassFor = {
+  error: 'is-danger',
+  info: '',
+};
+
+// TODO: This is what styleStringProperty looks like in the pure decorator world
+function styleString(target, name, descriptor) {
+  if (!descriptor.get) throw new Error('styleString only works on getters');
+  const orig = descriptor.get;
+  descriptor.get = function() {
+    const styles = orig.apply(this);
+
+    let str = '';
+
+    if (styles) {
+      str = Object.keys(styles)
+        .reduce(function(arr, key) {
+          const val = styles[key];
+          arr.push(key + ':' + (typeof val === 'number' ? val.toFixed(2) + 'px' : val));
+          return arr;
+        }, [])
+        .join(';');
+    }
+
+    return htmlSafe(str);
+  };
+  return descriptor;
+}
+
+export default class ChartPrimitiveVAnnotations extends Component {
+  @styleString
+  get chartAnnotationsStyle() {
+    return {
+      height: this.args.height,
+    };
+  }
+
+  get processed() {
+    const { scale, prop, annotations, timeseries, format } = this.args;
+
+    if (!annotations || !annotations.length) return null;
+
+    let sortedAnnotations = annotations.sortBy(prop);
+    if (timeseries) {
+      sortedAnnotations = sortedAnnotations.reverse();
+    }
+
+    let prevX = 0;
+    let prevHigh = false;
+    return sortedAnnotations.map(annotation => {
+      const x = scale(annotation[prop]);
+      if (prevX && !prevHigh && Math.abs(x - prevX) < 30) {
+        prevHigh = true;
+      } else if (prevHigh) {
+        prevHigh = false;
+      }
+      const y = prevHigh ? -15 : 0;
+      const formattedX = format(timeseries)(annotation[prop]);
+
+      prevX = x;
+      return {
+        annotation,
+        style: htmlSafe(`transform:translate(${x}px,${y}px)`),
+        icon: iconFor[annotation.type],
+        iconClass: iconClassFor[annotation.type],
+        staggerClass: prevHigh ? 'is-staggered' : '',
+        label: `${annotation.type} event at ${formattedX}`,
+      };
+    });
+  }
+
+  @action
+  selectAnnotation(annotation) {
+    if (this.args.annotationClick) this.args.annotationClick(annotation);
+  }
+}

--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -4,14 +4,12 @@ import { computed } from '@ember/object';
 import { assert } from '@ember/debug';
 import { observes } from '@ember-decorators/object';
 import { computed as overridable } from 'ember-overridable-computed';
-import { guidFor } from '@ember/object/internals';
 import { run } from '@ember/runloop';
 import { htmlSafe } from '@ember/template';
 import d3 from 'd3-selection';
 import d3Scale from 'd3-scale';
 import d3Axis from 'd3-axis';
 import d3Array from 'd3-array';
-import d3Shape from 'd3-shape';
 import d3Format from 'd3-format';
 import d3TimeFormat from 'd3-time-format';
 import WindowResizable from 'nomad-ui/mixins/window-resizable';
@@ -72,16 +70,6 @@ export default class LineChart extends Component.extend(WindowResizable) {
   height = 0;
 
   isActive = false;
-
-  @computed()
-  get fillId() {
-    return `line-chart-fill-${guidFor(this)}`;
-  }
-
-  @computed()
-  get maskId() {
-    return `line-chart-mask-${guidFor(this)}`;
-  }
 
   activeDatum = null;
 
@@ -252,35 +240,6 @@ export default class LineChart extends Component.extend(WindowResizable) {
     return this.width - this.yAxisWidth;
   }
 
-  @computed('data.[]', 'xScale', 'yScale', 'curveMethod')
-  get line() {
-    const { xScale, yScale, xProp, yProp, curveMethod } = this;
-
-    const line = d3Shape
-      .line()
-      .curve(d3Shape[curveMethod])
-      .defined(d => d[yProp] != null)
-      .x(d => xScale(d[xProp]))
-      .y(d => yScale(d[yProp]));
-
-    return line(this.data);
-  }
-
-  @computed('data.[]', 'xScale', 'yScale', 'curveMethod')
-  get area() {
-    const { xScale, yScale, xProp, yProp, curveMethod } = this;
-
-    const area = d3Shape
-      .area()
-      .curve(d3Shape[curveMethod])
-      .defined(d => d[yProp] != null)
-      .x(d => xScale(d[xProp]))
-      .y0(yScale(0))
-      .y1(d => yScale(d[yProp]));
-
-    return area(this.data);
-  }
-
   @computed('annotations.[]', 'xScale', 'xProp', 'timeseries')
   get processedAnnotations() {
     const { xScale, xProp, annotations, timeseries } = this;
@@ -319,7 +278,7 @@ export default class LineChart extends Component.extend(WindowResizable) {
   didInsertElement() {
     this.updateDimensions();
 
-    const canvas = d3.select(this.element.querySelector('.canvas'));
+    const canvas = d3.select(this.element.querySelector('.hover-target'));
     const updateActiveDatum = this.updateActiveDatum.bind(this);
 
     const chart = this;

--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -5,7 +5,6 @@ import { assert } from '@ember/debug';
 import { observes } from '@ember-decorators/object';
 import { computed as overridable } from 'ember-overridable-computed';
 import { run } from '@ember/runloop';
-import { htmlSafe } from '@ember/template';
 import d3 from 'd3-selection';
 import d3Scale from 'd3-scale';
 import d3Axis from 'd3-axis';
@@ -14,7 +13,7 @@ import d3Format from 'd3-format';
 import d3TimeFormat from 'd3-time-format';
 import WindowResizable from 'nomad-ui/mixins/window-resizable';
 import styleStringProperty from 'nomad-ui/utils/properties/style-string';
-import { classNames, classNameBindings } from '@ember-decorators/component';
+import { classNames } from '@ember-decorators/component';
 import classic from 'ember-classic-decorator';
 
 // Returns a new array with the specified number of points linearly
@@ -31,24 +30,12 @@ const lerp = ([low, high], numPoints) => {
 // Round a number or an array of numbers
 const nice = val => (val instanceof Array ? val.map(nice) : Math.round(val));
 
-const iconFor = {
-  error: 'cancel-circle-fill',
-  info: 'info-circle-fill',
-};
-
-const iconClassFor = {
-  error: 'is-danger',
-  info: '',
-};
-
 @classic
 @classNames('chart', 'line-chart')
-@classNameBindings('annotations.length:with-annotations')
 export default class LineChart extends Component.extend(WindowResizable) {
   // Public API
 
   data = null;
-  annotations = null;
   activeAnnotation = null;
   onAnnotationClick() {}
   xProp = null;
@@ -238,41 +225,6 @@ export default class LineChart extends Component.extend(WindowResizable) {
   @computed('width', 'yAxisWidth')
   get yAxisOffset() {
     return this.width - this.yAxisWidth;
-  }
-
-  @computed('annotations.[]', 'xScale', 'xProp', 'timeseries')
-  get processedAnnotations() {
-    const { xScale, xProp, annotations, timeseries } = this;
-
-    if (!annotations || !annotations.length) return null;
-
-    let sortedAnnotations = annotations.sortBy(xProp);
-    if (timeseries) {
-      sortedAnnotations = sortedAnnotations.reverse();
-    }
-
-    let prevX = 0;
-    let prevHigh = false;
-    return sortedAnnotations.map(annotation => {
-      const x = xScale(annotation[xProp]);
-      if (prevX && !prevHigh && Math.abs(x - prevX) < 30) {
-        prevHigh = true;
-      } else if (prevHigh) {
-        prevHigh = false;
-      }
-      const y = prevHigh ? -15 : 0;
-      const formattedX = this.xFormat(timeseries)(annotation[xProp]);
-
-      prevX = x;
-      return {
-        annotation,
-        style: htmlSafe(`transform:translate(${x}px,${y}px)`),
-        icon: iconFor[annotation.type],
-        iconClass: iconClassFor[annotation.type],
-        staggerClass: prevHigh ? 'is-staggered' : '',
-        label: `${annotation.type} event at ${formattedX}`,
-      };
-    });
   }
 
   didInsertElement() {

--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -59,6 +59,10 @@ export default class LineChart extends Component {
     chartClass = 'is-primary';
     activeAnnotation = null;
     onAnnotationClick() {}
+    xFormat;
+    yFormat;
+    xScale;
+    yScale;
   */
 
   @tracked width = 0;

--- a/ui/app/components/scale-events-chart.js
+++ b/ui/app/components/scale-events-chart.js
@@ -1,19 +1,17 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { get } from '@ember/object';
 import { copy } from 'ember-copy';
-import { computed, get } from '@ember/object';
-import { tagName } from '@ember-decorators/component';
-import classic from 'ember-classic-decorator';
 
-@classic
-@tagName('')
 export default class ScaleEventsChart extends Component {
-  events = [];
+  /** Args
+    events = []
+  */
 
-  activeEvent = null;
+  @tracked activeEvent = null;
 
-  @computed('annotations', 'events.[]')
   get data() {
-    const data = this.events.filterBy('hasCount').sortBy('time');
+    const data = this.args.events.filterBy('hasCount').sortBy('time');
 
     // Extend the domain of the chart to the current time
     data.push({
@@ -33,9 +31,8 @@ export default class ScaleEventsChart extends Component {
     return data;
   }
 
-  @computed('events.[]')
   get annotations() {
-    return this.events.rejectBy('hasCount').map(ev => ({
+    return this.args.events.rejectBy('hasCount').map(ev => ({
       type: ev.error ? 'error' : 'info',
       time: ev.time,
       event: copy(ev),
@@ -46,11 +43,11 @@ export default class ScaleEventsChart extends Component {
     if (this.activeEvent && get(this.activeEvent, 'event.uid') === get(ev, 'event.uid')) {
       this.closeEventDetails();
     } else {
-      this.set('activeEvent', ev);
+      this.activeEvent = ev;
     }
   }
 
   closeEventDetails() {
-    this.set('activeEvent', null);
+    this.activeEvent = null;
   }
 }

--- a/ui/app/components/stats-time-series.js
+++ b/ui/app/components/stats-time-series.js
@@ -1,39 +1,26 @@
-import { computed } from '@ember/object';
+import Component from '@glimmer/component';
 import moment from 'moment';
 import d3TimeFormat from 'd3-time-format';
 import d3Format from 'd3-format';
-import d3Scale from 'd3-scale';
+import { scaleTime, scaleLinear } from 'd3-scale';
 import d3Array from 'd3-array';
-import LineChart from 'nomad-ui/components/line-chart';
-import layout from '../templates/components/line-chart';
 import formatDuration from 'nomad-ui/utils/format-duration';
-import classic from 'ember-classic-decorator';
 
-@classic
-export default class StatsTimeSeries extends LineChart {
-  layout = layout;
-
-  xProp = 'timestamp';
-  yProp = 'percent';
-  timeseries = true;
-
-  xFormat() {
+export default class StatsTimeSeries extends Component {
+  get xFormat() {
     return d3TimeFormat.timeFormat('%H:%M:%S');
   }
 
-  yFormat() {
+  get yFormat() {
     return d3Format.format('.1~%');
   }
 
   // Specific a11y descriptors
-  title = 'Stats Time Series Chart';
-
-  @computed('data.[]', 'xProp', 'yProp')
   get description() {
-    const { xProp, yProp, data } = this;
-    const yRange = d3Array.extent(data, d => d[yProp]);
-    const xRange = d3Array.extent(data, d => d[xProp]);
-    const yFormatter = this.yFormat();
+    const data = this.args.data;
+    const yRange = d3Array.extent(data, d => d.percent);
+    const xRange = d3Array.extent(data, d => d.timestamp);
+    const yFormatter = this.yFormat;
 
     const duration = formatDuration(xRange[1] - xRange[0], 'ms', true);
 
@@ -42,36 +29,30 @@ export default class StatsTimeSeries extends LineChart {
     )} to ${yFormatter(yRange[1])}`;
   }
 
-  @computed('data.[]', 'xProp', 'timeseries', 'yAxisOffset')
-  get xScale() {
-    const xProp = this.xProp;
-    const scale = this.timeseries ? d3Scale.scaleTime() : d3Scale.scaleLinear();
-    const data = this.data;
+  xScale(data, yAxisOffset) {
+    const scale = scaleTime();
 
-    const [low, high] = d3Array.extent(data, d => d[xProp]);
+    const [low, high] = d3Array.extent(data, d => d.timestamp);
     const minLow = moment(high)
       .subtract(5, 'minutes')
       .toDate();
 
     const extent = data.length ? [Math.min(low, minLow), high] : [minLow, new Date()];
-    scale.rangeRound([10, this.yAxisOffset]).domain(extent);
+    scale.rangeRound([10, yAxisOffset]).domain(extent);
 
     return scale;
   }
 
-  @computed('data.[]', 'yProp', 'xAxisOffset')
-  get yScale() {
-    const yProp = this.yProp;
-    const yValues = (this.data || []).mapBy(yProp);
+  yScale(data, xAxisOffset) {
+    const yValues = (data || []).mapBy('percent');
 
     let [low, high] = [0, 1];
     if (yValues.compact().length) {
       [low, high] = d3Array.extent(yValues);
     }
 
-    return d3Scale
-      .scaleLinear()
-      .rangeRound([this.xAxisOffset, 10])
+    return scaleLinear()
+      .rangeRound([xAxisOffset, 10])
       .domain([Math.min(0, low), Math.max(1, high)]);
   }
 }

--- a/ui/app/styles/charts/line-chart.scss
+++ b/ui/app/styles/charts/line-chart.scss
@@ -14,16 +14,18 @@
     overflow: visible;
   }
 
-  .canvas {
-    .line {
-      fill: transparent;
-      stroke-width: 1.25;
-    }
+  .hover-target {
+    fill: transparent;
+    stroke: transparent;
+  }
 
-    .hover-target {
-      fill: transparent;
-      stroke: transparent;
-    }
+  .line {
+    fill: transparent;
+    stroke-width: 1.25;
+  }
+
+  .area {
+    fill: none;
   }
 
   .axis {
@@ -60,7 +62,7 @@
   @each $name, $pair in $colors {
     $color: nth($pair, 1);
 
-    .canvas.is-#{$name} {
+    .area.is-#{$name} {
       .line {
         stroke: $color;
       }

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -8,23 +8,20 @@
       and Y-axis values range from {{this.yRange.firstObject}} to {{this.yRange.lastObject}}.
     {{/if}}
   </description>
-  <defs>
-    <linearGradient x1="0" x2="0" y1="0" y2="1" class="{{this.chartClass}}" id="{{this.fillId}}">
-      <stop class="start" offset="0%" />
-      <stop class="end" offset="100%" />
-    </linearGradient>
-    <clipPath id="{{this.maskId}}">
-      <path class="fill" d="{{this.area}}" />
-    </clipPath>
-  </defs>
   <g class="y-gridlines gridlines" transform="translate({{this.yAxisOffset}}, 0)"></g>
-  <g class="canvas {{this.chartClass}}">
-    <path class="line" d="{{this.line}}" />
-    <rect class="area" x="0" y="0" width="{{this.yAxisOffset}}" height="{{this.xAxisOffset}}" fill="url(#{{this.fillId}})" clip-path="url(#{{this.maskId}})" />
-    <rect class="hover-target" x="0" y="0" width="{{this.yAxisOffset}}" height="{{this.xAxisOffset}}" />
-  </g>
+  <ChartPrimitives::Area
+    @data={{this.data}}
+    @colorClass={{this.chartClass}}
+    @xScale={{this.xScale}}
+    @yScale={{this.yScale}}
+    @xProp={{this.xProp}}
+    @yProp={{this.yProp}}
+    @width={{this.yAxisOffset}}
+    @height={{this.xAxisOffset}}
+    @curveMethod={{this.curveMethod}} />
   <g aria-hidden="true" class="x-axis axis" transform="translate(0, {{this.xAxisOffset}})"></g>
   <g aria-hidden="true" class="y-axis axis" transform="translate({{this.yAxisOffset}}, 0)"></g>
+  <rect class="hover-target" x="0" y="0" width="{{this.yAxisOffset}}" height="{{this.xAxisOffset}}" />
 </svg>
 <div data-test-annotations class="line-chart-annotations" style={{this.chartAnnotationsStyle}}>
   {{#each this.processedAnnotations key=this.annotationKey as |annotation|}}

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -1,43 +1,50 @@
-<svg data-test-line-chart role="img" aria-labelledby="{{concat "title-" this.elementId}} {{concat "desc-" this.elementId}}">
-  <title id="{{concat "title-" this.elementId}}">{{this.title}}</title>
-  <description id="{{concat "desc-" this.elementId}}">
-    {{#if this.description}}
-      {{this.description}}
-    {{else}}
-      X-axis values range from {{this.xRange.firstObject}} to {{this.xRange.lastObject}},
-      and Y-axis values range from {{this.yRange.firstObject}} to {{this.yRange.lastObject}}.
-    {{/if}}
-  </description>
-  <g class="y-gridlines gridlines" transform="translate({{this.yAxisOffset}}, 0)"></g>
-  <ChartPrimitives::Area
-    @data={{this.data}}
-    @colorClass={{this.chartClass}}
-    @xScale={{this.xScale}}
-    @yScale={{this.yScale}}
-    @xProp={{this.xProp}}
-    @yProp={{this.yProp}}
-    @width={{this.yAxisOffset}}
-    @height={{this.xAxisOffset}}
-    @curveMethod={{this.curveMethod}} />
-  <g aria-hidden="true" class="x-axis axis" transform="translate(0, {{this.xAxisOffset}})"></g>
-  <g aria-hidden="true" class="y-axis axis" transform="translate({{this.yAxisOffset}}, 0)"></g>
-  <rect class="hover-target" x="0" y="0" width="{{this.yAxisOffset}}" height="{{this.xAxisOffset}}" />
-</svg>
-<ChartPrimitives::VAnnotations
-  @annotations={{this.annotations}}
-  @key={{this.annotationKey}}
-  @annotationClick={{action this.annotationClick}}
-  @timeseries={{this.timeseries}}
-  @format={{this.xFormat}}
-  @scale={{this.xScale}}
-  @prop={{this.xProp}}
-  @height={{this.xAxisOffset}} />
-<div class="chart-tooltip is-snappy {{if this.isActive "active" "inactive"}}" style={{this.tooltipStyle}}>
-  <p>
-    <span class="label">
-      <span class="color-swatch {{this.chartClass}}" />
-      {{this.activeDatumLabel}}
-    </span>
-    <span class="value">{{this.activeDatumValue}}</span>
-  </p>
+<div
+  class="chart line-chart"
+  ...attributes
+  {{did-insert this.onInsert}}
+  {{did-update this.renderChart}}
+  {{window-resize this.updateDimensions}}>
+  <svg data-test-line-chart role="img" aria-labelledby="{{concat "title-" this.elementId}} {{concat "desc-" this.elementId}}">
+    <title id="{{concat "title-" this.elementId}}">{{this.title}}</title>
+    <description id="{{concat "desc-" this.elementId}}">
+      {{#if this.description}}
+        {{this.description}}
+      {{else}}
+        X-axis values range from {{this.xRange.firstObject}} to {{this.xRange.lastObject}},
+        and Y-axis values range from {{this.yRange.firstObject}} to {{this.yRange.lastObject}}.
+      {{/if}}
+    </description>
+    <g class="y-gridlines gridlines" transform="translate({{this.yAxisOffset}}, 0)"></g>
+    <ChartPrimitives::Area
+      @data={{this.data}}
+      @colorClass={{this.chartClass}}
+      @xScale={{this.xScale}}
+      @yScale={{this.yScale}}
+      @xProp={{this.xProp}}
+      @yProp={{this.yProp}}
+      @width={{this.yAxisOffset}}
+      @height={{this.xAxisOffset}}
+      @curveMethod={{this.curveMethod}} />
+    <g aria-hidden="true" class="x-axis axis" transform="translate(0, {{this.xAxisOffset}})"></g>
+    <g aria-hidden="true" class="y-axis axis" transform="translate({{this.yAxisOffset}}, 0)"></g>
+    <rect class="hover-target" x="0" y="0" width="{{this.yAxisOffset}}" height="{{this.xAxisOffset}}" />
+  </svg>
+  <ChartPrimitives::VAnnotations
+    @annotations={{@annotations}}
+    @key={{@annotationKey}}
+    @annotationClick={{action this.annotationClick}}
+    @timeseries={{this.timeseries}}
+    @format={{this.xFormat}}
+    @scale={{this.xScale}}
+    @prop={{this.xProp}}
+    @height={{this.xAxisOffset}} />
+  <div class="chart-tooltip is-snappy {{if this.isActive "active" "inactive"}}" style={{this.tooltipStyle}}>
+    <p>
+      <span class="label">
+        <span class="color-swatch {{this.chartClass}}" />
+        {{this.activeDatumLabel}}
+      </span>
+      <span class="value">{{this.activeDatumValue}}</span>
+    </p>
+  </div>
 </div>

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -23,23 +23,15 @@
   <g aria-hidden="true" class="y-axis axis" transform="translate({{this.yAxisOffset}}, 0)"></g>
   <rect class="hover-target" x="0" y="0" width="{{this.yAxisOffset}}" height="{{this.xAxisOffset}}" />
 </svg>
-<div data-test-annotations class="line-chart-annotations" style={{this.chartAnnotationsStyle}}>
-  {{#each this.processedAnnotations key=this.annotationKey as |annotation|}}
-  <div data-test-annotation class="chart-annotation {{annotation.iconClass}} {{annotation.staggerClass}}" style={{annotation.style}}>
-      <button
-        type="button"
-        class="indicator {{if (or
-          (and this.annotationKey (eq-by this.annotationKey annotation.annotation this.activeAnnotation))
-          (and (not this.annotationKey) (eq annotation.annotation this.activeAnnotation))
-        ) "is-active"}}"
-        title={{annotation.label}}
-        onclick={{action this.annotationClick annotation.annotation}}>
-        {{x-icon annotation.icon}}
-      </button>
-      <div class="line" />
-    </div>
-  {{/each}}
-</div>
+<ChartPrimitives::VAnnotations
+  @annotations={{this.annotations}}
+  @key={{this.annotationKey}}
+  @annotationClick={{action this.annotationClick}}
+  @timeseries={{this.timeseries}}
+  @format={{this.xFormat}}
+  @scale={{this.xScale}}
+  @prop={{this.xProp}}
+  @height={{this.xAxisOffset}} />
 <div class="chart-tooltip is-snappy {{if this.isActive "active" "inactive"}}" style={{this.tooltipStyle}}>
   <p>
     <span class="label">

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -4,16 +4,16 @@
   {{did-insert this.onInsert}}
   {{did-update this.renderChart}}
   {{window-resize this.updateDimensions}}>
-  <svg data-test-line-chart role="img" aria-labelledby="{{concat "title-" this.elementId}} {{concat "desc-" this.elementId}}">
-    <title id="{{concat "title-" this.elementId}}">{{this.title}}</title>
-    <description id="{{concat "desc-" this.elementId}}">
+  <svg data-test-line-chart aria-labelledby="{{this.titleId}}" aria-describedby="{{this.descriptionId}}">
+    <title id="{{this.titleId}}">{{this.title}}</title>
+    <desc id="{{this.descriptionId}}">
       {{#if this.description}}
         {{this.description}}
       {{else}}
         X-axis values range from {{this.xRange.firstObject}} to {{this.xRange.lastObject}},
         and Y-axis values range from {{this.yRange.firstObject}} to {{this.yRange.lastObject}}.
       {{/if}}
-    </description>
+    </desc>
     <g class="y-gridlines gridlines" transform="translate({{this.yAxisOffset}}, 0)"></g>
     <ChartPrimitives::Area
       @data={{this.data}}
@@ -33,7 +33,7 @@
     @annotations={{@annotations}}
     @key={{@annotationKey}}
     @annotationClick={{action this.annotationClick}}
-    @timeseries={{this.timeseries}}
+    @timeseries={{@timeseries}}
     @format={{this.xFormat}}
     @scale={{this.xScale}}
     @prop={{this.xProp}}

--- a/ui/app/templates/components/stats-time-series.hbs
+++ b/ui/app/templates/components/stats-time-series.hbs
@@ -1,0 +1,12 @@
+<LineChart
+  @data={{@data}}
+  @xProp="timestamp"
+  @yProp="percent"
+  @chartClass={{@chartClass}}
+  @timeseries={{true}}
+  @title="Stats Time Series Chart"
+  @description={{this.description}}
+  @xScale={{this.xScale}}
+  @yScale={{this.yScale}}
+  @xFormat={{this.xFormat}}
+  @yFormat={{this.yFormat}} />

--- a/ui/app/utils/properties/glimmer-style-string.js
+++ b/ui/app/utils/properties/glimmer-style-string.js
@@ -1,0 +1,31 @@
+import { htmlSafe } from '@ember/template';
+
+// A decorator for transforming an object into an html
+// compatible style attribute string.
+//
+// ex. @styleString
+//     get styleStr() {
+//       return { color: '#FF0', 'border-width': '1px' }
+//     }
+export default function styleString(target, name, descriptor) {
+  if (!descriptor.get) throw new Error('styleString only works on getters');
+  const orig = descriptor.get;
+  descriptor.get = function() {
+    const styles = orig.apply(this);
+
+    let str = '';
+
+    if (styles) {
+      str = Object.keys(styles)
+        .reduce(function(arr, key) {
+          const val = styles[key];
+          arr.push(key + ':' + (typeof val === 'number' ? val.toFixed(2) + 'px' : val));
+          return arr;
+        }, [])
+        .join(';');
+    }
+
+    return htmlSafe(str);
+  };
+  return descriptor;
+}

--- a/ui/app/utils/properties/uniquely.js
+++ b/ui/app/utils/properties/uniquely.js
@@ -1,0 +1,12 @@
+import { computed } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+
+// An Ember.Computed property for creating a unique string with a
+// common prefix (based on the guid of the object with the property)
+//
+// ex. @uniquely('name') // 'name-ember129383'
+export default function uniquely(prefix) {
+  return computed(function() {
+    return `${prefix}-${guidFor(this)}`;
+  });
+}

--- a/ui/stories/charts/line-chart.stories.js
+++ b/ui/stories/charts/line-chart.stories.js
@@ -153,6 +153,7 @@ export let Annotations = () => {
       <div class="block" style="height:250px">
         {{#if (and this.data this.annotations)}}
           <LineChart
+            class="with-annotations"
             @timeseries={{true}}
             @xProp="x"
             @yProp="y"
@@ -166,6 +167,7 @@ export let Annotations = () => {
       <div class="block" style="height:150px; width:450px">
         {{#if (and this.data this.annotations)}}
           <LineChart
+            class="with-annotations"
             @timeseries={{true}}
             @xProp="x"
             @yProp="y"

--- a/ui/stories/charts/line-chart.stories.js
+++ b/ui/stories/charts/line-chart.stories.js
@@ -112,7 +112,7 @@ export let LiveData = () => {
           clearInterval(this.timer);
         },
 
-        secondsFormat() {
+        get secondsFormat() {
           return date => moment(date).format('HH:mm:ss');
         },
       }).create(),

--- a/ui/stories/utils/delayed-array.js
+++ b/ui/stories/utils/delayed-array.js
@@ -12,9 +12,11 @@ export default ArrayProxy.extend({
   init(array) {
     this.set('content', A([]));
     this._super(...arguments);
+    this[Symbol.iterator] = this.content[Symbol.iterator];
 
     next(this, () => {
       this.set('content', A(array));
+      this[Symbol.iterator] = this.content[Symbol.iterator];
     });
   },
 });

--- a/ui/tests/helpers/glimmer-factory.js
+++ b/ui/tests/helpers/glimmer-factory.js
@@ -24,7 +24,7 @@ export default function setupGlimmerComponentFactory(hooks, componentKey) {
 // Look up the component class in the glimmer component manager and return a
 // function to construct components as if they were functions.
 function glimmerComponentInstantiator(owner, componentKey) {
-  return args => {
+  return (args = {}) => {
     const componentManager = owner.lookup('component-manager:glimmer');
     const componentClass = owner.factoryFor(`component:${componentKey}`).class;
     return componentManager.createComponent(componentClass, { named: args });

--- a/ui/tests/integration/components/line-chart-test.js
+++ b/ui/tests/integration/components/line-chart-test.js
@@ -8,14 +8,21 @@ import { componentA11yAudit } from 'nomad-ui/tests/helpers/a11y-audit';
 
 const REF_DATE = new Date();
 
-module('Integration | Component | line chart', function(hooks) {
+module('Integration | Component | line-chart', function(hooks) {
   setupRenderingTest(hooks);
 
   test('when a chart has annotations, they are rendered in order', async function(assert) {
-    const annotations = [{ x: 2, type: 'info' }, { x: 1, type: 'error' }, { x: 3, type: 'info' }];
+    const annotations = [
+      { x: 2, type: 'info' },
+      { x: 1, type: 'error' },
+      { x: 3, type: 'info' },
+    ];
     this.setProperties({
       annotations,
-      data: [{ x: 1, y: 1 }, { x: 10, y: 10 }],
+      data: [
+        { x: 1, y: 1 },
+        { x: 10, y: 10 },
+      ],
     });
 
     await render(hbs`
@@ -61,7 +68,10 @@ module('Integration | Component | line chart', function(hooks) {
     ];
     this.setProperties({
       annotations,
-      data: [{ x: 1, y: 1 }, { x: 10, y: 10 }],
+      data: [
+        { x: 1, y: 1 },
+        { x: 10, y: 10 },
+      ],
     });
 
     await render(hbs`
@@ -87,7 +97,10 @@ module('Integration | Component | line chart', function(hooks) {
     const annotations = [{ x: 2, type: 'info', meta: { data: 'here' } }];
     this.setProperties({
       annotations,
-      data: [{ x: 1, y: 1 }, { x: 10, y: 10 }],
+      data: [
+        { x: 1, y: 1 },
+        { x: 10, y: 10 },
+      ],
       click: sinon.spy(),
     });
 
@@ -105,10 +118,17 @@ module('Integration | Component | line chart', function(hooks) {
   });
 
   test('annotations will have staggered heights when too close to be positioned side-by-side', async function(assert) {
-    const annotations = [{ x: 2, type: 'info' }, { x: 2.4, type: 'error' }, { x: 9, type: 'info' }];
+    const annotations = [
+      { x: 2, type: 'info' },
+      { x: 2.4, type: 'error' },
+      { x: 9, type: 'info' },
+    ];
     this.setProperties({
       annotations,
-      data: [{ x: 1, y: 1 }, { x: 10, y: 10 }],
+      data: [
+        { x: 1, y: 1 },
+        { x: 10, y: 10 },
+      ],
       click: sinon.spy(),
     });
 

--- a/ui/tests/integration/components/primary-metric-test.js
+++ b/ui/tests/integration/components/primary-metric-test.js
@@ -90,7 +90,7 @@ module('Integration | Component | primary metric', function(hooks) {
     await render(commonTemplate);
 
     assert.ok(
-      find('[data-test-line-chart] .canvas').classList.contains('is-info'),
+      find('[data-test-line-chart] .area').classList.contains('is-info'),
       'Info class for CPU metric'
     );
   });
@@ -106,7 +106,7 @@ module('Integration | Component | primary metric', function(hooks) {
     await render(commonTemplate);
 
     assert.ok(
-      find('[data-test-line-chart] .canvas').classList.contains('is-danger'),
+      find('[data-test-line-chart] .area').classList.contains('is-danger'),
       'Danger class for Memory metric'
     );
   });

--- a/ui/tests/unit/components/line-chart-test.js
+++ b/ui/tests/unit/components/line-chart-test.js
@@ -1,9 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import d3Format from 'd3-format';
+import setupGlimmerComponentFactory from 'nomad-ui/tests/helpers/glimmer-factory';
 
 module('Unit | Component | line-chart', function(hooks) {
   setupTest(hooks);
+  setupGlimmerComponentFactory(hooks, 'line-chart');
 
   const data = [
     { foo: 1, bar: 100 },
@@ -14,14 +16,12 @@ module('Unit | Component | line-chart', function(hooks) {
   ];
 
   test('x scale domain is the min and max values in data based on the xProp value', function(assert) {
-    const chart = this.owner.factoryFor('component:line-chart').create();
-
-    chart.setProperties({
+    const chart = this.createComponent({
       xProp: 'foo',
       data,
     });
 
-    let [xDomainLow, xDomainHigh] = chart.get('xScale').domain();
+    let [xDomainLow, xDomainHigh] = chart.xScale.domain();
     assert.equal(
       xDomainLow,
       Math.min(...data.mapBy('foo')),
@@ -33,21 +33,19 @@ module('Unit | Component | line-chart', function(hooks) {
       'Domain upper bound is the highest foo value'
     );
 
-    chart.set('data', [...data, { foo: 12, bar: 600 }]);
+    chart.args.data = [...data, { foo: 12, bar: 600 }];
 
-    [, xDomainHigh] = chart.get('xScale').domain();
+    [, xDomainHigh] = chart.xScale.domain();
     assert.equal(xDomainHigh, 12, 'When the data changes, the xScale is recalculated');
   });
 
   test('y scale domain uses the max value in the data based off of yProp, but is always zero-based', function(assert) {
-    const chart = this.owner.factoryFor('component:line-chart').create();
-
-    chart.setProperties({
+    const chart = this.createComponent({
       yProp: 'bar',
       data,
     });
 
-    let [yDomainLow, yDomainHigh] = chart.get('yScale').domain();
+    let [yDomainLow, yDomainHigh] = chart.yScale.domain();
     assert.equal(yDomainLow, 0, 'Domain lower bound is always 0');
     assert.equal(
       yDomainHigh,
@@ -55,54 +53,47 @@ module('Unit | Component | line-chart', function(hooks) {
       'Domain upper bound is the highest bar value'
     );
 
-    chart.set('data', [...data, { foo: 12, bar: 600 }]);
+    chart.args.data = [...data, { foo: 12, bar: 600 }];
 
-    [, yDomainHigh] = chart.get('yScale').domain();
+    [, yDomainHigh] = chart.yScale.domain();
     assert.equal(yDomainHigh, 600, 'When the data changes, the yScale is recalculated');
   });
 
   test('the number of yTicks is always odd (to always have a mid-line) and is based off the chart height', function(assert) {
-    const chart = this.owner.factoryFor('component:line-chart').create();
-
-    chart.setProperties({
+    const chart = this.createComponent({
       yProp: 'bar',
-      xAxisOffset: 100,
       data,
     });
 
-    assert.equal(chart.get('yTicks').length, 3);
+    chart.height = 100;
+    assert.equal(chart.yTicks.length, 3);
 
-    chart.set('xAxisOffset', 240);
-    assert.equal(chart.get('yTicks').length, 5);
+    chart.height = 240;
+    assert.equal(chart.yTicks.length, 5);
 
-    chart.set('xAxisOffset', 241);
-    assert.equal(chart.get('yTicks').length, 7);
+    chart.height = 242;
+    assert.equal(chart.yTicks.length, 7);
   });
 
   test('the values for yTicks are rounded to whole numbers', function(assert) {
-    const chart = this.owner.factoryFor('component:line-chart').create();
-
-    chart.setProperties({
+    const chart = this.createComponent({
       yProp: 'bar',
-      xAxisOffset: 100,
       data,
     });
 
-    assert.deepEqual(chart.get('yTicks'), [0, 250, 500]);
+    chart.height = 100;
+    assert.deepEqual(chart.yTicks, [0, 250, 500]);
 
-    chart.set('xAxisOffset', 240);
-    assert.deepEqual(chart.get('yTicks'), [0, 125, 250, 375, 500]);
+    chart.height = 240;
+    assert.deepEqual(chart.yTicks, [0, 125, 250, 375, 500]);
 
-    chart.set('xAxisOffset', 241);
-    assert.deepEqual(chart.get('yTicks'), [0, 83, 167, 250, 333, 417, 500]);
+    chart.height = 242;
+    assert.deepEqual(chart.yTicks, [0, 83, 167, 250, 333, 417, 500]);
   });
 
   test('the values for yTicks are fractions when the domain is between 0 and 1', function(assert) {
-    const chart = this.owner.factoryFor('component:line-chart').create();
-
-    chart.setProperties({
+    const chart = this.createComponent({
       yProp: 'bar',
-      xAxisOffset: 100,
       data: [
         { foo: 1, bar: 0.1 },
         { foo: 2, bar: 0.2 },
@@ -112,38 +103,37 @@ module('Unit | Component | line-chart', function(hooks) {
       ],
     });
 
-    assert.deepEqual(chart.get('yTicks'), [0, 0.25, 0.5]);
+    chart.height = 100;
+    assert.deepEqual(chart.yTicks, [0, 0.25, 0.5]);
   });
 
   test('activeDatumLabel is the xProp value of the activeDatum formatted with xFormat', function(assert) {
-    const chart = this.owner.factoryFor('component:line-chart').create();
-
-    chart.setProperties({
+    const chart = this.createComponent({
       xProp: 'foo',
       yProp: 'bar',
       data,
-      activeDatum: data[1],
     });
 
+    chart.activeDatum = data[1];
+
     assert.equal(
-      chart.get('activeDatumLabel'),
+      chart.activeDatumLabel,
       d3Format.format(',')(data[1].foo),
       'activeDatumLabel correctly formats the correct prop of the correct datum'
     );
   });
 
   test('activeDatumValue is the yProp value of the activeDatum formatted with yFormat', function(assert) {
-    const chart = this.owner.factoryFor('component:line-chart').create();
-
-    chart.setProperties({
+    const chart = this.createComponent({
       xProp: 'foo',
       yProp: 'bar',
       data,
-      activeDatum: data[1],
     });
 
+    chart.activeDatum = data[1];
+
     assert.equal(
-      chart.get('activeDatumValue'),
+      chart.activeDatumValue,
       d3Format.format(',.2~r')(data[1].bar),
       'activeDatumValue correctly formats the correct prop of the correct datum'
     );

--- a/ui/tests/unit/components/scale-events-chart-test.js
+++ b/ui/tests/unit/components/scale-events-chart-test.js
@@ -1,9 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import setupGlimmerComponentFactory from 'nomad-ui/tests/helpers/glimmer-factory';
 
 module('Unit | Component | scale-events-chart', function(hooks) {
   setupTest(hooks);
+  setupGlimmerComponentFactory(hooks, 'scale-events-chart');
 
   hooks.beforeEach(function() {
     this.refTime = new Date();
@@ -16,13 +18,12 @@ module('Unit | Component | scale-events-chart', function(hooks) {
   });
 
   test('the current date is appended as a datum for the line chart to render', function(assert) {
-    const chart = this.owner.factoryFor('component:scale-events-chart').create();
     const events = [
       { time: new Date('2020-08-02T04:06:00'), count: 2, hasCount: true },
       { time: new Date('2020-08-01T04:06:00'), count: 2, hasCount: true },
     ];
 
-    chart.set('events', events);
+    const chart = this.createComponent({ events });
 
     assert.equal(chart.data.length, events.length + 1);
     assert.deepEqual(chart.data.slice(0, events.length), events.sortBy('time'));
@@ -33,7 +34,6 @@ module('Unit | Component | scale-events-chart', function(hooks) {
   });
 
   test('if the earliest annotation is outside the domain of the events, the earliest annotation time is added as a datum for the line chart to render', function(assert) {
-    const chart = this.owner.factoryFor('component:scale-events-chart').create();
     const annotationOutside = [
       { time: new Date('2020-08-01T04:06:00'), hasCount: false, error: true },
       { time: new Date('2020-08-02T04:06:00'), count: 2, hasCount: true },
@@ -45,7 +45,7 @@ module('Unit | Component | scale-events-chart', function(hooks) {
       { time: new Date('2020-08-03T04:06:00'), count: 2, hasCount: true },
     ];
 
-    chart.set('events', annotationOutside);
+    const chart = this.createComponent({ events: annotationOutside });
 
     assert.equal(chart.data.length, annotationOutside.length + 1);
     assert.deepEqual(
@@ -57,7 +57,7 @@ module('Unit | Component | scale-events-chart', function(hooks) {
     assert.equal(appendedDatum.count, annotationOutside[1].count);
     assert.equal(+appendedDatum.time, +annotationOutside[0].time);
 
-    chart.set('events', annotationInside);
+    chart.args.events = annotationInside;
 
     assert.equal(chart.data.length, annotationOutside.length);
     assert.deepEqual(


### PR DESCRIPTION
This PR does three things:

1. Pulls common chart primitives out of `LineChart` and into their own components
2. Refactors `StatsTimeSeries` to use composition instead of inheritance to get `LineCharts` base features
3. Converts `LineChart`, `StatsTimeSeries`, and `ScaleEventsChart` into Glimmer components.

Converting everything ended up being a doozy, but the before and after stats on `line-chart.js` tell the story, imo. Down from 435 lines to 324 lines with more reductions planned.

------------------------

This PR is the first step in the following project that concludes with improved stats charts:

1. **Pull common chart primitives out of `LineChart`**
2. Use contextual components to reduce the responsibilities and API surface area of `LineChart`
3. Add multi-area support and horizontal annotations to `LineChart` via the new contextual component interface 