### PR TITLE
[ui, bugfix] Link fix for volumes where per_alloc=true

### DIFF
--- a/.changelog/12713.txt
+++ b/.changelog/12713.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed a bug where volumes were being incorrectly linked when per_alloc=true
+```

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}

--- a/ui/.ember-cli
+++ b/ui/.ember-cli
@@ -6,5 +6,5 @@
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
   "disableAnalytics": false,
-  "proxy": "http://192.168.56.11:4646"
+  "proxy": "http://127.0.0.1:4646"
 }

--- a/ui/.ember-cli
+++ b/ui/.ember-cli
@@ -6,5 +6,5 @@
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
   "disableAnalytics": false,
-  "proxy": "http://127.0.0.1:4646"
+  "proxy": "http://192.168.56.11:4646"
 }

--- a/ui/.template-lintrc.js
+++ b/ui/.template-lintrc.js
@@ -7,5 +7,6 @@ module.exports = {
     'no-action': 'off',
     'no-invalid-interactive': 'off',
     'no-inline-styles': 'off',
+    'no-curly-component-invocation': { allow: ['format-volume-name'] },
   },
 };

--- a/ui/app/components/task-row.js
+++ b/ui/app/components/task-row.js
@@ -31,14 +31,6 @@ export default class TaskRow extends Component {
     return !Ember.testing;
   }
 
-  // When per_alloc is set to true on a volume, the volumes are duplicated between active allocations.
-  // We differentiate them with a [#] suffix, inferred from a volume's allocation's name property.
-  @computed('task.allocation.name')
-  get volumeExtension() {
-    let allocName = this.task.allocation.name;
-    return allocName.substring(allocName.lastIndexOf('['));
-  }
-
   // Since all tasks for an allocation share the same tracker, use the registry
   @computed('task.{allocation,isRunning}')
   get stats() {

--- a/ui/app/components/task-row.js
+++ b/ui/app/components/task-row.js
@@ -31,6 +31,14 @@ export default class TaskRow extends Component {
     return !Ember.testing;
   }
 
+  // When per_alloc is set to true on a volume, the volumes are duplicated between active allocations.
+  // We differentiate them with a [#] suffix, inferred from a volume's allocation's name property.
+  @computed('task.allocation.name')
+  get volumeExtension() {
+    let allocName = this.task.allocation.name;
+    return allocName.substring(allocName.lastIndexOf('['));
+  }
+
   // Since all tasks for an allocation share the same tracker, use the registry
   @computed('task.{allocation,isRunning}')
   get stats() {

--- a/ui/app/components/task-row.js
+++ b/ui/app/components/task-row.js
@@ -5,7 +5,6 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { task, timeout } from 'ember-concurrency';
 import { lazyClick } from '../helpers/lazy-click';
-import { formatVolumeName } from '../helpers/format-volume-name';
 
 import {
   classNames,

--- a/ui/app/components/task-row.js
+++ b/ui/app/components/task-row.js
@@ -5,6 +5,8 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { task, timeout } from 'ember-concurrency';
 import { lazyClick } from '../helpers/lazy-click';
+import { formatVolumeName } from '../helpers/format-volume-name';
+
 import {
   classNames,
   tagName,

--- a/ui/app/helpers/format-volume-name.js
+++ b/ui/app/helpers/format-volume-name.js
@@ -1,0 +1,15 @@
+import Helper from '@ember/component/helper';
+
+/**
+ * Volume Name Formatter
+ *
+ * Usage: {{format-volume-name source=string isPerAlloc=boolean volumeExtension=string}}
+ *
+ * Outputs a title/link for volumes that are per_alloc-aware.
+ * (when a volume is per_alloc, its route location requires an additional extension)
+ */
+function formatVolumeName(_, { source, isPerAlloc, volumeExtension }, b, c) {
+  return `${source}${isPerAlloc ? volumeExtension : ''}`;
+}
+
+export default Helper.helper(formatVolumeName);

--- a/ui/app/helpers/format-volume-name.js
+++ b/ui/app/helpers/format-volume-name.js
@@ -1,4 +1,4 @@
-import Helper from '@ember/component/helper';
+import { helper } from '@ember/component/helper';
 
 /**
  * Volume Name Formatter
@@ -8,8 +8,11 @@ import Helper from '@ember/component/helper';
  * Outputs a title/link for volumes that are per_alloc-aware.
  * (when a volume is per_alloc, its route location requires an additional extension)
  */
-function formatVolumeName(_, { source, isPerAlloc, volumeExtension }, b, c) {
+export function formatVolumeName(
+  _,
+  { source = '', isPerAlloc, volumeExtension }
+) {
   return `${source}${isPerAlloc ? volumeExtension : ''}`;
 }
 
-export default Helper.helper(formatVolumeName);
+export default helper(formatVolumeName);

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -119,6 +119,13 @@ export default class Allocation extends Model {
     return [];
   }
 
+  // When per_alloc is set to true on a volume, the volumes are duplicated between active allocations.
+  // We differentiate them with a [#] suffix, inferred from a volume's allocation's name property.
+  @computed('name')
+  get volumeExtension() {
+    return this.name.substring(this.name.lastIndexOf('['));
+  }
+
   @fragmentArray('task-state') states;
   @fragmentArray('reschedule-event') rescheduleEvents;
 

--- a/ui/app/models/volume-definition.js
+++ b/ui/app/models/volume-definition.js
@@ -11,6 +11,7 @@ export default class VolumeDefinition extends Fragment {
   @attr('string') source;
   @attr('string') type;
   @attr('boolean') readOnly;
+  @attr('boolean') perAlloc;
 
   @equal('type', 'csi') isCSI;
   @alias('taskGroup.job.namespace') namespace;

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -161,7 +161,6 @@
               </td>
               <td data-test-volume-client-source>
                 {{#if row.model.isCSI}}
-                {{log "ah heck" row.model}}
                   <LinkTo
                     @route="csi.volumes.volume"
                     @model={{concat row.model.source (if row.model.volumeDeclaration.perAlloc this.model.allocation.volumeExtension) "@" row.model.namespace.id

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -161,12 +161,13 @@
               </td>
               <td data-test-volume-client-source>
                 {{#if row.model.isCSI}}
+                {{log "ah heck" row.model}}
                   <LinkTo
                     @route="csi.volumes.volume"
-                    @model={{concat row.model.volume "@" row.model.namespace.id
+                    @model={{concat row.model.source (if row.model.volumeDeclaration.perAlloc this.model.allocation.volumeExtension) "@" row.model.namespace.id
                     }}
                   >
-                    {{row.model.volume}}
+                    {{row.model.source}}
                   </LinkTo>
                 {{else}}
                   {{row.model.source}}

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -163,10 +163,19 @@
                 {{#if row.model.isCSI}}
                   <LinkTo
                     @route="csi.volumes.volume"
-                    @model={{concat row.model.source (if row.model.volumeDeclaration.perAlloc this.model.allocation.volumeExtension) "@" row.model.namespace.id
+                    @model={{concat
+                    (format-volume-name
+                      source=row.model.source
+                      isPerAlloc=row.model.volumeDeclaration.perAlloc
+                      volumeExtension=this.model.allocation.volumeExtension)
+                    "@"
+                    row.model.namespace.id
                     }}
                   >
-                    {{row.model.source}}{{#if row.model.volumeDeclaration.perAlloc}}{{this.model.allocation.volumeExtension}}{{/if}}
+                  {{format-volume-name
+                    source=row.model.source
+                    isPerAlloc=row.model.volumeDeclaration.perAlloc
+                    volumeExtension=this.model.allocation.volumeExtension}}
                   </LinkTo>
                 {{else}}
                   {{row.model.source}}

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -166,7 +166,7 @@
                     @model={{concat row.model.source (if row.model.volumeDeclaration.perAlloc this.model.allocation.volumeExtension) "@" row.model.namespace.id
                     }}
                   >
-                    {{row.model.source}}
+                    {{row.model.source}}{{#if row.model.volumeDeclaration.perAlloc}}{{this.model.allocation.volumeExtension}}{{/if}}
                   </LinkTo>
                 {{else}}
                   {{row.model.source}}

--- a/ui/app/templates/components/task-row.hbs
+++ b/ui/app/templates/components/task-row.hbs
@@ -47,7 +47,7 @@
         {{#if volume.isCSI}}
           <LinkTo
             @route="csi.volumes.volume"
-            @model={{concat volume.source (if volume.volumeDeclaration.perAlloc this.volumeExtension) "@" volume.namespace.id}}
+            @model={{concat volume.source (if volume.volumeDeclaration.perAlloc this.task.allocation.volumeExtension) "@" volume.namespace.id}}
           >
             {{volume.source}}
           </LinkTo>

--- a/ui/app/templates/components/task-row.hbs
+++ b/ui/app/templates/components/task-row.hbs
@@ -49,7 +49,7 @@
             @route="csi.volumes.volume"
             @model={{concat volume.source (if volume.volumeDeclaration.perAlloc this.task.allocation.volumeExtension) "@" volume.namespace.id}}
           >
-            {{volume.source}}
+            {{volume.source}}{{#if volume.volumeDeclaration.perAlloc}}{{this.task.allocation.volumeExtension}}{{/if}}
           </LinkTo>
         {{else}}
           {{volume.source}}

--- a/ui/app/templates/components/task-row.hbs
+++ b/ui/app/templates/components/task-row.hbs
@@ -47,7 +47,7 @@
         {{#if volume.isCSI}}
           <LinkTo
             @route="csi.volumes.volume"
-            @model={{concat volume.source "@" volume.namespace.id}}
+            @model={{concat volume.source (if volume.volumeDeclaration.perAlloc this.volumeExtension) "@" volume.namespace.id}}
           >
             {{volume.source}}
           </LinkTo>

--- a/ui/app/templates/components/task-row.hbs
+++ b/ui/app/templates/components/task-row.hbs
@@ -47,9 +47,19 @@
         {{#if volume.isCSI}}
           <LinkTo
             @route="csi.volumes.volume"
-            @model={{concat volume.source (if volume.volumeDeclaration.perAlloc this.task.allocation.volumeExtension) "@" volume.namespace.id}}
+            @model={{concat
+              (format-volume-name
+                source=volume.source
+                isPerAlloc=volume.volumeDeclaration.perAlloc
+                volumeExtension=this.task.allocation.volumeExtension)
+              "@"
+              volume.namespace.id
+            }}
           >
-            {{volume.source}}{{#if volume.volumeDeclaration.perAlloc}}{{this.task.allocation.volumeExtension}}{{/if}}
+          {{format-volume-name
+            source=volume.source
+            isPerAlloc=volume.volumeDeclaration.perAlloc
+            volumeExtension=this.task.allocation.volumeExtension}}
           </LinkTo>
         {{else}}
           {{volume.source}}

--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -293,12 +293,17 @@
             <tr data-test-volume>
               <td data-test-volume-name>
                 {{#if row.model.isCSI}}
-                  <LinkTo
-                    @route="csi.volumes.volume"
-                    @model={{concat row.model.source "@" row.model.namespace.id}}
-                  >
-                    {{row.model.name}}
-                  </LinkTo>
+                  {{!-- if volume is per_alloc=true, there's no one specific volume. So, link to the volumes index with an active query --}}
+                  {{#if row.model.perAlloc}}
+                    <LinkTo @route="csi.volumes.index" @query={{hash search=row.model.source}}>{{row.model.name}}</LinkTo>
+                  {{else}}
+                    <LinkTo
+                      @route="csi.volumes.volume"
+                      @model={{concat row.model.source "@" row.model.namespace.id}}
+                    >
+                      {{row.model.name}}
+                    </LinkTo>
+                  {{/if}}
                 {{else}}
                   {{row.model.name}}
                 {{/if}}

--- a/ui/tests/unit/helpers/format-volume-name-test.js
+++ b/ui/tests/unit/helpers/format-volume-name-test.js
@@ -1,0 +1,39 @@
+import { module, test } from 'qunit';
+import { formatVolumeName } from 'nomad-ui/helpers/format-volume-name';
+
+module('Unit | Helper | formatVolumeName', function () {
+  test('Returns source as string when isPerAlloc is false', function (assert) {
+    const expectation = 'my-volume-source';
+    assert.equal(
+      formatVolumeName(null, {
+        source: 'my-volume-source',
+        isPerAlloc: false,
+        volumeExtension: '[arbitrary]',
+      }),
+      expectation,
+      'false perAlloc'
+    );
+    assert.equal(
+      formatVolumeName(null, {
+        source: 'my-volume-source',
+        isPerAlloc: null,
+        volumeExtension: '[arbitrary]',
+      }),
+      expectation,
+      'null perAlloc'
+    );
+  });
+
+  test('Returns concatonated name when isPerAlloc is true', function (assert) {
+    const expectation = 'my-volume-source[1]';
+    assert.equal(
+      formatVolumeName(null, {
+        source: 'my-volume-source',
+        isPerAlloc: true,
+        volumeExtension: '[1]',
+      }),
+      expectation,
+      expectation
+    );
+  });
+});


### PR DESCRIPTION
In situations where `per_alloc` of a volume stanza is set to `true`, we currently throw a broken link: we try to find a base volume in a situation where it is split into multiples.

With this change, we disambiguate the per_alloc'd volume where possible.

This happens in 3 places:
- on the allocation route, in the Tasks table
- on the task route, in the Volumes table
- on the task group route, in the Volume Requirements table.

Importantly, this third situation does not have the ability to disambiguate: because a task group does not know which allocation it refers to, I've opted to provide the user with a link to queried volumes route instead.

### Assumptions
- Allocations spread across multiple clients always receive a `[#]` suffix in their `name` property, and this is always the last bracketed text.

### Side-effects
- The Volumes table on the Task route was formerly using volumeMount.volume in its `Client Source` column. I've changed this to `volumeMount.source`, which I think is the intended string.

Resolves #11965 