### PR TITLE
dependabot: set proper theme/* labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,29 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-- package-ecosystem: gomod
-  directory: "/api"
-  schedule:
-    interval: daily
-- package-ecosystem: npm 
-  directory: "/ui"
-  schedule:
-    interval: daily
-- package-ecosystem: npm 
-  directory: "/website"
-  schedule:
-    interval: daily
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    labels:
+      - "theme/dependencies"
+  - package-ecosystem: gomod
+    directory: "/api"
+    schedule:
+      interval: daily
+    labels:
+      - "theme/dependencies"
+      - "theme/api"
+  - package-ecosystem: npm
+    directory: "/ui"
+    schedule:
+      interval: daily
+    labels:
+      - "theme/dependencies"
+      - "theme/ui"
+  - package-ecosystem: npm
+    directory: "/website"
+    schedule:
+      interval: daily
+    labels:
+      - "theme/dependencies"
+      - "theme/website"


### PR DESCRIPTION
By default, dependabot sets a `dependency` label to all of its PRs.

The Nomad team actually uses the `theme/dependency` label plus some `theme/*` specific labels for different parts of the codebase.

Docs: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#labels