### PR TITLE
Limit bytes passed to `http.DetectContentType`

### DIFF
--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -426,9 +426,9 @@ func detectContentType(fileInfo os.FileInfo, path string) string {
 		// We ignore errors because this is optional information
 		if err == nil {
 			fileBytes := make([]byte, 512)
-			_, err := f.Read(fileBytes)
+			n, err := f.Read(fileBytes)
 			if err == nil {
-				contentType = http.DetectContentType(fileBytes)
+				contentType = http.DetectContentType(fileBytes[:n])
 			}
 			f.Close()
 		}

--- a/client/allocdir/alloc_dir_test.go
+++ b/client/allocdir/alloc_dir_test.go
@@ -493,6 +493,7 @@ func TestAllocDir_DetectContentType(t *testing.T) {
 		"input/test.json": "application/json",
 		"input/test.txt":  "text/plain; charset=utf-8",
 		"input/test.go":   "text/plain; charset=utf-8",
+		"input/test.hcl":  "text/plain; charset=utf-8",
 	}
 	for _, file := range testFiles {
 		fileInfo, err := os.Stat(file)

--- a/client/allocdir/input/test.hcl
+++ b/client/allocdir/input/test.hcl
@@ -1,0 +1,3 @@
+test "test" {
+  test = "test"
+}


### PR DESCRIPTION
When detecting the content type for a file, Nomad uses the [`http.DetectContentType`](https://golang.org/pkg/net/http/#DetectContentType) function, which follows the [MIME Sniffing spec](https://mimesniff.spec.whatwg.org). This spec defines a set of [steps](https://mimesniff.spec.whatwg.org/#identifying-a-resource-with-an-unknown-mime-type) to be applied to the first 512 bytes of the file. 

Step 9 is for [binary file detection](https://mimesniff.spec.whatwg.org/#binary-data-byte). It looks for a set of predefined byte patterns, one of which is `0x00`.

Without limiting the amount of bytes passed to `http.DetectContentType`, a file smaller than 512 bytes would cause `fileBytes` to end with several `0x00` bytes, and so the content-type would be set `application/octet-stream`, preventing the UI from properly displaying the file.

Before:
<img width="714" alt="Screen Shot 2021-04-09 at 1 32 45 PM" src="https://user-images.githubusercontent.com/775380/114219006-22714900-9938-11eb-908a-8db518a10705.png">

After:
<img width="712" alt="Screen Shot 2021-04-09 at 1 32 13 PM" src="https://user-images.githubusercontent.com/775380/114219041-2dc47480-9938-11eb-90ab-3ca08b0a3836.png">
