### PR TITLE
ci: fixup task runner chroot test

### DIFF
--- a/ci/slow.go
+++ b/ci/slow.go
@@ -26,3 +26,41 @@ func Parallel(t *testing.T) {
 		t.Parallel()
 	}
 }
+
+// TinyChroot is useful for testing, where we do not use anything other than
+// trivial /bin commands like sleep and sh. Copying a minimal chroot helps in
+// environments like GHA with very poor [network] disk performance.
+//
+// Note that you cannot chroot a symlink.
+//
+// Do not modify this value.
+var TinyChroot = map[string]string{
+	// destination: /bin
+	"/usr/bin/sleep": "/bin/sleep",
+	"/usr/bin/dash":  "/bin/sh",
+	"/usr/bin/bash":  "/bin/bash",
+	"/usr/bin/cat":   "/bin/cat",
+
+	// destination: /usr/bin
+	"/usr/bin/stty":   "/usr/bin/stty",
+	"/usr/bin/head":   "/usr/bin/head",
+	"/usr/bin/mktemp": "/usr/bin/mktemp",
+	"/usr/bin/echo":   "/usr/bin/echo",
+	"/usr/bin/touch":  "/usr/bin/touch",
+	"/usr/bin/stat":   "/usr/bin/stat",
+
+	// destination: /etc/
+	"/etc/ld.so.cache":  "/etc/ld.so.cache",
+	"/etc/ld.so.conf":   "/etc/ld.so.conf",
+	"/etc/ld.so.conf.d": "/etc/ld.so.conf.d",
+	"/etc/passwd":       "/etc/passwd",
+	"/etc/resolv.conf":  "/etc/resolv.conf",
+
+	// others
+	"/lib":                 "/lib",
+	"/lib32":               "/lib32",
+	"/lib64":               "/lib64",
+	"/usr/lib/jvm":         "/usr/lib/jvm",
+	"/run/resolvconf":      "/run/resolvconf",
+	"/run/systemd/resolve": "/run/systemd/resolve",
+}

--- a/client/config/testing.go
+++ b/client/config/testing.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -50,6 +51,12 @@ func TestClientConfig(t testing.T) (*Config, func()) {
 		t.Fatalf("error creating alloc dir: %v", err)
 	}
 	conf.StateDir = stateDir
+
+	// Use a minimal chroot environment
+	conf.ChrootEnv = ci.TinyChroot
+
+	// Helps make sure we are respecting configured parent
+	conf.CgroupParent = "testing.slice"
 
 	conf.VaultConfig.Enabled = helper.BoolToPtr(false)
 	conf.DevMode = true

--- a/plugins/drivers/testutils/testing.go
+++ b/plugins/drivers/testutils/testing.go
@@ -12,6 +12,7 @@ import (
 
 	hclog "github.com/hashicorp/go-hclog"
 	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/lib/cgutil"
@@ -109,41 +110,6 @@ func (h *DriverHarness) cleanupCgroup() {
 	}
 }
 
-// tinyChroot is useful for testing, where we do not use anything other than
-// trivial /bin commands like sleep and sh.
-//
-// Note that you cannot chroot a symlink.
-var tinyChroot = map[string]string{
-	// destination: /bin
-	"/usr/bin/sleep": "/bin/sleep",
-	"/usr/bin/dash":  "/bin/sh",
-	"/usr/bin/bash":  "/bin/bash",
-	"/usr/bin/cat":   "/bin/cat",
-
-	// destination: /usr/bin
-	"/usr/bin/stty":   "/usr/bin/stty",
-	"/usr/bin/head":   "/usr/bin/head",
-	"/usr/bin/mktemp": "/usr/bin/mktemp",
-	"/usr/bin/echo":   "/usr/bin/echo",
-	"/usr/bin/touch":  "/usr/bin/touch",
-	"/usr/bin/stat":   "/usr/bin/stat",
-
-	// destination: /etc/
-	"/etc/ld.so.cache":  "/etc/ld.so.cache",
-	"/etc/ld.so.conf":   "/etc/ld.so.conf",
-	"/etc/ld.so.conf.d": "/etc/ld.so.conf.d",
-	"/etc/passwd":       "/etc/passwd",
-	"/etc/resolv.conf":  "/etc/resolv.conf",
-
-	// others
-	"/lib":                 "/lib",
-	"/lib32":               "/lib32",
-	"/lib64":               "/lib64",
-	"/usr/lib/jvm":         "/usr/lib/jvm",
-	"/run/resolvconf":      "/run/resolvconf",
-	"/run/systemd/resolve": "/run/systemd/resolve",
-}
-
 // MkAllocDir creates a temporary directory and allocdir structure.
 // If enableLogs is set to true a logmon instance will be started to write logs
 // to the LogDir of the task
@@ -165,7 +131,7 @@ func (h *DriverHarness) MkAllocDir(t *drivers.TaskConfig, enableLogs bool) func(
 
 	fsi := caps.FSIsolation
 	h.logger.Trace("FS isolation", "fsi", fsi)
-	require.NoError(h.t, taskDir.Build(fsi == drivers.FSIsolationChroot, tinyChroot))
+	require.NoError(h.t, taskDir.Build(fsi == drivers.FSIsolationChroot, ci.TinyChroot))
 
 	task := &structs.Task{
 		Name: t.Name,


### PR DESCRIPTION
This PR is 2 fixes for the flaky `TestTaskRunner_TaskEnv_Chroot` test, which hadn't been running in GHA until the recent [coverage fix](https://github.com/hashicorp/nomad/pull/12579/files#diff-999a0a7a9c02c83b86cfcdab3f79fa1a5f7eae38f6714e723beef804f1ba7aeaR95). 

- Use TinyChroot to stop copying gigabytes of data, which causes GHA
to fail to create the environment in time.

- Pre-create cgroups on V2 systems. Normally the cgroup directory is
managed by the cpuset manager, but that is not active in taskrunner tests,
so create it by hand in the test framework.
