### PR TITLE
UI: set memory max for oversubscription.

### DIFF
--- a/ui/app/components/primary-metric/allocation.hbs
+++ b/ui/app/components/primary-metric/allocation.hbs
@@ -32,11 +32,12 @@
   <PrimaryMetric::CurrentValue @chartClass={{this.chartClass}} @percent={{this.data.lastObject.percent}} />
   <div class="annotation" data-test-absolute-value>
     {{#if (eq this.metric "cpu")}}
-      <strong>{{format-scheduled-hertz this.data.lastObject.used}}</strong> / {{format-scheduled-hertz this.reservedAmount}} Total
+      <strong>{{format-scheduled-hertz this.data.lastObject.used}}</strong> / {{format-scheduled-hertz this.reservedAmount}} reserved
     {{else if (eq this.metric "memory")}}
-      <strong>{{format-scheduled-bytes this.data.lastObject.used}}</strong> / {{format-scheduled-bytes this.reservedAmount start="MiB"}} Total
+      <strong>{{format-scheduled-bytes this.data.lastObject.used}}</strong> / {{format-scheduled-bytes this.reservedAmount start="MiB"}} reserved
+      {{~#if this.reservedAmountMax }}, {{format-scheduled-bytes this.reservedAmountMax start="MiB"}} max {{/if}}
     {{else}}
-      <strong>{{this.data.lastObject.used}}</strong> / {{this.reservedAmount}} Total
+      <strong>{{this.data.lastObject.used}}</strong> / {{this.reservedAmount}} reserved
     {{/if}}
   </div>
 </div>

--- a/ui/app/components/primary-metric/allocation.js
+++ b/ui/app/components/primary-metric/allocation.js
@@ -50,6 +50,11 @@ export default class AllocationPrimaryMetric extends Component {
     return null;
   }
 
+  get reservedAmountMax() {
+    if (this.metric === 'memory') return this.tracker.reservedMemoryMax;
+    return null;
+  }
+
   get chartClass() {
     if (this.metric === 'cpu') return 'is-info';
     if (this.metric === 'memory') return 'is-danger';

--- a/ui/app/components/primary-metric/task.hbs
+++ b/ui/app/components/primary-metric/task.hbs
@@ -12,9 +12,10 @@
   <PrimaryMetric::CurrentValue @chartClass={{this.chartClass}} @percent={{this.data.lastObject.percent}} />
   <div class="annotation" data-test-absolute-value>
     {{#if (eq this.metric "cpu")}}
-      <strong>{{format-scheduled-hertz this.data.lastObject.used}}</strong> / {{format-scheduled-hertz this.reservedAmount}} Total
+      <strong>{{format-scheduled-hertz this.data.lastObject.used}}</strong> / {{format-scheduled-hertz this.reservedAmount}} reserved
     {{else if (eq this.metric "memory")}}
-      <strong>{{format-scheduled-bytes this.data.lastObject.used}}</strong> / {{format-scheduled-bytes this.reservedAmount start="MiB"}} Total
+      <strong>{{format-scheduled-bytes this.data.lastObject.used}}</strong> / {{format-scheduled-bytes this.reservedAmount start="MiB"}} reserved
+      {{~#if this.reservedAmountMax }}, {{format-scheduled-bytes this.reservedAmountMax start="MiB"}} max {{/if}}
     {{else}}
       <strong>{{this.data.lastObject.used}}</strong> / {{this.reservedAmount}} Total
     {{/if}}

--- a/ui/app/components/primary-metric/task.js
+++ b/ui/app/components/primary-metric/task.js
@@ -36,6 +36,13 @@ export default class TaskPrimaryMetric extends Component {
     return null;
   }
 
+  get reservedAmountMax() {
+    if (!this.tracker) return null;
+    const task = this.tracker.tasks.findBy('task', this.taskState.name);
+    if (this.metric === 'memory') return task.reservedMemoryMax;
+    return null;
+  }
+
   get chartClass() {
     if (this.metric === 'cpu') return 'is-info';
     if (this.metric === 'memory') return 'is-danger';

--- a/ui/app/models/resources.js
+++ b/ui/app/models/resources.js
@@ -5,6 +5,7 @@ import { fragmentArray } from 'ember-data-model-fragments/attributes';
 export default class Resources extends Fragment {
   @attr('number') cpu;
   @attr('number') memory;
+  @attr('number') memoryMax;
   @attr('number') disk;
   @attr('number') iops;
   @fragmentArray('network', { defaultValue: () => [] }) networks;

--- a/ui/app/models/task-group.js
+++ b/ui/app/models/task-group.js
@@ -38,6 +38,19 @@ export default class TaskGroup extends Fragment {
 
   @attr('number') reservedEphemeralDisk;
 
+  @computed('tasks.@each.{reservedMemory,reservedMemoryMax}')
+  get reservedMemoryMax() {
+    const s = this.tasks.reduce(
+      (sum, t) => {
+        sum.max += t.reservedMemoryMax || t.reservedMemory;
+        sum.has_max ||= t.reservedMemoryMax;
+        return sum;
+      },
+      { max: 0, has_max: false }
+    );
+    return s.has_max ? s.max : null;
+  }
+
   @computed('job.latestFailureEvaluation.failedTGAllocs.[]', 'name')
   get placementFailures() {
     const placementFailures = this.get('job.latestFailureEvaluation.failedTGAllocs');

--- a/ui/app/models/task.js
+++ b/ui/app/models/task.js
@@ -30,6 +30,7 @@ export default class Task extends Fragment {
   }
 
   @attr('number') reservedMemory;
+  @attr('number') reservedMemoryMax;
   @attr('number') reservedCPU;
   @attr('number') reservedDisk;
   @attr('number') reservedEphemeralDisk;

--- a/ui/app/serializers/allocation.js
+++ b/ui/app/serializers/allocation.js
@@ -12,13 +12,14 @@ const taskGroupFromJob = (job, taskGroupName) => {
 const merge = tasks => {
   const mergedResources = {
     Cpu: { CpuShares: 0 },
-    Memory: { MemoryMB: 0 },
+    Memory: { MemoryMB: 0, MemoryMaxMB: 0 },
     Disk: { DiskMB: 0 },
   };
 
   return tasks.reduce((resources, task) => {
     resources.Cpu.CpuShares += (task.Cpu && task.Cpu.CpuShares) || 0;
     resources.Memory.MemoryMB += (task.Memory && task.Memory.MemoryMB) || 0;
+    resources.Memory.MemoryMaxMB += (task.Memory && task.Memory.MemoryMaxMB) || 0;
     resources.Disk.DiskMB += (task.Disk && task.Disk.DiskMB) || 0;
     return resources;
   }, mergedResources);

--- a/ui/app/serializers/resources.js
+++ b/ui/app/serializers/resources.js
@@ -5,7 +5,11 @@ export default class ResourcesSerializer extends ApplicationSerializer {
 
   normalize(typeHash, hash) {
     hash.Cpu = hash.Cpu && hash.Cpu.CpuShares;
-    hash.Memory = hash.Memory && hash.Memory.MemoryMB;
+
+    const memory = hash.Memory;
+    hash.Memory = memory && memory.MemoryMB;
+    hash.MemoryMax = memory && memory.MemoryMaxMB;
+
     hash.Disk = hash.Disk && hash.Disk.DiskMB;
 
     // Networks for ReservedResources is different than for Resources.

--- a/ui/app/serializers/task.js
+++ b/ui/app/serializers/task.js
@@ -6,6 +6,7 @@ export default class Task extends ApplicationSerializer {
     const resources = hash.Resources;
     if (resources) {
       hash.ReservedMemory = resources.MemoryMB;
+      hash.ReservedMemoryMax = resources.MemoryMaxMB;
       hash.ReservedCPU = resources.CPU;
       hash.ReservedDisk = resources.DiskMB;
       hash.ReservedEphemeralDisk = hash.EphemeralDisk.SizeMB;

--- a/ui/app/utils/classes/allocation-stats-tracker.js
+++ b/ui/app/utils/classes/allocation-stats-tracker.js
@@ -131,7 +131,7 @@ class AllocationStatsTracker extends EmberObject.extend(AbstractStatsTracker) {
         // Static figures, denominators for stats
         reservedCPU: get(task, 'reservedCPU'),
         reservedMemory: get(task, 'reservedMemory'),
-        reservedMemoryMax: get(task, 'reservedMemoryMax'),
+        reservedMemoryMax: get(task, 'reservedMemoryMax') || null,
 
         // Dynamic figures, collected over time
         // []{ timestamp: Date, used: Number, percent: Number }

--- a/ui/app/utils/classes/allocation-stats-tracker.js
+++ b/ui/app/utils/classes/allocation-stats-tracker.js
@@ -104,6 +104,7 @@ class AllocationStatsTracker extends EmberObject.extend(AbstractStatsTracker) {
   // Static figures, denominators for stats
   @alias('allocation.taskGroup.reservedCPU') reservedCPU;
   @alias('allocation.taskGroup.reservedMemory') reservedMemory;
+  @alias('allocation.taskGroup.reservedMemoryMax') reservedMemoryMax;
 
   // Dynamic figures, collected over time
   // []{ timestamp: Date, used: Number, percent: Number }
@@ -130,6 +131,7 @@ class AllocationStatsTracker extends EmberObject.extend(AbstractStatsTracker) {
         // Static figures, denominators for stats
         reservedCPU: get(task, 'reservedCPU'),
         reservedMemory: get(task, 'reservedMemory'),
+        reservedMemoryMax: get(task, 'reservedMemoryMax'),
 
         // Dynamic figures, collected over time
         // []{ timestamp: Date, used: Number, percent: Number }

--- a/ui/mirage/common.js
+++ b/ui/mirage/common.js
@@ -30,6 +30,7 @@ export function generateResources(options = {}) {
     },
     Memory: {
       MemoryMB: options.MemoryMB || faker.helpers.randomize(MEMORY_RESERVATIONS),
+      MemoryMaxMB: options.MemoryMaxMB,
     },
     Disk: {
       DiskMB: options.DiskMB || faker.helpers.randomize(DISK_RESERVATIONS),

--- a/ui/mirage/factories/allocation.js
+++ b/ui/mirage/factories/allocation.js
@@ -48,6 +48,7 @@ export default Factory.extend({
           resources: generateResources({
             CPU: task.resources.CPU,
             MemoryMB: task.resources.MemoryMB,
+            MemoryMaxMB: task.resources.MemoryMaxMB,
             DiskMB: task.resources.DiskMB,
             networks: { minPorts: 1 },
           }),
@@ -69,6 +70,7 @@ export default Factory.extend({
           resources: generateResources({
             CPU: task.resources.CPU,
             MemoryMB: task.resources.MemoryMB,
+            MemoryMaxMB: task.resources.MemoryMaxMB,
             DiskMB: task.resources.DiskMB,
             networks: { minPorts: 0, maxPorts: 0 },
           }),

--- a/ui/mirage/factories/task-group.js
+++ b/ui/mirage/factories/task-group.js
@@ -157,6 +157,7 @@ function makeHostVolumes() {
 function parseResourceSpec(spec) {
   const mapping = {
     M: 'MemoryMB',
+    MM: 'MemoryMaxMB',
     C: 'CPU',
     D: 'DiskMB',
     I: 'IOPS',

--- a/ui/mirage/factories/task.js
+++ b/ui/mirage/factories/task.js
@@ -26,6 +26,7 @@ export default Factory.extend({
     return {
       CPU: resources.Cpu.CpuShares,
       MemoryMB: resources.Memory.MemoryMB,
+      MemoryMaxMB: resources.Memory.MemoryMaxMB,
       DiskMB: resources.Disk.DiskMB,
     };
   },

--- a/ui/tests/integration/components/primary-metric/allocation-test.js
+++ b/ui/tests/integration/components/primary-metric/allocation-test.js
@@ -1,6 +1,6 @@
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { find, findAll, render } from '@ember/test-helpers';
+import { findAll, render } from '@ember/test-helpers';
 import { initialize as fragmentSerializerInitializer } from 'nomad-ui/initializers/fragment-serializer';
 import hbs from 'htmlbars-inline-precompile';
 import { setupPrimaryMetricMocks, primaryMetric } from './primary-metric';
@@ -61,22 +61,6 @@ module('Integration | Component | PrimaryMetric::Allocation', function(hooks) {
 
     await render(template);
     assert.equal(findAll('[data-test-chart-area]').length, mockTasks.length);
-  });
-
-  test('memory chart shows max if enabled', async function(assert) {
-    await preload(this.store);
-
-    this.server.create('job', {
-      groupCount: 1,
-      resourceSpec: ['M: 256, MM: 512'],
-    });
-    const alloc = this.server.create('allocation');
-
-    this.setProperties({ alloc, metric: 'memory' });
-    await render(template);
-
-    console.log(find('.annotation').innerText);
-    assert.ok(find('.annotation').innerText.includes('/ 256 MiB reserved, 512 MiB max'));
   });
 
   primaryMetric({

--- a/ui/tests/integration/components/primary-metric/allocation-test.js
+++ b/ui/tests/integration/components/primary-metric/allocation-test.js
@@ -1,6 +1,6 @@
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { findAll, render } from '@ember/test-helpers';
+import { find, findAll, render } from '@ember/test-helpers';
 import { initialize as fragmentSerializerInitializer } from 'nomad-ui/initializers/fragment-serializer';
 import hbs from 'htmlbars-inline-precompile';
 import { setupPrimaryMetricMocks, primaryMetric } from './primary-metric';
@@ -61,6 +61,22 @@ module('Integration | Component | PrimaryMetric::Allocation', function(hooks) {
 
     await render(template);
     assert.equal(findAll('[data-test-chart-area]').length, mockTasks.length);
+  });
+
+  test('memory chart shows max if enabled', async function(assert) {
+    await preload(this.store);
+
+    this.server.create('job', {
+      groupCount: 1,
+      resourceSpec: ['M: 256, MM: 512'],
+    });
+    const alloc = this.server.create('allocation');
+
+    this.setProperties({ alloc, metric: 'memory' });
+    await render(template);
+
+    console.log(find('.annotation').innerText);
+    assert.ok(find('.annotation').innerText.includes('/ 256 MiB reserved, 512 MiB max'));
   });
 
   primaryMetric({

--- a/ui/tests/unit/models/task-group-test.js
+++ b/ui/tests/unit/models/task-group-test.js
@@ -10,39 +10,41 @@ module('Unit | Model | task-group', function(hooks) {
   setupTest(hooks);
 
   test("should expose reserved resource stats as aggregates of each task's reserved resources", function(assert) {
-    const taskGroup = run(() => this.owner.lookup('service:store').createRecord('task-group', {
-      name: 'group-example',
-      tasks: [
-        {
-          name: 'task-one',
-          driver: 'docker',
-          reservedMemory: 512,
-          reservedCPU: 500,
-          reservedDisk: 1024,
-        },
-        {
-          name: 'task-two',
-          driver: 'docker',
-          reservedMemory: 256,
-          reservedCPU: 1000,
-          reservedDisk: 512,
-        },
-        {
-          name: 'task-three',
-          driver: 'docker',
-          reservedMemory: 1024,
-          reservedCPU: 1500,
-          reservedDisk: 4096,
-        },
-        {
-          name: 'task-four',
-          driver: 'docker',
-          reservedMemory: 2048,
-          reservedCPU: 500,
-          reservedDisk: 128,
-        },
-      ],
-    }));
+    const taskGroup = run(() =>
+      this.owner.lookup('service:store').createRecord('task-group', {
+        name: 'group-example',
+        tasks: [
+          {
+            name: 'task-one',
+            driver: 'docker',
+            reservedMemory: 512,
+            reservedCPU: 500,
+            reservedDisk: 1024,
+          },
+          {
+            name: 'task-two',
+            driver: 'docker',
+            reservedMemory: 256,
+            reservedCPU: 1000,
+            reservedDisk: 512,
+          },
+          {
+            name: 'task-three',
+            driver: 'docker',
+            reservedMemory: 1024,
+            reservedCPU: 1500,
+            reservedDisk: 4096,
+          },
+          {
+            name: 'task-four',
+            driver: 'docker',
+            reservedMemory: 2048,
+            reservedCPU: 500,
+            reservedDisk: 128,
+          },
+        ],
+      })
+    );
 
     assert.equal(
       taskGroup.get('reservedCPU'),
@@ -55,9 +57,47 @@ module('Unit | Model | task-group', function(hooks) {
       'reservedMemory is an aggregate sum of task memory reservations'
     );
     assert.equal(
+      taskGroup.get('reservedMemoryMax'),
+      null,
+      'reservedMemoryMax is aggregate sum of task memory_max reservations, should be nil when not set'
+    );
+    assert.equal(
       taskGroup.get('reservedDisk'),
       sum(taskGroup.get('tasks'), 'reservedDisk'),
       'reservedDisk is an aggregate sum of task disk reservations'
+    );
+  });
+
+  test('should set reserved memory max', function(assert) {
+    const taskGroup = run(() =>
+      this.owner.lookup('service:store').createRecord('task-group', {
+        name: 'group-example',
+        tasks: [
+          {
+            name: 'with-memory-max',
+            driver: 'docker',
+            reservedMemory: 512,
+            reservedMemoryMax: 1024,
+          },
+          {
+            name: 'with-memory-max-1',
+            driver: 'docker',
+            reservedMemory: 512,
+            reservedMemoryMax: 1024,
+          },
+          {
+            name: 'without-memory-max',
+            driver: 'docker',
+            reservedMemory: 256,
+          },
+        ],
+      })
+    );
+
+    assert.equal(
+      taskGroup.get('reservedMemoryMax'),
+      1024 + 1024 + 256,
+      'reservedMemoryMax is aggregate sum of task memory_max reservations, should be nil when not set'
     );
   });
 });

--- a/ui/tests/unit/utils/allocation-stats-tracker-test.js
+++ b/ui/tests/unit/utils/allocation-stats-tracker-test.js
@@ -25,18 +25,21 @@ module('Unit | Util | AllocationStatsTracker', function() {
               name: 'log-shipper',
               reservedCPU: 50,
               reservedMemory: 128,
+              reservedMemoryMax: null,
               lifecycleName: 'poststop',
             },
             {
               name: 'service',
               reservedCPU: 100,
               reservedMemory: 256,
+              reservedMemoryMax: null,
               lifecycleName: 'main',
             },
             {
               name: 'sidecar',
               reservedCPU: 50,
               reservedMemory: 128,
+              reservedMemoryMax: null,
               lifecycleName: 'prestart-sidecar',
             },
           ],
@@ -192,9 +195,30 @@ module('Unit | Util | AllocationStatsTracker', function() {
     assert.deepEqual(
       tracker.get('tasks'),
       [
-        { task: 'service', reservedCPU: 100, reservedMemory: 256, cpu: [], memory: [] },
-        { task: 'sidecar', reservedCPU: 50, reservedMemory: 128, cpu: [], memory: [] },
-        { task: 'log-shipper', reservedCPU: 50, reservedMemory: 128, cpu: [], memory: [] },
+        {
+          task: 'service',
+          reservedCPU: 100,
+          reservedMemory: 256,
+          reservedMemoryMax: null,
+          cpu: [],
+          memory: [],
+        },
+        {
+          task: 'sidecar',
+          reservedCPU: 50,
+          reservedMemory: 128,
+          reservedMemoryMax: null,
+          cpu: [],
+          memory: [],
+        },
+        {
+          task: 'log-shipper',
+          reservedCPU: 50,
+          reservedMemory: 128,
+          reservedMemoryMax: null,
+          cpu: [],
+          memory: [],
+        },
       ],
       'tasks represents the tasks for the allocation with no stats yet'
     );
@@ -225,6 +249,7 @@ module('Unit | Util | AllocationStatsTracker', function() {
           task: 'service',
           reservedCPU: 100,
           reservedMemory: 256,
+          reservedMemoryMax: null,
           cpu: [
             {
               timestamp: makeDate(refDate + 1),
@@ -248,6 +273,7 @@ module('Unit | Util | AllocationStatsTracker', function() {
           task: 'sidecar',
           reservedCPU: 50,
           reservedMemory: 128,
+          reservedMemoryMax: null,
           cpu: [
             {
               timestamp: makeDate(refDate + 100),
@@ -271,6 +297,7 @@ module('Unit | Util | AllocationStatsTracker', function() {
           task: 'log-shipper',
           reservedCPU: 50,
           reservedMemory: 128,
+          reservedMemoryMax: null,
           cpu: [
             {
               timestamp: makeDate(refDate + 10),
@@ -320,6 +347,7 @@ module('Unit | Util | AllocationStatsTracker', function() {
           task: 'service',
           reservedCPU: 100,
           reservedMemory: 256,
+          reservedMemoryMax: null,
           cpu: [
             {
               timestamp: makeDate(refDate + 1),
@@ -357,6 +385,7 @@ module('Unit | Util | AllocationStatsTracker', function() {
           task: 'sidecar',
           reservedCPU: 50,
           reservedMemory: 128,
+          reservedMemoryMax: null,
           cpu: [
             {
               timestamp: makeDate(refDate + 100),
@@ -394,6 +423,7 @@ module('Unit | Util | AllocationStatsTracker', function() {
           task: 'log-shipper',
           reservedCPU: 50,
           reservedMemory: 128,
+          reservedMemoryMax: null,
           cpu: [
             {
               timestamp: makeDate(refDate + 10),


### PR DESCRIPTION
Display reserved vs max memory for allocations/tasks with memory oversubscription, introduced in https://github.com/hashicorp/nomad/pull/10247 .

Implements the alloc/task display memory info part of https://github.com/hashicorp/nomad/issues/10268 .

Needless to say, I very much lack javascript experience, and I'm unfamiliar with frontend patterns, so feel free to ignore the PR and do it the "proper" way and I can learn by watching it.  Thanks!

For a task with `memory_max` set, here are the screen shots:
<img width="1170" alt="Screen Shot 2021-04-06 at 12 09 09 PM" src="https://user-images.githubusercontent.com/136429/113748673-cb206e00-96d6-11eb-9f5c-1f2c35e10883.png">

After:

<img width="1169" alt="Screen Shot 2021-04-06 at 12 10 29 PM" src="https://user-images.githubusercontent.com/136429/113748698-d1164f00-96d6-11eb-8a92-5b3e4dbf4733.png">


