### PR TITLE
e2e: fix terraform output environment command instruction

### DIFF
--- a/e2e/terraform/outputs.tf
+++ b/e2e/terraform/outputs.tf
@@ -14,7 +14,7 @@ output "message" {
   value = <<EOM
 Your cluster has been provisioned! To prepare your environment, run:
 
-   $(terraform output environment)
+   $(terraform output --raw environment)
 
 Then you can run tests from the e2e directory with:
 


### PR DESCRIPTION
Without `--raw` this command fails: 

```shellsession
$ $(terraform output environment)
zsh: command not found: <<EOT
```