### PR TITLE
fix: load token in docker auth config

### DIFF
--- a/drivers/docker/utils.go
+++ b/drivers/docker/utils.go
@@ -125,6 +125,8 @@ func authFromDockerConfig(file string) authBackend {
 					Password:      dockerAuthConfig.Password,
 					Email:         dockerAuthConfig.Email,
 					ServerAddress: dockerAuthConfig.ServerAddress,
+					IdentityToken: dockerAuthConfig.IdentityToken,
+					RegistryToken: dockerAuthConfig.RegistryToken,
 				}
 				if authIsEmpty(auth) {
 					return nil, nil


### PR DESCRIPTION
Hi!

When evaluating Nomad on Azure I came across an authentication issue with our Azure Container Registry.
I looked at https://github.com/hashicorp/nomad/issues/10722  but I was not able to find a sustainable solution (other Azure authentication means could have worked, but I had not the opportunity to test)

After digging into the code, I found out that the IdentityToken from the docker.json auth config is simply not used and therefore not passed to docker, resulting in the authentication issue; I also added the RegistryToken, since it is missing as well.

I'm not sure AWS auth works the same, but it *may* explain why some solutions work but other not.

This is my first golang PR so please let me know if there is anything I'm not handling or could improve.

Thanks for your amazing work!