### PR TITLE
cni: respect default `cni_config_dir` and `cni_path`

### DIFF
--- a/.changelog/10870.txt
+++ b/.changelog/10870.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cni: Fixed a bug where fingerprinting of CNI configuration failed with default `cni_config_dir` and `cni_path`
+```

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -935,6 +935,8 @@ func DefaultConfig() *Config {
 				DisableSandbox:   false,
 			},
 			BindWildcardDefaultHostNetwork: true,
+			CNIPath:                        "/opt/cni/bin",
+			CNIConfigDir:                   "/opt/cni/config",
 		},
 		Server: &ServerConfig{
 			Enabled:           false,


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9028

The default agent configuration values were not set, which meant they were not
being set in the client configuration and this results in fingerprints failing
unless the values were set explicitly.