### PR TITLE
e2e: account for new job stop CLI exit behaviour.

### DIFF
--- a/e2e/consul/check_restart.go
+++ b/e2e/consul/check_restart.go
@@ -31,7 +31,7 @@ func (tc *CheckRestartE2ETest) AfterEach(f *framework.F) {
 	}
 
 	for _, id := range tc.jobIds {
-		_, err := e2e.Command("nomad", "job", "stop", "-purge", id)
+		err := e2e.StopJob(id, "-purge")
 		f.Assert().NoError(err)
 	}
 	tc.jobIds = []string{}

--- a/e2e/consultemplate/consultemplate.go
+++ b/e2e/consultemplate/consultemplate.go
@@ -46,7 +46,7 @@ func (tc *ConsulTemplateTest) AfterEach(f *framework.F) {
 	}
 
 	for _, id := range tc.jobIDs {
-		_, err := e2eutil.Command("nomad", "job", "stop", "-purge", id)
+		err := e2eutil.StopJob(id, "-purge")
 		f.Assert().NoError(err, "could not clean up job", id)
 	}
 	tc.jobIDs = []string{}

--- a/e2e/csi/ebs.go
+++ b/e2e/csi/ebs.go
@@ -78,8 +78,8 @@ func (tc *CSIControllerPluginEBSTest) AfterAll(f *framework.F) {
 
 	// Stop all jobs in test
 	for _, id := range tc.testJobIDs {
-		out, err := e2e.Command("nomad", "job", "stop", "-purge", id)
-		f.Assert().NoError(err, out)
+		err := e2e.StopJob(id, "-purge")
+		f.Assert().NoError(err)
 	}
 	tc.testJobIDs = []string{}
 
@@ -94,8 +94,8 @@ func (tc *CSIControllerPluginEBSTest) AfterAll(f *framework.F) {
 
 	// Deregister all plugin jobs in test
 	for _, id := range tc.pluginJobIDs {
-		out, err := e2e.Command("nomad", "job", "stop", "-purge", id)
-		f.Assert().NoError(err, out)
+		err := e2e.StopJob(id, "-purge")
+		f.Assert().NoError(err)
 	}
 	tc.pluginJobIDs = []string{}
 
@@ -130,7 +130,7 @@ func (tc *CSIControllerPluginEBSTest) TestVolumeClaim(f *framework.F) {
 	// Shutdown (and purge) the writer so we can run a reader.
 	// we could mount the EBS volume with multi-attach, but we
 	// want this test to exercise the unpublish workflow.
-	_, err = e2e.Command("nomad", "job", "stop", "-purge", writeJobID)
+	err = e2e.StopJob(writeJobID, "-purge")
 	f.NoError(err)
 
 	// wait for the volume unpublish workflow to complete

--- a/e2e/csi/efs.go
+++ b/e2e/csi/efs.go
@@ -93,7 +93,7 @@ func (tc *CSINodeOnlyPluginEFSTest) TestEFSVolumeClaim(f *framework.F) {
 	// Shutdown the writer so we can run a reader.
 	// although EFS should support multiple readers, the plugin
 	// does not.
-	_, err = e2e.Command("nomad", "job", "stop", writeJobID)
+	err = e2e.StopJob(writeJobID)
 	require.NoError(err)
 
 	// wait for the volume unpublish workflow to complete
@@ -123,8 +123,8 @@ func (tc *CSINodeOnlyPluginEFSTest) AfterEach(f *framework.F) {
 
 	// Stop all jobs in test
 	for _, id := range tc.testJobIDs {
-		out, err := e2e.Command("nomad", "job", "stop", "-purge", id)
-		f.Assert().NoError(err, out)
+		err := e2e.StopJob(id, "-purge")
+		f.Assert().NoError(err)
 	}
 	tc.testJobIDs = []string{}
 
@@ -142,8 +142,8 @@ func (tc *CSINodeOnlyPluginEFSTest) AfterEach(f *framework.F) {
 
 	// Deregister all plugin jobs in test
 	for _, id := range tc.pluginJobIDs {
-		out, err := e2e.Command("nomad", "job", "stop", "-purge", id)
-		f.Assert().NoError(err, out)
+		err := e2e.StopJob(id, "-purge")
+		f.Assert().NoError(err)
 	}
 	tc.pluginJobIDs = []string{}
 

--- a/e2e/namespaces/namespaces.go
+++ b/e2e/namespaces/namespaces.go
@@ -42,10 +42,10 @@ func (tc *NamespacesE2ETest) AfterEach(f *framework.F) {
 		ns := pair[0]
 		jobID := pair[1]
 		if ns != "" {
-			_, err := e2e.Command("nomad", "job", "stop", "-purge", "-namespace", ns, jobID)
+			err := e2e.StopJob(jobID, "-purge", "-namespace", ns)
 			f.Assert().NoError(err)
 		} else {
-			_, err := e2e.Command("nomad", "job", "stop", "-purge", jobID)
+			err := e2e.StopJob(jobID, "-purge")
 			f.Assert().NoError(err)
 		}
 	}
@@ -179,6 +179,6 @@ func (tc *NamespacesE2ETest) TestNamespacesFiltering(f *framework.F) {
 	f.Equal(fmt.Sprintf("No job(s) with prefix or id %q found\n", jobA), out)
 	f.Error(err, "exit status 1")
 
-	_, err = e2e.Command("nomad", "job", "stop", "-namespace", "NamespaceA", jobA)
+	err = e2e.StopJob(jobA, "-namespace", "NamespaceA")
 	f.NoError(err, "could not stop job in namespace")
 }

--- a/e2e/networking/networking.go
+++ b/e2e/networking/networking.go
@@ -36,7 +36,7 @@ func (tc *NetworkingE2ETest) AfterEach(f *framework.F) {
 	}
 
 	for _, jobID := range tc.jobIDs {
-		_, err := e2eutil.Command("nomad", "job", "stop", "-purge", jobID)
+		err := e2eutil.StopJob(jobID, "-purge")
 		f.NoError(err)
 	}
 	tc.jobIDs = []string{}

--- a/e2e/rescheduling/rescheduling.go
+++ b/e2e/rescheduling/rescheduling.go
@@ -44,7 +44,7 @@ func (tc *RescheduleE2ETest) AfterEach(f *framework.F) {
 	}
 
 	for _, id := range tc.jobIds {
-		_, err := e2e.Command("nomad", "job", "stop", "-purge", id)
+		err := e2e.StopJob(id, "-purge")
 		f.Assert().NoError(err)
 	}
 	tc.jobIds = []string{}

--- a/e2e/scaling/scaling.go
+++ b/e2e/scaling/scaling.go
@@ -38,8 +38,8 @@ func (tc *ScalingE2ETest) AfterEach(f *framework.F) {
 	}
 
 	for _, namespacedJob := range tc.namespacedJobIDs {
-		_, err := e2eutil.Command("nomad", "job", "stop", "-purge", "-namespace",
-			namespacedJob[0], namespacedJob[1])
+		err := e2eutil.StopJob(namespacedJob[1], "-purge", "-namespace",
+			namespacedJob[0])
 		f.NoError(err)
 	}
 	tc.namespacedJobIDs = [][2]string{}

--- a/e2e/scalingpolicies/scalingpolicies.go
+++ b/e2e/scalingpolicies/scalingpolicies.go
@@ -38,8 +38,8 @@ func (tc *ScalingPolicyE2ETest) AfterEach(f *framework.F) {
 	}
 
 	for _, namespacedJob := range tc.namespacedJobIDs {
-		_, err := e2eutil.Command("nomad", "job", "stop", "-purge", "-namespace",
-			namespacedJob[0], namespacedJob[1])
+		err := e2eutil.StopJob(namespacedJob[1], "-purge", "-namespace",
+			namespacedJob[0])
 		f.Assert().NoError(err)
 	}
 	tc.namespacedJobIDs = [][2]string{}

--- a/e2e/volumes/volumes.go
+++ b/e2e/volumes/volumes.go
@@ -41,7 +41,7 @@ func (tc *VolumesTest) AfterEach(f *framework.F) {
 	}
 
 	for _, id := range tc.jobIDs {
-		_, err := e2e.Command("nomad", "job", "stop", "-purge", id)
+		err := e2e.StopJob(id, "-purge")
 		f.Assert().NoError(err)
 	}
 	tc.jobIDs = []string{}


### PR DESCRIPTION
PR #11550 changed the job stop exit behaviour when monitoring the
deployment. When stopping a job, the deployment becomes cancelled
and therefore the CLI now exits with status code 1 as it see this
as an error.

This change adds a new utility e2e function that accounts for this
behaviour.

Closes #11950