### PR TITLE
conditional class looking for currentEval equality

### DIFF
--- a/ui/app/templates/evaluations/index.hbs
+++ b/ui/app/templates/evaluations/index.hbs
@@ -42,6 +42,7 @@
           <tr
             data-test-evaluation="{{row.model.shortId}}"
             style="cursor: pointer;"
+            class="{{if (eq this.currentEval row.model.id) 'is-active'}}"
             {{on "click" (fn this.handleEvaluationClick row.model)}}
           >
             <td data-test-id>


### PR DESCRIPTION
This change establishes an `active` style to evaluations table rows when they're the subject of the current sidebar.

https://user-images.githubusercontent.com/713991/160969243-3c514d12-f2d0-400f-a197-f343c8c27fd1.mov

