### PR TITLE
ui: update task group alloc summary chart to use new `SummaryLegendItem` component

### DIFF
--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -59,11 +59,7 @@
         <ol class="legend">
           {{#each chart.data as |datum index|}}
             <li class="{{datum.className}} {{if (eq datum.label chart.activeDatum.label) "is-active"}} {{if (eq datum.value 0) "is-empty"}}">
-              <span class="color-swatch {{if datum.className datum.className (concat "swatch-" index)}}" />
-              <span class="value">{{datum.value}}</span>
-              <span class="label">
-                {{datum.label}}
-              </span>
+              <JobPage::Parts::SummaryLegendItem @datum={{datum}} @index={{index}} />
             </li>
           {{/each}}
         </ol>


### PR DESCRIPTION
Using the right component ensures that the generate HTML structure matches the new style.

This fixes an issue introduced in an unreleased version of Nomad, so no changelog required.