### PR TITLE
build: upgrade and speedup circleci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,12 @@ version: 2.1
 references:
   # environment specific references - aim to avoid conflicts
   go-machine-image: &go_machine_image
-    circleci/classic:201808-01
-  go-machine-recent-image: &go_machine_recent_image
-    ubuntu-1604:201903-01
+    ubuntu-2004:202111-02
   go-windows-image: &go_windows_image
     windows-server-2019-vs2019:stable
 
   # common references
   common_envs: &common_envs
-    GOMAXPROCS: 1
     NOMAD_SLOW_TEST: 1
     GOTESTSUM_JUNITFILE: /tmp/test-reports/results.xml
     GOTESTSUM_JSONFILE: /tmp/test-reports/testjsonfile.json
@@ -289,7 +286,7 @@ jobs:
         default: ""
       executor:
         type: string
-        default: "go-machine-recent"
+        default: "go-machine"
       goarch:
         type: string
         default: "amd64"
@@ -513,6 +510,7 @@ executors:
     working_directory: /go/src/github.com/hashicorp/nomad
     docker:
       - image: docker.mirror.hashicorp.services/golang:1.17.5
+    resource_class: large
     environment:
       <<: *common_envs
       GOPATH: /go
@@ -521,18 +519,10 @@ executors:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     machine:
       image: *go_machine_image
+      resource_class: large
     environment: &machine_env
       <<: *common_envs
-      GOPATH: /home/circleci/go
       GOLANG_VERSION: 1.17.5
-
-  # uses a more recent image with unattended upgrades disabled properly
-  # but seems to break docker builds
-  go-machine-recent:
-    working_directory: ~/go/src/github.com/hashicorp/nomad
-    machine:
-      image: *go_machine_recent_image
-    environment: *machine_env
 
   go-macos:
     working_directory: ~/go/src/github.com/hashicorp/nomad
@@ -636,9 +626,6 @@ workflows:
       - test-machine:
           name: "test-docker"
           test_packages: "./drivers/docker"
-          # docker is misbehaving in docker-machine-recent image
-          # and we get unexpected failures
-          # e.g. https://circleci.com/gh/hashicorp/nomad/3854
           executor: go-machine
           filters: *backend_test_branches_filter
       - test-machine:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,6 +8,13 @@ GIT_DIRTY := $(if $(shell git status --porcelain),+CHANGES)
 
 GO_LDFLAGS := "-X github.com/hashicorp/nomad/version.GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)"
 
+ifneq (MSYS_NT,$(THIS_OS))
+# GOPATH supports PATH style multi-paths; assume the first entry is favorable.
+# Necessary because new Circle images override GOPATH with multiple values.
+# See: https://discuss.circleci.com/t/gopath-is-set-to-multiple-directories/7174
+GOPATH=$(shell go env GOPATH | cut -d: -f1)
+endif
+
 GO_TAGS ?=
 
 ifeq ($(CI),true)
@@ -241,7 +248,6 @@ tidy:
 .PHONY: dev
 dev: GOOS=$(shell go env GOOS)
 dev: GOARCH=$(shell go env GOARCH)
-dev: GOPATH=$(shell go env GOPATH)
 dev: DEV_TARGET=pkg/$(GOOS)_$(GOARCH)/nomad
 dev: hclfmt ## Build for the current development platform
 	@echo "==> Removing old development build..."
@@ -297,7 +303,7 @@ test-nomad: dev ## Run Nomad test suites
 
 .PHONY: test-nomad-module
 test-nomad-module: dev ## Run Nomad test suites on a sub-module
-	@echo "==> Running Nomad test suites on sub-module:"
+	@echo "==> Running Nomad test suites on sub-module $(GOTEST_MOD)"
 	@cd $(GOTEST_MOD) && $(if $(ENABLE_RACE),GORACE="strip_path_prefix=$(GOPATH)/src") $(GO_TEST_CMD) \
 		$(if $(ENABLE_RACE),-race) $(if $(VERBOSE),-v) \
 		-cover \

--- a/command/metrics_test.go
+++ b/command/metrics_test.go
@@ -72,7 +72,7 @@ func TestCommand_Metrics_Cases(t *testing.T) {
 			[]string{"-address=http://foo"},
 			1,
 			"",
-			"no such host",
+			"dial tcp: lookup foo: Temporary failure in name resolution",
 		},
 	}
 

--- a/drivers/exec/driver_test.go
+++ b/drivers/exec/driver_test.go
@@ -425,7 +425,7 @@ func TestExecDriver_Stats(t *testing.T) {
 	require.NoError(err)
 	select {
 	case stats := <-statsCh:
-		require.NotZero(stats.ResourceUsage.MemoryStats.RSS)
+		require.NotEmpty(stats.ResourceUsage.MemoryStats.Measured)
 		require.NotZero(stats.Timestamp)
 		require.WithinDuration(time.Now(), time.Unix(0, stats.Timestamp), time.Second)
 	case <-time.After(time.Second):

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -71,6 +71,7 @@ type LibcontainerExecutor struct {
 }
 
 func NewExecutorWithIsolation(logger hclog.Logger) Executor {
+
 	logger = logger.Named("isolated_executor")
 	if err := shelpers.Init(); err != nil {
 		logger.Error("unable to initialize stats", "error", err)


### PR DESCRIPTION
This PR upgrades our CI images and fixes some affected tests.

- upgrade go-machine-image to premade latest ubuntu LTS (ubuntu-2004:202111-02)

- eliminate go-machine-recent-image (no longer necessary)

- eliminate setting GOMAXPROCS=1 (build tools were also affected by this setting)

- upgrade resource type for all imanges to large (2C -> 4C)

- manage GOPATH in GNUMakefile (see https://discuss.circleci.com/t/gopath-is-set-to-multiple-directories/7174)

- fix tcp dial error check (message seems to be OS specific)

- spot check values measured instead of specifically 'RSS' (rss no longer reported in cgroups v2)
