### PR TITLE
docker: improve error message for auth helper

### DIFF
--- a/drivers/docker/utils.go
+++ b/drivers/docker/utils.go
@@ -156,12 +156,12 @@ func authFromHelper(helperName string) authBackend {
 		cmd.Stdin = strings.NewReader(repoInfo.Index.Name)
 		output, err := cmd.Output()
 		if err != nil {
-			switch err.(type) {
-			default:
-				return nil, err
-			case *exec.ExitError:
-				return nil, fmt.Errorf("%s with input %q failed with stderr: %s", helper, repo, err.Error())
+			exitErr, ok := err.(*exec.ExitError)
+			if ok {
+				return nil, fmt.Errorf(
+					"%s with input %q failed with stderr: %s", helper, repo, exitErr.Stderr)
 			}
+			return nil, err
 		}
 
 		var response map[string]string


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10480

The error returned from the stdlib's `exec` package is always a message with
the exit code of the exec'd process, not any error message that process might
have given us. This results in opaque failures for the Nomad user. Cast to an
`ExitError` so that we can access the output from stderr.

cc'ing @isabeldepapel @jsosulska b/c they shadowed on the issue triage for this one.