### PR TITLE
disconnected clients: Add reconnect task event

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -967,6 +967,7 @@ const (
 	TaskRestartSignal          = "Restart Signaled"
 	TaskLeaderDead             = "Leader Task Dead"
 	TaskBuildingTaskDir        = "Building Task Directory"
+	TaskClientReconnected      = "Reconnected"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -777,6 +777,17 @@ func (ar *allocRunner) NetworkStatus() *structs.AllocNetworkStatus {
 	return ar.state.NetworkStatus.Copy()
 }
 
+// setIndexes is a helper for forcing a set of server side indexes
+// on the alloc runner. This is used during reconnect when the task
+// has been marked unknown by the server.
+func (ar *allocRunner) setIndexes(update *structs.Allocation) {
+	ar.allocLock.Lock()
+	defer ar.allocLock.Unlock()
+	ar.alloc.AllocModifyIndex = update.AllocModifyIndex
+	ar.alloc.ModifyIndex = update.ModifyIndex
+	ar.alloc.ModifyTime = update.ModifyTime
+}
+
 // AllocState returns a copy of allocation state including a snapshot of task
 // states.
 func (ar *allocRunner) AllocState() *state.State {
@@ -1233,31 +1244,41 @@ func (ar *allocRunner) Signal(taskName, signal string) error {
 	return err.ErrorOrNil()
 }
 
-// Reconnect emits a reconnect event on each task runner for the allocation.
-func (ar *allocRunner) Reconnect() {
-	// Guard against the server sending update requests faster than the state
-	// gets propagated back to it.
-	now := time.Now()
-	taskStates := ar.AllocState().TaskStates
-	for _, taskState := range taskStates {
-		for _, taskEvent := range taskState.Events {
-			if taskEvent.Type != structs.TaskClientReconnected {
-				continue
-			}
+// Reconnect logs a reconnect event for each task in the allocation and syncs the current alloc state with the server.
+func (ar *allocRunner) Reconnect(update *structs.Allocation) (err error) {
+	ar.logger.Trace("reconnecting alloc", "alloc_id", update.ID, "alloc_modify_index", update.AllocModifyIndex)
 
-			if now.Sub(time.Unix(0, taskEvent.Time)) < (5 * time.Second) {
-				ar.logger.Trace("skipping due to recent reconnect")
-				return
-			}
-		}
-	}
-
-	// This triggers an update that has the side effect of changing the current
-	// client status on the server from unknown to whatever is on the client.
 	event := structs.NewTaskEvent(structs.TaskClientReconnected)
 	for _, tr := range ar.tasks {
-		tr.EmitEvent(event)
+		tr.AppendEvent(event)
 	}
+
+	// Update the client alloc with the server client side indexes.
+	ar.setIndexes(update)
+
+	// Calculate alloc state to get the final state with the new events.
+	// Cannot rely on AllocStates as it won't recompute TaskStates once they are set.
+	states := make(map[string]*structs.TaskState, len(ar.tasks))
+	for name, tr := range ar.tasks {
+		states[name] = tr.TaskState()
+	}
+
+	// Build the client allocation
+	alloc := ar.clientAlloc(states)
+
+	// Update the client state store.
+	err = ar.stateUpdater.PutAllocation(alloc)
+	if err != nil {
+		return
+	}
+
+	// Update the server.
+	ar.stateUpdater.AllocStateUpdated(alloc)
+
+	// Broadcast client alloc to listeners.
+	err = ar.allocBroadcaster.Send(alloc)
+
+	return
 }
 
 func (ar *allocRunner) GetTaskExecHandler(taskName string) drivermanager.TaskExecHandler {

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -1233,82 +1233,31 @@ func (ar *allocRunner) Signal(taskName, signal string) error {
 	return err.ErrorOrNil()
 }
 
-// Reconnect synchronizes client state between an incoming unknown allocation and
-// the current allocRunner and appends a reconnect event to each task if alloc is running.
-func (ar *allocRunner) Reconnect(update *structs.Allocation) {
+// Reconnect emits a reconnect event on each task runner for the allocation.
+func (ar *allocRunner) Reconnect() {
 	// Guard against the server sending update requests faster than the state
-	// gets propagated back to them.
-	if ar.hasPendingReconnect() {
-		ar.logger.Trace("skipping due to recent reconnect")
-		return
-	}
-
-	ar.maybeAppendReconnectEvent()
-
-	// Populate the alloc with updated events.
-	clientAlloc := ar.clientAlloc(ar.TaskRunnerTaskStates())
-
-	// Sync the incoming server state with the actual client state including the newly minted event.
-	update.ClientStatus = clientAlloc.ClientStatus
-	update.ClientDescription = clientAlloc.ClientDescription
-	update.TaskStates = clientAlloc.TaskStates
-
-	// Update the local copy of alloc.
-	if err := ar.stateDB.PutAllocation(update); err != nil {
-		ar.logger.Error("error reconnecting alloc when persisting updated alloc locally", "error", err, "alloc_id", update.ID)
-		return
-	}
-
-	// Sync the alloc runner. Important for ensuring the AllocModifyIndex is propagated.
-	// Do not call setAlloc on TaskRunners. That will restart the alloc.
-	ar.setAlloc(update)
-
-	// Update the server.
-	ar.stateUpdater.AllocStateUpdated(update)
-}
-
-// hasPendingReconnect checks the current alloc TaskRunnerTaskStates to see if a recent
-// reconnect event was appended. This is useful for allowing the client state to
-// have time to propagate to the servers before attempting another reconnect.
-func (ar *allocRunner) hasPendingReconnect() bool {
+	// gets propagated back to it.
 	now := time.Now()
-
-	for _, taskState := range ar.TaskRunnerTaskStates() {
+	taskStates := ar.AllocState().TaskStates
+	for _, taskState := range taskStates {
 		for _, taskEvent := range taskState.Events {
 			if taskEvent.Type != structs.TaskClientReconnected {
 				continue
 			}
 
 			if now.Sub(time.Unix(0, taskEvent.Time)) < (5 * time.Second) {
-				return true
+				ar.logger.Trace("skipping due to recent reconnect")
+				return
 			}
 		}
 	}
 
-	return false
-}
-
-// maybeAppendReconnectEvent appends a reconnect event if the computed client status is running.
-func (ar *allocRunner) maybeAppendReconnectEvent() {
-	clientStatus, _ := getClientStatus(ar.TaskRunnerTaskStates())
-
-	if clientStatus != structs.AllocClientStatusRunning {
-		return
-	}
-
+	// This triggers an update that has the side effect of changing the current
+	// client status on the server from unknown to whatever is on the client.
 	event := structs.NewTaskEvent(structs.TaskClientReconnected)
 	for _, tr := range ar.tasks {
-		tr.AppendEvent(event)
+		tr.EmitEvent(event)
 	}
-}
-
-// TaskRunnerTaskStates creates a map of task states by taskName.
-func (ar *allocRunner) TaskRunnerTaskStates() map[string]*structs.TaskState {
-	states := make(map[string]*structs.TaskState, len(ar.tasks))
-	for taskName, tr := range ar.tasks {
-		states[taskName] = tr.TaskState()
-	}
-	return states
 }
 
 func (ar *allocRunner) GetTaskExecHandler(taskName string) drivermanager.TaskExecHandler {

--- a/client/allocrunner/testing.go
+++ b/client/allocrunner/testing.go
@@ -35,6 +35,11 @@ func (m *MockStateUpdater) AllocStateUpdated(alloc *structs.Allocation) {
 	m.mu.Unlock()
 }
 
+// PutAllocation satisfies the AllocStateHandler interface.
+func (m *MockStateUpdater) PutAllocation(alloc *structs.Allocation) (err error) {
+	return
+}
+
 // Last returns a copy of the last alloc (or nil) update. Safe for concurrent
 // access with updates.
 func (m *MockStateUpdater) Last() *structs.Allocation {

--- a/client/client.go
+++ b/client/client.go
@@ -2413,7 +2413,7 @@ func (c *Client) updateAlloc(update *structs.Allocation) {
 	if update.ClientStatus == structs.AllocClientStatusUnknown && update.AllocModifyIndex > ar.Alloc().AllocModifyIndex {
 		err = ar.Reconnect(update)
 		if err != nil {
-			c.logger.Trace("error reconnecting alloc", "alloc_id", update.ID, "alloc_modify_index", update.AllocModifyIndex, "err", err)
+			c.logger.Error("error reconnecting alloc", "alloc_id", update.ID, "alloc_modify_index", update.AllocModifyIndex, "err", err)
 		}
 		return
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -156,6 +156,7 @@ type AllocRunner interface {
 
 	RestartTask(taskName string, taskEvent *structs.TaskEvent) error
 	RestartAll(taskEvent *structs.TaskEvent) error
+	Reconnect(update *structs.Allocation)
 
 	GetTaskExecHandler(taskName string) drivermanager.TaskExecHandler
 	GetTaskDriverCapabilities(taskName string) (*drivers.Capabilities, error)
@@ -2405,9 +2406,8 @@ func (c *Client) updateAlloc(update *structs.Allocation) {
 
 	// Reconnect unknown allocations
 	if update.ClientStatus == structs.AllocClientStatusUnknown && update.AllocModifyIndex > ar.Alloc().AllocModifyIndex {
-		update.ClientStatus = ar.AllocState().ClientStatus
-		update.ClientDescription = ar.AllocState().ClientDescription
-		c.AllocStateUpdated(update)
+		ar.Reconnect(update)
+		return
 	}
 
 	// Update local copy of alloc

--- a/client/client.go
+++ b/client/client.go
@@ -156,7 +156,7 @@ type AllocRunner interface {
 
 	RestartTask(taskName string, taskEvent *structs.TaskEvent) error
 	RestartAll(taskEvent *structs.TaskEvent) error
-	Reconnect()
+	Reconnect(update *structs.Allocation) error
 
 	GetTaskExecHandler(taskName string) drivermanager.TaskExecHandler
 	GetTaskDriverCapabilities(taskName string) (*drivers.Capabilities, error)
@@ -1962,6 +1962,11 @@ func (c *Client) AllocStateUpdated(alloc *structs.Allocation) {
 	}
 }
 
+// PutAllocation stores an allocation or returns an error if it could not be stored.
+func (c *Client) PutAllocation(alloc *structs.Allocation) error {
+	return c.stateDB.PutAllocation(alloc)
+}
+
 // allocSync is a long lived function that batches allocation updates to the
 // server.
 func (c *Client) allocSync() {
@@ -2406,7 +2411,10 @@ func (c *Client) updateAlloc(update *structs.Allocation) {
 
 	// Reconnect unknown allocations
 	if update.ClientStatus == structs.AllocClientStatusUnknown && update.AllocModifyIndex > ar.Alloc().AllocModifyIndex {
-		ar.Reconnect()
+		err = ar.Reconnect(update)
+		if err != nil {
+			c.logger.Trace("error reconnecting alloc", "alloc_id", update.ID, "alloc_modify_index", update.AllocModifyIndex, "err", err)
+		}
 		return
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -156,7 +156,7 @@ type AllocRunner interface {
 
 	RestartTask(taskName string, taskEvent *structs.TaskEvent) error
 	RestartAll(taskEvent *structs.TaskEvent) error
-	Reconnect(update *structs.Allocation)
+	Reconnect()
 
 	GetTaskExecHandler(taskName string) drivermanager.TaskExecHandler
 	GetTaskDriverCapabilities(taskName string) (*drivers.Capabilities, error)
@@ -2406,7 +2406,7 @@ func (c *Client) updateAlloc(update *structs.Allocation) {
 
 	// Reconnect unknown allocations
 	if update.ClientStatus == structs.AllocClientStatusUnknown && update.AllocModifyIndex > ar.Alloc().AllocModifyIndex {
-		ar.Reconnect(update)
+		ar.Reconnect()
 		return
 	}
 

--- a/client/interfaces/client.go
+++ b/client/interfaces/client.go
@@ -14,6 +14,9 @@ type AllocStateHandler interface {
 	// AllocStateUpdated is used to emit an updated allocation. This allocation
 	// is stripped to only include client settable fields.
 	AllocStateUpdated(alloc *structs.Allocation)
+
+	// PutAllocation is used to persist an updated allocation in the local state store.
+	PutAllocation(*structs.Allocation) error
 }
 
 // DeviceStatsReporter gives access to the latest resource usage

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -538,6 +538,8 @@ func buildDisplayMessage(event *api.TaskEvent) string {
 		desc = event.DriverMessage
 	case api.TaskLeaderDead:
 		desc = "Leader Task in Group dead"
+	case api.TaskClientReconnected:
+		desc = "Client reconnected"
 	default:
 		desc = event.Message
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7871,6 +7871,9 @@ const (
 
 	// TaskPluginHealthy indicates that a plugin managed by Nomad became healthy
 	TaskPluginHealthy = "Plugin became healthy"
+
+	// TaskClientReconnected indicates that the client running the task disconnected.
+	TaskClientReconnected = "Reconnected"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data
@@ -8082,6 +8085,8 @@ func (e *TaskEvent) PopulateEventDisplayMessage() {
 		desc = "Leader Task in Group dead"
 	case TaskMainDead:
 		desc = "Main tasks in the group died"
+	case TaskClientReconnected:
+		desc = "Client reconnected"
 	default:
 		desc = e.Message
 	}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -5569,7 +5569,8 @@ func TestTaskEventPopulate(t *testing.T) {
 		{NewTaskEvent(TaskSignaling).SetTaskSignal(os.Interrupt).SetTaskSignalReason("process interrupted"), "Task being sent signal interrupt: process interrupted"},
 		{NewTaskEvent(TaskRestartSignal), "Task signaled to restart"},
 		{NewTaskEvent(TaskRestartSignal).SetRestartReason("Chaos Monkey restarted it"), "Chaos Monkey restarted it"},
-		{NewTaskEvent(TaskDriverMessage).SetDriverMessage("YOLO"), "YOLO"},
+		{NewTaskEvent(TaskClientReconnected), "Client reconnected"},
+		{NewTaskEvent(TaskLeaderDead), "Leader Task in Group dead"},
 		{NewTaskEvent("Unknown Type, No message"), ""},
 		{NewTaskEvent("Unknown Type").SetMessage("Hello world"), "Hello world"},
 	}

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -419,9 +419,9 @@ func (s *GenericScheduler) computeJobAllocs() error {
 		s.ctx.Plan().AppendAlloc(update, nil)
 	}
 
-	// Handle reconnect updates
+	// Log reconnect updates. They will be pulled by the client when it reconnects.
 	for _, update := range results.reconnectUpdates {
-		s.ctx.Plan().AppendAlloc(update, nil)
+		s.logger.Trace("reconnecting alloc", "alloc_id", update.ID, "alloc_modify_index", update.AllocModifyIndex)
 	}
 
 	// Nothing remaining to do if placement is not required


### PR DESCRIPTION
This PR introduces a new `TaskClientReconnected` task event. This task event will be appended by the `allocRunner` each time an unknown alloc is reconnected after the `client` comes back online.

This PR includes:

- The changes related to defining the `TaskEvent` and translating it to meaningful human text for display.
- Refactors the reconnect logic out of the `client` and into the `allocRunner` as it has grown in scope. Specifically, the logic workflow is now:
  - Appends a task event entry for allocs still running on the `client`.
  -  Updates the existing alloc instance with the indexes from the incoming update.
  - Recomputes task states with new events.
  - Calls `clientAlloc` to compute the current alloc state including the appended events.
  - Updates the `client` state store with the updated alloc. Exits if this fails.
  - Propagates the `client` alloc state to the server. 
  - Broadcasts the alloc update to all listeners.
  - Removes reconnects from the `Plan` as they will be pulled by the node when it reconnects.