### PR TITLE
docs: Fix minor fuzzy search things

### DIFF
--- a/website/content/api-docs/search.mdx
+++ b/website/content/api-docs/search.mdx
@@ -259,23 +259,23 @@ $ curl \
 }
 ```
 
-##### Scope (jobs)
+#### Scope (jobs)
 
 - `Scope[0]` : Namespace
 - `Scope[1]` : Job ID
 
-##### Scope (groups)
+#### Scope (groups)
 
 - `Scope[0]` : Namespace
 - `Scope[1]` : Job ID
 
-##### Scope (tasks)
+#### Scope (tasks)
 
 - `Scope[0]` : Namespace
 - `Scope[1]` : Job ID
 - `Scope[2]` : Group
 
-##### Scope (group services)
+#### Scope (group services)
 
 - `Scope[0]` : Namespace
 - `Scope[1]` : Group

--- a/website/content/docs/configuration/search.mdx
+++ b/website/content/docs/configuration/search.mdx
@@ -37,7 +37,7 @@ server {
 
 - `limit_query` `(int: 20)` - Specifies the maximum number of Nomad objects to
   search through per context type in the Nomad server before truncating results.
-  Setting this parameter to high value may degrade Nomad server performance.
+  Setting this parameter to a high value may degrade Nomad server performance.
 
 - `limit_results` `(int: 100)` - Specifies the maximum number of matching results
   to accumulate per context type in the API response before truncating results.


### PR DESCRIPTION
I noticed the scope headers weren’t all the same and chose to make them `####` as they’re nested beneath a `###`.

I also added a missing `a` 🤓