### PR TITLE
job summary query in `Job.List` RPC should use job's namespace

### DIFF
--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1413,7 +1413,7 @@ func (j *Job) List(args *structs.JobListRequest, reply *structs.JobListResponse)
 					func(raw interface{}) error {
 						job := raw.(*structs.Job)
 						summary, err := state.JobSummaryByID(ws, job.Namespace, job.ID)
-						if err != nil {
+						if err != nil || summary == nil {
 							return fmt.Errorf("unable to look up summary for job: %v", job.ID)
 						}
 						jobs = append(jobs, job.Stub(summary))

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1412,7 +1412,7 @@ func (j *Job) List(args *structs.JobListRequest, reply *structs.JobListResponse)
 				paginator, err := paginator.NewPaginator(iter, tokenizer, filters, args.QueryOptions,
 					func(raw interface{}) error {
 						job := raw.(*structs.Job)
-						summary, err := state.JobSummaryByID(ws, namespace, job.ID)
+						summary, err := state.JobSummaryByID(ws, job.Namespace, job.ID)
 						if err != nil {
 							return fmt.Errorf("unable to look up summary for job: %v", job.ID)
 						}


### PR DESCRIPTION
The `Job.List` RPC attaches a `JobSummary` to each job stub. We're
using the request namespace and not the job namespace for that query,
which results in a nil `JobSummary` whenever we pass the wildcard
namespace. This is incorrect and causes panics in downstream consumers
like the CLI, which assume the `JobSummary` is non-nil as an unstated
invariant.