### PR TITLE
Change dashboard port to http

### DIFF
--- a/website/content/docs/integrations/consul-connect.mdx
+++ b/website/content/docs/integrations/consul-connect.mdx
@@ -185,7 +185,7 @@ job "countdash" {
 
     service {
       name = "count-dashboard"
-      port = "9002"
+      port = "http"
 
       connect {
         sidecar_service {
@@ -292,7 +292,7 @@ The web frontend connects to the API service via Consul Connect:
 ```hcl
     service {
       name = "count-dashboard"
-      port = "9002"
+      port = "http"
 
       connect {
         sidecar_service {


### PR DESCRIPTION
[This documentation](https://www.nomadproject.io/docs/integrations/consul-connect#run-the-connect-enabled-services) describes a `port` stanza in the group `dashboard`:

```
  group "dashboard" {
    network {
      mode = "bridge"

      port "http" {
        static = 9002
        to     = 9002
      }
    }
```

But then doesn't use this defined port in the `service` stanza:

```
    service {
      name = "count-dashboard"
      port = "9002"

      connect {
        sidecar_service {
          proxy {
            upstreams {
              destination_name = "count-api"
              local_bind_port  = 8080
            }
          }
        }
      }
    }
```

And instead just uses `port = "9002"`. I suppose you define the port inside of network to establish a static port on the host, but then it seems odd to redefine the port manually. I found this confusing, and it might contribute to people thinking this is the way it needs to be. It's bad because if you change the 9002 port in networking, it will have to also be manually changed in the service stanza.

I could be off-base here, and I'd be happy to find out if there is actually a reason behind this :smiley: