### PR TITLE
api: Ignore User provided ParentID

### DIFF
--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -782,7 +782,6 @@ func ApiJobToStructJob(job *api.Job) *structs.Job {
 		Region:         *job.Region,
 		Namespace:      *job.Namespace,
 		ID:             *job.ID,
-		ParentID:       *job.ParentID,
 		Name:           *job.Name,
 		Type:           *job.Type,
 		Priority:       *job.Priority,


### PR DESCRIPTION
ParentID is an internal field that Nomad sets for dispatched or parameterized jobs. Job submitters should not be able to set it
directly, as that messes up children tracking.

Fixes #10422 . It specifically stops the scheduler from honoring the ParentID.  The reason failure and why the scheduler didn't schedule that job once it was created is very interesting and requires follow up with a more technical issue.