### PR TITLE
CSI: presentation improvements

### DIFF
--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -547,6 +548,10 @@ func structsCSIVolumeToApi(vol *structs.CSIVolume) *api.CSIVolume {
 			}
 		}
 	}
+
+	sort.Slice(out.Allocations, func(i, j int) bool {
+		return out.Allocations[i].ModifyIndex > out.Allocations[j].ModifyIndex
+	})
 
 	return out
 }

--- a/command/plugin_status_csi.go
+++ b/command/plugin_status_csi.go
@@ -206,7 +206,8 @@ func (c *PluginStatusCommand) formatControllerCaps(controllers map[string]*api.C
 		return ""
 	}
 
-	return "  " + strings.Join(sort.StringSlice(caps), "\n  ")
+	sort.StringSlice(caps).Sort()
+	return "  " + strings.Join(caps, "\n  ")
 }
 
 func (c *PluginStatusCommand) formatNodeCaps(nodes map[string]*api.CSIInfo) string {
@@ -237,7 +238,8 @@ func (c *PluginStatusCommand) formatNodeCaps(nodes map[string]*api.CSIInfo) stri
 		return ""
 	}
 
-	return "  " + strings.Join(sort.StringSlice(caps), "\n  ")
+	sort.StringSlice(caps).Sort()
+	return "  " + strings.Join(caps, "\n  ")
 }
 
 func (c *PluginStatusCommand) formatTopology(nodes map[string]*api.CSIInfo) string {

--- a/command/volume_status.go
+++ b/command/volume_status.go
@@ -114,7 +114,6 @@ func (c *VolumeStatusCommand) Run(args []string) int {
 	if c.verbose {
 		c.length = fullId
 	}
-	c.length = fullId
 
 	// Get the HTTP client
 	client, err := c.Meta.Client()

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2793,6 +2793,9 @@ func (s *StateStore) CSIPluginDenormalizeTxn(txn Txn, ws memdb.WatchSet, plug *s
 		}
 		plug.Allocations = append(plug.Allocations, alloc.Stub(nil))
 	}
+	sort.Slice(plug.Allocations, func(i, j int) bool {
+		return plug.Allocations[i].ModifyIndex > plug.Allocations[j].ModifyIndex
+	})
 
 	return plug, nil
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/12073 and other fit-and-finish wobbles.

* Sort allocations for CSI plugins in the state store so they show up nice in `nomad plugin status :id`
* Sort allocations for CSI volumes in the HTTP server so they show up nice in `nomad volume status :id` (this has to be done here because the allocations list in the API response is a merge of 2 lists from the state store)
* Fix sorting of CSI plugins capabilities introduced in https://github.com/hashicorp/nomad/pull/12154. The `sort.StringSlice` method in the stdlib doesn't actually sort, but instead constructs a sorting type which you call `Sort()` on.
* Fix extra long alloc IDs in `nomad volume status` because of a line that got missed in https://github.com/hashicorp/nomad/pull/12153