### PR TITLE
CSI: Include MountOptions in capabilities sent to CSI for all RPCs

### DIFF
--- a/client/pluginmanager/csimanager/volume.go
+++ b/client/pluginmanager/csimanager/volume.go
@@ -127,11 +127,6 @@ func (v *volumeManager) ensureAllocDir(vol *structs.CSIVolume, alloc *structs.Al
 }
 
 func volumeCapability(vol *structs.CSIVolume, usage *UsageOptions) (*csi.VolumeCapability, error) {
-	capability, err := csi.VolumeCapabilityFromStructs(usage.AttachmentMode, usage.AccessMode)
-	if err != nil {
-		return nil, err
-	}
-
 	var opts *structs.CSIMountOptions
 	if vol.MountOptions == nil {
 		opts = usage.MountOptions
@@ -140,7 +135,10 @@ func volumeCapability(vol *structs.CSIVolume, usage *UsageOptions) (*csi.VolumeC
 		opts.Merge(usage.MountOptions)
 	}
 
-	capability.MountVolume = opts
+	capability, err := csi.VolumeCapabilityFromStructs(usage.AttachmentMode, usage.AccessMode, opts)
+	if err != nil {
+		return nil, err
+	}
 
 	return capability, nil
 }

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -417,6 +417,17 @@ func (v *CSIVolume) Claim(args *structs.CSIVolumeClaimRequest, reply *structs.CS
 	return nil
 }
 
+func csiVolumeMountOptions(c *structs.CSIMountOptions) *cstructs.CSIVolumeMountOptions {
+	if c == nil {
+		return nil
+	}
+
+	return &cstructs.CSIVolumeMountOptions{
+		Filesystem: c.FSType,
+		MountFlags: c.MountFlags,
+	}
+}
+
 // controllerPublishVolume sends publish request to the CSI controller
 // plugin associated with a volume, if any.
 func (v *CSIVolume) controllerPublishVolume(req *structs.CSIVolumeClaimRequest, resp *structs.CSIVolumeClaimResponse) error {
@@ -471,6 +482,7 @@ func (v *CSIVolume) controllerPublishVolume(req *structs.CSIVolumeClaimRequest, 
 		ClientCSINodeID: externalNodeID,
 		AttachmentMode:  req.AttachmentMode,
 		AccessMode:      req.AccessMode,
+		MountOptions:    csiVolumeMountOptions(vol.MountOptions),
 		ReadOnly:        req.Claim == structs.CSIVolumeClaimRead,
 		Secrets:         vol.Secrets,
 		VolumeContext:   vol.Context,
@@ -901,6 +913,7 @@ func (v *CSIVolume) createVolume(vol *structs.CSIVolume, plugin *structs.CSIPlug
 	cReq := &cstructs.ClientCSIControllerCreateVolumeRequest{
 		Name:               vol.Name,
 		VolumeCapabilities: vol.RequestedCapabilities,
+		MountOptions:       vol.MountOptions,
 		Parameters:         vol.Parameters,
 		Secrets:            vol.Secrets,
 		CapacityMin:        vol.RequestedCapacityMin,

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -886,7 +886,7 @@ type VolumeCapability struct {
 	MountVolume *structs.CSIMountOptions
 }
 
-func VolumeCapabilityFromStructs(sAccessType structs.CSIVolumeAttachmentMode, sAccessMode structs.CSIVolumeAccessMode) (*VolumeCapability, error) {
+func VolumeCapabilityFromStructs(sAccessType structs.CSIVolumeAttachmentMode, sAccessMode structs.CSIVolumeAccessMode, sMountOptions *structs.CSIMountOptions) (*VolumeCapability, error) {
 	var accessType VolumeAccessType
 	switch sAccessType {
 	case structs.CSIVolumeAttachmentModeBlockDevice:
@@ -922,8 +922,9 @@ func VolumeCapabilityFromStructs(sAccessType structs.CSIVolumeAttachmentMode, sA
 	}
 
 	return &VolumeCapability{
-		AccessType: accessType,
-		AccessMode: accessMode,
+		AccessType:  accessType,
+		AccessMode:  accessMode,
+		MountVolume: sMountOptions,
 	}, nil
 }
 


### PR DESCRIPTION
Include the VolumeCapability.MountVolume data in
ControllerPublishVolume, CreateVolume, and ValidateVolumeCapabilities
RPCs sent to the CSI controller. The previous behavior was to only
include the MountVolume capability in the NodeStageVolume request, which
on some CSI implementations would be rejected since the Volume was not
originally provisioned with the specific mount capabilities requested.