### PR TITLE
Don't timestamp active log file

### DIFF
--- a/.changelog/11070.txt
+++ b/.changelog/11070.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Don't timestamp active log file.
+```

--- a/command/agent/log_file_test.go
+++ b/command/agent/log_file_test.go
@@ -55,6 +55,8 @@ func TestLogFile_openNew(t *testing.T) {
 
 	_, err = ioutil.ReadFile(logFile.FileInfo.Name())
 	require.NoError(err)
+
+	require.Equal(logFile.FileInfo.Name(), filepath.Join(tempDir, testFileName))
 }
 
 func TestLogFile_byteRotation(t *testing.T) {

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -241,9 +241,9 @@ testing.
 - `log_json` `(bool: false)` - Output logs in a JSON format.
 
 - `log_file` `(string: "")` - Specifies the path for logging. If the path
-  does not includes a filename, the filename defaults to "nomad-{timestamp}.log".
-  This setting can be combined with `log_rotate_bytes` and `log_rotate_duration`
-  for a fine-grained log rotation control.
+  does not includes a filename, the filename defaults to `nomad.log`. This
+  setting can be combined with `log_rotate_bytes` and `log_rotate_duration` for
+  a fine-grained log rotation control.
 
 - `log_rotate_bytes` `(int: 0)` - Specifies the number of bytes that should be
   written to a log before it needs to be rotated. Unless specified, there is no

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -13,6 +13,15 @@ upgrade. However, specific versions of Nomad may have more details provided for
 their upgrades as a result of new features or changed behavior. This page is
 used to document those details separately from the standard upgrade flow.
 
+## Nomad 1.1.4 and 1.2.0
+
+#### Log file names
+
+The [`log_file`] configuration option was not being fully respected, as the
+generated filename would include a timestamp. After upgrade, the active log
+file will always be the value defined in `log_file`, with timestamped files
+being created during log rotation.
+
 ## Nomad 1.0.9 and 1.1.3
 
 #### Namespace in Job Run and Plan APIs
@@ -1173,3 +1182,4 @@ deleted and then Nomad 0.3.0 can be launched.
 [allow_caps_java]: /docs/drivers/java#allow_caps
 [cap_add_exec]: /docs/drivers/exec#cap_add
 [cap_drop_exec]: /docs/drivers/exec#cap_drop
+[`log_file`]: /docs/configuration#log_file


### PR DESCRIPTION
The `log_file` configuration option allows setting the log file name to use. In practice, however, this value was being used as a filename prefix with a timestamp appended.

This PR changes the log file creation logic to always use the value set in `log_file` as the active log file name.

Closes #11061 #9582 