### PR TITLE
docs: nomad can also install autocomplete for fish shell

### DIFF
--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -27,7 +27,7 @@ command can be found on the left.
 ## Autocomplete
 
 Nomad's CLI supports command autocomplete. Autocomplete can be installed or
-uninstalled by running the following on bash or zsh shells:
+uninstalled by running the following on bash, zsh or fish shells:
 
 ```shell-session
 $ nomad -autocomplete-install


### PR DESCRIPTION
The [posener/complete](https://github.com/posener/complete) package seems to automatically also support fish shell.  We should mention it in the docs.  I was about to go and roll my own autocomplete for fish but luckily it is already supported :)