### PR TITLE
docker: move host path for hosts file mount to alloc dir

### DIFF
--- a/.changelog/10823.txt
+++ b/.changelog/10823.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: Moved the generated `/etc/hosts` file's mount source to the allocation directory so that it can be shared between tasks of an allocation.
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.1.3 (Unreleased)
 
 BUG FIXES:
-csi: fixed a CLI panic when formatting `volume status` with `-verbose` flag [[GH-10818](https://github.com/hashicorp/nomad/issues/10818)]
+* csi: Fixed a CLI panic when formatting `volume status` with `-verbose` flag [[GH-10818](https://github.com/hashicorp/nomad/issues/10818)]
+* docker: Moved the generated `/etc/hosts` file's mount source to the allocation directory so that it can be shared between tasks of an allocation. [[GH-10823](https://github.com/hashicorp/nomad/issues/10823)]
 
 ## 1.1.2 (June 22, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## 1.1.3 (Unreleased)
 
 BUG FIXES:
-* csi: Fixed a CLI panic when formatting `volume status` with `-verbose` flag [[GH-10818](https://github.com/hashicorp/nomad/issues/10818)]
-* docker: Moved the generated `/etc/hosts` file's mount source to the allocation directory so that it can be shared between tasks of an allocation. [[GH-10823](https://github.com/hashicorp/nomad/issues/10823)]
+csi: fixed a CLI panic when formatting `volume status` with `-verbose` flag [[GH-10818](https://github.com/hashicorp/nomad/issues/10818)]
 
 ## 1.1.2 (June 22, 2021)
 

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -962,7 +962,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 	// that comes from the pause container
 	if task.NetworkIsolation != nil && driverConfig.NetworkMode == "" {
 		etcHostMount, err := hostnames.GenerateEtcHostsMount(
-			task.TaskDir().Dir, task.NetworkIsolation, driverConfig.ExtraHosts)
+			task.AllocDir, task.NetworkIsolation, driverConfig.ExtraHosts)
 		if err != nil {
 			return c, fmt.Errorf("failed to build mount for /etc/hosts: %v", err)
 		}

--- a/drivers/shared/hostnames/mount.go
+++ b/drivers/shared/hostnames/mount.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -56,9 +57,14 @@ ff02::3 ip6-allhosts
 	}
 
 	path := filepath.Join(taskDir, "hosts")
-	err := ioutil.WriteFile(path, []byte(content.String()), 0644)
-	if err != nil {
-		return nil, err
+
+	// tasks within an alloc should be able to share and modify the file, so
+	// only write to it if it doesn't exist
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		err := ioutil.WriteFile(path, []byte(content.String()), 0644)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Note that we're not setting readonly. The file is in the task dir

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -13,6 +13,16 @@ upgrade. However, specific versions of Nomad may have more details provided for
 their upgrades as a result of new features or changed behavior. This page is
 used to document those details separately from the standard upgrade flow.
 
+## Nomad 1.1.3
+
+#### Docker Driver
+
+Starting in Nomad 1.1.2, task groups with `network.mode = "bridge"` generated
+a hosts file in Docker containers. This generated hosts file was bind-mounted
+from the task directory to `/etc/hosts` within the task. In Nomad 1.1.3 the
+source for the bind mount was moved to the allocation directory so that it is
+shared between all tasks in an allocation.
+
 ## Nomad 1.1.0
 
 #### Enterprise licenses


### PR DESCRIPTION
Fixes #10809 

In Nomad 1.1.1 we generate a hosts file based on the Nomad-owned network
namespace, rather than using the default hosts file from the pause
container. This hosts file should be shared between tasks in the same
allocation so that tasks can update the file and have the results propagated
between tasks.