### PR TITLE
Support mTLS clusters for e2e testing

### DIFF
--- a/e2e/terraform/.terraform.lock.hcl
+++ b/e2e/terraform/.terraform.lock.hcl
@@ -2,21 +2,20 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.37.0"
+  version = "3.55.0"
   hashes = [
-    "h1:RvLGIfRZfbzY58wUja9B6CvGdgVVINy7zLVBdLqIelA=",
-    "h1:Tf6Os+utUxE8rEr/emCXLFEDdCb0Y6rsN4Ee84+aDCQ=",
-    "zh:064c9b21bcd69be7a8631ccb3eccb8690c6a9955051145920803ef6ce6fc06bf",
-    "zh:277dd05750187a41282cf6e066e882eac0dd0056e3211d125f94bf62c19c4b8b",
-    "zh:47050211f72dcbf3d99c82147abd2eefbb7238efb94d5188979f60de66c8a3df",
-    "zh:4a4e0d070399a050847545721dae925c192a2d6354802fdfbea73769077acca5",
-    "zh:4cbc46f79239c85d69389f9e91ca9a9ebf6a8a937cfada026c5a037fd09130fb",
-    "zh:6548dcb1ac4a388ed46034a5317fa74b3b0b0f68eec03393f2d4d09342683f95",
-    "zh:75b4a82596aa525d95b0b2847fe648368c6e2b054059c4dc4dcdee01d374b592",
-    "zh:75cf5cc674b61c82300667a82650f56722618b119ab0526b47b5ecbb4bbf49d0",
-    "zh:93c896682359039960c38eb5a4b29d1cc06422f228db0572b90330427e2a21ec",
-    "zh:c7256663aedbc9de121316b6d0623551386a476fc12b8eb77e88532ce15de354",
-    "zh:e995c32f49c23b5938200386e08b2a3fd69cf5102b5299366c0608bbeac68429",
+    "h1:Ls8MD4Olzybw9n0mP5Lr1S2PnZzlSKrpxvYN9u2p/dM=",
+    "zh:1795562df65e9e5a604c90fac17ab1a706bc398b38271a11bc43565d45532595",
+    "zh:266fd71ace988b5fecd72dae5f2f503e953a4d2ea51d8d490d22d1218b1407dc",
+    "zh:4b2daf1038352fb33df40a2bf9033f66383bb1f6509df70da08f86f4539df9f3",
+    "zh:59fa40d453baa15cee845fd62d8c807fc4d5204a5560ee7e54ebeef3a3143404",
+    "zh:5ad9f515354c654d53849d1193ee56e335b3b9cf8e8cbfa98479114e87089cc3",
+    "zh:69c3ebd945ce747e0b30315656bc8b4aec2f2486013c2a78d04890bff96d137d",
+    "zh:6bdb22a77b4d85b6d9f2403bce23d6c3c932dadd7c7541395cbbd51ec101842e",
+    "zh:7d5ba001be98432d6a1d385679a720cf0d6e6c0b1ee7d45384d2d6213e262b21",
+    "zh:ce4b85f470605c5cd24f8acfe05c6546d962a32ecf69a61034f0884c2e79fbcf",
+    "zh:d0b20e4e9e877279520162b7979e9cb8aa961cf06fb37d9f3e4ac7023c177545",
+    "zh:e029951f18e9dadd8929dddc752a5b354a4c9956b8ec1b67f4db7bc641199d22",
   ]
 }
 
@@ -24,7 +23,6 @@ provider "registry.terraform.io/hashicorp/external" {
   version = "2.1.0"
   hashes = [
     "h1:LTl5CGW8wiIEe16AC4MtXN/95xWWNDbap70zJsBTk0w=",
-    "h1:wbtDfLeawmv6xVT1W0w0fctRCb4ABlaD3JTxwb1jXag=",
     "zh:0d83ffb72fbd08986378204a7373d8c43b127049096eaf2765bfdd6b00ad9853",
     "zh:7577d6edc67b1e8c2cf62fe6501192df1231d74125d90e51d570d586d95269c5",
     "zh:9c669ded5d5affa4b2544952c4b6588dfed55260147d24ced02dca3a2829f328",
@@ -60,7 +58,6 @@ provider "registry.terraform.io/hashicorp/http" {
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.1.0"
   hashes = [
-    "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
     "h1:KfieWtVyGWwplSoLIB5usKAUnrIkDQBkWaR5TI+4WYg=",
     "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
     "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
@@ -79,7 +76,6 @@ provider "registry.terraform.io/hashicorp/local" {
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.1.0"
   hashes = [
-    "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
     "h1:xhbHC6in3nQryvTQBWKxebi3inG5OCgHgc4fRxL0ymc=",
     "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
     "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
@@ -98,7 +94,6 @@ provider "registry.terraform.io/hashicorp/null" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.1.0"
   hashes = [
-    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
     "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
@@ -118,7 +113,6 @@ provider "registry.terraform.io/hashicorp/template" {
   version = "2.2.0"
   hashes = [
     "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
-    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
     "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
     "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
     "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
@@ -136,7 +130,6 @@ provider "registry.terraform.io/hashicorp/tls" {
   version = "3.1.0"
   hashes = [
     "h1:XTU9f6sGMZHOT8r/+LWCz2BZOPH127FBTPjMMEAAu1U=",
-    "h1:fUJX8Zxx38e2kBln+zWr1Tl41X+OuiE++REjrEyiOM4=",
     "zh:3d46616b41fea215566f4a957b6d3a1aa43f1f75c26776d72a98bdba79439db6",
     "zh:623a203817a6dafa86f1b4141b645159e07ec418c82fe40acd4d2a27543cbaa2",
     "zh:668217e78b210a6572e7b0ecb4134a6781cc4d738f4f5d09eb756085b082592e",

--- a/e2e/terraform/config/dev-cluster/consul/base.json
+++ b/e2e/terraform/config/dev-cluster/consul/base.json
@@ -8,6 +8,8 @@
     "enabled": true
   },
   "ports": {
+    "http": -1,
+    "https": 8501,
     "grpc": 8502
   }
 }

--- a/e2e/terraform/config/shared/consul-tls.json
+++ b/e2e/terraform/config/shared/consul-tls.json
@@ -1,0 +1,8 @@
+{
+    "verify_incoming": true,
+    "verify_outgoing": true,
+    "verify_server_hostname": true,
+    "ca_file": "/etc/consul.d/tls/ca.crt",
+    "cert_file": "/etc/consul.d/tls/agent.crt",
+    "key_file": "/etc/consul.d/tls/agent.key"
+}

--- a/e2e/terraform/config/shared/nomad-tls.hcl
+++ b/e2e/terraform/config/shared/nomad-tls.hcl
@@ -1,0 +1,20 @@
+tls {
+  http = true
+  rpc  = true
+
+  ca_file   = "/etc/nomad.d/tls/ca.crt"
+  cert_file = "/etc/nomad.d/tls/agent.crt"
+  key_file  = "/etc/nomad.d/tls/agent.key"
+
+  verify_server_hostname = true
+  verify_https_client    = true
+}
+
+consul {
+  address = "127.0.0.1:8501"
+  ssl     = true
+
+  ca_file   = "/etc/nomad.d/tls/ca.crt"
+  cert_file = "/etc/nomad.d/tls/agent.crt"
+  key_file  = "/etc/nomad.d/tls/agent.key"
+}

--- a/e2e/terraform/config/shared/vault-tls.hcl
+++ b/e2e/terraform/config/shared/vault-tls.hcl
@@ -1,0 +1,26 @@
+listener "tcp" {
+  address = "0.0.0.0:8200"
+
+  tls_disable                        = false
+  tls_require_and_verify_client_cert = true
+
+  tls_client_ca_file = "/etc/vault.d/tls/ca.crt"
+  tls_cert_file      = "/etc/vault.d/tls/agent.crt"
+  tls_key_file       = "/etc/vault.d/tls/agent.key"
+}
+
+# this autounseal key is created by Terraform in the E2E infrastructure repo
+# and should be used only for these tests
+seal "awskms" {
+  region     = "us-east-1"
+  kms_key_id = "74b7e226-c745-4ddd-9b7f-2371024ee37d"
+}
+
+storage "consul" {
+  address = "127.0.0.1:8501"
+  scheme  = "https"
+
+  tls_ca_file   = "/etc/vault.d/tls/ca.crt"
+  tls_cert_file = "/etc/vault.d/tls/agent.crt"
+  tls_key_file  = "/etc/vault.d/tls/agent.key"
+}

--- a/e2e/terraform/network.tf
+++ b/e2e/terraform/network.tf
@@ -45,7 +45,7 @@ resource "aws_security_group" "primary" {
   # Consul
   ingress {
     from_port   = 8500
-    to_port     = 8500
+    to_port     = 8501
     protocol    = "tcp"
     cidr_blocks = [local.ingress_cidr]
   }

--- a/e2e/terraform/network.tf
+++ b/e2e/terraform/network.tf
@@ -42,7 +42,7 @@ resource "aws_security_group" "primary" {
     cidr_blocks = [local.ingress_cidr]
   }
 
-  # Consul
+  # Consul: 8500 for HTTP, 8501 for HTTPS
   ingress {
     from_port   = 8500
     to_port     = 8501

--- a/e2e/terraform/nomad.tf
+++ b/e2e/terraform/nomad.tf
@@ -26,10 +26,15 @@ module "nomad_server" {
   nomad_acls       = var.nomad_acls
   cluster_name     = local.random_name
 
+  tls         = var.tls
+  tls_ca_key  = tls_private_key.ca.private_key_pem
+  tls_ca_cert = tls_self_signed_cert.ca.cert_pem
+
+  instance = aws_instance.server[count.index]
+
   connection = {
     type        = "ssh"
     user        = "ubuntu"
-    host        = aws_instance.server[count.index].public_ip
     port        = 22
     private_key = "${path.root}/keys/${local.random_name}.pem"
   }
@@ -64,10 +69,15 @@ module "nomad_client_ubuntu_bionic_amd64" {
   nomad_acls       = false
   cluster_name     = local.random_name
 
+  tls         = var.tls
+  tls_ca_key  = tls_private_key.ca.private_key_pem
+  tls_ca_cert = tls_self_signed_cert.ca.cert_pem
+
+  instance        = aws_instance.client_ubuntu_bionic_amd64[count.index]
+
   connection = {
     type        = "ssh"
     user        = "ubuntu"
-    host        = aws_instance.client_ubuntu_bionic_amd64[count.index].public_ip
     port        = 22
     private_key = "${path.root}/keys/${local.random_name}.pem"
   }
@@ -105,10 +115,15 @@ module "nomad_client_windows_2016_amd64" {
   cluster_name     = local.random_name
 
 
+  tls         = var.tls
+  tls_ca_key  = tls_private_key.ca.private_key_pem
+  tls_ca_cert = tls_self_signed_cert.ca.cert_pem
+
+  instance        = aws_instance.client_windows_2016_amd64[count.index]
+
   connection = {
     type        = "ssh"
     user        = "Administrator"
-    host        = aws_instance.client_windows_2016_amd64[count.index].public_ip
     port        = 22
     private_key = "${path.root}/keys/${local.random_name}.pem"
   }

--- a/e2e/terraform/nomad.tf
+++ b/e2e/terraform/nomad.tf
@@ -73,7 +73,7 @@ module "nomad_client_ubuntu_bionic_amd64" {
   tls_ca_key  = tls_private_key.ca.private_key_pem
   tls_ca_cert = tls_self_signed_cert.ca.cert_pem
 
-  instance        = aws_instance.client_ubuntu_bionic_amd64[count.index]
+  instance = aws_instance.client_ubuntu_bionic_amd64[count.index]
 
   connection = {
     type        = "ssh"
@@ -119,7 +119,7 @@ module "nomad_client_windows_2016_amd64" {
   tls_ca_key  = tls_private_key.ca.private_key_pem
   tls_ca_cert = tls_self_signed_cert.ca.cert_pem
 
-  instance        = aws_instance.client_windows_2016_amd64[count.index]
+  instance = aws_instance.client_windows_2016_amd64[count.index]
 
   connection = {
     type        = "ssh"

--- a/e2e/terraform/outputs.tf
+++ b/e2e/terraform/outputs.tf
@@ -41,9 +41,28 @@ EOM
 output "environment" {
   description = "get connection config by running: $(terraform output environment)"
   value       = <<EOM
+%{ if var.tls }
+export NOMAD_ADDR=https://${aws_instance.server[0].public_ip}:4646
+export CONSUL_HTTP_ADDR=https://${aws_instance.server[0].public_ip}:8501
+export VAULT_ADDR=https://${aws_instance.server[0].public_ip}:8200
+
+export NOMAD_CACERT=${path.root}/keys/tls_ca.crt
+export CONSUL_CACERT=${path.root}/keys/tls_ca.crt
+export VAULT_CACERT=${path.root}/keys/tls_ca.crt
+
+export NOMAD_CLIENT_CERT=${path.root}/keys/tls_api_client.crt
+export CONSUL_CLIENT_CERT=${path.root}/keys/tls_api_client.crt
+export VAULT_CLIENT_CERT=${path.root}/keys/tls_api_client.crt
+
+export NOMAD_CLIENT_KEY=${path.root}/keys/tls_api_client.key
+export CONSUL_CLIENT_KEY=${path.root}/keys/tls_api_client.key
+export VAULT_CLIENT_KEY=${path.root}/keys/tls_api_client.key
+%{ else }
 export NOMAD_ADDR=http://${aws_instance.server[0].public_ip}:4646
 export CONSUL_HTTP_ADDR=http://${aws_instance.server[0].public_ip}:8500
 export VAULT_ADDR=http://${aws_instance.server[0].public_ip}:8200
+%{ endif }
+
 export NOMAD_E2E=1
 export NOMAD_TOKEN=${data.local_file.nomad_token.content}
 export VAULT_TOKEN=${data.local_file.vault_token.content}

--- a/e2e/terraform/outputs.tf
+++ b/e2e/terraform/outputs.tf
@@ -41,7 +41,7 @@ EOM
 output "environment" {
   description = "get connection config by running: $(terraform output environment)"
   value       = <<EOM
-%{ if var.tls }
+%{if var.tls}
 export NOMAD_ADDR=https://${aws_instance.server[0].public_ip}:4646
 export CONSUL_HTTP_ADDR=https://${aws_instance.server[0].public_ip}:8501
 export VAULT_ADDR=https://${aws_instance.server[0].public_ip}:8200
@@ -57,11 +57,11 @@ export VAULT_CLIENT_CERT=${path.root}/keys/tls_api_client.crt
 export NOMAD_CLIENT_KEY=${path.root}/keys/tls_api_client.key
 export CONSUL_CLIENT_KEY=${path.root}/keys/tls_api_client.key
 export VAULT_CLIENT_KEY=${path.root}/keys/tls_api_client.key
-%{ else }
+%{else}
 export NOMAD_ADDR=http://${aws_instance.server[0].public_ip}:4646
 export CONSUL_HTTP_ADDR=http://${aws_instance.server[0].public_ip}:8500
 export VAULT_ADDR=http://${aws_instance.server[0].public_ip}:8200
-%{ endif }
+%{endif}
 
 export NOMAD_E2E=1
 export NOMAD_TOKEN=${data.local_file.nomad_token.content}

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/provision.sh
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/provision.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 set -o nounset
-set +x
+set -x
 
 usage() {
     cat <<EOF
@@ -22,6 +22,9 @@ Options for configuration:
  --nomad_license            set the NOMAD_LICENSE environment variable
  --nomad_acls               write Nomad ACL configuration
  --autojoin                 the AWS ConsulAutoJoin tag value
+ --tls
+ --cert FILEPATH
+ --key FILEPATH
 
 EOF
 
@@ -42,6 +45,7 @@ BUILD_FOLDER="builds-oss"
 CONSUL_AUTOJOIN=
 ACLS=0
 NOMAD_LICENSE=
+TLS=0
 
 install_from_s3() {
     # check that we don't already have this version
@@ -135,6 +139,16 @@ install_config_profile() {
     if [ $ACLS == "1" ]; then
         sudo ln -fs /opt/config/shared/nomad-acl.hcl /etc/nomad.d/acl.hcl
     fi
+
+    if [ $TLS == "1" ]; then
+        sudo ln -fs /opt/config/shared/nomad-tls.hcl /etc/nomad.d/tls.hcl
+        sudo ln -fs /opt/config/shared/consul-tls.json /etc/consul.d/tls.json
+        sudo cp /opt/config/shared/vault-tls.hcl /etc/vault.d/vault.hcl
+
+        sudo cp -r /tmp/nomad-tls /etc/nomad.d/tls
+        sudo cp -r /tmp/nomad-tls /etc/consul.d/tls
+        sudo cp -r /tmp/nomad-tls /etc/vault.d/tls
+    fi
 }
 
 update_consul_autojoin() {
@@ -205,6 +219,10 @@ opt="$1"
             ;;
         --nomad_acls)
             ACLS=1
+            shift
+            ;;
+        --tls)
+            TLS=1
             shift
             ;;
         *) usage ;;

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/provision.sh
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/provision.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 set -o nounset
-set -x
+set +x
 
 usage() {
     cat <<EOF

--- a/e2e/terraform/provision-nomad/main.tf
+++ b/e2e/terraform/provision-nomad/main.tf
@@ -149,7 +149,7 @@ resource "null_resource" "upload_configs" {
 }
 
 resource "null_resource" "generate_instance_tls_certs" {
-  count = var.tls ? 1 : 0
+  count      = var.tls ? 1 : 0
   depends_on = [null_resource.upload_configs]
 
   connection {
@@ -203,8 +203,8 @@ EOF
       "mkdir -p /tmp/nomad-tls",
     ]
   }
-  provisioner "file"{
-    source = "keys/ca.crt"
+  provisioner "file" {
+    source      = "keys/ca.crt"
     destination = "/tmp/nomad-tls/ca.crt"
   }
   provisioner "file" {
@@ -217,11 +217,11 @@ EOF
   }
   # workaround to avoid updating packer
   provisioner "file" {
-    source = "packer/ubuntu-bionic-amd64/provision.sh"
+    source      = "packer/ubuntu-bionic-amd64/provision.sh"
     destination = "/opt/provision.sh"
   }
   provisioner "file" {
-    source = "config"
+    source      = "config"
     destination = "/tmp/config"
   }
 

--- a/e2e/terraform/provision-nomad/main.tf
+++ b/e2e/terraform/provision-nomad/main.tf
@@ -11,13 +11,16 @@ locals {
 
   # abstract-away platform-specific parameter expectations
   _arg = var.platform == "windows_amd64" ? "-" : "--"
+
+  tls_role = var.role == "server" ? "server" : "client"
 }
 
 resource "null_resource" "provision_nomad" {
 
   depends_on = [
     null_resource.upload_configs,
-    null_resource.upload_nomad_binary
+    null_resource.upload_nomad_binary,
+    null_resource.generate_instance_tls_certs
   ]
 
   # no need to re-run if nothing changes
@@ -29,7 +32,7 @@ resource "null_resource" "provision_nomad" {
   connection {
     type            = "ssh"
     user            = var.connection.user
-    host            = var.connection.host
+    host            = var.instance.public_ip
     port            = var.connection.port
     private_key     = file(var.connection.private_key)
     target_platform = var.platform == "windows_amd64" ? "windows" : "unix"
@@ -43,7 +46,7 @@ resource "null_resource" "provision_nomad" {
 }
 
 data "template_file" "provision_script" {
-  template = "${local.provision_script}${data.template_file.arg_nomad_url.rendered}${data.template_file.arg_nomad_sha.rendered}${data.template_file.arg_nomad_version.rendered}${data.template_file.arg_nomad_binary.rendered}${data.template_file.arg_nomad_enterprise.rendered}${data.template_file.arg_nomad_license.rendered}${data.template_file.arg_nomad_acls.rendered}${data.template_file.arg_profile.rendered}${data.template_file.arg_role.rendered}${data.template_file.arg_index.rendered}${data.template_file.autojoin_tag.rendered}"
+  template = "${local.provision_script}${data.template_file.arg_nomad_url.rendered}${data.template_file.arg_nomad_sha.rendered}${data.template_file.arg_nomad_version.rendered}${data.template_file.arg_nomad_binary.rendered}${data.template_file.arg_nomad_enterprise.rendered}${data.template_file.arg_nomad_license.rendered}${data.template_file.arg_nomad_acls.rendered}${data.template_file.arg_nomad_tls.rendered}${data.template_file.arg_profile.rendered}${data.template_file.arg_role.rendered}${data.template_file.arg_index.rendered}${data.template_file.autojoin_tag.rendered}"
 }
 
 data "template_file" "arg_nomad_sha" {
@@ -55,7 +58,7 @@ data "template_file" "arg_nomad_version" {
 }
 
 data "template_file" "arg_nomad_url" {
-  template = var.nomad_url != "" && var.nomad_local_binary == "" ? " ${local._arg}nomad_url ${var.nomad_url}" : ""
+  template = var.nomad_url != "" && var.nomad_local_binary == "" ? " ${local._arg}nomad_url '${var.nomad_url}'" : ""
 }
 
 data "template_file" "arg_nomad_binary" {
@@ -72,6 +75,10 @@ data "template_file" "arg_nomad_license" {
 
 data "template_file" "arg_nomad_acls" {
   template = var.nomad_acls ? " ${local._arg}nomad_acls" : ""
+}
+
+data "template_file" "arg_nomad_tls" {
+  template = var.tls ? " ${local._arg}tls" : ""
 }
 
 data "template_file" "arg_profile" {
@@ -101,7 +108,7 @@ resource "null_resource" "upload_nomad_binary" {
   connection {
     type            = "ssh"
     user            = var.connection.user
-    host            = var.connection.host
+    host            = var.instance.public_ip
     port            = var.connection.port
     private_key     = file(var.connection.private_key)
     target_platform = var.platform == "windows_amd64" ? "windows" : "unix"
@@ -123,7 +130,7 @@ resource "null_resource" "upload_configs" {
   connection {
     type            = "ssh"
     user            = var.connection.user
-    host            = var.connection.host
+    host            = var.instance.public_ip
     port            = var.connection.port
     private_key     = file(var.connection.private_key)
     target_platform = var.platform == "windows_amd64" ? "windows" : "unix"
@@ -137,6 +144,97 @@ resource "null_resource" "upload_configs" {
 
   provisioner "remote-exec" {
     inline = [local.update_config_command]
+  }
+
+}
+
+resource "null_resource" "generate_instance_tls_certs" {
+  count = var.tls ? 1 : 0
+  depends_on = [null_resource.upload_configs]
+
+  connection {
+    type        = "ssh"
+    user        = var.connection.user
+    host        = var.instance.public_ip
+    port        = var.connection.port
+    private_key = file(var.connection.private_key)
+    timeout     = "15m"
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+set -e
+
+cat <<'EOT' > keys/ca.crt
+${var.tls_ca_cert}
+EOT
+
+cat <<'EOT' > keys/ca.key
+${var.tls_ca_key}
+EOT
+
+openssl req -newkey rsa:2048 -nodes \
+	-subj "/CN=${local.tls_role}.global.nomad" \
+	-keyout keys/agent-${var.instance.public_ip}.key \
+	-out keys/agent-${var.instance.public_ip}.csr
+
+cat <<'NEOY' > keys/agent-${var.instance.public_ip}.conf
+
+subjectAltName=DNS:${local.tls_role}.global.nomad,DNS:${local.tls_role}.dc1.consul,DNS:localhost,DNS:${var.instance.public_dns},IP:127.0.0.1,IP:${var.instance.private_ip},IP:${var.instance.public_ip}
+extendedKeyUsage = serverAuth, clientAuth
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+NEOY
+
+openssl x509 -req -CAcreateserial \
+	-extfile ./keys/agent-${var.instance.public_ip}.conf \
+	-days 365 \
+  -sha256 \
+	-CA keys/ca.crt \
+	-CAkey keys/ca.key \
+	-in keys/agent-${var.instance.public_ip}.csr \
+	-out keys/agent-${var.instance.public_ip}.crt
+
+EOF
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "mkdir -p /tmp/nomad-tls",
+    ]
+  }
+  provisioner "file"{
+    source = "keys/ca.crt"
+    destination = "/tmp/nomad-tls/ca.crt"
+  }
+  provisioner "file" {
+    source      = "keys/agent-${var.instance.public_ip}.crt"
+    destination = "/tmp/nomad-tls/agent.crt"
+  }
+  provisioner "file" {
+    source      = "keys/agent-${var.instance.public_ip}.key"
+    destination = "/tmp/nomad-tls/agent.key"
+  }
+  # workaround to avoid updating packer
+  provisioner "file" {
+    source = "packer/ubuntu-bionic-amd64/provision.sh"
+    destination = "/opt/provision.sh"
+  }
+  provisioner "file" {
+    source = "config"
+    destination = "/tmp/config"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo cp -r /tmp/nomad-tls /opt/config/${var.profile}/nomad/tls",
+      "sudo cp -r /tmp/nomad-tls /opt/config/${var.profile}/consul/tls",
+      "sudo cp -r /tmp/nomad-tls /opt/config/${var.profile}/vault/tls",
+
+      # more workaround
+      "sudo rm -rf /opt/config",
+      "sudo mv /tmp/config /opt/config"
+    ]
   }
 
 }

--- a/e2e/terraform/provision-nomad/variables.tf
+++ b/e2e/terraform/provision-nomad/variables.tf
@@ -46,6 +46,24 @@ variable "nomad_acls" {
   default     = false
 }
 
+variable "tls" {
+  type        = bool
+  description = "Bootstrap TLS"
+  default     = false
+}
+
+variable "tls_ca_key" {
+  type        = string
+  description = "Cluster TLS CA private key"
+  default     = ""
+}
+
+variable "tls_ca_cert" {
+  type        = string
+  description = "Cluster TLS CA cert"
+  default     = ""
+}
+
 variable "profile" {
   type        = string
   description = "The name of the configuration profile (ex. 'full-cluster')"
@@ -70,11 +88,19 @@ variable "cluster_name" {
   default     = ""
 }
 
+variable "instance" {
+  type = object({
+    id = string
+    public_dns = string
+    public_ip = string
+    private_dns = string
+    private_ip = string
+  })
+}
+
 variable "connection" {
   type = object({
-    type        = string
     user        = string
-    host        = string
     port        = number
     private_key = string
   })

--- a/e2e/terraform/provision-nomad/variables.tf
+++ b/e2e/terraform/provision-nomad/variables.tf
@@ -90,11 +90,11 @@ variable "cluster_name" {
 
 variable "instance" {
   type = object({
-    id = string
-    public_dns = string
-    public_ip = string
+    id          = string
+    public_dns  = string
+    public_ip   = string
     private_dns = string
-    private_ip = string
+    private_ip  = string
   })
 }
 

--- a/e2e/terraform/terraform.tfvars
+++ b/e2e/terraform/terraform.tfvars
@@ -8,6 +8,7 @@ nomad_acls                       = false
 nomad_enterprise                 = false
 vault                            = true
 volumes                          = false
+tls                              = true
 
 nomad_version      = "1.0.1" # default version for deployment
 nomad_local_binary = ""      # overrides nomad_version if set

--- a/e2e/terraform/tls_ca.tf
+++ b/e2e/terraform/tls_ca.tf
@@ -15,21 +15,21 @@ resource "tls_self_signed_cert" "ca" {
   validity_period_hours = 720
 
   is_ca_certificate = true
-  allowed_uses = ["cert_signing"]
+  allowed_uses      = ["cert_signing"]
 }
 
 resource "local_file" "ca_key" {
   filename = "keys/tls_ca.key"
-  content = tls_private_key.ca.private_key_pem
+  content  = tls_private_key.ca.private_key_pem
 }
 
 resource "local_file" "ca_cert" {
   filename = "keys/tls_ca.crt"
-  content = tls_self_signed_cert.ca.cert_pem
+  content  = tls_self_signed_cert.ca.cert_pem
 }
 
 resource "tls_private_key" "api_client" {
-  algorithm = "ECDSA"
+  algorithm   = "ECDSA"
   ecdsa_curve = "P384"
 }
 
@@ -38,7 +38,7 @@ resource "tls_cert_request" "api_client" {
   private_key_pem = tls_private_key.api_client.private_key_pem
 
   subject {
-      common_name  = "${local.random_name} api client"
+    common_name = "${local.random_name} api client"
   }
 }
 
@@ -53,18 +53,18 @@ resource "tls_locally_signed_cert" "api_client" {
 
   # Reasonable set of uses for a server SSL certificate.
   allowed_uses = [
-      "key_encipherment",
-      "digital_signature",
-      "client_auth",
+    "key_encipherment",
+    "digital_signature",
+    "client_auth",
   ]
 }
 
 resource "local_file" "api_client_key" {
   filename = "keys/tls_api_client.key"
-  content = tls_private_key.api_client.private_key_pem
+  content  = tls_private_key.api_client.private_key_pem
 }
 
 resource "local_file" "api_client_cert" {
   filename = "keys/tls_api_client.crt"
-  content = tls_locally_signed_cert.api_client.cert_pem
+  content  = tls_locally_signed_cert.api_client.cert_pem
 }

--- a/e2e/terraform/tls_ca.tf
+++ b/e2e/terraform/tls_ca.tf
@@ -1,0 +1,70 @@
+resource "tls_private_key" "ca" {
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P384"
+}
+
+resource "tls_self_signed_cert" "ca" {
+  key_algorithm   = "ECDSA"
+  private_key_pem = tls_private_key.ca.private_key_pem
+
+  subject {
+    common_name  = "${local.random_name} Nomad E2E Cluster"
+    organization = local.random_name
+  }
+
+  validity_period_hours = 720
+
+  is_ca_certificate = true
+  allowed_uses = ["cert_signing"]
+}
+
+resource "local_file" "ca_key" {
+  filename = "keys/tls_ca.key"
+  content = tls_private_key.ca.private_key_pem
+}
+
+resource "local_file" "ca_cert" {
+  filename = "keys/tls_ca.crt"
+  content = tls_self_signed_cert.ca.cert_pem
+}
+
+resource "tls_private_key" "api_client" {
+  algorithm = "ECDSA"
+  ecdsa_curve = "P384"
+}
+
+resource "tls_cert_request" "api_client" {
+  key_algorithm   = "ECDSA"
+  private_key_pem = tls_private_key.api_client.private_key_pem
+
+  subject {
+      common_name  = "${local.random_name} api client"
+  }
+}
+
+resource "tls_locally_signed_cert" "api_client" {
+  cert_request_pem   = tls_cert_request.api_client.cert_request_pem
+  ca_key_algorithm   = tls_private_key.ca.algorithm
+  ca_private_key_pem = tls_private_key.ca.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.ca.cert_pem
+
+
+  validity_period_hours = 720
+
+  # Reasonable set of uses for a server SSL certificate.
+  allowed_uses = [
+      "key_encipherment",
+      "digital_signature",
+      "client_auth",
+  ]
+}
+
+resource "local_file" "api_client_key" {
+  filename = "keys/tls_api_client.key"
+  content = tls_private_key.api_client.private_key_pem
+}
+
+resource "local_file" "api_client_cert" {
+  filename = "keys/tls_api_client.crt"
+  content = tls_locally_signed_cert.api_client.cert_pem
+}

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -102,6 +102,12 @@ variable "nomad_acls" {
   default     = false
 }
 
+variable "tls" {
+  type        = bool
+  description = "Bootstrap TLS"
+  default     = false
+}
+
 variable "vault" {
   type        = bool
   description = "Bootstrap Vault"

--- a/e2e/terraform/vault.tf
+++ b/e2e/terraform/vault.tf
@@ -1,3 +1,8 @@
+locals {
+
+  vault_env = var.tls ? "VAULT_ADDR=https://${aws_instance.server.0.public_ip}:8200 VAULT_CACERT=keys/tls_ca.crt VAULT_CLIENT_CERT=keys/tls_api_client.crt VAULT_CLIENT_KEY=keys/tls_api_client.key" : "VAULT_ADDR=http://${aws_instance.server.0.public_ip}:8200"
+}
+
 resource "null_resource" "bootstrap_vault" {
   depends_on = [
     aws_instance.server,
@@ -16,7 +21,7 @@ resource "null_resource" "bootstrap_vault" {
 # so that we can read it into the data.local_file later. If not set,
 # ensure that it's empty.
 data "template_file" "bootstrap_vault_script" {
-  template = var.vault ? "VAULT_ADDR=http://${aws_instance.server.0.public_ip}:8200 ./scripts/bootstrap-vault.sh" : "mkdir -p ${path.root}/keys; echo > ${path.root}/keys/vault_root_token"
+  template = var.vault ? "${local.vault_env} ./scripts/bootstrap-vault.sh" : "mkdir -p ${path.root}/keys; echo > ${path.root}/keys/vault_root_token; echo ${path.root}/keys/nomad_vault.hcl"
 }
 
 data "local_file" "vault_token" {


### PR DESCRIPTION
This allows us to spin up e2e clusters with mTLS configured for all HashiCorp services, i.e. Nomad, Consul, and Vault. Used it for testing https://github.com/hashicorp/nomad/pull/11089 .

mTLS is disabled by default.  I have not updated Windows provisioning scripts yet - Windows also lacks ACL support from before. I intend to follow up for them in another round.

