### PR TITLE
B cores docker followup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ BUG FIXES:
 * csi: Fixed a bug where `capability` blocks were not passed to CSI controller plugins for validation for `nomad volume register` commands. [[GH-10703](https://github.com/hashicorp/nomad/issues/10703)]
 * client: Fixed a bug where `alloc exec` sessions may terminate abruptly after a few minutes [[GH-10710](https://github.com/hashicorp/nomad/issues/10710)]
 * drivers/exec: Fixed a bug where `exec` and `java` tasks inherit the Nomad agent's `oom_score_adj` value [[GH-10698](https://github.com/hashicorp/nomad/issues/10698)]
+* drivers/docker: Fixed a bug where short lived docker tasks may fail with obscure cpuset cgroup errors [[GH-10416](https://github.com/hashicorp/nomad/issues/10416)]
 * quotas (Enterprise): Fixed a bug where stopped allocations for a failed deployment can be double-credited to quota limits, resulting in a quota limit bypass. [[GH-10694](https://github.com/hashicorp/nomad/issues/10694)]
 * ui: Fixed a bug where exec would not work across regions. [[GH-10539](https://github.com/hashicorp/nomad/issues/10539)]
 * ui: Fixed global-search shortcut for non-english keyboards. [[GH-10714](https://github.com/hashicorp/nomad/issues/10714)]

--- a/drivers/docker/driver_linux.go
+++ b/drivers/docker/driver_linux.go
@@ -9,11 +9,9 @@ import (
 func setCPUSetCgroup(path string, pid int) error {
 	// Sometimes the container exists before we can write the
 	// cgroup resulting in an error which can be ignored.
-	if err := cgroups.WriteCgroupProc(path, pid); err != nil {
-		if strings.Contains(err.Error(), "no such process") {
-			return nil
-		}
-		return err
+	err := cgroups.WriteCgroupProc(path, pid)
+	if err != nil && strings.Contains(err.Error(), "no such process") {
+		return nil
 	}
-	return nil
+	return err
 }


### PR DESCRIPTION
Follow up for GH-10416 .

Should have pushed this to the original PR, but realized that the PR doesn't need backporting to 1.0.X only after merging the PR.