### PR TITLE
api: return 404 for alloc FS list/stat endpoints

### DIFF
--- a/.changelog/11482.txt
+++ b/.changelog/11482.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Return a HTTP 404 instead of a HTTP 500 from the Stat File and List Files API endpoints when a file or directory is not found.
+```

--- a/command/agent/fs_endpoint.go
+++ b/command/agent/fs_endpoint.go
@@ -80,7 +80,7 @@ func (s *HTTPServer) DirectoryListRequest(resp http.ResponseWriter, req *http.Re
 	}
 
 	if rpcErr != nil {
-		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) {
+		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) || structs.IsErrNoSuchFileOrDirectory(rpcErr) {
 			rpcErr = CodedError(404, rpcErr.Error())
 		}
 
@@ -120,7 +120,7 @@ func (s *HTTPServer) FileStatRequest(resp http.ResponseWriter, req *http.Request
 	}
 
 	if rpcErr != nil {
-		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) {
+		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) || structs.IsErrNoSuchFileOrDirectory(rpcErr) {
 			rpcErr = CodedError(404, rpcErr.Error())
 		}
 

--- a/nomad/structs/errors.go
+++ b/nomad/structs/errors.go
@@ -177,6 +177,10 @@ func IsErrNodeLacksRpc(err error) bool {
 	return err != nil && strings.Contains(err.Error(), errNodeLacksRpc)
 }
 
+func IsErrNoSuchFileOrDirectory(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "no such file or directory")
+}
+
 // NewErrRPCCoded wraps an RPC error with a code to be converted to HTTP status
 // code
 func NewErrRPCCoded(code int, msg string) error {

--- a/ui/app/adapters/allocation.js
+++ b/ui/app/adapters/allocation.js
@@ -31,14 +31,8 @@ async function handleFSResponse(response) {
   } else {
     const body = await response.text();
 
-    // TODO update this if/when endpoint returns 404 as expected
-    const statusIs500 = response.status === 500;
-    const bodyIncludes404Text = body.includes('no such file or directory');
-
-    const translatedCode = statusIs500 && bodyIncludes404Text ? 404 : response.status;
-
     throw {
-      code: translatedCode,
+      code: response.status,
       toString: () => body,
     };
   }

--- a/ui/tests/acceptance/behaviors/fs.js
+++ b/ui/tests/acceptance/behaviors/fs.js
@@ -361,7 +361,8 @@ export default function browseFilesystem({
       ...visitSegments({ allocation: this.allocation, task: this.task }),
       path: '/what-is-this',
     });
-    assert.equal(FS.error.title, 'Not Found', '500 is interpreted as 404');
+    assert.notEqual(FS.error.title, 'Not Found', '500 is not interpreted as 404');
+    assert.equal(FS.error.title, 'Server Error', '500 is not interpreted as 500');
 
     await visit('/');
 
@@ -385,7 +386,8 @@ export default function browseFilesystem({
       ...visitSegments({ allocation: this.allocation, task: this.task }),
       path: this.directory.name,
     });
-    assert.equal(FS.error.title, 'Not Found', '500 is interpreted as 404');
+    assert.notEqual(FS.error.title, 'Not Found', '500 is not interpreted as 404');
+    assert.equal(FS.error.title, 'Server Error', '500 is not interpreted as 404');
 
     await visit('/');
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11480

If the alloc filesystem doesn't have a file requested by the List Files (`/v1/client/fs/ls`) or Stat File API (`/v1/client/fs/stat`), we currently return a HTTP 500 error with the expected "file not found" error message. Return a HTTP 404 error instead.

This change doesn't help the streaming endpoints, but all our callers currently call the `/v1/client/fs/stat` endpoint first.