### PR TITLE
cli: include all possible scores in alloc status metric table

### DIFF
--- a/.changelog/11128.txt
+++ b/.changelog/11128.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Display all possible scores in the allocation status table
+```

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -355,33 +355,32 @@ func formatAllocMetrics(metrics *api.AllocationMetric, scores bool, prefix strin
 	if scores {
 		if len(metrics.ScoreMetaData) > 0 {
 			scoreOutput := make([]string, len(metrics.ScoreMetaData)+1)
-			var scorerNames []string
-			for i, scoreMeta := range metrics.ScoreMetaData {
-				// Add header as first row
-				if i == 0 {
-					scoreOutput[0] = "Node|"
 
-					// sort scores alphabetically
-					scores := make([]string, 0, len(scoreMeta.Scores))
-					for score := range scoreMeta.Scores {
-						scores = append(scores, score)
-					}
-					sort.Strings(scores)
-
-					// build score header output
-					for _, scorerName := range scores {
-						scoreOutput[0] += fmt.Sprintf("%v|", scorerName)
-						scorerNames = append(scorerNames, scorerName)
-					}
-					scoreOutput[0] += "final score"
+			// Find all possible scores and build header row.
+			allScores := make(map[string]struct{})
+			for _, scoreMeta := range metrics.ScoreMetaData {
+				for score := range scoreMeta.Scores {
+					allScores[score] = struct{}{}
 				}
+			}
+			// Sort scores alphabetically.
+			scores := make([]string, 0, len(allScores))
+			for score := range allScores {
+				scores = append(scores, score)
+			}
+			sort.Strings(scores)
+			scoreOutput[0] = fmt.Sprintf("Node|%s|final score", strings.Join(scores, "|"))
+
+			// Build row for each score.
+			for i, scoreMeta := range metrics.ScoreMetaData {
 				scoreOutput[i+1] = fmt.Sprintf("%v|", scoreMeta.NodeID)
-				for _, scorerName := range scorerNames {
+				for _, scorerName := range scores {
 					scoreVal := scoreMeta.Scores[scorerName]
 					scoreOutput[i+1] += fmt.Sprintf("%.3g|", scoreVal)
 				}
 				scoreOutput[i+1] += fmt.Sprintf("%.3g", scoreMeta.NormScore)
 			}
+
 			out += formatList(scoreOutput)
 		} else {
 			// Backwards compatibility for old allocs


### PR DESCRIPTION
The previous logic would only look at the first metric metadata to build the table header row. 

This PR changes this logic to look at all metadata values first, collecting the different metrics available in each of them.

Closes #11117