### PR TITLE
build: disable semgrep on structs.go for now

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,3 @@
+# Disable Semgrep on structs.go until it stops breaking.
+nomad/structs/structs.go
+


### PR DESCRIPTION
Semgrep seems to consistently break with the error below anytime `structs.go` is modified. There isn't much we can do besides disable the semgrep rules entirely or disable semgrep from running on this file, while we wait for an upstream fix.

```
=== setting up agent configuration
| using semgrep rules from the committed .semgrep/ directory
| not on head ref 990a6dfb5fd900388869c33c8ffa8c8cf0928eb3; checking that out now...
| reporting findings introduced by these commits:
|   * 990a6df client: follow up on CR comments
|   * 713de8b client: fix a bug
| looking at 5 changed paths
=== looking for current issues in 5 files
| returning to original head revision 024137f92d771c1b38071fa2f210dbd83e17d3f1

=== failed command's STDOUT:



=== failed command's STDERR:



Error: ROR] `/root/.local/bin/semgrep --skip-unknown-extensions --disable-nosem --json --autofix --dryrun --time --timeout-threshold 3 --config .semgrep/ --debug -o /tmp/tmp0yib0pmf helper/escapingfs/escapes.go helper/escapingfs/escapes_test.go client/allocdir/alloc_dir.go client/allocdir/alloc_dir_test.go nomad/structs/structs.go` failed with exit code 7
```