### PR TITLE
API docs: Fix allocation restart example

### DIFF
--- a/website/content/api-docs/allocations.mdx
+++ b/website/content/api-docs/allocations.mdx
@@ -697,14 +697,14 @@ The table below shows this endpoint's support for
 
 ```json
 {
-  "Task": "FOO"
+  "TaskName": "FOO"
 }
 ```
 
 ### Sample Request
 
 ```shell-session
-$ curl -X POST -d '{"Task": "redis" }' \
+$ curl -X POST -d '{"TaskName": "redis" }' \
     https://localhost:4646/v1/client/allocation/5456bd7a-9fc0-c0dd-6131-cbee77f57577/restart
 ```
 


### PR DESCRIPTION
The published docs state that the json parameter to restart a specific task is `Task` when it's `TaskName`. If we follow the docs we get a 500 response.

Example with `Task`:
```
$ curl -v -X PUT -d '{"Task": "php"}' -s "localhost:4646/v1/client/allocation/$php_dev_alloc_id/restart"
*   Trying 127.0.0.1:4646...                         
* TCP_NODELAY set                                    
* Connected to localhost (127.0.0.1) port 4646 (#0)                                                                                                                                                                                    
> PUT /v1/client/allocation/86da5b90-16b4-47b4-2174-b9ff6806d030/restart HTTP/1.1
> Host: localhost:4646
> User-Agent: curl/7.68.0                          
> Accept: */*                                                                                                      
> Content-Length: 15  
> Content-Type: application/x-www-form-urlencoded
>            
* upload completely sent off: 15 out of 15 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 500 Internal Server Error
< Vary: Accept-Encoding         
< Vary: Origin         
< Date: Fri, 30 Jul 2021 14:28:52 GMT
< Content-Length: 50                 
< Content-Type: text/plain; charset=utf-8
< 
rpc error: 1 error occurred:                 
        * Task not running          

* Connection #0 to host localhost left intact
```
Example with `TaskName`:
```
$ curl -v -X PUT -d '{"TaskName": "php"}' -s "localhost:4646/v1/client/allocation/$php_dev_alloc_id/restart"
*   Trying 127.0.0.1:4646...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 4646 (#0)
> PUT /v1/client/allocation/86da5b90-16b4-47b4-2174-b9ff6806d030/restart HTTP/1.1
> Host: localhost:4646
> User-Agent: curl/7.68.0
> Accept: */*
> Content-Length: 19
> Content-Type: application/x-www-form-urlencoded
> 
* upload completely sent off: 19 out of 19 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json
< Vary: Accept-Encoding
< Vary: Origin
< Date: Fri, 30 Jul 2021 14:31:45 GMT
< Content-Length: 11
< 
* Connection #0 to host localhost left intact
{"Index":0}
```