### PR TITLE
docs: add Autoscaler CLI flags for policy eval configuration

### DIFF
--- a/website/content/docs/autoscaling/cli.mdx
+++ b/website/content/docs/autoscaling/cli.mdx
@@ -81,6 +81,17 @@ passed in via CLI arguments. The `agent` command accepts the following arguments
   that will be applied to all scaling policies which do not specify an evaluation
   interval. The default is `10s`.
 
+- `-policy-eval-ack-timeout=<dur>`: The time limit that an eval must be ACK'd before
+  being considered NACK'd.
+
+- `-policy-eval-delivery-limit=<num>`: The maximum number of times a policy
+  evaluation can be dequeued from the broker.
+
+- `-policy-eval-workers=<key:value>`: The number of workers to initialize for each
+  queue, formatted as `<queue1>:<num>,<queue2>:<num>`. Nomad Autoscaler supports
+  `cluster` and `horizontal` queues. Nomad Autoscaler Enterprise supports additional
+  `vertical_mem` and `vertical_cpu` queues.
+
 - `-telemetry-disable-hostname`: Specifies whether gauge values should be prefixed
   with the local hostname.
 


### PR DESCRIPTION
Document new flags added in https://github.com/hashicorp/nomad-autoscaler/pull/421

Preview:

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/775380/111227498-07215100-85b9-11eb-8251-2fcbebfe4655.png">
