### PR TITLE
CSI: fix handling of garbage collected node in node unpublish

### DIFF
--- a/.changelog/12350.txt
+++ b/.changelog/12350.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where garbage collected nodes would block releasing a volume
+```

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -1,9 +1,9 @@
 package nomad
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	metrics "github.com/armon/go-metrics"
@@ -741,7 +741,9 @@ func (v *CSIVolume) nodeUnpublishVolumeImpl(vol *structs.CSIVolume, claim *struc
 		// we should only get this error if the Nomad node disconnects and
 		// is garbage-collected, so at this point we don't have any reason
 		// to operate as though the volume is attached to it.
-		if !errors.Is(err, structs.ErrUnknownNode) {
+		// note: errors.Is cannot be used because the RPC call breaks
+		// error wrapping.
+		if !strings.Contains(err.Error(), structs.ErrUnknownNode.Error()) {
 			return fmt.Errorf("could not detach from node: %w", err)
 		}
 	}


### PR DESCRIPTION
Fixes #12346 (ref https://github.com/hashicorp/nomad/issues/12346#issuecomment-1075343830)

When a node is garbage collected, we assume that the volume is no
longer attached to it and ignore the `ErrUnknownNode` error. But we
used `errors.Is` to check for a wrapped error, and RPC flattens the
errors during serialization. This results in an error check that works
in automated testing but not in real clusters. Use a string contains
check instead.