### PR TITLE
CSI: set attach/access modes on volume claims

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -377,13 +377,15 @@ func (m *MigrateStrategy) Copy() *MigrateStrategy {
 
 // VolumeRequest is a representation of a storage volume that a TaskGroup wishes to use.
 type VolumeRequest struct {
-	Name         string           `hcl:"name,label"`
-	Type         string           `hcl:"type,optional"`
-	Source       string           `hcl:"source,optional"`
-	ReadOnly     bool             `hcl:"read_only,optional"`
-	MountOptions *CSIMountOptions `hcl:"mount_options,block"`
-	PerAlloc     bool             `hcl:"per_alloc,optional"`
-	ExtraKeysHCL []string         `hcl1:",unusedKeys,optional" json:"-"`
+	Name           string           `hcl:"name,label"`
+	Type           string           `hcl:"type,optional"`
+	Source         string           `hcl:"source,optional"`
+	ReadOnly       bool             `hcl:"read_only,optional"`
+	AccessMode     string           `hcl:"access_mode,optional"`
+	AttachmentMode string           `hcl:"attachment_mode,optional"`
+	MountOptions   *CSIMountOptions `hcl:"mount_options,block"`
+	PerAlloc       bool             `hcl:"per_alloc,optional"`
+	ExtraKeysHCL   []string         `hcl1:",unusedKeys,optional" json:"-"`
 }
 
 const (

--- a/client/allocrunner/csi_hook.go
+++ b/client/allocrunner/csi_hook.go
@@ -54,8 +54,8 @@ func (c *csiHook) Prerun() error {
 
 		usageOpts := &csimanager.UsageOptions{
 			ReadOnly:       pair.request.ReadOnly,
-			AttachmentMode: string(pair.volume.AttachmentMode),
-			AccessMode:     string(pair.volume.AccessMode),
+			AttachmentMode: pair.request.AttachmentMode,
+			AccessMode:     pair.request.AccessMode,
 			MountOptions:   pair.request.MountOptions,
 		}
 
@@ -171,10 +171,12 @@ func (c *csiHook) claimVolumesFromAlloc() (map[string]*volumeAndRequest, error) 
 		}
 
 		req := &structs.CSIVolumeClaimRequest{
-			VolumeID:     source,
-			AllocationID: c.alloc.ID,
-			NodeID:       c.alloc.NodeID,
-			Claim:        claimType,
+			VolumeID:       source,
+			AllocationID:   c.alloc.ID,
+			NodeID:         c.alloc.NodeID,
+			Claim:          claimType,
+			AccessMode:     pair.request.AccessMode,
+			AttachmentMode: pair.request.AttachmentMode,
 			WriteRequest: structs.WriteRequest{
 				Region:    c.alloc.Job.Region,
 				Namespace: c.alloc.Job.Namespace,
@@ -191,6 +193,7 @@ func (c *csiHook) claimVolumesFromAlloc() (map[string]*volumeAndRequest, error) 
 			return nil, fmt.Errorf("Unexpected nil volume returned for ID: %v", pair.request.Source)
 		}
 
+		result[alias].request = pair.request
 		result[alias].volume = resp.Volume
 		result[alias].publishContext = resp.PublishContext
 	}

--- a/client/csi_endpoint.go
+++ b/client/csi_endpoint.go
@@ -468,8 +468,8 @@ func (c *CSI) NodeDetachVolume(req *structs.ClientCSINodeDetachVolumeRequest, re
 
 	usageOpts := &csimanager.UsageOptions{
 		ReadOnly:       req.ReadOnly,
-		AttachmentMode: string(req.AttachmentMode),
-		AccessMode:     string(req.AccessMode),
+		AttachmentMode: req.AttachmentMode,
+		AccessMode:     req.AccessMode,
 	}
 
 	err = mounter.UnmountVolume(ctx, req.VolumeID, req.ExternalID, req.AllocID, usageOpts)

--- a/client/pluginmanager/csimanager/interface.go
+++ b/client/pluginmanager/csimanager/interface.go
@@ -15,8 +15,8 @@ type MountInfo struct {
 
 type UsageOptions struct {
 	ReadOnly       bool
-	AttachmentMode string
-	AccessMode     string
+	AttachmentMode structs.CSIVolumeAttachmentMode
+	AccessMode     structs.CSIVolumeAccessMode
 	MountOptions   *structs.CSIMountOptions
 }
 
@@ -33,9 +33,9 @@ func (u *UsageOptions) ToFS() string {
 		sb.WriteString("rw-")
 	}
 
-	sb.WriteString(u.AttachmentMode)
+	sb.WriteString(string(u.AttachmentMode))
 	sb.WriteString("-")
-	sb.WriteString(u.AccessMode)
+	sb.WriteString(string(u.AccessMode))
 
 	return sb.String()
 }

--- a/client/pluginmanager/csimanager/volume.go
+++ b/client/pluginmanager/csimanager/volume.go
@@ -127,7 +127,7 @@ func (v *volumeManager) ensureAllocDir(vol *structs.CSIVolume, alloc *structs.Al
 }
 
 func volumeCapability(vol *structs.CSIVolume, usage *UsageOptions) (*csi.VolumeCapability, error) {
-	capability, err := csi.VolumeCapabilityFromStructs(vol.AttachmentMode, vol.AccessMode)
+	capability, err := csi.VolumeCapabilityFromStructs(usage.AttachmentMode, usage.AccessMode)
 	if err != nil {
 		return nil, err
 	}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -940,11 +940,13 @@ func ApiTgToStructsTG(job *structs.Job, taskGroup *api.TaskGroup, tg *structs.Ta
 			}
 
 			vol := &structs.VolumeRequest{
-				Name:     v.Name,
-				Type:     v.Type,
-				ReadOnly: v.ReadOnly,
-				Source:   v.Source,
-				PerAlloc: v.PerAlloc,
+				Name:           v.Name,
+				Type:           v.Type,
+				ReadOnly:       v.ReadOnly,
+				Source:         v.Source,
+				AttachmentMode: structs.CSIVolumeAttachmentMode(v.AttachmentMode),
+				AccessMode:     structs.CSIVolumeAccessMode(v.AccessMode),
+				PerAlloc:       v.PerAlloc,
 			}
 
 			if v.MountOptions != nil {

--- a/command/volume_init.go
+++ b/command/volume_init.go
@@ -125,10 +125,11 @@ snapshot_id = "snap-12345"
 capacity_min = "10GiB"
 capacity_max = "20G"
 
-# Optional: for 'nomad volume create', specify one or more capabilities to
-# validate. Registering an existing volume will record but ignore these fields.
+# Required (at least one): for 'nomad volume create', specify one or more
+# capabilities to validate. Registering an existing volume will record but
+# ignore these fields.
 capability {
-  access_mode     = "single-node-writer"
+  access_mode = "single-node-writer"
   attachment_mode = "file-system"
 }
 
@@ -137,9 +138,9 @@ capability {
   attachment_mode = "block-device"
 }
 
-# Optional: for 'nomad volume create', specify mount options to
-# validate. Registering an existing volume will record but ignore these
-# fields.
+# Optional: for 'nomad volume create', specify mount options to validate for
+# 'attachment_mode = "file-system". Registering an existing volume will record
+# but ignore these fields.
 mount_options {
   fs_type     = "ext4"
   mount_flags = ["ro"]

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -377,7 +377,6 @@ func (v *CSIVolume) Claim(args *structs.CSIVolumeClaimRequest, reply *structs.CS
 
 	isNewClaim := args.Claim != structs.CSIVolumeClaimGC &&
 		args.State == structs.CSIVolumeClaimStateTaken
-
 	// COMPAT(1.0): the NodeID field was added after 0.11.0 and so we
 	// need to ensure it's been populated during upgrades from 0.11.0
 	// to later patch versions. Remove this block in 1.0
@@ -470,8 +469,8 @@ func (v *CSIVolume) controllerPublishVolume(req *structs.CSIVolumeClaimRequest, 
 	cReq := &cstructs.ClientCSIControllerAttachVolumeRequest{
 		VolumeID:        vol.RemoteID(),
 		ClientCSINodeID: externalNodeID,
-		AttachmentMode:  vol.AttachmentMode,
-		AccessMode:      vol.AccessMode,
+		AttachmentMode:  req.AttachmentMode,
+		AccessMode:      req.AccessMode,
 		ReadOnly:        req.Claim == structs.CSIVolumeClaimRead,
 		Secrets:         vol.Secrets,
 		VolumeContext:   vol.Context,

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2479,6 +2479,23 @@ func (s *StateStore) CSIVolumeDenormalizeTxn(txn Txn, ws memdb.WatchSet, vol *st
 		}
 	}
 
+	// COMPAT: the AccessMode and AttachmentMode fields were added to claims
+	// in 1.1.0, so claims made before that may be missing this value. In this
+	// case, the volume will already have AccessMode/AttachmentMode until it
+	// no longer has any claims, so set from those values
+	for _, claim := range vol.ReadClaims {
+		if claim.AccessMode == "" || claim.AttachmentMode == "" {
+			claim.AccessMode = vol.AccessMode
+			claim.AttachmentMode = vol.AttachmentMode
+		}
+	}
+	for _, claim := range vol.WriteClaims {
+		if claim.AccessMode == "" || claim.AttachmentMode == "" {
+			claim.AccessMode = vol.AccessMode
+			claim.AttachmentMode = vol.AttachmentMode
+		}
+	}
+
 	return vol, nil
 }
 

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -224,6 +224,8 @@ type CSIVolumeClaim struct {
 	NodeID         string
 	ExternalNodeID string
 	Mode           CSIVolumeClaimMode
+	AccessMode     CSIVolumeAccessMode
+	AttachmentMode CSIVolumeAttachmentMode
 	State          CSIVolumeClaimState
 }
 
@@ -247,13 +249,14 @@ type CSIVolume struct {
 	ExternalID     string
 	Namespace      string
 	Topologies     []*CSITopology
-	AccessMode     CSIVolumeAccessMode
-	AttachmentMode CSIVolumeAttachmentMode
+	AccessMode     CSIVolumeAccessMode     // *current* access mode
+	AttachmentMode CSIVolumeAttachmentMode // *current* attachment mode
 	MountOptions   *CSIMountOptions
-	Secrets        CSISecrets
-	Parameters     map[string]string
-	Context        map[string]string
-	Capacity       int64 // bytes
+
+	Secrets    CSISecrets
+	Parameters map[string]string
+	Context    map[string]string
+	Capacity   int64 // bytes
 
 	// These values are used only on volume creation but we record them
 	// so that we can diff the volume later
@@ -376,19 +379,32 @@ func (v *CSIVolume) ReadSchedulable() bool {
 	return v.ResourceExhausted == time.Time{}
 }
 
-// WriteSchedulable determines if the volume is schedulable for writes, considering only
-// volume health
+// WriteSchedulable determines if the volume is schedulable for writes,
+// considering only volume capabilities and plugin health
 func (v *CSIVolume) WriteSchedulable() bool {
 	if !v.Schedulable {
 		return false
 	}
 
 	switch v.AccessMode {
-	case CSIVolumeAccessModeSingleNodeWriter, CSIVolumeAccessModeMultiNodeSingleWriter, CSIVolumeAccessModeMultiNodeMultiWriter:
+	case CSIVolumeAccessModeSingleNodeWriter,
+		CSIVolumeAccessModeMultiNodeSingleWriter,
+		CSIVolumeAccessModeMultiNodeMultiWriter:
 		return v.ResourceExhausted == time.Time{}
-	default:
-		return false
+
+	case CSIVolumeAccessModeUnknown:
+		// this volume was created but not currently claimed, so we check what
+		// it's capable of, not what it's been previously assigned
+		for _, cap := range v.RequestedCapabilities {
+			switch cap.AccessMode {
+			case CSIVolumeAccessModeSingleNodeWriter,
+				CSIVolumeAccessModeMultiNodeSingleWriter,
+				CSIVolumeAccessModeMultiNodeMultiWriter:
+				return v.ResourceExhausted == time.Time{}
+			}
+		}
 	}
+	return false
 }
 
 // WriteFreeClaims determines if there are any free write claims available
@@ -401,9 +417,25 @@ func (v *CSIVolume) WriteFreeClaims() bool {
 		// we track node resource exhaustion through v.ResourceExhausted
 		// which is checked in WriteSchedulable
 		return true
-	default:
-		return false
+	case CSIVolumeAccessModeUnknown:
+		// this volume was created but not yet claimed, so we check what it's
+		// capable of, not what it's been assigned
+		if len(v.RequestedCapabilities) == 0 {
+			// COMPAT: a volume that was registered before 1.1.0 and has not
+			// had a change in claims could have no requested caps. It will
+			// get corrected on the first claim.
+			return true
+		}
+		for _, cap := range v.RequestedCapabilities {
+			switch cap.AccessMode {
+			case CSIVolumeAccessModeSingleNodeWriter, CSIVolumeAccessModeMultiNodeSingleWriter:
+				return len(v.WriteClaims) == 0
+			case CSIVolumeAccessModeMultiNodeMultiWriter:
+				return true
+			}
+		}
 	}
+	return false
 }
 
 // InUse tests whether any allocations are actively using the volume
@@ -459,6 +491,23 @@ func (v *CSIVolume) Copy() *CSIVolume {
 
 // Claim updates the allocations and changes the volume state
 func (v *CSIVolume) Claim(claim *CSIVolumeClaim, alloc *Allocation) error {
+	// COMPAT: volumes registered prior to 1.1.0 will be missing caps for the
+	// volume on any claim. Correct this when we make the first change to a
+	// claim by setting its currently claimed capability as the only requested
+	// capability
+	if len(v.RequestedCapabilities) == 0 && v.AccessMode != "" && v.AttachmentMode != "" {
+		v.RequestedCapabilities = []*CSIVolumeCapability{
+			{
+				AccessMode:     v.AccessMode,
+				AttachmentMode: v.AttachmentMode,
+			},
+		}
+	}
+	if v.AttachmentMode != CSIVolumeAttachmentModeUnknown &&
+		claim.AttachmentMode != CSIVolumeAttachmentModeUnknown &&
+		v.AttachmentMode != claim.AttachmentMode {
+		return fmt.Errorf("cannot change attachment mode of claimed volume")
+	}
 
 	if claim.State == CSIVolumeClaimStateTaken {
 		switch claim.Mode {
@@ -494,6 +543,7 @@ func (v *CSIVolume) claimRead(claim *CSIVolumeClaim, alloc *Allocation) error {
 	delete(v.WriteClaims, claim.AllocationID)
 	delete(v.PastClaims, claim.AllocationID)
 
+	v.setModesFromClaim(claim)
 	return nil
 }
 
@@ -528,7 +578,22 @@ func (v *CSIVolume) claimWrite(claim *CSIVolumeClaim, alloc *Allocation) error {
 	delete(v.ReadClaims, alloc.ID)
 	delete(v.PastClaims, alloc.ID)
 
+	v.setModesFromClaim(claim)
 	return nil
+}
+
+// setModesFromClaim sets the volume AttachmentMode and AccessMode based on
+// the first claim we make.  Originally the volume AccessMode and
+// AttachmentMode were set during registration, but this is incorrect once we
+// started creating volumes ourselves. But we still want these values for CLI
+// and UI status.
+func (v *CSIVolume) setModesFromClaim(claim *CSIVolumeClaim) {
+	if v.AttachmentMode == CSIVolumeAttachmentModeUnknown {
+		v.AttachmentMode = claim.AttachmentMode
+	}
+	if v.AccessMode == CSIVolumeAccessModeUnknown {
+		v.AccessMode = claim.AccessMode
+	}
 }
 
 // claimRelease is called when the allocation has terminated and
@@ -540,6 +605,12 @@ func (v *CSIVolume) claimRelease(claim *CSIVolumeClaim) error {
 		delete(v.ReadClaims, claim.AllocationID)
 		delete(v.WriteClaims, claim.AllocationID)
 		delete(v.PastClaims, claim.AllocationID)
+
+		// remove AccessMode/AttachmentMode if this is the last claim
+		if len(v.ReadClaims) == 0 && len(v.WriteClaims) == 0 && len(v.PastClaims) == 0 {
+			v.AccessMode = CSIVolumeAccessModeUnknown
+			v.AttachmentMode = CSIVolumeAttachmentModeUnknown
+		}
 	} else {
 		v.PastClaims[claim.AllocationID] = claim
 	}
@@ -674,6 +745,8 @@ type CSIVolumeClaimRequest struct {
 	NodeID         string
 	ExternalNodeID string
 	Claim          CSIVolumeClaimMode
+	AccessMode     CSIVolumeAccessMode
+	AttachmentMode CSIVolumeAttachmentMode
 	State          CSIVolumeClaimState
 	WriteRequest
 }
@@ -684,6 +757,8 @@ func (req *CSIVolumeClaimRequest) ToClaim() *CSIVolumeClaim {
 		NodeID:         req.NodeID,
 		ExternalNodeID: req.ExternalNodeID,
 		Mode:           req.Claim,
+		AccessMode:     req.AccessMode,
+		AttachmentMode: req.AttachmentMode,
 		State:          req.State,
 	}
 }

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -463,17 +463,17 @@ func (v *CSIVolume) Claim(claim *CSIVolumeClaim, alloc *Allocation) error {
 	if claim.State == CSIVolumeClaimStateTaken {
 		switch claim.Mode {
 		case CSIVolumeClaimRead:
-			return v.ClaimRead(claim, alloc)
+			return v.claimRead(claim, alloc)
 		case CSIVolumeClaimWrite:
-			return v.ClaimWrite(claim, alloc)
+			return v.claimWrite(claim, alloc)
 		}
 	}
 	// either GC or a Unpublish checkpoint
-	return v.ClaimRelease(claim)
+	return v.claimRelease(claim)
 }
 
-// ClaimRead marks an allocation as using a volume read-only
-func (v *CSIVolume) ClaimRead(claim *CSIVolumeClaim, alloc *Allocation) error {
+// claimRead marks an allocation as using a volume read-only
+func (v *CSIVolume) claimRead(claim *CSIVolumeClaim, alloc *Allocation) error {
 	if _, ok := v.ReadAllocs[claim.AllocationID]; ok {
 		return nil
 	}
@@ -497,8 +497,8 @@ func (v *CSIVolume) ClaimRead(claim *CSIVolumeClaim, alloc *Allocation) error {
 	return nil
 }
 
-// ClaimWrite marks an allocation as using a volume as a writer
-func (v *CSIVolume) ClaimWrite(claim *CSIVolumeClaim, alloc *Allocation) error {
+// claimWrite marks an allocation as using a volume as a writer
+func (v *CSIVolume) claimWrite(claim *CSIVolumeClaim, alloc *Allocation) error {
 	if _, ok := v.WriteAllocs[claim.AllocationID]; ok {
 		return nil
 	}
@@ -531,9 +531,9 @@ func (v *CSIVolume) ClaimWrite(claim *CSIVolumeClaim, alloc *Allocation) error {
 	return nil
 }
 
-// ClaimRelease is called when the allocation has terminated and
+// claimRelease is called when the allocation has terminated and
 // already stopped using the volume
-func (v *CSIVolume) ClaimRelease(claim *CSIVolumeClaim) error {
+func (v *CSIVolume) claimRelease(claim *CSIVolumeClaim) error {
 	if claim.State == CSIVolumeClaimStateReadyToFree {
 		delete(v.ReadAllocs, claim.AllocationID)
 		delete(v.WriteAllocs, claim.AllocationID)

--- a/nomad/structs/csi_test.go
+++ b/nomad/structs/csi_test.go
@@ -8,41 +8,470 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestCSIVolumeClaim ensures that a volume claim workflows work as expected.
 func TestCSIVolumeClaim(t *testing.T) {
-	vol := NewCSIVolume("", 0)
-	vol.AccessMode = CSIVolumeAccessModeMultiNodeSingleWriter
+	require := require.New(t)
+	vol := NewCSIVolume("vol0", 0)
 	vol.Schedulable = true
-
-	alloc := &Allocation{ID: "a1", Namespace: "n", JobID: "j"}
-	claim := &CSIVolumeClaim{
-		AllocationID: alloc.ID,
-		NodeID:       "foo",
-		Mode:         CSIVolumeClaimRead,
+	vol.AccessMode = CSIVolumeAccessModeUnknown
+	vol.AttachmentMode = CSIVolumeAttachmentModeUnknown
+	vol.RequestedCapabilities = []*CSIVolumeCapability{
+		{
+			AccessMode:     CSIVolumeAccessModeMultiNodeSingleWriter,
+			AttachmentMode: CSIVolumeAttachmentModeFilesystem,
+		},
+		{
+			AccessMode:     CSIVolumeAccessModeMultiNodeReader,
+			AttachmentMode: CSIVolumeAttachmentModeFilesystem,
+		},
 	}
 
-	require.NoError(t, vol.claimRead(claim, alloc))
-	require.True(t, vol.ReadSchedulable())
-	require.True(t, vol.WriteSchedulable())
-	require.NoError(t, vol.claimRead(claim, alloc))
+	alloc1 := &Allocation{ID: "a1", Namespace: "n", JobID: "j"}
+	alloc2 := &Allocation{ID: "a2", Namespace: "n", JobID: "j"}
+	alloc3 := &Allocation{ID: "a3", Namespace: "n", JobID: "j3"}
+	claim := &CSIVolumeClaim{
+		AllocationID: alloc1.ID,
+		NodeID:       "foo",
+		State:        CSIVolumeClaimStateTaken,
+	}
 
+	// claim a read and ensure we are still schedulable
+	claim.Mode = CSIVolumeClaimRead
+	claim.AccessMode = CSIVolumeAccessModeMultiNodeReader
+	claim.AttachmentMode = CSIVolumeAttachmentModeFilesystem
+	require.NoError(vol.Claim(claim, alloc1))
+	require.True(vol.ReadSchedulable())
+	require.False(vol.WriteSchedulable())
+	require.False(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 1)
+	require.Len(vol.WriteClaims, 0)
+	require.Len(vol.PastClaims, 0)
+	require.Equal(CSIVolumeAccessModeMultiNodeReader, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+	require.Len(vol.RequestedCapabilities, 2)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter,
+		vol.RequestedCapabilities[0].AccessMode)
+	require.Equal(CSIVolumeAccessModeMultiNodeReader,
+		vol.RequestedCapabilities[1].AccessMode)
+
+	// claim a write and ensure we can't upgrade capabilities.
+	claim.AccessMode = CSIVolumeAccessModeMultiNodeSingleWriter
 	claim.Mode = CSIVolumeClaimWrite
-	require.NoError(t, vol.claimWrite(claim, alloc))
-	require.True(t, vol.ReadSchedulable())
-	require.False(t, vol.WriteFreeClaims())
+	claim.AllocationID = alloc2.ID
+	require.EqualError(vol.Claim(claim, alloc2), "unschedulable")
+	require.True(vol.ReadSchedulable())
+	require.False(vol.WriteSchedulable())
+	require.False(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 1)
+	require.Len(vol.WriteClaims, 0)
+	require.Len(vol.PastClaims, 0)
+	require.Equal(CSIVolumeAccessModeMultiNodeReader, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
 
-	vol.claimRelease(claim)
-	require.True(t, vol.ReadSchedulable())
-	require.False(t, vol.WriteFreeClaims())
-
+	// release our last claim, including unpublish workflow
+	claim.AllocationID = alloc1.ID
+	claim.Mode = CSIVolumeClaimRead
 	claim.State = CSIVolumeClaimStateReadyToFree
-	vol.claimRelease(claim)
-	require.True(t, vol.ReadSchedulable())
-	require.True(t, vol.WriteFreeClaims())
+	vol.Claim(claim, nil)
+	require.Len(vol.ReadClaims, 0)
+	require.Len(vol.WriteClaims, 0)
+	require.Equal(CSIVolumeAccessModeUnknown, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeUnknown, vol.AttachmentMode)
+	require.Len(vol.RequestedCapabilities, 2)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter,
+		vol.RequestedCapabilities[0].AccessMode)
+	require.Equal(CSIVolumeAccessModeMultiNodeReader,
+		vol.RequestedCapabilities[1].AccessMode)
 
-	vol.AccessMode = CSIVolumeAccessModeMultiNodeMultiWriter
-	require.NoError(t, vol.claimWrite(claim, alloc))
-	require.NoError(t, vol.claimWrite(claim, alloc))
-	require.True(t, vol.WriteFreeClaims())
+	// claim a write on the now-unclaimed volume and ensure we can upgrade
+	// capabilities so long as they're in our RequestedCapabilities.
+	claim.AccessMode = CSIVolumeAccessModeMultiNodeSingleWriter
+	claim.Mode = CSIVolumeClaimWrite
+	claim.State = CSIVolumeClaimStateTaken
+	claim.AllocationID = alloc2.ID
+	require.NoError(vol.Claim(claim, alloc2))
+	require.Len(vol.ReadClaims, 0)
+	require.Len(vol.WriteClaims, 1)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+	require.Len(vol.RequestedCapabilities, 2)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter,
+		vol.RequestedCapabilities[0].AccessMode)
+	require.Equal(CSIVolumeAccessModeMultiNodeReader,
+		vol.RequestedCapabilities[1].AccessMode)
+
+	// make the claim again to ensure its idempotent, and that the volume's
+	// access mode is unchanged.
+	require.NoError(vol.Claim(claim, alloc2))
+	require.True(vol.ReadSchedulable())
+	require.True(vol.WriteSchedulable())
+	require.False(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 0)
+	require.Len(vol.WriteClaims, 1)
+	require.Len(vol.PastClaims, 0)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+
+	// claim a read. ensure we are still schedulable and that we haven't
+	// changed the access mode
+	claim.AllocationID = alloc1.ID
+	claim.Mode = CSIVolumeClaimRead
+	claim.AccessMode = CSIVolumeAccessModeMultiNodeReader
+	claim.AttachmentMode = CSIVolumeAttachmentModeFilesystem
+	require.NoError(vol.Claim(claim, alloc1))
+	require.True(vol.ReadSchedulable())
+	require.True(vol.WriteSchedulable())
+	require.False(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 1)
+	require.Len(vol.WriteClaims, 1)
+	require.Len(vol.PastClaims, 0)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+
+	// ensure we can't change the attachment mode for a claimed volume
+	claim.AttachmentMode = CSIVolumeAttachmentModeBlockDevice
+	claim.AllocationID = alloc3.ID
+	require.EqualError(vol.Claim(claim, alloc3),
+		"cannot change attachment mode of claimed volume")
+	claim.AttachmentMode = CSIVolumeAttachmentModeFilesystem
+
+	// denormalize-on-read (simulating a volume we've gotten out of the state
+	// store) and then ensure we cannot claim another write
+	vol.WriteAllocs[alloc2.ID] = alloc2
+	claim.Mode = CSIVolumeClaimWrite
+	require.EqualError(vol.Claim(claim, alloc3), "volume max claim reached")
+
+	// release the write claim but ensure it doesn't free up write claims
+	// until after we've unpublished
+	claim.AllocationID = alloc2.ID
+	claim.State = CSIVolumeClaimStateUnpublishing
+	vol.Claim(claim, nil)
+	require.True(vol.ReadSchedulable())
+	require.True(vol.WriteSchedulable())
+	require.False(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 1)
+	require.Len(vol.WriteClaims, 1) // claim still exists until we're done
+	require.Len(vol.PastClaims, 1)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+
+	// complete the unpublish workflow
+	claim.State = CSIVolumeClaimStateReadyToFree
+	vol.Claim(claim, nil)
+	require.True(vol.ReadSchedulable())
+	require.True(vol.WriteSchedulable())
+	require.True(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 1)
+	require.Len(vol.WriteClaims, 0)
+	require.Len(vol.WriteAllocs, 0)
+	require.Len(vol.PastClaims, 0)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+
+	// release our last claim, including unpublish workflow
+	claim.AllocationID = alloc1.ID
+	claim.Mode = CSIVolumeClaimRead
+	vol.Claim(claim, nil)
+	require.Len(vol.ReadClaims, 0)
+	require.Len(vol.WriteClaims, 0)
+	require.Equal(CSIVolumeAccessModeUnknown, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeUnknown, vol.AttachmentMode)
+	require.Len(vol.RequestedCapabilities, 2)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter,
+		vol.RequestedCapabilities[0].AccessMode)
+	require.Equal(CSIVolumeAccessModeMultiNodeReader,
+		vol.RequestedCapabilities[1].AccessMode)
+}
+
+// TestCSIVolumeClaim_CompatOldClaims ensures that volume created before
+// v1.1.0 with claims that exist before v1.1.0 still work.
+//
+// COMPAT(1.3.0): safe to remove this test, but not the code, for 1.3.0
+func TestCSIVolumeClaim_CompatOldClaims(t *testing.T) {
+	require := require.New(t)
+	vol := NewCSIVolume("vol0", 0)
+	vol.Schedulable = true
+	vol.AccessMode = CSIVolumeAccessModeMultiNodeSingleWriter
+	vol.AttachmentMode = CSIVolumeAttachmentModeFilesystem
+
+	alloc1 := &Allocation{ID: "a1", Namespace: "n", JobID: "j"}
+	alloc2 := &Allocation{ID: "a2", Namespace: "n", JobID: "j"}
+	alloc3 := &Allocation{ID: "a3", Namespace: "n", JobID: "j3"}
+	claim := &CSIVolumeClaim{
+		AllocationID: alloc1.ID,
+		NodeID:       "foo",
+		State:        CSIVolumeClaimStateTaken,
+	}
+
+	// claim a read and ensure we are still schedulable
+	claim.Mode = CSIVolumeClaimRead
+	require.NoError(vol.Claim(claim, alloc1))
+	require.True(vol.ReadSchedulable())
+	require.True(vol.WriteSchedulable())
+	require.True(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 1)
+	require.Len(vol.WriteClaims, 0)
+	require.Len(vol.PastClaims, 0)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+	require.Len(vol.RequestedCapabilities, 1)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter,
+		vol.RequestedCapabilities[0].AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem,
+		vol.RequestedCapabilities[0].AttachmentMode)
+
+	// claim a write and ensure we no longer have free write claims
+	claim.Mode = CSIVolumeClaimWrite
+	claim.AllocationID = alloc2.ID
+	require.NoError(vol.Claim(claim, alloc2))
+	require.True(vol.ReadSchedulable())
+	require.True(vol.WriteSchedulable())
+	require.False(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 1)
+	require.Len(vol.WriteClaims, 1)
+	require.Len(vol.PastClaims, 0)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+
+	// denormalize-on-read (simulating a volume we've gotten out of the state
+	// store) and then ensure we cannot claim another write
+	vol.WriteAllocs[alloc2.ID] = alloc2
+	claim.AllocationID = alloc3.ID
+	require.EqualError(vol.Claim(claim, alloc3), "volume max claim reached")
+
+	// release the write claim but ensure it doesn't free up write claims
+	// until after we've unpublished
+	claim.AllocationID = alloc2.ID
+	claim.State = CSIVolumeClaimStateUnpublishing
+	vol.Claim(claim, nil)
+	require.True(vol.ReadSchedulable())
+	require.True(vol.WriteSchedulable())
+	require.False(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 1)
+	require.Len(vol.WriteClaims, 1) // claim still exists until we're done
+	require.Len(vol.PastClaims, 1)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+
+	// complete the unpublish workflow
+	claim.State = CSIVolumeClaimStateReadyToFree
+	vol.Claim(claim, nil)
+	require.True(vol.ReadSchedulable())
+	require.True(vol.WriteSchedulable())
+	require.True(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 1)
+	require.Len(vol.WriteClaims, 0)
+	require.Len(vol.WriteAllocs, 0)
+	require.Len(vol.PastClaims, 0)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+
+	// release our last claim, including unpublish workflow
+	claim.AllocationID = alloc1.ID
+	claim.Mode = CSIVolumeClaimRead
+	vol.Claim(claim, nil)
+	require.Len(vol.ReadClaims, 0)
+	require.Len(vol.WriteClaims, 0)
+	require.Equal(CSIVolumeAccessModeUnknown, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeUnknown, vol.AttachmentMode)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter,
+		vol.RequestedCapabilities[0].AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem,
+		vol.RequestedCapabilities[0].AttachmentMode)
+}
+
+// TestCSIVolumeClaim_CompatNewClaimsOK ensures that a volume created
+// before v1.1.0 is compatible with new claims.
+//
+// COMPAT(1.3.0): safe to remove this test, but not the code, for 1.3.0
+func TestCSIVolumeClaim_CompatNewClaimsOK(t *testing.T) {
+	require := require.New(t)
+	vol := NewCSIVolume("vol0", 0)
+	vol.Schedulable = true
+	vol.AccessMode = CSIVolumeAccessModeMultiNodeSingleWriter
+	vol.AttachmentMode = CSIVolumeAttachmentModeFilesystem
+
+	alloc1 := &Allocation{ID: "a1", Namespace: "n", JobID: "j"}
+	alloc2 := &Allocation{ID: "a2", Namespace: "n", JobID: "j"}
+	alloc3 := &Allocation{ID: "a3", Namespace: "n", JobID: "j3"}
+	claim := &CSIVolumeClaim{
+		AllocationID: alloc1.ID,
+		NodeID:       "foo",
+		State:        CSIVolumeClaimStateTaken,
+	}
+
+	// claim a read and ensure we are still schedulable
+	claim.Mode = CSIVolumeClaimRead
+	claim.AccessMode = CSIVolumeAccessModeMultiNodeReader
+	claim.AttachmentMode = CSIVolumeAttachmentModeFilesystem
+	require.NoError(vol.Claim(claim, alloc1))
+	require.True(vol.ReadSchedulable())
+	require.True(vol.WriteSchedulable())
+	require.True(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 1)
+	require.Len(vol.WriteClaims, 0)
+	require.Len(vol.PastClaims, 0)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+	require.Len(vol.RequestedCapabilities, 1)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter,
+		vol.RequestedCapabilities[0].AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem,
+		vol.RequestedCapabilities[0].AttachmentMode)
+
+	// claim a write and ensure we no longer have free write claims
+	claim.Mode = CSIVolumeClaimWrite
+	claim.AllocationID = alloc2.ID
+	require.NoError(vol.Claim(claim, alloc2))
+	require.True(vol.ReadSchedulable())
+	require.True(vol.WriteSchedulable())
+	require.False(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 1)
+	require.Len(vol.WriteClaims, 1)
+	require.Len(vol.PastClaims, 0)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+
+	// ensure we can't change the attachment mode for a claimed volume
+	claim.AttachmentMode = CSIVolumeAttachmentModeBlockDevice
+	require.EqualError(vol.Claim(claim, alloc2),
+		"cannot change attachment mode of claimed volume")
+	claim.AttachmentMode = CSIVolumeAttachmentModeFilesystem
+
+	// denormalize-on-read (simulating a volume we've gotten out of the state
+	// store) and then ensure we cannot claim another write
+	vol.WriteAllocs[alloc2.ID] = alloc2
+	claim.AllocationID = alloc3.ID
+	require.EqualError(vol.Claim(claim, alloc3), "volume max claim reached")
+
+	// release the write claim but ensure it doesn't free up write claims
+	// until after we've unpublished
+	claim.AllocationID = alloc2.ID
+	claim.State = CSIVolumeClaimStateUnpublishing
+	vol.Claim(claim, nil)
+	require.True(vol.ReadSchedulable())
+	require.True(vol.WriteSchedulable())
+	require.False(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 1)
+	require.Len(vol.WriteClaims, 1) // claim still exists until we're done
+	require.Len(vol.PastClaims, 1)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+
+	// complete the unpublish workflow
+	claim.State = CSIVolumeClaimStateReadyToFree
+	vol.Claim(claim, nil)
+	require.True(vol.ReadSchedulable())
+	require.True(vol.WriteSchedulable())
+	require.True(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 1)
+	require.Len(vol.WriteClaims, 0)
+	require.Len(vol.WriteAllocs, 0)
+	require.Len(vol.PastClaims, 0)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+
+	// release our last claim, including unpublish workflow
+	claim.AllocationID = alloc1.ID
+	claim.Mode = CSIVolumeClaimRead
+	vol.Claim(claim, nil)
+	require.Len(vol.ReadClaims, 0)
+	require.Len(vol.WriteClaims, 0)
+	require.Equal(CSIVolumeAccessModeUnknown, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeUnknown, vol.AttachmentMode)
+	require.Equal(CSIVolumeAccessModeMultiNodeSingleWriter,
+		vol.RequestedCapabilities[0].AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem,
+		vol.RequestedCapabilities[0].AttachmentMode)
+}
+
+// TestCSIVolumeClaim_CompatNewClaimsNoUpgrade ensures that a volume created
+// before v1.1.0 is compatible with new claims, but prevents unexpected
+// capability upgrades.
+//
+// COMPAT(1.3.0): safe to remove this test, but not the code, for 1.3.0
+func TestCSIVolumeClaim_CompatNewClaimsNoUpgrade(t *testing.T) {
+	require := require.New(t)
+	vol := NewCSIVolume("vol0", 0)
+	vol.Schedulable = true
+	vol.AccessMode = CSIVolumeAccessModeMultiNodeReader
+	vol.AttachmentMode = CSIVolumeAttachmentModeFilesystem
+
+	alloc1 := &Allocation{ID: "a1", Namespace: "n", JobID: "j"}
+	alloc2 := &Allocation{ID: "a2", Namespace: "n", JobID: "j"}
+	claim := &CSIVolumeClaim{
+		AllocationID: alloc1.ID,
+		NodeID:       "foo",
+		State:        CSIVolumeClaimStateTaken,
+	}
+
+	// claim a read and ensure we are still schedulable
+	claim.Mode = CSIVolumeClaimRead
+	claim.AccessMode = CSIVolumeAccessModeMultiNodeReader
+	claim.AttachmentMode = CSIVolumeAttachmentModeFilesystem
+	require.NoError(vol.Claim(claim, alloc1))
+	require.True(vol.ReadSchedulable())
+	require.False(vol.WriteSchedulable())
+	require.False(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 1)
+	require.Len(vol.WriteClaims, 0)
+	require.Len(vol.PastClaims, 0)
+	require.Equal(CSIVolumeAccessModeMultiNodeReader, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+	require.Len(vol.RequestedCapabilities, 1)
+	require.Equal(CSIVolumeAccessModeMultiNodeReader,
+		vol.RequestedCapabilities[0].AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem,
+		vol.RequestedCapabilities[0].AttachmentMode)
+
+	// claim a write and ensure we can't upgrade capabilities.
+	claim.AccessMode = CSIVolumeAccessModeMultiNodeSingleWriter
+	claim.Mode = CSIVolumeClaimWrite
+	claim.AllocationID = alloc2.ID
+	require.EqualError(vol.Claim(claim, alloc2), "unschedulable")
+	require.True(vol.ReadSchedulable())
+	require.False(vol.WriteSchedulable())
+	require.False(vol.WriteFreeClaims())
+	require.Len(vol.ReadClaims, 1)
+	require.Len(vol.WriteClaims, 0)
+	require.Len(vol.PastClaims, 0)
+	require.Equal(CSIVolumeAccessModeMultiNodeReader, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem, vol.AttachmentMode)
+	require.Len(vol.RequestedCapabilities, 1)
+	require.Equal(CSIVolumeAccessModeMultiNodeReader,
+		vol.RequestedCapabilities[0].AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem,
+		vol.RequestedCapabilities[0].AttachmentMode)
+
+	// release our last claim, including unpublish workflow
+	claim.AllocationID = alloc1.ID
+	claim.Mode = CSIVolumeClaimRead
+	claim.State = CSIVolumeClaimStateReadyToFree
+	vol.Claim(claim, nil)
+	require.Len(vol.ReadClaims, 0)
+	require.Len(vol.WriteClaims, 0)
+	require.Equal(CSIVolumeAccessModeUnknown, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeUnknown, vol.AttachmentMode)
+	require.Equal(CSIVolumeAccessModeMultiNodeReader,
+		vol.RequestedCapabilities[0].AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem,
+		vol.RequestedCapabilities[0].AttachmentMode)
+
+	// claim a write on the now-unclaimed volume and ensure we still can't
+	// upgrade capabilities.
+	claim.AccessMode = CSIVolumeAccessModeMultiNodeSingleWriter
+	claim.Mode = CSIVolumeClaimWrite
+	claim.State = CSIVolumeClaimStateTaken
+	claim.AllocationID = alloc2.ID
+	require.EqualError(vol.Claim(claim, alloc2), "unschedulable")
+	require.Len(vol.ReadClaims, 0)
+	require.Len(vol.WriteClaims, 0)
+	require.Equal(CSIVolumeAccessModeUnknown, vol.AccessMode)
+	require.Equal(CSIVolumeAttachmentModeUnknown, vol.AttachmentMode)
+	require.Equal(CSIVolumeAccessModeMultiNodeReader,
+		vol.RequestedCapabilities[0].AccessMode)
+	require.Equal(CSIVolumeAttachmentModeFilesystem,
+		vol.RequestedCapabilities[0].AttachmentMode)
 }
 
 func TestVolume_Copy(t *testing.T) {

--- a/nomad/structs/csi_test.go
+++ b/nomad/structs/csi_test.go
@@ -20,28 +20,28 @@ func TestCSIVolumeClaim(t *testing.T) {
 		Mode:         CSIVolumeClaimRead,
 	}
 
-	require.NoError(t, vol.ClaimRead(claim, alloc))
+	require.NoError(t, vol.claimRead(claim, alloc))
 	require.True(t, vol.ReadSchedulable())
 	require.True(t, vol.WriteSchedulable())
-	require.NoError(t, vol.ClaimRead(claim, alloc))
+	require.NoError(t, vol.claimRead(claim, alloc))
 
 	claim.Mode = CSIVolumeClaimWrite
-	require.NoError(t, vol.ClaimWrite(claim, alloc))
+	require.NoError(t, vol.claimWrite(claim, alloc))
 	require.True(t, vol.ReadSchedulable())
 	require.False(t, vol.WriteFreeClaims())
 
-	vol.ClaimRelease(claim)
+	vol.claimRelease(claim)
 	require.True(t, vol.ReadSchedulable())
 	require.False(t, vol.WriteFreeClaims())
 
 	claim.State = CSIVolumeClaimStateReadyToFree
-	vol.ClaimRelease(claim)
+	vol.claimRelease(claim)
 	require.True(t, vol.ReadSchedulable())
 	require.True(t, vol.WriteFreeClaims())
 
 	vol.AccessMode = CSIVolumeAccessModeMultiNodeMultiWriter
-	require.NoError(t, vol.ClaimWrite(claim, alloc))
-	require.NoError(t, vol.ClaimWrite(claim, alloc))
+	require.NoError(t, vol.claimWrite(claim, alloc))
+	require.NoError(t, vol.claimWrite(claim, alloc))
 	require.True(t, vol.WriteFreeClaims())
 }
 

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1088,7 +1088,7 @@ func TestTaskGroup_Validate(t *testing.T) {
 		},
 	}
 	err = tg.Validate(&Job{})
-	require.Contains(t, err.Error(), `Volume foo has unrecognised type nothost`)
+	require.Contains(t, err.Error(), `volume has unrecognised type nothost`)
 
 	tg = &TaskGroup{
 		Volumes: map[string]*VolumeRequest{
@@ -1104,7 +1104,7 @@ func TestTaskGroup_Validate(t *testing.T) {
 		},
 	}
 	err = tg.Validate(&Job{})
-	require.Contains(t, err.Error(), `Volume foo has an empty source`)
+	require.Contains(t, err.Error(), `volume has an empty source`)
 
 	tg = &TaskGroup{
 		Name: "group-a",
@@ -1125,8 +1125,8 @@ func TestTaskGroup_Validate(t *testing.T) {
 		},
 	}
 	err = tg.Validate(&Job{})
-	require.Contains(t, err.Error(), `Volume foo has an empty source`)
-	require.Contains(t, err.Error(), `Volume foo cannot be per_alloc when canaries are in use`)
+	require.Contains(t, err.Error(), `volume has an empty source`)
+	require.Contains(t, err.Error(), `volume cannot be per_alloc when canaries are in use`)
 
 	tg = &TaskGroup{
 		Volumes: map[string]*VolumeRequest{

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1088,7 +1088,7 @@ func TestTaskGroup_Validate(t *testing.T) {
 		},
 	}
 	err = tg.Validate(&Job{})
-	require.Contains(t, err.Error(), `volume has unrecognised type nothost`)
+	require.Contains(t, err.Error(), `volume has unrecognized type nothost`)
 
 	tg = &TaskGroup{
 		Volumes: map[string]*VolumeRequest{

--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -92,21 +92,44 @@ func HostVolumeSliceMerge(a, b []*ClientHostVolumeConfig) []*ClientHostVolumeCon
 
 // VolumeRequest is a representation of a storage volume that a TaskGroup wishes to use.
 type VolumeRequest struct {
-	Name         string
-	Type         string
-	Source       string
-	ReadOnly     bool
-	MountOptions *CSIMountOptions
-	PerAlloc     bool
+	Name           string
+	Type           string
+	Source         string
+	ReadOnly       bool
+	AccessMode     CSIVolumeAccessMode
+	AttachmentMode CSIVolumeAttachmentMode
+	MountOptions   *CSIMountOptions
+	PerAlloc       bool
 }
 
 func (v *VolumeRequest) Validate(canaries int) error {
 	if !(v.Type == VolumeTypeHost ||
 		v.Type == VolumeTypeCSI) {
-		return fmt.Errorf("volume has unrecognised type %s", v.Type)
+		return fmt.Errorf("volume has unrecognized type %s", v.Type)
 	}
 
 	var mErr multierror.Error
+	if v.Type == VolumeTypeHost && v.AttachmentMode != CSIVolumeAttachmentModeUnknown {
+		mErr.Errors = append(mErr.Errors,
+			fmt.Errorf("host volumes cannot have an attachment mode"))
+	}
+	if v.Type == VolumeTypeHost && v.AccessMode != CSIVolumeAccessModeUnknown {
+		mErr.Errors = append(mErr.Errors,
+			fmt.Errorf("host volumes cannot have an access mode"))
+	}
+
+	if v.AccessMode == CSIVolumeAccessModeSingleNodeReader || v.AccessMode == CSIVolumeAccessModeMultiNodeReader {
+		if !v.ReadOnly {
+			mErr.Errors = append(mErr.Errors,
+				fmt.Errorf("%s volumes must be read-only", v.AccessMode))
+		}
+	}
+
+	if v.AttachmentMode == CSIVolumeAttachmentModeBlockDevice && v.MountOptions != nil {
+		mErr.Errors = append(mErr.Errors,
+			fmt.Errorf("block devices cannot have mount options"))
+	}
+
 	if v.PerAlloc && canaries > 0 {
 		mErr.Errors = append(mErr.Errors,
 			fmt.Errorf("volume cannot be per_alloc when canaries are in use"))

--- a/vendor/github.com/hashicorp/nomad/api/tasks.go
+++ b/vendor/github.com/hashicorp/nomad/api/tasks.go
@@ -377,13 +377,15 @@ func (m *MigrateStrategy) Copy() *MigrateStrategy {
 
 // VolumeRequest is a representation of a storage volume that a TaskGroup wishes to use.
 type VolumeRequest struct {
-	Name         string           `hcl:"name,label"`
-	Type         string           `hcl:"type,optional"`
-	Source       string           `hcl:"source,optional"`
-	ReadOnly     bool             `hcl:"read_only,optional"`
-	MountOptions *CSIMountOptions `hcl:"mount_options,block"`
-	PerAlloc     bool             `hcl:"per_alloc,optional"`
-	ExtraKeysHCL []string         `hcl1:",unusedKeys,optional" json:"-"`
+	Name           string           `hcl:"name,label"`
+	Type           string           `hcl:"type,optional"`
+	Source         string           `hcl:"source,optional"`
+	ReadOnly       bool             `hcl:"read_only,optional"`
+	AccessMode     string           `hcl:"access_mode,optional"`
+	AttachmentMode string           `hcl:"attachment_mode,optional"`
+	MountOptions   *CSIMountOptions `hcl:"mount_options,block"`
+	PerAlloc       bool             `hcl:"per_alloc,optional"`
+	ExtraKeysHCL   []string         `hcl1:",unusedKeys,optional" json:"-"`
 }
 
 const (

--- a/website/content/docs/commands/volume/create.mdx
+++ b/website/content/docs/commands/volume/create.mdx
@@ -39,7 +39,6 @@ The file may be provided as either HCL or JSON. An example HCL configuration:
 id              = "ebs_prod_db1"
 name            = "database"
 type            = "csi"
-external_id     = "vol-23452345"
 plugin_id       = "ebs-prod"
 snapshot_id     = "snap-12345" # or clone_id, see below
 
@@ -48,12 +47,14 @@ capacity {
   limit    = "200G"
 }
 
-access_mode     = "single-node-writer"
-attachment_mode = "file-system"
+capability {
+  access_mode = "single-node-reader-only"
+  attachment_mode = "file-system"
+}
 
-mount_options {
-  fs_type     = "ext4"
-  mount_flags = ["ro"]
+capability {
+  access_mode = "single-node-writer"
+  attachment_mode = "file-system"
 }
 
 secrets {
@@ -75,14 +76,11 @@ context {
   [`volume.source`][csi_volume_source] field in a job specification will refer
   to the volume.
 
-- `name` `(string: <required>)` - The display name of the volume.
+- `name` `(string: <required>)` - The display name of the volume. This field
+  may be used by the external storage provider to tag the volume.
 
 - `type` `(string: <required>)` - The type of volume. Currently only `"csi"`
   is supported.
-
-- `external_id` `(string: <required>)` - The ID of the physical volume from
-  the storage provider. For example, the volume ID of an AWS EBS volume or
-  Digital Ocean volume.
 
 - `plugin_id` `(string: <required>)` - The ID of the [CSI plugin][csi_plugin]
   that manages this volume.
@@ -109,9 +107,10 @@ context {
   suffixes such as `"100GiB"`. This field may not be supported by all
   storage providers.
 
-- `capability` `(optional)` - Option for validating the capbility of a
-  volume. You may provide multiple `capability` blocks, each of which must
-  have the following fields:
+- `capability` `(Capability: <required>)` - Option for validating the
+  capbility of a volume. You must provide at least one `capability` block, and
+  you must provide a block for each capability you intend to use in a job's
+  [`volume`] block. Each `capability` block must have the following fields:
 
   - `access_mode` `(string: <required>)` - Defines whether a volume should be
     available concurrently. Can be one of `"single-node-reader-only"`,
@@ -127,9 +126,10 @@ context {
     within the container.
 
 - `mount_options` - Options for mounting `file-system` volumes that don't
-  already have a pre-formatted file system. Consult the documentation for your
-  storage provider and CSI plugin as to whether these options are required or
-  necessary.
+  already have a pre-formatted file system. These field will be validated
+  during volume creation against the `capability` field. Consult the
+  documentation for your storage provider and CSI plugin as to whether these
+  options are required or necessary.
 
   - `fs_type` `(string <optional>)` - File system type (ex. `"ext4"`)
   - `mount_flags` `([]string: <optional>)` - The flags passed to `mount`
@@ -145,9 +145,11 @@ context {
   to each storage provider, so please see the specific plugin
   documentation for more information.
 
-- `context` <code>(map<string|string>:nil)</code> - This field is only used
-  during volume registration, and will be set automatically by the plugin when
-  `volume create` is successful. See [`volume register`].
+### Unused Fields
+
+Note that several fields used in the [`volume register`] command are set
+automatically by the plugin when `volume create` is successful. You should not
+set the `external_id` or `context` fields described on that page.
 
 [csi]: https://github.com/container-storage-interface/spec
 [csi_plugins_internals]: /docs/internals/plugins/csi#csi-plugins
@@ -156,3 +158,4 @@ context {
 [csi_volume_source]: /docs/job-specification/volume#source
 [registered]: /docs/commands/volume/register
 [`volume register`]: /docs/commands/volume/register
+[`volume`]: /docs/job-specification/volume

--- a/website/content/docs/commands/volume/register.mdx
+++ b/website/content/docs/commands/volume/register.mdx
@@ -45,15 +45,6 @@ name            = "database"
 type            = "csi"
 external_id     = "vol-23452345"
 plugin_id       = "ebs-prod"
-snapshot_id     = "snap-12345" # or clone_id, see below
-capacity        = "100G"
-access_mode     = "single-node-writer"
-attachment_mode = "file-system"
-
-mount_options {
-  fs_type     = "ext4"
-  mount_flags = ["ro"]
-}
 
 secrets {
   example_secret = "xyzzy"
@@ -86,24 +77,6 @@ context {
 - `plugin_id` `(string: <required>)` - The ID of the [CSI plugin][csi_plugin]
   that manages this volume.
 
-- `snapshot_id` - This field is only used during volume creation, and is
-  ignored during volume registration. See [`volume create`].
-
-- `clone_id` - This field is only used during volume creation, and is ignored
-  during volume registration. See [`volume create`].
-
-- `capacity_min` - This field is only used during volume creation, and is
-  ignored during volume registration. See [`volume create`].
-
-- `capacity_max` - This field is only used during volume creation, and is
-  ignored during volume registration. See [`volume create`].
-
-- `capability` - This field is only used during volume creation, and is
-  ignored during volume registration. See [`volume create`].
-
-- `mount_options` - This field is only used during volume creation, and is
-  ignored during volume registration. See [`volume create`].
-
 - `secrets` <code>(map<string|string>:nil)</code> - An optional
   key-value map of strings used as credentials for publishing and
   unpublishing volumes.
@@ -119,6 +92,14 @@ context {
   validate the volume. The details of these parameters are specific to
   each storage provider, so please see the specific plugin
   documentation for more information.
+
+### Unused Fields
+
+Note that several fields used in the [`volume create`] command are set
+automatically by the plugin when `volume create` is successful and cannot be
+set on a pre-existing volume. You should not set the `snapshot_id`,
+`clone_id`, `capacity_min`, `capacity_max`, or `capability` fields described
+on that page.
 
 [csi]: https://github.com/container-storage-interface/spec
 [csi_plugins_internals]: /docs/internals/plugins/csi#csi-plugins

--- a/website/content/docs/job-specification/volume.mdx
+++ b/website/content/docs/job-specification/volume.mdx
@@ -29,6 +29,27 @@ job "docs" {
 }
 ```
 
+```hcl
+job "docs" {
+  group "example" {
+    volume "data" {
+      type            = "csi"
+      source          = "csi-volume"
+      read_only       = true
+      attachment_mode = "file-system"
+      access_mode     = "single-node-writer"
+      per_alloc       = true
+
+      mount_options {
+        fs_type     = "ext4"
+        mount_flags = "noatime"
+      }
+    }
+  }
+}
+```
+
+
 The Nomad server will ensure that the allocations are only scheduled
 on hosts that have a set of volumes that meet the criteria specified
 in the `volume` stanzas. These may be [host volumes][host_volume]
@@ -48,17 +69,33 @@ the [volume_mount][volume_mount] stanza in the `task` configuration.
   name of the host volume. When using `csi` volumes, this should match
   the ID of the registered volume.
 
-- `per_alloc` `(bool: false)` - Specifies that the `source` of the volume
-  should have the suffix `[n]`, where `n` is the allocation index. This allows
-  mounting a unique volume per allocation, so long as the volume's source is
-  named appropriately. For example, with the source `myvolume` and `per_alloc = true`, the allocation named `myjob.mygroup.mytask[0]` will require a
-  volume ID `myvolume[0]`.
-
 - `read_only` `(bool: false)` - Specifies that the group only requires
   read only access to a volume and is used as the default value for
   the `volume_mount -> read_only` configuration. This value is also
   used for validating `host_volume` ACLs and for scheduling when a
   matching `host_volume` requires `read_only` usage.
+
+The following fields are only valid for volumes with `type = "csi"`:
+
+- `access_mode` `(string: <required>)` - Defines whether a volume should be
+  available concurrently. Can be one of `"single-node-reader-only"`,
+  `"single-node-writer"`, `"multi-node-reader-only"`,
+  `"multi-node-single-writer"`, or `"multi-node-multi-writer"`. Most CSI
+  plugins support only single-node modes. Consult the documentation of the
+  storage provider and CSI plugin.
+
+- `attachment_mode` `(string: <required>)` - The storage API that will be used
+  by the volume. Most storage providers will support `"file-system"`, to mount
+  volumes using the CSI filesystem API. Some storage providers will support
+  `"block-device"`, which will mount the volume with the CSI block device API
+  within the container.
+
+- `per_alloc` `(bool: false)` - Specifies that the `source` of the volume
+  should have the suffix `[n]`, where `n` is the allocation index. This allows
+  mounting a unique volume per allocation, so long as the volume's source is
+  named appropriately. For example, with the source `myvolume` and `per_alloc
+  = true`, the allocation named `myjob.mygroup.mytask[0]` will require a
+  volume ID `myvolume[0]`.
 
 - `mount_options` - Options for mounting CSI volumes that have the
   `file-system` [attachment mode]. These options override the `mount_options`


### PR DESCRIPTION
Registration of Nomad volumes previously allowed for a single volume capability (access mode + attachment mode pair). The recent `volume create` command requires that we pass a list of requested capabilities, but the existing workflow for claiming volumes and attaching them on the client assumed that the volume's single capability was correct and unchanging. This resulted in volume we create not being schedulable!

Add `AccessMode` and `AttachmentMode` to `CSIVolumeClaim`, use these fields to set the initial claim value, and add backwards compatibility logic to handle the existing volumes that already have claims without these fields.

Includes documentation updates.

Note for reviewers:
* Best reviewed commit-by-commit.
* My apologies for the large diff but ~450 lines of that is new tests for backwards compatibility and not new code.
* I've end-to-end tested this with `nomad volume create` and LGTM 👍 (and I found some `volume snapshot` bugs to fix)