### PR TITLE
docs: clarify vault.token only required on servers

### DIFF
--- a/website/content/docs/configuration/vault.mdx
+++ b/website/content/docs/configuration/vault.mdx
@@ -83,8 +83,9 @@ vault {
   should install a custom CA bundle and validate against it. Disabling SSL
   verification can allow an attacker to easily compromise your cluster.
 
-- `token` `(string: "")` - Specifies the parent Vault token to use to derive child tokens for jobs
-  requesting tokens.
+- `token` `(string: "")` - Specifies the parent Vault token to use to derive
+  child tokens for jobs requesting tokens. Only required on Nomad servers.
+  Nomad client agents use the allocation's token when contacting Vault.
   Visit the [Vault Integration Guide](/docs/vault-integration)
   to see how to generate an appropriate token in Vault.
 


### PR DESCRIPTION
While it *is* clarified toward the bottom of this page, I've seen people
go to great lengths to configure tokens for clients anyway, so I think
it's worth noting on the parameter's docs as well.