### PR TITLE
Update csi_plugin.mdx

### DIFF
--- a/website/content/docs/job-specification/csi_plugin.mdx
+++ b/website/content/docs/job-specification/csi_plugin.mdx
@@ -96,10 +96,9 @@ job "plugin-efs" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-efs-csi-driver:latest"
+        image = "amazon/aws-efs-csi-driver:v.1.3.2"
 
         args = [
-          "node",
           "--endpoint=unix://csi/csi.sock",
           "--logtostderr",
           "--v=5",


### PR DESCRIPTION
Current efs driver does not support telling it if its a `node` or a `controller`, and it will not print any error it will just ignore all other parameters then:(
So this will result in endpoint being `/tmp/csi.sock` and not `/csi/csi.sock` which will in turn break nomad/csi integration.

Also I changed the latest image tag to v1.3.2 to make sure anybody copy pasting this example is sure that it will work.

Tested on nomad 1.1.2