### PR TITLE
csi: fix CLI panic when formatting volume status with -verbose flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.1.3 (Unreleased)
 
+BUG FIXES:
+csi: fixed a CLI panic when formatting `volume status` with `-verbose` flag [[GH-10818](https://github.com/hashicorp/nomad/issues/10818)]
+
 ## 1.1.2 (June 22, 2021)
 
 IMPROVEMENTS:

--- a/command/volume_status_csi.go
+++ b/command/volume_status_csi.go
@@ -119,19 +119,17 @@ NEXT_PLUGIN:
 				// rather than an empty list
 				continue NEXT_PLUGIN
 			}
-			rows := []string{}
-			rows[0] = "External ID|Condition|Nodes"
-			for i, v := range externalList.Volumes {
+			rows := []string{"External ID|Condition|Nodes"}
+			for _, v := range externalList.Volumes {
 				condition := "OK"
 				if v.IsAbnormal {
 					condition = fmt.Sprintf("Abnormal (%v)", v.Status)
 				}
-
-				rows[i+1] = fmt.Sprintf("%s|%s|%s",
+				rows = append(rows, fmt.Sprintf("%s|%s|%s",
 					limit(v.ExternalID, c.length),
 					limit(condition, 20),
 					strings.Join(v.PublishedExternalNodeIDs, ","),
-				)
+				))
 			}
 			c.Ui.Output(formatList(rows))
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10816

When the `-verbose` flag is passed to the `nomad volume status` command, we
hit a code path where the rows of text to be formatted were not initialized
correctly, resulting in a panic in the CLI.

This bug was introduced in 1.1.0 so no backport is required.