### PR TITLE
CSI: handle per-alloc volumes in `alloc status -verbose` CLI

### DIFF
--- a/.changelog/12573.txt
+++ b/.changelog/12573.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where per-alloc volumes used the incorrect ID when querying for `alloc status -verbose`
+```

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -826,9 +826,14 @@ FOUND:
 				fmt.Sprintf("%s|%v", volReq.Name, *volMount.ReadOnly))
 		case structs.VolumeTypeCSI:
 			if verbose {
+				source := volReq.Source
+				if volReq.PerAlloc {
+					source = source + structs.AllocSuffix(alloc.Name)
+				}
+
 				// there's an extra API call per volume here so we toggle it
 				// off with the -verbose flag
-				vol, _, err := client.CSIVolumes().Info(volReq.Source, nil)
+				vol, _, err := client.CSIVolumes().Info(source, nil)
 				if err != nil {
 					c.Ui.Error(fmt.Sprintf("Error retrieving volume info for %q: %s",
 						volReq.Name, err))


### PR DESCRIPTION
While walking @philrenaud thru https://github.com/hashicorp/nomad/issues/11965 I realized that we have the exact same problem in the CLI. 🤦 

The Nomad client's `csi_hook` interpolates the alloc suffix with the
volume request's name for CSI volumes with `per_alloc = true`, turning
`example` into `example[1]`. We need to do this same behavior in the
`alloc status` output so that we show the correct volume.