### PR TITLE
jobspec2: ensure consistent error handling between var-file & var.

### DIFF
--- a/.changelog/11165.txt
+++ b/.changelog/11165.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+jobspec: ensure consistent error handling between var-file & cli vars
+```

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -459,6 +459,7 @@ func (j *JobGetter) ApiJobWithArgs(jpath string, vars []string, varfiles []strin
 			AllowFS:  true,
 			VarFiles: varfiles,
 			Envs:     os.Environ(),
+			Strict:   true,
 		})
 
 		if err != nil {

--- a/jobspec2/types.variables.go
+++ b/jobspec2/types.variables.go
@@ -536,6 +536,12 @@ func (c *jobConfig) collectInputVariableValues(env []string, files []*hcl.File, 
 		})
 	}
 
+	// Define the severity of variable passed that are undefined.
+	undefSev := hcl.DiagWarning
+	if c.ParseConfig.Strict {
+		undefSev = hcl.DiagError
+	}
+
 	// files will contain files found in the folder then files passed as
 	// arguments.
 	for _, file := range files {
@@ -583,12 +589,8 @@ func (c *jobConfig) collectInputVariableValues(env []string, files []*hcl.File, 
 		for name, attr := range attrs {
 			variable, found := variables[name]
 			if !found {
-				sev := hcl.DiagWarning
-				if c.ParseConfig.Strict {
-					sev = hcl.DiagError
-				}
 				diags = append(diags, &hcl.Diagnostic{
-					Severity: sev,
+					Severity: undefSev,
 					Summary:  "Undefined variable",
 					Detail: fmt.Sprintf("A %q variable was set but was "+
 						"not found in known variables. To declare "+
@@ -630,7 +632,7 @@ func (c *jobConfig) collectInputVariableValues(env []string, files []*hcl.File, 
 		variable, found := variables[name]
 		if !found {
 			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
+				Severity: undefSev,
 				Summary:  "Undefined -var variable",
 				Detail: fmt.Sprintf("A %q variable was passed in the command "+
 					"line but was not found in known variables. "+


### PR DESCRIPTION
As per Nomad documentation, all variables used within a job specification must be defined via a variable block within the job specification file. Attempting to perform an override on a variable that doesn't exist will result in a parse error. This change fixes the behaviour, so there is consistency no matter where the override came.

closes #11149 