### PR TITLE
CSI: tolerate missing plugins on job delete

### DIFF
--- a/.changelog/12114.txt
+++ b/.changelog/12114.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where purging a job with a missing plugin would fail
+```

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1460,7 +1460,9 @@ func (s *StateStore) deleteJobFromPlugins(index uint64, txn Txn, job *structs.Jo
 				return fmt.Errorf("error getting plugin: %s, %v", x.pluginID, err)
 			}
 			if plug == nil {
-				return fmt.Errorf("plugin missing: %s %v", x.pluginID, err)
+				// plugin was never successfully registered or has been
+				// GC'd out from under us
+				continue
 			}
 			// only copy once, so we update the same plugin on each alloc
 			plugins[x.pluginID] = plug.Copy()
@@ -1484,8 +1486,10 @@ func (s *StateStore) deleteJobFromPlugins(index uint64, txn Txn, job *structs.Jo
 		}
 	}
 
-	if err = txn.Insert("index", &IndexEntry{"csi_plugins", index}); err != nil {
-		return fmt.Errorf("index update failed: %v", err)
+	if len(plugins) > 0 {
+		if err = txn.Insert("index", &IndexEntry{"csi_plugins", index}); err != nil {
+			return fmt.Errorf("index update failed: %v", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11758

If a plugin job fails before successfully fingerprinting the plugins,
the plugin will not exist when we try to delete the job. Tolerate
missing plugins.

---

```
$ nomad job stop -purge badplugin
==> 2022-02-23T16:02:06-05:00: Monitoring evaluation "c3b163b5"
    2022-02-23T16:02:06-05:00: Evaluation triggered by job "badplugin"
==> 2022-02-23T16:02:07-05:00: Monitoring evaluation "c3b163b5"
    2022-02-23T16:02:07-05:00: Evaluation status changed: "pending" -> "complete"
==> 2022-02-23T16:02:07-05:00: Evaluation "c3b163b5" finished with status "complete"

$ nomad job status badplugin
No job(s) with prefix or id "badplugin" found
```