### PR TITLE
Fix headshot image 404

### DIFF
--- a/website/pages/home/index.jsx
+++ b/website/pages/home/index.jsx
@@ -244,8 +244,7 @@ export default function Homepage() {
             person: {
               firstName: 'Dhasharath',
               lastName: 'Shrivathsa',
-              photo:
-                'https://www.datocms-assets.com/2885/1594233068-dharsharathshrivathsa.jpg',
+              photo: 'https://www.datocms-assets.com/2885/1623450501-dhasharath-shrivathsa.jpg',
               title: 'CEO',
             },
             company: {


### PR DESCRIPTION
Patch up a 404 on an image that appears on the homepage CaseStudyCarousel.

[🔍 Preview](https://nomad-8isly8xf5-hashicorp.vercel.app/)

Fixes #10749
