### PR TITLE
add semgrep rule to check for potential time.After leaks

### DIFF
--- a/.semgrep/time_after.yml
+++ b/.semgrep/time_after.yml
@@ -1,0 +1,16 @@
+rules:
+  - id: "time-after-leak"
+    patterns:
+      - pattern: |
+          select {
+          case <- time.After(...): ...
+          }
+    message: "Potential leak of time.Timer, consider using NewSafeTimer instead"
+    languages:
+      - "go"
+    severity: "WARNING"
+    paths:
+      exclude:
+        - "testutil/*"
+        - "*testing.go"
+        - "*_test.go"


### PR DESCRIPTION
As described in #11983, the use of `<- time.After` may lead to memory leaks. This rule check for potential leaks and suggests  using the new `NewSafeTimer` instead.