### PR TITLE
core: remove unused types pkg and PeriodicCallback type.

### DIFF
--- a/nomad/types/types.go
+++ b/nomad/types/types.go
@@ -1,3 +1,0 @@
-package types
-
-type PeriodicCallback func() error


### PR DESCRIPTION
```
 ~/go/src/github.com/hashicorp/nomad main  ag PeriodicCallback                                                                                ✔  4s  15:53:10
nomad/types/types.go
3:type PeriodicCallback func() error
```

I also checked the enterprise code and got the same result.