### PR TITLE
api: support namespace wildcard in CSI volume list

### DIFF
--- a/.changelog/11724.txt
+++ b/.changelog/11724.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Updated the CSI volumes list API to respect wildcard namespaces
+```

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -129,6 +129,8 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 				iter, err = snap.CSIVolumesByNodeID(ws, prefix, args.NodeID)
 			} else if args.PluginID != "" {
 				iter, err = snap.CSIVolumesByPluginID(ws, ns, prefix, args.PluginID)
+			} else if ns == structs.AllNamespacesSentinel {
+				iter, err = snap.CSIVolumes(ws)
 			} else {
 				iter, err = snap.CSIVolumesByNamespace(ws, ns, prefix)
 			}
@@ -155,7 +157,7 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 
 				// Remove by Namespace, since CSIVolumesByNodeID hasn't used
 				// the Namespace yet
-				if vol.Namespace != ns {
+				if ns != structs.AllNamespacesSentinel && vol.Namespace != ns {
 					continue
 				}
 


### PR DESCRIPTION
The lack of wildcard listing impacted the UI due to #11357, where users would first see an empty list when the page loads since the CSI volume list didn't have support for wildcard querying.

Closes #11574