### PR TITLE
Update autoscaler AWS ASG target docs: AWS keypair can be empty

### DIFF
--- a/website/content/tools/autoscaling/plugins/target/aws-asg.mdx
+++ b/website/content/tools/autoscaling/plugins/target/aws-asg.mdx
@@ -60,10 +60,10 @@ target "aws-asg" {
   to connect to and where resources should be managed.
 
 - `aws_access_key_id` `(string: "")` - The AWS access key ID used to authenticate
-  with the AWS API.
+  with the AWS API. Can be empty if the agent is running on an EC2 instance with an IAM role attached.
 
 - `aws_secret_access_key` `(string: "")` - The AWS secret key ID used to authenticate
-  with the AWS API.
+  with the AWS API. Can be empty if the agent is running on an EC2 instance with an IAM role attached.
 
 - `aws_session_token` `(string: "")` - The AWS session token used to authenticate
   with the AWS API.

--- a/website/content/tools/autoscaling/plugins/target/aws-asg.mdx
+++ b/website/content/tools/autoscaling/plugins/target/aws-asg.mdx
@@ -60,10 +60,12 @@ target "aws-asg" {
   to connect to and where resources should be managed.
 
 - `aws_access_key_id` `(string: "")` - The AWS access key ID used to authenticate
-  with the AWS API. Can be empty if the agent is running on an EC2 instance with an IAM role attached.
+  with the AWS API. If empty, the IAM role attached to the EC2 instance will be
+  used.
 
 - `aws_secret_access_key` `(string: "")` - The AWS secret key ID used to authenticate
-  with the AWS API. Can be empty if the agent is running on an EC2 instance with an IAM role attached.
+  with the AWS API. If empty, the IAM role attached to the EC2 instance will be
+  used.
 
 - `aws_session_token` `(string: "")` - The AWS session token used to authenticate
   with the AWS API.


### PR DESCRIPTION
docs update for PR https://github.com/hashicorp/nomad-autoscaler/pull/564 - the autoscaler agent no longer needs an AWS keypair if it's running on an EC2 instance with the appropriate IAM role attached to it.

