### PR TITLE
Automatically populate `CONSUL_HTTP_ADDR` for connect native tasks in host networking mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ BUG FIXES:
 IMPROVEMENTS:
  * cli: Update defaults for `nomad operator debug` flags `-interval` and `-server-id` to match common usage. [[GH-10121](https://github.com/hashicorp/nomad/issues/10121)]
  * consul/connect: Enable setting `local_bind_address` field on connect upstreams [[GH-6248](https://github.com/hashicorp/nomad/issues/6248)]
+ * consul/connect: Automatically populate `CONSUL_HTTP_ADDR` for connect native tasks in host networking mode. [[GH-10239](https://github.com/hashicorp/nomad/issues/10239)]
  * csi: Added support for jobs to request a unique volume ID per allocation. [[GH-10136](https://github.com/hashicorp/nomad/issues/10136)]
  * driver/docker: Added support for optional extra container labels. [[GH-9885](https://github.com/hashicorp/nomad/issues/9885)]
  * driver/docker: Added support for configuring default logger behavior in the client configuration. [[GH-10156](https://github.com/hashicorp/nomad/issues/10156)]

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -23,6 +23,12 @@ The Nomad agent metrics API now respects the
 configuration value. If this value is set to `false`, which is the default value,
 calling `/v1/metrics?format=prometheus` will now result in a response error.
 
+#### Connect native tasks
+
+Connect native tasks running in host networking mode will now have `CONSUL_HTTP_ADDR`
+set automatically. Before this was only the case for bridge networking. If an operator
+already explicitly set `CONSUL_HTTP_ADDR` then it will not get overriden.
+
 ## Nomad 1.0.3, 0.12.10
 
 Nomad versions 1.0.3 and 0.12.10 change the behavior of the `exec` and `java` drivers so that

--- a/website/content/partials/envvars.mdx
+++ b/website/content/partials/envvars.mdx
@@ -260,5 +260,65 @@
         Consul Connect enabled service.
       </td>
     </tr>
+    <tr>
+      <th colspan="2">Consul-related Variables (only set for connect native tasks)</th>
+    </tr>
+    <tr>
+      <td>
+        <code>CONSUL_HTTP_ADDR</code>
+      </td>
+      <td>
+        Specifies the address to the local Consul agent, will be a unix domain
+        socket in bridge mode and a tcp address in host networking.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>CONSUL_HTTP_TOKEN</code>
+      </td>
+      <td>
+        The token to authenticate against consul.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>CONSUL_HTTP_SSL</code>
+      </td>
+      <td>
+        Specifies whether HTTPS should be used when communicating with consul.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>CONSUL_HTTP_SSL_VERIFY</code>
+      </td>
+      <td>
+        Specifies whether the HTTPS connection should be verified.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>CONSUL_CACERT</code>
+      </td>
+      <td>
+        Specifies the path to the CA certificate used for Consul communication.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>CONSUL_CLIENT_CERT</code>
+      </td>
+      <td>
+        The client certificate to use when communicating with Consul.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>CONSUL_CLIENT_KEY</code>
+      </td>
+      <td>
+        The client key to use when communicating with Consul.
+      </td>
+    </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Fixes #10239. This only works if the `network` stanza is defined at the group level; otherwise
https://github.com/hashicorp/nomad/blob/3d9464023dbde64417468f4e623643d31fc3e7a5/nomad/job_endpoint_hook_connect.go#L100-L107
will skip the `groupConnectHook` which is responsible for setting the task kind to `connect-native`…

/cc @shoenig for a review :)