### PR TITLE
docs: add missing backwards compat warning about port_map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -547,6 +547,7 @@ FEATURES:
 __BACKWARDS INCOMPATIBILITIES:__
  * driver/docker: The Docker driver no longer allows binding host volumes by default.
    Operators can set `volume` `enabled` plugin configuration to restore previous permissive behavior. [[GH-8261](https://github.com/hashicorp/nomad/issues/8261)]
+ * driver/docker: The Docker driver's `port_map` configuration is deprecated in lieu of the `ports` field.
  * driver/qemu: The Qemu driver requires images to reside in a operator-defined paths allowed for task access. [[GH-8261](https://github.com/hashicorp/nomad/issues/8261)]
 
 IMPROVEMENTS:

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -386,6 +386,9 @@ network configuration. If any usecase or feature which was available with task
 network resource is not fulfilled with group network configuration, please open
 an issue detailing the missing capability.
 
+Additionally, the `docker` driver's `port_map` configuration is deprecated in
+lieu of the `ports` field.
+
 ### Enterprise Licensing
 
 Enterprise binaries for Nomad are now publicly available via


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9710

The `docker` driver's `port_map` field was deprecated in 0.12 and this is
documented in the task driver's docs, but we never explicitly flagged it for
backwards compatibility.