### PR TITLE
csi: ensure `WriteOptions` aren't nil when handling secrets

### DIFF
--- a/api/csi.go
+++ b/api/csi.go
@@ -130,6 +130,9 @@ func (v *CSIVolumes) DeleteSnapshot(snap *CSISnapshot, w *WriteOptions) error {
 	qp := url.Values{}
 	qp.Set("snapshot_id", snap.ID)
 	qp.Set("plugin_id", snap.PluginID)
+	if w == nil {
+		w = &WriteOptions{}
+	}
 	w.SetHeadersFromCSISecrets(snap.Secrets)
 	_, err := v.client.delete("/v1/volumes/snapshot?"+qp.Encode(), nil, w)
 	return err


### PR DESCRIPTION
When we set the headers for CSI secrets in the `WriteOptions`, it
turns out that we're not always passing a non-nil object. In that
case, instantiate it on demand in the API.

This slipped in with https://github.com/hashicorp/nomad/pull/12178 but got caught by E2E.