### PR TITLE
Update sys/capabilties-self to read only

### DIFF
--- a/website/content/docs/integrations/vault-integration.mdx
+++ b/website/content/docs/integrations/vault-integration.mdx
@@ -104,7 +104,7 @@ path "auth/token/revoke-accessor" {
 # Allow checking the capabilities of our own token. This is used to validate the
 # token upon startup.
 path "sys/capabilities-self" {
-  capabilities = ["update"]
+  capabilities = ["read"]
 }
 
 # Allow our own token to be renewed.

--- a/website/content/docs/integrations/vault-integration.mdx
+++ b/website/content/docs/integrations/vault-integration.mdx
@@ -102,9 +102,10 @@ path "auth/token/revoke-accessor" {
 }
 
 # Allow checking the capabilities of our own token. This is used to validate the
-# token upon startup.
+# token upon startup. Note this requires update permissions because the Vault API
+# is a POST
 path "sys/capabilities-self" {
-  capabilities = ["read"]
+  capabilities = ["update"]
 }
 
 # Allow our own token to be renewed.


### PR DESCRIPTION
Should the capability for "sys/capabilities-self" be read? From the comment above, it seems like we shouldn't need "update" as a capability if only checking is required.