### PR TITLE
CSI: fix redaction of `volume status` mount flags

### DIFF
--- a/.changelog/12150.txt
+++ b/.changelog/12150.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Return a redacted value for mount flags in the `volume status` command, instead of `<none>`
+```

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -136,7 +136,6 @@ func (s *HTTPServer) csiVolumeGet(id string, resp http.ResponseWriter, req *http
 	// remove sensitive fields, as our redaction mechanism doesn't
 	// help serializing here
 	vol.Secrets = nil
-	vol.MountOptions = nil
 
 	return vol, nil
 }
@@ -761,11 +760,14 @@ func structsCSIMountOptionsToApi(opts *structs.CSIMountOptions) *api.CSIMountOpt
 	if opts == nil {
 		return nil
 	}
-
-	return &api.CSIMountOptions{
-		FSType:     opts.FSType,
-		MountFlags: opts.MountFlags,
+	apiOpts := &api.CSIMountOptions{
+		FSType: opts.FSType,
 	}
+	if len(opts.MountFlags) > 0 {
+		apiOpts.MountFlags = []string{"[REDACTED]"}
+	}
+
+	return apiOpts
 }
 
 func structsCSISecretsToApi(secrets structs.CSISecrets) api.CSISecrets {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/9825

The `volume status` command and associated API redacts the entire
mount options instead of just the `MountFlags` field that can contain
sensitive data. Return a redacted value so that the return value makes
sense to operators who have set this field.