### PR TITLE
bug:  fix filter and search

### DIFF
--- a/ui/app/controllers/evaluations/index.js
+++ b/ui/app/controllers/evaluations/index.js
@@ -120,6 +120,7 @@ export default class EvaluationsController extends Controller {
       { key: 'rolling-update', label: 'Rolling Update' },
       { key: 'deployment-watcher', label: 'Deployment Watcher' },
       { key: 'failed-follow-up', label: 'Failed Follow Up' },
+      { key: 'max-disconnect-timeout', label: 'Max Disconnect Timeout' },
       { key: 'max-plan-attempts', label: 'Max Plan Attempts' },
       { key: 'alloc-failure', label: 'Allocation Failure' },
       { key: 'queued-allocs', label: 'Queued Allocations' },

--- a/ui/app/controllers/evaluations/index.js
+++ b/ui/app/controllers/evaluations/index.js
@@ -152,6 +152,45 @@ export default class EvaluationsController extends Controller {
     ];
   }
 
+  filters = ['status', 'qpNamespace', 'type', 'triggeredBy', 'searchTerm'];
+
+  get hasFiltersApplied() {
+    return this.filters.reduce((result, filter) => {
+      if (this[filter]) {
+        result = true;
+      }
+      return result;
+    }, false);
+  }
+
+  get currentFilters() {
+    const result = [];
+    for (const filter of this.filters) {
+      if (this[filter]) {
+        result.push({ [filter]: this[filter] });
+      }
+    }
+    return result;
+  }
+
+  get noMatchText() {
+    let text = '';
+    if (this.hasFiltersApplied) {
+      for (let i = 0; i < this.currentFilters.length; i++) {
+        const filter = this.currentFilters[i];
+        const [filterName] = Object.keys(filter);
+        const filterValue = filter[filterName];
+        if (i !== 0 && i !== this.currentFilters.length - 1)
+          text = text.concat(`, ${filterName}: ${filterValue}`);
+        if (i === 0) text = text.concat(`${filterName}: ${filterValue}`);
+        if (i === this.currentFilters.length - 1)
+          text = text.concat(`, ${filterName}: ${filterValue}.`);
+      }
+    }
+
+    return text;
+  }
+
   @tracked pageSize = this.userSettings.pageSize;
   @tracked nextToken = null;
   @tracked previousTokens = [];

--- a/ui/app/routes/evaluations/index.js
+++ b/ui/app/routes/evaluations/index.js
@@ -32,9 +32,7 @@ export default class EvaluationsIndexRoute extends Route {
     nextToken,
     pageSize,
     searchTerm,
-    // eslint-disable-next-line no-unused-vars
     status,
-    // eslint-disable-next-line no-unused-vars
     triggeredBy,
     type,
     qpNamespace: namespace,
@@ -59,9 +57,8 @@ export default class EvaluationsIndexRoute extends Route {
       namespace,
       per_page: pageSize,
       next_token: nextToken,
-      // TODO: add support for status and triggeredBy filters
-      //status,
-      //triggeredBy,
+      status,
+      triggeredBy,
       filter: generateFilter(),
     });
   }

--- a/ui/app/routes/evaluations/index.js
+++ b/ui/app/routes/evaluations/index.js
@@ -37,6 +37,10 @@ export default class EvaluationsIndexRoute extends Route {
     type,
     qpNamespace: namespace,
   }) {
+    /*
+    We use our own DSL for filter expressions. This function takes our query parameters and builds a query that matches our DSL.
+    Documentation can be found here:  https://www.nomadproject.io/api-docs#filtering
+    */
     const generateFilterExpression = () => {
       const searchFilter = searchTerm
         ? `ID contains "${searchTerm}" or JobID contains "${searchTerm}" or NodeID contains "${searchTerm}" or TriggeredBy contains "${searchTerm}"`

--- a/ui/app/routes/evaluations/index.js
+++ b/ui/app/routes/evaluations/index.js
@@ -37,20 +37,51 @@ export default class EvaluationsIndexRoute extends Route {
     type,
     qpNamespace: namespace,
   }) {
-    const generateFilter = () => {
+    const generateFilterExpression = () => {
       const searchFilter = searchTerm
         ? `ID contains "${searchTerm}" or JobID contains "${searchTerm}" or NodeID contains "${searchTerm}" or TriggeredBy contains "${searchTerm}"`
         : null;
       const typeFilter =
         type === 'client' ? `NodeID is not empty` : `NodeID is empty`;
       const triggeredByFilter = `TriggeredBy contains "${triggeredBy}"`;
+      const statusFilter = `Status contains "${status}"`;
 
-      if (searchTerm && type) return `${searchFilter} ${typeFilter}`;
-      if (searchTerm && triggeredBy)
-        return `${searchFilter} ${triggeredByFilter}`;
-      if (searchTerm) return searchFilter;
-      if (type) return typeFilter;
-      if (triggeredBy) return triggeredByFilter;
+      let filterExp;
+      if (searchTerm) {
+        if (!type && !status && !triggeredBy) {
+          return searchFilter;
+        }
+        filterExp = `(${searchFilter})`;
+        if (type) {
+          filterExp = `${filterExp} and ${typeFilter}`;
+        }
+        if (triggeredBy) {
+          filterExp = `${filterExp} and ${triggeredByFilter}`;
+        }
+        if (status) {
+          filterExp = `${filterExp} and ${statusFilter}`;
+        }
+        return filterExp;
+      }
+
+      if (type || status || triggeredBy) {
+        const lookup = {
+          [type]: typeFilter,
+          [status]: statusFilter,
+          [triggeredBy]: triggeredByFilter,
+        };
+
+        filterExp = [type, status, triggeredBy].reduce((result, filter) => {
+          const expression = lookup[filter];
+          if (!!filter && result !== '') {
+            result = result.concat(` and ${expression}`);
+          } else if (filter) {
+            result = expression;
+          }
+          return result;
+        }, '');
+        return filterExp;
+      }
 
       return null;
     };
@@ -61,8 +92,7 @@ export default class EvaluationsIndexRoute extends Route {
       namespace,
       per_page: pageSize,
       next_token: nextToken,
-      status,
-      filter: generateFilter(),
+      filter: generateFilterExpression(),
     });
   }
 }

--- a/ui/app/routes/evaluations/index.js
+++ b/ui/app/routes/evaluations/index.js
@@ -43,10 +43,14 @@ export default class EvaluationsIndexRoute extends Route {
         : null;
       const typeFilter =
         type === 'client' ? `NodeID is not empty` : `NodeID is empty`;
+      const triggeredByFilter = `TriggeredBy contains "${triggeredBy}"`;
 
       if (searchTerm && type) return `${searchFilter} ${typeFilter}`;
+      if (searchTerm && triggeredBy)
+        return `${searchFilter} ${triggeredByFilter}`;
       if (searchTerm) return searchFilter;
       if (type) return typeFilter;
+      if (triggeredBy) return triggeredByFilter;
 
       return null;
     };
@@ -58,7 +62,6 @@ export default class EvaluationsIndexRoute extends Route {
       per_page: pageSize,
       next_token: nextToken,
       status,
-      triggeredBy,
       filter: generateFilter(),
     });
   }

--- a/ui/app/templates/evaluations/index.hbs
+++ b/ui/app/templates/evaluations/index.hbs
@@ -12,7 +12,6 @@
         />
       </div>
       <div class="toolbar-item is-right-aligned">
-        {{!-- TODO: add support for status and triggered by
         <SingleSelectDropdown
           data-test-evaluation-status-facet
           @label="Status"
@@ -34,7 +33,6 @@
           @selection={{this.type}}
           @onSelect={{action this.setQueryParam "type"}}
         />
-        --}}
         <SingleSelectDropdown
           data-test-evaluation-namespace-facet
           @label="Namespace"
@@ -73,7 +71,7 @@
           <tr
             data-test-evaluation="{{row.model.shortId}}"
             style="cursor: pointer;"
-            class="{{if (eq this.currentEval row.model.id) 'is-active'}}"
+            class="{{if (eq this.currentEval row.model.id) "is-active"}}"
             tabindex="0"
             {{on "click" (fn this.handleEvaluationClick row.model)}}
             {{on "keyup" (fn this.handleEvaluationClick row.model)}}

--- a/ui/app/templates/evaluations/index.hbs
+++ b/ui/app/templates/evaluations/index.hbs
@@ -164,11 +164,11 @@
             No Matches
           </h3>
           <p class="empty-message-body">
-            {{#if this.status}}
+            {{#if this.hasFiltersApplied}}
               <span data-test-no-eval-match>
-                No evaluations match the status
+                No evaluations that match:
                 <strong>
-                  {{this.status}}
+                  {{this.noMatchText}}
                 </strong>
               </span>
             {{else}}

--- a/ui/tests/acceptance/evaluations-test.js
+++ b/ui/tests/acceptance/evaluations-test.js
@@ -143,9 +143,8 @@ module('Acceptance | evaluations list', function (hooks) {
           per_page: '25',
           next_token: '',
           filter: '',
-          // TODO: add support for status and triggeredBy filters.
-          // status: '',
-          // triggeredBy: '',
+          status: '',
+          triggeredBy: '',
         },
         'Forwards the correct query parameters on default query when route initially loads'
       );
@@ -163,8 +162,7 @@ module('Acceptance | evaluations list', function (hooks) {
   });
 
   module('filters', function () {
-    // TODO: add support for status and triggeredBy filters.
-    test.skip('it should enable filtering by evaluation status', async function (assert) {
+    test('it should enable filtering by evaluation status', async function (assert) {
       assert.expect(2);
 
       server.get('/evaluations', getStandardRes);
@@ -187,15 +185,12 @@ module('Acceptance | evaluations list', function (hooks) {
         return [];
       });
 
-      // TODO: add support for status and triggeredBy filters.
-      /*
       await clickTrigger('[data-test-evaluation-status-facet]');
       await selectChoose('[data-test-evaluation-status-facet]', 'Pending');
 
       assert
         .dom('[data-test-no-eval-match]')
         .exists('Renders a message saying no evaluations match filter status');
-      */
     });
 
     test('it should enable filtering by namespace', async function (assert) {
@@ -213,9 +208,8 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             next_token: '',
             filter: '',
-            // TODO: add support for status and triggeredBy filters.
-            // status: '',
-            // triggeredBy: '',
+            status: '',
+            triggeredBy: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -230,8 +224,7 @@ module('Acceptance | evaluations list', function (hooks) {
         .exists('Renders a message saying no evaluations match filter status');
     });
 
-    // TODO: add support for status and triggeredBy filters.
-    test.skip('it should enable filtering by triggered by', async function (assert) {
+    test('it should enable filtering by triggered by', async function (assert) {
       assert.expect(2);
 
       server.get('/evaluations', getStandardRes);
@@ -265,8 +258,7 @@ module('Acceptance | evaluations list', function (hooks) {
         .exists('Renders a message saying no evaluations match filter status');
     });
 
-    // TODO: add support for type filter.
-    test.skip('it should enable filtering by type', async function (assert) {
+    test('it should enable filtering by type', async function (assert) {
       assert.expect(2);
 
       server.get('/evaluations', getStandardRes);
@@ -313,9 +305,8 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             next_token: '',
             filter: `ID contains "${searchTerm}" or JobID contains "${searchTerm}" or NodeID contains "${searchTerm}" or TriggeredBy contains "${searchTerm}"`,
-            // TODO: add support for status and triggeredBy filters.
-            // status: '',
-            // triggeredBy: '',
+            status: '',
+            triggeredBy: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -352,9 +343,8 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '50',
             next_token: '',
             filter: '',
-            // TODO: add support for status and triggeredBy filters.
-            // status: '',
-            // triggeredBy: '',
+            status: '',
+            triggeredBy: '',
           },
           'It makes a request with the per_page set by the user'
         );
@@ -388,9 +378,8 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             next_token: 'next-token-1',
             filter: '',
-            // TODO: add support for status and triggeredBy filters.
-            // status: '',
-            // triggeredBy: '',
+            status: '',
+            triggeredBy: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -416,9 +405,8 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             next_token: 'next-token-2',
             filter: '',
-            // TODO: add support for status and triggeredBy filters.
-            // status: '',
-            // triggeredBy: '',
+            status: '',
+            triggeredBy: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -444,9 +432,8 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             next_token: 'next-token-1',
             filter: '',
-            // TODO: add support for status and triggeredBy filters.
-            // status: '',
-            // triggeredBy: '',
+            status: '',
+            triggeredBy: '',
           },
           'It makes a request using the stored old token.'
         );
@@ -467,9 +454,8 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             next_token: '',
             filter: '',
-            // TODO: add support for status and triggeredBy filters.
-            // status: '',
-            // triggeredBy: '',
+            status: '',
+            triggeredBy: '',
           },
           'When there are no more stored previous tokens, we will request with no next-token.'
         );
@@ -483,8 +469,7 @@ module('Acceptance | evaluations list', function (hooks) {
       await click('[data-test-eval-pagination-prev]');
     });
 
-    // TODO: add support for status and triggeredBy filters.
-    test.skip('it should clear all query parameters on refresh', async function (assert) {
+    test('it should clear all query parameters on refresh', async function (assert) {
       assert.expect(1);
 
       server.get('/evaluations', function () {
@@ -529,8 +514,7 @@ module('Acceptance | evaluations list', function (hooks) {
       await click('[data-test-eval-refresh]');
     });
 
-    // TODO: add support for status and triggeredBy filters.
-    test.skip('it should reset pagination when filters are applied', async function (assert) {
+    test('it should reset pagination when filters are applied', async function (assert) {
       assert.expect(1);
 
       server.get('/evaluations', function () {

--- a/ui/tests/acceptance/evaluations-test.js
+++ b/ui/tests/acceptance/evaluations-test.js
@@ -143,7 +143,6 @@ module('Acceptance | evaluations list', function (hooks) {
           per_page: '25',
           next_token: '',
           filter: '',
-          status: '',
         },
         'Forwards the correct query parameters on default query when route initially loads'
       );
@@ -174,9 +173,8 @@ module('Acceptance | evaluations list', function (hooks) {
           {
             namespace: '*',
             per_page: '25',
-            status: 'pending',
             next_token: '',
-            filter: '',
+            filter: 'Status contains "pending"',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -206,7 +204,6 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             next_token: '',
             filter: '',
-            status: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -234,7 +231,6 @@ module('Acceptance | evaluations list', function (hooks) {
           {
             namespace: '*',
             per_page: '25',
-            status: '',
             next_token: '',
             filter: `TriggeredBy contains "periodic-job"`,
           },
@@ -267,7 +263,6 @@ module('Acceptance | evaluations list', function (hooks) {
           {
             namespace: '*',
             per_page: '25',
-            status: '',
             next_token: '',
             filter: 'NodeID is not empty',
           },
@@ -300,7 +295,6 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             next_token: '',
             filter: `ID contains "${searchTerm}" or JobID contains "${searchTerm}" or NodeID contains "${searchTerm}" or TriggeredBy contains "${searchTerm}"`,
-            status: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -308,6 +302,81 @@ module('Acceptance | evaluations list', function (hooks) {
       });
 
       await typeIn('[data-test-evaluations-search] input', searchTerm);
+
+      assert
+        .dom('[data-test-empty-evaluations-list]')
+        .exists('Renders a message saying no evaluations match filter status');
+    });
+
+    test('it should enable combining filters and search', async function (assert) {
+      assert.expect(5);
+
+      server.get('/evaluations', getStandardRes);
+
+      await visit('/evaluations');
+
+      const searchTerm = 'Lasso';
+      server.get('/evaluations', function (_server, fakeRequest) {
+        assert.deepEqual(
+          fakeRequest.queryParams,
+          {
+            namespace: '*',
+            per_page: '25',
+            next_token: '',
+            filter: `ID contains "${searchTerm}" or JobID contains "${searchTerm}" or NodeID contains "${searchTerm}" or TriggeredBy contains "${searchTerm}"`,
+          },
+          'It makes another server request using the options selected by the user'
+        );
+        return [];
+      });
+      await typeIn('[data-test-evaluations-search] input', searchTerm);
+
+      server.get('/evaluations', function (_server, fakeRequest) {
+        assert.deepEqual(
+          fakeRequest.queryParams,
+          {
+            namespace: '*',
+            per_page: '25',
+            next_token: '',
+            filter: `(ID contains "${searchTerm}" or JobID contains "${searchTerm}" or NodeID contains "${searchTerm}" or TriggeredBy contains "${searchTerm}") and NodeID is not empty`,
+          },
+          'It makes another server request using the options selected by the user'
+        );
+        return [];
+      });
+      await clickTrigger('[data-test-evaluation-type-facet]');
+      await selectChoose('[data-test-evaluation-type-facet]', 'Client');
+
+      server.get('/evaluations', function (_server, fakeRequest) {
+        assert.deepEqual(
+          fakeRequest.queryParams,
+          {
+            namespace: '*',
+            per_page: '25',
+            next_token: '',
+            filter: `NodeID is not empty`,
+          },
+          'It makes another server request using the options selected by the user'
+        );
+        return [];
+      });
+      await click('[data-test-evaluations-search] button');
+
+      server.get('/evaluations', function (_server, fakeRequest) {
+        assert.deepEqual(
+          fakeRequest.queryParams,
+          {
+            namespace: '*',
+            per_page: '25',
+            next_token: '',
+            filter: `NodeID is not empty and Status contains "complete"`,
+          },
+          'It makes another server request using the options selected by the user'
+        );
+        return [];
+      });
+      await clickTrigger('[data-test-evaluation-status-facet]');
+      await selectChoose('[data-test-evaluation-status-facet]', 'Complete');
 
       assert
         .dom('[data-test-empty-evaluations-list]')
@@ -337,7 +406,6 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '50',
             next_token: '',
             filter: '',
-            status: '',
           },
           'It makes a request with the per_page set by the user'
         );
@@ -371,7 +439,6 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             next_token: 'next-token-1',
             filter: '',
-            status: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -397,7 +464,6 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             next_token: 'next-token-2',
             filter: '',
-            status: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -423,7 +489,6 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             next_token: 'next-token-1',
             filter: '',
-            status: '',
           },
           'It makes a request using the stored old token.'
         );
@@ -444,7 +509,6 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             next_token: '',
             filter: '',
-            status: '',
           },
           'When there are no more stored previous tokens, we will request with no next-token.'
         );
@@ -486,7 +550,6 @@ module('Acceptance | evaluations list', function (hooks) {
           {
             namespace: '*',
             per_page: '25',
-            status: '',
             next_token: '',
             filter: '',
           },
@@ -534,9 +597,8 @@ module('Acceptance | evaluations list', function (hooks) {
           {
             namespace: '*',
             per_page: '25',
-            status: 'pending',
             next_token: '',
-            filter: '',
+            filter: 'Status contains "pending"',
           },
           'It clears all next token when filtered request is made'
         );

--- a/ui/tests/acceptance/evaluations-test.js
+++ b/ui/tests/acceptance/evaluations-test.js
@@ -144,7 +144,6 @@ module('Acceptance | evaluations list', function (hooks) {
           next_token: '',
           filter: '',
           status: '',
-          triggeredBy: '',
         },
         'Forwards the correct query parameters on default query when route initially loads'
       );
@@ -177,7 +176,6 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             status: 'pending',
             next_token: '',
-            triggeredBy: '',
             filter: '',
           },
           'It makes another server request using the options selected by the user'
@@ -209,7 +207,6 @@ module('Acceptance | evaluations list', function (hooks) {
             next_token: '',
             filter: '',
             status: '',
-            triggeredBy: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -239,8 +236,7 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             status: '',
             next_token: '',
-            triggeredBy: 'periodic-job',
-            filter: '',
+            filter: `TriggeredBy contains "periodic-job"`,
           },
           'It makes another server request using the options selected by the user'
         );
@@ -273,7 +269,6 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             status: '',
             next_token: '',
-            triggeredBy: '',
             filter: 'NodeID is not empty',
           },
           'It makes another server request using the options selected by the user'
@@ -306,7 +301,6 @@ module('Acceptance | evaluations list', function (hooks) {
             next_token: '',
             filter: `ID contains "${searchTerm}" or JobID contains "${searchTerm}" or NodeID contains "${searchTerm}" or TriggeredBy contains "${searchTerm}"`,
             status: '',
-            triggeredBy: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -344,7 +338,6 @@ module('Acceptance | evaluations list', function (hooks) {
             next_token: '',
             filter: '',
             status: '',
-            triggeredBy: '',
           },
           'It makes a request with the per_page set by the user'
         );
@@ -379,7 +372,6 @@ module('Acceptance | evaluations list', function (hooks) {
             next_token: 'next-token-1',
             filter: '',
             status: '',
-            triggeredBy: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -406,7 +398,6 @@ module('Acceptance | evaluations list', function (hooks) {
             next_token: 'next-token-2',
             filter: '',
             status: '',
-            triggeredBy: '',
           },
           'It makes another server request using the options selected by the user'
         );
@@ -433,7 +424,6 @@ module('Acceptance | evaluations list', function (hooks) {
             next_token: 'next-token-1',
             filter: '',
             status: '',
-            triggeredBy: '',
           },
           'It makes a request using the stored old token.'
         );
@@ -455,7 +445,6 @@ module('Acceptance | evaluations list', function (hooks) {
             next_token: '',
             filter: '',
             status: '',
-            triggeredBy: '',
           },
           'When there are no more stored previous tokens, we will request with no next-token.'
         );
@@ -499,7 +488,6 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             status: '',
             next_token: '',
-            triggeredBy: '',
             filter: '',
           },
           'It clears all query parameters when making a refresh'
@@ -548,7 +536,6 @@ module('Acceptance | evaluations list', function (hooks) {
             per_page: '25',
             status: 'pending',
             next_token: '',
-            triggeredBy: '',
             filter: '',
           },
           'It clears all next token when filtered request is made'


### PR DESCRIPTION
Resolves #12741
Resolves #12742

Fixes the 400 error that was being returned by the API and uses the new filter expression DSL.

Side Effect:

Conditional logic to generate error and no match copy.
