### PR TITLE
docs: note that clients need to have ACLs enabled

### DIFF
--- a/website/content/docs/configuration/acl.mdx
+++ b/website/content/docs/configuration/acl.mdx
@@ -25,7 +25,10 @@ acl {
 ## `acl` Parameters
 
 - `enabled` `(bool: false)` - Specifies if ACL enforcement is enabled. All other
-  ACL configuration options depend on this value.
+  ACL configuration options depend on this value. Note that the Nomad command
+  line client will send requests for client endpoints such as `alloc exec`
+  directly to Nomad clients whenever they are accessible. In this scenario, the
+  client will enforce ACLs, so both servers and clients should have ACLs enabled.
 
 - `token_ttl` `(string: "30s")` - Specifies the maximum time-to-live (TTL) for
   cached ACL tokens. This does not affect servers, since they do not cache tokens.


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11676

Client endpoints such as `alloc exec` are enforced on the client if
the API client or CLI has "line of sight" to the client. This is
already in the Learn guide but having it in the ACL configuration docs
would be helpful.