### PR TITLE
CSI: demo for hostpath plugin

### DIFF
--- a/demo/csi/hostpath/README.md
+++ b/demo/csi/hostpath/README.md
@@ -1,0 +1,68 @@
+# Hostpath CSI Plugin
+
+This directory includes a demo using the [CSI host path
+driver](https://github.com/kubernetes-csi/csi-driver-host-path) to create
+local "host path" volumes that can be mounted via the Nomad CSI
+implementation.
+
+## What Is This For?
+
+The hostpath plugin is for demonstration and development purposes only. It
+shouldn't be used for production. If you want to get a quick idea of how CSI
+works on Nomad in a Vagrant environment, this demo is a good option.
+
+## Requirements
+
+* A running Nomad cluster with `docker.privileged.enabled = true` and
+  `docker.volumes.enabled = true`. The Nomad developer
+  [Vagrantfile](https://github.com/hashicorp/nomad/blob/main/Vagrantfile) in
+  this repo is suitable.
+
+Running the `run.sh` script in this directory will output the Nomad command
+used to run the demo, as well as their outputs:
+
+```
+$ nomad job run ./plugin.nomad
+==> Monitoring evaluation "7ac3cc8d"
+    Evaluation triggered by job "csi-plugin"
+    Allocation "bbd34b72" created: node "917b009b", group "csi"
+==> Monitoring evaluation "7ac3cc8d"
+    Allocation "bbd34b72" status changed: "pending" -> "running" (Tasks are running)
+    Evaluation status changed: "pending" -> "complete"
+==> Evaluation "7ac3cc8d" finished with status "complete"
+Nodes Healthy        = 1
+
+$ nomad plugin status hostpath
+ID                   = hostpath-plugin0
+Provider             = csi-hostpath
+Version              = v1.2.0-0-g83590990
+Controllers Healthy  = 1
+Controllers Expected = 1
+Nodes Healthy        = 1
+Nodes Expected       = 1
+
+Allocations
+ID        Node ID   Task Group  Version  Desired  Status   Created  Modified
+bbd34b72  917b009b  csi         0        run      running  3s ago   2s ago
+
+$ cat hostpath.hcl | sed | nomad volume create -
+Created external volume 7185cd16-993f-11eb-a052-0242ac110002 with ID test-volume[0]
+
+$ cat hostpath.hcl | sed | nomad volume create -
+Created external volume 718bd6b4-993f-11eb-a052-0242ac110002 with ID test-volume[1]
+
+$ nomad job run ./redis.nomad
+==> Monitoring evaluation "3178513e"
+    Evaluation triggered by job "example"
+    Evaluation within deployment: "ffb161f4"
+    Allocation "139caa78" created: node "917b009b", group "cache"
+    Allocation "5e1b57f5" created: node "917b009b", group "cache"
+    Evaluation status changed: "pending" -> "complete"
+==> Evaluation "3178513e" finished with status "complete"
+
+$ nomad volume status
+Container Storage Interface
+ID              Name            Plugin ID         Schedulable  Access Mode
+test-volume[0]  test-volume[0]  hostpath-plugin0  true         single-node-reader-only
+test-volume[1]  test-volume[1]  hostpath-plugin0  true         single-node-reader-only
+```

--- a/demo/csi/hostpath/hostpath.hcl
+++ b/demo/csi/hostpath/hostpath.hcl
@@ -1,0 +1,25 @@
+id          = "VOLUME_NAME"
+name        = "VOLUME_NAME"
+type        = "csi"
+plugin_id   = "hostpath-plugin0"
+
+capacity_min = "1MB"
+capacity_max = "1GB"
+
+capability {
+  access_mode     = "single-node-reader-only"
+  attachment_mode = "file-system"
+}
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}
+
+secrets {
+  somesecret = "xyzzy"
+}
+
+mount_options {
+  mount_flags = ["ro"]
+}

--- a/demo/csi/hostpath/plugin.nomad
+++ b/demo/csi/hostpath/plugin.nomad
@@ -1,0 +1,35 @@
+job "csi-plugin" {
+  type        = "system"
+  datacenters = ["dc1"]
+
+  group "csi" {
+
+    task "plugin" {
+      driver = "docker"
+
+      config {
+        image = "quay.io/k8scsi/hostpathplugin:v1.2.0"
+
+        args = [
+          "--drivername=csi-hostpath",
+          "--v=5",
+          "--endpoint=unix://csi/csi.sock",
+          "--nodeid=node-${NOMAD_ALLOC_INDEX}",
+        ]
+
+        privileged = true
+      }
+
+      csi_plugin {
+        id        = "hostpath-plugin0"
+        type      = "monolith" #node" # doesn't support Controller RPCs
+        mount_dir = "/csi"
+      }
+
+      resources {
+        cpu    = 256
+        memory = 128
+      }
+    }
+  }
+}

--- a/demo/csi/hostpath/redis.nomad
+++ b/demo/csi/hostpath/redis.nomad
@@ -1,0 +1,42 @@
+job "example" {
+  datacenters = ["dc1"]
+
+  group "cache" {
+
+    count = 2
+
+    volume "volume0" {
+      type            = "csi"
+      source          = "test-volume"
+      attachment_mode = "file-system"
+      access_mode     = "single-node-reader-only" # alt: "single-node-writer"
+      read_only       = true
+      per_alloc       = true
+    }
+
+    network {
+      port "db" {
+        to = 6379
+      }
+    }
+
+    task "redis" {
+      driver = "docker"
+
+      config {
+        image = "redis:3.2"
+        ports = ["db"]
+      }
+
+      volume_mount {
+        volume      = "volume0"
+        destination = "${NOMAD_ALLOC_DIR}/volume0"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 256
+      }
+    }
+  }
+}

--- a/demo/csi/hostpath/run.sh
+++ b/demo/csi/hostpath/run.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Run the hostpath plugin and create some volumes, and then claim them.
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+VOLUME_BASE_NAME=test-volume
+
+run_plugin() {
+    local expected
+    expected=$(nomad node status | grep -cv ID)
+    echo "$ nomad job run ./plugin.nomad"
+    nomad job run "${DIR}/plugin.nomad"
+
+    while :
+    do
+        nomad plugin status hostpath \
+            | grep "Nodes Healthy        = $expected" && break
+        sleep 2
+    done
+    echo
+    echo "$ nomad plugin status hostpath"
+    nomad plugin status hostpath
+}
+
+create_volumes() {
+    echo
+    echo "$ cat hostpath.hcl | sed | nomad volume create -"
+    sed -e "s/VOLUME_NAME/${VOLUME_BASE_NAME}[0]/" \
+        "${DIR}/hostpath.hcl" | nomad volume create -
+
+    echo
+    echo "$ cat hostpath.hcl | sed | nomad volume create -"
+    sed -e "s/VOLUME_NAME/${VOLUME_BASE_NAME}[1]/" \
+        "${DIR}/hostpath.hcl" | nomad volume create -
+}
+
+claim_volumes() {
+    echo
+    echo "$ nomad job run ./redis.nomad"
+    nomad job run "${DIR}/redis.nomad"
+}
+
+show_status() {
+    echo
+    echo "$ nomad volume status"
+    nomad volume status
+}
+
+run_plugin
+create_volumes
+claim_volumes
+show_status


### PR DESCRIPTION
A demo for the CSI hostpath plugin, used primarily for development
purposes. This reproduction has been used for testing during our CSI
implementation work, and this changeset makes that public.