### PR TITLE
E2E: test for nodes disconnected by netsplit

### DIFF
--- a/e2e/disconnectedclients/disconnectedclients_test.go
+++ b/e2e/disconnectedclients/disconnectedclients_test.go
@@ -23,7 +23,8 @@ func TestDisconnectedClients(t *testing.T) {
 	e2eutil.WaitForLeader(t, nomad)
 	e2eutil.WaitForNodesReady(t, nomad, 2) // needs at least 2 to test replacement
 
-	t.Run("AllocReplacementOnShutdown", testDisconnected_AllocReplacementOnShutdown)
+	// TODO(tgross): this is broken till be merge the disconnected clients feature
+	// t.Run("AllocReplacementOnShutdown", testDisconnected_AllocReplacementOnShutdown)
 	t.Run("AllocReplacementOnNetsplit", testDisconnected_AllocReplacementOnNetsplit)
 }
 
@@ -153,7 +154,7 @@ func testDisconnected_AllocReplacementOnNetsplit(t *testing.T) {
 		lostAllocID:  "complete",
 		otherAllocID: "running",
 		"":           "running",
-	}, wait30s)
+	}, wait60s) // this needs quite a while, because at first it's marked running
 	require.NoError(t, err, "expected lost alloc on reconnected client to be marked complete and replaced")
 }
 
@@ -175,7 +176,7 @@ func waitForAllocStatusMap(jobID string, allocsToStatus map[string]string, wc *e
 			} else {
 				if alloc["Status"] != allocsToStatus[""] {
 					return false, fmt.Errorf("expected status of alloc %q to be %q, got %q",
-						alloc["ID"], expectedAllocStatus, alloc["Status"])
+						alloc["ID"], allocsToStatus[""], alloc["Status"])
 				}
 			}
 		}

--- a/e2e/disconnectedclients/disconnectedclients_test.go
+++ b/e2e/disconnectedclients/disconnectedclients_test.go
@@ -44,7 +44,7 @@ func TestDisconnectedClients(t *testing.T) {
 			jobFile:      "./input/lost_simple.nomad",
 			disconnectFn: e2eutil.AgentDisconnect,
 			expectedAfterDisconnect: expectedAllocStatus{
-				disconnected: "lost", // TODO: getting "complete"
+				disconnected: "lost",
 				unchanged:    "running",
 				replacement:  "running",
 			},
@@ -81,7 +81,7 @@ func TestDisconnectedClients(t *testing.T) {
 			jobFile:      "./input/lost_simple.nomad",
 			disconnectFn: e2eutil.AgentDisconnect,
 			expectedAfterDisconnect: expectedAllocStatus{
-				disconnected: "lost", // TODO: getting "complete"
+				disconnected: "lost",
 				unchanged:    "running",
 				replacement:  "running",
 			},

--- a/e2e/disconnectedclients/input/lost_max_disconnect.nomad
+++ b/e2e/disconnectedclients/input/lost_max_disconnect.nomad
@@ -1,0 +1,37 @@
+job "lost_max_disconnect" {
+
+  datacenters = ["dc1", "dc2"]
+
+  group "group" {
+
+    max_client_disconnect = "1h"
+
+    count = 2
+
+    constraint {
+      attribute = "${attr.kernel.name}"
+      value     = "linux"
+    }
+
+    constraint {
+      operator = "distinct_hosts"
+      value    = "true"
+    }
+
+    task "task" {
+      driver = "docker"
+
+      config {
+        image   = "busybox:1"
+        command = "httpd"
+        args    = ["-v", "-f", "-p", "8001", "-h", "/var/www"]
+      }
+
+      resources {
+        cpu    = 128
+        memory = 128
+      }
+    }
+  }
+
+}

--- a/e2e/e2eutil/input/disconnect-node.nomad
+++ b/e2e/e2eutil/input/disconnect-node.nomad
@@ -1,0 +1,35 @@
+variable "nodeID" {
+  type = string
+}
+
+variable "time" {
+  type    = string
+  default = "0"
+}
+
+job "disconnect-node" {
+  type        = "batch"
+  datacenters = ["dc1", "dc2"]
+
+  group "group" {
+
+    constraint {
+      attribute = "${attr.kernel.name}"
+      value     = "linux"
+    }
+    constraint {
+      attribute = "${node.unique.id}"
+      value     = "${var.nodeID}"
+    }
+
+    task "task" {
+      driver = "raw_exec"
+      config {
+        command = "/bin/sh"
+        args = ["-c",
+        "iptables -I OUTPUT -p tcp --dport 4647 -j DROP; sleep ${var.time}; iptables -D OUTPUT -p tcp --dport 4647 -j DROP"]
+      }
+    }
+
+  }
+}

--- a/e2e/e2eutil/input/disconnect-node.nomad
+++ b/e2e/e2eutil/input/disconnect-node.nomad
@@ -31,7 +31,10 @@ job "disconnect-node" {
       config {
         command = "/bin/sh"
         args = ["-c",
-        "iptables -I OUTPUT -p tcp --dport 4647 -j DROP; sleep ${var.time}; iptables -D OUTPUT -p tcp --dport 4647 -j DROP"]
+          # before disconnecting, we need to sleep long enough for the
+          # task to register itself, otherwise we end up trying to
+          # re-run the task immediately on reconnect
+        "sleep 5; iptables -I OUTPUT -p tcp --dport 4647 -j DROP; sleep ${var.time}; iptables -D OUTPUT -p tcp --dport 4647 -j DROP"]
       }
     }
 

--- a/e2e/e2eutil/input/disconnect-node.nomad
+++ b/e2e/e2eutil/input/disconnect-node.nomad
@@ -13,6 +13,10 @@ job "disconnect-node" {
 
   group "group" {
 
+    # need to prevent the task from being restarted on reconnect, if
+    # we're stopped long enough for the node to be marked down
+    max_client_disconnect = "1h"
+
     constraint {
       attribute = "${attr.kernel.name}"
       value     = "linux"

--- a/e2e/e2eutil/input/restart-node.nomad
+++ b/e2e/e2eutil/input/restart-node.nomad
@@ -31,7 +31,10 @@ job "restart-node" {
       config {
         command = "/bin/sh"
         args = ["-c",
-        "systemctl stop nomad; sleep ${var.time}; systemctl start nomad"]
+          # before disconnecting, we need to sleep long enough for the
+          # task to register itself, otherwise we end up trying to
+          # re-run the task immediately on reconnect
+        "sleep 5; systemctl stop nomad; sleep ${var.time}; systemctl start nomad"]
       }
     }
 

--- a/e2e/e2eutil/input/restart-node.nomad
+++ b/e2e/e2eutil/input/restart-node.nomad
@@ -13,6 +13,10 @@ job "restart-node" {
 
   group "group" {
 
+    # need to prevent the task from being restarted on reconnect, if
+    # we're stopped long enough for the node to be marked down
+    max_client_disconnect = "1h"
+
     constraint {
       attribute = "${attr.kernel.name}"
       value     = "linux"


### PR DESCRIPTION
Adds a matrix of 4 test scenarios: shutdown vs netsplit, and with `max_client_disconnect` vs not.
Blocked on https://github.com/hashicorp/nomad/pull/12529

---

```
$ go test -v ./disconnectedclients -count=1
=== RUN   TestDisconnectedClients
=== RUN   TestDisconnectedClients/netsplit_client_no_max_disconnect
    disconnectedclients_test.go:179: waiting for 4 nodes to become ready again
=== RUN   TestDisconnectedClients/netsplit_client_with_max_disconnect
    disconnectedclients_test.go:179: waiting for 4 nodes to become ready again
=== RUN   TestDisconnectedClients/shutdown_client_no_max_disconnect
    disconnectedclients_test.go:179: waiting for 4 nodes to become ready again
=== RUN   TestDisconnectedClients/shutdown_client_with_max_disconnect
    disconnectedclients_test.go:179: waiting for 4 nodes to become ready again
--- PASS: TestDisconnectedClients (189.49s)
    --- PASS: TestDisconnectedClients/netsplit_client_no_max_disconnect (47.66s)
    --- PASS: TestDisconnectedClients/netsplit_client_with_max_disconnect (44.19s)
    --- PASS: TestDisconnectedClients/shutdown_client_no_max_disconnect (47.53s)
    --- PASS: TestDisconnectedClients/shutdown_client_with_max_disconnect (49.90s)
PASS
ok      github.com/hashicorp/nomad/e2e/disconnectedclients      190.446s
```