### PR TITLE
deployment query rate limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ IMPROVEMENTS:
 * cli: Cross-namespace `nomad job` commands will now select exact matches if the selection is unambiguous. [[GH-10648](https://github.com/hashicorp/nomad/issues/10648)]
 * client/fingerprint: Consul fingerprinter probes for additional enterprise and connect related attributes [[GH-10699](https://github.com/hashicorp/nomad/pull/10699)]
 * csi: Validate that `volume` blocks for CSI volumes include the required `attachment_mode` and `access_mode` fields. [[GH-10651](https://github.com/hashicorp/nomad/issues/10651)]
+* server: Make deployment rate limiting configurable for high volume loads [[GH-10706](https://github.com/hashicorp/nomad/pull/10706)]
 
 BUG FIXES:
 * api: Fixed event stream connection initialization when there are no events to send [[GH-10637](https://github.com/hashicorp/nomad/issues/10637)]

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/nomad/nomad/deploymentwatcher"
 	"io"
 	"io/ioutil"
 	golog "log"
@@ -418,6 +419,15 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 		return nil, fmt.Errorf("rpc_max_conns_per_client must be > %d; found: %d", minLimit, limit)
 	} else {
 		conf.RPCMaxConnsPerClient = limit
+	}
+
+	// Set deployment rate limit
+	if rate := agentConfig.Server.DeploymentRateLimit; rate == 0 {
+		conf.DeploymentRateLimit = deploymentwatcher.LimitStateQueriesPerSecond
+	} else if rate > 0 {
+		conf.DeploymentRateLimit = rate
+	} else {
+		return nil, fmt.Errorf("deployment-rate-limit must be greater than 0")
 	}
 
 	// Add Enterprise license configs

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -427,7 +427,7 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	} else if rate > 0 {
 		conf.DeploymentQueryRateLimit = rate
 	} else {
-		return nil, fmt.Errorf("deployment_query_rate_limit must be greater than 0")
+		return nil, fmt.Errorf("deploy_query_rate_limit must be greater than 0")
 	}
 
 	// Add Enterprise license configs

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -422,12 +422,12 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	}
 
 	// Set deployment rate limit
-	if rate := agentConfig.Server.DeploymentRateLimit; rate == 0 {
-		conf.DeploymentRateLimit = deploymentwatcher.LimitStateQueriesPerSecond
+	if rate := agentConfig.Server.DeploymentQueryRateLimit; rate == 0 {
+		conf.DeploymentQueryRateLimit = deploymentwatcher.LimitStateQueriesPerSecond
 	} else if rate > 0 {
-		conf.DeploymentRateLimit = rate
+		conf.DeploymentQueryRateLimit = rate
 	} else {
-		return nil, fmt.Errorf("deployment-rate-limit must be greater than 0")
+		return nil, fmt.Errorf("deployment_query_rate_limit must be greater than 0")
 	}
 
 	// Add Enterprise license configs

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/nomad/nomad/deploymentwatcher"
 	"io"
 	"io/ioutil"
 	golog "log"
@@ -30,6 +29,7 @@ import (
 	"github.com/hashicorp/nomad/helper/pluginutils/loader"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad"
+	"github.com/hashicorp/nomad/nomad/deploymentwatcher"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/raft"

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -98,7 +98,6 @@ func (c *Command) readConfig() *Config {
 		cmdConfig.Server.ServerJoin.RetryInterval = d
 		return nil
 	}), "retry-interval", "")
-	flags.Float64Var(&cmdConfig.Server.DeploymentRateLimit, "deployment-rate-limit", 0, "")
 
 	// Client-only options
 	flags.StringVar(&cmdConfig.Client.StateDir, "state-dir", "", "")

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -98,6 +98,7 @@ func (c *Command) readConfig() *Config {
 		cmdConfig.Server.ServerJoin.RetryInterval = d
 		return nil
 	}), "retry-interval", "")
+	flags.Float64Var(&cmdConfig.Server.DeploymentRateLimit, "deployment-rate-limit", 0, "")
 
 	// Client-only options
 	flags.StringVar(&cmdConfig.Client.StateDir, "state-dir", "", "")

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -517,9 +517,9 @@ type ServerConfig struct {
 
 	Search *Search `hcl:"search"`
 
-	// DeploymentRateLimit is in queries per second and is used by the
+	// DeploymentQueryRateLimit is in queries per second and is used by the
 	// DeploymentWatcher to throttle the amount of simultaneously deployments
-	DeploymentQueryRateLimit float64 `hcl:"deploy_query_rate_limt"`
+	DeploymentQueryRateLimit float64 `hcl:"deploy_query_rate_limit"`
 }
 
 // Search is used in servers to configure search API options.

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -1526,6 +1526,10 @@ func (a *ServerConfig) Merge(b *ServerConfig) *ServerConfig {
 		result.DefaultSchedulerConfig = &c
 	}
 
+	if b.DeploymentQueryRateLimit != 0 {
+		result.DeploymentQueryRateLimit = b.DeploymentQueryRateLimit
+	}
+
 	if b.Search != nil {
 		result.Search = &Search{FuzzyEnabled: b.Search.FuzzyEnabled}
 		if b.Search.LimitQuery > 0 {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -516,6 +516,10 @@ type ServerConfig struct {
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 
 	Search *Search `hcl:"search"`
+
+	// DeploymentRateLimit is in queries per second and is used by the
+	// DeploymentWatcher to throttle the amount of simultaneously deployments
+	DeploymentRateLimit float64
 }
 
 // Search is used in servers to configure search API options.

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -519,7 +519,7 @@ type ServerConfig struct {
 
 	// DeploymentRateLimit is in queries per second and is used by the
 	// DeploymentWatcher to throttle the amount of simultaneously deployments
-	DeploymentRateLimit float64
+	DeploymentQueryRateLimit float64 `hcl:"deploy_query_rate_limt"`
 }
 
 // Search is used in servers to configure search API options.

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -364,9 +364,9 @@ type Config struct {
 	// It is used primarily for licensing
 	AgentShutdown func() error
 
-	// DeploymentRateLimit is in queries per second and is used by the
+	// DeploymentQueryRateLimit is in queries per second and is used by the
 	// DeploymentWatcher to throttle the amount of simultaneously deployments
-	DeploymentRateLimit float64
+	DeploymentQueryRateLimit float64
 }
 
 // CheckVersion is used to check if the ProtocolVersion is valid

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/nomad/helper/pluginutils/loader"
 	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/deploymentwatcher"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/scheduler"
@@ -452,6 +453,7 @@ func DefaultConfig() *Config {
 				ServiceSchedulerEnabled: false,
 			},
 		},
+		DeploymentQueryRateLimit: deploymentwatcher.LimitStateQueriesPerSecond,
 	}
 
 	// Enable all known schedulers by default

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -363,6 +363,10 @@ type Config struct {
 	// AgentShutdown is used to call agent.Shutdown from the context of a Server
 	// It is used primarily for licensing
 	AgentShutdown func() error
+
+	// DeploymentRateLimit is in queries per second and is used by the
+	// DeploymentWatcher to throttle the amount of simultaneously deployments
+	DeploymentRateLimit float64
 }
 
 // CheckVersion is used to check if the ProtocolVersion is valid

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1021,7 +1021,7 @@ func (s *Server) setupDeploymentWatcher() error {
 		raftShim,
 		s.staticEndpoints.Deployment,
 		s.staticEndpoints.Job,
-		s.config.DeploymentRateLimit,
+		s.config.DeploymentQueryRateLimit,
 		deploymentwatcher.CrossDeploymentUpdateBatchDuration,
 	)
 

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1021,7 +1021,7 @@ func (s *Server) setupDeploymentWatcher() error {
 		raftShim,
 		s.staticEndpoints.Deployment,
 		s.staticEndpoints.Job,
-		deploymentwatcher.LimitStateQueriesPerSecond,
+		s.config.DeploymentRateLimit,
 		deploymentwatcher.CrossDeploymentUpdateBatchDuration,
 	)
 


### PR DESCRIPTION
Make it configurable for users to say how many statestore queries deployments can happen simultaneously. For the use case of huge deployment loads.