### PR TITLE
docs: update HCL2 dynamic example to use block with label.

### DIFF
--- a/website/content/docs/job-specification/hcl2/expressions.mdx
+++ b/website/content/docs/job-specification/hcl2/expressions.mdx
@@ -245,59 +245,72 @@ set.
 ## `dynamic` blocks
 
 Within top-level block constructs like sources, expressions can usually be used
-only when assigning a value to an argument using the `name = expression` or `key = expression` form. This covers many uses, but some source types include
+only when assigning a value to an argument using the `name = expression` or
+`key = expression` form. This covers many uses, but some source types include
 repeatable _nested blocks_ in their arguments, which do not accept expressions:
 
 ```hcl
-service {
-  port = "db" # can use expressions here
+network {
+  mode = "host" # can use expressions here
 
-  check {
-    # but the "check" block is always a literal block
+  port "label" {
+    # but the "port" block is always a literal block
   }
 }
 ```
 
-You can dynamically construct repeatable nested blocks like `check` using a
+You can dynamically construct repeatable nested blocks like `port` using a
 special `dynamic` block type, which is supported anywhere, example:
 
 ```hcl
 locals {
-  check_paths = ["/health", "/"]
+  ports = [
+    {
+      port_label = "api"
+      port       = 80
+    },
+    {
+      port_label = "ui"
+      port       = 8080
+    }
+  ]
 }
 
 job "example" {
-  # ...
-  service {
-    port = "lb" # can use expressions here
+  datacenters = ["dc1"]
 
-    dynamic "check" {
-      for_each = local.check_paths
+  group "cache" {
+    network {
 
-      content {
-        type     = "http"
-        port     = "lb"
-        path     = check.value
+      mode = "host"
+
+      dynamic "port" {
+        for_each = local.ports
+        labels   = [port.value.port_label]
+
+        content {
+          to = port.value.port
+        }
       }
     }
- }
-}
+    ...
 ```
 
 A `dynamic` block acts much like a `for` expression, but produces nested blocks
 instead of a complex typed value. It iterates over a given complex value, and
 generates a nested block for each element of that complex value.
 
-- The label of the dynamic block (`"check"` in the example above) specifies
+- The label of the dynamic block (`"port"` in the example above) specifies
   what kind of nested block to generate.
 - The `for_each` argument provides the complex value to iterate over.
 - The `iterator` argument (optional) sets the name of a temporary variable
   that represents the current element of the complex value. If omitted, the name
-  of the variable defaults to the label of the `dynamic` block (`"check"` in
+  of the variable defaults to the label of the `dynamic` block (`"port"` in
   the example above).
 - The `labels` argument (optional) is a list of strings that specifies the block
   labels, in order, to use for each generated block. You can use the temporary
-  iterator variable in this value.
+  iterator variable in this value. Nomad currently only has blocks that support
+  a single label such as `port`.
 - The nested `content` block defines the body of each generated block. You can
   use the temporary iterator variable inside this block.
 
@@ -305,7 +318,7 @@ Since the `for_each` argument accepts any collection or structural value,
 you can use a `for` expression or splat expression to transform an existing
 collection.
 
-The iterator object (`check` in the example above) has two attributes:
+The iterator object (`port` in the example above) has two attributes:
 
 - `key` is the map key or list element index for the current element. If the
   `for_each` expression produces a _set_ value then `key` is identical to


### PR DESCRIPTION
Updates the doc to use a more "complete" example which both uses a complex local as well as labels and loops.

closes https://github.com/hashicorp/nomad/issues/12681