### PR TITLE
Override TLS flags individually for meta commands

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -136,8 +136,8 @@ func (m *Meta) clientConfig() *api.Config {
 		config.SecretID = m.token
 	}
 
-	// If the user has passed custom TLS configuration, override with that.
-	// Refactored to address issue #11539
+	// Override TLS configuration fields we may have received from env vars with
+	// flag arguments from the user only if they're provided.
 	if m.caCert != "" {
 		config.TLSConfig.CACert = m.caCert
 	}

--- a/command/meta.go
+++ b/command/meta.go
@@ -121,6 +121,7 @@ type ApiClientFactory func() (*api.Client, error)
 // the default command line arguments and env vars.
 func (m *Meta) clientConfig() *api.Config {
 	config := api.DefaultConfig()
+
 	if m.flagAddress != "" {
 		config.Address = m.flagAddress
 	}
@@ -131,21 +132,34 @@ func (m *Meta) clientConfig() *api.Config {
 		config.Namespace = m.namespace
 	}
 
-	// If we need custom TLS configuration, then set it
-	if m.caCert != "" || m.caPath != "" || m.clientCert != "" || m.clientKey != "" || m.tlsServerName != "" || m.insecure {
-		t := &api.TLSConfig{
-			CACert:        m.caCert,
-			CAPath:        m.caPath,
-			ClientCert:    m.clientCert,
-			ClientKey:     m.clientKey,
-			TLSServerName: m.tlsServerName,
-			Insecure:      m.insecure,
-		}
-		config.TLSConfig = t
-	}
-
 	if m.token != "" {
 		config.SecretID = m.token
+	}
+
+	// If the user has passed custom TLS configuration, override with that.
+	// Refactored to address issue #11539
+	if m.caCert != "" {
+		config.TLSConfig.CACert = m.caCert
+	}
+
+	if m.caPath != "" {
+		config.TLSConfig.CAPath = m.caPath
+	}
+
+	if m.clientCert != "" {
+		config.TLSConfig.ClientCert = m.clientCert
+	}
+
+	if m.clientKey != "" {
+		config.TLSConfig.ClientKey = m.clientKey
+	}
+
+	if m.tlsServerName != "" {
+		config.TLSConfig.TLSServerName = m.tlsServerName
+	}
+
+	if m.insecure {
+		config.TLSConfig.Insecure = m.insecure
 	}
 
 	return config


### PR DESCRIPTION
This block used to set the entire config.TLSConfig with the
values passed by the user. This worked fine if the user set all the options,
or at least enough, but had the unintended side effect of overwriting values
that had been configured in environment variables. If the user passed only
one setting, say `tls-skip-verify`, all the other settings, like CACert would
get overwritten with blank strings.