### PR TITLE
cli: Add event stream capture to nomad operator debug

### DIFF
--- a/.changelog/11865.txt
+++ b/.changelog/11865.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Add event stream capture to `nomad operator debug`
+```

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1480,7 +1480,7 @@ func parseEventTopics(topicList []string) (map[api.Topic][]string, error) {
 	for _, topic := range topicList {
 		k, v, err := parseTopic(topic)
 		if err != nil {
-			mErrs = multierror.Append(mErrs, fmt.Errorf("error parsing topics: %w", err))
+			mErrs = multierror.Append(mErrs, err)
 		}
 
 		topics[api.Topic(k)] = append(topics[api.Topic(k)], v)
@@ -1495,7 +1495,7 @@ func parseTopic(topic string) (string, string, error) {
 	if len(parts) == 1 {
 		return topic, "*", nil
 	} else if len(parts) != 2 {
-		return "", "", fmt.Errorf("Invalid key value pair for topic, topic: %s", topic)
+		return "", "", fmt.Errorf("Invalid key value pair for topic: %s", topic)
 	}
 	return parts[0], parts[1], nil
 }

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -77,7 +77,7 @@ Usage: nomad operator debug [options]
   'list-jobs' capability for all namespaces. To collect pprof profiles the
   token will also require 'agent:write', or enable_debug configuration set to
   true.
-  
+
   If event stream capture is enabled, the Job, Allocation, Deployment,
   and Evaluation topics require 'namespace:read-job' capabilities, the Node
   topic requires 'node:read'.  A 'management' token is required to capture
@@ -153,7 +153,7 @@ Debug Options:
     Specifies the index to start streaming events from. If the requested index is
     no longer in the buffer the stream will start at the next available index.
     Defaults to 0.
-  
+
   -event-topic=<Allocation,Evaluation,Job,Node,*>:<filter>
     Enable event stream capture, filtered by comma delimited list of topic filters.
     Examples:
@@ -212,8 +212,8 @@ func (c *OperatorDebugCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
 			"-duration":       complete.PredictAnything,
-			"-event-topic":    complete.PredictAnything,
 			"-event-index":    complete.PredictAnything,
+			"-event-topic":    complete.PredictAnything,
 			"-interval":       complete.PredictAnything,
 			"-log-level":      complete.PredictSet("TRACE", "DEBUG", "INFO", "WARN", "ERROR"),
 			"-max-nodes":      complete.PredictAnything,

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -418,7 +418,7 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 
 	// Validate and set initial event stream index
 	if eventIndex < 0 {
-		c.Ui.Error(fmt.Sprintf("Event stream index must be greater than zero"))
+		c.Ui.Error("Event stream index must be greater than zero")
 		return 1
 	}
 	c.index = uint64(eventIndex)

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -184,12 +184,16 @@ Debug Options:
     Path to the parent directory of the output directory. If specified, no 
     archive is built. Defaults to the current directory.
 
-  -event-topic=<allocation,evaluation,job,node,*>:<filter>
-    Enable event stream capture. Filter by comma delimited list of topic filters
-    or "all".  Defaults to "none" (disabled).
+  -event-topic=<Allocation,Evaluation,Job,Node,*>:<filter>
+    Enable event stream capture, filtered by comma delimited list of topic filters.
+    Examples:
+      "all" or "*:*" for all events
+      "Evaluation" or "Evaluation:*" for all evaluation events
+      "*:example" for all events related to the job "example"
+    Defaults to "none" (disabled).
 
   -verbose
-    Enable verbose output
+    Enable verbose output.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1489,15 +1489,23 @@ func parseEventTopics(topicList []string) (map[api.Topic][]string, error) {
 	return topics, mErrs.ErrorOrNil()
 }
 
-func parseTopic(topic string) (string, string, error) {
-	parts := strings.Split(topic, ":")
-	// infer wildcard if only given a topic
-	if len(parts) == 1 {
-		return topic, "*", nil
-	} else if len(parts) != 2 {
+func parseTopic(input string) (string, string, error) {
+	var topic, filter string
+
+	parts := strings.Split(input, ":")
+	switch len(parts) {
+	case 1:
+		// infer wildcard if only given a topic
+		topic = input
+		filter = "*"
+	case 2:
+		topic = parts[0]
+		filter = parts[1]
+	default:
 		return "", "", fmt.Errorf("Invalid key value pair for topic: %s", topic)
 	}
-	return parts[0], parts[1], nil
+
+	return strings.Title(topic), filter, nil
 }
 
 func allTopics() map[api.Topic][]string {

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1461,16 +1461,18 @@ func stringToSlice(input string) []string {
 func parseEventTopics(topicList []string) (map[api.Topic][]string, error) {
 	topics := make(map[api.Topic][]string)
 
+	var mErrs *multierror.Error
+
 	for _, topic := range topicList {
 		k, v, err := parseTopic(topic)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing topics: %w", err)
+			mErrs = multierror.Append(mErrs, fmt.Errorf("error parsing topics: %w", err))
 		}
 
 		topics[api.Topic(k)] = append(topics[api.Topic(k)], v)
 	}
 
-	return topics, nil
+	return topics, mErrs.ErrorOrNil()
 }
 
 func parseTopic(topic string) (string, string, error) {

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -248,7 +248,7 @@ func NodePredictor(factory ApiClientFactory) complete.Predictor {
 }
 
 // NodeClassPredictor returns a client node class predictor
-// TODO: Consider API options for node class filtering
+// TODO dmay: Consider API options for node class filtering
 func NodeClassPredictor(factory ApiClientFactory) complete.Predictor {
 	return complete.PredictFunc(func(a complete.Args) []string {
 		client, err := factory()
@@ -284,7 +284,7 @@ func NodeClassPredictor(factory ApiClientFactory) complete.Predictor {
 }
 
 // ServerPredictor returns a server member predictor
-// TODO: Consider API options for server member filtering
+// TODO dmay: Consider API options for server member filtering
 func ServerPredictor(factory ApiClientFactory) complete.Predictor {
 	return complete.PredictFunc(func(a complete.Args) []string {
 		client, err := factory()

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -73,6 +74,8 @@ func newClientAgentConfigFunc(region string, nodeClass string, srvRPCAddr string
 }
 
 func TestDebug_NodeClass(t *testing.T) {
+	t.Parallel()
+
 	// Start test server and API client
 	srv, _, url := testServer(t, false, nil)
 
@@ -121,6 +124,8 @@ func TestDebug_NodeClass(t *testing.T) {
 }
 
 func TestDebug_ClientToServer(t *testing.T) {
+	t.Parallel()
+
 	// Start test server and API client
 	srv, _, url := testServer(t, false, nil)
 
@@ -264,6 +269,8 @@ func TestDebug_MultiRegion(t *testing.T) {
 }
 
 func TestDebug_SingleServer(t *testing.T) {
+	t.Parallel()
+
 	srv, _, url := testServer(t, false, nil)
 	testutil.WaitForLeader(t, srv.Agent.RPC)
 
@@ -296,6 +303,8 @@ func TestDebug_SingleServer(t *testing.T) {
 }
 
 func TestDebug_Failures(t *testing.T) {
+	t.Parallel()
+
 	srv, _, url := testServer(t, false, nil)
 	testutil.WaitForLeader(t, srv.Agent.RPC)
 
@@ -331,6 +340,11 @@ func TestDebug_Failures(t *testing.T) {
 			expectedCode: 1,
 		},
 		{
+			name:         "Fails bad pprof duration",
+			args:         []string{"-pprof-duration", "baz"},
+			expectedCode: 1,
+		},
+		{
 			name:          "Fails bad address",
 			args:          []string{"-address", url + "bogus"},
 			expectedCode:  1,
@@ -342,6 +356,8 @@ func TestDebug_Failures(t *testing.T) {
 }
 
 func TestDebug_Bad_CSIPlugin_Names(t *testing.T) {
+	t.Parallel()
+
 	// Start test server and API client
 	srv, _, url := testServer(t, false, nil)
 
@@ -391,6 +407,7 @@ func buildPathSlice(path string, files []string) []string {
 }
 
 func TestDebug_CapturedFiles(t *testing.T) {
+	// t.Parallel()
 	srv, _, url := testServer(t, true, nil)
 	testutil.WaitForLeader(t, srv.Agent.RPC)
 
@@ -500,6 +517,8 @@ func TestDebug_CapturedFiles(t *testing.T) {
 }
 
 func TestDebug_ExistingOutput(t *testing.T) {
+	t.Parallel()
+
 	ui := cli.NewMockUi()
 	cmd := &OperatorDebugCommand{Meta: Meta{Ui: ui}}
 
@@ -515,6 +534,8 @@ func TestDebug_ExistingOutput(t *testing.T) {
 }
 
 func TestDebug_Fail_Pprof(t *testing.T) {
+	t.Parallel()
+
 	// Setup agent config with debug endpoints disabled
 	agentConfFunc := func(c *agent.Config) {
 		c.EnableDebug = false
@@ -822,4 +843,172 @@ func testServerWithoutLeader(t *testing.T, runClient bool, cb func(*agent.Config
 
 	c := a.Client()
 	return a, c, a.HTTPAddr()
+}
+
+// testOutput is used to receive test output from a channel
+type testOutput struct {
+	name   string
+	code   int
+	output string
+	error  string
+}
+
+func TestDebug_EventStream_TopicsFromString(t *testing.T) {
+	cases := []struct {
+		name      string
+		topicList string
+		want      map[api.Topic][]string
+	}{
+		{
+			name:      "topics = all",
+			topicList: "all",
+			want:      allTopics(),
+		},
+		{
+			name:      "topics = none",
+			topicList: "none",
+			want:      nil,
+		},
+		{
+			name:      "two topics",
+			topicList: "Deployment,Job",
+			want: map[api.Topic][]string{
+				"Deployment": {"*"},
+				"Job":        {"*"},
+			},
+		},
+		{
+			name:      "multiple topics and filters (using api const)",
+			topicList: "Evaluation:example,Job:*,Node:*",
+			want: map[api.Topic][]string{
+				api.TopicEvaluation: {"example"},
+				api.TopicJob:        {"*"},
+				api.TopicNode:       {"*"},
+			},
+		},
+		{
+			name:      "all topics for filterKey",
+			topicList: "*:example",
+			want: map[api.Topic][]string{
+				"*": {"example"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := topicsFromString(tc.topicList)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestDebug_EventStream(t *testing.T) {
+	// TODO: specify output directory to allow inspection of eventstream.json
+	// TODO: require specific events in the eventstream.json file(s)
+	// TODO: scenario where no events are expected, verify "No events captured"
+	// TODO: verify event topic filtering only includes expected events
+
+	var start time.Time
+
+	// Start test server
+	srv, client, url := testServer(t, true, nil)
+	t.Logf("[TEST] %s: test server started, waiting for leadership to establish\n", time.Since(start))
+
+	// Ensure leader is ready
+	testutil.WaitForLeader(t, srv.Agent.RPC)
+	t.Logf("[TEST] %s: Leadership established\n", time.Since(start))
+
+	// Setup mock UI
+	ui := cli.NewMockUi()
+	cmd := &OperatorDebugCommand{Meta: Meta{Ui: ui}}
+
+	// Create channels to pass info back from goroutine
+	chOutput := make(chan testOutput)
+	chDone := make(chan bool)
+
+	// Set duration for capture
+	duration := 5 * time.Second
+	// Fail with timeout if duration is exceeded by 5 seconds
+	timeout := duration + 5*time.Second
+
+	// Run debug in a goroutine so we can start the capture before we run the test job
+	t.Logf("[TEST] %s: Starting nomad operator debug in goroutine\n", time.Since(start))
+	go func() {
+		code := cmd.Run([]string{"-address", url, "-duration", duration.String(), "-interval", "5s", "-event-topic", "Job:*"})
+		assert.Equal(t, 0, code)
+
+		chOutput <- testOutput{
+			name:   "yo",
+			code:   code,
+			output: ui.OutputWriter.String(),
+			error:  ui.ErrorWriter.String(),
+		}
+		chDone <- true
+	}()
+
+	// Start test job
+	t.Logf("[TEST] %s: Running test job\n", time.Since(start))
+	job := testJob("event_stream_test")
+	resp, _, err := client.Jobs().Register(job, nil)
+	t.Logf("[TEST] %s: Test job started\n", time.Since(start))
+
+	// Ensure job registered
+	require.NoError(t, err)
+
+	// Wait for the job to complete
+	if code := waitForSuccess(ui, client, fullId, t, resp.EvalID); code != 0 {
+		switch code {
+		case 1:
+			t.Fatalf("status code 1: All other failures (API connectivity, internal errors, etc)\n")
+		case 2:
+			t.Fatalf("status code 2: Problem scheduling job (impossible constraints, resources exhausted, etc)\n")
+		default:
+			t.Fatalf("status code non zero saw %d\n", code)
+		}
+	}
+	t.Logf("[TEST] %s: test job is complete, eval id: %s\n", time.Since(start), resp.EvalID)
+
+	// Capture the output struct from nomad operator debug goroutine
+	var testOut testOutput
+	var done bool
+	for {
+		select {
+		case testOut = <-chOutput:
+			t.Logf("out from channel testout\n")
+		case done = <-chDone:
+			t.Logf("[TEST] %s: goroutine is complete", time.Since(start))
+		case <-time.After(timeout):
+			t.Fatalf("timed out waiting for event stream event (duration: %s, timeout: %s", duration, timeout)
+		}
+
+		if done {
+			break
+		}
+	}
+
+	t.Logf("Values from struct -- code: %d, len(out): %d, len(outerr): %d\n", testOut.code, len(testOut.output), len(testOut.error))
+
+	require.Empty(t, testOut.error)
+
+	archive := extractArchiveName(testOut.output)
+	require.NotEmpty(t, archive)
+	fmt.Println(archive)
+
+	// TODO: verify evenstream.json output file contains expected content
+}
+
+// extractArchiveName searches string s for the archive filename
+func extractArchiveName(captureOutput string) string {
+	file := ""
+
+	r := regexp.MustCompile(`Created debug archive: (.+)?\n`)
+	res := r.FindStringSubmatch(captureOutput)
+	// If found, there will be 2 elements, where element [1] is the desired text from the submatch
+	if len(res) == 2 {
+		file = res[1]
+	}
+
+	return file
 }

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -905,10 +905,10 @@ func TestDebug_EventStream_TopicsFromString(t *testing.T) {
 }
 
 func TestDebug_EventStream(t *testing.T) {
-	// TODO: specify output directory to allow inspection of eventstream.json
-	// TODO: require specific events in the eventstream.json file(s)
-	// TODO: scenario where no events are expected, verify "No events captured"
-	// TODO: verify event topic filtering only includes expected events
+	// TODO dmay: specify output directory to allow inspection of eventstream.json
+	// TODO dmay: require specific events in the eventstream.json file(s)
+	// TODO dmay: scenario where no events are expected, verify "No events captured"
+	// TODO dmay: verify event topic filtering only includes expected events
 
 	var start time.Time
 
@@ -996,7 +996,7 @@ func TestDebug_EventStream(t *testing.T) {
 	require.NotEmpty(t, archive)
 	fmt.Println(archive)
 
-	// TODO: verify evenstream.json output file contains expected content
+	// TODO dmay: verify evenstream.json output file contains expected content
 }
 
 // extractArchiveName searches string s for the archive filename

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -887,6 +887,15 @@ func TestDebug_EventStream_TopicsFromString(t *testing.T) {
 			},
 		},
 		{
+			name:      "capitalize topics",
+			topicList: "evaluation:example,job:*,node:*",
+			want: map[api.Topic][]string{
+				api.TopicEvaluation: {"example"},
+				api.TopicJob:        {"*"},
+				api.TopicNode:       {"*"},
+			},
+		},
+		{
 			name:      "all topics for filterKey",
 			topicList: "*:example",
 			want: map[api.Topic][]string{

--- a/website/content/docs/commands/operator/debug.mdx
+++ b/website/content/docs/commands/operator/debug.mdx
@@ -75,6 +75,13 @@ true.
   leadership, it may be necessary to get the configuration from a non-leader
   server.
 
+- `-event-topic=<allocation,evaluation,job,node,*>:<filter>`: Enable event 
+  stream capture. Filter by comma delimited list of topic filters or "all".
+  Defaults to "none" (disabled).  Refer to the [Events API](/api-docs/events) for
+  additional detail.
+
+- `-verbose`: Enable verbose output
+
 - `-output=path`: Path to the parent directory of the output
   directory. Defaults to the current directory. If specified, no
   archive is built.


### PR DESCRIPTION
Adds Event Stream capture to `nomad operator debug`.  Enable `-verbose` output for realtime feedback on events as they are captured.

New CLI flags:
* `-event-filter`
* `-verbose`

Example usage:

`nomad operator debug -event-filter="Evaluation:*" -verbose`

See [Events API](https://www.nomadproject.io/api-docs/events) documentation for more details on topic filtering.

Closes #11493