### PR TITLE
Add support for setting pids_limit in docker plugin config.

### DIFF
--- a/.changelog/11526.txt
+++ b/.changelog/11526.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+driver/docker: Added support for client-wide `pids_limit` configuration
+```

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -289,6 +289,7 @@ var (
 			hclspec.NewAttr("pull_activity_timeout", "string", false),
 			hclspec.NewLiteral(`"2m"`),
 		),
+		"pids_limit": hclspec.NewAttr("pids_limit", "number", false),
 		// disable_log_collection indicates whether docker driver should collect logs of docker
 		// task containers.  If true, nomad doesn't start docker_logger/logmon processes
 		"disable_log_collection": hclspec.NewAttr("disable_log_collection", "bool", false),
@@ -623,6 +624,7 @@ type DriverConfig struct {
 	infraImagePullTimeoutDuration time.Duration `codec:"-"`
 	DisableLogCollection          bool          `codec:"disable_log_collection"`
 	PullActivityTimeout           string        `codec:"pull_activity_timeout"`
+	PidsLimit                     int64         `codec:"pids_limit"`
 	pullActivityTimeoutDuration   time.Duration `codec:"-"`
 	ExtraLabels                   []string      `codec:"extra_labels"`
 	Logging                       LoggingConfig `codec:"logging"`

--- a/drivers/docker/driver_linux_test.go
+++ b/drivers/docker/driver_linux_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/client/testutil"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/freeport"
 	tu "github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
@@ -67,7 +68,7 @@ func TestDockerDriver_PluginConfig_PidsLimit(t *testing.T) {
 	cfg.PidsLimit = 3
 	opts, err := driver.createContainerConfig(task, cfg, "org/repo:0.1")
 	require.NoError(t, err)
-	require.Equal(t, opts.HostConfig.PidsLimit, 3)
+	require.Equal(t, helper.Int64ToPtr(3), opts.HostConfig.PidsLimit)
 }
 
 func TestDockerDriver_PidsLimit(t *testing.T) {

--- a/drivers/docker/fingerprint.go
+++ b/drivers/docker/fingerprint.go
@@ -120,6 +120,10 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 		fp.Attributes["driver.docker.privileged.enabled"] = pstructs.NewBoolAttribute(true)
 	}
 
+	if d.config.PidsLimit > 0 {
+		fp.Attributes["driver.docker.pids.limit"] = pstructs.NewIntAttribute(d.config.PidsLimit, "")
+	}
+
 	if d.config.Volumes.Enabled {
 		fp.Attributes["driver.docker.volumes.enabled"] = pstructs.NewBoolAttribute(true)
 	}

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -836,11 +836,11 @@ plugin "docker" {
   from the Docker engine during an image pull within this timeframe, Nomad will
   timeout the request that initiated the pull command. (Minimum of `1m`)
 
-- `pids_limit` - An integer value (Defaults to unlimited) that specifies the pids
-   limit for all the docker containers running on that nomad client node. You can
-   override this limit by setting `pids_limit` in your job spec, however you can only
-   set `pids_limit` in your job spec which is less than or equal to `pids_limit`
-   defined in nomad client plugin config.
+- `pids_limit` - Defaults to unlimited (`0`). An integer value that specifies
+  the pid limit for all the Docker containers running on that Nomad client. You
+  can override this limit by setting [`pids_limit`] in your task config. If
+  this value is greater than `0`, your task `pids_limit` must be less than or
+  equal to the value defined here.
 
 - `allow_caps` - A list of allowed Linux capabilities. Defaults to
 
@@ -1173,3 +1173,4 @@ Windows is relatively new and rapidly evolving you may want to consult the
 [allow_caps]: /docs/drivers/docker#allow_caps
 [Connect]: /docs/job-specification/connect
 [`bridge`]: docs/job-specification/network#bridge
+[`pids_limit`]: /docs/drivers/docker#pids_limit

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -836,6 +836,12 @@ plugin "docker" {
   from the Docker engine during an image pull within this timeframe, Nomad will
   timeout the request that initiated the pull command. (Minimum of `1m`)
 
+- `pids_limit` - An integer value (Defaults to unlimited) that specifies the pids
+   limit for all the docker containers running on that nomad client node. You can
+   override this limit by setting `pids_limit` in your job spec, however you can only
+   set `pids_limit` in your job spec which is less than or equal to `pids_limit`
+   defined in nomad client plugin config.
+
 - `allow_caps` - A list of allowed Linux capabilities. Defaults to
 
 ```hcl


### PR DESCRIPTION
Currently, Nomad doesn't have a way to enforce `pids_limit` in containers, unless set by user in their job spec.
If a malicious user launches a container with a fork-bomb, that could exhaust entire nomad client host pids.

This PR will allow the operator to enforce `pids_limit` at Nomad client plugin config. User can still override that `pids_limit` in their job spec by setting [`pids_limit`](https://www.nomadproject.io/docs/drivers/docker#pids_limit)  however it must be less than the limit defined on nomad client plugin config.