### PR TITLE
Allow wildcard datacenters to be specified in job file

### DIFF
--- a/.changelog/11170.txt
+++ b/.changelog/11170.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+config: the `datacenter` field for agent configuration no longer accepts the `*` character as part of the datacenter name
+```
+
+```release-note:improvement
+jobspec: the `datacenters` field now accepts wildcards
+```

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -315,8 +315,8 @@ func (c *Command) IsValidConfig(config, cmdConfig *Config) bool {
 	}
 
 	// Check that the datacenter name does not contain invalid characters
-	if strings.ContainsAny(config.Datacenter, "\000") {
-		c.Ui.Error("Datacenter contains invalid characters")
+	if strings.ContainsAny(config.Datacenter, "\000?*") {
+		c.Ui.Error("Datacenter contains invalid characters (null, '?', or '*')")
 		return false
 	}
 

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -315,8 +315,8 @@ func (c *Command) IsValidConfig(config, cmdConfig *Config) bool {
 	}
 
 	// Check that the datacenter name does not contain invalid characters
-	if strings.ContainsAny(config.Datacenter, "\000?*") {
-		c.Ui.Error("Datacenter contains invalid characters (null, '?', or '*')")
+	if strings.ContainsAny(config.Datacenter, "\000*") {
+		c.Ui.Error("Datacenter contains invalid characters (null or '*')")
 		return false
 	}
 

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -157,9 +157,6 @@ func TestCommand_InvalidCharInDatacenter(t *testing.T) {
 		"char-\\000-in-the-middle",
 		"ends-with-\\000",
 		"\\000-at-the-beginning",
-		"char-?-in-the-middle",
-		"ends-with-?",
-		"?-at-the-beginning",
 		"char-*-in-the-middle",
 		"ends-with-*",
 		"*-at-the-beginning",
@@ -194,7 +191,7 @@ func TestCommand_InvalidCharInDatacenter(t *testing.T) {
 		}
 
 		out := ui.ErrorWriter.String()
-		exp := "Datacenter contains invalid characters (null, '?', or '*')"
+		exp := "Datacenter contains invalid characters (null or '*')"
 		if !strings.Contains(out, exp) {
 			t.Fatalf("expect to find %q\n\n%s", exp, out)
 		}

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -148,7 +148,7 @@ func TestCommand_MetaConfigValidation(t *testing.T) {
 	}
 }
 
-func TestCommand_NullCharInDatacenter(t *testing.T) {
+func TestCommand_InvalidCharInDatacenter(t *testing.T) {
 	ci.Parallel(t)
 
 	tmpDir := t.TempDir()
@@ -157,6 +157,12 @@ func TestCommand_NullCharInDatacenter(t *testing.T) {
 		"char-\\000-in-the-middle",
 		"ends-with-\\000",
 		"\\000-at-the-beginning",
+		"char-?-in-the-middle",
+		"ends-with-?",
+		"?-at-the-beginning",
+		"char-*-in-the-middle",
+		"ends-with-*",
+		"*-at-the-beginning",
 	}
 	for _, tc := range tcases {
 		configFile := filepath.Join(tmpDir, "conf1.hcl")
@@ -188,7 +194,7 @@ func TestCommand_NullCharInDatacenter(t *testing.T) {
 		}
 
 		out := ui.ErrorWriter.String()
-		exp := "Datacenter contains invalid characters"
+		exp := "Datacenter contains invalid characters (null, '?', or '*')"
 		if !strings.Contains(out, exp) {
 			t.Fatalf("expect to find %q\n\n%s", exp, out)
 		}

--- a/command/assets/connect-short.nomad
+++ b/command/assets/connect-short.nomad
@@ -1,5 +1,4 @@
 job "countdash" {
-  datacenters = ["dc1"]
 
   group "api" {
     network {

--- a/command/assets/connect.nomad
+++ b/command/assets/connect.nomad
@@ -17,8 +17,9 @@ job "countdash" {
   # region = "global"
   #
   # The "datacenters" parameter specifies the list of datacenters which should
-  # be considered when placing this task. This must be provided.
-  datacenters = ["dc1"]
+  # be considered when placing this task. This accepts wildcards and defaults
+  # allowing placement on all datacenters.
+  datacenters = ["*"]
 
   # The "type" parameter controls the type of job, which impacts the scheduler's
   # decision on placement. This configuration is optional and defaults to

--- a/command/assets/example-short.nomad
+++ b/command/assets/example-short.nomad
@@ -1,5 +1,4 @@
 job "example" {
-  datacenters = ["dc1"]
 
   group "cache" {
     network {

--- a/command/assets/example.nomad
+++ b/command/assets/example.nomad
@@ -17,8 +17,9 @@ job "example" {
   # region = "global"
   #
   # The "datacenters" parameter specifies the list of datacenters which should
-  # be considered when placing this task. This must be provided.
-  datacenters = ["dc1"]
+  # be considered when placing this task. This accepts wildcards and defaults
+  # allowing placement on all datacenters.
+  datacenters = ["*"]
 
   # The "type" parameter controls the type of job, which impacts the scheduler's
   # decision on placement. This configuration is optional and defaults to

--- a/command/testdata/example-short-bad.json
+++ b/command/testdata/example-short-bad.json
@@ -2,7 +2,7 @@
     "Job": {
         "Region": null,
         "Namespace": null,
-        "ID": "example",
+        "ID": "bad example",
         "Name": "example",
         "Type": null,
         "Priority": null,

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1621,7 +1621,7 @@ func (n *Node) createNodeEvals(node *structs.Node, nodeIndex uint64) ([]string, 
 		// datacenter cardinality tends to be low so the check
 		// shouldn't add much work.
 		for _, dc := range job.Datacenters {
-			if dc == node.Datacenter {
+			if node.IsInDC(dc) {
 				sysJobs = append(sysJobs, job)
 				break
 			}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4369,6 +4369,10 @@ func (j *Job) Canonicalize() {
 		j.Namespace = DefaultNamespace
 	}
 
+	if len(j.Datacenters) == 0 {
+		j.Datacenters = []string{"*"}
+	}
+
 	for _, tg := range j.TaskGroups {
 		tg.Canonicalize(j)
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -44,6 +44,7 @@ import (
 	psstructs "github.com/hashicorp/nomad/plugins/shared/structs"
 	"github.com/miekg/dns"
 	"github.com/mitchellh/copystructure"
+	"github.com/ryanuber/go-glob"
 	"golang.org/x/crypto/blake2b"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
@@ -2292,6 +2293,10 @@ func (n *Node) ComparableResources() *ComparableResources {
 			DiskMB: int64(n.Resources.DiskMB),
 		},
 	}
+}
+
+func (n *Node) IsInDC(dc string) bool {
+	return glob.Glob(dc, n.Datacenter)
 }
 
 // Stub returns a summarized version of the node

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -58,7 +58,7 @@ func TestJob_Validate(t *testing.T) {
 		Name:        "my-job",
 		Type:        JobTypeService,
 		Priority:    50,
-		Datacenters: []string{"dc1"},
+		Datacenters: []string{"*"},
 		TaskGroups: []*TaskGroup{
 			{
 				Name: "web",
@@ -91,7 +91,7 @@ func TestJob_Validate(t *testing.T) {
 		"group 3 missing name",
 		"Task group web validation failed",
 	)
-	// test for empty datacenters
+	// test for invalid datacenters
 	j = &Job{
 		Datacenters: []string{""},
 	}
@@ -372,7 +372,7 @@ func testJob() *Job {
 		Type:        JobTypeService,
 		Priority:    50,
 		AllAtOnce:   false,
-		Datacenters: []string{"dc1"},
+		Datacenters: []string{"*"},
 		Constraints: []*Constraint{
 			{
 				LTarget: "$attr.kernel.name",

--- a/scheduler/datacenters.go
+++ b/scheduler/datacenters.go
@@ -1,1 +1,0 @@
-package scheduler

--- a/scheduler/datacenters.go
+++ b/scheduler/datacenters.go
@@ -1,0 +1,1 @@
+package scheduler

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
@@ -1107,10 +1108,9 @@ func TestServiceSched_JobRegister_AllocFail(t *testing.T) {
 		t.Fatalf("bad: %#v", metrics)
 	}
 
-	// Check the available nodes
-	if _, ok := metrics.NodesAvailable["dc1"]; ok {
-		t.Fatalf("bad: %#v", metrics)
-	}
+	_, ok = metrics.NodesAvailable["dc1"]
+	must.False(t, ok, must.Sprintf(
+		"expected NodesAvailable metric to be unpopulated when there are no nodes"))
 
 	// Check queued allocations
 	queued := outEval.QueuedAllocations["web"]

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -757,7 +757,7 @@ func TestServiceSched_Spread(t *testing.T) {
 			remaining := uint8(100 - start)
 			// Create a job that uses spread over data center
 			job := mock.Job()
-			job.Datacenters = []string{"dc1", "dc2"}
+			job.Datacenters = []string{"dc*"}
 			job.TaskGroups[0].Count = 10
 			job.TaskGroups[0].Spreads = append(job.TaskGroups[0].Spreads,
 				&structs.Spread{

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -1108,7 +1108,7 @@ func TestServiceSched_JobRegister_AllocFail(t *testing.T) {
 	}
 
 	// Check the available nodes
-	if count, ok := metrics.NodesAvailable["dc1"]; !ok || count != 0 {
+	if _, ok := metrics.NodesAvailable["dc1"]; ok {
 		t.Fatalf("bad: %#v", metrics)
 	}
 

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/rand"
+	"path/filepath"
 	"reflect"
 	"time"
 
@@ -361,10 +362,7 @@ func diffSystemAllocs(
 // mapping of each data center to the count of ready nodes.
 func readyNodesInDCs(state State, dcs []string) ([]*structs.Node, map[string]struct{}, map[string]int, error) {
 	// Index the DCs
-	dcMap := make(map[string]int, len(dcs))
-	for _, dc := range dcs {
-		dcMap[dc] = 0
-	}
+	dcMap := make(map[string]int)
 
 	// Scan the nodes
 	ws := memdb.NewWatchSet()
@@ -386,13 +384,35 @@ func readyNodesInDCs(state State, dcs []string) ([]*structs.Node, map[string]str
 			notReady[node.ID] = struct{}{}
 			continue
 		}
-		if _, ok := dcMap[node.Datacenter]; !ok {
+
+		match, err := matchDcs(dcs, node)
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if !match {
 			continue
 		}
+
 		out = append(out, node)
 		dcMap[node.Datacenter]++
 	}
 	return out, notReady, dcMap, nil
+}
+
+func matchDcs(dcs []string, node *structs.Node) (bool, error) {
+	for _, dc := range dcs {
+		match, err := filepath.Match(dc, node.Datacenter)
+		if err != nil {
+			return false, err
+		}
+		if match {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // retryMax is used to retry a callback until it returns success or

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -560,53 +561,47 @@ func TestReadyNodesInDCs(t *testing.T) {
 	node3.Datacenter = "dc2"
 	node3.Status = structs.NodeStatusDown
 	node4 := mock.DrainNode()
-
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1000, node1))
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1001, node2))
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1002, node3))
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1003, node4))
-
-	nodes, notReady, dc, err := readyNodesInDCs(state, []string{"dc1", "dc2"})
-	require.NoError(t, err)
-	require.Equal(t, 2, len(nodes))
-	require.NotEqual(t, node3.ID, nodes[0].ID)
-	require.NotEqual(t, node3.ID, nodes[1].ID)
-
-	require.Contains(t, dc, "dc1")
-	require.Equal(t, 1, dc["dc1"])
-	require.Contains(t, dc, "dc2")
-	require.Equal(t, 1, dc["dc2"])
-
-	require.Contains(t, notReady, node3.ID)
-	require.Contains(t, notReady, node4.ID)
-}
-
-func TestReadyNodesInDCsWildcard(t *testing.T) {
-	state := state.TestStateStore(t)
-	node1 := mock.Node()
-	node2 := mock.Node()
-	node2.Datacenter = "dc2"
-	node3 := mock.Node()
-	node3.Datacenter = "dc2"
-	node3.Status = structs.NodeStatusDown
-	node4 := mock.DrainNode()
 	node5 := mock.Node()
-	node5.Datacenter = "other"
+	node5.Datacenter = "not-this-dc"
 
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1000, node1))
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1001, node2))
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1002, node3))
-	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1003, node4))
+	must.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1000, node1)) // dc1 ready
+	must.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1001, node2)) // dc2 ready
+	must.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1002, node3)) // dc2 not ready
+	must.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1003, node4)) // dc2 not ready
+	must.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1004, node5)) // ready never match
 
-	nodes, dc, err := readyNodesInDCs(state, []string{"dc*"})
-	require.NoError(t, err)
-	require.Equal(t, 2, len(nodes))
-	require.True(t, nodes[0].ID != node3.ID && nodes[1].ID != node3.ID)
+	testCases := []struct {
+		name           string
+		datacenters    []string
+		expectReady    []*structs.Node
+		expectNotReady map[string]struct{}
+		expectIndex    map[string]int
+	}{
+		{
+			name:           "no wildcards",
+			datacenters:    []string{"dc1", "dc2"},
+			expectReady:    []*structs.Node{node1, node2},
+			expectNotReady: map[string]struct{}{node3.ID: struct{}{}, node4.ID: struct{}{}},
+			expectIndex:    map[string]int{"dc1": 1, "dc2": 1},
+		},
+		{
+			name:           "with wildcard",
+			datacenters:    []string{"dc*"},
+			expectReady:    []*structs.Node{node1, node2},
+			expectNotReady: map[string]struct{}{node3.ID: struct{}{}, node4.ID: struct{}{}},
+			expectIndex:    map[string]int{"dc1": 1, "dc2": 1},
+		},
+	}
 
-	require.Contains(t, dc, "dc1")
-	require.Equal(t, 1, dc["dc1"])
-	require.Contains(t, dc, "dc2")
-	require.Equal(t, 1, dc["dc2"])
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ready, notReady, dcIndex, err := readyNodesInDCs(state, tc.datacenters)
+			must.NoError(t, err)
+			must.SliceContainsAll(t, tc.expectReady, ready, must.Sprint("expected ready to match"))
+			must.Eq(t, tc.expectNotReady, notReady, must.Sprint("expected not-ready to match"))
+			must.Eq(t, tc.expectIndex, dcIndex, must.Sprint("expected datacenter counts to match"))
+		})
+	}
 }
 
 func TestRetryMax(t *testing.T) {

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -58,7 +58,7 @@ func TestDiffSystemAllocsForNode_Sysbatch_terminal(t *testing.T) {
 	t.Run("current job", func(t *testing.T) {
 		terminal := structs.TerminalByNodeByName{
 			"node1": map[string]*structs.Allocation{
-				"my-sysbatch.pinger[0]": {
+				"my-sysbatch.pinger[0]": &structs.Allocation{
 					ID:           uuid.Generate(),
 					NodeID:       "node1",
 					Name:         "my-sysbatch.pinger[0]",
@@ -82,7 +82,7 @@ func TestDiffSystemAllocsForNode_Sysbatch_terminal(t *testing.T) {
 		previousJob.JobModifyIndex -= 1
 		terminal := structs.TerminalByNodeByName{
 			"node1": map[string]*structs.Allocation{
-				"my-sysbatch.pinger[0]": {
+				"my-sysbatch.pinger[0]": &structs.Allocation{
 					ID:     uuid.Generate(),
 					NodeID: "node1",
 					Name:   "my-sysbatch.pinger[0]",

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -585,11 +585,13 @@ func TestReadyNodesInDCsWildcard(t *testing.T) {
 	state := state.TestStateStore(t)
 	node1 := mock.Node()
 	node2 := mock.Node()
-	node2.Datacenter = "dc1"
+	node2.Datacenter = "dc2"
 	node3 := mock.Node()
 	node3.Datacenter = "dc2"
 	node3.Status = structs.NodeStatusDown
 	node4 := mock.DrainNode()
+	node5 := mock.Node()
+	node5.Datacenter = "other"
 
 	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1000, node1))
 	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1001, node2))

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -58,7 +58,7 @@ func TestDiffSystemAllocsForNode_Sysbatch_terminal(t *testing.T) {
 	t.Run("current job", func(t *testing.T) {
 		terminal := structs.TerminalByNodeByName{
 			"node1": map[string]*structs.Allocation{
-				"my-sysbatch.pinger[0]": &structs.Allocation{
+				"my-sysbatch.pinger[0]": {
 					ID:           uuid.Generate(),
 					NodeID:       "node1",
 					Name:         "my-sysbatch.pinger[0]",
@@ -82,7 +82,7 @@ func TestDiffSystemAllocsForNode_Sysbatch_terminal(t *testing.T) {
 		previousJob.JobModifyIndex -= 1
 		terminal := structs.TerminalByNodeByName{
 			"node1": map[string]*structs.Allocation{
-				"my-sysbatch.pinger[0]": &structs.Allocation{
+				"my-sysbatch.pinger[0]": {
 					ID:     uuid.Generate(),
 					NodeID: "node1",
 					Name:   "my-sysbatch.pinger[0]",

--- a/website/content/docs/job-specification/job.mdx
+++ b/website/content/docs/job-specification/job.mdx
@@ -76,9 +76,11 @@ job "docs" {
   to define criteria for spreading allocations across a node attribute or metadata.
   See the [Nomad spread reference][spread] for more details.
 
-- `datacenters` `(array<string>: <required>)` - A list of datacenters in the region which are eligible
-  for task placement. This must be provided, and does not have a default. It allows wildcard globbing 
-  through use of the '*' for multi-character matching, or '?' for single-character matching.
+- `datacenters` `(array<string>: <optional>)` - A list of datacenters in the
+  region which are eligible for task placement. This field allows wildcard
+  globbing through the use of `*` for multi-character matching. The default
+  value is `["*"]`, which allows the job to be placed in any available
+  datacenter.
 
 - `group` <code>([Group][group]: &lt;required&gt;)</code> - Specifies the start of a
   group of tasks. This can be provided multiple times to define additional

--- a/website/content/docs/job-specification/job.mdx
+++ b/website/content/docs/job-specification/job.mdx
@@ -77,7 +77,8 @@ job "docs" {
   See the [Nomad spread reference][spread] for more details.
 
 - `datacenters` `(array<string>: <required>)` - A list of datacenters in the region which are eligible
-  for task placement. This must be provided, and does not have a default.
+  for task placement. This must be provided, and does not have a default. It allows wildcard globbing 
+  through use of the '*' for multi-character matching, or '?' for single-character matching.
 
 - `group` <code>([Group][group]: &lt;required&gt;)</code> - Specifies the start of a
   group of tasks. This can be provided multiple times to define additional

--- a/website/content/docs/job-specification/job.mdx
+++ b/website/content/docs/job-specification/job.mdx
@@ -76,11 +76,10 @@ job "docs" {
   to define criteria for spreading allocations across a node attribute or metadata.
   See the [Nomad spread reference][spread] for more details.
 
-- `datacenters` `(array<string>: <optional>)` - A list of datacenters in the
-  region which are eligible for task placement. This field allows wildcard
-  globbing through the use of `*` for multi-character matching. The default
-  value is `["*"]`, which allows the job to be placed in any available
-  datacenter.
+- `datacenters` `(array<string>: ["*"])` - A list of datacenters in the region
+  which are eligible for task placement. This field allows wildcard globbing
+  through the use of `*` for multi-character matching. The default value is
+  `["*"]`, which allows the job to be placed in any available datacenter.
 
 - `group` <code>([Group][group]: &lt;required&gt;)</code> - Specifies the start of a
   group of tasks. This can be provided multiple times to define additional

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -72,8 +72,9 @@ for `datacenters` is now `["*"]`, so the field can be omitted.
 
 The `*` character is no longer a legal character in the
 [`datacenter`][/nomad/docs/configuration#datacenter] field for an agent
-configuration. Before upgrading to Nomad 1.5.0, you should ensure that no agents
-have this character in their `datacenter` field name.
+configuration. Before upgrading to Nomad 1.5.0, you should first ensure that
+you've updated any jobs that currently have a `*` in their datacenter name and
+then ensure that no agents have this character in their `datacenter` field name.
 
 #### Server `rejoin_after_leave` (default: `false`) now enforced
 

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -62,6 +62,19 @@ from the Nomad client by setting [`set_environment_variables`][artifact_env].
 The use of filesystem isolation can be disabled in Client configuration by
 setting [`disable_filesystem_isolation`][artifact_fs_isolation].
 
+#### Datacenter Wildcards
+
+In Nomad 1.5.0, the
+[`datacenters`][/nomad/docs/job-specification/job#datacenters] field for a job
+accepts wildcards for multi-character matching. For example, `datacenters =
+["dc*"]` will match all datacenters that start with `"dc"`. The default value
+for `datacenters` is now `["*"]`, so the field can be omitted.
+
+The `*` character is no longer a legal character in the
+[`datacenter`][/nomad/docs/configuration#datacenter] field for an agent
+configuration. Before upgrading to Nomad 1.5.0, you should ensure that no agents
+have this character in their `datacenter` field name.
+
 #### Server `rejoin_after_leave` (default: `false`) now enforced
 
 All Nomad versions prior to v1.5.0 have incorrectly ignored the Server


### PR DESCRIPTION
### Overview

This PR addresses the issue https://github.com/hashicorp/nomad/issues/9024

It uses the `filepath.Match` golang std lib to accomplish the matching, which is somewhat simpler and more intuitive than using a regex. Because of that simplicity, it should be minimally impactful.

It is not completely backwards compatible, as datacenters with "*", "]", "?" in their name may be impacted. I do not believe the requested feature could be implemented without a theoretical compatibility break, or an entirely new property (which feels worse).

### Notes 

The docs do not appear to be part of the project, at least not that I could see, so they would need to be updated as well.

The returned list of datacenters will no longer have keys with a node count of 0. This is because we cannot a priori determine the number of datacenters based on wildcard dc specs. So we have to allocate a map, then add and increment each dc as we match it.

I do not know what, if any, impact this will have.

### Example 
```
job "test" {
    name = "test"

    datacenters = ["dc1", "site.*", "*.site", "dc?"]

    type = "system"

    group "test" {
        task "test" {
            driver = "docker"

            config {
                image = "redis"
            }
        }
    }
}
```

### Interactions with other features

#### Spread

There was a comment in the feature request thread about the interaction with the spread stanza. As far as I can tell, the nodes are set on the stack based on the results of the `readyNodesInDCs` function, and the stack then uses those nodes when computing selections, both for spread and for bin packing. So it _seems_ like it should just work, and my limited testing with spread has done what was expected, but I could well be missing something.

#### multiregion.region[*].datacenters

There was another comment about parity with `multiregion.region[*].datacenters` for interpolation reasons. While I'd image the job spec that is received by the scheduler, which has the `Datacenters` property used by `readyNodesInDCs`, has that property set to the applicable region value, or the default job value, by the time it reaches the function, I have been unable to confirm that.

As multiregion requires Nomad Enterprise, I have also been unable to test it.