### PR TITLE
docs: CSI hostpath demo doesn't need docker.volumes.enabled

### DIFF
--- a/demo/csi/hostpath/README.md
+++ b/demo/csi/hostpath/README.md
@@ -13,10 +13,9 @@ works on Nomad in a Vagrant environment, this demo is a good option.
 
 ## Requirements
 
-* A running Nomad cluster with `docker.privileged.enabled = true` and
-  `docker.volumes.enabled = true`. The Nomad developer
-  [Vagrantfile](https://github.com/hashicorp/nomad/blob/main/Vagrantfile) in
-  this repo is suitable.
+* A running Nomad cluster with `docker.privileged.enabled = true`. The Nomad
+  developer [Vagrantfile](https://github.com/hashicorp/nomad/blob/main/Vagrantfile)
+  in this repo is suitable.
 
 Running the `run.sh` script in this directory will output the Nomad command
 used to run the demo, as well as their outputs:


### PR DESCRIPTION
As noted in https://github.com/hashicorp/nomad/commit/842d9d2aa9576a42c2c22b501e6739215197aab8#r49357169