### PR TITLE
client: avoid acting on stale data after launch

### DIFF
--- a/.changelog/10907.txt
+++ b/.changelog/10907.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+client: Fixed a bug where a restarted client may start an already completed tasks in rare conditions
+```
+


### PR DESCRIPTION
When the client launches, use a consistent read to fetch its own allocs,
but allow stale read afterwards as long as reads don't revert into older
state.

This change addresses an edge case affecting restarting clients. When a
client restarts, it may fetch a stale data concerning its allocs: allocs
that have completed prior to the client shutdown may still have "run/running"
desired/client status, and have the client attempt to re-run again.

An alternative approach is to track the indices such that the client
set MinQueryIndex on the maximum index the client ever saw, or compare
received allocs against locally restored client state. Garbage
collection complicates this approach (local knowledge is not complete),
and the approach still risks starting "dead" allocations (e.g. the
allocation may have been placed when client just restarted and have
already been rescheduled by the time the client started. This approach
here is effective against all kinds of staleness problems with small
overhead.

Fixes #10901