### PR TITLE
refactor reservedAmount to be calculated based on Allocation model

### DIFF
--- a/ui/app/components/primary-metric/allocation.js
+++ b/ui/app/components/primary-metric/allocation.js
@@ -47,8 +47,9 @@ export default class AllocationPrimaryMetric extends Component {
   }
 
   get reservedAmount() {
-    if (this.metric === 'cpu') return this.tracker.reservedCPU;
-    if (this.metric === 'memory') return this.tracker.reservedMemory;
+    const { cpu, memory } = this.allocation.allocatedResources;
+    if (this.metric === 'cpu') return cpu;
+    if (this.metric === 'memory') return memory;
     return null;
   }
 

--- a/ui/app/components/primary-metric/allocation.js
+++ b/ui/app/components/primary-metric/allocation.js
@@ -47,9 +47,8 @@ export default class AllocationPrimaryMetric extends Component {
   }
 
   get reservedAmount() {
-    const { cpu, memory } = this.allocation.allocatedResources;
-    if (this.metric === 'cpu') return cpu;
-    if (this.metric === 'memory') return memory;
+    if (this.metric === 'cpu') return this.tracker.reservedCPU;
+    if (this.metric === 'memory') return this.tracker.reservedMemory;
     return null;
   }
 

--- a/ui/app/components/primary-metric/task.js
+++ b/ui/app/components/primary-metric/task.js
@@ -29,7 +29,7 @@ export default class TaskPrimaryMetric extends Component {
   }
 
   get reservedAmount() {
-    const { cpu, memory } = this.args.taskState.allocation.allocatedResources;
+    const { cpu, memory } = this.args.taskState.resources;
     if (this.metric === 'cpu') return cpu;
     if (this.metric === 'memory') return memory;
     return null;

--- a/ui/app/components/primary-metric/task.js
+++ b/ui/app/components/primary-metric/task.js
@@ -29,10 +29,9 @@ export default class TaskPrimaryMetric extends Component {
   }
 
   get reservedAmount() {
-    if (!this.tracker) return null;
-    const task = this.tracker.tasks.findBy('task', this.taskState.name);
-    if (this.metric === 'cpu') return task.reservedCPU;
-    if (this.metric === 'memory') return task.reservedMemory;
+    const { cpu, memory } = this.args.taskState.allocation.allocatedResources;
+    if (this.metric === 'cpu') return cpu;
+    if (this.metric === 'memory') return memory;
     return null;
   }
 

--- a/ui/app/utils/classes/allocation-stats-tracker.js
+++ b/ui/app/utils/classes/allocation-stats-tracker.js
@@ -102,7 +102,7 @@ class AllocationStatsTracker extends EmberObject.extend(AbstractStatsTracker) {
   }
 
   // Static figures, denominators for stats
-  @alias('allocation.taskGroup.reservedCPU') reservedCPU;
+  @alias('allocation.allocatedResources.cpu') reservedCPU;
   @alias('allocation.taskGroup.reservedMemory') reservedMemory;
 
   // Dynamic figures, collected over time

--- a/ui/app/utils/classes/allocation-stats-tracker.js
+++ b/ui/app/utils/classes/allocation-stats-tracker.js
@@ -117,7 +117,7 @@ class AllocationStatsTracker extends EmberObject.extend(AbstractStatsTracker) {
     return RollingArray(this.bufferSize);
   }
 
-  @computed('allocation.taskGroup.tasks', 'bufferSize')
+  @computed('allocation.{states,taskGroup.tasks}', 'bufferSize')
   get tasks() {
     const bufferSize = this.bufferSize;
     const taskStates = this.get('allocation.states');

--- a/ui/app/utils/classes/allocation-stats-tracker.js
+++ b/ui/app/utils/classes/allocation-stats-tracker.js
@@ -120,16 +120,17 @@ class AllocationStatsTracker extends EmberObject.extend(AbstractStatsTracker) {
   @computed('allocation.{states,taskGroup.tasks}', 'bufferSize')
   get tasks() {
     const bufferSize = this.bufferSize;
-    const taskStates = this.get('allocation.states');
+    const taskStates = this.get('allocation.states') || [];
     const tasks = this.get('allocation.taskGroup.tasks') || [];
     return tasks
       .slice()
       .sort(taskPrioritySort)
       .map(task => {
-        const [resources] = taskStates
-          ?.filterBy('name', task.name)
-          ?.getEach('resources')
-          ?.toArray();
+        const [resources] =
+          taskStates
+            .filterBy('name', task.name)
+            .getEach('resources')
+            .toArray() ?? [];
         return {
           task: get(task, 'name'),
 

--- a/ui/app/utils/classes/allocation-stats-tracker.js
+++ b/ui/app/utils/classes/allocation-stats-tracker.js
@@ -127,15 +127,15 @@ class AllocationStatsTracker extends EmberObject.extend(AbstractStatsTracker) {
       .sort(taskPrioritySort)
       .map(task => {
         const [resources] = taskStates
-          .filterBy('name', task.name)
-          .getEach('resources')
-          .toArray();
+          ?.filterBy('name', task.name)
+          ?.getEach('resources')
+          ?.toArray();
         return {
           task: get(task, 'name'),
 
           // Static figures, denominators for stats
-          reservedCPU: resources.get('cpu'),
-          reservedMemory: resources.get('memory'),
+          reservedCPU: resources?.get('cpu') || 0,
+          reservedMemory: resources?.get('memory') || 0,
 
           // Dynamic figures, collected over time
           // []{ timestamp: Date, used: Number, percent: Number }

--- a/ui/mirage/factories/allocation.js
+++ b/ui/mirage/factories/allocation.js
@@ -199,7 +199,7 @@ export default Factory.extend({
       });
 
       allocation.update({
-        taskStateIds: allocation.clientStatus === 'pending' ? [] : states.mapBy('id'),
+        taskStateIds: states.mapBy('id'),
         taskResourceIds: resources.mapBy('id'),
       });
 

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -271,7 +271,9 @@ module('Acceptance | allocation detail', function(hooks) {
     await Allocation.stop.confirm();
 
     assert.equal(
-      server.pretender.handledRequests.reject(request => request.url.includes('fuzzy')).findBy('method', 'POST').url,
+      server.pretender.handledRequests
+        .reject(request => request.url.includes('fuzzy'))
+        .findBy('method', 'POST').url,
       `/v1/allocation/${allocation.id}/stop`,
       'Stop request is made for the allocation'
     );


### PR DESCRIPTION
Originally, we calculated RreservedAmount in the PrimaryMetric::Allocation component to be based
on the tracker service, however, this component is directly tied to the Allocation model and
gets the model passed in as a named argument in both places that its invoked, the Allocation Details page
and the Topology view. It should be safe to make this change and this does not break any existing tests.