### PR TITLE
docs: unset port `to` field maps to dynamic port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -561,6 +561,7 @@ IMPROVEMENTS:
 * build: Switched to Go modules for dependency management [[GH-8041](https://github.com/hashicorp/nomad/pull/8041)]
 * connect: Infer service task parameter where possible [[GH-8274](https://github.com/hashicorp/nomad/issues/8274)]
 * csi: Added `-force` flag to `nomad volume deregister` [[GH-8251](https://github.com/hashicorp/nomad/issues/8251)]
+* networking: Omitting the `port.to` field defaults to mapping to the same port as the dynamically assigned port. [[GH-8208](https://github.com/hashicorp/nomad/issues/8208)]
 * server: Added `raft_multiplier` config to tweak Raft related timeouts [[GH-8082](https://github.com/hashicorp/nomad/issues/8082)]
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -561,7 +561,7 @@ IMPROVEMENTS:
 * build: Switched to Go modules for dependency management [[GH-8041](https://github.com/hashicorp/nomad/pull/8041)]
 * connect: Infer service task parameter where possible [[GH-8274](https://github.com/hashicorp/nomad/issues/8274)]
 * csi: Added `-force` flag to `nomad volume deregister` [[GH-8251](https://github.com/hashicorp/nomad/issues/8251)]
-* networking: Omitting the `port.to` field defaults to mapping to the same port as the dynamically assigned port. [[GH-8208](https://github.com/hashicorp/nomad/issues/8208)]
+* networking: Omitting the `port.to` field defaults to mapping to the same port value as the dynamically assigned port. [[GH-8208](https://github.com/hashicorp/nomad/issues/8208)]
 * server: Added `raft_multiplier` config to tweak Raft related timeouts [[GH-8082](https://github.com/hashicorp/nomad/issues/8082)]
 
 BUG FIXES:

--- a/website/content/docs/job-specification/network.mdx
+++ b/website/content/docs/job-specification/network.mdx
@@ -72,9 +72,10 @@ job "docs" {
   dynamic port is chosen. We **do not recommend** using static ports, except
   for `system` or specialized jobs like load balancers.
 - `to` `(string:nil)` - Applicable when using "bridge" mode to configure port
-  to map to inside the task's network namespace. `-1` sets the mapped port equal to the
-  dynamic port allocated by the scheduler. The `NOMAD_PORT_<label>` environment variable
-  will contain the `to` value.
+  to map to inside the task's network namespace. Omitting this field or
+  setting it to `-1` sets the mapped port equal to the dynamic port allocated
+  by the scheduler. The `NOMAD_PORT_<label>` environment variable will contain
+  the `to` value.
 - `host_network` `(string:nil)` - Designates the host network name to use when allocating
   the port. When port mapping the host port will only forward traffic to the matched host
   network address.


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/6958 and https://github.com/hashicorp/nomad/issues/9456