### PR TITLE
Fixup uses of `sanity`

### DIFF
--- a/api/internal/testutil/server.go
+++ b/api/internal/testutil/server.go
@@ -148,7 +148,7 @@ func NewTestServer(t testing.T, cb ServerConfigCallback) *TestServer {
 		t.Skipf("nomad not found, skipping: %v", err)
 	}
 
-	// Do a sanity check that we are actually running nomad
+	// Check that we are actually running nomad
 	vcmd := exec.Command(path, "-version")
 	vcmd.Stdout = nil
 	vcmd.Stderr = nil

--- a/command/agent/consul/unit_test.go
+++ b/command/agent/consul/unit_test.go
@@ -176,7 +176,7 @@ func TestConsul_EnableTagOverride_Syncs(t *testing.T) {
 
 	const service = "taskname-service"
 
-	// sanity check things are what we expect
+	// check things are what we expect
 	consulServiceDefBefore := ctx.FakeConsul.lookupService(service)[0]
 	r.Equal(ctx.Workload.Services[0].Name, consulServiceDefBefore.Name)
 	r.Equal([]string{"tag1", "tag2"}, consulServiceDefBefore.Tags)

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -276,7 +276,7 @@ func TestExecutor_CgroupPaths(t *testing.T) {
 
 	tu.WaitForResult(func() (bool, error) {
 		output := strings.TrimSpace(testExecCmd.stdout.String())
-		// sanity check that we got some cgroups
+		// Verify that we got some cgroups
 		if !strings.Contains(output, ":devices:") {
 			return false, fmt.Errorf("was expected cgroup files but found:\n%v", output)
 		}
@@ -332,7 +332,7 @@ func TestExecutor_CgroupPathsAreDestroyed(t *testing.T) {
 	var cgroupsPaths string
 	tu.WaitForResult(func() (bool, error) {
 		output := strings.TrimSpace(testExecCmd.stdout.String())
-		// sanity check that we got some cgroups
+		// Verify that we got some cgroups
 		if !strings.Contains(output, ":devices:") {
 			return false, fmt.Errorf("was expected cgroup files but found:\n%v", output)
 		}

--- a/e2e/connect/acls.go
+++ b/e2e/connect/acls.go
@@ -44,12 +44,12 @@ func (tc *ConnectACLsE2ETest) BeforeAll(f *framework.F) {
 	require.NoError(f.T(), err)
 	tc.enableConsulACLs(f)
 
-	// Sanity check the consul master token exists, otherwise tests are just
+	// Validate the consul master token exists, otherwise tests are just
 	// going to be a train wreck.
 	tokenLength := len(tc.consulMasterToken)
 	require.Equal(f.T(), 36, tokenLength, "consul master token wrong length")
 
-	// Sanity check the CONSUL_HTTP_TOKEN is NOT set, because that will cause
+	// Validate the CONSUL_HTTP_TOKEN is NOT set, because that will cause
 	// the agent checks to fail (which do not allow having a token set (!)).
 	consulTokenEnv := os.Getenv(envConsulToken)
 	require.Empty(f.T(), consulTokenEnv)

--- a/helper/escapingio/reader_test.go
+++ b/helper/escapingio/reader_test.go
@@ -46,7 +46,7 @@ func TestEscapingReader_Static(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		t.Run("sanity check naive implementation", func(t *testing.T) {
+		t.Run("validate naive implementation", func(t *testing.T) {
 			h := &testHandler{}
 
 			processed := naiveEscapeCharacters(c.input, '~', h.handler)

--- a/helper/pluginutils/hclutils/util_test.go
+++ b/helper/pluginutils/hclutils/util_test.go
@@ -473,7 +473,7 @@ func TestParseNullFields(t *testing.T) {
 			TaskConfig{BlockList: []Sub{}},
 		},
 		{
-			// for sanity checking that the fields are actually set
+			// for checking that the fields are actually set
 			"explicitly set to not null",
 			`{"Config": {
                             "array_field": ["a"],

--- a/nomad/consul.go
+++ b/nomad/consul.go
@@ -224,7 +224,7 @@ func (c *consulACLsAPI) CreateToken(ctx context.Context, sir ServiceIdentityRequ
 		return nil, errors.New("client stopped and may no longer create tokens")
 	}
 
-	// sanity check the metadata for the token we want
+	// Check the metadata for the token we want
 	if err := sir.Validate(); err != nil {
 		return nil, err
 	}

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -3188,7 +3188,7 @@ func TestFSM_ClusterMetadata(t *testing.T) {
 	r.NoError(err)
 	r.Equal(clusterID, storedMetadata.ClusterID)
 
-	// Check that the reasonableness check prevents accidental UUID regeneration
+	// Assert cluster ID cannot be overwritten and is not regenerated
 	erroneous := structs.ClusterMetadata{
 		ClusterID: "99999999-9999-9999-9999-9999999999",
 	}

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -3188,7 +3188,7 @@ func TestFSM_ClusterMetadata(t *testing.T) {
 	r.NoError(err)
 	r.Equal(clusterID, storedMetadata.ClusterID)
 
-	// Check that the sanity check prevents accidental UUID regeneration
+	// Check that the reasonableness check prevents accidental UUID regeneration
 	erroneous := structs.ClusterMetadata{
 		ClusterID: "99999999-9999-9999-9999-9999999999",
 	}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -5456,7 +5456,7 @@ func (s *StateStore) schedulerSetConfigTxn(idx uint64, tx *txn, config *structs.
 }
 
 func (s *StateStore) setClusterMetadata(txn *txn, meta *structs.ClusterMetadata) error {
-	// Check for an existing config, if it exists, sanity check the cluster ID matches
+	// Check for an existing config, if it exists, verify that the cluster ID matches
 	existing, err := txn.First("cluster_meta", "id")
 	if err != nil {
 		return fmt.Errorf("failed cluster meta lookup: %v", err)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -1893,7 +1893,7 @@ func TestStateStore_DeleteJobTxn_BatchDeletes(t *testing.T) {
 
 	ws := memdb.NewWatchSet()
 
-	// Sanity check that jobs are present in DB
+	// Check that jobs are present in DB
 	job, err := state.JobByID(ws, jobs[0].Namespace, jobs[0].ID)
 	require.NoError(t, err)
 	require.Equal(t, jobs[0].ID, job.ID)

--- a/nomad/structs/funcs_test.go
+++ b/nomad/structs/funcs_test.go
@@ -187,11 +187,6 @@ func TestAllocsFit_Old(t *testing.T) {
 	fit, _, used, err := AllocsFit(n, []*Allocation{a1}, nil, false)
 	require.NoError(err)
 	require.True(fit)
-
-	// Check the used resources are expected values
-	// TODO: This comment is not super useful, but neither was
-	//       the original. It would be better if someone
-	//       explained the invariant that this check validates.
 	require.EqualValues(1000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(1024, used.Flattened.Memory.MemoryMB)
 
@@ -199,11 +194,6 @@ func TestAllocsFit_Old(t *testing.T) {
 	fit, _, used, err = AllocsFit(n, []*Allocation{a1, a1}, nil, false)
 	require.NoError(err)
 	require.False(fit)
-
-	// Check the used resources are expected values
-	// TODO: This comment is not super useful, but neither was
-	//       the original. It would be better if someone
-	//       explained the invariant that this check validates.
 	require.EqualValues(2000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(2048, used.Flattened.Memory.MemoryMB)
 }
@@ -260,11 +250,6 @@ func TestAllocsFit_TerminalAlloc_Old(t *testing.T) {
 	fit, _, used, err := AllocsFit(n, []*Allocation{a1}, nil, false)
 	require.NoError(err)
 	require.True(fit)
-
-	// Check the used resources are expected values
-	// TODO: This comment is not super useful, but neither was
-	//       the original. It would be better if someone
-	//       explained the invariant that this check validates.
 	require.EqualValues(1000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(1024, used.Flattened.Memory.MemoryMB)
 
@@ -274,11 +259,6 @@ func TestAllocsFit_TerminalAlloc_Old(t *testing.T) {
 	fit, _, used, err = AllocsFit(n, []*Allocation{a1, a2}, nil, false)
 	require.NoError(err)
 	require.True(fit)
-
-	// Check the used resources are expected values
-	// TODO: This comment is not super useful, but neither was
-	//       the original. It would be better if someone
-	//       explained the invariant that this check validates.
 	require.EqualValues(1000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(1024, used.Flattened.Memory.MemoryMB)
 }
@@ -368,11 +348,6 @@ func TestAllocsFit(t *testing.T) {
 	fit, _, used, err := AllocsFit(n, []*Allocation{a1}, nil, false)
 	require.NoError(err)
 	require.True(fit)
-
-	// Check the used resources are expected values
-	// TODO: This comment is not super useful, but neither was
-	//       the original. It would be better if someone
-	//       explained the invariant that this check validates.
 	require.EqualValues(1000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(1024, used.Flattened.Memory.MemoryMB)
 
@@ -380,11 +355,6 @@ func TestAllocsFit(t *testing.T) {
 	fit, _, used, err = AllocsFit(n, []*Allocation{a1, a1}, nil, false)
 	require.NoError(err)
 	require.False(fit)
-
-	// Check the used resources are expected values
-	// TODO: This comment is not super useful, but neither was
-	//       the original. It would be better if someone
-	//       explained the invariant that this check validates.
 	require.EqualValues(2000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(2048, used.Flattened.Memory.MemoryMB)
 }
@@ -458,11 +428,6 @@ func TestAllocsFit_TerminalAlloc(t *testing.T) {
 	fit, _, used, err := AllocsFit(n, []*Allocation{a1}, nil, false)
 	require.NoError(err)
 	require.True(fit)
-
-	// Check the used resources are expected values
-	// TODO: This comment is not super useful, but neither was
-	//       the original. It would be better if someone
-	//       explained the invariant that this check validates.
 	require.EqualValues(1000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(1024, used.Flattened.Memory.MemoryMB)
 
@@ -472,11 +437,6 @@ func TestAllocsFit_TerminalAlloc(t *testing.T) {
 	fit, dim, used, err := AllocsFit(n, []*Allocation{a1, a2}, nil, false)
 	require.NoError(err)
 	require.True(fit, dim)
-
-	// Check the used resources are expected values
-	// TODO: This comment is not super useful, but neither was
-	//       the original. It would be better if someone
-	//       explained the invariant that this check validates.
 	require.EqualValues(1000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(1024, used.Flattened.Memory.MemoryMB)
 }

--- a/nomad/structs/funcs_test.go
+++ b/nomad/structs/funcs_test.go
@@ -188,7 +188,10 @@ func TestAllocsFit_Old(t *testing.T) {
 	require.NoError(err)
 	require.True(fit)
 
-	// Sanity check the used resources
+	// Check the used resources are expected values
+	// TODO: This comment is not super useful, but neither was
+	//       the original. It would be better if someone
+	//       explained the invariant that this check validates.
 	require.EqualValues(1000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(1024, used.Flattened.Memory.MemoryMB)
 
@@ -197,7 +200,10 @@ func TestAllocsFit_Old(t *testing.T) {
 	require.NoError(err)
 	require.False(fit)
 
-	// Sanity check the used resources
+	// Check the used resources are expected values
+	// TODO: This comment is not super useful, but neither was
+	//       the original. It would be better if someone
+	//       explained the invariant that this check validates.
 	require.EqualValues(2000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(2048, used.Flattened.Memory.MemoryMB)
 }
@@ -255,7 +261,10 @@ func TestAllocsFit_TerminalAlloc_Old(t *testing.T) {
 	require.NoError(err)
 	require.True(fit)
 
-	// Sanity check the used resources
+	// Check the used resources are expected values
+	// TODO: This comment is not super useful, but neither was
+	//       the original. It would be better if someone
+	//       explained the invariant that this check validates.
 	require.EqualValues(1000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(1024, used.Flattened.Memory.MemoryMB)
 
@@ -266,7 +275,10 @@ func TestAllocsFit_TerminalAlloc_Old(t *testing.T) {
 	require.NoError(err)
 	require.True(fit)
 
-	// Sanity check the used resources
+	// Check the used resources are expected values
+	// TODO: This comment is not super useful, but neither was
+	//       the original. It would be better if someone
+	//       explained the invariant that this check validates.
 	require.EqualValues(1000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(1024, used.Flattened.Memory.MemoryMB)
 }
@@ -357,7 +369,10 @@ func TestAllocsFit(t *testing.T) {
 	require.NoError(err)
 	require.True(fit)
 
-	// Sanity check the used resources
+	// Check the used resources are expected values
+	// TODO: This comment is not super useful, but neither was
+	//       the original. It would be better if someone
+	//       explained the invariant that this check validates.
 	require.EqualValues(1000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(1024, used.Flattened.Memory.MemoryMB)
 
@@ -366,7 +381,10 @@ func TestAllocsFit(t *testing.T) {
 	require.NoError(err)
 	require.False(fit)
 
-	// Sanity check the used resources
+	// Check the used resources are expected values
+	// TODO: This comment is not super useful, but neither was
+	//       the original. It would be better if someone
+	//       explained the invariant that this check validates.
 	require.EqualValues(2000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(2048, used.Flattened.Memory.MemoryMB)
 }
@@ -441,7 +459,10 @@ func TestAllocsFit_TerminalAlloc(t *testing.T) {
 	require.NoError(err)
 	require.True(fit)
 
-	// Sanity check the used resources
+	// Check the used resources are expected values
+	// TODO: This comment is not super useful, but neither was
+	//       the original. It would be better if someone
+	//       explained the invariant that this check validates.
 	require.EqualValues(1000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(1024, used.Flattened.Memory.MemoryMB)
 
@@ -452,7 +473,10 @@ func TestAllocsFit_TerminalAlloc(t *testing.T) {
 	require.NoError(err)
 	require.True(fit, dim)
 
-	// Sanity check the used resources
+	// Check the used resources are expected values
+	// TODO: This comment is not super useful, but neither was
+	//       the original. It would be better if someone
+	//       explained the invariant that this check validates.
 	require.EqualValues(1000, used.Flattened.Cpu.CpuShares)
 	require.EqualValues(1024, used.Flattened.Memory.MemoryMB)
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4055,7 +4055,7 @@ func (j *Job) Copy() *Job {
 	return nj
 }
 
-// Validate is used to sanity check a job input
+// Validate is used to check a job for reasonable configuration
 func (j *Job) Validate() error {
 	var mErr multierror.Error
 
@@ -5972,7 +5972,7 @@ func (tg *TaskGroup) Canonicalize(job *Job) {
 	}
 }
 
-// Validate is used to sanity check a task group
+// Validate is used to check a task group for reasonable configuration
 func (tg *TaskGroup) Validate(j *Job) error {
 	var mErr multierror.Error
 	if tg.Name == "" {
@@ -6742,7 +6742,7 @@ func (t *Task) GoString() string {
 	return fmt.Sprintf("*%#v", *t)
 }
 
-// Validate is used to sanity check a task
+// Validate is used to check a task for reasonable configuration
 func (t *Task) Validate(ephemeralDisk *EphemeralDisk, jobType string, tgServices []*Service, tgNetworks Networks) error {
 	var mErr multierror.Error
 	if t.Name == "" {
@@ -10928,7 +10928,7 @@ func (a *ACLToken) Stub() *ACLTokenListStub {
 	}
 }
 
-// Validate is used to sanity check a token
+// Validate is used to check a token for reasonableness
 func (a *ACLToken) Validate() error {
 	var mErr multierror.Error
 	if len(a.Name) > maxTokenNameLength {

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -145,7 +145,7 @@ func NewTestServer(t testing.T, cb ServerConfigCallback) *TestServer {
 		t.Skipf("nomad not found, skipping: %v", err)
 	}
 
-	// Do a sanity check that we are actually running nomad
+	// Check that we are actually running nomad
 	vcmd := exec.Command(path, "-version")
 	vcmd.Stdout = nil
 	vcmd.Stderr = nil


### PR DESCRIPTION
`Sanity check` is not the preferred vernacular.  Ref: [Writing inclusive documentation. Google.](https://developers.google.com/style/inclusive-documentation#ableist-language)