### PR TITLE
client/fingerprint/java: improve java version string regex matching

### DIFF
--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -356,7 +356,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 		}
 	}
 
-	version, runtime, vm, err := javaVersionInfo()
+	version, jdkJRE, vm, err := javaVersionInfo()
 	if err != nil {
 		// return no error, as it isn't an error to not find java, it just means we
 		// can't use it.
@@ -367,7 +367,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 
 	fp.Attributes[driverAttr] = pstructs.NewBoolAttribute(true)
 	fp.Attributes[driverVersionAttr] = pstructs.NewStringAttribute(version)
-	fp.Attributes["driver.java.runtime"] = pstructs.NewStringAttribute(runtime)
+	fp.Attributes["driver.java.runtime"] = pstructs.NewStringAttribute(jdkJRE)
 	fp.Attributes["driver.java.vm"] = pstructs.NewStringAttribute(vm)
 
 	return fp

--- a/drivers/java/utils.go
+++ b/drivers/java/utils.go
@@ -50,6 +50,10 @@ func javaVersionInfo() (version, runtime, vm string, err error) {
 	return
 }
 
+var (
+	javaVersionRe = regexp.MustCompile(`([.\d_]+)`)
+)
+
 func parseJavaVersionOutput(infoString string) (version, runtime, vm string) {
 	infoString = strings.TrimSpace(infoString)
 
@@ -65,8 +69,7 @@ func parseJavaVersionOutput(infoString string) (version, runtime, vm string) {
 
 	versionString := strings.TrimSpace(lines[0])
 
-	re := regexp.MustCompile(`version "([^"]*)"`)
-	if match := re.FindStringSubmatch(lines[0]); len(match) == 2 {
+	if match := javaVersionRe.FindStringSubmatch(versionString); len(match) == 2 {
 		versionString = match[1]
 	}
 


### PR DESCRIPTION
This PR improves the regular expression used for matching the java
version string, which varies a lot depending on the java vendor and
version.

These are the example strings we now test for

```
java version "1.7.0_80"
openjdk version "11.0.1" 2018-10-16
openjdk version "11.0.1" 2018-10-16
java version "1.6.0_36"
openjdk version "1.8.0_192"
openjdk 11.0.11 2021-04-20 LTS
```

The last one is a new test added on behalf of #6081, which is
still broken on today's CentOS 7 default JDK package.

```
openjdk 11.0.11 2021-04-20 LTS
OpenJDK Runtime Environment 18.9 (build 11.0.11+9-LTS)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.11+9-LTS, mixed mode, sharing)
```

```
==> Evaluation "21c6caf7" finished with status "complete" but failed to place all allocations:
    Task Group "example" (failed to place 1 allocation):
      * Constraint "${driver.java.version} >= 11.0.0": 1 nodes excluded by filter
    Evaluation "2b737d48" waiting for additional capacity to place remainder
```

Fixes #6081