### PR TITLE
Fix typo in general options documentation

### DIFF
--- a/website/content/partials/general_options.mdx
+++ b/website/content/partials/general_options.mdx
@@ -7,7 +7,7 @@
 
 - `-namespace=<namespace>`: The target namespace for queries and actions bound
   to a namespace. Overrides the `NOMAD_NAMESPACE` environment variable if set.
-  If set to `'*'`, job and alloc subcommands query all namespacecs authorized to
+  If set to `'*'`, job and alloc subcommands query all namespaces authorized to
   user. Defaults to the "default" namespace.
 
 - `-no-color`: Disables colored command output. Alternatively,


### PR DESCRIPTION
There was a small typo of "namespacecs" instead of "namespaces"