### PR TITLE
suggestion for git example - provide a real repo

### DIFF
--- a/website/content/docs/job-specification/artifact.mdx
+++ b/website/content/docs/job-specification/artifact.mdx
@@ -111,7 +111,7 @@ This example downloads the artifact from the provided GitHub URL and places it a
 
 ```hcl
 artifact {
-  source      = "git::https://github.com/example/nomad-examples"
+  source      = "git::https://github.com/hashicorp/nomad-guides"
   destination = "local/repo"
 }
 ```
@@ -142,7 +142,7 @@ options:
 
 ```hcl
 artifact {
-  source      = "git::https://github.com/example/nomad-examples"
+  source      = "git::https://github.com/hashicorp/nomad-guides"
   destination = "local/repo"
   options {
     ref = "main"


### PR DESCRIPTION
when troubleshooting it is better if this command will actually work (pointing to a real repository)