### PR TITLE
core: write peers.json file with correct permissions

### DIFF
--- a/.changelog/12369.txt
+++ b/.changelog/12369.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Write peers.json file with correct permissions
+```

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1330,7 +1330,7 @@ func (s *Server) setupRaft() error {
 		peersFile := filepath.Join(path, "peers.json")
 		peersInfoFile := filepath.Join(path, "peers.info")
 		if _, err := os.Stat(peersInfoFile); os.IsNotExist(err) {
-			if err := ioutil.WriteFile(peersInfoFile, []byte(peersInfoContent), 0755); err != nil {
+			if err := ioutil.WriteFile(peersInfoFile, []byte(peersInfoContent), 0644); err != nil {
 				return fmt.Errorf("failed to write peers.info file: %v", err)
 			}
 


### PR DESCRIPTION
`0755` is common for directories, but `peers.json` is a file where we want `0644`. 