### PR TITLE
jobspec: add service block provider parameter

### DIFF
--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -742,6 +742,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 										PortLabel:   "db",
 										AddressMode: "auto",
 										OnUpdate:    "require_healthy",
+										Provider:    "consul",
 										Checks: []ServiceCheck{
 											{
 												Name:     "alive",

--- a/api/services.go
+++ b/api/services.go
@@ -116,12 +116,21 @@ type Service struct {
 	CanaryMeta        map[string]string `hcl:"canary_meta,block"`
 	TaskName          string            `mapstructure:"task" hcl:"task,optional"`
 	OnUpdate          string            `mapstructure:"on_update" hcl:"on_update,optional"`
+
+	// Provider defines which backend system provides the service registration
+	// mechanism for this service. This supports either structs.ProviderConsul
+	// or structs.ProviderNomad and defaults for the former.
+	Provider string `hcl:"provider,optional"`
 }
 
 const (
 	OnUpdateRequireHealthy = "require_healthy"
 	OnUpdateIgnoreWarn     = "ignore_warnings"
 	OnUpdateIgnore         = "ignore"
+
+	// ServiceProviderConsul is the default provider for services when no
+	// parameter is set.
+	ServiceProviderConsul = "consul"
 )
 
 // Canonicalize the Service by ensuring its name and address mode are set. Task
@@ -143,6 +152,11 @@ func (s *Service) Canonicalize(t *Task, tg *TaskGroup, job *Job) {
 	// Default to OnUpdateRequireHealthy
 	if s.OnUpdate == "" {
 		s.OnUpdate = OnUpdateRequireHealthy
+	}
+
+	// Default the service provider.
+	if s.Provider == "" {
+		s.Provider = ServiceProviderConsul
 	}
 
 	s.Connect.Canonicalize()

--- a/api/services_test.go
+++ b/api/services_test.go
@@ -21,6 +21,7 @@ func TestService_Canonicalize(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("%s-%s-%s", *j.Name, *tg.Name, task.Name), s.Name)
 	require.Equal(t, "auto", s.AddressMode)
 	require.Equal(t, OnUpdateRequireHealthy, s.OnUpdate)
+	require.Equal(t, ServiceProviderConsul, s.Provider)
 }
 
 func TestServiceCheck_Canonicalize(t *testing.T) {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1372,6 +1372,7 @@ func ApiServicesToStructs(in []*api.Service, group bool) []*structs.Service {
 			Meta:              helper.CopyMapStringString(s.Meta),
 			CanaryMeta:        helper.CopyMapStringString(s.CanaryMeta),
 			OnUpdate:          s.OnUpdate,
+			Provider:          s.Provider,
 		}
 
 		if l := len(s.Checks); l != 0 {

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -2902,6 +2902,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 				Services: []*structs.Service{
 					{
 						Name:              "groupserviceA",
+						Provider:          "consul",
 						Tags:              []string{"a", "b"},
 						CanaryTags:        []string{"d", "e"},
 						EnableTagOverride: true,
@@ -2993,6 +2994,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						Services: []*structs.Service{
 							{
 								Name:              "serviceA",
+								Provider:          "consul",
 								Tags:              []string{"1", "2"},
 								CanaryTags:        []string{"3", "4"},
 								EnableTagOverride: true,

--- a/jobspec/parse_service.go
+++ b/jobspec/parse_service.go
@@ -51,6 +51,7 @@ func parseService(o *ast.ObjectItem) (*api.Service, error) {
 		"meta",
 		"canary_meta",
 		"on_update",
+		"provider",
 	}
 	if err := checkHCLKeys(o.Val, valid); err != nil {
 		return nil, err

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -1763,6 +1763,32 @@ func TestParse(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"service-provider.hcl",
+			&api.Job{
+				ID:   stringToPtr("service-provider"),
+				Name: stringToPtr("service-provider"),
+				TaskGroups: []*api.TaskGroup{
+					{
+						Count: intToPtr(5),
+						Name:  stringToPtr("group"),
+						Tasks: []*api.Task{
+							{
+								Name:   "task",
+								Driver: "docker",
+								Services: []*api.Service{
+									{
+										Name:     "service-provider",
+										Provider: "nomad",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/jobspec/test-fixtures/service-provider.hcl
+++ b/jobspec/test-fixtures/service-provider.hcl
@@ -1,0 +1,14 @@
+job "service-provider" {
+  group "group" {
+    count = 5
+
+    task "task" {
+      driver = "docker"
+
+      service {
+        name     = "service-provider"
+        provider = "nomad"
+      }
+    }
+  }
+}

--- a/nomad/structs/consul.go
+++ b/nomad/structs/consul.go
@@ -70,13 +70,17 @@ func (j *Job) ConsulUsages() map[string]*ConsulUsage {
 
 		// Gather group services
 		for _, service := range tg.Services {
-			m[namespace].Services = append(m[namespace].Services, service.Name)
+			if service.Provider == ServiceProviderConsul {
+				m[namespace].Services = append(m[namespace].Services, service.Name)
+			}
 		}
 
 		// Gather task services and KV usage
 		for _, task := range tg.Tasks {
 			for _, service := range task.Services {
-				m[namespace].Services = append(m[namespace].Services, service.Name)
+				if service.Provider == ServiceProviderConsul {
+					m[namespace].Services = append(m[namespace].Services, service.Name)
+				}
 			}
 			if len(task.Templates) > 0 {
 				m[namespace].KV = true

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -2873,6 +2873,12 @@ func TestTaskGroupDiff(t *testing.T) {
 								New:  "",
 							},
 							{
+								Type: DiffTypeNone,
+								Name: "Provider",
+								Old:  "",
+								New:  "",
+							},
+							{
 								Type: DiffTypeEdited,
 								Name: "TaskName",
 								Old:  "task1",
@@ -5602,6 +5608,10 @@ func TestTaskDiff(t *testing.T) {
 								New:  "bar",
 							},
 							{
+								Type: DiffTypeNone,
+								Name: "Provider",
+							},
+							{
 								Type: DiffTypeAdded,
 								Name: "TaskName",
 								Old:  "",
@@ -5744,6 +5754,10 @@ func TestTaskDiff(t *testing.T) {
 							{
 								Type: DiffTypeNone,
 								Name: "PortLabel",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "Provider",
 							},
 							{
 								Type: DiffTypeNone,
@@ -6263,6 +6277,10 @@ func TestTaskDiff(t *testing.T) {
 								Name: "PortLabel",
 								Old:  "",
 								New:  "",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "Provider",
 							},
 							{
 								Type: DiffTypeNone,
@@ -7349,6 +7367,10 @@ func TestServicesDiff(t *testing.T) {
 						},
 						{
 							Type: DiffTypeNone,
+							Name: "Provider",
+						},
+						{
+							Type: DiffTypeNone,
 							Name: "TaskName",
 						},
 					},
@@ -7434,6 +7456,10 @@ func TestServicesDiff(t *testing.T) {
 						},
 						{
 							Type: DiffTypeNone,
+							Name: "Provider",
+						},
+						{
+							Type: DiffTypeNone,
 							Name: "TaskName",
 						},
 					},
@@ -7490,6 +7516,10 @@ func TestServicesDiff(t *testing.T) {
 							Type: DiffTypeAdded,
 							Name: "PortLabel",
 							New:  "https",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "Provider",
 						},
 						{
 							Type: DiffTypeNone,
@@ -7556,6 +7586,9 @@ func TestServicesDiff(t *testing.T) {
 							Name: "PortLabel",
 							Old:  "http",
 							New:  "https-redirect",
+						}, {
+							Type: DiffTypeNone,
+							Name: "Provider",
 						},
 						{
 							Type: DiffTypeNone,
@@ -7629,6 +7662,10 @@ func TestServicesDiff(t *testing.T) {
 						},
 						{
 							Type: DiffTypeNone,
+							Name: "Provider",
+						},
+						{
+							Type: DiffTypeNone,
 							Name: "TaskName",
 						},
 					},
@@ -7649,6 +7686,72 @@ func TestServicesDiff(t *testing.T) {
 									New:  "prod",
 								},
 							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:       "Service with different provider",
+			Contextual: true,
+			Old: []*Service{
+				{
+					Name:      "webapp",
+					Provider:  "nomad",
+					PortLabel: "http",
+				},
+			},
+			New: []*Service{
+				{
+					Name:      "webapp",
+					Provider:  "consul",
+					PortLabel: "http",
+				},
+			},
+			Expected: []*ObjectDiff{
+				{
+					Type: DiffTypeEdited,
+					Name: "Service",
+					Fields: []*FieldDiff{
+						{
+							Type: DiffTypeNone,
+							Name: "AddressMode",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "EnableTagOverride",
+							Old:  "false",
+							New:  "false",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "Name",
+							Old:  "webapp",
+							New:  "webapp",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "Namespace",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "OnUpdate",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "PortLabel",
+							Old:  "http",
+							New:  "http",
+						},
+						{
+							Type: DiffTypeEdited,
+							Name: "Provider",
+							Old:  "nomad",
+							New:  "consul",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "TaskName",
 						},
 					},
 				},

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -420,6 +420,15 @@ const (
 	AddressModeHost   = "host"
 	AddressModeDriver = "driver"
 	AddressModeAlloc  = "alloc"
+
+	// ServiceProviderConsul is the default service provider and the way Nomad
+	// worked before native service discovery.
+	ServiceProviderConsul = "consul"
+
+	// ServiceProviderNomad is the native service discovery provider. At the
+	// time of writing, there are a number of restrictions around its
+	// functionality and use.
+	ServiceProviderNomad = "nomad"
 )
 
 // Service represents a Consul service definition
@@ -468,6 +477,11 @@ type Service struct {
 	// OnUpdate Specifies how the service and its checks should be evaluated
 	// during an update
 	OnUpdate string
+
+	// Provider dictates which service discovery provider to use. This can be
+	// either ServiceProviderConsul or ServiceProviderNomad and defaults to the former when
+	// left empty by the operator.
+	Provider string
 }
 
 const (
@@ -504,7 +518,7 @@ func (s *Service) Copy() *Service {
 
 // Canonicalize interpolates values of Job, Task Group and Task in the Service
 // Name. This also generates check names, service id and check ids.
-func (s *Service) Canonicalize(job string, taskGroup string, task string) {
+func (s *Service) Canonicalize(job, taskGroup, task, jobNamespace string) {
 	// Ensure empty lists are treated as null to avoid scheduler issues when
 	// using DeepEquals
 	if len(s.Tags) == 0 {
@@ -528,10 +542,23 @@ func (s *Service) Canonicalize(job string, taskGroup string, task string) {
 		check.Canonicalize(s.Name)
 	}
 
+	// Set the provider to its default value. The value of consul ensures this
+	// new feature and parameter behaves in the same manner a previous versions
+	// which did not include this.
+	if s.Provider == "" {
+		s.Provider = ServiceProviderConsul
+	}
+
 	// Consul API returns "default" whether the namespace is empty or set as
-	// such, so we coerce our copy of the service to be the same.
-	if s.Namespace == "" {
+	// such, so we coerce our copy of the service to be the same if using the
+	// consul provider.
+	//
+	// When using ServiceProviderNomad, set the namespace to that of the job. This
+	// makes modifications and diffs on the service correct.
+	if s.Namespace == "" && s.Provider == ServiceProviderConsul {
 		s.Namespace = "default"
+	} else if s.Provider == ServiceProviderNomad {
+		s.Namespace = jobNamespace
 	}
 }
 
@@ -562,6 +589,26 @@ func (s *Service) Validate() error {
 	default:
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("Service on_update must be %q, %q, or %q; not %q", OnUpdateRequireHealthy, OnUpdateIgnoreWarn, OnUpdateIgnore, s.OnUpdate))
 	}
+
+	// Up until this point, all service validation has been independent of the
+	// provider. From this point on, we have different validation paths. We can
+	// also catch an incorrect provider parameter.
+	switch s.Provider {
+	case ServiceProviderConsul:
+		s.validateConsulService(&mErr)
+	case ServiceProviderNomad:
+		s.validateNomadService(&mErr)
+	default:
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("Service provider must be %q, or %q; not %q",
+			ServiceProviderConsul, ServiceProviderNomad, s.Provider))
+	}
+
+	return mErr.ErrorOrNil()
+}
+
+// validateConsulService performs validation on a service which is using the
+// consul provider.
+func (s *Service) validateConsulService(mErr *multierror.Error) {
 
 	// check checks
 	for _, c := range s.Checks {
@@ -595,8 +642,23 @@ func (s *Service) Validate() error {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("Service %s is Connect Native and requires setting the task", s.Name))
 		}
 	}
+}
 
-	return mErr.ErrorOrNil()
+// validateNomadService performs validation on a service which is using the
+// nomad provider.
+func (s *Service) validateNomadService(mErr *multierror.Error) {
+
+	// Service blocks for the Nomad provider do not support checks. We perform
+	// a nil check, as an empty check list is nilled within the service
+	// canonicalize function.
+	if s.Checks != nil {
+		mErr.Errors = append(mErr.Errors, errors.New("Service with provider nomad cannot include Check blocks"))
+	}
+
+	// Services using the Nomad provider do not support Consul connect.
+	if s.Connect != nil {
+		mErr.Errors = append(mErr.Errors, errors.New("Service with provider nomad cannot include Connect blocks"))
+	}
 }
 
 // ValidateName checks if the service Name is valid and should be called after
@@ -614,7 +676,8 @@ func (s *Service) ValidateName(name string) error {
 }
 
 // Hash returns a base32 encoded hash of a Service's contents excluding checks
-// as they're hashed independently.
+// as they're hashed independently and the provider in order to not cause churn
+// during cluster upgrades.
 func (s *Service) Hash(allocID, taskName string, canary bool) string {
 	h := sha1.New()
 	hashString(h, allocID)
@@ -631,6 +694,11 @@ func (s *Service) Hash(allocID, taskName string, canary bool) string {
 	hashConnect(h, s.Connect)
 	hashString(h, s.OnUpdate)
 	hashString(h, s.Namespace)
+
+	// Don't hash the provider parameter, so we don't cause churn of all
+	// registered services when upgrading Nomad versions. The provider is not
+	// used at the level the hash is and therefore is not needed to tell
+	// whether the service has changed.
 
 	// Base32 is used for encoding the hash as sha1 hashes can always be
 	// encoded without padding, only 4 bytes larger than base64, and saves
@@ -685,6 +753,10 @@ func hashConfig(h hash.Hash, c map[string]interface{}) {
 func (s *Service) Equals(o *Service) bool {
 	if s == nil || o == nil {
 		return s == o
+	}
+
+	if s.Provider != o.Provider {
+		return false
 	}
 
 	if s.Namespace != o.Namespace {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6195,7 +6195,7 @@ func (tg *TaskGroup) Canonicalize(job *Job) {
 	}
 
 	for _, service := range tg.Services {
-		service.Canonicalize(job.Name, tg.Name, "group")
+		service.Canonicalize(job.Name, tg.Name, "group", job.Namespace)
 	}
 
 	for _, network := range tg.Networks {
@@ -6491,6 +6491,10 @@ func (tg *TaskGroup) validateServices() error {
 	var mErr multierror.Error
 	knownTasks := make(map[string]struct{})
 
+	// Track the providers used for this task group. Currently, Nomad only
+	// allows the use of a single service provider within a task group.
+	configuredProviders := make(map[string]struct{})
+
 	// Create a map of known tasks and their services so we can compare
 	// vs the group-level services and checks
 	for _, task := range tg.Tasks {
@@ -6504,9 +6508,22 @@ func (tg *TaskGroup) validateServices() error {
 					mErr.Errors = append(mErr.Errors, fmt.Errorf("Check %s is invalid: only task group service checks can be assigned tasks", check.Name))
 				}
 			}
+
+			// Add the service provider to the tracking, if it has not already
+			// been seen.
+			if _, ok := configuredProviders[service.Provider]; !ok {
+				configuredProviders[service.Provider] = struct{}{}
+			}
 		}
 	}
 	for i, service := range tg.Services {
+
+		// Add the service provider to the tracking, if it has not already been
+		// seen.
+		if _, ok := configuredProviders[service.Provider]; !ok {
+			configuredProviders[service.Provider] = struct{}{}
+		}
+
 		if err := service.Validate(); err != nil {
 			outer := fmt.Errorf("Service[%d] %s validation failed: %s", i, service.Name, err)
 			mErr.Errors = append(mErr.Errors, outer)
@@ -6535,6 +6552,15 @@ func (tg *TaskGroup) validateServices() error {
 			}
 		}
 	}
+
+	// The initial feature release of native service discovery only allows for
+	// a single service provider to be used across all services in a task
+	// group.
+	if len(configuredProviders) > 1 {
+		mErr.Errors = append(mErr.Errors,
+			errors.New("Multiple service providers used: task group services must use the same provider"))
+	}
+
 	return mErr.ErrorOrNil()
 }
 
@@ -6946,7 +6972,7 @@ func (t *Task) Canonicalize(job *Job, tg *TaskGroup) {
 	}
 
 	for _, service := range t.Services {
-		service.Canonicalize(job.Name, tg.Name, t.Name)
+		service.Canonicalize(job.Name, tg.Name, t.Name, job.Namespace)
 	}
 
 	// If Resources are nil initialize them to defaults, otherwise canonicalize


### PR DESCRIPTION
This PR adds a new parameter to the service block named `provider`. This dictates which service registration provider to use and defaults to `consul` maintaining the current implementation default. The parameter can also be `nomad`; any other value will result in an error being returned to the user upon job registration or similar.

The validation of services now includes specific validations depending on the provider configuration parameter. The MVP also only allows a single provider to be used per task group.

closes https://github.com/hashicorp/team-nomad/issues/264