### PR TITLE
Memory stats for cgroup-v2

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/restarts"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/posener/complete"
 )
@@ -589,7 +590,7 @@ func (c *AllocStatusCommand) outputTaskResources(alloc *api.Allocation, task str
 				// Nomad uses RSS as the top-level metric to report, for historical reasons,
 				// but it's not always measured (e.g. with cgroup-v2)
 				usage := ms.RSS
-				if usage == 0 && !stringsContain(ms.Measured, "RSS") {
+				if usage == 0 && !helper.SliceStringContains(ms.Measured, "RSS") {
 					usage = ms.Usage
 				}
 				memUsage = fmt.Sprintf("%v/%v", humanize.IBytes(usage), memUsage)

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -542,14 +542,3 @@ func (w *uiErrorWriter) Close() error {
 	}
 	return nil
 }
-
-// stringsContains returns true if s is present in the vs string slice
-func stringsContain(vs []string, s string) bool {
-	for _, v := range vs {
-		if v == s {
-			return true
-		}
-	}
-
-	return false
-}

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -542,3 +542,14 @@ func (w *uiErrorWriter) Close() error {
 	}
 	return nil
 }
+
+// stringsContains returns true if s is present in the vs string slice
+func stringsContain(vs []string, s string) bool {
+	for _, v := range vs {
+		if v == s {
+			return true
+		}
+	}
+
+	return false
+}

--- a/drivers/docker/util/stats_posix.go
+++ b/drivers/docker/util/stats_posix.go
@@ -21,7 +21,7 @@ var (
 func DockerStatsToTaskResourceUsage(s *docker.Stats) *cstructs.TaskResourceUsage {
 	measuredMems := DockerCgroupV1MeasuredMemStats
 
-	// use a simple heauristic to check if cgroup-v2 is used.
+	// use a simple heuristic to check if cgroup-v2 is used.
 	// go-dockerclient doesn't distinguish between 0 and not-present value
 	if s.MemoryStats.Stats.Rss == 0 && s.MemoryStats.MaxUsage == 0 && s.MemoryStats.Usage != 0 {
 		measuredMems = DockerCgroupV2MeasuredMemStats

--- a/drivers/docker/util/stats_posix.go
+++ b/drivers/docker/util/stats_posix.go
@@ -12,17 +12,28 @@ import (
 
 var (
 	DockerMeasuredCPUStats = []string{"Throttled Periods", "Throttled Time", "Percent"}
-	DockerMeasuredMemStats = []string{"RSS", "Cache", "Swap", "Usage", "Max Usage"}
+
+	// cgroup-v2 only exposes a subset of memory stats
+	DockerCgroupV1MeasuredMemStats = []string{"RSS", "Cache", "Swap", "Usage", "Max Usage"}
+	DockerCgroupV2MeasuredMemStats = []string{"Cache", "Swap", "Usage"}
 )
 
 func DockerStatsToTaskResourceUsage(s *docker.Stats) *cstructs.TaskResourceUsage {
+	measuredMems := DockerCgroupV1MeasuredMemStats
+
+	// use a simple heauristic to check if cgroup-v2 is used.
+	// go-dockerclient doesn't distinguish between 0 and not-present value
+	if s.MemoryStats.Stats.Rss == 0 && s.MemoryStats.MaxUsage == 0 && s.MemoryStats.Usage != 0 {
+		measuredMems = DockerCgroupV2MeasuredMemStats
+	}
+
 	ms := &cstructs.MemoryStats{
 		RSS:      s.MemoryStats.Stats.Rss,
 		Cache:    s.MemoryStats.Stats.Cache,
 		Swap:     s.MemoryStats.Stats.Swap,
 		Usage:    s.MemoryStats.Usage,
 		MaxUsage: s.MemoryStats.MaxUsage,
-		Measured: DockerMeasuredMemStats,
+		Measured: measuredMems,
 	}
 
 	cs := &cstructs.CpuStats{

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -39,8 +39,11 @@ const (
 )
 
 var (
-	// ExecutorCgroupMeasuredMemStats is the list of memory stats captured by the executor
-	ExecutorCgroupMeasuredMemStats = []string{"RSS", "Cache", "Swap", "Usage", "Max Usage", "Kernel Usage", "Kernel Max Usage"}
+	// ExecutorCgroupV1MeasuredMemStats is the list of memory stats captured by the executor with cgroup-v1
+	ExecutorCgroupV1MeasuredMemStats = []string{"RSS", "Cache", "Swap", "Usage", "Max Usage", "Kernel Usage", "Kernel Max Usage"}
+
+	// ExecutorCgroupV2MeasuredMemStats is the list of memory stats captured by the executor with cgroup-v2. cgroup-v2 exposes different memory stats and no longer reports rss or max usage.
+	ExecutorCgroupV2MeasuredMemStats = []string{"Cache", "Swap", "Usage"}
 
 	// ExecutorCgroupMeasuredCpuStats is the list of CPU stats captures by the executor
 	ExecutorCgroupMeasuredCpuStats = []string{"System Mode", "User Mode", "Throttled Periods", "Throttled Time", "Percent"}
@@ -342,6 +345,12 @@ func (l *LibcontainerExecutor) Stats(ctx context.Context, interval time.Duration
 func (l *LibcontainerExecutor) handleStats(ch chan *cstructs.TaskResourceUsage, ctx context.Context, interval time.Duration) {
 	defer close(ch)
 	timer := time.NewTimer(0)
+
+	measuredMemStats := ExecutorCgroupV1MeasuredMemStats
+	if cgroups.IsCgroup2UnifiedMode() {
+		measuredMemStats = ExecutorCgroupV2MeasuredMemStats
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -379,7 +388,7 @@ func (l *LibcontainerExecutor) handleStats(ch chan *cstructs.TaskResourceUsage, 
 			MaxUsage:       maxUsage,
 			KernelUsage:    stats.MemoryStats.KernelUsage.Usage,
 			KernelMaxUsage: stats.MemoryStats.KernelUsage.MaxUsage,
-			Measured:       ExecutorCgroupMeasuredMemStats,
+			Measured:       measuredMemStats,
 		}
 
 		// CPU Related Stats


### PR DESCRIPTION
When running with cgroup-v2, the measured memory stats are Usage, Cache, and Swap only: https://github.com/opencontainers/runc/blob/v1.0.0-rc93/libcontainer/cgroups/fs2/memory.go#L75-L106 .

Also, in RSS isn't measured in a task, then `nomad alloc status` will use the reported Usage for the top level item.  This PR only changes the CLI, and we need to update the UI as well.

Fixes #10190
Related to #10251
