### PR TITLE
Handle successful/canceled/blocked deployments in CLI output

### DIFF
--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -319,6 +319,9 @@ UPDATE:
 				c.ttyMonitor(client, rollback.ID, index, verbose)
 				return
 			} else {
+				endSpinner = glint.Layout(
+					glint.Text(fmt.Sprintf("! Deployment %q %s", limit(deployID, length), status)),
+				).Row().MarginLeft(2)
 				break UPDATE
 			}
 		case structs.DeploymentStatusSuccessful:

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -321,7 +321,15 @@ UPDATE:
 			} else {
 				break UPDATE
 			}
-		case structs.DeploymentStatusSuccessful, structs.DeploymentStatusCancelled, structs.DeploymentStatusDescriptionBlocked:
+		case structs.DeploymentStatusSuccessful:
+			endSpinner = glint.Layout(
+				glint.Text(fmt.Sprintf("✓ Deployment %q %s", limit(deployID, length), status)),
+			).Row().MarginLeft(2)
+			break UPDATE
+		case structs.DeploymentStatusCancelled, structs.DeploymentStatusDescriptionBlocked:
+			endSpinner = glint.Layout(
+				glint.Text(fmt.Sprintf("! Deployment %q %s", limit(deployID, length), status)),
+			).Row().MarginLeft(2)
 			break UPDATE
 		default:
 			q.WaitIndex = meta.LastIndex

--- a/website/content/docs/commands/deployment/status.mdx
+++ b/website/content/docs/commands/deployment/status.mdx
@@ -104,7 +104,7 @@ Monitor the status of a deployment that fails and has `auto_revert` set to `true
 ```shell-session
 $ nomad deployment status -monitor e45
 2021-06-09T15:49:19-07:00: Monitoring deployment "e45cc3c1"
-  ⠦ Deployment "e45cc3c1" failed
+  ! Deployment "e45cc3c1" failed
 
     2021-06-09T15:49:48-07:00
     ID          = e45cc3c1

--- a/website/content/docs/commands/job/run.mdx
+++ b/website/content/docs/commands/job/run.mdx
@@ -153,7 +153,7 @@ $ nomad job run -check-index 6 example.nomad
     2021-06-09T16:57:30-07:00: Evaluation status changed: "pending" -> "complete"
 ==> 2021-06-09T16:57:30-07:00: Evaluation "5ef16dff" finished with status "complete"
 ==> 2021-06-09T16:57:30-07:00: Monitoring deployment "62eb607c"
-  ⠙ Deployment "62eb607c" successful
+  ✓ Deployment "62eb607c" successful
     
     2021-06-09T16:57:30-07:00
     ID          = 62eb607c


### PR DESCRIPTION
This PR introduces a slightly different CLI output to handle successful/canceled/blocked deployments. Otherwise the spinner would just end, which felt a bit awkward.

## Before

```console
$ nomad job run example.nomad
...
  ⠙ Deployment "62eb607c" successful
...
```

## After

```console
$ nomad job run example.nomad
...
  ✓ Deployment "62eb607c" successful
...
```