### PR TITLE
ci: more parallel removal 

### DIFF
--- a/.semgrep/go_tests.yml
+++ b/.semgrep/go_tests.yml
@@ -128,6 +128,5 @@ rules:
     severity: "WARNING"
     fix: "ci.Parallel(t)"
     paths:
-      exclude: ["*"]
       include:
         - "*_test.go"

--- a/.semgrep/go_tests.yml
+++ b/.semgrep/go_tests.yml
@@ -119,3 +119,15 @@ rules:
       exclude: ["*"]
       include:
         - "*_test.go"
+  - id: "tests-no-parallel"
+    patterns:
+      - pattern: "t.Parallel()"
+    message: "Use ci.Parallel(t) instead of t.Parallel()"
+    languages:
+      - "go"
+    severity: "WARNING"
+    fix: "ci.Parallel(t)"
+    paths:
+      exclude: ["*"]
+      include:
+        - "*_test.go"

--- a/api/acl_test.go
+++ b/api/acl_test.go
@@ -3,11 +3,12 @@ package api
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestACLPolicies_ListUpsert(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s, _ := makeACLClient(t, nil, nil)
 	defer s.Stop()
 	ap := c.ACLPolicies()
@@ -49,7 +50,7 @@ func TestACLPolicies_ListUpsert(t *testing.T) {
 }
 
 func TestACLPolicies_Delete(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s, _ := makeACLClient(t, nil, nil)
 	defer s.Stop()
 	ap := c.ACLPolicies()
@@ -84,7 +85,7 @@ func TestACLPolicies_Delete(t *testing.T) {
 }
 
 func TestACLPolicies_Info(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s, _ := makeACLClient(t, nil, nil)
 	defer s.Stop()
 	ap := c.ACLPolicies()
@@ -110,7 +111,7 @@ func TestACLPolicies_Info(t *testing.T) {
 }
 
 func TestACLTokens_List(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s, _ := makeACLClient(t, nil, nil)
 	defer s.Stop()
 	at := c.ACLTokens()
@@ -129,7 +130,7 @@ func TestACLTokens_List(t *testing.T) {
 }
 
 func TestACLTokens_CreateUpdate(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s, _ := makeACLClient(t, nil, nil)
 	defer s.Stop()
 	at := c.ACLTokens()
@@ -158,7 +159,7 @@ func TestACLTokens_CreateUpdate(t *testing.T) {
 }
 
 func TestACLTokens_Info(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s, _ := makeACLClient(t, nil, nil)
 	defer s.Stop()
 	at := c.ACLTokens()
@@ -183,7 +184,7 @@ func TestACLTokens_Info(t *testing.T) {
 }
 
 func TestACLTokens_Self(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s, _ := makeACLClient(t, nil, nil)
 	defer s.Stop()
 	at := c.ACLTokens()
@@ -213,7 +214,7 @@ func TestACLTokens_Self(t *testing.T) {
 }
 
 func TestACLTokens_Delete(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s, _ := makeACLClient(t, nil, nil)
 	defer s.Stop()
 	at := c.ACLTokens()
@@ -237,7 +238,7 @@ func TestACLTokens_Delete(t *testing.T) {
 }
 
 func TestACL_OneTimeToken(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s, _ := makeACLClient(t, nil, nil)
 	defer s.Stop()
 	at := c.ACLTokens()

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -9,15 +9,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kr/pretty"
-	"github.com/stretchr/testify/require"
-
 	"github.com/hashicorp/nomad/api/internal/testutil"
+	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAgent_Self(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 
@@ -42,7 +41,7 @@ func TestAgent_Self(t *testing.T) {
 }
 
 func TestAgent_NodeName(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	a := c.Agent()
@@ -58,7 +57,7 @@ func TestAgent_NodeName(t *testing.T) {
 }
 
 func TestAgent_Datacenter(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	a := c.Agent()
@@ -74,7 +73,7 @@ func TestAgent_Datacenter(t *testing.T) {
 }
 
 func TestAgent_Join(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c1, s1 := makeClient(t, nil, nil)
 	defer s1.Stop()
 	a1 := c1.Agent()
@@ -104,7 +103,7 @@ func TestAgent_Join(t *testing.T) {
 }
 
 func TestAgent_Members(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	a := c.Agent()
@@ -125,7 +124,7 @@ func TestAgent_Members(t *testing.T) {
 }
 
 func TestAgent_ForceLeave(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	a := c.Agent()
@@ -143,7 +142,7 @@ func (a *AgentMember) String() string {
 }
 
 func TestAgents_Sort(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	var sortTests = []struct {
 		in  []*AgentMember
 		out []*AgentMember
@@ -254,7 +253,7 @@ func TestAgents_Sort(t *testing.T) {
 }
 
 func TestAgent_Health(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	assert := assert.New(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -269,7 +268,7 @@ func TestAgent_Health(t *testing.T) {
 // passing in a log level and node ie, which tests monitor
 // functionality for a specific client node
 func TestAgent_MonitorWithNode(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	rpcPort := 0
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		rpcPort = c.Ports.RPC
@@ -339,7 +338,7 @@ OUTER:
 // passing in only a log level, which tests the servers
 // monitor functionality
 func TestAgent_Monitor(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 
@@ -379,7 +378,7 @@ OUTER:
 }
 
 func TestAgentCPUProfile(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, s, token := makeACLClient(t, nil, nil)
 	defer s.Stop()
@@ -415,7 +414,7 @@ func TestAgentCPUProfile(t *testing.T) {
 }
 
 func TestAgentTrace(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, s, token := makeACLClient(t, nil, nil)
 	defer s.Stop()
@@ -432,7 +431,7 @@ func TestAgentTrace(t *testing.T) {
 }
 
 func TestAgentProfile(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, s, token := makeACLClient(t, nil, nil)
 	defer s.Stop()
@@ -459,7 +458,7 @@ func TestAgentProfile(t *testing.T) {
 }
 
 func TestAgent_SchedulerWorkerConfig(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -475,7 +474,7 @@ func TestAgent_SchedulerWorkerConfig(t *testing.T) {
 }
 
 func TestAgent_SchedulerWorkerConfig_BadRequest(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -491,7 +490,7 @@ func TestAgent_SchedulerWorkerConfig_BadRequest(t *testing.T) {
 }
 
 func TestAgent_SchedulerWorkersInfo(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	a := c.Agent()

--- a/api/allocations_test.go
+++ b/api/allocations_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAllocations_List(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.DevMode = true
 	})
@@ -58,7 +58,7 @@ func TestAllocations_List(t *testing.T) {
 }
 
 func TestAllocations_PrefixList(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	a := c.Allocations()
@@ -106,7 +106,7 @@ func TestAllocations_PrefixList(t *testing.T) {
 }
 
 func TestAllocations_List_Resources(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.DevMode = true
 	})
@@ -137,7 +137,7 @@ func TestAllocations_List_Resources(t *testing.T) {
 }
 
 func TestAllocations_CreateIndexSort(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	allocs := []*AllocationListStub{
 		{CreateIndex: 2},
 		{CreateIndex: 1},
@@ -156,7 +156,7 @@ func TestAllocations_CreateIndexSort(t *testing.T) {
 }
 
 func TestAllocations_RescheduleInfo(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	// Create a job, task group and alloc
 	job := &Job{
 		Name:      stringToPtr("foo"),
@@ -317,7 +317,7 @@ func TestAllocations_ExecErrors(t *testing.T) {
 }
 
 func TestAllocation_ServerTerminalStatus(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	testCases := []struct {
 		inputAllocation *Allocation
@@ -349,7 +349,7 @@ func TestAllocation_ServerTerminalStatus(t *testing.T) {
 }
 
 func TestAllocation_ClientTerminalStatus(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	testCases := []struct {
 		inputAllocation *Allocation
@@ -391,7 +391,7 @@ func TestAllocation_ClientTerminalStatus(t *testing.T) {
 }
 
 func TestAllocations_ShouldMigrate(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require.True(t, DesiredTransition{Migrate: boolToPtr(true)}.ShouldMigrate())
 	require.False(t, DesiredTransition{}.ShouldMigrate())
 	require.False(t, DesiredTransition{Migrate: boolToPtr(false)}.ShouldMigrate())

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -16,10 +16,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/hashicorp/nomad/api/internal/testutil"
 )
 
 type configCallback func(c *Config)
@@ -71,7 +70,7 @@ func makeClient(t *testing.T, cb1 configCallback,
 }
 
 func TestRequestTime(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(100 * time.Millisecond)
 		d, err := json.Marshal(struct{ Done bool }{true})
@@ -119,7 +118,7 @@ func TestRequestTime(t *testing.T) {
 }
 
 func TestDefaultConfig_env(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	url := "http://1.2.3.4:5678"
 	auth := []string{"nomaduser", "12345"}
 	region := "test"
@@ -169,7 +168,7 @@ func TestDefaultConfig_env(t *testing.T) {
 }
 
 func TestSetQueryOptions(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 
@@ -203,7 +202,7 @@ func TestSetQueryOptions(t *testing.T) {
 }
 
 func TestQueryOptionsContext(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -227,7 +226,7 @@ func TestQueryOptionsContext(t *testing.T) {
 func TestWriteOptionsContext(t *testing.T) {
 	// No blocking query to test a real cancel of a pending request so
 	// just test that if we pass a pre-canceled context, writes fail quickly
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, err := NewClient(DefaultConfig())
 	if err != nil {
@@ -250,7 +249,7 @@ func TestWriteOptionsContext(t *testing.T) {
 }
 
 func TestSetWriteOptions(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 
@@ -278,7 +277,7 @@ func TestSetWriteOptions(t *testing.T) {
 }
 
 func TestRequestToHTTP(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 
@@ -306,7 +305,7 @@ func TestRequestToHTTP(t *testing.T) {
 }
 
 func TestParseQueryMeta(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	resp := &http.Response{
 		Header: make(map[string][]string),
 	}
@@ -331,7 +330,7 @@ func TestParseQueryMeta(t *testing.T) {
 }
 
 func TestParseWriteMeta(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	resp := &http.Response{
 		Header: make(map[string][]string),
 	}
@@ -348,7 +347,7 @@ func TestParseWriteMeta(t *testing.T) {
 }
 
 func TestClientHeader(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, func(c *Config) {
 		c.Headers = http.Header{
 			"Hello": []string{"World"},
@@ -364,7 +363,7 @@ func TestClientHeader(t *testing.T) {
 }
 
 func TestQueryString(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 

--- a/api/compose_test.go
+++ b/api/compose_test.go
@@ -3,10 +3,12 @@ package api
 import (
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/nomad/api/internal/testutil"
 )
 
 func TestCompose(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	// Compose a task
 	task := NewTask("task1", "exec").
 		SetConfig("foo", "bar").

--- a/api/constraint_test.go
+++ b/api/constraint_test.go
@@ -3,10 +3,12 @@ package api
 import (
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/nomad/api/internal/testutil"
 )
 
 func TestCompose_Constraints(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c := NewConstraint("kernel.name", "=", "darwin")
 	expect := &Constraint{
 		LTarget: "kernel.name",

--- a/api/consul_test.go
+++ b/api/consul_test.go
@@ -3,10 +3,12 @@ package api
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConsul_Canonicalize(t *testing.T) {
+	testutil.Parallel(t)
 	t.Run("missing ns", func(t *testing.T) {
 		c := new(Consul)
 		c.Canonicalize()
@@ -21,6 +23,7 @@ func TestConsul_Canonicalize(t *testing.T) {
 }
 
 func TestConsul_Copy(t *testing.T) {
+	testutil.Parallel(t)
 	t.Run("complete", func(t *testing.T) {
 		result := (&Consul{
 			Namespace: "foo",
@@ -32,6 +35,7 @@ func TestConsul_Copy(t *testing.T) {
 }
 
 func TestConsul_MergeNamespace(t *testing.T) {
+	testutil.Parallel(t)
 	t.Run("already set", func(t *testing.T) {
 		a := &Consul{Namespace: "foo"}
 		ns := stringToPtr("bar")

--- a/api/csi_test.go
+++ b/api/csi_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,7 +13,7 @@ import (
 // 1. Expose the test server RPC server and force a Node.Update to fingerprint a plugin
 // 2. Build and deploy a dummy CSI plugin via a job, and have it really fingerprint
 func TestCSIVolumes_CRUD(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s, root := makeACLClient(t, nil, nil)
 	defer s.Stop()
 	v := c.CSIVolumes()

--- a/api/evaluations_test.go
+++ b/api/evaluations_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEvaluations_List(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	e := c.Evaluations()
@@ -73,7 +73,7 @@ func TestEvaluations_List(t *testing.T) {
 }
 
 func TestEvaluations_PrefixList(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	e := c.Evaluations()
@@ -102,7 +102,7 @@ func TestEvaluations_PrefixList(t *testing.T) {
 }
 
 func TestEvaluations_Info(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	e := c.Evaluations()
@@ -129,7 +129,7 @@ func TestEvaluations_Info(t *testing.T) {
 }
 
 func TestEvaluations_Allocations(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	e := c.Evaluations()
@@ -142,7 +142,7 @@ func TestEvaluations_Allocations(t *testing.T) {
 }
 
 func TestEvaluations_Sort(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	evals := []*Evaluation{
 		{CreateIndex: 2},
 		{CreateIndex: 1},

--- a/api/event_stream_test.go
+++ b/api/event_stream_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestEvent_Stream(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -50,7 +50,7 @@ func TestEvent_Stream(t *testing.T) {
 }
 
 func TestEvent_Stream_Err_InvalidQueryParam(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -79,7 +79,7 @@ func TestEvent_Stream_Err_InvalidQueryParam(t *testing.T) {
 }
 
 func TestEvent_Stream_CloseCtx(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -116,7 +116,7 @@ func TestEvent_Stream_CloseCtx(t *testing.T) {
 }
 
 func TestEventStream_PayloadValue(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.DevMode = true
@@ -175,7 +175,7 @@ func TestEventStream_PayloadValue(t *testing.T) {
 }
 
 func TestEventStream_PayloadValueHelpers(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	testCases := []struct {
 		desc     string

--- a/api/fs_test.go
+++ b/api/fs_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestFS_Logs(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 	rpcPort := 0
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
@@ -160,7 +160,7 @@ func TestFS_Logs(t *testing.T) {
 }
 
 func TestFS_FrameReader(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	// Create a channel of the frames and a cancel channel
 	framesCh := make(chan *StreamFrame, 3)
 	errCh := make(chan error)
@@ -230,7 +230,7 @@ func TestFS_FrameReader(t *testing.T) {
 }
 
 func TestFS_FrameReader_Unblock(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	// Create a channel of the frames and a cancel channel
 	framesCh := make(chan *StreamFrame, 3)
 	errCh := make(chan error)
@@ -268,7 +268,7 @@ func TestFS_FrameReader_Unblock(t *testing.T) {
 }
 
 func TestFS_FrameReader_Error(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	// Create a channel of the frames and a cancel channel
 	framesCh := make(chan *StreamFrame, 3)
 	errCh := make(chan error, 1)

--- a/api/internal/testutil/slow.go
+++ b/api/internal/testutil/slow.go
@@ -2,14 +2,29 @@ package testutil
 
 import (
 	"os"
-
-	testing "github.com/mitchellh/go-testing-interface"
+	"strconv"
+	"testing"
 )
 
-// SkipSlow skips a slow test unless the NOMAD_SLOW_TEST environment variable
-// is set.
-func SkipSlow(t testing.T) {
-	if os.Getenv("NOMAD_SLOW_TEST") == "" {
-		t.Skip("Skipping slow test. Set NOMAD_SLOW_TEST=1 to run.")
+// Copy of ci/slow.go for API.
+
+// SkipSlow skips a slow test unless NOMAD_SLOW_TEST is set to a true value.
+func SkipSlow(t *testing.T, reason string) {
+	value := os.Getenv("NOMAD_SLOW_TEST")
+	run, err := strconv.ParseBool(value)
+	if !run || err != nil {
+		t.Skipf("Skipping slow test: %s", reason)
+	}
+}
+
+// Parallel runs t in parallel, unless CI is set to a true value.
+//
+// In CI (CircleCI / GitHub Actions) we get better performance by running tests
+// in serial while not restricting GOMAXPROCS.
+func Parallel(t *testing.T) {
+	value := os.Getenv("CI")
+	isCI, err := strconv.ParseBool(value)
+	if !isCI || err != nil {
+		t.Parallel()
 	}
 }

--- a/api/ioutil_test.go
+++ b/api/ioutil_test.go
@@ -13,10 +13,12 @@ import (
 	"testing"
 	"testing/iotest"
 
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestChecksumValidatingReader(t *testing.T) {
+	testutil.Parallel(t)
 	data := make([]byte, 4096)
 	_, err := rand.Read(data)
 	require.NoError(t, err)
@@ -66,7 +68,7 @@ func TestChecksumValidatingReader(t *testing.T) {
 }
 
 func TestChecksumValidatingReader_PropagatesError(t *testing.T) {
-
+	testutil.Parallel(t)
 	pr, pw := io.Pipe()
 	defer pr.Close()
 	defer pw.Close()

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestJobs_Register(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 
 	c, s := makeClient(t, nil, nil)
@@ -45,7 +45,7 @@ func TestJobs_Register(t *testing.T) {
 }
 
 func TestJobs_Register_PreserveCounts(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 
 	c, s := makeClient(t, nil, nil)
@@ -117,7 +117,7 @@ func TestJobs_Register_PreserveCounts(t *testing.T) {
 }
 
 func TestJobs_Register_NoPreserveCounts(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 
 	c, s := makeClient(t, nil, nil)
@@ -188,7 +188,7 @@ func TestJobs_Register_NoPreserveCounts(t *testing.T) {
 }
 
 func TestJobs_Register_EvalPriority(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	requireAssert := require.New(t)
 
 	c, s := makeClient(t, nil, nil)
@@ -215,7 +215,7 @@ func TestJobs_Register_EvalPriority(t *testing.T) {
 }
 
 func TestJobs_Register_NoEvalPriority(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	requireAssert := require.New(t)
 
 	c, s := makeClient(t, nil, nil)
@@ -242,7 +242,7 @@ func TestJobs_Register_NoEvalPriority(t *testing.T) {
 }
 
 func TestJobs_Validate(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	jobs := c.Jobs()
@@ -270,7 +270,7 @@ func TestJobs_Validate(t *testing.T) {
 }
 
 func TestJobs_Canonicalize(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	testCases := []struct {
 		name     string
 		expected *Job
@@ -1282,7 +1282,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 }
 
 func TestJobs_EnforceRegister(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -1328,7 +1328,7 @@ func TestJobs_EnforceRegister(t *testing.T) {
 }
 
 func TestJobs_Revert(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	jobs := c.Jobs()
@@ -1378,7 +1378,7 @@ func TestJobs_Revert(t *testing.T) {
 }
 
 func TestJobs_Info(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	jobs := c.Jobs()
@@ -1414,7 +1414,7 @@ func TestJobs_Info(t *testing.T) {
 }
 
 func TestJobs_ScaleInvalidAction(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 
 	c, s := makeClient(t, nil, nil)
@@ -1454,7 +1454,7 @@ func TestJobs_ScaleInvalidAction(t *testing.T) {
 }
 
 func TestJobs_Versions(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	jobs := c.Jobs()
@@ -1487,7 +1487,7 @@ func TestJobs_Versions(t *testing.T) {
 }
 
 func TestJobs_PrefixList(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	jobs := c.Jobs()
@@ -1523,7 +1523,7 @@ func TestJobs_PrefixList(t *testing.T) {
 }
 
 func TestJobs_List(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	jobs := c.Jobs()
@@ -1559,7 +1559,7 @@ func TestJobs_List(t *testing.T) {
 }
 
 func TestJobs_Allocations(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	jobs := c.Jobs()
@@ -1581,7 +1581,7 @@ func TestJobs_Allocations(t *testing.T) {
 }
 
 func TestJobs_Evaluations(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	jobs := c.Jobs()
@@ -1623,7 +1623,7 @@ func TestJobs_Evaluations(t *testing.T) {
 }
 
 func TestJobs_Deregister(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	jobs := c.Jobs()
@@ -1683,7 +1683,7 @@ func TestJobs_Deregister(t *testing.T) {
 }
 
 func TestJobs_Deregister_EvalPriority(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	requireAssert := require.New(t)
 
 	c, s := makeClient(t, nil, nil)
@@ -1714,7 +1714,7 @@ func TestJobs_Deregister_EvalPriority(t *testing.T) {
 }
 
 func TestJobs_Deregister_NoEvalPriority(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	requireAssert := require.New(t)
 
 	c, s := makeClient(t, nil, nil)
@@ -1745,7 +1745,7 @@ func TestJobs_Deregister_NoEvalPriority(t *testing.T) {
 }
 
 func TestJobs_ForceEvaluate(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	jobs := c.Jobs()
@@ -1785,7 +1785,7 @@ func TestJobs_ForceEvaluate(t *testing.T) {
 }
 
 func TestJobs_PeriodicForce(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	jobs := c.Jobs()
@@ -1838,7 +1838,7 @@ func TestJobs_PeriodicForce(t *testing.T) {
 }
 
 func TestJobs_Plan(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	jobs := c.Jobs()
@@ -1910,7 +1910,7 @@ func TestJobs_Plan(t *testing.T) {
 }
 
 func TestJobs_JobSummary(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	jobs := c.Jobs()
@@ -1948,7 +1948,7 @@ func TestJobs_JobSummary(t *testing.T) {
 }
 
 func TestJobs_NewBatchJob(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	job := NewBatchJob("job1", "myjob", "global", 5)
 	expect := &Job{
 		Region:   stringToPtr("global"),
@@ -1963,7 +1963,7 @@ func TestJobs_NewBatchJob(t *testing.T) {
 }
 
 func TestJobs_NewServiceJob(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	job := NewServiceJob("job1", "myjob", "global", 5)
 	expect := &Job{
 		Region:   stringToPtr("global"),
@@ -1978,7 +1978,7 @@ func TestJobs_NewServiceJob(t *testing.T) {
 }
 
 func TestJobs_NewSystemJob(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	job := NewSystemJob("job1", "myjob", "global", 5)
 	expect := &Job{
 		Region:   stringToPtr("global"),
@@ -1993,7 +1993,7 @@ func TestJobs_NewSystemJob(t *testing.T) {
 }
 
 func TestJobs_SetMeta(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	job := &Job{Meta: nil}
 
 	// Initializes a nil map
@@ -2016,7 +2016,7 @@ func TestJobs_SetMeta(t *testing.T) {
 }
 
 func TestJobs_Constrain(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	job := &Job{Constraints: nil}
 
 	// Create and add a constraint
@@ -2050,7 +2050,7 @@ func TestJobs_Constrain(t *testing.T) {
 }
 
 func TestJobs_AddAffinity(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	job := &Job{Affinities: nil}
 
 	// Create and add an affinity
@@ -2086,7 +2086,7 @@ func TestJobs_AddAffinity(t *testing.T) {
 }
 
 func TestJobs_Sort(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	jobs := []*JobListStub{
 		{ID: "job2"},
 		{ID: "job0"},
@@ -2105,7 +2105,7 @@ func TestJobs_Sort(t *testing.T) {
 }
 
 func TestJobs_AddSpread(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	job := &Job{Spreads: nil}
 
 	// Create and add a Spread
@@ -2157,7 +2157,7 @@ func TestJobs_AddSpread(t *testing.T) {
 
 // TestJobs_ScaleAction tests the scale target for task group count
 func TestJobs_ScaleAction(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 
 	c, s := makeClient(t, nil, nil)
@@ -2218,7 +2218,7 @@ func TestJobs_ScaleAction(t *testing.T) {
 }
 
 func TestJobs_ScaleAction_Error(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 
 	c, s := makeClient(t, nil, nil)
@@ -2270,7 +2270,7 @@ func TestJobs_ScaleAction_Error(t *testing.T) {
 }
 
 func TestJobs_ScaleAction_Noop(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 
 	c, s := makeClient(t, nil, nil)
@@ -2323,7 +2323,7 @@ func TestJobs_ScaleAction_Noop(t *testing.T) {
 
 // TestJobs_ScaleStatus tests the /scale status endpoint for task group count
 func TestJobs_ScaleStatus(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	require := require.New(t)
 

--- a/api/namespace_test.go
+++ b/api/namespace_test.go
@@ -3,11 +3,12 @@ package api
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNamespaces_Register(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	assert := assert.New(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -29,7 +30,7 @@ func TestNamespaces_Register(t *testing.T) {
 }
 
 func TestNamespaces_Register_Invalid(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	assert := assert.New(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -43,7 +44,7 @@ func TestNamespaces_Register_Invalid(t *testing.T) {
 }
 
 func TestNamespace_Info(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	assert := assert.New(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -69,7 +70,7 @@ func TestNamespace_Info(t *testing.T) {
 }
 
 func TestNamespaces_Delete(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	assert := assert.New(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -103,7 +104,7 @@ func TestNamespaces_Delete(t *testing.T) {
 }
 
 func TestNamespaces_List(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	assert := assert.New(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()

--- a/api/nodes_test.go
+++ b/api/nodes_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNodes_List(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.DevMode = true
 	})
@@ -43,7 +43,7 @@ func TestNodes_List(t *testing.T) {
 }
 
 func TestNodes_PrefixList(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.DevMode = true
 	})
@@ -86,7 +86,7 @@ func TestNodes_PrefixList(t *testing.T) {
 // TestNodes_List_Resources asserts that ?resources=true includes allocated and
 // reserved resources in the response.
 func TestNodes_List_Resources(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.DevMode = true
 	})
@@ -123,7 +123,7 @@ func TestNodes_List_Resources(t *testing.T) {
 }
 
 func TestNodes_Info(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	startTime := time.Now().Unix()
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.DevMode = true
@@ -182,7 +182,7 @@ func TestNodes_Info(t *testing.T) {
 }
 
 func TestNodes_NoSecretID(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.DevMode = true
 	})
@@ -216,7 +216,7 @@ func TestNodes_NoSecretID(t *testing.T) {
 }
 
 func TestNodes_ToggleDrain(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.DevMode = true
@@ -319,7 +319,7 @@ func TestNodes_ToggleDrain(t *testing.T) {
 }
 
 func TestNodes_ToggleEligibility(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.DevMode = true
 	})
@@ -388,7 +388,7 @@ func TestNodes_ToggleEligibility(t *testing.T) {
 }
 
 func TestNodes_Allocations(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	nodes := c.Nodes()
@@ -407,7 +407,7 @@ func TestNodes_Allocations(t *testing.T) {
 }
 
 func TestNodes_ForceEvaluate(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.DevMode = true
 	})
@@ -446,7 +446,7 @@ func TestNodes_ForceEvaluate(t *testing.T) {
 }
 
 func TestNodes_Sort(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	nodes := []*NodeListStub{
 		{CreateIndex: 2},
 		{CreateIndex: 1},
@@ -466,7 +466,7 @@ func TestNodes_Sort(t *testing.T) {
 
 // Unittest monitorDrainMultiplex when an error occurs
 func TestNodes_MonitorDrain_Multiplex_Bad(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 
 	ctx := context.Background()
@@ -518,7 +518,7 @@ func TestNodes_MonitorDrain_Multiplex_Bad(t *testing.T) {
 
 // Unittest monitorDrainMultiplex when drain finishes
 func TestNodes_MonitorDrain_Multiplex_Good(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 
 	ctx := context.Background()
@@ -583,7 +583,7 @@ func TestNodes_MonitorDrain_Multiplex_Good(t *testing.T) {
 }
 
 func TestNodes_DrainStrategy_Equal(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 
 	// nil
@@ -620,7 +620,7 @@ func TestNodes_DrainStrategy_Equal(t *testing.T) {
 }
 
 func TestNodes_Purge(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.DevMode = true
@@ -661,7 +661,7 @@ func TestNodes_Purge(t *testing.T) {
 }
 
 func TestNodeStatValueFormatting(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	cases := []struct {
 		expected string

--- a/api/operator_ent_test.go
+++ b/api/operator_ent_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestOperator_LicenseGet(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s, _ := makeACLClient(t, nil, nil)
 	defer s.Stop()
 

--- a/api/operator_metrics_test.go
+++ b/api/operator_metrics_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestOperator_MetricsSummary(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 
@@ -31,7 +31,7 @@ func TestOperator_MetricsSummary(t *testing.T) {
 }
 
 func TestOperator_Metrics_Prometheus(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.Telemetry = &testutil.Telemetry{PrometheusMetrics: true}
 	})

--- a/api/operator_test.go
+++ b/api/operator_test.go
@@ -3,10 +3,12 @@ package api
 import (
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/nomad/api/internal/testutil"
 )
 
 func TestOperator_RaftGetConfiguration(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 
@@ -23,7 +25,7 @@ func TestOperator_RaftGetConfiguration(t *testing.T) {
 }
 
 func TestOperator_RaftRemovePeerByAddress(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 
@@ -38,7 +40,7 @@ func TestOperator_RaftRemovePeerByAddress(t *testing.T) {
 }
 
 func TestOperator_RaftRemovePeerByID(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 

--- a/api/quota_test.go
+++ b/api/quota_test.go
@@ -6,11 +6,12 @@ package api
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestQuotas_Register(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	assert := assert.New(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -31,7 +32,7 @@ func TestQuotas_Register(t *testing.T) {
 }
 
 func TestQuotas_Register_Invalid(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	assert := assert.New(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -45,7 +46,7 @@ func TestQuotas_Register_Invalid(t *testing.T) {
 }
 
 func TestQuotas_Info(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	assert := assert.New(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -71,7 +72,7 @@ func TestQuotas_Info(t *testing.T) {
 }
 
 func TestQuotas_Usage(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	assert := assert.New(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -97,7 +98,7 @@ func TestQuotas_Usage(t *testing.T) {
 }
 
 func TestQuotas_Delete(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	assert := assert.New(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -129,7 +130,7 @@ func TestQuotas_Delete(t *testing.T) {
 }
 
 func TestQuotas_List(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	assert := assert.New(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -169,7 +170,7 @@ func TestQuotas_List(t *testing.T) {
 }
 
 func TestQuotas_ListUsages(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	assert := assert.New(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()

--- a/api/regions_test.go
+++ b/api/regions_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRegionsList(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c1, s1 := makeClient(t, nil, func(c *testutil.TestServerConfig) {
 		c.Region = "regionA"
 	})

--- a/api/resources_test.go
+++ b/api/resources_test.go
@@ -4,10 +4,12 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/kr/pretty"
 )
 
 func TestResources_Canonicalize(t *testing.T) {
+	testutil.Parallel(t)
 	testCases := []struct {
 		name     string
 		input    *Resources

--- a/api/scaling_test.go
+++ b/api/scaling_test.go
@@ -3,11 +3,12 @@ package api
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestScalingPolicies_ListPolicies(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 
 	c, s := makeClient(t, nil, nil)
@@ -55,7 +56,7 @@ func TestScalingPolicies_ListPolicies(t *testing.T) {
 }
 
 func TestScalingPolicies_GetPolicy(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	require := require.New(t)
 
 	c, s := makeClient(t, nil, nil)

--- a/api/search_test.go
+++ b/api/search_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSearch_PrefixSearch(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -30,7 +31,7 @@ func TestSearch_PrefixSearch(t *testing.T) {
 }
 
 func TestSearch_FuzzySearch(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()

--- a/api/sentinel_test.go
+++ b/api/sentinel_test.go
@@ -6,11 +6,12 @@ package api
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSentinelPolicies_ListUpsert(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s, _ := makeACLClient(t, nil, nil)
 	defer s.Stop()
 	ap := c.SentinelPolicies()
@@ -51,7 +52,7 @@ func TestSentinelPolicies_ListUpsert(t *testing.T) {
 }
 
 func TestSentinelPolicies_Delete(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s, _ := makeACLClient(t, nil, nil)
 	defer s.Stop()
 	ap := c.SentinelPolicies()
@@ -85,7 +86,7 @@ func TestSentinelPolicies_Delete(t *testing.T) {
 }
 
 func TestSentinelPolicies_Info(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s, _ := makeACLClient(t, nil, nil)
 	defer s.Stop()
 	ap := c.SentinelPolicies()

--- a/api/services_test.go
+++ b/api/services_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestService_Canonicalize(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	j := &Job{Name: stringToPtr("job")}
 	tg := &TaskGroup{Name: stringToPtr("group")}
@@ -24,7 +25,7 @@ func TestService_Canonicalize(t *testing.T) {
 }
 
 func TestServiceCheck_Canonicalize(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	j := &Job{Name: stringToPtr("job")}
 	tg := &TaskGroup{Name: stringToPtr("group")}
@@ -43,7 +44,7 @@ func TestServiceCheck_Canonicalize(t *testing.T) {
 }
 
 func TestService_Check_PassFail(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	job := &Job{Name: stringToPtr("job")}
 	tg := &TaskGroup{Name: stringToPtr("group")}
@@ -79,7 +80,7 @@ func TestService_Check_PassFail(t *testing.T) {
 // TestService_CheckRestart asserts Service.CheckRestart settings are properly
 // inherited by Checks.
 func TestService_CheckRestart(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	job := &Job{Name: stringToPtr("job")}
 	tg := &TaskGroup{Name: stringToPtr("group")}
@@ -127,7 +128,7 @@ func TestService_CheckRestart(t *testing.T) {
 }
 
 func TestService_Connect_Canonicalize(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil connect", func(t *testing.T) {
 		cc := (*ConsulConnect)(nil)
@@ -145,7 +146,7 @@ func TestService_Connect_Canonicalize(t *testing.T) {
 }
 
 func TestService_Connect_ConsulSidecarService_Canonicalize(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil sidecar_service", func(t *testing.T) {
 		css := (*ConsulSidecarService)(nil)
@@ -181,7 +182,7 @@ func TestService_Connect_ConsulSidecarService_Canonicalize(t *testing.T) {
 }
 
 func TestService_Connect_ConsulProxy_Canonicalize(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil proxy", func(t *testing.T) {
 		cp := (*ConsulProxy)(nil)
@@ -217,7 +218,7 @@ func TestService_Connect_ConsulProxy_Canonicalize(t *testing.T) {
 }
 
 func TestService_Connect_ConsulUpstream_Copy(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil upstream", func(t *testing.T) {
 		cu := (*ConsulUpstream)(nil)
@@ -239,7 +240,7 @@ func TestService_Connect_ConsulUpstream_Copy(t *testing.T) {
 }
 
 func TestService_Connect_ConsulUpstream_Canonicalize(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil upstream", func(t *testing.T) {
 		cu := (*ConsulUpstream)(nil)
@@ -267,7 +268,7 @@ func TestService_Connect_ConsulUpstream_Canonicalize(t *testing.T) {
 }
 
 func TestService_Connect_proxy_settings(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	job := &Job{Name: stringToPtr("job")}
 	tg := &TaskGroup{Name: stringToPtr("group")}
@@ -300,7 +301,7 @@ func TestService_Connect_proxy_settings(t *testing.T) {
 }
 
 func TestService_Tags(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	r := require.New(t)
 
 	// canonicalize does not modify eto or tags
@@ -320,7 +321,7 @@ func TestService_Tags(t *testing.T) {
 }
 
 func TestService_Connect_SidecarTask_Canonicalize(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil sidecar_task", func(t *testing.T) {
 		st := (*SidecarTask)(nil)
@@ -352,7 +353,7 @@ func TestService_Connect_SidecarTask_Canonicalize(t *testing.T) {
 }
 
 func TestService_ConsulGateway_Canonicalize(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
 		cg := (*ConsulGateway)(nil)
@@ -388,7 +389,7 @@ func TestService_ConsulGateway_Canonicalize(t *testing.T) {
 }
 
 func TestService_ConsulGateway_Copy(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
 		result := (*ConsulGateway)(nil).Copy()
@@ -439,7 +440,7 @@ func TestService_ConsulGateway_Copy(t *testing.T) {
 }
 
 func TestService_ConsulIngressConfigEntry_Canonicalize(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
 		c := (*ConsulIngressConfigEntry)(nil)
@@ -485,7 +486,7 @@ func TestService_ConsulIngressConfigEntry_Canonicalize(t *testing.T) {
 }
 
 func TestService_ConsulIngressConfigEntry_Copy(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
 		result := (*ConsulIngressConfigEntry)(nil).Copy()
@@ -516,7 +517,7 @@ func TestService_ConsulIngressConfigEntry_Copy(t *testing.T) {
 }
 
 func TestService_ConsulTerminatingConfigEntry_Canonicalize(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
 		c := (*ConsulTerminatingConfigEntry)(nil)
@@ -534,7 +535,7 @@ func TestService_ConsulTerminatingConfigEntry_Canonicalize(t *testing.T) {
 }
 
 func TestService_ConsulTerminatingConfigEntry_Copy(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
 		result := (*ConsulIngressConfigEntry)(nil).Copy()
@@ -560,7 +561,7 @@ func TestService_ConsulTerminatingConfigEntry_Copy(t *testing.T) {
 }
 
 func TestService_ConsulMeshConfigEntry_Canonicalize(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
 		ce := (*ConsulMeshConfigEntry)(nil)
@@ -576,7 +577,7 @@ func TestService_ConsulMeshConfigEntry_Canonicalize(t *testing.T) {
 }
 
 func TestService_ConsulMeshConfigEntry_Copy(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
 		ce := (*ConsulMeshConfigEntry)(nil)
@@ -592,7 +593,7 @@ func TestService_ConsulMeshConfigEntry_Copy(t *testing.T) {
 }
 
 func TestService_ConsulMeshGateway_Canonicalize(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
 		c := (*ConsulMeshGateway)(nil)
@@ -614,7 +615,7 @@ func TestService_ConsulMeshGateway_Canonicalize(t *testing.T) {
 }
 
 func TestService_ConsulMeshGateway_Copy(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
 		c := (*ConsulMeshGateway)(nil)

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"testing"
+
+	"github.com/hashicorp/nomad/api/internal/testutil"
 )
 
 func TestStatus_Leader(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	status := c.Status()

--- a/api/system_test.go
+++ b/api/system_test.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"testing"
+
+	"github.com/hashicorp/nomad/api/internal/testutil"
 )
 
 func TestSystem_GarbageCollect(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
 	e := c.System()

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTaskGroup_NewTaskGroup(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	grp := NewTaskGroup("grp1", 2)
 	expect := &TaskGroup{
 		Name:  stringToPtr("grp1"),
@@ -23,7 +24,7 @@ func TestTaskGroup_NewTaskGroup(t *testing.T) {
 }
 
 func TestTaskGroup_Constrain(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	grp := NewTaskGroup("grp1", 1)
 
 	// Add a constraint to the group
@@ -57,7 +58,7 @@ func TestTaskGroup_Constrain(t *testing.T) {
 }
 
 func TestTaskGroup_AddAffinity(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	grp := NewTaskGroup("grp1", 1)
 
 	// Add an affinity to the group
@@ -93,7 +94,7 @@ func TestTaskGroup_AddAffinity(t *testing.T) {
 }
 
 func TestTaskGroup_SetMeta(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	grp := NewTaskGroup("grp1", 1)
 
 	// Initializes an empty map
@@ -116,7 +117,7 @@ func TestTaskGroup_SetMeta(t *testing.T) {
 }
 
 func TestTaskGroup_AddSpread(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	grp := NewTaskGroup("grp1", 1)
 
 	// Create and add spread
@@ -167,7 +168,7 @@ func TestTaskGroup_AddSpread(t *testing.T) {
 }
 
 func TestTaskGroup_AddTask(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	grp := NewTaskGroup("grp1", 1)
 
 	// Add the task to the task group
@@ -199,7 +200,7 @@ func TestTaskGroup_AddTask(t *testing.T) {
 }
 
 func TestTask_NewTask(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	task := NewTask("task1", "exec")
 	expect := &Task{
 		Name:   "task1",
@@ -211,7 +212,7 @@ func TestTask_NewTask(t *testing.T) {
 }
 
 func TestTask_SetConfig(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	task := NewTask("task1", "exec")
 
 	// Initializes an empty map
@@ -234,7 +235,7 @@ func TestTask_SetConfig(t *testing.T) {
 }
 
 func TestTask_SetMeta(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	task := NewTask("task1", "exec")
 
 	// Initializes an empty map
@@ -257,7 +258,7 @@ func TestTask_SetMeta(t *testing.T) {
 }
 
 func TestTask_Require(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	task := NewTask("task1", "exec")
 
 	// Create some require resources
@@ -285,7 +286,7 @@ func TestTask_Require(t *testing.T) {
 }
 
 func TestTask_Constrain(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	task := NewTask("task1", "exec")
 
 	// Add a constraint to the task
@@ -319,7 +320,7 @@ func TestTask_Constrain(t *testing.T) {
 }
 
 func TestTask_AddAffinity(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	task := NewTask("task1", "exec")
 
 	// Add an affinity to the task
@@ -354,7 +355,7 @@ func TestTask_AddAffinity(t *testing.T) {
 }
 
 func TestTask_Artifact(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	a := TaskArtifact{
 		GetterSource:  stringToPtr("http://localhost/foo.txt"),
 		GetterMode:    stringToPtr("file"),
@@ -369,7 +370,7 @@ func TestTask_Artifact(t *testing.T) {
 }
 
 func TestTask_VolumeMount(t *testing.T) {
-	t.Parallel()
+	testutil.Parallel(t)
 	vm := &VolumeMount{}
 	vm.Canonicalize()
 	require.NotNil(t, vm.PropagationMode)
@@ -377,6 +378,7 @@ func TestTask_VolumeMount(t *testing.T) {
 }
 
 func TestTask_Canonicalize_TaskLifecycle(t *testing.T) {
+	testutil.Parallel(t)
 	testCases := []struct {
 		name     string
 		expected *TaskLifecycle
@@ -407,6 +409,7 @@ func TestTask_Canonicalize_TaskLifecycle(t *testing.T) {
 }
 
 func TestTask_Template_WaitConfig_Canonicalize_and_Copy(t *testing.T) {
+	testutil.Parallel(t)
 	taskWithWait := func(wc *WaitConfig) *Task {
 		return &Task{
 			Templates: []*Template{
@@ -493,6 +496,7 @@ func TestTask_Template_WaitConfig_Canonicalize_and_Copy(t *testing.T) {
 
 // Ensures no regression on https://github.com/hashicorp/nomad/issues/3132
 func TestTaskGroup_Canonicalize_Update(t *testing.T) {
+	testutil.Parallel(t)
 	// Job with an Empty() Update
 	job := &Job{
 		ID: stringToPtr("test"),
@@ -518,6 +522,7 @@ func TestTaskGroup_Canonicalize_Update(t *testing.T) {
 }
 
 func TestTaskGroup_Canonicalize_Scaling(t *testing.T) {
+	testutil.Parallel(t)
 	require := require.New(t)
 
 	job := &Job{
@@ -574,6 +579,7 @@ func TestTaskGroup_Canonicalize_Scaling(t *testing.T) {
 }
 
 func TestTaskGroup_Merge_Update(t *testing.T) {
+	testutil.Parallel(t)
 	job := &Job{
 		ID:     stringToPtr("test"),
 		Update: &UpdateStrategy{},
@@ -606,6 +612,7 @@ func TestTaskGroup_Merge_Update(t *testing.T) {
 
 // Verifies that migrate strategy is merged correctly
 func TestTaskGroup_Canonicalize_MigrateStrategy(t *testing.T) {
+	testutil.Parallel(t)
 	type testCase struct {
 		desc        string
 		jobType     string
@@ -758,6 +765,7 @@ func TestTaskGroup_Canonicalize_MigrateStrategy(t *testing.T) {
 
 // TestSpread_Canonicalize asserts that the spread stanza is canonicalized correctly
 func TestSpread_Canonicalize(t *testing.T) {
+	testutil.Parallel(t)
 	job := &Job{
 		ID:   stringToPtr("test"),
 		Type: stringToPtr("batch"),
@@ -810,6 +818,7 @@ func TestSpread_Canonicalize(t *testing.T) {
 }
 
 func Test_NewDefaultReschedulePolicy(t *testing.T) {
+	testutil.Parallel(t)
 	testCases := []struct {
 		desc         string
 		inputJobType string
@@ -874,6 +883,7 @@ func Test_NewDefaultReschedulePolicy(t *testing.T) {
 }
 
 func TestTaskGroup_Canonicalize_Consul(t *testing.T) {
+	testutil.Parallel(t)
 	t.Run("override job consul in group", func(t *testing.T) {
 		job := &Job{
 			ID:              stringToPtr("job"),

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -3,10 +3,12 @@ package api
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFormatRoundedFloat(t *testing.T) {
+	testutil.Parallel(t)
 	cases := []struct {
 		input    float64
 		expected string

--- a/e2e/clientstate/clientstate.go
+++ b/e2e/clientstate/clientstate.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/e2e/e2eutil"
 	"github.com/hashicorp/nomad/e2e/execagent"
@@ -82,7 +83,7 @@ func getPID(client *api.Client, alloc *api.Allocation, path string) (int, error)
 // loop to assert Nomad is crash safe.
 func (tc *ClientStateTC) TestClientState_Kill(f *framework.F) {
 	t := f.T()
-	t.Parallel()
+	ci.Parallel(t)
 
 	serverOut := testlog.NewPrefixWriter(t, "SERVER: ")
 	clientOut := testlog.NewPrefixWriter(t, "CLIENT: ")
@@ -223,7 +224,7 @@ func (tc *ClientStateTC) TestClientState_Kill(f *framework.F) {
 // in a tight loop to assert Nomad is crash safe while a task is restarting.
 func (tc *ClientStateTC) TestClientState_KillDuringRestart(f *framework.F) {
 	t := f.T()
-	t.Parallel()
+	ci.Parallel(t)
 
 	serverOut := testlog.NewPrefixWriter(t, "SERVER: ")
 	clientOut := testlog.NewPrefixWriter(t, "CLIENT: ")
@@ -345,7 +346,7 @@ func (tc *ClientStateTC) TestClientState_KillDuringRestart(f *framework.F) {
 // assert it recovers.
 func (tc *ClientStateTC) TestClientState_Corrupt(f *framework.F) {
 	t := f.T()
-	t.Parallel()
+	ci.Parallel(t)
 
 	serverOut := testlog.NewPrefixWriter(t, "SERVER: ")
 	clientOut := testlog.NewPrefixWriter(t, "CLIENT: ")

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/ci"
 	"github.com/stretchr/testify/require"
 )
 
@@ -212,7 +213,7 @@ func (f *Framework) runCase(t *testing.T, s *TestSuite, c TestCase) {
 	t.Run(c.Name(), func(t *testing.T) {
 		// If the TestSuite has Parallel set, all cases run in parallel
 		if s.Parallel {
-			t.Parallel()
+			ci.Parallel(t)
 		}
 
 		f := newF(t)

--- a/e2e/nomad09upgrade/upgrade.go
+++ b/e2e/nomad09upgrade/upgrade.go
@@ -119,7 +119,7 @@ func (tc *UpgradePathTC) TestRawExecTaskUpgrade(f *framework.F) {
 	for _, ver := range nomadVersions {
 		ver := ver
 		f.T().Run(ver, func(t *testing.T) {
-			t.Parallel()
+			ci.Parallel(t)
 			tc.testUpgradeForJob(t, ver, "nomad09upgrade/rawexec.nomad")
 		})
 	}
@@ -129,7 +129,7 @@ func (tc *UpgradePathTC) TestExecTaskUpgrade(f *framework.F) {
 	for _, ver := range nomadVersions {
 		ver := ver
 		f.T().Run(ver, func(t *testing.T) {
-			t.Parallel()
+			ci.Parallel(t)
 			tc.testUpgradeForJob(t, ver, "nomad09upgrade/exec.nomad")
 		})
 	}
@@ -139,7 +139,7 @@ func (tc *UpgradePathTC) TestDockerTaskUpgrade(f *framework.F) {
 	for _, ver := range nomadVersions {
 		ver := ver
 		f.T().Run(ver, func(t *testing.T) {
-			t.Parallel()
+			ci.Parallel(t)
 			tc.testUpgradeForJob(t, ver, "nomad09upgrade/docker.nomad")
 		})
 	}

--- a/e2e/nomad09upgrade/upgrade.go
+++ b/e2e/nomad09upgrade/upgrade.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	getter "github.com/hashicorp/go-getter"
+	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/e2e/e2eutil"
 	"github.com/hashicorp/nomad/e2e/execagent"
 	"github.com/hashicorp/nomad/e2e/framework"


### PR DESCRIPTION
ae21af4f9 2022-03-17 | ci: semgrep rule for parallel tests (HEAD -> purge-parallel-2, origin/purge-parallel-2) [Seth Hoenig]

> Adds a Semgrep rule blocking direct use of `t.Parallel()`


7e6767ddf 2022-03-17 | e2e: have e2e use ci.Parallel [Seth Hoenig]

> Switches e2e/ to use helper method


369590144 2022-03-17 | ci: use serial testing for api in CI [Seth Hoenig]

> Copies `slow.go` into `api/internal/testutil` so we can get same functionality in `api/`


