### PR TITLE
CSI: unique volume per allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ BUG FIXES:
 IMPROVEMENTS:
  * cli: Update defaults for `nomad operator debug` flags `-interval` and `-server-id` to match common usage. [[GH-10121](https://github.com/hashicorp/nomad/issues/10121)]
  * consul/connect: Enable setting `local_bind_address` field on connect upstreams [[GH-6248](https://github.com/hashicorp/nomad/issues/6248)]
+ * csi: Added support for jobs to request a unique volume ID per allocation. [[GH-10136](https://github.com/hashicorp/nomad/issues/10136)]
  * driver/docker: Added support for optional extra container labels. [[GH-9885](https://github.com/hashicorp/nomad/issues/9885)]
  * driver/docker: Added support for configuring default logger behavior in the client configuration. [[GH-10156](https://github.com/hashicorp/nomad/issues/10156)]
 

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -382,6 +382,7 @@ type VolumeRequest struct {
 	Source       string           `hcl:"source,optional"`
 	ReadOnly     bool             `hcl:"read_only,optional"`
 	MountOptions *CSIMountOptions `hcl:"mount_options,block"`
+	PerAlloc     bool             `hcl:"per_alloc,optional"`
 	ExtraKeysHCL []string         `hcl1:",unusedKeys,optional" json:"-"`
 }
 

--- a/client/allocrunner/csi_hook.go
+++ b/client/allocrunner/csi_hook.go
@@ -92,8 +92,13 @@ func (c *csiHook) Postrun() error {
 			mode = structs.CSIVolumeClaimWrite
 		}
 
+		source := pair.request.Source
+		if pair.request.PerAlloc {
+			source = source + structs.AllocSuffix(c.alloc.Name)
+		}
+
 		req := &structs.CSIVolumeUnpublishRequest{
-			VolumeID: pair.request.Source,
+			VolumeID: source,
 			Claim: &structs.CSIVolumeClaim{
 				AllocationID: c.alloc.ID,
 				NodeID:       c.alloc.NodeID,
@@ -159,8 +164,13 @@ func (c *csiHook) claimVolumesFromAlloc() (map[string]*volumeAndRequest, error) 
 			claimType = structs.CSIVolumeClaimRead
 		}
 
+		source := pair.request.Source
+		if pair.request.PerAlloc {
+			source = source + structs.AllocSuffix(c.alloc.Name)
+		}
+
 		req := &structs.CSIVolumeClaimRequest{
-			VolumeID:     pair.request.Source,
+			VolumeID:     source,
 			AllocationID: c.alloc.ID,
 			NodeID:       c.alloc.NodeID,
 			Claim:        claimType,

--- a/client/allocrunner/csi_hook.go
+++ b/client/allocrunner/csi_hook.go
@@ -94,6 +94,7 @@ func (c *csiHook) Postrun() error {
 
 		source := pair.request.Source
 		if pair.request.PerAlloc {
+			// NOTE: PerAlloc can't be set if we have canaries
 			source = source + structs.AllocSuffix(c.alloc.Name)
 		}
 

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -944,6 +944,7 @@ func ApiTgToStructsTG(job *structs.Job, taskGroup *api.TaskGroup, tg *structs.Ta
 				Type:     v.Type,
 				ReadOnly: v.ReadOnly,
 				Source:   v.Source,
+				PerAlloc: v.PerAlloc,
 			}
 
 			if v.MountOptions != nil {

--- a/e2e/csi/input/use-ebs-volume.nomad
+++ b/e2e/csi/input/use-ebs-volume.nomad
@@ -9,8 +9,9 @@ job "use-ebs-volume" {
 
   group "group" {
     volume "test" {
-      type   = "csi"
-      source = "ebs-vol0"
+      type      = "csi"
+      source    = "ebs-vol"
+      per_alloc = true
     }
 
     task "task" {

--- a/e2e/terraform/compute.tf
+++ b/e2e/terraform/compute.tf
@@ -63,7 +63,7 @@ data "external" "packer_sha" {
 sha=$(git log -n 1 --pretty=format:%H packer)
 echo "{\"sha\":\"$${sha}\"}"
 EOT
-]
+  ]
 
 }
 

--- a/e2e/terraform/terraform.tfvars
+++ b/e2e/terraform/terraform.tfvars
@@ -15,5 +15,5 @@ nomad_local_binary = ""      # overrides nomad_sha and nomad_version if set
 
 # Example overrides:
 # nomad_sha = "38e23b62a7700c96f4898be777543869499fea0a"
-# nomad_local_binary = "../../pkg/linux_amd/nomad"
+# nomad_local_binary = "../../pkg/linux_amd64/nomad"
 # nomad_local_binary_client_windows_2016_amd64 = ["../../pkg/windows_amd64/nomad.exe"]

--- a/e2e/terraform/volumes.tf
+++ b/e2e/terraform/volumes.tf
@@ -30,8 +30,8 @@ data "template_file" "ebs_volume_hcl" {
   count    = var.volumes ? 1 : 0
   template = <<EOT
 type = "csi"
-id = "ebs-vol0"
-name = "ebs-vol0"
+id = "ebs-vol[0]"
+name = "ebs-vol"
 external_id = "${aws_ebs_volume.csi[0].id}"
 access_mode = "single-node-writer"
 attachment_mode = "file-system"

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2135,10 +2135,7 @@ func (s *StateStore) CSIVolumeByID(ws memdb.WatchSet, namespace, id string) (*st
 	if obj == nil {
 		return nil, nil
 	}
-	vol, ok := obj.(*structs.CSIVolume)
-	if !ok {
-		return nil, fmt.Errorf("volume row conversion error")
-	}
+	vol := obj.(*structs.CSIVolume)
 
 	// we return the volume with the plugins denormalized by default,
 	// because the scheduler needs them for feasibility checking

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -3639,6 +3639,7 @@ func TestTaskGroupDiff(t *testing.T) {
 						Type:     "host",
 						Source:   "foo-src",
 						ReadOnly: true,
+						PerAlloc: true,
 					},
 				},
 			},
@@ -3655,6 +3656,12 @@ func TestTaskGroupDiff(t *testing.T) {
 								Name: "Name",
 								Old:  "",
 								New:  "foo",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "PerAlloc",
+								Old:  "",
+								New:  "true",
 							},
 							{
 								Type: DiffTypeAdded,

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -329,6 +329,17 @@ func AllocName(job, group string, idx uint) string {
 	return fmt.Sprintf("%s.%s[%d]", job, group, idx)
 }
 
+// AllocSuffix returns the alloc index suffix that was added by the AllocName
+// function above.
+func AllocSuffix(name string) string {
+	idx := strings.LastIndex(name, "[")
+	if idx == -1 {
+		return ""
+	}
+	suffix := name[idx:]
+	return suffix
+}
+
 // ACLPolicyListHash returns a consistent hash for a set of policies.
 func ACLPolicyListHash(policies []*ACLPolicy) string {
 	cacheKeyHash, err := blake2b.New256(nil)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6100,12 +6100,17 @@ func (tg *TaskGroup) Validate(j *Job) error {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("Only one task may be marked as leader"))
 	}
 
-	// Validate the Host Volumes
+	// Validate the volume requests
 	for name, decl := range tg.Volumes {
 		if !(decl.Type == VolumeTypeHost ||
 			decl.Type == VolumeTypeCSI) {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("Volume %s has unrecognised type %s", name, decl.Type))
 			continue
+		}
+
+		if decl.PerAlloc && tg.Update != nil && tg.Update.Canary > 0 {
+			mErr.Errors = append(mErr.Errors,
+				fmt.Errorf("Volume %s cannot be per_alloc when canaries are in use", name))
 		}
 
 		if decl.Source == "" {

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1107,6 +1107,28 @@ func TestTaskGroup_Validate(t *testing.T) {
 	require.Contains(t, err.Error(), `Volume foo has an empty source`)
 
 	tg = &TaskGroup{
+		Name: "group-a",
+		Update: &UpdateStrategy{
+			Canary: 1,
+		},
+		Volumes: map[string]*VolumeRequest{
+			"foo": {
+				Type:     "csi",
+				PerAlloc: true,
+			},
+		},
+		Tasks: []*Task{
+			{
+				Name:      "task-a",
+				Resources: &Resources{},
+			},
+		},
+	}
+	err = tg.Validate(&Job{})
+	require.Contains(t, err.Error(), `Volume foo has an empty source`)
+	require.Contains(t, err.Error(), `Volume foo cannot be per_alloc when canaries are in use`)
+
+	tg = &TaskGroup{
 		Volumes: map[string]*VolumeRequest{
 			"foo": {
 				Type: "host",

--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -91,6 +91,7 @@ type VolumeRequest struct {
 	Source       string
 	ReadOnly     bool
 	MountOptions *CSIMountOptions
+	PerAlloc     bool
 }
 
 func (v *VolumeRequest) Copy() *VolumeRequest {

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -227,23 +227,30 @@ func (c *CSIVolumeChecker) SetNamespace(namespace string) {
 	c.namespace = namespace
 }
 
-func (c *CSIVolumeChecker) SetVolumes(volumes map[string]*structs.VolumeRequest) {
+func (c *CSIVolumeChecker) SetVolumes(allocName string, volumes map[string]*structs.VolumeRequest) {
+
 	xs := make(map[string]*structs.VolumeRequest)
+
 	// Filter to only CSI Volumes
 	for alias, req := range volumes {
 		if req.Type != structs.VolumeTypeCSI {
 			continue
 		}
-
-		xs[alias] = req
+		if req.PerAlloc {
+			// provide a unique volume source per allocation
+			copied := req.Copy()
+			copied.Source = copied.Source + structs.AllocSuffix(allocName)
+			xs[alias] = copied
+		} else {
+			xs[alias] = req
+		}
 	}
 	c.volumes = xs
 }
 
 func (c *CSIVolumeChecker) Feasible(n *structs.Node) bool {
-	hasPlugins, failReason := c.hasPlugins(n)
-
-	if hasPlugins {
+	ok, failReason := c.isFeasible(n)
+	if ok {
 		return true
 	}
 
@@ -251,7 +258,7 @@ func (c *CSIVolumeChecker) Feasible(n *structs.Node) bool {
 	return false
 }
 
-func (c *CSIVolumeChecker) hasPlugins(n *structs.Node) (bool, string) {
+func (c *CSIVolumeChecker) isFeasible(n *structs.Node) (bool, string) {
 	// We can mount the volume if
 	// - if required, a healthy controller plugin is running the driver
 	// - the volume has free claims, or this job owns the claims

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -547,6 +547,7 @@ func (s *GenericScheduler) computePlacements(destructive, place []placementResul
 
 			// Compute penalty nodes for rescheduled allocs
 			selectOptions := getSelectOptions(prevAllocation, preferredNode)
+			selectOptions.AllocName = missing.Name()
 			option := s.selectNextOption(tg, selectOptions)
 
 			// Store the available nodes by datacenter

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -35,6 +35,7 @@ type SelectOptions struct {
 	PenaltyNodeIDs map[string]struct{}
 	PreferredNodes []*structs.Node
 	Preempt        bool
+	AllocName      string
 }
 
 // GenericStack is the Stack used for the Generic scheduler. It is
@@ -143,7 +144,7 @@ func (s *GenericStack) Select(tg *structs.TaskGroup, options *SelectOptions) *Ra
 	s.taskGroupConstraint.SetConstraints(tgConstr.constraints)
 	s.taskGroupDevices.SetTaskGroup(tg)
 	s.taskGroupHostVolumes.SetVolumes(tg.Volumes)
-	s.taskGroupCSIVolumes.SetVolumes(tg.Volumes)
+	s.taskGroupCSIVolumes.SetVolumes(options.AllocName, tg.Volumes)
 	if len(tg.Networks) > 0 {
 		s.taskGroupNetwork.SetNetwork(tg.Networks[0])
 	}
@@ -297,7 +298,7 @@ func (s *SystemStack) Select(tg *structs.TaskGroup, options *SelectOptions) *Ran
 	s.taskGroupConstraint.SetConstraints(tgConstr.constraints)
 	s.taskGroupDevices.SetTaskGroup(tg)
 	s.taskGroupHostVolumes.SetVolumes(tg.Volumes)
-	s.taskGroupCSIVolumes.SetVolumes(tg.Volumes)
+	s.taskGroupCSIVolumes.SetVolumes(options.AllocName, tg.Volumes)
 	if len(tg.Networks) > 0 {
 		s.taskGroupNetwork.SetNetwork(tg.Networks[0])
 	}

--- a/scheduler/system_sched.go
+++ b/scheduler/system_sched.go
@@ -284,7 +284,7 @@ func (s *SystemScheduler) computePlacements(place []allocTuple) error {
 		s.stack.SetNodes(nodes)
 
 		// Attempt to match the task group
-		option := s.stack.Select(missing.TaskGroup, nil)
+		option := s.stack.Select(missing.TaskGroup, &SelectOptions{AllocName: missing.Name})
 
 		if option == nil {
 			// If the task can't be placed on this node, update reporting data

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -695,7 +695,8 @@ func inplaceUpdate(ctx Context, eval *structs.Evaluation, job *structs.Job,
 		ctx.Plan().AppendStoppedAlloc(update.Alloc, allocInPlace, "", "")
 
 		// Attempt to match the task group
-		option := stack.Select(update.TaskGroup, nil) // This select only looks at one node so we don't pass selectOptions
+		option := stack.Select(update.TaskGroup,
+			&SelectOptions{AllocName: update.Alloc.Name})
 
 		// Pop the allocation
 		ctx.Plan().PopUpdate(update.Alloc)
@@ -977,7 +978,7 @@ func genericAllocUpdateFn(ctx Context, stack Stack, evalID string) allocUpdateTy
 		ctx.Plan().AppendStoppedAlloc(existing, allocInPlace, "", "")
 
 		// Attempt to match the task group
-		option := stack.Select(newTG, nil) // This select only looks at one node so we don't pass selectOptions
+		option := stack.Select(newTG, &SelectOptions{AllocName: existing.Name})
 
 		// Pop the allocation
 		ctx.Plan().PopUpdate(existing)

--- a/vendor/github.com/hashicorp/nomad/api/tasks.go
+++ b/vendor/github.com/hashicorp/nomad/api/tasks.go
@@ -382,6 +382,7 @@ type VolumeRequest struct {
 	Source       string           `hcl:"source,optional"`
 	ReadOnly     bool             `hcl:"read_only,optional"`
 	MountOptions *CSIMountOptions `hcl:"mount_options,block"`
+	PerAlloc     bool             `hcl:"per_alloc,optional"`
 	ExtraKeysHCL []string         `hcl1:",unusedKeys,optional" json:"-"`
 }
 

--- a/website/content/docs/job-specification/update.mdx
+++ b/website/content/docs/job-specification/update.mdx
@@ -105,7 +105,8 @@ a future release.
   destructive updates should create the specified number of canaries without
   stopping any previous allocations. Once the operator determines the canaries
   are healthy, they can be promoted which unblocks a rolling update of the
-  remaining allocations at a rate of `max_parallel`.
+  remaining allocations at a rate of `max_parallel`. Canary deployments cannot
+  be used with CSI volumes when `per_alloc = true`.
 
 - `stagger` `(string: "30s")` - Specifies the delay between each set of
   [`max_parallel`](#max_parallel) updates when updating system jobs. This

--- a/website/content/docs/job-specification/volume.mdx
+++ b/website/content/docs/job-specification/volume.mdx
@@ -49,6 +49,13 @@ the [volume_mount][volume_mount] stanza in the `task` configuration.
   name of the host volume. When using `csi` volumes, this should match
   the ID of the registered volume.
 
+- `per_alloc` `(bool: false)` - Specifies that the `source` of the volume
+  should have the suffix `[n]`, where `n` is the allocation index. This allows
+  mounting a unique volume per allocation, so long as the volume's source is
+  named appropriately. For example, with the source `myvolume` and `per_alloc
+  = true`, the allocation named `myjob.mygroup.mytask[0]` will require a
+  volume ID `myvolume[0]`.
+
 - `read_only` `(bool: false)` - Specifies that the group only requires
   read only access to a volume and is used as the default value for
   the `volume_mount -> read_only` configuration. This value is also
@@ -74,64 +81,62 @@ There are two limitations to using HCL2 interpolation for `volume` blocks:
 
 - The `volume` block is used to schedule workloads, so any interpolation needs
   to be done before placement. This means that variables like
-  `NOMAD_ALLOC_INDEX` can't be used for interpolation.
+  `NOMAD_ALLOC_INDEX` can't be used for interpolation. Use the `per_alloc`
+  field described above.
 - Nomad does not yet support dynamic volume creation (see [GH-8212]), so volumes
   must be created and registered before being used as a `volume.source`.
 
 The following job specification demonstrates how to use multiple volumes with
-multiple allocations. It uses a `dynamic` block to create a new task group for
-each of the two volumes. This job specification also shows using HCL2
-variables interpolation to expose information to the task's environment.
+multiple allocations, using the `per_alloc` field. This job specification also
+shows using HCL2 -variables interpolation to expose information to the task's
+environment.
 
 ```hcl
 variables {
-  volume_index = ["0", "1"]
-  path         = "test"
+  path = "test"
 }
 
 job "example" {
   datacenters = ["dc1"]
 
-  dynamic "group" {
-    for_each = var.volume_index
-    labels   = ["cache-${group.value}"]
+  group "cache" {
 
-    content {
+    count = 2
 
-      volume "cache-volume" {
-        type   = "csi"
-        source = "test-volume${group.value}"
+    volume "cache-volume" {
+      type      = "csi"
+      source    = "test-volume"
+      per_alloc = true
+    }
+
+    network {
+      port "db" {
+        to = 6379
+      }
+    }
+
+    task "redis" {
+      driver = "docker"
+      config {
+        image = "redis:3.2"
+        ports = ["db"]
+      }
+      resources {
+        cpu    = 500
+        memory = 256
       }
 
-      network {
-        port "db" {
-          to = 6379
-        }
+      env {
+        # this will be available as the MOUNT_PATH environment
+        # variable in the task
+        MOUNT_PATH = "${NOMAD_ALLOC_DIR}/${var.path}"
       }
 
-      task "redis" {
-        driver = "docker"
-        config {
-          image = "redis:3.2"
-          ports = ["db"]
-        }
-        resources {
-          cpu    = 500
-          memory = 256
-        }
-
-        env {
-          # this will be available as the MOUNT_PATH environment
-          # variable in the task
-          MOUNT_PATH = "${NOMAD_ALLOC_DIR}/${var.path}"
-        }
-
-        volume_mount {
-          volume      = "cache-volume"
-          destination = "${NOMAD_ALLOC_DIR}/${var.path}"
-        }
-
+      volume_mount {
+        volume      = "cache-volume"
+        destination = "${NOMAD_ALLOC_DIR}/${var.path}"
       }
+
     }
   }
 }
@@ -150,13 +155,13 @@ ID        Node ID   Task Group  Version  Desired  Status   Created  Modified
 81d32909  352c6926  cache-1     0        run      running  4s ago   3s ago
 ce6fbfc8  352c6926  cache-0     0        run      running  4s ago   3s ago
 
-$ nomad volume status test-volume0
+$ nomad volume status 'test-volume[0]'
 ...
 Allocations
 ID        Node ID   Task Group  Version  Desired  Status   Created  Modified
 ce6fbfc8  352c6926  cache-0     0        run      running  29s ago  18s ago
 
-$ nomad volume status test-volume1
+$ nomad volume status 'test-volume[1]'
 ...
 Allocations
 ID        Node ID   Task Group  Version  Desired  Status   Created  Modified


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/7877

Adds a `PerAlloc` field to volume requests that directs the scheduler to test feasibility for volumes with a source ID that includes the allocation index suffix (ex. `[0]`), rather than the exact source ID. This suffix is also being added at the client when the volume claim RPCs are sent.

Reviewer notes:
* Includes a very basic end-to-end smoke test, but I've tested this with multiple volumes as well. Once https://github.com/hashicorp/nomad/issues/8212 is complete, I'll update the E2E test to create multiple volumes for EBS (which has controllers) so that the entire lifecycle is being exercised.
* ~This PR currently depends on and includes 97bb912 from https://github.com/hashicorp/nomad/pull/10158. Once that's merged, d44d62e should be dropped from this PR.~ Done