### PR TITLE
CSI: create volume capability validation

### DIFF
--- a/api/csi.go
+++ b/api/csi.go
@@ -143,6 +143,14 @@ type CSIVolume struct {
 	Secrets        CSISecrets              `hcl:"secrets"`
 	Parameters     map[string]string       `hcl:"parameters"`
 	Context        map[string]string       `hcl:"context"`
+	Capacity       int64                   `hcl:"-"`
+
+	// These fields are used as part of the volume creation request
+	RequestedCapacityMin  int64                  `hcl:"capacity_min"`
+	RequestedCapacityMax  int64                  `hcl:"capacity_max"`
+	RequestedCapabilities []*CSIVolumeCapability `hcl:"capability"`
+	CloneID               string                 `hcl:"clone_id"`
+	SnapshotID            string                 `hcl:"snapshot_id"`
 
 	// ReadAllocs is a map of allocation IDs for tracking reader claim status.
 	// The Allocation value will always be nil; clients can populate this data
@@ -174,6 +182,13 @@ type CSIVolume struct {
 
 	// ExtraKeysHCL is used by the hcl parser to report unexpected keys
 	ExtraKeysHCL []string `hcl1:",unusedKeys" json:"-"`
+}
+
+// CSIVolumeCapability is a requested attachment and access mode for a
+// volume
+type CSIVolumeCapability struct {
+	AccessMode     CSIVolumeAccessMode     `hcl:"access_mode"`
+	AttachmentMode CSIVolumeAttachmentMode `hcl:"attachment_mode"`
 }
 
 type CSIVolumeIndexSort []*CSIVolumeListStub

--- a/client/pluginmanager/csimanager/fingerprint.go
+++ b/client/pluginmanager/csimanager/fingerprint.go
@@ -122,10 +122,18 @@ func (p *pluginFingerprinter) buildBasicFingerprint(ctx context.Context) (*struc
 }
 
 func applyCapabilitySetToControllerInfo(cs *csi.ControllerCapabilitySet, info *structs.CSIControllerInfo) {
-	info.SupportsReadOnlyAttach = cs.HasPublishReadonly
+	info.SupportsCreateDelete = cs.HasCreateDeleteVolume
 	info.SupportsAttachDetach = cs.HasPublishUnpublishVolume
 	info.SupportsListVolumes = cs.HasListVolumes
+	info.SupportsGetCapacity = cs.HasGetCapacity
+	info.SupportsCreateDeleteSnapshot = cs.HasCreateDeleteSnapshot
+	info.SupportsListSnapshots = cs.HasListSnapshots
+	info.SupportsClone = cs.HasCloneVolume
+	info.SupportsReadOnlyAttach = cs.HasPublishReadonly
+	info.SupportsExpand = cs.HasExpandVolume
 	info.SupportsListVolumesAttachedNodes = cs.HasListVolumesPublishedNodes
+	info.SupportsCondition = cs.HasVolumeCondition
+	info.SupportsGet = cs.HasGetVolume
 }
 
 func (p *pluginFingerprinter) buildControllerFingerprint(ctx context.Context, base *structs.CSIInfo) (*structs.CSIInfo, error) {

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -441,8 +441,9 @@ func (v *CSIVolume) controllerPublishVolume(req *structs.CSIVolumeClaimRequest, 
 		return fmt.Errorf("%s: %s", structs.ErrUnknownAllocationPrefix, req.AllocationID)
 	}
 
-	// if no plugin was returned or the plugin doesn't attach volumes, then
-	// controller validation is not required and we can safely return nil.
+	// Some plugins support controllers for create/snapshot but not attach. So
+	// if there's no plugin or the plugin doesn't attach volumes, then we can
+	// skip the controller publish workflow and return nil.
 	if plug == nil || !plug.HasControllerCapability(structs.CSIControllerSupportsAttachDetach) {
 		return nil
 	}

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -683,8 +683,10 @@ func (v *CSIVolume) controllerUnpublishVolume(vol *structs.CSIVolume, claim *str
 	ws := memdb.NewWatchSet()
 
 	plugin, err := state.CSIPluginByID(ws, vol.PluginID)
-	if err != nil || plugin == nil {
+	if err != nil {
 		return fmt.Errorf("could not query plugin: %v", err)
+	} else if plugin == nil {
+		return fmt.Errorf("no such plugin: %q", vol.PluginID)
 	}
 	if !plugin.HasControllerCapability(structs.CSIControllerSupportsAttachDetach) {
 		return nil

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -708,6 +708,7 @@ func TestCSIVolumeEndpoint_Create(t *testing.T) {
 			Healthy:  true,
 			ControllerInfo: &structs.CSIControllerInfo{
 				SupportsAttachDetach: true,
+				SupportsCreateDelete: true,
 			},
 			RequiresControllerPlugin: true,
 		},

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -162,11 +162,6 @@ func TestCSIVolumeEndpoint_Register(t *testing.T) {
 	}
 	resp1 := &structs.CSIVolumeRegisterResponse{}
 	err := msgpackrpc.CallWithCodec(codec, "CSIVolume.Register", req1, resp1)
-	require.Error(t, err, "expected validation error")
-
-	// Fix the registration so that it passes validation
-	vols[0].AttachmentMode = structs.CSIVolumeAttachmentModeFilesystem
-	err = msgpackrpc.CallWithCodec(codec, "CSIVolume.Register", req1, resp1)
 	require.NoError(t, err)
 	require.NotEqual(t, uint64(0), resp1.Index)
 

--- a/nomad/state/testing.go
+++ b/nomad/state/testing.go
@@ -81,6 +81,8 @@ func createTestCSIPlugin(s *StateStore, id string, requiresController bool) func
 				SupportsAttachDetach:             true,
 				SupportsListVolumes:              true,
 				SupportsListVolumesAttachedNodes: false,
+				SupportsCreateDeleteSnapshot:     true,
+				SupportsListSnapshots:            true,
 			},
 		},
 	}

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -590,22 +590,6 @@ func (v *CSIVolume) Validate() error {
 	if v.Namespace == "" {
 		errs = append(errs, "missing namespace")
 	}
-	if v.AccessMode == "" {
-		errs = append(errs, "missing access mode")
-	}
-	if v.AttachmentMode == "" {
-		errs = append(errs, "missing attachment mode")
-	}
-	if v.AttachmentMode == CSIVolumeAttachmentModeBlockDevice {
-		if v.MountOptions != nil {
-			if v.MountOptions.FSType != "" {
-				errs = append(errs, "mount options not allowed for block-device")
-			}
-			if v.MountOptions.MountFlags != nil && len(v.MountOptions.MountFlags) != 0 {
-				errs = append(errs, "mount options not allowed for block-device")
-			}
-		}
-	}
 	if v.SnapshotID != "" && v.CloneID != "" {
 		errs = append(errs, "only one of snapshot_id and clone_id is allowed")
 	}

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -846,21 +846,21 @@ func (p *CSIPlugin) Copy() *CSIPlugin {
 	return out
 }
 
-type CSIControllerCapability int
+type CSIControllerCapability byte
 
 const (
-	CSIControllerSupportsCreateDelete CSIControllerCapability = iota
-	CSIControllerSupportsAttachDetach
-	CSIControllerSupportsListVolumes
-	CSIControllerSupportsGetCapacity
-	CSIControllerSupportsCreateDeleteSnapshot
-	CSIControllerSupportsListSnapshots
-	CSIControllerSupportsClone
-	CSIControllerSupportsReadOnlyAttach
-	CSIControllerSupportsExpand
-	CSIControllerSupportsListVolumesAttachedNodes
-	CSIControllerSupportsCondition
-	CSIControllerSupportsGet
+	CSIControllerSupportsCreateDelete             CSIControllerCapability = 0
+	CSIControllerSupportsAttachDetach             CSIControllerCapability = 1
+	CSIControllerSupportsListVolumes              CSIControllerCapability = 2
+	CSIControllerSupportsGetCapacity              CSIControllerCapability = 3
+	CSIControllerSupportsCreateDeleteSnapshot     CSIControllerCapability = 4
+	CSIControllerSupportsListSnapshots            CSIControllerCapability = 5
+	CSIControllerSupportsClone                    CSIControllerCapability = 6
+	CSIControllerSupportsReadOnlyAttach           CSIControllerCapability = 7
+	CSIControllerSupportsExpand                   CSIControllerCapability = 8
+	CSIControllerSupportsListVolumesAttachedNodes CSIControllerCapability = 9
+	CSIControllerSupportsCondition                CSIControllerCapability = 10
+	CSIControllerSupportsGet                      CSIControllerCapability = 11
 )
 
 func (p *CSIPlugin) HasControllerCapability(cap CSIControllerCapability) bool {

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -849,18 +849,53 @@ func (p *CSIPlugin) Copy() *CSIPlugin {
 type CSIControllerCapability byte
 
 const (
-	CSIControllerSupportsCreateDelete             CSIControllerCapability = 0
-	CSIControllerSupportsAttachDetach             CSIControllerCapability = 1
-	CSIControllerSupportsListVolumes              CSIControllerCapability = 2
-	CSIControllerSupportsGetCapacity              CSIControllerCapability = 3
-	CSIControllerSupportsCreateDeleteSnapshot     CSIControllerCapability = 4
-	CSIControllerSupportsListSnapshots            CSIControllerCapability = 5
-	CSIControllerSupportsClone                    CSIControllerCapability = 6
-	CSIControllerSupportsReadOnlyAttach           CSIControllerCapability = 7
-	CSIControllerSupportsExpand                   CSIControllerCapability = 8
+	// CSIControllerSupportsCreateDelete indicates plugin support for
+	// CREATE_DELETE_VOLUME
+	CSIControllerSupportsCreateDelete CSIControllerCapability = 0
+
+	// CSIControllerSupportsAttachDetach is true when the controller
+	// implements the methods required to attach and detach volumes. If this
+	// is false Nomad should skip the controller attachment flow.
+	CSIControllerSupportsAttachDetach CSIControllerCapability = 1
+
+	// CSIControllerSupportsListVolumes is true when the controller implements
+	// the ListVolumes RPC. NOTE: This does not guarantee that attached nodes
+	// will be returned unless SupportsListVolumesAttachedNodes is also true.
+	CSIControllerSupportsListVolumes CSIControllerCapability = 2
+
+	// CSIControllerSupportsGetCapacity indicates plugin support for
+	// GET_CAPACITY
+	CSIControllerSupportsGetCapacity CSIControllerCapability = 3
+
+	// CSIControllerSupportsCreateDeleteSnapshot indicates plugin support for
+	// CREATE_DELETE_SNAPSHOT
+	CSIControllerSupportsCreateDeleteSnapshot CSIControllerCapability = 4
+
+	// CSIControllerSupportsListSnapshots indicates plugin support for
+	// LIST_SNAPSHOTS
+	CSIControllerSupportsListSnapshots CSIControllerCapability = 5
+
+	// CSIControllerSupportsClone indicates plugin support for CLONE_VOLUME
+	CSIControllerSupportsClone CSIControllerCapability = 6
+
+	// CSIControllerSupportsReadOnlyAttach is set to true when the controller
+	// returns the ATTACH_READONLY capability.
+	CSIControllerSupportsReadOnlyAttach CSIControllerCapability = 7
+
+	// CSIControllerSupportsExpand indicates plugin support for EXPAND_VOLUME
+	CSIControllerSupportsExpand CSIControllerCapability = 8
+
+	// CSIControllerSupportsListVolumesAttachedNodes indicates whether the
+	// plugin will return attached nodes data when making ListVolume RPCs
+	// (plugin support for LIST_VOLUMES_PUBLISHED_NODES)
 	CSIControllerSupportsListVolumesAttachedNodes CSIControllerCapability = 9
-	CSIControllerSupportsCondition                CSIControllerCapability = 10
-	CSIControllerSupportsGet                      CSIControllerCapability = 11
+
+	// CSIControllerSupportsCondition indicates plugin support for
+	// VOLUME_CONDITION
+	CSIControllerSupportsCondition CSIControllerCapability = 10
+
+	// CSIControllerSupportsGet indicates plugin support for GET_VOLUME
+	CSIControllerSupportsGet CSIControllerCapability = 11
 )
 
 func (p *CSIPlugin) HasControllerCapability(cap CSIControllerCapability) bool {

--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -112,23 +112,50 @@ func (n *CSINodeInfo) Copy() *CSINodeInfo {
 // CSIControllerInfo is the fingerprinted data from a CSI Plugin that is specific to
 // the Controller API.
 type CSIControllerInfo struct {
+
+	// SupportsCreateDelete indicates plugin support for CREATE_DELETE_VOLUME
+	SupportsCreateDelete bool
+
+	// SupportsPublishVolume is true when the controller implements the
+	// methods required to attach and detach volumes. If this is false Nomad
+	// should skip the controller attachment flow.
+	SupportsAttachDetach bool
+
+	// SupportsListVolumes is true when the controller implements the
+	// ListVolumes RPC. NOTE: This does not guarantee that attached nodes will
+	// be returned unless SupportsListVolumesAttachedNodes is also true.
+	SupportsListVolumes bool
+
+	// SupportsGetCapacity indicates plugin support for GET_CAPACITY
+	SupportsGetCapacity bool
+
+	// SupportsCreateDeleteSnapshot indicates plugin support for
+	// CREATE_DELETE_SNAPSHOT
+	SupportsCreateDeleteSnapshot bool
+
+	// SupportsListSnapshots indicates plugin support for LIST_SNAPSHOTS
+	SupportsListSnapshots bool
+
+	// SupportsClone indicates plugin support for CLONE_VOLUME
+	SupportsClone bool
+
 	// SupportsReadOnlyAttach is set to true when the controller returns the
 	// ATTACH_READONLY capability.
 	SupportsReadOnlyAttach bool
 
-	// SupportsPublishVolume is true when the controller implements the methods
-	// required to attach and detach volumes. If this is false Nomad should skip
-	// the controller attachment flow.
-	SupportsAttachDetach bool
+	// SupportsExpand indicates plugin support for EXPAND_VOLUME
+	SupportsExpand bool
 
-	// SupportsListVolumes is true when the controller implements the ListVolumes
-	// RPC. NOTE: This does not guaruntee that attached nodes will be returned
-	// unless SupportsListVolumesAttachedNodes is also true.
-	SupportsListVolumes bool
-
-	// SupportsListVolumesAttachedNodes indicates whether the plugin will return
-	// attached nodes data when making ListVolume RPCs
+	// SupportsListVolumesAttachedNodes indicates whether the plugin will
+	// return attached nodes data when making ListVolume RPCs (plugin support
+	// for LIST_VOLUMES_PUBLISHED_NODES)
 	SupportsListVolumesAttachedNodes bool
+
+	// SupportsCondition indicates plugin support for VOLUME_CONDITION
+	SupportsCondition bool
+
+	// SupportsGet indicates plugin support for GET_VOLUME
+	SupportsGet bool
 }
 
 func (c *CSIControllerInfo) Copy() *CSIControllerInfo {

--- a/plugins/csi/client_test.go
+++ b/plugins/csi/client_test.go
@@ -222,7 +222,7 @@ func TestClient_RPC_ControllerGetCapabilities(t *testing.T) {
 					{
 						Type: &csipbv1.ControllerServiceCapability_Rpc{
 							Rpc: &csipbv1.ControllerServiceCapability_RPC{
-								Type: csipbv1.ControllerServiceCapability_RPC_GET_CAPACITY,
+								Type: csipbv1.ControllerServiceCapability_RPC_UNKNOWN,
 							},
 						},
 					},

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -280,10 +280,18 @@ func NewPluginCapabilitySet(capabilities *csipbv1.GetPluginCapabilitiesResponse)
 }
 
 type ControllerCapabilitySet struct {
+	HasCreateDeleteVolume        bool
 	HasPublishUnpublishVolume    bool
-	HasPublishReadonly           bool
 	HasListVolumes               bool
+	HasGetCapacity               bool
+	HasCreateDeleteSnapshot      bool
+	HasListSnapshots             bool
+	HasCloneVolume               bool
+	HasPublishReadonly           bool
+	HasExpandVolume              bool
 	HasListVolumesPublishedNodes bool
+	HasVolumeCondition           bool
+	HasGetVolume                 bool
 }
 
 func NewControllerCapabilitySet(resp *csipbv1.ControllerGetCapabilitiesResponse) *ControllerCapabilitySet {
@@ -293,14 +301,30 @@ func NewControllerCapabilitySet(resp *csipbv1.ControllerGetCapabilitiesResponse)
 	for _, pcap := range pluginCapabilities {
 		if c := pcap.GetRpc(); c != nil {
 			switch c.Type {
+			case csipbv1.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME:
+				cs.HasCreateDeleteVolume = true
 			case csipbv1.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME:
 				cs.HasPublishUnpublishVolume = true
-			case csipbv1.ControllerServiceCapability_RPC_PUBLISH_READONLY:
-				cs.HasPublishReadonly = true
 			case csipbv1.ControllerServiceCapability_RPC_LIST_VOLUMES:
 				cs.HasListVolumes = true
+			case csipbv1.ControllerServiceCapability_RPC_GET_CAPACITY:
+				cs.HasGetCapacity = true
+			case csipbv1.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT:
+				cs.HasCreateDeleteSnapshot = true
+			case csipbv1.ControllerServiceCapability_RPC_LIST_SNAPSHOTS:
+				cs.HasListSnapshots = true
+			case csipbv1.ControllerServiceCapability_RPC_CLONE_VOLUME:
+				cs.HasCloneVolume = true
+			case csipbv1.ControllerServiceCapability_RPC_PUBLISH_READONLY:
+				cs.HasPublishReadonly = true
+			case csipbv1.ControllerServiceCapability_RPC_EXPAND_VOLUME:
+				cs.HasExpandVolume = true
 			case csipbv1.ControllerServiceCapability_RPC_LIST_VOLUMES_PUBLISHED_NODES:
 				cs.HasListVolumesPublishedNodes = true
+			case csipbv1.ControllerServiceCapability_RPC_VOLUME_CONDITION:
+				cs.HasVolumeCondition = true
+			case csipbv1.ControllerServiceCapability_RPC_GET_VOLUME:
+				cs.HasGetVolume = true
 			default:
 				continue
 			}

--- a/vendor/github.com/hashicorp/nomad/api/csi.go
+++ b/vendor/github.com/hashicorp/nomad/api/csi.go
@@ -143,6 +143,14 @@ type CSIVolume struct {
 	Secrets        CSISecrets              `hcl:"secrets"`
 	Parameters     map[string]string       `hcl:"parameters"`
 	Context        map[string]string       `hcl:"context"`
+	Capacity       int64                   `hcl:"-"`
+
+	// These fields are used as part of the volume creation request
+	RequestedCapacityMin  int64                  `hcl:"capacity_min"`
+	RequestedCapacityMax  int64                  `hcl:"capacity_max"`
+	RequestedCapabilities []*CSIVolumeCapability `hcl:"capability"`
+	CloneID               string                 `hcl:"clone_id"`
+	SnapshotID            string                 `hcl:"snapshot_id"`
 
 	// ReadAllocs is a map of allocation IDs for tracking reader claim status.
 	// The Allocation value will always be nil; clients can populate this data
@@ -174,6 +182,13 @@ type CSIVolume struct {
 
 	// ExtraKeysHCL is used by the hcl parser to report unexpected keys
 	ExtraKeysHCL []string `hcl1:",unusedKeys" json:"-"`
+}
+
+// CSIVolumeCapability is a requested attachment and access mode for a
+// volume
+type CSIVolumeCapability struct {
+	AccessMode     CSIVolumeAccessMode     `hcl:"access_mode"`
+	AttachmentMode CSIVolumeAttachmentMode `hcl:"attachment_mode"`
 }
 
 type CSIVolumeIndexSort []*CSIVolumeListStub


### PR DESCRIPTION
Fix a collection of validation-related issues for CSI volume creation that I discovered while getting things tested end-to-end.

* CSI: add missing `structs.CSIVolume` fields to `api.CSIVolume`

* CSI: volume creation/registration should not validate attachment. The CSI specification requires that we validate a list of `Capability` (access mode + accessibility) when we create volume, but the existing volume
registration workflow  incorrectly validates a single capability. The specific capability required by a volume claim is checked at the time we make the claim, so remove the check for `AttachmentMode`/`AccessMode`.

* CSI: fingerprint detailed controller capabilities. In order to support new controller RPCs, we need to fingerprint volume capabilities in more detail and perform controller RPCs only when the specific capability is present. This fixes a bug in Ceph support where the plugin can only support create/delete but we assume that it also supports attach/detach.

* CSI: the HTTP test to create CSI volumes depends on having a controller plugin to talk to, but the test was using a node-only plugin, which allows it to silently ignore the missing controller.

Note for reviewers:
* This PR is targeting the `csi-create-volume` branch: https://github.com/hashicorp/nomad/pull/10165
