### PR TITLE
ci: disable Go test semgrep rules

### DIFF
--- a/.semgrep/go_tests.yml
+++ b/.semgrep/go_tests.yml
@@ -13,6 +13,7 @@ rules:
     # TODO(luiz): figure out how to do a 'delete line' fix.
     fix: " "
     paths:
+      exclude: ["*"]
       include:
         - "*_test.go"
 
@@ -43,6 +44,7 @@ rules:
     severity: "WARNING"
     fix: "assert.$FUNC($T, $...ARGS)"
     paths:
+      exclude: ["*"]
       include:
         - "*_test.go"
   - id: "tests-no-assert-without-t-nested"
@@ -64,6 +66,7 @@ rules:
     severity: "WARNING"
     fix: "assert.$FUNC($T, $...ARGS)"
     paths:
+      exclude: ["*"]
       include:
         - "*_test.go"
   - id: "tests-no-require-without-t"
@@ -91,6 +94,7 @@ rules:
     severity: "WARNING"
     fix: "require.$FUNC($T, $...ARGS)"
     paths:
+      exclude: ["*"]
       include:
         - "*_test.go"
   - id: "tests-no-require-without-t-nested"
@@ -112,5 +116,6 @@ rules:
     severity: "WARNING"
     fix: "require.$FUNC($T, $...ARGS)"
     paths:
+      exclude: ["*"]
       include:
         - "*_test.go"


### PR DESCRIPTION
These rules have resulted in too many false positives that are confusing and interfere with development flow. I didn't find a way to disable specific rules with the semgrep GitHub Action, so I'm just excluding all paths instead.