### PR TITLE
docs: add deprecation note to old style network task env vars.

### DIFF
--- a/website/content/partials/envvars.mdx
+++ b/website/content/partials/envvars.mdx
@@ -196,8 +196,9 @@
         <code>NOMAD_IP_&lt;task&gt;_&lt;label&gt;</code>
       </td>
       <td>
-        Host IP for the given port <code>label</code> and <code>task</code> for
-        tasks in the same task group.
+        <b>Deprecated</b>. Host IP for the given port <code>label</code>
+        and <code>task</code> for tasks in the same task group. Only available
+        when setting ports via the task resource network port mapping.
       </td>
     </tr>
     <tr>
@@ -205,10 +206,11 @@
         <code>NOMAD_PORT_&lt;task&gt;_&lt;label&gt;</code>
       </td>
       <td>
-        Port for the given port <code>label</code> and <code>task</code> for
-        tasks in the same task group. Driver-specified port when a port map is
-        used, otherwise the host's static or dynamic port allocation.
-        Services should bind to this port.
+        <b>Deprecated</b>. Port for the given port <code>label</code> and
+        <code>task</code> for tasks in the same task group. Driver-specified port
+        when a port map is used, otherwise the host's static or dynamic port
+        allocation. Services should bind to this port. Only available when setting
+        ports via the task resource network port mapping.
       </td>
     </tr>
     <tr>
@@ -216,8 +218,10 @@
         <code>NOMAD_ADDR_&lt;task&gt;_&lt;label&gt;</code>
       </td>
       <td>
-        Host <code>IP:Port</code> pair for the given port <code>label</code> and
-        <code>task</code> for tasks in the same task group.
+        <b>Deprecated</b>. Host <code>IP:Port</code> pair for the given port
+        <code>label</code> and <code>task</code> for tasks in the same task group.
+        Only available when setting ports via the task resource network port
+        mapping.
       </td>
     </tr>
     <tr>
@@ -225,8 +229,9 @@
         <code>NOMAD_HOST_PORT_&lt;task&gt;_&lt;label&gt;</code>
       </td>
       <td>
-        Port on the host for the port <code>label</code> and <code>task</code>
-        for tasks in the same task group.
+        <b>Deprecated</b>. Port on the host for the port <code>label</code> and
+        <code>task</code> for tasks in the same task group. Only available when
+        setting ports via the task resource network port mapping.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
closes #11576 