### PR TITLE
website: upgrade react-head

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2029,9 +2029,9 @@
       }
     },
     "@hashicorp/react-head": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.0.2.tgz",
-      "integrity": "sha512-kKY/5XwWkBsDSvF8jHgNnxG4hx8ryPjoEtPFxPMVCly/ouwbslilIrWzqSYbeP7vUO686JzBLf5xkwq+HV0aig=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.1.0.tgz",
+      "integrity": "sha512-tXfxi9Aqhx83p6wt753WfiYUhOEMzrsWKON200zsNFdwN2WkHPwArWbR6+ludVXleEmsBufL8GRYq7iqnnKKlQ=="
     },
     "@hashicorp/react-hero": {
       "version": "7.1.2",

--- a/website/package.json
+++ b/website/package.json
@@ -18,6 +18,7 @@
     "@hashicorp/react-docs-page": "13.2.0",
     "@hashicorp/react-featured-slider": "4.0.2",
     "@hashicorp/react-hashi-stack-menu": "2.0.3",
+    "@hashicorp/react-head": "3.1.0",
     "@hashicorp/react-hero": "7.1.2",
     "@hashicorp/react-image": "4.0.1",
     "@hashicorp/react-inline-svg": "6.0.1",


### PR DESCRIPTION
[Preview](https://nomad-fc1r8ov3a-hashicorp.vercel.app/)

Upgrading `react-head` and dependencies to set the new Safari theme-color feature.

[_Created by Sourcegraph campaign `kstraut/upgrade-react-head`._](https://sourcegraph.hashi-mktg.com/users/kstraut/campaigns/upgrade-react-head)

**After**
<img width="1258" alt="Screen Shot 2021-06-25 at 8 29 29 AM" src="https://user-images.githubusercontent.com/36613477/123448233-8b5b7b00-d58f-11eb-89d7-385edb71f935.png">

**Before**
<img width="1267" alt="Screen Shot 2021-06-25 at 8 29 43 AM" src="https://user-images.githubusercontent.com/36613477/123448243-8d253e80-d58f-11eb-892c-f20453985f9f.png">
