### PR TITLE
minor docs and cli update for reserved cores

### DIFF
--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -9,12 +9,13 @@ import (
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
+	"github.com/posener/complete"
+
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/restarts"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/posener/complete"
 )
 
 type AllocStatusCommand struct {
@@ -562,7 +563,11 @@ func (c *AllocStatusCommand) outputTaskResources(alloc *api.Allocation, task str
 	}
 
 	var resourcesOutput []string
-	resourcesOutput = append(resourcesOutput, "CPU|Memory|Disk|Addresses")
+	cpuHeader := "CPU"
+	if resource.Cores != nil && *resource.Cores > 0 {
+		cpuHeader = fmt.Sprintf("CPU (%v cores)", *resource.Cores)
+	}
+	resourcesOutput = append(resourcesOutput, fmt.Sprintf("%s|Memory|Disk|Addresses", cpuHeader))
 	firstAddr := ""
 	secondAddr := ""
 	if len(addr) > 0 {

--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -144,6 +144,10 @@ client {
 - `host_network` <code>([host_network](#host_network-stanza): nil)</code> - Registers
   additional host networks with the node that can be selected when port mapping.
 
+- `cgroup_parent` `(string: "/nomad")` - Specifies the cgroup parent for which cgroup
+  subsystems managed by Nomad will be mounted under. Currently this only applies to the
+  `cpuset` subsystems. This field is ignored on non Linux platforms.
+
 ### `chroot_env` Parameters
 
 Drivers based on [isolated fork/exec](/docs/drivers/exec) implement file

--- a/website/content/docs/job-specification/resources.mdx
+++ b/website/content/docs/job-specification/resources.mdx
@@ -34,6 +34,9 @@ job "docs" {
 
 - `cpu` `(int: 100)` - Specifies the CPU required to run this task in MHz.
 
+- `cores` <code>(`int`: &lt;optional&gt;)</code> - Specifies the number of CPU cores to reserve
+  for the task. This may not be used with `cpu`.
+
 - `memory` `(int: 300)` - Specifies the memory required in MB.
 
 - `memory_max` <code>(`int`: &lt;optional&gt;)</code> - Optionally, specifies the maximum memory the task may use, if the client has excess memory capacity, in MB.
@@ -45,6 +48,20 @@ job "docs" {
 
 The following examples only show the `resources` stanzas. Remember that the
 `resources` stanza is only valid in the placements listed above.
+
+### Cores
+
+This example specifies that the task requires 2 reserved cores. With this stanza, Nomad will find
+a client with enough spare capacity to reserve 2 cores exclusively for the task. Unlike the `cpu` field, the
+task will not share cpu time with any other tasks managed by Nomad on the client.
+
+```hcl
+resources {
+  cores = 2
+}
+```
+
+If `cores` and `cpu` are both defined in the same resource stanza, validation of the job will fail.
 
 ### Memory
 


### PR DESCRIPTION
This PR adds some minor docs for the new `cores` resource field as well as updating the output of `nomad alloc status` to include the number of reserved cores if specified.