### PR TITLE
testing: fix leadership flapping in unit tests

### DIFF
--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -78,9 +78,9 @@ func TestServer(t testing.T, cb func(*Config)) (*Server, func()) {
 	config.SerfConfig.MemberlistConfig.GossipInterval = 100 * time.Millisecond
 
 	// Tighten the Raft timing
-	// config.RaftConfig.LeaderLeaseTimeout = 50 * time.Millisecond
-	// config.RaftConfig.HeartbeatTimeout = 50 * time.Millisecond
-	// config.RaftConfig.ElectionTimeout = 50 * time.Millisecond
+	config.RaftConfig.LeaderLeaseTimeout = 100 * time.Millisecond
+	config.RaftConfig.HeartbeatTimeout = 100 * time.Millisecond
+	config.RaftConfig.ElectionTimeout = 100 * time.Millisecond
 	config.RaftTimeout = 500 * time.Millisecond
 
 	// Disable Vault

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -78,9 +78,9 @@ func TestServer(t testing.T, cb func(*Config)) (*Server, func()) {
 	config.SerfConfig.MemberlistConfig.GossipInterval = 100 * time.Millisecond
 
 	// Tighten the Raft timing
-	config.RaftConfig.LeaderLeaseTimeout = 50 * time.Millisecond
-	config.RaftConfig.HeartbeatTimeout = 50 * time.Millisecond
-	config.RaftConfig.ElectionTimeout = 50 * time.Millisecond
+	// config.RaftConfig.LeaderLeaseTimeout = 50 * time.Millisecond
+	// config.RaftConfig.HeartbeatTimeout = 50 * time.Millisecond
+	// config.RaftConfig.ElectionTimeout = 50 * time.Millisecond
 	config.RaftTimeout = 500 * time.Millisecond
 
 	// Disable Vault


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10437

The [`nomad/testing.go`](https://github.com/hashicorp/nomad/blob/v1.1.0-rc1/nomad/testing.go#L72-L84) sets very tight default values for various raft timeouts, which may be leading to leadership flapping during unit test runs as described in https://github.com/hashicorp/nomad/issues/10437#issuecomment-840808496.

This PR is WIP to figure out whether removing this has widespread impact across the test suite.