### PR TITLE
Parse term gws

### DIFF
--- a/api/services.go
+++ b/api/services.go
@@ -636,9 +636,9 @@ func (e *ConsulIngressConfigEntry) Copy() *ConsulIngressConfigEntry {
 
 type ConsulLinkedService struct {
 	Name     string `hcl:"name,optional"`
-	CAFile   string `hcl:"ca_file,optional"`
-	CertFile string `hcl:"cert_file,optional"`
-	KeyFile  string `hcl:"key_file,optional"`
+	CAFile   string `hcl:"ca_file,optional" mapstructure:"ca_file"`
+	CertFile string `hcl:"cert_file,optional" mapstructure:"cert_file"`
+	KeyFile  string `hcl:"key_file,optional" mapstructure:"key_file"`
 	SNI      string `hcl:"sni,optional"`
 }
 

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -1533,6 +1533,45 @@ func TestParse(t *testing.T) {
 			false,
 		},
 		{
+			"tg-service-connect-gateway-terminating.hcl",
+			&api.Job{
+				ID:   stringToPtr("connect_gateway_terminating"),
+				Name: stringToPtr("connect_gateway_terminating"),
+				TaskGroups: []*api.TaskGroup{{
+					Name: stringToPtr("group"),
+					Services: []*api.Service{{
+						Name: "terminating-gateway-service",
+						Connect: &api.ConsulConnect{
+							Gateway: &api.ConsulGateway{
+								Proxy: &api.ConsulGatewayProxy{
+									ConnectTimeout:                  timeToPtr(3 * time.Second),
+									EnvoyGatewayBindTaggedAddresses: true,
+									EnvoyGatewayBindAddresses: map[string]*api.ConsulGatewayBindAddress{
+										"listener1": {Name: "listener1", Address: "10.0.0.1", Port: 8888},
+										"listener2": {Name: "listener2", Address: "10.0.0.2", Port: 8889},
+									},
+									EnvoyGatewayNoDefaultBind: true,
+									Config:                    map[string]interface{}{"foo": "bar"},
+								},
+								Terminating: &api.ConsulTerminatingConfigEntry{
+									Services: []*api.ConsulLinkedService{{
+										Name:     "service1",
+										CAFile:   "ca.pem",
+										CertFile: "cert.pem",
+										KeyFile:  "key.pem",
+									}, {
+										Name: "service2",
+										SNI:  "myhost",
+									}},
+								},
+							},
+						},
+					}},
+				}},
+			},
+			false,
+		},
+		{
 			"tg-scaling-policy-minimal.hcl",
 			&api.Job{
 				ID:   stringToPtr("elastic"),

--- a/jobspec/test-fixtures/tg-service-connect-gateway-terminating.hcl
+++ b/jobspec/test-fixtures/tg-service-connect-gateway-terminating.hcl
@@ -1,0 +1,46 @@
+job "connect_gateway_terminating" {
+  group "group" {
+    service {
+      name = "terminating-gateway-service"
+
+      connect {
+        gateway {
+          proxy {
+            connect_timeout                     = "3s"
+            envoy_gateway_bind_tagged_addresses = true
+
+            envoy_gateway_bind_addresses "listener1" {
+              address = "10.0.0.1"
+              port    = 8888
+            }
+
+            envoy_gateway_bind_addresses "listener2" {
+              address = "10.0.0.2"
+              port    = 8889
+            }
+
+            envoy_gateway_no_default_bind = true
+
+            config {
+              foo = "bar"
+            }
+          }
+
+          terminating {
+            service {
+              name      = "service1"
+              ca_file   = "ca.pem"
+              cert_file = "cert.pem"
+              key_file  = "key.pem"
+            }
+
+            service {
+              name = "service2"
+              sni  = "myhost"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/vendor/github.com/hashicorp/nomad/api/services.go
+++ b/vendor/github.com/hashicorp/nomad/api/services.go
@@ -636,9 +636,9 @@ func (e *ConsulIngressConfigEntry) Copy() *ConsulIngressConfigEntry {
 
 type ConsulLinkedService struct {
 	Name     string `hcl:"name,optional"`
-	CAFile   string `hcl:"ca_file,optional"`
-	CertFile string `hcl:"cert_file,optional"`
-	KeyFile  string `hcl:"key_file,optional"`
+	CAFile   string `hcl:"ca_file,optional" mapstructure:"ca_file"`
+	CertFile string `hcl:"cert_file,optional" mapstructure:"cert_file"`
+	KeyFile  string `hcl:"key_file,optional" mapstructure:"key_file"`
 	SNI      string `hcl:"sni,optional"`
 }
 


### PR DESCRIPTION
Parse terminating gateway stanzas. While Nomad supports terminating GWs, its own parse function doesn't actually support them and populate the structs. This attempts to address that.