### PR TITLE
fix alloc list test

### DIFF
--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -126,6 +126,10 @@ func TestAllocEndpoint_List_PaginationFiltering(t *testing.T) {
 
 	state := s1.fsm.State()
 
+	require.NoError(t, state.UpsertNamespaces(1099, []*structs.Namespace{
+		{Name: "non-default"},
+	}))
+
 	var allocs []*structs.Allocation
 	for i, m := range mocks {
 		allocsInTx := []*structs.Allocation{}
@@ -145,10 +149,6 @@ func TestAllocEndpoint_List_PaginationFiltering(t *testing.T) {
 		index := 1000 + uint64(i)
 		require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, index, allocsInTx))
 	}
-
-	require.NoError(t, state.UpsertNamespaces(1099, []*structs.Namespace{
-		{Name: "non-default"},
-	}))
 
 	aclToken := mock.CreatePolicyAndToken(t,
 		state, 1100, "test-valid-read",


### PR DESCRIPTION
The alloc list test with pagination was creating allocs before the
target namespace existed. This works in OSS but fails in ENT because
quotas are checked before the alloc can be created, so the namespace
must exist beforehand.

Test before and after the fix:

```console
$ go test -tags ent,consulent -run TestAllocEndpoint_List_PaginationFiltering ./nomad

[INFO] freeport: detected ephemeral port range of [49152, 65535]
--- FAIL: TestAllocEndpoint_List_PaginationFiltering (0.35s)
    alloc_endpoint_test.go:146:
                Error Trace:    alloc_endpoint_test.go:146
                Error:          Received unexpected error:
                                updating quota usage failed: allocation "aaaaaa33-3350-4b4b-d185-0e1992ed43e9" is in non-existent namespace "non-default"
                Test:           TestAllocEndpoint_List_PaginationFiltering
FAIL
FAIL    github.com/hashicorp/nomad/nomad        1.415s
FAIL
```

```console
$ go test -tags ent,consulent -run TestAllocEndpoint_List_PaginationFiltering ./nomad

ok      github.com/hashicorp/nomad/nomad        1.937s
```