### PR TITLE
E2E: test exercising node drain behavior for CSI volumes

### DIFF
--- a/e2e/terraform/Makefile
+++ b/e2e/terraform/Makefile
@@ -7,14 +7,14 @@ plan:
 	terraform plan \
 		-var="nomad_local_binary=$(PKG_PATH)" \
 		-var="volumes=false" \
-		-var="client_count_ubuntu_bionic_amd64=2" \
+		-var="client_count_ubuntu_bionic_amd64=4" \
 		-var="client_count_windows_2016_amd64=0"
 
 apply:
 	terraform apply -auto-approve \
 		-var="nomad_local_binary=$(PKG_PATH)" \
 		-var="volumes=false" \
-		-var="client_count_ubuntu_bionic_amd64=2" \
+		-var="client_count_ubuntu_bionic_amd64=4" \
 		-var="client_count_windows_2016_amd64=0"
 
 clean: destroy tidy
@@ -22,7 +22,7 @@ clean: destroy tidy
 destroy:
 	terraform destroy -auto-approve \
 		-var="nomad_local_binary=$(PKG_PATH)" \
-		-var="client_count_ubuntu_bionic_amd64=2" \
+		-var="client_count_ubuntu_bionic_amd64=4" \
 		-var="client_count_windows_2016_amd64=0"
 
 # deploy what's in E2E nightly

--- a/e2e/terraform/Makefile
+++ b/e2e/terraform/Makefile
@@ -7,14 +7,14 @@ plan:
 	terraform plan \
 		-var="nomad_local_binary=$(PKG_PATH)" \
 		-var="volumes=false" \
-		-var="client_count_ubuntu_bionic_amd64=4" \
+		-var="client_count_ubuntu_bionic_amd64=3" \
 		-var="client_count_windows_2016_amd64=0"
 
 apply:
 	terraform apply -auto-approve \
 		-var="nomad_local_binary=$(PKG_PATH)" \
 		-var="volumes=false" \
-		-var="client_count_ubuntu_bionic_amd64=4" \
+		-var="client_count_ubuntu_bionic_amd64=3" \
 		-var="client_count_windows_2016_amd64=0"
 
 clean: destroy tidy
@@ -22,7 +22,7 @@ clean: destroy tidy
 destroy:
 	terraform destroy -auto-approve \
 		-var="nomad_local_binary=$(PKG_PATH)" \
-		-var="client_count_ubuntu_bionic_amd64=4" \
+		-var="client_count_ubuntu_bionic_amd64=3" \
 		-var="client_count_windows_2016_amd64=0"
 
 # deploy what's in E2E nightly


### PR DESCRIPTION
Run a test on nightly that drains a node and ensures that the CSI volume is moved as expected. (This is still using the "framework-style" testing because I didn't want to rewrite the entire `e2e/csi` package just to land this. Will do that in a follow-up PR.)