### PR TITLE
csi: volume deregistration should require exact ID

### DIFF
--- a/.changelog/11852.txt
+++ b/.changelog/11852.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where deregistering volumes would attempt to deregister the wrong volume if the ID was a prefix of the intended volume
+```

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2375,7 +2375,7 @@ func (s *StateStore) CSIVolumeDeregister(index uint64, namespace string, ids []s
 	defer txn.Abort()
 
 	for _, id := range ids {
-		existing, err := txn.First("csi_volumes", "id_prefix", namespace, id)
+		existing, err := txn.First("csi_volumes", "id", namespace, id)
 		if err != nil {
 			return fmt.Errorf("volume lookup failed: %s: %v", id, err)
 		}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -2995,16 +2995,21 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	// registration is an error when the volume is in use
 	index++
 	err = state.CSIVolumeRegister(index, []*structs.CSIVolume{v0})
-	require.Error(t, err, fmt.Sprintf("volume exists: %s", vol0))
+	require.Error(t, err, "volume re-registered while in use")
 	// as is deregistration
 	index++
 	err = state.CSIVolumeDeregister(index, ns, []string{vol0}, false)
-	require.Error(t, err, fmt.Sprintf("volume in use: %s", vol0))
+	require.Error(t, err, "volume deregistered while in use")
 
 	// even if forced, because we have a non-terminal claim
 	index++
 	err = state.CSIVolumeDeregister(index, ns, []string{vol0}, true)
-	require.Error(t, err, fmt.Sprintf("volume in use: %s", vol0))
+	require.Error(t, err, "volume force deregistered while in use")
+
+	// we use the ID, not a prefix
+	index++
+	err = state.CSIVolumeDeregister(index, ns, []string{"fo"}, true)
+	require.Error(t, err, "volume deregistered by prefix")
 
 	// release claims to unblock deregister
 	index++


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11846


The command line client sends a specific volume ID, but this isn't
enforced at the API level and we were incorrectly using a prefix match
for volume deregistration, resulting in cases where a volume with a
shorter ID that's a prefix of another volume would be deregistered
instead of the intended volume.