### PR TITLE
e2e: Wait for deployment to finish before disconnect

### DIFF
--- a/e2e/disconnectedclients/disconnectedclients_test.go
+++ b/e2e/disconnectedclients/disconnectedclients_test.go
@@ -129,6 +129,9 @@ func TestDisconnectedClients(t *testing.T) {
 				[]string{"running", "running"})
 			require.NoError(t, err, "job should be running")
 
+			err = e2eutil.WaitForLastDeploymentStatus(jobID, ns, "successful", nil)
+			require.NoError(t, err, "success", "deployment did not complete")
+
 			// pick one alloc to make our disconnected alloc (and its node)
 			allocs, err := e2eutil.AllocsForJob(jobID, ns)
 			require.NoError(t, err, "could not query allocs for job")

--- a/e2e/e2eutil/input/disconnect-node.nomad
+++ b/e2e/e2eutil/input/disconnect-node.nomad
@@ -13,6 +13,11 @@ job "disconnect-node" {
 
   group "group" {
 
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+
     # need to prevent the task from being restarted on reconnect, if
     # we're stopped long enough for the node to be marked down
     max_client_disconnect = "1h"

--- a/e2e/e2eutil/input/restart-node.nomad
+++ b/e2e/e2eutil/input/restart-node.nomad
@@ -13,6 +13,11 @@ job "restart-node" {
 
   group "group" {
 
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+
     # need to prevent the task from being restarted on reconnect, if
     # we're stopped long enough for the node to be marked down
     max_client_disconnect = "1h"


### PR DESCRIPTION
The E2E tests for disconnected clients were disconnecting one of the clients before the initial deployment was complete. This triggered a replacement alloc on an unanticipated node. This PR adds a call to `e2eutil.WaitForLastDeploymentStatus` to ensure the deployment is complete before disconnecting the client. 