### PR TITLE
ci: make version script match ENT to avoid unnecessary merge conflicts

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -412,9 +412,9 @@ ui-screenshots-local:
 
 version:
 ifneq (,$(wildcard version/version_ent.go))
-	@$(CURDIR)/scripts/version.sh version/version_ent.go
+	@$(CURDIR)/scripts/version.sh version/version.go version/version_ent.go
 else
-	@$(CURDIR)/scripts/version.sh version/version.go
+	@$(CURDIR)/scripts/version.sh version/version.go version/version.go
 endif
 
 .PHONY: version

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 
 version_file=$1
+version_metadata_file=$2
 version=$(awk '$1 == "Version" && $2 == "=" { gsub(/"/, "", $3); print $3 }' <"${version_file}")
 prerelease=$(awk '$1 == "VersionPrerelease" && $2 == "=" { gsub(/"/, "", $3); print $3 }' <"${version_file}")
+metadata=$(awk '$1 == "VersionMetadata" && $2 == "=" { gsub(/"/, "", $3); print $3 }' <"${version_metadata_file}")
 
-if [ -n "$prerelease" ]; then
+if [ -n "$metadata" ] && [ -n "$prerelease" ]; then
+    echo "${version}-${prerelease}+${metadata}"
+elif [ -n "$metadata" ]; then
+    echo "${version}+${metadata}"
+elif [ -n "$prerelease" ]; then
     echo "${version}-${prerelease}"
 else
     echo "${version}"


### PR DESCRIPTION
The ENT version of this script works fine for OSS and having the same in both places reduces the chance of a merge conflict.