### PR TITLE
docker: back out cgroup v2 OOM detection

### DIFF
--- a/drivers/docker/handle.go
+++ b/drivers/docker/handle.go
@@ -242,14 +242,11 @@ func (h *taskHandle) run() {
 	if ierr != nil {
 		h.logger.Error("failed to inspect container", "error", ierr)
 	} else if container.State.OOMKilled {
+		// Note that with cgroups.v2 the cgroup OOM killer is not
+		// observed by docker container status. But we can't test the
+		// exit code, as 137 is used for any SIGKILL
 		oom = true
 		werr = fmt.Errorf("OOM Killed")
-	} else if container.State.ExitCode == 137 {
-		// With cgroups.v2 it seems the cgroup OOM killer is not observed by docker
-		// container status. So just fudge the connection for now.
-		// [Mon Mar 21 19:48:21 2022] Memory cgroup out of memory: Killed process 92768 (sh) [...]
-		oom = true
-		werr = fmt.Errorf("OOM Killed (137)")
 	}
 
 	// Shutdown stats collection


### PR DESCRIPTION
When shutting down an allocation that ends up needing to be
force-killed, we're getting a spurious "OOM Killed (137)" message on
the task termination event. We introduced this as part of cgroups v2
support because the Docker daemon isn't detecting the container status
correctly. Although exit code 137 is the exit code we get for
OOM-killed processes, that's because OOM kill is a `SIGKILL`. So any
sigkilled process will get that exit code.

(I'm totally open to trying another approach here @shoenig, just couldn't come up with one.)

---

Example of spurious error:

```
Recent Events:
Time                  Type        Description
2022-04-21T15:32:50Z  Killed      Task successfully killed
2022-04-21T15:32:50Z  Terminated  Exit Code: 137, Exit Message: "OOM Killed (137)"
2022-04-21T15:32:44Z  Killing     Sent interrupt. Waiting 5s before force killing
2022-04-21T15:32:08Z  Started     Task started by client
2022-04-21T15:32:07Z  Task Setup  Building Task Directory
2022-04-21T15:32:07Z  Received    Task received by client
```
