### PR TITLE
e2e allow setting an enterprise license environment variable

### DIFF
--- a/e2e/terraform/nomad.tf
+++ b/e2e/terraform/nomad.tf
@@ -20,6 +20,7 @@ module "nomad_server" {
   nomad_local_binary = count.index < length(var.nomad_local_binary_server) ? var.nomad_local_binary_server[count.index] : var.nomad_local_binary
 
   nomad_enterprise = var.nomad_enterprise
+  nomad_license    = var.nomad_license
   nomad_acls       = var.nomad_acls
   cluster_name     = local.random_name
 

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/nomad.service
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/nomad.service
@@ -8,6 +8,7 @@ StartLimitBurst=3
 [Service]
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/local/bin/nomad agent -config /etc/nomad.d
+EnvironmentFile=-/etc/nomad.d/.environment
 KillMode=process
 KillSignal=SIGINT
 LimitNOFILE=65536

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/provision.sh
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/provision.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 set -o nounset
-set +x
+set +ex
 
 usage() {
     cat <<EOF
@@ -18,6 +18,7 @@ Options for configuration:
  --index INDEX              count of instance, for profiles with per-instance config
  --nostart                  do not start or restart Nomad
  --enterprise               if nomad_sha is passed, use the ENT version
+ --nomad_license            set the NOMAD_LICENSE environment variable
  --nomad_acls               write Nomad ACL configuration
  --autojoin                 the AWS ConsulAutoJoin tag value
 
@@ -39,6 +40,7 @@ NOMAD_INDEX=
 BUILD_FOLDER="builds-oss"
 CONSUL_AUTOJOIN=
 ACLS=0
+NOMAD_LICENSE=
 
 install_from_s3() {
     # check that we don't already have this version
@@ -175,6 +177,11 @@ opt="$1"
             BUILD_FOLDER="builds-ent"
             shift
             ;;
+        --nomad_license)
+            if [ -z "$2" ]; then echo "Missing license parameter"; usage; fi
+            NOMAD_LICENSE="$2"
+            shift 2
+            ;;
         --nomad_acls)
             ACLS=1
             shift
@@ -193,6 +200,12 @@ fi
 
 if [ -n "$CONSUL_AUTOJOIN" ]; then
     update_consul_autojoin
+fi
+
+if [ -n "$NOMAD_LICENSE" ]; then
+  sudo touch /etc/nomad.d/.environment
+  echo "NOMAD_LICENSE=${NOMAD_LICENSE}" > /tmp/.nomad-environment
+  sudo mv /tmp/.nomad-environment /etc/nomad.d/.environment
 fi
 
 if [ $START == "1" ]; then

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/provision.sh
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/provision.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 set -o nounset
-set +ex
+set +x
 
 usage() {
     cat <<EOF
@@ -202,8 +202,8 @@ if [ -n "$CONSUL_AUTOJOIN" ]; then
     update_consul_autojoin
 fi
 
+sudo touch /etc/nomad.d/.environment
 if [ -n "$NOMAD_LICENSE" ]; then
-  sudo touch /etc/nomad.d/.environment
   echo "NOMAD_LICENSE=${NOMAD_LICENSE}" > /tmp/.nomad-environment
   sudo mv /tmp/.nomad-environment /etc/nomad.d/.environment
 fi

--- a/e2e/terraform/provision-nomad/main.tf
+++ b/e2e/terraform/provision-nomad/main.tf
@@ -41,7 +41,7 @@ resource "null_resource" "provision_nomad" {
 }
 
 data "template_file" "provision_script" {
-  template = "${local.provision_script}${data.template_file.arg_nomad_sha.rendered}${data.template_file.arg_nomad_version.rendered}${data.template_file.arg_nomad_binary.rendered}${data.template_file.arg_nomad_enterprise.rendered}${data.template_file.arg_nomad_acls.rendered}${data.template_file.arg_profile.rendered}${data.template_file.arg_role.rendered}${data.template_file.arg_index.rendered}${data.template_file.autojoin_tag.rendered}"
+  template = "${local.provision_script}${data.template_file.arg_nomad_sha.rendered}${data.template_file.arg_nomad_version.rendered}${data.template_file.arg_nomad_binary.rendered}${data.template_file.arg_nomad_enterprise.rendered}${data.template_file.arg_nomad_license.rendered}${data.template_file.arg_nomad_acls.rendered}${data.template_file.arg_profile.rendered}${data.template_file.arg_role.rendered}${data.template_file.arg_index.rendered}${data.template_file.autojoin_tag.rendered}"
 }
 
 data "template_file" "arg_nomad_sha" {
@@ -58,6 +58,10 @@ data "template_file" "arg_nomad_binary" {
 
 data "template_file" "arg_nomad_enterprise" {
   template = var.nomad_enterprise ? " ${local._arg}enterprise" : ""
+}
+
+data "template_file" "arg_nomad_license" {
+  template = var.nomad_license != "" ? " ${local._arg}nomad_license ${var.nomad_license}" : ""
 }
 
 data "template_file" "arg_nomad_acls" {

--- a/e2e/terraform/provision-nomad/variables.tf
+++ b/e2e/terraform/provision-nomad/variables.tf
@@ -28,6 +28,12 @@ variable "nomad_enterprise" {
   default     = false
 }
 
+variable "nomad_license" {
+  type        = string
+  description = "The enterprise license to user; overrides Nomad temporary license"
+  default     = ""
+}
+
 variable "nomad_acls" {
   type        = bool
   description = "Bootstrap ACLs"

--- a/e2e/terraform/provision-nomad/variables.tf
+++ b/e2e/terraform/provision-nomad/variables.tf
@@ -30,7 +30,7 @@ variable "nomad_enterprise" {
 
 variable "nomad_license" {
   type        = string
-  description = "The enterprise license to user; overrides Nomad temporary license"
+  description = "The enterprise license to use. overrides Nomad temporary license"
   default     = ""
 }
 

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -81,7 +81,7 @@ variable "nomad_enterprise" {
 
 variable "nomad_license" {
   type        = string
-  description = "If nomad_license is used, deploy override the temporary license"
+  description = "If nomad_license is set, deploy a license to override the temporary license"
   default     = ""
 }
 

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -79,6 +79,12 @@ variable "nomad_enterprise" {
   default     = false
 }
 
+variable "nomad_license" {
+  type        = string
+  description = "If nomad_license is used, deploy override the temporary license"
+  default     = ""
+}
+
 variable "nomad_acls" {
   type        = bool
   description = "Bootstrap ACLs"


### PR DESCRIPTION
Allow passing in an enterprise license to linux servers.

I believe we only use windows as clients right now so I didn't update the windows provisioning script