### PR TITLE
docs: fix examples for set_contains_all and set_contains_any

### DIFF
--- a/website/content/docs/job-specification/affinity.mdx
+++ b/website/content/docs/job-specification/affinity.mdx
@@ -132,7 +132,7 @@ affinity {
   ```hcl
   affinity {
     attribute = "..."
-    operator  = "set_contains"
+    operator  = "set_contains_all"
     value     = "a,b,c"
     weight    = 50
   }
@@ -147,7 +147,7 @@ affinity {
   ```hcl
   affinity {
     attribute = "..."
-    operator  = "set_contains"
+    operator  = "set_contains_any"
     value     = "a,b,c"
     weight    = 50
   }


### PR DESCRIPTION
Make the examples match the affinity operator being documented.