### PR TITLE
api: add ParseHCLOpts helper method

### DIFF
--- a/.changelog/12777.txt
+++ b/.changelog/12777.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Added ParseHCLOpts helper func to ease parsing HCLv1 jobspecs
+```

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -65,12 +65,21 @@ func (c *Client) Jobs() *Jobs {
 
 // ParseHCL is used to convert the HCL repesentation of a Job to JSON server side.
 // To parse the HCL client side see package github.com/hashicorp/nomad/jobspec
+// Use ParseHCLOpts if you need to customize JobsParseRequest.
 func (j *Jobs) ParseHCL(jobHCL string, canonicalize bool) (*Job, error) {
-	var job Job
 	req := &JobsParseRequest{
 		JobHCL:       jobHCL,
 		Canonicalize: canonicalize,
 	}
+	return j.ParseHCLOpts(req)
+}
+
+// ParseHCLOpts is used to convert the HCL representation of a Job to JSON
+// server side. To parse the HCL client side see package
+// github.com/hashicorp/nomad/jobspec.
+// ParseHCL is an alternative convenience API for HCLv2 users.
+func (j *Jobs) ParseHCLOpts(req *JobsParseRequest) (*Job, error) {
+	var job Job
 	_, err := j.client.write("/v1/jobs/parse", req, &job, nil)
 	return &job, err
 }


### PR DESCRIPTION
The existing ParseHCL func didn't allow setting HCLv1=true.

ParseHCLOpts name matches other "with options" helper funcs like https://pkg.go.dev/github.com/hashicorp/nomad/api#CSIVolumes.ListSnapshotsOpts