### PR TITLE
Update `scaling` and `policy` blocks documentation

### DIFF
--- a/website/content/docs/autoscaling/policy.mdx
+++ b/website/content/docs/autoscaling/policy.mdx
@@ -62,7 +62,8 @@ horizontal application scaling or horizontal cluster scaling.
 - `strategy` - The strategy to use, and it's configuration when calculating the
   desired state based on the current count and the metric returned by the APM.
   Detailed information on the configuration options can be found on the
-  [Strategy Plugins][strategy_plugin_docs] page.
+  [Strategy Plugins][strategy_plugin_docs] page. Strategies for
+  [Dynamic Application Sizing][das] are not allowed in this case.
 
 ### Example in a Job
 
@@ -192,7 +193,8 @@ currently supports `cpu` and `mem` labels, examples of which can be seen below.
 - `strategy` - The strategy to use, and it's configuration when calculating the
   desired state based on the current value and the available historic data. Detailed
   information on the configuration options can be found on the
-  [Strategy Plugins][strategy_plugin_docs] page.
+  [Strategy Plugins][strategy_plugin_docs] page. Only [Dynamic Application Sizing][das]
+  strategies are allowed.
 
 ### Example
 
@@ -219,6 +221,7 @@ scaling "mem" {
 }
 ```
 
+[das]: /docs/autoscaling#dynamic-application-sizing
 [policy_default_cooldown_agent]: /docs/autoscaling/agent#default_cooldown
 [eval_interval_agent]: /docs/autoscaling/agent#default_evaluation_interval
 [target_plugin_docs]: /docs/autoscaling/plugins/target

--- a/website/content/docs/job-specification/scaling.mdx
+++ b/website/content/docs/job-specification/scaling.mdx
@@ -6,27 +6,81 @@ description: The "scaling" stanza allows specifying scaling policy for a task gr
 
 # `scaling` Stanza
 
-<Placement groups={['job', 'group']} />
+<Placement
+  groups={[
+    ['job', 'group'],
+    ['job', 'group', 'task'],
+  ]}
+/>
 
-The `scaling` stanza allows configuring scaling options for a task group, for the purpose
-of supporting external autoscalers like the [Nomad Autoscaler](https://github.com/hashicorp/nomad-autoscaler)
-and scaling via the Nomad UI. This stanza is not supported within jobs of type `system`.
+The `scaling` block allows configuring scaling options for a `task` or a
+`group`, for the purpose of supporting external autoscalers like the
+[Nomad Autoscaler](https://github.com/hashicorp/nomad-autoscaler) and scaling
+via the Nomad UI. This stanza is not supported within jobs of type `system`.
+
+When placed at the `group` level, the scaling policy will be of type
+[horizontal application scaling][horizontal_app_scaling], controlling the value
+of [`count`][] for the group.
 
 ```hcl
 job "example" {
   datacenters = ["dc1"]
+
   group "cache" {
-    task "redis" {
-      driver = "docker"
-      config {
-        image = "redis:3.2"
-      }
-    }
+    count = 1
+
     scaling {
       enabled = true
       min = 0
       max = 10
+
       policy {
+        # ...
+      }
+    }
+    # ...
+  }
+}
+```
+
+When placed at the `task` level, the scaling policy will be of type
+[Dynamic Application Sizing][das], controlling the [`resources`][] values of
+the task. In this scenario, the `scaling` block must have a label indicating
+which resource will be controlled. Valid names are `cpu` and `mem`.
+
+```hcl
+job "example" {
+  datacenters = ["dc1"]
+
+  group "cache" {
+    task "redis" {
+      driver = "docker"
+
+      config {
+        image = "redis:3.2"
+      }
+
+      resources {
+        cpu = 100
+        memory = 256
+      }
+
+      scaling "cpu" {
+        enabled = true
+        min = 100
+        max = 500
+        policy {
+          # ...
+        }
+      }
+
+      scaling "mem" {
+        enabled = true
+        min = 100
+        max = 500
+        policy {
+          # ...
+        }
       }
     }
   }
@@ -37,7 +91,7 @@ job "example" {
 
 - `min` - <code>(int: nil)</code> - The minimum acceptable count for the task group.
   This should be honored by the external autoscaler. It will also be honored by Nomad
-  during job updates and scaling operations. Defaults to the specified task group [count][].
+  during job updates and scaling operations. Defaults to the specified task group [`count`][].
 
 - `max` - <code>(int: &lt;required&gt;)</code> - The maximum acceptable count for the task group.
   This should be honored by the external autoscaler. It will also be honored by Nomad
@@ -49,6 +103,11 @@ job "example" {
 
 - `policy` - <code>(map<string|...>: nil)</code> - The autoscaling policy. This is
   opaque to Nomad, consumed and parsed only by the external autoscaler. Therefore,
-  its contents are specific to the autoscaler; see autoscaler documentation.
+  its contents are specific to the autoscaler; consult the
+  [Nomad Autoscaler documentation][autoscaling_policy] for more details.
 
-[count]: /docs/job-specification/group#count 'Nomad Task Group specification'
+[autoscaling_policy]: /docs/autoscaling/policy
+[`count`]: /docs/job-specification/group#count 'Nomad Task Group specification'
+[`resources`]: /docs/job-specification/task#resources 'Nomad Task specification'
+[das]: /docs/autoscaling#dynamic-application-sizing
+[horizontal_app_scaling]: /docs/autoscaling#horizontal-application-autoscaling

--- a/website/content/docs/job-specification/scaling.mdx
+++ b/website/content/docs/job-specification/scaling.mdx
@@ -31,8 +31,8 @@ job "example" {
 
     scaling {
       enabled = true
-      min = 0
-      max = 10
+      min     = 0
+      max     = 10
 
       policy {
         # ...
@@ -61,14 +61,15 @@ job "example" {
       }
 
       resources {
-        cpu = 100
+        cpu    = 100
         memory = 256
       }
 
       scaling "cpu" {
         enabled = true
-        min = 100
-        max = 500
+        min     = 100
+        max     = 500
+
         policy {
           # ...
         }
@@ -76,8 +77,9 @@ job "example" {
 
       scaling "mem" {
         enabled = true
-        min = 100
-        max = 500
+        min     = 64
+        max     = 512
+
         policy {
           # ...
         }


### PR DESCRIPTION
The documentation for the `scaling` and `policy` blocks were not clear on how they are used for Dynamic Application Sizing.