### PR TITLE
docs: host_network does support Docker task port mapping

### DIFF
--- a/website/content/docs/job-specification/network.mdx
+++ b/website/content/docs/job-specification/network.mdx
@@ -264,8 +264,6 @@ If not set the "default" host network is used which is commonly the address with
 
 When Nomad does port mapping for ports with a defined `host_network`, the port mapping rule will use the host address as the destination address.
 
-~> Note: `host_network` does not currently support task-based mapped ports such as the Docker driver's `port_map` configuration.
-
 ```hcl
 network {
   mode = "bridge"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10010

---

Per the discussion in https://github.com/hashicorp/nomad/issues/10010#issuecomment-780669549 this has worked fine for a quite a while but we forgot to remove the note. The other items in that comment were addressed in docs fixes in https://github.com/hashicorp/nomad/pull/10766 and https://github.com/hashicorp/nomad/pull/10724.

To demonstrate, run the following job on a machine with a second network named `"public"` configured:

<details><summary>jobspec</summary>

```hcl
job "example" {
  datacenters = ["dc1"]

  group "web" {

    network {
      mode = "bridge"
      port "www" {
        to           = 8001
        host_network = "public"
      }
    }

    task "httpd" {
      driver = "docker"

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-v", "-f", "-p", "8001", "-h", "/local"]
        ports   = ["www"]
      }

      template {
        data        = "<html>hello, world</html>"
        destination = "local/index.html"
      }

      resources {
        cpu    = 128
        memory = 128
      }
    }
  }
}
```

</details>

```
$ nomad job run ./example.nomad
==> 2021-06-16T15:26:51-04:00: Monitoring evaluation "e9a1cdc0"
    2021-06-16T15:26:51-04:00: Evaluation triggered by job "example"
    2021-06-16T15:26:51-04:00: Evaluation within deployment: "db3499e8"
    2021-06-16T15:26:51-04:00: Allocation "b568505f" created: node "5e57b6a0", group "web"
    2021-06-16T15:26:51-04:00: Evaluation status changed: "pending" -> "complete"
==> 2021-06-16T15:26:51-04:00: Evaluation "e9a1cdc0" finished with status "complete"
==> 2021-06-16T15:26:51-04:00: Monitoring deployment "db3499e8"
  ⠦ Deployment "db3499e8" in progress...
...

$ nomad alloc status b5685
...

Allocation Addresses (mode = "bridge")
Label  Dynamic  Address
*www   yes      10.199.0.200:23377 -> 8001

$ curl 10.199.0.200:23377
<html>hello, world</html>
```
