### PR TITLE
scripts: fix interpreter for bash

### DIFF
--- a/demo/csi/hostpath/run.sh
+++ b/demo/csi/hostpath/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run the hostpath plugin and create some volumes, and then claim them.
 set -e
 

--- a/e2e/bin/run
+++ b/e2e/bin/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/e2e/bin/update
+++ b/e2e/bin/update
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ $# -ne 2 ]; then
     echo "./upload.sh <source> <destination>"

--- a/e2e/networking/inputs/validate.sh
+++ b/e2e/networking/inputs/validate.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 nomad operator api "/v1/allocation/${NOMAD_ALLOC_ID}" | jq '.NetworkStatus.Address | length'

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/dnsconfig.sh
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/dnsconfig.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # These tasks can't be executed during AMI builds because they rely on

--- a/e2e/terraform/packer/ubuntu-bionic-amd64/setup.sh
+++ b/e2e/terraform/packer/ubuntu-bionic-amd64/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # setup script for Ubuntu Linux 18.04. Assumes that Packer has placed
 # build-time config files at /tmp/linux
 

--- a/e2e/terraform/scripts/bootstrap-nomad.sh
+++ b/e2e/terraform/scripts/bootstrap-nomad.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/nomad/structs/generate.sh
+++ b/nomad/structs/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 FILES="$(ls ./*.go | grep -v -e _test.go -e .generated.go | tr '\n' ' ')"

--- a/scripts/example_weave.bash
+++ b/scripts/example_weave.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ "$USER" != "vagrant" ]]; then
     echo "WARNING: This script is intended to be run from Nomad's Vagrant"
     read -rsp $'Press any key to continue anyway...\n' -n1

--- a/terraform/aws/env/us-east/user-data-client.sh
+++ b/terraform/aws/env/us-east/user-data-client.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/terraform/aws/env/us-east/user-data-server.sh
+++ b/terraform/aws/env/us-east/user-data-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/terraform/azure/env/EastUS/user-data-client.sh
+++ b/terraform/azure/env/EastUS/user-data-client.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/terraform/azure/env/EastUS/user-data-server.sh
+++ b/terraform/azure/env/EastUS/user-data-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/terraform/shared/scripts/client.sh
+++ b/terraform/shared/scripts/client.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/terraform/shared/scripts/server.sh
+++ b/terraform/shared/scripts/server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/terraform/shared/scripts/setup.sh
+++ b/terraform/shared/scripts/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/website/scripts/should-build.sh
+++ b/website/scripts/should-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is run during the website build step to determine if we should skip the build or not.
 # More information: https://vercel.com/docs/platform/projects#ignored-build-step


### PR DESCRIPTION
Many of our scripts have a non-portable interpreter line for bash and
use bash-specific variables like `BASH_SOURCE`. Update the interpreter
line to be portable between various Linuxes and macOS without
complaint from posix shell users.

(This was originally encountered by @philrenaud in the CSI demo directory but it applies across a number of our scripts, so I've gone thru and fixed it everywhere.)