### PR TITLE
CSI: ensure page slices are within bounds

### DIFF
--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -1043,7 +1043,8 @@ func (v *CSIVolume) ListExternal(args *structs.CSIVolumeExternalListRequest, rep
 	if err != nil {
 		return err
 	}
-	if args.PerPage > 0 {
+	if args.PerPage > 0 && args.PerPage < int32(len(cResp.Entries)) {
+		// this should be done in the plugin already, but enforce it
 		reply.Volumes = cResp.Entries[:args.PerPage]
 	} else {
 		reply.Volumes = cResp.Entries
@@ -1242,7 +1243,8 @@ func (v *CSIVolume) ListSnapshots(args *structs.CSISnapshotListRequest, reply *s
 	if err != nil {
 		return err
 	}
-	if args.PerPage > 0 {
+	if args.PerPage > 0 && args.PerPage < int32(len(cResp.Entries)) {
+		// this should be done in the plugin already, but enforce it
 		reply.Snapshots = cResp.Entries[:args.PerPage]
 	} else {
 		reply.Snapshots = cResp.Entries


### PR DESCRIPTION
Plugins could potentially ignore the `max_entries` field and return a list of
entries that is greater, so we slice the return value in the server RPC to
enforce these value. But page sizes less than the number of entries for the
external CSI ListVolumes and ListSnapshots RPCs could cause a panic, so fix
the boundary checking.