### PR TITLE
Capture ACL Token from self API call for Reverse Proxy use-case

### DIFF
--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -15,8 +15,6 @@ export default class TokenService extends Service {
 
   aclEnabled = true;
 
-  @reads('fetchSelfToken.lastSuccessful.value') selfToken;
-
   @computed
   get secret() {
     return window.localStorage.nomadTokenSecret;
@@ -43,6 +41,8 @@ export default class TokenService extends Service {
     }
   })
   fetchSelfToken;
+
+  @reads('fetchSelfToken.lastSuccessful.value') selfToken;
 
   async exchangeOneTimeToken(oneTimeToken) {
     const TokenAdapter = getOwner(this).lookup('adapter:token');

--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -31,9 +31,7 @@ export default class TokenService extends Service {
   @task(function*() {
     const TokenAdapter = getOwner(this).lookup('adapter:token');
     try {
-      let token = yield TokenAdapter.findSelf();
-      this.secret = token.secret;
-      return token;
+      return yield TokenAdapter.findSelf();
     } catch (e) {
       const errors = e.errors ? e.errors.mapBy('detail') : [];
       if (errors.find(error => error === 'ACL support disabled')) {
@@ -51,10 +49,9 @@ export default class TokenService extends Service {
     this.secret = token.secret;
   }
 
-  @computed('secret', 'fetchSelfToken.lastSuccessful.value')
+  @computed('fetchSelfToken.lastSuccessful.value')
   get selfToken() {
-    if (this.secret) return this.get('fetchSelfToken.lastSuccessful.value');
-    return undefined;
+    return this.get('fetchSelfToken.lastSuccessful.value');
   }
 
   @task(function*() {

--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -1,6 +1,6 @@
 import Service, { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
-import { alias } from '@ember/object/computed';
+import { alias, reads } from '@ember/object/computed';
 import { getOwner } from '@ember/application';
 import { assign } from '@ember/polyfills';
 import { task } from 'ember-concurrency';
@@ -14,6 +14,8 @@ export default class TokenService extends Service {
   @service system;
 
   aclEnabled = true;
+
+  @reads('fetchSelfToken.lastSuccessful.value') selfToken;
 
   @computed
   get secret() {
@@ -47,11 +49,6 @@ export default class TokenService extends Service {
 
     const token = await TokenAdapter.exchangeOneTimeToken(oneTimeToken);
     this.secret = token.secret;
-  }
-
-  @computed('fetchSelfToken.lastSuccessful.value')
-  get selfToken() {
-    return this.get('fetchSelfToken.lastSuccessful.value');
   }
 
   @task(function*() {

--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -31,7 +31,9 @@ export default class TokenService extends Service {
   @task(function*() {
     const TokenAdapter = getOwner(this).lookup('adapter:token');
     try {
-      return yield TokenAdapter.findSelf();
+      let token = yield TokenAdapter.findSelf();
+      this.secret = token.secret;
+      return token;
     } catch (e) {
       const errors = e.errors ? e.errors.mapBy('detail') : [];
       if (errors.find(error => error === 'ACL support disabled')) {

--- a/ui/tests/acceptance/proxy-test.js
+++ b/ui/tests/acceptance/proxy-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable ember-a11y-testing/a11y-audit-called */ // Tests for non-UI behaviour.
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';

--- a/ui/tests/acceptance/proxy-test.js
+++ b/ui/tests/acceptance/proxy-test.js
@@ -1,0 +1,50 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import Jobs from 'nomad-ui/tests/pages/jobs/list';
+
+let managementToken;
+
+module('Acceptance | reverse proxy', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+
+    server.create('agent');
+    managementToken = server.create('token');
+
+    // Simulate a reverse proxy injecting X-Nomad-Token header for all requests
+    this._originalXMLHttpRequestSend = XMLHttpRequest.prototype.send;
+    (function(send) {
+      XMLHttpRequest.prototype.send = function(data) {
+        this.setRequestHeader('X-Nomad-Token', managementToken.secretId);
+        send.call(this, data);
+      };
+    })(this._originalXMLHttpRequestSend);
+  });
+
+  hooks.afterEach(function() {
+    XMLHttpRequest.prototype.send = this._originalXMLHttpRequestSend;
+  });
+
+  test('when token is inserted by a reverse proxy, the UI is adjusted', async function(assert) {
+    // when token is inserted by reserve proxy, the token is reverse proxy
+    const { secretId } = managementToken;
+
+    await Jobs.visit();
+    assert.ok(window.localStorage.nomadTokenSecret == null, 'No token secret set');
+
+    // Make sure that server received the header
+    assert.ok(
+      server.pretender.handledRequests
+        .mapBy('requestHeaders')
+        .every(headers => headers['X-Nomad-Token'] === secretId),
+      'The token header is always present'
+    );
+
+    assert.notOk(Jobs.runJobButton.isDisabled, 'Run job button is enabled');
+  });
+});


### PR DESCRIPTION
Proposed fix for issue #10561.

I looked into the source code and right now, the only places where a token secret is set are:
- https://github.com/hashicorp/nomad/blob/276644470e15f8e4b4dad967192d0ccf1e606417/ui/app/services/token.js#L49
- https://github.com/hashicorp/nomad/blob/276644470e15f8e4b4dad967192d0ccf1e606417/ui/app/controllers/settings/tokens.js#L43

We simply need to capture and store the secret in `TokenService` when call is made to the Token `self` API.

Here is a tentative implementation that I've tested here. I'm open for recommendations.