### PR TITLE
CI: build binaries for UI branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,7 +557,6 @@ workflows:
             branches:
               ignore:
                 - stable-website
-                - /^.-ui\b.*/
 
       - lint-go:
           # check branches are almost all the backend branches


### PR DESCRIPTION
Build binaries for every code change, not just backend code
changes. This means that we'll have up-to-date compiled assets for
every commit available in CircleCI artifacts.

(As far as I can tell, our GHA builds already include this step.)