### PR TITLE
CSI: volume snapshot list plugin option is required

### DIFF
--- a/.changelog/12197.txt
+++ b/.changelog/12197.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where `volume snapshot list` did not correctly filter by plugin IDs. The `-plugin` parameter is required.
+```

--- a/e2e/csi/ebs.go
+++ b/e2e/csi/ebs.go
@@ -176,7 +176,7 @@ func (tc *CSIControllerPluginEBSTest) TestSnapshot(f *framework.F) {
 	f.NoError(err, fmt.Sprintf("could not parse output:\n%v", out))
 	f.Len(snaps, 1, fmt.Sprintf("could not parse output:\n%v", out))
 
-	out, err = e2e.Command("nomad", "volume", "snapshot", "list")
+	out, err = e2e.Command("nomad", "volume", "snapshot", "list", "-plugin", ebsPluginID)
 	requireNoErrorElseDump(f, err, "could not list volume snapshots", tc.pluginJobIDs)
 	f.Contains(out, snaps[0]["ID"],
 		fmt.Sprintf("volume snapshot list did not include expected snapshot:\n%v", out))

--- a/website/content/docs/commands/volume/snapshot-list.mdx
+++ b/website/content/docs/commands/volume/snapshot-list.mdx
@@ -30,11 +30,10 @@ Nomad.
 ## Snapshot List Options
 
 - `-plugin`: Display only snapshots managed by a particular [CSI
-  plugin][csi_plugin]. By default the `snapshot list` command will query all
-  plugins for their snapshots. This flag accepts a plugin ID or prefix. If
-  there is an exact match based on the provided plugin, then that specific
-  plugin will be queried. Otherwise, a list of matching plugins will be
-  displayed.
+  plugin][csi_plugin]. This flag is required and accepts a plugin ID
+  or prefix. If there is an exact match based on the provided plugin,
+  then that specific plugin will be queried. Otherwise, a list of
+  matching plugins will be displayed.
 - `-secret`: Secrets to pass to the plugin to list snapshots. Accepts
   multiple flags in the form `-secret key=value`
 
@@ -54,7 +53,7 @@ snap-67890   vol-fedcba   50GiB  2021-01-04T15:45:00Z  true
 
 List volume snapshots with two secret key/value pairs:
 ```shell-session
-$ nomad volume snapshot list -secret key1=value1 -secret key2=val2
+$ nomad volume snapshot list -plugin aws-ebs0 -secret key1=value1 -secret key2=val2
 Snapshot ID  External ID  Size   Creation Time         Ready?
 snap-12345   vol-abcdef   50GiB  2021-01-03T12:15:02Z  true
 ```


### PR DESCRIPTION
The RPC for listing volume snapshots requires a plugin ID. Update the
`volume snapshot list` command to find the specific plugin from the
provided prefix.

---

Pulled out of https://github.com/hashicorp/nomad/pull/12193