### PR TITLE
CSI: HTTP handlers for create/delete/list

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -65,6 +65,14 @@ type QueryOptions struct {
 	// AuthToken is the secret ID of an ACL token
 	AuthToken string
 
+	// PerPage is the number of entries to be returned in queries that support
+	// paginated lists.
+	PerPage int32
+
+	// NextToken is the token used indicate where to start paging for queries
+	// that support paginated lists.
+	NextToken string
+
 	// ctx is an optional context pass through to the underlying HTTP
 	// request layer. Use Context() and WithContext() to manage this.
 	ctx context.Context

--- a/api/csi.go
+++ b/api/csi.go
@@ -79,12 +79,14 @@ func (v *CSIVolumes) Deregister(id string, force bool, w *WriteOptions) error {
 	return err
 }
 
-func (v *CSIVolumes) Create(vol *CSIVolume, w *WriteOptions) (*WriteMeta, error) {
+func (v *CSIVolumes) Create(vol *CSIVolume, w *WriteOptions) ([]*CSIVolume, *WriteMeta, error) {
 	req := CSIVolumeCreateRequest{
 		Volumes: []*CSIVolume{vol},
 	}
-	meta, err := v.client.write(fmt.Sprintf("/v1/volume/csi/%v/create", vol.ID), req, nil, w)
-	return meta, err
+
+	resp := &CSIVolumeCreateResponse{}
+	meta, err := v.client.write(fmt.Sprintf("/v1/volume/csi/%v/create", vol.ID), req, resp, w)
+	return resp.Volumes, meta, err
 }
 
 func (v *CSIVolumes) Delete(externalVolID string, w *WriteOptions) error {
@@ -248,6 +250,11 @@ func (v CSIVolumeExternalStubSort) Swap(i, j int) {
 type CSIVolumeCreateRequest struct {
 	Volumes []*CSIVolume
 	WriteRequest
+}
+
+type CSIVolumeCreateResponse struct {
+	Volumes []*CSIVolume
+	QueryMeta
 }
 
 type CSIVolumeRegisterRequest struct {

--- a/api/csi.go
+++ b/api/csi.go
@@ -28,6 +28,28 @@ func (v *CSIVolumes) List(q *QueryOptions) ([]*CSIVolumeListStub, *QueryMeta, er
 	return resp, qm, nil
 }
 
+// List returns all CSI volumes
+func (v *CSIVolumes) ListExternal(pluginID string, q *QueryOptions) (*CSIVolumeListExternalResponse, *QueryMeta, error) {
+	var resp *CSIVolumeListExternalResponse
+
+	qp := url.Values{}
+	qp.Set("plugin_id", pluginID)
+	if q.NextToken != "" {
+		qp.Set("next_token", q.NextToken)
+	}
+	if q.PerPage != 0 {
+		qp.Set("per_page", fmt.Sprint(q.PerPage))
+	}
+
+	qm, err := v.client.query("/v1/volumes/external?"+qp.Encode(), &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sort.Sort(CSIVolumeExternalStubSort(resp.Volumes))
+	return resp, qm, nil
+}
+
 // PluginList returns all CSI volumes for the specified plugin id
 func (v *CSIVolumes) PluginList(pluginID string) ([]*CSIVolumeListStub, *QueryMeta, error) {
 	return v.List(&QueryOptions{Prefix: pluginID})
@@ -54,6 +76,19 @@ func (v *CSIVolumes) Register(vol *CSIVolume, w *WriteOptions) (*WriteMeta, erro
 
 func (v *CSIVolumes) Deregister(id string, force bool, w *WriteOptions) error {
 	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v?force=%t", url.PathEscape(id), force), nil, w)
+	return err
+}
+
+func (v *CSIVolumes) Create(vol *CSIVolume, w *WriteOptions) (*WriteMeta, error) {
+	req := CSIVolumeCreateRequest{
+		Volumes: []*CSIVolume{vol},
+	}
+	meta, err := v.client.write(fmt.Sprintf("/v1/volume/csi/%v/create", vol.ID), req, nil, w)
+	return meta, err
+}
+
+func (v *CSIVolumes) Delete(externalVolID string, w *WriteOptions) error {
+	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v/delete", url.PathEscape(externalVolID)), nil, w)
 	return err
 }
 
@@ -174,6 +209,45 @@ type CSIVolumeListStub struct {
 
 	CreateIndex uint64
 	ModifyIndex uint64
+}
+
+type CSIVolumeListExternalResponse struct {
+	Volumes   []*CSIVolumeExternalStub
+	NextToken string
+}
+
+// CSIVolumeExternalStub is the storage provider's view of a volume, as
+// returned from the controller plugin; all IDs are for external resources
+type CSIVolumeExternalStub struct {
+	ExternalID               string
+	CapacityBytes            int64
+	VolumeContext            map[string]string
+	CloneID                  string
+	SnapshotID               string
+	PublishedExternalNodeIDs []string
+	IsAbnormal               bool
+	Status                   string
+}
+
+// We can't sort external volumes by creation time because we don't get that
+// data back from the storage provider. Sort by External ID within this page.
+type CSIVolumeExternalStubSort []*CSIVolumeExternalStub
+
+func (v CSIVolumeExternalStubSort) Len() int {
+	return len(v)
+}
+
+func (v CSIVolumeExternalStubSort) Less(i, j int) bool {
+	return v[i].ExternalID > v[j].ExternalID
+}
+
+func (v CSIVolumeExternalStubSort) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+type CSIVolumeCreateRequest struct {
+	Volumes []*CSIVolume
+	WriteRequest
 }
 
 type CSIVolumeRegisterRequest struct {

--- a/client/structs/csi.go
+++ b/client/structs/csi.go
@@ -263,6 +263,8 @@ type ClientCSIControllerDeleteVolumeResponse struct{}
 // a Nomad client to tell a CSI controller plugin on that client to perform
 // ListVolumes
 type ClientCSIControllerListVolumesRequest struct {
+	// these pagination fields match the pagination fields of the plugins and
+	// not Nomad's own fields, for clarity when mapping between the two RPCs
 	MaxEntries    int32
 	StartingToken string
 

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -161,13 +161,9 @@ func (s *HTTPServer) csiVolumeRegister(resp http.ResponseWriter, req *http.Reque
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
-	args0 := structs.CSIVolumeRegisterRequest{}
-	if err := decodeBody(req, &args0); err != nil {
+	args := structs.CSIVolumeRegisterRequest{}
+	if err := decodeBody(req, &args); err != nil {
 		return err, CodedError(400, err.Error())
-	}
-
-	args := structs.CSIVolumeRegisterRequest{
-		Volumes: args0.Volumes,
 	}
 	s.parseWriteRequest(req, &args.WriteRequest)
 
@@ -188,13 +184,9 @@ func (s *HTTPServer) csiVolumeCreate(resp http.ResponseWriter, req *http.Request
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
-	args0 := structs.CSIVolumeCreateRequest{}
-	if err := decodeBody(req, &args0); err != nil {
+	args := structs.CSIVolumeCreateRequest{}
+	if err := decodeBody(req, &args); err != nil {
 		return err, CodedError(400, err.Error())
-	}
-
-	args := structs.CSIVolumeCreateRequest{
-		Volumes: args0.Volumes,
 	}
 	s.parseWriteRequest(req, &args.WriteRequest)
 
@@ -205,7 +197,7 @@ func (s *HTTPServer) csiVolumeCreate(resp http.ResponseWriter, req *http.Request
 
 	setMeta(resp, &out.QueryMeta)
 
-	return nil, nil
+	return out, nil
 }
 
 func (s *HTTPServer) csiVolumeDelete(id string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -12,11 +12,28 @@ import (
 func (s *HTTPServer) CSIVolumesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	switch req.Method {
 	case http.MethodPut, http.MethodPost:
-		return s.csiVolumePut(resp, req)
+		return s.csiVolumeRegister(resp, req)
 	case http.MethodGet:
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
+
+	// Tokenize the suffix of the path to get the volume id
+	reqSuffix := strings.TrimPrefix(req.URL.Path, "/v1/volumes")
+	tokens := strings.Split(reqSuffix, "/")
+	if len(tokens) == 2 {
+		if tokens[1] == "external" {
+			return s.csiVolumesListExternal(resp, req)
+		}
+		return nil, CodedError(404, resourceNotFoundErr)
+	} else if len(tokens) > 2 {
+		return nil, CodedError(404, resourceNotFoundErr)
+	}
+
+	return s.csiVolumesList(resp, req)
+}
+
+func (s *HTTPServer) csiVolumesList(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 
 	// Type filters volume lists to a specific type. When support for non-CSI volumes is
 	// introduced, we'll need to dispatch here
@@ -30,20 +47,34 @@ func (s *HTTPServer) CSIVolumesRequest(resp http.ResponseWriter, req *http.Reque
 	}
 
 	args := structs.CSIVolumeListRequest{}
-
 	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
 		return nil, nil
 	}
 
-	if plugin, ok := query["plugin_id"]; ok {
-		args.PluginID = plugin[0]
-	}
-	if node, ok := query["node_id"]; ok {
-		args.NodeID = node[0]
-	}
+	args.PluginID = query.Get("plugin_id")
+	args.NodeID = query.Get("node_id")
 
 	var out structs.CSIVolumeListResponse
 	if err := s.agent.RPC("CSIVolume.List", &args, &out); err != nil {
+		return nil, err
+	}
+
+	setMeta(resp, &out.QueryMeta)
+	return out.Volumes, nil
+}
+
+func (s *HTTPServer) csiVolumesListExternal(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+
+	args := structs.CSIVolumeExternalListRequest{}
+	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
+		return nil, nil
+	}
+
+	query := req.URL.Query()
+	args.PluginID = query.Get("plugin_id")
+
+	var out structs.CSIVolumeExternalListResponse
+	if err := s.agent.RPC("CSIVolume.ListExternal", &args, &out); err != nil {
 		return nil, err
 	}
 
@@ -66,7 +97,7 @@ func (s *HTTPServer) CSIVolumeSpecificRequest(resp http.ResponseWriter, req *htt
 		case http.MethodGet:
 			return s.csiVolumeGet(id, resp, req)
 		case http.MethodPut:
-			return s.csiVolumePut(resp, req)
+			return s.csiVolumeRegister(resp, req)
 		case http.MethodDelete:
 			return s.csiVolumeDelete(id, resp, req)
 		default:
@@ -75,13 +106,21 @@ func (s *HTTPServer) CSIVolumeSpecificRequest(resp http.ResponseWriter, req *htt
 	}
 
 	if len(tokens) == 2 {
-		if tokens[1] != "detach" {
-			return nil, CodedError(404, resourceNotFoundErr)
-		}
-		if req.Method != http.MethodDelete {
+		switch req.Method {
+		case http.MethodPut:
+			if tokens[1] == "create" {
+				return s.csiVolumeCreate(resp, req)
+			}
+		case http.MethodDelete:
+			if tokens[1] == "detach" {
+				return s.csiVolumeDetach(id, resp, req)
+			}
+			if tokens[1] == "delete" {
+				return s.csiVolumeDelete(id, resp, req)
+			}
+		default:
 			return nil, CodedError(405, ErrInvalidMethod)
 		}
-		return s.csiVolumeDetach(id, resp, req)
 	}
 
 	return nil, CodedError(404, resourceNotFoundErr)
@@ -115,7 +154,7 @@ func (s *HTTPServer) csiVolumeGet(id string, resp http.ResponseWriter, req *http
 	return vol, nil
 }
 
-func (s *HTTPServer) csiVolumePut(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+func (s *HTTPServer) csiVolumeRegister(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	switch req.Method {
 	case http.MethodPost, http.MethodPut:
 	default:
@@ -134,6 +173,33 @@ func (s *HTTPServer) csiVolumePut(resp http.ResponseWriter, req *http.Request) (
 
 	var out structs.CSIVolumeRegisterResponse
 	if err := s.agent.RPC("CSIVolume.Register", &args, &out); err != nil {
+		return nil, err
+	}
+
+	setMeta(resp, &out.QueryMeta)
+
+	return nil, nil
+}
+
+func (s *HTTPServer) csiVolumeCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	switch req.Method {
+	case http.MethodPost, http.MethodPut:
+	default:
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+	args0 := structs.CSIVolumeCreateRequest{}
+	if err := decodeBody(req, &args0); err != nil {
+		return err, CodedError(400, err.Error())
+	}
+
+	args := structs.CSIVolumeCreateRequest{
+		Volumes: args0.Volumes,
+	}
+	s.parseWriteRequest(req, &args.WriteRequest)
+
+	var out structs.CSIVolumeCreateResponse
+	if err := s.agent.RPC("CSIVolume.Create", &args, &out); err != nil {
 		return nil, err
 	}
 

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -688,7 +688,23 @@ func (s *HTTPServer) parse(resp http.ResponseWriter, req *http.Request, r *strin
 	parseConsistency(req, b)
 	parsePrefix(req, b)
 	parseNamespace(req, &b.Namespace)
+	parsePagination(req, b)
 	return parseWait(resp, req, b)
+}
+
+// parsePagination parses the pagination fields for QueryOptions
+func parsePagination(req *http.Request, b *structs.QueryOptions) {
+	query := req.URL.Query()
+	rawPerPage := query.Get("per_page")
+	if rawPerPage != "" {
+		perPage, err := strconv.Atoi(rawPerPage)
+		if err == nil {
+			b.PerPage = int32(perPage)
+		}
+	}
+
+	nextToken := query.Get("next_token")
+	b.NextToken = nextToken
 }
 
 // parseWriteRequest is a convenience method for endpoints that need to parse a

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -564,6 +564,49 @@ func TestParseBool(t *testing.T) {
 	}
 }
 
+func TestParsePagination(t *testing.T) {
+	t.Parallel()
+	s := makeHTTPServer(t, nil)
+	defer s.Shutdown()
+
+	cases := []struct {
+		Input             string
+		ExpectedNextToken string
+		ExpectedPerPage   int32
+	}{
+		{
+			Input: "",
+		},
+		{
+			Input:             "next_token=a&per_page=3",
+			ExpectedNextToken: "a",
+			ExpectedPerPage:   3,
+		},
+		{
+			Input:             "next_token=a&next_token=b",
+			ExpectedNextToken: "a",
+		},
+		{
+			Input: "per_page=a",
+		},
+	}
+
+	for i := range cases {
+		tc := cases[i]
+		t.Run("Input-"+tc.Input, func(t *testing.T) {
+
+			req, err := http.NewRequest("GET",
+				"/v1/volumes/csi/external?"+tc.Input, nil)
+
+			require.NoError(t, err)
+			opts := &structs.QueryOptions{}
+			parsePagination(req, opts)
+			require.Equal(t, tc.ExpectedNextToken, opts.NextToken)
+			require.Equal(t, tc.ExpectedPerPage, opts.PerPage)
+		})
+	}
+}
+
 // TestHTTP_VerifyHTTPSClient asserts that a client certificate signed by the
 // appropriate CA is required when VerifyHTTPSClient=true.
 func TestHTTP_VerifyHTTPSClient(t *testing.T) {

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -1016,8 +1016,8 @@ func (v *CSIVolume) ListExternal(args *structs.CSIVolumeExternalListRequest, rep
 
 	method := "ClientCSI.ControllerListVolumes"
 	cReq := &cstructs.ClientCSIControllerListVolumesRequest{
-		MaxEntries:    args.MaxEntries,
-		StartingToken: args.StartingToken,
+		MaxEntries:    args.PerPage,
+		StartingToken: args.NextToken,
 	}
 	cReq.PluginID = plugin.ID
 	cResp := &cstructs.ClientCSIControllerListVolumesResponse{}
@@ -1026,8 +1026,8 @@ func (v *CSIVolume) ListExternal(args *structs.CSIVolumeExternalListRequest, rep
 	if err != nil {
 		return err
 	}
-	if args.MaxEntries > 0 {
-		reply.Volumes = cResp.Entries[:args.MaxEntries]
+	if args.PerPage > 0 {
+		reply.Volumes = cResp.Entries[:args.PerPage]
 	} else {
 		reply.Volumes = cResp.Entries
 	}

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -875,6 +875,7 @@ func (v *CSIVolume) Create(args *structs.CSIVolumeCreateRequest, reply *structs.
 		return err
 	}
 
+	reply.Volumes = regArgs.Volumes
 	reply.Index = index
 	v.srv.setQueryMeta(&reply.QueryMeta)
 	return nil

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -985,11 +985,11 @@ func TestCSIVolumeEndpoint_ListExternal(t *testing.T) {
 	// List external volumes; note that none of these exist in the state store
 
 	req := &structs.CSIVolumeExternalListRequest{
-		MaxEntries:    2,
-		StartingToken: "page1",
 		QueryOptions: structs.QueryOptions{
 			Region:    "global",
 			Namespace: structs.DefaultNamespace,
+			PerPage:   2,
+			NextToken: "page1",
 		},
 	}
 	resp := &structs.CSIVolumeExternalListResponse{}

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -740,11 +740,10 @@ type CSIVolumeListResponse struct {
 
 // CSIVolumeExternalListRequest is a request to a controller plugin to list
 // all the volumes known to the the storage provider. This request is
-// paginated by the plugin.
+// paginated by the plugin and accepts the QueryOptions.PerPage and
+// QueryOptions.NextToken fields
 type CSIVolumeExternalListRequest struct {
-	PluginID      string
-	MaxEntries    int32
-	StartingToken string
+	PluginID string
 	QueryOptions
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -291,6 +291,14 @@ type QueryOptions struct {
 	// AuthToken is secret portion of the ACL token used for the request
 	AuthToken string
 
+	// PerPage is the number of entries to be returned in queries that support
+	// paginated lists.
+	PerPage int32
+
+	// NextToken is the token used indicate where to start paging for queries
+	// that support paginated lists.
+	NextToken string
+
 	InternalRpcInfo
 }
 

--- a/vendor/github.com/hashicorp/nomad/api/api.go
+++ b/vendor/github.com/hashicorp/nomad/api/api.go
@@ -65,6 +65,14 @@ type QueryOptions struct {
 	// AuthToken is the secret ID of an ACL token
 	AuthToken string
 
+	// PerPage is the number of entries to be returned in queries that support
+	// paginated lists.
+	PerPage int32
+
+	// NextToken is the token used indicate where to start paging for queries
+	// that support paginated lists.
+	NextToken string
+
 	// ctx is an optional context pass through to the underlying HTTP
 	// request layer. Use Context() and WithContext() to manage this.
 	ctx context.Context

--- a/vendor/github.com/hashicorp/nomad/api/csi.go
+++ b/vendor/github.com/hashicorp/nomad/api/csi.go
@@ -79,12 +79,14 @@ func (v *CSIVolumes) Deregister(id string, force bool, w *WriteOptions) error {
 	return err
 }
 
-func (v *CSIVolumes) Create(vol *CSIVolume, w *WriteOptions) (*WriteMeta, error) {
+func (v *CSIVolumes) Create(vol *CSIVolume, w *WriteOptions) ([]*CSIVolume, *WriteMeta, error) {
 	req := CSIVolumeCreateRequest{
 		Volumes: []*CSIVolume{vol},
 	}
-	meta, err := v.client.write(fmt.Sprintf("/v1/volume/csi/%v/create", vol.ID), req, nil, w)
-	return meta, err
+
+	resp := &CSIVolumeCreateResponse{}
+	meta, err := v.client.write(fmt.Sprintf("/v1/volume/csi/%v/create", vol.ID), req, resp, w)
+	return resp.Volumes, meta, err
 }
 
 func (v *CSIVolumes) Delete(externalVolID string, w *WriteOptions) error {
@@ -248,6 +250,11 @@ func (v CSIVolumeExternalStubSort) Swap(i, j int) {
 type CSIVolumeCreateRequest struct {
 	Volumes []*CSIVolume
 	WriteRequest
+}
+
+type CSIVolumeCreateResponse struct {
+	Volumes []*CSIVolume
+	QueryMeta
 }
 
 type CSIVolumeRegisterRequest struct {

--- a/vendor/github.com/hashicorp/nomad/api/csi.go
+++ b/vendor/github.com/hashicorp/nomad/api/csi.go
@@ -28,6 +28,28 @@ func (v *CSIVolumes) List(q *QueryOptions) ([]*CSIVolumeListStub, *QueryMeta, er
 	return resp, qm, nil
 }
 
+// List returns all CSI volumes
+func (v *CSIVolumes) ListExternal(pluginID string, q *QueryOptions) (*CSIVolumeListExternalResponse, *QueryMeta, error) {
+	var resp *CSIVolumeListExternalResponse
+
+	qp := url.Values{}
+	qp.Set("plugin_id", pluginID)
+	if q.NextToken != "" {
+		qp.Set("next_token", q.NextToken)
+	}
+	if q.PerPage != 0 {
+		qp.Set("per_page", fmt.Sprint(q.PerPage))
+	}
+
+	qm, err := v.client.query("/v1/volumes/external?"+qp.Encode(), &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sort.Sort(CSIVolumeExternalStubSort(resp.Volumes))
+	return resp, qm, nil
+}
+
 // PluginList returns all CSI volumes for the specified plugin id
 func (v *CSIVolumes) PluginList(pluginID string) ([]*CSIVolumeListStub, *QueryMeta, error) {
 	return v.List(&QueryOptions{Prefix: pluginID})
@@ -54,6 +76,19 @@ func (v *CSIVolumes) Register(vol *CSIVolume, w *WriteOptions) (*WriteMeta, erro
 
 func (v *CSIVolumes) Deregister(id string, force bool, w *WriteOptions) error {
 	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v?force=%t", url.PathEscape(id), force), nil, w)
+	return err
+}
+
+func (v *CSIVolumes) Create(vol *CSIVolume, w *WriteOptions) (*WriteMeta, error) {
+	req := CSIVolumeCreateRequest{
+		Volumes: []*CSIVolume{vol},
+	}
+	meta, err := v.client.write(fmt.Sprintf("/v1/volume/csi/%v/create", vol.ID), req, nil, w)
+	return meta, err
+}
+
+func (v *CSIVolumes) Delete(externalVolID string, w *WriteOptions) error {
+	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v/delete", url.PathEscape(externalVolID)), nil, w)
 	return err
 }
 
@@ -174,6 +209,45 @@ type CSIVolumeListStub struct {
 
 	CreateIndex uint64
 	ModifyIndex uint64
+}
+
+type CSIVolumeListExternalResponse struct {
+	Volumes   []*CSIVolumeExternalStub
+	NextToken string
+}
+
+// CSIVolumeExternalStub is the storage provider's view of a volume, as
+// returned from the controller plugin; all IDs are for external resources
+type CSIVolumeExternalStub struct {
+	ExternalID               string
+	CapacityBytes            int64
+	VolumeContext            map[string]string
+	CloneID                  string
+	SnapshotID               string
+	PublishedExternalNodeIDs []string
+	IsAbnormal               bool
+	Status                   string
+}
+
+// We can't sort external volumes by creation time because we don't get that
+// data back from the storage provider. Sort by External ID within this page.
+type CSIVolumeExternalStubSort []*CSIVolumeExternalStub
+
+func (v CSIVolumeExternalStubSort) Len() int {
+	return len(v)
+}
+
+func (v CSIVolumeExternalStubSort) Less(i, j int) bool {
+	return v[i].ExternalID > v[j].ExternalID
+}
+
+func (v CSIVolumeExternalStubSort) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+type CSIVolumeCreateRequest struct {
+	Volumes []*CSIVolume
+	WriteRequest
 }
 
 type CSIVolumeRegisterRequest struct {


### PR DESCRIPTION
Implementation of the `CreateVolume`, `DeleteVolume`, and `ListExternalVolume` HTTP endpoints for CSI.

Notes for reviewers:
* Note there are no CLI commits; those will be handled in the next PR but I've got https://github.com/hashicorp/nomad/pull/10211 that uses this API so I feel comfortable with the "shape".
* HTTP API docs will be in a separate PR
* This PR is targeting the `csi-create-volume` branch: https://github.com/hashicorp/nomad/pull/10165, which has the RPCs already merged in.