### PR TITLE
remove flakey exec test that tests non-deterministic docker behavior

### DIFF
--- a/plugins/drivers/testutils/exec_testing.go
+++ b/plugins/drivers/testutils/exec_testing.go
@@ -70,15 +70,6 @@ var ExecTaskStreamingBasicCases = []struct {
 		Stdout:   "hello from command\nhello from stdin\n",
 		ExitCode: 0,
 	},
-	{
-		Name:    "notty: children processes",
-		Command: "(( sleep 3; echo from background ) & ); echo from main; exec sleep 1",
-		Tty:     false,
-		// when not using tty; wait for all processes to exit matching behavior of `docker exec`
-		Stdout:   "from main\nfrom background\n",
-		ExitCode: 0,
-	},
-
 	// TTY cases - difference is new lines add `\r` and child process waiting is different
 	{
 		Name:     "tty: basic",


### PR DESCRIPTION
The exec command for this test was flakey and tested docker behavior we don't control, removing