### PR TITLE
CSI: correctly handly empty capacity fields during registration

### DIFF
--- a/command/volume_register_csi.go
+++ b/command/volume_register_csi.go
@@ -126,12 +126,16 @@ func parseCapacityBytes(cap *ast.ObjectList) (int64, error) {
 			if !ok {
 				break
 			}
-			b, err := humanize.ParseBytes(strings.Trim(lit.Token.Text, "\""))
+			literal := strings.Trim(lit.Token.Text, "\"")
+			if literal == "" {
+				return 0, nil
+			}
+			b, err := humanize.ParseBytes(literal)
 			if err != nil {
 				return 0, fmt.Errorf("could not parse value as bytes: %v", err)
 			}
 			return int64(b), err
 		}
 	}
-	return 0, fmt.Errorf("could not parse value as bytes")
+	return 0, nil
 }

--- a/command/volume_register_test.go
+++ b/command/volume_register_test.go
@@ -51,7 +51,7 @@ func TestCSIVolumeDecode(t *testing.T) {
 		expected *api.CSIVolume
 		err      string
 	}{{
-		name: "typical volume",
+		name: "volume creation",
 		hcl: `
 id              = "testvolume"
 name            = "test"
@@ -108,6 +108,34 @@ capability {
 			},
 			Parameters: map[string]string{"skuname": "Premium_LRS"},
 			Secrets:    map[string]string{"password": "xyzzy"},
+		},
+		err: "",
+	}, {
+		name: "volume registration",
+		hcl: `
+id              = "testvolume"
+external_id     = "vol-12345"
+name            = "test"
+type            = "csi"
+plugin_id       = "myplugin"
+capacity_min    = "" # meaningless for registration
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}
+`,
+		expected: &api.CSIVolume{
+			ID:         "testvolume",
+			ExternalID: "vol-12345",
+			Name:       "test",
+			PluginID:   "myplugin",
+			RequestedCapabilities: []*api.CSIVolumeCapability{
+				{
+					AccessMode:     api.CSIVolumeAccessModeSingleNodeWriter,
+					AttachmentMode: api.CSIVolumeAttachmentModeFilesystem,
+				},
+			},
 		},
 		err: "",
 	},


### PR DESCRIPTION
When a volume is registered via `nomad volume register` and not via the
creation workflow, it may not have any of the capacity fields set (as they're
not used for registration). Handle this case without error, and let the
downstream RPCs handle the error case for `nomad volume create`.

---


Fixes these failing E2E tests:

```
=== RUN   TestE2E/CSI/*csi.CSIVolumesTest/TestEBSVolumeClaim
    csi.go:112: 
        	Error Trace:	csi.go:112
        	Error:      	Received unexpected error:
        	            	could not register vol: exit status 1
        	            	Error decoding the volume definition: invalid capacity_min: could not parse value as bytes
        	Test:       	TestE2E/CSI/*csi.CSIVolumesTest/TestEBSVolumeClaim
            --- FAIL: TestE2E/CSI/*csi.CSIVolumesTest/TestEBSVolumeClaim (33.82s)

=== RUN   TestE2E/CSI/*csi.CSIVolumesTest/TestEFSVolumeClaim
    csi.go:196: 
        	Error Trace:	csi.go:196
        	Error:      	Received unexpected error:
        	            	could not register vol: exit status 1
        	            	Error decoding the volume definition: invalid capacity_min: could not parse value as bytes
        	Test:       	TestE2E/CSI/*csi.CSIVolumesTest/TestEFSVolumeClaim
            --- FAIL: TestE2E/CSI/*csi.CSIVolumesTest/TestEFSVolumeClaim (31.53s)
```            