### PR TITLE
feat: Add force_download flag to artifact stanza

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -741,6 +741,7 @@ type TaskArtifact struct {
 	GetterHeaders map[string]string `mapstructure:"headers" hcl:"headers,block"`
 	GetterMode    *string           `mapstructure:"mode" hcl:"mode,optional"`
 	RelativeDest  *string           `mapstructure:"destination" hcl:"destination,optional"`
+	ForceDownload *bool             `mapstructure:"force_download" hcl:"force_download,optional"`
 }
 
 func (a *TaskArtifact) Canonicalize() {
@@ -769,6 +770,9 @@ func (a *TaskArtifact) Canonicalize() {
 			// Default to a directory
 			a.RelativeDest = stringToPtr("local/")
 		}
+	}
+	if a.ForceDownload == nil {
+		a.ForceDownload = boolToPtr(false)
 	}
 }
 

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -360,12 +360,14 @@ func TestTask_Artifact(t *testing.T) {
 		GetterMode:    stringToPtr("file"),
 		GetterHeaders: make(map[string]string),
 		GetterOptions: make(map[string]string),
+		ForceDownload: boolToPtr(false),
 	}
 	a.Canonicalize()
 	require.Equal(t, "file", *a.GetterMode)
 	require.Equal(t, "local/foo.txt", filepath.ToSlash(*a.RelativeDest))
 	require.Nil(t, a.GetterOptions)
 	require.Nil(t, a.GetterHeaders)
+	require.Equal(t, boolToPtr(false), a.ForceDownload)
 }
 
 func TestTask_VolumeMount(t *testing.T) {

--- a/client/allocrunner/taskrunner/artifact_hook.go
+++ b/client/allocrunner/taskrunner/artifact_hook.go
@@ -44,7 +44,7 @@ func (h *artifactHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 
 	for _, artifact := range req.Task.Artifacts {
 		aid := artifact.Hash()
-		if req.PreviousState[aid] != "" {
+		if req.PreviousState[aid] != "" && !artifact.ForceDownload {
 			h.logger.Trace("skipping already downloaded artifact", "artifact", artifact.GetterSource)
 			resp.State[aid] = req.PreviousState[aid]
 			continue

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1090,6 +1090,7 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 					GetterHeaders: helper.CopyMapStringString(ta.GetterHeaders),
 					GetterMode:    *ta.GetterMode,
 					RelativeDest:  *ta.RelativeDest,
+					ForceDownload: *ta.ForceDownload,
 				})
 		}
 	}

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -2268,8 +2268,9 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								GetterOptions: map[string]string{
 									"a": "b",
 								},
-								GetterMode:   helper.StringToPtr("dir"),
-								RelativeDest: helper.StringToPtr("dest"),
+								GetterMode:    helper.StringToPtr("dir"),
+								RelativeDest:  helper.StringToPtr("dest"),
+								ForceDownload: helper.BoolToPtr(false),
 							},
 						},
 						Vault: &api.Vault{

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -4488,6 +4488,12 @@ func TestTaskDiff(t *testing.T) {
 						Fields: []*FieldDiff{
 							{
 								Type: DiffTypeAdded,
+								Name: "ForceDownload",
+								Old:  "",
+								New:  "false",
+							},
+							{
+								Type: DiffTypeAdded,
 								Name: "GetterHeaders[User-Agent]",
 								Old:  "",
 								New:  "nomad",

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8098,6 +8098,10 @@ type TaskArtifact struct {
 	// RelativeDest is the download destination given relative to the task's
 	// directory.
 	RelativeDest string
+
+	// ForceDownload is a boolean flag to specify if the artifact
+	// has to be downloaded even if it exists in case of allocation restarts.
+	ForceDownload bool
 }
 
 func (ta *TaskArtifact) Copy() *TaskArtifact {
@@ -8110,6 +8114,7 @@ func (ta *TaskArtifact) Copy() *TaskArtifact {
 		GetterHeaders: helper.CopyMapStringString(ta.GetterHeaders),
 		GetterMode:    ta.GetterMode,
 		RelativeDest:  ta.RelativeDest,
+		ForceDownload: ta.ForceDownload,
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/hashicorp/nomad/issues/11297

As noted in https://github.com/hashicorp/nomad/issues/11297#issuecomment-941616924, the `force_download` flag is added to the Artifact hook. However, there's a blocker for this to actually work.

As seen on https://github.com/hashicorp/nomad/blob/v1.1.6/client/allocrunner/taskrunner/artifact_hook.go#L72 the PreStart response is marked as Done. Since Artifact fetching is a PreStart hook, during a restart of the allocation, this [check](https://github.com/hashicorp/nomad/blob/v1.1.6/client/allocrunner/taskrunner/task_runner_hooks.go#L212) kicks in which marks artifact fetching as completed. Since the hook is not even called during the restart, the `force_download` flag is ineffective. 

@lgfa29 What would be the best way around here :sweat_smile:  