### PR TITLE
Check if "make sync" is running from a symlink

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -223,6 +223,10 @@ tidy:
 .PHONY: sync
 sync: tidy
 	@echo "--> Sync vendor directory"
+	@if [[ -L "$(shell pwd)" ]]; then \
+		echo "==> Failed to sync vendor directory: current directory is a symlink, please run \"make sync\" within the referenced directory instead."; \
+		exit 1; \
+		fi
 	@go mod vendor
 
 .PHONY: dev


### PR DESCRIPTION
If `make sync` runs inside a symlink it will remove the `vendor` directory.