### PR TITLE
docs: add HashiBox to the list of community tools

### DIFF
--- a/website/content/tools/index.mdx
+++ b/website/content/tools/index.mdx
@@ -26,6 +26,7 @@ The following external tools are currently available for Nomad and maintained by
 - [Chaotic](https://github.com/ngine-io/chaotic) - A Chaos Engineering tool to stop allocations, reboot or stop/start virtual machines in your cloud environment
 - [Deadman Check](https://github.com/sepulworld/deadman-check) - A monitoring companion for Nomad periodic jobs that alerts if periodic isn't running at the expected interval
 - [Hashi Up](https://github.com/jsiebens/hashi-up) - A utility to install Nomad on remote Linux hosts
+- [HashiBox](https://github.com/nunchistudio/hashibox) - Vagrant environment to simulate a highly-available cloud with Consul, Vault, and Nomad.
 - [Jenkins Nomad Cloud Plugin](https://github.com/jenkinsci/nomad-plugin) - A Jenkins plugin using Nomad to provision build workers
 - [Kreconciler](https://github.com/koyeb/kreconciler) - A library to build control-loops for things on Nomad (or other schedulers)
 - [Nelson](https://getnelson.io/) - A tool for automated, multi-region container deployment using Nomad


### PR DESCRIPTION
HashiBox
https://github.com/nunchistudio/hashibox 

Vagrant environment to simulate a highly-available cloud with Consul, Vault, and Nomad.