### PR TITLE
api: revert to defaulting to http/1

### DIFF
--- a/.changelog/10958.txt
+++ b/.changelog/10958.txt
@@ -1,0 +1,4 @@
+
+```release-note:bug
+api: Reverted to using http/1 to fix a 1.1.2 regression in `alloc exec` sessions
+```

--- a/api/api.go
+++ b/api/api.go
@@ -249,6 +249,10 @@ func defaultHttpClient() *http.Client {
 		MinVersion: tls.VersionTLS12,
 	}
 
+	// Default to http/1: alloc exec/websocket aren't supported in http/2
+	// well yet: https://github.com/gorilla/websocket/issues/417
+	transport.ForceAttemptHTTP2 = false
+
 	return httpClient
 }
 


### PR DESCRIPTION
PR #10778 incidentally changed the api http client to connect with
HTTP/2 first. However, the websocket libraries used in `alloc exec`
features don't handle http/2 well, and don't downgrade to http/1
gracefully.

Given that the switch is incidental, and not requested by users.
Furthermore, api consumers can opt-in to forcing http/2 by setting
custom http clients.

Fixes #10922