### PR TITLE
dev: ignore msgpack codegen code in dev by default

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,7 +7,12 @@ GIT_COMMIT := $(shell git rev-parse HEAD)
 GIT_DIRTY := $(if $(shell git status --porcelain),+CHANGES)
 
 GO_LDFLAGS := "-X github.com/hashicorp/nomad/version.GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)"
-GO_TAGS ?= codegen_generated
+
+GO_TAGS ?=
+
+ifeq ($(CI),true)
+GO_TAGS := codegen_generated $(GO_TAGS)
+endif
 
 GO_TEST_CMD = $(if $(shell command -v gotestsum 2>/dev/null),gotestsum --,go test)
 


### PR DESCRIPTION
This change disables using msgpack generated serializers in dev by
default.

In released binaries, we use code-generated msgpack serializers to
improve performance.  However, in development, code generated
serializers are a pain. If a developer forgets to re-generate code, the
code generated gets out of sync with the go structs, and result into
subtle bugs where some values appear not to persist as expected.

The CI and release scripts will continue to use the msgpack
code-generation. Devs who want to test locally can set
`GO_TAGS=codegen_generated` as well.