### PR TITLE
chore: bump docs-page for code-block fix

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -18,7 +18,7 @@
         "@hashicorp/react-button": "^6.0.1",
         "@hashicorp/react-call-to-action": "^4.0.0",
         "@hashicorp/react-code-block": "^4.1.5",
-        "@hashicorp/react-consent-manager": "^7.1.0",
+        "@hashicorp/react-consent-manager": "^7.1.1",
         "@hashicorp/react-content": "^8.0.2",
         "@hashicorp/react-docs-page": "^14.14.3",
         "@hashicorp/react-featured-slider": "^5.0.1",
@@ -1301,14 +1301,30 @@
       }
     },
     "node_modules/@hashicorp/react-consent-manager": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-7.1.0.tgz",
-      "integrity": "sha512-Hxs58z80gbyfO2HpdyvQFB1PtXzazWICJnH5Kp1VRL2oQpJPeylG6jUsQ6K6a9kfdclZQjK1EeVKDZg2vVFrhA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-7.1.1.tgz",
+      "integrity": "sha512-dlGPLEX12Pn3lkro+PhpolLZO1Dq5qDGTuQCjYt6W/izp5VwAkhHodfUamBhCHq+kl1imtivjsEuR21/H6LMAA==",
       "dependencies": {
-        "@hashicorp/react-button": "^6.0.0",
+        "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-toggle": "^4.0.1",
         "classnames": "^2.3.1",
         "js-cookie": "^2.2.1"
+      },
+      "peerDependencies": {
+        "@hashicorp/mktg-global-styles": ">=3.x",
+        "next": ">=11.x",
+        "react": ">=16.x"
+      }
+    },
+    "node_modules/@hashicorp/react-consent-manager/node_modules/@hashicorp/react-button": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-button/-/react-button-6.1.0.tgz",
+      "integrity": "sha512-hQbL94l0wboOSelgfUTNPvpKsWwnZf16TKv5Y4gyE1iRD9TXUHvBJIt7a8TLFWA9tKu4ZwkPl8drGa6I8iGUPw==",
+      "dependencies": {
+        "@hashicorp/platform-product-meta": "^0.1.0",
+        "@hashicorp/react-inline-svg": "^6.0.3",
+        "classnames": "^2.3.1",
+        "slugify": "^1.6.5"
       },
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
@@ -1320,6 +1336,14 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
       "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
+    "node_modules/@hashicorp/react-consent-manager/node_modules/slugify": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/@hashicorp/react-content": {
       "version": "8.2.1",
@@ -20077,20 +20101,36 @@
       }
     },
     "@hashicorp/react-consent-manager": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-7.1.0.tgz",
-      "integrity": "sha512-Hxs58z80gbyfO2HpdyvQFB1PtXzazWICJnH5Kp1VRL2oQpJPeylG6jUsQ6K6a9kfdclZQjK1EeVKDZg2vVFrhA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-7.1.1.tgz",
+      "integrity": "sha512-dlGPLEX12Pn3lkro+PhpolLZO1Dq5qDGTuQCjYt6W/izp5VwAkhHodfUamBhCHq+kl1imtivjsEuR21/H6LMAA==",
       "requires": {
-        "@hashicorp/react-button": "^6.0.0",
+        "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-toggle": "^4.0.1",
         "classnames": "^2.3.1",
         "js-cookie": "^2.2.1"
       },
       "dependencies": {
+        "@hashicorp/react-button": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/@hashicorp/react-button/-/react-button-6.1.0.tgz",
+          "integrity": "sha512-hQbL94l0wboOSelgfUTNPvpKsWwnZf16TKv5Y4gyE1iRD9TXUHvBJIt7a8TLFWA9tKu4ZwkPl8drGa6I8iGUPw==",
+          "requires": {
+            "@hashicorp/platform-product-meta": "^0.1.0",
+            "@hashicorp/react-inline-svg": "^6.0.3",
+            "classnames": "^2.3.1",
+            "slugify": "^1.6.5"
+          }
+        },
         "classnames": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
           "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+        },
+        "slugify": {
+          "version": "1.6.5",
+          "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+          "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
         }
       }
     },

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -20,7 +20,7 @@
         "@hashicorp/react-code-block": "^4.1.5",
         "@hashicorp/react-consent-manager": "^7.1.0",
         "@hashicorp/react-content": "^8.0.2",
-        "@hashicorp/react-docs-page": "^14.11.0",
+        "@hashicorp/react-docs-page": "^14.14.3",
         "@hashicorp/react-featured-slider": "^5.0.1",
         "@hashicorp/react-hashi-stack-menu": "^2.1.2",
         "@hashicorp/react-head": "^3.1.2",
@@ -65,118 +65,123 @@
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.5.tgz",
-      "integrity": "sha512-cfX2rEKOtuuljcGI5DMDHClwZHdDqd2nT2Ohsc8aHtBiz6bUxKVyIqxr2gaC6tU8AgPtrTVBzcxCA+UavXpKww==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.12.1.tgz",
+      "integrity": "sha512-ERFFOnC9740xAkuO0iZTQqm2AzU7Dpz/s+g7o48GlZgx5p9GgNcsuK5eS0GoW/tAK+fnKlizCtlFHNuIWuvfsg==",
       "dependencies": {
-        "@algolia/cache-common": "4.10.5"
+        "@algolia/cache-common": "4.12.1"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.10.5.tgz",
-      "integrity": "sha512-1mClwdmTHll+OnHkG+yeRoFM17kSxDs4qXkjf6rNZhoZGXDvfYLy3YcZ1FX4Kyz0DJv8aroq5RYGBDsWkHj6Tw=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.12.1.tgz",
+      "integrity": "sha512-UugTER3V40jT+e19Dmph5PKMeliYKxycNPwrPNADin0RcWNfT2QksK9Ff2N2W7UKraqMOzoeDb4LAJtxcK1a8Q=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.10.5.tgz",
-      "integrity": "sha512-+ciQnfIGi5wjMk02XhEY8fmy2pzy+oY1nIIfu8LBOglaSipCRAtjk6WhHc7/KIbXPiYzIwuDbM2K1+YOwSGjwA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.12.1.tgz",
+      "integrity": "sha512-U6iaunaxK1lHsAf02UWF58foKFEcrVLsHwN56UkCtwn32nlP9rz52WOcHsgk6TJrL8NDcO5swMjtOQ5XHESFLw==",
       "dependencies": {
-        "@algolia/cache-common": "4.10.5"
+        "@algolia/cache-common": "4.12.1"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.10.5.tgz",
-      "integrity": "sha512-I9UkSS2glXm7RBZYZIALjBMmXSQbw/fI/djPcBHxiwXIheNIlqIFl2SNPkvihpPF979BSkzjqdJNRPhE1vku3Q==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.12.1.tgz",
+      "integrity": "sha512-jGo4ConJNoMdTCR2zouO0jO/JcJmzOK6crFxMMLvdnB1JhmMbuIKluOTJVlBWeivnmcsqb7r0v7qTCPW5PAyxQ==",
       "dependencies": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/client-search": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/client-search": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.10.5.tgz",
-      "integrity": "sha512-h2owwJSkovPxzc+xIsjY1pMl0gj+jdVwP9rcnGjlaTY2fqHbSLrR9yvGyyr6305LvTppxsQnfAbRdE/5Z3eFxw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.12.1.tgz",
+      "integrity": "sha512-h1It7KXzIthlhuhfBk7LteYq72tym9maQDUsyRW0Gft8b6ZQahnRak9gcCvKwhcJ1vJoP7T7JrNYGiYSicTD9g==",
       "dependencies": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/client-search": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/client-search": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.10.5.tgz",
-      "integrity": "sha512-21FAvIai5qm8DVmZHm2Gp4LssQ/a0nWwMchAx+1hIRj1TX7OcdW6oZDPyZ8asQdvTtK7rStQrRnD8a95SCUnzA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.12.1.tgz",
+      "integrity": "sha512-obnJ8eSbv+h94Grk83DTGQ3bqhViSWureV6oK1s21/KMGWbb3DkduHm+lcwFrMFkjSUSzosLBHV9EQUIBvueTw==",
       "dependencies": {
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.10.5.tgz",
-      "integrity": "sha512-nH+IyFKBi8tCyzGOanJTbXC5t4dspSovX3+ABfmwKWUYllYzmiQNFUadpb3qo+MLA3jFx5IwBesjneN6dD5o3w==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.12.1.tgz",
+      "integrity": "sha512-sMSnjjPjRgByGHYygV+5L/E8a6RgU7l2GbpJukSzJ9GRY37tHmBHuvahv8JjdCGJ2p7QDYLnQy5bN5Z02qjc7Q==",
       "dependencies": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.10.5.tgz",
-      "integrity": "sha512-1eQFMz9uodrc5OM+9HeT+hHcfR1E1AsgFWXwyJ9Q3xejA2c1c4eObGgOgC9ZoshuHHdptaTN1m3rexqAxXRDBg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.12.1.tgz",
+      "integrity": "sha512-MwwKKprfY6X2nJ5Ki/ccXM2GDEePvVjZnnoOB2io3dLKW4fTqeSRlC5DRXeFD7UM0vOPPHr4ItV2aj19APKNVQ==",
       "dependencies": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
+    "node_modules/@algolia/events": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@algolia/events/-/events-4.0.1.tgz",
+      "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
+    },
     "node_modules/@algolia/logger-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.10.5.tgz",
-      "integrity": "sha512-gRJo9zt1UYP4k3woEmZm4iuEBIQd/FrArIsjzsL/b+ihNoOqIxZKTSuGFU4UUZOEhvmxDReiA4gzvQXG+TMTmA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.12.1.tgz",
+      "integrity": "sha512-fCgrzlXGATNqdFTxwx0GsyPXK+Uqrx1SZ3iuY2VGPPqdt1a20clAG2n2OcLHJpvaa6vMFPlJyWvbqAgzxdxBlQ=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.10.5.tgz",
-      "integrity": "sha512-4WfIbn4253EDU12u9UiYvz+QTvAXDv39mKNg9xSoMCjKE5szcQxfcSczw2byc6pYhahOJ9PmxPBfs1doqsdTKQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.12.1.tgz",
+      "integrity": "sha512-0owaEnq/davngQMYqxLA4KrhWHiXujQ1CU3FFnyUcMyBR7rGHI48zSOUpqnsAXrMBdSH6rH5BDkSUUFwsh8RkQ==",
       "dependencies": {
-        "@algolia/logger-common": "4.10.5"
+        "@algolia/logger-common": "4.12.1"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.5.tgz",
-      "integrity": "sha512-53/MURQEqtK+bGdfq4ITSPwTh5hnADU99qzvpAINGQveUFNSFGERipJxHjTJjIrjFz3vxj5kKwjtxDnU6ygO9g==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.12.1.tgz",
+      "integrity": "sha512-OaMxDyG0TZG0oqz1lQh9e3woantAG1bLnuwq3fmypsrQxra4IQZiyn1x+kEb69D2TcXApI5gOgrD4oWhtEVMtw==",
       "dependencies": {
-        "@algolia/requester-common": "4.10.5"
+        "@algolia/requester-common": "4.12.1"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.10.5.tgz",
-      "integrity": "sha512-UkVa1Oyuj6NPiAEt5ZvrbVopEv1m/mKqjs40KLB+dvfZnNcj+9Fry4Oxnt15HMy/HLORXsx4UwcthAvBuOXE9Q=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.12.1.tgz",
+      "integrity": "sha512-XWIrWQNJ1vIrSuL/bUk3ZwNMNxl+aWz6dNboRW6+lGTcMIwc3NBFE90ogbZKhNrFRff8zI4qCF15tjW+Fyhpow=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.10.5.tgz",
-      "integrity": "sha512-aNEKVKXL4fiiC+bS7yJwAHdxln81ieBwY3tsMCtM4zF9f5KwCzY2OtN4WKEZa5AAADVcghSAUdyjs4AcGUlO5w==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.12.1.tgz",
+      "integrity": "sha512-awBtwaD+s0hxkA1aehYn8F0t9wqGoBVWgY4JPHBmp1ChO3pK7RKnnvnv7QQa9vTlllX29oPt/BBVgMo1Z3n1Qg==",
       "dependencies": {
-        "@algolia/requester-common": "4.10.5"
+        "@algolia/requester-common": "4.12.1"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.10.5.tgz",
-      "integrity": "sha512-F8DLkmIlvCoMwSCZA3FKHtmdjH3o5clbt0pi2ktFStVNpC6ZDmY307HcK619bKP5xW6h8sVJhcvrLB775D2cyA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.12.1.tgz",
+      "integrity": "sha512-BGeNgdEHc6dXIk2g8kdlOoQ6fQ6OIaKQcplEj7HPoi+XZUeAvRi3Pff3QWd7YmybWkjzd9AnTzieTASDWhL+sQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.10.5",
-        "@algolia/logger-common": "4.10.5",
-        "@algolia/requester-common": "4.10.5"
+        "@algolia/cache-common": "4.12.1",
+        "@algolia/logger-common": "4.12.1",
+        "@algolia/requester-common": "4.12.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1045,11 +1050,11 @@
       }
     },
     "node_modules/@hashicorp/platform-docs-mdx": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.3.tgz",
-      "integrity": "sha512-NPVvn3s/JuFfebvymJ9JkOd6CHKfCVISz/QenmPgPim1nzJfe3uXKFeqolYdfMb8k1++XpX7KM70nJMVDyQLpw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4.tgz",
+      "integrity": "sha512-/yAZDWR7pgrTkNzoNxZXyWZ1dvSO+KVw5/ZFsUR8d+kZhSKqiLAHVEAH6i7Jd4GlW074OytUzWmA3Je2jAVetA==",
       "dependencies": {
-        "@hashicorp/react-code-block": "^4.1.0",
+        "@hashicorp/react-code-block": "^4.4.2",
         "@hashicorp/react-enterprise-alert": "^6.0.1",
         "@hashicorp/react-tabs": "^7.0.1",
         "@mdx-js/react": "1.6.22"
@@ -1282,12 +1287,12 @@
       }
     },
     "node_modules/@hashicorp/react-code-block": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.1.5.tgz",
-      "integrity": "sha512-94IHagrdqxvoPE130b2FOvyeSZ26DIhaNSnZ3b/isKMpaNdWjoi/uo+nckRu3auiSyxldbMty8W5EXclgGkCEA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.2.tgz",
+      "integrity": "sha512-isnojue1SuTaq4jjh6C03jxVLCGmHaSK6D/m3OdEsUeV5PovZ7uNF9MFfhwHErIHKZztxOuIePepqaAB5sMHCw==",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
-        "@reach/listbox": "0.15.0",
+        "@reach/listbox": "0.16.2",
         "shellwords": "^0.1.1"
       },
       "peerDependencies": {
@@ -1317,9 +1322,9 @@
       "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "node_modules/@hashicorp/react-content": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.1.0.tgz",
-      "integrity": "sha512-L7z8/GiW2tvoBjLvpwZWWrf/KnGDch0SV29zDdkTtf4oa8Ojd5bVvQYo5Sz6Yva8CpQB2p4EZT6maDepJCnLqA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.1.tgz",
+      "integrity": "sha512-qqyK1uejHfsrd+jRlTqQtJpihyUYGdeUottoFmsfPwvcs0Wy+r+AyzetknGiXYbflidjgM9pP6kw2PLtAMwoVQ==",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
         "classnames": "^2.3.1"
@@ -1335,25 +1340,25 @@
       "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "node_modules/@hashicorp/react-docs-page": {
-      "version": "14.11.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.11.0.tgz",
-      "integrity": "sha512-3yMlHCRiOezB+TSbLxchy2pf14Atjxyz19wZmr/qjOM4BWtTAe6sTCSjl2Rh4ru6w5UOvPo0nwOxikSd56oACQ==",
+      "version": "14.14.3",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.3.tgz",
+      "integrity": "sha512-prRWKE/Ykr+LGouJgdYfxTOMrpjRQf72IJYFUrZx+wL+LV+bT5hFNyWiHgJWNKg7DCUMQreX7RNAidzNOoxc6g==",
       "dependencies": {
-        "@hashicorp/platform-docs-mdx": "^0.1.3",
+        "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
-        "@hashicorp/react-content": "^8.1.0",
-        "@hashicorp/react-docs-sidenav": "^8.4.0",
+        "@hashicorp/react-content": "^8.2.1",
+        "@hashicorp/react-docs-sidenav": "^8.4.1",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-placeholder": "^0.1.0",
-        "@hashicorp/react-search": "^6.3.1",
-        "@hashicorp/react-version-select": "^0.2.0",
+        "@hashicorp/react-search": "^6.4.1",
+        "@hashicorp/react-version-select": "^0.3.0",
         "classnames": "^2.3.1",
         "fs-exists-sync": "^0.1.0",
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0",
         "line-reader": "^0.4.0",
-        "moize": "^6.0.3",
+        "moize": "^6.1.0",
         "readdirp": "^3.6.0",
         "semver": "^7.3.5"
       },
@@ -1652,19 +1657,19 @@
       }
     },
     "node_modules/@hashicorp/react-search": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.3.1.tgz",
-      "integrity": "sha512-gU8J4D9SfaRmtn8tsjvRVq1J57Uq8KuYmok+RZzgaHpiPFLyGoIHy1MyAfxOgFptFtsJaNbMBhulEC0DjQ6pRQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.4.1.tgz",
+      "integrity": "sha512-VoFdfjSCyhmbwNT2nB5+midHjZBy+mO5jXAWAzXbQjTvlBA6NEEgPNXnCLCniOKFouiEVSsn9TnqsWfJt41SqQ==",
       "dependencies": {
-        "@hashicorp/react-inline-svg": "^6.0.1",
-        "@hashicorp/remark-plugins": "^3.1.1",
+        "@hashicorp/react-inline-svg": "^6.0.3",
+        "@hashicorp/remark-plugins": "^3.3.1",
         "@reach/visually-hidden": "^0.16.0",
-        "algoliasearch": "^4.10.3",
+        "algoliasearch": "^4.12.0",
         "classnames": "^2.3.1",
-        "dotenv": "^10.0.0",
-        "glob": "^7.1.7",
+        "dotenv": "^14.3.1",
+        "glob": "^7.2.0",
         "gray-matter": "^4.0.3",
-        "react-instantsearch-dom": "^6.12.1",
+        "react-instantsearch-dom": "^6.21.1",
         "remark": "^13.0.0",
         "search-insights": "^1.7.1",
         "unist-util-visit": "^2.0.3"
@@ -1678,6 +1683,25 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
       "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
+    "node_modules/@hashicorp/react-search/node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@hashicorp/react-search/node_modules/gray-matter": {
       "version": "4.0.3",
@@ -1787,32 +1811,6 @@
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
         "react": ">=16.x"
-      }
-    },
-    "node_modules/@hashicorp/react-tabs/node_modules/@reach/portal": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.0.tgz",
-      "integrity": "sha512-vXJ0O9T+72HiSEWHPs2cx7YbSO7pQsTMhgqPc5aaddIYpo2clJx1PnYuS0lSNlVaDO0IxQhwYq43evXaXnmviw==",
-      "dependencies": {
-        "@reach/utils": "0.16.0",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@hashicorp/react-tabs/node_modules/@reach/utils": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-      "dependencies": {
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
       }
     },
     "node_modules/@hashicorp/react-tabs/node_modules/classnames": {
@@ -1942,9 +1940,9 @@
       "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "node_modules/@hashicorp/react-version-select": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-version-select/-/react-version-select-0.2.2.tgz",
-      "integrity": "sha512-3mz/jRyOBPgK83YW89nuspTvdKrzKgVsIz9vjF4kKLB9SLSmo2BQCi72DWdPCIUPqy+4wp1PpAwkNPVGKs7IJA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-version-select/-/react-version-select-0.3.0.tgz",
+      "integrity": "sha512-wd708z+ftdUkK+jKBLFHdHE3U4a0g37LTOxH9X68LzFDWPUT9gTAI5dPEfT0Os/DeJxWcRvUoaS8Fbtd7SQPmg==",
       "dependencies": {
         "@hashicorp/react-select-input": ">=4.x"
       },
@@ -2427,12 +2425,12 @@
       }
     },
     "node_modules/@reach/auto-id": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.15.0.tgz",
-      "integrity": "sha512-iACaCcZeqAhDf4OOwJpmHHS/LaRj9z3Ip8JmlhpCrFWV2YOIiiZk42amlBZX6CKH66Md+eriYZQk3TyAjk6Oxg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
+      "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
       "dependencies": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -2440,12 +2438,12 @@
       }
     },
     "node_modules/@reach/descendants": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.15.0.tgz",
-      "integrity": "sha512-MGs+7sGjx07sm29Wc2d/Ya72qwatNVHofnYwwHMT6LImv99kE5TQMCgkMSDeRwqQxHURmcjb4I7Tab+ahvCGiw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
+      "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
       "dependencies": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -2453,15 +2451,15 @@
       }
     },
     "node_modules/@reach/listbox": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.15.0.tgz",
-      "integrity": "sha512-3Vvpte0HQkfo3sT4Cz6gG9h+E/La2IwbtLQDTesEmDzToQ8bk9rOfuFDVp7IXUyOdDggfDCOEz/ZphsuniADWA==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.16.2.tgz",
+      "integrity": "sha512-UBotBw7X8e2ajHn6tg1M9ArinisvSvwtu/aP3edEQKCvobd95nAa+dqnfAdihPAQFH2AQ2NFfa/73yawWV3LOQ==",
       "dependencies": {
-        "@reach/auto-id": "0.15.0",
-        "@reach/descendants": "0.15.0",
-        "@reach/machine": "0.15.0",
-        "@reach/popover": "0.15.0",
-        "@reach/utils": "0.15.0",
+        "@reach/auto-id": "0.16.0",
+        "@reach/descendants": "0.16.1",
+        "@reach/machine": "0.16.0",
+        "@reach/popover": "0.16.2",
+        "@reach/utils": "0.16.0",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
@@ -2470,13 +2468,13 @@
       }
     },
     "node_modules/@reach/machine": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.15.0.tgz",
-      "integrity": "sha512-o3vvqsTQyj7apxpbSuIn4xKYlqNagcjhlMnroJ2uqgJfFwy1tLrsQo4Sr8GnZu4hitPbNAfqGExYjV8ZV8SHpA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.16.0.tgz",
+      "integrity": "sha512-c8SRQz2xGtg5M9aXuuM5pFgaV1ZW5/nyMIYpZzBwHUlNFKGO+VBhwedbnqUxO0yLcbgl3wPvjPh740O3YjqiHg==",
       "dependencies": {
-        "@reach/utils": "0.15.0",
+        "@reach/utils": "0.16.0",
         "@xstate/fsm": "1.4.0",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -2489,15 +2487,15 @@
       "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
     },
     "node_modules/@reach/popover": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.15.0.tgz",
-      "integrity": "sha512-nBR6ZlULF7ZZIqkN47QEWmdqUX2Zd6FSeYJku1il9OkiMnWzI3aTOyu1B+IJfYeIqg28D/aeF4ff0oVu1VUrqQ==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.16.2.tgz",
+      "integrity": "sha512-IwkRrHM7Vt33BEkSXneovymJv7oIToOfTDwRKpuYEB/BWYMAuNfbsRL7KVe6MjkgchDeQzAk24cYY1ztQj5HQQ==",
       "dependencies": {
-        "@reach/portal": "0.15.0",
-        "@reach/rect": "0.15.0",
-        "@reach/utils": "0.15.0",
+        "@reach/portal": "0.16.2",
+        "@reach/rect": "0.16.0",
+        "@reach/utils": "0.16.0",
         "tabbable": "^4.0.0",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -2505,12 +2503,13 @@
       }
     },
     "node_modules/@reach/portal": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.15.0.tgz",
-      "integrity": "sha512-Aulqjk/PIRu+R7yhINYAAYfYh++ZdC30qwHDWDtGk2cmTEJT7m9AlvBX+W7T+Q3Ux6Wy5f37eV+TTGid1CcjFw==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.2.tgz",
+      "integrity": "sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==",
       "dependencies": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -2518,15 +2517,15 @@
       }
     },
     "node_modules/@reach/rect": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.15.0.tgz",
-      "integrity": "sha512-Nu0zG4Xq8Z0C3Yr3wbjtj7fvII1q2KopHDStNtmL26oWPzlaZJ9A1K6rZSPIqxKkx1hvl6AUTeom7eHTIKhHjA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.16.0.tgz",
+      "integrity": "sha512-/qO9jQDzpOCdrSxVPR6l674mRHNTqfEjkaxZHluwJ/2qGUtYsA0GSZiF/+wX/yOWeBif1ycxJDa6HusAMJZC5Q==",
       "dependencies": {
         "@reach/observe-rect": "1.2.0",
-        "@reach/utils": "0.15.0",
+        "@reach/utils": "0.16.0",
         "prop-types": "^15.7.2",
         "tiny-warning": "^1.0.3",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -2552,19 +2551,6 @@
         "react-dom": "^16.8.0 || 17.x"
       }
     },
-    "node_modules/@reach/tooltip/node_modules/@reach/auto-id": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
-      "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
-      "dependencies": {
-        "@reach/utils": "0.16.0",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
     "node_modules/@reach/tooltip/node_modules/@reach/portal": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.0.tgz",
@@ -2578,42 +2564,13 @@
         "react-dom": "^16.8.0 || 17.x"
       }
     },
-    "node_modules/@reach/tooltip/node_modules/@reach/rect": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.16.0.tgz",
-      "integrity": "sha512-/qO9jQDzpOCdrSxVPR6l674mRHNTqfEjkaxZHluwJ/2qGUtYsA0GSZiF/+wX/yOWeBif1ycxJDa6HusAMJZC5Q==",
-      "dependencies": {
-        "@reach/observe-rect": "1.2.0",
-        "@reach/utils": "0.16.0",
-        "prop-types": "^15.7.2",
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/tooltip/node_modules/@reach/utils": {
+    "node_modules/@reach/utils": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
       "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
       "dependencies": {
         "tiny-warning": "^1.0.3",
         "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/utils": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.15.0.tgz",
-      "integrity": "sha512-JHHN7T5ucFiuQbqkgv8ECbRWKfRiJxrO/xHR3fHf+f2C7mVs/KkJHhYtovS1iEapR4silygX9PY0+QUmHPOTYw==",
-      "dependencies": {
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.1.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -3316,32 +3273,32 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.5.tgz",
-      "integrity": "sha512-KmH2XkiN+8FxhND4nWFbQDkIoU6g2OjfeU9kIv4Lb+EiOOs3Gpp7jvd+JnatsCisAZsnWQdjd7zVlW7I/85QvQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.12.1.tgz",
+      "integrity": "sha512-c0dM1g3zZBJrkzE5GA/Nu1y3fFxx3LCzxKzcmp2dgGS8P4CjszB/l3lsSh2MSrrK1Hn/KV4BlbBMXtYgG1Bfrw==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.10.5",
-        "@algolia/cache-common": "4.10.5",
-        "@algolia/cache-in-memory": "4.10.5",
-        "@algolia/client-account": "4.10.5",
-        "@algolia/client-analytics": "4.10.5",
-        "@algolia/client-common": "4.10.5",
-        "@algolia/client-personalization": "4.10.5",
-        "@algolia/client-search": "4.10.5",
-        "@algolia/logger-common": "4.10.5",
-        "@algolia/logger-console": "4.10.5",
-        "@algolia/requester-browser-xhr": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/requester-node-http": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/cache-browser-local-storage": "4.12.1",
+        "@algolia/cache-common": "4.12.1",
+        "@algolia/cache-in-memory": "4.12.1",
+        "@algolia/client-account": "4.12.1",
+        "@algolia/client-analytics": "4.12.1",
+        "@algolia/client-common": "4.12.1",
+        "@algolia/client-personalization": "4.12.1",
+        "@algolia/client-search": "4.12.1",
+        "@algolia/logger-common": "4.12.1",
+        "@algolia/logger-console": "4.12.1",
+        "@algolia/requester-browser-xhr": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/requester-node-http": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.6.0.tgz",
-      "integrity": "sha512-F4Smiq+Vyv/JJytuKNFuzXndPSb4pjtiHZSkEztQCcB+SORu71A8grgt2NSJhbB5VhqHW19QDtlPKbdYdcNrLg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.7.0.tgz",
+      "integrity": "sha512-XJ3QfERBLfeVCyTVx80gon7r3/rgm/CE8Ha1H7cbablRe/X7SfYQ14g/eO+MhjVKIQp+gy9oC6G5ilmLwS1k6w==",
       "dependencies": {
-        "events": "^1.1.1"
+        "@algolia/events": "^4.0.1"
       },
       "peerDependencies": {
         "algoliasearch": ">= 3.1 < 5"
@@ -6312,11 +6269,11 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
+      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/download": {
@@ -7440,14 +7397,6 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-      "engines": {
-        "node": ">=0.4.x"
       }
     },
     "node_modules/evp_bytestokey": {
@@ -8585,6 +8534,7 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "devOptional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -14138,12 +14088,12 @@
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
     "node_modules/react-instantsearch-core": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.12.1.tgz",
-      "integrity": "sha512-X4OqakDI3DOcFiS1S46z+cciKEQcKBmH8HGQLztzW14hoHRqFfZzuqWydlSxfJZN5WksMMm78EmL2jvoqIHd/A==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.22.0.tgz",
+      "integrity": "sha512-K4GpydrStAGmUFYaV86eU65cvy0ZM97jKtNCF63sznhgYS1mJ3IaKO8HJV56/NP8dPKbr+HbdoD2GOnD1OaLlQ==",
       "dependencies": {
         "@babel/runtime": "^7.1.2",
-        "algoliasearch-helper": "^3.5.3",
+        "algoliasearch-helper": "^3.7.0",
         "prop-types": "^15.6.2",
         "react-fast-compare": "^3.0.0"
       },
@@ -14158,16 +14108,16 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "node_modules/react-instantsearch-dom": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.12.1.tgz",
-      "integrity": "sha512-KXk2UDmJ3OP9B57owPC0+7fdcVtmYAA6/UWimR9CXhvFGCMi11xlR/wscYMYxdPuxs9IkmnnLDIJSjSGADYnow==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.22.0.tgz",
+      "integrity": "sha512-geXYTQqGsLggbf7MMuSPgXjuZ3yWtWjjPRWEbXmAHZ4oodbdYiKIuieTDoadYM+m+Y90WXpwn+hMi0EDTffeRA==",
       "dependencies": {
         "@babel/runtime": "^7.1.2",
-        "algoliasearch-helper": "^3.5.3",
+        "algoliasearch-helper": "^3.7.0",
         "classnames": "^2.2.5",
         "prop-types": "^15.6.2",
         "react-fast-compare": "^3.0.0",
-        "react-instantsearch-core": "^6.12.1"
+        "react-instantsearch-core": "6.22.0"
       },
       "peerDependencies": {
         "react": ">= 16.3.0 < 18",
@@ -19094,118 +19044,123 @@
   },
   "dependencies": {
     "@algolia/cache-browser-local-storage": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.5.tgz",
-      "integrity": "sha512-cfX2rEKOtuuljcGI5DMDHClwZHdDqd2nT2Ohsc8aHtBiz6bUxKVyIqxr2gaC6tU8AgPtrTVBzcxCA+UavXpKww==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.12.1.tgz",
+      "integrity": "sha512-ERFFOnC9740xAkuO0iZTQqm2AzU7Dpz/s+g7o48GlZgx5p9GgNcsuK5eS0GoW/tAK+fnKlizCtlFHNuIWuvfsg==",
       "requires": {
-        "@algolia/cache-common": "4.10.5"
+        "@algolia/cache-common": "4.12.1"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.10.5.tgz",
-      "integrity": "sha512-1mClwdmTHll+OnHkG+yeRoFM17kSxDs4qXkjf6rNZhoZGXDvfYLy3YcZ1FX4Kyz0DJv8aroq5RYGBDsWkHj6Tw=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.12.1.tgz",
+      "integrity": "sha512-UugTER3V40jT+e19Dmph5PKMeliYKxycNPwrPNADin0RcWNfT2QksK9Ff2N2W7UKraqMOzoeDb4LAJtxcK1a8Q=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.10.5.tgz",
-      "integrity": "sha512-+ciQnfIGi5wjMk02XhEY8fmy2pzy+oY1nIIfu8LBOglaSipCRAtjk6WhHc7/KIbXPiYzIwuDbM2K1+YOwSGjwA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.12.1.tgz",
+      "integrity": "sha512-U6iaunaxK1lHsAf02UWF58foKFEcrVLsHwN56UkCtwn32nlP9rz52WOcHsgk6TJrL8NDcO5swMjtOQ5XHESFLw==",
       "requires": {
-        "@algolia/cache-common": "4.10.5"
+        "@algolia/cache-common": "4.12.1"
       }
     },
     "@algolia/client-account": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.10.5.tgz",
-      "integrity": "sha512-I9UkSS2glXm7RBZYZIALjBMmXSQbw/fI/djPcBHxiwXIheNIlqIFl2SNPkvihpPF979BSkzjqdJNRPhE1vku3Q==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.12.1.tgz",
+      "integrity": "sha512-jGo4ConJNoMdTCR2zouO0jO/JcJmzOK6crFxMMLvdnB1JhmMbuIKluOTJVlBWeivnmcsqb7r0v7qTCPW5PAyxQ==",
       "requires": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/client-search": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/client-search": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.10.5.tgz",
-      "integrity": "sha512-h2owwJSkovPxzc+xIsjY1pMl0gj+jdVwP9rcnGjlaTY2fqHbSLrR9yvGyyr6305LvTppxsQnfAbRdE/5Z3eFxw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.12.1.tgz",
+      "integrity": "sha512-h1It7KXzIthlhuhfBk7LteYq72tym9maQDUsyRW0Gft8b6ZQahnRak9gcCvKwhcJ1vJoP7T7JrNYGiYSicTD9g==",
       "requires": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/client-search": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/client-search": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "@algolia/client-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.10.5.tgz",
-      "integrity": "sha512-21FAvIai5qm8DVmZHm2Gp4LssQ/a0nWwMchAx+1hIRj1TX7OcdW6oZDPyZ8asQdvTtK7rStQrRnD8a95SCUnzA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.12.1.tgz",
+      "integrity": "sha512-obnJ8eSbv+h94Grk83DTGQ3bqhViSWureV6oK1s21/KMGWbb3DkduHm+lcwFrMFkjSUSzosLBHV9EQUIBvueTw==",
       "requires": {
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "@algolia/client-personalization": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.10.5.tgz",
-      "integrity": "sha512-nH+IyFKBi8tCyzGOanJTbXC5t4dspSovX3+ABfmwKWUYllYzmiQNFUadpb3qo+MLA3jFx5IwBesjneN6dD5o3w==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.12.1.tgz",
+      "integrity": "sha512-sMSnjjPjRgByGHYygV+5L/E8a6RgU7l2GbpJukSzJ9GRY37tHmBHuvahv8JjdCGJ2p7QDYLnQy5bN5Z02qjc7Q==",
       "requires": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "@algolia/client-search": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.10.5.tgz",
-      "integrity": "sha512-1eQFMz9uodrc5OM+9HeT+hHcfR1E1AsgFWXwyJ9Q3xejA2c1c4eObGgOgC9ZoshuHHdptaTN1m3rexqAxXRDBg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.12.1.tgz",
+      "integrity": "sha512-MwwKKprfY6X2nJ5Ki/ccXM2GDEePvVjZnnoOB2io3dLKW4fTqeSRlC5DRXeFD7UM0vOPPHr4ItV2aj19APKNVQ==",
       "requires": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
+    "@algolia/events": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@algolia/events/-/events-4.0.1.tgz",
+      "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
+    },
     "@algolia/logger-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.10.5.tgz",
-      "integrity": "sha512-gRJo9zt1UYP4k3woEmZm4iuEBIQd/FrArIsjzsL/b+ihNoOqIxZKTSuGFU4UUZOEhvmxDReiA4gzvQXG+TMTmA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.12.1.tgz",
+      "integrity": "sha512-fCgrzlXGATNqdFTxwx0GsyPXK+Uqrx1SZ3iuY2VGPPqdt1a20clAG2n2OcLHJpvaa6vMFPlJyWvbqAgzxdxBlQ=="
     },
     "@algolia/logger-console": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.10.5.tgz",
-      "integrity": "sha512-4WfIbn4253EDU12u9UiYvz+QTvAXDv39mKNg9xSoMCjKE5szcQxfcSczw2byc6pYhahOJ9PmxPBfs1doqsdTKQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.12.1.tgz",
+      "integrity": "sha512-0owaEnq/davngQMYqxLA4KrhWHiXujQ1CU3FFnyUcMyBR7rGHI48zSOUpqnsAXrMBdSH6rH5BDkSUUFwsh8RkQ==",
       "requires": {
-        "@algolia/logger-common": "4.10.5"
+        "@algolia/logger-common": "4.12.1"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.5.tgz",
-      "integrity": "sha512-53/MURQEqtK+bGdfq4ITSPwTh5hnADU99qzvpAINGQveUFNSFGERipJxHjTJjIrjFz3vxj5kKwjtxDnU6ygO9g==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.12.1.tgz",
+      "integrity": "sha512-OaMxDyG0TZG0oqz1lQh9e3woantAG1bLnuwq3fmypsrQxra4IQZiyn1x+kEb69D2TcXApI5gOgrD4oWhtEVMtw==",
       "requires": {
-        "@algolia/requester-common": "4.10.5"
+        "@algolia/requester-common": "4.12.1"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.10.5.tgz",
-      "integrity": "sha512-UkVa1Oyuj6NPiAEt5ZvrbVopEv1m/mKqjs40KLB+dvfZnNcj+9Fry4Oxnt15HMy/HLORXsx4UwcthAvBuOXE9Q=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.12.1.tgz",
+      "integrity": "sha512-XWIrWQNJ1vIrSuL/bUk3ZwNMNxl+aWz6dNboRW6+lGTcMIwc3NBFE90ogbZKhNrFRff8zI4qCF15tjW+Fyhpow=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.10.5.tgz",
-      "integrity": "sha512-aNEKVKXL4fiiC+bS7yJwAHdxln81ieBwY3tsMCtM4zF9f5KwCzY2OtN4WKEZa5AAADVcghSAUdyjs4AcGUlO5w==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.12.1.tgz",
+      "integrity": "sha512-awBtwaD+s0hxkA1aehYn8F0t9wqGoBVWgY4JPHBmp1ChO3pK7RKnnvnv7QQa9vTlllX29oPt/BBVgMo1Z3n1Qg==",
       "requires": {
-        "@algolia/requester-common": "4.10.5"
+        "@algolia/requester-common": "4.12.1"
       }
     },
     "@algolia/transporter": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.10.5.tgz",
-      "integrity": "sha512-F8DLkmIlvCoMwSCZA3FKHtmdjH3o5clbt0pi2ktFStVNpC6ZDmY307HcK619bKP5xW6h8sVJhcvrLB775D2cyA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.12.1.tgz",
+      "integrity": "sha512-BGeNgdEHc6dXIk2g8kdlOoQ6fQ6OIaKQcplEj7HPoi+XZUeAvRi3Pff3QWd7YmybWkjzd9AnTzieTASDWhL+sQ==",
       "requires": {
-        "@algolia/cache-common": "4.10.5",
-        "@algolia/logger-common": "4.10.5",
-        "@algolia/requester-common": "4.10.5"
+        "@algolia/cache-common": "4.12.1",
+        "@algolia/logger-common": "4.12.1",
+        "@algolia/requester-common": "4.12.1"
       }
     },
     "@babel/code-frame": {
@@ -19929,11 +19884,11 @@
       }
     },
     "@hashicorp/platform-docs-mdx": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.3.tgz",
-      "integrity": "sha512-NPVvn3s/JuFfebvymJ9JkOd6CHKfCVISz/QenmPgPim1nzJfe3uXKFeqolYdfMb8k1++XpX7KM70nJMVDyQLpw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4.tgz",
+      "integrity": "sha512-/yAZDWR7pgrTkNzoNxZXyWZ1dvSO+KVw5/ZFsUR8d+kZhSKqiLAHVEAH6i7Jd4GlW074OytUzWmA3Je2jAVetA==",
       "requires": {
-        "@hashicorp/react-code-block": "^4.1.0",
+        "@hashicorp/react-code-block": "^4.4.2",
         "@hashicorp/react-enterprise-alert": "^6.0.1",
         "@hashicorp/react-tabs": "^7.0.1",
         "@mdx-js/react": "1.6.22"
@@ -20112,12 +20067,12 @@
       }
     },
     "@hashicorp/react-code-block": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.1.5.tgz",
-      "integrity": "sha512-94IHagrdqxvoPE130b2FOvyeSZ26DIhaNSnZ3b/isKMpaNdWjoi/uo+nckRu3auiSyxldbMty8W5EXclgGkCEA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.2.tgz",
+      "integrity": "sha512-isnojue1SuTaq4jjh6C03jxVLCGmHaSK6D/m3OdEsUeV5PovZ7uNF9MFfhwHErIHKZztxOuIePepqaAB5sMHCw==",
       "requires": {
         "@hashicorp/react-inline-svg": "^6.0.3",
-        "@reach/listbox": "0.15.0",
+        "@reach/listbox": "0.16.2",
         "shellwords": "^0.1.1"
       }
     },
@@ -20140,9 +20095,9 @@
       }
     },
     "@hashicorp/react-content": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.1.0.tgz",
-      "integrity": "sha512-L7z8/GiW2tvoBjLvpwZWWrf/KnGDch0SV29zDdkTtf4oa8Ojd5bVvQYo5Sz6Yva8CpQB2p4EZT6maDepJCnLqA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.1.tgz",
+      "integrity": "sha512-qqyK1uejHfsrd+jRlTqQtJpihyUYGdeUottoFmsfPwvcs0Wy+r+AyzetknGiXYbflidjgM9pP6kw2PLtAMwoVQ==",
       "requires": {
         "@hashicorp/platform-product-meta": "^0.1.0",
         "classnames": "^2.3.1"
@@ -20156,25 +20111,25 @@
       }
     },
     "@hashicorp/react-docs-page": {
-      "version": "14.11.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.11.0.tgz",
-      "integrity": "sha512-3yMlHCRiOezB+TSbLxchy2pf14Atjxyz19wZmr/qjOM4BWtTAe6sTCSjl2Rh4ru6w5UOvPo0nwOxikSd56oACQ==",
+      "version": "14.14.3",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.3.tgz",
+      "integrity": "sha512-prRWKE/Ykr+LGouJgdYfxTOMrpjRQf72IJYFUrZx+wL+LV+bT5hFNyWiHgJWNKg7DCUMQreX7RNAidzNOoxc6g==",
       "requires": {
-        "@hashicorp/platform-docs-mdx": "^0.1.3",
+        "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
-        "@hashicorp/react-content": "^8.1.0",
-        "@hashicorp/react-docs-sidenav": "^8.4.0",
+        "@hashicorp/react-content": "^8.2.1",
+        "@hashicorp/react-docs-sidenav": "^8.4.1",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-placeholder": "^0.1.0",
-        "@hashicorp/react-search": "^6.3.1",
-        "@hashicorp/react-version-select": "^0.2.0",
+        "@hashicorp/react-search": "^6.4.1",
+        "@hashicorp/react-version-select": "^0.3.0",
         "classnames": "^2.3.1",
         "fs-exists-sync": "^0.1.0",
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0",
         "line-reader": "^0.4.0",
-        "moize": "^6.0.3",
+        "moize": "^6.1.0",
         "readdirp": "^3.6.0",
         "semver": "^7.3.5"
       },
@@ -20413,19 +20368,19 @@
       }
     },
     "@hashicorp/react-search": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.3.1.tgz",
-      "integrity": "sha512-gU8J4D9SfaRmtn8tsjvRVq1J57Uq8KuYmok+RZzgaHpiPFLyGoIHy1MyAfxOgFptFtsJaNbMBhulEC0DjQ6pRQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.4.1.tgz",
+      "integrity": "sha512-VoFdfjSCyhmbwNT2nB5+midHjZBy+mO5jXAWAzXbQjTvlBA6NEEgPNXnCLCniOKFouiEVSsn9TnqsWfJt41SqQ==",
       "requires": {
-        "@hashicorp/react-inline-svg": "^6.0.1",
-        "@hashicorp/remark-plugins": "^3.1.1",
+        "@hashicorp/react-inline-svg": "^6.0.3",
+        "@hashicorp/remark-plugins": "^3.3.1",
         "@reach/visually-hidden": "^0.16.0",
-        "algoliasearch": "^4.10.3",
+        "algoliasearch": "^4.12.0",
         "classnames": "^2.3.1",
-        "dotenv": "^10.0.0",
-        "glob": "^7.1.7",
+        "dotenv": "^14.3.1",
+        "glob": "^7.2.0",
         "gray-matter": "^4.0.3",
-        "react-instantsearch-dom": "^6.12.1",
+        "react-instantsearch-dom": "^6.21.1",
         "remark": "^13.0.0",
         "search-insights": "^1.7.1",
         "unist-util-visit": "^2.0.3"
@@ -20435,6 +20390,19 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
           "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+        },
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "gray-matter": {
           "version": "4.0.3",
@@ -20525,24 +20493,6 @@
         "classnames": "^2.3.1"
       },
       "dependencies": {
-        "@reach/portal": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.0.tgz",
-          "integrity": "sha512-vXJ0O9T+72HiSEWHPs2cx7YbSO7pQsTMhgqPc5aaddIYpo2clJx1PnYuS0lSNlVaDO0IxQhwYq43evXaXnmviw==",
-          "requires": {
-            "@reach/utils": "0.16.0",
-            "tslib": "^2.3.0"
-          }
-        },
-        "@reach/utils": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-          "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-          "requires": {
-            "tiny-warning": "^1.0.3",
-            "tslib": "^2.3.0"
-          }
-        },
         "classnames": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
@@ -20649,9 +20599,9 @@
       }
     },
     "@hashicorp/react-version-select": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-version-select/-/react-version-select-0.2.2.tgz",
-      "integrity": "sha512-3mz/jRyOBPgK83YW89nuspTvdKrzKgVsIz9vjF4kKLB9SLSmo2BQCi72DWdPCIUPqy+4wp1PpAwkNPVGKs7IJA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-version-select/-/react-version-select-0.3.0.tgz",
+      "integrity": "sha512-wd708z+ftdUkK+jKBLFHdHE3U4a0g37LTOxH9X68LzFDWPUT9gTAI5dPEfT0Os/DeJxWcRvUoaS8Fbtd7SQPmg==",
       "requires": {
         "@hashicorp/react-select-input": ">=4.x"
       }
@@ -21005,44 +20955,44 @@
       }
     },
     "@reach/auto-id": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.15.0.tgz",
-      "integrity": "sha512-iACaCcZeqAhDf4OOwJpmHHS/LaRj9z3Ip8JmlhpCrFWV2YOIiiZk42amlBZX6CKH66Md+eriYZQk3TyAjk6Oxg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
+      "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
       "requires": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
       }
     },
     "@reach/descendants": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.15.0.tgz",
-      "integrity": "sha512-MGs+7sGjx07sm29Wc2d/Ya72qwatNVHofnYwwHMT6LImv99kE5TQMCgkMSDeRwqQxHURmcjb4I7Tab+ahvCGiw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
+      "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
       "requires": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
       }
     },
     "@reach/listbox": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.15.0.tgz",
-      "integrity": "sha512-3Vvpte0HQkfo3sT4Cz6gG9h+E/La2IwbtLQDTesEmDzToQ8bk9rOfuFDVp7IXUyOdDggfDCOEz/ZphsuniADWA==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.16.2.tgz",
+      "integrity": "sha512-UBotBw7X8e2ajHn6tg1M9ArinisvSvwtu/aP3edEQKCvobd95nAa+dqnfAdihPAQFH2AQ2NFfa/73yawWV3LOQ==",
       "requires": {
-        "@reach/auto-id": "0.15.0",
-        "@reach/descendants": "0.15.0",
-        "@reach/machine": "0.15.0",
-        "@reach/popover": "0.15.0",
-        "@reach/utils": "0.15.0",
+        "@reach/auto-id": "0.16.0",
+        "@reach/descendants": "0.16.1",
+        "@reach/machine": "0.16.0",
+        "@reach/popover": "0.16.2",
+        "@reach/utils": "0.16.0",
         "prop-types": "^15.7.2"
       }
     },
     "@reach/machine": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.15.0.tgz",
-      "integrity": "sha512-o3vvqsTQyj7apxpbSuIn4xKYlqNagcjhlMnroJ2uqgJfFwy1tLrsQo4Sr8GnZu4hitPbNAfqGExYjV8ZV8SHpA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.16.0.tgz",
+      "integrity": "sha512-c8SRQz2xGtg5M9aXuuM5pFgaV1ZW5/nyMIYpZzBwHUlNFKGO+VBhwedbnqUxO0yLcbgl3wPvjPh740O3YjqiHg==",
       "requires": {
-        "@reach/utils": "0.15.0",
+        "@reach/utils": "0.16.0",
         "@xstate/fsm": "1.4.0",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       }
     },
     "@reach/observe-rect": {
@@ -21051,36 +21001,37 @@
       "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
     },
     "@reach/popover": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.15.0.tgz",
-      "integrity": "sha512-nBR6ZlULF7ZZIqkN47QEWmdqUX2Zd6FSeYJku1il9OkiMnWzI3aTOyu1B+IJfYeIqg28D/aeF4ff0oVu1VUrqQ==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.16.2.tgz",
+      "integrity": "sha512-IwkRrHM7Vt33BEkSXneovymJv7oIToOfTDwRKpuYEB/BWYMAuNfbsRL7KVe6MjkgchDeQzAk24cYY1ztQj5HQQ==",
       "requires": {
-        "@reach/portal": "0.15.0",
-        "@reach/rect": "0.15.0",
-        "@reach/utils": "0.15.0",
+        "@reach/portal": "0.16.2",
+        "@reach/rect": "0.16.0",
+        "@reach/utils": "0.16.0",
         "tabbable": "^4.0.0",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       }
     },
     "@reach/portal": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.15.0.tgz",
-      "integrity": "sha512-Aulqjk/PIRu+R7yhINYAAYfYh++ZdC30qwHDWDtGk2cmTEJT7m9AlvBX+W7T+Q3Ux6Wy5f37eV+TTGid1CcjFw==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.2.tgz",
+      "integrity": "sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==",
       "requires": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
       }
     },
     "@reach/rect": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.15.0.tgz",
-      "integrity": "sha512-Nu0zG4Xq8Z0C3Yr3wbjtj7fvII1q2KopHDStNtmL26oWPzlaZJ9A1K6rZSPIqxKkx1hvl6AUTeom7eHTIKhHjA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.16.0.tgz",
+      "integrity": "sha512-/qO9jQDzpOCdrSxVPR6l674mRHNTqfEjkaxZHluwJ/2qGUtYsA0GSZiF/+wX/yOWeBif1ycxJDa6HusAMJZC5Q==",
       "requires": {
         "@reach/observe-rect": "1.2.0",
-        "@reach/utils": "0.15.0",
+        "@reach/utils": "0.16.0",
         "prop-types": "^15.7.2",
         "tiny-warning": "^1.0.3",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       }
     },
     "@reach/tooltip": {
@@ -21098,15 +21049,6 @@
         "tslib": "^2.3.0"
       },
       "dependencies": {
-        "@reach/auto-id": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
-          "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
-          "requires": {
-            "@reach/utils": "0.16.0",
-            "tslib": "^2.3.0"
-          }
-        },
         "@reach/portal": {
           "version": "0.16.0",
           "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.0.tgz",
@@ -21115,37 +21057,16 @@
             "@reach/utils": "0.16.0",
             "tslib": "^2.3.0"
           }
-        },
-        "@reach/rect": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.16.0.tgz",
-          "integrity": "sha512-/qO9jQDzpOCdrSxVPR6l674mRHNTqfEjkaxZHluwJ/2qGUtYsA0GSZiF/+wX/yOWeBif1ycxJDa6HusAMJZC5Q==",
-          "requires": {
-            "@reach/observe-rect": "1.2.0",
-            "@reach/utils": "0.16.0",
-            "prop-types": "^15.7.2",
-            "tiny-warning": "^1.0.3",
-            "tslib": "^2.3.0"
-          }
-        },
-        "@reach/utils": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-          "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-          "requires": {
-            "tiny-warning": "^1.0.3",
-            "tslib": "^2.3.0"
-          }
         }
       }
     },
     "@reach/utils": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.15.0.tgz",
-      "integrity": "sha512-JHHN7T5ucFiuQbqkgv8ECbRWKfRiJxrO/xHR3fHf+f2C7mVs/KkJHhYtovS1iEapR4silygX9PY0+QUmHPOTYw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
+      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
       "requires": {
         "tiny-warning": "^1.0.3",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       }
     },
     "@reach/visually-hidden": {
@@ -21725,32 +21646,32 @@
       "requires": {}
     },
     "algoliasearch": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.5.tgz",
-      "integrity": "sha512-KmH2XkiN+8FxhND4nWFbQDkIoU6g2OjfeU9kIv4Lb+EiOOs3Gpp7jvd+JnatsCisAZsnWQdjd7zVlW7I/85QvQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.12.1.tgz",
+      "integrity": "sha512-c0dM1g3zZBJrkzE5GA/Nu1y3fFxx3LCzxKzcmp2dgGS8P4CjszB/l3lsSh2MSrrK1Hn/KV4BlbBMXtYgG1Bfrw==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.10.5",
-        "@algolia/cache-common": "4.10.5",
-        "@algolia/cache-in-memory": "4.10.5",
-        "@algolia/client-account": "4.10.5",
-        "@algolia/client-analytics": "4.10.5",
-        "@algolia/client-common": "4.10.5",
-        "@algolia/client-personalization": "4.10.5",
-        "@algolia/client-search": "4.10.5",
-        "@algolia/logger-common": "4.10.5",
-        "@algolia/logger-console": "4.10.5",
-        "@algolia/requester-browser-xhr": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/requester-node-http": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/cache-browser-local-storage": "4.12.1",
+        "@algolia/cache-common": "4.12.1",
+        "@algolia/cache-in-memory": "4.12.1",
+        "@algolia/client-account": "4.12.1",
+        "@algolia/client-analytics": "4.12.1",
+        "@algolia/client-common": "4.12.1",
+        "@algolia/client-personalization": "4.12.1",
+        "@algolia/client-search": "4.12.1",
+        "@algolia/logger-common": "4.12.1",
+        "@algolia/logger-console": "4.12.1",
+        "@algolia/requester-browser-xhr": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/requester-node-http": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "algoliasearch-helper": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.6.0.tgz",
-      "integrity": "sha512-F4Smiq+Vyv/JJytuKNFuzXndPSb4pjtiHZSkEztQCcB+SORu71A8grgt2NSJhbB5VhqHW19QDtlPKbdYdcNrLg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.7.0.tgz",
+      "integrity": "sha512-XJ3QfERBLfeVCyTVx80gon7r3/rgm/CE8Ha1H7cbablRe/X7SfYQ14g/eO+MhjVKIQp+gy9oC6G5ilmLwS1k6w==",
       "requires": {
-        "events": "^1.1.1"
+        "@algolia/events": "^4.0.1"
       }
     },
     "anser": {
@@ -24117,9 +24038,9 @@
       }
     },
     "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
+      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ=="
     },
     "download": {
       "version": "6.2.5",
@@ -24977,11 +24898,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-    },
-    "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -25903,6 +25819,7 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "devOptional": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -30105,12 +30022,12 @@
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
     "react-instantsearch-core": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.12.1.tgz",
-      "integrity": "sha512-X4OqakDI3DOcFiS1S46z+cciKEQcKBmH8HGQLztzW14hoHRqFfZzuqWydlSxfJZN5WksMMm78EmL2jvoqIHd/A==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.22.0.tgz",
+      "integrity": "sha512-K4GpydrStAGmUFYaV86eU65cvy0ZM97jKtNCF63sznhgYS1mJ3IaKO8HJV56/NP8dPKbr+HbdoD2GOnD1OaLlQ==",
       "requires": {
         "@babel/runtime": "^7.1.2",
-        "algoliasearch-helper": "^3.5.3",
+        "algoliasearch-helper": "^3.7.0",
         "prop-types": "^15.6.2",
         "react-fast-compare": "^3.0.0"
       },
@@ -30123,16 +30040,16 @@
       }
     },
     "react-instantsearch-dom": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.12.1.tgz",
-      "integrity": "sha512-KXk2UDmJ3OP9B57owPC0+7fdcVtmYAA6/UWimR9CXhvFGCMi11xlR/wscYMYxdPuxs9IkmnnLDIJSjSGADYnow==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.22.0.tgz",
+      "integrity": "sha512-geXYTQqGsLggbf7MMuSPgXjuZ3yWtWjjPRWEbXmAHZ4oodbdYiKIuieTDoadYM+m+Y90WXpwn+hMi0EDTffeRA==",
       "requires": {
         "@babel/runtime": "^7.1.2",
-        "algoliasearch-helper": "^3.5.3",
+        "algoliasearch-helper": "^3.7.0",
         "classnames": "^2.2.5",
         "prop-types": "^15.6.2",
         "react-fast-compare": "^3.0.0",
-        "react-instantsearch-core": "^6.12.1"
+        "react-instantsearch-core": "6.22.0"
       },
       "dependencies": {
         "react-fast-compare": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -18,7 +18,7 @@
         "@hashicorp/react-button": "^6.0.1",
         "@hashicorp/react-call-to-action": "^4.0.0",
         "@hashicorp/react-code-block": "^4.1.5",
-        "@hashicorp/react-consent-manager": "7.1.2-canary-20220224160734",
+        "@hashicorp/react-consent-manager": "^7.1.2",
         "@hashicorp/react-content": "^8.0.2",
         "@hashicorp/react-docs-page": "^14.14.3",
         "@hashicorp/react-featured-slider": "^5.0.1",
@@ -1301,9 +1301,9 @@
       }
     },
     "node_modules/@hashicorp/react-consent-manager": {
-      "version": "7.1.2-canary-20220224160734",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-7.1.2-canary-20220224160734.tgz",
-      "integrity": "sha512-/iuzRCgumlEhSL2QAVgK1BAIiIzaKasBgmohOWvT2bm3DPgfzUJS/FJqxOYeLOJtwcd+bDXP2J7gAxHPnwjZnw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-7.1.2.tgz",
+      "integrity": "sha512-ZwsxKFFaYBMOUX2gfsvYzPjqTU2X34OcCGqZrDCIwJBR1qQ5Z0UW3AXeKiszXnO6na8xiCBKiNs7xccYAMNhZA==",
       "dependencies": {
         "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-toggle": "^4.0.1",
@@ -20102,9 +20102,9 @@
       }
     },
     "@hashicorp/react-consent-manager": {
-      "version": "7.1.2-canary-20220224160734",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-7.1.2-canary-20220224160734.tgz",
-      "integrity": "sha512-/iuzRCgumlEhSL2QAVgK1BAIiIzaKasBgmohOWvT2bm3DPgfzUJS/FJqxOYeLOJtwcd+bDXP2J7gAxHPnwjZnw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-7.1.2.tgz",
+      "integrity": "sha512-ZwsxKFFaYBMOUX2gfsvYzPjqTU2X34OcCGqZrDCIwJBR1qQ5Z0UW3AXeKiszXnO6na8xiCBKiNs7xccYAMNhZA==",
       "requires": {
         "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-toggle": "^4.0.1",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -18,7 +18,7 @@
         "@hashicorp/react-button": "^6.0.1",
         "@hashicorp/react-call-to-action": "^4.0.0",
         "@hashicorp/react-code-block": "^4.1.5",
-        "@hashicorp/react-consent-manager": "^7.1.1",
+        "@hashicorp/react-consent-manager": "7.1.2-canary-20220224160734",
         "@hashicorp/react-content": "^8.0.2",
         "@hashicorp/react-docs-page": "^14.14.3",
         "@hashicorp/react-featured-slider": "^5.0.1",
@@ -1301,13 +1301,14 @@
       }
     },
     "node_modules/@hashicorp/react-consent-manager": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-7.1.1.tgz",
-      "integrity": "sha512-dlGPLEX12Pn3lkro+PhpolLZO1Dq5qDGTuQCjYt6W/izp5VwAkhHodfUamBhCHq+kl1imtivjsEuR21/H6LMAA==",
+      "version": "7.1.2-canary-20220224160734",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-7.1.2-canary-20220224160734.tgz",
+      "integrity": "sha512-/iuzRCgumlEhSL2QAVgK1BAIiIzaKasBgmohOWvT2bm3DPgfzUJS/FJqxOYeLOJtwcd+bDXP2J7gAxHPnwjZnw==",
       "dependencies": {
         "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-toggle": "^4.0.1",
         "classnames": "^2.3.1",
+        "events": "^3.3.0",
         "js-cookie": "^2.2.1"
       },
       "peerDependencies": {
@@ -7423,6 +7424,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -12455,14 +12464,6 @@
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
-      }
-    },
-    "node_modules/node-libs-browser/node_modules/events": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
-      "engines": {
-        "node": ">=0.8.x"
       }
     },
     "node_modules/node-libs-browser/node_modules/path-browserify": {
@@ -20101,13 +20102,14 @@
       }
     },
     "@hashicorp/react-consent-manager": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-7.1.1.tgz",
-      "integrity": "sha512-dlGPLEX12Pn3lkro+PhpolLZO1Dq5qDGTuQCjYt6W/izp5VwAkhHodfUamBhCHq+kl1imtivjsEuR21/H6LMAA==",
+      "version": "7.1.2-canary-20220224160734",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-7.1.2-canary-20220224160734.tgz",
+      "integrity": "sha512-/iuzRCgumlEhSL2QAVgK1BAIiIzaKasBgmohOWvT2bm3DPgfzUJS/FJqxOYeLOJtwcd+bDXP2J7gAxHPnwjZnw==",
       "requires": {
         "@hashicorp/react-button": "^6.0.4",
         "@hashicorp/react-toggle": "^4.0.1",
         "classnames": "^2.3.1",
+        "events": "^3.3.0",
         "js-cookie": "^2.2.1"
       },
       "dependencies": {
@@ -24939,6 +24941,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+    },
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -28786,11 +28793,6 @@
             "ieee754": "^1.1.4",
             "isarray": "^1.0.0"
           }
-        },
-        "events": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-          "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
         },
         "path-browserify": {
           "version": "0.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -18,7 +18,7 @@
     "@hashicorp/react-button": "^6.0.1",
     "@hashicorp/react-call-to-action": "^4.0.0",
     "@hashicorp/react-code-block": "^4.1.5",
-    "@hashicorp/react-consent-manager": "^7.1.0",
+    "@hashicorp/react-consent-manager": "^7.1.1",
     "@hashicorp/react-content": "^8.0.2",
     "@hashicorp/react-docs-page": "^14.14.3",
     "@hashicorp/react-featured-slider": "^5.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -18,7 +18,7 @@
     "@hashicorp/react-button": "^6.0.1",
     "@hashicorp/react-call-to-action": "^4.0.0",
     "@hashicorp/react-code-block": "^4.1.5",
-    "@hashicorp/react-consent-manager": "^7.1.1",
+    "@hashicorp/react-consent-manager": "7.1.2-canary-20220224160734",
     "@hashicorp/react-content": "^8.0.2",
     "@hashicorp/react-docs-page": "^14.14.3",
     "@hashicorp/react-featured-slider": "^5.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -18,7 +18,7 @@
     "@hashicorp/react-button": "^6.0.1",
     "@hashicorp/react-call-to-action": "^4.0.0",
     "@hashicorp/react-code-block": "^4.1.5",
-    "@hashicorp/react-consent-manager": "7.1.2-canary-20220224160734",
+    "@hashicorp/react-consent-manager": "^7.1.2",
     "@hashicorp/react-content": "^8.0.2",
     "@hashicorp/react-docs-page": "^14.14.3",
     "@hashicorp/react-featured-slider": "^5.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -20,7 +20,7 @@
     "@hashicorp/react-code-block": "^4.1.5",
     "@hashicorp/react-consent-manager": "^7.1.0",
     "@hashicorp/react-content": "^8.0.2",
-    "@hashicorp/react-docs-page": "^14.11.0",
+    "@hashicorp/react-docs-page": "^14.14.3",
     "@hashicorp/react-featured-slider": "^5.0.1",
     "@hashicorp/react-hashi-stack-menu": "^2.1.2",
     "@hashicorp/react-head": "^3.1.2",


### PR DESCRIPTION
👀 [Preview][preview]

This PR bumps to the latest `@hashicorp/react-docs-page` release, in order to fix an underlying issue in `@hashicorp/react-code-block` (via `@hashicorp/platform-docs-mdx`).

This fix is specific to Firefox browsers, and with this fix, newlines are now included when manually selecting and copying `code-block` contents.

See https://github.com/hashicorp/react-components/pull/503 for further details.

## Review notes

When using [Firefox](https://www.mozilla.org/en-US/firefox/new/):

- On [the live site][live], manually selecting code block contents, copying, and pasting into a plain text editor should result in missing newlines.
- On [the preview][preview], manually selecting code block contents, copying, and pasting into a plain text editor should result in the expected content, with newlines intact.

[preview]: https://nomad-git-zsbump-docs-page-hashicorp.vercel.app/docs/configuration
[live]: https://www.nomadproject.io/docs/configuration
