### PR TITLE
Docs memory oversubscription

### DIFF
--- a/website/content/api-docs/operator/scheduler.mdx
+++ b/website/content/api-docs/operator/scheduler.mdx
@@ -45,6 +45,7 @@ $ curl \
     "CreateIndex": 5,
     "ModifyIndex": 5,
     "SchedulerAlgorithm": "spread",
+    "MemoryOversubscriptionEnabled": true,
     "PreemptionConfig": {
       "SystemSchedulerEnabled": true,
       "BatchSchedulerEnabled": false,
@@ -63,6 +64,8 @@ $ curl \
   settings mentioned below.
 
   - `SchedulerAlgorithm` `(string: "binpack")` - Specifies whether scheduler binpacks or spreads allocations on available nodes.
+
+  - `MemoryOversubscriptionEnabled` `(bool: false)` - When `true`, tasks may exceed their reserved memory limit, if the client has excess memory capacity. Tasks must specify [`memory_max`](/docs/job-specification/resources#memory_max) to take advantage of memory oversubscription.
 
   - `PreemptionConfig` `(PreemptionConfig)` - Options to enable preemption for various schedulers.
 
@@ -111,6 +114,7 @@ server state is authoritative.
 ```json
 {
   "SchedulerAlgorithm": "spread",
+  "MemoryOversubscriptionEnabled": false,
   "PreemptionConfig": {
     "SystemSchedulerEnabled": true,
     "BatchSchedulerEnabled": false,
@@ -122,6 +126,8 @@ server state is authoritative.
 - `SchedulerAlgorithm` `(string: "binpack")` - Specifies whether scheduler
   binpacks or spreads allocations on available nodes. Possible values are
   `"binpack"` and `"spread"`
+
+- `MemoryOversubscriptionEnabled` `(bool: false)` - When `true`, tasks may exceed their reserved memory limit, if the client has excess memory capacity. Tasks must specify [`memory_max`](/docs/job-specification/resources#memory_max) to take advantage of memory oversubscription.
 
 - `PreemptionConfig` `(PreemptionConfig)` - Options to enable preemption for
   various schedulers.

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -300,6 +300,8 @@ server {
   default_scheduler_config {
     scheduler_algorithm = "spread"
 
+    memory_oversubscription_enabled = true
+
     preemption_config {
       batch_scheduler_enabled   = true
       system_scheduler_enabled  = true

--- a/website/content/docs/job-specification/resources.mdx
+++ b/website/content/docs/job-specification/resources.mdx
@@ -34,7 +34,9 @@ job "docs" {
 
 - `cpu` `(int: 100)` - Specifies the CPU required to run this task in MHz.
 
-- `memory` `(int: 300)` - Specifies the memory required in MB
+- `memory` `(int: 300)` - Specifies the memory required in MB.
+
+- `memory_max` <code>(`int`: &lt;optional&gt;)</code> - Optionally, specifies the maximum memory the task may use, if the client has excess memory capacity, in MB.
 
 - `device` <code>([Device][]: &lt;optional&gt;)</code> - Specifies the device
   requirements. This may be repeated to request multiple device types.


### PR DESCRIPTION
Basic documentation for the job specification and scheduler configuration for memory oversubscription.  A concept doc is on its way.