### PR TITLE
tests: wait on client in a couple of tests

### DIFF
--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -410,7 +410,7 @@ func buildPathSlice(path string, files []string) []string {
 }
 
 func TestDebug_CapturedFiles(t *testing.T) {
-	// ci.Parallel(t)
+	ci.Parallel(t)
 	srv, _, url := testServer(t, true, nil)
 	testutil.WaitForLeader(t, srv.Agent.RPC)
 
@@ -418,6 +418,7 @@ func TestDebug_CapturedFiles(t *testing.T) {
 	region := srv.Config.Region
 	serverName := fmt.Sprintf("%s.%s", serverNodeName, region)
 	clientID := srv.Agent.Client().NodeID()
+	testutil.WaitForClient(t, srv.Agent.Client().RPC, clientID, srv.Agent.Client().Region())
 
 	t.Logf("serverName: %s, clientID, %s", serverName, clientID)
 

--- a/command/recommendation_list_test.go
+++ b/command/recommendation_list_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,6 +17,10 @@ func TestRecommendationListCommand_Run(t *testing.T) {
 	require := require.New(t)
 	srv, client, url := testServer(t, true, nil)
 	defer srv.Shutdown()
+
+	testutil.WaitForLeader(t, srv.Agent.RPC)
+	clientID := srv.Agent.Client().NodeID()
+	testutil.WaitForClient(t, srv.Agent.Client().RPC, clientID, srv.Agent.Client().Region())
 
 	ui := cli.NewMockUi()
 	cmd := &RecommendationListCommand{Meta: Meta{Ui: ui}}

--- a/command/service_delete_test.go
+++ b/command/service_delete_test.go
@@ -17,6 +17,11 @@ func TestServiceDeleteCommand_Run(t *testing.T) {
 	srv, client, url := testServer(t, true, nil)
 	defer srv.Shutdown()
 
+	// Wait for server and client to start
+	testutil.WaitForLeader(t, srv.Agent.RPC)
+	clientID := srv.Agent.Client().NodeID()
+	testutil.WaitForClient(t, srv.Agent.Client().RPC, clientID, srv.Agent.Client().Region())
+
 	// Wait until our test node is ready.
 	testutil.WaitForResult(func() (bool, error) {
 		nodes, _, err := client.Nodes().List(nil)


### PR DESCRIPTION
These tend to fail on GHA, where I believe the client is not
starting up fast enough before making requests. So wait on
the client agent first.

e.g.
```
=== RUN   TestDebug_CapturedFiles
    operator_debug_test.go:422: serverName: TestDebug_CapturedFiles.global, clientID, 1afb00e6-13f2-d8d6-d0f9-745a3fd6e8e4
    operator_debug_test.go:492:
        	Error Trace:	operator_debug_test.go:492
        	Error:      	Should be empty, but was No node(s) with prefix "1afb00e6-13f2-d8d6-d0f9-745a3fd6e8e4" found
        	            	Failed to retrieve clients, 0 nodes found in list: 1afb00e6-13f2-d8d6-d0f9-745a3fd6e8e4
        	Test:       	TestDebug_CapturedFiles
--- FAIL: TestDebug_CapturedFiles (0.08s)
```
