### PR TITLE
Update monitoring-nomad.mdx

### DIFF
--- a/website/content/docs/operations/monitoring-nomad.mdx
+++ b/website/content/docs/operations/monitoring-nomad.mdx
@@ -215,8 +215,7 @@ when the CPU is at or above the reserved resources for the task.
 
 ## Job and Task Status
 
-We do not currently surface metrics for job and task/allocation status, although
-we will consider adding metrics where it makes sense.
+The metrics listed [here][job-summary-metrics] can be used to track a summary of the job status.
 
 ## Runtime Metrics
 


### PR DESCRIPTION
It seems like this is present now - but this shows it's not possible in this document.

I tested and I indeed see job status reported from the nomad server metrics exporter.