### PR TITLE
Add grpc and http2 listeners to gateway docs

### DIFF
--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -101,9 +101,8 @@ envoy_gateway_bind_addresses "<service>" {
 #### `listener` Parameters
 
 - `port` `(int: required)` - The port that the listener should receive traffic on.
-- `protocol` `(string: "tcp")` - 'The protocol associated with the listener. 
-   One of `tcp`, `http`, `http2`, or `grpc`.',
-  
+- `protocol` `(string: "tcp")` - The protocol associated with the listener. One
+  of `tcp`, `http`, `http2`, or `grpc`.
 
   ~> **Note:** If using `http`, preconfiguring a [service-default] in Consul to
   set the [Protocol](https://www.consul.io/docs/agent/config-entries/service-defaults#protocol)


### PR DESCRIPTION
Stating at Nomad version 1.2.0 `grpc` and `http2` protocols [are supported](https://github.com/hashicorp/nomad/pull/11187)

The change affects [gateway protocol docs](https://www.nomadproject.io/docs/job-specification/gateway#protocol)