### PR TITLE
docs: add note about docker DNS config when using bridge mode

### DIFF
--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -100,13 +100,21 @@ config {
 }
 ```
 
-- `dns_search_domains` - (Optional) A list of DNS search domains for the container
-  to use.
+- `dns_search_domains` - (Optional) A list of DNS search domains for
+  the container to use. If you are using bridge networking mode with a
+  `network` block in the task group, you must set all DNS options in
+  the `network.dns` block instead.
 
-- `dns_options` - (Optional) A list of DNS options for the container to use.
+- `dns_options` - (Optional) A list of DNS options for the container
+  to use. If you are using bridge networking mode with a `network`
+  block in the task group, you must set all DNS options in the
+  `network.dns` block instead.
 
-- `dns_servers` - (Optional) A list of DNS servers for the container to use
-  (e.g. ["8.8.8.8", "8.8.4.4"]). Requires Docker v1.10 or greater.
+- `dns_servers` - (Optional) A list of DNS servers for the container
+  to use (e.g. ["8.8.8.8", "8.8.4.4"]). Requires Docker v1.10 or
+  greater. If you are using bridge networking mode with a `network`
+  block in the task group, you must set all DNS options in the
+  `network.dns` block instead.
 
 - `entrypoint` - (Optional) A string list overriding the image's entrypoint.
 
@@ -257,7 +265,8 @@ config {
   the group `network.mode = "bridge"` you should not set the Docker config
   `network_mode`, or the container will be unable to reach other containers in
   the task group. This will also prevent [Connect]-enabled tasks from reaching
-  the Envoy sidecar proxy.
+  the Envoy sidecar proxy. You must also set any DNS options in the `network.dns`
+  block and not in the task configuration.
 
   If you are in the process of migrating from the default Docker network to
   group-wide bridge networking, you may encounter issues preventing your


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11857 https://github.com/hashicorp/nomad/issues/11239

The Docker DNS configuration options are not compatible with a
group-level network in `bridge` mode. Warn users about this in the
Docker task configuration docs.