### PR TITLE
Disable max parallel count warning when task group count is 1

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6483,7 +6483,7 @@ func (tg *TaskGroup) Warnings(j *Job) error {
 	// Validate the update strategy
 	if u := tg.Update; u != nil {
 		// Check the counts are appropriate
-		if u.MaxParallel > tg.Count && !(j.IsMultiregion() && tg.Count == 0) {
+		if tg.Count > 1 && u.MaxParallel > tg.Count && !(j.IsMultiregion() && tg.Count == 0) {
 			mErr.Errors = append(mErr.Errors,
 				fmt.Errorf("Update max parallel count is greater than task group count (%d > %d). "+
 					"A destructive change would result in the simultaneous replacement of all allocations.", u.MaxParallel, tg.Count))


### PR DESCRIPTION
It's pretty meaningless and annoying to see these warnings when the count is 1, any update is already destructive.