### PR TITLE
cli: improve wildcard namespace prefix matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## 1.1.1 (Unreleased)
 
+IMPROVEMENTS:
+* cli: Cross-namespace `nomad job` commands will now select exact matches if the selection is unambiguous. [[GH-10648](https://github.com/hashicorp/nomad/issues/10648)]
+
 BUG FIXES:
 * api: Fixed event stream connection initialization when there are no events to send [[GH-10637](https://github.com/hashicorp/nomad/issues/10637)]
 * cli: Fixed a bug where `quota status` and `namespace status` commands may panic if the CLI targets a pre-1.1.0 cluster
+
 
 ## 1.1.0 (May 18, 2021)
 

--- a/command/job_deployments.go
+++ b/command/job_deployments.go
@@ -122,10 +122,17 @@ func (c *JobDeploymentsCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("No job(s) with prefix or id %q found", jobID))
 		return 1
 	}
-	if len(jobs) > 1 && (c.allNamespaces() || strings.TrimSpace(jobID) != jobs[0].ID) {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
-		return 1
+	if len(jobs) > 1 {
+		if strings.TrimSpace(jobID) != jobs[0].ID {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
+			return 1
+		}
+		if c.allNamespaces() && jobs[0].ID == jobs[1].ID {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
+			return 1
+		}
 	}
+
 	jobID = jobs[0].ID
 	q := &api.QueryOptions{Namespace: jobs[0].JobSummary.Namespace}
 

--- a/command/job_deployments.go
+++ b/command/job_deployments.go
@@ -110,7 +110,7 @@ func (c *JobDeploymentsCommand) Run(args []string) int {
 		return 1
 	}
 
-	jobID := args[0]
+	jobID := strings.TrimSpace(args[0])
 
 	// Check if the job exists
 	jobs, _, err := client.Jobs().PrefixList(jobID)
@@ -123,7 +123,7 @@ func (c *JobDeploymentsCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 {
-		if strings.TrimSpace(jobID) != jobs[0].ID {
+		if jobID != jobs[0].ID {
 			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 			return 1
 		}

--- a/command/job_history.go
+++ b/command/job_history.go
@@ -121,7 +121,7 @@ func (c *JobHistoryCommand) Run(args []string) int {
 		return 1
 	}
 
-	jobID := args[0]
+	jobID := strings.TrimSpace(args[0])
 
 	// Check if the job exists
 	jobs, _, err := client.Jobs().PrefixList(jobID)
@@ -134,7 +134,7 @@ func (c *JobHistoryCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 {
-		if strings.TrimSpace(jobID) != jobs[0].ID {
+		if jobID != jobs[0].ID {
 			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 			return 1
 		}

--- a/command/job_history.go
+++ b/command/job_history.go
@@ -133,9 +133,15 @@ func (c *JobHistoryCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("No job(s) with prefix or id %q found", jobID))
 		return 1
 	}
-	if len(jobs) > 1 && (c.allNamespaces() || strings.TrimSpace(jobID) != jobs[0].ID) {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
-		return 1
+	if len(jobs) > 1 {
+		if strings.TrimSpace(jobID) != jobs[0].ID {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
+			return 1
+		}
+		if c.allNamespaces() && jobs[0].ID == jobs[1].ID {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
+			return 1
+		}
 	}
 
 	q := &api.QueryOptions{Namespace: jobs[0].JobSummary.Namespace}

--- a/command/job_inspect.go
+++ b/command/job_inspect.go
@@ -117,7 +117,7 @@ func (c *JobInspectCommand) Run(args []string) int {
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}
-	jobID := args[0]
+	jobID := strings.TrimSpace(args[0])
 
 	// Check if the job exists
 	jobs, _, err := client.Jobs().PrefixList(jobID)
@@ -130,7 +130,7 @@ func (c *JobInspectCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 {
-		if strings.TrimSpace(jobID) != jobs[0].ID {
+		if jobID != jobs[0].ID {
 			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 			return 1
 		}

--- a/command/job_inspect.go
+++ b/command/job_inspect.go
@@ -129,9 +129,15 @@ func (c *JobInspectCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("No job(s) with prefix or id %q found", jobID))
 		return 1
 	}
-	if len(jobs) > 1 && (c.allNamespaces() || strings.TrimSpace(jobID) != jobs[0].ID) {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
-		return 1
+	if len(jobs) > 1 {
+		if strings.TrimSpace(jobID) != jobs[0].ID {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
+			return 1
+		}
+		if c.allNamespaces() && jobs[0].ID == jobs[1].ID {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
+			return 1
+		}
 	}
 
 	var version *uint64

--- a/command/job_promote.go
+++ b/command/job_promote.go
@@ -127,9 +127,15 @@ func (c *JobPromoteCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("No job(s) with prefix or id %q found", jobID))
 		return 1
 	}
-	if len(jobs) > 1 && (c.allNamespaces() || strings.TrimSpace(jobID) != jobs[0].ID) {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
-		return 1
+	if len(jobs) > 1 {
+		if strings.TrimSpace(jobID) != jobs[0].ID {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
+			return 1
+		}
+		if c.allNamespaces() && jobs[0].ID == jobs[1].ID {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
+			return 1
+		}
 	}
 	jobID = jobs[0].ID
 	q := &api.QueryOptions{Namespace: jobs[0].JobSummary.Namespace}

--- a/command/job_promote.go
+++ b/command/job_promote.go
@@ -117,7 +117,7 @@ func (c *JobPromoteCommand) Run(args []string) int {
 	}
 
 	// Check if the job exists
-	jobID := args[0]
+	jobID := strings.TrimSpace(args[0])
 	jobs, _, err := client.Jobs().PrefixList(jobID)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error promoting job: %s", err))
@@ -128,7 +128,7 @@ func (c *JobPromoteCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 {
-		if strings.TrimSpace(jobID) != jobs[0].ID {
+		if jobID != jobs[0].ID {
 			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 			return 1
 		}

--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -147,9 +147,15 @@ func (c *JobRevertCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("No job(s) with prefix or id %q found", jobID))
 		return 1
 	}
-	if len(jobs) > 1 && (c.allNamespaces() || strings.TrimSpace(jobID) != jobs[0].ID) {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
-		return 1
+	if len(jobs) > 1 {
+		if strings.TrimSpace(jobID) != jobs[0].ID {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
+			return 1
+		}
+		if c.allNamespaces() && jobs[0].ID == jobs[1].ID {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
+			return 1
+		}
 	}
 
 	// Prefix lookup matched a single job

--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -126,7 +126,7 @@ func (c *JobRevertCommand) Run(args []string) int {
 		vaultToken = os.Getenv("VAULT_TOKEN")
 	}
 
-	jobID := args[0]
+	jobID := strings.TrimSpace(args[0])
 	revertVersion, ok, err := parseVersion(args[1])
 	if !ok {
 		c.Ui.Error("The job version to revert to must be specified using the -job-version flag")
@@ -148,7 +148,7 @@ func (c *JobRevertCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 {
-		if strings.TrimSpace(jobID) != jobs[0].ID {
+		if jobID != jobs[0].ID {
 			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 			return 1
 		}

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -146,7 +146,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 	}
 
 	// Try querying the job
-	jobID := args[0]
+	jobID := strings.TrimSpace(args[0])
 
 	jobs, _, err := client.Jobs().PrefixList(jobID)
 	if err != nil {
@@ -158,7 +158,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 {
-		if strings.TrimSpace(jobID) != jobs[0].ID {
+		if jobID != jobs[0].ID {
 			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, allNamespaces)))
 			return 1
 		}

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -157,10 +157,17 @@ func (c *JobStatusCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("No job(s) with prefix or id %q found", jobID))
 		return 1
 	}
-	if len(jobs) > 1 && (allNamespaces || strings.TrimSpace(jobID) != jobs[0].ID) {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, allNamespaces)))
-		return 1
+	if len(jobs) > 1 {
+		if strings.TrimSpace(jobID) != jobs[0].ID {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, allNamespaces)))
+			return 1
+		}
+		if allNamespaces && jobs[0].ID == jobs[1].ID {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, allNamespaces)))
+			return 1
+		}
 	}
+
 	// Prefix lookup matched a single job
 	q := &api.QueryOptions{Namespace: jobs[0].JobSummary.Namespace}
 	job, _, err := client.Jobs().Info(jobs[0].ID, q)

--- a/command/job_stop.go
+++ b/command/job_stop.go
@@ -135,10 +135,17 @@ func (c *JobStopCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("No job(s) with prefix or id %q found", jobID))
 		return 1
 	}
-	if len(jobs) > 1 && (c.allNamespaces() || strings.TrimSpace(jobID) != jobs[0].ID) {
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
-		return 1
+	if len(jobs) > 1 {
+		if strings.TrimSpace(jobID) != jobs[0].ID {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
+			return 1
+		}
+		if c.allNamespaces() && jobs[0].ID == jobs[1].ID {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
+			return 1
+		}
 	}
+
 	// Prefix lookup matched a single job
 	q := &api.QueryOptions{Namespace: jobs[0].JobSummary.Namespace}
 	job, _, err := client.Jobs().Info(jobs[0].ID, q)

--- a/command/job_stop.go
+++ b/command/job_stop.go
@@ -116,7 +116,7 @@ func (c *JobStopCommand) Run(args []string) int {
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}
-	jobID := args[0]
+	jobID := strings.TrimSpace(args[0])
 
 	// Get the HTTP client
 	client, err := c.Meta.Client()
@@ -136,7 +136,7 @@ func (c *JobStopCommand) Run(args []string) int {
 		return 1
 	}
 	if len(jobs) > 1 {
-		if strings.TrimSpace(jobID) != jobs[0].ID {
+		if jobID != jobs[0].ID {
 			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
 			return 1
 		}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10625

When a wildcard namespace is used for `nomad job` commands that support prefix
matching, avoid asking the user for input if a prefix is an unambiguous exact
match so that the behavior is similar to the commands using a specific or
unset namespace.