### PR TITLE
system: re-evaluate node on feasability changes

### DIFF
--- a/.changelog/11007.txt
+++ b/.changelog/11007.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+scheduler: Re-evaluate nodes for system jobs after attributes changes
+```

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -226,7 +226,7 @@ func shouldCreateNodeEval(original, updated *structs.Node) bool {
 		return true
 	}
 
-	// check fields used by the feasability checks in ../scheduler/feasible.go,
+	// check fields used by the feasibility checks in ../scheduler/feasible.go,
 	// whether through a Constraint explicitly added by user or an implicit constraint
 	// added through a driver/volume check.
 	//
@@ -251,7 +251,7 @@ func equalDevices(n1, n2 *structs.Node) bool {
 
 	// treat nil and empty value as equal
 	if len(n1.NodeResources.Devices) == 0 {
-		return len(n1.NodeResources.Devices) == len(n2.NodeResources.Devices) {
+		return len(n1.NodeResources.Devices) == len(n2.NodeResources.Devices)
 	}
 
 	return reflect.DeepEqual(n1.NodeResources.Devices, n2.NodeResources.Devices)

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -226,15 +226,35 @@ func shouldCreateNodeEval(original, updated *structs.Node) bool {
 		return true
 	}
 
-	// check fields used by the feasability checkers, through direct
-	// or interpolated constraints.
+	// check fields used by the feasability checks in ../scheduler/feasible.go,
+	// whether through a Constraint explicitly added by user or an implicit constraint
+	// added through a driver/volume check.
+	//
+	// Node Resources (e.g. CPU/Memory) are handled differently, using blocked evals,
+	// and not relevant in this check.
 	return !(original.ID == updated.ID &&
 		original.Datacenter == updated.Datacenter &&
 		original.Name == updated.Name &&
 		original.NodeClass == updated.NodeClass &&
 		reflect.DeepEqual(original.Attributes, updated.Attributes) &&
 		reflect.DeepEqual(original.Meta, updated.Meta) &&
-		reflect.DeepEqual(original.Drivers, updated.Drivers))
+		reflect.DeepEqual(original.Drivers, updated.Drivers) &&
+		reflect.DeepEqual(original.HostVolumes, updated.HostVolumes) &&
+		equalDevices(original, updated))
+}
+
+func equalDevices(n1, n2 *structs.Node) bool {
+	// ignore super old nodes, mostly to avoid nil dereferencing
+	if n1.NodeResources == nil || n2.NodeResources == nil {
+		return n1.NodeResources == n2.NodeResources
+	}
+
+	// treat nil and empty value as equal
+	if len(n1.NodeResources.Devices) == 0 {
+		return len(n1.NodeResources.Devices) == len(n2.NodeResources.Devices) {
+	}
+
+	return reflect.DeepEqual(n1.NodeResources.Devices, n2.NodeResources.Devices)
 }
 
 // updateNodeUpdateResponse assumes the n.srv.peerLock is held for reading.


### PR DESCRIPTION
Fix a bug where system jobs may fail to be placed on a node that
initially was not eligible for system job placement.

This changes causes the reschedule to re-evaluate the node if any
attribute used in feasability checks changes.

Fixes https://github.com/hashicorp/nomad/issues/8448