### PR TITLE
metrics: added `mapped_file` metric

### DIFF
--- a/.changelog/11500.txt
+++ b/.changelog/11500.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+metrics: added nomad.client.allocs.memory.mapped_file metric
+```

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -1388,7 +1388,7 @@ func (tr *TaskRunner) setGaugeForMemory(ru *cstructs.TaskResourceUsage) {
 	publishMetric(ms.RSS, "rss", "RSS")
 	publishMetric(ms.Cache, "cache", "Cache")
 	publishMetric(ms.Swap, "swap", "Swap")
-	publishMetric(ms.MappedFile, "mapped_file", "MappedFile")
+	publishMetric(ms.MappedFile, "mapped_file", "Mapped File")
 	publishMetric(ms.Usage, "usage", "Usage")
 	publishMetric(ms.MaxUsage, "max_usage", "Max Usage")
 	publishMetric(ms.KernelUsage, "kernel_usage", "Kernel Usage")

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -1388,6 +1388,7 @@ func (tr *TaskRunner) setGaugeForMemory(ru *cstructs.TaskResourceUsage) {
 	publishMetric(ms.RSS, "rss", "RSS")
 	publishMetric(ms.Cache, "cache", "Cache")
 	publishMetric(ms.Swap, "swap", "Swap")
+	publishMetric(ms.MappedFile, "mapped_file", "MappedFile")
 	publishMetric(ms.Usage, "usage", "Usage")
 	publishMetric(ms.MaxUsage, "max_usage", "Max Usage")
 	publishMetric(ms.KernelUsage, "kernel_usage", "Kernel Usage")

--- a/client/structs/structs.go
+++ b/client/structs/structs.go
@@ -206,6 +206,7 @@ type MemoryStats struct {
 	RSS            uint64
 	Cache          uint64
 	Swap           uint64
+	MappedFile     uint64
 	Usage          uint64
 	MaxUsage       uint64
 	KernelUsage    uint64
@@ -223,6 +224,7 @@ func (ms *MemoryStats) Add(other *MemoryStats) {
 	ms.RSS += other.RSS
 	ms.Cache += other.Cache
 	ms.Swap += other.Swap
+	ms.MappedFile += other.MappedFile
 	ms.Usage += other.Usage
 	ms.MaxUsage += other.MaxUsage
 	ms.KernelUsage += other.KernelUsage

--- a/drivers/docker/stats_test.go
+++ b/drivers/docker/stats_test.go
@@ -27,6 +27,7 @@ func TestDriver_DockerStatsCollector(t *testing.T) {
 	stats.MemoryStats.Stats.Rss = 6537216
 	stats.MemoryStats.Stats.Cache = 1234
 	stats.MemoryStats.Stats.Swap = 0
+	stats.MemoryStats.Stats.MappedFile = 1024
 	stats.MemoryStats.Usage = 5651904
 	stats.MemoryStats.MaxUsage = 6651904
 	stats.MemoryStats.Commit = 123231
@@ -47,6 +48,7 @@ func TestDriver_DockerStatsCollector(t *testing.T) {
 			require.Equal(stats.MemoryStats.Stats.Rss, ru.ResourceUsage.MemoryStats.RSS)
 			require.Equal(stats.MemoryStats.Stats.Cache, ru.ResourceUsage.MemoryStats.Cache)
 			require.Equal(stats.MemoryStats.Stats.Swap, ru.ResourceUsage.MemoryStats.Swap)
+			require.Equal(stats.MemoryStats.Stats.MappedFile, ru.ResourceUsage.MemoryStats.MappedFile)
 			require.Equal(stats.MemoryStats.Usage, ru.ResourceUsage.MemoryStats.Usage)
 			require.Equal(stats.MemoryStats.MaxUsage, ru.ResourceUsage.MemoryStats.MaxUsage)
 			require.Equal(stats.CPUStats.ThrottlingData.ThrottledPeriods, ru.ResourceUsage.CpuStats.ThrottledPeriods)

--- a/drivers/docker/util/stats_posix.go
+++ b/drivers/docker/util/stats_posix.go
@@ -29,12 +29,13 @@ func DockerStatsToTaskResourceUsage(s *docker.Stats) *cstructs.TaskResourceUsage
 	}
 
 	ms := &cstructs.MemoryStats{
-		RSS:      s.MemoryStats.Stats.Rss,
-		Cache:    s.MemoryStats.Stats.Cache,
-		Swap:     s.MemoryStats.Stats.Swap,
-		Usage:    s.MemoryStats.Usage,
-		MaxUsage: s.MemoryStats.MaxUsage,
-		Measured: measuredMems,
+		RSS:        s.MemoryStats.Stats.Rss,
+		Cache:      s.MemoryStats.Stats.Cache,
+		Swap:       s.MemoryStats.Stats.Swap,
+		MappedFile: s.MemoryStats.Stats.MappedFile,
+		Usage:      s.MemoryStats.Usage,
+		MaxUsage:   s.MemoryStats.MaxUsage,
+		Measured:   measuredMems,
 	}
 
 	cs := &cstructs.CpuStats{

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -383,10 +383,12 @@ func (l *LibcontainerExecutor) handleStats(ch chan *cstructs.TaskResourceUsage, 
 		maxUsage := stats.MemoryStats.Usage.MaxUsage
 		rss := stats.MemoryStats.Stats["rss"]
 		cache := stats.MemoryStats.Stats["cache"]
+		mapped_file := stats.MemoryStats.Stats["mapped_file"]
 		ms := &cstructs.MemoryStats{
 			RSS:            rss,
 			Cache:          cache,
 			Swap:           swap.Usage,
+			MappedFile:     mapped_file,
 			Usage:          stats.MemoryStats.Usage.Usage,
 			MaxUsage:       maxUsage,
 			KernelUsage:    stats.MemoryStats.KernelUsage.Usage,


### PR DESCRIPTION
This PR should address #10067 and trivially adds  `mapped_file` in DockerStatsToTaskResourceUsage.

It sounds like that the `mapped_file` metric is needed in here as well:

https://github.com/deblasis/nomad/blob/b4a230d2cf57ff7a18c1e3bca006a9a7c4b284ca/drivers/shared/executor/executor_linux.go#L386

I had a look at [runc](https://github.com/opencontainers/runc) code and it seems that the metric is pulled from the `memory.stat` file, in compliance with https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
 so I thought it was a good thing to add it in `LibcontainerExecutor` as well.

If you think it's a welcome addition and tests are needed, I would like a pointer on how to test that as well. 

Cheers


