### PR TITLE
Fix: demo vagrantfile with rubocop style

### DIFF
--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -1,95 +1,97 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-$script = <<SCRIPT
-echo "Installing Docker..."
-sudo apt-get update
-sudo apt-get remove docker docker-engine docker.io
-echo '* libraries/restart-without-asking boolean true' | sudo debconf-set-selections
-sudo apt-get install apt-transport-https ca-certificates curl software-properties-common -y
-sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg |  sudo apt-key add -
-sudo apt-key fingerprint 0EBFCD88
-sudo add-apt-repository \
-      "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-      $(lsb_release -cs) \
-      stable"
-sudo apt-get update
-sudo apt-get install -y docker-ce
-# Restart docker to make sure we get the latest version of the daemon if there is an upgrade
-sudo service docker restart
-# Make sure we can actually use docker as the vagrant user
-sudo usermod -aG docker vagrant
-sudo docker --version
+script = <<SCRIPT
+  echo "Installing Docker..."
+  sudo apt-get update
+  sudo apt-get remove docker docker-engine docker.io
+  echo '* libraries/restart-without-asking boolean true' | sudo debconf-set-selections
+  sudo apt-get install apt-transport-https ca-certificates curl software-properties-common -y
+  sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg |  sudo apt-key add -
+  sudo apt-key fingerprint 0EBFCD88
+  sudo add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+        $(lsb_release -cs) \
+        stable"
+  sudo apt-get update
+  sudo apt-get install -y docker-ce
+  # Restart docker to make sure we get the latest version of the daemon if there is an upgrade
+  sudo service docker restart
+  # Make sure we can actually use docker as the vagrant user
+  sudo usermod -aG docker vagrant
+  sudo docker --version
 
-# Packages required for nomad & consul
-sudo apt-get install unzip curl vim -y
+  # Packages required for nomad & consul
+  sudo apt-get install unzip curl vim -y
 
-echo "Installing Nomad..."
-NOMAD_VERSION=1.0.1
-cd /tmp/
-curl -sSL https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip -o nomad.zip
-unzip nomad.zip
-sudo install nomad /usr/bin/nomad
-sudo mkdir -p /etc/nomad.d
-sudo chmod a+w /etc/nomad.d
+  echo "Installing Nomad..."
+  NOMAD_VERSION=1.0.1
+  cd /tmp/
+  curl -sSL https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip -o nomad.zip
+  unzip nomad.zip
+  sudo install nomad /usr/bin/nomad
+  sudo mkdir -p /etc/nomad.d
+  sudo chmod a+w /etc/nomad.d
 
 
-echo "Installing Consul..."
-CONSUL_VERSION=1.9.0
-curl -sSL https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip > consul.zip
-unzip /tmp/consul.zip
-sudo install consul /usr/bin/consul
-(
-cat <<-EOF
-  [Unit]
-  Description=consul agent
-  Requires=network-online.target
-  After=network-online.target
+  echo "Installing Consul..."
+  CONSUL_VERSION=1.9.0
+  curl -sSL https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip > consul.zip
+  unzip /tmp/consul.zip
+  sudo install consul /usr/bin/consul
+  (
+  cat <<-EOF
+    [Unit]
+    Description=consul agent
+    Requires=network-online.target
+    After=network-online.target
 
-  [Service]
-  Restart=on-failure
-  ExecStart=/usr/bin/consul agent -dev
-  ExecReload=/bin/kill -HUP $MAINPID
+    [Service]
+    Restart=on-failure
+    ExecStart=/usr/bin/consul agent -dev
+    ExecReload=/bin/kill -HUP $MAINPID
 
-  [Install]
-  WantedBy=multi-user.target
-EOF
-) | sudo tee /etc/systemd/system/consul.service
-sudo systemctl enable consul.service
-sudo systemctl start consul
+    [Install]
+    WantedBy=multi-user.target
+  EOF
+  ) | sudo tee /etc/systemd/system/consul.service
+  sudo systemctl enable consul.service
+  sudo systemctl start consul
 
-for bin in cfssl cfssl-certinfo cfssljson
-do
-  echo "Installing $bin..."
-  curl -sSL https://pkg.cfssl.org/R1.2/${bin}_linux-amd64 > /tmp/${bin}
-  sudo install /tmp/${bin} /usr/local/bin/${bin}
-done
-nomad -autocomplete-install
-
+  for bin in cfssl cfssl-certinfo cfssljson
+  do
+    echo "Installing $bin..."
+    curl -sSL https://pkg.cfssl.org/R1.2/${bin}_linux-amd64 > /tmp/${bin}
+    sudo install /tmp/${bin} /usr/local/bin/${bin}
+  done
+  nomad -autocomplete-install
 SCRIPT
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "bento/ubuntu-18.04" # 18.04 LTS
-  config.vm.hostname = "nomad"
-  config.vm.provision "shell", inline: $script, privileged: false
+  config.vm.box = 'bento/ubuntu-18.04' # 18.04 LTS
+  config.vm.hostname = 'nomad'
+  config.vm.provision 'shell', inline: script, privileged: false
 
   # Expose the nomad api and ui to the host
-  config.vm.network "forwarded_port", guest: 4646, host: 4646, auto_correct: true, host_ip: "127.0.0.1"
+  config.vm.network 'forwarded_port', guest: 4646, host: 4646, auto_correct: true, host_ip: '127.0.0.1'
 
   # Increase memory for Parallels Desktop
-  config.vm.provider "parallels" do |p, o|
-    p.memory = "1024"
+  config.vm.provider 'parallels' do |p, _o|
+    p.memory = '1024'
   end
 
   # Increase memory for Virtualbox
-  config.vm.provider "virtualbox" do |vb|
-        vb.memory = "1024"
+  config.vm.provider 'virtualbox' do |vb|
+    vb.memory = '1024'
   end
 
   # Increase memory for VMware
-  ["vmware_fusion", "vmware_workstation"].each do |p|
+  %w[
+    vmware_fusion
+    vmware_workstation
+  ].each do |p|
     config.vm.provider p do |v|
-      v.vmx["memsize"] = "1024"
+      v.vmx['memsize'] = '1024'
     end
   end
 end


### PR DESCRIPTION
- Change $script variable into script to avoid introduce new global variable.
- Substitute all double-quoted strings without interpolation with single-quoted strings
- Change name of unused argument on vm provider definition to indicate that won't be used
- Substitute Word array to multiline array using %w