### PR TITLE
test infrastructure for mock client RPCs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -308,8 +308,12 @@ var (
 	noServersErr = errors.New("no servers")
 )
 
-// NewClient is used to create a new client from the given configuration
-func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxies consulApi.SupportedProxiesAPI, consulService consulApi.ConsulServiceAPI) (*Client, error) {
+// NewClient is used to create a new client from the given configuration.
+// `rpcs` is a map of RPC names to RPC structs that, if non-nil, will be
+// registered via https://golang.org/pkg/net/rpc/#Server.RegisterName in place
+// of the client's normal RPC handlers. This allows server tests to override
+// the behavior of the client.
+func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxies consulApi.SupportedProxiesAPI, consulService consulApi.ConsulServiceAPI, rpcs map[string]interface{}) (*Client, error) {
 	// Create the tls wrapper
 	var tlsWrap tlsutil.RegionWrapper
 	if cfg.TLSConfig.EnableRPC {
@@ -384,7 +388,7 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 		})
 
 	// Setup the clients RPC server
-	c.setupClientRpc()
+	c.setupClientRpc(rpcs)
 
 	// Initialize the ACL state
 	if err := c.clientACLResolver.init(); err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -622,7 +622,7 @@ func TestClient_SaveRestoreState(t *testing.T) {
 	c1.config.PluginLoader = catalog.TestPluginLoaderWithOptions(t, "", c1.config.Options, nil)
 	c1.config.PluginSingletonLoader = singleton.NewSingletonLoader(logger, c1.config.PluginLoader)
 
-	c2, err := NewClient(c1.config, consulCatalog, nil, mockService)
+	c2, err := NewClient(c1.config, consulCatalog, nil, mockService, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -245,19 +245,24 @@ func (c *Client) streamingRpcConn(server *servers.Server, method string) (net.Co
 }
 
 // setupClientRpc is used to setup the Client's RPC endpoints
-func (c *Client) setupClientRpc() {
-	// Initialize the RPC handlers
-	c.endpoints.ClientStats = &ClientStats{c}
-	c.endpoints.CSI = &CSI{c}
-	c.endpoints.FileSystem = NewFileSystemEndpoint(c)
-	c.endpoints.Allocations = NewAllocationsEndpoint(c)
-	c.endpoints.Agent = NewAgentEndpoint(c)
-
+func (c *Client) setupClientRpc(rpcs map[string]interface{}) {
 	// Create the RPC Server
 	c.rpcServer = rpc.NewServer()
 
-	// Register the endpoints with the RPC server
-	c.setupClientRpcServer(c.rpcServer)
+	// Initialize the RPC handlers
+	if rpcs != nil {
+		// override RPCs
+		for name, rpc := range rpcs {
+			c.rpcServer.RegisterName(name, rpc)
+		}
+	} else {
+		c.endpoints.ClientStats = &ClientStats{c}
+		c.endpoints.CSI = &CSI{c}
+		c.endpoints.FileSystem = NewFileSystemEndpoint(c)
+		c.endpoints.Allocations = NewAllocationsEndpoint(c)
+		c.endpoints.Agent = NewAgentEndpoint(c)
+		c.setupClientRpcServer(c.rpcServer)
+	}
 
 	go c.rpcConnListener()
 }

--- a/client/testing.go
+++ b/client/testing.go
@@ -2,14 +2,18 @@ package client
 
 import (
 	"fmt"
+	"net"
+	"net/rpc"
 	"time"
 
 	"github.com/hashicorp/nomad/client/config"
 	consulapi "github.com/hashicorp/nomad/client/consul"
 	"github.com/hashicorp/nomad/client/fingerprint"
+	"github.com/hashicorp/nomad/client/servers"
 	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/pluginutils/catalog"
 	"github.com/hashicorp/nomad/helper/pluginutils/singleton"
+	"github.com/hashicorp/nomad/helper/pool"
 	"github.com/hashicorp/nomad/helper/testlog"
 	testing "github.com/mitchellh/go-testing-interface"
 )
@@ -21,6 +25,10 @@ import (
 // and removed in the returned cleanup function. If they are overridden in the
 // callback then the caller still must run the returned cleanup func.
 func TestClient(t testing.T, cb func(c *config.Config)) (*Client, func() error) {
+	return TestClientWithRPCs(t, cb, nil)
+}
+
+func TestClientWithRPCs(t testing.T, cb func(c *config.Config), rpcs map[string]interface{}) (*Client, func() error) {
 	conf, cleanup := config.TestClientConfig(t)
 
 	// Tighten the fingerprinter timeouts (must be done in client package
@@ -46,7 +54,7 @@ func TestClient(t testing.T, cb func(c *config.Config)) (*Client, func() error) 
 	}
 	mockCatalog := agentconsul.NewMockCatalog(logger)
 	mockService := consulapi.NewMockConsulServiceClient(t, logger)
-	client, err := NewClient(conf, mockCatalog, nil, mockService)
+	client, err := NewClient(conf, mockCatalog, nil, mockService, rpcs)
 	if err != nil {
 		cleanup()
 		t.Fatalf("err: %v", err)
@@ -74,4 +82,52 @@ func TestClient(t testing.T, cb func(c *config.Config)) (*Client, func() error) 
 			return fmt.Errorf("timed out while shutting down client")
 		}
 	}
+}
+
+// TestRPCOnlyClient is a client that only pings to establish a connection
+// with the server and then returns mock RPC responses for those interfaces
+// passed in the `rpcs` parameter. Useful for testing client RPCs from the
+// server. Returns the Client, a shutdown function, and any error.
+func TestRPCOnlyClient(t testing.T, srvAddr net.Addr, rpcs map[string]interface{}) (*Client, func() error, error) {
+	var err error
+	conf, cleanup := config.TestClientConfig(t)
+
+	client := &Client{config: conf, logger: testlog.HCLogger(t)}
+	client.servers = servers.New(client.logger, client.shutdownCh, client)
+	client.configCopy = client.config.Copy()
+
+	client.rpcServer = rpc.NewServer()
+	for name, rpc := range rpcs {
+		client.rpcServer.RegisterName(name, rpc)
+	}
+
+	client.connPool = pool.NewPool(testlog.HCLogger(t), 10*time.Second, 10, nil)
+
+	cancelFunc := func() error {
+		ch := make(chan error)
+
+		go func() {
+			defer close(ch)
+			client.connPool.Shutdown()
+			client.shutdownGroup.Wait()
+			cleanup()
+		}()
+
+		select {
+		case <-ch:
+			return nil
+		case <-time.After(1 * time.Minute):
+			return fmt.Errorf("timed out while shutting down client")
+		}
+	}
+
+	go client.rpcConnListener()
+
+	_, err = client.SetServers([]string{srvAddr.String()})
+	if err != nil {
+		return nil, cancelFunc, fmt.Errorf("could not set servers: %v", err)
+	}
+	client.shutdownGroup.Go(client.registerAndHeartbeat)
+
+	return client, cancelFunc, nil
 }

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -857,7 +857,8 @@ func (a *Agent) setupClient() error {
 		conf.StateDBFactory = state.GetStateDBFactory(conf.DevMode)
 	}
 
-	nomadClient, err := client.NewClient(conf, a.consulCatalog, a.consulProxies, a.consulService)
+	nomadClient, err := client.NewClient(
+		conf, a.consulCatalog, a.consulProxies, a.consulService, nil)
 	if err != nil {
 		return fmt.Errorf("client setup failed: %v", err)
 	}


### PR DESCRIPTION
This commit includes a new test client that only implements the RPC protocol
and not any other state. Only the RPCs that are passed in are registered,
which lets you implement a mock RPC in the server tests. This commit includes
an example of this for the ClientCSI RPC server.

This commit has been extracted out of https://github.com/hashicorp/nomad/pull/10185 to make review sizes manageable.