### PR TITLE
allocs without max_client_disconnect should be lost on disconnect

### DIFF
--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -216,7 +216,7 @@ func (a allocSet) fromKeys(keys ...[]string) allocSet {
 // 4. Those that are on nodes that are disconnected, but have not had their ClientState set to unknown
 // 5. Those that are on a node that has reconnected.
 // 6. Those that are in a state that results in a noop.
-func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node, supportsDisconnectedClients bool, now time.Time) (untainted, migrate, lost, disconnecting, reconnecting, ignore allocSet) {
+func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node, serverSupportsDisconnectedClients bool, now time.Time) (untainted, migrate, lost, disconnecting, reconnecting, ignore allocSet) {
 	untainted = make(map[string]*structs.Allocation)
 	migrate = make(map[string]*structs.Allocation)
 	lost = make(map[string]*structs.Allocation)
@@ -224,7 +224,20 @@ func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node, support
 	reconnecting = make(map[string]*structs.Allocation)
 	ignore = make(map[string]*structs.Allocation)
 
+	supportsDisconnectedClients := serverSupportsDisconnectedClients
+
 	for _, alloc := range a {
+
+		// make sure we don't apply any reconnect logic to task groups
+		// without max_client_disconnect
+		if alloc.Job != nil {
+			tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
+			if tg != nil {
+				supportsDisconnectedClients = serverSupportsDisconnectedClients &&
+					tg.MaxClientDisconnect != nil
+			}
+		}
+
 		reconnected := false
 		expired := false
 
@@ -310,6 +323,10 @@ func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node, support
 				}
 				// Filter pending allocs on a node that is disconnected to be marked as lost.
 				if alloc.ClientStatus == structs.AllocClientStatusPending {
+					lost[alloc.ID] = alloc
+					continue
+				}
+				if !supportsDisconnectedClients {
 					lost[alloc.ID] = alloc
 					continue
 				}

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -316,17 +316,18 @@ func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node, serverS
 			// Group disconnecting/reconnecting
 			switch taintedNode.Status {
 			case structs.NodeStatusDisconnected:
-				// Filter running allocs on a node that is disconnected to be marked as unknown.
-				if supportsDisconnectedClients && alloc.ClientStatus == structs.AllocClientStatusRunning {
-					disconnecting[alloc.ID] = alloc
-					continue
-				}
-				// Filter pending allocs on a node that is disconnected to be marked as lost.
-				if alloc.ClientStatus == structs.AllocClientStatusPending {
-					lost[alloc.ID] = alloc
-					continue
-				}
-				if !supportsDisconnectedClients {
+				if supportsDisconnectedClients {
+					// Filter running allocs on a node that is disconnected to be marked as unknown.
+					if alloc.ClientStatus == structs.AllocClientStatusRunning {
+						disconnecting[alloc.ID] = alloc
+						continue
+					}
+					// Filter pending allocs on a node that is disconnected to be marked as lost.
+					if alloc.ClientStatus == structs.AllocClientStatusPending {
+						lost[alloc.ID] = alloc
+						continue
+					}
+				} else {
 					lost[alloc.ID] = alloc
 					continue
 				}


### PR DESCRIPTION
In the reconciler's filtering for tainted nodes, we use whether the
server supports disconnected clients as a gate to a bunch of our
logic, but this doesn't account for cases where the job doesn't have
`max_client_disconnect`. The only real consequence of this appears to
be that allocs on disconnected nodes are marked "complete" instead of
"lost".