### PR TITLE
cli: Handle nil MemoryMaxMB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.1.1 (Unreleased)
 
+BUG FIXES:
+* cli: Fixed a bug where `quota status` and `namespace status` commands may panic if the CLI targets a pre-1.1.0 cluster
+
 ## 1.1.0 (May 18, 2021)
 
 FEATURES:

--- a/command/quota_status.go
+++ b/command/quota_status.go
@@ -189,14 +189,16 @@ func formatQuotaLimits(spec *api.QuotaSpec, usages map[string]*api.QuotaUsage) s
 			continue
 		}
 
-		cpu := fmt.Sprintf("%d / %s", *used.RegionLimit.CPU, formatQuotaLimitInt(specLimit.RegionLimit.CPU))
-		memory := fmt.Sprintf("%d / %s", *used.RegionLimit.MemoryMB, formatQuotaLimitInt(specLimit.RegionLimit.MemoryMB))
-
-		memMax := 0
-		if mm := used.RegionLimit.MemoryMaxMB; mm != nil {
-			memMax = *mm
+		orZero := func(v *int) int {
+			if v == nil {
+				return 0
+			}
+			return *v
 		}
-		memoryMax := fmt.Sprintf("%d / %s", memMax, formatQuotaLimitInt(specLimit.RegionLimit.MemoryMaxMB))
+
+		cpu := fmt.Sprintf("%d / %s", orZero(used.RegionLimit.CPU), formatQuotaLimitInt(specLimit.RegionLimit.CPU))
+		memory := fmt.Sprintf("%d / %s", orZero(used.RegionLimit.MemoryMB), formatQuotaLimitInt(specLimit.RegionLimit.MemoryMB))
+		memoryMax := fmt.Sprintf("%d / %s", orZero(used.RegionLimit.MemoryMaxMB), formatQuotaLimitInt(specLimit.RegionLimit.MemoryMaxMB))
 
 		net := fmt.Sprintf("- / %s", formatQuotaLimitInt(&specBits))
 		if len(used.RegionLimit.Networks) == 1 {

--- a/command/quota_status.go
+++ b/command/quota_status.go
@@ -191,7 +191,13 @@ func formatQuotaLimits(spec *api.QuotaSpec, usages map[string]*api.QuotaUsage) s
 
 		cpu := fmt.Sprintf("%d / %s", *used.RegionLimit.CPU, formatQuotaLimitInt(specLimit.RegionLimit.CPU))
 		memory := fmt.Sprintf("%d / %s", *used.RegionLimit.MemoryMB, formatQuotaLimitInt(specLimit.RegionLimit.MemoryMB))
-		memoryMax := fmt.Sprintf("%d / %s", *used.RegionLimit.MemoryMaxMB, formatQuotaLimitInt(specLimit.RegionLimit.MemoryMaxMB))
+
+		memMax := 0
+		if mm := used.RegionLimit.MemoryMaxMB; mm != nil {
+			memMax = *mm
+		}
+		memoryMax := fmt.Sprintf("%d / %s", memMax, formatQuotaLimitInt(specLimit.RegionLimit.MemoryMaxMB))
+
 		net := fmt.Sprintf("- / %s", formatQuotaLimitInt(&specBits))
 		if len(used.RegionLimit.Networks) == 1 {
 			net = fmt.Sprintf("%d / %s", *used.RegionLimit.Networks[0].MBits, formatQuotaLimitInt(&specBits))


### PR DESCRIPTION
Handle when MemoryMaxMB is nil, as expected when a new 1.1.0 is hitting a pre-1.1.0 Server.

With this change, we sill still display `Memory Max Usage` column, though it's not meaningful:

```
$ nomad namespace status default
Name        = default
Description = Default shared namespace
Quota       = default-quota

Quota Limits
Region  CPU Usage   Memory Usage  Memory Max Usage  Network Usage
global  500 / 2500  256 / 1000    0 / -             - / inf
```

Fixes https://github.com/hashicorp/nomad/issues/10619