### PR TITLE
docs: update enterprise license page

### DIFF
--- a/website/content/docs/enterprise/license.mdx
+++ b/website/content/docs/enterprise/license.mdx
@@ -13,7 +13,7 @@ the cluster must have its own license. Nomad Enterprise can be downloaded from
 the [releases site].
 
 Click [here](https://www.hashicorp.com/go/nomad-enterprise) to set up a demo of Nomad Enterprise
-or [here](https://www.hashicorp.com/products/nomad/trial) to get a trial license.
+or [here](https://nomadproject.io/trial) to get a trial license.
 
 ~> **Note:** A Nomad Enterprise cluster cannot be downgraded to the open
 source version of Nomad. Servers running the open source version of Nomad will
@@ -77,6 +77,8 @@ immediately stop.
 See the server [license configuration] reference documentation on all the
 options to set an enterprise license. Nomad will load the license file from
 disk or environment when it starts.
+
+~> **Note:** An Enterprise license [tutorial](https://learn.hashicorp.com/tutorials/nomad/hashicorp-enterprise-license?in=nomad/enterprise) is available to help you install the license on the server.
 
 In order to immediately alert operators of a bad configuration setting, if a
 license configuration option is an invalid or expired license, the Nomad server


### PR DESCRIPTION
Added a link to the enterprise license tutorial and updated the trial link to use the recommended marketing url.