### PR TITLE
core: add deprecated mvn tag to serf

### DIFF
--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1407,6 +1407,7 @@ func (s *Server) setupSerf(conf *serf.Config, ch chan serf.Event, path string) (
 	conf.Tags["region"] = s.config.Region
 	conf.Tags["dc"] = s.config.Datacenter
 	conf.Tags["build"] = s.config.Build
+	conf.Tags["vsn"] = deprecatedAPIMajorVersionStr // for Nomad <= v1.2 compat
 	conf.Tags["raft_vsn"] = fmt.Sprintf("%d", s.config.RaftConfig.ProtocolVersion)
 	conf.Tags["id"] = s.config.NodeID
 	conf.Tags["rpc_addr"] = s.clientRpcAdvertise.(*net.TCPAddr).IP.String()         // Address that clients will use to RPC to servers

--- a/nomad/util.go
+++ b/nomad/util.go
@@ -15,6 +15,14 @@ import (
 	"github.com/hashicorp/serf/serf"
 )
 
+const (
+	// Deprecated: Through Nomad v1.2 these values were configurable but
+	// functionally unused. We still need to advertise them in Serf for
+	// compatibility with v1.2 and earlier.
+	deprecatedAPIMajorVersion    = 1
+	deprecatedAPIMajorVersionStr = "1"
+)
+
 // MinVersionPlanNormalization is the minimum version to support the
 // normalization of Plan in SubmitPlan, and the denormalization raft log entry committed
 // in ApplyPlanResultsRequest
@@ -43,6 +51,10 @@ type serverParts struct {
 	RPCAddr     net.Addr
 	Status      serf.MemberStatus
 	NonVoter    bool
+
+	// Deprecated: Functionally unused but needs to always be set by 1 for
+	// compatibility with v1.2.x and earlier.
+	MajorVersion int
 }
 
 func (s *serverParts) String() string {
@@ -113,19 +125,20 @@ func isNomadServer(m serf.Member) (bool, *serverParts) {
 	addr := &net.TCPAddr{IP: m.Addr, Port: port}
 	rpcAddr := &net.TCPAddr{IP: rpcIP, Port: port}
 	parts := &serverParts{
-		Name:        m.Name,
-		ID:          id,
-		Region:      region,
-		Datacenter:  datacenter,
-		Port:        port,
-		Bootstrap:   bootstrap,
-		Expect:      expect,
-		Addr:        addr,
-		RPCAddr:     rpcAddr,
-		Build:       *buildVersion,
-		RaftVersion: raftVsn,
-		Status:      m.Status,
-		NonVoter:    nonVoter,
+		Name:         m.Name,
+		ID:           id,
+		Region:       region,
+		Datacenter:   datacenter,
+		Port:         port,
+		Bootstrap:    bootstrap,
+		Expect:       expect,
+		Addr:         addr,
+		RPCAddr:      rpcAddr,
+		Build:        *buildVersion,
+		RaftVersion:  raftVsn,
+		Status:       m.Status,
+		NonVoter:     nonVoter,
+		MajorVersion: deprecatedAPIMajorVersion,
 	}
 	return true, parts
 }

--- a/nomad/util_test.go
+++ b/nomad/util_test.go
@@ -24,6 +24,7 @@ func TestIsNomadServer(t *testing.T) {
 			"dc":       "east-aws",
 			"rpc_addr": "1.1.1.1",
 			"port":     "10000",
+			"vsn":      "1",
 			"raft_vsn": "2",
 			"build":    "0.7.0+ent",
 			"nonvoter": "1",
@@ -52,6 +53,7 @@ func TestIsNomadServer(t *testing.T) {
 	if parts.RPCAddr.String() != "1.1.1.1:10000" {
 		t.Fatalf("bad: %v", parts.RPCAddr.String())
 	}
+	require.Equal(t, 1, parts.MajorVersion)
 	if seg := parts.Build.Segments(); len(seg) != 3 {
 		t.Fatalf("bad: %v", parts.Build)
 	} else if seg[0] != 0 && seg[1] != 7 && seg[2] != 0 {
@@ -201,6 +203,7 @@ func makeMember(version string, status serf.MemberStatus) serf.Member {
 			"dc":     "east-aws",
 			"port":   "10000",
 			"build":  version,
+			"vsn":    "1",
 		},
 		Status: status,
 	}


### PR DESCRIPTION
Revert a small part of #11600 after @lgfa29 discovered it would break
compatibility with Nomad <= v1.2!

Nomad <= v1.2 expects the `vsn` tag to exist in Serf. It has always been
`1`. It has no functional purpose. However it causes a parsing error if
it is not set:

https://github.com/hashicorp/nomad/blob/v1.2.6/nomad/util.go#L103-L108

This means Nomad servers at version v1.2 or older will not allow servers
without this tag to join.

The `mvn` minor version tag is also checked, but soft fails. I'm not
setting that because I want as much of this cruft gone as possible.