### PR TITLE
consul/connect: fix bug where ingress gateways could not use wildcard services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ BUG FIXES:
  * cli: Remove extra linefeeds in monitor.log files written by `nomad operator debug`. [[GH-10252](https://github.com/hashicorp/nomad/issues/10252)]
  * client: Fixed log formatting when killing tasks. [[GH-10135](https://github.com/hashicorp/nomad/issues/10135)]
  * client: Fixed a bug where small files would be assigned the wrong content type. [[GH-10348](https://github.com/hashicorp/nomad/pull/10348)]
+ * consul/connect: Fixed a bug where HTTP ingress gateways could not use wildcard names. [[GH-10457](https://github.com/hashicorp/nomad/pull/10457)]
  * csi: Fixed a bug where volume with IDs that are a substring prefix of another volume could use the wrong volume for feasibility checking. [[GH-10158](https://github.com/hashicorp/nomad/issues/10158)]
  * scheduler: Fixed a bug where Nomad reports negative or incorrect running children counts for periodic jobs. [[GH-10145](https://github.com/hashicorp/nomad/issues/10145)]
  * scheduler: Fixed a bug where jobs requesting multiple CSI volumes could be incorrectly scheduled if only one of the volumes passed feasibility checking. [[GH-10143](https://github.com/hashicorp/nomad/issues/10143)]

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -1106,6 +1106,20 @@ func TestConsulIngressService_Validate(t *testing.T) {
 		}).Validate(true)
 		require.NoError(t, err)
 	})
+
+	t.Run("http with wildcard service", func(t *testing.T) {
+		err := (&ConsulIngressService{
+			Name: "*",
+		}).Validate(true)
+		require.NoError(t, err)
+	})
+
+	t.Run("tcp with wildcard service", func(t *testing.T) {
+		err := (&ConsulIngressService{
+			Name: "*",
+		}).Validate(false)
+		require.EqualError(t, err, "Consul Ingress Service supports wildcard names only with HTTP protocol")
+	})
 }
 
 func TestConsulIngressListener_Validate(t *testing.T) {


### PR DESCRIPTION
This PR fixes a bug where Nomad was more restrictive on Ingress Gateway Configuration
Entry definitions than Consul. Before, Nomad would not allow for declaring IGCEs with
http listeners with service name "*", which is a [special feature](https://www.consul.io/docs/connect/config-entries/ingress-gateway#hosts) enabled by Consul.

Note: to make http protocol work, a `service-default` must be defined setting the
`protocol` to `http` for each service. (Setting `protocol` on the service definition in Consul is not possible)

Fixes: https://github.com/hashicorp/nomad/issues/9729