### PR TITLE
docs: add backward incompat note about #10875

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.1.3 (July 29, 2021)
 
+__BACKWARDS INCOMPATIBILITIES:__
+
+* api: The Job Run and Plan APIs now use the `?namespace=` query parameter before the namespace from the job. This matches region's behavior. Users of `api.Client` should ensure their `Config.Namespace` is unset if they want to use the namespace in the job. [[GH-10875](https://github.com/hashicorp/nomad/issues/10875)]
+
 IMPROVEMENTS:
 
 * api: Added `NewSystemJob` helper function to create base system job object. [[GH-10861](https://github.com/hashicorp/nomad/issues/10861)]
@@ -171,6 +175,10 @@ BUG FIXES:
  * ui: Fixed the rendering of interstitial components shown after processing a dynamic application sizing recommendation. [[GH-10094](https://github.com/hashicorp/nomad/pull/10094)]
 
 ## 1.0.9 (July 29, 2021)
+
+__BACKWARDS INCOMPATIBILITIES:__
+
+* api: The Job Run and Plan APIs now use the `?namespace=` query parameter before the namespace from the job. This matches region's behavior. Users of `api.Client` should ensure their `Config.Namespace` is unset if they want to use the namespace in the job. [[GH-10875](https://github.com/hashicorp/nomad/issues/10875)]
 
 BUG FIXES:
 

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -13,13 +13,25 @@ upgrade. However, specific versions of Nomad may have more details provided for
 their upgrades as a result of new features or changed behavior. This page is
 used to document those details separately from the standard upgrade flow.
 
-## Nomad 1.1.3
+## Nomad 1.0.9 and 1.1.3
+
+#### Namespace in Job Run and Plan APIs
+
+The Job Run and Plan APIs now respect the `?namespace=...` query parameter over
+the namespace specified in the job itself. This matches the precedence of
+region and [fixes a bug where the `-namespace` flag was not respected for the
+`nomad run` and `nomad apply` commands.][gh-10875]
+
+For users of [`api.Client`][go-client] who want their job namespace respected,
+you must ensure the `Config.Namespace` field is unset.
 
 #### Docker Driver
 
-Starting in Nomad 1.1.2, task groups with `network.mode = "bridge"` generated
-a hosts file in Docker containers. This generated hosts file was bind-mounted
-from the task directory to `/etc/hosts` within the task. In Nomad 1.1.3 the
+**1.1.3 only**
+
+Starting in Nomad 1.1.2, task groups with `network.mode = "bridge"` generated a
+hosts file in Docker containers. This generated hosts file was bind-mounted
+from the task directory to `/etc/hosts` within the task.  In Nomad 1.1.3 the
 source for the bind mount was moved to the allocation directory so that it is
 shared between all tasks in an allocation.
 
@@ -1128,6 +1140,8 @@ deleted and then Nomad 0.3.0 can be launched.
 [gh-6787]: https://github.com/hashicorp/nomad/issues/6787
 [gh-8457]: https://github.com/hashicorp/nomad/issues/8457
 [gh-9148]: https://github.com/hashicorp/nomad/issues/9148
+[gh-10875]: https://github.com/hashicorp/nomad/pull/10875
+[go-client]: https://pkg.go.dev/github.com/hashicorp/nomad/api#Client
 [hcl2]: https://github.com/hashicorp/hcl2
 [limits]: /docs/configuration#limits
 [lxc]: /docs/drivers/external/lxc


### PR DESCRIPTION
Fixes #11002

Is this the best way to update the changelog for old releases? It's certainly easy enough and doesn't seem to conflict with the new `go-changelog` driven generation. Since we always link to tags for the changelog it seems moot to update it anyway, but maybe it will help someone.

Wording advice always eagerly accepted. I'll update https://github.com/hashicorp/nomad/releases/tag/v1.1.3 once this is merged.

Screenshot of the upgrade guide:
![image](https://user-images.githubusercontent.com/113362/128427860-f6288d63-6864-4fe1-b324-0ceef3d7aa11.png)
