### PR TITLE
e2e: wait for allocs and deployments

### DIFF
--- a/e2e/nodedrain/nodedrain.go
+++ b/e2e/nodedrain/nodedrain.go
@@ -180,6 +180,8 @@ func (tc *NodeDrainE2ETest) TestNodeDrainIgnoreSystem(f *framework.F) {
 	f.NoError(e2e.Register(serviceJobID, "nodedrain/input/drain_simple.nomad"))
 	tc.jobIDs = append(tc.jobIDs, serviceJobID)
 
+	f.NoError(e2e.WaitForAllocStatusExpected(serviceJobID, ns, []string{"running"}))
+
 	allocs, err := e2e.AllocsForJob(serviceJobID, ns)
 	f.NoError(err, "could not get allocs for service job")
 	f.Len(allocs, 1, "could not get allocs for service job")

--- a/e2e/rescheduling/rescheduling.go
+++ b/e2e/rescheduling/rescheduling.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/nomad/e2e/framework"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/jobspec"
+	"github.com/hashicorp/nomad/testutil"
 )
 
 const ns = ""
@@ -435,6 +436,13 @@ func (tc *RescheduleE2ETest) TestRescheduleProgressDeadlineFail(f *framework.F) 
 	jobID := "test-reschedule-deadline-fail" + uuid.Generate()[0:8]
 	f.NoError(e2e.Register(jobID, "rescheduling/input/rescheduling_progressdeadline_fail.nomad"))
 	tc.jobIds = append(tc.jobIds, jobID)
+
+	testutil.WaitForResult(func() (bool, error) {
+		_, err := e2e.LastDeploymentID(jobID, ns)
+		return err == nil, err
+	}, func(err error) {
+		f.NoError(err, "deployment wasn't created yet")
+	})
 
 	deploymentID, err := e2e.LastDeploymentID(jobID, ns)
 	f.NoError(err, "couldn't look up deployment")


### PR DESCRIPTION
As we moved to using `-detach` for registering jobs, we should wait
until allocs and deployments are created before asserting their
properties.

Fixing `TestNodeDrainIgnoreSystem` and `TestRescheduleProgressDeadlineFail` tests as they seem particularly flaky, failing 9 and 7 times (respectively) in the last two weeks.