### PR TITLE
docs: add CLI and config docs for the Autoscaler policy source config

### DIFF
--- a/website/content/docs/autoscaling/agent/source.mdx
+++ b/website/content/docs/autoscaling/agent/source.mdx
@@ -1,0 +1,25 @@
+---
+layout: docs
+page_title: source Stanza - Nomad Autoscaler Agent Configuration
+description: >-
+  The "source" block is used to configure scaling target sources.
+---
+
+# `source` Block
+
+<Placement groups={['source']} />
+
+The `source` block is used to configure scaling target sources.
+
+```hcl
+source "nomad" {
+  enabled = false
+}
+```
+
+Supported sources are `file` and `nomad`.
+
+### `source` Parameters
+
+- `enabled` `(bool: true)` - Defines if the scaling policy source should be
+  enabled or disabled.

--- a/website/content/docs/autoscaling/agent/source.mdx
+++ b/website/content/docs/autoscaling/agent/source.mdx
@@ -7,13 +7,15 @@ description: >-
 
 # `source` Block
 
-<Placement groups={['source']} />
+<Placement groups={['policy', 'source']} />
 
 The `source` block is used to configure scaling target sources.
 
 ```hcl
-source "nomad" {
-  enabled = false
+policy {
+  source "nomad" {
+    enabled = false
+  }
 }
 ```
 

--- a/website/content/docs/autoscaling/cli.mdx
+++ b/website/content/docs/autoscaling/cli.mdx
@@ -91,6 +91,11 @@ passed in via CLI arguments. The `agent` command accepts the following arguments
   `cluster` and `horizontal` queues. Nomad Autoscaler Enterprise supports additional
   `vertical_mem` and `vertical_cpu` queues.
 
+- `-policy-source-disable-file`: Disable the sourcing of policies from disk.
+
+- `-policy-source-disable-nomad`: Disable the sourcing of policies from the
+  Nomad API.
+
 - `-telemetry-disable-hostname`: Specifies whether gauge values should be prefixed
   with the local hostname.
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1528,6 +1528,10 @@
             "path": "autoscaling/agent/policy_eval"
           },
           {
+            "title": "source",
+            "path": "autoscaling/agent/source"
+          },
+          {
             "title": "strategy",
             "path": "autoscaling/agent/strategy"
           },


### PR DESCRIPTION
Add support documentation for the new feature implemented in https://github.com/hashicorp/nomad-autoscaler/pull/544.