### PR TITLE
E2E: bump AWS CSI driver versions

### DIFF
--- a/e2e/csi/input/plugin-aws-ebs-controller.nomad
+++ b/e2e/csi/input/plugin-aws-ebs-controller.nomad
@@ -22,7 +22,7 @@ job "plugin-aws-ebs-controller" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-ebs-csi-driver:v0.7.1"
+        image = "amazon/aws-ebs-csi-driver:v0.9.0"
 
         args = [
           "controller",

--- a/e2e/csi/input/plugin-aws-ebs-nodes.nomad
+++ b/e2e/csi/input/plugin-aws-ebs-nodes.nomad
@@ -19,7 +19,7 @@ job "plugin-aws-ebs-nodes" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-ebs-csi-driver:v0.7.1"
+        image = "amazon/aws-ebs-csi-driver:v0.9.0"
 
         args = [
           "node",

--- a/e2e/csi/input/plugin-aws-efs-nodes.nomad
+++ b/e2e/csi/input/plugin-aws-efs-nodes.nomad
@@ -19,7 +19,7 @@ job "plugin-aws-efs-nodes" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-efs-csi-driver:v1.0.0"
+        image = "amazon/aws-efs-csi-driver:v1.2.0"
 
         # note: the EFS driver doesn't seem to respect the --endpoint
         # flag and always sets up the listener at '/tmp/csi.sock'


### PR DESCRIPTION
Related to the work being done in https://github.com/hashicorp/nomad/pull/10165 but can be merged independently.