### PR TITLE
CSI: plugin supervisor prestart should not mark itself done

### DIFF
--- a/.changelog/12752.txt
+++ b/.changelog/12752.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where plugins would not restart if they failed any time after a client restart
+```

--- a/client/allocrunner/taskrunner/plugin_supervisor_hook.go
+++ b/client/allocrunner/taskrunner/plugin_supervisor_hook.go
@@ -129,10 +129,10 @@ func (*csiPluginSupervisorHook) Name() string {
 }
 
 // Prestart is called before the task is started including after every
-// restart (but not after restore). This requires that the mount paths
-// for a plugin be idempotent, despite us not knowing the name of the
-// plugin ahead of time.  Because of this, we use the allocid_taskname
-// as the unique identifier for a plugin on the filesystem.
+// restart. This requires that the mount paths for a plugin be
+// idempotent, despite us not knowing the name of the plugin ahead of
+// time.  Because of this, we use the allocid_taskname as the unique
+// identifier for a plugin on the filesystem.
 func (h *csiPluginSupervisorHook) Prestart(ctx context.Context,
 	req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
 
@@ -191,9 +191,11 @@ func (h *csiPluginSupervisorHook) Prestart(ctx context.Context,
 	mounts = ensureMountpointInserted(mounts, volumeStagingMounts)
 	mounts = ensureMountpointInserted(mounts, devMount)
 
+	// we normally would set resp.Mounts here but without setting the
+	// hookResources before returning we can get a postrun hook that's
+	// missing resources.
 	h.runner.hookResources.setMounts(mounts)
 
-	resp.Done = true
 	return nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/12744

The task runner hook `Prestart` response object includes a `Done`
field that's intended to tell the client not to run the hook
again. The plugin supervisor creates mount points for the task during
prestart and saves these mounts in the hook resources. But if a client
restarts the hook resources will not be populated. If the plugin task
restarts at any time after the client restarts, it will fail to have
the correct mounts and crash loop until restart attempts run out.

Fix this by not returning `Done` in the response, just as we do for
the `volume_mount_hook`.