### PR TITLE
api: fix ENT-only test imports for moved testutil package

### DIFF
--- a/api/operator_ent_test.go
+++ b/api/operator_ent_test.go
@@ -6,6 +6,7 @@ package api
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
The `api/testutil` package was moved to `api/internal/testutil` but
this wasn't caught in the ENT tests because they're not run here in
the OSS repo.