### PR TITLE
e2e: `StopJob` should tolerate progress deadline expired

### DIFF
--- a/e2e/e2eutil/job.go
+++ b/e2e/e2eutil/job.go
@@ -211,7 +211,8 @@ func StopJob(jobID string, args ...string) error {
 		// expect that the monitor fails and exits with status code one because
 		// technically the deployment has failed. Overwrite the error to be
 		// nil.
-		if strings.Contains(err.Error(), "Description = Cancelled because job is stopped") {
+		if strings.Contains(err.Error(), "Description = Cancelled because job is stopped") ||
+			strings.Contains(err.Error(), "Description = Failed due to progress deadline") {
 			err = nil
 		}
 	}


### PR DESCRIPTION
The `TestRescheduleProgressDeadlineFail` E2E test failed during test
cleanup because the error message "progress deadline expired" that it
emits when we stop the job does not match the one expected from
monitoring the `job stop` command. Update the `StopJob` helper 
introduced in c2b5a5e to tolerate this use case as well.