### PR TITLE
Add go build flags for macOS

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -97,7 +97,7 @@ ifeq (Darwin,$(THIS_OS))
 pkg/linux_%/nomad:
 CGO_ENABLED = 0
 CGO_CFLAGS=-Wno-undef-prefix
-SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
 endif
 
 pkg/windows_%/nomad: GO_OUT = $@.exe

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -81,6 +81,8 @@ endif
 		GOOS=$(firstword $(subst _, ,$*)) \
 		GOARCH=$(lastword $(subst _, ,$*)) \
 		CC=$(CC) \
+		CGO_CFLAGS=$(CGO_CFLAGS) \
+		SDKROOT=$(SDKROOT) \
 		go build -trimpath -ldflags $(GO_LDFLAGS) -tags "$(GO_TAGS)" -o $(GO_OUT)
 
 ifneq (armv7l,$(THIS_ARCH))
@@ -92,7 +94,10 @@ pkg/linux_arm64/nomad: CC = aarch64-linux-gnu-gcc
 endif
 
 ifeq (Darwin,$(THIS_OS))
-pkg/linux_%/nomad: CGO_ENABLED = 0
+pkg/linux_%/nomad:
+CGO_ENABLED = 0
+CGO_CFLAGS=-Wno-undef-prefix
+SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 endif
 
 pkg/windows_%/nomad: GO_OUT = $@.exe

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,6 @@ GIT_DIRTY := $(if $(shell git status --porcelain),+CHANGES)
 GO_LDFLAGS := "-X github.com/hashicorp/nomad/version.GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)"
 CGO_ENABLED = 1
 CGO_CFLAGS ?=
-SDKROOT ?=
 
 GO_TAGS ?=
 
@@ -85,7 +84,6 @@ endif
 		GOOS=$(firstword $(subst _, ,$*)) \
 		GOARCH=$(lastword $(subst _, ,$*)) \
 		CC=$(CC) \
-		SDKROOT=$(SDKROOT) \
 		go build -trimpath -ldflags $(GO_LDFLAGS) -tags "$(GO_TAGS)" -o $(GO_OUT)
 
 ifneq (armv7l,$(THIS_ARCH))
@@ -100,9 +98,7 @@ ifeq (Darwin,$(THIS_OS))
 pkg/linux_%/nomad: CGO_ENABLED = 0
 endif
 
-pkg/darwin_%/nomad:
-CGO_CFLAGS=-Wno-undef-prefix
-SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+pkg/darwin_%/nomad: CGO_CFLAGS=-Wno-undef-prefix
 
 pkg/windows_%/nomad: GO_OUT = $@.exe
 


### PR DESCRIPTION
Closes #11539 

Added new `pkg/darwin_%/nomad` build target with required flags.

I tested to see if these flags were required for cross-compilation by running both

```shell
CGO_ENABLED=0 \
GOOS=linux \
GOARCH=arm \
CC=arm-linux-gnueabihf-gcc \
go build -trimpath -tags "ui" -o bin/nomad'
```

and 

```shell
CGO_ENABLED=0 \
GOOS=linux \
GOARCH=arm64 \
CC=aarch64-linux-gnu-gcc \
go build -trimpath -tags "ui" -o bin/nomad
```

Both worked without requiring me to add additional flags. If that was not a valid test, please let me know.