### PR TITLE
CSI: create/delete/list volume RPCs

### DIFF
--- a/client/csi_endpoint.go
+++ b/client/csi_endpoint.go
@@ -294,6 +294,9 @@ func (c *CSI) ControllerListVolumes(req *structs.ClientCSIControllerListVolumesR
 			}
 		}
 		resp.Entries = append(resp.Entries, vol)
+		if req.MaxEntries != 0 && int32(len(resp.Entries)) == req.MaxEntries {
+			break
+		}
 	}
 
 	return nil

--- a/client/csi_endpoint.go
+++ b/client/csi_endpoint.go
@@ -39,24 +39,25 @@ func (c *CSI) ControllerValidateVolume(req *structs.ClientCSIControllerValidateV
 	defer metrics.MeasureSince([]string{"client", "csi_controller", "validate_volume"}, time.Now())
 
 	if req.VolumeID == "" {
-		return errors.New("VolumeID is required")
+		return errors.New("CSI.ControllerValidateVolume: VolumeID is required")
 	}
 
 	if req.PluginID == "" {
-		return errors.New("PluginID is required")
+		return errors.New("CSI.ControllerValidateVolume: PluginID is required")
 	}
 
 	plugin, err := c.findControllerPlugin(req.PluginID)
 	if err != nil {
 		// the server's view of the plugin health is stale, so let it know it
 		// should retry with another controller instance
-		return fmt.Errorf("%w: %v", nstructs.ErrCSIClientRPCRetryable, err)
+		return fmt.Errorf("CSI.ControllerValidateVolume: %w: %v",
+			nstructs.ErrCSIClientRPCRetryable, err)
 	}
 	defer plugin.Close()
 
 	csiReq, err := req.ToCSIRequest()
 	if err != nil {
-		return err
+		return fmt.Errorf("CSI.ControllerValidateVolume: %v", err)
 	}
 
 	ctx, cancelFn := c.requestContext()
@@ -64,10 +65,14 @@ func (c *CSI) ControllerValidateVolume(req *structs.ClientCSIControllerValidateV
 
 	// CSI ValidateVolumeCapabilities errors for timeout, codes.Unavailable and
 	// codes.ResourceExhausted are retried; all other errors are fatal.
-	return plugin.ControllerValidateCapabilities(ctx, csiReq,
+	err = plugin.ControllerValidateCapabilities(ctx, csiReq,
 		grpc_retry.WithPerRetryTimeout(CSIPluginRequestTimeout),
 		grpc_retry.WithMax(3),
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(100*time.Millisecond)))
+	if err != nil {
+		return fmt.Errorf("CSI.ControllerValidateVolume: %v", err)
+	}
+	return nil
 }
 
 // ControllerAttachVolume is used to attach a volume from a CSI Cluster to
@@ -84,7 +89,8 @@ func (c *CSI) ControllerAttachVolume(req *structs.ClientCSIControllerAttachVolum
 	if err != nil {
 		// the server's view of the plugin health is stale, so let it know it
 		// should retry with another controller instance
-		return fmt.Errorf("%w: %v", nstructs.ErrCSIClientRPCRetryable, err)
+		return fmt.Errorf("CSI.ControllerAttachVolume: %w: %v",
+			nstructs.ErrCSIClientRPCRetryable, err)
 	}
 	defer plugin.Close()
 
@@ -94,16 +100,16 @@ func (c *CSI) ControllerAttachVolume(req *structs.ClientCSIControllerAttachVolum
 	// requests to plugins, and to aid with development.
 
 	if req.VolumeID == "" {
-		return errors.New("VolumeID is required")
+		return errors.New("CSI.ControllerAttachVolume: VolumeID is required")
 	}
 
 	if req.ClientCSINodeID == "" {
-		return errors.New("ClientCSINodeID is required")
+		return errors.New("CSI.ControllerAttachVolume: ClientCSINodeID is required")
 	}
 
 	csiReq, err := req.ToCSIRequest()
 	if err != nil {
-		return err
+		return fmt.Errorf("CSI.ControllerAttachVolume: %v", err)
 	}
 
 	// Submit the request for a volume to the CSI Plugin.
@@ -116,7 +122,7 @@ func (c *CSI) ControllerAttachVolume(req *structs.ClientCSIControllerAttachVolum
 		grpc_retry.WithMax(3),
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(100*time.Millisecond)))
 	if err != nil {
-		return err
+		return fmt.Errorf("CSI.ControllerAttachVolume: %v", err)
 	}
 
 	resp.PublishContext = cresp.PublishContext
@@ -131,7 +137,8 @@ func (c *CSI) ControllerDetachVolume(req *structs.ClientCSIControllerDetachVolum
 	if err != nil {
 		// the server's view of the plugin health is stale, so let it know it
 		// should retry with another controller instance
-		return fmt.Errorf("%w: %v", nstructs.ErrCSIClientRPCRetryable, err)
+		return fmt.Errorf("CSI.ControllerDetachVolume: %w: %v",
+			nstructs.ErrCSIClientRPCRetryable, err)
 	}
 	defer plugin.Close()
 
@@ -141,11 +148,11 @@ func (c *CSI) ControllerDetachVolume(req *structs.ClientCSIControllerDetachVolum
 	// requests to plugins, and to aid with development.
 
 	if req.VolumeID == "" {
-		return errors.New("VolumeID is required")
+		return errors.New("CSI.ControllerDetachVolume: VolumeID is required")
 	}
 
 	if req.ClientCSINodeID == "" {
-		return errors.New("ClientCSINodeID is required")
+		return errors.New("CSI.ControllerDetachVolume: ClientCSINodeID is required")
 	}
 
 	csiReq := req.ToCSIRequest()
@@ -159,16 +166,16 @@ func (c *CSI) ControllerDetachVolume(req *structs.ClientCSIControllerDetachVolum
 		grpc_retry.WithPerRetryTimeout(CSIPluginRequestTimeout),
 		grpc_retry.WithMax(3),
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(100*time.Millisecond)))
-	if err != nil {
-		if errors.Is(err, nstructs.ErrCSIClientRPCIgnorable) {
-			// if the controller detach previously happened but the server failed to
-			// checkpoint, we'll get an error from the plugin but can safely ignore it.
-			c.c.logger.Debug("could not unpublish volume: %v", err)
-			return nil
-		}
-		return err
+	if errors.Is(err, nstructs.ErrCSIClientRPCIgnorable) {
+		// if the controller detach previously happened but the server failed to
+		// checkpoint, we'll get an error from the plugin but can safely ignore it.
+		c.c.logger.Debug("could not unpublish volume: %v", err)
+		return nil
 	}
-	return nil
+	if err != nil {
+		return fmt.Errorf("CSI.ControllerDetachVolume: %v", err)
+	}
+	return err
 }
 
 func (c *CSI) ControllerCreateVolume(req *structs.ClientCSIControllerCreateVolumeRequest, resp *structs.ClientCSIControllerCreateVolumeResponse) error {
@@ -178,13 +185,14 @@ func (c *CSI) ControllerCreateVolume(req *structs.ClientCSIControllerCreateVolum
 	if err != nil {
 		// the server's view of the plugin health is stale, so let it know it
 		// should retry with another controller instance
-		return fmt.Errorf("%w: %v", nstructs.ErrCSIClientRPCRetryable, err)
+		return fmt.Errorf("CSI.ControllerCreateVolume: %w: %v",
+			nstructs.ErrCSIClientRPCRetryable, err)
 	}
 	defer plugin.Close()
 
 	csiReq, err := req.ToCSIRequest()
 	if err != nil {
-		return err
+		return fmt.Errorf("CSI.ControllerCreateVolume: %v", err)
 	}
 
 	ctx, cancelFn := c.requestContext()
@@ -197,12 +205,12 @@ func (c *CSI) ControllerCreateVolume(req *structs.ClientCSIControllerCreateVolum
 		grpc_retry.WithMax(3),
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(100*time.Millisecond)))
 	if err != nil {
-		return err
+		return fmt.Errorf("CSI.ControllerCreateVolume: %v", err)
 	}
 
 	if cresp == nil || cresp.Volume == nil {
 		c.c.logger.Warn("plugin did not return error or volume; this is a bug in the plugin and should be reported to the plugin author")
-		return fmt.Errorf("plugin did not return error or volume")
+		return fmt.Errorf("CSI.ControllerCreateVolume: plugin did not return error or volume")
 	}
 	resp.ExternalVolumeID = cresp.Volume.ExternalVolumeID
 	resp.CapacityBytes = cresp.Volume.CapacityBytes
@@ -218,7 +226,8 @@ func (c *CSI) ControllerDeleteVolume(req *structs.ClientCSIControllerDeleteVolum
 	if err != nil {
 		// the server's view of the plugin health is stale, so let it know it
 		// should retry with another controller instance
-		return fmt.Errorf("%w: %v", nstructs.ErrCSIClientRPCRetryable, err)
+		return fmt.Errorf("CSI.ControllerDeleteVolume: %w: %v",
+			nstructs.ErrCSIClientRPCRetryable, err)
 	}
 	defer plugin.Close()
 
@@ -233,17 +242,16 @@ func (c *CSI) ControllerDeleteVolume(req *structs.ClientCSIControllerDeleteVolum
 		grpc_retry.WithPerRetryTimeout(CSIPluginRequestTimeout),
 		grpc_retry.WithMax(3),
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(100*time.Millisecond)))
-	if err != nil {
-		if errors.Is(err, nstructs.ErrCSIClientRPCIgnorable) {
-			// if the volume was deleted out-of-band, we'll get an error from
-			// the plugin but can safely ignore it
-			c.c.logger.Debug("could not delete volume: %v", err)
-			return nil
-		}
-		return err
+	if errors.Is(err, nstructs.ErrCSIClientRPCIgnorable) {
+		// if the volume was deleted out-of-band, we'll get an error from
+		// the plugin but can safely ignore it
+		c.c.logger.Debug("could not delete volume: %v", err)
+		return nil
 	}
-
-	return nil
+	if err != nil {
+		return fmt.Errorf("CSI.ControllerDeleteVolume: %v", err)
+	}
+	return err
 }
 
 func (c *CSI) ControllerListVolumes(req *structs.ClientCSIControllerListVolumesRequest, resp *structs.ClientCSIControllerListVolumesResponse) error {
@@ -253,7 +261,8 @@ func (c *CSI) ControllerListVolumes(req *structs.ClientCSIControllerListVolumesR
 	if err != nil {
 		// the server's view of the plugin health is stale, so let it know it
 		// should retry with another controller instance
-		return fmt.Errorf("%w: %v", nstructs.ErrCSIClientRPCRetryable, err)
+		return fmt.Errorf("CSI.ControllerListVolumes: %w: %v",
+			nstructs.ErrCSIClientRPCRetryable, err)
 	}
 	defer plugin.Close()
 
@@ -269,7 +278,7 @@ func (c *CSI) ControllerListVolumes(req *structs.ClientCSIControllerListVolumesR
 		grpc_retry.WithMax(3),
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(100*time.Millisecond)))
 	if err != nil {
-		return err
+		return fmt.Errorf("CSI.ControllerListVolumes: %v", err)
 	}
 
 	resp.NextToken = cresp.NextToken
@@ -277,7 +286,7 @@ func (c *CSI) ControllerListVolumes(req *structs.ClientCSIControllerListVolumesR
 
 	for _, entry := range cresp.Entries {
 		if entry.Volume == nil {
-			return fmt.Errorf("plugin returned an invalid entry")
+			return fmt.Errorf("CSI.ControllerListVolumes: plugin returned an invalid entry")
 		}
 		vol := &nstructs.CSIVolumeExternalStub{
 			ExternalID:    entry.Volume.ExternalVolumeID,
@@ -311,13 +320,13 @@ func (c *CSI) NodeDetachVolume(req *structs.ClientCSINodeDetachVolumeRequest, re
 	// real Nomad cluster. They serve as a defensive check before forwarding
 	// requests to plugins, and to aid with development.
 	if req.PluginID == "" {
-		return errors.New("PluginID is required")
+		return errors.New("CSI.NodeDetachVolume: PluginID is required")
 	}
 	if req.VolumeID == "" {
-		return errors.New("VolumeID is required")
+		return errors.New("CSI.NodeDetachVolume: VolumeID is required")
 	}
 	if req.AllocID == "" {
-		return errors.New("AllocID is required")
+		return errors.New("CSI.NodeDetachVolume: AllocID is required")
 	}
 
 	ctx, cancelFn := c.requestContext()
@@ -325,7 +334,7 @@ func (c *CSI) NodeDetachVolume(req *structs.ClientCSINodeDetachVolumeRequest, re
 
 	mounter, err := c.c.csimanager.MounterForPlugin(ctx, req.PluginID)
 	if err != nil {
-		return err
+		return fmt.Errorf("CSI.NodeDetachVolume: %v", err)
 	}
 
 	usageOpts := &csimanager.UsageOptions{
@@ -339,7 +348,7 @@ func (c *CSI) NodeDetachVolume(req *structs.ClientCSINodeDetachVolumeRequest, re
 		// if the unmounting previously happened but the server failed to
 		// checkpoint, we'll get an error from Unmount but can safely
 		// ignore it.
-		return err
+		return fmt.Errorf("CSI.NodeDetachVolume: %v", err)
 	}
 	return nil
 }

--- a/client/csi_endpoint_test.go
+++ b/client/csi_endpoint_test.go
@@ -41,7 +41,7 @@ func TestCSIController_AttachVolume(t *testing.T) {
 					PluginID: "some-garbage",
 				},
 			},
-			ExpectedErr: errors.New("CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
+			ExpectedErr: errors.New("CSI.ControllerAttachVolume: CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
 		},
 		{
 			Name: "validates volumeid is not empty",
@@ -50,7 +50,7 @@ func TestCSIController_AttachVolume(t *testing.T) {
 					PluginID: fakePlugin.Name,
 				},
 			},
-			ExpectedErr: errors.New("VolumeID is required"),
+			ExpectedErr: errors.New("CSI.ControllerAttachVolume: VolumeID is required"),
 		},
 		{
 			Name: "validates nodeid is not empty",
@@ -60,7 +60,7 @@ func TestCSIController_AttachVolume(t *testing.T) {
 				},
 				VolumeID: "1234-4321-1234-4321",
 			},
-			ExpectedErr: errors.New("ClientCSINodeID is required"),
+			ExpectedErr: errors.New("CSI.ControllerAttachVolume: ClientCSINodeID is required"),
 		},
 		{
 			Name: "validates AccessMode",
@@ -73,7 +73,7 @@ func TestCSIController_AttachVolume(t *testing.T) {
 				AttachmentMode:  nstructs.CSIVolumeAttachmentModeFilesystem,
 				AccessMode:      nstructs.CSIVolumeAccessMode("foo"),
 			},
-			ExpectedErr: errors.New("Unknown volume access mode: foo"),
+			ExpectedErr: errors.New("CSI.ControllerAttachVolume: unknown volume access mode: foo"),
 		},
 		{
 			Name: "validates attachmentmode is not empty",
@@ -86,7 +86,7 @@ func TestCSIController_AttachVolume(t *testing.T) {
 				AccessMode:      nstructs.CSIVolumeAccessModeMultiNodeReader,
 				AttachmentMode:  nstructs.CSIVolumeAttachmentMode("bar"),
 			},
-			ExpectedErr: errors.New("Unknown volume attachment mode: bar"),
+			ExpectedErr: errors.New("CSI.ControllerAttachVolume: unknown volume attachment mode: bar"),
 		},
 		{
 			Name: "returns transitive errors",
@@ -102,7 +102,7 @@ func TestCSIController_AttachVolume(t *testing.T) {
 				AccessMode:      nstructs.CSIVolumeAccessModeSingleNodeWriter,
 				AttachmentMode:  nstructs.CSIVolumeAttachmentModeFilesystem,
 			},
-			ExpectedErr: errors.New("hello"),
+			ExpectedErr: errors.New("CSI.ControllerAttachVolume: hello"),
 		},
 		{
 			Name: "handles nil PublishContext",
@@ -188,7 +188,7 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 					PluginID: fakePlugin.Name,
 				},
 			},
-			ExpectedErr: errors.New("VolumeID is required"),
+			ExpectedErr: errors.New("CSI.ControllerValidateVolume: VolumeID is required"),
 		},
 		{
 			Name: "returns plugin not found errors",
@@ -198,7 +198,7 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 				},
 				VolumeID: "foo",
 			},
-			ExpectedErr: errors.New("CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
+			ExpectedErr: errors.New("CSI.ControllerValidateVolume: CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
 		},
 		{
 			Name: "validates attachmentmode",
@@ -210,7 +210,7 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 				AttachmentMode: nstructs.CSIVolumeAttachmentMode("bar"),
 				AccessMode:     nstructs.CSIVolumeAccessModeMultiNodeReader,
 			},
-			ExpectedErr: errors.New("Unknown volume attachment mode: bar"),
+			ExpectedErr: errors.New("CSI.ControllerValidateVolume: unknown volume attachment mode: bar"),
 		},
 		{
 			Name: "validates AccessMode",
@@ -222,7 +222,7 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 				AttachmentMode: nstructs.CSIVolumeAttachmentModeFilesystem,
 				AccessMode:     nstructs.CSIVolumeAccessMode("foo"),
 			},
-			ExpectedErr: errors.New("Unknown volume access mode: foo"),
+			ExpectedErr: errors.New("CSI.ControllerValidateVolume: unknown volume access mode: foo"),
 		},
 		{
 			Name: "returns transitive errors",
@@ -237,7 +237,7 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 				AccessMode:     nstructs.CSIVolumeAccessModeSingleNodeWriter,
 				AttachmentMode: nstructs.CSIVolumeAttachmentModeFilesystem,
 			},
-			ExpectedErr: errors.New("hello"),
+			ExpectedErr: errors.New("CSI.ControllerValidateVolume: hello"),
 		},
 	}
 
@@ -287,7 +287,7 @@ func TestCSIController_DetachVolume(t *testing.T) {
 					PluginID: "some-garbage",
 				},
 			},
-			ExpectedErr: errors.New("CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
+			ExpectedErr: errors.New("CSI.ControllerDetachVolume: CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
 		},
 		{
 			Name: "validates volumeid is not empty",
@@ -296,7 +296,7 @@ func TestCSIController_DetachVolume(t *testing.T) {
 					PluginID: fakePlugin.Name,
 				},
 			},
-			ExpectedErr: errors.New("VolumeID is required"),
+			ExpectedErr: errors.New("CSI.ControllerDetachVolume: VolumeID is required"),
 		},
 		{
 			Name: "validates nodeid is not empty",
@@ -306,7 +306,7 @@ func TestCSIController_DetachVolume(t *testing.T) {
 				},
 				VolumeID: "1234-4321-1234-4321",
 			},
-			ExpectedErr: errors.New("ClientCSINodeID is required"),
+			ExpectedErr: errors.New("CSI.ControllerDetachVolume: ClientCSINodeID is required"),
 		},
 		{
 			Name: "returns transitive errors",
@@ -320,7 +320,7 @@ func TestCSIController_DetachVolume(t *testing.T) {
 				VolumeID:        "1234-4321-1234-4321",
 				ClientCSINodeID: "abcde",
 			},
-			ExpectedErr: errors.New("hello"),
+			ExpectedErr: errors.New("CSI.ControllerDetachVolume: hello"),
 		},
 	}
 
@@ -370,7 +370,7 @@ func TestCSIController_CreateVolume(t *testing.T) {
 					PluginID: "some-garbage",
 				},
 			},
-			ExpectedErr: errors.New("CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
+			ExpectedErr: errors.New("CSI.ControllerCreateVolume: CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
 		},
 		{
 			Name: "validates AccessMode",
@@ -386,7 +386,7 @@ func TestCSIController_CreateVolume(t *testing.T) {
 					},
 				},
 			},
-			ExpectedErr: errors.New("Unknown volume access mode: foo"),
+			ExpectedErr: errors.New("CSI.ControllerCreateVolume: unknown volume access mode: foo"),
 		},
 		{
 			Name: "validates attachmentmode is not empty",
@@ -402,7 +402,7 @@ func TestCSIController_CreateVolume(t *testing.T) {
 					},
 				},
 			},
-			ExpectedErr: errors.New("Unknown volume attachment mode: bar"),
+			ExpectedErr: errors.New("CSI.ControllerCreateVolume: unknown volume attachment mode: bar"),
 		},
 		{
 			Name: "returns transitive errors",
@@ -421,7 +421,7 @@ func TestCSIController_CreateVolume(t *testing.T) {
 					},
 				},
 			},
-			ExpectedErr: errors.New("internal plugin error"),
+			ExpectedErr: errors.New("CSI.ControllerCreateVolume: internal plugin error"),
 		},
 	}
 
@@ -472,7 +472,7 @@ func TestCSIController_DeleteVolume(t *testing.T) {
 					PluginID: "some-garbage",
 				},
 			},
-			ExpectedErr: errors.New("CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
+			ExpectedErr: errors.New("CSI.ControllerDeleteVolume: CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
 		},
 		{
 			Name: "returns transitive errors",
@@ -485,7 +485,7 @@ func TestCSIController_DeleteVolume(t *testing.T) {
 				},
 				ExternalVolumeID: "1234-4321-1234-4321",
 			},
-			ExpectedErr: errors.New("internal plugin error"),
+			ExpectedErr: errors.New("CSI.ControllerDeleteVolume: internal plugin error"),
 		},
 	}
 
@@ -536,7 +536,7 @@ func TestCSIController_ListVolumes(t *testing.T) {
 					PluginID: "some-garbage",
 				},
 			},
-			ExpectedErr: errors.New("CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
+			ExpectedErr: errors.New("CSI.ControllerListVolumes: CSI client error (retryable): plugin some-garbage for type csi-controller not found"),
 		},
 		{
 			Name: "returns transitive errors",
@@ -548,7 +548,7 @@ func TestCSIController_ListVolumes(t *testing.T) {
 					PluginID: fakePlugin.Name,
 				},
 			},
-			ExpectedErr: errors.New("internal plugin error"),
+			ExpectedErr: errors.New("CSI.ControllerListVolumes: internal plugin error"),
 		},
 		{
 			Name: "returns volumes",
@@ -649,14 +649,14 @@ func TestCSINode_DetachVolume(t *testing.T) {
 				AccessMode:     nstructs.CSIVolumeAccessModeMultiNodeReader,
 				ReadOnly:       true,
 			},
-			ExpectedErr: errors.New("plugin some-garbage for type csi-node not found"),
+			ExpectedErr: errors.New("CSI.NodeDetachVolume: plugin some-garbage for type csi-node not found"),
 		},
 		{
 			Name: "validates volumeid is not empty",
 			Request: &structs.ClientCSINodeDetachVolumeRequest{
 				PluginID: fakeNodePlugin.Name,
 			},
-			ExpectedErr: errors.New("VolumeID is required"),
+			ExpectedErr: errors.New("CSI.NodeDetachVolume: VolumeID is required"),
 		},
 		{
 			Name: "validates nodeid is not empty",
@@ -664,7 +664,7 @@ func TestCSINode_DetachVolume(t *testing.T) {
 				PluginID: fakeNodePlugin.Name,
 				VolumeID: "1234-4321-1234-4321",
 			},
-			ExpectedErr: errors.New("AllocID is required"),
+			ExpectedErr: errors.New("CSI.NodeDetachVolume: AllocID is required"),
 		},
 		{
 			Name: "returns transitive errors",
@@ -677,7 +677,7 @@ func TestCSINode_DetachVolume(t *testing.T) {
 				AllocID:  "4321-1234-4321-1234",
 			},
 			// we don't have a csimanager in this context
-			ExpectedErr: errors.New("plugin test-plugin for type csi-node not found"),
+			ExpectedErr: errors.New("CSI.NodeDetachVolume: plugin test-plugin for type csi-node not found"),
 		},
 	}
 

--- a/client/pluginmanager/csimanager/volume_test.go
+++ b/client/pluginmanager/csimanager/volume_test.go
@@ -152,7 +152,7 @@ func TestVolumeManager_stageVolume(t *testing.T) {
 				AttachmentMode: "nonsense",
 			},
 			UsageOptions: &UsageOptions{},
-			ExpectedErr:  errors.New("Unknown volume attachment mode: nonsense"),
+			ExpectedErr:  errors.New("unknown volume attachment mode: nonsense"),
 		},
 		{
 			Name: "Returns an error when an invalid AccessMode is provided",
@@ -162,7 +162,7 @@ func TestVolumeManager_stageVolume(t *testing.T) {
 				AccessMode:     "nonsense",
 			},
 			UsageOptions: &UsageOptions{},
-			ExpectedErr:  errors.New("Unknown volume access mode: nonsense"),
+			ExpectedErr:  errors.New("unknown volume access mode: nonsense"),
 		},
 		{
 			Name: "Returns an error when the plugin returns an error",
@@ -490,14 +490,14 @@ func TestVolumeManager_MountVolumeEvents(t *testing.T) {
 	pubCtx := map[string]string{}
 
 	_, err := manager.MountVolume(ctx, vol, alloc, usage, pubCtx)
-	require.Error(t, err, "Unknown volume attachment mode: ")
+	require.Error(t, err, "unknown volume attachment mode: ")
 	require.Equal(t, 1, len(events))
 	e := events[0]
 	require.Equal(t, "Mount volume", e.Message)
 	require.Equal(t, "Storage", e.Subsystem)
 	require.Equal(t, "vol", e.Details["volume_id"])
 	require.Equal(t, "false", e.Details["success"])
-	require.Equal(t, "Unknown volume attachment mode: ", e.Details["error"])
+	require.Equal(t, "unknown volume attachment mode: ", e.Details["error"])
 	events = events[1:]
 
 	vol.AttachmentMode = structs.CSIVolumeAttachmentModeFilesystem

--- a/client/structs/csi.go
+++ b/client/structs/csi.go
@@ -175,6 +175,102 @@ func (c *ClientCSIControllerDetachVolumeRequest) ToCSIRequest() *csi.ControllerU
 
 type ClientCSIControllerDetachVolumeResponse struct{}
 
+// ClientCSIControllerCreateVolumeRequest the RPC made from the server to a
+// Nomad client to tell a CSI controller plugin on that client to perform
+// CreateVolume
+type ClientCSIControllerCreateVolumeRequest struct {
+	Name               string
+	VolumeCapabilities []*structs.CSIVolumeCapability
+	Parameters         map[string]string
+	Secrets            structs.CSISecrets
+	CapacityMin        int64
+	CapacityMax        int64
+	SnapshotID         string
+	CloneID            string
+	// TODO: topology is not yet supported
+	// TopologyRequirement
+
+	CSIControllerQuery
+}
+
+func (req *ClientCSIControllerCreateVolumeRequest) ToCSIRequest() (*csi.ControllerCreateVolumeRequest, error) {
+
+	creq := &csi.ControllerCreateVolumeRequest{
+		Name: req.Name,
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: req.CapacityMin,
+			LimitBytes:    req.CapacityMax,
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{},
+		Parameters:         req.Parameters,
+		Secrets:            req.Secrets,
+		ContentSource: &csi.VolumeContentSource{
+			CloneID:    req.CloneID,
+			SnapshotID: req.SnapshotID,
+		},
+		// TODO: topology is not yet supported
+		AccessibilityRequirements: &csi.TopologyRequirement{},
+	}
+	for _, cap := range req.VolumeCapabilities {
+		ccap, err := csi.VolumeCapabilityFromStructs(cap.AttachmentMode, cap.AccessMode)
+		if err != nil {
+			return nil, err
+		}
+		creq.VolumeCapabilities = append(creq.VolumeCapabilities, ccap)
+	}
+	return creq, nil
+}
+
+type ClientCSIControllerCreateVolumeResponse struct {
+	ExternalVolumeID string
+	CapacityBytes    int64
+	VolumeContext    map[string]string
+
+	// TODO: topology is not yet supported
+	// AccessibleTopology []*Topology
+}
+
+// ClientCSIControllerDeleteVolumeRequest the RPC made from the server to a
+// Nomad client to tell a CSI controller plugin on that client to perform
+// DeleteVolume
+type ClientCSIControllerDeleteVolumeRequest struct {
+	ExternalVolumeID string
+	Secrets          structs.CSISecrets
+
+	CSIControllerQuery
+}
+
+func (req *ClientCSIControllerDeleteVolumeRequest) ToCSIRequest() *csi.ControllerDeleteVolumeRequest {
+	return &csi.ControllerDeleteVolumeRequest{
+		ExternalVolumeID: req.ExternalVolumeID,
+		Secrets:          req.Secrets,
+	}
+}
+
+type ClientCSIControllerDeleteVolumeResponse struct{}
+
+// ClientCSIControllerListVolumesVolumeRequest the RPC made from the server to
+// a Nomad client to tell a CSI controller plugin on that client to perform
+// ListVolumes
+type ClientCSIControllerListVolumesRequest struct {
+	MaxEntries    int32
+	StartingToken string
+
+	CSIControllerQuery
+}
+
+func (req *ClientCSIControllerListVolumesRequest) ToCSIRequest() *csi.ControllerListVolumesRequest {
+	return &csi.ControllerListVolumesRequest{
+		MaxEntries:    req.MaxEntries,
+		StartingToken: req.StartingToken,
+	}
+}
+
+type ClientCSIControllerListVolumesResponse struct {
+	Entries   []*structs.CSIVolumeExternalStub
+	NextToken string
+}
+
 // ClientCSINodeDetachVolumeRequest is the RPC made from the server to
 // a Nomad client to tell a CSI node plugin on that client to perform
 // NodeUnpublish and NodeUnstage.

--- a/client/structs/csi.go
+++ b/client/structs/csi.go
@@ -20,6 +20,12 @@ type CSIVolumeMountOptions struct {
 	MountFlags []string
 }
 
+// CSIControllerRequest interface lets us set embedded CSIControllerQuery
+// fields in the server
+type CSIControllerRequest interface {
+	SetControllerNodeID(string)
+}
+
 // CSIControllerQuery is used to specify various flags for queries against CSI
 // Controllers
 type CSIControllerQuery struct {
@@ -28,6 +34,10 @@ type CSIControllerQuery struct {
 
 	// PluginID is the plugin that should be targeted on the given node.
 	PluginID string
+}
+
+func (c *CSIControllerQuery) SetControllerNodeID(nodeID string) {
+	c.ControllerNodeID = nodeID
 }
 
 type ClientCSIControllerValidateVolumeRequest struct {

--- a/nomad/client_csi_endpoint.go
+++ b/nomad/client_csi_endpoint.go
@@ -22,170 +22,98 @@ type ClientCSI struct {
 func (a *ClientCSI) ControllerAttachVolume(args *cstructs.ClientCSIControllerAttachVolumeRequest, reply *cstructs.ClientCSIControllerAttachVolumeResponse) error {
 	defer metrics.MeasureSince([]string{"nomad", "client_csi_controller", "attach_volume"}, time.Now())
 
-	clientIDs, err := a.clientIDsForController(args.PluginID)
+	err := a.sendCSIControllerRPC(args.PluginID,
+		"CSI.ControllerAttachVolume",
+		"ClientCSI.ControllerAttachVolume",
+		args, reply)
 	if err != nil {
 		return fmt.Errorf("controller attach volume: %v", err)
 	}
-
-	for _, clientID := range clientIDs {
-		args.ControllerNodeID = clientID
-		state, ok := a.srv.getNodeConn(clientID)
-		if !ok {
-			return findNodeConnAndForward(a.srv,
-				clientID, "ClientCSI.ControllerAttachVolume", args, reply)
-		}
-
-		err = NodeRpc(state.Session, "CSI.ControllerAttachVolume", args, reply)
-		if err == nil {
-			return nil
-		}
-		if a.isRetryable(err) {
-			a.logger.Debug("failed to reach controller on client",
-				"nodeID", clientID, "err", err)
-			continue
-		}
-		return fmt.Errorf("controller attach volume: %v", err)
-	}
-	return fmt.Errorf("controller attach volume: %v", err)
+	return nil
 }
 
 func (a *ClientCSI) ControllerValidateVolume(args *cstructs.ClientCSIControllerValidateVolumeRequest, reply *cstructs.ClientCSIControllerValidateVolumeResponse) error {
 	defer metrics.MeasureSince([]string{"nomad", "client_csi_controller", "validate_volume"}, time.Now())
 
-	clientIDs, err := a.clientIDsForController(args.PluginID)
+	err := a.sendCSIControllerRPC(args.PluginID,
+		"CSI.ControllerValidateVolume",
+		"ClientCSI.ControllerValidateVolume",
+		args, reply)
 	if err != nil {
-		return fmt.Errorf("validate volume: %v", err)
+		return fmt.Errorf("controller validate volume: %v", err)
 	}
-
-	for _, clientID := range clientIDs {
-		args.ControllerNodeID = clientID
-		state, ok := a.srv.getNodeConn(clientID)
-		if !ok {
-			return findNodeConnAndForward(a.srv,
-				clientID, "ClientCSI.ControllerValidateVolume", args, reply)
-		}
-
-		err = NodeRpc(state.Session, "CSI.ControllerValidateVolume", args, reply)
-		if err == nil {
-			return nil
-		}
-		if a.isRetryable(err) {
-			a.logger.Debug("failed to reach controller on client",
-				"nodeID", clientID, "err", err)
-			continue
-		}
-		return fmt.Errorf("validate volume: %v", err)
-	}
-	return fmt.Errorf("validate volume: %v", err)
+	return nil
 }
 
 func (a *ClientCSI) ControllerDetachVolume(args *cstructs.ClientCSIControllerDetachVolumeRequest, reply *cstructs.ClientCSIControllerDetachVolumeResponse) error {
 	defer metrics.MeasureSince([]string{"nomad", "client_csi_controller", "detach_volume"}, time.Now())
 
-	clientIDs, err := a.clientIDsForController(args.PluginID)
+	err := a.sendCSIControllerRPC(args.PluginID,
+		"CSI.ControllerDetachVolume",
+		"ClientCSI.ControllerDetachVolume",
+		args, reply)
 	if err != nil {
 		return fmt.Errorf("controller detach volume: %v", err)
 	}
-
-	for _, clientID := range clientIDs {
-		args.ControllerNodeID = clientID
-		state, ok := a.srv.getNodeConn(clientID)
-		if !ok {
-			return findNodeConnAndForward(a.srv,
-				clientID, "ClientCSI.ControllerDetachVolume", args, reply)
-		}
-
-		err = NodeRpc(state.Session, "CSI.ControllerDetachVolume", args, reply)
-		if err == nil {
-			return nil
-		}
-		if a.isRetryable(err) {
-			a.logger.Debug("failed to reach controller on client",
-				"nodeID", clientID, "err", err)
-			continue
-		}
-		return fmt.Errorf("controller detach volume: %v", err)
-	}
-	return fmt.Errorf("controller detach volume: %v", err)
+	return nil
 }
 
 func (a *ClientCSI) ControllerCreateVolume(args *cstructs.ClientCSIControllerCreateVolumeRequest, reply *cstructs.ClientCSIControllerCreateVolumeResponse) error {
 	defer metrics.MeasureSince([]string{"nomad", "client_csi_controller", "create_volume"}, time.Now())
 
-	clientIDs, err := a.clientIDsForController(args.PluginID)
+	err := a.sendCSIControllerRPC(args.PluginID,
+		"CSI.ControllerCreateVolume",
+		"ClientCSI.ControllerCreateVolume",
+		args, reply)
 	if err != nil {
-		return fmt.Errorf("create volume: %v", err)
+		return fmt.Errorf("controller create volume: %v", err)
 	}
-
-	for _, clientID := range clientIDs {
-		args.ControllerNodeID = clientID
-		state, ok := a.srv.getNodeConn(clientID)
-		if !ok {
-			return findNodeConnAndForward(a.srv,
-				clientID, "ClientCSI.ControllerCreateVolume", args, reply)
-		}
-
-		err = NodeRpc(state.Session, "CSI.ControllerCreateVolume", args, reply)
-		if err == nil {
-			return nil
-		}
-		if a.isRetryable(err) {
-			a.logger.Debug("failed to reach controller on client",
-				"nodeID", clientID, "err", err)
-			continue
-		}
-		return fmt.Errorf("create volume: %v", err)
-	}
-	return fmt.Errorf("create volume: %v", err)
+	return nil
 }
 
 func (a *ClientCSI) ControllerDeleteVolume(args *cstructs.ClientCSIControllerDeleteVolumeRequest, reply *cstructs.ClientCSIControllerDeleteVolumeResponse) error {
 	defer metrics.MeasureSince([]string{"nomad", "client_csi_controller", "delete_volume"}, time.Now())
 
-	clientIDs, err := a.clientIDsForController(args.PluginID)
+	err := a.sendCSIControllerRPC(args.PluginID,
+		"CSI.ControllerDeleteVolume",
+		"ClientCSI.ControllerDeleteVolume",
+		args, reply)
 	if err != nil {
 		return fmt.Errorf("controller delete volume: %v", err)
 	}
-
-	for _, clientID := range clientIDs {
-		args.ControllerNodeID = clientID
-		state, ok := a.srv.getNodeConn(clientID)
-		if !ok {
-			return findNodeConnAndForward(a.srv,
-				clientID, "ClientCSI.ControllerDeleteVolume", args, reply)
-		}
-
-		err = NodeRpc(state.Session, "CSI.ControllerDeleteVolume", args, reply)
-		if err == nil {
-			return nil
-		}
-		if a.isRetryable(err) {
-			a.logger.Debug("failed to reach controller on client",
-				"nodeID", clientID, "err", err)
-			continue
-		}
-		return fmt.Errorf("controller delete volume: %v", err)
-	}
-	return fmt.Errorf("controller delete volume: %v", err)
+	return nil
 }
 
 func (a *ClientCSI) ControllerListVolumes(args *cstructs.ClientCSIControllerListVolumesRequest, reply *cstructs.ClientCSIControllerListVolumesResponse) error {
 	defer metrics.MeasureSince([]string{"nomad", "client_csi_controller", "list_volumes"}, time.Now())
 
-	clientIDs, err := a.clientIDsForController(args.PluginID)
+	err := a.sendCSIControllerRPC(args.PluginID,
+		"CSI.ControllerListVolumes",
+		"ClientCSI.ControllerListVolumes",
+		args, reply)
 	if err != nil {
-		return fmt.Errorf("controller list external volumes: %v", err)
+		return fmt.Errorf("controller list volumes: %v", err)
+	}
+	return nil
+}
+
+func (a *ClientCSI) sendCSIControllerRPC(pluginID, method, fwdMethod string, args cstructs.CSIControllerRequest, reply interface{}) error {
+
+	clientIDs, err := a.clientIDsForController(pluginID)
+	if err != nil {
+		return err
 	}
 
 	for _, clientID := range clientIDs {
-		args.ControllerNodeID = clientID
+		args.SetControllerNodeID(clientID)
+
 		state, ok := a.srv.getNodeConn(clientID)
 		if !ok {
 			return findNodeConnAndForward(a.srv,
-				clientID, "ClientCSI.ControllerListVolumes", args, reply)
+				clientID, fwdMethod, args, reply)
 		}
 
-		err = NodeRpc(state.Session, "CSI.ControllerListVolumes", args, reply)
+		err = NodeRpc(state.Session, method, args, reply)
 		if err == nil {
 			return nil
 		}
@@ -194,9 +122,9 @@ func (a *ClientCSI) ControllerListVolumes(args *cstructs.ClientCSIControllerList
 				"nodeID", clientID, "err", err)
 			continue
 		}
-		return fmt.Errorf("controller list external volumes: %v", err)
+		return err
 	}
-	return fmt.Errorf("controller list external volumes: %v", err)
+	return err
 }
 
 // we can retry the same RPC on a different controller in the cases where the

--- a/nomad/client_csi_endpoint_test.go
+++ b/nomad/client_csi_endpoint_test.go
@@ -24,16 +24,23 @@ import (
 // responses that have no bodies have no "Next*Response" field and will always
 // return an empty response body.
 type MockClientCSI struct {
-	NextValidateError   error
-	NextAttachError     error
-	NextAttachResponse  *cstructs.ClientCSIControllerAttachVolumeResponse
-	NextDetachError     error
-	NextNodeDetachError error
+	NextValidateError        error
+	NextAttachError          error
+	NextAttachResponse       *cstructs.ClientCSIControllerAttachVolumeResponse
+	NextDetachError          error
+	NextCreateError          error
+	NextCreateResponse       *cstructs.ClientCSIControllerCreateVolumeResponse
+	NextDeleteError          error
+	NextListExternalError    error
+	NextListExternalResponse *cstructs.ClientCSIControllerListVolumesResponse
+	NextNodeDetachError      error
 }
 
 func newMockClientCSI() *MockClientCSI {
 	return &MockClientCSI{
-		NextAttachResponse: &cstructs.ClientCSIControllerAttachVolumeResponse{},
+		NextAttachResponse:       &cstructs.ClientCSIControllerAttachVolumeResponse{},
+		NextCreateResponse:       &cstructs.ClientCSIControllerCreateVolumeResponse{},
+		NextListExternalResponse: &cstructs.ClientCSIControllerListVolumesResponse{},
 	}
 }
 
@@ -48,6 +55,20 @@ func (c *MockClientCSI) ControllerAttachVolume(req *cstructs.ClientCSIController
 
 func (c *MockClientCSI) ControllerDetachVolume(req *cstructs.ClientCSIControllerDetachVolumeRequest, resp *cstructs.ClientCSIControllerDetachVolumeResponse) error {
 	return c.NextDetachError
+}
+
+func (c *MockClientCSI) ControllerCreateVolume(req *cstructs.ClientCSIControllerCreateVolumeRequest, resp *cstructs.ClientCSIControllerCreateVolumeResponse) error {
+	*resp = *c.NextCreateResponse
+	return c.NextCreateError
+}
+
+func (c *MockClientCSI) ControllerDeleteVolume(req *cstructs.ClientCSIControllerDeleteVolumeRequest, resp *cstructs.ClientCSIControllerDeleteVolumeResponse) error {
+	return c.NextDeleteError
+}
+
+func (c *MockClientCSI) ControllerListVolumes(req *cstructs.ClientCSIControllerListVolumesRequest, resp *cstructs.ClientCSIControllerListVolumesResponse) error {
+	*resp = *c.NextListExternalResponse
+	return c.NextListExternalError
 }
 
 func (c *MockClientCSI) NodeDetachVolume(req *cstructs.ClientCSINodeDetachVolumeRequest, resp *cstructs.ClientCSINodeDetachVolumeResponse) error {
@@ -164,7 +185,7 @@ func TestClientCSIController_CreateVolume_Local(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerCreateVolume", req, &resp)
-	require.NotNil(err)
+	require.Error(err)
 	require.Contains(err.Error(), "no plugins registered for type")
 }
 
@@ -180,7 +201,7 @@ func TestClientCSIController_CreateVolume_Forwarded(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerCreateVolume", req, &resp)
-	require.NotNil(err)
+	require.Error(err)
 	require.Contains(err.Error(), "no plugins registered for type")
 }
 
@@ -197,7 +218,7 @@ func TestClientCSIController_DeleteVolume_Local(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerDeleteVolume", req, &resp)
-	require.NotNil(err)
+	require.Error(err)
 	require.Contains(err.Error(), "no plugins registered for type")
 }
 
@@ -214,7 +235,7 @@ func TestClientCSIController_DeleteVolume_Forwarded(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerDeleteVolume", req, &resp)
-	require.NotNil(err)
+	require.Error(err)
 	require.Contains(err.Error(), "no plugins registered for type")
 }
 
@@ -230,7 +251,7 @@ func TestClientCSIController_ListVolumes_Local(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerListVolumes", req, &resp)
-	require.NotNil(err)
+	require.Error(err)
 	require.Contains(err.Error(), "no plugins registered for type")
 }
 
@@ -246,7 +267,7 @@ func TestClientCSIController_ListVolumes_Forwarded(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerListVolumes", req, &resp)
-	require.NotNil(err)
+	require.Error(err)
 	require.Contains(err.Error(), "no plugins registered for type")
 }
 
@@ -380,6 +401,9 @@ func setupLocal(t *testing.T) (rpc.ClientCodec, func()) {
 	mockCSI.NextValidateError = fmt.Errorf("no plugins registered for type")
 	mockCSI.NextAttachError = fmt.Errorf("no plugins registered for type")
 	mockCSI.NextDetachError = fmt.Errorf("no plugins registered for type")
+	mockCSI.NextCreateError = fmt.Errorf("no plugins registered for type")
+	mockCSI.NextDeleteError = fmt.Errorf("no plugins registered for type")
+	mockCSI.NextListExternalError = fmt.Errorf("no plugins registered for type")
 
 	c1, cleanupC1 := client.TestClientWithRPCs(t,
 		func(c *config.Config) {

--- a/nomad/client_csi_endpoint_test.go
+++ b/nomad/client_csi_endpoint_test.go
@@ -152,6 +152,104 @@ func TestClientCSIController_ValidateVolume_Forwarded(t *testing.T) {
 	require.Contains(err.Error(), "no plugins registered for type")
 }
 
+func TestClientCSIController_CreateVolume_Local(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	codec, cleanup := setupLocal(t)
+	defer cleanup()
+
+	req := &cstructs.ClientCSIControllerCreateVolumeRequest{
+		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
+	}
+
+	var resp structs.GenericResponse
+	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerCreateVolume", req, &resp)
+	require.NotNil(err)
+	require.Contains(err.Error(), "no plugins registered for type")
+}
+
+func TestClientCSIController_CreateVolume_Forwarded(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	codec, cleanup := setupForward(t)
+	defer cleanup()
+
+	req := &cstructs.ClientCSIControllerCreateVolumeRequest{
+		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
+	}
+
+	var resp structs.GenericResponse
+	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerCreateVolume", req, &resp)
+	require.NotNil(err)
+	require.Contains(err.Error(), "no plugins registered for type")
+}
+
+func TestClientCSIController_DeleteVolume_Local(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	codec, cleanup := setupLocal(t)
+	defer cleanup()
+
+	req := &cstructs.ClientCSIControllerDeleteVolumeRequest{
+		ExternalVolumeID:   "test",
+		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
+	}
+
+	var resp structs.GenericResponse
+	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerDeleteVolume", req, &resp)
+	require.NotNil(err)
+	require.Contains(err.Error(), "no plugins registered for type")
+}
+
+func TestClientCSIController_DeleteVolume_Forwarded(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	codec, cleanup := setupForward(t)
+	defer cleanup()
+
+	req := &cstructs.ClientCSIControllerDeleteVolumeRequest{
+		ExternalVolumeID:   "test",
+		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
+	}
+
+	var resp structs.GenericResponse
+	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerDeleteVolume", req, &resp)
+	require.NotNil(err)
+	require.Contains(err.Error(), "no plugins registered for type")
+}
+
+func TestClientCSIController_ListVolumes_Local(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	codec, cleanup := setupLocal(t)
+	defer cleanup()
+
+	req := &cstructs.ClientCSIControllerListVolumesRequest{
+		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
+	}
+
+	var resp structs.GenericResponse
+	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerListVolumes", req, &resp)
+	require.NotNil(err)
+	require.Contains(err.Error(), "no plugins registered for type")
+}
+
+func TestClientCSIController_ListVolumes_Forwarded(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	codec, cleanup := setupForward(t)
+	defer cleanup()
+
+	req := &cstructs.ClientCSIControllerListVolumesRequest{
+		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
+	}
+
+	var resp structs.GenericResponse
+	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerListVolumes", req, &resp)
+	require.NotNil(err)
+	require.Contains(err.Error(), "no plugins registered for type")
+}
+
 func TestClientCSI_NodeForControllerPlugin(t *testing.T) {
 	t.Parallel()
 	srv, shutdown := TestServer(t, func(c *Config) {})

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -108,8 +108,7 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 		return structs.ErrPermissionDenied
 	}
 
-	metricsStart := time.Now()
-	defer metrics.MeasureSince([]string{"nomad", "volume", "list"}, metricsStart)
+	defer metrics.MeasureSince([]string{"nomad", "volume", "list"}, time.Now())
 
 	ns := args.RequestNamespace()
 	opts := blockingOptions{
@@ -189,8 +188,7 @@ func (v *CSIVolume) Get(args *structs.CSIVolumeGetRequest, reply *structs.CSIVol
 		return structs.ErrPermissionDenied
 	}
 
-	metricsStart := time.Now()
-	defer metrics.MeasureSince([]string{"nomad", "volume", "get"}, metricsStart)
+	defer metrics.MeasureSince([]string{"nomad", "volume", "get"}, time.Now())
 
 	if args.ID == "" {
 		return fmt.Errorf("missing volume ID")
@@ -273,14 +271,13 @@ func (v *CSIVolume) Register(args *structs.CSIVolumeRegisterRequest, reply *stru
 		return err
 	}
 
-	metricsStart := time.Now()
-	defer metrics.MeasureSince([]string{"nomad", "volume", "register"}, metricsStart)
+	defer metrics.MeasureSince([]string{"nomad", "volume", "register"}, time.Now())
 
 	if !allowVolume(aclObj, args.RequestNamespace()) || !aclObj.AllowPluginRead() {
 		return structs.ErrPermissionDenied
 	}
 
-	if args.Volumes == nil || len(args.Volumes) == 0 {
+	if len(args.Volumes) == 0 {
 		return fmt.Errorf("missing volume definition")
 	}
 
@@ -328,8 +325,7 @@ func (v *CSIVolume) Deregister(args *structs.CSIVolumeDeregisterRequest, reply *
 		return err
 	}
 
-	metricsStart := time.Now()
-	defer metrics.MeasureSince([]string{"nomad", "volume", "deregister"}, metricsStart)
+	defer metrics.MeasureSince([]string{"nomad", "volume", "deregister"}, time.Now())
 
 	ns := args.RequestNamespace()
 	if !allowVolume(aclObj, ns) {
@@ -366,8 +362,7 @@ func (v *CSIVolume) Claim(args *structs.CSIVolumeClaimRequest, reply *structs.CS
 		return err
 	}
 
-	metricsStart := time.Now()
-	defer metrics.MeasureSince([]string{"nomad", "volume", "claim"}, metricsStart)
+	defer metrics.MeasureSince([]string{"nomad", "volume", "claim"}, time.Now())
 
 	if !allowVolume(aclObj, args.RequestNamespace()) || !aclObj.AllowPluginRead() {
 		return structs.ErrPermissionDenied
@@ -528,8 +523,7 @@ func (v *CSIVolume) Unpublish(args *structs.CSIVolumeUnpublishRequest, reply *st
 		return err
 	}
 
-	metricsStart := time.Now()
-	defer metrics.MeasureSince([]string{"nomad", "volume", "unpublish"}, metricsStart)
+	defer metrics.MeasureSince([]string{"nomad", "volume", "unpublish"}, time.Now())
 
 	allowVolume := acl.NamespaceValidator(acl.NamespaceCapabilityCSIMountVolume)
 	aclObj, err := v.srv.WriteACLObj(&args.WriteRequest, true)
@@ -798,8 +792,7 @@ func (v *CSIVolume) Create(args *structs.CSIVolumeCreateRequest, reply *structs.
 		return err
 	}
 
-	metricsStart := time.Now()
-	defer metrics.MeasureSince([]string{"nomad", "volume", "create"}, metricsStart)
+	defer metrics.MeasureSince([]string{"nomad", "volume", "create"}, time.Now())
 
 	allowVolume := acl.NamespaceValidator(acl.NamespaceCapabilityCSIWriteVolume)
 	aclObj, err := v.srv.WriteACLObj(&args.WriteRequest, false)
@@ -811,7 +804,7 @@ func (v *CSIVolume) Create(args *structs.CSIVolumeCreateRequest, reply *structs.
 		return structs.ErrPermissionDenied
 	}
 
-	if args.Volumes == nil || len(args.Volumes) == 0 {
+	if len(args.Volumes) == 0 {
 		return fmt.Errorf("missing volume definition")
 	}
 
@@ -897,8 +890,7 @@ func (v *CSIVolume) Delete(args *structs.CSIVolumeDeleteRequest, reply *structs.
 		return err
 	}
 
-	metricsStart := time.Now()
-	defer metrics.MeasureSince([]string{"nomad", "volume", "delete"}, metricsStart)
+	defer metrics.MeasureSince([]string{"nomad", "volume", "delete"}, time.Now())
 
 	allowVolume := acl.NamespaceValidator(acl.NamespaceCapabilityCSIWriteVolume)
 	aclObj, err := v.srv.WriteACLObj(&args.WriteRequest, false)
@@ -964,11 +956,7 @@ func (v *CSIVolume) deleteVolume(vol *structs.CSIVolume, plugin *structs.CSIPlug
 	cReq.PluginID = plugin.ID
 	cResp := &cstructs.ClientCSIControllerDeleteVolumeResponse{}
 
-	err := v.srv.RPC(method, cReq, cResp)
-	if err != nil {
-		return err
-	}
-	return nil
+	return v.srv.RPC(method, cReq, cResp)
 }
 
 func (v *CSIVolume) ListExternal(args *structs.CSIVolumeExternalListRequest, reply *structs.CSIVolumeExternalListResponse) error {
@@ -976,8 +964,7 @@ func (v *CSIVolume) ListExternal(args *structs.CSIVolumeExternalListRequest, rep
 	if done, err := v.srv.forward("CSIVolume.ListExternal", args, args, reply); done {
 		return err
 	}
-	metricsStart := time.Now()
-	defer metrics.MeasureSince([]string{"nomad", "volume", "list_external"}, metricsStart)
+	defer metrics.MeasureSince([]string{"nomad", "volume", "list_external"}, time.Now())
 
 	allowVolume := acl.NamespaceValidator(acl.NamespaceCapabilityCSIListVolume,
 		acl.NamespaceCapabilityCSIReadVolume,
@@ -1049,8 +1036,7 @@ func (v *CSIPlugin) List(args *structs.CSIPluginListRequest, reply *structs.CSIP
 		return structs.ErrPermissionDenied
 	}
 
-	metricsStart := time.Now()
-	defer metrics.MeasureSince([]string{"nomad", "plugin", "list"}, metricsStart)
+	defer metrics.MeasureSince([]string{"nomad", "plugin", "list"}, time.Now())
 
 	opts := blockingOptions{
 		queryOpts: &args.QueryOptions,
@@ -1098,8 +1084,7 @@ func (v *CSIPlugin) Get(args *structs.CSIPluginGetRequest, reply *structs.CSIPlu
 	withAllocs := aclObj == nil ||
 		aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJob)
 
-	metricsStart := time.Now()
-	defer metrics.MeasureSince([]string{"nomad", "plugin", "get"}, metricsStart)
+	defer metrics.MeasureSince([]string{"nomad", "plugin", "get"}, time.Now())
 
 	if args.ID == "" {
 		return fmt.Errorf("missing plugin ID")
@@ -1159,8 +1144,7 @@ func (v *CSIPlugin) Delete(args *structs.CSIPluginDeleteRequest, reply *structs.
 		return structs.ErrPermissionDenied
 	}
 
-	metricsStart := time.Now()
-	defer metrics.MeasureSince([]string{"nomad", "plugin", "delete"}, metricsStart)
+	defer metrics.MeasureSince([]string{"nomad", "plugin", "delete"}, time.Now())
 
 	if args.ID == "" {
 		return fmt.Errorf("missing plugin ID")

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -438,14 +438,14 @@ func TestCSIVolumeEndpoint_ClaimWithController(t *testing.T) {
 	claimResp := &structs.CSIVolumeClaimResponse{}
 	err = msgpackrpc.CallWithCodec(codec, "CSIVolume.Claim", claimReq, claimResp)
 	// Because the node is not registered
-	require.EqualError(t, err, "controller publish: attach volume: No path to node")
+	require.EqualError(t, err, "controller publish: attach volume: controller attach volume: No path to node")
 
 	// The node SecretID is authorized for all policies
 	claimReq.AuthToken = node.SecretID
 	claimReq.Namespace = ""
 	claimResp = &structs.CSIVolumeClaimResponse{}
 	err = msgpackrpc.CallWithCodec(codec, "CSIVolume.Claim", claimReq, claimResp)
-	require.EqualError(t, err, "controller publish: attach volume: No path to node")
+	require.EqualError(t, err, "controller publish: attach volume: controller attach volume: No path to node")
 }
 
 func TestCSIVolumeEndpoint_Unpublish(t *testing.T) {
@@ -499,7 +499,7 @@ func TestCSIVolumeEndpoint_Unpublish(t *testing.T) {
 		{
 			name:           "unpublish previously detached node",
 			startingState:  structs.CSIVolumeClaimStateNodeDetached,
-			expectedErrMsg: "could not detach from controller: No path to node",
+			expectedErrMsg: "could not detach from controller: controller detach volume: No path to node",
 		},
 		{
 			name:           "first unpublish",

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -79,6 +79,13 @@ func (t *TaskCSIPluginConfig) Copy() *TaskCSIPluginConfig {
 	return nt
 }
 
+// CSIVolumeCapability is the requested attachment and access mode for a
+// volume
+type CSIVolumeCapability struct {
+	AttachmentMode CSIVolumeAttachmentMode
+	AccessMode     CSIVolumeAccessMode
+}
+
 // CSIVolumeAttachmentMode chooses the type of storage api that will be used to
 // interact with the device.
 type CSIVolumeAttachmentMode string
@@ -246,6 +253,15 @@ type CSIVolume struct {
 	Secrets        CSISecrets
 	Parameters     map[string]string
 	Context        map[string]string
+	Capacity       int64 // bytes
+
+	// These values are used only on volume creation but we record them
+	// so that we can diff the volume later
+	RequestedCapacityMin  int64 // bytes
+	RequestedCapacityMax  int64 // bytes
+	RequestedCapabilities []*CSIVolumeCapability
+	CloneID               string
+	SnapshotID            string
 
 	// Allocations, tracking claim status
 	ReadAllocs  map[string]*Allocation // AllocID -> Allocation
@@ -590,6 +606,9 @@ func (v *CSIVolume) Validate() error {
 			}
 		}
 	}
+	if v.SnapshotID != "" && v.CloneID != "" {
+		errs = append(errs, "only one of snapshot_id and clone_id is allowed")
+	}
 
 	// TODO: Volume Topologies are optional - We should check to see if the plugin
 	//       the volume is being registered with requires them.
@@ -628,6 +647,21 @@ type CSIVolumeDeregisterRequest struct {
 
 type CSIVolumeDeregisterResponse struct {
 	QueryMeta
+}
+
+type CSIVolumeCreateRequest struct {
+	Volumes []*CSIVolume
+	WriteRequest
+}
+
+type CSIVolumeCreateResponse struct {
+	Volumes []*CSIVolume
+	QueryMeta
+}
+
+type CSIVolumeDeleteRequest struct {
+	VolumeIDs []string
+	WriteRequest
 }
 
 type CSIVolumeClaimMode int
@@ -698,6 +732,39 @@ type CSIVolumeListRequest struct {
 type CSIVolumeListResponse struct {
 	Volumes []*CSIVolListStub
 	QueryMeta
+}
+
+// CSIVolumeExternalListRequest is a request to a controller plugin to list
+// all the volumes known to the the storage provider. This request is
+// paginated by the plugin.
+type CSIVolumeExternalListRequest struct {
+	PluginID      string
+	MaxEntries    int32
+	StartingToken string
+	QueryOptions
+}
+
+type CSIVolumeExternalListResponse struct {
+	Volumes   []*CSIVolumeExternalStub
+	NextToken string
+	QueryMeta
+}
+
+// CSIVolumeExternalStub is the storage provider's view of a volume, as
+// returned from the controller plugin; all IDs are for external resources
+type CSIVolumeExternalStub struct {
+	ExternalID    string
+	CapacityBytes int64
+	VolumeContext map[string]string
+	CloneID       string
+	SnapshotID    string
+
+	// TODO: topology support
+	// AccessibleTopology []*Topology
+
+	PublishedExternalNodeIDs []string
+	IsAbnormal               bool
+	Status                   string
 }
 
 type CSIVolumeGetRequest struct {

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -664,6 +664,10 @@ type CSIVolumeDeleteRequest struct {
 	WriteRequest
 }
 
+type CSIVolumeDeleteResponse struct {
+	QueryMeta
+}
+
 type CSIVolumeClaimMode int
 
 const (

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -728,7 +728,7 @@ func VolumeCapabilityFromStructs(sAccessType structs.CSIVolumeAttachmentMode, sA
 		// final check during transformation into the requisite CSI Data type to
 		// defend against development bugs and corrupted state - and incompatible
 		// nomad versions in the future.
-		return nil, fmt.Errorf("Unknown volume attachment mode: %s", sAccessType)
+		return nil, fmt.Errorf("unknown volume attachment mode: %s", sAccessType)
 	}
 
 	var accessMode VolumeAccessMode
@@ -748,7 +748,7 @@ func VolumeCapabilityFromStructs(sAccessType structs.CSIVolumeAttachmentMode, sA
 		// final check during transformation into the requisite CSI Data type to
 		// defend against development bugs and corrupted state - and incompatible
 		// nomad versions in the future.
-		return nil, fmt.Errorf("Unknown volume access mode: %v", sAccessMode)
+		return nil, fmt.Errorf("unknown volume access mode: %v", sAccessMode)
 	}
 
 	return &VolumeCapability{


### PR DESCRIPTION
Implementation of the `CreateVolume`, `DeleteVolume`, and `ListVolume` (external volumes) for CSI.

Notes for reviewers:
* This is a bit of a beast of a PR but it's mostly plumbing code and I've got it so that you should be able to review commit-by-commit.
* Note there are no HTTP or CLI commits; those will be handled in the next PR.
* Also note there are no new raft messages for this work.
* This PR is targeting the `csi-create-volume` branch: https://github.com/hashicorp/nomad/pull/10165
* This changeset currently includes the contents of https://github.com/hashicorp/nomad/pull/10193 and will be rebased once that's been merged.