### PR TITLE
CI: increase test run timeout

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -300,7 +300,7 @@ test-nomad: dev ## Run Nomad test suites
 	$(if $(ENABLE_RACE),GORACE="strip_path_prefix=$(GOPATH)/src") $(GO_TEST_CMD) \
 		$(if $(ENABLE_RACE),-race) $(if $(VERBOSE),-v) \
 		-cover \
-		-timeout=15m \
+		-timeout=20m \
 		-tags "$(GO_TAGS)" \
 		$(GOTEST_PKGS) $(if $(VERBOSE), >test.log ; echo $$? > exit-code)
 	@if [ $(VERBOSE) ] ; then \
@@ -313,7 +313,7 @@ test-nomad-module: dev ## Run Nomad test suites on a sub-module
 	@cd $(GOTEST_MOD) && $(if $(ENABLE_RACE),GORACE="strip_path_prefix=$(GOPATH)/src") $(GO_TEST_CMD) \
 		$(if $(ENABLE_RACE),-race) $(if $(VERBOSE),-v) \
 		-cover \
-		-timeout=15m \
+		-timeout=20m \
 		-tags "$(GO_TAGS)" \
 		./... $(if $(VERBOSE), >test.log ; echo $$? > exit-code)
 	@if [ $(VERBOSE) ] ; then \


### PR DESCRIPTION
Our test runs are coming up against the timeout we set. [Some failures](https://app.circleci.com/pipelines/github/hashicorp/nomad/20207/workflows/694b6571-3edf-44f1-bcff-5ad97409f63b/jobs/207214/steps) may be because of this. Although we want to get the test times down, bump the timeout as a stop-gap measure.