### PR TITLE
agent/docs: add better clarification when top-level data dir needs setting

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -389,7 +389,7 @@ func (c *Command) isValidConfig(config, cmdConfig *Config) bool {
 	if !config.DevMode {
 		// Ensure that we have the directories we need to run.
 		if config.Server.Enabled && config.DataDir == "" {
-			c.Ui.Error("Must specify data directory")
+			c.Ui.Error(`Must specify "data_dir" config option or "data-dir" CLI flag`)
 			return false
 		}
 

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -47,7 +47,7 @@ func TestCommand_Args(t *testing.T) {
 		},
 		{
 			[]string{"-server"},
-			"Must specify data directory",
+			"Must specify \"data_dir\" config option or \"data-dir\" CLI flag",
 		},
 		{
 			[]string{"-client", "-alloc-dir="},

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -40,11 +40,11 @@ server {
   `1` does not provide any fault tolerance and is not recommended for production
   use cases.
 
-- `data_dir` `(string: "[data_dir]/server")` - Specifies the directory to use -
-  for server-specific data, including the replicated log. By default, this is -
-  the top-level [data_dir](/docs/configuration#data_dir)
-  suffixed with "server", like `"/opt/nomad/server"`. This must be an absolute
-  path.
+- `data_dir` `(string: "[data_dir]/server")` - Specifies the directory to use
+  for server-specific data, including the replicated log. By default, this is
+  the top-level [data_dir](/docs/configuration#data_dir) suffixed with "server",
+  like `"/opt/nomad/server"`. The top-level option must be set, even when
+  setting this value. This must be an absolute path.
 
 - `enabled` `(bool: false)` - Specifies if this agent should run in server mode.
   All other server options depend on this value being set.


### PR DESCRIPTION
closes #11059 