### PR TITLE
drivers: set world-readable permissions on copied resolv.conf

### DIFF
--- a/.changelog/11856.txt
+++ b/.changelog/11856.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+drivers: Fixed a bug where the `resolv.conf` copied from the system was not readable to unprivileged processes within the task
+```

--- a/drivers/shared/resolvconf/mount.go
+++ b/drivers/shared/resolvconf/mount.go
@@ -69,15 +69,10 @@ func copySystemDNS(dest string) error {
 	}
 	defer in.Close()
 
-	out, err := os.Create(dest)
+	content, err := io.ReadAll(in)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		out.Sync()
-		out.Close()
-	}()
 
-	_, err = io.Copy(out, in)
-	return err
+	return os.WriteFile(dest, content, 0644)
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11845

When we copy the system DNS to a task's `resolv.conf`, we should set
the permissions as world-readable so that unprivileged users within
the task can read it.