### PR TITLE
consul/connect: Avoid assumption of parent service when filtering connect proxies

### DIFF
--- a/.changelog/10872.txt
+++ b/.changelog/10872.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul/connect: Avoid assumption of parent service when syncing connect proxies
+```

--- a/command/agent/consul/group_test.go
+++ b/command/agent/consul/group_test.go
@@ -77,11 +77,6 @@ func TestConsul_Connect(t *testing.T) {
 		},
 	}
 
-	// required by isNomadSidecar assertion below
-	serviceRegMap := map[string]*consulapi.AgentServiceRegistration{
-		MakeAllocServiceID(alloc.ID, "group-"+alloc.TaskGroup, tg.Services[0]): nil,
-	}
-
 	require.NoError(t, serviceClient.RegisterWorkload(BuildAllocServices(mock.Node(), alloc, NoopRestarter())))
 
 	require.Eventually(t, func() bool {
@@ -102,7 +97,7 @@ func TestConsul_Connect(t *testing.T) {
 
 		require.Contains(t, services, serviceID)
 		require.True(t, isNomadService(serviceID))
-		require.False(t, isNomadSidecar(serviceID, serviceRegMap))
+		require.False(t, maybeConnectSidecar(serviceID))
 		agentService := services[serviceID]
 		require.Equal(t, agentService.Service, "testconnect")
 		require.Equal(t, agentService.Address, "10.0.0.1")
@@ -112,7 +107,7 @@ func TestConsul_Connect(t *testing.T) {
 
 		require.Contains(t, services, connectID)
 		require.True(t, isNomadService(connectID))
-		require.True(t, isNomadSidecar(connectID, serviceRegMap))
+		require.True(t, maybeConnectSidecar(connectID))
 		connectService := services[connectID]
 		require.Equal(t, connectService.Service, "testconnect-sidecar-proxy")
 		require.Equal(t, connectService.Address, "10.0.0.1")

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -1704,7 +1704,7 @@ func maybeConnectSidecar(id string) bool {
 }
 
 var (
-	sidecarProxyCheckRe = regexp.MustCompile(`service:_nomad-.+-sidecar-proxy(:[\d]+)?`)
+	sidecarProxyCheckRe = regexp.MustCompile(`^service:_nomad-.+-sidecar-proxy(:[\d]+)?$`)
 )
 
 // maybeSidecarProxyCheck returns true if the ID likely matches a Nomad generated

--- a/command/agent/consul/service_client_test.go
+++ b/command/agent/consul/service_client_test.go
@@ -624,3 +624,17 @@ func TestSyncOps_empty(t *testing.T) {
 	try(&operations{}, true)
 	try(nil, true)
 }
+
+func TestSyncLogic_maybeSidecarProxyCheck(t *testing.T) {
+	try := func(input string, exp bool) {
+		result := maybeSidecarProxyCheck(input)
+		require.Equal(t, exp, result)
+	}
+
+	try("service:_nomad-task-2f5fb517-57d4-44ee-7780-dc1cb6e103cd-group-api-count-api-9001-sidecar-proxy", true)
+	try("service:_nomad-task-2f5fb517-57d4-44ee-7780-dc1cb6e103cd-group-api-count-api-9001-sidecar-proxy:1", true)
+	try("service:_nomad-task-2f5fb517-57d4-44ee-7780-dc1cb6e103cd-group-api-count-api-9001-sidecar-proxy:2", true)
+	try("service:_nomad-task-2f5fb517-57d4-44ee-7780-dc1cb6e103cd-group-api-count-api-9001", false)
+	try("_nomad-task-2f5fb517-57d4-44ee-7780-dc1cb6e103cd-group-api-count-api-9001-sidecar-proxy:1", false)
+	try("service", false)
+}

--- a/command/agent/consul/service_client_test.go
+++ b/command/agent/consul/service_client_test.go
@@ -636,5 +636,7 @@ func TestSyncLogic_maybeSidecarProxyCheck(t *testing.T) {
 	try("service:_nomad-task-2f5fb517-57d4-44ee-7780-dc1cb6e103cd-group-api-count-api-9001-sidecar-proxy:2", true)
 	try("service:_nomad-task-2f5fb517-57d4-44ee-7780-dc1cb6e103cd-group-api-count-api-9001", false)
 	try("_nomad-task-2f5fb517-57d4-44ee-7780-dc1cb6e103cd-group-api-count-api-9001-sidecar-proxy:1", false)
+	try("service:_nomad-task-2f5fb517-57d4-44ee-7780-dc1cb6e103cd-group-api-count-api-9001-sidecar-proxy:X", false)
+	try("service:_nomad-task-2f5fb517-57d4-44ee-7780-dc1cb6e103cd-group-api-count-api-9001-sidecar-proxy: ", false)
 	try("service", false)
 }


### PR DESCRIPTION
This PR uses regex-based matching for sidecar proxy services and checks when syncing
with Consul. Previously we would check if the parent of the sidecar was still being
tracked in Nomad. This is a false invariant - one which we must not depend when we
make #10845 work.

Fixes #10843