### PR TITLE
CSI: Snapshot volume create should use vol.Secrets

### DIFF
--- a/.changelog/10840.txt
+++ b/.changelog/10840.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where volume secrets were not used for creating snapshots.
+```

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -1124,7 +1124,7 @@ func (v *CSIVolume) CreateSnapshot(args *structs.CSISnapshotCreateRequest, reply
 		cReq := &cstructs.ClientCSIControllerCreateSnapshotRequest{
 			ExternalSourceVolumeID: vol.ExternalID,
 			Name:                   snap.Name,
-			Secrets:                snap.Secrets,
+			Secrets:                vol.Secrets,
 			Parameters:             snap.Parameters,
 		}
 		cReq.PluginID = plugin.ID


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <ggriffiths@purestorage.com>

Fixes #10639 