### PR TITLE
Add metrics for blocked eval resources

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -374,6 +374,7 @@ type AllocationMetric struct {
 	ClassExhausted     map[string]int
 	DimensionExhausted map[string]int
 	QuotaExhausted     []string
+	ResourcesExhausted map[string]*Resources
 	// Deprecated, replaced with ScoreMetaData
 	Scores            map[string]float64
 	AllocationTime    time.Duration

--- a/nomad/blocked_evals.go
+++ b/nomad/blocked_evals.go
@@ -95,20 +95,6 @@ type wrappedEval struct {
 	token string
 }
 
-// BlockedStats returns all the stats about the blocked eval tracker.
-type BlockedStats struct {
-	// TotalEscaped is the total number of blocked evaluations that have escaped
-	// computed node classes.
-	TotalEscaped int
-
-	// TotalBlocked is the total number of blocked evaluations.
-	TotalBlocked int
-
-	// TotalQuotaLimit is the total number of blocked evaluations that are due
-	// to the quota limit being reached.
-	TotalQuotaLimit int
-}
-
 // NewBlockedEvals creates a new blocked eval tracker that will enqueue
 // unblocked evals into the passed broker.
 func NewBlockedEvals(evalBroker *EvalBroker, logger log.Logger) *BlockedEvals {
@@ -123,7 +109,7 @@ func NewBlockedEvals(evalBroker *EvalBroker, logger log.Logger) *BlockedEvals {
 		capacityChangeCh: make(chan *capacityUpdate, unblockBuffer),
 		duplicateCh:      make(chan struct{}, 1),
 		stopCh:           make(chan struct{}),
-		stats:            new(BlockedStats),
+		stats:            NewBlockedStats(),
 	}
 }
 
@@ -209,7 +195,7 @@ func (b *BlockedEvals) processBlock(eval *structs.Evaluation, token string) {
 
 	// Mark the job as tracked.
 	b.jobs[structs.NewNamespacedID(eval.JobID, eval.Namespace)] = eval.ID
-	b.stats.TotalBlocked++
+	b.stats.Block(eval)
 
 	// Track that the evaluation is being added due to reaching the quota limit
 	if eval.QuotaLimitReached != "" {
@@ -263,7 +249,7 @@ func (b *BlockedEvals) processBlockJobDuplicate(eval *structs.Evaluation) (newCa
 	if ok {
 		if latestEvalIndex(existingW.eval) <= latestEvalIndex(eval) {
 			delete(b.captured, existingID)
-			b.stats.TotalBlocked--
+			b.stats.Unblock(eval)
 			dup = existingW.eval
 		} else {
 			dup = eval
@@ -379,7 +365,7 @@ func (b *BlockedEvals) Untrack(jobID, namespace string) {
 	if evals, ok := b.system.JobEvals(nsID); ok {
 		for _, e := range evals {
 			b.system.Remove(e)
-			b.stats.TotalBlocked--
+			b.stats.Unblock(e)
 		}
 		return
 	}
@@ -395,7 +381,7 @@ func (b *BlockedEvals) Untrack(jobID, namespace string) {
 	if w, ok := b.captured[evalID]; ok {
 		delete(b.jobs, nsID)
 		delete(b.captured, evalID)
-		b.stats.TotalBlocked--
+		b.stats.Unblock(w.eval)
 		if w.eval.QuotaLimitReached != "" {
 			b.stats.TotalQuotaLimit--
 		}
@@ -405,7 +391,7 @@ func (b *BlockedEvals) Untrack(jobID, namespace string) {
 		delete(b.jobs, nsID)
 		delete(b.escaped, evalID)
 		b.stats.TotalEscaped--
-		b.stats.TotalBlocked--
+		b.stats.Unblock(w.eval)
 		if w.eval.QuotaLimitReached != "" {
 			b.stats.TotalQuotaLimit--
 		}
@@ -511,7 +497,7 @@ func (b *BlockedEvals) UnblockNode(nodeID string, index uint64) {
 
 	for e := range evals {
 		b.system.Remove(e)
-		b.stats.TotalBlocked--
+		b.stats.Unblock(e)
 	}
 
 	b.evalBroker.EnqueueAll(evals)
@@ -583,11 +569,13 @@ func (b *BlockedEvals) unblock(computedClass, quota string, index uint64) {
 		}
 	}
 
-	if l := len(unblocked); l != 0 {
+	if len(unblocked) != 0 {
 		// Update the counters
 		b.stats.TotalEscaped = 0
-		b.stats.TotalBlocked -= l
 		b.stats.TotalQuotaLimit -= numQuotaLimit
+		for eval := range unblocked {
+			b.stats.Unblock(eval)
+		}
 
 		// Enqueue all the unblocked evals into the broker.
 		b.evalBroker.EnqueueAll(unblocked)
@@ -630,9 +618,12 @@ func (b *BlockedEvals) UnblockFailed() {
 		}
 	}
 
-	if l := len(unblocked); l > 0 {
-		b.stats.TotalBlocked -= l
+	if len(unblocked) > 0 {
 		b.stats.TotalQuotaLimit -= quotaLimit
+		for eval := range unblocked {
+			b.stats.Unblock(eval)
+		}
+
 		b.evalBroker.EnqueueAll(unblocked)
 	}
 }
@@ -683,6 +674,7 @@ func (b *BlockedEvals) Flush() {
 	b.stats.TotalEscaped = 0
 	b.stats.TotalBlocked = 0
 	b.stats.TotalQuotaLimit = 0
+	b.stats.BlockedResources = NewBlockedResourcesStats()
 	b.captured = make(map[string]wrappedEval)
 	b.escaped = make(map[string]wrappedEval)
 	b.jobs = make(map[structs.NamespacedID]string)
@@ -698,7 +690,7 @@ func (b *BlockedEvals) Flush() {
 // Stats is used to query the state of the blocked eval tracker.
 func (b *BlockedEvals) Stats() *BlockedStats {
 	// Allocate a new stats struct
-	stats := new(BlockedStats)
+	stats := NewBlockedStats()
 
 	b.l.RLock()
 	defer b.l.RUnlock()
@@ -707,6 +699,8 @@ func (b *BlockedEvals) Stats() *BlockedStats {
 	stats.TotalEscaped = b.stats.TotalEscaped
 	stats.TotalBlocked = b.stats.TotalBlocked
 	stats.TotalQuotaLimit = b.stats.TotalQuotaLimit
+	stats.BlockedResources = b.stats.BlockedResources.Copy()
+
 	return stats
 }
 
@@ -719,6 +713,24 @@ func (b *BlockedEvals) EmitStats(period time.Duration, stopCh <-chan struct{}) {
 			metrics.SetGauge([]string{"nomad", "blocked_evals", "total_quota_limit"}, float32(stats.TotalQuotaLimit))
 			metrics.SetGauge([]string{"nomad", "blocked_evals", "total_blocked"}, float32(stats.TotalBlocked))
 			metrics.SetGauge([]string{"nomad", "blocked_evals", "total_escaped"}, float32(stats.TotalEscaped))
+
+			for k, v := range stats.BlockedResources.ByJob {
+				labels := []metrics.Label{
+					{Name: "namespace", Value: k.Namespace},
+					{Name: "job", Value: k.ID},
+				}
+				metrics.SetGaugeWithLabels([]string{"nomad", "blocked_evals", "job", "cpu"}, float32(v.CPU), labels)
+				metrics.SetGaugeWithLabels([]string{"nomad", "blocked_evals", "job", "memory"}, float32(v.MemoryMB), labels)
+			}
+
+			for k, v := range stats.BlockedResources.ByNodeInfo {
+				labels := []metrics.Label{
+					{Name: "datacenter", Value: k.Datacenter},
+					{Name: "node_class", Value: k.NodeClass},
+				}
+				metrics.SetGaugeWithLabels([]string{"nomad", "blocked_evals", "cpu"}, float32(v.CPU), labels)
+				metrics.SetGaugeWithLabels([]string{"nomad", "blocked_evals", "memory"}, float32(v.MemoryMB), labels)
+			}
 		case <-stopCh:
 			return
 		}
@@ -734,15 +746,17 @@ func (b *BlockedEvals) prune(stopCh <-chan struct{}) {
 		select {
 		case <-stopCh:
 			return
-		case <-ticker.C:
-			b.pruneUnblockIndexes()
+		case t := <-ticker.C:
+			cutoff := t.UTC().Add(-1 * pruneThreshold)
+			b.pruneUnblockIndexes(cutoff)
+			b.stats.prune(cutoff)
 		}
 	}
 }
 
 // pruneUnblockIndexes is used to prune any tracked entry that is excessively
 // old. This protects againsts unbounded growth of the map.
-func (b *BlockedEvals) pruneUnblockIndexes() {
+func (b *BlockedEvals) pruneUnblockIndexes(cutoff time.Time) {
 	b.l.Lock()
 	defer b.l.Unlock()
 
@@ -750,12 +764,18 @@ func (b *BlockedEvals) pruneUnblockIndexes() {
 		return
 	}
 
-	cutoff := time.Now().UTC().Add(-1 * pruneThreshold)
 	oldThreshold := b.timetable.NearestIndex(cutoff)
-
 	for key, index := range b.unblockIndexes {
 		if index < oldThreshold {
 			delete(b.unblockIndexes, key)
 		}
 	}
+}
+
+// pruneStats is used to prune any zero value stats that are excessively old.
+func (b *BlockedEvals) pruneStats(cutoff time.Time) {
+	b.l.Lock()
+	defer b.l.Unlock()
+
+	b.stats.prune(cutoff)
 }

--- a/nomad/blocked_evals.go
+++ b/nomad/blocked_evals.go
@@ -749,7 +749,7 @@ func (b *BlockedEvals) prune(stopCh <-chan struct{}) {
 		case t := <-ticker.C:
 			cutoff := t.UTC().Add(-1 * pruneThreshold)
 			b.pruneUnblockIndexes(cutoff)
-			b.stats.prune(cutoff)
+			b.pruneStats(cutoff)
 		}
 	}
 }

--- a/nomad/blocked_evals_stats.go
+++ b/nomad/blocked_evals_stats.go
@@ -1,0 +1,209 @@
+package nomad
+
+import (
+	"time"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// BlockedStats returns all the stats about the blocked eval tracker.
+type BlockedStats struct {
+	// TotalEscaped is the total number of blocked evaluations that have escaped
+	// computed node classes.
+	TotalEscaped int
+
+	// TotalBlocked is the total number of blocked evaluations.
+	TotalBlocked int
+
+	// TotalQuotaLimit is the total number of blocked evaluations that are due
+	// to the quota limit being reached.
+	TotalQuotaLimit int
+
+	// BlockedResources stores the amount of resources requested by blocked
+	// evaluations.
+	BlockedResources BlockedResourcesStats
+}
+
+// NewBlockedStats returns a new BlockedStats.
+func NewBlockedStats() *BlockedStats {
+	return &BlockedStats{
+		BlockedResources: NewBlockedResourcesStats(),
+	}
+}
+
+// Block updates the stats for the blocked eval tracker with the details of the
+// evaluation being blocked.
+func (b *BlockedStats) Block(eval *structs.Evaluation) {
+	b.TotalBlocked++
+	resourceStats := generateResourceStats(eval)
+	b.BlockedResources = b.BlockedResources.Add(resourceStats)
+}
+
+// Unblock updates the stats for the blocked eval tracker with the details of the
+// evaluation being unblocked.
+func (b *BlockedStats) Unblock(eval *structs.Evaluation) {
+	b.TotalBlocked--
+	resourceStats := generateResourceStats(eval)
+	b.BlockedResources = b.BlockedResources.Subtract(resourceStats)
+}
+
+// prune deletes any key zero metric values older than the cutoff.
+func (b *BlockedStats) prune(cutoff time.Time) {
+	shouldPrune := func(s BlockedResourcesSummary) bool {
+		return s.Timestamp.Before(cutoff) && s.IsZero()
+	}
+
+	for k, v := range b.BlockedResources.ByJob {
+		if shouldPrune(v) {
+			delete(b.BlockedResources.ByJob, k)
+		}
+	}
+
+	for k, v := range b.BlockedResources.ByNodeInfo {
+		if shouldPrune(v) {
+			delete(b.BlockedResources.ByNodeInfo, k)
+		}
+	}
+}
+
+// generateResourceStats returns a summary of the resources requested by the
+// input evaluation.
+func generateResourceStats(eval *structs.Evaluation) BlockedResourcesStats {
+	dcs := make(map[string]struct{})
+	classes := make(map[string]struct{})
+
+	resources := BlockedResourcesSummary{
+		Timestamp: time.Now().UTC(),
+	}
+
+	for _, allocMetrics := range eval.FailedTGAllocs {
+		for dc := range allocMetrics.NodesAvailable {
+			dcs[dc] = struct{}{}
+		}
+
+		for class := range allocMetrics.ClassExhausted {
+			classes[class] = struct{}{}
+		}
+
+		for _, r := range allocMetrics.ResourcesExhausted {
+			resources.CPU += r.CPU
+			resources.MemoryMB += r.MemoryMB
+		}
+	}
+
+	byJob := make(map[structs.NamespacedID]BlockedResourcesSummary)
+	byJob[structs.NewNamespacedID(eval.JobID, eval.Namespace)] = resources
+
+	byNodeInfo := make(map[NodeInfo]BlockedResourcesSummary)
+	for dc := range dcs {
+		for class := range classes {
+			k := NodeInfo{dc, class}
+			byNodeInfo[k] = resources
+		}
+	}
+
+	return BlockedResourcesStats{
+		ByJob:      byJob,
+		ByNodeInfo: byNodeInfo,
+	}
+}
+
+// BlockedResourcesStats stores resources requested by block evaluations
+// split into different dimensions.
+type BlockedResourcesStats struct {
+	ByJob      map[structs.NamespacedID]BlockedResourcesSummary
+	ByNodeInfo map[NodeInfo]BlockedResourcesSummary
+}
+
+// NewBlockedResourcesStats returns a new BlockedResourcesStats.
+func NewBlockedResourcesStats() BlockedResourcesStats {
+	return BlockedResourcesStats{
+		ByJob:      make(map[structs.NamespacedID]BlockedResourcesSummary),
+		ByNodeInfo: make(map[NodeInfo]BlockedResourcesSummary),
+	}
+}
+
+// Copy returns a deep copy of the blocked resource stats.
+func (b BlockedResourcesStats) Copy() BlockedResourcesStats {
+	result := NewBlockedResourcesStats()
+
+	for k, v := range b.ByJob {
+		result.ByJob[k] = v
+	}
+
+	for k, v := range b.ByNodeInfo {
+		result.ByNodeInfo[k] = v
+	}
+
+	return result
+}
+
+// Add returns a new BlockedResourcesStats with the values set to the current
+// resource values plus the input.
+func (b BlockedResourcesStats) Add(a BlockedResourcesStats) BlockedResourcesStats {
+	result := b.Copy()
+
+	for k, v := range a.ByJob {
+		result.ByJob[k] = b.ByJob[k].Add(v)
+	}
+
+	for k, v := range a.ByNodeInfo {
+		result.ByNodeInfo[k] = b.ByNodeInfo[k].Add(v)
+	}
+
+	return result
+}
+
+// Subtract returns a new BlockedResourcesStats with the values set to the
+// current resource values minus the input.
+func (b BlockedResourcesStats) Subtract(a BlockedResourcesStats) BlockedResourcesStats {
+	result := b.Copy()
+
+	for k, v := range a.ByJob {
+		result.ByJob[k] = b.ByJob[k].Subtract(v)
+	}
+
+	for k, v := range a.ByNodeInfo {
+		result.ByNodeInfo[k] = b.ByNodeInfo[k].Subtract(v)
+	}
+
+	return result
+}
+
+// NodeInfo stores information related to nodes.
+type NodeInfo struct {
+	Datacenter string
+	NodeClass  string
+}
+
+// BlockedResourcesSummary stores resource values for blocked evals.
+type BlockedResourcesSummary struct {
+	Timestamp time.Time
+	CPU       int
+	MemoryMB  int
+}
+
+// Add returns a new BlockedResourcesSummary with each resource set to the
+// current value plus the input.
+func (b BlockedResourcesSummary) Add(a BlockedResourcesSummary) BlockedResourcesSummary {
+	return BlockedResourcesSummary{
+		Timestamp: a.Timestamp,
+		CPU:       b.CPU + a.CPU,
+		MemoryMB:  b.MemoryMB + a.MemoryMB,
+	}
+}
+
+// Subtract returns a new BlockedResourcesSummary with each resource set to the
+// current value minus the input.
+func (b BlockedResourcesSummary) Subtract(a BlockedResourcesSummary) BlockedResourcesSummary {
+	return BlockedResourcesSummary{
+		Timestamp: a.Timestamp,
+		CPU:       b.CPU - a.CPU,
+		MemoryMB:  b.MemoryMB - a.MemoryMB,
+	}
+}
+
+// IsZero returns true if all resource values are zero.
+func (b BlockedResourcesSummary) IsZero() bool {
+	return b.CPU == 0 && b.MemoryMB == 0
+}

--- a/nomad/blocked_evals_stats_test.go
+++ b/nomad/blocked_evals_stats_test.go
@@ -1,0 +1,156 @@
+package nomad
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+	"time"
+
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// testBlockedEvalsRandomBlockedEval wraps an eval that is randomly generated.
+type testBlockedEvalsRandomBlockedEval struct {
+	eval *structs.Evaluation
+}
+
+// Generate returns a random eval.
+func (t testBlockedEvalsRandomBlockedEval) Generate(rand *rand.Rand, _ int) reflect.Value {
+	resourceTypes := []string{"cpu", "memory"}
+
+	// Start with a mock eval.
+	e := mock.BlockedEval()
+
+	// Get how many task groups, datacenters and node classes to generate.
+	// Add 1 to avoid 0.
+	tgCount := rand.Intn(10) + 1
+	dcCount := rand.Intn(3) + 1
+	nodeClassCount := rand.Intn(3) + 1
+
+	failedTGAllocs := map[string]*structs.AllocMetric{}
+
+	for tg := 1; tg <= tgCount; tg++ {
+		tgName := fmt.Sprintf("group-%d", tg)
+
+		// Get which resource type to use for this task group.
+		// Nomad stops at the first dimension that is exhausted, so only 1 is
+		// added per task group.
+		i := rand.Int() % len(resourceTypes)
+		resourceType := resourceTypes[i]
+
+		failedTGAllocs[tgName] = &structs.AllocMetric{
+			DimensionExhausted: map[string]int{
+				resourceType: 1,
+			},
+			NodesAvailable: map[string]int{},
+			ClassExhausted: map[string]int{},
+		}
+
+		for dc := 1; dc <= dcCount; dc++ {
+			dcName := fmt.Sprintf("dc%d", dc)
+			failedTGAllocs[tgName].NodesAvailable[dcName] = 1
+		}
+
+		for nc := 1; nc <= nodeClassCount; nc++ {
+			nodeClassName := fmt.Sprintf("node-class-%d", nc)
+			failedTGAllocs[tgName].ClassExhausted[nodeClassName] = 1
+		}
+
+		// Generate resources for each task.
+		taskCount := rand.Intn(5) + 1
+		resourcesExhausted := map[string]*structs.Resources{}
+
+		for t := 1; t <= taskCount; t++ {
+			task := fmt.Sprintf("task-%d", t)
+			resourcesExhausted[task] = &structs.Resources{}
+
+			resourceAmount := rand.Intn(1000)
+			switch resourceType {
+			case "cpu":
+				resourcesExhausted[task].CPU = resourceAmount
+			case "memory":
+				resourcesExhausted[task].MemoryMB = resourceAmount
+			}
+		}
+		failedTGAllocs[tgName].ResourcesExhausted = resourcesExhausted
+	}
+	e.FailedTGAllocs = failedTGAllocs
+	t.eval = e
+	return reflect.ValueOf(t)
+}
+
+// clearTimestampFromBlockedResourceStats set timestamp metrics to zero to
+// avoid invalid comparisons.
+func clearTimestampFromBlockedResourceStats(b *BlockedResourcesStats) {
+	for k, v := range b.ByJob {
+		v.Timestamp = time.Time{}
+		b.ByJob[k] = v
+	}
+	for k, v := range b.ByNodeInfo {
+		v.Timestamp = time.Time{}
+		b.ByNodeInfo[k] = v
+	}
+}
+
+// TestBlockedEvalsStats_BlockedResources generates random evals and processes
+// them using the expected code paths and a manual check of the expeceted result.
+func TestBlockedEvalsStats_BlockedResources(t *testing.T) {
+	t.Parallel()
+	blocked, _ := testBlockedEvals(t)
+
+	// evalHistory stores all evals generated during the test.
+	evalHistory := []*structs.Evaluation{}
+
+	// blockedEvals keeps track if evals are blocked or unblocked.
+	blockedEvals := map[string]bool{}
+
+	// blockAndUntrack processes the generated evals in order using a
+	// BlockedEvals instance.
+	blockAndUntrack := func(testEval testBlockedEvalsRandomBlockedEval, block bool, unblockIdx uint16) BlockedResourcesStats {
+		if block || len(evalHistory) == 0 {
+			blocked.Block(testEval.eval)
+		} else {
+			i := int(unblockIdx) % len(evalHistory)
+			eval := evalHistory[i]
+			blocked.Untrack(eval.JobID, eval.Namespace)
+		}
+
+		// Remove zero stats from unblocked evals.
+		blocked.pruneStats(time.Now().UTC())
+
+		result := blocked.Stats().BlockedResources
+		clearTimestampFromBlockedResourceStats(&result)
+		return result
+	}
+
+	// manualCount processes only the blocked evals and generate a
+	// BlockedResourcesStats result directly from the eval history.
+	manualCount := func(testEval testBlockedEvalsRandomBlockedEval, block bool, unblockIdx uint16) BlockedResourcesStats {
+		if block || len(evalHistory) == 0 {
+			evalHistory = append(evalHistory, testEval.eval)
+			blockedEvals[testEval.eval.ID] = true
+		} else {
+			i := int(unblockIdx) % len(evalHistory)
+			eval := evalHistory[i]
+			blockedEvals[eval.ID] = false
+		}
+
+		result := NewBlockedResourcesStats()
+		for _, e := range evalHistory {
+			if !blockedEvals[e.ID] {
+				continue
+			}
+			result = result.Add(generateResourceStats(e))
+		}
+		clearTimestampFromBlockedResourceStats(&result)
+		return result
+	}
+
+	err := quick.CheckEqual(blockAndUntrack, manualCount, nil)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -1092,6 +1092,26 @@ func Eval() *structs.Evaluation {
 	return eval
 }
 
+func BlockedEval() *structs.Evaluation {
+	e := Eval()
+	e.Status = structs.EvalStatusBlocked
+	e.FailedTGAllocs = map[string]*structs.AllocMetric{
+		"cache": {
+			DimensionExhausted: map[string]int{
+				"memory": 1,
+			},
+			ResourcesExhausted: map[string]*structs.Resources{
+				"redis": {
+					CPU:      100,
+					MemoryMB: 1024,
+				},
+			},
+		},
+	}
+
+	return e
+}
+
 func JobSummary(jobID string) *structs.JobSummary {
 	js := &structs.JobSummary{
 		JobID:     jobID,

--- a/vendor/github.com/hashicorp/nomad/api/allocations.go
+++ b/vendor/github.com/hashicorp/nomad/api/allocations.go
@@ -374,6 +374,7 @@ type AllocationMetric struct {
 	ClassExhausted     map[string]int
 	DimensionExhausted map[string]int
 	QuotaExhausted     []string
+	ResourcesExhausted map[string]*Resources
 	// Deprecated, replaced with ScoreMetaData
 	Scores            map[string]float64
 	AllocationTime    time.Duration

--- a/website/content/docs/operations/metrics.mdx
+++ b/website/content/docs/operations/metrics.mdx
@@ -228,214 +228,218 @@ Job status metrics are emitted by the Nomad leader server.
 The following table includes metrics for overall cluster health in addition to
 those listed in [Key Metrics](#key-metrics) above.
 
-| Metric                                               | Description                                                       | Unit                 | Type    | Labels |
-| ---------------------------------------------------- | ----------------------------------------------------------------- | -------------------- | ------- | ------ |
-| `nomad.memberlist.gossip`                            | Time elapsed to broadcast gossip messages                         | Nanoseconds          | Summary | host   |
-| `nomad.nomad.acl.bootstrap`                          | Time elapsed for `ACL.Bootstrap` RPC call                         | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.acl.delete_policies`                    | Time elapsed for `ACL.DeletePolicies` RPC call                    | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.acl.delete_tokens`                      | Time elapsed for `ACL.DeleteTokens` RPC call                      | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.acl.get_policies`                       | Time elapsed for `ACL.GetPolicies` RPC call                       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.acl.get_policy`                         | Time elapsed for `ACL.GetPolicy` RPC call                         | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.acl.get_token`                          | Time elapsed for `ACL.GetToken` RPC call                          | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.acl.get_tokens`                         | Time elapsed for `ACL.GetTokens` RPC call                         | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.acl.list_policies`                      | Time elapsed for `ACL.ListPolicies` RPC call                      | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.acl.list_tokens`                        | Time elapsed for `ACL.ListTokens` RPC call                        | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.acl.resolve_token`                      | Time elapsed for `ACL.ResolveToken` RPC call                      | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.acl.upsert_policies`                    | Time elapsed for `ACL.UpsertPolicies` RPC call                    | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.acl.upsert_tokens`                      | Time elapsed for `ACL.UpsertTokens` RPC call                      | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.alloc.exec`                             | Time elapsed to establish alloc exec                              | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.alloc.get_alloc`                        | Time elapsed for `Alloc.GetAlloc` RPC call                        | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.alloc.get_allocs`                       | Time elapsed for `Alloc.GetAllocs` RPC call                       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.alloc.list`                             | Time elapsed for `Alloc.List` RPC call                            | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.alloc.stop`                             | Time elapsed for `Alloc.Stop` RPC call                            | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.alloc.update_desired_transition`        | Time elapsed for `Alloc.UpdateDesiredTransition` RPC call         | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.blocked_evals.total_blocked`            | Count of evals in the blocked state                               | Integer              | Gauge   | host   |
-| `nomad.nomad.blocked_evals.total_escaped`            | Count of evals that have escaped computed node classes            | Integer              | Gauge   | host   |
-| `nomad.nomad.blocked_evals.total_quota_limit`        | Count of blocked evals due to quota limits                        | Integer              | Gauge   | host   |
-| `nomad.nomad.broker.batch_ready`                     | Count of batch evals ready to be scheduled                        | Integer              | Gauge   | host   |
-| `nomad.nomad.broker.batch_unacked`                   | Count of unacknowledged batch evals                               | Integer              | Gauge   | host   |
-| `nomad.nomad.broker.service_ready`                   | Count of service evals ready to be scheduled                      | Integer              | Gauge   | host   |
-| `nomad.nomad.broker.service_unacked`                 | Count of unacknowledged service evals                             | Integer              | Gauge   | host   |
-| `nomad.nomad.broker.system_ready`                    | Count of system evals ready to be scheduled                       | Integer              | Gauge   | host   |
-| `nomad.nomad.broker.system_unacked`                  | Count of unacknowledged system evals                              | Integer              | Gauge   | host   |
-| `nomad.nomad.broker.total_ready`                     | Count of evals in the ready state                                 | Integer              | Gauge   | host   |
-| `nomad.nomad.broker.total_waiting`                   | Count of evals in the waiting state                               | Integer              | Gauge   | host   |
-| `nomad.nomad.client.batch_deregister`                | Time elapsed for `Node.BatchDeregister` RPC call                  | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client.deregister`                      | Time elapsed for `Node.Deregister` RPC call                       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client.derive_si_token`                 | Time elapsed for `Node.DeriveSIToken` RPC call                    | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client.derive_vault_token`              | Time elapsed for `Node.DeriveVaultToken` RPC call                 | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client.emit_events`                     | Time elapsed for `Node.EmitEvents` RPC call                       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client.evaluate`                        | Time elapsed for `Node.Evaluate` RPC call                         | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client.get_allocs`                      | Time elapsed for `Node.GetAllocs` RPC call                        | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client.get_client_allocs`               | Time elapsed for `Node.GetClientAllocs` RPC call                  | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client.get_node`                        | Time elapsed for `Node.GetNode` RPC call                          | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client.list`                            | Time elapsed for `Node.List` RPC call                             | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client.register`                        | Time elapsed for `Node.Register` RPC call                         | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client.stats`                           | Time elapsed for `Client.Stats` RPC call                          | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client.update_alloc`                    | Time elapsed for `Node.UpdateAlloc` RPC call                      | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client.update_drain`                    | Time elapsed for `Node.UpdateDrain` RPC call                      | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client.update_eligibility`              | Time elapsed for `Node.UpdateEligibility` RPC call                | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client.update_status`                   | Time elapsed for `Node.UpdateStatus` RPC call                     | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client_allocations.garbage_collect_all` | Time elapsed for `ClientAllocations.GarbageCollectAll` RPC call   | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client_allocations.garbage_collect`     | Time elapsed for `ClientAllocations.GarbageCollect` RPC call      | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client_allocations.restart`             | Time elapsed for `ClientAllocations.Restart` RPC call             | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client_allocations.signal`              | Time elapsed for `ClientAllocations.Signal` RPC call              | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client_allocations.stats`               | Time elapsed for `ClientAllocations.Stats` RPC call               | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client_csi_controller.attach_volume`    | Time elapsed for `Controller.AttachVolume` RPC call               | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client_csi_controller.detach_volume`    | Time elapsed for `Controller.DetachVolume` RPC call               | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client_csi_controller.validate_volume`  | Time elapsed for `Controller.ValidateVolume` RPC call             | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.client_csi_node.detach_volume`          | Time elapsed for `Node.DetachVolume` RPC call                     | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.deployment.allocations`                 | Time elapsed for `Deployment.Allocations` RPC call                | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.deployment.cancel`                      | Time elapsed for `Deployment.Cancel` RPC call                     | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.deployment.fail`                        | Time elapsed for `Deployment.Fail` RPC call                       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.deployment.get_deployment`              | Time elapsed for `Deployment.GetDeployment` RPC call              | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.deployment.list`                        | Time elapsed for `Deployment.List` RPC call                       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.deployment.pause`                       | Time elapsed for `Deployment.Pause` RPC call                      | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.deployment.promote`                     | Time elapsed for `Deployment.Promote` RPC call                    | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.deployment.reap`                        | Time elapsed for `Deployment.Reap` RPC call                       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.deployment.run`                         | Time elapsed for `Deployment.Run` RPC call                        | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.deployment.set_alloc_health`            | Time elapsed for `Deployment.SetAllocHealth` RPC call             | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.deployment.unblock`                     | Time elapsed for `Deployment.Unblock` RPC call                    | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.eval.ack`                               | Time elapsed for `Eval.Ack` RPC call                              | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.eval.allocations`                       | Time elapsed for `Eval.Allocations` RPC call                      | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.eval.create`                            | Time elapsed for `Eval.Create` RPC call                           | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.eval.dequeue`                           | Time elapsed for `Eval.Dequeue` RPC call                          | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.eval.get_eval`                          | Time elapsed for `Eval.GetEval` RPC call                          | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.eval.list`                              | Time elapsed for `Eval.List` RPC call                             | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.eval.nack`                              | Time elapsed for `Eval.Nack` RPC call                             | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.eval.reap`                              | Time elapsed for `Eval.Reap` RPC call                             | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.eval.reblock`                           | Time elapsed for `Eval.Reblock` RPC call                          | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.eval.update`                            | Time elapsed for `Eval.Update` RPC call                           | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.file_system.list`                       | Time elapsed for `FileSystem.List` RPC call                       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.file_system.logs`                       | Time elapsed to establish `FileSystem.Logs` RPC                   | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.file_system.stat`                       | Time elapsed for `FileSystem.Stat` RPC call                       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.file_system.stream`                     | Time elapsed to establish `FileSystem.Stream` RPC                 | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.alloc_client_update`                | Time elapsed to apply `AllocClientUpdate` raft entry              | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.alloc_update_desired_transition`    | Time elapsed to apply `AllocUpdateDesiredTransition` raft entry   | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.alloc_update`                       | Time elapsed to apply `AllocUpdate` raft entry                    | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_acl_policy_delete`            | Time elapsed to apply `ApplyACLPolicyDelete` raft entry           | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_acl_policy_upsert`            | Time elapsed to apply `ApplyACLPolicyUpsert` raft entry           | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_acl_token_bootstrap`          | Time elapsed to apply `ApplyACLTokenBootstrap` raft entry         | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_acl_token_delete`             | Time elapsed to apply `ApplyACLTokenDelete` raft entry            | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_acl_token_upsert`             | Time elapsed to apply `ApplyACLTokenUpsert` raft entry            | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_csi_plugin_delete`            | Time elapsed to apply `ApplyCSIPluginDelete` raft entry           | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_csi_volume_batch_claim`       | Time elapsed to apply `ApplyCSIVolumeBatchClaim` raft entry       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_csi_volume_claim`             | Time elapsed to apply `ApplyCSIVolumeClaim` raft entry            | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_csi_volume_deregister`        | Time elapsed to apply `ApplyCSIVolumeDeregister` raft entry       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_csi_volume_register`          | Time elapsed to apply `ApplyCSIVolumeRegister` raft entry         | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_deployment_alloc_health`      | Time elapsed to apply `ApplyDeploymentAllocHealth` raft entry     | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_deployment_delete`            | Time elapsed to apply `ApplyDeploymentDelete` raft entry          | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_deployment_promotion`         | Time elapsed to apply `ApplyDeploymentPromotion` raft entry       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_deployment_status_update`     | Time elapsed to apply `ApplyDeploymentStatusUpdate` raft entry    | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_job_stability`                | Time elapsed to apply `ApplyJobStability` raft entry              | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_namespace_delete`             | Time elapsed to apply `ApplyNamespaceDelete` raft entry           | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_namespace_upsert`             | Time elapsed to apply `ApplyNamespaceUpsert` raft entry           | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_plan_results`                 | Time elapsed to apply `ApplyPlanResults` raft entry               | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.apply_scheduler_config`             | Time elapsed to apply `ApplySchedulerConfig` raft entry           | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.autopilot`                          | Time elapsed to apply `Autopilot` raft entry                      | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.batch_deregister_job`               | Time elapsed to apply `BatchDeregisterJob` raft entry             | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.batch_deregister_node`              | Time elapsed to apply `BatchDeregisterNode` raft entry            | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.batch_node_drain_update`            | Time elapsed to apply `BatchNodeDrainUpdate` raft entry           | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.cluster_meta`                       | Time elapsed to apply `ClusterMeta` raft entry                    | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.delete_eval`                        | Time elapsed to apply `DeleteEval` raft entry                     | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.deregister_job`                     | Time elapsed to apply `DeregisterJob` raft entry                  | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.deregister_node`                    | Time elapsed to apply `DeregisterNode` raft entry                 | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.deregister_si_accessor`             | Time elapsed to apply `DeregisterSITokenAccessor` raft entry      | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.deregister_vault_accessor`          | Time elapsed to apply `DeregisterVaultAccessor` raft entry        | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.node_drain_update`                  | Time elapsed to apply `NodeDrainUpdate` raft entry                | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.node_eligibility_update`            | Time elapsed to apply `NodeEligibilityUpdate` raft entry          | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.node_status_update`                 | Time elapsed to apply `NodeStatusUpdate` raft entry               | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.persist`                            | Time elapsed to apply `Persist` raft entry                        | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.register_job`                       | Time elapsed to apply `RegisterJob` raft entry                    | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.register_node`                      | Time elapsed to apply `RegisterNode` raft entry                   | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.update_eval`                        | Time elapsed to apply `UpdateEval` raft entry                     | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.upsert_node_events`                 | Time elapsed to apply `UpsertNodeEvents` raft entry               | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.upsert_scaling_event`               | Time elapsed to apply `UpsertScalingEvent` raft entry             | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.upsert_si_accessor`                 | Time elapsed to apply `UpsertSITokenAccessors` raft entry         | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.fsm.upsert_vault_accessor`              | Time elapsed to apply `UpsertVaultAccessor` raft entry            | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.allocations`                        | Time elapsed for `Job.Allocations` RPC call                       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.batch_deregister`                   | Time elapsed for `Job.BatchDeregister` RPC call                   | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.deployments`                        | Time elapsed for `Job.Deployments` RPC call                       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.deregister`                         | Time elapsed for `Job.Deregister` RPC call                        | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.dispatch`                           | Time elapsed for `Job.Dispatch` RPC call                          | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.evaluate`                           | Time elapsed for `Job.Evaluate` RPC call                          | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.evaluations`                        | Time elapsed for `Job.Evaluations` RPC call                       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.get_job_versions`                   | Time elapsed for `Job.GetJobVersions` RPC call                    | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.get_job`                            | Time elapsed for `Job.GetJob` RPC call                            | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.latest_deployment`                  | Time elapsed for `Job.LatestDeployment` RPC call                  | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.list`                               | Time elapsed for `Job.List` RPC call                              | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.plan`                               | Time elapsed for `Job.Plan` RPC call                              | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.register`                           | Time elapsed for `Job.Register` RPC call                          | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.revert`                             | Time elapsed for `Job.Revert` RPC call                            | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.scale_status`                       | Time elapsed for `Job.ScaleStatus` RPC call                       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.scale`                              | Time elapsed for `Job.Scale` RPC call                             | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.stable`                             | Time elapsed for `Job.Stable` RPC call                            | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job.validate`                           | Time elapsed for `Job.Validate` RPC call                          | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.job_summary.get_job_summary`            | Time elapsed for `Job.Summary` RPC call                           | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.leader.barrier`                         | Time elapsed to establish a raft barrier during leader transition | Nanoseconds          | Summary | host   |
-| `nomad.nomad.leader.reconcileMember`                 | Time elapsed to reconcile a serf peer with state store            | Nanoseconds          | Summary | host   |
-| `nomad.nomad.leader.reconcile`                       | Time elapsed to reconcile all serf peers with state store         | Nanoseconds          | Summary | host   |
-| `nomad.nomad.namespace.delete_namespaces`            | Time elapsed for `Namespace.DeleteNamespaces`                     | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.namespace.get_namespace`                | Time elapsed for `Namespace.GetNamespace`                         | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.namespace.get_namespaces`               | Time elapsed for `Namespace.GetNamespaces`                        | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.namespace.list_namespace`               | Time elapsed for `Namespace.ListNamespaces`                       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.namespace.upsert_namespaces`            | Time elapsed for `Namespace.UpsertNamespaces`                     | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.periodic.force`                         | Time elapsed for `Periodic.Force` RPC call                        | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.plan.apply`                             | Time elapsed to apply a plan                                      | Nanoseconds          | Summary | host   |
-| `nomad.nomad.plan.evaluate`                          | Time elapsed to evaluate a plan                                   | Nanoseconds          | Summary | host   |
-| `nomad.nomad.plan.queue_depth`                       | Count of evals in the plan queue                                  | Integer              | Gauge   | host   |
-| `nomad.nomad.plan.submit`                            | Time elapsed for `Plan.Submit` RPC call                           | Nanoseconds          | Summary | host   |
-| `nomad.nomad.plan.wait_for_index`                    | Time elapsed for the planner to obtain a snapshot                 | Nanoseconds          | Summary | host   |
-| `nomad.nomad.plugin.delete`                          | Time elapsed for `CSIPlugin.Delete` RPC call                      | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.plugin.get`                             | Time elapsed for `CSIPlugin.Get` RPC call                         | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.plugin.list`                            | Time elapsed for `CSIPlugin.List` RPC call                        | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.scaling.get_policy`                     | Time elapsed for `Scaling.GetPolicy` RPC call                     | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.scaling.list_policies`                  | Time elapsed for `Scaling.ListPolicies` RPC call                  | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.search.prefix_search`                   | Time elapsed for `Search.PrefixSearch` RPC call                   | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.vault.create_token`                     | Time elapsed to create Vault token                                | Nanoseconds          | Gauge   | host   |
-| `nomad.nomad.vault.distributed_tokens_revoked`       | Count of revoked tokens                                           | Integer              | Gauge   | host   |
-| `nomad.nomad.vault.lookup_token`                     | Time elapsed to lookup Vault token                                | Nanoseconds          | Gauge   | host   |
-| `nomad.nomad.vault.renew_failed`                     | Count of failed attempts to renew Vault token                     | Integer              | Gauge   | host   |
-| `nomad.nomad.vault.renew`                            | Time elapsed to renew Vault token                                 | Nanoseconds          | Gauge   | host   |
-| `nomad.nomad.vault.revoke_tokens`                    | Time elapsed to revoke Vault tokens                               | Nanoseconds          | Gauge   | host   |
-| `nomad.nomad.vault.token_ttl`                        | Time to live for Vault token                                      | Integer              | Gauge   | host   |
-| `nomad.nomad.vault.undistributed_tokens_abandoned`   | Count of abandoned tokens                                         | Integer              | Gauge   | host   |
-| `nomad.nomad.volume.claim`                           | Time elapsed for `CSIVolume.Claim` RPC call                       | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.volume.deregister`                      | Time elapsed for `CSIVolume.Deregister` RPC call                  | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.volume.get`                             | Time elapsed for `CSIVolume.Get` RPC call                         | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.volume.list`                            | Time elapsed for `CSIVolume.List` RPC call                        | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.volume.register`                        | Time elapsed for `CSIVolume.Register` RPC call                    | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.volume.unpublish`                       | Time elapsed for `CSIVolume.Unpublish` RPC call                   | Nanoseconds          | Summary | Host   |
-| `nomad.nomad.worker.create_eval`                     | Time elapsed for worker to create an eval                         | Nanoseconds          | Summary | host   |
-| `nomad.nomad.worker.dequeue_eval`                    | Time elapsed for worker to dequeue an eval                        | Nanoseconds          | Summary | host   |
-| `nomad.nomad.worker.invoke_scheduler_service`        | Time elapsed for worker to invoke the scheduler                   | Nanoseconds          | Summary | host   |
-| `nomad.nomad.worker.send_ack`                        | Time elapsed for worker to send acknowledgement                   | Nanoseconds          | Summary | host   |
-| `nomad.nomad.worker.submit_plan`                     | Time elapsed for worker to submit plan                            | Nanoseconds          | Summary | host   |
-| `nomad.nomad.worker.update_eval`                     | Time elapsed for worker to submit updated eval                    | Nanoseconds          | Summary | host   |
-| `nomad.nomad.worker.wait_for_index`                  | Time elapsed for worker get snapshot                              | Nanoseconds          | Summary | host   |
-| `nomad.raft.appliedIndex`                            | Current index applied to FSM                                      | Integer              | Gauge   | host   |
-| `nomad.raft.barrier`                                 | Count of blocking raft API calls                                  | Integer              | Counter | host   |
-| `nomad.raft.commitNumLogs`                           | Count of logs enqueued                                            | Integer              | Gauge   | host   |
-| `nomad.raft.commitTime`                              | Time elapsed to commit writes                                     | Nanoseconds          | Summary | host   |
-| `nomad.raft.fsm.apply`                               | Time elapsed to apply write to FSM                                | Nanoseconds          | Summary | host   |
-| `nomad.raft.fsm.enqueue`                             | Time elapsed to enqueue write to FSM                              | Nanoseconds          | Summary | host   |
-| `nomad.raft.lastIndex`                               | Most recent index seen                                            | Integer              | Gauge   | host   |
-| `nomad.raft.leader.dispatchLog`                      | Time elapsed to write log, mark in flight, and start replication  | Nanoseconds          | Summary | host   |
-| `nomad.raft.leader.dispatchNumLogs`                  | Count of logs dispatched                                          | Integer              | Gauge   | host   |
-| `nomad.raft.replication.appendEntries`               | Raft transaction commit time                                      | ms / Raft Log Append | Timer   |        |
-| `nomad.raft.state.candidate`                         | Count of entering candidate state                                 | Integer              | Gauge   | host   |
-| `nomad.raft.state.follower`                          | Count of entering follower state                                  | Integer              | Gauge   | host   |
-| `nomad.raft.state.leader`                            | Count of entering leader state                                    | Integer              | Gauge   | host   |
-| `nomad.raft.transition.heartbeat_timeout`            | Count of failing to heartbeat and starting election               | Integer              | Gauge   | host   |
-| `nomad.raft.transition.leader_lease_timeout`         | Count of stepping down as leader after losing quorum              | Integer              | Gauge   | host   |
-| `nomad.runtime.free_count`                           | Count of objects freed from heap by go runtime GC                 | Integer              | Gauge   | host   |
-| `nomad.runtime.gc_pause_ns`                          | Go runtime GC pause times                                         | Nanoseconds          | Summary | host   |
-| `nomad.runtime.sys_bytes`                            | Go runtime GC metadata size                                       | # of bytes           | Gauge   | host   |
-| `nomad.runtime.total_gc_pause_ns`                    | Total elapsed go runtime GC pause times                           | Nanoseconds          | Gauge   | host   |
-| `nomad.runtime.total_gc_runs`                        | Count of go runtime GC runs                                       | Integer              | Gauge   | host   |
-| `nomad.serf.queue.Event`                             | Count of memberlist events received                               | Integer              | Summary | host   |
-| `nomad.serf.queue.Intent`                            | Count of memberlist changes                                       | Integer              | Summary | host   |
-| `nomad.serf.queue.Query`                             | Count of memberlist queries                                       | Integer              | Summary | host   |
-| `nomad.state.snapshotIndex`                          | Current snapshot index                                            | Integer              | Gauge   | host   |
+| Metric                                               | Description                                                       | Unit                 | Type    | Labels                       |
+| ---------------------------------------------------- | ----------------------------------------------------------------- | -------------------- | ------- | ---------------------------- |
+| `nomad.memberlist.gossip`                            | Time elapsed to broadcast gossip messages                         | Nanoseconds          | Summary | host                         |
+| `nomad.nomad.acl.bootstrap`                          | Time elapsed for `ACL.Bootstrap` RPC call                         | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.acl.delete_policies`                    | Time elapsed for `ACL.DeletePolicies` RPC call                    | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.acl.delete_tokens`                      | Time elapsed for `ACL.DeleteTokens` RPC call                      | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.acl.get_policies`                       | Time elapsed for `ACL.GetPolicies` RPC call                       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.acl.get_policy`                         | Time elapsed for `ACL.GetPolicy` RPC call                         | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.acl.get_token`                          | Time elapsed for `ACL.GetToken` RPC call                          | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.acl.get_tokens`                         | Time elapsed for `ACL.GetTokens` RPC call                         | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.acl.list_policies`                      | Time elapsed for `ACL.ListPolicies` RPC call                      | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.acl.list_tokens`                        | Time elapsed for `ACL.ListTokens` RPC call                        | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.acl.resolve_token`                      | Time elapsed for `ACL.ResolveToken` RPC call                      | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.acl.upsert_policies`                    | Time elapsed for `ACL.UpsertPolicies` RPC call                    | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.acl.upsert_tokens`                      | Time elapsed for `ACL.UpsertTokens` RPC call                      | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.alloc.exec`                             | Time elapsed to establish alloc exec                              | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.alloc.get_alloc`                        | Time elapsed for `Alloc.GetAlloc` RPC call                        | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.alloc.get_allocs`                       | Time elapsed for `Alloc.GetAllocs` RPC call                       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.alloc.list`                             | Time elapsed for `Alloc.List` RPC call                            | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.alloc.stop`                             | Time elapsed for `Alloc.Stop` RPC call                            | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.alloc.update_desired_transition`        | Time elapsed for `Alloc.UpdateDesiredTransition` RPC call         | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.blocked_evals.cpu`                      | Amount of CPU shares requested by blocked evals                   | Integer              | Gauge   | datacenter, host, node_class |
+| `nomad.nomad.blocked_evals.memory`                   | Amount of memory requested by blocked evals                       | Integer              | Gauge   | datacenter, host, node_class |
+| `nomad.nomad.blocked_evals.job.cpu`                  | Amount of CPU shares requested by blocked evals of a job          | Integer              | Gauge   | host, job, namespace         |
+| `nomad.nomad.blocked_evals.job.memory`               | Amount of memory requested by blocked evals of a job              | Integer              | Gauge   | host, job, namespace         |
+| `nomad.nomad.blocked_evals.total_blocked`            | Count of evals in the blocked state                               | Integer              | Gauge   | host                         |
+| `nomad.nomad.blocked_evals.total_escaped`            | Count of evals that have escaped computed node classes            | Integer              | Gauge   | host                         |
+| `nomad.nomad.blocked_evals.total_quota_limit`        | Count of blocked evals due to quota limits                        | Integer              | Gauge   | host                         |
+| `nomad.nomad.broker.batch_ready`                     | Count of batch evals ready to be scheduled                        | Integer              | Gauge   | host                         |
+| `nomad.nomad.broker.batch_unacked`                   | Count of unacknowledged batch evals                               | Integer              | Gauge   | host                         |
+| `nomad.nomad.broker.service_ready`                   | Count of service evals ready to be scheduled                      | Integer              | Gauge   | host                         |
+| `nomad.nomad.broker.service_unacked`                 | Count of unacknowledged service evals                             | Integer              | Gauge   | host                         |
+| `nomad.nomad.broker.system_ready`                    | Count of system evals ready to be scheduled                       | Integer              | Gauge   | host                         |
+| `nomad.nomad.broker.system_unacked`                  | Count of unacknowledged system evals                              | Integer              | Gauge   | host                         |
+| `nomad.nomad.broker.total_ready`                     | Count of evals in the ready state                                 | Integer              | Gauge   | host                         |
+| `nomad.nomad.broker.total_waiting`                   | Count of evals in the waiting state                               | Integer              | Gauge   | host                         |
+| `nomad.nomad.client.batch_deregister`                | Time elapsed for `Node.BatchDeregister` RPC call                  | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client.deregister`                      | Time elapsed for `Node.Deregister` RPC call                       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client.derive_si_token`                 | Time elapsed for `Node.DeriveSIToken` RPC call                    | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client.derive_vault_token`              | Time elapsed for `Node.DeriveVaultToken` RPC call                 | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client.emit_events`                     | Time elapsed for `Node.EmitEvents` RPC call                       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client.evaluate`                        | Time elapsed for `Node.Evaluate` RPC call                         | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client.get_allocs`                      | Time elapsed for `Node.GetAllocs` RPC call                        | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client.get_client_allocs`               | Time elapsed for `Node.GetClientAllocs` RPC call                  | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client.get_node`                        | Time elapsed for `Node.GetNode` RPC call                          | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client.list`                            | Time elapsed for `Node.List` RPC call                             | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client.register`                        | Time elapsed for `Node.Register` RPC call                         | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client.stats`                           | Time elapsed for `Client.Stats` RPC call                          | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client.update_alloc`                    | Time elapsed for `Node.UpdateAlloc` RPC call                      | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client.update_drain`                    | Time elapsed for `Node.UpdateDrain` RPC call                      | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client.update_eligibility`              | Time elapsed for `Node.UpdateEligibility` RPC call                | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client.update_status`                   | Time elapsed for `Node.UpdateStatus` RPC call                     | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client_allocations.garbage_collect_all` | Time elapsed for `ClientAllocations.GarbageCollectAll` RPC call   | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client_allocations.garbage_collect`     | Time elapsed for `ClientAllocations.GarbageCollect` RPC call      | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client_allocations.restart`             | Time elapsed for `ClientAllocations.Restart` RPC call             | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client_allocations.signal`              | Time elapsed for `ClientAllocations.Signal` RPC call              | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client_allocations.stats`               | Time elapsed for `ClientAllocations.Stats` RPC call               | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client_csi_controller.attach_volume`    | Time elapsed for `Controller.AttachVolume` RPC call               | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client_csi_controller.detach_volume`    | Time elapsed for `Controller.DetachVolume` RPC call               | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client_csi_controller.validate_volume`  | Time elapsed for `Controller.ValidateVolume` RPC call             | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.client_csi_node.detach_volume`          | Time elapsed for `Node.DetachVolume` RPC call                     | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.deployment.allocations`                 | Time elapsed for `Deployment.Allocations` RPC call                | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.deployment.cancel`                      | Time elapsed for `Deployment.Cancel` RPC call                     | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.deployment.fail`                        | Time elapsed for `Deployment.Fail` RPC call                       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.deployment.get_deployment`              | Time elapsed for `Deployment.GetDeployment` RPC call              | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.deployment.list`                        | Time elapsed for `Deployment.List` RPC call                       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.deployment.pause`                       | Time elapsed for `Deployment.Pause` RPC call                      | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.deployment.promote`                     | Time elapsed for `Deployment.Promote` RPC call                    | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.deployment.reap`                        | Time elapsed for `Deployment.Reap` RPC call                       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.deployment.run`                         | Time elapsed for `Deployment.Run` RPC call                        | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.deployment.set_alloc_health`            | Time elapsed for `Deployment.SetAllocHealth` RPC call             | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.deployment.unblock`                     | Time elapsed for `Deployment.Unblock` RPC call                    | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.eval.ack`                               | Time elapsed for `Eval.Ack` RPC call                              | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.eval.allocations`                       | Time elapsed for `Eval.Allocations` RPC call                      | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.eval.create`                            | Time elapsed for `Eval.Create` RPC call                           | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.eval.dequeue`                           | Time elapsed for `Eval.Dequeue` RPC call                          | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.eval.get_eval`                          | Time elapsed for `Eval.GetEval` RPC call                          | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.eval.list`                              | Time elapsed for `Eval.List` RPC call                             | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.eval.nack`                              | Time elapsed for `Eval.Nack` RPC call                             | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.eval.reap`                              | Time elapsed for `Eval.Reap` RPC call                             | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.eval.reblock`                           | Time elapsed for `Eval.Reblock` RPC call                          | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.eval.update`                            | Time elapsed for `Eval.Update` RPC call                           | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.file_system.list`                       | Time elapsed for `FileSystem.List` RPC call                       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.file_system.logs`                       | Time elapsed to establish `FileSystem.Logs` RPC                   | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.file_system.stat`                       | Time elapsed for `FileSystem.Stat` RPC call                       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.file_system.stream`                     | Time elapsed to establish `FileSystem.Stream` RPC                 | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.alloc_client_update`                | Time elapsed to apply `AllocClientUpdate` raft entry              | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.alloc_update_desired_transition`    | Time elapsed to apply `AllocUpdateDesiredTransition` raft entry   | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.alloc_update`                       | Time elapsed to apply `AllocUpdate` raft entry                    | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_acl_policy_delete`            | Time elapsed to apply `ApplyACLPolicyDelete` raft entry           | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_acl_policy_upsert`            | Time elapsed to apply `ApplyACLPolicyUpsert` raft entry           | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_acl_token_bootstrap`          | Time elapsed to apply `ApplyACLTokenBootstrap` raft entry         | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_acl_token_delete`             | Time elapsed to apply `ApplyACLTokenDelete` raft entry            | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_acl_token_upsert`             | Time elapsed to apply `ApplyACLTokenUpsert` raft entry            | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_csi_plugin_delete`            | Time elapsed to apply `ApplyCSIPluginDelete` raft entry           | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_csi_volume_batch_claim`       | Time elapsed to apply `ApplyCSIVolumeBatchClaim` raft entry       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_csi_volume_claim`             | Time elapsed to apply `ApplyCSIVolumeClaim` raft entry            | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_csi_volume_deregister`        | Time elapsed to apply `ApplyCSIVolumeDeregister` raft entry       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_csi_volume_register`          | Time elapsed to apply `ApplyCSIVolumeRegister` raft entry         | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_deployment_alloc_health`      | Time elapsed to apply `ApplyDeploymentAllocHealth` raft entry     | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_deployment_delete`            | Time elapsed to apply `ApplyDeploymentDelete` raft entry          | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_deployment_promotion`         | Time elapsed to apply `ApplyDeploymentPromotion` raft entry       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_deployment_status_update`     | Time elapsed to apply `ApplyDeploymentStatusUpdate` raft entry    | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_job_stability`                | Time elapsed to apply `ApplyJobStability` raft entry              | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_namespace_delete`             | Time elapsed to apply `ApplyNamespaceDelete` raft entry           | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_namespace_upsert`             | Time elapsed to apply `ApplyNamespaceUpsert` raft entry           | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_plan_results`                 | Time elapsed to apply `ApplyPlanResults` raft entry               | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.apply_scheduler_config`             | Time elapsed to apply `ApplySchedulerConfig` raft entry           | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.autopilot`                          | Time elapsed to apply `Autopilot` raft entry                      | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.batch_deregister_job`               | Time elapsed to apply `BatchDeregisterJob` raft entry             | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.batch_deregister_node`              | Time elapsed to apply `BatchDeregisterNode` raft entry            | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.batch_node_drain_update`            | Time elapsed to apply `BatchNodeDrainUpdate` raft entry           | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.cluster_meta`                       | Time elapsed to apply `ClusterMeta` raft entry                    | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.delete_eval`                        | Time elapsed to apply `DeleteEval` raft entry                     | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.deregister_job`                     | Time elapsed to apply `DeregisterJob` raft entry                  | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.deregister_node`                    | Time elapsed to apply `DeregisterNode` raft entry                 | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.deregister_si_accessor`             | Time elapsed to apply `DeregisterSITokenAccessor` raft entry      | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.deregister_vault_accessor`          | Time elapsed to apply `DeregisterVaultAccessor` raft entry        | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.node_drain_update`                  | Time elapsed to apply `NodeDrainUpdate` raft entry                | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.node_eligibility_update`            | Time elapsed to apply `NodeEligibilityUpdate` raft entry          | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.node_status_update`                 | Time elapsed to apply `NodeStatusUpdate` raft entry               | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.persist`                            | Time elapsed to apply `Persist` raft entry                        | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.register_job`                       | Time elapsed to apply `RegisterJob` raft entry                    | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.register_node`                      | Time elapsed to apply `RegisterNode` raft entry                   | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.update_eval`                        | Time elapsed to apply `UpdateEval` raft entry                     | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.upsert_node_events`                 | Time elapsed to apply `UpsertNodeEvents` raft entry               | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.upsert_scaling_event`               | Time elapsed to apply `UpsertScalingEvent` raft entry             | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.upsert_si_accessor`                 | Time elapsed to apply `UpsertSITokenAccessors` raft entry         | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.fsm.upsert_vault_accessor`              | Time elapsed to apply `UpsertVaultAccessor` raft entry            | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.allocations`                        | Time elapsed for `Job.Allocations` RPC call                       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.batch_deregister`                   | Time elapsed for `Job.BatchDeregister` RPC call                   | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.deployments`                        | Time elapsed for `Job.Deployments` RPC call                       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.deregister`                         | Time elapsed for `Job.Deregister` RPC call                        | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.dispatch`                           | Time elapsed for `Job.Dispatch` RPC call                          | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.evaluate`                           | Time elapsed for `Job.Evaluate` RPC call                          | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.evaluations`                        | Time elapsed for `Job.Evaluations` RPC call                       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.get_job_versions`                   | Time elapsed for `Job.GetJobVersions` RPC call                    | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.get_job`                            | Time elapsed for `Job.GetJob` RPC call                            | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.latest_deployment`                  | Time elapsed for `Job.LatestDeployment` RPC call                  | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.list`                               | Time elapsed for `Job.List` RPC call                              | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.plan`                               | Time elapsed for `Job.Plan` RPC call                              | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.register`                           | Time elapsed for `Job.Register` RPC call                          | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.revert`                             | Time elapsed for `Job.Revert` RPC call                            | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.scale_status`                       | Time elapsed for `Job.ScaleStatus` RPC call                       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.scale`                              | Time elapsed for `Job.Scale` RPC call                             | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.stable`                             | Time elapsed for `Job.Stable` RPC call                            | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job.validate`                           | Time elapsed for `Job.Validate` RPC call                          | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.job_summary.get_job_summary`            | Time elapsed for `Job.Summary` RPC call                           | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.leader.barrier`                         | Time elapsed to establish a raft barrier during leader transition | Nanoseconds          | Summary | host                         |
+| `nomad.nomad.leader.reconcileMember`                 | Time elapsed to reconcile a serf peer with state store            | Nanoseconds          | Summary | host                         |
+| `nomad.nomad.leader.reconcile`                       | Time elapsed to reconcile all serf peers with state store         | Nanoseconds          | Summary | host                         |
+| `nomad.nomad.namespace.delete_namespaces`            | Time elapsed for `Namespace.DeleteNamespaces`                     | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.namespace.get_namespace`                | Time elapsed for `Namespace.GetNamespace`                         | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.namespace.get_namespaces`               | Time elapsed for `Namespace.GetNamespaces`                        | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.namespace.list_namespace`               | Time elapsed for `Namespace.ListNamespaces`                       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.namespace.upsert_namespaces`            | Time elapsed for `Namespace.UpsertNamespaces`                     | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.periodic.force`                         | Time elapsed for `Periodic.Force` RPC call                        | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.plan.apply`                             | Time elapsed to apply a plan                                      | Nanoseconds          | Summary | host                         |
+| `nomad.nomad.plan.evaluate`                          | Time elapsed to evaluate a plan                                   | Nanoseconds          | Summary | host                         |
+| `nomad.nomad.plan.queue_depth`                       | Count of evals in the plan queue                                  | Integer              | Gauge   | host                         |
+| `nomad.nomad.plan.submit`                            | Time elapsed for `Plan.Submit` RPC call                           | Nanoseconds          | Summary | host                         |
+| `nomad.nomad.plan.wait_for_index`                    | Time elapsed for the planner to obtain a snapshot                 | Nanoseconds          | Summary | host                         |
+| `nomad.nomad.plugin.delete`                          | Time elapsed for `CSIPlugin.Delete` RPC call                      | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.plugin.get`                             | Time elapsed for `CSIPlugin.Get` RPC call                         | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.plugin.list`                            | Time elapsed for `CSIPlugin.List` RPC call                        | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.scaling.get_policy`                     | Time elapsed for `Scaling.GetPolicy` RPC call                     | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.scaling.list_policies`                  | Time elapsed for `Scaling.ListPolicies` RPC call                  | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.search.prefix_search`                   | Time elapsed for `Search.PrefixSearch` RPC call                   | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.vault.create_token`                     | Time elapsed to create Vault token                                | Nanoseconds          | Gauge   | host                         |
+| `nomad.nomad.vault.distributed_tokens_revoked`       | Count of revoked tokens                                           | Integer              | Gauge   | host                         |
+| `nomad.nomad.vault.lookup_token`                     | Time elapsed to lookup Vault token                                | Nanoseconds          | Gauge   | host                         |
+| `nomad.nomad.vault.renew_failed`                     | Count of failed attempts to renew Vault token                     | Integer              | Gauge   | host                         |
+| `nomad.nomad.vault.renew`                            | Time elapsed to renew Vault token                                 | Nanoseconds          | Gauge   | host                         |
+| `nomad.nomad.vault.revoke_tokens`                    | Time elapsed to revoke Vault tokens                               | Nanoseconds          | Gauge   | host                         |
+| `nomad.nomad.vault.token_ttl`                        | Time to live for Vault token                                      | Integer              | Gauge   | host                         |
+| `nomad.nomad.vault.undistributed_tokens_abandoned`   | Count of abandoned tokens                                         | Integer              | Gauge   | host                         |
+| `nomad.nomad.volume.claim`                           | Time elapsed for `CSIVolume.Claim` RPC call                       | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.volume.deregister`                      | Time elapsed for `CSIVolume.Deregister` RPC call                  | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.volume.get`                             | Time elapsed for `CSIVolume.Get` RPC call                         | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.volume.list`                            | Time elapsed for `CSIVolume.List` RPC call                        | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.volume.register`                        | Time elapsed for `CSIVolume.Register` RPC call                    | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.volume.unpublish`                       | Time elapsed for `CSIVolume.Unpublish` RPC call                   | Nanoseconds          | Summary | Host                         |
+| `nomad.nomad.worker.create_eval`                     | Time elapsed for worker to create an eval                         | Nanoseconds          | Summary | host                         |
+| `nomad.nomad.worker.dequeue_eval`                    | Time elapsed for worker to dequeue an eval                        | Nanoseconds          | Summary | host                         |
+| `nomad.nomad.worker.invoke_scheduler_service`        | Time elapsed for worker to invoke the scheduler                   | Nanoseconds          | Summary | host                         |
+| `nomad.nomad.worker.send_ack`                        | Time elapsed for worker to send acknowledgement                   | Nanoseconds          | Summary | host                         |
+| `nomad.nomad.worker.submit_plan`                     | Time elapsed for worker to submit plan                            | Nanoseconds          | Summary | host                         |
+| `nomad.nomad.worker.update_eval`                     | Time elapsed for worker to submit updated eval                    | Nanoseconds          | Summary | host                         |
+| `nomad.nomad.worker.wait_for_index`                  | Time elapsed for worker get snapshot                              | Nanoseconds          | Summary | host                         |
+| `nomad.raft.appliedIndex`                            | Current index applied to FSM                                      | Integer              | Gauge   | host                         |
+| `nomad.raft.barrier`                                 | Count of blocking raft API calls                                  | Integer              | Counter | host                         |
+| `nomad.raft.commitNumLogs`                           | Count of logs enqueued                                            | Integer              | Gauge   | host                         |
+| `nomad.raft.commitTime`                              | Time elapsed to commit writes                                     | Nanoseconds          | Summary | host                         |
+| `nomad.raft.fsm.apply`                               | Time elapsed to apply write to FSM                                | Nanoseconds          | Summary | host                         |
+| `nomad.raft.fsm.enqueue`                             | Time elapsed to enqueue write to FSM                              | Nanoseconds          | Summary | host                         |
+| `nomad.raft.lastIndex`                               | Most recent index seen                                            | Integer              | Gauge   | host                         |
+| `nomad.raft.leader.dispatchLog`                      | Time elapsed to write log, mark in flight, and start replication  | Nanoseconds          | Summary | host                         |
+| `nomad.raft.leader.dispatchNumLogs`                  | Count of logs dispatched                                          | Integer              | Gauge   | host                         |
+| `nomad.raft.replication.appendEntries`               | Raft transaction commit time                                      | ms / Raft Log Append | Timer   |                              |
+| `nomad.raft.state.candidate`                         | Count of entering candidate state                                 | Integer              | Gauge   | host                         |
+| `nomad.raft.state.follower`                          | Count of entering follower state                                  | Integer              | Gauge   | host                         |
+| `nomad.raft.state.leader`                            | Count of entering leader state                                    | Integer              | Gauge   | host                         |
+| `nomad.raft.transition.heartbeat_timeout`            | Count of failing to heartbeat and starting election               | Integer              | Gauge   | host                         |
+| `nomad.raft.transition.leader_lease_timeout`         | Count of stepping down as leader after losing quorum              | Integer              | Gauge   | host                         |
+| `nomad.runtime.free_count`                           | Count of objects freed from heap by go runtime GC                 | Integer              | Gauge   | host                         |
+| `nomad.runtime.gc_pause_ns`                          | Go runtime GC pause times                                         | Nanoseconds          | Summary | host                         |
+| `nomad.runtime.sys_bytes`                            | Go runtime GC metadata size                                       | # of bytes           | Gauge   | host                         |
+| `nomad.runtime.total_gc_pause_ns`                    | Total elapsed go runtime GC pause times                           | Nanoseconds          | Gauge   | host                         |
+| `nomad.runtime.total_gc_runs`                        | Count of go runtime GC runs                                       | Integer              | Gauge   | host                         |
+| `nomad.serf.queue.Event`                             | Count of memberlist events received                               | Integer              | Summary | host                         |
+| `nomad.serf.queue.Intent`                            | Count of memberlist changes                                       | Integer              | Summary | host                         |
+| `nomad.serf.queue.Query`                             | Count of memberlist queries                                       | Integer              | Summary | host                         |
+| `nomad.state.snapshotIndex`                          | Current snapshot index                                            | Integer              | Gauge   | host                         |
 
 [tagged-metrics]: /docs/telemetry/metrics#tagged-metrics


### PR DESCRIPTION
When an eval is blocked, it's often because of insufficient resources available. Nomad currently tracks now many evals are blocked, but it has not indication of how much resource is required to unblock them, or how where they are assigned to run.

This PR adds a new set of metrics that emit how much resource have been requested by blocked evals. The metrics are split into jobs, datacenters and node classes.

If a job spans multiple datacenters or node classes, they will all be updated, since adding more resources to any of them would be enough to unblock the eval.

This metric is emitted by the leader, since it is the only node in the cluster that has the proper scheduling information.

Missing work:
* [x] More tests
* [x] Update documentation