### PR TITLE
Add description for allocs stopped due to reconnect

### DIFF
--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -25,6 +25,10 @@ const (
 	// allocNotNeeded is the status used when a job no longer requires an allocation
 	allocNotNeeded = "alloc not needed due to job update"
 
+	// allocReconnected is the status to use when a replacement allocation is stopped
+	// because a disconnected node reconnects.
+	allocReconnected = "alloc not needed due to disconnected client reconnect"
+
 	// allocMigrating is the status used when we must migrate an allocation
 	allocMigrating = "alloc is being migrated"
 

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -1053,15 +1053,18 @@ func (a *allocReconciler) computeStopByReconnecting(untainted, reconnecting, sto
 				continue
 			}
 
+			statusDescription := allocNotNeeded
 			if untaintedMaxScoreMeta.NormScore > reconnectingMaxScoreMeta.NormScore {
 				stopAlloc = reconnectingAlloc
 				deleteSet = reconnecting
+			} else {
+				statusDescription = allocReconnected
 			}
 
 			stop[stopAlloc.ID] = stopAlloc
 			a.result.stop = append(a.result.stop, allocStopResult{
 				alloc:             stopAlloc,
-				statusDescription: allocNotNeeded,
+				statusDescription: statusDescription,
 			})
 			delete(deleteSet, stopAlloc.ID)
 


### PR DESCRIPTION
When assessing the event stream for disconnected client events, I found that allocations that are stopped due to a reconnect had a description indicating the alloc was stopped because the jobspec had changed, which is inaccurate.  This PR adds a description so that the stop reason is accurate when an allocation is stopped due to a reconnect event.