### PR TITLE
csi: provide `CSI_ENDPOINT` env var to plugins

### DIFF
--- a/.changelog/12050.txt
+++ b/.changelog/12050.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: provide `CSI_ENDPOINT` environment variable to plugin tasks
+```

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -72,7 +72,7 @@ func (tr *TaskRunner) initHooks() {
 
 	// If the task has a CSI stanza, add the hook.
 	if task.CSIPluginConfig != nil {
-		tr.runnerHooks = append(tr.runnerHooks, newCSIPluginSupervisorHook(filepath.Join(tr.clientConfig.StateDir, "csi"), tr, tr, hookLogger))
+		tr.runnerHooks = append(tr.runnerHooks, newCSIPluginSupervisorHook(filepath.Join(tr.clientConfig.StateDir, "csi"), tr, tr, tr.driverCapabilities, hookLogger))
 	}
 
 	// If Vault is enabled, add the hook

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -3,7 +3,6 @@ package taskrunner
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -72,7 +71,14 @@ func (tr *TaskRunner) initHooks() {
 
 	// If the task has a CSI stanza, add the hook.
 	if task.CSIPluginConfig != nil {
-		tr.runnerHooks = append(tr.runnerHooks, newCSIPluginSupervisorHook(filepath.Join(tr.clientConfig.StateDir, "csi"), tr, tr, tr.driverCapabilities, hookLogger))
+		tr.runnerHooks = append(tr.runnerHooks, newCSIPluginSupervisorHook(
+			&csiPluginSupervisorHookConfig{
+				clientStateDirPath: tr.clientConfig.StateDir,
+				events:             tr,
+				runner:             tr,
+				capabilities:       tr.driverCapabilities,
+				logger:             hookLogger,
+			}))
 	}
 
 	// If Vault is enabled, add the hook


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11874 The CSI specification says:
> The CO SHALL provide the listen-address for the Plugin by way of the `CSI_ENDPOINT` environment variable.

Note that plugins without filesystem isolation won't have the plugin dir bind-mounted to their alloc dir, but we can provide a path to the socket anyways. These still won't quite work until https://github.com/hashicorp/nomad/issues/11885 is complete.

I've also refactored to use an options struct for the plugin supervisor hook config. The parameter list was getting out of control and we use this pattern for similar task runner hooks (ex. template). That's in a second commit.
