### PR TITLE
E2E: fix flaky event stream test

### DIFF
--- a/e2e/events/input/initial.nomad
+++ b/e2e/events/input/initial.nomad
@@ -1,5 +1,5 @@
 job "deployment_auto.nomad" {
-  datacenters = ["dc1"]
+  datacenters = ["dc1", "dc2"]
 
   constraint {
     attribute = "${attr.kernel.name}"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/12538

This changeset fixes two sources of flakiness in the event stream test.

First, the stream request gets the event *closest* to the index, not
the exact match. Although events are written before raft entries
they're written asynchronously, so it's possible to race and get a
raft index from this query higher than the current head of the event
buffer. Ensure the job is running before we try to get the index, so
that we've given the event enough time to land in the buffer.

Second, the assertion that the found index is greater than the start
index is only true if the `PlanResult` event manages to land before we
do the second registration. Although it should now with the first fix
above, it's not a correct assertion for what we're testing.