### PR TITLE
docs: remove mention of api versioning

### DIFF
--- a/website/content/api-docs/index.mdx
+++ b/website/content/api-docs/index.mdx
@@ -17,13 +17,6 @@ actually invokes Nomad's HTTP for many commands.
 
 All API routes are prefixed with `/v1/`.
 
-This documentation is only for the v1 API.
-
-~> **Backwards compatibility:** At the current version, Nomad does not yet
-promise backwards compatibility even with the v1 prefix. We'll remove this
-warning when this policy changes. We expect to reach API stability by Nomad
-1.0.
-
 ## Addressing and Ports
 
 Nomad binds to a specific set of addresses and ports. The HTTP API is served via


### PR DESCRIPTION
We've only ever had 1 API version, and we've broken backward
compatibility extremely rarely. Nothing changed about this with the
release of 1.0, let's just remove these sentences and save everybody
some reading.