### PR TITLE
core: bump rejected plans from debug -> info

### DIFF
--- a/.changelog/11416.txt
+++ b/.changelog/11416.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Elevated rejected node plan log lines to help diagnose #9506
+```

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -483,7 +483,8 @@ func evaluatePlanPlacements(pool *EvaluatePool, snap *state.StateSnapshot, plan 
 				//is resolved this log line is the only way to
 				//monitor the disagreement between workers and
 				//the plan applier.
-				logger.Info("plan for node rejected", "node_id", nodeID, "reason", reason, "eval_id", plan.EvalID)
+				logger.Info("plan for node rejected, refer to https://www.nomadproject.io/s/port-plan-failure for more information",
+					"node_id", nodeID, "reason", reason, "eval_id", plan.EvalID)
 			}
 			// Set that this is a partial commit
 			partialCommit = true

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -477,7 +477,13 @@ func evaluatePlanPlacements(pool *EvaluatePool, snap *state.StateSnapshot, plan 
 		if !fit {
 			// Log the reason why the node's allocations could not be made
 			if reason != "" {
-				logger.Debug("plan for node rejected", "node_id", nodeID, "reason", reason, "eval_id", plan.EvalID)
+				//TODO This was debug level and should return
+				//to debug level in the future. However until
+				//https://github.com/hashicorp/nomad/issues/9506
+				//is resolved this log line is the only way to
+				//monitor the disagreement between workers and
+				//the plan applier.
+				logger.Info("plan for node rejected", "node_id", nodeID, "reason", reason, "eval_id", plan.EvalID)
 			}
 			// Set that this is a partial commit
 			partialCommit = true

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -189,6 +189,14 @@ module.exports = [
     permanent: true,
   },
 
+  // /s/* redirects for useful links that need a stable URL but we may need to
+  // change its destination in the future.
+  {
+    source: '/s/port-plan-failure',
+    destination: 'https://github.com/hashicorp/nomad/issues/9506',
+    permanent: false,
+  },
+
   // Spark guide links are all repointed to deprecated nomad-spark repo
   {
     source: '/guides/spark',


### PR DESCRIPTION
As we have continued to see reports of #9506 we need to elevate this log
line as it is the only way to detect when plans are being *erroneously*
rejected.

Users who see this log line repeatedly should drain and restart the node
in the log line. This seems to workaorund the issue.

Please post any details on #9506!