### PR TITLE
ui: use `get` to access job meta value

### DIFF
--- a/ui/app/components/job-dispatch.js
+++ b/ui/app/components/job-dispatch.js
@@ -54,7 +54,7 @@ export default class JobDispatch extends Component {
             name: x,
             required,
             title: titleCase(noCase(x)),
-            value: this.args.job.meta ? this.args.job.meta[x] : '',
+            value: this.args.job.meta ? this.args.job.meta.get(x) : '',
           })
       );
 


### PR DESCRIPTION
Ember gets angry when you try to access the meta values directly and the job dispatch page fails to load. But this only happens in `development`, so no changelog or backport required.