### PR TITLE
Closes Nomad UI showing 'vUnknown' #10672

### DIFF
--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -39,10 +39,12 @@ export default class SystemService extends Service {
         .authorizedRawRequest(`/${namespace}/agent/self`)
         .then(jsonWithDefault({}))
         .then(agent => {
-          const { Version, VersionPrerelease, VersionMetadata } = agent.config.Version;
-          agent.version = Version;
-          if (VersionPrerelease) agent.version += `-${VersionPrerelease}`;
-          if (VersionMetadata) agent.version += `+${VersionMetadata}`;
+          if (agent.config.Version) {
+            const { Version, VersionPrerelease, VersionMetadata } = agent.config.Version;
+            agent.version = Version;
+            if (VersionPrerelease) agent.version = `${agent.version}-${VersionPrerelease}`;
+            if (VersionMetadata) agent.version = `${agent.version}+${VersionMetadata}`;
+          }
           return agent;
         }),
     });

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -39,7 +39,10 @@ export default class SystemService extends Service {
         .authorizedRawRequest(`/${namespace}/agent/self`)
         .then(jsonWithDefault({}))
         .then(agent => {
-          agent.version = agent.member?.Tags?.build || 'Unknown';
+          const { Version, VersionPrerelease, VersionMetadata } = agent.config.Version;
+          agent.version = Version;
+          if (VersionPrerelease) agent.version += `-${VersionPrerelease}`;
+          if (VersionMetadata) agent.version += `+${VersionMetadata}`;
           return agent;
         }),
     });

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -39,7 +39,7 @@ export default class SystemService extends Service {
         .authorizedRawRequest(`/${namespace}/agent/self`)
         .then(jsonWithDefault({}))
         .then(agent => {
-          if (agent.config.Version) {
+          if (agent?.config?.Version) {
             const { Version, VersionPrerelease, VersionMetadata } = agent.config.Version;
             agent.version = Version;
             if (VersionPrerelease) agent.version = `${agent.version}-${VersionPrerelease}`;

--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -68,9 +68,11 @@
         <li><LinkTo @route="topology" @activeClass="is-active" data-test-gutter-link="topology">Topology</LinkTo></li>
       </ul>
     </aside>
+    {{#if this.system.agent.version}}
     <footer class="gutter-footer">
-      <span class="is-faded">v{{this.system.agent.version}}</span>
+        <span class="is-faded">v{{this.system.agent.version}}</span>
     </footer>
+    {{/if}}
   </div>
 </div>
 <div data-test-page-content class="page-column is-right">

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -9,7 +9,7 @@ import formatHost from 'nomad-ui/utils/format-host';
 
 export function findLeader(schema) {
   const agent = schema.agents.first();
-  return formatHost(agent.address, agent.tags.port);
+  return formatHost(agent.member.Address, agent.member.Tags.port); // do we need to change this?
 }
 
 export function filesForPath(allocFiles, filterPath) {

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -342,6 +342,13 @@ export default function() {
   this.get('/agent/self', function({ agents }) {
     return {
       member: this.serialize(agents.first()),
+      config: {
+        Version: {
+          Version: '1.1.0',
+          VersionMetadata: 'ent',
+          VersionPrerelease: 'dev',
+        },
+      },
     };
   });
 
@@ -579,7 +586,10 @@ export default function() {
     });
   });
 
-  this.post('/search/fuzzy', function( { allocations, jobs, nodes, taskGroups, csiPlugins }, { requestBody }) {
+  this.post('/search/fuzzy', function(
+    { allocations, jobs, nodes, taskGroups, csiPlugins },
+    { requestBody }
+  ) {
     const { Text } = JSON.parse(requestBody);
 
     const matchedAllocs = allocations.where(allocation => allocation.name.includes(Text));
@@ -590,33 +600,22 @@ export default function() {
 
     const transformedAllocs = matchedAllocs.models.map(alloc => ({
       ID: alloc.name,
-      Scope: [
-        (alloc.namespace || {}).id,
-        alloc.id,
-      ],
+      Scope: [(alloc.namespace || {}).id, alloc.id],
     }));
 
     const transformedGroups = matchedGroups.models.map(group => ({
       ID: group.name,
-      Scope: [
-        group.job.namespace,
-        group.job.id,
-      ],
+      Scope: [group.job.namespace, group.job.id],
     }));
 
     const transformedJobs = matchedJobs.models.map(job => ({
       ID: job.name,
-      Scope: [
-        job.namespace,
-        job.id,
-      ]
+      Scope: [job.namespace, job.id],
     }));
 
     const transformedNodes = matchedNodes.models.map(node => ({
       ID: node.name,
-      Scope: [
-        node.id,
-      ],
+      Scope: [node.id],
     }));
 
     const transformedPlugins = matchedPlugins.models.map(plugin => ({
@@ -644,7 +643,7 @@ export default function() {
         nodes: truncatedNodes.length < transformedNodes.length,
         plugins: truncatedPlugins.length < transformedPlugins.length,
       },
-    }
+    };
   });
 
   this.get('/recommendations', function(

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -9,7 +9,7 @@ import formatHost from 'nomad-ui/utils/format-host';
 
 export function findLeader(schema) {
   const agent = schema.agents.first();
-  return formatHost(agent.member.Address, agent.member.Tags.port); // do we need to change this?
+  return formatHost(agent.member.Address, agent.member.Tags.port);
 }
 
 export function filesForPath(allocFiles, filterPath) {

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -335,21 +335,12 @@ export default function() {
     const firstRegion = regions.first();
     return {
       ServerRegion: firstRegion ? firstRegion.id : null,
-      Members: this.serialize(agents.all()),
+      Members: this.serialize(agents.all()).map(({ member }) => ({ ...member })),
     };
   });
 
   this.get('/agent/self', function({ agents }) {
-    return {
-      member: this.serialize(agents.first()),
-      config: {
-        Version: {
-          Version: '1.1.0',
-          VersionMetadata: 'ent',
-          VersionPrerelease: 'dev',
-        },
-      },
-    };
+    return agents.first();
   });
 
   this.get('/agent/monitor', function({ agents, nodes }, { queryParams }) {

--- a/ui/mirage/factories/agent.js
+++ b/ui/mirage/factories/agent.js
@@ -17,6 +17,8 @@ export default Factory.extend({
     return this.name.split('@')[1];
   },
 
+  config: makeConfig,
+
   tags() {
     const rpcPortCandidate = faker.random.number({ min: 4000, max: 4999 });
     return {
@@ -25,3 +27,13 @@ export default Factory.extend({
     };
   },
 });
+
+function makeConfig() {
+  return {
+    Version: {
+      Version: '1.1.0',
+      VersionMetadata: 'ent',
+      VersionPrerelease: 'dev',
+    },
+  };
+}

--- a/ui/mirage/factories/agent.js
+++ b/ui/mirage/factories/agent.js
@@ -8,32 +8,40 @@ const AGENT_STATUSES = ['alive', 'leaving', 'left', 'failed'];
 
 export default Factory.extend({
   id: i => (i / 100 >= 1 ? `${UUIDS[i]}-${i}` : UUIDS[i]),
-  name: () => `nomad@${faker.random.boolean() ? faker.internet.ip() : faker.internet.ipv6()}`,
 
-  status: () => faker.helpers.randomize(AGENT_STATUSES),
-  serfPort: () => faker.random.number({ min: 4000, max: 4999 }),
-
-  address() {
-    return this.name.split('@')[1];
-  },
-
-  config: makeConfig,
-
-  tags() {
-    const rpcPortCandidate = faker.random.number({ min: 4000, max: 4999 });
-    return {
-      port: rpcPortCandidate === this.serfPort ? rpcPortCandidate + 1 : rpcPortCandidate,
-      dc: faker.helpers.randomize(DATACENTERS),
-    };
-  },
-});
-
-function makeConfig() {
-  return {
+  config: {
     Version: {
       Version: '1.1.0',
       VersionMetadata: 'ent',
       VersionPrerelease: 'dev',
     },
+  },
+
+  member: () => {
+    const name = generateName();
+    const serfPort = faker.random.number({ min: 4000, max: 4999 });
+    return {
+      Name: name,
+      Port: serfPort,
+      Status: faker.helpers.randomize(AGENT_STATUSES),
+      Address: generateAddress(name),
+      Tags: generateTags(serfPort),
+    };
+  },
+});
+
+function generateName() {
+  return `nomad@${faker.random.boolean() ? faker.internet.ip() : faker.internet.ipv6()}`;
+}
+
+function generateAddress(name) {
+  return name.split('@')[1];
+}
+
+function generateTags(serfPort) {
+  const rpcPortCandidate = faker.random.number({ min: 4000, max: 4999 });
+  return {
+    port: rpcPortCandidate === serfPort ? rpcPortCandidate + 1 : rpcPortCandidate,
+    dc: faker.helpers.randomize(DATACENTERS),
   };
 }

--- a/ui/mirage/factories/agent.js
+++ b/ui/mirage/factories/agent.js
@@ -9,6 +9,8 @@ const AGENT_STATUSES = ['alive', 'leaving', 'left', 'failed'];
 export default Factory.extend({
   id: i => (i / 100 >= 1 ? `${UUIDS[i]}-${i}` : UUIDS[i]),
 
+  name: () => generateName(),
+
   config: {
     Version: {
       Version: '1.1.0',
@@ -17,14 +19,13 @@ export default Factory.extend({
     },
   },
 
-  member: () => {
-    const name = generateName();
+  member() {
     const serfPort = faker.random.number({ min: 4000, max: 4999 });
     return {
-      Name: name,
+      Name: this.name,
       Port: serfPort,
       Status: faker.helpers.randomize(AGENT_STATUSES),
-      Address: generateAddress(name),
+      Address: generateAddress(this.name),
       Tags: generateTags(serfPort),
     };
   },

--- a/ui/mirage/serializers/agent.js
+++ b/ui/mirage/serializers/agent.js
@@ -1,0 +1,10 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  keyForAttribute(str) {
+    if (str === 'config' || str === 'member') {
+      return str;
+    }
+    return ApplicationSerializer.prototype.keyForAttribute.apply(this, arguments);
+  },
+});

--- a/ui/tests/acceptance/server-detail-test.js
+++ b/ui/tests/acceptance/server-detail-test.js
@@ -15,7 +15,7 @@ module('Acceptance | server detail', function(hooks) {
   hooks.beforeEach(async function() {
     server.createList('agent', 3);
     agent = server.db.agents[0];
-    await ServerDetail.visit({ name: agent.name });
+    await ServerDetail.visit({ name: agent.member.Name });
   });
 
   test('it passes an accessibility audit', async function(assert) {
@@ -23,24 +23,27 @@ module('Acceptance | server detail', function(hooks) {
   });
 
   test('visiting /servers/:server_name', async function(assert) {
-    assert.equal(currentURL(), `/servers/${encodeURIComponent(agent.name)}`);
-    assert.equal(document.title, `Server ${agent.name} - Nomad`);
+    console.log('agent:  ', agent);
+    assert.equal(currentURL(), `/servers/${encodeURIComponent(agent.member.Name)}`);
+    assert.equal(document.title, `Server ${agent.member.Name} - Nomad`);
   });
 
   test('when the server is the leader, the title shows a leader badge', async function(assert) {
-    assert.ok(ServerDetail.title.includes(agent.name));
+    assert.ok(ServerDetail.title.includes(agent.member.Name));
     assert.ok(ServerDetail.hasLeaderBadge);
   });
 
   test('the details ribbon displays basic information about the server', async function(assert) {
-    assert.ok(ServerDetail.serverStatus.includes(agent.status));
-    assert.ok(ServerDetail.address.includes(formatHost(agent.address, agent.tags.port)));
-    assert.ok(ServerDetail.datacenter.includes(agent.tags.dc));
+    assert.ok(ServerDetail.serverStatus.includes(agent.member.Status));
+    assert.ok(
+      ServerDetail.address.includes(formatHost(agent.member.Address, agent.member.Tags.port))
+    );
+    assert.ok(ServerDetail.datacenter.includes(agent.member.Tags.dc));
   });
 
   test('the server detail page should list all tags for the server', async function(assert) {
-    const tags = Object.keys(agent.tags)
-      .map(name => ({ name, value: agent.tags[name] }))
+    const tags = Object.keys(agent.member.Tags)
+      .map(name => ({ name, value: agent.member.Tags[name] }))
       .sortBy('name');
 
     assert.equal(ServerDetail.tags.length, tags.length, '# of tags');
@@ -52,7 +55,7 @@ module('Acceptance | server detail', function(hooks) {
   });
 
   test('when the server is not the leader, there is no leader badge', async function(assert) {
-    await ServerDetail.visit({ name: server.db.agents[1].name });
+    await ServerDetail.visit({ name: server.db.agents[1].member.Name });
     assert.notOk(ServerDetail.hasLeaderBadge);
   });
 

--- a/ui/tests/acceptance/server-detail-test.js
+++ b/ui/tests/acceptance/server-detail-test.js
@@ -15,7 +15,7 @@ module('Acceptance | server detail', function(hooks) {
   hooks.beforeEach(async function() {
     server.createList('agent', 3);
     agent = server.db.agents[0];
-    await ServerDetail.visit({ name: agent.member.Name });
+    await ServerDetail.visit({ name: agent.name });
   });
 
   test('it passes an accessibility audit', async function(assert) {
@@ -23,13 +23,12 @@ module('Acceptance | server detail', function(hooks) {
   });
 
   test('visiting /servers/:server_name', async function(assert) {
-    console.log('agent:  ', agent);
-    assert.equal(currentURL(), `/servers/${encodeURIComponent(agent.member.Name)}`);
-    assert.equal(document.title, `Server ${agent.member.Name} - Nomad`);
+    assert.equal(currentURL(), `/servers/${encodeURIComponent(agent.name)}`);
+    assert.equal(document.title, `Server ${agent.name} - Nomad`);
   });
 
   test('when the server is the leader, the title shows a leader badge', async function(assert) {
-    assert.ok(ServerDetail.title.includes(agent.member.Name));
+    assert.ok(ServerDetail.title.includes(agent.name));
     assert.ok(ServerDetail.hasLeaderBadge);
   });
 
@@ -55,7 +54,7 @@ module('Acceptance | server detail', function(hooks) {
   });
 
   test('when the server is not the leader, there is no leader badge', async function(assert) {
-    await ServerDetail.visit({ name: server.db.agents[1].member.Name });
+    await ServerDetail.visit({ name: server.db.agents[1].name });
     assert.notOk(ServerDetail.hasLeaderBadge);
   });
 

--- a/ui/tests/acceptance/server-monitor-test.js
+++ b/ui/tests/acceptance/server-monitor-test.js
@@ -27,22 +27,22 @@ module('Acceptance | server monitor', function(hooks) {
   });
 
   test('it passes an accessibility audit', async function(assert) {
-    await ServerMonitor.visit({ name: agent.member.Name });
+    await ServerMonitor.visit({ name: agent.name });
     await a11yAudit(assert);
   });
 
   test('/servers/:id/monitor should have a breadcrumb trail linking back to servers', async function(assert) {
-    await ServerMonitor.visit({ name: agent.member.Name });
+    await ServerMonitor.visit({ name: agent.name });
 
     assert.equal(Layout.breadcrumbFor('servers.index').text, 'Servers');
-    assert.equal(Layout.breadcrumbFor('servers.server').text, agent.member.name);
+    assert.equal(Layout.breadcrumbFor('servers.server').text, agent.name);
 
     await Layout.breadcrumbFor('servers.index').visit();
     assert.equal(currentURL(), '/servers');
   });
 
   test('the monitor page immediately streams agent monitor output at the info level', async function(assert) {
-    await ServerMonitor.visit({ name: agent.member.Name });
+    await ServerMonitor.visit({ name: agent.name });
 
     const logRequest = server.pretender.handledRequests.find(req =>
       req.url.startsWith('/v1/agent/monitor')
@@ -53,16 +53,15 @@ module('Acceptance | server monitor', function(hooks) {
   });
 
   test('switching the log level persists the new log level as a query param', async function(assert) {
-    const name = agent.member.Name;
-    await ServerMonitor.visit({ name: agent.member.Name });
+    await ServerMonitor.visit({ name: agent.name });
     await ServerMonitor.selectLogLevel('Debug');
-    assert.equal(currentURL(), `/servers/${name}/monitor?level=debug`);
+    assert.equal(currentURL(), `/servers/${agent.name}/monitor?level=debug`);
   });
 
   test('when the current access token does not include the agent:read rule, a descriptive error message is shown', async function(assert) {
     window.localStorage.nomadTokenSecret = clientToken.secretId;
 
-    await ServerMonitor.visit({ name: agent.member.Name });
+    await ServerMonitor.visit({ name: agent.name });
     assert.notOk(ServerMonitor.logsArePresent);
     assert.ok(ServerMonitor.error.isShown);
     assert.equal(ServerMonitor.error.title, 'Not Authorized');

--- a/ui/tests/acceptance/server-monitor-test.js
+++ b/ui/tests/acceptance/server-monitor-test.js
@@ -27,22 +27,22 @@ module('Acceptance | server monitor', function(hooks) {
   });
 
   test('it passes an accessibility audit', async function(assert) {
-    await ServerMonitor.visit({ name: agent.name });
+    await ServerMonitor.visit({ name: agent.member.Name });
     await a11yAudit(assert);
   });
 
   test('/servers/:id/monitor should have a breadcrumb trail linking back to servers', async function(assert) {
-    await ServerMonitor.visit({ name: agent.name });
+    await ServerMonitor.visit({ name: agent.member.Name });
 
     assert.equal(Layout.breadcrumbFor('servers.index').text, 'Servers');
-    assert.equal(Layout.breadcrumbFor('servers.server').text, agent.name);
+    assert.equal(Layout.breadcrumbFor('servers.server').text, agent.member.name);
 
     await Layout.breadcrumbFor('servers.index').visit();
     assert.equal(currentURL(), '/servers');
   });
 
   test('the monitor page immediately streams agent monitor output at the info level', async function(assert) {
-    await ServerMonitor.visit({ name: agent.name });
+    await ServerMonitor.visit({ name: agent.member.Name });
 
     const logRequest = server.pretender.handledRequests.find(req =>
       req.url.startsWith('/v1/agent/monitor')
@@ -53,15 +53,16 @@ module('Acceptance | server monitor', function(hooks) {
   });
 
   test('switching the log level persists the new log level as a query param', async function(assert) {
-    await ServerMonitor.visit({ name: agent.name });
+    const name = agent.member.Name;
+    await ServerMonitor.visit({ name: agent.member.Name });
     await ServerMonitor.selectLogLevel('Debug');
-    assert.equal(currentURL(), `/servers/${agent.name}/monitor?level=debug`);
+    assert.equal(currentURL(), `/servers/${name}/monitor?level=debug`);
   });
 
   test('when the current access token does not include the agent:read rule, a descriptive error message is shown', async function(assert) {
     window.localStorage.nomadTokenSecret = clientToken.secretId;
 
-    await ServerMonitor.visit({ name: agent.name });
+    await ServerMonitor.visit({ name: agent.member.Name });
     assert.notOk(ServerMonitor.logsArePresent);
     assert.ok(ServerMonitor.error.isShown);
     assert.equal(ServerMonitor.error.title, 'Not Authorized');

--- a/ui/tests/acceptance/servers-list-test.js
+++ b/ui/tests/acceptance/servers-list-test.js
@@ -43,7 +43,7 @@ module('Acceptance | servers list', function(hooks) {
     assert.equal(ServersList.servers.length, ServersList.pageSize, 'List is stopped at pageSize');
 
     ServersList.servers.forEach((server, index) => {
-      assert.equal(server.name, sortedAgents[index].member.Name, 'Servers are ordered');
+      assert.equal(server.name, sortedAgents[index].name, 'Servers are ordered');
     });
 
     assert.equal(document.title, 'Servers - Nomad');
@@ -57,7 +57,7 @@ module('Acceptance | servers list', function(hooks) {
 
     const agentRow = ServersList.servers.objectAt(0);
 
-    assert.equal(agentRow.name, agent.member.Name, 'Name');
+    assert.equal(agentRow.name, agent.name, 'Name');
     assert.equal(agentRow.status, agent.member.Status, 'Status');
     assert.equal(agentRow.leader, 'True', 'Leader?');
     assert.equal(agentRow.address, agent.member.Address, 'Address');
@@ -72,7 +72,7 @@ module('Acceptance | servers list', function(hooks) {
     await ServersList.visit();
     await ServersList.servers.objectAt(0).clickRow();
 
-    assert.equal(currentURL(), `/servers/${agent.member.Name}`, 'Now at the server detail page');
+    assert.equal(currentURL(), `/servers/${agent.name}`, 'Now at the server detail page');
   });
 
   test('when accessing servers is forbidden, show a message with a link to the tokens page', async function(assert) {

--- a/ui/tests/acceptance/servers-list-test.js
+++ b/ui/tests/acceptance/servers-list-test.js
@@ -13,9 +13,9 @@ const minimumSetup = () => {
 };
 
 const agentSort = leader => (a, b) => {
-  if (formatHost(a.address, a.tags.port) === leader) {
+  if (formatHost(a.member.Address, a.member.Tags.port) === leader) {
     return 1;
-  } else if (formatHost(b.address, b.tags.port) === leader) {
+  } else if (formatHost(b.member.Address, b.member.Tags.port) === leader) {
     return -1;
   }
   return 0;
@@ -43,7 +43,7 @@ module('Acceptance | servers list', function(hooks) {
     assert.equal(ServersList.servers.length, ServersList.pageSize, 'List is stopped at pageSize');
 
     ServersList.servers.forEach((server, index) => {
-      assert.equal(server.name, sortedAgents[index].name, 'Servers are ordered');
+      assert.equal(server.name, sortedAgents[index].member.Name, 'Servers are ordered');
     });
 
     assert.equal(document.title, 'Servers - Nomad');
@@ -57,12 +57,12 @@ module('Acceptance | servers list', function(hooks) {
 
     const agentRow = ServersList.servers.objectAt(0);
 
-    assert.equal(agentRow.name, agent.name, 'Name');
-    assert.equal(agentRow.status, agent.status, 'Status');
+    assert.equal(agentRow.name, agent.member.Name, 'Name');
+    assert.equal(agentRow.status, agent.member.Status, 'Status');
     assert.equal(agentRow.leader, 'True', 'Leader?');
-    assert.equal(agentRow.address, agent.address, 'Address');
-    assert.equal(agentRow.serfPort, agent.serfPort, 'Serf Port');
-    assert.equal(agentRow.datacenter, agent.tags.dc, 'Datacenter');
+    assert.equal(agentRow.address, agent.member.Address, 'Address');
+    assert.equal(agentRow.serfPort, agent.member.Port, 'Serf Port');
+    assert.equal(agentRow.datacenter, agent.member.Tags.dc, 'Datacenter');
   });
 
   test('each server should link to the server detail page', async function(assert) {
@@ -72,7 +72,7 @@ module('Acceptance | servers list', function(hooks) {
     await ServersList.visit();
     await ServersList.servers.objectAt(0).clickRow();
 
-    assert.equal(currentURL(), `/servers/${agent.name}`, 'Now at the server detail page');
+    assert.equal(currentURL(), `/servers/${agent.member.Name}`, 'Now at the server detail page');
   });
 
   test('when accessing servers is forbidden, show a message with a link to the tokens page', async function(assert) {


### PR DESCRIPTION
This PR closes [10672](https://github.com/hashicorp/nomad/issues/10672).

The the Nomad UI previously made a request to the `agent/self` endpoint and returned information about the Nomad Agent Version via the Nomad Agent Version.

This PR edits that to retrieve the Nomad Agent Version from the Nomad Agent Config which is created at build time.

The rationale behind this change was that, we have a guaranteed result for Nomad Agent Config Version. Whereas, we didn't have a guarantee that we'd always have a Nomad Agent Member because Clients are not included in the Serf Gossip Protocol.

We know the bug always occurs when we have clients, but no servers.

This PR does not resolve the issue pointed out by @DingoEatingFuzz regarding [cached requests](https://github.com/hashicorp/nomad/issues/6458). That would require us to dynamically serve the `index.html` and also calculate the Nomad Agent Version based on text files, we believe. We will eventually handle this issue when we tackle this [issue](https://app.asana.com/0/758378679700210/1165474804795867/f).