### PR TITLE
Handle Consul API URL protocol mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ IMPROVEMENTS:
  * agent: Removed leading whitespace from JSON-formatted log output. [[GH-9795](https://github.com/hashicorp/nomad/issues/9795)]
  * cli: Added optional `-task <task-name>` flag to `alloc logs` to match `alloc exec` [[GH-10026](https://github.com/hashicorp/nomad/issues/10026)]
  * cli: Improved `scaling policy` commands with -verbose, auto-completion, and prefix-matching [[GH-9964](https://github.com/hashicorp/nomad/issues/9964)]
+ * cli: Fixed a bug where `nomad operator debug` incorrectly parsed https Consul API URLs. [[GH-9625](https://github.com/hashicorp/nomad/pull/10082)]
  * consul/connect: Enable custom sidecar tasks to use connect expose checks [[GH-9995](https://github.com/hashicorp/nomad/pull/9995)]
  * consul/connect: Added validation to prevent `connect` blocks from being added to task services. [[GH-9817](https://github.com/hashicorp/nomad/issues/9817)]
  * consul/connect: Made handling of sidecar task container image URLs consistent with the `docker` task driver. [[GH-9580](https://github.com/hashicorp/nomad/issues/9580)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BUG FIXES:
  * api: Added missing devices block to AllocatedTaskResources [[GH-10064](https://github.com/hashicorp/nomad/pull/10064)]
  * cli: Fixed a bug where non-int proxy port would panic CLI [[GH-10072](https://github.com/hashicorp/nomad/issues/10072)]
+ * cli: Fixed a bug where `nomad operator debug` incorrectly parsed https Consul API URLs. [[GH-10082](https://github.com/hashicorp/nomad/pull/10082)]
 
 ## 1.0.4 (February 24, 2021)
 
@@ -14,7 +15,6 @@ IMPROVEMENTS:
  * agent: Removed leading whitespace from JSON-formatted log output. [[GH-9795](https://github.com/hashicorp/nomad/issues/9795)]
  * cli: Added optional `-task <task-name>` flag to `alloc logs` to match `alloc exec` [[GH-10026](https://github.com/hashicorp/nomad/issues/10026)]
  * cli: Improved `scaling policy` commands with -verbose, auto-completion, and prefix-matching [[GH-9964](https://github.com/hashicorp/nomad/issues/9964)]
- * cli: Fixed a bug where `nomad operator debug` incorrectly parsed https Consul API URLs. [[GH-9625](https://github.com/hashicorp/nomad/pull/10082)]
  * consul/connect: Enable custom sidecar tasks to use connect expose checks [[GH-9995](https://github.com/hashicorp/nomad/pull/9995)]
  * consul/connect: Added validation to prevent `connect` blocks from being added to task services. [[GH-9817](https://github.com/hashicorp/nomad/issues/9817)]
  * consul/connect: Made handling of sidecar task container image URLs consistent with the `docker` task driver. [[GH-9580](https://github.com/hashicorp/nomad/issues/9580)]

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1064,6 +1064,10 @@ func (e *external) addr(defaultAddr string) string {
 		if strings.HasPrefix(e.addrVal, "http:") {
 			return e.addrVal
 		}
+		if strings.HasPrefix(e.addrVal, "https:") {
+			// Mismatch: e.ssl=false but addrVal is https
+			return strings.ReplaceAll(e.addrVal, "https://", "http://")
+		}
 		return "http://" + e.addrVal
 	}
 
@@ -1072,7 +1076,8 @@ func (e *external) addr(defaultAddr string) string {
 	}
 
 	if strings.HasPrefix(e.addrVal, "http:") {
-		return "https:" + e.addrVal[5:]
+		// Mismatch: e.ssl=true but addrVal is http
+		return strings.ReplaceAll(e.addrVal, "http://", "https://")
 	}
 
 	return "https://" + e.addrVal

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -433,17 +433,35 @@ func TestDebug_Utils(t *testing.T) {
 	require.Empty(t, xs)
 
 	// address calculation honors CONSUL_HTTP_SSL
-	e := &external{addrVal: "http://127.0.0.1:8500", ssl: true}
-	require.Equal(t, "https://127.0.0.1:8500", e.addr("foo"))
+	// ssl: true - Correct alignment
+	e := &external{addrVal: "https://127.0.0.1:8500", ssl: true}
+	addr := e.addr("foo")
+	require.Equal(t, "https://127.0.0.1:8500", addr)
 
-	e = &external{addrVal: "http://127.0.0.1:8500", ssl: false}
-	require.Equal(t, "http://127.0.0.1:8500", e.addr("foo"))
+	// ssl: true - protocol incorrect
+	e = &external{addrVal: "http://127.0.0.1:8500", ssl: true}
+	addr = e.addr("foo")
+	require.Equal(t, "https://127.0.0.1:8500", addr)
 
-	e = &external{addrVal: "127.0.0.1:8500", ssl: false}
-	require.Equal(t, "http://127.0.0.1:8500", e.addr("foo"))
-
+	// ssl: true - protocol missing
 	e = &external{addrVal: "127.0.0.1:8500", ssl: true}
-	require.Equal(t, "https://127.0.0.1:8500", e.addr("foo"))
+	addr = e.addr("foo")
+	require.Equal(t, "https://127.0.0.1:8500", addr)
+
+	// ssl: false - correct alignment
+	e = &external{addrVal: "http://127.0.0.1:8500", ssl: false}
+	addr = e.addr("foo")
+	require.Equal(t, "http://127.0.0.1:8500", addr)
+
+	// ssl: false - protocol incorrect
+	e = &external{addrVal: "https://127.0.0.1:8500", ssl: false}
+	addr = e.addr("foo")
+	require.Equal(t, "http://127.0.0.1:8500", addr)
+
+	// ssl: false - protocol missing
+	e = &external{addrVal: "127.0.0.1:8500", ssl: false}
+	addr = e.addr("foo")
+	require.Equal(t, "http://127.0.0.1:8500", addr)
 }
 
 func TestDebug_WriteBytes_Nil(t *testing.T) {


### PR DESCRIPTION
This fixes a bug in nomad operator debug that occurred when an HTTPS address was specified for Consul, either through the `-consul-http-addr` CLI argument or `CONSUL_HTTP_ADDR` environment variable

Fixes #10081 