### PR TITLE
E2E: remove broken Move-Item call during Windows provisioning

### DIFF
--- a/e2e/terraform/packer/windows-2016-amd64/provision.ps1
+++ b/e2e/terraform/packer/windows-2016-amd64/provision.ps1
@@ -79,9 +79,6 @@ function InstallFromS3 {
 
         Remove-Item -Path $install_path -Force -ErrorAction Stop
         Expand-Archive ./nomad.zip ./ -Force -ErrorAction Stop
-        Move-Item `
-          -Path .\pkg\windows_amd64\nomad.exe `
-          -Destination $install_path -Force -ErrorAction Stop
         Remove-Item -Path nomad.zip -Force -ErrorAction Ignore
 
         New-Item -ItemType Directory -Force -Path C:\opt\nomad.d -ErrorAction Stop


### PR DESCRIPTION
The archive does not include the `pkg/windows_amd64` path and unpacking the
archive happens in the installation directory.

