### PR TITLE
HTTP API support for 'nomad ui -login'

### DIFF
--- a/website/content/api-docs/acl-tokens.mdx
+++ b/website/content/api-docs/acl-tokens.mdx
@@ -374,11 +374,14 @@ $ curl \
 
 ```json
 {
-  "AccessorID": "b780e702-98ce-521f-2e5f-c6b87de05b24",
-  "OneTimeSecretID": "3f4a0fcd-7c42-773c-25db-2d31ba0c05fe",
-  "ExpiresAt": "2017-08-23T22:47:14.695408057Z",
-  "CreateIndex": 7,
-  "ModifyIndex": 7
+  "Index": 15,
+  "OneTimeToken": {
+    "AccessorID": "b780e702-98ce-521f-2e5f-c6b87de05b24",
+    "CreateIndex": 7,
+    "ExpiresAt": "2017-08-23T22:47:14.695408057Z",
+    "ModifyIndex": 7,
+    "OneTimeSecretID": "3f4a0fcd-7c42-773c-25db-2d31ba0c05fe"
+  }
 }
 ```
 
@@ -413,14 +416,20 @@ $ curl \
 
 ```json
 {
-  "AccessorID": "b780e702-98ce-521f-2e5f-c6b87de05b24",
-  "SecretID": "3f4a0fcd-7c42-773c-25db-2d31ba0c05fe",
-  "Name": "Developer token",
-  "Type": "client",
-  "Policies": null,
-  "Global": true,
-  "CreateTime": "2017-08-23T22:47:14.695408057Z",
-  "CreateIndex": 7,
-  "ModifyIndex": 7
+  "Index": 17,
+  "Token": {
+    "AccessorID": "b780e702-98ce-521f-2e5f-c6b87de05b24",
+    "CreateIndex": 7,
+    "CreateTime": "2017-08-23T22:47:14.695408057Z",
+    "Global": true,
+    "Hash": "UhZESkSFGFfX7eBgq5Uwph30OctbUbpe8+dlH2i4whA=",
+    "ModifyIndex": 7,
+    "Name": "Developer token",
+    "Policies": [
+      "developer"
+    ],
+    "SecretID": "3f4a0fcd-7c42-773c-25db-2d31ba0c05fe",
+    "Type": "client"
+  }
 }
 ```


### PR DESCRIPTION
Endpoints for requesting and exchanging one-time tokens via the HTTP API. Includes documentation updates.

Related to #10066 #10091 #10092 and the implementation of #6054. I'm making this PR to a branch `f-nomad-ui-login` so that I can make a number of incremental PRs as I work through this small project. @backspace I've tagged you as a reviewer on this PR mostly so you can verify the JSON response bodies look like something you won't hate working with. 😀 

---

In addition to the unit tests, I've tested this against a dev build via `curl`:

```sh
# request a one-time token
$ export NOMAD_TOKEN=18c44fd5-5501-3931-ef69-9a32c12e722c
$ curl -XPOST -H "X-Nomad-Token: $NOMAD_TOKEN" \
  "http://localhost:4646/v1/acl/token/onetime" | jq .
{
  "Index": 15,
  "OneTimeToken": {
    "AccessorID": "0ff9d33b-a937-c8cd-0bbe-616dd127caab",
    "CreateIndex": 15,
    "ExpiresAt": "2021-02-26T15:51:53.445639349Z",
    "ModifyIndex": 15,
    "OneTimeSecretID": "8ddbf9ce-d64e-cad5-1137-39aea1c9184b"
  }
}

# exchange the one-time token for an ACL token, note the resulting secret ID matches our NOMAD_TOKEN
$ curl -s -XPOST \
  -d '{"OneTimeSecretID": "8ddbf9ce-d64e-cad5-1137-39aea1c9184b" }' \
  "http://localhost:4646/v1/acl/token/onetime/exchange" | jq .
{
  "Index": 17,
  "Token": {
    "AccessorID": "0ff9d33b-a937-c8cd-0bbe-616dd127caab",
    "CreateIndex": 13,
    "CreateTime": "2021-02-26T15:41:15.933128677Z",
    "Global": false,
    "Hash": "UhZESkSFGFfX7eBgq5Uwph30OctbUbpe8+dlH2i4whA=",
    "ModifyIndex": 13,
    "Name": "operator",
    "Policies": [
      "operator"
    ],
    "SecretID": "18c44fd5-5501-3931-ef69-9a32c12e722c",
    "Type": "client"
  }
}

# try again, but the one-time token has already been exchanged
$ curl -s -XPOST \
  -d '{"OneTimeSecretID": "8ddbf9ce-d64e-cad5-1137-39aea1c9184b" }' \
  "http://localhost:4646/v1/acl/token/onetime/exchange"
Permission denied