### PR TITLE
E2E: remove references to nomad_sha

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -80,8 +80,8 @@ Run `terraform output` for IP addresses and details.
 
 ### ...Deploy a Cluster of Mixed Nomad Versions
 
-The `variables.tf` file describes the `nomad_sha`, `nomad_version`, and
-`nomad_local_binary` variable that can be used for most circumstances. But if
+The `variables.tf` file describes the `nomad_version`, and
+`nomad_local_binary` variables that can be used for most circumstances. But if
 you want to deploy mixed Nomad versions, you can provide a list of versions in
 your `terraform.tfvars` file.
 
@@ -111,7 +111,7 @@ Use the `"custom"` profile as described above.
 
 ### ...Change the Nomad Version After Provisioning
 
-You can update the `nomad_sha` or `nomad_version` variables, or simply rebuild
-the binary you have at the `nomad_local_binary` path so that Terraform picks
-up the changes. Then run `terraform plan`/`terraform apply` again. This will
-update Nomad in place, making the minimum amount of changes necessary.
+You can update the `nomad_version` variable, or simply rebuild the binary you
+have at the `nomad_local_binary` path so that Terraform picks up the
+changes. Then run `terraform plan`/`terraform apply` again. This will update
+Nomad in place, making the minimum amount of changes necessary.

--- a/e2e/terraform/README.md
+++ b/e2e/terraform/README.md
@@ -49,19 +49,13 @@ You'll need to pass one of the following variables in either your
 
 * `nomad_local_binary`: provision this specific local binary of Nomad. This is
   a path to a Nomad binary on your own host. Ex. `nomad_local_binary =
-  "/home/me/nomad"`. This setting overrides `nomad_sha` or `nomad_version`.
-* `nomad_sha`: provision this specific sha from S3. This is a Nomad binary
-  identified by its full commit SHA that's stored in a shared s3 bucket that
-  Nomad team developers can access. That commit SHA can be from any branch
-  that's pushed to remote. Ex. `nomad_sha =
-  "0b6b475e7da77fed25727ea9f01f155a58481b6c"`. This setting overrides
-  `nomad_version`.
+  "/home/me/nomad"`. This setting overrides `nomad_version`.
 * `nomad_version`: provision this version from
   [releases.hashicorp.com](https://releases.hashicorp.com/nomad). Ex. `nomad_version
   = "0.10.2+ent"`
 
-If you want to deploy the Enterprise build of a specific SHA, include
-`-var 'nomad_enterprise=true'`.
+If you want to deploy the Enterprise build, include `-var
+'nomad_enterprise=true'`.
 
 If you want to bootstrap Nomad ACLs, include `-var 'nomad_acls=true'`.
 

--- a/e2e/terraform/terraform.full.tfvars
+++ b/e2e/terraform/terraform.full.tfvars
@@ -11,5 +11,8 @@ volumes                          = true
 
 # required to avoid picking up defaults from terraform.tfvars file
 nomad_version      = "" # default version for deployment
-nomad_sha          = "" # overrides nomad_version if set
-nomad_local_binary = "" # overrides nomad_sha and nomad_version if set
+nomad_local_binary = "" # overrides nomad_version if set
+
+# The nightly E2E runner will set a nomad_sha flag; this should not be used
+# outside of the nightly E2E runner and will usually fail because the build
+# will not be available

--- a/e2e/terraform/terraform.tfvars
+++ b/e2e/terraform/terraform.tfvars
@@ -10,10 +10,12 @@ vault                            = true
 volumes                          = false
 
 nomad_version      = "1.0.1" # default version for deployment
-nomad_sha          = ""      # overrides nomad_version if set
-nomad_local_binary = ""      # overrides nomad_sha and nomad_version if set
+nomad_local_binary = ""      # overrides nomad_version if set
 
 # Example overrides:
-# nomad_sha = "38e23b62a7700c96f4898be777543869499fea0a"
 # nomad_local_binary = "../../pkg/linux_amd64/nomad"
 # nomad_local_binary_client_windows_2016_amd64 = ["../../pkg/windows_amd64/nomad.exe"]
+
+# The nightly E2E runner will set a nomad_sha flag; this should not be used
+# outside of the nightly E2E runner and will usually fail because the build
+# will not be available

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -59,7 +59,7 @@ variable "profile" {
 # nomad_sha, nomad_version, or nomad_local_binary is set
 
 variable "nomad_sha" {
-  description = "The sha of Nomad to provision"
+  description = "The sha of Nomad to provision; only used for automated nightly testing"
   default     = ""
 }
 


### PR DESCRIPTION
The `nomad_sha` variable for E2E runs can only be used by the nightly E2E run and not by developers who are running E2E from Terraform directly. Remove these references from the documentation so that they're not misled.