### PR TITLE
docs: Remove note on ingress gateway hosts field needing a port number

### DIFF
--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -132,13 +132,6 @@ envoy_gateway_bind_addresses "<service>" {
   hosts are valid DNS records. For example, `*.example.com` is valid while `example.*`
   and `*-suffix.example.com` are not.
 
-  ~> **Note:** If a well-known port is not used, i.e. a port other than 80 (http) or 443 (https),
-  then the port must be appended to the host to correctly match traffic. This is
-  defined in the [HTTP/1.1 RFC](https://tools.ietf.org/html/rfc2616#section-14.23).
-  If TLS is enabled, then the host **without** the port must be added to the `hosts`
-  field as well. TLS verification only matches against the hostname of the incoming
-  connection, and does not take into account the port.
-
 ### `terminating` Parameters
 
 - `service` <code>(array<[linked-service]>: required)</code> - One or more services to be


### PR DESCRIPTION
Update the ingress gateway documentation to remove the note stating that a port must be specified for values in the `hosts` field when the ingress gateway is listening on a non-standard HTTP port.

Specifying a port was required in Consul 1.8.0, but that requirement was removed in 1.8.1 with hashicorp/consul#8190 which made Consul include the port number when constructing the Envoy configuration.

Related Consul docs PR: hashicorp/consul#10827