### PR TITLE
api: return error when `LicenseGet` status is not `200`

### DIFF
--- a/.changelog/11644.txt
+++ b/.changelog/11644.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Improve error message returned by `Operator.LicenseGet`
+```

--- a/api/operator.go
+++ b/api/operator.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"strconv"
@@ -336,6 +337,11 @@ func (op *Operator) LicenseGet(q *QueryOptions) (*LicenseReply, *QueryMeta, erro
 
 	if resp.StatusCode == 204 {
 		return nil, nil, errors.New("Nomad Enterprise only endpoint")
+	}
+
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, nil, fmt.Errorf("Unexpected response code: %d (%s)", resp.StatusCode, body)
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&reply)

--- a/api/operator_ent_test.go
+++ b/api/operator_ent_test.go
@@ -1,0 +1,28 @@
+//go:build ent
+// +build ent
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperator_LicenseGet(t *testing.T) {
+	t.Parallel()
+	c, s, _ := makeACLClient(t, nil, nil)
+	defer s.Stop()
+
+	operator := c.Operator()
+
+	// Make atuhenticated request.
+	_, _, err := operator.LicenseGet(nil)
+	require.NoError(t, err)
+
+	// Make unatuhenticated request.
+	c.SetSecretID("")
+	_, _, err = operator.LicenseGet(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "403")
+}

--- a/api/operator_ent_test.go
+++ b/api/operator_ent_test.go
@@ -16,11 +16,11 @@ func TestOperator_LicenseGet(t *testing.T) {
 
 	operator := c.Operator()
 
-	// Make atuhenticated request.
+	// Make authenticated request.
 	_, _, err := operator.LicenseGet(nil)
 	require.NoError(t, err)
 
-	// Make unatuhenticated request.
+	// Make unauthenticated request.
 	c.SetSecretID("")
 	_, _, err = operator.LicenseGet(nil)
 	require.Error(t, err)


### PR DESCRIPTION
Without this check, the `api` package tries to parse the response as JSON regardless of status code. But in some situations, like with invalid ACL tokens, the response body is a plain text message, resulting in weird errors like this being sent to clients that make use of the Nomad `api` package:
```
invalid character 'P' looking for beginning of value
```