### PR TITLE
changelog: fix entry markdown

### DIFF
--- a/.changelog/10236.txt
+++ b/.changelog/10236.txt
@@ -1,3 +1,3 @@
-```improvement
+```release-note:improvement
 metrics: emit `nomad.nomad.broker.eval_waiting` metric for the time evaluations are waiting to be enqueued
 ```

--- a/.changelog/10237.txt
+++ b/.changelog/10237.txt
@@ -1,3 +1,3 @@
-```improvement
+```release-note:improvement
 metrics: emit `nomad.scheduler.allocs.rescheduled` metrics for evaluations that are rescheduled for later
 ```

--- a/.changelog/11507.txt
+++ b/.changelog/11507.txt
@@ -1,3 +1,3 @@
-```improvement
+```release-note:improvement
 cli: improve `nomad operator debug` error messages
 ```

--- a/.changelog/11793.txt
+++ b/.changelog/11793.txt
@@ -1,3 +1,3 @@
-```improvement
+```release-note:improvement
 scheduler: detect, log, and emit `nomad.nomad.plan.node_rejected` metric when an unexpected port collision is detected
 ```

--- a/.changelog/11853.txt
+++ b/.changelog/11853.txt
@@ -1,3 +1,3 @@
-```bug
+```release-note:bug
 csi: Fixed a bug in `volume deregister` and `volume detach` commands where volume IDs were truncated when asking the user to select one of several prefix matches
 ```

--- a/.changelog/11854.txt
+++ b/.changelog/11854.txt
@@ -1,3 +1,3 @@
-```bug
+```release-note:bug
 freebsd: Fixed a build failure on FreeBSD ARM7 32-bit systems
 ```


### PR DESCRIPTION
@shoenig pointed out that I had this wrong in https://github.com/hashicorp/nomad/pull/11891#discussion_r789748618 and I checked the existing changelog entries. Looks like it was wrong on a handful, probably copy-pasted from the first one in the directory.