### PR TITLE
docs: add note about the Nomad APM autoscaling plugin and scaling cluster to zero

### DIFF
--- a/website/content/docs/autoscaling/plugins/apm/nomad.mdx
+++ b/website/content/docs/autoscaling/plugins/apm/nomad.mdx
@@ -11,6 +11,10 @@ an immediate starting point without addition applications but comes at the price
 of efficiency. When using this APM, it is advised to monitor Nomad carefully
 ensuring it is not put under excessive load pressure.
 
+~> The Nomad APM plugin should only be used when scaling based on CPU and
+memory usage only. For more advanced scenarios, such as scaling a cluster to
+zero clients, you should use a different APM plugin.
+
 ## Agent Configuration Options
 
 ```hcl

--- a/website/content/docs/autoscaling/plugins/apm/nomad.mdx
+++ b/website/content/docs/autoscaling/plugins/apm/nomad.mdx
@@ -12,7 +12,7 @@ of efficiency. When using this APM, it is advised to monitor Nomad carefully
 ensuring it is not put under excessive load pressure.
 
 ~> The Nomad APM plugin should only be used when scaling based on CPU and
-memory usage only. For more advanced scenarios, such as scaling a cluster to
+memory usage. For more advanced scenarios, such as scaling a cluster to
 zero clients, you should use a different APM plugin.
 
 ## Agent Configuration Options


### PR DESCRIPTION
Scaling a cluster to zero clients while using the Nomad APM is [not possible](https://github.com/hashicorp/nomad-autoscaler/pull/534), so we should document this more explicitly.