### PR TITLE
cleanup: purge github.com/pkg/errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,8 +59,9 @@ linters-settings:
     # disallow packages from being used
     list-type: blacklist
     packages:
-      - github.com/hashicorp/consul/command/flags
       - github.com/boltdb/bolt
+      - github.com/hashicorp/consul/command/flags
+      - github.com/pkg/errors
   gocritic:
     disabled-checks:
       - commentFormatting

--- a/client/allocrunner/consul_grpc_sock_hook.go
+++ b/client/allocrunner/consul_grpc_sock_hook.go
@@ -2,6 +2,7 @@ package allocrunner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -11,12 +12,11 @@ import (
 	"sync"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/client/allocrunner/csi_hook_test.go
+++ b/client/allocrunner/csi_hook_test.go
@@ -2,15 +2,13 @@ package allocrunner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/nomad/ci"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
-
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/client/pluginmanager"
 	"github.com/hashicorp/nomad/client/pluginmanager/csimanager"
@@ -20,6 +18,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/stretchr/testify/require"
 )
 
 var _ interfaces.RunnerPrerunHook = (*csiHook)(nil)

--- a/client/allocrunner/taskrunner/envoy_version_hook.go
+++ b/client/allocrunner/taskrunner/envoy_version_hook.go
@@ -2,6 +2,7 @@ package taskrunner
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/go-hclog"
@@ -11,7 +12,6 @@ import (
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/helper/envoy"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -81,7 +81,7 @@ func (h *envoyVersionHook) Prestart(_ context.Context, request *ifs.TaskPrestart
 	// to the legacy default. Query Consul and use the (possibly empty) result.
 	proxies, err := h.proxiesClient.Proxies()
 	if err != nil {
-		return errors.Wrap(err, "error retrieving supported Envoy versions from Consul")
+		return fmt.Errorf("error retrieving supported Envoy versions from Consul: %w", err)
 	}
 
 	// Second [pseudo] interpolation of task image. This determines the concrete
@@ -89,7 +89,7 @@ func (h *envoyVersionHook) Prestart(_ context.Context, request *ifs.TaskPrestart
 	// ${NOMAD_envoy_version} acquired from Consul.
 	image, err := h.tweakImage(h.taskImage(request.Task.Config), proxies)
 	if err != nil {
-		return errors.Wrap(err, "error interpreting desired Envoy version from Consul")
+		return fmt.Errorf("error interpreting desired Envoy version from Consul: %w", err)
 	}
 
 	// Set the resulting image.
@@ -187,7 +187,7 @@ func (h *envoyVersionHook) tweakImage(configured string, supported map[string][]
 func semver(chosen string) (string, error) {
 	v, err := version.NewVersion(chosen)
 	if err != nil {
-		return "", errors.Wrap(err, "unexpected envoy version format")
+		return "", fmt.Errorf("unexpected envoy version format: %w", err)
 	}
 	return v.String(), nil
 }

--- a/client/allocrunner/taskrunner/envoy_version_hook_test.go
+++ b/client/allocrunner/taskrunner/envoy_version_hook_test.go
@@ -2,6 +2,7 @@ package taskrunner
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
@@ -13,7 +14,6 @@ import (
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 

--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -19,11 +20,6 @@ import (
 	"github.com/hashicorp/consul/lib"
 	hclog "github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/nomad/helper/envoy"
-	vaultapi "github.com/hashicorp/vault/api"
-	"github.com/pkg/errors"
-	"github.com/shirou/gopsutil/v3/host"
-
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/allocrunner"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
@@ -48,6 +44,7 @@ import (
 	"github.com/hashicorp/nomad/client/vaultclient"
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/envoy"
 	"github.com/hashicorp/nomad/helper/pool"
 	hstats "github.com/hashicorp/nomad/helper/stats"
 	"github.com/hashicorp/nomad/helper/tlsutil"
@@ -57,6 +54,8 @@ import (
 	"github.com/hashicorp/nomad/plugins/csi"
 	"github.com/hashicorp/nomad/plugins/device"
 	"github.com/hashicorp/nomad/plugins/drivers"
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/shirou/gopsutil/v3/host"
 )
 
 const (
@@ -536,7 +535,7 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 	}
 
 	if err := c.setupConsulTokenClient(); err != nil {
-		return nil, errors.Wrap(err, "failed to setup consul tokens client")
+		return nil, fmt.Errorf("failed to setup consul tokens client: %w", err)
 	}
 
 	// Setup the vault client for token and secret renewals

--- a/command/volume_snapshot_list.go
+++ b/command/volume_snapshot_list.go
@@ -1,17 +1,17 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"sort"
 	"strings"
 
-	humanize "github.com/dustin/go-humanize"
+	"github.com/dustin/go-humanize"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	flaghelper "github.com/hashicorp/nomad/helper/flags"
-	"github.com/pkg/errors"
 	"github.com/posener/complete"
 )
 

--- a/drivers/docker/win32_volume_parse.go
+++ b/drivers/docker/win32_volume_parse.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // This code is taken from github.com/docker/volume/mounts/windows_parser.go
@@ -73,7 +71,7 @@ const (
 )
 
 func errInvalidSpec(spec string) error {
-	return errors.Errorf("invalid volume specification: '%s'", spec)
+	return fmt.Errorf("invalid volume specification: '%s'", spec)
 }
 
 type fileInfoProvider interface {

--- a/e2e/consulacls/manage.go
+++ b/e2e/consulacls/manage.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,11 +83,11 @@ func extractSerial(filename string) (int, error) {
 	}
 	b, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to extract TF serial")
+		return 0, fmt.Errorf("failed to extract TF serial: %w", err)
 	}
 	var state tfState
 	if err := json.Unmarshal(b, &state); err != nil {
-		return 0, errors.Wrap(err, "failed to extract TF serial")
+		return 0, fmt.Errorf("failed to extract TF serial: %w", err)
 	}
 	return state.Serial, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,6 @@ require (
 	github.com/moby/sys/mountinfo v0.6.0
 	github.com/opencontainers/runc v1.0.3
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
-	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.3
 	github.com/prometheus/client_golang v1.12.0
 	github.com/prometheus/common v0.32.1
@@ -236,6 +235,7 @@ require (
 	github.com/opencontainers/selinux v1.10.0 // indirect
 	github.com/packethost/packngo v0.1.1-0.20180711074735-b9cb5096f54c // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/nomad/consul.go
+++ b/nomad/consul.go
@@ -2,6 +2,7 @@ package nomad
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -13,7 +14,6 @@ import (
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
 )
@@ -195,7 +195,7 @@ func (c *consulACLsAPI) readToken(ctx context.Context, secretID string) (*api.AC
 
 	// Ensure we are under our rate limit.
 	if err := c.limiter.Wait(ctx); err != nil {
-		return nil, errors.Wrap(err, "unable to read consul token")
+		return nil, fmt.Errorf("unable to read consul token: %w", err)
 	}
 
 	consulToken, _, err := c.aclClient.TokenReadSelf(&api.QueryOptions{
@@ -203,7 +203,7 @@ func (c *consulACLsAPI) readToken(ctx context.Context, secretID string) (*api.AC
 		Token:      secretID,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to read consul token")
+		return nil, fmt.Errorf("unable to read consul token: %w", err)
 	}
 
 	return consulToken, nil
@@ -248,7 +248,7 @@ func (c *consulACLsAPI) CheckPermissions(ctx context.Context, namespace string, 
 		if err != nil {
 			return err
 		} else if !allowable {
-			return errors.Errorf("insufficient Consul ACL permissions to write service %q", service)
+			return fmt.Errorf("insufficient Consul ACL permissions to write service %q", service)
 		}
 	}
 
@@ -259,7 +259,7 @@ func (c *consulACLsAPI) CheckPermissions(ctx context.Context, namespace string, 
 		if err != nil {
 			return err
 		} else if !allowable {
-			return errors.Errorf("insufficient Consul ACL permissions to write Connect service %q", service)
+			return fmt.Errorf("insufficient Consul ACL permissions to write Connect service %q", service)
 		}
 	}
 
@@ -389,9 +389,9 @@ func (c *consulACLsAPI) parallelRevoke(ctx context.Context, accessors []*structs
 						return nil
 					}
 					if err := c.singleRevoke(ctx, accessor); err != nil {
-						return errors.Wrapf(err,
-							"failed to revoke SI token accessor (alloc %q, node %q, task %q)",
-							accessor.AllocID, accessor.NodeID, accessor.TaskName,
+						return fmt.Errorf(
+							"failed to revoke SI token accessor (alloc %q, node %q, task %q): %w",
+							accessor.AllocID, accessor.NodeID, accessor.TaskName, err,
 						)
 					}
 				case <-pCtx.Done():

--- a/nomad/consul_policy.go
+++ b/nomad/consul_policy.go
@@ -1,11 +1,11 @@
 package nomad
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/hcl"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -44,7 +44,7 @@ type ConsulPolicy struct {
 func parseConsulPolicy(s string) (*ConsulPolicy, error) {
 	cp := new(ConsulPolicy)
 	if err := hcl.Decode(cp, s); err != nil {
-		return nil, errors.Wrap(err, "failed to parse ACL policy")
+		return nil, fmt.Errorf("failed to parse ACL policy: %w", err)
 	}
 	return cp, nil
 }
@@ -98,10 +98,10 @@ func namespaceCheck(namespace string, token *api.ACLToken) error {
 	case namespace == "" && token.Namespace != "default":
 		// ACLs enabled with non-default token, but namespace on job not set, so
 		// provide a more informative error message.
-		return errors.Errorf("consul ACL token requires using namespace %q", token.Namespace)
+		return fmt.Errorf("consul ACL token requires using namespace %q", token.Namespace)
 
 	default:
-		return errors.Errorf("consul ACL token cannot use namespace %q", namespace)
+		return fmt.Errorf("consul ACL token cannot use namespace %q", namespace)
 	}
 }
 

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	metrics "github.com/armon/go-metrics"
-	log "github.com/hashicorp/go-hclog"
-	memdb "github.com/hashicorp/go-memdb"
+	"github.com/armon/go-metrics"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler"
 	"github.com/hashicorp/raft"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -80,7 +79,7 @@ type nomadFSM struct {
 	evalBroker         *EvalBroker
 	blockedEvals       *BlockedEvals
 	periodicDispatcher *PeriodicDispatch
-	logger             log.Logger
+	logger             hclog.Logger
 	state              *state.StateStore
 	timetable          *TimeTable
 
@@ -126,7 +125,7 @@ type FSMConfig struct {
 	Blocked *BlockedEvals
 
 	// Logger is the logger used by the FSM
-	Logger log.Logger
+	Logger hclog.Logger
 
 	// Region is the region of the server embedding the FSM
 	Region string
@@ -975,7 +974,7 @@ func (n *nomadFSM) applyUpsertSIAccessor(buf []byte, index uint64) interface{} {
 	defer metrics.MeasureSince([]string{"nomad", "fsm", "upsert_si_accessor"}, time.Now())
 	var request structs.SITokenAccessorsRequest
 	if err := structs.Decode(buf, &request); err != nil {
-		panic(errors.Wrap(err, "failed to decode request"))
+		panic(fmt.Errorf("failed to decode request: %w", err))
 	}
 
 	if err := n.state.UpsertSITokenAccessors(index, request.Accessors); err != nil {
@@ -990,7 +989,7 @@ func (n *nomadFSM) applyDeregisterSIAccessor(buf []byte, index uint64) interface
 	defer metrics.MeasureSince([]string{"nomad", "fsm", "deregister_si_accessor"}, time.Now())
 	var request structs.SITokenAccessorsRequest
 	if err := structs.Decode(buf, &request); err != nil {
-		panic(errors.Wrap(err, "failed to decode request"))
+		panic(fmt.Errorf("failed to decode request: %w", err))
 	}
 
 	if err := n.state.DeleteSITokenAccessors(index, request.Accessors); err != nil {

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -2,21 +2,19 @@ package nomad
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
 	"strings"
 	"time"
 
-	metrics "github.com/armon/go-metrics"
-	log "github.com/hashicorp/go-hclog"
-	memdb "github.com/hashicorp/go-memdb"
-	multierror "github.com/hashicorp/go-multierror"
-
+	"github.com/armon/go-metrics"
 	"github.com/golang/snappy"
 	"github.com/hashicorp/consul/lib"
-	"github.com/pkg/errors"
-
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -51,7 +49,7 @@ var (
 // Job endpoint is used for job interactions
 type Job struct {
 	srv    *Server
-	logger log.Logger
+	logger hclog.Logger
 
 	// builtin admission controllers
 	mutators   []jobMutator
@@ -278,7 +276,7 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 		ctx := context.Background()
 		for namespace, usage := range usages {
 			if err := j.srv.consulACLs.CheckPermissions(ctx, namespace, usage, args.Job.ConsulToken); err != nil {
-				return errors.Wrap(err, "job-submitter consul token denied")
+				return fmt.Errorf("job-submitter consul token denied: %w", err)
 			}
 		}
 

--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -1,6 +1,7 @@
 package nomad
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -10,7 +11,6 @@ import (
 	"github.com/hashicorp/nomad/helper/envoy"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -184,7 +184,7 @@ func getNamedTaskForNativeService(tg *structs.TaskGroup, serviceName, taskName s
 		if len(tg.Tasks) == 1 {
 			return tg.Tasks[0], nil
 		}
-		return nil, errors.Errorf("task for Consul Connect Native service %s->%s is ambiguous and must be set", tg.Name, serviceName)
+		return nil, fmt.Errorf("task for Consul Connect Native service %s->%s is ambiguous and must be set", tg.Name, serviceName)
 	}
 
 	for _, t := range tg.Tasks {
@@ -192,7 +192,7 @@ func getNamedTaskForNativeService(tg *structs.TaskGroup, serviceName, taskName s
 			return t, nil
 		}
 	}
-	return nil, errors.Errorf("task %s named by Consul Connect Native service %s->%s does not exist", taskName, tg.Name, serviceName)
+	return nil, fmt.Errorf("task %s named by Consul Connect Native service %s->%s does not exist", taskName, tg.Name, serviceName)
 }
 
 func injectPort(group *structs.TaskGroup, label string) {

--- a/nomad/job_endpoint_hook_expose_check.go
+++ b/nomad/job_endpoint_hook_expose_check.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/pkg/errors"
 )
 
 type jobExposeCheckHook struct{}
@@ -111,7 +110,7 @@ func tgValidateUseOfCheckExpose(tg *structs.TaskGroup) error {
 	for _, s := range tg.Services {
 		for _, check := range s.Checks {
 			if check.Expose && !s.Connect.HasSidecar() {
-				return errors.Errorf(
+				return fmt.Errorf(
 					"exposed service check %s->%s->%s requires use of sidecar_proxy",
 					tg.Name, s.Name, check.Name,
 				)
@@ -124,7 +123,7 @@ func tgValidateUseOfCheckExpose(tg *structs.TaskGroup) error {
 		for _, s := range t.Services {
 			for _, check := range s.Checks {
 				if check.Expose {
-					return errors.Errorf(
+					return fmt.Errorf(
 						"exposed service check %s[%s]->%s->%s is not a task-group service",
 						tg.Name, t.Name, s.Name, check.Name,
 					)
@@ -141,10 +140,10 @@ func tgValidateUseOfCheckExpose(tg *structs.TaskGroup) error {
 func tgValidateUseOfBridgeMode(tg *structs.TaskGroup) error {
 	if tgUsesExposeCheck(tg) {
 		if len(tg.Networks) != 1 {
-			return errors.Errorf("group %q must specify one bridge network for exposing service check(s)", tg.Name)
+			return fmt.Errorf("group %q must specify one bridge network for exposing service check(s)", tg.Name)
 		}
 		if tg.Networks[0].Mode != "bridge" {
-			return errors.Errorf("group %q must use bridge network for exposing service check(s)", tg.Name)
+			return fmt.Errorf("group %q must use bridge network for exposing service check(s)", tg.Name)
 		}
 	}
 	return nil
@@ -223,7 +222,7 @@ func exposePathForCheck(tg *structs.TaskGroup, s *structs.Service, check *struct
 	var port int
 	if mapping := tg.Networks.Port(s.PortLabel); mapping.Value <= 0 { // try looking up by port label
 		if port, _ = strconv.Atoi(s.PortLabel); port <= 0 { // then try direct port value
-			return nil, errors.Errorf(
+			return nil, fmt.Errorf(
 				"unable to determine local service port for service check %s->%s->%s",
 				tg.Name, s.Name, check.Name,
 			)

--- a/nomad/job_endpoint_validators.go
+++ b/nomad/job_endpoint_validators.go
@@ -1,8 +1,9 @@
 package nomad
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/pkg/errors"
 )
 
 type jobNamespaceConstraintCheckHook struct {
@@ -20,7 +21,7 @@ func (c jobNamespaceConstraintCheckHook) Validate(job *structs.Job) (warnings []
 		return nil, err
 	}
 	if ns == nil {
-		return nil, errors.Errorf("job %q is in nonexistent namespace %q", job.ID, job.Namespace)
+		return nil, fmt.Errorf("job %q is in nonexistent namespace %q", job.ID, job.Namespace)
 	}
 
 	var disallowedDrivers []string
@@ -33,12 +34,14 @@ func (c jobNamespaceConstraintCheckHook) Validate(job *structs.Job) (warnings []
 	}
 	if len(disallowedDrivers) > 0 {
 		if len(disallowedDrivers) == 1 {
-			return nil, errors.Errorf(
-				"used task driver %q is not allowed in namespace %q", disallowedDrivers[0], ns.Name)
+			return nil, fmt.Errorf(
+				"used task driver %q is not allowed in namespace %q", disallowedDrivers[0], ns.Name,
+			)
 
 		} else {
-			return nil, errors.Errorf(
-				"used task drivers %q are not allowed in namespace %q", disallowedDrivers, ns.Name)
+			return nil, fmt.Errorf(
+				"used task drivers %q are not allowed in namespace %q", disallowedDrivers, ns.Name,
+			)
 		}
 	}
 	return nil, nil

--- a/nomad/state/state_store_restore.go
+++ b/nomad/state/state_store_restore.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/pkg/errors"
 )
 
 // StateRestore is used to optimize the performance when restoring state by
@@ -107,7 +106,7 @@ func (r *StateRestore) VaultAccessorRestore(accessor *structs.VaultAccessor) err
 // SITokenAccessorRestore is used to restore an SI token accessor
 func (r *StateRestore) SITokenAccessorRestore(accessor *structs.SITokenAccessor) error {
 	if err := r.txn.Insert(siTokenAccessorTable, accessor); err != nil {
-		return errors.Wrap(err, "si token accessor insert failed")
+		return fmt.Errorf("si token accessor insert failed: %w", err)
 	}
 	return nil
 }

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/version"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -130,7 +129,7 @@ func TestServerErr(t *testing.T, cb func(*Config)) (*Server, func(), error) {
 					// Shutdown server
 					err := server.Shutdown()
 					if err != nil {
-						ch <- errors.Wrap(err, "failed to shutdown server")
+						ch <- fmt.Errorf("failed to shutdown server: %w", err)
 					}
 
 					freeport.Return(ports)


### PR DESCRIPTION
https://github.com/pkg/errors has been marked as archived by the owner, presumably in favor of using buit-in `errors` and `fmt` packages for generating errors, now that they support much of the same functionality. 

But also, I realized `errors.New` and friends create a lot of garbage, as they grab a copy of the current stack trace (!) on creation 

https://github.com/pkg/errors/blob/master/errors.go#L105

Also drive-by cleanup some ineffective package aliasing. 