### PR TITLE
terraform: update installed version used to 1.0.11.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,11 @@ codecgen-*.generated.go
 **/structs.generated.go
 GNUMakefile.local
 
+# Terraform state and locking files.
 .terraform
 *.tfstate*
+.terraform.lock.hcl
+
 rkt-*
 
 ./idea

--- a/terraform/Vagrantfile
+++ b/terraform/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(2) do |config|
 
     PACKERVERSION=1.1.2
     PACKERDOWNLOAD=https://releases.hashicorp.com/packer/${PACKERVERSION}/packer_${PACKERVERSION}_linux_amd64.zip
-    TERRAFORMVERSION=0.11.0
+    TERRAFORMVERSION=1.0.11
     TERRAFORMDOWNLOAD=https://releases.hashicorp.com/terraform/${TERRAFORMVERSION}/terraform_${TERRAFORMVERSION}_linux_amd64.zip
 
     echo "Dependencies..."


### PR DESCRIPTION
The file syntax had been updated to post-0.12 syntax, whereas the Vagrant machine still installed a 0.11 version causing a failure to run `terraform init`. The update also includes a gitignore entry, ignoring the Terraform lock file present in newer versions.

closes #11536 