### PR TITLE
CSI: use HTTP headers for passing CSI secrets

### DIFF
--- a/.changelog/12144.txt
+++ b/.changelog/12144.txt
@@ -4,3 +4,4 @@ api: CSI secrets for list and delete snapshots are now passed in HTTP headers
 
 ```release-note:improvement
 cli: CSI secrets argument for `volume snapshot list` has been made consistent with `volume snapshot delete`
+```

--- a/.changelog/12144.txt
+++ b/.changelog/12144.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+api: CSI secrets for list and delete snapshots are now passed in HTTP headers
+```
+
+```release-note:improvement
+cli: CSI secrets argument for `volume snapshot list` has been made consistent with `volume snapshot delete`

--- a/api/api.go
+++ b/api/api.go
@@ -62,6 +62,9 @@ type QueryOptions struct {
 	// Set HTTP parameters on the query.
 	Params map[string]string
 
+	// Set HTTP headers on the query.
+	Headers map[string]string
+
 	// AuthToken is the secret ID of an ACL token
 	AuthToken string
 
@@ -100,6 +103,9 @@ type WriteOptions struct {
 
 	// AuthToken is the secret ID of an ACL token
 	AuthToken string
+
+	// Set HTTP headers on the query.
+	Headers map[string]string
 
 	// ctx is an optional context pass through to the underlying HTTP
 	// request layer. Use Context() and WithContext() to manage this.
@@ -606,6 +612,10 @@ func (r *request) setQueryOptions(q *QueryOptions) {
 		r.params.Set(k, v)
 	}
 	r.ctx = q.Context()
+
+	for k, v := range q.Headers {
+		r.header.Set(k, v)
+	}
 }
 
 // durToMsec converts a duration to a millisecond specified string
@@ -632,6 +642,10 @@ func (r *request) setWriteOptions(q *WriteOptions) {
 		r.params.Set("idempotency_token", q.IdempotencyToken)
 	}
 	r.ctx = q.Context()
+
+	for k, v := range q.Headers {
+		r.header.Set(k, v)
+	}
 }
 
 // toHTTP converts the request to an HTTP request

--- a/api/csi.go
+++ b/api/csi.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -129,13 +130,37 @@ func (v *CSIVolumes) DeleteSnapshot(snap *CSISnapshot, w *WriteOptions) error {
 	qp := url.Values{}
 	qp.Set("snapshot_id", snap.ID)
 	qp.Set("plugin_id", snap.PluginID)
-	for k, v := range snap.Secrets {
-		qp.Set("secret", fmt.Sprintf("%v=%v", k, v))
-	}
+	w.SetHeadersFromCSISecrets(snap.Secrets)
 	_, err := v.client.delete("/v1/volumes/snapshot?"+qp.Encode(), nil, w)
 	return err
 }
 
+// ListSnapshotsOpts lists external storage volume snapshots.
+func (v *CSIVolumes) ListSnapshotsOpts(req *CSISnapshotListRequest) (*CSISnapshotListResponse, *QueryMeta, error) {
+	var resp *CSISnapshotListResponse
+
+	qp := url.Values{}
+	if req.PluginID != "" {
+		qp.Set("plugin_id", req.PluginID)
+	}
+	if req.NextToken != "" {
+		qp.Set("next_token", req.NextToken)
+	}
+	if req.PerPage != 0 {
+		qp.Set("per_page", fmt.Sprint(req.PerPage))
+	}
+	req.QueryOptions.SetHeadersFromCSISecrets(req.Secrets)
+
+	qm, err := v.client.query("/v1/volumes/snapshot?"+qp.Encode(), &resp, &req.QueryOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sort.Sort(CSISnapshotSort(resp.Snapshots))
+	return resp, qm, nil
+}
+
+// DEPRECATED: will be removed in Nomad 1.4.0
 // ListSnapshots lists external storage volume snapshots.
 func (v *CSIVolumes) ListSnapshots(pluginID string, secrets string, q *QueryOptions) (*CSISnapshotListResponse, *QueryMeta, error) {
 	var resp *CSISnapshotListResponse
@@ -149,9 +174,6 @@ func (v *CSIVolumes) ListSnapshots(pluginID string, secrets string, q *QueryOpti
 	}
 	if q.PerPage != 0 {
 		qp.Set("per_page", fmt.Sprint(q.PerPage))
-	}
-	if secrets != "" {
-		qp.Set("secrets", secrets)
 	}
 
 	qm, err := v.client.query("/v1/volumes/snapshot?"+qp.Encode(), &resp, q)
@@ -205,6 +227,28 @@ type CSIMountOptions struct {
 // the storage provider. These values will be redacted when reported in the
 // API or in Nomad's logs.
 type CSISecrets map[string]string
+
+func (q *QueryOptions) SetHeadersFromCSISecrets(secrets CSISecrets) {
+	pairs := []string{}
+	for k, v := range secrets {
+		pairs = append(pairs, fmt.Sprintf("%v=%v", k, v))
+	}
+	if q.Headers == nil {
+		q.Headers = map[string]string{}
+	}
+	q.Headers["X-Nomad-CSI-Secrets"] = strings.Join(pairs, ",")
+}
+
+func (q *WriteOptions) SetHeadersFromCSISecrets(secrets CSISecrets) {
+	pairs := []string{}
+	for k, v := range secrets {
+		pairs = append(pairs, fmt.Sprintf("%v=%v", k, v))
+	}
+	if q.Headers == nil {
+		q.Headers = map[string]string{}
+	}
+	q.Headers["X-Nomad-CSI-Secrets"] = strings.Join(pairs, ",")
+}
 
 // CSIVolume is used for serialization, see also nomad/structs/csi.go
 type CSIVolume struct {

--- a/api/csi.go
+++ b/api/csi.go
@@ -239,15 +239,15 @@ func (q *QueryOptions) SetHeadersFromCSISecrets(secrets CSISecrets) {
 	q.Headers["X-Nomad-CSI-Secrets"] = strings.Join(pairs, ",")
 }
 
-func (q *WriteOptions) SetHeadersFromCSISecrets(secrets CSISecrets) {
+func (w *WriteOptions) SetHeadersFromCSISecrets(secrets CSISecrets) {
 	pairs := []string{}
 	for k, v := range secrets {
 		pairs = append(pairs, fmt.Sprintf("%v=%v", k, v))
 	}
-	if q.Headers == nil {
-		q.Headers = map[string]string{}
+	if w.Headers == nil {
+		w.Headers = map[string]string{}
 	}
-	q.Headers["X-Nomad-CSI-Secrets"] = strings.Join(pairs, ",")
+	w.Headers["X-Nomad-CSI-Secrets"] = strings.Join(pairs, ",")
 }
 
 // CSIVolume is used for serialization, see also nomad/structs/csi.go

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -305,13 +305,9 @@ func (s *HTTPServer) csiSnapshotDelete(resp http.ResponseWriter, req *http.Reque
 	query := req.URL.Query()
 	snap.PluginID = query.Get("plugin_id")
 	snap.ID = query.Get("snapshot_id")
-	secrets := query["secret"]
-	for _, raw := range secrets {
-		secret := strings.Split(raw, "=")
-		if len(secret) == 2 {
-			snap.Secrets[secret[0]] = secret[1]
-		}
-	}
+
+	secrets := parseCSISecrets(req)
+	snap.Secrets = secrets
 
 	args.Snapshots = []*structs.CSISnapshot{snap}
 
@@ -333,19 +329,9 @@ func (s *HTTPServer) csiSnapshotList(resp http.ResponseWriter, req *http.Request
 
 	query := req.URL.Query()
 	args.PluginID = query.Get("plugin_id")
-	querySecrets := query["secrets"]
 
-	// Parse comma separated secrets only when provided
-	if len(querySecrets) >= 1 {
-		secrets := strings.Split(querySecrets[0], ",")
-		args.Secrets = make(structs.CSISecrets)
-		for _, raw := range secrets {
-			secret := strings.Split(raw, "=")
-			if len(secret) == 2 {
-				args.Secrets[secret[0]] = secret[1]
-			}
-		}
-	}
+	secrets := parseCSISecrets(req)
+	args.Secrets = secrets
 
 	var out structs.CSISnapshotListResponse
 	if err := s.agent.RPC("CSIVolume.ListSnapshots", &args, &out); err != nil {
@@ -418,6 +404,28 @@ func (s *HTTPServer) CSIPluginSpecificRequest(resp http.ResponseWriter, req *htt
 	}
 
 	return structsCSIPluginToApi(out.Plugin), nil
+}
+
+// parseCSISecrets extracts a map of k/v pairs from the CSI secrets
+// header. Silently ignores invalid secrets
+func parseCSISecrets(req *http.Request) structs.CSISecrets {
+	secretsHeader := req.Header.Get("X-Nomad-CSI-Secrets")
+	if secretsHeader == "" {
+		return nil
+	}
+
+	secrets := map[string]string{}
+	secretkvs := strings.Split(secretsHeader, ",")
+	for _, secretkv := range secretkvs {
+		kv := strings.Split(secretkv, "=")
+		if len(kv) == 2 {
+			secrets[kv[0]] = kv[1]
+		}
+	}
+	if len(secrets) == 0 {
+		return nil
+	}
+	return structs.CSISecrets(secrets)
 }
 
 // structsCSIPluginToApi converts CSIPlugin, setting Expected the count of known plugin

--- a/command/volume_snapshot_delete.go
+++ b/command/volume_snapshot_delete.go
@@ -30,7 +30,7 @@ General Options:
 Snapshot Options:
 
   -secret
-    Secrets to pass to the plugin to create the snapshot. Accepts multiple
+    Secrets to pass to the plugin to delete the snapshot. Accepts multiple
     flags in the form -secret key=value
 
 `

--- a/website/content/docs/commands/volume/snapshot-delete.mdx
+++ b/website/content/docs/commands/volume/snapshot-delete.mdx
@@ -29,6 +29,11 @@ volume` and `plugin:read` capabilities.
 
 @include 'general_options.mdx'
 
+## Snapshot Delete Options
+
+- `-secret`: Secrets to pass to the plugin to delete the
+  snapshot. Accepts multiple flags in the form `-secret key=value`
+
 ## Examples
 
 Delete a volume snapshot:

--- a/website/content/docs/commands/volume/snapshot-list.mdx
+++ b/website/content/docs/commands/volume/snapshot-list.mdx
@@ -27,7 +27,7 @@ Nomad.
 
 @include 'general_options.mdx'
 
-## List Options
+## Snapshot List Options
 
 - `-plugin`: Display only snapshots managed by a particular [CSI
   plugin][csi_plugin]. By default the `snapshot list` command will query all
@@ -35,8 +35,8 @@ Nomad.
   there is an exact match based on the provided plugin, then that specific
   plugin will be queried. Otherwise, a list of matching plugins will be
   displayed.
-- `-secrets`: A list of comma separated secret key/value pairs to be passed 
-  to the CSI driver.
+- `-secret`: Secrets to pass to the plugin to delete the
+  snapshot. Accepts multiple flags in the form `-secret key=value`
 
 When ACLs are enabled, this command requires a token with the
 `csi-list-volumes` capability for the plugin's namespace.
@@ -54,7 +54,7 @@ snap-67890   vol-fedcba   50GiB  2021-01-04T15:45:00Z  true
 
 List volume snapshots with two secret key/value pairs:
 ```shell-session
-$ nomad volume snapshot list -secrets key1=value1,key2=val2
+$ nomad volume snapshot list -secret key1=value1 -secret key2=val2
 Snapshot ID  External ID  Size   Creation Time         Ready?
 snap-12345   vol-abcdef   50GiB  2021-01-03T12:15:02Z  true
 ```

--- a/website/content/docs/commands/volume/snapshot-list.mdx
+++ b/website/content/docs/commands/volume/snapshot-list.mdx
@@ -35,8 +35,8 @@ Nomad.
   there is an exact match based on the provided plugin, then that specific
   plugin will be queried. Otherwise, a list of matching plugins will be
   displayed.
-- `-secret`: Secrets to pass to the plugin to delete the
-  snapshot. Accepts multiple flags in the form `-secret key=value`
+- `-secret`: Secrets to pass to the plugin to list snapshots. Accepts
+  multiple flags in the form `-secret key=value`
 
 When ACLs are enabled, this command requires a token with the
 `csi-list-volumes` capability for the plugin's namespace.


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11308
Unblocks https://github.com/hashicorp/nomad/issues/10997 https://github.com/hashicorp/nomad/pull/11245


* Use a header for passing the CSI secrets rather than querystring params. 
* Deprecate the existing (*CSIVolumes) ListSnapshots()` HTTP API method.
* Updates the CLI for consistency across uses of the `-secret` flag.