### PR TITLE
fix panic when Connect mesh gateway doesn't have a proxy block

### DIFF
--- a/.changelog/11257.txt
+++ b/.changelog/11257.txt
@@ -1,3 +1,3 @@
-```release-note:bug
+```release-note:security
 consul/connect: Fixed a bug causing the Nomad agent to panic if a mesh gateway was registered without a `proxy` block.
 ```

--- a/.changelog/11257.txt
+++ b/.changelog/11257.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul/connect: Fixed a bug causing the Nomad agent to panic if a mesh gateway was registered without a `proxy` block.
+```

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -1100,26 +1100,32 @@ func (c *ServiceClient) serviceRegs(ops *operations, service *structs.Service, w
 		kind = api.ServiceKindIngressGateway
 	case service.Connect.IsTerminating():
 		kind = api.ServiceKindTerminatingGateway
-		// set the default port if bridge / default listener set
-		if defaultBind, exists := service.Connect.Gateway.Proxy.EnvoyGatewayBindAddresses["default"]; exists {
-			portLabel := envoy.PortLabel(structs.ConnectTerminatingPrefix, service.Name, "")
-			if dynPort, ok := workload.Ports.Get(portLabel); ok {
-				defaultBind.Port = dynPort.Value
+
+		if proxy := service.Connect.Gateway.Proxy; proxy != nil {
+			// set the default port if bridge / default listener set
+			if defaultBind, exists := proxy.EnvoyGatewayBindAddresses["default"]; exists {
+				portLabel := envoy.PortLabel(structs.ConnectTerminatingPrefix, service.Name, "")
+				if dynPort, ok := workload.Ports.Get(portLabel); ok {
+					defaultBind.Port = dynPort.Value
+				}
 			}
 		}
 	case service.Connect.IsMesh():
 		kind = api.ServiceKindMeshGateway
-		// wan uses the service port label, which is typically on a discrete host_network
-		if wanBind, exists := service.Connect.Gateway.Proxy.EnvoyGatewayBindAddresses["wan"]; exists {
-			if wanPort, ok := workload.Ports.Get(service.PortLabel); ok {
-				wanBind.Port = wanPort.Value
+
+		if proxy := service.Connect.Gateway.Proxy; proxy != nil {
+			// wan uses the service port label, which is typically on a discrete host_network
+			if wanBind, exists := proxy.EnvoyGatewayBindAddresses["wan"]; exists {
+				if wanPort, ok := workload.Ports.Get(service.PortLabel); ok {
+					wanBind.Port = wanPort.Value
+				}
 			}
-		}
-		// lan uses a nomad generated dynamic port on the default network
-		if lanBind, exists := service.Connect.Gateway.Proxy.EnvoyGatewayBindAddresses["lan"]; exists {
-			portLabel := envoy.PortLabel(structs.ConnectMeshPrefix, service.Name, "lan")
-			if dynPort, ok := workload.Ports.Get(portLabel); ok {
-				lanBind.Port = dynPort.Value
+			// lan uses a nomad generated dynamic port on the default network
+			if lanBind, exists := proxy.EnvoyGatewayBindAddresses["lan"]; exists {
+				portLabel := envoy.PortLabel(structs.ConnectMeshPrefix, service.Name, "lan")
+				if dynPort, ok := workload.Ports.Get(portLabel); ok {
+					lanBind.Port = dynPort.Value
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When a `gateway -> mesh` block is set in a service without a `proxy` block, Nomad is expected to generate a default proxy configuration. This was being done when the group network mode was `bridge`, but not when it was `host`, even though that is a [supported option](https://www.nomadproject.io/docs/job-specification/gateway#gateway-with-host-networking). 

Without the proxy configuration, Nomad would panic when trying to generate the Consul API request to register the service.

This PR generates the proxy configuration regardless of the network mode. When in `bridge`, the previous behaviour is preserved. In `host`, no special configuration is done, so the default Consul behaviour is used.

Closes #11243 