### PR TITLE
ui: fix job dispatch page when job doesn't have any meta fields

### DIFF
--- a/ui/app/components/job-dispatch.js
+++ b/ui/app/components/job-dispatch.js
@@ -47,7 +47,7 @@ export default class JobDispatch extends Component {
     super(...arguments);
 
     // Helper for mapping the params into a useable form.
-    const mapper = (values = [], required) =>
+    const mapper = (values, required) =>
       values.map(
         x =>
           new MetaField({
@@ -59,8 +59,8 @@ export default class JobDispatch extends Component {
       );
 
     // Fetch the different types of parameters.
-    const required = mapper(this.args.job.parameterizedDetails.MetaRequired, true);
-    const optional = mapper(this.args.job.parameterizedDetails.MetaOptional, false);
+    const required = mapper(this.args.job.parameterizedDetails.MetaRequired || [], true);
+    const optional = mapper(this.args.job.parameterizedDetails.MetaOptional || [], false);
 
     // Merge them, required before optional.
     this.metaFields = required.concat(optional);

--- a/ui/tests/acceptance/job-dispatch-test.js
+++ b/ui/tests/acceptance/job-dispatch-test.js
@@ -100,6 +100,20 @@ module('Acceptance | job dispatch', function(hooks) {
     });
   });
 
+  test('job without meta fields', async function(assert) {
+    const jobWithoutMeta = server.create('job', 'parameterized', {
+      status: 'running',
+      namespaceId: namespace.name,
+      parameterizedJob: {
+        MetaRequired: null,
+        MetaOptional: null,
+      },
+    });
+
+    await JobDispatch.visit({ id: jobWithoutMeta.id, namespace: namespace.name });
+    assert.ok(JobDispatch.dispatchButton.isPresent);
+  });
+
   test('payload text area is hidden when forbidden', async function(assert) {
     job.parameterizedJob.Payload = 'forbidden';
     job.save();

--- a/ui/tests/pages/jobs/dispatch.js
+++ b/ui/tests/pages/jobs/dispatch.js
@@ -18,6 +18,7 @@ export default create({
     scope: '[data-test-dispatch-button]',
     isDisabled: property('disabled'),
     click: clickable(),
+    isPresent: isPresent(),
   },
 
   hasError: isVisible('[data-test-dispatch-error]'),


### PR DESCRIPTION
When a job doesn't have any meta field declared, the API returns `null`. The previous logic would not cover this case.