### PR TITLE
CSI: accept list of caps during validation in volume register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ BUG FIXES:
 * cli: Fixed a bug where `quota status` and `namespace status` commands may panic if the CLI targets a pre-1.1.0 cluster [[GH-10620](https://github.com/hashicorp/nomad/pull/10620)]
 * cli: Fixed a bug where `alloc exec` may fail with "unexpected EOF" without returning the exit code after a command [[GH-10657](https://github.com/hashicorp/nomad/issues/10657)]
 * csi: Fixed a bug where `mount_options` were not passed to CSI controller plugins for validation during volume creation and mounting. [[GH-10643](https://github.com/hashicorp/nomad/issues/10643)]
+* csi: Fixed a bug where `capability` blocks were not passed to CSI controller plugins for validation for `nomad volume register` commands. [[GH-10703](https://github.com/hashicorp/nomad/issues/10703)]
 * drivers/exec: Fixed a bug where `exec` and `java` tasks inherit the Nomad agent's `oom_score_adj` value [[GH-10698](https://github.com/hashicorp/nomad/issues/10698)]
 * quotas (Enterprise): Fixed a bug where stopped allocations for a failed deployment can be double-credited to quota limits, resulting in a quota limit bypass. [[GH-10694](https://github.com/hashicorp/nomad/issues/10694)]
 * ui: Fixed a bug where exec would not work across regions. [[GH-10539](https://github.com/hashicorp/nomad/issues/10539)]

--- a/client/csi_endpoint_test.go
+++ b/client/csi_endpoint_test.go
@@ -206,9 +206,11 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 				CSIControllerQuery: structs.CSIControllerQuery{
 					PluginID: fakePlugin.Name,
 				},
-				VolumeID:       "1234-4321-1234-4321",
-				AttachmentMode: nstructs.CSIVolumeAttachmentMode("bar"),
-				AccessMode:     nstructs.CSIVolumeAccessModeMultiNodeReader,
+				VolumeID: "1234-4321-1234-4321",
+				VolumeCapabilities: []*nstructs.CSIVolumeCapability{{
+					AttachmentMode: nstructs.CSIVolumeAttachmentMode("bar"),
+					AccessMode:     nstructs.CSIVolumeAccessModeMultiNodeReader,
+				}},
 			},
 			ExpectedErr: errors.New("CSI.ControllerValidateVolume: unknown volume attachment mode: bar"),
 		},
@@ -218,9 +220,11 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 				CSIControllerQuery: structs.CSIControllerQuery{
 					PluginID: fakePlugin.Name,
 				},
-				VolumeID:       "1234-4321-1234-4321",
-				AttachmentMode: nstructs.CSIVolumeAttachmentModeFilesystem,
-				AccessMode:     nstructs.CSIVolumeAccessMode("foo"),
+				VolumeID: "1234-4321-1234-4321",
+				VolumeCapabilities: []*nstructs.CSIVolumeCapability{{
+					AttachmentMode: nstructs.CSIVolumeAttachmentModeFilesystem,
+					AccessMode:     nstructs.CSIVolumeAccessMode("foo"),
+				}},
 			},
 			ExpectedErr: errors.New("CSI.ControllerValidateVolume: unknown volume access mode: foo"),
 		},

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -249,12 +249,11 @@ func (v *CSIVolume) controllerValidateVolume(req *structs.CSIVolumeRegisterReque
 
 	method := "ClientCSI.ControllerValidateVolume"
 	cReq := &cstructs.ClientCSIControllerValidateVolumeRequest{
-		VolumeID:       vol.RemoteID(),
-		AttachmentMode: vol.AttachmentMode,
-		AccessMode:     vol.AccessMode,
-		Secrets:        vol.Secrets,
-		Parameters:     vol.Parameters,
-		Context:        vol.Context,
+		VolumeID:           vol.RemoteID(),
+		VolumeCapabilities: vol.RequestedCapabilities,
+		Secrets:            vol.Secrets,
+		Parameters:         vol.Parameters,
+		Context:            vol.Context,
 	}
 	cReq.PluginID = plugin.ID
 	cResp := &cstructs.ClientCSIControllerValidateVolumeResponse{}

--- a/plugins/csi/client_test.go
+++ b/plugins/csi/client_test.go
@@ -664,14 +664,14 @@ func TestClient_RPC_ControllerValidateVolume(t *testing.T) {
 			_, cc, _, client := newTestClient()
 			defer client.Close()
 
-			requestedCaps := &VolumeCapability{
+			requestedCaps := []*VolumeCapability{{
 				AccessType: tc.AccessType,
 				AccessMode: tc.AccessMode,
 				MountVolume: &structs.CSIMountOptions{ // should be ignored
 					FSType:     "ext4",
 					MountFlags: []string{"noatime", "errors=remount-ro"},
 				},
-			}
+			}}
 			req := &ControllerValidateVolumeRequest{
 				ExternalID:   "volumeID",
 				Secrets:      structs.CSISecrets{},

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -349,7 +349,7 @@ func NewControllerCapabilitySet(resp *csipbv1.ControllerGetCapabilitiesResponse)
 type ControllerValidateVolumeRequest struct {
 	ExternalID   string
 	Secrets      structs.CSISecrets
-	Capabilities *VolumeCapability
+	Capabilities []*VolumeCapability
 	Parameters   map[string]string
 	Context      map[string]string
 }
@@ -359,14 +359,17 @@ func (r *ControllerValidateVolumeRequest) ToCSIRepresentation() *csipbv1.Validat
 		return nil
 	}
 
+	caps := make([]*csipbv1.VolumeCapability, 0, len(r.Capabilities))
+	for _, cap := range r.Capabilities {
+		caps = append(caps, cap.ToCSIRepresentation())
+	}
+
 	return &csipbv1.ValidateVolumeCapabilitiesRequest{
-		VolumeId:      r.ExternalID,
-		VolumeContext: r.Context,
-		VolumeCapabilities: []*csipbv1.VolumeCapability{
-			r.Capabilities.ToCSIRepresentation(),
-		},
-		Parameters: r.Parameters,
-		Secrets:    r.Secrets,
+		VolumeId:           r.ExternalID,
+		VolumeContext:      r.Context,
+		VolumeCapabilities: caps,
+		Parameters:         r.Parameters,
+		Secrets:            r.Secrets,
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10626

When `nomad volume create` was introduced in Nomad 1.1.0, we changed the volume spec to take a list of capabilities rather than a single capability, to meet the requirements of the CSI spec. When a volume is registered via `nomad volume register`, we should be using the same fields to validate the volume with the controller plugin.