### PR TITLE
client: set environment variable indicating set of reserved cpu cores

### DIFF
--- a/.changelog/12496.txt
+++ b/.changelog/12496.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client: set NOMAD_CPU_CORES environment variable when reserving cpu cores
+```

--- a/client/taskenv/env_test.go
+++ b/client/taskenv/env_test.go
@@ -159,7 +159,10 @@ func TestEnvironment_AsList(t *testing.T) {
 	a := mock.Alloc()
 	a.Job.ParentID = fmt.Sprintf("mock-parent-service-%s", uuid.Generate())
 	a.AllocatedResources.Tasks["web"] = &structs.AllocatedTaskResources{
-		Cpu: structs.AllocatedCpuResources{CpuShares: 500},
+		Cpu: structs.AllocatedCpuResources{
+			CpuShares:     500,
+			ReservedCores: []uint16{0, 5, 6, 7},
+		},
 		Memory: structs.AllocatedMemoryResources{
 			MemoryMB:    256,
 			MemoryMaxMB: 512,
@@ -215,6 +218,7 @@ func TestEnvironment_AsList(t *testing.T) {
 		"NOMAD_PORT_ssh_other=1234",
 		"NOMAD_PORT_ssh_ssh=22",
 		"NOMAD_CPU_LIMIT=500",
+		"NOMAD_CPU_CORES=0,5-7",
 		"NOMAD_DC=dc1",
 		"NOMAD_NAMESPACE=not-default",
 		"NOMAD_REGION=global",
@@ -260,6 +264,7 @@ func TestEnvironment_AllValues(t *testing.T) {
 		MBits:         50,
 		DynamicPorts:  []structs.Port{{Label: "http", Value: 80}},
 	}
+	a.AllocatedResources.Tasks["web"].Cpu.ReservedCores = []uint16{0, 5, 6, 7}
 	a.AllocatedResources.Tasks["ssh"] = &structs.AllocatedTaskResources{
 		Networks: []*structs.NetworkResource{
 			{
@@ -378,6 +383,7 @@ func TestEnvironment_AllValues(t *testing.T) {
 		"NOMAD_PORT_ssh_other":                      "1234",
 		"NOMAD_PORT_ssh_ssh":                        "22",
 		"NOMAD_CPU_LIMIT":                           "500",
+		"NOMAD_CPU_CORES":                           "0,5-7",
 		"NOMAD_DC":                                  "dc1",
 		"NOMAD_PARENT_CGROUP":                       "abc.slice",
 		"NOMAD_NAMESPACE":                           "default",

--- a/website/content/partials/envvars.mdx
+++ b/website/content/partials/envvars.mdx
@@ -56,6 +56,15 @@
     </tr>
     <tr>
       <td>
+        <code>NOMAD_CPU_CORES</code>
+      </td>
+      <td>
+        The specific CPU cores reserved for the task in cpuset list notation.
+        Omitted if the the task does not request cpu cores. E.g. <code>0-2,7,12-14</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <code>NOMAD_ALLOC_ID</code>
       </td>
       <td>Allocation ID of the task</td>


### PR DESCRIPTION
This PR injects the `NOMAD_CPU_CORES` environment variable into
tasks that have been allocated reserved cpu cores. The value uses
normal cpuset notation, as found in cpuset.cpu cgroup interface files.

Note this value is not necessiarly the same as the content of the actual
cpuset.cpus interface file for the task, which will also include shared cpu 
cores when using cgroups v2. This variable is a workaround for users who 
used to be able to read the reserved cgroup cpuset file, but lose the information
about distinct reserved cores when using cgroups v2.

Side discussion in: https://github.com/hashicorp/nomad/issues/12374
