### PR TITLE
CSI: ensure that PastClaims are populated with correct mode

### DIFF
--- a/nomad/state/testing.go
+++ b/nomad/state/testing.go
@@ -221,8 +221,8 @@ func TestBadCSIState(t testing.TB, store *StateStore) error {
 	allocID2 := uuid.Generate() // nil alloc
 
 	alloc1 := mock.Alloc()
-	alloc1.ClientStatus = "complete"
-	alloc1.DesiredStatus = "stop"
+	alloc1.ClientStatus = structs.AllocClientStatusRunning
+	alloc1.DesiredStatus = structs.AllocDesiredStatusRun
 
 	// Insert allocs into the state store
 	err := store.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc1})
@@ -303,6 +303,7 @@ func TestBadCSIState(t testing.TB, store *StateStore) error {
 		NodesHealthy:        2,
 		NodesExpected:       0,
 	}
+	vol = vol.Copy() // canonicalize
 
 	err = store.CSIVolumeRegister(index, []*structs.CSIVolume{vol})
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10927#issuecomment-1020600171. 

In the client's `(*csiHook) Postrun()` method, we make an unpublish RPC that includes a claim in the `CSIVolumeClaimStateUnpublishing` state and using the mode from the client. But then in the `(*CSIVolume) Unpublish` RPC handler, we query the volume from the state store (because we only get an ID from the client). And when we make the client RPC for the node unpublish step, we use the _current volume's_ view of the mode. If the volume's mode has been changed before the old allocations can have their claims released, then we end up making a CSI RPC that will never succeed.

Why does this code path get the mode from the volume and not the claim? Because the claim written by the GC job in `(*CoreScheduler) csiVolumeClaimGC` doesn't have a mode. Instead it  just writes a claim in the unpublishing state to ensure the volumewatcher detects a "past claim" change and reaps all the claims on the volumes.

Fix this by ensuring that the `CSIVolumeDenormalize` creates past claims for all nil allocations with a correct access mode set. This ends up being a fairly large refactoring of the method because otherwise fixing the mode ends up repeating the past claim construction in 4 places and balloons the size of the method.