### PR TITLE
move json handle back to `structs`

### DIFF
--- a/client/agent_endpoint.go
+++ b/client/agent_endpoint.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/nomad/command/agent/monitor"
 	"github.com/hashicorp/nomad/command/agent/pprof"
 	"github.com/hashicorp/nomad/helper"
-	"github.com/hashicorp/nomad/nomad/jsonhandles"
 	"github.com/hashicorp/nomad/nomad/structs"
 
 	metrics "github.com/armon/go-metrics"
@@ -124,7 +123,7 @@ func (a *Agent) monitor(conn io.ReadWriteCloser) {
 	frames := make(chan *sframer.StreamFrame, streamFramesBuffer)
 	errCh := make(chan error)
 	var buf bytes.Buffer
-	frameCodec := codec.NewEncoder(&buf, jsonhandles.JsonHandle)
+	frameCodec := codec.NewEncoder(&buf, structs.JsonHandle)
 
 	framer := sframer.NewStreamFramer(frames, 1*time.Second, 200*time.Millisecond, 1024)
 	framer.Run()

--- a/client/alloc_endpoint.go
+++ b/client/alloc_endpoint.go
@@ -15,7 +15,6 @@ import (
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/uuid"
-	"github.com/hashicorp/nomad/nomad/jsonhandles"
 	"github.com/hashicorp/nomad/nomad/structs"
 	nstructs "github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
@@ -281,7 +280,7 @@ func newExecStream(decoder *codec.Decoder, encoder *codec.Encoder) drivers.ExecT
 
 		buf:        buf,
 		encoder:    encoder,
-		frameCodec: codec.NewEncoder(buf, jsonhandles.JsonHandle),
+		frameCodec: codec.NewEncoder(buf, nstructs.JsonHandle),
 	}
 }
 

--- a/client/fs_endpoint.go
+++ b/client/fs_endpoint.go
@@ -24,7 +24,6 @@ import (
 	sframer "github.com/hashicorp/nomad/client/lib/streamframer"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/helper"
-	"github.com/hashicorp/nomad/nomad/jsonhandles"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -239,7 +238,7 @@ func (f *FileSystem) stream(conn io.ReadWriteCloser) {
 	frames := make(chan *sframer.StreamFrame, streamFramesBuffer)
 	errCh := make(chan error)
 	var buf bytes.Buffer
-	frameCodec := codec.NewEncoder(&buf, jsonhandles.JsonHandle)
+	frameCodec := codec.NewEncoder(&buf, structs.JsonHandle)
 
 	// Create the framer
 	framer := sframer.NewStreamFramer(frames, streamHeartbeatRate, streamBatchWindow, streamFrameSize)
@@ -470,7 +469,7 @@ func (f *FileSystem) logs(conn io.ReadWriteCloser) {
 
 	var streamErr error
 	buf := new(bytes.Buffer)
-	frameCodec := codec.NewEncoder(buf, jsonhandles.JsonHandle)
+	frameCodec := codec.NewEncoder(buf, structs.JsonHandle)
 OUTER:
 	for {
 		select {

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/hashicorp/nomad/helper/noxssrw"
 	"github.com/hashicorp/nomad/helper/tlsutil"
-	"github.com/hashicorp/nomad/nomad/jsonhandles"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -501,13 +500,13 @@ func (s *HTTPServer) wrap(handler func(resp http.ResponseWriter, req *http.Reque
 		if obj != nil {
 			var buf bytes.Buffer
 			if prettyPrint {
-				enc := codec.NewEncoder(&buf, jsonhandles.JsonHandlePretty)
+				enc := codec.NewEncoder(&buf, structs.JsonHandlePretty)
 				err = enc.Encode(obj)
 				if err == nil {
 					buf.Write([]byte("\n"))
 				}
 			} else {
-				enc := codec.NewEncoder(&buf, jsonhandles.JsonHandleWithExtensions)
+				enc := codec.NewEncoder(&buf, structs.JsonHandleWithExtensions)
 				err = enc.Encode(obj)
 			}
 			if err != nil {

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -20,17 +20,15 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-msgpack/codec"
-	"github.com/hashicorp/nomad/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/testutil"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/hashicorp/nomad/nomad/jsonhandles"
 )
 
 // makeHTTPServer returns a test server whose logs will be written to
@@ -323,11 +321,11 @@ func testPrettyPrint(pretty string, prettyFmt bool, t *testing.T) {
 	var expected bytes.Buffer
 	var err error
 	if prettyFmt {
-		enc := codec.NewEncoder(&expected, jsonhandles.JsonHandlePretty)
+		enc := codec.NewEncoder(&expected, structs.JsonHandlePretty)
 		err = enc.Encode(r)
 		expected.WriteByte('\n')
 	} else {
-		enc := codec.NewEncoder(&expected, jsonhandles.JsonHandleWithExtensions)
+		enc := codec.NewEncoder(&expected, structs.JsonHandleWithExtensions)
 		err = enc.Encode(r)
 	}
 	if err != nil {
@@ -1300,13 +1298,13 @@ func Test_decodeBody(t *testing.T) {
 // BenchmarkHTTPServer_JSONEncodingWithExtensions benchmarks the performance of
 // encoding JSON objects using extensions
 func BenchmarkHTTPServer_JSONEncodingWithExtensions(b *testing.B) {
-	benchmarkJsonEncoding(b, jsonhandles.JsonHandleWithExtensions)
+	benchmarkJsonEncoding(b, structs.JsonHandleWithExtensions)
 }
 
 // BenchmarkHTTPServer_JSONEncodingWithoutExtensions benchmarks the performance of
 // encoding JSON objects using extensions
 func BenchmarkHTTPServer_JSONEncodingWithoutExtensions(b *testing.B) {
-	benchmarkJsonEncoding(b, jsonhandles.JsonHandle)
+	benchmarkJsonEncoding(b, structs.JsonHandle)
 }
 
 func benchmarkJsonEncoding(b *testing.B, handle *codec.JsonHandle) {

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"

--- a/helper/pluginutils/hclutils/testing.go
+++ b/helper/pluginutils/hclutils/testing.go
@@ -11,7 +11,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/nomad/helper/pluginutils/hclspecutils"
-	"github.com/hashicorp/nomad/nomad/jsonhandles"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
 )
@@ -122,7 +122,7 @@ func JsonConfigToInterface(t *testing.T, config string) interface{} {
 	t.Helper()
 
 	// Decode from json
-	dec := codec.NewDecoderBytes([]byte(config), jsonhandles.JsonHandle)
+	dec := codec.NewDecoderBytes([]byte(config), structs.JsonHandle)
 
 	var m map[string]interface{}
 	err := dec.Decode(&m)

--- a/helper/pluginutils/hclutils/util.go
+++ b/helper/pluginutils/hclutils/util.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hcldec"
 	hjson "github.com/hashicorp/hcl/v2/json"
 
-	"github.com/hashicorp/nomad/nomad/jsonhandles"
+	"github.com/hashicorp/nomad/nomad/structs"
 
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
@@ -28,7 +28,7 @@ func ParseHclInterface(val interface{}, spec hcldec.Spec, vars map[string]cty.Va
 
 	// Encode to json
 	var buf bytes.Buffer
-	enc := codec.NewEncoder(&buf, jsonhandles.JsonHandle)
+	enc := codec.NewEncoder(&buf, structs.JsonHandle)
 	err := enc.Encode(val)
 	if err != nil {
 		// Convert to a hcl diagnostics message

--- a/nomad/client_agent_endpoint.go
+++ b/nomad/client_agent_endpoint.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/nomad/command/agent/monitor"
 	"github.com/hashicorp/nomad/command/agent/pprof"
 	"github.com/hashicorp/nomad/helper"
-	"github.com/hashicorp/nomad/nomad/jsonhandles"
 	"github.com/hashicorp/nomad/nomad/structs"
 
 	"github.com/hashicorp/go-msgpack/codec"
@@ -187,7 +186,7 @@ func (a *Agent) monitor(conn io.ReadWriteCloser) {
 	frames := make(chan *sframer.StreamFrame, 32)
 	errCh := make(chan error)
 	var buf bytes.Buffer
-	frameCodec := codec.NewEncoder(&buf, jsonhandles.JsonHandle)
+	frameCodec := codec.NewEncoder(&buf, structs.JsonHandle)
 
 	framer := sframer.NewStreamFramer(frames, 1*time.Second, 200*time.Millisecond, 1024)
 	framer.Run()

--- a/nomad/stream/ndjson.go
+++ b/nomad/stream/ndjson.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/go-msgpack/codec"
 
-	"github.com/hashicorp/nomad/nomad/jsonhandles"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -75,7 +74,7 @@ func (n *JsonStream) Send(v interface{}) error {
 	}
 
 	var buf bytes.Buffer
-	enc := codec.NewEncoder(&buf, jsonhandles.JsonHandleWithExtensions)
+	enc := codec.NewEncoder(&buf, structs.JsonHandleWithExtensions)
 	err := enc.Encode(v)
 	if err != nil {
 		return fmt.Errorf("error marshaling json for stream: %w", err)

--- a/nomad/structs/encoding.go
+++ b/nomad/structs/encoding.go
@@ -1,4 +1,4 @@
-package jsonhandles
+package structs
 
 import (
 	"reflect"

--- a/nomad/structs/extensions.go
+++ b/nomad/structs/extensions.go
@@ -1,28 +1,26 @@
-package jsonhandles
+package structs
 
 import (
 	"reflect"
-
-	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 var (
 	// extendedTypes is a mapping of extended types to their extension function
 	// TODO: the duplicates could be simplified by looking up the base type in the case of a pointer type in ConvertExt
 	extendedTypes = map[reflect.Type]extendFunc{
-		reflect.TypeOf(structs.Node{}):  nodeExt,
-		reflect.TypeOf(&structs.Node{}): nodeExt,
+		reflect.TypeOf(Node{}):  nodeExt,
+		reflect.TypeOf(&Node{}): nodeExt,
 	}
 )
 
 // nodeExt ensures the node is sanitized and adds the legacy field .Drain back to encoded Node objects
 func nodeExt(v interface{}) interface{} {
-	node := v.(*structs.Node).Sanitize()
+	node := v.(*Node).Sanitize()
 	// transform to a struct with inlined Node fields plus the Drain field
 	// - using defined type (not an alias!) EmbeddedNode gives us free conversion to a distinct type
 	// - distinct type prevents this encoding extension from being called recursively/infinitely on the embedding
 	// - pointers mean the conversion function doesn't have to make a copy during conversion
-	type EmbeddedNode structs.Node
+	type EmbeddedNode Node
 	return &struct {
 		*EmbeddedNode
 		Drain bool

--- a/nomad/structs/handlers.go
+++ b/nomad/structs/handlers.go
@@ -1,4 +1,4 @@
-package jsonhandles
+package structs
 
 import (
 	"github.com/hashicorp/go-msgpack/codec"


### PR DESCRIPTION
json handles were moved to a new package in #10202
this was unecessary after refactoring, so this moves them back to their original location in package `structs`