### PR TITLE
e2e: enable Consul HTTPS port and always restart Nomad systemd unit

### DIFF
--- a/e2e/terraform/config/shared/consul-tls.json
+++ b/e2e/terraform/config/shared/consul-tls.json
@@ -4,5 +4,8 @@
     "verify_server_hostname": true,
     "ca_file": "/etc/consul.d/tls/ca.crt",
     "cert_file": "/etc/consul.d/tls/agent.crt",
-    "key_file": "/etc/consul.d/tls/agent.key"
+    "key_file": "/etc/consul.d/tls/agent.key",
+    "ports": {
+      "https": 8501
+    }
 }

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/nomad.service
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/nomad.service
@@ -2,7 +2,7 @@
 Description=Nomad Agent
 Requires=network-online.target
 After=network-online.target
-StartLimitIntervalSec=10
+StartLimitIntervalSec=0
 StartLimitBurst=3
 
 [Service]


### PR DESCRIPTION
Consul's HTTPS port is not enabled by default and setting a non-zero value for `StartLimitIntervalSec` will result in [systemd not attempting to restart Nomad anymore](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#StartLimitIntervalSec=interval).

Note: we have noticed the Windows client SSH connection timeout sometimes, but it seems like a separate issue.