### PR TITLE
docs: Update AWS permission requirements for the Autoscaler

### DIFF
--- a/website/content/docs/autoscaling/plugins/target.mdx
+++ b/website/content/docs/autoscaling/plugins/target.mdx
@@ -152,13 +152,11 @@ below.
       "Sid": "",
       "Effect": "Allow",
       "Action": [
-        "ec2:TerminateInstances",
-        "ec2:DescribeInstanceStatus",
         "autoscaling:UpdateAutoScalingGroup",
-        "autoscaling:DetachInstances",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeAutoScalingGroups",
-        "autoscaling:CreateOrUpdateTags"
+        "autoscaling:CreateOrUpdateTags",
+        "autoscaling:TerminateInstanceInAutoScalingGroup"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
https://github.com/hashicorp/nomad-autoscaler/pull/425 added a requirement for the `autoscaling:TerminateInstanceInAutoScalingGroup` permission.