### PR TITLE
fix: redirects website `/home` to `/`

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -2,6 +2,11 @@ module.exports = [
   // Define your custom redirects within this file.
   // Vercel's redirect documentation: https://vercel.com/docs/configuration#project/redirects
   // Playground for testing url pattern matching: https://npm.runkit.com/path-to-regexp
+  {
+    source: '/home',
+    destination: '/',
+    permanent: true,
+  },
 
   // Friendly URL for trial form redirection
   {


### PR DESCRIPTION
[https://nomad-9a6467pz5-hashicorp.vercel.app/home](https://nomad-9a6467pz5-hashicorp.vercel.app/home)
