### PR TITLE
fix(website): hide version select on `/plugins` & `/tools`

### DIFF
--- a/website/pages/api-docs/[[...page]].jsx
+++ b/website/pages/api-docs/[[...page]].jsx
@@ -12,7 +12,6 @@ export default function DocsLayout(props) {
       product={{ name: productName, slug: productSlug }}
       baseRoute={basePath}
       staticProps={props}
-      showVersionSelect={process.env.ENABLE_VERSIONED_DOCS === 'true'}
     />
   )
 }

--- a/website/pages/docs/[[...page]].jsx
+++ b/website/pages/docs/[[...page]].jsx
@@ -15,7 +15,6 @@ export default function DocsLayout(props) {
       baseRoute={basePath}
       staticProps={props}
       additionalComponents={additionalComponents}
-      showVersionSelect={process.env.ENABLE_VERSIONED_DOCS === 'true'}
     />
   )
 }

--- a/website/pages/intro/[[...page]].jsx
+++ b/website/pages/intro/[[...page]].jsx
@@ -12,7 +12,6 @@ export default function DocsLayout(props) {
       product={{ name: productName, slug: productSlug }}
       baseRoute={basePath}
       staticProps={props}
-      showVersionSelect={process.env.ENABLE_VERSIONED_DOCS === 'true'}
     />
   )
 }

--- a/website/pages/plugins/[[...page]].tsx
+++ b/website/pages/plugins/[[...page]].tsx
@@ -16,11 +16,21 @@ export default function DocsLayout(props) {
   )
 }
 
-const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
-  strategy: 'fs',
-  localContentDir: CONTENT_DIR,
-  navDataFile: NAV_DATA_FILE,
-  product: productSlug,
-})
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
+  process.env.ENABLE_VERSIONED_DOCS === 'true'
+    ? {
+        strategy: 'remote',
+        basePath: basePath,
+        fallback: 'blocking',
+        revalidate: 360, // 1 hour
+        product: productSlug,
+      }
+    : {
+        strategy: 'fs',
+        localContentDir: CONTENT_DIR,
+        navDataFile: NAV_DATA_FILE,
+        product: productSlug,
+      }
+)
 
 export { getStaticPaths, getStaticProps }

--- a/website/pages/plugins/[[...page]].tsx
+++ b/website/pages/plugins/[[...page]].tsx
@@ -12,25 +12,16 @@ export default function DocsLayout(props) {
       product={{ name: productName, slug: productSlug }}
       baseRoute={basePath}
       staticProps={props}
+      showVersionSelect={false}
     />
   )
 }
 
-const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
-  process.env.ENABLE_VERSIONED_DOCS === 'true'
-    ? {
-        strategy: 'remote',
-        basePath: basePath,
-        fallback: 'blocking',
-        revalidate: 360, // 1 hour
-        product: productSlug,
-      }
-    : {
-        strategy: 'fs',
-        localContentDir: CONTENT_DIR,
-        navDataFile: NAV_DATA_FILE,
-        product: productSlug,
-      }
-)
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
+  strategy: 'fs',
+  localContentDir: CONTENT_DIR,
+  navDataFile: NAV_DATA_FILE,
+  product: productSlug,
+})
 
 export { getStaticPaths, getStaticProps }

--- a/website/pages/tools/[[...page]].tsx
+++ b/website/pages/tools/[[...page]].tsx
@@ -12,6 +12,7 @@ export default function DocsLayout(props) {
       product={{ name: productName, slug: productSlug }}
       baseRoute={basePath}
       staticProps={props}
+      showVersionSelect={false}
     />
   )
 }


### PR DESCRIPTION
# Description

This fixes a bug on the UI where the version select is being incorrectly displayed for `/plugins` and `/tools`