### PR TITLE
bug:  migrating from classic to glimmer components

### DIFF
--- a/ui/app/components/job-page/abstract.js
+++ b/ui/app/components/job-page/abstract.js
@@ -1,9 +1,7 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
-import classic from 'ember-classic-decorator';
 
-@classic
 export default class Abstract extends Component {
   @service system;
 

--- a/ui/app/components/job-page/parts/summary.js
+++ b/ui/app/components/job-page/parts/summary.js
@@ -1,9 +1,7 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { computed } from '@ember/object';
 import { classNames } from '@ember-decorators/component';
-import classic from 'ember-classic-decorator';
 
-@classic
 @classNames('boxed-section')
 export default class Summary extends Component {
   job = null;

--- a/ui/app/components/job-page/service.js
+++ b/ui/app/components/job-page/service.js
@@ -1,5 +1,3 @@
 import AbstractJobPage from './abstract';
-import classic from 'ember-classic-decorator';
 
-@classic
 export default class Service extends AbstractJobPage {}


### PR DESCRIPTION
Migrating the abstract and service components in the job-page
view is causing the job page view to crash. This could be because
the job watchers and Watchers mixins isn't comptatabile with Glimmber
components. One alternative hypothesis is that setting job to null
in all of the job-page components.