### PR TITLE
CSI: display plugin capabilities in verbose status

### DIFF
--- a/.changelog/12116.txt
+++ b/.changelog/12116.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+csi: Display plugin capabilities in `nomad plugin status -verbose` output
+```


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10221

The behaviors of CSI plugins are governed by their capabilities as
defined by the CSI specification. When debugging plugin issues, it's
useful to know which behaviors are expected so they can be matched
against RPC calls made to the plugin allocations.

Expose the plugin capabilities as named in the CSI spec in the 
`nomad plugin status -verbose` output.