### PR TITLE
cli: display Raft version in `server members`

### DIFF
--- a/.changelog/12317.txt
+++ b/.changelog/12317.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+cli: display the Raft version instead of the Serf protocol in the `nomad server members` command
+```
+
+```release-note:improvement
+cli: rename the `nomad server members` `-detailed` flag to `-verbose` so it matches other commands
+```

--- a/command/server_members.go
+++ b/command/server_members.go
@@ -32,10 +32,9 @@ General Options:
 
 Server Members Options:
 
-  -detailed
-    Show detailed information about each member. This dumps
-    a raw set of tags which shows more information than the
-    default output format.
+  -verbose
+    Show detailed information about each member. This dumps a raw set of tags
+    which shows more information than the default output format.
 `
 	return strings.TrimSpace(helpText)
 }
@@ -58,11 +57,12 @@ func (c *ServerMembersCommand) Synopsis() string {
 func (c *ServerMembersCommand) Name() string { return "server members" }
 
 func (c *ServerMembersCommand) Run(args []string) int {
-	var detailed bool
+	var detailed, verbose bool
 
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.BoolVar(&detailed, "detailed", false, "Show detailed output")
+	flags.BoolVar(&verbose, "verbose", false, "Show detailed output")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -74,6 +74,11 @@ func (c *ServerMembersCommand) Run(args []string) int {
 		c.Ui.Error("This command takes no arguments")
 		c.Ui.Error(commandErrorText(c))
 		return 1
+	}
+
+	// Keep support for previous flag name
+	if detailed {
+		verbose = true
 	}
 
 	// Get the HTTP client
@@ -103,8 +108,8 @@ func (c *ServerMembersCommand) Run(args []string) int {
 
 	// Format the list
 	var out []string
-	if detailed {
-		out = detailedOutput(srvMembers.Members)
+	if verbose {
+		out = verboseOutput(srvMembers.Members, leaders)
 	} else {
 		out = standardOutput(srvMembers.Members, leaders)
 	}
@@ -125,25 +130,15 @@ func (c *ServerMembersCommand) Run(args []string) int {
 func standardOutput(mem []*api.AgentMember, leaders map[string]string) []string {
 	// Format the members list
 	members := make([]string, len(mem)+1)
-	members[0] = "Name|Address|Port|Status|Leader|Protocol|Build|Datacenter|Region"
+	members[0] = "Name|Address|Port|Status|Leader|Raft Version|Build|Datacenter|Region"
 	for i, member := range mem {
-		reg := member.Tags["region"]
-		regLeader, ok := leaders[reg]
-		isLeader := false
-		if ok {
-			if regLeader == net.JoinHostPort(member.Addr, member.Tags["port"]) {
-
-				isLeader = true
-			}
-		}
-
-		members[i+1] = fmt.Sprintf("%s|%s|%d|%s|%t|%d|%s|%s|%s",
+		members[i+1] = fmt.Sprintf("%s|%s|%d|%s|%t|%s|%s|%s|%s",
 			member.Name,
 			member.Addr,
 			member.Port,
 			member.Status,
-			isLeader,
-			member.ProtocolCur,
+			isLeader(member, leaders),
+			member.Tags["raft_vsn"],
 			member.Tags["build"],
 			member.Tags["dc"],
 			member.Tags["region"])
@@ -151,10 +146,10 @@ func standardOutput(mem []*api.AgentMember, leaders map[string]string) []string 
 	return members
 }
 
-func detailedOutput(mem []*api.AgentMember) []string {
+func verboseOutput(mem []*api.AgentMember, leaders map[string]string) []string {
 	// Format the members list
 	members := make([]string, len(mem)+1)
-	members[0] = "Name|Address|Port|Tags"
+	members[0] = "Name|Address|Port|Status|Leader|Protocol|Raft Version|Build|Datacenter|Region|Tags"
 	for i, member := range mem {
 		// Format the tags
 		tagPairs := make([]string, 0, len(member.Tags))
@@ -163,11 +158,19 @@ func detailedOutput(mem []*api.AgentMember) []string {
 		}
 		tags := strings.Join(tagPairs, ",")
 
-		members[i+1] = fmt.Sprintf("%s|%s|%d|%s",
+		members[i+1] = fmt.Sprintf("%s|%s|%d|%s|%t|%d|%s|%s|%s|%s|%s",
 			member.Name,
 			member.Addr,
 			member.Port,
-			tags)
+			member.Status,
+			isLeader(member, leaders),
+			member.ProtocolCur,
+			member.Tags["raft_vsn"],
+			member.Tags["build"],
+			member.Tags["dc"],
+			member.Tags["region"],
+			tags,
+		)
 	}
 	return members
 }
@@ -205,4 +208,11 @@ func regionLeaders(client *api.Client, mem []*api.AgentMember) (map[string]strin
 	}
 
 	return leaders, mErr.ErrorOrNil()
+}
+
+func isLeader(member *api.AgentMember, leaders map[string]string) bool {
+	addr := net.JoinHostPort(member.Addr, member.Tags["port"])
+	reg := member.Tags["region"]
+	regLeader, ok := leaders[reg]
+	return ok && regLeader == addr
 }

--- a/command/server_members_test.go
+++ b/command/server_members_test.go
@@ -38,7 +38,11 @@ func TestServerMembersCommand_Run(t *testing.T) {
 	}
 	ui.OutputWriter.Reset()
 
-	// Query members with detailed output
+	// Query members with verbose output
+	if code := cmd.Run([]string{"-address=" + url, "-verbose"}); code != 0 {
+		t.Fatalf("expected exit 0, got: %d", code)
+	}
+	// Still support previous detailed flag
 	if code := cmd.Run([]string{"-address=" + url, "-detailed"}); code != 0 {
 		t.Fatalf("expected exit 0, got: %d", code)
 	}

--- a/website/content/docs/commands/server/members.mdx
+++ b/website/content/docs/commands/server/members.mdx
@@ -27,9 +27,14 @@ capability.
 
 ## Server Members Options
 
-- `-detailed`: Dump the basic member information as well as the raw set of tags
-  for each member. This mode reveals additional information not displayed in the
-  standard output format.
+- `-detailed` (<code>_deprecated_</code> use `-verbose` instead): Dump the
+  basic member information as well as the raw set of tags for each member. This
+  mode reveals additional information not displayed in the standard output
+  format.
+
+- `-verbose`: Dump the basic member information as well as the raw set of tags
+  for each member. This mode reveals additional information not displayed in
+  the standard output format.
 
 ## Examples
 
@@ -37,16 +42,18 @@ Default view:
 
 ```shell-session
 $ nomad server members
-Name          Addr      Port  Status  Proto  Build     DC   Region
-node1.global  10.0.0.8  4648  alive   2      0.1.0dev  dc1  global
-node2.global  10.0.0.9  4648  alive   2      0.1.0dev  dc1  global
+Name             Address    Port  Status  Leader  Raft Version  Build  Datacenter  Region
+server-1.global  10.0.0.8   4648  alive   true    3             1.3.0  dc1         global
+server-2.global  10.0.0.9   4648  alive   false   3             1.3.0  dc1         global
+server-3.global  10.0.0.10  4648  alive   false   3             1.3.0  dc1         global
 ```
 
-Detailed view:
+Verbose view:
 
 ```shell-session
-$ nomad server members -detailed
-Name   Addr      Port  Tags
-node1  10.0.0.8  4648  bootstrap=1,build=0.1.0dev,vsn=1,vsn_max=1,dc=dc1,port=4647,region=global,role=nomad,vsn_min=1
-node2  10.0.0.9  4648  bootstrap=0,build=0.1.0dev,vsn=1,vsn_max=1,dc=dc1,port=4647,region=global,role=nomad,vsn_min=1
+$ nomad server members -verbose
+Name             Address    Port  Status  Leader  Protocol  Raft Version  Build  Datacenter  Region  Tags
+server-1.global  10.0.0.8   4648  alive   true    2         3             1.3.0  dc1         global  id=46122039-7c4d-4647-673a-81786bce2c23,rpc_addr=10.0.0.8,role=nomad,region=global,raft_vsn=3,expect=3,dc=dc1,build=1.3.0,port=4647
+server-2.global  10.0.0.9   4648  alive   false   2         3             1.3.0  dc1         global  id=04594bee-fec9-4cec-f308-eebe82025ae7,dc=dc1,expect=3,rpc_addr=10.0.0.9,raft_vsn=3,port=4647,role=nomad,region=global,build=1.3.0
+server-3.global  10.0.0.10  4648  alive   false   2         3             1.3.0  dc1         global  region=global,dc=dc1,rpc_addr=10.0.0.10,raft_vsn=3,build=1.3.0,expect=3,id=59542f6c-fb0e-50f1-4c9f-98bb593e9fe8,role=nomad,port=4647
 ```

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -81,6 +81,19 @@ server {
 }
 ```
 
+#### Changes to the `nomad server members` command
+
+The standard output of the `nomad server members` command replaces the previous
+`Protocol` column that indicated the Serf protocol version with a new column
+named `Raft Version` which outputs the Raft protocol version defined in each
+server.
+
+The `-detailed` flag is now called `-verbose` and outputs the standard values
+in addition to extra information. The previous name is still supported but may
+be removed in future releases.
+
+The previous `Protocol` value can be viewed using the `-verbose` flag.
+
 ## Nomad 1.2.6, 1.1.12, and 1.0.18
 
 #### ACL requirement for the job parse endpoint


### PR DESCRIPTION
The previous output of the `nomad server members` command would output a
column named `Protocol` that displayed the Serf protocol being currently
used by servers.

This is not a configurable option, so it holds very little value to
operators. It is also easy to confuse it with the Raft Protocol version,
which is configurable and highly relevant to operators.

This commit replaces the previous `Protocol` column with the new `Raft
Version`. It also updates the `-detailed` flag to be called `-verbose`
so it matches other commands. The detailed output now also outputs the
same information as the standard output with the addition of the
previous `Protocol` column and `Tags`.