### PR TITLE
csi: validate `volume` block has `attachment_mode` and `access_mode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 * cli: Added success confirmation message for `nomad volume delete` and `nomad volume deregister`. [[GH-10591](https://github.com/hashicorp/nomad/issues/10591)]
 * cli: Cross-namespace `nomad job` commands will now select exact matches if the selection is unambiguous. [[GH-10648](https://github.com/hashicorp/nomad/issues/10648)]
+* csi: Validate that `volume` blocks for CSI volumes include the required `attachment_mode` and `access_mode` fields. [[GH-10651](https://github.com/hashicorp/nomad/issues/10651)]
 
 BUG FIXES:
 * api: Fixed event stream connection initialization when there are no events to send [[GH-10637](https://github.com/hashicorp/nomad/issues/10637)]

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -811,8 +811,10 @@ func TestJobEndpoint_Register_ACL(t *testing.T) {
 				ReadOnly: readonlyVolume,
 			},
 			"csi": {
-				Type:   structs.VolumeTypeCSI,
-				Source: "prod-db",
+				Type:           structs.VolumeTypeCSI,
+				Source:         "prod-db",
+				AttachmentMode: structs.CSIVolumeAttachmentModeBlockDevice,
+				AccessMode:     structs.CSIVolumeAccessModeSingleNodeWriter,
 			},
 		}
 

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1127,6 +1127,8 @@ func TestTaskGroup_Validate(t *testing.T) {
 	err = tg.Validate(&Job{})
 	require.Contains(t, err.Error(), `volume has an empty source`)
 	require.Contains(t, err.Error(), `volume cannot be per_alloc when canaries are in use`)
+	require.Contains(t, err.Error(), `CSI volumes must have an attachment mode`)
+	require.Contains(t, err.Error(), `CSI volumes must have an access mode`)
 
 	tg = &TaskGroup{
 		Volumes: map[string]*VolumeRequest{

--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -117,6 +117,18 @@ func (v *VolumeRequest) Validate(canaries int) error {
 		mErr.Errors = append(mErr.Errors,
 			fmt.Errorf("host volumes cannot have an access mode"))
 	}
+	if v.Type == VolumeTypeHost && v.MountOptions != nil {
+		mErr.Errors = append(mErr.Errors,
+			fmt.Errorf("host volumes cannot have mount options"))
+	}
+	if v.Type == VolumeTypeCSI && v.AttachmentMode == CSIVolumeAttachmentModeUnknown {
+		mErr.Errors = append(mErr.Errors,
+			fmt.Errorf("CSI volumes must have an attachment mode"))
+	}
+	if v.Type == VolumeTypeCSI && v.AccessMode == CSIVolumeAccessModeUnknown {
+		mErr.Errors = append(mErr.Errors,
+			fmt.Errorf("CSI volumes must have an access mode"))
+	}
 
 	if v.AccessMode == CSIVolumeAccessModeSingleNodeReader || v.AccessMode == CSIVolumeAccessModeMultiNodeReader {
 		if !v.ReadOnly {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10645

The `attachment_mode` and `access_mode` fields are required for CSI
volumes. The `mount_options` block is only allowed for CSI volumes.