### PR TITLE
e2e: configure prometheus for mTLS for `Metrics` suite

### DIFF
--- a/e2e/metrics/input/prometheus.nomad
+++ b/e2e/metrics/input/prometheus.nomad
@@ -51,11 +51,18 @@ scrape_configs:
       regex: '(.*)http(.*)'
       action: keep
 
+    scheme: https
+    tls_config:
+        ca_file: '/etc/nomad.d/tls/ca.crt'
+        cert_file: '/etc/nomad.d/tls/agent.crt'
+        key_file: '/etc/nomad.d/tls/agent.key'
+
     scrape_interval: 5s
     metrics_path: /v1/metrics
     params:
       format: ['prometheus']
 EOH
+
       }
 
       driver = "docker"
@@ -66,6 +73,17 @@ EOH
         volumes = [
           "local/prometheus.yml:/etc/prometheus/prometheus.yml",
         ]
+
+        # TODO: https://github.com/hashicorp/nomad/issues/11484
+        # This is very much not how we should do this, because it
+        # exposes the client's mTLS cert to the task and lets the
+        # prometheus masquerade as the client.
+        mount {
+          type     = "bind"
+          target   = "/etc/nomad.d/tls"
+          source   = "/etc/nomad.d/tls"
+          readonly = true
+        }
 
         ports = ["prometheus_ui"]
       }

--- a/e2e/terraform/config/dev-cluster/nomad/client-linux/client.hcl
+++ b/e2e/terraform/config/dev-cluster/nomad/client-linux/client.hcl
@@ -6,12 +6,6 @@ client {
   options {
     # Allow jobs to run as root
     "user.denylist" = ""
-
-    # Allow rawexec jobs
-    "driver.raw_exec.enable" = "1"
-
-    # Allow privileged docker jobs
-    "docker.privileged.enabled" = "true"
   }
 
   host_volume "shared_data" {
@@ -32,6 +26,22 @@ plugin "nomad-driver-ecs" {
     enabled = true
     cluster = "nomad-rtd-e2e"
     region  = "us-east-1"
+  }
+}
+
+plugin "raw_exec" {
+  config {
+    enabled = true
+  }
+}
+
+plugin "docker" {
+  config {
+    allow_privileged = true
+
+    volumes {
+      enabled = true
+    }
   }
 }
 

--- a/e2e/terraform/config/full-cluster/nomad/client-linux/indexed/client-0.hcl
+++ b/e2e/terraform/config/full-cluster/nomad/client-linux/indexed/client-0.hcl
@@ -2,11 +2,6 @@
 client {
   enabled = true
 
-  options {
-    "driver.raw_exec.enable"    = "1"
-    "docker.privileged.enabled" = "true"
-  }
-
   meta {
     "rack" = "r1"
   }
@@ -30,6 +25,22 @@ plugin "nomad-driver-ecs" {
     enabled = true
     cluster = "nomad-rtd-e2e"
     region  = "us-east-1"
+  }
+}
+
+plugin "raw_exec" {
+  config {
+    enabled = true
+  }
+}
+
+plugin "docker" {
+  config {
+    allow_privileged = true
+
+    volumes {
+      enabled = true
+    }
   }
 }
 

--- a/e2e/terraform/config/full-cluster/nomad/client-linux/indexed/client-1.hcl
+++ b/e2e/terraform/config/full-cluster/nomad/client-linux/indexed/client-1.hcl
@@ -1,11 +1,6 @@
 client {
   enabled = true
 
-  options {
-    "driver.raw_exec.enable"    = "1"
-    "docker.privileged.enabled" = "true"
-  }
-
   meta {
     "rack" = "r2"
   }
@@ -25,6 +20,22 @@ plugin "nomad-driver-ecs" {
     enabled = true
     cluster = "nomad-rtd-e2e"
     region  = "us-east-1"
+  }
+}
+
+plugin "raw_exec" {
+  config {
+    enabled = true
+  }
+}
+
+plugin "docker" {
+  config {
+    allow_privileged = true
+
+    volumes {
+      enabled = true
+    }
   }
 }
 

--- a/e2e/terraform/config/full-cluster/nomad/client-linux/indexed/client-2.hcl
+++ b/e2e/terraform/config/full-cluster/nomad/client-linux/indexed/client-2.hcl
@@ -3,11 +3,6 @@ datacenter = "dc2"
 client {
   enabled = true
 
-  options {
-    "driver.raw_exec.enable"    = "1"
-    "docker.privileged.enabled" = "true"
-  }
-
   meta {
     "rack" = "r1"
   }
@@ -16,6 +11,22 @@ client {
 plugin_dir = "/opt/nomad/plugins"
 plugin "nomad-driver-podman" {
   config {
+    volumes {
+      enabled = true
+    }
+  }
+}
+
+plugin "raw_exec" {
+  config {
+    enabled = true
+  }
+}
+
+plugin "docker" {
+  config {
+    allow_privileged = true
+
     volumes {
       enabled = true
     }

--- a/e2e/terraform/config/full-cluster/nomad/client-linux/indexed/client-3.hcl
+++ b/e2e/terraform/config/full-cluster/nomad/client-linux/indexed/client-3.hcl
@@ -3,13 +3,24 @@ datacenter = "dc2"
 client {
   enabled = true
 
-  options {
-    "driver.raw_exec.enable"    = "1"
-    "docker.privileged.enabled" = "true"
-  }
-
   meta {
     "rack" = "r2"
+  }
+}
+
+plugin "raw_exec" {
+  config {
+    enabled = true
+  }
+}
+
+plugin "docker" {
+  config {
+    allow_privileged = true
+
+    volumes {
+      enabled = true
+    }
   }
 }
 


### PR DESCRIPTION
The `Metrics` suite uses prometheus to scrape Nomad metrics so that
we're testing the full user experience of extracting metrics from
Nomad. With the addition of mTLS, we need to make sure prometheus also
has mTLS configuration because the metrics endpoint is protected.

Update the Nomad client configuration and prometheus job to bind-mount
the client's certs into the task so that the job can use these certs
to scrape the server. This is a temporary solution that gets the job
passing; we should give the job its own certificates (issued by
Vault?) when we've done some of the infrastructure rework we'd like.

---

Temporary hack for https://github.com/hashicorp/nomad/issues/11484 but I'm going to leave that open with a note to complete the infra work required here.