### PR TITLE
Fix "read the the" typo in filesystem.mdx file

### DIFF
--- a/website/content/docs/internals/filesystem.mdx
+++ b/website/content/docs/internals/filesystem.mdx
@@ -66,7 +66,7 @@ allocation directory like the one below.
 
   - **«taskname»/secrets/**: This directory is the location provided to the task as
     `NOMAD_SECRETS_DIR`. The contents of files in this directory cannot be read
-    the the `nomad alloc fs` command. It can be used to store secret data that
+    by the `nomad alloc fs` command. It can be used to store secret data that
     should not be visible outside the task.
 
   - **«taskname»/tmp/**: A temporary directory used as scratch space by task drivers.


### PR DESCRIPTION
The file had "read the the" but it should have been "read by the"