### PR TITLE
License get command updates

### DIFF
--- a/command/license.go
+++ b/command/license.go
@@ -70,7 +70,6 @@ func outputLicenseInfo(ui cli.Ui, lic *api.License, expired bool) {
 		fmt.Sprintf("Customer ID|%s", lic.CustomerID),
 		fmt.Sprintf("Issued At|%s", lic.IssueTime),
 		expStr,
-		fmt.Sprintf("Terminates At|%s", lic.TerminationTime.String()),
 		fmt.Sprintf("Datacenter|%s", lic.InstallationID),
 	}
 	ui.Output(formatKV(output))


### PR DESCRIPTION
This changeset includes two small tweaks:
* In https://github.com/hashicorp/nomad/pull/10458 I missed porting over the updates to `license_get.go`
* Remove the deprecated `Terminates At` field from the command output so that it's not confusing to operators.