### PR TITLE
freebsd: build fix for ARM7 32-bit

### DIFF
--- a/.changelog/11854.txt
+++ b/.changelog/11854.txt
@@ -1,0 +1,3 @@
+```bug
+freebsd: Fixed a build failure on FreeBSD ARM7 32-bit systems
+```

--- a/command/agent/log_file_bsd.go
+++ b/command/agent/log_file_bsd.go
@@ -12,5 +12,6 @@ import (
 func (l *logFile) createTime(stat os.FileInfo) time.Time {
 	stat_t := stat.Sys().(*syscall.Stat_t)
 	createTime := stat_t.Ctimespec
-	return time.Unix(createTime.Sec, createTime.Nsec)
+	// Sec and Nsec are int32 in 32-bit architectures.
+	return time.Unix(int64(createTime.Sec), int64(createTime.Nsec)) //nolint:unconvert
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11850 (pending feedback by @clausecker)

The size of `stat_t` fields is architecture dependent, which was
reportedly causing a build failure on FreeBSD ARM7 32-bit
systems. This changeset matches the behavior we have on Linux.