### PR TITLE
Allow clients to specify namespaces they are eligible for.

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -586,6 +586,7 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	conf.Node.Name = agentConfig.NodeName
 	conf.Node.Meta = agentConfig.Client.Meta
 	conf.Node.NodeClass = agentConfig.Client.NodeClass
+	conf.Node.Namespaces = agentConfig.Client.Namespaces
 
 	// Set up the HTTP advertise address
 	conf.Node.HTTPAddr = agentConfig.AdvertiseAddrs.HTTP

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -193,6 +193,9 @@ type ClientConfig struct {
 	// NodeClass is used to group the node by class
 	NodeClass string `hcl:"node_class"`
 
+	// Namespaces is used to limit the node to certain namespaces
+	Namespaces []string `hcl:"namespaces"`
+
 	// Options is used for configuration of nomad internals,
 	// like fingerprinters and drivers. The format is:
 	//
@@ -1526,6 +1529,9 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 
 	// Add the servers
 	result.Servers = append(result.Servers, b.Servers...)
+
+	// Add the namespaces
+	result.Namespaces = append(result.Namespaces, b.Namespaces...)
 
 	// Add the options map values
 	if result.Options == nil {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1875,6 +1875,8 @@ type Node struct {
 	// together for the purpose of determining scheduling pressure.
 	NodeClass string
 
+	Namespaces []string
+
 	// ComputedClass is a unique id that identifies nodes with a common set of
 	// attributes and capabilities.
 	ComputedClass string


### PR DESCRIPTION
This is a draft for #9342. It allows one to set `namespaces = ["a", "b-*"]` in the client config and as such restrict scheduling for namespaces.