### PR TITLE
executor: suppress spurious log messages

### DIFF
--- a/.changelog/11273.txt
+++ b/.changelog/11273.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Removed spurious error log messages when tasks complete
+```

--- a/drivers/shared/executor/client.go
+++ b/drivers/shared/executor/client.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hashicorp/nomad/helper/pluginutils/grpcutils"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	dproto "github.com/hashicorp/nomad/plugins/drivers/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var _ Executor = (*grpcExecutorClient)(nil)
@@ -132,12 +134,14 @@ func (c *grpcExecutorClient) handleStats(ctx context.Context, stream proto.Execu
 			return
 		}
 
-		if err != nil {
-			if err != io.EOF {
-				c.logger.Error("error receiving stream from Stats executor RPC, closing stream", "error", err)
-			}
-
-			// End stream
+		if err == io.EOF ||
+			status.Code(err) == codes.Unavailable ||
+			status.Code(err) == codes.Canceled ||
+			err == context.Canceled {
+			c.logger.Trace("executor Stats stream closed", "error", err)
+			return
+		} else if err != nil {
+			c.logger.Warn("failed to receive Stats executor RPC stream, closing stream", "error", err)
 			return
 		}
 

--- a/drivers/shared/executor/client.go
+++ b/drivers/shared/executor/client.go
@@ -138,7 +138,7 @@ func (c *grpcExecutorClient) handleStats(ctx context.Context, stream proto.Execu
 			status.Code(err) == codes.Unavailable ||
 			status.Code(err) == codes.Canceled ||
 			err == context.Canceled {
-			c.logger.Trace("executor Stats stream closed", "error", err)
+			c.logger.Trace("executor Stats stream closed", "msg", err)
 			return
 		} else if err != nil {
 			c.logger.Warn("failed to receive Stats executor RPC stream, closing stream", "error", err)


### PR DESCRIPTION
Suppress stats streaming error log messages when task finishes.
Streaming errors are expected when a task finishes and they aren't
actionable to users.

Also, note that the task runner Stats hook retries collecting stats
after a delay. If the connection terminates prematurely, it will be
retried, and closing the stats stream is not very disruptive.

Ideally, executor terminates cleanly when task exits, but that's a more
substantial change that may require changing the executor/drivers interface.

Fixes https://github.com/hashicorp/nomad/issues/10814