### PR TITLE
ui: change Consul/Vault base URL field name

### DIFF
--- a/nomad/structs/config/ui.go
+++ b/nomad/structs/config/ui.go
@@ -15,19 +15,19 @@ type UIConfig struct {
 	Vault *VaultUIConfig `hcl:"vault"`
 }
 
-// ConsulUIConfig configures deep links to this cluster's Consul UI
+// ConsulUIConfig configures deep links to this cluster's Consul
 type ConsulUIConfig struct {
 
-	// BaseURL provides the full base URL, ex:
+	// BaseUIURL provides the full base URL to the UI, ex:
 	// https://consul.example.com:8500/ui/
-	BaseURL string `hcl:"base_url"`
+	BaseUIURL string `hcl:"ui_url"`
 }
 
-// VaultUIConfig configures deep links to this cluster's Vault UI
+// VaultUIConfig configures deep links to this cluster's Vault
 type VaultUIConfig struct {
-	// BaseURL provides the full base URL, ex:
+	// BaseUIURL provides the full base URL to the UI, ex:
 	// https://vault.example.com:8200/ui/
-	BaseURL string `hcl:"base_url"`
+	BaseUIURL string `hcl:"ui_url"`
 }
 
 // DefaultUIConfig returns the canonical defaults for the Nomad
@@ -95,8 +95,8 @@ func (this *ConsulUIConfig) Merge(other *ConsulUIConfig) *ConsulUIConfig {
 		return result
 	}
 
-	if other.BaseURL != "" {
-		result.BaseURL = other.BaseURL
+	if other.BaseUIURL != "" {
+		result.BaseUIURL = other.BaseUIURL
 	}
 	return result
 }
@@ -123,8 +123,8 @@ func (this *VaultUIConfig) Merge(other *VaultUIConfig) *VaultUIConfig {
 		return result
 	}
 
-	if other.BaseURL != "" {
-		result.BaseURL = other.BaseURL
+	if other.BaseUIURL != "" {
+		result.BaseUIURL = other.BaseUIURL
 	}
 	return result
 }

--- a/nomad/structs/config/ui_test.go
+++ b/nomad/structs/config/ui_test.go
@@ -11,10 +11,10 @@ func TestUIConfig_Merge(t *testing.T) {
 	fullConfig := &UIConfig{
 		Enabled: true,
 		Consul: &ConsulUIConfig{
-			BaseURL: "http://consul.example.com:8500",
+			BaseUIURL: "http://consul.example.com:8500",
 		},
 		Vault: &VaultUIConfig{
-			BaseURL: "http://vault.example.com:8200",
+			BaseUIURL: "http://vault.example.com:8200",
 		},
 	}
 
@@ -41,7 +41,7 @@ func TestUIConfig_Merge(t *testing.T) {
 			left: &UIConfig{
 				Enabled: false,
 				Consul: &ConsulUIConfig{
-					BaseURL: "http://consul-other.example.com:8500",
+					BaseUIURL: "http://consul-other.example.com:8500",
 				},
 			},
 			right:  fullConfig,
@@ -52,14 +52,14 @@ func TestUIConfig_Merge(t *testing.T) {
 			left: &UIConfig{
 				Enabled: true,
 				Consul: &ConsulUIConfig{
-					BaseURL: "http://consul-other.example.com:8500",
+					BaseUIURL: "http://consul-other.example.com:8500",
 				},
 			},
 			right: &UIConfig{},
 			expect: &UIConfig{
 				Enabled: false,
 				Consul: &ConsulUIConfig{
-					BaseURL: "http://consul-other.example.com:8500",
+					BaseUIURL: "http://consul-other.example.com:8500",
 				},
 				Vault: &VaultUIConfig{},
 			},

--- a/ui/app/templates/components/global-header.hbs
+++ b/ui/app/templates/components/global-header.hbs
@@ -23,13 +23,13 @@
         Storybook
       </a>
     {{/if}}
-    {{#if this.agent.config.UI.Consul.BaseUrl}}
-      <a href={{this.agent.config.UI.Consul.BaseUrl}} class="navbar-item">
+    {{#if this.system.agent.config.UI.Consul.BaseUIURL}}
+      <a href={{this.system.agent.config.UI.Consul.BaseUIURL}} class="navbar-item">
         Consul
       </a>
     {{/if}}
-    {{#if this.agent.config.UI.Vault.BaseUrl}}
-      <a href={{this.agent.config.UI.Vault.BaseUrl}} class="navbar-item">
+    {{#if this.system.agent.config.UI.Vault.BaseUIURL}}
+      <a href={{this.system.agent.config.UI.Vault.BaseUIURL}} class="navbar-item">
         Vault
       </a>
     {{/if}}

--- a/website/content/docs/configuration/ui.mdx
+++ b/website/content/docs/configuration/ui.mdx
@@ -17,11 +17,11 @@ ui {
   enabled =  true
 
   consul {
-    base_url = "https://consul.example.com:8500/ui"
+    ui_url = "https://consul.example.com:8500/ui"
   }
 
   vault {
-    base_url = "https://vault.example.com:8200/ui"
+    ui_url = "https://vault.example.com:8200/ui"
   }
 }
 ```
@@ -41,24 +41,24 @@ and the configuration is individual to each agent.
 
 ## `consul` Parameters
 
-- `base_url` `(string: "")` - Specifies the full base URL to a Consul
+- `ui_url` `(string: "")` - Specifies the full base URL to a Consul
   web UI (for example: `https://consul.example.com:8500/ui`. This URL
   is used to build links from the Nomad web UI to a Consul web
   UI. Note that this URL will not typically be the same one used for
   the agent's [`consul.address`]; the `consul.address` is the URL used
   by the Nomad to communicate with Consul, whereas the
-  `ui.consul.base_url` is the URL you'll visit in your browser. If
+  `ui.consul.ui_url` is the URL you'll visit in your browser. If
   this field is omitted, this integration will be disabled.
 
 ## `vault` Parameters
 
-- `base_url` `(string: "")` - Specifies the full base URL to a Vault
+- `ui_url` `(string: "")` - Specifies the full base URL to a Vault
   web UI (for example: `https://vault.example.com:8200/ui`. This URL
   is used to build links from the Nomad web UI to a Vault web
   UI. Note that this URL will not typically be the same one used for
   the agent's [`vault.address`]; the `vault.address` is the URL used
   by the Nomad to communicate with Vault, whereas the
-  `ui.vault.base_url` is the URL you'll visit in your browser. If
+  `ui.vault.ui_url` is the URL you'll visit in your browser. If
   this field is omitted, this integration will be disabled.
 
 


### PR DESCRIPTION
Give ourselves some room for extension in the UI configuration block
by naming the field `ui_url`, which will let us have an `api_url`.