### PR TITLE
Display confirmation message on 'nomad volume delete' and 'nomad volume deregister'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.1.1 (Unreleased)
 
 IMPROVEMENTS:
+* cli: Added success confirmation message for `nomad volume delete` and `nomad volume deregister`. [[GH-10591](https://github.com/hashicorp/nomad/issues/10591)]
 * cli: Cross-namespace `nomad job` commands will now select exact matches if the selection is unambiguous. [[GH-10648](https://github.com/hashicorp/nomad/issues/10648)]
 
 BUG FIXES:

--- a/command/volume_delete.go
+++ b/command/volume_delete.go
@@ -98,5 +98,6 @@ func (c *VolumeDeleteCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Ui.Output(fmt.Sprintf("Successfully deleted volume %q!", volID))
 	return 0
 }

--- a/command/volume_deregister.go
+++ b/command/volume_deregister.go
@@ -146,5 +146,6 @@ func (c *VolumeDeregisterCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Ui.Output(fmt.Sprintf("Successfully deregistered volume %q!", volID))
 	return 0
 }


### PR DESCRIPTION
Before:
<img width="458" alt="image" src="https://user-images.githubusercontent.com/775380/118191822-374b6b80-b413-11eb-91e7-174fc9846391.png">

After:
<img width="461" alt="image" src="https://user-images.githubusercontent.com/775380/118191876-43cfc400-b413-11eb-97e9-3355b498b9fb.png">
