### PR TITLE
check wildcard mTLS alt names

### DIFF
--- a/nomad/rpc.go
+++ b/nomad/rpc.go
@@ -131,12 +131,42 @@ func (ctx *RPCContext) ValidateCertificateForName(name string) error {
 	validNames := []string{cert.Subject.CommonName}
 	validNames = append(validNames, cert.DNSNames...)
 	for _, valid := range validNames {
-		if name == valid {
+		if matchHostnames(valid, name) {
 			return nil
 		}
 	}
 
 	return fmt.Errorf("invalid certificate, %s not in %s", name, strings.Join(validNames, ","))
+}
+
+// matchHostnames returns true if the given host is valid for pattern, Checking
+// for equal match or wildcard prefix.
+// Based on Go's x509.matchHostnames to also check the CommonName field:
+// https://cs.opensource.google/go/go/+/refs/tags/go1.17.7:src/crypto/x509/verify.go;l=940;drc=refs%2Ftags%2Fgo1.17.7
+func matchHostnames(pattern, host string) bool {
+	host = strings.TrimSuffix(host, ".")
+
+	if len(pattern) == 0 || len(host) == 0 {
+		return false
+	}
+
+	patternParts := strings.Split(pattern, ".")
+	hostParts := strings.Split(host, ".")
+
+	if len(patternParts) != len(hostParts) {
+		return false
+	}
+
+	for i, patternPart := range patternParts {
+		if i == 0 && patternPart == "*" {
+			continue
+		}
+		if patternPart != hostParts[i] {
+			return false
+		}
+	}
+
+	return true
 }
 
 // listen is used to listen for incoming RPC connections

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -96,6 +96,16 @@ timestamp appended.
 
 ## Nomad 1.0.10 and 1.1.4
 
+#### Strict mTLS certificate check
+
+Raft requests were not being verified for their certificate common alternative
+name. A check was introduced to make sure only servers in the same region are
+able to make Raft requests. This additional check results in a breaking change
+where wildcard values in the certificate alternative name list are not
+accepted.
+
+This breaking change will be fixed in a future version of Nomad.
+
 #### Log file names
 
 The [`log_file`] configuration option was not being fully respected, as the


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/11089 introduced strict server role mTLS role check for Raft requests. 

As pointed out in this [comment](https://github.com/hashicorp/nomad/pull/11998#issuecomment-1038989786), this change caused an issue for mTLS setups that use wildcard alt name domains, as they would fail this new check.

This PRs changes the mTLS verification to allow wildcard domains in addition to an equal match.