### PR TITLE
cli: improve debug error messages

### DIFF
--- a/.changelog/11507.txt
+++ b/.changelog/11507.txt
@@ -1,0 +1,3 @@
+```improvement
+cli: improve `nomad operator debug` error messages
+```

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -707,6 +707,11 @@ func (c *OperatorDebugCommand) collectAgentHost(path, id string, client *api.Cli
 		host, err = client.Agent().Host("", id, c.queryOpts())
 	}
 
+	if isRedirectError(err) {
+		c.Ui.Warn(fmt.Sprintf("%s/%s: /v1/agent/host unavailable on this agent", path, id))
+		return
+	}
+
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("%s/%s: Failed to retrieve agent host data, err: %v", path, id, err))
 
@@ -1427,4 +1432,14 @@ func defaultHttpClient() *http.Client {
 	}
 
 	return httpClient
+}
+
+// isRedirectError returns true if an error is a redirect error.
+func isRedirectError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	const redirectErr string = `invalid character '<' looking for beginning of value`
+	return strings.Contains(err.Error(), redirectErr)
 }


### PR DESCRIPTION
Improves `nomad debug` error messages when contacting agents that do not
have /v1/agent/host endpoints (the endpoint was added in v0.12.0)

Part of #9568 and manually tested against Nomad v0.8.7.

Hopefully isRedirectError can be reused for more cases listed in #9568