### PR TITLE
build: BIN value must use single-path GOPATH value

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,7 @@ endif
 # Respect $GOBIN if set in environment or via $GOENV file.
 BIN := $(shell go env GOBIN)
 ifndef BIN
-BIN := $(shell go env GOPATH)/bin
+BIN := $(GOPATH)/bin
 endif
 
 GO_TAGS ?=


### PR DESCRIPTION
I broke the build due to https://github.com/hashicorp/nomad/pull/12077 not using our workaround for GOPATH

2nd time I've been burned by https://discuss.circleci.com/t/gopath-is-set-to-multiple-directories/7174

Circle: 2 Seth: 0

```
BIN is /home/circleci/.go_workspace:/usr/local/go_workspace/bin
```

```
=== Failed
=== FAIL: command TestIntegration_Command_RoundTripJob (0.13s)
...
    integration_test.go:57: 
        	Error Trace:	integration_test.go:57
        	Error:      	Expected nil, but got: &exec.Error{Name:"nomad", Err:(*errors.errorString)(0xc000129190)}
        	Test:       	TestIntegration_Command_RoundTripJob
    integration_test.go:66: error running example.nomad: exec: "nomad": executable file not found in $PATH
```