### PR TITLE
CSI: ensure all fields are mapped from structs to api response

### DIFF
--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -545,11 +545,20 @@ func structsCSIInfoToApi(info *structs.CSIInfo) *api.CSIInfo {
 	}
 
 	if info.ControllerInfo != nil {
+		ci := info.ControllerInfo
 		out.ControllerInfo = &api.CSIControllerInfo{
-			SupportsReadOnlyAttach:           info.ControllerInfo.SupportsReadOnlyAttach,
-			SupportsAttachDetach:             info.ControllerInfo.SupportsAttachDetach,
-			SupportsListVolumes:              info.ControllerInfo.SupportsListVolumes,
-			SupportsListVolumesAttachedNodes: info.ControllerInfo.SupportsListVolumesAttachedNodes,
+			SupportsCreateDelete:             ci.SupportsCreateDelete,
+			SupportsAttachDetach:             ci.SupportsAttachDetach,
+			SupportsListVolumes:              ci.SupportsListVolumes,
+			SupportsGetCapacity:              ci.SupportsGetCapacity,
+			SupportsCreateDeleteSnapshot:     ci.SupportsCreateDeleteSnapshot,
+			SupportsListSnapshots:            ci.SupportsListSnapshots,
+			SupportsClone:                    ci.SupportsClone,
+			SupportsReadOnlyAttach:           ci.SupportsReadOnlyAttach,
+			SupportsExpand:                   ci.SupportsExpand,
+			SupportsListVolumesAttachedNodes: ci.SupportsListVolumesAttachedNodes,
+			SupportsCondition:                ci.SupportsCondition,
+			SupportsGet:                      ci.SupportsGet,
 		}
 	}
 
@@ -558,6 +567,9 @@ func structsCSIInfoToApi(info *structs.CSIInfo) *api.CSIInfo {
 			ID:                      info.NodeInfo.ID,
 			MaxVolumes:              info.NodeInfo.MaxVolumes,
 			RequiresNodeStageVolume: info.NodeInfo.RequiresNodeStageVolume,
+			SupportsStats:           info.NodeInfo.SupportsStats,
+			SupportsExpand:          info.NodeInfo.SupportsExpand,
+			SupportsCondition:       info.NodeInfo.SupportsCondition,
 		}
 
 		if info.NodeInfo.AccessibleTopology != nil {


### PR DESCRIPTION
In PR #12108 we added missing fields to the plugin response, but we
didn't include the manual serialization steps that we need until
issue #10470 is resolved.

(We should almost certainly have a bunch of testing to ensure that we're mapping structs->api structs correctly, but I'd rather fix this particular case with #10470 but that's not in the scope for blocking 1.3.0)