### PR TITLE
Update DigitalOcean CSI plugin demo

### DIFF
--- a/demo/csi/digitalocean/plugin.nomad
+++ b/demo/csi/digitalocean/plugin.nomad
@@ -1,6 +1,7 @@
 job "digitalocean" {
 
   datacenters = ["dc1"]
+  type = "system"
 
   group "csi" {
     task "plugin" {


### PR DESCRIPTION
The actual demo set the type to "service" but the csi plugin must be "system" otherwise tasks mounted on a client which hasn't the csi plugin running can't mount the desired volume.