### PR TITLE
ci: limit gotestsum to circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,7 +544,7 @@ executors:
       GOBIN: c:\gopath\bin
       GOTESTSUM_PATH: c:\tmp\test-reports
       GOLANG_VERSION: 1.17.5
-      GOTESTSUM_VERSION: 0.4.2
+      GOTESTSUM_VERSION: 1.7.0
       VAULT_VERSION: 1.4.1
 
 workflows:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -32,7 +32,11 @@ ifndef NOMAD_NO_UI
 GO_TAGS := ui $(GO_TAGS)
 endif
 
+ifeq ($(CIRCLECI),true)
 GO_TEST_CMD = $(if $(shell command -v gotestsum 2>/dev/null),gotestsum --,go test)
+else
+GO_TEST_CMD = go test
+endif
 
 ifeq ($(origin GOTEST_PKGS_EXCLUDE), undefined)
 GOTEST_PKGS ?= "./..."
@@ -48,12 +52,6 @@ PROTO_COMPARE_TAG ?= v1.0.3$(if $(findstring ent,$(GO_TAGS)),+ent,)
 LAST_RELEASE ?= v1.2.6
 
 default: help
-
-ifeq ($(CI),true)
-	$(info Running in a CI environment, verbose mode is disabled)
-else
-	VERBOSE="true"
-endif
 
 ifeq (Linux,$(THIS_OS))
 ALL_TARGETS = linux_386 \
@@ -131,7 +129,7 @@ deps:  ## Install build and development dependencies
 	go install github.com/hashicorp/go-bindata/go-bindata@bf7910af899725e4938903fb32048c7c0b15f12e
 	go install github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs@234c15e7648ff35458026de92b34c637bae5e6f7
 	go install github.com/a8m/tree/cmd/tree@fce18e2a750ea4e7f53ee706b1c3d9cbb22de79c
-	go install gotest.tools/gotestsum@v0.4.2
+	go install gotest.tools/gotestsum@v1.7.0
 	go install github.com/hashicorp/hcl/v2/cmd/hclfmt@v2.5.1
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.4
 	go install github.com/hashicorp/go-msgpack/codec/codecgen@v1.1.5

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -16,6 +16,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/api"
+	client "github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/fingerprint"
 	"github.com/hashicorp/nomad/helper/freeport"
 	"github.com/hashicorp/nomad/helper/testlog"
@@ -356,6 +357,14 @@ func (a *TestAgent) config() *Config {
 	// Customize the server configuration
 	config := nomad.DefaultConfig()
 	conf.NomadConfig = config
+
+	// Setup client config
+	conf.ClientConfig = client.DefaultConfig()
+
+	logger := testlog.HCLogger(a.T)
+	conf.LogLevel = testlog.HCLoggerTestLevel().String()
+	conf.NomadConfig.Logger = logger
+	conf.ClientConfig.Logger = logger
 
 	// Set the name
 	conf.NodeName = a.Name

--- a/helper/testlog/testlog.go
+++ b/helper/testlog/testlog.go
@@ -5,6 +5,7 @@ package testlog
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -39,25 +40,48 @@ func WithPrefix(t LogPrinter, prefix string) *log.Logger {
 	return New(t, prefix, log.Lmicroseconds)
 }
 
-// Logger returns a new test logger with the Lmicroseconds flag set and no
-// prefix.
+// Logger returns a new test logger with the Lmicroseconds flag set and no prefix.
+//
+// Note: only use this where HCLogger cannot be used (i.e. RPC yamux configuration).
 func Logger(t LogPrinter) *log.Logger {
 	return WithPrefix(t, "")
 }
 
-//HCLogger returns a new test hc-logger.
+// HCLogger returns a new test hc-logger.
+//
+// Default log level is TRACE. Set NOMAD_TEST_LOG_LEVEL for custom log level.
 func HCLogger(t LogPrinter) hclog.InterceptLogger {
+	logger, _ := HCLoggerNode(t, -1)
+	return logger
+}
+
+// HCLoggerTestLevel returns the level in which hc log should emit logs.
+//
+// Default log level is TRACE. Set NOMAD_TEST_LOG_LEVEL for custom log level.
+func HCLoggerTestLevel() hclog.Level {
 	level := hclog.Trace
 	envLogLevel := os.Getenv("NOMAD_TEST_LOG_LEVEL")
 	if envLogLevel != "" {
 		level = hclog.LevelFromString(envLogLevel)
 	}
+	return level
+}
+
+// HCLoggerNode returns a new hc-logger, but with a prefix indicating the node number
+// on each log line. Useful for TestServer in tests with more than one server.
+//
+// Default log level is TRACE. Set NOMAD_TEST_LOG_LEVEL for custom log level.
+func HCLoggerNode(t LogPrinter, node int32) (hclog.InterceptLogger, io.Writer) {
+	var output io.Writer = os.Stderr
+	if node > -1 {
+		output = NewPrefixWriter(t, fmt.Sprintf("node-%03d", node))
+	}
 	opts := &hclog.LoggerOptions{
-		Level:           level,
-		Output:          os.Stderr,
+		Level:           HCLoggerTestLevel(),
+		Output:          output,
 		IncludeLocation: true,
 	}
-	return hclog.NewInterceptLogger(opts)
+	return hclog.NewInterceptLogger(opts), output
 }
 
 type prefixStderr struct {


### PR DESCRIPTION
Part 2 of breaking up https://github.com/hashicorp/nomad/pull/12255

This PR makes it so `gotestsum` is invoked only in CircleCI. Also the
`HCLogger(t)` is plumbed more correctly in `TestServer` and `TestAgent` so
that they respect `NOMAD_TEST_LOG_LEVEL`.

The reason for these is we'll want to disable logging in GHA,
where spamming the disk with logs drags performance.

Also upgrade `gotestsum` while we're here. 