### PR TITLE
Speed up client startup and registration

### DIFF
--- a/.changelog/11005.txt
+++ b/.changelog/11005.txt
@@ -1,0 +1,4 @@
+
+```release-note:improvement
+client: Speed up client startup time
+```


### PR DESCRIPTION
Speed up client startup, by retrying more until the servers are known.

Currently, if client fingerprinting is fast and finishes before the
client connect to a server, node registration may be delayed by 15
seconds or so!

Ideally, we'd wait until the client discovers the servers and then retry
immediately, but that requires significant code changes.

Here, we simply retry the node registration request every second. That's
basically the equivalent of check if the client discovered servers every
second. Should be a cheap operation.

When testing this change on my local computer and where both servers and
clients are co-located, the time from startup till node registration
dropped from 34 seconds to 8 seconds!