### PR TITLE
make stop job message clearer

### DIFF
--- a/.changelog/12252.txt
+++ b/.changelog/12252.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: make buttons with confirmation more descriptive of their actions
+```

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -42,9 +42,9 @@
         <TwoStepButton
           data-test-stop
           @alignRight={{true}}
-          @idleText="Stop"
-          @cancelText="Cancel"
-          @confirmText="Yes, Stop"
+          @idleText="Stop Alloc"
+          @cancelText="Cancel Stop"
+          @confirmText="Yes, Stop Alloc"
           @confirmationMessage="Are you sure? This will reschedule the allocation on a different client."
           @awaitingConfirmation={{this.stopAllocation.isRunning}}
           @disabled={{or
@@ -56,9 +56,9 @@
         <TwoStepButton
           data-test-restart
           @alignRight={{true}}
-          @idleText="Restart"
-          @cancelText="Cancel"
-          @confirmText="Yes, Restart"
+          @idleText="Restart Alloc"
+          @cancelText="Cancel Restart"
+          @confirmText="Yes, Restart Alloc"
           @confirmationMessage="Are you sure? This will restart the allocation in-place."
           @awaitingConfirmation={{this.restartAllocation.isRunning}}
           @disabled={{or

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -53,9 +53,9 @@
         <TwoStepButton
           data-test-restart
           @alignRight={{true}}
-          @idleText="Restart"
+          @idleText="Restart Task"
           @cancelText="Cancel"
-          @confirmText="Yes, Restart"
+          @confirmText="Yes, Restart Task"
           @confirmationMessage="Are you sure? This will restart the task in-place."
           @awaitingConfirmation={{this.restartTask.isRunning}}
           @disabled={{this.restartTask.isRunning}}

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -197,7 +197,7 @@
           data-test-drain-stop
           @idleText="Stop Drain"
           @cancelText="Cancel"
-          @confirmText="Yes, Stop"
+          @confirmText="Yes, Stop Drain"
           @confirmationMessage="Are you sure you want to stop this drain?"
           @awaitingConfirmation={{this.stopDrain.isRunning}}
           @onConfirm={{perform this.stopDrain}}

--- a/ui/app/templates/components/job-page/parts/latest-deployment.hbs
+++ b/ui/app/templates/components/job-page/parts/latest-deployment.hbs
@@ -24,7 +24,7 @@
                 confirmButton="is-danger"}}
               @idleText="Fail Deployment"
               @cancelText="Cancel"
-              @confirmText="Yes, Fail"
+              @confirmText="Yes, Fail Deployment"
               @confirmationMessage="Are you sure?"
               @inlineText={{true}}
               @awaitingConfirmation={{this.fail.isRunning}}

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -18,9 +18,9 @@
       <TwoStepButton
         data-test-stop
         @alignRight={{true}}
-        @idleText="Stop"
+        @idleText="Stop Job"
         @cancelText="Cancel"
-        @confirmText="Yes, Stop"
+        @confirmText="Yes, Stop the job"
         @confirmationMessage="Are you sure you want to stop this job?"
         @awaitingConfirmation={{this.stopJob.isRunning}}
         @onConfirm={{perform this.stopJob}} />

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -20,7 +20,7 @@
         @alignRight={{true}}
         @idleText="Stop Job"
         @cancelText="Cancel"
-        @confirmText="Yes, Stop the job"
+        @confirmText="Yes, Stop Job"
         @confirmationMessage="Are you sure you want to stop this job?"
         @awaitingConfirmation={{this.stopJob.isRunning}}
         @onConfirm={{perform this.stopJob}} />
@@ -28,9 +28,9 @@
       <TwoStepButton
         data-test-start
         @alignRight={{true}}
-        @idleText="Start"
+        @idleText="Start Job"
         @cancelText="Cancel"
-        @confirmText="Yes, Start"
+        @confirmText="Yes, Start Job"
         @confirmationMessage="Are you sure you want to start this job?"
         @awaitingConfirmation={{this.startJob.isRunning}}
         @onConfirm={{perform this.startJob}} />

--- a/ui/app/templates/components/job-version.hbs
+++ b/ui/app/templates/components/job-version.hbs
@@ -17,9 +17,9 @@
             idleButton="is-warning is-outlined"
             confirmButton="is-warning"}}
           @alignRight={{true}}
-          @idleText="Revert"
+          @idleText="Revert Version"
           @cancelText="Cancel"
-          @confirmText="Yes, Revert"
+          @confirmText="Yes, Revert Version"
           @confirmationMessage="Are you sure you want to revert to this version?"
           @inlineText={{true}}
           @fadingBackground={{true}}


### PR DESCRIPTION
Make stop job message clearer to ensure job is not stopped by mistake instead of allocation

Decided to create a PR instead of requesting for change. Open to suggestions :)