### PR TITLE
drivers/exec: Don't inherit Nomad oom_score_adj value

### DIFF
--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -764,6 +764,10 @@ func newLibcontainerConfig(command *ExecCommand) (*lconfigs.Config, error) {
 
 	configureCapabilities(cfg, command)
 
+	// children should not inherit Nomad agent oom_score_adj value
+	oomScoreAdj := 0
+	cfg.OomScoreAdj = &oomScoreAdj
+
 	if err := configureIsolation(cfg, command); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Explicitly set the `oom_score_adj` value for `exec` and `java` tasks.

We recommend that the Nomad service to have oom_score_adj of a low value
(e.g. -1000) to avoid having nomad agent OOM Killed if the node is
oversubscriped.

However, Nomad's workloads should not inherit Nomad's process, which is
the default behavior.

Added a failed test first that you can see in https://app.circleci.com/pipelines/github/hashicorp/nomad/16419/workflows/2c6fee1f-13c5-4d8b-99c2-75bce52bb949/jobs/158264 .

Fixes #10663