### PR TITLE
scheduler: cache resource comparisons for each alloc

### DIFF
--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -158,7 +158,11 @@ func AllocsFit(node *Node, allocs []*Allocation, netIdx *NetworkIndex, checkDevi
 			continue
 		}
 
-		cr := alloc.ComparableResources()
+		if alloc.comparableResources == nil {
+			alloc.comparableResources = alloc.ComparableResources()
+		}
+
+		cr := alloc.comparableResources
 		used.Add(cr)
 
 		// Adding the comparable resource unions reserved core sets, need to check if reserved cores overlap

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9341,6 +9341,12 @@ type Allocation struct {
 
 	// ModifyTime is the time the allocation was last updated.
 	ModifyTime int64
+
+	// comparableResources is a cache of calculated resources to
+	// reduce work done by the scheduler during node fit checking in
+	// AllocsFit. Note: this should never be updated to be visible
+	// outside this package, so that it's not serialized to disk.
+	comparableResources *ComparableResources
 }
 
 // ConsulNamespace returns the Consul namespace of the task group associated


### PR DESCRIPTION
During scheduling, a given allocation will potentially be compared for
fit against a large number of nodes, particularly if the job has
`spread` blocks or the cluster is large and few nodes meet the
feasibility. The scheduler recalculates the `ComparableResources`
struct on the allocation for each node compared against, but this data
doesn't change for this evaluation.

Cache this information to reduce allocations and CPU time. This patch
was benchmarked on a large cluster with a `spread` job and reduced
heap allocations by ~16MB (which only amounts to ~2% of CPU time, but
can't hurt).

This popped up while investigating #11712 and obviously is small potatoes, 
but a little extra efficiency without any tradeoff sounds good to me.