### PR TITLE
api: /v1/jobs always include namespaces

### DIFF
--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1427,7 +1427,6 @@ func (j *Job) listAllNamespaces(args *structs.JobListRequest, reply *structs.Job
 				}
 
 				stub := job.Stub(summary)
-				stub.Namespace = job.Namespace
 				jobs = append(jobs, stub)
 			}
 			reply.Jobs = jobs

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -4662,9 +4662,7 @@ func TestJobEndpoint_ListJobs(t *testing.T) {
 	job := mock.Job()
 	state := s1.fsm.State()
 	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Lookup the jobs
 	get := &structs.JobListRequest{
@@ -4674,19 +4672,12 @@ func TestJobEndpoint_ListJobs(t *testing.T) {
 		},
 	}
 	var resp2 structs.JobListResponse
-	if err := msgpackrpc.CallWithCodec(codec, "Job.List", get, &resp2); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if resp2.Index != 1000 {
-		t.Fatalf("Bad index: %d %d", resp2.Index, 1000)
-	}
-
-	if len(resp2.Jobs) != 1 {
-		t.Fatalf("bad: %#v", resp2.Jobs)
-	}
-	if resp2.Jobs[0].ID != job.ID {
-		t.Fatalf("bad: %#v", resp2.Jobs[0])
-	}
+	err = msgpackrpc.CallWithCodec(codec, "Job.List", get, &resp2)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1000), resp2.Index)
+	require.Len(t, resp2.Jobs, 1)
+	require.Equal(t, job.ID, resp2.Jobs[0].ID)
+	require.Equal(t, job.Namespace, resp2.Jobs[0].Namespace)
 
 	// Lookup the jobs by prefix
 	get = &structs.JobListRequest{
@@ -4697,19 +4688,12 @@ func TestJobEndpoint_ListJobs(t *testing.T) {
 		},
 	}
 	var resp3 structs.JobListResponse
-	if err := msgpackrpc.CallWithCodec(codec, "Job.List", get, &resp3); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if resp3.Index != 1000 {
-		t.Fatalf("Bad index: %d %d", resp3.Index, 1000)
-	}
-
-	if len(resp3.Jobs) != 1 {
-		t.Fatalf("bad: %#v", resp3.Jobs)
-	}
-	if resp3.Jobs[0].ID != job.ID {
-		t.Fatalf("bad: %#v", resp3.Jobs[0])
-	}
+	err = msgpackrpc.CallWithCodec(codec, "Job.List", get, &resp3)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1000), resp3.Index)
+	require.Len(t, resp3.Jobs, 1)
+	require.Equal(t, job.ID, resp3.Jobs[0].ID)
+	require.Equal(t, job.Namespace, resp3.Jobs[0].Namespace)
 }
 
 // TestJobEndpoint_ListJobs_AllNamespaces_OSS asserts that server

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4334,6 +4334,7 @@ func (j *Job) HasUpdateStrategy() bool {
 func (j *Job) Stub(summary *JobSummary) *JobListStub {
 	return &JobListStub{
 		ID:                j.ID,
+		Namespace:         j.Namespace,
 		ParentID:          j.ParentID,
 		Name:              j.Name,
 		Datacenters:       j.Datacenters,


### PR DESCRIPTION
Add Namespace as a top-level field in `/v1/jobs` stub.

The `/v1/jobs` endpoint already includes the namespace under `JobSummary`, though the API is odd, as typically the job ID and Namespace are in the same level, and the oddity complicates the UI frontend development.

The downside of adding it is redundant field, that makes the response body a bit bigger, specially for clusters with large jobs. Though, it should compress nicely and I expect the overhead to be small to overall response size. The benefit of a cleaner and more consistent API seem worth it.

<details>
<summary>Sample /v1/api response before</summary>

```json
[
  {
    "CreateIndex": 10,
    "Datacenters": [
      "dc1"
    ],
    "ID": "example",
    "JobModifyIndex": 10,
    "JobSummary": {
      "Children": {
        "Dead": 0,
        "Pending": 0,
        "Running": 0
      },
      "CreateIndex": 10,
      "JobID": "example",
      "ModifyIndex": 14,
      "Namespace": "default",
      "Summary": {
        "cache": {
          "Complete": 0,
          "Failed": 0,
          "Lost": 0,
          "Queued": 0,
          "Running": 1,
          "Starting": 0
        }
      }
    },
    "ModifyIndex": 11,
    "Multiregion": null,
    "Name": "example",
    "ParameterizedJob": false,
    "ParentID": "",
    "Periodic": false,
    "Priority": 50,
    "Status": "running",
    "StatusDescription": "",
    "Stop": false,
    "SubmitTime": 1619192400425852000,
    "Type": "service"
  }
]
```
</details>

<details>
<summary>Sample /v1/api response: After</summary>

```json
[
  {
    "CreateIndex": 10,
    "Datacenters": [
      "dc1"
    ],
    "ID": "example",
    "JobModifyIndex": 10,
    "JobSummary": {
      "Children": {
        "Dead": 0,
        "Pending": 0,
        "Running": 0
      },
      "CreateIndex": 10,
      "JobID": "example",
      "ModifyIndex": 14,
      "Namespace": "default",
      "Summary": {
        "cache": {
          "Complete": 0,
          "Failed": 0,
          "Lost": 0,
          "Queued": 0,
          "Running": 1,
          "Starting": 0
        }
      }
    },
    "ModifyIndex": 11,
    "Multiregion": null,
    "Name": "example",
    "Namespace": "default",
    "ParameterizedJob": false,
    "ParentID": "",
    "Periodic": false,
    "Priority": 50,
    "Status": "running",
    "StatusDescription": "",
    "Stop": false,
    "SubmitTime": 1619192552309353000,
    "Type": "service"
  }
]
```
</details>

Fixes #10431