### PR TITLE
config: fix test-only failures in UI handler setup

### DIFF
--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -944,11 +944,6 @@ func TestHTTPServer_Limits_Error(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Use a fake agent since the HTTP server should never start
-			agent := &Agent{
-				logger: testlog.HCLogger(t),
-			}
-
 			conf := &Config{
 				normalizedAddrs: &Addresses{
 					HTTP: "localhost:0", // port is never used
@@ -960,6 +955,13 @@ func TestHTTPServer_Limits_Error(t *testing.T) {
 					HTTPSHandshakeTimeout: tc.timeout,
 					HTTPMaxConnsPerClient: tc.limit,
 				},
+			}
+
+			// Use a fake agent since the HTTP server should never start
+			agent := &Agent{
+				logger:     testlog.HCLogger(t),
+				httpLogger: testlog.HCLogger(t),
+				config:     conf,
 			}
 
 			srv, err := NewHTTPServer(agent, conf)


### PR DESCRIPTION
The `TestHTTPServer_Limits_Error` test never starts the agent so it
had an incomplete configuration, which caused panics in the test. Fix
the configuration.

The PR #11555 had a branch name like `f-ui-*` which caused CI to skip
the unit tests over the HTTP handler setup, so this wasn't caught in
PR review.