### PR TITLE
Draft: Add CPU in MHz to stats and emit nomad.client.allocs.cpu.total_mhz metric

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -34,6 +34,7 @@ type MemoryStats struct {
 type CpuStats struct {
 	SystemMode       float64
 	UserMode         float64
+	TotalMHz         float64
 	TotalTicks       float64
 	ThrottledPeriods uint64
 	ThrottledTime    uint64

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -1432,6 +1432,8 @@ func (tr *TaskRunner) setGaugeForCPU(ru *cstructs.TaskResourceUsage) {
 		float32(ru.ResourceUsage.CpuStats.ThrottledTime), tr.baseLabels)
 	metrics.SetGaugeWithLabels([]string{"client", "allocs", "cpu", "throttled_periods"},
 		float32(ru.ResourceUsage.CpuStats.ThrottledPeriods), tr.baseLabels)
+	metrics.SetGaugeWithLabels([]string{"client", "allocs", "cpu", "total_mhz"},
+		float32(ru.ResourceUsage.CpuStats.TotalMHz), tr.baseLabels)
 	metrics.SetGaugeWithLabels([]string{"client", "allocs", "cpu", "total_ticks"},
 		float32(ru.ResourceUsage.CpuStats.TotalTicks), tr.baseLabels)
 	if allocatedCPU > 0 {

--- a/client/stats/cpu.go
+++ b/client/stats/cpu.go
@@ -45,10 +45,16 @@ func (c *CpuStats) Percent(cpuTime float64) float64 {
 	return ret
 }
 
-// TicksConsumed calculates the total ticks consumes by the process across all
-// cpu cores
+// TicksConsumed calculates the total ticks consumed by the process across all
+// CPU cores
 func (c *CpuStats) TicksConsumed(percent float64) float64 {
 	return (percent / 100) * shelpers.TotalTicksAvailable() / float64(c.totalCpus)
+}
+
+// MHzConsumed calculates the total MHz consumed by the process across all CPU
+// cores
+func (c *CpuStats) MHzConsumed(percent float64) float64 {
+	return (percent / 100) * shelpers.CPUMHzTotal() / float64(c.totalCpus)
 }
 
 func (c *CpuStats) calculatePercent(t1, t2 float64, timeDelta int64) float64 {

--- a/client/structs/structs.go
+++ b/client/structs/structs.go
@@ -235,6 +235,7 @@ type CpuStats struct {
 	SystemMode       float64
 	UserMode         float64
 	TotalTicks       float64
+	TotalMHz         float64
 	ThrottledPeriods uint64
 	ThrottledTime    uint64
 	Percent          float64
@@ -250,6 +251,7 @@ func (cs *CpuStats) Add(other *CpuStats) {
 
 	cs.SystemMode += other.SystemMode
 	cs.UserMode += other.UserMode
+	cs.TotalMHz += other.TotalMHz
 	cs.TotalTicks += other.TotalTicks
 	cs.ThrottledPeriods += other.ThrottledPeriods
 	cs.ThrottledTime += other.ThrottledTime

--- a/drivers/docker/util/stats_posix.go
+++ b/drivers/docker/util/stats_posix.go
@@ -53,6 +53,7 @@ func DockerStatsToTaskResourceUsage(s *docker.Stats) *cstructs.TaskResourceUsage
 	cs.UserMode = CalculateCPUPercent(
 		s.CPUStats.CPUUsage.UsageInUsermode, s.PreCPUStats.CPUUsage.UsageInUsermode,
 		s.CPUStats.CPUUsage.TotalUsage, s.PreCPUStats.CPUUsage.TotalUsage, runtime.NumCPU())
+	cs.TotalMHz = (cs.Percent / 100) * stats.CPUMHzTotal() / float64(runtime.NumCPU())
 	cs.TotalTicks = (cs.Percent / 100) * stats.TotalTicksAvailable() / float64(runtime.NumCPU())
 
 	return &cstructs.TaskResourceUsage{

--- a/drivers/docker/util/stats_windows.go
+++ b/drivers/docker/util/stats_windows.go
@@ -42,6 +42,7 @@ func DockerStatsToTaskResourceUsage(s *docker.Stats) *cstructs.TaskResourceUsage
 		ThrottledPeriods: s.CPUStats.ThrottlingData.ThrottledPeriods,
 		ThrottledTime:    s.CPUStats.ThrottlingData.ThrottledTime,
 		Percent:          cpuPercent,
+		TotalMHz:         (cpuPercent / 100) * stats.CPUMHzTotal() / float64(runtime.NumCPU()),
 		TotalTicks:       (cpuPercent / 100) * stats.TotalTicksAvailable() / float64(runtime.NumCPU()),
 		Measured:         DockerMeasuredCPUStats,
 	}

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -406,6 +406,7 @@ func (l *LibcontainerExecutor) handleStats(ch chan *cstructs.TaskResourceUsage, 
 			Percent:          totalPercent,
 			ThrottledPeriods: stats.CpuStats.ThrottlingData.ThrottledPeriods,
 			ThrottledTime:    stats.CpuStats.ThrottlingData.ThrottledTime,
+			TotalMHz:         l.systemCpuStats.MHzConsumed(totalPercent),
 			TotalTicks:       l.systemCpuStats.TicksConsumed(totalPercent),
 			Measured:         ExecutorCgroupMeasuredCpuStats,
 		}

--- a/helper/stats/cpu.go
+++ b/helper/stats/cpu.go
@@ -70,6 +70,12 @@ func CPUMHzPerCore() float64 {
 	return cpuMhzPerCore
 }
 
+// CPUMHzTotal returns the total MHz across the number
+// of available cores
+func CPUMHzTotal() float64 {
+	return float64(cpuNumCores) * cpuMhzPerCore
+}
+
 // CPUModelName returns the model name of the CPU
 func CPUModelName() string {
 	return cpuModelName

--- a/plugins/drivers/utils.go
+++ b/plugins/drivers/utils.go
@@ -458,6 +458,7 @@ func resourceUsageToProto(ru *ResourceUsage) *proto.TaskResourceUsage {
 		MeasuredFields:   cpuUsageMeasuredFieldsToProto(ru.CpuStats.Measured),
 		SystemMode:       ru.CpuStats.SystemMode,
 		UserMode:         ru.CpuStats.UserMode,
+		TotalMHz:         ru.CpuStats.TotalMHz,
 		TotalTicks:       ru.CpuStats.TotalTicks,
 		ThrottledPeriods: ru.CpuStats.ThrottledPeriods,
 		ThrottledTime:    ru.CpuStats.ThrottledTime,

--- a/plugins/drivers/utils_test.go
+++ b/plugins/drivers/utils_test.go
@@ -15,6 +15,7 @@ func TestResourceUsageRoundTrip(t *testing.T) {
 		CpuStats: &CpuStats{
 			SystemMode:       0,
 			UserMode:         0.9963907032120152,
+			TotalMHz:         4096.71,
 			TotalTicks:       21.920595295932515,
 			ThrottledPeriods: 2321,
 			ThrottledTime:    123,


### PR DESCRIPTION
Signed-off-by: Conor Evans <coevans@tcd.ie>

Resolves #11142

This is a draft PR as I would like to get feedback if I've gone awry. I wasn't sure how the driver.pb.go file gets updated (I see a reference in the makefile but wasn't sure if that gets run as part of PR). I couldn't see any instructions as to regenerating it locally.