### PR TITLE
e2e: add e2e tests for consul namespaces on ent with acls

### DIFF
--- a/command/agent/consul/acl_testing.go
+++ b/command/agent/consul/acl_testing.go
@@ -119,8 +119,8 @@ func (m *MockACLsAPI) RoleRead(roleID string, _ *api.QueryOptions) (*api.ACLRole
 	}
 }
 
-// Example Consul "operator" tokens for use in tests.
-
+// Example Consul ACL tokens for use in tests. These tokens belong to the
+// default Consul namespace.
 const (
 	ExampleOperatorTokenID0 = "de591604-86eb-1e6f-8b44-d4db752921ae"
 	ExampleOperatorTokenID1 = "59c219c2-47e4-43f3-bb45-258fd13f59d5"
@@ -130,7 +130,20 @@ const (
 	ExampleOperatorTokenID5 = "097cbb45-506b-c79c-ec38-82eb0dc0794a"
 )
 
+// Example Consul ACL tokens for use in tests that match the policies as the
+// tokens above, but these belong to the "banana' Consul namespace.
+const (
+	ExampleOperatorTokenID10 = "ddfe688f-655f-e8dd-1db5-5650eed00aeb"
+	ExampleOperatorTokenID11 = "46d09394-598c-1e55-b7fd-64cd2f409707"
+	ExampleOperatorTokenID12 = "a041cb88-0f4b-0314-89f6-10e1e093d2e5"
+	ExampleOperatorTokenID13 = "cc22a583-243f-3258-14ad-db0e56749657"
+	ExampleOperatorTokenID14 = "5b6d0508-13a6-4bc3-33a1-ba1941e1175b"
+	ExampleOperatorTokenID15 = "e9db1754-c075-d0fc-0a7e-de1e9e7bff98"
+)
+
 var (
+	// In Consul namespace "default"
+
 	ExampleOperatorToken0 = &api.ACLToken{
 		SecretID:    ExampleOperatorTokenID0,
 		AccessorID:  "228865c6-3bf6-6683-df03-06dea2779088 ",
@@ -189,6 +202,67 @@ var (
 		}},
 		Namespace: "default",
 	}
+
+	// In Consul namespace "banana"
+
+	ExampleOperatorToken10 = &api.ACLToken{
+		SecretID:    ExampleOperatorTokenID0,
+		AccessorID:  "76a2c3b5-5d64-9089-f701-660eec2d3554",
+		Description: "Operator Token 0",
+		Namespace:   "banana",
+	}
+
+	ExampleOperatorToken11 = &api.ACLToken{
+		SecretID:    ExampleOperatorTokenID1,
+		AccessorID:  "40f2a36a-0a65-1972-106c-b2e5dd46d6e8",
+		Description: "Operator Token 1",
+		Policies: []*api.ACLTokenPolicyLink{{
+			ID: ExamplePolicyID1,
+		}},
+		Namespace: "banana",
+	}
+
+	ExampleOperatorToken12 = &api.ACLToken{
+		SecretID:    ExampleOperatorTokenID2,
+		AccessorID:  "894f2c5c-b285-71bf-4acb-6344cecf71f3",
+		Description: "Operator Token 2",
+		Policies: []*api.ACLTokenPolicyLink{{
+			ID: ExamplePolicyID2,
+		}},
+		Namespace: "banana",
+	}
+
+	ExampleOperatorToken13 = &api.ACLToken{
+		SecretID:    ExampleOperatorTokenID3,
+		AccessorID:  "2a81ec0b-692e-845e-f5b8-c33c05e5af22",
+		Description: "Operator Token 3",
+		Policies: []*api.ACLTokenPolicyLink{{
+			ID: ExamplePolicyID3,
+		}},
+		Namespace: "banana",
+	}
+
+	ExampleOperatorToken14 = &api.ACLToken{
+		SecretID:    ExampleOperatorTokenID4,
+		AccessorID:  "4273f1cc-5626-7a77-dc65-1f24af035ed5d",
+		Description: "Operator Token 4",
+		Policies:    nil, // no direct policy, only roles
+		Roles: []*api.ACLTokenRoleLink{{
+			ID:   ExampleRoleID1,
+			Name: "example-role-1",
+		}},
+		Namespace: "banana",
+	}
+
+	ExampleOperatorToken15 = &api.ACLToken{
+		SecretID:    ExampleOperatorTokenID5,
+		AccessorID:  "5b78e186-87d8-c1ad-966f-f5fa87b05c9a",
+		Description: "Operator Token 5",
+		Policies: []*api.ACLTokenPolicyLink{{
+			ID: ExamplePolicyID4,
+		}},
+		Namespace: "banana",
+	}
 )
 
 func (m *MockACLsAPI) TokenReadSelf(q *api.QueryOptions) (*api.ACLToken, *api.QueryMeta, error) {
@@ -208,6 +282,21 @@ func (m *MockACLsAPI) TokenReadSelf(q *api.QueryOptions) (*api.ACLToken, *api.Qu
 
 	case ExampleOperatorTokenID5:
 		return ExampleOperatorToken5, nil, nil
+
+	case ExampleOperatorTokenID11:
+		return ExampleOperatorToken11, nil, nil
+
+	case ExampleOperatorTokenID12:
+		return ExampleOperatorToken12, nil, nil
+
+	case ExampleOperatorTokenID13:
+		return ExampleOperatorToken13, nil, nil
+
+	case ExampleOperatorTokenID14:
+		return ExampleOperatorToken14, nil, nil
+
+	case ExampleOperatorTokenID15:
+		return ExampleOperatorToken15, nil, nil
 
 	default:
 		return nil, nil, errors.New("no such token")

--- a/e2e/connect/connect.go
+++ b/e2e/connect/connect.go
@@ -50,11 +50,11 @@ func init() {
 	})
 
 	// Connect tests with Consul ACLs enabled. These are now gated behind the
-	// NOMAD_TEST_CONNECT_ACLS environment variable, because they cause lots of
+	// NOMAD_TEST_CONSUL_ACLS environment variable, because they cause lots of
 	// problems for e2e test flakiness (due to restarting consul, nomad, etc.).
 	//
 	// Run these tests locally when working on Connect.
-	if os.Getenv("NOMAD_TEST_CONNECT_ACLS") == "1" {
+	if os.Getenv("NOMAD_TEST_CONSUL_ACLS") == "1" {
 		framework.AddSuites(&framework.TestSuite{
 			Component:   "ConnectACLs",
 			CanRunLocal: false,

--- a/e2e/consulacls/nomad-client-policy.hcl
+++ b/e2e/consulacls/nomad-client-policy.hcl
@@ -1,13 +1,22 @@
 // The Nomad Client will be registering things into its buddy Consul Client.
-
-service_prefix "" {
-  policy = "write"
-}
+// Note: because we also test the use of Consul namespaces, this token must be
+// able to register services, read the keystore, and read node data for any
+// namespace.
 
 agent_prefix "" {
   policy = "read"
 }
 
-node_prefix "" {
-  policy = "read"
+namespace_prefix "" {
+  key_prefix "" {
+    policy = "read"
+  }
+
+  node_prefix "" {
+    policy = "read"
+  }
+
+  service_prefix "" {
+    policy = "write"
+  }
 }

--- a/e2e/consulacls/nomad-server-policy.hcl
+++ b/e2e/consulacls/nomad-server-policy.hcl
@@ -1,10 +1,14 @@
-// The acl=write permission is required for generating Consul Service Identity
-// tokens for consul connect services.
-acl = "write"
-
 // The operator=write permission is required for creating config entries for
-// connect ingress gateways.
+// connect ingress gateways. operator ACLs are not namespaced, though the
+// config entries they can generate are.
 operator = "write"
+
+namespace_prefix "" {
+  // The acl=write permission is required for generating Consul Service Identity
+  // tokens for consul connect services. Those services could be configured for
+  // any Consul namespace the job-submitter has access to.
+  acl = "write"
+}
 
 service_prefix "" {
   policy = "write"

--- a/nomad/consul_policy.go
+++ b/nomad/consul_policy.go
@@ -8,6 +8,14 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// consulGlobalManagementPolicyID is the built-in policy ID used by Consul
+	// to denote global-management tokens.
+	//
+	// https://www.consul.io/docs/security/acl/acl-system#builtin-policies
+	consulGlobalManagementPolicyID = "00000000-0000-0000-0000-000000000001"
+)
+
 // ConsulServiceRule represents a policy for a service.
 type ConsulServiceRule struct {
 	Name   string `hcl:",key"`
@@ -23,41 +31,67 @@ type ConsulKeyRule struct {
 // ConsulPolicy represents the parts of a ConsulServiceRule Policy that are
 // relevant to Service Identity authorizations.
 type ConsulPolicy struct {
-	Services        []*ConsulServiceRule `hcl:"service,expand"`
-	ServicePrefixes []*ConsulServiceRule `hcl:"service_prefix,expand"`
-	KeyPrefixes     []*ConsulKeyRule     `hcl:"key_prefix,expand"`
+	Services          []*ConsulServiceRule     `hcl:"service,expand"`
+	ServicePrefixes   []*ConsulServiceRule     `hcl:"service_prefix,expand"`
+	KeyPrefixes       []*ConsulKeyRule         `hcl:"key_prefix,expand"`
+	Namespaces        map[string]*ConsulPolicy `hcl:"namespace,expand"`
+	NamespacePrefixes map[string]*ConsulPolicy `hcl:"namespace_prefix,expand"`
 }
 
-// IsEmpty returns true if there are no Services, ServicePrefixes, or KeyPrefixes
-// defined for the ConsulPolicy.
-func (cp *ConsulPolicy) IsEmpty() bool {
-	if cp == nil {
-		return true
-	}
-
-	policies := len(cp.Services) + len(cp.ServicePrefixes) + len(cp.KeyPrefixes)
-	return policies == 0
-}
-
-// ParseConsulPolicy parses raw string s into a ConsulPolicy. An error is
+// parseConsulPolicy parses raw string s into a ConsulPolicy. An error is
 // returned if decoding the policy fails, or if the decoded policy has no
 // Services or ServicePrefixes defined.
-func ParseConsulPolicy(s string) (*ConsulPolicy, error) {
+func parseConsulPolicy(s string) (*ConsulPolicy, error) {
 	cp := new(ConsulPolicy)
 	if err := hcl.Decode(cp, s); err != nil {
 		return nil, errors.Wrap(err, "failed to parse ACL policy")
 	}
-	if cp.IsEmpty() {
-		// the only use case for now, may as well validate asap
-		return nil, errors.New("consul policy contains no service rules")
-	}
 	return cp, nil
 }
 
-func (c *consulACLsAPI) canReadKeystore(token *api.ACLToken) (bool, error) {
+// isManagementToken returns true if the Consul token is backed by the
+// built-in global-management policy. Such a token has complete, unrestricted
+// access to all of Consul.
+//
+// https://www.consul.io/docs/security/acl/acl-system#builtin-policies
+func (c *consulACLsAPI) isManagementToken(token *api.ACLToken) bool {
+	if token == nil {
+		return false
+	}
+
+	for _, policy := range token.Policies {
+		if policy.ID == consulGlobalManagementPolicyID {
+			return true
+		}
+	}
+	return false
+}
+
+// namespaceCheck is used to verify the namespace of the object matches the
+// namespace of the ACL token provided.
+//
+// exception: iff token is in the default namespace, it may contain policies
+// that extend into other namespaces using namespace_prefix, which must bypass
+// this early check and validate in the service/keystore helpers
+func namespaceCheck(namespace string, token *api.ACLToken) error {
+	if token.Namespace != "default" && token.Namespace != namespace {
+		return errors.Errorf("consul ACL token cannot use namespace %q", namespace)
+	}
+	return nil
+}
+
+func (c *consulACLsAPI) canReadKeystore(namespace string, token *api.ACLToken) (bool, error) {
+	// early check the token is compatible with desired namespace
+	if err := namespaceCheck(namespace, token); err != nil {
+		return false, nil
+	}
+
+	// determines whether a top-level ACL policy will be applicable
+	matches := namespace == token.Namespace
+
 	// check each policy directly attached to the token
 	for _, policyRef := range token.Policies {
-		if allowable, err := c.policyAllowsKeystoreRead(policyRef.ID); err != nil {
+		if allowable, err := c.policyAllowsKeystoreRead(matches, namespace, policyRef.ID); err != nil {
 			return false, err
 		} else if allowable {
 			return true, nil
@@ -74,7 +108,7 @@ func (c *consulACLsAPI) canReadKeystore(token *api.ACLToken) (bool, error) {
 		}
 
 		for _, policyLink := range role.Policies {
-			allowable, err := c.policyAllowsKeystoreRead(policyLink.ID)
+			allowable, err := c.policyAllowsKeystoreRead(matches, namespace, policyLink.ID)
 			if err != nil {
 				return false, err
 			} else if allowable {
@@ -86,10 +120,18 @@ func (c *consulACLsAPI) canReadKeystore(token *api.ACLToken) (bool, error) {
 	return false, nil
 }
 
-func (c *consulACLsAPI) canWriteService(service string, token *api.ACLToken) (bool, error) {
+func (c *consulACLsAPI) canWriteService(namespace, service string, token *api.ACLToken) (bool, error) {
+	// early check the token is compatible with desired namespace
+	if err := namespaceCheck(namespace, token); err != nil {
+		return false, nil
+	}
+
+	// determines whether a top-level ACL policy will be applicable
+	matches := namespace == token.Namespace
+
 	// check each policy directly attached to the token
 	for _, policyRef := range token.Policies {
-		if allowable, err := c.policyAllowsServiceWrite(service, policyRef.ID); err != nil {
+		if allowable, err := c.policyAllowsServiceWrite(matches, namespace, service, policyRef.ID); err != nil {
 			return false, err
 		} else if allowable {
 			return true, nil
@@ -106,9 +148,9 @@ func (c *consulACLsAPI) canWriteService(service string, token *api.ACLToken) (bo
 		}
 
 		for _, policyLink := range role.Policies {
-			allowable, err := c.policyAllowsServiceWrite(service, policyLink.ID)
-			if err != nil {
-				return false, err
+			allowable, wErr := c.policyAllowsServiceWrite(matches, namespace, service, policyLink.ID)
+			if wErr != nil {
+				return false, wErr
 			} else if allowable {
 				return true, nil
 			}
@@ -118,7 +160,7 @@ func (c *consulACLsAPI) canWriteService(service string, token *api.ACLToken) (bo
 	return false, nil
 }
 
-func (c *consulACLsAPI) policyAllowsServiceWrite(service string, policyID string) (bool, error) {
+func (c *consulACLsAPI) policyAllowsServiceWrite(matches bool, namespace, service string, policyID string) (bool, error) {
 	policy, _, err := c.aclClient.PolicyRead(policyID, &api.QueryOptions{
 		AllowStale: false,
 	})
@@ -129,15 +171,14 @@ func (c *consulACLsAPI) policyAllowsServiceWrite(service string, policyID string
 	// compare policy to the necessary permission for service write
 	// e.g. service "db" { policy = "write" }
 	// e.g. service_prefix "" { policy == "write" }
-	cp, err := ParseConsulPolicy(policy.Rules)
+	cp, err := parseConsulPolicy(policy.Rules)
 	if err != nil {
 		return false, err
 	}
 
-	if cp.allowsServiceWrite(service) {
+	if cp.allowsServiceWrite(matches, namespace, service) {
 		return true, nil
 	}
-
 	return false, nil
 }
 
@@ -145,30 +186,65 @@ const (
 	serviceNameWildcard = "*"
 )
 
-func (cp *ConsulPolicy) allowsServiceWrite(task string) bool {
-	for _, service := range cp.Services {
-		name := strings.ToLower(service.Name)
-		policy := strings.ToLower(service.Policy)
-		if policy == ConsulPolicyWrite {
-			if name == task || name == serviceNameWildcard {
+func (cp *ConsulPolicy) allowsServiceWrite(matches bool, namespace, task string) bool {
+	canWriteService := func(services []*ConsulServiceRule) bool {
+		for _, service := range services {
+			name := strings.ToLower(service.Name)
+			policy := strings.ToLower(service.Policy)
+			if policy == ConsulPolicyWrite {
+				if name == task || name == serviceNameWildcard {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	canWriteServicePrefix := func(services []*ConsulServiceRule) bool {
+		for _, servicePrefix := range services {
+			prefix := strings.ToLower(servicePrefix.Name)
+			policy := strings.ToLower(servicePrefix.Policy)
+			if policy == ConsulPolicyWrite {
+				if strings.HasPrefix(task, prefix) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	if matches {
+		// check the top-level service/service_prefix rules
+		if canWriteService(cp.Services) || canWriteServicePrefix(cp.ServicePrefixes) {
+			return true
+		}
+	}
+
+	// for each namespace rule, if that namespace and the desired namespace
+	// are a match, we can then check the service/service_prefix policy rules
+	for ns, policy := range cp.Namespaces {
+		if ns == namespace {
+			if canWriteService(policy.Services) || canWriteServicePrefix(policy.ServicePrefixes) {
 				return true
 			}
 		}
 	}
 
-	for _, servicePrefix := range cp.ServicePrefixes {
-		prefix := strings.ToLower(servicePrefix.Name)
-		policy := strings.ToLower(servicePrefix.Policy)
-		if policy == ConsulPolicyWrite {
-			if strings.HasPrefix(task, prefix) {
+	// for each namespace_prefix rule, see if that namespace_prefix applies
+	// to this namespace, and if yes, also check those service/service_prefix
+	// policy rules
+	for prefix, policy := range cp.NamespacePrefixes {
+		if strings.HasPrefix(namespace, prefix) {
+			if canWriteService(policy.Services) || canWriteServicePrefix(policy.ServicePrefixes) {
 				return true
 			}
 		}
 	}
+
 	return false
 }
 
-func (c *consulACLsAPI) policyAllowsKeystoreRead(policyID string) (bool, error) {
+func (c *consulACLsAPI) policyAllowsKeystoreRead(matches bool, namespace, policyID string) (bool, error) {
 	policy, _, err := c.aclClient.PolicyRead(policyID, &api.QueryOptions{
 		AllowStale: false,
 	})
@@ -176,27 +252,57 @@ func (c *consulACLsAPI) policyAllowsKeystoreRead(policyID string) (bool, error) 
 		return false, err
 	}
 
-	cp, err := ParseConsulPolicy(policy.Rules)
+	cp, err := parseConsulPolicy(policy.Rules)
 	if err != nil {
 		return false, err
 	}
 
-	if cp.allowsKeystoreRead() {
+	if cp.allowsKeystoreRead(matches, namespace) {
 		return true, nil
 	}
 
 	return false, nil
 }
 
-func (cp *ConsulPolicy) allowsKeystoreRead() bool {
-	for _, keyPrefix := range cp.KeyPrefixes {
-		name := strings.ToLower(keyPrefix.Name)
-		policy := strings.ToLower(keyPrefix.Policy)
-		if name == "" {
-			if policy == ConsulPolicyWrite || policy == ConsulPolicyRead {
+func (cp *ConsulPolicy) allowsKeystoreRead(matches bool, namespace string) bool {
+	canReadKeystore := func(prefixes []*ConsulKeyRule) bool {
+		for _, keyPrefix := range prefixes {
+			name := strings.ToLower(keyPrefix.Name)
+			policy := strings.ToLower(keyPrefix.Policy)
+			if name == "" {
+				if policy == ConsulPolicyWrite || policy == ConsulPolicyRead {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// check the top-level key_prefix rules, but only if the desired namespace
+	// matches the namespace of the consul acl token
+	if matches && canReadKeystore(cp.KeyPrefixes) {
+		return true
+	}
+
+	// for each namespace rule, if that namespace matches the desired namespace
+	// we chan then check the keystore policy
+	for ns, policy := range cp.Namespaces {
+		if ns == namespace {
+			if canReadKeystore(policy.KeyPrefixes) {
 				return true
 			}
 		}
 	}
+
+	// for each namespace_prefix rule, see if that namespace_prefix applies to
+	// this namespace, and if yes, also check those key_prefix policy rules
+	for prefix, policy := range cp.NamespacePrefixes {
+		if strings.HasPrefix(namespace, prefix) {
+			if canReadKeystore(policy.KeyPrefixes) {
+				return true
+			}
+		}
+	}
+
 	return false
 }

--- a/nomad/consul_test.go
+++ b/nomad/consul_test.go
@@ -386,9 +386,14 @@ func TestConsulACLsAPI_CheckPermissions(t *testing.T) {
 			try(t, "default", u, "", nil)
 		})
 
-		t.Run("uses kv wrong namespace", func(t *testing.T) {
+		t.Run("uses kv default token missing permissions", func(t *testing.T) {
 			u := &structs.ConsulUsage{KV: true}
-			try(t, "other", u, consul.ExampleOperatorTokenID5, errors.New(`consul ACL token cannot use namespace "other"`))
+			try(t, "other", u, consul.ExampleOperatorTokenID5, errors.New(`insufficient Consul ACL permissions to use template`))
+		})
+
+		t.Run("uses kv token in wrong namespace", func(t *testing.T) {
+			u := &structs.ConsulUsage{KV: true}
+			try(t, "other", u, consul.ExampleOperatorTokenID15, errors.New(`consul ACL token cannot use namespace "other"`))
 		})
 	})
 
@@ -399,8 +404,12 @@ func TestConsulACLsAPI_CheckPermissions(t *testing.T) {
 			try(t, "default", usage, consul.ExampleOperatorTokenID1, nil)
 		})
 
-		t.Run("operator has service wrote wrong ns", func(t *testing.T) {
-			try(t, "other", usage, consul.ExampleOperatorTokenID1, errors.New(`consul ACL token cannot use namespace "other"`))
+		t.Run("operator has service write but no policy", func(t *testing.T) {
+			try(t, "other", usage, consul.ExampleOperatorTokenID1, errors.New(`insufficient Consul ACL permissions to write service "service1"`))
+		})
+
+		t.Run("operator has token in wrong namespace", func(t *testing.T) {
+			try(t, "other", usage, consul.ExampleOperatorTokenID11, errors.New(`consul ACL token cannot use namespace "other"`))
 		})
 
 		t.Run("operator has service_prefix write", func(t *testing.T) {
@@ -434,7 +443,11 @@ func TestConsulACLsAPI_CheckPermissions(t *testing.T) {
 		})
 
 		t.Run("operator has service write wrong ns", func(t *testing.T) {
-			try(t, "other", usage, consul.ExampleOperatorTokenID1, errors.New(`consul ACL token cannot use namespace "other"`))
+			try(t, "other", usage, consul.ExampleOperatorTokenID1, errors.New(`insufficient Consul ACL permissions to write Connect service "service1"`))
+		})
+
+		t.Run("operator has token in wrong namespace", func(t *testing.T) {
+			try(t, "other", usage, consul.ExampleOperatorTokenID11, errors.New(`consul ACL token cannot use namespace "other"`))
 		})
 
 		t.Run("operator has service_prefix write", func(t *testing.T) {


### PR DESCRIPTION
~(hold until ent half goes in - making sure oss CI still works)~

This PR cherry-picks changes made for ENT testing of Consul Namespaces with ACLs enabled. 

