### PR TITLE
consul: avoid extra sync operations when no action required

### DIFF
--- a/.changelog/10865.txt
+++ b/.changelog/10865.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul: avoid extra sync operations when no action required
+```

--- a/command/agent/consul/service_client_test.go
+++ b/command/agent/consul/service_client_test.go
@@ -1,6 +1,7 @@
 package consul
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -598,4 +599,28 @@ func TestSyncLogic_proxyUpstreamsDifferent(t *testing.T) {
 			upstream2(),
 		}
 	})
+}
+
+func TestSyncReason_String(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "periodic", fmt.Sprintf("%s", syncPeriodic))
+	require.Equal(t, "shutdown", fmt.Sprintf("%s", syncShutdown))
+	require.Equal(t, "operations", fmt.Sprintf("%s", syncNewOps))
+	require.Equal(t, "unexpected", fmt.Sprintf("%s", syncReason(128)))
+}
+
+func TestSyncOps_empty(t *testing.T) {
+	t.Parallel()
+
+	try := func(ops *operations, exp bool) {
+		require.Equal(t, exp, ops.empty())
+	}
+
+	try(&operations{regServices: make([]*api.AgentServiceRegistration, 1)}, false)
+	try(&operations{regChecks: make([]*api.AgentCheckRegistration, 1)}, false)
+	try(&operations{deregServices: make([]string, 1)}, false)
+	try(&operations{deregChecks: make([]string, 1)}, false)
+	try(&operations{}, true)
+	try(nil, true)
 }


### PR DESCRIPTION
This PR makes it so the Consul sync logic will ignore operations that
do not specify an action to take (i.e. [de-]register [services|checks]).

Ideally such noops would be discarded at the callsites (i.e. users
of [Create|Update|Remove]Workload], but we can also be defensive
at the commit point.

Also adds 2 trace logging statements which are helpful for diagnosing
sync operations with Consul - when they happen and why.

Fixes #10797