### PR TITLE
deploymentwatcher: fix test data race.

### DIFF
--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -614,8 +614,17 @@ func TestWatcher_AutoPromoteDeployment(t *testing.T) {
 
 	// Start the deployment
 	w.SetEnabled(true, m.state)
-	testutil.WaitForResult(func() (bool, error) { return 1 == len(w.watchers), nil },
-		func(err error) { require.Equal(t, 1, len(w.watchers), "Should have 1 deployment") })
+	testutil.WaitForResult(func() (bool, error) {
+		w.l.RLock()
+		defer w.l.RUnlock()
+		return 1 == len(w.watchers), nil
+	},
+		func(err error) {
+			w.l.RLock()
+			defer w.l.RUnlock()
+			require.Equal(t, 1, len(w.watchers), "Should have 1 deployment")
+		},
+	)
 
 	// Mark the canaries healthy
 	req := &structs.DeploymentAllocHealthRequest{


### PR DESCRIPTION
<details>
  <summary>Data race stack trace</summary>

```
==================
WARNING: DATA RACE
Read at 0x00c0003fd740 by goroutine 17:
  github.com/hashicorp/nomad/nomad/deploymentwatcher.TestWatcher_AutoPromoteDeployment.func2()
      /Users/jrasell/go/src/github.com/hashicorp/nomad/nomad/deploymentwatcher/deployments_watcher_test.go:617 +0x6c
2021-06-11T11:26:00.889+0200 [TRACE] deploymentwatcher/deployment_watcher.go:481: deployments_watcher: resetting deadline: deployment_id=f7406e82-ac4b-aed9-f16e-9c673e5b4300 job="<ns: "default", id: "mock-service-2e0bcb57-df41-52e4-d528-370d30ad3bdb">"
  github.com/hashicorp/nomad/testutil.WaitForResultRetries()
      /Users/jrasell/go/src/github.com/hashicorp/nomad/testutil/wait.go:27 +0x5a
  github.com/hashicorp/nomad/testutil.WaitForResult()
      /Users/jrasell/go/src/github.com/hashicorp/nomad/testutil/wait.go:19 +0x84
  github.com/hashicorp/nomad/nomad/deploymentwatcher.TestWatcher_AutoPromoteDeployment()
      /Users/jrasell/go/src/github.com/hashicorp/nomad/nomad/deploymentwatcher/deployments_watcher_test.go:617 +0x15ca
  testing.tRunner()
      /Users/jrasell/.gvm/gos/go1.16.4/src/testing/testing.go:1193 +0x202

Previous write at 0x00c0003fd740 by goroutine 84:
  runtime.mapassign_faststr()
      /Users/jrasell/.gvm/gos/go1.16.4/src/runtime/map_faststr.go:202 +0x0
  github.com/hashicorp/nomad/nomad/deploymentwatcher.(*Watcher).addLocked()
      /Users/jrasell/go/src/github.com/hashicorp/nomad/nomad/deploymentwatcher/deployments_watcher.go:273 +0x48e
  github.com/hashicorp/nomad/nomad/deploymentwatcher.(*Watcher).add()
      /Users/jrasell/go/src/github.com/hashicorp/nomad/nomad/deploymentwatcher/deployments_watcher.go:235 +0xbc
  github.com/hashicorp/nomad/nomad/deploymentwatcher.(*Watcher).watchDeployments()
      /Users/jrasell/go/src/github.com/hashicorp/nomad/nomad/deploymentwatcher/deployments_watcher.go:184 +0xfb

Goroutine 17 (running) created at:
  testing.(*T).Run()
      /Users/jrasell/.gvm/gos/go1.16.4/src/testing/testing.go:1238 +0x5d7
  testing.runTests.func1()
      /Users/jrasell/.gvm/gos/go1.16.4/src/testing/testing.go:1511 +0xa6
  testing.tRunner()
      /Users/jrasell/.gvm/gos/go1.16.4/src/testing/testing.go:1193 +0x202
  testing.runTests()
      /Users/jrasell/.gvm/gos/go1.16.4/src/testing/testing.go:1509 +0x612
  testing.(*M).Run()
      /Users/jrasell/.gvm/gos/go1.16.4/src/testing/testing.go:1417 +0x3b3
  main.main()
      _testmain.go:89 +0x236

Goroutine 84 (running) created at:
  github.com/hashicorp/nomad/nomad/deploymentwatcher.(*Watcher).SetEnabled()
      /Users/jrasell/go/src/github.com/hashicorp/nomad/nomad/deploymentwatcher/deployments_watcher.go:136 +0x173
  github.com/hashicorp/nomad/nomad/deploymentwatcher.TestWatcher_AutoPromoteDeployment()
      /Users/jrasell/go/src/github.com/hashicorp/nomad/nomad/deploymentwatcher/deployments_watcher_test.go:616 +0x154a
  testing.tRunner()
      /Users/jrasell/.gvm/gos/go1.16.4/src/testing/testing.go:1193 +0x202
==================
```

</details>