### PR TITLE
api: include ent fuzzy struct types in oss

### DIFF
--- a/api/search_test.go
+++ b/api/search_test.go
@@ -31,6 +31,7 @@ func TestSearch_PrefixSearch(t *testing.T) {
 
 func TestSearch_FuzzySearch(t *testing.T) {
 	t.Parallel()
+
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 

--- a/nomad/search_endpoint.go
+++ b/nomad/search_endpoint.go
@@ -652,7 +652,7 @@ func (s *Search) FuzzySearch(args *structs.FuzzySearchRequest, reply *structs.Fu
 			for _, ctx := range prefixContexts {
 				switch ctx {
 				// only apply on the types that use UUID prefix searching
-				case structs.Evals, structs.Deployments, structs.ScalingPolicies, structs.Volumes:
+				case structs.Evals, structs.Deployments, structs.ScalingPolicies, structs.Volumes, structs.Quotas, structs.Recommendations:
 					iter, err := getResourceIter(ctx, aclObj, namespace, roundUUIDDownIfOdd(args.Prefix, args.Context), ws, state)
 					if err != nil {
 						if !s.silenceError(err) {
@@ -668,7 +668,7 @@ func (s *Search) FuzzySearch(args *structs.FuzzySearchRequest, reply *structs.Fu
 			for _, ctx := range fuzzyContexts {
 				switch ctx {
 				// skip the types that use UUID prefix searching
-				case structs.Evals, structs.Deployments, structs.ScalingPolicies, structs.Volumes:
+				case structs.Evals, structs.Deployments, structs.ScalingPolicies, structs.Volumes, structs.Quotas, structs.Recommendations:
 					continue
 				default:
 					iter, err := getFuzzyResourceIterator(ctx, aclObj, namespace, ws, state)


### PR DESCRIPTION
Pulling in small change from https://github.com/hashicorp/nomad-enterprise/commit/7846fc9e8506bf78f4aca063031d04eb2618d0c1
that apply to the shared part of `search_endpoint.go`

Where we have the `ent` types referenced in a switch statement,
that are just not relevant in oss. Copying them here to prevent merge
diffs between oss/ent. 