### PR TITLE
api: apply consistent behaviour of the reverse query parameter

### DIFF
--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -665,12 +665,12 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 			var opts paginator.StructsTokenizerOptions
 
 			if prefix := args.QueryOptions.Prefix; prefix != "" {
-				iter, err = state.ACLTokenByAccessorIDPrefix(ws, prefix)
+				iter, err = state.ACLTokenByAccessorIDPrefix(ws, prefix, sort)
 				opts = paginator.StructsTokenizerOptions{
 					WithID: true,
 				}
 			} else if args.GlobalOnly {
-				iter, err = state.ACLTokensByGlobal(ws, true)
+				iter, err = state.ACLTokensByGlobal(ws, true, sort)
 				opts = paginator.StructsTokenizerOptions{
 					WithID: true,
 				}

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -80,7 +80,7 @@ func (a *Alloc) List(args *structs.AllocListRequest, reply *structs.AllocListRes
 				return err
 			} else {
 				if prefix := args.QueryOptions.Prefix; prefix != "" {
-					iter, err = state.AllocsByIDPrefix(ws, namespace, prefix)
+					iter, err = state.AllocsByIDPrefix(ws, namespace, prefix, sort)
 					opts = paginator.StructsTokenizerOptions{
 						WithID: true,
 					}

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -414,7 +414,7 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 			var opts paginator.StructsTokenizerOptions
 
 			if prefix := args.QueryOptions.Prefix; prefix != "" {
-				iter, err = store.DeploymentsByIDPrefix(ws, namespace, prefix)
+				iter, err = store.DeploymentsByIDPrefix(ws, namespace, prefix, sort)
 				opts = paginator.StructsTokenizerOptions{
 					WithID: true,
 				}

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -419,7 +419,7 @@ func (e *Eval) List(args *structs.EvalListRequest, reply *structs.EvalListRespon
 			var opts paginator.StructsTokenizerOptions
 
 			if prefix := args.QueryOptions.Prefix; prefix != "" {
-				iter, err = store.EvalsByIDPrefix(ws, namespace, prefix)
+				iter, err = store.EvalsByIDPrefix(ws, namespace, prefix, sort)
 				opts = paginator.StructsTokenizerOptions{
 					WithID: true,
 				}

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -1524,13 +1524,13 @@ ERR_WAIT:
 // diffACLTokens is used to perform a two-way diff between the local
 // tokens and the remote tokens to determine which tokens need to
 // be deleted or updated.
-func diffACLTokens(state *state.StateStore, minIndex uint64, remoteList []*structs.ACLTokenListStub) (delete []string, update []string) {
+func diffACLTokens(store *state.StateStore, minIndex uint64, remoteList []*structs.ACLTokenListStub) (delete []string, update []string) {
 	// Construct a set of the local and remote policies
 	local := make(map[string][]byte)
 	remote := make(map[string]struct{})
 
 	// Add all the local global tokens
-	iter, err := state.ACLTokensByGlobal(nil, true)
+	iter, err := store.ACLTokensByGlobal(nil, true, state.SortDefault)
 	if err != nil {
 		panic("failed to iterate local tokens")
 	}

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -2063,11 +2063,11 @@ func TestClientEndpoint_GetClientAllocs_Blocking(t *testing.T) {
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
 	alloc.ModifyTime = now
-	state := s1.fsm.State()
-	state.UpsertJobSummary(99, mock.JobSummary(alloc.JobID))
+	store := s1.fsm.State()
+	store.UpsertJobSummary(99, mock.JobSummary(alloc.JobID))
 	start := time.Now()
 	time.AfterFunc(100*time.Millisecond, func() {
-		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc})
+		err := store.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -2101,7 +2101,7 @@ func TestClientEndpoint_GetClientAllocs_Blocking(t *testing.T) {
 		t.Fatalf("bad: %#v", resp2.Allocs)
 	}
 
-	iter, err := state.AllocsByIDPrefix(nil, structs.DefaultNamespace, alloc.ID)
+	iter, err := store.AllocsByIDPrefix(nil, structs.DefaultNamespace, alloc.ID, state.SortDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2133,8 +2133,8 @@ func TestClientEndpoint_GetClientAllocs_Blocking(t *testing.T) {
 		allocUpdate.NodeID = alloc.NodeID
 		allocUpdate.ID = alloc.ID
 		allocUpdate.ClientStatus = structs.AllocClientStatusRunning
-		state.UpsertJobSummary(199, mock.JobSummary(allocUpdate.JobID))
-		err := state.UpsertAllocs(structs.MsgTypeTestSetup, 200, []*structs.Allocation{allocUpdate})
+		store.UpsertJobSummary(199, mock.JobSummary(allocUpdate.JobID))
+		err := store.UpsertAllocs(structs.MsgTypeTestSetup, 200, []*structs.Allocation{allocUpdate})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/nomad/search_endpoint.go
+++ b/nomad/search_endpoint.go
@@ -355,26 +355,26 @@ func sortSet(matches []fuzzyMatch) {
 
 // getResourceIter takes a context and returns a memdb iterator specific to
 // that context
-func getResourceIter(context structs.Context, aclObj *acl.ACL, namespace, prefix string, ws memdb.WatchSet, state *state.StateStore) (memdb.ResultIterator, error) {
+func getResourceIter(context structs.Context, aclObj *acl.ACL, namespace, prefix string, ws memdb.WatchSet, store *state.StateStore) (memdb.ResultIterator, error) {
 	switch context {
 	case structs.Jobs:
-		return state.JobsByIDPrefix(ws, namespace, prefix)
+		return store.JobsByIDPrefix(ws, namespace, prefix)
 	case structs.Evals:
-		return state.EvalsByIDPrefix(ws, namespace, prefix)
+		return store.EvalsByIDPrefix(ws, namespace, prefix, state.SortDefault)
 	case structs.Allocs:
-		return state.AllocsByIDPrefix(ws, namespace, prefix)
+		return store.AllocsByIDPrefix(ws, namespace, prefix)
 	case structs.Nodes:
-		return state.NodesByIDPrefix(ws, prefix)
+		return store.NodesByIDPrefix(ws, prefix)
 	case structs.Deployments:
-		return state.DeploymentsByIDPrefix(ws, namespace, prefix)
+		return store.DeploymentsByIDPrefix(ws, namespace, prefix)
 	case structs.Plugins:
-		return state.CSIPluginsByIDPrefix(ws, prefix)
+		return store.CSIPluginsByIDPrefix(ws, prefix)
 	case structs.ScalingPolicies:
-		return state.ScalingPoliciesByIDPrefix(ws, namespace, prefix)
+		return store.ScalingPoliciesByIDPrefix(ws, namespace, prefix)
 	case structs.Volumes:
-		return state.CSIVolumesByIDPrefix(ws, namespace, prefix)
+		return store.CSIVolumesByIDPrefix(ws, namespace, prefix)
 	case structs.Namespaces:
-		iter, err := state.NamespacesByNamePrefix(ws, prefix)
+		iter, err := store.NamespacesByNamePrefix(ws, prefix)
 		if err != nil {
 			return nil, err
 		}
@@ -383,7 +383,7 @@ func getResourceIter(context structs.Context, aclObj *acl.ACL, namespace, prefix
 		}
 		return memdb.NewFilterIterator(iter, nsCapFilter(aclObj)), nil
 	default:
-		return getEnterpriseResourceIter(context, aclObj, namespace, prefix, ws, state)
+		return getEnterpriseResourceIter(context, aclObj, namespace, prefix, ws, store)
 	}
 }
 

--- a/nomad/search_endpoint.go
+++ b/nomad/search_endpoint.go
@@ -366,7 +366,7 @@ func getResourceIter(context structs.Context, aclObj *acl.ACL, namespace, prefix
 	case structs.Nodes:
 		return store.NodesByIDPrefix(ws, prefix)
 	case structs.Deployments:
-		return store.DeploymentsByIDPrefix(ws, namespace, prefix)
+		return store.DeploymentsByIDPrefix(ws, namespace, prefix, state.SortDefault)
 	case structs.Plugins:
 		return store.CSIPluginsByIDPrefix(ws, prefix)
 	case structs.ScalingPolicies:

--- a/nomad/search_endpoint.go
+++ b/nomad/search_endpoint.go
@@ -362,7 +362,7 @@ func getResourceIter(context structs.Context, aclObj *acl.ACL, namespace, prefix
 	case structs.Evals:
 		return store.EvalsByIDPrefix(ws, namespace, prefix, state.SortDefault)
 	case structs.Allocs:
-		return store.AllocsByIDPrefix(ws, namespace, prefix)
+		return store.AllocsByIDPrefix(ws, namespace, prefix, state.SortDefault)
 	case structs.Nodes:
 		return store.NodesByIDPrefix(ws, prefix)
 	case structs.Deployments:

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3171,11 +3171,19 @@ func (s *StateStore) EvalByID(ws memdb.WatchSet, id string) (*structs.Evaluation
 
 // EvalsByIDPrefix is used to lookup evaluations by prefix in a particular
 // namespace
-func (s *StateStore) EvalsByIDPrefix(ws memdb.WatchSet, namespace, id string) (memdb.ResultIterator, error) {
+func (s *StateStore) EvalsByIDPrefix(ws memdb.WatchSet, namespace, id string, sort SortOption) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
+	var iter memdb.ResultIterator
+	var err error
+
 	// Get an iterator over all evals by the id prefix
-	iter, err := txn.Get("evals", "id_prefix", id)
+	switch sort {
+	case SortReverse:
+		iter, err = txn.GetReverse("evals", "id_prefix", id)
+	default:
+		iter, err = txn.Get("evals", "id_prefix", id)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("eval lookup failed: %v", err)
 	}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -617,11 +617,19 @@ func (s *StateStore) DeploymentsByNamespaceOrdered(ws memdb.WatchSet, namespace 
 	return it, nil
 }
 
-func (s *StateStore) DeploymentsByIDPrefix(ws memdb.WatchSet, namespace, deploymentID string) (memdb.ResultIterator, error) {
+func (s *StateStore) DeploymentsByIDPrefix(ws memdb.WatchSet, namespace, deploymentID string, sort SortOption) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
+	var iter memdb.ResultIterator
+	var err error
+
 	// Walk the entire deployments table
-	iter, err := txn.Get("deployment", "id_prefix", deploymentID)
+	switch sort {
+	case SortReverse:
+		iter, err = txn.GetReverse("deployment", "id_prefix", deploymentID)
+	default:
+		iter, err = txn.Get("deployment", "id_prefix", deploymentID)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3647,10 +3647,18 @@ func (s *StateStore) allocByIDImpl(txn Txn, ws memdb.WatchSet, id string) (*stru
 }
 
 // AllocsByIDPrefix is used to lookup allocs by prefix
-func (s *StateStore) AllocsByIDPrefix(ws memdb.WatchSet, namespace, id string) (memdb.ResultIterator, error) {
+func (s *StateStore) AllocsByIDPrefix(ws memdb.WatchSet, namespace, id string, sort SortOption) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
-	iter, err := txn.Get("allocs", "id_prefix", id)
+	var iter memdb.ResultIterator
+	var err error
+
+	switch sort {
+	case SortReverse:
+		iter, err = txn.GetReverse("allocs", "id_prefix", id)
+	default:
+		iter, err = txn.Get("allocs", "id_prefix", id)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("alloc lookup failed: %v", err)
 	}

--- a/website/content/api-docs/acl-tokens.mdx
+++ b/website/content/api-docs/acl-tokens.mdx
@@ -70,10 +70,18 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
+- `global` `(bool: false)` - If true, only return ACL tokens that are
+  replicated globally to all regions.
+
 - `prefix` `(string: "")` - Specifies a string to filter ACL tokens based on an
   accessor ID prefix. Because the value is decoded to bytes, the prefix must
   have an even number of hexadecimal characters (0-9a-f). This is specified as
   a query string parameter.
+
+- `reverse` `(bool: false)` - Specifies the list of returned ACL tokens should
+  be sorted in the reverse order. By default ACL tokens are returned sorted in
+  chronological order (older ACL tokens first), or in lexicographical order by
+  their ID if the `prefix` or `global` query parameters are used.
 
 ### Sample Request
 

--- a/website/content/api-docs/allocations.mdx
+++ b/website/content/api-docs/allocations.mdx
@@ -43,6 +43,11 @@ The table below shows this endpoint's support for
   a large number of allocations may set `task_states=false` to significantly
   reduce the size of the response.
 
+- `reverse` `(bool: false)` - Specifies the list of returned allocations should
+  be sorted in the reverse order. By default allocations are returned sorted in
+  chronological order (older evaluations first), or in lexicographical order by
+  their ID if the `prefix` query parameter is used.
+
 ### Sample Request
 
 ```shell-session

--- a/website/content/api-docs/deployments.mdx
+++ b/website/content/api-docs/deployments.mdx
@@ -50,9 +50,10 @@ The table below shows this endpoint's support for
   results. Consider using pagination or a query parameter to reduce resource
   used to serve the request.
 
-- `ascending` `(bool: false)` - Specifies the list of returned deployments should
-  be sorted in chronological order (oldest evaluations first). By default deployments
-  are returned sorted in reverse chronological order (newest deployments first).
+- `reverse` `(bool: false)` - Specifies the list of returned deployments should
+  be sorted in the reverse order. By default deployments are returned sorted in
+  chronological order (older deployments first), or in lexicographical order
+  by their ID if the `prefix` query parameter is used.
 
 ### Sample Request
 

--- a/website/content/api-docs/evaluations.mdx
+++ b/website/content/api-docs/evaluations.mdx
@@ -57,9 +57,10 @@ The table below shows this endpoint's support for
   Specifying `*` will return all evaluations across all authorized namespaces.
   This parameter is used before any `filter` expression is applied.
 
-- `ascending` `(bool: false)` - Specifies the list of returned evaluations should
-  be sorted in chronological order (oldest evaluations first). By default evaluations
-  are returned sorted in reverse chronological order (newest evaluations first).
+- `reverse` `(bool: false)` - Specifies the list of returned evaluations should
+  be sorted in the reverse order. By default evaluations are returned sorted in
+  chronological order (older evaluations first), or in lexicographical order by
+  their ID if the `prefix` query parameter is used.
 
 ### Sample Request
 


### PR DESCRIPTION
The `reverse` query parameter uses `GetReverse` to traverse the go-memdb table in the opposite order. Initially (https://github.com/hashicorp/nomad/pull/12186) this was used to return results in ascending or descending chronological order, but since this was only possible in some situations where the table schema allowed the `reverse` query parameter would only work in some specific combination of query parameters.

Given that there is no inherit meaning in using `Get` or `GetReverse` (they are just opposite orders to traverse results) the `reverse` query parameter can actually be used in most situations.

This PR adds the `sort` argument to state store functions used by the list endpoints that have been updated so far. If `sort` is `SortReverse`, the `GetReverse` method is used and results are returned in the reverse order from the default.

No changelog required since it's continuation of #12186.