### PR TITLE
docs: clarify `capacity_min/max` for volumes

### DIFF
--- a/website/content/docs/commands/volume/create.mdx
+++ b/website/content/docs/commands/volume/create.mdx
@@ -108,17 +108,25 @@ parameters {
   volume. If omitted, the volume will be created from scratch. The
   `clone_id` cannot be set if the `snapshot_id` field is set.
 
-- `capacity_min` `(string: <optional>)` - Option for setting the capacity. The
-  volume must be at least this large, in bytes. The storage provider may
-  return a volume that is larger than this value. Accepts human-friendly
-  suffixes such as `"100GiB"`. This field may not be supported by all
-  storage providers.
+- `capacity_min` `(string: <optional>)` - Option for requesting a
+  minimum capacity, in bytes. The capacity of a volume may be the
+  physical size of a disk, or a quota, depending on the storage
+  provider. The specific size of the resulting volume will be
+  somewhere between `capacity_min` and `capacity_max`; the exact
+  behavior is up to the storage provider. If you want to specify an
+  exact size, you should set `capacity_min` and `capacity_max` to the
+  same value. Accepts human-friendly suffixes such as `"100GiB"`. This
+  field may not be supported by all storage providers.
 
-- `capacity_max` `(string: <optional>)` - Option for setting the capacity. The
-  volume must be no more than this large, in bytes. The storage provider may
-  return a volume that is smaller than this value. Accepts human-friendly
-  suffixes such as `"100GiB"`. This field may not be supported by all
-  storage providers.
+- `capacity_max` `(string: <optional>)` - Option for requesting a
+  maximum capacity, in bytes. The capacity of a volume may be the
+  physical size of a disk, or a quota, depending on the storage
+  provider. The specific size of the resulting volume will be
+  somewhere between `capacity_min` and `capacity_max`; the exact
+  behavior is up to the storage provider. If you want to specify an
+  exact size, you should set `capacity_min` and `capacity_max` to the
+  same value. Accepts human-friendly suffixes such as `"100GiB"`. This
+  field may not be supported by all storage providers.
 
 - `capability` `(Capability: <required>)` - Option for validating the
   capability of a volume. You must provide at least one `capability` block, and


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/12821

The capacity fields for `create volume` set bounds on the resulting
size of the volume, but the ultimate size of the volume will be
determined by the storage provider (between the min and max). Clarify
this in the documentation and provide a suggestion for how to set a
exact size.