### PR TITLE
ui: remove beta tag from gutter menu for CSI

### DIFF
--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -68,9 +68,6 @@
             data-test-gutter-link="storage"
           >
             Storage
-            <span class="tag is-small">
-              Beta
-            </span>
           </LinkTo>
         </li>
       </ul>


### PR DESCRIPTION
In Nomad 1.3.0, the storage integration (CSI) is finally out of beta.