### PR TITLE
CSI: don't truncate CSI volume IDs

### DIFF
--- a/command/volume_status.go
+++ b/command/volume_status.go
@@ -109,11 +109,7 @@ func (c *VolumeStatusCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Truncate the id unless full length is requested
-	c.length = shortId
-	if c.verbose {
-		c.length = fullId
-	}
+	c.length = fullId
 
 	// Get the HTTP client
 	client, err := c.Meta.Client()


### PR DESCRIPTION
Volume IDs are not UUIDs, so truncating them to the short ID isn't really
necessary and makes for especially awkward UX when per-alloc volumes are in
use.