### PR TITLE
fix host network reserved port fingerprint

### DIFF
--- a/.changelog/11728.txt
+++ b/.changelog/11728.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed host network reserved port fingerprinting
+```

--- a/client/fingerprint/network.go
+++ b/client/fingerprint/network.go
@@ -178,6 +178,10 @@ func (f *NetworkFingerprint) createNodeNetworkResources(ifaces []net.Interface, 
 					Alias:   alias,
 				}
 
+				if hostNetwork, ok := conf.HostNetworks[alias]; ok {
+					newAddr.ReservedPorts = hostNetwork.ReservedPorts
+				}
+
 				if newAddr.Alias != "" {
 					if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
 						linkLocalAddrs = append(linkLocalAddrs, newAddr)


### PR DESCRIPTION
During the network fingerprint, client configuration values are mapped to actual network addresses and interfaces. During this process a `ClientHostNetworkConfig` is translated into `NodeNetworkResource`, but reserved ports were not being set.

Closes #9492