### PR TITLE
Removing the project root jsconfig.json

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,1 +1,0 @@
-{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}


### PR DESCRIPTION
Accidentally added while setting lint rules elsewhere. It already exists at /ui/jsconfig.json , so removing this one.