### PR TITLE
client: hookup service wrapper for use in clients

### DIFF
--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/nomad/client/lib/cgutil"
-
 	log "github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/client/allocdir"
@@ -20,9 +18,11 @@ import (
 	"github.com/hashicorp/nomad/client/devicemanager"
 	"github.com/hashicorp/nomad/client/dynamicplugins"
 	cinterfaces "github.com/hashicorp/nomad/client/interfaces"
+	"github.com/hashicorp/nomad/client/lib/cgutil"
 	"github.com/hashicorp/nomad/client/pluginmanager/csimanager"
 	"github.com/hashicorp/nomad/client/pluginmanager/drivermanager"
 	"github.com/hashicorp/nomad/client/serviceregistration"
+	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	cstate "github.com/hashicorp/nomad/client/state"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/vaultclient"
@@ -178,6 +178,10 @@ type allocRunner struct {
 	// rpcClient is the RPC Client that should be used by the allocrunner and its
 	// hooks to communicate with Nomad Servers.
 	rpcClient RPCer
+
+	// serviceRegWrapper is the handler wrapper that is used by service hooks
+	// to perform service and check registration and deregistration.
+	serviceRegWrapper *wrapper.HandlerWrapper
 }
 
 // RPCer is the interface needed by hooks to make RPC calls.
@@ -221,6 +225,7 @@ func NewAllocRunner(config *Config) (*allocRunner, error) {
 		driverManager:            config.DriverManager,
 		serversContactedCh:       config.ServersContactedCh,
 		rpcClient:                config.RPCClient,
+		serviceRegWrapper:        config.ServiceRegWrapper,
 	}
 
 	// Create the logger based on the allocation ID
@@ -274,6 +279,7 @@ func (ar *allocRunner) initTaskRunners(tasks []*structs.Task) error {
 			ServersContactedCh:   ar.serversContactedCh,
 			StartConditionMetCtx: ar.taskHookCoordinator.startConditionForTask(task),
 			ShutdownDelayCtx:     ar.shutdownDelayCtx,
+			ServiceRegWrapper:    ar.serviceRegWrapper,
 		}
 
 		if ar.cpusetManager != nil {

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -153,8 +153,8 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 		newNetworkHook(hookLogger, ns, alloc, nm, nc, ar, builtTaskEnv),
 		newGroupServiceHook(groupServiceHookConfig{
 			alloc:               alloc,
-			consul:              ar.consulClient,
-			consulNamespace:     alloc.ConsulNamespace(),
+			namespace:           alloc.ServiceProviderNamespace(),
+			serviceRegWrapper:   ar.serviceRegWrapper,
 			restarter:           ar,
 			taskEnvBuilder:      envBuilder,
 			networkStatusGetter: ar,

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -489,7 +489,8 @@ func TestAllocRunner_TaskGroup_ShutdownDelay(t *testing.T) {
 	tg := alloc.Job.TaskGroups[0]
 	tg.Services = []*structs.Service{
 		{
-			Name: "shutdown_service",
+			Name:     "shutdown_service",
+			Provider: structs.ServiceProviderConsul,
 		},
 	}
 
@@ -1314,6 +1315,7 @@ func TestAllocRunner_TaskFailed_KillTG(t *testing.T) {
 		{
 			Name:      "fakservice",
 			PortLabel: "http",
+			Provider:  structs.ServiceProviderConsul,
 			Checks: []*structs.ServiceCheck{
 				{
 					Name:     "fakecheck",

--- a/client/allocrunner/alloc_runner_unix_test.go
+++ b/client/allocrunner/alloc_runner_unix_test.go
@@ -38,6 +38,7 @@ func TestAllocRunner_Restore_RunningTerminal(t *testing.T) {
 		{
 			Name:      "foo",
 			PortLabel: "8888",
+			Provider:  structs.ServiceProviderConsul,
 		},
 	}
 	task := alloc.Job.TaskGroups[0].Tasks[0]

--- a/client/allocrunner/config.go
+++ b/client/allocrunner/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/nomad/client/pluginmanager/csimanager"
 	"github.com/hashicorp/nomad/client/pluginmanager/drivermanager"
 	"github.com/hashicorp/nomad/client/serviceregistration"
+	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	cstate "github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/client/vaultclient"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -81,4 +82,8 @@ type Config struct {
 	// RPCClient is the RPC Client that should be used by the allocrunner and its
 	// hooks to communicate with Nomad Servers.
 	RPCClient RPCer
+
+	// ServiceRegWrapper is the handler wrapper that is used by service hooks
+	// to perform service and check registration and deregistration.
+	ServiceRegWrapper *wrapper.HandlerWrapper
 }

--- a/client/allocrunner/taskrunner/script_check_hook_test.go
+++ b/client/allocrunner/taskrunner/script_check_hook_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/interfaces"
 	"github.com/hashicorp/nomad/client/serviceregistration"
 	regMock "github.com/hashicorp/nomad/client/serviceregistration/mock"
+	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	"github.com/hashicorp/nomad/client/taskenv"
 	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/testlog"
@@ -228,6 +229,7 @@ func TestScript_TaskEnvInterpolation(t *testing.T) {
 
 	logger := testlog.HCLogger(t)
 	consulClient := regMock.NewServiceRegistrationHandler(logger)
+	regWrap := wrapper.NewHandlerWrapper(logger, consulClient, nil)
 	exec, cancel := newBlockingScriptExec()
 	defer cancel()
 
@@ -243,10 +245,10 @@ func TestScript_TaskEnvInterpolation(t *testing.T) {
 		map[string]string{"SVC_NAME": "frontend"}).Build()
 
 	svcHook := newServiceHook(serviceHookConfig{
-		alloc:          alloc,
-		task:           task,
-		consulServices: consulClient,
-		logger:         logger,
+		alloc:             alloc,
+		task:              task,
+		serviceRegWrapper: regWrap,
+		logger:            logger,
 	})
 	// emulate prestart having been fired
 	svcHook.taskEnv = env

--- a/client/allocrunner/taskrunner/service_hook.go
+++ b/client/allocrunner/taskrunner/service_hook.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	tinterfaces "github.com/hashicorp/nomad/client/allocrunner/taskrunner/interfaces"
 	"github.com/hashicorp/nomad/client/serviceregistration"
+	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	"github.com/hashicorp/nomad/client/taskenv"
 	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -21,11 +22,21 @@ var _ interfaces.TaskExitedHook = &serviceHook{}
 var _ interfaces.TaskStopHook = &serviceHook{}
 var _ interfaces.TaskUpdateHook = &serviceHook{}
 
+const (
+	taskServiceHookName = "task_services"
+)
+
 type serviceHookConfig struct {
-	alloc           *structs.Allocation
-	task            *structs.Task
-	consulServices  serviceregistration.Handler
-	consulNamespace string
+	alloc *structs.Allocation
+	task  *structs.Task
+
+	// namespace is the Nomad or Consul namespace in which service
+	// registrations will be made.
+	namespace string
+
+	// serviceRegWrapper is the handler wrapper that is used to perform service
+	// and check registration and deregistration.
+	serviceRegWrapper *wrapper.HandlerWrapper
 
 	// Restarter is a subset of the TaskLifecycle interface
 	restarter agentconsul.WorkloadRestarter
@@ -34,12 +45,11 @@ type serviceHookConfig struct {
 }
 
 type serviceHook struct {
-	allocID         string
-	taskName        string
-	consulNamespace string
-	consulServices  serviceregistration.Handler
-	restarter       agentconsul.WorkloadRestarter
-	logger          log.Logger
+	allocID   string
+	jobID     string
+	taskName  string
+	restarter agentconsul.WorkloadRestarter
+	logger    log.Logger
 
 	// The following fields may be updated
 	driverExec tinterfaces.ScriptExecutor
@@ -49,6 +59,14 @@ type serviceHook struct {
 	networks   structs.Networks
 	ports      structs.AllocatedPorts
 	taskEnv    *taskenv.TaskEnv
+
+	// namespace is the Nomad or Consul namespace in which service
+	// registrations will be made.
+	namespace string
+
+	// serviceRegWrapper is the handler wrapper that is used to perform service
+	// and check registration and deregistration.
+	serviceRegWrapper *wrapper.HandlerWrapper
 
 	// initialRegistrations tracks if Poststart has completed, initializing
 	// fields required in other lifecycle funcs
@@ -65,13 +83,14 @@ type serviceHook struct {
 
 func newServiceHook(c serviceHookConfig) *serviceHook {
 	h := &serviceHook{
-		allocID:         c.alloc.ID,
-		taskName:        c.task.Name,
-		consulServices:  c.consulServices,
-		consulNamespace: c.consulNamespace,
-		services:        c.task.Services,
-		restarter:       c.restarter,
-		ports:           c.alloc.AllocatedResources.Shared.Ports,
+		allocID:           c.alloc.ID,
+		jobID:             c.alloc.JobID,
+		taskName:          c.task.Name,
+		namespace:         c.namespace,
+		serviceRegWrapper: c.serviceRegWrapper,
+		services:          c.task.Services,
+		restarter:         c.restarter,
+		ports:             c.alloc.AllocatedResources.Shared.Ports,
 	}
 
 	if res := c.alloc.AllocatedResources.Tasks[c.task.Name]; res != nil {
@@ -86,9 +105,7 @@ func newServiceHook(c serviceHookConfig) *serviceHook {
 	return h
 }
 
-func (h *serviceHook) Name() string {
-	return "consul_services"
-}
+func (h *serviceHook) Name() string { return taskServiceHookName }
 
 func (h *serviceHook) Poststart(ctx context.Context, req *interfaces.TaskPoststartRequest, _ *interfaces.TaskPoststartResponse) error {
 	h.mu.Lock()
@@ -106,15 +123,15 @@ func (h *serviceHook) Poststart(ctx context.Context, req *interfaces.TaskPoststa
 	// Create task services struct with request's driver metadata
 	workloadServices := h.getWorkloadServices()
 
-	return h.consulServices.RegisterWorkload(workloadServices)
+	return h.serviceRegWrapper.RegisterWorkload(workloadServices)
 }
 
 func (h *serviceHook) Update(ctx context.Context, req *interfaces.TaskUpdateRequest, _ *interfaces.TaskUpdateResponse) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if !h.initialRegistration {
-		// no op Consul since initial registration has not finished
-		// only update hook fields
+		// no op since initial registration has not finished only update hook
+		// fields.
 		return h.updateHookFields(req)
 	}
 
@@ -129,7 +146,7 @@ func (h *serviceHook) Update(ctx context.Context, req *interfaces.TaskUpdateRequ
 	// Create new task services struct with those new values
 	newWorkloadServices := h.getWorkloadServices()
 
-	return h.consulServices.UpdateWorkload(oldWorkloadServices, newWorkloadServices)
+	return h.serviceRegWrapper.UpdateWorkload(oldWorkloadServices, newWorkloadServices)
 }
 
 func (h *serviceHook) updateHookFields(req *interfaces.TaskUpdateRequest) error {
@@ -180,7 +197,7 @@ func (h *serviceHook) Exited(context.Context, *interfaces.TaskExitedRequest, *in
 func (h *serviceHook) deregister() {
 	if len(h.services) > 0 && !h.deregistered {
 		workloadServices := h.getWorkloadServices()
-		h.consulServices.RemoveWorkload(workloadServices)
+		h.serviceRegWrapper.RemoveWorkload(workloadServices)
 	}
 	h.initialRegistration = false
 	h.deregistered = true
@@ -200,8 +217,9 @@ func (h *serviceHook) getWorkloadServices() *serviceregistration.WorkloadService
 	// Create task services struct with request's driver metadata
 	return &serviceregistration.WorkloadServices{
 		AllocID:       h.allocID,
+		JobID:         h.jobID,
 		Task:          h.taskName,
-		Namespace:     h.consulNamespace,
+		Namespace:     h.namespace,
 		Restarter:     h.restarter,
 		Services:      interpolatedServices,
 		DriverExec:    h.driverExec,

--- a/client/allocrunner/taskrunner/service_hook_test.go
+++ b/client/allocrunner/taskrunner/service_hook_test.go
@@ -6,8 +6,12 @@ import (
 
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	regMock "github.com/hashicorp/nomad/client/serviceregistration/mock"
+	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
+	"github.com/hashicorp/nomad/client/taskenv"
+	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,20 +23,38 @@ var _ interfaces.TaskUpdateHook = (*serviceHook)(nil)
 
 func TestUpdate_beforePoststart(t *testing.T) {
 	alloc := mock.Alloc()
+	alloc.Job.Canonicalize()
 	logger := testlog.HCLogger(t)
+
 	c := regMock.NewServiceRegistrationHandler(logger)
+	regWrap := wrapper.NewHandlerWrapper(logger, c, nil)
+
+	// Interpolating workload services performs a check on the task env, if it
+	// is nil, nil is returned meaning no services. This does not work with the
+	// wrapper len protections, so we need a dummy taskenv.
+	spoofTaskEnv := taskenv.TaskEnv{NodeAttrs: map[string]string{}}
 
 	hook := newServiceHook(serviceHookConfig{
-		alloc:          alloc,
-		task:           alloc.LookupTask("web"),
-		consulServices: c,
-		logger:         logger,
+		alloc:             alloc,
+		task:              alloc.LookupTask("web"),
+		serviceRegWrapper: regWrap,
+		logger:            logger,
 	})
-	require.NoError(t, hook.Update(context.Background(), &interfaces.TaskUpdateRequest{Alloc: alloc}, &interfaces.TaskUpdateResponse{}))
+	require.NoError(t, hook.Update(context.Background(), &interfaces.TaskUpdateRequest{
+		Alloc:   alloc,
+		TaskEnv: &spoofTaskEnv,
+	}, &interfaces.TaskUpdateResponse{}))
 	require.Len(t, c.GetOps(), 0)
-	require.NoError(t, hook.Poststart(context.Background(), &interfaces.TaskPoststartRequest{}, &interfaces.TaskPoststartResponse{}))
+
+	require.NoError(t, hook.Poststart(context.Background(), &interfaces.TaskPoststartRequest{
+		TaskEnv: &spoofTaskEnv,
+	}, &interfaces.TaskPoststartResponse{}))
 	require.Len(t, c.GetOps(), 1)
-	require.NoError(t, hook.Update(context.Background(), &interfaces.TaskUpdateRequest{Alloc: alloc}, &interfaces.TaskUpdateResponse{}))
+
+	require.NoError(t, hook.Update(context.Background(), &interfaces.TaskUpdateRequest{
+		Alloc:   alloc,
+		TaskEnv: &spoofTaskEnv,
+	}, &interfaces.TaskUpdateResponse{}))
 	require.Len(t, c.GetOps(), 2)
 
 	// When a task exits it could be restarted with new driver info
@@ -40,15 +62,31 @@ func TestUpdate_beforePoststart(t *testing.T) {
 
 	require.NoError(t, hook.Exited(context.Background(), &interfaces.TaskExitedRequest{}, &interfaces.TaskExitedResponse{}))
 	require.Len(t, c.GetOps(), 3)
-	require.NoError(t, hook.Update(context.Background(), &interfaces.TaskUpdateRequest{Alloc: alloc}, &interfaces.TaskUpdateResponse{}))
+
+	require.NoError(t, hook.Update(context.Background(), &interfaces.TaskUpdateRequest{
+		Alloc:   alloc,
+		TaskEnv: &spoofTaskEnv,
+	}, &interfaces.TaskUpdateResponse{}))
 	require.Len(t, c.GetOps(), 3)
-	require.NoError(t, hook.Poststart(context.Background(), &interfaces.TaskPoststartRequest{}, &interfaces.TaskPoststartResponse{}))
+
+	require.NoError(t, hook.Poststart(context.Background(), &interfaces.TaskPoststartRequest{
+		TaskEnv: &spoofTaskEnv,
+	}, &interfaces.TaskPoststartResponse{}))
 	require.Len(t, c.GetOps(), 4)
-	require.NoError(t, hook.Update(context.Background(), &interfaces.TaskUpdateRequest{Alloc: alloc}, &interfaces.TaskUpdateResponse{}))
+
+	require.NoError(t, hook.Update(context.Background(), &interfaces.TaskUpdateRequest{
+		Alloc:   alloc,
+		TaskEnv: &spoofTaskEnv,
+	}, &interfaces.TaskUpdateResponse{}))
 	require.Len(t, c.GetOps(), 5)
+
 	require.NoError(t, hook.PreKilling(context.Background(), &interfaces.TaskPreKillRequest{}, &interfaces.TaskPreKillResponse{}))
 	require.Len(t, c.GetOps(), 6)
-	require.NoError(t, hook.Update(context.Background(), &interfaces.TaskUpdateRequest{Alloc: alloc}, &interfaces.TaskUpdateResponse{}))
+
+	require.NoError(t, hook.Update(context.Background(), &interfaces.TaskUpdateRequest{
+		Alloc:   alloc,
+		TaskEnv: &spoofTaskEnv,
+	}, &interfaces.TaskUpdateResponse{}))
 	require.Len(t, c.GetOps(), 6)
 }
 
@@ -56,17 +94,26 @@ func Test_serviceHook_multipleDeRegisterCall(t *testing.T) {
 
 	alloc := mock.Alloc()
 	logger := testlog.HCLogger(t)
+
 	c := regMock.NewServiceRegistrationHandler(logger)
+	regWrap := wrapper.NewHandlerWrapper(logger, c, nil)
 
 	hook := newServiceHook(serviceHookConfig{
-		alloc:          alloc,
-		task:           alloc.LookupTask("web"),
-		consulServices: c,
-		logger:         logger,
+		alloc:             alloc,
+		task:              alloc.LookupTask("web"),
+		serviceRegWrapper: regWrap,
+		logger:            logger,
 	})
 
+	// Interpolating workload services performs a check on the task env, if it
+	// is nil, nil is returned meaning no services. This does not work with the
+	// wrapper len protections, so we need a dummy taskenv.
+	spoofTaskEnv := taskenv.TaskEnv{NodeAttrs: map[string]string{}}
+
 	// Add a registration, as we would in normal operation.
-	require.NoError(t, hook.Poststart(context.Background(), &interfaces.TaskPoststartRequest{}, &interfaces.TaskPoststartResponse{}))
+	require.NoError(t, hook.Poststart(context.Background(), &interfaces.TaskPoststartRequest{
+		TaskEnv: &spoofTaskEnv,
+	}, &interfaces.TaskPoststartResponse{}))
 	require.Len(t, c.GetOps(), 1)
 
 	// Call all three deregister backed functions in a row. Ensure the number
@@ -84,7 +131,9 @@ func Test_serviceHook_multipleDeRegisterCall(t *testing.T) {
 	require.Equal(t, c.GetOps()[1].Op, "remove")
 
 	// Now we act like a restart.
-	require.NoError(t, hook.Poststart(context.Background(), &interfaces.TaskPoststartRequest{}, &interfaces.TaskPoststartResponse{}))
+	require.NoError(t, hook.Poststart(context.Background(), &interfaces.TaskPoststartRequest{
+		TaskEnv: &spoofTaskEnv,
+	}, &interfaces.TaskPoststartResponse{}))
 	require.Len(t, c.GetOps(), 3)
 	require.Equal(t, c.GetOps()[2].Op, "add")
 
@@ -100,4 +149,58 @@ func Test_serviceHook_multipleDeRegisterCall(t *testing.T) {
 	require.NoError(t, hook.Stop(context.Background(), &interfaces.TaskStopRequest{}, &interfaces.TaskStopResponse{}))
 	require.Len(t, c.GetOps(), 4)
 	require.Equal(t, c.GetOps()[3].Op, "remove")
+}
+
+// Test_serviceHook_Nomad performs a normal operation test of the serviceHook
+// when using task services which utilise the Nomad provider.
+func Test_serviceHook_Nomad(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock alloc, and add a task service using provider Nomad.
+	alloc := mock.Alloc()
+	alloc.Job.TaskGroups[0].Tasks[0].Services = []*structs.Service{
+		{
+			Name:     "nomad-provider-service",
+			Provider: structs.ServiceProviderNomad,
+		},
+	}
+
+	// Create our base objects and our subsequent wrapper.
+	logger := testlog.HCLogger(t)
+	consulMockClient := regMock.NewServiceRegistrationHandler(logger)
+	nomadMockClient := regMock.NewServiceRegistrationHandler(logger)
+
+	regWrapper := wrapper.NewHandlerWrapper(logger, consulMockClient, nomadMockClient)
+
+	h := newServiceHook(serviceHookConfig{
+		alloc:             alloc,
+		task:              alloc.LookupTask("web"),
+		namespace:         "default",
+		serviceRegWrapper: regWrapper,
+		restarter:         agentconsul.NoopRestarter(),
+		logger:            logger,
+	})
+
+	// Create a taskEnv builder to use in requests, otherwise interpolation of
+	// services will always return nil.
+	taskEnvBuilder := taskenv.NewBuilder(mock.Node(), alloc, nil, alloc.Job.Region)
+
+	// Trigger our initial hook function.
+	require.NoError(t, h.Poststart(context.Background(), &interfaces.TaskPoststartRequest{
+		TaskEnv: taskEnvBuilder.Build()}, nil))
+
+	// Trigger all the possible stop functions to ensure we only deregister
+	// once.
+	require.NoError(t, h.PreKilling(context.Background(), nil, nil))
+	require.NoError(t, h.Exited(context.Background(), nil, nil))
+	require.NoError(t, h.Stop(context.Background(), nil, nil))
+
+	// Ensure the Nomad mock provider has the expected operations.
+	nomadOps := nomadMockClient.GetOps()
+	require.Len(t, nomadOps, 2)
+	require.Equal(t, "add", nomadOps[0].Op)    // Poststart
+	require.Equal(t, "remove", nomadOps[1].Op) // PreKilling,Exited,Stop
+
+	// Ensure the Consul mock provider has zero operations.
+	require.Len(t, consulMockClient.GetOps(), 0)
 }

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/nomad/client/pluginmanager/csimanager"
 	"github.com/hashicorp/nomad/client/pluginmanager/drivermanager"
 	"github.com/hashicorp/nomad/client/serviceregistration"
+	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	cstate "github.com/hashicorp/nomad/client/state"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/taskenv"
@@ -239,6 +240,10 @@ type TaskRunner struct {
 	networkIsolationSpec *drivers.NetworkIsolationSpec
 
 	allocHookResources *cstructs.AllocHookResources
+
+	// serviceRegWrapper is the handler wrapper that is used by service hooks
+	// to perform service and check registration and deregistration.
+	serviceRegWrapper *wrapper.HandlerWrapper
 }
 
 type Config struct {
@@ -300,6 +305,10 @@ type Config struct {
 
 	// ShutdownDelayCancelFn should only be used in testing.
 	ShutdownDelayCancelFn context.CancelFunc
+
+	// ServiceRegWrapper is the handler wrapper that is used by service hooks
+	// to perform service and check registration and deregistration.
+	ServiceRegWrapper *wrapper.HandlerWrapper
 }
 
 func NewTaskRunner(config *Config) (*TaskRunner, error) {
@@ -357,6 +366,7 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 		startConditionMetCtx:   config.StartConditionMetCtx,
 		shutdownDelayCtx:       config.ShutdownDelayCtx,
 		shutdownDelayCancelFn:  config.ShutdownDelayCancelFn,
+		serviceRegWrapper:      config.ServiceRegWrapper,
 	}
 
 	// Create the logger based on the allocation ID

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -96,8 +96,12 @@ func (tr *TaskRunner) initHooks() {
 		}))
 	}
 
-	// Get the consul namespace for the TG of the allocation
+	// Get the consul namespace for the TG of the allocation.
 	consulNamespace := tr.alloc.ConsulNamespace()
+
+	// Identify the service registration provider, which can differ from the
+	// Consul namespace depending on which provider is used.
+	serviceProviderNamespace := tr.alloc.ServiceProviderNamespace()
 
 	// If there are templates is enabled, add the hook
 	if len(task.Templates) != 0 {
@@ -115,12 +119,12 @@ func (tr *TaskRunner) initHooks() {
 	// Always add the service hook. A task with no services on initial registration
 	// may be updated to include services, which must be handled with this hook.
 	tr.runnerHooks = append(tr.runnerHooks, newServiceHook(serviceHookConfig{
-		alloc:           tr.Alloc(),
-		task:            tr.Task(),
-		consulServices:  tr.consulServiceClient,
-		consulNamespace: consulNamespace,
-		restarter:       tr,
-		logger:          hookLogger,
+		alloc:             tr.Alloc(),
+		task:              tr.Task(),
+		namespace:         serviceProviderNamespace,
+		serviceRegWrapper: tr.serviceRegWrapper,
+		restarter:         tr,
+		logger:            hookLogger,
 	}))
 
 	// If this is a Connect sidecar proxy (or a Connect Native) service,

--- a/client/allocrunner/testing.go
+++ b/client/allocrunner/testing.go
@@ -7,14 +7,14 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/hashicorp/nomad/client/lib/cgutil"
-
 	"github.com/hashicorp/nomad/client/allocwatcher"
 	clientconfig "github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/consul"
 	"github.com/hashicorp/nomad/client/devicemanager"
+	"github.com/hashicorp/nomad/client/lib/cgutil"
 	"github.com/hashicorp/nomad/client/pluginmanager/drivermanager"
 	"github.com/hashicorp/nomad/client/serviceregistration/mock"
+	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/client/vaultclient"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -57,13 +57,17 @@ func (m *MockStateUpdater) Reset() {
 
 func testAllocRunnerConfig(t *testing.T, alloc *structs.Allocation) (*Config, func()) {
 	clientConf, cleanup := clientconfig.TestClientConfig(t)
+
+	consulRegMock := mock.NewServiceRegistrationHandler(clientConf.Logger)
+	nomadRegMock := mock.NewServiceRegistrationHandler(clientConf.Logger)
+
 	conf := &Config{
 		// Copy the alloc in case the caller edits and reuses it
 		Alloc:              alloc.Copy(),
 		Logger:             clientConf.Logger,
 		ClientConfig:       clientConf,
 		StateDB:            state.NoopDB{},
-		Consul:             mock.NewServiceRegistrationHandler(clientConf.Logger),
+		Consul:             consulRegMock,
 		ConsulSI:           consul.NewMockServiceIdentitiesClient(),
 		Vault:              vaultclient.NewMockVaultClient(),
 		StateUpdater:       &MockStateUpdater{},
@@ -73,6 +77,7 @@ func testAllocRunnerConfig(t *testing.T, alloc *structs.Allocation) (*Config, fu
 		DriverManager:      drivermanager.TestDriverManager(t),
 		CpusetManager:      cgutil.NoopCpusetManager(),
 		ServersContactedCh: make(chan struct{}),
+		ServiceRegWrapper:  wrapper.NewHandlerWrapper(clientConf.Logger, consulRegMock, nomadRegMock),
 	}
 	return conf, cleanup
 }

--- a/client/client.go
+++ b/client/client.go
@@ -40,6 +40,8 @@ import (
 	"github.com/hashicorp/nomad/client/pluginmanager/drivermanager"
 	"github.com/hashicorp/nomad/client/servers"
 	"github.com/hashicorp/nomad/client/serviceregistration"
+	"github.com/hashicorp/nomad/client/serviceregistration/nsd"
+	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/client/stats"
 	cstructs "github.com/hashicorp/nomad/client/structs"
@@ -226,9 +228,18 @@ type Client struct {
 	// allocUpdates stores allocations that need to be synced to the server.
 	allocUpdates chan *structs.Allocation
 
-	// consulService is Nomad's custom Consul client for managing services
+	// consulService is the Consul handler implementation for managing services
 	// and checks.
 	consulService serviceregistration.Handler
+
+	// nomadService is the Nomad handler implementation for managing service
+	// registrations.
+	nomadService serviceregistration.Handler
+
+	// serviceRegWrapper wraps the consulService and nomadService
+	// implementations so that the alloc and task runner service hooks can call
+	// this without needing to identify which backend provider should be used.
+	serviceRegWrapper *wrapper.HandlerWrapper
 
 	// consulProxies is Nomad's custom Consul client for looking up supported
 	// envoy versions
@@ -471,6 +482,12 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 	devManager := devicemanager.New(devConfig)
 	c.devicemanager = devManager
 	c.pluginManagers.RegisterAndRun(devManager)
+
+	// Set up the service registration wrapper using the Consul and Nomad
+	// implementations. The Nomad implementation is only ever used on the
+	// client, so we do that here rather than within the agent.
+	c.setupNomadServiceRegistrationHandler()
+	c.serviceRegWrapper = wrapper.NewHandlerWrapper(c.logger, c.consulService, c.nomadService)
 
 	// Batching of initial fingerprints is done to reduce the number of node
 	// updates sent to the server on startup. This is the first RPC to the servers
@@ -784,6 +801,13 @@ func (c *Client) Shutdown() error {
 		}
 	}
 	arGroup.Wait()
+
+	// Assert the implementation, so we can trigger the shutdown call. This is
+	// the only place this occurs, so it's OK to store the interface rather
+	// than the implementation.
+	if h, ok := c.nomadService.(*nsd.ServiceRegistrationHandler); ok {
+		h.Shutdown()
+	}
 
 	// Shutdown the plugin managers
 	c.pluginManagers.Shutdown()
@@ -1141,6 +1165,7 @@ func (c *Client) restoreState() error {
 			DeviceManager:       c.devicemanager,
 			DriverManager:       c.drivermanager,
 			ServersContactedCh:  c.serversContactedCh,
+			ServiceRegWrapper:   c.serviceRegWrapper,
 			RPCClient:           c,
 		}
 		c.configLock.RUnlock()
@@ -2462,6 +2487,7 @@ func (c *Client) addAlloc(alloc *structs.Allocation, migrateToken string) error 
 		CpusetManager:       c.cpusetManager,
 		DeviceManager:       c.devicemanager,
 		DriverManager:       c.drivermanager,
+		ServiceRegWrapper:   c.serviceRegWrapper,
 		RPCClient:           c,
 	}
 	c.configLock.RUnlock()
@@ -2507,6 +2533,20 @@ func (c *Client) setupVaultClient() error {
 	c.vaultClient.Start()
 
 	return nil
+}
+
+// setupNomadServiceRegistrationHandler sets up the registration handler to use
+// for native service discovery.
+func (c *Client) setupNomadServiceRegistrationHandler() {
+	cfg := nsd.ServiceRegistrationHandlerCfg{
+		Datacenter: c.Datacenter(),
+		Enabled:    c.config.NomadServiceDiscovery,
+		NodeID:     c.NodeID(),
+		NodeSecret: c.secretNodeID(),
+		Region:     c.Region(),
+		RPCFn:      c.RPC,
+	}
+	c.nomadService = nsd.NewServiceRegistrationHandler(c.logger, &cfg)
 }
 
 // deriveToken takes in an allocation and a set of tasks and derives vault

--- a/client/serviceregistration/wrapper/wrapper_test.go
+++ b/client/serviceregistration/wrapper/wrapper_test.go
@@ -131,10 +131,10 @@ func TestHandlerWrapper_RemoveWorkload(t *testing.T) {
 				// Generate the test wrapper and provider mocks.
 				wrapper, consul, nomad := setupTestWrapper()
 
-				// Call the function with no services and check that nothing is
-				// registered.
+				// Call the function with no services and check that consul is
+				// defaulted to.
 				wrapper.RemoveWorkload(&serviceregistration.WorkloadServices{})
-				require.Len(t, consul.GetOps(), 0)
+				require.Len(t, consul.GetOps(), 1)
 				require.Len(t, nomad.GetOps(), 0)
 			},
 			name: "zero services",

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -14,8 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/nomad/lib/cpuset"
-
 	metrics "github.com/armon/go-metrics"
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
@@ -28,6 +26,7 @@ import (
 	"github.com/hashicorp/nomad/command/agent/event"
 	"github.com/hashicorp/nomad/helper/pluginutils/loader"
 	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/lib/cpuset"
 	"github.com/hashicorp/nomad/nomad"
 	"github.com/hashicorp/nomad/nomad/deploymentwatcher"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -891,7 +890,6 @@ func (a *Agent) setupClient() error {
 	if !a.config.Client.Enabled {
 		return nil
 	}
-
 	// Setup the configuration
 	conf, err := a.clientConfig()
 	if err != nil {

--- a/command/agent/consul/int_test.go
+++ b/command/agent/consul/int_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/devicemanager"
 	"github.com/hashicorp/nomad/client/pluginmanager/drivermanager"
+	regMock "github.com/hashicorp/nomad/client/serviceregistration/mock"
+	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/client/vaultclient"
 	"github.com/hashicorp/nomad/command/agent/consul"
@@ -93,6 +95,7 @@ func TestConsul_Integration(t *testing.T) {
 			Name:      "httpd",
 			PortLabel: "http",
 			Tags:      []string{"nomad", "test", "http"},
+			Provider:  structs.ServiceProviderConsul,
 			Checks: []*structs.ServiceCheck{
 				{
 					Name:     "httpd-http-check",
@@ -114,6 +117,7 @@ func TestConsul_Integration(t *testing.T) {
 		{
 			Name:      "httpd2",
 			PortLabel: "http",
+			Provider:  structs.ServiceProviderConsul,
 			Tags: []string{
 				"test",
 				// Use URL-unfriendly tags to test #3620
@@ -162,6 +166,7 @@ func TestConsul_Integration(t *testing.T) {
 		DeviceManager:        devicemanager.NoopMockManager(),
 		DriverManager:        drivermanager.TestDriverManager(t),
 		StartConditionMetCtx: closedCh,
+		ServiceRegWrapper:    wrapper.NewHandlerWrapper(logger, serviceClient, regMock.NewServiceRegistrationHandler(logger)),
 	}
 
 	tr, err := taskrunner.NewTaskRunner(config)

--- a/nomad/structs/alloc_test.go
+++ b/nomad/structs/alloc_test.go
@@ -10,3 +10,105 @@ func TestAllocServiceRegistrationsRequest_StaleReadSupport(t *testing.T) {
 	req := &AllocServiceRegistrationsRequest{}
 	require.True(t, req.IsRead())
 }
+
+func Test_Allocation_ServiceProviderNamespace(t *testing.T) {
+	testCases := []struct {
+		inputAllocation *Allocation
+		expectedOutput  string
+		name            string
+	}{
+		{
+			inputAllocation: &Allocation{
+				Job: &Job{
+					TaskGroups: []*TaskGroup{
+						{
+							Name: "test-group",
+							Services: []*Service{
+								{
+									Provider: ServiceProviderConsul,
+								},
+							},
+						},
+					},
+				},
+				TaskGroup: "test-group",
+			},
+			expectedOutput: "",
+			name:           "consul task group service",
+		},
+		{
+			inputAllocation: &Allocation{
+				Job: &Job{
+					TaskGroups: []*TaskGroup{
+						{
+							Name: "test-group",
+							Tasks: []*Task{
+								{
+									Services: []*Service{
+										{
+											Provider: ServiceProviderConsul,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				TaskGroup: "test-group",
+			},
+			expectedOutput: "",
+			name:           "consul task service",
+		},
+		{
+			inputAllocation: &Allocation{
+				Job: &Job{
+					Namespace: "platform",
+					TaskGroups: []*TaskGroup{
+						{
+							Name: "test-group",
+							Services: []*Service{
+								{
+									Provider: ServiceProviderNomad,
+								},
+							},
+						},
+					},
+				},
+				TaskGroup: "test-group",
+			},
+			expectedOutput: "platform",
+			name:           "nomad task group service",
+		},
+		{
+			inputAllocation: &Allocation{
+				Job: &Job{
+					Namespace: "platform",
+					TaskGroups: []*TaskGroup{
+						{
+							Name: "test-group",
+							Tasks: []*Task{
+								{
+									Services: []*Service{
+										{
+											Provider: ServiceProviderNomad,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				TaskGroup: "test-group",
+			},
+			expectedOutput: "platform",
+			name:           "nomad task service",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := tc.inputAllocation.ServiceProviderNamespace()
+			require.Equal(t, tc.expectedOutput, actualOutput)
+		})
+	}
+}


### PR DESCRIPTION
This PR modifies the client task and alloc runners to utilise the new service registration wrapper. The service hooks have also been updated to use the wrapper along with some naming improvements which were previously Consul specific.

In order to handle a test case, the wrapper has been slightly modified. The function has a comment which details this change. Additional testing via table driven test should be added in the future.

closes https://github.com/hashicorp/team-nomad/issues/266