### PR TITLE
Upgrade buf to 0.46.0 and fix boostrap typo

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -111,7 +111,7 @@ deps:  ## Install build and development dependencies
 	go install github.com/hashicorp/hcl/v2/cmd/hclfmt@v2.5.1
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.4
 	go install github.com/hashicorp/go-msgpack/codec/codecgen@v1.1.5
-	go install github.com/bufbuild/buf/cmd/buf@v0.36.0
+	go install github.com/bufbuild/buf/cmd/buf@v0.46.0
 	go install github.com/hashicorp/go-changelog/cmd/changelog-build@latest
 
 .PHONY: lint-deps
@@ -174,10 +174,10 @@ checkscripts: ## Lint shell scripts
 .PHONY: checkproto
 checkproto: ## Lint protobuf files
 	@echo "==> Lint proto files..."
-	@buf check lint --config tools/buf/buf.yaml
+	@buf lint --config tools/buf/buf.yaml
 
 	@echo "==> Checking for breaking changes in protos..."
-	@buf check breaking --config tools/buf/buf.yaml --against-config tools/buf/buf.yaml --against .git#tag=$(PROTO_COMPARE_TAG)
+	@buf breaking --config tools/buf/buf.yaml --against-config tools/buf/buf.yaml --against .git#tag=$(PROTO_COMPARE_TAG)
 
 .PHONY: generate-all
 generate-all: generate-structs proto generate-examples

--- a/client/allocrunner/taskrunner/envoy_bootstrap_hook.go
+++ b/client/allocrunner/taskrunner/envoy_bootstrap_hook.go
@@ -34,7 +34,7 @@ const (
 	// envoyBootstrapInitialGap is the initial amount of time the envoy bootstrap
 	// retry loop will wait, exponentially increasing each iteration, not including
 	// jitter.
-	envoyBoostrapInitialGap = 1 * time.Second
+	envoyBootstrapInitialGap = 1 * time.Second
 
 	// envoyBootstrapMaxJitter is the maximum amount of jitter applied to the
 	// wait gap each iteration of the envoy bootstrap retry loop.
@@ -124,7 +124,7 @@ type envoyBootstrapHook struct {
 	envoyBootstrapWaitTime time.Duration
 
 	// envoyBootstrapInitialGap is the initial wait gap when retyring
-	envoyBoostrapInitialGap time.Duration
+	envoyBootstrapInitialGap time.Duration
 
 	// envoyBootstrapMaxJitter is the maximum amount of jitter applied to retries
 	envoyBootstrapMaxJitter time.Duration
@@ -138,14 +138,14 @@ type envoyBootstrapHook struct {
 
 func newEnvoyBootstrapHook(c *envoyBootstrapHookConfig) *envoyBootstrapHook {
 	return &envoyBootstrapHook{
-		alloc:                   c.alloc,
-		consulConfig:            c.consul,
-		consulNamespace:         c.consulNamespace,
-		envoyBootstrapWaitTime:  envoyBootstrapWaitTime,
-		envoyBoostrapInitialGap: envoyBoostrapInitialGap,
-		envoyBootstrapMaxJitter: envoyBootstrapMaxJitter,
-		envoyBootstrapExpSleep:  time.Sleep,
-		logger:                  c.logger.Named(envoyBootstrapHookName),
+		alloc:                    c.alloc,
+		consulConfig:             c.consul,
+		consulNamespace:          c.consulNamespace,
+		envoyBootstrapWaitTime:   envoyBootstrapWaitTime,
+		envoyBootstrapInitialGap: envoyBootstrapInitialGap,
+		envoyBootstrapMaxJitter:  envoyBootstrapMaxJitter,
+		envoyBootstrapExpSleep:   time.Sleep,
+		logger:                   c.logger.Named(envoyBootstrapHookName),
 	}
 }
 
@@ -326,7 +326,7 @@ func (h *envoyBootstrapHook) Prestart(ctx context.Context, req *ifs.TaskPrestart
 		return true, cmdErr
 	}, exptime.BackoffOptions{
 		MaxSleepTime:   h.envoyBootstrapWaitTime,
-		InitialGapSize: h.envoyBoostrapInitialGap,
+		InitialGapSize: h.envoyBootstrapInitialGap,
 		MaxJitterSize:  h.envoyBootstrapMaxJitter,
 	}); backoffErr != nil {
 		// Wrap the last error from Consul and set that as our status.

--- a/client/allocrunner/taskrunner/envoy_bootstrap_hook_test.go
+++ b/client/allocrunner/taskrunner/envoy_bootstrap_hook_test.go
@@ -658,7 +658,7 @@ func TestTaskRunner_EnvoyBootstrapHook_RecoverableError(t *testing.T) {
 
 	// Lower the allowable wait time for testing
 	h.envoyBootstrapWaitTime = 1 * time.Second
-	h.envoyBoostrapInitialGap = 100 * time.Millisecond
+	h.envoyBootstrapInitialGap = 100 * time.Millisecond
 
 	req := &interfaces.TaskPrestartRequest{
 		Task:    sidecarTask,
@@ -741,7 +741,7 @@ func TestTaskRunner_EnvoyBootstrapHook_retryTimeout(t *testing.T) {
 
 	// Lower the allowable wait time for testing
 	h.envoyBootstrapWaitTime = 3 * time.Second
-	h.envoyBoostrapInitialGap = 1 * time.Second
+	h.envoyBootstrapInitialGap = 1 * time.Second
 	h.envoyBootstrapExpSleep = func(d time.Duration) {
 		iterations++
 		time.Sleep(d)

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -71,7 +71,7 @@ Compiling Protobufs
 ---
 If in the course of your development you change a Protobuf file (those ending in .proto), you'll need to recompile the protos.
 
-1. Run `make boostrap` to install the [`buf`](https://github.com/bufbuild/buf)
+1. Run `make bootstrap` to install the [`buf`](https://github.com/bufbuild/buf)
    command.
 1. Compile Protobufs
     ```sh

--- a/scripts/vagrant-linux-priv-buf.sh
+++ b/scripts/vagrant-linux-priv-buf.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 # Make sure you grab the latest version
-VERSION=0.36.0
+VERSION=0.46.0
 DOWNLOAD=https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-Linux-x86_64
 
 function install() {


### PR DESCRIPTION
This upgrades github.com/bufbuild/buf to 0.46.0, as 0.36.0 was many versions back, and replaces usages of deprecated `buf check {breaking,lint}` subcommands with `buf {breaking,lint}`.

This also fixes the typo "boostrap" throughout the codebase.