### PR TITLE
make: embed the Nomad UI data by default

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,6 +14,11 @@ ifeq ($(CI),true)
 GO_TAGS := codegen_generated $(GO_TAGS)
 endif
 
+# Don't embed the Nomad UI when the NOMAD_NO_UI env var is set.
+ifndef NOMAD_NO_UI
+GO_TAGS := ui $(GO_TAGS)
+endif
+
 GO_TEST_CMD = $(if $(shell command -v gotestsum 2>/dev/null),gotestsum --,go test)
 
 ifeq ($(origin GOTEST_PKGS_EXCLUDE), undefined)


### PR DESCRIPTION
The Nomad UI is [compiled to binary data](https://raw.githubusercontent.com/hashicorp/nomad/main/command/agent/bindata_assetfs.go) that is conditionally loaded based on the `ui` Go build tag. Historically, the `make dev` command didn't include this tag, resulting in a `nomad` executable without the Nomad UI.

`make dev-ui` does include the Nomad UI, but it re-compiles the UI code and requires the entire UI dev stack to be installed, which is an additional burden when you are not actually changing UI code.

This PR changes the default behaviour of the makefile to always include the UI by default. The original behaviour can be achieved by setting the `NOMAD_NO_UI` environment variable before building. 