### PR TITLE
Enable go-sockaddr templating for `network-interface`

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -1136,7 +1136,7 @@ func (c *Config) Merge(b *Config) *Config {
 }
 
 // normalizeAddrs normalizes Addresses and AdvertiseAddrs to always be
-// initialized and have sane defaults.
+// initialized and have reasonable defaults.
 func (c *Config) normalizeAddrs() error {
 	if c.BindAddr != "" {
 		ipStr, err := parseSingleIPTemplate(c.BindAddr)
@@ -1226,22 +1226,12 @@ func parseSingleInterfaceTemplate(tpl string) (string, error) {
 	// guaranteed separators that we can use to test if the template returned
 	// multiple interfaces.
 	// The test below checks if the template results to a single valid interface.
-
-	if !isValidInterface(out) {
+	_, err = net.InterfaceByName(out)
+	if err != nil {
 		return "", fmt.Errorf("invalid interface name %q", out)
 	}
+
 	return out, nil
-
-}
-
-// isValidInterface returns true if the input interface name exists.
-func isValidInterface(name string) bool {
-	if name == "" {
-		return true
-	}
-
-	_, err := net.InterfaceByName(name)
-	return err == nil
 }
 
 // parseSingleIPTemplate is used as a helper function to parse out a single IP

--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -48,7 +48,8 @@ client {
   to force network fingerprinting on. When run in dev mode, this defaults to the
   loopback interface. When not in dev mode, the interface attached to the
   default route is used. The scheduler chooses from these fingerprinted IP
-  addresses when allocating ports for tasks.
+  addresses when allocating ports for tasks. This value support [go-sockaddr/template
+  format][go-sockaddr/template].
 
   If no non-local IP addresses are found, Nomad could fingerprint link-local IPv6
   addresses depending on the client's

--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -456,3 +456,4 @@ client {
 [server-join]: /docs/configuration/server_join 'Server Join'
 [metadata_constraint]: /docs/job-specification/constraint#user-specified-metadata 'Nomad User-Specified Metadata Constraint Example'
 [task working directory]: /docs/runtime/environment#task-directories 'Task directories'
+[go-sockaddr/template]: https://godoc.org/github.com/hashicorp/go-sockaddr/template


### PR DESCRIPTION
This adds go-sockaddr templating for the client.network_interface attribute. @lgfa29 helped me write the tests.

Closes #3675
Fixes #5498