### PR TITLE
Intial implementation for #11807

### DIFF
--- a/.changelog/11807.txt
+++ b/.changelog/11807.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+namespaces: Allow enabling/disabling allowed drivers per namespace.
+```

--- a/api/namespace.go
+++ b/api/namespace.go
@@ -70,8 +70,15 @@ type Namespace struct {
 	Name        string
 	Description string
 	Quota       string
-	CreateIndex uint64
-	ModifyIndex uint64
+	// TODO: how to encode properly?
+	Capabilities *NamespaceCapabilities
+	CreateIndex  uint64
+	ModifyIndex  uint64
+}
+
+// TODO: is this duplication between struct & api expected/wanted?
+type NamespaceCapabilities struct {
+	EnabledTaskDrivers []string
 }
 
 // NamespaceIndexSort is a wrapper to sort Namespaces by CreateIndex. We

--- a/api/namespace.go
+++ b/api/namespace.go
@@ -67,18 +67,17 @@ func (n *Namespaces) Delete(namespace string, q *WriteOptions) (*WriteMeta, erro
 
 // Namespace is used to serialize a namespace.
 type Namespace struct {
-	Name        string
-	Description string
-	Quota       string
-	// TODO: how to encode properly?
-	Capabilities *NamespaceCapabilities
+	Name         string
+	Description  string
+	Quota        string
+	Capabilities *NamespaceCapabilities `hcl:"capabilities,block"`
 	CreateIndex  uint64
 	ModifyIndex  uint64
 }
 
-// TODO: is this duplication between struct & api expected/wanted?
 type NamespaceCapabilities struct {
-	EnabledTaskDrivers []string
+	EnabledTaskDrivers  []string `hcl:"enabled_task_drivers"`
+	DisabledTaskDrivers []string `hcl:"disabled_task_drivers"`
 }
 
 // NamespaceIndexSort is a wrapper to sort Namespaces by CreateIndex. We

--- a/command/namespace_list.go
+++ b/command/namespace_list.go
@@ -114,11 +114,16 @@ func formatNamespaces(namespaces []*api.Namespace) string {
 	sort.Slice(namespaces, func(i, j int) bool { return namespaces[i].Name < namespaces[j].Name })
 
 	rows := make([]string, len(namespaces)+1)
-	rows[0] = "Name|Description"
+	rows[0] = "Name|Description|Drivers"
 	for i, ns := range namespaces {
-		rows[i+1] = fmt.Sprintf("%s|%s",
+		drivers := "*"
+		if ns.Capabilities != nil && len(ns.Capabilities.EnabledTaskDrivers) != 0 {
+			drivers = strings.Join(ns.Capabilities.EnabledTaskDrivers, ",")
+		}
+		rows[i+1] = fmt.Sprintf("%s|%s|%s",
 			ns.Name,
-			ns.Description)
+			ns.Description,
+			drivers)
 	}
 	return formatList(rows)
 }

--- a/command/namespace_list.go
+++ b/command/namespace_list.go
@@ -114,23 +114,11 @@ func formatNamespaces(namespaces []*api.Namespace) string {
 	sort.Slice(namespaces, func(i, j int) bool { return namespaces[i].Name < namespaces[j].Name })
 
 	rows := make([]string, len(namespaces)+1)
-	rows[0] = "Name|Description|EnabledDrivers|DisabledDrivers"
+	rows[0] = "Name|Description"
 	for i, ns := range namespaces {
-		enabled_drivers := "*"
-		disabled_drivers := ""
-		if ns.Capabilities != nil {
-			if len(ns.Capabilities.EnabledTaskDrivers) != 0 {
-				enabled_drivers = strings.Join(ns.Capabilities.EnabledTaskDrivers, ",")
-			}
-			if len(ns.Capabilities.DisabledTaskDrivers) != 0 {
-				disabled_drivers = strings.Join(ns.Capabilities.DisabledTaskDrivers, ",")
-			}
-		}
-		rows[i+1] = fmt.Sprintf("%s|%s|%s|%s",
+		rows[i+1] = fmt.Sprintf("%s|%s",
 			ns.Name,
-			ns.Description,
-			enabled_drivers,
-			disabled_drivers)
+			ns.Description)
 	}
 	return formatList(rows)
 }

--- a/command/namespace_list.go
+++ b/command/namespace_list.go
@@ -114,16 +114,23 @@ func formatNamespaces(namespaces []*api.Namespace) string {
 	sort.Slice(namespaces, func(i, j int) bool { return namespaces[i].Name < namespaces[j].Name })
 
 	rows := make([]string, len(namespaces)+1)
-	rows[0] = "Name|Description|Drivers"
+	rows[0] = "Name|Description|EnabledDrivers|DisabledDrivers"
 	for i, ns := range namespaces {
-		drivers := "*"
-		if ns.Capabilities != nil && len(ns.Capabilities.EnabledTaskDrivers) != 0 {
-			drivers = strings.Join(ns.Capabilities.EnabledTaskDrivers, ",")
+		enabled_drivers := "*"
+		disabled_drivers := ""
+		if ns.Capabilities != nil {
+			if len(ns.Capabilities.EnabledTaskDrivers) != 0 {
+				enabled_drivers = strings.Join(ns.Capabilities.EnabledTaskDrivers, ",")
+			}
+			if len(ns.Capabilities.DisabledTaskDrivers) != 0 {
+				disabled_drivers = strings.Join(ns.Capabilities.DisabledTaskDrivers, ",")
+			}
 		}
-		rows[i+1] = fmt.Sprintf("%s|%s|%s",
+		rows[i+1] = fmt.Sprintf("%s|%s|%s|%s",
 			ns.Name,
 			ns.Description,
-			drivers)
+			enabled_drivers,
+			disabled_drivers)
 	}
 	return formatList(rows)
 }

--- a/command/namespace_status.go
+++ b/command/namespace_status.go
@@ -111,15 +111,22 @@ func (c *NamespaceStatusCommand) Run(args []string) int {
 
 // formatNamespaceBasics formats the basic information of the namespace
 func formatNamespaceBasics(ns *api.Namespace) string {
-	drivers := "*"
-	if ns.Capabilities != nil && len(ns.Capabilities.EnabledTaskDrivers) != 0 {
-		drivers = strings.Join(ns.Capabilities.EnabledTaskDrivers, ",")
+	enabled_drivers := "*"
+	disabled_drivers := ""
+	if ns.Capabilities != nil {
+		if len(ns.Capabilities.EnabledTaskDrivers) != 0 {
+			enabled_drivers = strings.Join(ns.Capabilities.EnabledTaskDrivers, ",")
+		}
+		if len(ns.Capabilities.DisabledTaskDrivers) != 0 {
+			disabled_drivers = strings.Join(ns.Capabilities.DisabledTaskDrivers, ",")
+		}
 	}
 	basic := []string{
 		fmt.Sprintf("Name|%s", ns.Name),
 		fmt.Sprintf("Description|%s", ns.Description),
 		fmt.Sprintf("Quota|%s", ns.Quota),
-		fmt.Sprintf("Drivers|%s", drivers),
+		fmt.Sprintf("EnabledDrivers|%s", enabled_drivers),
+		fmt.Sprintf("DisabledDrivers|%s", disabled_drivers),
 	}
 
 	return formatKV(basic)

--- a/command/namespace_status.go
+++ b/command/namespace_status.go
@@ -111,10 +111,15 @@ func (c *NamespaceStatusCommand) Run(args []string) int {
 
 // formatNamespaceBasics formats the basic information of the namespace
 func formatNamespaceBasics(ns *api.Namespace) string {
+	drivers := "*"
+	if ns.Capabilities != nil && len(ns.Capabilities.EnabledTaskDrivers) != 0 {
+		drivers = strings.Join(ns.Capabilities.EnabledTaskDrivers, ",")
+	}
 	basic := []string{
 		fmt.Sprintf("Name|%s", ns.Name),
 		fmt.Sprintf("Description|%s", ns.Description),
 		fmt.Sprintf("Quota|%s", ns.Quota),
+		fmt.Sprintf("Drivers|%s", drivers),
 	}
 
 	return formatKV(basic)

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -70,6 +70,7 @@ func NewJobEndpoints(s *Server) *Job {
 		validators: []jobValidator{
 			jobConnectHook{},
 			jobExposeCheckHook{},
+			jobNamespaceConstraintCheckHook{srv: s},
 			jobValidate{},
 			&memoryOversubscriptionValidate{srv: s},
 		},

--- a/nomad/job_endpoint_validators.go
+++ b/nomad/job_endpoint_validators.go
@@ -1,0 +1,49 @@
+package nomad
+
+import (
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/pkg/errors"
+)
+
+type jobNamespaceConstraintCheckHook struct {
+	srv *Server
+}
+
+func (jobNamespaceConstraintCheckHook) Name() string {
+	return "namespace-constraint-check"
+}
+
+func (c jobNamespaceConstraintCheckHook) Validate(job *structs.Job) (warnings []error, err error) {
+	// This was validated before and matches the WriteRequest namespace
+	ns, err := c.srv.State().NamespaceByName(nil, job.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	// TODO: Should this not get checked by another validator before?
+	if ns == nil {
+		return nil, errors.Errorf("requested namespace %s does not exist", job.Namespace)
+	}
+
+	for _, tg := range job.TaskGroups {
+		for _, t := range tg.Tasks {
+			if !taskValidateDriver(t, ns) {
+				return nil, errors.Errorf(
+					"used task driver '%s' in %s[%s] is not allowed in namespace %s",
+					t.Driver, tg.Name, t.Name, ns.Name)
+			}
+		}
+	}
+	return nil, nil
+}
+
+func taskValidateDriver(task *structs.Task, ns *structs.Namespace) bool {
+	if ns.Capabilities == nil || len(ns.Capabilities.EnabledTaskDrivers) == 0 {
+		return true
+	}
+	for _, d := range ns.Capabilities.EnabledTaskDrivers {
+		if task.Driver == d {
+			return true
+		}
+	}
+	return false
+}

--- a/nomad/job_endpoint_validators.go
+++ b/nomad/job_endpoint_validators.go
@@ -1,8 +1,6 @@
 package nomad
 
 import (
-	"strings"
-
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/pkg/errors"
 )
@@ -36,14 +34,11 @@ func (c jobNamespaceConstraintCheckHook) Validate(job *structs.Job) (warnings []
 	if len(disallowedDrivers) > 0 {
 		if len(disallowedDrivers) == 1 {
 			return nil, errors.Errorf(
-				"used task driver '%s' is not allowed in namespace %s", disallowedDrivers[0], ns.Name)
+				"used task driver %q is not allowed in namespace %q", disallowedDrivers[0], ns.Name)
 
 		} else {
-			for i := 0; i < len(disallowedDrivers); i++ {
-				disallowedDrivers[i] = "'" + disallowedDrivers[i] + "'"
-			}
 			return nil, errors.Errorf(
-				"used task drivers %s are not allowed in namespace %s", strings.Join(disallowedDrivers, ", "), ns.Name)
+				"used task drivers %q are not allowed in namespace %q", disallowedDrivers, ns.Name)
 		}
 	}
 	return nil, nil

--- a/nomad/job_endpoint_validators_test.go
+++ b/nomad/job_endpoint_validators_test.go
@@ -1,0 +1,15 @@
+package nomad
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJobNamespaceConstraintCheckHook_Name(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "namespace-constraint-check", new(jobNamespaceConstraintCheckHook).Name())
+}
+
+// TODO: More tests

--- a/nomad/job_endpoint_validators_test.go
+++ b/nomad/job_endpoint_validators_test.go
@@ -47,7 +47,7 @@ func TestJobNamespaceConstraintCheckHook_taskValidateDriver(t *testing.T) {
 			false,
 		},
 		{
-			"disable takes precedence over enable", // TODO: Wanted?
+			"disable takes precedence over enable",
 			"docker",
 			&structs.Namespace{
 				Capabilities: &structs.NamespaceCapabilities{

--- a/nomad/job_endpoint_validators_test.go
+++ b/nomad/job_endpoint_validators_test.go
@@ -3,6 +3,7 @@ package nomad
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,4 +13,71 @@ func TestJobNamespaceConstraintCheckHook_Name(t *testing.T) {
 	require.Equal(t, "namespace-constraint-check", new(jobNamespaceConstraintCheckHook).Name())
 }
 
-// TODO: More tests
+func TestJobNamespaceConstraintCheckHook_taskValidateDriver(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		driver      string
+		ns          *structs.Namespace
+		result      bool
+	}{
+		{
+			"No drivers enabled/disabled, allow all",
+			"docker",
+			&structs.Namespace{},
+			true,
+		},
+		{
+			"Only exec and docker are allowed 1/2",
+			"docker",
+			&structs.Namespace{
+				Capabilities: &structs.NamespaceCapabilities{
+					EnabledTaskDrivers: []string{"docker", "exec"}},
+			},
+			true,
+		},
+		{
+			"Only exec and docker are allowed 2/2",
+			"raw_exec",
+			&structs.Namespace{
+				Capabilities: &structs.NamespaceCapabilities{
+					EnabledTaskDrivers: []string{"docker", "exec"}},
+			},
+			false,
+		},
+		{
+			"disable takes precedence over enable", // TODO: Wanted?
+			"docker",
+			&structs.Namespace{
+				Capabilities: &structs.NamespaceCapabilities{
+					EnabledTaskDrivers:  []string{"docker"},
+					DisabledTaskDrivers: []string{"docker"}},
+			},
+			false,
+		},
+		{
+			"All drivers but docker are allowed 1/2",
+			"docker",
+			&structs.Namespace{
+				Capabilities: &structs.NamespaceCapabilities{
+					DisabledTaskDrivers: []string{"docker"}},
+			},
+			false,
+		},
+		{
+			"All drivers but docker are allowed 2/2",
+			"raw_exec",
+			&structs.Namespace{
+				Capabilities: &structs.NamespaceCapabilities{
+					DisabledTaskDrivers: []string{"docker"}},
+			},
+			true,
+		},
+	}
+
+	for _, c := range cases {
+		var task = &structs.Task{Driver: c.driver}
+		require.Equal(t, c.result, taskValidateDriver(task, c.ns), c.description)
+	}
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5016,8 +5016,8 @@ func (n *Namespace) Copy() *Namespace {
 	if n.Capabilities != nil {
 		c := new(NamespaceCapabilities)
 		*c = *n.Capabilities
-		copy(c.EnabledTaskDrivers, n.Capabilities.EnabledTaskDrivers)
-		copy(c.DisabledTaskDrivers, n.Capabilities.DisabledTaskDrivers)
+		c.EnabledTaskDrivers = helper.CopySliceString(n.Capabilities.EnabledTaskDrivers)
+		c.DisabledTaskDrivers = helper.CopySliceString(n.Capabilities.DisabledTaskDrivers)
 		nc.Capabilities = c
 	}
 	copy(nc.Hash, n.Hash)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5015,8 +5015,10 @@ func (n *Namespace) Copy() *Namespace {
 	nc.Hash = make([]byte, len(n.Hash))
 	if n.Capabilities != nil {
 		c := new(NamespaceCapabilities)
-		*c = *nc.Capabilities
-		*nc.Capabilities = *c
+		*c = *n.Capabilities
+		copy(c.EnabledTaskDrivers, n.Capabilities.EnabledTaskDrivers)
+		copy(c.DisabledTaskDrivers, n.Capabilities.DisabledTaskDrivers)
+		nc.Capabilities = c
 	}
 	copy(nc.Hash, n.Hash)
 	return nc

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4960,7 +4960,8 @@ type Namespace struct {
 // NamespaceCapabilities represents a set of capabilities allowed for this
 // namespace, to be checked at job submission time.
 type NamespaceCapabilities struct {
-	EnabledTaskDrivers []string
+	EnabledTaskDrivers  []string
+	DisabledTaskDrivers []string
 }
 
 func (n *Namespace) Validate() error {
@@ -4991,6 +4992,14 @@ func (n *Namespace) SetHash() []byte {
 	_, _ = hash.Write([]byte(n.Name))
 	_, _ = hash.Write([]byte(n.Description))
 	_, _ = hash.Write([]byte(n.Quota))
+	if n.Capabilities != nil {
+		for _, driver := range n.Capabilities.EnabledTaskDrivers {
+			_, _ = hash.Write([]byte(driver))
+		}
+		for _, driver := range n.Capabilities.DisabledTaskDrivers {
+			_, _ = hash.Write([]byte(driver))
+		}
+	}
 
 	// Finalize the hash
 	hashVal := hash.Sum(nil)
@@ -5004,6 +5013,11 @@ func (n *Namespace) Copy() *Namespace {
 	nc := new(Namespace)
 	*nc = *n
 	nc.Hash = make([]byte, len(n.Hash))
+	if n.Capabilities != nil {
+		c := new(NamespaceCapabilities)
+		*c = *nc.Capabilities
+		*nc.Capabilities = *c
+	}
 	copy(nc.Hash, n.Hash)
 	return nc
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4945,6 +4945,9 @@ type Namespace struct {
 	// against.
 	Quota string
 
+	// Capabilities is the set of capabilities allowed for this namespace
+	Capabilities *NamespaceCapabilities
+
 	// Hash is the hash of the namespace which is used to efficiently replicate
 	// cross-regions.
 	Hash []byte
@@ -4952,6 +4955,12 @@ type Namespace struct {
 	// Raft Indexes
 	CreateIndex uint64
 	ModifyIndex uint64
+}
+
+// NamespaceCapabilities represents a set of capabilities allowed for this
+// namespace, to be checked at job submission time.
+type NamespaceCapabilities struct {
+	EnabledTaskDrivers []string
 }
 
 func (n *Namespace) Validate() error {

--- a/website/content/docs/commands/namespace/apply.mdx
+++ b/website/content/docs/commands/namespace/apply.mdx
@@ -64,5 +64,5 @@ capabilities {
   enabled_task_drivers  = ["docker", "exec"]
   disabled_task_drivers = ["raw_exec"]
 }
-$ nomad naspace apply namespace.json
+$ nomad namespace apply namespace.json
 ```

--- a/website/content/docs/commands/namespace/apply.mdx
+++ b/website/content/docs/commands/namespace/apply.mdx
@@ -15,11 +15,15 @@ when introduced in Nomad 0.7.
 ## Usage
 
 ```plaintext
-nomad namespace apply [options] <namespace>
+nomad namespace apply [options] <input>
 ```
 
-The `namespace apply` command requires the name of the namespace to be created
-or updated.
+Apply is used to create or update a namespace. The specification file
+will be read from stdin by specifying "-", otherwise a path to the file is
+expected.
+
+Instead of a file, you may instead pass the namespace name to create
+or update as the only argument.
 
 If ACLs are enabled, this command requires a management ACL token.
 
@@ -32,6 +36,8 @@ If ACLs are enabled, this command requires a management ACL token.
 - `-quota` : An optional quota to apply to the namespace.
 
 - `-description` : An optional human readable description for the namespace.
+
+- `json` : Parse the input as a JSON namespace specification.
 
 ## Examples
 
@@ -46,4 +52,17 @@ Remove a quota from a namespace:
 
 ```shell-session
 $ nomad namespace apply -quota= api-prod
+```
+
+Create a namespace from a file:
+```shell-session
+$ cat namespace.json
+name        = "dev"
+description = "Namespace for developers"
+
+capabilities {
+  enabled_task_drivers  = ["docker", "exec"]
+  disabled_task_drivers = ["raw_exec"]
+}
+$ nomad naspace apply namespace.json
 ```

--- a/website/content/docs/commands/namespace/status.mdx
+++ b/website/content/docs/commands/namespace/status.mdx
@@ -33,9 +33,11 @@ View the status of a namespace:
 
 ```shell-session
 $ nomad namespace status default
-Name        = default
-Description = Default shared namespace
-Quota       = shared-default-quota
+Name            = default
+Description     = Default shared namespace
+Quota           = shared-default-quota
+EnabledDrivers  = docker,exec
+DisabledDrivers = raw_exec
 
 Quota Limits
 Region  CPU Usage   Memory Usage


### PR DESCRIPTION
Looks good so far:
```
➜  nomad git:(main) ✗ ./bin/nomad namespace list                                         
Name     Description               Drivers
default  Default shared namespace  *
test     <none>                    docker,test
➜  nomad git:(main) ✗ ./bin/nomad job plan test.nomad                                    
Error during plan: Unexpected response code: 500 (1 error occurred:
	* used task driver 'lala' in cache[redis] is not allowed in namespace test
```

@tgross Do you mind giving it an initial quick review -- if I am on the right track I will continue with it.

Refs #11807