### PR TITLE
docs: clarify HCL is parsed in CLI

### DIFF
--- a/website/content/docs/job-specification/index.mdx
+++ b/website/content/docs/job-specification/index.mdx
@@ -15,8 +15,8 @@ The job specification is broken down into smaller pieces, which you will find
 expanded in the navigation menu. We recommend getting started at the [job][]
 stanza. Alternatively, you can keep reading to see a few examples.
 
-For machine-friendliness, Nomad can also read JSON-equivalent configurations. In
-general, we recommend using the HCL syntax.
+Nomad HCL is parsed in the command line and sent to Nomad in JSON format via
+the HTTP API.
 
 The general hierarchy for a job is:
 


### PR DESCRIPTION
Clarify a frequent point of confusion. We'd probably like to improve upon this situation (see https://github.com/hashicorp/nomad/issues/6758) but right now, especially with HCL2 being able to access local environment data, this is not likely to land anytime soon.