### PR TITLE
ci: turn on testing in github actions

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -1,20 +1,5 @@
 name: Core CI Tests
 on:
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - 'README.md'
-      - 'CHANGELOG.md'
-      - '.changelog/*'
-      - '.tours/*'
-      - 'contributing/*'
-      - 'demo/*'
-      - 'pkg/*'
-      - 'scripts/*'
-      - 'terraform/*'
-      - 'ui/*'
-      - 'website/*'
   push:
     branches-ignore:
       - main
@@ -26,6 +11,9 @@ on:
       - '.tours/*'
       - 'contributing/*'
       - 'demo/*'
+      - 'dev/*'
+      - 'e2e/terraform/*'
+      - 'integrations/*'
       - 'pkg/*'
       - 'scripts/*'
       - 'terraform/*'

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -1,0 +1,152 @@
+name: Core CI Tests
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.changelog/*'
+      - '.tours/*'
+      - 'contributing/*'
+      - 'demo/*'
+      - 'pkg/*'
+      - 'scripts/*'
+      - 'terraform/*'
+      - 'ui/*'
+      - 'website/*'
+  push:
+    branches-ignore:
+      - main
+      - release-**
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.changelog/*'
+      - '.tours/*'
+      - 'contributing/*'
+      - 'demo/*'
+      - 'pkg/*'
+      - 'scripts/*'
+      - 'terraform/*'
+      - 'ui/*'
+      - 'website/*'
+env:
+  GO_VERSION: 1.17.7
+  GOBIN: /usr/local/bin
+  GOTESTARCH: amd64
+  CONSUL_VERSION: 1.11.3
+  VAULT_VERSION: 1.9.3
+  NOMAD_SLOW_TEST: 0
+  NOMAD_TEST_LOG_LEVEL: ERROR
+jobs:
+  checks:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # needs tags for checkproto
+      - uses: magnetikonline/action-golang-cache@v1
+        with:
+          go-version: ${{env.GO_VERSION}}
+          cache-key-suffix: -checks
+      - name: Run make check
+        run: |
+          make bootstrap
+          make check
+  compile:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, macos-11, windows-2019]
+    runs-on: ${{matrix.os}}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+      - uses: magnetikonline/action-golang-cache@v1
+        with:
+          go-version: ${{env.GO_VERSION}}
+          cache-key-suffix: -compile
+      - name: Run make dev
+        env:
+          GOBIN: ${{env.GOROOT}}/bin # windows kludge
+        run: |
+          make bootstrap
+          make dev
+  tests-api:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - uses: magnetikonline/action-golang-cache@v1
+        with:
+          go-version: ${{env.GO_VERSION}}
+          cache-key-suffix: -api
+      - name: Run API tests
+        env:
+          GOTEST_MOD: api
+        run: |
+          make bootstrap
+          make generate-all
+          make test-nomad-module
+  tests-pkgs:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg:
+          - acl
+          - client
+          - client/allocdir
+          - client/allochealth
+          - client/allocrunner
+          - client/allocwatcher
+          - client/config
+          - client/consul
+          - client/devicemanager
+          - client/dynamicplugins
+          - client/fingerprint
+          # - client/lib/...
+          - client/logmon
+          - client/pluginmanager
+          - client/state
+          - client/stats
+          - client/structs
+          - client/taskenv
+          - command
+          - command/agent
+          # - drivers/docker
+          # - drivers/exec
+          - drivers/java
+          - drivers/rawexec
+          - helper/...
+          - internal/...
+          - jobspec/...
+          - lib/...
+          - nomad
+          - nomad/deploymentwatcher
+          - nomad/stream
+          - nomad/structs
+          - nomad/volumewatcher
+          - plugins/...
+          - scheduler/...
+          - testutil
+    steps:
+      - uses: actions/checkout@v2
+      - uses: magnetikonline/action-golang-cache@v1
+        with:
+          go-version: ${{env.GO_VERSION}}
+          cache-key-suffix: -pkgs
+      - name: Run Matrix Tests
+        env:
+          GOTEST_PKGS: ./${{matrix.pkg}}
+        run: |
+          make bootstrap
+          make generate-all
+          hc-install vault ${{env.VAULT_VERSION}}
+          hc-install consul ${{env.CONSUL_VERSION}}
+          sudo sed -i 's!Defaults!#Defaults!g' /etc/sudoers
+          sudo -E env "PATH=$PATH" make test-nomad
+

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -136,6 +136,7 @@ deps:  ## Install build and development dependencies
 	go install github.com/bufbuild/buf/cmd/buf@v0.36.0
 	go install github.com/hashicorp/go-changelog/cmd/changelog-build@latest
 	go install golang.org/x/tools/cmd/stringer@v0.1.8
+	go install gophers.dev/cmds/hc-install/cmd/hc-install@v1.0.1
 
 .PHONY: lint-deps
 lint-deps: ## Install linter dependencies

--- a/scripts/update_golang_version.sh
+++ b/scripts/update_golang_version.sh
@@ -23,6 +23,9 @@ sed -i'' -e "s|/golang:[.0-9]*|/golang:${golang_version}|g" .circleci/config.yml
 sed -i'' -e "s|GOLANG_VERSION:[ \"]*[.0-9]*\"*|GOLANG_VERSION: ${golang_version}|g" \
 	.circleci/config.yml
 
+sed -i'' -e "s|GO_VERSION:[ \"]*[.0-9]*\"*|GO_VERSION: ${golang_version}|g" \
+	.github/workflows/test-core.yaml
+
 sed -i'' -e "s|\\(Install .Go\\) [.0-9]*|\\1 ${golang_version}|g" \
 	contributing/README.md
 


### PR DESCRIPTION
This is part 3 of breaking up https://github.com/hashicorp/nomad/pull/12255

Start running CI on GHA! But not the packages that currently assume cgroups v1. These will be turned back on in the cgroups v2 PR. 