### PR TITLE
CI: update homebrew before installing protobuf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,7 +393,7 @@ jobs:
       - install-golang:
           target_directory: ~/goinstall
       - run: source ${BASH_ENV} && make deps
-      - run: brew install protobuf
+      - run: brew update && brew install protobuf
       - run: PATH="$GOPATH/bin:${HOME}/goinstall/go/bin:$PATH" make generate-structs
 
       - run:


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10363

"Bottles" have been migrated to GitHub packages, so we need to update homebrew
to point to that new source before installing the `protobuf` formula.

ref https://github.com/Homebrew/homebrew-core/issues/75028#issuecomment-817904447