### PR TITLE
ci: cleanup verbose mode and enable for gha

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -20,6 +20,7 @@ on:
       - 'ui/*'
       - 'website/*'
 env:
+  VERBOSE: 1
   GO_VERSION: 1.17.7
   GOBIN: /usr/local/bin
   GOTESTARCH: amd64

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -301,10 +301,7 @@ test-nomad: dev ## Run Nomad test suites
 		-cover \
 		-timeout=20m \
 		-tags "$(GO_TAGS)" \
-		$(GOTEST_PKGS) $(if $(VERBOSE), >test.log ; echo $$? > exit-code)
-	@if [ $(VERBOSE) ] ; then \
-		bash -C "$(PROJECT_ROOT)/scripts/test_check.sh" ; \
-	fi
+		$(GOTEST_PKGS)
 
 .PHONY: test-nomad-module
 test-nomad-module: dev ## Run Nomad test suites on a sub-module
@@ -314,10 +311,7 @@ test-nomad-module: dev ## Run Nomad test suites on a sub-module
 		-cover \
 		-timeout=20m \
 		-tags "$(GO_TAGS)" \
-		./... $(if $(VERBOSE), >test.log ; echo $$? > exit-code)
-	@if [ $(VERBOSE) ] ; then \
-		bash -C "$(PROJECT_ROOT)/scripts/test_check.sh" ; \
-	fi
+		./...
 
 .PHONY: e2e-test
 e2e-test: dev ## Run the Nomad e2e test suite


### PR DESCRIPTION
test_checks.sh was removed in 2019 and now just breaks if VERBOSE is
set when running tests via make targets

in GHA, use verbose mode to display what tests are running
