### PR TITLE
docs: remove mutual-exclusion between node class and datacenter in scaling policies

### DIFF
--- a/website/content/docs/autoscaling/plugins/target/aws-asg.mdx
+++ b/website/content/docs/autoscaling/plugins/target/aws-asg.mdx
@@ -98,12 +98,10 @@ check "hashistack-allocated-cpu" {
   interact with when performing scaling actions.
 
 - `datacenter` `(string: "")` - The Nomad client [datacenter][nomad_datacenter]
-  identifier used to group nodes into a pool of resource. Conflicts with
-  `node_class`.
+  identifier used to group nodes into a pool of resource.
 
 - `node_class` `(string: "")` - The Nomad [client node class][nomad_node_class]
-  identifier used to group nodes into a pool of resource. Conflicts with
-  `datacenter`.
+  identifier used to group nodes into a pool of resource.
 
 - `node_drain_deadline` `(duration: "15m")` The Nomad [drain
   deadline][nomad_node_drain_deadline] to use when performing node draining

--- a/website/content/docs/autoscaling/plugins/target/azure-vmss.mdx
+++ b/website/content/docs/autoscaling/plugins/target/azure-vmss.mdx
@@ -101,12 +101,10 @@ check "clients-azure-vmss" {
   scale set to interact with when performing scaling actions.
 
 - `datacenter` `(string: "")` - The Nomad client [datacenter][nomad_datacenter]
-  identifier used to group nodes into a pool of resource. Conflicts with
-  `node_class`.
+  identifier used to group nodes into a pool of resource.
 
 - `node_class` `(string: "")` - The Nomad [client node class][nomad_node_class]
-  identifier used to group nodes into a pool of resource. Conflicts with
-  `datacenter`.
+  identifier used to group nodes into a pool of resource.
 
 - `node_drain_deadline` `(duration: "15m")` The Nomad [drain
   deadline][nomad_node_drain_deadline] to use when performing node draining

--- a/website/content/docs/autoscaling/plugins/target/gce-mig.mdx
+++ b/website/content/docs/autoscaling/plugins/target/gce-mig.mdx
@@ -77,12 +77,10 @@ check "hashistack-allocated-cpu" {
   Group to interact with when performing scaling actions.
 
 - `datacenter` `(string: "")` - The Nomad client [datacenter][nomad_datacenter]
-  identifier used to group nodes into a pool of resource. Conflicts with
-  `node_class`.
+  identifier used to group nodes into a pool of resource.
 
 - `node_class` `(string: "")` - The Nomad [client node class][nomad_node_class]
-  identifier used to group nodes into a pool of resource. Conflicts with
-  `datacenter`.
+  identifier used to group nodes into a pool of resource.
 
 - `node_drain_deadline` `(duration: "15m")` The Nomad [drain
   deadline][nomad_node_drain_deadline] to use when performing node draining


### PR DESCRIPTION
With https://github.com/hashicorp/nomad-autoscaler/pull/535, `node_class` and `datacenter` can be defined at the same time in a scaling policy.