### PR TITLE
client: account for service provider namespace updates in hooks.

### DIFF
--- a/client/allocrunner/groupservice_hook.go
+++ b/client/allocrunner/groupservice_hook.go
@@ -35,7 +35,7 @@ type groupServiceHook struct {
 	shutdownDelayCtx    context.Context
 
 	// namespace is the Nomad or Consul namespace in which service
-	// registrations will be made.
+	// registrations will be made. This field may be updated.
 	namespace string
 
 	// serviceRegWrapper is the handler wrapper that is used to perform service
@@ -162,6 +162,10 @@ func (h *groupServiceHook) Update(req *interfaces.RunnerUpdateRequest) error {
 	h.canary = canary
 	h.delay = shutdown
 	h.taskEnvBuilder.UpdateTask(req.Alloc, nil)
+
+	// An update may change the service provider, therefore we need to account
+	// for how namespaces work across providers also.
+	h.namespace = req.Alloc.ServiceProviderNamespace()
 
 	// Create new task services struct with those new values
 	newWorkloadServices := h.getWorkloadServices()

--- a/client/allocrunner/taskrunner/service_hook.go
+++ b/client/allocrunner/taskrunner/service_hook.go
@@ -61,7 +61,7 @@ type serviceHook struct {
 	taskEnv    *taskenv.TaskEnv
 
 	// namespace is the Nomad or Consul namespace in which service
-	// registrations will be made.
+	// registrations will be made. This field may be updated.
 	namespace string
 
 	// serviceRegWrapper is the handler wrapper that is used to perform service
@@ -172,6 +172,10 @@ func (h *serviceHook) updateHookFields(req *interfaces.TaskUpdateRequest) error 
 	h.networks = networks
 	h.canary = canary
 	h.ports = req.Alloc.AllocatedResources.Shared.Ports
+
+	// An update may change the service provider, therefore we need to account
+	// for how namespaces work across providers also.
+	h.namespace = req.Alloc.ServiceProviderNamespace()
 
 	return nil
 }


### PR DESCRIPTION
When a service is updated, the service hooks update a number of
internal fields which helps generate the new workload. This also
needs to update the namespace for the service provider. It is
possible for these to be different, and in the case of Nomad and
Consul running OSS, this is to be expected.

I'll add a backlog item to come up with integration tests which cover
this alongside the E2E tests I can currently writing which found this.