### PR TITLE
docs: describe k8s in terms of "Linux containers"

### DIFF
--- a/website/content/docs/nomad-vs-kubernetes/index.mdx
+++ b/website/content/docs/nomad-vs-kubernetes/index.mdx
@@ -7,7 +7,7 @@ description: Comparison between Nomad and Kubernetes
 
 # Nomad vs. Kubernetes
 
-Kubernetes is an orchestration system for containers originally designed by Google, now governed by the Cloud Native Computing Foundation (CNCF) and developed by Google, Red Hat, and many others. Kubernetes and Nomad support similar core use cases for application deployment and management, but they differ in a few key ways. Kubernetes aims to provide all the features needed to run Docker-based applications including cluster management, scheduling, service discovery, monitoring, secrets management and more. Nomad only aims to focus on cluster management and scheduling and is designed with the Unix philosophy of having a small scope while composing with tools like Consul for service discovery/service mesh and Vault for secret management.
+Kubernetes is an orchestration system for containers originally designed by Google, now governed by the Cloud Native Computing Foundation (CNCF) and developed by Google, Red Hat, and many others. Kubernetes and Nomad support similar core use cases for application deployment and management, but they differ in a few key ways. Kubernetes aims to provide all the features needed to run Linux container-based applications including cluster management, scheduling, service discovery, monitoring, secrets management and more. Nomad only aims to focus on cluster management and scheduling and is designed with the Unix philosophy of having a small scope while composing with tools like Consul for service discovery/service mesh and Vault for secret management.
 
 The following characteristics generally differentiate Nomad from Kubernetes:
 
@@ -19,7 +19,7 @@ Nomad is architecturally much simpler. Nomad is a single binary, both for client
 
 ## Flexible Workload Support
 
-While Kubernetes is specifically focused on Docker, Nomad is more general purpose. Nomad supports virtualized, containerized and standalone applications, including Docker, Java, IIS on Windows, Qemu, etc. Nomad is designed with extensible drivers and support will be extended to all common drivers.
+While Kubernetes is specifically focused on Linux containers, Nomad is more general purpose. Nomad supports virtualized, containerized and standalone applications, including Docker, Java, IIS on Windows, Qemu, etc. Nomad is designed with extensible drivers and support will be extended to all common drivers.
 
 ## Consistent Deployment
 


### PR DESCRIPTION
The terminology here is a bit tricky. Technically Kuberbetes deprecated
their Docker *runtime* support but can still run Docker images. Sadly in
a lot of people's minds "Docker" and "containers" are nearly synonymous.

I think "Linux containers" is a more accurate characterization of
Kubernetes focus than "Docker" at this point.

Fixes #10120