### PR TITLE
website: remove redirect away from existing page

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -661,11 +661,6 @@ module.exports = [
     destination: '/docs/schedulers',
     permanent: true,
   },
-  {
-    source: '/docs/internals/scheduling',
-    destination: '/docs/internals/scheduling/scheduling',
-    permanent: true,
-  },
 
   // Sometimes code names are too good not to mention
   {


### PR DESCRIPTION
This PR removes a seemingly unnecessary redirect that causes odd reload behaviour when on the [`/docs/internals/scheduling`](https://www.nomadproject.io/docs/internals/scheduling) page.

This page can be accessed via client-side navigation, but on reload, the viewer is redirected to [`/docs/internals/scheduling/scheduling`](https://www.nomadproject.io/docs/internals/scheduling/scheduling), which doesn't seem intentional.

