### PR TITLE
fix `nomad job allocs` command name

### DIFF
--- a/command/job_allocs.go
+++ b/command/job_allocs.go
@@ -73,7 +73,7 @@ func (c *JobAllocsCommand) AutocompleteArgs() complete.Predictor {
 	})
 }
 
-func (c *JobAllocsCommand) Name() string { return "job allocations" }
+func (c *JobAllocsCommand) Name() string { return "job allocs" }
 
 func (c *JobAllocsCommand) Run(args []string) int {
 	var json, verbose, all bool


### PR DESCRIPTION
#11242 added the `nomad job allocs` command, but the command name was set to `job allocations`. The command name is displayed in the error message.

Before:
```console
$ nomad job allocs
This command takes one argument: <job>
For additional help try 'nomad job allocations -help'
```

After:
```console
$ nomad job allocs
This command takes one argument: <job>
For additional help try 'nomad job allocs -help'
```

No changelog since this is still an unreleased feature.