### PR TITLE
Added new Question to FAQs

### DIFF
--- a/website/content/docs/faq.mdx
+++ b/website/content/docs/faq.mdx
@@ -58,6 +58,11 @@ all of the Nomad servers in the same outage, the cluster will re-bootstrap based
 on the Nomad defaults and any configuration present that impacts the bootstrap
 process.
 
+
+## Q: What are the key differences between Nomad and Kubernetes?
+
+TBA
+
 [consul_dc]: https://www.consul.io/docs/agent/options#_datacenter
 [consul_fed]: https://learn.hashicorp.com/tutorials/consul/federarion-gossip-wan
 [nomad_region]: /docs/configuration#datacenter


### PR DESCRIPTION
Added a popular question amongst cloud native DevOps engineers. This question seeks to help engineers in getting a proper understanding of the unique traits of Nomad - as an orchestration tool - compared to Kubernetes.

I believe the answer to this specific question lives [here](https://www.nomadproject.io/docs/nomad-vs-kubernetes). But having a summary of these key distinctions in the FAQ section (plus a URL to the page that details the comparison) would ensure a faster comprehension of these differences.