### PR TITLE
Fix ACL requirements for job details UI

### DIFF
--- a/.changelog/11672.txt
+++ b/.changelog/11672.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix the ACL requirements for displaying the job details page
+```

--- a/ui/app/abilities/client.js
+++ b/ui/app/abilities/client.js
@@ -7,18 +7,30 @@ import classic from 'ember-classic-decorator';
 export default class Client extends AbstractAbility {
   // Map abilities to policy options (which are coarse for nodes)
   // instead of specific behaviors.
+  @or('bypassAuthorization', 'selfTokenIsManagement', 'policiesIncludeNodeRead')
+  canRead;
+
   @or('bypassAuthorization', 'selfTokenIsManagement', 'policiesIncludeNodeWrite')
   canWrite;
 
   @computed('token.selfTokenPolicies.[]')
-  get policiesIncludeNodeWrite() {
-    // For each policy record, extract the Node policy
-    const policies = (this.get('token.selfTokenPolicies') || [])
-      .toArray()
-      .map(policy => get(policy, 'rulesJSON.Node.Policy'))
-      .compact();
-
-    // Node write is allowed if any policy allows it
-    return policies.some(policy => policy === 'write');
+  get policiesIncludeNodeRead() {
+    return policiesIncludePermissions(this.get('token.selfTokenPolicies'), ['read', 'write']);
   }
+
+  @computed('token.selfTokenPolicies.[]')
+  get policiesIncludeNodeWrite() {
+    return policiesIncludePermissions(this.get('token.selfTokenPolicies'), ['write']);
+  }
+}
+
+function policiesIncludePermissions(policies = [], permissions = []) {
+  // For each policy record, extract the Node policy
+  const nodePolicies = policies
+    .toArray()
+    .map(policy => get(policy, 'rulesJSON.Node.Policy'))
+    .compact();
+
+  // Check for requested permissions
+  return nodePolicies.some(policy => permissions.includes(policy));
 }

--- a/ui/app/components/job-page/abstract.js
+++ b/ui/app/components/job-page/abstract.js
@@ -5,6 +5,7 @@ import classic from 'ember-classic-decorator';
 
 @classic
 export default class Abstract extends Component {
+  @service can;
   @service system;
 
   job = null;
@@ -19,6 +20,10 @@ export default class Abstract extends Component {
 
   // Set to a { title, description } to surface an error
   errorMessage = null;
+
+  get shouldDisplayClientInformation() {
+    return this.can.can('read client') && this.job.hasClientStatus;
+  }
 
   @action
   clearErrorMessage() {

--- a/ui/app/components/job-page/parameterized-child.js
+++ b/ui/app/components/job-page/parameterized-child.js
@@ -1,14 +1,11 @@
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
 import PeriodicChildJobPage from './periodic-child';
 import classic from 'ember-classic-decorator';
-import jobClientStatus from 'nomad-ui/utils/properties/job-client-status';
 
 @classic
 export default class ParameterizedChild extends PeriodicChildJobPage {
   @alias('job.decodedPayload') payload;
-  @service store;
 
   @computed('payload')
   get payloadJSON() {
@@ -19,11 +16,5 @@ export default class ParameterizedChild extends PeriodicChildJobPage {
       // Swallow error and fall back to plain text rendering
     }
     return json;
-  }
-
-  @jobClientStatus('nodes', 'job') jobClientStatus;
-
-  get nodes() {
-    return this.store.peekAll('node');
   }
 }

--- a/ui/app/components/job-page/parameterized-child.js
+++ b/ui/app/components/job-page/parameterized-child.js
@@ -8,6 +8,7 @@ import jobClientStatus from 'nomad-ui/utils/properties/job-client-status';
 @classic
 export default class ParameterizedChild extends PeriodicChildJobPage {
   @alias('job.decodedPayload') payload;
+  @service can;
   @service store;
 
   @computed('payload')
@@ -25,5 +26,9 @@ export default class ParameterizedChild extends PeriodicChildJobPage {
 
   get nodes() {
     return this.store.peekAll('node');
+  }
+
+  get shouldDisplayClientInformation() {
+    return this.can.can('read client') && this.job.hasClientStatus;
   }
 }

--- a/ui/app/components/job-page/parameterized-child.js
+++ b/ui/app/components/job-page/parameterized-child.js
@@ -8,7 +8,6 @@ import jobClientStatus from 'nomad-ui/utils/properties/job-client-status';
 @classic
 export default class ParameterizedChild extends PeriodicChildJobPage {
   @alias('job.decodedPayload') payload;
-  @service can;
   @service store;
 
   @computed('payload')
@@ -26,9 +25,5 @@ export default class ParameterizedChild extends PeriodicChildJobPage {
 
   get nodes() {
     return this.store.peekAll('node');
-  }
-
-  get shouldDisplayClientInformation() {
-    return this.can.can('read client') && this.job.hasClientStatus;
   }
 }

--- a/ui/app/components/job-page/parts/job-client-status-summary.js
+++ b/ui/app/components/job-page/parts/job-client-status-summary.js
@@ -8,10 +8,13 @@ import classic from 'ember-classic-decorator';
 export default class JobClientStatusSummary extends Component {
   job = null;
   jobClientStatus = null;
+  forceCollapsed = false;
   gotoClients() {}
 
-  @computed
+  @computed('forceCollapsed')
   get isExpanded() {
+    if (this.forceCollapsed) return false;
+
     const storageValue = window.localStorage.nomadExpandJobClientStatusSummary;
     return storageValue != null ? JSON.parse(storageValue) : true;
   }

--- a/ui/app/components/job-page/parts/job-client-status-summary.js
+++ b/ui/app/components/job-page/parts/job-client-status-summary.js
@@ -2,12 +2,13 @@ import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { classNames } from '@ember-decorators/component';
 import classic from 'ember-classic-decorator';
+import jobClientStatus from 'nomad-ui/utils/properties/job-client-status';
 
 @classic
 @classNames('boxed-section')
 export default class JobClientStatusSummary extends Component {
   job = null;
-  jobClientStatus = null;
+  nodes = null;
   forceCollapsed = false;
   gotoClients() {}
 
@@ -18,6 +19,8 @@ export default class JobClientStatusSummary extends Component {
     const storageValue = window.localStorage.nomadExpandJobClientStatusSummary;
     return storageValue != null ? JSON.parse(storageValue) : true;
   }
+
+  @jobClientStatus('nodes', 'job') jobClientStatus;
 
   @action
   onSliceClick(ev, slice) {

--- a/ui/app/components/job-page/periodic-child.js
+++ b/ui/app/components/job-page/periodic-child.js
@@ -1,13 +1,9 @@
 import AbstractJobPage from './abstract';
 import { computed } from '@ember/object';
-import { inject as service } from '@ember/service';
 import classic from 'ember-classic-decorator';
-import jobClientStatus from 'nomad-ui/utils/properties/job-client-status';
 
 @classic
 export default class PeriodicChild extends AbstractJobPage {
-  @service store;
-
   @computed('job.{name,id}', 'job.parent.{name,id}')
   get breadcrumbs() {
     const job = this.job;
@@ -24,11 +20,5 @@ export default class PeriodicChild extends AbstractJobPage {
         args: ['jobs.job', job],
       },
     ];
-  }
-
-  @jobClientStatus('nodes', 'job') jobClientStatus;
-
-  get nodes() {
-    return this.store.peekAll('node');
   }
 }

--- a/ui/app/components/job-page/periodic-child.js
+++ b/ui/app/components/job-page/periodic-child.js
@@ -6,7 +6,6 @@ import jobClientStatus from 'nomad-ui/utils/properties/job-client-status';
 
 @classic
 export default class PeriodicChild extends AbstractJobPage {
-  @service can;
   @service store;
 
   @computed('job.{name,id}', 'job.parent.{name,id}')
@@ -31,9 +30,5 @@ export default class PeriodicChild extends AbstractJobPage {
 
   get nodes() {
     return this.store.peekAll('node');
-  }
-
-  get shouldDisplayClientInformation() {
-    return this.can.can('read client') && this.job.hasClientStatus;
   }
 }

--- a/ui/app/components/job-page/periodic-child.js
+++ b/ui/app/components/job-page/periodic-child.js
@@ -6,6 +6,7 @@ import jobClientStatus from 'nomad-ui/utils/properties/job-client-status';
 
 @classic
 export default class PeriodicChild extends AbstractJobPage {
+  @service can;
   @service store;
 
   @computed('job.{name,id}', 'job.parent.{name,id}')
@@ -30,5 +31,9 @@ export default class PeriodicChild extends AbstractJobPage {
 
   get nodes() {
     return this.store.peekAll('node');
+  }
+
+  get shouldDisplayClientInformation() {
+    return this.can.can('read client') && this.job.hasClientStatus;
   }
 }

--- a/ui/app/components/job-page/sysbatch.js
+++ b/ui/app/components/job-page/sysbatch.js
@@ -1,15 +1,5 @@
 import AbstractJobPage from './abstract';
 import classic from 'ember-classic-decorator';
-import { inject as service } from '@ember/service';
-import jobClientStatus from 'nomad-ui/utils/properties/job-client-status';
 
 @classic
-export default class Sysbatch extends AbstractJobPage {
-  @service store;
-
-  @jobClientStatus('nodes', 'job') jobClientStatus;
-
-  get nodes() {
-    return this.store.peekAll('node');
-  }
-}
+export default class Sysbatch extends AbstractJobPage {}

--- a/ui/app/components/job-page/system.js
+++ b/ui/app/components/job-page/system.js
@@ -1,15 +1,5 @@
 import AbstractJobPage from './abstract';
 import classic from 'ember-classic-decorator';
-import { inject as service } from '@ember/service';
-import jobClientStatus from 'nomad-ui/utils/properties/job-client-status';
 
 @classic
-export default class System extends AbstractJobPage {
-  @service store;
-
-  @jobClientStatus('nodes', 'job') jobClientStatus;
-
-  get nodes() {
-    return this.store.peekAll('node');
-  }
-}
+export default class System extends AbstractJobPage {}

--- a/ui/app/components/list-accordion/accordion-head.js
+++ b/ui/app/components/list-accordion/accordion-head.js
@@ -9,8 +9,10 @@ export default class AccordionHead extends Component {
   'data-test-accordion-head' = true;
 
   buttonLabel = 'toggle';
+  tooltip = '';
   isOpen = false;
   isExpandable = true;
+  isDisabled = false;
   item = null;
 
   onClose() {}

--- a/ui/app/controllers/jobs/job/index.js
+++ b/ui/app/controllers/jobs/job/index.js
@@ -28,7 +28,7 @@ export default class IndexController extends Controller.extend(WithNamespaceRese
     return this.model.job;
   }
 
-  @computed('model.nodes')
+  @computed('model.nodes.[]')
   get nodes() {
     return this.model.nodes;
   }

--- a/ui/app/controllers/jobs/job/index.js
+++ b/ui/app/controllers/jobs/job/index.js
@@ -1,5 +1,5 @@
 import { inject as service } from '@ember/service';
-import { alias } from '@ember/object/computed';
+import { computed } from '@ember/object';
 import Controller from '@ember/controller';
 import WithNamespaceResetting from 'nomad-ui/mixins/with-namespace-resetting';
 import { action } from '@ember/object';
@@ -23,7 +23,15 @@ export default class IndexController extends Controller.extend(WithNamespaceRese
 
   currentPage = 1;
 
-  @alias('model') job;
+  @computed('model.job')
+  get job() {
+    return this.model.job;
+  }
+
+  @computed('model.nodes')
+  get nodes() {
+    return this.model.nodes;
+  }
 
   sortProperty = 'name';
   sortDescending = false;

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -29,6 +29,16 @@ export default class Allocation extends Model {
   @fragment('resources') allocatedResources;
   @attr('number') jobVersion;
 
+  // Store basic node information returned by the API to avoid the need for
+  // node:read ACL permission.
+  @attr('string') nodeName;
+  @computed
+  get shortNodeId() {
+    return this.belongsTo('node')
+      .id()
+      .split('-')[0];
+  }
+
   @attr('number') modifyIndex;
   @attr('date') modifyTime;
 

--- a/ui/app/routes/jobs/job/index.js
+++ b/ui/app/routes/jobs/job/index.js
@@ -11,42 +11,48 @@ import WithWatchers from 'nomad-ui/mixins/with-watchers';
 
 export default class IndexRoute extends Route.extend(WithWatchers) {
   @service can;
+  @service store;
 
   async model() {
-    return this.modelFor('jobs.job');
-  }
+    const job = this.modelFor('jobs.job');
+    if (!job) {
+      return { job, nodes: [] };
+    }
 
-  async afterModel(model) {
     // Optimizing future node look ups by preemptively loading all nodes if
     // necessary and allowed.
-    if (model && model.get('hasClientStatus') && this.can.can('read client')) {
+    if (this.can.can('read client') && job.get('hasClientStatus')) {
       await this.store.findAll('node');
     }
+    const nodes = this.store.peekAll('node');
+    return { job, nodes };
   }
 
   startWatchers(controller, model) {
-    if (!model) {
+    if (!model.job) {
       return;
     }
     controller.set('watchers', {
-      model: this.watch.perform(model),
-      summary: this.watchSummary.perform(model.get('summary')),
-      allocations: this.watchAllocations.perform(model),
-      evaluations: this.watchEvaluations.perform(model),
+      model: this.watch.perform(model.job),
+      summary: this.watchSummary.perform(model.job.get('summary')),
+      allocations: this.watchAllocations.perform(model.job),
+      evaluations: this.watchEvaluations.perform(model.job),
       latestDeployment:
-        model.get('supportsDeployments') && this.watchLatestDeployment.perform(model),
+        model.job.get('supportsDeployments') && this.watchLatestDeployment.perform(model.job),
       list:
-        model.get('hasChildren') &&
-        this.watchAllJobs.perform({ namespace: model.namespace.get('name') }),
+        model.job.get('hasChildren') &&
+        this.watchAllJobs.perform({ namespace: model.job.namespace.get('name') }),
       nodes:
-        this.can.can('read client') && model.get('hasClientStatus') && this.watchNodes.perform(),
+        this.can.can('read client') &&
+        model.job.get('hasClientStatus') &&
+        this.watchNodes.perform(),
     });
   }
 
   setupController(controller, model) {
     // Parameterized and periodic detail pages, which list children jobs,
     // should sort by submit time.
-    if (model && ['periodic', 'parameterized'].includes(model.templateType)) {
+    if (model.job && ['periodic', 'parameterized'].includes(model.job.templateType)) {
       controller.setProperties({
         sortProperty: 'submitTime',
         sortDescending: true,

--- a/ui/app/routes/jobs/job/index.js
+++ b/ui/app/routes/jobs/job/index.js
@@ -19,7 +19,7 @@ export default class IndexRoute extends Route.extend(WithWatchers) {
   async afterModel(model) {
     // Optimizing future node look ups by preemptively loading all nodes if
     // necessary and allowed.
-    if (model.get('hasClientStatus') && this.can.can('read client')) {
+    if (model && model.get('hasClientStatus') && this.can.can('read client')) {
       await this.store.findAll('node');
     }
   }

--- a/ui/app/templates/components/allocation-row.hbs
+++ b/ui/app/templates/components/allocation-row.hbs
@@ -1,8 +1,10 @@
 <td data-test-indicators class="is-narrow">
-  {{#if this.allocation.unhealthyDrivers.length}}
-    <span data-test-icon="unhealthy-driver" class="tooltip text-center" role="tooltip" aria-label="Allocation depends on unhealthy drivers">
-      {{x-icon "alert-triangle" class="is-warning"}}
-    </span>
+  {{#if (can "read client")}}
+    {{#if this.allocation.unhealthyDrivers.length}}
+      <span data-test-icon="unhealthy-driver" class="tooltip text-center" role="tooltip" aria-label="Allocation depends on unhealthy drivers">
+        {{x-icon "alert-triangle" class="is-warning"}}
+      </span>
+    {{/if}}
   {{/if}}
   {{#if this.allocation.nextAllocation}}
     <span data-test-icon="reschedule" class="tooltip text-center" role="tooltip" aria-label="Allocation was rescheduled">
@@ -38,21 +40,25 @@
 </td>
 {{#if (eq this.context "volume")}}
   <td data-test-client>
-    <Tooltip @text={{this.allocation.node.name}}>
-      <LinkTo @route="clients.client" @model={{this.allocation.node}}>
-        {{this.allocation.node.shortId}}
-      </LinkTo>
-    </Tooltip>
+    {{#if (can "read client")}}
+      <Tooltip @text={{this.allocation.node.name}}>
+        <LinkTo @route="clients.client" @model={{this.allocation.node}}>
+          {{this.allocation.node.shortId}}
+        </LinkTo>
+      </Tooltip>
+    {{/if}}
   </td>
 {{/if}}
 {{#if (or (eq this.context "taskGroup") (eq this.context "job"))}}
   <td data-test-job-version>{{this.allocation.jobVersion}}</td>
   <td data-test-client>
-    <Tooltip @text={{this.allocation.node.name}}>
-      <LinkTo @route="clients.client" @model={{this.allocation.node}}>
-        {{this.allocation.node.shortId}}
-      </LinkTo>
-    </Tooltip>
+    {{#if (can "read client")}}
+      <Tooltip @text={{this.allocation.node.name}}>
+        <LinkTo @route="clients.client" @model={{this.allocation.node}}>
+          {{this.allocation.node.shortId}}
+        </LinkTo>
+      </Tooltip>
+    {{/if}}
   </td>
 {{else if (or (eq this.context "node") (eq this.context "volume"))}}
   <td>

--- a/ui/app/templates/components/allocation-row.hbs
+++ b/ui/app/templates/components/allocation-row.hbs
@@ -40,25 +40,29 @@
 </td>
 {{#if (eq this.context "volume")}}
   <td data-test-client>
-    {{#if (can "read client")}}
-      <Tooltip @text={{this.allocation.node.name}}>
+    <Tooltip @text={{this.allocation.nodeName}}>
+      {{#if (can "read client")}}
         <LinkTo @route="clients.client" @model={{this.allocation.node}}>
-          {{this.allocation.node.shortId}}
+          {{this.allocation.shortNodeId}}
         </LinkTo>
-      </Tooltip>
-    {{/if}}
+      {{else}}
+        {{this.allocation.shortNodeId}}
+      {{/if}}
+    </Tooltip>
   </td>
 {{/if}}
 {{#if (or (eq this.context "taskGroup") (eq this.context "job"))}}
   <td data-test-job-version>{{this.allocation.jobVersion}}</td>
   <td data-test-client>
-    {{#if (can "read client")}}
-      <Tooltip @text={{this.allocation.node.name}}>
+    <Tooltip @text={{this.allocation.nodeName}}>
+      {{#if (can "read client")}}
         <LinkTo @route="clients.client" @model={{this.allocation.node}}>
-          {{this.allocation.node.shortId}}
+          {{this.allocation.shortNodeId}}
         </LinkTo>
-      </Tooltip>
-    {{/if}}
+      {{else}}
+        {{this.allocation.shortNodeId}}
+      {{/if}}
+    </Tooltip>
   </td>
 {{else if (or (eq this.context "node") (eq this.context "volume"))}}
   <td>

--- a/ui/app/templates/components/job-page/parameterized-child.hbs
+++ b/ui/app/templates/components/job-page/parameterized-child.hbs
@@ -17,7 +17,7 @@
   {{#if this.job.hasClientStatus}}
     <JobPage::Parts::JobClientStatusSummary
       @job={{this.job}}
-      @jobClientStatus={{if this.shouldDisplayClientInformation this.jobClientStatus}}
+      @nodes={{this.nodes}}
       @forceCollapsed={{not this.shouldDisplayClientInformation}}
       @gotoClients={{this.gotoClients}} />
   {{/if}}

--- a/ui/app/templates/components/job-page/parameterized-child.hbs
+++ b/ui/app/templates/components/job-page/parameterized-child.hbs
@@ -14,14 +14,12 @@
     </:before-namespace>
   </JobPage::Parts::StatsBox>
 
-  {{#if this.shouldDisplayClientInformation}}
+  {{#if this.job.hasClientStatus}}
     <JobPage::Parts::JobClientStatusSummary
-      @gotoClients={{this.gotoClients}}
       @job={{this.job}}
-      @jobClientStatus={{this.jobClientStatus}}
-    />
-  {{else}}
-    <JobPage::Parts::JobClientStatusSummary @job={{this.job}} @forceCollapsed="true" />
+      @jobClientStatus={{if this.shouldDisplayClientInformation this.jobClientStatus}}
+      @forceCollapsed={{not this.shouldDisplayClientInformation}}
+      @gotoClients={{this.gotoClients}} />
   {{/if}}
 
   <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{this.shouldDisplayClientInformation}} />

--- a/ui/app/templates/components/job-page/parameterized-child.hbs
+++ b/ui/app/templates/components/job-page/parameterized-child.hbs
@@ -20,6 +20,8 @@
       @job={{this.job}}
       @jobClientStatus={{this.jobClientStatus}}
     />
+  {{else}}
+    <JobPage::Parts::JobClientStatusSummary @job={{this.job}} @forceCollapsed="true" />
   {{/if}}
 
   <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{this.shouldDisplayClientInformation}} />

--- a/ui/app/templates/components/job-page/parameterized-child.hbs
+++ b/ui/app/templates/components/job-page/parameterized-child.hbs
@@ -14,7 +14,7 @@
     </:before-namespace>
   </JobPage::Parts::StatsBox>
 
-  {{#if this.job.hasClientStatus}}
+  {{#if this.shouldDisplayClientInformation}}
     <JobPage::Parts::JobClientStatusSummary
       @gotoClients={{this.gotoClients}}
       @job={{this.job}}
@@ -22,7 +22,7 @@
     />
   {{/if}}
 
-  <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{this.job.hasClientStatus}} />
+  <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{this.shouldDisplayClientInformation}} />
 
   <JobPage::Parts::PlacementFailures @job={{this.job}} />
 

--- a/ui/app/templates/components/job-page/parts/job-client-status-summary.hbs
+++ b/ui/app/templates/components/job-page/parts/job-client-status-summary.hbs
@@ -1,5 +1,5 @@
 <ListAccordion
-  data-test-job-summary
+  data-test-job-client-summary
   @source={{array this.job}}
   @key="id"
   @startExpanded={{this.isExpanded}}
@@ -9,14 +9,16 @@
     <div class="columns">
       <div class="column is-minimum nowrap">
         Job Status in Client
-        <span class="badge {{if a.isOpen "is-white" "is-light"}}">
-          {{this.jobClientStatus.totalNodes}}
-        </span>
+        {{#if this.jobClientStatus}}
+          <span class="badge {{if a.isOpen "is-white" "is-light"}}">
+            {{this.jobClientStatus.totalNodes}}
+          </span>
+        {{/if}}
         <span class="tooltip multiline" aria-label="Aggreate status of job's allocations in each client.">
           {{x-icon "info-circle-outline" class="is-faded"}}
         </span>
       </div>
-      {{#unless a.isOpen}}
+      {{#if (and this.jobClientStatus (not a.isOpen))}}
         <div class="column">
           <div class="inline-chart bumper-left">
             <JobClientStatusBar
@@ -27,29 +29,38 @@
             />
           </div>
         </div>
-      {{/unless}}
+      {{/if}}
     </div>
   </a.head>
   <a.body>
-    <JobClientStatusBar
-      @onSliceClick={{action this.onSliceClick}}
-      @job={{this.job}}
-      @jobClientStatus={{this.jobClientStatus}}
-      class="split-view" as |chart|
-    >
-      <ol data-test-legend class="legend">
-        {{#each chart.data as |datum index|}}
-          <li data-test-legent-label="{{datum.className}}" class="{{datum.className}} {{if (eq datum.label chart.activeDatum.label) "is-active"}} {{if (eq datum.value 0) "is-empty" "is-clickable"}}">
-            {{#if (gt datum.value 0)}}
-              <LinkTo @route="jobs.job.clients" @model={{this.job}} @query={{datum.legendLink.queryParams}}>
+    {{#if this.jobClientStatus}}
+      <JobClientStatusBar
+        @onSliceClick={{action this.onSliceClick}}
+        @job={{this.job}}
+        @jobClientStatus={{this.jobClientStatus}}
+        class="split-view" as |chart|
+      >
+        <ol data-test-legend class="legend">
+          {{#each chart.data as |datum index|}}
+            <li data-test-legent-label="{{datum.className}}" class="{{datum.className}} {{if (eq datum.label chart.activeDatum.label) "is-active"}} {{if (eq datum.value 0) "is-empty" "is-clickable"}}">
+              {{#if (gt datum.value 0)}}
+                <LinkTo @route="jobs.job.clients" @model={{this.job}} @query={{datum.legendLink.queryParams}}>
+                  <JobPage::Parts::SummaryLegendItem @datum={{datum}} @index={{index}} />
+                </LinkTo>
+              {{else}}
                 <JobPage::Parts::SummaryLegendItem @datum={{datum}} @index={{index}} />
-              </LinkTo>
-            {{else}}
-              <JobPage::Parts::SummaryLegendItem @datum={{datum}} @index={{index}} />
-            {{/if}}
-          </li>
-        {{/each}}
-      </ol>
-    </JobClientStatusBar>
+              {{/if}}
+            </li>
+          {{/each}}
+        </ol>
+      </JobClientStatusBar>
+    {{else if (cannot "read clients") }}
+      <div data-test-not-authorized-message class="empty-message">
+        <h3 class="empty-message-headline">Not Authorized</h3>
+        <p class="empty-message-body">
+          Your <LinkTo @route="settings.tokens">ACL token</LinkTo> does not provide <code>node:read</code> permission.
+        </p>
+      </div>
+    {{/if}}
   </a.body>
 </ListAccordion>

--- a/ui/app/templates/components/job-page/parts/job-client-status-summary.hbs
+++ b/ui/app/templates/components/job-page/parts/job-client-status-summary.hbs
@@ -5,7 +5,11 @@
   @startExpanded={{this.isExpanded}}
   @onToggle={{action this.persist}} as |a|
 >
-  <a.head @buttonLabel={{if a.isOpen "collapse" "expand"}}>
+  <a.head
+    @buttonLabel={{if a.isOpen "collapse" "expand"}}
+    @tooltip={{if (cannot "read client") "You don’t have permission to read clients"}}
+    @isDisabled={{cannot "read client"}}
+  >
     <div class="columns">
       <div class="column is-minimum nowrap">
         Job Status in Client
@@ -54,13 +58,6 @@
           {{/each}}
         </ol>
       </JobClientStatusBar>
-    {{else if (cannot "read clients") }}
-      <div data-test-not-authorized-message class="empty-message">
-        <h3 class="empty-message-headline">Not Authorized</h3>
-        <p class="empty-message-body">
-          Your <LinkTo @route="settings.tokens">ACL token</LinkTo> does not provide <code>node:read</code> permission.
-        </p>
-      </div>
     {{/if}}
   </a.body>
 </ListAccordion>

--- a/ui/app/templates/components/job-page/periodic-child.hbs
+++ b/ui/app/templates/components/job-page/periodic-child.hbs
@@ -17,7 +17,7 @@
   {{#if this.job.hasClientStatus}}
     <JobPage::Parts::JobClientStatusSummary
       @job={{this.job}}
-      @jobClientStatus={{if this.shouldDisplayClientInformation this.jobClientStatus}}
+      @nodes={{this.nodes}}
       @forceCollapsed={{not this.shouldDisplayClientInformation}}
       @gotoClients={{this.gotoClients}} />
   {{/if}}

--- a/ui/app/templates/components/job-page/periodic-child.hbs
+++ b/ui/app/templates/components/job-page/periodic-child.hbs
@@ -14,14 +14,12 @@
     </:before-namespace>
   </JobPage::Parts::StatsBox>
 
-  {{#if this.shouldDisplayClientInformation}}
+  {{#if this.job.hasClientStatus}}
     <JobPage::Parts::JobClientStatusSummary
-      @gotoClients={{this.gotoClients}}
       @job={{this.job}}
-      @jobClientStatus={{this.jobClientStatus}}
-    />
-  {{else}}
-    <JobPage::Parts::JobClientStatusSummary @job={{this.job}} @forceCollapsed="true" />
+      @jobClientStatus={{if this.shouldDisplayClientInformation this.jobClientStatus}}
+      @forceCollapsed={{not this.shouldDisplayClientInformation}}
+      @gotoClients={{this.gotoClients}} />
   {{/if}}
 
   <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{this.shouldDisplayClientInformation}} />

--- a/ui/app/templates/components/job-page/periodic-child.hbs
+++ b/ui/app/templates/components/job-page/periodic-child.hbs
@@ -20,6 +20,8 @@
       @job={{this.job}}
       @jobClientStatus={{this.jobClientStatus}}
     />
+  {{else}}
+    <JobPage::Parts::JobClientStatusSummary @job={{this.job}} @forceCollapsed="true" />
   {{/if}}
 
   <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{this.shouldDisplayClientInformation}} />

--- a/ui/app/templates/components/job-page/periodic-child.hbs
+++ b/ui/app/templates/components/job-page/periodic-child.hbs
@@ -14,7 +14,7 @@
     </:before-namespace>
   </JobPage::Parts::StatsBox>
 
-  {{#if this.job.hasClientStatus}}
+  {{#if this.shouldDisplayClientInformation}}
     <JobPage::Parts::JobClientStatusSummary
       @gotoClients={{this.gotoClients}}
       @job={{this.job}}
@@ -22,7 +22,7 @@
     />
   {{/if}}
 
-  <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{this.job.hasClientStatus}} />
+  <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{this.shouldDisplayClientInformation}} />
 
   <JobPage::Parts::PlacementFailures @job={{this.job}} />
 

--- a/ui/app/templates/components/job-page/sysbatch.hbs
+++ b/ui/app/templates/components/job-page/sysbatch.hbs
@@ -5,16 +5,13 @@
 
   <JobPage::Parts::StatsBox @job={{this.job}} />
 
-  {{#if (can "read client")}}
-    <JobPage::Parts::JobClientStatusSummary
-      @job={{this.job}}
-      @jobClientStatus={{this.jobClientStatus}}
-      @gotoClients={{this.gotoClients}} />
-  {{else}}
-    <JobPage::Parts::JobClientStatusSummary @job={{this.job}} @forceCollapsed="true" />
-  {{/if}}
+  <JobPage::Parts::JobClientStatusSummary
+    @job={{this.job}}
+    @jobClientStatus={{if this.shouldDisplayClientInformation this.jobClientStatus}}
+    @forceCollapsed={{not this.shouldDisplayClientInformation}}
+    @gotoClients={{this.gotoClients}} />
 
-  <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{if (can "read client") true false}} />
+  <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{this.shouldDisplayClientInformation}} />
 
   <JobPage::Parts::PlacementFailures @job={{this.job}} />
 

--- a/ui/app/templates/components/job-page/sysbatch.hbs
+++ b/ui/app/templates/components/job-page/sysbatch.hbs
@@ -10,6 +10,8 @@
       @job={{this.job}}
       @jobClientStatus={{this.jobClientStatus}}
       @gotoClients={{this.gotoClients}} />
+  {{else}}
+    <JobPage::Parts::JobClientStatusSummary @job={{this.job}} @forceCollapsed="true" />
   {{/if}}
 
   <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{if (can "read client") true false}} />

--- a/ui/app/templates/components/job-page/sysbatch.hbs
+++ b/ui/app/templates/components/job-page/sysbatch.hbs
@@ -5,12 +5,14 @@
 
   <JobPage::Parts::StatsBox @job={{this.job}} />
 
-  <JobPage::Parts::JobClientStatusSummary
-    @job={{this.job}}
-    @jobClientStatus={{this.jobClientStatus}}
-    @gotoClients={{this.gotoClients}} />
+  {{#if (can "read client")}}
+    <JobPage::Parts::JobClientStatusSummary
+      @job={{this.job}}
+      @jobClientStatus={{this.jobClientStatus}}
+      @gotoClients={{this.gotoClients}} />
+  {{/if}}
 
-  <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed="true" />
+  <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{if (can "read client") true false}} />
 
   <JobPage::Parts::PlacementFailures @job={{this.job}} />
 

--- a/ui/app/templates/components/job-page/sysbatch.hbs
+++ b/ui/app/templates/components/job-page/sysbatch.hbs
@@ -7,7 +7,7 @@
 
   <JobPage::Parts::JobClientStatusSummary
     @job={{this.job}}
-    @jobClientStatus={{if this.shouldDisplayClientInformation this.jobClientStatus}}
+    @nodes={{this.nodes}}
     @forceCollapsed={{not this.shouldDisplayClientInformation}}
     @gotoClients={{this.gotoClients}} />
 

--- a/ui/app/templates/components/job-page/system.hbs
+++ b/ui/app/templates/components/job-page/system.hbs
@@ -16,6 +16,8 @@
       @job={{this.job}}
       @jobClientStatus={{this.jobClientStatus}}
       @gotoClients={{this.gotoClients}} />
+  {{else}}
+    <JobPage::Parts::JobClientStatusSummary @job={{this.job}} @forceCollapsed="true" />
   {{/if}}
 
   <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{if (can "read client") true false}} />

--- a/ui/app/templates/components/job-page/system.hbs
+++ b/ui/app/templates/components/job-page/system.hbs
@@ -11,16 +11,13 @@
     {{/each}}
   {{/if}}
 
-  {{#if (can "read client")}}
-    <JobPage::Parts::JobClientStatusSummary
-      @job={{this.job}}
-      @jobClientStatus={{this.jobClientStatus}}
-      @gotoClients={{this.gotoClients}} />
-  {{else}}
-    <JobPage::Parts::JobClientStatusSummary @job={{this.job}} @forceCollapsed="true" />
-  {{/if}}
+  <JobPage::Parts::JobClientStatusSummary
+    @job={{this.job}}
+    @jobClientStatus={{if this.shouldDisplayClientInformation this.jobClientStatus}}
+    @forceCollapsed={{not this.shouldDisplayClientInformation}}
+    @gotoClients={{this.gotoClients}} />
 
-  <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{if (can "read client") true false}} />
+  <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{this.shouldDisplayClientInformation}} />
 
   <JobPage::Parts::PlacementFailures @job={{this.job}} />
 

--- a/ui/app/templates/components/job-page/system.hbs
+++ b/ui/app/templates/components/job-page/system.hbs
@@ -13,7 +13,7 @@
 
   <JobPage::Parts::JobClientStatusSummary
     @job={{this.job}}
-    @jobClientStatus={{if this.shouldDisplayClientInformation this.jobClientStatus}}
+    @nodes={{this.nodes}}
     @forceCollapsed={{not this.shouldDisplayClientInformation}}
     @gotoClients={{this.gotoClients}} />
 

--- a/ui/app/templates/components/job-page/system.hbs
+++ b/ui/app/templates/components/job-page/system.hbs
@@ -11,12 +11,14 @@
     {{/each}}
   {{/if}}
 
-  <JobPage::Parts::JobClientStatusSummary
-    @job={{this.job}}
-    @jobClientStatus={{this.jobClientStatus}}
-    @gotoClients={{this.gotoClients}} />
+  {{#if (can "read client")}}
+    <JobPage::Parts::JobClientStatusSummary
+      @job={{this.job}}
+      @jobClientStatus={{this.jobClientStatus}}
+      @gotoClients={{this.gotoClients}} />
+  {{/if}}
 
-  <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed="true" />
+  <JobPage::Parts::Summary @job={{this.job}} @forceCollapsed={{if (can "read client") true false}} />
 
   <JobPage::Parts::PlacementFailures @job={{this.job}} />
 

--- a/ui/app/templates/components/job-subnav.hbs
+++ b/ui/app/templates/components/job-subnav.hbs
@@ -8,7 +8,7 @@
     {{/if}}
     <li data-test-tab="allocations"><LinkTo @route="jobs.job.allocations" @query={{hash namespace=this.job.namespace.id}} @model={{@job}} @activeClass="is-active">Allocations</LinkTo></li>
     <li data-test-tab="evaluations"><LinkTo @route="jobs.job.evaluations" @query={{hash namespace=this.job.namespace.id}} @model={{@job}} @activeClass="is-active">Evaluations</LinkTo></li>
-    {{#if (and this.job.hasClientStatus (not this.job.hasChildren))}}
+    {{#if (and (can "read client") (and this.job.hasClientStatus (not this.job.hasChildren)))}}
       <li data-test-tab="clients"><LinkTo @route="jobs.job.clients" @query={{hash namespace=this.job.namespace.id}} @model={{@job}} @activeClass="is-active">Clients</LinkTo></li>
     {{/if}}
   </ul>

--- a/ui/app/templates/components/list-accordion/accordion-head.hbs
+++ b/ui/app/templates/components/list-accordion/accordion-head.hbs
@@ -3,7 +3,9 @@
 </div>
 <button
   data-test-accordion-toggle
-  class="button is-light is-compact pull-right accordion-toggle {{unless this.isExpandable "is-invisible"}}"
+  class="button is-light is-compact pull-right accordion-toggle {{unless this.isExpandable "is-invisible"}} {{if this.tooltip "tooltip multiline"}}"
+  disabled={{if this.isDisabled "disabled"}}
+  aria-label={{this.tooltip}}
   onclick={{action (if this.isOpen this.onClose this.onOpen) this.item}}
   type="button">
   {{this.buttonLabel}}

--- a/ui/app/templates/components/task-row.hbs
+++ b/ui/app/templates/components/task-row.hbs
@@ -1,9 +1,11 @@
 <td class="is-narrow">
-  {{#unless this.task.driverStatus.healthy}}
-    <span data-test-icon="unhealthy-driver" class="tooltip text-center" aria-label="{{this.task.driver}} is unhealthy">
-      {{x-icon "alert-triangle" class="is-warning"}}
-    </span>
-  {{/unless}}
+  {{#if (can "read client")}}
+    {{#unless this.task.driverStatus.healthy}}
+      <span data-test-icon="unhealthy-driver" class="tooltip text-center" aria-label="{{this.task.driver}} is unhealthy">
+        {{x-icon "alert-triangle" class="is-warning"}}
+      </span>
+    {{/unless}}
+  {{/if}}
 </td>
 <td data-test-name class="nowrap">
   <LinkTo @route="allocations.allocation.task" @models={{array this.task.allocation this.task}} class="is-primary">

--- a/ui/app/templates/jobs/job/index.hbs
+++ b/ui/app/templates/jobs/job/index.hbs
@@ -1,6 +1,7 @@
-{{page-title "Job " this.model.name}}
-{{component (concat "job-page/" this.model.templateType)
-  job=this.model
+{{page-title "Job " this.job.name}}
+{{component (concat "job-page/" this.job.templateType)
+  job=this.job
+  nodes=this.nodes
   sortProperty=this.sortProperty
   sortDescending=this.sortDescending
   currentPage=this.currentPage

--- a/ui/app/utils/properties/job-client-status.js
+++ b/ui/app/utils/properties/job-client-status.js
@@ -35,7 +35,7 @@ export default function jobClientStatus(nodesKey, jobKey) {
       // Group the job allocations by the ID of the client that is running them.
       const allocsByNodeID = {};
       job.allocations.forEach(a => {
-        const nodeId = a.node.get('id');
+        const nodeId = a.belongsTo('node').id();
         if (!allocsByNodeID[nodeId]) {
           allocsByNodeID[nodeId] = [];
         }

--- a/ui/mirage/factories/allocation.js
+++ b/ui/mirage/factories/allocation.js
@@ -175,6 +175,7 @@ export default Factory.extend({
       namespace,
       jobId: job.id,
       nodeId: node.id,
+      nodeName: node.name,
       taskStateIds: [],
       taskResourceIds: [],
       taskGroup: taskGroup.name,

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -6,6 +6,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import Allocation from 'nomad-ui/tests/pages/allocations/detail';
+import Tokens from 'nomad-ui/tests/pages/settings/tokens';
 import moment from 'moment';
 import formatHost from 'nomad-ui/utils/format-host';
 
@@ -44,6 +45,8 @@ module('Acceptance | allocation detail', function(hooks) {
     server.schema.tasks.first().update({
       driver: 'docker',
     });
+
+    window.localStorage.clear();
 
     await Allocation.visit({ id: allocation.id });
   });
@@ -177,6 +180,26 @@ module('Acceptance | allocation detail', function(hooks) {
   });
 
   test('tasks with an unhealthy driver have a warning icon', async function(assert) {
+    // Driver health status require node:read permission.
+    const policy = server.create('policy', {
+      id: 'node-read',
+      name: 'node-read',
+      rulesJSON: {
+        Node: {
+          Policy: 'read',
+        },
+      },
+    });
+    const clientToken = server.create('token', { type: 'client' });
+    clientToken.policyIds = [policy.id];
+    clientToken.save();
+
+    // Since the page is already visited in the beforeEach hook, setting the
+    // localStorage directly is not enough.
+    await Tokens.visit();
+    await Tokens.secret(clientToken.secretId).submit();
+    await Allocation.visit({ id: allocation.id });
+
     assert.ok(Allocation.firstUnhealthyTask().hasUnhealthyDriver, 'Warning is shown');
   });
 
@@ -271,7 +294,9 @@ module('Acceptance | allocation detail', function(hooks) {
     await Allocation.stop.confirm();
 
     assert.equal(
-      server.pretender.handledRequests.reject(request => request.url.includes('fuzzy')).findBy('method', 'POST').url,
+      server.pretender.handledRequests
+        .reject(request => request.url.includes('fuzzy'))
+        .findBy('method', 'POST').url,
       `/v1/allocation/${allocation.id}/stop`,
       'Stop request is made for the allocation'
     );
@@ -381,6 +406,7 @@ module('Acceptance | allocation detail (preemptions)', function(hooks) {
     server.create('agent');
     node = server.create('node');
     job = server.create('job', { createAllocations: false });
+    window.localStorage.clear();
   });
 
   test('shows a dedicated section to the allocation that preempted this allocation', async function(assert) {
@@ -463,6 +489,32 @@ module('Acceptance | allocation detail (preemptions)', function(hooks) {
       server.db.nodes.find(preemption.nodeId).id.split('-')[0],
       'Node ID'
     );
+  });
+
+  test('clicking the client ID in the preempted allocation row naviates to the client page', async function(assert) {
+    // Navigating to the client page requires node:read permission.
+    const policy = server.create('policy', {
+      id: 'node-read',
+      name: 'node-read',
+      rulesJSON: {
+        Node: {
+          Policy: 'read',
+        },
+      },
+    });
+    const clientToken = server.create('token', { type: 'client' });
+    clientToken.policyIds = [policy.id];
+    clientToken.save();
+    window.localStorage.nomadTokenSecret = clientToken.secretId;
+
+    allocation = server.create('allocation', 'preempter');
+    await Allocation.visit({ id: allocation.id });
+
+    const preemption = allocation.preemptedAllocations
+      .map(id => server.schema.find('allocation', id))
+      .sortBy('modifyIndex')
+      .reverse()[0];
+    const preemptionRow = Allocation.preemptions.objectAt(0);
 
     await preemptionRow.visitClient();
     assert.equal(currentURL(), `/clients/${preemption.nodeId}`, 'Node links to node page');

--- a/ui/tests/acceptance/task-group-detail-test.js
+++ b/ui/tests/acceptance/task-group-detail-test.js
@@ -282,9 +282,30 @@ module('Acceptance | task group detail', function(hooks) {
       Object.keys(taskGroup.volumes).length ? 'Yes' : '',
       'Volumes'
     );
+  });
+
+  test('clicking the client ID in the allocation row naviates to the client page', async function(assert) {
+    // Navigating to the client page requires node:read permission.
+    const policy = server.create('policy', {
+      id: 'node-read',
+      name: 'node-read',
+      rulesJSON: {
+        Node: {
+          Policy: 'read',
+        },
+      },
+    });
+    const clientToken = server.create('token', { type: 'client' });
+    clientToken.policyIds = [policy.id];
+    clientToken.save();
+    window.localStorage.nomadTokenSecret = clientToken.secretId;
+
+    await TaskGroup.visit({ id: job.id, name: taskGroup.name });
+
+    const allocation = allocations.sortBy('modifyIndex').reverse()[0];
+    const allocationRow = TaskGroup.allocations.objectAt(0);
 
     await allocationRow.visitClient();
-
     assert.equal(currentURL(), `/clients/${allocation.nodeId}`, 'Node links to node page');
   });
 

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -153,13 +153,13 @@ export function moduleForJobWithClientStatus(title, jobFactory, additionalTests)
 
     test('job status summary is shown in the overview', async function(assert) {
       assert.ok(
-        JobDetail.jobClientStatusSummary.isPresent,
+        JobDetail.jobClientStatusSummary.statusBar.isPresent,
         'Summary bar is displayed in the Job Status in Client summary section'
       );
     });
 
     test('clicking legend item navigates to a pre-filtered clients table', async function(assert) {
-      const legendItem = JobDetail.jobClientStatusSummary.legend.clickableItems[0];
+      const legendItem = JobDetail.jobClientStatusSummary.statusBar.legend.clickableItems[0];
       const status = legendItem.label;
       await legendItem.click();
 
@@ -174,7 +174,7 @@ export function moduleForJobWithClientStatus(title, jobFactory, additionalTests)
     });
 
     test('clicking in a slice takes you to a pre-filtered clients table', async function(assert) {
-      const slice = JobDetail.jobClientStatusSummary.slices[0];
+      const slice = JobDetail.jobClientStatusSummary.statusBar.slices[0];
       const status = slice.label;
       await slice.click();
 
@@ -212,8 +212,10 @@ export function moduleForJobWithClientStatus(title, jobFactory, additionalTests)
       window.localStorage.nomadTokenSecret = clientToken.secretId;
 
       await JobDetail.visit({ id: job.id, namespace: job.namespace });
+      await JobDetail.jobClientStatusSummary.toggle();
 
-      assert.false(JobDetail.jobClientStatusSummary.isPresent);
+      assert.false(JobDetail.jobClientStatusSummary.statusBar.isPresent);
+      assert.true(JobDetail.jobClientStatusSummary.notAuthorized);
       assert.notOk(JobDetail.tabFor('clients'));
     });
 

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import JobDetail from 'nomad-ui/tests/pages/jobs/detail';
+import Tokens from 'nomad-ui/tests/pages/settings/tokens';
 
 // eslint-disable-next-line ember/no-test-module-for
 export default function moduleForJob(title, context, jobFactory, additionalTests) {
@@ -167,6 +168,23 @@ export function moduleForJobWithClientStatus(title, jobFactory, additionalTests)
       } else {
         await JobDetail.visit({ id: job.id, namespace: job.namespace });
       }
+    });
+
+    test('job status summary is collapsed when not authorized', async function(assert) {
+      const clientToken = server.create('token', { type: 'client' });
+      await Tokens.visit();
+      await Tokens.secret(clientToken.secretId).submit();
+
+      await JobDetail.visit({ id: job.id, namespace: job.namespace });
+
+      assert.ok(
+        JobDetail.jobClientStatusSummary.toggle.isDisabled,
+        'Job client status summar is disabled'
+      );
+      assert.equal(
+        JobDetail.jobClientStatusSummary.toggle.tooltip,
+        'You don’t have permission to read clients'
+      );
     });
 
     test('the subnav links to clients', async function(assert) {

--- a/ui/tests/pages/jobs/detail.js
+++ b/ui/tests/pages/jobs/detail.js
@@ -75,8 +75,12 @@ export default create({
   jobClientStatusSummary: {
     scope: '[data-test-job-client-summary]',
     statusBar: jobClientStatusBar('[data-test-job-client-status-bar]'),
-    notAuthorized: isPresent('[data-test-not-authorized-message]'),
-    toggle: clickable('[data-test-accordion-head] [data-test-accordion-toggle]'),
+    toggle: {
+      scope: '[data-test-accordion-head] [data-test-accordion-toggle]',
+      click: clickable(),
+      isDisabled: attribute('disabled'),
+      tooltip: attribute('aria-label'),
+    },
   },
 
   childrenSummary: isPresent('[data-test-job-summary] [data-test-children-status-bar]'),

--- a/ui/tests/pages/jobs/detail.js
+++ b/ui/tests/pages/jobs/detail.js
@@ -72,7 +72,13 @@ export default create({
     return this.packStats.toArray().findBy('id', id);
   },
 
-  jobClientStatusSummary: jobClientStatusBar('[data-test-job-client-status-bar]'),
+  jobClientStatusSummary: {
+    scope: '[data-test-job-client-summary]',
+    statusBar: jobClientStatusBar('[data-test-job-client-status-bar]'),
+    notAuthorized: isPresent('[data-test-not-authorized-message]'),
+    toggle: clickable('[data-test-accordion-head] [data-test-accordion-toggle]'),
+  },
+
   childrenSummary: isPresent('[data-test-job-summary] [data-test-children-status-bar]'),
   allocationsSummary: isPresent('[data-test-job-summary] [data-test-allocation-status-bar]'),
 

--- a/ui/tests/unit/abilities/client-test.js
+++ b/ui/tests/unit/abilities/client-test.js
@@ -8,26 +8,28 @@ module('Unit | Ability | client', function(hooks) {
   setupTest(hooks);
   setupAbility('client')(hooks);
 
-  test('it permits client write when ACLs are disabled', function(assert) {
+  test('it permits client read and write when ACLs are disabled', function(assert) {
     const mockToken = Service.extend({
       aclEnabled: false,
     });
     this.owner.register('service:token', mockToken);
 
+    assert.ok(this.ability.canRead);
     assert.ok(this.ability.canWrite);
   });
 
-  test('it permits client write for management tokens', function(assert) {
+  test('it permits client read and write for management tokens', function(assert) {
     const mockToken = Service.extend({
       aclEnabled: true,
       selfToken: { type: 'management' },
     });
     this.owner.register('service:token', mockToken);
 
+    assert.ok(this.ability.canRead);
     assert.ok(this.ability.canWrite);
   });
 
-  test('it permits client write for tokens with a policy that has node-write', function(assert) {
+  test('it permits client read and write for tokens with a policy that has node-write', function(assert) {
     const mockToken = Service.extend({
       aclEnabled: true,
       selfToken: { type: 'client' },
@@ -43,10 +45,11 @@ module('Unit | Ability | client', function(hooks) {
     });
     this.owner.register('service:token', mockToken);
 
+    assert.ok(this.ability.canRead);
     assert.ok(this.ability.canWrite);
   });
 
-  test('it permits client write for tokens with a policy that allows write and another policy that disallows it', function(assert) {
+  test('it permits client read and write for tokens with a policy that allows write and another policy that disallows it', function(assert) {
     const mockToken = Service.extend({
       aclEnabled: true,
       selfToken: { type: 'client' },
@@ -69,10 +72,11 @@ module('Unit | Ability | client', function(hooks) {
     });
     this.owner.register('service:token', mockToken);
 
+    assert.ok(this.ability.canRead);
     assert.ok(this.ability.canWrite);
   });
 
-  test('it blocks client write for tokens with a policy that does not allow node-write', function(assert) {
+  test('it permits client read and blocks client write for tokens with a policy that does not allow node-write', function(assert) {
     const mockToken = Service.extend({
       aclEnabled: true,
       selfToken: { type: 'client' },
@@ -88,6 +92,23 @@ module('Unit | Ability | client', function(hooks) {
     });
     this.owner.register('service:token', mockToken);
 
+    assert.ok(this.ability.canRead);
+    assert.notOk(this.ability.canWrite);
+  });
+
+  test('it blocks client read and write for tokens without a node policy', function(assert) {
+    const mockToken = Service.extend({
+      aclEnabled: true,
+      selfToken: { type: 'client' },
+      selfTokenPolicies: [
+        {
+          rulesJSON: {},
+        },
+      ],
+    });
+    this.owner.register('service:token', mockToken);
+
+    assert.notOk(this.ability.canRead);
     assert.notOk(this.ability.canWrite);
   });
 });

--- a/ui/tests/unit/utils/job-client-status-test.js
+++ b/ui/tests/unit/utils/job-client-status-test.js
@@ -35,6 +35,22 @@ class NodeMock {
   }
 }
 
+class AllocationMock {
+  constructor(node, clientStatus) {
+    this.node = node;
+    this.clientStatus = clientStatus;
+  }
+
+  belongsTo() {
+    const self = this;
+    return {
+      id() {
+        return self.node.id;
+      },
+    };
+  }
+}
+
 module('Unit | Util | JobClientStatus', function() {
   test('it handles the case where all nodes are running', async function(assert) {
     const node = new NodeMock('node-1', 'dc1');
@@ -42,7 +58,7 @@ module('Unit | Util | JobClientStatus', function() {
     const job = {
       datacenters: ['dc1'],
       status: 'running',
-      allocations: [{ node, clientStatus: 'running' }],
+      allocations: [new AllocationMock(node, 'running')],
       taskGroups: [{}],
     };
     const expected = {
@@ -75,9 +91,9 @@ module('Unit | Util | JobClientStatus', function() {
       datacenters: ['dc1'],
       status: 'running',
       allocations: [
-        { node, clientStatus: 'running' },
-        { node, clientStatus: 'failed' },
-        { node, clientStatus: 'running' },
+        new AllocationMock(node, 'running'),
+        new AllocationMock(node, 'failed'),
+        new AllocationMock(node, 'running'),
       ],
       taskGroups: [{}, {}, {}],
     };
@@ -111,9 +127,9 @@ module('Unit | Util | JobClientStatus', function() {
       datacenters: ['dc1'],
       status: 'running',
       allocations: [
-        { node, clientStatus: 'lost' },
-        { node, clientStatus: 'lost' },
-        { node, clientStatus: 'lost' },
+        new AllocationMock(node, 'lost'),
+        new AllocationMock(node, 'lost'),
+        new AllocationMock(node, 'lost'),
       ],
       taskGroups: [{}, {}, {}],
     };
@@ -147,9 +163,9 @@ module('Unit | Util | JobClientStatus', function() {
       datacenters: ['dc1'],
       status: 'running',
       allocations: [
-        { node, clientStatus: 'failed' },
-        { node, clientStatus: 'failed' },
-        { node, clientStatus: 'failed' },
+        new AllocationMock(node, 'failed'),
+        new AllocationMock(node, 'failed'),
+        new AllocationMock(node, 'failed'),
       ],
       taskGroups: [{}, {}, {}],
     };
@@ -183,9 +199,9 @@ module('Unit | Util | JobClientStatus', function() {
       datacenters: ['dc1'],
       status: 'running',
       allocations: [
-        { node, clientStatus: 'running' },
-        { node, clientStatus: 'running' },
-        { node, clientStatus: 'running' },
+        new AllocationMock(node, 'running'),
+        new AllocationMock(node, 'running'),
+        new AllocationMock(node, 'running'),
       ],
       taskGroups: [{}, {}, {}, {}],
     };
@@ -251,9 +267,9 @@ module('Unit | Util | JobClientStatus', function() {
       datacenters: ['dc1'],
       status: 'pending',
       allocations: [
-        { node, clientStatus: 'starting' },
-        { node, clientStatus: 'starting' },
-        { node, clientStatus: 'starting' },
+        new AllocationMock(node, 'starting'),
+        new AllocationMock(node, 'starting'),
+        new AllocationMock(node, 'starting'),
       ],
       taskGroups: [{}, {}, {}, {}],
     };
@@ -288,9 +304,9 @@ module('Unit | Util | JobClientStatus', function() {
       datacenters: ['dc1'],
       status: 'running',
       allocations: [
-        { node: node1, clientStatus: 'running' },
-        { node: node2, clientStatus: 'failed' },
-        { node: node1, clientStatus: 'running' },
+        new AllocationMock(node1, 'running'),
+        new AllocationMock(node2, 'failed'),
+        new AllocationMock(node1, 'running'),
       ],
       taskGroups: [{}, {}],
     };


### PR DESCRIPTION
#11078 added a new component to compute and display the job status in individual clients. This resulted in an unexpected increase in the ACL permissions required to navigate to the job detail page. Namely the job detail page would now require

```hcl
node {
  policy = "read"
}
```

This resulted in unexpected `Not Authorized` error page (#11660).

This PR adds a new ability to check for read node permission. It also updates the job details components to only render pieces and components that require node data when ACL permits.