### PR TITLE
CSI: subcommand for volume snapshot

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -854,6 +854,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"volume snapshot": func() (cli.Command, error) {
+			return &VolumeSnapshotCommand{
+				Meta: meta,
+			}, nil
+		},
 		"volume snapshot create": func() (cli.Command, error) {
 			return &VolumeSnapshotCreateCommand{
 				Meta: meta,

--- a/command/volume_snapshot.go
+++ b/command/volume_snapshot.go
@@ -1,0 +1,45 @@
+package command
+
+import (
+	"strings"
+
+	"github.com/mitchellh/cli"
+)
+
+type VolumeSnapshotCommand struct {
+	Meta
+}
+
+func (f *VolumeSnapshotCommand) Name() string { return "snapshot" }
+
+func (f *VolumeSnapshotCommand) Run(args []string) int {
+	return cli.RunResultHelp
+}
+
+func (f *VolumeSnapshotCommand) Synopsis() string {
+	return "Interact with volume snapshots"
+}
+
+func (f *VolumeSnapshotCommand) Help() string {
+	helpText := `
+Usage: nomad volume snapshot <subcommand> [options] [args]
+
+  This command groups subcommands for interacting with CSI volume snapshots.
+
+  Create a snapshot of an external storage volume:
+
+      $ nomad volume snapshot create <volume id>
+
+  Display a list of CSI volume snapshots along with their
+  source volume ID as known to the external storage provider.
+
+      $ nomad volume snapshot list -plugin <plugin id>
+
+  Delete a snapshot of an external storage volume:
+
+      $ nomad volume snapshot delete <snapshot id>
+
+  Please see the individual subcommand help for detailed usage information.
+`
+	return strings.TrimSpace(helpText)
+}


### PR DESCRIPTION
The `nomad volume snapshot` subcommand wasn't defined, which left an unpolished blank spot in the help text if you ran `nomad volume`