### PR TITLE
RPC endpoints to support 'nomad ui -login'

### DIFF
--- a/helper/raftutil/msgtypes.go
+++ b/helper/raftutil/msgtypes.go
@@ -48,6 +48,9 @@ var msgTypeNames = map[structs.MessageType]string{
 	structs.EventSinkUpsertRequestType:                   "EventSinkUpsertRequestType",
 	structs.EventSinkDeleteRequestType:                   "EventSinkDeleteRequestType",
 	structs.BatchEventSinkUpdateProgressType:             "BatchEventSinkUpdateProgressType",
+	structs.OneTimeTokenUpsertRequestType:                "OneTimeTokenUpsertRequestType",
+	structs.OneTimeTokenDeleteRequestType:                "OneTimeTokenDeleteRequestType",
+	structs.OneTimeTokenExpireRequestType:                "OneTimeTokenExpireRequestType",
 	structs.NamespaceUpsertRequestType:                   "NamespaceUpsertRequestType",
 	structs.NamespaceDeleteRequestType:                   "NamespaceDeleteRequestType",
 }

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -913,7 +913,7 @@ func (a *ACL) ExchangeOneTimeToken(args *structs.OneTimeTokenExchangeRequest, re
 		return structs.ErrPermissionDenied
 	}
 
-	// Look for the token
+	// Look for the token; it may have been deleted, in which case, 403
 	aclToken, err := state.ACLTokenByAccessorID(nil, ott.AccessorID)
 	if err != nil {
 		return err

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -839,3 +839,130 @@ func (a *ACL) ResolveToken(args *structs.ResolveACLTokenRequest, reply *structs.
 	}
 	return nil
 }
+
+func (a *ACL) UpsertOneTimeToken(args *structs.OneTimeTokenUpsertRequest, reply *structs.OneTimeTokenUpsertResponse) error {
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
+	if done, err := a.srv.forward(
+		"ACL.UpsertOneTimeToken", args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince(
+		[]string{"nomad", "acl", "upsert_one_time_token"}, time.Now())
+
+	// Snapshot the state
+	state, err := a.srv.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
+	// Look up the token; there's no capability check as you can only
+	// request a OTT for your own ACL token
+	aclToken, err := state.ACLTokenBySecretID(nil, args.AuthToken)
+	if err != nil {
+		return err
+	}
+	if aclToken == nil {
+		return structs.ErrPermissionDenied
+	}
+
+	ott := &structs.OneTimeToken{
+		OneTimeSecretID: uuid.Generate(),
+		AccessorID:      aclToken.AccessorID,
+		ExpiresAt:       time.Now().Add(10 * time.Minute),
+	}
+
+	// Update via Raft
+	_, index, err := a.srv.raftApply(structs.OneTimeTokenUpsertRequestType, ott)
+	if err != nil {
+		return err
+	}
+
+	ott.ModifyIndex = index
+	ott.CreateIndex = index
+	reply.OneTimeToken = ott
+	reply.Index = index
+	return nil
+}
+
+// ExchangeOneTimeToken provides a one-time token's secret ID to exchange it
+// for the ACL token that created that one-time token
+func (a *ACL) ExchangeOneTimeToken(args *structs.OneTimeTokenExchangeRequest, reply *structs.OneTimeTokenExchangeResponse) error {
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
+	if done, err := a.srv.forward(
+		"ACL.ExchangeOneTimeToken", args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince(
+		[]string{"nomad", "acl", "exchange_one_time_token"}, time.Now())
+
+	// Snapshot the state
+	state, err := a.srv.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
+	ott, err := state.OneTimeTokenBySecret(nil, args.OneTimeSecretID)
+	if err != nil {
+		return err
+	}
+	if ott == nil {
+		return structs.ErrPermissionDenied
+	}
+
+	// Look for the token
+	aclToken, err := state.ACLTokenByAccessorID(nil, ott.AccessorID)
+	if err != nil {
+		return err
+	}
+	if aclToken == nil {
+		return structs.ErrPermissionDenied
+	}
+
+	// Expire token via raft; because this is the only write in the RPC the
+	// caller can safely retry with the same token if the raft write fails
+	_, index, err := a.srv.raftApply(structs.OneTimeTokenDeleteRequestType,
+		&structs.OneTimeTokenDeleteRequest{
+			AccessorIDs: []string{ott.AccessorID},
+		})
+	if err != nil {
+		return err
+	}
+
+	reply.Token = aclToken
+	reply.Index = index
+	return nil
+}
+
+// ExpireOneTimeTokens removes all expired tokens from the state store. It is
+// called only by garbage collection
+func (a *ACL) ExpireOneTimeTokens(args *structs.OneTimeTokenExpireRequest, reply *structs.GenericResponse) error {
+
+	if done, err := a.srv.forward(
+		"ACL.ExpireOneTimeTokens", args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince(
+		[]string{"nomad", "acl", "expire_one_time_tokens"}, time.Now())
+
+	// Check management level permissions
+	if a.srv.config.ACLEnabled {
+		if acl, err := a.srv.ResolveToken(args.AuthToken); err != nil {
+			return err
+		} else if acl == nil || !acl.IsManagement() {
+			return structs.ErrPermissionDenied
+		}
+	}
+
+	// Expire token via raft; because this is the only write in the RPC the
+	// caller can safely retry with the same token if the raft write fails
+	_, index, err := a.srv.raftApply(structs.OneTimeTokenExpireRequestType, args)
+	if err != nil {
+		return err
+	}
+	reply.Index = index
+	return nil
+}

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -1247,3 +1247,112 @@ func TestACLEndpoint_ResolveToken(t *testing.T) {
 	assert.Equal(t, uint64(1000), resp.Index)
 	assert.Nil(t, resp.Token)
 }
+
+func TestACLEndpoint_OneTimeToken(t *testing.T) {
+	t.Parallel()
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// create an ACL token
+
+	p1 := mock.ACLToken()
+	p1.AccessorID = "" // has to be blank to create
+	aclReq := &structs.ACLTokenUpsertRequest{
+		Tokens: []*structs.ACLToken{p1},
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			AuthToken: root.SecretID,
+		},
+	}
+	var aclResp structs.ACLTokenUpsertResponse
+	err := msgpackrpc.CallWithCodec(codec, "ACL.UpsertTokens", aclReq, &aclResp)
+	require.NoError(t, err)
+	aclToken := aclResp.Tokens[0]
+
+	// Generate a one-time token for this ACL token
+	upReq := &structs.OneTimeTokenUpsertRequest{
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			AuthToken: aclToken.SecretID,
+		}}
+
+	var upResp structs.OneTimeTokenUpsertResponse
+
+	// Call the upsert RPC
+	err = msgpackrpc.CallWithCodec(codec, "ACL.UpsertOneTimeToken", upReq, &upResp)
+	require.NoError(t, err)
+	result := upResp.OneTimeToken
+	require.True(t, time.Now().Before(result.ExpiresAt))
+	require.Equal(t, aclToken.AccessorID, result.AccessorID)
+
+	// make sure we can get it back out
+	ott, err := s1.fsm.State().OneTimeTokenBySecret(nil, result.OneTimeSecretID)
+	require.NoError(t, err)
+	require.NotNil(t, ott)
+
+	exReq := &structs.OneTimeTokenExchangeRequest{
+		OneTimeSecretID: result.OneTimeSecretID,
+		WriteRequest: structs.WriteRequest{
+			Region: "global", // note: not authenticated!
+		}}
+	var exResp structs.OneTimeTokenExchangeResponse
+
+	// Call the exchange RPC
+	err = msgpackrpc.CallWithCodec(codec, "ACL.ExchangeOneTimeToken", exReq, &exResp)
+	require.NoError(t, err)
+	token := exResp.Token
+	require.Equal(t, aclToken.AccessorID, token.AccessorID)
+	require.Equal(t, aclToken.SecretID, token.SecretID)
+
+	// Make sure the one-time token is gone
+	ott, err = s1.fsm.State().OneTimeTokenBySecret(nil, result.OneTimeSecretID)
+	require.NoError(t, err)
+	require.Nil(t, ott)
+
+	// directly write the OTT to the state store so that we can write an
+	// expired OTT, and query to ensure it's been written
+	index := exResp.Index
+	index += 10
+	ott = &structs.OneTimeToken{
+		OneTimeSecretID: uuid.Generate(),
+		AccessorID:      token.AccessorID,
+		ExpiresAt:       time.Now().Add(-1 * time.Minute),
+	}
+
+	err = s1.fsm.State().UpsertOneTimeToken(structs.MsgTypeTestSetup, index, ott)
+	require.NoError(t, err)
+	ott, err = s1.fsm.State().OneTimeTokenBySecret(nil, ott.OneTimeSecretID)
+	require.NoError(t, err)
+	require.NotNil(t, ott)
+
+	// Call the delete RPC, should fail without proper auth
+	expReq := &structs.OneTimeTokenExpireRequest{
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			AuthToken: aclToken.SecretID,
+		},
+	}
+	err = msgpackrpc.CallWithCodec(codec, "ACL.ExpireOneTimeTokens",
+		expReq, &structs.GenericResponse{})
+	require.EqualError(t, err, structs.ErrPermissionDenied.Error(),
+		"one-time token garbage collection requires management ACL")
+
+	// should not have caused an expiration either!
+	ott, err = s1.fsm.State().OneTimeTokenBySecret(nil, ott.OneTimeSecretID)
+	require.NoError(t, err)
+	require.NotNil(t, ott)
+
+	// Call with correct permissions
+	expReq.WriteRequest.AuthToken = root.SecretID
+	err = msgpackrpc.CallWithCodec(codec, "ACL.ExpireOneTimeTokens",
+		expReq, &structs.GenericResponse{})
+	require.NoError(t, err)
+
+	// Now the expired OTT should be gone
+	ott, err = s1.fsm.State().OneTimeTokenBySecret(nil, result.OneTimeSecretID)
+	require.NoError(t, err)
+	require.Nil(t, ott)
+}

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -213,6 +213,10 @@ type Config struct {
 	// eligible for GC. This gives users some time to debug volumes.
 	CSIVolumeClaimGCThreshold time.Duration
 
+	// OneTimeTokenGCInterval is how often we dispatch a job to GC
+	// one-time tokens.
+	OneTimeTokenGCInterval time.Duration
+
 	// EvalNackTimeout controls how long we allow a sub-scheduler to
 	// work on an evaluation before we consider it failed and Nack it.
 	// This allows that evaluation to be handed to another sub-scheduler
@@ -402,6 +406,7 @@ func DefaultConfig() *Config {
 		CSIPluginGCThreshold:             1 * time.Hour,
 		CSIVolumeClaimGCInterval:         5 * time.Minute,
 		CSIVolumeClaimGCThreshold:        5 * time.Minute,
+		OneTimeTokenGCInterval:           10 * time.Minute,
 		EvalNackTimeout:                  60 * time.Second,
 		EvalDeliveryLimit:                3,
 		EvalNackInitialReenqueueDelay:    1 * time.Second,

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -56,6 +56,8 @@ func (c *CoreScheduler) Process(eval *structs.Evaluation) error {
 		return c.csiVolumeClaimGC(eval)
 	case structs.CoreJobCSIPluginGC:
 		return c.csiPluginGC(eval)
+	case structs.CoreJobOneTimeTokenGC:
+		return c.expiredOneTimeTokenGC(eval)
 	case structs.CoreJobForceGC:
 		return c.forceGC(eval)
 	default:

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -80,7 +80,9 @@ func (c *CoreScheduler) forceGC(eval *structs.Evaluation) error {
 	if err := c.csiVolumeClaimGC(eval); err != nil {
 		return err
 	}
-
+	if err := c.expiredOneTimeTokenGC(eval); err != nil {
+		return err
+	}
 	// Node GC must occur after the others to ensure the allocations are
 	// cleared.
 	return c.nodeGC(eval)
@@ -869,4 +871,14 @@ func (c *CoreScheduler) csiPluginGC(eval *structs.Evaluation) error {
 		}
 	}
 	return nil
+}
+
+func (c *CoreScheduler) expiredOneTimeTokenGC(eval *structs.Evaluation) error {
+	req := &structs.OneTimeTokenExpireRequest{
+		WriteRequest: structs.WriteRequest{
+			Region:    c.srv.Region(),
+			AuthToken: eval.LeaderACL,
+		},
+	}
+	return c.srv.RPC("ACL.ExpireOneTimeTokens", req, &structs.GenericResponse{})
 }

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -299,6 +299,12 @@ func (n *nomadFSM) Apply(log *raft.Log) interface{} {
 		structs.EventSinkDeleteRequestType,
 		structs.BatchEventSinkUpdateProgressType:
 		return nil
+	case structs.OneTimeTokenUpsertRequestType:
+		return n.applyOneTimeTokenUpsert(msgType, buf[1:], log.Index)
+	case structs.OneTimeTokenDeleteRequestType:
+		return n.applyOneTimeTokenDelete(msgType, buf[1:], log.Index)
+	case structs.OneTimeTokenExpireRequestType:
+		return n.applyOneTimeTokenExpire(msgType, buf[1:], log.Index)
 	}
 
 	// Check enterprise only message types.
@@ -1140,6 +1146,51 @@ func (n *nomadFSM) applyACLTokenBootstrap(msgType structs.MessageType, buf []byt
 
 	if err := n.state.BootstrapACLTokens(msgType, index, req.ResetIndex, req.Token); err != nil {
 		n.logger.Error("BootstrapACLToken failed", "error", err)
+		return err
+	}
+	return nil
+}
+
+// applyOneTimeTokenUpsert is used to upsert a one-time token
+func (n *nomadFSM) applyOneTimeTokenUpsert(msgType structs.MessageType, buf []byte, index uint64) interface{} {
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_one_time_token_upsert"}, time.Now())
+	var req structs.OneTimeToken
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+
+	if err := n.state.UpsertOneTimeToken(msgType, index, &req); err != nil {
+		n.logger.Error("UpsertOneTimeToken failed", "error", err)
+		return err
+	}
+	return nil
+}
+
+// applyOneTimeTokenDelete is used to delete a set of one-time tokens
+func (n *nomadFSM) applyOneTimeTokenDelete(msgType structs.MessageType, buf []byte, index uint64) interface{} {
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_one_time_token_delete"}, time.Now())
+	var req structs.OneTimeTokenDeleteRequest
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+
+	if err := n.state.DeleteOneTimeTokens(msgType, index, req.AccessorIDs); err != nil {
+		n.logger.Error("DeleteOneTimeToken failed", "error", err)
+		return err
+	}
+	return nil
+}
+
+// applyOneTimeTokenExpire is used to delete a set of one-time tokens
+func (n *nomadFSM) applyOneTimeTokenExpire(msgType structs.MessageType, buf []byte, index uint64) interface{} {
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_one_time_token_expire"}, time.Now())
+	var req structs.OneTimeTokenExpireRequest
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+
+	if err := n.state.ExpireOneTimeTokens(msgType, index); err != nil {
+		n.logger.Error("ExpireOneTimeToken failed", "error", err)
 		return err
 	}
 	return nil

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1175,7 +1175,7 @@ func (n *nomadFSM) applyOneTimeTokenDelete(msgType structs.MessageType, buf []by
 	}
 
 	if err := n.state.DeleteOneTimeTokens(msgType, index, req.AccessorIDs); err != nil {
-		n.logger.Error("DeleteOneTimeToken failed", "error", err)
+		n.logger.Error("DeleteOneTimeTokens failed", "error", err)
 		return err
 	}
 	return nil
@@ -1190,7 +1190,7 @@ func (n *nomadFSM) applyOneTimeTokenExpire(msgType structs.MessageType, buf []by
 	}
 
 	if err := n.state.ExpireOneTimeTokens(msgType, index); err != nil {
-		n.logger.Error("ExpireOneTimeToken failed", "error", err)
+		n.logger.Error("ExpireOneTimeTokens failed", "error", err)
 		return err
 	}
 	return nil

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -5361,7 +5361,7 @@ func (s *StateStore) UpsertOneTimeToken(msgType structs.MessageType, index uint6
 	return txn.Commit()
 }
 
-// DeleteOneTimeTokens deletes the token withs the given ACLToken Accessor IDs
+// DeleteOneTimeTokens deletes the tokens with the given ACLToken Accessor IDs
 func (s *StateStore) DeleteOneTimeTokens(msgType structs.MessageType, index uint64, ids []string) error {
 	txn := s.db.WriteTxnMsgT(msgType, index)
 	defer txn.Abort()

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -8549,7 +8549,9 @@ func TestStateStore_OneTimeTokens(t *testing.T) {
 
 	getExpiredTokens := func() []*structs.OneTimeToken {
 		// find all the expired tokens
-		iter, err := state.OneTimeTokensExpired(nil)
+
+		txn := state.db.ReadTxn()
+		iter, err := state.oneTimeTokensExpiredTxn(txn, nil)
 		require.NoError(t, err)
 
 		results := []*structs.OneTimeToken{}
@@ -8578,8 +8580,7 @@ func TestStateStore_OneTimeTokens(t *testing.T) {
 	// clear the expired tokens and verify they're gone
 	index++
 	require.NoError(t,
-		state.DeleteOneTimeTokens(structs.MsgTypeTestSetup, index,
-			[]string{results[0].AccessorID, results[1].AccessorID}))
+		state.ExpireOneTimeTokens(structs.MsgTypeTestSetup, index))
 
 	results = getExpiredTokens()
 	require.Len(t, results, 0)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -100,6 +100,9 @@ const (
 	EventSinkUpsertRequestType                   MessageType = 41
 	EventSinkDeleteRequestType                   MessageType = 42
 	BatchEventSinkUpdateProgressType             MessageType = 43
+	OneTimeTokenUpsertRequestType                MessageType = 44
+	OneTimeTokenDeleteRequestType                MessageType = 45
+	OneTimeTokenExpireRequestType                MessageType = 46
 
 	// Namespace types were moved from enterprise and therefore start at 64
 	NamespaceUpsertRequestType MessageType = 64
@@ -11048,6 +11051,42 @@ type OneTimeToken struct {
 	ExpiresAt       time.Time
 	CreateIndex     uint64
 	ModifyIndex     uint64
+}
+
+// OneTimeTokenUpsertRequest is the request for a UpsertOneTimeToken RPC
+type OneTimeTokenUpsertRequest struct {
+	WriteRequest
+}
+
+// OneTimeTokenUpsertResponse is the response to a UpsertOneTimeToken RPC.
+type OneTimeTokenUpsertResponse struct {
+	OneTimeToken *OneTimeToken
+	WriteMeta
+}
+
+// OneTimeTokenExchangeRequest is a request to swap the one-time token with
+// the backing ACL token
+type OneTimeTokenExchangeRequest struct {
+	OneTimeSecretID string
+	WriteRequest
+}
+
+// OneTimeTokenExchangeResponse is the response to swapping the one-time token
+// with the backing ACL token
+type OneTimeTokenExchangeResponse struct {
+	Token *ACLToken
+	WriteMeta
+}
+
+// OneTimeTokenDeleteRequest is a request to delete a group of one-time tokens
+type OneTimeTokenDeleteRequest struct {
+	AccessorIDs []string
+	WriteRequest
+}
+
+// OneTimeTokenExpireRequest is a request to delete all expired one-time tokens
+type OneTimeTokenExpireRequest struct {
+	WriteRequest
 }
 
 // RpcError is used for serializing errors with a potential error code

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10009,6 +10009,10 @@ const (
 	// or allocs running them. If so, we delete the plugin.
 	CoreJobCSIPluginGC = "csi-plugin-gc"
 
+	// CoreJobOneTimeTokenGC is use for the garbage collection of one-time
+	// tokens. We periodically scan for expired tokens and delete them.
+	CoreJobOneTimeTokenGC = "one-time-token-gc"
+
 	// CoreJobForceGC is used to force garbage collection of all GCable objects.
 	CoreJobForceGC = "force-gc"
 )


### PR DESCRIPTION
RPC endpoints for the user-driven APIs (`UpsertOneTimeToken` and `ExchangeOneTimeToken`) and token expiration (`ExpireOneTimeTokens`). Includes adding expiration to the periodic core GC job.

Related to #10066 #10091 and the implementation of #6054. I'm making this PR to a branch `f-nomad-ui-login` so that I can make a number of incremental PRs as I work through this small project. This PR does not include the HTTP APIs that call these RPCs, which will be in the next PR.