### PR TITLE
ui: fix an error when navigating to a task group

### DIFF
--- a/ui/app/components/job-page/parts/task-groups.js
+++ b/ui/app/components/job-page/parts/task-groups.js
@@ -19,7 +19,7 @@ export default class TaskGroups extends Component.extend(Sortable) {
 
   @action
   gotoTaskGroup(taskGroup) {
-    this.router.transitionTo('jobs.job.task-group', this.job, taskGroup);
+    this.router.transitionTo('jobs.job.task-group', this.job, taskGroup.name);
   }
 
   @computed('job.taskGroups.[]')

--- a/ui/app/components/task-group-row.js
+++ b/ui/app/components/task-group-row.js
@@ -3,13 +3,18 @@ import { inject as service } from '@ember/service';
 import { computed, action } from '@ember/object';
 import { alias, oneWay } from '@ember/object/computed';
 import { debounce } from '@ember/runloop';
-import { classNames, tagName } from '@ember-decorators/component';
+import {
+  classNames,
+  tagName,
+  attributeBindings,
+} from '@ember-decorators/component';
 import classic from 'ember-classic-decorator';
 import { lazyClick } from '../helpers/lazy-click';
 
 @classic
 @tagName('tr')
 @classNames('task-group-row', 'is-interactive')
+@attributeBindings('data-test-task-group')
 export default class TaskGroupRow extends Component {
   @service can;
 

--- a/ui/app/templates/components/job-page/parts/task-groups.hbs
+++ b/ui/app/templates/components/job-page/parts/task-groups.hbs
@@ -33,7 +33,7 @@
       </t.head>
       <t.body as |row|>
         <TaskGroupRow
-          data-test-task-group
+          @data-test-task-group={{row.model.name}}
           @taskGroup={{row.model}}
           @onClick={{fn this.gotoTaskGroup row.model}}
         />

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -136,6 +136,20 @@ export default function moduleForJob(
         );
       });
 
+      test('clicking in a task group row navigates to that task group', async function (assert) {
+        const tgRow = JobDetail.taskGroups[0];
+        const tgName = tgRow.name;
+        console.log(tgName);
+
+        await tgRow.visitRow();
+
+        const expectedURL = job.namespace
+          ? `/jobs/${encodeURIComponent(job.name)}@${job.namespace}/${tgName}`
+          : `/jobs/${encodeURIComponent(job.name)}/${tgName}`;
+
+        assert.equal(currentURL(), expectedURL);
+      });
+
       test('clicking legend item navigates to a pre-filtered allocations table', async function (assert) {
         const legendItem =
           JobDetail.allocationsSummary.legend.clickableItems[1];

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -139,7 +139,6 @@ export default function moduleForJob(
       test('clicking in a task group row navigates to that task group', async function (assert) {
         const tgRow = JobDetail.taskGroups[0];
         const tgName = tgRow.name;
-        console.log(tgName);
 
         await tgRow.visitRow();
 

--- a/ui/tests/pages/components/task-groups.js
+++ b/ui/tests/pages/components/task-groups.js
@@ -1,0 +1,26 @@
+import { collection, clickable, text } from 'ember-cli-page-object';
+import { singularize } from 'ember-inflector';
+
+export default function (
+  selector = '[data-test-task-group]',
+  propKey = 'taskGroups'
+) {
+  const lookupKey = `${singularize(propKey)}For`;
+
+  return {
+    [propKey]: collection(selector, {
+      name: text('[data-test-task-group-name]'),
+      count: text('[data-test-task-group-count]'),
+      volume: text('[data-test-task-group-volume]'),
+      cpu: text('[data-test-task-group-cpu]'),
+      mem: text('[data-test-task-group-mem]'),
+      disk: text('[data-test-task-group-disk]'),
+      visit: clickable('[data-test-task-group-name] a'),
+      visitRow: clickable(),
+    }),
+
+    [lookupKey]: function (name) {
+      return this[propKey].toArray().find((tg) => tg.name === name);
+    },
+  };
+}

--- a/ui/tests/pages/jobs/detail.js
+++ b/ui/tests/pages/jobs/detail.js
@@ -11,6 +11,7 @@ import {
 } from 'ember-cli-page-object';
 
 import allocations from 'nomad-ui/tests/pages/components/allocations';
+import taskGroups from 'nomad-ui/tests/pages/components/task-groups';
 import twoStepButton from 'nomad-ui/tests/pages/components/two-step-button';
 import recommendationAccordion from 'nomad-ui/tests/pages/components/recommendation-accordion';
 import jobClientStatusBar from 'nomad-ui/tests/pages/components/job-client-status-bar';
@@ -91,6 +92,7 @@ export default create({
   allocationsSummary: jobClientStatusBar(
     '[data-test-job-summary] [data-test-allocation-status-bar]'
   ),
+  ...taskGroups(),
   ...allocations(),
 
   viewAllAllocations: text('[data-test-view-all-allocations]'),


### PR DESCRIPTION
Clicking in a task group row in the job details page would throw the
error:

```
Uncaught Error: You didn't provide enough string/numeric parameters to satisfy all of the dynamic segments for route jobs.job.task-group. Missing params: name
    createParamHandlerInfo http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:4814
    applyToHandlers http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:4804
    applyToState http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:4801
    getTransitionByIntent http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:4843
    transitionByIntent http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:4836
    refresh http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:4885
    refresh http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:2254
    queryParamsDidChange http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:2326
    k http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:2423
    triggerEvent http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:2349
    fireQueryParamDidChange http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:4863
    getTransitionByIntent http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:4848
    transitionByIntent http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:4836
    doTransition http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:4853
    transitionTo http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:4882
    _doTransition http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:2392
    transitionTo http://localhost:4646/ui/assets/vendor-194b1e0d68d11ef7a4bf334eb30ba74d.js:2177
    gotoTaskGroup http://localhost:4646/ui/assets/nomad-ui-4a2c1941e03e60e1feef715f23cf268c.js:623
...
```

This was caused because the attribute being passed to the transitionTo
function was not the task group name, but the whole model.