### PR TITLE
testing: default nomad test nodes to 1.0.0

### DIFF
--- a/nomad/structs/testing.go
+++ b/nomad/structs/testing.go
@@ -42,7 +42,7 @@ func MockNode() *Node {
 		Attributes: map[string]string{
 			"kernel.name":        "linux",
 			"arch":               "x86",
-			"nomad.version":      "0.5.0",
+			"nomad.version":      "1.0.0",
 			"driver.exec":        "1",
 			"driver.mock_driver": "1",
 		},


### PR DESCRIPTION
Update the tests to default to running as 1.0.0 - to ensure that we exercise the latest/modern paths.  When testing compatibility mode with older servers, tests should explicitly downgrade versions; our tests already do like done in https://github.com/hashicorp/nomad/blob/v1.0.4/nomad/client_stats_endpoint_test.go#L144-L169 .

Closes https://github.com/hashicorp/nomad/issues/10201