### PR TITLE
Making RPC Upgrade mode reloadable.

### DIFF
--- a/.changelog/11144.txt
+++ b/.changelog/11144.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: Added `tls -> rpc_upgrade_mode` to be reloaded on SIGHUP
+```

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1093,6 +1093,11 @@ func (a *Agent) ShouldReload(newConfig *Config) (agent, http bool) {
 		agent = true
 	}
 
+	// Allow the ability to only reload HTTP connections
+	if a.config.TLSConfig.RPCUpgradeMode != newConfig.TLSConfig.RPCUpgradeMode {
+		agent = true
+	}
+
 	return agent, http
 }
 

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1093,7 +1093,6 @@ func (a *Agent) ShouldReload(newConfig *Config) (agent, http bool) {
 		agent = true
 	}
 
-	// Allow the ability to only reload HTTP connections
 	if a.config.TLSConfig.RPCUpgradeMode != newConfig.TLSConfig.RPCUpgradeMode {
 		agent = true
 	}

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -1293,44 +1293,23 @@ func TestServer_ShouldReload_ShouldHandleMultipleChanges(t *testing.T) {
 
 func TestServer_ShouldReload_ReturnTrueForRPCUpgradeModeChanges(t *testing.T) {
 	t.Parallel()
-	assert := assert.New(t)
-
-	const (
-		cafile  = "../../helper/tlsutil/testdata/ca.pem"
-		foocert = "../../helper/tlsutil/testdata/nomad-foo.pem"
-		fookey  = "../../helper/tlsutil/testdata/nomad-foo-key.pem"
-	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
 
 	sameAgentConfig := &Config{
 		TLSConfig: &config.TLSConfig{
-			EnableHTTP:           true,
-			EnableRPC:            true,
-			VerifyServerHostname: true,
-			CAFile:               cafile,
-			CertFile:             foocert,
-			KeyFile:              fookey,
-			RPCUpgradeMode:       true,
+			RPCUpgradeMode: true,
 		},
 	}
 
 	agent := NewTestAgent(t, t.Name(), func(c *Config) {
 		c.TLSConfig = &config.TLSConfig{
-			EnableHTTP:           true,
-			EnableRPC:            true,
-			VerifyServerHostname: true,
-			CAFile:               cafile,
-			CertFile:             foocert,
-			KeyFile:              fookey,
-			RPCUpgradeMode:       false,
+			RPCUpgradeMode: false,
 		}
 	})
 	defer agent.Shutdown()
 
 	shouldReloadAgent, shouldReloadHTTP := agent.ShouldReload(sameAgentConfig)
-	assert.True(shouldReloadAgent)
-	assert.False(shouldReloadHTTP)
+	require.True(t, shouldReloadAgent)
+	require.False(t, shouldReloadHTTP)
 }
 
 func TestAgent_ProxyRPC_Dev(t *testing.T) {


### PR DESCRIPTION
Almost all of the TLS settings are reloadable, but changes to RPC upgrade mode don't trigger TLS configuration reloads. This PR adds the value to the ShouldReload function.