### PR TITLE
website: Add Demandbase tag to consent manager

### DIFF
--- a/website/lib/consent-manager-services/index.ts
+++ b/website/lib/consent-manager-services/index.ts
@@ -1,0 +1,15 @@
+import { ConsentManagerService } from '@hashicorp/react-consent-manager/types'
+
+const localConsentManagerServices: ConsentManagerService[] = [
+  {
+    name: 'Demandbase Tag',
+    description:
+      'The Demandbase tag is a tracking service to identify website visitors and measure interest on our website.',
+    category: 'Analytics',
+    url: 'https://tag.demandbase.com/960ab0a0f20fb102.min.js',
+    async: true,
+  },
+]
+
+export default localConsentManagerServices
+

--- a/website/pages/_app.js
+++ b/website/pages/_app.js
@@ -6,6 +6,7 @@ import Head from 'next/head'
 import NProgress from '@hashicorp/platform-util/nprogress'
 import { ErrorBoundary } from '@hashicorp/platform-runtime-error-monitoring'
 import createConsentManager from '@hashicorp/react-consent-manager/loader'
+import localConsentManagerServices from 'lib/consent-manager-services'
 import useFathomAnalytics from '@hashicorp/platform-analytics'
 import useAnchorLinkAnalytics from '@hashicorp/platform-util/anchor-link-analytics'
 import HashiStackMenu from '@hashicorp/react-hashi-stack-menu'
@@ -19,6 +20,7 @@ import alertBannerData, { ALERT_BANNER_ACTIVE } from 'data/alert-banner'
 NProgress({ Router })
 const { ConsentManager, openConsentManager } = createConsentManager({
   preset: 'oss',
+  otherServices: [...localConsentManagerServices],
 })
 
 export default function App({ Component, pageProps }) {


### PR DESCRIPTION
[:mag: Preview link](https://nomad-git-nqweb-add-demandbase-consent-hashicorp.vercel.app/)

---

This PR adds a Demandbase tag to the consent manager for the Nomad website.