### PR TITLE
docs: swap master for main in Nomad repo

### DIFF
--- a/contributing/README.md
+++ b/contributing/README.md
@@ -51,7 +51,7 @@ Developing without Vagrant
 
 Running a development build
 ---
-1. Compile a development binary (see the [UI README](https://github.com/hashicorp/nomad/blob/master/ui/README.md) to include the web UI in the binary)
+1. Compile a development binary (see the [UI README](https://github.com/hashicorp/nomad/blob/main/ui/README.md) to include the web UI in the binary)
     ```sh
     $ make dev
     # find the built binary at ./bin/nomad
@@ -79,7 +79,7 @@ If in the course of your development you change a Protobuf file (those ending in
 
 Building the Web UI
 ---
-See the [UI README](https://github.com/hashicorp/nomad/blob/master/ui/README.md) for instructions.
+See the [UI README](https://github.com/hashicorp/nomad/blob/main/ui/README.md) for instructions.
 
 Create a release binary
 ---

--- a/contributing/checklist-jobspec.md
+++ b/contributing/checklist-jobspec.md
@@ -36,7 +36,7 @@ required in the original `jobspec` package.
 
 * [ ] Changelog
 * [ ] Jobspec entry https://www.nomadproject.io/docs/job-specification/index.html
-* [ ] Jobspec sidebar entry https://github.com/hashicorp/nomad/blob/master/website/source/layouts/docs.erb
+* [ ] Jobspec sidebar entry https://github.com/hashicorp/nomad/blob/main/website/data/docs-navigation.js
 * [ ] Job JSON API entry https://www.nomadproject.io/api/json-jobs.html
 * [ ] Sample Response output in API https://www.nomadproject.io/api/jobs.html
 * [ ] Consider if it needs a guide https://www.nomadproject.io/guides/index.html

--- a/contributing/golang.md
+++ b/contributing/golang.md
@@ -28,10 +28,10 @@ version.
 ## Code
 
 The
-[`update_golang_version.sh`](https://github.com/hashicorp/nomad/blob/master/scripts/update_golang_version.sh)
+[`update_golang_version.sh`](https://github.com/hashicorp/nomad/blob/main/scripts/update_golang_version.sh)
 script is used to update the Go version for all build tools.
 
-The [Changelog](https://github.com/hashicorp/nomad/blob/master/CHANGELOG.md)
+The [Changelog](https://github.com/hashicorp/nomad/blob/main/CHANGELOG.md)
 will note when the Go version has changed in the Improvements section:
 
 ```

--- a/dev/hooks/pre-push
+++ b/dev/hooks/pre-push
@@ -13,12 +13,12 @@ if [ "$2" != "$ent" -a -f version/version_ent.go ]; then
     fail "found enterprise version file version/version_ent.go while pushing to oss remote"
 fi
 
-# don't push to master, stable-*
+# don't push to main, stable-*
 # ====================
 while read local_ref local_sha remote_ref remote_sha
 do
-    if [ "$remote_ref" = "refs/heads/master" ]; then
-	fail "refusing to push directly to master"
+    if [ "$remote_ref" = "refs/heads/main" ]; then
+	fail "refusing to push directly to main"
     fi
 
     if echo "$remote_ref"|grep -q 'refs/heads/stable-.*'; then

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -13,7 +13,7 @@ The `NOMAD_E2E=1` environment variable must be set for these tests to run.
 The `terraform/` folder has provisioning code to spin up a Nomad cluster on
 AWS. You'll need both Terraform and AWS credentials to setup AWS instances on
 which e2e tests will run. See the
-[README](https://github.com/hashicorp/nomad/blob/master/e2e/terraform/README.md)
+[README](https://github.com/hashicorp/nomad/blob/main/e2e/terraform/README.md)
 for details. The number of servers and clients is configurable, as is the
 specific build of Nomad to deploy and the configuration file for each client
 and server.
@@ -103,7 +103,7 @@ nomad_version_client_linux = [
 
 Set the `profile` field to `"custom"` and put the configuration files in
 `./terraform/config/custom/` as described in the
-[README](https://github.com/hashicorp/nomad/blob/master/e2e/terraform/README.md#Profiles).
+[README](https://github.com/hashicorp/nomad/blob/main/e2e/terraform/README.md#Profiles).
 
 ### ...Deploy More Than 4 Linux Clients
 

--- a/e2e/terraform/Makefile
+++ b/e2e/terraform/Makefile
@@ -3,7 +3,7 @@ PKG_PATH = $(shell pwd)/../../pkg/linux_amd64/nomad
 
 # The version of nomad that gets deployed depends on an order of precedence
 # linked below
-# https://github.com/hashicorp/nomad/blob/master/e2e/terraform/README.md#nomad-version
+# https://github.com/hashicorp/nomad/blob/main/e2e/terraform/README.md#nomad-version
 dev-cluster:
 	terraform apply -auto-approve \
 		-var="nomad_sha=$(NOMAD_SHA)"

--- a/terraform/gcp/README.md
+++ b/terraform/gcp/README.md
@@ -77,7 +77,7 @@ terraform --version
 
 **If you are using [Google Cloud](https://cloud.google.com/shell), you already have `gcloud` set up, and you can safely skip this step.**
 
-To install the GCP SDK Command Line Tools, follow the installation instructions for your specific operating system: 
+To install the GCP SDK Command Line Tools, follow the installation instructions for your specific operating system:
 
 * [Linux](https://cloud.google.com/sdk/docs/downloads-interactive#linux)
 * [MacOS](https://cloud.google.com/sdk/docs/downloads-interactive#mac)
@@ -177,7 +177,7 @@ Before moving onto the next steps, ensure the following environment variables ar
 
 ## Build HashiStack Golden Image with Packer
 
-[Packer](https://www.packer.io/intro/index.html) is HashiCorp's open source tool for creating identical machine images for multiple platforms from a single source configuration. The machine image created here can be customized through modifications to the [build configuration file](https://github.com/hashicorp/nomad/blob/master/terraform/gcp/packer.json) and the [shell script](https://github.com/hashicorp/nomad/blob/master/terraform/shared/scripts/setup.sh).
+[Packer](https://www.packer.io/intro/index.html) is HashiCorp's open source tool for creating identical machine images for multiple platforms from a single source configuration. The machine image created here can be customized through modifications to the [build configuration file](https://github.com/hashicorp/nomad/blob/main/terraform/gcp/packer.json) and the [shell script](https://github.com/hashicorp/nomad/blob/main/terraform/shared/scripts/setup.sh).
 
 Use the following command to build the machine image:
 
@@ -202,13 +202,13 @@ terraform init
 Plan infrastructure changes with Terraform:
 
 ```console
-terraform plan -var="project=${GOOGLE_PROJECT}" -var="credentials=${GOOGLE_APPLICATION_CREDENTIALS}" 
+terraform plan -var="project=${GOOGLE_PROJECT}" -var="credentials=${GOOGLE_APPLICATION_CREDENTIALS}"
 ```
 
 Apply infrastructure changes with Terraform:
 
 ```console
-terraform apply -auto-approve -var="project=${GOOGLE_PROJECT}" -var="credentials=${GOOGLE_APPLICATION_CREDENTIALS}" 
+terraform apply -auto-approve -var="project=${GOOGLE_PROJECT}" -var="credentials=${GOOGLE_APPLICATION_CREDENTIALS}"
 ```
 
 ## Access the Cluster
@@ -233,7 +233,7 @@ If you're **not** using Cloud Shell, you can use any of these links:
 * [Vault](http://127.0.0.1:8200)
 * [Consul](http://127.0.0.1:8500)
 
-In case you want to try out any of the optional steps with the Vault CLI later on, set this helper variable: 
+In case you want to try out any of the optional steps with the Vault CLI later on, set this helper variable:
 
 ```
 export VAULT_ADDR=http://localhost:8200
@@ -243,29 +243,28 @@ export VAULT_ADDR=http://localhost:8200
 
 You have deployed a Nomad cluster to GCP! 🎉
 
-Click [here](https://github.com/hashicorp/nomad/blob/master/terraform/README.md#test) for next steps.
+Click [here](https://github.com/hashicorp/nomad/blob/main/terraform/README.md#test) for next steps.
 
 > ### After You Finish
-> Come back here when you're done exploring Nomad and the HashiCorp stack. In the next section, you'll learn how to clean up, and will destroy the demo infrastructure you've created. 
+> Come back here when you're done exploring Nomad and the HashiCorp stack. In the next section, you'll learn how to clean up, and will destroy the demo infrastructure you've created.
 
 ## Conclusion
 
-You have deployed a Nomad cluster to GCP! 
+You have deployed a Nomad cluster to GCP!
 
 ### Destroy Infrastructure
 
-To destroy all the demo infrastructure: 
+To destroy all the demo infrastructure:
 
 ```console
-terraform destroy -force -var="project=${GOOGLE_PROJECT}" -var="credentials=${GOOGLE_APPLICATION_CREDENTIALS}" 
+terraform destroy -force -var="project=${GOOGLE_PROJECT}" -var="credentials=${GOOGLE_APPLICATION_CREDENTIALS}"
 ```
 ### Delete the Project
 
-Finally, to completely delete the project: 
+Finally, to completely delete the project:
 
 gcloud projects delete $GOOGLE_PROJECT
 
 > ### Alternative: Use the GUI
-> 
+>
 > If you prefer to delete the project using GCP's Cloud Console, follow this link to GCP's [Cloud Resource Manager](https://console.cloud.google.com/cloud-resource-manager).
-

--- a/ui/README.md
+++ b/ui/README.md
@@ -83,7 +83,7 @@ Nomad UI releases are in lockstep with Nomad releases and are integrated into th
 
 ### Storybook UI Library
 
-The Storybook project provides a browser to see what components and patterns are present in the application and how to use them. You can run it locally with `yarn storybook` after you have `ember serve` running. The latest version from the `master` branch is at [`nomad-storybook-and-ui.vercel.app/storybook/`](https://nomad-storybook-and-ui.vercel.app/storybook/).
+The Storybook project provides a browser to see what components and patterns are present in the application and how to use them. You can run it locally with `yarn storybook` after you have `ember serve` running. The latest version from the `main` branch is at [`nomad-storybook-and-ui.vercel.app/storybook/`](https://nomad-storybook-and-ui.vercel.app/storybook/).
 
 To generate a new story for a component, run `ember generate story component-name`. You can use the existing stories as a guide.
 


### PR DESCRIPTION
Nomad's `master` branch is being renamed to `main`. Once that's done, we'll want to update the links in this PR.