### PR TITLE
Update default VM size to comply with East US

### DIFF
--- a/terraform/azure/packer.json
+++ b/terraform/azure/packer.json
@@ -13,6 +13,7 @@
     "subscription_id": "{{ user `azure_subscription_id` }}",
     "managed_image_resource_group_name": "{{ user `azure_resource_group` }}",
     "location": "East US",
+    "vm_size": "Standard_DS1_v2",
     "image_publisher": "Canonical",
     "image_offer": "UbuntuServer",
     "image_sku": "16.04-LTS",


### PR DESCRIPTION
When the vm_size attribute is missing in a packer definition, the size will default to Standard_A1. When running using the provided steps in the /terraform/azure README, the packer build will fail with an error like: 

```
==> azure-arm: resources.DeploymentsClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="InvalidTemplateDeployment" Message="The template deployment failed with error: 'The resource with id: '/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.Compute/virtualMachines/pkrvm7l8m8u2g9t' failed validation with message: 'The requested size for resource '/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.Compute/virtualMachines/pkrvm7l8m8u2g9t' is currently not available in location 'eastus' zones '' for subscription '{subscription-id}'. Please try another size or deploy to a different location or zones. See https://aka.ms/azureskunotavailable for details.'.'."
```

I was able to get around this message by adding the vm_size attribute to the packer.json.
