### PR TITLE
Fix client test reconnect test; Remove guard test

### DIFF
--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -1641,10 +1641,6 @@ func TestAllocRunner_Reconnect(t *testing.T) {
 
 			require.Equal(t, tc.clientStatus, ar.AllocState().ClientStatus)
 
-			// Make sure the runner alloc's indexes are not the same as the original.
-			require.NotEqual(t, original.AllocModifyIndex, ar.Alloc().AllocModifyIndex)
-			require.NotEqual(t, original.ModifyIndex, ar.Alloc().ModifyIndex)
-			require.NotEqual(t, original.ModifyTime, ar.Alloc().ModifyTime)
 
 			// Make sure the runner's alloc indexes match the update.
 			require.Equal(t, update.AllocModifyIndex, ar.Alloc().AllocModifyIndex)

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -1605,11 +1605,16 @@ func TestAllocRunner_Reconnect(t *testing.T) {
 		t.Run(tc.clientStatus, func(t *testing.T) {
 			// create a running alloc
 			alloc := mock.BatchAlloc()
+			alloc.AllocModifyIndex = 10
+			alloc.ModifyIndex = 10
+			alloc.ModifyTime = time.Now().UnixNano()
 
 			// Ensure task takes some time
 			task := alloc.Job.TaskGroups[0].Tasks[0]
 			task.Driver = "mock_driver"
 			task.Config["run_for"] = "30s"
+
+			original := alloc.Copy()
 
 			conf, cleanup := testAllocRunnerConfig(t, alloc)
 			defer cleanup()
@@ -1624,9 +1629,27 @@ func TestAllocRunner_Reconnect(t *testing.T) {
 				taskRunner.UpdateState(tc.taskState, tc.taskEvent)
 			}
 
-			ar.Reconnect()
+			update := ar.Alloc().Copy()
+
+			update.ClientStatus = structs.AllocClientStatusUnknown
+			update.AllocModifyIndex = original.AllocModifyIndex + 10
+			update.ModifyIndex = original.ModifyIndex + 10
+			update.ModifyTime = original.ModifyTime + 10
+
+			err = ar.Reconnect(update)
+			require.NoError(t, err)
 
 			require.Equal(t, tc.clientStatus, ar.AllocState().ClientStatus)
+
+			// Make sure the runner alloc's indexes are not the same as the original.
+			require.NotEqual(t, original.AllocModifyIndex, ar.Alloc().AllocModifyIndex)
+			require.NotEqual(t, original.ModifyIndex, ar.Alloc().ModifyIndex)
+			require.NotEqual(t, original.ModifyTime, ar.Alloc().ModifyTime)
+
+			// Make sure the runner's alloc indexes match the update.
+			require.Equal(t, update.AllocModifyIndex, ar.Alloc().AllocModifyIndex)
+			require.Equal(t, update.ModifyIndex, ar.Alloc().ModifyIndex)
+			require.Equal(t, update.ModifyTime, ar.Alloc().ModifyTime)
 
 			found := false
 
@@ -1654,101 +1677,6 @@ func TestAllocRunner_Reconnect(t *testing.T) {
 			})
 
 			require.True(t, found, "no reconnect event found")
-		})
-	}
-}
-
-func TestAllocRunner_MaybeHasPendingReconnect(t *testing.T) {
-	t.Parallel()
-
-	type tcase struct {
-		name         string
-		timestamp    int64
-		expectedDiff int
-	}
-	tcases := []tcase{
-		{
-			"should guard now",
-			time.Now().UnixNano(),
-			1,
-		},
-		{
-			"should guard 3 seconds",
-			time.Now().Add(-(3 * time.Second)).UnixNano(),
-			1,
-		},
-		{
-			"should not guard 6 seconds",
-			time.Now().Add(-(6 * time.Second)).UnixNano(),
-			2,
-		},
-	}
-
-	for _, tc := range tcases {
-		t.Run(tc.name, func(t *testing.T) {
-			alloc := mock.BatchAlloc()
-
-			task := alloc.Job.TaskGroups[0].Tasks[0]
-			task.Driver = "mock_driver"
-			task.Config["run_for"] = "30s"
-
-			conf, cleanup := testAllocRunnerConfig(t, alloc)
-			defer cleanup()
-
-			ar, err := NewAllocRunner(conf)
-			require.NoError(t, err)
-			defer destroy(ar)
-
-			go ar.Run()
-
-			reconnectEvent := structs.NewTaskEvent(structs.TaskClientReconnected)
-			reconnectEvent.Time = tc.timestamp
-			for _, tr := range ar.tasks {
-				tr.EmitEvent(reconnectEvent)
-			}
-
-			updater := conf.StateUpdater.(*MockStateUpdater)
-			// get a copy of the first states so that we can compare lengths to
-			// determine how many events were appended.
-			var firstStates map[string]*structs.TaskState
-			testutil.WaitForResult(func() (bool, error) {
-				last := updater.Last()
-				if last == nil {
-					return false, errors.New("last update nil")
-				}
-				states := last.TaskStates
-				for _, s := range states {
-					for _, e := range s.Events {
-						if e.Type == structs.TaskClientReconnected {
-							firstStates = states
-							return true, nil
-						}
-					}
-				}
-
-				return false, errors.New("no reconnect event found")
-			}, func(err error) {
-				require.NoError(t, err)
-			})
-
-			ar.Reconnect()
-
-			testutil.WaitForResult(func() (bool, error) {
-				last := updater.Last()
-				if last == nil {
-					return false, errors.New("last update nil")
-				}
-
-				for k, taskState := range last.TaskStates {
-					if len(taskState.Events) != len(firstStates[k].Events)+tc.expectedDiff {
-						return false, fmt.Errorf("expected %d reconnect events", tc.expectedDiff)
-					}
-				}
-
-				return true, nil
-			}, func(err error) {
-				require.NoError(t, err)
-			})
 		})
 	}
 }


### PR DESCRIPTION
I looked at the wrong CircleCI notification and missed that these tests were failing before merging.

- Refactor failing test
- Remove no longer necessary guard test