### PR TITLE
Fix agent-info help message formatting

### DIFF
--- a/command/agent_info.go
+++ b/command/agent_info.go
@@ -30,7 +30,7 @@ Agent Info Options:
   -json
     Output the node in its JSON format.
 
--t
+  -t
     Format and display node using a Go template.
 `
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
Small formatting fix in the `nomad agent-info` help message.