### PR TITLE
website(style): Update gray brand colors

### DIFF
--- a/website/components/basic-hero/style.css
+++ b/website/components/basic-hero/style.css
@@ -11,7 +11,7 @@
   }
 
   & .g-type-body-large {
-    color: var(--gray-3);
+    color: var(--gray-2);
     margin: 0 auto 0 auto;
     text-align: center;
     max-width: 40em;

--- a/website/components/case-study-carousel/style.css
+++ b/website/components/case-study-carousel/style.css
@@ -23,7 +23,7 @@
 
   &::after {
     content: '';
-    background: var(--gray-7);
+    background: var(--gray-6);
     width: 100%;
     height: 500px;
     position: absolute;
@@ -33,7 +33,7 @@
 
   & .background-section {
     width: 100%;
-    background: var(--gray-7);
+    background: var(--gray-6);
     & .mono-logos {
       display: flex;
       justify-content: center;
@@ -113,7 +113,7 @@
     }
 
     &:disabled svg path {
-      stroke: var(--gray-5);
+      stroke: var(--gray-4);
     }
   }
 
@@ -127,7 +127,7 @@
 
     @media (max-width: 800px) {
       box-shadow: none;
-      border: 1px solid var(--gray-6);
+      border: 1px solid var(--gray-5);
       padding: 48px;
     }
 
@@ -228,7 +228,7 @@
     }
 
     & .case {
-      color: var(--gray-5);
+      color: var(--gray-4);
       font-size: 24px;
       line-height: 31px; /* Called for within the design, no custom property seemed appropriate */
     }

--- a/website/components/comparison-callouts/style.module.css
+++ b/website/components/comparison-callouts/style.module.css
@@ -1,7 +1,7 @@
 .comparisonCallouts {
   padding-top: 128px;
   padding-bottom: 128px;
-  background: var(--gray-7);
+  background: var(--gray-6);
 }
 
 .content {
@@ -39,7 +39,7 @@
   padding: 48px 24px;
   background-color: var(--white);
   box-shadow: 0 2px 3px rgba(37, 41, 55, 0.08);
-  border: 1px solid var(--gray-6);
+  border: 1px solid var(--gray-5);
   border-radius: 1px;
   transition-duration: 0.25s;
   transition-property: box-shadow, transform;

--- a/website/components/enterprise-info/style.css
+++ b/website/components/enterprise-info/style.css
@@ -1,7 +1,7 @@
 .g-enterprise-info {
   padding-top: 128px;
   padding-bottom: 128px;
-  background: var(--gray-7);
+  background: var(--gray-6);
 
   & h2 {
     text-align: center;

--- a/website/components/featured-slider/style.css
+++ b/website/components/featured-slider/style.css
@@ -42,10 +42,10 @@
         width: 100%;
         height: 2px;
         display: block;
-        background-color: var(--DEPRECATED-gray-9);
+        background-color: var(--gray-5);
 
         &.dark {
-          background-color: var(--DEPRECATED-gray-3);
+          background-color: var(--gray-2);
         }
 
         & span {

--- a/website/components/features-list/style.css
+++ b/website/components/features-list/style.css
@@ -23,7 +23,7 @@
     flex-wrap: wrap;
 
     & .item {
-      border: 1px solid var(--gray-6);
+      border: 1px solid var(--gray-5);
       flex-basis: calc(50% - 16px);
       margin-bottom: 32px;
       padding: 40px;

--- a/website/components/homepage-hero/style.css
+++ b/website/components/homepage-hero/style.css
@@ -1,6 +1,6 @@
 .g-homepage-hero {
   background-repeat: no-repeat;
-  background-color: var(--gray-7);
+  background-color: var(--gray-6);
   background-image: url(/img/nomad-hero-pattern.svg);
   width: 100%;
   background-size: cover;

--- a/website/components/learn-nomad/style.css
+++ b/website/components/learn-nomad/style.css
@@ -91,7 +91,7 @@
       }
 
       & .course {
-        border: 1px solid var(--gray-6);
+        border: 1px solid var(--gray-5);
         display: flex;
         flex-direction: column;
         width: 100%;
@@ -102,7 +102,7 @@
         }
 
         & .image {
-          background: var(--gray-7);
+          background: var(--gray-6);
           position: relative;
           display: flex;
           justify-content: center;
@@ -119,7 +119,7 @@
         }
 
         & .time {
-          color: var(--gray-4);
+          color: var(--gray-3);
           position: absolute;
           top: 10px;
           right: 10px;

--- a/website/components/mini-cta/style.css
+++ b/website/components/mini-cta/style.css
@@ -1,12 +1,12 @@
 .g-mini-cta {
-  background: var(--gray-7);
+  background: var(--gray-6);
   text-align: center;
   padding-bottom: 64px;
   padding-top: 48px;
 
   & hr {
     width: 64px;
-    color: var(--gray-5);
+    color: var(--gray-4);
     margin: 0 auto 64px auto;
 
     @media (max-width: 800px) {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1318,9 +1318,9 @@
       "integrity": "sha512-AvRPKxi6bEzjS6U8dZR9FGjPmlqxxTdzPeFZXYTsc8kUGjoY/X9/GXY2zYCpzEpmUdnLzOSJrDl17INPEeL4Pw=="
     },
     "@hashicorp/mktg-global-styles": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/mktg-global-styles/-/mktg-global-styles-2.1.0.tgz",
-      "integrity": "sha512-REr07tPJDKpyTh/u9tUS3sf29LnkDrWFVgY7FTvDJfbJ60IJ/R1TYNmcE7QKREGJ8j0p43QWEDabqVWOWvOXFA=="
+      "version": "2.1.1-canary.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/mktg-global-styles/-/mktg-global-styles-2.1.1-canary.0.tgz",
+      "integrity": "sha512-P/PtJNKU8SQPwiVM4FAXT28D3IQqQCtm1CuyP/5uJvZCljzHQ8bTWqQuoV0wVw5ceAPbYoQyACB9fait9eCm7Q=="
     },
     "@hashicorp/nextjs-scripts": {
       "version": "16.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,7 @@
     "node": "12.x"
   },
   "dependencies": {
-    "@hashicorp/mktg-global-styles": "2.1.0",
+    "@hashicorp/mktg-global-styles": "2.1.1-canary.0",
     "@hashicorp/nextjs-scripts": "16.0.1",
     "@hashicorp/react-alert-banner": "5.0.0",
     "@hashicorp/react-button": "4.0.0",


### PR DESCRIPTION
Removes references to deprecated gray CSS properties and maps all gray colors to new brand values.

[_Created by Sourcegraph campaign `kstraut/product-sites-migrate-v3-gray-colors`._](https://sourcegraph.hashi-mktg.com/users/kstraut/campaigns/product-sites-migrate-v3-gray-colors)

## **Important**
Due to old imports of `react-global-styles` within `react-components`, the proper gray values will not show until we update `react-components` later on because the old style sheets are taking precedent.

## The Map
```
// v2 gray css properties to new v3 values
"--gray-3" --> "--gray-2" 
 
"--gray-4" --> "--gray-3" 
 
"--gray-5" --> "--gray-4" 
 
"--gray-6" --> "--gray-5" 
 
"--gray-7" --> "--gray-6" 
 

// Replace Deprecated Gray Value references
"DEPRECATED-gray-:[~1|2]" --> "gray-1" 
 
"DEPRECATED-gray-:[~3|4]" --> "gray-2" 
 
"DEPRECATED-gray-:[~5|6]" --> "gray-3" 
 
"DEPRECATED-gray-7" --> "gray-4" 
 
"DEPRECATED-gray-:[~8|9]" --> "gray-5" 
 
"DEPRECATED-gray-10" --> "gray-6" 
```