### PR TITLE
Mesh Gateway doc enhancements

### DIFF
--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -163,13 +163,12 @@ envoy_gateway_bind_addresses "<service>" {
 
 ### `mesh` Parameters
 
-  The `mesh` block currently does not have any configurable parameters.
+The `mesh` block currently does not have any configurable parameters.
 
-  ~> **Note:** If using the Mesh Gateway for [WAN Federation](https://www.consul.io/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways#mesh-gateways), 
-  the additional piece of service metadata `{"consul-wan-federation":"1"}` must be applied. 
-  This can be done with the service [`meta`](https://www.nomadproject.io/docs/job-specification/service#meta)
-  parameter.
-  
+~> **Note:** If using the Mesh Gateway for [WAN Federation][connect_mesh_gw],
+the additional piece of service metadata `{"consul-wan-federation":"1"}` must
+be applied. This can be done with the service [`meta`][meta] parameter.
+
 ### Gateway with host networking
 
 Nomad supports running gateways using host networking. A static port must be allocated
@@ -635,6 +634,7 @@ job "countdash-mesh-two" {
 [address]: /docs/job-specification/gateway#address-parameters
 [advanced configuration]: https://www.consul.io/docs/connect/proxies/envoy#advanced-configuration
 [connect_timeout_ms]: https://www.consul.io/docs/agent/config-entries/service-resolver#connecttimeout
+[connect_mesh_gw]: https://www.consul.io/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways#mesh-gateways
 [envoy docker]: https://hub.docker.com/r/envoyproxy/envoy/tags
 [ingress]: /docs/job-specification/gateway#ingress-parameters
 [proxy]: /docs/job-specification/gateway#proxy-parameters
@@ -646,3 +646,4 @@ job "countdash-mesh-two" {
 [terminating]: /docs/job-specification/gateway#terminating-parameters
 [tls]: /docs/job-specification/gateway#tls-parameters
 [mesh]: /docs/job-specification/gateway#mesh-parameters
+[meta]: /docs/job-specification/service#meta

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -35,7 +35,7 @@ service {
 
 ## `gateway` Parameters
 
-Exactly one of `ingress` or `terminating` must be configured.
+Exactly one of `ingress`, `terminating`, or `mesh` must be configured.
 
 - `proxy` <code>([proxy]: nil)</code> - Configuration of the Envoy proxy that will
   be injected into the task group.
@@ -165,6 +165,11 @@ envoy_gateway_bind_addresses "<service>" {
 
   The `mesh` block currently does not have any configurable parameters.
 
+  ~> **Note:** If using the Mesh Gateway for [WAN Federation](https://www.consul.io/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways#mesh-gateways), 
+  the additional piece of service metadata `{"consul-wan-federation":"1"}` must be applied. 
+  This can be done with the service [`meta`](https://www.nomadproject.io/docs/job-specification/service#meta)
+  parameter.
+  
 ### Gateway with host networking
 
 Nomad supports running gateways using host networking. A static port must be allocated


### PR DESCRIPTION
1. I believe this line should be corrected to add mesh as one of the choices
2. I found that we are not setting this meta, and it is a required element for wan federation. I believe it would be helpful and potentially time saving to note that right here.