### PR TITLE
Adds error handling for client error in getRandomJobAlloc.

### DIFF
--- a/command/alloc_fs.go
+++ b/command/alloc_fs.go
@@ -381,6 +381,9 @@ func (f *AllocFSCommand) followFile(client *api.Client, alloc *api.Allocation,
 func getRandomJobAlloc(client *api.Client, jobID string) (*api.AllocationListStub, error) {
 	var runningAllocs []*api.AllocationListStub
 	allocs, _, err := client.Jobs().Allocations(jobID, false, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error querying job %q: %w", jobID, err)
+	}
 
 	// Check that the job actually has allocations
 	if len(allocs) == 0 {


### PR DESCRIPTION
Resolves: #10786

Rub a bit of:

```go
if err != nil {
```

On `getRandomJobAlloc`. If the client returns an error, forward that error along, rather than the less helpful error about no job allocations existing.