### PR TITLE
docs: add ports to jobspec overview example

### DIFF
--- a/website/content/docs/job-specification/index.mdx
+++ b/website/content/docs/job-specification/index.mdx
@@ -106,6 +106,7 @@ job "docs" {
       # Configuration is specific to each driver.
       config {
         image = "hashicorp/web-frontend"
+        ports = ["http", "https"]
       }
 
       # It is possible to set environment variables which will be


### PR DESCRIPTION
As pointed out from an user in our [Discuss forum](https://discuss.hashicorp.com/t/group-network-vs-group-task-resources-network/21963/5), the jobspec example in our overview page is missing `ports` assignment to the task.
