### PR TITLE
CSI: external volume list bug fixes

### DIFF
--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -266,6 +266,7 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/deployment/", s.wrap(s.DeploymentSpecificRequest))
 
 	s.mux.HandleFunc("/v1/volumes", s.wrap(s.CSIVolumesRequest))
+	s.mux.HandleFunc("/v1/volumes/external", s.wrap(s.CSIExternalVolumesRequest))
 	s.mux.HandleFunc("/v1/volumes/snapshot", s.wrap(s.CSISnapshotsRequest))
 	s.mux.HandleFunc("/v1/volume/csi/", s.wrap(s.CSIVolumeSpecificRequest))
 	s.mux.HandleFunc("/v1/plugins", s.wrap(s.CSIPluginsRequest))

--- a/command/volume_status_csi.go
+++ b/command/volume_status_csi.go
@@ -96,6 +96,7 @@ func (c *VolumeStatusCommand) listVolumes(client *api.Client) int {
 	var code int
 	q := &api.QueryOptions{PerPage: 30} // TODO: tune page size
 
+NEXT_PLUGIN:
 	for _, plugin := range plugins {
 		if !plugin.ControllerRequired || plugin.ControllersHealthy < 1 {
 			continue // only controller plugins can support this query
@@ -109,7 +110,7 @@ func (c *VolumeStatusCommand) listVolumes(client *api.Client) int {
 				// query, so report and set the error code but move on to the
 				// next plugin
 				code = 1
-				continue
+				continue NEXT_PLUGIN
 			}
 			rows := []string{}
 			if len(externalList.Volumes) > 0 {

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -1028,6 +1028,9 @@ func (v *CSIVolume) ListExternal(args *structs.CSIVolumeExternalListRequest, rep
 	if plugin == nil {
 		return fmt.Errorf("no such plugin")
 	}
+	if !plugin.HasControllerCapability(structs.CSIControllerSupportsListVolumes) {
+		return fmt.Errorf("unimplemented for this plugin")
+	}
 
 	method := "ClientCSI.ControllerListVolumes"
 	cReq := &cstructs.ClientCSIControllerListVolumesRequest{

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -964,6 +964,7 @@ func TestCSIVolumeEndpoint_ListExternal(t *testing.T) {
 			Healthy:  true,
 			ControllerInfo: &structs.CSIControllerInfo{
 				SupportsAttachDetach: true,
+				SupportsListVolumes:  true,
 			},
 			RequiresControllerPlugin: true,
 		},


### PR DESCRIPTION
This changeset fixes two bugs discovered during E2E testing that unfortunately don't get picked up by our typical approach to HTTP endpoint unit testing (mostly because we don't have live CSI plugins to talk to in the test):
* Fix HTTP routing for external volume list. The HTTP router did not correctly route `/v1/volumes/external` without being explicitly added to the top-level router. Break this out into its own request handler.
* Fix early return on error from list external volumes command. If a plugin returns an error, we should continue at the outer scope to query the next plugin, otherwise we just retry the plugin we got an error on (potentially infinitely if it's an invalid request like an unsupported plugin).

It also includes an error message improvement:
* Capability check `ListVolumes` at RPC for nicer error messages. The plugin stub object does not include fine-grained capability checks, which means `nomad volume status -verbose` will return ugly and verbose error "Unimplemented" messages from the plugin if it does not support the CSI `ListVolumes` RPC. Return a nicer error message from our RPC handler instead.


