### PR TITLE
CSI: snapshot list pagination parameters

### DIFF
--- a/.changelog/12193.txt
+++ b/.changelog/12193.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+csi: Add pagination parameters to `volume snapshot list` command
+```

--- a/e2e/csi/ebs.go
+++ b/e2e/csi/ebs.go
@@ -176,7 +176,11 @@ func (tc *CSIControllerPluginEBSTest) TestSnapshot(f *framework.F) {
 	f.NoError(err, fmt.Sprintf("could not parse output:\n%v", out))
 	f.Len(snaps, 1, fmt.Sprintf("could not parse output:\n%v", out))
 
-	out, err = e2e.Command("nomad", "volume", "snapshot", "list", "-plugin", ebsPluginID)
+	// the snapshot we're looking for should be the first one because
+	// we just created it, but give us some breathing room to allow
+	// for concurrent test runs
+	out, err = e2e.Command("nomad", "volume", "snapshot", "list",
+		"-plugin", ebsPluginID, "-per-page", "10")
 	requireNoErrorElseDump(f, err, "could not list volume snapshots", tc.pluginJobIDs)
 	f.Contains(out, snaps[0]["ID"],
 		fmt.Sprintf("volume snapshot list did not include expected snapshot:\n%v", out))

--- a/website/content/docs/commands/volume/snapshot-list.mdx
+++ b/website/content/docs/commands/volume/snapshot-list.mdx
@@ -36,6 +36,8 @@ Nomad.
   matching plugins will be displayed.
 - `-secret`: Secrets to pass to the plugin to list snapshots. Accepts
   multiple flags in the form `-secret key=value`
+- `-per-page`: How many results to show per page.
+- `-page-token`: Where to start pagination.
 
 When ACLs are enabled, this command requires a token with the
 `csi-list-volumes` capability for the plugin's namespace.


### PR DESCRIPTION
The snapshot list API supports pagination as part of the CSI
specification, but we didn't have it plumbed through to the command
line.

This also breaks E2E testing because the output from the AWS EBS plugin
can be extremely long without pagination, bringing the time it takes to
complete the command above the test timeout.

---

This PR requires bugfixes in https://github.com/hashicorp/nomad/pull/12194 https://github.com/hashicorp/nomad/pull/12195 and https://github.com/hashicorp/nomad/pull/12197, and currently includes those commits. It'll be rebased once those get merged.