### PR TITLE
E2E/CSI: fix name of column used for snapshot create output parsing

### DIFF
--- a/e2e/csi/ebs.go
+++ b/e2e/csi/ebs.go
@@ -161,7 +161,7 @@ func (tc *CSIControllerPluginEBSTest) TestSnapshot(f *framework.F) {
 
 	defer func() {
 		_, err := e2e.Command("nomad", "volume", "snapshot", "delete",
-			ebsPluginID, snaps[0]["External ID"])
+			ebsPluginID, snaps[0]["Snapshot ID"])
 		requireNoErrorElseDump(f, err, "could not delete volume snapshot", tc.pluginJobIDs)
 	}()
 


### PR DESCRIPTION
The command line output got changed out from under this test.