### PR TITLE
Reserved Cores [2/4]: Client fingerprinting implementation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -636,8 +636,9 @@ func (c *Client) init() error {
 
 	// Ensure cgroups are created on linux platform
 	if err := cgutil.InitCpusetParent(c.config.CgroupParent); err != nil {
-		// if the client cannot initialize the cgroup then reserved cores will not be reported and the cpuset manager
-		// will be disabled. this is common when running in dev mode under a non-root user for example
+		// If the client cannot initialize the cgroup then reserved cores will
+		// not be reported and the cpuset manager will be disabled. This is
+		// common when running in dev mode under a non-root user for example.
 		c.logger.Warn("could not initialize cpuset cgroup subsystem, cpuset management disabled", "error", err)
 		c.config.DisableCgroupManagement = true
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1118,7 +1118,11 @@ func TestClient_UpdateNodeFromDevicesAccumulates(t *testing.T) {
 		Disk:         client.configCopy.Node.NodeResources.Disk,
 
 		// injected
-		Cpu:    structs.NodeCpuResources{CpuShares: 123},
+		Cpu: structs.NodeCpuResources{
+			CpuShares:          123,
+			ReservableCpuCores: client.configCopy.Node.NodeResources.Cpu.ReservableCpuCores,
+			TotalCpuCores:      client.configCopy.Node.NodeResources.Cpu.TotalCpuCores,
+		},
 		Memory: structs.NodeMemoryResources{MemoryMB: 1024},
 		Devices: []*structs.NodeDeviceResource{
 			{
@@ -1156,7 +1160,11 @@ func TestClient_UpdateNodeFromDevicesAccumulates(t *testing.T) {
 		Disk:         client.configCopy.Node.NodeResources.Disk,
 
 		// injected
-		Cpu:    structs.NodeCpuResources{CpuShares: 123},
+		Cpu: structs.NodeCpuResources{
+			CpuShares:          123,
+			ReservableCpuCores: client.configCopy.Node.NodeResources.Cpu.ReservableCpuCores,
+			TotalCpuCores:      client.configCopy.Node.NodeResources.Cpu.TotalCpuCores,
+		},
 		Memory: structs.NodeMemoryResources{MemoryMB: 2048},
 		Devices: []*structs.NodeDeviceResource{
 			{

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/nomad/client/lib/cgutil"
+
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/helper"
@@ -265,6 +267,14 @@ type Config struct {
 	//
 	// This configuration is only considered if no host networks are defined.
 	BindWildcardDefaultHostNetwork bool
+
+	// CgroupParent is the parent cgroup Nomad should use when managing any cgroup subsystems.
+	// Currently this only includes the 'cpuset' cgroup subsystem
+	CgroupParent string
+
+	// DisableCgroupManagement if true disables all management of cgroup subsystems by the Nomad client. It does
+	// not prevent individual drivers from manging their own cgroups.
+	DisableCgroupManagement bool
 }
 
 type ClientTemplateConfig struct {
@@ -323,6 +333,7 @@ func DefaultConfig() *Config {
 		CNIConfigDir:       "/opt/cni/config",
 		CNIInterfacePrefix: "eth",
 		HostNetworks:       map[string]*structs.ClientHostNetworkConfig{},
+		CgroupParent:       cgutil.DefaultCgroupParent,
 	}
 }
 

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -272,6 +272,9 @@ type Config struct {
 	// Currently this only includes the 'cpuset' cgroup subsystem
 	CgroupParent string
 
+	// ReservableCores if set overrides the set of reservable cores reported in fingerprinting
+	ReservableCores []uint16
+
 	// DisableCgroupManagement if true disables all management of cgroup subsystems by the Nomad client. It does
 	// not prevent individual drivers from manging their own cgroups.
 	DisableCgroupManagement bool
@@ -303,6 +306,10 @@ func (c *Config) Copy() *Config {
 	nc.ConsulConfig = c.ConsulConfig.Copy()
 	nc.VaultConfig = c.VaultConfig.Copy()
 	nc.TemplateConfig = c.TemplateConfig.Copy()
+	if c.ReservableCores != nil {
+		nc.ReservableCores = make([]uint16, len(c.ReservableCores))
+		copy(nc.ReservableCores, c.ReservableCores)
+	}
 	return nc
 }
 

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -269,10 +269,10 @@ type Config struct {
 	BindWildcardDefaultHostNetwork bool
 
 	// CgroupParent is the parent cgroup Nomad should use when managing any cgroup subsystems.
-	// Currently this only includes the 'cpuset' cgroup subsystem
+	// Currently this only includes the 'cpuset' cgroup subsystem.
 	CgroupParent string
 
-	// ReservableCores if set overrides the set of reservable cores reported in fingerprinting
+	// ReservableCores if set overrides the set of reservable cores reported in fingerprinting.
 	ReservableCores []uint16
 
 	// DisableCgroupManagement if true disables all management of cgroup subsystems by the Nomad client. It does

--- a/client/fingerprint/cpu.go
+++ b/client/fingerprint/cpu.go
@@ -3,6 +3,8 @@ package fingerprint
 import (
 	"fmt"
 
+	"github.com/hashicorp/nomad/lib/cpuset"
+
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/helper/stats"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -30,7 +32,7 @@ func NewCPUFingerprint(logger log.Logger) Fingerprint {
 
 func (f *CPUFingerprint) Fingerprint(req *FingerprintRequest, resp *FingerprintResponse) error {
 	cfg := req.Config
-	setResourcesCPU := func(totalCompute int) {
+	setResourcesCPU := func(totalCompute int, totalCores uint16, reservableCores []uint16) {
 		// COMPAT(0.10): Remove in 0.10
 		resp.Resources = &structs.Resources{
 			CPU: totalCompute,
@@ -38,7 +40,9 @@ func (f *CPUFingerprint) Fingerprint(req *FingerprintRequest, resp *FingerprintR
 
 		resp.NodeResources = &structs.NodeResources{
 			Cpu: structs.NodeCpuResources{
-				CpuShares: int64(totalCompute),
+				CpuShares:          int64(totalCompute),
+				TotalCpuCores:      totalCores,
+				ReservableCpuCores: reservableCores,
 			},
 		}
 	}
@@ -56,9 +60,18 @@ func (f *CPUFingerprint) Fingerprint(req *FingerprintRequest, resp *FingerprintR
 		f.logger.Debug("detected cpu frequency", "MHz", log.Fmt("%.0f", mhz))
 	}
 
-	if numCores := stats.CPUNumCores(); numCores > 0 {
+	var numCores int
+	if numCores = stats.CPUNumCores(); numCores > 0 {
 		resp.AddAttribute("cpu.numcores", fmt.Sprintf("%d", numCores))
 		f.logger.Debug("detected core count", "cores", numCores)
+	}
+
+	var reservableCores []uint16
+	if cores, err := f.deriveReservableCores(req, numCores); err != nil {
+		f.logger.Warn("failed to detect set of reservable cores", "error", err)
+	} else {
+		reservableCores = cpuset.New(cores...).Difference(cpuset.New(req.Node.ReservedResources.Cpu.ReservedCpuCores...)).ToSlice()
+		f.logger.Debug("detected reservable cores", "cpuset", reservableCores)
 	}
 
 	tt := int(stats.TotalTicksAvailable())
@@ -77,8 +90,16 @@ func (f *CPUFingerprint) Fingerprint(req *FingerprintRequest, resp *FingerprintR
 	}
 
 	resp.AddAttribute("cpu.totalcompute", fmt.Sprintf("%d", tt))
-	setResourcesCPU(tt)
+	setResourcesCPU(tt, uint16(numCores), reservableCores)
 	resp.Detected = true
 
 	return nil
+}
+
+func defaultReservableCores(totalCores int) []uint16 {
+	cores := make([]uint16, totalCores)
+	for i := range cores {
+		cores[i] = uint16(i)
+	}
+	return cores
 }

--- a/client/fingerprint/cpu_default.go
+++ b/client/fingerprint/cpu_default.go
@@ -1,0 +1,7 @@
+//+build !linux
+
+package fingerprint
+
+func (f *CPUFingerprint) deriveReservableCores(req *FingerprintRequest, totalCores int) ([]uint16, error) {
+	return defaultReservableCores(totalCores), nil
+}

--- a/client/fingerprint/cpu_default.go
+++ b/client/fingerprint/cpu_default.go
@@ -2,6 +2,6 @@
 
 package fingerprint
 
-func (f *CPUFingerprint) deriveReservableCores(req *FingerprintRequest, totalCores int) ([]uint16, error) {
-	return defaultReservableCores(totalCores), nil
+func (f *CPUFingerprint) deriveReservableCores(req *FingerprintRequest) ([]uint16, error) {
+	return nil, nil
 }

--- a/client/fingerprint/cpu_linux.go
+++ b/client/fingerprint/cpu_linux.go
@@ -1,0 +1,13 @@
+package fingerprint
+
+import (
+	"github.com/hashicorp/nomad/client/lib/cgutil"
+)
+
+func (f *CPUFingerprint) deriveReservableCores(req *FingerprintRequest, totalCores int) ([]uint16, error) {
+	if req.Config.DisableCgroupManagement {
+		return defaultReservableCores(totalCores), nil
+	}
+	return cgutil.GetCPUsFromCgroup(req.Config.CgroupParent)
+
+}

--- a/client/fingerprint/cpu_linux.go
+++ b/client/fingerprint/cpu_linux.go
@@ -4,10 +4,6 @@ import (
 	"github.com/hashicorp/nomad/client/lib/cgutil"
 )
 
-func (f *CPUFingerprint) deriveReservableCores(req *FingerprintRequest, totalCores int) ([]uint16, error) {
-	if req.Config.DisableCgroupManagement {
-		return defaultReservableCores(totalCores), nil
-	}
+func (f *CPUFingerprint) deriveReservableCores(req *FingerprintRequest) ([]uint16, error) {
 	return cgutil.GetCPUsFromCgroup(req.Config.CgroupParent)
-
 }

--- a/client/lib/cgutil/cgutil_default.go
+++ b/client/lib/cgutil/cgutil_default.go
@@ -1,0 +1,9 @@
+// +build !linux
+
+package cgutil
+
+const (
+	DefaultCgroupParent = ""
+)
+
+func InitCpusetParent(string) error { return nil }

--- a/client/lib/cgutil/cgutil_linux.go
+++ b/client/lib/cgutil/cgutil_linux.go
@@ -1,0 +1,140 @@
+package cgutil
+
+import (
+	"os"
+	"path/filepath"
+
+	cgroupFs "github.com/opencontainers/runc/libcontainer/cgroups/fs"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	DefaultCgroupParent    = "/nomad"
+	SharedCpusetCgroupName = "shared"
+)
+
+// InitCpusetParent checks that the cgroup parent and expected child cgroups have been created
+// If the cgroup parent is set to /nomad then this will ensure that the /nomad/shared
+// cgroup is initialized. The /nomad/reserved cgroup will be lazily created when a workload
+// with reserved cores is created
+func InitCpusetParent(cgroupParent string) error {
+	if cgroupParent == "" {
+		cgroupParent = DefaultCgroupParent
+	}
+	var err error
+	if cgroupParent, err = getCgroupPathHelper("cpuset", cgroupParent); err != nil {
+		return err
+	}
+
+	// 'ensureParent' start with parent because we don't want to
+	// explicitly inherit from parent, it could conflict with
+	// 'cpuset.cpu_exclusive'.
+	if err := cpusetEnsureParent(cgroupParent); err != nil {
+		return err
+	}
+	if err := os.Mkdir(filepath.Join(cgroupParent, SharedCpusetCgroupName), 0755); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	return nil
+}
+
+func GetCPUsFromCgroup(group string) ([]uint16, error) {
+	cgroupPath, err := getCgroupPathHelper("cpuset", group)
+	if err != nil {
+		return nil, err
+	}
+
+	man := cgroupFs.NewManager(&configs.Cgroup{Path: group}, map[string]string{"cpuset": cgroupPath}, false)
+	stats, err := man.GetStats()
+	if err != nil {
+		return nil, err
+	}
+	return stats.CPUSetStats.CPUs, nil
+}
+
+func getCpusetSubsystemSettings(parent string) (cpus, mems string, err error) {
+	if cpus, err = fscommon.ReadFile(parent, "cpuset.cpus"); err != nil {
+		return
+	}
+	if mems, err = fscommon.ReadFile(parent, "cpuset.mems"); err != nil {
+		return
+	}
+	return cpus, mems, nil
+}
+
+// cpusetEnsureParent makes sure that the parent directories of current
+// are created and populated with the proper cpus and mems files copied
+// from their respective parent. It does that recursively, starting from
+// the top of the cpuset hierarchy (i.e. cpuset cgroup mount point).
+func cpusetEnsureParent(current string) error {
+	var st unix.Statfs_t
+
+	parent := filepath.Dir(current)
+	err := unix.Statfs(parent, &st)
+	if err == nil && st.Type != unix.CGROUP_SUPER_MAGIC {
+		return nil
+	}
+	// Treat non-existing directory as cgroupfs as it will be created,
+	// and the root cpuset directory obviously exists.
+	if err != nil && err != unix.ENOENT {
+		return &os.PathError{Op: "statfs", Path: parent, Err: err}
+	}
+
+	if err := cpusetEnsureParent(parent); err != nil {
+		return err
+	}
+	if err := os.Mkdir(current, 0755); err != nil && !os.IsExist(err) {
+		return err
+	}
+	return cpusetCopyIfNeeded(current, parent)
+}
+
+// cpusetCopyIfNeeded copies the cpuset.cpus and cpuset.mems from the parent
+// directory to the current directory if the file's contents are 0
+func cpusetCopyIfNeeded(current, parent string) error {
+	currentCpus, currentMems, err := getCpusetSubsystemSettings(current)
+	if err != nil {
+		return err
+	}
+	parentCpus, parentMems, err := getCpusetSubsystemSettings(parent)
+	if err != nil {
+		return err
+	}
+
+	if isEmptyCpuset(currentCpus) {
+		if err := fscommon.WriteFile(current, "cpuset.cpus", string(parentCpus)); err != nil {
+			return err
+		}
+	}
+	if isEmptyCpuset(currentMems) {
+		if err := fscommon.WriteFile(current, "cpuset.mems", string(parentMems)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isEmptyCpuset(str string) bool {
+	return str == "" || str == "\n"
+}
+
+func getCgroupPathHelper(subsystem, cgroup string) (string, error) {
+	mnt, root, err := cgroups.FindCgroupMountpointAndRoot("", subsystem)
+	if err != nil {
+		return "", err
+	}
+
+	// This is needed for nested containers, because in /proc/self/cgroup we
+	// see paths from host, which don't exist in container.
+	relCgroup, err := filepath.Rel(root, cgroup)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(mnt, relCgroup), nil
+}

--- a/client/lib/cgutil/cgutil_linux.go
+++ b/client/lib/cgutil/cgutil_linux.go
@@ -107,12 +107,12 @@ func cpusetCopyIfNeeded(current, parent string) error {
 	}
 
 	if isEmptyCpuset(currentCpus) {
-		if err := fscommon.WriteFile(current, "cpuset.cpus", string(parentCpus)); err != nil {
+		if err := fscommon.WriteFile(current, "cpuset.cpus", parentCpus); err != nil {
 			return err
 		}
 	}
 	if isEmptyCpuset(currentMems) {
-		if err := fscommon.WriteFile(current, "cpuset.mems", string(parentMems)); err != nil {
+		if err := fscommon.WriteFile(current, "cpuset.mems", parentMems); err != nil {
 			return err
 		}
 	}

--- a/client/lib/cgutil/cgutil_linux.go
+++ b/client/lib/cgutil/cgutil_linux.go
@@ -17,10 +17,10 @@ const (
 	SharedCpusetCgroupName = "shared"
 )
 
-// InitCpusetParent checks that the cgroup parent and expected child cgroups have been created
+// InitCpusetParent checks that the cgroup parent and expected child cgroups have been created.
 // If the cgroup parent is set to /nomad then this will ensure that the /nomad/shared
 // cgroup is initialized. The /nomad/reserved cgroup will be lazily created when a workload
-// with reserved cores is created
+// with reserved cores is created.
 func InitCpusetParent(cgroupParent string) error {
 	if cgroupParent == "" {
 		cgroupParent = DefaultCgroupParent

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -671,6 +671,13 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	conf.BindWildcardDefaultHostNetwork = agentConfig.Client.BindWildcardDefaultHostNetwork
 
 	conf.CgroupParent = agentConfig.Client.CgroupParent
+	if agentConfig.Client.ReserveableCores != "" {
+		cores, err := cpuset.Parse(agentConfig.Client.ReserveableCores)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse 'reservable_cores': %v", err)
+		}
+		conf.ReservableCores = cores.ToSlice()
+	}
 
 	return conf, nil
 }

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/nomad/lib/cpuset"
+
 	metrics "github.com/armon/go-metrics"
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
@@ -613,6 +615,13 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	res.Memory.MemoryMB = int64(agentConfig.Client.Reserved.MemoryMB)
 	res.Disk.DiskMB = int64(agentConfig.Client.Reserved.DiskMB)
 	res.Networks.ReservedHostPorts = agentConfig.Client.Reserved.ReservedPorts
+	if agentConfig.Client.Reserved.Cores != "" {
+		cores, err := cpuset.Parse(agentConfig.Client.Reserved.Cores)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse client > reserved > cores value %q: %v", agentConfig.Client.Reserved.Cores, err)
+		}
+		res.Cpu.ReservedCpuCores = cores.ToSlice()
+	}
 
 	conf.Version = agentConfig.Version
 
@@ -660,6 +669,8 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 		conf.HostNetworks[hn.Name] = hn
 	}
 	conf.BindWildcardDefaultHostNetwork = agentConfig.Client.BindWildcardDefaultHostNetwork
+
+	conf.CgroupParent = agentConfig.Client.CgroupParent
 
 	return conf, nil
 }

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -517,6 +517,19 @@ func TestAgent_ClientConfig(t *testing.T) {
 	}
 }
 
+func TestAgent_ClientConfig_ReservedCores(t *testing.T) {
+	t.Parallel()
+	conf := DefaultConfig()
+	conf.Client.Enabled = true
+	conf.Client.ReserveableCores = "0-7"
+	conf.Client.Reserved.Cores = "0,2-3"
+	a := &Agent{config: conf}
+	c, err := a.clientConfig()
+	require.NoError(t, err)
+	require.Exactly(t, []uint16{0, 1, 2, 3, 4, 5, 6, 7}, c.ReservableCores)
+	require.Exactly(t, []uint16{0, 2, 3}, c.Node.ReservedResources.Cpu.ReservedCpuCores)
+}
+
 // Clients should inherit telemetry configuration
 func TestAgent_Client_TelemetryConfiguration(t *testing.T) {
 	assert := assert.New(t)

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -219,6 +219,9 @@ type ClientConfig struct {
 	// MemoryMB is used to override any detected or default total memory.
 	MemoryMB int `hcl:"memory_total_mb"`
 
+	// ReservableCores is used to override detected reservable cpu cores.
+	ReserveableCores string `hcl:"reservable_cores"`
+
 	// MaxKillTimeout allows capping the user-specifiable KillTimeout.
 	MaxKillTimeout string `hcl:"max_kill_timeout"`
 

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -299,6 +299,10 @@ type ClientConfig struct {
 	// matching any destination address (true). Defaults to true
 	BindWildcardDefaultHostNetwork bool `hcl:"bind_wildcard_default_host_network"`
 
+	// CgroupParent sets the parent cgroup for subsystems managed by Nomad. If the cgroup
+	// doest not exist Nomad will attempt to create it during startup. Defaults to '/nomad'
+	CgroupParent string `hcl:"cgroup_parent"`
+
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 }
@@ -720,16 +724,9 @@ type Resources struct {
 	MemoryMB      int    `hcl:"memory"`
 	DiskMB        int    `hcl:"disk"`
 	ReservedPorts string `hcl:"reserved_ports"`
+	Cores         string `hcl:"cores"`
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
-}
-
-// CanParseReserved returns if the reserved ports specification is parsable.
-// The supported syntax is comma separated integers or ranges separated by
-// hyphens. For example, "80,120-150,160"
-func (r *Resources) CanParseReserved() error {
-	_, err := structs.ParsePortRanges(r.ReservedPorts)
-	return err
 }
 
 // devModeConfig holds the config for the -dev and -dev-connect flags
@@ -1740,6 +1737,9 @@ func (r *Resources) Merge(b *Resources) *Resources {
 	}
 	if b.ReservedPorts != "" {
 		result.ReservedPorts = b.ReservedPorts
+	}
+	if b.Cores != "" {
+		result.Cores = b.Cores
 	}
 	return &result
 }


### PR DESCRIPTION
This PR implements the Nomad client discovery of reservable CPU cores. On Linux systems with cgroups enabled, this uses the configured `cgroup_parent` to inspect the cpuset cgroup for the list of configured cores. On non-Linux systems or Linux systems where the cgroup subsystem is not mounted or the agent is not running as root, the set of reservable cpus defaults to all system cores.

A `cores` field has been added to the client configuration's `reserved` block which accepts a list of cpus or cpu range to remove from the set of discovered cpus, "reserving" them for the Nomad system.