### PR TITLE
debug: add version constraint to avoid pprof panic

### DIFF
--- a/.changelog/12807.txt
+++ b/.changelog/12807.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-cli: `operator debug` command now skips generating pprofs to avoid a panic on Nomad 0.11.2 and 0.11.1
+cli: `operator debug` command now skips generating pprofs to avoid a panic on Nomad 0.11.2. 0.11.1, and 0.11.0
 ```

--- a/.changelog/12807.txt
+++ b/.changelog/12807.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-cli: `operator debug` command now skips generating pprofs to avoid a panic on unsupported versions of Nomad older than 0.12.0
+cli: `operator debug` command now skips generating pprofs to avoid a panic on Nomad 0.11.2 and 0.11.1
 ```

--- a/.changelog/12807.txt
+++ b/.changelog/12807.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: `operator debug` command now skips generating pprofs to avoid a panic on unsupported versions of Nomad older than 0.12.0
+```

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1750,6 +1750,12 @@ func (c *OperatorDebugCommand) getNomadVersion(serverID string, nodeID string) s
 	version := ""
 	if serverID != "" {
 		for _, server := range c.members.Members {
+			// Raft v2 server
+			if server.Name == serverID {
+				version = server.Tags["build"]
+			}
+
+			// Raft v3 server
 			if server.Tags["id"] == serverID {
 				version = server.Tags["version"]
 			}

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -60,11 +60,12 @@ type OperatorDebugCommand struct {
 }
 
 const (
-	userAgent   = "nomad operator debug"
-	clusterDir  = "cluster"
-	clientDir   = "client"
-	serverDir   = "server"
-	intervalDir = "interval"
+	userAgent                     = "nomad operator debug"
+	clusterDir                    = "cluster"
+	clientDir                     = "client"
+	serverDir                     = "server"
+	intervalDir                   = "interval"
+	minimumVersionPprofConstraint = ">= 0.11.0, <= 0.11.2"
 )
 
 func (c *OperatorDebugCommand) Help() string {
@@ -1008,9 +1009,10 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client,
 
 	// threadcreate pprof causes a panic on Nomad 0.11.0 to 0.11.2 -- skip those versions
 	version := c.getNomadVersion(opts.ServerID, opts.NodeID)
-	skip, err := checkVersion(version, ">= 0.11.0, <= 0.11.2")
+	skip, err := checkVersion(version, minimumVersionPprofConstraint)
+
 	if skip {
-		c.Ui.Warn(fmt.Sprintf("Skipping threadcreate pprof: unsupported version=%s matches constraint %s", version, ">= 0.11.0, <= 0.11.2"))
+		c.Ui.Warn(fmt.Sprintf("Skipping threadcreate pprof: unsupported version=%s matches constraint %s", version, minimumVersionPprofConstraint))
 		return
 	}
 	if err != nil {

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -506,9 +506,11 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 	}
 
 	// Get complete list of client nodes
-	var qm *api.QueryMeta
-	c.nodes, qm, err = client.Nodes().List(c.queryOpts())
-	c.verboseOutf("%d nodes retrieved in %s", len(c.nodes), qm.RequestTime.String())
+	c.nodes, _, err = client.Nodes().List(c.queryOpts())
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error querying node info: %v", err))
+		return 1
+	}
 
 	// Write nodes to file
 	c.writeJSON(clusterDir, "nodes.json", c.nodes, err)

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -65,7 +65,7 @@ const (
 	clientDir                     = "client"
 	serverDir                     = "server"
 	intervalDir                   = "interval"
-	minimumVersionPprofConstraint = "< 0.12.0"
+	minimumVersionPprofConstraint = ">= 0.11.0, <= 0.11.2"
 )
 
 func (c *OperatorDebugCommand) Help() string {

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1008,7 +1008,7 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client,
 
 	// threadcreate pprof causes a panic on Nomad 0.11.0 to 0.11.2 -- skip those versions
 	version := c.getNomadVersion(opts.NodeID, opts.ServerID)
-	if _, err := checkVersion(version, ">= 0.11.0, <= 0.11.2"); err != nil {
+	if skip, err := checkVersion(version, ">= 0.11.0, <= 0.11.2"); skip || err != nil {
 		c.Ui.Error((fmt.Sprintf("Not running threadcreate pprof profile, err: %v", err)))
 		return
 	}
@@ -1775,6 +1775,5 @@ func checkVersion(version string, versionConstraint string) (bool, error) {
 		return true, nil
 	}
 
-	err = fmt.Errorf("version %s did not match constraint: %s", version, c.String())
-	return false, err
+	return false, nil
 }

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1001,12 +1001,6 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client,
 	c.savePprofProfile(path, "heap", opts, client)      // A sampling of memory allocations of live objects. You can specify the gc GET parameter to run GC before taking the heap sample.
 	c.savePprofProfile(path, "allocs", opts, client)    // A sampling of all past memory allocations
 
-	// This profile is disabled by default -- Requires runtime.SetBlockProfileRate to enable
-	// c.savePprofProfile(path, "block", opts, client)        // Stack traces that led to blocking on synchronization primitives
-
-	// This profile is disabled by default -- Requires runtime.SetMutexProfileFraction to enable
-	// c.savePprofProfile(path, "mutex", opts, client)        // Stack traces of holders of contended mutexes
-
 	// threadcreate pprof causes a panic on Nomad 0.11.0 to 0.11.2 -- skip those versions
 	version := c.getNomadVersion(opts.ServerID, opts.NodeID)
 	skip, err := checkVersion(version, minimumVersionPprofConstraint)

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -993,10 +993,10 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client,
 	// Reset to pprof binary format
 	opts.Debug = 0
 
-	c.savePprofProfile(path, "goroutine", opts, client)    // Stack traces of all current goroutines
-	c.savePprofProfile(path, "heap", opts, client)         // A sampling of memory allocations of live objects. You can specify the gc GET parameter to run GC before taking the heap sample.
-	c.savePprofProfile(path, "allocs", opts, client)       // A sampling of all past memory allocations
-	c.savePprofProfile(path, "threadcreate", opts, client) // Stack traces that led to the creation of new OS threads
+	c.savePprofProfile(path, "goroutine", opts, client) // Stack traces of all current goroutines
+	c.savePprofProfile(path, "trace", opts, client)     // A trace of execution of the current program
+	c.savePprofProfile(path, "heap", opts, client)      // A sampling of memory allocations of live objects. You can specify the gc GET parameter to run GC before taking the heap sample.
+	c.savePprofProfile(path, "allocs", opts, client)    // A sampling of all past memory allocations
 
 	// This profile is disabled by default -- Requires runtime.SetBlockProfileRate to enable
 	// c.savePprofProfile(path, "block", opts, client)        // Stack traces that led to blocking on synchronization primitives
@@ -1004,18 +1004,14 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client,
 	// This profile is disabled by default -- Requires runtime.SetMutexProfileFraction to enable
 	// c.savePprofProfile(path, "mutex", opts, client)        // Stack traces of holders of contended mutexes
 
-	// trace pprof causes a panic on Nomad 0.11.0 to 0.11.2, so verify the the
-	// Nomad version of this agent before capture
+	// threadcreate pprof causes a panic on Nomad 0.11.0 to 0.11.2 -- skip those versions
 	version := c.getNomadVersion(opts.NodeID, opts.ServerID)
-	// c.Ui.Output(fmt.Sprintf("Nomad Version: %v", version))
-
 	if _, err := checkVersion(version, ">= 0.11.0, <= 0.11.2"); err != nil {
-		c.Ui.Error((fmt.Sprintf("Not running trace pprof profile, err: %v", err)))
+		c.Ui.Error((fmt.Sprintf("Not running threadcreate pprof profile, err: %v", err)))
 		return
 	}
 
-	c.savePprofProfile(path, "trace", opts, client) // A trace of execution of the current program
-
+	c.savePprofProfile(path, "threadcreate", opts, client) // Stack traces that led to the creation of new OS threads
 }
 
 // savePprofProfile retrieves a pprof profile and writes to disk

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-multierror"
+	goversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/hashicorp/nomad/helper"
@@ -1713,4 +1714,25 @@ func isRedirectError(err error) bool {
 
 	const redirectErr string = `invalid character '<' looking for beginning of value`
 	return strings.Contains(err.Error(), redirectErr)
+}
+
+
+// checkVersion verifies that version satisfies the constraint
+func checkVersion(version string, versionConstraint string) (bool, error) {
+	v, err := goversion.NewVersion(version)
+	if err != nil {
+		return false, err
+	}
+
+	c, err := goversion.NewConstraint(versionConstraint)
+	if err != nil {
+		return false, err
+	}
+
+	if c.Check(v) {
+		return true, nil
+	}
+
+	err = fmt.Errorf("version %s did not match constraint: %s", version, c.String())
+	return false, err
 }

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1008,8 +1008,13 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client,
 
 	// threadcreate pprof causes a panic on Nomad 0.11.0 to 0.11.2 -- skip those versions
 	version := c.getNomadVersion(opts.ServerID, opts.NodeID)
-	if skip, err := checkVersion(version, ">= 0.11.0, <= 0.11.2"); skip || err != nil {
-		c.Ui.Error((fmt.Sprintf("Not running threadcreate pprof profile, err: %v", err)))
+	skip, err := checkVersion(version, ">= 0.11.0, <= 0.11.2")
+	if skip {
+		c.Ui.Warn(fmt.Sprintf("Skipping threadcreate pprof: unsupported version=%s matches constraint %s", version, ">= 0.11.0, <= 0.11.2"))
+		return
+	}
+	if err != nil {
+		c.Ui.Error((fmt.Sprintf("Skipping threadcreate pprof, error: %v", err)))
 		return
 	}
 

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1007,7 +1007,7 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client,
 	// c.savePprofProfile(path, "mutex", opts, client)        // Stack traces of holders of contended mutexes
 
 	// threadcreate pprof causes a panic on Nomad 0.11.0 to 0.11.2 -- skip those versions
-	version := c.getNomadVersion(opts.NodeID, opts.ServerID)
+	version := c.getNomadVersion(opts.ServerID, opts.NodeID)
 	if skip, err := checkVersion(version, ">= 0.11.0, <= 0.11.2"); skip || err != nil {
 		c.Ui.Error((fmt.Sprintf("Not running threadcreate pprof profile, err: %v", err)))
 		return
@@ -1738,12 +1738,15 @@ func isRedirectError(err error) bool {
 
 // getNomadVersion fetches the version of Nomad running on a given server/client node ID
 func (c *OperatorDebugCommand) getNomadVersion(serverID string, nodeID string) string {
-	version := ""
+	if serverID == "" && nodeID == "" {
+		return ""
+	}
 
+	version := ""
 	if serverID != "" {
 		for _, server := range c.members.Members {
 			if server.Tags["id"] == serverID {
-				version = server.Tags["id"]
+				version = server.Tags["version"]
 			}
 		}
 	}

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -582,23 +582,22 @@ func TestDebug_Fail_Pprof(t *testing.T) {
 // the version constraint.
 func TestDebug_PprofVersionCheck(t *testing.T) {
 	cases := []struct {
-		version    string
-		constraint string
-		isMatch    bool
-		isError    bool
+		version string
+		isMatch bool
+		isError bool
 	}{
-		{"0.8.7", ">= 0.11.0, <= 0.11.2", false, false},
-		{"0.11.0", ">= 0.11.0, <= 0.11.2", true, false},
-		{"0.11.1", ">= 0.11.0, <= 0.11.2", true, false},
-		{"0.11.2", ">= 0.11.0, <= 0.11.2", true, false},
-		{"0.11.3", ">= 0.11.0, <= 0.11.2", false, false},
-		{"0.12.0", ">= 0.11.0, <= 0.11.2", false, false},
-		{"1.3.0", ">= 0.11.0, <= 0.11.2", false, false},
-		{"foo.bar", ">= 0.11.0, <= 0.11.2", false, true},
+		{"0.8.7", false, false},
+		{"0.11.0", true, false},
+		{"0.11.1", true, false},
+		{"0.11.2", true, false},
+		{"0.11.3", false, false},
+		{"0.12.0", false, false},
+		{"1.3.0", false, false},
+		{"foo.bar", false, true},
 	}
 
 	for _, tc := range cases {
-		match, err := checkVersion(tc.version, ">= 0.11.0, <= 0.11.2")
+		match, err := checkVersion(tc.version, minimumVersionPprofConstraint)
 		assert.Equal(t, tc.isMatch, match)
 		if tc.isError {
 			require.Error(t, err)

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -585,11 +585,12 @@ func TestDebug_PprofVersionCheck(t *testing.T) {
 		version string
 		errMsg  string
 	}{
-		{"0.8.7", "unsupported version=0.8.7 matches version filter < 0.12.0"},
-		{"0.11.0", "unsupported version=0.11.0 matches version filter < 0.12.0"},
-		{"0.11.2+ent", "unsupported version=0.11.2+ent matches version filter < 0.12.0"},
-		{"0.11.3", "unsupported version=0.11.3 matches version filter < 0.12.0"},
-		{"0.11.3+ent", "unsupported version=0.11.3+ent matches version filter < 0.12.0"},
+		{"0.8.7", ""},
+		{"0.11.1", "unsupported version=0.11.1 matches version filter >= 0.11.0, <= 0.11.2"},
+		{"0.11.2", "unsupported version=0.11.2 matches version filter >= 0.11.0, <= 0.11.2"},
+		{"0.11.2+ent", "unsupported version=0.11.2+ent matches version filter >= 0.11.0, <= 0.11.2"},
+		{"0.11.3", ""},
+		{"0.11.3+ent", ""},
 		{"0.12.0", ""},
 		{"1.3.0", ""},
 		{"foo.bar", "error: Malformed version: foo.bar"},

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -587,13 +587,14 @@ func TestDebug_PprofVersionCheck(t *testing.T) {
 		isMatch    bool
 		isError    bool
 	}{
-		{"0.8.7", ">= 0.11.0, <= 0.11.2", false, true},
+		{"0.8.7", ">= 0.11.0, <= 0.11.2", false, false},
 		{"0.11.0", ">= 0.11.0, <= 0.11.2", true, false},
 		{"0.11.1", ">= 0.11.0, <= 0.11.2", true, false},
 		{"0.11.2", ">= 0.11.0, <= 0.11.2", true, false},
-		{"0.11.3", ">= 0.11.0, <= 0.11.2", false, true},
-		{"0.12.0", ">= 0.11.0, <= 0.11.2", false, true},
-		{"1.3.0", ">= 0.11.0, <= 0.11.2", false, true},
+		{"0.11.3", ">= 0.11.0, <= 0.11.2", false, false},
+		{"0.12.0", ">= 0.11.0, <= 0.11.2", false, false},
+		{"1.3.0", ">= 0.11.0, <= 0.11.2", false, false},
+		{"foo.bar", ">= 0.11.0, <= 0.11.2", false, true},
 	}
 
 	for _, tc := range cases {
@@ -601,7 +602,6 @@ func TestDebug_PprofVersionCheck(t *testing.T) {
 		assert.Equal(t, tc.isMatch, match)
 		if tc.isError {
 			require.Error(t, err)
-			fmt.Println(err.Error())
 		} else {
 			require.NoError(t, err)
 		}

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -578,6 +578,36 @@ func TestDebug_Fail_Pprof(t *testing.T) {
 	require.Contains(t, ui.OutputWriter.String(), "Created debug archive")   // Archive should be generated anyway
 }
 
+// TestDebug_PprofVersionCheck asserts that only versions 0.11.0 -> 0.11.2 match
+// the version constraint.
+func TestDebug_PprofVersionCheck(t *testing.T) {
+	cases := []struct {
+		version    string
+		constraint string
+		isMatch    bool
+		isError    bool
+	}{
+		{"0.8.7", ">= 0.11.0, <= 0.11.2", false, true},
+		{"0.11.0", ">= 0.11.0, <= 0.11.2", true, false},
+		{"0.11.1", ">= 0.11.0, <= 0.11.2", true, false},
+		{"0.11.2", ">= 0.11.0, <= 0.11.2", true, false},
+		{"0.11.3", ">= 0.11.0, <= 0.11.2", false, true},
+		{"0.12.0", ">= 0.11.0, <= 0.11.2", false, true},
+		{"1.3.0", ">= 0.11.0, <= 0.11.2", false, true},
+	}
+
+	for _, tc := range cases {
+		match, err := checkVersion(tc.version, ">= 0.11.0, <= 0.11.2")
+		assert.Equal(t, tc.isMatch, match)
+		if tc.isError {
+			require.Error(t, err)
+			fmt.Println(err.Error())
+		} else {
+			require.NoError(t, err)
+		}
+	}
+}
+
 func TestDebug_StringToSlice(t *testing.T) {
 	ci.Parallel(t)
 


### PR DESCRIPTION
This PR introduces `go-version` constraint checks to avoid capturing the threadcreate pprof profile on Nomad versions 0.11.0 to 0.11.2.  The code to obtain the version number for a given server or node ID isn't pretty, but in lieu of a better method it should suffice for now.

Fixes #12804.