### PR TITLE
docs: `mount_flags` takes a slice of strings

### DIFF
--- a/website/content/docs/job-specification/volume.mdx
+++ b/website/content/docs/job-specification/volume.mdx
@@ -42,7 +42,7 @@ job "docs" {
 
       mount_options {
         fs_type     = "ext4"
-        mount_flags = "noatime"
+        mount_flags = ["noatime"]
       }
     }
   }
@@ -106,7 +106,7 @@ The following fields are only valid for volumes with `type = "csi"`:
   necessary.
 
   - `fs_type`: file system type (ex. `"ext4"`)
-  - `mount_flags`: the flags passed to `mount` (ex. `"ro,noatime"`)
+  - `mount_flags`: the flags passed to `mount` (ex. `["ro", "noatime"]`)
 
 ## Volume Interpolation
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11581

The `mount_flags` option takes a slice of strings, not a comma-separated string like the flags passed to `mount(8)`.

Examples in use in [ceph](https://github.com/hashicorp/nomad/blob/main/demo/csi/ceph-csi-plugin/volume.hcl#L21) and [hostpath](https://github.com/hashicorp/nomad/blob/main/demo/csi/hostpath/hostpath.hcl#L24) demos