### PR TITLE
api: add related evals to eval details 

### DIFF
--- a/.changelog/12305.txt
+++ b/.changelog/12305.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Add `related` query parameter to the Evaluation details endpoint
+```

--- a/api/evaluations.go
+++ b/api/evaluations.go
@@ -71,6 +71,7 @@ type Evaluation struct {
 	NextEval             string
 	PreviousEval         string
 	BlockedEval          string
+	RelatedEvals         []*EvaluationStub
 	FailedTGAllocs       map[string]*AllocationMetric
 	ClassEligibility     map[string]bool
 	EscapedComputedClass bool
@@ -82,6 +83,29 @@ type Evaluation struct {
 	ModifyIndex          uint64
 	CreateTime           int64
 	ModifyTime           int64
+}
+
+// EvaluationStub is used to serialize parts of an evaluation returned in the
+// RelatedEvals field of an Evaluation.
+type EvaluationStub struct {
+	ID                string
+	Priority          int
+	Type              string
+	TriggeredBy       string
+	Namespace         string
+	JobID             string
+	NodeID            string
+	DeploymentID      string
+	Status            string
+	StatusDescription string
+	WaitUntil         time.Time
+	NextEval          string
+	PreviousEval      string
+	BlockedEval       string
+	CreateIndex       uint64
+	ModifyIndex       uint64
+	CreateTime        int64
+	ModifyTime        int64
 }
 
 // EvalIndexSort is a wrapper to sort evaluations by CreateIndex.

--- a/api/evaluations_test.go
+++ b/api/evaluations_test.go
@@ -126,6 +126,25 @@ func TestEvaluations_Info(t *testing.T) {
 	// Check that we got the right result
 	require.NotNil(t, result)
 	require.Equal(t, resp.EvalID, result.ID)
+
+	// Register the job again to get a related eval
+	resp, wm, err = jobs.Register(job, nil)
+	evals, _, err := e.List(nil)
+	require.NoError(t, err)
+
+	// Find an eval that should have related evals
+	for _, eval := range evals {
+		if eval.NextEval != "" || eval.PreviousEval != "" || eval.BlockedEval != "" {
+			result, qm, err := e.Info(eval.ID, &QueryOptions{
+				Params: map[string]string{
+					"related": "true",
+				},
+			})
+			require.NoError(t, err)
+			assertQueryMeta(t, qm)
+			require.NotNil(t, result.RelatedEvals)
+		}
+	}
 }
 
 func TestEvaluations_Allocations(t *testing.T) {

--- a/command/agent/eval_endpoint.go
+++ b/command/agent/eval_endpoint.go
@@ -80,6 +80,9 @@ func (s *HTTPServer) evalQuery(resp http.ResponseWriter, req *http.Request, eval
 		return nil, nil
 	}
 
+	query := req.URL.Query()
+	args.IncludeRelated = query.Get("related") == "true"
+
 	var out structs.SingleEvalResponse
 	if err := s.agent.RPC("Eval.GetEval", &args, &out); err != nil {
 		return nil, err

--- a/command/agent/eval_endpoint_test.go
+++ b/command/agent/eval_endpoint_test.go
@@ -200,3 +200,44 @@ func TestHTTP_EvalQuery(t *testing.T) {
 		}
 	})
 }
+
+func TestHTTP_EvalQueryWithRelated(t *testing.T) {
+	t.Parallel()
+	httpTest(t, nil, func(s *TestAgent) {
+		// Directly manipulate the state
+		state := s.Agent.server.State()
+		eval1 := mock.Eval()
+		eval2 := mock.Eval()
+
+		// Link related evals
+		eval1.NextEval = eval2.ID
+		eval2.PreviousEval = eval1.ID
+
+		err := state.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1, eval2})
+		require.NoError(t, err)
+
+		// Make the HTTP request
+		req, err := http.NewRequest("GET", fmt.Sprintf("/v1/evaluation/%s?related=true", eval1.ID), nil)
+		require.NoError(t, err)
+		respW := httptest.NewRecorder()
+
+		// Make the request
+		obj, err := s.Server.EvalSpecificRequest(respW, req)
+		require.NoError(t, err)
+
+		// Check for the index
+		require.NotEmpty(t, respW.Result().Header.Get("X-Nomad-Index"))
+		require.NotEmpty(t, respW.Result().Header.Get("X-Nomad-KnownLeader"))
+		require.NotEmpty(t, respW.Result().Header.Get("X-Nomad-LastContact"))
+
+		// Check the eval
+		e := obj.(*structs.Evaluation)
+		require.Equal(t, eval1.ID, e.ID)
+
+		// Check for the related evals
+		expected := []*structs.EvaluationStub{
+			eval2.Stub(),
+		}
+		require.Equal(t, expected, e.RelatedEvals)
+	})
+}

--- a/website/content/api-docs/evaluations.mdx
+++ b/website/content/api-docs/evaluations.mdx
@@ -129,41 +129,78 @@ The table below shows this endpoint's support for
   must be the full UUID, not the short 8-character one. This is specified as
   part of the path.
 
+- `related` `(bool: false)` - Specifies if related evaluations should be
+  returned. Related evaluations are the ones that can be reached by following
+  the trail of IDs for `NextEval`, `PreviousEval`, and `BlockedEval`. This is
+  specified as a query parameter.
+
 ### Sample Request
 
 ```shell-session
 $ curl \
-    https://localhost:4646/v1/evaluation/5456bd7a-9fc0-c0dd-6131-cbee77f57577
+    https://localhost:4646/v1/evaluation/2deb5f06-a100-f01a-3316-5e501a4965e7?related=true
 ```
 
 ### Sample Response
 
 ```json
 {
-  "ID": "5456bd7a-9fc0-c0dd-6131-cbee77f57577",
-  "Priority": 50,
-  "Type": "service",
-  "TriggeredBy": "job-register",
-  "JobID": "example",
-  "JobModifyIndex": 52,
-  "NodeID": "",
-  "NodeModifyIndex": 0,
-  "Status": "complete",
-  "StatusDescription": "",
-  "Wait": 0,
-  "NextEval": "",
-  "PreviousEval": "",
-  "BlockedEval": "",
-  "FailedTGAllocs": null,
-  "ClassEligibility": null,
-  "EscapedComputedClass": false,
-  "AnnotatePlan": false,
-  "SnapshotIndex": 53,
-  "QueuedAllocations": {
-    "cache": 0
+  "CreateIndex": 28,
+  "CreateTime": 1647394818583344000,
+  "FailedTGAllocs": {
+    "cache": {
+      "AllocationTime": 4111,
+      "ClassExhausted": null,
+      "ClassFiltered": null,
+      "CoalescedFailures": 0,
+      "ConstraintFiltered": null,
+      "DimensionExhausted": null,
+      "NodesAvailable": {
+        "dc1": 0
+      },
+      "NodesEvaluated": 0,
+      "NodesExhausted": 0,
+      "NodesFiltered": 0,
+      "QuotaExhausted": null,
+      "ResourcesExhausted": null,
+      "ScoreMetaData": null,
+      "Scores": null
+    }
   },
-  "CreateIndex": 53,
-  "ModifyIndex": 55
+  "ID": "2deb5f06-a100-f01a-3316-5e501a4965e7",
+  "JobID": "example",
+  "ModifyIndex": 28,
+  "ModifyTime": 1647394818583344000,
+  "Namespace": "default",
+  "PreviousEval": "0f98f7ea-59ae-4d90-d9bd-b8ce80b9e100",
+  "Priority": 50,
+  "RelatedEvals": [
+    {
+      "BlockedEval": "2deb5f06-a100-f01a-3316-5e501a4965e7",
+      "CreateIndex": 27,
+      "CreateTime": 1647394818582736000,
+      "DeploymentID": "79ae0a49-acf6-0fcf-183f-8646f3167b88",
+      "ID": "0f98f7ea-59ae-4d90-d9bd-b8ce80b9e100",
+      "JobID": "example",
+      "ModifyIndex": 30,
+      "ModifyTime": 1647394818583565000,
+      "Namespace": "default",
+      "NextEval": "",
+      "NodeID": "",
+      "PreviousEval": "",
+      "Priority": 50,
+      "Status": "complete",
+      "StatusDescription": "",
+      "TriggeredBy": "node-drain",
+      "Type": "service",
+      "WaitUntil": null
+    }
+  ],
+  "SnapshotIndex": 27,
+  "Status": "blocked",
+  "StatusDescription": "created to place remaining allocations",
+  "TriggeredBy": "queued-allocs",
+  "Type": "service"
 }
 ```
 


### PR DESCRIPTION
The `related` query param is used to indicate that the request should
return a list of related (next, previous, and blocked) evaluations.

Closes #11858