### PR TITLE
Return SchedulerConfig instead of SchedulerConfigResponse struct

### DIFF
--- a/.changelog/10799.txt
+++ b/.changelog/10799.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+api: Return scheduler configuration as top-level result in the `/v1/operator/scheduler/configuration`
+```

--- a/api/operator.go
+++ b/api/operator.go
@@ -171,8 +171,8 @@ type PreemptionConfig struct {
 }
 
 // SchedulerGetConfiguration is used to query the current Scheduler configuration.
-func (op *Operator) SchedulerGetConfiguration(q *QueryOptions) (*SchedulerConfigurationResponse, *QueryMeta, error) {
-	var resp SchedulerConfigurationResponse
+func (op *Operator) SchedulerGetConfiguration(q *QueryOptions) (*SchedulerConfiguration, *QueryMeta, error) {
+	var resp SchedulerConfiguration
 	qm, err := op.c.query("/v1/operator/scheduler/configuration", &resp, q)
 	if err != nil {
 		return nil, nil, err

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -246,7 +246,7 @@ func (s *HTTPServer) schedulerGetConfig(resp http.ResponseWriter, req *http.Requ
 	}
 	setMeta(resp, &reply.QueryMeta)
 
-	return reply, nil
+	return reply.SchedulerConfig, nil
 }
 
 func (s *HTTPServer) schedulerUpdateConfig(resp http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/command/agent/operator_endpoint_test.go
+++ b/command/agent/operator_endpoint_test.go
@@ -277,15 +277,15 @@ func TestOperator_SchedulerGetConfiguration(t *testing.T) {
 		obj, err := s.Server.OperatorSchedulerConfiguration(resp, req)
 		require.Nil(err)
 		require.Equal(200, resp.Code)
-		out, ok := obj.(structs.SchedulerConfigurationResponse)
+		out, ok := obj.(*structs.SchedulerConfiguration)
 		require.True(ok)
 
 		// Only system jobs can preempt other jobs by default.
-		require.True(out.SchedulerConfig.PreemptionConfig.SystemSchedulerEnabled)
-		require.False(out.SchedulerConfig.PreemptionConfig.SysBatchSchedulerEnabled)
-		require.False(out.SchedulerConfig.PreemptionConfig.BatchSchedulerEnabled)
-		require.False(out.SchedulerConfig.PreemptionConfig.ServiceSchedulerEnabled)
-		require.False(out.SchedulerConfig.MemoryOversubscriptionEnabled)
+		require.True(out.PreemptionConfig.SystemSchedulerEnabled)
+		require.True(out.PreemptionConfig.SysBatchSchedulerEnabled)
+		require.False(out.PreemptionConfig.BatchSchedulerEnabled)
+		require.False(out.PreemptionConfig.ServiceSchedulerEnabled)
+		require.False(out.MemoryOversubscriptionEnabled)
 	})
 }
 

--- a/command/agent/operator_endpoint_test.go
+++ b/command/agent/operator_endpoint_test.go
@@ -282,7 +282,7 @@ func TestOperator_SchedulerGetConfiguration(t *testing.T) {
 
 		// Only system jobs can preempt other jobs by default.
 		require.True(out.PreemptionConfig.SystemSchedulerEnabled)
-		require.True(out.PreemptionConfig.SysBatchSchedulerEnabled)
+		require.False(out.PreemptionConfig.SysBatchSchedulerEnabled)
 		require.False(out.PreemptionConfig.BatchSchedulerEnabled)
 		require.False(out.PreemptionConfig.ServiceSchedulerEnabled)
 		require.False(out.MemoryOversubscriptionEnabled)

--- a/e2e/oversubscription/oversubscription.go
+++ b/e2e/oversubscription/oversubscription.go
@@ -41,11 +41,10 @@ func (tc *OversubscriptionTest) enableMemoryOversubscription(f *framework.F) {
 	resp, _, err := tc.Nomad().Operator().SchedulerGetConfiguration(nil)
 	f.NoError(err)
 
-	tc.initialSchedulerConfig = resp.SchedulerConfig
+	tc.initialSchedulerConfig = resp
 
-	conf := *resp.SchedulerConfig
-	conf.MemoryOversubscriptionEnabled = true
-	_, _, err = tc.Nomad().Operator().SchedulerSetConfiguration(&conf, nil)
+	resp.MemoryOversubscriptionEnabled = true
+	_, _, err = tc.Nomad().Operator().SchedulerSetConfiguration(resp, nil)
 	f.NoError(err)
 }
 

--- a/internal/testing/apitests/operator_test.go
+++ b/internal/testing/apitests/operator_test.go
@@ -15,15 +15,15 @@ func TestAPI_OperatorSchedulerGetSetConfiguration(t *testing.T) {
 	defer s.Stop()
 
 	operator := c.Operator()
-	var config *api.SchedulerConfigurationResponse
+	var config *api.SchedulerConfiguration
 	retry.Run(t, func(r *retry.R) {
 		var err error
 		config, _, err = operator.SchedulerGetConfiguration(nil)
 		r.Check(err)
 	})
-	require.True(config.SchedulerConfig.PreemptionConfig.SystemSchedulerEnabled)
-	require.False(config.SchedulerConfig.PreemptionConfig.BatchSchedulerEnabled)
-	require.False(config.SchedulerConfig.PreemptionConfig.ServiceSchedulerEnabled)
+	require.True(config.PreemptionConfig.SystemSchedulerEnabled)
+	require.False(config.PreemptionConfig.BatchSchedulerEnabled)
+	require.False(config.PreemptionConfig.ServiceSchedulerEnabled)
 
 	// Change a config setting
 	newConf := &api.SchedulerConfiguration{
@@ -41,9 +41,9 @@ func TestAPI_OperatorSchedulerGetSetConfiguration(t *testing.T) {
 
 	config, _, err = operator.SchedulerGetConfiguration(nil)
 	require.Nil(err)
-	require.False(config.SchedulerConfig.PreemptionConfig.SystemSchedulerEnabled)
-	require.True(config.SchedulerConfig.PreemptionConfig.BatchSchedulerEnabled)
-	require.True(config.SchedulerConfig.PreemptionConfig.ServiceSchedulerEnabled)
+	require.False(config.PreemptionConfig.SystemSchedulerEnabled)
+	require.True(config.PreemptionConfig.BatchSchedulerEnabled)
+	require.True(config.PreemptionConfig.ServiceSchedulerEnabled)
 }
 
 func TestAPI_OperatorSchedulerCASConfiguration(t *testing.T) {
@@ -53,21 +53,21 @@ func TestAPI_OperatorSchedulerCASConfiguration(t *testing.T) {
 	defer s.Stop()
 
 	operator := c.Operator()
-	var config *api.SchedulerConfigurationResponse
+	var config *api.SchedulerConfiguration
 	retry.Run(t, func(r *retry.R) {
 		var err error
 		config, _, err = operator.SchedulerGetConfiguration(nil)
 		r.Check(err)
 	})
-	require.True(config.SchedulerConfig.PreemptionConfig.SystemSchedulerEnabled)
-	require.False(config.SchedulerConfig.PreemptionConfig.BatchSchedulerEnabled)
-	require.False(config.SchedulerConfig.PreemptionConfig.ServiceSchedulerEnabled)
+	require.True(config.PreemptionConfig.SystemSchedulerEnabled)
+	require.False(config.PreemptionConfig.BatchSchedulerEnabled)
+	require.False(config.PreemptionConfig.ServiceSchedulerEnabled)
 
 	// Pass an invalid ModifyIndex
 	{
 		newConf := &api.SchedulerConfiguration{
 			PreemptionConfig: api.PreemptionConfig{SystemSchedulerEnabled: false, BatchSchedulerEnabled: true},
-			ModifyIndex:      config.SchedulerConfig.ModifyIndex - 1,
+			ModifyIndex:      config.ModifyIndex - 1,
 		}
 		resp, wm, err := operator.SchedulerCASConfiguration(newConf, nil)
 		require.Nil(err)
@@ -79,7 +79,7 @@ func TestAPI_OperatorSchedulerCASConfiguration(t *testing.T) {
 	{
 		newConf := &api.SchedulerConfiguration{
 			PreemptionConfig: api.PreemptionConfig{SystemSchedulerEnabled: false, BatchSchedulerEnabled: true},
-			ModifyIndex:      config.SchedulerConfig.ModifyIndex,
+			ModifyIndex:      config.ModifyIndex,
 		}
 		resp, wm, err := operator.SchedulerCASConfiguration(newConf, nil)
 		require.Nil(err)
@@ -89,7 +89,7 @@ func TestAPI_OperatorSchedulerCASConfiguration(t *testing.T) {
 
 	config, _, err := operator.SchedulerGetConfiguration(nil)
 	require.Nil(err)
-	require.False(config.SchedulerConfig.PreemptionConfig.SystemSchedulerEnabled)
-	require.True(config.SchedulerConfig.PreemptionConfig.BatchSchedulerEnabled)
-	require.False(config.SchedulerConfig.PreemptionConfig.ServiceSchedulerEnabled)
+	require.False(config.PreemptionConfig.SystemSchedulerEnabled)
+	require.True(config.PreemptionConfig.BatchSchedulerEnabled)
+	require.False(config.PreemptionConfig.ServiceSchedulerEnabled)
 }

--- a/website/content/api-docs/operator/scheduler.mdx
+++ b/website/content/api-docs/operator/scheduler.mdx
@@ -37,48 +37,46 @@ $ curl \
 
 ```json
 {
-  "Index": 5,
-  "KnownLeader": true,
-  "LastContact": 0,
-  "SchedulerConfig": {
-    "CreateIndex": 5,
-    "ModifyIndex": 5,
-    "SchedulerAlgorithm": "spread",
-    "MemoryOversubscriptionEnabled": true,
-    "PreemptionConfig": {
-      "SystemSchedulerEnabled": true,
-      "BatchSchedulerEnabled": false,
-      "ServiceSchedulerEnabled": false
-    }
-  }
+  "CreateIndex": 5,
+  "MemoryOversubscriptionEnabled": false,
+  "ModifyIndex": 5,
+  "PreemptionConfig": {
+    "BatchSchedulerEnabled": false,
+    "ServiceSchedulerEnabled": false,
+    "SystemSchedulerEnabled": true
+  },
+  "SchedulerAlgorithm": "binpack"
 }
 ```
 
 #### Field Reference
 
-- `Index` `(int)` - The `Index` value is the Raft index corresponding to this
-  configuration.
+- `SchedulerAlgorithm` `(string: "binpack")` - Specifies whether scheduler
+  binpacks or spreads allocations on available nodes.
 
-- `SchedulerConfig` `(SchedulerConfig)` - The returned `SchedulerConfig` object has configuration
-  settings mentioned below.
+- `MemoryOversubscriptionEnabled` `(bool: false)` <sup>1.1 or later</sup> - When
+  `true`, tasks may exceed their reserved memory limit, if the client has excess
+  memory capacity. Tasks must specify
+  [`memory_max`](/docs/job-specification/resources#memory_max) to take advantage
+  of memory oversubscription.
 
-  - `SchedulerAlgorithm` `(string: "binpack")` - Specifies whether scheduler binpacks or spreads allocations on available nodes.
+- `PreemptionConfig` `(PreemptionConfig)` - Options to enable preemption for
+  various schedulers.
 
-  - `MemoryOversubscriptionEnabled` `(bool: false)` <sup>1.1 Beta</sup> - When `true`, tasks may exceed their reserved memory limit, if the client has excess memory capacity. Tasks must specify [`memory_max`](/docs/job-specification/resources#memory_max) to take advantage of memory oversubscription.
+  - `SystemSchedulerEnabled` `(bool: true)` - Specifies whether preemption for
+    system jobs is enabled. Note that this defaults to true.
 
-  - `PreemptionConfig` `(PreemptionConfig)` - Options to enable preemption for various schedulers.
+  - `BatchSchedulerEnabled` `(bool: false)` - Specifies whether preemption for
+    batch jobs is enabled. Note that this defaults to false and must be explicitly
+    enabled.
 
-    - `SystemSchedulerEnabled` `(bool: true)` - Specifies whether preemption for system jobs is enabled. Note that
-      this defaults to true.
+  - `ServiceSchedulerEnabled` `(bool: false)` - Specifies whether preemption for
+    service jobs is enabled. Note that this defaults to false and must be
+    explicitly enabled.
 
-    - `BatchSchedulerEnabled` `(bool: false)` - Specifies whether preemption for batch jobs is enabled. Note that
-      this defaults to false and must be explicitly enabled.
+- `CreateIndex` - The Raft index at which the configuration was created.
 
-    - `ServiceSchedulerEnabled` `(bool: false)` - Specifies whether preemption for service jobs is enabled. Note that
-      this defaults to false and must be explicitly enabled.
-
-  - `CreateIndex` - The Raft index at which the config was created.
-  - `ModifyIndex` - The Raft index at which the config was modified.
+- `ModifyIndex` - The Raft index at which the configuration was modified.
 
 ## Update Scheduler Configuration
 

--- a/website/content/api-docs/operator/scheduler.mdx
+++ b/website/content/api-docs/operator/scheduler.mdx
@@ -43,6 +43,7 @@ $ curl \
   "PreemptionConfig": {
     "BatchSchedulerEnabled": false,
     "ServiceSchedulerEnabled": false,
+    "SysBatchSchedulerEnabled": false,
     "SystemSchedulerEnabled": true
   },
   "SchedulerAlgorithm": "binpack"
@@ -65,6 +66,10 @@ $ curl \
 
   - `SystemSchedulerEnabled` `(bool: true)` - Specifies whether preemption for
     system jobs is enabled. Note that this defaults to true.
+
+  - `SysBatchSchedulerEnabled` `(bool: false)` - Specifies whether preemption
+    for sysbatch jobs is enabled. Note that this defaults to false and must be
+    explicitly enabled.
 
   - `BatchSchedulerEnabled` `(bool: false)` - Specifies whether preemption for
     batch jobs is enabled. Note that this defaults to false and must be explicitly


### PR DESCRIPTION
Currently, `GET /v1/operator/scheduler/configuration` returns a SchedulerConfigResponse object. The APIs usually use the QueryMeta from the Response objects to populate the HTTP headers for their response to the HTTP API client, but then return the object next to them as the HTTP body.

This is a breaking change to the API; however, this endpoint should be an extremely low use endpoint so it might be acceptable to make it consistent at this point?

Reference code:
https://github.com/hashicorp/nomad/blob/b430bafe9031f871e21403fde008bd8494350091/command/agent/node_endpoint.go#L184-L193