### PR TITLE
[docs] Fix missing opening quote

### DIFF
--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -465,7 +465,7 @@ config {
 
 ```hcl
 config {
-  cap_add = ["net_raw", sys_time"]
+  cap_add = ["net_raw", "sys_time"]
 }
 ```
 


### PR DESCRIPTION
Fix missing quote in `cap_add` documentation code snippet.