### PR TITLE
Document Docker `extra_hosts` behaviour post v1.1.3

### DIFF
--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -112,7 +112,7 @@ config {
 
 - `extra_hosts` - (Optional) A list of hosts, given as host:IP, to be added to
   `/etc/hosts`. This option may not work as expected in `bridge` network mode
-  when there are more than one task within the same group. Refer to the
+  when there is more than one task within the same group. Refer to the
   [upgrade guide][upgrade_guide_extra_hosts] for more information.
 
 - `force_pull` - (Optional) `true` or `false` (default). Always pull most recent image

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -111,7 +111,9 @@ config {
 - `entrypoint` - (Optional) A string list overriding the image's entrypoint.
 
 - `extra_hosts` - (Optional) A list of hosts, given as host:IP, to be added to
-  `/etc/hosts`.
+  `/etc/hosts`. This option may not work as expected in `bridge` network mode
+  when there are more than one task within the same group. Refer to the
+  [upgrade guide][upgrade_guide_extra_hosts] for more information.
 
 - `force_pull` - (Optional) `true` or `false` (default). Always pull most recent image
   instead of using existing local image. Should be set to `true` if repository tags
@@ -1149,6 +1151,7 @@ Windows is relatively new and rapidly evolving you may want to consult the
 [cap_add]: /docs/drivers/docker#cap_add
 [cap_drop]: /docs/drivers/docker#cap_drop
 [no_net_raw]: /docs/upgrade/upgrade-specific#nomad-1-1-0-rc1-1-0-5-0-12-12
+[upgrade_guide_extra_hosts]: /docs/upgrade/upgrade-specific#docker-driver
 [docker_caps]: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
 [allow_caps]: /docs/drivers/docker#allow_caps
 [Connect]: /docs/job-specification/connect

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -44,6 +44,11 @@ from the task directory to `/etc/hosts` within the task.  In Nomad 1.1.3 the
 source for the bind mount was moved to the allocation directory so that it is
 shared between all tasks in an allocation.
 
+Please note that this change may prevent [`extra_hosts`] values from being
+properly set in each task when there are multiple tasks within the same group.
+When using `extra_hosts` with Consul Connect in `bridge` network mode, you
+should set the hosts values in the [`sidecar_task.config`] block instead.
+
 ## Nomad 1.1.0
 
 #### Enterprise licenses
@@ -1160,6 +1165,7 @@ deleted and then Nomad 0.3.0 can be launched.
 [preemption-api]: /api-docs/operator#update-scheduler-configuration
 [preemption]: /docs/internals/scheduling/preemption
 [proxy_concurrency]: /docs/job-specification/sidecar_task#proxy_concurrency
+[`sidecar_task.config`]: /docs/job-specification/sidecar_task#config
 [reserved]: /docs/configuration/client#reserved-parameters
 [task-config]: /docs/job-specification/task#config
 [tls-guide]: https://learn.hashicorp.com/tutorials/nomad/security-enable-tls
@@ -1177,6 +1183,7 @@ deleted and then Nomad 0.3.0 can be launched.
 [`CAP_NET_RAW`]: https://security.stackexchange.com/a/128988
 [`linux capabilities`]: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
 [`allow_caps`]: /docs/drivers/docker#allow_caps
+[`extra_hosts`]: /docs/drivers/docker#extra_hosts
 [no_net_raw]: /docs/upgrade/upgrade-specific#nomad-1-1-0-rc1-1-0-5-0-12-12
 [allow_caps_exec]: /docs/drivers/exec#allow_caps
 [allow_caps_java]: /docs/drivers/java#allow_caps


### PR DESCRIPTION
#11056 highlighted an issue with using `extra_hosts` with Consul Connect in Nomad v1.1.3 that was introduced by #10823.

This PR documents this new behaviour and provides a workaround for using `sidecar_task.config` instead to set the desired `extra_hosts`.

Preview:

Docker driver docs
<img width="924" alt="image" src="https://user-images.githubusercontent.com/775380/130664931-2b689056-1931-4aa4-b078-4a411d75bc13.png">

Nomad 1.0.9 and 1.1.3 upgrade docs:
<img width="962" alt="image" src="https://user-images.githubusercontent.com/775380/130665102-eff43335-72da-4a84-b98a-0f3b209a204d.png">
