### PR TITLE
Fix network.dns interpolation

### DIFF
--- a/.changelog/12817.txt
+++ b/.changelog/12817.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where network.dns block was not interpolated
+```

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -1041,10 +1041,7 @@ func (tr *TaskRunner) buildTaskConfig() *drivers.TaskConfig {
 	if alloc.AllocatedResources != nil && len(alloc.AllocatedResources.Shared.Networks) > 0 {
 		allocDNS := alloc.AllocatedResources.Shared.Networks[0].DNS
 		if allocDNS != nil {
-		// could potentially interpolate here
 		interpolatedNetworks := taskenv.InterpolateNetworks(env, alloc.AllocatedResources.Shared.Networks)
-		tr.logger.Info("allocDNS is set", "dnsserver", allocDNS.Servers)
-		tr.logger.Info("interpolatedDNS is set", "dnsserver", interpolatedNetworks[0].DNS.Servers)
 			dns = &drivers.DNSConfig{
 				Servers:  interpolatedNetworks[0].DNS.Servers,
 				Searches: interpolatedNetworks[0].DNS.Searches,

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -1041,7 +1041,7 @@ func (tr *TaskRunner) buildTaskConfig() *drivers.TaskConfig {
 	if alloc.AllocatedResources != nil && len(alloc.AllocatedResources.Shared.Networks) > 0 {
 		allocDNS := alloc.AllocatedResources.Shared.Networks[0].DNS
 		if allocDNS != nil {
-		interpolatedNetworks := taskenv.InterpolateNetworks(env, alloc.AllocatedResources.Shared.Networks)
+			interpolatedNetworks := taskenv.InterpolateNetworks(env, alloc.AllocatedResources.Shared.Networks)
 			dns = &drivers.DNSConfig{
 				Servers:  interpolatedNetworks[0].DNS.Servers,
 				Searches: interpolatedNetworks[0].DNS.Searches,

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -1041,10 +1041,14 @@ func (tr *TaskRunner) buildTaskConfig() *drivers.TaskConfig {
 	if alloc.AllocatedResources != nil && len(alloc.AllocatedResources.Shared.Networks) > 0 {
 		allocDNS := alloc.AllocatedResources.Shared.Networks[0].DNS
 		if allocDNS != nil {
+		// could potentially interpolate here
+		interpolatedNetworks := taskenv.InterpolateNetworks(env, alloc.AllocatedResources.Shared.Networks)
+		tr.logger.Info("allocDNS is set", "dnsserver", allocDNS.Servers)
+		tr.logger.Info("interpolatedDNS is set", "dnsserver", interpolatedNetworks[0].DNS.Servers)
 			dns = &drivers.DNSConfig{
-				Servers:  allocDNS.Servers,
-				Searches: allocDNS.Searches,
-				Options:  allocDNS.Options,
+				Servers:  interpolatedNetworks[0].DNS.Servers,
+				Searches: interpolatedNetworks[0].DNS.Searches,
+				Options:  interpolatedNetworks[0].DNS.Options,
 			}
 		}
 	}


### PR DESCRIPTION
This fixes https://github.com/hashicorp/nomad/issues/12780

When https://github.com/hashicorp/nomad/pull/12021 was introduced, it doesn't actually work for the group -> network -> dns stanza. This PR finishes the work to get network.dns interpolation working, by actually using the interpolated DNS values.

