### PR TITLE
agent: support multiple http address in addresses.http

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -935,7 +935,9 @@ func (a *Agent) setupClient() error {
 // If no HTTP health check can be supported nil is returned.
 func (a *Agent) agentHTTPCheck(server bool) *structs.ServiceCheck {
 	// Resolve the http check address
-	httpCheckAddr := a.config.normalizedAddrs.HTTP
+    // TODO: evaluate if this is the best way to handle this default, maybe
+    // BindAddr?
+	httpCheckAddr := a.config.normalizedAddrs.HTTP[0]
 	if *a.config.Consul.ChecksUseAdvertise {
 		httpCheckAddr = a.config.AdvertiseAddrs.HTTP
 	}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -935,8 +935,8 @@ func (a *Agent) setupClient() error {
 // If no HTTP health check can be supported nil is returned.
 func (a *Agent) agentHTTPCheck(server bool) *structs.ServiceCheck {
 	// Resolve the http check address
-    // TODO: evaluate if this is the best way to handle this default, maybe
-    // BindAddr?
+	// TODO: evaluate if this is the best way to handle this default, maybe
+	// BindAddr?
 	httpCheckAddr := a.config.normalizedAddrs.HTTP[0]
 	if *a.config.Consul.ChecksUseAdvertise {
 		httpCheckAddr = a.config.AdvertiseAddrs.HTTP

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -935,8 +935,6 @@ func (a *Agent) setupClient() error {
 // If no HTTP health check can be supported nil is returned.
 func (a *Agent) agentHTTPCheck(server bool) *structs.ServiceCheck {
 	// Resolve the http check address
-	// TODO: evaluate if this is the best way to handle this default, maybe
-	// BindAddr?
 	httpCheckAddr := a.config.normalizedAddrs.HTTP[0]
 	if *a.config.Consul.ChecksUseAdvertise {
 		httpCheckAddr = a.config.AdvertiseAddrs.HTTP

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -166,7 +166,7 @@ func TestAgent_ServerConfig(t *testing.T) {
 	require.Equal(t, "127.0.0.3", conf.Addresses.HTTP)
 	require.Equal(t, "127.0.0.3", conf.Addresses.RPC)
 	require.Equal(t, "127.0.0.3", conf.Addresses.Serf)
-	require.Equal(t, "127.0.0.3:4646", conf.normalizedAddrs.HTTP)
+	require.Equal(t, []string{"127.0.0.3:4646"}, conf.normalizedAddrs.HTTP)
 	require.Equal(t, "127.0.0.3:4647", conf.normalizedAddrs.RPC)
 	require.Equal(t, "127.0.0.3:4648", conf.normalizedAddrs.Serf)
 

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -105,7 +105,7 @@ func TestAgent_ServerConfig(t *testing.T) {
 	require.Equal(t, "127.0.0.2", conf.Addresses.HTTP)
 	require.Equal(t, "127.0.0.2", conf.Addresses.RPC)
 	require.Equal(t, "127.0.0.2", conf.Addresses.Serf)
-	require.Equal(t, "127.0.0.2:4646", conf.normalizedAddrs.HTTP)
+	require.Equal(t, []string{"127.0.0.2:4646"}, conf.normalizedAddrs.HTTP)
 	require.Equal(t, "127.0.0.2:4003", conf.normalizedAddrs.RPC)
 	require.Equal(t, "127.0.0.2:4004", conf.normalizedAddrs.Serf)
 	require.Equal(t, "10.0.0.10:4646", conf.AdvertiseAddrs.HTTP)
@@ -563,7 +563,7 @@ func TestAgent_HTTPCheck(t *testing.T) {
 			logger: logger,
 			config: &Config{
 				AdvertiseAddrs:  &AdvertiseAddrs{HTTP: "advertise:4646"},
-				normalizedAddrs: &Addresses{HTTP: "normalized:4646"},
+				normalizedAddrs: &NormalizedAddrs{HTTP: []string{"normalized:4646"}},
 				Consul: &config.ConsulConfig{
 					ChecksUseAdvertise: helper.BoolToPtr(false),
 				},
@@ -587,7 +587,7 @@ func TestAgent_HTTPCheck(t *testing.T) {
 		if check.Protocol != "http" {
 			t.Errorf("expected http proto not: %q", check.Protocol)
 		}
-		if expected := a.config.normalizedAddrs.HTTP; check.PortLabel != expected {
+		if expected := a.config.normalizedAddrs.HTTP[0]; check.PortLabel != expected {
 			t.Errorf("expected normalized addr not %q", check.PortLabel)
 		}
 	})

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -500,13 +500,14 @@ func (c *Command) setupAgent(config *Config, logger hclog.InterceptLogger, logOu
 	c.agent = agent
 
 	// Setup the HTTP server
-	http, err := NewHTTPServer(agent, config)
+	httpServers, err := NewHTTPServers(agent, config)
 	if err != nil {
 		agent.Shutdown()
 		c.Ui.Error(fmt.Sprintf("Error starting http server: %s", err))
 		return err
 	}
-	c.httpServer = http
+    // TODO: update for multiple or change the type of NewHTTPServer
+	c.httpServer = &httpServers[0]
 
 	// If DisableUpdateCheck is not enabled, set up update checking
 	// (DisableUpdateCheck is false by default)
@@ -904,11 +905,12 @@ func (c *Command) reloadHTTPServer() error {
 
 	c.httpServer.Shutdown()
 
-	http, err := NewHTTPServer(c.agent, c.agent.config)
+	httpServers, err := NewHTTPServers(c.agent, c.agent.config)
 	if err != nil {
 		return err
 	}
-	c.httpServer = http
+    // TODO: change type or handle with list
+	c.httpServer = &httpServers[0]
 
 	return nil
 }

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -51,7 +51,7 @@ type Command struct {
 
 	args           []string
 	agent          *Agent
-	httpServer     *HTTPServer
+	httpServers    []HTTPServer
 	logFilter      *logutils.LevelFilter
 	logOutput      io.Writer
 	retryJoinErrCh chan struct{}
@@ -506,8 +506,7 @@ func (c *Command) setupAgent(config *Config, logger hclog.InterceptLogger, logOu
 		c.Ui.Error(fmt.Sprintf("Error starting http server: %s", err))
 		return err
 	}
-    // TODO: update for multiple or change the type of NewHTTPServer
-	c.httpServer = &httpServers[0]
+	c.httpServers = httpServers
 
 	// If DisableUpdateCheck is not enabled, set up update checking
 	// (DisableUpdateCheck is false by default)
@@ -701,8 +700,10 @@ func (c *Command) Run(args []string) int {
 
 		// Shutdown the http server at the end, to ease debugging if
 		// the agent takes long to shutdown
-		if c.httpServer != nil {
-			c.httpServer.Shutdown()
+		if len(c.httpServers) > 0 {
+			for _, srv := range c.httpServers {
+				srv.Shutdown()
+			}
 		}
 	}()
 
@@ -903,14 +904,15 @@ WAIT:
 func (c *Command) reloadHTTPServer() error {
 	c.agent.logger.Info("reloading HTTP server with new TLS configuration")
 
-	c.httpServer.Shutdown()
+	for _, srv := range c.httpServers {
+		srv.Shutdown()
+	}
 
 	httpServers, err := NewHTTPServers(c.agent, c.agent.config)
 	if err != nil {
 		return err
 	}
-    // TODO: change type or handle with list
-	c.httpServer = &httpServers[0]
+	c.httpServers = httpServers
 
 	return nil
 }

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -51,7 +51,7 @@ type Command struct {
 
 	args           []string
 	agent          *Agent
-	httpServers    []HTTPServer
+	httpServers    []*HTTPServer
 	logFilter      *logutils.LevelFilter
 	logOutput      io.Writer
 	retryJoinErrCh chan struct{}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -1261,13 +1261,6 @@ func (c *Config) normalizeAddrs() error {
 		Serf: net.JoinHostPort(c.Addresses.Serf, strconv.Itoa(c.Ports.Serf)),
 	}
 
-    // defaultHTTPAdvertiseAddr := c.BindAddr
-    // // Preserving the old behavior to defaulting to address.http field if only
-    // // 1 ip is specified
-    // if len(httpAddrs) == 1 {
-    //     defaultHTTPAdvertiseAddr = httpAddrs[0]
-    // }
-
 	addr, err = normalizeAdvertise(c.AdvertiseAddrs.HTTP, c.BindAddr, c.Ports.HTTP, c.DevMode)
 	if err != nil {
 		return fmt.Errorf("Failed to parse HTTP advertise address (%v, %v, %v, %v): %v", c.AdvertiseAddrs.HTTP, c.Addresses.HTTP, c.Ports.HTTP, c.DevMode, err)
@@ -1406,9 +1399,7 @@ func normalizeAdvertise(addr string, bind string, defport int, dev bool) (string
 		return "", fmt.Errorf("Error parsing advertise address template: %v", err)
 	}
 
-    fmt.Println("addr", addr)
 	if addr != "" {
-        fmt.Println("test1")
 		// Default to using manually configured address
 		_, _, err = net.SplitHostPort(addr)
 		if err != nil {
@@ -1423,8 +1414,6 @@ func normalizeAdvertise(addr string, bind string, defport int, dev bool) (string
 		return addr, nil
 	}
 
-    fmt.Println("bind", bind)
-    fmt.Println("test2")
 	// Fallback to bind address first, and then try resolving the local hostname
 	ips, err := net.LookupIP(bind)
 	if err != nil {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -1261,7 +1261,7 @@ func (c *Config) normalizeAddrs() error {
 		Serf: net.JoinHostPort(c.Addresses.Serf, strconv.Itoa(c.Ports.Serf)),
 	}
 
-	addr, err = normalizeAdvertise(c.AdvertiseAddrs.HTTP, c.BindAddr, c.Ports.HTTP, c.DevMode)
+	addr, err = normalizeAdvertise(c.AdvertiseAddrs.HTTP, httpAddrs[0], c.Ports.HTTP, c.DevMode)
 	if err != nil {
 		return fmt.Errorf("Failed to parse HTTP advertise address (%v, %v, %v, %v): %v", c.AdvertiseAddrs.HTTP, c.Addresses.HTTP, c.Ports.HTTP, c.DevMode, err)
 	}
@@ -2034,7 +2034,7 @@ func LoadConfigDir(dir string) (*Config, error) {
 
 // joinHostPorts joins every addr in addrs with the specified port
 func joinHostPorts(addrs []string, port string) []string {
-	localAddrs := addrs
+	localAddrs := make([]string, len(addrs))
 	for i, k := range addrs {
 		localAddrs[i] = net.JoinHostPort(k, port)
 

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -85,7 +85,7 @@ type Config struct {
 	Addresses *Addresses `hcl:"addresses"`
 
 	// normalizedAddr is set to the Address+Port by normalizeAddrs()
-	normalizedAddrs *Addresses
+	normalizedAddrs *NormalizedAddrs
 
 	// AdvertiseAddrs is used to control the addresses we advertise.
 	AdvertiseAddrs *AdvertiseAddrs `hcl:"advertise"`
@@ -777,6 +777,15 @@ type Addresses struct {
 // AdvertiseAddrs is used to control the addresses we advertise out for
 // different network services. All are optional and default to BindAddr and
 // their default Port.
+type NormalizedAddrs struct {
+	HTTP []string
+	RPC  string
+	Serf string
+}
+
+// AdvertiseAddrs is used to control the addresses we advertise out for
+// different network services. All are optional and default to BindAddr and
+// their default Port.
 type AdvertiseAddrs struct {
 	HTTP string `hcl:"http"`
 	RPC  string `hcl:"rpc"`
@@ -1228,13 +1237,13 @@ func (c *Config) normalizeAddrs() error {
 		c.BindAddr = ipStr
 	}
 
-	addr, err := normalizeBind(c.Addresses.HTTP, c.BindAddr)
+	httpAddrs, err := normalizeMultipleBind(c.Addresses.HTTP, c.BindAddr)
 	if err != nil {
 		return fmt.Errorf("Failed to parse HTTP address: %v", err)
 	}
-	c.Addresses.HTTP = addr
+	c.Addresses.HTTP = strings.Join(httpAddrs, " ")
 
-	addr, err = normalizeBind(c.Addresses.RPC, c.BindAddr)
+	addr, err := normalizeBind(c.Addresses.RPC, c.BindAddr)
 	if err != nil {
 		return fmt.Errorf("Failed to parse RPC address: %v", err)
 	}
@@ -1246,13 +1255,20 @@ func (c *Config) normalizeAddrs() error {
 	}
 	c.Addresses.Serf = addr
 
-	c.normalizedAddrs = &Addresses{
-		HTTP: net.JoinHostPort(c.Addresses.HTTP, strconv.Itoa(c.Ports.HTTP)),
+	c.normalizedAddrs = &NormalizedAddrs{
+		HTTP: joinHostPorts(httpAddrs, strconv.Itoa(c.Ports.HTTP)),
 		RPC:  net.JoinHostPort(c.Addresses.RPC, strconv.Itoa(c.Ports.RPC)),
 		Serf: net.JoinHostPort(c.Addresses.Serf, strconv.Itoa(c.Ports.Serf)),
 	}
 
-	addr, err = normalizeAdvertise(c.AdvertiseAddrs.HTTP, c.Addresses.HTTP, c.Ports.HTTP, c.DevMode)
+    // defaultHTTPAdvertiseAddr := c.BindAddr
+    // // Preserving the old behavior to defaulting to address.http field if only
+    // // 1 ip is specified
+    // if len(httpAddrs) == 1 {
+    //     defaultHTTPAdvertiseAddr = httpAddrs[0]
+    // }
+
+	addr, err = normalizeAdvertise(c.AdvertiseAddrs.HTTP, c.BindAddr, c.Ports.HTTP, c.DevMode)
 	if err != nil {
 		return fmt.Errorf("Failed to parse HTTP advertise address (%v, %v, %v, %v): %v", c.AdvertiseAddrs.HTTP, c.Addresses.HTTP, c.Ports.HTTP, c.DevMode, err)
 	}
@@ -1335,6 +1351,23 @@ func parseSingleIPTemplate(ipTmpl string) (string, error) {
 	}
 }
 
+// parseMultipleIPTemplate is used as a helper function to parse out a multiple IP
+// addresses from a config parameter.
+func parseMultipleIPTemplate(ipTmpl string) ([]string, error) {
+	out, err := template.Parse(ipTmpl)
+	if err != nil {
+		return []string{}, fmt.Errorf("Unable to parse address template %q: %v", ipTmpl, err)
+	}
+
+	// TODO: deduplicate the parsed ips
+	ips := strings.Split(out, " ")
+	if len(ips) == 0 {
+		return []string{}, errors.New("No addresses found, please configure one.")
+	}
+
+	return ips, nil
+}
+
 // normalizeBind returns a normalized bind address.
 //
 // If addr is set it is used, if not the default bind address is used.
@@ -1343,6 +1376,16 @@ func normalizeBind(addr, bind string) (string, error) {
 		return bind, nil
 	}
 	return parseSingleIPTemplate(addr)
+}
+
+// normalizeMultipleBind returns normalized bind addresses.
+//
+// If addr is set it is used, if not the default bind address is used.
+func normalizeMultipleBind(addr, bind string) ([]string, error) {
+	if addr == "" {
+		return []string{bind}, nil
+	}
+	return parseMultipleIPTemplate(addr)
 }
 
 // normalizeAdvertise returns a normalized advertise address.
@@ -1363,7 +1406,9 @@ func normalizeAdvertise(addr string, bind string, defport int, dev bool) (string
 		return "", fmt.Errorf("Error parsing advertise address template: %v", err)
 	}
 
+    fmt.Println("addr", addr)
 	if addr != "" {
+        fmt.Println("test1")
 		// Default to using manually configured address
 		_, _, err = net.SplitHostPort(addr)
 		if err != nil {
@@ -1378,6 +1423,8 @@ func normalizeAdvertise(addr string, bind string, defport int, dev bool) (string
 		return addr, nil
 	}
 
+    fmt.Println("bind", bind)
+    fmt.Println("test2")
 	// Fallback to bind address first, and then try resolving the local hostname
 	ips, err := net.LookupIP(bind)
 	if err != nil {
@@ -1994,6 +2041,17 @@ func LoadConfigDir(dir string) (*Config, error) {
 	}
 
 	return result, nil
+}
+
+// joinHostPorts joins every addr in addrs with the specified port
+func joinHostPorts(addrs []string, port string) []string {
+	localAddrs := addrs
+	for i, k := range addrs {
+		localAddrs[i] = net.JoinHostPort(k, port)
+
+	}
+
+	return localAddrs
 }
 
 // isTemporaryFile returns true or false depending on whether the

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -1352,7 +1352,6 @@ func parseMultipleIPTemplate(ipTmpl string) ([]string, error) {
 		return []string{}, fmt.Errorf("Unable to parse address template %q: %v", ipTmpl, err)
 	}
 
-	// TODO: deduplicate the parsed ips
 	ips := strings.Split(out, " ")
 	if len(ips) == 0 {
 		return []string{}, errors.New("No addresses found, please configure one.")

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -2053,14 +2053,14 @@ func isTemporaryFile(name string) bool {
 }
 
 func deduplicateAddrs(addrs []string) []string {
-  keys := make(map[string]bool)
-  list := []string{}
+	keys := make(map[string]bool)
+	list := []string{}
 
-  for _, entry := range addrs {
-      if _, value := keys[entry]; !value {
-          keys[entry] = true
-          list = append(list, entry)
-      }
-  }
-  return list
+	for _, entry := range addrs {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	return list
 }

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -1358,7 +1358,7 @@ func parseMultipleIPTemplate(ipTmpl string) ([]string, error) {
 		return []string{}, errors.New("No addresses found, please configure one.")
 	}
 
-	return ips, nil
+	return deduplicateAddrs(ips), nil
 }
 
 // normalizeBind returns a normalized bind address.
@@ -2050,4 +2050,17 @@ func isTemporaryFile(name string) bool {
 	return strings.HasSuffix(name, "~") || // vim
 		strings.HasPrefix(name, ".#") || // emacs
 		(strings.HasPrefix(name, "#") && strings.HasSuffix(name, "#")) // emacs
+}
+
+func deduplicateAddrs(addrs []string) []string {
+  keys := make(map[string]bool)
+  list := []string{}
+
+  for _, entry := range addrs {
+      if _, value := keys[entry]; !value {
+          keys[entry] = true
+          list = append(list, entry)
+      }
+  }
+  return list
 }

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -958,7 +958,7 @@ func TestConfig_normalizeAddrs(t *testing.T) {
 	}
 
 	if c.AdvertiseAddrs.HTTP != "169.254.1.10:4646" {
-		t.Fatalf("expected HTTP advertise address 169.254.1.5:4646, got %s", c.AdvertiseAddrs.HTTP)
+		t.Fatalf("expected HTTP advertise address 169.254.1.10:4646, got %s", c.AdvertiseAddrs.HTTP)
 	}
 
 	if c.AdvertiseAddrs.RPC != "169.254.1.40:4647" {

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -883,7 +883,7 @@ func TestConfig_normalizeAddrs_IPv6Loopback(t *testing.T) {
 // TestConfig_normalizeAddrs_MultipleInterface asserts that normalizeAddrs will
 // handle normalizing multiple interfaces in a single protocol.
 func TestConfig_normalizeAddrs_MultipleInterfaces(t *testing.T) {
-    // TODO: add test with go-sockaddr templates
+	// TODO: add test with go-sockaddr templates
 	testCases := []struct {
 		name                    string
 		addressConfig           *Addresses
@@ -957,7 +957,7 @@ func TestConfig_normalizeAddrs(t *testing.T) {
 		t.Fatalf("expected BindAddr 169.254.1.5, got %s", c.BindAddr)
 	}
 
-    // was this test case incorrect? should default to bind addr if not specified (https://www.nomadproject.io/docs/configuration#advertise)
+	// was this test case incorrect? should default to bind addr if not specified (https://www.nomadproject.io/docs/configuration#advertise)
 	if c.AdvertiseAddrs.HTTP != "169.254.1.5:4646" {
 		t.Fatalf("expected HTTP advertise address 169.254.1.5:4646, got %s", c.AdvertiseAddrs.HTTP)
 	}

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -957,8 +957,7 @@ func TestConfig_normalizeAddrs(t *testing.T) {
 		t.Fatalf("expected BindAddr 169.254.1.5, got %s", c.BindAddr)
 	}
 
-	// was this test case incorrect? should default to bind addr if not specified (https://www.nomadproject.io/docs/configuration#advertise)
-	if c.AdvertiseAddrs.HTTP != "169.254.1.5:4646" {
+	if c.AdvertiseAddrs.HTTP != "169.254.1.10:4646" {
 		t.Fatalf("expected HTTP advertise address 169.254.1.5:4646, got %s", c.AdvertiseAddrs.HTTP)
 	}
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -1365,3 +1365,26 @@ func TestEventBroker_Parse(t *testing.T) {
 		require.Equal(20000, *result.EventBufferSize)
 	}
 }
+
+func TestParseMultipleIPTemplates(t *testing.T) {
+  testCases := []struct {
+		name                    string
+		tmpl string
+		expectedOut []string
+		expectErr               bool
+	}{
+		{
+			name: "deduplicates same ip",
+      tmpl: "127.0.0.1 127.0.0.1",
+			expectedOut: []string{"127.0.0.1"},
+			expectErr: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+      out, err := parseMultipleIPTemplate(tc.tmpl)
+      require.NoError(t, err)
+      require.Equal(t, tc.expectedOut, out)
+		})
+	}
+}

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -883,7 +883,6 @@ func TestConfig_normalizeAddrs_IPv6Loopback(t *testing.T) {
 // TestConfig_normalizeAddrs_MultipleInterface asserts that normalizeAddrs will
 // handle normalizing multiple interfaces in a single protocol.
 func TestConfig_normalizeAddrs_MultipleInterfaces(t *testing.T) {
-	// TODO: add test with go-sockaddr templates
 	testCases := []struct {
 		name                    string
 		addressConfig           *Addresses

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -1367,24 +1367,24 @@ func TestEventBroker_Parse(t *testing.T) {
 }
 
 func TestParseMultipleIPTemplates(t *testing.T) {
-  testCases := []struct {
-		name                    string
-		tmpl string
+	testCases := []struct {
+		name        string
+		tmpl        string
 		expectedOut []string
-		expectErr               bool
+		expectErr   bool
 	}{
 		{
-			name: "deduplicates same ip",
-      tmpl: "127.0.0.1 127.0.0.1",
+			name:        "deduplicates same ip",
+			tmpl:        "127.0.0.1 127.0.0.1",
 			expectedOut: []string{"127.0.0.1"},
-			expectErr: false,
+			expectErr:   false,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-      out, err := parseMultipleIPTemplate(tc.tmpl)
-      require.NoError(t, err)
-      require.Equal(t, tc.expectedOut, out)
+			out, err := parseMultipleIPTemplate(tc.tmpl)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedOut, out)
 		})
 	}
 }

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -117,8 +117,8 @@ func NewHTTPServers(agent *Agent, config *Config) ([]HTTPServer, error) {
 
 	// Start the listener
 	for _, addr := range config.normalizedAddrs.HTTP {
-    // Create the mux
-    mux := http.NewServeMux()
+		// Create the mux
+		mux := http.NewServeMux()
 
 		lnAddr, err := net.ResolveTCPAddr("tcp", addr)
 		if err != nil {

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -78,8 +78,8 @@ type HTTPServer struct {
 
 // NewHTTPServers starts an HTTP server for every address.http configured in
 // the agent.
-func NewHTTPServers(agent *Agent, config *Config) ([]HTTPServer, error) {
-	var srvs []HTTPServer
+func NewHTTPServers(agent *Agent, config *Config) ([]*HTTPServer, error) {
+	var srvs []*HTTPServer
 	var serverInitializationErrors error
 
 	// Handle requests with gzip compression
@@ -166,7 +166,7 @@ func NewHTTPServers(agent *Agent, config *Config) ([]HTTPServer, error) {
 			httpServer.Serve(ln)
 		}()
 
-		srvs = append(srvs, *srv)
+		srvs = append(srvs, srv)
 	}
 
 	if serverInitializationErrors != nil {

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -115,10 +115,10 @@ func NewHTTPServers(agent *Agent, config *Config) ([]HTTPServer, error) {
 		WriteBufferSize: 2048,
 	}
 
-	// Create the mux
-	mux := http.NewServeMux()
 	// Start the listener
 	for _, addr := range config.normalizedAddrs.HTTP {
+    // Create the mux
+    mux := http.NewServeMux()
 
 		lnAddr, err := net.ResolveTCPAddr("tcp", addr)
 		if err != nil {

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -70,21 +70,21 @@ func BenchmarkHTTPRequests(b *testing.B) {
 }
 
 func TestMultipleInterfaces(t *testing.T) {
-  httpIps := []string{ "127.0.0.1", "127.0.0.2"}
+	httpIps := []string{"127.0.0.1", "127.0.0.2"}
 
-  s := makeHTTPServer(t, func(c *Config) {
-    c.Addresses.HTTP = strings.Join(httpIps, " ")
+	s := makeHTTPServer(t, func(c *Config) {
+		c.Addresses.HTTP = strings.Join(httpIps, " ")
 		c.ACL.Enabled = true
 	})
 	defer s.Shutdown()
 
-  httpPort := s.ports[0]
-  for _, ip := range httpIps {
-    resp, err := http.Get(fmt.Sprintf("http://%s:%d/", ip, httpPort))
+	httpPort := s.ports[0]
+	for _, ip := range httpIps {
+		resp, err := http.Get(fmt.Sprintf("http://%s:%d/", ip, httpPort))
 
-    assert.Nil(t, err)
-    assert.Equal(t, resp.StatusCode, 200)
-  }
+		assert.Nil(t, err)
+		assert.Equal(t, resp.StatusCode, 200)
+	}
 }
 
 // TestRootFallthrough tests rootFallthrough handler to

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -945,8 +945,8 @@ func TestHTTPServer_Limits_Error(t *testing.T) {
 			t.Parallel()
 
 			conf := &Config{
-				normalizedAddrs: &Addresses{
-					HTTP: "localhost:0", // port is never used
+				normalizedAddrs: &NormalizedAddrs{
+					HTTP: []string{"localhost:0"}, // port is never used
 				},
 				TLSConfig: &config.TLSConfig{
 					EnableHTTP: tc.tls,
@@ -964,7 +964,7 @@ func TestHTTPServer_Limits_Error(t *testing.T) {
 				config:     conf,
 			}
 
-			srv, err := NewHTTPServer(agent, conf)
+			srv, err := NewHTTPServers(agent, conf)
 			require.Error(t, err)
 			require.Nil(t, srv)
 			require.Contains(t, err.Error(), tc.expectedErr)

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -69,6 +69,24 @@ func BenchmarkHTTPRequests(b *testing.B) {
 	})
 }
 
+func TestMultipleInterfaces(t *testing.T) {
+  httpIps := []string{ "127.0.0.1", "127.0.0.2"}
+
+  s := makeHTTPServer(t, func(c *Config) {
+    c.Addresses.HTTP = strings.Join(httpIps, " ")
+		c.ACL.Enabled = true
+	})
+	defer s.Shutdown()
+
+  httpPort := s.ports[0]
+  for _, ip := range httpIps {
+    resp, err := http.Get(fmt.Sprintf("http://%s:%d/", ip, httpPort))
+
+    assert.Nil(t, err)
+    assert.Equal(t, resp.StatusCode, 200)
+  }
+}
+
 // TestRootFallthrough tests rootFallthrough handler to
 // verify redirect and 404 behavior
 func TestRootFallthrough(t *testing.T) {

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -259,7 +259,7 @@ func (a *TestAgent) start() (*Agent, error) {
 	if err != nil {
 		return agent, err
 	}
-    // TODO: change type or handle better
+	// TODO: change type or handle better
 	a.Server = &httpServers[0]
 	return agent, nil
 }

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -255,12 +255,12 @@ func (a *TestAgent) start() (*Agent, error) {
 	}
 
 	// Setup the HTTP server
-	http, err := NewHTTPServer(agent, a.Config)
+	httpServers, err := NewHTTPServers(agent, a.Config)
 	if err != nil {
 		return agent, err
 	}
-
-	a.Server = http
+    // TODO: change type or handle better
+	a.Server = &httpServers[0]
 	return agent, nil
 }
 

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -68,7 +68,7 @@ type TestAgent struct {
 
 	// All HTTP servers started. Used to prevent server leaks and preserve
 	// backwards compability.
-	Servers []HTTPServer
+	Servers []*HTTPServer
 
 	// Server is a reference to the primary, started HTTP endpoint.
 	// It is valid after Start().
@@ -267,7 +267,7 @@ func (a *TestAgent) start() (*Agent, error) {
 	// TODO: investigate if there is a way to remove the requirement by updating test.
 	// Initial pass at implementing this is https://github.com/kevinschoonover/nomad/tree/tests.
 	a.Servers = httpServers
-	a.Server = &httpServers[0]
+	a.Server = httpServers[0]
 	return agent, nil
 }
 

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -263,7 +263,9 @@ func (a *TestAgent) start() (*Agent, error) {
 	if err != nil {
 		return agent, err
 	}
-	// TODO: change type or handle better
+
+	// TODO: investigate if there is a way to remove the requirement by updating test.
+	// Initial pass at implementing this is https://github.com/kevinschoonover/nomad/tree/tests.
 	a.Servers = httpServers
 	a.Server = &httpServers[0]
 	return agent, nil

--- a/website/content/docs/configuration/consul.mdx
+++ b/website/content/docs/configuration/consul.mdx
@@ -72,7 +72,7 @@ configuring Nomad to talk to Consul via DNS such as consul.service.consul
   address](https://www.nomadproject.io/docs/configuration#http). If no
   [HTTP address](https://www.nomadproject.io/docs/configuration#http) is
   specified, it will fall back to the
-  [bind_addr](https://www.nomadproject.io/docs/configuration#bind_addr)
+  [bind_addr](https://www.nomadproject.io/docs/configuration#bind_addr).
 
 - `client_auto_join` `(bool: true)` - Specifies if the Nomad clients should
   automatically discover servers in the same region by searching for the Consul

--- a/website/content/docs/configuration/consul.mdx
+++ b/website/content/docs/configuration/consul.mdx
@@ -68,7 +68,11 @@ configuring Nomad to talk to Consul via DNS such as consul.service.consul
   Consul communication. If this is set then you need to also set `key_file`.
 
 - `checks_use_advertise` `(bool: false)` - Specifies if Consul health checks
-  should bind to the advertise address. By default, this is the bind address.
+  should bind to the advertise address. By default, this is the first [HTTP
+  address](https://www.nomadproject.io/docs/configuration#http). If no
+  [HTTP address](https://www.nomadproject.io/docs/configuration#http) is
+  specified, it will fall back to the
+  [bind_addr](https://www.nomadproject.io/docs/configuration#bind_addr)
 
 - `client_auto_join` `(bool: true)` - Specifies if the Nomad clients should
   automatically discover servers in the same region by searching for the Consul


### PR DESCRIPTION
naive partial support for #9257 (HTTP addresses only) by creating a `http.Server` for every space-seperated address defined in `addresses.http`. Example:
```hcl
addresses {
  http="127.0.0.1 {{ GetPrivateIP }} ..."
}
```

Hoping to get some feedback if this is the approach that should be take or something like consul is doing by abstracting the servers into [apiserver.go](https://github.com/hashicorp/consul/blob/main/agent/apiserver.go). There are also one or two TODOs I am not sure the best approach to take.
