### PR TITLE
Refactor `sendAck` with bool into `sendAck` and `sendNack`

### DIFF
--- a/nomad/worker_test.go
+++ b/nomad/worker_test.go
@@ -133,7 +133,7 @@ func TestWorker_dequeueEvaluation_SerialJobs(t *testing.T) {
 	}
 
 	// Send the Ack
-	w.sendAck(eval1.ID, token, true)
+	w.sendAck(eval1.ID, token)
 
 	// Attempt second dequeue
 	eval, token, waitIndex, shutdown = w.dequeueEvaluation(10 * time.Millisecond)
@@ -258,7 +258,7 @@ func TestWorker_sendAck(t *testing.T) {
 	}
 
 	// Send the Nack
-	w.sendAck(eval.ID, token, false)
+	w.sendNack(eval.ID, token)
 
 	// Check the depth is 1, nothing unacked
 	stats = s1.evalBroker.Stats()
@@ -270,7 +270,7 @@ func TestWorker_sendAck(t *testing.T) {
 	eval, token, _, _ = w.dequeueEvaluation(10 * time.Millisecond)
 
 	// Send the Ack
-	w.sendAck(eval.ID, token, true)
+	w.sendAck(eval.ID, token)
 
 	// Check the depth is 0
 	stats = s1.evalBroker.Stats()
@@ -674,7 +674,7 @@ func TestWorker_ReblockEval(t *testing.T) {
 	}
 
 	// Ack the eval
-	w.sendAck(evalOut.ID, token, true)
+	w.sendAck(evalOut.ID, token)
 
 	// Check that it is blocked
 	bStats := s1.blockedEvals.Stats()


### PR DESCRIPTION
This is a small refactor to improve code scanability by developers. Originally the `sendAck` function took a bool as its third parameter which indicated whether to `ack` or `nack` the evaluation. This change makes the intention more clear without having to know the intention of that third parameter by creating small wrapper functions called `sendAck` and `sendNack`. These are thin shims over the original behavior, which was renamed to `sendAcknowledgement`.