### PR TITLE
Fix for #11884: Move volume link to the source column and fix the link target

### DIFF
--- a/.changelog/11896.txt
+++ b/.changelog/11896.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix the link target for CSI volumes on the task detail page
+```

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -108,18 +108,18 @@
           </t.head>
           <t.body as |row|>
             <tr data-test-volume>
-              <td data-test-volume-name>
-                {{#if row.model.isCSI}}
-                  <LinkTo @route="csi.volumes.volume" @model={{row.model.volume}} @query={{hash volumeNamespace=row.model.namespace.id}}>
-                    {{row.model.volume}}
-                  </LinkTo>
-                {{else}}
-                  {{row.model.volume}}
-                {{/if}}
-              </td>
+              <td data-test-volume-name>{{row.model.volume}}</td>
               <td data-test-volume-destination><code>{{row.model.destination}}</code></td>
               <td data-test-volume-permissions>{{if row.model.readOnly "Read" "Read/Write"}}</td>
-              <td data-test-volume-client-source>{{row.model.source}}</td>
+              <td data-test-volume-client-source>
+                {{#if row.model.isCSI}}
+                  <LinkTo @route="csi.volumes.volume" @model={{row.model.source}} @query={{hash volumeNamespace=row.model.namespace.id}}>
+                    {{row.model.source}}
+                  </LinkTo>
+                {{else}}
+                  {{row.model.source}}
+                {{/if}}
+              </td>
             </tr>
           </t.body>
         </ListTable>


### PR DESCRIPTION
This fixes the wrong link target in the volumes list of tasks. I moved the link to the source column which is the actual link target.