### PR TITLE
docs: update link to `mount` in Docker task driver

### DIFF
--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -315,7 +315,7 @@ config {
   that exist inside the allocation working directory. You can allow mounting
   host paths outside of the [allocation working directory] on individual clients
   by setting the `docker.volumes.enabled` option to `true` in the client's
-  configuration. We recommend using [`mounts`](#mounts) if you wish to have more
+  configuration. We recommend using [`mount`](#mount) if you wish to have more
   control over volume definitions.
 
   ```hcl


### PR DESCRIPTION
Update `mount` link to point to non-deprecated option.

Closes #12074