### PR TITLE
redirect from HTTP root to UI should include query params

### DIFF
--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -407,7 +407,11 @@ func (s *HTTPServer) handleUI(h http.Handler) http.Handler {
 func (s *HTTPServer) handleRootFallthrough() http.Handler {
 	return s.auditHTTPHandler(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.URL.Path == "/" {
-			http.Redirect(w, req, "/ui/", 307)
+			url := "/ui/"
+			if req.URL.RawQuery != "" {
+				url = url + "?" + req.URL.RawQuery
+			}
+			http.Redirect(w, req, url, 307)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -74,10 +74,11 @@ func TestRootFallthrough(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		desc         string
-		path         string
-		expectedPath string
-		expectedCode int
+		desc             string
+		path             string
+		expectedPath     string
+		expectedRawQuery string
+		expectedCode     int
 	}{
 		{
 			desc:         "unknown endpoint 404s",
@@ -89,6 +90,13 @@ func TestRootFallthrough(t *testing.T) {
 			path:         "/",
 			expectedPath: "/ui/",
 			expectedCode: 307,
+		},
+		{
+			desc:             "root path with one-time token redirects to ui",
+			path:             "/?ott=whatever",
+			expectedPath:     "/ui/",
+			expectedRawQuery: "ott=whatever",
+			expectedCode:     307,
 		},
 	}
 
@@ -115,6 +123,7 @@ func TestRootFallthrough(t *testing.T) {
 				loc, err := resp.Location()
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedPath, loc.Path)
+				require.Equal(t, tc.expectedRawQuery, loc.RawQuery)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10241

The OTT feature relies on having a query parameter for a one-time token which
gets handled by the UI. We need to make sure that query param is preserved
when redirecting from the root URL to the `/ui/` URI.