### PR TITLE
scheduler: fix panic in system jobs when nodes filtered by class

### DIFF
--- a/.changelog/11565.txt
+++ b/.changelog/11565.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Fix panic when system jobs are filtered by node class
+```

--- a/scheduler/scheduler_system.go
+++ b/scheduler/scheduler_system.go
@@ -287,8 +287,15 @@ func mergeNodeFiltered(acc, curr *structs.AllocMetric) *structs.AllocMetric {
 
 	acc.NodesEvaluated += curr.NodesEvaluated
 	acc.NodesFiltered += curr.NodesFiltered
+
+	if acc.ClassFiltered == nil {
+		acc.ClassFiltered = make(map[string]int)
+	}
 	for k, v := range curr.ClassFiltered {
 		acc.ClassFiltered[k] += v
+	}
+	if acc.ConstraintFiltered == nil {
+		acc.ConstraintFiltered = make(map[string]int)
 	}
 	for k, v := range curr.ConstraintFiltered {
 		acc.ConstraintFiltered[k] += v


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11563

In the system scheduler, if a subset of clients are filtered by class,
we hit a code path where the `AllocMetric` has been copied, but the
`Copy` method does not instantiate the various maps. This leads to an
assignment to a nil map. This changeset ensures that the maps are
non-nil before continuing.

The `Copy` method relies on functions in the `helper` package that all
return nil slices or maps when passed zero-length inputs. This
changeset to fix the panic bug intentionally defers updating those
functions because it'll have potential impact on memory usage. See
https://github.com/hashicorp/nomad/issues/11564 for more details.

This impacts 1.2.0 and above, so there's no backport required.