### PR TITLE
E2E disconnected clients test refactor

### DIFF
--- a/e2e/disconnectedclients/disconnectedclients_test.go
+++ b/e2e/disconnectedclients/disconnectedclients_test.go
@@ -67,7 +67,7 @@ func testDisconnected_AllocReplacementOnShutdown(t *testing.T) {
 	lostAlloc := allocs[0]
 	lostAllocID := lostAlloc["ID"]
 	disconnectedNodeID := lostAlloc["Node ID"]
-	otherAllocID := allocs[0]["ID"]
+	otherAllocID := allocs[1]["ID"]
 
 	restartJobID, err := e2eutil.AgentRestartAfter(disconnectedNodeID, 30*time.Second)
 	require.NoError(t, err, "expected agent restart job to register")
@@ -91,11 +91,11 @@ func testDisconnected_AllocReplacementOnShutdown(t *testing.T) {
 	require.NoError(t, err, "expected node to come back up")
 
 	err = waitForAllocStatusMap(jobID, map[string]string{
-		lostAllocID:  "dead",
+		lostAllocID:  "complete",
 		otherAllocID: "running",
 		"":           "running",
 	}, wait30s)
-	require.NoError(t, err, "expected lost alloc on reconnected client to be marked dead and replaced")
+	require.NoError(t, err, "expected lost alloc on reconnected client to be marked complete and replaced")
 }
 
 func waitForAllocStatusMap(jobID string, allocsToStatus map[string]string, wc *e2eutil.WaitConfig) error {

--- a/e2e/disconnectedclients/doc.go
+++ b/e2e/disconnectedclients/doc.go
@@ -1,0 +1,4 @@
+package disconnectedclients
+
+// This package contains only tests, so this is a placeholder file to
+// make sure builds don't fail with "no non-test Go files in" errors

--- a/e2e/e2eutil/node.go
+++ b/e2e/e2eutil/node.go
@@ -2,6 +2,8 @@ package e2eutil
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/hashicorp/nomad/api"
@@ -22,7 +24,20 @@ func AgentRestartAfter(nodeID string, after time.Duration) (string, error) {
 		vars = append(vars, "-var", fmt.Sprintf("time=%d", int(after.Seconds())))
 	}
 
-	err := RegisterWithArgs(jobID, "e2eutil/input/restart-node.nomad", vars...)
+	jobFilePath := "../e2eutil/input/restart-node.nomad"
+
+	// TODO: temporary hack around having older tests running on the
+	// framework vs new tests not, as the framework has a different
+	// working directory
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	if filepath.Base(dir) == "e2e" {
+		jobFilePath = "e2eutil/input/restart-node.nomad"
+	}
+
+	err = RegisterWithArgs(jobID, jobFilePath, vars...)
 	return jobID, err
 }
 


### PR DESCRIPTION
* Wait longer for the node to go down. The existing helper only waits 10s, 
  but there's a jitter on heartbeats that we need to account for. Wait for 30s 
  for node to go down to give us plenty of room

* Port the test to the stdlib style test as we did in https://github.com/hashicorp/nomad/pull/12383