### PR TITLE
build: install buf during bootstrap

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -102,6 +102,7 @@ deps:  ## Install build and development dependencies
 	go install github.com/hashicorp/hcl/v2/cmd/hclfmt@v2.5.1
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.4
 	go install github.com/hashicorp/go-msgpack/codec/codecgen@v1.1.5
+	go install github.com/bufbuild/buf/cmd/buf@v0.36.0
 
 .PHONY: lint-deps
 lint-deps: ## Install linter dependencies

--- a/tools/buf/README.md
+++ b/tools/buf/README.md
@@ -4,11 +4,14 @@
 
 ## Installation
 
-See installation instructions [here](https://docs.buf.build/installation/).
+Use `make bootstrap` in the root of this repo to install the version of `buf` used by Nomad.
 
 ## Usage
 `make proto` in the root of this repo will invoke `buf` using the configuration in this directory.
 
 ## Why use `buf` instead of `protoc`?
 
-Buf is a user-friendly tool to work with Protobuf that outperforms `protoc` in every conceivable way. It was written by the author(s) of [`prototool`](https://github.com/uber/prototool), another tool that made generating Protobuf easier, but which is now deprecated in favor of `buf`. Buf also does linting and breaking-change detection.
+Buf is a user-friendly tool to work with Protobuf that outperforms `protoc` in every conceivable way.
+It was written by the author(s) of [`prototool`](https://github.com/uber/prototool), another tool
+that made generating Protobuf easier, but which is now deprecated in favor of `buf`. Buf also does
+linting and breaking-change detection.


### PR DESCRIPTION
Previously installing `buf` was left out of `make bootstrap` because it
had conflicts with the `tools/go.mod` file and dependencies used by
other tools. With Go 1.16 we eliminated that `go.mod` file, and can
now just install `buf` with `go install` like everything else.

Note that v0.36.0 is the version installed in our `scripts/`, so that's the version set here. I noticed the latest version uses a different type for proto timestamps, which seems concerning. 