### PR TITLE
`MaxClientDisconnect` Jobspec checklist

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -431,6 +431,7 @@ type TaskGroup struct {
 	Services                  []*Service                `hcl:"service,block"`
 	ShutdownDelay             *time.Duration            `mapstructure:"shutdown_delay" hcl:"shutdown_delay,optional"`
 	StopAfterClientDisconnect *time.Duration            `mapstructure:"stop_after_client_disconnect" hcl:"stop_after_client_disconnect,optional"`
+	MaxClientDisconnect       *time.Duration            `mapstructure:"max_client_disconnect" hcl:"max_client_disconnect,optional"`
 	Scaling                   *ScalingPolicy            `hcl:"scaling,block"`
 	Consul                    *Consul                   `hcl:"consul,block"`
 }

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -972,6 +972,10 @@ func ApiTgToStructsTG(job *structs.Job, taskGroup *api.TaskGroup, tg *structs.Ta
 		tg.StopAfterClientDisconnect = taskGroup.StopAfterClientDisconnect
 	}
 
+	if taskGroup.MaxClientDisconnect != nil {
+		tg.MaxClientDisconnect = taskGroup.MaxClientDisconnect
+	}
+
 	if taskGroup.ReschedulePolicy != nil {
 		tg.ReschedulePolicy = &structs.ReschedulePolicy{
 			Attempts:      *taskGroup.ReschedulePolicy.Attempts,

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -2445,6 +2445,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						},
 					},
 				},
+				MaxClientDisconnect: helper.TimeToPtr(30 * time.Second),
 				Tasks: []*api.Task{
 					{
 						Name:   "task1",
@@ -2840,6 +2841,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						},
 					},
 				},
+				MaxClientDisconnect: helper.TimeToPtr(30 * time.Second),
 				Tasks: []*structs.Task{
 					{
 						Name:   "task1",

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -265,6 +265,20 @@ func (tg *TaskGroup) Diff(other *TaskGroup, contextual bool) (*TaskGroupDiff, er
 		}
 	}
 
+	// MaxClientDisconnect diff
+	if oldPrimitiveFlat != nil && newPrimitiveFlat != nil {
+		if tg.MaxClientDisconnect == nil {
+			oldPrimitiveFlat["MaxClientDisconnect"] = ""
+		} else {
+			oldPrimitiveFlat["MaxClientDisconnect"] = fmt.Sprintf("%d", *tg.MaxClientDisconnect)
+		}
+		if other.MaxClientDisconnect == nil {
+			newPrimitiveFlat["MaxClientDisconnect"] = ""
+		} else {
+			newPrimitiveFlat["MaxClientDisconnect"] = fmt.Sprintf("%d", *other.MaxClientDisconnect)
+		}
+	}
+
 	// Diff the primitive fields.
 	diff.Fields = fieldDiffs(oldPrimitiveFlat, newPrimitiveFlat, false)
 

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -3899,6 +3899,75 @@ func TestTaskGroupDiff(t *testing.T) {
 				},
 			},
 		},
+		{
+			TestCase: "MaxClientDisconnect added",
+			Old: &TaskGroup{
+				Name:                "foo",
+				MaxClientDisconnect: nil,
+			},
+			New: &TaskGroup{
+				Name:                "foo",
+				MaxClientDisconnect: helper.TimeToPtr(20 * time.Second),
+			},
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Name: "foo",
+				Fields: []*FieldDiff{
+					{
+						Type: DiffTypeAdded,
+						Name: "MaxClientDisconnect",
+						Old:  "",
+						New:  "20000000000",
+					},
+				},
+			},
+		},
+		{
+			TestCase: "MaxClientDisconnect updated",
+			Old: &TaskGroup{
+				Name:                "foo",
+				MaxClientDisconnect: helper.TimeToPtr(10 * time.Second),
+			},
+			New: &TaskGroup{
+				Name:                "foo",
+				MaxClientDisconnect: helper.TimeToPtr(20 * time.Second),
+			},
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Name: "foo",
+				Fields: []*FieldDiff{
+					{
+						Type: DiffTypeEdited,
+						Name: "MaxClientDisconnect",
+						Old:  "10000000000",
+						New:  "20000000000",
+					},
+				},
+			},
+		},
+		{
+			TestCase: "MaxClientDisconnect deleted",
+			Old: &TaskGroup{
+				Name:                "foo",
+				MaxClientDisconnect: helper.TimeToPtr(10 * time.Second),
+			},
+			New: &TaskGroup{
+				Name:                "foo",
+				MaxClientDisconnect: nil,
+			},
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Name: "foo",
+				Fields: []*FieldDiff{
+					{
+						Type: DiffTypeDeleted,
+						Name: "MaxClientDisconnect",
+						Old:  "10000000000",
+						New:  "",
+					},
+				},
+			},
+		},
 	}
 
 	for i, c := range cases {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6145,6 +6145,10 @@ func (tg *TaskGroup) Copy() *TaskGroup {
 		ntg.StopAfterClientDisconnect = tg.StopAfterClientDisconnect
 	}
 
+	if tg.MaxClientDisconnect != nil {
+		ntg.MaxClientDisconnect = tg.MaxClientDisconnect
+	}
+
 	return ntg
 }
 
@@ -6206,6 +6210,10 @@ func (tg *TaskGroup) Validate(j *Job) error {
 	if len(tg.Tasks) == 0 {
 		// could be a lone consul gateway inserted by the connect mutator
 		mErr.Errors = append(mErr.Errors, errors.New("Missing tasks for task group"))
+	}
+
+	if tg.MaxClientDisconnect != nil && *tg.MaxClientDisconnect < 0 {
+		mErr.Errors = append(mErr.Errors, errors.New("max_client_disconnect must be a positive value"))
 	}
 
 	for idx, constr := range tg.Constraints {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6213,7 +6213,7 @@ func (tg *TaskGroup) Validate(j *Job) error {
 	}
 
 	if tg.MaxClientDisconnect != nil && *tg.MaxClientDisconnect < 0 {
-		mErr.Errors = append(mErr.Errors, errors.New("max_client_disconnect must be a positive value"))
+		mErr.Errors = append(mErr.Errors, errors.New("max_client_disconnect cannot be negative"))
 	}
 
 	for idx, constr := range tg.Constraints {

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -403,6 +403,7 @@ func testJob() *Job {
 					"elb_check_interval": "30s",
 					"elb_check_min":      "3",
 				},
+				MaxClientDisconnect: helper.TimeToPtr(1 * time.Hour),
 			},
 		},
 		Meta: map[string]string{
@@ -5036,6 +5037,47 @@ func TestAllocation_WaitClientStop(t *testing.T) {
 	}
 }
 
+func TestAllocation_DisconnectTimeout(t *testing.T) {
+	type testCase struct {
+		desc          string
+		maxDisconnect *time.Duration
+	}
+
+	testCases := []testCase{
+		{
+			desc:          "no max_client_disconnect",
+			maxDisconnect: nil,
+		},
+		{
+			desc:          "has max_client_disconnect",
+			maxDisconnect: helper.TimeToPtr(30 * time.Second),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			j := testJob()
+			a := &Allocation{
+				Job: j,
+			}
+
+			j.TaskGroups[0].MaxClientDisconnect = tc.maxDisconnect
+			a.TaskGroup = j.TaskGroups[0].Name
+
+			now := time.Now()
+
+			reschedTime := a.DisconnectTimeout(now)
+
+			if tc.maxDisconnect == nil {
+				require.Equal(t, now, reschedTime, "expected to be now")
+			} else {
+				difference := reschedTime.Sub(now)
+				require.Equal(t, *tc.maxDisconnect, difference, "expected durations to be equal")
+			}
+
+		})
+	}
+}
+
 func TestAllocation_Canonicalize_Old(t *testing.T) {
 	alloc := MockAlloc()
 	alloc.AllocatedResources = nil
@@ -5203,6 +5245,23 @@ func TestJobConfig_Validate_StopAferClientDisconnect(t *testing.T) {
 	// Modify the job to a batch job with a valid stop_after_client_disconnect value
 	job.Type = JobTypeBatch
 	job.TaskGroups[0].StopAfterClientDisconnect = &stop
+	err = job.Validate()
+	require.NoError(t, err)
+}
+
+func TestJobConfig_Validate_MaxClientDisconnect(t *testing.T) {
+	// Set up a job with an invalid max_client_disconnect value
+	job := testJob()
+	timeout := -1 * time.Minute
+	job.TaskGroups[0].MaxClientDisconnect = &timeout
+
+	err := job.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "max_client_disconnect must be a positive value")
+
+	// Modify the job with a valid max_client_disconnect value
+	timeout = 1 * time.Minute
+	job.TaskGroups[0].MaxClientDisconnect = &timeout
 	err = job.Validate()
 	require.NoError(t, err)
 }

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -5052,6 +5052,10 @@ func TestAllocation_DisconnectTimeout(t *testing.T) {
 			desc:          "has max_client_disconnect",
 			maxDisconnect: helper.TimeToPtr(30 * time.Second),
 		},
+		{
+			desc:          "zero max_client_disconnect",
+			maxDisconnect: helper.TimeToPtr(0 * time.Second),
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -5257,7 +5261,7 @@ func TestJobConfig_Validate_MaxClientDisconnect(t *testing.T) {
 
 	err := job.Validate()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "max_client_disconnect must be a positive value")
+	require.Contains(t, err.Error(), "max_client_disconnect cannot be negative")
 
 	// Modify the job with a valid max_client_disconnect value
 	timeout = 1 * time.Minute

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -595,6 +595,7 @@ $ curl \
             "SizeMB": 300,
             "Sticky": false
           },
+          "MaxClientDisconnect": null,
           "Meta": null,
           "Migrate": {
             "HealthCheck": "checks",
@@ -808,6 +809,7 @@ $ curl \
             "SizeMB": 300,
             "Sticky": false
           },
+          "MaxClientDisconnect": null,
           "Meta": null,
           "Migrate": {
             "HealthCheck": "checks",
@@ -975,6 +977,7 @@ $ curl \
             "SizeMB": 300,
             "Sticky": false
           },
+          "MaxClientDisconnect": null,
           "Meta": null,
           "Migrate": {
             "HealthCheck": "checks",

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -595,7 +595,7 @@ $ curl \
             "SizeMB": 300,
             "Sticky": false
           },
-          "MaxClientDisconnect": null,
+          "MaxClientDisconnect": 300000000000,
           "Meta": null,
           "Migrate": {
             "HealthCheck": "checks",


### PR DESCRIPTION
## `max_client_disconnect` Jobspec Checklist

## Code

* [x] Consider similar features in Consul, Kubernetes, and other tools. Is there prior art we should match? Terminology, structure, etc?
* [x] Add structs/[fields](https://github.com/hashicorp/nomad/pull/12177/files#diff-3ad9ba0d601a2f9fc8d17141b39c83e0d5810f1fd653e1ab5f05ae95b0ff6008) to `api/` package
  * New fields should be added to existing Canonicalize, Copy methods
    * [x] No existing `Copy` Method
    * [x] No default and nothing inherited from job, so no need to updated `Canonicalize`
  * Test the structs/fields via methods mentioned above
    * [x] Not applicable
* [x] Add structs/[fields](https://github.com/hashicorp/nomad/pull/12058/files#diff-297649e31d8e88fd89ff63dac7aff450569cca19009616f08c1d73d1e8239725) to `nomad/structs` package - **NOTE: That field was added in a previous PR**
  * [x] `structs/` structs usually have [Copy](https://github.com/hashicorp/nomad/pull/12177/files#diff-297649e31d8e88fd89ff63dac7aff450569cca19009616f08c1d73d1e8239725), ~~Equals~~, and Validate methods
  * [x] [Validation](https://github.com/hashicorp/nomad/pull/12177/files#diff-297649e31d8e88fd89ff63dac7aff450569cca19009616f08c1d73d1e8239725) happens in this package and _must_ be implemented
  * [x] Note that analogous struct field names should match with `api/` package
  * [x] [Test](https://github.com/hashicorp/nomad/pull/12177/files?diff=split&w=0#diff-897605edf4370ef2c1cc4c1cdc9ade324caef8450e156f513a2f2aaaa8610e1c) the structs/fields via methods mentioned above
  * [x] [Implement](https://github.com/hashicorp/nomad/pull/12058/files#diff-297649e31d8e88fd89ff63dac7aff450569cca19009616f08c1d73d1e8239725) and [test](https://github.com/hashicorp/nomad/pull/12177/files?diff=split&w=0#diff-897605edf4370ef2c1cc4c1cdc9ade324caef8450e156f513a2f2aaaa8610e1c) other logical methods - **Note: implementation link is to a previous PR**
* [x] Add [conversion](https://github.com/hashicorp/nomad/pull/12177/files#diff-56b3c82fcbc857f8fb93a903f1610f6e6859b3610a4eddf92bad9ea27fdc85ec) between `api/` and `nomad/structs/` in `command/agent/job_endpoint.go`
  * [x] Add [test](https://github.com/hashicorp/nomad/pull/12177/files#diff-0814cccabba6012fc72d6e71710cd6541328fbaa312320d2b4776f0359e51f6c) for conversion
* [x] Determine JSON encoding strategy for responses from RPC
* [x] Implement [diff](https://github.com/hashicorp/nomad/pull/12177/files?diff=split&w=0#diff-cc08e6b9f9b4a6ad617e54b7447a48a6cc8722f74319ac922387eae4018f348a) logic for new structs/fields in `nomad/structs/diff.go`
  * [x] Add [test](https://github.com/hashicorp/nomad/pull/12177/files?diff=split&w=0#diff-486e32a5d4805af1ae5dc2d19ddd401ff61d6baf957b0c0abbce524d1ee6cd8c) for diff of new structs/fields
* [x] Add change detection for new structs/fields in `scheduler/util.go/tasksUpdated`
  * [x] Not applicable - non-desctructive change

## Docs

* [x] Changelog - Not applicable - will be part of feature branch PR
* [x] Jobspec entry https://www.nomadproject.io/docs/job-specification/index.html
  * [x] Not applicable
* [x] Jobspec sidebar entry https://github.com/hashicorp/nomad/blob/main/website/data/docs-navigation.js
  * [x] Not applicable
* [X] Job JSON API entry https://www.nomadproject.io/api/json-jobs.html
  * [x] Not applicable
* [x] Sample Response output in API [contents/api-docs/jobs.mdx](https://github.com/hashicorp/nomad/pull/12177/files?diff=split&w=0#diff-565febd56dff73a39ccecc8602ab09c37ff61932b171c2b87ef6cd55eb30934c)