### PR TITLE
Use cleanhttp.DefaultPooledTransport for the default API client

### DIFF
--- a/.changelog/12409.txt
+++ b/.changelog/12409.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: default to using DefaultPooledTransport client to support keep-alive by default
+```

--- a/api/api.go
+++ b/api/api.go
@@ -264,7 +264,7 @@ func (t *TLSConfig) Copy() *TLSConfig {
 }
 
 func defaultHttpClient() *http.Client {
-	httpClient := cleanhttp.DefaultClient()
+	httpClient := cleanhttp.DefaultPooledClient()
 	transport := httpClient.Transport.(*http.Transport)
 	transport.TLSHandshakeTimeout = 10 * time.Second
 	transport.TLSClientConfig = &tls.Config{


### PR DESCRIPTION
The only difference is DefaultTransport sets DisableKeepAlives

This doesn't make much sense to me - every http connection from the
nomad client goes to the same NOMAD_ADDR so it's a great case for keep
alive. Except round robin DNS and anycast perhaps.

Consul does this already
https://github.com/hashicorp/consul/blob/1e47e3c82b6eb937baab0688a67cf7ef334ce42c/api/api.go#L397