### PR TITLE
Add remaining pprof profiles to nomad operator debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 * cli: Added `-monitor` flag to `deployment status` command and automatically monitor deployments from `job run` command. [[GH-10661](https://github.com/hashicorp/nomad/pull/10661)]
+* cli: Added remainder of available pprof profiles to `nomad operator debug` capture. [[GH-10748](https://github.com/hashicorp/nomad/issues/10748)]
 * consul/connect: Validate Connect service upstream address uniqueness within task group [[GH-7833](https://github.com/hashicorp/nomad/issues/7833)]
 * deps: Update gopsutil for multisocket cpuinfo detection performance fix [[GH-10761](https://github.com/hashicorp/nomad/pull/10790)]
 * docker: Tasks using `network.mode = "bridge"` that don't set their `network_mode` will receive a `/etc/hosts` file that includes the pause container's hostname and any `extra_hosts`. [[GH-10766](https://github.com/hashicorp/nomad/issues/10766)]

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -654,71 +654,60 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client)
 		}
 	}
 
-	bs, err = client.Agent().Trace(opts, nil)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("%s: Failed to retrieve pprof trace.prof, err: %v", path, err))
-	} else {
-		err := c.writeBytes(path, "trace.prof", bs)
-		if err != nil {
-			c.Ui.Error(err.Error())
-		}
-	}
-
-	bs, err = client.Agent().Lookup("goroutine", opts, nil)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("%s: Failed to retrieve pprof goroutine.prof, err: %v", path, err))
-	} else {
-		err := c.writeBytes(path, "goroutine.prof", bs)
-		if err != nil {
-			c.Ui.Error(err.Error())
-		}
-	}
-
-	err = c.savePprofProfile(path, "heap", opts, client)
-	err = c.savePprofProfile(path, "allocs", opts, client)
-	err = c.savePprofProfile(path, "threadcreate", opts, client)
-	err = c.savePprofProfile(path, "block", opts, client)
-	err = c.savePprofProfile(path, "mutex", opts, client)
-
-	// Gather goroutine text output - debug type 1
-	// debug type 1 writes the legacy text format for human readable output
+	// goroutine debug type 1 = legacy text format for human readable output
 	opts.Debug = 1
-	bs, err = client.Agent().Lookup("goroutine", opts, nil)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("%s: Failed to retrieve pprof goroutine-debug1.txt, err: %v", path, err))
-	} else {
-		err := c.writeBytes(path, "goroutine-debug1.txt", bs)
-		if err != nil {
-			c.Ui.Error(err.Error())
-		}
+	c.savePprofProfile(path, "goroutine", opts, client)
+
+	// goroutine debug type 2 = goroutine stacks in panic format
+	opts.Debug = 2
+	c.savePprofProfile(path, "goroutine", opts, client)
+
+	// Reset to pprof binary format
+	opts.Debug = 0
+
+	c.savePprofProfile(path, "goroutine", opts, client)    // Stack traces of all current goroutines
+	c.savePprofProfile(path, "trace", opts, client)        // A trace of execution of the current program
+	c.savePprofProfile(path, "heap", opts, client)         // A sampling of memory allocations of live objects. You can specify the gc GET parameter to run GC before taking the heap sample.
+	c.savePprofProfile(path, "allocs", opts, client)       // A sampling of all past memory allocations
+	c.savePprofProfile(path, "threadcreate", opts, client) // Stack traces that led to the creation of new OS threads
+
+	// This profile is disabled by default -- Requires runtime.SetBlockProfileRate to enable
+	// c.savePprofProfile(path, "block", opts, client)        // Stack traces that led to blocking on synchronization primitives
+
+	// This profile is disabled by default -- Requires runtime.SetMutexProfileFraction to enable
+	// c.savePprofProfile(path, "mutex", opts, client)        // Stack traces of holders of contended mutexes
+}
+
+// savePprofProfile retrieves a pprof profile and writes to disk
+func (c *OperatorDebugCommand) savePprofProfile(path string, profile string, opts api.PprofOptions, client *api.Client) {
+	fileName := fmt.Sprintf("%s.prof", profile)
+	if opts.Debug > 0 {
+		fileName = fmt.Sprintf("%s-debug%d.txt", profile, opts.Debug)
 	}
 
-	// Gather goroutine text output - debug type 2
-	// When printing the "goroutine" profile, debug=2 means to print the goroutine
-	// stacks in the same form that a Go program uses when dying due to an unrecovered panic.
-	opts.Debug = 2
-	bs, err = client.Agent().Lookup("goroutine", opts, nil)
+	bs, err := retrievePprofProfile(profile, opts, client)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("%s: Failed to retrieve pprof goroutine-debug2.txt, err: %v", path, err))
-	} else {
-		err := c.writeBytes(path, "goroutine-debug2.txt", bs)
-		if err != nil {
-			c.Ui.Error(err.Error())
-		}
+		c.Ui.Error(fmt.Sprintf("%s: Failed to retrieve pprof %s, err: %s", path, fileName, err.Error()))
+	}
+
+	err = c.writeBytes(path, fileName, bs)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("%s: Failed to write file %s, err: %s", path, fileName, err.Error()))
 	}
 }
 
-// savePprofProfile collects a pprof profile from the client API and writes to disk
-func (c *OperatorDebugCommand) savePprofProfile(path string, profile string, opts api.PprofOptions, client *api.Client) error {
-	bs, err := client.Agent().Lookup(profile, opts, nil)
-	if err != nil {
-		return fmt.Errorf("%s: Failed to retrieve pprof profile %s, err: %v", path, profile, err)
+// retrievePprofProfile gets a pprof profile from the node specified in opts using the API client
+func retrievePprofProfile(profile string, opts api.PprofOptions, client *api.Client) (bs []byte, err error) {
+	switch profile {
+	case "cpuprofile":
+		bs, err = client.Agent().CPUProfile(opts, nil)
+	case "trace":
+		bs, err = client.Agent().Trace(opts, nil)
+	default:
+		bs, err = client.Agent().Lookup(profile, opts, nil)
 	}
 
-	fileName := fmt.Sprintf("%s.prof", profile)
-	err = c.writeBytes(path, fileName, bs)
-
-	return err
+	return bs, err
 }
 
 // collectPeriodic runs for duration, capturing the cluster state every interval. It flushes and stops

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -674,6 +674,12 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client)
 		}
 	}
 
+	err = c.savePprofProfile(path, "heap", opts, client)
+	err = c.savePprofProfile(path, "allocs", opts, client)
+	err = c.savePprofProfile(path, "threadcreate", opts, client)
+	err = c.savePprofProfile(path, "block", opts, client)
+	err = c.savePprofProfile(path, "mutex", opts, client)
+
 	// Gather goroutine text output - debug type 1
 	// debug type 1 writes the legacy text format for human readable output
 	opts.Debug = 1
@@ -700,6 +706,19 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client)
 			c.Ui.Error(err.Error())
 		}
 	}
+}
+
+// savePprofProfile collects a pprof profile from the client API and writes to disk
+func (c *OperatorDebugCommand) savePprofProfile(path string, profile string, opts api.PprofOptions, client *api.Client) error {
+	bs, err := client.Agent().Lookup(profile, opts, nil)
+	if err != nil {
+		return fmt.Errorf("%s: Failed to retrieve pprof profile %s, err: %v", path, profile, err)
+	}
+
+	fileName := fmt.Sprintf("%s.prof", profile)
+	err = c.writeBytes(path, fileName, bs)
+
+	return err
 }
 
 // collectPeriodic runs for duration, capturing the cluster state every interval. It flushes and stops

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -365,11 +365,16 @@ func TestDebug_CapturedFiles(t *testing.T) {
 
 		// Monitor files are only created when selected
 		filepath.Join(path, "server", "leader", "monitor.log"),
+
+		// Pprof profiles
 		filepath.Join(path, "server", "leader", "profile.prof"),
 		filepath.Join(path, "server", "leader", "trace.prof"),
 		filepath.Join(path, "server", "leader", "goroutine.prof"),
 		filepath.Join(path, "server", "leader", "goroutine-debug1.txt"),
 		filepath.Join(path, "server", "leader", "goroutine-debug2.txt"),
+		filepath.Join(path, "server", "leader", "heap.prof"),
+		filepath.Join(path, "server", "leader", "allocs.prof"),
+		filepath.Join(path, "server", "leader", "threadcreate.prof"),
 
 		// Multiple snapshots are collected, 00 is always created
 		filepath.Join(path, "nomad", "0000", "jobs.json"),

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -387,7 +387,7 @@ func TestDebug_CapturedFiles(t *testing.T) {
 		filepath.Join(path, "nomad", "0001", "metrics.json"),
 	}
 
-	testutil.WaitForFiles(t, serverFiles)
+	testutil.WaitForFilesUntil(t, serverFiles, 2*time.Minute)
 }
 
 func TestDebug_ExistingOutput(t *testing.T) {

--- a/testutil/wait_test.go
+++ b/testutil/wait_test.go
@@ -1,1 +1,43 @@
 package testutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWait_WaitForFilesUntil(t *testing.T) {
+
+	var files []string
+	for i := 1; i < 10; i++ {
+		filename := fmt.Sprintf("test%d.txt", i)
+		filepath := filepath.Join(os.TempDir(), filename)
+		files = append(files, filepath)
+
+		defer os.Remove(filepath)
+	}
+
+	go func() {
+		for _, filepath := range files {
+			t.Logf("Creating file %s...", filepath)
+			fh, err := os.Create(filepath)
+			fh.Close()
+
+			require.NoError(t, err, "error creating test file")
+			require.FileExists(t, filepath)
+
+			time.Sleep(250 * time.Millisecond)
+		}
+	}()
+
+	duration := 5 * time.Second
+	t.Log("Waiting 5 seconds for files...")
+	WaitForFilesUntil(t, files, duration)
+
+	t.Log("done")
+
+}


### PR DESCRIPTION
This PR adds to the remaining pprof profiles to `nomad operator debug`.  It also adds 2 helper functions `WaitForResultUntil` and `WaitForFilesUntil` which reduce the flakiness of the associated test.

* heap
* allocs
* threadcreate
* block
* mutex

In the future the `block` and `mutex` profiles can be enabled using the `runtime.SetBlockProfileRate` and `runtime.SetMutexProfileFraction` functions, respectively.