### PR TITLE
fingerprint: digitalocean fingerprint test requires metadata header

### DIFF
--- a/client/fingerprint/env_digitalocean.go
+++ b/client/fingerprint/env_digitalocean.go
@@ -73,6 +73,7 @@ func (f *EnvDigitalOceanFingerprint) Get(attribute string, format string) (strin
 		URL:    parsedURL,
 		Header: http.Header{
 			"User-Agent": []string{useragent.String()},
+			"Metadata":   []string{"true"},
 		},
 	}
 


### PR DESCRIPTION
Fixes the unit tests on `main`, which for some reason didn't run for https://github.com/hashicorp/nomad/pull/12015

This PR should fix the broken test, but that being said @kevinschoonover I'm not sure I understand where the test requirement for that header is coming from. I don't see anything about that in the DO docs: https://docs.digitalocean.com/reference/api/metadata-api/