### PR TITLE
Custom Connect Sidecar Checks

### DIFF
--- a/api/services.go
+++ b/api/services.go
@@ -189,9 +189,10 @@ func (cc *ConsulConnect) Canonicalize() {
 // ConsulSidecarService represents a Consul Connect SidecarService jobspec
 // stanza.
 type ConsulSidecarService struct {
-	Tags  []string     `hcl:"tags,optional"`
-	Port  string       `hcl:"port,optional"`
-	Proxy *ConsulProxy `hcl:"proxy,block"`
+	Tags   []string       `hcl:"tags,optional"`
+	Port   string         `hcl:"port,optional"`
+	Proxy  *ConsulProxy   `hcl:"proxy,block"`
+	Checks []ServiceCheck `hcl:"check,block"`
 }
 
 func (css *ConsulSidecarService) Canonicalize() {

--- a/command/agent/consul/connect_test.go
+++ b/command/agent/consul/connect_test.go
@@ -79,6 +79,42 @@ func TestConnect_newConnect(t *testing.T) {
 			},
 		}, asr.SidecarService)
 	})
+
+	t.Run("with sidecar and custom check", func(t *testing.T) {
+		asr, err := newConnect("redis-service-id", "redis", &structs.ConsulConnect{
+			Native: false,
+			SidecarService: &structs.ConsulSidecarService{
+				Tags: []string{"foo", "bar"},
+				Port: "connect-proxy-redis",
+				Checks: []*structs.ServiceCheck{
+					{
+						Type:     "tcp",
+						Interval: 5 * time.Second,
+						Timeout:  2 * time.Second,
+					},
+				},
+			},
+		}, testConnectNetwork, testConnectPorts)
+		require.NoError(t, err)
+		require.Equal(t, &api.AgentServiceRegistration{
+			Tags:    []string{"foo", "bar"},
+			Port:    3000,
+			Address: "192.168.30.1",
+			Proxy: &api.AgentServiceConnectProxyConfig{
+				Config: map[string]interface{}{
+					"bind_address": "0.0.0.0",
+					"bind_port":    3000,
+				},
+			},
+			Checks: api.AgentServiceChecks{
+				{
+					TCP:      "192.168.30.1:3000",
+					Interval: "5s",
+					Timeout:  "2s",
+				},
+			},
+		}, asr.SidecarService)
+	})
 }
 
 func TestConnect_connectSidecarRegistration(t *testing.T) {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1333,7 +1333,7 @@ func apiServiceChecksToStructs(in []api.ServiceCheck, defaultOnUpdate string) []
 			TaskName:      inc.TaskName,
 			OnUpdate:      onUpdate,
 		}
-		if check.CheckRestart != nil {
+		if inc.CheckRestart != nil {
 			check.CheckRestart = &structs.CheckRestart{
 				Limit:          inc.CheckRestart.Limit,
 				Grace:          *inc.CheckRestart.Grace,

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -2037,6 +2035,14 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 							SidecarService: &api.ConsulSidecarService{
 								Tags: []string{"f", "g"},
 								Port: "9000",
+
+								Checks: []api.ServiceCheck{
+									{
+										Type:     "TCP",
+										Interval: 10 * time.Second,
+										Timeout:  5 * time.Second,
+									},
+								},
 							},
 						},
 					},
@@ -2416,6 +2422,13 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 							SidecarService: &structs.ConsulSidecarService{
 								Tags: []string{"f", "g"},
 								Port: "9000",
+								Checks: []*structs.ServiceCheck{
+									{
+										Type:     "TCP",
+										Interval: 10 * time.Second,
+										Timeout:  5 * time.Second,
+									},
+								},
 							},
 						},
 					},
@@ -2605,9 +2618,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 
 	structsJob := ApiJobToStructJob(apiJob)
 
-	if diff := pretty.Diff(expected, structsJob); len(diff) > 0 {
-		t.Fatalf("bad:\n%s", strings.Join(diff, "\n"))
-	}
+	require.Equal(t, expected, structsJob)
 
 	systemAPIJob := &api.Job{
 		Stop:        helper.BoolToPtr(true),
@@ -2850,9 +2861,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 
 	systemStructsJob := ApiJobToStructJob(systemAPIJob)
 
-	if diff := pretty.Diff(expectedSystemJob, systemStructsJob); len(diff) > 0 {
-		t.Fatalf("bad:\n%s", strings.Join(diff, "\n"))
-	}
+	require.Equal(t, expectedSystemJob, systemStructsJob)
 }
 
 func TestJobs_ApiJobToStructsJobUpdate(t *testing.T) {

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -2,14 +2,13 @@ package jobspec
 
 import (
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	capi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/nomad/api"
-	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
 )
 
 // consts copied from nomad/structs package to keep jobspec isolated from rest of nomad
@@ -1254,6 +1253,33 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
+			"tg-service-connect-sidecar_check.hcl",
+			&api.Job{
+				ID:   stringToPtr("sidecar_task_name"),
+				Name: stringToPtr("sidecar_task_name"),
+				Type: stringToPtr("service"),
+				TaskGroups: []*api.TaskGroup{{
+					Name: stringToPtr("group"),
+					Services: []*api.Service{{
+						Name: "example",
+						Connect: &api.ConsulConnect{
+							Native: false,
+							SidecarService: &api.ConsulSidecarService{
+								Checks: []api.ServiceCheck{
+									{
+										Type:     "tcp",
+										Interval: 10 * time.Second,
+										Timeout:  2 * time.Second,
+									},
+								},
+							},
+						},
+					}},
+				}},
+			},
+			false,
+		},
+		{
 			"tg-service-connect-proxy.hcl",
 			&api.Job{
 				ID:   stringToPtr("service-connect-proxy"),
@@ -1608,26 +1634,20 @@ func TestParse(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Logf("Testing parse: %s", tc.File)
+		t.Run(tc.File, func(t *testing.T) {
+			t.Logf("Testing parse: %s", tc.File)
 
-		path, err := filepath.Abs(filepath.Join("./test-fixtures", tc.File))
-		if err != nil {
-			t.Fatalf("file: %s\n\n%s", tc.File, err)
-			continue
-		}
+			path, err := filepath.Abs(filepath.Join("./test-fixtures", tc.File))
+			require.NoError(t, err)
 
-		actual, err := ParseFile(path)
-		if (err != nil) != tc.Err {
-			t.Fatalf("file: %s\n\n%s", tc.File, err)
-			continue
-		}
-
-		if !reflect.DeepEqual(actual, tc.Result) {
-			for _, d := range pretty.Diff(actual, tc.Result) {
-				t.Logf(d)
+			actual, err := ParseFile(path)
+			if tc.Err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.Result, actual)
 			}
-			t.Fatalf("file: %s", tc.File)
-		}
+		})
 	}
 }
 

--- a/jobspec/test-fixtures/tg-service-connect-sidecar_check.hcl
+++ b/jobspec/test-fixtures/tg-service-connect-sidecar_check.hcl
@@ -1,0 +1,19 @@
+job "sidecar_task_name" {
+  type = "service"
+
+  group "group" {
+    service {
+      name = "example"
+
+      connect {
+        sidecar_service {
+          check {
+            type     = "tcp"
+            interval = "10s"
+            timeout  = "2s"
+          }
+        }
+      }
+    }
+  }
+}

--- a/vendor/github.com/hashicorp/nomad/api/services.go
+++ b/vendor/github.com/hashicorp/nomad/api/services.go
@@ -189,9 +189,10 @@ func (cc *ConsulConnect) Canonicalize() {
 // ConsulSidecarService represents a Consul Connect SidecarService jobspec
 // stanza.
 type ConsulSidecarService struct {
-	Tags  []string     `hcl:"tags,optional"`
-	Port  string       `hcl:"port,optional"`
-	Proxy *ConsulProxy `hcl:"proxy,block"`
+	Tags   []string       `hcl:"tags,optional"`
+	Port   string         `hcl:"port,optional"`
+	Proxy  *ConsulProxy   `hcl:"proxy,block"`
+	Checks []ServiceCheck `hcl:"check,block"`
 }
 
 func (css *ConsulSidecarService) Canonicalize() {


### PR DESCRIPTION
This is WIP PR to ensure I'm in the right path before committing to this approach.  This is all very foreign to me.

This PR adds supports for custom checks for connect's `sidecar_service`, in a similar fashion to normal services.  When specified, it overrides the hardcoded "Connect Sidecar Listening" TCP check inserted by Nomad.

A sample connect stanza might be:

```hcl
connect {
  sidecar_service {
    tags = ["mytest"]
    proxy {
      upstreams {
        destination_name = "count-api"
        local_bind_port  = 8080
      }
    }

    check {
      type     = "http"
      path     = "/"
      interval = "10s"
      timeout  = "3s"
    }
  }
}
```

I have few comments/questions that are inlined.

Related to #9773