### PR TITLE
e2e license smoke test

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/hashicorp/nomad/e2e/events"
 	_ "github.com/hashicorp/nomad/e2e/example"
 	_ "github.com/hashicorp/nomad/e2e/isolation"
+	_ "github.com/hashicorp/nomad/e2e/license"
 	_ "github.com/hashicorp/nomad/e2e/lifecycle"
 	_ "github.com/hashicorp/nomad/e2e/metrics"
 	_ "github.com/hashicorp/nomad/e2e/namespaces"

--- a/e2e/license/license.go
+++ b/e2e/license/license.go
@@ -1,0 +1,33 @@
+package license
+
+import (
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/e2e/framework"
+	"github.com/stretchr/testify/require"
+)
+
+type LicenseE2ETest struct {
+	framework.TC
+}
+
+func init() {
+	framework.AddSuites(&framework.TestSuite{
+		Component:   "License",
+		CanRunLocal: true,
+		Cases:       []framework.TestCase{new(LicenseE2ETest)},
+	})
+}
+
+func (tc *LicenseE2ETest) TestLicenseGet(f *framework.F) {
+	t := f.T()
+
+	client := tc.Nomad()
+
+	// Get the license and do not forward to the leader
+	lic, _, err := client.Operator().LicenseGet(&api.QueryOptions{
+		AllowStale: true,
+	})
+
+	require.NoError(t, err)
+	require.NotEqual(t, "temporary-license", lic.License.LicenseID)
+}


### PR DESCRIPTION
adds a small e2e test to ensure the cluster license is what we expect. 