### PR TITLE
docs: clarify mount source path in filesystem docs

### DIFF
--- a/website/content/docs/internals/filesystem.mdx
+++ b/website/content/docs/internals/filesystem.mdx
@@ -232,6 +232,11 @@ EOT
 }
 ```
 
+Note that relative mount source path are relative to the task working
+directory, so to bind the `NOMAD_ALLOC_DIR` as a mount source, you will need
+to use a relative path that traverses up into the allocation working directory
+(ex. `source = "../alloc"`).
+
 ### `chroot` isolation
 
 Task drivers like `exec` or `java` (on Linux) use `chroot` isolation, where


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10122

---

Full example of the path here:

```hcl
job "example" {
  datacenters = ["dc1"]

  group "web" {

    network {
      port "www" {
        to = 8001
      }
    }

    task "httpd" {
      driver = "docker"

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-v", "-f", "-p", "8001", "-h", "/srv"]
        ports   = ["www"]

        mounts = [{
          type   = "bind"
          source = "../alloc"
          target = "/srv"
        }]

      }

      template {
        data        = "<html>hello, world</html>"
        destination = "${NOMAD_ALLOC_DIR}/index.html"
      }

      resources {
        cpu    = 128
        memory = 128
      }
    }
  }
}

```