### PR TITLE
Allow configuring memory oversubscription

### DIFF
--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -71,6 +71,7 @@ func NewJobEndpoints(s *Server) *Job {
 			jobConnectHook{},
 			jobExposeCheckHook{},
 			jobValidate{},
+			&memoryOversubscriptionValidate{srv: s},
 		},
 	}
 }

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -213,3 +213,32 @@ func (jobValidate) Validate(job *structs.Job) (warnings []error, err error) {
 
 	return warnings, validationErrors.ErrorOrNil()
 }
+
+type memoryOversubscriptionValidate struct {
+	srv *Server
+}
+
+func (*memoryOversubscriptionValidate) Name() string {
+	return "memory_oversubscription"
+}
+
+func (v *memoryOversubscriptionValidate) Validate(job *structs.Job) (warnings []error, err error) {
+	_, c, err := v.srv.State().SchedulerConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if c != nil && c.MemoryOversubscriptionEnabled {
+		return nil, nil
+	}
+
+	for _, tg := range job.TaskGroups {
+		for _, t := range tg.Tasks {
+			if t.Resources != nil && t.Resources.MemoryMaxMB != 0 {
+				warnings = append(warnings, fmt.Errorf("Memory oversubscription is not enabled; Task %v.%v memory_max value will be ignored", tg.Name, t.Name))
+			}
+		}
+	}
+
+	return warnings, err
+}

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -235,7 +235,7 @@ func (v *memoryOversubscriptionValidate) Validate(job *structs.Job) (warnings []
 	for _, tg := range job.TaskGroups {
 		for _, t := range tg.Tasks {
 			if t.Resources != nil && t.Resources.MemoryMaxMB != 0 {
-				warnings = append(warnings, fmt.Errorf("Memory oversubscription is not enabled; Task %v.%v memory_max value will be ignored", tg.Name, t.Name))
+				warnings = append(warnings, fmt.Errorf("Memory oversubscription is not enabled; Task \"%v.%v\" memory_max value will be ignored. Update the Scheduler Configuration to allow oversubscription.", tg.Name, t.Name))
 			}
 		}
 	}

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -149,6 +149,8 @@ type SchedulerConfiguration struct {
 	// priority jobs to place higher priority jobs.
 	PreemptionConfig PreemptionConfig `hcl:"preemption_config"`
 
+	MemoryOversubscriptionEnabled bool `hcl:"memory_oversubscription"`
+
 	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
 	CreateIndex uint64
 	ModifyIndex uint64

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -149,7 +149,7 @@ type SchedulerConfiguration struct {
 	// priority jobs to place higher priority jobs.
 	PreemptionConfig PreemptionConfig `hcl:"preemption_config"`
 
-	MemoryOversubscriptionEnabled bool `hcl:"memory_oversubscription"`
+	MemoryOversubscriptionEnabled bool `hcl:"memory_oversubscription_enabled"`
 
 	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
 	CreateIndex uint64

--- a/scheduler/preemption_test.go
+++ b/scheduler/preemption_test.go
@@ -1349,7 +1349,7 @@ func TestPreemption(t *testing.T) {
 				ctx.plan.NodePreemptions[node.ID] = tc.currentPreemptions
 			}
 			static := NewStaticRankIterator(ctx, nodes)
-			binPackIter := NewBinPackIterator(ctx, static, true, tc.jobPriority, structs.SchedulerAlgorithmBinpack)
+			binPackIter := NewBinPackIterator(ctx, static, true, tc.jobPriority, testSchedulerConfig)
 			job := mock.Job()
 			job.Priority = tc.jobPriority
 			binPackIter.SetJob(job)

--- a/scheduler/rank_test.go
+++ b/scheduler/rank_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var testSchedulerConfig = &structs.SchedulerConfiguration{
+	SchedulerAlgorithm:            structs.SchedulerAlgorithmBinpack,
+	MemoryOversubscriptionEnabled: true,
+}
+
 func TestFeasibleRankIterator(t *testing.T) {
 	_, ctx := testContext(t)
 	var nodes []*structs.Node
@@ -107,7 +112,7 @@ func TestBinPackIterator_NoExistingAlloc(t *testing.T) {
 			},
 		},
 	}
-	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
+	binp := NewBinPackIterator(ctx, static, false, 0, testSchedulerConfig)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -220,7 +225,7 @@ func TestBinPackIterator_NoExistingAlloc_MixedReserve(t *testing.T) {
 			},
 		},
 	}
-	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
+	binp := NewBinPackIterator(ctx, static, false, 0, testSchedulerConfig)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -341,7 +346,7 @@ func TestBinPackIterator_Network_Success(t *testing.T) {
 			},
 		},
 	}
-	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
+	binp := NewBinPackIterator(ctx, static, false, 0, testSchedulerConfig)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -473,7 +478,7 @@ func TestBinPackIterator_Network_Failure(t *testing.T) {
 		},
 	}
 
-	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
+	binp := NewBinPackIterator(ctx, static, false, 0, testSchedulerConfig)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -619,7 +624,7 @@ func TestBinPackIterator_Network_Interpolation_Success(t *testing.T) {
 			},
 		},
 	}
-	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
+	binp := NewBinPackIterator(ctx, static, false, 0, testSchedulerConfig)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -730,7 +735,7 @@ func TestBinPackIterator_Host_Network_Interpolation_Absent_Value(t *testing.T) {
 		},
 	}
 
-	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
+	binp := NewBinPackIterator(ctx, static, false, 0, testSchedulerConfig)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -831,7 +836,7 @@ func TestBinPackIterator_Host_Network_Interpolation_Interface_Not_Exists(t *test
 		},
 	}
 
-	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
+	binp := NewBinPackIterator(ctx, static, false, 0, testSchedulerConfig)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -925,7 +930,7 @@ func TestBinPackIterator_PlannedAlloc(t *testing.T) {
 		},
 	}
 
-	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
+	binp := NewBinPackIterator(ctx, static, false, 0, testSchedulerConfig)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -1047,7 +1052,7 @@ func TestBinPackIterator_ReservedCores(t *testing.T) {
 			},
 		},
 	}
-	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
+	binp := NewBinPackIterator(ctx, static, false, 0, testSchedulerConfig)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -1157,7 +1162,7 @@ func TestBinPackIterator_ExistingAlloc(t *testing.T) {
 			},
 		},
 	}
-	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
+	binp := NewBinPackIterator(ctx, static, false, 0, testSchedulerConfig)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -1277,7 +1282,7 @@ func TestBinPackIterator_ExistingAlloc_PlannedEvict(t *testing.T) {
 		},
 	}
 
-	binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
+	binp := NewBinPackIterator(ctx, static, false, 0, testSchedulerConfig)
 	binp.SetTaskGroup(taskGroup)
 
 	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
@@ -1582,7 +1587,7 @@ func TestBinPackIterator_Devices(t *testing.T) {
 			}
 
 			static := NewStaticRankIterator(ctx, []*RankedNode{{Node: c.Node}})
-			binp := NewBinPackIterator(ctx, static, false, 0, structs.SchedulerAlgorithmBinpack)
+			binp := NewBinPackIterator(ctx, static, false, 0, testSchedulerConfig)
 			binp.SetTaskGroup(c.TaskGroup)
 
 			out := binp.Next()

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -255,13 +255,12 @@ func NewSystemStack(ctx Context) *SystemStack {
 	// by a particular task group. Enable eviction as system jobs are high
 	// priority.
 	_, schedConfig, _ := s.ctx.State().SchedulerConfig()
-	schedulerAlgorithm := schedConfig.EffectiveSchedulerAlgorithm()
 	enablePreemption := true
 	if schedConfig != nil {
 		enablePreemption = schedConfig.PreemptionConfig.SystemSchedulerEnabled
 	}
 
-	s.binPack = NewBinPackIterator(ctx, rankSource, enablePreemption, 0, schedulerAlgorithm)
+	s.binPack = NewBinPackIterator(ctx, rankSource, enablePreemption, 0, schedConfig)
 
 	// Apply score normalization
 	s.scoreNorm = NewScoreNormalizationIterator(ctx, s.binPack)
@@ -381,7 +380,7 @@ func NewGenericStack(batch bool, ctx Context) *GenericStack {
 	// Apply the bin packing, this depends on the resources needed
 	// by a particular task group.
 	_, schedConfig, _ := ctx.State().SchedulerConfig()
-	s.binPack = NewBinPackIterator(ctx, rankSource, false, 0, schedConfig.EffectiveSchedulerAlgorithm())
+	s.binPack = NewBinPackIterator(ctx, rankSource, false, 0, schedConfig)
 
 	// Apply the job anti-affinity iterator. This is to avoid placing
 	// multiple allocations on the same node for this job.


### PR DESCRIPTION
Cluster operators want to have better constrol over memory
oversubscription and may want to enable/disable it based on their
experience.

This PR adds a scheduler configuration field to control memory
oversubscription. It's additional field that can be set in the [API via Scheduler Config](https://www.nomadproject.io/api-docs/operator/scheduler), or [the agent server config](https://www.nomadproject.io/docs/configuration/server#configuring-scheduler-config).

I opted to have the memory oversubscription be an opt-in, but happy to change it.  To enable it, operators should call the API with:
```json
{
  "MemoryOversubscriptionEnabled": true
}
```

If memory oversubscription is disabled, submitting jobs specifying `memory_max` will get a "Memory oversubscription is not
enabled" warnings, but the jobs will be accepted without them accessing
the additional memory.

The warning message is like:
```
$ nomad job run /tmp/j
Job Warnings:
1 warning(s):

* Memory oversubscription is not enabled; Task cache.redis memory_max value will be ignored

==> Monitoring evaluation "7c444157"
    Evaluation triggered by job "example"
==> Monitoring evaluation "7c444157"
    Evaluation within deployment: "9d826f13"
    Allocation "aa5c3cad" created: node "9272088e", group "cache"
    Evaluation status changed: "pending" -> "complete"
==> Evaluation "7c444157" finished with status "complete"

# then you can examine the Alloc AllocatedResources to validate whether the task is allowed to exceed memory:
mars:scheduler notnoop$ nomad alloc status -json aa5c3cad | jq '.AllocatedResources.Tasks["redis"].Memory'
{
  "MemoryMB": 256,
  "MemoryMaxMB": 0
}
```


Would love feedback on the default state and the warning message!