### PR TITLE
revert `cleanhttp.DefaultPooledTransport`

### DIFF
--- a/.changelog/12409.txt
+++ b/.changelog/12409.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-api: default to using DefaultPooledTransport client to support keep-alive by default
-```

--- a/api/api.go
+++ b/api/api.go
@@ -264,7 +264,7 @@ func (t *TLSConfig) Copy() *TLSConfig {
 }
 
 func defaultHttpClient() *http.Client {
-	httpClient := cleanhttp.DefaultPooledClient()
+	httpClient := cleanhttp.DefaultClient()
 	transport := httpClient.Transport.(*http.Transport)
 	transport.TLSHandshakeTimeout = 10 * time.Second
 	transport.TLSClientConfig = &tls.Config{


### PR DESCRIPTION
I merged https://github.com/hashicorp/nomad/pull/12409 earlier today but missed that it was failing one of our tests. I've had a look at the test and it _looks_ to me like the test is this is an artifact of the test rig and not a real bug, plus the author of the PR is using the patch in production at large scale already. But rather than have our tests failing and/or holding up the upcoming Nomad 1.3.0 beta, let's revert and then I'll track down the issue with the test under a bit less time pressure.