### PR TITLE
CSI: enforce usage at claim time

### DIFF
--- a/.changelog/12112.txt
+++ b/.changelog/12112.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where the maximum number of volume claims was incorrectly enforced when an allocation claims a volume
+```

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -243,9 +243,11 @@ func TestCSIVolumeEndpoint_Claim(t *testing.T) {
 	// Create an initial volume claim request; we expect it to fail
 	// because there's no such volume yet.
 	claimReq := &structs.CSIVolumeClaimRequest{
-		VolumeID:     id0,
-		AllocationID: alloc.ID,
-		Claim:        structs.CSIVolumeClaimWrite,
+		VolumeID:       id0,
+		AllocationID:   alloc.ID,
+		Claim:          structs.CSIVolumeClaimWrite,
+		AccessMode:     structs.CSIVolumeAccessModeMultiNodeSingleWriter,
+		AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
 		WriteRequest: structs.WriteRequest{
 			Region:    "global",
 			Namespace: structs.DefaultNamespace,

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -554,12 +554,7 @@ func (v *CSIVolume) claimWrite(claim *CSIVolumeClaim, alloc *Allocation) error {
 	}
 
 	if !v.HasFreeWriteClaims() {
-		// Check the blocking allocations to see if they belong to this job
-		for _, a := range v.WriteAllocs {
-			if a != nil && (a.Namespace != alloc.Namespace || a.JobID != alloc.JobID) {
-				return ErrCSIVolumeMaxClaims
-			}
-		}
+		return ErrCSIVolumeMaxClaims
 	}
 
 	// Allocations are copy on write, so we want to keep the id but don't need the

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -422,24 +422,13 @@ func (v *CSIVolume) HasFreeWriteClaims() bool {
 		// which is checked in WriteSchedulable
 		return true
 	case CSIVolumeAccessModeUnknown:
-		// this volume was created but not yet claimed, so we check what it's
-		// capable of, not what it's been assigned
-		if len(v.RequestedCapabilities) == 0 {
-			// COMPAT: a volume that was registered before 1.1.0 and has not
-			// had a change in claims could have no requested caps. It will
-			// get corrected on the first claim.
-			return true
-		}
-		for _, cap := range v.RequestedCapabilities {
-			switch cap.AccessMode {
-			case CSIVolumeAccessModeSingleNodeWriter, CSIVolumeAccessModeMultiNodeSingleWriter:
-				return len(v.WriteClaims) == 0
-			case CSIVolumeAccessModeMultiNodeMultiWriter:
-				return true
-			}
-		}
+		// This volume was created but not yet claimed, so its
+		// capabilities have been checked in WriteSchedulable
+		return true
+	default:
+		// Reader modes never have free write claims
+		return false
 	}
-	return false
 }
 
 // InUse tests whether any allocations are actively using the volume


### PR DESCRIPTION
When the scheduler checks feasibility for CSI volumes, the check is
fairly loose: earlier versions of the same job are not counted as
active claims. This allows the scheduler to place new allocations
for the new version of a job, under the assumption that we'll replace
the existing allocations and their volume claims.

But when the alloc runner claims the volume, we need to enforce the
active claims even if they're for allocations of an earlier version of
the job. Otherwise we'll try to mount a volume that's currently being
unmounted, and this will cause replacement allocations to frequently
fail.

This changeset corrects this behavior for both write claims and read 
claims. I've broken it across a small set of commits for clarity.

---

Partial fix for https://github.com/hashicorp/nomad/issues/8609 but will also require https://github.com/hashicorp/nomad/pull/12113 to handle this scenario gracefully on the client.