### PR TITLE
ui: fix bug that prevented files streaming

### DIFF
--- a/ui/app/utils/classes/stream-logger.js
+++ b/ui/app/utils/classes/stream-logger.js
@@ -10,7 +10,7 @@ import classic from 'ember-classic-decorator';
 export default class StreamLogger extends EmberObject.extend(AbstractLogger) {
   reader = null;
 
-  get isSupported() {
+  static get isSupported() {
     return !!window.ReadableStream;
   }
 

--- a/ui/tests/unit/utils/stream-logger-test.js
+++ b/ui/tests/unit/utils/stream-logger-test.js
@@ -43,6 +43,11 @@ module('Unit | Util | StreamLogger', function () {
     assert.notOk(logger.poll.isRunning);
     assert.equal(fetchMock.reader.readSpy.callCount, 1);
   });
+
+  test('disable streaming if not supported', async function (assert) {
+    window.ReadableStream = null;
+    assert.false(StreamLogger.isSupported);
+  });
 });
 
 class FetchMock {


### PR DESCRIPTION
During the Ember dependecy upgrade work,
https://github.com/hashicorp/nomad/commit/ce8c039f4ce7359d60ede5dee36b9cef82
moved the `isSupported` method from using Ember's `reopenClass` to a
getter, but `reopenClass` creates a static method, so the getter must be
static as well.

~I couldn't find a way to test this since the test suite uses a mock object.~
Not true, the mocks are for something else.

Closes #12647