### PR TITLE
agent: return req error if prometheus metrics are disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.1.0 (Unreleased)
 
 BUG FIXES:
+ * agent: Only allow querying Prometheus formatted metrics if Prometheus is enabled within the config [[GH-10140](https://github.com/hashicorp/nomad/pull/10140)]
  * api: Added missing devices block to AllocatedTaskResources [[GH-10064](https://github.com/hashicorp/nomad/pull/10064)]
  * cli: Fixed a bug where non-int proxy port would panic CLI [[GH-10072](https://github.com/hashicorp/nomad/issues/10072)]
  * cli: Fixed a bug where `nomad operator debug` incorrectly parsed https Consul API URLs. [[GH-10082](https://github.com/hashicorp/nomad/pull/10082)]

--- a/api/internal/testutil/server.go
+++ b/api/internal/testutil/server.go
@@ -42,6 +42,7 @@ type TestServerConfig struct {
 	Client            *ClientConfig `json:"client,omitempty"`
 	Vault             *VaultConfig  `json:"vault,omitempty"`
 	ACL               *ACLConfig    `json:"acl,omitempty"`
+	Telemetry         *Telemetry    `json:"telemetry,omitempty"`
 	DevMode           bool          `json:"-"`
 	Stdout, Stderr    io.Writer     `json:"-"`
 }
@@ -88,6 +89,11 @@ type VaultConfig struct {
 // ACLConfig is used to configure ACLs
 type ACLConfig struct {
 	Enabled bool `json:"enabled"`
+}
+
+// Telemetry is used to configure the Nomad telemetry setup.
+type Telemetry struct {
+	PrometheusMetrics bool `json:"prometheus_metrics"`
 }
 
 // ServerConfigCallback is a function interface which can be

--- a/api/operator_metrics_test.go
+++ b/api/operator_metrics_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,7 +32,9 @@ func TestOperator_MetricsSummary(t *testing.T) {
 
 func TestOperator_Metrics_Prometheus(t *testing.T) {
 	t.Parallel()
-	c, s := makeClient(t, nil, nil)
+	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
+		c.Telemetry = &testutil.Telemetry{PrometheusMetrics: true}
+	})
 	defer s.Stop()
 
 	operator := c.Operator()

--- a/command/agent/metrics_endpoint.go
+++ b/command/agent/metrics_endpoint.go
@@ -22,6 +22,12 @@ func (s *HTTPServer) MetricsRequest(resp http.ResponseWriter, req *http.Request)
 	}
 
 	if format := req.URL.Query().Get("format"); format == "prometheus" {
+
+		// Only return Prometheus formatted metrics if the user has enabled
+		// this functionality.
+		if !s.agent.config.Telemetry.PrometheusMetrics {
+			return nil, CodedError(http.StatusUnsupportedMediaType, "Prometheus is not enabled")
+		}
 		s.prometheusHandler().ServeHTTP(resp, req)
 		return nil, nil
 	}

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -14,6 +14,15 @@ upgrade. However, specific versions of Nomad may have more details provided for
 their upgrades as a result of new features or changed behavior. This page is
 used to document those details separately from the standard upgrade flow.
 
+## Nomad 1.1.0
+
+#### Agent Metrics API
+
+The Nomad agent metrics API now respects the
+[prometheus_metrics](https://www.nomadproject.io/docs/configuration/telemetry#prometheus_metrics)
+configuration value. If this value is set to `false`, which is the default value,
+calling `/v1/metrics?format=prometheus` will now result in a response error.
+
 ## Nomad 1.0.3, 0.12.10
 
 Nomad versions 1.0.3 and 0.12.10 change the behavior of the `exec` and `java` drivers so that

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -19,7 +19,7 @@ used to document those details separately from the standard upgrade flow.
 #### Agent Metrics API
 
 The Nomad agent metrics API now respects the
-[prometheus_metrics](https://www.nomadproject.io/docs/configuration/telemetry#prometheus_metrics)
+[`prometheus_metrics`](https://www.nomadproject.io/docs/configuration/telemetry#prometheus_metrics)
 configuration value. If this value is set to `false`, which is the default value,
 calling `/v1/metrics?format=prometheus` will now result in a response error.
 


### PR DESCRIPTION
If the user has disabled Prometheus metrics and a request is
sent to the metrics endpoint requesting Prometheus formatted
metrics, then the request should fail.

The returned response code copies that of Consul, to provide a
consistent user experience.

It also fixes a knock-on test failure which assumed Prometheus
formatted metrics were available from the test server.

closes #10070 