### PR TITLE
Add OpenAPI instructions to RPC Endpoint Checklist

### DIFF
--- a/contributing/checklist-rpc-endpoint.md
+++ b/contributing/checklist-rpc-endpoint.md
@@ -1,4 +1,4 @@
-# New RPC Endpoint Checklist
+# New/Updated RPC Endpoint Checklist
 
 Prefer adding a new message to changing any existing RPC messages.
 
@@ -21,12 +21,21 @@ Prefer adding a new message to changing any existing RPC messages.
   * Register new RPC struct in `nomad/server.go`
   * Check ACLs to enforce security
 
-* Wrapper for the HTTP request in `command/agent/foo_endpoint.go`
+* [ ] Wrapper for the HTTP request in `command/agent/foo_endpoint.go`
   * Backwards compatibility requires a new endpoint, an upgraded
     client or server may be forwarding this request to an old server,
     without support for the new RPC
   * RPCs triggered by an internal process may not need support
   * Check ACLs as an optimization
+
+* [ ] Endpoint added/updated in the [`nomad-openapi`](https://github.com/hashicorp/nomad-openapi) repository.
+  * New endpoints will need to be configured in that repository's `generator` package.
+  * Updated endpoints may require the `generator` configuration to change, especially if parameters or headers change.
+  * If the accepted or returned `struct` schema changes, the Nomad version references in `generator/go.mod` will need
+    to be updated. Once the version is updated, regenerate the spec and all all clients so that the new schema is
+    reflected in the spec and thus the generated models.
+  * If `QueryOptions`, `QueryMeta`, `WriteOptions`, or `WriteMeta` change, the `v1` framework will need to updated to
+    support the change.
 
 * [ ] `nomad/core_sched.go` sends many RPCs
   * `ServersMeetMinimumVersion` asserts that the server cluster is


### PR DESCRIPTION
This PR adds instructions for making sure that RPC/HTTP API changes get appropriately reflected in the Nomad OpenAPI project.