### PR TITLE
ci: set test log level off in gha

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -27,7 +27,7 @@ env:
   CONSUL_VERSION: 1.11.3
   VAULT_VERSION: 1.9.3
   NOMAD_SLOW_TEST: 0
-  NOMAD_TEST_LOG_LEVEL: ERROR
+  NOMAD_TEST_LOG_LEVEL: OFF
 jobs:
   checks:
     runs-on: ubuntu-20.04

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -300,6 +300,7 @@ test-nomad: dev ## Run Nomad test suites
 		$(if $(ENABLE_RACE),-race) $(if $(VERBOSE),-v) \
 		-cover \
 		-timeout=20m \
+		-count=1 \
 		-tags "$(GO_TAGS)" \
 		$(GOTEST_PKGS)
 
@@ -310,6 +311,7 @@ test-nomad-module: dev ## Run Nomad test suites on a sub-module
 		$(if $(ENABLE_RACE),-race) $(if $(VERBOSE),-v) \
 		-cover \
 		-timeout=20m \
+		-count=1 \
 		-tags "$(GO_TAGS)" \
 		./...
 

--- a/command/agent/keyring_test.go
+++ b/command/agent/keyring_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper/testlog"
 )
 
 func TestAgent_LoadKeyrings(t *testing.T) {
@@ -29,9 +30,10 @@ func TestAgent_LoadKeyrings(t *testing.T) {
 
 	// Server should auto-load WAN keyring files
 	agent2 := &TestAgent{
-		T:    t,
-		Name: t.Name() + "2",
-		Key:  key,
+		T:      t,
+		Name:   t.Name() + "2",
+		Key:    key,
+		logger: testlog.HCLogger(t),
 	}
 	agent2.Start()
 	defer agent2.Shutdown()

--- a/command/agent/log_levels.go
+++ b/command/agent/log_levels.go
@@ -10,7 +10,7 @@ import (
 // levels that we use.
 func LevelFilter() *logutils.LevelFilter {
 	return &logutils.LevelFilter{
-		Levels:   []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"},
+		Levels:   []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF"},
 		MinLevel: "INFO",
 		Writer:   ioutil.Discard,
 	}


### PR DESCRIPTION
Many of our tests do terrible things, causing many log lines even at ERROR level. From CI all we really want is the normal `go test` output with the line number of the failure. `TestAgent` still needed some plumbing for `NOMAD_TEST_LOG_LEVEL` to take affect. 

includes https://github.com/hashicorp/nomad/pull/12379