### PR TITLE
fingerprint: remove metadata from digitalocean

### DIFF
--- a/client/fingerprint/env_digitalocean.go
+++ b/client/fingerprint/env_digitalocean.go
@@ -73,7 +73,6 @@ func (f *EnvDigitalOceanFingerprint) Get(attribute string, format string) (strin
 		URL:    parsedURL,
 		Header: http.Header{
 			"User-Agent": []string{useragent.String()},
-			"Metadata":   []string{"true"},
 		},
 	}
 

--- a/client/fingerprint/env_digitalocean_test.go
+++ b/client/fingerprint/env_digitalocean_test.go
@@ -50,14 +50,6 @@ func TestFingerprint_DigitalOcean(t *testing.T) {
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		value, ok := r.Header["Metadata"]
-		if !ok {
-			t.Fatal("Metadata not present in HTTP request header")
-		}
-		if value[0] != "true" {
-			t.Fatalf("Expected Metadata true, saw %s", value[0])
-		}
-
 		uavalue, ok := r.Header["User-Agent"]
 		if !ok {
 			t.Fatal("User-Agent not present in HTTP request header")


### PR DESCRIPTION
follow up to #12028.

Feel free to close this as noise as I'm not sure if this PR is necessary, but wanted to try to address the comments on #12028 since metadata was a remanent of me copying the GCE fingerprinter and is not necessary / used.


ran the tests locally:
```console
 > pwd
./nomad/client/fingerprint
> go test
PASS
ok  	github.com/hashicorp/nomad/client/fingerprint	0.875s
```
