### PR TITLE
cli: check deployment exists before monitoring

### DIFF
--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -231,10 +231,10 @@ UPDATE:
 	for {
 		deploy, meta, err := client.Deployments().Info(deployID, &q)
 		if err != nil {
-			d.Append(glint.Style(
+			d.Append(glint.Layout(glint.Style(
 				glint.Text(fmt.Sprintf("%s: Error fetching deployment", formatTime(time.Now()))),
 				glint.Color("red"),
-			))
+			)).MarginLeft(4))
 			d.RenderFrame()
 			return
 		}

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -234,7 +234,7 @@ UPDATE:
 			d.Append(glint.Layout(glint.Style(
 				glint.Text(fmt.Sprintf("%s: Error fetching deployment", formatTime(time.Now()))),
 				glint.Color("red"),
-			)).MarginLeft(4))
+			)).MarginLeft(4), glint.Text(""))
 			d.RenderFrame()
 			return
 		}
@@ -291,7 +291,7 @@ UPDATE:
 				d.Set(
 					endSpinner,
 					statusComponent,
-					glint.Layout(glint.Text("")),
+					glint.Text(""),
 				)
 
 				// Wait for rollback to launch
@@ -299,10 +299,10 @@ UPDATE:
 				rollback, _, err := client.Jobs().LatestDeployment(deploy.JobID, nil)
 
 				if err != nil {
-					d.Append(glint.Style(
+					d.Append(glint.Layout(glint.Style(
 						glint.Text(fmt.Sprintf("%s: Error fetching rollback deployment", formatTime(time.Now()))),
-						glint.Color("red")),
-					)
+						glint.Color("red"),
+					)).MarginLeft(4), glint.Text(""))
 					d.RenderFrame()
 					return
 				}
@@ -329,7 +329,7 @@ UPDATE:
 		}
 	}
 	// Render one final time with completion message
-	d.Set(endSpinner, statusComponent)
+	d.Set(endSpinner, statusComponent, glint.Text(""))
 	d.RenderFrame()
 }
 

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -285,21 +285,23 @@ func (m *monitor) monitor(evalID string) int {
 		break
 	}
 
-	// Monitor the deployment
+	// Monitor the deployment if it exists
 	dID := m.state.deployment
-	m.ui.Info(fmt.Sprintf("%s: Monitoring deployment %q", formatTime(time.Now()), limit(dID, m.length)))
+	if len(dID) > 0 {
+		m.ui.Info(fmt.Sprintf("%s: Monitoring deployment %q", formatTime(time.Now()), limit(dID, m.length)))
 
-	var verbose bool
-	if m.length == fullId {
-		verbose = true
-	} else {
-		verbose = false
+		var verbose bool
+		if m.length == fullId {
+			verbose = true
+		} else {
+			verbose = false
+		}
+
+		meta := new(Meta)
+		meta.Ui = m.ui
+		cmd := &DeploymentStatusCommand{Meta: *meta}
+		cmd.monitor(m.client, dID, 0, verbose)
 	}
-
-	meta := new(Meta)
-	meta.Ui = m.ui
-	cmd := &DeploymentStatusCommand{Meta: *meta}
-	cmd.monitor(m.client, dID, 0, verbose)
 
 	// Treat scheduling failures specially using a dedicated exit code.
 	// This makes it easier to detect failures from the CLI.

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -287,7 +287,7 @@ func (m *monitor) monitor(evalID string) int {
 
 	// Monitor the deployment if it exists
 	dID := m.state.deployment
-	if len(dID) > 0 {
+	if dID != "" {
 		m.ui.Info(fmt.Sprintf("%s: Monitoring deployment %q", formatTime(time.Now()), limit(dID, m.length)))
 
 		var verbose bool

--- a/website/content/docs/commands/job/run.mdx
+++ b/website/content/docs/commands/job/run.mdx
@@ -27,8 +27,9 @@ downloaded and read from URL specified. Nomad downloads the job file using
 
 By default, on successful job submission the run command will enter an
 interactive monitor and display log information detailing the scheduling
-decisions, placement information, and [deployment status] for the provided job. 
-The monitor will exit after scheduling and deployment have finished or failed.
+decisions, placement information, and [deployment status] for the provided job 
+if applicable ([`batch`] and [`system`] jobs don't create deployments). The monitor will 
+exit after scheduling and deployment have finished or failed.
 
 On successful job submission and scheduling, exit code 0 will be returned. If
 there are job placement issues encountered (unsatisfiable constraints, resource
@@ -204,8 +205,22 @@ $ nomad job run failing.nomad
     cache       1        0       0        0          N/A
 ```
 
+Sample output when scheduling a system job, which doesn't create a deployment:
+
+```shell-session
+$ nomad job run example.nomad
+==> 2021-06-14T09:25:08-07:00: Monitoring evaluation "88a91284"
+    2021-06-14T09:25:08-07:00: Evaluation triggered by job "example"
+    2021-06-14T09:25:08-07:00: Allocation "03501797" created: node "7849439f", group "cache"
+==> 2021-06-14T09:25:09-07:00: Monitoring evaluation "88a91284"
+    2021-06-14T09:25:09-07:00: Evaluation status changed: "pending" -> "complete"
+==> 2021-06-14T09:25:09-07:00: Evaluation "88a91284" finished with status "complete"
+```
+
 [`go-getter`]: https://github.com/hashicorp/go-getter
 [deployment status]: /docs/commands/deployment#status 
+[`batch`]: /docs/schedulers#batch
+[`system`]: /docs/schedulers#system
 [`job plan` command]: /docs/commands/job/plan
 [eval status]: /docs/commands/eval-status
 [job specification]: /docs/job-specification


### PR DESCRIPTION
System and batch jobs don't create deployments, which means nomad tries
to monitor a non-existent deployment when it runs a job and ouputs an
error message. This adds a check to make sure a deployment exists before
monitoring.