### PR TITLE
ui: only dipslay "Dispatch Job" button on parameterized jobs

### DIFF
--- a/.changelog/11019.txt
+++ b/.changelog/11019.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed a bug where the "Dispatch Job" button was displayed for non-parameterized jobs
+```

--- a/ui/app/templates/components/job-page/parts/children.hbs
+++ b/ui/app/templates/components/job-page/parts/children.hbs
@@ -1,21 +1,23 @@
 <div class="boxed-section-head">
   Job Launches
-  {{#if (can "dispatch job" namespace=this.job.namespace)}}
-    <LinkTo
-      data-test-dispatch-button
-      @route="jobs.job.dispatch"
-      class="button is-primary is-compact pull-right">
-      Dispatch Job
-    </LinkTo>
-  {{else}}
-    <button
-      data-test-dispatch-button
-      class="button is-disabled is-primary is-compact pull-right tooltip multiline"
-      aria-label="You don’t have permission to dispatch jobs"
-      disabled
-      type="button">
-      Dispatch Job
-    </button>
+  {{#if this.job.parameterized}}
+    {{#if (can "dispatch job" namespace=this.job.namespace)}}
+      <LinkTo
+        data-test-dispatch-button
+        @route="jobs.job.dispatch"
+        class="button is-primary is-compact pull-right">
+        Dispatch Job
+      </LinkTo>
+    {{else}}
+      <button
+        data-test-dispatch-button
+        class="button is-disabled is-primary is-compact pull-right tooltip multiline"
+        aria-label="You don’t have permission to dispatch jobs"
+        disabled
+        type="button">
+        Dispatch Job
+      </button>
+    {{/if}}
   {{/if}}
 </div>
 <div class="boxed-section-body {{if this.sortedChildren.length "is-full-bleed"}}">


### PR DESCRIPTION
The `Dispatch Job` button is only supported on parameterized jobs. Currently it is also being displayed in periodic jobs as well. Clicking the button in a non-parameterized job can cause the UI to crash.