### PR TITLE
client: task env vars should take precedence over host env vars.

### DIFF
--- a/.changelog/11206.txt
+++ b/.changelog/11206.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Task vars should take precedence over host vars when performing interpolation.
+```

--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -551,9 +551,14 @@ func (b *Builder) buildEnv(allocDir, localDir, secretsDir string,
 		envMap[hargs.ReplaceEnv(k, nodeAttrs, envMap)] = hargs.ReplaceEnv(v, nodeAttrs, envMap)
 	}
 
-	// Interpolate and add environment variables
+	// Interpolate and add environment variables from the host. Only do this if
+	// the variable is not present in the map; we do not want to override task
+	// variables in favour of the same variable found within the host OS env
+	// vars.
 	for k, v := range b.hostEnv {
-		envMap[k] = hargs.ReplaceEnv(v, nodeAttrs, envMap)
+		if _, ok := envMap[k]; !ok {
+			envMap[k] = hargs.ReplaceEnv(v, nodeAttrs, envMap)
+		}
 	}
 
 	// Copy interpolated task env vars second as they override host env vars

--- a/client/taskenv/env_test.go
+++ b/client/taskenv/env_test.go
@@ -299,6 +299,17 @@ func TestEnvironment_AllValues(t *testing.T) {
 		&drivers.DriverNetwork{PortMap: map[string]int{"https": 443}},
 	)
 
+	// Add a host environment variable which matches a task variable. It means
+	// we can test to ensure the allocation ID variable from the task overrides
+	// that found on the host. The second entry tests to ensure other host env
+	// vars are added as expected.
+	env.mu.Lock()
+	env.hostEnv = map[string]string{
+		AllocID:    "94fa69a3-73a5-4099-85c3-7a1b6e228796",
+		"LC_CTYPE": "C.UTF-8",
+	}
+	env.mu.Unlock()
+
 	values, errs, err := env.Build().AllValues()
 	require.NoError(t, err)
 
@@ -384,6 +395,9 @@ func TestEnvironment_AllValues(t *testing.T) {
 		"NOMAD_PORT_admin":                          "9000",
 		"NOMAD_ALLOC_PORT_admin":                    "9000",
 		"NOMAD_HOST_PORT_admin":                     "32000",
+
+		// Env vars from the host.
+		"LC_CTYPE": "C.UTF-8",
 
 		// 0.9 style env map
 		`env["taskEnvKey"]`:        "taskEnvVal",


### PR DESCRIPTION
closes #11202 