### PR TITLE
Don't emit scaling event error when a deployment is underway

### DIFF
--- a/.changelog/11556.txt
+++ b/.changelog/11556.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+scaling: Don't emit scaling action with error in case of active deployment
+```

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1094,31 +1094,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 		}
 
 		if deployment != nil && deployment.Active() && deployment.JobCreateIndex == job.CreateIndex {
-			msg := "job scaling blocked due to active deployment"
-			_, _, err := j.srv.raftApply(
-				structs.ScalingEventRegisterRequestType,
-				&structs.ScalingEventRequest{
-					Namespace: job.Namespace,
-					JobID:     job.ID,
-					TaskGroup: groupName,
-					ScalingEvent: &structs.ScalingEvent{
-						Time:          now,
-						PreviousCount: prevCount,
-						Message:       msg,
-						Error:         true,
-						Meta: map[string]interface{}{
-							"OriginalMessage": args.Message,
-							"OriginalCount":   *args.Count,
-							"OriginalMeta":    args.Meta,
-						},
-					},
-				},
-			)
-			if err != nil {
-				// just log the error, this was a best-effort attempt
-				j.logger.Error("scaling event create failed during block scaling action", "error", err)
-			}
-			return structs.NewErrRPCCoded(400, msg)
+			return structs.NewErrRPCCoded(400, "job scaling blocked due to active deployment")
 		}
 
 		// Commit the job update

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -6695,22 +6695,6 @@ func TestJobEndpoint_Scale_DeploymentBlocking(t *testing.T) {
 			require.NotEmpty(resp.EvalID)
 			require.Greater(resp.EvalCreateIndex, resp.JobModifyIndex)
 		}
-
-		events, _, _ := state.ScalingEventsByJob(nil, job.Namespace, job.ID)
-		require.Equal(1, len(events[groupName]))
-		latestEvent := events[groupName][0]
-		if dLatest.Active() {
-			require.True(latestEvent.Error)
-			require.Nil(latestEvent.Count)
-			require.Contains(latestEvent.Message, "blocked due to active deployment")
-			require.Equal(latestEvent.Meta["OriginalCount"], newCount)
-			require.Equal(latestEvent.Meta["OriginalMessage"], scalingMessage)
-			require.Equal(latestEvent.Meta["OriginalMeta"], scalingMetadata)
-		} else {
-			require.False(latestEvent.Error)
-			require.NotNil(latestEvent.Count)
-			require.Equal(newCount, *latestEvent.Count)
-		}
 	}
 }
 


### PR DESCRIPTION
Following-up on https://github.com/hashicorp/nomad-autoscaler/pull/542, scaling actions not being performed due to active deployments is actually not uncommon. 

This PR removes the scaling event error that used to emitted in these situations to reduce noise and avoid confusing operators and make them look into possible errors that are not really a problem.