### PR TITLE
Fix the broken link in the bootstrapping custom scheduler warning

### DIFF
--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -308,7 +308,7 @@ server {
 
 [encryption]: https://learn.hashicorp.com/tutorials/nomad/security-gossip-encryption 'Nomad Encryption Overview'
 [server-join]: /docs/configuration/server_join 'Server Join'
-[update-scheduler-config]: /api-docs/operator#update-scheduler-configuration 'Scheduler Config'
+[update-scheduler-config]: /api-docs/operator/scheduler#update-scheduler-configuration 'Scheduler Config'
 [bootstrapping a cluster]: /docs/faq#bootstrapping
 [rfc4648]: https://tools.ietf.org/html/rfc4648#section-5
 [`nomad operator keygen`]: /docs/commands/operator/keygen


### PR DESCRIPTION
At some point the Operator API docs got broken into multiple pages so this anchor stopped working.