### PR TITLE
UI: Line Chart contextual components

### DIFF
--- a/ui/.storybook/babel.config.js
+++ b/ui/.storybook/babel.config.js
@@ -1,4 +1,11 @@
 /* eslint-env node */
+
+// Inject the named blocks polyfill into the template compiler (and then into the babel plugin)
+const templateCompiler = require('ember-source/dist/ember-template-compiler');
+const namedBlocksPolyfillPlugin = require('ember-named-blocks-polyfill/lib/named-blocks-polyfill-plugin');
+
+templateCompiler.registerPlugin('ast', namedBlocksPolyfillPlugin);
+
 module.exports = {
   presets: [
     [
@@ -23,5 +30,20 @@ module.exports = {
     ['@babel/plugin-proposal-object-rest-spread', { loose: true, useBuiltIns: true }],
     'babel-plugin-macros',
     ['emotion', { sourceMap: true, autoLabel: true }],
+    [
+      'babel-plugin-htmlbars-inline-precompile',
+      {
+        precompile: templateCompiler.precompile,
+        modules: {
+          'ember-cli-htmlbars': 'hbs',
+          'ember-cli-htmlbars-inline-precompile': 'default',
+          'htmlbars-inline-precompile': 'default',
+        },
+      },
+      // This is an arbitrary label to prevent a collision with the existing htmlbars inline precompile
+      // plugin that comes in from the @storybook/ember defaults.
+      // TODO: After upgrading to Storybook 6.1 this should move into the new emberOptions construct.
+      'override',
+    ],
   ],
 };

--- a/ui/app/components/chart-primitives/area.js
+++ b/ui/app/components/chart-primitives/area.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
 import { default as d3Shape, area, line } from 'd3-shape';
 import uniquely from 'nomad-ui/utils/properties/uniquely';
 
@@ -10,11 +11,23 @@ export default class ChartPrimitiveArea extends Component {
   @uniquely('area-mask') maskId;
   @uniquely('area-fill') fillId;
 
+  get curveMethod() {
+    const mappings = {
+      linear: 'curveLinear',
+      stepAfter: 'curveStepAfter',
+    };
+    assert(
+      `Provided curve "${this.curve}" is not an allowed curve type`,
+      mappings[this.args.curve]
+    );
+    return mappings[this.args.curve];
+  }
+
   get line() {
-    const { xScale, yScale, xProp, yProp, curveMethod } = this.args;
+    const { xScale, yScale, xProp, yProp } = this.args;
 
     const builder = line()
-      .curve(d3Shape[curveMethod])
+      .curve(d3Shape[this.curveMethod])
       .defined(d => d[yProp] != null)
       .x(d => xScale(d[xProp]))
       .y(d => yScale(d[yProp]));
@@ -23,10 +36,10 @@ export default class ChartPrimitiveArea extends Component {
   }
 
   get area() {
-    const { xScale, yScale, xProp, yProp, curveMethod } = this.args;
+    const { xScale, yScale, xProp, yProp } = this.args;
 
     const builder = area()
-      .curve(d3Shape[curveMethod])
+      .curve(d3Shape[this.curveMethod])
       .defined(d => d[yProp] != null)
       .x(d => xScale(d[xProp]))
       .y0(yScale(0))

--- a/ui/app/components/chart-primitives/v-annotations.hbs
+++ b/ui/app/components/chart-primitives/v-annotations.hbs
@@ -5,8 +5,8 @@
         type="button"
         title={{annotation.label}}
         class="indicator {{if (or
-          (and @key (eq-by @key annotation.annotation this.activeAnnotation))
-          (and (not @key) (eq annotation.annotation this.activeAnnotation))
+          (and @key (eq-by @key annotation.annotation @activeAnnotation))
+          (and (not @key) (eq annotation.annotation @activeAnnotation))
         ) "is-active"}}"
         {{on "click" (fn this.selectAnnotation annotation.annotation)}}>
         {{x-icon annotation.icon}}

--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -70,6 +70,7 @@ export default class LineChart extends Component {
   @tracked activeDatum = null;
   @tracked tooltipPosition = null;
   @tracked element = null;
+  @tracked ready = false;
 
   @uniquely('title') titleId;
   @uniquely('desc') descriptionId;
@@ -289,6 +290,7 @@ export default class LineChart extends Component {
       // axis, the axes themselves are recomputed and need to
       // be re-rendered.
       this.mountD3Elements();
+      this.ready = true;
       if (this.isActive) {
         this.updateActiveDatum(this.latestMouseX);
       }

--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -209,11 +209,11 @@ export default class LineChart extends Component {
   }
 
   get xAxisOffset() {
-    return this.height - this.xAxisHeight;
+    return Math.max(0, this.height - this.xAxisHeight);
   }
 
   get yAxisOffset() {
-    return this.width - this.yAxisWidth;
+    return Math.max(0, this.width - this.yAxisWidth);
   }
 
   @action

--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { assert } from '@ember/debug';
 import { run } from '@ember/runloop';
 import d3 from 'd3-selection';
 import d3Scale from 'd3-scale';
@@ -119,15 +118,6 @@ export default class LineChart extends Component {
 
     const y = datum[this.yProp];
     return this.yFormat()(y);
-  }
-
-  get curveMethod() {
-    const mappings = {
-      linear: 'curveLinear',
-      stepAfter: 'curveStepAfter',
-    };
-    assert(`Provided curve "${this.curve}" is not an allowed curve type`, mappings[this.curve]);
-    return mappings[this.curve];
   }
 
   @styleString

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -15,29 +15,33 @@
       {{/if}}
     </desc>
     <g class="y-gridlines gridlines" transform="translate({{this.yAxisOffset}}, 0)"></g>
-    <ChartPrimitives::Area
-      @data={{this.data}}
-      @colorClass={{this.chartClass}}
-      @xScale={{this.xScale}}
-      @yScale={{this.yScale}}
-      @xProp={{this.xProp}}
-      @yProp={{this.yProp}}
-      @width={{this.yAxisOffset}}
-      @height={{this.xAxisOffset}}
-      @curveMethod={{this.curveMethod}} />
+    {{#if this.ready}}
+      {{yield (hash
+        Area=(component "chart-primitives/area"
+          colorClass=this.chartClass
+          curve="linear"
+          xScale=this.xScale
+          yScale=this.yScale
+          xProp=this.xProp
+          yProp=this.yProp
+          width=this.yAxisOffset
+          height=this.xAxisOffset)
+      ) to="svg"}}
+    {{/if}}
     <g aria-hidden="true" class="x-axis axis" transform="translate(0, {{this.xAxisOffset}})"></g>
     <g aria-hidden="true" class="y-axis axis" transform="translate({{this.yAxisOffset}}, 0)"></g>
     <rect class="hover-target" x="0" y="0" width="{{this.yAxisOffset}}" height="{{this.xAxisOffset}}" />
   </svg>
-  <ChartPrimitives::VAnnotations
-    @annotations={{@annotations}}
-    @key={{@annotationKey}}
-    @annotationClick={{action this.annotationClick}}
-    @timeseries={{@timeseries}}
-    @format={{this.xFormat}}
-    @scale={{this.xScale}}
-    @prop={{this.xProp}}
-    @height={{this.xAxisOffset}} />
+  {{#if this.ready}}
+    {{yield (hash
+      VAnnotations=(component "chart-primitives/v-annotations"
+        timeseries=@timeseries
+        format=this.xFormat
+        scale=this.xScale
+        prop=this.xProp
+        height=this.xAxisOffset)
+    ) to="after"}}
+  {{/if}}
   <div class="chart-tooltip is-snappy {{if this.isActive "active" "inactive"}}" style={{this.tooltipStyle}}>
     <p>
       <span class="label">

--- a/ui/app/templates/components/scale-events-chart.hbs
+++ b/ui/app/templates/components/scale-events-chart.hbs
@@ -1,13 +1,21 @@
 <LineChart
   @timeseries={{true}}
-  @curve="stepAfter"
   @xProp="time"
   @yProp="count"
-  @data={{this.data}}
-  @annotations={{this.annotations}}
-  @activeAnnotation={{this.activeEvent}}
-  @annotationKey="event.uid"
-  @onAnnotationClick={{action this.toggleEvent}} />
+  @data={{this.data}}>
+  <:svg as |c|>
+    <c.Area
+      @curve="stepAfter"
+      @data={{this.data}} />
+  </:svg>
+  <:after as |c|>
+    <c.VAnnotations
+      @annotations={{this.annotations}}
+      @key="event.uid"
+      @activeAnnotation={{this.activeEvent}}
+      @annotationClick={{action this.toggleEvent}} />
+  </:after>
+</LineChart>
 {{#if this.activeEvent}}
   <div data-test-event-details>
     <div class="event">

--- a/ui/app/templates/components/stats-time-series.hbs
+++ b/ui/app/templates/components/stats-time-series.hbs
@@ -9,4 +9,8 @@
   @xScale={{this.xScale}}
   @yScale={{this.yScale}}
   @xFormat={{this.xFormat}}
-  @yFormat={{this.yFormat}} />
+  @yFormat={{this.yFormat}}>
+  <:svg as |c|>
+    <c.Area @data={{@data}} @colorClass={{@chartClass}} />
+  </:svg>
+</LineChart>

--- a/ui/package.json
+++ b/ui/package.json
@@ -88,6 +88,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-modifier": "^2.1.1",
     "ember-moment": "^7.8.1",
+    "ember-named-blocks-polyfill": "^0.2.4",
     "ember-overridable-computed": "^1.0.0",
     "ember-page-title": "^6.0.3",
     "ember-power-select": "^3.0.4",

--- a/ui/stories/charts/line-chart.stories.js
+++ b/ui/stories/charts/line-chart.stories.js
@@ -39,13 +39,21 @@ export let Standard = () => {
     template: hbs`
       <h5 class="title is-5">Line Chart</h5>
       <div class="block" style="height:100px; width: 400px;">
-        {{#if lineChartData}}
-          <LineChart @data={{lineChartData}} @xProp="year" @yProp="value" @chartClass="is-primary" />
+        {{#if this.lineChartData}}
+          <LineChart @data={{this.lineChartData}} @xProp="year" @yProp="value">
+            <:svg as |c|>
+              <c.Area @data={{this.lineChartData}} />
+            </:svg>
+          </LineChart>
         {{/if}}
       </div>
       <div class="block" style="height:100px; width: 400px;">
-        {{#if lineChartMild}}
-          <LineChart @data={{lineChartMild}} @xProp="year" @yProp="value" @chartClass="is-info" />
+        {{#if this.lineChartMild}}
+          <LineChart @data={{this.lineChartMild}} @xProp="year" @yProp="value" @chartClass="is-info">
+            <:svg as |c|>
+              <c.Area @data={{this.lineChartMild}} />
+            </:svg>
+          </LineChart>
         {{/if}}
       </div>
       `,
@@ -61,13 +69,21 @@ export let FluidWidth = () => {
     template: hbs`
       <h5 class="title is-5">Fluid-width Line Chart</h5>
       <div class="block" style="height:250px;">
-        {{#if lineChartData}}
-          <LineChart @data={{lineChartData}} @xProp="year" @yProp="value" @chartClass="is-danger" />
+        {{#if this.lineChartData}}
+          <LineChart @data={{this.lineChartData}} @xProp="year" @yProp="value" @chartClass="is-danger">
+            <:svg as |c|>
+              <c.Area @data={{this.lineChartData}} />
+            </:svg>
+          </LineChart>
         {{/if}}
       </div>
       <div class="block" style="height:250px;">
-        {{#if lineChartMild}}
-          <LineChart @data={{lineChartMild}} @xProp="year" @yProp="value" @chartClass="is-warning" />
+        {{#if this.lineChartMild}}
+          <LineChart @data={{this.lineChartMild}} @xProp="year" @yProp="value" @chartClass="is-warning">
+            <:svg as |c|>
+              <c.Area @data={{this.lineChartMild}} />
+            </:svg>
+          </LineChart>
         {{/if}}
       </div>
       <p class="annotation">A line chart will assume the width of its container. This includes the dimensions of the axes, which are calculated based on real DOM measurements. This requires a two-pass render: first the axes are placed with their real domains (in order to capture width and height of tick labels), second the axes are adjusted to make sure both the x and y axes are within the height and width bounds of the container.</p>
@@ -84,8 +100,18 @@ export let LiveData = () => {
     template: hbs`
       <h5 class="title is-5">Live data Line Chart</h5>
       <div class="block" style="height:250px">
-        {{#if controller.lineChartLive}}
-          <LineChart @data={{controller.lineChartLive}} @xProp="ts" @yProp="val" @timeseries={{true}} @chartClass="is-primary" @xFormat={{controller.secondsFormat}} />
+        {{#if this.controller.lineChartLive}}
+          <LineChart
+            @data={{this.controller.lineChartLive}}
+            @xProp="ts"
+            @yProp="val"
+            @timeseries={{true}}
+            @chartClass="is-primary"
+            @xFormat={{this.controller.secondsFormat}}>
+            <:svg as |c|>
+              <c.Area @data={{this.controller.lineChartLive}} />
+            </:svg>
+          </LineChart>
         {{/if}}
       </div>
       `,
@@ -125,8 +151,12 @@ export let Gaps = () => {
     template: hbs`
       <h5 class="title is-5">Line Chart data with gaps</h5>
       <div class="block" style="height:250px">
-        {{#if lineChartGapData}}
-          <LineChart @data={{lineChartGapData}} @xProp="year" @yProp="value" @chartClass="is-primary" />
+        {{#if this.lineChartGapData}}
+          <LineChart @data={{this.lineChartGapData}} @xProp="year" @yProp="value" @chartClass="is-primary">
+            <:svg as |c|>
+              <c.Area @data={{this.lineChartGapData}} />
+            </:svg>
+          </LineChart>
         {{/if}}
       </div>
       `,
@@ -157,9 +187,17 @@ export let Annotations = () => {
             @timeseries={{true}}
             @xProp="x"
             @yProp="y"
-            @data={{this.data}}
-            @annotations={{this.annotations}}
-            @onAnnotationClick={{action (mut this.activeAnnotation)}}/>
+            @data={{this.data}}>
+            <:svg as |c|>
+              <c.Area @data={{this.data}} @annotationClick={{action (mut this.activeAnnotation)}} />
+            </:svg>
+            <:after as |c|>
+              <c.VAnnotations
+                @annotations={{this.annotations}}
+                @annotationClick={{action (mut this.activeAnnotation)}}
+                @activeAnnotation={{this.activeAnnotation}} />
+            </:after>
+          </LineChart>
         {{/if}}
       </div>
       <p style="margin:2em 0; padding: 1em; background:#FFEEAC">{{this.activeAnnotation.info}}</p>
@@ -171,9 +209,17 @@ export let Annotations = () => {
             @timeseries={{true}}
             @xProp="x"
             @yProp="y"
-            @data={{this.data}}
-            @annotations={{this.annotations}}
-            @onAnnotationClick={{action (mut this.activeAnnotation)}}/>
+            @data={{this.data}}>
+            <:svg as |c|>
+              <c.Area @data={{this.data}} @annotationClick={{action (mut this.activeAnnotation)}} />
+            </:svg>
+            <:after as |c|>
+              <c.VAnnotations
+                @annotations={{this.annotations}}
+                @annotationClick={{action (mut this.activeAnnotation)}}
+                @activeAnnotation={{this.activeAnnotation}} />
+            </:after>
+          </LineChart>
         {{/if}}
       </div>
     `,
@@ -241,8 +287,11 @@ export let StepLine = () => {
           <LineChart
             @xProp="x"
             @yProp="y"
-            @curve="stepAfter"
-            @data={{this.data}} />
+            @data={{this.data}}>
+            <:svg as |c|>
+              <c.Area @data={{this.data}} @curve="stepAfter" />
+            </:svg>
+          </LineChart>
           <p>{{this.activeAnnotation.info}}</p>
         {{/if}}
       </div>

--- a/ui/tests/integration/components/line-chart-test.js
+++ b/ui/tests/integration/components/line-chart-test.js
@@ -29,8 +29,11 @@ module('Integration | Component | line-chart', function(hooks) {
       <LineChart
         @xProp="x"
         @yProp="y"
-        @data={{this.data}}
-        @annotations={{this.annotations}} />
+        @data={{this.data}}>
+        <:after as |c|>
+          <c.VAnnotations @annotations={{this.annotations}} />
+        </:after>
+      </LineChart>
     `);
 
     const sortedAnnotations = annotations.sortBy('x');
@@ -79,8 +82,11 @@ module('Integration | Component | line-chart', function(hooks) {
         @xProp="x"
         @yProp="y"
         @timeseries={{true}}
-        @data={{this.data}}
-        @annotations={{this.annotations}} />
+        @data={{this.data}}>
+        <:after as |c|>
+          <c.VAnnotations @annotations={{this.annotations}} />
+        </:after>
+      </LineChart>
     `);
 
     const sortedAnnotations = annotations.sortBy('x').reverse();
@@ -108,9 +114,11 @@ module('Integration | Component | line-chart', function(hooks) {
       <LineChart
         @xProp="x"
         @yProp="y"
-        @data={{this.data}}
-        @annotations={{this.annotations}}
-        @onAnnotationClick={{this.click}} />
+        @data={{this.data}}>
+        <:after as |c|>
+          <c.VAnnotations @annotations={{this.annotations}} @annotationClick={{this.click}} />
+        </:after>
+      </LineChart>
     `);
 
     await click('[data-test-annotation] button');
@@ -137,8 +145,11 @@ module('Integration | Component | line-chart', function(hooks) {
         <LineChart
           @xProp="x"
           @yProp="y"
-          @data={{this.data}}
-          @annotations={{this.annotations}} />
+          @data={{this.data}}>
+          <:after as |c|>
+            <c.VAnnotations @annotations={{this.annotations}} />
+          </:after>
+        </LineChart>
       </div>
     `);
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7398,6 +7398,14 @@ ember-moment@^7.8.1:
     ember-getowner-polyfill "^2.2.0"
     ember-macro-helpers "^2.1.0"
 
+ember-named-blocks-polyfill@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/ember-named-blocks-polyfill/-/ember-named-blocks-polyfill-0.2.4.tgz#f5f30711ee89244927b55aae7fa9630edaadc974"
+  integrity sha512-PsohC7ejjS7V++6i/JSy0pl1hXLV3IS3Qs+O7SrjIPYcg1UEmUwqgPiDmXqNgy0p2dc5TK5bIJTtX8wofCI63Q==
+  dependencies:
+    ember-cli-babel "^7.19.0"
+    ember-cli-version-checker "^5.1.1"
+
 ember-native-dom-helpers@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.7.0.tgz#98a87c11a391cec5c12382a4857e59ea2fb4b00a"


### PR DESCRIPTION
**WIP:** Still need to update the line chart stories and reassess test coverage.

In addition to using contextual components, this PR brings in the [named blocks polyfill](https://github.com/ember-polyfills/ember-named-blocks-polyfill) that will be released in Ember core in 3.25. This is due to some yielded components needing to be in the SVG while others need to be outside (e.g., annotations are HTML and cannot be in the SVG).

---------------
This PR is the second step in the following project that concludes with improved stats charts:

1. Pull common chart primitives out of LineChart
2. **Use contextual components to reduce the responsibilities and API surface area of LineChart**
3. Add multi-area support and horizontal annotations to LineChart via the new contextual component interface