### PR TITLE
command/agent: check err before close

### DIFF
--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -1113,9 +1113,8 @@ func TestHTTPServer_Limits_OK(t *testing.T) {
 			conf.Address = a.HTTPAddr()
 			conf.TLSConfig.Insecure = true
 			client, err := api.NewClient(conf)
-			defer client.Close()
-
 			require.NoError(t, err)
+			defer client.Close()
 
 			// Assert a blocking query isn't timed out by the
 			// handshake timeout


### PR DESCRIPTION
This fixes a test where `defer client.Close()` was happening before an `err` check.