### PR TITLE
scheduler: fix unused dstate variable

### DIFF
--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -466,7 +466,7 @@ func (a *allocReconciler) computeGroup(groupName string, all allocSet) bool {
 	a.createDeployment(tg.Name, tg.Update, existingDeployment, dstate, all, destructive)
 
 	deploymentComplete := a.isDeploymentComplete(groupName, destructive, inplace,
-		migrate, rescheduleNow, dstate, place, rescheduleLater, requiresCanaries)
+		migrate, rescheduleNow, place, rescheduleLater, requiresCanaries)
 
 	return deploymentComplete
 }
@@ -833,7 +833,7 @@ func (a *allocReconciler) createDeployment(groupName string, strategy *structs.U
 }
 
 func (a *allocReconciler) isDeploymentComplete(groupName string, destructive, inplace, migrate, rescheduleNow allocSet,
-	dstate *structs.DeploymentState, place []allocPlaceResult, rescheduleLater []*delayedRescheduleInfo, requiresCanaries bool) bool {
+	place []allocPlaceResult, rescheduleLater []*delayedRescheduleInfo, requiresCanaries bool) bool {
 
 	complete := len(destructive)+len(inplace)+len(place)+len(migrate)+len(rescheduleNow)+len(rescheduleLater) == 0 &&
 		!requiresCanaries
@@ -844,6 +844,7 @@ func (a *allocReconciler) isDeploymentComplete(groupName string, destructive, in
 
 	// Final check to see if the deployment is complete is to ensure everything is healthy
 	var ok bool
+	var dstate *structs.DeploymentState
 	if dstate, ok = a.deployment.TaskGroups[groupName]; ok {
 		if dstate.HealthyAllocs < helper.IntMax(dstate.DesiredTotal, dstate.DesiredCanaries) || // Make sure we have enough healthy allocs
 			(dstate.DesiredCanaries > 0 && !dstate.Promoted) { // Make sure we are promoted if we have canaries


### PR DESCRIPTION
`isDeploymentComplete()` takes a `*structs.DeploymentState` as one of its arguments, but then does nothing with it before clobbering it with `a.deployment.TaskGroups[groupName]`.

This fixes the function signature to no longer use the un-needed variable.