### PR TITLE
jobspec: Add vault secret stanza

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -832,11 +832,12 @@ func (tmpl *Template) Canonicalize() {
 }
 
 type Vault struct {
-	Policies     []string `hcl:"policies,optional"`
-	Namespace    *string  `mapstructure:"namespace" hcl:"namespace,optional"`
-	Env          *bool    `hcl:"env,optional"`
-	ChangeMode   *string  `mapstructure:"change_mode" hcl:"change_mode,optional"`
-	ChangeSignal *string  `mapstructure:"change_signal" hcl:"change_signal,optional"`
+	Policies     []string       `hcl:"policies,optional"`
+	Namespace    *string        `mapstructure:"namespace" hcl:"namespace,optional"`
+	Env          *bool          `hcl:"env,optional"`
+	ChangeMode   *string        `mapstructure:"change_mode" hcl:"change_mode,optional"`
+	ChangeSignal *string        `mapstructure:"change_signal" hcl:"change_signal,optional"`
+	Secrets      []*VaultSecret `hcl:"secret,block"`
 }
 
 func (v *Vault) Canonicalize() {
@@ -852,6 +853,11 @@ func (v *Vault) Canonicalize() {
 	if v.ChangeSignal == nil {
 		v.ChangeSignal = stringToPtr("SIGHUP")
 	}
+}
+
+type VaultSecret struct {
+	Name string `hcl:"name,label"`
+	Path string `hcl:"path"`
 }
 
 // NewTask creates and initializes a new Task.

--- a/client/allocrunner/taskrunner/artifact_hook_test.go
+++ b/client/allocrunner/taskrunner/artifact_hook_test.go
@@ -94,7 +94,7 @@ func TestTaskRunner_ArtifactHook_PartialDone(t *testing.T) {
 	}()
 
 	req := &interfaces.TaskPrestartRequest{
-		TaskEnv: taskenv.NewTaskEnv(nil, nil, nil, nil, destdir, ""),
+		TaskEnv: taskenv.NewTaskEnv(nil, nil, nil, nil, nil, destdir, ""),
 		TaskDir: &allocdir.TaskDir{Dir: destdir},
 		Task: &structs.Task{
 			Artifacts: []*structs.TaskArtifact{

--- a/client/allocrunner/taskrunner/envoy_version_hook_test.go
+++ b/client/allocrunner/taskrunner/envoy_version_hook_test.go
@@ -20,7 +20,7 @@ var (
 	taskEnvDefault = taskenv.NewTaskEnv(nil, nil, nil, map[string]string{
 		"meta.connect.sidecar_image": envoy.ImageFormat,
 		"meta.connect.gateway_image": envoy.ImageFormat,
-	}, "", "")
+	}, nil, "", "")
 )
 
 func TestEnvoyVersionHook_semver(t *testing.T) {
@@ -142,7 +142,7 @@ func TestEnvoyVersionHook_interpolateImage(t *testing.T) {
 			"MY_ENVOY": "my/envoy",
 		}, map[string]string{
 			"MY_ENVOY": "my/envoy",
-		}, nil, nil, "", ""))
+		}, nil, nil, nil, "", ""))
 		require.Equal(t, "my/envoy", task.Config["image"])
 	})
 

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -65,7 +65,6 @@ func (tr *TaskRunner) initHooks() {
 		newLogMonHook(tr, hookLogger),
 		newDispatchHook(alloc, hookLogger),
 		newVolumeHook(tr, hookLogger),
-		newArtifactHook(tr, hookLogger),
 		newStatsHook(tr, tr.clientConfig.StatsCollectionInterval, hookLogger),
 		newDeviceHook(tr.devicemanager, hookLogger),
 	}
@@ -79,6 +78,7 @@ func (tr *TaskRunner) initHooks() {
 	if task.Vault != nil {
 		tr.runnerHooks = append(tr.runnerHooks, newVaultHook(&vaultHookConfig{
 			vaultStanza: task.Vault,
+			envBuilder:  tr.envBuilder,
 			client:      tr.vaultClient,
 			events:      tr,
 			lifecycle:   tr,
@@ -88,6 +88,8 @@ func (tr *TaskRunner) initHooks() {
 			task:        tr.taskName,
 		}))
 	}
+
+	tr.runnerHooks = append(tr.runnerHooks, newArtifactHook(tr, hookLogger))
 
 	// Get the consul namespace for the TG of the allocation
 	consulNamespace := tr.alloc.ConsulNamespace()

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -1339,6 +1339,7 @@ func TestTaskTemplateManager_Env_InterpolatedDest(t *testing.T) {
 		map[string]string{"NOMAD_META_path": "exists"},
 		map[string]string{},
 		map[string]string{},
+		map[string]string{},
 		d, "")
 
 	vars, err := loadTemplateEnv(templates, taskEnv)

--- a/client/allocrunner/taskrunner/vault_hook_test.go
+++ b/client/allocrunner/taskrunner/vault_hook_test.go
@@ -1,8 +1,127 @@
 package taskrunner
 
-import "github.com/hashicorp/nomad/client/allocrunner/interfaces"
+import (
+	"context"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/allocdir"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/client/vaultclient"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	vapi "github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
 
 // Statically assert the stats hook implements the expected interfaces
 var _ interfaces.TaskPrestartHook = (*vaultHook)(nil)
 var _ interfaces.TaskStopHook = (*vaultHook)(nil)
 var _ interfaces.ShutdownHook = (*vaultHook)(nil)
+
+func newTestVault(t *testing.T, logger hclog.Logger) (*testutil.TestVault, vaultclient.VaultClient, error) {
+	testVault := testutil.NewTestVault(t)
+
+	vc, err := vaultclient.NewVaultClient(testVault.Config, logger, func(alloc *structs.Allocation, tasks []string, v *vapi.Client) (map[string]string, error) {
+		tokens := make(map[string]string)
+		for _, taskName := range tasks {
+			task := alloc.LookupTask(taskName)
+			tcr := vapi.TokenCreateRequest{
+				Policies:  task.Vault.Policies,
+				Renewable: new(bool),
+			}
+			*tcr.Renewable = true
+
+			s, err := testVault.Client.Auth().Token().Create(&tcr)
+			if err != nil {
+				return nil, err
+			}
+			tokens[taskName] = s.Auth.ClientToken
+		}
+
+		return tokens, nil
+	})
+
+	return testVault, vc, err
+}
+
+func TestVaultHook_Secret(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	logger := testlog.HCLogger(t)
+
+	testVault, vaultClient, err := newTestVault(t, logger)
+	r.NoError(err)
+	defer testVault.Stop()
+
+	policy := "test"
+	vaultPath := "secret/data/password"
+	key := "password"
+	content := "bar"
+
+	// Write policy & secret to Vault
+	sys := testVault.Client.Sys()
+	r.NoError(sys.PutPolicy(policy, `
+		path "secret/data/*" {
+			capabilities = ["read"]
+		}
+	`))
+	logical := testVault.Client.Logical()
+	_, err = logical.Write(vaultPath, map[string]interface{}{"data": map[string]interface{}{key: content}})
+	r.NoError(err)
+
+	// Create alloc, task and taskrunner
+	allocDir, cleanup := allocdir.TestAllocDir(t, logger, "ConnectNative")
+	defer cleanup()
+
+	alloc := mock.Alloc()
+	task := alloc.Job.LookupTaskGroup(alloc.TaskGroup).Tasks[0]
+
+	trConfig, cleanup := testTaskRunnerConfig(t, alloc, task.Name)
+	defer cleanup()
+	tr, err := NewTaskRunner(trConfig)
+	r.NoError(err)
+
+	// Build the vault stanza
+	secretName := "topsecret"
+	vaultStanza := structs.Vault{
+		Policies: []string{policy},
+		Secrets: []*structs.VaultSecret{
+			{Name: secretName, Path: vaultPath},
+		},
+	}
+	task.Vault = &vaultStanza
+
+	h := newVaultHook(&vaultHookConfig{
+		vaultStanza: &vaultStanza,
+		client:      vaultClient,
+		lifecycle:   tr,
+		updater:     tr,
+		envBuilder:  tr.envBuilder,
+		logger:      logger,
+		alloc:       alloc,
+		task:        task.Name,
+	})
+
+	request := &interfaces.TaskPrestartRequest{
+		Task:    task,
+		TaskDir: allocDir.NewTaskDir(task.Name),
+	}
+	r.NoError(request.TaskDir.Build(false, nil))
+
+	response := new(interfaces.TaskPrestartResponse)
+
+	// Run vault client & prestart hook
+	vaultClient.Start()
+	defer vaultClient.Stop()
+	r.NoError(h.Prestart(context.Background(), request, response))
+
+	// Assert the secret was put into envbuilder
+	env := tr.envBuilder.Build().All()
+	r.Equal(env["secret."+secretName+"."+key], content)
+	values, errs, err := tr.envBuilder.Build().AllValues()
+	r.Empty(errs)
+	r.NoError(err)
+	r.Equal(values["secret"].AsValueMap()[secretName].AsValueMap()[key].AsString(), content)
+}

--- a/client/taskenv/services_test.go
+++ b/client/taskenv/services_test.go
@@ -104,7 +104,7 @@ func TestInterpolateServices(t *testing.T) {
 var testEnv = NewTaskEnv(
 	map[string]string{"foo": "bar", "baz": "blah"},
 	map[string]string{"foo": "bar", "baz": "blah"},
-	nil, nil, "", "")
+	nil, nil, nil, "", "")
 
 func TestInterpolate_interpolateMapStringSliceString(t *testing.T) {
 	t.Parallel()
@@ -201,7 +201,7 @@ func TestInterpolate_interpolateConnect(t *testing.T) {
 		"service1":          "_service1",
 		"host1":             "_host1",
 	}
-	env := NewTaskEnv(e, e, nil, nil, "", "")
+	env := NewTaskEnv(e, e, nil, nil, nil, "", "")
 
 	connect := &structs.ConsulConnect{
 		Native: false,

--- a/client/vaultclient/vaultclient_testing.go
+++ b/client/vaultclient/vaultclient_testing.go
@@ -117,6 +117,8 @@ func (vc *MockVaultClient) Stop() {}
 
 func (vc *MockVaultClient) GetConsulACL(string, string) (*vaultapi.Secret, error) { return nil, nil }
 
+func (vc *MockVaultClient) GetSecret(string, string) (*vaultapi.Secret, error) { return nil, nil }
+
 // StoppedTokens tracks the tokens that have stopped renewing
 func (vc *MockVaultClient) StoppedTokens() []string {
 	vc.mu.Lock()

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1102,6 +1102,15 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 			ChangeMode:   *apiTask.Vault.ChangeMode,
 			ChangeSignal: *apiTask.Vault.ChangeSignal,
 		}
+		for _, secret := range apiTask.Vault.Secrets {
+			structsTask.Vault.Secrets = append(structsTask.Vault.Secrets,
+				&structs.VaultSecret{
+					Name: secret.Name,
+					Path: secret.Path,
+				},
+			)
+		}
+
 	}
 
 	if len(apiTask.Templates) > 0 {

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -2278,6 +2278,12 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 							Env:          helper.BoolToPtr(true),
 							ChangeMode:   helper.StringToPtr("c"),
 							ChangeSignal: helper.StringToPtr("sighup"),
+							Secrets: []*api.VaultSecret{
+								{
+									Name: "name",
+									Path: "path",
+								},
+							},
 						},
 						Templates: []*api.Template{
 							{
@@ -2671,6 +2677,12 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 							Env:          true,
 							ChangeMode:   "c",
 							ChangeSignal: "sighup",
+							Secrets: []*structs.VaultSecret{
+								{
+									Name: "name",
+									Path: "path",
+								},
+							},
 						},
 						Templates: []*structs.Template{
 							{

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8669,6 +8669,16 @@ type Vault struct {
 	// ChangeSignal is the signal sent to the task when a new token is
 	// retrieved. This is only valid when using the signal change mode.
 	ChangeSignal string
+
+	// Secrets is the set of secrets that should be made available
+	Secrets []*VaultSecret
+}
+
+type VaultSecret struct {
+	// Name is the name the secret should be made available under
+	Name string
+	// Path is the Vault path to read the secret from
+	Path string
 }
 
 func DefaultVaultBlock() *Vault {

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -5022,6 +5022,20 @@ func TestVault_Validate(t *testing.T) {
 	}
 }
 
+func TestVaultSecret_Validate(t *testing.T) {
+	s := &VaultSecret{}
+	err := s.Validate()
+	if err == nil {
+		t.Fatalf("Expeceted validation errors")
+	}
+	if ! strings.Contains(err.Error(), "name") {
+		t.Fatalf("Expected missing name error")
+	}
+	if ! strings.Contains(err.Error(), "path") {
+		t.Fatalf("Expected missing path error")
+	}
+}
+
 func TestParameterizedJobConfig_Validate(t *testing.T) {
 	d := &ParameterizedJobConfig{
 		Payload: "foo",


### PR DESCRIPTION
This PR adds a new `secret` stanza for loading secrets from Vault similar to the `credentials` stanza proposed by @schmichael in https://github.com/hashicorp/nomad/issues/3854#issuecomment-682104557. Compared to the existing way of loading secrets into environment variables using `template`, this solution
* Allows using secrets elsewhere in the jobspec where templates' environment variables are not available such as the `artifact` stanza (#3854, e.g. S3 credentials) or the driver config (e.g. Docker auth #9740)
* Has security benefits because secrets that are only needed internally within Nomad will not be exposed to the task 
* Isn't as [verbose](https://learn.hashicorp.com/tutorials/nomad/vault-pki-nomad#nomad-servers) with more complex use cases such as generating certificates using the PKI Secrets Engine

In contrast to a possible HCL2 vault function (see #9434) this doesn't require Vault access from the CLI and doesn't leak secrets into the job spec.

As part of the vault prestart hook, requested secrets will be fetched from Vault and the response's `.Data` is made available as `${secret.<name>}`:

```hcl
# Example adapted from the linked comment by @schmichael  
job "example" {
  vault {
    policies = ["s3_artifacts", "dockerhub"]
    secret "s3" {
      path = "secret/data/s3/artifacts"
    }
    secret "docker" {
      path = "secret/data/dockerhub"
    }
  }
  group "example" {
    task "example" {
      artifact {
        source      = "..."
        destination = "..."
        options { 
          aws_access_key_id = "${secret.s3.access_key}"
          aws_access_key_secret = "${secret.s3.secret_key}"
        }
      }
      driver = "docker"
      config {
        image = "private/image"
        auth {
          username = "${secret.docker.user}"
          password = "${secret.docker.password}"
        }
      }
    }
  }
}
```

This isn't finished yet because I wanted to ask for feedback before putting more time into this. I've hardly done any development in Go before and I'm totally unfamiliar with Nomad's code, so there may be rookie mistakes. The test I wrote in `vault_hook_test.go` is a copy-pasty mess. I've changed the task runner hook order so that `artifactHook` is executed after `vaultHook`, not sure if this causes any problems. Also, this implementation doesn't support updates when a secret changes in Vault. I personally believe that's fine as long as it's documented; use cases like `artifact` don't need it and for use cases that do, `template` is still available. Some other things that are missing:

- [ ] Support for writing data to Vault (needed for certificate generation)
- [ ] Per [jobspec checklist](https://github.com/hashicorp/nomad/blob/main/contributing/checklist-jobspec.md): Diff logic for the new `VaultSecret` struct
- [ ] Per jobspec checklist: Change detection
- [ ] Documentation

Looking forward to some feedback! If this is a candidate for merging, I'd be happy to continue working on the remaining points though any help is appreciated, especially with documentation since that may better be left to a native speaker.