### PR TITLE
Remove vendor folder during make clean

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -241,6 +241,7 @@ dev: hclfmt ## Build for the current development platform
 	@rm -f $(PROJECT_ROOT)/$(DEV_TARGET)
 	@rm -f $(PROJECT_ROOT)/bin/nomad
 	@rm -f $(GOPATH)/bin/nomad
+	@if [ -d vendor ]; then echo -e "==> WARNING: Found vendor directory.  This may cause build errors, consider running 'rm -r vendor' or 'make clean' to remove.\n"; fi
 	@$(MAKE) --no-print-directory \
 		$(DEV_TARGET) \
 		GO_TAGS="$(GO_TAGS) $(NOMAD_UI_TAG)"


### PR DESCRIPTION
Nomad 1.1.3 introduced a change in #10898 which removes the build requirement of vendored Golang dependencies.

When upgrading a source repository from a version prior to Nomad 1.1.3, if you do not remove the `vendor` directory before building you will get an error similar to the following:

```
dmay@ubu20:~/git/hashicorp/nomad$ make dev
--> Formatting HCL
==> Removing old development build...
==> Building pkg/linux_amd64/nomad with tags ui  ...
go: inconsistent vendoring in /home/dmay/git/hashicorp/nomad:
....
        To sync the vendor directory, run:
                go mod vendor
make[1]: *** [GNUmakefile:78: pkg/linux_amd64/nomad] Error 1
make: *** [GNUmakefile:244: dev] Error 2
```

For a smoother development experience this PR contains the following:
* Add a step to `make clean` to remove the vendor directory
* Add a warning to `make dev` to either remove the vendor directory or run make clean.  NOTE -- during development some authors may need to temporarily use a vendor directory, so this does not stop the build process.