### PR TITLE
api: paginated results with different ordering

### DIFF
--- a/api/evaluations_test.go
+++ b/api/evaluations_test.go
@@ -1,12 +1,11 @@
 package api
 
 import (
-	"reflect"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/api/internal/testutil"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEvaluations_List(t *testing.T) {
@@ -17,41 +16,27 @@ func TestEvaluations_List(t *testing.T) {
 
 	// Listing when nothing exists returns empty
 	result, qm, err := e.List(nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if qm.LastIndex != 0 {
-		t.Fatalf("bad index: %d", qm.LastIndex)
-	}
-	if n := len(result); n != 0 {
-		t.Fatalf("expected 0 evaluations, got: %d", n)
-	}
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), qm.LastIndex, "bad index")
+	require.Equal(t, 0, len(result), "expected 0 evaluations")
 
 	// Register a job. This will create an evaluation.
 	jobs := c.Jobs()
 	job := testJob()
 	resp, wm, err := jobs.Register(job, nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	require.NoError(t, err)
 	assertWriteMeta(t, wm)
 
 	// Check the evaluations again
 	result, qm, err = e.List(nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	require.NoError(t, err)
 	assertQueryMeta(t, qm)
 
 	// if the eval fails fast there can be more than 1
 	// but they are in order of most recent first, so look at the last one
-	if len(result) == 0 {
-		t.Fatalf("expected eval (%s), got none", resp.EvalID)
-	}
+	require.Greater(t, len(result), 0, "expected eval (%s), got none", resp.EvalID)
 	idx := len(result) - 1
-	if result[idx].ID != resp.EvalID {
-		t.Fatalf("expected eval (%s), got: %#v", resp.EvalID, result[idx])
-	}
+	require.Equal(t, resp.EvalID, result[idx].ID, "expected eval (%s), got: %#v", resp.EvalID, result[idx])
 
 	// wait until the 2nd eval shows up before we try paging
 	results := []*Evaluation{}
@@ -69,32 +54,22 @@ func TestEvaluations_List(t *testing.T) {
 	result, qm, err = e.List(&QueryOptions{
 		PerPage: int32(1),
 	})
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if len(result) != 1 {
-		t.Fatalf("expected no evals after last one but got %d: %#v", len(result), result)
-	}
+	require.NoError(t, err)
+	require.Equal(t, 1, len(result), "expected no evals after last one but got %d: %#v", len(result), result)
 
 	// query second page
 	result, qm, err = e.List(&QueryOptions{
 		PerPage:   int32(1),
 		NextToken: qm.NextToken,
 	})
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if len(result) != 1 {
-		t.Fatalf("expected no evals after last one but got %d: %#v", len(result), result)
-	}
+	require.NoError(t, err)
+	require.Equal(t, 1, len(result), "expected no evals after last one but got %d: %#v", len(result), result)
 
 	// Query evaluations using a filter.
 	results, _, err = e.List(&QueryOptions{
 		Filter: `TriggeredBy == "job-register"`,
 	})
-	if len(result) != 1 {
-		t.Fatalf("expected 1 eval, got %d", len(result))
-	}
+	require.Equal(t, 1, len(result), "expected 1 eval, got %d", len(result))
 }
 
 func TestEvaluations_PrefixList(t *testing.T) {
@@ -105,36 +80,25 @@ func TestEvaluations_PrefixList(t *testing.T) {
 
 	// Listing when nothing exists returns empty
 	result, qm, err := e.PrefixList("abcdef")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if qm.LastIndex != 0 {
-		t.Fatalf("bad index: %d", qm.LastIndex)
-	}
-	if n := len(result); n != 0 {
-		t.Fatalf("expected 0 evaluations, got: %d", n)
-	}
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), qm.LastIndex, "bad index")
+	require.Equal(t, 0, len(result), "expected 0 evaluations")
 
 	// Register a job. This will create an evaluation.
 	jobs := c.Jobs()
 	job := testJob()
 	resp, wm, err := jobs.Register(job, nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	require.NoError(t, err)
 	assertWriteMeta(t, wm)
 
 	// Check the evaluations again
 	result, qm, err = e.PrefixList(resp.EvalID[:4])
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	require.NoError(t, err)
 	assertQueryMeta(t, qm)
 
 	// Check if we have the right list
-	if len(result) != 1 || result[0].ID != resp.EvalID {
-		t.Fatalf("bad: %#v", result)
-	}
+	require.Equal(t, 1, len(result))
+	require.Equal(t, resp.EvalID, result[0].ID)
 }
 
 func TestEvaluations_Info(t *testing.T) {
@@ -145,30 +109,23 @@ func TestEvaluations_Info(t *testing.T) {
 
 	// Querying a nonexistent evaluation returns error
 	_, _, err := e.Info("8E231CF4-CA48-43FF-B694-5801E69E22FA", nil)
-	if err == nil || !strings.Contains(err.Error(), "not found") {
-		t.Fatalf("expected not found error, got: %s", err)
-	}
+	require.Error(t, err)
 
 	// Register a job. Creates a new evaluation.
 	jobs := c.Jobs()
 	job := testJob()
 	resp, wm, err := jobs.Register(job, nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	require.NoError(t, err)
 	assertWriteMeta(t, wm)
 
 	// Try looking up by the new eval ID
 	result, qm, err := e.Info(resp.EvalID, nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	require.NoError(t, err)
 	assertQueryMeta(t, qm)
 
 	// Check that we got the right result
-	if result == nil || result.ID != resp.EvalID {
-		t.Fatalf("expected eval %q, got: %#v", resp.EvalID, result)
-	}
+	require.NotNil(t, result)
+	require.Equal(t, resp.EvalID, result.ID)
 }
 
 func TestEvaluations_Allocations(t *testing.T) {
@@ -179,15 +136,9 @@ func TestEvaluations_Allocations(t *testing.T) {
 
 	// Returns empty if no allocations
 	allocs, qm, err := e.Allocations("8E231CF4-CA48-43FF-B694-5801E69E22FA", nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if qm.LastIndex != 0 {
-		t.Fatalf("bad index: %d", qm.LastIndex)
-	}
-	if n := len(allocs); n != 0 {
-		t.Fatalf("expected 0 allocs, got: %d", n)
-	}
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), qm.LastIndex, "bad index")
+	require.Equal(t, 0, len(allocs), "expected 0 evaluations")
 }
 
 func TestEvaluations_Sort(t *testing.T) {
@@ -204,7 +155,5 @@ func TestEvaluations_Sort(t *testing.T) {
 		{CreateIndex: 2},
 		{CreateIndex: 1},
 	}
-	if !reflect.DeepEqual(evals, expect) {
-		t.Fatalf("\n\n%#v\n\n%#v", evals, expect)
-	}
+	require.Equal(t, expect, evals)
 }

--- a/api/evaluations_test.go
+++ b/api/evaluations_test.go
@@ -65,17 +65,27 @@ func TestEvaluations_List(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	})
 
-	// Check the evaluations again with paging; note that while this
-	// package sorts by timestamp, the actual HTTP API sorts by ID
-	// so we need to use that for the NextToken
-	ids := []string{results[0].ID, results[1].ID}
-	sort.Strings(ids)
-	result, qm, err = e.List(&QueryOptions{PerPage: int32(1), NextToken: ids[1]})
+	// query first page
+	result, qm, err = e.List(&QueryOptions{
+		PerPage: int32(1),
+	})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	if len(result) != 1 {
-		t.Fatalf("expected no evals after last one but got %v", result[0])
+		t.Fatalf("expected no evals after last one but got %d: %#v", len(result), result)
+	}
+
+	// query second page
+	result, qm, err = e.List(&QueryOptions{
+		PerPage:   int32(1),
+		NextToken: qm.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected no evals after last one but got %d: %#v", len(result), result)
 	}
 
 	// Query evaluations using a filter.

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -21,6 +21,30 @@ const (
 	DefaultDequeueTimeout = time.Second
 )
 
+// EvalPaginationIterator is a wrapper over a go-memdb iterator that implements
+// the paginator Iterator interface.
+type EvalPaginationIterator struct {
+	iter          memdb.ResultIterator
+	byCreateIndex bool
+}
+
+func (it EvalPaginationIterator) Next() (string, interface{}) {
+	raw := it.iter.Next()
+	if raw == nil {
+		return "", nil
+	}
+
+	eval := raw.(*structs.Evaluation)
+	token := eval.ID
+
+	// prefix the pagination token by CreateIndex to keep it properly sorted.
+	if it.byCreateIndex {
+		token = fmt.Sprintf("%v-%v", eval.CreateIndex, eval.ID)
+	}
+
+	return token, eval
+}
+
 // Eval endpoint is used for eval interactions
 type Eval struct {
 	srv    *Server
@@ -414,13 +438,17 @@ func (e *Eval) List(args *structs.EvalListRequest, reply *structs.EvalListRespon
 			// Scan all the evaluations
 			var err error
 			var iter memdb.ResultIterator
+			var evalIter EvalPaginationIterator
 
 			if prefix := args.QueryOptions.Prefix; prefix != "" {
 				iter, err = store.EvalsByIDPrefix(ws, namespace, prefix)
+				evalIter.byCreateIndex = false
 			} else if namespace != structs.AllNamespacesSentinel {
 				iter, err = store.EvalsByNamespaceOrdered(ws, namespace, args.Ascending)
+				evalIter.byCreateIndex = true
 			} else {
 				iter, err = store.Evals(ws, args.Ascending)
+				evalIter.byCreateIndex = true
 			}
 			if err != nil {
 				return err
@@ -432,9 +460,10 @@ func (e *Eval) List(args *structs.EvalListRequest, reply *structs.EvalListRespon
 				}
 				return false
 			})
+			evalIter.iter = iter
 
 			var evals []*structs.Evaluation
-			paginator, err := state.NewPaginator(iter, args.QueryOptions,
+			paginator, err := state.NewPaginator(evalIter, args.QueryOptions,
 				func(raw interface{}) error {
 					eval := raw.(*structs.Evaluation)
 					evals = append(evals, eval)

--- a/nomad/eval_endpoint_test.go
+++ b/nomad/eval_endpoint_test.go
@@ -1013,40 +1013,51 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 	// in the order that the state store will return them from the
 	// iterator (sorted by create index), for ease of writing tests
 	mocks := []struct {
-		id        string
+		ids       []string
 		namespace string
 		jobID     string
 		status    string
 	}{
-		{id: "aaaa1111-3350-4b4b-d185-0e1992ed43e9", jobID: "example"},                    // 0
-		{id: "aaaaaa22-3350-4b4b-d185-0e1992ed43e9", jobID: "example"},                    // 1
-		{id: "aaaaaa33-3350-4b4b-d185-0e1992ed43e9", namespace: "non-default"},            // 2
-		{id: "aaaaaaaa-3350-4b4b-d185-0e1992ed43e9", jobID: "example", status: "blocked"}, // 3
-		{id: "aaaaaabb-3350-4b4b-d185-0e1992ed43e9"},                                      // 4
-		{id: "aaaaaacc-3350-4b4b-d185-0e1992ed43e9"},                                      // 5
-		{id: "aaaaaadd-3350-4b4b-d185-0e1992ed43e9", jobID: "example"},                    // 6
-		{id: "aaaaaaee-3350-4b4b-d185-0e1992ed43e9", jobID: "example"},                    // 7
-		{id: "aaaaaaff-3350-4b4b-d185-0e1992ed43e9"},                                      // 8
+		{ids: []string{"aaaa1111-3350-4b4b-d185-0e1992ed43e9"}, jobID: "example"},                    // 0
+		{ids: []string{"aaaaaa22-3350-4b4b-d185-0e1992ed43e9"}, jobID: "example"},                    // 1
+		{ids: []string{"aaaaaa33-3350-4b4b-d185-0e1992ed43e9"}, namespace: "non-default"},            // 2
+		{ids: []string{"aaaaaaaa-3350-4b4b-d185-0e1992ed43e9"}, jobID: "example", status: "blocked"}, // 3
+		{ids: []string{"aaaaaabb-3350-4b4b-d185-0e1992ed43e9"}},                                      // 4
+		{ids: []string{"aaaaaacc-3350-4b4b-d185-0e1992ed43e9"}},                                      // 5
+		{ids: []string{"aaaaaadd-3350-4b4b-d185-0e1992ed43e9"}, jobID: "example"},                    // 6
+		{ids: []string{"aaaaaaee-3350-4b4b-d185-0e1992ed43e9"}, jobID: "example"},                    // 7
+		{ids: []string{"aaaaaaff-3350-4b4b-d185-0e1992ed43e9"}},                                      // 8
+		{ids: []string{"00000111-3350-4b4b-d185-0e1992ed43e9"}},                                      // 9
+		{ids: []string{ // 10
+			"00000222-3350-4b4b-d185-0e1992ed43e9",
+			"00000333-3350-4b4b-d185-0e1992ed43e9",
+		}},
+		{}, // 11, index missing
+		{ids: []string{"bbbb1111-3350-4b4b-d185-0e1992ed43e9"}}, // 12
 	}
 
 	state := s1.fsm.State()
 
 	var evals []*structs.Evaluation
 	for i, m := range mocks {
-		eval := mock.Eval()
-		eval.ID = m.id
-		if m.namespace != "" { // defaults to "default"
-			eval.Namespace = m.namespace
+		evalsInTx := []*structs.Evaluation{}
+		for _, id := range m.ids {
+			eval := mock.Eval()
+			eval.ID = id
+			if m.namespace != "" { // defaults to "default"
+				eval.Namespace = m.namespace
+			}
+			if m.jobID != "" { // defaults to some random UUID
+				eval.JobID = m.jobID
+			}
+			if m.status != "" { // defaults to "pending"
+				eval.Status = m.status
+			}
+			evals = append(evals, eval)
+			evalsInTx = append(evalsInTx, eval)
 		}
-		if m.jobID != "" { // defaults to some random UUID
-			eval.JobID = m.jobID
-		}
-		if m.status != "" { // defaults to "pending"
-			eval.Status = m.status
-		}
-		evals = append(evals, eval)
 		index := 1000 + uint64(i)
-		require.NoError(t, state.UpsertEvals(structs.MsgTypeTestSetup, index, []*structs.Evaluation{eval}))
+		require.NoError(t, state.UpsertEvals(structs.MsgTypeTestSetup, index, evalsInTx))
 	}
 
 	aclToken := mock.CreatePolicyAndToken(t, state, 1100, "test-valid-read",
@@ -1073,13 +1084,13 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
 				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
 			},
-			expectedNextToken: "aaaaaaaa-3350-4b4b-d185-0e1992ed43e9", // next one in default namespace
+			expectedNextToken: "1003-aaaaaaaa-3350-4b4b-d185-0e1992ed43e9", // next one in default namespace
 		},
 		{
 			name:              "test02 size-2 page-1 default NS with prefix",
 			prefix:            "aaaa",
 			pageSize:          2,
-			expectedNextToken: "aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "aaaaaaaa-3350-4b4b-d185-0e1992ed43e9", // prefix results are not sorted by create index
 			expectedIDs: []string{
 				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
 				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
@@ -1088,8 +1099,8 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 		{
 			name:              "test03 size-2 page-2 default NS",
 			pageSize:          2,
-			nextToken:         "aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
-			expectedNextToken: "aaaaaacc-3350-4b4b-d185-0e1992ed43e9",
+			nextToken:         "1003-aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1005-aaaaaacc-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{
 				"aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
 				"aaaaaabb-3350-4b4b-d185-0e1992ed43e9",
@@ -1112,7 +1123,7 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 			filterJobID:  "example",
 			filterStatus: "pending",
 			// aaaaaaaa, bb, and cc are filtered by status
-			expectedNextToken: "aaaaaadd-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1006-aaaaaadd-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{
 				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
 				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
@@ -1148,7 +1159,7 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 			pageSize:          3,                                            // reads off the end
 			filterJobID:       "example",
 			filterStatus:      "pending",
-			nextToken:         "aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+			nextToken:         "1003-aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
 			expectedNextToken: "",
 			expectedIDs: []string{
 				"aaaaaadd-3350-4b4b-d185-0e1992ed43e9",
@@ -1169,14 +1180,25 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 			},
 		},
 		{
-			name:        "test10 no valid results with filters",
+			name:              "test10 size-2 page-2 all namespaces",
+			namespace:         "*",
+			pageSize:          2,
+			nextToken:         "1002-aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1004-aaaaaabb-3350-4b4b-d185-0e1992ed43e9",
+			expectedIDs: []string{
+				"aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
+				"aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:        "test11 no valid results with filters",
 			pageSize:    2,
 			filterJobID: "whatever",
 			nextToken:   "",
 			expectedIDs: []string{},
 		},
 		{
-			name:        "test11 no valid results with filters and prefix",
+			name:        "test12 no valid results with filters and prefix",
 			prefix:      "aaaa",
 			pageSize:    2,
 			filterJobID: "whatever",
@@ -1184,36 +1206,36 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 			expectedIDs: []string{},
 		},
 		{
-			name:        "test12 no valid results with filters page-2",
+			name:        "test13 no valid results with filters page-2",
 			filterJobID: "whatever",
 			nextToken:   "aaaaaa11-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{},
 		},
 		{
-			name:        "test13 no valid results with filters page-2 with prefix",
+			name:        "test14 no valid results with filters page-2 with prefix",
 			prefix:      "aaaa",
 			filterJobID: "whatever",
 			nextToken:   "aaaaaa11-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{},
 		},
 		{
-			name:        "test14 go-bexpr filter",
+			name:        "test15 go-bexpr filter",
 			filter:      `Status == "blocked"`,
 			nextToken:   "",
 			expectedIDs: []string{"aaaaaaaa-3350-4b4b-d185-0e1992ed43e9"},
 		},
 		{
-			name:              "test15 go-bexpr filter with pagination",
+			name:              "test16 go-bexpr filter with pagination",
 			filter:            `JobID == "example"`,
 			pageSize:          2,
-			expectedNextToken: "aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1003-aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{
 				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
 				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
 			},
 		},
 		{
-			name:      "test16 go-bexpr filter namespace",
+			name:      "test17 go-bexpr filter namespace",
 			namespace: "non-default",
 			filter:    `ID contains "aaa"`,
 			expectedIDs: []string{
@@ -1221,26 +1243,52 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 			},
 		},
 		{
-			name:        "test17 go-bexpr wrong namespace",
+			name:        "test18 go-bexpr wrong namespace",
 			namespace:   "default",
 			filter:      `Namespace == "non-default"`,
 			expectedIDs: []string{},
 		},
 		{
-			name:          "test18 incompatible filtering",
+			name:          "test19 incompatible filtering",
 			filter:        `JobID == "example"`,
 			filterStatus:  "complete",
 			expectedError: structs.ErrIncompatibleFiltering.Error(),
 		},
 		{
-			name:          "test19 go-bexpr invalid expression",
+			name:          "test20 go-bexpr invalid expression",
 			filter:        `NotValid`,
 			expectedError: "failed to read filter expression",
 		},
 		{
-			name:          "test20 go-bexpr invalid field",
+			name:          "test21 go-bexpr invalid field",
 			filter:        `InvalidField == "value"`,
 			expectedError: "error finding value in datum",
+		},
+		{
+			name:              "test22 non-lexicographic order",
+			pageSize:          1,
+			nextToken:         "1009-00000111-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1010-00000222-3350-4b4b-d185-0e1992ed43e9",
+			expectedIDs: []string{
+				"00000111-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:              "test23 same index",
+			pageSize:          1,
+			nextToken:         "1010-00000222-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1010-00000333-3350-4b4b-d185-0e1992ed43e9",
+			expectedIDs: []string{
+				"00000222-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:      "test24 missing index",
+			pageSize:  1,
+			nextToken: "1011-e9522802-0cd8-4b1d-9c9e-ab3d97938371",
+			expectedIDs: []string{
+				"bbbb1111-3350-4b4b-d185-0e1992ed43e9",
+			},
 		},
 	}
 

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -320,9 +320,16 @@ func deploymentSchema() *memdb.TableSchema {
 			"create": {
 				Name:         "create",
 				AllowMissing: false,
-				Unique:       false,
-				Indexer: &memdb.UintFieldIndex{
-					Field: "CreateIndex",
+				Unique:       true,
+				Indexer: &memdb.CompoundIndex{
+					Indexes: []memdb.Indexer{
+						&memdb.UintFieldIndex{
+							Field: "CreateIndex",
+						},
+						&memdb.StringFieldIndex{
+							Field: "ID",
+						},
+					},
 				},
 			},
 
@@ -346,7 +353,7 @@ func deploymentSchema() *memdb.TableSchema {
 			"namespace_create": {
 				Name:         "namespace_create",
 				AllowMissing: false,
-				Unique:       false,
+				Unique:       true,
 				Indexer: &memdb.CompoundIndex{
 					AllowMissing: false,
 					Indexes: []memdb.Indexer{
@@ -355,6 +362,9 @@ func deploymentSchema() *memdb.TableSchema {
 						},
 						&memdb.UintFieldIndex{
 							Field: "CreateIndex",
+						},
+						&memdb.StringFieldIndex{
+							Field: "ID",
 						},
 					},
 				},
@@ -438,9 +448,16 @@ func evalTableSchema() *memdb.TableSchema {
 			"create": {
 				Name:         "create",
 				AllowMissing: false,
-				Unique:       false,
-				Indexer: &memdb.UintFieldIndex{
-					Field: "CreateIndex",
+				Unique:       true,
+				Indexer: &memdb.CompoundIndex{
+					Indexes: []memdb.Indexer{
+						&memdb.UintFieldIndex{
+							Field: "CreateIndex",
+						},
+						&memdb.StringFieldIndex{
+							Field: "ID",
+						},
+					},
 				},
 			},
 
@@ -486,7 +503,7 @@ func evalTableSchema() *memdb.TableSchema {
 			"namespace_create": {
 				Name:         "namespace_create",
 				AllowMissing: false,
-				Unique:       false,
+				Unique:       true,
 				Indexer: &memdb.CompoundIndex{
 					AllowMissing: false,
 					Indexes: []memdb.Indexer{
@@ -495,6 +512,9 @@ func evalTableSchema() *memdb.TableSchema {
 						},
 						&memdb.UintFieldIndex{
 							Field: "CreateIndex",
+						},
+						&memdb.StringFieldIndex{
+							Field: "ID",
 						},
 					},
 				},

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10548,14 +10548,6 @@ type Evaluation struct {
 	ModifyTime int64
 }
 
-// GetID implements the IDGetter interface, required for pagination
-func (e *Evaluation) GetID() string {
-	if e == nil {
-		return ""
-	}
-	return e.ID
-}
-
 // TerminalStatus returns if the current status is terminal and
 // will no longer transition.
 func (e *Evaluation) TerminalStatus() bool {


### PR DESCRIPTION
The paginator logic was built when go-memdb iterators would return items
ordered lexicographically by their ID prefixes, but #12054 added the
option for some tables to return results ordered by their `CreateIndex`
instead, which invalidated the previous paginator assumption.
                                                                         
The iterator used for pagination must still return results in some order
so that the paginator can properly handle requests where the next_token
value is not present in the results anymore (e.g., the eval was GC'ed).
                                                                         
In these situations, the paginator will start the returned page in the
first element right after where the requested token should've been.
                                                                         
This commit moves the logic to generate pagination tokens from the
elements being paginated to the iterator itself so that callers can have
more control over the token format to make sure they are properly
ordered and stable.
                                                                         
It also allows configuring the paginator as being ordered in ascending
or descending order, which is relevant when looking for a token that may
not be present anymore.

-----
Note to reviewers: this PR was re-worked a few times, so I squashed and force-pused a single commit because the commit history was a mess. The resulting changes turned out to be not that big, but let me know if it would help to break it into multiple commits instead of just one.
