### PR TITLE
reconciler: refactor `computeGroup`

### DIFF
--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -412,22 +412,16 @@ func (s *GenericScheduler) computeJobAllocs() error {
 		return nil
 	}
 
-	// Record the number of allocations that needs to be placed per Task Group
-	for _, place := range results.place {
-		s.queuedAllocs[place.taskGroup.Name] += 1
-	}
-	for _, destructive := range results.destructiveUpdate {
-		s.queuedAllocs[destructive.placeTaskGroup.Name] += 1
-	}
-
 	// Compute the placements
 	place := make([]placementResult, 0, len(results.place))
 	for _, p := range results.place {
+		s.queuedAllocs[p.taskGroup.Name] += 1
 		place = append(place, p)
 	}
 
 	destructive := make([]placementResult, 0, len(results.destructiveUpdate))
 	for _, p := range results.destructiveUpdate {
+		s.queuedAllocs[p.placeTaskGroup.Name] += 1
 		destructive = append(destructive, p)
 	}
 	return s.computePlacements(destructive, place)

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -398,7 +398,7 @@ func (a *allocReconciler) computeGroup(groupName string, all allocSet) bool {
 
 	// Create batched follow up evaluations for allocations that are
 	// reschedulable later and mark the allocations for in place updating
-	a.processReschedulerLater(rescheduleLater, all, tg.Name)
+	a.processRescheduleLater(rescheduleLater, all, tg.Name)
 
 	// Create a structure for choosing names. Seed with the taken names
 	// which is the union of untainted, rescheduled, allocs on migrating
@@ -982,10 +982,10 @@ func (a *allocReconciler) computeUpdates(group *structs.TaskGroup, untainted all
 	return
 }
 
-// processReschedulerLater creates batched followup evaluations with the WaitUntil field
+// processRescheduleLater creates batched followup evaluations with the WaitUntil field
 // set for allocations that are eligible to be rescheduled later, and marks the alloc with
 // the followupEvalID
-func (a *allocReconciler) processReschedulerLater(rescheduleLater []*delayedRescheduleInfo, all allocSet, tgName string) {
+func (a *allocReconciler) processRescheduleLater(rescheduleLater []*delayedRescheduleInfo, all allocSet, tgName string) {
 	// followupEvals are created in the same way as for delayed lost allocs
 	allocIDToFollowupEvalID := a.processLostLaterEvals(rescheduleLater, all, tgName)
 

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -331,7 +331,7 @@ func (a *allocReconciler) stopAllocSet(set allocSet) uint64 {
 	a.markStop(untainted, "", allocNotNeeded)
 	a.markStop(migrate, "", allocNotNeeded)
 	a.markStop(lost, structs.AllocClientStatusLost, allocLost)
-	return uint64(len(untainted) + len(migrate) + len(lost))
+	return uint64(len(set))
 }
 
 // markStop is a helper for marking a set of allocation for stop with a

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -394,11 +394,11 @@ func (a *allocReconciler) computeGroup(groupName string, all allocSet) bool {
 
 	// Find delays for any lost allocs that have stop_after_client_disconnect
 	lostLater := lost.delayByStopAfterClientDisconnect()
-	lostLaterEvals := a.processLostLaterEvals(lostLater, all, tg.Name)
+	lostLaterEvals := a.createLostLaterEvals(lostLater, all, tg.Name)
 
 	// Create batched follow up evaluations for allocations that are
 	// reschedulable later and mark the allocations for in place updating
-	a.processRescheduleLater(rescheduleLater, all, tg.Name)
+	a.createRescheduleLaterEvals(rescheduleLater, all, tg.Name)
 
 	// Create a structure for choosing names. Seed with the taken names
 	// which is the union of untainted, rescheduled, allocs on migrating
@@ -982,12 +982,12 @@ func (a *allocReconciler) computeUpdates(group *structs.TaskGroup, untainted all
 	return
 }
 
-// processRescheduleLater creates batched followup evaluations with the WaitUntil field
+// createRescheduleLaterEvals creates batched followup evaluations with the WaitUntil field
 // set for allocations that are eligible to be rescheduled later, and marks the alloc with
 // the followupEvalID
-func (a *allocReconciler) processRescheduleLater(rescheduleLater []*delayedRescheduleInfo, all allocSet, tgName string) {
+func (a *allocReconciler) createRescheduleLaterEvals(rescheduleLater []*delayedRescheduleInfo, all allocSet, tgName string) {
 	// followupEvals are created in the same way as for delayed lost allocs
-	allocIDToFollowupEvalID := a.processLostLaterEvals(rescheduleLater, all, tgName)
+	allocIDToFollowupEvalID := a.createLostLaterEvals(rescheduleLater, all, tgName)
 
 	// Create updates that will be applied to the allocs to mark the FollowupEvalID
 	for allocID, evalID := range allocIDToFollowupEvalID {
@@ -998,10 +998,10 @@ func (a *allocReconciler) processRescheduleLater(rescheduleLater []*delayedResch
 	}
 }
 
-// processLostLaterEvals creates batched followup evaluations with the WaitUntil field set for
+// createLostLaterEvals creates batched followup evaluations with the WaitUntil field set for
 // lost allocations. followupEvals are appended to a.result as a side effect, we return a
 // map of alloc IDs to their followupEval IDs.
-func (a *allocReconciler) processLostLaterEvals(rescheduleLater []*delayedRescheduleInfo, all allocSet, tgName string) map[string]string {
+func (a *allocReconciler) createLostLaterEvals(rescheduleLater []*delayedRescheduleInfo, all allocSet, tgName string) map[string]string {
 	if len(rescheduleLater) == 0 {
 		return map[string]string{}
 	}

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -451,43 +451,7 @@ func (a *allocReconciler) computeGroup(groupName string, all allocSet) bool {
 	// placements can be made without any other consideration.
 	deploymentPlaceReady := !a.deploymentPaused && !a.deploymentFailed && !isCanarying
 
-	if deploymentPlaceReady {
-		desiredChanges.Place += uint64(len(place))
-		a.result.place = append(a.result.place, place...)
-		a.markStop(rescheduleNow, "", allocRescheduled)
-		desiredChanges.Stop += uint64(len(rescheduleNow))
-
-		min := helper.IntMin(len(place), underProvisionedBy)
-		underProvisionedBy -= min
-	} else if !deploymentPlaceReady {
-		// We do not want to place additional allocations but in the case we
-		// have lost allocations or allocations that require rescheduling now,
-		// we do so regardless to avoid odd user experiences.
-		if len(lost) != 0 {
-			allowed := helper.IntMin(len(lost), len(place))
-			desiredChanges.Place += uint64(allowed)
-			a.result.place = append(a.result.place, place[:allowed]...)
-		}
-
-		// Handle rescheduling of failed allocations even if the deployment is
-		// failed. We do not reschedule if the allocation is part of the failed
-		// deployment.
-		if now := len(rescheduleNow); now != 0 {
-			for _, p := range place {
-				prev := p.PreviousAllocation()
-				if p.IsRescheduling() && !(a.deploymentFailed && prev != nil && a.deployment.ID == prev.DeploymentID) {
-					a.result.place = append(a.result.place, p)
-					desiredChanges.Place++
-
-					a.result.stop = append(a.result.stop, allocStopResult{
-						alloc:             prev,
-						statusDescription: allocRescheduled,
-					})
-					desiredChanges.Stop++
-				}
-			}
-		}
-	}
+	underProvisionedBy = a.computeReplacements(deploymentPlaceReady, desiredChanges, place, rescheduleNow, lost, underProvisionedBy)
 
 	if deploymentPlaceReady {
 		// Do all destructive updates
@@ -806,6 +770,65 @@ func (a *allocReconciler) computePlacements(group *structs.TaskGroup,
 	}
 
 	return place
+}
+
+// computeReplacements either applies the placements calculated by computePlacements,
+// or computes more placements based on whether the deployment is ready for placement
+// and if the placement is already rescheduling or part of a failed deployment.
+// The input deploymentPlaceReady is calculated as the deployment is not paused, failed, or canarying
+// The following rules are applied:
+// * If the deployment is place ready, apply all placements and return
+// * If not place ready, check if any allocs have been lost
+// * If allocs have been lost, determine the number of replacements that are needed.
+// * Add placements to the result for the lost allocs.
+// * If there are failed allocations, inspect them.
+// * If the placement is rescheduling, and not part of a failed deployment, add
+//   to the place set, and add the previous alloc to the stop set.
+// * Return the number of allocs still needed.
+func (a *allocReconciler) computeReplacements(deploymentPlaceReady bool, desiredChanges *structs.DesiredUpdates,
+	place []allocPlaceResult, rescheduleNow, lost allocSet, underProvisionedBy int) int {
+
+	if deploymentPlaceReady {
+		desiredChanges.Place += uint64(len(place))
+		// This relies on the computePlacements having built this set, which in
+		// turn relies on len(lostLater) == 0.
+		a.result.place = append(a.result.place, place...)
+		a.markStop(rescheduleNow, "", allocRescheduled)
+		desiredChanges.Stop += uint64(len(rescheduleNow))
+
+		min := helper.IntMin(len(place), underProvisionedBy)
+		underProvisionedBy -= min
+	} else if !deploymentPlaceReady {
+		// We do not want to place additional allocations but in the case we
+		// have lost allocations or allocations that require rescheduling now,
+		// we do so regardless to avoid odd user experiences.
+		if len(lost) != 0 {
+			allowed := helper.IntMin(len(lost), len(place))
+			desiredChanges.Place += uint64(allowed)
+			a.result.place = append(a.result.place, place[:allowed]...)
+		}
+
+		// Handle rescheduling of failed allocations even if the deployment is
+		// failed. We do not reschedule if the allocation is part of the failed
+		// deployment.
+		if now := len(rescheduleNow); now != 0 {
+			for _, p := range place {
+				prev := p.PreviousAllocation()
+				if p.IsRescheduling() && !(a.deploymentFailed && prev != nil && a.deployment.ID == prev.DeploymentID) {
+					a.result.place = append(a.result.place, p)
+					desiredChanges.Place++
+
+					a.result.stop = append(a.result.stop, allocStopResult{
+						alloc:             prev,
+						statusDescription: allocRescheduled,
+					})
+					desiredChanges.Stop++
+				}
+			}
+		}
+	}
+
+	return underProvisionedBy
 }
 
 // computeStop returns the set of allocations that are marked for stopping given

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -593,7 +593,6 @@ func (a *allocReconciler) cancelUnneededCanaries(all allocSet, desiredChanges *s
 // computeUnderProvisionedBy returns the number of allocs that still need to be
 // placed for a particular group. The inputs are the group definition, the untainted,
 // destructive, and migrate allocation sets, and whether we are in a canary state.
-// This function
 func (a *allocReconciler) computeUnderProvisionedBy(group *structs.TaskGroup, untainted, destructive, migrate allocSet, isCanarying bool) int {
 	// If no update strategy, nothing is migrating, and nothing is being replaced,
 	// allow as many as defined in group.Count
@@ -796,10 +795,6 @@ func (a *allocReconciler) computeMigrations(desiredChanges *structs.DesiredUpdat
 func (a *allocReconciler) createDeployment(groupName string, strategy *structs.UpdateStrategy,
 	existingDeployment bool, dstate *structs.DeploymentState, all, destructive allocSet) {
 	// Guard the simple cases that require no computation first.
-	// Don't create a deployment if:
-	// 1. There is an existing deployment
-	// 2. There is no update strategy defined
-	// 3. The deployment state doesn't specify we want any allocs
 	if existingDeployment ||
 		strategy.IsEmpty() ||
 		dstate.DesiredTotal == 0 {

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -478,7 +478,7 @@ func bitmapFrom(input allocSet, minSize uint) structs.Bitmap {
 	return bitmap
 }
 
-// RemoveHighest removes and returns the highest n used names. The returned set
+// Highest removes and returns the highest n used names. The returned set
 // can be less than n if there aren't n names set in the index
 func (a *allocNameIndex) Highest(n uint) map[string]struct{} {
 	h := make(map[string]struct{}, n)

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -413,6 +413,17 @@ func (a allocSet) delayByStopAfterClientDisconnect() (later []*delayedReschedule
 	return later
 }
 
+// An allocSet is unhealthy if any members have an unhealthy deployment status.
+func (a allocSet) isUnhealthy(deploymentID string) bool {
+	partOf, _ := a.filterByDeployment(deploymentID)
+	for _, alloc := range partOf {
+		if alloc.DeploymentStatus.IsUnhealthy() {
+			return true
+		}
+	}
+	return false
+}
+
 // allocNameIndex is used to select allocation names for placement or removal
 // given an existing set of placed allocations.
 type allocNameIndex struct {

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -413,17 +413,6 @@ func (a allocSet) delayByStopAfterClientDisconnect() (later []*delayedReschedule
 	return later
 }
 
-// An allocSet is unhealthy if any members have an unhealthy deployment status.
-func (a allocSet) isUnhealthy(deploymentID string) bool {
-	partOf, _ := a.filterByDeployment(deploymentID)
-	for _, alloc := range partOf {
-		if alloc.DeploymentStatus.IsUnhealthy() {
-			return true
-		}
-	}
-	return false
-}
-
 // allocNameIndex is used to select allocation names for placement or removal
 // given an existing set of placed allocations.
 type allocNameIndex struct {


### PR DESCRIPTION
**This PR contains the following:**

- Refactored `allocReconciler.computeGroup` - extracted inline logic to a series of intention-revealing functions.
- Combined iteration logic in `GenericScheduler`.
- Added or improved comments throughout.
