### PR TITLE
e2e: fix a couple recent e2e bugs

### DIFF
--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -874,7 +874,7 @@ func ApiTgToStructsTG(job *structs.Job, taskGroup *api.TaskGroup, tg *structs.Ta
 	tg.Constraints = ApiConstraintsToStructs(taskGroup.Constraints)
 	tg.Affinities = ApiAffinitiesToStructs(taskGroup.Affinities)
 	tg.Networks = ApiNetworkResourceToStructs(taskGroup.Networks)
-	tg.Services = ApiServicesToStructs(taskGroup.Services)
+	tg.Services = ApiServicesToStructs(taskGroup.Services, true)
 	tg.Consul = apiConsulToStructs(taskGroup.Consul)
 
 	tg.RestartPolicy = &structs.RestartPolicy{
@@ -1044,7 +1044,7 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 		}
 	}
 
-	structsTask.Services = ApiServicesToStructs(apiTask.Services)
+	structsTask.Services = ApiServicesToStructs(apiTask.Services, false)
 
 	structsTask.Resources = ApiResourcesToStructs(apiTask.Resources)
 
@@ -1212,7 +1212,7 @@ func ApiPortToStructs(in api.Port) structs.Port {
 	}
 }
 
-func ApiServicesToStructs(in []*api.Service) []*structs.Service {
+func ApiServicesToStructs(in []*api.Service, group bool) []*structs.Service {
 	if len(in) == 0 {
 		return nil
 	}
@@ -1258,11 +1258,16 @@ func ApiServicesToStructs(in []*api.Service) []*structs.Service {
 					Body:                   check.Body,
 					GRPCService:            check.GRPCService,
 					GRPCUseTLS:             check.GRPCUseTLS,
-					TaskName:               check.TaskName,
 					SuccessBeforePassing:   check.SuccessBeforePassing,
 					FailuresBeforeCritical: check.FailuresBeforeCritical,
 					OnUpdate:               onUpdate,
 				}
+
+				if group {
+					// only copy over task name for group level checks
+					out[i].Checks[j].TaskName = check.TaskName
+				}
+
 				if check.CheckRestart != nil {
 					out[i].Checks[j].CheckRestart = &structs.CheckRestart{
 						Limit:          check.CheckRestart.Limit,

--- a/e2e/e2eutil/job.go
+++ b/e2e/e2eutil/job.go
@@ -12,7 +12,7 @@ import (
 // Register registers a jobspec from a file but with a unique ID.
 // The caller is responsible for recording that ID for later cleanup.
 func Register(jobID, jobFilePath string) error {
-	cmd := exec.Command("nomad", "job", "run", "-")
+	cmd := exec.Command("nomad", "job", "run", "-detach", "-")
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return fmt.Errorf("could not open stdin?: %w", err)


### PR DESCRIPTION
15d39f0de - use `-detatch` mode when registering jobs with the CLI

57fdb8143 - only set task name for group service checks (broke in [refactoring](https://github.com/hashicorp/nomad/pull/10764/files))

No CL or BP needed, these happened after 1.1.1

Fixes https://github.com/hashicorp/nomad/issues/10781