### PR TITLE
Add pagination, filtering and sort to more API endpoints

### DIFF
--- a/.changelog/12186.txt
+++ b/.changelog/12186.txt
@@ -1,15 +1,7 @@
 ```release-note:improvement
-api: Add support for filtering, sorting, and pagination to the ACL tokens list endpoint
+api: Add support for filtering, sorting, and pagination to the ACL tokens and allocations list endpoint
 ```
 
 ```release-note:improvement
-api: Add support for filtering, sorting, and pagination to the allocations list endpoint
-```
-
-```release-note:improvement
-api: Add support for filtering and pagination to the jobs list endpoint
-```
-
-```release-note:improvement
-api: Add support for filtering and pagination to the volumes list endpoint
+api: Add support for filtering and pagination to the jobs and volumes list endpoint
 ```

--- a/.changelog/12186.txt
+++ b/.changelog/12186.txt
@@ -1,0 +1,15 @@
+```release-note:improvement
+api: Add support for filtering, sorting, and pagination to the ACL tokens list endpoint
+```
+
+```release-note:improvement
+api: Add support for filtering, sorting, and pagination to the allocations list endpoint
+```
+
+```release-note:improvement
+api: Add support for filtering and pagination to the jobs list endpoint
+```
+
+```release-note:improvement
+api: Add support for filtering and pagination to the volumes list endpoint
+```

--- a/api/api.go
+++ b/api/api.go
@@ -82,10 +82,10 @@ type QueryOptions struct {
 	// previous response.
 	NextToken string
 
-	// Ascending is used to have results sorted in ascending chronological order.
+	// Reverse is used to reverse the default order of list results.
 	//
-	// Currently only supported by evaluations.List and deployments.list endpoints.
-	Ascending bool
+	// Currently only supported by specific endpoints.
+	Reverse bool
 
 	// ctx is an optional context pass through to the underlying HTTP
 	// request layer. Use Context() and WithContext() to manage this.
@@ -605,8 +605,8 @@ func (r *request) setQueryOptions(q *QueryOptions) {
 	if q.NextToken != "" {
 		r.params.Set("next_token", q.NextToken)
 	}
-	if q.Ascending {
-		r.params.Set("ascending", "true")
+	if q.Reverse {
+		r.params.Set("reverse", "true")
 	}
 	for k, v := range q.Params {
 		r.params.Set(k, v)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -181,7 +181,7 @@ func TestSetQueryOptions(t *testing.T) {
 		WaitIndex:  1000,
 		WaitTime:   100 * time.Second,
 		AuthToken:  "foobar",
-		Ascending:  true,
+		Reverse:    true,
 	}
 	r.setQueryOptions(q)
 
@@ -199,7 +199,7 @@ func TestSetQueryOptions(t *testing.T) {
 	try("stale", "") // should not be present
 	try("index", "1000")
 	try("wait", "100000ms")
-	try("ascending", "true")
+	try("reverse", "true")
 }
 
 func TestQueryOptionsContext(t *testing.T) {

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -788,7 +788,7 @@ func (s *HTTPServer) parse(resp http.ResponseWriter, req *http.Request, r *strin
 	parseNamespace(req, &b.Namespace)
 	parsePagination(req, b)
 	parseFilter(req, b)
-	parseAscending(req, b)
+	parseReverse(req, b)
 	return parseWait(resp, req, b)
 }
 
@@ -814,10 +814,10 @@ func parseFilter(req *http.Request, b *structs.QueryOptions) {
 	}
 }
 
-// parseAscending parses the ascending query parameter for QueryOptions
-func parseAscending(req *http.Request, b *structs.QueryOptions) {
+// parseReverse parses the reverse query parameter for QueryOptions
+func parseReverse(req *http.Request, b *structs.QueryOptions) {
 	query := req.URL.Query()
-	b.Ascending = query.Get("ascending") == "true"
+	b.Reverse = query.Get("reverse") == "true"
 }
 
 // parseWriteRequest is a convenience method for endpoints that need to parse a

--- a/helper/raftutil/fsm.go
+++ b/helper/raftutil/fsm.go
@@ -188,7 +188,7 @@ func (f *FSMHelper) StateAsMap() map[string][]interface{} {
 func StateAsMap(state *state.StateStore) map[string][]interface{} {
 	result := map[string][]interface{}{
 		"ACLPolicies":      toArray(state.ACLPolicies(nil)),
-		"ACLTokens":        toArray(state.ACLTokens(nil)),
+		"ACLTokens":        toArray(state.ACLTokens(nil, false)),
 		"Allocs":           toArray(state.Allocs(nil)),
 		"CSIPlugins":       toArray(state.CSIPlugins(nil)),
 		"CSIVolumes":       toArray(state.CSIVolumes(nil)),

--- a/helper/raftutil/fsm.go
+++ b/helper/raftutil/fsm.go
@@ -189,7 +189,7 @@ func StateAsMap(state *state.StateStore) map[string][]interface{} {
 	result := map[string][]interface{}{
 		"ACLPolicies":      toArray(state.ACLPolicies(nil)),
 		"ACLTokens":        toArray(state.ACLTokens(nil, false)),
-		"Allocs":           toArray(state.Allocs(nil)),
+		"Allocs":           toArray(state.Allocs(nil, false)),
 		"CSIPlugins":       toArray(state.CSIPlugins(nil)),
 		"CSIVolumes":       toArray(state.CSIVolumes(nil)),
 		"Deployments":      toArray(state.Deployments(nil, false)),

--- a/helper/raftutil/fsm.go
+++ b/helper/raftutil/fsm.go
@@ -185,28 +185,28 @@ func (f *FSMHelper) StateAsMap() map[string][]interface{} {
 }
 
 // StateAsMap returns a json-able representation of the state
-func StateAsMap(state *state.StateStore) map[string][]interface{} {
+func StateAsMap(store *state.StateStore) map[string][]interface{} {
 	result := map[string][]interface{}{
-		"ACLPolicies":      toArray(state.ACLPolicies(nil)),
-		"ACLTokens":        toArray(state.ACLTokens(nil, false)),
-		"Allocs":           toArray(state.Allocs(nil, false)),
-		"CSIPlugins":       toArray(state.CSIPlugins(nil)),
-		"CSIVolumes":       toArray(state.CSIVolumes(nil)),
-		"Deployments":      toArray(state.Deployments(nil, false)),
-		"Evals":            toArray(state.Evals(nil, false)),
-		"Indexes":          toArray(state.Indexes()),
-		"JobSummaries":     toArray(state.JobSummaries(nil)),
-		"JobVersions":      toArray(state.JobVersions(nil)),
-		"Jobs":             toArray(state.Jobs(nil)),
-		"Nodes":            toArray(state.Nodes(nil)),
-		"PeriodicLaunches": toArray(state.PeriodicLaunches(nil)),
-		"SITokenAccessors": toArray(state.SITokenAccessors(nil)),
-		"ScalingEvents":    toArray(state.ScalingEvents(nil)),
-		"ScalingPolicies":  toArray(state.ScalingPolicies(nil)),
-		"VaultAccessors":   toArray(state.VaultAccessors(nil)),
+		"ACLPolicies":      toArray(store.ACLPolicies(nil)),
+		"ACLTokens":        toArray(store.ACLTokens(nil, state.SortDefault)),
+		"Allocs":           toArray(store.Allocs(nil, state.SortDefault)),
+		"CSIPlugins":       toArray(store.CSIPlugins(nil)),
+		"CSIVolumes":       toArray(store.CSIVolumes(nil)),
+		"Deployments":      toArray(store.Deployments(nil, state.SortDefault)),
+		"Evals":            toArray(store.Evals(nil, state.SortDefault)),
+		"Indexes":          toArray(store.Indexes()),
+		"JobSummaries":     toArray(store.JobSummaries(nil)),
+		"JobVersions":      toArray(store.JobVersions(nil)),
+		"Jobs":             toArray(store.Jobs(nil)),
+		"Nodes":            toArray(store.Nodes(nil)),
+		"PeriodicLaunches": toArray(store.PeriodicLaunches(nil)),
+		"SITokenAccessors": toArray(store.SITokenAccessors(nil)),
+		"ScalingEvents":    toArray(store.ScalingEvents(nil)),
+		"ScalingPolicies":  toArray(store.ScalingPolicies(nil)),
+		"VaultAccessors":   toArray(store.VaultAccessors(nil)),
 	}
 
-	insertEnterpriseState(result, state)
+	insertEnterpriseState(result, store)
 
 	return result
 

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -654,6 +654,7 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 	}
 
 	// Setup the blocking query
+	sort := state.SortOption(args.Reverse)
 	opts := blockingOptions{
 		queryOpts: &args.QueryOptions,
 		queryMeta: &reply.QueryMeta,
@@ -674,7 +675,7 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 					WithID: true,
 				}
 			} else {
-				iter, err = state.ACLTokens(ws, args.Reverse)
+				iter, err = state.ACLTokens(ws, sort)
 				opts = paginator.StructsTokenizerOptions{
 					WithCreateIndex: true,
 					WithID:          true,

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -674,7 +674,7 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 					WithID: true,
 				}
 			} else {
-				iter, err = state.ACLTokens(ws, args.Ascending)
+				iter, err = state.ACLTokens(ws, args.Reverse)
 				opts = paginator.StructsTokenizerOptions{
 					WithCreateIndex: true,
 					WithID:          true,

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -3,6 +3,7 @@ package nomad
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	policy "github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/state/paginator"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -659,27 +661,51 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 			// Iterate over all the tokens
 			var err error
 			var iter memdb.ResultIterator
+			var opts paginator.StructsTokenizerOptions
+
 			if prefix := args.QueryOptions.Prefix; prefix != "" {
 				iter, err = state.ACLTokenByAccessorIDPrefix(ws, prefix)
+				opts = paginator.StructsTokenizerOptions{
+					WithID: true,
+				}
 			} else if args.GlobalOnly {
 				iter, err = state.ACLTokensByGlobal(ws, true)
+				opts = paginator.StructsTokenizerOptions{
+					WithID: true,
+				}
 			} else {
-				iter, err = state.ACLTokens(ws)
+				iter, err = state.ACLTokens(ws, args.Ascending)
+				opts = paginator.StructsTokenizerOptions{
+					WithCreateIndex: true,
+					WithID:          true,
+				}
 			}
 			if err != nil {
 				return err
 			}
 
-			// Convert all the tokens to a list stub
-			reply.Tokens = nil
-			for {
-				raw := iter.Next()
-				if raw == nil {
-					break
-				}
-				token := raw.(*structs.ACLToken)
-				reply.Tokens = append(reply.Tokens, token.Stub())
+			tokenizer := paginator.NewStructsTokenizer(iter, opts)
+
+			var tokens []*structs.ACLTokenListStub
+			paginator, err := paginator.NewPaginator(iter, tokenizer, nil, args.QueryOptions,
+				func(raw interface{}) error {
+					token := raw.(*structs.ACLToken)
+					tokens = append(tokens, token.Stub())
+					return nil
+				})
+			if err != nil {
+				return structs.NewErrRPCCodedf(
+					http.StatusBadRequest, "failed to create result paginator: %v", err)
 			}
+
+			nextToken, err := paginator.Page()
+			if err != nil {
+				return structs.NewErrRPCCodedf(
+					http.StatusBadRequest, "failed to read result page: %v", err)
+			}
+
+			reply.QueryMeta.NextToken = nextToken
+			reply.Tokens = tokens
 
 			// Use the last index that affected the token table
 			index, err := state.Index("acl_token")
@@ -687,6 +713,7 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 				return err
 			}
 			reply.Index = index
+
 			return nil
 		}}
 	return a.srv.blockingRPC(&opts)

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -1084,7 +1084,6 @@ func TestACLEndpoint_ListTokens_PaginationFiltering(t *testing.T) {
 					Filter:    tc.filter,
 					PerPage:   tc.pageSize,
 					NextToken: tc.nextToken,
-					Ascending: true, // counting up is easier to think about
 				},
 			}
 			req.AuthToken = bootstrapToken
@@ -1146,12 +1145,11 @@ func TestACLEndpoint_ListTokens_Order(t *testing.T) {
 	err = s1.fsm.State().UpsertACLTokens(structs.MsgTypeTestSetup, 1003, []*structs.ACLToken{token2})
 	require.NoError(t, err)
 
-	t.Run("ascending", func(t *testing.T) {
-		// Lookup the jobs in chronological order (oldest first)
+	t.Run("default", func(t *testing.T) {
+		// Lookup the tokens in the default order (oldest first)
 		get := &structs.ACLTokenListRequest{
 			QueryOptions: structs.QueryOptions{
-				Region:    "global",
-				Ascending: true,
+				Region: "global",
 			},
 		}
 		get.AuthToken = bootstrapToken
@@ -1173,12 +1171,12 @@ func TestACLEndpoint_ListTokens_Order(t *testing.T) {
 		require.Equal(t, uuid3, resp.Tokens[2].AccessorID)
 	})
 
-	t.Run("descending", func(t *testing.T) {
-		// Lookup the jobs in reverse chronological order (newest first)
+	t.Run("reverse", func(t *testing.T) {
+		// Lookup the tokens in reverse order (newest first)
 		get := &structs.ACLTokenListRequest{
 			QueryOptions: structs.QueryOptions{
-				Region:    "global",
-				Ascending: false,
+				Region:  "global",
+				Reverse: true,
 			},
 		}
 		get.AuthToken = bootstrapToken

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -919,6 +919,288 @@ func TestACLEndpoint_ListTokens(t *testing.T) {
 	assert.Equal(t, 2, len(resp3.Tokens))
 }
 
+func TestACLEndpoint_ListTokens_PaginationFiltering(t *testing.T) {
+	t.Parallel()
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
+		c.ACLEnabled = true
+	})
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// create a set of ACL tokens. these are in the order that the state store
+	// will return them from the iterator (sorted by key) for ease of writing
+	// tests
+	mocks := []struct {
+		ids []string
+		typ string
+	}{
+		{ids: []string{"aaaa1111-3350-4b4b-d185-0e1992ed43e9"}, typ: "management"}, // 0
+		{ids: []string{"aaaaaa22-3350-4b4b-d185-0e1992ed43e9"}},                    // 1
+		{ids: []string{"aaaaaa33-3350-4b4b-d185-0e1992ed43e9"}},                    // 2
+		{ids: []string{"aaaaaaaa-3350-4b4b-d185-0e1992ed43e9"}},                    // 3
+		{ids: []string{"aaaaaabb-3350-4b4b-d185-0e1992ed43e9"}},                    // 4
+		{ids: []string{"aaaaaacc-3350-4b4b-d185-0e1992ed43e9"}},                    // 5
+		{ids: []string{"aaaaaadd-3350-4b4b-d185-0e1992ed43e9"}},                    // 6
+		{ids: []string{"00000111-3350-4b4b-d185-0e1992ed43e9"}},                    // 7
+		{ids: []string{ // 8
+			"00000222-3350-4b4b-d185-0e1992ed43e9",
+			"00000333-3350-4b4b-d185-0e1992ed43e9",
+		}},
+		{}, // 9, index missing
+		{ids: []string{"bbbb1111-3350-4b4b-d185-0e1992ed43e9"}}, // 10
+	}
+
+	state := s1.fsm.State()
+
+	var bootstrapToken string
+	for i, m := range mocks {
+		tokensInTx := []*structs.ACLToken{}
+		for _, id := range m.ids {
+			token := mock.ACLToken()
+			token.AccessorID = id
+			token.Type = m.typ
+			tokensInTx = append(tokensInTx, token)
+		}
+		index := 1000 + uint64(i)
+
+		// bootstrap cluster with the first token
+		if i == 0 {
+			token := tokensInTx[0]
+			bootstrapToken = token.SecretID
+			err := s1.State().BootstrapACLTokens(structs.MsgTypeTestSetup, index, 0, token)
+			require.NoError(t, err)
+
+			err = state.UpsertACLTokens(structs.MsgTypeTestSetup, index, tokensInTx[1:])
+			require.NoError(t, err)
+		} else {
+			err := state.UpsertACLTokens(structs.MsgTypeTestSetup, index, tokensInTx)
+			require.NoError(t, err)
+		}
+	}
+
+	cases := []struct {
+		name              string
+		prefix            string
+		filter            string
+		nextToken         string
+		pageSize          int32
+		expectedNextToken string
+		expectedIDs       []string
+		expectedError     string
+	}{
+		{
+			name:              "test01 size-2 page-1",
+			pageSize:          2,
+			expectedNextToken: "1002.aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
+			expectedIDs: []string{
+				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
+				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:              "test02 size-2 page-1 with prefix",
+			prefix:            "aaaa",
+			pageSize:          2,
+			expectedNextToken: "aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
+			expectedIDs: []string{
+				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
+				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:              "test03 size-2 page-2 default NS",
+			pageSize:          2,
+			nextToken:         "1002.aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1004.aaaaaabb-3350-4b4b-d185-0e1992ed43e9",
+			expectedIDs: []string{
+				"aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
+				"aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:   "test04 go-bexpr filter",
+			filter: `AccessorID matches "^a+[123]"`,
+			expectedIDs: []string{
+				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
+				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
+				"aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:              "test05 go-bexpr filter with pagination",
+			filter:            `AccessorID matches "^a+[123]"`,
+			pageSize:          2,
+			expectedNextToken: "1002.aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
+			expectedIDs: []string{
+				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
+				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:          "test06 go-bexpr invalid expression",
+			filter:        `NotValid`,
+			expectedError: "failed to read filter expression",
+		},
+		{
+			name:          "test07 go-bexpr invalid field",
+			filter:        `InvalidField == "value"`,
+			expectedError: "error finding value in datum",
+		},
+		{
+			name:              "test08 non-lexicographic order",
+			pageSize:          1,
+			nextToken:         "1007.00000111-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1008.00000222-3350-4b4b-d185-0e1992ed43e9",
+			expectedIDs: []string{
+				"00000111-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:              "test09 same index",
+			pageSize:          1,
+			nextToken:         "1008.00000222-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1008.00000333-3350-4b4b-d185-0e1992ed43e9",
+			expectedIDs: []string{
+				"00000222-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:      "test10 missing index",
+			pageSize:  1,
+			nextToken: "1009.e9522802-0cd8-4b1d-9c9e-ab3d97938371",
+			expectedIDs: []string{
+				"bbbb1111-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &structs.ACLTokenListRequest{
+				QueryOptions: structs.QueryOptions{
+					Region:    "global",
+					Prefix:    tc.prefix,
+					Filter:    tc.filter,
+					PerPage:   tc.pageSize,
+					NextToken: tc.nextToken,
+					Ascending: true, // counting up is easier to think about
+				},
+			}
+			req.AuthToken = bootstrapToken
+			var resp structs.ACLTokenListResponse
+			err := msgpackrpc.CallWithCodec(codec, "ACL.ListTokens", req, &resp)
+			if tc.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedError)
+				return
+			}
+
+			gotIDs := []string{}
+			for _, token := range resp.Tokens {
+				gotIDs = append(gotIDs, token.AccessorID)
+			}
+			require.Equal(t, tc.expectedIDs, gotIDs, "unexpected page of tokens")
+			require.Equal(t, tc.expectedNextToken, resp.QueryMeta.NextToken, "unexpected NextToken")
+		})
+	}
+}
+
+func TestACLEndpoint_ListTokens_Order(t *testing.T) {
+	t.Parallel()
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) {
+		c.ACLEnabled = true
+	})
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create register requests
+	uuid1 := uuid.Generate()
+	token1 := mock.ACLManagementToken()
+	token1.AccessorID = uuid1
+
+	uuid2 := uuid.Generate()
+	token2 := mock.ACLToken()
+	token2.AccessorID = uuid2
+
+	uuid3 := uuid.Generate()
+	token3 := mock.ACLToken()
+	token3.AccessorID = uuid3
+
+	// bootstrap cluster with the first token
+	bootstrapToken := token1.SecretID
+	err := s1.State().BootstrapACLTokens(structs.MsgTypeTestSetup, 1000, 0, token1)
+	require.NoError(t, err)
+
+	err = s1.fsm.State().UpsertACLTokens(structs.MsgTypeTestSetup, 1001, []*structs.ACLToken{token2})
+	require.NoError(t, err)
+
+	err = s1.fsm.State().UpsertACLTokens(structs.MsgTypeTestSetup, 1002, []*structs.ACLToken{token3})
+	require.NoError(t, err)
+
+	// update token2 again so we can later assert create index order did not change
+	err = s1.fsm.State().UpsertACLTokens(structs.MsgTypeTestSetup, 1003, []*structs.ACLToken{token2})
+	require.NoError(t, err)
+
+	t.Run("ascending", func(t *testing.T) {
+		// Lookup the jobs in chronological order (oldest first)
+		get := &structs.ACLTokenListRequest{
+			QueryOptions: structs.QueryOptions{
+				Region:    "global",
+				Ascending: true,
+			},
+		}
+		get.AuthToken = bootstrapToken
+
+		var resp structs.ACLTokenListResponse
+		err = msgpackrpc.CallWithCodec(codec, "ACL.ListTokens", get, &resp)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1003), resp.Index)
+		require.Len(t, resp.Tokens, 3)
+
+		// Assert returned order is by CreateIndex (ascending)
+		require.Equal(t, uint64(1000), resp.Tokens[0].CreateIndex)
+		require.Equal(t, uuid1, resp.Tokens[0].AccessorID)
+
+		require.Equal(t, uint64(1001), resp.Tokens[1].CreateIndex)
+		require.Equal(t, uuid2, resp.Tokens[1].AccessorID)
+
+		require.Equal(t, uint64(1002), resp.Tokens[2].CreateIndex)
+		require.Equal(t, uuid3, resp.Tokens[2].AccessorID)
+	})
+
+	t.Run("descending", func(t *testing.T) {
+		// Lookup the jobs in reverse chronological order (newest first)
+		get := &structs.ACLTokenListRequest{
+			QueryOptions: structs.QueryOptions{
+				Region:    "global",
+				Ascending: false,
+			},
+		}
+		get.AuthToken = bootstrapToken
+
+		var resp structs.ACLTokenListResponse
+		err = msgpackrpc.CallWithCodec(codec, "ACL.ListTokens", get, &resp)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1003), resp.Index)
+		require.Len(t, resp.Tokens, 3)
+
+		// Assert returned order is by CreateIndex (descending)
+		require.Equal(t, uint64(1002), resp.Tokens[0].CreateIndex)
+		require.Equal(t, uuid3, resp.Tokens[0].AccessorID)
+
+		require.Equal(t, uint64(1001), resp.Tokens[1].CreateIndex)
+		require.Equal(t, uuid2, resp.Tokens[1].AccessorID)
+
+		require.Equal(t, uint64(1000), resp.Tokens[2].CreateIndex)
+		require.Equal(t, uuid1, resp.Tokens[2].AccessorID)
+	})
+}
+
 func TestACLEndpoint_ListTokens_Blocking(t *testing.T) {
 	t.Parallel()
 

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -60,6 +60,7 @@ func (a *Alloc) List(args *structs.AllocListRequest, reply *structs.AllocListRes
 	}
 
 	// Setup the blocking query
+	sort := state.SortOption(args.Reverse)
 	opts := blockingOptions{
 		queryOpts: &args.QueryOptions,
 		queryMeta: &reply.QueryMeta,
@@ -84,13 +85,13 @@ func (a *Alloc) List(args *structs.AllocListRequest, reply *structs.AllocListRes
 						WithID: true,
 					}
 				} else if namespace != structs.AllNamespacesSentinel {
-					iter, err = state.AllocsByNamespaceOrdered(ws, namespace, args.Reverse)
+					iter, err = state.AllocsByNamespaceOrdered(ws, namespace, sort)
 					opts = paginator.StructsTokenizerOptions{
 						WithCreateIndex: true,
 						WithID:          true,
 					}
 				} else {
-					iter, err = state.Allocs(ws, args.Reverse)
+					iter, err = state.Allocs(ws, sort)
 					opts = paginator.StructsTokenizerOptions{
 						WithCreateIndex: true,
 						WithID:          true,

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -84,13 +84,13 @@ func (a *Alloc) List(args *structs.AllocListRequest, reply *structs.AllocListRes
 						WithID: true,
 					}
 				} else if namespace != structs.AllNamespacesSentinel {
-					iter, err = state.AllocsByNamespaceOrdered(ws, namespace, args.Ascending)
+					iter, err = state.AllocsByNamespaceOrdered(ws, namespace, args.Reverse)
 					opts = paginator.StructsTokenizerOptions{
 						WithCreateIndex: true,
 						WithID:          true,
 					}
 				} else {
-					iter, err = state.Allocs(ws, args.Ascending)
+					iter, err = state.Allocs(ws, args.Reverse)
 					opts = paginator.StructsTokenizerOptions{
 						WithCreateIndex: true,
 						WithID:          true,

--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -287,7 +287,6 @@ func TestAllocEndpoint_List_PaginationFiltering(t *testing.T) {
 					PerPage:   tc.pageSize,
 					NextToken: tc.nextToken,
 					Filter:    tc.filter,
-					Ascending: true,
 				},
 				Fields: &structs.AllocStubFields{
 					Resources:  false,
@@ -347,13 +346,12 @@ func TestAllocEndpoint_List_order(t *testing.T) {
 	err = s1.fsm.State().UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{alloc2})
 	require.NoError(t, err)
 
-	t.Run("ascending", func(t *testing.T) {
-		// Lookup the allocations in reverse chronological order (newest first)
+	t.Run("default", func(t *testing.T) {
+		// Lookup the allocations in the default order (oldest first)
 		get := &structs.AllocListRequest{
 			QueryOptions: structs.QueryOptions{
 				Region:    "global",
 				Namespace: "*",
-				Ascending: true,
 			},
 		}
 
@@ -374,13 +372,13 @@ func TestAllocEndpoint_List_order(t *testing.T) {
 		require.Equal(t, uuid3, resp.Allocations[2].ID)
 	})
 
-	t.Run("descending", func(t *testing.T) {
-		// Lookup the allocations in reverse chronological order
+	t.Run("reverse", func(t *testing.T) {
+		// Lookup the allocations in reverse order (newest first)
 		get := &structs.AllocListRequest{
 			QueryOptions: structs.QueryOptions{
 				Region:    "global",
 				Namespace: "*",
-				Ascending: false,
+				Reverse:   true,
 			},
 		}
 

--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -74,6 +74,332 @@ func TestAllocEndpoint_List(t *testing.T) {
 	require.Equal(t, uint64(1000), resp2.Index)
 	require.Len(t, resp2.Allocations, 1)
 	require.Equal(t, alloc.ID, resp2.Allocations[0].ID)
+
+	// Lookup allocations with a filter
+	get = &structs.AllocListRequest{
+		QueryOptions: structs.QueryOptions{
+			Region:    "global",
+			Namespace: structs.DefaultNamespace,
+			Filter:    "TaskGroup == web",
+		},
+	}
+
+	var resp3 structs.AllocListResponse
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Alloc.List", get, &resp3))
+	require.Equal(t, uint64(1000), resp3.Index)
+	require.Len(t, resp3.Allocations, 1)
+	require.Equal(t, alloc.ID, resp3.Allocations[0].ID)
+}
+
+func TestAllocEndpoint_List_PaginationFiltering(t *testing.T) {
+	t.Parallel()
+	s1, _, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// create a set of allocs and field values to filter on. these are in the order
+	// that the state store will return them from the iterator (sorted by create
+	// index), for ease of writing tests.
+	mocks := []struct {
+		ids       []string
+		namespace string
+		group     string
+	}{
+		{ids: []string{"aaaa1111-3350-4b4b-d185-0e1992ed43e9"}},                           // 0
+		{ids: []string{"aaaaaa22-3350-4b4b-d185-0e1992ed43e9"}},                           // 1
+		{ids: []string{"aaaaaa33-3350-4b4b-d185-0e1992ed43e9"}, namespace: "non-default"}, // 2
+		{ids: []string{"aaaaaaaa-3350-4b4b-d185-0e1992ed43e9"}, group: "bar"},             // 3
+		{ids: []string{"aaaaaabb-3350-4b4b-d185-0e1992ed43e9"}, group: "goo"},             // 4
+		{ids: []string{"aaaaaacc-3350-4b4b-d185-0e1992ed43e9"}},                           // 5
+		{ids: []string{"aaaaaadd-3350-4b4b-d185-0e1992ed43e9"}, group: "bar"},             // 6
+		{ids: []string{"aaaaaaee-3350-4b4b-d185-0e1992ed43e9"}, group: "goo"},             // 7
+		{ids: []string{"aaaaaaff-3350-4b4b-d185-0e1992ed43e9"}, group: "bar"},             // 8
+		{ids: []string{"00000111-3350-4b4b-d185-0e1992ed43e9"}},                           // 9
+		{ids: []string{ // 10
+			"00000222-3350-4b4b-d185-0e1992ed43e9",
+			"00000333-3350-4b4b-d185-0e1992ed43e9",
+		}},
+		{}, // 11, index missing
+		{ids: []string{"bbbb1111-3350-4b4b-d185-0e1992ed43e9"}}, // 12
+	}
+
+	state := s1.fsm.State()
+
+	var allocs []*structs.Allocation
+	for i, m := range mocks {
+		allocsInTx := []*structs.Allocation{}
+		for _, id := range m.ids {
+			alloc := mock.Alloc()
+			alloc.ID = id
+			if m.namespace != "" {
+				alloc.Namespace = m.namespace
+			}
+			if m.group != "" {
+				alloc.TaskGroup = m.group
+			}
+			allocs = append(allocs, alloc)
+			allocsInTx = append(allocsInTx, alloc)
+		}
+		// other fields
+		index := 1000 + uint64(i)
+		require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, index, allocsInTx))
+	}
+
+	require.NoError(t, state.UpsertNamespaces(1099, []*structs.Namespace{
+		{Name: "non-default"},
+	}))
+
+	aclToken := mock.CreatePolicyAndToken(t,
+		state, 1100, "test-valid-read",
+		mock.NamespacePolicy("*", "read", nil),
+	).SecretID
+
+	cases := []struct {
+		name         string
+		namespace    string
+		prefix       string
+		nextToken    string
+		pageSize     int32
+		filter       string
+		expIDs       []string
+		expNextToken string
+		expErr       string
+	}{
+		{
+			name:     "test01 size-2 page-1 ns-default",
+			pageSize: 2,
+			expIDs: []string{ // first two items
+				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
+				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
+			},
+			expNextToken: "1003.aaaaaaaa-3350-4b4b-d185-0e1992ed43e9", // next one in default ns
+		},
+		{
+			name:     "test02 size-2 page-1 ns-default with-prefix",
+			prefix:   "aaaa",
+			pageSize: 2,
+			expIDs: []string{
+				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
+				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
+			},
+			expNextToken: "aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+		},
+		{
+			name:         "test03 size-2 page-2 ns-default",
+			pageSize:     2,
+			nextToken:    "1003.aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+			expNextToken: "1005.aaaaaacc-3350-4b4b-d185-0e1992ed43e9",
+			expIDs: []string{
+				"aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+				"aaaaaabb-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:         "test04 size-2 page-2 ns-default with prefix",
+			prefix:       "aaaa",
+			pageSize:     2,
+			nextToken:    "aaaaaabb-3350-4b4b-d185-0e1992ed43e9",
+			expNextToken: "aaaaaadd-3350-4b4b-d185-0e1992ed43e9",
+			expIDs: []string{
+				"aaaaaabb-3350-4b4b-d185-0e1992ed43e9",
+				"aaaaaacc-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:      "test05 go-bexpr filter",
+			filter:    `TaskGroup == "goo"`,
+			nextToken: "",
+			expIDs: []string{
+				"aaaaaabb-3350-4b4b-d185-0e1992ed43e9",
+				"aaaaaaee-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:         "test06 go-bexpr filter with pagination",
+			filter:       `TaskGroup == "bar"`,
+			pageSize:     2,
+			expNextToken: "1008.aaaaaaff-3350-4b4b-d185-0e1992ed43e9",
+			expIDs: []string{
+				"aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+				"aaaaaadd-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:      "test07 go-bexpr filter namespace",
+			namespace: "non-default",
+			filter:    `ID contains "aaa"`,
+			expIDs: []string{
+				"aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:      "test08 go-bexpr wrong namespace",
+			namespace: "default",
+			filter:    `Namespace == "non-default"`,
+			expIDs:    []string(nil),
+		},
+		{
+			name:   "test09 go-bexpr invalid expression",
+			filter: `NotValid`,
+			expErr: "failed to read filter expression",
+		},
+		{
+			name:   "test10 go-bexpr invalid field",
+			filter: `InvalidField == "value"`,
+			expErr: "error finding value in datum",
+		},
+		{
+			name:         "test11 non-lexicographic order",
+			pageSize:     1,
+			nextToken:    "1009.00000111-3350-4b4b-d185-0e1992ed43e9",
+			expNextToken: "1010.00000222-3350-4b4b-d185-0e1992ed43e9",
+			expIDs: []string{
+				"00000111-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:         "test12 same index",
+			pageSize:     1,
+			nextToken:    "1010.00000222-3350-4b4b-d185-0e1992ed43e9",
+			expNextToken: "1010.00000333-3350-4b4b-d185-0e1992ed43e9",
+			expIDs: []string{
+				"00000222-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:      "test13 missing index",
+			pageSize:  1,
+			nextToken: "1011.e9522802-0cd8-4b1d-9c9e-ab3d97938371",
+			expIDs: []string{
+				"bbbb1111-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var req = &structs.AllocListRequest{
+				QueryOptions: structs.QueryOptions{
+					Region:    "global",
+					Namespace: tc.namespace,
+					Prefix:    tc.prefix,
+					PerPage:   tc.pageSize,
+					NextToken: tc.nextToken,
+					Filter:    tc.filter,
+					Ascending: true,
+				},
+				Fields: &structs.AllocStubFields{
+					Resources:  false,
+					TaskStates: false,
+				},
+			}
+			req.AuthToken = aclToken
+			var resp structs.AllocListResponse
+			err := msgpackrpc.CallWithCodec(codec, "Alloc.List", req, &resp)
+			if tc.expErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Contains(t, err, tc.expErr)
+			}
+
+			var gotIDs []string
+			for _, alloc := range resp.Allocations {
+				gotIDs = append(gotIDs, alloc.ID)
+			}
+			require.Equal(t, tc.expIDs, gotIDs)
+			require.Equal(t, tc.expNextToken, resp.QueryMeta.NextToken)
+		})
+	}
+}
+
+func TestAllocEndpoint_List_order(t *testing.T) {
+	t.Parallel()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create register requests
+	uuid1 := uuid.Generate()
+	alloc1 := mock.Alloc()
+	alloc1.ID = uuid1
+
+	uuid2 := uuid.Generate()
+	alloc2 := mock.Alloc()
+	alloc2.ID = uuid2
+
+	uuid3 := uuid.Generate()
+	alloc3 := mock.Alloc()
+	alloc3.ID = uuid3
+
+	err := s1.fsm.State().UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1})
+	require.NoError(t, err)
+
+	err = s1.fsm.State().UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc2})
+	require.NoError(t, err)
+
+	err = s1.fsm.State().UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc3})
+	require.NoError(t, err)
+
+	// update alloc2 again so we can later assert create index order did not change
+	err = s1.fsm.State().UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{alloc2})
+	require.NoError(t, err)
+
+	t.Run("ascending", func(t *testing.T) {
+		// Lookup the allocations in reverse chronological order (newest first)
+		get := &structs.AllocListRequest{
+			QueryOptions: structs.QueryOptions{
+				Region:    "global",
+				Namespace: "*",
+				Ascending: true,
+			},
+		}
+
+		var resp structs.AllocListResponse
+		err = msgpackrpc.CallWithCodec(codec, "Alloc.List", get, &resp)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1003), resp.Index)
+		require.Len(t, resp.Allocations, 3)
+
+		// Assert returned order is by CreateIndex (ascending)
+		require.Equal(t, uint64(1000), resp.Allocations[0].CreateIndex)
+		require.Equal(t, uuid1, resp.Allocations[0].ID)
+
+		require.Equal(t, uint64(1001), resp.Allocations[1].CreateIndex)
+		require.Equal(t, uuid2, resp.Allocations[1].ID)
+
+		require.Equal(t, uint64(1002), resp.Allocations[2].CreateIndex)
+		require.Equal(t, uuid3, resp.Allocations[2].ID)
+	})
+
+	t.Run("descending", func(t *testing.T) {
+		// Lookup the allocations in reverse chronological order
+		get := &structs.AllocListRequest{
+			QueryOptions: structs.QueryOptions{
+				Region:    "global",
+				Namespace: "*",
+				Ascending: false,
+			},
+		}
+
+		var resp structs.AllocListResponse
+		err = msgpackrpc.CallWithCodec(codec, "Alloc.List", get, &resp)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1003), resp.Index)
+		require.Len(t, resp.Allocations, 3)
+
+		// Assert returned order is by CreateIndex (descending)
+		require.Equal(t, uint64(1002), resp.Allocations[0].CreateIndex)
+		require.Equal(t, uuid3, resp.Allocations[0].ID)
+
+		require.Equal(t, uint64(1001), resp.Allocations[1].CreateIndex)
+		require.Equal(t, uuid2, resp.Allocations[1].ID)
+
+		require.Equal(t, uint64(1000), resp.Allocations[2].CreateIndex)
+		require.Equal(t, uuid1, resp.Allocations[2].ID)
+	})
 }
 
 func TestAllocEndpoint_List_Fields(t *testing.T) {
@@ -327,18 +653,23 @@ func TestAllocEndpoint_List_AllNamespaces_OSS(t *testing.T) {
 	require.NoError(t, state.UpsertNamespaces(900, []*structs.Namespace{ns1, ns2}))
 
 	// Create the allocations
+	uuid1 := uuid.Generate()
 	alloc1 := mock.Alloc()
-	alloc1.ID = "a" + alloc1.ID[1:]
+	alloc1.ID = uuid1
 	alloc1.Namespace = ns1.Name
+
+	uuid2 := uuid.Generate()
 	alloc2 := mock.Alloc()
-	alloc2.ID = "b" + alloc2.ID[1:]
+	alloc2.ID = uuid2
 	alloc2.Namespace = ns2.Name
+
 	summary1 := mock.JobSummary(alloc1.JobID)
 	summary2 := mock.JobSummary(alloc2.JobID)
 
-	require.NoError(t, state.UpsertJobSummary(999, summary1))
-	require.NoError(t, state.UpsertJobSummary(999, summary2))
-	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1, alloc2}))
+	require.NoError(t, state.UpsertJobSummary(1000, summary1))
+	require.NoError(t, state.UpsertJobSummary(1001, summary2))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc1}))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{alloc2}))
 
 	t.Run("looking up all allocations", func(t *testing.T) {
 		get := &structs.AllocListRequest{
@@ -349,7 +680,7 @@ func TestAllocEndpoint_List_AllNamespaces_OSS(t *testing.T) {
 		}
 		var resp structs.AllocListResponse
 		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Alloc.List", get, &resp))
-		require.Equal(t, uint64(1000), resp.Index)
+		require.Equal(t, uint64(1003), resp.Index)
 		require.Len(t, resp.Allocations, 2)
 		require.ElementsMatch(t,
 			[]string{resp.Allocations[0].ID, resp.Allocations[1].ID},
@@ -367,26 +698,23 @@ func TestAllocEndpoint_List_AllNamespaces_OSS(t *testing.T) {
 		}
 		var resp structs.AllocListResponse
 		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Alloc.List", get, &resp))
-		require.Equal(t, uint64(1000), resp.Index)
+		require.Equal(t, uint64(1003), resp.Index)
 		require.Len(t, resp.Allocations, 1)
 		require.Equal(t, alloc1.ID, resp.Allocations[0].ID)
 		require.Equal(t, alloc1.Namespace, resp.Allocations[0].Namespace)
 	})
 
 	t.Run("looking up allocations with mismatch prefix", func(t *testing.T) {
-		// allocations were constructed above to have prefix starting with "a" or "b"
-		badPrefix := "cc"
-
 		get := &structs.AllocListRequest{
 			QueryOptions: structs.QueryOptions{
 				Region:    "global",
 				Namespace: "*",
-				Prefix:    badPrefix,
+				Prefix:    "000000", // unlikely to match
 			},
 		}
 		var resp structs.AllocListResponse
 		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Alloc.List", get, &resp))
-		require.Equal(t, uint64(1000), resp.Index)
+		require.Equal(t, uint64(1003), resp.Index)
 		require.Empty(t, resp.Allocations)
 	})
 }

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -545,7 +545,7 @@ func (c *CoreScheduler) nodeReap(eval *structs.Evaluation, nodeIDs []string) err
 func (c *CoreScheduler) deploymentGC(eval *structs.Evaluation) error {
 	// Iterate over the deployments
 	ws := memdb.NewWatchSet()
-	iter, err := c.snap.Deployments(ws, false)
+	iter, err := c.snap.Deployments(ws, state.SortDefault)
 	if err != nil {
 		return err
 	}

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -3,6 +3,7 @@ package nomad
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	metrics "github.com/armon/go-metrics"
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/nomad/acl"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/state/paginator"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -136,40 +138,66 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 			} else {
 				iter, err = snap.CSIVolumes(ws)
 			}
-
 			if err != nil {
 				return err
 			}
 
+			tokenizer := paginator.NewStructsTokenizer(
+				iter,
+				paginator.StructsTokenizerOptions{
+					WithNamespace: true,
+					WithID:        true,
+				},
+			)
+			volFilter := paginator.GenericFilter{
+				Allow: func(raw interface{}) (bool, error) {
+					vol := raw.(*structs.CSIVolume)
+
+					// Remove (possibly again) by PluginID to handle passing both
+					// NodeID and PluginID
+					if args.PluginID != "" && args.PluginID != vol.PluginID {
+						return false, nil
+					}
+
+					// Remove by Namespace, since CSIVolumesByNodeID hasn't used
+					// the Namespace yet
+					if ns != structs.AllNamespacesSentinel && vol.Namespace != ns {
+						return false, nil
+					}
+
+					return true, nil
+				},
+			}
+			filters := []paginator.Filter{volFilter}
+
 			// Collect results, filter by ACL access
 			vs := []*structs.CSIVolListStub{}
 
-			for {
-				raw := iter.Next()
-				if raw == nil {
-					break
-				}
-				vol := raw.(*structs.CSIVolume)
+			args.QueryOptions.Ascending = true
+			paginator, err := paginator.NewPaginator(iter, tokenizer, filters, args.QueryOptions,
+				func(raw interface{}) error {
+					vol := raw.(*structs.CSIVolume)
 
-				// Remove (possibly again) by PluginID to handle passing both
-				// NodeID and PluginID
-				if args.PluginID != "" && args.PluginID != vol.PluginID {
-					continue
-				}
+					vol, err := snap.CSIVolumeDenormalizePlugins(ws, vol.Copy())
+					if err != nil {
+						return err
+					}
 
-				// Remove by Namespace, since CSIVolumesByNodeID hasn't used
-				// the Namespace yet
-				if ns != structs.AllNamespacesSentinel && vol.Namespace != ns {
-					continue
-				}
-
-				vol, err := snap.CSIVolumeDenormalizePlugins(ws, vol.Copy())
-				if err != nil {
-					return err
-				}
-
-				vs = append(vs, vol.Stub())
+					vs = append(vs, vol.Stub())
+					return nil
+				})
+			if err != nil {
+				return structs.NewErrRPCCodedf(
+					http.StatusBadRequest, "failed to create result paginator: %v", err)
 			}
+
+			nextToken, err := paginator.Page()
+			if err != nil {
+				return structs.NewErrRPCCodedf(
+					http.StatusBadRequest, "failed to read result page: %v", err)
+			}
+
+			reply.QueryMeta.NextToken = nextToken
 			reply.Volumes = vs
 			return v.srv.replySetIndex(csiVolumeTable, &reply.QueryMeta)
 		}}

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -173,7 +173,6 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 			// Collect results, filter by ACL access
 			vs := []*structs.CSIVolListStub{}
 
-			args.QueryOptions.Ascending = true
 			paginator, err := paginator.NewPaginator(iter, tokenizer, filters, args.QueryOptions,
 				func(raw interface{}) error {
 					vol := raw.(*structs.CSIVolume)

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -754,6 +754,200 @@ func TestCSIVolumeEndpoint_ListAllNamespaces(t *testing.T) {
 	require.Equal(t, structs.DefaultNamespace, resp2.Volumes[0].Namespace)
 }
 
+func TestCSIVolumeEndpoint_List_PaginationFiltering(t *testing.T) {
+	t.Parallel()
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	nonDefaultNS := "non-default"
+
+	// create a set of volumes. these are in the order that the state store
+	// will return them from the iterator (sorted by create index), for ease of
+	// writing tests
+	mocks := []struct {
+		id        string
+		namespace string
+	}{
+		{id: "vol-01"},                          // 0
+		{id: "vol-02"},                          // 1
+		{id: "vol-03", namespace: nonDefaultNS}, // 2
+		{id: "vol-04"},                          // 3
+		{id: "vol-05"},                          // 4
+		{id: "vol-06"},                          // 5
+		{id: "vol-07"},                          // 6
+		{id: "vol-08"},                          // 7
+		{},                                      // 9, missing volume
+		{id: "vol-10"},                          // 10
+	}
+
+	state := s1.fsm.State()
+	plugin := mock.CSIPlugin()
+
+	// Create namespaces.
+	err := state.UpsertNamespaces(999, []*structs.Namespace{{Name: nonDefaultNS}})
+	require.NoError(t, err)
+
+	for i, m := range mocks {
+		if m.id == "" {
+			continue
+		}
+
+		volume := mock.CSIVolume(plugin)
+		volume.ID = m.id
+		if m.namespace != "" { // defaults to "default"
+			volume.Namespace = m.namespace
+		}
+		index := 1000 + uint64(i)
+		require.NoError(t, state.CSIVolumeRegister(index, []*structs.CSIVolume{volume}))
+	}
+
+	cases := []struct {
+		name              string
+		namespace         string
+		prefix            string
+		filter            string
+		nextToken         string
+		pageSize          int32
+		expectedNextToken string
+		expectedIDs       []string
+		expectedError     string
+	}{
+		{
+			name:              "test01 size-2 page-1 default NS",
+			pageSize:          2,
+			expectedNextToken: "default.vol-04",
+			expectedIDs: []string{
+				"vol-01",
+				"vol-02",
+			},
+		},
+		{
+			name:              "test02 size-2 page-1 default NS with prefix",
+			prefix:            "vol",
+			pageSize:          2,
+			expectedNextToken: "default.vol-04",
+			expectedIDs: []string{
+				"vol-01",
+				"vol-02",
+			},
+		},
+		{
+			name:              "test03 size-2 page-2 default NS",
+			pageSize:          2,
+			nextToken:         "default.vol-04",
+			expectedNextToken: "default.vol-06",
+			expectedIDs: []string{
+				"vol-04",
+				"vol-05",
+			},
+		},
+		{
+			name:              "test04 size-2 page-2 default NS with prefix",
+			prefix:            "vol",
+			pageSize:          2,
+			nextToken:         "default.vol-04",
+			expectedNextToken: "default.vol-06",
+			expectedIDs: []string{
+				"vol-04",
+				"vol-05",
+			},
+		},
+		{
+			name:        "test05 no valid results with filters and prefix",
+			prefix:      "cccc",
+			pageSize:    2,
+			nextToken:   "",
+			expectedIDs: []string{},
+		},
+		{
+			name:      "test06 go-bexpr filter",
+			namespace: "*",
+			filter:    `ID matches "^vol-0[123]"`,
+			expectedIDs: []string{
+				"vol-01",
+				"vol-02",
+				"vol-03",
+			},
+		},
+		{
+			name:              "test07 go-bexpr filter with pagination",
+			namespace:         "*",
+			filter:            `ID matches "^vol-0[123]"`,
+			pageSize:          2,
+			expectedNextToken: "non-default.vol-03",
+			expectedIDs: []string{
+				"vol-01",
+				"vol-02",
+			},
+		},
+		{
+			name:      "test08 go-bexpr filter in namespace",
+			namespace: "non-default",
+			filter:    `Provider == "com.hashicorp:mock"`,
+			expectedIDs: []string{
+				"vol-03",
+			},
+		},
+		{
+			name:        "test09 go-bexpr wrong namespace",
+			namespace:   "default",
+			filter:      `Namespace == "non-default"`,
+			expectedIDs: []string{},
+		},
+		{
+			name:          "test10 go-bexpr invalid expression",
+			filter:        `NotValid`,
+			expectedError: "failed to read filter expression",
+		},
+		{
+			name:          "test11 go-bexpr invalid field",
+			filter:        `InvalidField == "value"`,
+			expectedError: "error finding value in datum",
+		},
+		{
+			name:      "test14 missing volume",
+			pageSize:  1,
+			nextToken: "default.vol-09",
+			expectedIDs: []string{
+				"vol-10",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &structs.CSIVolumeListRequest{
+				QueryOptions: structs.QueryOptions{
+					Region:    "global",
+					Namespace: tc.namespace,
+					Prefix:    tc.prefix,
+					Filter:    tc.filter,
+					PerPage:   tc.pageSize,
+					NextToken: tc.nextToken,
+				},
+			}
+			var resp structs.CSIVolumeListResponse
+			err := msgpackrpc.CallWithCodec(codec, "CSIVolume.List", req, &resp)
+			if tc.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedError)
+				return
+			}
+
+			gotIDs := []string{}
+			for _, deployment := range resp.Volumes {
+				gotIDs = append(gotIDs, deployment.ID)
+			}
+			require.Equal(t, tc.expectedIDs, gotIDs, "unexpected page of volumes")
+			require.Equal(t, tc.expectedNextToken, resp.QueryMeta.NextToken, "unexpected NextToken")
+		})
+	}
+}
+
 func TestCSIVolumeEndpoint_Create(t *testing.T) {
 	t.Parallel()
 	var err error

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -403,6 +403,7 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 	}
 
 	// Setup the blocking query
+	sort := state.SortOption(args.Reverse)
 	opts := blockingOptions{
 		queryOpts: &args.QueryOptions,
 		queryMeta: &reply.QueryMeta,
@@ -418,13 +419,13 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 					WithID: true,
 				}
 			} else if namespace != structs.AllNamespacesSentinel {
-				iter, err = store.DeploymentsByNamespaceOrdered(ws, namespace, args.Reverse)
+				iter, err = store.DeploymentsByNamespaceOrdered(ws, namespace, sort)
 				opts = paginator.StructsTokenizerOptions{
 					WithCreateIndex: true,
 					WithID:          true,
 				}
 			} else {
-				iter, err = store.Deployments(ws, args.Reverse)
+				iter, err = store.Deployments(ws, sort)
 				opts = paginator.StructsTokenizerOptions{
 					WithCreateIndex: true,
 					WithID:          true,

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -418,13 +418,13 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 					WithID: true,
 				}
 			} else if namespace != structs.AllNamespacesSentinel {
-				iter, err = store.DeploymentsByNamespaceOrdered(ws, namespace, args.Ascending)
+				iter, err = store.DeploymentsByNamespaceOrdered(ws, namespace, args.Reverse)
 				opts = paginator.StructsTokenizerOptions{
 					WithCreateIndex: true,
 					WithID:          true,
 				}
 			} else {
-				iter, err = store.Deployments(ws, args.Ascending)
+				iter, err = store.Deployments(ws, args.Reverse)
 				opts = paginator.StructsTokenizerOptions{
 					WithCreateIndex: true,
 					WithID:          true,

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -10,32 +10,9 @@ import (
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/state/paginator"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
-
-// DeploymentPaginationIterator is a wrapper over a go-memdb iterator that
-// implements the paginator Iterator interface.
-type DeploymentPaginationIterator struct {
-	iter          memdb.ResultIterator
-	byCreateIndex bool
-}
-
-func (it DeploymentPaginationIterator) Next() (string, interface{}) {
-	raw := it.iter.Next()
-	if raw == nil {
-		return "", nil
-	}
-
-	d := raw.(*structs.Deployment)
-	token := d.ID
-
-	// prefix the pagination token by CreateIndex to keep it properly sorted.
-	if it.byCreateIndex {
-		token = fmt.Sprintf("%v-%v", d.CreateIndex, d.ID)
-	}
-
-	return token, d
-}
 
 // Deployment endpoint is used for manipulating deployments
 type Deployment struct {
@@ -433,26 +410,34 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 			// Capture all the deployments
 			var err error
 			var iter memdb.ResultIterator
-			var deploymentIter DeploymentPaginationIterator
+			var opts paginator.StructsTokenizerOptions
 
 			if prefix := args.QueryOptions.Prefix; prefix != "" {
 				iter, err = store.DeploymentsByIDPrefix(ws, namespace, prefix)
-				deploymentIter.byCreateIndex = false
+				opts = paginator.StructsTokenizerOptions{
+					WithID: true,
+				}
 			} else if namespace != structs.AllNamespacesSentinel {
 				iter, err = store.DeploymentsByNamespaceOrdered(ws, namespace, args.Ascending)
-				deploymentIter.byCreateIndex = true
+				opts = paginator.StructsTokenizerOptions{
+					WithCreateIndex: true,
+					WithID:          true,
+				}
 			} else {
 				iter, err = store.Deployments(ws, args.Ascending)
-				deploymentIter.byCreateIndex = true
+				opts = paginator.StructsTokenizerOptions{
+					WithCreateIndex: true,
+					WithID:          true,
+				}
 			}
 			if err != nil {
 				return err
 			}
 
-			deploymentIter.iter = iter
+			tokenizer := paginator.NewStructsTokenizer(iter, opts)
 
 			var deploys []*structs.Deployment
-			paginator, err := state.NewPaginator(deploymentIter, args.QueryOptions,
+			paginator, err := paginator.NewPaginator(iter, tokenizer, nil, args.QueryOptions,
 				func(raw interface{}) error {
 					deploy := raw.(*structs.Deployment)
 					deploys = append(deploys, deploy)

--- a/nomad/deployment_endpoint_test.go
+++ b/nomad/deployment_endpoint_test.go
@@ -1312,7 +1312,7 @@ func TestDeploymentEndpoint_List_Pagination(t *testing.T) {
 		{
 			name:              "test01 size-2 page-1 default NS",
 			pageSize:          2,
-			expectedNextToken: "1003-aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1003.aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{
 				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
 				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
@@ -1331,8 +1331,8 @@ func TestDeploymentEndpoint_List_Pagination(t *testing.T) {
 		{
 			name:              "test03 size-2 page-2 default NS",
 			pageSize:          2,
-			nextToken:         "1003-aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
-			expectedNextToken: "1005-aaaaaacc-3350-4b4b-d185-0e1992ed43e9",
+			nextToken:         "1003.aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1005.aaaaaacc-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{
 				"aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
 				"aaaaaabb-3350-4b4b-d185-0e1992ed43e9",
@@ -1353,8 +1353,8 @@ func TestDeploymentEndpoint_List_Pagination(t *testing.T) {
 			name:              "test05 size-2 page-2 all namespaces",
 			namespace:         "*",
 			pageSize:          2,
-			nextToken:         "1002-aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
-			expectedNextToken: "1004-aaaaaabb-3350-4b4b-d185-0e1992ed43e9",
+			nextToken:         "1002.aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1004.aaaaaabb-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{
 				"aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
 				"aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
@@ -1382,7 +1382,7 @@ func TestDeploymentEndpoint_List_Pagination(t *testing.T) {
 			namespace:         "*",
 			filter:            `ID matches "^a+[123]"`,
 			pageSize:          2,
-			expectedNextToken: "1002-aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1002.aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{
 				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
 				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
@@ -1415,8 +1415,8 @@ func TestDeploymentEndpoint_List_Pagination(t *testing.T) {
 		{
 			name:              "test13 non-lexicographic order",
 			pageSize:          1,
-			nextToken:         "1007-00000111-3350-4b4b-d185-0e1992ed43e9",
-			expectedNextToken: "1009-bbbb1111-3350-4b4b-d185-0e1992ed43e9",
+			nextToken:         "1007.00000111-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1009.bbbb1111-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{
 				"00000111-3350-4b4b-d185-0e1992ed43e9",
 			},
@@ -1424,7 +1424,7 @@ func TestDeploymentEndpoint_List_Pagination(t *testing.T) {
 		{
 			name:      "test14 missing index",
 			pageSize:  1,
-			nextToken: "1008-e9522802-0cd8-4b1d-9c9e-ab3d97938371",
+			nextToken: "1008.e9522802-0cd8-4b1d-9c9e-ab3d97938371",
 			expectedIDs: []string{
 				"bbbb1111-3350-4b4b-d185-0e1992ed43e9",
 			},

--- a/nomad/deployment_endpoint_test.go
+++ b/nomad/deployment_endpoint_test.go
@@ -1066,13 +1066,12 @@ func TestDeploymentEndpoint_List_order(t *testing.T) {
 	err = s1.fsm.State().UpsertDeployment(1003, dep2)
 	require.NoError(t, err)
 
-	t.Run("ascending", func(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
 		// Lookup the deployments in chronological order (oldest first)
 		get := &structs.DeploymentListRequest{
 			QueryOptions: structs.QueryOptions{
 				Region:    "global",
 				Namespace: "*",
-				Ascending: true,
 			},
 		}
 
@@ -1093,13 +1092,13 @@ func TestDeploymentEndpoint_List_order(t *testing.T) {
 		require.Equal(t, uuid3, resp.Deployments[2].ID)
 	})
 
-	t.Run("descending", func(t *testing.T) {
+	t.Run("reverse", func(t *testing.T) {
 		// Lookup the deployments in reverse chronological order (newest first)
 		get := &structs.DeploymentListRequest{
 			QueryOptions: structs.QueryOptions{
 				Region:    "global",
 				Namespace: "*",
-				Ascending: false,
+				Reverse:   true,
 			},
 		}
 
@@ -1441,7 +1440,6 @@ func TestDeploymentEndpoint_List_Pagination(t *testing.T) {
 					Filter:    tc.filter,
 					PerPage:   tc.pageSize,
 					NextToken: tc.nextToken,
-					Ascending: true, // counting up is easier to think about
 				},
 			}
 			req.AuthToken = aclToken

--- a/nomad/deploymentwatcher/deployments_watcher.go
+++ b/nomad/deploymentwatcher/deployments_watcher.go
@@ -202,9 +202,9 @@ func (w *Watcher) getDeploys(ctx context.Context, minIndex uint64) ([]*structs.D
 }
 
 // getDeploysImpl retrieves all deployments from the passed state store.
-func (w *Watcher) getDeploysImpl(ws memdb.WatchSet, state *state.StateStore) (interface{}, uint64, error) {
+func (w *Watcher) getDeploysImpl(ws memdb.WatchSet, store *state.StateStore) (interface{}, uint64, error) {
 
-	iter, err := state.Deployments(ws, false)
+	iter, err := store.Deployments(ws, state.SortDefault)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -220,7 +220,7 @@ func (w *Watcher) getDeploysImpl(ws memdb.WatchSet, state *state.StateStore) (in
 	}
 
 	// Use the last index that affected the deployment table
-	index, err := state.Index("deployment")
+	index, err := store.Index("deployment")
 	if err != nil {
 		return nil, 0, err
 	}

--- a/nomad/drainer_int_test.go
+++ b/nomad/drainer_int_test.go
@@ -933,7 +933,7 @@ func TestDrainer_MultipleNSes_ServiceOnly(t *testing.T) {
 	// Wait for the two allocations to be placed
 	state := s1.State()
 	testutil.WaitForResult(func() (bool, error) {
-		iter, err := state.Allocs(nil)
+		iter, err := state.Allocs(nil, false)
 		if err != nil {
 			return false, err
 		}

--- a/nomad/drainer_int_test.go
+++ b/nomad/drainer_int_test.go
@@ -931,9 +931,9 @@ func TestDrainer_MultipleNSes_ServiceOnly(t *testing.T) {
 	}
 
 	// Wait for the two allocations to be placed
-	state := s1.State()
+	store := s1.State()
 	testutil.WaitForResult(func() (bool, error) {
-		iter, err := state.Allocs(nil, false)
+		iter, err := store.Allocs(nil, state.SortDefault)
 		if err != nil {
 			return false, err
 		}
@@ -974,11 +974,11 @@ func TestDrainer_MultipleNSes_ServiceOnly(t *testing.T) {
 	errCh := make(chan error, 2)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go allocPromoter(errCh, ctx, state, codec, n1.ID, s1.logger)
-	go allocPromoter(errCh, ctx, state, codec, n2.ID, s1.logger)
+	go allocPromoter(errCh, ctx, store, codec, n1.ID, s1.logger)
+	go allocPromoter(errCh, ctx, store, codec, n2.ID, s1.logger)
 
 	testutil.WaitForResult(func() (bool, error) {
-		allocs, err := state.AllocsByNode(nil, n2.ID)
+		allocs, err := store.AllocsByNode(nil, n2.ID)
 		if err != nil {
 			return false, err
 		}
@@ -992,7 +992,7 @@ func TestDrainer_MultipleNSes_ServiceOnly(t *testing.T) {
 		if err := checkAllocPromoter(errCh); err != nil {
 			return false, err
 		}
-		node, err := state.NodeByID(nil, n1.ID)
+		node, err := store.NodeByID(nil, n1.ID)
 		if err != nil {
 			return false, err
 		}
@@ -1002,7 +1002,7 @@ func TestDrainer_MultipleNSes_ServiceOnly(t *testing.T) {
 	})
 
 	// Check we got the right events
-	node, err := state.NodeByID(nil, n1.ID)
+	node, err := store.NodeByID(nil, n1.ID)
 	require.NoError(err)
 	// sometimes test gets a duplicate node drain complete event
 	require.GreaterOrEqualf(len(node.Events), 3, "unexpected number of events: %v", node.Events)

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -423,13 +423,13 @@ func (e *Eval) List(args *structs.EvalListRequest, reply *structs.EvalListRespon
 					WithID: true,
 				}
 			} else if namespace != structs.AllNamespacesSentinel {
-				iter, err = store.EvalsByNamespaceOrdered(ws, namespace, args.Ascending)
+				iter, err = store.EvalsByNamespaceOrdered(ws, namespace, args.Reverse)
 				opts = paginator.StructsTokenizerOptions{
 					WithCreateIndex: true,
 					WithID:          true,
 				}
 			} else {
-				iter, err = store.Evals(ws, args.Ascending)
+				iter, err = store.Evals(ws, args.Reverse)
 				opts = paginator.StructsTokenizerOptions{
 					WithCreateIndex: true,
 					WithID:          true,

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/state/paginator"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler"
 )
@@ -20,30 +21,6 @@ const (
 	// DefaultDequeueTimeout is used if no dequeue timeout is provided
 	DefaultDequeueTimeout = time.Second
 )
-
-// EvalPaginationIterator is a wrapper over a go-memdb iterator that implements
-// the paginator Iterator interface.
-type EvalPaginationIterator struct {
-	iter          memdb.ResultIterator
-	byCreateIndex bool
-}
-
-func (it EvalPaginationIterator) Next() (string, interface{}) {
-	raw := it.iter.Next()
-	if raw == nil {
-		return "", nil
-	}
-
-	eval := raw.(*structs.Evaluation)
-	token := eval.ID
-
-	// prefix the pagination token by CreateIndex to keep it properly sorted.
-	if it.byCreateIndex {
-		token = fmt.Sprintf("%v-%v", eval.CreateIndex, eval.ID)
-	}
-
-	return token, eval
-}
 
 // Eval endpoint is used for eval interactions
 type Eval struct {
@@ -438,17 +415,25 @@ func (e *Eval) List(args *structs.EvalListRequest, reply *structs.EvalListRespon
 			// Scan all the evaluations
 			var err error
 			var iter memdb.ResultIterator
-			var evalIter EvalPaginationIterator
+			var opts paginator.StructsTokenizerOptions
 
 			if prefix := args.QueryOptions.Prefix; prefix != "" {
 				iter, err = store.EvalsByIDPrefix(ws, namespace, prefix)
-				evalIter.byCreateIndex = false
+				opts = paginator.StructsTokenizerOptions{
+					WithID: true,
+				}
 			} else if namespace != structs.AllNamespacesSentinel {
 				iter, err = store.EvalsByNamespaceOrdered(ws, namespace, args.Ascending)
-				evalIter.byCreateIndex = true
+				opts = paginator.StructsTokenizerOptions{
+					WithCreateIndex: true,
+					WithID:          true,
+				}
 			} else {
 				iter, err = store.Evals(ws, args.Ascending)
-				evalIter.byCreateIndex = true
+				opts = paginator.StructsTokenizerOptions{
+					WithCreateIndex: true,
+					WithID:          true,
+				}
 			}
 			if err != nil {
 				return err
@@ -460,10 +445,11 @@ func (e *Eval) List(args *structs.EvalListRequest, reply *structs.EvalListRespon
 				}
 				return false
 			})
-			evalIter.iter = iter
+
+			tokenizer := paginator.NewStructsTokenizer(iter, opts)
 
 			var evals []*structs.Evaluation
-			paginator, err := state.NewPaginator(evalIter, args.QueryOptions,
+			paginator, err := paginator.NewPaginator(iter, tokenizer, nil, args.QueryOptions,
 				func(raw interface{}) error {
 					eval := raw.(*structs.Evaluation)
 					evals = append(evals, eval)

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -408,6 +408,7 @@ func (e *Eval) List(args *structs.EvalListRequest, reply *structs.EvalListRespon
 	}
 
 	// Setup the blocking query
+	sort := state.SortOption(args.Reverse)
 	opts := blockingOptions{
 		queryOpts: &args.QueryOptions,
 		queryMeta: &reply.QueryMeta,
@@ -423,13 +424,13 @@ func (e *Eval) List(args *structs.EvalListRequest, reply *structs.EvalListRespon
 					WithID: true,
 				}
 			} else if namespace != structs.AllNamespacesSentinel {
-				iter, err = store.EvalsByNamespaceOrdered(ws, namespace, args.Reverse)
+				iter, err = store.EvalsByNamespaceOrdered(ws, namespace, sort)
 				opts = paginator.StructsTokenizerOptions{
 					WithCreateIndex: true,
 					WithID:          true,
 				}
 			} else {
-				iter, err = store.Evals(ws, args.Reverse)
+				iter, err = store.Evals(ws, sort)
 				opts = paginator.StructsTokenizerOptions{
 					WithCreateIndex: true,
 					WithID:          true,

--- a/nomad/eval_endpoint_test.go
+++ b/nomad/eval_endpoint_test.go
@@ -1084,7 +1084,7 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
 				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
 			},
-			expectedNextToken: "1003-aaaaaaaa-3350-4b4b-d185-0e1992ed43e9", // next one in default namespace
+			expectedNextToken: "1003.aaaaaaaa-3350-4b4b-d185-0e1992ed43e9", // next one in default namespace
 		},
 		{
 			name:              "test02 size-2 page-1 default NS with prefix",
@@ -1099,8 +1099,8 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 		{
 			name:              "test03 size-2 page-2 default NS",
 			pageSize:          2,
-			nextToken:         "1003-aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
-			expectedNextToken: "1005-aaaaaacc-3350-4b4b-d185-0e1992ed43e9",
+			nextToken:         "1003.aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1005.aaaaaacc-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{
 				"aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
 				"aaaaaabb-3350-4b4b-d185-0e1992ed43e9",
@@ -1123,7 +1123,7 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 			filterJobID:  "example",
 			filterStatus: "pending",
 			// aaaaaaaa, bb, and cc are filtered by status
-			expectedNextToken: "1006-aaaaaadd-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1006.aaaaaadd-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{
 				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
 				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
@@ -1159,7 +1159,7 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 			pageSize:          3,                                            // reads off the end
 			filterJobID:       "example",
 			filterStatus:      "pending",
-			nextToken:         "1003-aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+			nextToken:         "1003.aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
 			expectedNextToken: "",
 			expectedIDs: []string{
 				"aaaaaadd-3350-4b4b-d185-0e1992ed43e9",
@@ -1183,8 +1183,8 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 			name:              "test10 size-2 page-2 all namespaces",
 			namespace:         "*",
 			pageSize:          2,
-			nextToken:         "1002-aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
-			expectedNextToken: "1004-aaaaaabb-3350-4b4b-d185-0e1992ed43e9",
+			nextToken:         "1002.aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1004.aaaaaabb-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{
 				"aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
 				"aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
@@ -1228,7 +1228,7 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 			name:              "test16 go-bexpr filter with pagination",
 			filter:            `JobID == "example"`,
 			pageSize:          2,
-			expectedNextToken: "1003-aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1003.aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{
 				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
 				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
@@ -1267,8 +1267,8 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 		{
 			name:              "test22 non-lexicographic order",
 			pageSize:          1,
-			nextToken:         "1009-00000111-3350-4b4b-d185-0e1992ed43e9",
-			expectedNextToken: "1010-00000222-3350-4b4b-d185-0e1992ed43e9",
+			nextToken:         "1009.00000111-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1010.00000222-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{
 				"00000111-3350-4b4b-d185-0e1992ed43e9",
 			},
@@ -1276,8 +1276,8 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 		{
 			name:              "test23 same index",
 			pageSize:          1,
-			nextToken:         "1010-00000222-3350-4b4b-d185-0e1992ed43e9",
-			expectedNextToken: "1010-00000333-3350-4b4b-d185-0e1992ed43e9",
+			nextToken:         "1010.00000222-3350-4b4b-d185-0e1992ed43e9",
+			expectedNextToken: "1010.00000333-3350-4b4b-d185-0e1992ed43e9",
 			expectedIDs: []string{
 				"00000222-3350-4b4b-d185-0e1992ed43e9",
 			},
@@ -1285,7 +1285,7 @@ func TestEvalEndpoint_List_PaginationFiltering(t *testing.T) {
 		{
 			name:      "test24 missing index",
 			pageSize:  1,
-			nextToken: "1011-e9522802-0cd8-4b1d-9c9e-ab3d97938371",
+			nextToken: "1011.e9522802-0cd8-4b1d-9c9e-ab3d97938371",
 			expectedIDs: []string{
 				"bbbb1111-3350-4b4b-d185-0e1992ed43e9",
 			},

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -2306,7 +2306,7 @@ func (s *nomadSnapshot) persistACLTokens(sink raft.SnapshotSink,
 	encoder *codec.Encoder) error {
 	// Get all the policies
 	ws := memdb.NewWatchSet()
-	tokens, err := s.snap.ACLTokens(ws)
+	tokens, err := s.snap.ACLTokens(ws, false)
 	if err != nil {
 		return err
 	}

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -2099,7 +2099,7 @@ func (s *nomadSnapshot) persistAllocs(sink raft.SnapshotSink,
 	encoder *codec.Encoder) error {
 	// Get all the allocations
 	ws := memdb.NewWatchSet()
-	allocs, err := s.snap.Allocs(ws)
+	allocs, err := s.snap.Allocs(ws, false)
 	if err != nil {
 		return err
 	}

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1704,16 +1704,16 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 
 // failLeakedDeployments is used to fail deployments that do not have a job.
 // This state is a broken invariant that should not occur since 0.8.X.
-func (n *nomadFSM) failLeakedDeployments(state *state.StateStore) error {
+func (n *nomadFSM) failLeakedDeployments(store *state.StateStore) error {
 	// Scan for deployments that are referencing a job that no longer exists.
 	// This could happen if multiple deployments were created for a given job
 	// and thus the older deployment leaks and then the job is removed.
-	iter, err := state.Deployments(nil, false)
+	iter, err := store.Deployments(nil, state.SortDefault)
 	if err != nil {
 		return fmt.Errorf("failed to query deployments: %v", err)
 	}
 
-	dindex, err := state.Index("deployment")
+	dindex, err := store.Index("deployment")
 	if err != nil {
 		return fmt.Errorf("couldn't fetch index of deployments table: %v", err)
 	}
@@ -1733,7 +1733,7 @@ func (n *nomadFSM) failLeakedDeployments(state *state.StateStore) error {
 		}
 
 		// Find the job
-		job, err := state.JobByID(nil, d.Namespace, d.JobID)
+		job, err := store.JobByID(nil, d.Namespace, d.JobID)
 		if err != nil {
 			return fmt.Errorf("failed to lookup job %s from deployment %q: %v", d.JobID, d.ID, err)
 		}
@@ -1747,7 +1747,7 @@ func (n *nomadFSM) failLeakedDeployments(state *state.StateStore) error {
 		failed := d.Copy()
 		failed.Status = structs.DeploymentStatusCancelled
 		failed.StatusDescription = structs.DeploymentStatusDescriptionStoppedJob
-		if err := state.UpsertDeployment(dindex, failed); err != nil {
+		if err := store.UpsertDeployment(dindex, failed); err != nil {
 			return fmt.Errorf("failed to mark leaked deployment %q as failed: %v", failed.ID, err)
 		}
 	}
@@ -2099,7 +2099,7 @@ func (s *nomadSnapshot) persistAllocs(sink raft.SnapshotSink,
 	encoder *codec.Encoder) error {
 	// Get all the allocations
 	ws := memdb.NewWatchSet()
-	allocs, err := s.snap.Allocs(ws, false)
+	allocs, err := s.snap.Allocs(ws, state.SortDefault)
 	if err != nil {
 		return err
 	}
@@ -2250,7 +2250,7 @@ func (s *nomadSnapshot) persistDeployments(sink raft.SnapshotSink,
 	encoder *codec.Encoder) error {
 	// Get all the jobs
 	ws := memdb.NewWatchSet()
-	deployments, err := s.snap.Deployments(ws, false)
+	deployments, err := s.snap.Deployments(ws, state.SortDefault)
 	if err != nil {
 		return err
 	}
@@ -2306,7 +2306,7 @@ func (s *nomadSnapshot) persistACLTokens(sink raft.SnapshotSink,
 	encoder *codec.Encoder) error {
 	// Get all the policies
 	ws := memdb.NewWatchSet()
-	tokens, err := s.snap.ACLTokens(ws, false)
+	tokens, err := s.snap.ACLTokens(ws, state.SortDefault)
 	if err != nil {
 		return err
 	}

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1409,7 +1409,6 @@ func (j *Job) List(args *structs.JobListRequest, reply *structs.JobListResponse)
 				}
 
 				var jobs []*structs.JobListStub
-				args.QueryOptions.Ascending = true
 				paginator, err := paginator.NewPaginator(iter, tokenizer, filters, args.QueryOptions,
 					func(raw interface{}) error {
 						job := raw.(*structs.Job)

--- a/nomad/search_endpoint.go
+++ b/nomad/search_endpoint.go
@@ -405,7 +405,7 @@ func getFuzzyResourceIterator(context structs.Context, aclObj *acl.ACL, namespac
 
 	case structs.Allocs:
 		if wildcard(namespace) {
-			iter, err := state.Allocs(ws)
+			iter, err := state.Allocs(ws, false)
 			return nsCapIterFilter(iter, err, aclObj)
 		}
 		return state.AllocsByNamespace(ws, namespace)

--- a/nomad/search_endpoint.go
+++ b/nomad/search_endpoint.go
@@ -394,42 +394,42 @@ func wildcard(namespace string) bool {
 	return namespace == structs.AllNamespacesSentinel
 }
 
-func getFuzzyResourceIterator(context structs.Context, aclObj *acl.ACL, namespace string, ws memdb.WatchSet, state *state.StateStore) (memdb.ResultIterator, error) {
+func getFuzzyResourceIterator(context structs.Context, aclObj *acl.ACL, namespace string, ws memdb.WatchSet, store *state.StateStore) (memdb.ResultIterator, error) {
 	switch context {
 	case structs.Jobs:
 		if wildcard(namespace) {
-			iter, err := state.Jobs(ws)
+			iter, err := store.Jobs(ws)
 			return nsCapIterFilter(iter, err, aclObj)
 		}
-		return state.JobsByNamespace(ws, namespace)
+		return store.JobsByNamespace(ws, namespace)
 
 	case structs.Allocs:
 		if wildcard(namespace) {
-			iter, err := state.Allocs(ws, false)
+			iter, err := store.Allocs(ws, state.SortDefault)
 			return nsCapIterFilter(iter, err, aclObj)
 		}
-		return state.AllocsByNamespace(ws, namespace)
+		return store.AllocsByNamespace(ws, namespace)
 
 	case structs.Nodes:
 		if wildcard(namespace) {
-			iter, err := state.Nodes(ws)
+			iter, err := store.Nodes(ws)
 			return nsCapIterFilter(iter, err, aclObj)
 		}
-		return state.Nodes(ws)
+		return store.Nodes(ws)
 
 	case structs.Plugins:
 		if wildcard(namespace) {
-			iter, err := state.CSIPlugins(ws)
+			iter, err := store.CSIPlugins(ws)
 			return nsCapIterFilter(iter, err, aclObj)
 		}
-		return state.CSIPlugins(ws)
+		return store.CSIPlugins(ws)
 
 	case structs.Namespaces:
-		iter, err := state.Namespaces(ws)
+		iter, err := store.Namespaces(ws)
 		return nsCapIterFilter(iter, err, aclObj)
 
 	default:
-		return getEnterpriseFuzzyResourceIter(context, aclObj, namespace, ws, state)
+		return getEnterpriseFuzzyResourceIter(context, aclObj, namespace, ws, store)
 	}
 }
 

--- a/nomad/state/paginator/filter.go
+++ b/nomad/state/paginator/filter.go
@@ -1,0 +1,41 @@
+package paginator
+
+// Filter is the interface that must be implemented to skip values when using
+// the Paginator.
+type Filter interface {
+	// Evaluate returns true if the element should be added to the page.
+	Evaluate(interface{}) (bool, error)
+}
+
+// GenericFilter wraps a function that can be used to provide simple or in
+// scope filtering.
+type GenericFilter struct {
+	Allow func(interface{}) (bool, error)
+}
+
+func (f GenericFilter) Evaluate(raw interface{}) (bool, error) {
+	return f.Allow(raw)
+}
+
+// NamespaceFilter skips elements with a namespace value that is not in the
+// allowable set.
+type NamespaceFilter struct {
+	AllowableNamespaces map[string]bool
+}
+
+func (f NamespaceFilter) Evaluate(raw interface{}) (bool, error) {
+	if raw == nil {
+		return false, nil
+	}
+
+	item, _ := raw.(NamespaceGetter)
+	namespace := item.GetNamespace()
+
+	if f.AllowableNamespaces == nil {
+		return true, nil
+	}
+	if f.AllowableNamespaces[namespace] {
+		return true, nil
+	}
+	return false, nil
+}

--- a/nomad/state/paginator/filter_test.go
+++ b/nomad/state/paginator/filter_test.go
@@ -24,8 +24,7 @@ func TestGenericFilter(t *testing.T) {
 	iter := newTestIterator(ids)
 	tokenizer := testTokenizer{}
 	opts := structs.QueryOptions{
-		PerPage:   3,
-		Ascending: true,
+		PerPage: 3,
 	}
 	results := []string{}
 	paginator, err := NewPaginator(iter, tokenizer, filters, opts,
@@ -84,8 +83,7 @@ func TestNamespaceFilter(t *testing.T) {
 			iter := newTestIteratorWithMocks(mocks)
 			tokenizer := testTokenizer{}
 			opts := structs.QueryOptions{
-				PerPage:   int32(len(mocks)),
-				Ascending: true,
+				PerPage: int32(len(mocks)),
 			}
 
 			results := []string{}

--- a/nomad/state/paginator/filter_test.go
+++ b/nomad/state/paginator/filter_test.go
@@ -1,14 +1,110 @@
-package state
+package paginator
 
 import (
 	"testing"
 	"time"
 
 	"github.com/hashicorp/go-bexpr"
-	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
 )
+
+func TestGenericFilter(t *testing.T) {
+	t.Parallel()
+	ids := []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"}
+
+	filters := []Filter{GenericFilter{
+		Allow: func(raw interface{}) (bool, error) {
+			result := raw.(*mockObject)
+			return result.id > "5", nil
+		},
+	}}
+	iter := newTestIterator(ids)
+	tokenizer := testTokenizer{}
+	opts := structs.QueryOptions{
+		PerPage:   3,
+		Ascending: true,
+	}
+	results := []string{}
+	paginator, err := NewPaginator(iter, tokenizer, filters, opts,
+		func(raw interface{}) error {
+			result := raw.(*mockObject)
+			results = append(results, result.id)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	nextToken, err := paginator.Page()
+	require.NoError(t, err)
+
+	expected := []string{"6", "7", "8"}
+	require.Equal(t, "9", nextToken)
+	require.Equal(t, expected, results)
+}
+
+func TestNamespaceFilter(t *testing.T) {
+	t.Parallel()
+
+	mocks := []*mockObject{
+		{namespace: "default"},
+		{namespace: "dev"},
+		{namespace: "qa"},
+		{namespace: "region-1"},
+	}
+
+	cases := []struct {
+		name      string
+		allowable map[string]bool
+		expected  []string
+	}{
+		{
+			name:     "nil map",
+			expected: []string{"default", "dev", "qa", "region-1"},
+		},
+		{
+			name:      "allow default",
+			allowable: map[string]bool{"default": true},
+			expected:  []string{"default"},
+		},
+		{
+			name:      "allow multiple",
+			allowable: map[string]bool{"default": true, "dev": false, "qa": true},
+			expected:  []string{"default", "qa"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			filters := []Filter{NamespaceFilter{
+				AllowableNamespaces: tc.allowable,
+			}}
+			iter := newTestIteratorWithMocks(mocks)
+			tokenizer := testTokenizer{}
+			opts := structs.QueryOptions{
+				PerPage:   int32(len(mocks)),
+				Ascending: true,
+			}
+
+			results := []string{}
+			paginator, err := NewPaginator(iter, tokenizer, filters, opts,
+				func(raw interface{}) error {
+					result := raw.(*mockObject)
+					results = append(results, result.namespace)
+					return nil
+				},
+			)
+			require.NoError(t, err)
+
+			nextToken, err := paginator.Page()
+			require.NoError(t, err)
+			require.Equal(t, "", nextToken)
+			require.Equal(t, tc.expected, results)
+		})
+	}
+}
 
 func BenchmarkEvalListFilter(b *testing.B) {
 	const evalCount = 100_000
@@ -76,9 +172,10 @@ func BenchmarkEvalListFilter(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.EvalsByNamespace(nil, structs.DefaultNamespace)
-			evalIter := evalPaginationIterator{iter}
+			tokenizer := NewStructsTokenizer(iter, StructsTokenizerOptions{WithID: true})
+
 			var evals []*structs.Evaluation
-			paginator, err := NewPaginator(evalIter, opts, func(raw interface{}) error {
+			paginator, err := NewPaginator(iter, tokenizer, nil, opts, func(raw interface{}) error {
 				eval := raw.(*structs.Evaluation)
 				evals = append(evals, eval)
 				return nil
@@ -100,9 +197,10 @@ func BenchmarkEvalListFilter(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.Evals(nil, false)
-			evalIter := evalPaginationIterator{iter}
+			tokenizer := NewStructsTokenizer(iter, StructsTokenizerOptions{WithID: true})
+
 			var evals []*structs.Evaluation
-			paginator, err := NewPaginator(evalIter, opts, func(raw interface{}) error {
+			paginator, err := NewPaginator(iter, tokenizer, nil, opts, func(raw interface{}) error {
 				eval := raw.(*structs.Evaluation)
 				evals = append(evals, eval)
 				return nil
@@ -137,9 +235,10 @@ func BenchmarkEvalListFilter(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.EvalsByNamespace(nil, structs.DefaultNamespace)
-			evalIter := evalPaginationIterator{iter}
+			tokenizer := NewStructsTokenizer(iter, StructsTokenizerOptions{WithID: true})
+
 			var evals []*structs.Evaluation
-			paginator, err := NewPaginator(evalIter, opts, func(raw interface{}) error {
+			paginator, err := NewPaginator(iter, tokenizer, nil, opts, func(raw interface{}) error {
 				eval := raw.(*structs.Evaluation)
 				evals = append(evals, eval)
 				return nil
@@ -175,9 +274,10 @@ func BenchmarkEvalListFilter(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.Evals(nil, false)
-			evalIter := evalPaginationIterator{iter}
+			tokenizer := NewStructsTokenizer(iter, StructsTokenizerOptions{WithID: true})
+
 			var evals []*structs.Evaluation
-			paginator, err := NewPaginator(evalIter, opts, func(raw interface{}) error {
+			paginator, err := NewPaginator(iter, tokenizer, nil, opts, func(raw interface{}) error {
 				eval := raw.(*structs.Evaluation)
 				evals = append(evals, eval)
 				return nil
@@ -193,12 +293,12 @@ func BenchmarkEvalListFilter(b *testing.B) {
 // -----------------
 // BENCHMARK HELPER FUNCTIONS
 
-func setupPopulatedState(b *testing.B, evalCount int) *StateStore {
+func setupPopulatedState(b *testing.B, evalCount int) *state.StateStore {
 	evals := generateEvals(evalCount)
 
 	index := uint64(0)
 	var err error
-	state := TestStateStore(b)
+	state := state.TestStateStore(b)
 	for _, eval := range evals {
 		index++
 		err = state.UpsertEvals(
@@ -234,18 +334,4 @@ func generateEval(i int, ns string) *structs.Evaluation {
 		CreateTime: now,
 		ModifyTime: now,
 	}
-}
-
-type evalPaginationIterator struct {
-	iter memdb.ResultIterator
-}
-
-func (it evalPaginationIterator) Next() (string, interface{}) {
-	raw := it.iter.Next()
-	if raw == nil {
-		return "", nil
-	}
-
-	eval := raw.(*structs.Evaluation)
-	return eval.ID, eval
 }

--- a/nomad/state/paginator/paginator.go
+++ b/nomad/state/paginator/paginator.go
@@ -1,4 +1,4 @@
-package state
+package paginator
 
 import (
 	"fmt"
@@ -7,20 +7,19 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
-// Iterator is the interface that must be implemented to use the Paginator.
+// Iterator is the interface that must be implemented to suply data to the
+// Paginator.
 type Iterator interface {
-	// Next returns the next element to be considered for pagination along with
-	// a token string used to uniquely identify elements in the iteration.
+	// Next returns the next element to be considered for pagination.
 	// The page will end if nil is returned.
-	// Tokens should have a stable order and the order must match the paginator
-	// ascending property.
-	Next() (string, interface{})
+	Next() interface{}
 }
 
-// Paginator is an iterator over a memdb.ResultIterator that returns
-// only the expected number of pages.
+// Paginator wraps an iterator and returns only the expected number of pages.
 type Paginator struct {
 	iter           Iterator
+	tokenizer      Tokenizer
+	filters        []Filter
 	perPage        int32
 	itemCount      int32
 	seekingToken   string
@@ -29,17 +28,16 @@ type Paginator struct {
 	nextTokenFound bool
 	pageErr        error
 
-	// filterEvaluator is used to filter results using go-bexpr. It's nil if
-	// no filter expression is defined.
-	filterEvaluator *bexpr.Evaluator
-
 	// appendFunc is the function the caller should use to append raw
 	// entries to the results set. The object is guaranteed to be
 	// non-nil.
 	appendFunc func(interface{}) error
 }
 
-func NewPaginator(iter Iterator, opts structs.QueryOptions, appendFunc func(interface{}) error) (*Paginator, error) {
+// NewPaginator returns a new Paginator.
+func NewPaginator(iter Iterator, tokenizer Tokenizer, filters []Filter,
+	opts structs.QueryOptions, appendFunc func(interface{}) error) (*Paginator, error) {
+
 	var evaluator *bexpr.Evaluator
 	var err error
 
@@ -48,21 +46,23 @@ func NewPaginator(iter Iterator, opts structs.QueryOptions, appendFunc func(inte
 		if err != nil {
 			return nil, fmt.Errorf("failed to read filter expression: %v", err)
 		}
+		filters = append(filters, evaluator)
 	}
 
 	return &Paginator{
-		iter:            iter,
-		perPage:         opts.PerPage,
-		seekingToken:    opts.NextToken,
-		ascending:       opts.Ascending,
-		nextTokenFound:  opts.NextToken == "",
-		filterEvaluator: evaluator,
-		appendFunc:      appendFunc,
+		iter:           iter,
+		tokenizer:      tokenizer,
+		filters:        filters,
+		perPage:        opts.PerPage,
+		seekingToken:   opts.NextToken,
+		ascending:      opts.Ascending,
+		nextTokenFound: opts.NextToken == "",
+		appendFunc:     appendFunc,
 	}, nil
 }
 
 // Page populates a page by running the append function
-// over all results. Returns the next token
+// over all results. Returns the next token.
 func (p *Paginator) Page() (string, error) {
 DONE:
 	for {
@@ -84,11 +84,12 @@ DONE:
 }
 
 func (p *Paginator) next() (interface{}, paginatorState) {
-	token, raw := p.iter.Next()
+	raw := p.iter.Next()
 	if raw == nil {
 		p.nextToken = ""
 		return nil, paginatorComplete
 	}
+	token := p.tokenizer.GetToken(raw)
 
 	// have we found the token we're seeking (if any)?
 	p.nextToken = token
@@ -104,14 +105,14 @@ func (p *Paginator) next() (interface{}, paginatorState) {
 		return nil, paginatorSkip
 	}
 
-	// apply filter if defined
-	if p.filterEvaluator != nil {
-		match, err := p.filterEvaluator.Evaluate(raw)
+	// apply filters if defined
+	for _, f := range p.filters {
+		allow, err := f.Evaluate(raw)
 		if err != nil {
 			p.pageErr = err
 			return nil, paginatorComplete
 		}
-		if !match {
+		if !allow {
 			return nil, paginatorSkip
 		}
 	}

--- a/nomad/state/paginator/paginator.go
+++ b/nomad/state/paginator/paginator.go
@@ -24,7 +24,7 @@ type Paginator struct {
 	itemCount      int32
 	seekingToken   string
 	nextToken      string
-	ascending      bool
+	reverse        bool
 	nextTokenFound bool
 	pageErr        error
 
@@ -55,7 +55,7 @@ func NewPaginator(iter Iterator, tokenizer Tokenizer, filters []Filter,
 		filters:        filters,
 		perPage:        opts.PerPage,
 		seekingToken:   opts.NextToken,
-		ascending:      opts.Ascending,
+		reverse:        opts.Reverse,
 		nextTokenFound: opts.NextToken == "",
 		appendFunc:     appendFunc,
 	}, nil
@@ -95,10 +95,11 @@ func (p *Paginator) next() (interface{}, paginatorState) {
 	p.nextToken = token
 
 	var passedToken bool
-	if p.ascending {
-		passedToken = token < p.seekingToken
-	} else {
+
+	if p.reverse {
 		passedToken = token > p.seekingToken
+	} else {
+		passedToken = token < p.seekingToken
 	}
 
 	if !p.nextTokenFound && passedToken {

--- a/nomad/state/paginator/paginator.go
+++ b/nomad/state/paginator/paginator.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
-// Iterator is the interface that must be implemented to suply data to the
+// Iterator is the interface that must be implemented to supply data to the
 // Paginator.
 type Iterator interface {
 	// Next returns the next element to be considered for pagination.

--- a/nomad/state/paginator/paginator_test.go
+++ b/nomad/state/paginator/paginator_test.go
@@ -1,4 +1,4 @@
-package state
+package paginator
 
 import (
 	"errors"
@@ -58,14 +58,15 @@ func TestPaginator(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			iter := newTestIterator(ids)
-			results := []string{}
+			tokenizer := testTokenizer{}
+			opts := structs.QueryOptions{
+				PerPage:   tc.perPage,
+				NextToken: tc.nextToken,
+				Ascending: true,
+			}
 
-			paginator, err := NewPaginator(iter,
-				structs.QueryOptions{
-					PerPage:   tc.perPage,
-					NextToken: tc.nextToken,
-					Ascending: true,
-				},
+			results := []string{}
+			paginator, err := NewPaginator(iter, tokenizer, nil, opts,
 				func(raw interface{}) error {
 					if tc.expectedError != "" {
 						return errors.New(tc.expectedError)
@@ -94,27 +95,32 @@ func TestPaginator(t *testing.T) {
 
 // helpers for pagination tests
 
-// implements memdb.ResultIterator interface
+// implements Iterator interface
 type testResultIterator struct {
 	results chan interface{}
 }
 
-func (i testResultIterator) Next() (string, interface{}) {
+func (i testResultIterator) Next() interface{} {
 	select {
 	case raw := <-i.results:
 		if raw == nil {
-			return "", nil
+			return nil
 		}
 
 		m := raw.(*mockObject)
-		return m.id, m
+		return m
 	default:
-		return "", nil
+		return nil
 	}
 }
 
 type mockObject struct {
-	id string
+	id        string
+	namespace string
+}
+
+func (m *mockObject) GetNamespace() string {
+	return m.namespace
 }
 
 func newTestIterator(ids []string) testResultIterator {
@@ -123,4 +129,19 @@ func newTestIterator(ids []string) testResultIterator {
 		iter.results <- &mockObject{id: id}
 	}
 	return iter
+}
+
+func newTestIteratorWithMocks(mocks []*mockObject) testResultIterator {
+	iter := testResultIterator{results: make(chan interface{}, 20)}
+	for _, m := range mocks {
+		iter.results <- m
+	}
+	return iter
+}
+
+// implements Tokenizer interface
+type testTokenizer struct{}
+
+func (t testTokenizer) GetToken(raw interface{}) string {
+	return raw.(*mockObject).id
 }

--- a/nomad/state/paginator/paginator_test.go
+++ b/nomad/state/paginator/paginator_test.go
@@ -62,7 +62,6 @@ func TestPaginator(t *testing.T) {
 			opts := structs.QueryOptions{
 				PerPage:   tc.perPage,
 				NextToken: tc.nextToken,
-				Ascending: true,
 			}
 
 			results := []string{}

--- a/nomad/state/paginator/tokenizer.go
+++ b/nomad/state/paginator/tokenizer.go
@@ -41,14 +41,12 @@ type StructsTokenizerOptions struct {
 // formats of pagination tokens based on common fields found in the structs
 // package.
 type StructsTokenizer struct {
-	iter Iterator
 	opts StructsTokenizerOptions
 }
 
 // NewStructsTokenizer returns a new StructsTokenizer.
 func NewStructsTokenizer(it Iterator, opts StructsTokenizerOptions) StructsTokenizer {
 	return StructsTokenizer{
-		iter: it,
 		opts: opts,
 	}
 }

--- a/nomad/state/paginator/tokenizer.go
+++ b/nomad/state/paginator/tokenizer.go
@@ -1,0 +1,84 @@
+package paginator
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Tokenizer is the interface that must be implemented to provide pagination
+// tokens to the Paginator.
+type Tokenizer interface {
+	// GetToken returns the pagination token for the given element.
+	GetToken(interface{}) string
+}
+
+// IDGetter is the interface that must be implemented by structs that need to
+// have their ID as part of the pagination token.
+type IDGetter interface {
+	GetID() string
+}
+
+// NamespaceGetter is the interface that must be implemented by structs that
+// need to have their Namespace as part of the pagination token.
+type NamespaceGetter interface {
+	GetNamespace() string
+}
+
+// CreateIndexGetter is the interface that must be implemented by structs that
+// need to have their CreateIndex as part of the pagination token.
+type CreateIndexGetter interface {
+	GetCreateIndex() uint64
+}
+
+// StructsTokenizerOptions is the configuration provided to a StructsTokenizer.
+type StructsTokenizerOptions struct {
+	WithCreateIndex bool
+	WithNamespace   bool
+	WithID          bool
+}
+
+// StructsTokenizer is an pagination token generator that can create different
+// formats of pagination tokens based on common fields found in the structs
+// package.
+type StructsTokenizer struct {
+	iter Iterator
+	opts StructsTokenizerOptions
+}
+
+// NewStructsTokenizer returns a new StructsTokenizer.
+func NewStructsTokenizer(it Iterator, opts StructsTokenizerOptions) StructsTokenizer {
+	return StructsTokenizer{
+		iter: it,
+		opts: opts,
+	}
+}
+
+func (it StructsTokenizer) GetToken(raw interface{}) string {
+	if raw == nil {
+		return ""
+	}
+
+	parts := []string{}
+
+	if it.opts.WithCreateIndex {
+		token := raw.(CreateIndexGetter).GetCreateIndex()
+		parts = append(parts, fmt.Sprintf("%v", token))
+	}
+
+	if it.opts.WithNamespace {
+		token := raw.(NamespaceGetter).GetNamespace()
+		parts = append(parts, token)
+	}
+
+	if it.opts.WithID {
+		token := raw.(IDGetter).GetID()
+		parts = append(parts, token)
+	}
+
+	// Use a character that is not part of validNamespaceName as separator to
+	// avoid accidentally generating collisions.
+	// For example, namespace `a` and job `b-c` would collide with namespace
+	// `a-b` and job `c` into the same token `a-b-c`, since `-` is an allowed
+	// character in namespace.
+	return strings.Join(parts, ".")
+}

--- a/nomad/state/paginator/tokenizer_test.go
+++ b/nomad/state/paginator/tokenizer_test.go
@@ -1,0 +1,67 @@
+package paginator
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStructsTokenizer(t *testing.T) {
+	j := mock.Job()
+
+	cases := []struct {
+		name     string
+		opts     StructsTokenizerOptions
+		expected string
+	}{
+		{
+			name: "ID",
+			opts: StructsTokenizerOptions{
+				WithID: true,
+			},
+			expected: fmt.Sprintf("%v", j.ID),
+		},
+		{
+			name: "Namespace.ID",
+			opts: StructsTokenizerOptions{
+				WithNamespace: true,
+				WithID:        true,
+			},
+			expected: fmt.Sprintf("%v.%v", j.Namespace, j.ID),
+		},
+		{
+			name: "CreateIndex.Namespace.ID",
+			opts: StructsTokenizerOptions{
+				WithCreateIndex: true,
+				WithNamespace:   true,
+				WithID:          true,
+			},
+			expected: fmt.Sprintf("%v.%v.%v", j.CreateIndex, j.Namespace, j.ID),
+		},
+		{
+			name: "CreateIndex.ID",
+			opts: StructsTokenizerOptions{
+				WithCreateIndex: true,
+				WithID:          true,
+			},
+			expected: fmt.Sprintf("%v.%v", j.CreateIndex, j.ID),
+		},
+		{
+			name: "CreateIndex.Namespace",
+			opts: StructsTokenizerOptions{
+				WithCreateIndex: true,
+				WithNamespace:   true,
+			},
+			expected: fmt.Sprintf("%v.%v", j.CreateIndex, j.Namespace),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tokenizer := StructsTokenizer{opts: tc.opts}
+			require.Equal(t, tc.expected, tokenizer.GetToken(j))
+		})
+	}
+}

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -728,6 +728,21 @@ func aclTokenTableSchema() *memdb.TableSchema {
 					Field: "AccessorID",
 				},
 			},
+			"create": {
+				Name:         "create",
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.CompoundIndex{
+					Indexes: []memdb.Indexer{
+						&memdb.UintFieldIndex{
+							Field: "CreateIndex",
+						},
+						&memdb.StringFieldIndex{
+							Field: "AccessorID",
+						},
+					},
+				},
+			},
 			"secret": {
 				Name:         "secret",
 				AllowMissing: false,

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -530,7 +530,7 @@ func allocTableSchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
 		Name: "allocs",
 		Indexes: map[string]*memdb.IndexSchema{
-			// Primary index is a UUID
+			// id index is used for direct lookup of allocation by ID.
 			"id": {
 				Name:         "id",
 				AllowMissing: false,
@@ -540,12 +540,57 @@ func allocTableSchema() *memdb.TableSchema {
 				},
 			},
 
+			// create index is used for listing allocations, ordering them by
+			// creation chronology. (Use a reverse iterator for newest first).
+			"create": {
+				Name:         "create",
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.CompoundIndex{
+					Indexes: []memdb.Indexer{
+						&memdb.UintFieldIndex{
+							Field: "CreateIndex",
+						},
+						&memdb.StringFieldIndex{
+							Field: "ID",
+						},
+					},
+				},
+			},
+
+			// namespace is used to lookup evaluations by namespace.
+			// todo(shoenig): i think we can deprecate this and other like it
 			"namespace": {
 				Name:         "namespace",
 				AllowMissing: false,
 				Unique:       false,
 				Indexer: &memdb.StringFieldIndex{
 					Field: "Namespace",
+				},
+			},
+
+			// namespace_create index is used to lookup evaluations by namespace
+			// in their original chronological order based on CreateIndex.
+			//
+			// Use a prefix iterator (namespace_prefix) on a Namespace to iterate
+			// those evaluations in order of CreateIndex.
+			"namespace_create": {
+				Name:         "namespace_create",
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.CompoundIndex{
+					AllowMissing: false,
+					Indexes: []memdb.Indexer{
+						&memdb.StringFieldIndex{
+							Field: "Namespace",
+						},
+						&memdb.UintFieldIndex{
+							Field: "CreateIndex",
+						},
+						&memdb.StringFieldIndex{
+							Field: "ID",
+						},
+					},
 				},
 			},
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -5462,14 +5462,21 @@ func (s *StateStore) ACLTokenByAccessorIDPrefix(ws memdb.WatchSet, prefix string
 }
 
 // ACLTokens returns an iterator over all the tokens
-func (s *StateStore) ACLTokens(ws memdb.WatchSet) (memdb.ResultIterator, error) {
+func (s *StateStore) ACLTokens(ws memdb.WatchSet, ascending bool) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
-	// Walk the entire table
-	iter, err := txn.Get("acl_token", "id")
+	var iter memdb.ResultIterator
+	var err error
+
+	if ascending {
+		iter, err = txn.Get("acl_token", "create")
+	} else {
+		iter, err = txn.GetReverse("acl_token", "create")
+	}
 	if err != nil {
 		return nil, err
 	}
+
 	ws.Add(iter.WatchCh())
 	return iter, nil
 }

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -22,6 +22,19 @@ import (
 // This can be a read or write transaction.
 type Txn = *txn
 
+// SortOption represents how results can be sorted.
+type SortOption bool
+
+const (
+	// SortDefault indicates that the result should be returned using the
+	// default go-memdb ResultIterator order.
+	SortDefault SortOption = false
+
+	// SortReverse indicates that the result should be returned using the
+	// reversed go-memdb ResultIterator order.
+	SortReverse SortOption = true
+)
+
 const (
 	// NodeRegisterEventReregistered is the message used when the node becomes
 	// reregistered.
@@ -544,15 +557,16 @@ func (s *StateStore) upsertDeploymentImpl(index uint64, deployment *structs.Depl
 	return nil
 }
 
-func (s *StateStore) Deployments(ws memdb.WatchSet, reverse bool) (memdb.ResultIterator, error) {
+func (s *StateStore) Deployments(ws memdb.WatchSet, sort SortOption) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
 	var it memdb.ResultIterator
 	var err error
 
-	if reverse {
+	switch sort {
+	case SortReverse:
 		it, err = txn.GetReverse("deployment", "create")
-	} else {
+	default:
 		it, err = txn.Get("deployment", "create")
 	}
 
@@ -578,7 +592,7 @@ func (s *StateStore) DeploymentsByNamespace(ws memdb.WatchSet, namespace string)
 	return iter, nil
 }
 
-func (s *StateStore) DeploymentsByNamespaceOrdered(ws memdb.WatchSet, namespace string, reverse bool) (memdb.ResultIterator, error) {
+func (s *StateStore) DeploymentsByNamespaceOrdered(ws memdb.WatchSet, namespace string, sort SortOption) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
 	var (
@@ -587,9 +601,10 @@ func (s *StateStore) DeploymentsByNamespaceOrdered(ws memdb.WatchSet, namespace 
 		exact = terminate(namespace)
 	)
 
-	if reverse {
+	switch sort {
+	case SortReverse:
 		it, err = txn.GetReverse("deployment", "namespace_create_prefix", exact)
-	} else {
+	default:
 		it, err = txn.Get("deployment", "namespace_create_prefix", exact)
 	}
 
@@ -3215,16 +3230,17 @@ func (s *StateStore) EvalsByJob(ws memdb.WatchSet, namespace, jobID string) ([]*
 }
 
 // Evals returns an iterator over all the evaluations in ascending or descending
-// order of CreationIndex as determined by the ascending parameter.
-func (s *StateStore) Evals(ws memdb.WatchSet, reverse bool) (memdb.ResultIterator, error) {
+// order of CreationIndex as determined by the reverse parameter.
+func (s *StateStore) Evals(ws memdb.WatchSet, sort SortOption) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
 	var it memdb.ResultIterator
 	var err error
 
-	if reverse {
+	switch sort {
+	case SortReverse:
 		it, err = txn.GetReverse("evals", "create")
-	} else {
+	default:
 		it, err = txn.Get("evals", "create")
 	}
 
@@ -3254,7 +3270,7 @@ func (s *StateStore) EvalsByNamespace(ws memdb.WatchSet, namespace string) (memd
 	return it, nil
 }
 
-func (s *StateStore) EvalsByNamespaceOrdered(ws memdb.WatchSet, namespace string, reverse bool) (memdb.ResultIterator, error) {
+func (s *StateStore) EvalsByNamespaceOrdered(ws memdb.WatchSet, namespace string, sort SortOption) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
 	var (
@@ -3263,9 +3279,10 @@ func (s *StateStore) EvalsByNamespaceOrdered(ws memdb.WatchSet, namespace string
 		exact = terminate(namespace)
 	)
 
-	if reverse {
+	switch sort {
+	case SortReverse:
 		it, err = txn.GetReverse("evals", "namespace_create_prefix", exact)
-	} else {
+	default:
 		it, err = txn.Get("evals", "namespace_create_prefix", exact)
 	}
 
@@ -3798,15 +3815,16 @@ func (s *StateStore) AllocsByDeployment(ws memdb.WatchSet, deploymentID string) 
 }
 
 // Allocs returns an iterator over all the evaluations.
-func (s *StateStore) Allocs(ws memdb.WatchSet, reverse bool) (memdb.ResultIterator, error) {
+func (s *StateStore) Allocs(ws memdb.WatchSet, sort SortOption) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
 	var it memdb.ResultIterator
 	var err error
 
-	if reverse {
+	switch sort {
+	case SortReverse:
 		it, err = txn.GetReverse("allocs", "create")
-	} else {
+	default:
 		it, err = txn.Get("allocs", "create")
 	}
 
@@ -3819,7 +3837,7 @@ func (s *StateStore) Allocs(ws memdb.WatchSet, reverse bool) (memdb.ResultIterat
 	return it, nil
 }
 
-func (s *StateStore) AllocsByNamespaceOrdered(ws memdb.WatchSet, namespace string, reverse bool) (memdb.ResultIterator, error) {
+func (s *StateStore) AllocsByNamespaceOrdered(ws memdb.WatchSet, namespace string, sort SortOption) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
 	var (
@@ -3828,9 +3846,10 @@ func (s *StateStore) AllocsByNamespaceOrdered(ws memdb.WatchSet, namespace strin
 		exact = terminate(namespace)
 	)
 
-	if reverse {
+	switch sort {
+	case SortReverse:
 		it, err = txn.GetReverse("allocs", "namespace_create_prefix", exact)
-	} else {
+	default:
 		it, err = txn.Get("allocs", "namespace_create_prefix", exact)
 	}
 
@@ -5526,15 +5545,16 @@ func (s *StateStore) ACLTokenByAccessorIDPrefix(ws memdb.WatchSet, prefix string
 }
 
 // ACLTokens returns an iterator over all the tokens
-func (s *StateStore) ACLTokens(ws memdb.WatchSet, reverse bool) (memdb.ResultIterator, error) {
+func (s *StateStore) ACLTokens(ws memdb.WatchSet, sort SortOption) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
 	var iter memdb.ResultIterator
 	var err error
 
-	if reverse {
+	switch sort {
+	case SortReverse:
 		iter, err = txn.GetReverse("acl_token", "create")
-	} else {
+	default:
 		iter, err = txn.Get("acl_token", "create")
 	}
 	if err != nil {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -544,16 +544,16 @@ func (s *StateStore) upsertDeploymentImpl(index uint64, deployment *structs.Depl
 	return nil
 }
 
-func (s *StateStore) Deployments(ws memdb.WatchSet, ascending bool) (memdb.ResultIterator, error) {
+func (s *StateStore) Deployments(ws memdb.WatchSet, reverse bool) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
 	var it memdb.ResultIterator
 	var err error
 
-	if ascending {
-		it, err = txn.Get("deployment", "create")
-	} else {
+	if reverse {
 		it, err = txn.GetReverse("deployment", "create")
+	} else {
+		it, err = txn.Get("deployment", "create")
 	}
 
 	if err != nil {
@@ -578,7 +578,7 @@ func (s *StateStore) DeploymentsByNamespace(ws memdb.WatchSet, namespace string)
 	return iter, nil
 }
 
-func (s *StateStore) DeploymentsByNamespaceOrdered(ws memdb.WatchSet, namespace string, ascending bool) (memdb.ResultIterator, error) {
+func (s *StateStore) DeploymentsByNamespaceOrdered(ws memdb.WatchSet, namespace string, reverse bool) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
 	var (
@@ -587,10 +587,10 @@ func (s *StateStore) DeploymentsByNamespaceOrdered(ws memdb.WatchSet, namespace 
 		exact = terminate(namespace)
 	)
 
-	if ascending {
-		it, err = txn.Get("deployment", "namespace_create_prefix", exact)
-	} else {
+	if reverse {
 		it, err = txn.GetReverse("deployment", "namespace_create_prefix", exact)
+	} else {
+		it, err = txn.Get("deployment", "namespace_create_prefix", exact)
 	}
 
 	if err != nil {
@@ -3216,16 +3216,16 @@ func (s *StateStore) EvalsByJob(ws memdb.WatchSet, namespace, jobID string) ([]*
 
 // Evals returns an iterator over all the evaluations in ascending or descending
 // order of CreationIndex as determined by the ascending parameter.
-func (s *StateStore) Evals(ws memdb.WatchSet, ascending bool) (memdb.ResultIterator, error) {
+func (s *StateStore) Evals(ws memdb.WatchSet, reverse bool) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
 	var it memdb.ResultIterator
 	var err error
 
-	if ascending {
-		it, err = txn.Get("evals", "create")
-	} else {
+	if reverse {
 		it, err = txn.GetReverse("evals", "create")
+	} else {
+		it, err = txn.Get("evals", "create")
 	}
 
 	if err != nil {
@@ -3254,7 +3254,7 @@ func (s *StateStore) EvalsByNamespace(ws memdb.WatchSet, namespace string) (memd
 	return it, nil
 }
 
-func (s *StateStore) EvalsByNamespaceOrdered(ws memdb.WatchSet, namespace string, ascending bool) (memdb.ResultIterator, error) {
+func (s *StateStore) EvalsByNamespaceOrdered(ws memdb.WatchSet, namespace string, reverse bool) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
 	var (
@@ -3263,10 +3263,10 @@ func (s *StateStore) EvalsByNamespaceOrdered(ws memdb.WatchSet, namespace string
 		exact = terminate(namespace)
 	)
 
-	if ascending {
-		it, err = txn.Get("evals", "namespace_create_prefix", exact)
-	} else {
+	if reverse {
 		it, err = txn.GetReverse("evals", "namespace_create_prefix", exact)
+	} else {
+		it, err = txn.Get("evals", "namespace_create_prefix", exact)
 	}
 
 	if err != nil {
@@ -3798,16 +3798,16 @@ func (s *StateStore) AllocsByDeployment(ws memdb.WatchSet, deploymentID string) 
 }
 
 // Allocs returns an iterator over all the evaluations.
-func (s *StateStore) Allocs(ws memdb.WatchSet, ascending bool) (memdb.ResultIterator, error) {
+func (s *StateStore) Allocs(ws memdb.WatchSet, reverse bool) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
 	var it memdb.ResultIterator
 	var err error
 
-	if ascending {
-		it, err = txn.Get("allocs", "create")
-	} else {
+	if reverse {
 		it, err = txn.GetReverse("allocs", "create")
+	} else {
+		it, err = txn.Get("allocs", "create")
 	}
 
 	if err != nil {
@@ -3819,7 +3819,7 @@ func (s *StateStore) Allocs(ws memdb.WatchSet, ascending bool) (memdb.ResultIter
 	return it, nil
 }
 
-func (s *StateStore) AllocsByNamespaceOrdered(ws memdb.WatchSet, namespace string, ascending bool) (memdb.ResultIterator, error) {
+func (s *StateStore) AllocsByNamespaceOrdered(ws memdb.WatchSet, namespace string, reverse bool) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
 	var (
@@ -3828,10 +3828,10 @@ func (s *StateStore) AllocsByNamespaceOrdered(ws memdb.WatchSet, namespace strin
 		exact = terminate(namespace)
 	)
 
-	if ascending {
-		it, err = txn.Get("allocs", "namespace_create_prefix", exact)
-	} else {
+	if reverse {
 		it, err = txn.GetReverse("allocs", "namespace_create_prefix", exact)
+	} else {
+		it, err = txn.Get("allocs", "namespace_create_prefix", exact)
 	}
 
 	if err != nil {
@@ -5526,16 +5526,16 @@ func (s *StateStore) ACLTokenByAccessorIDPrefix(ws memdb.WatchSet, prefix string
 }
 
 // ACLTokens returns an iterator over all the tokens
-func (s *StateStore) ACLTokens(ws memdb.WatchSet, ascending bool) (memdb.ResultIterator, error) {
+func (s *StateStore) ACLTokens(ws memdb.WatchSet, reverse bool) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
 	var iter memdb.ResultIterator
 	var err error
 
-	if ascending {
-		iter, err = txn.Get("acl_token", "create")
-	} else {
+	if reverse {
 		iter, err = txn.GetReverse("acl_token", "create")
+	} else {
+		iter, err = txn.Get("acl_token", "create")
 	}
 	if err != nil {
 		return nil, err

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3607,6 +3607,10 @@ func allocNamespaceFilter(namespace string) func(interface{}) bool {
 			return true
 		}
 
+		if namespace == structs.AllNamespacesSentinel {
+			return false
+		}
+
 		return alloc.Namespace != namespace
 	}
 }

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -7500,7 +7500,7 @@ func TestStateStore_BootstrapACLTokens(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 
-	iter, err := state.ACLTokens(nil)
+	iter, err := state.ACLTokens(nil, false)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -7594,7 +7594,7 @@ func TestStateStore_UpsertACLTokens(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, tk2, out)
 
-	iter, err := state.ACLTokens(ws)
+	iter, err := state.ACLTokens(ws, false)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -7661,7 +7661,7 @@ func TestStateStore_DeleteACLTokens(t *testing.T) {
 		t.Fatalf("bad: %#v", out)
 	}
 
-	iter, err := state.ACLTokens(ws)
+	iter, err := state.ACLTokens(ws, false)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -670,7 +670,7 @@ func TestStateStore_Deployments(t *testing.T) {
 	}
 
 	ws := memdb.NewWatchSet()
-	it, err := state.Deployments(ws, true)
+	it, err := state.Deployments(ws, false)
 	require.NoError(t, err)
 
 	var out []*structs.Deployment

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -5424,7 +5424,7 @@ func TestStateStore_Allocs(t *testing.T) {
 	}
 
 	ws := memdb.NewWatchSet()
-	iter, err := state.Allocs(ws)
+	iter, err := state.Allocs(ws, false)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5472,7 +5472,7 @@ func TestStateStore_Allocs_PrevAlloc(t *testing.T) {
 	require.Nil(err)
 
 	ws := memdb.NewWatchSet()
-	iter, err := state.Allocs(ws)
+	iter, err := state.Allocs(ws, false)
 	require.Nil(err)
 
 	var out []*structs.Allocation

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -670,7 +670,7 @@ func TestStateStore_Deployments(t *testing.T) {
 	}
 
 	ws := memdb.NewWatchSet()
-	it, err := state.Deployments(ws, false)
+	it, err := state.Deployments(ws, SortDefault)
 	require.NoError(t, err)
 
 	var out []*structs.Deployment
@@ -5424,7 +5424,7 @@ func TestStateStore_Allocs(t *testing.T) {
 	}
 
 	ws := memdb.NewWatchSet()
-	iter, err := state.Allocs(ws, false)
+	iter, err := state.Allocs(ws, SortDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -5472,7 +5472,7 @@ func TestStateStore_Allocs_PrevAlloc(t *testing.T) {
 	require.Nil(err)
 
 	ws := memdb.NewWatchSet()
-	iter, err := state.Allocs(ws, false)
+	iter, err := state.Allocs(ws, SortDefault)
 	require.Nil(err)
 
 	var out []*structs.Allocation
@@ -7500,7 +7500,7 @@ func TestStateStore_BootstrapACLTokens(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 
-	iter, err := state.ACLTokens(nil, false)
+	iter, err := state.ACLTokens(nil, SortDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -7594,7 +7594,7 @@ func TestStateStore_UpsertACLTokens(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, tk2, out)
 
-	iter, err := state.ACLTokens(ws, false)
+	iter, err := state.ACLTokens(ws, SortDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -7661,7 +7661,7 @@ func TestStateStore_DeleteACLTokens(t *testing.T) {
 		t.Fatalf("bad: %#v", out)
 	}
 
-	iter, err := state.ACLTokens(ws, false)
+	iter, err := state.ACLTokens(ws, SortDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -301,6 +301,32 @@ type CSIVolume struct {
 	ModifyIndex uint64
 }
 
+// GetID implements the IDGetter interface, required for pagination.
+func (v *CSIVolume) GetID() string {
+	if v == nil {
+		return ""
+	}
+	return v.ID
+}
+
+// GetNamespace implements the NamespaceGetter interface, required for
+// pagination.
+func (v *CSIVolume) GetNamespace() string {
+	if v == nil {
+		return ""
+	}
+	return v.Namespace
+}
+
+// GetCreateIndex implements the CreateIndexGetter interface, required for
+// pagination.
+func (v *CSIVolume) GetCreateIndex() uint64 {
+	if v == nil {
+		return 0
+	}
+	return v.CreateIndex
+}
+
 // CSIVolListStub is partial representation of a CSI Volume for inclusion in lists
 type CSIVolListStub struct {
 	ID                  string

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9482,6 +9482,33 @@ type Allocation struct {
 	ModifyTime int64
 }
 
+// GetID implements the IDGetter interface, required for pagination.
+func (a *Allocation) GetID() string {
+	if a == nil {
+		return ""
+	}
+	return a.ID
+}
+
+// GetNamespace implements the NamespaceGetter interface, required for
+// pagination and filtering namespaces in endpoints that support glob namespace
+// requests using tokens with limited access.
+func (a *Allocation) GetNamespace() string {
+	if a == nil {
+		return ""
+	}
+	return a.Namespace
+}
+
+// GetCreateIndex implements the CreateIndexGetter interface, required for
+// pagination.
+func (a *Allocation) GetCreateIndex() uint64 {
+	if a == nil {
+		return 0
+	}
+	return a.CreateIndex
+}
+
 // ConsulNamespace returns the Consul namespace of the task group associated
 // with this allocation.
 func (a *Allocation) ConsulNamespace() string {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -273,8 +273,8 @@ type QueryOptions struct {
 	// previous response.
 	NextToken string
 
-	// Ascending is used to have results sorted in ascending chronological order.
-	Ascending bool
+	// Reverse is used to reverse the default order of list results.
+	Reverse bool
 
 	InternalRpcInfo
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -11344,6 +11344,23 @@ type ACLToken struct {
 	ModifyIndex uint64
 }
 
+// GetID implements the IDGetter interface, required for pagination.
+func (a *ACLToken) GetID() string {
+	if a == nil {
+		return ""
+	}
+	return a.AccessorID
+}
+
+// GetCreateIndex implements the CreateIndexGetter interface, required for
+// pagination.
+func (a *ACLToken) GetCreateIndex() uint64 {
+	if a == nil {
+		return 0
+	}
+	return a.CreateIndex
+}
+
 func (a *ACLToken) Copy() *ACLToken {
 	c := new(ACLToken)
 	*c = *a

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9057,6 +9057,15 @@ func (d *Deployment) GetID() string {
 	return d.ID
 }
 
+// GetCreateIndex implements the CreateIndexGetter interface, required for
+// pagination.
+func (d *Deployment) GetCreateIndex() uint64 {
+	if d == nil {
+		return 0
+	}
+	return d.CreateIndex
+}
+
 // HasPlacedCanaries returns whether the deployment has placed canaries
 func (d *Deployment) HasPlacedCanaries() bool {
 	if d == nil || len(d.TaskGroups) == 0 {
@@ -10546,6 +10555,23 @@ type Evaluation struct {
 
 	CreateTime int64
 	ModifyTime int64
+}
+
+// GetID implements the IDGetter interface, required for pagination.
+func (e *Evaluation) GetID() string {
+	if e == nil {
+		return ""
+	}
+	return e.ID
+}
+
+// GetCreateIndex implements the CreateIndexGetter interface, required for
+// pagination.
+func (e *Evaluation) GetCreateIndex() uint64 {
+	if e == nil {
+		return 0
+	}
+	return e.CreateIndex
 }
 
 // TerminalStatus returns if the current status is terminal and

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4188,6 +4188,33 @@ func (j *Job) NamespacedID() NamespacedID {
 	}
 }
 
+// GetID implements the IDGetter interface, required for pagination.
+func (j *Job) GetID() string {
+	if j == nil {
+		return ""
+	}
+	return j.ID
+}
+
+// GetNamespace implements the NamespaceGetter interface, required for
+// pagination and filtering namespaces in endpoints that support glob namespace
+// requests using tokens with limited access.
+func (j *Job) GetNamespace() string {
+	if j == nil {
+		return ""
+	}
+	return j.Namespace
+}
+
+// GetCreateIndex implements the CreateIndexGetter interface, required for
+// pagination.
+func (j *Job) GetCreateIndex() uint64 {
+	if j == nil {
+		return 0
+	}
+	return j.CreateIndex
+}
+
 // Canonicalize is used to canonicalize fields in the Job. This should be
 // called when registering a Job.
 func (j *Job) Canonicalize() {


### PR DESCRIPTION
This PR builds on previous PR s(#11648, #12034, #12128, #12090) to add pagination, filtering, and sorting to the following endpoints:

- `/v1/acl/tokens`
- `/v1/allocations`
- `/v1/jobs`
- `/v1/volumes`

Adding sort turned out to be more complex for job and volumes because their IDs are not globally unique, they need to use a `CompoundIndex` with namespace and ID. Adding `CreateIndex` as an additional component of this index resulted in an error when trying to do prefix query, so reverse sorting is not supported `/v1/jobs` and `/v1/volumes`.

This PR also renamed the `Ascending` flag to `Reverse` so its meaning is more generic. `Ascending` assumes that the default order is descending, but that may not always be the case.

It also refactors the paginator (more details in https://github.com/hashicorp/nomad/pull/12186/commits/1a5d07c5ec0521fefe2cb8418c63f2f932ea149c) and the implementation of wildcard namespace listing for `/v1/jobs` and `/v1/allocations` to avoid having two different methods that are almost the same.

Documentation will be provided in https://github.com/hashicorp/nomad/pull/12094

Closes #11742
Closes #7118

----------

Note to reviewers: it's probably better to review by commit, the work of implementing additional endpoints is somewhat repetitive, and some of the changes resulted in a significant diff, but are easier to understand in isolation.

