### PR TITLE
CSI: volume cli prefix matching should accept exact match

### DIFF
--- a/.changelog/12051.txt
+++ b/.changelog/12051.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: fixed a bug where `volume detach`, `volume deregister`, and `volume status` commands did not accept an exact ID if multiple volumes matched the prefix
+```

--- a/command/volume_deregister.go
+++ b/command/volume_deregister.go
@@ -99,19 +99,21 @@ func (c *VolumeDeregisterCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error querying volumes: %s", err))
 		return 1
 	}
-	if len(vols) > 1 {
-		sort.Slice(vols, func(i, j int) bool { return vols[i].ID < vols[j].ID })
-		out, err := csiFormatSortedVolumes(vols, fullId)
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error formatting: %s", err))
-			return 1
-		}
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple volumes\n\n%s", out))
-		return 1
-	}
 	if len(vols) == 0 {
 		c.Ui.Error(fmt.Sprintf("No volumes(s) with prefix or ID %q found", volID))
 		return 1
+	}
+	if len(vols) > 1 {
+		if (volID != vols[0].ID) || (c.allNamespaces() && vols[0].ID == vols[1].ID) {
+			sort.Slice(vols, func(i, j int) bool { return vols[i].ID < vols[j].ID })
+			out, err := csiFormatSortedVolumes(vols, fullId)
+			if err != nil {
+				c.Ui.Error(fmt.Sprintf("Error formatting: %s", err))
+				return 1
+			}
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple volumes\n\n%s", out))
+			return 1
+		}
 	}
 	volID = vols[0].ID
 

--- a/command/volume_detach.go
+++ b/command/volume_detach.go
@@ -121,19 +121,21 @@ func (c *VolumeDetachCommand) Run(args []string) int {
 			c.Ui.Error(fmt.Sprintf("Error querying volumes: %s", err))
 			return 1
 		}
-		if len(vols) > 1 {
-			sort.Slice(vols, func(i, j int) bool { return vols[i].ID < vols[j].ID })
-			out, err := csiFormatSortedVolumes(vols, fullId)
-			if err != nil {
-				c.Ui.Error(fmt.Sprintf("Error formatting: %s", err))
-				return 1
-			}
-			c.Ui.Error(fmt.Sprintf("Prefix matched multiple volumes\n\n%s", out))
-			return 1
-		}
 		if len(vols) == 0 {
 			c.Ui.Error(fmt.Sprintf("No volumes(s) with prefix or ID %q found", volID))
 			return 1
+		}
+		if len(vols) > 1 {
+			if (volID != vols[0].ID) || (c.allNamespaces() && vols[0].ID == vols[1].ID) {
+				sort.Slice(vols, func(i, j int) bool { return vols[i].ID < vols[j].ID })
+				out, err := csiFormatSortedVolumes(vols, fullId)
+				if err != nil {
+					c.Ui.Error(fmt.Sprintf("Error formatting: %s", err))
+					return 1
+				}
+				c.Ui.Error(fmt.Sprintf("Prefix matched multiple volumes\n\n%s", out))
+				return 1
+			}
 		}
 		volID = vols[0].ID
 

--- a/command/volume_status_csi.go
+++ b/command/volume_status_csi.go
@@ -29,18 +29,20 @@ func (c *VolumeStatusCommand) csiStatus(client *api.Client, id string) int {
 		c.Ui.Error(fmt.Sprintf("Error querying volumes: %s", err))
 		return 1
 	}
-	if len(vols) > 1 {
-		out, err := c.csiFormatVolumes(vols)
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error formatting: %s", err))
-			return 1
-		}
-		c.Ui.Error(fmt.Sprintf("Prefix matched multiple volumes\n\n%s", out))
-		return 1
-	}
 	if len(vols) == 0 {
 		c.Ui.Error(fmt.Sprintf("No volumes(s) with prefix or ID %q found", id))
 		return 1
+	}
+	if len(vols) > 1 {
+		if (id != vols[0].ID) || (c.allNamespaces() && vols[0].ID == vols[1].ID) {
+			out, err := c.csiFormatVolumes(vols)
+			if err != nil {
+				c.Ui.Error(fmt.Sprintf("Error formatting: %s", err))
+				return 1
+			}
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple volumes\n\n%s", out))
+			return 1
+		}
 	}
 	id = vols[0].ID
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/12005

The `volume detach`, `volume deregister`, and `volume status` commands
accept a prefix argument for the volume ID. Update the behavior on
exact matches so that if there is more than one volume that matches
the prefix, we should only return an error if one of the volume IDs is
not an exact match. Otherwise we won't be able to use these commands
at all on those volumes. This also makes the behavior of these commands
consistent with `job stop`.