### PR TITLE
Migrate all allocs when draining a node

### DIFF
--- a/nomad/drainer/drainer.go
+++ b/nomad/drainer/drainer.go
@@ -392,25 +392,25 @@ func (n *NodeDrainer) batchDrainAllocs(allocs []*structs.Allocation) (uint64, er
 // affected jobs.
 func (n *NodeDrainer) drainAllocs(future *structs.BatchFuture, allocs []*structs.Allocation) {
 	// Compute the effected jobs and make the transition map
-	jobs := make(map[string]*structs.Allocation, 4)
+	jobs := make(map[structs.NamespacedID]*structs.Allocation, 4)
 	transitions := make(map[string]*structs.DesiredTransition, len(allocs))
 	for _, alloc := range allocs {
 		transitions[alloc.ID] = &structs.DesiredTransition{
 			Migrate: helper.BoolToPtr(true),
 		}
-		jobs[alloc.JobID] = alloc
+		jobs[alloc.JobNamespacedID()] = alloc
 	}
 
 	evals := make([]*structs.Evaluation, 0, len(jobs))
 	now := time.Now().UTC().UnixNano()
-	for job, alloc := range jobs {
+	for _, alloc := range jobs {
 		evals = append(evals, &structs.Evaluation{
 			ID:          uuid.Generate(),
 			Namespace:   alloc.Namespace,
 			Priority:    alloc.Job.Priority,
 			Type:        alloc.Job.Type,
 			TriggeredBy: structs.EvalTriggerNodeDrain,
-			JobID:       job,
+			JobID:       alloc.JobID,
 			Status:      structs.EvalStatusPending,
 			CreateTime:  now,
 			ModifyTime:  now,

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9184,6 +9184,10 @@ func (a *Allocation) ConsulNamespace() string {
 	return a.Job.LookupTaskGroup(a.TaskGroup).Consul.GetNamespace()
 }
 
+func (a *Allocation) JobNamespacedID() NamespacedID {
+	return NewNamespacedID(a.JobID, a.Namespace)
+}
+
 // Index returns the index of the allocation. If the allocation is from a task
 // group with count greater than 1, there will be multiple allocations for it.
 func (a *Allocation) Index() uint {


### PR DESCRIPTION
This fixes a bug affecting drain nodes, where allocs may fail to be
migrated if they belong to different namespaces but share the same job
name.

The reason is that the helper function that creates the migration evals
indexed the allocs by job ID without accounting for the namespaces.
When job ids clash, only an eval is created for one and the rest of the
allocs remain intact.

I've added the test first, so the failure can be seen in https://app.circleci.com/pipelines/github/hashicorp/nomad/15799/workflows/383e0ec3-0803-4751-ba8f-862461d12741/jobs/151142 .

Fixes #10172 