### PR TITLE
api: set operator query meta

### DIFF
--- a/api/operator.go
+++ b/api/operator.go
@@ -319,7 +319,7 @@ func (op *Operator) LicenseGet(q *QueryOptions) (*LicenseReply, *QueryMeta, erro
 	}
 
 	var reply LicenseReply
-	_, resp, err := op.c.doRequest(req)
+	rtt, resp, err := op.c.doRequest(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -330,9 +330,13 @@ func (op *Operator) LicenseGet(q *QueryOptions) (*LicenseReply, *QueryMeta, erro
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&reply)
-	if err == nil {
-		return &reply, nil, nil
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return nil, nil, err
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	return &reply, qm, nil
 }

--- a/vendor/github.com/hashicorp/nomad/api/operator.go
+++ b/vendor/github.com/hashicorp/nomad/api/operator.go
@@ -319,7 +319,7 @@ func (op *Operator) LicenseGet(q *QueryOptions) (*LicenseReply, *QueryMeta, erro
 	}
 
 	var reply LicenseReply
-	_, resp, err := op.c.doRequest(req)
+	rtt, resp, err := op.c.doRequest(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -330,9 +330,13 @@ func (op *Operator) LicenseGet(q *QueryOptions) (*LicenseReply, *QueryMeta, erro
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&reply)
-	if err == nil {
-		return &reply, nil, nil
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return nil, nil, err
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	return &reply, qm, nil
 }


### PR DESCRIPTION
Set the query meta for LicenseGet request. It's expected by api consumers to determine the raft index.

This fixes a regression in 1.0.4. I'll add a test for this on the Enterprise repository.