### PR TITLE
Ensure to close StreamFrame channel

### DIFF
--- a/.changelog/12248.txt
+++ b/.changelog/12248.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: `AllocFS.Logs` now explicitly closes frames channel after being canceled
+```

--- a/api/fs.go
+++ b/api/fs.go
@@ -257,6 +257,7 @@ func (a *AllocFS) Logs(alloc *Allocation, follow bool, task, logType, origin str
 			// Check if we have been cancelled
 			select {
 			case <-cancel:
+				close(frames)
 				return
 			default:
 			}


### PR DESCRIPTION
A tiny fix to close the StreamFream channel before finishing the streaming by the `<-cancel` channel.

Let's say you use [FrameReader.Read()](https://pkg.go.dev/github.com/hashicorp/nomad/api#FrameReader.Read), now we have no way to quit the select block even when the streaming finished. (Actually we can pass `cancelCh chan struct{}` to [NewFrameReader](https://github.com/hashicorp/nomad/blob/154264fcd927/api/fs.go#L306) but I'd like to stop reading when `<-ctx.Done()`)

Therefore, I would say it should close immediately as soon as the streaming finished.