### PR TITLE
fix(circle): change website branch filter to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -656,7 +656,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
 
       - algolia_index:
           context: static-sites


### PR DESCRIPTION
I believe this should be `main` so that the website image will get built on the base branch.