### PR TITLE
constraint on Docker driver missing "attr"

### DIFF
--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -1062,7 +1062,7 @@ Here is an example of using these properties in a job file:
 job "docs" {
   # Require docker version higher than 1.2.
   constraint {
-    attribute = "${driver.docker.version}"
+    attribute = "${attr.driver.docker.version}"
     operator  = ">"
     version   = "1.2"
   }


### PR DESCRIPTION
Between this page and https://www.nomadproject.io/docs/runtime/interpolation
I realized that the syntax on the Docker page was missing the `attr`.