### PR TITLE
Update IsEmpty logic in finalizeClientTemplateConfig

### DIFF
--- a/.changelog/11902.txt
+++ b/.changelog/11902.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+template: Fixed a bug where client template configuration that did not include any
+of the new 1.2.4 configuration options could result in none of the configuration getting set.
+```

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -450,7 +450,10 @@ func (c *ClientTemplateConfig) IsEmpty() bool {
 		return true
 	}
 
-	return c.BlockQueryWaitTime == nil &&
+	return !c.DisableSandbox &&
+		len(c.FunctionDenylist) == 0 &&
+		len(c.FunctionBlacklist) == 0 &&
+		c.BlockQueryWaitTime == nil &&
 		c.BlockQueryWaitTimeHCL == "" &&
 		c.MaxStale == nil &&
 		c.MaxStaleHCL == "" &&

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -1413,6 +1413,41 @@ func TestConfig_LoadConsulTemplateConfig(t *testing.T) {
 	require.Equal(t, 20*time.Second, *templateConfig.VaultRetry.MaxBackoff)
 }
 
+func TestConfig_LoadConsulTemplateBasic(t *testing.T) {
+	defaultConfig := DefaultConfig()
+
+	// hcl
+	agentConfig, err := LoadConfig("test-resources/client_with_basic_template.hcl")
+	require.NoError(t, err)
+	require.NotNil(t, agentConfig.Client.TemplateConfig)
+
+	agentConfig = defaultConfig.Merge(agentConfig)
+
+	clientAgent := Agent{config: agentConfig}
+	clientConfig, err := clientAgent.clientConfig()
+	require.NoError(t, err)
+
+	templateConfig := clientConfig.TemplateConfig
+	require.NotNil(t, templateConfig)
+	require.True(t, templateConfig.DisableSandbox)
+	require.Len(t, templateConfig.FunctionDenylist, 1)
+
+	// json
+	agentConfig, err = LoadConfig("test-resources/client_with_basic_template.json")
+	require.NoError(t, err)
+
+	agentConfig = defaultConfig.Merge(agentConfig)
+
+	clientAgent = Agent{config: agentConfig}
+	clientConfig, err = clientAgent.clientConfig()
+	require.NoError(t, err)
+
+	templateConfig = clientConfig.TemplateConfig
+	require.NotNil(t, templateConfig)
+	require.True(t, templateConfig.DisableSandbox)
+	require.Len(t, templateConfig.FunctionDenylist, 1)
+}
+
 func TestParseMultipleIPTemplates(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/command/agent/test-resources/client_with_basic_template.hcl
+++ b/command/agent/test-resources/client_with_basic_template.hcl
@@ -1,0 +1,9 @@
+
+client {
+  enabled = true
+
+  template {
+    disable_file_sandbox = true
+    function_denylist    = []
+  }
+}

--- a/command/agent/test-resources/client_with_basic_template.json
+++ b/command/agent/test-resources/client_with_basic_template.json
@@ -1,0 +1,9 @@
+{
+  "client": {
+    "enabled": true,
+    "template": {
+      "disable_file_sandbox": true,
+      "function_denylist": []
+    }
+  }
+}


### PR DESCRIPTION
When parsing the new `consul-template` configuration parameters introduced in 1.2.4 , the `finalizeClientTemplateConfig` function failed to account for the pre-1.2.4 fields in its logic and set the `ClientTemplateConfig` to `nil` only if none of the new configuration options were set. 

This PR:

- Updates that logic to check the pre-1.2.4 fields
- Adds negative tests to ensure configs without the new `consul-template` settings introduced in 1.2.4 can still parse.

Closes #11902
