### PR TITLE
CSI: retry claims from client

### DIFF
--- a/.changelog/12113.txt
+++ b/.changelog/12113.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+csi: Fixed a bug where allocations with volume claims would fail their first placement after a reschedule
+```
+
+```release-note:bug
+csi: Fixed a bug where allocations with volume claims would fail to restore after a client restart
+```


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/8609 when combined with https://github.com/hashicorp/nomad/pull/12112
Fixes https://github.com/hashicorp/nomad/issues/11477

When the alloc runner claims a volume, an allocation for a previous
version of the job may still have the volume claimed because it's
still shutting down. In this case we'll receive an error from the
server. Retry this error until we succeed or until a very long timeout
expires, to give operators a chance to recover broken plugins.

Make the claim hook tolerate temporary RPC failures in general to
prevent errors during client restart or during leadership elections.

---

(Tests don't pass until #12112 is merged; I'll rebase this on that PR)