### PR TITLE
add assertion to rulesForName to prevent using namespaces without bound property

### DIFF
--- a/ui/app/abilities/abstract.js
+++ b/ui/app/abilities/abstract.js
@@ -1,4 +1,5 @@
 import { Ability } from 'ember-can';
+import { assert } from '@ember/debug';
 import { inject as service } from '@ember/service';
 import { computed, get } from '@ember/object';
 import { equal, not } from '@ember/object/computed';
@@ -14,10 +15,9 @@ export default class Abstract extends Ability {
 
   // Pass in a namespace to `can` or `cannot` calls to override
   // https://github.com/minutebase/ember-can#additional-attributes
-  namespace = 'default';
+  namespace = null;
 
   get _namespace() {
-    if (!this.namespace) return 'default';
     if (typeof this.namespace === 'string') return this.namespace;
     return get(this.namespace, 'name');
   }
@@ -26,6 +26,15 @@ export default class Abstract extends Ability {
   get rulesForNamespace() {
     let namespace = this._namespace;
 
+    // Assertion to prevent folks from not passing bound properties
+    if (namespace === null) {
+      assert(
+        'Must pass a bound property to handle cases for client token ACLs',
+        namespace === null
+      );
+      /* eslint-disable-next-line ember/no-side-effects */
+      this._namespace = null;
+    }
     return (this.get('token.selfTokenPolicies') || []).toArray().reduce((rules, policy) => {
       let policyNamespaces = get(policy, 'rulesJSON.Namespaces') || [];
 


### PR DESCRIPTION


Namespaces changed from being a global property to page-level. As a result, when we use ember-can
to check for permissions to do operations like scale-job we want to check if the namespace the
job is under has permissions to perform that action if we're using a client token. Its very easy to
forget to pass a bound property to ember-can and we can have a way to throw an error to prevent a
bug from being committed. Our best option is using an assert.