### PR TITLE
disconnected clients: ensure servers meet minimum required version

### DIFF
--- a/nomad/util_test.go
+++ b/nomad/util_test.go
@@ -194,6 +194,44 @@ func TestServersMeetMinimumVersionIncludingFailed(t *testing.T) {
 	}
 }
 
+func TestServersMeetMinimumVersionSuffix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		members  []serf.Member
+		ver      *version.Version
+		expected bool
+	}{
+		// Multiple servers, meets req version
+		{
+			members: []serf.Member{
+				makeMember("1.3.0", serf.StatusAlive),
+				makeMember("1.2.6", serf.StatusAlive),
+				makeMember("1.2.6-dev", serf.StatusFailed),
+			},
+			ver:      version.Must(version.NewVersion("1.2.6-dev")),
+			expected: true,
+		},
+		// Multiple servers, doesn't meet req version
+		{
+			members: []serf.Member{
+				makeMember("1.1.18", serf.StatusAlive),
+				makeMember("1.2.6-dev", serf.StatusAlive),
+				makeMember("1.0.11", serf.StatusFailed),
+			},
+			ver:      version.Must(version.NewVersion("1.2.6-dev")),
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		result := ServersMeetMinimumVersion(tc.members, tc.ver, true)
+		if result != tc.expected {
+			t.Fatalf("bad: %v, %v, %v", result, tc.ver.String(), tc)
+		}
+	}
+}
+
 func makeMember(version string, status serf.MemberStatus) serf.Member {
 	return serf.Member{
 		Name: "foo",

--- a/nomad/worker.go
+++ b/nomad/worker.go
@@ -11,6 +11,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	log "github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -578,6 +579,13 @@ func (w *Worker) invokeScheduler(snap *state.StateSnapshot, eval *structs.Evalua
 		return fmt.Errorf("failed to process evaluation: %v", err)
 	}
 	return nil
+}
+
+// ServersMeetMinimumVersion allows implementations of the Scheduler interface in
+// other packages to perform server version checks without direct references to
+// the Nomad server.
+func (w *Worker) ServersMeetMinimumVersion(minVersion *version.Version, checkFailedServers bool) bool {
+	return ServersMeetMinimumVersion(w.srv.Members(), minVersion, checkFailedServers)
 }
 
 // SubmitPlan is used to submit a plan for consideration. This allows

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -67,6 +68,9 @@ const (
 	// that we track when unlimited rescheduling is enabled
 	maxPastRescheduleEvents = 5
 )
+
+// minVersionMaxClientDisconnect is the minimum version that supports max_client_disconnect.
+var minVersionMaxClientDisconnect = version.Must(version.NewVersion("1.2.6"))
 
 // SetStatusError is used to set the status of the evaluation to the given error
 type SetStatusError struct {
@@ -369,7 +373,9 @@ func (s *GenericScheduler) computeJobAllocs() error {
 
 	reconciler := NewAllocReconciler(s.logger,
 		genericAllocUpdateFn(s.ctx, s.stack, s.eval.ID),
-		s.batch, s.eval.JobID, s.job, s.deployment, allocs, tainted, s.eval.ID, s.eval.Priority)
+		s.batch, s.eval.JobID, s.job, s.deployment, allocs, tainted, s.eval.ID,
+		s.eval.Priority, s.planner.ServersMeetMinimumVersion(minVersionMaxClientDisconnect, true))
+
 	results := reconciler.Compute()
 	s.logger.Debug("reconciled current state with desired state", "results", log.Fmt("%#v", results))
 

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -345,7 +345,7 @@ func TestReconciler_Place_NoExisting(t *testing.T) {
 	job := mock.Job()
 	reconciler := NewAllocReconciler(
 		testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, nil, nil, "", job.Priority)
+		nil, nil, nil, "", job.Priority, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -382,7 +382,7 @@ func TestReconciler_Place_Existing(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -421,7 +421,7 @@ func TestReconciler_ScaleDown_Partial(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -461,7 +461,7 @@ func TestReconciler_ScaleDown_Zero(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -502,7 +502,7 @@ func TestReconciler_ScaleDown_Zero_DuplicateNames(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -538,7 +538,7 @@ func TestReconciler_Inplace(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnInplace, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -577,7 +577,7 @@ func TestReconciler_Inplace_ScaleUp(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnInplace, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -618,7 +618,7 @@ func TestReconciler_Inplace_ScaleDown(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnInplace, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -680,7 +680,7 @@ func TestReconciler_Inplace_Rollback(t *testing.T) {
 	}, allocUpdateFnDestructive)
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFn,
-		false, job.ID, job, nil, allocs, nil, uuid.Generate(), 50)
+		false, job.ID, job, nil, allocs, nil, uuid.Generate(), 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -724,7 +724,7 @@ func TestReconciler_Destructive(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -758,7 +758,7 @@ func TestReconciler_DestructiveMaxParallel(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -795,7 +795,7 @@ func TestReconciler_Destructive_ScaleUp(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -835,7 +835,7 @@ func TestReconciler_Destructive_ScaleDown(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -881,7 +881,7 @@ func TestReconciler_LostNode(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, tainted, "", 50)
+		nil, allocs, tainted, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -932,7 +932,7 @@ func TestReconciler_LostNode_ScaleUp(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, tainted, "", 50)
+		nil, allocs, tainted, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -983,7 +983,7 @@ func TestReconciler_LostNode_ScaleDown(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, tainted, "", 50)
+		nil, allocs, tainted, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -1029,7 +1029,7 @@ func TestReconciler_DrainNode(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, tainted, "", 50)
+		nil, allocs, tainted, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -1082,7 +1082,7 @@ func TestReconciler_DrainNode_ScaleUp(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, tainted, "", 50)
+		nil, allocs, tainted, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -1136,7 +1136,7 @@ func TestReconciler_DrainNode_ScaleDown(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, tainted, "", 50)
+		nil, allocs, tainted, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -1182,7 +1182,7 @@ func TestReconciler_RemovedTG(t *testing.T) {
 	job.TaskGroups[0].Name = newName
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -1245,7 +1245,7 @@ func TestReconciler_JobStopped(t *testing.T) {
 			}
 
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, c.jobID, c.job,
-				nil, allocs, nil, "", 50)
+				nil, allocs, nil, "", 50, false)
 			r := reconciler.Compute()
 
 			// Assert the correct results
@@ -1312,7 +1312,7 @@ func TestReconciler_JobStopped_TerminalAllocs(t *testing.T) {
 			}
 
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, c.jobID, c.job,
-				nil, allocs, nil, "", 50)
+				nil, allocs, nil, "", 50, false)
 			r := reconciler.Compute()
 			require.Len(t, r.stop, 0)
 			// Assert the correct results
@@ -1349,7 +1349,7 @@ func TestReconciler_MultiTG(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -1402,7 +1402,7 @@ func TestReconciler_MultiTG_SingleUpdateStanza(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -1479,7 +1479,7 @@ func TestReconciler_RescheduleLater_Batch(t *testing.T) {
 	allocs[5].ClientStatus = structs.AllocClientStatusComplete
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, true, job.ID, job,
-		nil, allocs, nil, uuid.Generate(), 50)
+		nil, allocs, nil, uuid.Generate(), 50, false)
 	r := reconciler.Compute()
 
 	// Two reschedule attempts were already made, one more can be made at a future time
@@ -1560,7 +1560,7 @@ func TestReconciler_RescheduleLaterWithBatchedEvals_Batch(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, true, job.ID, job,
-		nil, allocs, nil, uuid.Generate(), 50)
+		nil, allocs, nil, uuid.Generate(), 50, false)
 	r := reconciler.Compute()
 
 	// Verify that two follow up evals were created
@@ -1655,7 +1655,7 @@ func TestReconciler_RescheduleNow_Batch(t *testing.T) {
 	allocs[5].ClientStatus = structs.AllocClientStatusComplete
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, true, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	reconciler.now = now
 	r := reconciler.Compute()
 
@@ -1731,7 +1731,7 @@ func TestReconciler_RescheduleLater_Service(t *testing.T) {
 	allocs[4].DesiredStatus = structs.AllocDesiredStatusStop
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, uuid.Generate(), 50)
+		nil, allocs, nil, uuid.Generate(), 50, false)
 	r := reconciler.Compute()
 
 	// Should place a new placement and create a follow up eval for the delayed reschedule
@@ -1801,7 +1801,7 @@ func TestReconciler_Service_ClientStatusComplete(t *testing.T) {
 	allocs[4].ClientStatus = structs.AllocClientStatusComplete
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Should place a new placement for the alloc that was marked complete
@@ -1858,7 +1858,7 @@ func TestReconciler_Service_DesiredStop_ClientStatusComplete(t *testing.T) {
 	allocs[4].DesiredStatus = structs.AllocDesiredStatusStop
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Should place a new placement for the alloc that was marked stopped
@@ -1936,7 +1936,7 @@ func TestReconciler_RescheduleNow_Service(t *testing.T) {
 	allocs[4].DesiredStatus = structs.AllocDesiredStatusStop
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Verify that no follow up evals were created
@@ -2015,7 +2015,7 @@ func TestReconciler_RescheduleNow_WithinAllowedTimeWindow(t *testing.T) {
 	allocs[1].ClientStatus = structs.AllocClientStatusFailed
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	reconciler.now = now
 	r := reconciler.Compute()
 
@@ -2097,7 +2097,7 @@ func TestReconciler_RescheduleNow_EvalIDMatch(t *testing.T) {
 	allocs[1].FollowupEvalID = evalID
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, evalID, 50)
+		nil, allocs, nil, evalID, 50, false)
 	reconciler.now = now.Add(-30 * time.Second)
 	r := reconciler.Compute()
 
@@ -2207,7 +2207,7 @@ func TestReconciler_RescheduleNow_Service_WithCanaries(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job2,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Verify that no follow up evals were created
@@ -2331,7 +2331,7 @@ func TestReconciler_RescheduleNow_Service_Canaries(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job2,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	reconciler.now = now
 	r := reconciler.Compute()
 
@@ -2459,7 +2459,7 @@ func TestReconciler_RescheduleNow_Service_Canaries_Limit(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job2,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	reconciler.now = now
 	r := reconciler.Compute()
 
@@ -2525,7 +2525,7 @@ func TestReconciler_DontReschedule_PreviouslyRescheduled(t *testing.T) {
 	allocs[4].DesiredStatus = structs.AllocDesiredStatusStop
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Should place 1 - one is a new placement to make up the desired count of 5
@@ -2613,7 +2613,7 @@ func TestReconciler_CancelDeployment_JobStop(t *testing.T) {
 			}
 
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, c.jobID, c.job,
-				c.deployment, allocs, nil, "", 50)
+				c.deployment, allocs, nil, "", 50, false)
 			r := reconciler.Compute()
 
 			var updates []*structs.DeploymentStatusUpdate
@@ -2691,7 +2691,7 @@ func TestReconciler_CancelDeployment_JobUpdate(t *testing.T) {
 			}
 
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-				c.deployment, allocs, nil, "", 50)
+				c.deployment, allocs, nil, "", 50, false)
 			r := reconciler.Compute()
 
 			var updates []*structs.DeploymentStatusUpdate
@@ -2741,7 +2741,7 @@ func TestReconciler_CreateDeployment_RollingUpgrade_Destructive(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	d := structs.NewDeployment(job, 50)
@@ -2785,7 +2785,7 @@ func TestReconciler_CreateDeployment_RollingUpgrade_Inplace(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnInplace, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	d := structs.NewDeployment(job, 50)
@@ -2828,7 +2828,7 @@ func TestReconciler_CreateDeployment_NewerCreateIndex(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	d := structs.NewDeployment(job, 50)
@@ -2873,7 +2873,7 @@ func TestReconciler_DontCreateDeployment_NoChanges(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -2952,7 +2952,7 @@ func TestReconciler_PausedOrFailedDeployment_NoMoreCanaries(t *testing.T) {
 
 			mockUpdateFn := allocUpdateFnMock(map[string]allocUpdateType{canary.ID: allocUpdateFnIgnore}, allocUpdateFnDestructive)
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-				d, allocs, nil, "", 50)
+				d, allocs, nil, "", 50, false)
 			r := reconciler.Compute()
 
 			// Assert the correct results
@@ -3018,7 +3018,7 @@ func TestReconciler_PausedOrFailedDeployment_NoMorePlacements(t *testing.T) {
 			}
 
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-				d, allocs, nil, "", 50)
+				d, allocs, nil, "", 50, false)
 			r := reconciler.Compute()
 
 			// Assert the correct results
@@ -3093,7 +3093,7 @@ func TestReconciler_PausedOrFailedDeployment_NoMoreDestructiveUpdates(t *testing
 
 			mockUpdateFn := allocUpdateFnMock(map[string]allocUpdateType{newAlloc.ID: allocUpdateFnIgnore}, allocUpdateFnDestructive)
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-				d, allocs, nil, "", 50)
+				d, allocs, nil, "", 50, false)
 			r := reconciler.Compute()
 
 			// Assert the correct results
@@ -3165,7 +3165,7 @@ func TestReconciler_DrainNode_Canary(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, tainted, "", 50)
+		d, allocs, tainted, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -3238,7 +3238,7 @@ func TestReconciler_LostNode_Canary(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, tainted, "", 50)
+		d, allocs, tainted, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -3305,7 +3305,7 @@ func TestReconciler_StopOldCanaries(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job, d,
-		allocs, nil, "", 50)
+		allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	newD := structs.NewDeployment(job, 50)
@@ -3359,7 +3359,7 @@ func TestReconciler_NewCanaries(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	newD := structs.NewDeployment(job, 50)
@@ -3408,7 +3408,7 @@ func TestReconciler_NewCanaries_CountGreater(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	newD := structs.NewDeployment(job, 50)
@@ -3460,7 +3460,7 @@ func TestReconciler_NewCanaries_MultiTG(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	newD := structs.NewDeployment(job, 50)
@@ -3514,7 +3514,7 @@ func TestReconciler_NewCanaries_ScaleUp(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	newD := structs.NewDeployment(job, 50)
@@ -3563,7 +3563,7 @@ func TestReconciler_NewCanaries_ScaleDown(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	newD := structs.NewDeployment(job, 50)
@@ -3641,7 +3641,7 @@ func TestReconciler_NewCanaries_FillNames(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -3711,7 +3711,7 @@ func TestReconciler_PromoteCanaries_Unblock(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -3786,7 +3786,7 @@ func TestReconciler_PromoteCanaries_CanariesEqualCount(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	updates := []*structs.DeploymentStatusUpdate{
@@ -3886,7 +3886,7 @@ func TestReconciler_DeploymentLimit_HealthAccounting(t *testing.T) {
 
 			mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-				d, allocs, nil, "", 50)
+				d, allocs, nil, "", 50, false)
 			r := reconciler.Compute()
 
 			// Assert the correct results
@@ -3968,7 +3968,7 @@ func TestReconciler_TaintedNode_RollingUpgrade(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, tainted, "", 50)
+		d, allocs, tainted, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -4054,7 +4054,7 @@ func TestReconciler_FailedDeployment_TaintedNodes(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, tainted, "", 50)
+		d, allocs, tainted, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -4111,7 +4111,7 @@ func TestReconciler_CompleteDeployment(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -4167,7 +4167,7 @@ func TestReconciler_MarkDeploymentComplete_FailedAllocations(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID,
-		job, d, allocs, nil, "", 50)
+		job, d, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	updates := []*structs.DeploymentStatusUpdate{
@@ -4263,7 +4263,7 @@ func TestReconciler_FailedDeployment_CancelCanaries(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -4333,7 +4333,7 @@ func TestReconciler_FailedDeployment_NewJob(t *testing.T) {
 	jobNew.Version += 100
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, jobNew,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	dnew := structs.NewDeployment(jobNew, 50)
@@ -4387,7 +4387,7 @@ func TestReconciler_MarkDeploymentComplete(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	updates := []*structs.DeploymentStatusUpdate{
@@ -4457,7 +4457,7 @@ func TestReconciler_JobChange_ScaleUp_SecondEval(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -4493,7 +4493,7 @@ func TestReconciler_RollingUpgrade_MissingAllocs(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	d := structs.NewDeployment(job, 50)
@@ -4546,7 +4546,7 @@ func TestReconciler_Batch_Rerun(t *testing.T) {
 	job2.CreateIndex++
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, true, job2.ID, job2,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -4608,7 +4608,7 @@ func TestReconciler_FailedDeployment_DontReschedule(t *testing.T) {
 		FinishedAt: now.Add(-10 * time.Second)}}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert that no rescheduled placements were created
@@ -4664,7 +4664,7 @@ func TestReconciler_DeploymentWithFailedAllocs_DontReschedule(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert that no rescheduled placements were created
@@ -4750,7 +4750,7 @@ func TestReconciler_FailedDeployment_AutoRevert_CancelCanaries(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, jobv2,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	updates := []*structs.DeploymentStatusUpdate{
@@ -4813,7 +4813,7 @@ func TestReconciler_SuccessfulDeploymentWithFailedAllocs_Reschedule(t *testing.T
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		d, allocs, nil, "", 50)
+		d, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Assert that rescheduled placements were created
@@ -4878,7 +4878,7 @@ func TestReconciler_ForceReschedule_Service(t *testing.T) {
 	allocs[0].DesiredTransition = structs.DesiredTransition{ForceReschedule: helper.BoolToPtr(true)}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Verify that no follow up evals were created
@@ -4961,7 +4961,7 @@ func TestReconciler_RescheduleNot_Service(t *testing.T) {
 	allocs[4].DesiredStatus = structs.AllocDesiredStatusStop
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	r := reconciler.Compute()
 
 	// Verify that no follow up evals were created
@@ -5047,7 +5047,7 @@ func TestReconciler_RescheduleNot_Batch(t *testing.T) {
 	allocs[5].ClientStatus = structs.AllocClientStatusComplete
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, true, job.ID, job,
-		nil, allocs, nil, "", 50)
+		nil, allocs, nil, "", 50, false)
 	reconciler.now = now
 	r := reconciler.Compute()
 
@@ -5079,7 +5079,7 @@ func TestReconciler_Node_Disconnect_Updates_Alloc_To_Unknown(t *testing.T) {
 	nodes := buildDisconnectedNodes(allocs, 2)
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nodes, "", 50)
+		nil, allocs, nodes, "", 50, true)
 	reconciler.now = time.Now().UTC()
 	results := reconciler.Compute()
 
@@ -5143,7 +5143,7 @@ func TestReconciler_Node_Reconnect_ScaleIn_And_Reconnect_Unknown(t *testing.T) {
 	// allocUpdateFnIgnore, because computeUpdates in a real setting should return
 	// ignore == true for the 1 remaining untainted update after computeStop
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, append(allocs, scaleInAllocs...), nil, "", 50)
+		nil, append(allocs, scaleInAllocs...), nil, "", 50, true)
 	reconciler.now = time.Now().UTC()
 	results := reconciler.Compute()
 
@@ -5200,7 +5200,7 @@ func TestReconciler_Disconnected_Node_FollowUpEvals_Stop_After_Timeout(t *testin
 	// Use the allocUpdateFnIngore since alloc.TerminalStatus() will evaluate to
 	// false and  cause the real genericAllocUpdateFn to return ignore=true destructive=false
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nodes, "", 50)
+		nil, allocs, nodes, "", 50, true)
 	reconciler.now = time.Now().UTC()
 	results := reconciler.Compute()
 
@@ -5228,7 +5228,7 @@ func TestReconciler_Disconnected_Node_FollowUpEvals_Stop_After_Timeout(t *testin
 	// Run the followup eval through the reconciler and verify the resumable allocs
 	// have timed out, will be stopped, and new placements are scheduled.
 	reconciler = NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nodes, eval.ID, eval.Priority)
+		nil, allocs, nodes, eval.ID, eval.Priority, false)
 
 	// Allocs were configured to expire in 5 min, so configure the reconciler
 	// to believe that time has passed.
@@ -5275,12 +5275,12 @@ func TestReconciler_Compute_Disconnecting(t *testing.T) {
 	nodes := buildDisconnectedNodes(allocs, 2)
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nodes, "", 50)
+		nil, allocs, nodes, "", 50, true)
 	reconciler.now = time.Now().UTC()
 
 	tgName := allocs[0].TaskGroup
 	matrix := newAllocMatrix(job, allocs)
-	_, _, _, reconnecting, _ := matrix[tgName].filterByTainted(nodes)
+	_, _, _, reconnecting, _ := matrix[tgName].filterByTainted(nodes, reconciler.supportsDisconnectedClients)
 	require.NotNil(t, reconnecting)
 	require.Len(t, reconnecting, 2)
 

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -345,7 +345,7 @@ func TestReconciler_Place_NoExisting(t *testing.T) {
 	job := mock.Job()
 	reconciler := NewAllocReconciler(
 		testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, nil, nil, "", job.Priority, false)
+		nil, nil, nil, "", job.Priority, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -382,7 +382,7 @@ func TestReconciler_Place_Existing(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -421,7 +421,7 @@ func TestReconciler_ScaleDown_Partial(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -461,7 +461,7 @@ func TestReconciler_ScaleDown_Zero(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -502,7 +502,7 @@ func TestReconciler_ScaleDown_Zero_DuplicateNames(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -538,7 +538,7 @@ func TestReconciler_Inplace(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnInplace, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -577,7 +577,7 @@ func TestReconciler_Inplace_ScaleUp(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnInplace, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -618,7 +618,7 @@ func TestReconciler_Inplace_ScaleDown(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnInplace, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -680,7 +680,7 @@ func TestReconciler_Inplace_Rollback(t *testing.T) {
 	}, allocUpdateFnDestructive)
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFn,
-		false, job.ID, job, nil, allocs, nil, uuid.Generate(), 50, false)
+		false, job.ID, job, nil, allocs, nil, uuid.Generate(), 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -724,7 +724,7 @@ func TestReconciler_Destructive(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -758,7 +758,7 @@ func TestReconciler_DestructiveMaxParallel(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -795,7 +795,7 @@ func TestReconciler_Destructive_ScaleUp(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -835,7 +835,7 @@ func TestReconciler_Destructive_ScaleDown(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -881,7 +881,7 @@ func TestReconciler_LostNode(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, tainted, "", 50, false)
+		nil, allocs, tainted, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -932,7 +932,7 @@ func TestReconciler_LostNode_ScaleUp(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, tainted, "", 50, false)
+		nil, allocs, tainted, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -983,7 +983,7 @@ func TestReconciler_LostNode_ScaleDown(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, tainted, "", 50, false)
+		nil, allocs, tainted, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -1029,7 +1029,7 @@ func TestReconciler_DrainNode(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, tainted, "", 50, false)
+		nil, allocs, tainted, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -1082,7 +1082,7 @@ func TestReconciler_DrainNode_ScaleUp(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, tainted, "", 50, false)
+		nil, allocs, tainted, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -1136,7 +1136,7 @@ func TestReconciler_DrainNode_ScaleDown(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, tainted, "", 50, false)
+		nil, allocs, tainted, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -1182,7 +1182,7 @@ func TestReconciler_RemovedTG(t *testing.T) {
 	job.TaskGroups[0].Name = newName
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -1245,7 +1245,7 @@ func TestReconciler_JobStopped(t *testing.T) {
 			}
 
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, c.jobID, c.job,
-				nil, allocs, nil, "", 50, false)
+				nil, allocs, nil, "", 50, true)
 			r := reconciler.Compute()
 
 			// Assert the correct results
@@ -1312,7 +1312,7 @@ func TestReconciler_JobStopped_TerminalAllocs(t *testing.T) {
 			}
 
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, c.jobID, c.job,
-				nil, allocs, nil, "", 50, false)
+				nil, allocs, nil, "", 50, true)
 			r := reconciler.Compute()
 			require.Len(t, r.stop, 0)
 			// Assert the correct results
@@ -1349,7 +1349,7 @@ func TestReconciler_MultiTG(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -1402,7 +1402,7 @@ func TestReconciler_MultiTG_SingleUpdateStanza(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -1479,7 +1479,7 @@ func TestReconciler_RescheduleLater_Batch(t *testing.T) {
 	allocs[5].ClientStatus = structs.AllocClientStatusComplete
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, true, job.ID, job,
-		nil, allocs, nil, uuid.Generate(), 50, false)
+		nil, allocs, nil, uuid.Generate(), 50, true)
 	r := reconciler.Compute()
 
 	// Two reschedule attempts were already made, one more can be made at a future time
@@ -1560,7 +1560,7 @@ func TestReconciler_RescheduleLaterWithBatchedEvals_Batch(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, true, job.ID, job,
-		nil, allocs, nil, uuid.Generate(), 50, false)
+		nil, allocs, nil, uuid.Generate(), 50, true)
 	r := reconciler.Compute()
 
 	// Verify that two follow up evals were created
@@ -1655,7 +1655,7 @@ func TestReconciler_RescheduleNow_Batch(t *testing.T) {
 	allocs[5].ClientStatus = structs.AllocClientStatusComplete
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, true, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	reconciler.now = now
 	r := reconciler.Compute()
 
@@ -1731,7 +1731,7 @@ func TestReconciler_RescheduleLater_Service(t *testing.T) {
 	allocs[4].DesiredStatus = structs.AllocDesiredStatusStop
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, uuid.Generate(), 50, false)
+		nil, allocs, nil, uuid.Generate(), 50, true)
 	r := reconciler.Compute()
 
 	// Should place a new placement and create a follow up eval for the delayed reschedule
@@ -1801,7 +1801,7 @@ func TestReconciler_Service_ClientStatusComplete(t *testing.T) {
 	allocs[4].ClientStatus = structs.AllocClientStatusComplete
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Should place a new placement for the alloc that was marked complete
@@ -1858,7 +1858,7 @@ func TestReconciler_Service_DesiredStop_ClientStatusComplete(t *testing.T) {
 	allocs[4].DesiredStatus = structs.AllocDesiredStatusStop
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Should place a new placement for the alloc that was marked stopped
@@ -1936,7 +1936,7 @@ func TestReconciler_RescheduleNow_Service(t *testing.T) {
 	allocs[4].DesiredStatus = structs.AllocDesiredStatusStop
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Verify that no follow up evals were created
@@ -2015,7 +2015,7 @@ func TestReconciler_RescheduleNow_WithinAllowedTimeWindow(t *testing.T) {
 	allocs[1].ClientStatus = structs.AllocClientStatusFailed
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	reconciler.now = now
 	r := reconciler.Compute()
 
@@ -2097,7 +2097,7 @@ func TestReconciler_RescheduleNow_EvalIDMatch(t *testing.T) {
 	allocs[1].FollowupEvalID = evalID
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, evalID, 50, false)
+		nil, allocs, nil, evalID, 50, true)
 	reconciler.now = now.Add(-30 * time.Second)
 	r := reconciler.Compute()
 
@@ -2207,7 +2207,7 @@ func TestReconciler_RescheduleNow_Service_WithCanaries(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job2,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Verify that no follow up evals were created
@@ -2331,7 +2331,7 @@ func TestReconciler_RescheduleNow_Service_Canaries(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job2,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	reconciler.now = now
 	r := reconciler.Compute()
 
@@ -2459,7 +2459,7 @@ func TestReconciler_RescheduleNow_Service_Canaries_Limit(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job2,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	reconciler.now = now
 	r := reconciler.Compute()
 
@@ -2525,7 +2525,7 @@ func TestReconciler_DontReschedule_PreviouslyRescheduled(t *testing.T) {
 	allocs[4].DesiredStatus = structs.AllocDesiredStatusStop
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Should place 1 - one is a new placement to make up the desired count of 5
@@ -2613,7 +2613,7 @@ func TestReconciler_CancelDeployment_JobStop(t *testing.T) {
 			}
 
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, c.jobID, c.job,
-				c.deployment, allocs, nil, "", 50, false)
+				c.deployment, allocs, nil, "", 50, true)
 			r := reconciler.Compute()
 
 			var updates []*structs.DeploymentStatusUpdate
@@ -2691,7 +2691,7 @@ func TestReconciler_CancelDeployment_JobUpdate(t *testing.T) {
 			}
 
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-				c.deployment, allocs, nil, "", 50, false)
+				c.deployment, allocs, nil, "", 50, true)
 			r := reconciler.Compute()
 
 			var updates []*structs.DeploymentStatusUpdate
@@ -2741,7 +2741,7 @@ func TestReconciler_CreateDeployment_RollingUpgrade_Destructive(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	d := structs.NewDeployment(job, 50)
@@ -2785,7 +2785,7 @@ func TestReconciler_CreateDeployment_RollingUpgrade_Inplace(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnInplace, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	d := structs.NewDeployment(job, 50)
@@ -2828,7 +2828,7 @@ func TestReconciler_CreateDeployment_NewerCreateIndex(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	d := structs.NewDeployment(job, 50)
@@ -2873,7 +2873,7 @@ func TestReconciler_DontCreateDeployment_NoChanges(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -2952,7 +2952,7 @@ func TestReconciler_PausedOrFailedDeployment_NoMoreCanaries(t *testing.T) {
 
 			mockUpdateFn := allocUpdateFnMock(map[string]allocUpdateType{canary.ID: allocUpdateFnIgnore}, allocUpdateFnDestructive)
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-				d, allocs, nil, "", 50, false)
+				d, allocs, nil, "", 50, true)
 			r := reconciler.Compute()
 
 			// Assert the correct results
@@ -3018,7 +3018,7 @@ func TestReconciler_PausedOrFailedDeployment_NoMorePlacements(t *testing.T) {
 			}
 
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-				d, allocs, nil, "", 50, false)
+				d, allocs, nil, "", 50, true)
 			r := reconciler.Compute()
 
 			// Assert the correct results
@@ -3093,7 +3093,7 @@ func TestReconciler_PausedOrFailedDeployment_NoMoreDestructiveUpdates(t *testing
 
 			mockUpdateFn := allocUpdateFnMock(map[string]allocUpdateType{newAlloc.ID: allocUpdateFnIgnore}, allocUpdateFnDestructive)
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-				d, allocs, nil, "", 50, false)
+				d, allocs, nil, "", 50, true)
 			r := reconciler.Compute()
 
 			// Assert the correct results
@@ -3165,7 +3165,7 @@ func TestReconciler_DrainNode_Canary(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, tainted, "", 50, false)
+		d, allocs, tainted, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -3238,7 +3238,7 @@ func TestReconciler_LostNode_Canary(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, tainted, "", 50, false)
+		d, allocs, tainted, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -3305,7 +3305,7 @@ func TestReconciler_StopOldCanaries(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job, d,
-		allocs, nil, "", 50, false)
+		allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	newD := structs.NewDeployment(job, 50)
@@ -3359,7 +3359,7 @@ func TestReconciler_NewCanaries(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	newD := structs.NewDeployment(job, 50)
@@ -3408,7 +3408,7 @@ func TestReconciler_NewCanaries_CountGreater(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	newD := structs.NewDeployment(job, 50)
@@ -3460,7 +3460,7 @@ func TestReconciler_NewCanaries_MultiTG(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	newD := structs.NewDeployment(job, 50)
@@ -3514,7 +3514,7 @@ func TestReconciler_NewCanaries_ScaleUp(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	newD := structs.NewDeployment(job, 50)
@@ -3563,7 +3563,7 @@ func TestReconciler_NewCanaries_ScaleDown(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	newD := structs.NewDeployment(job, 50)
@@ -3641,7 +3641,7 @@ func TestReconciler_NewCanaries_FillNames(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -3711,7 +3711,7 @@ func TestReconciler_PromoteCanaries_Unblock(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -3786,7 +3786,7 @@ func TestReconciler_PromoteCanaries_CanariesEqualCount(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	updates := []*structs.DeploymentStatusUpdate{
@@ -3886,7 +3886,7 @@ func TestReconciler_DeploymentLimit_HealthAccounting(t *testing.T) {
 
 			mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 			reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-				d, allocs, nil, "", 50, false)
+				d, allocs, nil, "", 50, true)
 			r := reconciler.Compute()
 
 			// Assert the correct results
@@ -3968,7 +3968,7 @@ func TestReconciler_TaintedNode_RollingUpgrade(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, tainted, "", 50, false)
+		d, allocs, tainted, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -4054,7 +4054,7 @@ func TestReconciler_FailedDeployment_TaintedNodes(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, tainted, "", 50, false)
+		d, allocs, tainted, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -4111,7 +4111,7 @@ func TestReconciler_CompleteDeployment(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -4167,7 +4167,7 @@ func TestReconciler_MarkDeploymentComplete_FailedAllocations(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID,
-		job, d, allocs, nil, "", 50, false)
+		job, d, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	updates := []*structs.DeploymentStatusUpdate{
@@ -4263,7 +4263,7 @@ func TestReconciler_FailedDeployment_CancelCanaries(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -4333,7 +4333,7 @@ func TestReconciler_FailedDeployment_NewJob(t *testing.T) {
 	jobNew.Version += 100
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, jobNew,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	dnew := structs.NewDeployment(jobNew, 50)
@@ -4387,7 +4387,7 @@ func TestReconciler_MarkDeploymentComplete(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	updates := []*structs.DeploymentStatusUpdate{
@@ -4457,7 +4457,7 @@ func TestReconciler_JobChange_ScaleUp_SecondEval(t *testing.T) {
 
 	mockUpdateFn := allocUpdateFnMock(handled, allocUpdateFnDestructive)
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), mockUpdateFn, false, job.ID, job,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -4493,7 +4493,7 @@ func TestReconciler_RollingUpgrade_MissingAllocs(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	d := structs.NewDeployment(job, 50)
@@ -4546,7 +4546,7 @@ func TestReconciler_Batch_Rerun(t *testing.T) {
 	job2.CreateIndex++
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, true, job2.ID, job2,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert the correct results
@@ -4608,7 +4608,7 @@ func TestReconciler_FailedDeployment_DontReschedule(t *testing.T) {
 		FinishedAt: now.Add(-10 * time.Second)}}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert that no rescheduled placements were created
@@ -4664,7 +4664,7 @@ func TestReconciler_DeploymentWithFailedAllocs_DontReschedule(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert that no rescheduled placements were created
@@ -4750,7 +4750,7 @@ func TestReconciler_FailedDeployment_AutoRevert_CancelCanaries(t *testing.T) {
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, jobv2,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	updates := []*structs.DeploymentStatusUpdate{
@@ -4813,7 +4813,7 @@ func TestReconciler_SuccessfulDeploymentWithFailedAllocs_Reschedule(t *testing.T
 	}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnDestructive, false, job.ID, job,
-		d, allocs, nil, "", 50, false)
+		d, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Assert that rescheduled placements were created
@@ -4878,7 +4878,7 @@ func TestReconciler_ForceReschedule_Service(t *testing.T) {
 	allocs[0].DesiredTransition = structs.DesiredTransition{ForceReschedule: helper.BoolToPtr(true)}
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Verify that no follow up evals were created
@@ -4961,7 +4961,7 @@ func TestReconciler_RescheduleNot_Service(t *testing.T) {
 	allocs[4].DesiredStatus = structs.AllocDesiredStatusStop
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	r := reconciler.Compute()
 
 	// Verify that no follow up evals were created
@@ -5047,7 +5047,7 @@ func TestReconciler_RescheduleNot_Batch(t *testing.T) {
 	allocs[5].ClientStatus = structs.AllocClientStatusComplete
 
 	reconciler := NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, true, job.ID, job,
-		nil, allocs, nil, "", 50, false)
+		nil, allocs, nil, "", 50, true)
 	reconciler.now = now
 	r := reconciler.Compute()
 
@@ -5228,7 +5228,7 @@ func TestReconciler_Disconnected_Node_FollowUpEvals_Stop_After_Timeout(t *testin
 	// Run the followup eval through the reconciler and verify the resumable allocs
 	// have timed out, will be stopped, and new placements are scheduled.
 	reconciler = NewAllocReconciler(testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
-		nil, allocs, nodes, eval.ID, eval.Priority, false)
+		nil, allocs, nodes, eval.ID, eval.Priority, true)
 
 	// Allocs were configured to expire in 5 min, so configure the reconciler
 	// to believe that time has passed.

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -219,11 +219,8 @@ func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node, support
 	untainted = make(map[string]*structs.Allocation)
 	migrate = make(map[string]*structs.Allocation)
 	lost = make(map[string]*structs.Allocation)
-
-	if supportsDisconnectedClients {
-		disconnecting = make(map[string]*structs.Allocation)
-		reconnecting = make(map[string]*structs.Allocation)
-	}
+	disconnecting = make(map[string]*structs.Allocation)
+	reconnecting = make(map[string]*structs.Allocation)
 
 	for _, alloc := range a {
 		// Terminal allocs are always untainted as they should never be migrated

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -215,12 +215,15 @@ func (a allocSet) fromKeys(keys ...[]string) allocSet {
 // 3. Those that exist on lost nodes
 // 4. Those that are on nodes that are disconnected, but have not had their ClientState set to unknown
 // 5. Those that have had their ClientState set to unknown, but their node has reconnected.
-func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node) (untainted, migrate, lost, disconnecting, reconnecting allocSet) {
+func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node, supportsDisconnectedClients bool) (untainted, migrate, lost, disconnecting, reconnecting allocSet) {
 	untainted = make(map[string]*structs.Allocation)
 	migrate = make(map[string]*structs.Allocation)
 	lost = make(map[string]*structs.Allocation)
-	disconnecting = make(map[string]*structs.Allocation)
-	reconnecting = make(map[string]*structs.Allocation)
+
+	if supportsDisconnectedClients {
+		disconnecting = make(map[string]*structs.Allocation)
+		reconnecting = make(map[string]*structs.Allocation)
+	}
 
 	for _, alloc := range a {
 		// Terminal allocs are always untainted as they should never be migrated
@@ -238,7 +241,7 @@ func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node) (untain
 		taintedNode, ok := taintedNodes[alloc.NodeID]
 		if !ok {
 			// Filter allocs on a node that is now re-connected to be resumed.
-			if alloc.ClientStatus == structs.AllocClientStatusUnknown {
+			if supportsDisconnectedClients && alloc.ClientStatus == structs.AllocClientStatusUnknown {
 				reconnecting[alloc.ID] = alloc
 				continue
 			}
@@ -253,7 +256,7 @@ func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node) (untain
 			switch taintedNode.Status {
 			case structs.NodeStatusDisconnected:
 				// Filter running allocs on a node that is disconnected to be marked as unknown.
-				if alloc.ClientStatus == structs.AllocClientStatusRunning {
+				if supportsDisconnectedClients && alloc.ClientStatus == structs.AllocClientStatusRunning {
 					disconnecting[alloc.ID] = alloc
 					continue
 				}
@@ -264,7 +267,7 @@ func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node) (untain
 				}
 			case structs.NodeStatusReady:
 				// Filter unknown allocs on a node that is connected to reconnect.
-				if alloc.ClientStatus == structs.AllocClientStatusUnknown {
+				if supportsDisconnectedClients && alloc.ClientStatus == structs.AllocClientStatusUnknown {
 					reconnecting[alloc.ID] = alloc
 					continue
 				}

--- a/scheduler/reconcile_util_test.go
+++ b/scheduler/reconcile_util_test.go
@@ -195,7 +195,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 		},
 	}
 
-	untainted, migrate, lost, disconnecting, reconnecting := allocs.filterByTainted(nodes)
+	untainted, migrate, lost, disconnecting, reconnecting := allocs.filterByTainted(nodes, true)
 	require.Len(t, untainted, 10)
 	require.Contains(t, untainted, "untainted1")
 	require.Contains(t, untainted, "untainted2")

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -6,6 +6,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -132,4 +133,9 @@ type Planner interface {
 	// evaluation must exist in a blocked state prior to this being called such
 	// that on leader changes, the evaluation will be reblocked properly.
 	ReblockEval(*structs.Evaluation) error
+
+	// ServersMeetMinimumVersion returns whether the Nomad servers are at least on the
+	// given Nomad version. The checkFailedServers parameter specifies whether version
+	// for the failed servers should be verified.
+	ServersMeetMinimumVersion(minVersion *version.Version, checkFailedServers bool) bool
 }

--- a/scheduler/testing.go
+++ b/scheduler/testing.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -55,16 +56,18 @@ type Harness struct {
 	nextIndex     uint64
 	nextIndexLock sync.Mutex
 
-	optimizePlan bool
+	optimizePlan              bool
+	serversMeetMinimumVersion bool
 }
 
 // NewHarness is used to make a new testing harness
 func NewHarness(t testing.TB) *Harness {
 	state := state.TestStateStore(t)
 	h := &Harness{
-		t:         t,
-		State:     state,
-		nextIndex: 1,
+		t:                         t,
+		State:                     state,
+		nextIndex:                 1,
+		serversMeetMinimumVersion: true,
 	}
 	return h
 }
@@ -241,6 +244,10 @@ func (h *Harness) ReblockEval(eval *structs.Evaluation) error {
 
 	h.ReblockEvals = append(h.ReblockEvals, eval)
 	return nil
+}
+
+func (h *Harness) ServersMeetMinimumVersion(_ *version.Version, _ bool) bool {
+	return h.serversMeetMinimumVersion
 }
 
 // NextIndex returns the next index

--- a/scheduler/testing.go
+++ b/scheduler/testing.go
@@ -20,6 +20,10 @@ type RejectPlan struct {
 	Harness *Harness
 }
 
+func (r *RejectPlan) ServersMeetMinimumVersion(minVersion *version.Version, checkFailedServers bool) bool {
+	return r.Harness.serversMeetMinimumVersion
+}
+
 func (r *RejectPlan) SubmitPlan(*structs.Plan) (*structs.PlanResult, State, error) {
 	result := new(structs.PlanResult)
 	result.RefreshIndex = r.Harness.NextIndex()


### PR DESCRIPTION
**Note for Reviewer**: This is a pragmatic compromise that might need discussion. 
- The `CoreScheduler` has a direct reference to the `nomad.Server` and thus its members and is responsible for 
  performing server version checks for core jobs.
- Initially, I tried exposing this functionality via the `Scheduler` interface, however, the `GenericScheduler` cannot have a 
  direct reference to the `nomad.Server` because it is in the `scheduler` package and that creates an import cycle.
- The `Worker` fulfills the `Planner` interface, is made available to the `GenericScheduler` by that interface, and also 
  has a reference to the `nomad.Server`. So the `Planner` interface was extended instead.

## Overview 
This PR contains the logic necessary to ensure clusters running mixed version servers do not enable the `max_client_disconnect` feature until all servers meet the minimum required version. 
- [bf71504](https://github.com/hashicorp/nomad/pull/12202/commits/bf71504d0158d622059f506e88974e412f5843bc)
  - Exposes the `ServersMeetMinimumVersion` utility function via the `Planner` interface. 
- [6e60a2c](https://github.com/hashicorp/nomad/pull/12202/commits/6e60a2c9285d1c47788fcc3285e3596345297732) 
  - Modifies `filterByTained` to include a boolean flag indicating whether the caller supports disconnected clients. 
  - If not, the `disconnected` and `reconnecting` `allocSet`s are never populated.
  - Effectively short-circuits disconnect/reconnect logic from ever triggering in the `reconciler`.  
- [b41401b](https://github.com/hashicorp/nomad/pull/12202/commits/b41401b4fece2d94e63b608da20658672a8f542f) 
  - Adds the version check logic in the `GenericScheduler`
  - Adds a field to the `allocReconciler`.
  - Modifies`NewAllocReconciler` to accept a parameter to set the field.
  - Plumbs it through to all calls to`filterByTainted`. 
- [cfc5f49](https://github.com/hashicorp/nomad/pull/12202/commits/cfc5f49c071524ecc1c901506b25678904d3b644)
  - Updates affected/dependent tests
 