### PR TITLE
docs: add namespace param to job parse API

### DIFF
--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -209,8 +209,13 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+  enabled, this value must match a namespace that the token is allowed to
+  access. This is specified as a query string parameter.
+
 - `JobHCL` `(string: <required>)` - Specifies the HCL definition of the job
   encoded in a JSON string.
+
 - `Canonicalize` `(bool: false)` - Flag to enable setting any unset fields to
   their default values.
 


### PR DESCRIPTION
https://github.com/hashicorp/nomad/issues/12038 added ACL requirements to the job parse endpoint to prevent potential abuse via malformed jobs.

Since job ACLs are attached to namespaces, and the token is checked before the job data is parsed to avoid abuse, the request must contain a `namespace` query param that the token is allowed to access.