### PR TITLE
csi: when warning for multiple prefix matches, use full ID

### DIFF
--- a/.changelog/11853.txt
+++ b/.changelog/11853.txt
@@ -1,0 +1,3 @@
+```bug
+csi: Fixed a bug in `volume deregister` and `volume detach` commands where volume IDs were truncated when asking the user to select one of several prefix matches
+```

--- a/command/volume_deregister.go
+++ b/command/volume_deregister.go
@@ -101,7 +101,7 @@ func (c *VolumeDeregisterCommand) Run(args []string) int {
 	}
 	if len(vols) > 1 {
 		sort.Slice(vols, func(i, j int) bool { return vols[i].ID < vols[j].ID })
-		out, err := csiFormatSortedVolumes(vols, shortId)
+		out, err := csiFormatSortedVolumes(vols, fullId)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error formatting: %s", err))
 			return 1

--- a/command/volume_detach.go
+++ b/command/volume_detach.go
@@ -123,7 +123,7 @@ func (c *VolumeDetachCommand) Run(args []string) int {
 		}
 		if len(vols) > 1 {
 			sort.Slice(vols, func(i, j int) bool { return vols[i].ID < vols[j].ID })
-			out, err := csiFormatSortedVolumes(vols, shortId)
+			out, err := csiFormatSortedVolumes(vols, fullId)
 			if err != nil {
 				c.Ui.Error(fmt.Sprintf("Error formatting: %s", err))
 				return 1


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11847

When the `volume deregister` or `volume detach` commands get an ID
prefix that matches multiple volumes, show the full length of the
volume IDs in the list of volumes shown so so that the user can select
the correct one.

---

Before:

```
$ nomad volume deregister test-
Prefix matched multiple volumes

ID        Name            Plugin ID         Schedulable  Access Mode
test-vol  test-volume[0]  hostpath-plugin0  true         single-node-reader-only
test-vol  test-volume[1]  hostpath-plugin0  true         single-node-reader-only
```

After

```
$ nomad volume deregister test-
Prefix matched multiple volumes

ID              Name            Plugin ID         Schedulable  Access Mode
test-volume[0]  test-volume[0]  hostpath-plugin0  true         single-node-reader-only
test-volume[1]  test-volume[1]  hostpath-plugin0  true         single-node-reader-only
```