### PR TITLE
rpc: fix scaling policy get index response when policy is found.

### DIFF
--- a/nomad/scaling_endpoint_test.go
+++ b/nomad/scaling_endpoint_test.go
@@ -36,7 +36,11 @@ func TestScalingEndpoint_GetPolicy(t *testing.T) {
 	p2 := mock.ScalingPolicy()
 	s1.fsm.State().UpsertScalingPolicies(1000, []*structs.ScalingPolicy{p1, p2})
 
-	// Lookup the policy
+	// Add another policy at a higher index.
+	p3 := mock.ScalingPolicy()
+	require.NoError(s1.fsm.State().UpsertScalingPolicies(2000, []*structs.ScalingPolicy{p3}))
+
+	// Lookup the first policy and perform assertions.
 	get := &structs.ScalingPolicySpecificRequest{
 		ID: p1.ID,
 		QueryOptions: structs.QueryOptions{
@@ -54,7 +58,7 @@ func TestScalingEndpoint_GetPolicy(t *testing.T) {
 	resp = structs.SingleScalingPolicyResponse{}
 	err = msgpackrpc.CallWithCodec(codec, "Scaling.GetPolicy", get, &resp)
 	require.NoError(err)
-	require.EqualValues(1000, resp.Index)
+	require.EqualValues(2000, resp.Index)
 	require.Nil(resp.Policy)
 }
 


### PR DESCRIPTION
When GetPolicy is called within the scaling handler, the index
table was being used to populate the reply index irregardless of
whether the policy was found or not. This change fixes that
behaviour so that the policy modify index is used when the policy
lookup is successful.