### PR TITLE
client: respect `client_auto_join` after connection loss

### DIFF
--- a/.changelog/11585.txt
+++ b/.changelog/11585.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where clients would ignore the `client_auto_join` setting after losing connection with the servers, causing them to incorrectly fallback to Consul discovery if it was set to `false`.
+```

--- a/client/client.go
+++ b/client/client.go
@@ -2690,11 +2690,13 @@ func taskIsPresent(taskName string, tasks []*structs.Task) bool {
 
 // triggerDiscovery causes a Consul discovery to begin (if one hasn't already)
 func (c *Client) triggerDiscovery() {
-	select {
-	case c.triggerDiscoveryCh <- struct{}{}:
-		// Discovery goroutine was released to execute
-	default:
-		// Discovery goroutine was already running
+	if c.configCopy.ConsulConfig.ClientAutoJoin != nil && *c.configCopy.ConsulConfig.ClientAutoJoin {
+		select {
+		case c.triggerDiscoveryCh <- struct{}{}:
+			// Discovery goroutine was released to execute
+		default:
+			// Discovery goroutine was already running
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11404

The `consul.client_auto_join` configuration block tells the Nomad
client whether to use Consul service discovery to find Nomad
servers. By default it is set to `true`, but contrary to the
documentation it was only respected during the initial client
registration. If a client missed a heartbeat, failed a
`Node.UpdateStatus` RPC, or if there was no Nomad leader, the client
would fallback to Consul even if `client_auto_join` was set to
`false`. This changeset returns early from the client's trigger for
Consul discovery if the `client_auto_join` field is set to `false`.

---

To test this I ran a client node and a server node with Consul under Vagrant. Then I blocked access to the server's ports and Consul:

```
$ sudo iptables -A INPUT -p tcp --destination-port 4647 -j DROP
$ sudo iptables -A INPUT -p tcp --destination-port 8500 -j DROP
```

Then waited for the client to log that it had lost it's connection to the server, and removed the server rule while leaving the Consul rule in place:

```
$ sudo iptables --line-numbers -L INPUT

Chain INPUT (policy ACCEPT)
num  target     prot opt source               destination
1    DROP       tcp  --  anywhere             anywhere             tcp dpt:8500
2    DROP       tcp  --  anywhere             anywhere             tcp dpt:4647

$ sudo iptables -D INPUT 2
```

And after a few moments, the client restored its connection with the server without needing to have Consul, as expected. I also did the same exercise without dropping packets to Consul and watched the logs to ensure that no requests were being made from the client to Consul to get the server address.