### PR TITLE
CSI: add missing fields to HTTP API response

### DIFF
--- a/.changelog/12178.txt
+++ b/.changelog/12178.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where fields were missing from the Read Volume API response
+```

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -475,10 +475,11 @@ func structsCSIVolumeToApi(vol *structs.CSIVolume) *api.CSIVolume {
 	allocCount := len(vol.ReadAllocs) + len(vol.WriteAllocs)
 
 	out := &api.CSIVolume{
-		ID:             vol.ID,
-		Name:           vol.Name,
-		ExternalID:     vol.ExternalID,
-		Namespace:      vol.Namespace,
+		ID:         vol.ID,
+		Name:       vol.Name,
+		ExternalID: vol.ExternalID,
+		Namespace:  vol.Namespace,
+
 		Topologies:     structsCSITopolgiesToApi(vol.Topologies),
 		AccessMode:     structsCSIAccessModeToApi(vol.AccessMode),
 		AttachmentMode: structsCSIAttachmentModeToApi(vol.AttachmentMode),
@@ -486,6 +487,13 @@ func structsCSIVolumeToApi(vol *structs.CSIVolume) *api.CSIVolume {
 		Secrets:        structsCSISecretsToApi(vol.Secrets),
 		Parameters:     vol.Parameters,
 		Context:        vol.Context,
+		Capacity:       vol.Capacity,
+
+		RequestedCapacityMin:  vol.RequestedCapacityMin,
+		RequestedCapacityMax:  vol.RequestedCapacityMax,
+		RequestedCapabilities: structsCSICapabilityToApi(vol.RequestedCapabilities),
+		CloneID:               vol.CloneID,
+		SnapshotID:            vol.SnapshotID,
 
 		// Allocations is the collapsed list of both read and write allocs
 		Allocations: make([]*api.AllocationListStub, 0, allocCount),
@@ -770,6 +778,18 @@ func structsCSIAttachmentModeToApi(mode structs.CSIVolumeAttachmentMode) api.CSI
 	default:
 	}
 	return api.CSIVolumeAttachmentModeUnknown
+}
+
+// structsCSICapabilityToApi converts capabilities, part of structsCSIVolumeToApi
+func structsCSICapabilityToApi(caps []*structs.CSIVolumeCapability) []*api.CSIVolumeCapability {
+	out := make([]*api.CSIVolumeCapability, len(caps))
+	for i, cap := range caps {
+		out[i] = &api.CSIVolumeCapability{
+			AccessMode:     api.CSIVolumeAccessMode(cap.AccessMode),
+			AttachmentMode: api.CSIVolumeAttachmentMode(cap.AttachmentMode),
+		}
+	}
+	return out
 }
 
 // structsCSIMountOptionsToApi converts mount options, part of structsCSIVolumeToApi


### PR DESCRIPTION
The HTTP endpoint for CSI manually serializes the internal struct to
the API struct for purposes of redaction (see also #10470). Add fields
that were missing from this serialization so they don't show up as
always empty in the API response.

Found these while testing https://github.com/hashicorp/nomad/pull/12167
That PR won't get backported but we'll want this one to be.