### PR TITLE
reconciler: support disconnected clients

### DIFF
--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -344,6 +344,29 @@ func CopyMapStringInterface(m map[string]interface{}) map[string]interface{} {
 	return c
 }
 
+// MergeMapStringString will merge two maps into one. If a duplicate key exists
+// the value in the second map will replace the value in the first map. If both
+// maps are nil this returns an empty map.
+func MergeMapStringString(m map[string]string, n map[string]string) map[string]string {
+	if len(m) == 0 && len(n) == 0 {
+		return map[string]string{}
+	}
+	if len(m) == 0 {
+		return n
+	}
+	if len(n) == 0 {
+		return m
+	}
+
+	result := CopyMapStringString(m)
+
+	for k, v := range n {
+		result[k] = v
+	}
+
+	return result
+}
+
 func CopyMapStringInt(m map[string]int) map[string]int {
 	l := len(m)
 	if l == 0 {

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -346,7 +346,7 @@ func CopyMapStringInterface(m map[string]interface{}) map[string]interface{} {
 
 // MergeMapStringString will merge two maps into one. If a duplicate key exists
 // the value in the second map will replace the value in the first map. If both
-// maps are nil this returns an empty map.
+// maps are empty or nil this returns an empty map.
 func MergeMapStringString(m map[string]string, n map[string]string) map[string]string {
 	if len(m) == 0 && len(n) == 0 {
 		return map[string]string{}

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -196,6 +196,27 @@ func TestCopyMapSliceInterface(t *testing.T) {
 	require.False(t, reflect.DeepEqual(m, c))
 }
 
+func TestMergeMapStringString(t *testing.T) {
+	type testCase struct {
+		map1     map[string]string
+		map2     map[string]string
+		expected map[string]string
+	}
+
+	cases := []testCase{
+		{map[string]string{"foo": "bar"}, map[string]string{"baz": "qux"}, map[string]string{"foo": "bar", "baz": "qux"}},
+		{map[string]string{"foo": "bar"}, nil, map[string]string{"foo": "bar"}},
+		{nil, map[string]string{"baz": "qux"}, map[string]string{"baz": "qux"}},
+		{nil, nil, map[string]string{}},
+	}
+
+	for _, c := range cases {
+		if output := MergeMapStringString(c.map1, c.map2); !CompareMapStringString(output, c.expected) {
+			t.Errorf("MergeMapStringString(%q, %q) -> %q != %q", c.map1, c.map2, output, c.expected)
+		}
+	}
+}
+
 func TestCleanEnvVar(t *testing.T) {
 	type testCase struct {
 		input    string

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3308,9 +3308,10 @@ func (s *StateStore) upsertAllocsImpl(index uint64, allocs []*structs.Allocation
 			// Keep the clients task states
 			alloc.TaskStates = exist.TaskStates
 
-			// If the scheduler is marking this allocation as lost we do not
+			// If the scheduler is marking this allocation as lost or unknown we do not
 			// want to reuse the status of the existing allocation.
-			if alloc.ClientStatus != structs.AllocClientStatusLost {
+			if alloc.ClientStatus != structs.AllocClientStatusLost &&
+				alloc.ClientStatus != structs.AllocClientStatusUnknown {
 				alloc.ClientStatus = exist.ClientStatus
 				alloc.ClientDescription = exist.ClientDescription
 			}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10939,15 +10939,9 @@ func (p *Plan) AppendPreemptedAlloc(alloc *Allocation, preemptingAllocID string)
 
 // AppendUnknownAlloc marks an allocation as unknown.
 func (p *Plan) AppendUnknownAlloc(alloc *Allocation) {
-	// TODO (derek): review this with Tim
-
-	// Already created a copy in reconiler
-	//newAlloc := new(Allocation)
-	//*newAlloc = *alloc
-
-	// Not sure if these should be set to nil
+	// Strip the job as it's set once on the ApplyPlanResultRequest.
 	alloc.Job = nil
-	// Strip the resources as it can be rebuilt.
+	// Strip the resources as they can be rebuilt.
 	alloc.Resources = nil
 
 	existing := p.NodeAllocation[alloc.NodeID]

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9732,6 +9732,10 @@ func (a *Allocation) WaitClientStop() time.Time {
 // DisconnectTimeout uses the MaxClientDisconnect to compute when the allocation
 // should transition to lost.
 func (a *Allocation) DisconnectTimeout(now time.Time) time.Time {
+	if a == nil || a.Job == nil {
+		return now
+	}
+
 	tg := a.Job.LookupTaskGroup(a.TaskGroup)
 
 	// Prefer the duration from the task group.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -24,8 +24,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/nomad/helper/escapingfs"
 	"golang.org/x/crypto/blake2b"
+
+	"github.com/hashicorp/nomad/helper/escapingfs"
 
 	"github.com/hashicorp/cronexpr"
 	"github.com/hashicorp/go-msgpack/codec"
@@ -1698,16 +1699,17 @@ func (ne *NodeEvent) AddDetail(k, v string) *NodeEvent {
 }
 
 const (
-	NodeStatusInit  = "initializing"
-	NodeStatusReady = "ready"
-	NodeStatusDown  = "down"
+	NodeStatusInit         = "initializing"
+	NodeStatusReady        = "ready"
+	NodeStatusDown         = "down"
+	NodeStatusDisconnected = "disconnected"
 )
 
 // ShouldDrainNode checks if a given node status should trigger an
 // evaluation. Some states don't require any further action.
 func ShouldDrainNode(status string) bool {
 	switch status {
-	case NodeStatusInit, NodeStatusReady:
+	case NodeStatusInit, NodeStatusReady, NodeStatusDisconnected:
 		return false
 	case NodeStatusDown:
 		return true
@@ -1719,7 +1721,7 @@ func ShouldDrainNode(status string) bool {
 // ValidNodeStatus is used to check if a node status is valid
 func ValidNodeStatus(status string) bool {
 	switch status {
-	case NodeStatusInit, NodeStatusReady, NodeStatusDown:
+	case NodeStatusInit, NodeStatusReady, NodeStatusDown, NodeStatusDisconnected:
 		return true
 	default:
 		return false
@@ -6084,6 +6086,10 @@ type TaskGroup struct {
 	// StopAfterClientDisconnect, if set, configures the client to stop the task group
 	// after this duration since the last known good heartbeat
 	StopAfterClientDisconnect *time.Duration
+
+	// MaxClientDisconnect, if set, configures the client to allow placed
+	// allocations for tasks in this group to attempt to resume running without a restart.
+	MaxClientDisconnect *time.Duration
 }
 
 func (tg *TaskGroup) Copy() *TaskGroup {
@@ -9300,6 +9306,7 @@ const (
 	AllocClientStatusComplete = "complete"
 	AllocClientStatusFailed   = "failed"
 	AllocClientStatusLost     = "lost"
+	AllocClientStatusUnknown  = "unknown"
 )
 
 // Allocation is used to allocate the placement of a task group to a node.
@@ -9721,6 +9728,22 @@ func (a *Allocation) WaitClientStop() time.Time {
 	}
 
 	return t.Add(*tg.StopAfterClientDisconnect + kill)
+}
+
+// DisconnectTimeout uses the MaxClientDisconnect to compute when the allocation
+// should transition to lost.
+func (a *Allocation) DisconnectTimeout(now time.Time) time.Time {
+	tg := a.Job.LookupTaskGroup(a.TaskGroup)
+
+	// Prefer the duration from the task group.
+	timeout := tg.MaxClientDisconnect
+
+	// If not configured, return now
+	if timeout == nil {
+		return now
+	}
+
+	return now.Add(*timeout)
 }
 
 // NextDelay returns a duration after which the allocation can be rescheduled.
@@ -10223,6 +10246,28 @@ func (a *AllocMetric) PopulateScoreMetaData() {
 	}
 }
 
+// MaxNormScore returns the ScoreMetaData entry with the highest normalized
+// score.
+func (a *AllocMetric) MaxNormScore() *NodeScoreMeta {
+	if a == nil || len(a.ScoreMetaData) == 0 {
+		return nil
+	}
+
+	var maxNormScore *NodeScoreMeta
+	for _, scoreMetaData := range a.ScoreMetaData {
+		if maxNormScore == nil {
+			maxNormScore = scoreMetaData
+			continue
+		}
+
+		if scoreMetaData.NormScore > maxNormScore.NormScore {
+			maxNormScore = scoreMetaData
+		}
+	}
+
+	return maxNormScore
+}
+
 // NodeScoreMeta captures scoring meta data derived from
 // different scoring factors.
 type NodeScoreMeta struct {
@@ -10351,21 +10396,22 @@ const (
 )
 
 const (
-	EvalTriggerJobRegister       = "job-register"
-	EvalTriggerJobDeregister     = "job-deregister"
-	EvalTriggerPeriodicJob       = "periodic-job"
-	EvalTriggerNodeDrain         = "node-drain"
-	EvalTriggerNodeUpdate        = "node-update"
-	EvalTriggerAllocStop         = "alloc-stop"
-	EvalTriggerScheduled         = "scheduled"
-	EvalTriggerRollingUpdate     = "rolling-update"
-	EvalTriggerDeploymentWatcher = "deployment-watcher"
-	EvalTriggerFailedFollowUp    = "failed-follow-up"
-	EvalTriggerMaxPlans          = "max-plan-attempts"
-	EvalTriggerRetryFailedAlloc  = "alloc-failure"
-	EvalTriggerQueuedAllocs      = "queued-allocs"
-	EvalTriggerPreemption        = "preemption"
-	EvalTriggerScaling           = "job-scaling"
+	EvalTriggerJobRegister          = "job-register"
+	EvalTriggerJobDeregister        = "job-deregister"
+	EvalTriggerPeriodicJob          = "periodic-job"
+	EvalTriggerNodeDrain            = "node-drain"
+	EvalTriggerNodeUpdate           = "node-update"
+	EvalTriggerAllocStop            = "alloc-stop"
+	EvalTriggerScheduled            = "scheduled"
+	EvalTriggerRollingUpdate        = "rolling-update"
+	EvalTriggerDeploymentWatcher    = "deployment-watcher"
+	EvalTriggerFailedFollowUp       = "failed-follow-up"
+	EvalTriggerMaxPlans             = "max-plan-attempts"
+	EvalTriggerRetryFailedAlloc     = "alloc-failure"
+	EvalTriggerQueuedAllocs         = "queued-allocs"
+	EvalTriggerPreemption           = "preemption"
+	EvalTriggerScaling              = "job-scaling"
+	EvalTriggerMaxDisconnectTimeout = "max-disconnect-timeout"
 )
 
 const (
@@ -10467,7 +10513,8 @@ type Evaluation struct {
 	Wait time.Duration
 
 	// WaitUntil is the time when this eval should be run. This is used to
-	// supported delayed rescheduling of failed allocations
+	// supported delayed rescheduling of failed allocations, and delayed
+	// stopping of allocations that are configured with resume_after_client_reconnect.
 	WaitUntil time.Time
 
 	// NextEval is the evaluation ID for the eval created to do a followup.
@@ -10902,6 +10949,23 @@ func (p *Plan) AppendPreemptedAlloc(alloc *Allocation, preemptingAllocID string)
 	node := alloc.NodeID
 	existing := p.NodePreemptions[node]
 	p.NodePreemptions[node] = append(existing, newAlloc)
+}
+
+// AppendUnknownAlloc marks an allocation as unknown.
+func (p *Plan) AppendUnknownAlloc(alloc *Allocation) {
+	// TODO (derek): review this with Tim
+
+	// Already created a copy in reconiler
+	//newAlloc := new(Allocation)
+	//*newAlloc = *alloc
+
+	// Not sure if these should be set to nil
+	alloc.Job = nil
+	// Strip the resources as it can be rebuilt.
+	alloc.Resources = nil
+
+	existing := p.NodeAllocation[alloc.NodeID]
+	p.NodeAllocation[alloc.NodeID] = append(existing, alloc)
 }
 
 func (p *Plan) PopUpdate(alloc *Allocation) {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -24,9 +24,8 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/crypto/blake2b"
-
 	"github.com/hashicorp/nomad/helper/escapingfs"
+	"golang.org/x/crypto/blake2b"
 
 	"github.com/hashicorp/cronexpr"
 	"github.com/hashicorp/go-msgpack/codec"
@@ -10252,20 +10251,7 @@ func (a *AllocMetric) MaxNormScore() *NodeScoreMeta {
 	if a == nil || len(a.ScoreMetaData) == 0 {
 		return nil
 	}
-
-	var maxNormScore *NodeScoreMeta
-	for _, scoreMetaData := range a.ScoreMetaData {
-		if maxNormScore == nil {
-			maxNormScore = scoreMetaData
-			continue
-		}
-
-		if scoreMetaData.NormScore > maxNormScore.NormScore {
-			maxNormScore = scoreMetaData
-		}
-	}
-
-	return maxNormScore
+	return a.ScoreMetaData[0]
 }
 
 // NodeScoreMeta captures scoring meta data derived from

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -6420,9 +6420,8 @@ func TestServiceSched_Client_Disconnect_Creates_Updates_and_Evals(t *testing.T) 
 	require.NotEmpty(t, followUpEval.WaitUntil)
 
 	// Insert eval in the state store
-	ws := memdb.NewWatchSet()
 	testutil.WaitForResult(func() (bool, error) {
-		found, err := h.State.EvalByID(ws, followUpEval.ID)
+		found, err := h.State.EvalByID(nil, followUpEval.ID)
 		if err != nil {
 			return false, err
 		}
@@ -6447,17 +6446,12 @@ func TestServiceSched_Client_Disconnect_Creates_Updates_and_Evals(t *testing.T) 
 	}
 
 	// Simulate that NodeAllocation got processed.
-	testutil.WaitForResult(func() (bool, error) {
-		err = h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), h.Plans[0].NodeAllocation[disconnectedNode.ID])
-		require.NoError(t, err, "plan.NodeUpdate")
-		return true, nil
-	}, func(err error) {
-		require.NoError(t, err)
-	})
+	err = h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), h.Plans[0].NodeAllocation[disconnectedNode.ID])
+	require.NoError(t, err, "plan.NodeUpdate")
 
 	// Validate that the StateStore Upsert applied the ClientStatus we specified.
 	for _, alloc := range unknownAllocs {
-		alloc, err = h.State.AllocByID(ws, alloc.ID)
+		alloc, err = h.State.AllocByID(nil, alloc.ID)
 		require.NoError(t, err)
 		require.Equal(t, alloc.ClientStatus, structs.AllocClientStatusUnknown)
 

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -6395,7 +6395,7 @@ func TestServiceSched_Client_Disconnect_Creates_Updates_and_Evals(t *testing.T) 
 	}
 
 	for _, tc := range cases {
-		t.Run(fmt.Sprintf(""), func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			h := NewHarness(t)
 
 			disconnectedNode, job, unknownAllocs := initNodeAndAllocs(t, h, tc.count, tc.maxClientDisconnect,

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -994,16 +994,13 @@ func (a *allocReconciler) computeStop(group *structs.TaskGroup, nameIndex *alloc
 	return stop
 }
 
-// computeStopByReconnecting helps build the stop set by analyzing the reconnecting
-// and untainted sets. The function accepts and decrements a target number of
-// allocations to remove. If at any time that reaches zero, the function exits.
-// If there are still allocations to be removed after analyzing the full reconnecting
-// set, that count is returned.
-// The following rules are enforced.
-// * If the reconnecting alloc's desired status in not run, stop it.
-// * If the user-specified desired transition for the reconnecting alloc is not run, stop it.
-// * If the reconnecting alloc has been rescheduled, compare the node NormScores and keep the best.
+// computeStopByReconnecting moves allocations from either the untainted or reconnecting
+// sets to the stop set and returns the number of allocations that still need to be removed.
 func (a *allocReconciler) computeStopByReconnecting(untainted, reconnecting, stop allocSet, remove int) int {
+	if remove == 0 {
+		return remove
+	}
+
 	for _, reconnectingAlloc := range reconnecting {
 		// if the desired status is not run, stop the allocation.
 		if reconnectingAlloc.DesiredStatus != structs.AllocDesiredStatusRun {

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -1280,7 +1280,7 @@ func (a *allocReconciler) createTimeoutLaterEvals(disconnecting allocSet, tgName
 }
 
 // appendFollowupEvals appends a set of followup evals for a task group to the
-// desiredFollowupEvals queue which is later added to the scheduler's followUpEvals set.
+// desiredFollowupEvals map which is later added to the scheduler's followUpEvals set.
 func (a *allocReconciler) appendFollowupEvals(tgName string, evals []*structs.Evaluation) {
 	// Merge with
 	if existingFollowUpEvals, ok := a.result.desiredFollowupEvals[tgName]; ok {

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -1203,7 +1203,8 @@ func (a *allocReconciler) createLostLaterEvals(rescheduleLater []*delayedResched
 
 // createTimeoutLaterEvals creates followup evaluations with the
 // WaitUntil field set for allocations in an unknown state on disconnected nodes.
-// Followup Evals are appended to a.result as a side effect.
+// Followup Evals are appended to a.result as a side effect. It returns a map of
+// allocIDs to their associated followUpEvalIDs.
 func (a *allocReconciler) createTimeoutLaterEvals(disconnecting allocSet, tgName string) map[string]string {
 	if len(disconnecting) == 0 {
 		return map[string]string{}

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -336,6 +336,8 @@ func (a *allocReconciler) handleStop(m allocMatrix) {
 	}
 }
 
+// filterAndStopAll stops all allocations in an allocSet. This is useful in when
+// stopping an entire job or task group.
 func (a *allocReconciler) filterAndStopAll(set allocSet) uint64 {
 	untainted, migrate, lost, disconnecting, reconnecting := set.filterByTainted(a.taintedNodes)
 	a.markStop(untainted, "", allocNotNeeded)

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -1263,7 +1263,7 @@ func (a *allocReconciler) createTimeoutLaterEvals(disconnecting allocSet, tgName
 
 	// Important to remember that these are sorted. The rescheduleTime can only
 	// get farther into the future. If this loop detects the next delay is greater
-	// that the batch window (5s) it creates another batch.
+	// than the batch window (5s) it creates another batch.
 	for _, timeoutInfo := range timeoutDelays {
 		// If more than 5s in the future, create another eval batch.
 		if timeoutInfo.rescheduleTime.Sub(nextReschedTime) < batchedFailedAllocWindowSize {
@@ -1301,7 +1301,7 @@ func (a *allocReconciler) createTimeoutLaterEvals(disconnecting allocSet, tgName
 	return allocIDToFollowupEvalID
 }
 
-// appendFollowupEvals appends a set of followup evals for task group to the
+// appendFollowupEvals appends a set of followup evals for a task group to the
 // desiredFollowupEvals queue which is later added to the scheduler's followUpEvals set.
 func (a *allocReconciler) appendFollowupEvals(tgName string, evals []*structs.Evaluation) {
 	// Merge with

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -1125,12 +1125,12 @@ func (a *allocReconciler) computeReconnecting(reconnecting allocSet) {
 
 	// Create updates that will be appended to the plan.
 	for _, alloc := range reconnecting {
-		// If the user has defined a DesiredTransition don't queue to resume.
+		// If the user has defined a DesiredTransition don't resume the alloc.
 		if alloc.DesiredTransition.ShouldMigrate() || alloc.DesiredTransition.ShouldReschedule() || alloc.DesiredTransition.ShouldForceReschedule() {
 			continue
 		}
 
-		// If the scheduler has defined a terminal DesiredStatus don't queue to resume.
+		// If the scheduler has defined a terminal DesiredStatus don't resume the alloc.
 		if alloc.DesiredStatus != structs.AllocDesiredStatusRun {
 			continue
 		}

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -5074,12 +5074,6 @@ func TestReconciler_RescheduleNot_Batch(t *testing.T) {
 
 // Tests that when a node disconnects running allocations are queued to transition to unknown.
 func TestReconciler_Node_Disconnect_Updates_Alloc_To_Unknown(t *testing.T) {
-	// TODO: Table tests
-	// * Reschedule Policy doesn't allow reschedule
-	// * Constraints don't allow reschedule
-	// * No replacement nodes available
-	// * Canaries in progress
-
 	job, allocs := buildResumableAllocations(3, structs.AllocClientStatusRunning, structs.AllocDesiredStatusRun, 2)
 	// Build a map of disconnected nodes
 	nodes := buildDisconnectedNodes(allocs, 2)

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -446,7 +446,7 @@ func (a allocSet) delayByStopAfterClientDisconnect() (later []*delayedReschedule
 }
 
 // delayByMaxClientDisconnect returns a delay for any unknown allocation
-// that's got a resume_after_client_reconnect configured
+// that's got a max_client_reconnect configured
 func (a allocSet) delayByMaxClientDisconnect(now time.Time) (later []*delayedRescheduleInfo, err error) {
 	for _, alloc := range a {
 		timeout := alloc.DisconnectTimeout(now)

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -237,7 +237,7 @@ func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node) (untain
 
 		taintedNode, ok := taintedNodes[alloc.NodeID]
 		if !ok {
-			// Queue allocs on a node that is now re-connected to be resumed.
+			// Filter allocs on a node that is now re-connected to be resumed.
 			if alloc.ClientStatus == structs.AllocClientStatusUnknown {
 				reconnecting[alloc.ID] = alloc
 				continue
@@ -252,13 +252,18 @@ func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node) (untain
 			// Group disconnecting/reconnecting
 			switch taintedNode.Status {
 			case structs.NodeStatusDisconnected:
-				// Queue running allocs on a node that is disconnected to be marked as unknown.
+				// Filter running allocs on a node that is disconnected to be marked as unknown.
 				if alloc.ClientStatus == structs.AllocClientStatusRunning {
 					disconnecting[alloc.ID] = alloc
 					continue
 				}
+				// Filter pending allocs on a node that is disconnected to be marked as lost.
+				if alloc.ClientStatus == structs.AllocClientStatusPending {
+					lost[alloc.ID] = alloc
+					continue
+				}
 			case structs.NodeStatusReady:
-				// Queue unknown allocs on a node that is connected to reconnect.
+				// Filter unknown allocs on a node that is connected to reconnect.
 				if alloc.ClientStatus == structs.AllocClientStatusUnknown {
 					reconnecting[alloc.ID] = alloc
 					continue

--- a/scheduler/reconcile_util_test.go
+++ b/scheduler/reconcile_util_test.go
@@ -137,6 +137,27 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 			Job:          batchJob,
 			NodeID:       "disconnected",
 		},
+		// Complete allocs on disconnected nodes don't get restarted
+		"disconnecting4": {
+			ID:           "disconnecting4",
+			ClientStatus: structs.AllocClientStatusComplete,
+			Job:          batchJob,
+			NodeID:       "disconnected",
+		},
+		// Failed allocs on disconnected nodes don't get restarted
+		"disconnecting5": {
+			ID:           "disconnecting5",
+			ClientStatus: structs.AllocClientStatusFailed,
+			Job:          batchJob,
+			NodeID:       "disconnected",
+		},
+		// Lost allocs on disconnected nodes don't get restarted
+		"disconnecting6": {
+			ID:           "disconnecting6",
+			ClientStatus: structs.AllocClientStatusLost,
+			Job:          batchJob,
+			NodeID:       "disconnected",
+		},
 		// Unknown allocs on re-connected nodes are reconnecting
 		"reconnecting1": {
 			ID:           "reconnecting1",
@@ -151,14 +172,41 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 			Job:          batchJob,
 			NodeID:       "normal",
 		},
+		// Complete allocs on disconnected nodes don't get restarted
+		"reconnecting3": {
+			ID:           "reconnecting3",
+			ClientStatus: structs.AllocClientStatusComplete,
+			Job:          batchJob,
+			NodeID:       "normal",
+		},
+		// Failed allocs on disconnected nodes don't get restarted
+		"reconnecting4": {
+			ID:           "reconnecting4",
+			ClientStatus: structs.AllocClientStatusFailed,
+			Job:          batchJob,
+			NodeID:       "normal",
+		},
+		// Lost allocs on disconnected nodes don't get restarted
+		"reconnecting5": {
+			ID:           "reconnecting5",
+			ClientStatus: structs.AllocClientStatusLost,
+			Job:          batchJob,
+			NodeID:       "normal",
+		},
 	}
 
 	untainted, migrate, lost, disconnecting, reconnecting := allocs.filterByTainted(nodes)
-	require.Len(t, untainted, 4)
+	require.Len(t, untainted, 10)
 	require.Contains(t, untainted, "untainted1")
 	require.Contains(t, untainted, "untainted2")
 	require.Contains(t, untainted, "untainted3")
 	require.Contains(t, untainted, "untainted4")
+	require.Contains(t, untainted, "disconnecting4")
+	require.Contains(t, untainted, "disconnecting5")
+	require.Contains(t, untainted, "disconnecting6")
+	require.Contains(t, untainted, "reconnecting3")
+	require.Contains(t, untainted, "reconnecting4")
+	require.Contains(t, untainted, "reconnecting5")
 	require.Len(t, migrate, 2)
 	require.Contains(t, migrate, "migrating1")
 	require.Contains(t, migrate, "migrating2")

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -350,8 +350,9 @@ func progressMade(result *structs.PlanResult) bool {
 }
 
 // taintedNodes is used to scan the allocations and then check if the
-// underlying nodes are tainted, and should force a migration of the allocation.
-// All the nodes returned in the map are tainted.
+// underlying nodes are tainted, and should force a migration of the allocation,
+// or if the underlying nodes are disconnected, and should be used to calculate
+// the reconnect timeout of its allocations. All the nodes returned in the map are tainted.
 func taintedNodes(state State, allocs []*structs.Allocation) (map[string]*structs.Node, error) {
 	out := make(map[string]*structs.Node)
 	for _, alloc := range allocs {
@@ -373,7 +374,16 @@ func taintedNodes(state State, allocs []*structs.Allocation) (map[string]*struct
 		if structs.ShouldDrainNode(node.Status) || node.DrainStrategy != nil {
 			out[alloc.NodeID] = node
 		}
+
+		// If the node is in the disconnected state, add to the tainted set.
+		// Disconnected nodes must also be returned so that their
+		// ResumeAfterClientDisconnect configuration can be included in the
+		// timeout calculation.
+		if node.Status == structs.NodeStatusDisconnected {
+			out[alloc.NodeID] = node
+		}
 	}
+
 	return out, nil
 }
 

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -375,9 +375,8 @@ func taintedNodes(state State, allocs []*structs.Allocation) (map[string]*struct
 			out[alloc.NodeID] = node
 		}
 
-		// If the node is in the disconnected state, add to the tainted set.
-		// Disconnected nodes must also be returned so that their
-		// ResumeAfterClientDisconnect configuration can be included in the
+		// Disconnected nodes are included in the tainted set so that their
+		// MaxClientDisconnect configuration can be included in the
 		// timeout calculation.
 		if node.Status == structs.NodeStatusDisconnected {
 			out[alloc.NodeID] = node


### PR DESCRIPTION
**Description**

This PR is a work in progress tracking against the long-running feature branch `f-disconnected-client-handling`.

It includes:

- New node status (`NodeStatusDisconnected`), new client status (`AllocClientStatusUnknown`), and a new eval trigger (`EvalTriggerMaxDisconnectTimeout`)
- Updates to the `taintedNodes` function to include disconnected nodes as part of the tainted set
- A new `MaxClientDisconnect` field on the `Allocation` struct for tracking how long an alloc is allowed to be disconnected
- `allocReconciler` changes to support allocs that can disconnect and reconnect without restarting
- `GenericScheduler` changes to add disconnects to the `NodeAllocation` set for upsert with new status `AllocClientStatusUnknown`
- `GenericScheduler` changes to add reconnects to `queuedAllocations`.
- Changes to the `StateStore` alloc upsert code so that allocs with the unknown status don't have their `ClientStatus` overwritten by the existing allocs `ClientStatus`