### PR TITLE
client: add service registration wrapper to handle providers.

### DIFF
--- a/client/serviceregistration/wrapper/wrapper.go
+++ b/client/serviceregistration/wrapper/wrapper.go
@@ -1,0 +1,131 @@
+package wrapper
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/serviceregistration"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// HandlerWrapper is used to wrap service registration implementations of the
+// Handler interface. We do not use a map or similar to store the handlers, so
+// we can avoid having to use a lock. This may need to be updated if we ever
+// support additional registration providers.
+type HandlerWrapper struct {
+	log hclog.Logger
+
+	// consulServiceProvider is the handler for services where Consul is the
+	// provider. This provider is always created and available.
+	consulServiceProvider serviceregistration.Handler
+
+	// nomadServiceProvider is the handler for services where Nomad is the
+	// provider.
+	nomadServiceProvider serviceregistration.Handler
+}
+
+// NewHandlerWrapper configures and returns a HandlerWrapper for use within
+// client hooks that need to interact with service and check registrations. It
+// mimics the serviceregistration.Handler interface, but returns the
+// implementation to allow future flexibility and is initially only intended
+// for use with the alloc and task runner service hooks.
+func NewHandlerWrapper(
+	log hclog.Logger, consulProvider, nomadProvider serviceregistration.Handler) *HandlerWrapper {
+	return &HandlerWrapper{
+		log:                   log,
+		nomadServiceProvider:  nomadProvider,
+		consulServiceProvider: consulProvider,
+	}
+}
+
+// RegisterWorkload wraps the serviceregistration.Handler RegisterWorkload
+// function. It determines which backend provider to call and passes the
+// workload unless the provider is unknown, in which case an error will be
+// returned.
+func (h *HandlerWrapper) RegisterWorkload(workload *serviceregistration.WorkloadServices) error {
+
+	// Don't rely on callers to check there are no services to register.
+	if len(workload.Services) == 0 {
+		return nil
+	}
+
+	provider := workload.RegistrationProvider()
+
+	switch provider {
+	case structs.ServiceProviderNomad:
+		return h.nomadServiceProvider.RegisterWorkload(workload)
+	case structs.ServiceProviderConsul:
+		return h.consulServiceProvider.RegisterWorkload(workload)
+	default:
+		return fmt.Errorf("unknown service registration provider: %q", provider)
+	}
+}
+
+// RemoveWorkload wraps the serviceregistration.Handler RemoveWorkload
+// function. It determines which backend provider to call and passes the
+// workload unless the provider is unknown.
+func (h *HandlerWrapper) RemoveWorkload(services *serviceregistration.WorkloadServices) {
+
+	// Don't rely on callers to check there are no services to remove.
+	if len(services.Services) == 0 {
+		return
+	}
+
+	provider := services.RegistrationProvider()
+
+	// Call the correct provider. In the case it is not supported, we can't do
+	// much apart from log, although we should never reach this point because
+	// of job validation.
+	switch provider {
+	case structs.ServiceProviderNomad:
+		h.nomadServiceProvider.RemoveWorkload(services)
+	case structs.ServiceProviderConsul:
+		h.consulServiceProvider.RemoveWorkload(services)
+	default:
+		h.log.Error("unknown service registration provider", "provider", provider)
+	}
+}
+
+// UpdateWorkload identifies which provider to call for the new and old
+// workloads provided. In the event both use the same provider, the
+// UpdateWorkload function will be called, otherwise the register and remove
+// functions will be called.
+func (h *HandlerWrapper) UpdateWorkload(old, new *serviceregistration.WorkloadServices) error {
+
+	// Hot path to exit if there is nothing to do.
+	if len(old.Services) == 0 && len(new.Services) == 0 {
+		return nil
+	}
+
+	newProvider := new.RegistrationProvider()
+	oldProvider := old.RegistrationProvider()
+
+	// If the new and old services use the same provider, call the
+	// UpdateWorkload and leave it at that.
+	if newProvider == oldProvider {
+		switch newProvider {
+		case structs.ServiceProviderNomad:
+			return h.nomadServiceProvider.UpdateWorkload(old, new)
+		case structs.ServiceProviderConsul:
+			return h.consulServiceProvider.UpdateWorkload(old, new)
+		default:
+			return fmt.Errorf("unknown service registration provider for update: %q", newProvider)
+		}
+	}
+
+	// If we have new services, call the relevant provider. Registering can
+	// return an error. Do this before RemoveWorkload, so we can halt the
+	// process if needed, otherwise we may leave the task/group
+	// registration-less.
+	if len(new.Services) > 0 {
+		if err := h.RegisterWorkload(new); err != nil {
+			return err
+		}
+	}
+
+	if len(old.Services) > 0 {
+		h.RemoveWorkload(old)
+	}
+
+	return nil
+}

--- a/client/serviceregistration/wrapper/wrapper_test.go
+++ b/client/serviceregistration/wrapper/wrapper_test.go
@@ -1,0 +1,384 @@
+package wrapper
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/serviceregistration"
+	regMock "github.com/hashicorp/nomad/client/serviceregistration/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_NewHandlerWrapper(t *testing.T) {
+	log := hclog.NewNullLogger()
+	mockProvider := regMock.NewServiceRegistrationHandler(log)
+	wrapper := NewHandlerWrapper(log, mockProvider, mockProvider)
+	require.NotNil(t, wrapper)
+	require.NotNil(t, wrapper.log)
+	require.NotNil(t, wrapper.nomadServiceProvider)
+	require.NotNil(t, wrapper.consulServiceProvider)
+}
+
+func TestHandlerWrapper_RegisterWorkload(t *testing.T) {
+	testCases := []struct {
+		testFn func(t *testing.T)
+		name   string
+	}{
+		{
+			testFn: func(t *testing.T) {
+
+				// Generate the test wrapper and provider mocks.
+				wrapper, consul, nomad := setupTestWrapper()
+
+				// Call the function with no services and check that nothing is
+				// registered.
+				require.NoError(t, wrapper.RegisterWorkload(&serviceregistration.WorkloadServices{}))
+				require.Len(t, consul.GetOps(), 0)
+				require.Len(t, nomad.GetOps(), 0)
+			},
+			name: "zero services",
+		},
+		{
+			testFn: func(t *testing.T) {
+
+				// Generate the test wrapper and provider mocks.
+				wrapper, consul, nomad := setupTestWrapper()
+
+				// Generate a minimal workload with an unknown provider.
+				workload := serviceregistration.WorkloadServices{
+					Services: []*structs.Service{
+						{
+							Provider: "istio",
+						},
+					},
+				}
+
+				// Call register and ensure an error is returned along with
+				// nothing registered in the providers.
+				err := wrapper.RegisterWorkload(&workload)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "unknown service registration provider: \"istio\"")
+				require.Len(t, consul.GetOps(), 0)
+				require.Len(t, nomad.GetOps(), 0)
+
+			},
+			name: "unknown provider",
+		},
+		{
+			testFn: func(t *testing.T) {
+
+				// Generate the test wrapper and provider mocks.
+				wrapper, consul, nomad := setupTestWrapper()
+
+				// Generate a minimal workload with the nomad provider.
+				workload := serviceregistration.WorkloadServices{
+					Services: []*structs.Service{
+						{
+							Provider: structs.ServiceProviderNomad,
+						},
+					},
+				}
+
+				// Call register and ensure no error is returned along with the
+				// correct operations.
+				require.NoError(t, wrapper.RegisterWorkload(&workload))
+				require.Len(t, consul.GetOps(), 0)
+				require.Len(t, nomad.GetOps(), 1)
+
+			},
+			name: "nomad provider",
+		},
+		{
+			testFn: func(t *testing.T) {
+
+				// Generate the test wrapper and provider mocks.
+				wrapper, consul, nomad := setupTestWrapper()
+
+				// Generate a minimal workload with the consul provider.
+				workload := serviceregistration.WorkloadServices{
+					Services: []*structs.Service{
+						{
+							Provider: structs.ServiceProviderConsul,
+						},
+					},
+				}
+
+				// Call register and ensure no error is returned along with the
+				// correct operations.
+				require.NoError(t, wrapper.RegisterWorkload(&workload))
+				require.Len(t, consul.GetOps(), 1)
+				require.Len(t, nomad.GetOps(), 0)
+			},
+			name: "consul provider",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.testFn(t)
+		})
+	}
+}
+
+func TestHandlerWrapper_RemoveWorkload(t *testing.T) {
+	testCases := []struct {
+		testFn func(t *testing.T)
+		name   string
+	}{
+		{
+			testFn: func(t *testing.T) {
+				// Generate the test wrapper and provider mocks.
+				wrapper, consul, nomad := setupTestWrapper()
+
+				// Call the function with no services and check that nothing is
+				// registered.
+				wrapper.RemoveWorkload(&serviceregistration.WorkloadServices{})
+				require.Len(t, consul.GetOps(), 0)
+				require.Len(t, nomad.GetOps(), 0)
+			},
+			name: "zero services",
+		},
+		{
+			testFn: func(t *testing.T) {
+
+				// Generate the test wrapper and provider mocks.
+				wrapper, consul, nomad := setupTestWrapper()
+
+				// Generate a minimal workload with an unknown provider.
+				workload := serviceregistration.WorkloadServices{
+					Services: []*structs.Service{
+						{
+							Provider: "istio",
+						},
+					},
+				}
+
+				// Call remove and ensure nothing registered in the providers.
+				wrapper.RemoveWorkload(&workload)
+				require.Len(t, consul.GetOps(), 0)
+				require.Len(t, nomad.GetOps(), 0)
+			},
+			name: "unknown provider",
+		},
+		{
+			testFn: func(t *testing.T) {
+
+				// Generate the test wrapper and provider mocks.
+				wrapper, consul, nomad := setupTestWrapper()
+
+				// Generate a minimal workload with the consul provider.
+				workload := serviceregistration.WorkloadServices{
+					Services: []*structs.Service{
+						{
+							Provider: structs.ServiceProviderConsul,
+						},
+					},
+				}
+
+				// Call remove and ensure the correct backend includes
+				// operations.
+				wrapper.RemoveWorkload(&workload)
+				require.Len(t, consul.GetOps(), 1)
+				require.Len(t, nomad.GetOps(), 0)
+			},
+			name: "consul provider",
+		},
+		{
+			testFn: func(t *testing.T) {
+
+				// Generate the test wrapper and provider mocks.
+				wrapper, consul, nomad := setupTestWrapper()
+
+				// Generate a minimal workload with the nomad provider.
+				workload := serviceregistration.WorkloadServices{
+					Services: []*structs.Service{
+						{
+							Provider: structs.ServiceProviderNomad,
+						},
+					},
+				}
+
+				// Call remove and ensure the correct backend includes
+				// operations.
+				wrapper.RemoveWorkload(&workload)
+				require.Len(t, consul.GetOps(), 0)
+				require.Len(t, nomad.GetOps(), 1)
+			},
+			name: "nomad provider",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.testFn(t)
+		})
+	}
+}
+
+func TestHandlerWrapper_UpdateWorkload(t *testing.T) {
+	testCases := []struct {
+		testFn func(t *testing.T)
+		name   string
+	}{
+		{
+			testFn: func(t *testing.T) {
+
+				// Generate the test wrapper and provider mocks.
+				wrapper, consul, nomad := setupTestWrapper()
+
+				// Call the function with no services and check that nothing is
+				// registered in either mock backend.
+				err := wrapper.UpdateWorkload(&serviceregistration.WorkloadServices{},
+					&serviceregistration.WorkloadServices{})
+				require.NoError(t, err)
+				require.Len(t, consul.GetOps(), 0)
+				require.Len(t, nomad.GetOps(), 0)
+
+			},
+			name: "zero new or old",
+		},
+		{
+			testFn: func(t *testing.T) {
+
+				// Generate the test wrapper and provider mocks.
+				wrapper, consul, nomad := setupTestWrapper()
+
+				// Create a single workload that we can use twice, using the
+				// consul provider.
+				workload := serviceregistration.WorkloadServices{
+					Services: []*structs.Service{
+						{
+							Provider: structs.ServiceProviderConsul,
+						},
+					},
+				}
+
+				// Call the function and ensure the consul backend has the
+				// expected operations.
+				require.NoError(t, wrapper.UpdateWorkload(&workload, &workload))
+				require.Len(t, nomad.GetOps(), 0)
+
+				consulOps := consul.GetOps()
+				require.Len(t, consulOps, 1)
+				require.Equal(t, "update", consulOps[0].Op)
+			},
+			name: "consul new and old",
+		},
+		{
+			testFn: func(t *testing.T) {
+
+				// Generate the test wrapper and provider mocks.
+				wrapper, consul, nomad := setupTestWrapper()
+
+				// Create a single workload that we can use twice, using the
+				// nomad provider.
+				workload := serviceregistration.WorkloadServices{
+					Services: []*structs.Service{
+						{
+							Provider: structs.ServiceProviderNomad,
+						},
+					},
+				}
+
+				// Call the function and ensure the nomad backend has the
+				// expected operations.
+				require.NoError(t, wrapper.UpdateWorkload(&workload, &workload))
+				require.Len(t, consul.GetOps(), 0)
+
+				nomadOps := nomad.GetOps()
+				require.Len(t, nomadOps, 1)
+				require.Equal(t, "update", nomadOps[0].Op)
+			},
+			name: "nomad new and old",
+		},
+		{
+			testFn: func(t *testing.T) {
+
+				// Generate the test wrapper and provider mocks.
+				wrapper, consul, nomad := setupTestWrapper()
+
+				// Create each workload.
+				newWorkload := serviceregistration.WorkloadServices{
+					Services: []*structs.Service{
+						{
+							Provider: structs.ServiceProviderNomad,
+						},
+					},
+				}
+
+				oldWorkload := serviceregistration.WorkloadServices{
+					Services: []*structs.Service{
+						{
+							Provider: structs.ServiceProviderConsul,
+						},
+					},
+				}
+
+				// Call the function and ensure the backends have the expected
+				// operations.
+				require.NoError(t, wrapper.UpdateWorkload(&oldWorkload, &newWorkload))
+
+				nomadOps := nomad.GetOps()
+				require.Len(t, nomadOps, 1)
+				require.Equal(t, "add", nomadOps[0].Op)
+
+				consulOps := consul.GetOps()
+				require.Len(t, consulOps, 1)
+				require.Equal(t, "remove", consulOps[0].Op)
+			},
+			name: "nomad new and consul old",
+		},
+		{
+			testFn: func(t *testing.T) {
+
+				// Generate the test wrapper and provider mocks.
+				wrapper, consul, nomad := setupTestWrapper()
+
+				// Create each workload.
+				newWorkload := serviceregistration.WorkloadServices{
+					Services: []*structs.Service{
+						{
+							Provider: structs.ServiceProviderConsul,
+						},
+					},
+				}
+
+				oldWorkload := serviceregistration.WorkloadServices{
+					Services: []*structs.Service{
+						{
+							Provider: structs.ServiceProviderNomad,
+						},
+					},
+				}
+
+				// Call the function and ensure the backends have the expected
+				// operations.
+				require.NoError(t, wrapper.UpdateWorkload(&oldWorkload, &newWorkload))
+
+				nomadOps := nomad.GetOps()
+				require.Len(t, nomadOps, 1)
+				require.Equal(t, "remove", nomadOps[0].Op)
+
+				consulOps := consul.GetOps()
+				require.Len(t, consulOps, 1)
+				require.Equal(t, "add", consulOps[0].Op)
+			},
+			name: "consul new and nomad old",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.testFn(t)
+		})
+	}
+}
+
+func setupTestWrapper() (*HandlerWrapper, *regMock.ServiceRegistrationHandler, *regMock.ServiceRegistrationHandler) {
+	log := hclog.NewNullLogger()
+	consulMock := regMock.NewServiceRegistrationHandler(log)
+	nomadMock := regMock.NewServiceRegistrationHandler(log)
+	wrapper := NewHandlerWrapper(log, consulMock, nomadMock)
+	return wrapper, consulMock, nomadMock
+}


### PR DESCRIPTION
The service registration wrapper handles sending requests to
backend providers without the caller needing to know this
information. This will be used within the task and alloc runner
service hooks when performing service registration activities.

related https://github.com/hashicorp/team-nomad/issues/266