### PR TITLE
vagrantfile: expose Nomad and Consul APIs to local machine.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,10 @@ Vagrant.configure(2) do |config|
 
 		vmCfg = configureLinuxProvisioners(vmCfg)
 
+        # Expose Nomad and Consul ports for ease.
+		vmCfg.vm.network :forwarded_port, guest: 4646, host: 4646, auto_correct: true, host_ip: "127.0.0.1"
+		vmCfg.vm.network :forwarded_port, guest: 8500, host: 8500, auto_correct: true, host_ip: "127.0.0.1"
+
 		vmCfg.vm.synced_folder '.',
 			'/opt/gopath/src/github.com/hashicorp/nomad'
 


### PR DESCRIPTION
When running the default Vagrant machine, it would be beneficial
to expose the Nomad and Consul APIs to the local machine. This
makes testing and development easier, particularly when working
with external tools such as nomad-pack which is not available on
the Vagrant machine.