### PR TITLE
consul/connect: automatically set consul tls sni name for connect native tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 BUG FIXES:
 csi: fixed a CLI panic when formatting `volume status` with `-verbose` flag [[GH-10818](https://github.com/hashicorp/nomad/issues/10818)]
 
+IMPROVEMENTS:
+* consul/connect: automatically set CONSUL_TLS_SERVER_NAME for connect native tasks [[GH-10804](https://github.com/hashicorp/nomad/issues/10804)]
+
 ## 1.1.2 (June 22, 2021)
 
 IMPROVEMENTS:

--- a/client/allocrunner/taskrunner/connect_native_hook.go
+++ b/client/allocrunner/taskrunner/connect_native_hook.go
@@ -212,18 +212,26 @@ func (h *connectNativeHook) tlsEnv(env map[string]string) map[string]string {
 // if the task is running inside an alloc's network namespace (i.e. bridge mode).
 //
 // Sets CONSUL_HTTP_ADDR if not already set.
+// Sets CONSUL_TLS_SERVER_NAME if not already set, and consul tls is enabled.
 func (h *connectNativeHook) bridgeEnv(env map[string]string) map[string]string {
+
 	if h.alloc.AllocatedResources.Shared.Networks[0].Mode != "bridge" {
 		return nil
 	}
 
+	result := make(map[string]string)
+
 	if _, exists := env["CONSUL_HTTP_ADDR"]; !exists {
-		return map[string]string{
-			"CONSUL_HTTP_ADDR": "unix:///" + allocdir.AllocHTTPSocket,
+		result["CONSUL_HTTP_ADDR"] = "unix:///" + allocdir.AllocHTTPSocket
+	}
+
+	if _, exists := env["CONSUL_TLS_SERVER_NAME"]; !exists {
+		if v := h.consulConfig.SSL; v != "" {
+			result["CONSUL_TLS_SERVER_NAME"] = "localhost"
 		}
 	}
 
-	return nil
+	return result
 }
 
 // hostEnv creates a set of additional environment variables to be used when launching

--- a/client/allocrunner/taskrunner/connect_native_hook_test.go
+++ b/client/allocrunner/taskrunner/connect_native_hook_test.go
@@ -165,21 +165,45 @@ func TestConnectNativeHook_tlsEnv(t *testing.T) {
 func TestConnectNativeHook_bridgeEnv_bridge(t *testing.T) {
 	t.Parallel()
 
-	hook := new(connectNativeHook)
-	hook.alloc = mock.ConnectNativeAlloc("bridge")
+	t.Run("without tls", func(t *testing.T) {
+		hook := new(connectNativeHook)
+		hook.alloc = mock.ConnectNativeAlloc("bridge")
 
-	t.Run("consul address env not preconfigured", func(t *testing.T) {
-		result := hook.bridgeEnv(nil)
-		require.Equal(t, map[string]string{
-			"CONSUL_HTTP_ADDR": "unix:///alloc/tmp/consul_http.sock",
-		}, result)
+		t.Run("consul address env not preconfigured", func(t *testing.T) {
+			result := hook.bridgeEnv(nil)
+			require.Equal(t, map[string]string{
+				"CONSUL_HTTP_ADDR": "unix:///alloc/tmp/consul_http.sock",
+			}, result)
+		})
+
+		t.Run("consul address env is preconfigured", func(t *testing.T) {
+			result := hook.bridgeEnv(map[string]string{
+				"CONSUL_HTTP_ADDR": "10.1.1.1",
+			})
+			require.Empty(t, result)
+		})
 	})
 
-	t.Run("consul address env is preconfigured", func(t *testing.T) {
-		result := hook.bridgeEnv(map[string]string{
-			"CONSUL_HTTP_ADDR": "10.1.1.1",
+	t.Run("with tls", func(t *testing.T) {
+		hook := new(connectNativeHook)
+		hook.alloc = mock.ConnectNativeAlloc("bridge")
+		hook.consulConfig.SSL = "true"
+
+		t.Run("consul tls server name not preconfigured", func(t *testing.T) {
+			result := hook.bridgeEnv(nil)
+			require.Equal(t, map[string]string{
+				"CONSUL_HTTP_ADDR":       "unix:///alloc/tmp/consul_http.sock",
+				"CONSUL_TLS_SERVER_NAME": "localhost",
+			}, result)
 		})
-		require.Empty(t, result)
+
+		t.Run("consul tls server name preconfigured", func(t *testing.T) {
+			result := hook.bridgeEnv(map[string]string{
+				"CONSUL_HTTP_ADDR":       "10.1.1.1",
+				"CONSUL_TLS_SERVER_NAME": "consul.local",
+			})
+			require.Empty(t, result)
+		})
 	})
 }
 

--- a/website/content/partials/envvars.mdx
+++ b/website/content/partials/envvars.mdx
@@ -277,8 +277,9 @@
         <code>CONSUL_HTTP_ADDR</code>
       </td>
       <td>
-        Specifies the address to the local Consul agent, will be a unix domain
-        socket in bridge mode and a tcp address in host networking.
+        Specifies the address to the local Consul agent. Will be automatically
+        set to a unix domain socket in bridge networking mode, or a tcp address in
+        host networking mode.
       </td>
     </tr>
     <tr>
@@ -286,7 +287,9 @@
         <code>CONSUL_HTTP_TOKEN</code>
       </td>
       <td>
-        The token to authenticate against consul.
+        Specifies the Consul ACL token used to authorize with Consul. Will be
+        automatically set to a generated Connect service identity token specific
+        to the service instance if Consul ACLs are enabled.
       </td>
     </tr>
     <tr>
@@ -294,7 +297,9 @@
         <code>CONSUL_HTTP_SSL</code>
       </td>
       <td>
-        Specifies whether HTTPS should be used when communicating with consul.
+        Specifies whether HTTPS should be used when communicating with consul. Will
+        be automatically set to true if Nomad is configured to communicate with
+        Consul using TLS.
       </td>
     </tr>
     <tr>
@@ -302,7 +307,9 @@
         <code>CONSUL_HTTP_SSL_VERIFY</code>
       </td>
       <td>
-        Specifies whether the HTTPS connection should be verified.
+        Specifies whether the HTTPS connection with Consul should be mutually
+        verified. Will be automatically set to true if Nomad is configured to
+        verify TLS certificates.
       </td>
     </tr>
     <tr>
@@ -311,6 +318,8 @@
       </td>
       <td>
         Specifies the path to the CA certificate used for Consul communication.
+        Will be automatically set if Nomad is configured with the <code>consul.share_ssl</code>
+        option.
       </td>
     </tr>
     <tr>
@@ -318,7 +327,9 @@
         <code>CONSUL_CLIENT_CERT</code>
       </td>
       <td>
-        The client certificate to use when communicating with Consul.
+        Specifies the path to the Client certificate used for Consul communication.
+        Will be automatically set if Nomad is configured with the <code>consul.share_ssl</code>
+        option.
       </td>
     </tr>
     <tr>
@@ -326,7 +337,19 @@
         <code>CONSUL_CLIENT_KEY</code>
       </td>
       <td>
-        The client key to use when communicating with Consul.
+        Specifies the path to the CLient Key certificate used for Consul communication.
+        Will be automatically set if Nomad is configured with the <code>consul.share_ssl</code>
+        option.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>CONSUL_TLS_SERVER_NAME</code>
+      </td>
+      <td>
+        Specifies the server name to use as the SNI host for Consul communication.
+        Will be automatically set if Consul is configured to use TLS and the task
+        is in a group using bridge networking mode.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
This PR makes it so that Nomad will automatically set the CONSUL_TLS_SERVER_NAME
environment variable for Connect native tasks running in bridge networking mode
where Consul has TLS enabled. Because of the use of a unix domain socket for
communicating with Consul when in bridge networking mode, the server name is
a file name instead of something compatible with the mTLS certificate Consul
will authenticate against. "localhost" is by default a compatible name, so Nomad
will set the environment variable to that.

Fixes #10804