### PR TITLE
Removed unsupported options from volume create

### DIFF
--- a/website/content/docs/commands/volume/create.mdx
+++ b/website/content/docs/commands/volume/create.mdx
@@ -61,10 +61,6 @@ secrets {
 parameters {
   skuname = "Premium_LRS"
 }
-
-context {
-  endpoint = "http://192.168.1.101:9425"
-}
 ```
 
 ## Volume Specification Parameters


### PR DESCRIPTION
Volume creation doesn't support the context (this would only be used for register)