### PR TITLE
ci: setup release process with CRT

### DIFF
--- a/.github/workflows/build-trigger.yml
+++ b/.github/workflows/build-trigger.yml
@@ -1,0 +1,13 @@
+name: Build trigger
+
+on:
+  push:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      make-prerelease: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,18 @@
-name: build
+name: Build
 
 on:
-  push:
-    branches:
-      - "main"
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      build-ref:
+        description: 'The git ref to build from'
+        type: string
+        default: ''
+        required: false
+      make-prerelease:
+        description: "Run prerelease to generate files"
+        type: "boolean"
+        required: false
+        default: true
 
 env:
   PKG_NAME: "nomad"
@@ -17,6 +25,8 @@ jobs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.build-ref }}
       - name: Determine Go version
         id: get-go-version
         # We use .go-version as our source of truth for current Go
@@ -30,6 +40,8 @@ jobs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.build-ref }}
       - name: get product version
         id: get-product-version
         run: |
@@ -43,6 +55,8 @@ jobs:
     steps:
       - name: "Checkout directory"
         uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.build-ref }}
       - name: Generate metadata file
         id: generate-metadata-file
         uses: hashicorp/actions-generate-metadata@v1
@@ -61,6 +75,8 @@ jobs:
       ldflags: ${{ steps.generate-ld-flags.outputs.ldflags }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.build-ref }}
       - name: "Generate ld flags"
         id: generate-ld-flags
         run: |
@@ -82,6 +98,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.build-ref }}
       - name: Setup go
         uses: actions/setup-go@v2
         with:
@@ -102,7 +120,7 @@ jobs:
 
       - name: Build prerelease
         run: make prerelease
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ inputs.make-prerelease == 'true' }}
 
       - name: Build
         env:
@@ -132,6 +150,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.build-ref }}
       - name: Setup go
         uses: actions/setup-go@v2
         with:
@@ -152,7 +172,7 @@ jobs:
 
       - name: Build prerelease
         run: make prerelease
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ inputs.make-prerelease == 'true' }}
 
       - name: Install Linux build utilties
         run: |
@@ -239,6 +259,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.build-ref }}
 
       - name: Setup go
         uses: actions/setup-go@v2
@@ -260,7 +282,7 @@ jobs:
 
       - name: Build prerelease
         run: make prerelease
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ inputs.make-prerelease == 'true' }}
 
       - name: Build
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
-name: Build
+name: build
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       build-ref:
         description: 'The git ref to build from'
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ inputs.build-ref }}
+          ref: ${{ github.event.inputs.build-ref }}
       - name: Determine Go version
         id: get-go-version
         # We use .go-version as our source of truth for current Go
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ inputs.build-ref }}
+          ref: ${{ github.event.inputs.build-ref }}
       - name: get product version
         id: get-product-version
         run: |
@@ -56,14 +56,15 @@ jobs:
       - name: "Checkout directory"
         uses: actions/checkout@v2
         with:
-          ref: ${{ inputs.build-ref }}
+          ref: ${{ github.event.inputs.build-ref }}
       - name: Generate metadata file
         id: generate-metadata-file
-        uses: hashicorp/actions-generate-metadata@v1
+        uses: hashicorp/actions-generate-metadata@add-optional-sha-param
         with:
           version: ${{ needs.get-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
           repositoryOwner: "hashicorp"
+          sha: ${{ github.event.inputs.build-ref }}
       - uses: actions/upload-artifact@v2
         with:
           name: metadata.json
@@ -76,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ inputs.build-ref }}
+          ref: ${{ github.event.inputs.build-ref }}
       - name: "Generate ld flags"
         id: generate-ld-flags
         run: |
@@ -99,7 +100,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ inputs.build-ref }}
+          ref: ${{ github.event.inputs.build-ref }}
       - name: Setup go
         uses: actions/setup-go@v2
         with:
@@ -120,7 +121,7 @@ jobs:
 
       - name: Build prerelease
         run: make prerelease
-        if: ${{ inputs.make-prerelease == 'true' }}
+        if: ${{ github.event.inputs.make-prerelease == 'true' }}
 
       - name: Build
         env:
@@ -151,7 +152,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ inputs.build-ref }}
+          ref: ${{ github.event.inputs.build-ref }}
       - name: Setup go
         uses: actions/setup-go@v2
         with:
@@ -172,7 +173,7 @@ jobs:
 
       - name: Build prerelease
         run: make prerelease
-        if: ${{ inputs.make-prerelease == 'true' }}
+        if: ${{ github.event.inputs.make-prerelease == 'true' }}
 
       - name: Install Linux build utilties
         run: |
@@ -260,7 +261,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ inputs.build-ref }}
+          ref: ${{ github.event.inputs.build-ref }}
 
       - name: Setup go
         uses: actions/setup-go@v2
@@ -282,7 +283,7 @@ jobs:
 
       - name: Build prerelease
         run: make prerelease
-        if: ${{ inputs.make-prerelease == 'true' }}
+        if: ${{ github.event.inputs.make-prerelease == 'true' }}
 
       - name: Build
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,9 @@ jobs:
         run: |
           NOMAD_MAIN_VERSION = $(echo "${{ inputs.version }}" | cut -d- -f1)
           NOMAD_PRERELEASE_VERSION = $(echo "${{ inputs.version }}" | sed 's|^[^-]*-\{0,1\}||g' )
-          echo "updating version to $(NOMAD_MAIN_VERSION)-$(NOMAD_PRERELEASE_VERSION)"
-          sed -i.bak -e 's|\(Version * = *"\)[^"]*|\1$(NOMAD_MAIN_VERSION)|g' version/version.go
-          sed -i.bak -e 's|\(VersionPrerelease * = *"\)[^"]*|\1$(NOMAD_PRERELEASE_VERSION)|g' version/version.go
+          echo "updating version to ${NOMAD_MAIN_VERSION}-${NOMAD_PRERELEASE_VERSION}"
+          sed -i.bak -e 's|\(Version * = *"\)[^"]*|\1${NOMAD_MAIN_VERSION}|g' version/version.go
+          sed -i.bak -e 's|\(VersionPrerelease * = *"\)[^"]*|\1${NOMAD_PRERELEASE_VERSION}|g' version/version.go
           rm -rf version/version.go.bak
 
       - name: Update changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,13 @@
-name: Generate Static Assets
+name: Release
 
 on:
-  push:
-    branches:
-      - "release/**"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version being released'
+        required: true
+        type: string
+
 env:
   GO_TAGS: "release"
 
@@ -21,12 +25,15 @@ jobs:
         run: |
           echo "Building with Go $(cat .go-version)"
           echo "::set-output name=go-version::$(cat .go-version)"
-  generate-metadata:
-    runs-on: ubuntu-latest
+
+  prepare-release:
     needs: get-go-version
-    name: generate-metadata
+    runs-on: ubuntu-latest
+    outputs:
+      build-ref: ${{ steps.commit-change-push.outputs.build-ref }}
     steps:
       - uses: actions/checkout@v2
+
       - name: Setup go
         uses: actions/setup-go@v2
         with:
@@ -37,15 +44,17 @@ jobs:
         with:
           node-version: "14"
           cache-dependency-path: "ui/yarn.lock"
+
       - name: Install Yarn
         run: |
           npm install -g yarn
-      - uses: actions/checkout@v2
+
       - name: Generate static assets
         id: generate-static-assets
         run: |
           make deps
           make prerelease
+
       - name: Commit and push changes
         id: commit-change-push
         run: |
@@ -61,8 +70,11 @@ jobs:
           else
             echo "no files were updated"
           fi
-      - name: Invoke build workflow
-        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7
-        with:
-          workflow: build
-          token: ${{ secrets.ELEVATED_GITHUB_TOKEN}}
+          echo "::set-output name=build-ref::$(git rev-parse HEAD)"
+
+  build:
+    needs: prepare-release
+    uses: ./.github/workflows/build.yml
+    with:
+      build-ref: ${{ needs.prepare-release.outputs.build-ref }}
+      make-prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,9 +115,12 @@ jobs:
           fi
           echo "::set-output name=build-ref::$(git rev-parse HEAD)"
 
-  build:
-    needs: prepare-release
-    uses: ./.github/workflows/build.yml
-    with:
-      build-ref: ${{ needs.prepare-release.outputs.build-ref }}
-      make-prerelease: false
+      - run: sleep 120
+
+      - name: Invoke build workflow
+        uses: benc-uk/workflow-dispatch@v1.1
+        with:
+          workflow: build
+          token: ${{ secrets.ELEVATED_GITHUB_TOKEN}}
+          inputs: '{"build-ref": "${{ steps.commit-change-push.outputs.build-ref }}", "make-prerelease": "false"}'
+          ref: ${{ needs.prepare-release.outputs.build-ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           then
             git config --global user.email "github-team-nomad-core@hashicorp.com"
             git config --global user.name "hc-github-team-nomad-core"
-            git commit --message "Generate files for release"
+            git commit --message "Generate files for ${{ inputs.version }} release"
             git push origin "$(git rev-parse --abbrev-ref HEAD)"
             echo "committing generated files"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,15 @@ jobs:
         run: |
           npm install -g yarn
 
+      - name: Update version file
+        run: |
+          NOMAD_MAIN_VERSION = $(echo "${{ inputs.version }}" | cut -d- -f1)
+          NOMAD_PRERELEASE_VERSION = $(echo "${{ inputs.version }}" | sed 's|^[^-]*-\{0,1\}||g' )
+          echo "updating version to $(NOMAD_MAIN_VERSION)-$(NOMAD_PRERELEASE_VERSION)"
+          sed -i.bak -e 's|\(Version * = *"\)[^"]*|\1$(NOMAD_MAIN_VERSION)|g' version/version.go
+          sed -i.bak -e 's|\(VersionPrerelease * = *"\)[^"]*|\1$(NOMAD_PRERELEASE_VERSION)|g' version/version.go
+          rm -rf version/version.go.bak
+
       - name: Generate static assets
         id: generate-static-assets
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
         description: 'The version being released'
         required: true
         type: string
-      upddate-changelog:
+      update-changelog:
         description: 'Update CHANGELOG'
         required: true
         type: boolean
@@ -59,30 +59,43 @@ jobs:
         run: |
           npm install -g yarn
 
-      - name: Update notification channel
-        if: ${{ inputs.notification-channel != '' }}
+      - name: Install dependencies
         run: |
-          sed -i.bak -e 's|\(notification_channel * = *"\)[^"]*|\1${{ inputs.notification-channel }}|g' .release/ci.hcl
+          make deps
+
+      - name: Update notification channel
+        if: ${{ github.event.inputs.notification-channel != '' }}
+        run: |
+          sed -i.bak -e 's|\(notification_channel * = *"\)[^"]*|\1${{ github.event.inputs.notification-channel }}|g' .release/ci.hcl
           rm -rf .release/ci.hcl.bak
+          git diff --color=always .release/ci.hcl
 
       - name: Update version file
         run: |
-          NOMAD_MAIN_VERSION = $(echo "${{ inputs.version }}" | cut -d- -f1)
-          NOMAD_PRERELEASE_VERSION = $(echo "${{ inputs.version }}" | sed 's|^[^-]*-\{0,1\}||g' )
+          NOMAD_VERSION="${{ github.event.inputs.version }}"
+          NOMAD_MAIN_VERSION=$(echo "$NOMAD_VERSION" | cut -d- -f1)
+          NOMAD_PRERELEASE_VERSION=$(echo "$NOMAD_VERSION" | sed 's|^[^-]*-\{0,1\}||g')
+
           echo "updating version to ${NOMAD_MAIN_VERSION}-${NOMAD_PRERELEASE_VERSION}"
-          sed -i.bak -e 's|\(Version * = *"\)[^"]*|\1${NOMAD_MAIN_VERSION}|g' version/version.go
-          sed -i.bak -e 's|\(VersionPrerelease * = *"\)[^"]*|\1${NOMAD_PRERELEASE_VERSION}|g' version/version.go
+
+          sed -i.bak -e "s|\(Version * = *\"\)[^\"]*|\1${NOMAD_MAIN_VERSION}|g" version/version.go
+          sed -i.bak -e "s|\(VersionPrerelease * = *\"\)[^\"]*|\1${NOMAD_PRERELEASE_VERSION}|g" version/version.go
           rm -rf version/version.go.bak
+          git diff --color=always version/version.go
 
       - name: Update changelog
-        if: ${{ inputs.update-changelog == 'true' }}
+        if: ${{ github.event.inputs.update-changelog == 'true' }}
         run: |
-          echo -e "## ${{ inputs.version }} ($(date '+%B %d, %Y'))\n$(make changelog)\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
+          echo "::group::Fetch all git repo"
+          git fetch --unshallow
+          echo "::endgroup::"
+
+          echo -e "## ${{ github.event.inputs.version }} ($(date '+%B %d, %Y'))\n$(make changelog)\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
+          git diff --color=always CHANGELOG.md
 
       - name: Generate static assets
         id: generate-static-assets
         run: |
-          make deps
           make prerelease
 
       - name: Commit and push changes
@@ -94,7 +107,7 @@ jobs:
           then
             git config --global user.email "github-team-nomad-core@hashicorp.com"
             git config --global user.name "hc-github-team-nomad-core"
-            git commit --message "Generate files for ${{ inputs.version }} release"
+            git commit --message "Generate files for ${{ github.event.inputs.version }} release"
             git push origin "$(git rev-parse --abbrev-ref HEAD)"
             echo "committing generated files"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,16 @@ on:
         description: 'The version being released'
         required: true
         type: string
+      upddate-changelog:
+        description: 'Update CHANGELOG'
+        required: true
+        type: boolean
+        default: true
+      notification-channel:
+        description: 'Slack channel to use for notifications'
+        required: false
+        type: string
+        default: 'CUYKT2A73'
 
 env:
   GO_TAGS: "release"
@@ -49,6 +59,12 @@ jobs:
         run: |
           npm install -g yarn
 
+      - name: Update notification channel
+        if: ${{ inputs.notification-channel != '' }}
+        run: |
+          sed -i.bak -e 's|\(notification_channel * = *"\)[^"]*|\1${{ inputs.notification-channel }}|g' .release/ci.hcl
+          rm -rf .release/ci.hcl.bak
+
       - name: Update version file
         run: |
           NOMAD_MAIN_VERSION = $(echo "${{ inputs.version }}" | cut -d- -f1)
@@ -57,6 +73,11 @@ jobs:
           sed -i.bak -e 's|\(Version * = *"\)[^"]*|\1$(NOMAD_MAIN_VERSION)|g' version/version.go
           sed -i.bak -e 's|\(VersionPrerelease * = *"\)[^"]*|\1$(NOMAD_PRERELEASE_VERSION)|g' version/version.go
           rm -rf version/version.go.bak
+
+      - name: Update changelog
+        if: ${{ inputs.update-changelog == 'true' }}
+        run: |
+          echo -e "## ${{ inputs.version }} ($(date '+%B %d, %Y'))\n$(make changelog)\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
 
       - name: Generate static assets
         id: generate-static-assets

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -9,9 +9,15 @@ project "nomad" {
     // notification_channel = "CUYKT2A73"
   }
   github {
-    organization     = "hashicorp"
-    repository       = "nomad"
-    release_branches = ["main"]
+    organization = "hashicorp"
+    repository   = "nomad"
+    release_branches = [
+      "main",
+      "release/1.0.x",
+      "release/1.1.x",
+      "release/1.2.x",
+      "release/1.3.x",
+    ]
   }
 }
 


### PR DESCRIPTION
The Nomad release process requires several files to be modified and committed back to the repo. Some of those changes are currently done manually (update `version.go`, add new entries to `CHANGELOG.md` etc.) and others are automated (call `make prerelease` to build the UI and other auto-generated code).

These changes are committed to the repo to provide users with a deterministic build from the release SHA, meaning that anyone building from that commit will always get the same binary regardless of external dependencies.

But these files are fairly large so we only commit them on release and never to the `main` branch.

For Nomad 1.3.0-beta.1, the release was created from a short-lived release branch specific to that version, but this is not the recommended pattern for CRT. The reason for using a branch was two-fold:
1. provide an isolated work area where these files can be modified and committed without potential interference from other commits.
2. have the release commit in a branch different from `main` so that we can delete these files before merging the short-lived release branch back to `main`.

```
              (tag: v1.3.0-beta.1)
                    Generate         Delete
                      files           files
                        v               v 
                      ┌-*---------------*-┐
release/1.3.0-beta.1  |                   |
                main -*---*---*---*---*---*-
```

This PR changes the release flow to do everything in the long-lived release branch itself. 

The `generate-static-assets.yml` workflow is renamed to `release.yml` and is now triggered using the `workflow_dispatch` event instead of the push to the short-lived release branch. 

The `build.yml` workflow is changed to be a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) so it can be called more easily in different ways and without requiring third-party actions. The build is also parameterized to take a specific git commit as source, so that we can make sure the binary is generated from the commit that generated the necessary files, even if new commits are made to the release branch.

Triggering the `release.yml` workflow will generate the static assets in the release branch and call the `build.yml` workflow in the resulting commit. 

Currently only the generated files are part of the `release.yml` commit, but in the future we can expand it to include all other required code changes so that the release commit would be atomic.

The `build-trigger.yml` workflow is used to call the `build.yml` workflow for non-release purposes, like manual custom builds and automated builds on commits to `main`.