### PR TITLE
Avoid pulling locally cached "infrastructure" (pause) image unless :latest tag is specified.  Applies the same logic used for tasks to this image.

### DIFF
--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -955,7 +955,8 @@ host system.
 
 - `infra_image` - This is the Docker image to use when creating the parent
   container necessary when sharing network namespaces between tasks. Defaults to
-  `gcr.io/google_containers/pause-<goarch>:3.1`.
+  `gcr.io/google_containers/pause-<goarch>:3.1`.  If the image is already present,
+  it won't be pulled again unless the `"latest"` tag is specified.
 
 - `infra_image_pull_timeout` - A time duration that controls how long Nomad will
   wait before cancelling an in-progress pull of the Docker image as specified in

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -955,7 +955,7 @@ host system.
 
 - `infra_image` - This is the Docker image to use when creating the parent
   container necessary when sharing network namespaces between tasks. Defaults to
-  `gcr.io/google_containers/pause-<goarch>:3.1`.  If the image is already present,
+  `gcr.io/google_containers/pause-<goarch>:3.1`. If the image is already present,
   it won't be pulled again unless the `"latest"` tag is specified.
 
 - `infra_image_pull_timeout` - A time duration that controls how long Nomad will


### PR DESCRIPTION
Running without internet connectivity requires a private registry to serve this image today and that is not always ideal.  This provides some extra control over how it's image is handled and uses the same logic as tasks.  

closes #10318
closes #11014