### PR TITLE
docs: fix typo in the comment

### DIFF
--- a/client/config/config.go
+++ b/client/config/config.go
@@ -87,7 +87,7 @@ type Config struct {
 	// LogOutput is the destination for logs
 	LogOutput io.Writer
 
-	// Logger provides a logger to thhe client
+	// Logger provides a logger to the client
 	Logger log.InterceptLogger
 
 	// Region is the clients region


### PR DESCRIPTION
This PR fixes a typo in the source code for `Config.Logger` field: `thhe -> the`.