### PR TITLE
fix(alloc/exec): trim spaces on secretID to prevent error on lookup

### DIFF
--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -5302,7 +5302,7 @@ func (s *StateStore) ACLTokenBySecretID(ws memdb.WatchSet, secretID string) (*st
 
 	txn := s.db.ReadTxn()
 
-	watchCh, existing, err := txn.FirstWatch("acl_token", "secret", secretID)
+	watchCh, existing, err := txn.FirstWatch("acl_token", "secret", strings.TrimSpace(secretID))
 	if err != nil {
 		return nil, fmt.Errorf("acl token lookup failed: %v", err)
 	}


### PR DESCRIPTION
If the ACL Token set in localstorage contains prefixed/suffixed spaces, any RPC calls to `Allocations.Exec` results in:

```
  Connection Closed: 1011 acl token lookup failed: index error: UUID must be 36 characters
```

### How to reproduce:

1. Set token in `https://<nomad-instance>/ui/settings/tokens`, preferably with an added space before the token. The token gets set correctly, which means that the system is handling spaces just fine.

2. Exec into any allocation through the web UI, which would fail as described above.

### Sample Request Payload:

```json
{
  "version": 1,
  "auth_token": " XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
}
```

Notice the prefixed added space in the `auth_token` value which causes the error.

### Proposed fix:

RPC to `Allocations.Exec` calls `ACLTokenBySecretID()`, which should pass the space-trimmed `secretID` to lookup the ACL token. A simple `strings.TrimSpace()` call around `secretID` should fix the issue.