### PR TITLE
CSI: handle nil topologies safely in command line

### DIFF
--- a/command/volume_status_csi.go
+++ b/command/volume_status_csi.go
@@ -252,6 +252,9 @@ func (c *VolumeStatusCommand) formatBasic(vol *api.CSIVolume) (string, error) {
 func (c *VolumeStatusCommand) formatTopology(vol *api.CSIVolume) string {
 	rows := []string{"Topology|Segments"}
 	for i, t := range vol.Topologies {
+		if t == nil {
+			continue
+		}
 		segmentPairs := make([]string, 0, len(t.Segments))
 		for k, v := range t.Segments {
 			segmentPairs = append(segmentPairs, fmt.Sprintf("%s=%s", k, v))


### PR DESCRIPTION
Fixes panic demonstrated in [CircleCI workflow 32eb0f1f](https://app.circleci.com/pipelines/github/hashicorp/nomad-e2e/489/workflows/32eb0f1f-bd01-4e19-ade9-60d2fc03be29/jobs/2818). I'm not sure why this hadn't shown up previously and it's at least possible something is wrong in the volume API output, but regardless of what comes back from the API the CLI shouldn't panic.