### PR TITLE
E2E: CSI test should use expected unique-volume name

### DIFF
--- a/e2e/csi/csi.go
+++ b/e2e/csi/csi.go
@@ -107,8 +107,7 @@ func (tc *CSIVolumesTest) TestEBSVolumeClaim(f *framework.F) {
 		"aws-ebs0 node plugins did not become healthy")
 
 	// register a volume
-	// TODO: we don't have a unique ID threaded thru the jobspec yet
-	volID := "ebs-vol0"
+	volID := "ebs-vol[0]"
 	err := volumeRegister(volID, "csi/input/volume-ebs.hcl")
 	require.NoError(err)
 	tc.volumeIDs = append(tc.volumeIDs, volID)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10205, which turned out to be a missed TODO.

---

```
$ go test -v . -run 'TestE2E/CSI/\*csi\.CSIVolumesTest/TestEBSVolumeClaim'
=== RUN   TestE2E
=== RUN   TestE2E/CSI
=== RUN   TestE2E/CSI/*csi.CSIVolumesTest
=== RUN   TestE2E/CSI/*csi.CSIVolumesTest/TestEBSVolumeClaim
--- PASS: TestE2E (75.58s)
    --- PASS: TestE2E/CSI (75.58s)
        --- PASS: TestE2E/CSI/*csi.CSIVolumesTest (75.50s)
            --- PASS: TestE2E/CSI/*csi.CSIVolumesTest/TestEBSVolumeClaim (75.32s)
PASS
ok      github.com/hashicorp/nomad/e2e  75.699s
```