### PR TITLE
chore: ensure consistent file naming for non-enterprise files.

### DIFF
--- a/nomad/fsm_oss.go
+++ b/nomad/fsm_oss.go
@@ -5,6 +5,6 @@ package nomad
 
 // allocQuota returns the quota object associated with the allocation. In
 // anything but Premium this will always be empty
-func (n *nomadFSM) allocQuota(allocID string) (string, error) {
+func (n *nomadFSM) allocQuota(_ string) (string, error) {
 	return "", nil
 }

--- a/nomad/plan_apply_oss.go
+++ b/nomad/plan_apply_oss.go
@@ -23,6 +23,6 @@ func refreshIndex(snap *state.StateSnapshot) (uint64, error) {
 }
 
 // evaluatePlanQuota returns whether the plan would be over quota
-func evaluatePlanQuota(snap *state.StateSnapshot, plan *structs.Plan) (bool, error) {
+func evaluatePlanQuota(_ *state.StateSnapshot, _ *structs.Plan) (bool, error) {
 	return false, nil
 }

--- a/scheduler/stack_not_ent.go
+++ b/scheduler/stack_not_ent.go
@@ -1,8 +1,0 @@
-//go:build !ent
-// +build !ent
-
-package scheduler
-
-func NewQuotaIterator(ctx Context, source FeasibleIterator) FeasibleIterator {
-	return source
-}

--- a/scheduler/stack_oss.go
+++ b/scheduler/stack_oss.go
@@ -1,0 +1,8 @@
+//go:build !ent
+// +build !ent
+
+package scheduler
+
+func NewQuotaIterator(_ Context, source FeasibleIterator) FeasibleIterator {
+	return source
+}


### PR DESCRIPTION
Files mostly use the `_oss.go` pattern apart from these ones, which
confused me for a moment when I first came across one. I also fixed-up
the unused function param style where needed.