### PR TITLE
Log network device name during fingerprinting

### DIFF
--- a/.changelog/11184.txt
+++ b/.changelog/11184.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client: Add network interface name to log output during fingerprint
+```

--- a/client/fingerprint/network.go
+++ b/client/fingerprint/network.go
@@ -78,18 +78,21 @@ func (f *NetworkFingerprint) Fingerprint(req *FingerprintRequest, resp *Fingerpr
 		return nil
 	}
 
+	// Create a sub-logger with common values to help with debugging
+	logger := f.logger.With("interface", intf.Name)
+
 	// Record the throughput of the interface
 	var mbits int
 	throughput := f.linkSpeed(intf.Name)
 	if cfg.NetworkSpeed != 0 {
 		mbits = cfg.NetworkSpeed
-		f.logger.Debug("setting link speed to user configured speed", "mbits", mbits)
+		logger.Debug("setting link speed to user configured speed", "mbits", mbits)
 	} else if throughput != 0 {
 		mbits = throughput
-		f.logger.Debug("link speed detected", "interface", intf.Name, "mbits", mbits)
+		logger.Debug("link speed detected", "mbits", mbits)
 	} else {
 		mbits = defaultNetworkSpeed
-		f.logger.Debug("link speed could not be detected and no speed specified by user, falling back to default speed", "mbits", defaultNetworkSpeed)
+		logger.Debug("link speed could not be detected and no speed specified by user, falling back to default speed", "mbits", defaultNetworkSpeed)
 	}
 
 	// Create the network resources from the interface
@@ -109,7 +112,7 @@ func (f *NetworkFingerprint) Fingerprint(req *FingerprintRequest, resp *Fingerpr
 	}
 
 	for _, nwResource := range nwResources {
-		f.logger.Debug("detected interface IP", "interface", intf.Name, "IP", nwResource.IP)
+		logger.Debug("detected interface IP", "IP", nwResource.IP)
 	}
 
 	// Deprecated, setting the first IP as unique IP for the node
@@ -138,7 +141,7 @@ func (f *NetworkFingerprint) createNodeNetworkResources(ifaces []net.Interface, 
 		speed := f.linkSpeed(iface.Name)
 		if speed == 0 {
 			speed = defaultNetworkSpeed
-			f.logger.Debug("link speed could not be detected, falling back to default speed", "mbits", defaultNetworkSpeed)
+			f.logger.Debug("link speed could not be detected, falling back to default speed", "interface", iface.Name, "mbits", defaultNetworkSpeed)
 		}
 
 		newNetwork := &structs.NodeNetworkResource{

--- a/client/fingerprint/network_linux.go
+++ b/client/fingerprint/network_linux.go
@@ -16,14 +16,14 @@ func (f *NetworkFingerprint) linkSpeedSys(device string) int {
 	// Read contents of the device/speed file
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
-		f.logger.Debug("unable to read link speed", "path", path)
+		f.logger.Debug("unable to read link speed", "path", path, "device", device)
 		return 0
 	}
 
 	lines := strings.Split(string(content), "\n")
 	mbs, err := strconv.Atoi(lines[0])
 	if err != nil || mbs <= 0 {
-		f.logger.Debug("unable to parse link speed", "path", path)
+		f.logger.Debug("unable to parse link speed", "path", path, "device", device)
 		return 0
 	}
 

--- a/client/fingerprint/network_windows.go
+++ b/client/fingerprint/network_windows.go
@@ -14,26 +14,26 @@ func (f *NetworkFingerprint) linkSpeed(device string) int {
 	outBytes, err := exec.Command(path, command).Output()
 
 	if err != nil {
-		f.logger.Warn("failed to detect link speed", "path", path, "command", command, "error", err)
+		f.logger.Warn("failed to detect link speed", "device", device, "path", path, "command", command, "error", err)
 		return 0
 	}
 
 	output := strings.TrimSpace(string(outBytes))
 
-	return f.parseLinkSpeed(output)
+	return f.parseLinkSpeed(device, output)
 }
 
-func (f *NetworkFingerprint) parseLinkSpeed(commandOutput string) int {
+func (f *NetworkFingerprint) parseLinkSpeed(device, commandOutput string) int {
 	args := strings.Split(commandOutput, " ")
 	if len(args) != 2 {
-		f.logger.Warn("couldn't split LinkSpeed output", "output", commandOutput)
+		f.logger.Warn("couldn't split LinkSpeed output", "device", device, "output", commandOutput)
 		return 0
 	}
 
 	unit := strings.Replace(args[1], "\r\n", "", -1)
 	value, err := strconv.Atoi(args[0])
 	if err != nil {
-		f.logger.Warn("unable to parse LinkSpeed value", "value", commandOutput)
+		f.logger.Warn("unable to parse LinkSpeed value", "device", device, "value", commandOutput, "error", err)
 		return 0
 	}
 


### PR DESCRIPTION
While debugging an issue with network fingerprinting, I found it useful to have the network device name in the log output.