### PR TITLE
E2E: ensure `ConnectACLsE2ETest` has clean state before starting

### DIFF
--- a/e2e/connect/acls.go
+++ b/e2e/connect/acls.go
@@ -40,6 +40,13 @@ func (tc *ConnectACLsE2ETest) BeforeAll(f *framework.F) {
 
 	_, err := uuidparse.ParseUUID(tc.consulManagementToken)
 	f.NoError(err, "CONSUL_HTTP_TOKEN not set")
+
+	// ensure SI tokens from previous test cases were removed
+	f.Eventually(func() bool {
+		siTokens := tc.countSITokens(f.T())
+		f.T().Log("cleanup: checking for remaining SI tokens:", siTokens)
+		return len(siTokens) == 0
+	}, 2*time.Minute, 2*time.Second, "SI tokens did not get removed")
 }
 
 // AfterEach does cleanup of Consul ACL objects that were created during each


### PR DESCRIPTION
The `ConnectACLsE2ETest` checks that the SI tokens have been properly
cleaned up between tests, but following the change to use HCP the
previous `Connect` test suite will often have SI tokens that haven't
been cleaned up by the time this test suite runs. Wait for the SI
tokens to be cleaned up at the start of the test to ensure we have a
clean state.

----

The longer-term fix for this might be something like https://github.com/hashicorp/nomad/issues/12316 but for now this will get nightly green again. Test run with Nomad ENT binaries, showing that we're now waiting for the SI tokens to be cleaned up before proceeding:

```
$ go test -v .
=== RUN   TestE2E
=== RUN   TestE2E/Affinity
=== RUN   TestE2E/Affinity/*affinities.BasicAffinityTest
=== RUN   TestE2E/Affinity/*affinities.BasicAffinityTest/TestAntiAffinities
=== RUN   TestE2E/Affinity/*affinities.BasicAffinityTest/TestMultipleAffinities
=== RUN   TestE2E/Affinity/*affinities.BasicAffinityTest/TestSingleAffinities
=== RUN   TestE2E/clientstate
=== RUN   TestE2E/clientstate/*clientstate.ClientStateTC
    clientstate.go:47: Skipping very slow state corruption test unless NOMAD_TEST_STATE=1
=== RUN   TestE2E/Connect
=== RUN   TestE2E/Connect/*connect.ConnectE2ETest
=== RUN   TestE2E/Connect/*connect.ConnectE2ETest/TestConnectCustomSidecarExposed
=== RUN   TestE2E/Connect/*connect.ConnectE2ETest/TestConnectDemo
=== RUN   TestE2E/Connect/*connect.ConnectE2ETest/TestConnectIngressGatewayDemo
=== RUN   TestE2E/Connect/*connect.ConnectE2ETest/TestConnectMultiIngressGatewayDemo
=== RUN   TestE2E/Connect/*connect.ConnectE2ETest/TestConnectNativeDemo
=== RUN   TestE2E/Connect/*connect.ConnectE2ETest/TestConnectTerminatingGatewayDemo
=== RUN   TestE2E/Connect/*connect.ConnectE2ETest/TestMultiServiceConnect
=== RUN   TestE2E/Connect/*connect.ConnectClientStateE2ETest
=== RUN   TestE2E/Connect/*connect.ConnectClientStateE2ETest/TestClientRestart
=== RUN   TestE2E/ConnectACLs
=== RUN   TestE2E/ConnectACLs/*connect.ConnectACLsE2ETest
    acls.go:47: cleanup: checking for remaining SI tokens: map[connect-proxy-count-api:1 connect-proxy-count-dashboard:1]
    acls.go:47: cleanup: checking for remaining SI tokens: map[connect-proxy-count-api:1 connect-proxy-count-dashboard:1]
    acls.go:47: cleanup: checking for remaining SI tokens: map[connect-proxy-count-api:1 connect-proxy-count-dashboard:1]
    acls.go:47: cleanup: checking for remaining SI tokens: map[]
=== RUN   TestE2E/ConnectACLs/*connect.ConnectACLsE2ETest/TestConnectACLsConnectDemo
...
```