### PR TITLE
e2e terraform tweaks: 2021-06 edition

### DIFF
--- a/e2e/terraform/.terraform.lock.hcl
+++ b/e2e/terraform/.terraform.lock.hcl
@@ -39,6 +39,24 @@ provider "registry.terraform.io/hashicorp/external" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/http" {
+  version = "2.1.0"
+  hashes = [
+    "h1:GYoVrTtiSAE3AlP1fad3fFmHoPaXAPhm/DJyMcVCwZA=",
+    "zh:03d82dc0887d755b8406697b1d27506bc9f86f93b3e9b4d26e0679d96b802826",
+    "zh:0704d02926393ddc0cfad0b87c3d51eafeeae5f9e27cc71e193c141079244a22",
+    "zh:095ea350ea94973e043dad2394f10bca4a4bf41be775ba59d19961d39141d150",
+    "zh:0b71ac44e87d6964ace82979fc3cbb09eb876ed8f954449481bcaa969ba29cb7",
+    "zh:0e255a170db598bd1142c396cefc59712ad6d4e1b0e08a840356a371e7b73bc4",
+    "zh:67c8091cfad226218c472c04881edf236db8f2dc149dc5ada878a1cd3c1de171",
+    "zh:75df05e25d14b5101d4bc6624ac4a01bb17af0263c9e8a740e739f8938b86ee3",
+    "zh:b4e36b2c4f33fdc44bf55fa1c9bb6864b5b77822f444bd56f0be7e9476674d0e",
+    "zh:b9b36b01d2ec4771838743517bc5f24ea27976634987c6d5529ac4223e44365d",
+    "zh:ca264a916e42e221fddb98d640148b12e42116046454b39ede99a77fc52f59f4",
+    "zh:fe373b2fb2cc94777a91ecd7ac5372e699748c455f44f6ea27e494de9e5e6f92",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.1.0"
   hashes = [

--- a/e2e/terraform/network.tf
+++ b/e2e/terraform/network.tf
@@ -7,6 +7,14 @@ data "aws_subnet" "default" {
   vpc_id            = data.aws_vpc.default.id
 }
 
+data "http" "my_public_ipv4" {
+  url = "https://ipv4.icanhazip.com"
+}
+
+locals {
+  ingress_cidr = var.restrict_ingress_cidrblock ? "${chomp(data.http.my_public_ipv4.body)}/32" : "0.0.0.0/0"
+}
+
 resource "aws_security_group" "primary" {
   name   = local.random_name
   vpc_id = data.aws_vpc.default.id
@@ -15,7 +23,7 @@ resource "aws_security_group" "primary" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [local.ingress_cidr]
   }
 
   # Nomad
@@ -23,7 +31,7 @@ resource "aws_security_group" "primary" {
     from_port   = 4646
     to_port     = 4646
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [local.ingress_cidr]
   }
 
   # Fabio
@@ -31,7 +39,7 @@ resource "aws_security_group" "primary" {
     from_port   = 9998
     to_port     = 9999
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [local.ingress_cidr]
   }
 
   # Consul
@@ -39,7 +47,7 @@ resource "aws_security_group" "primary" {
     from_port   = 8500
     to_port     = 8500
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [local.ingress_cidr]
   }
 
   # Vault
@@ -47,7 +55,7 @@ resource "aws_security_group" "primary" {
     from_port   = 8200
     to_port     = 8200
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [local.ingress_cidr]
   }
 
   # HDFS NameNode UI
@@ -55,7 +63,7 @@ resource "aws_security_group" "primary" {
     from_port   = 50070
     to_port     = 50070
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [local.ingress_cidr]
   }
 
   # HDFS DataNode UI
@@ -63,7 +71,7 @@ resource "aws_security_group" "primary" {
     from_port   = 50075
     to_port     = 50075
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [local.ingress_cidr]
   }
 
   # Spark history server UI
@@ -71,7 +79,7 @@ resource "aws_security_group" "primary" {
     from_port   = 18080
     to_port     = 18080
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [local.ingress_cidr]
   }
 
   ingress {

--- a/e2e/terraform/network.tf
+++ b/e2e/terraform/network.tf
@@ -58,30 +58,6 @@ resource "aws_security_group" "primary" {
     cidr_blocks = [local.ingress_cidr]
   }
 
-  # HDFS NameNode UI
-  ingress {
-    from_port   = 50070
-    to_port     = 50070
-    protocol    = "tcp"
-    cidr_blocks = [local.ingress_cidr]
-  }
-
-  # HDFS DataNode UI
-  ingress {
-    from_port   = 50075
-    to_port     = 50075
-    protocol    = "tcp"
-    cidr_blocks = [local.ingress_cidr]
-  }
-
-  # Spark history server UI
-  ingress {
-    from_port   = 18080
-    to_port     = 18080
-    protocol    = "tcp"
-    cidr_blocks = [local.ingress_cidr]
-  }
-
   ingress {
     from_port = 0
     to_port   = 0

--- a/e2e/terraform/nomad.tf
+++ b/e2e/terraform/nomad.tf
@@ -19,6 +19,8 @@ module "nomad_server" {
 
   nomad_local_binary = count.index < length(var.nomad_local_binary_server) ? var.nomad_local_binary_server[count.index] : var.nomad_local_binary
 
+  nomad_url = count.index < length(var.nomad_url_server) ? var.nomad_url_server[count.index] : var.nomad_url
+
   nomad_enterprise = var.nomad_enterprise
   nomad_license    = var.nomad_license
   nomad_acls       = var.nomad_acls
@@ -55,6 +57,8 @@ module "nomad_client_ubuntu_bionic_amd64" {
   nomad_sha = count.index < length(var.nomad_sha_client_ubuntu_bionic_amd64) ? var.nomad_sha_client_ubuntu_bionic_amd64[count.index] : var.nomad_sha
 
   nomad_local_binary = count.index < length(var.nomad_local_binary_client_ubuntu_bionic_amd64) ? var.nomad_local_binary_client_ubuntu_bionic_amd64[count.index] : var.nomad_local_binary
+
+  nomad_url = count.index < length(var.nomad_url_client_ubuntu_bionic_amd64) ? var.nomad_url_client_ubuntu_bionic_amd64[count.index] : var.nomad_url
 
   nomad_enterprise = var.nomad_enterprise
   nomad_acls       = false

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/provision.sh
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/provision.sh
@@ -11,6 +11,7 @@ Options (use one of the following):
  --nomad_sha SHA          full git sha to install from S3
  --nomad_version VERSION  release version number (ex. 0.12.4+ent)
  --nomad_binary FILEPATH  path to file on host
+ --nomad_url URL          url to nomad binary archive
 
 Options for configuration:
  --config_profile FILEPATH  path to config profile directory
@@ -76,12 +77,6 @@ install_from_release() {
 }
 
 install_from_url() {
-    # check that we don't already have this version
-    if [ "$(command -v nomad)" ]; then
-        nomad -version | grep -v 'dev' | grep -q "${NOMAD_VERSION}" \
-            && echo "$NOMAD_VERSION already installed" && return
-    fi
-
     case "${NOMAD_URL}" in
         *.zip*)
             curl -sL --fail -o /tmp/nomad.zip "$NOMAD_URL"

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -54,6 +54,12 @@ variable "profile" {
   default     = ""
 }
 
+variable "restrict_ingress_cidrblock" {
+  description = "Restrict ingress traffic to cluster to invoker ip address"
+  type        = bool
+  default     = true
+}
+
 # ----------------------------------------
 # The specific version of Nomad deployed will default to whichever one of
 # nomad_sha, nomad_version, or nomad_local_binary is set


### PR DESCRIPTION
Tweaks to the terraform scripts, mainly so that we restrict ingress traffic by default to the host invoking the terraform apply. Useful as a basic security control for our e2e infrastructure as well as dev clusters. Dev clusters are typically accessed from a single host, the developers account, and they can change the security groups after creation.

Also, some fixes for handling `nomad_url`.