### PR TITLE
chore: redirects

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1384,33 +1384,13 @@ module.exports = [
 
   // Redirects for exact versioned-docs to respective generic versions
   {
-    source: '/:base(docs|api-docs)/v1.2.(\\d)',
-    destination: '/:base/v1.2.x',
+    source: '/:base(docs|api-docs)/v1.:minor([0-2]{1,}).(\\d)',
+    destination: '/:base/v1.:minor.x',
     permanent: true,
   },
   {
-    source: '/:base(docs|api-docs)/v1.2.(\\d)/:path*',
-    destination: '/:base/v1.2.x/:path',
-    permanent: true,
-  },
-  {
-    source: '/:base(docs|api-docs)/v1.1.(\\d)',
-    destination: '/:base/v1.1.x',
-    permanent: true,
-  },
-  {
-    source: '/:base(docs|api-docs)/v1.1.(\\d)/:path*',
-    destination: '/:base/v1.1.x/:path',
-    permanent: true,
-  },
-  {
-    source: '/:base(docs|api-docs)/v1.0.(\\d)',
-    destination: '/:base/v1.0.x',
-    permanent: true,
-  },
-  {
-    source: '/:base(docs|api-docs)/v1.0.(\\d)/:path*',
-    destination: '/:base/v1.0.x/:path',
+    source: '/:base(docs|api-docs)/v1.:minor([0-2]{1,}).(\\d)/:path*',
+    destination: '/:base/v1.:minor.x/:path',
     permanent: true,
   },
 ]

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1384,7 +1384,7 @@ module.exports = [
 
   // Redirects for exact versioned-docs to respective generic versions
   {
-    source: '/:base(docs|api-docs)/v1.:minor([0-2]{1,}).(\\d)',
+    source: '/:base(docs|api-docs)/v1.:minor([0-2]{1,}).(\\d+)',
     destination: '/:base/v1.:minor.x',
     permanent: true,
   },

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1393,27 +1393,27 @@ module.exports = [
   //   permanent: true
   // }
   {
-    source: '/:base(docs|api-docs)/v1.2.(?\\d)',
+    source: '/:base(docs|api-docs)/v1.2.(\\d)',
     destination: '/:base/v1.2.x',
     permanent: true,
   },
   // {
-  //   source: '/:base(docs|api-docs)/v1.2.(?\\d)/:path*',
+  //   source: '/:base(docs|api-docs)/v1.2.(\\d)/:path*',
   //   destination: '/:base/v1.2.x/:path',
   //   permanent: true,
   // },
   {
-    source: '/:base(docs|api-docs)/v1.1.(?\\d)',
+    source: '/:base(docs|api-docs)/v1.1.(\\d)',
     destination: '/:base/v1.2.x',
     permanent: true,
   },
   // {
-  //   source: '/:base(docs|api-docs)/v1.1.(?\\d)/:path*',
+  //   source: '/:base(docs|api-docs)/v1.1.(\\d)/:path*',
   //   destination: '/:base/v1.2.x/:path',
   //   permanent: true,
   // },
   {
-    source: '/:base(docs|api-docs)/v1.0.(?\\d)',
+    source: '/:base(docs|api-docs)/v1.0.(\\d)',
     destination: '/:base/v1.2.x',
     permanent: true,
   },

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1381,4 +1381,45 @@ module.exports = [
     destination: '/api-docs/:path*',
     permanent: true,
   },
+
+  // Redirects for exact versioned-docs to respective generic versions
+  //   /docs/v1.2.5            -> /docs/v1.2.x
+  //   /docs/v1.2.5/install    -> /docs/v1.2.x/install
+  //   /api-docs/v1.2.5        -> /api-docs/v1.2.x
+  //   /api-docs/v1.2.5/client -> /api-docs/v1.2.x/client
+  // {
+  //   source: '/:base(docs|api-docs)/((?<majorMinor>\\d\.\\d)\.(?!x))/:path*'
+  //   destination: '/:base/:majorMinor.x/:path'
+  //   permanent: true
+  // }
+  {
+    source: '/:base(docs|api-docs)/v1.2.(?\\d)',
+    destination: '/:base/v1.2.x',
+    permanent: true,
+  },
+  // {
+  //   source: '/:base(docs|api-docs)/v1.2.(?\\d)/:path*',
+  //   destination: '/:base/v1.2.x/:path',
+  //   permanent: true,
+  // },
+  {
+    source: '/:base(docs|api-docs)/v1.1.(?\\d)',
+    destination: '/:base/v1.2.x',
+    permanent: true,
+  },
+  // {
+  //   source: '/:base(docs|api-docs)/v1.1.(?\\d)/:path*',
+  //   destination: '/:base/v1.2.x/:path',
+  //   permanent: true,
+  // },
+  {
+    source: '/:base(docs|api-docs)/v1.0.(?\\d)',
+    destination: '/:base/v1.2.x',
+    permanent: true,
+  },
+  // {
+  //   source: '/:base(docs|api-docs)/v1.0.(?\\d)/:path*',
+  //   destination: '/:base/v1.2.x/:path',
+  //   permanent: true,
+  // },
 ]

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1383,43 +1383,34 @@ module.exports = [
   },
 
   // Redirects for exact versioned-docs to respective generic versions
-  //   /docs/v1.2.5            -> /docs/v1.2.x
-  //   /docs/v1.2.5/install    -> /docs/v1.2.x/install
-  //   /api-docs/v1.2.5        -> /api-docs/v1.2.x
-  //   /api-docs/v1.2.5/client -> /api-docs/v1.2.x/client
-  // {
-  //   source: '/:base(docs|api-docs)/((?<majorMinor>\\d\.\\d)\.(?!x))/:path*'
-  //   destination: '/:base/:majorMinor.x/:path'
-  //   permanent: true
-  // }
   {
     source: '/:base(docs|api-docs)/v1.2.(\\d)',
     destination: '/:base/v1.2.x',
     permanent: true,
   },
-  // {
-  //   source: '/:base(docs|api-docs)/v1.2.(\\d)/:path*',
-  //   destination: '/:base/v1.2.x/:path',
-  //   permanent: true,
-  // },
+  {
+    source: '/:base(docs|api-docs)/v1.2.(\\d)/:path*',
+    destination: '/:base/v1.2.x/:path',
+    permanent: true,
+  },
   {
     source: '/:base(docs|api-docs)/v1.1.(\\d)',
-    destination: '/:base/v1.2.x',
+    destination: '/:base/v1.1.x',
     permanent: true,
   },
-  // {
-  //   source: '/:base(docs|api-docs)/v1.1.(\\d)/:path*',
-  //   destination: '/:base/v1.2.x/:path',
-  //   permanent: true,
-  // },
+  {
+    source: '/:base(docs|api-docs)/v1.1.(\\d)/:path*',
+    destination: '/:base/v1.1.x/:path',
+    permanent: true,
+  },
   {
     source: '/:base(docs|api-docs)/v1.0.(\\d)',
-    destination: '/:base/v1.2.x',
+    destination: '/:base/v1.0.x',
     permanent: true,
   },
-  // {
-  //   source: '/:base(docs|api-docs)/v1.0.(?\\d)/:path*',
-  //   destination: '/:base/v1.2.x/:path',
-  //   permanent: true,
-  // },
+  {
+    source: '/:base(docs|api-docs)/v1.0.(\\d)/:path*',
+    destination: '/:base/v1.0.x/:path',
+    permanent: true,
+  },
 ]

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1389,7 +1389,7 @@ module.exports = [
     permanent: true,
   },
   {
-    source: '/:base(docs|api-docs)/v1.:minor([0-2]{1,}).(\\d)/:path*',
+    source: '/:base(docs|api-docs)/v1.:minor([0-2]{1,}).(\\d+)/:path*',
     destination: '/:base/v1.:minor.x/:path',
     permanent: true,
   },


### PR DESCRIPTION
# Description

This redirects all `v1.2._`, `v1.1._` and `v1.0._` docs to respective generic release versions: `v1.2.x`, `v1.1.x`, and `v1.0.x`

**Dont merge until the targets are live and ready**

### Tests

```console
λ  curl -I -X GET nomad-p2ipxjp94-hashicorp.vercel.app/docs/1.0.9000
HTTP/1.1 308 Permanent Redirect
Location: https://nomad-p2ipxjp94-hashicorp.vercel.app/docs/1.0.9000

λ  curl -I -X GET nomad-p2ipxjp94-hashicorp.vercel.app/docs/1.0.9000/foobar
HTTP/1.1 308 Permanent Redirect
Location: https://nomad-p2ipxjp94-hashicorp.vercel.app/docs/1.0.9000/foobar

λ  curl -I -X GET nomad-p2ipxjp94-hashicorp.vercel.app/docs/1.1.9000
HTTP/1.1 308 Permanent Redirect
Location: https://nomad-p2ipxjp94-hashicorp.vercel.app/docs/1.1.9000

λ  curl -I -X GET nomad-p2ipxjp94-hashicorp.vercel.app/docs/1.1.9000/foobar
HTTP/1.1 308 Permanent Redirect
Location: https://nomad-p2ipxjp94-hashicorp.vercel.app/docs/1.1.9000/foobar

λ  curl -I -X GET nomad-p2ipxjp94-hashicorp.vercel.app/docs/1.2.9000
HTTP/1.1 308 Permanent Redirect
Location: https://nomad-p2ipxjp94-hashicorp.vercel.app/docs/1.2.9000

λ  curl -I -X GET nomad-p2ipxjp94-hashicorp.vercel.app/docs/1.2.9000/foobar
HTTP/1.1 308 Permanent Redirect
Location: https://nomad-p2ipxjp94-hashicorp.vercel.app/docs/1.2.9000/foobar
```