### PR TITLE
docs: add some extra documentation around client host environment variables

### DIFF
--- a/website/content/docs/job-specification/meta.mdx
+++ b/website/content/docs/job-specification/meta.mdx
@@ -41,6 +41,8 @@ Metadata is merged up the job specification, so metadata defined at the job
 level applies to all groups and tasks within that job. Metadata defined at the
 group layer applies to all tasks within that group.
 
+Meta values are made available inside tasks as [runtime environment variables][env_meta].
+
 ## `meta` Parameters
 
 The "parameters" for the `meta` stanza can be any key-value. The keys and values
@@ -93,3 +95,4 @@ meta = {
 [group]: /docs/job-specification/group 'Nomad group Job Specification'
 [task]: /docs/job-specification/task 'Nomad task Job Specification'
 [interpolation]: /docs/runtime/interpolation 'Nomad interpolation'
+[env_meta]: /docs/runtime/environment#meta

--- a/website/content/docs/runtime/environment.mdx
+++ b/website/content/docs/runtime/environment.mdx
@@ -105,6 +105,14 @@ Currently there is no enforcement that the meta keys be lowercase, but using
 multiple keys with the same uppercased representation will lead to undefined
 behavior.
 
+## Host environment variables
+
+Nomad passes the environment variables defined in the client host to tasks when
+using the `exec`, `raw_exec` and `java` task drivers. The variables that are
+passed to the tasks can be controlled using the client configuration
+[`env.denylist`][].
+
 [jobspec]: /docs/job-specification 'Nomad Job Specification'
 [vault]: /docs/vault-integration 'Nomad Vault Integration'
 [filesystem internals]: /docs/internals/filesystem
+[`env.denylist`]: /docs/configuration/client#env-denylist

--- a/website/content/docs/runtime/environment.mdx
+++ b/website/content/docs/runtime/environment.mdx
@@ -108,7 +108,7 @@ behavior.
 ## Host environment variables
 
 Nomad passes the environment variables defined in the client host to tasks when
-using the `exec`, `raw_exec` and `java` task drivers. The variables that are
+using the `exec`, `raw_exec`, and `java` task drivers. The variables that are
 passed to the tasks can be controlled using the client configuration
 [`env.denylist`][].
 


### PR DESCRIPTION
Nomad passes some of the client host environment variables to tasks, as well as `meta` values defined in the jobspec, but this behaviour is not documented very clearly. 

This PR adds some content to https://www.nomadproject.io/docs/runtime/environment and https://www.nomadproject.io/docs/job-specification/meta to explain this behaviour in more visible places.

Preview:
![image](https://user-images.githubusercontent.com/775380/134060040-b177842d-a498-41fd-b5cf-23cd4f83499d.png)

-----------

![image](https://user-images.githubusercontent.com/775380/134060056-357ae857-b4ff-4597-99aa-d33c715dc4dc.png)
