### PR TITLE
Remove changes to `evaluateNodePlan`

### DIFF
--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -655,11 +655,6 @@ func evaluateNodePlan(snap *state.StateSnapshot, plan *structs.Plan, nodeID stri
 	// the Raft commit happens.
 	if node == nil {
 		return false, "node does not exist", nil
-	} else if node.Status == structs.NodeStatusDisconnected {
-		if isValidForDisconnectedNode(plan, node.ID) {
-			return true, "", nil
-		}
-		return false, "node is disconnected and contains invalid updates", nil
 	} else if node.Status != structs.NodeStatusReady {
 		return false, "node is not ready for placements", nil
 	} else if node.SchedulingEligibility == structs.NodeSchedulingIneligible {
@@ -693,22 +688,6 @@ func evaluateNodePlan(snap *state.StateSnapshot, plan *structs.Plan, nodeID stri
 	// Check if these allocations fit
 	fit, reason, _, err := structs.AllocsFit(node, proposed, nil, true)
 	return fit, reason, err
-}
-
-// The plan is only valid for disconnected nodes if it only contains
-// updates to mark allocations as unknown.
-func isValidForDisconnectedNode(plan *structs.Plan, nodeID string) bool {
-	if len(plan.NodeUpdate[nodeID]) != 0 || len(plan.NodePreemptions[nodeID]) != 0 {
-		return false
-	}
-
-	for _, alloc := range plan.NodeAllocation[nodeID] {
-		if alloc.ClientStatus != structs.AllocClientStatusUnknown {
-			return false
-		}
-	}
-
-	return true
 }
 
 func max(a, b uint64) uint64 {


### PR DESCRIPTION
The changes from [8f2fa49](https://github.com/hashicorp/nomad/commit/8f2fa49ae0788c2e58c6b5d3a29be252a43371cd) weren't actually required as the client will request its allocations when it reconnects. 