### PR TITLE
CSI: fix timestamp from volume snapshot responses

### DIFF
--- a/.changelog/12352.txt
+++ b/.changelog/12352.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where volume snapshot timestamps were always zero values
+```

--- a/command/volume_snapshot_list.go
+++ b/command/volume_snapshot_list.go
@@ -186,7 +186,7 @@ func csiFormatSnapshots(snapshots []*api.CSISnapshot, verbose bool) string {
 			v.ID,
 			limit(v.ExternalSourceVolumeID, length),
 			humanize.IBytes(uint64(v.SizeBytes)),
-			formatUnixNanoTime(v.CreateTime),
+			formatUnixNanoTime(v.CreateTime*1000000000), // this time is in seconds
 			v.IsReady,
 		))
 	}

--- a/command/volume_snapshot_list.go
+++ b/command/volume_snapshot_list.go
@@ -186,7 +186,7 @@ func csiFormatSnapshots(snapshots []*api.CSISnapshot, verbose bool) string {
 			v.ID,
 			limit(v.ExternalSourceVolumeID, length),
 			humanize.IBytes(uint64(v.SizeBytes)),
-			formatUnixNanoTime(v.CreateTime*1000000000), // this time is in seconds
+			formatUnixNanoTime(v.CreateTime*1e9), // seconds to nanoseconds
 			v.IsReady,
 		))
 	}

--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ require (
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	google.golang.org/grpc v1.44.0
+	google.golang.org/protobuf v1.27.1
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 	gopkg.in/tomb.v2 v2.0.0-20140626144623-14b3d72120e8
 	oss.indeed.com/go/libtime v1.5.0
@@ -265,7 +266,6 @@ require (
 	google.golang.org/api v0.60.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20211104193956-4c6863e31247 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/resty.v1 v1.12.0 // indirect

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/acl"
@@ -1322,12 +1323,14 @@ func TestCSIVolumeEndpoint_CreateSnapshot(t *testing.T) {
 
 	testutil.WaitForLeader(t, srv.RPC)
 
+	now := time.Now().Unix()
 	fake := newMockClientCSI()
 	fake.NextCreateSnapshotError = nil
 	fake.NextCreateSnapshotResponse = &cstructs.ClientCSIControllerCreateSnapshotResponse{
 		ID:                     "snap-12345",
 		ExternalSourceVolumeID: "vol-12345",
 		SizeBytes:              42,
+		CreateTime:             now,
 		IsReady:                true,
 	}
 

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -788,7 +788,7 @@ func NewListSnapshotsResponse(resp *csipbv1.ListSnapshotsResponse) *ControllerLi
 					SizeBytes:      snap.GetSizeBytes(),
 					ID:             snap.GetSnapshotId(),
 					SourceVolumeID: snap.GetSourceVolumeId(),
-					CreateTime:     int64(snap.GetCreationTime().GetNanos()),
+					CreateTime:     snap.GetCreationTime().GetSeconds(),
 					IsReady:        snap.GetReadyToUse(),
 				},
 			})


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/10670

Listing snapshots was incorrectly returning nanoseconds instead of
seconds, and formatting of timestamps both list and create snapshot
was treating the timestamp as though it were nanoseconds instead of
seconds. This resulted in create timestamps always being displayed as
zero values.

Fix the unit conversion error in the command line and the incorrect
extraction in the CSI plugin client code. Beef up the unit tests to
make sure this code is actually exercised.

---

After this patch, the CLI outputs look like the following.

Listing snapshots. Note these sort the reverse way I'd expect and want, but we'll come back to that in a separate patch.

```
$ nomad volume snapshot list -plugin aws-ebs0 -per-page 5
Snapshot ID             Volume ID     Size     Create Time                Ready?
snap-08391e1d0fe151035  vol-ffffffff  8.0 GiB  2017-02-08T07:14:09-05:00  true
snap-0d67b4f5b5355ba43  vol-ffffffff  8.0 GiB  2017-02-03T14:52:02-05:00  true
snap-0a65a2caffea0382e  vol-ffffffff  8.0 GiB  2017-02-03T14:09:45-05:00  true
snap-046281ab24d756c50  vol-033ca269  8.0 GiB  2017-02-02T18:57:19-05:00  true
snap-00de7e12fd08987c4  vol-0bf7e5b6  8.0 GiB  2017-02-02T18:44:49-05:00  true
```

Creating a snapshot:

```
$ nomad volume create ./input/ebs-volume0.hcl
Created external volume vol-0c7afdbcfa7a9d715 with ID ebs-vol[0]

$ nomad volume snapshot create 'ebs-vol[0]' tim-test-snapshot2
Snapshot ID             Volume ID     Size    Create Time                Ready?
snap-01b2cfe069ef183aa  vol-0c7afdbc  10 GiB  2022-03-22T16:52:15-04:00  false
```
