### PR TITLE
cli: add -json flag to support job commands

### DIFF
--- a/.changelog/12591.txt
+++ b/.changelog/12591.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Added -json flag to `nomad job {run,plan,validate}` to support parsing JSON formatted jobs
+```

--- a/command/helpers_test.go
+++ b/command/helpers_test.go
@@ -451,6 +451,84 @@ func TestJobGetter_HTTPServer(t *testing.T) {
 	}
 }
 
+func TestJobGetter_Validate(t *testing.T) {
+	cases := []struct {
+		name        string
+		jg          JobGetter
+		errContains string
+	}{
+		{
+			"StrictAndHCL1",
+			JobGetter{
+				HCL1:   true,
+				Strict: true,
+			},
+			"HCLv1 and HCLv2 strict",
+		},
+		{
+			"JSONandHCL1",
+			JobGetter{
+				HCL1: true,
+				JSON: true,
+			},
+			"HCL and JSON",
+		},
+		{
+			"VarsAndHCL1",
+			JobGetter{
+				HCL1: true,
+				Vars: []string{"foo"},
+			},
+			"variables with HCLv1",
+		},
+		{
+			"VarFilesAndHCL1",
+			JobGetter{
+				HCL1:     true,
+				VarFiles: []string{"foo.var"},
+			},
+			"variables with HCLv1",
+		},
+		{
+			"VarsAndJSON",
+			JobGetter{
+				JSON: true,
+				Vars: []string{"foo"},
+			},
+			"variables with JSON",
+		},
+		{
+			"VarFilesAndJSON",
+			JobGetter{
+				JSON:     true,
+				VarFiles: []string{"foo.var"},
+			},
+			"variables with JSON files",
+		},
+		{
+			"JSON_OK",
+			JobGetter{
+				JSON: true,
+			},
+			"",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.jg.Validate()
+
+			switch tc.errContains {
+			case "":
+				require.NoError(t, err)
+			default:
+				require.ErrorContains(t, err, tc.errContains)
+			}
+
+		})
+	}
+}
+
 func TestPrettyTimeDiff(t *testing.T) {
 	// Grab the time and truncate to the nearest second. This allows our tests
 	// to be deterministic since we don't have to worry about rounding.

--- a/command/job_plan_test.go
+++ b/command/job_plan_test.go
@@ -255,3 +255,19 @@ func TestPlanCommad_Preemptions(t *testing.T) {
 	require.Contains(out, "batch")
 	require.Contains(out, "service")
 }
+
+func TestPlanCommad_JSON(t *testing.T) {
+	ui := cli.NewMockUi()
+	cmd := &JobPlanCommand{
+		Meta: Meta{Ui: ui},
+	}
+
+	args := []string{
+		"-address=http://nope",
+		"-json",
+		"testdata/example-short.json",
+	}
+	code := cmd.Run(args)
+	require.Equal(t, 255, code)
+	require.Contains(t, ui.ErrorWriter.String(), "Error during plan: Put")
+}

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/helper"
-	flaghelper "github.com/hashicorp/nomad/helper/flags"
 	"github.com/posener/complete"
 )
 
@@ -90,6 +89,11 @@ Run Options:
     Override the priority of the evaluations produced as a result of this job
     submission. By default, this is set to the priority of the job.
 
+  -json
+    Parses the job file as JSON. If the outer object has a Job field, such as
+    from "nomad job inspect" or "nomad run -output", the value of the field is
+    used as the job.
+
   -hcl1
     Parses the job file as HCLv1.
 
@@ -158,6 +162,7 @@ func (c *JobRunCommand) AutocompleteFlags() complete.Flags {
 			"-output":          complete.PredictNothing,
 			"-policy-override": complete.PredictNothing,
 			"-preserve-counts": complete.PredictNothing,
+			"-json":            complete.PredictNothing,
 			"-hcl1":            complete.PredictNothing,
 			"-hcl2-strict":     complete.PredictNothing,
 			"-var":             complete.PredictAnything,
@@ -167,15 +172,18 @@ func (c *JobRunCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *JobRunCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictOr(complete.PredictFiles("*.nomad"), complete.PredictFiles("*.hcl"))
+	return complete.PredictOr(
+		complete.PredictFiles("*.nomad"),
+		complete.PredictFiles("*.hcl"),
+		complete.PredictFiles("*.json"),
+	)
 }
 
 func (c *JobRunCommand) Name() string { return "job run" }
 
 func (c *JobRunCommand) Run(args []string) int {
-	var detach, verbose, output, override, preserveCounts, hcl2Strict bool
+	var detach, verbose, output, override, preserveCounts bool
 	var checkIndexStr, consulToken, consulNamespace, vaultToken, vaultNamespace string
-	var varArgs, varFiles flaghelper.StringFlag
 	var evalPriority int
 
 	flagSet := c.Meta.FlagSet(c.Name(), FlagSetClient)
@@ -185,15 +193,16 @@ func (c *JobRunCommand) Run(args []string) int {
 	flagSet.BoolVar(&output, "output", false, "")
 	flagSet.BoolVar(&override, "policy-override", false, "")
 	flagSet.BoolVar(&preserveCounts, "preserve-counts", false, "")
-	flagSet.BoolVar(&c.JobGetter.hcl1, "hcl1", false, "")
-	flagSet.BoolVar(&hcl2Strict, "hcl2-strict", true, "")
+	flagSet.BoolVar(&c.JobGetter.JSON, "json", false, "")
+	flagSet.BoolVar(&c.JobGetter.HCL1, "hcl1", false, "")
+	flagSet.BoolVar(&c.JobGetter.Strict, "hcl2-strict", true, "")
 	flagSet.StringVar(&checkIndexStr, "check-index", "", "")
 	flagSet.StringVar(&consulToken, "consul-token", "", "")
 	flagSet.StringVar(&consulNamespace, "consul-namespace", "", "")
 	flagSet.StringVar(&vaultToken, "vault-token", "", "")
 	flagSet.StringVar(&vaultNamespace, "vault-namespace", "", "")
-	flagSet.Var(&varArgs, "var", "")
-	flagSet.Var(&varFiles, "var-file", "")
+	flagSet.Var(&c.JobGetter.Vars, "var", "")
+	flagSet.Var(&c.JobGetter.VarFiles, "var-file", "")
 	flagSet.IntVar(&evalPriority, "eval-priority", 0, "")
 
 	if err := flagSet.Parse(args); err != nil {
@@ -214,8 +223,13 @@ func (c *JobRunCommand) Run(args []string) int {
 		return 1
 	}
 
+	if err := c.JobGetter.Validate(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Invalid job options: %s", err))
+		return 1
+	}
+
 	// Get Job struct from Jobfile
-	job, err := c.JobGetter.ApiJobWithArgs(args[0], varArgs, varFiles, hcl2Strict)
+	job, err := c.JobGetter.Get(args[0])
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error getting job struct: %s", err))
 		return 1

--- a/command/job_run_test.go
+++ b/command/job_run_test.go
@@ -1,20 +1,22 @@
 package command
 
 import (
+	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
 )
 
-func TestRunCommand_Implements(t *testing.T) {
-	ci.Parallel(t)
-	var _ cli.Command = &JobRunCommand{}
-}
+var _ cli.Command = (*JobRunCommand)(nil)
 
 func TestRunCommand_Output_Json(t *testing.T) {
 	ci.Parallel(t)
@@ -214,4 +216,66 @@ func TestRunCommand_From_URL(t *testing.T) {
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Error getting jobfile") {
 		t.Fatalf("expected error getting jobfile, got: %s", out)
 	}
+}
+
+// TestRunCommand_JSON asserts that `nomad job run -json` accepts JSON jobs
+// with or without a top level Job key.
+func TestRunCommand_JSON(t *testing.T) {
+	ci.Parallel(t)
+	run := func(args ...string) (stdout string, stderr string, code int) {
+		ui := cli.NewMockUi()
+		cmd := &JobRunCommand{
+			Meta: Meta{Ui: ui},
+		}
+		t.Logf("run: nomad job run %s", strings.Join(args, " "))
+		code = cmd.Run(args)
+		return ui.OutputWriter.String(), ui.ErrorWriter.String(), code
+	}
+
+	// Agent startup is slow, do some work while we wait
+	agentReady := make(chan string)
+	go func() {
+		_, _, addr := testServer(t, false, nil)
+		agentReady <- addr
+	}()
+
+	// First convert HCL -> JSON with -output
+	stdout, stderr, code := run("-output", "assets/example-short.nomad")
+	require.Zero(t, code, stderr)
+	require.Empty(t, stderr)
+	require.NotEmpty(t, stdout)
+	t.Logf("run -output==> %s...", stdout[:12])
+
+	jsonFile := filepath.Join(t.TempDir(), "redis.json")
+	require.NoError(t, os.WriteFile(jsonFile, []byte(stdout), 0o640))
+
+	// Wait for agent to start and get its address
+	addr := ""
+	select {
+	case addr = <-agentReady:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out waiting for agent to start")
+	}
+
+	// Submit JSON
+	stdout, stderr, code = run("-detach", "-address", addr, "-json", jsonFile)
+	require.Zero(t, code, stderr)
+	require.Empty(t, stderr)
+
+	// Read the JSON from the API as it omits the Job envelope and
+	// therefore differs from -output
+	resp, err := http.Get(addr + "/v1/job/example")
+	require.NoError(t, err)
+	buf, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.NotEmpty(t, buf)
+	t.Logf("/v1/job/example==> %s...", string(buf[:12]))
+	require.NoError(t, os.WriteFile(jsonFile, buf, 0o640))
+
+	// Submit JSON
+	stdout, stderr, code = run("-detach", "-address", addr, "-json", jsonFile)
+	require.Zerof(t, code, "stderr: %s\njson: %s\n", stderr, string(buf))
+	require.Empty(t, stderr)
+	require.NotEmpty(t, stdout)
 }

--- a/command/job_validate_test.go
+++ b/command/job_validate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateCommand_Implements(t *testing.T) {
@@ -175,4 +176,25 @@ func TestValidateCommand_From_URL(t *testing.T) {
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Error getting jobfile") {
 		t.Fatalf("expected error getting jobfile, got: %s", out)
 	}
+}
+
+func TestValidateCommand_JSON(t *testing.T) {
+	ci.Parallel(t)
+
+	_, _, addr := testServer(t, false, nil)
+
+	ui := cli.NewMockUi()
+	cmd := &JobValidateCommand{
+		Meta: Meta{Ui: ui},
+	}
+
+	code := cmd.Run([]string{"-address", addr, "-json", "testdata/example-short.json"})
+
+	require.Zerof(t, code, "stdout: %s\nstdout: %s\n",
+		ui.OutputWriter.String(), ui.ErrorWriter.String())
+
+	code = cmd.Run([]string{"-address", addr, "-json", "testdata/example-short-bad.json"})
+
+	require.Equalf(t, 1, code, "stdout: %s\nstdout: %s\n",
+		ui.OutputWriter.String(), ui.ErrorWriter.String())
 }

--- a/command/testdata/example-short-bad.json
+++ b/command/testdata/example-short-bad.json
@@ -1,0 +1,124 @@
+{
+    "Job": {
+        "Region": null,
+        "Namespace": null,
+        "ID": "example",
+        "Name": "example",
+        "Type": null,
+        "Priority": null,
+        "AllAtOnce": null,
+        "Constraints": null,
+        "Affinities": null,
+        "TaskGroups": [
+            {
+                "Name": "cache",
+                "Count": null,
+                "Constraints": null,
+                "Affinities": null,
+                "Tasks": [
+                    {
+                        "Name": "redis",
+                        "Driver": "docker",
+                        "User": "",
+                        "Lifecycle": null,
+                        "Config": {
+                            "auth_soft_fail": true,
+                            "image": "redis:3.2",
+                            "ports": [
+                                "db"
+                            ]
+                        },
+                        "Constraints": null,
+                        "Affinities": null,
+                        "Env": null,
+                        "Services": null,
+                        "Resources": {
+                            "CPU": 500,
+                            "Cores": null,
+                            "MemoryMB": 256,
+                            "MemoryMaxMB": null,
+                            "DiskMB": null,
+                            "Networks": null,
+                            "Devices": null,
+                            "IOPS": null
+                        },
+                        "RestartPolicy": null,
+                        "Meta": null,
+                        "KillTimeout": null,
+                        "LogConfig": null,
+                        "Artifacts": null,
+                        "Vault": null,
+                        "Templates": null,
+                        "DispatchPayload": null,
+                        "VolumeMounts": null,
+                        "Leader": false,
+                        "ShutdownDelay": 0,
+                        "KillSignal": "",
+                        "Kind": "",
+                        "ScalingPolicies": null
+                    }
+                ],
+                "Spreads": null,
+                "Volumes": null,
+                "RestartPolicy": null,
+                "ReschedulePolicy": null,
+                "EphemeralDisk": null,
+                "Update": null,
+                "Migrate": null,
+                "Networks": [
+                    {
+                        "Mode": "",
+                        "Device": "",
+                        "CIDR": "",
+                        "IP": "",
+                        "DNS": null,
+                        "ReservedPorts": null,
+                        "DynamicPorts": [
+                            {
+                                "Label": "db",
+                                "Value": 0,
+                                "To": 6379,
+                                "HostNetwork": ""
+                            }
+                        ],
+                        "Hostname": "",
+                        "MBits": null
+                    }
+                ],
+                "Meta": null,
+                "Services": null,
+                "ShutdownDelay": null,
+                "StopAfterClientDisconnect": null,
+                "MaxClientDisconnect": null,
+                "Scaling": null,
+                "Consul": null
+            }
+        ],
+        "Update": null,
+        "Multiregion": null,
+        "Spreads": null,
+        "Periodic": null,
+        "ParameterizedJob": null,
+        "Reschedule": null,
+        "Migrate": null,
+        "Meta": null,
+        "ConsulToken": null,
+        "VaultToken": null,
+        "Stop": null,
+        "ParentID": null,
+        "Dispatched": false,
+        "DispatchIdempotencyToken": null,
+        "Payload": null,
+        "ConsulNamespace": null,
+        "VaultNamespace": null,
+        "NomadTokenID": null,
+        "Status": null,
+        "StatusDescription": null,
+        "Stable": null,
+        "Version": null,
+        "SubmitTime": null,
+        "CreateIndex": null,
+        "ModifyIndex": null,
+        "JobModifyIndex": null
+    }
+}

--- a/command/testdata/example-short.json
+++ b/command/testdata/example-short.json
@@ -1,0 +1,127 @@
+{
+    "Job": {
+        "Region": null,
+        "Namespace": null,
+        "ID": "example",
+        "Name": "example",
+        "Type": null,
+        "Priority": null,
+        "AllAtOnce": null,
+        "Datacenters": [
+            "dc1"
+        ],
+        "Constraints": null,
+        "Affinities": null,
+        "TaskGroups": [
+            {
+                "Name": "cache",
+                "Count": null,
+                "Constraints": null,
+                "Affinities": null,
+                "Tasks": [
+                    {
+                        "Name": "redis",
+                        "Driver": "docker",
+                        "User": "",
+                        "Lifecycle": null,
+                        "Config": {
+                            "auth_soft_fail": true,
+                            "image": "redis:3.2",
+                            "ports": [
+                                "db"
+                            ]
+                        },
+                        "Constraints": null,
+                        "Affinities": null,
+                        "Env": null,
+                        "Services": null,
+                        "Resources": {
+                            "CPU": 500,
+                            "Cores": null,
+                            "MemoryMB": 256,
+                            "MemoryMaxMB": null,
+                            "DiskMB": null,
+                            "Networks": null,
+                            "Devices": null,
+                            "IOPS": null
+                        },
+                        "RestartPolicy": null,
+                        "Meta": null,
+                        "KillTimeout": null,
+                        "LogConfig": null,
+                        "Artifacts": null,
+                        "Vault": null,
+                        "Templates": null,
+                        "DispatchPayload": null,
+                        "VolumeMounts": null,
+                        "Leader": false,
+                        "ShutdownDelay": 0,
+                        "KillSignal": "",
+                        "Kind": "",
+                        "ScalingPolicies": null
+                    }
+                ],
+                "Spreads": null,
+                "Volumes": null,
+                "RestartPolicy": null,
+                "ReschedulePolicy": null,
+                "EphemeralDisk": null,
+                "Update": null,
+                "Migrate": null,
+                "Networks": [
+                    {
+                        "Mode": "",
+                        "Device": "",
+                        "CIDR": "",
+                        "IP": "",
+                        "DNS": null,
+                        "ReservedPorts": null,
+                        "DynamicPorts": [
+                            {
+                                "Label": "db",
+                                "Value": 0,
+                                "To": 6379,
+                                "HostNetwork": ""
+                            }
+                        ],
+                        "Hostname": "",
+                        "MBits": null
+                    }
+                ],
+                "Meta": null,
+                "Services": null,
+                "ShutdownDelay": null,
+                "StopAfterClientDisconnect": null,
+                "MaxClientDisconnect": null,
+                "Scaling": null,
+                "Consul": null
+            }
+        ],
+        "Update": null,
+        "Multiregion": null,
+        "Spreads": null,
+        "Periodic": null,
+        "ParameterizedJob": null,
+        "Reschedule": null,
+        "Migrate": null,
+        "Meta": null,
+        "ConsulToken": null,
+        "VaultToken": null,
+        "Stop": null,
+        "ParentID": null,
+        "Dispatched": false,
+        "DispatchIdempotencyToken": null,
+        "Payload": null,
+        "ConsulNamespace": null,
+        "VaultNamespace": null,
+        "NomadTokenID": null,
+        "Status": null,
+        "StatusDescription": null,
+        "Stable": null,
+        "Version": null,
+        "SubmitTime": null,
+        "CreateIndex": null,
+        "ModifyIndex": null,
+        "JobModifyIndex": null
+    }
+}

--- a/website/content/docs/commands/job/plan.mdx
+++ b/website/content/docs/commands/job/plan.mdx
@@ -63,6 +63,10 @@ capability for the job's namespace.
 - `-policy-override`: Sets the flag to force override any soft mandatory
   Sentinel policies.
 
+- `-json`: Parses the job file as JSON. If the outer object has a Job field,
+  such as from "nomad job inspect" or "nomad run -output", the value of the
+  field is used as the job.
+
 - `-hcl1`: If set, HCL1 parser is used for parsing the job spec.
 
 - `-hcl2-strict`: Whether an error should be produced from the HCL2 parser where

--- a/website/content/docs/commands/job/run.mdx
+++ b/website/content/docs/commands/job/run.mdx
@@ -74,6 +74,10 @@ that volume.
 - `-eval-priority`: Override the priority of the evaluations produced as a result
   of this job submission. By default, this is set to the priority of the job.
 
+- `-json`: Parses the job file as JSON. If the outer object has a Job field,
+  such as from "nomad job inspect" or "nomad run -output", the value of the
+  field is used as the job.
+
 - `-hcl1`: If set, HCL1 parser is used for parsing the job spec.
 
 - `-hcl2-strict`: Whether an error should be produced from the HCL2 parser where

--- a/website/content/docs/commands/job/validate.mdx
+++ b/website/content/docs/commands/job/validate.mdx
@@ -32,7 +32,15 @@ of 1 indicates an error.
 When ACLs are enabled, this command requires a token with the `read-job`
 capability for the job's namespace.
 
+## General Options
+
+@include 'general_options.mdx'
+
 ## Validate Options
+
+- `-json`: Parses the job file as JSON. If the outer object has a Job field,
+  such as from "nomad job inspect" or "nomad run -output", the value of the
+  field is used as the job.
 
 - `-hcl1`: If set, HCL1 parser is used for parsing the job spec.
 

--- a/website/content/docs/commands/job/validate.mdx
+++ b/website/content/docs/commands/job/validate.mdx
@@ -54,16 +54,13 @@ Defaults to true.
 
 ## Examples
 
-Validate a job with invalid syntax:
+Validate a JSON job with invalid syntax:
 
 ```shell-session
-$ nomad job validate example.nomad
+$ nomad job validate -json example.json
 Job validation errors:
-1 error(s) occurred:
-
-* group "cache" -> task "redis" -> config: 1 error(s) occurred:
-
-* field "image" is required
+1 error occurred:
+        * Missing job datacenters
 ```
 
 Validate a job that has a configuration that causes warnings:


### PR DESCRIPTION
Fixes #6758
Fixes #1749

While the CLI has always supported running JSON jobs, its support has
been via HCLv2's JSON parsing. I have no idea what format it expects the
job to be in, but it's absolutely not in the same format as the API
expects.

So I ignored that and added a new -json flag to explicitly support *API*
style JSON jobspecs.