### PR TITLE
ui: Add guard against missing namespace in Mirage

### DIFF
--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -589,7 +589,7 @@ export default function() {
     const transformedAllocs = matchedAllocs.models.map(alloc => ({
       ID: alloc.name,
       Scope: [
-        alloc.namespace.id,
+        (alloc.namespace || {}).id,
         alloc.id,
       ],
     }));


### PR DESCRIPTION
Similarly to [735f056](https://github.com/hashicorp/nomad/pull/10444/commits/735f0560f152f9580da2c035198f78483d4d35ed), this won’t happen with real data,
but can happen in the current Mirage factory setup.