### PR TITLE
cli: Use glint to determine if os.Stdout is tty

### DIFF
--- a/.changelog/10926.txt
+++ b/.changelog/10926.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a panic when deployment monitor is invoked in some CI environments
+```

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -229,7 +229,6 @@ func (c *DeploymentStatusCommand) ttyMonitor(client *api.Client, deployID string
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	d.RenderFrame()
 	go d.Render(ctx)
 
 	q := api.QueryOptions{

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -182,13 +182,26 @@ func (c *DeploymentStatusCommand) Run(args []string) int {
 }
 
 func (c *DeploymentStatusCommand) monitor(client *api.Client, deployID string, index uint64, verbose bool) {
-	_, isStdoutTerminal := term.GetFdInfo(os.Stdout)
-	// TODO if/when glint offers full Windows support take out the runtime check
-	if isStdoutTerminal && runtime.GOOS != "windows" {
+	if isStdoutTerminal() {
 		c.ttyMonitor(client, deployID, index, verbose)
 	} else {
 		c.defaultMonitor(client, deployID, index, verbose)
 	}
+}
+
+func isStdoutTerminal() bool {
+	// TODO if/when glint offers full Windows support take out the runtime check
+	if runtime.GOOS == "windows" {
+		return false
+	}
+
+	// glint checks if the writer is a tty with additional
+	// checks (e.g. terminal has non-0 size)
+	r := &glint.TerminalRenderer{
+		Output: os.Stdout,
+	}
+
+	return r.LayoutRoot() != nil
 }
 
 // Uses glint for printing in place. Same logic as the defaultMonitor function
@@ -214,9 +227,10 @@ func (c *DeploymentStatusCommand) ttyMonitor(client *api.Client, deployID string
 	d.Set(spinner)
 
 	ctx, cancel := context.WithCancel(context.Background())
-
-	go d.Render(ctx)
 	defer cancel()
+
+	d.RenderFrame()
+	go d.Render(ctx)
 
 	q := api.QueryOptions{
 		AllowStale: true,

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/mitchellh/cli v1.1.0
 	github.com/mitchellh/colorstring v0.0.0-20150917214807-8631ce90f286
 	github.com/mitchellh/copystructure v1.0.0
-	github.com/mitchellh/go-glint v0.0.0-20201119015200-53f6eb3bf4d2
+	github.com/mitchellh/go-glint v0.0.0-20210722152315-6515ceb4a127
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b
 	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/mitchellh/hashstructure v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -540,8 +540,8 @@ github.com/mitchellh/colorstring v0.0.0-20150917214807-8631ce90f286 h1:KHyL+3mQO
 github.com/mitchellh/colorstring v0.0.0-20150917214807-8631ce90f286/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
-github.com/mitchellh/go-glint v0.0.0-20201119015200-53f6eb3bf4d2 h1:p6jvEJYVtY05cbttwUhvxzV1j/e/40musLqs18vkv+E=
-github.com/mitchellh/go-glint v0.0.0-20201119015200-53f6eb3bf4d2/go.mod h1:9X3rpO+I3yuihb6p8ktF8qWxROGwij9DBW/czUsMlhk=
+github.com/mitchellh/go-glint v0.0.0-20210722152315-6515ceb4a127 h1:/EdGXMUGYFdp0+cmGjVLl/Qbx3G10csqgj22ZkrPFEA=
+github.com/mitchellh/go-glint v0.0.0-20210722152315-6515ceb4a127/go.mod h1:9X3rpO+I3yuihb6p8ktF8qWxROGwij9DBW/czUsMlhk=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=


### PR DESCRIPTION
Use glint to determine if os.Stdout is a terminal.

glint Terminal renderer expects os.Stdout [not only to be a terminal, but also to have non-zero size](https://github.com/mitchellh/go-glint/blob/b492b545f6208fc979e7ee498d55599b8107e770/renderer_term.go#L39-L46). It's unclear how this condition arises, but this additional check causes Nomad to render deployments progress through glint when glint cannot support it.

By using golint to perform the check, we eliminate the risk of mis-judgement.

I opened https://github.com/mitchellh/go-glint/pull/4 to fix the panic upstream: https://github.com/mitchellh/go-glint/pull/4 . The upstream fix isn't sufficient for us, as it would just skip rendering deployments in this condition, instead of going the non-terminal rendering path in Nomad.

Fixes https://github.com/hashicorp/nomad/issues/10923