### PR TITLE
core: log CSI GC cutoff index only on non-forced GC

### DIFF
--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -767,11 +767,10 @@ func (c *CoreScheduler) csiVolumeClaimGC(eval *structs.Evaluation) error {
 		tt := c.srv.fsm.TimeTable()
 		cutoff := time.Now().UTC().Add(-1 * c.srv.config.CSIVolumeClaimGCThreshold)
 		oldThreshold = tt.NearestIndex(cutoff)
+		c.logger.Debug("CSI volume claim GC scanning before cutoff index",
+			"index", oldThreshold,
+			"csi_volume_claim_gc_threshold", c.srv.config.CSIVolumeClaimGCThreshold)
 	}
-
-	c.logger.Debug("CSI volume claim GC scanning before cutoff index",
-		"index", oldThreshold,
-		"csi_volume_claim_gc_threshold", c.srv.config.CSIVolumeClaimGCThreshold)
 
 	for i := iter.Next(); i != nil; i = iter.Next() {
 		vol := i.(*structs.CSIVolume)
@@ -821,10 +820,9 @@ func (c *CoreScheduler) csiPluginGC(eval *structs.Evaluation) error {
 		tt := c.srv.fsm.TimeTable()
 		cutoff := time.Now().UTC().Add(-1 * c.srv.config.CSIPluginGCThreshold)
 		oldThreshold = tt.NearestIndex(cutoff)
+		c.logger.Debug("CSI plugin GC scanning before cutoff index",
+			"index", oldThreshold, "csi_plugin_gc_threshold", c.srv.config.CSIPluginGCThreshold)
 	}
-
-	c.logger.Debug("CSI plugin GC scanning before cutoff index",
-		"index", oldThreshold, "csi_plugin_gc_threshold", c.srv.config.CSIPluginGCThreshold)
 
 	for i := iter.Next(); i != nil; i = iter.Next() {
 		plugin := i.(*structs.CSIPlugin)


### PR DESCRIPTION
Non-CSI garbage collection tasks on the server only log the cutoff
index in the case where it's not a forced GC from `nomad system gc`.
Do the same for CSI for consistency.

Compare to https://github.com/hashicorp/nomad/blob/v1.2.4/nomad/core_sched.go#L102-L115
Pulled this out of plugin count work to keep review sizes reasonable.