### PR TITLE
CLI 'nomad ui -authenticate' flag for one-time token exchange

### DIFF
--- a/api/acl.go
+++ b/api/acl.go
@@ -154,6 +154,36 @@ func (a *ACLTokens) Self(q *QueryOptions) (*ACLToken, *QueryMeta, error) {
 	return &resp, wm, nil
 }
 
+// UpsertOneTimeToken is used to create a one-time token
+func (a *ACLTokens) UpsertOneTimeToken(q *WriteOptions) (*OneTimeToken, *WriteMeta, error) {
+	var resp *OneTimeTokenUpsertResponse
+	wm, err := a.client.write("/v1/acl/token/onetime", nil, &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp == nil {
+		return nil, nil, fmt.Errorf("no one-time token returned")
+	}
+	return resp.OneTimeToken, wm, nil
+}
+
+// ExchangeOneTimeToken is used to create a one-time token
+func (a *ACLTokens) ExchangeOneTimeToken(secret string, q *WriteOptions) (*ACLToken, *WriteMeta, error) {
+	if secret == "" {
+		return nil, nil, fmt.Errorf("missing secret ID")
+	}
+	req := &OneTimeTokenExchangeRequest{OneTimeSecretID: secret}
+	var resp *OneTimeTokenExchangeResponse
+	wm, err := a.client.write("/v1/acl/token/onetime/exchange", req, &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp == nil {
+		return nil, nil, fmt.Errorf("no ACL token returned")
+	}
+	return resp.Token, wm, nil
+}
+
 // ACLPolicyListStub is used to for listing ACL policies
 type ACLPolicyListStub struct {
 	Name        string
@@ -193,4 +223,24 @@ type ACLTokenListStub struct {
 	CreateTime  time.Time
 	CreateIndex uint64
 	ModifyIndex uint64
+}
+
+type OneTimeToken struct {
+	OneTimeSecretID string
+	AccessorID      string
+	ExpiresAt       time.Time
+	CreateIndex     uint64
+	ModifyIndex     uint64
+}
+
+type OneTimeTokenUpsertResponse struct {
+	OneTimeToken *OneTimeToken
+}
+
+type OneTimeTokenExchangeRequest struct {
+	OneTimeSecretID string
+}
+
+type OneTimeTokenExchangeResponse struct {
+	Token *ACLToken
 }

--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -277,3 +277,42 @@ func (s *HTTPServer) aclTokenDelete(resp http.ResponseWriter, req *http.Request,
 	setIndex(resp, out.Index)
 	return nil, nil
 }
+
+func (s *HTTPServer) UpsertOneTimeToken(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	// Ensure this is a PUT or POST
+	if !(req.Method == "PUT" || req.Method == "POST") {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+	// the request body is empty but we need to parse to get the auth token
+	args := structs.OneTimeTokenUpsertRequest{}
+	s.parseWriteRequest(req, &args.WriteRequest)
+
+	var out structs.OneTimeTokenUpsertResponse
+	if err := s.agent.RPC("ACL.UpsertOneTimeToken", &args, &out); err != nil {
+		return nil, err
+	}
+	setIndex(resp, out.Index)
+	return out, nil
+}
+
+func (s *HTTPServer) ExchangeOneTimeToken(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	// Ensure this is a PUT or POST
+	if !(req.Method == "PUT" || req.Method == "POST") {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+	var args structs.OneTimeTokenExchangeRequest
+	if err := decodeBody(req, &args); err != nil {
+		return nil, CodedError(500, err.Error())
+	}
+
+	s.parseWriteRequest(req, &args.WriteRequest)
+
+	var out structs.OneTimeTokenExchangeResponse
+	if err := s.agent.RPC("ACL.ExchangeOneTimeToken", &args, &out); err != nil {
+		return nil, err
+	}
+	setIndex(resp, out.Index)
+	return out, nil
+}

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -272,6 +272,8 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/acl/policies", s.wrap(s.ACLPoliciesRequest))
 	s.mux.HandleFunc("/v1/acl/policy/", s.wrap(s.ACLPolicySpecificRequest))
 
+	s.mux.HandleFunc("/v1/acl/token/onetime", s.wrap(s.UpsertOneTimeToken))
+	s.mux.HandleFunc("/v1/acl/token/onetime/exchange", s.wrap(s.ExchangeOneTimeToken))
 	s.mux.HandleFunc("/v1/acl/bootstrap", s.wrap(s.ACLTokenBootstrap))
 	s.mux.HandleFunc("/v1/acl/tokens", s.wrap(s.ACLTokensRequest))
 	s.mux.HandleFunc("/v1/acl/token", s.wrap(s.ACLTokenSpecificRequest))

--- a/command/ui.go
+++ b/command/ui.go
@@ -75,11 +75,11 @@ func (c *UiCommand) Synopsis() string {
 func (c *UiCommand) Name() string { return "ui" }
 
 func (c *UiCommand) Run(args []string) int {
-	var login bool
+	var authenticate bool
 
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
-	flags.BoolVar(&login, "login", false, "")
+	flags.BoolVar(&authenticate, "authenticate", false, "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -107,7 +107,7 @@ func (c *UiCommand) Run(args []string) int {
 	}
 
 	var ottSecret string
-	if login {
+	if authenticate {
 		ott, _, err := client.ACLTokens().UpsertOneTimeToken(nil)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Could not get one-time token: %s", err))
@@ -172,7 +172,7 @@ func (c *UiCommand) Run(args []string) int {
 		}
 	}
 
-	if login && ottSecret != "" {
+	if authenticate && ottSecret != "" {
 		c.Ui.Output(fmt.Sprintf("Opening URL %q with one-time token", url.String()))
 		url.RawQuery = fmt.Sprintf("ott=%s", ottSecret)
 	} else {

--- a/command/ui.go
+++ b/command/ui.go
@@ -75,8 +75,11 @@ func (c *UiCommand) Synopsis() string {
 func (c *UiCommand) Name() string { return "ui" }
 
 func (c *UiCommand) Run(args []string) int {
+	var login bool
+
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.BoolVar(&login, "login", false, "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -101,6 +104,16 @@ func (c *UiCommand) Run(args []string) int {
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing Nomad address %q: %s", client.Address(), err))
 		return 1
+	}
+
+	var ottSecret string
+	if login {
+		ott, _, err := client.ACLTokens().UpsertOneTimeToken(nil)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Could not get one-time token: %s", err))
+			return 1
+		}
+		ottSecret = ott.OneTimeSecretID
 	}
 
 	// We were given an id so look it up
@@ -159,7 +172,12 @@ func (c *UiCommand) Run(args []string) int {
 		}
 	}
 
-	c.Ui.Output(fmt.Sprintf("Opening URL %q", url.String()))
+	if login && ottSecret != "" {
+		c.Ui.Output(fmt.Sprintf("Opening URL %q with one-time token", url.String()))
+		url.RawQuery = fmt.Sprintf("ott=%s", ottSecret)
+	} else {
+		c.Ui.Output(fmt.Sprintf("Opening URL %q", url.String()))
+	}
 	if err := open.Start(url.String()); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error opening URL: %s", err))
 		return 1

--- a/vendor/github.com/hashicorp/nomad/api/acl.go
+++ b/vendor/github.com/hashicorp/nomad/api/acl.go
@@ -154,6 +154,36 @@ func (a *ACLTokens) Self(q *QueryOptions) (*ACLToken, *QueryMeta, error) {
 	return &resp, wm, nil
 }
 
+// UpsertOneTimeToken is used to create a one-time token
+func (a *ACLTokens) UpsertOneTimeToken(q *WriteOptions) (*OneTimeToken, *WriteMeta, error) {
+	var resp *OneTimeTokenUpsertResponse
+	wm, err := a.client.write("/v1/acl/token/onetime", nil, &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp == nil {
+		return nil, nil, fmt.Errorf("no one-time token returned")
+	}
+	return resp.OneTimeToken, wm, nil
+}
+
+// ExchangeOneTimeToken is used to create a one-time token
+func (a *ACLTokens) ExchangeOneTimeToken(secret string, q *WriteOptions) (*ACLToken, *WriteMeta, error) {
+	if secret == "" {
+		return nil, nil, fmt.Errorf("missing secret ID")
+	}
+	req := &OneTimeTokenExchangeRequest{OneTimeSecretID: secret}
+	var resp *OneTimeTokenExchangeResponse
+	wm, err := a.client.write("/v1/acl/token/onetime/exchange", req, &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp == nil {
+		return nil, nil, fmt.Errorf("no ACL token returned")
+	}
+	return resp.Token, wm, nil
+}
+
 // ACLPolicyListStub is used to for listing ACL policies
 type ACLPolicyListStub struct {
 	Name        string
@@ -193,4 +223,24 @@ type ACLTokenListStub struct {
 	CreateTime  time.Time
 	CreateIndex uint64
 	ModifyIndex uint64
+}
+
+type OneTimeToken struct {
+	OneTimeSecretID string
+	AccessorID      string
+	ExpiresAt       time.Time
+	CreateIndex     uint64
+	ModifyIndex     uint64
+}
+
+type OneTimeTokenUpsertResponse struct {
+	OneTimeToken *OneTimeToken
+}
+
+type OneTimeTokenExchangeRequest struct {
+	OneTimeSecretID string
+}
+
+type OneTimeTokenExchangeResponse struct {
+	Token *ACLToken
 }

--- a/website/content/api-docs/acl-tokens.mdx
+++ b/website/content/api-docs/acl-tokens.mdx
@@ -342,3 +342,85 @@ $ curl \
     --request DELETE \
     https://localhost:4646/v1/acl/token/aa534e09-6a07-0a45-2295-a7f77063d429
 ```
+
+## Upsert One-Time Token
+
+This endpoint creates a one-time token for the ACL token provided in the
+`X-Nomad-Token` header. Returns 403 if the token header is not set.
+
+| Method   | Path                      | Produces       |
+| -------- | ------------------------- | -------------- |
+| `POST`   | `/acl/token/onetime`      | `application/json` |
+
+The table below shows this endpoint's support for
+[blocking queries](/api-docs#blocking-queries) and
+[required ACLs](/api-docs#acls).
+
+| Blocking Queries | ACL Required |
+| ---------------- | ------------ |
+| `NO`             | `any`        |
+
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --request POST \
+    -H "X-Nomad-Token: aa534e09-6a07-0a45-2295-a7f77063d429" \
+    https://localhost:4646/v1/acl/token/onetime
+```
+
+### Sample Response
+
+```json
+{
+  "AccessorID": "b780e702-98ce-521f-2e5f-c6b87de05b24",
+  "OneTimeSecretID": "3f4a0fcd-7c42-773c-25db-2d31ba0c05fe",
+  "ExpiresAt": "2017-08-23T22:47:14.695408057Z",
+  "CreateIndex": 7,
+  "ModifyIndex": 7
+}
+```
+
+## Exchange One-Time Token
+
+This endpoint exchanges a one-time token for the original ACL token used to
+create it.
+
+| Method   | Path                          | Produces           |
+| -------- | -------------------------     | --------------     |
+| `POST`   | `/acl/token/onetime/exchange` | `application/json` |
+
+The table below shows this endpoint's support for
+[blocking queries](/api-docs#blocking-queries) and
+[required ACLs](/api-docs#acls).
+
+| Blocking Queries | ACL Required |
+| ---------------- | ------------ |
+| `NO`             | `any`        |
+
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --request POST \
+    -d '{ "OneTimeSecretID": "aa534e09-6a07-0a45-2295-a7f77063d429" } \
+    https://localhost:4646/v1/acl/token/onetime/exchange
+```
+
+### Sample Response
+
+```json
+{
+  "AccessorID": "b780e702-98ce-521f-2e5f-c6b87de05b24",
+  "SecretID": "3f4a0fcd-7c42-773c-25db-2d31ba0c05fe",
+  "Name": "Developer token",
+  "Type": "client",
+  "Policies": null,
+  "Global": true,
+  "CreateTime": "2017-08-23T22:47:14.695408057Z",
+  "CreateIndex": 7,
+  "ModifyIndex": 7
+}
+```

--- a/website/content/docs/commands/ui.mdx
+++ b/website/content/docs/commands/ui.mdx
@@ -24,10 +24,10 @@ details for that object. Supported identifiers are jobs, allocations and nodes.
 
 If ACLs are enabled, the web UI will start in an unauthenticated state and you
 may see a 403 Unauthorized page if anonymous read access is denied. The `nomad
-ui -login` option will exchange your command line client's Nomad ACL token for
-a one-time login token to the web UI. That one-time token will be exchanged
-for your Nomad ACL token and stored in the browser's local storage for
-authentication.
+ui -authenticate` option will exchange your command line client's Nomad ACL
+token for a one-time token to the web UI. That one-time token will be
+exchanged for your Nomad ACL token and stored in the browser's local storage
+for authentication.
 
 ## General Options
 
@@ -35,7 +35,8 @@ authentication.
 
 ## UI Options
 
-- `-login`: Exchange your Nomad ACL token for a one-time token in the web UI.
+- `-authenticate`: Exchange your Nomad ACL token for a one-time token in the
+  web UI.
 
 ## Examples
 
@@ -60,9 +61,9 @@ $ nomad ui d4005969
 Opening URL "http://127.0.0.1:4646/ui/allocations/d4005969-b16f-10eb-4fe1-a5374986083d"
 ```
 
-Open the UI and login using your ACL token:
+Open the UI and authenticate using your ACL token:
 
 ```shell-session
-$ NOMAD_ACL_TOKEN=e9674b26-763b-4637-a28f-0df95c53cdda nomad ui -login
+$ NOMAD_ACL_TOKEN=e9674b26-763b-4637-a28f-0df95c53cdda nomad ui -authenticate
 Opening URL "http://127.0.0.1:4646" with token
 ```


### PR DESCRIPTION
The last bit of `nomad ui -authenticate`. Only the 3a7dba9 and dfd8407  commits are part of this PR; it won't compile without #10095, but I'll rebase it once that's been merged.

Related to #10066 #10091 #10092 #10095 and the implementation of #6054. I'm making this PR to a branch `f-nomad-ui-login`.