### PR TITLE
consul/connect: add support for connect mesh gateways

### DIFF
--- a/api/services.go
+++ b/api/services.go
@@ -281,17 +281,81 @@ func (cp *ConsulProxy) Canonicalize() {
 		cp.Upstreams = nil
 	}
 
+	for i := 0; i < len(cp.Upstreams); i++ {
+		cp.Upstreams[i].Canonicalize()
+	}
+
 	if len(cp.Config) == 0 {
 		cp.Config = nil
 	}
 }
 
+// ConsulMeshGateway is used to configure mesh gateway usage when connecting to
+// a connect upstream in another datacenter.
+type ConsulMeshGateway struct {
+	// Mode configures how an upstream should be accessed with regard to using
+	// mesh gateways.
+	//
+	// local - the connect proxy makes outbound connections through mesh gateway
+	// originating in the same datacenter.
+	//
+	// remote - the connect proxy makes outbound connections to a mesh gateway
+	// in the destination datacenter.
+	//
+	// none (default) - no mesh gateway is used, the proxy makes outbound connections
+	// directly to destination services.
+	//
+	// https://www.consul.io/docs/connect/gateways/mesh-gateway#modes-of-operation
+	Mode string `mapstructure:"mode" hcl:"mode,optional"`
+}
+
+func (c *ConsulMeshGateway) Canonicalize() {
+	if c == nil {
+		return
+	}
+
+	if c.Mode == "" {
+		c.Mode = "none"
+	}
+}
+
+func (c *ConsulMeshGateway) Copy() *ConsulMeshGateway {
+	if c == nil {
+		return nil
+	}
+
+	return &ConsulMeshGateway{
+		Mode: c.Mode,
+	}
+}
+
 // ConsulUpstream represents a Consul Connect upstream jobspec stanza.
 type ConsulUpstream struct {
-	DestinationName  string `mapstructure:"destination_name" hcl:"destination_name,optional"`
-	LocalBindPort    int    `mapstructure:"local_bind_port" hcl:"local_bind_port,optional"`
-	Datacenter       string `mapstructure:"datacenter" hcl:"datacenter,optional"`
-	LocalBindAddress string `mapstructure:"local_bind_address" hcl:"local_bind_address,optional"`
+	DestinationName  string             `mapstructure:"destination_name" hcl:"destination_name,optional"`
+	LocalBindPort    int                `mapstructure:"local_bind_port" hcl:"local_bind_port,optional"`
+	Datacenter       string             `mapstructure:"datacenter" hcl:"datacenter,optional"`
+	LocalBindAddress string             `mapstructure:"local_bind_address" hcl:"local_bind_address,optional"`
+	MeshGateway      *ConsulMeshGateway `mapstructure:"mesh_gateway" hcl:"mesh_gateway,block"`
+}
+
+func (cu *ConsulUpstream) Copy() *ConsulUpstream {
+	if cu == nil {
+		return nil
+	}
+	return &ConsulUpstream{
+		DestinationName:  cu.DestinationName,
+		LocalBindPort:    cu.LocalBindPort,
+		Datacenter:       cu.Datacenter,
+		LocalBindAddress: cu.LocalBindAddress,
+		MeshGateway:      cu.MeshGateway.Copy(),
+	}
+}
+
+func (cu *ConsulUpstream) Canonicalize() {
+	if cu == nil {
+		return
+	}
+	cu.MeshGateway.Canonicalize()
 }
 
 type ConsulExposeConfig struct {
@@ -326,8 +390,8 @@ type ConsulGateway struct {
 	// Terminating represents the Consul Configuration Entry for a Terminating Gateway.
 	Terminating *ConsulTerminatingConfigEntry `hcl:"terminating,block"`
 
-	// Mesh is not yet supported.
-	// Mesh *ConsulMeshConfigEntry
+	// Mesh indicates the Consul service should be a Mesh Gateway.
+	Mesh *ConsulMeshConfigEntry `hcl:"mesh,block"`
 }
 
 func (g *ConsulGateway) Canonicalize() {
@@ -643,6 +707,21 @@ func (e *ConsulTerminatingConfigEntry) Copy() *ConsulTerminatingConfigEntry {
 	}
 }
 
-// ConsulMeshConfigEntry is not yet supported.
-// type ConsulMeshConfigEntry struct {
-// }
+// ConsulMeshConfigEntry is a stub used to represent that the gateway service type
+// should be for a Mesh Gateway. Unlike Ingress and Terminating, there is no
+// actual Consul Config Entry type for mesh-gateway, at least for now. We still
+// create a type for future proofing, instead just using a bool for example.
+type ConsulMeshConfigEntry struct {
+	// nothing in here
+}
+
+func (e *ConsulMeshConfigEntry) Canonicalize() {
+	return
+}
+
+func (e *ConsulMeshConfigEntry) Copy() *ConsulMeshConfigEntry {
+	if e == nil {
+		return nil
+	}
+	return new(ConsulMeshConfigEntry)
+}

--- a/api/services.go
+++ b/api/services.go
@@ -281,8 +281,8 @@ func (cp *ConsulProxy) Canonicalize() {
 		cp.Upstreams = nil
 	}
 
-	for i := 0; i < len(cp.Upstreams); i++ {
-		cp.Upstreams[i].Canonicalize()
+	for _, upstream := range cp.Upstreams {
+		upstream.Canonicalize()
 	}
 
 	if len(cp.Config) == 0 {

--- a/api/services.go
+++ b/api/services.go
@@ -310,13 +310,9 @@ type ConsulMeshGateway struct {
 }
 
 func (c *ConsulMeshGateway) Canonicalize() {
-	if c == nil {
-		return
-	}
-
-	if c.Mode == "" {
-		c.Mode = "none"
-	}
+	// Mode may be empty string, indicating behavior will defer to Consul
+	// service-defaults config entry.
+	return
 }
 
 func (c *ConsulMeshGateway) Copy() *ConsulMeshGateway {

--- a/api/services_test.go
+++ b/api/services_test.go
@@ -214,6 +214,68 @@ func TestService_Connect_ConsulProxy_Canonicalize(t *testing.T) {
 		require.Nil(t, cp.Upstreams)
 		require.Nil(t, cp.Config)
 	})
+
+	t.Run("fix upstream mesh_gateway", func(t *testing.T) {
+		cp := &ConsulProxy{
+			Upstreams: []*ConsulUpstream{{
+				MeshGateway: &ConsulMeshGateway{
+					Mode: "",
+				}},
+			},
+		}
+		cp.Canonicalize()
+		require.Equal(t, "none", cp.Upstreams[0].MeshGateway.Mode)
+	})
+}
+
+func TestService_Connect_ConsulUpstream_Copy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil upstream", func(t *testing.T) {
+		cu := (*ConsulUpstream)(nil)
+		result := cu.Copy()
+		require.Nil(t, result)
+	})
+
+	t.Run("complete upstream", func(t *testing.T) {
+		cu := &ConsulUpstream{
+			DestinationName:  "dest1",
+			Datacenter:       "dc2",
+			LocalBindPort:    2000,
+			LocalBindAddress: "10.0.0.1",
+			MeshGateway:      &ConsulMeshGateway{Mode: "remote"},
+		}
+		result := cu.Copy()
+		require.Equal(t, cu, result)
+	})
+}
+
+func TestService_Connect_ConsulUpstream_Canonicalize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil upstream", func(t *testing.T) {
+		cu := (*ConsulUpstream)(nil)
+		cu.Canonicalize()
+		require.Nil(t, cu)
+	})
+
+	t.Run("fix mesh_gateway", func(t *testing.T) {
+		cu := &ConsulUpstream{
+			DestinationName:  "dest1",
+			Datacenter:       "dc2",
+			LocalBindPort:    2000,
+			LocalBindAddress: "10.0.0.1",
+			MeshGateway:      &ConsulMeshGateway{Mode: ""},
+		}
+		cu.Canonicalize()
+		require.Equal(t, &ConsulUpstream{
+			DestinationName:  "dest1",
+			Datacenter:       "dc2",
+			LocalBindPort:    2000,
+			LocalBindAddress: "10.0.0.1",
+			MeshGateway:      &ConsulMeshGateway{Mode: "none"},
+		}, cu)
+	})
 }
 
 func TestService_Connect_proxy_settings(t *testing.T) {
@@ -506,5 +568,75 @@ func TestService_ConsulTerminatingConfigEntry_Copy(t *testing.T) {
 	t.Run("complete", func(t *testing.T) {
 		result := entry.Copy()
 		require.Equal(t, entry, result)
+	})
+}
+
+func TestService_ConsulMeshConfigEntry_Canonicalize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		ce := (*ConsulMeshConfigEntry)(nil)
+		ce.Canonicalize()
+		require.Nil(t, ce)
+	})
+
+	t.Run("instantiated", func(t *testing.T) {
+		ce := new(ConsulMeshConfigEntry)
+		ce.Canonicalize()
+		require.NotNil(t, ce)
+	})
+}
+
+func TestService_ConsulMeshConfigEntry_Copy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		ce := (*ConsulMeshConfigEntry)(nil)
+		ce2 := ce.Copy()
+		require.Nil(t, ce2)
+	})
+
+	t.Run("instantiated", func(t *testing.T) {
+		ce := new(ConsulMeshConfigEntry)
+		ce2 := ce.Copy()
+		require.NotNil(t, ce2)
+	})
+}
+
+func TestService_ConsulMeshGateway_Canonicalize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		c := (*ConsulMeshGateway)(nil)
+		c.Canonicalize()
+		require.Nil(t, c)
+	})
+
+	t.Run("unset mode", func(t *testing.T) {
+		c := &ConsulMeshGateway{
+			Mode: "",
+		}
+		c.Canonicalize()
+		require.Equal(t, &ConsulMeshGateway{
+			Mode: "none",
+		}, c)
+	})
+}
+
+func TestService_ConsulMeshGateway_Copy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		c := (*ConsulMeshGateway)(nil)
+		result := c.Copy()
+		require.Nil(t, result)
+	})
+
+	t.Run("instantiated", func(t *testing.T) {
+		c := &ConsulMeshGateway{
+			Mode: "local",
+		}
+		result := c.Copy()
+		require.Equal(t, c, result)
 	})
 }

--- a/api/services_test.go
+++ b/api/services_test.go
@@ -613,13 +613,15 @@ func TestService_ConsulMeshGateway_Canonicalize(t *testing.T) {
 	})
 
 	t.Run("unset mode", func(t *testing.T) {
-		c := &ConsulMeshGateway{
-			Mode: "",
-		}
+		c := &ConsulMeshGateway{Mode: ""}
 		c.Canonicalize()
-		require.Equal(t, &ConsulMeshGateway{
-			Mode: "none",
-		}, c)
+		require.Equal(t, "", c.Mode)
+	})
+
+	t.Run("set mode", func(t *testing.T) {
+		c := &ConsulMeshGateway{Mode: "remote"}
+		c.Canonicalize()
+		require.Equal(t, "remote", c.Mode)
 	})
 }
 

--- a/api/services_test.go
+++ b/api/services_test.go
@@ -214,18 +214,6 @@ func TestService_Connect_ConsulProxy_Canonicalize(t *testing.T) {
 		require.Nil(t, cp.Upstreams)
 		require.Nil(t, cp.Config)
 	})
-
-	t.Run("fix upstream mesh_gateway", func(t *testing.T) {
-		cp := &ConsulProxy{
-			Upstreams: []*ConsulUpstream{{
-				MeshGateway: &ConsulMeshGateway{
-					Mode: "",
-				}},
-			},
-		}
-		cp.Canonicalize()
-		require.Equal(t, "none", cp.Upstreams[0].MeshGateway.Mode)
-	})
 }
 
 func TestService_Connect_ConsulUpstream_Copy(t *testing.T) {
@@ -259,7 +247,7 @@ func TestService_Connect_ConsulUpstream_Canonicalize(t *testing.T) {
 		require.Nil(t, cu)
 	})
 
-	t.Run("fix mesh_gateway", func(t *testing.T) {
+	t.Run("complete", func(t *testing.T) {
 		cu := &ConsulUpstream{
 			DestinationName:  "dest1",
 			Datacenter:       "dc2",
@@ -273,7 +261,7 @@ func TestService_Connect_ConsulUpstream_Canonicalize(t *testing.T) {
 			Datacenter:       "dc2",
 			LocalBindPort:    2000,
 			LocalBindAddress: "10.0.0.1",
-			MeshGateway:      &ConsulMeshGateway{Mode: "none"},
+			MeshGateway:      &ConsulMeshGateway{Mode: ""},
 		}, cu)
 	})
 }

--- a/command/agent/consul/connect.go
+++ b/command/agent/consul/connect.go
@@ -198,9 +198,34 @@ func connectUpstreams(in []structs.ConsulUpstream) []api.Upstream {
 			LocalBindPort:    upstream.LocalBindPort,
 			Datacenter:       upstream.Datacenter,
 			LocalBindAddress: upstream.LocalBindAddress,
+			MeshGateway:      connectMeshGateway(upstream.MeshGateway),
 		}
 	}
 	return upstreams
+}
+
+// connectMeshGateway creates an api.MeshGatewayConfig from the nomad upstream
+// block. A non-existent config or unsupported gateway mode will default to the
+// Consul default mode.
+func connectMeshGateway(in *structs.ConsulMeshGateway) api.MeshGatewayConfig {
+	gw := api.MeshGatewayConfig{
+		Mode: api.MeshGatewayModeDefault,
+	}
+
+	if in == nil {
+		return gw
+	}
+
+	switch in.Mode {
+	case "local":
+		gw.Mode = api.MeshGatewayModeLocal
+	case "remote":
+		gw.Mode = api.MeshGatewayModeRemote
+	case "none":
+		gw.Mode = api.MeshGatewayModeNone
+	}
+
+	return gw
 }
 
 func connectProxyConfig(cfg map[string]interface{}, port int) map[string]interface{} {

--- a/command/agent/consul/connect_test.go
+++ b/command/agent/consul/connect_test.go
@@ -514,7 +514,7 @@ func TestConnect_newConnectGateway(t *testing.T) {
 					ConnectTimeout:                  helper.TimeToPtr(1 * time.Second),
 					EnvoyGatewayBindTaggedAddresses: true,
 					EnvoyGatewayBindAddresses: map[string]*structs.ConsulGatewayBindAddress{
-						"service1": &structs.ConsulGatewayBindAddress{
+						"service1": {
 							Address: "10.0.0.1",
 							Port:    2000,
 						},
@@ -532,7 +532,7 @@ func TestConnect_newConnectGateway(t *testing.T) {
 				"connect_timeout_ms":                  int64(1000),
 				"envoy_gateway_bind_tagged_addresses": true,
 				"envoy_gateway_bind_addresses": map[string]*structs.ConsulGatewayBindAddress{
-					"service1": &structs.ConsulGatewayBindAddress{
+					"service1": {
 						Address: "10.0.0.1",
 						Port:    2000,
 					},
@@ -542,5 +542,34 @@ func TestConnect_newConnectGateway(t *testing.T) {
 				"foo":                           1,
 			},
 		}, result)
+	})
+}
+
+func Test_connectMeshGateway(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		result := connectMeshGateway(nil)
+		require.Equal(t, api.MeshGatewayConfig{Mode: api.MeshGatewayModeDefault}, result)
+	})
+
+	t.Run("local", func(t *testing.T) {
+		result := connectMeshGateway(&structs.ConsulMeshGateway{Mode: "local"})
+		require.Equal(t, api.MeshGatewayConfig{Mode: api.MeshGatewayModeLocal}, result)
+	})
+
+	t.Run("remote", func(t *testing.T) {
+		result := connectMeshGateway(&structs.ConsulMeshGateway{Mode: "remote"})
+		require.Equal(t, api.MeshGatewayConfig{Mode: api.MeshGatewayModeRemote}, result)
+	})
+
+	t.Run("none", func(t *testing.T) {
+		result := connectMeshGateway(&structs.ConsulMeshGateway{Mode: "none"})
+		require.Equal(t, api.MeshGatewayConfig{Mode: api.MeshGatewayModeNone}, result)
+	})
+
+	t.Run("nonsense", func(t *testing.T) {
+		result := connectMeshGateway(nil)
+		require.Equal(t, api.MeshGatewayConfig{Mode: api.MeshGatewayModeDefault}, result)
 	})
 }

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/golang/snappy"
-	"github.com/hashicorp/nomad/api"
+	api "github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/jobspec"
 	"github.com/hashicorp/nomad/jobspec2"
@@ -1362,6 +1362,7 @@ func apiConnectGatewayToStructs(in *api.ConsulGateway) *structs.ConsulGateway {
 		Proxy:       apiConnectGatewayProxyToStructs(in.Proxy),
 		Ingress:     apiConnectIngressGatewayToStructs(in.Ingress),
 		Terminating: apiConnectTerminatingGatewayToStructs(in.Terminating),
+		Mesh:        apiConnectMeshGatewayToStructs(in.Mesh),
 	}
 }
 
@@ -1494,6 +1495,13 @@ func apiConnectTerminatingServiceToStructs(in *api.ConsulLinkedService) *structs
 	}
 }
 
+func apiConnectMeshGatewayToStructs(in *api.ConsulMeshConfigEntry) *structs.ConsulMeshConfigEntry {
+	if in == nil {
+		return nil
+	}
+	return new(structs.ConsulMeshConfigEntry)
+}
+
 func apiConnectSidecarServiceToStructs(in *api.ConsulSidecarService) *structs.ConsulSidecarService {
 	if in == nil {
 		return nil
@@ -1530,9 +1538,19 @@ func apiUpstreamsToStructs(in []*api.ConsulUpstream) []structs.ConsulUpstream {
 			LocalBindPort:    upstream.LocalBindPort,
 			Datacenter:       upstream.Datacenter,
 			LocalBindAddress: upstream.LocalBindAddress,
+			MeshGateway:      apiMeshGatewayToStructs(upstream.MeshGateway),
 		}
 	}
 	return upstreams
+}
+
+func apiMeshGatewayToStructs(in *api.ConsulMeshGateway) *structs.ConsulMeshGateway {
+	if in == nil {
+		return nil
+	}
+	return &structs.ConsulMeshGateway{
+		Mode: in.Mode,
+	}
 }
 
 func apiConsulExposeConfigToStructs(in *api.ConsulExposeConfig) *structs.ConsulExposeConfig {

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/golang/snappy"
-	"github.com/hashicorp/nomad/api"
+	api "github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -3138,12 +3138,21 @@ func TestConversion_apiUpstreamsToStructs(t *testing.T) {
 		LocalBindPort:    8000,
 		Datacenter:       "dc2",
 		LocalBindAddress: "127.0.0.2",
+		MeshGateway:      &structs.ConsulMeshGateway{Mode: "local"},
 	}}, apiUpstreamsToStructs([]*api.ConsulUpstream{{
 		DestinationName:  "upstream",
 		LocalBindPort:    8000,
 		Datacenter:       "dc2",
 		LocalBindAddress: "127.0.0.2",
+		MeshGateway:      &api.ConsulMeshGateway{Mode: "local"},
 	}}))
+}
+
+func TestConversion_apiConsulMeshGatewayToStructs(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, apiMeshGatewayToStructs(nil))
+	require.Equal(t, &structs.ConsulMeshGateway{Mode: "remote"},
+		apiMeshGatewayToStructs(&api.ConsulMeshGateway{Mode: "remote"}))
 }
 
 func TestConversion_apiConnectSidecarServiceProxyToStructs(t *testing.T) {
@@ -3308,6 +3317,22 @@ func TestConversion_ApiConsulConnectToStructs(t *testing.T) {
 						KeyFile:  "key.pem",
 						SNI:      "linked.consul",
 					}},
+				},
+			},
+		}))
+	})
+
+	t.Run("gateway mesh", func(t *testing.T) {
+		require.Equal(t, &structs.ConsulConnect{
+			Gateway: &structs.ConsulGateway{
+				Mesh: &structs.ConsulMeshConfigEntry{
+					// nothing
+				},
+			},
+		}, ApiConsulConnectToStructs(&api.ConsulConnect{
+			Gateway: &api.ConsulGateway{
+				Mesh: &api.ConsulMeshConfigEntry{
+					// nothing
 				},
 			},
 		}))

--- a/helper/envoy/envoy.go
+++ b/helper/envoy/envoy.go
@@ -2,6 +2,10 @@
 // selecting an envoy version.
 package envoy
 
+import (
+	"fmt"
+)
+
 const (
 	// SidecarMetaParam is the parameter name used to configure the connect sidecar
 	// at the client level. Setting this option in client configuration takes the
@@ -27,7 +31,7 @@ const (
 	// gateway proxies, when they are injected in the job connect mutator.
 	GatewayConfigVar = "${meta." + GatewayMetaParam + "}"
 
-	// envoyImageFormat is the default format string used for official envoy Docker
+	// ImageFormat is the default format string used for official envoy Docker
 	// images with the tag being the semver of the version of envoy. Nomad fakes
 	// interpolation of ${NOMAD_envoy_version} by replacing it with the version
 	// string for envoy that Consul reports as preferred.
@@ -37,7 +41,7 @@ const (
 	// to something like: "custom/envoy:${NOMAD_envoy_version}".
 	ImageFormat = "envoyproxy/envoy:v" + VersionVar
 
-	// envoyVersionVar will be replaced with the Envoy version string when
+	// VersionVar will be replaced with the Envoy version string when
 	// used in the meta.connect.sidecar_image variable.
 	VersionVar = "${NOMAD_envoy_version}"
 
@@ -47,3 +51,13 @@ const (
 	// dynamic envoy versions.
 	FallbackImage = "envoyproxy/envoy:v1.11.2@sha256:a7769160c9c1a55bb8d07a3b71ce5d64f72b1f665f10d81aa1581bc3cf850d09"
 )
+
+// PortLabel creates a consistent port label using the inputs of a prefix,
+// service name, and optional suffix. The prefix should be the Kind part of
+// TaskKind the envoy is being configured for.
+func PortLabel(prefix, service, suffix string) string {
+	if suffix == "" {
+		return fmt.Sprintf("%s-%s", prefix, service)
+	}
+	return fmt.Sprintf("%s-%s-%s", prefix, service, suffix)
+}

--- a/helper/envoy/envoy_test.go
+++ b/helper/envoy/envoy_test.go
@@ -1,0 +1,29 @@
+package envoy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvoy_PortLabel(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		prefix  string
+		service string
+		suffix  string
+		exp     string
+	}{
+		{prefix: structs.ConnectProxyPrefix, service: "foo", suffix: "", exp: "connect-proxy-foo"},
+		{prefix: structs.ConnectMeshPrefix, service: "bar", exp: "connect-mesh-bar"},
+	} {
+		test := fmt.Sprintf("%s_%s_%s", tc.prefix, tc.service, tc.suffix)
+		t.Run(test, func(t *testing.T) {
+			result := PortLabel(tc.prefix, tc.service, tc.suffix)
+			require.Equal(t, tc.exp, result)
+		})
+	}
+}

--- a/nomad/job_endpoint_hook_connect_test.go
+++ b/nomad/job_endpoint_hook_connect_test.go
@@ -16,9 +16,9 @@ func TestJobEndpointConnect_isSidecarForService(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		t *structs.Task // task
-		s string        // service
-		r bool          // result
+		task    *structs.Task
+		sidecar string
+		exp     bool
 	}{
 		{
 			&structs.Task{},
@@ -49,7 +49,7 @@ func TestJobEndpointConnect_isSidecarForService(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		require.Equal(t, c.r, isSidecarForService(c.t, c.s))
+		require.Equal(t, c.exp, isSidecarForService(c.task, c.sidecar))
 	}
 }
 
@@ -115,17 +115,16 @@ func TestJobEndpointConnect_groupConnectHook(t *testing.T) {
 func TestJobEndpointConnect_groupConnectHook_IngressGateway(t *testing.T) {
 	t.Parallel()
 
-	// Test that the connect gateway task is inserted if a gateway service exists
-	// and since this is a bridge network, will rewrite the default gateway proxy
+	// Test that the connect ingress gateway task is inserted if a gateway service
+	// exists and since this is a bridge network, will rewrite the default gateway proxy
 	// block with correct configuration.
 	job := mock.ConnectIngressGatewayJob("bridge", false)
-
 	job.Meta = map[string]string{
 		"gateway_name": "my-gateway",
 	}
-
 	job.TaskGroups[0].Services[0].Name = "${NOMAD_META_gateway_name}"
 
+	// setup expectations
 	expTG := job.TaskGroups[0].Copy()
 	expTG.Tasks = []*structs.Task{
 		// inject the gateway task
@@ -153,11 +152,9 @@ func TestJobEndpointConnect_groupConnectHook_IngressGateway_CustomTask(t *testin
 	// and since this is a bridge network, will rewrite the default gateway proxy
 	// block with correct configuration.
 	job := mock.ConnectIngressGatewayJob("bridge", false)
-
 	job.Meta = map[string]string{
 		"gateway_name": "my-gateway",
 	}
-
 	job.TaskGroups[0].Services[0].Name = "${NOMAD_META_gateway_name}"
 	job.TaskGroups[0].Services[0].Connect.SidecarTask = &structs.SidecarTask{
 		Driver: "raw_exec",
@@ -173,6 +170,7 @@ func TestJobEndpointConnect_groupConnectHook_IngressGateway_CustomTask(t *testin
 		KillSignal: "SIGHUP",
 	}
 
+	// setup expectations
 	expTG := job.TaskGroups[0].Copy()
 	expTG.Tasks = []*structs.Task{
 		// inject merged gateway task
@@ -203,6 +201,80 @@ func TestJobEndpointConnect_groupConnectHook_IngressGateway_CustomTask(t *testin
 		},
 	}
 	expTG.Services[0].Name = "my-gateway"
+	expTG.Tasks[0].Canonicalize(job, expTG)
+	expTG.Networks[0].Canonicalize()
+
+	// rewrite the service gateway proxy configuration
+	expTG.Services[0].Connect.Gateway.Proxy = gatewayProxyForBridge(expTG.Services[0].Connect.Gateway)
+
+	require.NoError(t, groupConnectHook(job, job.TaskGroups[0]))
+	require.Exactly(t, expTG, job.TaskGroups[0])
+
+	// Test that the hook is idempotent
+	require.NoError(t, groupConnectHook(job, job.TaskGroups[0]))
+	require.Exactly(t, expTG, job.TaskGroups[0])
+}
+
+func TestJobEndpointConnect_groupConnectHook_TerminatingGateway(t *testing.T) {
+	t.Parallel()
+
+	// Tests that the connect terminating gateway task is inserted if a gateway
+	// service exists and since this is a bridge network, will rewrite the default
+	// gateway proxy block with correct configuration.
+	job := mock.ConnectTerminatingGatewayJob("bridge", false)
+	job.Meta = map[string]string{
+		"gateway_name": "my-gateway",
+	}
+	job.TaskGroups[0].Services[0].Name = "${NOMAD_META_gateway_name}"
+
+	// setup expectations
+	expTG := job.TaskGroups[0].Copy()
+	expTG.Tasks = []*structs.Task{
+		// inject the gateway task
+		newConnectGatewayTask(structs.ConnectTerminatingPrefix, "my-gateway", false),
+	}
+	expTG.Services[0].Name = "my-gateway"
+	expTG.Tasks[0].Canonicalize(job, expTG)
+	expTG.Networks[0].Canonicalize()
+
+	// rewrite the service gateway proxy configuration
+	expTG.Services[0].Connect.Gateway.Proxy = gatewayProxyForBridge(expTG.Services[0].Connect.Gateway)
+
+	require.NoError(t, groupConnectHook(job, job.TaskGroups[0]))
+	require.Exactly(t, expTG, job.TaskGroups[0])
+
+	// Test that the hook is idempotent
+	require.NoError(t, groupConnectHook(job, job.TaskGroups[0]))
+	require.Exactly(t, expTG, job.TaskGroups[0])
+}
+
+func TestJobEndpointConnect_groupConnectHook_MeshGateway(t *testing.T) {
+	t.Parallel()
+
+	// Test that the connect mesh gateway task is inserted if a gateway service
+	// exists and since this is a bridge network, will rewrite the default gateway
+	// proxy block with correct configuration, injecting a dynamic port for use
+	// by the envoy lan listener.
+	job := mock.ConnectMeshGatewayJob("bridge", false)
+	job.Meta = map[string]string{
+		"gateway_name": "my-gateway",
+	}
+	job.TaskGroups[0].Services[0].Name = "${NOMAD_META_gateway_name}"
+
+	// setup expectations
+	expTG := job.TaskGroups[0].Copy()
+	expTG.Tasks = []*structs.Task{
+		// inject the gateway task
+		newConnectGatewayTask(structs.ConnectMeshPrefix, "my-gateway", false),
+	}
+	expTG.Services[0].Name = "my-gateway"
+	expTG.Services[0].PortLabel = "public_port"
+	expTG.Networks[0].DynamicPorts = []structs.Port{{
+		Label:       "connect-mesh-my-gateway-lan",
+		Value:       0,
+		To:          -1,
+		HostNetwork: "default",
+	}}
 	expTG.Tasks[0].Canonicalize(job, expTG)
 	expTG.Networks[0].Canonicalize()
 
@@ -395,6 +467,8 @@ func TestJobEndpointConnect_groupConnectGatewayValidate(t *testing.T) {
 }
 
 func TestJobEndpointConnect_newConnectGatewayTask_host(t *testing.T) {
+	t.Parallel()
+
 	t.Run("ingress", func(t *testing.T) {
 		task := newConnectGatewayTask(structs.ConnectIngressPrefix, "foo", true)
 		require.Equal(t, "connect-ingress-foo", task.Name)
@@ -415,11 +489,15 @@ func TestJobEndpointConnect_newConnectGatewayTask_host(t *testing.T) {
 }
 
 func TestJobEndpointConnect_newConnectGatewayTask_bridge(t *testing.T) {
+	t.Parallel()
+
 	task := newConnectGatewayTask(structs.ConnectIngressPrefix, "service1", false)
 	require.NotContains(t, task.Config, "network_mode")
 }
 
 func TestJobEndpointConnect_hasGatewayTaskForService(t *testing.T) {
+	t.Parallel()
+
 	t.Run("no gateway task", func(t *testing.T) {
 		result := hasGatewayTaskForService(&structs.TaskGroup{
 			Name: "group",
@@ -452,9 +530,22 @@ func TestJobEndpointConnect_hasGatewayTaskForService(t *testing.T) {
 		}, "my-service")
 		require.True(t, result)
 	})
+
+	t.Run("has mesh task", func(t *testing.T) {
+		result := hasGatewayTaskForService(&structs.TaskGroup{
+			Name: "group",
+			Tasks: []*structs.Task{{
+				Name: "mesh-gateway-my-service",
+				Kind: structs.NewTaskKind(structs.ConnectMeshPrefix, "my-service"),
+			}},
+		}, "my-service")
+		require.True(t, result)
+	})
 }
 
 func TestJobEndpointConnect_gatewayProxyIsDefault(t *testing.T) {
+	t.Parallel()
+
 	t.Run("nil", func(t *testing.T) {
 		result := gatewayProxyIsDefault(nil)
 		require.True(t, result)
@@ -496,6 +587,8 @@ func TestJobEndpointConnect_gatewayProxyIsDefault(t *testing.T) {
 }
 
 func TestJobEndpointConnect_gatewayBindAddresses(t *testing.T) {
+	t.Parallel()
+
 	t.Run("nil", func(t *testing.T) {
 
 		result := gatewayBindAddressesIngress(nil)
@@ -561,6 +654,8 @@ func TestJobEndpointConnect_gatewayBindAddresses(t *testing.T) {
 }
 
 func TestJobEndpointConnect_gatewayProxyForBridge(t *testing.T) {
+	t.Parallel()
+
 	t.Run("nil", func(t *testing.T) {
 		result := gatewayProxyForBridge(nil)
 		require.Nil(t, result)
@@ -636,6 +731,7 @@ func TestJobEndpointConnect_gatewayProxyForBridge(t *testing.T) {
 			},
 		})
 		require.Equal(t, &structs.ConsulGatewayProxy{
+			ConnectTimeout:                  nil,
 			Config:                          map[string]interface{}{"foo": 1},
 			EnvoyGatewayNoDefaultBind:       false,
 			EnvoyGatewayBindTaggedAddresses: true,
@@ -674,6 +770,69 @@ func TestJobEndpointConnect_gatewayProxyForBridge(t *testing.T) {
 	})
 
 	t.Run("terminating leave as-is", func(t *testing.T) {
-		//
+		result := gatewayProxyForBridge(&structs.ConsulGateway{
+			Proxy: &structs.ConsulGatewayProxy{
+				Config:                          map[string]interface{}{"foo": 1},
+				EnvoyGatewayBindTaggedAddresses: true,
+			},
+			Terminating: &structs.ConsulTerminatingConfigEntry{
+				Services: []*structs.ConsulLinkedService{{
+					Name: "service1",
+				}},
+			},
+		})
+		require.Equal(t, &structs.ConsulGatewayProxy{
+			ConnectTimeout:                  nil,
+			Config:                          map[string]interface{}{"foo": 1},
+			EnvoyGatewayNoDefaultBind:       false,
+			EnvoyGatewayBindTaggedAddresses: true,
+			EnvoyGatewayBindAddresses:       nil,
+		}, result)
 	})
+
+	t.Run("mesh set defaults", func(t *testing.T) {
+		result := gatewayProxyForBridge(&structs.ConsulGateway{
+			Proxy: &structs.ConsulGatewayProxy{
+				ConnectTimeout: helper.TimeToPtr(2 * time.Second),
+			},
+			Mesh: &structs.ConsulMeshConfigEntry{
+				// nothing
+			},
+		})
+		require.Equal(t, &structs.ConsulGatewayProxy{
+			ConnectTimeout:                  helper.TimeToPtr(2 * time.Second),
+			EnvoyGatewayNoDefaultBind:       true,
+			EnvoyGatewayBindTaggedAddresses: false,
+			EnvoyGatewayBindAddresses: map[string]*structs.ConsulGatewayBindAddress{
+				"lan": {
+					Address: "0.0.0.0",
+					Port:    -1,
+				},
+				"wan": {
+					Address: "0.0.0.0",
+					Port:    -1,
+				},
+			},
+		}, result)
+	})
+
+	t.Run("mesh leave as-is", func(t *testing.T) {
+		result := gatewayProxyForBridge(&structs.ConsulGateway{
+			Proxy: &structs.ConsulGatewayProxy{
+				Config:                          map[string]interface{}{"foo": 1},
+				EnvoyGatewayBindTaggedAddresses: true,
+			},
+			Mesh: &structs.ConsulMeshConfigEntry{
+				// nothing
+			},
+		})
+		require.Equal(t, &structs.ConsulGatewayProxy{
+			ConnectTimeout:                  nil,
+			Config:                          map[string]interface{}{"foo": 1},
+			EnvoyGatewayNoDefaultBind:       false,
+			EnvoyGatewayBindTaggedAddresses: true,
+			EnvoyGatewayBindAddresses:       nil,
+		}, result)
+	})
+
 }

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -899,6 +899,9 @@ func ConnectIngressGatewayJob(mode string, inject bool) *structs.Job {
 			},
 		},
 	}}
+
+	tg.Tasks = nil
+
 	// some tests need to assume the gateway proxy task has already been injected
 	if inject {
 		tg.Tasks = []*structs.Task{{
@@ -912,9 +915,102 @@ func ConnectIngressGatewayJob(mode string, inject bool) *structs.Job {
 				MaxFileSizeMB: 2,
 			},
 		}}
-	} else {
-		// otherwise there are no tasks in the group yet
-		tg.Tasks = nil
+	}
+	return job
+}
+
+// ConnectTerminatingGatewayJob creates a structs.Job that contains the definition
+// of a Consul Terminating Gateway service. The mode is the name of the network mode
+// assumed by the task group. If inject is true, a corresponding task is set on the
+// group's Tasks (i.e. what the job would look like after mutation).
+func ConnectTerminatingGatewayJob(mode string, inject bool) *structs.Job {
+	job := Job()
+	tg := job.TaskGroups[0]
+	tg.Networks = []*structs.NetworkResource{{
+		Mode: mode,
+	}}
+	tg.Services = []*structs.Service{{
+		Name:      "my-terminating-service",
+		PortLabel: "9999",
+		Connect: &structs.ConsulConnect{
+			Gateway: &structs.ConsulGateway{
+				Proxy: &structs.ConsulGatewayProxy{
+					ConnectTimeout:            helper.TimeToPtr(3 * time.Second),
+					EnvoyGatewayBindAddresses: make(map[string]*structs.ConsulGatewayBindAddress),
+				},
+				Terminating: &structs.ConsulTerminatingConfigEntry{
+					Services: []*structs.ConsulLinkedService{{
+						Name:     "service1",
+						CAFile:   "/ssl/ca_file",
+						CertFile: "/ssl/cert_file",
+						KeyFile:  "/ssl/key_file",
+						SNI:      "sni-name",
+					}},
+				},
+			},
+		},
+	}}
+
+	tg.Tasks = nil
+
+	// some tests need to assume the gateway proxy task has already been injected
+	if inject {
+		tg.Tasks = []*structs.Task{{
+			Name:          fmt.Sprintf("%s-%s", structs.ConnectTerminatingPrefix, "my-terminating-service"),
+			Kind:          structs.NewTaskKind(structs.ConnectTerminatingPrefix, "my-terminating-service"),
+			Driver:        "docker",
+			Config:        make(map[string]interface{}),
+			ShutdownDelay: 5 * time.Second,
+			LogConfig: &structs.LogConfig{
+				MaxFiles:      2,
+				MaxFileSizeMB: 2,
+			},
+		}}
+	}
+	return job
+}
+
+// ConnectMeshGatewayJob creates a structs.Job that contains the definition of a
+// Consul Mesh Gateway service. The mode is the name of the network mode assumed
+// by the task group. If inject is true, a corresponding task is set on the group's
+// Tasks (i.e. what the job would look like after job mutation).
+func ConnectMeshGatewayJob(mode string, inject bool) *structs.Job {
+	job := Job()
+	tg := job.TaskGroups[0]
+	tg.Networks = []*structs.NetworkResource{{
+		Mode: mode,
+	}}
+	tg.Services = []*structs.Service{{
+		Name:      "my-mesh-service",
+		PortLabel: "public_port",
+		Connect: &structs.ConsulConnect{
+			Gateway: &structs.ConsulGateway{
+				Proxy: &structs.ConsulGatewayProxy{
+					ConnectTimeout:            helper.TimeToPtr(3 * time.Second),
+					EnvoyGatewayBindAddresses: make(map[string]*structs.ConsulGatewayBindAddress),
+				},
+				Mesh: &structs.ConsulMeshConfigEntry{
+					// nothing to configure
+				},
+			},
+		},
+	}}
+
+	tg.Tasks = nil
+
+	// some tests need to assume the gateway task has already been injected
+	if inject {
+		tg.Tasks = []*structs.Task{{
+			Name:          fmt.Sprintf("%s-%s", structs.ConnectMeshPrefix, "my-mesh-service"),
+			Kind:          structs.NewTaskKind(structs.ConnectMeshPrefix, "my-mesh-service"),
+			Driver:        "docker",
+			Config:        make(map[string]interface{}),
+			ShutdownDelay: 5 * time.Second,
+			LogConfig: &structs.LogConfig{
+				MaxFiles:      2,
+				MaxFileSizeMB: 2,
+			},
+		}}
 	}
 	return job
 }

--- a/nomad/structs/connect_test.go
+++ b/nomad/structs/connect_test.go
@@ -1,0 +1,21 @@
+package structs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskKind_IsAnyConnectGateway(t *testing.T) {
+	t.Run("gateways", func(t *testing.T) {
+		require.True(t, NewTaskKind(ConnectIngressPrefix, "foo").IsAnyConnectGateway())
+		require.True(t, NewTaskKind(ConnectTerminatingPrefix, "foo").IsAnyConnectGateway())
+		require.True(t, NewTaskKind(ConnectMeshPrefix, "foo").IsAnyConnectGateway())
+	})
+
+	t.Run("not gateways", func(t *testing.T) {
+		require.False(t, NewTaskKind(ConnectProxyPrefix, "foo").IsAnyConnectGateway())
+		require.False(t, NewTaskKind(ConnectNativePrefix, "foo").IsAnyConnectGateway())
+		require.False(t, NewTaskKind("", "foo").IsAnyConnectGateway())
+	})
+}

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -2742,6 +2742,9 @@ func TestTaskGroupDiff(t *testing.T) {
 										SNI:      "linked1.consul",
 									}},
 								},
+								Mesh: &ConsulMeshConfigEntry{
+									// nothing
+								},
 							},
 						},
 					},
@@ -2785,6 +2788,9 @@ func TestTaskGroupDiff(t *testing.T) {
 											LocalBindPort:    8000,
 											Datacenter:       "dc2",
 											LocalBindAddress: "127.0.0.2",
+											MeshGateway: &ConsulMeshGateway{
+												Mode: "remote",
+											},
 										},
 									},
 									Config: map[string]interface{}{
@@ -2829,6 +2835,9 @@ func TestTaskGroupDiff(t *testing.T) {
 										KeyFile:  "key2.pem",
 										SNI:      "linked2.consul",
 									}},
+								},
+								Mesh: &ConsulMeshConfigEntry{
+									// nothing
 								},
 							},
 						},
@@ -3102,6 +3111,20 @@ func TestTaskGroupDiff(t *testing.T) {
 																Name: "LocalBindPort",
 																Old:  "",
 																New:  "8000",
+															},
+														},
+														Objects: []*ObjectDiff{
+															{
+																Type: DiffTypeAdded,
+																Name: "MeshGateway",
+																Fields: []*FieldDiff{
+																	{
+																		Type: DiffTypeAdded,
+																		Name: "Mode",
+																		Old:  "",
+																		New:  "remote",
+																	},
+																},
 															},
 														},
 													},

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -522,6 +522,12 @@ func TestConsulUpstream_upstreamEquals(t *testing.T) {
 		require.False(t, upstreamsEquals(a, b))
 	})
 
+	t.Run("different mesh_gateway", func(t *testing.T) {
+		a := []ConsulUpstream{{DestinationName: "foo", MeshGateway: &ConsulMeshGateway{Mode: "local"}}}
+		b := []ConsulUpstream{{DestinationName: "foo", MeshGateway: &ConsulMeshGateway{Mode: "remote"}}}
+		require.False(t, upstreamsEquals(a, b))
+	})
+
 	t.Run("identical", func(t *testing.T) {
 		a := []ConsulUpstream{up("foo", 8000), up("bar", 9000)}
 		b := []ConsulUpstream{up("foo", 8000), up("bar", 9000)}
@@ -682,6 +688,15 @@ var (
 			}},
 		},
 	}
+
+	consulMeshGateway1 = &ConsulGateway{
+		Proxy: &ConsulGatewayProxy{
+			ConnectTimeout: helper.TimeToPtr(1 * time.Second),
+		},
+		Mesh: &ConsulMeshConfigEntry{
+			// nothing
+		},
+	}
 )
 
 func TestConsulGateway_Prefix(t *testing.T) {
@@ -695,7 +710,10 @@ func TestConsulGateway_Prefix(t *testing.T) {
 		require.Equal(t, ConnectTerminatingPrefix, result)
 	})
 
-	// also mesh
+	t.Run("mesh", func(t *testing.T) {
+		result := (&ConsulGateway{Mesh: new(ConsulMeshConfigEntry)}).Prefix()
+		require.Equal(t, ConnectMeshPrefix, result)
+	})
 }
 
 func TestConsulGateway_Copy(t *testing.T) {
@@ -719,6 +737,29 @@ func TestConsulGateway_Copy(t *testing.T) {
 		require.Equal(t, consulTerminatingGateway1, result)
 		require.True(t, result.Equals(consulTerminatingGateway1))
 		require.True(t, consulTerminatingGateway1.Equals(result))
+	})
+
+	t.Run("as mesh", func(t *testing.T) {
+		result := consulMeshGateway1.Copy()
+		require.Equal(t, consulMeshGateway1, result)
+		require.True(t, result.Equals(consulMeshGateway1))
+		require.True(t, consulMeshGateway1.Equals(result))
+	})
+}
+
+func TestConsulGateway_Equals_mesh(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		a := (*ConsulGateway)(nil)
+		b := (*ConsulGateway)(nil)
+		require.True(t, a.Equals(b))
+		require.False(t, a.Equals(consulMeshGateway1))
+		require.False(t, consulMeshGateway1.Equals(a))
+	})
+
+	t.Run("reflexive", func(t *testing.T) {
+		require.True(t, consulMeshGateway1.Equals(consulMeshGateway1))
 	})
 }
 
@@ -962,8 +1003,9 @@ func TestConsulGateway_Validate(t *testing.T) {
 		err := (&ConsulGateway{
 			Ingress:     nil,
 			Terminating: nil,
+			Mesh:        nil,
 		}).Validate()
-		require.EqualError(t, err, "One Consul Gateway Configuration Entry must be set")
+		require.EqualError(t, err, "One Consul Gateway Configuration must be set")
 	})
 
 	t.Run("multiple config entries set", func(t *testing.T) {
@@ -983,7 +1025,14 @@ func TestConsulGateway_Validate(t *testing.T) {
 				}},
 			},
 		}).Validate()
-		require.EqualError(t, err, "One Consul Gateway Configuration Entry must be set")
+		require.EqualError(t, err, "One Consul Gateway Configuration must be set")
+	})
+
+	t.Run("ok mesh", func(t *testing.T) {
+		err := (&ConsulGateway{
+			Mesh: new(ConsulMeshConfigEntry),
+		}).Validate()
+		require.NoError(t, err)
 	})
 }
 
@@ -1227,7 +1276,7 @@ func TestConsulLinkedService_Validate(t *testing.T) {
 		require.EqualError(t, err, "Consul Linked Service requires Name")
 	})
 
-	t.Run("missing cafile", func(t *testing.T) {
+	t.Run("missing ca_file", func(t *testing.T) {
 		err := (&ConsulLinkedService{
 			Name:     "linked-service1",
 			CertFile: "cert_file.pem",
@@ -1245,7 +1294,7 @@ func TestConsulLinkedService_Validate(t *testing.T) {
 		require.EqualError(t, err, "Consul Linked Service TLS Cert and Key must both be set")
 	})
 
-	t.Run("sni without cafile", func(t *testing.T) {
+	t.Run("sni without ca_file", func(t *testing.T) {
 		err := (&ConsulLinkedService{
 			Name: "linked-service1",
 			SNI:  "service.consul",
@@ -1339,7 +1388,7 @@ func TestConsulLinkedService_linkedServicesEqual(t *testing.T) {
 	require.True(t, linkedServicesEqual(services, reversed))
 
 	different := []*ConsulLinkedService{
-		services[0], &ConsulLinkedService{
+		services[0], {
 			Name:   "service2",
 			CAFile: "ca.pem",
 			SNI:    "service2.consul",
@@ -1379,6 +1428,47 @@ func TestConsulTerminatingConfigEntry_Validate(t *testing.T) {
 				Name: "service1",
 			}},
 		}).Validate()
+		require.NoError(t, err)
+	})
+}
+
+func TestConsulMeshGateway_Copy(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, (*ConsulMeshGateway)(nil))
+	require.Equal(t, &ConsulMeshGateway{
+		Mode: "remote",
+	}, &ConsulMeshGateway{
+		Mode: "remote",
+	})
+}
+
+func TestConsulMeshGateway_Equals(t *testing.T) {
+	t.Parallel()
+
+	c := &ConsulMeshGateway{Mode: "local"}
+	require.False(t, c.Equals(nil))
+	require.True(t, c.Equals(c))
+
+	o := &ConsulMeshGateway{Mode: "remote"}
+	require.False(t, c.Equals(o))
+}
+
+func TestConsulMeshGateway_Validate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		err := (*ConsulMeshGateway)(nil).Validate()
+		require.NoError(t, err)
+	})
+
+	t.Run("mode invalid", func(t *testing.T) {
+		err := (&ConsulMeshGateway{Mode: "banana"}).Validate()
+		require.EqualError(t, err, `Connect mesh_gateway mode "banana" not supported`)
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		err := (&ConsulMeshGateway{Mode: "local"}).Validate()
 		require.NoError(t, err)
 	})
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7209,19 +7209,30 @@ func (k TaskKind) IsConnectNative() bool {
 	return k.hasPrefix(ConnectNativePrefix)
 }
 
+// IsConnectIngress returns true if the TaskKind is connect-ingress.
 func (k TaskKind) IsConnectIngress() bool {
 	return k.hasPrefix(ConnectIngressPrefix)
 }
 
+// IsConnectTerminating returns true if the TaskKind is connect-terminating.
 func (k TaskKind) IsConnectTerminating() bool {
 	return k.hasPrefix(ConnectTerminatingPrefix)
 }
 
+// IsConnectMesh returns true if the TaskKind is connect-mesh.
+func (k TaskKind) IsConnectMesh() bool {
+	return k.hasPrefix(ConnectMeshPrefix)
+}
+
+// IsAnyConnectGateway returns true if the TaskKind represents any one of the
+// supported connect gateway types.
 func (k TaskKind) IsAnyConnectGateway() bool {
 	switch {
 	case k.IsConnectIngress():
 		return true
 	case k.IsConnectTerminating():
+		return true
+	case k.IsConnectMesh():
 		return true
 	default:
 		return false
@@ -7243,14 +7254,11 @@ const (
 
 	// ConnectTerminatingPrefix is the prefix used for fields referencing a Consul
 	// Connect Terminating Gateway Proxy.
-	//
 	ConnectTerminatingPrefix = "connect-terminating"
 
 	// ConnectMeshPrefix is the prefix used for fields referencing a Consul Connect
 	// Mesh Gateway Proxy.
-	//
-	// Not yet supported.
-	// ConnectMeshPrefix = "connect-mesh"
+	ConnectMeshPrefix = "connect-mesh"
 )
 
 // ValidateConnectProxyService checks that the service that is being

--- a/vendor/github.com/hashicorp/nomad/api/services.go
+++ b/vendor/github.com/hashicorp/nomad/api/services.go
@@ -281,17 +281,81 @@ func (cp *ConsulProxy) Canonicalize() {
 		cp.Upstreams = nil
 	}
 
+	for i := 0; i < len(cp.Upstreams); i++ {
+		cp.Upstreams[i].Canonicalize()
+	}
+
 	if len(cp.Config) == 0 {
 		cp.Config = nil
 	}
 }
 
+// ConsulMeshGateway is used to configure mesh gateway usage when connecting to
+// a connect upstream in another datacenter.
+type ConsulMeshGateway struct {
+	// Mode configures how an upstream should be accessed with regard to using
+	// mesh gateways.
+	//
+	// local - the connect proxy makes outbound connections through mesh gateway
+	// originating in the same datacenter.
+	//
+	// remote - the connect proxy makes outbound connections to a mesh gateway
+	// in the destination datacenter.
+	//
+	// none (default) - no mesh gateway is used, the proxy makes outbound connections
+	// directly to destination services.
+	//
+	// https://www.consul.io/docs/connect/gateways/mesh-gateway#modes-of-operation
+	Mode string `mapstructure:"mode" hcl:"mode,optional"`
+}
+
+func (c *ConsulMeshGateway) Canonicalize() {
+	if c == nil {
+		return
+	}
+
+	if c.Mode == "" {
+		c.Mode = "none"
+	}
+}
+
+func (c *ConsulMeshGateway) Copy() *ConsulMeshGateway {
+	if c == nil {
+		return nil
+	}
+
+	return &ConsulMeshGateway{
+		Mode: c.Mode,
+	}
+}
+
 // ConsulUpstream represents a Consul Connect upstream jobspec stanza.
 type ConsulUpstream struct {
-	DestinationName  string `mapstructure:"destination_name" hcl:"destination_name,optional"`
-	LocalBindPort    int    `mapstructure:"local_bind_port" hcl:"local_bind_port,optional"`
-	Datacenter       string `mapstructure:"datacenter" hcl:"datacenter,optional"`
-	LocalBindAddress string `mapstructure:"local_bind_address" hcl:"local_bind_address,optional"`
+	DestinationName  string             `mapstructure:"destination_name" hcl:"destination_name,optional"`
+	LocalBindPort    int                `mapstructure:"local_bind_port" hcl:"local_bind_port,optional"`
+	Datacenter       string             `mapstructure:"datacenter" hcl:"datacenter,optional"`
+	LocalBindAddress string             `mapstructure:"local_bind_address" hcl:"local_bind_address,optional"`
+	MeshGateway      *ConsulMeshGateway `mapstructure:"mesh_gateway" hcl:"mesh_gateway,block"`
+}
+
+func (cu *ConsulUpstream) Copy() *ConsulUpstream {
+	if cu == nil {
+		return nil
+	}
+	return &ConsulUpstream{
+		DestinationName:  cu.DestinationName,
+		LocalBindPort:    cu.LocalBindPort,
+		Datacenter:       cu.Datacenter,
+		LocalBindAddress: cu.LocalBindAddress,
+		MeshGateway:      cu.MeshGateway.Copy(),
+	}
+}
+
+func (cu *ConsulUpstream) Canonicalize() {
+	if cu == nil {
+		return
+	}
+	cu.MeshGateway.Canonicalize()
 }
 
 type ConsulExposeConfig struct {
@@ -326,8 +390,8 @@ type ConsulGateway struct {
 	// Terminating represents the Consul Configuration Entry for a Terminating Gateway.
 	Terminating *ConsulTerminatingConfigEntry `hcl:"terminating,block"`
 
-	// Mesh is not yet supported.
-	// Mesh *ConsulMeshConfigEntry
+	// Mesh indicates the Consul service should be a Mesh Gateway.
+	Mesh *ConsulMeshConfigEntry `hcl:"mesh,block"`
 }
 
 func (g *ConsulGateway) Canonicalize() {
@@ -643,6 +707,21 @@ func (e *ConsulTerminatingConfigEntry) Copy() *ConsulTerminatingConfigEntry {
 	}
 }
 
-// ConsulMeshConfigEntry is not yet supported.
-// type ConsulMeshConfigEntry struct {
-// }
+// ConsulMeshConfigEntry is a stub used to represent that the gateway service type
+// should be for a Mesh Gateway. Unlike Ingress and Terminating, there is no
+// actual Consul Config Entry type for mesh-gateway, at least for now. We still
+// create a type for future proofing, instead just using a bool for example.
+type ConsulMeshConfigEntry struct {
+	// nothing in here
+}
+
+func (e *ConsulMeshConfigEntry) Canonicalize() {
+	return
+}
+
+func (e *ConsulMeshConfigEntry) Copy() *ConsulMeshConfigEntry {
+	if e == nil {
+		return nil
+	}
+	return new(ConsulMeshConfigEntry)
+}

--- a/vendor/github.com/hashicorp/nomad/api/services.go
+++ b/vendor/github.com/hashicorp/nomad/api/services.go
@@ -281,8 +281,8 @@ func (cp *ConsulProxy) Canonicalize() {
 		cp.Upstreams = nil
 	}
 
-	for i := 0; i < len(cp.Upstreams); i++ {
-		cp.Upstreams[i].Canonicalize()
+	for _, upstream := range cp.Upstreams {
+		upstream.Canonicalize()
 	}
 
 	if len(cp.Config) == 0 {

--- a/vendor/github.com/hashicorp/nomad/api/services.go
+++ b/vendor/github.com/hashicorp/nomad/api/services.go
@@ -310,13 +310,9 @@ type ConsulMeshGateway struct {
 }
 
 func (c *ConsulMeshGateway) Canonicalize() {
-	if c == nil {
-		return
-	}
-
-	if c.Mode == "" {
-		c.Mode = "none"
-	}
+	// Mode may be empty string, indicating behavior will defer to Consul
+	// service-defaults config entry.
+	return
 }
 
 func (c *ConsulMeshGateway) Copy() *ConsulMeshGateway {

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -43,6 +43,8 @@ Exactly one of `ingress` or `terminating` must be configured.
   that will be associated with the service.
 - `terminating` <code>([terminating]: nil)</code> - Configuration Entry of type `terminating-gateway`
   that will be associated with the service.
+- `mesh` <code>([mesh]: nil)</code> - Indicates a mesh gateway will be associated
+  with the service.
 
 ### `proxy` Parameters
 
@@ -165,6 +167,10 @@ envoy_gateway_bind_addresses "<service>" {
   to verify the gateway's authenticity. It must be provided if a `cert_file` is provided.
 - `sni` `(string: <optional>)` - An optional hostname or domain name to specify during
   the TLS handshake.
+
+### `mesh` Parameters
+
+  The `mesh` block currently does not have any configurable parameters.
 
 ### Gateway with host networking
 
@@ -433,6 +439,201 @@ job "countdash-terminating" {
 }
 ```
 
+#### mesh gateway
+
+Mesh gateways are useful when Connect services need to make cross-datacenter
+requests where not all nodes in each datacenter have full connectivity. This example
+demonstrates using mesh gateways to enable making requests between datacenters
+`one` and `two`, where each mesh gateway will bind to the `public` host network
+configured on at least one Nomad client in each datacenter.
+
+Job running where Nomad and Consul are in datacenter `one`.
+
+```hcl
+job "countdash-mesh-one" {
+  datacenters = ["one"]
+
+  group "mesh-gateway-one" {
+    network {
+      mode = "bridge"
+
+      # A mesh gateway will require a host_network configured on at least one
+      # Nomad client that can establish cross-datacenter connections. Nomad will
+      # automatically schedule the mesh gateway task on compatible Nomad clients.
+      port "mesh_wan" {
+        host_network = "public"
+      }
+    }
+
+    service {
+      name = "mesh-gateway"
+
+      # The mesh gateway connect service should be configured to use a port from
+      # the host_network capable of cross-datacenter connections.
+      port = "mesh_wan"
+
+      connect {
+        gateway {
+          mesh {
+            # No configuration options in the mesh block.
+          }
+
+          # Consul gateway [envoy] proxy options.
+          proxy {
+            # The following options are automatically set by Nomad if not explicitly
+            # configured with using bridge networking.
+            #
+            # envoy_gateway_no_default_bind = true
+            # envoy_gateway_bind_addresses "lan" {
+            #   address = "0.0.0.0"
+            #   port    = <generated dynamic port>
+            # }
+            # envoy_gateway_bind_addresses "wan" {
+            #   address = "0.0.0.0"
+            #   port    = <configured service port>
+            # }
+            # Additional options are documented at
+            # https://www.nomadproject.io/docs/job-specification/gateway#proxy-parameters
+          }
+        }
+      }
+    }
+  }
+
+  group "dashboard" {
+    network {
+      mode = "bridge"
+
+      port "http" {
+        static = 9002
+        to     = 9002
+      }
+    }
+
+    service {
+      name = "count-dashboard"
+      port = "9002"
+
+      connect {
+        sidecar_service {
+          proxy {
+            upstreams {
+              destination_name = "count-api"
+              local_bind_port  = 8080
+
+              # This dashboard service is running in datacenter "one", and will
+              # make requests to the "count-api" service running in datacenter
+              # "two", by going through the mesh gateway in each datacenter.
+              datacenter       = "two"
+
+              mesh_gateway {
+                # Using "local" mode indicates requests should exit this datacenter
+                # through the mesh gateway, and enter the destination datacenter
+                # through a mesh gateway in that datacenter.
+                # Using "remote" mode indicates requests should bypass the local
+                # mesh gateway, instead directly connecting to the mesh gateway
+                # in the destination datacenter.
+                mode = "local"
+              }
+            }
+          }
+        }
+      }
+    }
+
+    task "dashboard" {
+      driver = "docker"
+
+      env {
+        COUNTING_SERVICE_URL = "http://${NOMAD_UPSTREAM_ADDR_count_api}"
+      }
+
+      config {
+        image = "hashicorpnomad/counter-dashboard:v3"
+      }
+    }
+  }
+}
+```
+
+Job running where Nomad and Consul are in datacenter `two`.
+
+```hcl
+job "countdash-mesh-two" {
+  datacenters = ["two"]
+
+  group "mesh-gateway-two" {
+    network {
+      mode = "bridge"
+
+      # A mesh gateway will require a host_network configured for at least one
+      # Nomad client that can establish cross-datacenter connections. Nomad will
+      # automatically schedule the mesh gateway task on compatible Nomad clients.
+      port "mesh_wan" {
+        host_network = "public"
+      }
+    }
+
+    service {
+      name = "mesh-gateway"
+
+      # The mesh gateway connect service should be configured to use a port from
+      # the host_network capable of cross-datacenter connections.
+      port = "mesh_wan"
+
+      connect {
+        gateway {
+          mesh {
+            # No configuration options in the mesh block.
+          }
+
+          # Consul gateway [envoy] proxy options.
+          proxy {
+            # The following options are automatically set by Nomad if not explicitly
+            # configured with using bridge networking.
+            #
+            # envoy_gateway_no_default_bind = true
+            # envoy_gateway_bind_addresses "lan" {
+            #   address = "0.0.0.0"
+            #   port    = <generated dynamic port>
+            # }
+            # envoy_gateway_bind_addresses "wan" {
+            #   address = "0.0.0.0"
+            #   port    = <configured service port>
+            # }
+            # Additional options are documented at
+            # https://www.nomadproject.io/docs/job-specification/gateway#proxy-parameters
+          }
+        }
+      }
+    }
+  }
+
+  group "api" {
+    network {
+      mode = "bridge"
+    }
+
+    service {
+      name = "count-api"
+      port = "9001"
+      connect {
+        sidecar_service {}
+      }
+    }
+
+    task "api" {
+      driver = "docker"
+
+      config {
+        image = "hashicorpnomad/counter-api:v3"
+      }
+    }
+  }
+}
+```
+
+
 [address]: /docs/job-specification/gateway#address-parameters
 [advanced configuration]: https://www.consul.io/docs/connect/proxies/envoy#advanced-configuration
 [connect_timeout_ms]: https://www.consul.io/docs/agent/config-entries/service-resolver#connecttimeout
@@ -446,3 +647,4 @@ job "countdash-terminating" {
 [sidecar_task]: /docs/job-specification/sidecar_task
 [terminating]: /docs/job-specification/gateway#terminating-parameters
 [tls]: /docs/job-specification/gateway#tls-parameters
+[mesh]: /docs/job-specification/gateway#mesh-parameters

--- a/website/content/docs/job-specification/upstreams.mdx
+++ b/website/content/docs/job-specification/upstreams.mdx
@@ -52,8 +52,11 @@ job "countdash" {
             upstreams {
               destination_name = "count-api"
               local_bind_port  = 8080
-              datacenter = "dc1"
+              datacenter = "dc2"
               local_bind_address = "127.0.0.1"
+              mesh_gateway {
+                mode = "local"
+              }
             }
           }
         }
@@ -86,6 +89,22 @@ job "countdash" {
   local Consul datacenter.
 - `local_bind_address` - `(string: "")` - The address the proxy will receive
   connections for the upstream on.
+- `mesh_gateway` <code>([mesh_gateway][mesh_gateway_param]: nil)</code> - Configures the mesh gateway
+  behavior for connecting to this upstream.
+
+### `mesh_gateway` Parameters
+
+- `mode` `(string: "default")` - The mode of operation in which to use [Connect Mesh Gateways][mesh_gateways]
+Defaults to the mode as determined by the Consul [service-defaults][service_defaults_mode]
+  configuration for the service. Can be configured with the following modes:
+  - `local` - In this mode the Connect proxy makes its outbound connection to a
+  gateway running in the same datacenter. That gateway is then responsible for
+  ensuring the data gets forwarded along to gateways in the destination datacenter.
+  - `remote` - In this mode the Connect proxy makes its outbound connection to a
+  gateway running in the destination datacenter. That gateway will then forward
+  the data to the final destination service.
+  - `none` - In this mode, no gateway is used and a Connect proxy makes its
+  outbound connections directly to the destination services.
 
 The `NOMAD_UPSTREAM_ADDR_<destination_name>` environment variables may be used
 to interpolate the upstream's `host:port` address.
@@ -113,3 +132,6 @@ and a local bind port.
 [interpolation]: /docs/runtime/interpolation 'Nomad interpolation'
 [sidecar_service]: /docs/job-specification/sidecar_service 'Nomad sidecar service Specification'
 [upstreams]: /docs/job-specification/upstreams 'Nomad upstream config Specification'
+[service_defaults_mode]: https://www.consul.io/docs/connect/config-entries/service-defaults#meshgateway
+[mesh_gateway_param]: /docs/job-specification/upstreams#mesh_gateway-parameters
+[mesh_gateways]: https://www.consul.io/docs/connect/gateways/mesh-gateway#mesh-gateways

--- a/website/content/docs/job-specification/upstreams.mdx
+++ b/website/content/docs/job-specification/upstreams.mdx
@@ -94,8 +94,8 @@ job "countdash" {
 
 ### `mesh_gateway` Parameters
 
-- `mode` `(string: "default")` - The mode of operation in which to use [Connect Mesh Gateways][mesh_gateways]
-Defaults to the mode as determined by the Consul [service-defaults][service_defaults_mode]
+- `mode` `(string: "")` - The mode of operation in which to use [Connect Mesh Gateways][mesh_gateways].
+  If left unset, the mode will default to the mode as determined by the Consul [service-defaults][service_defaults_mode]
   configuration for the service. Can be configured with the following modes:
   - `local` - In this mode the Connect proxy makes its outbound connection to a
   gateway running in the same datacenter. That gateway is then responsible for


### PR DESCRIPTION
This PR implements first-class support for Nomad running Consul
Connect Mesh Gateways. Mesh gateways enable services in the Connect
mesh to make cross-DC connections via gateways, where each datacenter
may not have full node inter-connectivity.

Note: in this context "datacenter" means _Consul_ datacenter.

Consul docs with more information:
https://www.consul.io/docs/connect/gateways/mesh-gateway

The following group level service block can be used to establish
a Connect mesh gateway.

```hcl
service {
  connect {
    gateway {
      mesh {
        // no configuration
      }
    }
  }
}
```

Services can make use of a mesh gateway by configuring so in their
upstream blocks, e.g.

```hcl
service {
  connect {
    sidecar_service {
      proxy {
        upstreams {
          destination_name = "<service>"
          local_bind_port  = <port>
          datacenter       = "<datacenter>"
          mesh_gateway {
            mode = "<mode>"
          }
        }
      }
    }
  }
}
```

Typical use of a mesh gateway is to create a bridge between DCs.
A mesh gateway should then be configured with a service port that is
mapped from a `host_network` configured on a WAN interface in Nomad agent
config, e.g.

```hcl
client {
  host_network "public" {
    interface = "eth1"
  }
}
```

Create a port mapping in the `group.network` block for use by the mesh
gateway service from the public `host_network`, e.g.

```hcl
network {
  mode = "bridge"
  port "mesh_wan" {
    host_network = "public"
  }
}
```

Use this port label for the `service.port` of the mesh gateway, e.g.

```hcl
service {
  name = "mesh-gateway"
  port = "mesh_wan"
  connect {
    gateway {
      mesh {}
    }
  }
}
```

Currently Envoy is the only supported gateway implementation in Consul.
By default Nomad client will run the latest official Envoy docker image
supported by the local Consul agent. The Envoy task can be customized
by setting `meta.connect.gateway_image` in agent config or by setting
the `connect.sidecar_task` block.

Gateways require Consul 1.8.0+, enforced by the Nomad scheduler.

Closes #9446