### PR TITLE
build: first pass at running CI on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,150 @@
+name: Run CI Tests
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.changelog/*'
+      - '.tours/*'
+      - 'contributing/*'
+      - 'demo/*'
+      - 'pkg/*'
+      - 'scripts/*'
+      - 'terraform/*'
+      - 'ui/*'
+      - 'website/*'
+  push:
+    branches-ignore:
+      - main
+      - release-**
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.changelog/*'
+      - '.tours/*'
+      - 'contributing/*'
+      - 'demo/*'
+      - 'pkg/*'
+      - 'scripts/*'
+      - 'terraform/*'
+      - 'ui/*'
+      - 'website/*'
+env:
+  GO_VERSION: 1.17.7
+  GOBIN: /usr/local/bin
+  GOTESTARCH: amd64
+  CONSUL_VERSION: 1.11.3
+  VAULT_VERSION: 1.9.3
+  NOMAD_SLOW_TEST: 0
+jobs:
+  checks:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # needs tags for checkproto
+      - uses: magnetikonline/action-golang-cache@v1
+        with:
+          go-version: ${{env.GO_VERSION}}
+          cache-key-suffix: -checks
+      - name: Run make check
+        run: |
+          make bootstrap
+          make check
+  compile:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, macos-11, windows-2019]
+    runs-on: ${{matrix.os}}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+      - uses: magnetikonline/action-golang-cache@v1
+        with:
+          go-version: ${{env.GO_VERSION}}
+          cache-key-suffix: -compile
+      - name: Run make dev
+        env:
+          GOBIN: ${{env.GOROOT}}/bin # windows kludge
+        run: |
+          make bootstrap
+          make dev
+  tests-api:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - uses: magnetikonline/action-golang-cache@v1
+        with:
+          go-version: ${{env.GO_VERSION}}
+          cache-key-suffix: -api
+      - name: Run API tests
+        env:
+          GOTEST_MOD: api
+        run: |
+          make bootstrap
+          make generate-all
+          make test-nomad-module
+  tests-pkgs:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg:
+          - acl
+          - client
+          - client/allocdir
+          - client/allochealth
+          - client/allocrunner
+          - client/allocwatcher
+          - client/config
+          - client/consul
+          - client/devicemanager
+          - client/dynamicplugins
+          - client/fingerprint
+          - client/lib/...
+          - client/logmon
+          - client/pluginmanager
+          - client/state
+          - client/stats
+          - client/structs
+          - client/taskenv
+          - command
+          - command/agent
+          - drivers/docker
+          - drivers/exec
+          - drivers/java
+          - drivers/rawexec
+          - helper/...
+          - internal/...
+          - jobspec/...
+          - lib/...
+          - nomad
+          - nomad/deploymentwatcher
+          - nomad/stream
+          - nomad/structs
+          - nomad/volumewatcher
+          - plugins/...
+          - scheduler/...
+          - testutil
+    steps:
+      - uses: actions/checkout@v2
+      - uses: magnetikonline/action-golang-cache@v1
+        with:
+          go-version: ${{env.GO_VERSION}}
+          cache-key-suffix: -pkgs
+      - name: Run Matrix Tests
+        env:
+          GOTEST_PKGS: ./${{matrix.pkg}}
+        run: |
+          make bootstrap
+          make generate-all
+          hc-install vault ${{env.VAULT_VERSION}}
+          hc-install consul ${{env.CONSUL_VERSION}}
+          sudo sed -i 's!Defaults!#Defaults!g' /etc/sudoers
+          sudo -E env "PATH=$PATH" make test-nomad

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -32,7 +32,7 @@ ifndef NOMAD_NO_UI
 GO_TAGS := ui $(GO_TAGS)
 endif
 
-GO_TEST_CMD = $(if $(shell command -v gotestsum 2>/dev/null),gotestsum --,go test)
+GO_TEST_CMD := go test
 
 ifeq ($(origin GOTEST_PKGS_EXCLUDE), undefined)
 GOTEST_PKGS ?= "./..."
@@ -48,12 +48,6 @@ PROTO_COMPARE_TAG ?= v1.0.3$(if $(findstring ent,$(GO_TAGS)),+ent,)
 LAST_RELEASE ?= v1.2.6
 
 default: help
-
-ifeq ($(CI),true)
-	$(info Running in a CI environment, verbose mode is disabled)
-else
-	VERBOSE="true"
-endif
 
 ifeq (Linux,$(THIS_OS))
 ALL_TARGETS = linux_386 \
@@ -138,6 +132,7 @@ deps:  ## Install build and development dependencies
 	go install github.com/bufbuild/buf/cmd/buf@v0.36.0
 	go install github.com/hashicorp/go-changelog/cmd/changelog-build@latest
 	go install golang.org/x/tools/cmd/stringer@v0.1.8
+	go install gophers.dev/cmds/hc-install/cmd/hc-install@v1.0.1
 
 .PHONY: lint-deps
 lint-deps: ## Install linter dependencies
@@ -298,7 +293,8 @@ test: ## Run the Nomad test suite and/or the Nomad UI test suite
 test-nomad: dev ## Run Nomad test suites
 	@echo "==> Running Nomad test suites:"
 	$(if $(ENABLE_RACE),GORACE="strip_path_prefix=$(GOPATH)/src") $(GO_TEST_CMD) \
-		$(if $(ENABLE_RACE),-race) $(if $(VERBOSE),-v) \
+		$(if $(ENABLE_RACE),-race) \
+		-v \
 		-cover \
 		-timeout=20m \
 		-tags "$(GO_TAGS)" \

--- a/client/acl_test.go
+++ b/client/acl_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestClient_ACL_resolveTokenValue(t *testing.T) {
+	testutil.Parallel(t)
+
 	s1, _, _, cleanupS1 := testACLServer(t, nil)
 	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
@@ -62,6 +64,8 @@ func TestClient_ACL_resolveTokenValue(t *testing.T) {
 }
 
 func TestClient_ACL_resolvePolicies(t *testing.T) {
+	testutil.Parallel(t)
+
 	s1, _, root, cleanupS1 := testACLServer(t, nil)
 	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
@@ -102,6 +106,8 @@ func TestClient_ACL_resolvePolicies(t *testing.T) {
 }
 
 func TestClient_ACL_ResolveToken_Disabled(t *testing.T) {
+	testutil.Parallel(t)
+
 	s1, _, cleanupS1 := testServer(t, nil)
 	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
@@ -118,6 +124,8 @@ func TestClient_ACL_ResolveToken_Disabled(t *testing.T) {
 }
 
 func TestClient_ACL_ResolveToken(t *testing.T) {
+	testutil.Parallel(t)
+
 	s1, _, _, cleanupS1 := testACLServer(t, nil)
 	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
@@ -167,7 +175,7 @@ func TestClient_ACL_ResolveToken(t *testing.T) {
 }
 
 func TestClient_ACL_ResolveSecretToken(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	s1, _, _, cleanupS1 := testACLServer(t, nil)
 	defer cleanupS1()

--- a/client/agent_endpoint_test.go
+++ b/client/agent_endpoint_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestMonitor_Monitor(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// start server and client
 	s, cleanupS := nomad.TestServer(t, nil)
@@ -43,7 +42,7 @@ func TestMonitor_Monitor(t *testing.T) {
 	}
 
 	handler, err := c.StreamingRpcHandler("Agent.Monitor")
-	require.Nil(err)
+	require.Nil(t, err)
 
 	// create pipe
 	p1, p2 := net.Pipe()
@@ -73,7 +72,7 @@ func TestMonitor_Monitor(t *testing.T) {
 
 	// send request
 	encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
-	require.Nil(encoder.Encode(req))
+	require.Nil(t, encoder.Encode(req))
 
 	timeout := time.After(5 * time.Second)
 	expected := "[DEBUG]"
@@ -97,7 +96,7 @@ OUTER:
 
 			received += string(frame.Data)
 			if strings.Contains(received, expected) {
-				require.Nil(p2.Close())
+				require.Nil(t, p2.Close())
 				break OUTER
 			}
 		}
@@ -105,8 +104,7 @@ OUTER:
 }
 
 func TestMonitor_Monitor_ACL(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// start server
 	s, root, cleanupS := nomad.TestACLServer(t, nil)
@@ -159,7 +157,7 @@ func TestMonitor_Monitor_ACL(t *testing.T) {
 			}
 
 			handler, err := c.StreamingRpcHandler("Agent.Monitor")
-			require.Nil(err)
+			require.Nil(t, err)
 
 			// create pipe
 			p1, p2 := net.Pipe()
@@ -189,7 +187,7 @@ func TestMonitor_Monitor_ACL(t *testing.T) {
 
 			// send request
 			encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
-			require.Nil(encoder.Encode(req))
+			require.Nil(t, encoder.Encode(req))
 
 			timeout := time.After(5 * time.Second)
 		OUTER:
@@ -217,8 +215,7 @@ func TestMonitor_Monitor_ACL(t *testing.T) {
 
 // Test that by default with no acl, endpoint is disabled
 func TestAgentProfile_DefaultDisabled(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// start server and client
 	s1, cleanup := nomad.TestServer(t, nil)
@@ -239,12 +236,11 @@ func TestAgentProfile_DefaultDisabled(t *testing.T) {
 	reply := structs.AgentPprofResponse{}
 
 	err := c.ClientRPC("Agent.Profile", &req, &reply)
-	require.EqualError(err, structs.ErrPermissionDenied.Error())
+	require.EqualError(t, err, structs.ErrPermissionDenied.Error())
 }
 
 func TestAgentProfile(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// start server and client
 	s1, cleanup := nomad.TestServer(t, nil)
@@ -268,10 +264,10 @@ func TestAgentProfile(t *testing.T) {
 		reply := structs.AgentPprofResponse{}
 
 		err := c.ClientRPC("Agent.Profile", &req, &reply)
-		require.NoError(err)
+		require.NoError(t, err)
 
-		require.NotNil(reply.Payload)
-		require.Equal(c.NodeID(), reply.AgentID)
+		require.NotNil(t, reply.Payload)
+		require.Equal(t, c.NodeID(), reply.AgentID)
 	}
 
 	// Unknown profile request
@@ -285,13 +281,12 @@ func TestAgentProfile(t *testing.T) {
 		reply := structs.AgentPprofResponse{}
 
 		err := c.ClientRPC("Agent.Profile", &req, &reply)
-		require.EqualError(err, "RPC Error:: 404,Pprof profile not found profile: unknown")
+		require.EqualError(t, err, "RPC Error:: 404,Pprof profile not found profile: unknown")
 	}
 }
 
 func TestAgentProfile_ACL(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// start server
 	s, root, cleanupS := nomad.TestACLServer(t, nil)
@@ -345,17 +340,17 @@ func TestAgentProfile_ACL(t *testing.T) {
 
 			err := c.ClientRPC("Agent.Profile", req, reply)
 			if tc.authErr {
-				require.EqualError(err, structs.ErrPermissionDenied.Error())
+				require.EqualError(t, err, structs.ErrPermissionDenied.Error())
 			} else {
-				require.NoError(err)
-				require.NotNil(reply.Payload)
+				require.NoError(t, err)
+				require.NotNil(t, reply.Payload)
 			}
 		})
 	}
 }
 
 func TestAgentHost(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	// start server and client
 	s1, cleanup := nomad.TestServer(t, nil)
@@ -380,7 +375,7 @@ func TestAgentHost(t *testing.T) {
 }
 
 func TestAgentHost_ACL(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	s, root, cleanupS := nomad.TestACLServer(t, nil)
 	defer cleanupS()

--- a/client/allocdir/alloc_dir_test.go
+++ b/client/allocdir/alloc_dir_test.go
@@ -458,7 +458,6 @@ func TestPathFuncs(t *testing.T) {
 }
 
 func TestAllocDir_DetectContentType(t *testing.T) {
-	require := require.New(t)
 	inputPath := "input/"
 	var testFiles []string
 	err := filepath.Walk(inputPath, func(path string, info os.FileInfo, err error) error {
@@ -467,7 +466,7 @@ func TestAllocDir_DetectContentType(t *testing.T) {
 		}
 		return err
 	})
-	require.Nil(err)
+	require.Nil(t, err)
 
 	expectedEncodings := map[string]string{
 		"input/happy.gif": "image/gif",
@@ -481,9 +480,9 @@ func TestAllocDir_DetectContentType(t *testing.T) {
 	}
 	for _, file := range testFiles {
 		fileInfo, err := os.Stat(file)
-		require.Nil(err)
+		require.Nil(t, err)
 		res := detectContentType(fileInfo, file)
-		require.Equal(expectedEncodings[file], res, "unexpected output for %v", file)
+		require.Equal(t, expectedEncodings[file], res, "unexpected output for %v", file)
 	}
 }
 

--- a/client/allochealth/tracker_test.go
+++ b/client/allochealth/tracker_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestTracker_Checks_Healthy(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	alloc := mock.Alloc()
 	alloc.Job.TaskGroups[0].Migrate.MinHealthyTime = 1 // let's speed things up
@@ -59,8 +59,8 @@ func TestTracker_Checks_Healthy(t *testing.T) {
 
 	// Don't reply on the first call
 	var called uint64
-	consul := consul.NewMockConsulServiceClient(t, logger)
-	consul.AllocRegistrationsFn = func(string) (*agentconsul.AllocRegistration, error) {
+	consulClient := consul.NewMockConsulServiceClient(t, logger)
+	consulClient.AllocRegistrationsFn = func(string) (*agentconsul.AllocRegistration, error) {
 		if atomic.AddUint64(&called, 1) == 1 {
 			return nil, nil
 		}
@@ -76,7 +76,7 @@ func TestTracker_Checks_Healthy(t *testing.T) {
 	defer cancelFn()
 
 	checkInterval := 10 * time.Millisecond
-	tracker := NewTracker(ctx, logger, alloc, b.Listen(), consul,
+	tracker := NewTracker(ctx, logger, alloc, b.Listen(), consulClient,
 		time.Millisecond, true)
 	tracker.checkLookupInterval = checkInterval
 	tracker.Start()
@@ -90,7 +90,7 @@ func TestTracker_Checks_Healthy(t *testing.T) {
 }
 
 func TestTracker_Checks_PendingPostStop_Healthy(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	alloc := mock.LifecycleAllocWithPoststopDeploy()
 	alloc.Job.TaskGroups[0].Migrate.MinHealthyTime = 1 // let's speed things up
@@ -111,12 +111,12 @@ func TestTracker_Checks_PendingPostStop_Healthy(t *testing.T) {
 	b := cstructs.NewAllocBroadcaster(logger)
 	defer b.Close()
 
-	consul := consul.NewMockConsulServiceClient(t, logger)
+	consulClient := consul.NewMockConsulServiceClient(t, logger)
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
 
 	checkInterval := 10 * time.Millisecond
-	tracker := NewTracker(ctx, logger, alloc, b.Listen(), consul,
+	tracker := NewTracker(ctx, logger, alloc, b.Listen(), consulClient,
 		time.Millisecond, true)
 	tracker.checkLookupInterval = checkInterval
 	tracker.Start()
@@ -130,7 +130,7 @@ func TestTracker_Checks_PendingPostStop_Healthy(t *testing.T) {
 }
 
 func TestTracker_Succeeded_PostStart_Healthy(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	alloc := mock.LifecycleAllocWithPoststartDeploy()
 	alloc.Job.TaskGroups[0].Migrate.MinHealthyTime = time.Millisecond * 1
@@ -152,12 +152,12 @@ func TestTracker_Succeeded_PostStart_Healthy(t *testing.T) {
 	b := cstructs.NewAllocBroadcaster(logger)
 	defer b.Close()
 
-	consul := consul.NewMockConsulServiceClient(t, logger)
+	consulClient := consul.NewMockConsulServiceClient(t, logger)
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
 
 	checkInterval := 10 * time.Millisecond
-	tracker := NewTracker(ctx, logger, alloc, b.Listen(), consul,
+	tracker := NewTracker(ctx, logger, alloc, b.Listen(), consulClient,
 		alloc.Job.TaskGroups[0].Migrate.MinHealthyTime, true)
 	tracker.checkLookupInterval = checkInterval
 	tracker.Start()
@@ -171,7 +171,7 @@ func TestTracker_Succeeded_PostStart_Healthy(t *testing.T) {
 }
 
 func TestTracker_Checks_Unhealthy(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	alloc := mock.Alloc()
 	alloc.Job.TaskGroups[0].Migrate.MinHealthyTime = 1 // let's speed things up
@@ -219,8 +219,8 @@ func TestTracker_Checks_Unhealthy(t *testing.T) {
 
 	// Don't reply on the first call
 	var called uint64
-	consul := consul.NewMockConsulServiceClient(t, logger)
-	consul.AllocRegistrationsFn = func(string) (*agentconsul.AllocRegistration, error) {
+	consulClient := consul.NewMockConsulServiceClient(t, logger)
+	consulClient.AllocRegistrationsFn = func(string) (*agentconsul.AllocRegistration, error) {
 		if atomic.AddUint64(&called, 1) == 1 {
 			return nil, nil
 		}
@@ -236,7 +236,7 @@ func TestTracker_Checks_Unhealthy(t *testing.T) {
 	defer cancelFn()
 
 	checkInterval := 10 * time.Millisecond
-	tracker := NewTracker(ctx, logger, alloc, b.Listen(), consul,
+	tracker := NewTracker(ctx, logger, alloc, b.Listen(), consulClient,
 		time.Millisecond, true)
 	tracker.checkLookupInterval = checkInterval
 	tracker.Start()
@@ -261,7 +261,7 @@ func TestTracker_Checks_Unhealthy(t *testing.T) {
 }
 
 func TestTracker_Healthy_IfBothTasksAndConsulChecksAreHealthy(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	alloc := mock.Alloc()
 	logger := testlog.HCLogger(t)
@@ -312,7 +312,7 @@ func TestTracker_Healthy_IfBothTasksAndConsulChecksAreHealthy(t *testing.T) {
 // TestTracker_Checks_Healthy_Before_TaskHealth asserts that we mark an alloc
 // healthy, if the checks pass before task health pass
 func TestTracker_Checks_Healthy_Before_TaskHealth(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	alloc := mock.Alloc()
 	alloc.Job.TaskGroups[0].Migrate.MinHealthyTime = 1 // let's speed things up
@@ -361,8 +361,8 @@ func TestTracker_Checks_Healthy_Before_TaskHealth(t *testing.T) {
 
 	// Don't reply on the first call
 	var called uint64
-	consul := consul.NewMockConsulServiceClient(t, logger)
-	consul.AllocRegistrationsFn = func(string) (*agentconsul.AllocRegistration, error) {
+	consulClient := consul.NewMockConsulServiceClient(t, logger)
+	consulClient.AllocRegistrationsFn = func(string) (*agentconsul.AllocRegistration, error) {
 		if atomic.AddUint64(&called, 1) == 1 {
 			return nil, nil
 		}
@@ -378,7 +378,7 @@ func TestTracker_Checks_Healthy_Before_TaskHealth(t *testing.T) {
 	defer cancelFn()
 
 	checkInterval := 10 * time.Millisecond
-	tracker := NewTracker(ctx, logger, alloc, b.Listen(), consul,
+	tracker := NewTracker(ctx, logger, alloc, b.Listen(), consulClient,
 		time.Millisecond, true)
 	tracker.checkLookupInterval = checkInterval
 	tracker.Start()
@@ -419,7 +419,7 @@ func TestTracker_Checks_Healthy_Before_TaskHealth(t *testing.T) {
 }
 
 func TestTracker_Checks_OnUpdate(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		desc          string
@@ -503,8 +503,8 @@ func TestTracker_Checks_OnUpdate(t *testing.T) {
 
 			// Don't reply on the first call
 			var called uint64
-			consul := consul.NewMockConsulServiceClient(t, logger)
-			consul.AllocRegistrationsFn = func(string) (*agentconsul.AllocRegistration, error) {
+			consulClient := consul.NewMockConsulServiceClient(t, logger)
+			consulClient.AllocRegistrationsFn = func(string) (*agentconsul.AllocRegistration, error) {
 				if atomic.AddUint64(&called, 1) == 1 {
 					return nil, nil
 				}
@@ -520,7 +520,7 @@ func TestTracker_Checks_OnUpdate(t *testing.T) {
 			defer cancelFn()
 
 			checkInterval := 10 * time.Millisecond
-			tracker := NewTracker(ctx, logger, alloc, b.Listen(), consul,
+			tracker := NewTracker(ctx, logger, alloc, b.Listen(), consulClient,
 				time.Millisecond, true)
 			tracker.checkLookupInterval = checkInterval
 			tracker.Start()

--- a/client/allocrunner/alloc_runner_unix_test.go
+++ b/client/allocrunner/alloc_runner_unix_test.go
@@ -25,7 +25,7 @@ import (
 // DesiredStatus=Stop, persisting the update, but crashing before terminating
 // the task.
 func TestAllocRunner_Restore_RunningTerminal(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	// 1. Run task
 	// 2. Shutdown alloc runner
@@ -143,7 +143,7 @@ func TestAllocRunner_Restore_RunningTerminal(t *testing.T) {
 // TestAllocRunner_Restore_CompletedBatch asserts that restoring a completed
 // batch alloc doesn't run it again
 func TestAllocRunner_Restore_CompletedBatch(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	// 1. Run task and wait for it to complete
 	// 2. Start new alloc runner
@@ -228,7 +228,7 @@ func TestAllocRunner_Restore_CompletedBatch(t *testing.T) {
 // prestart hooks failed, then the alloc and subsequent tasks transition
 // to failed state
 func TestAllocRunner_PreStartFailuresLeadToFailed(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	alloc := mock.Alloc()
 	alloc.Job.Type = structs.JobTypeBatch

--- a/client/allocrunner/consul_grpc_sock_hook_test.go
+++ b/client/allocrunner/consul_grpc_sock_hook_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs/config"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +25,7 @@ import (
 // Consul unix socket hook's Prerun method is called and stopped with the
 // Postrun method is called.
 func TestConsulGRPCSocketHook_PrerunPostrun_Ok(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	// As of Consul 1.6.0 the test server does not support the gRPC
 	// endpoint so we have to fake it.
@@ -101,7 +102,7 @@ func TestConsulGRPCSocketHook_PrerunPostrun_Ok(t *testing.T) {
 // TestConsulGRPCSocketHook_Prerun_Error asserts that invalid Consul addresses cause
 // Prerun to return an error if the alloc requires a grpc proxy.
 func TestConsulGRPCSocketHook_Prerun_Error(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	logger := testlog.HCLogger(t)
 
@@ -153,7 +154,7 @@ func TestConsulGRPCSocketHook_Prerun_Error(t *testing.T) {
 // TestConsulGRPCSocketHook_proxy_Unix asserts that the destination can be a unix
 // socket path.
 func TestConsulGRPCSocketHook_proxy_Unix(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	dir, err := ioutil.TempDir("", "nomadtest_proxy_Unix")
 	require.NoError(t, err)

--- a/client/allocrunner/consul_http_sock_hook_test.go
+++ b/client/allocrunner/consul_http_sock_hook_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs/config"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConsulSocketHook_PrerunPostrun_Ok(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	fakeConsul, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -89,7 +90,7 @@ func TestConsulSocketHook_PrerunPostrun_Ok(t *testing.T) {
 }
 
 func TestConsulHTTPSocketHook_Prerun_Error(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	logger := testlog.HCLogger(t)
 

--- a/client/allocrunner/groupservice_hook_test.go
+++ b/client/allocrunner/groupservice_hook_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,7 +28,7 @@ var _ interfaces.RunnerTaskRestartHook = (*groupServiceHook)(nil)
 // TestGroupServiceHook_NoGroupServices asserts calling group service hooks
 // without group services does not error.
 func TestGroupServiceHook_NoGroupServices(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	alloc := mock.Alloc()
 	alloc.Job.TaskGroups[0].Services = []*structs.Service{{
@@ -65,7 +66,7 @@ func TestGroupServiceHook_NoGroupServices(t *testing.T) {
 // TestGroupServiceHook_ShutdownDelayUpdate asserts calling group service hooks
 // update updates the hooks delay value.
 func TestGroupServiceHook_ShutdownDelayUpdate(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	alloc := mock.Alloc()
 	alloc.Job.TaskGroups[0].ShutdownDelay = helper.TimeToPtr(10 * time.Second)
@@ -102,7 +103,7 @@ func TestGroupServiceHook_ShutdownDelayUpdate(t *testing.T) {
 // TestGroupServiceHook_GroupServices asserts group service hooks with group
 // services does not error.
 func TestGroupServiceHook_GroupServices(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	alloc := mock.ConnectAlloc()
 	logger := testlog.HCLogger(t)
@@ -136,7 +137,7 @@ func TestGroupServiceHook_GroupServices(t *testing.T) {
 // TestGroupServiceHook_Error asserts group service hooks with group
 // services but no group network is handled gracefully.
 func TestGroupServiceHook_NoNetwork(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	alloc := mock.Alloc()
 	alloc.Job.TaskGroups[0].Networks = []*structs.NetworkResource{}
@@ -180,7 +181,7 @@ func TestGroupServiceHook_NoNetwork(t *testing.T) {
 }
 
 func TestGroupServiceHook_getWorkloadServices(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	alloc := mock.Alloc()
 	alloc.Job.TaskGroups[0].Networks = []*structs.NetworkResource{}
@@ -215,6 +216,8 @@ func TestGroupServiceHook_getWorkloadServices(t *testing.T) {
 //
 // COMPAT(0.11) Only valid for upgrades from 0.8.
 func TestGroupServiceHook_Update08Alloc(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Create an embedded Consul server
 	testconsul, err := ctestutil.NewTestServerConfigT(t, func(c *ctestutil.TestServerConfig) {
 		// If -v wasn't specified squelch consul logging

--- a/client/allocrunner/network_hook_test.go
+++ b/client/allocrunner/network_hook_test.go
@@ -78,26 +78,25 @@ func TestNetworkHook_Prerun_Postrun(t *testing.T) {
 		t:              t,
 		expectedStatus: nil,
 	}
-	require := require.New(t)
 
 	envBuilder := taskenv.NewBuilder(mock.Node(), alloc, nil, alloc.Job.Region)
 
 	logger := testlog.HCLogger(t)
 	hook := newNetworkHook(logger, setter, alloc, nm, &hostNetworkConfigurator{}, statusSetter, envBuilder.Build())
-	require.NoError(hook.Prerun())
-	require.True(setter.called)
-	require.False(destroyCalled)
-	require.NoError(hook.Postrun())
-	require.True(destroyCalled)
+	require.NoError(t, hook.Prerun())
+	require.True(t, setter.called)
+	require.False(t, destroyCalled)
+	require.NoError(t, hook.Postrun())
+	require.True(t, destroyCalled)
 
 	// reset and use host network mode
 	setter.called = false
 	destroyCalled = false
 	alloc.Job.TaskGroups[0].Networks[0].Mode = "host"
 	hook = newNetworkHook(logger, setter, alloc, nm, &hostNetworkConfigurator{}, statusSetter, envBuilder.Build())
-	require.NoError(hook.Prerun())
-	require.False(setter.called)
-	require.False(destroyCalled)
-	require.NoError(hook.Postrun())
-	require.False(destroyCalled)
+	require.NoError(t, hook.Prerun())
+	require.False(t, setter.called)
+	require.False(t, destroyCalled)
+	require.NoError(t, hook.Postrun())
+	require.False(t, destroyCalled)
 }

--- a/client/allocrunner/network_manager_linux_test.go
+++ b/client/allocrunner/network_manager_linux_test.go
@@ -252,23 +252,22 @@ func TestNewNetworkManager(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			require := require.New(t)
 			nm, err := newNetworkManager(tc.alloc, &mockDriverManager{})
 			if tc.err {
-				require.Error(err)
-				require.Contains(err.Error(), tc.errContains)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errContains)
 			} else {
-				require.NoError(err)
+				require.NoError(t, err)
 			}
 
 			if tc.mustInit {
 				_, ok := nm.(*testutils.MockDriver)
-				require.True(ok)
+				require.True(t, ok)
 			} else if tc.err {
-				require.Nil(nm)
+				require.Nil(t, nm)
 			} else {
 				_, ok := nm.(*defaultNetworkManager)
-				require.True(ok)
+				require.True(t, ok)
 			}
 		})
 	}

--- a/client/allocrunner/taskrunner/artifact_hook_test.go
+++ b/client/allocrunner/taskrunner/artifact_hook_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,7 +34,7 @@ func (m *mockEmitter) EmitEvent(ev *structs.TaskEvent) {
 // TestTaskRunner_ArtifactHook_Recoverable asserts that failures to download
 // artifacts are a recoverable error.
 func TestTaskRunner_ArtifactHook_Recoverable(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	me := &mockEmitter{}
 	artifactHook := newArtifactHook(me, testlog.HCLogger(t))
@@ -66,7 +67,7 @@ func TestTaskRunner_ArtifactHook_Recoverable(t *testing.T) {
 // already downloaded artifacts when subsequent artifacts fail and cause a
 // restart.
 func TestTaskRunner_ArtifactHook_PartialDone(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	me := &mockEmitter{}
 	artifactHook := newArtifactHook(me, testlog.HCLogger(t))

--- a/client/allocrunner/taskrunner/connect_native_hook_test.go
+++ b/client/allocrunner/taskrunner/connect_native_hook_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 
 	consulapi "github.com/hashicorp/consul/api"
-	consultest "github.com/hashicorp/consul/sdk/testutil"
+	consultestutil "github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/client/taskenv"
-	"github.com/hashicorp/nomad/client/testutil"
+	clienttestutil "github.com/hashicorp/nomad/client/testutil"
 	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/testlog"
@@ -20,11 +20,12 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
-func getTestConsul(t *testing.T) *consultest.TestServer {
-	testConsul, err := consultest.NewTestServerConfigT(t, func(c *consultest.TestServerConfig) {
+func getTestConsul(t *testing.T) *consultestutil.TestServer {
+	testConsul, err := consultestutil.NewTestServerConfigT(t, func(c *consultestutil.TestServerConfig) {
 		if !testing.Verbose() { // disable consul logging if -v not set
 			c.Stdout = ioutil.Discard
 			c.Stderr = ioutil.Discard
@@ -35,7 +36,8 @@ func getTestConsul(t *testing.T) *consultest.TestServer {
 }
 
 func TestConnectNativeHook_Name(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	name := new(connectNativeHook).Name()
 	require.Equal(t, "connect_native", name)
 }
@@ -61,7 +63,7 @@ func cleanupCertDirs(t *testing.T, original, secrets string) {
 }
 
 func TestConnectNativeHook_copyCertificate(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	f, d := setupCertDirs(t)
 	defer cleanupCertDirs(t, f, d)
@@ -81,7 +83,7 @@ func TestConnectNativeHook_copyCertificate(t *testing.T) {
 }
 
 func TestConnectNativeHook_copyCertificates(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	f, d := setupCertDirs(t)
 	defer cleanupCertDirs(t, f, d)
@@ -109,7 +111,7 @@ func TestConnectNativeHook_copyCertificates(t *testing.T) {
 }
 
 func TestConnectNativeHook_tlsEnv(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	// the hook config comes from client config
 	emptyHook := new(connectNativeHook)
@@ -163,7 +165,7 @@ func TestConnectNativeHook_tlsEnv(t *testing.T) {
 }
 
 func TestConnectNativeHook_bridgeEnv_bridge(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("without tls", func(t *testing.T) {
 		hook := new(connectNativeHook)
@@ -208,7 +210,7 @@ func TestConnectNativeHook_bridgeEnv_bridge(t *testing.T) {
 }
 
 func TestConnectNativeHook_bridgeEnv_host(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	hook := new(connectNativeHook)
 	hook.alloc = mock.ConnectNativeAlloc("host")
@@ -227,7 +229,7 @@ func TestConnectNativeHook_bridgeEnv_host(t *testing.T) {
 }
 
 func TestConnectNativeHook_hostEnv_host(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	hook := new(connectNativeHook)
 	hook.alloc = mock.ConnectNativeAlloc("host")
@@ -249,7 +251,7 @@ func TestConnectNativeHook_hostEnv_host(t *testing.T) {
 }
 
 func TestConnectNativeHook_hostEnv_bridge(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	hook := new(connectNativeHook)
 	hook.alloc = mock.ConnectNativeAlloc("bridge")
@@ -269,7 +271,8 @@ func TestConnectNativeHook_hostEnv_bridge(t *testing.T) {
 }
 
 func TestTaskRunner_ConnectNativeHook_Noop(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 
 	alloc := mock.Alloc()
@@ -307,8 +310,8 @@ func TestTaskRunner_ConnectNativeHook_Noop(t *testing.T) {
 }
 
 func TestTaskRunner_ConnectNativeHook_Ok(t *testing.T) {
-	t.Parallel()
-	testutil.RequireConsul(t)
+	testutil.Parallel(t)
+	clienttestutil.RequireConsul(t)
 
 	testConsul := getTestConsul(t)
 	defer testConsul.Stop()
@@ -372,8 +375,8 @@ func TestTaskRunner_ConnectNativeHook_Ok(t *testing.T) {
 }
 
 func TestTaskRunner_ConnectNativeHook_with_SI_token(t *testing.T) {
-	t.Parallel()
-	testutil.RequireConsul(t)
+	testutil.Parallel(t)
+	clienttestutil.RequireConsul(t)
 
 	testConsul := getTestConsul(t)
 	defer testConsul.Stop()
@@ -445,8 +448,8 @@ func TestTaskRunner_ConnectNativeHook_with_SI_token(t *testing.T) {
 }
 
 func TestTaskRunner_ConnectNativeHook_shareTLS(t *testing.T) {
-	t.Parallel()
-	testutil.RequireConsul(t)
+	testutil.Parallel(t)
+	clienttestutil.RequireConsul(t)
 
 	try := func(t *testing.T, shareSSL *bool) {
 		fakeCert, fakeCertDir := setupCertDirs(t)
@@ -566,8 +569,8 @@ func checkFilesInDir(t *testing.T, dir string, includes, excludes []string) {
 }
 
 func TestTaskRunner_ConnectNativeHook_shareTLS_override(t *testing.T) {
-	t.Parallel()
-	testutil.RequireConsul(t)
+	testutil.Parallel(t)
+	clienttestutil.RequireConsul(t)
 
 	fakeCert, fakeCertDir := setupCertDirs(t)
 	defer cleanupCertDirs(t, fakeCert, fakeCertDir)

--- a/client/allocrunner/taskrunner/device_hook_test.go
+++ b/client/allocrunner/taskrunner/device_hook_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/device"
 	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDeviceHook_CorrectDevice(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	dm := devicemanager.NoopMockManager()
 	l := testlog.HCLogger(t)
@@ -69,13 +69,13 @@ func TestDeviceHook_CorrectDevice(t *testing.T) {
 
 	var resp interfaces.TaskPrestartResponse
 	err := h.Prestart(context.Background(), req, &resp)
-	require.NoError(err)
-	require.NotNil(resp)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
 
 	expEnv := map[string]string{
 		"123": "456",
 	}
-	require.EqualValues(expEnv, resp.Env)
+	require.EqualValues(t, expEnv, resp.Env)
 
 	expMounts := []*drivers.MountConfig{
 		{
@@ -84,7 +84,7 @@ func TestDeviceHook_CorrectDevice(t *testing.T) {
 			HostPath: "bar",
 		},
 	}
-	require.EqualValues(expMounts, resp.Mounts)
+	require.EqualValues(t, expMounts, resp.Mounts)
 
 	expDevices := []*drivers.DeviceConfig{
 		{
@@ -93,12 +93,11 @@ func TestDeviceHook_CorrectDevice(t *testing.T) {
 			Permissions: "123",
 		},
 	}
-	require.EqualValues(expDevices, resp.Devices)
+	require.EqualValues(t, expDevices, resp.Devices)
 }
 
 func TestDeviceHook_IncorrectDevice(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	dm := devicemanager.NoopMockManager()
 	l := testlog.HCLogger(t)
@@ -127,5 +126,5 @@ func TestDeviceHook_IncorrectDevice(t *testing.T) {
 
 	var resp interfaces.TaskPrestartResponse
 	err := h.Prestart(context.Background(), req, &resp)
-	require.Error(err)
+	require.Error(t, err)
 }

--- a/client/allocrunner/taskrunner/dispatch_hook_test.go
+++ b/client/allocrunner/taskrunner/dispatch_hook_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,9 +22,8 @@ var _ interfaces.TaskPrestartHook = (*dispatchHook)(nil)
 // TestTaskRunner_DispatchHook_NoPayload asserts that the hook is a noop and is
 // marked as done if there is no dispatch payload.
 func TestTaskRunner_DispatchHook_NoPayload(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
-	require := require.New(t)
 	ctx := context.Background()
 	logger := testlog.HCLogger(t)
 
@@ -34,7 +34,7 @@ func TestTaskRunner_DispatchHook_NoPayload(t *testing.T) {
 	allocDir := allocdir.NewAllocDir(logger, "nomadtest_nopayload", alloc.ID)
 	defer allocDir.Destroy()
 	taskDir := allocDir.NewTaskDir(task.Name)
-	require.NoError(taskDir.Build(false, nil))
+	require.NoError(t, taskDir.Build(false, nil))
 
 	h := newDispatchHook(alloc, logger)
 
@@ -45,21 +45,20 @@ func TestTaskRunner_DispatchHook_NoPayload(t *testing.T) {
 	resp := interfaces.TaskPrestartResponse{}
 
 	// Assert no error and Done=true as this job has no payload
-	require.NoError(h.Prestart(ctx, &req, &resp))
-	require.True(resp.Done)
+	require.NoError(t, h.Prestart(ctx, &req, &resp))
+	require.True(t, resp.Done)
 
 	// Assert payload directory is empty
 	files, err := ioutil.ReadDir(req.TaskDir.LocalDir)
-	require.NoError(err)
-	require.Empty(files)
+	require.NoError(t, err)
+	require.Empty(t, files)
 }
 
 // TestTaskRunner_DispatchHook_Ok asserts that dispatch payloads are written to
 // a file in the task dir.
 func TestTaskRunner_DispatchHook_Ok(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
-	require := require.New(t)
 	ctx := context.Background()
 	logger := testlog.HCLogger(t)
 
@@ -80,7 +79,7 @@ func TestTaskRunner_DispatchHook_Ok(t *testing.T) {
 	allocDir := allocdir.NewAllocDir(logger, "nomadtest_dispatchok", alloc.ID)
 	defer allocDir.Destroy()
 	taskDir := allocDir.NewTaskDir(task.Name)
-	require.NoError(taskDir.Build(false, nil))
+	require.NoError(t, taskDir.Build(false, nil))
 
 	h := newDispatchHook(alloc, logger)
 
@@ -89,21 +88,20 @@ func TestTaskRunner_DispatchHook_Ok(t *testing.T) {
 		TaskDir: taskDir,
 	}
 	resp := interfaces.TaskPrestartResponse{}
-	require.NoError(h.Prestart(ctx, &req, &resp))
-	require.True(resp.Done)
+	require.NoError(t, h.Prestart(ctx, &req, &resp))
+	require.True(t, resp.Done)
 
 	filename := filepath.Join(req.TaskDir.LocalDir, task.DispatchPayload.File)
 	result, err := ioutil.ReadFile(filename)
-	require.NoError(err)
-	require.Equal(expected, result)
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
 }
 
 // TestTaskRunner_DispatchHook_Error asserts that on an error dispatch payloads
 // are not written and Done=false.
 func TestTaskRunner_DispatchHook_Error(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
-	require := require.New(t)
 	ctx := context.Background()
 	logger := testlog.HCLogger(t)
 
@@ -125,7 +123,7 @@ func TestTaskRunner_DispatchHook_Error(t *testing.T) {
 	allocDir := allocdir.NewAllocDir(logger, "nomadtest_dispatcherr", alloc.ID)
 	defer allocDir.Destroy()
 	taskDir := allocDir.NewTaskDir(task.Name)
-	require.NoError(taskDir.Build(false, nil))
+	require.NoError(t, taskDir.Build(false, nil))
 
 	h := newDispatchHook(alloc, logger)
 
@@ -136,11 +134,11 @@ func TestTaskRunner_DispatchHook_Error(t *testing.T) {
 	resp := interfaces.TaskPrestartResponse{}
 
 	// Assert an error was returned and Done=false
-	require.Error(h.Prestart(ctx, &req, &resp))
-	require.False(resp.Done)
+	require.Error(t, h.Prestart(ctx, &req, &resp))
+	require.False(t, resp.Done)
 
 	// Assert payload directory is empty
 	files, err := ioutil.ReadDir(req.TaskDir.LocalDir)
-	require.NoError(err)
-	require.Empty(files)
+	require.NoError(t, err)
+	require.Empty(t, files)
 }

--- a/client/allocrunner/taskrunner/envoy_bootstrap_hook_test.go
+++ b/client/allocrunner/taskrunner/envoy_bootstrap_hook_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/client/taskenv"
-	"github.com/hashicorp/nomad/client/testutil"
+	clienttestutil "github.com/hashicorp/nomad/client/testutil"
 	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/args"
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
@@ -53,7 +54,7 @@ func writeTmp(t *testing.T, s string, fm os.FileMode) string {
 }
 
 func TestEnvoyBootstrapHook_maybeLoadSIToken(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	// This test fails when running as root because the test case for checking
 	// the error condition when the file is unreadable fails (root can read the
@@ -94,7 +95,7 @@ func TestEnvoyBootstrapHook_maybeLoadSIToken(t *testing.T) {
 }
 
 func TestEnvoyBootstrapHook_decodeTriState(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	require.Equal(t, "", decodeTriState(nil))
 	require.Equal(t, "true", decodeTriState(helper.BoolToPtr(true)))
@@ -118,7 +119,7 @@ var (
 )
 
 func TestEnvoyBootstrapHook_envoyBootstrapArgs(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("excluding SI token", func(t *testing.T) {
 		ebArgs := envoyBootstrapArgs{
@@ -227,7 +228,7 @@ func TestEnvoyBootstrapHook_envoyBootstrapArgs(t *testing.T) {
 }
 
 func TestEnvoyBootstrapHook_envoyBootstrapEnv(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	environment := []string{"foo=bar", "baz=1"}
 
@@ -291,8 +292,8 @@ type envoyConfig struct {
 // TestEnvoyBootstrapHook_with_SI_token asserts the bootstrap file written for
 // Envoy contains a Consul SI token.
 func TestEnvoyBootstrapHook_with_SI_token(t *testing.T) {
-	t.Parallel()
-	testutil.RequireConsul(t)
+	testutil.Parallel(t)
+	clienttestutil.RequireConsul(t)
 
 	testConsul := getTestConsul(t)
 	defer testConsul.Stop()
@@ -392,8 +393,8 @@ func TestEnvoyBootstrapHook_with_SI_token(t *testing.T) {
 // creates Envoy's bootstrap.json configuration based on Connect proxy sidecars
 // registered for the task.
 func TestTaskRunner_EnvoyBootstrapHook_sidecar_ok(t *testing.T) {
-	t.Parallel()
-	testutil.RequireConsul(t)
+	testutil.Parallel(t)
+	clienttestutil.RequireConsul(t)
 
 	testConsul := getTestConsul(t)
 	defer testConsul.Stop()
@@ -487,7 +488,8 @@ func TestTaskRunner_EnvoyBootstrapHook_sidecar_ok(t *testing.T) {
 }
 
 func TestTaskRunner_EnvoyBootstrapHook_gateway_ok(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 
 	testConsul := getTestConsul(t)
@@ -570,7 +572,8 @@ func TestTaskRunner_EnvoyBootstrapHook_gateway_ok(t *testing.T) {
 // TestTaskRunner_EnvoyBootstrapHook_Noop asserts that the Envoy bootstrap hook
 // is a noop for non-Connect proxy sidecar / gateway tasks.
 func TestTaskRunner_EnvoyBootstrapHook_Noop(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 
 	alloc := mock.Alloc()
@@ -607,8 +610,8 @@ func TestTaskRunner_EnvoyBootstrapHook_Noop(t *testing.T) {
 // bootstrap hook returns a Recoverable error if the bootstrap command runs but
 // fails.
 func TestTaskRunner_EnvoyBootstrapHook_RecoverableError(t *testing.T) {
-	t.Parallel()
-	testutil.RequireConsul(t)
+	testutil.Parallel(t)
+	clienttestutil.RequireConsul(t)
 
 	testConsul := getTestConsul(t)
 	defer testConsul.Stop()
@@ -685,7 +688,8 @@ func TestTaskRunner_EnvoyBootstrapHook_RecoverableError(t *testing.T) {
 }
 
 func TestTaskRunner_EnvoyBootstrapHook_retryTimeout(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 
 	testConsul := getTestConsul(t)
@@ -778,6 +782,8 @@ func TestTaskRunner_EnvoyBootstrapHook_retryTimeout(t *testing.T) {
 }
 
 func TestTaskRunner_EnvoyBootstrapHook_extractNameAndKind(t *testing.T) {
+	testutil.Parallel(t)
+
 	t.Run("connect sidecar", func(t *testing.T) {
 		kind, name, err := (*envoyBootstrapHook)(nil).extractNameAndKind(
 			structs.NewTaskKind(structs.ConnectProxyPrefix, "foo"),
@@ -812,6 +818,8 @@ func TestTaskRunner_EnvoyBootstrapHook_extractNameAndKind(t *testing.T) {
 }
 
 func TestTaskRunner_EnvoyBootstrapHook_grpcAddress(t *testing.T) {
+	testutil.Parallel(t)
+
 	bridgeH := newEnvoyBootstrapHook(newEnvoyBootstrapHookConfig(
 		mock.ConnectIngressGatewayAlloc("bridge"),
 		new(config.ConsulConfig),

--- a/client/allocrunner/taskrunner/envoy_version_hook_test.go
+++ b/client/allocrunner/taskrunner/envoy_version_hook_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +25,7 @@ var (
 )
 
 func TestEnvoyVersionHook_semver(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("with v", func(t *testing.T) {
 		result, err := semver("v1.2.3")
@@ -45,7 +46,7 @@ func TestEnvoyVersionHook_semver(t *testing.T) {
 }
 
 func TestEnvoyVersionHook_taskImage(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("absent", func(t *testing.T) {
 		result := (*envoyVersionHook)(nil).taskImage(map[string]interface{}{
@@ -70,8 +71,7 @@ func TestEnvoyVersionHook_taskImage(t *testing.T) {
 }
 
 func TestEnvoyVersionHook_tweakImage(t *testing.T) {
-	t.Parallel()
-
+	testutil.Parallel(t)
 	image := envoy.ImageFormat
 
 	t.Run("legacy", func(t *testing.T) {
@@ -106,8 +106,7 @@ func TestEnvoyVersionHook_tweakImage(t *testing.T) {
 }
 
 func TestEnvoyVersionHook_interpolateImage(t *testing.T) {
-	t.Parallel()
-
+	testutil.Parallel(t)
 	hook := (*envoyVersionHook)(nil)
 
 	t.Run("default sidecar", func(t *testing.T) {
@@ -156,8 +155,7 @@ func TestEnvoyVersionHook_interpolateImage(t *testing.T) {
 }
 
 func TestEnvoyVersionHook_skip(t *testing.T) {
-	t.Parallel()
-
+	testutil.Parallel(t)
 	h := new(envoyVersionHook)
 
 	t.Run("not docker", func(t *testing.T) {
@@ -221,8 +219,7 @@ func TestEnvoyVersionHook_skip(t *testing.T) {
 }
 
 func TestTaskRunner_EnvoyVersionHook_Prestart_standard(t *testing.T) {
-	t.Parallel()
-
+	testutil.Parallel(t)
 	logger := testlog.HCLogger(t)
 
 	// Setup an Allocation
@@ -264,8 +261,7 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_standard(t *testing.T) {
 }
 
 func TestTaskRunner_EnvoyVersionHook_Prestart_custom(t *testing.T) {
-	t.Parallel()
-
+	testutil.Parallel(t)
 	logger := testlog.HCLogger(t)
 
 	// Setup an Allocation
@@ -308,8 +304,7 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_custom(t *testing.T) {
 }
 
 func TestTaskRunner_EnvoyVersionHook_Prestart_skip(t *testing.T) {
-	t.Parallel()
-
+	testutil.Parallel(t)
 	logger := testlog.HCLogger(t)
 
 	// Setup an Allocation
@@ -355,8 +350,7 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_skip(t *testing.T) {
 }
 
 func TestTaskRunner_EnvoyVersionHook_Prestart_fallback(t *testing.T) {
-	t.Parallel()
-
+	testutil.Parallel(t)
 	logger := testlog.HCLogger(t)
 
 	// Setup an Allocation
@@ -396,8 +390,7 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_fallback(t *testing.T) {
 }
 
 func TestTaskRunner_EnvoyVersionHook_Prestart_error(t *testing.T) {
-	t.Parallel()
-
+	testutil.Parallel(t)
 	logger := testlog.HCLogger(t)
 
 	// Setup an Allocation

--- a/client/allocrunner/taskrunner/errors_test.go
+++ b/client/allocrunner/taskrunner/errors_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,7 +15,7 @@ var _ structs.Recoverable = (*hookError)(nil)
 // TestHookError_Recoverable asserts that a NewHookError is recoverable if
 // passed a recoverable error.
 func TestHookError_Recoverable(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	// Create root error
 	root := errors.New("test error")
@@ -36,8 +37,8 @@ func TestHookError_Recoverable(t *testing.T) {
 // TestHookError_Unrecoverable asserts that a NewHookError is not recoverable
 // unless it is passed a recoverable error.
 func TestHookError_Unrecoverable(t *testing.T) {
-	t.Parallel()
-
+	testutil.Parallel(t)
+	 
 	// Create error
 	err := errors.New("test error")
 

--- a/client/allocrunner/taskrunner/logmon_hook_test.go
+++ b/client/allocrunner/taskrunner/logmon_hook_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	pstructs "github.com/hashicorp/nomad/plugins/shared/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,7 +25,7 @@ var _ interfaces.TaskStopHook = (*logmonHook)(nil)
 // TestTaskRunner_LogmonHook_LoadReattach unit tests loading logmon reattach
 // config from persisted hook state.
 func TestTaskRunner_LogmonHook_LoadReattach(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	// No hook data should return nothing
 	cfg, err := reattachConfigFromHookData(nil)
@@ -60,7 +61,7 @@ func TestTaskRunner_LogmonHook_LoadReattach(t *testing.T) {
 // first time Prestart is called, reattached to on subsequent restarts, and
 // killed on Stop.
 func TestTaskRunner_LogmonHook_StartStop(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	alloc := mock.BatchAlloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]

--- a/client/allocrunner/taskrunner/logmon_hook_unix_test.go
+++ b/client/allocrunner/taskrunner/logmon_hook_unix_test.go
@@ -25,7 +25,6 @@ import (
 // Nomad client is restarting and asserts failing to reattach to logmon causes
 // nomad to spawn a new logmon.
 func TestTaskRunner_LogmonHook_StartCrashStop(t *testing.T) {
-	t.Parallel()
 
 	alloc := mock.BatchAlloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
@@ -94,7 +93,6 @@ func TestTaskRunner_LogmonHook_StartCrashStop(t *testing.T) {
 // TestTaskRunner_LogmonHook_ShutdownMidStart simulates logmon crashing while the
 // Nomad client is calling Start() and asserts that we recover and spawn a new logmon.
 func TestTaskRunner_LogmonHook_ShutdownMidStart(t *testing.T) {
-	t.Parallel()
 
 	alloc := mock.BatchAlloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]

--- a/client/allocrunner/taskrunner/restarts/restarts_test.go
+++ b/client/allocrunner/taskrunner/restarts/restarts_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -34,7 +35,8 @@ func testExitResult(exit int) *drivers.ExitResult {
 }
 
 func TestClient_RestartTracker_ModeDelay(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	p := testPolicy(true, structs.RestartPolicyModeDelay)
 	rt := NewRestartTracker(p, structs.JobTypeService, nil)
 	for i := 0; i < p.Attempts; i++ {
@@ -60,7 +62,8 @@ func TestClient_RestartTracker_ModeDelay(t *testing.T) {
 }
 
 func TestClient_RestartTracker_ModeFail(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	p := testPolicy(true, structs.RestartPolicyModeFail)
 	rt := NewRestartTracker(p, structs.JobTypeSystem, nil)
 	for i := 0; i < p.Attempts; i++ {
@@ -80,7 +83,8 @@ func TestClient_RestartTracker_ModeFail(t *testing.T) {
 }
 
 func TestClient_RestartTracker_NoRestartOnSuccess(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	p := testPolicy(false, structs.RestartPolicyModeDelay)
 	rt := NewRestartTracker(p, structs.JobTypeBatch, nil)
 	if state, _ := rt.SetExitResult(testExitResult(0)).GetState(); state != structs.TaskTerminated {
@@ -89,7 +93,8 @@ func TestClient_RestartTracker_NoRestartOnSuccess(t *testing.T) {
 }
 
 func TestClient_RestartTracker_ZeroAttempts(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	p := testPolicy(true, structs.RestartPolicyModeFail)
 	p.Attempts = 0
 
@@ -122,7 +127,8 @@ func TestClient_RestartTracker_ZeroAttempts(t *testing.T) {
 }
 
 func TestClient_RestartTracker_TaskKilled(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	p := testPolicy(true, structs.RestartPolicyModeFail)
 	p.Attempts = 0
 	rt := NewRestartTracker(p, structs.JobTypeService, nil)
@@ -132,7 +138,8 @@ func TestClient_RestartTracker_TaskKilled(t *testing.T) {
 }
 
 func TestClient_RestartTracker_RestartTriggered(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	p := testPolicy(true, structs.RestartPolicyModeFail)
 	p.Attempts = 0
 	rt := NewRestartTracker(p, structs.JobTypeService, nil)
@@ -142,7 +149,8 @@ func TestClient_RestartTracker_RestartTriggered(t *testing.T) {
 }
 
 func TestClient_RestartTracker_RestartTriggered_Failure(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	p := testPolicy(true, structs.RestartPolicyModeFail)
 	p.Attempts = 1
 	rt := NewRestartTracker(p, structs.JobTypeService, nil)
@@ -155,7 +163,8 @@ func TestClient_RestartTracker_RestartTriggered_Failure(t *testing.T) {
 }
 
 func TestClient_RestartTracker_StartError_Recoverable_Fail(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	p := testPolicy(true, structs.RestartPolicyModeFail)
 	rt := NewRestartTracker(p, structs.JobTypeSystem, nil)
 	recErr := structs.NewRecoverableError(fmt.Errorf("foo"), true)
@@ -176,7 +185,8 @@ func TestClient_RestartTracker_StartError_Recoverable_Fail(t *testing.T) {
 }
 
 func TestClient_RestartTracker_StartError_Recoverable_Delay(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	p := testPolicy(true, structs.RestartPolicyModeDelay)
 	rt := NewRestartTracker(p, structs.JobTypeSystem, nil)
 	recErr := structs.NewRecoverableError(fmt.Errorf("foo"), true)
@@ -201,7 +211,7 @@ func TestClient_RestartTracker_StartError_Recoverable_Delay(t *testing.T) {
 }
 
 func TestClient_RestartTracker_Lifecycle(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	testCase := []struct {
 		name                   string

--- a/client/allocrunner/taskrunner/script_check_hook_test.go
+++ b/client/allocrunner/taskrunner/script_check_hook_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,6 +64,8 @@ type heartbeat struct {
 // TestScript_Exec_Cancel asserts cancelling a script check shortcircuits
 // any running scripts.
 func TestScript_Exec_Cancel(t *testing.T) {
+	testutil.Parallel(t)
+
 	exec, cancel := newBlockingScriptExec()
 	defer cancel()
 
@@ -89,7 +92,8 @@ func TestScript_Exec_Cancel(t *testing.T) {
 // TestScript_Exec_TimeoutBasic asserts a script will be killed when the
 // timeout is reached.
 func TestScript_Exec_TimeoutBasic(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	exec, cancel := newBlockingScriptExec()
 	defer cancel()
 
@@ -130,7 +134,8 @@ func TestScript_Exec_TimeoutBasic(t *testing.T) {
 // the timeout is reached and always set a critical status regardless of what
 // Exec returns.
 func TestScript_Exec_TimeoutCritical(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 	hb := newFakeHeartbeater()
 	script := newScriptMock(hb, sleeperExec{}, logger, time.Hour, time.Nanosecond)
@@ -151,6 +156,8 @@ func TestScript_Exec_TimeoutCritical(t *testing.T) {
 // TestScript_Exec_Shutdown asserts a script will be executed once more
 // when told to shutdown.
 func TestScript_Exec_Shutdown(t *testing.T) {
+	testutil.Parallel(t)
+
 	shutdown := make(chan struct{})
 	exec := newSimpleExec(0, nil)
 	logger := testlog.HCLogger(t)
@@ -180,6 +187,7 @@ func TestScript_Exec_Shutdown(t *testing.T) {
 // TestScript_Exec_Codes asserts script exit codes are translated to their
 // corresponding Consul health check status.
 func TestScript_Exec_Codes(t *testing.T) {
+	testutil.Parallel(t)
 
 	exec := newScriptedExec([]execResult{
 		{[]byte("output"), 1, nil},
@@ -224,6 +232,7 @@ func TestScript_Exec_Codes(t *testing.T) {
 // TestScript_TaskEnvInterpolation asserts that script check hooks are
 // interpolated in the same way that services are
 func TestScript_TaskEnvInterpolation(t *testing.T) {
+	testutil.Parallel(t)
 
 	logger := testlog.HCLogger(t)
 	consulClient := consul.NewMockConsulServiceClient(t, logger)
@@ -288,6 +297,8 @@ func TestScript_TaskEnvInterpolation(t *testing.T) {
 }
 
 func TestScript_associated(t *testing.T) {
+	testutil.Parallel(t)
+
 	t.Run("neither set", func(t *testing.T) {
 		require.False(t, new(scriptCheckHook).associated("task1", "", ""))
 	})

--- a/client/allocrunner/taskrunner/tasklet_test.go
+++ b/client/allocrunner/taskrunner/tasklet_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/interfaces"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/testtask"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,6 +24,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestTasklet_Exec_HappyPath(t *testing.T) {
+	testutil.Parallel(t)
+
 	results := []execResult{
 		{[]byte("output"), 0, nil},
 		{[]byte("output"), 1, nil},
@@ -53,6 +56,8 @@ func TestTasklet_Exec_HappyPath(t *testing.T) {
 // TestTasklet_Exec_Cancel asserts cancelling a tasklet short-circuits
 // any running executions the tasklet
 func TestTasklet_Exec_Cancel(t *testing.T) {
+	testutil.Parallel(t)
+
 	exec, cancel := newBlockingScriptExec()
 	defer cancel()
 	tm := newTaskletMock(exec, testlog.HCLogger(t), time.Hour, time.Hour)
@@ -85,7 +90,8 @@ func TestTasklet_Exec_Cancel(t *testing.T) {
 // TestTasklet_Exec_Timeout asserts a tasklet script will be killed
 // when the timeout is reached.
 func TestTasklet_Exec_Timeout(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	exec, cancel := newBlockingScriptExec()
 	defer cancel()
 
@@ -125,6 +131,8 @@ func TestTasklet_Exec_Timeout(t *testing.T) {
 // TestTasklet_Exec_Shutdown asserts a script will be executed once more
 // when told to shutdown.
 func TestTasklet_Exec_Shutdown(t *testing.T) {
+	testutil.Parallel(t)
+
 	exec := newSimpleExec(0, nil)
 	shutdown := make(chan struct{})
 	tm := newTaskletMock(exec, testlog.HCLogger(t), time.Hour, 3*time.Second)

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -230,7 +230,8 @@ func (h *testHarness) stop() {
 }
 
 func TestTaskTemplateManager_InvalidConfig(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	hooks := NewMockTaskHooks()
 	clientConfig := &config.Config{Region: "global"}
 	taskDir := "foo"
@@ -371,7 +372,8 @@ func TestTaskTemplateManager_InvalidConfig(t *testing.T) {
 }
 
 func TestTaskTemplateManager_HostPath(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	// Make a template that will render immediately and write it to a tmp file
 	f, err := ioutil.TempFile("", "")
 	if err != nil {
@@ -463,7 +465,8 @@ func TestTaskTemplateManager_HostPath(t *testing.T) {
 }
 
 func TestTaskTemplateManager_Unblock_Static(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	// Make a template that will render immediately
 	content := "hello, world!"
 	file := "my.tmpl"
@@ -497,7 +500,8 @@ func TestTaskTemplateManager_Unblock_Static(t *testing.T) {
 }
 
 func TestTaskTemplateManager_Permissions(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	// Make a template that will render immediately
 	content := "hello, world!"
 	file := "my.tmpl"
@@ -532,7 +536,8 @@ func TestTaskTemplateManager_Permissions(t *testing.T) {
 }
 
 func TestTaskTemplateManager_Unblock_Static_NomadEnv(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	// Make a template that will render immediately
 	content := `Hello Nomad Task: {{env "NOMAD_TASK_NAME"}}`
 	expected := fmt.Sprintf("Hello Nomad Task: %s", TestTaskName)
@@ -567,7 +572,8 @@ func TestTaskTemplateManager_Unblock_Static_NomadEnv(t *testing.T) {
 }
 
 func TestTaskTemplateManager_Unblock_Static_AlreadyRendered(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	// Make a template that will render immediately
 	content := "hello, world!"
 	file := "my.tmpl"
@@ -608,7 +614,8 @@ func TestTaskTemplateManager_Unblock_Static_AlreadyRendered(t *testing.T) {
 }
 
 func TestTaskTemplateManager_Unblock_Consul(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	// Make a template that will render based on a key in Consul
 	key := "foo"
 	content := "barbaz"
@@ -654,8 +661,8 @@ func TestTaskTemplateManager_Unblock_Consul(t *testing.T) {
 }
 
 func TestTaskTemplateManager_Unblock_Vault(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	// Make a template that will render based on a key in Vault
 	vaultPath := "secret/data/password"
 	key := "password"
@@ -682,7 +689,7 @@ func TestTaskTemplateManager_Unblock_Vault(t *testing.T) {
 	// Write the secret to Vault
 	logical := harness.vault.Client.Logical()
 	_, err := logical.Write(vaultPath, map[string]interface{}{"data": map[string]interface{}{key: content}})
-	require.NoError(err)
+	require.NoError(t, err)
 
 	// Wait for the unblock
 	select {
@@ -704,7 +711,8 @@ func TestTaskTemplateManager_Unblock_Vault(t *testing.T) {
 }
 
 func TestTaskTemplateManager_Unblock_Multi_Template(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	// Make a template that will render immediately
 	staticContent := "hello, world!"
 	staticFile := "my.tmpl"
@@ -772,8 +780,8 @@ func TestTaskTemplateManager_Unblock_Multi_Template(t *testing.T) {
 // TestTaskTemplateManager_FirstRender_Restored tests that a task that's been
 // restored renders and triggers its change mode if the template has changed
 func TestTaskTemplateManager_FirstRender_Restored(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	// Make a template that will render based on a key in Vault
 	vaultPath := "secret/data/password"
 	key := "password"
@@ -793,27 +801,27 @@ func TestTaskTemplateManager_FirstRender_Restored(t *testing.T) {
 	// Ensure no unblock
 	select {
 	case <-harness.mockHooks.UnblockCh:
-		require.Fail("Task unblock should not have been called")
+		require.Fail(t, "Task unblock should not have been called")
 	case <-time.After(time.Duration(1*testutil.TestMultiplier()) * time.Second):
 	}
 
 	// Write the secret to Vault
 	logical := harness.vault.Client.Logical()
 	_, err := logical.Write(vaultPath, map[string]interface{}{"data": map[string]interface{}{key: content}})
-	require.NoError(err)
+	require.NoError(t, err)
 
 	// Wait for the unblock
 	select {
 	case <-harness.mockHooks.UnblockCh:
 	case <-time.After(time.Duration(5*testutil.TestMultiplier()) * time.Second):
-		require.Fail("Task unblock should have been called")
+		require.Fail(t, "Task unblock should have been called")
 	}
 
 	// Check the file is there
 	path := filepath.Join(harness.taskDir, file)
 	raw, err := ioutil.ReadFile(path)
-	require.NoError(err, "Failed to read rendered template from %q", path)
-	require.Equal(content, string(raw), "Unexpected template data; got %s, want %q", raw, content)
+	require.NoError(t, err, "Failed to read rendered template from %q", path)
+	require.Equal(t, content, string(raw), "Unexpected template data; got %s, want %q", raw, content)
 
 	// task is now running
 	harness.mockHooks.hasHandle = true
@@ -827,14 +835,14 @@ func TestTaskTemplateManager_FirstRender_Restored(t *testing.T) {
 	select {
 	case <-harness.mockHooks.UnblockCh:
 	case <-time.After(time.Duration(5*testutil.TestMultiplier()) * time.Second):
-		require.Fail("Task unblock should have been called")
+		require.Fail(t, "Task unblock should have been called")
 	}
 
 	select {
 	case <-harness.mockHooks.RestartCh:
-		require.Fail("should not have restarted", harness.mockHooks)
+		require.Fail(t, "should not have restarted", harness.mockHooks)
 	case <-harness.mockHooks.SignalCh:
-		require.Fail("should not have restarted", harness.mockHooks)
+		require.Fail(t, "should not have restarted", harness.mockHooks)
 	case <-time.After(time.Duration(1*testutil.TestMultiplier()) * time.Second):
 	}
 
@@ -842,7 +850,7 @@ func TestTaskTemplateManager_FirstRender_Restored(t *testing.T) {
 	harness.manager.Stop()
 	content = "bazbar"
 	_, err = logical.Write(vaultPath, map[string]interface{}{"data": map[string]interface{}{key: content}})
-	require.NoError(err)
+	require.NoError(t, err)
 	harness.mockHooks.UnblockCh = make(chan struct{}, 1)
 	harness.start(t)
 
@@ -850,7 +858,7 @@ func TestTaskTemplateManager_FirstRender_Restored(t *testing.T) {
 	select {
 	case <-harness.mockHooks.UnblockCh:
 	case <-time.After(time.Duration(5*testutil.TestMultiplier()) * time.Second):
-		require.Fail("Task unblock should have been called")
+		require.Fail(t, "Task unblock should have been called")
 	}
 
 	// Wait for restart
@@ -861,15 +869,16 @@ OUTER:
 		case <-harness.mockHooks.RestartCh:
 			break OUTER
 		case <-harness.mockHooks.SignalCh:
-			require.Fail("Signal with restart policy", harness.mockHooks)
+			require.Fail(t, "Signal with restart policy", harness.mockHooks)
 		case <-timeout:
-			require.Fail("Should have received a restart", harness.mockHooks)
+			require.Fail(t, "Should have received a restart", harness.mockHooks)
 		}
 	}
 }
 
 func TestTaskTemplateManager_Rerender_Noop(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	// Make a template that will render based on a key in Consul
 	key := "foo"
 	content1 := "bar"
@@ -938,7 +947,8 @@ func TestTaskTemplateManager_Rerender_Noop(t *testing.T) {
 }
 
 func TestTaskTemplateManager_Rerender_Signal(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	// Make a template that renders based on a key in Consul and sends SIGALRM
 	key1 := "foo"
 	content1_1 := "bar"
@@ -1038,7 +1048,8 @@ OUTER:
 }
 
 func TestTaskTemplateManager_Rerender_Restart(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	// Make a template that renders based on a key in Consul and sends restart
 	key1 := "bam"
 	content1_1 := "cat"
@@ -1102,7 +1113,8 @@ OUTER:
 }
 
 func TestTaskTemplateManager_Interpolate_Destination(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	// Make a template that will have its destination interpolated
 	content := "hello, world!"
 	file := "${node.unique.id}.tmpl"
@@ -1137,8 +1149,7 @@ func TestTaskTemplateManager_Interpolate_Destination(t *testing.T) {
 }
 
 func TestTaskTemplateManager_Signal_Error(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Make a template that renders based on a key in Consul and sends SIGALRM
 	key1 := "foo"
@@ -1180,8 +1191,8 @@ func TestTaskTemplateManager_Signal_Error(t *testing.T) {
 		t.Fatalf("Should have received a signals: %+v", harness.mockHooks)
 	}
 
-	require.NotNil(harness.mockHooks.KillEvent)
-	require.Contains(harness.mockHooks.KillEvent.DisplayMessage, "failed to send signals")
+	require.NotNil(t, harness.mockHooks.KillEvent)
+	require.Contains(t, harness.mockHooks.KillEvent.DisplayMessage, "failed to send signals")
 }
 
 // TestTaskTemplateManager_FiltersProcessEnvVars asserts that we only render
@@ -1189,7 +1200,7 @@ func TestTaskTemplateManager_Signal_Error(t *testing.T) {
 // process environment variables.  nomad host process environment variables
 // are to be treated the same as not found environment variables.
 func TestTaskTemplateManager_FiltersEnvVars(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	defer os.Setenv("NOMAD_TASK_NAME", os.Getenv("NOMAD_TASK_NAME"))
 	os.Setenv("NOMAD_TASK_NAME", "should be overridden by task")
@@ -1233,7 +1244,8 @@ TEST_ENV_NOT_FOUND: {{env "` + testenv + `_NOTFOUND" }}`
 // TestTaskTemplateManager_Env asserts templates with the env flag set are read
 // into the task's environment.
 func TestTaskTemplateManager_Env(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	template := &structs.Template{
 		EmbeddedTmpl: `
 # Comment lines are ok
@@ -1276,7 +1288,8 @@ ANYTHING_goes=Spaces are=ok!
 // TestTaskTemplateManager_Env_Missing asserts the core env
 // template processing function returns errors when files don't exist
 func TestTaskTemplateManager_Env_Missing(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	d, err := ioutil.TempDir("", "ct_env_missing")
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -1311,8 +1324,7 @@ func TestTaskTemplateManager_Env_Missing(t *testing.T) {
 // TestTaskTemplateManager_Env_InterpolatedDest asserts the core env
 // template processing function handles interpolated destinations
 func TestTaskTemplateManager_Env_InterpolatedDest(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	d, err := ioutil.TempDir("", "ct_env_interpolated")
 	if err != nil {
@@ -1343,16 +1355,17 @@ func TestTaskTemplateManager_Env_InterpolatedDest(t *testing.T) {
 		d, "")
 
 	vars, err := loadTemplateEnv(templates, taskEnv)
-	require.NoError(err)
-	require.Contains(vars, "FOO")
-	require.Equal(vars["FOO"], "bar")
+	require.NoError(t, err)
+	require.Contains(t, vars, "FOO")
+	require.Equal(t, vars["FOO"], "bar")
 }
 
 // TestTaskTemplateManager_Env_Multi asserts the core env
 // template processing function returns combined env vars from multiple
 // templates correctly.
 func TestTaskTemplateManager_Env_Multi(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	d, err := ioutil.TempDir("", "ct_env_missing")
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -1398,7 +1411,8 @@ func TestTaskTemplateManager_Env_Multi(t *testing.T) {
 }
 
 func TestTaskTemplateManager_Rerender_Env(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	// Make a template that renders based on a key in Consul and sends restart
 	key1 := "bam"
 	key2 := "bar"
@@ -1480,7 +1494,8 @@ OUTER:
 // TestTaskTemplateManager_Config_ServerName asserts the tls_server_name
 // setting is propagated to consul-template's configuration. See #2776
 func TestTaskTemplateManager_Config_ServerName(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	c := config.DefaultConfig()
 	c.VaultConfig = &sconfig.VaultConfig{
 		Enabled:       helper.BoolToPtr(true),
@@ -1504,8 +1519,7 @@ func TestTaskTemplateManager_Config_ServerName(t *testing.T) {
 // TestTaskTemplateManager_Config_VaultNamespace asserts the Vault namespace setting is
 // propagated to consul-template's configuration.
 func TestTaskTemplateManager_Config_VaultNamespace(t *testing.T) {
-	t.Parallel()
-	assert := assert.New(t)
+	testutil.Parallel(t)
 
 	testNS := "test-namespace"
 	c := config.DefaultConfig()
@@ -1525,18 +1539,17 @@ func TestTaskTemplateManager_Config_VaultNamespace(t *testing.T) {
 	}
 
 	ctmplMapping, err := parseTemplateConfigs(config)
-	assert.Nil(err, "Parsing Templates")
+	assert.Nil(t, err, "Parsing Templates")
 
 	ctconf, err := newRunnerConfig(config, ctmplMapping)
-	assert.Nil(err, "Building Runner Config")
-	assert.Equal(testNS, *ctconf.Vault.Namespace, "Vault Namespace Value")
+	assert.Nil(t, err, "Building Runner Config")
+	assert.Equal(t, testNS, *ctconf.Vault.Namespace, "Vault Namespace Value")
 }
 
 // TestTaskTemplateManager_Config_VaultNamespace asserts the Vault namespace setting is
 // propagated to consul-template's configuration.
 func TestTaskTemplateManager_Config_VaultNamespace_TaskOverride(t *testing.T) {
-	t.Parallel()
-	assert := assert.New(t)
+	testutil.Parallel(t)
 
 	testNS := "test-namespace"
 	c := config.DefaultConfig()
@@ -1560,17 +1573,17 @@ func TestTaskTemplateManager_Config_VaultNamespace_TaskOverride(t *testing.T) {
 	}
 
 	ctmplMapping, err := parseTemplateConfigs(config)
-	assert.Nil(err, "Parsing Templates")
+	assert.Nil(t, err, "Parsing Templates")
 
 	ctconf, err := newRunnerConfig(config, ctmplMapping)
-	assert.Nil(err, "Building Runner Config")
-	assert.Equal(overriddenNS, *ctconf.Vault.Namespace, "Vault Namespace Value")
+	assert.Nil(t, err, "Building Runner Config")
+	assert.Equal(t, overriddenNS, *ctconf.Vault.Namespace, "Vault Namespace Value")
 }
 
 // TestTaskTemplateManager_Escapes asserts that when sandboxing is enabled
 // interpolated paths are not incorrectly treated as escaping the alloc dir.
 func TestTaskTemplateManager_Escapes(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	clientConf := config.DefaultConfig()
 	require.False(t, clientConf.TemplateConfig.DisableSandbox, "expected sandbox to be disabled")
@@ -1818,12 +1831,12 @@ func TestTaskTemplateManager_Escapes(t *testing.T) {
 }
 
 func TestTaskTemplateManager_BlockedEvents(t *testing.T) {
+	testutil.Parallel(t)
+
 	// The tests sets a template that need keys 0, 1, 2, 3, 4,
 	// then subsequently sets 0, 1, 2 keys
 	// then asserts that templates are still blocked on 3 and 4,
 	// and check that we got the relevant task events
-	t.Parallel()
-	require := require.New(t)
 
 	// Make a template that will render based on a key in Consul
 	var embedded string
@@ -1875,11 +1888,11 @@ func TestTaskTemplateManager_BlockedEvents(t *testing.T) {
 
 	// Check to see we got a correct message
 	// assert that all 0-4 keys are missing
-	require.Len(harness.mockHooks.Events, 1)
+	require.Len(t, harness.mockHooks.Events, 1)
 	t.Logf("first message: %v", harness.mockHooks.Events[0])
 	missing, more := missingKeys(harness.mockHooks.Events[0])
-	require.Equal(5, len(missing)+more)
-	require.Contains(harness.mockHooks.Events[0].DisplayMessage, "and 2 more")
+	require.Equal(t, 5, len(missing)+more)
+	require.Contains(t, harness.mockHooks.Events[0].DisplayMessage, "and 2 more")
 
 	// Write 0-2 keys to Consul
 	for i := 0; i < 3; i++ {
@@ -1920,7 +1933,7 @@ WAIT_LOOP:
 // configuration is accurately mapped from the client to the TaskTemplateManager
 // and that any operator defined boundaries are enforced.
 func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	testNS := "test-namespace"
 
@@ -2126,7 +2139,7 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 // configuration is accurately mapped from the template to the TaskTemplateManager's
 // template config.
 func TestTaskTemplateManager_Template_Wait_Set(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c := config.DefaultConfig()
 	c.Node = mock.Node()
@@ -2150,7 +2163,7 @@ func TestTaskTemplateManager_Template_Wait_Set(t *testing.T) {
 	templateMapping, err := parseTemplateConfigs(ttmConfig)
 	require.NoError(t, err)
 
-	for k, _ := range templateMapping {
+	for k := range templateMapping {
 		require.True(t, *k.Wait.Enabled)
 		require.Equal(t, 5*time.Second, *k.Wait.Min)
 		require.Equal(t, 10*time.Second, *k.Wait.Max)

--- a/client/allocrunner/taskrunner/validate_hook_test.go
+++ b/client/allocrunner/taskrunner/validate_hook_test.go
@@ -6,11 +6,12 @@ import (
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTaskRunner_Validate_UserEnforcement(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	taskEnv := taskenv.NewEmptyBuilder().Build()
 	conf := config.DefaultConfig()
@@ -35,7 +36,7 @@ func TestTaskRunner_Validate_UserEnforcement(t *testing.T) {
 }
 
 func TestTaskRunner_Validate_ServiceName(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	builder := taskenv.NewEmptyBuilder()
 	conf := config.DefaultConfig()

--- a/client/allocwatcher/alloc_watcher_test.go
+++ b/client/allocwatcher/alloc_watcher_test.go
@@ -88,6 +88,8 @@ func newConfig(t *testing.T) (Config, func()) {
 // TestPrevAlloc_Noop asserts that when no previous allocation is set the noop
 // implementation is returned that does not block or perform migrations.
 func TestPrevAlloc_Noop(t *testing.T) {
+	testutil.Parallel(t)
+
 	conf, cleanup := newConfig(t)
 	defer cleanup()
 
@@ -114,7 +116,8 @@ func TestPrevAlloc_Noop(t *testing.T) {
 // TestPrevAlloc_LocalPrevAlloc_Block asserts that when a previous alloc runner
 // is set a localPrevAlloc will block on it.
 func TestPrevAlloc_LocalPrevAlloc_Block(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	conf, cleanup := newConfig(t)
 
 	defer cleanup()
@@ -181,7 +184,8 @@ func TestPrevAlloc_LocalPrevAlloc_Block(t *testing.T) {
 // TestPrevAlloc_LocalPrevAlloc_Terminated asserts that when a previous alloc
 // runner has already terminated the watcher does not block on the broadcaster.
 func TestPrevAlloc_LocalPrevAlloc_Terminated(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	conf, cleanup := newConfig(t)
 	defer cleanup()
 
@@ -201,7 +205,8 @@ func TestPrevAlloc_LocalPrevAlloc_Terminated(t *testing.T) {
 // streaming a tar cause the migration to be cancelled and no files are written
 // (migrations are atomic).
 func TestPrevAlloc_StreamAllocDir_Error(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	dest, err := ioutil.TempDir("", "nomadtest-")
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/client/allocwatcher/alloc_watcher_unix_test.go
+++ b/client/allocwatcher/alloc_watcher_unix_test.go
@@ -23,7 +23,7 @@ import (
 // works.
 func TestPrevAlloc_StreamAllocDir_Ok(t *testing.T) {
 	ctestutil.RequireRoot(t)
-	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/client/allocwatcher/group_alloc_watcher_test.go
+++ b/client/allocwatcher/group_alloc_watcher_test.go
@@ -13,7 +13,8 @@ import (
 // TestPrevAlloc_GroupPrevAllocWatcher_Block asserts that when there are
 // prevAllocs is set a groupPrevAllocWatcher will block on them
 func TestPrevAlloc_GroupPrevAllocWatcher_Block(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	conf, cleanup := newConfig(t)
 
 	defer cleanup()
@@ -80,7 +81,8 @@ func TestPrevAlloc_GroupPrevAllocWatcher_Block(t *testing.T) {
 // multiple prevAllocs is set a groupPrevAllocWatcher will block until all
 // are complete
 func TestPrevAlloc_GroupPrevAllocWatcher_BlockMulti(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	conf1, cleanup1 := newConfig(t)
 	defer cleanup1()
 	conf1.Alloc.Job.TaskGroups[0].Tasks[0].Config = map[string]interface{}{

--- a/client/client_stats_endpoint_test.go
+++ b/client/client_stats_endpoint_test.go
@@ -8,26 +8,26 @@ import (
 	"github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/mock"
 	nstructs "github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestClientStats_Stats(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	client, cleanup := TestClient(t, nil)
 	defer cleanup()
 
 	req := &nstructs.NodeSpecificRequest{}
 	var resp structs.ClientStatsResponse
-	require.Nil(client.ClientRPC("ClientStats.Stats", &req, &resp))
-	require.NotNil(resp.HostStats)
-	require.NotNil(resp.HostStats.AllocDirStats)
-	require.NotZero(resp.HostStats.Uptime)
+	require.Nil(t, client.ClientRPC("ClientStats.Stats", &req, &resp))
+	require.NotNil(t, resp.HostStats)
+	require.NotNil(t, resp.HostStats.AllocDirStats)
+	require.NotZero(t, resp.HostStats.Uptime)
 }
 
 func TestClientStats_Stats_ACL(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	server, addr, root, cleanupS := testACLServer(t, nil)
 	defer cleanupS()
@@ -43,8 +43,8 @@ func TestClientStats_Stats_ACL(t *testing.T) {
 		req := &nstructs.NodeSpecificRequest{}
 		var resp structs.ClientStatsResponse
 		err := client.ClientRPC("ClientStats.Stats", &req, &resp)
-		require.NotNil(err)
-		require.EqualError(err, nstructs.ErrPermissionDenied.Error())
+		require.NotNil(t, err)
+		require.EqualError(t, err, nstructs.ErrPermissionDenied.Error())
 	}
 
 	// Try request with an invalid token and expect failure
@@ -56,8 +56,8 @@ func TestClientStats_Stats_ACL(t *testing.T) {
 		var resp structs.ClientStatsResponse
 		err := client.ClientRPC("ClientStats.Stats", &req, &resp)
 
-		require.NotNil(err)
-		require.EqualError(err, nstructs.ErrPermissionDenied.Error())
+		require.NotNil(t, err)
+		require.EqualError(t, err, nstructs.ErrPermissionDenied.Error())
 	}
 
 	// Try request with a valid token
@@ -69,8 +69,8 @@ func TestClientStats_Stats_ACL(t *testing.T) {
 		var resp structs.ClientStatsResponse
 		err := client.ClientRPC("ClientStats.Stats", &req, &resp)
 
-		require.Nil(err)
-		require.NotNil(resp.HostStats)
+		require.Nil(t, err)
+		require.NotNil(t, resp.HostStats)
 	}
 
 	// Try request with a management token
@@ -81,7 +81,7 @@ func TestClientStats_Stats_ACL(t *testing.T) {
 		var resp structs.ClientStatsResponse
 		err := client.ClientRPC("ClientStats.Stats", &req, &resp)
 
-		require.Nil(err)
-		require.NotNil(resp.HostStats)
+		require.Nil(t, err)
+		require.NotNil(t, resp.HostStats)
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -45,7 +45,8 @@ func testServer(t *testing.T, cb func(*nomad.Config)) (*nomad.Server, string, fu
 }
 
 func TestClient_StartStop(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	client, cleanup := TestClient(t, nil)
 	defer cleanup()
 	if err := client.Shutdown(); err != nil {
@@ -56,8 +57,7 @@ func TestClient_StartStop(t *testing.T) {
 // Certain labels for metrics are dependant on client initial setup. This tests
 // that the client has properly initialized before we assign values to labels
 func TestClient_BaseLabels(t *testing.T) {
-	t.Parallel()
-	assert := assert.New(t)
+	testutil.Parallel(t)
 
 	client, cleanup := TestClient(t, nil)
 	if err := client.Shutdown(); err != nil {
@@ -70,18 +70,18 @@ func TestClient_BaseLabels(t *testing.T) {
 	client.emitStats()
 
 	baseLabels := client.baseLabels
-	assert.NotEqual(0, len(baseLabels))
+	assert.NotEqual(t, 0, len(baseLabels))
 
 	nodeID := client.Node().ID
 	for _, e := range baseLabels {
 		if e.Name == "node_id" {
-			assert.Equal(nodeID, e.Value)
+			assert.Equal(t, nodeID, e.Value)
 		}
 	}
 }
 
 func TestClient_RPC(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	_, addr, cleanupS1 := testServer(t, nil)
 	defer cleanupS1()
@@ -102,7 +102,7 @@ func TestClient_RPC(t *testing.T) {
 }
 
 func TestClient_RPC_FireRetryWatchers(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	_, addr, cleanupS1 := testServer(t, nil)
 	defer cleanupS1()
@@ -131,7 +131,7 @@ func TestClient_RPC_FireRetryWatchers(t *testing.T) {
 }
 
 func TestClient_RPC_Passthrough(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	s1, _, cleanupS1 := testServer(t, nil)
 	defer cleanupS1()
@@ -152,7 +152,7 @@ func TestClient_RPC_Passthrough(t *testing.T) {
 }
 
 func TestClient_Fingerprint(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, cleanup := TestClient(t, nil)
 	defer cleanup()
@@ -175,7 +175,7 @@ func TestClient_Fingerprint(t *testing.T) {
 // TestClient_Fingerprint_Periodic asserts that driver node attributes are
 // periodically fingerprinted.
 func TestClient_Fingerprint_Periodic(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c1, cleanup := TestClient(t, func(c *config.Config) {
 		confs := []*nconfig.PluginConfig{
@@ -253,7 +253,8 @@ func TestClient_Fingerprint_Periodic(t *testing.T) {
 // TestClient_MixedTLS asserts that when a server is running with TLS enabled
 // it will reject any RPC connections from clients that lack TLS. See #2525
 func TestClient_MixedTLS(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	const (
 		cafile  = "../helper/tlsutil/testdata/ca.pem"
 		foocert = "../helper/tlsutil/testdata/nomad-foo.pem"
@@ -300,7 +301,7 @@ func TestClient_MixedTLS(t *testing.T) {
 // enabled -- but their certificates are signed by different CAs -- they're
 // unable to communicate.
 func TestClient_BadTLS(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	const (
 		cafile  = "../helper/tlsutil/testdata/ca.pem"
@@ -356,7 +357,7 @@ func TestClient_BadTLS(t *testing.T) {
 }
 
 func TestClient_Register(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	s1, _, cleanupS1 := testServer(t, nil)
 	defer cleanupS1()
@@ -389,7 +390,7 @@ func TestClient_Register(t *testing.T) {
 }
 
 func TestClient_Heartbeat(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	s1, _, cleanupS1 := testServer(t, func(c *nomad.Config) {
 		c.MinHeartbeatTTL = 50 * time.Millisecond
@@ -426,7 +427,7 @@ func TestClient_Heartbeat(t *testing.T) {
 // TestClient_UpdateAllocStatus that once running allocations send updates to
 // the server.
 func TestClient_UpdateAllocStatus(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	s1, _, cleanupS1 := testServer(t, nil)
 	defer cleanupS1()
@@ -452,7 +453,7 @@ func TestClient_UpdateAllocStatus(t *testing.T) {
 }
 
 func TestClient_WatchAllocs(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	s1, _, cleanupS1 := testServer(t, nil)
 	defer cleanupS1()
@@ -552,7 +553,7 @@ func waitTilNodeReady(client *Client, t *testing.T) {
 }
 
 func TestClient_SaveRestoreState(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	s1, _, cleanupS1 := testServer(t, nil)
 	defer cleanupS1()
@@ -653,8 +654,7 @@ func TestClient_SaveRestoreState(t *testing.T) {
 }
 
 func TestClient_AddAllocError(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	s1, _, cleanupS1 := testServer(t, nil)
 	defer cleanupS1()
@@ -687,13 +687,13 @@ func TestClient_AddAllocError(t *testing.T) {
 
 	state := s1.State()
 	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
-	require.Nil(err)
+	require.Nil(t, err)
 
 	err = state.UpsertJobSummary(101, mock.JobSummary(alloc1.JobID))
-	require.Nil(err)
+	require.Nil(t, err)
 
 	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 102, []*structs.Allocation{alloc1})
-	require.Nil(err)
+	require.Nil(t, err)
 
 	// Push this alloc update to the client
 	allocUpdates := &allocUpdates{
@@ -716,20 +716,21 @@ func TestClient_AddAllocError(t *testing.T) {
 			return false, fmt.Errorf("expected alloc to be marked as invalid")
 		}
 		alloc, err := s1.State().AllocByID(nil, alloc1.ID)
-		require.Nil(err)
+		require.Nil(t, err)
 		failed := alloc.ClientStatus == structs.AllocClientStatusFailed
 		if !failed {
 			return false, fmt.Errorf("Expected failed client status, but got %v", alloc.ClientStatus)
 		}
 		return true, nil
 	}, func(err error) {
-		require.NoError(err)
+		require.NoError(t, err)
 	})
 
 }
 
 func TestClient_Init(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	dir, err := ioutil.TempDir("", "nomad")
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -759,7 +760,7 @@ func TestClient_Init(t *testing.T) {
 }
 
 func TestClient_BlockedAllocations(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	s1, _, cleanupS1 := testServer(t, nil)
 	defer cleanupS1()
@@ -872,8 +873,7 @@ func TestClient_BlockedAllocations(t *testing.T) {
 }
 
 func TestClient_ValidateMigrateToken_ValidToken(t *testing.T) {
-	t.Parallel()
-	assert := assert.New(t)
+	testutil.Parallel(t)
 
 	c, cleanup := TestClient(t, func(c *config.Config) {
 		c.ACLEnabled = true
@@ -882,40 +882,37 @@ func TestClient_ValidateMigrateToken_ValidToken(t *testing.T) {
 
 	alloc := mock.Alloc()
 	validToken, err := structs.GenerateMigrateToken(alloc.ID, c.secretNodeID())
-	assert.Nil(err)
+	assert.Nil(t, err)
 
-	assert.Equal(c.ValidateMigrateToken(alloc.ID, validToken), true)
+	assert.Equal(t, c.ValidateMigrateToken(alloc.ID, validToken), true)
 }
 
 func TestClient_ValidateMigrateToken_InvalidToken(t *testing.T) {
-	t.Parallel()
-	assert := assert.New(t)
+	testutil.Parallel(t)
 
 	c, cleanup := TestClient(t, func(c *config.Config) {
 		c.ACLEnabled = true
 	})
 	defer cleanup()
 
-	assert.Equal(c.ValidateMigrateToken("", ""), false)
+	assert.Equal(t, c.ValidateMigrateToken("", ""), false)
 
 	alloc := mock.Alloc()
-	assert.Equal(c.ValidateMigrateToken(alloc.ID, alloc.ID), false)
-	assert.Equal(c.ValidateMigrateToken(alloc.ID, ""), false)
+	assert.Equal(t, c.ValidateMigrateToken(alloc.ID, alloc.ID), false)
+	assert.Equal(t, c.ValidateMigrateToken(alloc.ID, ""), false)
 }
 
 func TestClient_ValidateMigrateToken_ACLDisabled(t *testing.T) {
-	t.Parallel()
-	assert := assert.New(t)
+	testutil.Parallel(t)
 
 	c, cleanup := TestClient(t, func(c *config.Config) {})
 	defer cleanup()
 
-	assert.Equal(c.ValidateMigrateToken("", ""), true)
+	assert.Equal(t, c.ValidateMigrateToken("", ""), true)
 }
 
 func TestClient_ReloadTLS_UpgradePlaintextToTLS(t *testing.T) {
-	t.Parallel()
-	assert := assert.New(t)
+	testutil.Parallel(t)
 
 	s1, addr, cleanupS1 := testServer(t, func(c *nomad.Config) {
 		c.Region = "global"
@@ -965,7 +962,7 @@ func TestClient_ReloadTLS_UpgradePlaintextToTLS(t *testing.T) {
 	}
 
 	err := c1.reloadTLSConnections(newConfig)
-	assert.Nil(err)
+	assert.Nil(t, err)
 
 	// Registering a node over plaintext should fail after the node has upgraded
 	// to TLS
@@ -990,8 +987,7 @@ func TestClient_ReloadTLS_UpgradePlaintextToTLS(t *testing.T) {
 }
 
 func TestClient_ReloadTLS_DowngradeTLSToPlaintext(t *testing.T) {
-	t.Parallel()
-	assert := assert.New(t)
+	testutil.Parallel(t)
 
 	s1, addr, cleanupS1 := testServer(t, func(c *nomad.Config) {
 		c.Region = "global"
@@ -1041,7 +1037,7 @@ func TestClient_ReloadTLS_DowngradeTLSToPlaintext(t *testing.T) {
 	newConfig := &nconfig.TLSConfig{}
 
 	err := c1.reloadTLSConnections(newConfig)
-	assert.Nil(err)
+	assert.Nil(t, err)
 
 	// assert that when both nodes are in plaintext mode, a RPC request should
 	// succeed
@@ -1067,7 +1063,8 @@ func TestClient_ReloadTLS_DowngradeTLSToPlaintext(t *testing.T) {
 // TestClient_ServerList tests client methods that interact with the internal
 // nomad server list.
 func TestClient_ServerList(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	client, cleanup := TestClient(t, func(c *config.Config) {})
 	defer cleanup()
 
@@ -1090,7 +1087,8 @@ func TestClient_ServerList(t *testing.T) {
 }
 
 func TestClient_UpdateNodeFromDevicesAccumulates(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	client, cleanup := TestClient(t, func(c *config.Config) {})
 	defer cleanup()
 
@@ -1188,10 +1186,11 @@ func TestClient_UpdateNodeFromDevicesAccumulates(t *testing.T) {
 // TestClient_UpdateNodeFromFingerprintKeepsConfig asserts manually configured
 // network interfaces take precedence over fingerprinted ones.
 func TestClient_UpdateNodeFromFingerprintKeepsConfig(t *testing.T) {
-	t.Parallel()
 	if runtime.GOOS != "linux" {
 		t.Skip("assertions assume linux platform")
 	}
+
+	testutil.Parallel(t)
 
 	// Client without network configured updates to match fingerprint
 	client, cleanup := TestClient(t, nil)
@@ -1266,7 +1265,7 @@ func TestClient_UpdateNodeFromFingerprintKeepsConfig(t *testing.T) {
 
 // Support multiple IP addresses (ipv4 vs. 6, e.g.) on the configured network interface
 func Test_UpdateNodeFromFingerprintMultiIP(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	var dev string
 	switch runtime.GOOS {
@@ -1304,6 +1303,8 @@ func Test_UpdateNodeFromFingerprintMultiIP(t *testing.T) {
 }
 
 func TestClient_computeAllocatedDeviceStats(t *testing.T) {
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 	c := &Client{logger: logger}
 
@@ -1400,8 +1401,8 @@ func TestClient_computeAllocatedDeviceStats(t *testing.T) {
 }
 
 func TestClient_getAllocatedResources(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	client, cleanup := TestClient(t, nil)
 	defer cleanup()
 
@@ -1416,7 +1417,7 @@ func TestClient_getAllocatedResources(t *testing.T) {
 	allocStops.AllocatedResources.Shared.DiskMB = 64
 	allocStops.AllocatedResources.Tasks["web"].Cpu = structs.AllocatedCpuResources{CpuShares: 64}
 	allocStops.AllocatedResources.Tasks["web"].Memory = structs.AllocatedMemoryResources{MemoryMB: 64}
-	require.Nil(client.addAlloc(allocStops, ""))
+	require.Nil(t, client.addAlloc(allocStops, ""))
 
 	allocFails := mock.BatchAlloc()
 	allocFails.Job.TaskGroups[0].Count = 1
@@ -1429,7 +1430,7 @@ func TestClient_getAllocatedResources(t *testing.T) {
 	allocFails.AllocatedResources.Shared.DiskMB = 128
 	allocFails.AllocatedResources.Tasks["web"].Cpu = structs.AllocatedCpuResources{CpuShares: 128}
 	allocFails.AllocatedResources.Tasks["web"].Memory = structs.AllocatedMemoryResources{MemoryMB: 128}
-	require.Nil(client.addAlloc(allocFails, ""))
+	require.Nil(t, client.addAlloc(allocFails, ""))
 
 	allocRuns := mock.Alloc()
 	allocRuns.Job.TaskGroups[0].Count = 1
@@ -1440,7 +1441,7 @@ func TestClient_getAllocatedResources(t *testing.T) {
 	allocRuns.AllocatedResources.Shared.DiskMB = 256
 	allocRuns.AllocatedResources.Tasks["web"].Cpu = structs.AllocatedCpuResources{CpuShares: 256}
 	allocRuns.AllocatedResources.Tasks["web"].Memory = structs.AllocatedMemoryResources{MemoryMB: 256}
-	require.Nil(client.addAlloc(allocRuns, ""))
+	require.Nil(t, client.addAlloc(allocRuns, ""))
 
 	allocPends := mock.Alloc()
 	allocPends.Job.TaskGroups[0].Count = 1
@@ -1452,7 +1453,7 @@ func TestClient_getAllocatedResources(t *testing.T) {
 	allocPends.AllocatedResources.Shared.DiskMB = 512
 	allocPends.AllocatedResources.Tasks["web"].Cpu = structs.AllocatedCpuResources{CpuShares: 512}
 	allocPends.AllocatedResources.Tasks["web"].Memory = structs.AllocatedMemoryResources{MemoryMB: 512}
-	require.Nil(client.addAlloc(allocPends, ""))
+	require.Nil(t, client.addAlloc(allocPends, ""))
 
 	// wait for allocStops to stop running and for allocRuns to be pending/running
 	testutil.WaitForResult(func() (bool, error) {
@@ -1486,7 +1487,7 @@ func TestClient_getAllocatedResources(t *testing.T) {
 
 		return true, nil
 	}, func(err error) {
-		require.NoError(err)
+		require.NoError(t, err)
 	})
 
 	result := client.getAllocatedResources(client.config.Node)
@@ -1515,7 +1516,8 @@ func TestClient_getAllocatedResources(t *testing.T) {
 }
 
 func TestClient_updateNodeFromDriverUpdatesAll(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	client, cleanup := TestClient(t, nil)
 	defer cleanup()
 
@@ -1598,7 +1600,7 @@ func TestClient_updateNodeFromDriverUpdatesAll(t *testing.T) {
 
 // COMPAT(0.12): remove once upgrading from 0.9.5 is no longer supported
 func TestClient_hasLocalState(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, cleanup := TestClient(t, nil)
 	defer cleanup()
@@ -1638,7 +1640,7 @@ func TestClient_hasLocalState(t *testing.T) {
 }
 
 func Test_verifiedTasks(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	logger := testlog.HCLogger(t)
 
 	// produce a result and check against expected tasks and/or error output

--- a/client/config/testing.go
+++ b/client/config/testing.go
@@ -34,7 +34,7 @@ func TestClientConfig(t testing.T) (*Config, func()) {
 		t.Fatalf("error creating client dir: %v", err)
 	}
 	cleanup := func() {
-		os.RemoveAll(parent)
+		_ = os.RemoveAll(parent)
 	}
 
 	allocDir := filepath.Join(parent, "allocs")

--- a/client/csi_endpoint_test.go
+++ b/client/csi_endpoint_test.go
@@ -9,6 +9,7 @@ import (
 	nstructs "github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/csi"
 	"github.com/hashicorp/nomad/plugins/csi/fake"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,7 +26,7 @@ var fakeNodePlugin = &dynamicplugins.PluginInfo{
 }
 
 func TestCSIController_AttachVolume(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		Name             string
@@ -144,7 +145,6 @@ func TestCSIController_AttachVolume(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			require := require.New(t)
 			client, cleanup := TestClient(t, nil)
 			defer cleanup()
 
@@ -159,20 +159,20 @@ func TestCSIController_AttachVolume(t *testing.T) {
 			client.dynamicRegistry.StubDispenserForType(dynamicplugins.PluginTypeCSIController, dispenserFunc)
 
 			err := client.dynamicRegistry.RegisterPlugin(fakePlugin)
-			require.Nil(err)
+			require.Nil(t, err)
 
 			var resp structs.ClientCSIControllerAttachVolumeResponse
 			err = client.ClientRPC("CSI.ControllerAttachVolume", tc.Request, &resp)
-			require.Equal(tc.ExpectedErr, err)
+			require.Equal(t, tc.ExpectedErr, err)
 			if tc.ExpectedResponse != nil {
-				require.Equal(tc.ExpectedResponse, &resp)
+				require.Equal(t, tc.ExpectedResponse, &resp)
 			}
 		})
 	}
 }
 
 func TestCSIController_ValidateVolume(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		Name             string
@@ -247,7 +247,6 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			require := require.New(t)
 			client, cleanup := TestClient(t, nil)
 			defer cleanup()
 
@@ -262,20 +261,20 @@ func TestCSIController_ValidateVolume(t *testing.T) {
 			client.dynamicRegistry.StubDispenserForType(dynamicplugins.PluginTypeCSIController, dispenserFunc)
 
 			err := client.dynamicRegistry.RegisterPlugin(fakePlugin)
-			require.Nil(err)
+			require.Nil(t, err)
 
 			var resp structs.ClientCSIControllerValidateVolumeResponse
 			err = client.ClientRPC("CSI.ControllerValidateVolume", tc.Request, &resp)
-			require.Equal(tc.ExpectedErr, err)
+			require.Equal(t, tc.ExpectedErr, err)
 			if tc.ExpectedResponse != nil {
-				require.Equal(tc.ExpectedResponse, &resp)
+				require.Equal(t, tc.ExpectedResponse, &resp)
 			}
 		})
 	}
 }
 
 func TestCSIController_DetachVolume(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		Name             string
@@ -330,7 +329,6 @@ func TestCSIController_DetachVolume(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			require := require.New(t)
 			client, cleanup := TestClient(t, nil)
 			defer cleanup()
 
@@ -345,20 +343,20 @@ func TestCSIController_DetachVolume(t *testing.T) {
 			client.dynamicRegistry.StubDispenserForType(dynamicplugins.PluginTypeCSIController, dispenserFunc)
 
 			err := client.dynamicRegistry.RegisterPlugin(fakePlugin)
-			require.Nil(err)
+			require.Nil(t, err)
 
 			var resp structs.ClientCSIControllerDetachVolumeResponse
 			err = client.ClientRPC("CSI.ControllerDetachVolume", tc.Request, &resp)
-			require.Equal(tc.ExpectedErr, err)
+			require.Equal(t, tc.ExpectedErr, err)
 			if tc.ExpectedResponse != nil {
-				require.Equal(tc.ExpectedResponse, &resp)
+				require.Equal(t, tc.ExpectedResponse, &resp)
 			}
 		})
 	}
 }
 
 func TestCSIController_CreateVolume(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		Name             string
@@ -431,7 +429,6 @@ func TestCSIController_CreateVolume(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			require := require.New(t)
 			client, cleanup := TestClient(t, nil)
 			defer cleanup()
 
@@ -447,20 +444,20 @@ func TestCSIController_CreateVolume(t *testing.T) {
 				dynamicplugins.PluginTypeCSIController, dispenserFunc)
 
 			err := client.dynamicRegistry.RegisterPlugin(fakePlugin)
-			require.Nil(err)
+			require.Nil(t, err)
 
 			var resp structs.ClientCSIControllerCreateVolumeResponse
 			err = client.ClientRPC("CSI.ControllerCreateVolume", tc.Request, &resp)
-			require.Equal(tc.ExpectedErr, err)
+			require.Equal(t, tc.ExpectedErr, err)
 			if tc.ExpectedResponse != nil {
-				require.Equal(tc.ExpectedResponse, &resp)
+				require.Equal(t, tc.ExpectedResponse, &resp)
 			}
 		})
 	}
 }
 
 func TestCSIController_DeleteVolume(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		Name             string
@@ -495,7 +492,6 @@ func TestCSIController_DeleteVolume(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			require := require.New(t)
 			client, cleanup := TestClient(t, nil)
 			defer cleanup()
 
@@ -511,20 +507,20 @@ func TestCSIController_DeleteVolume(t *testing.T) {
 				dynamicplugins.PluginTypeCSIController, dispenserFunc)
 
 			err := client.dynamicRegistry.RegisterPlugin(fakePlugin)
-			require.Nil(err)
+			require.Nil(t, err)
 
 			var resp structs.ClientCSIControllerDeleteVolumeResponse
 			err = client.ClientRPC("CSI.ControllerDeleteVolume", tc.Request, &resp)
-			require.Equal(tc.ExpectedErr, err)
+			require.Equal(t, tc.ExpectedErr, err)
 			if tc.ExpectedResponse != nil {
-				require.Equal(tc.ExpectedResponse, &resp)
+				require.Equal(t, tc.ExpectedResponse, &resp)
 			}
 		})
 	}
 }
 
 func TestCSIController_ListVolumes(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		Name             string
@@ -604,7 +600,6 @@ func TestCSIController_ListVolumes(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			require := require.New(t)
 			client, cleanup := TestClient(t, nil)
 			defer cleanup()
 
@@ -620,19 +615,19 @@ func TestCSIController_ListVolumes(t *testing.T) {
 				dynamicplugins.PluginTypeCSIController, dispenserFunc)
 
 			err := client.dynamicRegistry.RegisterPlugin(fakePlugin)
-			require.Nil(err)
+			require.Nil(t, err)
 
 			var resp structs.ClientCSIControllerListVolumesResponse
 			err = client.ClientRPC("CSI.ControllerListVolumes", tc.Request, &resp)
-			require.Equal(tc.ExpectedErr, err)
+			require.Equal(t, tc.ExpectedErr, err)
 			if tc.ExpectedResponse != nil {
-				require.Equal(tc.ExpectedResponse, &resp)
+				require.Equal(t, tc.ExpectedResponse, &resp)
 			}
 		})
 	}
 }
 func TestCSIController_CreateSnapshot(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		Name             string
@@ -696,7 +691,6 @@ func TestCSIController_CreateSnapshot(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			require := require.New(t)
 			client, cleanup := TestClient(t, nil)
 			defer cleanup()
 
@@ -712,20 +706,20 @@ func TestCSIController_CreateSnapshot(t *testing.T) {
 				dynamicplugins.PluginTypeCSIController, dispenserFunc)
 
 			err := client.dynamicRegistry.RegisterPlugin(fakePlugin)
-			require.Nil(err)
+			require.Nil(t, err)
 
 			var resp structs.ClientCSIControllerCreateSnapshotResponse
 			err = client.ClientRPC("CSI.ControllerCreateSnapshot", tc.Request, &resp)
-			require.Equal(tc.ExpectedErr, err)
+			require.Equal(t, tc.ExpectedErr, err)
 			if tc.ExpectedResponse != nil {
-				require.Equal(tc.ExpectedResponse, &resp)
+				require.Equal(t, tc.ExpectedResponse, &resp)
 			}
 		})
 	}
 }
 
 func TestCSIController_DeleteSnapshot(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		Name             string
@@ -760,7 +754,6 @@ func TestCSIController_DeleteSnapshot(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			require := require.New(t)
 			client, cleanup := TestClient(t, nil)
 			defer cleanup()
 
@@ -776,20 +769,20 @@ func TestCSIController_DeleteSnapshot(t *testing.T) {
 				dynamicplugins.PluginTypeCSIController, dispenserFunc)
 
 			err := client.dynamicRegistry.RegisterPlugin(fakePlugin)
-			require.Nil(err)
+			require.Nil(t, err)
 
 			var resp structs.ClientCSIControllerDeleteSnapshotResponse
 			err = client.ClientRPC("CSI.ControllerDeleteSnapshot", tc.Request, &resp)
-			require.Equal(tc.ExpectedErr, err)
+			require.Equal(t, tc.ExpectedErr, err)
 			if tc.ExpectedResponse != nil {
-				require.Equal(tc.ExpectedResponse, &resp)
+				require.Equal(t, tc.ExpectedResponse, &resp)
 			}
 		})
 	}
 }
 
 func TestCSIController_ListSnapshots(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		Name             string
@@ -864,7 +857,6 @@ func TestCSIController_ListSnapshots(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			require := require.New(t)
 			client, cleanup := TestClient(t, nil)
 			defer cleanup()
 
@@ -880,20 +872,20 @@ func TestCSIController_ListSnapshots(t *testing.T) {
 				dynamicplugins.PluginTypeCSIController, dispenserFunc)
 
 			err := client.dynamicRegistry.RegisterPlugin(fakePlugin)
-			require.Nil(err)
+			require.Nil(t, err)
 
 			var resp structs.ClientCSIControllerListSnapshotsResponse
 			err = client.ClientRPC("CSI.ControllerListSnapshots", tc.Request, &resp)
-			require.Equal(tc.ExpectedErr, err)
+			require.Equal(t, tc.ExpectedErr, err)
 			if tc.ExpectedResponse != nil {
-				require.Equal(tc.ExpectedResponse, &resp)
+				require.Equal(t, tc.ExpectedResponse, &resp)
 			}
 		})
 	}
 }
 
 func TestCSINode_DetachVolume(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		Name             string
@@ -947,7 +939,6 @@ func TestCSINode_DetachVolume(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			require := require.New(t)
 			client, cleanup := TestClient(t, nil)
 			defer cleanup()
 
@@ -961,13 +952,13 @@ func TestCSINode_DetachVolume(t *testing.T) {
 			}
 			client.dynamicRegistry.StubDispenserForType(dynamicplugins.PluginTypeCSINode, dispenserFunc)
 			err := client.dynamicRegistry.RegisterPlugin(fakeNodePlugin)
-			require.Nil(err)
+			require.Nil(t, err)
 
 			var resp structs.ClientCSINodeDetachVolumeResponse
 			err = client.ClientRPC("CSI.NodeDetachVolume", tc.Request, &resp)
-			require.Equal(tc.ExpectedErr, err)
+			require.Equal(t, tc.ExpectedErr, err)
 			if tc.ExpectedResponse != nil {
-				require.Equal(tc.ExpectedResponse, &resp)
+				require.Equal(t, tc.ExpectedResponse, &resp)
 			}
 		})
 	}

--- a/client/driver_manager_test.go
+++ b/client/driver_manager_test.go
@@ -16,7 +16,7 @@ import (
 // TestDriverManager_Fingerprint_Run asserts that node is populated with
 // driver fingerprints
 func TestDriverManager_Fingerprint_Run(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	testClient, cleanup := TestClient(t, nil)
 	defer cleanup()
@@ -54,7 +54,7 @@ func TestDriverManager_Fingerprint_Run(t *testing.T) {
 // TestDriverManager_Fingerprint_Run asserts that node is populated with
 // driver fingerprints and it's updated periodically
 func TestDriverManager_Fingerprint_Periodic(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		pluginConfig := []*nconfig.PluginConfig{
@@ -124,7 +124,7 @@ func TestDriverManager_Fingerprint_Periodic(t *testing.T) {
 // TestDriverManager_NodeAttributes_Run asserts that node attributes are populated
 // in addition to node.Drivers until we fully deprecate it
 func TestDriverManager_NodeAttributes_Run(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{

--- a/client/dynamicplugins/registry_test.go
+++ b/client/dynamicplugins/registry_test.go
@@ -7,11 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPluginEventBroadcaster_SendsMessagesToAllClients(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	b := newPluginEventBroadcaster()
 	defer close(b.stopCh)
 	var rcv1, rcv2 bool
@@ -37,7 +39,7 @@ func TestPluginEventBroadcaster_SendsMessagesToAllClients(t *testing.T) {
 }
 
 func TestPluginEventBroadcaster_UnsubscribeWorks(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	b := newPluginEventBroadcaster()
 	defer close(b.stopCh)
@@ -66,7 +68,8 @@ func TestPluginEventBroadcaster_UnsubscribeWorks(t *testing.T) {
 }
 
 func TestDynamicRegistry_RegisterPlugin_SendsUpdateEvents(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	r := NewRegistry(nil, nil)
 
 	ctx, cancelFn := context.WithCancel(context.Background())
@@ -104,7 +107,8 @@ func TestDynamicRegistry_RegisterPlugin_SendsUpdateEvents(t *testing.T) {
 }
 
 func TestDynamicRegistry_DeregisterPlugin_SendsUpdateEvents(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	r := NewRegistry(nil, nil)
 
 	ctx, cancelFn := context.WithCancel(context.Background())
@@ -147,6 +151,8 @@ func TestDynamicRegistry_DeregisterPlugin_SendsUpdateEvents(t *testing.T) {
 }
 
 func TestDynamicRegistry_DispensePlugin_Works(t *testing.T) {
+	testutil.Parallel(t)
+
 	dispenseFn := func(i *PluginInfo) (interface{}, error) {
 		return struct{}{}, nil
 	}
@@ -174,7 +180,8 @@ func TestDynamicRegistry_DispensePlugin_Works(t *testing.T) {
 }
 
 func TestDynamicRegistry_IsolatePluginTypes(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	r := NewRegistry(nil, nil)
 
 	err := r.RegisterPlugin(&PluginInfo{
@@ -200,7 +207,8 @@ func TestDynamicRegistry_IsolatePluginTypes(t *testing.T) {
 }
 
 func TestDynamicRegistry_StateStore(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	dispenseFn := func(i *PluginInfo) (interface{}, error) {
 		return i, nil
 	}
@@ -226,8 +234,8 @@ func TestDynamicRegistry_StateStore(t *testing.T) {
 }
 
 func TestDynamicRegistry_ConcurrentAllocs(t *testing.T) {
+	testutil.Parallel(t)
 
-	t.Parallel()
 	dispenseFn := func(i *PluginInfo) (interface{}, error) {
 		return i, nil
 	}

--- a/client/fingerprint/consul_test.go
+++ b/client/fingerprint/consul_test.go
@@ -12,6 +12,7 @@ import (
 	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,7 +48,7 @@ func newConsulFingerPrint(t *testing.T) *ConsulFingerprint {
 }
 
 func TestConsulFingerprint_server(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	fp := newConsulFingerPrint(t)
 
@@ -83,7 +84,7 @@ func TestConsulFingerprint_server(t *testing.T) {
 }
 
 func TestConsulFingerprint_version(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	fp := newConsulFingerPrint(t)
 
@@ -119,7 +120,7 @@ func TestConsulFingerprint_version(t *testing.T) {
 }
 
 func TestConsulFingerprint_sku(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	fp := newConsulFingerPrint(t)
 
@@ -171,7 +172,7 @@ func TestConsulFingerprint_sku(t *testing.T) {
 }
 
 func TestConsulFingerprint_revision(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	fp := newConsulFingerPrint(t)
 
@@ -199,7 +200,7 @@ func TestConsulFingerprint_revision(t *testing.T) {
 }
 
 func TestConsulFingerprint_dc(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	fp := newConsulFingerPrint(t)
 
@@ -227,7 +228,7 @@ func TestConsulFingerprint_dc(t *testing.T) {
 }
 
 func TestConsulFingerprint_segment(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	fp := newConsulFingerPrint(t)
 
@@ -262,7 +263,7 @@ func TestConsulFingerprint_segment(t *testing.T) {
 }
 
 func TestConsulFingerprint_connect(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	fp := newConsulFingerPrint(t)
 
@@ -291,7 +292,7 @@ func TestConsulFingerprint_connect(t *testing.T) {
 }
 
 func TestConsulFingerprint_grpc(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	fp := newConsulFingerPrint(t)
 
@@ -321,7 +322,7 @@ func TestConsulFingerprint_grpc(t *testing.T) {
 }
 
 func TestConsulFingerprint_namespaces(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	fp := newConsulFingerPrint(t)
 
@@ -362,6 +363,8 @@ func TestConsulFingerprint_namespaces(t *testing.T) {
 }
 
 func TestConsulFingerprint_Fingerprint_oss(t *testing.T) {
+	testutil.Parallel(t)
+
 	cf := newConsulFingerPrint(t)
 
 	ts, cfg := fakeConsul(fakeConsulPayload(t, "test_fixtures/consul/agent_self_oss.json"))
@@ -408,7 +411,7 @@ func TestConsulFingerprint_Fingerprint_oss(t *testing.T) {
 
 	// execute second query with error
 	err2 := cf.Fingerprint(&FingerprintRequest{Config: cfg, Node: node}, &resp2)
-	require.NoError(t, err2)            // does not return error
+	require.NoError(t, err2) // does not return error
 	require.Equal(t, map[string]string{ // attributes set empty
 		"consul.datacenter":    "",
 		"consul.revision":      "",
@@ -449,6 +452,8 @@ func TestConsulFingerprint_Fingerprint_oss(t *testing.T) {
 }
 
 func TestConsulFingerprint_Fingerprint_ent(t *testing.T) {
+	testutil.Parallel(t)
+
 	cf := newConsulFingerPrint(t)
 
 	ts, cfg := fakeConsul(fakeConsulPayload(t, "test_fixtures/consul/agent_self_ent.json"))
@@ -496,7 +501,7 @@ func TestConsulFingerprint_Fingerprint_ent(t *testing.T) {
 
 	// execute second query with error
 	err2 := cf.Fingerprint(&FingerprintRequest{Config: cfg, Node: node}, &resp2)
-	require.NoError(t, err2)            // does not return error
+	require.NoError(t, err2) // does not return error
 	require.Equal(t, map[string]string{ // attributes set empty
 		"consul.datacenter":    "",
 		"consul.revision":      "",

--- a/client/fingerprint/memory_test.go
+++ b/client/fingerprint/memory_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestMemoryFingerprint(t *testing.T) {
-	require := require.New(t)
 
 	f := NewMemoryFingerprint(testlog.HCLogger(t))
 	node := &structs.Node{
@@ -21,13 +20,13 @@ func TestMemoryFingerprint(t *testing.T) {
 	request := &FingerprintRequest{Config: &config.Config{}, Node: node}
 	var response FingerprintResponse
 	err := f.Fingerprint(request, &response)
-	require.NoError(err)
+	require.NoError(t, err)
 
 	assertNodeAttributeContains(t, response.Attributes, "memory.totalbytes")
-	require.NotNil(response.Resources, "expected response Resources to not be nil")
-	require.NotZero(response.Resources.MemoryMB, "expected memory to be non-zero")
-	require.NotNil(response.NodeResources, "expected response NodeResources to not be nil")
-	require.NotZero(response.NodeResources.Memory.MemoryMB, "expected memory to be non-zero")
+	require.NotNil(t, response.Resources, "expected response Resources to not be nil")
+	require.NotZero(t, response.Resources.MemoryMB, "expected memory to be non-zero")
+	require.NotNil(t, response.NodeResources, "expected response NodeResources to not be nil")
+	require.NotZero(t, response.NodeResources.Memory.MemoryMB, "expected memory to be non-zero")
 }
 
 func TestMemoryFingerprint_Override(t *testing.T) {
@@ -45,9 +44,8 @@ func TestMemoryFingerprint_Override(t *testing.T) {
 	}
 
 	assertNodeAttributeContains(t, response.Attributes, "memory.totalbytes")
-	require := require.New(t)
-	require.NotNil(response.Resources)
-	require.EqualValues(response.Resources.MemoryMB, memoryMB)
-	require.NotNil(response.NodeResources)
-	require.EqualValues(response.NodeResources.Memory.MemoryMB, memoryMB)
+	require.NotNil(t, response.Resources)
+	require.EqualValues(t, response.Resources.MemoryMB, memoryMB)
+	require.NotNil(t, response.NodeResources)
+	require.EqualValues(t, response.NodeResources.Memory.MemoryMB, memoryMB)
 }

--- a/client/fingerprint_manager_test.go
+++ b/client/fingerprint_manager_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFingerprintManager_Run_ResourcesFingerprint(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	testClient, cleanup := TestClient(t, nil)
 	defer cleanup()
 
@@ -23,18 +24,17 @@ func TestFingerprintManager_Run_ResourcesFingerprint(t *testing.T) {
 	)
 
 	err := fm.Run()
-	require.Nil(err)
+	require.Nil(t, err)
 
 	node := testClient.config.Node
 
-	require.NotEqual(0, node.Resources.CPU)
-	require.NotEqual(0, node.Resources.MemoryMB)
-	require.NotZero(node.Resources.DiskMB)
+	require.NotEqual(t, 0, node.Resources.CPU)
+	require.NotEqual(t, 0, node.Resources.MemoryMB)
+	require.NotZero(t, node.Resources.DiskMB)
 }
 
 func TestFimgerprintManager_Run_InWhitelist(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
@@ -54,16 +54,16 @@ func TestFimgerprintManager_Run_InWhitelist(t *testing.T) {
 	)
 
 	err := fm.Run()
-	require.Nil(err)
+	require.Nil(t, err)
 
 	node := testClient.config.Node
 
-	require.NotEqual(node.Attributes["cpu.frequency"], "")
+	require.NotEqual(t, node.Attributes["cpu.frequency"], "")
 }
 
 func TestFingerprintManager_Run_InDenylist(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
 			"fingerprint.allowlist": "  arch,memory,foo,bar	",
@@ -82,17 +82,16 @@ func TestFingerprintManager_Run_InDenylist(t *testing.T) {
 	)
 
 	err := fm.Run()
-	require.Nil(err)
+	require.Nil(t, err)
 
 	node := testClient.config.Node
 
-	require.NotContains(node.Attributes, "cpu.frequency")
-	require.NotEqual(node.Attributes["memory.totalbytes"], "")
+	require.NotContains(t, node.Attributes, "cpu.frequency")
+	require.NotEqual(t, node.Attributes["memory.totalbytes"], "")
 }
 
 func TestFingerprintManager_Run_Combination(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
@@ -112,19 +111,18 @@ func TestFingerprintManager_Run_Combination(t *testing.T) {
 	)
 
 	err := fm.Run()
-	require.Nil(err)
+	require.Nil(t, err)
 
 	node := testClient.config.Node
 
-	require.NotEqual(node.Attributes["cpu.frequency"], "")
-	require.NotEqual(node.Attributes["cpu.arch"], "")
-	require.NotContains(node.Attributes, "memory.totalbytes")
-	require.NotContains(node.Attributes, "os.name")
+	require.NotEqual(t, node.Attributes["cpu.frequency"], "")
+	require.NotEqual(t, node.Attributes["cpu.arch"], "")
+	require.NotContains(t, node.Attributes, "memory.totalbytes")
+	require.NotContains(t, node.Attributes, "os.name")
 }
 
 func TestFingerprintManager_Run_CombinationLegacyNames(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	testClient, cleanup := TestClient(t, func(c *config.Config) {
 		c.Options = map[string]string{
@@ -144,12 +142,12 @@ func TestFingerprintManager_Run_CombinationLegacyNames(t *testing.T) {
 	)
 
 	err := fm.Run()
-	require.Nil(err)
+	require.Nil(t, err)
 
 	node := testClient.config.Node
 
-	require.NotEqual(node.Attributes["cpu.frequency"], "")
-	require.NotEqual(node.Attributes["cpu.arch"], "")
-	require.NotContains(node.Attributes, "memory.totalbytes")
-	require.NotContains(node.Attributes, "os.name")
+	require.NotEqual(t, node.Attributes["cpu.frequency"], "")
+	require.NotEqual(t, node.Attributes["cpu.arch"], "")
+	require.NotContains(t, node.Attributes, "memory.totalbytes")
+	require.NotContains(t, node.Attributes, "os.name")
 }

--- a/client/fs_endpoint_test.go
+++ b/client/fs_endpoint_test.go
@@ -50,8 +50,7 @@ func (n nopWriteCloser) Close() error {
 }
 
 func TestFS_Stat_NoAlloc(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Start a client
 	c, cleanup := TestClient(t, nil)
@@ -66,13 +65,12 @@ func TestFS_Stat_NoAlloc(t *testing.T) {
 
 	var resp cstructs.FsStatResponse
 	err := c.ClientRPC("FileSystem.Stat", req, &resp)
-	require.NotNil(err)
-	require.True(structs.IsErrUnknownAllocation(err))
+	require.NotNil(t, err)
+	require.True(t, structs.IsErrUnknownAllocation(err))
 }
 
 func TestFS_Stat(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Start a server and client
 	s, cleanupS := nomad.TestServer(t, nil)
@@ -102,13 +100,13 @@ func TestFS_Stat(t *testing.T) {
 
 	var resp cstructs.FsStatResponse
 	err := c.ClientRPC("FileSystem.Stat", req, &resp)
-	require.Nil(err)
-	require.NotNil(resp.Info)
-	require.True(resp.Info.IsDir)
+	require.Nil(t, err)
+	require.NotNil(t, resp.Info)
+	require.True(t, resp.Info.IsDir)
 }
 
 func TestFS_Stat_ACL(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	// Start a server
 	s, root, cleanupS := nomad.TestACLServer(t, nil)
@@ -183,8 +181,7 @@ func TestFS_Stat_ACL(t *testing.T) {
 }
 
 func TestFS_List_NoAlloc(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Start a client
 	c, cleanup := TestClient(t, nil)
@@ -199,13 +196,12 @@ func TestFS_List_NoAlloc(t *testing.T) {
 
 	var resp cstructs.FsListResponse
 	err := c.ClientRPC("FileSystem.List", req, &resp)
-	require.NotNil(err)
-	require.True(structs.IsErrUnknownAllocation(err))
+	require.NotNil(t, err)
+	require.True(t, structs.IsErrUnknownAllocation(err))
 }
 
 func TestFS_List(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Start a server and client
 	s, cleanupS := nomad.TestServer(t, nil)
@@ -235,13 +231,13 @@ func TestFS_List(t *testing.T) {
 
 	var resp cstructs.FsListResponse
 	err := c.ClientRPC("FileSystem.List", req, &resp)
-	require.Nil(err)
-	require.NotEmpty(resp.Files)
-	require.True(resp.Files[0].IsDir)
+	require.Nil(t, err)
+	require.NotEmpty(t, resp.Files)
+	require.True(t, resp.Files[0].IsDir)
 }
 
 func TestFS_List_ACL(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	// Start a server
 	s, root, cleanupS := nomad.TestACLServer(t, nil)
@@ -316,8 +312,7 @@ func TestFS_List_ACL(t *testing.T) {
 }
 
 func TestFS_Stream_NoAlloc(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Start a client
 	c, cleanup := TestClient(t, nil)
@@ -333,7 +328,7 @@ func TestFS_Stream_NoAlloc(t *testing.T) {
 
 	// Get the handler
 	handler, err := c.StreamingRpcHandler("FileSystem.Stream")
-	require.Nil(err)
+	require.Nil(t, err)
 
 	// Create a pipe
 	p1, p2 := net.Pipe()
@@ -364,7 +359,7 @@ func TestFS_Stream_NoAlloc(t *testing.T) {
 
 	// Send the request
 	encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
-	require.Nil(encoder.Encode(req))
+	require.Nil(t, encoder.Encode(req))
 
 	timeout := time.After(3 * time.Second)
 
@@ -391,7 +386,7 @@ OUTER:
 }
 
 func TestFS_Stream_ACL(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	// Start a server
 	s, root, cleanupS := nomad.TestACLServer(t, nil)
@@ -519,8 +514,7 @@ func TestFS_Stream_ACL(t *testing.T) {
 }
 
 func TestFS_Stream(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Start a server and client
 	s, cleanupS := nomad.TestServer(t, nil)
@@ -553,7 +547,7 @@ func TestFS_Stream(t *testing.T) {
 
 	// Get the handler
 	handler, err := c.StreamingRpcHandler("FileSystem.Stream")
-	require.Nil(err)
+	require.Nil(t, err)
 
 	// Create a pipe
 	p1, p2 := net.Pipe()
@@ -587,7 +581,7 @@ func TestFS_Stream(t *testing.T) {
 
 	// Send the request
 	encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
-	require.Nil(encoder.Encode(req))
+	require.Nil(t, encoder.Encode(req))
 
 	timeout := time.After(3 * time.Second)
 	received := ""
@@ -635,8 +629,7 @@ func (r *ReadWriteCloseChecker) Close() error {
 }
 
 func TestFS_Stream_Follow(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Start a server and client
 	s, cleanupS := nomad.TestServer(t, nil)
@@ -674,7 +667,7 @@ func TestFS_Stream_Follow(t *testing.T) {
 
 	// Get the handler
 	handler, err := c.StreamingRpcHandler("FileSystem.Stream")
-	require.Nil(err)
+	require.Nil(t, err)
 
 	// Create a pipe
 	p1, p2 := net.Pipe()
@@ -705,7 +698,7 @@ func TestFS_Stream_Follow(t *testing.T) {
 
 	// Send the request
 	encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
-	require.Nil(encoder.Encode(req))
+	require.Nil(t, encoder.Encode(req))
 
 	timeout := time.After(20 * time.Second)
 	expected := strings.Repeat(expectedBase, repeat+1)
@@ -732,8 +725,7 @@ OUTER:
 }
 
 func TestFS_Stream_Limit(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Start a server and client
 	s, cleanupS := nomad.TestServer(t, nil)
@@ -769,7 +761,7 @@ func TestFS_Stream_Limit(t *testing.T) {
 
 	// Get the handler
 	handler, err := c.StreamingRpcHandler("FileSystem.Stream")
-	require.Nil(err)
+	require.Nil(t, err)
 
 	// Create a pipe
 	p1, p2 := net.Pipe()
@@ -800,7 +792,7 @@ func TestFS_Stream_Limit(t *testing.T) {
 
 	// Send the request
 	encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
-	require.Nil(encoder.Encode(req))
+	require.Nil(t, encoder.Encode(req))
 
 	timeout := time.After(3 * time.Second)
 	received := ""
@@ -826,8 +818,7 @@ OUTER:
 }
 
 func TestFS_Logs_NoAlloc(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Start a client
 	c, cleanup := TestClient(t, nil)
@@ -844,7 +835,7 @@ func TestFS_Logs_NoAlloc(t *testing.T) {
 
 	// Get the handler
 	handler, err := c.StreamingRpcHandler("FileSystem.Logs")
-	require.Nil(err)
+	require.Nil(t, err)
 
 	// Create a pipe
 	p1, p2 := net.Pipe()
@@ -875,7 +866,7 @@ func TestFS_Logs_NoAlloc(t *testing.T) {
 
 	// Send the request
 	encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
-	require.Nil(encoder.Encode(req))
+	require.Nil(t, encoder.Encode(req))
 
 	timeout := time.After(3 * time.Second)
 
@@ -904,8 +895,7 @@ OUTER:
 // TestFS_Logs_TaskPending asserts that trying to stream logs for tasks which
 // have not started returns a 404 error.
 func TestFS_Logs_TaskPending(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Start a server and client
 	s, cleanupS := nomad.TestServer(t, nil)
@@ -929,7 +919,7 @@ func TestFS_Logs_TaskPending(t *testing.T) {
 	args.WriteRequest.Region = "global"
 	args.Namespace = job.Namespace
 	var jobResp structs.JobRegisterResponse
-	require.NoError(s.RPC("Job.Register", args, &jobResp))
+	require.NoError(t, s.RPC("Job.Register", args, &jobResp))
 
 	// Get the allocation ID
 	var allocID string
@@ -969,7 +959,7 @@ func TestFS_Logs_TaskPending(t *testing.T) {
 
 	// Get the handler
 	handler, err := c.StreamingRpcHandler("FileSystem.Logs")
-	require.Nil(err)
+	require.Nil(t, err)
 
 	// Create a pipe
 	p1, p2 := net.Pipe()
@@ -1000,7 +990,7 @@ func TestFS_Logs_TaskPending(t *testing.T) {
 
 	// Send the request
 	encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
-	require.Nil(encoder.Encode(req))
+	require.Nil(t, encoder.Encode(req))
 
 	for {
 		select {
@@ -1009,18 +999,17 @@ func TestFS_Logs_TaskPending(t *testing.T) {
 		case err := <-errCh:
 			t.Fatalf("unexpected stream error: %v", err)
 		case msg := <-streamMsg:
-			require.NotNil(msg.Error)
-			require.NotNil(msg.Error.Code)
-			require.EqualValues(404, *msg.Error.Code)
-			require.Contains(msg.Error.Message, "not started")
+			require.NotNil(t, msg.Error)
+			require.NotNil(t, msg.Error.Code)
+			require.EqualValues(t, 404, *msg.Error.Code)
+			require.Contains(t, msg.Error.Message, "not started")
 			return
 		}
 	}
 }
 
 func TestFS_Logs_ACL(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Start a server
 	s, root, cleanupS := nomad.TestACLServer(t, nil)
@@ -1087,7 +1076,7 @@ func TestFS_Logs_ACL(t *testing.T) {
 
 			// Get the handler
 			handler, err := client.StreamingRpcHandler("FileSystem.Logs")
-			require.Nil(err)
+			require.Nil(t, err)
 
 			// Create a pipe
 			p1, p2 := net.Pipe()
@@ -1116,7 +1105,7 @@ func TestFS_Logs_ACL(t *testing.T) {
 
 			// Send the request
 			encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
-			require.Nil(encoder.Encode(req))
+			require.Nil(t, encoder.Encode(req))
 
 			timeout := time.After(5 * time.Second)
 
@@ -1150,8 +1139,7 @@ func TestFS_Logs_ACL(t *testing.T) {
 }
 
 func TestFS_Logs(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Start a server and client
 	s, cleanupS := nomad.TestServer(t, nil)
@@ -1178,8 +1166,8 @@ func TestFS_Logs(t *testing.T) {
 	args := structs.AllocListRequest{}
 	args.Region = "global"
 	resp := structs.AllocListResponse{}
-	require.NoError(s.RPC("Alloc.List", &args, &resp))
-	require.Len(resp.Allocations, 1)
+	require.NoError(t, s.RPC("Alloc.List", &args, &resp))
+	require.Len(t, resp.Allocations, 1)
 	allocID := resp.Allocations[0].ID
 
 	// Make the request
@@ -1194,7 +1182,7 @@ func TestFS_Logs(t *testing.T) {
 
 	// Get the handler
 	handler, err := c.StreamingRpcHandler("FileSystem.Logs")
-	require.Nil(err)
+	require.Nil(t, err)
 
 	// Create a pipe
 	p1, p2 := net.Pipe()
@@ -1225,7 +1213,7 @@ func TestFS_Logs(t *testing.T) {
 
 	// Send the request
 	encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
-	require.Nil(encoder.Encode(req))
+	require.Nil(t, encoder.Encode(req))
 
 	timeout := time.After(3 * time.Second)
 	received := ""
@@ -1251,8 +1239,7 @@ OUTER:
 }
 
 func TestFS_Logs_Follow(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Start a server and client
 	s, cleanupS := nomad.TestServer(t, nil)
@@ -1292,7 +1279,7 @@ func TestFS_Logs_Follow(t *testing.T) {
 
 	// Get the handler
 	handler, err := c.StreamingRpcHandler("FileSystem.Logs")
-	require.NoError(err)
+	require.NoError(t, err)
 
 	// Create a pipe
 	p1, p2 := net.Pipe()
@@ -1323,7 +1310,7 @@ func TestFS_Logs_Follow(t *testing.T) {
 
 	// Send the request
 	encoder := codec.NewEncoder(p1, structs.MsgpackHandle)
-	require.Nil(encoder.Encode(req))
+	require.Nil(t, encoder.Encode(req))
 
 	timeout := time.After(20 * time.Second)
 	expected := strings.Repeat(expectedBase, repeat+1)
@@ -1350,6 +1337,8 @@ OUTER:
 }
 
 func TestFS_findClosest(t *testing.T) {
+	testutil.Parallel(t)
+
 	task := "foo"
 	entries := []*cstructs.AllocFileInfo{
 		{
@@ -1555,7 +1544,8 @@ func TestFS_findClosest(t *testing.T) {
 }
 
 func TestFS_streamFile_NoFile(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	c, cleanup := TestClient(t, nil)
 	defer cleanup()
 
@@ -1578,7 +1568,7 @@ func TestFS_streamFile_NoFile(t *testing.T) {
 }
 
 func TestFS_streamFile_Modify(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, cleanup := TestClient(t, nil)
 	defer cleanup()
@@ -1649,7 +1639,8 @@ func TestFS_streamFile_Modify(t *testing.T) {
 }
 
 func TestFS_streamFile_Truncate(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	c, cleanup := TestClient(t, nil)
 	defer cleanup()
 
@@ -1755,7 +1746,8 @@ func TestFS_streamImpl_Delete(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows does not allow us to delete a file while it is open")
 	}
-	t.Parallel()
+
+	testutil.Parallel(t)
 
 	c, cleanup := TestClient(t, nil)
 	defer cleanup()
@@ -1828,7 +1820,7 @@ func TestFS_streamImpl_Delete(t *testing.T) {
 }
 
 func TestFS_logsImpl_NoFollow(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, cleanup := TestClient(t, nil)
 	defer cleanup()
@@ -1897,7 +1889,7 @@ func TestFS_logsImpl_NoFollow(t *testing.T) {
 }
 
 func TestFS_logsImpl_Follow(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, cleanup := TestClient(t, nil)
 	defer cleanup()

--- a/client/gc_test.go
+++ b/client/gc_test.go
@@ -37,7 +37,8 @@ func exitAllocRunner(runners ...AllocRunner) {
 }
 
 func TestIndexedGCAllocPQ(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	pq := NewIndexedGCAllocPQ()
 
 	ar1, cleanup1 := allocrunner.TestAllocRunnerFromAlloc(t, mock.Alloc())
@@ -122,7 +123,8 @@ func (m *MockStatsCollector) Stats() *stats.HostStats {
 }
 
 func TestAllocGarbageCollector_MarkForCollection(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 	gc := NewAllocGarbageCollector(logger, &MockStatsCollector{}, &MockAllocCounter{}, gcConfig())
 
@@ -138,7 +140,8 @@ func TestAllocGarbageCollector_MarkForCollection(t *testing.T) {
 }
 
 func TestAllocGarbageCollector_Collect(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 	gc := NewAllocGarbageCollector(logger, &MockStatsCollector{}, &MockAllocCounter{}, gcConfig())
 
@@ -164,7 +167,8 @@ func TestAllocGarbageCollector_Collect(t *testing.T) {
 }
 
 func TestAllocGarbageCollector_CollectAll(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 	gc := NewAllocGarbageCollector(logger, &MockStatsCollector{}, &MockAllocCounter{}, gcConfig())
 
@@ -184,7 +188,8 @@ func TestAllocGarbageCollector_CollectAll(t *testing.T) {
 }
 
 func TestAllocGarbageCollector_MakeRoomForAllocations_EnoughSpace(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 	statsCollector := &MockStatsCollector{}
 	conf := gcConfig()
@@ -226,7 +231,8 @@ func TestAllocGarbageCollector_MakeRoomForAllocations_EnoughSpace(t *testing.T) 
 }
 
 func TestAllocGarbageCollector_MakeRoomForAllocations_GC_Partial(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 	statsCollector := &MockStatsCollector{}
 	conf := gcConfig()
@@ -269,7 +275,8 @@ func TestAllocGarbageCollector_MakeRoomForAllocations_GC_Partial(t *testing.T) {
 }
 
 func TestAllocGarbageCollector_MakeRoomForAllocations_GC_All(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 	statsCollector := &MockStatsCollector{}
 	conf := gcConfig()
@@ -308,7 +315,8 @@ func TestAllocGarbageCollector_MakeRoomForAllocations_GC_All(t *testing.T) {
 }
 
 func TestAllocGarbageCollector_MakeRoomForAllocations_GC_Fallback(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 	statsCollector := &MockStatsCollector{}
 	conf := gcConfig()
@@ -348,8 +356,9 @@ func TestAllocGarbageCollector_MakeRoomForAllocations_GC_Fallback(t *testing.T) 
 // TestAllocGarbageCollector_MakeRoomFor_MaxAllocs asserts that when making room for new
 // allocs, terminal allocs are GC'd until old_allocs + new_allocs <= limit
 func TestAllocGarbageCollector_MakeRoomFor_MaxAllocs(t *testing.T) {
+	testutil.Parallel(t)
+
 	const maxAllocs = 6
-	require := require.New(t)
 
 	server, serverAddr, cleanupS := testServer(t, nil)
 	defer cleanupS()
@@ -383,8 +392,8 @@ func TestAllocGarbageCollector_MakeRoomFor_MaxAllocs(t *testing.T) {
 
 	upsertJobFn := func(server *nomad.Server, j *structs.Job) {
 		state := server.State()
-		require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, nextIndex(), j))
-		require.NoError(state.UpsertJobSummary(nextIndex(), mock.JobSummary(j.ID)))
+		require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, nextIndex(), j))
+		require.NoError(t, state.UpsertJobSummary(nextIndex(), mock.JobSummary(j.ID)))
 	}
 
 	// Insert the Job
@@ -392,7 +401,7 @@ func TestAllocGarbageCollector_MakeRoomFor_MaxAllocs(t *testing.T) {
 
 	upsertAllocFn := func(server *nomad.Server, a *structs.Allocation) {
 		state := server.State()
-		require.NoError(state.UpsertAllocs(structs.MsgTypeTestSetup, nextIndex(), []*structs.Allocation{a}))
+		require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, nextIndex(), []*structs.Allocation{a}))
 	}
 
 	upsertNewAllocFn := func(server *nomad.Server, j *structs.Job) *structs.Allocation {
@@ -489,12 +498,13 @@ func TestAllocGarbageCollector_MakeRoomFor_MaxAllocs(t *testing.T) {
 		}
 		return true, nil
 	}, func(err error) {
-		require.NoError(err)
+		require.NoError(t, err)
 	})
 }
 
 func TestAllocGarbageCollector_UsageBelowThreshold(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 	statsCollector := &MockStatsCollector{}
 	conf := gcConfig()
@@ -533,7 +543,8 @@ func TestAllocGarbageCollector_UsageBelowThreshold(t *testing.T) {
 }
 
 func TestAllocGarbageCollector_UsedPercentThreshold(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 	statsCollector := &MockStatsCollector{}
 	conf := gcConfig()

--- a/client/heartbeatstop_test.go
+++ b/client/heartbeatstop_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestHeartbeatStop_allocHook(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	server, _, cleanupS1 := testServer(t, nil)
 	defer cleanupS1()

--- a/client/lib/cgutil/cpuset_manager_linux_test.go
+++ b/client/lib/cgutil/cpuset_manager_linux_test.go
@@ -7,15 +7,12 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/lib/cpuset"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-
-	"github.com/hashicorp/nomad/helper/uuid"
-
 	"github.com/stretchr/testify/require"
-
-	"github.com/hashicorp/nomad/helper/testlog"
 )
 
 func tmpCpusetManager(t *testing.T) (manager *cpusetManager, cleanup func()) {
@@ -121,9 +118,9 @@ func TestCpusetManager_RemoveAlloc(t *testing.T) {
 	require.NoError(t, manager.Init())
 
 	// this case tests adding 2 allocs, reconciling then removing 1 alloc
-	// it requires the system to have atleast 2 cpu cores (one for each alloc)
+	// it requires the system to have at least 2 cpu cores (one for each alloc)
 	if manager.parentCpuset.Size() < 2 {
-		t.Skip("test requires atleast 2 cpu cores")
+		t.Skip("test requires at least 2 cpu cores")
 	}
 
 	alloc1 := mock.Alloc()

--- a/client/lib/fifo/fifo_test.go
+++ b/client/lib/fifo/fifo_test.go
@@ -18,21 +18,20 @@ import (
 
 // TestFIFO tests basic behavior, and that reader closes when writer closes
 func TestFIFO(t *testing.T) {
-	require := require.New(t)
 	var path string
 
 	if runtime.GOOS == "windows" {
 		path = "//./pipe/fifo"
 	} else {
 		dir, err := ioutil.TempDir("", "")
-		require.NoError(err)
+		require.NoError(t, err)
 		defer os.RemoveAll(dir)
 
 		path = filepath.Join(dir, "fifo")
 	}
 
 	readerOpenFn, err := CreateAndRead(path)
-	require.NoError(err)
+	require.NoError(t, err)
 
 	var reader io.ReadCloser
 
@@ -62,41 +61,40 @@ func TestFIFO(t *testing.T) {
 	}()
 
 	writer, err := OpenWriter(path)
-	require.NoError(err)
+	require.NoError(t, err)
 	for _, b := range toWrite {
 		n, err := writer.Write(b)
-		require.NoError(err)
-		require.Equal(n, len(b))
+		require.NoError(t, err)
+		require.Equal(t, n, len(b))
 	}
-	require.NoError(writer.Close())
+	require.NoError(t, writer.Close())
 	time.Sleep(500 * time.Millisecond)
 
 	wait.Wait()
-	require.NoError(reader.Close())
+	require.NoError(t, reader.Close())
 
 	expected := "abc\ndef\nnomad\n"
-	require.Equal(expected, readBuf.String())
+	require.Equal(t, expected, readBuf.String())
 
-	require.NoError(Remove(path))
+	require.NoError(t, Remove(path))
 }
 
 // TestWriteClose asserts that when writer closes, subsequent Write() fails
 func TestWriteClose(t *testing.T) {
-	require := require.New(t)
 	var path string
 
 	if runtime.GOOS == "windows" {
 		path = "//./pipe/" + uuid.Generate()[:4]
 	} else {
 		dir, err := ioutil.TempDir("", "")
-		require.NoError(err)
+		require.NoError(t, err)
 		defer os.RemoveAll(dir)
 
 		path = filepath.Join(dir, "fifo")
 	}
 
 	readerOpenFn, err := CreateAndRead(path)
-	require.NoError(err)
+	require.NoError(t, err)
 	var reader io.ReadCloser
 
 	var readBuf bytes.Buffer
@@ -117,7 +115,7 @@ func TestWriteClose(t *testing.T) {
 	}()
 
 	writer, err := OpenWriter(path)
-	require.NoError(err)
+	require.NoError(t, err)
 
 	var count int
 	wait.Add(1)
@@ -128,14 +126,14 @@ func TestWriteClose(t *testing.T) {
 			if err != nil && IsClosedErr(err) {
 				break
 			}
-			require.NoError(err)
+			require.NoError(t, err)
 			time.Sleep(5 * time.Millisecond)
 		}
 	}()
 
 	time.Sleep(500 * time.Millisecond)
-	require.NoError(writer.Close())
+	require.NoError(t, writer.Close())
 	wait.Wait()
 
-	require.Equal(count, len(readBuf.String()))
+	require.Equal(t, count, len(readBuf.String()))
 }

--- a/client/pluginmanager/csimanager/volume_test.go
+++ b/client/pluginmanager/csimanager/volume_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/csi"
 	csifake "github.com/hashicorp/nomad/plugins/csi/fake"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,7 +40,7 @@ func TestVolumeManager_ensureStagingDir(t *testing.T) {
 	if !checkMountSupport() {
 		t.Skip("mount point detection not supported for this platform")
 	}
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		Name                 string
@@ -136,7 +137,7 @@ func TestVolumeManager_stageVolume(t *testing.T) {
 	if !checkMountSupport() {
 		t.Skip("mount point detection not supported for this platform")
 	}
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		Name         string
@@ -217,7 +218,7 @@ func TestVolumeManager_unstageVolume(t *testing.T) {
 	if !checkMountSupport() {
 		t.Skip("mount point detection not supported for this platform")
 	}
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		Name                 string
@@ -279,8 +280,7 @@ func TestVolumeManager_publishVolume(t *testing.T) {
 	if !checkMountSupport() {
 		t.Skip("mount point detection not supported for this platform")
 	}
-
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		Name                     string
@@ -406,7 +406,7 @@ func TestVolumeManager_unpublishVolume(t *testing.T) {
 	if !checkMountSupport() {
 		t.Skip("mount point detection not supported for this platform")
 	}
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		Name                 string
@@ -471,7 +471,7 @@ func TestVolumeManager_MountVolumeEvents(t *testing.T) {
 	if !checkMountSupport() {
 		t.Skip("mount point detection not supported for this platform")
 	}
-	t.Parallel()
+	testutil.Parallel(t)
 
 	tmpPath := tmpDir(t)
 	defer os.RemoveAll(tmpPath)

--- a/client/pluginmanager/drivermanager/manager_test.go
+++ b/client/pluginmanager/drivermanager/manager_test.go
@@ -101,8 +101,8 @@ func noopUpdater(string, *structs.DriverInfo)             {}
 func noopEventHandlerFactory(string, string) EventHandler { return nil }
 
 func TestManager_Fingerprint(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	fpChan, _, mgr := testSetup(t)
 	var infos []*structs.DriverInfo
 	mgr.updater = func(d string, i *structs.DriverInfo) {
@@ -116,7 +116,7 @@ func TestManager_Fingerprint(t *testing.T) {
 		defer mgr.instancesMu.Unlock()
 		return len(mgr.instances) == 1, fmt.Errorf("manager should have registered 1 instance")
 	}, func(err error) {
-		require.NoError(err)
+		require.NoError(t, err)
 	})
 
 	testutil.WaitForResult(func() (bool, error) {
@@ -127,7 +127,7 @@ func TestManager_Fingerprint(t *testing.T) {
 		}
 		return true, nil
 	}, func(err error) {
-		require.NoError(err)
+		require.NoError(t, err)
 	})
 
 	fpChan <- &drivers.Fingerprint{
@@ -141,7 +141,7 @@ func TestManager_Fingerprint(t *testing.T) {
 		}
 		return true, nil
 	}, func(err error) {
-		require.NoError(err)
+		require.NoError(t, err)
 	})
 
 	fpChan <- &drivers.Fingerprint{
@@ -155,21 +155,21 @@ func TestManager_Fingerprint(t *testing.T) {
 		}
 		return true, nil
 	}, func(err error) {
-		require.NoError(err)
+		require.NoError(t, err)
 	})
 
-	require.Len(infos, 3)
-	require.True(infos[0].Healthy)
-	require.True(infos[0].Detected)
-	require.False(infos[1].Healthy)
-	require.True(infos[1].Detected)
-	require.False(infos[2].Healthy)
-	require.False(infos[2].Detected)
+	require.Len(t, infos, 3)
+	require.True(t, infos[0].Healthy)
+	require.True(t, infos[0].Detected)
+	require.False(t, infos[1].Healthy)
+	require.True(t, infos[1].Detected)
+	require.False(t, infos[2].Healthy)
+	require.False(t, infos[2].Detected)
 }
 
 func TestManager_TaskEvents(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	fpChan, evChan, mgr := testSetup(t)
 	go mgr.Run()
 	defer mgr.Shutdown()
@@ -179,7 +179,7 @@ func TestManager_TaskEvents(t *testing.T) {
 		defer mgr.instancesMu.Unlock()
 		return len(mgr.instances) == 1, fmt.Errorf("manager should have registered 1 instance")
 	}, func(err error) {
-		require.NoError(err)
+		require.NoError(t, err)
 	})
 
 	event1 := mockTaskEvent("abc1")
@@ -199,8 +199,8 @@ func TestManager_TaskEvents(t *testing.T) {
 }
 
 func TestManager_Run_AllowedDrivers(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	fpChan, _, mgr := testSetup(t)
 	mgr.allowedDrivers = map[string]struct{}{"foo": {}}
 	go mgr.Run()
@@ -214,13 +214,13 @@ func TestManager_Run_AllowedDrivers(t *testing.T) {
 		defer mgr.instancesMu.Unlock()
 		return len(mgr.instances) == 0, fmt.Errorf("manager should have no registered instances")
 	}, func(err error) {
-		require.NoError(err)
+		require.NoError(t, err)
 	})
 }
 
 func TestManager_Run_BlockedDrivers(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	fpChan, _, mgr := testSetup(t)
 	mgr.blockedDrivers = map[string]struct{}{"mock": {}}
 	go mgr.Run()
@@ -234,13 +234,13 @@ func TestManager_Run_BlockedDrivers(t *testing.T) {
 		defer mgr.instancesMu.Unlock()
 		return len(mgr.instances) == 0, fmt.Errorf("manager should have no registered instances")
 	}, func(err error) {
-		require.NoError(err)
+		require.NoError(t, err)
 	})
 }
 
 func TestManager_Run_AllowedBlockedDrivers_Combined(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	drvs := map[string]drivers.DriverPlugin{}
 	fpChs := map[string]chan *drivers.Fingerprint{}
 	names := []string{"mock1", "mock2", "mock3", "mock4", "mock5"}
@@ -287,11 +287,11 @@ func TestManager_Run_AllowedBlockedDrivers_Combined(t *testing.T) {
 		defer mgr.instancesMu.Unlock()
 		return len(mgr.instances) < 2, fmt.Errorf("manager should have 1 registered instance, %v", len(mgr.instances))
 	}, func(err error) {
-		require.NoError(err)
+		require.NoError(t, err)
 	})
 	mgr.instancesMu.Lock()
-	require.Len(mgr.instances, 1)
+	require.Len(t, mgr.instances, 1)
 	_, ok := mgr.instances["mock3"]
 	mgr.instancesMu.Unlock()
-	require.True(ok)
+	require.True(t, ok)
 }

--- a/client/rpc_test.go
+++ b/client/rpc_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestRpc_streamingRpcConn_badEndpoint(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	s1, cleanupS1 := nomad.TestServer(t, nil)
 	defer cleanupS1()
@@ -42,17 +41,16 @@ func TestRpc_streamingRpcConn_badEndpoint(t *testing.T) {
 
 	// Get the server
 	server := c.servers.FindServer()
-	require.NotNil(server)
+	require.NotNil(t, server)
 
 	conn, err := c.streamingRpcConn(server, "Bogus")
-	require.Nil(conn)
-	require.NotNil(err)
-	require.Contains(err.Error(), "Unknown rpc method: \"Bogus\"")
+	require.Nil(t, conn)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Unknown rpc method: \"Bogus\"")
 }
 
 func TestRpc_streamingRpcConn_badEndpoint_TLS(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	const (
 		cafile  = "../helper/tlsutil/testdata/ca.pem"
@@ -106,10 +104,10 @@ func TestRpc_streamingRpcConn_badEndpoint_TLS(t *testing.T) {
 
 	// Get the server
 	server := c.servers.FindServer()
-	require.NotNil(server)
+	require.NotNil(t, server)
 
 	conn, err := c.streamingRpcConn(server, "Bogus")
-	require.Nil(conn)
-	require.NotNil(err)
-	require.Contains(err.Error(), "Unknown rpc method: \"Bogus\"")
+	require.Nil(t, conn)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Unknown rpc method: \"Bogus\"")
 }

--- a/client/servers/manager_test.go
+++ b/client/servers/manager_test.go
@@ -47,7 +47,6 @@ func testManagerFailProb(t *testing.T, failPct float64) (m *servers.Manager) {
 }
 
 func TestServers_SetServers(t *testing.T) {
-	require := require.New(t)
 	m := testManager(t)
 	var num int
 	num = m.NumServers()
@@ -57,28 +56,28 @@ func TestServers_SetServers(t *testing.T) {
 
 	s1 := &servers.Server{Addr: &fauxAddr{"server1"}}
 	s2 := &servers.Server{Addr: &fauxAddr{"server2"}}
-	require.True(m.SetServers([]*servers.Server{s1, s2}))
-	require.False(m.SetServers([]*servers.Server{s1, s2}))
-	require.False(m.SetServers([]*servers.Server{s2, s1}))
-	require.Equal(2, m.NumServers())
-	require.Len(m.GetServers(), 2)
+	require.True(t, m.SetServers([]*servers.Server{s1, s2}))
+	require.False(t, m.SetServers([]*servers.Server{s1, s2}))
+	require.False(t, m.SetServers([]*servers.Server{s2, s1}))
+	require.Equal(t, 2, m.NumServers())
+	require.Len(t, m.GetServers(), 2)
 
-	require.True(m.SetServers([]*servers.Server{s1}))
-	require.Equal(1, m.NumServers())
-	require.Len(m.GetServers(), 1)
+	require.True(t, m.SetServers([]*servers.Server{s1}))
+	require.Equal(t, 1, m.NumServers())
+	require.Len(t, m.GetServers(), 1)
 
 	// Test that the list of servers does not get shuffled
 	// as a side effect when incoming list is equal
-	require.True(m.SetServers([]*servers.Server{s1, s2}))
+	require.True(t, m.SetServers([]*servers.Server{s1, s2}))
 	before := m.GetServers()
-	require.False(m.SetServers([]*servers.Server{s1, s2}))
+	require.False(t, m.SetServers([]*servers.Server{s1, s2}))
 	after := m.GetServers()
-	require.Equal(before, after)
+	require.Equal(t, before, after)
 
 	// Send a shuffled list, verify original order doesn't change
-	require.False(m.SetServers([]*servers.Server{s2, s1}))
+	require.False(t, m.SetServers([]*servers.Server{s2, s1}))
 	afterShuffledInput := m.GetServers()
-	require.Equal(after, afterShuffledInput)
+	require.Equal(t, after, afterShuffledInput)
 }
 
 func TestServers_FindServer(t *testing.T) {

--- a/client/state/db_test.go
+++ b/client/state/db_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 )
@@ -62,31 +63,30 @@ func testDB(t *testing.T, f func(*testing.T, StateDB)) {
 // TestStateDB_Allocations asserts the behavior of GetAllAllocations, PutAllocation, and
 // DeleteAllocationBucket for all operational StateDB implementations.
 func TestStateDB_Allocations(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	testDB(t, func(t *testing.T, db StateDB) {
-		require := require.New(t)
 
 		// Empty database should return empty non-nil results
 		allocs, errs, err := db.GetAllAllocations()
-		require.NoError(err)
-		require.NotNil(allocs)
-		require.Empty(allocs)
-		require.NotNil(errs)
-		require.Empty(errs)
+		require.NoError(t, err)
+		require.NotNil(t, allocs)
+		require.Empty(t, allocs)
+		require.NotNil(t, errs)
+		require.Empty(t, errs)
 
 		// Put allocations
 		alloc1 := mock.Alloc()
 		alloc2 := mock.BatchAlloc()
 
-		require.NoError(db.PutAllocation(alloc1))
-		require.NoError(db.PutAllocation(alloc2))
+		require.NoError(t, db.PutAllocation(alloc1))
+		require.NoError(t, db.PutAllocation(alloc2))
 
 		// Retrieve them
 		allocs, errs, err = db.GetAllAllocations()
-		require.NoError(err)
-		require.NotNil(allocs)
-		require.Len(allocs, 2)
+		require.NoError(t, err)
+		require.NotNil(t, allocs)
+		require.Len(t, allocs, 2)
 		for _, a := range allocs {
 			switch a.ID {
 			case alloc1.ID:
@@ -103,39 +103,39 @@ func TestStateDB_Allocations(t *testing.T) {
 				t.Fatalf("unexpected alloc id %q", a.ID)
 			}
 		}
-		require.NotNil(errs)
-		require.Empty(errs)
+		require.NotNil(t, errs)
+		require.Empty(t, errs)
 
 		// Add another
 		alloc3 := mock.SystemAlloc()
-		require.NoError(db.PutAllocation(alloc3))
+		require.NoError(t, db.PutAllocation(alloc3))
 		allocs, errs, err = db.GetAllAllocations()
-		require.NoError(err)
-		require.NotNil(allocs)
-		require.Len(allocs, 3)
-		require.Contains(allocs, alloc1)
-		require.Contains(allocs, alloc2)
-		require.Contains(allocs, alloc3)
-		require.NotNil(errs)
-		require.Empty(errs)
+		require.NoError(t, err)
+		require.NotNil(t, allocs)
+		require.Len(t, allocs, 3)
+		require.Contains(t, allocs, alloc1)
+		require.Contains(t, allocs, alloc2)
+		require.Contains(t, allocs, alloc3)
+		require.NotNil(t, errs)
+		require.Empty(t, errs)
 
 		// Deleting a nonexistent alloc is a noop
-		require.NoError(db.DeleteAllocationBucket("asdf"))
+		require.NoError(t, db.DeleteAllocationBucket("asdf"))
 		allocs, _, err = db.GetAllAllocations()
-		require.NoError(err)
-		require.NotNil(allocs)
-		require.Len(allocs, 3)
+		require.NoError(t, err)
+		require.NotNil(t, allocs)
+		require.Len(t, allocs, 3)
 
 		// Delete alloc1
-		require.NoError(db.DeleteAllocationBucket(alloc1.ID))
+		require.NoError(t, db.DeleteAllocationBucket(alloc1.ID))
 		allocs, errs, err = db.GetAllAllocations()
-		require.NoError(err)
-		require.NotNil(allocs)
-		require.Len(allocs, 2)
-		require.Contains(allocs, alloc2)
-		require.Contains(allocs, alloc3)
-		require.NotNil(errs)
-		require.Empty(errs)
+		require.NoError(t, err)
+		require.NotNil(t, allocs)
+		require.Len(t, allocs, 2)
+		require.Contains(t, allocs, alloc2)
+		require.Contains(t, allocs, alloc3)
+		require.NotNil(t, errs)
+		require.Empty(t, errs)
 	})
 }
 
@@ -147,10 +147,9 @@ func ceilDiv(a, b int) int {
 // TestStateDB_Batch asserts the behavior of PutAllocation, PutNetworkStatus and
 // DeleteAllocationBucket in batch mode, for all operational StateDB implementations.
 func TestStateDB_Batch(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	testDB(t, func(t *testing.T, db StateDB) {
-		require := require.New(t)
 
 		// For BoltDB, get initial tx_id
 		var getTxID func() int
@@ -161,7 +160,7 @@ func TestStateDB_Batch(t *testing.T) {
 			boltdb := boltStateDB.DB().BoltDB()
 			getTxID = func() int {
 				tx, err := boltdb.Begin(true)
-				require.NoError(err)
+				require.NoError(t, err)
 				defer tx.Rollback()
 				return tx.ID()
 			}
@@ -181,8 +180,8 @@ func TestStateDB_Batch(t *testing.T) {
 		for _, alloc := range allocs {
 			wg.Add(1)
 			go func(alloc *structs.Allocation) {
-				require.NoError(db.PutNetworkStatus(alloc.ID, mock.AllocNetworkStatus(), WithBatchMode()))
-				require.NoError(db.PutAllocation(alloc, WithBatchMode()))
+				require.NoError(t, db.PutNetworkStatus(alloc.ID, mock.AllocNetworkStatus(), WithBatchMode()))
+				require.NoError(t, db.PutAllocation(alloc, WithBatchMode()))
 				wg.Done()
 			}(alloc)
 		}
@@ -197,17 +196,17 @@ func TestStateDB_Batch(t *testing.T) {
 			numTransactions := getTxID() - prevTxID
 			writeTime := time.Now().Sub(startTime)
 			expectedNumTransactions := ceilDiv(2*numAllocs, batchSize) + ceilDiv(int(writeTime), int(batchDelay))
-			require.LessOrEqual(numTransactions, expectedNumTransactions)
+			require.LessOrEqual(t, numTransactions, expectedNumTransactions)
 			prevTxID = getTxID()
 		}
 
 		// Retrieve allocs and make sure they are the same (order can differ)
 		readAllocs, errs, err := db.GetAllAllocations()
-		require.NoError(err)
-		require.NotNil(readAllocs)
-		require.Len(readAllocs, len(allocs))
-		require.NotNil(errs)
-		require.Empty(errs)
+		require.NoError(t, err)
+		require.NotNil(t, readAllocs)
+		require.Len(t, readAllocs, len(allocs))
+		require.NotNil(t, errs)
+		require.Empty(t, errs)
 
 		readAllocsById := make(map[string]*structs.Allocation)
 		for _, readAlloc := range readAllocs {
@@ -229,7 +228,7 @@ func TestStateDB_Batch(t *testing.T) {
 		for _, alloc := range allocs {
 			wg.Add(1)
 			go func(alloc *structs.Allocation) {
-				require.NoError(db.DeleteAllocationBucket(alloc.ID, WithBatchMode()))
+				require.NoError(t, db.DeleteAllocationBucket(alloc.ID, WithBatchMode()))
 				wg.Done()
 			}(alloc)
 		}
@@ -240,149 +239,145 @@ func TestStateDB_Batch(t *testing.T) {
 			numTransactions := getTxID() - prevTxID
 			writeTime := time.Now().Sub(startTime)
 			expectedNumTransactions := ceilDiv(numAllocs, batchSize) + ceilDiv(int(writeTime), int(batchDelay))
-			require.LessOrEqual(numTransactions, expectedNumTransactions)
+			require.LessOrEqual(t, numTransactions, expectedNumTransactions)
 			prevTxID = getTxID()
 		}
 
 		// Check all allocs were deleted.
 		readAllocs, errs, err = db.GetAllAllocations()
-		require.NoError(err)
-		require.Empty(readAllocs)
-		require.Empty(errs)
+		require.NoError(t, err)
+		require.Empty(t, readAllocs)
+		require.Empty(t, errs)
 	})
 }
 
 // TestStateDB_TaskState asserts the behavior of task state related StateDB
 // methods.
 func TestStateDB_TaskState(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	testDB(t, func(t *testing.T, db StateDB) {
-		require := require.New(t)
 
 		// Getting nonexistent state should return nils
 		ls, ts, err := db.GetTaskRunnerState("allocid", "taskname")
-		require.NoError(err)
-		require.Nil(ls)
-		require.Nil(ts)
+		require.NoError(t, err)
+		require.Nil(t, ls)
+		require.Nil(t, ts)
 
 		// Putting TaskState without first putting the allocation should work
 		state := structs.NewTaskState()
 		state.Failed = true // set a non-default value
-		require.NoError(db.PutTaskState("allocid", "taskname", state))
+		require.NoError(t, db.PutTaskState("allocid", "taskname", state))
 
 		// Getting should return the available state
 		ls, ts, err = db.GetTaskRunnerState("allocid", "taskname")
-		require.NoError(err)
-		require.Nil(ls)
-		require.Equal(state, ts)
+		require.NoError(t, err)
+		require.Nil(t, ls)
+		require.Equal(t, state, ts)
 
 		// Deleting a nonexistent task should not error
-		require.NoError(db.DeleteTaskBucket("adsf", "asdf"))
-		require.NoError(db.DeleteTaskBucket("asllocid", "asdf"))
+		require.NoError(t, db.DeleteTaskBucket("adsf", "asdf"))
+		require.NoError(t, db.DeleteTaskBucket("asllocid", "asdf"))
 
 		// Data should be untouched
 		ls, ts, err = db.GetTaskRunnerState("allocid", "taskname")
-		require.NoError(err)
-		require.Nil(ls)
-		require.Equal(state, ts)
+		require.NoError(t, err)
+		require.Nil(t, ls)
+		require.Equal(t, state, ts)
 
 		// Deleting the task should remove the state
-		require.NoError(db.DeleteTaskBucket("allocid", "taskname"))
+		require.NoError(t, db.DeleteTaskBucket("allocid", "taskname"))
 		ls, ts, err = db.GetTaskRunnerState("allocid", "taskname")
-		require.NoError(err)
-		require.Nil(ls)
-		require.Nil(ts)
+		require.NoError(t, err)
+		require.Nil(t, ls)
+		require.Nil(t, ts)
 
 		// Putting LocalState should work just like TaskState
 		origLocalState := trstate.NewLocalState()
-		require.NoError(db.PutTaskRunnerLocalState("allocid", "taskname", origLocalState))
+		require.NoError(t, db.PutTaskRunnerLocalState("allocid", "taskname", origLocalState))
 		ls, ts, err = db.GetTaskRunnerState("allocid", "taskname")
-		require.NoError(err)
-		require.Equal(origLocalState, ls)
-		require.Nil(ts)
+		require.NoError(t, err)
+		require.Equal(t, origLocalState, ls)
+		require.Nil(t, ts)
 	})
 }
 
 // TestStateDB_DeviceManager asserts the behavior of device manager state related StateDB
 // methods.
 func TestStateDB_DeviceManager(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	testDB(t, func(t *testing.T, db StateDB) {
-		require := require.New(t)
 
 		// Getting nonexistent state should return nils
 		ps, err := db.GetDevicePluginState()
-		require.NoError(err)
-		require.Nil(ps)
+		require.NoError(t, err)
+		require.Nil(t, ps)
 
 		// Putting PluginState should work
 		state := &dmstate.PluginState{}
-		require.NoError(db.PutDevicePluginState(state))
+		require.NoError(t, db.PutDevicePluginState(state))
 
 		// Getting should return the available state
 		ps, err = db.GetDevicePluginState()
-		require.NoError(err)
-		require.NotNil(ps)
-		require.Equal(state, ps)
+		require.NoError(t, err)
+		require.NotNil(t, ps)
+		require.Equal(t, state, ps)
 	})
 }
 
 // TestStateDB_DriverManager asserts the behavior of device manager state related StateDB
 // methods.
 func TestStateDB_DriverManager(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	testDB(t, func(t *testing.T, db StateDB) {
-		require := require.New(t)
 
 		// Getting nonexistent state should return nils
 		ps, err := db.GetDriverPluginState()
-		require.NoError(err)
-		require.Nil(ps)
+		require.NoError(t, err)
+		require.Nil(t, ps)
 
 		// Putting PluginState should work
 		state := &driverstate.PluginState{}
-		require.NoError(db.PutDriverPluginState(state))
+		require.NoError(t, db.PutDriverPluginState(state))
 
 		// Getting should return the available state
 		ps, err = db.GetDriverPluginState()
-		require.NoError(err)
-		require.NotNil(ps)
-		require.Equal(state, ps)
+		require.NoError(t, err)
+		require.NotNil(t, ps)
+		require.Equal(t, state, ps)
 	})
 }
 
 // TestStateDB_DynamicRegistry asserts the behavior of dynamic registry state related StateDB
 // methods.
 func TestStateDB_DynamicRegistry(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	testDB(t, func(t *testing.T, db StateDB) {
-		require := require.New(t)
 
 		// Getting nonexistent state should return nils
 		ps, err := db.GetDynamicPluginRegistryState()
-		require.NoError(err)
-		require.Nil(ps)
+		require.NoError(t, err)
+		require.Nil(t, ps)
 
 		// Putting PluginState should work
 		state := &dynamicplugins.RegistryState{}
-		require.NoError(db.PutDynamicPluginRegistryState(state))
+		require.NoError(t, db.PutDynamicPluginRegistryState(state))
 
 		// Getting should return the available state
 		ps, err = db.GetDynamicPluginRegistryState()
-		require.NoError(err)
-		require.NotNil(ps)
-		require.Equal(state, ps)
+		require.NoError(t, err)
+		require.NotNil(t, ps)
+		require.Equal(t, state, ps)
 	})
 }
 
 // TestStateDB_Upgrade asserts calling Upgrade on new databases always
 // succeeds.
 func TestStateDB_Upgrade(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	testDB(t, func(t *testing.T, db StateDB) {
 		require.NoError(t, db.Upgrade())

--- a/client/state/upgrade_int_test.go
+++ b/client/state/upgrade_int_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
 	pstructs "github.com/hashicorp/nomad/plugins/shared/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
@@ -32,7 +33,7 @@ import (
 // TestBoltStateDB_Upgrade_Ok asserts upgading an old state db does not error
 // during upgrade and restore.
 func TestBoltStateDB_UpgradeOld_Ok(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	dbFromTestFile := func(t *testing.T, dir, fn string) *BoltStateDB {
 

--- a/client/state/upgrade_test.go
+++ b/client/state/upgrade_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/nomad/helper/boltdd"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
 )
@@ -32,7 +33,7 @@ func setupBoltDB(t *testing.T) (*bbolt.DB, func()) {
 
 // TestUpgrade_NeedsUpgrade_New asserts new state dbs do not need upgrading.
 func TestUpgrade_NeedsUpgrade_New(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	// Setting up a new StateDB should initialize it at the latest version.
 	db, cleanup := setupBoltStateDB(t)
@@ -47,7 +48,7 @@ func TestUpgrade_NeedsUpgrade_New(t *testing.T) {
 // TestUpgrade_NeedsUpgrade_Old asserts state dbs with just the alloctions
 // bucket *do* need upgrading.
 func TestUpgrade_NeedsUpgrade_Old(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	db, cleanup := setupBoltDB(t)
 	defer cleanup()
@@ -77,7 +78,7 @@ func TestUpgrade_NeedsUpgrade_Old(t *testing.T) {
 // NeedsUpgrade if an invalid db version is found. This is a safety measure to
 // prevent invalid and unintentional upgrades when downgrading Nomad.
 func TestUpgrade_NeedsUpgrade_Error(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := [][]byte{
 		{'"', '2', '"'}, // wrong type
@@ -107,7 +108,7 @@ func TestUpgrade_NeedsUpgrade_Error(t *testing.T) {
 // TestUpgrade_DeleteInvalidAllocs asserts invalid allocations are deleted
 // during state upgades instead of failing the entire agent.
 func TestUpgrade_DeleteInvalidAllocs_NoAlloc(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	bdb, cleanup := setupBoltDB(t)
 	defer cleanup()
@@ -152,7 +153,7 @@ func TestUpgrade_DeleteInvalidAllocs_NoAlloc(t *testing.T) {
 // TestUpgrade_DeleteInvalidTaskEntries asserts invalid entries under a task
 // bucket are deleted.
 func TestUpgrade_upgradeTaskBucket_InvalidEntries(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	db, cleanup := setupBoltDB(t)
 	defer cleanup()

--- a/client/stats/cpu_test.go
+++ b/client/stats/cpu_test.go
@@ -23,37 +23,36 @@ func TestCpuStatsPercent(t *testing.T) {
 }
 
 func TestHostStats_CPU(t *testing.T) {
-	assert := assert.New(t)
-	assert.Nil(shelpers.Init())
+	assert.Nil(t, shelpers.Init())
 
 	logger := testlog.HCLogger(t)
 	cwd, err := os.Getwd()
-	assert.Nil(err)
+	assert.Nil(t, err)
 	hs := NewHostStatsCollector(logger, cwd, nil)
 
 	// Collect twice so we can calculate percents we need to generate some work
 	// so that the cpu values change
-	assert.Nil(hs.Collect())
+	assert.Nil(t, hs.Collect())
 	total := 0
 	for i := 1; i < 1000000000; i++ {
 		total *= i
 		total = total % i
 	}
-	assert.Nil(hs.Collect())
+	assert.Nil(t, hs.Collect())
 	stats := hs.Stats()
 
-	assert.NotZero(stats.CPUTicksConsumed)
-	assert.NotZero(len(stats.CPU))
+	assert.NotZero(t, stats.CPUTicksConsumed)
+	assert.NotZero(t, len(stats.CPU))
 
 	for _, cpu := range stats.CPU {
-		assert.False(math.IsNaN(cpu.Idle))
-		assert.False(math.IsNaN(cpu.Total))
-		assert.False(math.IsNaN(cpu.System))
-		assert.False(math.IsNaN(cpu.User))
+		assert.False(t, math.IsNaN(cpu.Idle))
+		assert.False(t, math.IsNaN(cpu.Total))
+		assert.False(t, math.IsNaN(cpu.System))
+		assert.False(t, math.IsNaN(cpu.User))
 
-		assert.False(math.IsInf(cpu.Idle, 0))
-		assert.False(math.IsInf(cpu.Total, 0))
-		assert.False(math.IsInf(cpu.System, 0))
-		assert.False(math.IsInf(cpu.User, 0))
+		assert.False(t, math.IsInf(cpu.Idle, 0))
+		assert.False(t, math.IsInf(cpu.Total, 0))
+		assert.False(t, math.IsInf(cpu.System, 0))
+		assert.False(t, math.IsInf(cpu.User, 0))
 	}
 }

--- a/client/structs/broadcaster_test.go
+++ b/client/structs/broadcaster_test.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 // TestAllocBroadcaster_SendRecv asserts the latest sends to a broadcaster are
 // received by listeners.
 func TestAllocBroadcaster_SendRecv(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	b := NewAllocBroadcaster(testlog.HCLogger(t))
 	defer b.Close()
@@ -47,7 +48,7 @@ func TestAllocBroadcaster_SendRecv(t *testing.T) {
 
 // TestAllocBroadcaster_RecvBlocks asserts listeners are blocked until a send occurs.
 func TestAllocBroadcaster_RecvBlocks(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	alloc := mock.Alloc()
 	b := NewAllocBroadcaster(testlog.HCLogger(t))
@@ -87,7 +88,7 @@ func TestAllocBroadcaster_RecvBlocks(t *testing.T) {
 // TestAllocBroadcaster_Concurrency asserts that the broadcaster behaves
 // correctly with concurrent listeners being added and closed.
 func TestAllocBroadcaster_Concurrency(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	alloc := mock.Alloc()
 	b := NewAllocBroadcaster(testlog.HCLogger(t))
@@ -164,7 +165,7 @@ func TestAllocBroadcaster_Concurrency(t *testing.T) {
 // TestAllocBroadcaster_PrimeListener asserts that newly created listeners are
 // primed with the last sent alloc.
 func TestAllocBroadcaster_PrimeListener(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	b := NewAllocBroadcaster(testlog.HCLogger(t))
 	defer b.Close()
@@ -188,7 +189,7 @@ func TestAllocBroadcaster_PrimeListener(t *testing.T) {
 // TestAllocBroadcaster_Closed asserts that newly created listeners are
 // primed with the last sent alloc even when the broadcaster is closed.
 func TestAllocBroadcaster_Closed(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	b := NewAllocBroadcaster(testlog.HCLogger(t))
 

--- a/client/taskenv/env_test.go
+++ b/client/taskenv/env_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,6 +63,8 @@ func testEnvBuilder() *Builder {
 }
 
 func TestEnvironment_ParseAndReplace_Env(t *testing.T) {
+	testutil.Parallel(t)
+
 	env := testEnvBuilder()
 
 	input := []string{fmt.Sprintf(`"${%v}"!`, envOneKey), fmt.Sprintf("${%s}${%s}", envOneKey, envTwoKey)}
@@ -74,6 +77,8 @@ func TestEnvironment_ParseAndReplace_Env(t *testing.T) {
 }
 
 func TestEnvironment_ParseAndReplace_Meta(t *testing.T) {
+	testutil.Parallel(t)
+
 	input := []string{fmt.Sprintf("${%v%v}", nodeMetaPrefix, metaKey)}
 	exp := []string{metaVal}
 	env := testEnvBuilder()
@@ -85,6 +90,8 @@ func TestEnvironment_ParseAndReplace_Meta(t *testing.T) {
 }
 
 func TestEnvironment_ParseAndReplace_Attr(t *testing.T) {
+	testutil.Parallel(t)
+
 	input := []string{fmt.Sprintf("${%v%v}", nodeAttributePrefix, attrKey)}
 	exp := []string{attrVal}
 	env := testEnvBuilder()
@@ -96,6 +103,8 @@ func TestEnvironment_ParseAndReplace_Attr(t *testing.T) {
 }
 
 func TestEnvironment_ParseAndReplace_Node(t *testing.T) {
+	testutil.Parallel(t)
+
 	input := []string{fmt.Sprintf("${%v}", nodeNameKey), fmt.Sprintf("${%v}", nodeClassKey)}
 	exp := []string{nodeName, nodeClass}
 	env := testEnvBuilder()
@@ -107,6 +116,8 @@ func TestEnvironment_ParseAndReplace_Node(t *testing.T) {
 }
 
 func TestEnvironment_ParseAndReplace_Mixed(t *testing.T) {
+	testutil.Parallel(t)
+
 	input := []string{
 		fmt.Sprintf("${%v}${%v%v}", nodeNameKey, nodeAttributePrefix, attrKey),
 		fmt.Sprintf("${%v}${%v%v}", nodeClassKey, nodeMetaPrefix, metaKey),
@@ -126,6 +137,8 @@ func TestEnvironment_ParseAndReplace_Mixed(t *testing.T) {
 }
 
 func TestEnvironment_ReplaceEnv_Mixed(t *testing.T) {
+	testutil.Parallel(t)
+
 	input := fmt.Sprintf("${%v}${%v%v}", nodeNameKey, nodeAttributePrefix, attrKey)
 	exp := fmt.Sprintf("%v%v", nodeName, attrVal)
 	env := testEnvBuilder()
@@ -137,6 +150,8 @@ func TestEnvironment_ReplaceEnv_Mixed(t *testing.T) {
 }
 
 func TestEnvironment_AsList(t *testing.T) {
+	testutil.Parallel(t)
+
 	n := mock.Node()
 	n.Meta = map[string]string{
 		"metaKey": "metaVal",
@@ -227,7 +242,7 @@ func TestEnvironment_AsList(t *testing.T) {
 }
 
 func TestEnvironment_AllValues(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	n := mock.Node()
 	n.Meta = map[string]string{
@@ -431,6 +446,8 @@ func TestEnvironment_AllValues(t *testing.T) {
 }
 
 func TestEnvironment_VaultToken(t *testing.T) {
+	testutil.Parallel(t)
+
 	n := mock.Node()
 	a := mock.Alloc()
 	env := NewBuilder(n, a, a.Job.TaskGroups[0].Tasks[0], "global")
@@ -491,6 +508,8 @@ func TestEnvironment_VaultToken(t *testing.T) {
 }
 
 func TestEnvironment_Envvars(t *testing.T) {
+	testutil.Parallel(t)
+
 	envMap := map[string]string{"foo": "baz", "bar": "bang"}
 	n := mock.Node()
 	a := mock.Alloc()
@@ -512,6 +531,8 @@ func TestEnvironment_Envvars(t *testing.T) {
 // TestEnvironment_HookVars asserts hook env vars are LWW and deletes of later
 // writes allow earlier hook's values to be visible.
 func TestEnvironment_HookVars(t *testing.T) {
+	testutil.Parallel(t)
+
 	n := mock.Node()
 	a := mock.Alloc()
 	builder := NewBuilder(n, a, a.Job.TaskGroups[0].Tasks[0], "global")
@@ -548,7 +569,8 @@ func TestEnvironment_HookVars(t *testing.T) {
 // TestEnvironment_DeviceHookVars asserts device hook env vars are accessible
 // separately.
 func TestEnvironment_DeviceHookVars(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	n := mock.Node()
 	a := mock.Alloc()
 	builder := NewBuilder(n, a, a.Job.TaskGroups[0].Tasks[0], "global")
@@ -565,14 +587,16 @@ func TestEnvironment_DeviceHookVars(t *testing.T) {
 
 	b := builder.Build()
 	deviceEnv := b.DeviceEnv()
-	require.Len(deviceEnv, 1)
-	require.Contains(deviceEnv, "hook")
+	require.Len(t, deviceEnv, 1)
+	require.Contains(t, deviceEnv, "hook")
 
 	all := b.Map()
-	require.Contains(all, "foo")
+	require.Contains(t, all, "foo")
 }
 
 func TestEnvironment_Interpolate(t *testing.T) {
+	testutil.Parallel(t)
+
 	n := mock.Node()
 	n.Attributes["arch"] = "x86"
 	n.NodeClass = "test class"
@@ -598,6 +622,8 @@ func TestEnvironment_Interpolate(t *testing.T) {
 }
 
 func TestEnvironment_AppendHostEnvvars(t *testing.T) {
+	testutil.Parallel(t)
+
 	host := os.Environ()
 	if len(host) < 2 {
 		t.Skip("No host environment variables. Can't test")
@@ -620,6 +646,8 @@ func TestEnvironment_AppendHostEnvvars(t *testing.T) {
 // converted to underscores in environment variables.
 // See: https://github.com/hashicorp/nomad/issues/2405
 func TestEnvironment_DashesInTaskName(t *testing.T) {
+	testutil.Parallel(t)
+
 	a := mock.Alloc()
 	task := a.Job.TaskGroups[0].Tasks[0]
 	task.Env = map[string]string{
@@ -639,6 +667,8 @@ func TestEnvironment_DashesInTaskName(t *testing.T) {
 // TestEnvironment_UpdateTask asserts env vars and task meta are updated when a
 // task is updated.
 func TestEnvironment_UpdateTask(t *testing.T) {
+	testutil.Parallel(t)
+
 	a := mock.Alloc()
 	a.Job.TaskGroups[0].Meta = map[string]string{"tgmeta": "tgmetaval"}
 	task := a.Job.TaskGroups[0].Tasks[0]
@@ -688,7 +718,8 @@ func TestEnvironment_UpdateTask(t *testing.T) {
 // job, if an optional meta field is not set, it will get interpolated as an
 // empty string.
 func TestEnvironment_InterpolateEmptyOptionalMeta(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	a := mock.Alloc()
 	a.Job.ParameterizedJob = &structs.ParameterizedJobConfig{
 		MetaOptional: []string{"metaopt1", "metaopt2"},
@@ -697,14 +728,14 @@ func TestEnvironment_InterpolateEmptyOptionalMeta(t *testing.T) {
 	task := a.Job.TaskGroups[0].Tasks[0]
 	task.Meta = map[string]string{"metaopt1": "metaopt1val"}
 	env := NewBuilder(mock.Node(), a, task, "global").Build()
-	require.Equal("metaopt1val", env.ReplaceEnv("${NOMAD_META_metaopt1}"))
-	require.Empty(env.ReplaceEnv("${NOMAD_META_metaopt2}"))
+	require.Equal(t, "metaopt1val", env.ReplaceEnv("${NOMAD_META_metaopt1}"))
+	require.Empty(t, env.ReplaceEnv("${NOMAD_META_metaopt2}"))
 }
 
 // TestEnvironment_Upsteams asserts that group.service.upstreams entries are
 // added to the environment.
 func TestEnvironment_Upstreams(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	// Add some upstreams to the mock alloc
 	a := mock.Alloc()
@@ -754,6 +785,8 @@ func TestEnvironment_Upstreams(t *testing.T) {
 }
 
 func TestEnvironment_SetPortMapEnvs(t *testing.T) {
+	testutil.Parallel(t)
+
 	envs := map[string]string{
 		"foo":            "bar",
 		"NOMAD_PORT_ssh": "2342",
@@ -774,21 +807,24 @@ func TestEnvironment_SetPortMapEnvs(t *testing.T) {
 }
 
 func TestEnvironment_TasklessBuilder(t *testing.T) {
+	testutil.Parallel(t)
+
 	node := mock.Node()
 	alloc := mock.Alloc()
 	alloc.Job.Meta["jobt"] = "foo"
 	alloc.Job.TaskGroups[0].Meta["groupt"] = "bar"
-	require := require.New(t)
 	var taskEnv *TaskEnv
-	require.NotPanics(func() {
+	require.NotPanics(t, func() {
 		taskEnv = NewBuilder(node, alloc, nil, "global").SetAllocDir("/tmp/alloc").Build()
 	})
 
-	require.Equal("foo", taskEnv.ReplaceEnv("${NOMAD_META_jobt}"))
-	require.Equal("bar", taskEnv.ReplaceEnv("${NOMAD_META_groupt}"))
+	require.Equal(t, "foo", taskEnv.ReplaceEnv("${NOMAD_META_jobt}"))
+	require.Equal(t, "bar", taskEnv.ReplaceEnv("${NOMAD_META_groupt}"))
 }
 
 func TestTaskEnv_ClientPath(t *testing.T) {
+	testutil.Parallel(t)
+	
 	builder := testEnvBuilder()
 	builder.SetAllocDir("/tmp/testAlloc")
 	builder.SetClientSharedAllocDir("/tmp/testAlloc/alloc")

--- a/client/taskenv/services_test.go
+++ b/client/taskenv/services_test.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 // TestInterpolateServices asserts that all service
 // and check fields are properly interpolated.
 func TestInterpolateServices(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	services := []*structs.Service{
 		{
@@ -107,7 +108,7 @@ var testEnv = NewTaskEnv(
 	nil, nil, "", "")
 
 func TestInterpolate_interpolateMapStringSliceString(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
 		require.Nil(t, interpolateMapStringSliceString(testEnv, nil))
@@ -125,7 +126,7 @@ func TestInterpolate_interpolateMapStringSliceString(t *testing.T) {
 }
 
 func TestInterpolate_interpolateMapStringString(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
 		require.Nil(t, interpolateMapStringString(testEnv, nil))
@@ -143,7 +144,7 @@ func TestInterpolate_interpolateMapStringString(t *testing.T) {
 }
 
 func TestInterpolate_interpolateMapStringInterface(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
 		require.Nil(t, interpolateMapStringInterface(testEnv, nil))
@@ -161,7 +162,7 @@ func TestInterpolate_interpolateMapStringInterface(t *testing.T) {
 }
 
 func TestInterpolate_interpolateConnect(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	e := map[string]string{
 		"tag1":              "_tag1",

--- a/client/taskenv/util_test.go
+++ b/client/taskenv/util_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -11,6 +12,8 @@ import (
 // TestAddNestedKey_Ok asserts test cases that succeed when passed to
 // addNestedKey.
 func TestAddNestedKey_Ok(t *testing.T) {
+	testutil.Parallel(t)
+
 	cases := []struct {
 		// M will be initialized if unset
 		M map[string]interface{}
@@ -209,7 +212,7 @@ func TestAddNestedKey_Ok(t *testing.T) {
 			name = fmt.Sprintf("%s-%d", name, len(tc.M))
 		}
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
+
 			if tc.M == nil {
 				tc.M = map[string]interface{}{}
 			}
@@ -222,6 +225,8 @@ func TestAddNestedKey_Ok(t *testing.T) {
 // TestAddNestedKey_Bad asserts test cases return an error when passed to
 // addNestedKey.
 func TestAddNestedKey_Bad(t *testing.T) {
+	testutil.Parallel(t)
+
 	cases := []struct {
 		// M will be initialized if unset
 		M func() map[string]interface{}
@@ -320,7 +325,6 @@ func TestAddNestedKey_Bad(t *testing.T) {
 			name += "-cleanup"
 		}
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 
 			// Copy original M value to ensure it doesn't get altered
 			if tc.M == nil {
@@ -341,6 +345,8 @@ func TestAddNestedKey_Bad(t *testing.T) {
 }
 
 func TestCtyify_Ok(t *testing.T) {
+	testutil.Parallel(t)
+
 	cases := []struct {
 		Name string
 		In   map[string]interface{}
@@ -402,7 +408,6 @@ func TestCtyify_Ok(t *testing.T) {
 	for i := range cases {
 		tc := cases[i]
 		t.Run(tc.Name, func(t *testing.T) {
-			t.Parallel()
 
 			// ctiyif and check for errors
 			result, err := ctyify(tc.In)
@@ -417,6 +422,8 @@ func TestCtyify_Ok(t *testing.T) {
 }
 
 func TestCtyify_Bad(t *testing.T) {
+	testutil.Parallel(t)
+	
 	cases := []struct {
 		Name string
 		In   map[string]interface{}
@@ -441,7 +448,6 @@ func TestCtyify_Bad(t *testing.T) {
 	for i := range cases {
 		tc := cases[i]
 		t.Run(tc.Name, func(t *testing.T) {
-			t.Parallel()
 
 			// ctiyif and check for errors
 			result, err := ctyify(tc.In)

--- a/client/util_test.go
+++ b/client/util_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDiffAllocs(t *testing.T) {
-	t.Parallel()
+
 	alloc1 := mock.Alloc() // Ignore
 	alloc2 := mock.Alloc() // Update
 	alloc2u := new(structs.Allocation)
@@ -56,7 +56,7 @@ func TestDiffAllocs(t *testing.T) {
 }
 
 func TestShuffleStrings(t *testing.T) {
-	t.Parallel()
+
 	// Generate input
 	inp := make([]string, 10)
 	for idx := range inp {

--- a/client/vaultclient/vaultclient_test.go
+++ b/client/vaultclient/vaultclient_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func TestVaultClient_TokenRenewals(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	v := testutil.NewTestVault(t)
 	defer v.Stop()
 
@@ -71,7 +71,7 @@ func TestVaultClient_TokenRenewals(t *testing.T) {
 			for {
 				select {
 				case err := <-errCh:
-					require.NoError(err, "unexpected error while renewing vault token")
+					require.NoError(t, err, "unexpected error while renewing vault token")
 				}
 			}
 		}(errCh)
@@ -88,7 +88,7 @@ func TestVaultClient_TokenRenewals(t *testing.T) {
 
 	for i := 0; i < num; i++ {
 		if err := c.StopRenewToken(tokens[i]); err != nil {
-			require.NoError(err)
+			require.NoError(t, err)
 		}
 	}
 
@@ -103,8 +103,8 @@ func TestVaultClient_TokenRenewals(t *testing.T) {
 // TestVaultClient_NamespaceSupport tests that the Vault namespace config, if present, will result in the
 // namespace header being set on the created Vault client.
 func TestVaultClient_NamespaceSupport(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	tr := true
 	testNs := "test-namespace"
 
@@ -115,12 +115,13 @@ func TestVaultClient_NamespaceSupport(t *testing.T) {
 	conf.VaultConfig.Token = "testvaulttoken"
 	conf.VaultConfig.Namespace = testNs
 	c, err := NewVaultClient(conf.VaultConfig, logger, nil)
-	require.NoError(err)
-	require.Equal(testNs, c.client.Headers().Get(vaultconsts.NamespaceHeaderName))
+	require.NoError(t, err)
+	require.Equal(t, testNs, c.client.Headers().Get(vaultconsts.NamespaceHeaderName))
 }
 
 func TestVaultClient_Heap(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	tr := true
 	conf := config.DefaultConfig()
 	conf.VaultConfig.Enabled = &tr
@@ -226,7 +227,8 @@ func TestVaultClient_Heap(t *testing.T) {
 }
 
 func TestVaultClient_RenewNonRenewableLease(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	v := testutil.NewTestVault(t)
 	defer v.Stop()
 
@@ -275,7 +277,8 @@ func TestVaultClient_RenewNonRenewableLease(t *testing.T) {
 }
 
 func TestVaultClient_RenewNonexistentLease(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	v := testutil.NewTestVault(t)
 	defer v.Stop()
 
@@ -311,7 +314,7 @@ func TestVaultClient_RenewNonexistentLease(t *testing.T) {
 // TestVaultClient_RenewalTime_Long asserts that for leases over 1m the renewal
 // time is jittered.
 func TestVaultClient_RenewalTime_Long(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	// highRoller is a randIntn func that always returns the max value
 	highRoller := func(n int) int {
@@ -337,8 +340,8 @@ func TestVaultClient_RenewalTime_Long(t *testing.T) {
 // TestVaultClient_RenewalTime_Short asserts that for leases under 1m the renewal
 // time is lease/2.
 func TestVaultClient_RenewalTime_Short(t *testing.T) {
-	t.Parallel()
-
+	testutil.Parallel(t)
+	
 	dice := func(int) int {
 		require.Fail(t, "dice should not have been called")
 		panic("unreachable")

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -16,6 +16,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/api"
+	client "github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/fingerprint"
 	"github.com/hashicorp/nomad/helper/freeport"
 	"github.com/hashicorp/nomad/helper/testlog"
@@ -356,6 +357,14 @@ func (a *TestAgent) config() *Config {
 	// Customize the server configuration
 	config := nomad.DefaultConfig()
 	conf.NomadConfig = config
+
+	// Setup client config
+	conf.ClientConfig = client.DefaultConfig()
+
+	logger := testlog.HCLogger(a.T)
+	conf.LogLevel = testlog.HCLoggerTestLevel().String()
+	conf.NomadConfig.Logger = logger
+	conf.ClientConfig.Logger = logger
 
 	// Set the name
 	conf.NodeName = a.Name

--- a/drivers/exec/driver_unix_test.go
+++ b/drivers/exec/driver_unix_test.go
@@ -25,9 +25,8 @@ import (
 )
 
 func TestExecDriver_StartWaitStop(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
 	ctestutils.ExecCompatible(t)
+	testutil.Parallel(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -44,19 +43,19 @@ func TestExecDriver_StartWaitStop(t *testing.T) {
 		"command": "/bin/sleep",
 		"args":    []string{"600"},
 	}
-	require.NoError(task.EncodeConcreteDriverConfig(&taskConfig))
+	require.NoError(t, task.EncodeConcreteDriverConfig(&taskConfig))
 
 	cleanup := harness.MkAllocDir(task, false)
 	defer cleanup()
 
 	handle, _, err := harness.StartTask(task)
 	defer harness.DestroyTask(task.ID, true)
-	require.NoError(err)
+	require.NoError(t, err)
 
 	ch, err := harness.WaitTask(context.Background(), handle.Config.ID)
-	require.NoError(err)
+	require.NoError(t, err)
 
-	require.NoError(harness.WaitUntilStarted(task.ID, 1*time.Second))
+	require.NoError(t, harness.WaitUntilStarted(task.ID, 1*time.Second))
 
 	go func() {
 		harness.StopTask(task.ID, 2*time.Second, "SIGKILL")
@@ -64,9 +63,9 @@ func TestExecDriver_StartWaitStop(t *testing.T) {
 
 	select {
 	case result := <-ch:
-		require.Equal(int(unix.SIGKILL), result.Signal)
+		require.Equal(t, int(unix.SIGKILL), result.Signal)
 	case <-time.After(10 * time.Second):
-		require.Fail("timeout waiting for task to shutdown")
+		require.Fail(t, "timeout waiting for task to shutdown")
 	}
 
 	// Ensure that the task is marked as dead, but account
@@ -82,13 +81,12 @@ func TestExecDriver_StartWaitStop(t *testing.T) {
 
 		return true, nil
 	}, func(err error) {
-		require.NoError(err)
+		require.NoError(t, err)
 	})
 }
 
 func TestExec_ExecTaskStreaming(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -109,10 +107,10 @@ func TestExec_ExecTaskStreaming(t *testing.T) {
 		Command: "/bin/sleep",
 		Args:    []string{"9000"},
 	}
-	require.NoError(task.EncodeConcreteDriverConfig(&tc))
+	require.NoError(t, task.EncodeConcreteDriverConfig(&tc))
 
 	_, _, err := harness.StartTask(task)
-	require.NoError(err)
+	require.NoError(t, err)
 	defer d.DestroyTask(task.ID, true)
 
 	dtestutil.ExecTaskStreamingConformanceTests(t, harness, task.ID)
@@ -121,10 +119,9 @@ func TestExec_ExecTaskStreaming(t *testing.T) {
 
 // Tests that a given DNSConfig properly configures dns
 func TestExec_dnsConfig(t *testing.T) {
-	t.Parallel()
-	ctestutils.RequireRoot(t)
 	ctestutils.ExecCompatible(t)
-	require := require.New(t)
+	ctestutils.RequireRoot(t)
+	testutil.Parallel(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -170,10 +167,10 @@ func TestExec_dnsConfig(t *testing.T) {
 			Command: "/bin/sleep",
 			Args:    []string{"9000"},
 		}
-		require.NoError(task.EncodeConcreteDriverConfig(&tc))
+		require.NoError(t, task.EncodeConcreteDriverConfig(&tc))
 
 		_, _, err := harness.StartTask(task)
-		require.NoError(err)
+		require.NoError(t, err)
 		defer d.DestroyTask(task.ID, true)
 
 		dtestutil.TestTaskDNSConfig(t, harness, task.ID, c.cfg)

--- a/helper/testlog/testlog.go
+++ b/helper/testlog/testlog.go
@@ -5,6 +5,7 @@ package testlog
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -39,25 +40,45 @@ func WithPrefix(t LogPrinter, prefix string) *log.Logger {
 	return New(t, prefix, log.Lmicroseconds)
 }
 
-// Logger returns a new test logger with the Lmicroseconds flag set and no
-// prefix.
+// Logger returns a new test logger with the Lmicroseconds flag set and no prefix.
+//
+// Note: only use this where HCLogger cannot be used (i.e. RPC yamux configuration).
 func Logger(t LogPrinter) *log.Logger {
 	return WithPrefix(t, "")
 }
 
-//HCLogger returns a new test hc-logger.
+// HCLogger returns a new test hc-logger.
+//
+// Default log level is warn. Set NOMAD_TEST_LOG_LEVEL for custom log level.
 func HCLogger(t LogPrinter) hclog.InterceptLogger {
-	level := hclog.Trace
+	logger, _ := HCLoggerNode(t, -1)
+	return logger
+}
+
+func HCLoggerTestLevel() hclog.Level {
+	level := hclog.Off
 	envLogLevel := os.Getenv("NOMAD_TEST_LOG_LEVEL")
 	if envLogLevel != "" {
 		level = hclog.LevelFromString(envLogLevel)
 	}
+	return level
+}
+
+// HCLoggerNode returns a new hc-logger, but with a prefix indicating the node number
+// on each log line. Useful for TestServer in tests with more than one server.
+//
+// Default log level is warn. Set NOMAD_TEST_LOG_LEVEL for custom log level.
+func HCLoggerNode(t LogPrinter, node int32) (hclog.InterceptLogger, io.Writer) {
+	var output io.Writer = os.Stderr
+	if node > -1 {
+		output = NewPrefixWriter(t, fmt.Sprintf("node-%03d", node))
+	}
 	opts := &hclog.LoggerOptions{
-		Level:           level,
-		Output:          os.Stderr,
+		Level:           HCLoggerTestLevel(),
+		Output:          output,
 		IncludeLocation: true,
 	}
-	return hclog.NewInterceptLogger(opts)
+	return hclog.NewInterceptLogger(opts), output
 }
 
 type prefixStderr struct {

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -4,14 +4,9 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-	"os"
 	"sync/atomic"
 	"time"
 
-	testing "github.com/mitchellh/go-testing-interface"
-	"github.com/pkg/errors"
-
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/freeport"
 	"github.com/hashicorp/nomad/helper/pluginutils/catalog"
@@ -20,10 +15,12 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/version"
+	testing "github.com/mitchellh/go-testing-interface"
+	"github.com/pkg/errors"
 )
 
 var (
-	nodeNumber uint32 = 0
+	nodeNumber int32 = 0
 )
 
 func TestACLServer(t testing.T, cb func(*Config)) (*Server, *structs.ACLToken, func()) {
@@ -48,26 +45,15 @@ func TestServer(t testing.T, cb func(*Config)) (*Server, func()) {
 	// Setup default enterprise-specific settings, including license
 	defaultEnterpriseTestConfig(config)
 
-	config.Logger = testlog.HCLogger(t)
 	config.Build = version.Version + "+unittest"
 	config.DevMode = true
 	config.EnableEventBroker = true
 	config.BootstrapExpect = 1
-	nodeNum := atomic.AddUint32(&nodeNumber, 1)
+	nodeNum := atomic.AddInt32(&nodeNumber, 1)
 	config.NodeName = fmt.Sprintf("nomad-%03d", nodeNum)
 
 	// configure logger
-	level := hclog.Trace
-	if envLogLevel := os.Getenv("NOMAD_TEST_LOG_LEVEL"); envLogLevel != "" {
-		level = hclog.LevelFromString(envLogLevel)
-	}
-	opts := &hclog.LoggerOptions{
-		Level:           level,
-		Output:          testlog.NewPrefixWriter(t, config.NodeName+" "),
-		IncludeLocation: true,
-	}
-	config.Logger = hclog.NewInterceptLogger(opts)
-	config.LogOutput = opts.Output
+	config.Logger, config.LogOutput = testlog.HCLoggerNode(t, nodeNum)
 
 	// Tighten the Serf timing
 	config.SerfConfig.MemberlistConfig.BindAddr = "127.0.0.1"

--- a/scheduler/annotate_test.go
+++ b/scheduler/annotate_test.go
@@ -5,9 +5,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 )
 
 func TestAnnotateTaskGroup_Updates(t *testing.T) {
+	testutil.Parallel(t)
+
 	annotations := &structs.PlanAnnotations{
 		DesiredTGUpdates: map[string]*structs.DesiredUpdates{
 			"foo": {
@@ -50,6 +53,8 @@ func TestAnnotateTaskGroup_Updates(t *testing.T) {
 }
 
 func TestAnnotateCountChange_NonEdited(t *testing.T) {
+	testutil.Parallel(t)
+
 	tg := &structs.TaskGroupDiff{}
 	tgOrig := &structs.TaskGroupDiff{}
 	annotateCountChange(tg)
@@ -59,6 +64,8 @@ func TestAnnotateCountChange_NonEdited(t *testing.T) {
 }
 
 func TestAnnotateCountChange(t *testing.T) {
+	testutil.Parallel(t)
+
 	up := &structs.FieldDiff{
 		Type: structs.DiffTypeEdited,
 		Name: "Count",
@@ -100,6 +107,8 @@ func TestAnnotateCountChange(t *testing.T) {
 }
 
 func TestAnnotateTask_NonEdited(t *testing.T) {
+	testutil.Parallel(t)
+
 	tgd := &structs.TaskGroupDiff{Type: structs.DiffTypeNone}
 	td := &structs.TaskDiff{Type: structs.DiffTypeNone}
 	tdOrig := &structs.TaskDiff{Type: structs.DiffTypeNone}
@@ -110,6 +119,8 @@ func TestAnnotateTask_NonEdited(t *testing.T) {
 }
 
 func TestAnnotateTask(t *testing.T) {
+	testutil.Parallel(t)
+
 	cases := []struct {
 		Diff    *structs.TaskDiff
 		Parent  *structs.TaskGroupDiff

--- a/scheduler/context_test.go
+++ b/scheduler/context_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,6 +28,8 @@ func testContext(t testing.TB) (*state.StateStore, *EvalContext) {
 }
 
 func TestEvalContext_ProposedAlloc(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	nodes := []*RankedNode{
 		{
@@ -156,7 +159,8 @@ func TestEvalContext_ProposedAlloc(t *testing.T) {
 // See https://github.com/hashicorp/nomad/issues/6787
 //
 func TestEvalContext_ProposedAlloc_EvictPreempt(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	nodes := []*RankedNode{
 		{
@@ -261,6 +265,8 @@ func TestEvalContext_ProposedAlloc_EvictPreempt(t *testing.T) {
 }
 
 func TestEvalEligibility_JobStatus(t *testing.T) {
+	testutil.Parallel(t)
+
 	e := NewEvalEligibility()
 	cc := "v1:100"
 
@@ -282,6 +288,8 @@ func TestEvalEligibility_JobStatus(t *testing.T) {
 }
 
 func TestEvalEligibility_TaskGroupStatus(t *testing.T) {
+	testutil.Parallel(t)
+
 	e := NewEvalEligibility()
 	cc := "v1:100"
 	tg := "foo"
@@ -304,6 +312,8 @@ func TestEvalEligibility_TaskGroupStatus(t *testing.T) {
 }
 
 func TestEvalEligibility_SetJob(t *testing.T) {
+	testutil.Parallel(t)
+
 	e := NewEvalEligibility()
 	ne1 := &structs.Constraint{
 		LTarget: "${attr.kernel.name}",
@@ -349,6 +359,8 @@ func TestEvalEligibility_SetJob(t *testing.T) {
 }
 
 func TestEvalEligibility_GetClasses(t *testing.T) {
+	testutil.Parallel(t)
+
 	e := NewEvalEligibility()
 	e.SetJobEligibility(true, "v1:1")
 	e.SetJobEligibility(false, "v1:2")
@@ -372,6 +384,8 @@ func TestEvalEligibility_GetClasses(t *testing.T) {
 	require.Equal(t, expClasses, actClasses)
 }
 func TestEvalEligibility_GetClasses_JobEligible_TaskGroupIneligible(t *testing.T) {
+	testutil.Parallel(t)
+
 	e := NewEvalEligibility()
 	e.SetJobEligibility(true, "v1:1")
 	e.SetTaskGroupEligibility(false, "foo", "v1:1")
@@ -395,6 +409,8 @@ func TestEvalEligibility_GetClasses_JobEligible_TaskGroupIneligible(t *testing.T
 }
 
 func TestPortCollisionEvent_Copy(t *testing.T) {
+	testutil.Parallel(t)
+
 	ev := &PortCollisionEvent{
 		Reason: "original",
 		Node:   mock.Node(),
@@ -425,6 +441,8 @@ func TestPortCollisionEvent_Copy(t *testing.T) {
 }
 
 func TestPortCollisionEvent_Sanitize(t *testing.T) {
+	testutil.Parallel(t)
+
 	ev := &PortCollisionEvent{
 		Reason: "original",
 		Node:   mock.Node(),

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -10,11 +10,14 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	psstructs "github.com/hashicorp/nomad/plugins/shared/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStaticIterator_Reset(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	var nodes []*structs.Node
 	for i := 0; i < 3; i++ {
@@ -46,6 +49,8 @@ func TestStaticIterator_Reset(t *testing.T) {
 }
 
 func TestStaticIterator_SetNodes(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	var nodes []*structs.Node
 	for i := 0; i < 3; i++ {
@@ -63,6 +68,8 @@ func TestStaticIterator_SetNodes(t *testing.T) {
 }
 
 func TestRandomIterator(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	var nodes []*structs.Node
 	for i := 0; i < 10; i++ {
@@ -83,6 +90,8 @@ func TestRandomIterator(t *testing.T) {
 }
 
 func TestHostVolumeChecker(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -165,6 +174,8 @@ func TestHostVolumeChecker(t *testing.T) {
 }
 
 func TestHostVolumeChecker_ReadOnly(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -233,7 +244,8 @@ func TestHostVolumeChecker_ReadOnly(t *testing.T) {
 }
 
 func TestCSIVolumeChecker(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -494,6 +506,8 @@ func TestCSIVolumeChecker(t *testing.T) {
 }
 
 func TestNetworkChecker(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 
 	node := func(mode string) *structs.Node {
@@ -638,6 +652,8 @@ func TestNetworkChecker(t *testing.T) {
 }
 
 func TestNetworkChecker_bridge_upgrade_path(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 
 	t.Run("older client", func(t *testing.T) {
@@ -668,6 +684,8 @@ func TestNetworkChecker_bridge_upgrade_path(t *testing.T) {
 }
 
 func TestDriverChecker_DriverInfo(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -717,6 +735,8 @@ func TestDriverChecker_DriverInfo(t *testing.T) {
 	}
 }
 func TestDriverChecker_Compatibility(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -768,7 +788,8 @@ func TestDriverChecker_Compatibility(t *testing.T) {
 }
 
 func Test_HealthChecks(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 
 	nodes := []*structs.Node{
@@ -826,11 +847,13 @@ func Test_HealthChecks(t *testing.T) {
 		}
 		checker := NewDriverChecker(ctx, drivers)
 		act := checker.Feasible(c.Node)
-		require.Equal(act, c.Result)
+		require.Equal(t, act, c.Result)
 	}
 }
 
 func TestConstraintChecker(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -891,6 +914,8 @@ func TestConstraintChecker(t *testing.T) {
 }
 
 func TestResolveConstraintTarget(t *testing.T) {
+	testutil.Parallel(t)
+
 	type tcase struct {
 		target string
 		node   *structs.Node
@@ -966,6 +991,8 @@ func TestResolveConstraintTarget(t *testing.T) {
 }
 
 func TestCheckConstraint(t *testing.T) {
+	testutil.Parallel(t)
+
 	type tcase struct {
 		op         string
 		lVal, rVal interface{}
@@ -1103,6 +1130,8 @@ func TestCheckConstraint(t *testing.T) {
 }
 
 func TestCheckLexicalOrder(t *testing.T) {
+	testutil.Parallel(t)
+
 	type tcase struct {
 		op         string
 		lVal, rVal interface{}
@@ -1143,7 +1172,7 @@ func TestCheckLexicalOrder(t *testing.T) {
 }
 
 func TestCheckVersionConstraint(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	type tcase struct {
 		lVal, rVal interface{}
@@ -1196,7 +1225,7 @@ func TestCheckVersionConstraint(t *testing.T) {
 }
 
 func TestCheckSemverConstraint(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	type tcase struct {
 		name       string
@@ -1258,6 +1287,8 @@ func TestCheckSemverConstraint(t *testing.T) {
 }
 
 func TestCheckRegexpConstraint(t *testing.T) {
+	testutil.Parallel(t)
+
 	type tcase struct {
 		lVal, rVal interface{}
 		result     bool
@@ -1295,6 +1326,8 @@ func TestCheckRegexpConstraint(t *testing.T) {
 // This test puts allocations on the node to test if it detects infeasibility of
 // nodes correctly and picks the only feasible one
 func TestDistinctHostsIterator_JobDistinctHosts(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -1369,6 +1402,8 @@ func TestDistinctHostsIterator_JobDistinctHosts(t *testing.T) {
 }
 
 func TestDistinctHostsIterator_JobDistinctHosts_InfeasibleCount(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -1420,6 +1455,8 @@ func TestDistinctHostsIterator_JobDistinctHosts_InfeasibleCount(t *testing.T) {
 }
 
 func TestDistinctHostsIterator_TaskGroupDistinctHosts(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -1488,6 +1525,8 @@ func TestDistinctHostsIterator_TaskGroupDistinctHosts(t *testing.T) {
 // value to detect if the constraint at the job level properly considers all
 // task groups.
 func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -1668,6 +1707,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty(t *testing.T) {
 // detect if the constraint at the job level properly considers all task groups
 // when the constraint allows a count greater than one
 func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -1875,6 +1916,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Count(t *testing.T) {
 // there is a plan to re-use that for a new allocation, that the next select
 // won't select that node.
 func TestDistinctPropertyIterator_JobDistinctProperty_RemoveAndReplace(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -1957,6 +2000,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty_RemoveAndReplace(t *testin
 // test if it detects infeasibility of property values correctly and picks the
 // only feasible one
 func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -2034,6 +2079,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible(t *testing.T) {
 // test if it detects infeasibility of property values correctly and picks the
 // only feasible one
 func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible_Count(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -2129,6 +2176,8 @@ func TestDistinctPropertyIterator_JobDistinctProperty_Infeasible_Count(t *testin
 // test if it detects infeasibility of property values correctly and picks the
 // only feasible one when the constraint is at the task group.
 func TestDistinctPropertyIterator_TaskGroupDistinctProperty(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -2290,6 +2339,8 @@ func (c *mockFeasibilityChecker) Feasible(*structs.Node) bool {
 func (c *mockFeasibilityChecker) calls() int { return c.i }
 
 func TestFeasibilityWrapper_JobIneligible(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{mock.Node()}
 	static := NewStaticIterator(ctx, nodes)
@@ -2308,6 +2359,8 @@ func TestFeasibilityWrapper_JobIneligible(t *testing.T) {
 }
 
 func TestFeasibilityWrapper_JobEscapes(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{mock.Node()}
 	static := NewStaticIterator(ctx, nodes)
@@ -2333,6 +2386,8 @@ func TestFeasibilityWrapper_JobEscapes(t *testing.T) {
 }
 
 func TestFeasibilityWrapper_JobAndTg_Eligible(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{mock.Node()}
 	static := NewStaticIterator(ctx, nodes)
@@ -2355,6 +2410,8 @@ func TestFeasibilityWrapper_JobAndTg_Eligible(t *testing.T) {
 }
 
 func TestFeasibilityWrapper_JobEligible_TgIneligible(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{mock.Node()}
 	static := NewStaticIterator(ctx, nodes)
@@ -2377,6 +2434,8 @@ func TestFeasibilityWrapper_JobEligible_TgIneligible(t *testing.T) {
 }
 
 func TestFeasibilityWrapper_JobEligible_TgEscaped(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{mock.Node()}
 	static := NewStaticIterator(ctx, nodes)
@@ -2404,6 +2463,8 @@ func TestFeasibilityWrapper_JobEligible_TgEscaped(t *testing.T) {
 }
 
 func TestSetContainsAny(t *testing.T) {
+	testutil.Parallel(t)
+
 	require.True(t, checkSetContainsAny("a", "a"))
 	require.True(t, checkSetContainsAny("a,b", "a"))
 	require.True(t, checkSetContainsAny("  a,b  ", "a "))
@@ -2412,6 +2473,8 @@ func TestSetContainsAny(t *testing.T) {
 }
 
 func TestDeviceChecker(t *testing.T) {
+	testutil.Parallel(t)
+
 	getTg := func(devices ...*structs.RequestedDevice) *structs.TaskGroup {
 		return &structs.TaskGroup{
 			Name: "example",
@@ -2750,6 +2813,8 @@ func TestDeviceChecker(t *testing.T) {
 }
 
 func TestCheckAttributeConstraint(t *testing.T) {
+	testutil.Parallel(t)
+
 	type tcase struct {
 		op         string
 		lVal, rVal *psstructs.Attribute

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -289,6 +290,8 @@ func assertResults(t *testing.T, r *reconcileResults, exp *resultExpectation) {
 // Tests the reconciler properly handles placements for a job that has no
 // existing allocations
 func TestReconciler_Place_NoExisting(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	reconciler := NewAllocReconciler(
 		testlog.HCLogger(t), allocUpdateFnIgnore, false, job.ID, job,
@@ -315,6 +318,8 @@ func TestReconciler_Place_NoExisting(t *testing.T) {
 // Tests the reconciler properly handles placements for a job that has some
 // existing allocations
 func TestReconciler_Place_Existing(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 
 	// Create 3 existing allocations
@@ -353,6 +358,8 @@ func TestReconciler_Place_Existing(t *testing.T) {
 // Tests the reconciler properly handles stopping allocations for a job that has
 // scaled down
 func TestReconciler_ScaleDown_Partial(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Has desired 10
 	job := mock.Job()
 
@@ -392,6 +399,8 @@ func TestReconciler_ScaleDown_Partial(t *testing.T) {
 // Tests the reconciler properly handles stopping allocations for a job that has
 // scaled down to zero desired
 func TestReconciler_ScaleDown_Zero(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Set desired 0
 	job := mock.Job()
 	job.TaskGroups[0].Count = 0
@@ -431,6 +440,8 @@ func TestReconciler_ScaleDown_Zero(t *testing.T) {
 // Tests the reconciler properly handles stopping allocations for a job that has
 // scaled down to zero desired where allocs have duplicate names
 func TestReconciler_ScaleDown_Zero_DuplicateNames(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Set desired 0
 	job := mock.Job()
 	job.TaskGroups[0].Count = 0
@@ -471,6 +482,8 @@ func TestReconciler_ScaleDown_Zero_DuplicateNames(t *testing.T) {
 
 // Tests the reconciler properly handles inplace upgrading allocations
 func TestReconciler_Inplace(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 
 	// Create 10 existing allocations
@@ -508,6 +521,8 @@ func TestReconciler_Inplace(t *testing.T) {
 // Tests the reconciler properly handles inplace upgrading allocations while
 // scaling up
 func TestReconciler_Inplace_ScaleUp(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Set desired 15
 	job := mock.Job()
 	job.TaskGroups[0].Count = 15
@@ -549,6 +564,8 @@ func TestReconciler_Inplace_ScaleUp(t *testing.T) {
 // Tests the reconciler properly handles inplace upgrading allocations while
 // scaling down
 func TestReconciler_Inplace_ScaleDown(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Set desired 5
 	job := mock.Job()
 	job.TaskGroups[0].Count = 5
@@ -591,6 +608,8 @@ func TestReconciler_Inplace_ScaleDown(t *testing.T) {
 // generates the expected placements for any already-running allocations of
 // that version.
 func TestReconciler_Inplace_Rollback(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Count = 4
 	job.TaskGroups[0].ReschedulePolicy = &structs.ReschedulePolicy{
@@ -657,6 +676,8 @@ func TestReconciler_Inplace_Rollback(t *testing.T) {
 
 // Tests the reconciler properly handles destructive upgrading allocations
 func TestReconciler_Destructive(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 
 	// Create 10 existing allocations
@@ -691,6 +712,8 @@ func TestReconciler_Destructive(t *testing.T) {
 
 // Tests the reconciler properly handles destructive upgrading allocations when max_parallel=0
 func TestReconciler_DestructiveMaxParallel(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.MaxParallelJob()
 
 	// Create 10 existing allocations
@@ -726,6 +749,8 @@ func TestReconciler_DestructiveMaxParallel(t *testing.T) {
 // Tests the reconciler properly handles destructive upgrading allocations while
 // scaling up
 func TestReconciler_Destructive_ScaleUp(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Set desired 15
 	job := mock.Job()
 	job.TaskGroups[0].Count = 15
@@ -766,6 +791,8 @@ func TestReconciler_Destructive_ScaleUp(t *testing.T) {
 // Tests the reconciler properly handles destructive upgrading allocations while
 // scaling down
 func TestReconciler_Destructive_ScaleDown(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Set desired 5
 	job := mock.Job()
 	job.TaskGroups[0].Count = 5
@@ -805,6 +832,8 @@ func TestReconciler_Destructive_ScaleDown(t *testing.T) {
 
 // Tests the reconciler properly handles lost nodes with allocations
 func TestReconciler_LostNode(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 
 	// Create 10 existing allocations
@@ -854,6 +883,8 @@ func TestReconciler_LostNode(t *testing.T) {
 // Tests the reconciler properly handles lost nodes with allocations while
 // scaling up
 func TestReconciler_LostNode_ScaleUp(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Set desired 15
 	job := mock.Job()
 	job.TaskGroups[0].Count = 15
@@ -905,6 +936,8 @@ func TestReconciler_LostNode_ScaleUp(t *testing.T) {
 // Tests the reconciler properly handles lost nodes with allocations while
 // scaling down
 func TestReconciler_LostNode_ScaleDown(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Set desired 5
 	job := mock.Job()
 	job.TaskGroups[0].Count = 5
@@ -953,6 +986,8 @@ func TestReconciler_LostNode_ScaleDown(t *testing.T) {
 
 // Tests the reconciler properly handles draining nodes with allocations
 func TestReconciler_DrainNode(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 
 	// Create 10 existing allocations
@@ -1004,6 +1039,8 @@ func TestReconciler_DrainNode(t *testing.T) {
 // Tests the reconciler properly handles draining nodes with allocations while
 // scaling up
 func TestReconciler_DrainNode_ScaleUp(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Set desired 15
 	job := mock.Job()
 	job.TaskGroups[0].Count = 15
@@ -1058,6 +1095,8 @@ func TestReconciler_DrainNode_ScaleUp(t *testing.T) {
 // Tests the reconciler properly handles draining nodes with allocations while
 // scaling down
 func TestReconciler_DrainNode_ScaleDown(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Set desired 8
 	job := mock.Job()
 	job.TaskGroups[0].Count = 8
@@ -1111,6 +1150,8 @@ func TestReconciler_DrainNode_ScaleDown(t *testing.T) {
 
 // Tests the reconciler properly handles a task group being removed
 func TestReconciler_RemovedTG(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 
 	// Create 10 allocations for a tg that no longer exists
@@ -1155,6 +1196,8 @@ func TestReconciler_RemovedTG(t *testing.T) {
 
 // Tests the reconciler properly handles a job in stopped states
 func TestReconciler_JobStopped(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.Stop = true
 
@@ -1217,6 +1260,8 @@ func TestReconciler_JobStopped(t *testing.T) {
 // Tests the reconciler doesn't update allocs in terminal state
 // when job is stopped or nil
 func TestReconciler_JobStopped_TerminalAllocs(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.Stop = true
 
@@ -1279,6 +1324,8 @@ func TestReconciler_JobStopped_TerminalAllocs(t *testing.T) {
 
 // Tests the reconciler properly handles jobs with multiple task groups
 func TestReconciler_MultiTG(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	tg2 := job.TaskGroups[0].Copy()
 	tg2.Name = "foo"
@@ -1323,6 +1370,8 @@ func TestReconciler_MultiTG(t *testing.T) {
 // Tests the reconciler properly handles jobs with multiple task groups with
 // only one having an update stanza and a deployment already being created
 func TestReconciler_MultiTG_SingleUpdateStanza(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	tg2 := job.TaskGroups[0].Copy()
 	tg2.Name = "foo"
@@ -1372,7 +1421,7 @@ func TestReconciler_MultiTG_SingleUpdateStanza(t *testing.T) {
 
 // Tests delayed rescheduling of failed batch allocations
 func TestReconciler_RescheduleLater_Batch(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Set desired 4
 	job := mock.Job()
@@ -1432,9 +1481,9 @@ func TestReconciler_RescheduleLater_Batch(t *testing.T) {
 	// Two reschedule attempts were already made, one more can be made at a future time
 	// Verify that the follow up eval has the expected waitUntil time
 	evals := r.desiredFollowupEvals[tgName]
-	require.NotNil(evals)
-	require.Equal(1, len(evals))
-	require.Equal(now.Add(delayDur), evals[0].WaitUntil)
+	require.NotNil(t, evals)
+	require.Equal(t, 1, len(evals))
+	require.Equal(t, now.Add(delayDur), evals[0].WaitUntil)
 
 	// Alloc 5 should not be replaced because it is terminal
 	assertResults(t, r, &resultExpectation{
@@ -1460,13 +1509,13 @@ func TestReconciler_RescheduleLater_Batch(t *testing.T) {
 	for _, a := range r.attributeUpdates {
 		annotated = a
 	}
-	require.Equal(evals[0].ID, annotated.FollowupEvalID)
+	require.Equal(t, evals[0].ID, annotated.FollowupEvalID)
 }
 
 // Tests delayed rescheduling of failed batch allocations and batching of allocs
 // with fail times that are close together
 func TestReconciler_RescheduleLaterWithBatchedEvals_Batch(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Set desired 4
 	job := mock.Job()
@@ -1512,13 +1561,13 @@ func TestReconciler_RescheduleLaterWithBatchedEvals_Batch(t *testing.T) {
 
 	// Verify that two follow up evals were created
 	evals := r.desiredFollowupEvals[tgName]
-	require.NotNil(evals)
-	require.Equal(2, len(evals))
+	require.NotNil(t, evals)
+	require.Equal(t, 2, len(evals))
 
 	// Verify expected WaitUntil values for both batched evals
-	require.Equal(now.Add(delayDur), evals[0].WaitUntil)
+	require.Equal(t, now.Add(delayDur), evals[0].WaitUntil)
 	secondBatchDuration := delayDur + 10*time.Second
-	require.Equal(now.Add(secondBatchDuration), evals[1].WaitUntil)
+	require.Equal(t, now.Add(secondBatchDuration), evals[1].WaitUntil)
 
 	// Alloc 5 should not be replaced because it is terminal
 	assertResults(t, r, &resultExpectation{
@@ -1542,9 +1591,9 @@ func TestReconciler_RescheduleLaterWithBatchedEvals_Batch(t *testing.T) {
 	// Verify that the followup evalID field is set correctly
 	for _, alloc := range r.attributeUpdates {
 		if allocNameToIndex(alloc.Name) < 5 {
-			require.Equal(evals[0].ID, alloc.FollowupEvalID)
+			require.Equal(t, evals[0].ID, alloc.FollowupEvalID)
 		} else if allocNameToIndex(alloc.Name) < 7 {
-			require.Equal(evals[1].ID, alloc.FollowupEvalID)
+			require.Equal(t, evals[1].ID, alloc.FollowupEvalID)
 		} else {
 			t.Fatalf("Unexpected alloc name in Inplace results %v", alloc.Name)
 		}
@@ -1553,7 +1602,8 @@ func TestReconciler_RescheduleLaterWithBatchedEvals_Batch(t *testing.T) {
 
 // Tests rescheduling failed batch allocations
 func TestReconciler_RescheduleNow_Batch(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	// Set desired 4
 	job := mock.Job()
 	job.TaskGroups[0].Count = 4
@@ -1608,7 +1658,7 @@ func TestReconciler_RescheduleNow_Batch(t *testing.T) {
 
 	// Verify that no follow up evals were created
 	evals := r.desiredFollowupEvals[tgName]
-	require.Nil(evals)
+	require.Nil(t, evals)
 
 	// Two reschedule attempts were made, one more can be made now
 	// Alloc 5 should not be replaced because it is terminal
@@ -1635,7 +1685,7 @@ func TestReconciler_RescheduleNow_Batch(t *testing.T) {
 
 // Tests rescheduling failed service allocations with desired state stop
 func TestReconciler_RescheduleLater_Service(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Set desired 5
 	job := mock.Job()
@@ -1684,9 +1734,9 @@ func TestReconciler_RescheduleLater_Service(t *testing.T) {
 	// Should place a new placement and create a follow up eval for the delayed reschedule
 	// Verify that the follow up eval has the expected waitUntil time
 	evals := r.desiredFollowupEvals[tgName]
-	require.NotNil(evals)
-	require.Equal(1, len(evals))
-	require.Equal(now.Add(delayDur), evals[0].WaitUntil)
+	require.NotNil(t, evals)
+	require.Equal(t, 1, len(evals))
+	require.Equal(t, now.Add(delayDur), evals[0].WaitUntil)
 
 	assertResults(t, r, &resultExpectation{
 		createDeployment:  nil,
@@ -1713,11 +1763,13 @@ func TestReconciler_RescheduleLater_Service(t *testing.T) {
 	for _, a := range r.attributeUpdates {
 		annotated = a
 	}
-	require.Equal(evals[0].ID, annotated.FollowupEvalID)
+	require.Equal(t, evals[0].ID, annotated.FollowupEvalID)
 }
 
 // Tests service allocations with client status complete
 func TestReconciler_Service_ClientStatusComplete(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Set desired 5
 	job := mock.Job()
 	job.TaskGroups[0].Count = 5
@@ -1773,6 +1825,8 @@ func TestReconciler_Service_ClientStatusComplete(t *testing.T) {
 
 // Tests service job placement with desired stop and client status complete
 func TestReconciler_Service_DesiredStop_ClientStatusComplete(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Set desired 5
 	job := mock.Job()
 	job.TaskGroups[0].Count = 5
@@ -1827,13 +1881,12 @@ func TestReconciler_Service_DesiredStop_ClientStatusComplete(t *testing.T) {
 	assertNamesHaveIndexes(t, intRange(4, 4), placeResultsToNames(r.place))
 
 	// Should not have any follow up evals created
-	require := require.New(t)
-	require.Equal(0, len(r.desiredFollowupEvals))
+	require.Equal(t, 0, len(r.desiredFollowupEvals))
 }
 
 // Tests rescheduling failed service allocations with desired state stop
 func TestReconciler_RescheduleNow_Service(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Set desired 5
 	job := mock.Job()
@@ -1888,7 +1941,7 @@ func TestReconciler_RescheduleNow_Service(t *testing.T) {
 
 	// Verify that no follow up evals were created
 	evals := r.desiredFollowupEvals[tgName]
-	require.Nil(evals)
+	require.Nil(t, evals)
 
 	// Verify that one rescheduled alloc and one replacement for terminal alloc were placed
 	assertResults(t, r, &resultExpectation{
@@ -1914,7 +1967,7 @@ func TestReconciler_RescheduleNow_Service(t *testing.T) {
 
 // Tests rescheduling failed service allocations when there's clock drift (upto a second)
 func TestReconciler_RescheduleNow_WithinAllowedTimeWindow(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Set desired 5
 	job := mock.Job()
@@ -1968,7 +2021,7 @@ func TestReconciler_RescheduleNow_WithinAllowedTimeWindow(t *testing.T) {
 
 	// Verify that no follow up evals were created
 	evals := r.desiredFollowupEvals[tgName]
-	require.Nil(evals)
+	require.Nil(t, evals)
 
 	// Verify that one rescheduled alloc was placed
 	assertResults(t, r, &resultExpectation{
@@ -1994,7 +2047,7 @@ func TestReconciler_RescheduleNow_WithinAllowedTimeWindow(t *testing.T) {
 
 // Tests rescheduling failed service allocations when the eval ID matches and there's a large clock drift
 func TestReconciler_RescheduleNow_EvalIDMatch(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Set desired 5
 	job := mock.Job()
@@ -2050,7 +2103,7 @@ func TestReconciler_RescheduleNow_EvalIDMatch(t *testing.T) {
 
 	// Verify that no follow up evals were created
 	evals := r.desiredFollowupEvals[tgName]
-	require.Nil(evals)
+	require.Nil(t, evals)
 
 	// Verify that one rescheduled alloc was placed
 	assertResults(t, r, &resultExpectation{
@@ -2076,7 +2129,7 @@ func TestReconciler_RescheduleNow_EvalIDMatch(t *testing.T) {
 
 // Tests rescheduling failed service allocations when there are canaries
 func TestReconciler_RescheduleNow_Service_WithCanaries(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Set desired 5
 	job := mock.Job()
@@ -2159,7 +2212,7 @@ func TestReconciler_RescheduleNow_Service_WithCanaries(t *testing.T) {
 
 	// Verify that no follow up evals were created
 	evals := r.desiredFollowupEvals[tgName]
-	require.Nil(evals)
+	require.Nil(t, evals)
 
 	// Verify that one rescheduled alloc and one replacement for terminal alloc were placed
 	assertResults(t, r, &resultExpectation{
@@ -2185,7 +2238,7 @@ func TestReconciler_RescheduleNow_Service_WithCanaries(t *testing.T) {
 
 // Tests rescheduling failed canary service allocations
 func TestReconciler_RescheduleNow_Service_Canaries(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Set desired 5
 	job := mock.Job()
@@ -2284,7 +2337,7 @@ func TestReconciler_RescheduleNow_Service_Canaries(t *testing.T) {
 
 	// Verify that no follow up evals were created
 	evals := r.desiredFollowupEvals[tgName]
-	require.Nil(evals)
+	require.Nil(t, evals)
 
 	// Verify that one rescheduled alloc and one replacement for terminal alloc were placed
 	assertResults(t, r, &resultExpectation{
@@ -2311,7 +2364,7 @@ func TestReconciler_RescheduleNow_Service_Canaries(t *testing.T) {
 // Tests rescheduling failed canary service allocations when one has reached its
 // reschedule limit
 func TestReconciler_RescheduleNow_Service_Canaries_Limit(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Set desired 5
 	job := mock.Job()
@@ -2412,7 +2465,7 @@ func TestReconciler_RescheduleNow_Service_Canaries_Limit(t *testing.T) {
 
 	// Verify that no follow up evals were created
 	evals := r.desiredFollowupEvals[tgName]
-	require.Nil(evals)
+	require.Nil(t, evals)
 
 	// Verify that one rescheduled alloc and one replacement for terminal alloc were placed
 	assertResults(t, r, &resultExpectation{
@@ -2438,6 +2491,8 @@ func TestReconciler_RescheduleNow_Service_Canaries_Limit(t *testing.T) {
 
 // Tests failed service allocations that were already rescheduled won't be rescheduled again
 func TestReconciler_DontReschedule_PreviouslyRescheduled(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Set desired 5
 	job := mock.Job()
 	job.TaskGroups[0].Count = 5
@@ -2497,6 +2552,8 @@ func TestReconciler_DontReschedule_PreviouslyRescheduled(t *testing.T) {
 
 // Tests the reconciler cancels an old deployment when the job is being stopped
 func TestReconciler_CancelDeployment_JobStop(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.Stop = true
 
@@ -2595,6 +2652,8 @@ func TestReconciler_CancelDeployment_JobStop(t *testing.T) {
 
 // Tests the reconciler cancels an old deployment when the job is updated
 func TestReconciler_CancelDeployment_JobUpdate(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Create a base job
 	job := mock.Job()
 
@@ -2672,6 +2731,8 @@ func TestReconciler_CancelDeployment_JobUpdate(t *testing.T) {
 // Tests the reconciler creates a deployment and does a rolling upgrade with
 // destructive changes
 func TestReconciler_CreateDeployment_RollingUpgrade_Destructive(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = noCanaryUpdate
 
@@ -2714,6 +2775,8 @@ func TestReconciler_CreateDeployment_RollingUpgrade_Destructive(t *testing.T) {
 
 // Tests the reconciler creates a deployment for inplace updates
 func TestReconciler_CreateDeployment_RollingUpgrade_Inplace(t *testing.T) {
+	testutil.Parallel(t)
+
 	jobOld := mock.Job()
 	job := jobOld.Copy()
 	job.Version++
@@ -2757,6 +2820,8 @@ func TestReconciler_CreateDeployment_RollingUpgrade_Inplace(t *testing.T) {
 
 // Tests the reconciler creates a deployment when the job has a newer create index
 func TestReconciler_CreateDeployment_NewerCreateIndex(t *testing.T) {
+	testutil.Parallel(t)
+
 	jobOld := mock.Job()
 	job := jobOld.Copy()
 	job.TaskGroups[0].Update = noCanaryUpdate
@@ -2804,6 +2869,8 @@ func TestReconciler_CreateDeployment_NewerCreateIndex(t *testing.T) {
 
 // Tests the reconciler doesn't creates a deployment if there are no changes
 func TestReconciler_DontCreateDeployment_NoChanges(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = noCanaryUpdate
 
@@ -2842,6 +2909,8 @@ func TestReconciler_DontCreateDeployment_NoChanges(t *testing.T) {
 // Tests the reconciler doesn't place any more canaries when the deployment is
 // paused or failed
 func TestReconciler_PausedOrFailedDeployment_NoMoreCanaries(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = canaryUpdate
 
@@ -2923,6 +2992,8 @@ func TestReconciler_PausedOrFailedDeployment_NoMoreCanaries(t *testing.T) {
 // Tests the reconciler doesn't place any more allocs when the deployment is
 // paused or failed
 func TestReconciler_PausedOrFailedDeployment_NoMorePlacements(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = noCanaryUpdate
 	job.TaskGroups[0].Count = 15
@@ -2988,6 +3059,8 @@ func TestReconciler_PausedOrFailedDeployment_NoMorePlacements(t *testing.T) {
 // Tests the reconciler doesn't do any more destructive updates when the
 // deployment is paused or failed
 func TestReconciler_PausedOrFailedDeployment_NoMoreDestructiveUpdates(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = noCanaryUpdate
 
@@ -3062,6 +3135,8 @@ func TestReconciler_PausedOrFailedDeployment_NoMoreDestructiveUpdates(t *testing
 
 // Tests the reconciler handles migrating a canary correctly on a draining node
 func TestReconciler_DrainNode_Canary(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = canaryUpdate
 
@@ -3135,6 +3210,8 @@ func TestReconciler_DrainNode_Canary(t *testing.T) {
 
 // Tests the reconciler handles migrating a canary correctly on a lost node
 func TestReconciler_LostNode_Canary(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = canaryUpdate
 
@@ -3209,6 +3286,8 @@ func TestReconciler_LostNode_Canary(t *testing.T) {
 
 // Tests the reconciler handles stopping canaries from older deployments
 func TestReconciler_StopOldCanaries(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = canaryUpdate
 
@@ -3290,6 +3369,8 @@ func TestReconciler_StopOldCanaries(t *testing.T) {
 
 // Tests the reconciler creates new canaries when the job changes
 func TestReconciler_NewCanaries(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = canaryUpdate
 
@@ -3337,6 +3418,8 @@ func TestReconciler_NewCanaries(t *testing.T) {
 // Tests the reconciler creates new canaries when the job changes and the
 // canary count is greater than the task group count
 func TestReconciler_NewCanaries_CountGreater(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Count = 3
 	job.TaskGroups[0].Update = canaryUpdate.Copy()
@@ -3387,6 +3470,8 @@ func TestReconciler_NewCanaries_CountGreater(t *testing.T) {
 // Tests the reconciler creates new canaries when the job changes for multiple
 // task groups
 func TestReconciler_NewCanaries_MultiTG(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = canaryUpdate
 	job.TaskGroups = append(job.TaskGroups, job.TaskGroups[0].Copy())
@@ -3443,6 +3528,8 @@ func TestReconciler_NewCanaries_MultiTG(t *testing.T) {
 
 // Tests the reconciler creates new canaries when the job changes and scales up
 func TestReconciler_NewCanaries_ScaleUp(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Scale the job up to 15
 	job := mock.Job()
 	job.TaskGroups[0].Update = canaryUpdate
@@ -3492,6 +3579,8 @@ func TestReconciler_NewCanaries_ScaleUp(t *testing.T) {
 // Tests the reconciler creates new canaries when the job changes and scales
 // down
 func TestReconciler_NewCanaries_ScaleDown(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Scale the job down to 5
 	job := mock.Job()
 	job.TaskGroups[0].Update = canaryUpdate
@@ -3542,6 +3631,8 @@ func TestReconciler_NewCanaries_ScaleDown(t *testing.T) {
 
 // Tests the reconciler handles filling the names of partially placed canaries
 func TestReconciler_NewCanaries_FillNames(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = &structs.UpdateStrategy{
 		Canary:          4,
@@ -3611,6 +3702,8 @@ func TestReconciler_NewCanaries_FillNames(t *testing.T) {
 
 // Tests the reconciler handles canary promotion by unblocking max_parallel
 func TestReconciler_PromoteCanaries_Unblock(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = canaryUpdate
 
@@ -3684,6 +3777,8 @@ func TestReconciler_PromoteCanaries_Unblock(t *testing.T) {
 // Tests the reconciler handles canary promotion when the canary count equals
 // the total correctly
 func TestReconciler_PromoteCanaries_CanariesEqualCount(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = canaryUpdate
 	job.TaskGroups[0].Count = 2
@@ -3766,6 +3861,8 @@ func TestReconciler_PromoteCanaries_CanariesEqualCount(t *testing.T) {
 // Tests the reconciler checks the health of placed allocs to determine the
 // limit
 func TestReconciler_DeploymentLimit_HealthAccounting(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = noCanaryUpdate
 
@@ -3859,6 +3956,8 @@ func TestReconciler_DeploymentLimit_HealthAccounting(t *testing.T) {
 // Tests the reconciler handles an alloc on a tainted node during a rolling
 // update
 func TestReconciler_TaintedNode_RollingUpgrade(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = noCanaryUpdate
 
@@ -3944,6 +4043,8 @@ func TestReconciler_TaintedNode_RollingUpgrade(t *testing.T) {
 // Tests the reconciler handles a failed deployment with allocs on tainted
 // nodes
 func TestReconciler_FailedDeployment_TaintedNodes(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = noCanaryUpdate
 
@@ -4028,6 +4129,8 @@ func TestReconciler_FailedDeployment_TaintedNodes(t *testing.T) {
 // Tests the reconciler handles a run after a deployment is complete
 // successfully.
 func TestReconciler_CompleteDeployment(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = canaryUpdate
 
@@ -4080,6 +4183,8 @@ func TestReconciler_CompleteDeployment(t *testing.T) {
 // nothing left to place even if there are failed allocations that are part of
 // the deployment.
 func TestReconciler_MarkDeploymentComplete_FailedAllocations(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = noCanaryUpdate
 
@@ -4142,6 +4247,8 @@ func TestReconciler_MarkDeploymentComplete_FailedAllocations(t *testing.T) {
 
 // Test that a failed deployment cancels non-promoted canaries
 func TestReconciler_FailedDeployment_CancelCanaries(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Create a job with two task groups
 	job := mock.Job()
 	job.TaskGroups[0].Update = canaryUpdate
@@ -4236,6 +4343,8 @@ func TestReconciler_FailedDeployment_CancelCanaries(t *testing.T) {
 
 // Test that a failed deployment and updated job works
 func TestReconciler_FailedDeployment_NewJob(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = noCanaryUpdate
 
@@ -4306,6 +4415,8 @@ func TestReconciler_FailedDeployment_NewJob(t *testing.T) {
 
 // Tests the reconciler marks a deployment as complete
 func TestReconciler_MarkDeploymentComplete(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = noCanaryUpdate
 
@@ -4363,6 +4474,8 @@ func TestReconciler_MarkDeploymentComplete(t *testing.T) {
 // Tests the reconciler handles changing a job such that a deployment is created
 // while doing a scale up but as the second eval.
 func TestReconciler_JobChange_ScaleUp_SecondEval(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Scale the job up to 15
 	job := mock.Job()
 	job.TaskGroups[0].Update = noCanaryUpdate
@@ -4424,6 +4537,8 @@ func TestReconciler_JobChange_ScaleUp_SecondEval(t *testing.T) {
 // Tests the reconciler doesn't stop allocations when doing a rolling upgrade
 // where the count of the old job allocs is < desired count.
 func TestReconciler_RollingUpgrade_MissingAllocs(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = noCanaryUpdate
 
@@ -4470,6 +4585,8 @@ func TestReconciler_RollingUpgrade_MissingAllocs(t *testing.T) {
 // Tests that the reconciler handles rerunning a batch job in the case that the
 // allocations are from an older instance of the job.
 func TestReconciler_Batch_Rerun(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Update = nil
@@ -4516,6 +4633,8 @@ func TestReconciler_Batch_Rerun(t *testing.T) {
 
 // Test that a failed deployment will not result in rescheduling failed allocations
 func TestReconciler_FailedDeployment_DontReschedule(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = noCanaryUpdate
 
@@ -4574,6 +4693,8 @@ func TestReconciler_FailedDeployment_DontReschedule(t *testing.T) {
 // Test that a running deployment with failed allocs will not result in
 // rescheduling failed allocations unless they are marked as reschedulable.
 func TestReconciler_DeploymentWithFailedAllocs_DontReschedule(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = noCanaryUpdate
 	tgName := job.TaskGroups[0].Name
@@ -4632,6 +4753,8 @@ func TestReconciler_DeploymentWithFailedAllocs_DontReschedule(t *testing.T) {
 
 // Test that a failed deployment cancels non-promoted canaries
 func TestReconciler_FailedDeployment_AutoRevert_CancelCanaries(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Create a job
 	job := mock.Job()
 	job.TaskGroups[0].Count = 3
@@ -4728,6 +4851,8 @@ func TestReconciler_FailedDeployment_AutoRevert_CancelCanaries(t *testing.T) {
 // Test that a successful deployment with failed allocs will result in
 // rescheduling failed allocations
 func TestReconciler_SuccessfulDeploymentWithFailedAllocs_Reschedule(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Update = noCanaryUpdate
 	tgName := job.TaskGroups[0].Name
@@ -4782,7 +4907,7 @@ func TestReconciler_SuccessfulDeploymentWithFailedAllocs_Reschedule(t *testing.T
 
 // Tests force rescheduling a failed alloc that is past its reschedule limit
 func TestReconciler_ForceReschedule_Service(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Set desired 5
 	job := mock.Job()
@@ -4830,7 +4955,7 @@ func TestReconciler_ForceReschedule_Service(t *testing.T) {
 
 	// Verify that no follow up evals were created
 	evals := r.desiredFollowupEvals[tgName]
-	require.Nil(evals)
+	require.Nil(t, evals)
 
 	// Verify that one rescheduled alloc was created because of the forced reschedule
 	assertResults(t, r, &resultExpectation{
@@ -4858,7 +4983,7 @@ func TestReconciler_ForceReschedule_Service(t *testing.T) {
 // new allocs should be placed to satisfy the job count, and current allocations are
 // left unmodified
 func TestReconciler_RescheduleNot_Service(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	// Set desired 5
 	job := mock.Job()
@@ -4913,7 +5038,7 @@ func TestReconciler_RescheduleNot_Service(t *testing.T) {
 
 	// Verify that no follow up evals were created
 	evals := r.desiredFollowupEvals[tgName]
-	require.Nil(evals)
+	require.Nil(t, evals)
 
 	// no rescheduling, ignore all 4 allocs
 	// but place one to substitute allocs[4] that was stopped explicitly
@@ -4940,7 +5065,8 @@ func TestReconciler_RescheduleNot_Service(t *testing.T) {
 // Tests behavior of batch failure with rescheduling policy preventing rescheduling:
 // current allocations are left unmodified and no follow up
 func TestReconciler_RescheduleNot_Batch(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
+
 	// Set desired 4
 	job := mock.Job()
 	job.TaskGroups[0].Count = 4
@@ -5000,7 +5126,7 @@ func TestReconciler_RescheduleNot_Batch(t *testing.T) {
 
 	// Verify that no follow up evals were created
 	evals := r.desiredFollowupEvals[tgName]
-	require.Nil(evals)
+	require.Nil(t, evals)
 
 	// No reschedule attempts were made and all allocs are untouched
 	assertResults(t, r, &resultExpectation{

--- a/scheduler/reconcile_util_test.go
+++ b/scheduler/reconcile_util_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,6 +15,8 @@ import (
 // aligned.
 // Ensure no regression from: https://github.com/hashicorp/nomad/issues/3008
 func TestBitmapFrom(t *testing.T) {
+	testutil.Parallel(t)
+
 	input := map[string]*structs.Allocation{
 		"8": {
 			JobID:     "foo",
@@ -34,7 +37,7 @@ func TestBitmapFrom(t *testing.T) {
 }
 
 func TestAllocSet_filterByTainted(t *testing.T) {
-	require := require.New(t)
+	testutil.Parallel(t)
 
 	nodes := map[string]*structs.Node{
 		"draining": {
@@ -117,15 +120,15 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 	}
 
 	untainted, migrate, lost := allocs.filterByTainted(nodes)
-	require.Len(untainted, 4)
-	require.Contains(untainted, "untainted1")
-	require.Contains(untainted, "untainted2")
-	require.Contains(untainted, "untainted3")
-	require.Contains(untainted, "untainted4")
-	require.Len(migrate, 2)
-	require.Contains(migrate, "migrating1")
-	require.Contains(migrate, "migrating2")
-	require.Len(lost, 2)
-	require.Contains(lost, "lost1")
-	require.Contains(lost, "lost2")
+	require.Len(t, untainted, 4)
+	require.Contains(t, untainted, "untainted1")
+	require.Contains(t, untainted, "untainted2")
+	require.Contains(t, untainted, "untainted3")
+	require.Contains(t, untainted, "untainted4")
+	require.Len(t, migrate, 2)
+	require.Contains(t, migrate, "migrating1")
+	require.Contains(t, migrate, "migrating2")
+	require.Len(t, lost, 2)
+	require.Contains(t, lost, "lost1")
+	require.Contains(t, lost, "lost2")
 }

--- a/scheduler/scheduler_sysbatch_test.go
+++ b/scheduler/scheduler_sysbatch_test.go
@@ -10,11 +10,14 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSysBatch_JobRegister(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -74,6 +77,8 @@ func TestSysBatch_JobRegister(t *testing.T) {
 }
 
 func TestSysBatch_JobRegister_AddNode_Running(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -149,6 +154,8 @@ func TestSysBatch_JobRegister_AddNode_Running(t *testing.T) {
 }
 
 func TestSysBatch_JobRegister_AddNode_Dead(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -225,6 +232,8 @@ func TestSysBatch_JobRegister_AddNode_Dead(t *testing.T) {
 }
 
 func TestSysBatch_JobModify(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -313,6 +322,8 @@ func TestSysBatch_JobModify(t *testing.T) {
 }
 
 func TestSysBatch_JobModify_InPlace(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -385,6 +396,8 @@ func TestSysBatch_JobModify_InPlace(t *testing.T) {
 }
 
 func TestSysBatch_JobDeregister_Purged(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -444,6 +457,8 @@ func TestSysBatch_JobDeregister_Purged(t *testing.T) {
 }
 
 func TestSysBatch_JobDeregister_Stopped(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -505,6 +520,8 @@ func TestSysBatch_JobDeregister_Stopped(t *testing.T) {
 }
 
 func TestSysBatch_NodeDown(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Register a down node
@@ -564,6 +581,8 @@ func TestSysBatch_NodeDown(t *testing.T) {
 }
 
 func TestSysBatch_NodeDrain_Down(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Register a draining node
@@ -616,6 +635,8 @@ func TestSysBatch_NodeDrain_Down(t *testing.T) {
 }
 
 func TestSysBatch_NodeDrain(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Register a draining node
@@ -671,6 +692,8 @@ func TestSysBatch_NodeDrain(t *testing.T) {
 }
 
 func TestSysBatch_NodeUpdate(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Register a node
@@ -713,6 +736,8 @@ func TestSysBatch_NodeUpdate(t *testing.T) {
 }
 
 func TestSysBatch_RetryLimit(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 	h.Planner = &RejectPlan{h}
 
@@ -757,6 +782,8 @@ func TestSysBatch_RetryLimit(t *testing.T) {
 // count for a task group when allocations can't be created on currently
 // available nodes because of constraint mismatches.
 func TestSysBatch_Queued_With_Constraints(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	nodes := createNodes(t, h, 3)
@@ -802,6 +829,8 @@ func TestSysBatch_Queued_With_Constraints(t *testing.T) {
 }
 
 func TestSysBatch_Queued_With_Constraints_PartialMatch(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// linux machines
@@ -850,6 +879,8 @@ func TestSysBatch_Queued_With_Constraints_PartialMatch(t *testing.T) {
 // should be that the TaskGroup constrained to the newly added node class is
 // added and that the TaskGroup constrained to the ineligible node is ignored.
 func TestSysBatch_JobConstraint_AddNode(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create two nodes
@@ -995,6 +1026,8 @@ func TestSysBatch_JobConstraint_AddNode(t *testing.T) {
 
 // No errors reported when no available nodes prevent placement
 func TestSysBatch_ExistingAllocNoNodes(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	var node *structs.Node
@@ -1074,6 +1107,8 @@ func TestSysBatch_ExistingAllocNoNodes(t *testing.T) {
 }
 
 func TestSysBatch_ConstraintErrors(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	var node *structs.Node
@@ -1147,6 +1182,8 @@ func TestSysBatch_ConstraintErrors(t *testing.T) {
 }
 
 func TestSysBatch_ChainedAlloc(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -1234,6 +1271,8 @@ func TestSysBatch_ChainedAlloc(t *testing.T) {
 }
 
 func TestSysBatch_PlanWithDrainedNode(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Register two nodes with two different classes
@@ -1314,6 +1353,8 @@ func TestSysBatch_PlanWithDrainedNode(t *testing.T) {
 }
 
 func TestSysBatch_QueuedAllocsMultTG(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Register two nodes with two different classes
@@ -1370,6 +1411,8 @@ func TestSysBatch_QueuedAllocsMultTG(t *testing.T) {
 }
 
 func TestSysBatch_Preemption(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create nodes
@@ -1654,6 +1697,8 @@ func TestSysBatch_Preemption(t *testing.T) {
 }
 
 func TestSysBatch_canHandle(t *testing.T) {
+	testutil.Parallel(t)
+
 	s := SystemScheduler{sysbatch: true}
 	t.Run("sysbatch register", func(t *testing.T) {
 		require.True(t, s.canHandle(structs.EvalTriggerJobRegister))

--- a/scheduler/scheduler_system_test.go
+++ b/scheduler/scheduler_system_test.go
@@ -12,10 +12,13 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSystemSched_JobRegister(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -75,6 +78,8 @@ func TestSystemSched_JobRegister(t *testing.T) {
 }
 
 func TestSystemSched_JobRegister_StickyAllocs(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -148,6 +153,8 @@ func TestSystemSched_JobRegister_StickyAllocs(t *testing.T) {
 }
 
 func TestSystemSched_JobRegister_EphemeralDiskConstraint(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create a node
@@ -217,6 +224,8 @@ func TestSystemSched_JobRegister_EphemeralDiskConstraint(t *testing.T) {
 }
 
 func TestSystemSched_ExhaustResources(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create a node
@@ -272,20 +281,19 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 	}
 
 	// System scheduler will preempt the service job and would have placed eval1
-	require := require.New(t)
 
 	newPlan := h.Plans[1]
-	require.Len(newPlan.NodeAllocation, 1)
-	require.Len(newPlan.NodePreemptions, 1)
+	require.Len(t, newPlan.NodeAllocation, 1)
+	require.Len(t, newPlan.NodePreemptions, 1)
 
 	for _, allocList := range newPlan.NodeAllocation {
-		require.Len(allocList, 1)
-		require.Equal(job.ID, allocList[0].JobID)
+		require.Len(t, allocList, 1)
+		require.Equal(t, job.ID, allocList[0].JobID)
 	}
 
 	for _, allocList := range newPlan.NodePreemptions {
-		require.Len(allocList, 1)
-		require.Equal(svcJob.ID, allocList[0].JobID)
+		require.Len(t, allocList, 1)
+		require.Equal(t, svcJob.ID, allocList[0].JobID)
 	}
 	// Ensure that we have no queued allocations on the second eval
 	queued := h.Evals[1].QueuedAllocations["web"]
@@ -295,6 +303,8 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 }
 
 func TestSystemSched_JobRegister_Annotate(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -391,6 +401,8 @@ func TestSystemSched_JobRegister_Annotate(t *testing.T) {
 }
 
 func TestSystemSched_JobRegister_AddNode(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -469,6 +481,8 @@ func TestSystemSched_JobRegister_AddNode(t *testing.T) {
 }
 
 func TestSystemSched_JobRegister_AllocFail(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create NO nodes
@@ -501,6 +515,8 @@ func TestSystemSched_JobRegister_AllocFail(t *testing.T) {
 }
 
 func TestSystemSched_JobModify(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -588,6 +604,8 @@ func TestSystemSched_JobModify(t *testing.T) {
 }
 
 func TestSystemSched_JobModify_Rolling(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -686,6 +704,8 @@ func TestSystemSched_JobModify_Rolling(t *testing.T) {
 }
 
 func TestSystemSched_JobModify_InPlace(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -766,6 +786,8 @@ func TestSystemSched_JobModify_InPlace(t *testing.T) {
 }
 
 func TestSystemSched_JobModify_RemoveDC(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -851,6 +873,8 @@ func TestSystemSched_JobModify_RemoveDC(t *testing.T) {
 }
 
 func TestSystemSched_JobDeregister_Purged(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -910,6 +934,8 @@ func TestSystemSched_JobDeregister_Purged(t *testing.T) {
 }
 
 func TestSystemSched_JobDeregister_Stopped(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -971,6 +997,8 @@ func TestSystemSched_JobDeregister_Stopped(t *testing.T) {
 }
 
 func TestSystemSched_NodeDown(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Register a down node
@@ -1030,6 +1058,8 @@ func TestSystemSched_NodeDown(t *testing.T) {
 }
 
 func TestSystemSched_NodeDrain_Down(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Register a draining node
@@ -1082,6 +1112,8 @@ func TestSystemSched_NodeDrain_Down(t *testing.T) {
 }
 
 func TestSystemSched_NodeDrain(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Register a draining node
@@ -1137,6 +1169,8 @@ func TestSystemSched_NodeDrain(t *testing.T) {
 }
 
 func TestSystemSched_NodeUpdate(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Register a node
@@ -1179,6 +1213,8 @@ func TestSystemSched_NodeUpdate(t *testing.T) {
 }
 
 func TestSystemSched_RetryLimit(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 	h.Planner = &RejectPlan{h}
 
@@ -1223,6 +1259,8 @@ func TestSystemSched_RetryLimit(t *testing.T) {
 // count for a task group when allocations can't be created on currently
 // available nodes because of constraint mismatches.
 func TestSystemSched_Queued_With_Constraints(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Register a node
@@ -1262,6 +1300,8 @@ func TestSystemSched_Queued_With_Constraints(t *testing.T) {
 // should be that the TaskGroup constrained to the newly added node class is
 // added and that the TaskGroup constrained to the ineligible node is ignored.
 func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create two nodes
@@ -1409,6 +1449,8 @@ func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
 
 // No errors reported when no available nodes prevent placement
 func TestSystemSched_ExistingAllocNoNodes(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	var node *structs.Node
@@ -1488,6 +1530,8 @@ func TestSystemSched_ExistingAllocNoNodes(t *testing.T) {
 
 // No errors reported when constraints prevent placement
 func TestSystemSched_ConstraintErrors(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	var node *structs.Node
@@ -1559,6 +1603,8 @@ func TestSystemSched_ConstraintErrors(t *testing.T) {
 }
 
 func TestSystemSched_ChainedAlloc(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create some nodes
@@ -1647,6 +1693,8 @@ func TestSystemSched_ChainedAlloc(t *testing.T) {
 }
 
 func TestSystemSched_PlanWithDrainedNode(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Register two nodes with two different classes
@@ -1727,6 +1775,8 @@ func TestSystemSched_PlanWithDrainedNode(t *testing.T) {
 }
 
 func TestSystemSched_QueuedAllocsMultTG(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Register two nodes with two different classes
@@ -1783,6 +1833,8 @@ func TestSystemSched_QueuedAllocsMultTG(t *testing.T) {
 }
 
 func TestSystemSched_Preemption(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 
 	// Create nodes
@@ -2066,6 +2118,8 @@ func TestSystemSched_Preemption(t *testing.T) {
 }
 
 func TestSystemSched_canHandle(t *testing.T) {
+	testutil.Parallel(t)
+
 	s := SystemScheduler{sysbatch: false}
 	t.Run("system register", func(t *testing.T) {
 		require.True(t, s.canHandle(structs.EvalTriggerJobRegister))

--- a/scheduler/select_test.go
+++ b/scheduler/select_test.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLimitIterator(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*RankedNode{
 		{
@@ -53,6 +56,8 @@ func TestLimitIterator(t *testing.T) {
 }
 
 func TestLimitIterator_ScoreThreshold(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	type testCase struct {
 		desc        string
@@ -305,18 +310,19 @@ func TestLimitIterator_ScoreThreshold(t *testing.T) {
 			limit := NewLimitIterator(ctx, static, 1, 0, 2)
 			limit.SetLimit(2)
 			out := collectRanked(limit)
-			require := require.New(t)
-			require.Equal(tc.expectedOut, out)
+			require.Equal(t, tc.expectedOut, out)
 
 			limit.Reset()
-			require.Equal(0, limit.skippedNodeIndex)
-			require.Equal(0, len(limit.skippedNodes))
+			require.Equal(t, 0, limit.skippedNodeIndex)
+			require.Equal(t, 0, len(limit.skippedNodes))
 		})
 	}
 
 }
 
 func TestMaxScoreIterator(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*RankedNode{
 		{

--- a/scheduler/spread_test.go
+++ b/scheduler/spread_test.go
@@ -1,22 +1,24 @@
 package scheduler
 
 import (
+	"fmt"
 	"math"
 	"math/rand"
 	"sort"
 	"testing"
 	"time"
 
-	"fmt"
-
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSpreadIterator_SingleAttribute(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	dcs := []string{"dc1", "dc2", "dc1", "dc1"}
 	var nodes []*RankedNode
@@ -175,6 +177,8 @@ func TestSpreadIterator_SingleAttribute(t *testing.T) {
 }
 
 func TestSpreadIterator_MultipleAttributes(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	dcs := []string{"dc1", "dc2", "dc1", "dc1"}
 	rack := []string{"r1", "r1", "r2", "r2"}
@@ -276,6 +280,8 @@ func TestSpreadIterator_MultipleAttributes(t *testing.T) {
 }
 
 func TestSpreadIterator_EvenSpread(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	dcs := []string{"dc1", "dc2", "dc1", "dc2", "dc1", "dc2", "dc2", "dc1", "dc1", "dc1"}
 	var nodes []*RankedNode
@@ -464,6 +470,8 @@ func TestSpreadIterator_EvenSpread(t *testing.T) {
 
 // Test scenarios where the spread iterator sets maximum penalty (-1.0)
 func TestSpreadIterator_MaxPenalty(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	var nodes []*RankedNode
 
@@ -551,6 +559,8 @@ func TestSpreadIterator_MaxPenalty(t *testing.T) {
 }
 
 func Test_evenSpreadScoreBoost(t *testing.T) {
+	testutil.Parallel(t)
+
 	pset := &propertySet{
 		existingValues: map[string]uint64{},
 		proposedValues: map[string]uint64{
@@ -580,7 +590,8 @@ func Test_evenSpreadScoreBoost(t *testing.T) {
 // can prevent quadratic performance but then we need this test to
 // verify we have satisfactory spread results.
 func TestSpreadOnLargeCluster(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	cases := []struct {
 		name      string
 		nodeCount int
@@ -814,6 +825,7 @@ func validateEqualSpread(h *Harness) error {
 }
 
 func TestSpreadPanicDowngrade(t *testing.T) {
+	testutil.Parallel(t)
 
 	h := NewHarness(t)
 

--- a/scheduler/stack_test.go
+++ b/scheduler/stack_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,6 +56,8 @@ func benchmarkServiceStack_MetaKeyConstraint(b *testing.B, key string, numNodes,
 }
 
 func TestServiceStack_SetNodes(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	stack := NewGenericStack(false, ctx)
 
@@ -82,6 +85,8 @@ func TestServiceStack_SetNodes(t *testing.T) {
 }
 
 func TestServiceStack_SetJob(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	stack := NewGenericStack(false, ctx)
 
@@ -97,6 +102,8 @@ func TestServiceStack_SetJob(t *testing.T) {
 }
 
 func TestServiceStack_Select_Size(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -122,6 +129,8 @@ func TestServiceStack_Select_Size(t *testing.T) {
 }
 
 func TestServiceStack_Select_PreferringNodes(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -166,6 +175,8 @@ func TestServiceStack_Select_PreferringNodes(t *testing.T) {
 }
 
 func TestServiceStack_Select_MetricsReset(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -202,6 +213,8 @@ func TestServiceStack_Select_MetricsReset(t *testing.T) {
 }
 
 func TestServiceStack_Select_DriverFilter(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -232,6 +245,8 @@ func TestServiceStack_Select_DriverFilter(t *testing.T) {
 }
 
 func TestServiceStack_Select_CSI(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -308,6 +323,8 @@ func TestServiceStack_Select_CSI(t *testing.T) {
 }
 
 func TestServiceStack_Select_ConstraintFilter(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -348,6 +365,8 @@ func TestServiceStack_Select_ConstraintFilter(t *testing.T) {
 }
 
 func TestServiceStack_Select_BinPack_Overflow(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -391,6 +410,8 @@ func TestServiceStack_Select_BinPack_Overflow(t *testing.T) {
 }
 
 func TestSystemStack_SetNodes(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	stack := NewSystemStack(false, ctx)
 
@@ -413,6 +434,8 @@ func TestSystemStack_SetNodes(t *testing.T) {
 }
 
 func TestSystemStack_SetJob(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	stack := NewSystemStack(false, ctx)
 
@@ -428,6 +451,8 @@ func TestSystemStack_SetJob(t *testing.T) {
 }
 
 func TestSystemStack_Select_Size(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{mock.Node()}
 	stack := NewSystemStack(false, ctx)
@@ -451,6 +476,8 @@ func TestSystemStack_Select_Size(t *testing.T) {
 }
 
 func TestSystemStack_Select_MetricsReset(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -487,6 +514,8 @@ func TestSystemStack_Select_MetricsReset(t *testing.T) {
 }
 
 func TestSystemStack_Select_DriverFilter(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -526,6 +555,8 @@ func TestSystemStack_Select_DriverFilter(t *testing.T) {
 }
 
 func TestSystemStack_Select_ConstraintFilter(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),
@@ -567,6 +598,8 @@ func TestSystemStack_Select_ConstraintFilter(t *testing.T) {
 }
 
 func TestSystemStack_Select_BinPack_Overflow(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	nodes := []*structs.Node{
 		mock.Node(),

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/nomad/helper"
@@ -17,6 +18,8 @@ import (
 )
 
 func TestMaterializeTaskGroups(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	index := materializeTaskGroups(job)
 	require.Equal(t, 10, len(index))
@@ -35,6 +38,8 @@ func newNode(name string) *structs.Node {
 }
 
 func TestDiffSystemAllocsForNode_Sysbatch_terminal(t *testing.T) {
+	testutil.Parallel(t)
+
 	// For a sysbatch job, the scheduler should not re-place an allocation
 	// that has become terminal, unless the job has been updated.
 
@@ -99,6 +104,8 @@ func TestDiffSystemAllocsForNode_Sysbatch_terminal(t *testing.T) {
 }
 
 func TestDiffSystemAllocsForNode(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	required := materializeTaskGroups(job)
 
@@ -233,6 +240,8 @@ func TestDiffSystemAllocsForNode(t *testing.T) {
 // Test the desired diff for an updated system job running on a
 // ineligible node
 func TestDiffSystemAllocsForNode_ExistingAllocIneligibleNode(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.Job()
 	job.TaskGroups[0].Count = 1
 	required := materializeTaskGroups(job)
@@ -284,6 +293,8 @@ func TestDiffSystemAllocsForNode_ExistingAllocIneligibleNode(t *testing.T) {
 }
 
 func TestDiffSystemAllocs(t *testing.T) {
+	testutil.Parallel(t)
+
 	job := mock.SystemJob()
 
 	drainNode := mock.DrainNode()
@@ -391,6 +402,8 @@ func TestDiffSystemAllocs(t *testing.T) {
 }
 
 func TestReadyNodesInDCs(t *testing.T) {
+	testutil.Parallel(t)
+
 	state := state.TestStateStore(t)
 	node1 := mock.Node()
 	node2 := mock.Node()
@@ -421,6 +434,8 @@ func TestReadyNodesInDCs(t *testing.T) {
 }
 
 func TestRetryMax(t *testing.T) {
+	testutil.Parallel(t)
+
 	calls := 0
 	bad := func() (bool, error) {
 		calls += 1
@@ -454,6 +469,8 @@ func TestRetryMax(t *testing.T) {
 }
 
 func TestTaintedNodes(t *testing.T) {
+	testutil.Parallel(t)
+
 	state := state.TestStateStore(t)
 	node1 := mock.Node()
 	node2 := mock.Node()
@@ -491,6 +508,8 @@ func TestTaintedNodes(t *testing.T) {
 }
 
 func TestShuffleNodes(t *testing.T) {
+	testutil.Parallel(t)
+
 	// Use a large number of nodes to make the probability of shuffling to the
 	// original order very low.
 	nodes := []*structs.Node{
@@ -521,6 +540,8 @@ func TestShuffleNodes(t *testing.T) {
 }
 
 func TestTaskUpdatedAffinity(t *testing.T) {
+	testutil.Parallel(t)
+
 	j1 := mock.Job()
 	j2 := mock.Job()
 	name := j1.TaskGroups[0].Name
@@ -589,6 +610,8 @@ func TestTaskUpdatedAffinity(t *testing.T) {
 }
 
 func TestTaskUpdatedSpread(t *testing.T) {
+	testutil.Parallel(t)
+
 	j1 := mock.Job()
 	j2 := mock.Job()
 	name := j1.TaskGroups[0].Name
@@ -654,6 +677,8 @@ func TestTaskUpdatedSpread(t *testing.T) {
 	require.False(t, tasksUpdated(j5, j6, name))
 }
 func TestTasksUpdated(t *testing.T) {
+	testutil.Parallel(t)
+
 	j1 := mock.Job()
 	j2 := mock.Job()
 	name := j1.TaskGroups[0].Name
@@ -789,6 +814,8 @@ func TestTasksUpdated(t *testing.T) {
 }
 
 func TestTasksUpdated_connectServiceUpdated(t *testing.T) {
+	testutil.Parallel(t)
+
 	servicesA := []*structs.Service{{
 		Name:      "service1",
 		PortLabel: "1111",
@@ -868,7 +895,8 @@ func TestTasksUpdated_connectServiceUpdated(t *testing.T) {
 }
 
 func TestNetworkUpdated(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
+
 	cases := []struct {
 		name    string
 		a       []*structs.NetworkResource
@@ -935,6 +963,8 @@ func TestNetworkUpdated(t *testing.T) {
 }
 
 func TestEvictAndPlace_LimitLessThanAllocs(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	allocs := []allocTuple{
 		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
@@ -951,6 +981,8 @@ func TestEvictAndPlace_LimitLessThanAllocs(t *testing.T) {
 }
 
 func TestEvictAndPlace_LimitEqualToAllocs(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	allocs := []allocTuple{
 		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
@@ -967,6 +999,8 @@ func TestEvictAndPlace_LimitEqualToAllocs(t *testing.T) {
 }
 
 func TestSetStatus(t *testing.T) {
+	testutil.Parallel(t)
+
 	h := NewHarness(t)
 	logger := testlog.HCLogger(t)
 	eval := mock.Eval()
@@ -1027,6 +1061,8 @@ func TestSetStatus(t *testing.T) {
 }
 
 func TestInplaceUpdate_ChangedTaskGroup(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	eval := mock.Eval()
 	job := mock.Job()
@@ -1082,6 +1118,8 @@ func TestInplaceUpdate_ChangedTaskGroup(t *testing.T) {
 }
 
 func TestInplaceUpdate_AllocatedResources(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	eval := mock.Eval()
 	job := mock.Job()
@@ -1139,6 +1177,8 @@ func TestInplaceUpdate_AllocatedResources(t *testing.T) {
 }
 
 func TestInplaceUpdate_NoMatch(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	eval := mock.Eval()
 	job := mock.Job()
@@ -1190,6 +1230,8 @@ func TestInplaceUpdate_NoMatch(t *testing.T) {
 }
 
 func TestInplaceUpdate_Success(t *testing.T) {
+	testutil.Parallel(t)
+
 	state, ctx := testContext(t)
 	eval := mock.Eval()
 	job := mock.Job()
@@ -1279,6 +1321,8 @@ func TestInplaceUpdate_Success(t *testing.T) {
 }
 
 func TestEvictAndPlace_LimitGreaterThanAllocs(t *testing.T) {
+	testutil.Parallel(t)
+
 	_, ctx := testContext(t)
 	allocs := []allocTuple{
 		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
@@ -1295,6 +1339,8 @@ func TestEvictAndPlace_LimitGreaterThanAllocs(t *testing.T) {
 }
 
 func TestTaskGroupConstraints(t *testing.T) {
+	testutil.Parallel(t)
+
 	constr := &structs.Constraint{RTarget: "bar"}
 	constr2 := &structs.Constraint{LTarget: "foo"}
 	constr3 := &structs.Constraint{Operand: "<"}
@@ -1336,6 +1382,8 @@ func TestTaskGroupConstraints(t *testing.T) {
 }
 
 func TestProgressMade(t *testing.T) {
+	testutil.Parallel(t)
+
 	noopPlan := &structs.PlanResult{}
 	require.False(t, progressMade(nil) || progressMade(noopPlan), "no progress plan marked as making progress")
 
@@ -1360,6 +1408,8 @@ func TestProgressMade(t *testing.T) {
 }
 
 func TestDesiredUpdates(t *testing.T) {
+	testutil.Parallel(t)
+
 	tg1 := &structs.TaskGroup{Name: "foo"}
 	tg2 := &structs.TaskGroup{Name: "bar"}
 	a2 := &structs.Allocation{TaskGroup: "bar"}
@@ -1416,6 +1466,8 @@ func TestDesiredUpdates(t *testing.T) {
 }
 
 func TestUtil_AdjustQueuedAllocations(t *testing.T) {
+	testutil.Parallel(t)
+
 	logger := testlog.HCLogger(t)
 	alloc1 := mock.Alloc()
 	alloc2 := mock.Alloc()
@@ -1451,6 +1503,8 @@ func TestUtil_AdjustQueuedAllocations(t *testing.T) {
 }
 
 func TestUtil_UpdateNonTerminalAllocsToLost(t *testing.T) {
+	testutil.Parallel(t)
+
 	node := mock.Node()
 	node.Status = structs.NodeStatusDown
 	alloc1 := mock.Alloc()
@@ -1503,6 +1557,8 @@ func TestUtil_UpdateNonTerminalAllocsToLost(t *testing.T) {
 }
 
 func TestUtil_connectUpdated(t *testing.T) {
+	testutil.Parallel(t)
+
 	t.Run("both nil", func(t *testing.T) {
 		require.False(t, connectUpdated(nil, nil))
 	})
@@ -1555,6 +1611,8 @@ func TestUtil_connectUpdated(t *testing.T) {
 }
 
 func TestUtil_connectSidecarServiceUpdated(t *testing.T) {
+	testutil.Parallel(t)
+
 	t.Run("both nil", func(t *testing.T) {
 		require.False(t, connectSidecarServiceUpdated(nil, nil))
 	})

--- a/testutil/slow.go
+++ b/testutil/slow.go
@@ -2,14 +2,23 @@ package testutil
 
 import (
 	"os"
-
-	testing "github.com/mitchellh/go-testing-interface"
+	"strconv"
+	"testing"
 )
 
-// SkipSlow skips a slow test unless the NOMAD_SLOW_TEST environment variable
-// is set.
-func SkipSlow(t testing.T) {
-	if os.Getenv("NOMAD_SLOW_TEST") == "" {
-		t.Skip("Skipping slow test. Set NOMAD_SLOW_TEST=1 to run.")
+// SkipSlow skips a slow test unless the NOMAD_SLOW_TEST environment variable is set.
+func SkipSlow(t *testing.T, reason string) {
+	value := os.Getenv("NOMAD_SLOW_TEST")
+	run, err := strconv.ParseBool(value)
+	if !run || err != nil {
+		t.Skipf("Skipping slow test: %s", reason)
+	}
+}
+
+func Parallel(t *testing.T) {
+	value := os.Getenv("CI")
+	isCI, err := strconv.ParseBool(value)
+	if !isCI || err != nil {
+		t.Parallel()
 	}
 }


### PR DESCRIPTION
This PR adds initial support for running our CI suite on Github Actions. 

The motivations are
- Make tests run faster (currently down to ~20 minutes from 30+)
- Have a way to run CI against machine images configured with [cgroupsv2](https://github.com/hashicorp/nomad/issues/11289)
- Cleanup / modernize some of our testing infra
- Look like I did something for hackathon

Synopsis 
Packages are split up for testing more than in Circle (no more "other" default category). Logging is largely suppressed in favor of being able to view normal `go test` output. This makes individual test case results viewable in the browser. Many tests are now configured to _not_ run in Parallel if `CI` is set - instead we make the tradeoff of no longer suppressing `GOMAXPROCS` to `1`. Since the workers are so small (2C), the net performance is about the same, but now those tests are not stepping on each other. 

The key changes 
- add `.github/workflows/ci.yaml` for running unit tests on push/pull_request
- `gotestsum` is dropped in favor of plain `go test`
- `-v` is now always set when running tests
- `VERBOSE` enablement is removed from GNUMakefile
- `testutil.Parallel` is used to *not* run tests in parallel if `CI` is set
- `GOMAXPROCS` is *not* set to `1`
- Chunks of `require := require.New` shadowing removed
- Logging from `TestServer`, `TestClient`, and `TestAgent` now default to `WARN`
- vault/consul are installed using a [fork](https://github.com/shoenig/hc-install/commit/4bf4cf66ecdf5b152393dab12848bc8e79029ae8) of `hc-install`
  - HC's does not implement [cmd](https://github.com/hashicorp/hc-install/blob/main/cmd/hc-install/main.go)
- `NOMAD_SLOW_TEST` is respected only if the value is true-like

Test failures
The remaining failures (exec, docker, cgutil) are all related to cgroupsv2. I'd like to get this merged despite the failures so I have something to CI against while finishing up the cpuset changes. There are also still occasional flakes but not often. 

This is **not**
- a replacement for CircleCI (yet) - Circle remains the source of truth for PRs
- ui tests (only Go tests for now)

Future work
- An additional `check-missing` that scans the packages covered by `ci.yaml` and compares that with the actual list of source packages in the nomad repo, and fails the build if a package is not covered by CI.
- UI tests
- ent packages