### PR TITLE
cli: detect directory when applying namespace spec file

### DIFF
--- a/command/namespace_apply.go
+++ b/command/namespace_apply.go
@@ -27,7 +27,7 @@ Usage: nomad namespace apply [options] <input>
   Apply is used to create or update a namespace. The specification file
   will be read from stdin by specifying "-", otherwise a path to the file is
   expected.
-  
+
   Instead of a file, you may instead pass the namespace name to create
   or update as the only argument.
 
@@ -114,7 +114,7 @@ func (c *NamespaceApplyCommand) Run(args []string) int {
 		return 1
 	}
 
-	if _, err = os.Stat(file); file == "-" || err == nil {
+	if fi, err := os.Stat(file); (file == "-" || err == nil) && !fi.IsDir() {
 		if quota != nil || description != nil {
 			c.Ui.Warn("Flags are ignored when a file is specified!")
 		}

--- a/website/content/docs/commands/namespace/apply.mdx
+++ b/website/content/docs/commands/namespace/apply.mdx
@@ -67,7 +67,7 @@ capabilities {
 
 meta {
   owner        = "John Doe"
-  contact_mail = "john@mycompany.com
+  contact_mail = "john@mycompany.com"
 }
 $ nomad namespace apply namespace.hcl
 ```


### PR DESCRIPTION
The new `namespace apply` feature that allows for passing a namespace
specification file detects the difference between an empty namespace
and a namespace specification by checking if the file exists. For most
cases, the file will have an extension like `.hcl` and so there's
little danger that a user will apply a file spec when they intended to
apply a file name.

But because directory names typically don't include an extension,
you're much more likely to collide when trying to `namespace apply` by
name only, and then you get a confusing error message of the form:

> Failed to read file: read $namespace: is a directory

Detect the case where the namespace name collides with a directory in
the current working directory, and skip trying to load the directory.

---

No changelog entry, as this feature shipped for the first time in Nomad 1.3.0-beta.1 (ref https://github.com/hashicorp/nomad/pull/11813)

Before:

```
$ nomad namespace apply prod
Successfully applied namespace "prod"!

$ nomad namespace apply ./namespace.hcl
Successfully applied namespace "staging"!

$ nomad namespace apply dev
Failed to read file: read dev: is a directory
```

After:

```
$ nomad namespace apply prod
Successfully applied namespace "prod"!

$ nomad namespace apply ./namespace.hcl
Successfully applied namespace "staging"!

$ nomad namespace apply dev
Successfully applied namespace "dev"!
```