### PR TITLE
style: fix up very long tag word breaking the allocation service table width

### DIFF
--- a/.changelog/11995.txt
+++ b/.changelog/11995.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: break long service tags into multiple lines
+```

--- a/ui/app/styles/core/table.scss
+++ b/ui/app/styles/core/table.scss
@@ -128,6 +128,10 @@
         font-weight: $weight-semibold;
       }
     }
+
+    &.ensure-break {
+      word-break: break-word;
+    }
   }
 
   thead {

--- a/ui/app/styles/core/table.scss
+++ b/ui/app/styles/core/table.scss
@@ -1,4 +1,4 @@
-@use "sass:math";
+@use 'sass:math';
 
 .table {
   color: $text;
@@ -103,6 +103,10 @@
       }
     }
 
+    &.is-long-text {
+      word-break: break-word;
+    }
+
     // Only use px modifiers when text needs to be truncated.
     // In this and only this scenario are percentages not effective.
     &.is-200px {
@@ -127,10 +131,6 @@
         text-decoration: none;
         font-weight: $weight-semibold;
       }
-    }
-
-    &.ensure-break {
-      word-break: break-word;
     }
   }
 

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -173,7 +173,7 @@
             <tr data-test-service>
               <td data-test-service-name>{{row.model.name}}</td>
               <td data-test-service-port>{{row.model.portLabel}}</td>
-              <td data-test-service-tags>{{join ", " row.model.tags}}</td>
+              <td data-test-service-tags class="ensure-break">{{join ", " row.model.tags}}</td>
               <td data-test-service-onupdate>{{row.model.onUpdate}}</td>
               <td data-test-service-connect>{{if row.model.connect "Yes" "No"}}</td>
               <td data-test-service-upstreams>

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -173,7 +173,7 @@
             <tr data-test-service>
               <td data-test-service-name>{{row.model.name}}</td>
               <td data-test-service-port>{{row.model.portLabel}}</td>
-              <td data-test-service-tags class="ensure-break">{{join ", " row.model.tags}}</td>
+              <td data-test-service-tags class="is-long-text">{{join ", " row.model.tags}}</td>
               <td data-test-service-onupdate>{{row.model.onUpdate}}</td>
               <td data-test-service-connect>{{if row.model.connect "Yes" "No"}}</td>
               <td data-test-service-upstreams>


### PR DESCRIPTION

for service like [traefik](https://github.com/traefik/traefik), it is easy to break the table ui when specific a middleware config like basic auth.

ref https://doc.traefik.io/traefik/middlewares/http/basicauth/  an example consul catalog tags look like this:

```
traefik.http.middlewares.test-auth.basicauth.users=test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/,test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0
```

![image](https://user-images.githubusercontent.com/41882455/152371487-b7dc61a9-01a7-4cf2-b470-1f9750ae7a2c.png)

with word break css enbled:

![image](https://user-images.githubusercontent.com/41882455/152371596-b3e7f0a1-5834-42ea-8668-a585849d03bc.png)
