### PR TITLE
Fix Node.Copy()

### DIFF
--- a/.changelog/11744.txt
+++ b/.changelog/11744.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix missing fields in Node.Copy()
+```

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -1531,9 +1531,7 @@ func TestClientEndpoint_GetNode(t *testing.T) {
 	node.StatusUpdatedAt = resp2.Node.StatusUpdatedAt
 	node.SecretID = ""
 	node.Events = resp2.Node.Events
-	if !reflect.DeepEqual(node, resp2.Node) {
-		t.Fatalf("bad: %#v \n %#v", node, resp2.Node)
-	}
+	require.Equal(t, node, resp2.Node)
 
 	// assert that the node register event was set correctly
 	if len(resp2.Node.Events) != 1 {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2657,6 +2657,7 @@ func (n *NetworkResource) Copy() *NetworkResource {
 	}
 	newR := new(NetworkResource)
 	*newR = *n
+	newR.DNS = n.DNS.Copy()
 	if n.ReservedPorts != nil {
 		newR.ReservedPorts = make([]Port, len(n.ReservedPorts))
 		copy(newR.ReservedPorts, n.ReservedPorts)
@@ -2874,8 +2875,7 @@ func (n *NodeResources) Copy() *NodeResources {
 
 	newN := new(NodeResources)
 	*newN = *n
-
-	// Copy the networks
+	newN.Cpu = n.Cpu.Copy()
 	newN.Networks = n.Networks.Copy()
 
 	// Copy the devices
@@ -3060,6 +3060,14 @@ type NodeCpuResources struct {
 	// This value is currently only reported on Linux platforms which support cgroups and is
 	// discovered by inspecting the cpuset of the agent's cgroup.
 	ReservableCpuCores []uint16
+}
+
+func (n NodeCpuResources) Copy() NodeCpuResources {
+	newN := n
+	newN.ReservableCpuCores = make([]uint16, len(n.ReservableCpuCores))
+	copy(newN.ReservableCpuCores, n.ReservableCpuCores)
+
+	return newN
 }
 
 func (n *NodeCpuResources) Merge(o *NodeCpuResources) {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2025,20 +2025,20 @@ func (n *Node) Copy() *Node {
 	nn := new(Node)
 	*nn = *n
 	nn.Attributes = helper.CopyMapStringString(nn.Attributes)
-	nn.Resources = nn.Resources.Copy()
-	nn.Reserved = nn.Reserved.Copy()
 	nn.NodeResources = nn.NodeResources.Copy()
 	nn.ReservedResources = nn.ReservedResources.Copy()
+	nn.Resources = nn.Resources.Copy()
+	nn.Reserved = nn.Reserved.Copy()
 	nn.Links = helper.CopyMapStringString(nn.Links)
 	nn.Meta = helper.CopyMapStringString(nn.Meta)
-	nn.Events = copyNodeEvents(n.Events)
 	nn.DrainStrategy = nn.DrainStrategy.Copy()
-	nn.LastDrain = nn.LastDrain.Copy()
+	nn.Events = copyNodeEvents(n.Events)
+	nn.Drivers = copyNodeDrivers(n.Drivers)
 	nn.CSIControllerPlugins = copyNodeCSI(nn.CSIControllerPlugins)
 	nn.CSINodePlugins = copyNodeCSI(nn.CSINodePlugins)
-	nn.Drivers = copyNodeDrivers(n.Drivers)
 	nn.HostVolumes = copyNodeHostVolumes(n.HostVolumes)
 	nn.HostNetworks = copyNodeHostNetworks(n.HostNetworks)
+	nn.LastDrain = nn.LastDrain.Copy()
 	return nn
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3064,8 +3064,10 @@ type NodeCpuResources struct {
 
 func (n NodeCpuResources) Copy() NodeCpuResources {
 	newN := n
-	newN.ReservableCpuCores = make([]uint16, len(n.ReservableCpuCores))
-	copy(newN.ReservableCpuCores, n.ReservableCpuCores)
+	if n.ReservableCpuCores != nil {
+		newN.ReservableCpuCores = make([]uint16, len(n.ReservableCpuCores))
+		copy(newN.ReservableCpuCores, n.ReservableCpuCores)
+	}
 
 	return newN
 }


### PR DESCRIPTION
Node.Copy() had a couple minor bugs. I believe both fields incorrectly copied (DNS and CPU) are only ever overwritten, so I don't think this fixes any existing buggy behavior.

fd1c71dc8d40dfa2b974f3d83f79fad9069efda5 also reorders fields in Node.Copy to match their order on the struct. Makes checking easier.