### PR TITLE
api: paginate deployment list and accept wildcard namespace

### DIFF
--- a/.changelog/11743.txt
+++ b/.changelog/11743.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+api: Updated the deployments list API to respect wildcard namespaces
+```
+
+```release-note:improvement
+api: Added pagination to deployments list API
+```

--- a/website/content/api-docs/deployments.mdx
+++ b/website/content/api-docs/deployments.mdx
@@ -31,6 +31,21 @@ The table below shows this endpoint's support for
   even number of hexadecimal characters (0-9a-f) .This is specified as a query
   string parameter.
 
+- `namespace` `(string: "default")` - Specifies the target
+  namespace. Specifying `*` will return all evaluations across all
+  authorized namespaces.
+
+- `next_token` `(string: "")` - This endpoint supports paging. The
+  `next_token` parameter accepts a string which is the `ID` field of
+  the next expected deployment. This value can be obtained from the
+  `X-Nomad-NextToken` header from the previous response.
+
+- `per_page` `(int: 0)` - Specifies a maximum number of deployments to
+  return for this request. If omitted, the response is not
+  paginated. The `ID` of the last deployment in the response can be
+  used as the `last_token` of the next request to fetch additional
+  pages.
+
 ### Sample Request
 
 ```shell-session


### PR DESCRIPTION
Add `per_page` and `next_token` handling to `Deployment.List` RPC, and
allow the use of a wildcard namespace for namespace filtering.

Note for reviewers: this brings the API up to parity with `Eval.List` but doesn't
include the CLI updates we'd need to use it. I want to hold off on that until we 
have #11742 figured out, because that'll impact the design.