### PR TITLE
debug: Improve namespace and region support

### DIFF
--- a/.changelog/11269.txt
+++ b/.changelog/11269.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Improve debug namespace and region support
+```

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -387,7 +387,7 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 	c.writeJSON("version", "members.json", members, err)
 
 	// Filter for servers matching criteria
-	c.serverIDs, err = parseMembers(members, serverIDs, c.region)
+	c.serverIDs, err = filterServerMembers(members, serverIDs, c.region)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to parse server list; err: %v", err))
 		return 1
@@ -1064,10 +1064,8 @@ func TarCZF(archive string, src, target string) error {
 	})
 }
 
-// parseMembers returns a slice of server member names matching the search criteria
-func parseMembers(serverMembers *api.ServerMembers, serverIDs string, region string) (membersFound []string, err error) {
-	prefixes := stringToSlice(serverIDs)
-
+// filterServerMembers returns a slice of server member names matching the search criteria
+func filterServerMembers(serverMembers *api.ServerMembers, serverIDs string, region string) (membersFound []string, err error) {
 	if serverMembers.Members == nil {
 		return nil, fmt.Errorf("Failed to parse server members, members==nil")
 	}

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -329,7 +329,7 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 	nodeLookupFailCount := 0
 	nodeCaptureCount := 0
 
-	for _, id := range argNodes(nodeIDs) {
+	for _, id := range stringToSlice(nodeIDs) {
 		if id == "all" {
 			// Capture from all nodes using empty prefix filter
 			id = ""
@@ -390,7 +390,7 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 			c.serverIDs = append(c.serverIDs, member.Name)
 		}
 	} else {
-		c.serverIDs = append(c.serverIDs, argNodes(serverIDs)...)
+		c.serverIDs = append(c.serverIDs, stringToSlice(serverIDs)...)
 	}
 
 	serversFound := 0
@@ -1055,8 +1055,9 @@ func TarCZF(archive string, src, target string) error {
 	})
 }
 
-// argNodes splits node ids from the command line by ","
-func argNodes(input string) []string {
+// stringToSlice splits CSV string into slice, trims whitespace, and prunes
+// empty values
+func stringToSlice(input string) []string {
 	ns := strings.Split(input, ",")
 	var out []string
 	for _, n := range ns {

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1101,8 +1101,8 @@ func filterServerMembers(serverMembers *api.ServerMembers, serverIDs string, reg
 	return membersFound, nil
 }
 
-// stringToSlice splits CSV string into slice, trims whitespace, and prunes
-// empty values
+// stringToSlice splits comma-separated input string into slice, trims
+// whitespace, and prunes empty values
 func stringToSlice(input string) []string {
 	ns := strings.Split(input, ",")
 	var out []string

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1092,8 +1092,8 @@ func filterServerMembers(serverMembers *api.ServerMembers, serverIDs string, reg
 			continue
 		}
 
-		// Include member if name matches any prefix
-		if helper.SliceStringContainsPrefix(prefixes, member.Name) {
+		// Include member if name matches any prefix from serverIDs
+		if helper.StringHasPrefixInSlice(member.Name, prefixes) {
 			membersFound = append(membersFound, member.Name)
 		}
 	}

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -470,6 +470,13 @@ func (c *OperatorDebugCommand) collect(client *api.Client) error {
 	self, err := client.Agent().Self()
 	c.writeJSON(dir, "agent-self.json", self, err)
 
+	var qo *api.QueryOptions
+	namespaces, _, err := client.Namespaces().List(qo)
+	c.writeJSON(dir, "namespaces.json", namespaces, err)
+
+	regions, err := client.Regions().List()
+	c.writeJSON(dir, "regions.json", regions, err)
+
 	// Fetch data directly from consul and vault. Ignore errors
 	var consul, vault string
 

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -412,6 +412,8 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 	// Display general info about the capture
 	c.Ui.Output("Starting debugger...")
 	c.Ui.Output("")
+	c.Ui.Output(fmt.Sprintf("           Region: %s", c.region))
+	c.Ui.Output(fmt.Sprintf("        Namespace: %s", c.namespace))
 	c.Ui.Output(fmt.Sprintf("          Servers: (%d/%d) %v", serverCaptureCount, serversFound, c.serverIDs))
 	c.Ui.Output(fmt.Sprintf("          Clients: (%d/%d) %v", nodeCaptureCount, nodesFound, c.nodeIDs))
 	if nodeCaptureCount > 0 && nodeCaptureCount == c.maxNodes {

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -225,7 +225,7 @@ func TestDebug_ClientToServer_Region(t *testing.T) {
 	var cases = testCases{
 		// Good
 		{
-			name:         "testAgent api server",
+			name:         "region - testAgent api server",
 			args:         []string{"-address", url, "-region", "testregion", "-duration", "250ms", "-interval", "250ms", "-server-id", "all", "-node-id", "all"},
 			expectedCode: 0,
 			expectedOutputs: []string{
@@ -236,13 +236,13 @@ func TestDebug_ClientToServer_Region(t *testing.T) {
 			},
 		},
 		{
-			name:            "server address",
+			name:            "region - erver address",
 			args:            []string{"-address", addrServer, "-region", "testregion", "-duration", "250ms", "-interval", "250ms", "-server-id", "all", "-node-id", "all"},
 			expectedCode:    0,
 			expectedOutputs: []string{"Created debug archive"},
 		},
 		{
-			name:            "client1 address - verify no SIGSEGV panic",
+			name:            "region - client1 address - verify no SIGSEGV panic",
 			args:            []string{"-address", addrClient1, "-region", "testregion", "-duration", "250ms", "-interval", "250ms", "-server-id", "all", "-node-id", "all"},
 			expectedCode:    0,
 			expectedOutputs: []string{"Created debug archive"},

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -78,7 +78,8 @@ func TestDebug_NodeClass(t *testing.T) {
 
 	// Wait for client1 to connect
 	client1NodeID := client1.Agent.Client().NodeID()
-	testutil.WaitForClient(t, srv.Agent.RPC, client1NodeID)
+	client1Region := client1.Agent.Client().Region()
+	testutil.WaitForClient(t, srv.Agent.RPC, client1NodeID, client1Region)
 	t.Logf("[TEST] Client1 ready, id: %s", client1NodeID)
 
 	// Setup client 2 (nodeclass = clientb)
@@ -96,7 +97,8 @@ func TestDebug_NodeClass(t *testing.T) {
 
 	// Wait for client2 to connect
 	client2NodeID := client2.Agent.Client().NodeID()
-	testutil.WaitForClient(t, srv.Agent.RPC, client2NodeID)
+	client2Region := client2.Agent.Client().Region()
+	testutil.WaitForClient(t, srv.Agent.RPC, client2NodeID, client2Region)
 	t.Logf("[TEST] Client2 ready, id: %s", client2NodeID)
 
 	// Setup client 3 (nodeclass = clienta)
@@ -112,7 +114,8 @@ func TestDebug_NodeClass(t *testing.T) {
 
 	// Wait for client3 to connect
 	client3NodeID := client3.Agent.Client().NodeID()
-	testutil.WaitForClient(t, srv.Agent.RPC, client3NodeID)
+	client3Region := client3.Agent.Client().Region()
+	testutil.WaitForClient(t, srv.Agent.RPC, client3NodeID, client3Region)
 	t.Logf("[TEST] Client3 ready, id: %s", client3NodeID)
 
 	// Setup test cases
@@ -174,7 +177,8 @@ func TestDebug_ClientToServer(t *testing.T) {
 
 	// Wait for client 1 to connect
 	client1NodeID := client1.Agent.Client().NodeID()
-	testutil.WaitForClient(t, srv.Agent.RPC, client1NodeID)
+	client1Region := client1.Agent.Client().Region()
+	testutil.WaitForClient(t, srv.Agent.RPC, client1NodeID, client1Region)
 	t.Logf("[TEST] Client1 ready, id: %s", client1NodeID)
 
 	// Get API addresses

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -492,11 +492,12 @@ func TestDebug_StringToSlice(t *testing.T) {
 		{input: ",,", expected: []string(nil)},
 		{input: "", expected: []string(nil)},
 		{input: "foo, bar", expected: []string{"foo", "bar"}},
+		{input: "  foo, bar ", expected: []string{"foo", "bar"}},
+		{input: "foo,,bar", expected: []string{"foo", "bar"}},
 	}
 	for _, tc := range cases {
 		out := stringToSlice(tc.input)
 		require.Equal(t, tc.expected, out)
-		require.Equal(t, true, helper.CompareSliceSetString(tc.expected, out))
 	}
 }
 

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -73,14 +73,15 @@ func TestDebug_NodeClass(t *testing.T) {
 	}
 
 	// Start client 1
-	client1 := agent.NewTestAgent(t, "client1", agentConfFunc1)
-	defer client1.Shutdown()
+	agent1 := agent.NewTestAgent(t, "client1", agentConfFunc1)
+	defer agent1.Shutdown()
 
 	// Wait for client1 to connect
-	client1NodeID := client1.Agent.Client().NodeID()
-	client1Region := client1.Agent.Client().Region()
+	client1 := agent1.Agent.Client()
+	client1NodeID := client1.NodeID()
+	client1Region := client1.Region()
 	testutil.WaitForClient(t, srv.Agent.RPC, client1NodeID, client1Region)
-	t.Logf("[TEST] Client1 ready, id: %s", client1NodeID)
+	t.Logf("[TEST] Client1 ready, id: %s, region: %s", client1NodeID, client1Region)
 
 	// Setup client 2 (nodeclass = clientb)
 	agentConfFunc2 := func(c *agent.Config) {
@@ -92,14 +93,15 @@ func TestDebug_NodeClass(t *testing.T) {
 	}
 
 	// Start client 2
-	client2 := agent.NewTestAgent(t, "client2", agentConfFunc2)
-	defer client2.Shutdown()
+	agent2 := agent.NewTestAgent(t, "client2", agentConfFunc2)
+	defer agent2.Shutdown()
 
 	// Wait for client2 to connect
-	client2NodeID := client2.Agent.Client().NodeID()
-	client2Region := client2.Agent.Client().Region()
+	client2 := agent2.Agent.Client()
+	client2NodeID := client2.NodeID()
+	client2Region := client2.Region()
 	testutil.WaitForClient(t, srv.Agent.RPC, client2NodeID, client2Region)
-	t.Logf("[TEST] Client2 ready, id: %s", client2NodeID)
+	t.Logf("[TEST] Client2 ready, id: %s, region: %s", client2NodeID, client2Region)
 
 	// Setup client 3 (nodeclass = clienta)
 	agentConfFunc3 := func(c *agent.Config) {
@@ -109,14 +111,15 @@ func TestDebug_NodeClass(t *testing.T) {
 	}
 
 	// Start client 3
-	client3 := agent.NewTestAgent(t, "client3", agentConfFunc3)
-	defer client3.Shutdown()
+	agent3 := agent.NewTestAgent(t, "client3", agentConfFunc3)
+	defer agent3.Shutdown()
 
 	// Wait for client3 to connect
-	client3NodeID := client3.Agent.Client().NodeID()
-	client3Region := client3.Agent.Client().Region()
+	client3 := agent3.Agent.Client()
+	client3NodeID := client3.NodeID()
+	client3Region := client3.Region()
 	testutil.WaitForClient(t, srv.Agent.RPC, client3NodeID, client3Region)
-	t.Logf("[TEST] Client3 ready, id: %s", client3NodeID)
+	t.Logf("[TEST] Client3 ready, id: %s, region: %s", client3NodeID, client3Region)
 
 	// Setup test cases
 	cases := testCases{
@@ -172,18 +175,19 @@ func TestDebug_ClientToServer(t *testing.T) {
 	}
 
 	// Start client 1
-	client1 := agent.NewTestAgent(t, "client1", agentConfFunc1)
-	defer client1.Shutdown()
+	agent1 := agent.NewTestAgent(t, "client1", agentConfFunc1)
+	defer agent1.Shutdown()
 
 	// Wait for client 1 to connect
-	client1NodeID := client1.Agent.Client().NodeID()
-	client1Region := client1.Agent.Client().Region()
+	client1 := agent1.Agent.Client()
+	client1NodeID := client1.NodeID()
+	client1Region := client1.Region()
 	testutil.WaitForClient(t, srv.Agent.RPC, client1NodeID, client1Region)
-	t.Logf("[TEST] Client1 ready, id: %s", client1NodeID)
+	t.Logf("[TEST] Client1 ready, id: %s, region: %s", client1NodeID, client1Region)
 
 	// Get API addresses
 	addrServer := srv.HTTPAddr()
-	addrClient1 := client1.HTTPAddr()
+	addrClient1 := agent1.HTTPAddr()
 
 	t.Logf("[TEST] testAgent api address: %s", url)
 	t.Logf("[TEST] Server    api address: %s", addrServer)

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -193,23 +193,33 @@ func TestDebug_ClientToServer_Region(t *testing.T) {
 			args:         []string{"-address", url, "-region", region, "-duration", "250ms", "-interval", "250ms", "-server-id", "all", "-node-id", "all"},
 			expectedCode: 0,
 			expectedOutputs: []string{
-				"Region: testregion\n",
+				"Region: " + region + "\n",
 				"Servers: (1/1)",
 				"Clients: (1/1)",
 				"Created debug archive",
 			},
 		},
 		{
-			name:            "region - server address",
-			args:            []string{"-address", addrServer, "-region", region, "-duration", "250ms", "-interval", "250ms", "-server-id", "all", "-node-id", "all"},
-			expectedCode:    0,
-			expectedOutputs: []string{"Created debug archive"},
+			name:         "region - server address",
+			args:         []string{"-address", addrServer, "-region", region, "-duration", "250ms", "-interval", "250ms", "-server-id", "all", "-node-id", "all"},
+			expectedCode: 0,
+			expectedOutputs: []string{
+				"Region: " + region + "\n",
+				"Servers: (1/1)",
+				"Clients: (1/1)",
+				"Created debug archive",
+			},
 		},
 		{
-			name:            "region - client1 address - verify no SIGSEGV panic",
-			args:            []string{"-address", addrClient1, "-region", region, "-duration", "250ms", "-interval", "250ms", "-server-id", "all", "-node-id", "all"},
-			expectedCode:    0,
-			expectedOutputs: []string{"Created debug archive"},
+			name:         "region - client1 address - verify no SIGSEGV panic",
+			args:         []string{"-address", addrClient1, "-region", region, "-duration", "250ms", "-interval", "250ms", "-server-id", "all", "-node-id", "all"},
+			expectedCode: 0,
+			expectedOutputs: []string{
+				"Region: " + region + "\n",
+				"Servers: (1/1)",
+				"Clients: (1/1)",
+				"Created debug archive",
+			},
 		},
 
 		// Bad

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -432,15 +432,26 @@ func TestDebug_Fail_Pprof(t *testing.T) {
 	require.Contains(t, ui.OutputWriter.String(), "Created debug archive")   // Archive should be generated anyway
 }
 
-func TestDebug_Utils(t *testing.T) {
+func TestDebug_StringToSlice(t *testing.T) {
 	t.Parallel()
 
-	xs := argNodes("foo, bar")
-	require.Equal(t, []string{"foo", "bar"}, xs)
+	cases := []struct {
+		input    string
+		expected []string
+	}{
+		{input: ",,", expected: []string(nil)},
+		{input: "", expected: []string(nil)},
+		{input: "foo, bar", expected: []string{"foo", "bar"}},
+	}
+	for _, tc := range cases {
+		out := stringToSlice(tc.input)
+		require.Equal(t, tc.expected, out)
+		require.Equal(t, true, helper.CompareSliceSetString(tc.expected, out))
+	}
+}
 
-	xs = argNodes("")
-	require.Len(t, xs, 0)
-	require.Empty(t, xs)
+func TestDebug_External(t *testing.T) {
+	t.Parallel()
 
 	// address calculation honors CONSUL_HTTP_SSL
 	// ssl: true - Correct alignment

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -67,7 +67,6 @@ func newClientAgentConfigFunc(region string, nodeClass string, srvRPCAddr string
 func TestDebug_NodeClass(t *testing.T) {
 	// Start test server and API client
 	srv, _, url := testServer(t, false, nil)
-	defer srv.Shutdown()
 
 	// Wait for leadership to establish
 	testutil.WaitForLeader(t, srv.Agent.RPC)
@@ -116,7 +115,6 @@ func TestDebug_NodeClass(t *testing.T) {
 func TestDebug_ClientToServer(t *testing.T) {
 	// Start test server and API client
 	srv, _, url := testServer(t, false, nil)
-	defer srv.Shutdown()
 
 	// Wait for leadership to establish
 	testutil.WaitForLeader(t, srv.Agent.RPC)
@@ -168,8 +166,6 @@ func TestDebug_ClientToServer_Region(t *testing.T) {
 	srv, _, url := testServer(t, false, func(c *agent.Config) {
 		c.Region = region
 	})
-
-	defer srv.Shutdown()
 
 	// Wait for leadership to establish
 	testutil.WaitForLeader(t, srv.Agent.RPC)
@@ -230,7 +226,6 @@ func TestDebug_ClientToServer_Region(t *testing.T) {
 
 func TestDebug_SingleServer(t *testing.T) {
 	srv, _, url := testServer(t, false, nil)
-	defer srv.Shutdown()
 	testutil.WaitForLeader(t, srv.Agent.RPC)
 
 	var cases = testCases{
@@ -263,7 +258,6 @@ func TestDebug_SingleServer(t *testing.T) {
 
 func TestDebug_Failures(t *testing.T) {
 	srv, _, url := testServer(t, false, nil)
-	defer srv.Shutdown()
 	testutil.WaitForLeader(t, srv.Agent.RPC)
 
 	var cases = testCases{
@@ -311,7 +305,6 @@ func TestDebug_Failures(t *testing.T) {
 func TestDebug_Bad_CSIPlugin_Names(t *testing.T) {
 	// Start test server and API client
 	srv, _, url := testServer(t, false, nil)
-	defer srv.Shutdown()
 
 	// Wait for leadership to establish
 	testutil.WaitForLeader(t, srv.Agent.RPC)
@@ -352,7 +345,6 @@ func TestDebug_Bad_CSIPlugin_Names(t *testing.T) {
 
 func TestDebug_CapturedFiles(t *testing.T) {
 	srv, _, url := testServer(t, false, nil)
-	defer srv.Shutdown()
 	testutil.WaitForLeader(t, srv.Agent.RPC)
 
 	ui := cli.NewMockUi()
@@ -431,7 +423,6 @@ func TestDebug_Fail_Pprof(t *testing.T) {
 
 	// Start test server and API client
 	srv, _, url := testServer(t, false, agentConfFunc)
-	defer srv.Shutdown()
 
 	// Wait for leadership to establish
 	testutil.WaitForLeader(t, srv.Agent.RPC)
@@ -440,7 +431,7 @@ func TestDebug_Fail_Pprof(t *testing.T) {
 	ui := cli.NewMockUi()
 	cmd := &OperatorDebugCommand{Meta: Meta{Ui: ui}}
 
-	// Debug on client - node class = "clienta"
+	// Debug on server with endpoints disabled
 	code := cmd.Run([]string{"-address", url, "-duration", "250ms", "-interval", "250ms", "-server-id", "all"})
 
 	assert.Equal(t, 0, code) // Pprof failure isn't fatal

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -66,9 +66,7 @@ func TestDebug_NodeClass(t *testing.T) {
 	// Setup client 1 (nodeclass = clienta)
 	agentConfFunc1 := func(c *agent.Config) {
 		c.Region = "global"
-		c.Server.Enabled = false
 		c.Client.NodeClass = "clienta"
-		c.Client.Enabled = true
 		c.Client.Servers = []string{srvRPCAddr}
 	}
 
@@ -80,9 +78,7 @@ func TestDebug_NodeClass(t *testing.T) {
 	// Setup client 2 (nodeclass = clientb)
 	agentConfFunc2 := func(c *agent.Config) {
 		c.Region = "global"
-		c.Server.Enabled = false
 		c.Client.NodeClass = "clientb"
-		c.Client.Enabled = true
 		c.Client.Servers = []string{srvRPCAddr}
 	}
 
@@ -93,7 +89,6 @@ func TestDebug_NodeClass(t *testing.T) {
 
 	// Setup client 3 (nodeclass = clienta)
 	agentConfFunc3 := func(c *agent.Config) {
-		c.Server.Enabled = false
 		c.Client.NodeClass = "clienta"
 		c.Client.Servers = []string{srvRPCAddr}
 	}
@@ -149,10 +144,7 @@ func TestDebug_ClientToServer(t *testing.T) {
 
 	// Setup client 1 (nodeclass = clienta)
 	agentConfFunc1 := func(c *agent.Config) {
-		c.Region = "global"
-		c.Server.Enabled = false
 		c.Client.NodeClass = "clienta"
-		c.Client.Enabled = true
 		c.Client.Servers = []string{srvRPCAddr}
 	}
 
@@ -195,12 +187,11 @@ func TestDebug_ClientToServer(t *testing.T) {
 }
 
 func TestDebug_ClientToServer_Region(t *testing.T) {
-	agentConfFunc := func(c *agent.Config) {
-		c.Region = "testregion"
-	}
-
 	// Start test server and API client
-	srv, _, url := testServer(t, false, agentConfFunc)
+	srv, _, url := testServer(t, false, func(c *agent.Config) {
+		c.Region = "testregion"
+	})
+
 	defer srv.Shutdown()
 
 	// Wait for leadership to establish
@@ -213,9 +204,7 @@ func TestDebug_ClientToServer_Region(t *testing.T) {
 	// Setup client 1 (nodeclass = clienta)
 	agentConfFunc1 := func(c *agent.Config) {
 		c.Region = "testregion"
-		c.Server.Enabled = false
 		c.Client.NodeClass = "clienta"
-		c.Client.Enabled = true
 		c.Client.Servers = []string{srvRPCAddr}
 	}
 

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -75,13 +75,7 @@ func TestDebug_NodeClass(t *testing.T) {
 	// Start client 1
 	agent1 := agent.NewTestAgent(t, "client1", agentConfFunc1)
 	defer agent1.Shutdown()
-
-	// Wait for client1 to connect
-	client1 := agent1.Agent.Client()
-	client1NodeID := client1.NodeID()
-	client1Region := client1.Region()
-	testutil.WaitForClient(t, srv.Agent.RPC, client1NodeID, client1Region)
-	t.Logf("[TEST] Client1 ready, id: %s, region: %s", client1NodeID, client1Region)
+	testutil.WaitForClient(t, srv.Agent.RPC, agent1.Agent.Client())
 
 	// Setup client 2 (nodeclass = clientb)
 	agentConfFunc2 := func(c *agent.Config) {
@@ -95,13 +89,7 @@ func TestDebug_NodeClass(t *testing.T) {
 	// Start client 2
 	agent2 := agent.NewTestAgent(t, "client2", agentConfFunc2)
 	defer agent2.Shutdown()
-
-	// Wait for client2 to connect
-	client2 := agent2.Agent.Client()
-	client2NodeID := client2.NodeID()
-	client2Region := client2.Region()
-	testutil.WaitForClient(t, srv.Agent.RPC, client2NodeID, client2Region)
-	t.Logf("[TEST] Client2 ready, id: %s, region: %s", client2NodeID, client2Region)
+	testutil.WaitForClient(t, srv.Agent.RPC, agent2.Agent.Client())
 
 	// Setup client 3 (nodeclass = clienta)
 	agentConfFunc3 := func(c *agent.Config) {
@@ -113,13 +101,7 @@ func TestDebug_NodeClass(t *testing.T) {
 	// Start client 3
 	agent3 := agent.NewTestAgent(t, "client3", agentConfFunc3)
 	defer agent3.Shutdown()
-
-	// Wait for client3 to connect
-	client3 := agent3.Agent.Client()
-	client3NodeID := client3.NodeID()
-	client3Region := client3.Region()
-	testutil.WaitForClient(t, srv.Agent.RPC, client3NodeID, client3Region)
-	t.Logf("[TEST] Client3 ready, id: %s, region: %s", client3NodeID, client3Region)
+	testutil.WaitForClient(t, srv.Agent.RPC, agent3.Agent.Client())
 
 	// Setup test cases
 	cases := testCases{
@@ -177,13 +159,7 @@ func TestDebug_ClientToServer(t *testing.T) {
 	// Start client 1
 	agent1 := agent.NewTestAgent(t, "client1", agentConfFunc1)
 	defer agent1.Shutdown()
-
-	// Wait for client 1 to connect
-	client1 := agent1.Agent.Client()
-	client1NodeID := client1.NodeID()
-	client1Region := client1.Region()
-	testutil.WaitForClient(t, srv.Agent.RPC, client1NodeID, client1Region)
-	t.Logf("[TEST] Client1 ready, id: %s, region: %s", client1NodeID, client1Region)
+	testutil.WaitForClient(t, srv.Agent.RPC, agent1.Agent.Client())
 
 	// Get API addresses
 	addrServer := srv.HTTPAddr()
@@ -246,12 +222,7 @@ func TestDebug_ClientToServer_Region(t *testing.T) {
 	// Start client 1
 	agent1 := agent.NewTestAgent(t, "client1", agentConfFunc1)
 	defer agent1.Shutdown()
-
-	// Wait for client 1 to connect
-	client1NodeID := agent1.Agent.Client().NodeID()
-	client1Region := agent1.Agent.Client().Region()
-	testutil.WaitForClient(t, srv.Agent.RPC, client1NodeID, client1Region)
-	t.Logf("[TEST] Client1 ready, id: %s, region: %s", client1NodeID, client1Region)
+	testutil.WaitForClient(t, srv.Agent.RPC, agent1.Agent.Client())
 
 	// Get API addresses
 	addrServer := srv.HTTPAddr()

--- a/command/util_test.go
+++ b/command/util_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/nomad/helper"
-	// "github.com/hashicorp/nomad/testutil"
+	"github.com/hashicorp/nomad/testutil"
 )
 
 func testServer(t *testing.T, runClient bool, cb func(*agent.Config)) (*agent.TestAgent, *api.Client, string) {
@@ -36,8 +36,8 @@ func testClient(t *testing.T, name string, cb func(*agent.Config)) (*agent.TestA
 	t.Cleanup(func() { a.Shutdown() })
 
 	c := a.Client()
-	// t.Logf("[TEST] Waiting for client %s to join server(s) %s", name, a.GetConfig().Client.Servers)
-	// testutil.WaitForClient(t, a.Agent.RPC, a.Agent.Client())
+	t.Logf("[TEST] Waiting for client %s to join server(s) %s", name, a.GetConfig().Client.Servers)
+	testutil.WaitForClient(t, a.Agent.RPC, a.Agent.Client().NodeID(), a.Agent.Client().Region())
 
 	return a, c, a.HTTPAddr()
 }

--- a/command/util_test.go
+++ b/command/util_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/nomad/helper"
-	"github.com/hashicorp/nomad/testutil"
+	// "github.com/hashicorp/nomad/testutil"
 )
 
 func testServer(t *testing.T, runClient bool, cb func(*agent.Config)) (*agent.TestAgent, *api.Client, string) {
@@ -28,7 +28,6 @@ func testServer(t *testing.T, runClient bool, cb func(*agent.Config)) (*agent.Te
 // cleanup after the test is complete.
 func testClient(t *testing.T, name string, cb func(*agent.Config)) (*agent.TestAgent, *api.Client, string) {
 	t.Logf("[TEST] Starting client agent %s", name)
-	// a := agent.NewTestAgent(t, name, cb)
 	a := agent.NewTestAgent(t, name, func(config *agent.Config) {
 		if cb != nil {
 			cb(config)
@@ -37,8 +36,8 @@ func testClient(t *testing.T, name string, cb func(*agent.Config)) (*agent.TestA
 	t.Cleanup(func() { a.Shutdown() })
 
 	c := a.Client()
-	t.Logf("[TEST] Waiting for client %s to join server(s) %s", name, a.GetConfig().Client.Servers)
-	testutil.WaitForClient(t, a.Agent.RPC, a.Agent.Client())
+	// t.Logf("[TEST] Waiting for client %s to join server(s) %s", name, a.GetConfig().Client.Servers)
+	// testutil.WaitForClient(t, a.Agent.RPC, a.Agent.Client())
 
 	return a, c, a.HTTPAddr()
 }

--- a/command/util_test.go
+++ b/command/util_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/testutil"
 )
 
 func testServer(t *testing.T, runClient bool, cb func(*agent.Config)) (*agent.TestAgent, *api.Client, string) {
@@ -20,6 +21,25 @@ func testServer(t *testing.T, runClient bool, cb func(*agent.Config)) (*agent.Te
 	t.Cleanup(func() { a.Shutdown() })
 
 	c := a.Client()
+	return a, c, a.HTTPAddr()
+}
+
+// testClient starts a new test client, blocks until it joins, and performs
+// cleanup after the test is complete.
+func testClient(t *testing.T, name string, cb func(*agent.Config)) (*agent.TestAgent, *api.Client, string) {
+	t.Logf("[TEST] Starting client agent %s", name)
+	// a := agent.NewTestAgent(t, name, cb)
+	a := agent.NewTestAgent(t, name, func(config *agent.Config) {
+		if cb != nil {
+			cb(config)
+		}
+	})
+	t.Cleanup(func() { a.Shutdown() })
+
+	c := a.Client()
+	t.Logf("[TEST] Waiting for client %s to join server(s) %s", name, a.GetConfig().Client.Servers)
+	testutil.WaitForClient(t, a.Agent.RPC, a.Agent.Client())
+
 	return a, c, a.HTTPAddr()
 }
 

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -197,9 +197,19 @@ func SliceStringContains(list []string, item string) bool {
 	return false
 }
 
-// SliceStringContainsPrefix returns true if any string in list matches prefix
-func SliceStringContainsPrefix(list []string, prefix string) bool {
+// SliceStringHasPrefix returns true if any string in list starts with prefix
+func SliceStringHasPrefix(list []string, prefix string) bool {
 	for _, s := range list {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// StringHasPrefixInSlice returns true if string starts with any prefix in list
+func StringHasPrefixInSlice(s string, prefixes []string) bool {
+	for _, prefix := range prefixes {
 		if strings.HasPrefix(s, prefix) {
 			return true
 		}

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -197,6 +197,16 @@ func SliceStringContains(list []string, item string) bool {
 	return false
 }
 
+// SliceStringContainsPrefix returns true if any string in list matches prefix
+func SliceStringContainsPrefix(list []string, prefix string) bool {
+	for _, s := range list {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 func SliceSetDisjoint(first, second []string) (bool, []string) {
 	contained := make(map[string]struct{}, len(first))
 	for _, k := range first {

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -34,6 +34,16 @@ func TestSliceStringContains(t *testing.T) {
 	require.False(t, SliceStringContains(list, "d"))
 }
 
+func TestSliceStringContainsPrefix(t *testing.T) {
+	list := []string{"abc", "def", "abcdef", "definitely", "most definitely"}
+	require.True(t, SliceStringContainsPrefix(list, "a"))
+	require.False(t, SliceStringContainsPrefix(list, "b"))
+	require.False(t, SliceStringContainsPrefix(list, "c"))
+	require.True(t, SliceStringContainsPrefix(list, "d"))
+	require.True(t, SliceStringContainsPrefix(list, "mos"))
+	require.True(t, SliceStringContainsPrefix(list, "def"))
+}
+
 func TestCompareTimePtrs(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		a := (*time.Duration)(nil)

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -34,14 +34,25 @@ func TestSliceStringContains(t *testing.T) {
 	require.False(t, SliceStringContains(list, "d"))
 }
 
-func TestSliceStringContainsPrefix(t *testing.T) {
+func TestSliceStringHasPrefix(t *testing.T) {
 	list := []string{"abc", "def", "abcdef", "definitely", "most definitely"}
-	require.True(t, SliceStringContainsPrefix(list, "a"))
-	require.False(t, SliceStringContainsPrefix(list, "b"))
-	require.False(t, SliceStringContainsPrefix(list, "c"))
-	require.True(t, SliceStringContainsPrefix(list, "d"))
-	require.True(t, SliceStringContainsPrefix(list, "mos"))
-	require.True(t, SliceStringContainsPrefix(list, "def"))
+	require.True(t, SliceStringHasPrefix(list, "a"))
+	require.False(t, SliceStringHasPrefix(list, "b"))
+	require.False(t, SliceStringHasPrefix(list, "c"))
+	require.True(t, SliceStringHasPrefix(list, "d"))
+	require.True(t, SliceStringHasPrefix(list, "mos"))
+	require.True(t, SliceStringHasPrefix(list, "def"))
+}
+
+func TestStringHasPrefixInSlice(t *testing.T) {
+	prefixes := []string{"a", "b", "c", "definitely", "most definitely"}
+	require.True(t, StringHasPrefixInSlice("alpha", prefixes))
+	require.True(t, StringHasPrefixInSlice("bravo", prefixes))
+	require.True(t, StringHasPrefixInSlice("charlie", prefixes))
+	require.False(t, StringHasPrefixInSlice("delta", prefixes))
+	require.True(t, StringHasPrefixInSlice("definitely", prefixes))
+	require.False(t, StringHasPrefixInSlice("most", prefixes))
+	require.True(t, StringHasPrefixInSlice("most definitely", prefixes))
 }
 
 func TestCompareTimePtrs(t *testing.T) {

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -35,24 +35,31 @@ func TestSliceStringContains(t *testing.T) {
 }
 
 func TestSliceStringHasPrefix(t *testing.T) {
-	list := []string{"abc", "def", "abcdef", "definitely", "most definitely"}
+	list := []string{"alpha", "bravo", "charlie", "definitely", "most definitely"}
+	// At least one string in the slice above starts with the following test prefix strings
 	require.True(t, SliceStringHasPrefix(list, "a"))
-	require.False(t, SliceStringHasPrefix(list, "b"))
-	require.False(t, SliceStringHasPrefix(list, "c"))
+	require.True(t, SliceStringHasPrefix(list, "b"))
+	require.True(t, SliceStringHasPrefix(list, "c"))
 	require.True(t, SliceStringHasPrefix(list, "d"))
 	require.True(t, SliceStringHasPrefix(list, "mos"))
 	require.True(t, SliceStringHasPrefix(list, "def"))
+	require.False(t, SliceStringHasPrefix(list, "delta"))
+
 }
 
 func TestStringHasPrefixInSlice(t *testing.T) {
 	prefixes := []string{"a", "b", "c", "definitely", "most definitely"}
+	// The following strings all start with at least one prefix in the slice above
 	require.True(t, StringHasPrefixInSlice("alpha", prefixes))
 	require.True(t, StringHasPrefixInSlice("bravo", prefixes))
 	require.True(t, StringHasPrefixInSlice("charlie", prefixes))
-	require.False(t, StringHasPrefixInSlice("delta", prefixes))
 	require.True(t, StringHasPrefixInSlice("definitely", prefixes))
-	require.False(t, StringHasPrefixInSlice("most", prefixes))
 	require.True(t, StringHasPrefixInSlice("most definitely", prefixes))
+
+	require.False(t, StringHasPrefixInSlice("mos", prefixes))
+	require.False(t, StringHasPrefixInSlice("def", prefixes))
+	require.False(t, StringHasPrefixInSlice("delta", prefixes))
+
 }
 
 func TestCompareTimePtrs(t *testing.T) {

--- a/nomad/client_agent_endpoint_test.go
+++ b/nomad/client_agent_endpoint_test.go
@@ -548,7 +548,7 @@ func TestAgentProfile_RemoteClient(t *testing.T) {
 	})
 	defer cleanupC()
 
-	testutil.WaitForClient(t, s2.RPC, c.NodeID())
+	testutil.WaitForClient(t, s2.RPC, c.NodeID(), c.Region())
 	testutil.WaitForResult(func() (bool, error) {
 		nodes := s2.connectedNodes()
 		return len(nodes) == 1, nil

--- a/nomad/client_agent_endpoint_test.go
+++ b/nomad/client_agent_endpoint_test.go
@@ -548,7 +548,7 @@ func TestAgentProfile_RemoteClient(t *testing.T) {
 	})
 	defer cleanupC()
 
-	testutil.WaitForClient(t, s2.RPC, c.NodeID(), c.Region())
+	testutil.WaitForClient(t, s2.RPC, c)
 	testutil.WaitForResult(func() (bool, error) {
 		nodes := s2.connectedNodes()
 		return len(nodes) == 1, nil

--- a/nomad/client_agent_endpoint_test.go
+++ b/nomad/client_agent_endpoint_test.go
@@ -548,7 +548,7 @@ func TestAgentProfile_RemoteClient(t *testing.T) {
 	})
 	defer cleanupC()
 
-	testutil.WaitForClient(t, s2.RPC, c)
+	testutil.WaitForClient(t, s2.RPC, c.NodeID(), c.Region())
 	testutil.WaitForResult(func() (bool, error) {
 		nodes := s2.connectedNodes()
 		return len(nodes) == 1, nil

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -115,13 +115,15 @@ func WaitForLeader(t testing.TB, rpc rpcFn) {
 // WaitForClient blocks until the client can be found
 func WaitForClient(t testing.TB, rpc rpcFn, client *client.Client) {
 	t.Helper()
+
+	region := client.Region()
 	if region == "" {
 		region = "global"
 	}
 	WaitForResult(func() (bool, error) {
 		req := structs.NodeSpecificRequest{
 			NodeID:       client.NodeID(),
-			QueryOptions: structs.QueryOptions{Region: client.Region()},
+			QueryOptions: structs.QueryOptions{Region: region},
 		}
 		var out structs.SingleNodeResponse
 
@@ -137,7 +139,7 @@ func WaitForClient(t testing.TB, rpc rpcFn, client *client.Client) {
 		t.Fatalf("failed to find node: %v", err)
 	})
 
-	t.Logf("[TEST] Client %s ready, id: %s, region: %s", client.GetConfig().Node.Name, client.NodeID(), client.Region())
+	t.Logf("[TEST] Client %s ready, id: %s, region: %s", client.GetConfig().Node.Name, client.NodeID(), region)
 }
 
 // WaitForVotingMembers blocks until autopilot promotes all server peers

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/nomad/client"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
@@ -113,16 +112,16 @@ func WaitForLeader(t testing.TB, rpc rpcFn) {
 }
 
 // WaitForClient blocks until the client can be found
-func WaitForClient(t testing.TB, rpc rpcFn, client *client.Client) {
+func WaitForClient(t testing.TB, rpc rpcFn, nodeID string, region string) {
+
 	t.Helper()
 
-	region := client.Region()
 	if region == "" {
 		region = "global"
 	}
 	WaitForResult(func() (bool, error) {
 		req := structs.NodeSpecificRequest{
-			NodeID:       client.NodeID(),
+			NodeID:       nodeID,
 			QueryOptions: structs.QueryOptions{Region: region},
 		}
 		var out structs.SingleNodeResponse
@@ -139,7 +138,7 @@ func WaitForClient(t testing.TB, rpc rpcFn, client *client.Client) {
 		t.Fatalf("failed to find node: %v", err)
 	})
 
-	t.Logf("[TEST] Client %s ready, id: %s, region: %s", client.GetConfig().Node.Name, client.NodeID(), region)
+	t.Logf("[TEST] Client for test %s ready, id: %s, region: %s", t.Name(), nodeID, region)
 }
 
 // WaitForVotingMembers blocks until autopilot promotes all server peers

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -112,12 +112,15 @@ func WaitForLeader(t testing.TB, rpc rpcFn) {
 }
 
 // WaitForClient blocks until the client can be found
-func WaitForClient(t testing.TB, rpc rpcFn, nodeID string) {
+func WaitForClient(t testing.TB, rpc rpcFn, nodeID string, region string) {
 	t.Helper()
+	if region == "" {
+		region = "global"
+	}
 	WaitForResult(func() (bool, error) {
 		req := structs.NodeSpecificRequest{
 			NodeID:       nodeID,
-			QueryOptions: structs.QueryOptions{Region: "global"},
+			QueryOptions: structs.QueryOptions{Region: region},
 		}
 		var out structs.SingleNodeResponse
 

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/nomad/client"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
@@ -112,15 +113,15 @@ func WaitForLeader(t testing.TB, rpc rpcFn) {
 }
 
 // WaitForClient blocks until the client can be found
-func WaitForClient(t testing.TB, rpc rpcFn, nodeID string, region string) {
+func WaitForClient(t testing.TB, rpc rpcFn, client *client.Client) {
 	t.Helper()
 	if region == "" {
 		region = "global"
 	}
 	WaitForResult(func() (bool, error) {
 		req := structs.NodeSpecificRequest{
-			NodeID:       nodeID,
-			QueryOptions: structs.QueryOptions{Region: region},
+			NodeID:       client.NodeID(),
+			QueryOptions: structs.QueryOptions{Region: client.Region()},
 		}
 		var out structs.SingleNodeResponse
 
@@ -135,6 +136,8 @@ func WaitForClient(t testing.TB, rpc rpcFn, nodeID string, region string) {
 	}, func(err error) {
 		t.Fatalf("failed to find node: %v", err)
 	})
+
+	t.Logf("[TEST] Client %s ready, id: %s, region: %s", client.GetConfig().Node.Name, client.NodeID(), client.Region())
 }
 
 // WaitForVotingMembers blocks until autopilot promotes all server peers


### PR DESCRIPTION
This PR provides additional insight into namespaces and regions known to the cluster.

* Add namespace/region filter to CLI output
* Add region filtering for servers
* Add namespaces.json and regions.json to cluster meta
* Add helper function to test for presence of string prefix in slice of strings
* Refactor tests to validate correct behavior