### PR TITLE
agent: validate reserved_ports are valid

### DIFF
--- a/.changelog/11830.txt
+++ b/.changelog/11830.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Validate reserved_ports are valid to prevent unschedulable nodes.
+```

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -386,6 +386,27 @@ func (c *Command) isValidConfig(config, cmdConfig *Config) bool {
 		return false
 	}
 
+	if config.Client.Reserved == nil {
+		// Coding error; should always be set by DefaultConfig()
+		c.Ui.Error("client.reserved must be initialized. Please report a bug.")
+		return false
+	}
+
+	if ports := config.Client.Reserved.ReservedPorts; ports != "" {
+		if _, err := structs.ParsePortRanges(ports); err != nil {
+			c.Ui.Error(fmt.Sprintf("reserved.reserved_ports %q invalid: %v", ports, err))
+			return false
+		}
+	}
+
+	for _, hn := range config.Client.HostNetworks {
+		if _, err := structs.ParsePortRanges(hn.ReservedPorts); err != nil {
+			c.Ui.Error(fmt.Sprintf("host_network[%q].reserved_ports %q invalid: %v",
+				hn.Name, hn.ReservedPorts, err))
+			return false
+		}
+	}
+
 	if !config.DevMode {
 		// Ensure that we have the directories we need to run.
 		if config.Server.Enabled && config.DataDir == "" {

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/version"
 )
 
@@ -362,6 +363,33 @@ func TestIsValidConfig(t *testing.T) {
 					MaxDynamicPort: 5000,
 				},
 			},
+		},
+		{
+			name: "BadReservedPorts",
+			conf: Config{
+				Client: &ClientConfig{
+					Enabled: true,
+					Reserved: &Resources{
+						ReservedPorts: "3-2147483647",
+					},
+				},
+			},
+			err: `reserved.reserved_ports "3-2147483647" invalid: port must be < 65536 but found 2147483647`,
+		},
+		{
+			name: "BadHostNetworkReservedPorts",
+			conf: Config{
+				Client: &ClientConfig{
+					Enabled: true,
+					HostNetworks: []*structs.ClientHostNetworkConfig{
+						&structs.ClientHostNetworkConfig{
+							Name:          "test",
+							ReservedPorts: "3-2147483647",
+						},
+					},
+				},
+			},
+			err: `host_network["test"].reserved_ports "3-2147483647" invalid: port must be < 65536 but found 2147483647`,
 		},
 	}
 

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -531,6 +531,12 @@ func ParsePortRanges(spec string) ([]uint64, error) {
 				return nil, fmt.Errorf("invalid range: starting value (%v) less than ending (%v) value", end, start)
 			}
 
+			// Full range validation is below but prevent creating
+			// arbitrarily large arrays here
+			if end > MaxValidPort {
+				return nil, fmt.Errorf("port must be < %d but found %d", MaxValidPort, end)
+			}
+
 			for i := start; i <= end; i++ {
 				ports[i] = struct{}{}
 			}
@@ -541,6 +547,12 @@ func ParsePortRanges(spec string) ([]uint64, error) {
 
 	var results []uint64
 	for port := range ports {
+		if port == 0 {
+			return nil, fmt.Errorf("port must be > 0")
+		}
+		if port > MaxValidPort {
+			return nil, fmt.Errorf("port must be < %d but found %d", MaxValidPort, port)
+		}
 		results = append(results, port)
 	}
 


### PR DESCRIPTION
Minimal alternative to #11819. I think the more drastic changes in the other PR should wait until 1.3.

Goal is to fix at least one of the causes that can cause a node to be
ineligible to receive work:
https://github.com/hashicorp/nomad/issues/9506#issuecomment-1002880600