### PR TITLE
api: use `cleanhttp.DefaultPooledTransport` for default API client

### DIFF
--- a/.changelog/12492.txt
+++ b/.changelog/12492.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: default to using `DefaultPooledTransport` client to support keep-alive by default
+```

--- a/api/api.go
+++ b/api/api.go
@@ -264,7 +264,7 @@ func (t *TLSConfig) Copy() *TLSConfig {
 }
 
 func defaultHttpClient() *http.Client {
-	httpClient := cleanhttp.DefaultClient()
+	httpClient := cleanhttp.DefaultPooledClient()
 	transport := httpClient.Transport.(*http.Transport)
 	transport.TLSHandshakeTimeout = 10 * time.Second
 	transport.TLSClientConfig = &tls.Config{
@@ -474,6 +474,18 @@ func NewClient(config *Config) (*Client, error) {
 		httpClient: httpClient,
 	}
 	return client, nil
+}
+
+// Close closes the client's idle keep-alived connections. The default
+// client configuration uses keep-alive to maintain connections and
+// you should instantiate a single Client and reuse it for all
+// requests from the same host. Connections will be closed
+// automatically once the client is garbage collected. If you are
+// creating multiple clients on the same host (for example, for
+// testing), it may be useful to call Close() to avoid hitting
+// connection limits.
+func (c *Client) Close() {
+	c.httpClient.CloseIdleConnections()
 }
 
 // Address return the address of the Nomad agent

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -1113,6 +1113,8 @@ func TestHTTPServer_Limits_OK(t *testing.T) {
 			conf.Address = a.HTTPAddr()
 			conf.TLSConfig.Insecure = true
 			client, err := api.NewClient(conf)
+			defer client.Close()
+
 			require.NoError(t, err)
 
 			// Assert a blocking query isn't timed out by the


### PR DESCRIPTION
We expect every Nomad API client to use a single connection to any
given agent, so take advantage of keep-alive by switching the default
transport to `DefaultPooledClient`. Provide a facility to close idle
connections for testing purposes.

Restores the previously reverted #12409 (cc @benbuzbee)