### PR TITLE
website: Disable alert banner

### DIFF
--- a/website/data/alert-banner.js
+++ b/website/data/alert-banner.js
@@ -1,4 +1,4 @@
-export const ALERT_BANNER_ACTIVE = true
+export const ALERT_BANNER_ACTIVE = false
 // https://github.com/hashicorp/web-components/tree/master/packages/alert-banner
 export default {
   tag: 'Blog post',


### PR DESCRIPTION
This PR disables the alert banner for the website.

[_Created by Sourcegraph batch change `nquiles/disable-alert-banners`._](https://hashicorp-mktg.sourcegraph.com/users/nquiles/batch-changes/disable-alert-banners)