### PR TITLE
fix wrong control plane discovery, when serf advertised address located in network, unreachable from clients

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2773,7 +2773,7 @@ DISCOLOOP:
 				continue
 			}
 			var peers []string
-			if err := c.connPool.RPC(region, addr, c.RPCMajorVersion(), "Status.Peers", rpcargs, &peers); err != nil {
+			if err := c.connPool.RPC(region, addr, c.RPCMajorVersion(), "Status.RpcPeers", rpcargs, &peers); err != nil {
 				mErr.Errors = append(mErr.Errors, err)
 				continue
 			}


### PR DESCRIPTION
Suppose follow configuration, when we use nomad federation:

1. We have 2 nomad regions (`A` and `B`)
2. controlplane of regions located in common network: `10.168.0.0/16`, rpc and http addresses located in private networks, unique for both regions(`192.168.102.0/24` for region `A`, and `192.168.103.0/24` for region `B`)
3. nomad clients located only in private networks and can't communicate with controlplane throw `10.168.0.0/24`
4. on controllplane we advertise addreses like this:
    1. for region `A`  on first server
        ```
        advertise
        {
            http = "192.168.102.11"
            rpc =  "192.168.102.11"
            serf = "10.168.0.11"
        } 
        ```  
     1. for region `B`  on first server
        ```
        advertise
        {
            http = "192.168.103.11"
            rpc =  "192.168.103.11"
            serf = "10.168.1.11"
        } 
        ```

In such configuration nomad clients when discover controlplane by consul will get addresses from network `10.168.0.0/16`, and of course nothing will work, because  they can't reach this network

This patch try fix this situation by adding new RPC method `RpcPeers` which will return private RPC adresses instead of Serf