### PR TITLE
events: fix event endpoint tests to ignore heartbeats.

### DIFF
--- a/nomad/event_endpoint_test.go
+++ b/nomad/event_endpoint_test.go
@@ -1,6 +1,7 @@
 package nomad
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -96,7 +97,7 @@ OUTER:
 			}
 
 			// ignore heartbeat
-			if msg.Event == stream.JsonHeartbeat {
+			if bytes.Equal(msg.Event.Data, stream.JsonHeartbeat.Data) {
 				continue
 			}
 
@@ -283,7 +284,7 @@ OUTER:
 				t.Fatalf("Got error: %v", msg.Error.Error())
 			}
 
-			if msg.Event == stream.JsonHeartbeat {
+			if bytes.Equal(msg.Event.Data, stream.JsonHeartbeat.Data) {
 				continue
 			}
 


### PR DESCRIPTION
#10637 added initial heartbeat functionality to events and it
seems when this PR was raised, the Nomad CI provider was having
availability issues meaning the test suite was not correctly run,
thus allowing broken tests into main. The PR itself exercised test
code which had not been hit before.

The particular problem is when identifying whether the event
received is a heartbeat; this was performed using standard Golang
conditionals. Unfortunately the operator == is not defined on byte
arrays, resulting in the check always returning false. To overcome
this issue the code now uses the bytes.Equal function to correctly
compare the data.