### PR TITLE
Raft Debugging Improvements

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -566,6 +566,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"operator snapshot _state": func() (cli.Command, error) {
+			return &OperatorSnapshotStateCommand{
+				Meta: meta,
+			}, nil
+		},
 		"operator snapshot restore": func() (cli.Command, error) {
 			return &OperatorSnapshotRestoreCommand{
 				Meta: meta,

--- a/command/operator_raft_state.go
+++ b/command/operator_raft_state.go
@@ -76,12 +76,20 @@ func (c *OperatorRaftStateCommand) Run(args []string) int {
 		return 1
 	}
 
-	state, err := raftutil.FSMState(raftPath, fLastIdx)
+	fsm, err := raftutil.NewFSM(raftPath)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+	defer fsm.Close()
+
+	_, _, err = fsm.ApplyAll()
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
 	}
 
+	state := fsm.StateAsMap()
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(state); err != nil {

--- a/command/operator_snapshot_state.go
+++ b/command/operator_snapshot_state.go
@@ -16,11 +16,12 @@ type OperatorSnapshotStateCommand struct {
 
 func (c *OperatorSnapshotStateCommand) Help() string {
 	helpText := `
-Usage: nomad operator snapshot _state [options] <file>
+Usage: nomad operator snapshot _state <file>
 
-  Displays a json representation of state in the snapshot
+  Displays a JSON representation of state in the snapshot.
 
   To inspect the file "backup.snap":
+
     $ nomad operator snapshot _state backup.snap
 `
 	return strings.TrimSpace(helpText)
@@ -43,7 +44,7 @@ func (c *OperatorSnapshotStateCommand) Name() string { return "operator snapshot
 func (c *OperatorSnapshotStateCommand) Run(args []string) int {
 	// Check that we either got no filename or exactly one.
 	if len(args) != 1 {
-		c.Ui.Error("This command takes one argument: <filename>")
+		c.Ui.Error("This command takes one argument: <file>")
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}
@@ -68,7 +69,7 @@ func (c *OperatorSnapshotStateCommand) Run(args []string) int {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(sm); err != nil {
-		c.Ui.Error(fmt.Sprintf("failed to encode output: %v", err))
+		c.Ui.Error(fmt.Sprintf("Failed to encode output: %v", err))
 		return 1
 	}
 

--- a/command/operator_snapshot_state.go
+++ b/command/operator_snapshot_state.go
@@ -1,0 +1,76 @@
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/nomad/helper/raftutil"
+	"github.com/posener/complete"
+)
+
+type OperatorSnapshotStateCommand struct {
+	Meta
+}
+
+func (c *OperatorSnapshotStateCommand) Help() string {
+	helpText := `
+Usage: nomad operator snapshot _state [options] <file>
+
+  Displays a json representation of state in the snapshot
+
+  To inspect the file "backup.snap":
+    $ nomad operator snapshot _state backup.snap
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *OperatorSnapshotStateCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{}
+}
+
+func (c *OperatorSnapshotStateCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *OperatorSnapshotStateCommand) Synopsis() string {
+	return "Displays information about a Nomad snapshot file"
+}
+
+func (c *OperatorSnapshotStateCommand) Name() string { return "operator snapshot _state" }
+
+func (c *OperatorSnapshotStateCommand) Run(args []string) int {
+	// Check that we either got no filename or exactly one.
+	if len(args) != 1 {
+		c.Ui.Error("This command takes one argument: <filename>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+
+	path := args[0]
+	f, err := os.Open(path)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error opening snapshot file: %s", err))
+		return 1
+	}
+	defer f.Close()
+
+	state, meta, err := raftutil.RestoreFromArchive(f)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to read archive file: %s", err))
+		return 1
+	}
+
+	sm := raftutil.StateAsMap(state)
+	sm["SnapshotMeta"] = []interface{}{meta}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(sm); err != nil {
+		c.Ui.Error(fmt.Sprintf("failed to encode output: %v", err))
+		return 1
+	}
+
+	return 0
+}

--- a/helper/raftutil/sample_test.go
+++ b/helper/raftutil/sample_test.go
@@ -1,0 +1,106 @@
+package raftutil
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/scheduler"
+	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSampleInvariant illustrates how to find offending log entry for an invariant
+func TestSampleInvariant(t *testing.T) {
+	t.Skip("not a real test")
+
+	path := "/tmp/nomad-datadir/server/raft"
+	ns := "default"
+	parentID := "myjob"
+
+	fsm, err := NewFSM(path)
+	require.NoError(t, err)
+
+	state := fsm.State()
+	for {
+		idx, _, err := fsm.ApplyNext()
+		if err == ErrNoMoreLogs {
+			break
+		}
+		require.NoError(t, err)
+
+		// Test invariant for each entry
+
+		// For example, test job summary numbers against running jobs
+		summary, err := state.JobSummaryByID(nil, ns, parentID)
+		require.NoError(t, err)
+
+		if summary == nil {
+			// job hasn't been created yet
+			continue
+		}
+
+		summaryCount := summary.Children.Running + summary.Children.Pending + summary.Children.Dead
+		jobCountByParent := 0
+
+		iter, err := state.Jobs(nil)
+		require.NoError(t, err)
+		for {
+			rawJob := iter.Next()
+			if rawJob == nil {
+				break
+			}
+			job := rawJob.(*structs.Job)
+			if job.Namespace == ns && job.ParentID == parentID {
+				jobCountByParent++
+			}
+		}
+
+		require.Equalf(t, summaryCount, jobCountByParent, "job summary at idx=%v", idx)
+
+	}
+
+	// any post-assertion follow
+}
+
+// TestSchedulerLogic illustrates how to test how to test the scheduler
+// logic for handling an eval
+func TestSchedulerLogic(t *testing.T) {
+	t.Skip("not a real test")
+
+	path := "/tmp/nomad-datadir/server/raft"
+	ns := "default"
+	jobID := "myjob"
+	testIdx := uint64(3234)
+
+	fsm, err := NewFSM(path)
+	require.NoError(t, err)
+
+	_, _, err = fsm.ApplyUntil(testIdx)
+	require.NoError(t, err)
+
+	state := fsm.State()
+
+	job, err := state.JobByID(nil, ns, jobID)
+	require.NoError(t, err)
+
+	// Create an eval and schedule it!
+	// Create a mock evaluation to register the job
+	eval := &structs.Evaluation{
+		Namespace:   ns,
+		ID:          uuid.Generate(),
+		Priority:    job.Priority,
+		TriggeredBy: structs.EvalTriggerJobRegister,
+		JobID:       job.ID,
+		Status:      structs.EvalStatusPending,
+	}
+
+	// Process the evaluation
+	h := scheduler.NewHarnessWithState(t, state)
+	err = h.Process(scheduler.NewServiceScheduler, eval)
+	require.NoError(t, err)
+
+	require.Len(t, h.Plans, 1)
+	pretty.Println(h.Plans[0])
+
+}

--- a/helper/raftutil/snapshot.go
+++ b/helper/raftutil/snapshot.go
@@ -1,0 +1,46 @@
+package raftutil
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/helper/snapshot"
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/raft"
+)
+
+func RestoreFromArchive(archive io.Reader) (*state.StateStore, *raft.SnapshotMeta, error) {
+	logger := hclog.L()
+
+	fsm, err := dummyFSM(logger)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create FSM: %w", err)
+	}
+
+	snap, err := ioutil.TempFile("", "snap-")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create a temp file: %w", err)
+	}
+	defer os.Remove(snap.Name())
+	defer snap.Close()
+
+	meta, err := snapshot.CopySnapshot(archive, snap)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read snapshot: %w", err)
+	}
+
+	_, err = snap.Seek(0, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to seek: %w", err)
+	}
+
+	err = fsm.Restore(snap)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to restore from snapshot: %w", err)
+	}
+
+	return fsm.State(), meta, nil
+}

--- a/helper/snapshot/snapshot.go
+++ b/helper/snapshot/snapshot.go
@@ -140,6 +140,11 @@ func (s *Snapshot) Close() error {
 
 // Verify takes the snapshot from the reader and verifies its contents.
 func Verify(in io.Reader) (*raft.SnapshotMeta, error) {
+	return CopySnapshot(in, ioutil.Discard)
+}
+
+// CopySnapshot copies the snapshot content from snapshot archive to dest
+func CopySnapshot(in io.Reader, dest io.Writer) (*raft.SnapshotMeta, error) {
 	// Wrap the reader in a gzip decompressor.
 	decomp, err := gzip.NewReader(in)
 	if err != nil {
@@ -149,7 +154,7 @@ func Verify(in io.Reader) (*raft.SnapshotMeta, error) {
 
 	// Read the archive, throwing away the snapshot data.
 	var metadata raft.SnapshotMeta
-	if err := read(decomp, &metadata, ioutil.Discard); err != nil {
+	if err := read(decomp, &metadata, dest); err != nil {
 		return nil, fmt.Errorf("failed to read snapshot file: %v", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ var (
 		"operator raft _info",
 		"operator raft _logs",
 		"operator raft _state",
+		"operator snapshot _state",
 	}
 
 	// aliases is the list of aliases we want users to be aware of. We hide


### PR DESCRIPTION
This PR refactors `helper/raftutil` package to ease testing and debugging a cluster dump programatically. When debugging a customer cluster, one can write a test case to find the offending raft entry that voilates an invariant, or simulate a scheduling decision based on a state index. Illustrative tests are in [`helper/raftutil/sample_test.go`](https://github.com/hashicorp/nomad/blob/c-raftutil-debug-3/helper/raftutil/sample_test.go).

Also, adding `nomad operator snapshot _state` command that emits the state in json from a snapshot generated by `operator snapshot save`. This basically the equivalent of `nomad operator raft _state` but for snapshots.