### PR TITLE
feat: expose hcl1 property publicly

### DIFF
--- a/command/helpers.go
+++ b/command/helpers.go
@@ -380,7 +380,7 @@ READ:
 }
 
 type JobGetter struct {
-	hcl1 bool
+	Hcl1 bool
 
 	// The fields below can be overwritten for tests
 	testStdin io.Reader
@@ -444,7 +444,7 @@ func (j *JobGetter) ApiJobWithArgs(jpath string, vars []string, varfiles []strin
 	// Parse the JobFile
 	var jobStruct *api.Job
 	var err error
-	if j.hcl1 {
+	if j.Hcl1 {
 		jobStruct, err = jobspec.Parse(jobfile)
 	} else {
 		var buf bytes.Buffer

--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -124,7 +124,7 @@ func (c *JobPlanCommand) Run(args []string) int {
 	flagSet.BoolVar(&diff, "diff", true, "")
 	flagSet.BoolVar(&policyOverride, "policy-override", false, "")
 	flagSet.BoolVar(&verbose, "verbose", false, "")
-	flagSet.BoolVar(&c.JobGetter.hcl1, "hcl1", false, "")
+	flagSet.BoolVar(&c.JobGetter.Hcl1, "hcl1", false, "")
 	flagSet.Var(&varArgs, "var", "")
 	flagSet.Var(&varFiles, "var-file", "")
 

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -167,7 +167,7 @@ func (c *JobRunCommand) Run(args []string) int {
 	flagSet.BoolVar(&output, "output", false, "")
 	flagSet.BoolVar(&override, "policy-override", false, "")
 	flagSet.BoolVar(&preserveCounts, "preserve-counts", false, "")
-	flagSet.BoolVar(&c.JobGetter.hcl1, "hcl1", false, "")
+	flagSet.BoolVar(&c.JobGetter.Hcl1, "hcl1", false, "")
 	flagSet.StringVar(&checkIndexStr, "check-index", "", "")
 	flagSet.StringVar(&consulToken, "consul-token", "", "")
 	flagSet.StringVar(&consulNamespace, "consul-namespace", "", "")

--- a/command/job_validate.go
+++ b/command/job_validate.go
@@ -70,7 +70,7 @@ func (c *JobValidateCommand) Run(args []string) int {
 
 	flagSet := c.Meta.FlagSet(c.Name(), FlagSetNone)
 	flagSet.Usage = func() { c.Ui.Output(c.Help()) }
-	flagSet.BoolVar(&c.JobGetter.hcl1, "hcl1", false, "")
+	flagSet.BoolVar(&c.JobGetter.Hcl1, "hcl1", false, "")
 	flagSet.Var(&varArgs, "var", "")
 	flagSet.Var(&varFiles, "var-file", "")
 


### PR DESCRIPTION
This allows tools other than the nomad cli to use the JobGetter code as is for hcl1-based projects.

As far as my use case, I am writing a tool that will be used to submit multiple jobs and tail the resulting deployments until Nomad marks the deployments as complete. These job files all use hcl1, and won't be able to migrate to hcl2 in an uncontrolled fashion.