### PR TITLE
allow setting stale flag from cli to retrieve individual server license

### DIFF
--- a/api/operator.go
+++ b/api/operator.go
@@ -317,6 +317,7 @@ func (op *Operator) LicenseGet(q *QueryOptions) (*LicenseReply, *QueryMeta, erro
 	if err != nil {
 		return nil, nil, err
 	}
+	req.setQueryOptions(q)
 
 	var reply LicenseReply
 	_, resp, err := op.c.doRequest(req)

--- a/command/license_get.go
+++ b/command/license_get.go
@@ -2,6 +2,9 @@ package command
 
 import (
 	"fmt"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/posener/complete"
 )
 
 type LicenseGetCommand struct {
@@ -17,11 +20,30 @@ Usage: nomad license get [options]
   When ACLs are enabled, this command requires a token with the
   'operator:read' capability.
 
+  -stale=[true|false]
+	By default the license get command will be forwarded to the Nomad leader.
+	If -stale is set to true, the command will not be forwarded to the
+	leader and will return the license from the specific server being
+	contacted. This option may be useful during upgrade scenarios when a server
+	is given a new file license and is a follower so the new license has not
+	yet been propagated to raft.
+
 General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
 
 	return helpText
+}
+
+func (c *LicenseGetCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-stale": complete.PredictAnything,
+		})
+}
+
+func (c *LicenseGetCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
 }
 
 func (c *LicenseGetCommand) Synopsis() string {
@@ -31,8 +53,12 @@ func (c *LicenseGetCommand) Synopsis() string {
 func (c *LicenseGetCommand) Name() string { return "license get" }
 
 func (c *LicenseGetCommand) Run(args []string) int {
+	var stale bool
+
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
+
+	flags.BoolVar(&stale, "stale", false, "")
 
 	if err := flags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing flags: %s", err))
@@ -45,7 +71,10 @@ func (c *LicenseGetCommand) Run(args []string) int {
 		return 1
 	}
 
-	resp, _, err := client.Operator().LicenseGet(nil)
+	q := &api.QueryOptions{
+		AllowStale: stale,
+	}
+	resp, _, err := client.Operator().LicenseGet(q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error getting license: %v", err))
 		return 1

--- a/vendor/github.com/hashicorp/nomad/api/operator.go
+++ b/vendor/github.com/hashicorp/nomad/api/operator.go
@@ -317,6 +317,7 @@ func (op *Operator) LicenseGet(q *QueryOptions) (*LicenseReply, *QueryMeta, erro
 	if err != nil {
 		return nil, nil, err
 	}
+	req.setQueryOptions(q)
 
 	var reply LicenseReply
 	_, resp, err := op.c.doRequest(req)

--- a/website/content/docs/commands/license/get.mdx
+++ b/website/content/docs/commands/license/get.mdx
@@ -25,6 +25,15 @@ capability.
 
 @include 'general_options_no_namespace.mdx'
 
+## License Get Options
+
+- `-stale`: By default the `license get` command will be forwarded to the Nomad
+  leader. If `-stale` is set to `true`, the command will not be forwarded to
+  the leader and will return the license from the specific server being
+  contacted. This option may be useful during upgrade scenarios when a server
+  is given a new file license and is a follower so the new license has not yet
+  been propagated to raft.
+
 ## Examples
 
 ```shell-session
@@ -50,4 +59,31 @@ Licensed Features:
         Preemption
         Audit Logging
         Setinel Policies
+```
+
+```shell-session
+$ nomad license get -stale=true
+
+Product        = nomad
+License Status = valid
+License ID     = 8c647f6c-1e6d-18d8-7f05-92c4d8110b2d
+Customer ID    = 350356e5-8aec-bdf4-8510-b205079ccad2
+Issued At      = 2021-03-31 14:21:16.969610774 +0000 UTC
+Expires At     = 2022-04-01 00:00:00 +0000 UTC
+Terminates At  = 2022-04-04 00:00:00 +0000 UTC
+Datacenter     = *
+Modules:
+        governance-policy
+        multicluster-and-efficiency
+Licensed Features:
+        Automated Upgrades
+        Enhanced Read Scalability
+        Redundancy Zones
+        Namespaces
+        Resource Quotas
+        Audit Logging
+        Sentinel Policies
+        Multiregion Deployments
+        Automated Backups
+        Multi-Vault Namespaces
 ```


### PR DESCRIPTION
enable `-stale` flag to retrieve a servers license without forwarding request to leader