### PR TITLE
client: fix multiple imports

### DIFF
--- a/client/alloc_endpoint_test.go
+++ b/client/alloc_endpoint_test.go
@@ -779,7 +779,7 @@ func TestAlloc_ExecStreaming_ACL_Basic(t *testing.T) {
 		{
 			Name:          "bad token",
 			Token:         tokenBad.SecretID,
-			ExpectedError: structs.ErrPermissionDenied.Error(),
+			ExpectedError: nstructs.ErrPermissionDenied.Error(),
 		},
 		{
 			Name:          "good token",
@@ -912,7 +912,7 @@ func TestAlloc_ExecStreaming_ACL_WithIsolation_Image(t *testing.T) {
 		{
 			Name:          "bad token",
 			Token:         tokenBad.SecretID,
-			ExpectedError: structs.ErrPermissionDenied.Error(),
+			ExpectedError: nstructs.ErrPermissionDenied.Error(),
 		},
 		{
 			Name:          "alloc-exec token",
@@ -1061,7 +1061,7 @@ func TestAlloc_ExecStreaming_ACL_WithIsolation_Chroot(t *testing.T) {
 		{
 			Name:          "bad token",
 			Token:         tokenBad.SecretID,
-			ExpectedError: structs.ErrPermissionDenied.Error(),
+			ExpectedError: nstructs.ErrPermissionDenied.Error(),
 		},
 		{
 			Name:          "alloc-exec token",
@@ -1205,12 +1205,12 @@ func TestAlloc_ExecStreaming_ACL_WithIsolation_None(t *testing.T) {
 		{
 			Name:          "bad token",
 			Token:         tokenBad.SecretID,
-			ExpectedError: structs.ErrPermissionDenied.Error(),
+			ExpectedError: nstructs.ErrPermissionDenied.Error(),
 		},
 		{
 			Name:          "alloc-exec token",
 			Token:         tokenAllocExec.SecretID,
-			ExpectedError: structs.ErrPermissionDenied.Error(),
+			ExpectedError: nstructs.ErrPermissionDenied.Error(),
 		},
 		{
 			Name:          "alloc-node-exec token",

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/nomad/client/config"
 	consulApi "github.com/hashicorp/nomad/client/consul"
 	"github.com/hashicorp/nomad/client/fingerprint"
-	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/pluginutils/catalog"
 	"github.com/hashicorp/nomad/helper/pluginutils/singleton"
@@ -1600,7 +1599,7 @@ func TestClient_hasLocalState(t *testing.T) {
 	c, cleanup := TestClient(t, nil)
 	defer cleanup()
 
-	c.stateDB = state.NewMemDB(c.logger)
+	c.stateDB = cstate.NewMemDB(c.logger)
 
 	t.Run("plain alloc", func(t *testing.T) {
 		alloc := mock.BatchAlloc()


### PR DESCRIPTION
This fixes three instances of multiple imports of the same package in `client`.