### PR TITLE
tests: fix rpc limit tests

### DIFF
--- a/nomad/rpc_test.go
+++ b/nomad/rpc_test.go
@@ -868,6 +868,12 @@ func TestRPC_Limits_OK(t *testing.T) {
 				}
 				c.RPCHandshakeTimeout = tc.timeout
 				c.RPCMaxConnsPerClient = tc.limit
+
+				// With Raft v3 Autopilot makes a lot of RPC requests to
+				// Status.RaftStats using the StatsFetcher. This makes it very
+				// likely that there will be a concurrent request that will
+				// mess with the request limit enforcer.
+				c.RaftConfig.ProtocolVersion = 2
 			})
 			defer func() {
 				cleanup()


### PR DESCRIPTION
Autopilot [makes a lot of requests to `Status.RaftStats`](https://github.com/hashicorp/nomad/blob/v1.2.6/nomad/stats_fetcher.go#L46) which end up affecting the connection limit enforcer. 

I couldn't find a way to stop it, or ignore these requests in the counter (the connection limiter [rejects the request](https://github.com/hashicorp/nomad/blob/v1.2.6/nomad/rpc.go#L135-L144) before we can read and figure out what method is being called), so I'm downgrading the Raft version for this test.

It may be worth investigating the impact of this in real clusters as the configured request limit may be off. I tried setting `c.RPCMaxConnsPerClient = tc.limit + 1` to account for the potential concurrent `Status.RaftStats` but that wasn't enough.