### PR TITLE
system_scheduler: support disconnected clients

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9935,6 +9935,24 @@ func (a *Allocation) DisconnectTimeout(now time.Time) time.Time {
 	return now.Add(*timeout)
 }
 
+// SupportsDisconnectedClients determines whether both the server and the task group
+// are configured to allow the allocation to reconnect after network connectivity
+// has been lost and then restored.
+func (a *Allocation) SupportsDisconnectedClients(serverSupportsDisconnectedClients bool) bool {
+	if !serverSupportsDisconnectedClients {
+		return false
+	}
+
+	if a.Job != nil {
+		tg := a.Job.LookupTaskGroup(a.TaskGroup)
+		if tg != nil {
+			return tg.MaxClientDisconnect != nil
+		}
+	}
+
+	return false
+}
+
 // NextDelay returns a duration after which the allocation can be rescheduled.
 // It is calculated according to the delay function and previous reschedule attempts.
 func (a *Allocation) NextDelay() time.Duration {

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -429,11 +429,6 @@ func (s *GenericScheduler) computeJobAllocs() error {
 		s.ctx.Plan().AppendAlloc(update, nil)
 	}
 
-	// Log reconnect updates. They will be pulled by the client when it reconnects.
-	for _, update := range results.reconnectUpdates {
-		s.logger.Trace("reconnecting alloc", "alloc_id", update.ID, "alloc_modify_index", update.AllocModifyIndex)
-	}
-
 	// Nothing remaining to do if placement is not required
 	if len(results.place)+len(results.destructiveUpdate) == 0 {
 		// If the job has been purged we don't have access to the job. Otherwise

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -224,19 +224,11 @@ func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node, serverS
 	reconnecting = make(map[string]*structs.Allocation)
 	ignore = make(map[string]*structs.Allocation)
 
-	supportsDisconnectedClients := serverSupportsDisconnectedClients
-
 	for _, alloc := range a {
 
 		// make sure we don't apply any reconnect logic to task groups
 		// without max_client_disconnect
-		if alloc.Job != nil {
-			tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
-			if tg != nil {
-				supportsDisconnectedClients = serverSupportsDisconnectedClients &&
-					tg.MaxClientDisconnect != nil
-			}
-		}
+		supportsDisconnectedClients := alloc.SupportsDisconnectedClients(serverSupportsDisconnectedClients)
 
 		reconnected := false
 		expired := false

--- a/scheduler/scheduler_system.go
+++ b/scheduler/scheduler_system.go
@@ -229,7 +229,9 @@ func (s *SystemScheduler) computeJobAllocs() error {
 	live, term := structs.SplitTerminalAllocs(allocs)
 
 	// Diff the required and existing allocations
-	diff := diffSystemAllocs(s.job, s.nodes, s.notReadyNodes, tainted, live, term)
+	diff := diffSystemAllocs(s.job, s.nodes, s.notReadyNodes, tainted, live, term,
+		s.planner.ServersMeetMinimumVersion(minVersionMaxClientDisconnect, true))
+
 	s.logger.Debug("reconciled current state with desired state",
 		"place", len(diff.place), "update", len(diff.update),
 		"migrate", len(diff.migrate), "stop", len(diff.stop),
@@ -249,6 +251,15 @@ func (s *SystemScheduler) computeJobAllocs() error {
 	// status lost.
 	for _, e := range diff.lost {
 		s.plan.AppendStoppedAlloc(e.Alloc, allocLost, structs.AllocClientStatusLost, "")
+	}
+
+	for _, e := range diff.disconnecting {
+		s.plan.AppendUnknownAlloc(e.Alloc)
+	}
+
+	// Log reconnect updates. They will be pulled by the client when it reconnects.
+	for _, e := range diff.reconnecting {
+		s.logger.Trace("reconnecting alloc", "alloc_id", e.Alloc.ID, "alloc_modify_index", e.Alloc.AllocModifyIndex)
 	}
 
 	// Attempt to do the upgrades in place
@@ -508,6 +519,7 @@ func (s *SystemScheduler) canHandle(trigger string) bool {
 	case structs.EvalTriggerAllocStop:
 	case structs.EvalTriggerQueuedAllocs:
 	case structs.EvalTriggerScaling:
+	case structs.EvalTriggerReconnect:
 	default:
 		switch s.sysbatch {
 		case true:

--- a/scheduler/scheduler_system.go
+++ b/scheduler/scheduler_system.go
@@ -257,11 +257,6 @@ func (s *SystemScheduler) computeJobAllocs() error {
 		s.plan.AppendUnknownAlloc(e.Alloc)
 	}
 
-	// Log reconnect updates. They will be pulled by the client when it reconnects.
-	for _, e := range diff.reconnecting {
-		s.logger.Trace("reconnecting alloc", "alloc_id", e.Alloc.ID, "alloc_modify_index", e.Alloc.AllocModifyIndex)
-	}
-
 	// Attempt to do the upgrades in place
 	destructiveUpdates, inplaceUpdates := inplaceUpdate(s.ctx, s.eval, s.job, s.stack, diff.update)
 	diff.update = destructiveUpdates

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"time"
 
 	log "github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
@@ -38,12 +39,12 @@ func materializeTaskGroups(job *structs.Job) map[string]*structs.TaskGroup {
 
 // diffResult is used to return the sets that result from the diff
 type diffResult struct {
-	place, update, migrate, stop, ignore, lost []allocTuple
+	place, update, migrate, stop, ignore, lost, disconnecting, reconnecting []allocTuple
 }
 
 func (d *diffResult) GoString() string {
-	return fmt.Sprintf("allocs: (place %d) (update %d) (migrate %d) (stop %d) (ignore %d) (lost %d)",
-		len(d.place), len(d.update), len(d.migrate), len(d.stop), len(d.ignore), len(d.lost))
+	return fmt.Sprintf("allocs: (place %d) (update %d) (migrate %d) (stop %d) (ignore %d) (lost %d) (disconnecting %d) (reconnecting %d)",
+		len(d.place), len(d.update), len(d.migrate), len(d.stop), len(d.ignore), len(d.lost), len(d.disconnecting), len(d.reconnecting))
 }
 
 func (d *diffResult) Append(other *diffResult) {
@@ -53,15 +54,19 @@ func (d *diffResult) Append(other *diffResult) {
 	d.stop = append(d.stop, other.stop...)
 	d.ignore = append(d.ignore, other.ignore...)
 	d.lost = append(d.lost, other.lost...)
+	d.disconnecting = append(d.disconnecting, other.disconnecting...)
+	d.reconnecting = append(d.reconnecting, other.reconnecting...)
 }
 
 // diffSystemAllocsForNode is used to do a set difference between the target allocations
-// and the existing allocations for a particular node. This returns 6 sets of results,
+// and the existing allocations for a particular node. This returns 8 sets of results,
 // the list of named task groups that need to be placed (no existing allocation), the
 // allocations that need to be updated (job definition is newer), allocs that
 // need to be migrated (node is draining), the allocs that need to be evicted
-// (no longer required), those that should be ignored and those that are lost
-// that need to be replaced (running on a lost node).
+// (no longer required), those that should be ignored, those that are lost
+// that need to be replaced (running on a lost node), those that are running on
+// a disconnected node but may resume, and those that may still be running on
+// a node that has resumed reconnected.
 func diffSystemAllocsForNode(
 	job *structs.Job, // job whose allocs are going to be diff-ed
 	nodeID string,
@@ -71,6 +76,7 @@ func diffSystemAllocsForNode(
 	required map[string]*structs.TaskGroup, // set of allocations that must exist
 	allocs []*structs.Allocation, // non-terminal allocations that exist
 	terminal structs.TerminalByNodeByName, // latest terminal allocations (by node, id)
+	serverSupportsDisconnectedClients bool, // flag indicating whether to apply disconnected client logic
 ) *diffResult {
 	result := new(diffResult)
 
@@ -94,6 +100,16 @@ func diffSystemAllocsForNode(
 			continue
 		}
 
+		supportsDisconnectedClients := exist.SupportsDisconnectedClients(serverSupportsDisconnectedClients)
+
+		reconnected := false
+		// Only compute reconnected for unknown and running since they need to go through the reconnect process.
+		if supportsDisconnectedClients &&
+			(exist.ClientStatus == structs.AllocClientStatusUnknown ||
+				exist.ClientStatus == structs.AllocClientStatusRunning) {
+			reconnected, _ = exist.Reconnected()
+		}
+
 		// If we have been marked for migration and aren't terminal, migrate
 		if !exist.TerminalStatus() && exist.DesiredTransition.ShouldMigrate() {
 			result.migrate = append(result.migrate, allocTuple{
@@ -114,9 +130,45 @@ func diffSystemAllocsForNode(
 			continue
 		}
 
+		// Expired unknown allocs are lost. Expired checks that status is unknown.
+		if supportsDisconnectedClients && exist.Expired(time.Now().UTC()) {
+			result.lost = append(result.lost, allocTuple{
+				Name:      name,
+				TaskGroup: tg,
+				Alloc:     exist,
+			})
+			continue
+		}
+
+		// Ignore unknown allocs that we want to reconnect eventually.
+		if supportsDisconnectedClients &&
+			exist.ClientStatus == structs.AllocClientStatusUnknown &&
+			exist.DesiredStatus == structs.AllocDesiredStatusRun {
+			result.ignore = append(result.ignore, allocTuple{
+				Name:      name,
+				TaskGroup: tg,
+				Alloc:     exist,
+			})
+			continue
+		}
+
+		node, nodeIsTainted := taintedNodes[exist.NodeID]
+
+		// Filter allocs on a node that is now re-connected to reconnecting.
+		if supportsDisconnectedClients &&
+			!nodeIsTainted &&
+			reconnected {
+			result.reconnecting = append(result.reconnecting, allocTuple{
+				Name:      name,
+				TaskGroup: tg,
+				Alloc:     exist,
+			})
+			continue
+		}
+
 		// If we are on a tainted node, we must migrate if we are a service or
 		// if the batch allocation did not finish
-		if node, ok := taintedNodes[exist.NodeID]; ok {
+		if nodeIsTainted {
 			// If the job is batch and finished successfully, the fact that the
 			// node is tainted does not mean it should be migrated or marked as
 			// lost as the work was already successfully finished. However for
@@ -124,6 +176,24 @@ func diffSystemAllocsForNode(
 			// batch type, defends against client bugs.
 			if exist.Job.Type == structs.JobTypeBatch && exist.RanSuccessfully() {
 				goto IGNORE
+			}
+
+			// Filter running allocs on a node that is disconnected to be marked as unknown.
+			if node != nil &&
+				supportsDisconnectedClients &&
+				node.Status == structs.NodeStatusDisconnected &&
+				exist.ClientStatus == structs.AllocClientStatusRunning {
+
+				disconnect := exist.Copy()
+				disconnect.ClientStatus = structs.AllocClientStatusUnknown
+				disconnect.AppendState(structs.AllocStateFieldClientStatus, structs.AllocClientStatusUnknown)
+				disconnect.ClientDescription = allocUnknown
+				result.disconnecting = append(result.disconnecting, allocTuple{
+					Name:      name,
+					TaskGroup: tg,
+					Alloc:     disconnect,
+				})
+				continue
 			}
 
 			if !exist.TerminalStatus() && (node == nil || node.TerminalStatus()) {
@@ -141,13 +211,13 @@ func diffSystemAllocsForNode(
 
 		// For an existing allocation, if the nodeID is no longer
 		// eligible, the diff should be ignored
-		if _, ok := notReadyNodes[nodeID]; ok {
+		if _, ineligible := notReadyNodes[nodeID]; ineligible {
 			goto IGNORE
 		}
 
 		// Existing allocations on nodes that are no longer targeted
 		// should be stopped
-		if _, ok := eligibleNodes[nodeID]; !ok {
+		if _, eligible := eligibleNodes[nodeID]; !eligible {
 			result.stop = append(result.stop, allocTuple{
 				Name:      name,
 				TaskGroup: tg,
@@ -247,6 +317,7 @@ func diffSystemAllocs(
 	taintedNodes map[string]*structs.Node, // nodes which are down or drain mode (by node id)
 	allocs []*structs.Allocation, // non-terminal allocations
 	terminal structs.TerminalByNodeByName, // latest terminal allocations (by node id)
+	serverSupportsDisconnectedClients bool, // flag indicating whether to apply disconnected client logic
 ) *diffResult {
 
 	// Build a mapping of nodes to all their allocs.
@@ -268,7 +339,7 @@ func diffSystemAllocs(
 
 	result := new(diffResult)
 	for nodeID, allocs := range nodeAllocs {
-		diff := diffSystemAllocsForNode(job, nodeID, eligibleNodes, notReadyNodes, taintedNodes, required, allocs, terminal)
+		diff := diffSystemAllocsForNode(job, nodeID, eligibleNodes, notReadyNodes, taintedNodes, required, allocs, terminal, serverSupportsDisconnectedClients)
 		result.Append(diff)
 	}
 

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -174,7 +174,7 @@ func diffSystemAllocsForNode(
 			// lost as the work was already successfully finished. However for
 			// service/system jobs, tasks should never complete. The check of
 			// batch type, defends against client bugs.
-			if exist.Job.Type == structs.JobTypeBatch && exist.RanSuccessfully() {
+			if exist.Job.Type == structs.JobTypeSysBatch && exist.RanSuccessfully() {
 				goto IGNORE
 			}
 

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -67,7 +67,7 @@ func TestDiffSystemAllocsForNode_Sysbatch_terminal(t *testing.T) {
 			},
 		}
 
-		diff := diffSystemAllocsForNode(job, "node1", eligible, nil, tainted, required, live, terminal)
+		diff := diffSystemAllocsForNode(job, "node1", eligible, nil, tainted, required, live, terminal, true)
 		require.Empty(t, diff.place)
 		require.Empty(t, diff.update)
 		require.Empty(t, diff.stop)
@@ -93,7 +93,7 @@ func TestDiffSystemAllocsForNode_Sysbatch_terminal(t *testing.T) {
 		expAlloc := terminal["node1"]["my-sysbatch.pinger[0]"]
 		expAlloc.NodeID = "node1"
 
-		diff := diffSystemAllocsForNode(job, "node1", eligible, nil, tainted, required, live, terminal)
+		diff := diffSystemAllocsForNode(job, "node1", eligible, nil, tainted, required, live, terminal, true)
 		require.Empty(t, diff.place)
 		require.Len(t, diff.update, 1)
 		require.Empty(t, diff.stop)
@@ -199,7 +199,7 @@ func TestDiffSystemAllocsForNode(t *testing.T) {
 		},
 	}
 
-	diff := diffSystemAllocsForNode(job, "zip", eligible, nil, tainted, required, allocs, terminal)
+	diff := diffSystemAllocsForNode(job, "zip", eligible, nil, tainted, required, allocs, terminal, true)
 
 	// We should update the first alloc
 	require.Len(t, diff.update, 1)
@@ -282,7 +282,7 @@ func TestDiffSystemAllocsForNode_ExistingAllocIneligibleNode(t *testing.T) {
 	// No terminal allocs
 	terminal := make(structs.TerminalByNodeByName)
 
-	diff := diffSystemAllocsForNode(job, eligibleNode.ID, eligible, nil, tainted, required, allocs, terminal)
+	diff := diffSystemAllocsForNode(job, eligibleNode.ID, eligible, nil, tainted, required, allocs, terminal, true)
 
 	require.Len(t, diff.place, 0)
 	require.Len(t, diff.update, 1)
@@ -364,7 +364,7 @@ func TestDiffSystemAllocs(t *testing.T) {
 		},
 	}
 
-	diff := diffSystemAllocs(job, nodes, nil, tainted, allocs, terminal)
+	diff := diffSystemAllocs(job, nodes, nil, tainted, allocs, terminal, true)
 
 	// We should update the first alloc
 	require.Len(t, diff.update, 1)


### PR DESCRIPTION
This PR modifies the system scheduler so that `system` and `sysbatch` jobs can take advantage of the disconnected client feature.

- `e2090b1`: Adds a shared logic function to `Allocation` for determining if an allocation is configured with `max_client_disconnect`
- `4dbb5f6`: Modifies the system scheduler to 
  - Guard against minimum server version
  - Track and report disconnecting/reconnecting allocs
  - Mark an allocation as `unknown` when its node transitions to disconnected
  - Mark an allocation as `lost` when its disconnect duration expires
  - Ignore `unknown` allocations that have not yet expired
  - Log reconnecting allocations when the node transitions back to `ready`