### PR TITLE
UI: Line Chart new primitives and tooltip refactor

### DIFF
--- a/ui/app/components/chart-primitives/area.js
+++ b/ui/app/components/chart-primitives/area.js
@@ -5,7 +5,10 @@ import uniquely from 'nomad-ui/utils/properties/uniquely';
 
 export default class ChartPrimitiveArea extends Component {
   get colorClass() {
-    return this.args.colorClass || `${this.args.colorScale}-${this.args.index}`;
+    if (this.args.colorClass) return this.args.colorClass;
+    if (this.args.colorScale && this.args.index != null)
+      return `${this.args.colorScale} ${this.args.colorScale}-${this.args.index + 1}`;
+    return 'is-primary';
   }
 
   @uniquely('area-mask') maskId;

--- a/ui/app/components/chart-primitives/h-annotations.hbs
+++ b/ui/app/components/chart-primitives/h-annotations.hbs
@@ -1,15 +1,15 @@
 <div data-test-annotations class="line-chart-annotations" style={{this.chartAnnotationsStyle}} ...attributes>
   {{#each this.processed key=@key as |annotation|}}
-    <div data-test-annotation class="chart-vertical-annotation {{annotation.iconClass}} {{annotation.staggerClass}}" style={{annotation.style}}>
+    <div data-test-annotation class="chart-horizontal-annotation" style={{annotation.style}}>
       <button
         type="button"
-        title={{annotation.label}}
+        title={{annotation.a11yLabel}}
         class="indicator {{if (or
           (and @key (eq-by @key annotation.annotation @activeAnnotation))
           (and (not @key) (eq annotation.annotation @activeAnnotation))
         ) "is-active"}}"
         {{on "click" (fn this.selectAnnotation annotation.annotation)}}>
-        {{x-icon annotation.icon}}
+        {{annotation.label}}
       </button>
       <div class="line" />
     </div>

--- a/ui/app/components/chart-primitives/h-annotations.js
+++ b/ui/app/components/chart-primitives/h-annotations.js
@@ -1,0 +1,40 @@
+import Component from '@glimmer/component';
+import { htmlSafe } from '@ember/template';
+import { action } from '@ember/object';
+import styleString from 'nomad-ui/utils/properties/glimmer-style-string';
+
+export default class ChartPrimitiveVAnnotations extends Component {
+  @styleString
+  get chartAnnotationsStyle() {
+    return {
+      width: this.args.width,
+      left: this.args.left,
+    };
+  }
+
+  get processed() {
+    const { scale, prop, annotations, format, labelProp } = this.args;
+
+    if (!annotations || !annotations.length) return null;
+
+    let sortedAnnotations = annotations.sortBy(prop).reverse();
+
+    return sortedAnnotations.map(annotation => {
+      const y = scale(annotation[prop]);
+      const x = 0;
+      const formattedY = format()(annotation[prop]);
+
+      return {
+        annotation,
+        style: htmlSafe(`transform:translate(${x}px,${y}px)`),
+        label: annotation[labelProp],
+        a11yLabel: `${annotation[labelProp]} at ${formattedY}`,
+      };
+    });
+  }
+
+  @action
+  selectAnnotation(annotation) {
+    if (this.args.annotationClick) this.args.annotationClick(annotation);
+  }
+}

--- a/ui/app/components/chart-primitives/tooltip.hbs
+++ b/ui/app/components/chart-primitives/tooltip.hbs
@@ -1,4 +1,4 @@
-<div class="chart-tooltip {{if @active "active" "inactive"}}" style={{@style}} ...attributes>
+<div data-test-chart-tooltip class="chart-tooltip {{if @active "active" "inactive"}}" style={{@style}} ...attributes>
   <ol>
     {{#each @data as |props|}}
       {{yield props.series  props.datum (inc props.index)}}

--- a/ui/app/components/chart-primitives/tooltip.hbs
+++ b/ui/app/components/chart-primitives/tooltip.hbs
@@ -1,0 +1,7 @@
+<div class="chart-tooltip {{if @active "active" "inactive"}}" style={{@style}} ...attributes>
+  <ol>
+    {{#each @data as |props|}}
+      {{yield props.series  props.datum (inc props.index)}}
+    {{/each}}
+  </ol>
+</div>

--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -293,7 +293,7 @@ export default class LineChart extends Component {
       return {
         series,
         datum: {
-          formattedX: this.xFormat()(datum[xProp]),
+          formattedX: this.xFormat(this.args.timeseries)(datum[xProp]),
           formattedY: this.yFormat()(datum[yProp]),
           datum,
         },

--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -290,24 +290,31 @@ export default class LineChart extends Component {
         datum = x - dLeft[xProp] > dRight[xProp] - x ? dRight : dLeft;
       }
 
-      // TODO: Preformat numbers
-      return { series, datum, index: seriesIndex };
+      return {
+        series,
+        datum: {
+          formattedX: this.xFormat()(datum[xProp]),
+          formattedY: this.yFormat()(datum[yProp]),
+          datum,
+        },
+        index: seriesIndex,
+      };
     });
 
     // Of the selected data, determine which is closest
     const closestDatum = activeData.sort(
-      (a, b) => Math.abs(a.datum[xProp] - x) - Math.abs(b.datum[xProp] - x)
+      (a, b) => Math.abs(a.datum.datum[xProp] - x) - Math.abs(b.datum.datum[xProp] - x)
     )[0];
 
     // If any other selected data are beyond a distance threshold, drop them from the list
     // xScale is used here to measure distance in screen-space rather than data-space.
-    const dist = Math.abs(xScale(closestDatum.datum[xProp]) - mouseX);
+    const dist = Math.abs(xScale(closestDatum.datum.datum[xProp]) - mouseX);
     const filteredData = activeData.filter(
-      d => Math.abs(xScale(d.datum[xProp]) - mouseX) < dist + 10
+      d => Math.abs(xScale(d.datum.datum[xProp]) - mouseX) < dist + 10
     );
 
     this.activeData = filteredData;
-    this.activeDatum = closestDatum.datum;
+    this.activeDatum = closestDatum.datum.datum;
     this.tooltipPosition = {
       left: xScale(this.activeDatum[xProp]),
       top: yScale(this.activeDatum[yProp]) - 10,

--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -82,7 +82,11 @@ export default class LineChart extends Component {
     return this.args.yProp || 'value';
   }
   get data() {
-    return this.args.data || [];
+    if (!this.args.data) return [];
+    if (this.args.dataProp) {
+      return this.args.data.mapBy(this.args.dataProp).flat();
+    }
+    return this.args.data;
   }
   get curve() {
     return this.args.curve || 'linear';

--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -188,7 +188,7 @@ export default class LineChart extends Component {
       .axisRight()
       .scale(this.yScale)
       .tickValues(ticks)
-      .tickSize(-this.yAxisOffset)
+      .tickSize(-this.canvasDimensions.width)
       .tickFormat('');
   }
 
@@ -214,6 +214,12 @@ export default class LineChart extends Component {
 
   get yAxisOffset() {
     return Math.max(0, this.width - this.yAxisWidth);
+  }
+
+  get canvasDimensions() {
+    const [left, right] = this.xScale.range();
+    const [top, bottom] = this.yScale.range();
+    return { left, width: right - left, top, height: bottom - top };
   }
 
   @action

--- a/ui/app/styles/charts/chart-annotation.scss
+++ b/ui/app/styles/charts/chart-annotation.scss
@@ -1,4 +1,4 @@
-.chart-annotation {
+.chart-vertical-annotation {
   position: absolute;
   height: 100%;
 
@@ -50,6 +50,34 @@
     width: 1px;
     height: calc(100% - 8px);
     background: $grey;
+    z-index: -1;
+  }
+}
+
+.chart-horizontal-annotation {
+  position: absolute;
+  width: 100%;
+
+  .indicator {
+    transform: translateY(-50%);
+    display: block;
+    border: none;
+    border-radius: 100px;
+    background: $red;
+    color: $white;
+    font-weight: $weight-semibold;
+    font-size: $size-7;
+    margin-left: 10px;
+    pointer-events: auto;
+  }
+
+  .line {
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 1px;
+    width: 100%;
+    background: $red;
     z-index: -1;
   }
 }

--- a/ui/app/styles/charts/colors.scss
+++ b/ui/app/styles/charts/colors.scss
@@ -58,6 +58,18 @@ $lost: $dark;
     }
   }
 
+  @each $name, $scale in $chart-scales {
+    &.swatch-#{$name} {
+      background: nth($scale, -1);
+    }
+
+    @each $color in $scale {
+      &.swatch-#{$name}-#{index($scale, $color)} {
+        background: $color;
+      }
+    }
+  }
+
   &.queued {
     box-shadow: inset 0 0 0 1px rgba($black, 0.3);
     background: $queued;

--- a/ui/app/styles/charts/line-chart.scss
+++ b/ui/app/styles/charts/line-chart.scss
@@ -1,3 +1,17 @@
+@mixin standard-gradient($class, $color) {
+  linearGradient.#{$class} {
+    > .start {
+      stop-color: $color;
+      stop-opacity: 0.6;
+    }
+
+    > .end {
+      stop-color: $color;
+      stop-opacity: 0.05;
+    }
+  }
+}
+
 .chart.line-chart {
   display: block;
   height: 100%;
@@ -79,6 +93,20 @@
           stop-color: $color;
           stop-opacity: 0.05;
         }
+      }
+    }
+  }
+
+  @each $name, $scale in $chart-scales {
+    @include standard-gradient($name, nth($scale, -1));
+    .area.#{$name} .line {
+      stroke: nth($scale, -1);
+    }
+
+    @each $color in $scale {
+      @include standard-gradient((#{$name}-#{index($scale, $color)}), $color);
+      .area.#{$name}-#{index($scale, $color)} .line {
+        stroke: $color;
       }
     }
   }

--- a/ui/app/styles/charts/tooltip.scss
+++ b/ui/app/styles/charts/tooltip.scss
@@ -67,8 +67,7 @@
     }
   }
 
-  ol > li,
-  p {
+  ol > li {
     display: flex;
     flex-flow: row;
     flex-wrap: nowrap;
@@ -93,24 +92,24 @@
     .value {
       padding-left: 1em;
     }
+
+    + li {
+      border-top: 1px solid $grey-light;
+    }
   }
 
-  ol > li {
-    .label {
+  &.with-active-datum {
+    li .label {
       color: rgba($black, 0.6);
     }
 
-    &.active {
+    li.is-active {
       color: $black;
       background: $white-ter;
 
       .label {
         color: $black;
       }
-    }
-
-    + li {
-      border-top: 1px solid $grey-light;
     }
   }
 }

--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -2,7 +2,6 @@
 @import './utils/reset.scss';
 @import './utils/z-indices';
 @import './utils/product-colors';
-@import './utils/structure-colors';
 @import './utils/bumper';
 @import './utils/layout';
 
@@ -14,6 +13,8 @@
 
 // Bring in the rest of Bulma
 @import 'bulma/bulma';
+
+@import './utils/structure-colors';
 
 // Override Bulma details where appropriate
 @import './core/buttons';

--- a/ui/app/styles/storybook.scss
+++ b/ui/app/styles/storybook.scss
@@ -122,6 +122,17 @@
     flex-wrap: wrap;
     align-items: center;
     justify-content: center;
+
+    &.with-spacing {
+      > * {
+        margin-right: 1em;
+        margin-bottom: 1em;
+      }
+    }
+
+    &.is-left-aligned {
+      justify-content: flex-start;
+    }
   }
 
   .chart-container {
@@ -161,5 +172,18 @@
         color: $grey;
       }
     }
+  }
+
+  .mock-hover-region {
+    width: 200px;
+    height: 100px;
+    position: relative;
+    border-radius: $radius;
+    margin: 1em 0;
+    padding: 1em;
+    border: 1px solid $grey-blue;
+    background: $white-ter;
+    color: $grey;
+    font-weight: $weight-bold;
   }
 }

--- a/ui/app/styles/utils/structure-colors.scss
+++ b/ui/app/styles/utils/structure-colors.scss
@@ -35,7 +35,9 @@ $green-500: #2eb039;
 // Chart Color Scales
 $chart-reds: $red-500, $red-400, $red-300, $red-200;
 $chart-blues: $blue-500, $blue-400, $blue-300, $blue-200;
+$chart-ordinal: $orange, $yellow, $green, $turquoise, $blue, $purple, $red;
 $chart-scales: (
   'reds': $chart-reds,
   'blues': $chart-blues,
+  'ordinal': $chart-ordinal,
 );

--- a/ui/app/styles/utils/structure-colors.scss
+++ b/ui/app/styles/utils/structure-colors.scss
@@ -8,8 +8,14 @@ $ui-gray-800: #373a42;
 $ui-gray-900: #1f2124;
 
 $red-500: #c73445;
+$red-400: #d15866;
 $red-300: #db7d88;
 $red-200: #e5a2aa;
+
+$blue-500: #1563ff;
+$blue-400: #387aff;
+$blue-300: #5b92ff;
+$blue-200: #8ab1ff;
 
 $teal-500: #25ba81;
 $teal-300: #74d3ae;
@@ -25,3 +31,11 @@ $yellow-400: #face30;
 $yellow-700: #a07d02;
 
 $green-500: #2eb039;
+
+// Chart Color Scales
+$chart-reds: $red-500, $red-400, $red-300, $red-200;
+$chart-blues: $blue-500, $blue-400, $blue-300, $blue-200;
+$chart-scales: (
+  'reds': $chart-reds,
+  'blues': $chart-blues,
+);

--- a/ui/app/templates/components/distribution-bar.hbs
+++ b/ui/app/templates/components/distribution-bar.hbs
@@ -12,10 +12,10 @@
     activeDatum=this.activeDatum
   )}}
 {{else}}
-  <div class="chart-tooltip {{if this.isActive "active" "inactive"}}" style={{this.tooltipStyle}}>
+  <div class="chart-tooltip with-active-datum {{if this.isActive "active" "inactive"}}" style={{this.tooltipStyle}}>
     <ol>
       {{#each this._data as |datum index|}}
-        <li class="{{if (eq datum.label this.activeDatum.label) "active"}}">
+        <li class="{{if (eq datum.label this.activeDatum.label) "is-active"}}">
           <span class="label {{if (eq datum.value 0) "is-empty"}}">
             <span class="color-swatch {{if datum.className datum.className (concat "swatch-" index)}}" />
             {{datum.label}}

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -40,6 +40,12 @@
         scale=this.xScale
         prop=this.xProp
         height=this.xAxisOffset)
+      HAnnotations=(component "chart-primitives/h-annotations"
+        format=this.yFormat
+        scale=this.yScale
+        prop=this.yProp
+        left=this.canvasDimensions.left
+        width=this.canvasDimensions.width)
     ) to="after"}}
   {{/if}}
   <div class="chart-tooltip is-snappy {{if this.isActive "active" "inactive"}}" style={{this.tooltipStyle}}>

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -29,7 +29,7 @@
     {{/if}}
     <g aria-hidden="true" class="x-axis axis" transform="translate(0, {{this.xAxisOffset}})"></g>
     <g aria-hidden="true" class="y-axis axis" transform="translate({{this.yAxisOffset}}, 0)"></g>
-    <rect class="hover-target" x="0" y="0" width="{{this.yAxisOffset}}" height="{{this.xAxisOffset}}" />
+    <rect data-test-hover-target class="hover-target" x="0" y="0" width="{{this.yAxisOffset}}" height="{{this.xAxisOffset}}" />
   </svg>
   {{#if this.ready}}
     {{yield (hash

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -18,7 +18,6 @@
     {{#if this.ready}}
       {{yield (hash
         Area=(component "chart-primitives/area"
-          colorClass=this.chartClass
           curve="linear"
           xScale=this.xScale
           yScale=this.yScale

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -51,17 +51,4 @@
         data=this.activeData)
     ) to="after"}}
   {{/if}}
-  {{#unless @dataProp}}
-    <div class="chart-tooltip is-snappy {{if this.isActive "active" "inactive"}}" style={{this.tooltipStyle}}>
-      <ol>
-        <li>
-          <span class="label">
-            <span class="color-swatch {{this.chartClass}}" />
-            {{this.activeDatumLabel}}
-          </span>
-          <span class="value">{{this.activeDatumValue}}</span>
-        </li>
-      </ol>
-    </div>
-  {{/unless}}
 </div>

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -53,13 +53,15 @@
   {{/if}}
   {{#unless @dataProp}}
     <div class="chart-tooltip is-snappy {{if this.isActive "active" "inactive"}}" style={{this.tooltipStyle}}>
-      <p>
-        <span class="label">
-          <span class="color-swatch {{this.chartClass}}" />
-          {{this.activeDatumLabel}}
-        </span>
-        <span class="value">{{this.activeDatumValue}}</span>
-      </p>
+      <ol>
+        <li>
+          <span class="label">
+            <span class="color-swatch {{this.chartClass}}" />
+            {{this.activeDatumLabel}}
+          </span>
+          <span class="value">{{this.activeDatumValue}}</span>
+        </li>
+      </ol>
     </div>
   {{/unless}}
 </div>

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -45,15 +45,21 @@
         prop=this.yProp
         left=this.canvasDimensions.left
         width=this.canvasDimensions.width)
+      Tooltip=(component "chart-primitives/tooltip"
+        active=this.activeData.length
+        style=this.tooltipStyle
+        data=this.activeData)
     ) to="after"}}
   {{/if}}
-  <div class="chart-tooltip is-snappy {{if this.isActive "active" "inactive"}}" style={{this.tooltipStyle}}>
-    <p>
-      <span class="label">
-        <span class="color-swatch {{this.chartClass}}" />
-        {{this.activeDatumLabel}}
-      </span>
-      <span class="value">{{this.activeDatumValue}}</span>
-    </p>
-  </div>
+  {{#unless @dataProp}}
+    <div class="chart-tooltip is-snappy {{if this.isActive "active" "inactive"}}" style={{this.tooltipStyle}}>
+      <p>
+        <span class="label">
+          <span class="color-swatch {{this.chartClass}}" />
+          {{this.activeDatumLabel}}
+        </span>
+        <span class="value">{{this.activeDatumValue}}</span>
+      </p>
+    </div>
+  {{/unless}}
 </div>

--- a/ui/app/templates/components/scale-events-chart.hbs
+++ b/ui/app/templates/components/scale-events-chart.hbs
@@ -9,6 +9,12 @@
       @data={{this.data}} />
   </:svg>
   <:after as |c|>
+    <c.Tooltip class="is-snappy" as |series datum|>
+      <li>
+        <span class="label"><span class="color-swatch is-primary" />{{datum.formattedX}}</span>
+        <span class="value">{{datum.formattedY}}</span>
+      </li>
+    </c.Tooltip>
     <c.VAnnotations
       @annotations={{this.annotations}}
       @key="event.uid"

--- a/ui/app/templates/components/stats-time-series.hbs
+++ b/ui/app/templates/components/stats-time-series.hbs
@@ -13,4 +13,12 @@
   <:svg as |c|>
     <c.Area @data={{@data}} @colorClass={{@chartClass}} />
   </:svg>
+  <:after as |c|>
+    <c.Tooltip class="is-snappy" as |series datum|>
+      <li>
+        <span class="label"><span class="color-swatch {{@chartClass}}" />{{datum.formattedX}}</span>
+        <span class="value">{{datum.formattedY}}</span>
+      </li>
+    </c.Tooltip>
+  </:after>
 </LineChart>

--- a/ui/stories/charts/line-chart.stories.js
+++ b/ui/stories/charts/line-chart.stories.js
@@ -49,9 +49,9 @@ export let Standard = () => {
       </div>
       <div class="block" style="height:100px; width: 400px;">
         {{#if this.lineChartMild}}
-          <LineChart @data={{this.lineChartMild}} @xProp="year" @yProp="value" @chartClass="is-info">
+          <LineChart @data={{this.lineChartMild}} @xProp="year" @yProp="value">
             <:svg as |c|>
-              <c.Area @data={{this.lineChartMild}} />
+              <c.Area @data={{this.lineChartMild}} @colorClass="is-info" />
             </:svg>
           </LineChart>
         {{/if}}
@@ -70,18 +70,18 @@ export let FluidWidth = () => {
       <h5 class="title is-5">Fluid-width Line Chart</h5>
       <div class="block" style="height:250px;">
         {{#if this.lineChartData}}
-          <LineChart @data={{this.lineChartData}} @xProp="year" @yProp="value" @chartClass="is-danger">
+          <LineChart @data={{this.lineChartData}} @xProp="year" @yProp="value">
             <:svg as |c|>
-              <c.Area @data={{this.lineChartData}} />
+              <c.Area @data={{this.lineChartData}} @colorClass="is-danger" />
             </:svg>
           </LineChart>
         {{/if}}
       </div>
       <div class="block" style="height:250px;">
         {{#if this.lineChartMild}}
-          <LineChart @data={{this.lineChartMild}} @xProp="year" @yProp="value" @chartClass="is-warning">
+          <LineChart @data={{this.lineChartMild}} @xProp="year" @yProp="value">
             <:svg as |c|>
-              <c.Area @data={{this.lineChartMild}} />
+              <c.Area @data={{this.lineChartMild}} @colorClass="is-warning" />
             </:svg>
           </LineChart>
         {{/if}}
@@ -106,7 +106,6 @@ export let LiveData = () => {
             @xProp="ts"
             @yProp="val"
             @timeseries={{true}}
-            @chartClass="is-primary"
             @xFormat={{this.controller.secondsFormat}}>
             <:svg as |c|>
               <c.Area @data={{this.controller.lineChartLive}} />
@@ -152,7 +151,7 @@ export let Gaps = () => {
       <h5 class="title is-5">Line Chart data with gaps</h5>
       <div class="block" style="height:250px">
         {{#if this.lineChartGapData}}
-          <LineChart @data={{this.lineChartGapData}} @xProp="year" @yProp="value" @chartClass="is-primary">
+          <LineChart @data={{this.lineChartGapData}} @xProp="year" @yProp="value">
             <:svg as |c|>
               <c.Area @data={{this.lineChartGapData}} />
             </:svg>

--- a/ui/stories/charts/line-chart.stories.js
+++ b/ui/stories/charts/line-chart.stories.js
@@ -44,6 +44,14 @@ export let Standard = () => {
             <:svg as |c|>
               <c.Area @data={{this.lineChartData}} />
             </:svg>
+            <:after as |c|>
+              <c.Tooltip class="is-snappy" as |series datum|>
+                <li>
+                  <span class="label"><span class="color-swatch is-primary" />{{datum.formattedX}}</span>
+                  <span class="value">{{datum.formattedY}}</span>
+                </li>
+              </c.Tooltip>
+            </:after>
           </LineChart>
         {{/if}}
       </div>
@@ -53,6 +61,14 @@ export let Standard = () => {
             <:svg as |c|>
               <c.Area @data={{this.lineChartMild}} @colorClass="is-info" />
             </:svg>
+            <:after as |c|>
+              <c.Tooltip class="is-snappy" as |series datum|>
+                <li>
+                  <span class="label"><span class="color-swatch is-info" />{{datum.formattedX}}</span>
+                  <span class="value">{{datum.formattedY}}</span>
+                </li>
+              </c.Tooltip>
+            </:after>
           </LineChart>
         {{/if}}
       </div>
@@ -74,6 +90,14 @@ export let FluidWidth = () => {
             <:svg as |c|>
               <c.Area @data={{this.lineChartData}} @colorClass="is-danger" />
             </:svg>
+            <:after as |c|>
+              <c.Tooltip class="is-snappy" as |series datum|>
+                <li>
+                  <span class="label"><span class="color-swatch is-danger" />{{datum.formattedX}}</span>
+                  <span class="value">{{datum.formattedY}}</span>
+                </li>
+              </c.Tooltip>
+            </:after>
           </LineChart>
         {{/if}}
       </div>
@@ -83,6 +107,14 @@ export let FluidWidth = () => {
             <:svg as |c|>
               <c.Area @data={{this.lineChartMild}} @colorClass="is-warning" />
             </:svg>
+            <:after as |c|>
+              <c.Tooltip class="is-snappy" as |series datum|>
+                <li>
+                  <span class="label"><span class="color-swatch is-warning" />{{datum.formattedX}}</span>
+                  <span class="value">{{datum.formattedY}}</span>
+                </li>
+              </c.Tooltip>
+            </:after>
           </LineChart>
         {{/if}}
       </div>
@@ -155,6 +187,14 @@ export let Gaps = () => {
             <:svg as |c|>
               <c.Area @data={{this.lineChartGapData}} />
             </:svg>
+            <:after as |c|>
+              <c.Tooltip class="is-snappy" as |series datum|>
+                <li>
+                  <span class="label"><span class="color-swatch is-primary" />{{datum.formattedX}}</span>
+                  <span class="value">{{datum.formattedY}}</span>
+                </li>
+              </c.Tooltip>
+            </:after>
           </LineChart>
         {{/if}}
       </div>
@@ -217,6 +257,12 @@ export let VerticalAnnotations = () => {
                 @annotations={{this.annotations}}
                 @annotationClick={{action (mut this.activeAnnotation)}}
                 @activeAnnotation={{this.activeAnnotation}} />
+              <c.Tooltip class="is-snappy" as |series datum|>
+                <li>
+                  <span class="label"><span class="color-swatch is-primary" />{{datum.formattedX}}</span>
+                  <span class="value">{{datum.formattedY}}</span>
+                </li>
+              </c.Tooltip>
             </:after>
           </LineChart>
         {{/if}}
@@ -334,6 +380,14 @@ export let StepLine = () => {
             <:svg as |c|>
               <c.Area @data={{this.data}} @curve="stepAfter" />
             </:svg>
+            <:after as |c|>
+              <c.Tooltip class="is-snappy" as |series datum|>
+                <li>
+                  <span class="label"><span class="color-swatch is-primary" />{{datum.formattedX}}</span>
+                  <span class="value">{{datum.formattedY}}</span>
+                </li>
+              </c.Tooltip>
+            </:after>
           </LineChart>
           <p>{{this.activeAnnotation.info}}</p>
         {{/if}}

--- a/ui/stories/charts/line-chart.stories.js
+++ b/ui/stories/charts/line-chart.stories.js
@@ -370,6 +370,14 @@ export let MultiLine = () => ({
                 <c.Area @data={{series.data}} @colorScale="reds" @index={{idx}} />
               {{/each}}
             </:svg>
+            <:after as |c|>
+              <c.Tooltip class="is-snappy" as |series datum index|>
+                <li>
+                  <span class="label"><span class="color-swatch swatch-reds swatch-reds-{{index}}" />{{series.name}}</span>
+                  <span class="value">{{datum.y}}</span>
+                </li>
+              </c.Tooltip>
+            </:after>
           </LineChart>
           <p>{{this.activeAnnotation.info}}</p>
         {{/if}}
@@ -380,18 +388,6 @@ export let MultiLine = () => ({
       {
         name: 'Series 1',
         data: [
-          { x: 1, y: 5 },
-          { x: 2, y: 1 },
-          { x: 3, y: 2 },
-          { x: 4, y: 2 },
-          { x: 5, y: 9 },
-          { x: 6, y: 3 },
-          { x: 7, y: 4 },
-        ],
-      },
-      {
-        name: 'Series 2',
-        data: [
           { x: 3, y: 7 },
           { x: 4, y: 5 },
           { x: 5, y: 8 },
@@ -399,6 +395,18 @@ export let MultiLine = () => ({
           { x: 7, y: 10 },
           { x: 8, y: 8 },
           { x: 9, y: 6 },
+        ],
+      },
+      {
+        name: 'Series 2',
+        data: [
+          { x: 1, y: 5 },
+          { x: 2, y: 1 },
+          { x: 3, y: 2 },
+          { x: 4, y: 2 },
+          { x: 5, y: 9 },
+          { x: 6, y: 3 },
+          { x: 7, y: 4 },
         ],
       },
     ]),

--- a/ui/stories/charts/line-chart.stories.js
+++ b/ui/stories/charts/line-chart.stories.js
@@ -374,7 +374,7 @@ export let MultiLine = () => ({
               <c.Tooltip class="is-snappy" as |series datum index|>
                 <li>
                   <span class="label"><span class="color-swatch swatch-reds swatch-reds-{{index}}" />{{series.name}}</span>
-                  <span class="value">{{datum.y}}</span>
+                  <span class="value">{{datum.formattedY}}</span>
                 </li>
               </c.Tooltip>
             </:after>

--- a/ui/stories/charts/line-chart.stories.js
+++ b/ui/stories/charts/line-chart.stories.js
@@ -176,7 +176,7 @@ export let Gaps = () => {
   };
 };
 
-export let Annotations = () => {
+export let VerticalAnnotations = () => {
   return {
     template: hbs`
       <h5 class="title is-5">Line Chart data with annotations</h5>
@@ -272,6 +272,50 @@ export let Annotations = () => {
             .toDate(),
           type: 'info',
           info: 'Far right',
+        },
+      ],
+    },
+  };
+};
+
+export let HorizontalAnnotations = () => {
+  return {
+    template: hbs`
+      <div class="block" style="height:250px">
+        {{#if (and this.data this.annotations)}}
+          <LineChart
+            class="with-annotations"
+            @timeseries={{true}}
+            @xProp="x"
+            @yProp="y"
+            @data={{this.data}}>
+            <:svg as |c|>
+              <c.Area @data={{this.data}} @annotationClick={{action (mut this.activeAnnotation)}} />
+            </:svg>
+            <:after as |c|>
+              <c.HAnnotations @annotations={{this.annotations}} @labelProp="info" />
+            </:after>
+          </LineChart>
+        {{/if}}
+      </div>
+    `,
+    context: {
+      data: DelayedArray.create(
+        new Array(180).fill(null).map((_, idx) => ({
+          y: Math.sin((idx * 4 * Math.PI) / 180) * 100 + 200,
+          x: moment()
+            .add(idx, 'd')
+            .toDate(),
+        }))
+      ),
+      annotations: [
+        {
+          y: 300,
+          info: 'High',
+        },
+        {
+          y: 100,
+          info: 'Low',
         },
       ],
     },

--- a/ui/stories/charts/line-chart.stories.js
+++ b/ui/stories/charts/line-chart.stories.js
@@ -354,3 +354,53 @@ export let StepLine = () => {
     },
   };
 };
+
+export let MultiLine = () => ({
+  template: hbs`
+      <h5 class="title is-5">Multiple Lines on One Chart</h5>
+      <div class="block" style="height:250px">
+        {{#if this.data}}
+          <LineChart
+            @xProp="x"
+            @yProp="y"
+            @dataProp="data"
+            @data={{this.data}}>
+            <:svg as |c|>
+              {{#each this.data as |series idx|}}
+                <c.Area @data={{series.data}} @colorScale="reds" @index={{idx}} />
+              {{/each}}
+            </:svg>
+          </LineChart>
+          <p>{{this.activeAnnotation.info}}</p>
+        {{/if}}
+      </div>
+  `,
+  context: {
+    data: DelayedArray.create([
+      {
+        name: 'Series 1',
+        data: [
+          { x: 1, y: 5 },
+          { x: 2, y: 1 },
+          { x: 3, y: 2 },
+          { x: 4, y: 2 },
+          { x: 5, y: 9 },
+          { x: 6, y: 3 },
+          { x: 7, y: 4 },
+        ],
+      },
+      {
+        name: 'Series 2',
+        data: [
+          { x: 3, y: 7 },
+          { x: 4, y: 5 },
+          { x: 5, y: 8 },
+          { x: 6, y: 9 },
+          { x: 7, y: 10 },
+          { x: 8, y: 8 },
+          { x: 9, y: 6 },
+        ],
+      },
+    ]),
+  },
+});

--- a/ui/stories/charts/primitives.stories.js
+++ b/ui/stories/charts/primitives.stories.js
@@ -1,0 +1,68 @@
+import hbs from 'htmlbars-inline-precompile';
+
+export default {
+  title: 'Charts|Primitives',
+};
+
+export let Tooltip = () => ({
+  template: hbs`
+    <h5 class="title is-5">Single Entry</h5>
+    <div class="mock-hover-region" style="width:300px;height:100px">
+      <ChartPrimitives::Tooltip @active={{true}} @style={{this.style}} @data={{this.dataSingle}} as |series|>
+        <li>
+          <span class="label"><span class="color-swatch swatch-reds" />{{series.name}}</span>
+          <span class="value">{{series.value}}</span>
+        </li>
+      </ChartPrimitives::Tooltip>
+    </div>
+
+    <h5 class="title is-5">Multiple Entries</h5>
+    <div class="mock-hover-region" style="width:300px;height:100px">
+      <ChartPrimitives::Tooltip @active={{true}} @style={{this.style}} @data={{take 4 this.dataMultiple}} as |series datum index|>
+        <li>
+          <span class="label"><span class="color-swatch swatch-reds swatch-reds-{{index}}" />{{series.name}}</span>
+          <span class="value">{{datum.value}}</span>
+        </li>
+      </ChartPrimitives::Tooltip>
+    </div>
+
+    <h5 class="title is-5">Active Entry</h5>
+    <div class="mock-hover-region" style="width:300px;height:100px">
+      <ChartPrimitives::Tooltip @active={{true}} @style={{this.style}} @data={{take 4 this.dataMultiple}} class="with-active-datum" as |series datum index|>
+        <li class="{{if (eq series.name "Three") "is-active"}}">
+          <span class="label"><span class="color-swatch swatch-reds swatch-reds-{{index}}" />{{series.name}}</span>
+          <span class="value">{{datum.value}}</span>
+        </li>
+      </ChartPrimitives::Tooltip>
+    </div>
+
+    <h5 class="title is-5">Color Scales</h5>
+    <div class="multiples is-left-aligned with-spacing">
+      {{#each this.scales as |scale|}}
+        <div class="mock-hover-region" style="width:300px;height:200px">
+          {{scale}}
+          <ChartPrimitives::Tooltip @active={{true}} @style="left:70%;top:75%" @data={{this.dataMultiple}} as |series datum index|>
+            <li>
+              <span class="label"><span class="color-swatch swatch-{{scale}} swatch-{{scale}}-{{index}}" />{{series.name}}</span>
+              <span class="value">{{datum.value}}</span>
+            </li>
+          </ChartPrimitives::Tooltip>
+        </div>
+      {{/each}}
+    </div>
+  `,
+  context: {
+    style: 'left:70%;top:50%;',
+    dataSingle: [{ series: { name: 'Example', value: 12 } }],
+    dataMultiple: [
+      { series: { name: 'One' }, datum: { value: 12 }, index: 0 },
+      { series: { name: 'Two' }, datum: { value: 24 }, index: 1 },
+      { series: { name: 'Three' }, datum: { value: 36 }, index: 2 },
+      { series: { name: 'Four' }, datum: { value: 48 }, index: 3 },
+      { series: { name: 'Five' }, datum: { value: 60 }, index: 4 },
+      { series: { name: 'Six' }, datum: { value: 72 }, index: 5 },
+      { series: { name: 'Seven' }, datum: { value: 84 }, index: 6 },
+    ],
+    scales: ['reds', 'blues', 'ordinal'],
+  },
+});


### PR DESCRIPTION
The last PR of the LineChart refactor 🎉 Next comes making actual application changes.

This includes:

1. A new `HAnnotations` chart primitive
2. Examples of using multiple `Area` primitives on a single canvas
3. A new `Tooltip` chart primitive
4. A refactor of the LineChart tooltip to use the new `Tooltip` primitive as well as to support multiple areas.
5. A CSS refactor of chart tooltips since they sorta grew organically and needed to be straightened out.
6. CSS chart color scales (to be used with multiple areas and tooltip swatches)

### Horizontal annotations

This one is straightforward. They're like vertical annotations except horizontal this time. The styles on them are limited to how we intend on using them. 

![image](https://user-images.githubusercontent.com/174740/110421756-f6218e80-8052-11eb-85d9-08c121b96318.png)

### Multiple areas on a single canvas

This one is secretly tricky. Areas aren't guaranteed to have "lock-step" data, meaning equal length sets with identical `x` values throughout. For this reason, the `LineChart` itself needs a reference to the outer data structure to determine the bounds of the union of all data series.

![image](https://user-images.githubusercontent.com/174740/110421980-5d3f4300-8053-11eb-958d-621e311562df.png)

### Tooltip primitive

Since each `Area` is expected to be utilized by the consumer of `LineChart`, the same should be true for `Tooltip`. If for whatever reason only half of the data series are plotted, then only that half should ever show up in the tooltip, but the `LineChart` itself wouldn't know which half. The tricky part about the `Tooltip` primitive is determining what data needs to be yielded to make sure that all relevant data is available and no redundant calculations need to happen.

### LineChart tooltip refactor

The `LineChart` component still owns the mouse events that trigger the tooltip. This prevents excessive event handlers, potentially finicky trigger sizes, and the headache of trying to coordinate mouse events from anywhere else (like `Area` primitives) and determine what data is underneath the cursor and how to get that data into the tooltip.

The biggest impact here is that now instead of simply figuring out which datum is closest to the cursor, the `LineChart` now needs to figure out which datum among all data series is closest to the cursor. And then, which datum for each data series is closest to the closest point to the cursor. And then, are of those data so far away that it would be misleading/surprising to include them in the tooltip?

### CSS refactor of tooltips

Tooltips were originally written for the distribution bar component, which has N entries with one active at a time. The tooltips for line charts were tacked on. They have no active state and were guaranteed to have only one entry. Now we have the need for multiple entries but with no notion of active/inactive states. So I refactored everything to use modifier classes as we usually do instead of using `ol > li` vs. `p` as the differentiator. I added a Story for this too.

![image](https://user-images.githubusercontent.com/174740/110422761-d5f2cf00-8054-11eb-85a8-ed05be849902.png)

### CSS chart color scales

The `Area` primitive has a concept of a color scale which expects certain things from CSS. The way it works is pretty simple. Instead of giving the `Area` component a color class, you give it a color scale and an index. That then becomes an indexed CSS class:

```hbs
<c.Area @colorScale="reds" @index="1" @data={{data}} />
{{! rendered }}
<g class="area reds reds-2">...</g>
```

The expectation is that there will be CSS to color things accordingly. So `reds-2` (and `reds-1`, `reds-3`, etc.) will define the appropriate color, and `reds` will define the fallback color in the event that the index for the chart is larger than length of the color scale (i.e., `reds reds-10` will fallback to `reds` since there is no CSS for `reds-10`).

Since we have lines and gradients and things it made sense to also make use of SCSS mixins and lists and sets to tidy this all up.

```scss
@each $name, $scale in $chart-scales {
  @include standard-gradient($name, nth($scale, -1));
  .area.#{$name} .line {
    stroke: nth($scale, -1);
  }

  @each $color in $scale {
    @include standard-gradient((#{$name}-#{index($scale, $color)}), $color);
    .area.#{$name}-#{index($scale, $color)} .line {
      stroke: $color;
    }
  }
}
```

-------

This PR is the third step in the following project that concludes with improved stats charts:

1. Pull common chart primitives out of LineChart
2. Use contextual components to reduce the responsibilities and API surface area of LineChart
3. **Add multi-area support and horizontal annotations to LineChart via the new contextual component interface**
4. Apply new patterns to the allocation and client stats charts