### PR TITLE
scheduler: config option to reject job registration

### DIFF
--- a/.changelog/11610.txt
+++ b/.changelog/11610.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+scheduler: Added a `RejectJobRegistration` field to the scheduler configuration API that enabled a setting to reject job register, dispatch, and scale requests without a management ACL token
+```

--- a/api/operator.go
+++ b/api/operator.go
@@ -129,6 +129,10 @@ type SchedulerConfiguration struct {
 	// MemoryOversubscriptionEnabled specifies whether memory oversubscription is enabled
 	MemoryOversubscriptionEnabled bool
 
+	// RejectJobRegistration disables new job registrations except with a
+	// management ACL token
+	RejectJobRegistration bool
+
 	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
 	CreateIndex uint64
 	ModifyIndex uint64

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -451,6 +451,9 @@ func errCodeFromHandler(err error) (int, string) {
 		} else if strings.HasSuffix(errMsg, structs.ErrTokenNotFound.Error()) {
 			errMsg = structs.ErrTokenNotFound.Error()
 			code = 403
+		} else if strings.HasSuffix(errMsg, structs.ErrJobRegistrationDisabled.Error()) {
+			errMsg = structs.ErrJobRegistrationDisabled.Error()
+			code = 403
 		}
 	}
 
@@ -486,6 +489,9 @@ func (s *HTTPServer) wrap(handler func(resp http.ResponseWriter, req *http.Reque
 					code = 403
 				} else if strings.HasSuffix(errMsg, structs.ErrTokenNotFound.Error()) {
 					errMsg = structs.ErrTokenNotFound.Error()
+					code = 403
+				} else if strings.HasSuffix(errMsg, structs.ErrJobRegistrationDisabled.Error()) {
+					errMsg = structs.ErrJobRegistrationDisabled.Error()
 					code = 403
 				}
 			}

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -261,6 +261,7 @@ func (s *HTTPServer) schedulerUpdateConfig(resp http.ResponseWriter, req *http.R
 	args.Config = structs.SchedulerConfiguration{
 		SchedulerAlgorithm:            structs.SchedulerAlgorithm(conf.SchedulerAlgorithm),
 		MemoryOversubscriptionEnabled: conf.MemoryOversubscriptionEnabled,
+		RejectJobRegistration:         conf.RejectJobRegistration,
 		PreemptionConfig: structs.PreemptionConfig{
 			SystemSchedulerEnabled:   conf.PreemptionConfig.SystemSchedulerEnabled,
 			SysBatchSchedulerEnabled: conf.PreemptionConfig.SysBatchSchedulerEnabled,

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -176,8 +176,8 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 		}
 	}
 
-	if ok, err := allowedRegistration(aclObj, j.srv.State()); !ok || err != nil {
-		j.logger.Warn("job registration for non-management ACL rejected")
+	if ok, err := registrationsAreAllowed(aclObj, j.srv.State()); !ok || err != nil {
+		j.logger.Warn("job registration is currently disabled for non-management ACL")
 		return structs.ErrJobRegistrationDisabled
 	}
 
@@ -186,7 +186,6 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 	if err != nil {
 		return err
 	}
-
 	ws := memdb.NewWatchSet()
 	existingJob, err := snap.JobByID(ws, args.RequestNamespace(), args.Job.ID)
 	if err != nil {
@@ -1029,8 +1028,8 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 		}
 	}
 
-	if ok, err := allowedRegistration(aclObj, j.srv.State()); !ok || err != nil {
-		j.logger.Warn("job scaling for non-management ACL rejected")
+	if ok, err := registrationsAreAllowed(aclObj, j.srv.State()); !ok || err != nil {
+		j.logger.Warn("job scaling is currently disabled for non-management ACL")
 		return structs.ErrJobRegistrationDisabled
 	}
 
@@ -1316,9 +1315,9 @@ func allowedNSes(aclObj *acl.ACL, state *state.StateStore, allow func(ns string)
 	return r, nil
 }
 
-// allowedRegistration checks that the scheduler is not in
+// registrationsAreAllowed checks that the scheduler is not in
 // RejectJobRegistration mode for load-shedding.
-func allowedRegistration(aclObj *acl.ACL, state *state.StateStore) (bool, error) {
+func registrationsAreAllowed(aclObj *acl.ACL, state *state.StateStore) (bool, error) {
 	_, cfg, err := state.SchedulerConfig()
 	if err != nil {
 		return false, err
@@ -1888,8 +1887,8 @@ func (j *Job) Dispatch(args *structs.JobDispatchRequest, reply *structs.JobDispa
 		return structs.ErrPermissionDenied
 	}
 
-	if ok, err := allowedRegistration(aclObj, j.srv.State()); !ok || err != nil {
-		j.logger.Warn("job dispatch for non-management ACL rejected")
+	if ok, err := registrationsAreAllowed(aclObj, j.srv.State()); !ok || err != nil {
+		j.logger.Warn("job dispatch is currently disabled for non-management ACL")
 		return structs.ErrJobRegistrationDisabled
 	}
 

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -2248,6 +2248,100 @@ func TestJobEndpoint_Register_ACL_Namespace(t *testing.T) {
 	assert.NotNil(out, "expected job")
 }
 
+func TestJobRegister_ACL_RejectedBySchedulerConfig(t *testing.T) {
+	t.Parallel()
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
+		c.NumSchedulers = 0 // Prevent automatic dequeue
+	})
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	submitJobToken := mock.CreatePolicyAndToken(t, s1.State(), 1001, "test-valid-write",
+		mock.NamespacePolicy(structs.DefaultNamespace, "write", nil)).
+		SecretID
+
+	cases := []struct {
+		name          string
+		token         string
+		rejectEnabled bool
+		errExpected   string
+	}{
+		{
+			name:          "reject disabled, with a submit token",
+			token:         submitJobToken,
+			rejectEnabled: false,
+		},
+		{
+			name:          "reject enabled, with a submit token",
+			token:         submitJobToken,
+			rejectEnabled: true,
+			errExpected:   structs.ErrJobRegistrationDisabled.Error(),
+		},
+		{
+			name:          "reject enabled, without a token",
+			token:         "",
+			rejectEnabled: true,
+			errExpected:   structs.ErrPermissionDenied.Error(),
+		},
+		{
+			name:          "reject enabled, with a management token",
+			token:         root.SecretID,
+			rejectEnabled: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			job := mock.Job()
+			req := &structs.JobRegisterRequest{
+				Job: job,
+				WriteRequest: structs.WriteRequest{
+					Region:    "global",
+					Namespace: job.Namespace,
+				},
+			}
+			req.AuthToken = tc.token
+
+			cfgReq := &structs.SchedulerSetConfigRequest{
+				Config: structs.SchedulerConfiguration{
+					RejectJobRegistration: tc.rejectEnabled,
+				},
+				WriteRequest: structs.WriteRequest{
+					Region: "global",
+				},
+			}
+			cfgReq.AuthToken = root.SecretID
+			err := msgpackrpc.CallWithCodec(codec, "Operator.SchedulerSetConfiguration",
+				cfgReq, &structs.SchedulerSetConfigurationResponse{},
+			)
+			require.NoError(t, err)
+
+			var resp structs.JobRegisterResponse
+			err = msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp)
+
+			if tc.errExpected != "" {
+				require.Error(t, err, "expected error")
+				require.EqualError(t, err, tc.errExpected)
+				state := s1.fsm.State()
+				ws := memdb.NewWatchSet()
+				out, err := state.JobByID(ws, job.Namespace, job.ID)
+				require.NoError(t, err)
+				require.Nil(t, out)
+			} else {
+				require.NoError(t, err, "unexpected error")
+				require.NotEqual(t, 0, resp.Index)
+				state := s1.fsm.State()
+				ws := memdb.NewWatchSet()
+				out, err := state.JobByID(ws, job.Namespace, job.ID)
+				require.NoError(t, err)
+				require.NotNil(t, out)
+				require.Equal(t, job.TaskGroups, out.TaskGroups)
+			}
+		})
+	}
+}
+
 func TestJobEndpoint_Revert(t *testing.T) {
 	t.Parallel()
 
@@ -6646,6 +6740,95 @@ func TestJobEndpoint_Dispatch_JobChildrenSummary(t *testing.T) {
 	require.Equal(t, structs.JobStatusDead, dispatchedStatus())
 }
 
+func TestJobEndpoint_Dispatch_ACL_RejectedBySchedulerConfig(t *testing.T) {
+	t.Parallel()
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+	state := s1.fsm.State()
+
+	job := mock.BatchJob()
+	job.ParameterizedJob = &structs.ParameterizedJobConfig{}
+
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	require.NoError(t, err)
+
+	dispatch := &structs.JobDispatchRequest{
+		JobID: job.ID,
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	submitJobToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid-write",
+		mock.NamespacePolicy(structs.DefaultNamespace, "write", nil)).
+		SecretID
+
+	cases := []struct {
+		name          string
+		token         string
+		rejectEnabled bool
+		errExpected   string
+	}{
+		{
+			name:          "reject disabled, with a submit token",
+			token:         submitJobToken,
+			rejectEnabled: false,
+		},
+		{
+			name:          "reject enabled, with a submit token",
+			token:         submitJobToken,
+			rejectEnabled: true,
+			errExpected:   structs.ErrJobRegistrationDisabled.Error(),
+		},
+		{
+			name:          "reject enabled, without a token",
+			token:         "",
+			rejectEnabled: true,
+			errExpected:   structs.ErrPermissionDenied.Error(),
+		},
+		{
+			name:          "reject enabled, with a management token",
+			token:         root.SecretID,
+			rejectEnabled: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			cfgReq := &structs.SchedulerSetConfigRequest{
+				Config: structs.SchedulerConfiguration{
+					RejectJobRegistration: tc.rejectEnabled,
+				},
+				WriteRequest: structs.WriteRequest{
+					Region: "global",
+				},
+			}
+			cfgReq.AuthToken = root.SecretID
+			err := msgpackrpc.CallWithCodec(codec, "Operator.SchedulerSetConfiguration",
+				cfgReq, &structs.SchedulerSetConfigurationResponse{},
+			)
+			require.NoError(t, err)
+
+			dispatch.AuthToken = tc.token
+			var resp structs.JobDispatchResponse
+			err = msgpackrpc.CallWithCodec(codec, "Job.Dispatch", dispatch, &resp)
+
+			if tc.errExpected != "" {
+				require.Error(t, err, "expected error")
+				require.EqualError(t, err, tc.errExpected)
+			} else {
+				require.NoError(t, err, "unexpected error")
+				require.NotEqual(t, 0, resp.Index)
+			}
+		})
+	}
+
+}
+
 func TestJobEndpoint_Scale(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
@@ -6930,6 +7113,97 @@ func TestJobEndpoint_Scale_ACL(t *testing.T) {
 		err = msgpackrpc.CallWithCodec(codec, "Job.Scale", scale, &resp)
 		require.NoError(err, tc.name)
 		require.NotNil(resp.EvalID)
+	}
+
+}
+
+func TestJobEndpoint_Scale_ACL_RejectedBySchedulerConfig(t *testing.T) {
+	t.Parallel()
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+	state := s1.fsm.State()
+
+	job := mock.Job()
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	require.NoError(t, err)
+
+	scale := &structs.JobScaleRequest{
+		JobID: job.ID,
+		Target: map[string]string{
+			structs.ScalingTargetGroup: job.TaskGroups[0].Name,
+		},
+		Message: "because of the load",
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	submitJobToken := mock.CreatePolicyAndToken(t, state, 1001, "test-valid-write",
+		mock.NamespacePolicy(structs.DefaultNamespace, "write", nil)).
+		SecretID
+
+	cases := []struct {
+		name          string
+		token         string
+		rejectEnabled bool
+		errExpected   string
+	}{
+		{
+			name:          "reject disabled, with a submit token",
+			token:         submitJobToken,
+			rejectEnabled: false,
+		},
+		{
+			name:          "reject enabled, with a submit token",
+			token:         submitJobToken,
+			rejectEnabled: true,
+			errExpected:   structs.ErrJobRegistrationDisabled.Error(),
+		},
+		{
+			name:          "reject enabled, without a token",
+			token:         "",
+			rejectEnabled: true,
+			errExpected:   structs.ErrPermissionDenied.Error(),
+		},
+		{
+			name:          "reject enabled, with a management token",
+			token:         root.SecretID,
+			rejectEnabled: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			cfgReq := &structs.SchedulerSetConfigRequest{
+				Config: structs.SchedulerConfiguration{
+					RejectJobRegistration: tc.rejectEnabled,
+				},
+				WriteRequest: structs.WriteRequest{
+					Region: "global",
+				},
+			}
+			cfgReq.AuthToken = root.SecretID
+			err := msgpackrpc.CallWithCodec(codec, "Operator.SchedulerSetConfiguration",
+				cfgReq, &structs.SchedulerSetConfigurationResponse{},
+			)
+			require.NoError(t, err)
+
+			var resp structs.JobRegisterResponse
+			scale.AuthToken = tc.token
+			err = msgpackrpc.CallWithCodec(codec, "Job.Scale", scale, &resp)
+
+			if tc.errExpected != "" {
+				require.Error(t, err, "expected error")
+				require.EqualError(t, err, tc.errExpected)
+			} else {
+				require.NoError(t, err, "unexpected error")
+				require.NotEqual(t, 0, resp.Index)
+			}
+		})
 	}
 
 }

--- a/nomad/structs/errors.go
+++ b/nomad/structs/errors.go
@@ -13,6 +13,7 @@ const (
 	errNoRegionPath               = "No path to region"
 	errTokenNotFound              = "ACL token not found"
 	errPermissionDenied           = "Permission denied"
+	errJobRegistrationDisabled    = "Job registration, dispatch, and scale are disabled by the scheduler configuration"
 	errNoNodeConn                 = "No path to node"
 	errUnknownMethod              = "Unknown rpc method"
 	errUnknownNomadVersion        = "Unable to determine Nomad version"
@@ -46,6 +47,7 @@ var (
 	ErrNoRegionPath               = errors.New(errNoRegionPath)
 	ErrTokenNotFound              = errors.New(errTokenNotFound)
 	ErrPermissionDenied           = errors.New(errPermissionDenied)
+	ErrJobRegistrationDisabled    = errors.New(errJobRegistrationDisabled)
 	ErrNoNodeConn                 = errors.New(errNoNodeConn)
 	ErrUnknownMethod              = errors.New(errUnknownMethod)
 	ErrUnknownNomadVersion        = errors.New(errUnknownNomadVersion)

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -149,7 +149,12 @@ type SchedulerConfiguration struct {
 	// priority jobs to place higher priority jobs.
 	PreemptionConfig PreemptionConfig `hcl:"preemption_config"`
 
+	// MemoryOversubscriptionEnabled specifies whether memory oversubscription is enabled
 	MemoryOversubscriptionEnabled bool `hcl:"memory_oversubscription_enabled"`
+
+	// RejectJobRegistration disables new job registrations except with a
+	// management ACL token
+	RejectJobRegistration bool `hcl:"reject_job_registration"`
 
 	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
 	CreateIndex uint64

--- a/website/content/api-docs/operator/scheduler.mdx
+++ b/website/content/api-docs/operator/scheduler.mdx
@@ -45,6 +45,7 @@ $ curl \
     "ModifyIndex": 5,
     "SchedulerAlgorithm": "spread",
     "MemoryOversubscriptionEnabled": true,
+    "RejectJobRegistration": false,
     "PreemptionConfig": {
       "SystemSchedulerEnabled": true,
       "BatchSchedulerEnabled": false,
@@ -114,6 +115,7 @@ server state is authoritative.
 {
   "SchedulerAlgorithm": "spread",
   "MemoryOversubscriptionEnabled": false,
+  "RejectJobRegistration": false,
   "PreemptionConfig": {
     "SystemSchedulerEnabled": true,
     "BatchSchedulerEnabled": false,
@@ -127,6 +129,8 @@ server state is authoritative.
   `"binpack"` and `"spread"`
 
 - `MemoryOversubscriptionEnabled` `(bool: false)` <sup>1.1 Beta</sup> - When `true`, tasks may exceed their reserved memory limit, if the client has excess memory capacity. Tasks must specify [`memory_max`](/docs/job-specification/resources#memory_max) to take advantage of memory oversubscription.
+
+- `RejectJobRegistration` `(bool: false)` - When `true`, the server will return permission denied errors for job registration, job dispatch, and job scale APIs, unless the ACL token for the request is a management token. If ACLs are disabled, no user will be able to register jobs. This allows operators to shed load from automated proceses during incident response.
 
 - `PreemptionConfig` `(PreemptionConfig)` - Options to enable preemption for
   various schedulers.

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -312,6 +312,8 @@ server {
 
     memory_oversubscription_enabled = true
 
+    reject_job_registration = false
+
     preemption_config {
       batch_scheduler_enabled    = true
       system_scheduler_enabled   = true


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11450

During incident response, operators may find that automated processes
elsewhere in the organization can be generating new workloads on Nomad
clusters that are unable to handle the workload. This changeset adds a
field to the `SchedulerConfiguration` API that causes all job
registration calls to be rejected unless the request has a management
ACL token.

---

Note this doesn't include any new CLI commands (see https://github.com/hashicorp/nomad/issues/11450#issuecomment-984944578 for why)