### PR TITLE
docs: update website links from master to main

### DIFF
--- a/website/content/api-docs/libraries-and-sdks.mdx
+++ b/website/content/api-docs/libraries-and-sdks.mdx
@@ -16,8 +16,8 @@ the community.
 
 ## Official Libraries
 
-- [`api`](https://github.com/hashicorp/nomad/tree/master/api) - Official Golang
-  client for the Nomad HTTP API ([GoDoc](https://godoc.org/github.com/hashicorp/nomad/api))
+- [`api`](https://github.com/hashicorp/nomad/tree/main/api) - Official Golang
+  client for the Nomad HTTP API ([GoDoc](https://pkg.go.dev/github.com/hashicorp/nomad/api))
 
 - [`nomad-java-sdk`](https://github.com/hashicorp/nomad-java-sdk) - Official
   Java client for the Nomad HTTP API.

--- a/website/content/api-docs/quotas.mdx
+++ b/website/content/api-docs/quotas.mdx
@@ -165,7 +165,7 @@ The table below shows this endpoint's support for
 
 The request body contains a valid, JSON quota specification. View the api
 package to see the definition of a [`QuotaSpec`
-object](https://github.com/hashicorp/nomad/blob/master/api/quota.go#L100-L131).
+object](https://pkg.go.dev/github.com/hashicorp/nomad/api#QuotaSpec).
 
 ### Sample Payload
 

--- a/website/content/docs/internals/plugins/devices.mdx
+++ b/website/content/docs/internals/plugins/devices.mdx
@@ -14,7 +14,7 @@ devices and working with the Nomad client to make them available to assigned
 tasks.
 
 For a real world example of a Nomad device plugin implementation, see the [Nvidia
-GPU plugin](https://github.com/hashicorp/nomad/tree/master/devices/gpu/nvidia).
+GPU plugin](https://github.com/hashicorp/nomad/tree/main/devices/gpu/nvidia).
 
 ## Authoring Device Plugins
 

--- a/website/pages/docs/[[...page]].jsx
+++ b/website/pages/docs/[[...page]].jsx
@@ -17,7 +17,7 @@ export default function DocsLayout(props) {
       subpath={subpath}
       order={order}
       staticProps={props}
-      mainBranch="master"
+      mainBranch="main"
       additionalComponents={additionalComponents}
     />
   )


### PR DESCRIPTION
Updates all our internal links. Punted on hunting down third-parties to verify they're up-to-date.