### PR TITLE
website: Update website Docker image

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.mirror.hashicorp.services/node:14-alpine
+FROM docker.mirror.hashicorp.services/node:14.17.0-alpine
 RUN apk add --update --no-cache git make g++ automake autoconf libtool nasm libpng-dev
 
 COPY ./package.json /website/package.json


### PR DESCRIPTION
This PR updates the website's Dockerfile to use a `node:14.17.0-alpine` image, bringing it in line with other product site Dockerfiles.
