### PR TITLE
docs: clarify that a default update strategy is used when update strategy is omitted

### DIFF
--- a/website/content/docs/job-specification/group.mdx
+++ b/website/content/docs/job-specification/group.mdx
@@ -99,6 +99,9 @@ job "docs" {
   within this group. This can be specified multiple times, to add a task as part
   of the group.
 
+- `update` <code>([Update][update]: nil)</code> - Specifies the task's update
+  strategy. When omitted, a default update strategy is applied.
+
 - `vault` <code>([Vault][]: nil)</code> - Specifies the set of Vault policies
   required by all tasks in this group. Overrides a `vault` block set at the
   `job` level.

--- a/website/content/docs/job-specification/group.mdx
+++ b/website/content/docs/job-specification/group.mdx
@@ -271,5 +271,6 @@ group "second" {
 [restart]: /docs/job-specification/restart 'Nomad restart Job Specification'
 [service]: /docs/job-specification/service 'Nomad service Job Specification'
 [service_discovery]: /docs/integrations/consul-integration#service-discovery 'Nomad Service Discovery'
+[update]: /docs/job-specification/update 'Nomad update Job Specification'
 [vault]: /docs/job-specification/vault 'Nomad vault Job Specification'
 [volume]: /docs/job-specification/volume 'Nomad volume Job Specification'

--- a/website/content/docs/job-specification/job.mdx
+++ b/website/content/docs/job-specification/job.mdx
@@ -116,7 +116,7 @@ job "docs" {
   use. Nomad provides the `service`, `system` and `batch` schedulers.
 
 - `update` <code>([Update][update]: nil)</code> - Specifies the task's update
-  strategy. When omitted, rolling updates are disabled.
+  strategy. When omitted, a default update strategy is applied.
 
 - `vault` <code>([Vault][]: nil)</code> - Specifies the set of Vault policies
   required by all tasks in this job.

--- a/website/content/docs/job-specification/update.mdx
+++ b/website/content/docs/job-specification/update.mdx
@@ -4,7 +4,7 @@ page_title: update Stanza - Job Specification
 description: |-
   The "update" stanza specifies the group's update strategy. The update strategy
   is used to control things like rolling upgrades and canary deployments. If
-  omitted, rolling updates and canaries are disabled.
+  omitted, a default update strategy is applied.
 ---
 
 # `update` Stanza
@@ -18,7 +18,7 @@ description: |-
 
 The `update` stanza specifies the group's update strategy. The update strategy
 is used to control things like [rolling upgrades][rolling] and [canary
-deployments][canary]. If omitted, rolling updates and canaries are disabled. If
+deployments][canary]. If omitted, a default update strategy is applied. If
 specified at the job level, the configuration will apply to all groups within
 the job. If multiple `update` stanzas are specified, they are merged with the
 group stanza taking the highest precedence and then the job.


### PR DESCRIPTION
Fixes #10542

I have tried to clarify that a default update strategy is used if no update strategy is specified, see issue above. I'm not very familiar with Nomad, so could be very well that I missed something.

I believe this change in behaviour was introduced in https://github.com/hashicorp/nomad/pull/6191
