### PR TITLE
CSI: add `-secret` and `-parameter` flags to `volume snapshot create`

### DIFF
--- a/.changelog/12360.txt
+++ b/.changelog/12360.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+csi: Added `-secret` and `-parameter` flags to `volume snapshot create` command
+```

--- a/api/csi.go
+++ b/api/csi.go
@@ -120,6 +120,10 @@ func (v *CSIVolumes) CreateSnapshot(snap *CSISnapshot, w *WriteOptions) (*CSISna
 	req := &CSISnapshotCreateRequest{
 		Snapshots: []*CSISnapshot{snap},
 	}
+	if w == nil {
+		w = &WriteOptions{}
+	}
+	w.SetHeadersFromCSISecrets(snap.Secrets)
 	resp := &CSISnapshotCreateResponse{}
 	meta, err := v.client.write("/v1/volumes/snapshot", req, resp, w)
 	return resp, meta, err

--- a/command/volume_snapshot_delete.go
+++ b/command/volume_snapshot_delete.go
@@ -77,7 +77,7 @@ func (c *VolumeSnapshotDeleteCommand) Run(args []string) int {
 	}
 	// Check that we get exactly two arguments
 	args = flags.Args()
-	if l := len(args); l != 2 {
+	if l := len(args); l < 2 {
 		c.Ui.Error("This command takes two arguments: <plugin id> <snapshot id>")
 		c.Ui.Error(commandErrorText(c))
 		return 1
@@ -97,6 +97,9 @@ func (c *VolumeSnapshotDeleteCommand) Run(args []string) int {
 		s := strings.Split(kv, "=")
 		if len(s) == 2 {
 			secrets[s[0]] = s[1]
+		} else {
+			c.Ui.Error("Secret must be in the format: -secret key=value")
+			return 1
 		}
 	}
 

--- a/command/volume_snapshot_list.go
+++ b/command/volume_snapshot_list.go
@@ -36,6 +36,12 @@ General Options:
 
 List Options:
 
+  -page-token
+    Where to start pagination.
+
+  -per-page
+    How many results to show per page. Defaults to 30.
+
   -plugin: Display only snapshots managed by a particular plugin. This
     parameter is required.
 
@@ -43,12 +49,10 @@ List Options:
     Secrets to pass to the plugin to list snapshots. Accepts multiple
     flags in the form -secret key=value
 
-  -per-page
-    How many results to show per page. Defaults to 30.
-
-  -page-token
-    Where to start pagination.
+  -verbose
+    Display full information for snapshots.
 `
+
 	return strings.TrimSpace(helpText)
 }
 
@@ -139,6 +143,9 @@ func (c *VolumeSnapshotListCommand) Run(args []string) int {
 		s := strings.Split(kv, "=")
 		if len(s) == 2 {
 			secrets[s[0]] = s[1]
+		} else {
+			c.Ui.Error("Secret must be in the format: -secret key=value")
+			return 1
 		}
 	}
 

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -1195,10 +1195,16 @@ func (v *CSIVolume) CreateSnapshot(args *structs.CSISnapshotCreateRequest, reply
 			continue
 		}
 
+		secrets := vol.Secrets
+		for k, v := range snap.Secrets {
+			// merge request secrets onto volume secrets
+			secrets[k] = v
+		}
+
 		cReq := &cstructs.ClientCSIControllerCreateSnapshotRequest{
 			ExternalSourceVolumeID: vol.ExternalID,
 			Name:                   snap.Name,
-			Secrets:                vol.Secrets,
+			Secrets:                secrets,
 			Parameters:             snap.Parameters,
 		}
 		cReq.PluginID = pluginID

--- a/website/content/docs/commands/volume/snapshot-create.mdx
+++ b/website/content/docs/commands/volume/snapshot-create.mdx
@@ -1,5 +1,6 @@
 ---
 layout: docs
+
 page_title: 'Commands: volume snapshot create'
 description: |
   Create external volume snapshots.
@@ -34,6 +35,16 @@ When ACLs are enabled, this command requires a token with the
 ## General Options
 
 @include 'general_options.mdx'
+
+## Snapshot Create Options
+
+- `-parameter`: Parameters to pass to the plugin to create a
+  snapshot. Accepts multiple flags in the form `-parameter key=value`
+
+- `-secret`: Secrets to pass to the plugin to create a snapshot. Accepts
+  multiple flags in the form `-secret key=value`
+
+- `-verbose`: Display full information for the resulting snapshot.
 
 ## Examples
 

--- a/website/content/docs/commands/volume/snapshot-list.mdx
+++ b/website/content/docs/commands/volume/snapshot-list.mdx
@@ -29,6 +29,8 @@ Nomad.
 
 ## Snapshot List Options
 
+- `-page-token`: Where to start pagination.
+- `-per-page`: How many results to show per page.
 - `-plugin`: Display only snapshots managed by a particular [CSI
   plugin][csi_plugin]. This flag is required and accepts a plugin ID
   or prefix. If there is an exact match based on the provided plugin,
@@ -36,8 +38,7 @@ Nomad.
   matching plugins will be displayed.
 - `-secret`: Secrets to pass to the plugin to list snapshots. Accepts
   multiple flags in the form `-secret key=value`
-- `-per-page`: How many results to show per page.
-- `-page-token`: Where to start pagination.
+- `-verbose`: Display full information for the resulting snapshot.
 
 When ACLs are enabled, this command requires a token with the
 `csi-list-volumes` capability for the plugin's namespace.


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/12318

Pass-through the `-secret` and `-parameter` flags to allow setting
parameters for the snapshot and overriding the secrets we've stored on
the CSI volume in the state store.