### PR TITLE
ci: prepare unprivileged user for checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,6 +339,11 @@ jobs:
             echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep
             chown -R circleci:circleci /go
 
+            # configure git and ssh for the user
+            cp -r ~/.ssh /home/circleci/.ssh
+            chown -R circleci:circleci /home/circleci/.ssh
+            sudo -H -u circleci git config --global url."ssh://git@github.com".insteadOf "https://github.com"
+
       - run: sudo -E -H -u circleci PATH=${PATH} make deps
       - run: sudo -E -H -u circleci PATH=${PATH} make integration-test
       - run: sudo -E -H -u circleci PATH=${PATH} make e2e-test


### PR DESCRIPTION
Job `test-e2e` uses an unprivileged user to compile and run tests.
Ensure that the user has ssh and git properly configured to checkout
dependencies.