### PR TITLE
one-time token: never return expired tokens

### DIFF
--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -912,6 +912,10 @@ func (a *ACL) ExchangeOneTimeToken(args *structs.OneTimeTokenExchangeRequest, re
 	if ott == nil {
 		return structs.ErrPermissionDenied
 	}
+	if ott.ExpiresAt.Before(time.Now()) {
+		// we return early and leave cleaning up the expired token for GC
+		return structs.ErrPermissionDenied
+	}
 
 	// Look for the token; it may have been deleted, in which case, 403
 	aclToken, err := state.ACLTokenByAccessorID(nil, ott.AccessorID)


### PR DESCRIPTION
Fix a bug in the `nomad ui -login` RPCs introduced in #10092. The exchange RPC was not verifying that the one-time token was not expired.

Related to #10066 #10091 #10092 and the implementation of #6054. I'm making this PR to a branch f-nomad-ui-login so that I can make a number of incremental PRs as I work through this small project.