### PR TITLE
e2e: get consul ent in e2e packer builds

### DIFF
--- a/e2e/terraform/packer/ubuntu-bionic-amd64/setup.sh
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/setup.sh
@@ -6,7 +6,7 @@ set -e
 
 # Will be overwritten at test time with the version specified
 NOMADVERSION=0.12.7
-CONSULVERSION=1.9.0
+CONSULVERSION=1.9.4+ent
 VAULTVERSION=1.5.4
 
 NOMAD_PLUGIN_DIR=/opt/nomad/plugins/

--- a/e2e/terraform/packer/windows-2016-amd64/install-consul.ps1
+++ b/e2e/terraform/packer/windows-2016-amd64/install-consul.ps1
@@ -8,7 +8,7 @@ Set-Location C:\opt
 
 Try {
     $releases = "https://releases.hashicorp.com"
-    $version = "1.9.0"
+    $version = "1.9.4+ent"
     $url = "${releases}/consul/${version}/consul_${version}_windows_amd64.zip"
 
     New-Item -ItemType Directory -Force -Path C:\opt\consul


### PR DESCRIPTION
Using Consul Enterprise is going to be necessary for testing Nomad's
Consul Namespace integration in Nomad v1.1 in e2e.