### PR TITLE
add enterprise downloads page

### DIFF
--- a/website/components/downloads-props/index.jsx
+++ b/website/components/downloads-props/index.jsx
@@ -1,0 +1,38 @@
+import s from '../../pages/downloads/style.module.css'
+
+export default function DownloadsProps(preMerchandisingSlot) {
+  return {
+    getStartedDescription:
+      'Follow step-by-step tutorials on the essentials of Nomad.',
+    getStartedLinks: [
+      {
+        label: 'Getting Started',
+        href: 'https://learn.hashicorp.com/collections/nomad/get-started',
+      },
+      {
+        label: 'Deploy and Manage Nomad Jobs',
+        href: 'https://learn.hashicorp.com/collections/nomad/manage-jobs',
+      },
+      {
+        label: 'Explore the Nomad Web UI',
+        href: 'https://learn.hashicorp.com/collections/nomad/web-ui',
+      },
+      {
+        label: 'View all Nomad tutorials',
+        href: 'https://learn.hashicorp.com/nomad',
+      },
+    ],
+    logo: (
+      <img
+        className={s.logo}
+        alt="Nomad"
+        src={require('@hashicorp/mktg-logos/product/nomad/primary/color.svg')}
+      />
+    ),
+    tutorialLink: {
+      href: 'https://learn.hashicorp.com/nomad',
+      label: 'View Tutorials at HashiCorp Learn',
+    },
+    merchandisingSlot: preMerchandisingSlot && preMerchandisingSlot,
+  }
+}

--- a/website/pages/downloads/enterprise.jsx
+++ b/website/pages/downloads/enterprise.jsx
@@ -1,0 +1,38 @@
+import VERSION from 'data/version'
+import { productSlug } from 'data/metadata'
+import ProductDownloadsPage from '@hashicorp/react-product-downloads-page'
+import { generateStaticProps } from '@hashicorp/react-product-downloads-page/server'
+import baseProps from 'components/downloads-props'
+import s from './style.module.css'
+
+export default function DownloadsPage(staticProps) {
+  return (
+    <>
+      <ProductDownloadsPage
+        enterpriseMode={true}
+        {...baseProps(
+          <p className={s.legalNotice}>
+            <em>
+              The following shall apply unless your organization has a
+              separately signed Enterprise License Agreement or Evaluation
+              Agreement governing your use of the package: Enterprise packages
+              in this repository are subject to the license terms located in the
+              package. Please read the license terms prior to using the package.
+              Your installation and use of the package constitutes your
+              acceptance of these terms. If you do not accept the terms, do not
+              use the package.
+            </em>
+          </p>
+        )}
+        {...staticProps}
+      />
+    </>
+  )
+}
+
+export async function getStaticProps() {
+  return generateStaticProps({
+    product: productSlug,
+    latestVersion: VERSION,
+  })
+}

--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -2,44 +2,10 @@ import VERSION from 'data/version'
 import { productSlug } from 'data/metadata'
 import ProductDownloadsPage from '@hashicorp/react-product-downloads-page'
 import { generateStaticProps } from '@hashicorp/react-product-downloads-page/server'
-import s from './style.module.css'
+import baseProps from 'components/downloads-props'
 
 export default function DownloadsPage(staticProps) {
-  return (
-    <ProductDownloadsPage
-      getStartedDescription="Follow step-by-step tutorials on the essentials of Nomad."
-      getStartedLinks={[
-        {
-          label: 'Getting Started',
-          href: 'https://learn.hashicorp.com/collections/nomad/get-started',
-        },
-        {
-          label: 'Deploy and Manage Nomad Jobs',
-          href: 'https://learn.hashicorp.com/collections/nomad/manage-jobs',
-        },
-        {
-          label: 'Explore the Nomad Web UI',
-          href: 'https://learn.hashicorp.com/collections/nomad/web-ui',
-        },
-        {
-          label: 'View all Nomad tutorials',
-          href: 'https://learn.hashicorp.com/nomad',
-        },
-      ]}
-      logo={
-        <img
-          className={s.logo}
-          alt="Nomad"
-          src={require('@hashicorp/mktg-logos/product/nomad/primary/color.svg')}
-        />
-      }
-      tutorialLink={{
-        href: 'https://learn.hashicorp.com/nomad',
-        label: 'View Tutorials at HashiCorp Learn',
-      }}
-      {...staticProps}
-    />
-  )
+  return <ProductDownloadsPage {...baseProps()} {...staticProps} />
 }
 
 export async function getStaticProps() {


### PR DESCRIPTION
A nicer interface to see enterprise binaries, approved by release engineering and legal. A license key is required to actually run any given enterprise binary.

[🔎 Preview](https://nomad-27azxzas8-hashicorp.vercel.app/downloads/enterprise)