### PR TITLE
Related Evaluations: don't show up as links, style as active.

### DIFF
--- a/ui/app/components/evaluation-sidebar/detail.hbs
+++ b/ui/app/components/evaluation-sidebar/detail.hbs
@@ -142,6 +142,7 @@
               height=this.height
               parentEvaluation=this.parentEvaluation
               descendentsMap=this.descendentsMap
+              activeEvaluationID=this.currentEvalDetail.id
             }}
           />
         {{else}}

--- a/ui/app/components/evaluation-sidebar/related-evaluations.hbs
+++ b/ui/app/components/evaluation-sidebar/related-evaluations.hbs
@@ -47,6 +47,7 @@
       <div>
         <EvaluationSidebar::EvaluationActor
           @eval={{@data.parentEvaluation}}
+          @activeEvaluationID={{@data.activeEvaluationID}}
           @onClick={{fn @fns.handleEvaluationClick @data.parentEvaluation}}
         />
       </div>
@@ -58,6 +59,7 @@
           {{#each evals as |eval|}}
             <EvaluationSidebar::EvaluationActor
               @eval={{eval.data}}
+              @activeEvaluationID={{@data.activeEvaluationID}}
               @onClick={{fn @fns.handleEvaluationClick eval.data}}
             />
           {{/each}}

--- a/ui/app/styles/components.scss
+++ b/ui/app/styles/components.scss
@@ -45,3 +45,4 @@
 @import './components/toolbar';
 @import './components/tooltip';
 @import './components/two-step-button';
+@import './components/evaluations';

--- a/ui/app/styles/components/evaluations.scss
+++ b/ui/app/styles/components/evaluations.scss
@@ -1,0 +1,5 @@
+.related-evaluation {
+  &.is-active {
+    background-color: whitesmoke;
+  }
+}

--- a/ui/app/templates/components/evaluation-sidebar/evaluation-actor.hbs
+++ b/ui/app/templates/components/evaluation-sidebar/evaluation-actor.hbs
@@ -1,5 +1,6 @@
 <Providers::ActorsRelationships as |actors|>
   <div
+    class="related-evaluation {{if (eq @eval.id @activeEvaluationID) 'is-active'}}"
     style="margin: 24px; outline: 1px solid #D9DEE6; padding: 10px; width: 100px;"
     data-eval={{@eval.id}}
     ...attributes
@@ -7,9 +8,15 @@
     {{will-destroy (fn actors.fns.deregisterActor @eval)}}
     {{! #F5F5F5 background for parent}}
   >
-    <a data-test-rel-eval={{@eval.id}} {{on "click" @onClick}}>
-      {{@eval.shortId}}
-    </a>
+    {{#if (eq @eval.id @activeEvaluationID)}}
+      <span>
+        {{@eval.shortId}}
+      </span>
+    {{else}}
+      <a data-test-rel-eval={{@eval.id}} {{on "click" @onClick}}>
+        {{@eval.shortId}}
+      </a>
+    {{/if}}
     <span>
       <StatusCell @status={{@eval.status}} />
     </span>


### PR DESCRIPTION
Side-effect: new component style file (evaluations.scss). If we like this, we should move some of our inline style here.

![image](https://user-images.githubusercontent.com/713991/161149244-e9f58a31-dbe4-407a-8121-a3743f75db1f.png)
