### PR TITLE
E2E: add debugging outputs for disconnected clients test

### DIFF
--- a/e2e/disconnectedclients/disconnectedclients_test.go
+++ b/e2e/disconnectedclients/disconnectedclients_test.go
@@ -216,6 +216,13 @@ func waitForAllocStatusMap(jobID, disconnectedAllocID, unchangedAllocID string, 
 			}
 		}
 		if merr != nil {
+			fmt.Printf("test failed, printing allocation status of all %q allocs for analysis\n", jobID)
+			fmt.Println("----------------")
+			for _, alloc := range allocs {
+				out, _ := e2eutil.Command("nomad", "alloc", "status", alloc["ID"])
+				fmt.Println(out)
+				fmt.Println("----------------")
+			}
 			return false, merr.ErrorOrNil()
 		}
 


### PR DESCRIPTION
This test has a failure that's happening only occassionally and not
very reproducibly. Print out the allocation status on test failure so
that we can do some post-mortum debugging of the test on nightly.