### PR TITLE
E2E: test for allocations replacement on disconnected clients

### DIFF
--- a/e2e/disconnectedclients/disconnectedclients.go
+++ b/e2e/disconnectedclients/disconnectedclients.go
@@ -1,0 +1,138 @@
+package disconnectedclients
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/hashicorp/nomad/e2e/e2eutil"
+	"github.com/hashicorp/nomad/e2e/framework"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/testutil"
+)
+
+type DisconnectedClientsE2ETest struct {
+	framework.TC
+	jobIDs  []string
+	nodeIDs []string
+}
+
+const ns = ""
+
+func init() {
+	framework.AddSuites(&framework.TestSuite{
+		Component:   "DisconnectedClients",
+		CanRunLocal: true,
+		Cases: []framework.TestCase{
+			new(DisconnectedClientsE2ETest),
+		},
+	})
+
+}
+
+func (tc *DisconnectedClientsE2ETest) BeforeAll(f *framework.F) {
+	e2eutil.WaitForLeader(f.T(), tc.Nomad())
+	e2eutil.WaitForNodesReady(f.T(), tc.Nomad(), 2) // needs at least 2 to test replacement
+
+	nodeStatuses, err := e2eutil.NodeStatusList()
+	f.NoError(err)
+	for _, nodeStatus := range nodeStatuses {
+		tc.nodeIDs = append(tc.nodeIDs, nodeStatus["ID"])
+	}
+}
+
+func (tc *DisconnectedClientsE2ETest) AfterEach(f *framework.F) {
+	if os.Getenv("NOMAD_TEST_SKIPCLEANUP") == "1" {
+		return
+	}
+
+	for _, id := range tc.jobIDs {
+		_, err := e2eutil.Command("nomad", "job", "stop", "-purge", id)
+		f.Assert().NoError(err)
+	}
+	tc.jobIDs = []string{}
+
+	_, err := e2eutil.Command("nomad", "system", "gc")
+	f.Assert().NoError(err)
+
+	// make sure we've waited for all the nodes to come back up
+	e2eutil.WaitForNodesReady(f.T(), tc.Nomad(), len(tc.nodeIDs))
+}
+
+// TestDisconnectedClients_AllocReplacement tests that allocations on
+// disconnected clients are replaced
+func (tc *DisconnectedClientsE2ETest) TestDisconnectedClients_AllocReplacment(f *framework.F) {
+	jobID := "test-lost-allocs-" + uuid.Generate()[0:8]
+
+	f.NoError(e2eutil.Register(jobID, "disconnectedclients/input/lost_simple.nomad"))
+	tc.jobIDs = append(tc.jobIDs, jobID)
+	f.NoError(e2eutil.WaitForAllocStatusExpected(jobID, ns,
+		[]string{"running", "running"}), "job should be running")
+
+	// pick a node to make our lost node
+	allocs, err := e2eutil.AllocsForJob(jobID, ns)
+	f.NoError(err, "could not query allocs for job")
+	f.Len(allocs, 2, "could not find 2 allocs for job")
+
+	lostAlloc := allocs[0]
+	lostAllocID := lostAlloc["ID"]
+	disconnectedNodeID := lostAlloc["Node ID"]
+	otherAllocID := allocs[0]["ID"]
+
+	restartJobID, err := e2eutil.AgentRestartAfter(disconnectedNodeID, 30*time.Second)
+	f.NoError(err, "expected agent restart job to register")
+	tc.jobIDs = append(tc.jobIDs, restartJobID)
+
+	err = e2eutil.WaitForNodeStatus(disconnectedNodeID, "down", nil)
+	f.NoError(err, "expected node to go down")
+
+	err = waitForAllocStatusMap(jobID, map[string]string{
+		lostAllocID:  "lost",
+		otherAllocID: "running",
+		"":           "running",
+	}, &e2eutil.WaitConfig{Interval: time.Second, Retries: 60})
+	f.NoError(err, "expected alloc on disconnected client to be marked lost and replaced")
+
+	allocs, err = e2eutil.AllocsForJob(jobID, ns)
+	f.NoError(err, "could not query allocs for job")
+	f.Len(allocs, 3, "could not find 3 allocs for job")
+
+	err = e2eutil.WaitForNodeStatus(disconnectedNodeID, "ready", nil)
+	f.NoError(err, "expected node to come back up")
+
+	err = waitForAllocStatusMap(jobID, map[string]string{
+		lostAllocID:  "dead",
+		otherAllocID: "running",
+		"":           "running",
+	}, &e2eutil.WaitConfig{Interval: time.Second, Retries: 30})
+	f.NoError(err, "expected lost alloc on reconnected client to be marked dead and replaced")
+}
+
+func waitForAllocStatusMap(jobID string, allocsToStatus map[string]string, wc *e2eutil.WaitConfig) error {
+	var err error
+	interval, retries := wc.OrDefault()
+	testutil.WaitForResultRetries(retries, func() (bool, error) {
+		time.Sleep(interval)
+		allocs, err := e2eutil.AllocsForJob(jobID, ns)
+		if err != nil {
+			return false, err
+		}
+		for _, alloc := range allocs {
+			if expectedAllocStatus, ok := allocsToStatus[alloc["ID"]]; ok {
+				if alloc["Status"] != expectedAllocStatus {
+					return false, fmt.Errorf("expected status of alloc %q to be %q, got %q",
+						alloc["ID"], expectedAllocStatus, alloc["Status"])
+				}
+			} else {
+				if alloc["Status"] != allocsToStatus[""] {
+					return false, fmt.Errorf("expected status of alloc %q to be %q, got %q",
+						alloc["ID"], expectedAllocStatus, alloc["Status"])
+				}
+			}
+		}
+		return true, nil
+	}, func(e error) {
+		err = e
+	})
+	return err
+}

--- a/e2e/disconnectedclients/input/lost_simple.nomad
+++ b/e2e/disconnectedclients/input/lost_simple.nomad
@@ -1,0 +1,34 @@
+job "lost_simple" {
+
+  datacenters = ["dc1", "dc2"]
+
+  group "group" {
+
+    count = 2
+
+    constraint {
+      attribute = "${attr.kernel.name}"
+      value     = "linux"
+    }
+
+    constraint {
+      operator = "distinct_hosts"
+      value    = "true"
+    }
+
+    task "task" {
+      driver = "docker"
+
+      config {
+        image   = "busybox:1"
+        command = "httpd"
+        args    = ["-v", "-f", "-p", "8001", "-h", "/var/www"]
+      }
+
+      resources {
+        cpu    = 128
+        memory = 128
+      }
+    }
+  }
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/hashicorp/nomad/e2e/consultemplate"
 	_ "github.com/hashicorp/nomad/e2e/csi"
 	_ "github.com/hashicorp/nomad/e2e/deployment"
+	_ "github.com/hashicorp/nomad/e2e/disconnectedclients"
 	_ "github.com/hashicorp/nomad/e2e/eval_priority"
 	_ "github.com/hashicorp/nomad/e2e/events"
 	_ "github.com/hashicorp/nomad/e2e/example"

--- a/e2e/e2eutil/input/restart-node.nomad
+++ b/e2e/e2eutil/input/restart-node.nomad
@@ -1,0 +1,35 @@
+variable "nodeID" {
+  type = string
+}
+
+variable "time" {
+  type    = string
+  default = "0"
+}
+
+job "restart-node" {
+  type        = "batch"
+  datacenters = ["dc1", "dc2"]
+
+  group "group" {
+
+    constraint {
+      attribute = "${attr.kernel.name}"
+      value     = "linux"
+    }
+    constraint {
+      attribute = "${node.unique.id}"
+      value     = "${var.nodeID}"
+    }
+
+    task "task" {
+      driver = "raw_exec"
+      config {
+        command = "/bin/sh"
+        args = ["-c",
+        "systemctl stop nomad; sleep ${var.time}; systemctl start nomad"]
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
This test exercises the behavior of clients that become disconnected
and have their allocations replaced. Future test cases will exercise
the `max_client_disconnect` field on the job spec.

---

Example test run. I think we'll end up having to tune the timeouts on this a bit as we add more test cases; this is a naturally slow test because it takes a while for a node to get marked lost.

```
$ go test -v . -suite DisconnectedClients
=== RUN   TestE2E
...
=== RUN   TestE2E/DisconnectedClients
=== RUN   TestE2E/DisconnectedClients/*disconnectedclients.DisconnectedClientsE2ETest
=== RUN   TestE2E/DisconnectedClients/*disconnectedclients.DisconnectedClientsE2ETest/TestDisconnectedClients_AllocReplacment
...
--- PASS: TestE2E (42.85s)
...
    --- PASS: TestE2E/DisconnectedClients (42.85s)
        --- PASS: TestE2E/DisconnectedClients/*disconnectedclients.DisconnectedClientsE2ETest (42.77s)
            --- PASS: TestE2E/DisconnectedClients/*disconnectedclients.DisconnectedClientsE2ETest/TestDisconnectedClients_AllocReplacment (42.35s)
...
PASS
ok      github.com/hashicorp/nomad/e2e  43.599s
```