### PR TITLE
e2e: Run system jobs on all datacenters

### DIFF
--- a/e2e/scheduler_sysbatch/input/sysbatch_dispatch.nomad
+++ b/e2e/scheduler_sysbatch/input/sysbatch_dispatch.nomad
@@ -1,5 +1,5 @@
 job "sysbatchjob" {
-  datacenters = ["dc1"]
+  datacenters = ["dc1", "dc2"]
 
   type = "sysbatch"
 

--- a/e2e/scheduler_sysbatch/input/sysbatch_job_fast.nomad
+++ b/e2e/scheduler_sysbatch/input/sysbatch_job_fast.nomad
@@ -1,5 +1,5 @@
 job "sysbatchjob" {
-  datacenters = ["dc1"]
+  datacenters = ["dc1", "dc2"]
 
   type = "sysbatch"
 

--- a/e2e/scheduler_sysbatch/input/sysbatch_job_slow.nomad
+++ b/e2e/scheduler_sysbatch/input/sysbatch_job_slow.nomad
@@ -1,5 +1,5 @@
 job "sysbatchjob" {
-  datacenters = ["dc1"]
+  datacenters = ["dc1", "dc2"]
 
   type = "sysbatch"
 

--- a/e2e/scheduler_sysbatch/input/sysbatch_periodic.nomad
+++ b/e2e/scheduler_sysbatch/input/sysbatch_periodic.nomad
@@ -1,5 +1,5 @@
 job "sysbatchjob" {
-  datacenters = ["dc1"]
+  datacenters = ["dc1", "dc2"]
 
   type = "sysbatch"
 

--- a/e2e/scheduler_system/input/system_job0.nomad
+++ b/e2e/scheduler_system/input/system_job0.nomad
@@ -1,5 +1,5 @@
 job "system_job" {
-  datacenters = ["dc1"]
+  datacenters = ["dc1", "dc2"]
 
   type = "system"
 

--- a/e2e/scheduler_system/input/system_job1.nomad
+++ b/e2e/scheduler_system/input/system_job1.nomad
@@ -1,5 +1,5 @@
 job "system_job" {
-  datacenters = ["dc1"]
+  datacenters = ["dc1", "dc2"]
 
   type = "system"
 


### PR DESCRIPTION
Target all e2e datacenters for system and sysbatch e2e tests.  They
require that the system jobs run on all linux clients.

However, the jobs currenly only target `dc1` datacenter, but the nightly
e2e cluster has 4 clients spread in `dc1` and `dc2` datacenters, causing
the tests to fail.

I missed this problem in e2e dev cluster because it only used a single
dc1 datacenter.