### PR TITLE
tests: allocrunner CNI tests are Linux-only

### DIFF
--- a/client/allocrunner/networking_cni_test.go
+++ b/client/allocrunner/networking_cni_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package allocrunner
 
 import (


### PR DESCRIPTION
Running the `client/allocrunner` tests fail to compile on macOS because the
CNI test file depends on the CNI network configurator, which is in a
Linux-only file.

Without this patch, on macOS:

```
$ go test ./client/allocrunner
# github.com/hashicorp/nomad/client/allocrunner [github.com/hashicorp/nomad/client/allocrunner.test]
client/allocrunner/networking_cni_test.go:32:8: undefined: cniNetworkConfigurator
client/allocrunner/networking_cni_test.go:57:8: undefined: cniNetworkConfigurator
FAIL    github.com/hashicorp/nomad/client/allocrunner [build failed]
FAIL
```