### PR TITLE
build: allow golangci-lint to use more than 1 core

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -151,7 +151,7 @@ $(git-dir)/hooks/%: dev/hooks/%
 .PHONY: check
 check: ## Lint the source code
 	@echo "==> Linting source code..."
-	@golangci-lint run -j 1
+	@golangci-lint run
 
 	@echo "==> Linting hclog statements..."
 	@hclogvet .


### PR DESCRIPTION
Since switching to `golangci-lint` we have set the `-j 1` flag, which
restricts the tool to using 1 CPU thread.

This PR removes the flag so `make check` takes less time on good
computers.

```
➜ golangci-lint | grep '\-j'
  -j, --concurrency int           Concurrency (default NumCPU) (default 16)
```