### PR TITLE
added Int32ToPtr helper function

### DIFF
--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -83,6 +83,11 @@ func Int8ToPtr(i int8) *int8 {
 	return &i
 }
 
+// Int32ToPtr returns the pointer to an int
+func Int32ToPtr(i int32) *int32 {
+	return &i
+}
+
 // Int64ToPtr returns the pointer to an int
 func Int64ToPtr(i int64) *int64 {
 	return &i

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -83,12 +83,12 @@ func Int8ToPtr(i int8) *int8 {
 	return &i
 }
 
-// Int32ToPtr returns the pointer to an int
+// Int32ToPtr returns the pointer to an int32
 func Int32ToPtr(i int32) *int32 {
 	return &i
 }
 
-// Int64ToPtr returns the pointer to an int
+// Int64ToPtr returns the pointer to an int64
 func Int64ToPtr(i int64) *int64 {
 	return &i
 }


### PR DESCRIPTION
I've been working on [hashicorp/nomad-openapi](https://github.com/hashicorp/nomad-openapi) and some of the parameters (i.e. `MaxTrailingLogs` in [Autopilot Configuration](https://www.nomadproject.io/api-docs/operator/autopilot#parameters) is of type `*int32` and I had to write a local `Int32ToPtr` function as one didn't exist in nomad/helper, which doesn't look as clean, so would like to add one in to referenced in the future.