### PR TITLE
allow non-batch jobs to be parameterized

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4326,12 +4326,6 @@ func (j *Job) Validate() error {
 	}
 
 	if j.IsParameterized() {
-		if j.Type != JobTypeBatch && j.Type != JobTypeSysBatch {
-			mErr.Errors = append(mErr.Errors, fmt.Errorf(
-				"Parameterized job can only be used with %q or %q scheduler", JobTypeBatch, JobTypeSysBatch,
-			))
-		}
-
 		if err := j.ParameterizedJob.Validate(); err != nil {
 			mErr.Errors = append(mErr.Errors, err)
 		}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -5040,18 +5040,6 @@ func TestParameterizedJobConfig_Validate(t *testing.T) {
 	}
 }
 
-func TestParameterizedJobConfig_Validate_NonBatch(t *testing.T) {
-	job := testJob()
-	job.ParameterizedJob = &ParameterizedJobConfig{
-		Payload: DispatchPayloadOptional,
-	}
-	job.Type = JobTypeSystem
-
-	if err := job.Validate(); err == nil || !strings.Contains(err.Error(), "only be used with") {
-		t.Fatalf("Expected bad scheduler tpye: %v", err)
-	}
-}
-
 func TestJobConfig_Validate_StopAferClientDisconnect(t *testing.T) {
 	// Setup a system Job with stop_after_client_disconnect set, which is invalid
 	job := testJob()


### PR DESCRIPTION
Hey!
I would like to be able to dispatch `service` jobs from a parameterized job.
I've browsed around the history here a bit, and I can't figure out what these checks that enforce batch-only are here for. 

They seem to have been added as part of https://github.com/hashicorp/nomad/pull/2128 (https://github.com/hashicorp/nomad/pull/2128/commits/c308ef7e49abed72825bc5bfa534cdac3f8b01f5 specifically) that originally added "Constructor" job support 

I tried removing the checks (this PR) and from what I can tell I can create a parameterized service job and dispatch child services no problem. 

But... I'm pretty new to nomad, so I'm guessing there's a good reason for the checks.. right?