### PR TITLE
leader: call argument eval for log formatting lazily

### DIFF
--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -784,7 +784,8 @@ func (s *Server) reapFailedEvaluations(stopCh chan struct{}) {
 			updateEval := eval.Copy()
 			updateEval.Status = structs.EvalStatusFailed
 			updateEval.StatusDescription = fmt.Sprintf("evaluation reached delivery limit (%d)", s.config.EvalDeliveryLimit)
-			s.logger.Warn("eval reached delivery limit, marking as failed", "eval", updateEval.GoString())
+			s.logger.Warn("eval reached delivery limit, marking as failed",
+				"eval", log.Fmt("%#v", updateEval))
 
 			// Core job evals that fail or span leader elections will never
 			// succeed because the follow-up doesn't have the leader ACL. We
@@ -807,7 +808,8 @@ func (s *Server) reapFailedEvaluations(stopCh chan struct{}) {
 					Evals: []*structs.Evaluation{updateEval, followupEval},
 				}
 				if _, _, err := s.raftApply(structs.EvalUpdateRequestType, &req); err != nil {
-					s.logger.Error("failed to update failed eval and create a follow-up", "eval", updateEval.GoString(), "error", err)
+					s.logger.Error("failed to update failed eval and create a follow-up",
+						"eval", log.Fmt("%#v", updateEval), "error", err)
 					continue
 				}
 			}


### PR DESCRIPTION
Arguments to our logger's various write methods are evaluated eagerly, so method calls in log parameters will always be called, regardless of log level. Move some logger messages to the logger's `Fmt` method so that `GoString` is evaluated lazily instead.

Noticed this while working on an unrelated bug, where it'll matter more as it's in a hot code path. Realistically if we're on this code path we're going to evaluate these anyways because our worst log level is `warn`, but given that we have a habit of copy-and-pasting code around it's better to "always do it right". 

https://play.golang.org/p/azP_04QmQGY gives a demonstration of how the lazy evaluation works out.