### PR TITLE
drivers/docker: fix flaky image coordinator test

### DIFF
--- a/drivers/docker/coordinator_test.go
+++ b/drivers/docker/coordinator_test.go
@@ -168,11 +168,15 @@ func TestDockerCoordinator_Pull_Remove(t *testing.T) {
 	})
 
 	// Make sure there is no future still
-	coordinator.imageLock.Lock()
-	if _, ok := coordinator.deleteFuture[id]; ok {
-		t.Fatal("Got delete future")
-	}
-	coordinator.imageLock.Unlock()
+	testutil.WaitForResult(func() (bool, error) {
+		coordinator.imageLock.Lock()
+		defer coordinator.imageLock.Unlock()
+		_, ok := coordinator.deleteFuture[id]
+		return !ok, fmt.Errorf("got delete future")
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
 }
 
 func TestDockerCoordinator_Remove_Cancel(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10197

The test assertion that we don't have a delete future remaining races with the
code it's testing, because the removal of the image and the removal of the
future are not atomic. Move this assertion into a `WaitForResult` to avoid
test flakes which we're seeing on CI on Windows in particular.