### PR TITLE
client: Add AWS EC2 instance-life-cycle from metadata to client fingerprint

### DIFF
--- a/.changelog/12371.txt
+++ b/.changelog/12371.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client: fingerprint AWS instance life cycle option
+```

--- a/client/fingerprint/env_aws.go
+++ b/client/fingerprint/env_aws.go
@@ -91,6 +91,7 @@ func (f *EnvAWSFingerprint) Fingerprint(request *FingerprintRequest, response *F
 		"ami-id":                      false,
 		"hostname":                    true,
 		"instance-id":                 true,
+		"instance-life-cycle":         false,
 		"instance-type":               false,
 		"local-hostname":              true,
 		"local-ipv4":                  true,

--- a/client/fingerprint/env_aws_test.go
+++ b/client/fingerprint/env_aws_test.go
@@ -52,6 +52,7 @@ func TestEnvAWSFingerprint_aws(t *testing.T) {
 		"platform.aws.ami-id",
 		"unique.platform.aws.hostname",
 		"unique.platform.aws.instance-id",
+		"platform.aws.instance-life-cycle",
 		"platform.aws.instance-type",
 		"unique.platform.aws.local-hostname",
 		"unique.platform.aws.local-ipv4",
@@ -335,6 +336,11 @@ var awsStubs = []endpoint{
 		Body:        "i-b3ba3875",
 	},
 	{
+		Uri:         "/latest/meta-data/instance-life-cycle",
+		ContentType: "text/plain",
+		Body:        "on-demand",
+	},
+	{
 		Uri:         "/latest/meta-data/instance-type",
 		ContentType: "text/plain",
 		Body:        "t3a.2xlarge",
@@ -388,6 +394,11 @@ var unknownInstanceType = []endpoint{
 		Body:        "i-b3ba3875",
 	},
 	{
+		Uri:         "/latest/meta-data/instance-life-cycle",
+		ContentType: "text/plain",
+		Body:        "on-demand",
+	},
+	{
 		Uri:         "/latest/meta-data/instance-type",
 		ContentType: "text/plain",
 		Body:        "xyz123.uber",
@@ -416,6 +427,11 @@ var noNetworkAWSStubs = []endpoint{
 		Uri:         "/latest/meta-data/instance-id",
 		ContentType: "text/plain",
 		Body:        "i-b3ba3875",
+	},
+	{
+		Uri:         "/latest/meta-data/instance-life-cycle",
+		ContentType: "text/plain",
+		Body:        "on-demand",
 	},
 	{
 		Uri:         "/latest/meta-data/instance-type",

--- a/website/content/docs/runtime/interpolation.mdx
+++ b/website/content/docs/runtime/interpolation.mdx
@@ -237,6 +237,12 @@ Below is a table documenting common node properties:
     </tr>
     <tr>
       <td>
+        <code>{'${attr.platform.aws.instance-life-cycle}'}</code>
+      </td>
+      <td>Instance lifecycle (e.g. spot, on-demand) of the client (if on AWS EC2)</td>
+    </tr>
+    <tr>
+      <td>
         <code>{'${attr.platform.aws.instance-type}'}</code>
       </td>
       <td>Instance type of the client (if on AWS EC2)</td>


### PR DESCRIPTION
The EC2 instance life cycle metadata allows jobs to add constraints or affinity stanzas with a preference for on-demand or spot requests. On AWS, this can be particularly useful for segmenting workloads based on risk tolerance of preemption.