### PR TITLE
fix `nomad alloc signal` help message

### DIFF
--- a/.changelog/10917.txt
+++ b/.changelog/10917.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed the help message for the `nomad alloc signal` command
+```

--- a/command/alloc_signal.go
+++ b/command/alloc_signal.go
@@ -15,7 +15,7 @@ type AllocSignalCommand struct {
 
 func (a *AllocSignalCommand) Help() string {
 	helpText := `
-Usage: nomad alloc signal [options] <signal> <allocation> <task>
+Usage: nomad alloc signal [options] <allocation> <task>
 
   signal an existing allocation. This command is used to signal a specific alloc
   and its subtasks. If no task is provided then all of the allocations subtasks
@@ -35,8 +35,8 @@ Signal Specific Options:
     Specify the signal that the selected tasks should receive.
 
   -task <task-name>
-	Specify the individual task that will receive the signal. If task name is given 
-	with both an argument and the '-task' option, preference is given to the '-task' 
+	Specify the individual task that will receive the signal. If task name is given
+	with both an argument and the '-task' option, preference is given to the '-task'
 	option.
 
   -verbose

--- a/command/alloc_signal.go
+++ b/command/alloc_signal.go
@@ -17,7 +17,7 @@ func (a *AllocSignalCommand) Help() string {
 	helpText := `
 Usage: nomad alloc signal [options] <allocation> <task>
 
-  signal an existing allocation. This command is used to signal a specific alloc
+  Signal an existing allocation. This command is used to signal a specific alloc
   and its subtasks. If no task is provided then all of the allocations subtasks
   will receive the signal.
 
@@ -32,7 +32,7 @@ General Options:
 Signal Specific Options:
 
   -s
-    Specify the signal that the selected tasks should receive.
+    Specify the signal that the selected tasks should receive. Defaults to SIGKILL.
 
   -task <task-name>
 	Specify the individual task that will receive the signal. If task name is given


### PR DESCRIPTION
The `nomad alloc signal` CLI command takes the signal input as a flag.