### PR TITLE
client: always set script checks hook

### DIFF
--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -143,14 +143,15 @@ func (tr *TaskRunner) initHooks() {
 		}
 	}
 
-	// If there are any script checks, add the hook
-	scriptCheckHook := newScriptCheckHook(scriptCheckHookConfig{
+	// Always add the script checks hook. A task with no script check hook on
+	// initial registration may be updated to include script checks, which must
+	// be handled with this hook.
+	tr.runnerHooks = append(tr.runnerHooks, newScriptCheckHook(scriptCheckHookConfig{
 		alloc:  tr.Alloc(),
 		task:   tr.Task(),
 		consul: tr.consulServiceClient,
 		logger: hookLogger,
-	})
-	tr.runnerHooks = append(tr.runnerHooks, scriptCheckHook)
+	}))
 }
 
 func (tr *TaskRunner) emitHookError(err error, hookName string) {


### PR DESCRIPTION
Similar to a bugfix made for the services hook, we need to always
set the script checks hook, in case a task is initially launched
without script checks, but then updated to include script checks.

The scipt checks hook is the thing that handles that new registration.