### PR TITLE
fingerprint: check if the CNI bridge plugin is available

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1236,9 +1236,16 @@ func TestClient_UpdateNodeFromFingerprintKeepsConfig(t *testing.T) {
 	})
 	require.Equal(t, int64(123), client.config.Node.NodeResources.Cpu.CpuShares)
 	// only the configured device is kept
-	require.Equal(t, 2, len(client.config.Node.NodeResources.Networks))
-	require.Equal(t, dev, client.config.Node.NodeResources.Networks[0].Device)
-	require.Equal(t, "bridge", client.config.Node.NodeResources.Networks[1].Mode)
+	if networks := client.config.Node.NodeResources.Networks; len(networks) == 2 {
+		// in Linux environments with CNI plugins present, we expect to see bridge network
+		require.Len(t, 2, networks)
+		require.Equal(t, dev, networks[0].Device)
+		require.Equal(t, "bridge", networks[1].Mode)
+	} else {
+		// otherwise, should only see the configured device
+		require.Len(t, 1, networks)
+		require.Equal(t, dev, networks[0].Device)
+	}
 
 	// Network speed is applied to all NetworkResources
 	client.config.NetworkInterface = ""

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1238,12 +1238,12 @@ func TestClient_UpdateNodeFromFingerprintKeepsConfig(t *testing.T) {
 	// only the configured device is kept
 	if networks := client.config.Node.NodeResources.Networks; len(networks) == 2 {
 		// in Linux environments with CNI plugins present, we expect to see bridge network
-		require.Len(t, 2, networks)
+		require.Len(t, networks, 2)
 		require.Equal(t, dev, networks[0].Device)
 		require.Equal(t, "bridge", networks[1].Mode)
 	} else {
 		// otherwise, should only see the configured device
-		require.Len(t, 1, networks)
+		require.Len(t, networks, 1)
 		require.Equal(t, dev, networks[0].Device)
 	}
 
@@ -1261,10 +1261,11 @@ func TestClient_UpdateNodeFromFingerprintKeepsConfig(t *testing.T) {
 			CPU: 80,
 		},
 	})
-	assert.Equal(t, 3, len(client.config.Node.NodeResources.Networks))
-	assert.Equal(t, "any-interface", client.config.Node.NodeResources.Networks[2].Device)
-	assert.Equal(t, 100, client.config.Node.NodeResources.Networks[2].MBits)
-	assert.Equal(t, 0, client.config.Node.NodeResources.Networks[1].MBits)
+	networks := client.config.Node.NodeResources.Networks
+	require.NotEmpty(t, networks)
+	anyIfNet := networks[len(networks)-1]
+	assert.Equal(t, "any-interface", anyIfNet.Device)
+	assert.Equal(t, 100, anyIfNet.MBits)
 }
 
 // Support multiple IP addresses (ipv4 vs. 6, e.g.) on the configured network interface

--- a/client/fingerprint/bridge_linux.go
+++ b/client/fingerprint/bridge_linux.go
@@ -59,11 +59,11 @@ func (f *BridgeFingerprint) detectCNIBinaries(cniPath string) error {
 
 	var errs error
 
-	// plugins required by in client/allocrunner/networking_bridge_linux.go
-	plugins := []string{"bridge", "firewall", "portmap"}
+	// plugins required by in client/allocrunner/networking_bridge_linux.go.
+	plugins := []string{"bridge", "firewall", "portmap", "host-local"}
 	for _, plugin := range plugins {
 		if err := f.checkCNIPluginBinary(cniPath, plugin); err != nil {
-			err = multierror.Append(errs, err)
+			errs = multierror.Append(errs, err)
 		}
 	}
 

--- a/client/fingerprint/bridge_linux_test.go
+++ b/client/fingerprint/bridge_linux_test.go
@@ -14,9 +14,9 @@ import (
 
 func TestBridgeFingerprint_detect(t *testing.T) {
 	f := &BridgeFingerprint{logger: testlog.HCLogger(t)}
-	require.NoError(t, f.detect("ip_tables"))
+	require.NoError(t, f.detectKernelModule("ip_tables"))
 
-	err := f.detect("nonexistentmodule")
+	err := f.detectKernelModule("nonexistentmodule")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "3 errors occurred")
 }


### PR DESCRIPTION
A client should declare the "bridge" network fingerprint only if the
bridge CNI plugin is available.

Currently, Linux clients with the bridge kernel module enabled (pretty
much all Linux boxes with Docker installed) declare "bridge" network,
but allocs requiring it will fail with `failed to find plugin "bridge"
in path [/opt/cni/bin]` error.

Related to https://github.com/hashicorp/nomad/pull/11034 