### PR TITLE
Replace 'a alloc' with 'an alloc' where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1385,7 +1385,7 @@ FEATURES:
  * core: Add `nomad alloc stop` command to reschedule allocs [[GH-5512](https://github.com/hashicorp/nomad/pull/5512)]
  * core: Add `nomad alloc signal` command to signal allocs and tasks [[GH-5515](https://github.com/hashicorp/nomad/pull/5515)]
  * core: Add `nomad alloc restart` command to restart allocs and tasks [[GH-5502](https://github.com/hashicorp/nomad/pull/5502)]
- * code: Add `nomad alloc exec` command for debugging and running commands in a alloc [[GH-5632](https://github.com/hashicorp/nomad/pull/5632)]
+ * code: Add `nomad alloc exec` command for debugging and running commands in an alloc [[GH-5632](https://github.com/hashicorp/nomad/pull/5632)]
  * core/enterprise: Preemption capabilities for batch and service jobs
  * ui: Preemption reporting everywhere where allocations are shown and as part of the plan step of job submit [[GH-5594](https://github.com/hashicorp/nomad/issues/5594)]
  * ui: Ability to search clients list by class, status, datacenter, or eligibility flags [[GH-5318](https://github.com/hashicorp/nomad/issues/5318)]

--- a/client/allocdir/input/test.go
+++ b/client/allocdir/input/test.go
@@ -9,7 +9,7 @@ type Client interface {
 	AllocStateHandler
 }
 
-// AllocStateHandler exposes a handler to be called when a allocation's state changes
+// AllocStateHandler exposes a handler to be called when an allocation's state changes
 type AllocStateHandler interface {
 	// AllocStateUpdated is used to emit an updated allocation. This allocation
 	// is stripped to only include client settable fields.

--- a/client/client.go
+++ b/client/client.go
@@ -1122,7 +1122,7 @@ func (c *Client) restoreState() error {
 		// now.  If allocs should be run, they will be started when the client
 		// gets allocs from servers.
 		if !c.hasLocalState(alloc) {
-			c.logger.Warn("found a alloc without any local state, skipping restore", "alloc_id", alloc.ID)
+			c.logger.Warn("found an alloc without any local state, skipping restore", "alloc_id", alloc.ID)
 			continue
 		}
 

--- a/client/interfaces/client.go
+++ b/client/interfaces/client.go
@@ -9,7 +9,7 @@ type Client interface {
 	AllocStateHandler
 }
 
-// AllocStateHandler exposes a handler to be called when a allocation's state changes
+// AllocStateHandler exposes a handler to be called when an allocation's state changes
 type AllocStateHandler interface {
 	// AllocStateUpdated is used to emit an updated allocation. This allocation
 	// is stripped to only include client settable fields.

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -6788,7 +6788,7 @@ func TestJobEndpoint_Dispatch_JobChildrenSummary(t *testing.T) {
 		return job.Status
 	}
 
-	// Let's start a alloc for the dispatch job and walk through states
+	// Let's start an alloc for the dispatch job and walk through states
 	// Note that job summary reports 1 running even when alloc is pending!
 	nextIdx++
 	alloc := mock.Alloc()

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4735,7 +4735,7 @@ type TaskGroupSummary struct {
 
 const (
 	// Checks uses any registered health check state in combination with task
-	// states to determine if a allocation is healthy.
+	// states to determine if an allocation is healthy.
 	UpdateStrategyHealthCheck_Checks = "checks"
 
 	// TaskStates uses the task states of an allocation to determine if the


### PR DESCRIPTION
Signed-off-by: Conor Evans <coevans@tcd.ie>

If this is deemed inappropriate, feel free to close it. I spotted one of these when making a different contribution and figured I'd fix it, then figured it might be spread throughout the comments etc.