### PR TITLE
consul/connect: remove unnecessary connect constraint on clients

### DIFF
--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -89,14 +89,6 @@ func connectGatewayVersionConstraint() *structs.Constraint {
 	}
 }
 
-func connectEnabledConstraint() *structs.Constraint {
-	return &structs.Constraint{
-		LTarget: "${attr.consul.connect}",
-		RTarget: "true",
-		Operand: "=",
-	}
-}
-
 func connectListenerConstraint() *structs.Constraint {
 	return &structs.Constraint{
 		LTarget: "${attr.consul.grpc}",
@@ -459,7 +451,6 @@ func newConnectGatewayTask(prefix, service string, netHost bool) *structs.Task {
 		Resources: connectSidecarResources(),
 		Constraints: structs.Constraints{
 			connectGatewayVersionConstraint(),
-			connectEnabledConstraint(),
 			connectListenerConstraint(),
 		},
 	}
@@ -484,7 +475,6 @@ func newConnectSidecarTask(service string) *structs.Task {
 		},
 		Constraints: structs.Constraints{
 			connectSidecarVersionConstraint(),
-			connectEnabledConstraint(),
 			connectListenerConstraint(),
 		},
 	}

--- a/nomad/job_endpoint_hook_connect_test.go
+++ b/nomad/job_endpoint_hook_connect_test.go
@@ -195,7 +195,6 @@ func TestJobEndpointConnect_groupConnectHook_IngressGateway_CustomTask(t *testin
 			KillSignal:    "SIGHUP",
 			Constraints: structs.Constraints{
 				connectGatewayVersionConstraint(),
-				connectEnabledConstraint(),
 				connectListenerConstraint(),
 			},
 		},


### PR DESCRIPTION
PR https://github.com/hashicorp/nomad/pull/10702 added 2 new constraints
for connect jobs - one for Consul gRPC listener, and one for Connect being
enabled on Clients. Connect does not need to be enabled on clients, only
on Consul servers. Remove the extra constraint.

Discuss:
https://discuss.hashicorp.com/t/nomad-1-1-1-and-consul-connect-enabled-on-consul-clients/25295