### PR TITLE
CSI: CLI for create/delete/list 

### DIFF
--- a/api/csi.go
+++ b/api/csi.go
@@ -134,23 +134,23 @@ type CSISecrets map[string]string
 type CSIVolume struct {
 	ID             string
 	Name           string
-	ExternalID     string `hcl:"external_id"`
+	ExternalID     string `mapstructure:"external_id" hcl:"external_id"`
 	Namespace      string
 	Topologies     []*CSITopology
 	AccessMode     CSIVolumeAccessMode     `hcl:"access_mode"`
 	AttachmentMode CSIVolumeAttachmentMode `hcl:"attachment_mode"`
 	MountOptions   *CSIMountOptions        `hcl:"mount_options"`
-	Secrets        CSISecrets              `hcl:"secrets"`
-	Parameters     map[string]string       `hcl:"parameters"`
-	Context        map[string]string       `hcl:"context"`
+	Secrets        CSISecrets              `mapstructure:"secrets" hcl:"secrets"`
+	Parameters     map[string]string       `mapstructure:"parameters" hcl:"parameters"`
+	Context        map[string]string       `mapstructure:"context" hcl:"context"`
 	Capacity       int64                   `hcl:"-"`
 
 	// These fields are used as part of the volume creation request
 	RequestedCapacityMin  int64                  `hcl:"capacity_min"`
 	RequestedCapacityMax  int64                  `hcl:"capacity_max"`
 	RequestedCapabilities []*CSIVolumeCapability `hcl:"capability"`
-	CloneID               string                 `hcl:"clone_id"`
-	SnapshotID            string                 `hcl:"snapshot_id"`
+	CloneID               string                 `mapstructure:"clone_id" hcl:"clone_id"`
+	SnapshotID            string                 `mapstructure:"snapshot_id" hcl:"snapshot_id"`
 
 	// ReadAllocs is a map of allocation IDs for tracking reader claim status.
 	// The Allocation value will always be nil; clients can populate this data
@@ -167,7 +167,7 @@ type CSIVolume struct {
 
 	// Schedulable is true if all the denormalized plugin health fields are true
 	Schedulable         bool
-	PluginID            string `hcl:"plugin_id"`
+	PluginID            string `mapstructure:"plugin_id" hcl:"plugin_id"`
 	Provider            string
 	ProviderVersion     string
 	ControllerRequired  bool
@@ -187,8 +187,8 @@ type CSIVolume struct {
 // CSIVolumeCapability is a requested attachment and access mode for a
 // volume
 type CSIVolumeCapability struct {
-	AccessMode     CSIVolumeAccessMode     `hcl:"access_mode"`
-	AttachmentMode CSIVolumeAttachmentMode `hcl:"attachment_mode"`
+	AccessMode     CSIVolumeAccessMode     `mapstructure:"access_mode" hcl:"access_mode"`
+	AttachmentMode CSIVolumeAttachmentMode `mapstructure:"attachment_mode" hcl:"attachment_mode"`
 }
 
 type CSIVolumeIndexSort []*CSIVolumeListStub

--- a/command/commands.go
+++ b/command/commands.go
@@ -821,6 +821,16 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"volume create": func() (cli.Command, error) {
+			return &VolumeCreateCommand{
+				Meta: meta,
+			}, nil
+		},
+		"volume delete": func() (cli.Command, error) {
+			return &VolumeDeleteCommand{
+				Meta: meta,
+			}, nil
+		},
 	}
 
 	deprecated := map[string]cli.CommandFactory{

--- a/command/volume.go
+++ b/command/volume.go
@@ -32,6 +32,14 @@ Usage: nomad volume <subcommand> [options]
 
       $ nomad volume detach <vol id> <node id>
 
+  Create an external volume and register it:
+
+      $ nomad volume create <input>
+
+  Delete an external volume and deregister it:
+
+      $ nomad volume delete <external id>
+
   Please see the individual subcommand help for detailed usage information.
 `
 	return strings.TrimSpace(helpText)

--- a/command/volume_create.go
+++ b/command/volume_create.go
@@ -1,0 +1,105 @@
+package command
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/posener/complete"
+)
+
+type VolumeCreateCommand struct {
+	Meta
+}
+
+func (c *VolumeCreateCommand) Help() string {
+	helpText := `
+Usage: nomad volume create [options] <input>
+
+  Creates a volume in an external storage provider and registers it in Nomad.
+
+  If the supplied path is "-" the volume file is read from stdin. Otherwise, it
+  is read from the file at the supplied path.
+
+  When ACLs are enabled, this command requires a token with the
+  'csi-write-volume' capability for the volume's namespace.
+
+General Options:
+
+  ` + generalOptionsUsage(usageOptsDefault)
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *VolumeCreateCommand) AutocompleteFlags() complete.Flags {
+	return c.Meta.AutocompleteFlags(FlagSetClient)
+}
+
+func (c *VolumeCreateCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFiles("*")
+}
+
+func (c *VolumeCreateCommand) Synopsis() string {
+	return "Create an external volume"
+}
+
+func (c *VolumeCreateCommand) Name() string { return "volume create" }
+
+func (c *VolumeCreateCommand) Run(args []string) int {
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error parsing arguments %s", err))
+		return 1
+	}
+
+	// Check that we get exactly one argument
+	args = flags.Args()
+	if l := len(args); l != 1 {
+		c.Ui.Error("This command takes one argument: <input>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+
+	// Read the file contents
+	file := args[0]
+	var rawVolume []byte
+	var err error
+	if file == "-" {
+		rawVolume, err = ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Failed to read stdin: %v", err))
+			return 1
+		}
+	} else {
+		rawVolume, err = ioutil.ReadFile(file)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Failed to read file: %v", err))
+			return 1
+		}
+	}
+
+	ast, volType, err := parseVolumeType(string(rawVolume))
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error parsing the volume type: %s", err))
+		return 1
+	}
+
+	// Get the HTTP client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	switch strings.ToLower(volType) {
+	case "csi":
+		code := c.csiCreate(client, ast)
+		return code
+	default:
+		c.Ui.Error(fmt.Sprintf("Error unknown volume type: %s", volType))
+		return 1
+	}
+}

--- a/command/volume_create_csi.go
+++ b/command/volume_create_csi.go
@@ -1,0 +1,29 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/hashicorp/nomad/api"
+)
+
+func (c *VolumeCreateCommand) csiCreate(client *api.Client, ast *ast.File) int {
+	vol, err := csiDecodeVolume(ast)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error decoding the volume definition: %s", err))
+		return 1
+	}
+
+	vols, _, err := client.CSIVolumes().Create(vol, nil)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error creating volume: %s", err))
+		return 1
+	}
+	for _, vol := range vols {
+		// note: the command only ever returns 1 volume from the API
+		c.Ui.Output(fmt.Sprintf(
+			"Created external volume %s with ID %s", vol.ExternalID, vol.ID))
+	}
+
+	return 0
+}

--- a/command/volume_delete.go
+++ b/command/volume_delete.go
@@ -1,0 +1,102 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
+)
+
+type VolumeDeleteCommand struct {
+	Meta
+}
+
+func (c *VolumeDeleteCommand) Help() string {
+	helpText := `
+Usage: nomad volume delete [options] <vol id>
+
+  Delete a volume from an external storage provider. The volume must still be
+  registered with Nomad in order to be deleted. Deleting will fail if the
+  volume is still in use by an allocation or in the process of being
+  unpublished. If the volume no longer exists, this command will silently
+  return without an error.
+
+  When ACLs are enabled, this command requires a token with the
+  'csi-write-volume' and 'csi-read-volume' capabilities for the volume's
+  namespace.
+
+General Options:
+
+  ` + generalOptionsUsage(usageOptsDefault) + `
+
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *VolumeDeleteCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{})
+}
+
+func (c *VolumeDeleteCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFunc(func(a complete.Args) []string {
+		client, err := c.Meta.Client()
+		if err != nil {
+			return nil
+		}
+
+		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Volumes, nil)
+		if err != nil {
+			return []string{}
+		}
+		matches := resp.Matches[contexts.Volumes]
+
+		resp, _, err = client.Search().PrefixSearch(a.Last, contexts.Nodes, nil)
+		if err != nil {
+			return []string{}
+		}
+		matches = append(matches, resp.Matches[contexts.Nodes]...)
+		return matches
+	})
+}
+
+func (c *VolumeDeleteCommand) Synopsis() string {
+	return "Delete a volume"
+}
+
+func (c *VolumeDeleteCommand) Name() string { return "volume delete" }
+
+func (c *VolumeDeleteCommand) Run(args []string) int {
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error parsing arguments %s", err))
+		return 1
+	}
+
+	// Check that we get exactly two arguments
+	args = flags.Args()
+	if l := len(args); l != 1 {
+		c.Ui.Error("This command takes one argument: <vol id>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+	volID := args[0]
+
+	// Get the HTTP client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	err = client.CSIVolumes().Delete(volID, nil)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error deleting volume: %s", err))
+		return 1
+	}
+
+	return 0
+}

--- a/command/volume_init.go
+++ b/command/volume_init.go
@@ -105,23 +105,59 @@ func (c *VolumeInitCommand) Run(args []string) int {
 }
 
 var defaultHclVolumeSpec = strings.TrimSpace(`
-id              = "ebs_prod_db1"
-name            = "database"
-type            = "csi"
-external_id     = "vol-23452345"
-access_mode     = "single-node-writer"
-attachment_mode = "file-system"
+id        = "ebs_prod_db1"
+name      = "database"
+type      = "csi"
+plugin_id = "plugin_id"
 
+# For 'nomad volume register', provide the external ID from the storage
+# provider. This field should be omitted when creating a volume with
+# 'nomad volume create'
+external_id = "vol-23452345"
+
+# For 'nomad volume create', specify a snapshot ID or volume to clone. You can
+# specify only one of these two fields.
+snapshot_id = "snap-12345"
+# clone_id    = "vol-abcdef"
+
+# Optional: for 'nomad volume create', specify a maximum and minimum capacity.
+# Registering an existing volume will record but ignore these fields.
+capacity_min = "10GiB"
+capacity_max = "20G"
+
+# Optional: for 'nomad volume create', specify one or more capabilities to
+# validate. Registering an existing volume will record but ignore these fields.
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}
+
+capability {
+  access_mode     = "single-node-reader"
+  attachment_mode = "block-device"
+}
+
+# Optional: for 'nomad volume create', specify mount options to
+# validate. Registering an existing volume will record but ignore these
+# fields.
 mount_options {
   fs_type     = "ext4"
   mount_flags = ["ro"]
 }
+
+# Optional: provide any secrets specified by the plugin.
 secrets {
   example_secret = "xyzzy"
 }
+
+# Optional: provide a map of keys to string values expected by the plugin.
 parameters {
   skuname = "Premium_LRS"
 }
+
+# Optional: for 'nomad volume register', provide a map of keys to string
+# values expected by the plugin. This field will populated automatically by
+# 'nomad volume create'.
 context {
   endpoint = "http://192.168.1.101:9425"
 }
@@ -132,23 +168,43 @@ var defaultJsonVolumeSpec = strings.TrimSpace(`
   "id": "ebs_prod_db1",
   "name": "database",
   "type": "csi",
+  "plugin_id": "plugin_id",
   "external_id": "vol-23452345",
-  "access_mode": "single-node-writer",
-  "attachment_mode": "file-system",
-  "mount_options": {
-    "fs_type": "ext4",
-    "mount_flags": [
-      "ro"
-    ]
-  },
-  "secrets": {
-    "example_secret": "xyzzy"
-  },
-  "parameters": {
-    "skuname": "Premium_LRS"
-  },
-  "context": {
-    "endpoint": "http://192.168.1.101:9425"
-  }
+  "snapshot_id": "snap-12345",
+  "capacity_min": "10GiB",
+  "capacity_max": "20G",
+  "capability": [
+    {
+      "access_mode": "single-node-writer",
+      "attachment_mode": "file-system"
+    },
+    {
+      "access_mode": "single-node-reader",
+      "attachment_mode": "block-device"
+    }
+  ],
+  "context": [
+    {
+      "endpoint": "http://192.168.1.101:9425"
+    }
+  ],
+  "mount_options": [
+    {
+      "fs_type": "ext4",
+      "mount_flags": [
+        "ro"
+      ]
+    }
+  ],
+  "parameters": [
+    {
+      "skuname": "Premium_LRS"
+    }
+  ],
+  "secrets": [
+    {
+      "example_secret": "xyzzy"
+    }
+  ]
 }
 `)

--- a/command/volume_register_csi.go
+++ b/command/volume_register_csi.go
@@ -2,11 +2,14 @@ package command
 
 import (
 	"fmt"
+	"strings"
 
+	humanize "github.com/dustin/go-humanize"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/mitchellh/mapstructure"
 )
 
 func (c *VolumeRegisterCommand) csiRegister(client *api.Client, ast *ast.File) int {
@@ -24,21 +27,111 @@ func (c *VolumeRegisterCommand) csiRegister(client *api.Client, ast *ast.File) i
 	return 0
 }
 
-// parseVolume is used to parse the quota specification from HCL
 func csiDecodeVolume(input *ast.File) (*api.CSIVolume, error) {
-	output := &api.CSIVolume{}
-	err := hcl.DecodeObject(output, input)
+	var err error
+	vol := &api.CSIVolume{}
+
+	list, ok := input.Node.(*ast.ObjectList)
+	if !ok {
+		return nil, fmt.Errorf("error parsing: root should be an object")
+	}
+
+	// Decode the full thing into a map[string]interface for ease
+	var m map[string]interface{}
+	err = hcl.DecodeObject(&m, list)
 	if err != nil {
 		return nil, err
 	}
 
-	// api.CSIVolume doesn't have the type field, it's used only for dispatch in
-	// parseVolumeType
-	helper.RemoveEqualFold(&output.ExtraKeysHCL, "type")
-	err = helper.UnusedKeys(output)
+	// Need to manually parse these fields
+	delete(m, "capability")
+	delete(m, "mount_options")
+	delete(m, "capacity_max")
+	delete(m, "capacity_min")
+	delete(m, "type")
+
+	// Decode the rest
+	err = mapstructure.WeakDecode(m, vol)
 	if err != nil {
 		return nil, err
 	}
 
-	return output, nil
+	capacityMin, err := parseCapacityBytes(list.Filter("capacity_min"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid capacity_min: %v", err)
+	}
+	vol.RequestedCapacityMin = capacityMin
+	capacityMax, err := parseCapacityBytes(list.Filter("capacity_max"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid capacity_max: %v", err)
+	}
+	vol.RequestedCapacityMax = capacityMax
+
+	capObj := list.Filter("capability")
+	if len(capObj.Items) > 0 {
+
+		for _, o := range capObj.Elem().Items {
+			valid := []string{"access_mode", "attachment_mode"}
+			if err := helper.CheckHCLKeys(o.Val, valid); err != nil {
+				return nil, err
+			}
+
+			ot, ok := o.Val.(*ast.ObjectType)
+			if !ok {
+				break
+			}
+
+			var m map[string]interface{}
+			if err := hcl.DecodeObject(&m, ot.List); err != nil {
+				return nil, err
+			}
+			var cap *api.CSIVolumeCapability
+			if err := mapstructure.WeakDecode(&m, &cap); err != nil {
+				return nil, err
+			}
+
+			vol.RequestedCapabilities = append(vol.RequestedCapabilities, cap)
+		}
+	}
+
+	mObj := list.Filter("mount_options")
+	if len(mObj.Items) > 0 {
+
+		for _, o := range mObj.Elem().Items {
+			valid := []string{"fs_type", "mount_flags"}
+			if err := helper.CheckHCLKeys(o.Val, valid); err != nil {
+				return nil, err
+			}
+
+			ot, ok := o.Val.(*ast.ObjectType)
+			if !ok {
+				break
+			}
+			var opts *api.CSIMountOptions
+			if err := hcl.DecodeObject(&opts, ot.List); err != nil {
+				return nil, err
+			}
+			vol.MountOptions = opts
+			break
+		}
+	}
+
+	return vol, nil
+}
+
+func parseCapacityBytes(cap *ast.ObjectList) (int64, error) {
+	if len(cap.Items) > 0 {
+		for _, o := range cap.Elem().Items {
+			lit, ok := o.Val.(*ast.LiteralType)
+			if !ok {
+				break
+			}
+			b, err := humanize.ParseBytes(strings.Trim(lit.Token.Text, "\""))
+			if err != nil {
+				return 0, fmt.Errorf("could not parse value as bytes: %v", err)
+			}
+			return int64(b), err
+		}
+	}
+	return 0, fmt.Errorf("could not parse value as bytes")
 }

--- a/command/volume_register_test.go
+++ b/command/volume_register_test.go
@@ -42,60 +42,90 @@ rando = "bar"
 	}
 }
 
-func TestCSIVolumeParse(t *testing.T) {
+func TestCSIVolumeDecode(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		hcl string
-		q   *api.CSIVolume
-		err string
+		name     string
+		hcl      string
+		expected *api.CSIVolume
+		err      string
 	}{{
+		name: "typical volume",
 		hcl: `
-id = "foo"
-type = "csi"
-namespace = "n"
-access_mode = "single-node-writer"
-attachment_mode = "file-system"
-plugin_id = "p"
+id              = "testvolume"
+name            = "test"
+type            = "csi"
+plugin_id       = "myplugin"
+
+capacity_min = "10 MiB"
+capacity_max = "1G"
+snapshot_id  = "snap-12345"
+
+mount_options {
+  fs_type     = "ext4"
+  mount_flags = ["ro"]
+}
+
 secrets {
-  mysecret = "secretvalue"
+  password = "xyzzy"
+}
+
+parameters {
+  skuname = "Premium_LRS"
+}
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}
+
+capability {
+  access_mode     = "single-node-reader-only"
+  attachment_mode = "block-device"
 }
 `,
-		q: &api.CSIVolume{
-			ID:             "foo",
-			Namespace:      "n",
-			AccessMode:     "single-node-writer",
-			AttachmentMode: "file-system",
-			PluginID:       "p",
-			Secrets:        api.CSISecrets{"mysecret": "secretvalue"},
+		expected: &api.CSIVolume{
+			ID:                   "testvolume",
+			Name:                 "test",
+			PluginID:             "myplugin",
+			SnapshotID:           "snap-12345",
+			RequestedCapacityMin: 10485760,
+			RequestedCapacityMax: 1000000000,
+			RequestedCapabilities: []*api.CSIVolumeCapability{
+				{
+					AccessMode:     api.CSIVolumeAccessModeSingleNodeWriter,
+					AttachmentMode: api.CSIVolumeAttachmentModeFilesystem,
+				},
+				{
+					AccessMode:     api.CSIVolumeAccessModeSingleNodeReader,
+					AttachmentMode: api.CSIVolumeAttachmentModeBlockDevice,
+				},
+			},
+			MountOptions: &api.CSIMountOptions{
+				FSType:     "ext4",
+				MountFlags: []string{"ro"},
+			},
+			Parameters: map[string]string{"skuname": "Premium_LRS"},
+			Secrets:    map[string]string{"password": "xyzzy"},
 		},
 		err: "",
-	}, {
-		hcl: `
-{"id": "foo", "namespace": "n", "type": "csi", "access_mode": "single-node-writer", "attachment_mode": "file-system",
-"plugin_id": "p"}
-`,
-		q: &api.CSIVolume{
-			ID:             "foo",
-			Namespace:      "n",
-			AccessMode:     "single-node-writer",
-			AttachmentMode: "file-system",
-			PluginID:       "p",
-		},
-		err: "",
-	}}
+	},
+	}
 
 	for _, c := range cases {
-		t.Run(c.hcl, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			ast, err := hcl.ParseString(c.hcl)
 			require.NoError(t, err)
 			vol, err := csiDecodeVolume(ast)
-			require.Equal(t, c.q, vol)
 			if c.err == "" {
 				require.NoError(t, err)
 			} else {
 				require.Contains(t, err.Error(), c.err)
 			}
+			require.Equal(t, c.expected, vol)
+
 		})
+
 	}
 }

--- a/vendor/github.com/hashicorp/nomad/api/csi.go
+++ b/vendor/github.com/hashicorp/nomad/api/csi.go
@@ -134,23 +134,23 @@ type CSISecrets map[string]string
 type CSIVolume struct {
 	ID             string
 	Name           string
-	ExternalID     string `hcl:"external_id"`
+	ExternalID     string `mapstructure:"external_id" hcl:"external_id"`
 	Namespace      string
 	Topologies     []*CSITopology
 	AccessMode     CSIVolumeAccessMode     `hcl:"access_mode"`
 	AttachmentMode CSIVolumeAttachmentMode `hcl:"attachment_mode"`
 	MountOptions   *CSIMountOptions        `hcl:"mount_options"`
-	Secrets        CSISecrets              `hcl:"secrets"`
-	Parameters     map[string]string       `hcl:"parameters"`
-	Context        map[string]string       `hcl:"context"`
+	Secrets        CSISecrets              `mapstructure:"secrets" hcl:"secrets"`
+	Parameters     map[string]string       `mapstructure:"parameters" hcl:"parameters"`
+	Context        map[string]string       `mapstructure:"context" hcl:"context"`
 	Capacity       int64                   `hcl:"-"`
 
 	// These fields are used as part of the volume creation request
 	RequestedCapacityMin  int64                  `hcl:"capacity_min"`
 	RequestedCapacityMax  int64                  `hcl:"capacity_max"`
 	RequestedCapabilities []*CSIVolumeCapability `hcl:"capability"`
-	CloneID               string                 `hcl:"clone_id"`
-	SnapshotID            string                 `hcl:"snapshot_id"`
+	CloneID               string                 `mapstructure:"clone_id" hcl:"clone_id"`
+	SnapshotID            string                 `mapstructure:"snapshot_id" hcl:"snapshot_id"`
 
 	// ReadAllocs is a map of allocation IDs for tracking reader claim status.
 	// The Allocation value will always be nil; clients can populate this data
@@ -167,7 +167,7 @@ type CSIVolume struct {
 
 	// Schedulable is true if all the denormalized plugin health fields are true
 	Schedulable         bool
-	PluginID            string `hcl:"plugin_id"`
+	PluginID            string `mapstructure:"plugin_id" hcl:"plugin_id"`
 	Provider            string
 	ProviderVersion     string
 	ControllerRequired  bool
@@ -187,8 +187,8 @@ type CSIVolume struct {
 // CSIVolumeCapability is a requested attachment and access mode for a
 // volume
 type CSIVolumeCapability struct {
-	AccessMode     CSIVolumeAccessMode     `hcl:"access_mode"`
-	AttachmentMode CSIVolumeAttachmentMode `hcl:"attachment_mode"`
+	AccessMode     CSIVolumeAccessMode     `mapstructure:"access_mode" hcl:"access_mode"`
+	AttachmentMode CSIVolumeAttachmentMode `mapstructure:"attachment_mode" hcl:"attachment_mode"`
 }
 
 type CSIVolumeIndexSort []*CSIVolumeListStub

--- a/website/content/docs/commands/volume/create.mdx
+++ b/website/content/docs/commands/volume/create.mdx
@@ -98,28 +98,34 @@ context {
   volume. If omitted, the volume will be created from scratch. The
   `clone_id` cannot be set if the `snapshot_id` field is set.
 
-- `capacity` - Options for setting the capacity. Not all options are supported
-  by all storage providers.
+- `capacity_min` `(string: <optional>)` - Option for setting the capacity. The
+  volume must be at least this large, in bytes. The storage provider may
+  return a volume that is larger than this value. Accepts human-friendly
+  suffixes such as `"100GiB"`. This field may not be supported by all
+  storage providers.
 
-  - `required` `(string: <optional>)` - The volume must be at least this
-    large, in bytes. The storage provider may return a volume that is larger
-    than this value. Accepts human-friendly suffixes such as `"100GiB"`.
-  - `limit` `(string: <optional>)` - The volume must be no more than this
-    large, in bytes. The storage provider may return a volume that is smaller
-    than this value. Accepts human-friendly suffixes such as `"100GiB"`.
+- `capacity_max` `(string: <optional>)` - Option for setting the capacity. The
+  volume must be no more than this large, in bytes. The storage provider may
+  return a volume that is smaller than this value. Accepts human-friendly
+  suffixes such as `"100GiB"`. This field may not be supported by all
+  storage providers.
 
-- `access_mode` `(string: <required>)` - Defines whether a volume should be
-  available concurrently. Can be one of `"single-node-reader-only"`,
-  `"single-node-writer"`, `"multi-node-reader-only"`,
-  `"multi-node-single-writer"`, or `"multi-node-multi-writer"`. Most CSI
-  plugins support only single-node modes. Consult the documentation of the
-  storage provider and CSI plugin.
+- `capability` `(optional)` - Option for validating the capbility of a
+  volume. You may provide multiple `capability` blocks, each of which must
+  have the following fields:
 
-- `attachment_mode` `(string: <required>)` - The storage API that will be used
-  by the volume. Most storage providers will support `"file-system"`, to mount
-  volumes using the CSI filesystem API. Some storage providers will support
-  `"block-device"`, which will mount the volume with the CSI block device API
-  within the container.
+  - `access_mode` `(string: <required>)` - Defines whether a volume should be
+    available concurrently. Can be one of `"single-node-reader-only"`,
+    `"single-node-writer"`, `"multi-node-reader-only"`,
+    `"multi-node-single-writer"`, or `"multi-node-multi-writer"`. Most CSI
+    plugins support only single-node modes. Consult the documentation of the
+    storage provider and CSI plugin.
+
+  - `attachment_mode` `(string: <required>)` - The storage API that will be used
+    by the volume. Most storage providers will support `"file-system"`, to mount
+    volumes using the CSI filesystem API. Some storage providers will support
+    `"block-device"`, which will mount the volume with the CSI block device API
+    within the container.
 
 - `mount_options` - Options for mounting `file-system` volumes that don't
   already have a pre-formatted file system. Consult the documentation for your
@@ -139,11 +145,9 @@ context {
   to each storage provider, so please see the specific plugin
   documentation for more information.
 
-- `context` <code>(map<string|string>:nil)</code> - An optional
-  key-value map of strings passed directly to the CSI plugin to
-  validate the volume. The details of these parameters are specific to
-  each storage provider, so please see the specific plugin
-  documentation for more information.
+- `context` <code>(map<string|string>:nil)</code> - This field is only used
+  during volume registration, and will be set automatically by the plugin when
+  `volume create` is successful. See [`volume register`].
 
 [csi]: https://github.com/container-storage-interface/spec
 [csi_plugins_internals]: /docs/internals/plugins/csi#csi-plugins
@@ -151,3 +155,4 @@ context {
 [csi_plugin]: /docs/job-specification/csi_plugin
 [csi_volume_source]: /docs/job-specification/volume#source
 [registered]: /docs/commands/volume/register
+[`volume register`]: /docs/commands/volume/register

--- a/website/content/docs/commands/volume/register.mdx
+++ b/website/content/docs/commands/volume/register.mdx
@@ -93,29 +93,17 @@ context {
 - `clone_id` - This field is only used during volume creation, and is ignored
   during volume registration. See [`volume create`].
 
-- `capacity` - This field is only used during volume creation, and is ignored
-  during volume registration. See [`volume create`].
+- `capacity_min` - This field is only used during volume creation, and is
+  ignored during volume registration. See [`volume create`].
 
-- `access_mode` `(string: <required>)` - Defines whether a volume should be
-  available concurrently. Can be one of `"single-node-reader-only"`,
-  `"single-node-writer"`, `"multi-node-reader-only"`,
-  `"multi-node-single-writer"`, or `"multi-node-multi-writer"`. Most CSI
-  plugins support only single-node modes. Consult the documentation of the
-  storage provider and CSI plugin.
+- `capacity_max` - This field is only used during volume creation, and is
+  ignored during volume registration. See [`volume create`].
 
-- `attachment_mode` `(string: <required>)` - The storage API that will be used
-  by the volume. Most storage providers will support `"file-system"`, to mount
-  volumes using the CSI filesystem API. Some storage providers will support
-  `"block-device"`, which will mount the volume with the CSI block device API
-  within the container.
+- `capability` - This field is only used during volume creation, and is
+  ignored during volume registration. See [`volume create`].
 
-- `mount_options` - Options for mounting `file-system` volumes that don't
-  already have a pre-formatted file system. Consult the documentation for your
-  storage provider and CSI plugin as to whether these options are required or
-  necessary.
-
-  - `fs_type`: file system type (ex. `"ext4"`)
-  - `mount_flags`: the flags passed to `mount` (ex. `"ro,noatime"`)
+- `mount_options` - This field is only used during volume creation, and is
+  ignored during volume registration. See [`volume create`].
 
 - `secrets` <code>(map<string|string>:nil)</code> - An optional
   key-value map of strings used as credentials for publishing and

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -177,7 +177,7 @@ export default [
       'version',
       {
         category: 'volume',
-        content: ['deregister', 'detach', 'init', 'register', 'status'],
+        content: ['create', 'delete', 'deregister', 'detach', 'init', 'register', 'status'],
       },
     ],
   },


### PR DESCRIPTION
Implementation of the `nomad volume create/delete` and extended `nomad volume status` commands for CSI. Includes HCL decoding update for volume spec so that we can humanize capacity bytes input values. 

Notes for reviewers:
* This PR is targeting the `csi-create-volume` branch: https://github.com/hashicorp/nomad/pull/10165