### PR TITLE
fix potential race condition in API client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,14 +294,14 @@ jobs:
         type: string
         default: "amd64"
       enable_race_testing:
-        type: string
-        default: ""
+        type: boolean
+        default: false
     environment:
       GOTEST_PKGS_EXCLUDE: "<< parameters.exclude_packages >>"
       GOTEST_PKGS: "<< parameters.test_packages >>"
       GOTEST_MOD: "<< parameters.test_module >>"
       GOTESTARCH: "<< parameters.goarch >>"
-      ENABLE_RACE: "<< parameters.enable_race_testing >>"
+      ENABLE_RACE: << parameters.enable_race_testing >> && "TRUE" || ""
     steps:
       - checkout
       - install-golang
@@ -620,7 +620,7 @@ workflows:
           name: "test-api"
           test_module: "api"
           filters: *backend_test_branches_filter
-          enable_race_testing: "1"
+          enable_race_testing: true
       - test-container:
           name: "test-devices"
           test_packages: "./devices/..."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,7 +301,7 @@ jobs:
       GOTEST_PKGS: "<< parameters.test_packages >>"
       GOTEST_MOD: "<< parameters.test_module >>"
       GOTESTARCH: "<< parameters.goarch >>"
-      ENABLE_RACE: << parameters.enable_race_testing >> && "TRUE" || ""
+      ENABLE_RACE: <<# parameters.enable_race_testing >>TRUE<</ parameters.enable_race_testing >>
     steps:
       - checkout
       - install-golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,7 +301,7 @@ jobs:
       GOTEST_PKGS: "<< parameters.test_packages >>"
       GOTEST_MOD: "<< parameters.test_module >>"
       GOTESTARCH: "<< parameters.goarch >>"
-      ENABLE_RACE: <<# parameters.enable_race_testing >>TRUE<</ parameters.enable_race_testing >>
+      ENABLE_RACE: "<<# parameters.enable_race_testing >>TRUE<</ parameters.enable_race_testing >>"
     steps:
       - checkout
       - install-golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,11 +293,15 @@ jobs:
       goarch:
         type: string
         default: "amd64"
+      enable_race_testing:
+        type: string
+        default: ""
     environment:
       GOTEST_PKGS_EXCLUDE: "<< parameters.exclude_packages >>"
       GOTEST_PKGS: "<< parameters.test_packages >>"
       GOTEST_MOD: "<< parameters.test_module >>"
       GOTESTARCH: "<< parameters.goarch >>"
+      ENABLE_RACE: "<< parameters.enable_race_testing >>"
     steps:
       - checkout
       - install-golang
@@ -616,6 +620,7 @@ workflows:
           name: "test-api"
           test_module: "api"
           filters: *backend_test_branches_filter
+          enable_race_testing: "1"
       - test-container:
           name: "test-devices"
           test_packages: "./devices/..."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
  * agent: Only allow querying Prometheus formatted metrics if Prometheus is enabled within the config [[GH-10140](https://github.com/hashicorp/nomad/pull/10140)]
- * api: Fixed race condition around headers in API client [[GH-10302](https://github.com/hashicorp/nomad/issues/10302)]
+ * api: Fixed a panic that may occur on concurrent access to an SDK client [[GH-10302](https://github.com/hashicorp/nomad/issues/10302)]
  * api: Added missing devices block to AllocatedTaskResources [[GH-10064](https://github.com/hashicorp/nomad/pull/10064)]
  * cli: Fixed a bug where non-int proxy port would panic CLI [[GH-10072](https://github.com/hashicorp/nomad/issues/10072)]
  * cli: Fixed a bug where `nomad operator debug` incorrectly parsed https Consul API URLs. [[GH-10082](https://github.com/hashicorp/nomad/pull/10082)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
  * agent: Only allow querying Prometheus formatted metrics if Prometheus is enabled within the config [[GH-10140](https://github.com/hashicorp/nomad/pull/10140)]
+ * api: Fixed race condition around headers in API client [[GH-10302](https://github.com/hashicorp/nomad/issues/10302)]
  * api: Added missing devices block to AllocatedTaskResources [[GH-10064](https://github.com/hashicorp/nomad/pull/10064)]
  * cli: Fixed a bug where non-int proxy port would panic CLI [[GH-10072](https://github.com/hashicorp/nomad/issues/10072)]
  * cli: Fixed a bug where `nomad operator debug` incorrectly parsed https Consul API URLs. [[GH-10082](https://github.com/hashicorp/nomad/pull/10082)]

--- a/api/api.go
+++ b/api/api.go
@@ -685,8 +685,8 @@ func (c *Client) newRequest(method, path string) (*request, error) {
 		}
 	}
 
-	if c.config.Headers != nil {
-		r.header = c.config.Headers
+	for key, values := range c.config.Headers {
+		r.header[key] = values
 	}
 
 	return r, nil

--- a/vendor/github.com/hashicorp/nomad/api/api.go
+++ b/vendor/github.com/hashicorp/nomad/api/api.go
@@ -685,8 +685,8 @@ func (c *Client) newRequest(method, path string) (*request, error) {
 		}
 	}
 
-	if c.config.Headers != nil {
-		r.header = c.config.Headers
+	for key, values := range c.config.Headers {
+		r.header[key] = values
 	}
 
 	return r, nil


### PR DESCRIPTION
Resolves #10301 

* Updates the `/api` tests to run with `-race`.
* Documenting test for #10301 
* Resolves race condition

Commit 4e25e8e2350579581b88bf96e67c18627008e65e shows a documenting test, which fails under `-race`:
https://app.circleci.com/pipelines/github/hashicorp/nomad/15527/workflows/d2032205-895a-4d7b-8ec6-41301a1614cb/jobs/147802

New test passes after 60648672518b642ea3b4dcab431ca521b3e6597b