### PR TITLE
interpolate network.dns block on client (fixes #11851)

### DIFF
--- a/.changelog/12021.txt
+++ b/.changelog/12021.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client: Allow interpolation of the network.dns block
+```

--- a/client/taskenv/network.go
+++ b/client/taskenv/network.go
@@ -9,6 +9,7 @@ import (
 //
 // Current interoperable fields:
 //   - Hostname
+//   - DNS
 func InterpolateNetworks(taskEnv *TaskEnv, networks structs.Networks) structs.Networks {
 
 	// Guard against not having a valid taskEnv. This can be the case if the
@@ -23,6 +24,11 @@ func InterpolateNetworks(taskEnv *TaskEnv, networks structs.Networks) structs.Ne
 	// Iterate the copy and perform the interpolation.
 	for i := range interpolated {
 		interpolated[i].Hostname = taskEnv.ReplaceEnv(interpolated[i].Hostname)
+		if interpolated[i].DNS != nil {
+			interpolated[i].DNS.Servers = taskEnv.ParseAndReplace(interpolated[i].DNS.Servers)
+			interpolated[i].DNS.Searches = taskEnv.ParseAndReplace(interpolated[i].DNS.Searches)
+			interpolated[i].DNS.Options = taskEnv.ParseAndReplace(interpolated[i].DNS.Options)
+		}
 	}
 
 	return interpolated

--- a/client/taskenv/network_test.go
+++ b/client/taskenv/network_test.go
@@ -39,36 +39,44 @@ func Test_InterpolateNetworks(t *testing.T) {
 			inputNetworks: structs.Networks{
 				{
 					DNS: &structs.DNSConfig{
-						Servers: []string{"127.0.0.1"},
+						Servers:  []string{"127.0.0.1"},
+						Options:  []string{"some-opt"},
+						Searches: []string{"example.com"},
 					},
 				},
 			},
 			expectedOutputNetworks: structs.Networks{
 				{
 					DNS: &structs.DNSConfig{
-						Servers: []string{"127.0.0.1"},
+						Servers:  []string{"127.0.0.1"},
+						Options:  []string{"some-opt"},
+						Searches: []string{"example.com"},
 					},
 				},
 			},
-			name: "non-interpolated dns",
+			name: "non-interpolated dns servers",
 		},
 		{
 			inputTaskEnv: testEnv,
 			inputNetworks: structs.Networks{
 				{
 					DNS: &structs.DNSConfig{
-						Servers: []string{"${foo}"},
+						Servers:  []string{"${foo}"},
+						Options:  []string{"${foo}-opt"},
+						Searches: []string{"${foo}.example.com"},
 					},
 				},
 			},
 			expectedOutputNetworks: structs.Networks{
 				{
 					DNS: &structs.DNSConfig{
-						Servers: []string{"bar"},
+						Servers:  []string{"bar"},
+						Options:  []string{"bar-opt"},
+						Searches: []string{"bar.example.com"},
 					},
 				},
 			},
-			name: "interpolated dns",
+			name: "interpolated dns servers",
 		},
 	}
 

--- a/client/taskenv/network_test.go
+++ b/client/taskenv/network_test.go
@@ -34,6 +34,42 @@ func Test_InterpolateNetworks(t *testing.T) {
 			},
 			name: "interpolated hostname",
 		},
+		{
+			inputTaskEnv: testEnv,
+			inputNetworks: structs.Networks{
+				{
+					DNS: &structs.DNSConfig{
+						Servers: []string{"127.0.0.1"},
+					},
+				},
+			},
+			expectedOutputNetworks: structs.Networks{
+				{
+					DNS: &structs.DNSConfig{
+						Servers: []string{"127.0.0.1"},
+					},
+				},
+			},
+			name: "non-interpolated dns",
+		},
+		{
+			inputTaskEnv: testEnv,
+			inputNetworks: structs.Networks{
+				{
+					DNS: &structs.DNSConfig{
+						Servers: []string{"${foo}"},
+					},
+				},
+			},
+			expectedOutputNetworks: structs.Networks{
+				{
+					DNS: &structs.DNSConfig{
+						Servers: []string{"bar"},
+					},
+				},
+			},
+			name: "interpolated dns",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/website/content/docs/job-specification/network.mdx
+++ b/website/content/docs/job-specification/network.mdx
@@ -120,6 +120,8 @@ The label of the port is just text - it has no special meaning to Nomad.
 - `searches` `(array<string>: nil)` - Sets the search list for hostname lookup
 - `options` `(array<string>: nil)` - Sets internal resolver variables.
 
+These parameters support [interpolation](/docs/runtime/interpolation).
+
 ## `network` Examples
 
 The following examples only show the `network` stanzas. Remember that the


### PR DESCRIPTION
This implements client side interpolation of the network.dns block to fix #11851.

Unit tests, changelog entry, and website docs have been added/updated.