### PR TITLE
Test lint touchup

### DIFF
--- a/nomad/volumewatcher/volumes_watcher_test.go
+++ b/nomad/volumewatcher/volumes_watcher_test.go
@@ -17,7 +17,6 @@ import (
 // to happen during leader step-up/step-down
 func TestVolumeWatch_EnableDisable(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 
 	srv := &MockRPCServer{}
 	srv.state = state.TestStateStore(t)
@@ -34,7 +33,7 @@ func TestVolumeWatch_EnableDisable(t *testing.T) {
 
 	index++
 	err := srv.State().UpsertCSIVolume(index, []*structs.CSIVolume{vol})
-	require.NoError(err)
+	require.NoError(t, err)
 
 	claim := &structs.CSIVolumeClaim{
 		Mode:  structs.CSIVolumeClaimGC,
@@ -42,22 +41,21 @@ func TestVolumeWatch_EnableDisable(t *testing.T) {
 	}
 	index++
 	err = srv.State().CSIVolumeClaim(index, vol.Namespace, vol.ID, claim)
-	require.NoError(err)
-	require.Eventually(func() bool {
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
 		watcher.wlock.RLock()
 		defer watcher.wlock.RUnlock()
 		return 1 == len(watcher.watchers)
 	}, time.Second, 10*time.Millisecond)
 
 	watcher.SetEnabled(false, nil, "")
-	require.Equal(0, len(watcher.watchers))
+	require.Equal(t, 0, len(watcher.watchers))
 }
 
 // TestVolumeWatch_LeadershipTransition tests the correct behavior of
 // claim reaping across leader step-up/step-down
 func TestVolumeWatch_LeadershipTransition(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 
 	srv := &MockRPCServer{}
 	srv.state = state.TestStateStore(t)
@@ -74,25 +72,25 @@ func TestVolumeWatch_LeadershipTransition(t *testing.T) {
 	index++
 	err := srv.State().UpsertAllocs(structs.MsgTypeTestSetup, index,
 		[]*structs.Allocation{alloc})
-	require.NoError(err)
+	require.NoError(t, err)
 
 	watcher.SetEnabled(true, srv.State(), "")
 
 	index++
 	err = srv.State().UpsertCSIVolume(index, []*structs.CSIVolume{vol})
-	require.NoError(err)
+	require.NoError(t, err)
 
 	// we should get or start up a watcher when we get an update for
 	// the volume from the state store
-	require.Eventually(func() bool {
+	require.Eventually(t, func() bool {
 		watcher.wlock.RLock()
 		defer watcher.wlock.RUnlock()
 		return 1 == len(watcher.watchers)
 	}, time.Second, 10*time.Millisecond)
 
 	vol, _ = srv.State().CSIVolumeByID(nil, vol.Namespace, vol.ID)
-	require.Len(vol.PastClaims, 0, "expected to have 0 PastClaims")
-	require.Equal(srv.countCSIUnpublish, 0, "expected no CSI.Unpublish RPC calls")
+	require.Len(t, vol.PastClaims, 0, "expected to have 0 PastClaims")
+	require.Equal(t, srv.countCSIUnpublish, 0, "expected no CSI.Unpublish RPC calls")
 
 	// trying to test a dropped watch is racy, so to reliably simulate
 	// this condition, step-down the watcher first and then perform
@@ -101,12 +99,12 @@ func TestVolumeWatch_LeadershipTransition(t *testing.T) {
 
 	// step-down (this is sync)
 	watcher.SetEnabled(false, nil, "")
-	require.Equal(0, len(watcher.watchers))
+	require.Equal(t, 0, len(watcher.watchers))
 
 	// allocation is now invalid
 	index++
 	err = srv.State().DeleteEval(index, []string{}, []string{alloc.ID})
-	require.NoError(err)
+	require.NoError(t, err)
 
 	// emit a GC so that we have a volume change that's dropped
 	claim := &structs.CSIVolumeClaim{
@@ -117,14 +115,14 @@ func TestVolumeWatch_LeadershipTransition(t *testing.T) {
 	}
 	index++
 	err = srv.State().CSIVolumeClaim(index, vol.Namespace, vol.ID, claim)
-	require.NoError(err)
+	require.NoError(t, err)
 
 	// create a new watcher and enable it to simulate the leadership
 	// transition
 	watcher = NewVolumesWatcher(testlog.HCLogger(t), srv, "")
 	watcher.SetEnabled(true, srv.State(), "")
 
-	require.Eventually(func() bool {
+	require.Eventually(t, func() bool {
 		watcher.wlock.RLock()
 		defer watcher.wlock.RUnlock()
 
@@ -133,15 +131,14 @@ func TestVolumeWatch_LeadershipTransition(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 
 	vol, _ = srv.State().CSIVolumeByID(nil, vol.Namespace, vol.ID)
-	require.Len(vol.PastClaims, 1, "expected to have 1 PastClaim")
-	require.Equal(srv.countCSIUnpublish, 1, "expected CSI.Unpublish RPC to be called")
+	require.Len(t, vol.PastClaims, 1, "expected to have 1 PastClaim")
+	require.Equal(t, srv.countCSIUnpublish, 1, "expected CSI.Unpublish RPC to be called")
 }
 
 // TestVolumeWatch_StartStop tests the start and stop of the watcher when
 // it receives notifcations and has completed its work
 func TestVolumeWatch_StartStop(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 
 	srv := &MockStatefulRPCServer{}
 	srv.state = state.TestStateStore(t)
@@ -149,7 +146,7 @@ func TestVolumeWatch_StartStop(t *testing.T) {
 	watcher := NewVolumesWatcher(testlog.HCLogger(t), srv, "")
 
 	watcher.SetEnabled(true, srv.State(), "")
-	require.Equal(0, len(watcher.watchers))
+	require.Equal(t, 0, len(watcher.watchers))
 
 	plugin := mock.CSIPlugin()
 	node := testNode(plugin, srv.State())
@@ -160,19 +157,19 @@ func TestVolumeWatch_StartStop(t *testing.T) {
 	alloc2.ClientStatus = structs.AllocClientStatusRunning
 	index++
 	err := srv.State().UpsertJob(structs.MsgTypeTestSetup, index, alloc1.Job)
-	require.NoError(err)
+	require.NoError(t, err)
 	index++
 	err = srv.State().UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc1, alloc2})
-	require.NoError(err)
+	require.NoError(t, err)
 
 	// register a volume
 	vol := testVolume(plugin, alloc1, node.ID)
 	index++
 	err = srv.State().UpsertCSIVolume(index, []*structs.CSIVolume{vol})
-	require.NoError(err)
+	require.NoError(t, err)
 
 	// assert we get a watcher; there are no claims so it should immediately stop
-	require.Eventually(func() bool {
+	require.Eventually(t, func() bool {
 		watcher.wlock.RLock()
 		defer watcher.wlock.RUnlock()
 		return 1 == len(watcher.watchers) &&
@@ -189,11 +186,11 @@ func TestVolumeWatch_StartStop(t *testing.T) {
 
 	index++
 	err = srv.State().CSIVolumeClaim(index, vol.Namespace, vol.ID, claim)
-	require.NoError(err)
+	require.NoError(t, err)
 	claim.AllocationID = alloc2.ID
 	index++
 	err = srv.State().CSIVolumeClaim(index, vol.Namespace, vol.ID, claim)
-	require.NoError(err)
+	require.NoError(t, err)
 
 	// reap the volume and assert nothing has happened
 	claim = &structs.CSIVolumeClaim{
@@ -202,30 +199,30 @@ func TestVolumeWatch_StartStop(t *testing.T) {
 	}
 	index++
 	err = srv.State().CSIVolumeClaim(index, vol.Namespace, vol.ID, claim)
-	require.NoError(err)
+	require.NoError(t, err)
 
 	ws := memdb.NewWatchSet()
 	vol, _ = srv.State().CSIVolumeByID(ws, vol.Namespace, vol.ID)
-	require.Equal(2, len(vol.ReadAllocs))
+	require.Equal(t, 2, len(vol.ReadAllocs))
 
 	// alloc becomes terminal
 	alloc1.ClientStatus = structs.AllocClientStatusComplete
 	index++
 	err = srv.State().UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc1})
-	require.NoError(err)
+	require.NoError(t, err)
 	index++
 	claim.State = structs.CSIVolumeClaimStateReadyToFree
 	err = srv.State().CSIVolumeClaim(index, vol.Namespace, vol.ID, claim)
-	require.NoError(err)
+	require.NoError(t, err)
 
 	// 1 claim has been released and watcher stops
-	require.Eventually(func() bool {
+	require.Eventually(t, func() bool {
 		ws := memdb.NewWatchSet()
 		vol, _ := srv.State().CSIVolumeByID(ws, vol.Namespace, vol.ID)
 		return len(vol.ReadAllocs) == 1 && len(vol.PastClaims) == 0
 	}, time.Second*2, 10*time.Millisecond)
 
-	require.Eventually(func() bool {
+	require.Eventually(t, func() bool {
 		watcher.wlock.RLock()
 		defer watcher.wlock.RUnlock()
 		return !watcher.watchers[vol.ID+vol.Namespace].isRunning()
@@ -236,7 +233,6 @@ func TestVolumeWatch_StartStop(t *testing.T) {
 // watchers around registration
 func TestVolumeWatch_RegisterDeregister(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 
 	srv := &MockStatefulRPCServer{}
 	srv.state = state.TestStateStore(t)
@@ -246,7 +242,7 @@ func TestVolumeWatch_RegisterDeregister(t *testing.T) {
 	watcher := NewVolumesWatcher(testlog.HCLogger(t), srv, "")
 
 	watcher.SetEnabled(true, srv.State(), "")
-	require.Equal(0, len(watcher.watchers))
+	require.Equal(t, 0, len(watcher.watchers))
 
 	plugin := mock.CSIPlugin()
 	alloc := mock.Alloc()
@@ -256,14 +252,14 @@ func TestVolumeWatch_RegisterDeregister(t *testing.T) {
 	vol := mock.CSIVolume(plugin)
 	index++
 	err := srv.State().UpsertCSIVolume(index, []*structs.CSIVolume{vol})
-	require.NoError(err)
+	require.NoError(t, err)
 
 	// watcher should be started but immediately stopped
-	require.Eventually(func() bool {
+	require.Eventually(t, func() bool {
 		watcher.wlock.RLock()
 		defer watcher.wlock.RUnlock()
 		return 1 == len(watcher.watchers)
 	}, time.Second, 10*time.Millisecond)
 
-	require.False(watcher.watchers[vol.ID+vol.Namespace].isRunning())
+	require.False(t, watcher.watchers[vol.ID+vol.Namespace].isRunning())
 }


### PR DESCRIPTION
I have a gnarly PR coming up that's touching both these files, so I want to split out the `require` fixes and removing the `state` aliasing into their own PR so as not to scare-off reviewers with a large changeset.