### PR TITLE
Fix for stable website

### DIFF
--- a/website/data/version.js
+++ b/website/data/version.js
@@ -1,1 +1,1 @@
-export default '1.2.2'
+export default '1.2.3'


### PR DESCRIPTION
The 1.2.3 release pushed documentation that was supposed to be only in `main` (i.e. for unreleased features). We'll need to update the release checklist but in the meantime this branch was forked from `v1.2.2` and cherry-picks over only the appropriate commits from https://github.com/hashicorp/nomad/compare/v1.2.2..stable-website