### PR TITLE
E2E: namespace HCP vault and consul policies to avoid collisions

### DIFF
--- a/e2e/terraform/hcp_consul.tf
+++ b/e2e/terraform/hcp_consul.tf
@@ -11,7 +11,7 @@ data "hcp_consul_cluster" "e2e_shared_consul" {
 # policy and configuration for the Consul Agent
 
 resource "consul_acl_policy" "consul_agent" {
-  name        = "consul_agent_policy"
+  name        = "${local.random_name}_consul_agent_policy"
   datacenters = [var.hcp_consul_cluster_id]
   rules       = data.local_file.consul_policy_for_consul_agent.content
 }
@@ -65,7 +65,7 @@ resource "local_file" "consul_systemd_unit_file" {
 # Nomad servers configuration for Consul
 
 resource "consul_acl_policy" "nomad_servers" {
-  name        = "nomad_server_policy"
+  name        = "${local.random_name}_nomad_server_policy"
   datacenters = [var.hcp_consul_cluster_id]
   rules       = data.local_file.consul_policy_for_nomad_server.content
 }
@@ -97,7 +97,7 @@ resource "local_file" "nomad_server_config_for_consul" {
 # Nomad clients configuration for Consul
 
 resource "consul_acl_policy" "nomad_clients" {
-  name        = "nomad_client_policy"
+  name        = "${local.random_name}_nomad_client_policy"
   datacenters = [var.hcp_consul_cluster_id]
   rules       = data.local_file.consul_policy_for_nomad_clients.content
 }

--- a/e2e/terraform/hcp_vault.tf
+++ b/e2e/terraform/hcp_vault.tf
@@ -11,7 +11,7 @@ data "hcp_vault_cluster" "e2e_shared_vault" {
 # Nomad servers configuration for Vault
 
 resource "vault_policy" "nomad" {
-  name   = "nomad-server"
+  name   = "${local.random_name}-nomad-server"
   policy = data.local_file.vault_policy_for_nomad.content
 }
 


### PR DESCRIPTION
Concurrent E2E runs can collide when provisioning policies on HCP
Consul and HCP Vault. Namespace these by the test run name, as we do
for most everything else.

Errors on the runner look like so:

```
Error: error creating ACL policy: Unexpected response code: 500 (Invalid Policy: A Policy with Name "consul_agent_policy" already exists)

  on hcp_consul.tf line 13, in resource "consul_acl_policy" "consul_agent":
  13: resource "consul_acl_policy" "consul_agent" {
```