### PR TITLE
Add metadata to namespaces

### DIFF
--- a/.changelog/12138.txt
+++ b/.changelog/12138.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+namespaces: Allow adding custom metadata to namespaces.
+```

--- a/api/namespace.go
+++ b/api/namespace.go
@@ -71,6 +71,7 @@ type Namespace struct {
 	Description  string
 	Quota        string
 	Capabilities *NamespaceCapabilities `hcl:"capabilities,block"`
+	Meta         map[string]string
 	CreateIndex  uint64
 	ModifyIndex  uint64
 }

--- a/command/agent/namespace_endpoint_test.go
+++ b/command/agent/namespace_endpoint_test.go
@@ -1,6 +1,3 @@
-//go:build ent
-// +build ent
-
 package agent
 
 import (

--- a/command/namespace_apply.go
+++ b/command/namespace_apply.go
@@ -61,7 +61,11 @@ func (c *NamespaceApplyCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *NamespaceApplyCommand) AutocompleteArgs() complete.Predictor {
-	return NamespacePredictor(c.Meta.Client, nil)
+	return complete.PredictOr(
+		NamespacePredictor(c.Meta.Client, nil),
+		complete.PredictFiles("*.hcl"),
+		complete.PredictFiles("*.json"),
+	)
 }
 
 func (c *NamespaceApplyCommand) Synopsis() string {

--- a/command/namespace_apply.go
+++ b/command/namespace_apply.go
@@ -216,6 +216,7 @@ func parseNamespaceSpecImpl(result *api.Namespace, list *ast.ObjectList) error {
 	}
 
 	delete(m, "capabilities")
+	delete(m, "meta")
 
 	// Decode the rest
 	if err := mapstructure.WeakDecode(m, result); err != nil {
@@ -235,6 +236,18 @@ func parseNamespaceSpecImpl(result *api.Namespace, list *ast.ObjectList) error {
 			}
 			result.Capabilities = opts
 			break
+		}
+	}
+
+	if metaO := list.Filter("meta"); len(metaO.Items) > 0 {
+		for _, o := range metaO.Elem().Items {
+			var m map[string]interface{}
+			if err := hcl.DecodeObject(&m, o.Val); err != nil {
+				return err
+			}
+			if err := mapstructure.WeakDecode(m, &result.Meta); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/command/namespace_apply_test.go
+++ b/command/namespace_apply_test.go
@@ -1,6 +1,3 @@
-//go:build ent
-// +build ent
-
 package command
 
 import (

--- a/command/namespace_delete_test.go
+++ b/command/namespace_delete_test.go
@@ -1,6 +1,3 @@
-//go:build ent
-// +build ent
-
 package command
 
 import (

--- a/command/namespace_inspect_test.go
+++ b/command/namespace_inspect_test.go
@@ -1,6 +1,3 @@
-//go:build ent
-// +build ent
-
 package command
 
 import (

--- a/command/namespace_list_test.go
+++ b/command/namespace_list_test.go
@@ -1,6 +1,3 @@
-//go:build ent
-// +build ent
-
 package command
 
 import (
@@ -10,10 +7,7 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-func TestNamespaceListCommand_Implements(t *testing.T) {
-	t.Parallel()
-	var _ cli.Command = &NamespaceListCommand{}
-}
+var _ cli.Command = (*NamespaceListCommand)(nil)
 
 func TestNamespaceListCommand_Fails(t *testing.T) {
 	t.Parallel()

--- a/command/namespace_status.go
+++ b/command/namespace_status.go
@@ -84,14 +84,12 @@ func (c *NamespaceStatusCommand) Run(args []string) int {
 
 	if len(ns.Meta) > 0 {
 		c.Ui.Output(c.Colorize().Color("\n[bold]Metadata[reset]"))
-		var keys []string
+		var meta []string
 		for k := range ns.Meta {
-			keys = append(keys, k)
+			meta = append(meta, fmt.Sprintf("%s|%s", k, ns.Meta[k]))
 		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			c.Ui.Output(fmt.Sprintf("%s:\x1f%s", k, ns.Meta[k]))
-		}
+		sort.Strings(meta)
+		c.Ui.Output(formatKV(meta))
 	}
 
 	if ns.Quota != "" {

--- a/command/namespace_status.go
+++ b/command/namespace_status.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
@@ -80,6 +81,18 @@ func (c *NamespaceStatusCommand) Run(args []string) int {
 	}
 
 	c.Ui.Output(formatNamespaceBasics(ns))
+
+	if len(ns.Meta) > 0 {
+		c.Ui.Output(c.Colorize().Color("\n[bold]Metadata[reset]"))
+		var keys []string
+		for k := range ns.Meta {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			c.Ui.Output(fmt.Sprintf("%s:\x1f%s", k, ns.Meta[k]))
+		}
+	}
 
 	if ns.Quota != "" {
 		quotas := client.Quotas()

--- a/command/namespace_status_oss_test.go
+++ b/command/namespace_status_oss_test.go
@@ -1,0 +1,10 @@
+//go:build !ent
+// +build !ent
+
+package command
+
+import "github.com/hashicorp/nomad/api"
+
+func testQuotaSpec() *api.QuotaSpec {
+	panic("not implemented - enterprise only")
+}

--- a/command/namespace_status_test.go
+++ b/command/namespace_status_test.go
@@ -1,6 +1,3 @@
-//go:build ent
-// +build ent
-
 package command
 
 import (
@@ -76,6 +73,10 @@ func TestNamespaceStatusCommand_Good_Quota(t *testing.T) {
 	// Create a server
 	srv, client, url := testServer(t, true, nil)
 	defer srv.Shutdown()
+
+	if !srv.Enterprise {
+		t.Skip("Skipping enterprise-only quota test")
+	}
 
 	ui := cli.NewMockUi()
 	cmd := &NamespaceStatusCommand{Meta: Meta{Ui: ui}}

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -2246,8 +2246,10 @@ func AllocNetworkStatus() *structs.AllocNetworkStatus {
 }
 
 func Namespace() *structs.Namespace {
+	uuid := uuid.Generate()
 	ns := &structs.Namespace{
-		Name:        fmt.Sprintf("team-%s", uuid.Generate()),
+		Name:        fmt.Sprintf("team-%s", uuid),
+		Meta:        map[string]string{"team": uuid},
 		Description: "test namespace",
 		CreateIndex: 100,
 		ModifyIndex: 200,

--- a/website/content/api-docs/namespaces.mdx
+++ b/website/content/api-docs/namespaces.mdx
@@ -48,17 +48,24 @@ $ curl \
 ```json
 [
   {
-    "CreateIndex": 31,
-    "Description": "Production API Servers",
-    "ModifyIndex": 31,
-    "Name": "api-prod",
+    "Capabilities": null,
+    "CreateIndex": 1,
+    "Description": "Default shared namespace",
+    "Meta": null,
+    "ModifyIndex": 1,
+    "Name": "default",
     "Quota": ""
   },
   {
-    "CreateIndex": 5,
-    "Description": "Default shared namespace",
-    "ModifyIndex": 5,
-    "Name": "default",
+    "Capabilities": null,
+    "CreateIndex": 17,
+    "Description": "Development Staging Namespace",
+    "Meta": {
+        "type": "dev",
+        "contact": "helpdesk@example.com"
+    },
+    "ModifyIndex": 17,
+    "Name": "staging",
     "Quota": ""
   }
 ]
@@ -88,19 +95,23 @@ The table below shows this endpoint's support for
 
 ```shell-session
 $ curl \
-    https://localhost:4646/v1/namespace/api-prod
+    https://localhost:4646/v1/namespace/staging
 ```
 
 ### Sample Response
 
 ```json
 {
-  "CreateIndex": 31,
-  "Description": "Production API Servers",
-  "Quota": "",
-  "Hash": "N8WvePwqkp6J354eLJMKyhvsFdPELAos0VuBfMoVKoU=",
-  "ModifyIndex": 31,
-  "Name": "api-prod"
+  "Capabilities": null,
+  "CreateIndex": 17,
+  "Description": "Development Staging Namespace",
+  "Meta": {
+    "type": "dev",
+    "contact": "helpdesk@example.com"
+  },
+  "ModifyIndex": 17,
+  "Name": "staging",
+  "Quota": ""
 }
 ```
 
@@ -128,6 +139,10 @@ The table below shows this endpoint's support for
 - `Description` `(string: "")` - Specifies an optional human-readable
   description of the namespace.
 
+- `Meta` `(object: null)` - Optional object with string keys and values of
+  metadata to attach to the namespace. Namespace metadata is not used by Nomad
+  and is intended for use by operators and third party tools.
+
 - `Quota` `(string: "")` - Specifies an quota to attach to the namespace.
 
 ### Sample Payload
@@ -136,9 +151,14 @@ The table below shows this endpoint's support for
 {
   "Name": "api-prod",
   "Description": "Production API Servers",
+  "Meta": {
+    "contact": "platform-eng@example.com"
+  },
   "Quota": "prod-quota"
 }
 ```
+
+Note that the `Quota` key is Enterprise-only.
 
 ### Sample Request
 

--- a/website/content/docs/commands/namespace/apply.mdx
+++ b/website/content/docs/commands/namespace/apply.mdx
@@ -64,5 +64,10 @@ capabilities {
   enabled_task_drivers  = ["docker", "exec"]
   disabled_task_drivers = ["raw_exec"]
 }
+
+meta {
+  owner = "John Doe"
+  contact_mail = "john@mycompany.com
+}
 $ nomad namespace apply namespace.json
 ```

--- a/website/content/docs/commands/namespace/apply.mdx
+++ b/website/content/docs/commands/namespace/apply.mdx
@@ -18,7 +18,7 @@ when introduced in Nomad 0.7.
 nomad namespace apply [options] <input>
 ```
 
-Apply is used to create or update a namespace. The specification file
+Apply is used to create or update a namespace. The HCL specification file
 will be read from stdin by specifying "-", otherwise a path to the file is
 expected.
 
@@ -37,7 +37,7 @@ If ACLs are enabled, this command requires a management ACL token.
 
 - `-description` : An optional human readable description for the namespace.
 
-- `json` : Parse the input as a JSON namespace specification.
+- `-json` : Parse the input as a JSON namespace specification.
 
 ## Examples
 
@@ -56,7 +56,7 @@ $ nomad namespace apply -quota= api-prod
 
 Create a namespace from a file:
 ```shell-session
-$ cat namespace.json
+$ cat namespace.hcl
 name        = "dev"
 description = "Namespace for developers"
 
@@ -66,8 +66,8 @@ capabilities {
 }
 
 meta {
-  owner = "John Doe"
+  owner        = "John Doe"
   contact_mail = "john@mycompany.com
 }
-$ nomad namespace apply namespace.json
+$ nomad namespace apply namespace.hcl
 ```

--- a/website/content/docs/commands/namespace/status.mdx
+++ b/website/content/docs/commands/namespace/status.mdx
@@ -33,11 +33,14 @@ View the status of a namespace:
 
 ```shell-session
 $ nomad namespace status default
-Name            = default
-Description     = Default shared namespace
-Quota           = shared-default-quota
+Name            = api-prod
+Description     = Prod API servers
+Quota           = prod
 EnabledDrivers  = docker,exec
 DisabledDrivers = raw_exec
+ 
+Metadata
+contact = platform-eng@example.com
 
 Quota Limits
 Region  CPU Usage   Memory Usage


### PR DESCRIPTION
This PR adds a metadata field to the namespace objects allowing users to attach custom data to namespaces.

Fixes #9631