### PR TITLE
e2e: use `operator api` for Networking suite validation

### DIFF
--- a/e2e/networking/inputs/validate.sh
+++ b/e2e/networking/inputs/validate.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-test $(curl --silent ${NOMAD_ADDR}/v1/allocation/${NOMAD_ALLOC_ID} | jq '.NetworkStatus.Address | length') -ne 0
+nomad operator api "/v1/allocation/${NOMAD_ALLOC_ID}" | jq '.NetworkStatus.Address | length'


### PR DESCRIPTION
With mTLS enabled in nightly E2E as of bfac8d8, using `curl` in a bash 
script for validation involves having to configure arguments to `curl` 
based  on whether or not the test infrastructure is using mTLS, whether 
ACLs are enabled, etc. Use the new `operator api` command instead to
pick up the client configuration from the test environment automatically.