### PR TITLE
docs: revert 1.3.0 upgrade specific instructions

### DIFF
--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -13,18 +13,6 @@ upgrade. However, specific versions of Nomad may have more details provided for
 their upgrades as a result of new features or changed behavior. This page is
 used to document those details separately from the standard upgrade flow.
 
-## Nomad 1.3.0
-
-#### Raft Protocol Version 2 Deprecation
-
-Raft protocol version 2 will be removed from Nomad in the next major
-release of Nomad, 1.4.0.
-
-In Nomad 1.3.0, the default raft protocol version has been updated to
-3. If the [`raft_protocol_version`] is not explicitly set, upgrading a
-server will automatically upgrade that server's raft protocol. See the
-[Upgrading to Raft Protocol 3] guide.
-
 ## Nomad 1.2.6, 1.1.12, and 1.0.18
 
 #### ACL requirement for the job parse endpoint


### PR DESCRIPTION
These instructions were pushed to `stable-website` unintentionally. 