### PR TITLE
Log client node plan rejection at INFO instead of DEBUG

### DIFF
--- a/.changelog/11191.txt
+++ b/.changelog/11191.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+server: Log client node plan rejection at INFO instead of DEBUG
+```

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -477,7 +477,7 @@ func evaluatePlanPlacements(pool *EvaluatePool, snap *state.StateSnapshot, plan 
 		if !fit {
 			// Log the reason why the node's allocations could not be made
 			if reason != "" {
-				logger.Debug("plan for node rejected", "node_id", nodeID, "reason", reason, "eval_id", plan.EvalID)
+				logger.Info("plan for node rejected", "node_id", nodeID, "reason", reason, "eval_id", plan.EvalID)
 			}
 			// Set that this is a partial commit
 			partialCommit = true


### PR DESCRIPTION
When a Nomad client node rejects a plan to place an allocation, such as the case when a port collision has occurred, Nomad currently logs the plan rejection at DEBUG level.  To improve visibility and debuggability this PR increases the logging level to INFO.