### PR TITLE
E2E: set longer timeout for CSI plugin alloc start

### DIFF
--- a/e2e/csi/csi.go
+++ b/e2e/csi/csi.go
@@ -34,8 +34,9 @@ func init() {
 
 const ns = ""
 
-var pluginWait = &e2e.WaitConfig{Interval: 5 * time.Second, Retries: 36} // 3min
-var reapWait = &e2e.WaitConfig{Interval: 5 * time.Second, Retries: 36}   // 3min
+var pluginAllocWait = &e2e.WaitConfig{Interval: 5 * time.Second, Retries: 12} // 1min
+var pluginWait = &e2e.WaitConfig{Interval: 5 * time.Second, Retries: 36}      // 3min
+var reapWait = &e2e.WaitConfig{Interval: 5 * time.Second, Retries: 36}        // 3min
 
 // assertNoErrorElseDump calls a non-halting assert on the error and dumps the
 // plugin logs if it fails.

--- a/e2e/csi/efs.go
+++ b/e2e/csi/efs.go
@@ -60,8 +60,8 @@ func (tc *CSINodeOnlyPluginEFSTest) TestEFSVolumeClaim(f *framework.F) {
 				}
 			}
 			return true
-		}, nil,
-	))
+		}, pluginAllocWait,
+	), "plugin job should be running")
 
 	f.NoError(waitForPluginStatusMinNodeCount(efsPluginID, 2, pluginWait),
 		"aws-efs0 node plugins did not become healthy")


### PR DESCRIPTION
The CSI plugin allocations take a while to be marked healthy,
sometimes causing E2E test flakes during the setup phase of the
tests. There's nothing CSI specific about marking plugin allocs
healthy, as the plugin supervisor hook does all the fingerprinting in
the postrun hook (the prestart hook just makes a couple of empty
directories). The timeouts we're seeing may be because of where we're
pulling the images from; most our jobs pull from a CDN-backed public
registry whereas these are pulling from ECR. Set a 1min timeout for
these to make sure we have enough time to pull the image and start the
task.