### PR TITLE
tools: update virtualbox networking configuration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 LINUX_BASE_BOX = "bento/ubuntu-18.04"
 FREEBSD_BASE_BOX = "freebsd/FreeBSD-11.3-STABLE"
 
-LINUX_IP_ADDRESS = "10.199.0.200"
+LINUX_IP_ADDRESS = "192.168.56.200"
 
 Vagrant.configure(2) do |config|
 	# Compilation and development boxes
@@ -82,8 +82,8 @@ Vagrant.configure(2) do |config|
 	1.upto(3) do |n|
 		serverName = "nomad-server%02d" % [n]
 		clientName = "nomad-client%02d" % [n]
-		serverIP = "10.199.0.%d" % [10 + n]
-		clientIP = "10.199.0.%d" % [20 + n]
+		serverIP = "192.168.56.%d" % [10 + n]
+		clientIP = "192.168.56.%d" % [20 + n]
 
 		config.vm.define serverName, autostart: false, primary: false do |vmCfg|
 			vmCfg.vm.box = LINUX_BASE_BOX


### PR DESCRIPTION
As of VirtualBox 6.1.28, host-only networks [are restricted to `192.168.56.0/21` by default](https://www.virtualbox.org/manual/ch06.html#network_hostonly),  so spinning up the Vagrant boxes with secondary networks fail with an error `E_ACCESSDENIED`.

Update the IP configuration of the Vagrant boxes to fall within the allowed range so that we don't need to ask developers from the community to make VirtualBox configuration updates outside of their normal Vagrant use.

(I ran into this myself but see also https://github.com/hashicorp/vagrant/issues/12553)