### PR TITLE
client: wait for create index when deriving vault token

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2586,8 +2586,9 @@ func (c *Client) deriveToken(alloc *structs.Allocation, taskNames []string, vcli
 		AllocID:  alloc.ID,
 		Tasks:    verifiedTasks,
 		QueryOptions: structs.QueryOptions{
-			Region:     c.Region(),
-			AllowStale: false,
+			Region:        c.Region(),
+			AllowStale:    false,
+			MinQueryIndex: alloc.CreateIndex,
 		},
 	}
 


### PR DESCRIPTION
Implemented originally for https://github.com/hashicorp/nomad/issues/12261 but this was reported not to fix their problem. However, it does appear to be a legitimate race that's possible to hit.