### PR TITLE
docs: add license expiry metric to metrics website doc.

### DIFF
--- a/website/content/docs/operations/metrics.mdx
+++ b/website/content/docs/operations/metrics.mdx
@@ -113,6 +113,7 @@ signals.
 | `nomad.raft.apply`                           | Number of Raft transactions                                                                                                                                                | Raft transactions / `interval` | Counter |
 | `nomad.raft.leader.lastContact`              | Time since last contact to leader. General indicator of Raft latency                                                                                                       | ms / Leader Contact            | Timer   |
 | `nomad.raft.replication.appendEntries`       | Raft transaction commit time                                                                                                                                               | ms / Raft Log Append           | Timer   |
+| `nomad.license.expiration_time_epoch`        | Time as epoch (seconds since Jan 1 1970) at which license will expire                                                                                                      | Seconds                        | Gauge   |
 
 ## Client Metrics
 


### PR DESCRIPTION
I didn't add additional detail as I noticed https://github.com/hashicorp/nomad/pull/11623 was in-progress.