### PR TITLE
UI: Add removal of OTT query parameter with delay

### DIFF
--- a/ui/app/controllers/application.js
+++ b/ui/app/controllers/application.js
@@ -19,9 +19,14 @@ export default class ApplicationController extends Controller {
     {
       region: 'region',
     },
+    {
+      oneTimeToken: 'ott',
+    },
   ];
 
   region = null;
+
+  oneTimeToken = '';
 
   error = null;
 

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -75,27 +75,30 @@ export default class ApplicationRoute extends Route {
     return promises;
   }
 
-  // Model is being used as a way to transfer the provided region
-  // query param to update the controller state.
-  model(params) {
-    return params.region;
+  // Model is being used as a way to propagate the region and
+  // one time token query parameters for use in setupController.
+  model({ region }, { to: { queryParams: { ott }}}) {
+    return {
+      region,
+      hasOneTimeToken: ott,
+    };
   }
 
-  setupController(controller, model) {
-    const queryParam = model;
-
-    if (queryParam === this.get('system.defaultRegion.region')) {
+  setupController(controller, { region, hasOneTimeToken }) {
+    if (region === this.get('system.defaultRegion.region')) {
       next(() => {
         controller.set('region', null);
       });
     }
 
-    // Hack to force clear the OTT query parameter
-    later(() => {
-      controller.set('oneTimeToken', '');
-    }, 500);
+    super.setupController(...arguments);
 
-    return super.setupController(...arguments);
+    if (hasOneTimeToken) {
+      // Hack to force clear the OTT query parameter
+      later(() => {
+        controller.set('oneTimeToken', '');
+      }, 500);
+    }
   }
 
   @action

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -1,5 +1,5 @@
 import { inject as service } from '@ember/service';
-import { next } from '@ember/runloop';
+import { later, next } from '@ember/runloop';
 import Route from '@ember/routing/route';
 import { AbortError } from '@ember-data/adapter/error';
 import RSVP from 'rsvp';
@@ -89,6 +89,11 @@ export default class ApplicationRoute extends Route {
         controller.set('region', null);
       });
     }
+
+    // Hack to force clear the OTT query parameter
+    later(() => {
+      controller.set('oneTimeToken', '');
+    }, 500);
 
     return super.setupController(...arguments);
   }

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -1,4 +1,4 @@
-import { find, visit } from '@ember/test-helpers';
+import { currentURL, find, visit } from '@ember/test-helpers';
 import { module, skip, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -169,6 +169,9 @@ module('Acceptance | tokens', function(hooks) {
     const { oneTimeSecret, secretId } = managementToken;
 
     await JobDetail.visit({ id: job.id, ott: oneTimeSecret });
+
+    assert.notOk(currentURL().includes(oneTimeSecret), 'OTT is cleared from the URL after loading');
+
     await Tokens.visit();
 
     assert.equal(window.localStorage.nomadTokenSecret, secretId, 'Token secret was set');


### PR DESCRIPTION
This is a follow-on to #10066 to clear out the OTT from the URL after loading. While this approach
is unsightly, it’s how I was able to get it to happen, and it seems less unsightly than having the OTT
persist in the URL.

Here’s a GIF showing it being cleared when passing a job to `nomad ui -authenticate`:

![ott-erasure](https://user-images.githubusercontent.com/43280/113879765-7cc7a980-9780-11eb-99b9-01931923ea3c.gif)
