### PR TITLE
Add `guest_agent` config option for QEMU driver

### DIFF
--- a/.changelog/12800.txt
+++ b/.changelog/12800.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+qemu: add support for guest agent socket
+```

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -462,7 +462,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 
 	if driverConfig.GuestAgent {
 		if runtime.GOOS == "windows" {
-			return nil, nil, errors.New("QEMU Guest Agent is unsupported on the Windows platform")
+			return nil, nil, errors.New("QEMU Guest Agent socket is unsupported on the Windows platform")
 		}
 		// This socket will be used to communicate with the Guest Agent (if it's running)
 		taskDir := filepath.Join(cfg.AllocDir, cfg.Name)

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -41,6 +41,9 @@ const (
 	qemuGracefulShutdownMsg = "system_powerdown\n"
 	qemuMonitorSocketName   = "qemu-monitor.sock"
 
+	// Socket file enabling communication with the Qemu Guest Agent (if enabled and running)
+	qemuGuestAgentSocketName = "qemu-guest-agent.sock"
+
 	// Maximum socket path length prior to qemu 2.10.1
 	qemuLegacyMaxMonitorPathLen = 108
 
@@ -94,6 +97,7 @@ var (
 		"image_path":        hclspec.NewAttr("image_path", "string", true),
 		"accelerator":       hclspec.NewAttr("accelerator", "string", false),
 		"graceful_shutdown": hclspec.NewAttr("graceful_shutdown", "bool", false),
+		"guest_agent":       hclspec.NewAttr("guest_agent", "bool", false),
 		"args":              hclspec.NewAttr("args", "list(string)", false),
 		"port_map":          hclspec.NewAttr("port_map", "list(map(number))", false),
 	})
@@ -121,6 +125,7 @@ type TaskConfig struct {
 	Args             []string           `codec:"args"`     // extra arguments to qemu executable
 	PortMap          hclutils.MapStrInt `codec:"port_map"` // A map of host port and the port name defined in the image manifest file
 	GracefulShutdown bool               `codec:"graceful_shutdown"`
+	GuestAgent       bool               `codec:"guest_agent"`
 }
 
 // TaskState is the state which is encoded in the handle returned in StartTask.
@@ -453,6 +458,17 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		}
 		d.logger.Debug("got monitor path", "monitorPath", monitorPath)
 		args = append(args, "-monitor", fmt.Sprintf("unix:%s,server,nowait", monitorPath))
+	}
+
+	if driverConfig.GuestAgent {
+		if runtime.GOOS == "windows" {
+			return nil, nil, errors.New("QEMU Guest Agent is unsupported on the Windows platform")
+		}
+		// This socket will be used to communicate with the Guest Agent (if it's running)
+		taskDir := filepath.Join(cfg.AllocDir, cfg.Name)
+		args = append(args, "-chardev", fmt.Sprintf("socket,path=%s/%s,server,nowait,id=qga0", taskDir, qemuGuestAgentSocketName))
+		args = append(args, "-device", "virtio-serial")
+		args = append(args, "-device", "virtserialport,chardev=qga0,name=org.qemu.guest_agent.0")
 	}
 
 	// Add pass through arguments to qemu executable. A user can specify

--- a/website/content/docs/drivers/qemu.mdx
+++ b/website/content/docs/drivers/qemu.mdx
@@ -61,11 +61,11 @@ The `qemu` driver supports the following configuration in the job spec:
   [alloc_dir](/docs/configuration/client#alloc_dir)
   paths.) This feature is currently not supported on Windows.
 
-- `guest_agent` `(bool: false)` - Enable the [QEMU Guest 
-  Agent](https://wiki.qemu.org/Features/GuestAgent) for this virtual machine.  This 
+- `guest_agent` `(bool: false)` - Enable support for the [QEMU Guest 
+  Agent](https://wiki.qemu.org/Features/GuestAgent) for this virtual machine. This 
   will add the necessary virtual hardware and create a `qemu-guest-agent.sock`
-  file in the task's working directory for interacting with the agent, which
-  must be running in the VM to work.  This feature is currently not supported
+  file in the task's working directory for interacting with the agent. The QEMU Guest
+  Agent must be running in the guest VM.  This feature is currently not supported
   on Windows.
 
 - `port_map` - (Optional) A key-value map of port labels.

--- a/website/content/docs/drivers/qemu.mdx
+++ b/website/content/docs/drivers/qemu.mdx
@@ -61,6 +61,13 @@ The `qemu` driver supports the following configuration in the job spec:
   [alloc_dir](/docs/configuration/client#alloc_dir)
   paths.) This feature is currently not supported on Windows.
 
+- `guest_agent` `(bool: false)` - Enable the [QEMU Guest 
+  Agent](https://wiki.qemu.org/Features/GuestAgent) for this virtual machine.  This 
+  will add the necessary virtual hardware and create a `qemu-guest-agent.sock`
+  file in the task's working directory for interacting with the agent, which
+  must be running in the VM to work.  This feature is currently not supported
+  on Windows.
+
 - `port_map` - (Optional) A key-value map of port labels.
 
   ```hcl


### PR DESCRIPTION
When enabled, this will add the necessary virtual hardware and create a `qemu-guest-agent.sock` file in the task's working directory for interacting with the agent, which must be running in the VM to work. 
https://wiki.qemu.org/Features/GuestAgent