### PR TITLE
nomad/structs: fix diff

### DIFF
--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -1642,7 +1642,7 @@ func volumeCSIMountOptionsDiff(oldMO, newMO *CSIMountOptions, contextual bool) *
 		oldMO = &CSIMountOptions{}
 		diff.Type = DiffTypeAdded
 		newPrimitiveFlat = flatmap.Flatten(newMO, nil, true)
-	} else if oldMO == nil && newMO != nil {
+	} else if oldMO != nil && newMO == nil {
 		newMO = &CSIMountOptions{}
 		diff.Type = DiffTypeDeleted
 		oldPrimitiveFlat = flatmap.Flatten(oldMO, nil, true)


### PR DESCRIPTION
This fixes a function in `nomad/structs` that was testing the exact same conditions twice between an `if` and an `if else`. This fixes the second check to look for a `nil` `newMO` instead of looking for a `nil` `oldMO` and then clobbering the `newMO`.