### PR TITLE
cli: return error from raft commands if db is open

### DIFF
--- a/helper/raftutil/state_test.go
+++ b/helper/raftutil/state_test.go
@@ -1,0 +1,52 @@
+package raftutil
+
+import (
+	"path/filepath"
+	"testing"
+
+	raftboltdb "github.com/hashicorp/raft-boltdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRaftStateInfo_InUse asserts that commands that inspect raft
+// state such as "nomad operator raft info" and "nomad operator raft
+// logs" fail with a helpful error message when called on an inuse
+// database.
+func TestRaftStateInfo_InUse(t *testing.T) {
+	t.Parallel() // since there's a 1s timeout.
+
+	// First create an empty raft db
+	dir := filepath.Join(t.TempDir(), "raft.db")
+
+	fakedb, err := raftboltdb.NewBoltStore(dir)
+	require.NoError(t, err)
+
+	// Next try to read the db without closing it
+	s, _, _, err := RaftStateInfo(dir)
+	assert.Nil(t, s)
+	require.EqualError(t, err, errAlreadyOpen.Error())
+
+	// LogEntries should produce the same error
+	_, _, err = LogEntries(dir)
+	require.EqualError(t, err, "failed to open raft logs: "+errAlreadyOpen.Error())
+
+	// Commands should work once the db is closed
+	require.NoError(t, fakedb.Close())
+
+	s, _, _, err = RaftStateInfo(dir)
+	assert.NotNil(t, s)
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+
+	logCh, errCh, err := LogEntries(dir)
+	require.NoError(t, err)
+
+	// Consume entries to cleanly close db
+	for closed := false; closed; {
+		select {
+		case _, closed = <-logCh:
+		case <-errCh:
+		}
+	}
+}


### PR DESCRIPTION
Before this change trying to run `nomad operator raft {info,logs}` on an
inuse raft.db would cause the command to block until the agent using
raft.db is closed.

After this change the command will block for 1s before returning a
(hopefully) helpful error message.

This change also sets the ReadOnly mode on the underlying BoltDb to
ensure diagnostics make no changes to the underlying store. We have no
evidence this has ever occurred, but it seems like a useful safety
measure.

No changelog added since this is a minor tweak in a "new" feature (it
was hidden in previous relases).