### PR TITLE
ui: create tooltip component

### DIFF
--- a/ui/app/components/tooltip.js
+++ b/ui/app/components/tooltip.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+
+export default class Tooltip extends Component {
+  get text() {
+    const inputText = this.args.text;
+    if (!inputText || inputText.length < 30) {
+      return inputText;
+    }
+
+    const prefix = inputText.substr(0, 15).trim();
+    const suffix = inputText.substr(inputText.length - 10, inputText.length).trim();
+    return `${prefix}...${suffix}`;
+  }
+}

--- a/ui/app/templates/components/allocation-row.hbs
+++ b/ui/app/templates/components/allocation-row.hbs
@@ -38,21 +38,21 @@
 </td>
 {{#if (eq this.context "volume")}}
   <td data-test-client>
-    <span class="tooltip multiline" aria-label="{{this.allocation.node.name}}">
+    <Tooltip @text={{this.allocation.node.name}}>
       <LinkTo @route="clients.client" @model={{this.allocation.node}}>
         {{this.allocation.node.shortId}}
       </LinkTo>
-    </span>
+    </Tooltip>
   </td>
 {{/if}}
 {{#if (or (eq this.context "taskGroup") (eq this.context "job"))}}
   <td data-test-job-version>{{this.allocation.jobVersion}}</td>
   <td data-test-client>
-    <span class="tooltip multiline" aria-label="{{this.allocation.node.name}}">
+    <Tooltip @text={{this.allocation.node.name}}>
       <LinkTo @route="clients.client" @model={{this.allocation.node}}>
         {{this.allocation.node.shortId}}
       </LinkTo>
-    </span>
+    </Tooltip>
   </td>
 {{else if (or (eq this.context "node") (eq this.context "volume"))}}
   <td>

--- a/ui/app/templates/components/plugin-allocation-row.hbs
+++ b/ui/app/templates/components/plugin-allocation-row.hbs
@@ -45,11 +45,11 @@
   </td>
 
   <td data-test-client>
-    <span class="tooltip multiline" aria-label="{{this.allocation.node.name}}">
+    <Tooltip @text={{this.allocation.node.name}}>
       <LinkTo @route="clients.client" @model={{this.allocation.node}}>
         {{this.allocation.node.shortId}}
       </LinkTo>
-    </span>
+    </Tooltip>
   </td>
   <td>
     {{#if (or this.allocation.job.isPending this.allocation.job.isReloading)}}

--- a/ui/app/templates/components/tooltip.hbs
+++ b/ui/app/templates/components/tooltip.hbs
@@ -1,0 +1,3 @@
+<span class="tooltip" aria-label="{{this.text}}">
+  {{yield}}
+</span>

--- a/ui/tests/acceptance/plugin-detail-test.js
+++ b/ui/tests/acceptance/plugin-detail-test.js
@@ -117,6 +117,11 @@ module('Acceptance | plugin detail', function(hooks) {
         server.db.nodes.find(allocation.nodeId).id.split('-')[0],
         'Node ID'
       );
+      assert.equal(
+        allocationRow.clientTooltip.substr(0, 15),
+        server.db.nodes.find(allocation.nodeId).name.substr(0, 15),
+        'Node Name'
+      );
       assert.equal(allocationRow.job, server.db.jobs.find(allocation.jobId).name, 'Job name');
       assert.ok(allocationRow.taskGroup, 'Task group name');
       assert.ok(allocationRow.jobVersion, 'Job Version');

--- a/ui/tests/acceptance/volume-detail-test.js
+++ b/ui/tests/acceptance/volume-detail-test.js
@@ -136,6 +136,11 @@ module('Acceptance | volume detail', function(hooks) {
         'Node ID'
       );
       assert.equal(
+        allocationRow.clientTooltip.substr(0, 15),
+        server.db.nodes.find(allocation.nodeId).name.substr(0, 15),
+        'Node Name'
+      );
+      assert.equal(
         allocationRow.cpu,
         Math.floor(allocStats.resourceUsage.CpuStats.TotalTicks) / cpuUsed,
         'CPU %'

--- a/ui/tests/pages/components/allocations.js
+++ b/ui/tests/pages/components/allocations.js
@@ -18,6 +18,7 @@ export default function(selector = '[data-test-allocation]', propKey = 'allocati
       job: text('[data-test-job]'),
       taskGroup: text('[data-test-task-group]'),
       client: text('[data-test-client]'),
+      clientTooltip: attribute('aria-label', '[data-test-client] .tooltip'),
       jobVersion: text('[data-test-job-version]'),
       volume: text('[data-test-volume]'),
       cpu: text('[data-test-cpu]'),

--- a/ui/tests/unit/components/tooltip-test.js
+++ b/ui/tests/unit/components/tooltip-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import setupGlimmerComponentFactory from 'nomad-ui/tests/helpers/glimmer-factory';
+
+module('Unit | Component | tooltip', function(hooks) {
+  setupTest(hooks);
+  setupGlimmerComponentFactory(hooks, 'tooltip');
+
+  test('long texts are ellipsised in the middle', function(assert) {
+    const tooltip = this.createComponent({ text: 'reeeeeeeeeeeeeeeeeally long text' });
+    assert.equal(tooltip.text, 'reeeeeeeeeeeeee...long text');
+  });
+});


### PR DESCRIPTION
After using #11358 for a bit, I was quickly annoyed with the unnecessarily wide tooltip when client names are relatively short. This PR creates a `Tooltip` component that ellipsizes the tooltip text content in the middle, keeping it short enough to fit into a single-line tooltip.

Before:
![image](https://user-images.githubusercontent.com/775380/138316849-7c98d8b6-47e6-4d90-98e0-2f7e011b3e01.png)

After:
![image](https://user-images.githubusercontent.com/775380/138316871-756b3514-803a-4c96-92a1-6096f30c1655.png)
![image](https://user-images.githubusercontent.com/775380/138316884-0670ab39-dd2c-45e2-a43d-898ac206a89b.png)

Ellipsizing in the middle allow users to glance at the beginning and end of text. This is important for client names since they are often prefixed and indexed in a standard format. Cutting off the end of the string would make impossible to distinguish between `nomad-client-with-long-name-1` and `nomad-client-with-long-name-2`.

Using `multiline` was also not helpful in the case where client names had no spaces.

The value used as a threshold to decide if the text must be ellipsized is fairly arbitrary and can be adjusted based on user feedback.

No changelog since this fixes an unreleased feature.