### PR TITLE
heartbeat: Handle transitioning from disconnected to down

### DIFF
--- a/nomad/heartbeat_test.go
+++ b/nomad/heartbeat_test.go
@@ -8,6 +8,7 @@ import (
 	memdb "github.com/hashicorp/go-memdb"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
@@ -284,4 +285,72 @@ func TestHeartbeat_Server_HeartbeatTTL_Failover(t *testing.T) {
 	}, func(err error) {
 		t.Fatalf("err: %s", err)
 	})
+}
+
+func TestHeartbeat_InvalidateHeartbeat_DisconnectedClient(t *testing.T) {
+	ci.Parallel(t)
+
+	type testCase struct {
+		name                string
+		now                 time.Time
+		maxClientDisconnect *time.Duration
+		expectedNodeStatus  string
+	}
+
+	testCases := []testCase{
+		{
+			name:                "has-pending-reconnects",
+			now:                 time.Now().UTC(),
+			maxClientDisconnect: helper.TimeToPtr(5 * time.Second),
+			expectedNodeStatus:  structs.NodeStatusDisconnected,
+		},
+		{
+			name:                "has-expired-reconnects",
+			maxClientDisconnect: helper.TimeToPtr(5 * time.Second),
+			now:                 time.Now().UTC().Add(-10 * time.Second),
+			expectedNodeStatus:  structs.NodeStatusDown,
+		},
+		{
+			name:                "has-expired-reconnects-equal-timestamp",
+			maxClientDisconnect: helper.TimeToPtr(5 * time.Second),
+			now:                 time.Now().UTC().Add(-5 * time.Second),
+			expectedNodeStatus:  structs.NodeStatusDown,
+		},
+		{
+			name:                "has-no-reconnects",
+			now:                 time.Now().UTC(),
+			maxClientDisconnect: nil,
+			expectedNodeStatus:  structs.NodeStatusDown,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s1, cleanupS1 := TestServer(t, nil)
+			defer cleanupS1()
+			testutil.WaitForLeader(t, s1.RPC)
+
+			// Create a node
+			node := mock.Node()
+			state := s1.fsm.State()
+			require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1, node))
+
+			alloc := mock.Alloc()
+			alloc.NodeID = node.ID
+			alloc.Job.TaskGroups[0].MaxClientDisconnect = tc.maxClientDisconnect
+			alloc.ClientStatus = structs.AllocClientStatusUnknown
+			alloc.AllocStates = []*structs.AllocState{{
+				Field: structs.AllocStateFieldClientStatus,
+				Value: structs.AllocClientStatusUnknown,
+				Time:  tc.now,
+			}}
+			require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 2, []*structs.Allocation{alloc}))
+
+			// Trigger status update
+			s1.invalidateHeartbeat(node.ID)
+			out, err := state.NodeByID(nil, node.ID)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedNodeStatus, out.Status)
+		})
+	}
 }


### PR DESCRIPTION
Closes #12470

This PR updates the `nodeHeartbeater` to handle transitioning a client from `disconnected` to `down`

It does this by:

- Updating `node_endpoint` to allow `disconnect` updates to participate in the heartbeat timer process
- Checking to see if the node has any pending reconnectable allocations on each heartbeat
- Setting the node status to `down` when there are no more pending reconnectable allocations