### PR TITLE
e2e: Spin clusters with custom url binaries

### DIFF
--- a/e2e/terraform/README.md
+++ b/e2e/terraform/README.md
@@ -50,6 +50,7 @@ You'll need to pass one of the following variables in either your
 * `nomad_local_binary`: provision this specific local binary of Nomad. This is
   a path to a Nomad binary on your own host. Ex. `nomad_local_binary =
   "/home/me/nomad"`. This setting overrides `nomad_version`.
+* `nomad_url`: provision this version from a binary, e.g. `build-binaries` CircleCI artifacts zip file urls.
 * `nomad_version`: provision this version from
   [releases.hashicorp.com](https://releases.hashicorp.com/nomad). Ex. `nomad_version
   = "0.10.2+ent"`

--- a/e2e/terraform/README.md
+++ b/e2e/terraform/README.md
@@ -50,7 +50,7 @@ You'll need to pass one of the following variables in either your
 * `nomad_local_binary`: provision this specific local binary of Nomad. This is
   a path to a Nomad binary on your own host. Ex. `nomad_local_binary =
   "/home/me/nomad"`. This setting overrides `nomad_version`.
-* `nomad_url`: provision this version from a binary, e.g. `build-binaries` CircleCI artifacts zip file urls.
+* `nomad_url`: provision this version from a remote archived binary, e.g. `build-binaries` CircleCI artifacts zip file urls.
 * `nomad_version`: provision this version from
   [releases.hashicorp.com](https://releases.hashicorp.com/nomad). Ex. `nomad_version
   = "0.10.2+ent"`

--- a/e2e/terraform/nomad.tf
+++ b/e2e/terraform/nomad.tf
@@ -93,6 +93,9 @@ module "nomad_client_windows_2016_amd64" {
   # if nomad_local_binary is in use, you must pass a nomad_local_binary_client_windows_2016_amd64!
   nomad_local_binary = count.index < length(var.nomad_local_binary_client_windows_2016_amd64) ? var.nomad_local_binary_client_windows_2016_amd64[count.index] : ""
 
+  # if nomad_url is in use, you must pass a nomad_url_client_windows_2016_amd64!
+  nomad_url = count.index < length(var.nomad_url_client_windows_2016_amd64) ? var.nomad_url_client_windows_2016_amd64[count.index] : ""
+
   nomad_enterprise = var.nomad_enterprise
   nomad_acls       = false
   cluster_name     = local.random_name

--- a/e2e/terraform/packer/build
+++ b/e2e/terraform/packer/build
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -u
 set -e

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/provision.sh
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/provision.sh
@@ -75,6 +75,26 @@ install_from_release() {
     set_ownership
 }
 
+install_from_url() {
+    # check that we don't already have this version
+    if [ "$(command -v nomad)" ]; then
+        nomad -version | grep -v 'dev' | grep -q "${NOMAD_VERSION}" \
+            && echo "$NOMAD_VERSION already installed" && return
+    fi
+
+    case "${NOMAD_URL}" in
+        *.zip*)
+            curl -sL --fail -o /tmp/nomad.zip "$NOMAD_URL"
+            sudo unzip -o /tmp/nomad.zip -d "$INSTALL_DIR"
+            ;;
+        *.tar.gz*)
+            curl -sL --fail -o /tmp/nomad.zip "$NOMAD_URL"
+            sudo tar -zxvf nomad.tar.gz -C "$INSTALL_DIR"
+            ;;
+    esac
+    set_ownership
+}
+
 set_ownership() {
     sudo chmod 0755 "$INSTALL_PATH"
     sudo chown root:root "$INSTALL_PATH"
@@ -146,6 +166,12 @@ opt="$1"
             if [ -z "$2" ]; then echo "Missing file parameter"; usage; fi
             NOMAD_UPLOADED_BINARY="$2"
             install_fn=install_from_uploaded_binary
+            shift 2
+            ;;
+        --nomad_url)
+            if [ -z "$2" ]; then echo "Missing URL parameter"; usage; fi
+            NOMAD_URL="$2"
+            install_fn=install_from_url
             shift 2
             ;;
         --config_profile)

--- a/e2e/terraform/packer/windows-2016-amd64/provision.ps1
+++ b/e2e/terraform/packer/windows-2016-amd64/provision.ps1
@@ -53,18 +53,6 @@ function Usage {
 }
 
 function InstallFromS3 {
-
-    Try {
-        # check that we don't already have this version
-        if (C:\opt\nomad.exe -version `
-          | Select-String -Pattern $nomad_sha -SimpleMatch -Quiet) {
-              Write-Output "${nomad_sha} already installed"
-              return
-          }
-    } Catch {
-        Write-Output "${nomad_sha} not previously installed"
-    }
-
     Stop-Service -Name nomad -ErrorAction Ignore
 
     $build_folder = "builds-oss"
@@ -158,20 +146,6 @@ function InstallFromRelease {
 }
 
 function InstallFromURL {
-    Try {
-        # check that we don't already have this version
-        if (C:\opt\nomad.exe -version `
-          | Select-String -Pattern $nomad_version -SimpleMatch -Quiet) {
-              if (C:\opt\nomad.exe -version `
-                | Select-String -Pattern dev -SimpleMatch -Quiet -NotMatch) {
-                    Write-Output "${nomad_version} already installed"
-                    return
-                }
-          }
-    } Catch {
-        Write-Output "${nomad_version} not previously installed"
-    }
-
     Stop-Service -Name nomad -ErrorAction Ignore
 
     Write-Output "Downloading Nomad from: $nomad_url"

--- a/e2e/terraform/provision-nomad/main.tf
+++ b/e2e/terraform/provision-nomad/main.tf
@@ -43,15 +43,19 @@ resource "null_resource" "provision_nomad" {
 }
 
 data "template_file" "provision_script" {
-  template = "${local.provision_script}${data.template_file.arg_nomad_sha.rendered}${data.template_file.arg_nomad_version.rendered}${data.template_file.arg_nomad_binary.rendered}${data.template_file.arg_nomad_enterprise.rendered}${data.template_file.arg_nomad_license.rendered}${data.template_file.arg_nomad_acls.rendered}${data.template_file.arg_profile.rendered}${data.template_file.arg_role.rendered}${data.template_file.arg_index.rendered}${data.template_file.autojoin_tag.rendered}"
+  template = "${local.provision_script}${data.template_file.arg_nomad_url.rendered}${data.template_file.arg_nomad_sha.rendered}${data.template_file.arg_nomad_version.rendered}${data.template_file.arg_nomad_binary.rendered}${data.template_file.arg_nomad_enterprise.rendered}${data.template_file.arg_nomad_license.rendered}${data.template_file.arg_nomad_acls.rendered}${data.template_file.arg_profile.rendered}${data.template_file.arg_role.rendered}${data.template_file.arg_index.rendered}${data.template_file.autojoin_tag.rendered}"
 }
 
 data "template_file" "arg_nomad_sha" {
-  template = var.nomad_sha != "" && var.nomad_local_binary == "" ? " ${local._arg}nomad_sha ${var.nomad_sha}" : ""
+  template = var.nomad_sha != "" && var.nomad_local_binary == "" && var.nomad_url == "" ? " ${local._arg}nomad_sha ${var.nomad_sha}" : ""
 }
 
 data "template_file" "arg_nomad_version" {
-  template = var.nomad_version != "" && var.nomad_sha == "" && var.nomad_local_binary == "" ? " ${local._arg}nomad_version ${var.nomad_version}" : ""
+  template = var.nomad_version != "" && var.nomad_sha == "" && var.nomad_url == "" && var.nomad_local_binary == "" ? " ${local._arg}nomad_version ${var.nomad_version}" : ""
+}
+
+data "template_file" "arg_nomad_url" {
+  template = var.nomad_url != "" && var.nomad_local_binary == "" ? " ${local._arg}nomad_url ${var.nomad_url}" : ""
 }
 
 data "template_file" "arg_nomad_binary" {

--- a/e2e/terraform/provision-nomad/variables.tf
+++ b/e2e/terraform/provision-nomad/variables.tf
@@ -22,6 +22,12 @@ variable "nomad_local_binary" {
   default     = ""
 }
 
+variable "nomad_url" {
+  type        = string
+  description = "URL to Nomad binary (ex. \"https://circleci.com/.../linux_amd64.zip\")"
+  default     = ""
+}
+
 variable "nomad_enterprise" {
   type        = bool
   description = "If nomad_sha is used, deploy Nomad Enterprise"

--- a/e2e/terraform/terraform.tfvars
+++ b/e2e/terraform/terraform.tfvars
@@ -11,6 +11,7 @@ volumes                          = false
 
 nomad_version      = "1.0.1" # default version for deployment
 nomad_local_binary = ""      # overrides nomad_version if set
+nomad_url          = ""      # overrides nomad_version if set
 
 # Example overrides:
 # nomad_local_binary = "../../pkg/linux_amd64/nomad"

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -73,6 +73,11 @@ variable "nomad_local_binary" {
   default     = ""
 }
 
+variable "nomad_url" {
+  description = "the URL to Nomad binary archives e.g. CircleCI artifacts"
+  default     = ""
+}
+
 variable "nomad_enterprise" {
   type        = bool
   description = "If nomad_sha is used, deploy Nomad Enterprise"
@@ -121,7 +126,13 @@ variable "nomad_sha_server" {
 }
 
 variable "nomad_local_binary_server" {
-  description = "A list of Nomad SHAs to deploy to servers, to override nomad_sha"
+  description = "A list of nomad local binary paths to deploy to servers, to override nomad_local_binary"
+  type        = list(string)
+  default     = []
+}
+
+variable "nomad_url_server" {
+  description = "A list of Nomad binary archive URLs to deploy to servers, to override nomad_url"
   type        = list(string)
   default     = []
 }
@@ -139,7 +150,13 @@ variable "nomad_sha_client_ubuntu_bionic_amd64" {
 }
 
 variable "nomad_local_binary_client_ubuntu_bionic_amd64" {
-  description = "A list of Nomad SHAs to deploy to Ubuntu Bionic clients, to override nomad_sha"
+  description = "A list of nomad local binary paths to deploy to Ubuntu Bionic clients, to override nomad_local_binary"
+  type        = list(string)
+  default     = []
+}
+
+variable "nomad_url_client_ubuntu_bionic_amd64" {
+  description = "A list of Nomad binary archive URLs to deploy to Ubuntu Bionic clients, to override nomad_url"
   type        = list(string)
   default     = []
 }
@@ -157,7 +174,13 @@ variable "nomad_sha_client_windows_2016_amd64" {
 }
 
 variable "nomad_local_binary_client_windows_2016_amd64" {
-  description = "A list of Nomad SHAs to deploy to Windows 2016 clients, to override nomad_sha"
+  description = "A list of nomad local binary paths to deploy to Windows 2016 clients, to override nomad_local_binary"
+  type        = list(string)
+  default     = []
+}
+
+variable "nomad_url_client_windows_2016_amd64" {
+  description = "A list of Nomad binary archive URLs to deploy to Windows 2016 clients, to override nomad_url"
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
Ease spinning up a cluster, where binaries are fetched from arbitrary urls.  These could be CircleCI `build-binaries` job artifacts, or presigned S3 urls.