### PR TITLE
CSI: unset proto fields for volume create should be nil

### DIFF
--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -463,6 +463,9 @@ func (r *ControllerCreateVolumeRequest) Validate() error {
 	return nil
 }
 
+// VolumeContentSource is snapshot or volume that the plugin will use to
+// create the new volume. At most one of these fields can be set, but nil (and
+// not an empty struct) is expected by CSI plugins if neither field is set.
 type VolumeContentSource struct {
 	SnapshotID string
 	CloneID    string
@@ -479,8 +482,7 @@ func (vcr *VolumeContentSource) ToCSIRepresentation() *csipbv1.VolumeContentSour
 				VolumeId: vcr.CloneID,
 			},
 		}
-	}
-	if vcr.SnapshotID != "" {
+	} else if vcr.SnapshotID != "" {
 		result.Type = &csipbv1.VolumeContentSource_Snapshot{
 			Snapshot: &csipbv1.VolumeContentSource_SnapshotSource{
 				SnapshotId: vcr.SnapshotID,

--- a/plugins/csi/testing/client.go
+++ b/plugins/csi/testing/client.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"context"
+	"fmt"
 
 	csipbv1 "github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
@@ -87,6 +88,17 @@ func (c *ControllerClient) ValidateVolumeCapabilities(ctx context.Context, in *c
 }
 
 func (c *ControllerClient) CreateVolume(ctx context.Context, in *csipbv1.CreateVolumeRequest, opts ...grpc.CallOption) (*csipbv1.CreateVolumeResponse, error) {
+	if in.VolumeContentSource != nil {
+		if in.VolumeContentSource.Type == nil || (in.VolumeContentSource.Type ==
+			&csipbv1.VolumeContentSource_Volume{
+				Volume: &csipbv1.VolumeContentSource_VolumeSource{VolumeId: ""},
+			}) || (in.VolumeContentSource.Type ==
+			&csipbv1.VolumeContentSource_Snapshot{
+				Snapshot: &csipbv1.VolumeContentSource_SnapshotSource{SnapshotId: ""},
+			}) {
+			return nil, fmt.Errorf("empty content source should be nil")
+		}
+	}
 	return c.NextCreateVolumeResponse, c.NextErr
 }
 


### PR DESCRIPTION
The CSI spec handles empty fields and nil fields in the protobuf differently,
which may result in validation failures for creating volumes with no prior
source (and does in testing with the AWS EBS plugin). Refactor the
`CreateVolumeRequest` mapping to the protobuf in the plugin client to avoid
this bug.

Reviewers: note this is targeting `csi-create-volume`