### PR TITLE
service discovery: add HTTP endpoints and sdk wrapper

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -147,6 +147,14 @@ func (a *Allocations) Signal(alloc *Allocation, q *QueryOptions, task, signal st
 	return err
 }
 
+// Services is used to return a list of service registrations associated to the
+// specified allocID.
+func (a *Allocations) Services(allocID string, q *QueryOptions) ([]*ServiceRegistration, *QueryMeta, error) {
+	var resp []*ServiceRegistration
+	qm, err := a.client.query("/v1/allocation/"+allocID+"/services", &resp, q)
+	return resp, qm, err
+}
+
 // Allocation is used for serialization of allocations.
 type Allocation struct {
 	ID                    string

--- a/api/allocations_test.go
+++ b/api/allocations_test.go
@@ -396,3 +396,7 @@ func TestAllocations_ShouldMigrate(t *testing.T) {
 	require.False(t, DesiredTransition{}.ShouldMigrate())
 	require.False(t, DesiredTransition{Migrate: boolToPtr(false)}.ShouldMigrate())
 }
+
+func TestAllocations_Services(t *testing.T) {
+	// TODO(jrasell) add tests once registration process is in place.
+}

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -459,6 +459,14 @@ func (j *Jobs) Stable(jobID string, version uint64, stable bool,
 	return &resp, wm, nil
 }
 
+// Services is used to return a list of service registrations associated to the
+// specified jobID.
+func (j *Jobs) Services(jobID string, q *QueryOptions) ([]*ServiceRegistration, *QueryMeta, error) {
+	var resp []*ServiceRegistration
+	qm, err := j.client.query("/v1/job/"+jobID+"/services", &resp, q)
+	return resp, qm, err
+}
+
 // periodicForceResponse is used to deserialize a force response
 type periodicForceResponse struct {
 	EvalID string

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -2356,3 +2356,7 @@ func TestJobs_ScaleStatus(t *testing.T) {
 	// Check that the result is what we expect
 	require.Equal(groupCount, result.TaskGroups[groupName].Desired)
 }
+
+func TestJobs_Services(t *testing.T) {
+	// TODO(jrasell) add tests once registration process is in place.
+}

--- a/api/service_registrations.go
+++ b/api/service_registrations.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// ServiceRegistrations is used to query the service endpoints.
+type ServiceRegistrations struct {
+	client *Client
+}
+
+// ServiceRegistration is an instance of a single allocation advertising itself
+// as a named service with a specific address. Each registration is constructed
+// from the job specification Service block. Whether the service is registered
+// within Nomad, and therefore generates a ServiceRegistration is controlled by
+// the Service.Provider parameter.
+type ServiceRegistration struct {
+
+	// ID is the unique identifier for this registration. It currently follows
+	// the Consul service registration format to provide consistency between
+	// the two solutions.
+	ID string
+
+	// ServiceName is the human friendly identifier for this service
+	// registration.
+	ServiceName string
+
+	// Namespace represents the namespace within which this service is
+	// registered.
+	Namespace string
+
+	// NodeID is Node.ID on which this service registration is currently
+	// running.
+	NodeID string
+
+	// Datacenter is the DC identifier of the node as identified by
+	// Node.Datacenter.
+	Datacenter string
+
+	// JobID is Job.ID and represents the job which contained the service block
+	// which resulted in this service registration.
+	JobID string
+
+	// AllocID is Allocation.ID and represents the allocation within which this
+	// service is running.
+	AllocID string
+
+	// Tags are determined from either Service.Tags or Service.CanaryTags and
+	// help identify this service. Tags can also be used to perform lookups of
+	// services depending on their state and role.
+	Tags []string
+
+	// Address is the IP address of this service registration. This information
+	// comes from the client and is not guaranteed to be routable; this depends
+	// on cluster network topology.
+	Address string
+
+	// Port is the port number on which this service registration is bound. It
+	// is determined by a combination of factors on the client.
+	Port int
+
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+// ServiceRegistrationListStub represents all service registrations held within a
+// single namespace.
+type ServiceRegistrationListStub struct {
+
+	// Namespace details the namespace in which these services have been
+	// registered.
+	Namespace string
+
+	// Services is a list of services found within the namespace.
+	Services []*ServiceRegistrationStub
+}
+
+// ServiceRegistrationStub is the stub object describing an individual
+// namespaced service. The object is built in a manner which would allow us to
+// add additional fields in the future, if we wanted.
+type ServiceRegistrationStub struct {
+
+	// ServiceName is the human friendly name for this service as specified
+	// within Service.Name.
+	ServiceName string
+
+	// Tags is a list of unique tags found for this service. The list is
+	// de-duplicated automatically by Nomad.
+	Tags []string
+}
+
+// ServiceRegistrations returns a new handle on the services endpoints.
+func (c *Client) ServiceRegistrations() *ServiceRegistrations {
+	return &ServiceRegistrations{client: c}
+}
+
+// List can be used to list all service registrations currently stored within
+// the target namespace. It returns a stub response object.
+func (s *ServiceRegistrations) List(q *QueryOptions) ([]*ServiceRegistrationListStub, *QueryMeta, error) {
+	var resp []*ServiceRegistrationListStub
+	qm, err := s.client.query("/v1/services", &resp, q)
+	if err != nil {
+		return nil, qm, err
+	}
+	return resp, qm, nil
+}
+
+// Get is used to return a list of service registrations whose name matches the
+// specified parameter.
+func (s *ServiceRegistrations) Get(serviceName string, q *QueryOptions) ([]*ServiceRegistration, *QueryMeta, error) {
+	var resp []*ServiceRegistration
+	qm, err := s.client.query("/v1/service/"+url.PathEscape(serviceName), &resp, q)
+	if err != nil {
+		return nil, qm, err
+	}
+	return resp, qm, nil
+}
+
+// Delete can be used to delete an individual service registration as defined
+// by its service name and service ID.
+func (s *ServiceRegistrations) Delete(serviceName, serviceID string, q *WriteOptions) (*WriteMeta, error) {
+	path := fmt.Sprintf("/v1/service/%s/%s", url.PathEscape(serviceName), url.PathEscape(serviceID))
+	wm, err := s.client.delete(path, nil, q)
+	if err != nil {
+		return nil, err
+	}
+	return wm, nil
+}

--- a/api/service_registrations_test.go
+++ b/api/service_registrations_test.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestServiceRegistrations_List(t *testing.T) {
+	// TODO(jrasell) add tests once registration process is in place.
+}
+
+func TestServiceRegistrations_Get(t *testing.T) {
+	// TODO(jrasell) add tests once registration process is in place.
+}
+
+func TestServiceRegistrations_Delete(t *testing.T) {
+	// TODO(jrasell) add tests once registration process is in place.
+}

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -433,6 +433,119 @@ func TestHTTP_AllocStop(t *testing.T) {
 	})
 }
 
+func TestHTTP_allocServiceRegistrations(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		testFn func(srv *TestAgent)
+		name   string
+	}{
+		{
+			testFn: func(s *TestAgent) {
+
+				// Grab the state, so we can manipulate it and test against it.
+				testState := s.Agent.server.State()
+
+				// Generate an alloc and upsert this.
+				alloc := mock.Alloc()
+				require.NoError(t, testState.UpsertAllocs(
+					structs.MsgTypeTestSetup, 10, []*structs.Allocation{alloc}))
+
+				// Generate a service registration, assigned the allocID to the
+				// mocked allocation ID, and upsert this.
+				serviceReg := mock.ServiceRegistrations()[0]
+				serviceReg.AllocID = alloc.ID
+				require.NoError(t, testState.UpsertServiceRegistrations(
+					structs.MsgTypeTestSetup, 20, []*structs.ServiceRegistration{serviceReg}))
+
+				// Build the HTTP request.
+				path := fmt.Sprintf("/v1/allocation/%s/services", alloc.ID)
+				req, err := http.NewRequest(http.MethodGet, path, nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.AllocSpecificRequest(respW, req)
+				require.NoError(t, err)
+
+				// Check the response.
+				require.Equal(t, "20", respW.Header().Get("X-Nomad-Index"))
+				require.ElementsMatch(t, []*structs.ServiceRegistration{serviceReg},
+					obj.([]*structs.ServiceRegistration))
+			},
+			name: "alloc has registrations",
+		},
+		{
+			testFn: func(s *TestAgent) {
+
+				// Grab the state, so we can manipulate it and test against it.
+				testState := s.Agent.server.State()
+
+				// Generate an alloc and upsert this.
+				alloc := mock.Alloc()
+				require.NoError(t, testState.UpsertAllocs(
+					structs.MsgTypeTestSetup, 10, []*structs.Allocation{alloc}))
+
+				// Build the HTTP request.
+				path := fmt.Sprintf("/v1/allocation/%s/services", alloc.ID)
+				req, err := http.NewRequest(http.MethodGet, path, nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.AllocSpecificRequest(respW, req)
+				require.NoError(t, err)
+
+				// Check the response.
+				require.Equal(t, "1", respW.Header().Get("X-Nomad-Index"))
+				require.ElementsMatch(t, []*structs.ServiceRegistration{},
+					obj.([]*structs.ServiceRegistration))
+			},
+			name: "alloc without registrations",
+		},
+		{
+			testFn: func(s *TestAgent) {
+
+				// Build the HTTP request.
+				path := fmt.Sprintf("/v1/allocation/%s/services", uuid.Generate())
+				req, err := http.NewRequest(http.MethodGet, path, nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.AllocSpecificRequest(respW, req)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "allocation not found")
+				require.Nil(t, obj)
+			},
+			name: "alloc not found",
+		},
+		{
+			testFn: func(s *TestAgent) {
+
+				// Build the HTTP request.
+				path := fmt.Sprintf("/v1/allocation/%s/services", uuid.Generate())
+				req, err := http.NewRequest(http.MethodHead, path, nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.AllocSpecificRequest(respW, req)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "Invalid method")
+				require.Nil(t, obj)
+			},
+			name: "alloc not found",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			httpTest(t, nil, tc.testFn)
+		})
+	}
+}
+
 func TestHTTP_AllocStats(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -341,6 +341,10 @@ func (s HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/agent/health", s.wrap(s.HealthRequest))
 	s.mux.HandleFunc("/v1/agent/host", s.wrap(s.AgentHostRequest))
 
+	// Register our service registration handlers.
+	s.mux.HandleFunc("/v1/services", s.wrap(s.ServiceRegistrationListRequest))
+	s.mux.HandleFunc("/v1/service/", s.wrap(s.ServiceRegistrationRequest))
+
 	// Monitor is *not* an untrusted endpoint despite the log contents
 	// potentially containing unsanitized user input. Monitor, like
 	// "/v1/client/fs/logs", explicitly sets a "text/plain" or

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -2242,6 +2243,114 @@ func TestJobs_NamespaceForJob(t *testing.T) {
 			require.Equal(t, tc.expected,
 				namespaceForJob(tc.job.Namespace, tc.queryNamespace, tc.apiNamespace),
 			)
+		})
+	}
+}
+
+func TestHTTPServer_jobServiceRegistrations(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		testFn func(srv *TestAgent)
+		name   string
+	}{
+		{
+			testFn: func(s *TestAgent) {
+
+				// Grab the state, so we can manipulate it and test against it.
+				testState := s.Agent.server.State()
+
+				// Generate a job and upsert this.
+				job := mock.Job()
+				require.NoError(t, testState.UpsertJob(structs.MsgTypeTestSetup, 10, job))
+
+				// Generate a service registration, assigned the jobID to the
+				// mocked jobID, and upsert this.
+				serviceReg := mock.ServiceRegistrations()[0]
+				serviceReg.JobID = job.ID
+				require.NoError(t, testState.UpsertServiceRegistrations(
+					structs.MsgTypeTestSetup, 20, []*structs.ServiceRegistration{serviceReg}))
+
+				// Build the HTTP request.
+				path := fmt.Sprintf("/v1/job/%s/services", job.ID)
+				req, err := http.NewRequest(http.MethodGet, path, nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.JobSpecificRequest(respW, req)
+				require.NoError(t, err)
+
+				// Check the response.
+				require.Equal(t, "20", respW.Header().Get("X-Nomad-Index"))
+				require.ElementsMatch(t, []*structs.ServiceRegistration{serviceReg},
+					obj.([]*structs.ServiceRegistration))
+			},
+			name: "job has registrations",
+		},
+		{
+			testFn: func(s *TestAgent) {
+
+				// Grab the state, so we can manipulate it and test against it.
+				testState := s.Agent.server.State()
+
+				// Generate a job and upsert this.
+				job := mock.Job()
+				require.NoError(t, testState.UpsertJob(structs.MsgTypeTestSetup, 10, job))
+
+				// Build the HTTP request.
+				path := fmt.Sprintf("/v1/job/%s/services", job.ID)
+				req, err := http.NewRequest(http.MethodGet, path, nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.JobSpecificRequest(respW, req)
+				require.NoError(t, err)
+
+				// Check the response.
+				require.Equal(t, "1", respW.Header().Get("X-Nomad-Index"))
+				require.ElementsMatch(t, []*structs.ServiceRegistration{}, obj.([]*structs.ServiceRegistration))
+			},
+			name: "job without registrations",
+		},
+		{
+			testFn: func(s *TestAgent) {
+
+				// Build the HTTP request.
+				req, err := http.NewRequest(http.MethodGet, "/v1/job/example/services", nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.JobSpecificRequest(respW, req)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "job not found")
+				require.Nil(t, obj)
+			},
+			name: "job not found",
+		},
+		{
+			testFn: func(s *TestAgent) {
+
+				// Build the HTTP request.
+				req, err := http.NewRequest(http.MethodHead, "/v1/job/example/services", nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.JobSpecificRequest(respW, req)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "Invalid method")
+				require.Nil(t, obj)
+			},
+			name: "incorrect method",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			httpTest(t, nil, tc.testFn)
 		})
 	}
 }

--- a/command/agent/service_registration_endpoint.go
+++ b/command/agent/service_registration_endpoint.go
@@ -1,0 +1,124 @@
+package agent
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// ServiceRegistrationListRequest performs a listing of service registrations
+// using the structs.ServiceRegistrationListRPCMethod RPC endpoint and is
+// callable via the /v1/services HTTP API.
+func (s *HTTPServer) ServiceRegistrationListRequest(
+	resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+
+	// The endpoint only supports GET requests.
+	if req.Method != http.MethodGet {
+		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
+	}
+
+	// Set up the request args and parse this to ensure the query options are
+	// set.
+	args := structs.ServiceRegistrationListRequest{}
+
+	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
+		return nil, nil
+	}
+
+	// Perform the RPC request.
+	var reply structs.ServiceRegistrationListResponse
+	if err := s.agent.RPC(structs.ServiceRegistrationListRPCMethod, &args, &reply); err != nil {
+		return nil, err
+	}
+
+	setMeta(resp, &reply.QueryMeta)
+
+	if reply.Services == nil {
+		reply.Services = make([]*structs.ServiceRegistrationListStub, 0)
+	}
+	return reply.Services, nil
+}
+
+// ServiceRegistrationRequest is callable via the /v1/service/ HTTP API and
+// handles service reads and individual service registration deletions.
+func (s *HTTPServer) ServiceRegistrationRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+
+	// Grab the suffix of the request, so we can further understand it.
+	reqSuffix := strings.TrimPrefix(req.URL.Path, "/v1/service/")
+
+	// Split the request suffix in order to identify whether this is a lookup
+	// of a service, or whether this includes a service and service identifier.
+	suffixParts := strings.Split(reqSuffix, "/")
+
+	switch len(suffixParts) {
+	case 1:
+		// This endpoint only supports GET.
+		if req.Method != http.MethodGet {
+			return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
+		}
+
+		// Ensure the service ID is not an empty string which is possible if
+		// the caller requested "/v1/service/service-name/"
+		if suffixParts[0] == "" {
+			return nil, CodedError(http.StatusBadRequest, "missing service name")
+		}
+
+		return s.serviceGetRequest(resp, req, suffixParts[0])
+
+	case 2:
+		// This endpoint only supports DELETE.
+		if req.Method != http.MethodDelete {
+			return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
+		}
+
+		// Ensure the service ID is not an empty string which is possible if
+		// the caller requested "/v1/service/service-name/"
+		if suffixParts[1] == "" {
+			return nil, CodedError(http.StatusBadRequest, "missing service id")
+		}
+
+		return s.serviceDeleteRequest(resp, req, suffixParts[1])
+
+	default:
+		return nil, CodedError(http.StatusBadRequest, "invalid URI")
+	}
+}
+
+// serviceGetRequest performs a reading of service registrations by name using
+// the structs.ServiceRegistrationGetServiceRPCMethod RPC endpoint.
+func (s *HTTPServer) serviceGetRequest(
+	resp http.ResponseWriter, req *http.Request, serviceName string) (interface{}, error) {
+
+	args := structs.ServiceRegistrationByNameRequest{ServiceName: serviceName}
+	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
+		return nil, nil
+	}
+
+	var reply structs.ServiceRegistrationByNameResponse
+	if err := s.agent.RPC(structs.ServiceRegistrationGetServiceRPCMethod, &args, &reply); err != nil {
+		return nil, err
+	}
+	setIndex(resp, reply.Index)
+
+	if reply.Services == nil {
+		reply.Services = make([]*structs.ServiceRegistration, 0)
+	}
+	return reply.Services, nil
+}
+
+// serviceDeleteRequest performs a reading of service registrations by name using
+// the structs.ServiceRegistrationDeleteByIDRPCMethod RPC endpoint.
+func (s *HTTPServer) serviceDeleteRequest(
+	resp http.ResponseWriter, req *http.Request, serviceID string) (interface{}, error) {
+
+	args := structs.ServiceRegistrationDeleteByIDRequest{ID: serviceID}
+	s.parseWriteRequest(req, &args.WriteRequest)
+
+	var reply structs.ServiceRegistrationDeleteByIDResponse
+	if err := s.agent.RPC(structs.ServiceRegistrationDeleteByIDRPCMethod, &args, &reply); err != nil {
+		return nil, err
+	}
+	setIndex(resp, reply.Index)
+	return nil, nil
+}

--- a/command/agent/service_registration_endpoint_test.go
+++ b/command/agent/service_registration_endpoint_test.go
@@ -1,0 +1,305 @@
+package agent
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPServer_ServiceRegistrationListRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		testFn func(srv *TestAgent)
+		name   string
+	}{
+		{
+			testFn: func(s *TestAgent) {
+
+				// Grab the state, so we can manipulate it and test against it.
+				testState := s.Agent.server.State()
+
+				// Generate service registrations and upsert.
+				serviceRegs := mock.ServiceRegistrations()
+				require.NoError(t, testState.UpsertServiceRegistrations(
+					structs.MsgTypeTestSetup, 10, serviceRegs))
+
+				// Build the HTTP request.
+				req, err := http.NewRequest(http.MethodGet, "/v1/services", nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.ServiceRegistrationListRequest(respW, req)
+				require.NoError(t, err)
+				require.NotNil(t, obj)
+
+				// Check the index is not zero.
+				require.EqualValues(t, "10", respW.Header().Get("X-Nomad-Index"))
+				require.ElementsMatch(t, []*structs.ServiceRegistrationListStub{
+					{
+						Namespace: "default",
+						Services: []*structs.ServiceRegistrationStub{
+							{
+								ServiceName: "example-cache",
+								Tags:        []string{"foo"},
+							},
+						},
+					},
+				}, obj.([]*structs.ServiceRegistrationListStub))
+			},
+			name: "list default namespace",
+		},
+		{
+			testFn: func(s *TestAgent) {
+
+				// Grab the state, so we can manipulate it and test against it.
+				testState := s.Agent.server.State()
+
+				// Generate service registrations and upsert.
+				serviceRegs := mock.ServiceRegistrations()
+				require.NoError(t, testState.UpsertServiceRegistrations(
+					structs.MsgTypeTestSetup, 10, serviceRegs))
+
+				// Build the HTTP request.
+				req, err := http.NewRequest(http.MethodGet, "/v1/services?namespace=platform", nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.ServiceRegistrationListRequest(respW, req)
+				require.NoError(t, err)
+				require.NotNil(t, obj)
+
+				// Check the index is not zero.
+				require.EqualValues(t, "10", respW.Header().Get("X-Nomad-Index"))
+				require.ElementsMatch(t, []*structs.ServiceRegistrationListStub{
+					{
+						Namespace: "platform",
+						Services: []*structs.ServiceRegistrationStub{
+							{
+								ServiceName: "countdash-api",
+								Tags:        []string{"bar"},
+							},
+						},
+					},
+				}, obj.([]*structs.ServiceRegistrationListStub))
+			},
+			name: "list platform namespace",
+		},
+		{
+			testFn: func(s *TestAgent) {
+
+				// Grab the state, so we can manipulate it and test against it.
+				testState := s.Agent.server.State()
+
+				// Generate service registrations and upsert.
+				serviceRegs := mock.ServiceRegistrations()
+				require.NoError(t, testState.UpsertServiceRegistrations(
+					structs.MsgTypeTestSetup, 10, serviceRegs))
+
+				// Build the HTTP request.
+				req, err := http.NewRequest(http.MethodGet, "/v1/services?namespace=*", nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.ServiceRegistrationListRequest(respW, req)
+				require.NoError(t, err)
+				require.NotNil(t, obj)
+
+				// Check the index is not zero.
+				require.EqualValues(t, "10", respW.Header().Get("X-Nomad-Index"))
+				require.ElementsMatch(t, []*structs.ServiceRegistrationListStub{
+					{
+						Namespace: "default",
+						Services: []*structs.ServiceRegistrationStub{
+							{
+								ServiceName: "example-cache",
+								Tags:        []string{"foo"},
+							},
+						},
+					},
+					{
+						Namespace: "platform",
+						Services: []*structs.ServiceRegistrationStub{
+							{
+								ServiceName: "countdash-api",
+								Tags:        []string{"bar"},
+							},
+						},
+					},
+				}, obj.([]*structs.ServiceRegistrationListStub))
+			},
+			name: "list wildcard namespace",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			httpTest(t, nil, tc.testFn)
+		})
+	}
+}
+
+func TestHTTPServer_ServiceRegistrationRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		testFn func(srv *TestAgent)
+		name   string
+	}{
+		{
+			testFn: func(s *TestAgent) {
+
+				// Grab the state, so we can manipulate it and test against it.
+				testState := s.Agent.server.State()
+
+				// Generate a service registration and upsert this.
+				serviceReg := mock.ServiceRegistrations()[0]
+				require.NoError(t, testState.UpsertServiceRegistrations(
+					structs.MsgTypeTestSetup, 10, []*structs.ServiceRegistration{serviceReg}))
+
+				// Build the HTTP request.
+				path := fmt.Sprintf("/v1/service/%s/%s", serviceReg.ServiceName, serviceReg.ID)
+				req, err := http.NewRequest(http.MethodDelete, path, nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.ServiceRegistrationRequest(respW, req)
+				require.NoError(t, err)
+				require.Nil(t, obj)
+
+				// Check the index is not zero.
+				require.NotZero(t, respW.Header().Get("X-Nomad-Index"))
+
+				// Check that the service is not found within state.
+				out, err := testState.GetServiceRegistrationByID(memdb.NewWatchSet(), serviceReg.Namespace, serviceReg.ID)
+				require.Nil(t, out)
+				require.NoError(t, err)
+			},
+			name: "delete by ID",
+		},
+		{
+			testFn: func(s *TestAgent) {
+
+				// Grab the state, so we can manipulate it and test against it.
+				testState := s.Agent.server.State()
+
+				// Generate a service registration and upsert this.
+				serviceReg := mock.ServiceRegistrations()[0]
+				require.NoError(t, testState.UpsertServiceRegistrations(
+					structs.MsgTypeTestSetup, 10, []*structs.ServiceRegistration{serviceReg}))
+
+				// Build the HTTP request.
+				path := fmt.Sprintf("/v1/service/%s", serviceReg.ServiceName)
+				req, err := http.NewRequest(http.MethodGet, path, nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.ServiceRegistrationRequest(respW, req)
+				require.NoError(t, err)
+
+				// Check the index is not zero and that we see the service
+				// registration.
+				require.NotZero(t, respW.Header().Get("X-Nomad-Index"))
+				require.Equal(t, serviceReg, obj.([]*structs.ServiceRegistration)[0])
+			},
+			name: "get service by name",
+		},
+		{
+			testFn: func(s *TestAgent) {
+
+				// Build the HTTP request.
+				req, err := http.NewRequest(http.MethodGet, "/v1/service/foo/bar/baz/bonkers", nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.ServiceRegistrationRequest(respW, req)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "invalid URI")
+				require.Nil(t, obj)
+			},
+			name: "incorrect URI format",
+		},
+		{
+			testFn: func(s *TestAgent) {
+
+				// Build the HTTP request.
+				req, err := http.NewRequest(http.MethodGet, "/v1/service/", nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.ServiceRegistrationRequest(respW, req)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "missing service name")
+				require.Nil(t, obj)
+			},
+			name: "get service empty name",
+		},
+		{
+			testFn: func(s *TestAgent) {
+
+				// Build the HTTP request.
+				req, err := http.NewRequest(http.MethodHead, "/v1/service/foo", nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.ServiceRegistrationRequest(respW, req)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "Invalid method")
+				require.Nil(t, obj)
+			},
+			name: "get service incorrect method",
+		},
+		{
+			testFn: func(s *TestAgent) {
+
+				// Build the HTTP request.
+				req, err := http.NewRequest(http.MethodDelete, "/v1/service/foo/", nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.ServiceRegistrationRequest(respW, req)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "missing service id")
+				require.Nil(t, obj)
+			},
+			name: "delete service empty id",
+		},
+		{
+			testFn: func(s *TestAgent) {
+
+				// Build the HTTP request.
+				req, err := http.NewRequest(http.MethodHead, "/v1/service/foo/bar", nil)
+				require.NoError(t, err)
+				respW := httptest.NewRecorder()
+
+				// Send the HTTP request.
+				obj, err := s.Server.ServiceRegistrationRequest(respW, req)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "Invalid method")
+				require.Nil(t, obj)
+			},
+			name: "delete service incorrect method",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			httpTest(t, nil, tc.testFn)
+		})
+	}
+}


### PR DESCRIPTION
This work continues to build out the service discovery feature by adding the HTTP and Go SDK covering all the publicly available RPC endpoints. This includes a new endpoint as well as updates to the alloc and job endpoints to provide easy lookup of registrations associated to these objects.

The PR is split into commits which group the additions into logical chunks and hope to make it easier to review.

closes https://github.com/hashicorp/team-nomad/issues/262