### PR TITLE
docs: remove API doc for license PUT

### DIFF
--- a/website/content/api-docs/operator/license.mdx
+++ b/website/content/api-docs/operator/license.mdx
@@ -2,7 +2,7 @@
 layout: api
 page_title: License - Operator - HTTP API
 description: |-
-  The /operator/license endpoints allow for setting and retrieving the Nomad Enterprise License.
+  The /operator/license endpoints allow for retrieving the Nomad Enterprise License.
 ---
 
 # License Operator HTTP API
@@ -40,7 +40,7 @@ $ curl \
   "LastContact": 0,
   "LastIndex": 0,
   "License": {
-    "CustomerID": "temporary license customer",
+    "CustomerID": "customer name",
     "ExpirationTime": "2020-06-01T14:50:16.581304556-04:00",
     "Features": [
       "Automated Upgrades",
@@ -57,56 +57,12 @@ $ curl \
     },
     "InstallationID": "*",
     "IssueTime": "2020-06-01T08:50:16.581304556-04:00",
-    "LicenseID": "temporary-license",
+    "LicenseID": "6f706a45-bdac-4a70-968b-d93784894653",
     "Modules": ["governance-policy"],
     "Product": "nomad",
     "StartTime": "2020-06-01T08:50:16.581304556-04:00",
     "TerminationTime": "2020-06-01T14:50:16.581304556-04:00"
   },
   "RequestTime": 0
-}
-```
-
-## Updating the Nomad Enterprise License
-
-This endpoint updates the Nomad license.
-
-| Method | Path                   | Produces           |
-| ------ | ---------------------- | ------------------ |
-| `PUT`  | `/v1/operator/license` | `application/json` |
-
-The table below shows this endpoint's support for
-[blocking queries](/api-docs#blocking-queries) and
-[required ACLs](/api-docs#acls).
-
-| Blocking Queries | ACL Required     |
-| ---------------- | ---------------- |
-| `NO`             | `operator:write` |
-
-### Parameters
-
-- `force` `(bool: false)` Force the license to be applied. By default, Nomad
-  will only accept a new license if it is newer than the one currently applied
-  (specified by the license issue date). Use `force` to override and apply an
-  older, unexpired license.
-
-### Sample Payload
-
-The payload is the raw license blob.
-
-### Sample Request
-
-```shell-session
-$ curl \
-    --request PUT \
-    --data @nomad.license \
-    https://localhost:4646/v1/operator/license?force=true
-```
-
-### Sample Response
-
-```json
-{
-  "Index": 15
 }
 ```


### PR DESCRIPTION
This got missed in https://github.com/hashicorp/nomad/pull/10463