### PR TITLE
ci: skip `prerelease` if triggered by the generate assets workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,7 @@ jobs:
 
       - name: Build prerelease
         run: make prerelease
+        if: ${{ github.event_name != 'workflow_dispatch' }}
 
       - name: Build
         env:
@@ -151,6 +152,7 @@ jobs:
 
       - name: Build prerelease
         run: make prerelease
+        if: ${{ github.event_name != 'workflow_dispatch' }}
 
       - name: Install Linux build utilties
         run: |
@@ -258,6 +260,7 @@ jobs:
 
       - name: Build prerelease
         run: make prerelease
+        if: ${{ github.event_name != 'workflow_dispatch' }}
 
       - name: Build
         env:


### PR DESCRIPTION
The `make prerelease` target is not idempotent, which causes the binary version to show with `+CHANGES`