### PR TITLE
wrap `log` messages with `hclog`

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -470,7 +470,6 @@ func SetupLoggers(ui cli.Ui, config *Config) (*logutils.LevelFilter, *gatedwrite
 	}
 
 	logOutput := io.MultiWriter(writers...)
-	log.SetOutput(logOutput)
 	return logFilter, logGate, logOutput
 }
 
@@ -648,6 +647,12 @@ func (c *Command) Run(args []string) int {
 		Output:     logOutput,
 		JSONFormat: config.LogJson,
 	})
+
+	// Wrap log messages emitted with the 'log' package.
+	// These usually come from external dependencies.
+	log.SetOutput(logger.StandardWriter(&hclog.StandardLoggerOptions{InferLevels: true}))
+	log.SetPrefix("")
+	log.SetFlags(0)
 
 	// Swap out UI implementation if json logging is enabled
 	if config.LogJson {


### PR DESCRIPTION
`hclog` provides a `Writer` that can be used to [configure Go's `log` package to write logs through the application logger](https://pkg.go.dev/github.com/hashicorp/go-hclog#readme-use-this-with-code-that-uses-the-standard-library-logger), but the agent configuration was not actually using the `hclog` writer.

This PR calls `log.SetOutput` with the correct input. The `logOutput` value that was being used before is already being set as the `logger.Output` value.

`InferLevels` doesn't always work, but at least now all messages are proper JSON strings.

Closes #11232

### Sample agent config
```hcl
log_json = true

client {
  enabled = true

  server_join {
    retry_join = ["provider=mdns service=nomad v6=false"]
  }
}
```

### Before

```json
{"@level":"debug","@message":"allocation updates","@module":"client","@timestamp":"2021-10-08T18:09:25.902441-04:00","added":0,"ignored":0,"removed":0,"updated":0}
{"@level":"debug","@message":"allocation updates applied","@module":"client","@timestamp":"2021-10-08T18:09:25.902926-04:00","added":0,"errors":0,"ignored":0,"removed":0,"updated":0}
2021/10/08 18:09:25.903199 [ERR] mdns: Failed to bind to udp6 port: listen udp6 [ff02::fb]:5353: setsockopt: can't assign requested address
{"@level":"debug","@message":"state updated","@module":"client","@timestamp":"2021-10-08T18:09:25.903585-04:00","node_status":"ready"}
{"@level":"debug","@message":"state changed, updating node and re-registering","@module":"client","@timestamp":"2021-10-08T18:09:26.907301-04:00"}
```

### After

```json
{"@level":"debug","@message":"discover: Using provider \"mdns\"","@module":"agent.joiner","@timestamp":"2021-10-08T18:17:29.088634-04:00"}
{"@level":"debug","@message":"state updated","@module":"client","@timestamp":"2021-10-08T18:17:29.088902-04:00","node_status":"ready"}
{"@level":"info","@message":"2021/10/08 18:17:29.089869 [ERR] mdns: Failed to bind to udp6 port: listen udp6 [ff02::fb]:5353: setsockopt: can't assign requested address","@module":"agent","@timestamp":"2021-10-08T18:17:29.089872-04:00"}
{"@level":"debug","@message":"state changed, updating node and re-registering","@module":"client","@timestamp":"2021-10-08T18:17:30.089674-04:00"}
{"@level":"info","@message":"node registration complete","@module":"client","@timestamp":"2021-10-08T18:17:30.090978-04:00"}

```