### PR TITLE
docs/tests for multiple HTTP address config

### DIFF
--- a/.changelog/11582.txt
+++ b/.changelog/11582.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent/config: Allow binding the HTTP server to multiple addresses.
+```

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -1373,9 +1373,15 @@ func TestParseMultipleIPTemplates(t *testing.T) {
 		expectErr   bool
 	}{
 		{
-			name:        "deduplicates same ip",
-			tmpl:        "127.0.0.1 127.0.0.1",
-			expectedOut: []string{"127.0.0.1"},
+			name:        "deduplicates same ip and preserves order",
+			tmpl:        "127.0.0.1 10.0.0.1 127.0.0.1",
+			expectedOut: []string{"127.0.0.1", "10.0.0.1"},
+			expectErr:   false,
+		},
+		{
+			name:        "includes sockaddr expression",
+			tmpl:        "10.0.0.1 {{ GetAllInterfaces | include \"flags\" \"loopback\" | limit 1 | attr \"address\" }} 10.0.0.2",
+			expectedOut: []string{"10.0.0.1", "127.0.0.1", "10.0.0.2"},
 			expectErr:   false,
 		},
 	}

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -67,7 +67,7 @@ type TestAgent struct {
 	Key string
 
 	// All HTTP servers started. Used to prevent server leaks and preserve
-	// backwards compability.
+	// backwards compatibility.
 	Servers []*HTTPServer
 
 	// Server is a reference to the primary, started HTTP endpoint.

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -88,8 +88,9 @@ testing.
   see the [`ports`](#ports) field. The values support [go-sockaddr/template
   format][go-sockaddr/template].
 
-  - `http` - The address the HTTP server is bound to. This is the most common
-    bind address to change.
+  - `http` - The address the HTTP server is bound to. This is the most
+    common bind address to change. The `http` field accepts multiple
+    values, separated by spaces, to bind to multiple addresses.
 
   - `rpc` - The address to bind the internal RPC interfaces to. Should be
     exposed only to other cluster members if possible.


### PR DESCRIPTION
Some minor follow-ups to https://github.com/hashicorp/nomad/pull/11582:
* changelog entry
* expanded the tests a bit
* added the docs for the config value


