### PR TITLE
docs: fix autoscaling Datadog site configuration

### DIFF
--- a/website/content/tools/autoscaling/plugins/apm/datadog.mdx
+++ b/website/content/tools/autoscaling/plugins/apm/datadog.mdx
@@ -19,7 +19,7 @@ apm "datadog" {
     dd_api_key = "<api key>"
     dd_app_key = "<app key>"
 
-    site = "app.datadoghq.eu"
+    site = "datadoghq.eu"
   }
 }
 ```
@@ -30,7 +30,7 @@ apm "datadog" {
 - `dd_app_key` `(string: <required>)` - The Datadog application key to use for
   authentication.
 
-- `site` `(string: "")` - The [Datadog site][datadog_sites] to connect to.
+- `site` `(string: "datadoghq.com")` - The Datadog site to connect to.
 
 The Datadog plugin can also read its configuration options via environment
 variables. The accepted keys are `DD_API_KEY` and `DD_APP_KEY`. The agent
@@ -47,5 +47,4 @@ check {
 ```
 
 [datadog_homepage]: https://www.datadoghq.com/
-[datadog_sites]: https://docs.datadoghq.com/getting_started/site/
 [datadog_timeseries]: https://docs.datadoghq.com/api/v1/metrics/#query-timeseries-points


### PR DESCRIPTION
As pointed out in https://github.com/hashicorp/nomad-autoscaler/issues/558, the `site` configuration for the Datadog Autoscaler plugin should not include a subdomain (and even if it did, it was the example had the wrong one).

The site linked for the list of possible values is also misleading and I couldn't find anything better, so I removed it for now.