### PR TITLE
e2e: more -detach mode when registering jobs

### DIFF
--- a/e2e/e2eutil/job.go
+++ b/e2e/e2eutil/job.go
@@ -93,7 +93,7 @@ func JobInspectTemplate(jobID, template string) (string, error) {
 // The caller is responsible for recording that ID for later cleanup.
 func RegisterFromJobspec(jobID, jobspec string) error {
 
-	cmd := exec.Command("nomad", "job", "run", "-")
+	cmd := exec.Command("nomad", "job", "run", "-detach", "-")
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return fmt.Errorf("could not open stdin?: %w", err)


### PR DESCRIPTION
Pick up 15d39f0dee but for RegisterFromJobspec:

>  This PR changes the e2e helper thingy to set -detach option
>  when registering a job with the CLI instead of the API. This is
>  necessary for jobs which never become healthy, as the deployment
>  never finishes for failing jobs and the command never returns,
>  causing the test to timeout after 10 minutes.

This case occurs in TestVaultSecrets