### PR TITLE
Fix parameterized job child meta/payload UI

### DIFF
--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -313,6 +313,17 @@ export default class Job extends Model {
     return window.atob(this.payload || '');
   }
 
+  @computed('decodedPayload')
+  get payloadJSON() {
+    let json;
+    try {
+      json = JSON.parse(this.decodedPayload);
+    } catch (e) {
+      // Swallow error and fall back to plain text rendering
+    }
+    return json;
+  }
+
   // An arbitrary HCL or JSON string that is used by the serializer to plan
   // and run this job. Used for both new job models and saved job models.
   @attr('string') _newDefinition;

--- a/ui/app/templates/components/job-page.hbs
+++ b/ui/app/templates/components/job-page.hbs
@@ -21,6 +21,7 @@
       TaskGroups=(component "job-page/parts/task-groups" job=@job)
       RecentAllocations=(component "job-page/parts/recent-allocations" job=@job)
       Meta=(component "job-page/parts/meta" job=@job)
+      Payload=(component "job-page/parts/payload" job=@job)
       DasRecommendations=(component
         "job-page/parts/das-recommendations" job=@job
       )

--- a/ui/app/templates/components/job-page/parameterized-child.hbs
+++ b/ui/app/templates/components/job-page/parameterized-child.hbs
@@ -23,40 +23,7 @@
     <jobPage.ui.PlacementFailures />
     <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}} />
     <jobPage.ui.RecentAllocations />
-    <div class="boxed-section">
-      <div class="boxed-section-head">
-        Meta
-      </div>
-      {{#if @job.definition.Meta}}
-        <jobPage.ui.Meta />
-      {{else}}
-        <div class="boxed-section-body">
-          <div data-test-empty-meta-message class="empty-message">
-            <h3 class="empty-message-headline">
-              No Meta Attributes
-            </h3>
-            <p class="empty-message-body">
-              This job is configured with no meta attributes.
-            </p>
-          </div>
-        </div>
-      {{/if}}
-    </div>
-    <div class="boxed-section">
-      <div class="boxed-section-head">
-        Payload
-      </div>
-      <div class="boxed-section-body is-dark">
-        {{#if this.payloadJSON}}
-          <JsonViewer @json={{this.payloadJSON}} />
-        {{else}}
-          <pre class="cli-window is-elastic">
-            <code>
-              {{this.payload}}
-            </code>
-          </pre>
-        {{/if}}
-      </div>
-    </div>
+    <jobPage.ui.Meta />
+    <jobPage.ui.Payload />
   </jobPage.ui.Body>
 </JobPage>

--- a/ui/app/templates/components/job-page/parts/payload.hbs
+++ b/ui/app/templates/components/job-page/parts/payload.hbs
@@ -1,0 +1,14 @@
+{{#if @job.payload}}
+  <div class="boxed-section">
+    <div class="boxed-section-head">
+      Payload
+    </div>
+    <div class="boxed-section-body is-dark">
+      {{#if @job.payloadJSON}}
+        <JsonViewer @json={{@job.payloadJSON}} @fluidHeight={{true}} />
+      {{else}}
+        <pre class="cli-window is-elastic"><code>{{ @job.decodedPayload }}</code></pre>
+      {{/if}}
+    </div>
+  </div>
+{{/if}}


### PR DESCRIPTION
_Disclaimer: I don't know anything about UI things._
This seems to work for me, but I'm sure there are better ways to make this fix. 

<details>
  <summary>Test Job</summary>

```nomad
job "example" {
  datacenters = ["dc1"]
  type = "batch"

  parameterized {
    payload = "required"
    meta_optional = ["something"]
  }

  group "web" {

    network {
      mode = "bridge"
      port "www" {
        to = 8001
      }
    }

    task "http" {

      driver = "docker"

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-v", "-f", "-p", "8001", "-h", "/local"]
        ports   = ["www"]
      }

      dispatch_payload {
        file = "/local/text.index.html"
      }

      resources {
        cpu    = 128
        memory = 128
      }

    }
  }
}
```
</details>

**Metadata**
Previously the metadata UI bit for parameterized children was completely broken. Even jobs that did have metadata would appear to have none.
It seems that the `<jobPage.ui.Meta />` component already handles non-existent metadata, so I simply dropped the (broken) checking for no metadata.

Before:
![Screen Shot 2022-01-27 at 10 29 05 AM](https://user-images.githubusercontent.com/3588162/151421244-2c71f55f-ae6d-4af6-bed1-87c092f8fb6f.png)

After
![Screen Shot 2022-01-27 at 10 28 32 AM](https://user-images.githubusercontent.com/3588162/151421154-7f6204ad-f1b9-4864-9a8e-8b5db06fafe6.png)

**Payload**
I think something has broken recently with https://github.com/hashicorp/nomad/blob/main/ui/app/components/job-page/parameterized-child.js such that those `payload` and `payloadJSON` attributes aren't working, but I couldn't figure out how to fix it which is why I copied the payloadJSON method into the job model -- if someone smarter than me could help me fix this properly that would be great.
