### PR TITLE
demo: hclfmt a jobspec

### DIFF
--- a/demo/csi/digitalocean/plugin.nomad
+++ b/demo/csi/digitalocean/plugin.nomad
@@ -1,7 +1,7 @@
 job "digitalocean" {
 
   datacenters = ["dc1"]
-  type = "system"
+  type        = "system"
 
   group "csi" {
     task "plugin" {


### PR DESCRIPTION
This is causing everyone's `lint-go` tests to fail.