### PR TITLE
clickable links in allocations chart

### DIFF
--- a/ui/app/components/job-page/parts/summary.js
+++ b/ui/app/components/job-page/parts/summary.js
@@ -1,13 +1,31 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 import { classNames } from '@ember-decorators/component';
 import classic from 'ember-classic-decorator';
 
 @classic
 @classNames('boxed-section')
 export default class Summary extends Component {
+  @service router;
+
   job = null;
   forceCollapsed = false;
+
+  @action
+  gotoAllocations(status) {
+    this.router.transitionTo('jobs.job.allocations', this.job, {
+      queryParams: {
+        status: JSON.stringify(status),
+        namespace: this.job.get('namespace.name'),
+      },
+    });
+  }
+
+  @action
+  onSliceClick(ev, slice) {
+    this.gotoAllocations([slice.label.camelize()]);
+  }
 
   @computed('forceCollapsed')
   get isExpanded() {

--- a/ui/app/templates/components/job-page/parts/summary.hbs
+++ b/ui/app/templates/components/job-page/parts/summary.hbs
@@ -44,6 +44,7 @@
       (if a.item.hasChildren "children-status-bar" "allocation-status-bar")
       allocationContainer=a.item.summary
       job=a.item.summary
+      onSliceClick=this.onSliceClick
       class="split-view" as |chart|
     }}
       <ol data-test-legend class="legend">

--- a/ui/app/templates/components/job-page/parts/summary.hbs
+++ b/ui/app/templates/components/job-page/parts/summary.hbs
@@ -1,4 +1,10 @@
-<ListAccordion data-test-job-summary @source={{array this.job}} @key="id" @startExpanded={{this.isExpanded}} @onToggle={{action this.persist}} as |a|>
+<ListAccordion
+  data-test-job-summary
+  @source={{array this.job}}
+  @key="id"
+  @startExpanded={{this.isExpanded}}
+  @onToggle={{action this.persist}} as |a|
+>
   <a.head @buttonLabel={{if a.isOpen "collapse" "expand"}}>
     <div class="columns">
       <div class="column is-minimum nowrap">
@@ -14,7 +20,6 @@
           </span>
         {{/if}}
       </div>
-
       {{#unless a.isOpen}}
         <div class="column">
           <div class="inline-chart bumper-left">
@@ -22,7 +27,9 @@
               {{#if (gt a.item.totalChildren 0)}}
                 <ChildrenStatusBar @job={{a.item}} @isNarrow={{true}} />
               {{else}}
-                <em class="is-faded">No Children</em>
+                <em class="is-faded">
+                  No Children
+                </em>
               {{/if}}
             {{else}}
               <AllocationStatusBar @allocationContainer={{a.item}} @isNarrow={{true}} />
@@ -33,17 +40,25 @@
     </div>
   </a.head>
   <a.body>
-    {{#component (if a.item.hasChildren "children-status-bar" "allocation-status-bar")
-    allocationContainer=a.item.summary
-    job=a.item.summary
-    class="split-view" as |chart|}}
-    <ol data-test-legend class="legend">
-      {{#each chart.data as |datum index|}}
-        <li class="{{datum.className}} {{if (eq datum.label chart.activeDatum.label) "is-active"}} {{if (eq datum.value 0) "is-empty"}}">
-          <JobPage::Parts::SummaryLegendItem @datum={{datum}} @index={{index}} />
-        </li>
-      {{/each}}
-    </ol>
-  {{/component}}
+    {{#component
+      (if a.item.hasChildren "children-status-bar" "allocation-status-bar")
+      allocationContainer=a.item.summary
+      job=a.item.summary
+      class="split-view" as |chart|
+    }}
+      <ol data-test-legend class="legend">
+        {{#each chart.data as |datum index|}}
+          <li
+            class="{{datum.className}}
+
+              {{if (eq datum.label chart.activeDatum.label) "is-active"}}
+
+              {{if (eq datum.value 0) "is-empty"}}"
+          >
+            <JobPage::Parts::SummaryLegendItem @datum={{datum}} @index={{index}} />
+          </li>
+        {{/each}}
+      </ol>
+    {{/component}}
   </a.body>
 </ListAccordion>


### PR DESCRIPTION
The spec calls for editing the Allocation Status Chart to look more like the Job Client Status Chart. However, the surface area of the Allocation Status Chart spans much further than the Job Client Status Chart as it appears in severals rows throughout the application, as well as, in the Task Group page.

Additionally, the linking capability requested by this feature requires getting the context of a job (and its associated namespace).

Until, we have clarity regarding the surface area of the requested changes:  is this change scoped only to the Job Detail Overview page or everywhere that we are rendering an Allocation Status Summary chart, we can't complete the work for adding links to the legend chart (and reformatting the legend).

Spec:

![image](https://user-images.githubusercontent.com/41024828/143475989-1ee2e7cd-ea3d-4439-b238-011d86cc58e3.png)
