### PR TITLE
csi: account for nil volume/mount in API-to-structs conversion

### DIFF
--- a/.changelog/10855.txt
+++ b/.changelog/10855.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+volumes: Fix a bug where the HTTP server would crash if a `volume_mount` block was empty
+```


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10834

Fix a nil pointer in the API struct to `nomad/structs` conversion when a
`volume` or `volume_mount` block is empty.