### PR TITLE
driver/docker: ignore error if container exists before cgroup can be written

### DIFF
--- a/drivers/docker/driver_linux.go
+++ b/drivers/docker/driver_linux.go
@@ -1,9 +1,19 @@
 package docker
 
 import (
+	"strings"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 )
 
 func setCPUSetCgroup(path string, pid int) error {
-	return cgroups.WriteCgroupProc(path, pid)
+	// Sometimes the container exists before we can write the
+	// cgroup resulting in an error which can be ignored.
+	if err := cgroups.WriteCgroupProc(path, pid); err != nil {
+		if strings.Contains(err.Error(), "no such process") {
+			return nil
+		}
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
This PR fixes an edge case in the reserved cores feature where switching the cpuset of a docker container occurs after the container has exited. 

