### PR TITLE
Deflaking Test 2021 June edition

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -287,7 +287,7 @@ type Client struct {
 	batchNodeUpdates *batchNodeUpdates
 
 	// fpInitialized chan is closed when the first batch of fingerprints are
-	// applied to the node and the server is updated
+	// applied to the node
 	fpInitialized chan struct{}
 
 	// serversContactedCh is closed when GetClientAllocs and runAllocs have
@@ -524,7 +524,7 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 
 	// wait until drivers are healthy before restoring or registering with servers
 	select {
-	case <-c.Ready():
+	case <-c.fpInitialized:
 	case <-time.After(batchFirstFingerprintsProcessingGrace):
 		logger.Warn("batch fingerprint operation timed out; proceeding to register with fingerprinted plugins so far")
 	}
@@ -566,7 +566,7 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 
 // Ready returns a chan that is closed when the client is fully initialized
 func (c *Client) Ready() <-chan struct{} {
-	return c.fpInitialized
+	return c.serversContactedCh
 }
 
 // init is used to initialize the client and perform any setup

--- a/nomad/autopilot_test.go
+++ b/nomad/autopilot_test.go
@@ -151,7 +151,7 @@ func TestAutopilot_CleanupDeadServerPeriodic(t *testing.T) {
 
 	// Join the servers to s1, and wait until they are all promoted to
 	// voters.
-	TestJoin(t, s1, servers[1:]...)
+	TestJoin(t, servers...)
 	retry.Run(t, func(r *retry.R) {
 		r.Check(wantRaft(servers))
 		for _, s := range servers {

--- a/nomad/client_agent_endpoint_test.go
+++ b/nomad/client_agent_endpoint_test.go
@@ -548,6 +548,7 @@ func TestAgentProfile_RemoteClient(t *testing.T) {
 	})
 	defer cleanupC()
 
+	testutil.WaitForClient(t, s2.RPC, c.NodeID())
 	testutil.WaitForResult(func() (bool, error) {
 		nodes := s2.connectedNodes()
 		return len(nodes) == 1, nil

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -1547,7 +1547,11 @@ func waitForStableLeadership(t *testing.T, servers []*Server) *Server {
 	for _, s := range servers {
 		testutil.WaitForResult(func() (bool, error) {
 			peers, _ := s.numPeers()
-			return peers == 3, fmt.Errorf("should find %d peers but found %d", nPeers, peers)
+			if peers != nPeers {
+				return false, fmt.Errorf("should find %d peers but found %d", nPeers, peers)
+			}
+
+			return true, nil
 		}, func(err error) {
 			require.NoError(t, err)
 		})

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -168,14 +168,19 @@ func TestServer(t testing.T, cb func(*Config)) (*Server, func()) {
 	return nil, nil
 }
 
-func TestJoin(t testing.T, s1 *Server, other ...*Server) {
-	addr := fmt.Sprintf("127.0.0.1:%d",
-		s1.config.SerfConfig.MemberlistConfig.BindPort)
-	for _, s2 := range other {
-		if num, err := s2.Join([]string{addr}); err != nil {
-			t.Fatalf("err: %v", err)
-		} else if num != 1 {
-			t.Fatalf("bad: %d", num)
+func TestJoin(t testing.T, servers ...*Server) {
+	for i := 0; i < len(servers)-1; i++ {
+		addr := fmt.Sprintf("127.0.0.1:%d",
+			servers[i].config.SerfConfig.MemberlistConfig.BindPort)
+
+		for j := i + 1; j < len(servers); j++ {
+			num, err := servers[j].Join([]string{addr})
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if num != 1 {
+				t.Fatalf("bad: %d", num)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Best reviewed commit-by-commit. The commit messages have more info.

Deflake tests that I examined part of https://github.com/hashicorp/nomad/issues/10437. After examining the tests, I believe now that the test failures were due to improper handling.

One common source of flakiness is tests not waiting for clients to be properly registered with servers. The leadership transition isn't the cause of failure there, but simply highlight the issue further. Some tests were blocking only until the nomad client fingerprinted, and others waited until network connection to server got established but not necessary that the node info got committed. I addressed the issue in the tests that flaked the most in my sample. I anticipate having another round of deflakiness due to this type of bug.