### PR TITLE
Specify restictions about edge proxies and Connect

### DIFF
--- a/website/content/docs/integrations/consul-connect.mdx
+++ b/website/content/docs/integrations/consul-connect.mdx
@@ -331,6 +331,9 @@ dashes (`-`) are converted to underscores (`_`) in environment variables so
 - Consul Connect using network namespaces is only supported on Linux.
 - Prior to Consul 1.9, the Envoy sidecar proxy will drop and stop accepting
   connections while the Nomad agent is restarting.
+- Currently, there are no edge proxy available that can route traffic to a
+  connect enabled service. This means that you cannot route traffic from
+  the internet to private connect services.
 
 [count-dashboard]: /img/count-dashboard.png
 [gh-9907]: https://github.com/hashicorp/nomad/issues/9907


### PR DESCRIPTION
Currently, there is no way to route internet traffic to Nomad tasks using Consul Connect (as far as I know)

This change adds a note about edge proxies to the "limitations" of the [Consul Connect in Nomad page](https://www.nomadproject.io/docs/integrations/consul-connect). It specifies that there are currently no options to route external traffic to Nomad tasks that are using Consul Connect.

The language used in my description was taken from the description of [this issue](https://github.com/traefik/traefik/pull/7407). It may be outdated, and I'd like to refer to those who are more familiar with Nomad to suggest how it might be re-worded.

**A few references:**

Hashicorp forum post: https://discuss.hashicorp.com/t/nomad-load-balancing-with-traefik-and-consul-connect-on-the-same-time/16787/3

Work in the Traefik repo on this: https://github.com/traefik/traefik/pull/7407

Once more options for routing internet traefik to Connect tasks become available, it would be good to edit this line to specify what proxies support this. It is still a very important limitation that people should know about right away, until the point that every standard proxy recommended by Nomad supports this feature.

If any of my assumptions here aren't true, feel free to point them out! This is just knowledge I've gained from looking for a solution to my problem.