### PR TITLE
Allow saving the job's check-index to a file so it can be utilized in CI, fixes #10974.

### DIFF
--- a/.changelog/11282.txt
+++ b/.changelog/11282.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+cli: Allow saving the check-index to a file during `nomad plan`.
+```

--- a/website/content/docs/commands/job/plan.mdx
+++ b/website/content/docs/commands/job/plan.mdx
@@ -65,6 +65,8 @@ capability for the job's namespace.
 
 - `-hcl1`: If set, HCL1 parser is used for parsing the job spec.
 
+- `check-index-file`: If set the check index is written to the specified file.
+
 - `-verbose`: Increase diff verbosity.
 
 ## Examples


### PR DESCRIPTION
Fix for #10974. Not really sure how to test for this.

Closes #10974