### PR TITLE
ui: hide triggered by and status filters for now

### DIFF
--- a/ui/app/routes/evaluations/index.js
+++ b/ui/app/routes/evaluations/index.js
@@ -32,7 +32,9 @@ export default class EvaluationsIndexRoute extends Route {
     nextToken,
     pageSize,
     searchTerm,
+    // eslint-disable-next-line no-unused-vars
     status,
+    // eslint-disable-next-line no-unused-vars
     triggeredBy,
     type,
     qpNamespace: namespace,

--- a/ui/app/routes/evaluations/index.js
+++ b/ui/app/routes/evaluations/index.js
@@ -57,8 +57,9 @@ export default class EvaluationsIndexRoute extends Route {
       namespace,
       per_page: pageSize,
       next_token: nextToken,
-      status,
-      triggeredBy,
+      // TODO: add support for status and triggeredBy filters
+      //status,
+      //triggeredBy,
       filter: generateFilter(),
     });
   }

--- a/ui/app/templates/evaluations/index.hbs
+++ b/ui/app/templates/evaluations/index.hbs
@@ -27,6 +27,13 @@
           @selection={{this.triggeredBy}}
           @onSelect={{action this.setQueryParam "triggeredBy"}}
         />
+        <SingleSelectDropdown
+          data-test-evaluation-type-facet
+          @label="Type"
+          @options={{this.optionsType}}
+          @selection={{this.type}}
+          @onSelect={{action this.setQueryParam "type"}}
+        />
         --}}
         <SingleSelectDropdown
           data-test-evaluation-namespace-facet
@@ -34,13 +41,6 @@
           @options={{this.optionsNamespaces}}
           @selection={{this.qpNamespace}}
           @onSelect={{action this.setQueryParam "qpNamespace"}}
-        />
-        <SingleSelectDropdown
-          data-test-evaluation-type-facet
-          @label="Type"
-          @options={{this.optionsType}}
-          @selection={{this.type}}
-          @onSelect={{action this.setQueryParam "type"}}
         />
       </div>
     </div>

--- a/ui/app/templates/evaluations/index.hbs
+++ b/ui/app/templates/evaluations/index.hbs
@@ -12,7 +12,7 @@
         />
       </div>
       <div class="toolbar-item is-right-aligned">
-        <!-- TODO: add support for status and triggered by
+        {{!-- TODO: add support for status and triggered by
         <SingleSelectDropdown
           data-test-evaluation-status-facet
           @label="Status"
@@ -27,7 +27,7 @@
           @selection={{this.triggeredBy}}
           @onSelect={{action this.setQueryParam "triggeredBy"}}
         />
-        -->
+        --}}
         <SingleSelectDropdown
           data-test-evaluation-namespace-facet
           @label="Namespace"
@@ -73,7 +73,7 @@
           <tr
             data-test-evaluation="{{row.model.shortId}}"
             style="cursor: pointer;"
-            class="{{if (eq this.currentEval row.model.id) "is-active"}}"
+            class="{{if (eq this.currentEval row.model.id) 'is-active'}}"
             tabindex="0"
             {{on "click" (fn this.handleEvaluationClick row.model)}}
             {{on "keyup" (fn this.handleEvaluationClick row.model)}}

--- a/ui/app/templates/evaluations/index.hbs
+++ b/ui/app/templates/evaluations/index.hbs
@@ -12,6 +12,7 @@
         />
       </div>
       <div class="toolbar-item is-right-aligned">
+        <!-- TODO: add support for status and triggered by
         <SingleSelectDropdown
           data-test-evaluation-status-facet
           @label="Status"
@@ -26,6 +27,7 @@
           @selection={{this.triggeredBy}}
           @onSelect={{action this.setQueryParam "triggeredBy"}}
         />
+        -->
         <SingleSelectDropdown
           data-test-evaluation-namespace-facet
           @label="Namespace"

--- a/ui/tests/acceptance/evaluations-test.js
+++ b/ui/tests/acceptance/evaluations-test.js
@@ -141,10 +141,11 @@ module('Acceptance | evaluations list', function (hooks) {
         {
           namespace: '*',
           per_page: '25',
-          status: '',
           next_token: '',
-          triggeredBy: '',
           filter: '',
+          // TODO: add support for status and triggeredBy filters.
+          // status: '',
+          // triggeredBy: '',
         },
         'Forwards the correct query parameters on default query when route initially loads'
       );
@@ -162,7 +163,8 @@ module('Acceptance | evaluations list', function (hooks) {
   });
 
   module('filters', function () {
-    test('it should enable filtering by evaluation status', async function (assert) {
+    // TODO: add support for status and triggeredBy filters.
+    test.skip('it should enable filtering by evaluation status', async function (assert) {
       assert.expect(2);
 
       server.get('/evaluations', getStandardRes);
@@ -185,12 +187,15 @@ module('Acceptance | evaluations list', function (hooks) {
         return [];
       });
 
+      // TODO: add support for status and triggeredBy filters.
+      /*
       await clickTrigger('[data-test-evaluation-status-facet]');
       await selectChoose('[data-test-evaluation-status-facet]', 'Pending');
 
       assert
         .dom('[data-test-no-eval-match]')
         .exists('Renders a message saying no evaluations match filter status');
+      */
     });
 
     test('it should enable filtering by namespace', async function (assert) {
@@ -206,10 +211,11 @@ module('Acceptance | evaluations list', function (hooks) {
           {
             namespace: 'default',
             per_page: '25',
-            status: '',
             next_token: '',
-            triggeredBy: '',
             filter: '',
+            // TODO: add support for status and triggeredBy filters.
+            // status: '',
+            // triggeredBy: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -224,7 +230,8 @@ module('Acceptance | evaluations list', function (hooks) {
         .exists('Renders a message saying no evaluations match filter status');
     });
 
-    test('it should enable filtering by triggered by', async function (assert) {
+    // TODO: add support for status and triggeredBy filters.
+    test.skip('it should enable filtering by triggered by', async function (assert) {
       assert.expect(2);
 
       server.get('/evaluations', getStandardRes);
@@ -271,10 +278,11 @@ module('Acceptance | evaluations list', function (hooks) {
           {
             namespace: '*',
             per_page: '25',
-            status: '',
             next_token: '',
-            triggeredBy: '',
             filter: 'NodeID is not empty',
+            // TODO: add support for status and triggeredBy filters.
+            // status: '',
+            // triggeredBy: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -303,10 +311,11 @@ module('Acceptance | evaluations list', function (hooks) {
           {
             namespace: '*',
             per_page: '25',
-            status: '',
             next_token: '',
-            triggeredBy: '',
             filter: `ID contains "${searchTerm}" or JobID contains "${searchTerm}" or NodeID contains "${searchTerm}" or TriggeredBy contains "${searchTerm}"`,
+            // TODO: add support for status and triggeredBy filters.
+            // status: '',
+            // triggeredBy: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -341,10 +350,11 @@ module('Acceptance | evaluations list', function (hooks) {
           {
             namespace: '*',
             per_page: '50',
-            status: '',
             next_token: '',
-            triggeredBy: '',
             filter: '',
+            // TODO: add support for status and triggeredBy filters.
+            // status: '',
+            // triggeredBy: '',
           },
           'It makes a request with the per_page set by the user'
         );
@@ -376,10 +386,11 @@ module('Acceptance | evaluations list', function (hooks) {
           {
             namespace: '*',
             per_page: '25',
-            status: '',
             next_token: 'next-token-1',
-            triggeredBy: '',
             filter: '',
+            // TODO: add support for status and triggeredBy filters.
+            // status: '',
+            // triggeredBy: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -403,10 +414,11 @@ module('Acceptance | evaluations list', function (hooks) {
           {
             namespace: '*',
             per_page: '25',
-            status: '',
             next_token: 'next-token-2',
-            triggeredBy: '',
             filter: '',
+            // TODO: add support for status and triggeredBy filters.
+            // status: '',
+            // triggeredBy: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -430,10 +442,11 @@ module('Acceptance | evaluations list', function (hooks) {
           {
             namespace: '*',
             per_page: '25',
-            status: '',
             next_token: 'next-token-1',
-            triggeredBy: '',
             filter: '',
+            // TODO: add support for status and triggeredBy filters.
+            // status: '',
+            // triggeredBy: '',
           },
           'It makes a request using the stored old token.'
         );
@@ -452,10 +465,11 @@ module('Acceptance | evaluations list', function (hooks) {
           {
             namespace: '*',
             per_page: '25',
-            status: '',
             next_token: '',
-            triggeredBy: '',
             filter: '',
+            // TODO: add support for status and triggeredBy filters.
+            // status: '',
+            // triggeredBy: '',
           },
           'When there are no more stored previous tokens, we will request with no next-token.'
         );
@@ -469,7 +483,8 @@ module('Acceptance | evaluations list', function (hooks) {
       await click('[data-test-eval-pagination-prev]');
     });
 
-    test('it should clear all query parameters on refresh', async function (assert) {
+    // TODO: add support for status and triggeredBy filters.
+    test.skip('it should clear all query parameters on refresh', async function (assert) {
       assert.expect(1);
 
       server.get('/evaluations', function () {
@@ -514,7 +529,8 @@ module('Acceptance | evaluations list', function (hooks) {
       await click('[data-test-eval-refresh]');
     });
 
-    test('it should reset pagination when filters are applied', async function (assert) {
+    // TODO: add support for status and triggeredBy filters.
+    test.skip('it should reset pagination when filters are applied', async function (assert) {
       assert.expect(1);
 
       server.get('/evaluations', function () {

--- a/ui/tests/acceptance/evaluations-test.js
+++ b/ui/tests/acceptance/evaluations-test.js
@@ -265,7 +265,8 @@ module('Acceptance | evaluations list', function (hooks) {
         .exists('Renders a message saying no evaluations match filter status');
     });
 
-    test('it should enable filtering by type', async function (assert) {
+    // TODO: add support for type filter.
+    test.skip('it should enable filtering by type', async function (assert) {
       assert.expect(2);
 
       server.get('/evaluations', getStandardRes);
@@ -278,11 +279,10 @@ module('Acceptance | evaluations list', function (hooks) {
           {
             namespace: '*',
             per_page: '25',
+            status: '',
             next_token: '',
+            triggeredBy: '',
             filter: 'NodeID is not empty',
-            // TODO: add support for status and triggeredBy filters.
-            // status: '',
-            // triggeredBy: '',
           },
           'It makes another server request using the options selected by the user'
         );


### PR DESCRIPTION
Using query param filters with the new `filter` param will return an error, so hiding these for now.
