### PR TITLE
add some godocs for the API pagination tokenizer options

### DIFF
--- a/nomad/state/paginator/tokenizer.go
+++ b/nomad/state/paginator/tokenizer.go
@@ -31,6 +31,29 @@ type CreateIndexGetter interface {
 }
 
 // StructsTokenizerOptions is the configuration provided to a StructsTokenizer.
+//
+// These are some of the common use cases:
+//   - Structs that can be uniquely identified with only its own ID:
+//
+//       StructsTokenizerOptions {
+//           WithID: true,
+//       }
+//
+//   - Structs that are only unique within their namespace:
+//
+//       StructsTokenizerOptions {
+//           WithID:        true,
+//           WithNamespace: true,
+//       }
+//
+//   - Structs that can be sorted by their create index should also set
+//     `WithCreateIndex` to `true` along with the other options:
+//
+//       StructsTokenizerOptions {
+//           WithID:          true,
+//           WithNamespace:   true,
+//           WithCreateIndex: true,
+//       }
 type StructsTokenizerOptions struct {
 	WithCreateIndex bool
 	WithNamespace   bool


### PR DESCRIPTION
It wasn't clear how these options were supposed to be set since any combination is technically valid, but in practice may result in unexpected pagination results.

In the future, we should probably have specialized tokenizers for each of the use cases.