### PR TITLE
e2e: use api.ipify.org

### DIFF
--- a/e2e/terraform/network.tf
+++ b/e2e/terraform/network.tf
@@ -8,7 +8,7 @@ data "aws_subnet" "default" {
 }
 
 data "http" "my_public_ipv4" {
-  url = "https://ipv4.icanhazip.com"
+  url = "https://api.ipify.org"
 }
 
 locals {


### PR DESCRIPTION
ipv4.icanhazip.com returns ipv6 addresses

```
$ curl ipv4.icanhazip.com
2601:1c2:1a80:xxxx:xxxx:xxxx:xxxx:xxxx
$ curl https://api.ipify.org
73.xxx.xxx.xxx
```