### PR TITLE
CSI: fix volume status prefix matching in CLI

### DIFF
--- a/command/volume_status_csi.go
+++ b/command/volume_status_csi.go
@@ -37,6 +37,7 @@ func (c *VolumeStatusCommand) csiStatus(client *api.Client, id string) int {
 	var ns string
 
 	if len(vols) == 1 {
+		// need to set id from the actual ID because it might be a prefix
 		id = vols[0].ID
 		ns = vols[0].Namespace
 	}

--- a/command/volume_status_csi.go
+++ b/command/volume_status_csi.go
@@ -33,8 +33,26 @@ func (c *VolumeStatusCommand) csiStatus(client *api.Client, id string) int {
 		c.Ui.Error(fmt.Sprintf("No volumes(s) with prefix or ID %q found", id))
 		return 1
 	}
+
+	var ns string
+
+	if len(vols) == 1 {
+		id = vols[0].ID
+		ns = vols[0].Namespace
+	}
+
+	// List sorts by CreateIndex, not by ID, so we need to search for
+	// exact matches but account for multiple exact ID matches across
+	// namespaces
 	if len(vols) > 1 {
-		if (id != vols[0].ID) || (c.allNamespaces() && vols[0].ID == vols[1].ID) {
+		exactMatchesCount := 0
+		for _, vol := range vols {
+			if vol.ID == id {
+				exactMatchesCount++
+				ns = vol.Namespace
+			}
+		}
+		if exactMatchesCount != 1 {
 			out, err := c.csiFormatVolumes(vols)
 			if err != nil {
 				c.Ui.Error(fmt.Sprintf("Error formatting: %s", err))
@@ -44,9 +62,9 @@ func (c *VolumeStatusCommand) csiStatus(client *api.Client, id string) int {
 			return 1
 		}
 	}
-	id = vols[0].ID
 
 	// Try querying the volume
+	client.SetNamespace(ns)
 	vol, _, err := client.CSIVolumes().Info(id, nil)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error querying volume: %s", err))


### PR DESCRIPTION
The API for `CSIVolume.List` sorts by created index and not by ID,
which breaks the logic for prefix matching in the `volume status`
output when the prefix is also an exact match. Ensure that we're
handling this case correctly.

---

No changelog because this hasn't shipped in a GA version.

```
$ nomad volume status -namespace '*'
Container Storage Interface
ID                 Name               Plugin ID               Schedulable  Access Mode
csi-volume-nfs     csi-volume-nfs     org.democratic-csi.nfs  true         multi-node-multi-writer
csi-volume-nfs[0]  csi-volume-nfs[0]  org.democratic-csi.nfs  true         multi-node-multi-writer
csi-volume-nfs[1]  csi-volume-nfs[1]  org.democratic-csi.nfs  true         multi-node-multi-writer

$ nomad volume status -namespace '*' csi-volume-nfs | head -1
ID                   = csi-volume-nfs

$ nomad volume status -namespace 'prod' csi-volume-nfs | head -1
ID                   = csi-volume-nfs

$ nomad volume status csi-volume-nfs
No volumes(s) with prefix or ID "csi-volume-nfs" found

$ nomad volume status -namespace 'prod' 'csi-volume-nfs['
Prefix matched multiple volumes

ID                 Name               Plugin ID               Schedulable  Access Mode
csi-volume-nfs[0]  csi-volume-nfs[0]  org.democratic-csi.nfs  true         multi-node-multi-writer
csi-volume-nfs[1]  csi-volume-nfs[1]  org.democratic-csi.nfs  true         multi-node-multi-writer
```
