### PR TITLE
config: add native service discovery admin boolean parameter.

### DIFF
--- a/client/config/config.go
+++ b/client/config/config.go
@@ -279,6 +279,10 @@ type Config struct {
 
 	// ReservableCores if set overrides the set of reservable cores reported in fingerprinting.
 	ReservableCores []uint16
+
+	// NomadServiceDiscovery determines whether the Nomad native service
+	// discovery client functionality is enabled.
+	NomadServiceDiscovery bool
 }
 
 // ClientTemplateConfig is configuration on the client specific to template

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -704,6 +704,10 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 		conf.ReservableCores = cores.ToSlice()
 	}
 
+	if agentConfig.Client.NomadServiceDiscovery != nil {
+		conf.NomadServiceDiscovery = *agentConfig.Client.NomadServiceDiscovery
+	}
+
 	return conf, nil
 }
 

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -519,6 +519,14 @@ func TestAgent_ClientConfig(t *testing.T) {
 	if c.Node.HTTPAddr != expectedHttpAddr {
 		t.Fatalf("Expected http addr: %v, got: %v", expectedHttpAddr, c.Node.HTTPAddr)
 	}
+
+	// Test the default, and then custom setting of the client service
+	// discovery boolean.
+	require.True(t, c.NomadServiceDiscovery)
+	conf.Client.NomadServiceDiscovery = helper.BoolToPtr(false)
+	c, err = a.clientConfig()
+	require.NoError(t, err)
+	require.False(t, c.NomadServiceDiscovery)
 }
 
 func TestAgent_ClientConfig_ReservedCores(t *testing.T) {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -318,6 +318,12 @@ type ClientConfig struct {
 	// doest not exist Nomad will attempt to create it during startup. Defaults to '/nomad'
 	CgroupParent string `hcl:"cgroup_parent"`
 
+	// NomadServiceDiscovery is a boolean parameter which allows operators to
+	// enable/disable to Nomad native service discovery feature on the client.
+	// This parameter is exposed via the Nomad fingerprinter and used to ensure
+	// correct scheduling decisions on allocations which require this.
+	NomadServiceDiscovery *bool `hcl:"nomad_service_discovery"`
+
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 }
@@ -915,6 +921,7 @@ func DevConfig(mode *devModeConfig) *Config {
 		DisableSandbox:   false,
 	}
 	conf.Client.BindWildcardDefaultHostNetwork = true
+	conf.Client.NomadServiceDiscovery = helper.BoolToPtr(true)
 	conf.Telemetry.PrometheusMetrics = true
 	conf.Telemetry.PublishAllocationMetrics = true
 	conf.Telemetry.PublishNodeMetrics = true
@@ -966,6 +973,7 @@ func DefaultConfig() *Config {
 			BindWildcardDefaultHostNetwork: true,
 			CNIPath:                        "/opt/cni/bin",
 			CNIConfigDir:                   "/opt/cni/config",
+			NomadServiceDiscovery:          helper.BoolToPtr(true),
 		},
 		Server: &ServerConfig{
 			Enabled:           false,
@@ -1763,6 +1771,13 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	if b.BindWildcardDefaultHostNetwork {
 		result.BindWildcardDefaultHostNetwork = true
 	}
+
+	// This value is a pointer, therefore if it is not nil the user has
+	// supplied an override value.
+	if b.NomadServiceDiscovery != nil {
+		result.NomadServiceDiscovery = b.NomadServiceDiscovery
+	}
+
 	return &result
 }
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -126,6 +126,7 @@ func TestConfig_Merge(t *testing.T) {
 				DiskMB:        10,
 				ReservedPorts: "1,10-30,55",
 			},
+			NomadServiceDiscovery: helper.BoolToPtr(false),
 		},
 		Server: &ServerConfig{
 			Enabled:                false,
@@ -314,6 +315,7 @@ func TestConfig_Merge(t *testing.T) {
 			GCParallelDestroys:    6,
 			GCDiskUsageThreshold:  71,
 			GCInodeUsageThreshold: 86,
+			NomadServiceDiscovery: helper.BoolToPtr(false),
 		},
 		Server: &ServerConfig{
 			Enabled:                true,


### PR DESCRIPTION
This adds a boolean configuration parameter giving operators the ability to enable/disable clients from utilising the Nomad native service discovery feature.

closes https://github.com/hashicorp/team-nomad/issues/261