### PR TITLE
consul/connect: remove sidecar proxy before removing parent service

### DIFF
--- a/.changelog/10873.txt
+++ b/.changelog/10873.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul/connect: Fixed a bug where service deregistered before connect sidecar
+```


### PR DESCRIPTION
This PR will have Nomad de-register a sidecar proxy service before
attempting to de-register the parent service. Otherwise, Consul will
emit a warning and an error.

Fixes #10845

