### PR TITLE
CSI: listing from plugins can return EOF

### DIFF
--- a/command/volume_snapshot_list.go
+++ b/command/volume_snapshot_list.go
@@ -2,12 +2,14 @@ package command
 
 import (
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/pkg/errors"
 	"github.com/posener/complete"
 )
 
@@ -120,15 +122,18 @@ func (c *VolumeSnapshotListCommand) Run(args []string) int {
 
 	for {
 		resp, _, err := client.CSIVolumes().ListSnapshots(pluginID, q)
-		if err != nil {
+		if err != nil && !errors.Is(err, io.EOF) {
 			c.Ui.Error(fmt.Sprintf(
 				"Error querying CSI external snapshots for plugin %q: %s", pluginID, err))
 			return 1
 		}
-		if len(resp.Snapshots) > 0 {
-			c.Ui.Output(csiFormatSnapshots(resp.Snapshots, verbose))
+		if resp == nil || len(resp.Snapshots) == 0 {
+			// several plugins return EOF once you hit the end of the page,
+			// rather than an empty list
+			break
 		}
 
+		c.Ui.Output(csiFormatSnapshots(resp.Snapshots, verbose))
 		q.NextToken = resp.NextToken
 		if q.NextToken == "" {
 			break

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -782,7 +782,7 @@ func NewListSnapshotsResponse(resp *csipbv1.ListSnapshotsResponse) *ControllerLi
 					SizeBytes:      snap.GetSizeBytes(),
 					ID:             snap.GetSnapshotId(),
 					SourceVolumeID: snap.GetSourceVolumeId(),
-					CreateTime:     snap.GetCreationTime().GetSeconds(),
+					CreateTime:     int64(snap.GetCreationTime().GetNanos()),
 					IsReady:        snap.GetReadyToUse(),
 				},
 			})


### PR DESCRIPTION
The AWS EBS CSI plugin was observed (see #10322) to return a EOF when we get to the end of the paging for `ListSnapshots`, counter to specification. Handle this case gracefully, including for `ListVolumes` (which EBS doesn't support but has similar semantics).

Also fixes a timestamp formatting bug on `ListSnapshots`