### PR TITLE
client: add Nomad template service functionality to runner. 

### DIFF
--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -113,6 +113,7 @@ func (tr *TaskRunner) initHooks() {
 			clientConfig:    tr.clientConfig,
 			envBuilder:      tr.envBuilder,
 			consulNamespace: consulNamespace,
+			nomadNamespace:  tr.alloc.Job.Namespace,
 		}))
 	}
 

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -102,6 +102,9 @@ type TaskTemplateManagerConfig struct {
 
 	// MaxTemplateEventRate is the maximum rate at which we should emit events.
 	MaxTemplateEventRate time.Duration
+
+	// NomadNamespace is the Nomad namespace for the task
+	NomadNamespace string
 }
 
 // Validate validates the configuration.
@@ -806,6 +809,11 @@ func newRunnerConfig(config *TaskTemplateManagerConfig,
 			}
 		}
 	}
+
+	// Set up Nomad
+	conf.Nomad.Namespace = &config.NomadNamespace
+	conf.Nomad.CustomDialer = cc.TemplateDialer
+	conf.Nomad.Token = &cc.Node.SecretID
 
 	conf.Finalize()
 	return conf, nil

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -812,7 +812,7 @@ func newRunnerConfig(config *TaskTemplateManagerConfig,
 
 	// Set up Nomad
 	conf.Nomad.Namespace = &config.NomadNamespace
-	conf.Nomad.CustomDialer = cc.TemplateDialer
+	conf.Nomad.Transport.CustomDialer = cc.TemplateDialer
 	conf.Nomad.Token = &cc.Node.SecretID
 
 	conf.Finalize()

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -813,6 +813,8 @@ func newRunnerConfig(config *TaskTemplateManagerConfig,
 	// Set up Nomad
 	conf.Nomad.Namespace = &config.NomadNamespace
 	conf.Nomad.Transport.CustomDialer = cc.TemplateDialer
+
+	// Use the Node's SecretID to authenticate Nomad template function calls.
 	conf.Nomad.Token = &cc.Node.SecretID
 
 	conf.Finalize()

--- a/client/allocrunner/taskrunner/template_hook.go
+++ b/client/allocrunner/taskrunner/template_hook.go
@@ -39,6 +39,9 @@ type templateHookConfig struct {
 
 	// consulNamespace is the current Consul namespace
 	consulNamespace string
+
+	// nomadNamespace is the job's Nomad namespace
+	nomadNamespace string
 }
 
 type templateHook struct {
@@ -122,6 +125,7 @@ func (h *templateHook) newManager() (unblock chan struct{}, err error) {
 		TaskDir:              h.taskDir,
 		EnvBuilder:           h.config.envBuilder,
 		MaxTemplateEventRate: template.DefaultMaxTemplateEventRate,
+		NomadNamespace:       h.config.nomadNamespace,
 	})
 	if err != nil {
 		h.logger.Error("failed to create template manager", "error", err)

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -17,6 +17,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/bufconndialer"
 	"github.com/hashicorp/nomad/helper/pluginutils/loader"
 	"github.com/hashicorp/nomad/nomad/structs"
 	structsc "github.com/hashicorp/nomad/nomad/structs/config"
@@ -285,6 +286,10 @@ type Config struct {
 	// NomadServiceDiscovery determines whether the Nomad native service
 	// discovery client functionality is enabled.
 	NomadServiceDiscovery bool
+
+	// TemplateDialer is our custom HTTP dialer for consul-template. This is
+	// used for template functions which require access to the Nomad API.
+	TemplateDialer *bufconndialer.BufConnWrapper
 }
 
 // ClientTemplateConfig is configuration on the client specific to template

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/command/agent/event"
+	"github.com/hashicorp/nomad/helper/bufconndialer"
 	"github.com/hashicorp/nomad/helper/pluginutils/loader"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/lib/cpuset"
@@ -106,6 +107,12 @@ type Agent struct {
 	shutdown     bool
 	shutdownCh   chan struct{}
 	shutdownLock sync.Mutex
+
+	// builtinDialer dials the builtinListener. It is used for connecting
+	// consul-template to the HTTP API in process. In the event this agent is
+	// not running in client mode, these two fields will be nil.
+	builtinListener net.Listener
+	builtinDialer   *bufconndialer.BufConnWrapper
 
 	InmemSink *metrics.InmemSink
 }
@@ -905,6 +912,13 @@ func (a *Agent) setupClient() error {
 	if conf.StateDBFactory == nil {
 		conf.StateDBFactory = state.GetStateDBFactory(conf.DevMode)
 	}
+
+	// Set up a custom listener and dialer. This is used by Nomad clients when
+	// running consul-template functions that utilise the Nomad API. We lazy
+	// load this into the client config, therefore this needs to happen before
+	// we call NewClient.
+	a.builtinListener, a.builtinDialer = bufconndialer.New()
+	conf.TemplateDialer = a.builtinDialer
 
 	nomadClient, err := client.NewClient(
 		conf, a.consulCatalog, a.consulProxies, a.consulService, nil)

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -517,6 +517,7 @@ func SetupLoggers(ui cli.Ui, config *Config) (*logutils.LevelFilter, *gatedwrite
 // setupAgent is used to start the agent and various interfaces
 func (c *Command) setupAgent(config *Config, logger hclog.InterceptLogger, logOutput io.Writer, inmem *metrics.InmemSink) error {
 	c.Ui.Output("Starting Nomad agent...")
+
 	agent, err := NewAgent(config, logger, logOutput, inmem)
 	if err != nil {
 		// log the error as well, so it appears at the end

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -178,8 +178,6 @@ func NewHTTPServers(agent *Agent, config *Config) ([]*HTTPServer, error) {
 			wsUpgrader: wsUpgrader,
 		}
 
-		// TODO(schmichael) only register services and inject auth token (or
-		//  inject auth token into template config?)
 		srv.registerHandlers(config.EnableDebug)
 
 		httpServer := http.Server{

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -116,9 +116,6 @@ func NewHTTPServers(agent *Agent, config *Config) ([]*HTTPServer, error) {
 
 	// Start the listener
 	for _, addr := range config.normalizedAddrs.HTTP {
-		// Create the mux
-		mux := http.NewServeMux()
-
 		lnAddr, err := net.ResolveTCPAddr("tcp", addr)
 		if err != nil {
 			serverInitializationErrors = multierror.Append(serverInitializationErrors, err)
@@ -143,7 +140,7 @@ func NewHTTPServers(agent *Agent, config *Config) ([]*HTTPServer, error) {
 		// Create the server
 		srv := &HTTPServer{
 			agent:      agent,
-			mux:        mux,
+			mux:        http.NewServeMux(),
 			listener:   ln,
 			listenerCh: make(chan struct{}),
 			logger:     agent.httpLogger,
@@ -155,7 +152,7 @@ func NewHTTPServers(agent *Agent, config *Config) ([]*HTTPServer, error) {
 		// Create HTTP server with timeouts
 		httpServer := http.Server{
 			Addr:      srv.Addr,
-			Handler:   handlers.CompressHandler(mux),
+			Handler:   handlers.CompressHandler(srv.mux),
 			ConnState: makeConnState(config.TLSConfig.EnableHTTP, handshakeTimeout, maxConns),
 			ErrorLog:  newHTTPServerLogger(srv.logger),
 		}
@@ -163,6 +160,37 @@ func NewHTTPServers(agent *Agent, config *Config) ([]*HTTPServer, error) {
 		go func() {
 			defer close(srv.listenerCh)
 			httpServer.Serve(ln)
+		}()
+
+		srvs = append(srvs, srv)
+	}
+
+	// This HTTP server is only create when running in client mode, otherwise
+	// the builtinDialer and builtinListener will be nil.
+	if agent.builtinDialer != nil && agent.builtinListener != nil {
+		srv := &HTTPServer{
+			agent:      agent,
+			mux:        http.NewServeMux(),
+			listener:   agent.builtinListener,
+			listenerCh: make(chan struct{}),
+			logger:     agent.httpLogger,
+			Addr:       "builtin",
+			wsUpgrader: wsUpgrader,
+		}
+
+		// TODO(schmichael) only register services and inject auth token (or
+		//  inject auth token into template config?)
+		srv.registerHandlers(config.EnableDebug)
+
+		httpServer := http.Server{
+			Addr:     srv.Addr,
+			Handler:  srv.mux,
+			ErrorLog: newHTTPServerLogger(srv.logger),
+		}
+
+		go func() {
+			defer close(srv.listenerCh)
+			httpServer.Serve(agent.builtinListener)
 		}()
 
 		srvs = append(srvs, srv)

--- a/e2e/consultemplate/input/nomad_provider_service.nomad
+++ b/e2e/consultemplate/input/nomad_provider_service.nomad
@@ -1,0 +1,33 @@
+job "nomad_provider_service" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "nomad_provider_service" {
+
+    service {
+      name     = "${NOMAD_NAMESPACE}-nomad-provider-service-primary"
+      provider = "nomad"
+      tags     = ["foo", "bar"]
+    }
+
+    service {
+      name     = "${NOMAD_NAMESPACE}-nomad-provider-service-secondary"
+      provider = "nomad"
+      tags     = ["baz", "buz"]
+    }
+
+    task "test" {
+      driver = "raw_exec"
+
+      config {
+        command = "bash"
+        args    = ["-c", "sleep 15000"]
+      }
+    }
+  }
+}

--- a/e2e/consultemplate/input/nomad_provider_service_lookup.nomad
+++ b/e2e/consultemplate/input/nomad_provider_service_lookup.nomad
@@ -1,0 +1,41 @@
+job "nomad_provider_service_lookup" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "nomad_provider_service_lookup" {
+
+    task "test" {
+      driver = "raw_exec"
+
+      config {
+        command = "bash"
+        args    = ["-c", "sleep 15000"]
+      }
+
+      template {
+        data = <<EOH
+{{ range nomadServices }}
+service {{ .Name }} {{ .Tags }}{{ end }}
+EOH
+
+        destination = "${NOMAD_TASK_DIR}/services.conf"
+        change_mode = "restart"
+      }
+
+      template {
+        data = <<EOH
+{{ range nomadService "default-nomad-provider-service-primary" }}
+service {{ .Name }} {{ .Tags }} {{ .Datacenter }} {{ .AllocID }}{{ end }}
+EOH
+
+        destination = "${NOMAD_TASK_DIR}/service.conf"
+        change_mode = "noop"
+      }
+    }
+  }
+}

--- a/e2e/consultemplate/input/nomad_provider_service_ns.nomad
+++ b/e2e/consultemplate/input/nomad_provider_service_ns.nomad
@@ -1,0 +1,34 @@
+job "nomad_provider_service" {
+  datacenters = ["dc1"]
+  type        = "service"
+  namespace   = "platform"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "nomad_provider_service" {
+
+    service {
+      name     = "${NOMAD_NAMESPACE}-nomad-provider-service-primary"
+      provider = "nomad"
+      tags     = ["foo", "bar"]
+    }
+
+    service {
+      name     = "${NOMAD_NAMESPACE}-nomad-provider-service-secondary"
+      provider = "nomad"
+      tags     = ["baz", "buz"]
+    }
+
+    task "test" {
+      driver = "raw_exec"
+
+      config {
+        command = "bash"
+        args    = ["-c", "sleep 15000"]
+      }
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/gosuri/uilive v0.0.4
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.1-0.20200228141219-3ce3d519df39
 	github.com/hashicorp/consul v1.7.8
-	github.com/hashicorp/consul-template v0.28.0
+	github.com/hashicorp/consul-template v0.28.1-0.20220401205807-9005d749c0fe
 	github.com/hashicorp/consul/api v1.12.0
 	github.com/hashicorp/consul/sdk v0.8.0
 	github.com/hashicorp/cronexpr v1.1.1
@@ -75,7 +75,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/memberlist v0.3.1
 	github.com/hashicorp/net-rpc-msgpackrpc v0.0.0-20151116020338-a14192a58a69
-	github.com/hashicorp/nomad/api v0.0.0-20200529203653-c4416b26d3eb
+	github.com/hashicorp/nomad/api v0.0.0-20220202221254-5a3278368db7
 	github.com/hashicorp/raft v1.3.5
 	github.com/hashicorp/raft-boltdb/v2 v2.2.0
 	github.com/hashicorp/serf v0.9.7

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/gosuri/uilive v0.0.4
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.1-0.20200228141219-3ce3d519df39
 	github.com/hashicorp/consul v1.7.8
-	github.com/hashicorp/consul-template v0.28.1-0.20220401205807-9005d749c0fe
+	github.com/hashicorp/consul-template v0.28.1-0.20220406001259-e710909d8054
 	github.com/hashicorp/consul/api v1.12.0
 	github.com/hashicorp/consul/sdk v0.8.0
 	github.com/hashicorp/cronexpr v1.1.1
@@ -75,7 +75,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/memberlist v0.3.1
 	github.com/hashicorp/net-rpc-msgpackrpc v0.0.0-20151116020338-a14192a58a69
-	github.com/hashicorp/nomad/api v0.0.0-20220202221254-5a3278368db7
+	github.com/hashicorp/nomad/api v0.0.0-20220401211553-29eff9ab2a92
 	github.com/hashicorp/raft v1.3.5
 	github.com/hashicorp/raft-boltdb/v2 v2.2.0
 	github.com/hashicorp/serf v0.9.7

--- a/go.sum
+++ b/go.sum
@@ -661,8 +661,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul v1.7.8 h1:hp308KxAf3zWoGuwp2e+0UUhrm6qHjeBQk3jCZ+bjcY=
 github.com/hashicorp/consul v1.7.8/go.mod h1:urbfGaVZDmnXC6geg0LYPh/SRUk1E8nfmDHpz+Q0nLw=
-github.com/hashicorp/consul-template v0.28.0 h1:BctmTIm9baJlwXqqEjISzXYPDZCs6qTrPgYOYzKppZM=
-github.com/hashicorp/consul-template v0.28.0/go.mod h1:324C5f8AHp6JqhyfZcX4JsguFdNkKIpZvjZyeCf5W4w=
+github.com/hashicorp/consul-template v0.28.1-0.20220401205807-9005d749c0fe h1:GuSNdU8CUW0wAlTnFfnyZYwcl5YrJpkq0Sf+KiMZLik=
+github.com/hashicorp/consul-template v0.28.1-0.20220401205807-9005d749c0fe/go.mod h1:0p/k281DONmXdD4SkoDqXpOhYL35+wMbptYu4EXaT7Y=
 github.com/hashicorp/consul/api v1.4.0/go.mod h1:xc8u05kyMa3Wjr9eEAsIAo3dg8+LywT5E/Cl7cNS5nU=
 github.com/hashicorp/consul/api v1.12.0 h1:k3y1FYv6nuKyNTqj6w9gXOx5r5CfLj/k/euUeBXj1OY=
 github.com/hashicorp/consul/api v1.12.0/go.mod h1:6pVBMo0ebnYdt2S3H87XhekM/HHrUoTD2XXb/VrZVy0=
@@ -979,7 +979,6 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.2.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=

--- a/go.sum
+++ b/go.sum
@@ -663,6 +663,8 @@ github.com/hashicorp/consul v1.7.8 h1:hp308KxAf3zWoGuwp2e+0UUhrm6qHjeBQk3jCZ+bjc
 github.com/hashicorp/consul v1.7.8/go.mod h1:urbfGaVZDmnXC6geg0LYPh/SRUk1E8nfmDHpz+Q0nLw=
 github.com/hashicorp/consul-template v0.28.1-0.20220401205807-9005d749c0fe h1:GuSNdU8CUW0wAlTnFfnyZYwcl5YrJpkq0Sf+KiMZLik=
 github.com/hashicorp/consul-template v0.28.1-0.20220401205807-9005d749c0fe/go.mod h1:0p/k281DONmXdD4SkoDqXpOhYL35+wMbptYu4EXaT7Y=
+github.com/hashicorp/consul-template v0.28.1-0.20220406001259-e710909d8054 h1:OmSwttQVWtsaFAR5fgjkcn5iNnanQM8KuVAWeBxoSVM=
+github.com/hashicorp/consul-template v0.28.1-0.20220406001259-e710909d8054/go.mod h1:WPYxOkWS57H7jPT3XefIF5ICkNrDRPDxGdrbRtHtovY=
 github.com/hashicorp/consul/api v1.4.0/go.mod h1:xc8u05kyMa3Wjr9eEAsIAo3dg8+LywT5E/Cl7cNS5nU=
 github.com/hashicorp/consul/api v1.12.0 h1:k3y1FYv6nuKyNTqj6w9gXOx5r5CfLj/k/euUeBXj1OY=
 github.com/hashicorp/consul/api v1.12.0/go.mod h1:6pVBMo0ebnYdt2S3H87XhekM/HHrUoTD2XXb/VrZVy0=

--- a/go.sum
+++ b/go.sum
@@ -661,8 +661,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul v1.7.8 h1:hp308KxAf3zWoGuwp2e+0UUhrm6qHjeBQk3jCZ+bjcY=
 github.com/hashicorp/consul v1.7.8/go.mod h1:urbfGaVZDmnXC6geg0LYPh/SRUk1E8nfmDHpz+Q0nLw=
-github.com/hashicorp/consul-template v0.28.1-0.20220401205807-9005d749c0fe h1:GuSNdU8CUW0wAlTnFfnyZYwcl5YrJpkq0Sf+KiMZLik=
-github.com/hashicorp/consul-template v0.28.1-0.20220401205807-9005d749c0fe/go.mod h1:0p/k281DONmXdD4SkoDqXpOhYL35+wMbptYu4EXaT7Y=
 github.com/hashicorp/consul-template v0.28.1-0.20220406001259-e710909d8054 h1:OmSwttQVWtsaFAR5fgjkcn5iNnanQM8KuVAWeBxoSVM=
 github.com/hashicorp/consul-template v0.28.1-0.20220406001259-e710909d8054/go.mod h1:WPYxOkWS57H7jPT3XefIF5ICkNrDRPDxGdrbRtHtovY=
 github.com/hashicorp/consul/api v1.4.0/go.mod h1:xc8u05kyMa3Wjr9eEAsIAo3dg8+LywT5E/Cl7cNS5nU=

--- a/helper/bufconndialer/bufconndialer.go
+++ b/helper/bufconndialer/bufconndialer.go
@@ -1,0 +1,48 @@
+// BufConnWrapper implements consul-template's TransportDialer using a
+// bufconn listener, to provide a way to Dial the in-memory listener
+//
+// Copied from github.com/hashicorp/vault/internalshared/listenerutil/bufconn.go
+
+package bufconndialer
+
+import (
+	"context"
+	"net"
+
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// BufConnWrapper implements consul-template's TransportDialer using a
+// bufconn listener, to provide a way to Dial the in-memory listener
+type BufConnWrapper struct {
+	listener *bufconn.Listener
+}
+
+// New returns a new BufConnWrapper with a new bufconn.Listener. The wrapper
+// provides a dialer for creating connections to the listener.
+func New() (net.Listener, *BufConnWrapper) {
+	ln := bufconn.Listen(1024 * 1024)
+	return ln, &BufConnWrapper{listener: ln}
+}
+
+// NewBufConnWrapper returns a new BufConnWrapper using an
+// existing bufconn.Listener
+func NewBufConnWrapper(bcl *bufconn.Listener) *BufConnWrapper {
+	return &BufConnWrapper{
+		listener: bcl,
+	}
+}
+
+// Dial connects to the listening end of the bufconn (satisfies
+// consul-template's TransportDialer interface). This is essentially the client
+// side of the bufconn connection.
+func (bcl *BufConnWrapper) Dial(_, _ string) (net.Conn, error) {
+	return bcl.listener.Dial()
+}
+
+// DialContext connects to the listening end of the bufconn (satisfies
+// consul-template's TransportDialer interface). This is essentially the client
+// side of the bufconn connection.
+func (bcl *BufConnWrapper) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
+	return bcl.listener.DialContext(ctx)
+}


### PR DESCRIPTION
This change modifies the template task runner to utilise the
new consul-template which includes Nomad service lookup template
funcs.

In order to provide security and auth to consul-template, we use
a custom HTTP dialer which is passed to consul-template when
setting up the runner. This method follows Vault implementation.

This PR also includes an E2E test in lieu of integration tests. This
is due to the taskrunner/template pkg being in a long import chain
making utilising current test agents/clients impossible without a
large refactor. We will therefore step back and address this
properly in the future.