### PR TITLE
ease building Linux binaries on macOS

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -65,6 +65,8 @@ endif
 
 SUPPORTED_OSES = Darwin Linux FreeBSD Windows MSYS_NT
 
+CGO_ENABLED = 1
+
 # include per-user customization after all variables are defined
 -include GNUMakefile.local
 
@@ -75,7 +77,7 @@ ifeq (,$(findstring $(THIS_OS),$(SUPPORTED_OSES)))
 	$(warning WARNING: Building Nomad is only supported on $(SUPPORTED_OSES); not $(THIS_OS))
 endif
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
-	@CGO_ENABLED=1 \
+	@CGO_ENABLED=$(CGO_ENABLED) \
 		GOOS=$(firstword $(subst _, ,$*)) \
 		GOARCH=$(lastword $(subst _, ,$*)) \
 		CC=$(CC) \
@@ -87,6 +89,10 @@ endif
 
 ifneq (aarch64,$(THIS_ARCH))
 pkg/linux_arm64/nomad: CC = aarch64-linux-gnu-gcc
+endif
+
+ifeq (Darwin,$(THIS_OS))
+pkg/linux_%/nomad: CGO_ENABLED = 0
 endif
 
 pkg/windows_%/nomad: GO_OUT = $@.exe


### PR DESCRIPTION
Meant for development purposes only, so one can compile binary on a
macos host then start a Docker container or scp the binary to a linux
host easily.

The resulting binary is statically linked and has very subtle
differences. e.g. static binaries use go native network stack that
honor /etc/hosts and /etc/resolve differently from the glibc
implementation. In development environment, I don't expect these to
materially change our experience.