### PR TITLE
docs: clarify alloc signal behavior

### DIFF
--- a/website/content/api-docs/allocations.mdx
+++ b/website/content/api-docs/allocations.mdx
@@ -656,6 +656,8 @@ The table below shows this endpoint's support for
 }
 ```
 
+If `Task` is omitted, the signal will be sent to all tasks in the allocation.
+
 ### Sample Request
 
 ```shell-session


### PR DESCRIPTION
The API docs don't make it immediately clear that the alloc signal API signals *all* tasks in an allocation if the `Task` parameter is omitted. You have to dig all the way down into the alloc runner to discover that behavior: https://github.com/hashicorp/nomad/blob/v1.0.4/client/allocrunner/alloc_runner.go#L1189-L1213