### PR TITLE
rpc: set the job scale eval priority to the job priority.

### DIFF
--- a/.changelog/11429.txt
+++ b/.changelog/11429.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+rpc: Set the job scale eval priority to the job priority
+```

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1129,7 +1129,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 			eval := &structs.Evaluation{
 				ID:             uuid.Generate(),
 				Namespace:      namespace,
-				Priority:       structs.JobDefaultPriority,
+				Priority:       job.Priority, // Safe as nil check performed above.
 				Type:           structs.JobTypeService,
 				TriggeredBy:    structs.EvalTriggerScaling,
 				JobID:          args.JobID,


### PR DESCRIPTION
Previously the eval priority was set to the default priority
rather than the priority configured within the target job. This
change fixes this bug, ensuring any eval created as a result of
scaling uses the job priority.