### PR TITLE
ci: set count to bypass caching

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -300,6 +300,7 @@ test-nomad: dev ## Run Nomad test suites
 		$(if $(ENABLE_RACE),-race) $(if $(VERBOSE),-v) \
 		-cover \
 		-timeout=20m \
+		-count=1 \
 		-tags "$(GO_TAGS)" \
 		$(GOTEST_PKGS)
 
@@ -310,6 +311,7 @@ test-nomad-module: dev ## Run Nomad test suites on a sub-module
 		$(if $(ENABLE_RACE),-race) $(if $(VERBOSE),-v) \
 		-cover \
 		-timeout=20m \
+		-count=1 \
 		-tags "$(GO_TAGS)" \
 		./...
 


### PR DESCRIPTION
This PR adds `-count=1` ([ticket](https://github.com/golang/go/issues/24573)) to the test commands in `test-nomad` and `test-nomad-module`, forcing tests to run. This is because in GHA the caching layer is causing tests not to run (because the results are cached) if
- the tests passed last time
- files in that package are not modified
- the cache is not otherwise invalidated (modify go.sum, expired)
