### PR TITLE
cli: refactor operator debug capture

### DIFF
--- a/.changelog/11466.txt
+++ b/.changelog/11466.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Improve debug capture for Consul/Vault
+```

--- a/client/testutil/driver_compatible.go
+++ b/client/testutil/driver_compatible.go
@@ -24,6 +24,14 @@ func RequireConsul(t *testing.T) {
 	}
 }
 
+// RequireVault skips tests unless a Vault binary is available on $PATH.
+func RequireVault(t *testing.T) {
+	_, err := exec.Command("vault", "version").CombinedOutput()
+	if err != nil {
+		t.Skipf("Test requires Vault: %v", err)
+	}
+}
+
 func ExecCompatible(t *testing.T) {
 	if runtime.GOOS != "linux" || syscall.Geteuid() != 0 {
 		t.Skip("Test only available running as root on linux")

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/version"
 	"github.com/posener/complete"
 )
 
@@ -500,6 +501,7 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 	// Display general info about the capture
 	c.Ui.Output("Starting debugger...")
 	c.Ui.Output("")
+	c.Ui.Output(fmt.Sprintf("Nomad CLI Version: %s", version.GetVersion().FullVersionNumber(true)))
 	c.Ui.Output(fmt.Sprintf("           Region: %s", c.region))
 	c.Ui.Output(fmt.Sprintf("        Namespace: %s", c.namespace))
 	c.Ui.Output(fmt.Sprintf("          Servers: (%d/%d) %v", serverCaptureCount, serversFound, c.serverIDs))

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -426,13 +426,18 @@ func TestDebug_CapturedFiles(t *testing.T) {
 	ui := cli.NewMockUi()
 	cmd := &OperatorDebugCommand{Meta: Meta{Ui: ui}}
 
+	duration := 2 * time.Second
+	interval := 750 * time.Millisecond
+	waitTime := 2 * duration
+
 	code := cmd.Run([]string{
 		"-address", url,
 		"-output", os.TempDir(),
 		"-server-id", serverName,
 		"-node-id", clientID,
-		"-duration", "1300ms",
-		"-interval", "600ms",
+		"-duration", duration.String(),
+		"-interval", interval.String(),
+		"-pprof-duration", "0",
 	})
 
 	// Get capture directory
@@ -447,27 +452,27 @@ func TestDebug_CapturedFiles(t *testing.T) {
 	// Verify cluster files
 	clusterPaths := buildPathSlice(cmd.path(clusterDir), clusterFiles)
 	t.Logf("Waiting for cluster files in path: %s", clusterDir)
-	testutil.WaitForFilesUntil(t, clusterPaths, 2*time.Minute)
+	testutil.WaitForFilesUntil(t, clusterPaths, waitTime)
 
 	// Verify client files
 	clientPaths := buildPathSlice(cmd.path(clientDir, clientID), clientFiles)
 	t.Logf("Waiting for client files in path: %s", clientDir)
-	testutil.WaitForFilesUntil(t, clientPaths, 2*time.Minute)
+	testutil.WaitForFilesUntil(t, clientPaths, waitTime)
 
 	// Verify server files
 	serverPaths := buildPathSlice(cmd.path(serverDir, serverName), serverFiles)
 	t.Logf("Waiting for server files in path: %s", serverDir)
-	testutil.WaitForFilesUntil(t, serverPaths, 2*time.Minute)
+	testutil.WaitForFilesUntil(t, serverPaths, waitTime)
 
 	// Verify interval 0000 files
 	intervalPaths0 := buildPathSlice(cmd.path(intervalDir, "0000"), intervalFiles)
 	t.Logf("Waiting for interval 0000 files in path: %s", intervalDir)
-	testutil.WaitForFilesUntil(t, intervalPaths0, 2*time.Minute)
+	testutil.WaitForFilesUntil(t, intervalPaths0, waitTime)
 
 	// Verify interval 0001 files
 	intervalPaths1 := buildPathSlice(cmd.path(intervalDir, "0001"), intervalFiles)
 	t.Logf("Waiting for interval 0001 files in path: %s", intervalDir)
-	testutil.WaitForFilesUntil(t, intervalPaths1, 2*time.Minute)
+	testutil.WaitForFilesUntil(t, intervalPaths1, waitTime)
 }
 
 func TestDebug_ExistingOutput(t *testing.T) {

--- a/testutil/vault.go
+++ b/testutil/vault.go
@@ -130,7 +130,7 @@ func NewTestVaultFromPath(t testing.T, binary string) *TestVault {
 
 }
 
-// NewTestVault returns a new TestVault instance that has yet to be started
+// NewTestVault returns a new TestVault instance that is ready for API calls
 func NewTestVault(t testing.T) *TestVault {
 	// Lookup vault from the path
 	return NewTestVaultFromPath(t, "vault")


### PR DESCRIPTION
This PR refactors the collection routines for Consul and Vault, captures a bit more useful information for troubleshooting, and expands the unit test coverage.

* Fix Consul/Vault TLS address mismatch issues
* Fix Vault sys health URL
* Add capture of Consul agent host and agent metrics
* Add CLI version to output
* Update unit test to validate multiregion cluster
