### PR TITLE
docs: Update volume create/register mount options to use []string example

### DIFF
--- a/website/content/docs/commands/volume/create.mdx
+++ b/website/content/docs/commands/volume/create.mdx
@@ -56,7 +56,7 @@ capability {
 
 mount_options {
   fs_type     = "ext4"
-  mount_flags = "noatime"
+  mount_flags = ["noatime"]
 }
 
 secrets {

--- a/website/content/docs/commands/volume/register.mdx
+++ b/website/content/docs/commands/volume/register.mdx
@@ -58,7 +58,7 @@ capability {
 
 mount_options {
   fs_type     = "ext4"
-  mount_flags = "noatime"
+  mount_flags = ["noatime"]
 }
 
 secrets {


### PR DESCRIPTION
The examples for `nomad volume create` and `nomad volume register` are
not setting `mount_flags` using an array of strings.

This fixes the issue by changing the example to be `mount_flags =
["noatime"]`.