### PR TITLE
website: redirect /api to api-docs and update internal links

### DIFF
--- a/website/content/api-docs/allocations.mdx
+++ b/website/content/api-docs/allocations.mdx
@@ -762,8 +762,8 @@ It opens a WebSocket to transmit input to and output from the command.
 | `WebSocket` | `/v1/client/allocation/:alloc_id/exec` | WebSocket JSON streams |
 
 The table below shows this endpoint's support for
-[blocking queries](/api/index.html#blocking-queries) and
-[required ACLs](/api/index.html#acls).
+[blocking queries](/api-docs#blocking-queries) and
+[required ACLs](/api-docs#acls).
 
 | Blocking Queries | ACL Required                                                                                 |
 | ---------------- | -------------------------------------------------------------------------------------------- |

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -1,6 +1,5 @@
 const withHashicorp = require('@hashicorp/platform-nextjs-plugin')
 const redirects = require('./redirects')
-const rewrites = require('./rewrites')
 
 module.exports = withHashicorp({
   defaultLayout: true,
@@ -8,9 +7,6 @@ module.exports = withHashicorp({
 })({
   redirects() {
     return redirects
-  },
-  rewrites() {
-    return rewrites
   },
   svgo: {
     plugins: [

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1376,4 +1376,9 @@ module.exports = [
     destination: '/plugins/drivers/remote',
     permanent: true,
   },
+  {
+    source: '/api/:path*',
+    destination: '/api-docs/:path*',
+    permanent: true,
+  },
 ]

--- a/website/rewrites.js
+++ b/website/rewrites.js
@@ -1,1 +1,0 @@
-module.exports = [{ source: '/api/:splat*', destination: '/api-docs/:splat*' }]


### PR DESCRIPTION
Instead of rewriting /api to render /api-docs, update the route to redirect instead. This should reduce duplicated content across different pages and be a nice improvement for SEO.

[🔍  Preview](https://nomad-git-brkfeat-api-docs-rewrite-hashicorp.vercel.app/)