### PR TITLE
Add custom variable validation to docs

### DIFF
--- a/website/content/docs/job-specification/hcl2/variables.mdx
+++ b/website/content/docs/job-specification/hcl2/variables.mdx
@@ -154,6 +154,28 @@ documentation about the job, and so it should be written from the perspective
 of the user of the job rather than its maintainer. For commentary for job
 maintainers, use comments.
 
+## Input Variable Custom Validation Rules
+
+Input variables support specifying arbitrary custom validation rules for a particular variable using a `validation` block nested within the corresponding `variable` block:
+
+```hcl
+variable "image_id" {
+  type        = string
+  description = "The id of the machine image (AMI) to use for the server."
+
+  validation {
+    condition     = length(var.image_id) > 4 && substr(var.image_id, 0, 4) == "ami-"
+    error_message = "The image_id value must be a valid AMI id, starting with \"ami-\"."
+  }
+}
+```
+
+The condition argument is an expression that must use the value of the variable to return true if the value is valid, or false if it is invalid. The expression can refer only to the variable that the condition applies to, and _must_ not produce errors.
+
+If condition evaluates to false, Nomad will produce an error message that includes the sentences given in `error_message`. The error message string should be at least one full sentence explaining the constraint that failed, starting with an uppercase letter ( if the alphabet permits it ) and ending with a period or question mark.
+
+Multiple validation blocks can be declared in which case error messages will be returned for all failed conditions.
+
 ## Assigning Values to job Variables
 
 Once a variable is declared in your configuration, you can set it:

--- a/website/content/docs/job-specification/hcl2/variables.mdx
+++ b/website/content/docs/job-specification/hcl2/variables.mdx
@@ -156,7 +156,8 @@ maintainers, use comments.
 
 ## Input Variable Custom Validation Rules
 
-Input variables support specifying arbitrary custom validation rules for a particular variable using a `validation` block nested within the corresponding `variable` block:
+Input variables support specifying arbitrary custom validation rules for a particular
+variable using a `validation` block nested within the corresponding `variable` block:
 
 ```hcl
 variable "image_id" {
@@ -164,17 +165,23 @@ variable "image_id" {
   description = "The id of the machine image (AMI) to use for the server."
 
   validation {
-    condition     = length(var.image_id) > 4 && substr(var.image_id, 0, 4) == "ami-"
+    condition     = substr(var.image_id, 0, 4) == "ami-"
     error_message = "The image_id value must be a valid AMI id, starting with \"ami-\"."
   }
 }
 ```
 
-The condition argument is an expression that must use the value of the variable to return true if the value is valid, or false if it is invalid. The expression can refer only to the variable that the condition applies to, and _must_ not produce errors.
+The condition argument is an expression that must use the value of the variable to
+return true if the value is valid, or false if it is invalid. The expression can
+refer only to the variable that the condition applies to, and _must_ not produce errors.
 
-If condition evaluates to false, Nomad will produce an error message that includes the sentences given in `error_message`. The error message string should be at least one full sentence explaining the constraint that failed, starting with an uppercase letter ( if the alphabet permits it ) and ending with a period or question mark.
+If condition evaluates to false, Nomad will produce an error message that includes
+the sentences given in `error_message`. The error message string should be at least
+one full sentence explaining the constraint that failed, starting with an uppercase
+letter ( if the alphabet permits it ) and ending with a period or question mark.
 
-Multiple validation blocks can be declared in which case error messages will be returned for all failed conditions.
+Multiple validation blocks can be declared in which case error messages will be
+returned for all failed conditions.
 
 ## Assigning Values to job Variables
 


### PR DESCRIPTION
This adds a custom variable validation section to the input variable docs since it wasn't apparent that this was supported in Nomad. Personally I was surprised that this worked in Nomad I couldn't find any mention in the official docs.
I've cribbed the content from the terraform docs, specifically from https://www.terraform.io/language/values/variables#custom-validation-rules with some light changes. Feel free to make any wording, grammar changes etc.

This addresses issue https://github.com/hashicorp/nomad/issues/12507