### PR TITLE
changelog: minor fixes

### DIFF
--- a/.changelog/11945.txt
+++ b/.changelog/11945.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Fixed a bug where successful poststart tasks were marked as unhealthy
+lifecycle: Fixed a bug where successful poststart tasks were marked as unhealthy
 ```

--- a/.changelog/12274.txt
+++ b/.changelog/12274.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-Enable support for cgroups v2
+client: Enable support for cgroups v2
 ```

--- a/.changelog/12369.txt
+++ b/.changelog/12369.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Write peers.json file with correct permissions
+server: Write peers.json file with correct permissions
 ```

--- a/.changelog/12419.txt
+++ b/.changelog/12419.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-Add support for cgroups v2 in raw_exec driver
+drivers/raw_exec: Add support for cgroups v2 in raw_exec driver
 ```

--- a/.changelog/changelog.tmpl
+++ b/.changelog/changelog.tmpl
@@ -6,7 +6,7 @@ FEATURES:
 {{ end -}}
 {{- end -}}
 
-{{- if index .NotesByType "breaking-change" -}}
+{{- if index .NotesByType "breaking-change" }}
 BREAKING CHANGES:
 
 {{range index .NotesByType "breaking-change" -}}
@@ -53,4 +53,3 @@ NOTES:
 * {{ template "note" . }}
 {{ end -}}
 {{- end -}}
-


### PR DESCRIPTION
Add missing component prefix in some entries and preserve the line break after the `BREAKING CHANGES` section title