### PR TITLE
ci: add semgrep rule to catch usage of invalid string extensions

### DIFF
--- a/.semgrep/ui.yml
+++ b/.semgrep/ui.yml
@@ -1,0 +1,24 @@
+rules:
+  - id: ui-no-string-extensions
+    patterns:
+      - pattern: "$S.$FUNC()"
+      - metavariable-pattern:
+          metavariable: $FUNC
+          pattern-either:
+            - pattern: "w"
+            - pattern: "loc"
+            - pattern: "camelize"
+            - pattern: "decamelize"
+            - pattern: "dasherize"
+            - pattern: "underscore"
+            - pattern: "classify"
+            - pattern: "capitalize"
+    message: "Invalid call to string extension `$FUNC` in `$S.$FUNC()`"
+    languages:
+      - javascript
+    severity: ERROR
+    paths:
+      include:
+        - "ui/**/*.js"
+      exclude:
+        - "ui/node_modules"


### PR DESCRIPTION
Detect invalid calls to string extensions that were deprecated. List of functions taken from https://github.com/hashicorp/nomad/pull/12502

Playground link: https://semgrep.dev/s/vpvl