### PR TITLE
Allow using specific object ID on diff

### DIFF
--- a/.changelog/11400.txt
+++ b/.changelog/11400.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Improve `nomad job plan` output for `artifact` and `template` changes
+```

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -10,6 +10,14 @@ import (
 	"github.com/mitchellh/hashstructure"
 )
 
+// DiffableWithID defines an object that have an unique and stable field that
+// can be used as an identifier when generating a diff.
+type DiffableWithID interface {
+	// DiffID returns the value to use to match entities between the old and
+	// the new input.
+	DiffID() string
+}
+
 // DiffType denotes the type of a diff object.
 type DiffType string
 
@@ -2419,11 +2427,20 @@ func primitiveObjectSetDiff(old, new []interface{}, filter []string, name string
 	makeSet := func(objects []interface{}) map[string]interface{} {
 		objMap := make(map[string]interface{}, len(objects))
 		for _, obj := range objects {
-			hash, err := hashstructure.Hash(obj, nil)
-			if err != nil {
-				panic(err)
+			var key string
+
+			if diffable, ok := obj.(DiffableWithID); ok {
+				key = diffable.DiffID()
 			}
-			objMap[fmt.Sprintf("%d", hash)] = obj
+
+			if key == "" {
+				hash, err := hashstructure.Hash(obj, nil)
+				if err != nil {
+					panic(err)
+				}
+				key = fmt.Sprintf("%d", hash)
+			}
+			objMap[key] = obj
 		}
 
 		return objMap
@@ -2433,10 +2450,11 @@ func primitiveObjectSetDiff(old, new []interface{}, filter []string, name string
 	newSet := makeSet(new)
 
 	var diffs []*ObjectDiff
-	for k, v := range oldSet {
-		// Deleted
-		if _, ok := newSet[k]; !ok {
-			diffs = append(diffs, primitiveObjectDiff(v, nil, filter, name, contextual))
+	for k, oldObj := range oldSet {
+		newObj := newSet[k]
+		diff := primitiveObjectDiff(oldObj, newObj, filter, name, contextual)
+		if diff != nil {
+			diffs = append(diffs, diff)
 		}
 	}
 	for k, v := range newSet {

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -10,8 +10,8 @@ import (
 	"github.com/mitchellh/hashstructure"
 )
 
-// DiffableWithID defines an object that have an unique and stable field that
-// can be used as an identifier when generating a diff.
+// DiffableWithID defines an object that has a unique and stable value that can
+// be used as an identifier when generating a diff.
 type DiffableWithID interface {
 	// DiffID returns the value to use to match entities between the old and
 	// the new input.

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -4459,7 +4459,7 @@ func TestTaskDiff(t *testing.T) {
 			New: &Task{
 				Artifacts: []*TaskArtifact{
 					{
-						GetterSource: "foo",
+						GetterSource: "foo/bar",
 						GetterOptions: map[string]string{
 							"foo": "bar",
 						},
@@ -4482,6 +4482,18 @@ func TestTaskDiff(t *testing.T) {
 			Expected: &TaskDiff{
 				Type: DiffTypeEdited,
 				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeEdited,
+						Name: "Artifact",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeEdited,
+								Name: "GetterSource",
+								Old:  "foo",
+								New:  "foo/bar",
+							},
+						},
+					},
 					{
 						Type: DiffTypeAdded,
 						Name: "Artifact",
@@ -6914,7 +6926,7 @@ func TestTaskDiff(t *testing.T) {
 					{
 						SourcePath:   "foo",
 						DestPath:     "bar",
-						EmbeddedTmpl: "baz",
+						EmbeddedTmpl: "baz new",
 						ChangeMode:   "bam",
 						ChangeSignal: "SIGHUP",
 						Splay:        1,
@@ -6934,6 +6946,18 @@ func TestTaskDiff(t *testing.T) {
 			Expected: &TaskDiff{
 				Type: DiffTypeEdited,
 				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeEdited,
+						Name: "Template",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeEdited,
+								Name: "EmbeddedTmpl",
+								Old:  "baz",
+								New:  "baz new",
+							},
+						},
+					},
 					{
 						Type: DiffTypeAdded,
 						Name: "Template",

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7479,6 +7479,11 @@ func (t *Template) Warnings() error {
 	return mErr.ErrorOrNil()
 }
 
+// DiffID fulfills the DiffableWithID interface.
+func (t *Template) DiffID() string {
+	return t.DestPath
+}
+
 // AllocState records a single event that changes the state of the whole allocation
 type AllocStateField uint8
 
@@ -8118,6 +8123,11 @@ func (ta *TaskArtifact) Copy() *TaskArtifact {
 
 func (ta *TaskArtifact) GoString() string {
 	return fmt.Sprintf("%+v", ta)
+}
+
+// DiffID fulfills the DiffableWithID interface.
+func (ta *TaskArtifact) DiffID() string {
+	return ta.RelativeDest
 }
 
 // hashStringMap appends a deterministic hash of m onto h.


### PR DESCRIPTION
Currently Nomad will use a generic diff method when computing changes in a jobspec. This method uses a hash of the block content as a way to match values from the old jobspec to the new one. This approach generates less than ideal diffs since any change to block will result in a add/delete pair instead of a more precise edit output.

This PR introduces a new interface that can be implemented by structs that have some kind of stable and uniquely identifiable field that can be used to match blocks from the old jobspec to the new one.

Implementing this interface for the `Template` struct, for example, allows using the destination path as the ID. Nomad guarantees its uniqueness in a task and If the user modifies it it's fair to assume this is a new block.

Big thanks to @apollo13  for flagging this and proposing a solution. Builds upon #11378.

### Sample outpus

Before:

```shell-session
$ nomad job plan example.nomad
+/- Job: "example"
+/- Task Group: "cache" (1 create/destroy update)
  +/- Task: "redis" (forces create/destroy update)
    + Template {
      + ChangeMode:   "restart"
        ChangeSignal: ""
      + DestPath:     "local/test"
      + EmbeddedTmpl: "new test"
      + Envvars:      "false"
      + LeftDelim:    "{{"
      + Perms:        "0644"
      + RightDelim:   "}}"
        SourcePath:   ""
      + Splay:        "5000000000"
      + VaultGrace:   "0"
      }
    - Template {
      - ChangeMode:   "restart"
        ChangeSignal: ""
      - DestPath:     "local/test"
      - EmbeddedTmpl: "test"
      - Envvars:      "false"
      - LeftDelim:    "{{"
      - Perms:        "0644"
      - RightDelim:   "}}"
        SourcePath:   ""
      - Splay:        "5000000000"
      - VaultGrace:   "0"
      }
```

After:

```shell-session
$ nomad job plan example.nomad
+/- Job: "example"
+/- Task Group: "cache" (1 create/destroy update)
  +/- Task: "redis" (forces create/destroy update)
    +/- Template {
          ChangeMode:   "restart"
          ChangeSignal: ""
          DestPath:     "local/test"
      +/- EmbeddedTmpl: "test" => "new test"
          Envvars:      "false"
          LeftDelim:    "{{"
          Perms:        "0644"
          RightDelim:   "}}"
          SourcePath:   ""
          Splay:        "5000000000"
          VaultGrace:   "0"
        }
```