### PR TITLE
Fix log streaming missing frames

### DIFF
--- a/.changelog/11721.txt
+++ b/.changelog/11721.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where the allocation log streaming API was missing log frames that spanned log file rotation
+```

--- a/client/fs_endpoint.go
+++ b/client/fs_endpoint.go
@@ -704,7 +704,10 @@ OUTER:
 			continue
 		}
 
-		// When eof and cancel received then cancel
+		// At this point we can stop without waiting for more changes,
+		// because we have EOF and either we're not following at all,
+		// or we received an event from the eofCancelCh channel
+		// and last read was executed
 		if cancelReceived {
 			return nil
 		}

--- a/client/fs_endpoint.go
+++ b/client/fs_endpoint.go
@@ -826,7 +826,6 @@ func blockUntilNextLog(ctx context.Context, fs allocdir.AllocDirFS, logPath, tas
 				// waiting for.
 				for _, entry := range indexes {
 					if entry.idx >= nextIndex {
-						//<-time.NewTicker(5 * time.Second).C
 						next <- nil
 						close(next)
 						return

--- a/client/fs_endpoint.go
+++ b/client/fs_endpoint.go
@@ -761,6 +761,10 @@ OUTER:
 					return nil
 				}
 
+				if err != nil {
+					return err
+				}
+
 				cancelReceived = true
 				continue OUTER
 			}

--- a/client/fs_endpoint_test.go
+++ b/client/fs_endpoint_test.go
@@ -1918,12 +1918,28 @@ func TestFS_logsImpl_Follow(t *testing.T) {
 	expected := []byte("012345")
 	initialWrites := 3
 
-	writeToFile := func(index int, data []byte) {
+	filePath := func(index int) string {
 		logFile := fmt.Sprintf("%s.%s.%d", task, logType, index)
-		logFilePath := filepath.Join(logDir, logFile)
+		return filepath.Join(logDir, logFile)
+	}
+	writeToFile := func(index int, data []byte) {
+		logFilePath := filePath(index)
 		err := ioutil.WriteFile(logFilePath, data, 0777)
 		if err != nil {
 			t.Fatalf("Failed to create file: %v", err)
+		}
+	}
+	appendToFile := func(index int, data []byte) {
+		logFilePath := filePath(index)
+		f, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_WRONLY, 0600)
+		if err != nil {
+			t.Fatalf("Failed to create file: %v", err)
+		}
+
+		defer f.Close()
+
+		if _, err = f.Write(data); err != nil {
+			t.Fatalf("Failed to write file: %v", err)
 		}
 	}
 	for i := 0; i < initialWrites; i++ {
@@ -1967,11 +1983,13 @@ func TestFS_logsImpl_Follow(t *testing.T) {
 		t.Fatalf("did not receive data: got %q", string(received))
 	}
 
-	// We got the first chunk of data, write out the rest to the next file
+	// We got the first chunk of data, write out the rest splitted
+	// between the last file and to the next file
 	// at an index much ahead to check that it is following and detecting
 	// skips
 	skipTo := initialWrites + 10
-	writeToFile(skipTo, expected[initialWrites:])
+	appendToFile(initialWrites-1, expected[initialWrites:initialWrites+1])
+	writeToFile(skipTo, expected[initialWrites+1:])
 
 	select {
 	case <-fullResultCh:

--- a/client/fs_endpoint_test.go
+++ b/client/fs_endpoint_test.go
@@ -1568,7 +1568,7 @@ func TestFS_streamFile_NoFile(t *testing.T) {
 	defer framer.Destroy()
 
 	err := c.endpoints.FileSystem.streamFile(
-		context.Background(), 0, "foo", 0, ad, framer, nil)
+		context.Background(), 0, "foo", 0, ad, framer, nil, nil)
 	require.Error(t, err)
 	if runtime.GOOS == "windows" {
 		require.Contains(t, err.Error(), "cannot find the file")
@@ -1629,7 +1629,7 @@ func TestFS_streamFile_Modify(t *testing.T) {
 	// Start streaming
 	go func() {
 		if err := c.endpoints.FileSystem.streamFile(
-			context.Background(), 0, streamFile, 0, ad, framer, nil); err != nil {
+			context.Background(), 0, streamFile, 0, ad, framer, nil, nil); err != nil {
 			t.Fatalf("stream() failed: %v", err)
 		}
 	}()
@@ -1704,7 +1704,7 @@ func TestFS_streamFile_Truncate(t *testing.T) {
 	// Start streaming
 	go func() {
 		if err := c.endpoints.FileSystem.streamFile(
-			context.Background(), 0, streamFile, 0, ad, framer, nil); err != nil {
+			context.Background(), 0, streamFile, 0, ad, framer, nil, nil); err != nil {
 			t.Fatalf("stream() failed: %v", err)
 		}
 	}()
@@ -1808,7 +1808,7 @@ func TestFS_streamImpl_Delete(t *testing.T) {
 	// Start streaming
 	go func() {
 		if err := c.endpoints.FileSystem.streamFile(
-			context.Background(), 0, streamFile, 0, ad, framer, nil); err != nil {
+			context.Background(), 0, streamFile, 0, ad, framer, nil, nil); err != nil {
 			t.Fatalf("stream() failed: %v", err)
 		}
 	}()

--- a/client/fs_endpoint_test.go
+++ b/client/fs_endpoint_test.go
@@ -1568,7 +1568,7 @@ func TestFS_streamFile_NoFile(t *testing.T) {
 	defer framer.Destroy()
 
 	err := c.endpoints.FileSystem.streamFile(
-		context.Background(), 0, "foo", 0, ad, framer, nil, nil)
+		context.Background(), 0, "foo", 0, ad, framer, nil, false)
 	require.Error(t, err)
 	if runtime.GOOS == "windows" {
 		require.Contains(t, err.Error(), "cannot find the file")
@@ -1629,7 +1629,7 @@ func TestFS_streamFile_Modify(t *testing.T) {
 	// Start streaming
 	go func() {
 		if err := c.endpoints.FileSystem.streamFile(
-			context.Background(), 0, streamFile, 0, ad, framer, nil, nil); err != nil {
+			context.Background(), 0, streamFile, 0, ad, framer, nil, false); err != nil {
 			t.Fatalf("stream() failed: %v", err)
 		}
 	}()
@@ -1704,7 +1704,7 @@ func TestFS_streamFile_Truncate(t *testing.T) {
 	// Start streaming
 	go func() {
 		if err := c.endpoints.FileSystem.streamFile(
-			context.Background(), 0, streamFile, 0, ad, framer, nil, nil); err != nil {
+			context.Background(), 0, streamFile, 0, ad, framer, nil, false); err != nil {
 			t.Fatalf("stream() failed: %v", err)
 		}
 	}()
@@ -1808,7 +1808,7 @@ func TestFS_streamImpl_Delete(t *testing.T) {
 	// Start streaming
 	go func() {
 		if err := c.endpoints.FileSystem.streamFile(
-			context.Background(), 0, streamFile, 0, ad, framer, nil, nil); err != nil {
+			context.Background(), 0, streamFile, 0, ad, framer, nil, false); err != nil {
 			t.Fatalf("stream() failed: %v", err)
 		}
 	}()


### PR DESCRIPTION
Hi,

this MR aims to address the issue reported here https://github.com/hashicorp/nomad/issues/11653 .  I described the problem in [this comment](https://github.com/hashicorp/nomad/issues/11653#issuecomment-996874918). 

This solution adds one more channel to the `streamFile` function that instead of cancelling on the event from channel when eof is reached, it performs one more read until eof which I think should be an expected behavior while streaming logs.

It is a draft for now opened for discussion. I confirmed that it works for the example posted in the issue. It should work since while newFileEvent is generated, the previous file is already full.

 I haven't checked tests yet.   