### PR TITLE
Moves the evaluations table toolbar outside of the table-container

### DIFF
--- a/ui/app/templates/evaluations/index.hbs
+++ b/ui/app/templates/evaluations/index.hbs
@@ -1,7 +1,6 @@
 {{page-title "Evaluations"}}
 {{did-update this.notifyEvalChange this.currentEval}}
 <section class="section">
-  <div class="table-container">
     <div class="toolbar">
       <div class="toolbar-item">
         <SearchBox
@@ -42,6 +41,7 @@
         />
       </div>
     </div>
+  <div class="table-container">
     {{#if @model.length}}
       <ListTable data-test-eval-table @source={{@model}} as |t|>
         <t.head>


### PR DESCRIPTION
Resolves #12763 

Horizontal scrollbar was happening by combination of .toolbar's negative margins, while being inside the .table-container for evaluations.

Elsewhere, this toolbar is outside the table container, causing no such break.

### Before
![image](https://user-images.githubusercontent.com/713991/165535759-135e7da3-9b0d-4223-9999-2bc0dcfd43a7.png)

### After
![image](https://user-images.githubusercontent.com/713991/165535674-6d30115f-3ec7-4024-9a9f-01f5e03ac451.png)

