### PR TITLE
Add tools and plugins page to docs

### DIFF
--- a/website/content/docs/tools-and-plugins.mdx
+++ b/website/content/docs/tools-and-plugins.mdx
@@ -1,0 +1,30 @@
+---
+layout: docs
+page_title: Tools and Plugins
+description: Learn about tools that work with Nomad built by our community and HashiCorp.
+---
+
+# Nomad Tools and Plugins
+
+From this page you can download various tools for Nomad. These tools are maintained by HashiCorp and the Nomad Community.
+
+## HashiCorp Tools and Plugins
+
+These Nomad tools and plugins are created and managed by the dedicated engineers at HashiCorp:
+
+- [Autoscaler](https://github.com/hashicorp/nomad-autoscaler/) - HashiCorp's official Nomad Autoscaler. Supports scaling allocations within Nomad and scaling nodes on AWS, Azure, GCP, or arbitrary infrastructure via plugins.
+- [Damon](https://github.com/hashicorp/damon) - An terminal dashboard for Nomad.
+
+## Community Tools and Plugins
+
+These Nomad tools are created and managed by the amazing members of the Nomad community:
+
+- [Node Problem Detector](https://github.com/Roblox/nomad-node-problem-detector) - A tool used to detect problems on Nomad nodes based on user-defined health checks.
+- [Hashi Up](https://github.com/jsiebens/hashi-up) - A utility to install Nomad on remote Linux hosts.
+
+Thank you to jippi for compiling the great [awesome-nomad](https://github.com/jippi/awesome-nomad/) repository on GitHub, from which
+many of these tools were found.
+
+Are you the author of a tool and you would like to be featured on this page?
+The Nomad website is open source and is embedded inside the [Nomad repository](https://github.com/hashicorp/nomad) on GitHub.
+You can submit a Pull Request to add your tool or plugin to the list and we will gladly review it.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1759,6 +1759,10 @@
     "path": "who-uses-nomad"
   },
   {
+    "title": "Nomad Tools and Plugins",
+    "path": "tools-and-plugins"
+  },
+  {
     "title": "Nomad Enterprise",
     "routes": [
       {


### PR DESCRIPTION
This adds a "Tools and Plugins" page to the Nomad docs. This would be an official place to highlight community and HashiCorp-built tools/plugins/extensions to Nomad.

See [this issue](https://github.com/hashicorp/nomad/issues/11036).

This PR is currently incomplete as it will take me time to compile the full list. I figured I could get layout/wording/general feedback on this before compiling the list.

Are there other ways of categorizing this list that make sense? Should we split tools and plugins?

Screenshot of what this currently looks like:

![Screenshot 2021-08-11 at 11-05-00 Tools and Plugins Nomad by HashiCorp](https://user-images.githubusercontent.com/2732204/129080483-49e28e42-aab1-4c43-abf6-f53e84380ea9.png)

Also, anybody reading this should feel free to add their tools to the list!

@jippi, I added a link to awesome-nomad, as that has been the de facto spot for sharing Nomad tools. If you would rather we not link to that repo, please let me know. Thanks for providing a platform for the community!
