### PR TITLE
tests: ensure that tests restore env-var values

### DIFF
--- a/command/helpers_test.go
+++ b/command/helpers_test.go
@@ -346,8 +346,7 @@ job "example" {
 }
 `
 
-	os.Setenv("NOMAD_VAR_var4", "from-envvar")
-	defer os.Unsetenv("NOMAD_VAR_var4")
+	setEnv(t, "NOMAD_VAR_var4", "from-envvar")
 
 	cliArgs := []string{`var2=from-cli`}
 	fileVars := `var3 = "from-varfile"`

--- a/command/util_test.go
+++ b/command/util_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/nomad/api"
@@ -105,4 +106,18 @@ func testMultiRegionJob(jobID, region, datacenter string) *api.Job {
 	}
 
 	return job
+}
+
+// setEnv wraps os.Setenv(key, value) and restores the environment variable to initial value in test cleanup
+func setEnv(t *testing.T, key, value string) {
+	initial, ok := os.LookupEnv(key)
+	os.Setenv(key, value)
+
+	t.Cleanup(func() {
+		if ok {
+			os.Setenv(key, initial)
+		} else {
+			os.Unsetenv(key)
+		}
+	})
 }


### PR DESCRIPTION
Fix a test corruption issue, where a test accidentally unsets
the `NOMAD_LICENSE` environment variable, that's relied on by some
tests.

As a habit, tests should always restore the environment variable value
on test completion. Golang 1.17 introduced
[`t.Setenv`](https://pkg.go.dev/testing#T.Setenv) to address this issue.
However, as 1.0.x and 1.1.x branches target golang 1.15 and 1.16, I
opted to use a helper function to ease backports.