### PR TITLE
Add initial Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
   directory: "/ui"
   schedule:
     interval: daily
+- package-ecosystem: npm 
+  directory: "/website"
+  schedule:
+    interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+- package-ecosystem: npm 
+  directory: "/ui"
+  schedule:
+    interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+- package-ecosystem: gomod
+  directory: "/api"
+  schedule:
+    interval: daily
 - package-ecosystem: npm 
   directory: "/ui"
   schedule:


### PR DESCRIPTION
This PR adds a Dependabot configuration file to enable daily Go module and NPM scanning. More information on this feature can be found [here](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-version-updates).