### PR TITLE
Deflake tests attempts

### DIFF
--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -113,16 +113,8 @@ func TestLeader_LeftLeader(t *testing.T) {
 	}
 
 	// Kill the leader!
-	var leader *Server
-	for _, s := range servers {
-		if s.IsLeader() {
-			leader = s
-			break
-		}
-	}
-	if leader == nil {
-		t.Fatalf("Should have a leader")
-	}
+	leader := waitForStableLeadership(t, servers)
+
 	leader.Leave()
 	leader.Shutdown()
 


### PR DESCRIPTION
Best reviewed commit-by-commit.

Attempt to deflake TestLeader_LeftLeader and TestAutopilot_CleanupDeadServer , mostly by validating leadership transition, and waiting if necessary.  Look at individual commit messages for info.

Also, update the assertion failures so we can get more meaningful errors and the like.