### PR TITLE
docs: add `cores` to client reserved config block.

### DIFF
--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -336,6 +336,8 @@ see the [drivers documentation](/docs/drivers).
 
 - `cpu` `(int: 0)` - Specifies the amount of CPU to reserve, in MHz.
 
+- `cores` `(int: 0)` - Specifies the number of CPU cores to reserve.
+
 - `memory` `(int: 0)` - Specifies the amount of memory to reserve, in MB.
 
 - `disk` `(int: 0)` - Specifies the amount of disk to reserve, in MB.


### PR DESCRIPTION
note: need to figure out the right labels to get this onto the correct versioned websites (back to 1.1.0)