### PR TITLE
improve error message on service length

### DIFF
--- a/.changelog/12012.txt
+++ b/.changelog/12012.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+consul: improve service name validation message to include maximum length requirement
+```

--- a/client/allocrunner/taskrunner/validate_hook.go
+++ b/client/allocrunner/taskrunner/validate_hook.go
@@ -56,10 +56,10 @@ func validateTask(task *structs.Task, taskEnv *taskenv.TaskEnv, conf *config.Con
 	}
 
 	// Validate the Service names once they're interpolated
-	for i, service := range task.Services {
+	for _, service := range task.Services {
 		name := taskEnv.ReplaceEnv(service.Name)
 		if err := service.ValidateName(name); err != nil {
-			mErr.Errors = append(mErr.Errors, fmt.Errorf("service (%d) failed validation: %v", i, err))
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("service (%s) failed validation: %v", name, err))
 		}
 	}
 

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -545,7 +545,8 @@ func (s *Service) Validate() error {
 	serviceNameStripped := args.ReplaceEnvWithPlaceHolder(s.Name, "ENV-VAR")
 
 	if err := s.ValidateName(serviceNameStripped); err != nil {
-		mErr.Errors = append(mErr.Errors, fmt.Errorf("Service name must be valid per RFC 1123 and can contain only alphanumeric characters or dashes: %q", s.Name))
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("Service name must be valid per RFC 1123 and can contain only alphanumeric characters or dashes and must be no longer than 63 characters: %q",
+			s.Name))
 	}
 
 	switch s.AddressMode {

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -545,8 +545,8 @@ func (s *Service) Validate() error {
 	serviceNameStripped := args.ReplaceEnvWithPlaceHolder(s.Name, "ENV-VAR")
 
 	if err := s.ValidateName(serviceNameStripped); err != nil {
-		mErr.Errors = append(mErr.Errors, fmt.Errorf("Service name must be valid per RFC 1123 and can contain only alphanumeric characters or dashes and must be no longer than 63 characters: %q",
-			s.Name))
+		// Log actual service name, not the stripped version.
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("%v: %q", err, s.Name))
 	}
 
 	switch s.AddressMode {
@@ -608,7 +608,7 @@ func (s *Service) ValidateName(name string) error {
 	// (https://tools.ietf.org/html/rfc2782).
 	re := regexp.MustCompile(`^(?i:[a-z0-9]|[a-z0-9][a-z0-9\-]{0,61}[a-z0-9])$`)
 	if !re.MatchString(name) {
-		return fmt.Errorf("Service name must be valid per RFC 1123 and can contain only alphanumeric characters or dashes and must be no longer than 63 characters: %q", name)
+		return fmt.Errorf("Service name must be valid per RFC 1123 and can contain only alphanumeric characters or dashes and must be no longer than 63 characters")
 	}
 	return nil
 }


### PR DESCRIPTION
Currently if len(service name) > 63, the API incorrectly reports the issue to be "not a valid RFC 1123" misleading the developer. Changed the wording to ensure it reflects the correct logic