### PR TITLE
set Raft v3 as the default config

### DIFF
--- a/nomad/config.go
+++ b/nomad/config.go
@@ -446,8 +446,8 @@ func DefaultConfig() *Config {
 	// Disable shutdown on removal
 	c.RaftConfig.ShutdownOnRemove = false
 
-	// Default to Raft v2, update to v3 to enable new Raft and autopilot features.
-	c.RaftConfig.ProtocolVersion = 2
+	// Default to Raft v3 since Nomad 1.3
+	c.RaftConfig.ProtocolVersion = 3
 
 	return c
 }


### PR DESCRIPTION
The Raft version is being properly set in [`command/agent/config.go`](https://github.com/hashicorp/nomad/blob/main/command/agent/config.go#L974) so I don't think this was impacting anything, so the change is mostly for consistency.