### PR TITLE
E2E/CSI: ensure jobs are stopped before checking claims are released

### DIFF
--- a/e2e/csi/ebs.go
+++ b/e2e/csi/ebs.go
@@ -75,6 +75,14 @@ func (tc *CSIControllerPluginEBSTest) BeforeAll(f *framework.F) {
 
 // AfterAll cleans up the volumes and plugin jobs created by the test.
 func (tc *CSIControllerPluginEBSTest) AfterAll(f *framework.F) {
+
+	// Stop all jobs in test
+	for _, id := range tc.testJobIDs {
+		out, err := e2e.Command("nomad", "job", "stop", "-purge", id)
+		f.Assert().NoError(err, out)
+	}
+	tc.testJobIDs = []string{}
+
 	for _, volID := range tc.volumeIDs {
 		err := waitForVolumeClaimRelease(volID, reapWait)
 		f.Assert().NoError(err, "volume claims were not released")


### PR DESCRIPTION
During refactoring of the CSI tests, the EBS test dropped the step where we stop the jobs before checking that the claims were released.

---

```
$ go test . -v -suite CSI
=== RUN   TestE2E
...
--- PASS: TestE2E (290.865s)
...
    --- PASS: TestE2E/CSI (233.32s)
        --- PASS: TestE2E/CSI/*csi.CSIControllerPluginEBSTest (233.14s)
            --- PASS: TestE2E/CSI/*csi.CSIControllerPluginEBSTest/TestSnapshot (137.06s)
            --- PASS: TestE2E/CSI/*csi.CSIControllerPluginEBSTest/TestVolumeClaim (34.22s)
        --- PASS: TestE2E/CSI/*csi.CSINodeOnlyPluginEFSTest (56.93s)
            --- PASS: TestE2E/CSI/*csi.CSINodeOnlyPluginEFSTest/TestEFSVolumeClaim (56.74s)
...
PASS
ok      github.com/hashicorp/nomad/e2e  290.865s
```