### PR TITLE
ci: change notification channel to feed-nomad-releases

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -3,8 +3,10 @@ schema = "1"
 project "nomad" {
   team = "nomad"
   slack {
+    // #feed-nomad-releases
+    notification_channel = "C03B5EWFW01"
     // #proj-nomad-releases
-    notification_channel = "CUYKT2A73"
+    // notification_channel = "CUYKT2A73"
   }
   github {
     organization     = "hashicorp"


### PR DESCRIPTION
`#proj-nomad-releases` is starting to get a bit nosy. Another option would be change the `verify` event notification to `on = "error"`, but this would have to be change during releases and it's a bit too far down to find it.

Switching channels is easier since it's defined at the top of the file. Keeping both channel IDs also means we can comment/uncomment them when needed.