### PR TITLE
ui: Fix bug where switching topo viz allocation highlights doesn’t update charts

### DIFF
--- a/ui/app/components/primary-metric/allocation.hbs
+++ b/ui/app/components/primary-metric/allocation.hbs
@@ -10,7 +10,11 @@
     <StatsTimeSeries @data={{this.series}} @dataProp="data" >
       <:svg as |c|>
         {{#each (reverse this.series) as |series idx|}}
-          <c.Area @data={{series.data}} @colorScale={{this.colorScale}} @index={{idx}} />
+          <c.Area
+            @data={{series.data}}
+            @colorScale={{this.colorScale}}
+            @index={{idx}}
+            data-test-task-name={{series.name}} />
         {{/each}}
       </:svg>
       <:after as |c|>

--- a/ui/app/components/primary-metric/allocation.js
+++ b/ui/app/components/primary-metric/allocation.js
@@ -4,6 +4,7 @@ import { task, timeout } from 'ember-concurrency';
 import { assert } from '@ember/debug';
 import { inject as service } from '@ember/service';
 import { action, get, computed } from '@ember/object';
+import { dependentKeyCompat } from '@ember/object/compat';
 
 export default class AllocationPrimaryMetric extends Component {
   @service('stats-trackers-registry') statsTrackersRegistry;
@@ -18,6 +19,7 @@ export default class AllocationPrimaryMetric extends Component {
     return this.args.metric;
   }
 
+  @dependentKeyCompat
   get allocation() {
     return this.args.allocation;
   }

--- a/ui/tests/pages/topology.js
+++ b/ui/tests/pages/topology.js
@@ -1,4 +1,4 @@
-import { attribute, clickable, create, hasClass, text, visitable } from 'ember-cli-page-object';
+import { attribute, clickable, collection, create, hasClass, text, visitable } from 'ember-cli-page-object';
 
 import TopoViz from 'nomad-ui/tests/pages/components/topo-viz';
 import notification from 'nomad-ui/tests/pages/components/notification';
@@ -59,5 +59,11 @@ export default create({
 
     client: text('[data-test-client]'),
     visitClient: clickable('[data-test-client]'),
+
+    charts: collection('[data-test-primary-metric]', {
+      areas: collection('[data-test-chart-area]', {
+        taskName: attribute('data-test-task-name'),
+      }),
+    }),
   },
 });


### PR DESCRIPTION
This closes #10489. It adds `dependentKeyCompat` to the allocation getter so it works
as expected as a dependent key for the `tracker` computed property, as described [here](https://guides.emberjs.com/release/upgrading/current-edition/tracked-properties/#toc_backwards-compatibility):

> Note, however, that if you want to use a getter as a dependent key, you will need to use the `dependentKeyCompat` decorator. This allows you to refactor existing computed properties into getters without breaking existing code that observes them.

From the [documentation](https://api.emberjs.com/ember/release/functions/@ember%2Fobject%2Fcompat/dependentKeyCompat):

> In general, only properties which you _expect_ to be watched by older, untracked clases should be marked as dependency compatible. The decorator is meant as an interop layer for parts of Ember's older classic APIs, and should not be applied to every possible getter/setter in classes. The number of dependency compatible getters should be _minimized_ wherever possible. New application code should not need to use `@dependentKeyCompat`, since it is only for interoperation with older code.

I’d prefer to avoid computed properties altogether but my attempts in that vein failed, so I’m settling for this workaround.

You can see the failure [here](https://app.circleci.com/pipelines/github/hashicorp/nomad/15984/workflows/dae7e9a9-8deb-49cc-8257-4624bba925c4/jobs/153108) that asserts that the task names shown in the
allocation metrics change when the highlighted allocation changes.