### PR TITLE
chore: verify backport-assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,3 @@ Guides are available on [HashiCorp Learn](https://learn.hashicorp.com/nomad).
 Contributing
 --------------------
 See the [`contributing`](contributing/) directory for more developer documentation.
-
-<!-- labeling & merging a PR w/ `backport/1.2.2` should automerge this comment to release-1.2.2 -->

--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ Guides are available on [HashiCorp Learn](https://learn.hashicorp.com/nomad).
 Contributing
 --------------------
 See the [`contributing`](contributing/) directory for more developer documentation.
+
+<!-- labeling & merging a PR w/ `backport/1.2.2` should automerge this comment to release-1.2.2 -->

--- a/website/README.md
+++ b/website/README.md
@@ -486,3 +486,5 @@ We support the following browsers targeting roughly the versions specified.
 This website is hosted on Vercel and configured to automatically deploy anytime you push code to the `stable-website` branch. Any time a pull request is submitted that changes files within the `website` folder, a deployment preview will appear in the github checks which can be used to validate the way docs changes will look live. Deployments from `stable-website` will look and behave the same way as deployment previews.
 
 <!-- END: deployment -->
+
+<!-- labeling & merging a PR w/ `backport/1.2.2` should automerge this comment to release-1.2.2 -->


### PR DESCRIPTION
# Description

Use a trivial change to verify `backport-assistant` functionality 

Label `backport/1.2.2` should backport to `release-1.2.2`

### Note
The target of this PR is `stable-website`