### PR TITLE
Node Drain Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ IMPROVEMENTS:
  * consul/connect: Added job-submission validation for Connect sidecar service and group names [[GH-10455](https://github.com/hashicorp/nomad/pull/10455)]
  * consul/connect: Automatically populate `CONSUL_HTTP_ADDR` for connect native tasks in host networking mode. [[GH-10239](https://github.com/hashicorp/nomad/issues/10239)]
  * consul/connect: Added `disable_default_tcp_check` field to `connect.sidecar_service` blocks to disable the default TCP listener check for Connect sidecar tasks. [[GH-10531](https://github.com/hashicorp/nomad/pull/10531)]
+ * core: Persist metadata about most recent drain in Node.LastDrain [[GH-10250](https://github.com/hashicorp/nomad/issues/10250)]
  * csi: Added support for jobs to request a unique volume ID per allocation. [[GH-10136](https://github.com/hashicorp/nomad/issues/10136)]
  * driver/docker: Added support for optional extra container labels. [[GH-9885](https://github.com/hashicorp/nomad/issues/9885)]
  * driver/docker: Added support for configuring default logger behavior in the client configuration. [[GH-10156](https://github.com/hashicorp/nomad/issues/10156)]

--- a/api/event_stream_test.go
+++ b/api/event_stream_test.go
@@ -167,7 +167,7 @@ func TestEventStream_PayloadValue(t *testing.T) {
 			require.Contains(t, raw, "Node")
 			rawNode := raw["Node"]
 			require.Equal(t, n.ID, rawNode["ID"])
-			require.NotContains(t, rawNode, "SecretID")
+			require.Empty(t, rawNode["SecretID"])
 		}
 	case <-time.After(5 * time.Second):
 		require.Fail(t, "failed waiting for event stream event")

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -71,6 +71,9 @@ type NodeUpdateDrainRequest struct {
 	// MarkEligible marks the node as eligible for scheduling if removing
 	// the drain strategy.
 	MarkEligible bool
+
+	// Meta allows operators to specify metadata related to the drain operation
+	Meta map[string]string
 }
 
 // NodeDrainUpdateResponse is used to respond to a node drain update
@@ -81,14 +84,45 @@ type NodeDrainUpdateResponse struct {
 	WriteMeta
 }
 
+// DrainOptions is used to pass through node drain parameters
+type DrainOptions struct {
+	// DrainSpec contains the drain specification for the node. If non-nil,
+	// the node will be marked ineligible and begin/continue draining according
+	// to the provided drain spec.
+	// If nil, any existing drain operation will be canceled.
+	DrainSpec *DrainSpec
+
+	// MarkEligible indicates whether the node should be marked as eligible when
+	// canceling a drain operation.
+	MarkEligible bool
+
+	// Meta is metadata that is persisted in Node.LastDrain about this
+	// drain update.
+	Meta map[string]string
+}
+
 // UpdateDrain is used to update the drain strategy for a given node. If
 // markEligible is true and the drain is being removed, the node will be marked
 // as having its scheduling being eligible
 func (n *Nodes) UpdateDrain(nodeID string, spec *DrainSpec, markEligible bool, q *WriteOptions) (*NodeDrainUpdateResponse, error) {
-	req := &NodeUpdateDrainRequest{
-		NodeID:       nodeID,
+	resp, err := n.UpdateDrainOpts(nodeID, DrainOptions{
 		DrainSpec:    spec,
 		MarkEligible: markEligible,
+		Meta:         nil,
+	}, q)
+	return resp, err
+}
+
+// UpdateDrainWithMeta is used to update the drain strategy for a given node. If
+// markEligible is true and the drain is being removed, the node will be marked
+// as having its scheduling being eligible
+func (n *Nodes) UpdateDrainOpts(nodeID string, opts DrainOptions, q *WriteOptions) (*NodeDrainUpdateResponse,
+	error) {
+	req := &NodeUpdateDrainRequest{
+		NodeID:       nodeID,
+		DrainSpec:    opts.DrainSpec,
+		MarkEligible: opts.MarkEligible,
+		Meta:         opts.Meta,
 	}
 
 	var resp NodeDrainUpdateResponse

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -18,6 +18,10 @@ const (
 	// status being ready.
 	NodeSchedulingEligible   = "eligible"
 	NodeSchedulingIneligible = "ineligible"
+
+	DrainStatusDraining  = "draining"
+	DrainStatusCompleted = "complete"
+	DrainStatusCancelled = "cancelled"
 )
 
 // Nodes is used to query node-related API endpoints
@@ -468,6 +472,15 @@ type HostVolumeInfo struct {
 	ReadOnly bool
 }
 
+// DrainMetadata contains information about the most recent drain operation for a given Node.
+type DrainMetadata struct {
+	StartedAt  time.Time
+	UpdatedAt  time.Time
+	Status     string
+	AccessorID string
+	Meta       map[string]string
+}
+
 // Node is used to deserialize a node entry.
 type Node struct {
 	ID                    string
@@ -494,6 +507,7 @@ type Node struct {
 	HostVolumes           map[string]*HostVolumeInfo
 	CSIControllerPlugins  map[string]*CSIInfo
 	CSINodePlugins        map[string]*CSIInfo
+	LastDrain             *DrainMetadata
 	CreateIndex           uint64
 	ModifyIndex           uint64
 }
@@ -789,6 +803,7 @@ type NodeListStub struct {
 	Drivers               map[string]*DriverInfo
 	NodeResources         *NodeResources         `json:",omitempty"`
 	ReservedResources     *NodeReservedResources `json:",omitempty"`
+	LastDrain             *DrainMetadata
 	CreateIndex           uint64
 	ModifyIndex           uint64
 }

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -105,7 +105,7 @@ type DrainOptions struct {
 // markEligible is true and the drain is being removed, the node will be marked
 // as having its scheduling being eligible
 func (n *Nodes) UpdateDrain(nodeID string, spec *DrainSpec, markEligible bool, q *WriteOptions) (*NodeDrainUpdateResponse, error) {
-	resp, err := n.UpdateDrainOpts(nodeID, DrainOptions{
+	resp, err := n.UpdateDrainOpts(nodeID, &DrainOptions{
 		DrainSpec:    spec,
 		MarkEligible: markEligible,
 		Meta:         nil,
@@ -116,7 +116,7 @@ func (n *Nodes) UpdateDrain(nodeID string, spec *DrainSpec, markEligible bool, q
 // UpdateDrainWithMeta is used to update the drain strategy for a given node. If
 // markEligible is true and the drain is being removed, the node will be marked
 // as having its scheduling being eligible
-func (n *Nodes) UpdateDrainOpts(nodeID string, opts DrainOptions, q *WriteOptions) (*NodeDrainUpdateResponse,
+func (n *Nodes) UpdateDrainOpts(nodeID string, opts *DrainOptions, q *WriteOptions) (*NodeDrainUpdateResponse,
 	error) {
 	req := &NodeUpdateDrainRequest{
 		NodeID:       nodeID,

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -19,9 +19,9 @@ const (
 	NodeSchedulingEligible   = "eligible"
 	NodeSchedulingIneligible = "ineligible"
 
-	DrainStatusDraining  = "draining"
-	DrainStatusCompleted = "complete"
-	DrainStatusCancelled = "cancelled"
+	DrainStatusDraining DrainStatus = "draining"
+	DrainStatusComplete DrainStatus = "complete"
+	DrainStatusCanceled DrainStatus = "canceled"
 )
 
 // Nodes is used to query node-related API endpoints
@@ -506,11 +506,13 @@ type HostVolumeInfo struct {
 	ReadOnly bool
 }
 
+type DrainStatus string
+
 // DrainMetadata contains information about the most recent drain operation for a given Node.
 type DrainMetadata struct {
 	StartedAt  time.Time
 	UpdatedAt  time.Time
-	Status     string
+	Status     DrainStatus
 	AccessorID string
 	Meta       map[string]string
 }

--- a/api/nodes_test.go
+++ b/api/nodes_test.go
@@ -291,7 +291,7 @@ func TestNodes_ToggleDrain(t *testing.T) {
 					sawDraining = node.ModifyIndex
 				} else if sawDraining != 0 && !node.Drain && node.SchedulingEligibility == NodeSchedulingIneligible {
 					require.NotNil(node.LastDrain)
-					require.Equal(DrainStatusCompleted, node.LastDrain.Status)
+					require.Equal(DrainStatusComplete, node.LastDrain.Status)
 					require.True(!node.LastDrain.UpdatedAt.Before(node.LastDrain.StartedAt))
 					require.Equal(drainMeta, node.LastDrain.Meta)
 					sawDrainComplete = node.ModifyIndex

--- a/command/agent/node_endpoint.go
+++ b/command/agent/node_endpoint.go
@@ -125,6 +125,7 @@ func (s *HTTPServer) nodeToggleDrain(resp http.ResponseWriter, req *http.Request
 	args := structs.NodeUpdateDrainRequest{
 		NodeID:       nodeID,
 		MarkEligible: drainRequest.MarkEligible,
+		Meta:         drainRequest.Meta,
 	}
 	if drainRequest.DrainSpec != nil {
 		args.DrainStrategy = &structs.DrainStrategy{

--- a/command/agent/node_endpoint_test.go
+++ b/command/agent/node_endpoint_test.go
@@ -262,7 +262,7 @@ func TestHTTP_NodeDrain(t *testing.T) {
 			},
 		}
 
-		beforeDrain := time.Now().Add(-1 * time.Second) // handle roundoff
+		beforeDrain := time.Unix(time.Now().Unix(), 0)
 
 		// Make the HTTP request
 		buf := encodeReq(drainReq)

--- a/command/agent/node_endpoint_test.go
+++ b/command/agent/node_endpoint_test.go
@@ -43,13 +43,13 @@ func TestHTTP_NodesList(t *testing.T) {
 		}
 
 		// Check for the index
-		if respW.HeaderMap.Get("X-Nomad-Index") == "" {
+		if respW.Header().Get("X-Nomad-Index") == "" {
 			t.Fatalf("missing index")
 		}
-		if respW.HeaderMap.Get("X-Nomad-KnownLeader") != "true" {
+		if respW.Header().Get("X-Nomad-KnownLeader") != "true" {
 			t.Fatalf("missing known leader")
 		}
-		if respW.HeaderMap.Get("X-Nomad-LastContact") == "" {
+		if respW.Header().Get("X-Nomad-LastContact") == "" {
 			t.Fatalf("missing last contact")
 		}
 
@@ -100,13 +100,13 @@ func TestHTTP_NodesPrefixList(t *testing.T) {
 		}
 
 		// Check for the index
-		if respW.HeaderMap.Get("X-Nomad-Index") == "" {
+		if respW.Header().Get("X-Nomad-Index") == "" {
 			t.Fatalf("missing index")
 		}
-		if respW.HeaderMap.Get("X-Nomad-KnownLeader") != "true" {
+		if respW.Header().Get("X-Nomad-KnownLeader") != "true" {
 			t.Fatalf("missing known leader")
 		}
-		if respW.HeaderMap.Get("X-Nomad-LastContact") == "" {
+		if respW.Header().Get("X-Nomad-LastContact") == "" {
 			t.Fatalf("missing last contact")
 		}
 
@@ -158,7 +158,7 @@ func TestHTTP_NodeForceEval(t *testing.T) {
 		}
 
 		// Check for the index
-		if respW.HeaderMap.Get("X-Nomad-Index") == "" {
+		if respW.Header().Get("X-Nomad-Index") == "" {
 			t.Fatalf("missing index")
 		}
 
@@ -218,13 +218,13 @@ func TestHTTP_NodeAllocations(t *testing.T) {
 		}
 
 		// Check for the index
-		if respW.HeaderMap.Get("X-Nomad-Index") == "" {
+		if respW.Header().Get("X-Nomad-Index") == "" {
 			t.Fatalf("missing index")
 		}
-		if respW.HeaderMap.Get("X-Nomad-KnownLeader") != "true" {
+		if respW.Header().Get("X-Nomad-KnownLeader") != "true" {
 			t.Fatalf("missing known leader")
 		}
-		if respW.HeaderMap.Get("X-Nomad-LastContact") == "" {
+		if respW.Header().Get("X-Nomad-LastContact") == "" {
 			t.Fatalf("missing last contact")
 		}
 
@@ -275,13 +275,13 @@ func TestHTTP_NodeDrain(t *testing.T) {
 		require.Nil(err)
 
 		// Check for the index
-		require.NotZero(respW.HeaderMap.Get("X-Nomad-Index"))
+		require.NotEmpty(respW.Header().Get("X-Nomad-Index"))
 
 		// Check the response
 		dresp, ok := obj.(structs.NodeDrainUpdateResponse)
 		require.True(ok)
 
-		t.Logf("response index=%v node_update_index=0x%x", respW.HeaderMap.Get("X-Nomad-Index"),
+		t.Logf("response index=%v node_update_index=0x%x", respW.Header().Get("X-Nomad-Index"),
 			dresp.NodeModifyIndex)
 
 		// Check that the node has been updated
@@ -304,6 +304,9 @@ func TestHTTP_NodeDrain(t *testing.T) {
 
 		// Make the HTTP request to unset drain
 		drainReq.DrainSpec = nil
+		drainReq.Meta = map[string]string{
+			"cancel_reason": "changed my mind",
+		}
 		buf = encodeReq(drainReq)
 		req, err = http.NewRequest("POST", "/v1/node/"+node.ID+"/drain", buf)
 		require.Nil(err)
@@ -319,7 +322,16 @@ func TestHTTP_NodeDrain(t *testing.T) {
 		require.NotNil(out.LastDrain)
 		require.False(out.LastDrain.StartedAt.Before(beforeDrain))
 		require.False(out.LastDrain.UpdatedAt.Before(out.LastDrain.StartedAt))
-		require.Equal(structs.DrainStatusCompleted, out.LastDrain.Status)
+		require.Contains([]string{structs.DrainStatusCancelled, structs.DrainStatusComplete}, out.LastDrain.Status)
+		if out.LastDrain.Status == structs.DrainStatusComplete {
+			require.Equal(map[string]string{
+				"reason": "drain",
+			}, out.LastDrain.Meta)
+		} else if out.LastDrain.Status == structs.DrainStatusCancelled {
+			require.Equal(map[string]string{
+				"cancel_reason": "changed my mind",
+			}, out.LastDrain.Meta)
+		}
 	})
 }
 
@@ -351,7 +363,7 @@ func TestHTTP_NodeEligible(t *testing.T) {
 		require.Nil(err)
 
 		// Check for the index
-		require.NotZero(respW.HeaderMap.Get("X-Nomad-Index"))
+		require.NotZero(respW.Header().Get("X-Nomad-Index"))
 
 		// Check the response
 		_, ok := obj.(structs.NodeEligibilityUpdateResponse)
@@ -417,7 +429,7 @@ func TestHTTP_NodePurge(t *testing.T) {
 		}
 
 		// Check for the index
-		if respW.HeaderMap.Get("X-Nomad-Index") == "" {
+		if respW.Header().Get("X-Nomad-Index") == "" {
 			t.Fatalf("missing index")
 		}
 
@@ -470,13 +482,13 @@ func TestHTTP_NodeQuery(t *testing.T) {
 		}
 
 		// Check for the index
-		if respW.HeaderMap.Get("X-Nomad-Index") == "" {
+		if respW.Header().Get("X-Nomad-Index") == "" {
 			t.Fatalf("missing index")
 		}
-		if respW.HeaderMap.Get("X-Nomad-KnownLeader") != "true" {
+		if respW.Header().Get("X-Nomad-KnownLeader") != "true" {
 			t.Fatalf("missing known leader")
 		}
-		if respW.HeaderMap.Get("X-Nomad-LastContact") == "" {
+		if respW.Header().Get("X-Nomad-LastContact") == "" {
 			t.Fatalf("missing last contact")
 		}
 

--- a/command/agent/node_endpoint_test.go
+++ b/command/agent/node_endpoint_test.go
@@ -322,12 +322,12 @@ func TestHTTP_NodeDrain(t *testing.T) {
 		require.NotNil(out.LastDrain)
 		require.False(out.LastDrain.StartedAt.Before(beforeDrain))
 		require.False(out.LastDrain.UpdatedAt.Before(out.LastDrain.StartedAt))
-		require.Contains([]string{structs.DrainStatusCancelled, structs.DrainStatusComplete}, out.LastDrain.Status)
+		require.Contains([]string{structs.DrainStatusCanceled, structs.DrainStatusComplete}, out.LastDrain.Status)
 		if out.LastDrain.Status == structs.DrainStatusComplete {
 			require.Equal(map[string]string{
 				"reason": "drain",
 			}, out.LastDrain.Meta)
-		} else if out.LastDrain.Status == structs.DrainStatusCancelled {
+		} else if out.LastDrain.Status == structs.DrainStatusCanceled {
 			require.Equal(map[string]string{
 				"cancel_reason": "changed my mind",
 			}, out.LastDrain.Meta)

--- a/command/agent/node_endpoint_test.go
+++ b/command/agent/node_endpoint_test.go
@@ -322,7 +322,7 @@ func TestHTTP_NodeDrain(t *testing.T) {
 		require.NotNil(out.LastDrain)
 		require.False(out.LastDrain.StartedAt.Before(beforeDrain))
 		require.False(out.LastDrain.UpdatedAt.Before(out.LastDrain.StartedAt))
-		require.Contains([]string{structs.DrainStatusCanceled, structs.DrainStatusComplete}, out.LastDrain.Status)
+		require.Contains([]structs.DrainStatus{structs.DrainStatusCanceled, structs.DrainStatusComplete}, out.LastDrain.Status)
 		if out.LastDrain.Status == structs.DrainStatusComplete {
 			require.Equal(map[string]string{
 				"reason": "drain",

--- a/command/node_drain.go
+++ b/command/node_drain.go
@@ -77,7 +77,7 @@ Node Drain Options:
     Message for the drain update operation. Registered in drain metadata as
     "message" for drain enable and "cancel_message" for drain disable.
 
-  --meta <key>=<value>
+  -meta <key>=<value>
     Custom metadata to store on thed drain operation, can be used multiple times.
 
   -self
@@ -105,7 +105,7 @@ func (c *NodeDrainCommand) AutocompleteFlags() complete.Flags {
 			"-ignore-system":   complete.PredictNothing,
 			"-keep-ineligible": complete.PredictNothing,
 			"-m":               complete.PredictNothing,
-			"--meta":           complete.PredictNothing,
+			"-meta":            complete.PredictNothing,
 			"-self":            complete.PredictNothing,
 			"-yes":             complete.PredictNothing,
 		})

--- a/command/node_drain.go
+++ b/command/node_drain.go
@@ -75,10 +75,10 @@ Node Drain Options:
 
   -m 
     Message for the drain update operation. Registered in drain metadata as
-    "message" for drain enable and "cancel_message" for drain disable.
+    "message" during drain enable and "cancel_message" during drain disable.
 
   -meta <key>=<value>
-    Custom metadata to store on thed drain operation, can be used multiple times.
+    Custom metadata to store on the drain operation, can be used multiple times.
 
   -self
     Set the drain status of the local node.

--- a/command/node_drain.go
+++ b/command/node_drain.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
+	flaghelper "github.com/hashicorp/nomad/helper/flags"
+
 	"github.com/posener/complete"
 )
 
@@ -71,6 +73,13 @@ Node Drain Options:
     the drain is being disabled. This is useful when an existing drain is being
     cancelled but additional scheduling on the node is not desired.
 
+  -m 
+    Message for the drain update operation. Registered in drain metadata as
+    "message" for drain enable and "cancel_message" for drain disable.
+
+  --meta <key>=<value>
+    Custom metadata to store on thed drain operation, can be used multiple times.
+
   -self
     Set the drain status of the local node.
 
@@ -95,6 +104,8 @@ func (c *NodeDrainCommand) AutocompleteFlags() complete.Flags {
 			"-no-deadline":     complete.PredictNothing,
 			"-ignore-system":   complete.PredictNothing,
 			"-keep-ineligible": complete.PredictNothing,
+			"-m":               complete.PredictNothing,
+			"--meta":           complete.PredictNothing,
 			"-self":            complete.PredictNothing,
 			"-yes":             complete.PredictNothing,
 		})
@@ -121,7 +132,8 @@ func (c *NodeDrainCommand) Run(args []string) int {
 	var enable, disable, detach, force,
 		noDeadline, ignoreSystem, keepIneligible,
 		self, autoYes, monitor bool
-	var deadline string
+	var deadline, message string
+	var metaVars flaghelper.StringFlag
 
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
@@ -136,6 +148,8 @@ func (c *NodeDrainCommand) Run(args []string) int {
 	flags.BoolVar(&self, "self", false, "")
 	flags.BoolVar(&autoYes, "yes", false, "Automatic yes to prompts.")
 	flags.BoolVar(&monitor, "monitor", false, "Monitor drain status.")
+	flags.StringVar(&message, "m", "", "Drain message")
+	flags.Var(&metaVars, "meta", "Drain metadata")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -251,7 +265,7 @@ func (c *NodeDrainCommand) Run(args []string) int {
 		return 1
 	}
 
-	// If monitoring the drain start the montior and return when done
+	// If monitoring the drain start the monitor and return when done
 	if monitor {
 		if node.DrainStrategy == nil {
 			c.Ui.Warn("No drain strategy set")
@@ -297,8 +311,38 @@ func (c *NodeDrainCommand) Run(args []string) int {
 		}
 	}
 
+	// fill drain metadata map, copy existing map if we're updating or cancelling drain
+	var drainMeta map[string]string
+	if node.DrainStrategy != nil && node.LastDrain != nil && node.LastDrain.Meta != nil {
+		drainMeta = node.LastDrain.Meta
+	} else {
+		drainMeta = make(map[string]string)
+	}
+	if message != "" {
+		if enable {
+			drainMeta["message"] = message
+		} else {
+			drainMeta["cancel_message"] = message
+		}
+	}
+	for _, m := range metaVars {
+		if len(m) == 0 {
+			continue
+		}
+		kv := strings.SplitN(m, "=", 2)
+		if len(kv) == 2 {
+			drainMeta[kv[0]] = kv[1]
+		} else {
+			drainMeta[kv[0]] = ""
+		}
+	}
+
 	// Toggle node draining
-	updateMeta, err := client.Nodes().UpdateDrain(node.ID, spec, !keepIneligible, nil)
+	drainResponse, err := client.Nodes().UpdateDrainOpts(node.ID, &api.DrainOptions{
+		DrainSpec:    spec,
+		MarkEligible: !keepIneligible,
+		Meta:         drainMeta,
+	}, nil)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error updating drain specification: %s", err))
 		return 1
@@ -316,7 +360,7 @@ func (c *NodeDrainCommand) Run(args []string) int {
 		now := time.Now()
 		c.Ui.Info(fmt.Sprintf("%s: Ctrl-C to stop monitoring: will not cancel the node drain", formatTime(now)))
 		c.Ui.Output(fmt.Sprintf("%s: Node %q drain strategy set", formatTime(now), node.ID))
-		c.monitorDrain(client, context.Background(), node, updateMeta.LastIndex, ignoreSystem)
+		c.monitorDrain(client, context.Background(), node, drainResponse.LastIndex, ignoreSystem)
 	}
 	return 0
 }

--- a/command/node_drain.go
+++ b/command/node_drain.go
@@ -311,7 +311,7 @@ func (c *NodeDrainCommand) Run(args []string) int {
 		}
 	}
 
-	// copy drain if cancelling and we have -m or -meta
+	// propagate drain metadata if cancelling
 	drainMeta := make(map[string]string)
 	if disable && node.LastDrain != nil && node.LastDrain.Meta != nil {
 		drainMeta = node.LastDrain.Meta

--- a/nomad/drainer/watch_nodes_test.go
+++ b/nomad/drainer/watch_nodes_test.go
@@ -88,7 +88,7 @@ func TestNodeDrainWatcher_Remove(t *testing.T) {
 	require.Equal(n, tracked[n.ID])
 
 	// Change the node to be not draining and wait for it to be untracked
-	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 101, n.ID, nil, false, 0, nil))
+	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 101, n.ID, nil, false, 0, nil, nil, ""))
 	testutil.WaitForResult(func() (bool, error) {
 		return len(m.events()) == 2, nil
 	}, func(err error) {
@@ -166,7 +166,7 @@ func TestNodeDrainWatcher_Update(t *testing.T) {
 	// Change the node to have a new spec
 	s2 := n.DrainStrategy.Copy()
 	s2.Deadline += time.Hour
-	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 101, n.ID, s2, false, 0, nil))
+	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 101, n.ID, s2, false, 0, nil, nil, ""))
 
 	// Wait for it to be updated
 	testutil.WaitForResult(func() (bool, error) {

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -515,6 +515,8 @@ func (n *Node) UpdateDrain(args *structs.NodeUpdateDrainRequest,
 	}
 	defer metrics.MeasureSince([]string{"nomad", "client", "update_drain"}, time.Now())
 
+	n.logger.Warn("Node.UpdateDrain info", "meta", args.Meta)
+
 	// Check node write permissions
 	if aclObj, err := n.srv.ResolveToken(args.AuthToken); err != nil {
 		return err
@@ -801,6 +803,7 @@ func (n *Node) GetNode(args *structs.NodeSpecificRequest,
 
 			// Setup the output
 			if out != nil {
+				n.logger.Warn("Node.GetNode()", "LastDrain", out.LastDrain)
 				out = out.Sanitize()
 				reply.Node = out
 				reply.Index = out.ModifyIndex

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -515,8 +515,6 @@ func (n *Node) UpdateDrain(args *structs.NodeUpdateDrainRequest,
 	}
 	defer metrics.MeasureSince([]string{"nomad", "client", "update_drain"}, time.Now())
 
-	n.logger.Warn("Node.UpdateDrain info", "meta", args.Meta)
-
 	// Check node write permissions
 	if aclObj, err := n.srv.ResolveToken(args.AuthToken); err != nil {
 		return err
@@ -803,7 +801,6 @@ func (n *Node) GetNode(args *structs.NodeSpecificRequest,
 
 			// Setup the output
 			if out != nil {
-				n.logger.Warn("Node.GetNode()", "LastDrain", out.LastDrain)
 				out = out.Sanitize()
 				reply.Node = out
 				reply.Index = out.ModifyIndex

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -903,7 +903,10 @@ func TestClientEndpoint_UpdateDrain(t *testing.T) {
 	dereg := &structs.NodeUpdateDrainRequest{
 		NodeID:        node.ID,
 		DrainStrategy: strategy,
-		WriteRequest:  structs.WriteRequest{Region: "global"},
+		Meta: map[string]string{
+			"message": "this node looks funny",
+		},
+		WriteRequest: structs.WriteRequest{Region: "global"},
 	}
 	var resp2 structs.NodeDrainUpdateResponse
 	require.Nil(msgpackrpc.CallWithCodec(codec, "Node.UpdateDrain", dereg, &resp2))
@@ -918,6 +921,11 @@ func TestClientEndpoint_UpdateDrain(t *testing.T) {
 	require.Equal(strategy.Deadline, out.DrainStrategy.Deadline)
 	require.Len(out.Events, 2)
 	require.Equal(NodeDrainEventDrainSet, out.Events[1].Message)
+	require.NotNil(out.LastDrain)
+	require.Equal(structs.DrainStatusDraining, out.LastDrain.Status)
+	require.True(out.LastDrain.StartedAt.Before(time.Now()))
+	require.Equal(out.LastDrain.StartedAt, out.LastDrain.UpdatedAt)
+	require.Equal("this node looks funny", out.LastDrain.Meta["message"])
 
 	// before+deadline should be before the forced deadline
 	require.True(beforeUpdate.Add(strategy.Deadline).Before(out.DrainStrategy.ForceDeadline))
@@ -1006,6 +1014,9 @@ func TestClientEndpoint_UpdateDrain_ACL(t *testing.T) {
 	{
 		var resp structs.NodeDrainUpdateResponse
 		require.Nil(msgpackrpc.CallWithCodec(codec, "Node.UpdateDrain", dereg, &resp), "RPC")
+		out, err := state.NodeByID(nil, node.ID)
+		require.NoError(err)
+		require.Equal(validToken.AccessorID, out.LastDrain.AccessorID)
 	}
 
 	// Try with a invalid token
@@ -2858,7 +2869,7 @@ func TestClientEndpoint_ListNodes_Blocking(t *testing.T) {
 				Deadline: 10 * time.Second,
 			},
 		}
-		errCh <- state.UpdateNodeDrain(structs.MsgTypeTestSetup, 3, node.ID, s, false, 0, nil)
+		errCh <- state.UpdateNodeDrain(structs.MsgTypeTestSetup, 3, node.ID, s, false, 0, nil, nil, "")
 	})
 
 	req.MinQueryIndex = 2

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -975,7 +975,7 @@ func TestClientEndpoint_UpdateDrain(t *testing.T) {
 	require.Equal(structs.DrainMetadata{
 		StartedAt: out.LastDrain.StartedAt,
 		UpdatedAt: out.LastDrain.UpdatedAt,
-		Status:    structs.DrainStatusCancelled,
+		Status:    structs.DrainStatusCanceled,
 		Meta:      map[string]string{"cancelled": "yes"},
 	}, *out.LastDrain)
 

--- a/nomad/state/events_test.go
+++ b/nomad/state/events_test.go
@@ -935,7 +935,7 @@ func TestNodeDrainEventFromChanges(t *testing.T) {
 	updatedAt := time.Now()
 	event := &structs.NodeEvent{}
 
-	require.NoError(t, s.updateNodeDrainImpl(tx, 100, node.ID, strat, markEligible, updatedAt.UnixNano(), event))
+	require.NoError(t, s.updateNodeDrainImpl(tx, 100, node.ID, strat, markEligible, updatedAt.UnixNano(), event, nil, "", false))
 	changes := Changes{Changes: tx.Changes(), Index: 100, MsgType: structs.NodeUpdateDrainRequestType}
 	got := eventsFromChanges(tx, changes)
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1034,7 +1034,6 @@ func (s *StateStore) updateNodeDrainImpl(txn *txn, index uint64, nodeID string,
 			updatedNode.LastDrain = &structs.DrainMetadata{
 				// we don't have sub-second accuracy on these fields, so truncate this
 				StartedAt: time.Unix(existingNode.DrainStrategy.StartedAt.Unix(), 0),
-				Status:    structs.DrainStatusDraining,
 				Meta:      drainMeta,
 			}
 		}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1034,7 +1034,7 @@ func (s *StateStore) updateNodeDrainImpl(txn *txn, index uint64, nodeID string,
 		case updatedNode.DrainStrategy != nil:
 			updatedNode.LastDrain.Status = structs.DrainStatusDraining
 		case drainCompleted:
-			updatedNode.LastDrain.Status = structs.DrainStatusCompleted
+			updatedNode.LastDrain.Status = structs.DrainStatusComplete
 		default:
 			updatedNode.LastDrain.Status = structs.DrainStatusCancelled
 		}
@@ -1050,7 +1050,7 @@ func (s *StateStore) updateNodeDrainImpl(txn *txn, index uint64, nodeID string,
 		}
 		if updatedNode.DrainStrategy == nil {
 			if drainCompleted {
-				updatedNode.LastDrain.Status = structs.DrainStatusCompleted
+				updatedNode.LastDrain.Status = structs.DrainStatusComplete
 			} else {
 				updatedNode.LastDrain.Status = structs.DrainStatusCancelled
 			}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1056,7 +1056,7 @@ func (s *StateStore) updateNodeDrainImpl(txn *txn, index uint64, nodeID string,
 		} else if drainCompleted {
 			updatedNode.LastDrain.Status = structs.DrainStatusComplete
 		} else {
-			updatedNode.LastDrain.Status = structs.DrainStatusCancelled
+			updatedNode.LastDrain.Status = structs.DrainStatusCanceled
 		}
 	}
 

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -1156,7 +1156,6 @@ func TestStateStore_UpdateNodeDrain_ResetEligiblity(t *testing.T) {
 	require.Nil(err)
 	require.Nil(out.DrainStrategy)
 	require.Equal(out.SchedulingEligibility, structs.NodeSchedulingEligible)
-	// TODO: cgbaker: more tests for LastDrain
 	require.NotNil(out.LastDrain)
 	require.Equal(structs.DrainStatusCancelled, out.LastDrain.Status)
 	require.Equal(time.Unix(7, 0), out.LastDrain.StartedAt)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -965,6 +965,9 @@ func TestStateStore_BatchUpdateNodeDrain(t *testing.T) {
 		require.Nil(err)
 		require.NotNil(out.DrainStrategy)
 		require.Equal(out.DrainStrategy, expectedDrain)
+		// TODO: cgbaker: more tests for LastDrain
+		require.NotNil(out.LastDrain)
+		require.Equal(structs.DrainStatusDraining, out.LastDrain.Status)
 		require.Len(out.Events, 2)
 		require.EqualValues(1002, out.ModifyIndex)
 		require.EqualValues(7, out.StatusUpdatedAt)
@@ -1001,13 +1004,16 @@ func TestStateStore_UpdateNodeDrain_Node(t *testing.T) {
 		Subsystem: structs.NodeEventSubsystemDrain,
 		Timestamp: time.Now(),
 	}
-	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 1001, node.ID, expectedDrain, false, 7, event))
+	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 1001, node.ID, expectedDrain, false, 7, event, nil, ""))
 	require.True(watchFired(ws))
 
 	ws = memdb.NewWatchSet()
 	out, err := state.NodeByID(ws, node.ID)
 	require.Nil(err)
 	require.NotNil(out.DrainStrategy)
+	// TODO: cgbaker: more tests for LastDrain
+	require.NotNil(out.LastDrain)
+	require.Equal(structs.DrainStatusDraining, out.LastDrain.Status)
 	require.Equal(out.DrainStrategy, expectedDrain)
 	require.Len(out.Events, 2)
 	require.EqualValues(1001, out.ModifyIndex)
@@ -1136,7 +1142,7 @@ func TestStateStore_UpdateNodeDrain_ResetEligiblity(t *testing.T) {
 		Subsystem: structs.NodeEventSubsystemDrain,
 		Timestamp: time.Now(),
 	}
-	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 1001, node.ID, drain, false, 7, event1))
+	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 1001, node.ID, drain, false, 7, event1, nil, ""))
 	require.True(watchFired(ws))
 
 	// Remove the drain
@@ -1145,13 +1151,18 @@ func TestStateStore_UpdateNodeDrain_ResetEligiblity(t *testing.T) {
 		Subsystem: structs.NodeEventSubsystemDrain,
 		Timestamp: time.Now(),
 	}
-	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 1002, node.ID, nil, true, 9, event2))
+	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 1002, node.ID, nil, true, 9, event2, nil, ""))
 
 	ws = memdb.NewWatchSet()
 	out, err := state.NodeByID(ws, node.ID)
 	require.Nil(err)
 	require.Nil(out.DrainStrategy)
 	require.Equal(out.SchedulingEligibility, structs.NodeSchedulingEligible)
+	// TODO: cgbaker: more tests for LastDrain
+	require.NotNil(out.LastDrain)
+	require.Equal(structs.DrainStatusCancelled, out.LastDrain.Status)
+	require.Equal(time.Unix(7, 0), out.LastDrain.StartedAt)
+	require.Equal(time.Unix(9, 0), out.LastDrain.UpdatedAt)
 	require.Len(out.Events, 3)
 	require.EqualValues(1002, out.ModifyIndex)
 	require.EqualValues(9, out.StatusUpdatedAt)
@@ -1210,7 +1221,7 @@ func TestStateStore_UpdateNodeEligibility(t *testing.T) {
 			Deadline: -1 * time.Second,
 		},
 	}
-	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 1002, node.ID, expectedDrain, false, 7, nil))
+	require.Nil(state.UpdateNodeDrain(structs.MsgTypeTestSetup, 1002, node.ID, expectedDrain, false, 7, nil, nil, ""))
 
 	// Try to set the node to eligible
 	err = state.UpdateNodeEligibility(structs.MsgTypeTestSetup, 1003, node.ID, structs.NodeSchedulingEligible, 9, nil)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -965,7 +965,6 @@ func TestStateStore_BatchUpdateNodeDrain(t *testing.T) {
 		require.Nil(err)
 		require.NotNil(out.DrainStrategy)
 		require.Equal(out.DrainStrategy, expectedDrain)
-		// TODO: cgbaker: more tests for LastDrain
 		require.NotNil(out.LastDrain)
 		require.Equal(structs.DrainStatusDraining, out.LastDrain.Status)
 		require.Len(out.Events, 2)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -1010,7 +1010,6 @@ func TestStateStore_UpdateNodeDrain_Node(t *testing.T) {
 	out, err := state.NodeByID(ws, node.ID)
 	require.Nil(err)
 	require.NotNil(out.DrainStrategy)
-	// TODO: cgbaker: more tests for LastDrain
 	require.NotNil(out.LastDrain)
 	require.Equal(structs.DrainStatusDraining, out.LastDrain.Status)
 	require.Equal(out.DrainStrategy, expectedDrain)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -1157,7 +1157,7 @@ func TestStateStore_UpdateNodeDrain_ResetEligiblity(t *testing.T) {
 	require.Nil(out.DrainStrategy)
 	require.Equal(out.SchedulingEligibility, structs.NodeSchedulingEligible)
 	require.NotNil(out.LastDrain)
-	require.Equal(structs.DrainStatusCancelled, out.LastDrain.Status)
+	require.Equal(structs.DrainStatusCanceled, out.LastDrain.Status)
 	require.Equal(time.Unix(7, 0), out.LastDrain.StartedAt)
 	require.Equal(time.Unix(9, 0), out.LastDrain.UpdatedAt)
 	require.Len(out.Events, 3)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1768,10 +1768,12 @@ func (d *DrainStrategy) Equal(o *DrainStrategy) bool {
 
 const (
 	// DrainStatuses are the various states a drain can be in, as reflect in DrainMetadata
-	DrainStatusDraining  = "draining"
-	DrainStatusComplete  = "complete"
-	DrainStatusCancelled = "cancelled"
+	DrainStatusDraining DrainStatus = "draining"
+	DrainStatusComplete DrainStatus = "complete"
+	DrainStatusCanceled DrainStatus = "canceled"
 )
+
+type DrainStatus string
 
 // DrainMetadata contains information about the most recent drain operation for a given Node.
 type DrainMetadata struct {
@@ -1783,8 +1785,8 @@ type DrainMetadata struct {
 	// or drain completion
 	UpdatedAt time.Time
 
-	// Status reflects the status of the drain operation: "draining", "completed", "cancelled"
-	Status string
+	// Status reflects the status of the drain operation.
+	Status DrainStatus
 
 	// AccessorID is the accessor ID of the ACL token used in the most recent API operation against this drain
 	AccessorID string

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1769,7 +1769,7 @@ func (d *DrainStrategy) Equal(o *DrainStrategy) bool {
 const (
 	// DrainStatuses are the various states a drain can be in, as reflect in DrainMetadata
 	DrainStatusDraining  = "draining"
-	DrainStatusCompleted = "complete"
+	DrainStatusComplete  = "complete"
 	DrainStatusCancelled = "cancelled"
 )
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -508,6 +508,9 @@ type NodeUpdateDrainRequest struct {
 	// UpdatedAt represents server time of receiving request
 	UpdatedAt int64
 
+	// Meta is user-provided metadata relating to the drain operation
+	Meta map[string]string
+
 	WriteRequest
 }
 
@@ -1763,6 +1766,43 @@ func (d *DrainStrategy) Equal(o *DrainStrategy) bool {
 	return true
 }
 
+const (
+	// DrainStatuses are the various states a drain can be in, as reflect in DrainMetadata
+	DrainStatusDraining  = "draining"
+	DrainStatusCompleted = "complete"
+	DrainStatusCancelled = "cancelled"
+)
+
+// DrainMetadata contains information about the most recent drain operation for a given Node.
+type DrainMetadata struct {
+	// StartedAt is the time that the drain operation started. This is equal to Node.DrainStrategy.StartedAt,
+	// if it exists
+	StartedAt time.Time
+
+	// UpdatedAt is the time that that this struct was most recently updated, either via API action
+	// or drain completion
+	UpdatedAt time.Time
+
+	// Status reflects the status of the drain operation: "draining", "completed", "cancelled"
+	Status string
+
+	// AccessorID is the accessor ID of the ACL token used in the most recent API operation against this drain
+	AccessorID string
+
+	// Meta includes the operator-submitted metadata about this drain operation
+	Meta map[string]string
+}
+
+func (m *DrainMetadata) Copy() *DrainMetadata {
+	if m == nil {
+		return nil
+	}
+	c := new(DrainMetadata)
+	*c = *m
+	c.Meta = helper.CopyMapStringString(m.Meta)
+	return c
+}
+
 // Node is a representation of a schedulable client node
 type Node struct {
 	// ID is a unique identifier for the node. It can be constructed
@@ -1773,7 +1813,7 @@ type Node struct {
 	// SecretID is an ID that is only known by the Node and the set of Servers.
 	// It is not accessible via the API and is used to authenticate nodes
 	// conducting privileged activities.
-	SecretID string `json:"-"`
+	SecretID string
 
 	// Datacenter for this node
 	Datacenter string
@@ -1864,6 +1904,9 @@ type Node struct {
 	// HostVolumes is a map of host volume names to their configuration
 	HostVolumes map[string]*ClientHostVolumeConfig
 
+	// LastDrain contains metadata about the most recent drain operation
+	LastDrain *DrainMetadata
+
 	// Raft Indexes
 	CreateIndex uint64
 	ModifyIndex uint64
@@ -1941,6 +1984,7 @@ func (n *Node) Copy() *Node {
 	nn.Meta = helper.CopyMapStringString(nn.Meta)
 	nn.Events = copyNodeEvents(n.Events)
 	nn.DrainStrategy = nn.DrainStrategy.Copy()
+	nn.LastDrain = nn.LastDrain.Copy()
 	nn.CSIControllerPlugins = copyNodeCSI(nn.CSIControllerPlugins)
 	nn.CSINodePlugins = copyNodeCSI(nn.CSINodePlugins)
 	nn.Drivers = copyNodeDrivers(n.Drivers)
@@ -2093,6 +2137,7 @@ func (n *Node) Stub(fields *NodeStubFields) *NodeListStub {
 		StatusDescription:     n.StatusDescription,
 		Drivers:               n.Drivers,
 		HostVolumes:           n.HostVolumes,
+		LastDrain:             n.LastDrain,
 		CreateIndex:           n.CreateIndex,
 		ModifyIndex:           n.ModifyIndex,
 	}
@@ -2124,6 +2169,7 @@ type NodeListStub struct {
 	HostVolumes           map[string]*ClientHostVolumeConfig
 	NodeResources         *NodeResources         `json:",omitempty"`
 	ReservedResources     *NodeReservedResources `json:",omitempty"`
+	LastDrain             *DrainMetadata
 	CreateIndex           uint64
 	ModifyIndex           uint64
 }

--- a/vendor/github.com/hashicorp/nomad/api/nodes.go
+++ b/vendor/github.com/hashicorp/nomad/api/nodes.go
@@ -468,6 +468,15 @@ type HostVolumeInfo struct {
 	ReadOnly bool
 }
 
+// DrainMetadata contains information about the most recent drain operation for a given Node.
+type DrainMetadata struct {
+	StartedAt  time.Time
+	UpdatedAt  time.Time
+	Status     string
+	AccessorID string
+	Meta       map[string]string
+}
+
 // Node is used to deserialize a node entry.
 type Node struct {
 	ID                    string
@@ -494,6 +503,7 @@ type Node struct {
 	HostVolumes           map[string]*HostVolumeInfo
 	CSIControllerPlugins  map[string]*CSIInfo
 	CSINodePlugins        map[string]*CSIInfo
+	LastDrain             *DrainMetadata
 	CreateIndex           uint64
 	ModifyIndex           uint64
 }
@@ -789,6 +799,7 @@ type NodeListStub struct {
 	Drivers               map[string]*DriverInfo
 	NodeResources         *NodeResources         `json:",omitempty"`
 	ReservedResources     *NodeReservedResources `json:",omitempty"`
+	LastDrain             *DrainMetadata
 	CreateIndex           uint64
 	ModifyIndex           uint64
 }

--- a/vendor/github.com/hashicorp/nomad/api/nodes.go
+++ b/vendor/github.com/hashicorp/nomad/api/nodes.go
@@ -105,7 +105,7 @@ type DrainOptions struct {
 // markEligible is true and the drain is being removed, the node will be marked
 // as having its scheduling being eligible
 func (n *Nodes) UpdateDrain(nodeID string, spec *DrainSpec, markEligible bool, q *WriteOptions) (*NodeDrainUpdateResponse, error) {
-	resp, err := n.UpdateDrainOpts(nodeID, DrainOptions{
+	resp, err := n.UpdateDrainOpts(nodeID, &DrainOptions{
 		DrainSpec:    spec,
 		MarkEligible: markEligible,
 		Meta:         nil,
@@ -116,7 +116,7 @@ func (n *Nodes) UpdateDrain(nodeID string, spec *DrainSpec, markEligible bool, q
 // UpdateDrainWithMeta is used to update the drain strategy for a given node. If
 // markEligible is true and the drain is being removed, the node will be marked
 // as having its scheduling being eligible
-func (n *Nodes) UpdateDrainOpts(nodeID string, opts DrainOptions, q *WriteOptions) (*NodeDrainUpdateResponse,
+func (n *Nodes) UpdateDrainOpts(nodeID string, opts *DrainOptions, q *WriteOptions) (*NodeDrainUpdateResponse,
 	error) {
 	req := &NodeUpdateDrainRequest{
 		NodeID:       nodeID,

--- a/vendor/github.com/hashicorp/nomad/api/nodes.go
+++ b/vendor/github.com/hashicorp/nomad/api/nodes.go
@@ -19,9 +19,9 @@ const (
 	NodeSchedulingEligible   = "eligible"
 	NodeSchedulingIneligible = "ineligible"
 
-	DrainStatusDraining  = "draining"
-	DrainStatusCompleted = "complete"
-	DrainStatusCancelled = "cancelled"
+	DrainStatusDraining DrainStatus = "draining"
+	DrainStatusComplete DrainStatus = "complete"
+	DrainStatusCanceled DrainStatus = "canceled"
 )
 
 // Nodes is used to query node-related API endpoints
@@ -506,11 +506,13 @@ type HostVolumeInfo struct {
 	ReadOnly bool
 }
 
+type DrainStatus string
+
 // DrainMetadata contains information about the most recent drain operation for a given Node.
 type DrainMetadata struct {
 	StartedAt  time.Time
 	UpdatedAt  time.Time
-	Status     string
+	Status     DrainStatus
 	AccessorID string
 	Meta       map[string]string
 }

--- a/website/content/api-docs/nodes.mdx
+++ b/website/content/api-docs/nodes.mdx
@@ -112,6 +112,7 @@ $ curl \
       }
     },
     "ID": "f7476465-4d6e-c0de-26d0-e383c49be941",
+    "LastDrain": null,
     "ModifyIndex": 2526,
     "Name": "nomad-4",
     "NodeClass": "",
@@ -180,7 +181,7 @@ $ curl \
     "memory.totalbytes": "16571674624",
     "nomad.advertise.address": "127.0.0.1:4646",
     "nomad.revision": "30da2b8f6c3aa860113c9d313c695a05eff5bb97+CHANGES",
-    "nomad.version": "0.10.0-dev",
+    "nomad.version": "1.1.0",
     "os.name": "nixos",
     "os.signals": "SIGTTOU,SIGTTIN,SIGSTOP,SIGSYS,SIGXCPU,SIGBUS,SIGKILL,SIGTERM,SIGIOT,SIGILL,SIGIO,SIGQUIT,SIGSEGV,SIGUSR1,SIGXFSZ,SIGCHLD,SIGUSR2,SIGURG,SIGFPE,SIGHUP,SIGINT,SIGPROF,SIGCONT,SIGALRM,SIGPIPE,SIGTRAP,SIGTSTP,SIGWINCH,SIGABRT",
     "os.version": "\"19.03.173017.85f820d6e41 (Koi)\"",
@@ -261,11 +262,25 @@ $ curl \
   },
   "Events": [
     {
-      "CreateIndex": 0,
+      "CreateIndex": 6,
       "Details": null,
       "Message": "Node registered",
       "Subsystem": "Cluster",
-      "Timestamp": "2019-08-26T12:22:50+02:00"
+      "Timestamp": "2021-03-31T12:11:39Z"
+    },
+    {
+      "CreateIndex": 11,
+      "Details": null,
+      "Message": "Node drain strategy set",
+      "Subsystem": "Drain",
+      "Timestamp": "2021-03-31T12:12:20.213412Z"
+    },
+    {
+      "CreateIndex": 12,
+      "Details": null,
+      "Message": "Node drain complete",
+      "Subsystem": "Drain",
+      "Timestamp": "2021-03-31T12:12:20.213639Z"
     }
   ],
   "HTTPAddr": "127.0.0.1:4646",
@@ -282,6 +297,15 @@ $ curl \
     }
   },
   "ID": "1ac61e33-a465-2ace-f63f-cffa1285e7eb",
+  "LastDrain": {
+    "AccessorID": "4e1b7ce1-f8aa-d7ff-09f1-55c3a0fd3988",
+    "Meta": {
+      "message": "node maintenance"
+    },
+    "StartedAt": "2021-03-31T12:12:20Z",
+    "Status": "complete",
+    "UpdatedAt": "2021-03-31T12:12:20Z"
+  },
   "Links": {
     "consul": "dc1.mew"
   },
@@ -289,7 +313,7 @@ $ curl \
     "connect.log_level": "info",
     "connect.sidecar_image": "envoyproxy/envoy:v1.11.1"
   },
-  "ModifyIndex": 9,
+  "ModifyIndex": 14,
   "Name": "mew",
   "NodeClass": "",
   "NodeResources": {
@@ -929,6 +953,9 @@ The table below shows this endpoint's support for
 - `MarkEligible` `(bool: false)` - Specifies whether to mark a node as eligible
   for scheduling again when _disabling_ a drain.
 
+- `Meta` `(json: <optional>)` - A JSON map of strings with drain operation
+  metadata that will be persisted in `.LastDrain.Meta`.
+
 ### Sample Payload
 
 ```json
@@ -936,6 +963,9 @@ The table below shows this endpoint's support for
   "DrainSpec": {
     "Deadline": 3600000000000,
     "IgnoreSystemJobs": true
+  },
+  "Meta": {
+    "message": "drain for maintenance"
   }
 }
 ```

--- a/website/content/docs/commands/node/drain.mdx
+++ b/website/content/docs/commands/node/drain.mdx
@@ -79,6 +79,12 @@ capability.
   existing drain is being cancelled but additional scheduling on the node is not
   desired.
 
+- `-m`: Message for the drain update operation. Registered in drain metadata as
+  `"message"` during drain enable and `"cancel_message"` during drain disable.
+
+- `-meta <key>=<value>`: Custom metadata to store on the drain operation, can be
+  used multiple times.
+
 - `-self`: Drain the local node.
 
 - `-yes`: Automatic yes to prompts.
@@ -88,7 +94,7 @@ capability.
 Enable drain mode on node with ID prefix "4d2ba53b":
 
 ```shell-session
-$ nomad node drain -enable f4e8a9e5
+$ nomad node drain -enable f4e8a9e5 -m "node maintenance"
 Are you sure you want to enable drain mode for node "f4e8a9e5-30d8-3536-1e6f-cda5c869c35e"? [y/N] y
 2018-03-30T23:13:16Z: Ctrl-C to stop monitoring: will not cancel the node drain
 2018-03-30T23:13:16Z: Node "f4e8a9e5-30d8-3536-1e6f-cda5c869c35e" drain strategy set


### PR DESCRIPTION
resolves #9928 

This persists information about the last "drain operation" in a new `Node.LastDrain` field. A "drain operation" begins when the node begins draining, and ends when the drain is complete or canceled. A new drain operation will overwrite any existing `Node.LastDrain` field.

In addition to native metadata about the drain operation (start time, status, end time), operators can provide additional key/value pairs about the drain operation:
* API: via the `.Meta` field in the drain payload
* CLI: via the `-meta` flag or the `-m` git-style shortcut (which is a shortcut for `Meta.message` or `Meta.cancel_message`, appropriately)

The work in this PR performs the following:
* a new field `LastDrain` in `structs.Node` and `api.Node`
* updates to the FSM and the state store to propagate `LastDrain`
  * a fair bit of this was just around properly resetting or propagating this field
* tests, including the distinction between drain cancellation and completion
* API and SDK support for `LastDrain` and drain metadata during drain updates
* CLI support for `-m` and `-meta`
* CLI and API documentation

