### PR TITLE
client: interpolate meta blocks with task environment

### DIFF
--- a/.changelog/10876.txt
+++ b/.changelog/10876.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed bug where meta blocks were not interpolated with task environment
+```

--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -546,9 +546,9 @@ func (b *Builder) buildEnv(allocDir, localDir, secretsDir string,
 		envMap[VaultNamespace] = b.vaultNamespace
 	}
 
-	// Copy task meta
+	// Copy and interpolate task meta
 	for k, v := range b.taskMeta {
-		envMap[k] = v
+		envMap[hargs.ReplaceEnv(k, nodeAttrs, envMap)] = hargs.ReplaceEnv(v, nodeAttrs, envMap)
 	}
 
 	// Interpolate and add environment variables

--- a/client/taskenv/env_test.go
+++ b/client/taskenv/env_test.go
@@ -291,6 +291,10 @@ func TestEnvironment_AllValues(t *testing.T) {
 		"b.":                "b",
 		".":                 "c",
 	}
+	task.Meta = map[string]string{
+		"taskMetaKey-${NOMAD_TASK_NAME}": "taskMetaVal-${node.unique.id}",
+		"foo":                            "bar",
+	}
 	env := NewBuilder(n, a, task, "global").SetDriverNetwork(
 		&drivers.DriverNetwork{PortMap: map[string]int{"https": 443}},
 	)
@@ -361,6 +365,7 @@ func TestEnvironment_AllValues(t *testing.T) {
 		"NOMAD_META_elb_check_type":                 "http",
 		"NOMAD_META_foo":                            "bar",
 		"NOMAD_META_owner":                          "armon",
+		"NOMAD_META_taskMetaKey_web":                "taskMetaVal-" + n.ID,
 		"NOMAD_JOB_ID":                              a.Job.ID,
 		"NOMAD_JOB_NAME":                            "my-job",
 		"NOMAD_JOB_PARENT_ID":                       a.Job.ParentID,
@@ -405,7 +410,8 @@ func TestEnvironment_AllValues(t *testing.T) {
 			out := ""
 			diag = gohcl.DecodeExpression(expr, evalCtx, &out)
 			require.Empty(t, diag)
-			require.Equal(t, out, expectedVal)
+			require.Equal(t, expectedVal, out,
+				fmt.Sprintf("expected %q got %q", expectedVal, out))
 		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/6506 so our [`meta`](https://www.nomadproject.io/docs/job-specification/meta#interpolation) docs are correct.

Adds missing interpolation step to the `meta` blocks when building the task
environment. Also fixes incorrect parameter order in the test assertion and
adds diagnostics to the test.