### PR TITLE
doc(typo): technical typo in advertised example

### DIFF
--- a/website/content/docs/job-specification/hcl2/index.mdx
+++ b/website/content/docs/job-specification/hcl2/index.mdx
@@ -157,7 +157,7 @@ Or better yet, the new [`mount`](/docs/drivers/docker#mount) syntax, introduced 
 ```hcl
 mount {
   type = "tmpfs"
-  tmpf_options {
+  tmpfs_options {
     size = 10000
   }
 }


### PR DESCRIPTION
I came upon this error in one of your example of code in the docs.