### PR TITLE
CSI: volume creation

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -65,6 +65,14 @@ type QueryOptions struct {
 	// AuthToken is the secret ID of an ACL token
 	AuthToken string
 
+	// PerPage is the number of entries to be returned in queries that support
+	// paginated lists.
+	PerPage int32
+
+	// NextToken is the token used indicate where to start paging for queries
+	// that support paginated lists.
+	NextToken string
+
 	// ctx is an optional context pass through to the underlying HTTP
 	// request layer. Use Context() and WithContext() to manage this.
 	ctx context.Context

--- a/api/csi.go
+++ b/api/csi.go
@@ -134,23 +134,23 @@ type CSISecrets map[string]string
 type CSIVolume struct {
 	ID             string
 	Name           string
-	ExternalID     string `hcl:"external_id"`
+	ExternalID     string `mapstructure:"external_id" hcl:"external_id"`
 	Namespace      string
 	Topologies     []*CSITopology
 	AccessMode     CSIVolumeAccessMode     `hcl:"access_mode"`
 	AttachmentMode CSIVolumeAttachmentMode `hcl:"attachment_mode"`
 	MountOptions   *CSIMountOptions        `hcl:"mount_options"`
-	Secrets        CSISecrets              `hcl:"secrets"`
-	Parameters     map[string]string       `hcl:"parameters"`
-	Context        map[string]string       `hcl:"context"`
+	Secrets        CSISecrets              `mapstructure:"secrets" hcl:"secrets"`
+	Parameters     map[string]string       `mapstructure:"parameters" hcl:"parameters"`
+	Context        map[string]string       `mapstructure:"context" hcl:"context"`
 	Capacity       int64                   `hcl:"-"`
 
 	// These fields are used as part of the volume creation request
 	RequestedCapacityMin  int64                  `hcl:"capacity_min"`
 	RequestedCapacityMax  int64                  `hcl:"capacity_max"`
 	RequestedCapabilities []*CSIVolumeCapability `hcl:"capability"`
-	CloneID               string                 `hcl:"clone_id"`
-	SnapshotID            string                 `hcl:"snapshot_id"`
+	CloneID               string                 `mapstructure:"clone_id" hcl:"clone_id"`
+	SnapshotID            string                 `mapstructure:"snapshot_id" hcl:"snapshot_id"`
 
 	// ReadAllocs is a map of allocation IDs for tracking reader claim status.
 	// The Allocation value will always be nil; clients can populate this data
@@ -167,7 +167,7 @@ type CSIVolume struct {
 
 	// Schedulable is true if all the denormalized plugin health fields are true
 	Schedulable         bool
-	PluginID            string `hcl:"plugin_id"`
+	PluginID            string `mapstructure:"plugin_id" hcl:"plugin_id"`
 	Provider            string
 	ProviderVersion     string
 	ControllerRequired  bool
@@ -187,8 +187,8 @@ type CSIVolume struct {
 // CSIVolumeCapability is a requested attachment and access mode for a
 // volume
 type CSIVolumeCapability struct {
-	AccessMode     CSIVolumeAccessMode     `hcl:"access_mode"`
-	AttachmentMode CSIVolumeAttachmentMode `hcl:"attachment_mode"`
+	AccessMode     CSIVolumeAccessMode     `mapstructure:"access_mode" hcl:"access_mode"`
+	AttachmentMode CSIVolumeAttachmentMode `mapstructure:"attachment_mode" hcl:"attachment_mode"`
 }
 
 type CSIVolumeIndexSort []*CSIVolumeListStub

--- a/api/csi.go
+++ b/api/csi.go
@@ -28,6 +28,33 @@ func (v *CSIVolumes) List(q *QueryOptions) ([]*CSIVolumeListStub, *QueryMeta, er
 	return resp, qm, nil
 }
 
+// ListExternal returns all CSI volumes, as known to the storage provider
+func (v *CSIVolumes) ListExternal(pluginID string, q *QueryOptions) (*CSIVolumeListExternalResponse, *QueryMeta, error) {
+	var resp *CSIVolumeListExternalResponse
+
+	qp := url.Values{}
+	qp.Set("plugin_id", pluginID)
+	if q.NextToken != "" {
+		qp.Set("next_token", q.NextToken)
+	}
+	if q.PerPage != 0 {
+		qp.Set("per_page", fmt.Sprint(q.PerPage))
+	}
+
+	qm, err := v.client.query("/v1/volumes/external?"+qp.Encode(), &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sort.Sort(CSIVolumeExternalStubSort(resp.Volumes))
+	return resp, qm, nil
+}
+
+// PluginList returns all CSI volumes for the specified plugin id
+func (v *CSIVolumes) PluginList(pluginID string) ([]*CSIVolumeListStub, *QueryMeta, error) {
+	return v.List(&QueryOptions{Prefix: pluginID})
+}
+
 // Info is used to retrieve a single CSIVolume
 func (v *CSIVolumes) Info(id string, q *QueryOptions) (*CSIVolume, *QueryMeta, error) {
 	var resp CSIVolume
@@ -49,6 +76,21 @@ func (v *CSIVolumes) Register(vol *CSIVolume, w *WriteOptions) (*WriteMeta, erro
 
 func (v *CSIVolumes) Deregister(id string, force bool, w *WriteOptions) error {
 	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v?force=%t", url.PathEscape(id), force), nil, w)
+	return err
+}
+
+func (v *CSIVolumes) Create(vol *CSIVolume, w *WriteOptions) ([]*CSIVolume, *WriteMeta, error) {
+	req := CSIVolumeCreateRequest{
+		Volumes: []*CSIVolume{vol},
+	}
+
+	resp := &CSIVolumeCreateResponse{}
+	meta, err := v.client.write(fmt.Sprintf("/v1/volume/csi/%v/create", vol.ID), req, resp, w)
+	return resp.Volumes, meta, err
+}
+
+func (v *CSIVolumes) Delete(externalVolID string, w *WriteOptions) error {
+	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v/delete", url.PathEscape(externalVolID)), nil, w)
 	return err
 }
 
@@ -101,6 +143,14 @@ type CSIVolume struct {
 	Secrets        CSISecrets              `hcl:"secrets"`
 	Parameters     map[string]string       `hcl:"parameters"`
 	Context        map[string]string       `hcl:"context"`
+	Capacity       int64                   `hcl:"-"`
+
+	// These fields are used as part of the volume creation request
+	RequestedCapacityMin  int64                  `hcl:"capacity_min"`
+	RequestedCapacityMax  int64                  `hcl:"capacity_max"`
+	RequestedCapabilities []*CSIVolumeCapability `hcl:"capability"`
+	CloneID               string                 `hcl:"clone_id"`
+	SnapshotID            string                 `hcl:"snapshot_id"`
 
 	// ReadAllocs is a map of allocation IDs for tracking reader claim status.
 	// The Allocation value will always be nil; clients can populate this data
@@ -132,6 +182,13 @@ type CSIVolume struct {
 
 	// ExtraKeysHCL is used by the hcl parser to report unexpected keys
 	ExtraKeysHCL []string `hcl1:",unusedKeys" json:"-"`
+}
+
+// CSIVolumeCapability is a requested attachment and access mode for a
+// volume
+type CSIVolumeCapability struct {
+	AccessMode     CSIVolumeAccessMode     `hcl:"access_mode"`
+	AttachmentMode CSIVolumeAttachmentMode `hcl:"attachment_mode"`
 }
 
 type CSIVolumeIndexSort []*CSIVolumeListStub
@@ -169,6 +226,50 @@ type CSIVolumeListStub struct {
 
 	CreateIndex uint64
 	ModifyIndex uint64
+}
+
+type CSIVolumeListExternalResponse struct {
+	Volumes   []*CSIVolumeExternalStub
+	NextToken string
+}
+
+// CSIVolumeExternalStub is the storage provider's view of a volume, as
+// returned from the controller plugin; all IDs are for external resources
+type CSIVolumeExternalStub struct {
+	ExternalID               string
+	CapacityBytes            int64
+	VolumeContext            map[string]string
+	CloneID                  string
+	SnapshotID               string
+	PublishedExternalNodeIDs []string
+	IsAbnormal               bool
+	Status                   string
+}
+
+// We can't sort external volumes by creation time because we don't get that
+// data back from the storage provider. Sort by External ID within this page.
+type CSIVolumeExternalStubSort []*CSIVolumeExternalStub
+
+func (v CSIVolumeExternalStubSort) Len() int {
+	return len(v)
+}
+
+func (v CSIVolumeExternalStubSort) Less(i, j int) bool {
+	return v[i].ExternalID > v[j].ExternalID
+}
+
+func (v CSIVolumeExternalStubSort) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+type CSIVolumeCreateRequest struct {
+	Volumes []*CSIVolume
+	WriteRequest
+}
+
+type CSIVolumeCreateResponse struct {
+	Volumes []*CSIVolume
+	QueryMeta
 }
 
 type CSIVolumeRegisterRequest struct {

--- a/client/client.go
+++ b/client/client.go
@@ -308,8 +308,12 @@ var (
 	noServersErr = errors.New("no servers")
 )
 
-// NewClient is used to create a new client from the given configuration
-func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxies consulApi.SupportedProxiesAPI, consulService consulApi.ConsulServiceAPI) (*Client, error) {
+// NewClient is used to create a new client from the given configuration.
+// `rpcs` is a map of RPC names to RPC structs that, if non-nil, will be
+// registered via https://golang.org/pkg/net/rpc/#Server.RegisterName in place
+// of the client's normal RPC handlers. This allows server tests to override
+// the behavior of the client.
+func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxies consulApi.SupportedProxiesAPI, consulService consulApi.ConsulServiceAPI, rpcs map[string]interface{}) (*Client, error) {
 	// Create the tls wrapper
 	var tlsWrap tlsutil.RegionWrapper
 	if cfg.TLSConfig.EnableRPC {
@@ -384,7 +388,7 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 		})
 
 	// Setup the clients RPC server
-	c.setupClientRpc()
+	c.setupClientRpc(rpcs)
 
 	// Initialize the ACL state
 	if err := c.clientACLResolver.init(); err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -622,7 +622,7 @@ func TestClient_SaveRestoreState(t *testing.T) {
 	c1.config.PluginLoader = catalog.TestPluginLoaderWithOptions(t, "", c1.config.Options, nil)
 	c1.config.PluginSingletonLoader = singleton.NewSingletonLoader(logger, c1.config.PluginLoader)
 
-	c2, err := NewClient(c1.config, consulCatalog, nil, mockService)
+	c2, err := NewClient(c1.config, consulCatalog, nil, mockService, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/client/csi_endpoint_test.go
+++ b/client/csi_endpoint_test.go
@@ -41,7 +41,7 @@ func TestCSIController_AttachVolume(t *testing.T) {
 					PluginID: "some-garbage",
 				},
 			},
-			ExpectedErr: errors.New("CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
+			ExpectedErr: errors.New("CSI.ControllerAttachVolume: CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
 		},
 		{
 			Name: "validates volumeid is not empty",
@@ -50,7 +50,7 @@ func TestCSIController_AttachVolume(t *testing.T) {
 					PluginID: fakePlugin.Name,
 				},
 			},
-			ExpectedErr: errors.New("VolumeID is required"),
+			ExpectedErr: errors.New("CSI.ControllerAttachVolume: VolumeID is required"),
 		},
 		{
 			Name: "validates nodeid is not empty",
@@ -60,7 +60,7 @@ func TestCSIController_AttachVolume(t *testing.T) {
 				},
 				VolumeID: "1234-4321-1234-4321",
 			},
-			ExpectedErr: errors.New("ClientCSINodeID is required"),
+			ExpectedErr: errors.New("CSI.ControllerAttachVolume: ClientCSINodeID is required"),
 		},
 		{
 			Name: "validates AccessMode",
@@ -73,7 +73,7 @@ func TestCSIController_AttachVolume(t *testing.T) {
 				AttachmentMode:  nstructs.CSIVolumeAttachmentModeFilesystem,
 				AccessMode:      nstructs.CSIVolumeAccessMode("foo"),
 			},
-			ExpectedErr: errors.New("Unknown volume access mode: foo"),
+			ExpectedErr: errors.New("CSI.ControllerAttachVolume: unknown volume access mode: foo"),
 		},
 		{
 			Name: "validates attachmentmode is not empty",
@@ -86,7 +86,7 @@ func TestCSIController_AttachVolume(t *testing.T) {
 				AccessMode:      nstructs.CSIVolumeAccessModeMultiNodeReader,
 				AttachmentMode:  nstructs.CSIVolumeAttachmentMode("bar"),
 			},
-			ExpectedErr: errors.New("Unknown volume attachment mode: bar"),
+			ExpectedErr: errors.New("CSI.ControllerAttachVolume: unknown volume attachment mode: bar"),
 		},
 		{
 			Name: "returns transitive errors",
@@ -102,7 +102,7 @@ func TestCSIController_AttachVolume(t *testing.T) {
 				AccessMode:      nstructs.CSIVolumeAccessModeSingleNodeWriter,
 				AttachmentMode:  nstructs.CSIVolumeAttachmentModeFilesystem,
 			},
-			ExpectedErr: errors.New("hello"),
+			ExpectedErr: errors.New("CSI.ControllerAttachVolume: hello"),
 		},
 		{
 			Name: "handles nil PublishContext",
@@ -188,7 +188,7 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 					PluginID: fakePlugin.Name,
 				},
 			},
-			ExpectedErr: errors.New("VolumeID is required"),
+			ExpectedErr: errors.New("CSI.ControllerValidateVolume: VolumeID is required"),
 		},
 		{
 			Name: "returns plugin not found errors",
@@ -198,7 +198,7 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 				},
 				VolumeID: "foo",
 			},
-			ExpectedErr: errors.New("CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
+			ExpectedErr: errors.New("CSI.ControllerValidateVolume: CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
 		},
 		{
 			Name: "validates attachmentmode",
@@ -210,7 +210,7 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 				AttachmentMode: nstructs.CSIVolumeAttachmentMode("bar"),
 				AccessMode:     nstructs.CSIVolumeAccessModeMultiNodeReader,
 			},
-			ExpectedErr: errors.New("Unknown volume attachment mode: bar"),
+			ExpectedErr: errors.New("CSI.ControllerValidateVolume: unknown volume attachment mode: bar"),
 		},
 		{
 			Name: "validates AccessMode",
@@ -222,7 +222,7 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 				AttachmentMode: nstructs.CSIVolumeAttachmentModeFilesystem,
 				AccessMode:     nstructs.CSIVolumeAccessMode("foo"),
 			},
-			ExpectedErr: errors.New("Unknown volume access mode: foo"),
+			ExpectedErr: errors.New("CSI.ControllerValidateVolume: unknown volume access mode: foo"),
 		},
 		{
 			Name: "returns transitive errors",
@@ -237,7 +237,7 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 				AccessMode:     nstructs.CSIVolumeAccessModeSingleNodeWriter,
 				AttachmentMode: nstructs.CSIVolumeAttachmentModeFilesystem,
 			},
-			ExpectedErr: errors.New("hello"),
+			ExpectedErr: errors.New("CSI.ControllerValidateVolume: hello"),
 		},
 	}
 
@@ -287,7 +287,7 @@ func TestCSIController_DetachVolume(t *testing.T) {
 					PluginID: "some-garbage",
 				},
 			},
-			ExpectedErr: errors.New("CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
+			ExpectedErr: errors.New("CSI.ControllerDetachVolume: CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
 		},
 		{
 			Name: "validates volumeid is not empty",
@@ -296,7 +296,7 @@ func TestCSIController_DetachVolume(t *testing.T) {
 					PluginID: fakePlugin.Name,
 				},
 			},
-			ExpectedErr: errors.New("VolumeID is required"),
+			ExpectedErr: errors.New("CSI.ControllerDetachVolume: VolumeID is required"),
 		},
 		{
 			Name: "validates nodeid is not empty",
@@ -306,7 +306,7 @@ func TestCSIController_DetachVolume(t *testing.T) {
 				},
 				VolumeID: "1234-4321-1234-4321",
 			},
-			ExpectedErr: errors.New("ClientCSINodeID is required"),
+			ExpectedErr: errors.New("CSI.ControllerDetachVolume: ClientCSINodeID is required"),
 		},
 		{
 			Name: "returns transitive errors",
@@ -320,7 +320,7 @@ func TestCSIController_DetachVolume(t *testing.T) {
 				VolumeID:        "1234-4321-1234-4321",
 				ClientCSINodeID: "abcde",
 			},
-			ExpectedErr: errors.New("hello"),
+			ExpectedErr: errors.New("CSI.ControllerDetachVolume: hello"),
 		},
 	}
 
@@ -353,6 +353,281 @@ func TestCSIController_DetachVolume(t *testing.T) {
 	}
 }
 
+func TestCSIController_CreateVolume(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name             string
+		ClientSetupFunc  func(*fake.Client)
+		Request          *structs.ClientCSIControllerCreateVolumeRequest
+		ExpectedErr      error
+		ExpectedResponse *structs.ClientCSIControllerCreateVolumeResponse
+	}{
+		{
+			Name: "returns plugin not found errors",
+			Request: &structs.ClientCSIControllerCreateVolumeRequest{
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: "some-garbage",
+				},
+			},
+			ExpectedErr: errors.New("CSI.ControllerCreateVolume: CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
+		},
+		{
+			Name: "validates AccessMode",
+			Request: &structs.ClientCSIControllerCreateVolumeRequest{
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
+				Name: "1234-4321-1234-4321",
+				VolumeCapabilities: []*nstructs.CSIVolumeCapability{
+					{
+						AttachmentMode: nstructs.CSIVolumeAttachmentModeFilesystem,
+						AccessMode:     nstructs.CSIVolumeAccessMode("foo"),
+					},
+				},
+			},
+			ExpectedErr: errors.New("CSI.ControllerCreateVolume: unknown volume access mode: foo"),
+		},
+		{
+			Name: "validates attachmentmode is not empty",
+			Request: &structs.ClientCSIControllerCreateVolumeRequest{
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
+				Name: "1234-4321-1234-4321",
+				VolumeCapabilities: []*nstructs.CSIVolumeCapability{
+					{
+						AccessMode:     nstructs.CSIVolumeAccessModeMultiNodeReader,
+						AttachmentMode: nstructs.CSIVolumeAttachmentMode("bar"),
+					},
+				},
+			},
+			ExpectedErr: errors.New("CSI.ControllerCreateVolume: unknown volume attachment mode: bar"),
+		},
+		{
+			Name: "returns transitive errors",
+			ClientSetupFunc: func(fc *fake.Client) {
+				fc.NextControllerCreateVolumeErr = errors.New("internal plugin error")
+			},
+			Request: &structs.ClientCSIControllerCreateVolumeRequest{
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
+				Name: "1234-4321-1234-4321",
+				VolumeCapabilities: []*nstructs.CSIVolumeCapability{
+					{
+						AccessMode:     nstructs.CSIVolumeAccessModeSingleNodeWriter,
+						AttachmentMode: nstructs.CSIVolumeAttachmentModeFilesystem,
+					},
+				},
+			},
+			ExpectedErr: errors.New("CSI.ControllerCreateVolume: internal plugin error"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			require := require.New(t)
+			client, cleanup := TestClient(t, nil)
+			defer cleanup()
+
+			fakeClient := &fake.Client{}
+			if tc.ClientSetupFunc != nil {
+				tc.ClientSetupFunc(fakeClient)
+			}
+
+			dispenserFunc := func(*dynamicplugins.PluginInfo) (interface{}, error) {
+				return fakeClient, nil
+			}
+			client.dynamicRegistry.StubDispenserForType(
+				dynamicplugins.PluginTypeCSIController, dispenserFunc)
+
+			err := client.dynamicRegistry.RegisterPlugin(fakePlugin)
+			require.Nil(err)
+
+			var resp structs.ClientCSIControllerCreateVolumeResponse
+			err = client.ClientRPC("CSI.ControllerCreateVolume", tc.Request, &resp)
+			require.Equal(tc.ExpectedErr, err)
+			if tc.ExpectedResponse != nil {
+				require.Equal(tc.ExpectedResponse, &resp)
+			}
+		})
+	}
+}
+
+func TestCSIController_DeleteVolume(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name             string
+		ClientSetupFunc  func(*fake.Client)
+		Request          *structs.ClientCSIControllerDeleteVolumeRequest
+		ExpectedErr      error
+		ExpectedResponse *structs.ClientCSIControllerDeleteVolumeResponse
+	}{
+		{
+			Name: "returns plugin not found errors",
+			Request: &structs.ClientCSIControllerDeleteVolumeRequest{
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: "some-garbage",
+				},
+			},
+			ExpectedErr: errors.New("CSI.ControllerDeleteVolume: CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
+		},
+		{
+			Name: "returns transitive errors",
+			ClientSetupFunc: func(fc *fake.Client) {
+				fc.NextControllerDeleteVolumeErr = errors.New("internal plugin error")
+			},
+			Request: &structs.ClientCSIControllerDeleteVolumeRequest{
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
+				ExternalVolumeID: "1234-4321-1234-4321",
+			},
+			ExpectedErr: errors.New("CSI.ControllerDeleteVolume: internal plugin error"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			require := require.New(t)
+			client, cleanup := TestClient(t, nil)
+			defer cleanup()
+
+			fakeClient := &fake.Client{}
+			if tc.ClientSetupFunc != nil {
+				tc.ClientSetupFunc(fakeClient)
+			}
+
+			dispenserFunc := func(*dynamicplugins.PluginInfo) (interface{}, error) {
+				return fakeClient, nil
+			}
+			client.dynamicRegistry.StubDispenserForType(
+				dynamicplugins.PluginTypeCSIController, dispenserFunc)
+
+			err := client.dynamicRegistry.RegisterPlugin(fakePlugin)
+			require.Nil(err)
+
+			var resp structs.ClientCSIControllerDeleteVolumeResponse
+			err = client.ClientRPC("CSI.ControllerDeleteVolume", tc.Request, &resp)
+			require.Equal(tc.ExpectedErr, err)
+			if tc.ExpectedResponse != nil {
+				require.Equal(tc.ExpectedResponse, &resp)
+			}
+		})
+	}
+}
+
+func TestCSIController_ListVolumes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name             string
+		ClientSetupFunc  func(*fake.Client)
+		Request          *structs.ClientCSIControllerListVolumesRequest
+		ExpectedErr      error
+		ExpectedResponse *structs.ClientCSIControllerListVolumesResponse
+	}{
+		{
+			Name: "returns plugin not found errors",
+			Request: &structs.ClientCSIControllerListVolumesRequest{
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: "some-garbage",
+				},
+			},
+			ExpectedErr: errors.New("CSI.ControllerListVolumes: CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
+		},
+		{
+			Name: "returns transitive errors",
+			ClientSetupFunc: func(fc *fake.Client) {
+				fc.NextControllerListVolumesErr = errors.New("internal plugin error")
+			},
+			Request: &structs.ClientCSIControllerListVolumesRequest{
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
+			},
+			ExpectedErr: errors.New("CSI.ControllerListVolumes: internal plugin error"),
+		},
+		{
+			Name: "returns volumes",
+			ClientSetupFunc: func(fc *fake.Client) {
+				fc.NextControllerListVolumesResponse = &csi.ControllerListVolumesResponse{
+					Entries: []*csi.ListVolumesResponse_Entry{
+						{
+							Volume: &csi.Volume{
+								CapacityBytes:    1000000,
+								ExternalVolumeID: "vol-1",
+								VolumeContext:    map[string]string{"foo": "bar"},
+								ContentSource: &csi.VolumeContentSource{
+									SnapshotID: "snap-1",
+								},
+							},
+							Status: &csi.ListVolumesResponse_VolumeStatus{
+								PublishedNodeIds: []string{"i-1234", "i-5678"},
+								VolumeCondition: &csi.VolumeCondition{
+									Message: "ok",
+								},
+							},
+						},
+					},
+					NextToken: "2",
+				}
+			},
+			Request: &structs.ClientCSIControllerListVolumesRequest{
+				CSIControllerQuery: structs.CSIControllerQuery{
+					PluginID: fakePlugin.Name,
+				},
+				StartingToken: "1",
+				MaxEntries:    100,
+			},
+			ExpectedResponse: &structs.ClientCSIControllerListVolumesResponse{
+				Entries: []*nstructs.CSIVolumeExternalStub{
+					{
+						ExternalID:               "vol-1",
+						CapacityBytes:            1000000,
+						VolumeContext:            map[string]string{"foo": "bar"},
+						SnapshotID:               "snap-1",
+						PublishedExternalNodeIDs: []string{"i-1234", "i-5678"},
+						Status:                   "ok",
+					},
+				},
+				NextToken: "2",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			require := require.New(t)
+			client, cleanup := TestClient(t, nil)
+			defer cleanup()
+
+			fakeClient := &fake.Client{}
+			if tc.ClientSetupFunc != nil {
+				tc.ClientSetupFunc(fakeClient)
+			}
+
+			dispenserFunc := func(*dynamicplugins.PluginInfo) (interface{}, error) {
+				return fakeClient, nil
+			}
+			client.dynamicRegistry.StubDispenserForType(
+				dynamicplugins.PluginTypeCSIController, dispenserFunc)
+
+			err := client.dynamicRegistry.RegisterPlugin(fakePlugin)
+			require.Nil(err)
+
+			var resp structs.ClientCSIControllerListVolumesResponse
+			err = client.ClientRPC("CSI.ControllerListVolumes", tc.Request, &resp)
+			require.Equal(tc.ExpectedErr, err)
+			if tc.ExpectedResponse != nil {
+				require.Equal(tc.ExpectedResponse, &resp)
+			}
+		})
+	}
+}
+
 func TestCSINode_DetachVolume(t *testing.T) {
 	t.Parallel()
 
@@ -374,14 +649,14 @@ func TestCSINode_DetachVolume(t *testing.T) {
 				AccessMode:     nstructs.CSIVolumeAccessModeMultiNodeReader,
 				ReadOnly:       true,
 			},
-			ExpectedErr: errors.New("plugin some-garbage for type csi-node not found"),
+			ExpectedErr: errors.New("CSI.NodeDetachVolume: plugin some-garbage for type csi-node not found"),
 		},
 		{
 			Name: "validates volumeid is not empty",
 			Request: &structs.ClientCSINodeDetachVolumeRequest{
 				PluginID: fakeNodePlugin.Name,
 			},
-			ExpectedErr: errors.New("VolumeID is required"),
+			ExpectedErr: errors.New("CSI.NodeDetachVolume: VolumeID is required"),
 		},
 		{
 			Name: "validates nodeid is not empty",
@@ -389,7 +664,7 @@ func TestCSINode_DetachVolume(t *testing.T) {
 				PluginID: fakeNodePlugin.Name,
 				VolumeID: "1234-4321-1234-4321",
 			},
-			ExpectedErr: errors.New("AllocID is required"),
+			ExpectedErr: errors.New("CSI.NodeDetachVolume: AllocID is required"),
 		},
 		{
 			Name: "returns transitive errors",
@@ -402,7 +677,7 @@ func TestCSINode_DetachVolume(t *testing.T) {
 				AllocID:  "4321-1234-4321-1234",
 			},
 			// we don't have a csimanager in this context
-			ExpectedErr: errors.New("plugin test-plugin for type csi-node not found"),
+			ExpectedErr: errors.New("CSI.NodeDetachVolume: plugin test-plugin for type csi-node not found"),
 		},
 	}
 

--- a/client/pluginmanager/csimanager/fingerprint.go
+++ b/client/pluginmanager/csimanager/fingerprint.go
@@ -122,10 +122,18 @@ func (p *pluginFingerprinter) buildBasicFingerprint(ctx context.Context) (*struc
 }
 
 func applyCapabilitySetToControllerInfo(cs *csi.ControllerCapabilitySet, info *structs.CSIControllerInfo) {
-	info.SupportsReadOnlyAttach = cs.HasPublishReadonly
+	info.SupportsCreateDelete = cs.HasCreateDeleteVolume
 	info.SupportsAttachDetach = cs.HasPublishUnpublishVolume
 	info.SupportsListVolumes = cs.HasListVolumes
+	info.SupportsGetCapacity = cs.HasGetCapacity
+	info.SupportsCreateDeleteSnapshot = cs.HasCreateDeleteSnapshot
+	info.SupportsListSnapshots = cs.HasListSnapshots
+	info.SupportsClone = cs.HasCloneVolume
+	info.SupportsReadOnlyAttach = cs.HasPublishReadonly
+	info.SupportsExpand = cs.HasExpandVolume
 	info.SupportsListVolumesAttachedNodes = cs.HasListVolumesPublishedNodes
+	info.SupportsCondition = cs.HasVolumeCondition
+	info.SupportsGet = cs.HasGetVolume
 }
 
 func (p *pluginFingerprinter) buildControllerFingerprint(ctx context.Context, base *structs.CSIInfo) (*structs.CSIInfo, error) {

--- a/client/pluginmanager/csimanager/volume_test.go
+++ b/client/pluginmanager/csimanager/volume_test.go
@@ -152,7 +152,7 @@ func TestVolumeManager_stageVolume(t *testing.T) {
 				AttachmentMode: "nonsense",
 			},
 			UsageOptions: &UsageOptions{},
-			ExpectedErr:  errors.New("Unknown volume attachment mode: nonsense"),
+			ExpectedErr:  errors.New("unknown volume attachment mode: nonsense"),
 		},
 		{
 			Name: "Returns an error when an invalid AccessMode is provided",
@@ -162,7 +162,7 @@ func TestVolumeManager_stageVolume(t *testing.T) {
 				AccessMode:     "nonsense",
 			},
 			UsageOptions: &UsageOptions{},
-			ExpectedErr:  errors.New("Unknown volume access mode: nonsense"),
+			ExpectedErr:  errors.New("unknown volume access mode: nonsense"),
 		},
 		{
 			Name: "Returns an error when the plugin returns an error",
@@ -490,14 +490,14 @@ func TestVolumeManager_MountVolumeEvents(t *testing.T) {
 	pubCtx := map[string]string{}
 
 	_, err := manager.MountVolume(ctx, vol, alloc, usage, pubCtx)
-	require.Error(t, err, "Unknown volume attachment mode: ")
+	require.Error(t, err, "unknown volume attachment mode: ")
 	require.Equal(t, 1, len(events))
 	e := events[0]
 	require.Equal(t, "Mount volume", e.Message)
 	require.Equal(t, "Storage", e.Subsystem)
 	require.Equal(t, "vol", e.Details["volume_id"])
 	require.Equal(t, "false", e.Details["success"])
-	require.Equal(t, "Unknown volume attachment mode: ", e.Details["error"])
+	require.Equal(t, "unknown volume attachment mode: ", e.Details["error"])
 	events = events[1:]
 
 	vol.AttachmentMode = structs.CSIVolumeAttachmentModeFilesystem

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -245,19 +245,24 @@ func (c *Client) streamingRpcConn(server *servers.Server, method string) (net.Co
 }
 
 // setupClientRpc is used to setup the Client's RPC endpoints
-func (c *Client) setupClientRpc() {
-	// Initialize the RPC handlers
-	c.endpoints.ClientStats = &ClientStats{c}
-	c.endpoints.CSI = &CSI{c}
-	c.endpoints.FileSystem = NewFileSystemEndpoint(c)
-	c.endpoints.Allocations = NewAllocationsEndpoint(c)
-	c.endpoints.Agent = NewAgentEndpoint(c)
-
+func (c *Client) setupClientRpc(rpcs map[string]interface{}) {
 	// Create the RPC Server
 	c.rpcServer = rpc.NewServer()
 
-	// Register the endpoints with the RPC server
-	c.setupClientRpcServer(c.rpcServer)
+	// Initialize the RPC handlers
+	if rpcs != nil {
+		// override RPCs
+		for name, rpc := range rpcs {
+			c.rpcServer.RegisterName(name, rpc)
+		}
+	} else {
+		c.endpoints.ClientStats = &ClientStats{c}
+		c.endpoints.CSI = &CSI{c}
+		c.endpoints.FileSystem = NewFileSystemEndpoint(c)
+		c.endpoints.Allocations = NewAllocationsEndpoint(c)
+		c.endpoints.Agent = NewAgentEndpoint(c)
+		c.setupClientRpcServer(c.rpcServer)
+	}
 
 	go c.rpcConnListener()
 }

--- a/client/structs/csi.go
+++ b/client/structs/csi.go
@@ -263,6 +263,8 @@ type ClientCSIControllerDeleteVolumeResponse struct{}
 // a Nomad client to tell a CSI controller plugin on that client to perform
 // ListVolumes
 type ClientCSIControllerListVolumesRequest struct {
+	// these pagination fields match the pagination fields of the plugins and
+	// not Nomad's own fields, for clarity when mapping between the two RPCs
 	MaxEntries    int32
 	StartingToken string
 

--- a/client/testing.go
+++ b/client/testing.go
@@ -2,14 +2,18 @@ package client
 
 import (
 	"fmt"
+	"net"
+	"net/rpc"
 	"time"
 
 	"github.com/hashicorp/nomad/client/config"
 	consulapi "github.com/hashicorp/nomad/client/consul"
 	"github.com/hashicorp/nomad/client/fingerprint"
+	"github.com/hashicorp/nomad/client/servers"
 	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/pluginutils/catalog"
 	"github.com/hashicorp/nomad/helper/pluginutils/singleton"
+	"github.com/hashicorp/nomad/helper/pool"
 	"github.com/hashicorp/nomad/helper/testlog"
 	testing "github.com/mitchellh/go-testing-interface"
 )
@@ -21,6 +25,10 @@ import (
 // and removed in the returned cleanup function. If they are overridden in the
 // callback then the caller still must run the returned cleanup func.
 func TestClient(t testing.T, cb func(c *config.Config)) (*Client, func() error) {
+	return TestClientWithRPCs(t, cb, nil)
+}
+
+func TestClientWithRPCs(t testing.T, cb func(c *config.Config), rpcs map[string]interface{}) (*Client, func() error) {
 	conf, cleanup := config.TestClientConfig(t)
 
 	// Tighten the fingerprinter timeouts (must be done in client package
@@ -46,7 +54,7 @@ func TestClient(t testing.T, cb func(c *config.Config)) (*Client, func() error) 
 	}
 	mockCatalog := agentconsul.NewMockCatalog(logger)
 	mockService := consulapi.NewMockConsulServiceClient(t, logger)
-	client, err := NewClient(conf, mockCatalog, nil, mockService)
+	client, err := NewClient(conf, mockCatalog, nil, mockService, rpcs)
 	if err != nil {
 		cleanup()
 		t.Fatalf("err: %v", err)
@@ -74,4 +82,52 @@ func TestClient(t testing.T, cb func(c *config.Config)) (*Client, func() error) 
 			return fmt.Errorf("timed out while shutting down client")
 		}
 	}
+}
+
+// TestRPCOnlyClient is a client that only pings to establish a connection
+// with the server and then returns mock RPC responses for those interfaces
+// passed in the `rpcs` parameter. Useful for testing client RPCs from the
+// server. Returns the Client, a shutdown function, and any error.
+func TestRPCOnlyClient(t testing.T, srvAddr net.Addr, rpcs map[string]interface{}) (*Client, func() error, error) {
+	var err error
+	conf, cleanup := config.TestClientConfig(t)
+
+	client := &Client{config: conf, logger: testlog.HCLogger(t)}
+	client.servers = servers.New(client.logger, client.shutdownCh, client)
+	client.configCopy = client.config.Copy()
+
+	client.rpcServer = rpc.NewServer()
+	for name, rpc := range rpcs {
+		client.rpcServer.RegisterName(name, rpc)
+	}
+
+	client.connPool = pool.NewPool(testlog.HCLogger(t), 10*time.Second, 10, nil)
+
+	cancelFunc := func() error {
+		ch := make(chan error)
+
+		go func() {
+			defer close(ch)
+			client.connPool.Shutdown()
+			client.shutdownGroup.Wait()
+			cleanup()
+		}()
+
+		select {
+		case <-ch:
+			return nil
+		case <-time.After(1 * time.Minute):
+			return fmt.Errorf("timed out while shutting down client")
+		}
+	}
+
+	go client.rpcConnListener()
+
+	_, err = client.SetServers([]string{srvAddr.String()})
+	if err != nil {
+		return nil, cancelFunc, fmt.Errorf("could not set servers: %v", err)
+	}
+	client.shutdownGroup.Go(client.registerAndHeartbeat)
+
+	return client, cancelFunc, nil
 }

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -861,7 +861,8 @@ func (a *Agent) setupClient() error {
 		conf.StateDBFactory = state.GetStateDBFactory(conf.DevMode)
 	}
 
-	nomadClient, err := client.NewClient(conf, a.consulCatalog, a.consulProxies, a.consulService)
+	nomadClient, err := client.NewClient(
+		conf, a.consulCatalog, a.consulProxies, a.consulService, nil)
 	if err != nil {
 		return fmt.Errorf("client setup failed: %v", err)
 	}

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -692,7 +692,23 @@ func (s *HTTPServer) parse(resp http.ResponseWriter, req *http.Request, r *strin
 	parseConsistency(req, b)
 	parsePrefix(req, b)
 	parseNamespace(req, &b.Namespace)
+	parsePagination(req, b)
 	return parseWait(resp, req, b)
+}
+
+// parsePagination parses the pagination fields for QueryOptions
+func parsePagination(req *http.Request, b *structs.QueryOptions) {
+	query := req.URL.Query()
+	rawPerPage := query.Get("per_page")
+	if rawPerPage != "" {
+		perPage, err := strconv.Atoi(rawPerPage)
+		if err == nil {
+			b.PerPage = int32(perPage)
+		}
+	}
+
+	nextToken := query.Get("next_token")
+	b.NextToken = nextToken
 }
 
 // parseWriteRequest is a convenience method for endpoints that need to parse a

--- a/command/commands.go
+++ b/command/commands.go
@@ -821,6 +821,16 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"volume create": func() (cli.Command, error) {
+			return &VolumeCreateCommand{
+				Meta: meta,
+			}, nil
+		},
+		"volume delete": func() (cli.Command, error) {
+			return &VolumeDeleteCommand{
+				Meta: meta,
+			}, nil
+		},
 	}
 
 	deprecated := map[string]cli.CommandFactory{

--- a/command/volume.go
+++ b/command/volume.go
@@ -32,6 +32,14 @@ Usage: nomad volume <subcommand> [options]
 
       $ nomad volume detach <vol id> <node id>
 
+  Create an external volume and register it:
+
+      $ nomad volume create <input>
+
+  Delete an external volume and deregister it:
+
+      $ nomad volume delete <external id>
+
   Please see the individual subcommand help for detailed usage information.
 `
 	return strings.TrimSpace(helpText)

--- a/command/volume_create.go
+++ b/command/volume_create.go
@@ -1,0 +1,105 @@
+package command
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/posener/complete"
+)
+
+type VolumeCreateCommand struct {
+	Meta
+}
+
+func (c *VolumeCreateCommand) Help() string {
+	helpText := `
+Usage: nomad volume create [options] <input>
+
+  Creates a volume in an external storage provider and registers it in Nomad.
+
+  If the supplied path is "-" the volume file is read from stdin. Otherwise, it
+  is read from the file at the supplied path.
+
+  When ACLs are enabled, this command requires a token with the
+  'csi-write-volume' capability for the volume's namespace.
+
+General Options:
+
+  ` + generalOptionsUsage(usageOptsDefault)
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *VolumeCreateCommand) AutocompleteFlags() complete.Flags {
+	return c.Meta.AutocompleteFlags(FlagSetClient)
+}
+
+func (c *VolumeCreateCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFiles("*")
+}
+
+func (c *VolumeCreateCommand) Synopsis() string {
+	return "Create an external volume"
+}
+
+func (c *VolumeCreateCommand) Name() string { return "volume create" }
+
+func (c *VolumeCreateCommand) Run(args []string) int {
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error parsing arguments %s", err))
+		return 1
+	}
+
+	// Check that we get exactly one argument
+	args = flags.Args()
+	if l := len(args); l != 1 {
+		c.Ui.Error("This command takes one argument: <input>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+
+	// Read the file contents
+	file := args[0]
+	var rawVolume []byte
+	var err error
+	if file == "-" {
+		rawVolume, err = ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Failed to read stdin: %v", err))
+			return 1
+		}
+	} else {
+		rawVolume, err = ioutil.ReadFile(file)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Failed to read file: %v", err))
+			return 1
+		}
+	}
+
+	ast, volType, err := parseVolumeType(string(rawVolume))
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error parsing the volume type: %s", err))
+		return 1
+	}
+
+	// Get the HTTP client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	switch strings.ToLower(volType) {
+	case "csi":
+		code := c.csiCreate(client, ast)
+		return code
+	default:
+		c.Ui.Error(fmt.Sprintf("Error unknown volume type: %s", volType))
+		return 1
+	}
+}

--- a/command/volume_create_csi.go
+++ b/command/volume_create_csi.go
@@ -1,0 +1,29 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/hashicorp/nomad/api"
+)
+
+func (c *VolumeCreateCommand) csiCreate(client *api.Client, ast *ast.File) int {
+	vol, err := csiDecodeVolume(ast)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error decoding the volume definition: %s", err))
+		return 1
+	}
+
+	vols, _, err := client.CSIVolumes().Create(vol, nil)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error creating volume: %s", err))
+		return 1
+	}
+	for _, vol := range vols {
+		// note: the command only ever returns 1 volume from the API
+		c.Ui.Output(fmt.Sprintf(
+			"Created external volume %s with ID %s", vol.ExternalID, vol.ID))
+	}
+
+	return 0
+}

--- a/command/volume_delete.go
+++ b/command/volume_delete.go
@@ -1,0 +1,102 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
+)
+
+type VolumeDeleteCommand struct {
+	Meta
+}
+
+func (c *VolumeDeleteCommand) Help() string {
+	helpText := `
+Usage: nomad volume delete [options] <vol id>
+
+  Delete a volume from an external storage provider. The volume must still be
+  registered with Nomad in order to be deleted. Deleting will fail if the
+  volume is still in use by an allocation or in the process of being
+  unpublished. If the volume no longer exists, this command will silently
+  return without an error.
+
+  When ACLs are enabled, this command requires a token with the
+  'csi-write-volume' and 'csi-read-volume' capabilities for the volume's
+  namespace.
+
+General Options:
+
+  ` + generalOptionsUsage(usageOptsDefault) + `
+
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *VolumeDeleteCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{})
+}
+
+func (c *VolumeDeleteCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFunc(func(a complete.Args) []string {
+		client, err := c.Meta.Client()
+		if err != nil {
+			return nil
+		}
+
+		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Volumes, nil)
+		if err != nil {
+			return []string{}
+		}
+		matches := resp.Matches[contexts.Volumes]
+
+		resp, _, err = client.Search().PrefixSearch(a.Last, contexts.Nodes, nil)
+		if err != nil {
+			return []string{}
+		}
+		matches = append(matches, resp.Matches[contexts.Nodes]...)
+		return matches
+	})
+}
+
+func (c *VolumeDeleteCommand) Synopsis() string {
+	return "Delete a volume"
+}
+
+func (c *VolumeDeleteCommand) Name() string { return "volume delete" }
+
+func (c *VolumeDeleteCommand) Run(args []string) int {
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error parsing arguments %s", err))
+		return 1
+	}
+
+	// Check that we get exactly two arguments
+	args = flags.Args()
+	if l := len(args); l != 1 {
+		c.Ui.Error("This command takes one argument: <vol id>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+	volID := args[0]
+
+	// Get the HTTP client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	err = client.CSIVolumes().Delete(volID, nil)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error deleting volume: %s", err))
+		return 1
+	}
+
+	return 0
+}

--- a/command/volume_init.go
+++ b/command/volume_init.go
@@ -105,23 +105,59 @@ func (c *VolumeInitCommand) Run(args []string) int {
 }
 
 var defaultHclVolumeSpec = strings.TrimSpace(`
-id              = "ebs_prod_db1"
-name            = "database"
-type            = "csi"
-external_id     = "vol-23452345"
-access_mode     = "single-node-writer"
-attachment_mode = "file-system"
+id        = "ebs_prod_db1"
+name      = "database"
+type      = "csi"
+plugin_id = "plugin_id"
 
+# For 'nomad volume register', provide the external ID from the storage
+# provider. This field should be omitted when creating a volume with
+# 'nomad volume create'
+external_id = "vol-23452345"
+
+# For 'nomad volume create', specify a snapshot ID or volume to clone. You can
+# specify only one of these two fields.
+snapshot_id = "snap-12345"
+# clone_id    = "vol-abcdef"
+
+# Optional: for 'nomad volume create', specify a maximum and minimum capacity.
+# Registering an existing volume will record but ignore these fields.
+capacity_min = "10GiB"
+capacity_max = "20G"
+
+# Optional: for 'nomad volume create', specify one or more capabilities to
+# validate. Registering an existing volume will record but ignore these fields.
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}
+
+capability {
+  access_mode     = "single-node-reader"
+  attachment_mode = "block-device"
+}
+
+# Optional: for 'nomad volume create', specify mount options to
+# validate. Registering an existing volume will record but ignore these
+# fields.
 mount_options {
   fs_type     = "ext4"
   mount_flags = ["ro"]
 }
+
+# Optional: provide any secrets specified by the plugin.
 secrets {
   example_secret = "xyzzy"
 }
+
+# Optional: provide a map of keys to string values expected by the plugin.
 parameters {
   skuname = "Premium_LRS"
 }
+
+# Optional: for 'nomad volume register', provide a map of keys to string
+# values expected by the plugin. This field will populated automatically by
+# 'nomad volume create'.
 context {
   endpoint = "http://192.168.1.101:9425"
 }
@@ -132,23 +168,43 @@ var defaultJsonVolumeSpec = strings.TrimSpace(`
   "id": "ebs_prod_db1",
   "name": "database",
   "type": "csi",
+  "plugin_id": "plugin_id",
   "external_id": "vol-23452345",
-  "access_mode": "single-node-writer",
-  "attachment_mode": "file-system",
-  "mount_options": {
-    "fs_type": "ext4",
-    "mount_flags": [
-      "ro"
-    ]
-  },
-  "secrets": {
-    "example_secret": "xyzzy"
-  },
-  "parameters": {
-    "skuname": "Premium_LRS"
-  },
-  "context": {
-    "endpoint": "http://192.168.1.101:9425"
-  }
+  "snapshot_id": "snap-12345",
+  "capacity_min": "10GiB",
+  "capacity_max": "20G",
+  "capability": [
+    {
+      "access_mode": "single-node-writer",
+      "attachment_mode": "file-system"
+    },
+    {
+      "access_mode": "single-node-reader",
+      "attachment_mode": "block-device"
+    }
+  ],
+  "context": [
+    {
+      "endpoint": "http://192.168.1.101:9425"
+    }
+  ],
+  "mount_options": [
+    {
+      "fs_type": "ext4",
+      "mount_flags": [
+        "ro"
+      ]
+    }
+  ],
+  "parameters": [
+    {
+      "skuname": "Premium_LRS"
+    }
+  ],
+  "secrets": [
+    {
+      "example_secret": "xyzzy"
+    }
+  ]
 }
 `)

--- a/command/volume_register_csi.go
+++ b/command/volume_register_csi.go
@@ -2,11 +2,14 @@ package command
 
 import (
 	"fmt"
+	"strings"
 
+	humanize "github.com/dustin/go-humanize"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/mitchellh/mapstructure"
 )
 
 func (c *VolumeRegisterCommand) csiRegister(client *api.Client, ast *ast.File) int {
@@ -24,21 +27,111 @@ func (c *VolumeRegisterCommand) csiRegister(client *api.Client, ast *ast.File) i
 	return 0
 }
 
-// parseVolume is used to parse the quota specification from HCL
 func csiDecodeVolume(input *ast.File) (*api.CSIVolume, error) {
-	output := &api.CSIVolume{}
-	err := hcl.DecodeObject(output, input)
+	var err error
+	vol := &api.CSIVolume{}
+
+	list, ok := input.Node.(*ast.ObjectList)
+	if !ok {
+		return nil, fmt.Errorf("error parsing: root should be an object")
+	}
+
+	// Decode the full thing into a map[string]interface for ease
+	var m map[string]interface{}
+	err = hcl.DecodeObject(&m, list)
 	if err != nil {
 		return nil, err
 	}
 
-	// api.CSIVolume doesn't have the type field, it's used only for dispatch in
-	// parseVolumeType
-	helper.RemoveEqualFold(&output.ExtraKeysHCL, "type")
-	err = helper.UnusedKeys(output)
+	// Need to manually parse these fields
+	delete(m, "capability")
+	delete(m, "mount_options")
+	delete(m, "capacity_max")
+	delete(m, "capacity_min")
+	delete(m, "type")
+
+	// Decode the rest
+	err = mapstructure.WeakDecode(m, vol)
 	if err != nil {
 		return nil, err
 	}
 
-	return output, nil
+	capacityMin, err := parseCapacityBytes(list.Filter("capacity_min"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid capacity_min: %v", err)
+	}
+	vol.RequestedCapacityMin = capacityMin
+	capacityMax, err := parseCapacityBytes(list.Filter("capacity_max"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid capacity_max: %v", err)
+	}
+	vol.RequestedCapacityMax = capacityMax
+
+	capObj := list.Filter("capability")
+	if len(capObj.Items) > 0 {
+
+		for _, o := range capObj.Elem().Items {
+			valid := []string{"access_mode", "attachment_mode"}
+			if err := helper.CheckHCLKeys(o.Val, valid); err != nil {
+				return nil, err
+			}
+
+			ot, ok := o.Val.(*ast.ObjectType)
+			if !ok {
+				break
+			}
+
+			var m map[string]interface{}
+			if err := hcl.DecodeObject(&m, ot.List); err != nil {
+				return nil, err
+			}
+			var cap *api.CSIVolumeCapability
+			if err := mapstructure.WeakDecode(&m, &cap); err != nil {
+				return nil, err
+			}
+
+			vol.RequestedCapabilities = append(vol.RequestedCapabilities, cap)
+		}
+	}
+
+	mObj := list.Filter("mount_options")
+	if len(mObj.Items) > 0 {
+
+		for _, o := range mObj.Elem().Items {
+			valid := []string{"fs_type", "mount_flags"}
+			if err := helper.CheckHCLKeys(o.Val, valid); err != nil {
+				return nil, err
+			}
+
+			ot, ok := o.Val.(*ast.ObjectType)
+			if !ok {
+				break
+			}
+			var opts *api.CSIMountOptions
+			if err := hcl.DecodeObject(&opts, ot.List); err != nil {
+				return nil, err
+			}
+			vol.MountOptions = opts
+			break
+		}
+	}
+
+	return vol, nil
+}
+
+func parseCapacityBytes(cap *ast.ObjectList) (int64, error) {
+	if len(cap.Items) > 0 {
+		for _, o := range cap.Elem().Items {
+			lit, ok := o.Val.(*ast.LiteralType)
+			if !ok {
+				break
+			}
+			b, err := humanize.ParseBytes(strings.Trim(lit.Token.Text, "\""))
+			if err != nil {
+				return 0, fmt.Errorf("could not parse value as bytes: %v", err)
+			}
+			return int64(b), err
+		}
+	}
+	return 0, fmt.Errorf("could not parse value as bytes")
 }

--- a/command/volume_register_test.go
+++ b/command/volume_register_test.go
@@ -42,60 +42,90 @@ rando = "bar"
 	}
 }
 
-func TestCSIVolumeParse(t *testing.T) {
+func TestCSIVolumeDecode(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		hcl string
-		q   *api.CSIVolume
-		err string
+		name     string
+		hcl      string
+		expected *api.CSIVolume
+		err      string
 	}{{
+		name: "typical volume",
 		hcl: `
-id = "foo"
-type = "csi"
-namespace = "n"
-access_mode = "single-node-writer"
-attachment_mode = "file-system"
-plugin_id = "p"
+id              = "testvolume"
+name            = "test"
+type            = "csi"
+plugin_id       = "myplugin"
+
+capacity_min = "10 MiB"
+capacity_max = "1G"
+snapshot_id  = "snap-12345"
+
+mount_options {
+  fs_type     = "ext4"
+  mount_flags = ["ro"]
+}
+
 secrets {
-  mysecret = "secretvalue"
+  password = "xyzzy"
+}
+
+parameters {
+  skuname = "Premium_LRS"
+}
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}
+
+capability {
+  access_mode     = "single-node-reader-only"
+  attachment_mode = "block-device"
 }
 `,
-		q: &api.CSIVolume{
-			ID:             "foo",
-			Namespace:      "n",
-			AccessMode:     "single-node-writer",
-			AttachmentMode: "file-system",
-			PluginID:       "p",
-			Secrets:        api.CSISecrets{"mysecret": "secretvalue"},
+		expected: &api.CSIVolume{
+			ID:                   "testvolume",
+			Name:                 "test",
+			PluginID:             "myplugin",
+			SnapshotID:           "snap-12345",
+			RequestedCapacityMin: 10485760,
+			RequestedCapacityMax: 1000000000,
+			RequestedCapabilities: []*api.CSIVolumeCapability{
+				{
+					AccessMode:     api.CSIVolumeAccessModeSingleNodeWriter,
+					AttachmentMode: api.CSIVolumeAttachmentModeFilesystem,
+				},
+				{
+					AccessMode:     api.CSIVolumeAccessModeSingleNodeReader,
+					AttachmentMode: api.CSIVolumeAttachmentModeBlockDevice,
+				},
+			},
+			MountOptions: &api.CSIMountOptions{
+				FSType:     "ext4",
+				MountFlags: []string{"ro"},
+			},
+			Parameters: map[string]string{"skuname": "Premium_LRS"},
+			Secrets:    map[string]string{"password": "xyzzy"},
 		},
 		err: "",
-	}, {
-		hcl: `
-{"id": "foo", "namespace": "n", "type": "csi", "access_mode": "single-node-writer", "attachment_mode": "file-system",
-"plugin_id": "p"}
-`,
-		q: &api.CSIVolume{
-			ID:             "foo",
-			Namespace:      "n",
-			AccessMode:     "single-node-writer",
-			AttachmentMode: "file-system",
-			PluginID:       "p",
-		},
-		err: "",
-	}}
+	},
+	}
 
 	for _, c := range cases {
-		t.Run(c.hcl, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			ast, err := hcl.ParseString(c.hcl)
 			require.NoError(t, err)
 			vol, err := csiDecodeVolume(ast)
-			require.Equal(t, c.q, vol)
 			if c.err == "" {
 				require.NoError(t, err)
 			} else {
 				require.Contains(t, err.Error(), c.err)
 			}
+			require.Equal(t, c.expected, vol)
+
 		})
+
 	}
 }

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -878,6 +878,7 @@ func (v *CSIVolume) Create(args *structs.CSIVolumeCreateRequest, reply *structs.
 		return err
 	}
 
+	reply.Volumes = regArgs.Volumes
 	reply.Index = index
 	v.srv.setQueryMeta(&reply.QueryMeta)
 	return nil
@@ -1019,8 +1020,8 @@ func (v *CSIVolume) ListExternal(args *structs.CSIVolumeExternalListRequest, rep
 
 	method := "ClientCSI.ControllerListVolumes"
 	cReq := &cstructs.ClientCSIControllerListVolumesRequest{
-		MaxEntries:    args.MaxEntries,
-		StartingToken: args.StartingToken,
+		MaxEntries:    args.PerPage,
+		StartingToken: args.NextToken,
 	}
 	cReq.PluginID = plugin.ID
 	cResp := &cstructs.ClientCSIControllerListVolumesResponse{}
@@ -1029,8 +1030,8 @@ func (v *CSIVolume) ListExternal(args *structs.CSIVolumeExternalListRequest, rep
 	if err != nil {
 		return err
 	}
-	if args.MaxEntries > 0 {
-		reply.Volumes = cResp.Entries[:args.MaxEntries]
+	if args.PerPage > 0 {
+		reply.Volumes = cResp.Entries[:args.PerPage]
 	} else {
 		reply.Volumes = cResp.Entries
 	}

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -708,6 +708,7 @@ func TestCSIVolumeEndpoint_Create(t *testing.T) {
 			Healthy:  true,
 			ControllerInfo: &structs.CSIControllerInfo{
 				SupportsAttachDetach: true,
+				SupportsCreateDelete: true,
 			},
 			RequiresControllerPlugin: true,
 		},

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -985,11 +985,11 @@ func TestCSIVolumeEndpoint_ListExternal(t *testing.T) {
 	// List external volumes; note that none of these exist in the state store
 
 	req := &structs.CSIVolumeExternalListRequest{
-		MaxEntries:    2,
-		StartingToken: "page1",
 		QueryOptions: structs.QueryOptions{
 			Region:    "global",
 			Namespace: structs.DefaultNamespace,
+			PerPage:   2,
+			NextToken: "page1",
 		},
 	}
 	resp := &structs.CSIVolumeExternalListResponse{}

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -162,11 +162,6 @@ func TestCSIVolumeEndpoint_Register(t *testing.T) {
 	}
 	resp1 := &structs.CSIVolumeRegisterResponse{}
 	err := msgpackrpc.CallWithCodec(codec, "CSIVolume.Register", req1, resp1)
-	require.Error(t, err, "expected validation error")
-
-	// Fix the registration so that it passes validation
-	vols[0].AttachmentMode = structs.CSIVolumeAttachmentModeFilesystem
-	err = msgpackrpc.CallWithCodec(codec, "CSIVolume.Register", req1, resp1)
 	require.NoError(t, err)
 	require.NotEqual(t, uint64(0), resp1.Index)
 

--- a/nomad/state/testing.go
+++ b/nomad/state/testing.go
@@ -81,6 +81,8 @@ func createTestCSIPlugin(s *StateStore, id string, requiresController bool) func
 				SupportsAttachDetach:             true,
 				SupportsListVolumes:              true,
 				SupportsListVolumesAttachedNodes: false,
+				SupportsCreateDeleteSnapshot:     true,
+				SupportsListSnapshots:            true,
 			},
 		},
 	}

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -590,22 +590,6 @@ func (v *CSIVolume) Validate() error {
 	if v.Namespace == "" {
 		errs = append(errs, "missing namespace")
 	}
-	if v.AccessMode == "" {
-		errs = append(errs, "missing access mode")
-	}
-	if v.AttachmentMode == "" {
-		errs = append(errs, "missing attachment mode")
-	}
-	if v.AttachmentMode == CSIVolumeAttachmentModeBlockDevice {
-		if v.MountOptions != nil {
-			if v.MountOptions.FSType != "" {
-				errs = append(errs, "mount options not allowed for block-device")
-			}
-			if v.MountOptions.MountFlags != nil && len(v.MountOptions.MountFlags) != 0 {
-				errs = append(errs, "mount options not allowed for block-device")
-			}
-		}
-	}
 	if v.SnapshotID != "" && v.CloneID != "" {
 		errs = append(errs, "only one of snapshot_id and clone_id is allowed")
 	}

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -740,11 +740,10 @@ type CSIVolumeListResponse struct {
 
 // CSIVolumeExternalListRequest is a request to a controller plugin to list
 // all the volumes known to the the storage provider. This request is
-// paginated by the plugin.
+// paginated by the plugin and accepts the QueryOptions.PerPage and
+// QueryOptions.NextToken fields
 type CSIVolumeExternalListRequest struct {
-	PluginID      string
-	MaxEntries    int32
-	StartingToken string
+	PluginID string
 	QueryOptions
 }
 

--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -112,23 +112,50 @@ func (n *CSINodeInfo) Copy() *CSINodeInfo {
 // CSIControllerInfo is the fingerprinted data from a CSI Plugin that is specific to
 // the Controller API.
 type CSIControllerInfo struct {
+
+	// SupportsCreateDelete indicates plugin support for CREATE_DELETE_VOLUME
+	SupportsCreateDelete bool
+
+	// SupportsPublishVolume is true when the controller implements the
+	// methods required to attach and detach volumes. If this is false Nomad
+	// should skip the controller attachment flow.
+	SupportsAttachDetach bool
+
+	// SupportsListVolumes is true when the controller implements the
+	// ListVolumes RPC. NOTE: This does not guarantee that attached nodes will
+	// be returned unless SupportsListVolumesAttachedNodes is also true.
+	SupportsListVolumes bool
+
+	// SupportsGetCapacity indicates plugin support for GET_CAPACITY
+	SupportsGetCapacity bool
+
+	// SupportsCreateDeleteSnapshot indicates plugin support for
+	// CREATE_DELETE_SNAPSHOT
+	SupportsCreateDeleteSnapshot bool
+
+	// SupportsListSnapshots indicates plugin support for LIST_SNAPSHOTS
+	SupportsListSnapshots bool
+
+	// SupportsClone indicates plugin support for CLONE_VOLUME
+	SupportsClone bool
+
 	// SupportsReadOnlyAttach is set to true when the controller returns the
 	// ATTACH_READONLY capability.
 	SupportsReadOnlyAttach bool
 
-	// SupportsPublishVolume is true when the controller implements the methods
-	// required to attach and detach volumes. If this is false Nomad should skip
-	// the controller attachment flow.
-	SupportsAttachDetach bool
+	// SupportsExpand indicates plugin support for EXPAND_VOLUME
+	SupportsExpand bool
 
-	// SupportsListVolumes is true when the controller implements the ListVolumes
-	// RPC. NOTE: This does not guaruntee that attached nodes will be returned
-	// unless SupportsListVolumesAttachedNodes is also true.
-	SupportsListVolumes bool
-
-	// SupportsListVolumesAttachedNodes indicates whether the plugin will return
-	// attached nodes data when making ListVolume RPCs
+	// SupportsListVolumesAttachedNodes indicates whether the plugin will
+	// return attached nodes data when making ListVolume RPCs (plugin support
+	// for LIST_VOLUMES_PUBLISHED_NODES)
 	SupportsListVolumesAttachedNodes bool
+
+	// SupportsCondition indicates plugin support for VOLUME_CONDITION
+	SupportsCondition bool
+
+	// SupportsGet indicates plugin support for GET_VOLUME
+	SupportsGet bool
 }
 
 func (c *CSIControllerInfo) Copy() *CSIControllerInfo {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -293,6 +293,14 @@ type QueryOptions struct {
 	// AuthToken is secret portion of the ACL token used for the request
 	AuthToken string
 
+	// PerPage is the number of entries to be returned in queries that support
+	// paginated lists.
+	PerPage int32
+
+	// NextToken is the token used indicate where to start paging for queries
+	// that support paginated lists.
+	NextToken string
+
 	InternalRpcInfo
 }
 

--- a/plugins/csi/client_test.go
+++ b/plugins/csi/client_test.go
@@ -222,7 +222,7 @@ func TestClient_RPC_ControllerGetCapabilities(t *testing.T) {
 					{
 						Type: &csipbv1.ControllerServiceCapability_Rpc{
 							Rpc: &csipbv1.ControllerServiceCapability_RPC{
-								Type: csipbv1.ControllerServiceCapability_RPC_GET_CAPACITY,
+								Type: csipbv1.ControllerServiceCapability_RPC_UNKNOWN,
 							},
 						},
 					},

--- a/plugins/csi/fake/client.go
+++ b/plugins/csi/fake/client.go
@@ -50,6 +50,17 @@ type Client struct {
 	NextControllerUnpublishVolumeErr      error
 	ControllerUnpublishVolumeCallCount    int64
 
+	NextControllerCreateVolumeResponse *csi.ControllerCreateVolumeResponse
+	NextControllerCreateVolumeErr      error
+	ControllerCreateVolumeCallCount    int64
+
+	NextControllerDeleteVolumeErr   error
+	ControllerDeleteVolumeCallCount int64
+
+	NextControllerListVolumesResponse *csi.ControllerListVolumesResponse
+	NextControllerListVolumesErr      error
+	ControllerListVolumesCallCount    int64
+
 	NextControllerValidateVolumeErr   error
 	ControllerValidateVolumeCallCount int64
 
@@ -166,6 +177,27 @@ func (c *Client) ControllerValidateCapabilities(ctx context.Context, req *csi.Co
 	c.ControllerValidateVolumeCallCount++
 
 	return c.NextControllerValidateVolumeErr
+}
+
+func (c *Client) ControllerCreateVolume(ctx context.Context, in *csi.ControllerCreateVolumeRequest, opts ...grpc.CallOption) (*csi.ControllerCreateVolumeResponse, error) {
+	c.Mu.Lock()
+	defer c.Mu.Unlock()
+	c.ControllerCreateVolumeCallCount++
+	return c.NextControllerCreateVolumeResponse, c.NextControllerCreateVolumeErr
+}
+
+func (c *Client) ControllerDeleteVolume(ctx context.Context, req *csi.ControllerDeleteVolumeRequest, opts ...grpc.CallOption) error {
+	c.Mu.Lock()
+	defer c.Mu.Unlock()
+	c.ControllerDeleteVolumeCallCount++
+	return c.NextControllerDeleteVolumeErr
+}
+
+func (c *Client) ControllerListVolumes(ctx context.Context, req *csi.ControllerListVolumesRequest, opts ...grpc.CallOption) (*csi.ControllerListVolumesResponse, error) {
+	c.Mu.Lock()
+	defer c.Mu.Unlock()
+	c.ControllerListVolumesCallCount++
+	return c.NextControllerListVolumesResponse, c.NextControllerListVolumesErr
 }
 
 func (c *Client) NodeGetCapabilities(ctx context.Context) (*csi.NodeCapabilitySet, error) {

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -280,10 +280,18 @@ func NewPluginCapabilitySet(capabilities *csipbv1.GetPluginCapabilitiesResponse)
 }
 
 type ControllerCapabilitySet struct {
+	HasCreateDeleteVolume        bool
 	HasPublishUnpublishVolume    bool
-	HasPublishReadonly           bool
 	HasListVolumes               bool
+	HasGetCapacity               bool
+	HasCreateDeleteSnapshot      bool
+	HasListSnapshots             bool
+	HasCloneVolume               bool
+	HasPublishReadonly           bool
+	HasExpandVolume              bool
 	HasListVolumesPublishedNodes bool
+	HasVolumeCondition           bool
+	HasGetVolume                 bool
 }
 
 func NewControllerCapabilitySet(resp *csipbv1.ControllerGetCapabilitiesResponse) *ControllerCapabilitySet {
@@ -293,14 +301,30 @@ func NewControllerCapabilitySet(resp *csipbv1.ControllerGetCapabilitiesResponse)
 	for _, pcap := range pluginCapabilities {
 		if c := pcap.GetRpc(); c != nil {
 			switch c.Type {
+			case csipbv1.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME:
+				cs.HasCreateDeleteVolume = true
 			case csipbv1.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME:
 				cs.HasPublishUnpublishVolume = true
-			case csipbv1.ControllerServiceCapability_RPC_PUBLISH_READONLY:
-				cs.HasPublishReadonly = true
 			case csipbv1.ControllerServiceCapability_RPC_LIST_VOLUMES:
 				cs.HasListVolumes = true
+			case csipbv1.ControllerServiceCapability_RPC_GET_CAPACITY:
+				cs.HasGetCapacity = true
+			case csipbv1.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT:
+				cs.HasCreateDeleteSnapshot = true
+			case csipbv1.ControllerServiceCapability_RPC_LIST_SNAPSHOTS:
+				cs.HasListSnapshots = true
+			case csipbv1.ControllerServiceCapability_RPC_CLONE_VOLUME:
+				cs.HasCloneVolume = true
+			case csipbv1.ControllerServiceCapability_RPC_PUBLISH_READONLY:
+				cs.HasPublishReadonly = true
+			case csipbv1.ControllerServiceCapability_RPC_EXPAND_VOLUME:
+				cs.HasExpandVolume = true
 			case csipbv1.ControllerServiceCapability_RPC_LIST_VOLUMES_PUBLISHED_NODES:
 				cs.HasListVolumesPublishedNodes = true
+			case csipbv1.ControllerServiceCapability_RPC_VOLUME_CONDITION:
+				cs.HasVolumeCondition = true
+			case csipbv1.ControllerServiceCapability_RPC_GET_VOLUME:
+				cs.HasGetVolume = true
 			default:
 				continue
 			}

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -45,6 +45,18 @@ type CSIPlugin interface {
 	// supports the requested capability.
 	ControllerValidateCapabilities(ctx context.Context, req *ControllerValidateVolumeRequest, opts ...grpc.CallOption) error
 
+	// ControllerCreateVolume is used to create a remote volume in the
+	// external storage provider
+	ControllerCreateVolume(ctx context.Context, req *ControllerCreateVolumeRequest, opts ...grpc.CallOption) (*ControllerCreateVolumeResponse, error)
+
+	// ControllerDeleteVolume is used to delete a remote volume in the
+	// external storage provider
+	ControllerDeleteVolume(ctx context.Context, req *ControllerDeleteVolumeRequest, opts ...grpc.CallOption) error
+
+	// ControllerListVolumes is used to list all volumes available in the
+	// external storage provider
+	ControllerListVolumes(ctx context.Context, req *ControllerListVolumesRequest, opts ...grpc.CallOption) (*ControllerListVolumesResponse, error)
+
 	// NodeGetCapabilities is used to return the available capabilities from the
 	// Node Service.
 	NodeGetCapabilities(ctx context.Context) (*NodeCapabilitySet, error)
@@ -392,6 +404,259 @@ func (r *ControllerUnpublishVolumeRequest) Validate() error {
 
 type ControllerUnpublishVolumeResponse struct{}
 
+type ControllerCreateVolumeRequest struct {
+	// note that Name is intentionally differentiated from both CSIVolume.ID
+	// and ExternalVolumeID. This name is only a recommendation for the
+	// storage provider, and many will discard this suggestion
+	Name                      string
+	CapacityRange             *CapacityRange
+	VolumeCapabilities        []*VolumeCapability
+	Parameters                map[string]string
+	Secrets                   structs.CSISecrets
+	ContentSource             *VolumeContentSource
+	AccessibilityRequirements *TopologyRequirement
+}
+
+func (r *ControllerCreateVolumeRequest) ToCSIRepresentation() *csipbv1.CreateVolumeRequest {
+	if r == nil {
+		return nil
+	}
+	caps := make([]*csipbv1.VolumeCapability, 0, len(r.VolumeCapabilities))
+	for _, cap := range r.VolumeCapabilities {
+		caps = append(caps, cap.ToCSIRepresentation())
+	}
+	req := &csipbv1.CreateVolumeRequest{
+		Name:                      r.Name,
+		CapacityRange:             r.CapacityRange.ToCSIRepresentation(),
+		VolumeCapabilities:        caps,
+		Parameters:                r.Parameters,
+		Secrets:                   r.Secrets,
+		VolumeContentSource:       r.ContentSource.ToCSIRepresentation(),
+		AccessibilityRequirements: r.AccessibilityRequirements.ToCSIRepresentation(),
+	}
+
+	return req
+}
+
+func (r *ControllerCreateVolumeRequest) Validate() error {
+	if r.Name == "" {
+		return errors.New("missing Name")
+	}
+	if r.VolumeCapabilities == nil {
+		return errors.New("missing VolumeCapabilities")
+	}
+	if r.CapacityRange != nil {
+		if r.CapacityRange.LimitBytes == 0 && r.CapacityRange.RequiredBytes == 0 {
+			return errors.New(
+				"one of LimitBytes or RequiredBytes must be set if CapacityRange is set")
+		}
+		if r.CapacityRange.LimitBytes < r.CapacityRange.RequiredBytes {
+			return errors.New("LimitBytes cannot be less than RequiredBytes")
+		}
+	}
+	if r.ContentSource != nil {
+		if r.ContentSource.CloneID != "" && r.ContentSource.SnapshotID != "" {
+			return errors.New(
+				"one of SnapshotID or CloneID must be set if ContentSource is set")
+		}
+	}
+	return nil
+}
+
+// VolumeContentSource is snapshot or volume that the plugin will use to
+// create the new volume. At most one of these fields can be set, but nil (and
+// not an empty struct) is expected by CSI plugins if neither field is set.
+type VolumeContentSource struct {
+	SnapshotID string
+	CloneID    string
+}
+
+func (vcr *VolumeContentSource) ToCSIRepresentation() *csipbv1.VolumeContentSource {
+	if vcr == nil {
+		return nil
+	}
+	if vcr.CloneID != "" {
+		return &csipbv1.VolumeContentSource{
+			Type: &csipbv1.VolumeContentSource_Volume{
+				Volume: &csipbv1.VolumeContentSource_VolumeSource{
+					VolumeId: vcr.CloneID,
+				},
+			},
+		}
+	} else if vcr.SnapshotID != "" {
+		return &csipbv1.VolumeContentSource{
+			Type: &csipbv1.VolumeContentSource_Snapshot{
+				Snapshot: &csipbv1.VolumeContentSource_SnapshotSource{
+					SnapshotId: vcr.SnapshotID,
+				},
+			},
+		}
+	}
+	// Nomad's RPCs will hand us an empty struct, not nil
+	return nil
+}
+
+func newVolumeContentSource(src *csipbv1.VolumeContentSource) *VolumeContentSource {
+	return &VolumeContentSource{
+		SnapshotID: src.GetSnapshot().GetSnapshotId(),
+		CloneID:    src.GetVolume().GetVolumeId(),
+	}
+}
+
+type TopologyRequirement struct {
+	Requisite []*Topology
+	Preferred []*Topology
+}
+
+func (tr *TopologyRequirement) ToCSIRepresentation() *csipbv1.TopologyRequirement {
+	if tr == nil {
+		return nil
+	}
+	result := &csipbv1.TopologyRequirement{
+		Requisite: []*csipbv1.Topology{},
+		Preferred: []*csipbv1.Topology{},
+	}
+	for _, topo := range tr.Requisite {
+		result.Requisite = append(result.Requisite,
+			&csipbv1.Topology{Segments: topo.Segments})
+	}
+	for _, topo := range tr.Preferred {
+		result.Preferred = append(result.Preferred,
+			&csipbv1.Topology{Segments: topo.Segments})
+	}
+	return result
+}
+
+func newTopologies(src []*csipbv1.Topology) []*Topology {
+	t := []*Topology{}
+	for _, topo := range src {
+		t = append(t, &Topology{Segments: topo.Segments})
+	}
+	return t
+}
+
+type ControllerCreateVolumeResponse struct {
+	Volume *Volume
+}
+
+func NewCreateVolumeResponse(resp *csipbv1.CreateVolumeResponse) *ControllerCreateVolumeResponse {
+	vol := resp.GetVolume()
+	return &ControllerCreateVolumeResponse{Volume: &Volume{
+		CapacityBytes:    vol.GetCapacityBytes(),
+		ExternalVolumeID: vol.GetVolumeId(),
+		VolumeContext:    vol.GetVolumeContext(),
+		ContentSource:    newVolumeContentSource(vol.GetContentSource()),
+	}}
+}
+
+type Volume struct {
+	CapacityBytes int64
+
+	// this is differentiated from VolumeID so as not to create confusion
+	// between the Nomad CSIVolume.ID and the storage provider's ID.
+	ExternalVolumeID   string
+	VolumeContext      map[string]string
+	ContentSource      *VolumeContentSource
+	AccessibleTopology []*Topology
+}
+
+type ControllerDeleteVolumeRequest struct {
+	ExternalVolumeID string
+	Secrets          structs.CSISecrets
+}
+
+func (r *ControllerDeleteVolumeRequest) ToCSIRepresentation() *csipbv1.DeleteVolumeRequest {
+	if r == nil {
+		return nil
+	}
+	return &csipbv1.DeleteVolumeRequest{
+		VolumeId: r.ExternalVolumeID,
+		Secrets:  r.Secrets,
+	}
+}
+
+func (r *ControllerDeleteVolumeRequest) Validate() error {
+	if r.ExternalVolumeID == "" {
+		return errors.New("missing ExternalVolumeID")
+	}
+	return nil
+}
+
+type ControllerListVolumesRequest struct {
+	MaxEntries    int32
+	StartingToken string
+}
+
+func (r *ControllerListVolumesRequest) ToCSIRepresentation() *csipbv1.ListVolumesRequest {
+	if r == nil {
+		return nil
+	}
+	return &csipbv1.ListVolumesRequest{
+		MaxEntries:    r.MaxEntries,
+		StartingToken: r.StartingToken,
+	}
+}
+
+func (r *ControllerListVolumesRequest) Validate() error {
+	if r.MaxEntries < 0 {
+		return errors.New("MaxEntries cannot be negative")
+	}
+	return nil
+}
+
+type ControllerListVolumesResponse struct {
+	Entries   []*ListVolumesResponse_Entry
+	NextToken string
+}
+
+func NewListVolumesResponse(resp *csipbv1.ListVolumesResponse) *ControllerListVolumesResponse {
+	if resp == nil {
+		return &ControllerListVolumesResponse{}
+	}
+	entries := []*ListVolumesResponse_Entry{}
+	if resp.Entries != nil {
+		for _, entry := range resp.Entries {
+			vol := entry.GetVolume()
+			status := entry.GetStatus()
+			entries = append(entries, &ListVolumesResponse_Entry{
+				Volume: &Volume{
+					CapacityBytes:      vol.CapacityBytes,
+					ExternalVolumeID:   vol.VolumeId,
+					VolumeContext:      vol.VolumeContext,
+					ContentSource:      newVolumeContentSource(vol.ContentSource),
+					AccessibleTopology: newTopologies(vol.AccessibleTopology),
+				},
+				Status: &ListVolumesResponse_VolumeStatus{
+					PublishedNodeIds: status.GetPublishedNodeIds(),
+					VolumeCondition: &VolumeCondition{
+						Abnormal: status.GetVolumeCondition().GetAbnormal(),
+						Message:  status.GetVolumeCondition().GetMessage(),
+					},
+				},
+			})
+		}
+	}
+	return &ControllerListVolumesResponse{
+		Entries:   entries,
+		NextToken: resp.NextToken,
+	}
+}
+
+type ListVolumesResponse_Entry struct {
+	Volume *Volume
+	Status *ListVolumesResponse_VolumeStatus
+}
+
+type ListVolumesResponse_VolumeStatus struct {
+	PublishedNodeIds []string
+	VolumeCondition  *VolumeCondition
+}
+
+type VolumeCondition struct {
+	Abnormal bool
+	Message  string
+}
+
 type NodeCapabilitySet struct {
 	HasStageUnstageVolume bool
 }
@@ -530,4 +795,19 @@ func (c *VolumeCapability) ToCSIRepresentation() *csipbv1.VolumeCapability {
 	}
 
 	return vc
+}
+
+type CapacityRange struct {
+	RequiredBytes int64
+	LimitBytes    int64
+}
+
+func (c *CapacityRange) ToCSIRepresentation() *csipbv1.CapacityRange {
+	if c == nil {
+		return nil
+	}
+	return &csipbv1.CapacityRange{
+		RequiredBytes: c.RequiredBytes,
+		LimitBytes:    c.LimitBytes,
+	}
 }

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -743,7 +743,7 @@ func VolumeCapabilityFromStructs(sAccessType structs.CSIVolumeAttachmentMode, sA
 		// final check during transformation into the requisite CSI Data type to
 		// defend against development bugs and corrupted state - and incompatible
 		// nomad versions in the future.
-		return nil, fmt.Errorf("Unknown volume attachment mode: %s", sAccessType)
+		return nil, fmt.Errorf("unknown volume attachment mode: %s", sAccessType)
 	}
 
 	var accessMode VolumeAccessMode
@@ -763,7 +763,7 @@ func VolumeCapabilityFromStructs(sAccessType structs.CSIVolumeAttachmentMode, sA
 		// final check during transformation into the requisite CSI Data type to
 		// defend against development bugs and corrupted state - and incompatible
 		// nomad versions in the future.
-		return nil, fmt.Errorf("Unknown volume access mode: %v", sAccessMode)
+		return nil, fmt.Errorf("unknown volume access mode: %v", sAccessMode)
 	}
 
 	return &VolumeCapability{

--- a/plugins/csi/testing/client.go
+++ b/plugins/csi/testing/client.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"context"
+	"fmt"
 
 	csipbv1 "github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
@@ -49,6 +50,9 @@ type ControllerClient struct {
 	NextPublishVolumeResponse              *csipbv1.ControllerPublishVolumeResponse
 	NextUnpublishVolumeResponse            *csipbv1.ControllerUnpublishVolumeResponse
 	NextValidateVolumeCapabilitiesResponse *csipbv1.ValidateVolumeCapabilitiesResponse
+	NextCreateVolumeResponse               *csipbv1.CreateVolumeResponse
+	NextDeleteVolumeResponse               *csipbv1.DeleteVolumeResponse
+	NextListVolumesResponse                *csipbv1.ListVolumesResponse
 }
 
 // NewControllerClient returns a new ControllerClient
@@ -62,6 +66,9 @@ func (f *ControllerClient) Reset() {
 	f.NextPublishVolumeResponse = nil
 	f.NextUnpublishVolumeResponse = nil
 	f.NextValidateVolumeCapabilitiesResponse = nil
+	f.NextCreateVolumeResponse = nil
+	f.NextDeleteVolumeResponse = nil
+	f.NextListVolumesResponse = nil
 }
 
 func (c *ControllerClient) ControllerGetCapabilities(ctx context.Context, in *csipbv1.ControllerGetCapabilitiesRequest, opts ...grpc.CallOption) (*csipbv1.ControllerGetCapabilitiesResponse, error) {
@@ -78,6 +85,29 @@ func (c *ControllerClient) ControllerUnpublishVolume(ctx context.Context, in *cs
 
 func (c *ControllerClient) ValidateVolumeCapabilities(ctx context.Context, in *csipbv1.ValidateVolumeCapabilitiesRequest, opts ...grpc.CallOption) (*csipbv1.ValidateVolumeCapabilitiesResponse, error) {
 	return c.NextValidateVolumeCapabilitiesResponse, c.NextErr
+}
+
+func (c *ControllerClient) CreateVolume(ctx context.Context, in *csipbv1.CreateVolumeRequest, opts ...grpc.CallOption) (*csipbv1.CreateVolumeResponse, error) {
+	if in.VolumeContentSource != nil {
+		if in.VolumeContentSource.Type == nil || (in.VolumeContentSource.Type ==
+			&csipbv1.VolumeContentSource_Volume{
+				Volume: &csipbv1.VolumeContentSource_VolumeSource{VolumeId: ""},
+			}) || (in.VolumeContentSource.Type ==
+			&csipbv1.VolumeContentSource_Snapshot{
+				Snapshot: &csipbv1.VolumeContentSource_SnapshotSource{SnapshotId: ""},
+			}) {
+			return nil, fmt.Errorf("empty content source should be nil")
+		}
+	}
+	return c.NextCreateVolumeResponse, c.NextErr
+}
+
+func (c *ControllerClient) DeleteVolume(ctx context.Context, in *csipbv1.DeleteVolumeRequest, opts ...grpc.CallOption) (*csipbv1.DeleteVolumeResponse, error) {
+	return c.NextDeleteVolumeResponse, c.NextErr
+}
+
+func (c *ControllerClient) ListVolumes(ctx context.Context, in *csipbv1.ListVolumesRequest, opts ...grpc.CallOption) (*csipbv1.ListVolumesResponse, error) {
+	return c.NextListVolumesResponse, c.NextErr
 }
 
 // NodeClient is a CSI Node client used for testing

--- a/vendor/github.com/hashicorp/nomad/api/api.go
+++ b/vendor/github.com/hashicorp/nomad/api/api.go
@@ -65,6 +65,14 @@ type QueryOptions struct {
 	// AuthToken is the secret ID of an ACL token
 	AuthToken string
 
+	// PerPage is the number of entries to be returned in queries that support
+	// paginated lists.
+	PerPage int32
+
+	// NextToken is the token used indicate where to start paging for queries
+	// that support paginated lists.
+	NextToken string
+
 	// ctx is an optional context pass through to the underlying HTTP
 	// request layer. Use Context() and WithContext() to manage this.
 	ctx context.Context

--- a/vendor/github.com/hashicorp/nomad/api/csi.go
+++ b/vendor/github.com/hashicorp/nomad/api/csi.go
@@ -134,23 +134,23 @@ type CSISecrets map[string]string
 type CSIVolume struct {
 	ID             string
 	Name           string
-	ExternalID     string `hcl:"external_id"`
+	ExternalID     string `mapstructure:"external_id" hcl:"external_id"`
 	Namespace      string
 	Topologies     []*CSITopology
 	AccessMode     CSIVolumeAccessMode     `hcl:"access_mode"`
 	AttachmentMode CSIVolumeAttachmentMode `hcl:"attachment_mode"`
 	MountOptions   *CSIMountOptions        `hcl:"mount_options"`
-	Secrets        CSISecrets              `hcl:"secrets"`
-	Parameters     map[string]string       `hcl:"parameters"`
-	Context        map[string]string       `hcl:"context"`
+	Secrets        CSISecrets              `mapstructure:"secrets" hcl:"secrets"`
+	Parameters     map[string]string       `mapstructure:"parameters" hcl:"parameters"`
+	Context        map[string]string       `mapstructure:"context" hcl:"context"`
 	Capacity       int64                   `hcl:"-"`
 
 	// These fields are used as part of the volume creation request
 	RequestedCapacityMin  int64                  `hcl:"capacity_min"`
 	RequestedCapacityMax  int64                  `hcl:"capacity_max"`
 	RequestedCapabilities []*CSIVolumeCapability `hcl:"capability"`
-	CloneID               string                 `hcl:"clone_id"`
-	SnapshotID            string                 `hcl:"snapshot_id"`
+	CloneID               string                 `mapstructure:"clone_id" hcl:"clone_id"`
+	SnapshotID            string                 `mapstructure:"snapshot_id" hcl:"snapshot_id"`
 
 	// ReadAllocs is a map of allocation IDs for tracking reader claim status.
 	// The Allocation value will always be nil; clients can populate this data
@@ -167,7 +167,7 @@ type CSIVolume struct {
 
 	// Schedulable is true if all the denormalized plugin health fields are true
 	Schedulable         bool
-	PluginID            string `hcl:"plugin_id"`
+	PluginID            string `mapstructure:"plugin_id" hcl:"plugin_id"`
 	Provider            string
 	ProviderVersion     string
 	ControllerRequired  bool
@@ -187,8 +187,8 @@ type CSIVolume struct {
 // CSIVolumeCapability is a requested attachment and access mode for a
 // volume
 type CSIVolumeCapability struct {
-	AccessMode     CSIVolumeAccessMode     `hcl:"access_mode"`
-	AttachmentMode CSIVolumeAttachmentMode `hcl:"attachment_mode"`
+	AccessMode     CSIVolumeAccessMode     `mapstructure:"access_mode" hcl:"access_mode"`
+	AttachmentMode CSIVolumeAttachmentMode `mapstructure:"attachment_mode" hcl:"attachment_mode"`
 }
 
 type CSIVolumeIndexSort []*CSIVolumeListStub

--- a/vendor/github.com/hashicorp/nomad/api/csi.go
+++ b/vendor/github.com/hashicorp/nomad/api/csi.go
@@ -28,6 +28,33 @@ func (v *CSIVolumes) List(q *QueryOptions) ([]*CSIVolumeListStub, *QueryMeta, er
 	return resp, qm, nil
 }
 
+// ListExternal returns all CSI volumes, as known to the storage provider
+func (v *CSIVolumes) ListExternal(pluginID string, q *QueryOptions) (*CSIVolumeListExternalResponse, *QueryMeta, error) {
+	var resp *CSIVolumeListExternalResponse
+
+	qp := url.Values{}
+	qp.Set("plugin_id", pluginID)
+	if q.NextToken != "" {
+		qp.Set("next_token", q.NextToken)
+	}
+	if q.PerPage != 0 {
+		qp.Set("per_page", fmt.Sprint(q.PerPage))
+	}
+
+	qm, err := v.client.query("/v1/volumes/external?"+qp.Encode(), &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sort.Sort(CSIVolumeExternalStubSort(resp.Volumes))
+	return resp, qm, nil
+}
+
+// PluginList returns all CSI volumes for the specified plugin id
+func (v *CSIVolumes) PluginList(pluginID string) ([]*CSIVolumeListStub, *QueryMeta, error) {
+	return v.List(&QueryOptions{Prefix: pluginID})
+}
+
 // Info is used to retrieve a single CSIVolume
 func (v *CSIVolumes) Info(id string, q *QueryOptions) (*CSIVolume, *QueryMeta, error) {
 	var resp CSIVolume
@@ -49,6 +76,21 @@ func (v *CSIVolumes) Register(vol *CSIVolume, w *WriteOptions) (*WriteMeta, erro
 
 func (v *CSIVolumes) Deregister(id string, force bool, w *WriteOptions) error {
 	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v?force=%t", url.PathEscape(id), force), nil, w)
+	return err
+}
+
+func (v *CSIVolumes) Create(vol *CSIVolume, w *WriteOptions) ([]*CSIVolume, *WriteMeta, error) {
+	req := CSIVolumeCreateRequest{
+		Volumes: []*CSIVolume{vol},
+	}
+
+	resp := &CSIVolumeCreateResponse{}
+	meta, err := v.client.write(fmt.Sprintf("/v1/volume/csi/%v/create", vol.ID), req, resp, w)
+	return resp.Volumes, meta, err
+}
+
+func (v *CSIVolumes) Delete(externalVolID string, w *WriteOptions) error {
+	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v/delete", url.PathEscape(externalVolID)), nil, w)
 	return err
 }
 
@@ -101,6 +143,14 @@ type CSIVolume struct {
 	Secrets        CSISecrets              `hcl:"secrets"`
 	Parameters     map[string]string       `hcl:"parameters"`
 	Context        map[string]string       `hcl:"context"`
+	Capacity       int64                   `hcl:"-"`
+
+	// These fields are used as part of the volume creation request
+	RequestedCapacityMin  int64                  `hcl:"capacity_min"`
+	RequestedCapacityMax  int64                  `hcl:"capacity_max"`
+	RequestedCapabilities []*CSIVolumeCapability `hcl:"capability"`
+	CloneID               string                 `hcl:"clone_id"`
+	SnapshotID            string                 `hcl:"snapshot_id"`
 
 	// ReadAllocs is a map of allocation IDs for tracking reader claim status.
 	// The Allocation value will always be nil; clients can populate this data
@@ -132,6 +182,13 @@ type CSIVolume struct {
 
 	// ExtraKeysHCL is used by the hcl parser to report unexpected keys
 	ExtraKeysHCL []string `hcl1:",unusedKeys" json:"-"`
+}
+
+// CSIVolumeCapability is a requested attachment and access mode for a
+// volume
+type CSIVolumeCapability struct {
+	AccessMode     CSIVolumeAccessMode     `hcl:"access_mode"`
+	AttachmentMode CSIVolumeAttachmentMode `hcl:"attachment_mode"`
 }
 
 type CSIVolumeIndexSort []*CSIVolumeListStub
@@ -169,6 +226,50 @@ type CSIVolumeListStub struct {
 
 	CreateIndex uint64
 	ModifyIndex uint64
+}
+
+type CSIVolumeListExternalResponse struct {
+	Volumes   []*CSIVolumeExternalStub
+	NextToken string
+}
+
+// CSIVolumeExternalStub is the storage provider's view of a volume, as
+// returned from the controller plugin; all IDs are for external resources
+type CSIVolumeExternalStub struct {
+	ExternalID               string
+	CapacityBytes            int64
+	VolumeContext            map[string]string
+	CloneID                  string
+	SnapshotID               string
+	PublishedExternalNodeIDs []string
+	IsAbnormal               bool
+	Status                   string
+}
+
+// We can't sort external volumes by creation time because we don't get that
+// data back from the storage provider. Sort by External ID within this page.
+type CSIVolumeExternalStubSort []*CSIVolumeExternalStub
+
+func (v CSIVolumeExternalStubSort) Len() int {
+	return len(v)
+}
+
+func (v CSIVolumeExternalStubSort) Less(i, j int) bool {
+	return v[i].ExternalID > v[j].ExternalID
+}
+
+func (v CSIVolumeExternalStubSort) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+type CSIVolumeCreateRequest struct {
+	Volumes []*CSIVolume
+	WriteRequest
+}
+
+type CSIVolumeCreateResponse struct {
+	Volumes []*CSIVolume
+	QueryMeta
 }
 
 type CSIVolumeRegisterRequest struct {

--- a/website/content/docs/commands/volume/create.mdx
+++ b/website/content/docs/commands/volume/create.mdx
@@ -1,0 +1,158 @@
+---
+layout: docs
+page_title: 'Commands: volume create'
+description: |
+  Create volumes with CSI plugins.
+---
+
+# Command: volume create
+
+The `volume create` command creates external storage volumes with Nomad's
+[Container Storage Interface (CSI)][csi] support. Only CSI plugins that
+implement the [Controller][csi_plugins_internals] interface support this
+command. The volume will also be [registered] when it is successfully created.
+
+## Usage
+
+```plaintext
+nomad volume create [options] [file]
+```
+
+The `volume create` command requires a single argument, specifying the path to
+a file containing a valid [volume specification][volume_specification]. This
+file will be read and the volume will be submitted to Nomad for scheduling. If
+the supplied path is "-", the volume file is read from STDIN. Otherwise it is
+read from the file at the supplied path.
+
+When ACLs are enabled, this command requires a token with the
+`csi-write-volume` capability for the volume's namespace.
+
+## General Options
+
+@include 'general_options.mdx'
+
+## Volume Specification
+
+The file may be provided as either HCL or JSON. An example HCL configuration:
+
+```hcl
+id              = "ebs_prod_db1"
+name            = "database"
+type            = "csi"
+external_id     = "vol-23452345"
+plugin_id       = "ebs-prod"
+snapshot_id     = "snap-12345" # or clone_id, see below
+
+capacity {
+  required = "100G"
+  limit    = "200G"
+}
+
+access_mode     = "single-node-writer"
+attachment_mode = "file-system"
+
+mount_options {
+  fs_type     = "ext4"
+  mount_flags = ["ro"]
+}
+
+secrets {
+  example_secret = "xyzzy"
+}
+
+parameters {
+  skuname = "Premium_LRS"
+}
+
+context {
+  endpoint = "http://192.168.1.101:9425"
+}
+```
+
+## Volume Specification Parameters
+
+- `id` `(string: <required>)` - The unique ID of the volume. This is how the
+  [`volume.source`][csi_volume_source] field in a job specification will refer
+  to the volume.
+
+- `name` `(string: <required>)` - The display name of the volume.
+
+- `type` `(string: <required>)` - The type of volume. Currently only `"csi"`
+  is supported.
+
+- `external_id` `(string: <required>)` - The ID of the physical volume from
+  the storage provider. For example, the volume ID of an AWS EBS volume or
+  Digital Ocean volume.
+
+- `plugin_id` `(string: <required>)` - The ID of the [CSI plugin][csi_plugin]
+  that manages this volume.
+
+- `snapshot_id` `(string: <optional>)` - If the storage provider supports
+  snapshots, the external ID of the snapshot to restore when creating this
+  volume. If omitted, the volume will be created from scratch. The
+  `snapshot_id` cannot be set if the `clone_id` field is set.
+
+- `clone_id` `(string: <optional>)` - If the storage provider supports
+  cloning, the external ID of the volume to clone when creating this
+  volume. If omitted, the volume will be created from scratch. The
+  `clone_id` cannot be set if the `snapshot_id` field is set.
+
+- `capacity_min` `(string: <optional>)` - Option for setting the capacity. The
+  volume must be at least this large, in bytes. The storage provider may
+  return a volume that is larger than this value. Accepts human-friendly
+  suffixes such as `"100GiB"`. This field may not be supported by all
+  storage providers.
+
+- `capacity_max` `(string: <optional>)` - Option for setting the capacity. The
+  volume must be no more than this large, in bytes. The storage provider may
+  return a volume that is smaller than this value. Accepts human-friendly
+  suffixes such as `"100GiB"`. This field may not be supported by all
+  storage providers.
+
+- `capability` `(optional)` - Option for validating the capbility of a
+  volume. You may provide multiple `capability` blocks, each of which must
+  have the following fields:
+
+  - `access_mode` `(string: <required>)` - Defines whether a volume should be
+    available concurrently. Can be one of `"single-node-reader-only"`,
+    `"single-node-writer"`, `"multi-node-reader-only"`,
+    `"multi-node-single-writer"`, or `"multi-node-multi-writer"`. Most CSI
+    plugins support only single-node modes. Consult the documentation of the
+    storage provider and CSI plugin.
+
+  - `attachment_mode` `(string: <required>)` - The storage API that will be used
+    by the volume. Most storage providers will support `"file-system"`, to mount
+    volumes using the CSI filesystem API. Some storage providers will support
+    `"block-device"`, which will mount the volume with the CSI block device API
+    within the container.
+
+- `mount_options` - Options for mounting `file-system` volumes that don't
+  already have a pre-formatted file system. Consult the documentation for your
+  storage provider and CSI plugin as to whether these options are required or
+  necessary.
+
+  - `fs_type` `(string <optional>)` - File system type (ex. `"ext4"`)
+  - `mount_flags` `([]string: <optional>)` - The flags passed to `mount`
+    (ex. `["ro", "noatime"]`)
+
+- `secrets` <code>(map<string|string>:nil)</code> - An optional
+  key-value map of strings used as credentials for publishing and
+  unpublishing volumes.
+
+- `parameters` <code>(map<string|string>:nil)</code> - An optional
+  key-value map of strings passed directly to the CSI plugin to
+  configure the volume. The details of these parameters are specific
+  to each storage provider, so please see the specific plugin
+  documentation for more information.
+
+- `context` <code>(map<string|string>:nil)</code> - This field is only used
+  during volume registration, and will be set automatically by the plugin when
+  `volume create` is successful. See [`volume register`].
+
+[csi]: https://github.com/container-storage-interface/spec
+[csi_plugins_internals]: /docs/internals/plugins/csi#csi-plugins
+[volume_specification]: #volume-specification
+[csi_plugin]: /docs/job-specification/csi_plugin
+[csi_volume_source]: /docs/job-specification/volume#source
+[registered]: /docs/commands/volume/register
+[`volume register`]: /docs/commands/volume/register

--- a/website/content/docs/commands/volume/delete.mdx
+++ b/website/content/docs/commands/volume/delete.mdx
@@ -1,0 +1,38 @@
+---
+layout: docs
+page_title: 'Commands: volume delete'
+description: |
+  Delete volumes with CSI plugins.
+---
+
+# Command: volume delete
+
+The `volume delete` command deletes external storage volumes with Nomad's
+[Container Storage Interface (CSI)][csi] support. Only CSI plugins that
+implement the [Controller][csi_plugins_internals] interface support this
+command. The volume will also be [deregistered] when it is successfully
+deleted.
+
+## Usage
+
+```plaintext
+nomad volume delete [options] [volume]
+```
+
+The `volume delete` command requires a single argument, specifying the ID of
+volume to be deleted. The volume must still be [registered] with Nomad in
+order to be deleted. Deleting will fail if the volume is still in use by an
+allocation or in the process of being unpublished. If the volume no longer
+exists, this command will silently return without an error.
+
+When ACLs are enabled, this command requires a token with the
+`csi-write-volume` capability for the volume's namespace.
+
+## General Options
+
+@include 'general_options.mdx'
+
+[csi]: https://github.com/container-storage-interface/spec
+[csi_plugins_internals]: /docs/internals/plugins/csi#csi-plugins
+[deregistered]: /docs/commands/volume/deregister
+[registered]: /docs/commands/volume/register

--- a/website/content/docs/commands/volume/deregister.mdx
+++ b/website/content/docs/commands/volume/deregister.mdx
@@ -8,9 +8,10 @@ description: |
 # Command: volume deregister
 
 The `volume deregister` command deregisters external storage volumes with
-Nomad's [Container Storage Interface (CSI)][csi] support. The volume
-must exist on the remote storage provider before it can be deregistered
-and used by a task.
+Nomad's [Container Storage Interface (CSI)][csi] support. The volume will be
+removed from Nomad's state store but not deleted from the external storage
+provider. Note that deregistering a volume prevents Nomad from deleting it via
+[`volume delete`] at a later time.
 
 ## Usage
 
@@ -37,3 +38,4 @@ When ACLs are enabled, this command requires a token with the
   allocations. This does not detach the volume from client nodes.
 
 [csi]: https://github.com/container-storage-interface/spec
+[`volume delete`]: /docs/commands/volume/delete

--- a/website/content/docs/commands/volume/register.mdx
+++ b/website/content/docs/commands/volume/register.mdx
@@ -7,10 +7,13 @@ description: |
 
 # Command: volume register
 
-The `volume register` command registers external storage volumes with
-Nomad's [Container Storage Interface (CSI)][csi] support. The volume
-must exist on the remote storage provider before it can be registered
-and used by a task.
+The `volume register` command registers external storage volumes with Nomad's
+[Container Storage Interface (CSI)][csi] support. The volume must exist on the
+remote storage provider before it can be registered and used by a task.
+
+CSI plugins that implement the [Controller][csi_plugins_internals] interface
+can be created via the [`volume create`] command, which will automatically
+register the volume as well.
 
 ## Usage
 
@@ -18,12 +21,12 @@ and used by a task.
 nomad volume register [options] [file]
 ```
 
-The `volume register` command requires a single argument, specifying
-the path to a file containing a valid [volume
-specification][volume_specification]. This file will be read and the
-job will be submitted to Nomad for scheduling. If the supplied path is
-"-", the job file is read from STDIN. Otherwise it is read from the
-file at the supplied path.
+The `volume register` command requires a single argument, specifying the path
+to a file containing a valid [volume
+specification][volume_specification]. This file will be read and the job will
+be submitted to Nomad for scheduling. If the supplied path is "-", the job
+file is read from STDIN. Otherwise it is read from the file at the supplied
+path.
 
 When ACLs are enabled, this command requires a token with the
 `csi-write-volume` capability for the volume's namespace.
@@ -37,66 +40,69 @@ When ACLs are enabled, this command requires a token with the
 The file may be provided as either HCL or JSON. An example HCL configuration:
 
 ```hcl
-id = "ebs_prod_db1"
-name = "database"
-type = "csi"
-external_id = "vol-23452345"
-plugin_id = "ebs-prod"
-access_mode = "single-node-writer"
+id              = "ebs_prod_db1"
+name            = "database"
+type            = "csi"
+external_id     = "vol-23452345"
+plugin_id       = "ebs-prod"
+snapshot_id     = "snap-12345" # or clone_id, see below
+capacity        = "100G"
+access_mode     = "single-node-writer"
 attachment_mode = "file-system"
+
 mount_options {
-   fs_type = "ext4"
-   mount_flags = ["ro"]
+  fs_type     = "ext4"
+  mount_flags = ["ro"]
 }
+
 secrets {
-   example_secret = "xyzzy"
+  example_secret = "xyzzy"
 }
+
 parameters {
-    skuname = "Premium_LRS"
+  skuname = "Premium_LRS"
 }
+
 context {
-    endpoint = "http://192.168.1.101:9425"
+  endpoint = "http://192.168.1.101:9425"
 }
 ```
 
 ## Volume Specification Parameters
 
-- `id` `(string: <required>)` - The unique ID of the volume. This will
-  be how [`volume`][csi_volume] stanzas in a jobspec refer to the volume.
+- `id` `(string: <required>)` - The unique ID of the volume. This is how the
+  [`volume.source`][csi_volume_source] field in a job specification will refer
+  to the volume.
 
 - `name` `(string: <required>)` - The display name of the volume.
 
-- `type` `(string: <required>)` - The type of volume. Currently only
-  `"csi"` is supported.
+- `type` `(string: <required>)` - The type of volume. Currently only `"csi"`
+  is supported.
 
-- `external_id` `(string: <required>)` - The ID of the physical volume
-  from the storage provider. For example, the volume ID of an AWS EBS
-  volume or Digital Ocean volume.
+- `external_id` `(string: <required>)` - The ID of the physical volume from
+  the storage provider. For example, the volume ID of an AWS EBS volume or
+  Digital Ocean volume.
 
-- `plugin_id` `(string: <required>)` - The ID of the [CSI
-  plugin][csi_plugin] that manages this volume.
+- `plugin_id` `(string: <required>)` - The ID of the [CSI plugin][csi_plugin]
+  that manages this volume.
 
-- `access_mode` `(string: <required>)` - Defines whether a volume
-  should be available concurrently. Can be one of
-  `"single-node-reader-only"`, `"single-node-writer"`,
-  `"multi-node-reader-only"`, `"multi-node-single-writer"`, or
-  `"multi-node-multi-writer"`. Most CSI plugins support only
-  single-node modes. Consult the documentation of the storage provider
-  and CSI plugin.
+- `snapshot_id` - This field is only used during volume creation, and is
+  ignored during volume registration. See [`volume create`].
 
-- `attachment_mode` `(string: <required>)` - The storage API that will be used
-  by the volume. Most storage providers will support `"file-system"`, to mount
-  volumes using the CSI filesystem API. Some storage providers will support
-  `"block-device"`, which will mount the volume with the CSI block device API
-  within the container.
+- `clone_id` - This field is only used during volume creation, and is ignored
+  during volume registration. See [`volume create`].
 
-- `mount_options` - Options for mounting `file-system` volumes that don't
-  already have a pre-formatted file system. Consult the documentation for your
-  storage provider and CSI plugin as to whether these options are required or
-  necessary.
+- `capacity_min` - This field is only used during volume creation, and is
+  ignored during volume registration. See [`volume create`].
 
-  - `fs_type`: file system type (ex. `"ext4"`)
-  - `mount_flags`: the flags passed to `mount` (ex. `"ro,noatime"`)
+- `capacity_max` - This field is only used during volume creation, and is
+  ignored during volume registration. See [`volume create`].
+
+- `capability` - This field is only used during volume creation, and is
+  ignored during volume registration. See [`volume create`].
+
+- `mount_options` - This field is only used during volume creation, and is
+  ignored during volume registration. See [`volume create`].
 
 - `secrets` <code>(map<string|string>:nil)</code> - An optional
   key-value map of strings used as credentials for publishing and
@@ -114,7 +120,9 @@ context {
   each storage provider, so please see the specific plugin
   documentation for more information.
 
-[volume_specification]: #volume-specification
 [csi]: https://github.com/container-storage-interface/spec
+[csi_plugins_internals]: /docs/internals/plugins/csi#csi-plugins
+[volume_specification]: #volume-specification
 [csi_plugin]: /docs/job-specification/csi_plugin
-[csi_volumes]: /docs/job-specification/volume
+[csi_volume_source]: /docs/job-specification/volume#source
+[`volume create`]: /docs/commands/volume/create

--- a/website/content/docs/commands/volume/status.mdx
+++ b/website/content/docs/commands/volume/status.mdx
@@ -45,8 +45,12 @@ namespace.
   being queried. Drops verbose volume allocation data from the
   output.
 
-- `-verbose`: Show full information. Allocation create and modify
-  times are shown in `yyyy/mm/dd hh:mm:ss` format.
+- `-verbose`: Show full information. Allocation create and modify times are
+  shown in `yyyy/mm/dd hh:mm:ss` format. When listing volumes, this flag will
+  cause Nomad to query the storage provider for volumes that are known to the
+  storage provider but not yet registered with Nomad. This may include volumes
+  that have been created by the [`volume create`] command that are not yet
+  schedulable.
 
 ## Examples
 
@@ -56,6 +60,18 @@ List of all volumes:
 $ nomad volume [-type csi] status
 ID            Name      Plugin ID  Schedulable  Access Mode
 ebs_prod_db1  database  ebs-prod   true         single-node-writer
+```
+
+List of all volumes, with external provider info:
+
+```shell-session
+$ nomad volume [-type csi] status -verbose
+ID            Name      Plugin ID  Schedulable  Access Mode
+ebs_prod_db1  database  ebs-prod   true         single-node-writer
+
+External ID   Condition                         Nodes
+vol-abcedf    OK                                i-abc123f2,i-14a12df13
+vol-cd46df    Abnormal (provider message here)  i-14a12df13
 ```
 
 Short view of a specific volume:
@@ -108,3 +124,4 @@ b00fa322  28be17d5  write         csi         0        run
 
 [csi]: https://github.com/container-storage-interface/spec
 [csi_plugin]: /docs/job-specification/csi_plugin
+[`volume create`]: /docs/commands/volume/create

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -724,6 +724,14 @@
             "path": "commands/volume"
           },
           {
+            "title": "create",
+            "path": "commands/volume/create"
+          },
+          {
+            "title": "delete",
+            "path": "commands/volume/delete"
+          },
+          {
             "title": "deregister",
             "path": "commands/volume/deregister"
           },


### PR DESCRIPTION
CSI volume creation workflow for https://github.com/hashicorp/nomad/issues/8212. The snapshot and resize workflows will be implemented in separate PRs once this is complete. 

Consists of the contents of these PRs, previously reviewed and merged:
* #10170 protobuffer mappings
* #10185 create/delete/list RPCs
* #10193 test infrastructure for mock client RPCs
* #10206 HTTP endpoints
* #10224 capability validation
* #10256 bugfix for protobuf mapping
* #10211 CLI for create/delete/list
* #10273 second bugfix for protobuf mapping 😊 
* #10274 wrong RPC for Delete HTTP 😊 

I've rebased these a bit to squash redundant commits on the same content and fixup doc navigation updates, so that we have a git-bisectable result once this PR is merged. But no content has changed other than the [docs navigation file](https://github.com/hashicorp/nomad/pull/10165/files#diff-27a78be5e3ffe5904295bee5000454df8614ef9595cb5fbeddcf648dc6d9f9e7).