### PR TITLE
CSI: allow `namespace` field to be passed in volume spec

### DIFF
--- a/.changelog/12400.txt
+++ b/.changelog/12400.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+csi: allow namespace field to be passed in volume spec
+```

--- a/command/volume_init.go
+++ b/command/volume_init.go
@@ -110,6 +110,7 @@ func (c *VolumeInitCommand) Run(args []string) int {
 
 var defaultHclVolumeSpec = strings.TrimSpace(`
 id        = "ebs_prod_db1"
+namespace = "default"
 name      = "database"
 type      = "csi"
 plugin_id = "plugin_id"
@@ -183,6 +184,7 @@ context {
 var defaultJsonVolumeSpec = strings.TrimSpace(`
 {
   "id": "ebs_prod_db1",
+  "namespace": "default",
   "name": "database",
   "type": "csi",
   "plugin_id": "plugin_id",

--- a/command/volume_register_test.go
+++ b/command/volume_register_test.go
@@ -55,6 +55,7 @@ func TestCSIVolumeDecode(t *testing.T) {
 		name: "volume creation",
 		hcl: `
 id              = "testvolume"
+namespace       = "prod"
 name            = "test"
 type            = "csi"
 plugin_id       = "myplugin"
@@ -99,6 +100,7 @@ topology_request {
 `,
 		expected: &api.CSIVolume{
 			ID:                   "testvolume",
+			Namespace:            "prod",
 			Name:                 "test",
 			PluginID:             "myplugin",
 			SnapshotID:           "snap-12345",
@@ -136,6 +138,7 @@ topology_request {
 		name: "volume registration",
 		hcl: `
 id              = "testvolume"
+namespace       = "prod"
 external_id     = "vol-12345"
 name            = "test"
 type            = "csi"
@@ -162,6 +165,7 @@ topology_request {
 `,
 		expected: &api.CSIVolume{
 			ID:         "testvolume",
+			Namespace:  "prod",
 			ExternalID: "vol-12345",
 			Name:       "test",
 			PluginID:   "myplugin",

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -332,8 +332,6 @@ func (v *CSIVolume) Register(args *structs.CSIVolumeRegisterRequest, reply *stru
 		if err != nil {
 			return err
 		}
-		// TODO: allow volume spec file to set namespace
-		// https://github.com/hashicorp/nomad/issues/11196
 		if vol.Namespace == "" {
 			vol.Namespace = args.RequestNamespace()
 		}
@@ -921,7 +919,9 @@ func (v *CSIVolume) Create(args *structs.CSIVolumeCreateRequest, reply *structs.
 	// We also validate that the plugin exists for each plugin, and validate the
 	// capabilities when the plugin has a controller.
 	for _, vol := range args.Volumes {
-		vol.Namespace = args.RequestNamespace()
+		if vol.Namespace == "" {
+			vol.Namespace = args.RequestNamespace()
+		}
 		if err = vol.Validate(); err != nil {
 			return err
 		}

--- a/website/content/docs/commands/volume/create.mdx
+++ b/website/content/docs/commands/volume/create.mdx
@@ -37,6 +37,7 @@ The file may be provided as either HCL or JSON. An example HCL configuration:
 
 ```hcl
 id           = "ebs_prod_db1"
+namespace    = "default"
 name         = "database"
 type         = "csi"
 plugin_id    = "ebs-prod"
@@ -83,6 +84,10 @@ parameters {
 - `id` `(string: <required>)` - The unique ID of the volume. This is how the
   [`volume.source`][csi_volume_source] field in a job specification will refer
   to the volume.
+
+- `namespace` `(string: <optional>)` - The namespace of the volume. This field
+  overrides the namespace provided by the `-namespace` flag or `NOMAD_NAMESPACE`
+  environment variable. Defaults to `"default"` if unset.
 
 - `name` `(string: <required>)` - The display name of the volume. This field
   may be used by the external storage provider to tag the volume.

--- a/website/content/docs/commands/volume/register.mdx
+++ b/website/content/docs/commands/volume/register.mdx
@@ -87,6 +87,10 @@ context {
   [`volume.source`][csi_volume_source] field in a job specification will refer
   to the volume.
 
+- `namespace` `(string: <optional>)` - The namespace of the volume. This field
+  overrides the namespace provided by the `-namespace` flag or `NOMAD_NAMESPACE`
+  environment variable. Defaults to `"default"` if unset.
+
 - `name` `(string: <required>)` - The display name of the volume.
 
 - `type` `(string: <required>)` - The type of volume. Currently only `"csi"`


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11196.

Use the volume spec's `namespace` field to override the value of the
`-namespace` and `NOMAD_NAMESPACE` field, just as we do with job spec.