### PR TITLE
Made template diffing a bit smarter.

### DIFF
--- a/.changelog/11378.txt
+++ b/.changelog/11378.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plan: Smarter diffing of template stanzas
+```

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -6914,7 +6914,7 @@ func TestTaskDiff(t *testing.T) {
 					{
 						SourcePath:   "foo",
 						DestPath:     "bar",
-						EmbeddedTmpl: "baz",
+						EmbeddedTmpl: "baz new",
 						ChangeMode:   "bam",
 						ChangeSignal: "SIGHUP",
 						Splay:        1,
@@ -6934,6 +6934,18 @@ func TestTaskDiff(t *testing.T) {
 			Expected: &TaskDiff{
 				Type: DiffTypeEdited,
 				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeEdited,
+						Name: "Template",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeEdited,
+								Name: "EmbeddedTmpl",
+								Old:  "baz",
+								New:  "baz new",
+							},
+						},
+					},
 					{
 						Type: DiffTypeAdded,
 						Name: "Template",


### PR DESCRIPTION
Previously templates diff always showed up as delete & add. The new code
always diffs if there is only one template and if there are multiple
templates it uses DestPath as unique identifier (this works because
nomad checks that this is actually unique).

@lgfa29 This is similar to the service diffing PR of mine that you reviewed. But this one is massively easier since `DestPath` has to be uniqe.