### PR TITLE
CSI: node drain should end once only plugins remain

### DIFF
--- a/nomad/drainer/draining_node.go
+++ b/nomad/drainer/draining_node.go
@@ -66,9 +66,9 @@ func (n *drainingNode) IsDone() (bool, error) {
 	}
 
 	for _, alloc := range allocs {
-		// System jobs are only stopped after a node is done draining
-		// everything else, so ignore them here.
-		if alloc.Job.Type == structs.JobTypeSystem {
+		// System and plugin jobs are only stopped after a node is
+		// done draining everything else, so ignore them here.
+		if alloc.Job.Type == structs.JobTypeSystem || alloc.Job.IsPlugin() {
 			continue
 		}
 

--- a/website/content/docs/commands/node/drain.mdx
+++ b/website/content/docs/commands/node/drain.mdx
@@ -71,7 +71,7 @@ capability.
 
 - `-ignore-system`: Ignore system allows the drain to complete without
   stopping system job allocations. By default system jobs (and CSI
-  plugins) are stopped last, after the `deadline` time has expired.
+  plugins) are stopped last.
 
 - `-keep-ineligible`: Keep ineligible will maintain the node's scheduling
   ineligibility even if the drain is being disabled. This is useful when an


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/12835

In #12324 we made it so that plugins wait until the node drain is
complete, as we do for system jobs. But we neglected to mark the node
drain as complete once only plugins (or system jobs) remaining, which
means that the node drain is left in a draining state until the
`deadline` time expires. This was incorrectly documented as expected
behavior in #12324.

---

The new behavior shipped in 1.3.0-beta.1 but not yet in GA, so depending on when this can get merged we might not need a changelog entry for this one.