### PR TITLE
chore: bump golangci-lint from v1.24 to v1.39

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,9 @@ run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 10m
 
+  # Modules download mode. If not empty, passed as -mod=<mode> to go tools
+  module-download-mode: vendor
+
   tests: false
 
   # which dirs to skip: they won't be analyzed;

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,6 +57,10 @@ linters-settings:
     list-type: blacklist
     packages:
       - github.com/hashicorp/consul/command/flags
+  gocritic:
+    disabled-checks:
+      - commentFormatting
+      - deprecatedComment
 
 issues:
   exclude:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -107,7 +107,7 @@ deps:  ## Install build and development dependencies
 lint-deps: ## Install linter dependencies
 ## Keep versions in sync with tools/go.mod (see https://github.com/golang/go/issues/30515)
 	@echo "==> Updating linter dependencies..."
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.39.0
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4
 	go install github.com/hashicorp/go-hclog/hclogvet@v0.1.3
 

--- a/api/api.go
+++ b/api/api.go
@@ -720,7 +720,7 @@ func (c *Client) doRequest(r *request) (time.Duration, *http.Response, error) {
 	}
 	start := time.Now()
 	resp, err := c.httpClient.Do(req)
-	diff := time.Now().Sub(start)
+	diff := time.Since(start)
 
 	// If the response is compressed, we swap the body's reader.
 	if resp != nil && resp.Header != nil {

--- a/api/csi.go
+++ b/api/csi.go
@@ -120,7 +120,7 @@ func (v *CSIVolumes) CreateSnapshot(snap *CSISnapshot, w *WriteOptions) ([]*CSIS
 		Snapshots: []*CSISnapshot{snap},
 	}
 	resp := &CSISnapshotCreateResponse{}
-	meta, err := v.client.write(fmt.Sprintf("/v1/volumes/snapshot"), req, resp, w)
+	meta, err := v.client.write("/v1/volumes/snapshot", req, resp, w)
 	return resp.Snapshots, meta, err
 }
 
@@ -129,7 +129,7 @@ func (v *CSIVolumes) DeleteSnapshot(snap *CSISnapshot, w *WriteOptions) error {
 	req := &CSISnapshotDeleteRequest{
 		Snapshots: []*CSISnapshot{snap},
 	}
-	_, err := v.client.delete(fmt.Sprintf("/v1/volumes/snapshot"), req, w)
+	_, err := v.client.delete("/v1/volumes/snapshot", req, w)
 	return err
 }
 

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -691,9 +691,7 @@ func (m *Multiregion) Copy() *Multiregion {
 		copyRegion := new(MultiregionRegion)
 		copyRegion.Name = region.Name
 		copyRegion.Count = intToPtr(*region.Count)
-		for _, dc := range region.Datacenters {
-			copyRegion.Datacenters = append(copyRegion.Datacenters, dc)
-		}
+		copyRegion.Datacenters = append(copyRegion.Datacenters, region.Datacenters...)
 		for k, v := range region.Meta {
 			copyRegion.Meta[k] = v
 		}

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -224,8 +224,7 @@ func (n *Nodes) monitorDrainNode(ctx context.Context, nodeID string,
 		}
 
 		if node.DrainStrategy == nil {
-			var msg *MonitorMessage
-			msg = Messagef(MonitorMsgLevelInfo, "Drain complete for node %s", nodeID)
+			msg := Messagef(MonitorMsgLevelInfo, "Drain complete for node %s", nodeID)
 			select {
 			case nodeCh <- msg:
 			case <-ctx.Done():

--- a/api/scaling.go
+++ b/api/scaling.go
@@ -24,9 +24,9 @@ func (s *Scaling) ListPolicies(q *QueryOptions) ([]*ScalingPolicyListStub, *Quer
 	return resp, qm, nil
 }
 
-func (s *Scaling) GetPolicy(ID string, q *QueryOptions) (*ScalingPolicy, *QueryMeta, error) {
+func (s *Scaling) GetPolicy(id string, q *QueryOptions) (*ScalingPolicy, *QueryMeta, error) {
 	var policy ScalingPolicy
-	qm, err := s.client.query("/v1/scaling/policy/"+ID, &policy, q)
+	qm, err := s.client.query("/v1/scaling/policy/"+id, &policy, q)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -165,12 +165,12 @@ type Affinity struct {
 	Weight  *int8  `hcl:"weight,optional"`    // Weight applied to nodes that match the affinity. Can be negative
 }
 
-func NewAffinity(LTarget string, Operand string, RTarget string, Weight int8) *Affinity {
+func NewAffinity(lTarget string, operand string, rTarget string, weight int8) *Affinity {
 	return &Affinity{
-		LTarget: LTarget,
-		RTarget: RTarget,
-		Operand: Operand,
-		Weight:  int8ToPtr(Weight),
+		LTarget: lTarget,
+		RTarget: rTarget,
+		Operand: operand,
+		Weight:  int8ToPtr(weight),
 	}
 }
 

--- a/client/fingerprint/env_aws.go
+++ b/client/fingerprint/env_aws.go
@@ -121,7 +121,7 @@ func (f *EnvAWSFingerprint) Fingerprint(request *FingerprintRequest, response *F
 		}
 
 		// assume we want blank entries
-		key := "platform.aws." + strings.Replace(k, "/", ".", -1)
+		key := "platform.aws." + strings.ReplaceAll(k, "/", ".")
 		if unique {
 			key = structs.UniqueNamespace(key)
 		}

--- a/client/fingerprint/env_azure.go
+++ b/client/fingerprint/env_azure.go
@@ -162,7 +162,7 @@ func (f *EnvAzureFingerprint) Fingerprint(request *FingerprintRequest, response 
 		}
 
 		// assume we want blank entries
-		key := "platform.azure." + strings.Replace(k, "/", ".", -1)
+		key := "platform.azure." + strings.ReplaceAll(k, "/", ".")
 		if attr.unique {
 			key = structs.UniqueNamespace(key)
 		}

--- a/client/fingerprint/env_gce.go
+++ b/client/fingerprint/env_gce.go
@@ -166,7 +166,7 @@ func (f *EnvGCEFingerprint) Fingerprint(req *FingerprintRequest, resp *Fingerpri
 		}
 
 		// assume we want blank entries
-		key := "platform.gce." + strings.Replace(k, "/", ".", -1)
+		key := "platform.gce." + strings.ReplaceAll(k, "/", ".")
 		if unique {
 			key = structs.UniqueNamespace(key)
 		}

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -117,7 +117,7 @@ func (a *TestAgent) Start() *TestAgent {
 		if a.Name != "" {
 			name = a.Name + "-agent"
 		}
-		name = strings.Replace(name, "/", "_", -1)
+		name = strings.ReplaceAll(name, "/", "_")
 		d, err := ioutil.TempDir(TempDir, name)
 		if err != nil {
 			a.T.Fatalf("Error creating data dir %s: %s", filepath.Join(TempDir, name), err)

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -159,7 +159,7 @@ func getDeployment(client *api.Deployments, dID string) (match *api.Deployment, 
 		return d, nil, nil
 	}
 
-	dID = strings.Replace(dID, "-", "", -1)
+	dID = strings.ReplaceAll(dID, "-", "")
 	if len(dID) == 1 {
 		return nil, nil, fmt.Errorf("Identifier must contain at least two characters.")
 	}

--- a/command/job_validate.go
+++ b/command/job_validate.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/command/agent"
 	flaghelper "github.com/hashicorp/nomad/helper/flags"

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1018,7 +1018,7 @@ func TarCZF(archive string, src, target string) error {
 		}
 
 		// remove leading path to the src, so files are relative to the archive
-		path := strings.Replace(file, src, "", -1)
+		path := strings.ReplaceAll(file, src, "")
 		if target != "" {
 			path = filepath.Join([]string{target, path}...)
 		}

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1159,7 +1159,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 
 	config.Env = task.EnvList()
 
-	containerName := fmt.Sprintf("%s-%s", strings.Replace(task.Name, "/", "_", -1), task.AllocID)
+	containerName := fmt.Sprintf("%s-%s", strings.ReplaceAll(task.Name, "/", "_"), task.AllocID)
 	logger.Debug("setting container name", "container_name", containerName)
 
 	var networkingConfig *docker.NetworkingConfig

--- a/drivers/java/utils.go
+++ b/drivers/java/utils.go
@@ -20,7 +20,7 @@ func checkForMacJVM() (ok bool, err error) {
 	cmd.Stderr = &out
 	err = cmd.Run()
 	if err != nil {
-		err = fmt.Errorf("failed check for macOS jvm: %v, out: %v", err, strings.Replace(strings.Replace(out.String(), "\n", " ", -1), `"`, `\"`, -1))
+		err = fmt.Errorf("failed check for macOS jvm: %v, out: %v", err, strings.ReplaceAll(strings.ReplaceAll(out.String(), "\n", " "), `"`, `\"`))
 		return false, err
 	}
 	return true, nil

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -73,7 +73,7 @@ func NewExecutorWithIsolation(logger hclog.Logger) Executor {
 		logger.Error("unable to initialize stats", "error", err)
 	}
 	return &LibcontainerExecutor{
-		id:             strings.Replace(uuid.Generate(), "-", "_", -1),
+		id:             strings.ReplaceAll(uuid.Generate(), "-", "_"),
 		logger:         logger,
 		totalCpuStats:  stats.NewCpuStats(),
 		userCpuStats:   stats.NewCpuStats(),

--- a/e2e/cli/command/test_decoder.go
+++ b/e2e/cli/command/test_decoder.go
@@ -218,7 +218,7 @@ func (r *TestReport) Summary() string {
 				fmt.Fprintf(w, "[%s]\t\t↳\t%s\t (%vs)\n", status, tname, test.Elapsed)
 				if test.Failed {
 					for _, line := range test.Output[2:] {
-						fmt.Fprintf(w, "\t\t\t%s\n", strings.Replace(strings.TrimSpace(line), "\t", "  ", -1))
+						fmt.Fprintf(w, "\t\t\t%s\n", strings.ReplaceAll(strings.TrimSpace(line), "\t", "  "))
 					}
 					fmt.Fprintln(w, "\t\t\t----------")
 				}

--- a/vendor/github.com/hashicorp/nomad/api/api.go
+++ b/vendor/github.com/hashicorp/nomad/api/api.go
@@ -720,7 +720,7 @@ func (c *Client) doRequest(r *request) (time.Duration, *http.Response, error) {
 	}
 	start := time.Now()
 	resp, err := c.httpClient.Do(req)
-	diff := time.Now().Sub(start)
+	diff := time.Since(start)
 
 	// If the response is compressed, we swap the body's reader.
 	if resp != nil && resp.Header != nil {

--- a/vendor/github.com/hashicorp/nomad/api/csi.go
+++ b/vendor/github.com/hashicorp/nomad/api/csi.go
@@ -120,7 +120,7 @@ func (v *CSIVolumes) CreateSnapshot(snap *CSISnapshot, w *WriteOptions) ([]*CSIS
 		Snapshots: []*CSISnapshot{snap},
 	}
 	resp := &CSISnapshotCreateResponse{}
-	meta, err := v.client.write(fmt.Sprintf("/v1/volumes/snapshot"), req, resp, w)
+	meta, err := v.client.write("/v1/volumes/snapshot", req, resp, w)
 	return resp.Snapshots, meta, err
 }
 
@@ -129,7 +129,7 @@ func (v *CSIVolumes) DeleteSnapshot(snap *CSISnapshot, w *WriteOptions) error {
 	req := &CSISnapshotDeleteRequest{
 		Snapshots: []*CSISnapshot{snap},
 	}
-	_, err := v.client.delete(fmt.Sprintf("/v1/volumes/snapshot"), req, w)
+	_, err := v.client.delete("/v1/volumes/snapshot", req, w)
 	return err
 }
 

--- a/vendor/github.com/hashicorp/nomad/api/jobs.go
+++ b/vendor/github.com/hashicorp/nomad/api/jobs.go
@@ -691,9 +691,7 @@ func (m *Multiregion) Copy() *Multiregion {
 		copyRegion := new(MultiregionRegion)
 		copyRegion.Name = region.Name
 		copyRegion.Count = intToPtr(*region.Count)
-		for _, dc := range region.Datacenters {
-			copyRegion.Datacenters = append(copyRegion.Datacenters, dc)
-		}
+		copyRegion.Datacenters = append(copyRegion.Datacenters, region.Datacenters...)
 		for k, v := range region.Meta {
 			copyRegion.Meta[k] = v
 		}

--- a/vendor/github.com/hashicorp/nomad/api/nodes.go
+++ b/vendor/github.com/hashicorp/nomad/api/nodes.go
@@ -224,8 +224,7 @@ func (n *Nodes) monitorDrainNode(ctx context.Context, nodeID string,
 		}
 
 		if node.DrainStrategy == nil {
-			var msg *MonitorMessage
-			msg = Messagef(MonitorMsgLevelInfo, "Drain complete for node %s", nodeID)
+			msg := Messagef(MonitorMsgLevelInfo, "Drain complete for node %s", nodeID)
 			select {
 			case nodeCh <- msg:
 			case <-ctx.Done():

--- a/vendor/github.com/hashicorp/nomad/api/scaling.go
+++ b/vendor/github.com/hashicorp/nomad/api/scaling.go
@@ -24,9 +24,9 @@ func (s *Scaling) ListPolicies(q *QueryOptions) ([]*ScalingPolicyListStub, *Quer
 	return resp, qm, nil
 }
 
-func (s *Scaling) GetPolicy(ID string, q *QueryOptions) (*ScalingPolicy, *QueryMeta, error) {
+func (s *Scaling) GetPolicy(id string, q *QueryOptions) (*ScalingPolicy, *QueryMeta, error) {
 	var policy ScalingPolicy
-	qm, err := s.client.query("/v1/scaling/policy/"+ID, &policy, q)
+	qm, err := s.client.query("/v1/scaling/policy/"+id, &policy, q)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/hashicorp/nomad/api/tasks.go
+++ b/vendor/github.com/hashicorp/nomad/api/tasks.go
@@ -165,12 +165,12 @@ type Affinity struct {
 	Weight  *int8  `hcl:"weight,optional"`    // Weight applied to nodes that match the affinity. Can be negative
 }
 
-func NewAffinity(LTarget string, Operand string, RTarget string, Weight int8) *Affinity {
+func NewAffinity(lTarget string, operand string, rTarget string, weight int8) *Affinity {
 	return &Affinity{
-		LTarget: LTarget,
-		RTarget: RTarget,
-		Operand: Operand,
-		Weight:  int8ToPtr(Weight),
+		LTarget: lTarget,
+		RTarget: rTarget,
+		Operand: operand,
+		Weight:  int8ToPtr(weight),
 	}
 }
 


### PR DESCRIPTION
What changed

- golangci-lint [v1.39](https://github.com/golangci/golangci-lint/releases/tag/v1.39.0)
- `Replace(..., -1)` becomes `ReplaceAll(...)`
- some extra `fmt.Sprintf`, empty vars, or `for`loops
- `Time.Now().Sub(...)` becomes `Time.Since(...)`

What didn't change and the checks are disabled.

- `Deprecated in Nomad 0.10` which should be `Deprecated: ...`. See: `deprecatedComment`
- `//TODO` instead of `// TODO`. See: `commentFormatting`