### PR TITLE
changelog: new metrics in Nomad Enterprise

### DIFF
--- a/.changelog/_664.txt
+++ b/.changelog/_664.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+metrics (Enterprise): Emit `nomad.license.expiration_time_epoch` metric to show the expiration time of the Nomad Enterprise license.
+```


### PR DESCRIPTION
This changelog is for a PR that landed in Nomad Enterprise only ([ref](https://github.com/hashicorp/nomad-enterprise/pull/664))

(I checked with the Consul folks and `_<id of ENT PR>.txt` is how they do the changelog entries for ENT-only items with go-changelog.)