### PR TITLE
fix integer bounds checks

### DIFF
--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -772,7 +772,7 @@ func parsePagination(req *http.Request, b *structs.QueryOptions) {
 	query := req.URL.Query()
 	rawPerPage := query.Get("per_page")
 	if rawPerPage != "" {
-		perPage, err := strconv.Atoi(rawPerPage)
+		perPage, err := strconv.ParseInt(rawPerPage, 10, 32)
 		if err == nil {
 			b.PerPage = int32(perPage)
 		}

--- a/drivers/shared/executor/executor_universal_linux.go
+++ b/drivers/shared/executor/executor_universal_linux.go
@@ -33,9 +33,9 @@ func setCmdUser(cmd *exec.Cmd, userid string) error {
 
 	gids := make([]uint32, len(gidStrings))
 	for _, gidString := range gidStrings {
-		u, err := strconv.Atoi(gidString)
+		u, err := strconv.ParseUint(gidString, 10, 32)
 		if err != nil {
-			return fmt.Errorf("Unable to convert user's group to int %s: %v", gidString, err)
+			return fmt.Errorf("Unable to convert user's group to uint32 %s: %v", gidString, err)
 		}
 
 		gids = append(gids, uint32(u))

--- a/helper/flags/autopilot_flags.go
+++ b/helper/flags/autopilot_flags.go
@@ -5,6 +5,7 @@ package flags
 
 import (
 	"fmt"
+	"math/bits"
 	"strconv"
 	"time"
 )
@@ -88,7 +89,8 @@ func (u *UintValue) Set(v string) error {
 	if u.v == nil {
 		u.v = new(uint)
 	}
-	parsed, err := strconv.ParseUint(v, 0, 64)
+
+	parsed, err := strconv.ParseUint(v, 0, bits.UintSize)
 	*(u.v) = (uint)(parsed)
 	return err
 }

--- a/lib/cpuset/cpuset.go
+++ b/lib/cpuset/cpuset.go
@@ -2,6 +2,7 @@ package cpuset
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"sort"
 	"strconv"
@@ -153,6 +154,9 @@ func Parse(s string) (CPUSet, error) {
 				return New(), err
 			}
 
+			if v > math.MaxUint16 {
+				return New(), fmt.Errorf("failed to parse element %s, more than max allowed cores", set)
+			}
 			cpuset.cpus[uint16(v)] = struct{}{}
 			continue
 		}
@@ -168,7 +172,11 @@ func Parse(s string) (CPUSet, error) {
 		if err != nil {
 			return New(), err
 		}
+
 		for v := lower; v <= upper; v++ {
+			if v > math.MaxUint16 {
+				return New(), fmt.Errorf("failed to parse element %s, more than max allowed cores", set)
+			}
 			cpuset.cpus[uint16(v)] = struct{}{}
 		}
 	}

--- a/plugins/drivers/server.go
+++ b/plugins/drivers/server.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"fmt"
 	"io"
+	"math"
 
 	"github.com/golang/protobuf/ptypes"
 	plugin "github.com/hashicorp/go-plugin"
@@ -125,6 +126,9 @@ func (b *driverPluginServer) StartTask(ctx context.Context, req *proto.StartTask
 			AutoAdvertise: net.AutoAdvertise,
 		}
 		for k, v := range net.PortMap {
+			if v > math.MaxInt32 {
+				return nil, fmt.Errorf("port map out of bounds")
+			}
 			pbNet.PortMap[k] = int32(v)
 		}
 	}


### PR DESCRIPTION
This series of commits fixes some integer bounds checking bugs that in practice don't result in user-visible issues but were triggering security and code quality scanners. Fixing these reduces automated scanner noise.

(Partially covers https://github.com/hashicorp/nomad/issues/11777)