### PR TITLE
consul/connect: Validate uniqueness of Connect upstreams within task group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 * cli: Added `-monitor` flag to `deployment status` command and automatically monitor deployments from `job run` command. [[GH-10661](https://github.com/hashicorp/nomad/pull/10661)]
+* consul/connect: Validate Connect service upstream address uniqueness within task group [[GH-7833](https://github.com/hashicorp/nomad/issues/7833)]
 * docker: Tasks using `network.mode = "bridge"` that don't set their `network_mode` will receive a `/etc/hosts` file that includes the pause container's hostname and any `extra_hosts`. [[GH-10766](https://github.com/hashicorp/nomad/issues/10766)]
 
 BUG FIXES:


### PR DESCRIPTION
This PR adds validation during job submission that Connect proxy upstreams
within a task group are using different listener address:port. Otherwise, a
duplicate envoy listener will be created and not be able to bind.

Perhaps one day Consul will have a way to consolidate envoys, but this is not that day.

Closes #7833