### PR TITLE
ui: add missing pipe separator in parameterized and periodic jobs

### DIFF
--- a/.changelog/11020.txt
+++ b/.changelog/11020.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Add header separator between a child job priority and its parent
+```

--- a/ui/app/templates/components/job-page/parameterized-child.hbs
+++ b/ui/app/templates/components/job-page/parameterized-child.hbs
@@ -6,7 +6,7 @@
   <div class="boxed-section job-stats">
     <div class="boxed-section-body">
       <span data-test-job-stat="type"><strong>Type:</strong> {{this.job.type}} | </span>
-      <span data-test-job-stat="priority"><strong>Priority:</strong> {{this.job.priority}} </span>
+      <span data-test-job-stat="priority"><strong>Priority:</strong> {{this.job.priority}} |</span>
       <span data-test-job-stat="parent">
         <strong>Parent:</strong>
         <LinkTo @route="jobs.job" @model={{this.job.parent}} @query={{hash jobNamespace=this.job.parent.namespace.name}}>

--- a/ui/app/templates/components/job-page/periodic-child.hbs
+++ b/ui/app/templates/components/job-page/periodic-child.hbs
@@ -6,7 +6,7 @@
   <div class="boxed-section job-stats">
     <div class="boxed-section-body">
       <span data-test-job-stat="type"><strong>Type:</strong> {{this.job.type}} | </span>
-      <span data-test-job-stat="priority"><strong>Priority:</strong> {{this.job.priority}} </span>
+      <span data-test-job-stat="priority"><strong>Priority:</strong> {{this.job.priority}} |</span>
       <span data-test-job-stat="parent">
         <strong>Parent:</strong>
         <LinkTo @route="jobs.job" @model={{this.job.parent}} @query={{hash namespace=this.job.parent.namespace.name}}>


### PR DESCRIPTION
The detail page for a child job include a header section pointing back to its parent. This header has a missing `|` separator between the job priority and the parent link.

### Before
<img width="398" alt="Screen Shot 2021-08-09 at 6 22 51 PM" src="https://user-images.githubusercontent.com/775380/128782015-427f8135-d13e-4502-a93d-1045344aea37.png">

### After
<img width="384" alt="Screen Shot 2021-08-09 at 6 22 55 PM" src="https://user-images.githubusercontent.com/775380/128782019-92a36ff5-626b-4b4d-a6c3-c2ce322efeca.png">
