### PR TITLE
docs: improve changelog for PR #11783

### DIFF
--- a/.changelog/11783.txt
+++ b/.changelog/11783.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-template: Fixed a bug where templates did not receive updated vault token if `change_mode = "noop"` was set
+template: Fixed a bug where templates did not receive an updated vault token if `change_mode = "noop"` was set in the job definition's `vault` stanza.
 ```


### PR DESCRIPTION
As pointed out in https://github.com/hashicorp/nomad/commit/ef93ab2d560179ccd401d8e26b3033ae1879a76e#r63487464, the changelog I wrote for #11783 was ambiguous between the `vault` and `template` `change_mode` field. Correct that for clarity.