### PR TITLE
Debug: Remove extra linefeed in monitor.log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ BUG FIXES:
  * api: Removed unimplemented `CSIVolumes.PluginList` API. [[GH-10158](https://github.com/hashicorp/nomad/issues/10158)]
  * cli: Fixed a bug where non-int proxy port would panic CLI [[GH-10072](https://github.com/hashicorp/nomad/issues/10072)]
  * cli: Fixed a bug where `nomad operator debug` incorrectly parsed https Consul API URLs. [[GH-10082](https://github.com/hashicorp/nomad/pull/10082)]
+ * cli: Remove extra linefeeds in monitor.log files written by `nomad operator debug`. [[GH-10252](https://github.com/hashicorp/nomad/issues/10252)]
  * client: Fixed log formatting when killing tasks. [[GH-10135](https://github.com/hashicorp/nomad/issues/10135)]
  * csi: Fixed a bug where volume with IDs that are a substring prefix of another volume could use the wrong volume for feasibility checking. [[GH-10158](https://github.com/hashicorp/nomad/issues/10158)]
  * scheduler: Fixed a bug where jobs requesting multiple CSI volumes could be incorrectly scheduled if only one of the volumes passed feasibility checking. [[GH-10143](https://github.com/hashicorp/nomad/issues/10143)]

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -567,7 +567,6 @@ func (c *OperatorDebugCommand) startMonitor(path, idKey, nodeID string, client *
 				continue
 			}
 			fh.Write(out.Data)
-			fh.WriteString("\n")
 
 		case err := <-errCh:
 			fh.WriteString(fmt.Sprintf("monitor: %s\n", err.Error()))


### PR DESCRIPTION
Remove extra linefeed character written to `monitor.log` after each StreamFrame.  Fixes #9889.

Linefeeds are already included in the buffer from StreamFrame.  When a full frame was received (1024 bytes) the extra LF split the last log line in the frame.  Frames with less than 1024 bytes resulted in an extra blank line written to file.