### PR TITLE
docs: Update Nvidia GPU installation instructions

### DIFF
--- a/website/content/docs/devices/nvidia.mdx
+++ b/website/content/docs/devices/nvidia.mdx
@@ -100,9 +100,10 @@ In order to use the `nvidia-gpu` the following prerequisites must be met:
 
 ### Docker Driver Requirements
 
-In order to use the Nvidia driver plugin with the Docker driver, please follow
-the installation instructions for
-[`nvidia-docker`](<https://github.com/NVIDIA/nvidia-docker/wiki/Installation-(version-1.0)>).
+The Nvidia driver plugin currently only supports the older v1.0 version of the
+Docker driver provided by Nvidia. In order to use the Nvidia driver plugin with
+the Docker driver, please follow the installation instructions for
+[`nvidia-container-runtime`](https://github.com/nvidia/nvidia-container-runtime#installation).
 
 ## Plugin Configuration
 


### PR DESCRIPTION
The instructions we linked to previously were to an outdated document that contains instructions that no longer work (the `nvidia-docker` package is no longer available in their repository – only the `nvidia-docker2` package is which is not compatible). Instead, you need to follow the instructions for installing the `nvidia-container-runtime`.