### PR TITLE
1.0.7: update golang to latest 1.15 point release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,7 +508,7 @@ executors:
   go:
     working_directory: /go/src/github.com/hashicorp/nomad
     docker:
-      - image: docker.mirror.hashicorp.services/golang:1.15.6
+      - image: docker.mirror.hashicorp.services/golang:1.15.13
     environment:
       <<: *common_envs
       GOPATH: /go
@@ -520,7 +520,7 @@ executors:
     environment: &machine_env
       <<: *common_envs
       GOPATH: /home/circleci/go
-      GOLANG_VERSION: 1.15.6
+      GOLANG_VERSION: 1.15.13
 
   # uses a more recent image with unattended upgrades disabled properly
   # but seems to break docker builds
@@ -537,7 +537,7 @@ executors:
     environment:
       <<: *common_envs
       GOPATH: /Users/distiller/go
-      GOLANG_VERSION: 1.15.6
+      GOLANG_VERSION: 1.15.13
 
   go-windows:
     machine:
@@ -549,7 +549,7 @@ executors:
       GOPATH: c:\gopath
       GOBIN: c:\gopath\bin
       GOTESTSUM_PATH: c:\tmp\test-reports
-      GOLANG_VERSION: 1.15.6
+      GOLANG_VERSION: 1.15.13
       GOTESTSUM_VERSION: 0.4.2
       VAULT_VERSION: 1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.0.7 (June 9, 2021)
 
+IMPROVEMENTS:
+* build: Updated to Go 1.15.13 [[GH-10734](https://github.com/hashicorp/nomad/issues/10734)]
+
 BUG FIXES:
 * api: Fixed event stream connection initialization when there are no events to send [[GH-10637](https://github.com/hashicorp/nomad/issues/10637)]
 * cli: Fixed a bug where `plugin status` did not validate the passed `type` flag correctly [[GH-10712](https://github.com/hashicorp/nomad/pull/10712)]

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -30,7 +30,7 @@ A development environment is supplied via Vagrant to make getting started easier
 
 Developing without Vagrant
 ---
-1. Install [Go 1.15.6+](https://golang.org/) *(Note: `gcc-go` is not supported)*
+1. Install [Go 1.15.13+](https://golang.org/) *(Note: `gcc-go` is not supported)*
 1. Clone this repo
    ```sh
    $ git clone https://github.com/hashicorp/nomad.git

--- a/nomad/event_endpoint_test.go
+++ b/nomad/event_endpoint_test.go
@@ -1,6 +1,7 @@
 package nomad
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -96,7 +97,7 @@ OUTER:
 			}
 
 			// ignore heartbeat
-			if msg.Event == stream.JsonHeartbeat {
+			if bytes.Equal(msg.Event.Data, stream.JsonHeartbeat.Data) {
 				continue
 			}
 
@@ -283,7 +284,7 @@ OUTER:
 				t.Fatalf("Got error: %v", msg.Error.Error())
 			}
 
-			if msg.Event == stream.JsonHeartbeat {
+			if bytes.Equal(msg.Event.Data, stream.JsonHeartbeat.Data) {
 				continue
 			}
 

--- a/scripts/release/mac-remote-build
+++ b/scripts/release/mac-remote-build
@@ -56,7 +56,7 @@ REPO_PATH="${TMP_WORKSPACE}/gopath/src/github.com/hashicorp/nomad"
 mkdir -p "${TMP_WORKSPACE}/tmp"
 
 install_go() {
-  local go_version="1.15.6"
+  local go_version="1.15.13"
   local download=
 
   download="https://storage.googleapis.com/golang/go${go_version}.darwin-amd64.tar.gz"

--- a/scripts/vagrant-linux-priv-go.sh
+++ b/scripts/vagrant-linux-priv-go.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 function install_go() {
-	local go_version="1.15.6"
+	local go_version="1.15.13"
 	local download="https://storage.googleapis.com/golang/go${go_version}.linux-amd64.tar.gz"
 
 		if go version 2>&1 | grep -q "${go_version}"; then


### PR DESCRIPTION
The golang 1.15 line contains many fixes since 1.15.6: https://golang.org/doc/devel/release#go1.15 .