### PR TITLE
parse ACL token from authorization header

### DIFF
--- a/website/content/api-docs/index.mdx
+++ b/website/content/api-docs/index.mdx
@@ -72,14 +72,22 @@ For more details about ACLs, please see the [ACL Guide](https://learn.hashicorp.
 
 ## Authentication
 
-When ACLs are enabled, a Nomad token should be provided to API requests using the `X-Nomad-Token` header. When using authentication, clients should communicate via TLS.
+When ACLs are enabled, a Nomad token should be provided to API requests using the `X-Nomad-Token` header or with the Bearer scheme in the authorization header. When using authentication, clients should communicate via TLS.
 
-Here is an example using curl:
+Here is an example using curl with `X-Nomad-Token`:
 
 ```shell-session
 $ curl \
     --header "X-Nomad-Token: aa534e09-6a07-0a45-2295-a7f77063d429" \
     https://localhost:4646/v1/jobs
+```
+
+Below is an example using `curl` with a [RFC6750](https://tools.ietf.org/html/rfc6750) Bearer token:
+
+```shell-session
+$ curl \
+    --header "Authorization: Bearer <token>" \
+    http://localhost:4646/v1/jobs
 ```
 
 ## Namespaces

--- a/website/content/api-docs/index.mdx
+++ b/website/content/api-docs/index.mdx
@@ -66,7 +66,7 @@ administration.
 
 ## ACLs
 
-Several endpoints in Nomad use or require ACL tokens to operate. The token are used to authenticate the request and determine if the request is allowed based on the associated authorizations. Tokens are specified per-request by using the `X-Nomad-Token` request header set to the `SecretID` of an ACL Token.
+Several endpoints in Nomad use or require ACL tokens to operate. The token are used to authenticate the request and determine if the request is allowed based on the associated authorizations. Tokens are specified per-request by using the `X-Nomad-Token` request header or with the Bearer scheme in the authorization header set to the `SecretID` of an ACL Token.
 
 For more details about ACLs, please see the [ACL Guide](https://learn.hashicorp.com/collections/nomad/access-control).
 


### PR DESCRIPTION
Adds support for reading ACL token from the [RFC6750](https://tools.ietf.org/html/rfc6750) Bearer token (`Authorization: Bearer <token>`).

The code samples / documentation were taken from Consul:
https://github.com/hashicorp/consul/blob/973d2d0f9a2d32f6f3eae506c2b5b89f98007b58/agent/http.go#L1021-L1041
https://github.com/hashicorp/consul/blob/1d817f683a4922756db44b991428cd5f582ea6ae/website/content/api-docs/index.mdx

Background behind this is I'm using prometheus static_config to scrape metrics from nomad and the [static_config configuration doesn't support custom headers, only authorization tokens](https://github.com/prometheus/prometheus/issues/1724). This would allow me to properly embed and use the token.

I have yet to test the locally, but will update here when I have a chance to do. Wanted to start the conversation of if this is something y'all wanted to support.

Let me know your thoughts and if there is anything else I should add!