### PR TITLE
client: add task environment variable providing job version

### DIFF
--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -61,6 +61,9 @@ const (
 	// JobParentID is the environment variable for passing the ID of the parnt of the job
 	JobParentID = "NOMAD_JOB_PARENT_ID"
 
+	// JobVersion is the environment variable for passing the version number of the job.
+	JobVersion = "NOMAD_JOB_VERSION"
+
 	// AllocIndex is the environment variable for passing the allocation index.
 	AllocIndex = "NOMAD_ALLOC_INDEX"
 
@@ -411,6 +414,7 @@ type Builder struct {
 	jobID            string
 	jobName          string
 	jobParentID      string
+	jobVersion       uint64
 
 	// otherPorts for tasks in the same alloc
 	otherPorts map[string]string
@@ -514,6 +518,9 @@ func (b *Builder) buildEnv(allocDir, localDir, secretsDir string,
 	}
 	if b.jobParentID != "" {
 		envMap[JobParentID] = b.jobParentID
+	}
+	if b.jobVersion != 0 {
+		envMap[JobVersion] = strconv.FormatUint(b.jobVersion, 10)
 	}
 	if b.datacenter != "" {
 		envMap[Datacenter] = b.datacenter
@@ -699,6 +706,7 @@ func (b *Builder) setAlloc(alloc *structs.Allocation) *Builder {
 	b.jobID = alloc.Job.ID
 	b.jobName = alloc.Job.Name
 	b.jobParentID = alloc.Job.ParentID
+	b.jobVersion = alloc.Job.Version
 	b.namespace = alloc.Namespace
 
 	// Set meta

--- a/client/taskenv/env_test.go
+++ b/client/taskenv/env_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -235,6 +236,7 @@ func TestEnvironment_AsList(t *testing.T) {
 		fmt.Sprintf("NOMAD_JOB_PARENT_ID=%s", a.Job.ParentID),
 		fmt.Sprintf("NOMAD_ALLOC_ID=%s", a.ID),
 		"NOMAD_ALLOC_INDEX=0",
+		fmt.Sprintf("NOMAD_JOB_VERSION=%d", a.Job.Version),
 	}
 	sort.Strings(act)
 	sort.Strings(exp)
@@ -395,6 +397,7 @@ func TestEnvironment_AllValues(t *testing.T) {
 		"NOMAD_JOB_ID":                              a.Job.ID,
 		"NOMAD_JOB_NAME":                            "my-job",
 		"NOMAD_JOB_PARENT_ID":                       a.Job.ParentID,
+		"NOMAD_JOB_VERSION":                         strconv.FormatUint(a.Job.Version, 10),
 		"NOMAD_ALLOC_ID":                            a.ID,
 		"NOMAD_ALLOC_INDEX":                         "0",
 		"NOMAD_PORT_connect_proxy_testconnect":      "9999",

--- a/client/taskenv/env_test.go
+++ b/client/taskenv/env_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -159,6 +158,7 @@ func TestEnvironment_AsList(t *testing.T) {
 	}
 	a := mock.Alloc()
 	a.Job.ParentID = fmt.Sprintf("mock-parent-service-%s", uuid.Generate())
+	a.Job.Version = 5
 	a.AllocatedResources.Tasks["web"] = &structs.AllocatedTaskResources{
 		Cpu: structs.AllocatedCpuResources{CpuShares: 500},
 		Memory: structs.AllocatedMemoryResources{
@@ -234,9 +234,9 @@ func TestEnvironment_AsList(t *testing.T) {
 		fmt.Sprintf("NOMAD_JOB_ID=%s", a.Job.ID),
 		"NOMAD_JOB_NAME=my-job",
 		fmt.Sprintf("NOMAD_JOB_PARENT_ID=%s", a.Job.ParentID),
+		"NOMAD_JOB_VERSION=5",
 		fmt.Sprintf("NOMAD_ALLOC_ID=%s", a.ID),
 		"NOMAD_ALLOC_INDEX=0",
-		fmt.Sprintf("NOMAD_JOB_VERSION=%d", a.Job.Version),
 	}
 	sort.Strings(act)
 	sort.Strings(exp)
@@ -254,6 +254,7 @@ func TestEnvironment_AllValues(t *testing.T) {
 	}
 	a := mock.ConnectAlloc()
 	a.Job.ParentID = fmt.Sprintf("mock-parent-service-%s", uuid.Generate())
+	a.Job.Version = 9152
 	a.AllocatedResources.Tasks["web"].Networks[0] = &structs.NetworkResource{
 		Device:        "eth0",
 		IP:            "127.0.0.1",
@@ -397,7 +398,7 @@ func TestEnvironment_AllValues(t *testing.T) {
 		"NOMAD_JOB_ID":                              a.Job.ID,
 		"NOMAD_JOB_NAME":                            "my-job",
 		"NOMAD_JOB_PARENT_ID":                       a.Job.ParentID,
-		"NOMAD_JOB_VERSION":                         strconv.FormatUint(a.Job.Version, 10),
+		"NOMAD_JOB_VERSION":                         "9152",
 		"NOMAD_ALLOC_ID":                            a.ID,
 		"NOMAD_ALLOC_INDEX":                         "0",
 		"NOMAD_PORT_connect_proxy_testconnect":      "9999",

--- a/website/content/docs/job-specification/artifact.mdx
+++ b/website/content/docs/job-specification/artifact.mdx
@@ -87,8 +87,9 @@ artifact {
   source = "https://example.com/file.txt"
 
   headers {
-    User-Agent    = "nomad-[${NOMAD_JOB_ID}]-[${NOMAD_GROUP_NAME}]-[${NOMAD_TASK_NAME}]"
-    X-Nomad-Alloc = "${NOMAD_ALLOC_ID}"
+    User-Agent          = "nomad-[${NOMAD_JOB_ID}]-[${NOMAD_GROUP_NAME}]-[${NOMAD_TASK_NAME}]"
+    X-Nomad-Alloc       = "${NOMAD_ALLOC_ID}"
+    X-Nomad-Job-Version = "${NOMAD_JOB_VERSION}"
   }
 }
 ```

--- a/website/content/docs/runtime/environment.mdx
+++ b/website/content/docs/runtime/environment.mdx
@@ -22,9 +22,9 @@ environment variable names such as `NOMAD_ADDR_<task>_<label>`.
 ## Task Identifiers
 
 Nomad will pass both the allocation ID and name, the deployment ID that created
-the allocation, the job ID and name, the parent job ID as well as
+the allocation, the job ID, name, version, the parent job ID as well as
 the task and group's names. These are given as `NOMAD_ALLOC_ID`, `NOMAD_ALLOC_NAME`,
-`NOMAD_ALLOC_INDEX`, `NOMAD_JOB_NAME`, `NOMAD_JOB_ID`,
+`NOMAD_ALLOC_INDEX`, `NOMAD_JOB_NAME`, `NOMAD_JOB_ID`, `NOMAD_JOB_VERSION`,
 `NOMAD_JOB_PARENT_ID`, `NOMAD_GROUP_NAME` and `NOMAD_TASK_NAME`. The allocation ID
 and index can be useful when the task being run needs a unique identifier or to
 know its instance count.

--- a/website/content/partials/envvars.mdx
+++ b/website/content/partials/envvars.mdx
@@ -111,6 +111,12 @@
     </tr>
     <tr>
       <td>
+        <code>NOMAD_JOB_VERSION</code>
+      </td>
+      <td>Job's version</td>
+    </tr>
+    <tr>
+      <td>
         <code>NOMAD_DC</code>
       </td>
       <td>Datacenter in which the allocation is running</td>


### PR DESCRIPTION
In order to facilitate the use of the job version in a task to support task group configurations like those mentioned in https://github.com/hashicorp/nomad/issues/8045#issuecomment-634004128, pass the version ID as `NOMAD_JOB_VERSION` in the task environment.