### PR TITLE
Nomad job restart

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -171,6 +171,24 @@ func (j *Jobs) Info(jobID string, q *QueryOptions) (*Job, *QueryMeta, error) {
 	return &resp, qm, nil
 }
 
+type JobRestartRequest struct {
+	BatchSize string
+	BatchWait int
+}
+
+// Batch restart a job
+func (j *Jobs) Restart(jobID string, q *WriteOptions, batchSize string, batchWait int) error {
+	req := &JobRestartRequest{
+		BatchSize: batchSize,
+		BatchWait: batchWait,
+	}
+	_, err := j.client.write(fmt.Sprintf("/v1/job/%s/restart", url.PathEscape(jobID)), req, nil, q)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Scale is used to retrieve information about a particular
 // job given its unique ID.
 func (j *Jobs) Scale(jobID, group string, count *int, message string, error bool, meta map[string]interface{},

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -270,6 +270,7 @@ func (s *HTTPServer) ClientGCRequest(resp http.ResponseWriter, req *http.Request
 
 func (s *HTTPServer) allocRestart(allocID string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Build the request and parse the ACL token
+	fmt.Println("HELLO: command/agent/alloc_endpoint.go: allocRestart")
 	args := structs.AllocRestartRequest{
 		AllocID:  allocID,
 		TaskName: "",
@@ -295,10 +296,13 @@ func (s *HTTPServer) allocRestart(allocID string, resp http.ResponseWriter, req 
 	var reply structs.GenericResponse
 	var rpcErr error
 	if useLocalClient {
+		fmt.Println("HELLO: useLocalClient")
 		rpcErr = s.agent.Client().ClientRPC("Allocations.Restart", &args, &reply)
 	} else if useClientRPC {
+		fmt.Println("HELLO: useClientRPC")
 		rpcErr = s.agent.Client().RPC("ClientAllocations.Restart", &args, &reply)
 	} else if useServerRPC {
+		fmt.Println("HELLO: useServerRPC")
 		rpcErr = s.agent.Server().RPC("ClientAllocations.Restart", &args, &reply)
 	} else {
 		rpcErr = CodedError(400, "No local Node and node_id not provided")

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -508,9 +508,6 @@ func (s *HTTPServer) jobRestart(resp http.ResponseWriter, req *http.Request, job
 		return nil, CodedError(400, err.Error())
 	}
 
-	fmt.Println(restartRequest.BatchSize)
-	fmt.Println(restartRequest.BatchWait)
-
 	args := structs.JobRestartRequest{
 		ID:              uuid.Generate(),
 		JobID:           jobName,

--- a/command/commands.go
+++ b/command/commands.go
@@ -320,6 +320,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"job restart": func() (cli.Command, error) {
+			return &JobRestartCommand{
+				Meta: meta,
+			}, nil
+		},
 		"job deployments": func() (cli.Command, error) {
 			return &JobDeploymentsCommand{
 				Meta: meta,

--- a/command/job_restart.go
+++ b/command/job_restart.go
@@ -1,0 +1,124 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
+)
+
+type JobRestartCommand struct {
+	Meta
+	BatchSize string
+	BatchWait int
+}
+
+func (c *JobRestartCommand) Help() string {
+	helpText := `
+Usage: nomad job restart [options] <job>
+
+  Restart allocations for a particular job in batches.
+
+  When ACLs are enabled, this command requires a token with the
+  'alloc-lifecycle', 'read-job', and 'list-jobs' capabilities for the
+  allocation's namespace.
+
+General Options:
+
+  ` + generalOptionsUsage(usageOptsDefault) + `
+
+Allocs Options:
+
+  -batch-size
+    Number of allocations to restart at once.
+
+  -batch-wait
+    Wait time in seconds between each batch restart.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *JobRestartCommand) Synopsis() string {
+	return "Restart all allocations for a job"
+}
+
+func (c *JobRestartCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-batch-size": complete.PredictNothing,
+			"-batch-wait": complete.PredictAnything,
+		})
+}
+
+func (c *JobRestartCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFunc(func(a complete.Args) []string {
+		client, err := c.Meta.Client()
+		if err != nil {
+			return nil
+		}
+
+		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Jobs, nil)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Jobs]
+	})
+}
+
+func (c *JobRestartCommand) Name() string { return "restart job and all it's allocations" }
+
+func (c *JobRestartCommand) Run(args []string) int {
+	var batchSize string
+	var batchWait int
+
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.StringVar(&batchSize, "batch-size", "5", "")
+	flags.IntVar(&batchWait, "batch-wait", 10, "")
+
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	// Check that we got exactly one job
+	args = flags.Args()
+	if len(args) != 1 {
+		c.Ui.Error("This command takes one argument: <job>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+
+	// Get the HTTP client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	jobID := strings.TrimSpace(args[0])
+
+	// Check if the job exists
+	jobs, _, err := client.Jobs().PrefixList(jobID)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error listing jobs: %s", err))
+		return 1
+	}
+	if len(jobs) == 0 {
+		c.Ui.Error(fmt.Sprintf("No job(s) with prefix or id %q found", jobID))
+		return 1
+	}
+	if len(jobs) > 1 {
+		if (jobID != jobs[0].ID) || (c.allNamespaces() && jobs[0].ID == jobs[1].ID) {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple jobs\n\n%s", createStatusListOutput(jobs, c.allNamespaces())))
+			return 1
+		}
+	}
+
+	jobID = jobs[0].ID
+	q := &api.WriteOptions{Namespace: jobs[0].JobSummary.Namespace}
+
+	client.Jobs().Restart(jobID, q, batchSize, batchWait)
+	return 0
+}

--- a/helper/raftutil/msgtypes.go
+++ b/helper/raftutil/msgtypes.go
@@ -54,6 +54,7 @@ var msgTypeNames = map[structs.MessageType]string{
 	structs.ServiceRegistrationUpsertRequestType:         "ServiceRegistrationUpsertRequestType",
 	structs.ServiceRegistrationDeleteByIDRequestType:     "ServiceRegistrationDeleteByIDRequestType",
 	structs.ServiceRegistrationDeleteByNodeIDRequestType: "ServiceRegistrationDeleteByNodeIDRequestType",
+	structs.JobRestartRequestType:                        "JobRestartRequestType",
 	structs.NamespaceUpsertRequestType:                   "NamespaceUpsertRequestType",
 	structs.NamespaceDeleteRequestType:                   "NamespaceDeleteRequestType",
 }

--- a/main.go
+++ b/main.go
@@ -64,7 +64,6 @@ var (
 	// Common commands are grouped separately to call them out to operators.
 	commonCommands = []string{
 		"run",
-		"restart",
 		"stop",
 		"status",
 		"alloc",

--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ var (
 	// Common commands are grouped separately to call them out to operators.
 	commonCommands = []string{
 		"run",
+		"restart",
 		"stop",
 		"status",
 		"alloc",

--- a/nomad/client_alloc_endpoint.go
+++ b/nomad/client_alloc_endpoint.go
@@ -180,6 +180,7 @@ func (a *ClientAllocations) GarbageCollect(args *structs.AllocSpecificRequest, r
 
 // Restart is used to trigger a restart of an allocation or a subtask on a client.
 func (a *ClientAllocations) Restart(args *structs.AllocRestartRequest, reply *structs.GenericResponse) error {
+	fmt.Println("HELLO nomad/client_alloc_endpoint.go")
 	// We only allow stale reads since the only potentially stale information is
 	// the Node registration and the cost is fairly high for adding another hop
 	// in the forwarding chain.

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -220,6 +220,8 @@ func (n *nomadFSM) Apply(log *raft.Log) interface{} {
 		return n.applyUpsertJob(msgType, buf[1:], log.Index)
 	case structs.JobDeregisterRequestType:
 		return n.applyDeregisterJob(msgType, buf[1:], log.Index)
+	case structs.JobRestartRequestType:
+		return n.applyRestartJob(msgType, buf[1:], log.Index)
 	case structs.EvalUpdateRequestType:
 		return n.applyUpdateEval(msgType, buf[1:], log.Index)
 	case structs.EvalDeleteRequestType:
@@ -426,6 +428,19 @@ func (n *nomadFSM) applyStatusUpdate(msgType structs.MessageType, buf []byte, in
 		n.blockedEvals.UnblockNode(req.NodeID, index)
 	}
 
+	return nil
+}
+
+func (n *nomadFSM) applyRestartJob(reqType structs.MessageType, buf []byte, index uint64) interface{} {
+
+	fmt.Println("HELLO HELLO: applyRestartJob")
+	var req structs.JobRestartRequest
+
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+
+	fmt.Printf("Hello JobRestartRequest object: %+v\n", req)
 	return nil
 }
 

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -432,8 +432,7 @@ func (n *nomadFSM) applyStatusUpdate(msgType structs.MessageType, buf []byte, in
 }
 
 func (n *nomadFSM) applyRestartJob(reqType structs.MessageType, buf []byte, index uint64) interface{} {
-
-	fmt.Println("HELLO HELLO: applyRestartJob")
+	fmt.Println("HELLO nomad/fsm.go: applyRestartJob")
 	var req structs.JobRestartRequest
 
 	if err := structs.Decode(buf, &req); err != nil {
@@ -441,6 +440,12 @@ func (n *nomadFSM) applyRestartJob(reqType structs.MessageType, buf []byte, inde
 	}
 
 	fmt.Printf("Hello JobRestartRequest object: %+v\n", req)
+
+	if err := n.state.UpdateJobRestart(reqType, index, &req); err != nil {
+		n.logger.Error("UpdateJobRestart failed", "error", err)
+		return err
+	}
+
 	return nil
 }
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1489,7 +1489,7 @@ func (j *Job) Restart(args *structs.JobRestartRequest,
 	}
 
 	for _, alloc := range allocs {
-		fmt.Printf("Hello alloc: %+v\n", alloc)
+		fmt.Printf("Hello alloc ID: %+s\n", alloc.ID)
 	}
 
 	// Commit this update via Raft

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1462,6 +1462,14 @@ func (j *Job) Allocations(args *structs.JobSpecificRequest,
 	return j.srv.blockingRPC(&opts)
 }
 
+func (j *Job) Restart(args *structs.JobRestartRequest,
+	reply *structs.JobRestartResponse) error {
+
+	fmt.Printf("Hello nomad/job_endpoint.go JobRestartRequest: %+v\n", args)
+
+	return nil
+}
+
 // Evaluations is used to list the evaluations for a job
 func (j *Job) Evaluations(args *structs.JobSpecificRequest,
 	reply *structs.JobEvaluationsResponse) error {

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1466,9 +1466,9 @@ func (j *Job) Restart(args *structs.JobRestartRequest,
 	reply *structs.JobRestartResponse) error {
 	fmt.Printf("HELLO HELLO: nomad/job_endpoint.go JobRestartRequest: %+v\n", args)
 
-	if done, err := j.srv.forward("Job.Restart", args, args, reply); done {
-		return err
-	}
+	//if done, err := j.srv.forward("Job.Restart", args, args, reply); done {
+	//	return err
+	//}
 
 	// Check for alloc-lifecycle, read-job and list-jobs permissions
 	if aclObj, err := j.srv.ResolveToken(args.AuthToken); err != nil {
@@ -1490,6 +1490,23 @@ func (j *Job) Restart(args *structs.JobRestartRequest,
 
 	for _, alloc := range allocs {
 		fmt.Printf("Hello alloc ID: %+s\n", alloc.ID)
+		queryOptions := structs.QueryOptions{}
+		queryOptions.Region = args.Region
+		queryOptions.Namespace = args.Namespace
+
+		allocRestartRequest := &structs.AllocRestartRequest{
+			AllocID: alloc.ID,
+			// Hardcoding this right now to test it out. Figure out how to get the task names for the allocation?
+			TaskName: "count-task",
+			//Region:    args.RequestRegion(),
+			//Namespace: args.Namespace,
+			QueryOptions: queryOptions,
+		}
+
+		var allocRestartResponse *structs.GenericResponse
+		if done, err := j.srv.forward("Allocations.Restart", allocRestartRequest, allocRestartRequest, allocRestartResponse); done {
+			return err
+		}
 	}
 
 	// Commit this update via Raft

--- a/nomad/state/events.go
+++ b/nomad/state/events.go
@@ -31,6 +31,7 @@ var MsgTypeEvents = map[structs.MessageType]string{
 	structs.ServiceRegistrationUpsertRequestType:         structs.TypeServiceRegistration,
 	structs.ServiceRegistrationDeleteByIDRequestType:     structs.TypeServiceDeregistration,
 	structs.ServiceRegistrationDeleteByNodeIDRequestType: structs.TypeServiceDeregistration,
+	structs.JobRestartRequestType:                        structs.TypeJobRestart,
 }
 
 func eventsFromChanges(tx ReadTxn, changes Changes) *structs.Events {

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -49,6 +49,7 @@ func init() {
 	RegisterSchemaFactories([]SchemaFactory{
 		indexTableSchema,
 		nodeTableSchema,
+		jobRestartSchema,
 		jobTableSchema,
 		jobSummarySchema,
 		jobVersionSchema,
@@ -103,6 +104,27 @@ func indexTableSchema() *memdb.TableSchema {
 				Indexer: &memdb.StringFieldIndex{
 					Field:     "Key",
 					Lowercase: true,
+				},
+			},
+		},
+	}
+}
+
+// jobRestartSchema returns the MemDB schema for the job restart table.
+// This table is used to store uuid and job restart state object.
+func jobRestartSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: "restart",
+		Indexes: map[string]*memdb.IndexSchema{
+			// Primary index is used for job restart management
+			// and simple direct lookup. ID (UUID) is required to be
+			// unique.
+			"id": {
+				Name:         "id",
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.UUIDFieldIndex{
+					Field: "ID",
 				},
 			},
 		},

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1027,6 +1027,28 @@ func (s *StateStore) BatchUpdateNodeDrain(msgType structs.MessageType, index uin
 	return txn.Commit()
 }
 
+// UpdateJobRestart updates jobRestart object into memdb.
+func (s *StateStore) UpdateJobRestart(msgType structs.MessageType, index uint64, req *structs.JobRestartRequest) error {
+	fmt.Println("HELLO state/state_store.go: UpdateJobRestart")
+	txn := s.db.WriteTxnMsgT(msgType, index)
+	defer txn.Abort()
+
+	if err := s.updateJobRestartImpl(txn, index, req); err != nil {
+		return err
+	}
+	return txn.Commit()
+}
+
+func (s *StateStore) updateJobRestartImpl(txn *txn, index uint64, req *structs.JobRestartRequest) error {
+	fmt.Println("HELLO: state/state_store.go: updateJobRestartImpl")
+	req.ModifyIndex = index
+	// Insert the job restart object
+	if err := txn.Insert("restart", req); err != nil {
+		return fmt.Errorf("job restart update failed: %v", err)
+	}
+	return nil
+}
+
 // UpdateNodeDrain is used to update the drain of a node
 func (s *StateStore) UpdateNodeDrain(msgType structs.MessageType, index uint64, nodeID string,
 	drain *structs.DrainStrategy, markEligible bool, updatedAt int64,

--- a/nomad/structs/event.go
+++ b/nomad/structs/event.go
@@ -40,6 +40,7 @@ const (
 	TypeEvalUpdated                   = "EvaluationUpdated"
 	TypeJobRegistered                 = "JobRegistered"
 	TypeJobDeregistered               = "JobDeregistered"
+	TypeJobRestart                    = "JobRestart"
 	TypeJobBatchDeregistered          = "JobBatchDeregistered"
 	TypePlanResult                    = "PlanResult"
 	TypeACLTokenDeleted               = "ACLTokenDeleted"

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -108,6 +108,7 @@ const (
 	ServiceRegistrationUpsertRequestType         MessageType = 47
 	ServiceRegistrationDeleteByIDRequestType     MessageType = 48
 	ServiceRegistrationDeleteByNodeIDRequestType MessageType = 49
+	JobRestartRequestType                        MessageType = 50
 
 	// Namespace types were moved from enterprise and therefore start at 64
 	NamespaceUpsertRequestType MessageType = 64
@@ -565,7 +566,8 @@ type JobRestartRequest struct {
 }
 
 type JobRestartResponse struct {
-	ID string
+	ID                 string
+	RestartModifyIndex uint64
 
 	WriteMeta
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -543,6 +543,33 @@ type DrainUpdate struct {
 	MarkEligible bool
 }
 
+// JobRestart is used for tracking the state of job restart.
+type JobRestartRequest struct {
+	ID    string // uuid of restart
+	JobID string // job being restarted
+
+	BatchSize string // number of allocations to restart at once
+	BatchWait int    // amount of time to wait between restarting each batch
+
+	Status string // running, paused, cancelled, complete
+
+	RestartedAllocs []string // Allocation IDs which have been restarted
+
+	StartedAt time.Time // time restart was started
+	UpdatedAt time.Time // time restart was last modified
+
+	CreateIndex uint64 // raft index when restart was started
+	ModifyIndex uint64 // raft index when restart was last modified
+
+	WriteRequest
+}
+
+type JobRestartResponse struct {
+	ID string
+
+	WriteMeta
+}
+
 // NodeUpdateEligibilityRequest is used for updating the scheduling	eligibility
 type NodeUpdateEligibilityRequest struct {
 	NodeID      string


### PR DESCRIPTION
@schmichael 
Thank you for writing the [`nomad-job-restart-rfc`](https://gist.github.com/schmichael/e0b8b2ec1eb146301175fd87ddd46180). This was super helpful!

This PR is not ready for review. I am just opening this, so I can put in my understanding of the flow, and ask some questions.
We can use this PR as a brainstorming ground to progress on the RFC, and eventually get it in shape to be merged.

Based on [`nomad/checklist-command`](https://github.com/hashicorp/nomad/blob/main/contributing/checklist-command.md)
This PR only has changes on `Code` section. No `Doc` changes are included right now.
The PR doesn't have implemented the `monitor` (and `detach`) mode where the `job restart` by default will start in `monitor` mode. And user can pass `-detach` to run the command in `detach` mode.

In phase 1, we ll just implement:
   - `nomad job restart -batch-size n -batch-wait d <job_id>`
   - `nomad job restart -attach <restart_id>`
   - `nomad job restart -cancel <restart_id>`

`Pause/resume` can come in Phase 2.

My understanding around the changes are as follows:

- New CLI Command: [`nomad job restart`](https://github.com/hashicorp/nomad/blob/334470746e11a395147f4d60252f017321f072af/command/job_restart.go)
    
- From the CLI, you jump to HTTP API client code in `api/jobs.go`. 
- From the HTTP API client, you call [`Restart`](https://github.com/hashicorp/nomad/blob/334470746e11a395147f4d60252f017321f072af/api/jobs.go#L164-L175) which calls into the actual HTTP API defined in `command/agent/job_endpoint.go`.
- `jobRestart` function is called in `command/agent/job_endpoint.go`. This decodes the HTTP request into API struct `api.JobRestartRequest` which can then be used to map into the RPC struct `structs.JobRestartRequest` and send an RPC.
 
   - Following structs are defined.
     - API request (I didn't define the response yet. Still contemplating what would be needed in the API response struct? Do we just send the UUID back to the user?). [`api.JobRestartRequest`](https://github.com/hashicorp/nomad/blob/334470746e11a395147f4d60252f017321f072af/api/jobs.go#L159-L162)
     - RPC Request struct: [`structs.JobRestartRequest`](https://github.com/hashicorp/nomad/blob/334470746e11a395147f4d60252f017321f072af/nomad/structs/structs.go#L544-L563)
     - RPC Response struct [`structs.JobRestartResponse`](https://github.com/hashicorp/nomad/blob/334470746e11a395147f4d60252f017321f072af/nomad/structs/structs.go#L565-L570)

- [`Restart RPC`](https://github.com/hashicorp/nomad/blob/334470746e11a395147f4d60252f017321f072af/nomad/job_endpoint.go#L1523-L1564) is called. This will check permissions on the auth-token, get the snapshot from the state store, get the allocations for the job, Restart all the allocations (Restarting of allocations is not coded yet). Everytime we restart an allocation, we update the modify index and commit this into raft.

- New raft message type defined: [`JobRestartRequestType`](https://github.com/hashicorp/nomad/blob/334470746e11a395147f4d60252f017321f072af/nomad/structs/structs.go#L107)
    
- Raft apply [`here`](https://github.com/hashicorp/nomad/blob/334470746e11a395147f4d60252f017321f072af/nomad/job_endpoint.go#L1554)
    
- raft log message applied by FSM in `nomad/fsm.go`
    
- This will call [`applyRestartJob`](https://github.com/hashicorp/nomad/blob/334470746e11a395147f4d60252f017321f072af/nomad/fsm.go#L427). This will decode the raft message into RPC struct and call into the state store: [`n.state.UpdateJobRestart`](https://github.com/hashicorp/nomad/blob/334470746e11a395147f4d60252f017321f072af/nomad/fsm.go#L437)

-  State store logic for committing the transaction to boltDB: https://github.com/hashicorp/nomad/blob/334470746e11a395147f4d60252f017321f072af/nomad/state/state_store.go#L969-L989 

 - New boltDB table schema defined: https://github.com/hashicorp/nomad/blob/334470746e11a395147f4d60252f017321f072af/nomad/state/schema.go#L101-L120
      
 Like I mentioned above, this patch might not be ready for review yet. It has a bunch of print statement left out. I added those just to test the flow and see if the data is being passed around correctly. E.g When I run this on a test job with 5 allocations, I can print some info like:

```
Nov 18 20:08:10 linux nomad[1955]:     2021-11-18T20:08:10.489Z [INFO]  client: started client: node_id=3757b276-95bb-1ed4-4fd7-c3169f6d919d
Nov 18 20:08:18 linux nomad[1955]:     2021-11-18T20:08:18.984Z [INFO]  client: node registration complete
Nov 18 20:10:06 linux nomad[1955]: HELLO HELLO: nomad/job_endpoint.go JobRestartRequest: &{ID:58d503f8-2c54-d3f5-4ca3-8484d123206d JobID:count BatchSize:5 BatchWait:10 Status:running RestartedAllocs:[] StartedAt:2021-11-18 20:10:06.373692499 +0000 UTC m=+122.230232254 UpdatedAt:2021-11-18 20:10:06.373692568 +0000 UTC m=+122.230232321 CreateIndex:0 ModifyIndex:0 WriteRequest:{Region:global Namespace:default AuthToken: IdempotencyToken: InternalRpcInfo:{Forwarded:false}}}
Nov 18 20:10:06 linux nomad[1955]: Hello alloc ID: 4089ce63-50e3-c370-54fe-6ab8a90d647e
Nov 18 20:10:06 linux nomad[1955]: Hello alloc ID: 910ed5bc-20dc-c027-1a40-e3d9c5d1eb2a
Nov 18 20:10:06 linux nomad[1955]: Hello alloc ID: c8d77bff-95bb-b4cb-b1d7-1dc2e8f294ef
Nov 18 20:10:06 linux nomad[1955]: Hello alloc ID: df98f5ce-b716-8e6e-cd48-55c37cd2d1f1
Nov 18 20:10:06 linux nomad[1955]: Hello alloc ID: fd9661e3-b167-6916-0350-84da97cae0a2
Nov 18 20:10:06 linux nomad[1955]: HELLO nomad/fsm.go: applyRestartJob
Nov 18 20:10:06 linux nomad[1955]: Hello JobRestartRequest object: {ID:58d503f8-2c54-d3f5-4ca3-8484d123206d JobID:count BatchSize:5 BatchWait:10 Status:running RestartedAllocs:[] StartedAt:2021-11-18 20:10:06.373692499 +0000 UTC UpdatedAt:2021-11-18 20:10:06.373692568 +0000 UTC CreateIndex:0 ModifyIndex:0 WriteRequest:{Region:global Namespace:default AuthToken: IdempotencyToken: InternalRpcInfo:{Forwarded:false}}}
Nov 18 20:10:06 linux nomad[1955]: HELLO state/state_store.go: UpdateJobRestart
Nov 18 20:10:06 linux nomad[1955]: HELLO: state/state_store.go: updateJobRestartImpl
```

Questions:

1) What would be the best way to restart allocations in the RPC code? (Any code references in the RPC code I could refer to?).
    Should we signal the restart right before [`raftApply`](https://github.com/hashicorp/nomad/blob/334470746e11a395147f4d60252f017321f072af/nomad/job_endpoint.go#L1554)
     i.e. for each alloc that we restart, we update the modify index and apply a new log message into raft. My understanding of the indexes is there are two indexes `CreateIndex` and `ModifyIndex`. The first time, we ll create the `JobRestartObject` in the server, we ll update the `CreateIndex`, and from that point onwards everytime we restart an alloc, `ModifyIndex` will be updated.

2) I am still not 100% clear on the boltDB table schema since it only has a `key` e.g. `id` in my table. Does that mean we can just store the entire `JobRestartRequest` Object against that key. If you can take a look at the state store code where I am committing the transaction and let me know if I am missing something.

This is probably a lot to read, and if this doesn't make a lot of sense, let me know. We can also carry some of this conversation back to our internal slack. I just wanted to put the patch out so it's easier to look at some code and go from there.

References: Issue #698 