### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/client/allocdir/alloc_dir_test.go
+++ b/client/allocdir/alloc_dir_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/fs"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -51,11 +50,7 @@ var (
 func TestAllocDir_BuildAlloc(t *testing.T) {
 	ci.Parallel(t)
 
-	tmp, err := ioutil.TempDir("", "AllocDir")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	d := NewAllocDir(testlog.HCLogger(t), tmp, "test")
 	defer d.Destroy()
@@ -103,11 +98,7 @@ func TestAllocDir_MountSharedAlloc(t *testing.T) {
 	ci.Parallel(t)
 	MountCompatible(t)
 
-	tmp, err := ioutil.TempDir("", "AllocDir")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	d := NewAllocDir(testlog.HCLogger(t), tmp, "test")
 	defer d.Destroy()
@@ -150,11 +141,7 @@ func TestAllocDir_MountSharedAlloc(t *testing.T) {
 func TestAllocDir_Snapshot(t *testing.T) {
 	ci.Parallel(t)
 
-	tmp, err := ioutil.TempDir("", "AllocDir")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	d := NewAllocDir(testlog.HCLogger(t), tmp, "test")
 	defer d.Destroy()
@@ -232,17 +219,8 @@ func TestAllocDir_Snapshot(t *testing.T) {
 func TestAllocDir_Move(t *testing.T) {
 	ci.Parallel(t)
 
-	tmp1, err := ioutil.TempDir("", "AllocDir")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmp1)
-
-	tmp2, err := ioutil.TempDir("", "AllocDir")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmp2)
+	tmp1 := t.TempDir()
+	tmp2 := t.TempDir()
 
 	// Create two alloc dirs
 	d1 := NewAllocDir(testlog.HCLogger(t), tmp1, "test")
@@ -302,11 +280,7 @@ func TestAllocDir_Move(t *testing.T) {
 func TestAllocDir_EscapeChecking(t *testing.T) {
 	ci.Parallel(t)
 
-	tmp, err := ioutil.TempDir("", "AllocDir")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	d := NewAllocDir(testlog.HCLogger(t), tmp, "test")
 	if err := d.Build(); err != nil {
@@ -373,11 +347,7 @@ func TestAllocDir_ReadAt_SecretDir(t *testing.T) {
 func TestAllocDir_SplitPath(t *testing.T) {
 	ci.Parallel(t)
 
-	dir, err := ioutil.TempDir("", "tmpdirtest")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	dest := filepath.Join(dir, "/foo/bar/baz")
 	if err := os.MkdirAll(dest, os.ModePerm); err != nil {
@@ -401,11 +371,7 @@ func TestAllocDir_CreateDir(t *testing.T) {
 		t.Skip("Must be root to run test")
 	}
 
-	dir, err := ioutil.TempDir("", "tmpdirtest")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// create a subdir and a file
 	subdir := filepath.Join(dir, "subdir")
@@ -418,10 +384,7 @@ func TestAllocDir_CreateDir(t *testing.T) {
 	}
 
 	// Create the above hierarchy under another destination
-	dir1, err := ioutil.TempDir("/tmp", "tempdirdest")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	dir1 := t.TempDir()
 
 	if err := createDir(dir1, subdir); err != nil {
 		t.Fatalf("err: %v", err)
@@ -440,11 +403,7 @@ func TestAllocDir_CreateDir(t *testing.T) {
 func TestPathFuncs(t *testing.T) {
 	ci.Parallel(t)
 
-	dir, err := ioutil.TempDir("", "nomadtest-pathfuncs")
-	if err != nil {
-		t.Fatalf("error creating temp dir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	missingDir := filepath.Join(dir, "does-not-exist")
 

--- a/client/allocdir/fs_linux_test.go
+++ b/client/allocdir/fs_linux_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,13 +54,7 @@ func TestLinuxRootSecretDir(t *testing.T) {
 		t.Skip("Must be run as root")
 	}
 
-	tmpdir, err := ioutil.TempDir("", "nomadtest-rootsecretdir")
-	if err != nil {
-		t.Fatalf("unable to create tempdir for test: %v", err)
-	}
-	defer os.RemoveAll(tmpdir)
-
-	secretsDir := filepath.Join(tmpdir, TaskSecrets)
+	secretsDir := filepath.Join(t.TempDir(), TaskSecrets)
 
 	// removing a nonexistent secrets dir should NOT error
 	if err := removeSecretDir(secretsDir); err != nil {
@@ -117,13 +110,7 @@ func TestLinuxUnprivilegedSecretDir(t *testing.T) {
 		t.Skip("Must not be run as root")
 	}
 
-	tmpdir, err := ioutil.TempDir("", "nomadtest-secretdir")
-	if err != nil {
-		t.Fatalf("unable to create tempdir for test: %s", err)
-	}
-	defer os.RemoveAll(tmpdir)
-
-	secretsDir := filepath.Join(tmpdir, TaskSecrets)
+	secretsDir := filepath.Join(t.TempDir(), TaskSecrets)
 
 	// removing a nonexistent secrets dir should NOT error
 	if err := removeSecretDir(secretsDir); err != nil {

--- a/client/allocdir/task_dir_test.go
+++ b/client/allocdir/task_dir_test.go
@@ -14,11 +14,7 @@ import (
 func TestTaskDir_EmbedNonexistent(t *testing.T) {
 	ci.Parallel(t)
 
-	tmp, err := ioutil.TempDir("", "AllocDir")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	d := NewAllocDir(testlog.HCLogger(t), tmp, "test")
 	defer d.Destroy()
@@ -38,11 +34,7 @@ func TestTaskDir_EmbedNonexistent(t *testing.T) {
 func TestTaskDir_EmbedDirs(t *testing.T) {
 	ci.Parallel(t)
 
-	tmp, err := ioutil.TempDir("", "AllocDir")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	d := NewAllocDir(testlog.HCLogger(t), tmp, "test")
 	defer d.Destroy()
@@ -53,11 +45,7 @@ func TestTaskDir_EmbedDirs(t *testing.T) {
 
 	// Create a fake host directory, with a file, and a subfolder that contains
 	// a file.
-	host, err := ioutil.TempDir("", "AllocDirHost")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(host)
+	host := t.TempDir()
 
 	subDirName := "subdir"
 	subDir := filepath.Join(host, subDirName)
@@ -96,11 +84,7 @@ func TestTaskDir_NonRoot_Image(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("test should be run as non-root user")
 	}
-	tmp, err := ioutil.TempDir("", "AllocDir")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	d := NewAllocDir(testlog.HCLogger(t), tmp, "test")
 	defer d.Destroy()
@@ -121,11 +105,7 @@ func TestTaskDir_NonRoot(t *testing.T) {
 		t.Skip("test should be run as non-root user")
 	}
 
-	tmp, err := ioutil.TempDir("", "AllocDir")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	d := NewAllocDir(testlog.HCLogger(t), tmp, "test")
 	defer d.Destroy()
@@ -139,7 +119,7 @@ func TestTaskDir_NonRoot(t *testing.T) {
 	}
 
 	// ${TASK_DIR}/alloc should not exist!
-	if _, err = os.Stat(td.SharedTaskDir); !os.IsNotExist(err) {
+	if _, err := os.Stat(td.SharedTaskDir); !os.IsNotExist(err) {
 		t.Fatalf("Expected a NotExist error for shared alloc dir in task dir: %q", td.SharedTaskDir)
 	}
 }

--- a/client/allocrunner/consul_grpc_sock_hook_test.go
+++ b/client/allocrunner/consul_grpc_sock_hook_test.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
-	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -156,11 +154,7 @@ func TestConsulGRPCSocketHook_Prerun_Error(t *testing.T) {
 func TestConsulGRPCSocketHook_proxy_Unix(t *testing.T) {
 	ci.Parallel(t)
 
-	dir, err := ioutil.TempDir("", "nomadtest_proxy_Unix")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	// Setup fake listener that would be inside the netns (normally a unix
 	// socket, but it doesn't matter for this test).

--- a/client/allocrunner/taskrunner/artifact_hook_test.go
+++ b/client/allocrunner/taskrunner/artifact_hook_test.go
@@ -85,11 +85,7 @@ func TestTaskRunner_ArtifactHook_PartialDone(t *testing.T) {
 	defer ts.Close()
 
 	// Create the target directory.
-	destdir, err := ioutil.TempDir("", "nomadtest-dest")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(destdir))
-	}()
+	destdir := t.TempDir()
 
 	req := &interfaces.TaskPrestartRequest{
 		TaskEnv: taskenv.NewTaskEnv(nil, nil, nil, nil, destdir, ""),
@@ -112,7 +108,7 @@ func TestTaskRunner_ArtifactHook_PartialDone(t *testing.T) {
 
 	// On first run file1 (foo) should download but file2 (bar) should
 	// fail.
-	err = artifactHook.Prestart(context.Background(), req, &resp)
+	err := artifactHook.Prestart(context.Background(), req, &resp)
 
 	require.NotNil(t, err)
 	require.True(t, structs.IsRecoverable(err))
@@ -179,11 +175,7 @@ func TestTaskRunner_ArtifactHook_ConcurrentDownloadSuccess(t *testing.T) {
 	defer ts.Close()
 
 	// Create the target directory.
-	destdir, err := ioutil.TempDir("", "nomadtest-dest")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(destdir))
-	}()
+	destdir := t.TempDir()
 
 	req := &interfaces.TaskPrestartRequest{
 		TaskEnv: taskenv.NewTaskEnv(nil, nil, nil, nil, destdir, ""),
@@ -225,7 +217,7 @@ func TestTaskRunner_ArtifactHook_ConcurrentDownloadSuccess(t *testing.T) {
 	resp := interfaces.TaskPrestartResponse{}
 
 	// start the hook
-	err = artifactHook.Prestart(context.Background(), req, &resp)
+	err := artifactHook.Prestart(context.Background(), req, &resp)
 
 	require.NoError(t, err)
 	require.True(t, resp.Done)
@@ -273,11 +265,7 @@ func TestTaskRunner_ArtifactHook_ConcurrentDownloadFailure(t *testing.T) {
 	defer ts.Close()
 
 	// Create the target directory.
-	destdir, err := ioutil.TempDir("", "nomadtest-dest")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(destdir))
-	}()
+	destdir := t.TempDir()
 
 	req := &interfaces.TaskPrestartRequest{
 		TaskEnv: taskenv.NewTaskEnv(nil, nil, nil, nil, destdir, ""),
@@ -307,7 +295,7 @@ func TestTaskRunner_ArtifactHook_ConcurrentDownloadFailure(t *testing.T) {
 	resp := interfaces.TaskPrestartResponse{}
 
 	// On first run all files will be downloaded except file0.txt
-	err = artifactHook.Prestart(context.Background(), req, &resp)
+	err := artifactHook.Prestart(context.Background(), req, &resp)
 
 	require.Error(t, err)
 	require.True(t, structs.IsRecoverable(err))

--- a/client/allocrunner/taskrunner/connect_native_hook_test.go
+++ b/client/allocrunner/taskrunner/connect_native_hook_test.go
@@ -3,7 +3,6 @@ package taskrunner
 import (
 	"context"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -42,30 +41,20 @@ func TestConnectNativeHook_Name(t *testing.T) {
 }
 
 func setupCertDirs(t *testing.T) (string, string) {
-	fd, err := ioutil.TempFile("", "connect_native_testcert")
+	fd, err := ioutil.TempFile(t.TempDir(), "connect_native_testcert")
 	require.NoError(t, err)
 	_, err = fd.WriteString("ABCDEF")
 	require.NoError(t, err)
 	err = fd.Close()
 	require.NoError(t, err)
 
-	d, err := ioutil.TempDir("", "connect_native_testsecrets")
-	require.NoError(t, err)
-	return fd.Name(), d
-}
-
-func cleanupCertDirs(t *testing.T, original, secrets string) {
-	err := os.Remove(original)
-	require.NoError(t, err)
-	err = os.RemoveAll(secrets)
-	require.NoError(t, err)
+	return fd.Name(), t.TempDir()
 }
 
 func TestConnectNativeHook_copyCertificate(t *testing.T) {
 	ci.Parallel(t)
 
 	f, d := setupCertDirs(t)
-	defer cleanupCertDirs(t, f, d)
 
 	t.Run("no source", func(t *testing.T) {
 		err := new(connectNativeHook).copyCertificate("", d, "out.pem")
@@ -85,7 +74,6 @@ func TestConnectNativeHook_copyCertificates(t *testing.T) {
 	ci.Parallel(t)
 
 	f, d := setupCertDirs(t)
-	defer cleanupCertDirs(t, f, d)
 
 	t.Run("normal", func(t *testing.T) {
 		err := new(connectNativeHook).copyCertificates(consulTransportConfig{
@@ -450,8 +438,7 @@ func TestTaskRunner_ConnectNativeHook_shareTLS(t *testing.T) {
 	testutil.RequireConsul(t)
 
 	try := func(t *testing.T, shareSSL *bool) {
-		fakeCert, fakeCertDir := setupCertDirs(t)
-		defer cleanupCertDirs(t, fakeCert, fakeCertDir)
+		fakeCert, _ := setupCertDirs(t)
 
 		testConsul := getTestConsul(t)
 		defer testConsul.Stop()
@@ -570,8 +557,7 @@ func TestTaskRunner_ConnectNativeHook_shareTLS_override(t *testing.T) {
 	ci.Parallel(t)
 	testutil.RequireConsul(t)
 
-	fakeCert, fakeCertDir := setupCertDirs(t)
-	defer cleanupCertDirs(t, fakeCert, fakeCertDir)
+	fakeCert, _ := setupCertDirs(t)
 
 	testConsul := getTestConsul(t)
 	defer testConsul.Stop()

--- a/client/allocrunner/taskrunner/envoy_bootstrap_hook_test.go
+++ b/client/allocrunner/taskrunner/envoy_bootstrap_hook_test.go
@@ -43,11 +43,10 @@ const (
 )
 
 func writeTmp(t *testing.T, s string, fm os.FileMode) string {
-	dir, err := ioutil.TempDir("", "envoy-")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	fPath := filepath.Join(dir, sidsTokenFile)
-	err = ioutil.WriteFile(fPath, []byte(s), fm)
+	err := ioutil.WriteFile(fPath, []byte(s), fm)
 	require.NoError(t, err)
 
 	return dir
@@ -73,7 +72,6 @@ func TestEnvoyBootstrapHook_maybeLoadSIToken(t *testing.T) {
 	t.Run("load token from file", func(t *testing.T) {
 		token := uuid.Generate()
 		f := writeTmp(t, token, 0440)
-		defer cleanupDir(t, f)
 
 		h := newEnvoyBootstrapHook(&envoyBootstrapHookConfig{logger: testlog.HCLogger(t)})
 		cfg, err := h.maybeLoadSIToken("task1", f)
@@ -84,7 +82,6 @@ func TestEnvoyBootstrapHook_maybeLoadSIToken(t *testing.T) {
 	t.Run("file is unreadable", func(t *testing.T) {
 		token := uuid.Generate()
 		f := writeTmp(t, token, 0200)
-		defer cleanupDir(t, f)
 
 		h := newEnvoyBootstrapHook(&envoyBootstrapHookConfig{logger: testlog.HCLogger(t)})
 		cfg, err := h.maybeLoadSIToken("task1", f)

--- a/client/allocrunner/taskrunner/getter/getter_test.go
+++ b/client/allocrunner/taskrunner/getter/getter_test.go
@@ -67,10 +67,6 @@ func (u upperReplacer) ClientPath(p string, join bool) (string, bool) {
 	return path, escapes
 }
 
-func removeAllT(t *testing.T, path string) {
-	require.NoError(t, os.RemoveAll(path))
-}
-
 func TestGetArtifact_getHeaders(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		require.Nil(t, getHeaders(noopTaskEnv(""), nil))
@@ -109,9 +105,7 @@ func TestGetArtifact_Headers(t *testing.T) {
 	defer ts.Close()
 
 	// Create a temp directory to download into.
-	taskDir, err := ioutil.TempDir("", "nomad-test")
-	require.NoError(t, err)
-	defer removeAllT(t, taskDir)
+	taskDir := t.TempDir()
 
 	// Create the artifact.
 	artifact := &structs.TaskArtifact{
@@ -127,7 +121,7 @@ func TestGetArtifact_Headers(t *testing.T) {
 	taskEnv := upperReplacer{
 		taskDir: taskDir,
 	}
-	err = GetArtifact(taskEnv, artifact)
+	err := GetArtifact(taskEnv, artifact)
 	require.NoError(t, err)
 
 	// Verify artifact exists.
@@ -145,11 +139,7 @@ func TestGetArtifact_FileAndChecksum(t *testing.T) {
 	defer ts.Close()
 
 	// Create a temp directory to download into
-	taskDir, err := ioutil.TempDir("", "nomad-test")
-	if err != nil {
-		t.Fatalf("failed to make temp directory: %v", err)
-	}
-	defer removeAllT(t, taskDir)
+	taskDir := t.TempDir()
 
 	// Create the artifact
 	file := "test.sh"
@@ -177,11 +167,7 @@ func TestGetArtifact_File_RelativeDest(t *testing.T) {
 	defer ts.Close()
 
 	// Create a temp directory to download into
-	taskDir, err := ioutil.TempDir("", "nomad-test")
-	if err != nil {
-		t.Fatalf("failed to make temp directory: %v", err)
-	}
-	defer removeAllT(t, taskDir)
+	taskDir := t.TempDir()
 
 	// Create the artifact
 	file := "test.sh"
@@ -211,11 +197,7 @@ func TestGetArtifact_File_EscapeDest(t *testing.T) {
 	defer ts.Close()
 
 	// Create a temp directory to download into
-	taskDir, err := ioutil.TempDir("", "nomad-test")
-	if err != nil {
-		t.Fatalf("failed to make temp directory: %v", err)
-	}
-	defer removeAllT(t, taskDir)
+	taskDir := t.TempDir()
 
 	// Create the artifact
 	file := "test.sh"
@@ -229,7 +211,7 @@ func TestGetArtifact_File_EscapeDest(t *testing.T) {
 	}
 
 	// attempt to download the artifact
-	err = GetArtifact(noopTaskEnv(taskDir), artifact)
+	err := GetArtifact(noopTaskEnv(taskDir), artifact)
 	if err == nil || !strings.Contains(err.Error(), "escapes") {
 		t.Fatalf("expected GetArtifact to disallow sandbox escape: %v", err)
 	}
@@ -263,11 +245,7 @@ func TestGetArtifact_InvalidChecksum(t *testing.T) {
 	defer ts.Close()
 
 	// Create a temp directory to download into
-	taskDir, err := ioutil.TempDir("", "nomad-test")
-	if err != nil {
-		t.Fatalf("failed to make temp directory: %v", err)
-	}
-	defer removeAllT(t, taskDir)
+	taskDir := t.TempDir()
 
 	// Create the artifact with an incorrect checksum
 	file := "test.sh"
@@ -324,11 +302,7 @@ func TestGetArtifact_Archive(t *testing.T) {
 
 	// Create a temp directory to download into and create some of the same
 	// files that exist in the artifact to ensure they are overridden
-	taskDir, err := ioutil.TempDir("", "nomad-test")
-	if err != nil {
-		t.Fatalf("failed to make temp directory: %v", err)
-	}
-	defer removeAllT(t, taskDir)
+	taskDir := t.TempDir()
 
 	create := map[string]string{
 		"exist/my.config": "to be replaced",
@@ -365,9 +339,7 @@ func TestGetArtifact_Setuid(t *testing.T) {
 
 	// Create a temp directory to download into and create some of the same
 	// files that exist in the artifact to ensure they are overridden
-	taskDir, err := ioutil.TempDir("", "nomad-test")
-	require.NoError(t, err)
-	defer removeAllT(t, taskDir)
+	taskDir := t.TempDir()
 
 	file := "setuid.tgz"
 	artifact := &structs.TaskArtifact{

--- a/client/allocrunner/taskrunner/logmon_hook_test.go
+++ b/client/allocrunner/taskrunner/logmon_hook_test.go
@@ -3,9 +3,7 @@ package taskrunner
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net"
-	"os"
 	"testing"
 
 	plugin "github.com/hashicorp/go-plugin"
@@ -66,11 +64,7 @@ func TestTaskRunner_LogmonHook_StartStop(t *testing.T) {
 	alloc := mock.BatchAlloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 
-	dir, err := ioutil.TempDir("", "nomadtest")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	hookConf := newLogMonHookConfig(task.Name, dir)
 	runner := &TaskRunner{logmonHookConfig: hookConf}

--- a/client/allocrunner/taskrunner/logmon_hook_unix_test.go
+++ b/client/allocrunner/taskrunner/logmon_hook_unix_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"syscall"
 	"testing"
@@ -31,11 +30,7 @@ func TestTaskRunner_LogmonHook_StartCrashStop(t *testing.T) {
 	alloc := mock.BatchAlloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 
-	dir, err := ioutil.TempDir("", "nomadtest")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	hookConf := newLogMonHookConfig(task.Name, dir)
 	runner := &TaskRunner{logmonHookConfig: hookConf}
@@ -84,7 +79,7 @@ func TestTaskRunner_LogmonHook_StartCrashStop(t *testing.T) {
 		logmonReattachKey: origHookData,
 	}
 	resp = interfaces.TaskPrestartResponse{}
-	err = hook.Prestart(context.Background(), &req, &resp)
+	err := hook.Prestart(context.Background(), &req, &resp)
 	require.NoError(t, err)
 	require.NotEqual(t, origState, resp.State)
 
@@ -100,11 +95,7 @@ func TestTaskRunner_LogmonHook_ShutdownMidStart(t *testing.T) {
 	alloc := mock.BatchAlloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 
-	dir, err := ioutil.TempDir("", "nomadtest")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	hookConf := newLogMonHookConfig(task.Name, dir)
 	runner := &TaskRunner{logmonHookConfig: hookConf}

--- a/client/allocrunner/taskrunner/sids_hook_test.go
+++ b/client/allocrunner/taskrunner/sids_hook_test.go
@@ -29,17 +29,6 @@ import (
 
 var _ interfaces.TaskPrestartHook = (*sidsHook)(nil)
 
-func tmpDir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "sids-")
-	require.NoError(t, err)
-	return dir
-}
-
-func cleanupDir(t *testing.T, dir string) {
-	err := os.RemoveAll(dir)
-	require.NoError(t, err)
-}
-
 func sidecar(task string) (string, structs.TaskKind) {
 	name := structs.ConnectProxyPrefix + "-" + task
 	kind := structs.TaskKind(structs.ConnectProxyPrefix + ":" + task)
@@ -50,8 +39,7 @@ func TestSIDSHook_recoverToken(t *testing.T) {
 	ci.Parallel(t)
 	r := require.New(t)
 
-	secrets := tmpDir(t)
-	defer cleanupDir(t, secrets)
+	secrets := t.TempDir()
 
 	taskName, taskKind := sidecar("foo")
 	h := newSIDSHook(sidsHookConfig{
@@ -75,8 +63,7 @@ func TestSIDSHook_recoverToken_empty(t *testing.T) {
 	ci.Parallel(t)
 	r := require.New(t)
 
-	secrets := tmpDir(t)
-	defer cleanupDir(t, secrets)
+	secrets := t.TempDir()
 
 	taskName, taskKind := sidecar("foo")
 	h := newSIDSHook(sidsHookConfig{
@@ -103,8 +90,7 @@ func TestSIDSHook_recoverToken_unReadable(t *testing.T) {
 
 	r := require.New(t)
 
-	secrets := tmpDir(t)
-	defer cleanupDir(t, secrets)
+	secrets := t.TempDir()
 
 	err := os.Chmod(secrets, 0000)
 	r.NoError(err)
@@ -126,8 +112,7 @@ func TestSIDSHook_writeToken(t *testing.T) {
 	ci.Parallel(t)
 	r := require.New(t)
 
-	secrets := tmpDir(t)
-	defer cleanupDir(t, secrets)
+	secrets := t.TempDir()
 
 	id := uuid.Generate()
 	h := new(sidsHook)
@@ -150,8 +135,7 @@ func TestSIDSHook_writeToken_unWritable(t *testing.T) {
 
 	r := require.New(t)
 
-	secrets := tmpDir(t)
-	defer cleanupDir(t, secrets)
+	secrets := t.TempDir()
 
 	err := os.Chmod(secrets, 0000)
 	r.NoError(err)
@@ -166,8 +150,7 @@ func Test_SIDSHook_writeToken_nonExistent(t *testing.T) {
 	ci.Parallel(t)
 	r := require.New(t)
 
-	base := tmpDir(t)
-	defer cleanupDir(t, base)
+	base := t.TempDir()
 	secrets := filepath.Join(base, "does/not/exist")
 
 	id := uuid.Generate()
@@ -289,8 +272,7 @@ func TestTaskRunner_DeriveSIToken_UnWritableTokenFile(t *testing.T) {
 
 	// make the si_token file un-writable, triggering a failure after a
 	// successful token derivation
-	secrets := tmpDir(t)
-	defer cleanupDir(t, secrets)
+	secrets := t.TempDir()
 	trConfig.TaskDir.SecretsDir = secrets
 	err := ioutil.WriteFile(filepath.Join(secrets, sidsTokenFile), nil, 0400)
 	r.NoError(err)

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -167,14 +167,11 @@ func newTestHarness(t *testing.T, templates []*structs.Template, consul, vault b
 	harness.nomadNamespace = a.Namespace
 
 	// Make a tempdir
-	d, err := ioutil.TempDir("", "ct_test")
-	if err != nil {
-		t.Fatalf("Failed to make tmpdir: %v", err)
-	}
-	harness.taskDir = d
+	harness.taskDir = t.TempDir()
 	harness.envBuilder.SetClientTaskRoot(harness.taskDir)
 
 	if consul {
+		var err error
 		harness.consul, err = ctestutil.NewTestServerConfigT(t, func(c *ctestutil.TestServerConfig) {
 			// defaults
 		})
@@ -1286,14 +1283,10 @@ ANYTHING_goes=Spaces are=ok!
 // template processing function returns errors when files don't exist
 func TestTaskTemplateManager_Env_Missing(t *testing.T) {
 	ci.Parallel(t)
-	d, err := ioutil.TempDir("", "ct_env_missing")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
 	// Fake writing the file so we don't have to run the whole template manager
-	err = ioutil.WriteFile(filepath.Join(d, "exists.env"), []byte("FOO=bar\n"), 0644)
+	err := ioutil.WriteFile(filepath.Join(d, "exists.env"), []byte("FOO=bar\n"), 0644)
 	if err != nil {
 		t.Fatalf("error writing template file: %v", err)
 	}
@@ -1323,14 +1316,10 @@ func TestTaskTemplateManager_Env_InterpolatedDest(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 
-	d, err := ioutil.TempDir("", "ct_env_interpolated")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
 	// Fake writing the file so we don't have to run the whole template manager
-	err = ioutil.WriteFile(filepath.Join(d, "exists.env"), []byte("FOO=bar\n"), 0644)
+	err := ioutil.WriteFile(filepath.Join(d, "exists.env"), []byte("FOO=bar\n"), 0644)
 	if err != nil {
 		t.Fatalf("error writing template file: %v", err)
 	}
@@ -1362,14 +1351,10 @@ func TestTaskTemplateManager_Env_InterpolatedDest(t *testing.T) {
 // templates correctly.
 func TestTaskTemplateManager_Env_Multi(t *testing.T) {
 	ci.Parallel(t)
-	d, err := ioutil.TempDir("", "ct_env_missing")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
 	// Fake writing the files so we don't have to run the whole template manager
-	err = ioutil.WriteFile(filepath.Join(d, "zzz.env"), []byte("FOO=bar\nSHARED=nope\n"), 0644)
+	err := ioutil.WriteFile(filepath.Join(d, "zzz.env"), []byte("FOO=bar\nSHARED=nope\n"), 0644)
 	if err != nil {
 		t.Fatalf("error writing template file 1: %v", err)
 	}

--- a/client/allocwatcher/alloc_watcher_test.go
+++ b/client/allocwatcher/alloc_watcher_test.go
@@ -208,11 +208,7 @@ func TestPrevAlloc_LocalPrevAlloc_Terminated(t *testing.T) {
 func TestPrevAlloc_StreamAllocDir_Error(t *testing.T) {
 	ci.Parallel(t)
 
-	dest, err := ioutil.TempDir("", "nomadtest-")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(dest)
+	dest := t.TempDir()
 
 	// This test only unit tests streamAllocDir so we only need a partially
 	// complete remotePrevAlloc
@@ -232,7 +228,7 @@ func TestPrevAlloc_StreamAllocDir_Error(t *testing.T) {
 		ModTime:  time.Now(),
 		Typeflag: tar.TypeReg,
 	}
-	err = tw.WriteHeader(&fooHdr)
+	err := tw.WriteHeader(&fooHdr)
 	if err != nil {
 		t.Fatalf("error writing file header: %v", err)
 	}

--- a/client/allocwatcher/alloc_watcher_unix_test.go
+++ b/client/allocwatcher/alloc_watcher_unix_test.go
@@ -26,11 +26,7 @@ func TestPrevAlloc_StreamAllocDir_Ok(t *testing.T) {
 	ci.Parallel(t)
 	ctestutil.RequireRoot(t)
 
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create foo/
 	fooDir := filepath.Join(dir, "foo")
@@ -124,11 +120,7 @@ func TestPrevAlloc_StreamAllocDir_Ok(t *testing.T) {
 	}
 	tw.Close()
 
-	dir1, err := ioutil.TempDir("", "nomadtest-")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(dir1)
+	dir1 := t.TempDir()
 
 	rc := ioutil.NopCloser(buf)
 	prevAlloc := &remotePrevAlloc{logger: testlog.HCLogger(t)}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -734,11 +733,7 @@ func TestClient_AddAllocError(t *testing.T) {
 func TestClient_Init(t *testing.T) {
 	ci.Parallel(t)
 
-	dir, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	allocDir := filepath.Join(dir, "alloc")
 
 	config := config.DefaultConfig()

--- a/client/lib/fifo/fifo_test.go
+++ b/client/lib/fifo/fifo_test.go
@@ -3,8 +3,6 @@ package fifo
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -24,11 +22,7 @@ func TestFIFO(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		path = "//./pipe/fifo"
 	} else {
-		dir, err := ioutil.TempDir("", "")
-		require.NoError(err)
-		defer os.RemoveAll(dir)
-
-		path = filepath.Join(dir, "fifo")
+		path = filepath.Join(t.TempDir(), "fifo")
 	}
 
 	readerOpenFn, err := CreateAndRead(path)
@@ -88,11 +82,7 @@ func TestWriteClose(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		path = "//./pipe/" + uuid.Generate()[:4]
 	} else {
-		dir, err := ioutil.TempDir("", "")
-		require.NoError(err)
-		defer os.RemoveAll(dir)
-
-		path = filepath.Join(dir, "fifo")
+		path = filepath.Join(t.TempDir(), "fifo")
 	}
 
 	readerOpenFn, err := CreateAndRead(path)

--- a/client/logmon/logging/rotator_test.go
+++ b/client/logmon/logging/rotator_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 var (
-	pathPrefix   = "logrotator"
 	baseFileName = "redis.stdout"
 )
 
@@ -30,9 +29,7 @@ func TestFileRotator_IncorrectPath(t *testing.T) {
 func TestFileRotator_CreateNewFile(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	path, err := ioutil.TempDir("", pathPrefix)
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	fr, err := NewFileRotator(path, baseFileName, 10, 10, testlog.HCLogger(t))
 	require.NoError(t, err)
@@ -45,9 +42,7 @@ func TestFileRotator_CreateNewFile(t *testing.T) {
 func TestFileRotator_OpenLastFile(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	path, err := ioutil.TempDir("", pathPrefix)
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	fname1 := filepath.Join(path, "redis.stdout.0")
 	fname2 := filepath.Join(path, "redis.stdout.2")
@@ -70,9 +65,7 @@ func TestFileRotator_OpenLastFile(t *testing.T) {
 func TestFileRotator_WriteToCurrentFile(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	path, err := ioutil.TempDir("", pathPrefix)
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	fname1 := filepath.Join(path, "redis.stdout.0")
 	f1, err := os.Create(fname1)
@@ -104,9 +97,7 @@ func TestFileRotator_WriteToCurrentFile(t *testing.T) {
 func TestFileRotator_RotateFiles(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	path, err := ioutil.TempDir("", pathPrefix)
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	fr, err := NewFileRotator(path, baseFileName, 10, 5, testlog.HCLogger(t))
 	require.NoError(t, err)
@@ -149,9 +140,7 @@ func TestFileRotator_RotateFiles(t *testing.T) {
 func TestFileRotator_RotateFiles_Boundary(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	path, err := ioutil.TempDir("", pathPrefix)
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	fr, err := NewFileRotator(path, baseFileName, 10, 5, testlog.HCLogger(t))
 	require.NoError(t, err)
@@ -197,12 +186,10 @@ func TestFileRotator_RotateFiles_Boundary(t *testing.T) {
 func TestFileRotator_WriteRemaining(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	path, err := ioutil.TempDir("", pathPrefix)
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	fname1 := filepath.Join(path, "redis.stdout.0")
-	err = ioutil.WriteFile(fname1, []byte("abcd"), 0600)
+	err := ioutil.WriteFile(fname1, []byte("abcd"), 0600)
 	require.NoError(t, err)
 
 	fr, err := NewFileRotator(path, baseFileName, 10, 5, testlog.HCLogger(t))
@@ -259,9 +246,7 @@ func TestFileRotator_WriteRemaining(t *testing.T) {
 func TestFileRotator_PurgeOldFiles(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	path, err := ioutil.TempDir("", pathPrefix)
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	fr, err := NewFileRotator(path, baseFileName, 2, 2, testlog.HCLogger(t))
 	require.NoError(t, err)
@@ -298,9 +283,7 @@ func BenchmarkRotator(b *testing.B) {
 }
 
 func benchmarkRotatorWithInputSize(size int, b *testing.B) {
-	path, err := ioutil.TempDir("", pathPrefix)
-	require.NoError(b, err)
-	defer os.RemoveAll(path)
+	path := b.TempDir()
 
 	fr, err := NewFileRotator(path, baseFileName, 5, 1024*1024, testlog.HCLogger(b))
 	require.NoError(b, err)

--- a/client/logmon/logmon_test.go
+++ b/client/logmon/logmon_test.go
@@ -23,9 +23,7 @@ func TestLogmon_Start_rotate(t *testing.T) {
 	require := require.New(t)
 	var stdoutFifoPath, stderrFifoPath string
 
-	dir, err := ioutil.TempDir("", "nomadtest")
-	require.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if runtime.GOOS == "windows" {
 		stdoutFifoPath = "//./pipe/test-rotate.stdout"
@@ -89,9 +87,7 @@ func TestLogmon_Start_restart_flusheslogs(t *testing.T) {
 	require := require.New(t)
 	var stdoutFifoPath, stderrFifoPath string
 
-	dir, err := ioutil.TempDir("", "nomadtest")
-	require.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if runtime.GOOS == "windows" {
 		stdoutFifoPath = "//./pipe/test-restart.stdout"
@@ -194,9 +190,7 @@ func TestLogmon_Start_restart(t *testing.T) {
 	require := require.New(t)
 	var stdoutFifoPath, stderrFifoPath string
 
-	dir, err := ioutil.TempDir("", "nomadtest")
-	require.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if runtime.GOOS == "windows" {
 		stdoutFifoPath = "//./pipe/test-restart.stdout"

--- a/client/pluginmanager/csimanager/volume_test.go
+++ b/client/pluginmanager/csimanager/volume_test.go
@@ -3,7 +3,6 @@ package csimanager
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
@@ -17,13 +16,6 @@ import (
 	csifake "github.com/hashicorp/nomad/plugins/csi/fake"
 	"github.com/stretchr/testify/require"
 )
-
-func tmpDir(t testing.TB) string {
-	t.Helper()
-	dir, err := ioutil.TempDir("", "nomad")
-	require.NoError(t, err)
-	return dir
-}
 
 func checkMountSupport() bool {
 	path, err := os.Getwd()
@@ -93,8 +85,7 @@ func TestVolumeManager_ensureStagingDir(t *testing.T) {
 			}
 
 			// Step 2: Test Setup
-			tmpPath := tmpDir(t)
-			defer os.RemoveAll(tmpPath)
+			tmpPath := t.TempDir()
 
 			csiFake := &csifake.Client{}
 			eventer := func(e *structs.NodeEvent) {}
@@ -193,8 +184,7 @@ func TestVolumeManager_stageVolume(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tmpPath := tmpDir(t)
-			defer os.RemoveAll(tmpPath)
+			tmpPath := t.TempDir()
 
 			csiFake := &csifake.Client{}
 			csiFake.NextNodeStageVolumeErr = tc.PluginErr
@@ -252,8 +242,7 @@ func TestVolumeManager_unstageVolume(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tmpPath := tmpDir(t)
-			defer os.RemoveAll(tmpPath)
+			tmpPath := t.TempDir()
 
 			csiFake := &csifake.Client{}
 			csiFake.NextNodeUnstageVolumeErr = tc.PluginErr
@@ -376,8 +365,7 @@ func TestVolumeManager_publishVolume(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tmpPath := tmpDir(t)
-			defer os.RemoveAll(tmpPath)
+			tmpPath := t.TempDir()
 
 			csiFake := &csifake.Client{}
 			csiFake.NextNodePublishVolumeErr = tc.PluginErr
@@ -444,8 +432,7 @@ func TestVolumeManager_unpublishVolume(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			tmpPath := tmpDir(t)
-			defer os.RemoveAll(tmpPath)
+			tmpPath := t.TempDir()
 
 			csiFake := &csifake.Client{}
 			csiFake.NextNodeUnpublishVolumeErr = tc.PluginErr
@@ -474,8 +461,7 @@ func TestVolumeManager_MountVolumeEvents(t *testing.T) {
 	}
 	ci.Parallel(t)
 
-	tmpPath := tmpDir(t)
-	defer os.RemoveAll(tmpPath)
+	tmpPath := t.TempDir()
 
 	csiFake := &csifake.Client{}
 

--- a/client/state/upgrade_int_test.go
+++ b/client/state/upgrade_int_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,9 +71,7 @@ func TestBoltStateDB_UpgradeOld_Ok(t *testing.T) {
 	for _, fn := range pre09files {
 		t.Run(fn, func(t *testing.T) {
 
-			dir, err := ioutil.TempDir("", "nomadtest")
-			require.NoError(t, err)
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			db := dbFromTestFile(t, dir, fn)
 			defer db.Close()
@@ -133,9 +130,7 @@ func TestBoltStateDB_UpgradeOld_Ok(t *testing.T) {
 
 	t.Run("testdata/state-1.2.6.db.gz", func(t *testing.T) {
 		fn := "testdata/state-1.2.6.db.gz"
-		dir, err := ioutil.TempDir("", "nomadtest")
-		require.NoError(t, err)
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		db := dbFromTestFile(t, dir, fn)
 		defer db.Close()

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -19,14 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func tmpDir(t testing.TB) string {
-	dir, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	return dir
-}
-
 func TestAgent_RPC_Ping(t *testing.T) {
 	ci.Parallel(t)
 	agent := NewTestAgent(t, t.Name(), nil)
@@ -916,8 +908,6 @@ func TestServer_Reload_TLS_UpgradeToTLS(t *testing.T) {
 		foocert = "../../helper/tlsutil/testdata/nomad-foo.pem"
 		fookey  = "../../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
 
 	logger := testlog.HCLogger(t)
 
@@ -959,8 +949,6 @@ func TestServer_Reload_TLS_DowngradeFromTLS(t *testing.T) {
 		foocert = "../../helper/tlsutil/testdata/nomad-foo.pem"
 		fookey  = "../../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
 
 	logger := testlog.HCLogger(t)
 
@@ -1002,8 +990,6 @@ func TestServer_ShouldReload_ReturnFalseForNoChanges(t *testing.T) {
 		foocert = "../../helper/tlsutil/testdata/nomad-foo.pem"
 		fookey  = "../../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
 
 	sameAgentConfig := &Config{
 		TLSConfig: &config.TLSConfig{
@@ -1042,8 +1028,6 @@ func TestServer_ShouldReload_ReturnTrueForOnlyHTTPChanges(t *testing.T) {
 		foocert = "../../helper/tlsutil/testdata/nomad-foo.pem"
 		fookey  = "../../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
 
 	sameAgentConfig := &Config{
 		TLSConfig: &config.TLSConfig{
@@ -1082,8 +1066,6 @@ func TestServer_ShouldReload_ReturnTrueForOnlyRPCChanges(t *testing.T) {
 		foocert = "../../helper/tlsutil/testdata/nomad-foo.pem"
 		fookey  = "../../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
 
 	sameAgentConfig := &Config{
 		TLSConfig: &config.TLSConfig{
@@ -1124,8 +1106,6 @@ func TestServer_ShouldReload_ReturnTrueForConfigChanges(t *testing.T) {
 		foocert2 = "../../helper/tlsutil/testdata/nomad-bad.pem"
 		fookey2  = "../../helper/tlsutil/testdata/nomad-bad-key.pem"
 	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
 
 	agent := NewTestAgent(t, t.Name(), func(c *Config) {
 		c.TLSConfig = &config.TLSConfig{
@@ -1180,14 +1160,10 @@ func TestServer_ShouldReload_ReturnTrueForFileChanges(t *testing.T) {
 	`
 
 	content := []byte(oldCertificate)
-	dir, err := ioutil.TempDir("", "certificate")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir) // clean up
+	dir := t.TempDir()
 
 	tmpfn := filepath.Join(dir, "testcert")
-	err = ioutil.WriteFile(tmpfn, content, 0666)
+	err := ioutil.WriteFile(tmpfn, content, 0666)
 	require.Nil(err)
 
 	const (
@@ -1269,8 +1245,6 @@ func TestServer_ShouldReload_ShouldHandleMultipleChanges(t *testing.T) {
 		foocert2 = "../../helper/tlsutil/testdata/nomad-bad.pem"
 		fookey2  = "../../helper/tlsutil/testdata/nomad-bad-key.pem"
 	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
 
 	sameAgentConfig := &Config{
 		TLSConfig: &config.TLSConfig{

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"io/ioutil"
 	"math"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,11 +23,7 @@ func TestCommand_Implements(t *testing.T) {
 
 func TestCommand_Args(t *testing.T) {
 	ci.Parallel(t)
-	tmpDir, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	type tcase struct {
 		args   []string
@@ -99,11 +94,7 @@ func TestCommand_Args(t *testing.T) {
 func TestCommand_MetaConfigValidation(t *testing.T) {
 	ci.Parallel(t)
 
-	tmpDir, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	tcases := []string{
 		"foo..invalid",
@@ -112,7 +103,7 @@ func TestCommand_MetaConfigValidation(t *testing.T) {
 	}
 	for _, tc := range tcases {
 		configFile := filepath.Join(tmpDir, "conf1.hcl")
-		err = ioutil.WriteFile(configFile, []byte(`client{
+		err := ioutil.WriteFile(configFile, []byte(`client{
 			enabled = true
 			meta = {
 				"valid" = "yes"
@@ -154,11 +145,7 @@ func TestCommand_MetaConfigValidation(t *testing.T) {
 func TestCommand_NullCharInDatacenter(t *testing.T) {
 	ci.Parallel(t)
 
-	tmpDir, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	tcases := []string{
 		"char-\\000-in-the-middle",
@@ -167,7 +154,7 @@ func TestCommand_NullCharInDatacenter(t *testing.T) {
 	}
 	for _, tc := range tcases {
 		configFile := filepath.Join(tmpDir, "conf1.hcl")
-		err = ioutil.WriteFile(configFile, []byte(`
+		err := ioutil.WriteFile(configFile, []byte(`
         datacenter = "`+tc+`"
         client{
 			enabled = true
@@ -205,11 +192,7 @@ func TestCommand_NullCharInDatacenter(t *testing.T) {
 func TestCommand_NullCharInRegion(t *testing.T) {
 	ci.Parallel(t)
 
-	tmpDir, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	tcases := []string{
 		"char-\\000-in-the-middle",
@@ -218,7 +201,7 @@ func TestCommand_NullCharInRegion(t *testing.T) {
 	}
 	for _, tc := range tcases {
 		configFile := filepath.Join(tmpDir, "conf1.hcl")
-		err = ioutil.WriteFile(configFile, []byte(`
+		err := ioutil.WriteFile(configFile, []byte(`
         region = "`+tc+`"
         client{
 			enabled = true

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -491,11 +491,7 @@ func TestConfig_LoadConfigDir(t *testing.T) {
 		t.Fatalf("expected error, got nothing")
 	}
 
-	dir, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Returns empty config on empty dir
 	config, err := LoadConfig(dir)
@@ -576,11 +572,7 @@ func TestConfig_LoadConfig(t *testing.T) {
 			expectedConfigFiles, config.Files)
 	}
 
-	dir, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	file1 := filepath.Join(dir, "config1.hcl")
 	err = ioutil.WriteFile(file1, []byte(`{"datacenter":"sfo"}`), 0600)
@@ -1337,12 +1329,10 @@ func TestTelemetry_Parse(t *testing.T) {
 	ci.Parallel(t)
 
 	require := require.New(t)
-	dir, err := ioutil.TempDir("", "nomad")
-	require.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	file1 := filepath.Join(dir, "config1.hcl")
-	err = ioutil.WriteFile(file1, []byte(`telemetry{
+	err := ioutil.WriteFile(file1, []byte(`telemetry{
 		prefix_filter = ["+nomad.raft"]
 		filter_default = false
 		disable_dispatched_job_summary_metrics = true

--- a/command/agent/consul/int_test.go
+++ b/command/agent/consul/int_test.go
@@ -3,7 +3,6 @@ package consul_test
 import (
 	"context"
 	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -66,16 +65,8 @@ func TestConsul_Integration(t *testing.T) {
 		t.Fatalf("error generating consul config: %v", err)
 	}
 
-	conf.StateDir, err = ioutil.TempDir("", "nomadtest-consulstate")
-	if err != nil {
-		t.Fatalf("error creating temp dir: %v", err)
-	}
-	defer os.RemoveAll(conf.StateDir)
-	conf.AllocDir, err = ioutil.TempDir("", "nomdtest-consulalloc")
-	if err != nil {
-		t.Fatalf("error creating temp dir: %v", err)
-	}
-	defer os.RemoveAll(conf.AllocDir)
+	conf.StateDir = t.TempDir()
+	conf.AllocDir = t.TempDir()
 
 	alloc := mock.Alloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]

--- a/command/agent/keyring_test.go
+++ b/command/agent/keyring_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -53,11 +52,7 @@ func TestAgent_InitKeyring(t *testing.T) {
 	key2 := "4leC33rgtXKIVUr9Nr0snQ=="
 	expected := fmt.Sprintf(`["%s"]`, key1)
 
-	dir, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	file := filepath.Join(dir, "keyring")
 

--- a/command/agent/log_file_test.go
+++ b/command/agent/log_file_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -20,12 +19,8 @@ const (
 
 func TestLogFile_timeRotation(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 
-	tempDir, err := ioutil.TempDir("", "LogWriterTimeTest")
-	require.NoError(err)
-
-	defer os.Remove(tempDir)
+	tempDir := t.TempDir()
 
 	filt := LevelFilter()
 	logFile := logFile{
@@ -47,9 +42,7 @@ func TestLogFile_openNew(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 
-	tempDir, err := ioutil.TempDir("", "LogWriterOpenTest")
-	require.NoError(err)
-	defer os.Remove(tempDir)
+	tempDir := t.TempDir()
 
 	filt := LevelFilter()
 	filt.MinLevel = logutils.LogLevel("INFO")
@@ -62,7 +55,7 @@ func TestLogFile_openNew(t *testing.T) {
 	}
 	require.NoError(logFile.openNew())
 
-	_, err = ioutil.ReadFile(logFile.FileInfo.Name())
+	_, err := ioutil.ReadFile(logFile.FileInfo.Name())
 	require.NoError(err)
 
 	require.Equal(logFile.FileInfo.Name(), filepath.Join(tempDir, testFileName))
@@ -84,9 +77,7 @@ func TestLogFile_byteRotation(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 
-	tempDir, err := ioutil.TempDir("", "LogWriterByteTest")
-	require.NoError(err)
-	defer os.Remove(tempDir)
+	tempDir := t.TempDir()
 
 	filt := LevelFilter()
 	filt.MinLevel = logutils.LogLevel("INFO")
@@ -108,9 +99,7 @@ func TestLogFile_logLevelFiltering(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 
-	tempDir, err := ioutil.TempDir("", "LogWriterFilterTest")
-	require.NoError(err)
-	defer os.Remove(tempDir)
+	tempDir := t.TempDir()
 	filt := LevelFilter()
 	logFile := logFile{
 		logFilter: filt,
@@ -131,9 +120,7 @@ func TestLogFile_deleteArchives(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 
-	tempDir, err := ioutil.TempDir("", "LogWriterDeleteArchivesTest")
-	require.NoError(err)
-	defer os.Remove(tempDir)
+	tempDir := t.TempDir()
 
 	filt := LevelFilter()
 	filt.MinLevel = logutils.LogLevel("INFO")
@@ -171,9 +158,7 @@ func TestLogFile_deleteArchivesDisabled(t *testing.T) {
 	ci.Parallel(t)
 
 	require := require.New(t)
-	tempDir, err := ioutil.TempDir("", "LogWriterDeleteArchivesDisabledTest")
-	require.NoError(err)
-	defer os.Remove(tempDir)
+	tempDir := t.TempDir()
 
 	filt := LevelFilter()
 	filt.MinLevel = logutils.LogLevel("INFO")

--- a/command/agent/operator_endpoint_test.go
+++ b/command/agent/operator_endpoint_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -411,9 +410,7 @@ func TestOperator_SchedulerCASConfiguration(t *testing.T) {
 func TestOperator_SnapshotRequests(t *testing.T) {
 	ci.Parallel(t)
 
-	dir, err := ioutil.TempDir("", "nomadtest-operator-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	snapshotPath := filepath.Join(dir, "snapshot.bin")
 	job := mock.Job()

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -2,8 +2,6 @@ package command
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -387,11 +385,7 @@ func TestAllocStatusCommand_HostVolumes(t *testing.T) {
 	ci.Parallel(t)
 	// We have to create a tempdir for the host volume even though we're
 	// not going to use it b/c the server validates the config on startup
-	tmpDir, err := ioutil.TempDir("", "vol0")
-	if err != nil {
-		t.Fatalf("unable to create tempdir for test: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	vol0 := uuid.Generate()
 	srv, _, url := testServer(t, true, func(c *agent.Config) {

--- a/command/config_validate_test.go
+++ b/command/config_validate_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -12,11 +11,7 @@ import (
 
 func TestConfigValidateCommand_FailWithEmptyDir(t *testing.T) {
 	ci.Parallel(t)
-	fh, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Remove(fh)
+	fh := t.TempDir()
 
 	ui := cli.NewMockUi()
 	cmd := &ConfigValidateCommand{Meta: Meta{Ui: ui}}
@@ -30,14 +25,10 @@ func TestConfigValidateCommand_FailWithEmptyDir(t *testing.T) {
 
 func TestConfigValidateCommand_SucceedWithMinimalConfigFile(t *testing.T) {
 	ci.Parallel(t)
-	fh, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Remove(fh)
+	fh := t.TempDir()
 
 	fp := filepath.Join(fh, "config.hcl")
-	err = ioutil.WriteFile(fp, []byte(`data_dir="/"
+	err := ioutil.WriteFile(fp, []byte(`data_dir="/"
 	client {
 		enabled = true
 	}`), 0644)
@@ -57,14 +48,10 @@ func TestConfigValidateCommand_SucceedWithMinimalConfigFile(t *testing.T) {
 
 func TestConfigValidateCommand_FailOnParseBadConfigFile(t *testing.T) {
 	ci.Parallel(t)
-	fh, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Remove(fh)
+	fh := t.TempDir()
 
 	fp := filepath.Join(fh, "config.hcl")
-	err = ioutil.WriteFile(fp, []byte(`a: b`), 0644)
+	err := ioutil.WriteFile(fp, []byte(`a: b`), 0644)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -81,14 +68,10 @@ func TestConfigValidateCommand_FailOnParseBadConfigFile(t *testing.T) {
 
 func TestConfigValidateCommand_FailOnValidateParsableConfigFile(t *testing.T) {
 	ci.Parallel(t)
-	fh, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Remove(fh)
+	fh := t.TempDir()
 
 	fp := filepath.Join(fh, "config.hcl")
-	err = ioutil.WriteFile(fp, []byte(`data_dir="../"
+	err := ioutil.WriteFile(fp, []byte(`data_dir="../"
 	client {
 		enabled = true
 	}`), 0644)

--- a/command/integration_test.go
+++ b/command/integration_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -17,11 +15,7 @@ import (
 
 func TestIntegration_Command_NomadInit(t *testing.T) {
 	ci.Parallel(t)
-	tmpDir, err := ioutil.TempDir("", "nomadtest-rootsecretdir")
-	if err != nil {
-		t.Fatalf("unable to create tempdir for test: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	{
 		cmd := exec.Command("nomad", "job", "init")
@@ -44,9 +38,7 @@ func TestIntegration_Command_NomadInit(t *testing.T) {
 func TestIntegration_Command_RoundTripJob(t *testing.T) {
 	ci.Parallel(t)
 	assert := assert.New(t)
-	tmpDir, err := ioutil.TempDir("", "nomadtest-rootsecretdir")
-	assert.Nil(err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Start in dev mode so we get a node registration
 	srv, client, url := testServer(t, true, nil)

--- a/command/job_init_test.go
+++ b/command/job_init_test.go
@@ -38,11 +38,7 @@ func TestInitCommand_Run(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Create a temp dir and change into it
-	dir, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	if err := os.Chdir(dir); err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -104,11 +100,7 @@ func TestInitCommand_customFilename(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Create a temp dir and change into it
-	dir, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	if err := os.Chdir(dir); err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/operator_snapshot_inspect_test.go
+++ b/command/operator_snapshot_inspect_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -39,11 +38,9 @@ func TestOperatorSnapshotInspect_Works(t *testing.T) {
 func TestOperatorSnapshotInspect_HandlesFailure(t *testing.T) {
 	ci.Parallel(t)
 
-	tmpDir, err := ioutil.TempDir("", "nomad-clitests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
-	err = ioutil.WriteFile(
+	err := ioutil.WriteFile(
 		filepath.Join(tmpDir, "invalid.snap"),
 		[]byte("invalid data"),
 		0600)
@@ -69,10 +66,7 @@ func TestOperatorSnapshotInspect_HandlesFailure(t *testing.T) {
 }
 
 func generateSnapshotFile(t *testing.T, prepare func(srv *agent.TestAgent, client *api.Client, url string)) string {
-	tmpDir, err := ioutil.TempDir("", "nomad-tempdir")
-	require.NoError(t, err)
-
-	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	tmpDir := t.TempDir()
 
 	srv, api, url := testServer(t, false, func(c *agent.Config) {
 		c.DevMode = false

--- a/command/operator_snapshot_restore_test.go
+++ b/command/operator_snapshot_restore_test.go
@@ -1,8 +1,6 @@
 package command
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -18,9 +16,7 @@ import (
 func TestOperatorSnapshotRestore_Works(t *testing.T) {
 	ci.Parallel(t)
 
-	tmpDir, err := ioutil.TempDir("", "nomad-tempdir")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	snapshotPath := generateSnapshotFile(t, func(srv *agent.TestAgent, client *api.Client, url string) {
 		sampleJob := `

--- a/command/operator_snapshot_save_test.go
+++ b/command/operator_snapshot_save_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,10 +15,7 @@ import (
 func TestOperatorSnapshotSave_Works(t *testing.T) {
 	ci.Parallel(t)
 
-	tmpDir, err := ioutil.TempDir("", "nomad-tempdir")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	srv, _, url := testServer(t, false, func(c *agent.Config) {
 		c.DevMode = false

--- a/command/quota_init_test.go
+++ b/command/quota_init_test.go
@@ -32,9 +32,7 @@ func TestQuotaInitCommand_Run_HCL(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Create a temp dir and change into it
-	dir, err := ioutil.TempDir("", "nomad")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	err = os.Chdir(dir)
 	require.NoError(t, err)
@@ -81,9 +79,7 @@ func TestQuotaInitCommand_Run_JSON(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	// Create a temp dir and change into it
-	dir, err := ioutil.TempDir("", "nomad")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	err = os.Chdir(dir)
 	require.NoError(t, err)

--- a/drivers/docker/driver_linux_test.go
+++ b/drivers/docker/driver_linux_test.go
@@ -22,14 +22,12 @@ import (
 func TestDockerDriver_authFromHelper(t *testing.T) {
 	ci.Parallel(t)
 
-	dir, err := ioutil.TempDir("", "test-docker-driver_authfromhelper")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	helperPayload := "{\"Username\":\"hashi\",\"Secret\":\"nomad\"}"
 	helperContent := []byte(fmt.Sprintf("#!/bin/sh\ncat > %s/helper-$1.out;echo '%s'", dir, helperPayload))
 
 	helperFile := filepath.Join(dir, "docker-credential-testnomad")
-	err = ioutil.WriteFile(helperFile, helperContent, 0777)
+	err := ioutil.WriteFile(helperFile, helperContent, 0777)
 	require.NoError(t, err)
 
 	path := os.Getenv("PATH")

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -2113,15 +2113,12 @@ func TestDockerDriver_VolumesDisabled(t *testing.T) {
 	}
 
 	{
-		tmpvol, err := ioutil.TempDir("", "nomadtest_docker_volumesdisabled")
-		if err != nil {
-			t.Fatalf("error creating temporary dir: %v", err)
-		}
+		tmpvol := t.TempDir()
 
 		task, driver, _, _, cleanup := setupDockerVolumes(t, cfg, tmpvol)
 		defer cleanup()
 
-		_, _, err = driver.StartTask(task)
+		_, _, err := driver.StartTask(task)
 		defer driver.DestroyTask(task.ID, true)
 		if err == nil {
 			require.Fail(t, "Started driver successfully when volumes should have been disabled.")
@@ -2182,11 +2179,10 @@ func TestDockerDriver_VolumesEnabled(t *testing.T) {
 		},
 	}
 
-	tmpvol, err := ioutil.TempDir("", "nomadtest_docker_volumesenabled")
-	require.NoError(t, err)
+	tmpvol := t.TempDir()
 
 	// Evaluate symlinks so it works on MacOS
-	tmpvol, err = filepath.EvalSymlinks(tmpvol)
+	tmpvol, err := filepath.EvalSymlinks(tmpvol)
 	require.NoError(t, err)
 
 	task, driver, _, hostpath, cleanup := setupDockerVolumes(t, cfg, tmpvol)

--- a/drivers/exec/driver_test.go
+++ b/drivers/exec/driver_test.go
@@ -622,11 +622,9 @@ func TestExecDriver_DevicesAndMounts(t *testing.T) {
 	ci.Parallel(t)
 	ctestutils.ExecCompatible(t)
 
-	tmpDir, err := ioutil.TempDir("", "exec_binds_mounts")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(tmpDir, "testfile"), []byte("from-host"), 600)
+	err := ioutil.WriteFile(filepath.Join(tmpDir, "testfile"), []byte("from-host"), 600)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -417,9 +417,7 @@ func TestUniversalExecutor_LookupTaskBin(t *testing.T) {
 	require := require.New(t)
 
 	// Create a temp dir
-	tmpDir, err := ioutil.TempDir("", "")
-	require.Nil(err)
-	defer os.Remove(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Create the command
 	cmd := &ExecCommand{Env: []string{"PATH=/bin"}, TaskDir: tmpDir}
@@ -429,7 +427,7 @@ func TestUniversalExecutor_LookupTaskBin(t *testing.T) {
 
 	// Write a file under foo
 	filePath := filepath.Join(tmpDir, "foo", "tmp.txt")
-	err = ioutil.WriteFile(filePath, []byte{1, 2}, os.ModeAppend)
+	err := ioutil.WriteFile(filePath, []byte{1, 2}, os.ModeAppend)
 	require.NoError(err)
 
 	// Lookout with an absolute path to the binary

--- a/drivers/shared/executor/executor_test.go
+++ b/drivers/shared/executor/executor_test.go
@@ -415,16 +415,14 @@ func TestUniversalExecutor_LookupPath(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 	// Create a temp dir
-	tmpDir, err := ioutil.TempDir("", "")
-	require.Nil(err)
-	defer os.Remove(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Make a foo subdir
 	os.MkdirAll(filepath.Join(tmpDir, "foo"), 0700)
 
 	// Write a file under foo
 	filePath := filepath.Join(tmpDir, "foo", "tmp.txt")
-	err = ioutil.WriteFile(filePath, []byte{1, 2}, os.ModeAppend)
+	err := ioutil.WriteFile(filePath, []byte{1, 2}, os.ModeAppend)
 	require.Nil(err)
 
 	// Lookup with full path on host to binary
@@ -606,9 +604,7 @@ func TestExecutor_Start_NonExecutableBinaries(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
 
-			tmpDir, err := ioutil.TempDir("", "nomad-executor-tests")
-			require.NoError(err)
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			nonExecutablePath := filepath.Join(tmpDir, "nonexecutablefile")
 			ioutil.WriteFile(nonExecutablePath,

--- a/drivers/shared/hostnames/mount_unix_test.go
+++ b/drivers/shared/hostnames/mount_unix_test.go
@@ -4,9 +4,7 @@
 package hostnames
 
 import (
-	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -92,10 +90,7 @@ func TestGenerateEtcHostsMount(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
-			taskDir, err := ioutil.TempDir("",
-				fmt.Sprintf("generateEtcHosts_Test-%s", tc.name))
-			defer os.RemoveAll(taskDir)
-			require.NoError(err)
+			taskDir := t.TempDir()
 			dest := filepath.Join(taskDir, "hosts")
 
 			got, err := GenerateEtcHostsMount(taskDir, tc.spec, tc.extraHosts)

--- a/drivers/shared/resolvconf/mount_unix_test.go
+++ b/drivers/shared/resolvconf/mount_unix_test.go
@@ -5,7 +5,6 @@ package resolvconf
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -18,10 +17,7 @@ func Test_copySystemDNS(t *testing.T) {
 	data, err := ioutil.ReadFile(dresolvconf.Path())
 	require.NoError(err)
 
-	tmp, err := ioutil.TempDir("", "copySystemDNS_Test")
-	require.NoError(err)
-	defer os.RemoveAll(tmp)
-	dest := filepath.Join(tmp, "resolv.conf")
+	dest := filepath.Join(t.TempDir(), "resolv.conf")
 
 	require.NoError(copySystemDNS(dest))
 	require.FileExists(dest)

--- a/helper/boltdd/boltdd_test.go
+++ b/helper/boltdd/boltdd_test.go
@@ -3,8 +3,6 @@ package boltdd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -16,42 +14,27 @@ import (
 	"go.etcd.io/bbolt"
 )
 
-type testingT interface {
-	Fatalf(format string, args ...interface{})
-	Logf(format string, args ...interface{})
-}
-
-func setupBoltDB(t testingT) (*DB, func()) {
-	dir, err := ioutil.TempDir("", "nomadtest_")
-	if err != nil {
-		t.Fatalf("error creating tempdir: %v", err)
-	}
-
-	cleanup := func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Logf("error removing test dir: %v", err)
-		}
-	}
+func setupBoltDB(t testing.TB) *DB {
+	dir := t.TempDir()
 
 	dbFilename := filepath.Join(dir, "nomadtest.db")
 	db, err := Open(dbFilename, 0600, nil)
 	if err != nil {
-		cleanup()
 		t.Fatalf("error creating boltdb: %v", err)
 	}
 
-	return db, func() {
+	t.Cleanup(func() {
 		db.Close()
-		cleanup()
-	}
+	})
+
+	return db
 }
 
 func TestDB_Open(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 
-	db, cleanup := setupBoltDB(t)
-	defer cleanup()
+	db := setupBoltDB(t)
 
 	require.Equal(0, db.BoltDB().Stats().TxStats.Write)
 }
@@ -59,8 +42,7 @@ func TestDB_Open(t *testing.T) {
 func TestDB_Close(t *testing.T) {
 	ci.Parallel(t)
 
-	db, cleanup := setupBoltDB(t)
-	defer cleanup()
+	db := setupBoltDB(t)
 
 	db.Close()
 
@@ -79,8 +61,7 @@ func TestBucket_Create(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 
-	db, cleanup := setupBoltDB(t)
-	defer cleanup()
+	db := setupBoltDB(t)
 
 	name := []byte("create_test")
 
@@ -116,8 +97,7 @@ func TestBucket_DedupeWrites(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 
-	db, cleanup := setupBoltDB(t)
-	defer cleanup()
+	db := setupBoltDB(t)
 
 	bname := []byte("dedupewrites_test")
 	k1name := []byte("k1")
@@ -170,8 +150,7 @@ func TestBucket_Delete(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 
-	db, cleanup := setupBoltDB(t)
-	defer cleanup()
+	db := setupBoltDB(t)
 
 	parentName := []byte("delete_test")
 	parentKey := []byte("parent_key")
@@ -275,8 +254,7 @@ func TestBucket_Delete(t *testing.T) {
 }
 
 func BenchmarkWriteDeduplication_On(b *testing.B) {
-	db, cleanup := setupBoltDB(b)
-	defer cleanup()
+	db := setupBoltDB(b)
 
 	bucketName := []byte("allocations")
 	alloc := mock.Alloc()
@@ -308,16 +286,7 @@ func BenchmarkWriteDeduplication_On(b *testing.B) {
 }
 
 func BenchmarkWriteDeduplication_Off(b *testing.B) {
-	dir, err := ioutil.TempDir("", "nomadtest_")
-	if err != nil {
-		b.Fatalf("error creating tempdir: %v", err)
-	}
-
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			b.Logf("error removing test dir: %v", err)
-		}
-	}()
+	dir := b.TempDir()
 
 	dbFilename := filepath.Join(dir, "nomadtest.db")
 	db, err := Open(dbFilename, 0600, nil)

--- a/helper/escapingfs/escapes_test.go
+++ b/helper/escapingfs/escapes_test.go
@@ -9,17 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setup(t *testing.T) string {
-	p, err := ioutil.TempDir("", "escapist")
-	require.NoError(t, err)
-	return p
-}
-
-func cleanup(t *testing.T, root string) {
-	err := os.RemoveAll(root)
-	require.NoError(t, err)
-}
-
 func write(t *testing.T, file, data string) {
 	err := ioutil.WriteFile(file, []byte(data), 0600)
 	require.NoError(t, err)
@@ -58,8 +47,7 @@ func Test_PathEscapesAllocViaRelative(t *testing.T) {
 
 func Test_pathEscapesBaseViaSymlink(t *testing.T) {
 	t.Run("symlink-escape", func(t *testing.T) {
-		dir := setup(t)
-		defer cleanup(t, dir)
+		dir := t.TempDir()
 
 		// link from dir/link
 		link := filepath.Join(dir, "link")
@@ -75,8 +63,7 @@ func Test_pathEscapesBaseViaSymlink(t *testing.T) {
 	})
 
 	t.Run("symlink-noescape", func(t *testing.T) {
-		dir := setup(t)
-		defer cleanup(t, dir)
+		dir := t.TempDir()
 
 		// create a file within dir
 		target := filepath.Join(dir, "foo")
@@ -97,8 +84,7 @@ func Test_pathEscapesBaseViaSymlink(t *testing.T) {
 func Test_PathEscapesAllocDir(t *testing.T) {
 
 	t.Run("no-escape-root", func(t *testing.T) {
-		dir := setup(t)
-		defer cleanup(t, dir)
+		dir := t.TempDir()
 
 		escape, err := PathEscapesAllocDir(dir, "", "/")
 		require.NoError(t, err)
@@ -106,8 +92,7 @@ func Test_PathEscapesAllocDir(t *testing.T) {
 	})
 
 	t.Run("no-escape", func(t *testing.T) {
-		dir := setup(t)
-		defer cleanup(t, dir)
+		dir := t.TempDir()
 
 		write(t, filepath.Join(dir, "foo"), "hi")
 
@@ -117,8 +102,7 @@ func Test_PathEscapesAllocDir(t *testing.T) {
 	})
 
 	t.Run("no-escape-no-exist", func(t *testing.T) {
-		dir := setup(t)
-		defer cleanup(t, dir)
+		dir := t.TempDir()
 
 		escape, err := PathEscapesAllocDir(dir, "", "/no-exist")
 		require.NoError(t, err)
@@ -126,8 +110,7 @@ func Test_PathEscapesAllocDir(t *testing.T) {
 	})
 
 	t.Run("symlink-escape", func(t *testing.T) {
-		dir := setup(t)
-		defer cleanup(t, dir)
+		dir := t.TempDir()
 
 		// link from dir/link
 		link := filepath.Join(dir, "link")
@@ -143,8 +126,7 @@ func Test_PathEscapesAllocDir(t *testing.T) {
 	})
 
 	t.Run("relative-escape", func(t *testing.T) {
-		dir := setup(t)
-		defer cleanup(t, dir)
+		dir := t.TempDir()
 
 		escape, err := PathEscapesAllocDir(dir, "", "../../foo")
 		require.NoError(t, err)
@@ -152,8 +134,7 @@ func Test_PathEscapesAllocDir(t *testing.T) {
 	})
 
 	t.Run("relative-escape-prefix", func(t *testing.T) {
-		dir := setup(t)
-		defer cleanup(t, dir)
+		dir := t.TempDir()
 
 		escape, err := PathEscapesAllocDir(dir, "/foo/bar", "../../../foo")
 		require.NoError(t, err)

--- a/helper/pluginutils/loader/loader_test.go
+++ b/helper/pluginutils/loader/loader_test.go
@@ -45,11 +45,7 @@ func newHarness(t *testing.T, plugins []string) *harness {
 	}
 
 	// Build a temp directory
-	path, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatalf("failed to build tmp directory")
-	}
-	h.tmpDir = path
+	h.tmpDir = t.TempDir()
 
 	// Get our own executable path
 	selfExe, err := os.Executable()
@@ -100,13 +96,6 @@ func (h *harness) pluginDir() string {
 	return h.tmpDir
 }
 
-// cleanup removes the temp directory
-func (h *harness) cleanup() {
-	if err := os.RemoveAll(h.tmpDir); err != nil {
-		h.t.Fatalf("failed to remove tmp directory %q: %v", h.tmpDir, err)
-	}
-}
-
 func TestPluginLoader_External(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
@@ -115,7 +104,6 @@ func TestPluginLoader_External(t *testing.T) {
 	plugins := []string{"mock-device", "mock-device-2"}
 	pluginVersions := []string{"v0.0.1", "v0.0.2"}
 	h := newHarness(t, plugins)
-	defer h.cleanup()
 
 	logger := testlog.HCLogger(t)
 	logger.SetLevel(log.Trace)
@@ -175,7 +163,6 @@ func TestPluginLoader_External_ApiVersions(t *testing.T) {
 	plugins := []string{"mock-device", "mock-device-2", "mock-device-3"}
 	pluginVersions := []string{"v0.0.1", "v0.0.2"}
 	h := newHarness(t, plugins)
-	defer h.cleanup()
 
 	logger := testlog.HCLogger(t)
 	logger.SetLevel(log.Trace)
@@ -279,7 +266,6 @@ func TestPluginLoader_External_NoApiVersion(t *testing.T) {
 	plugins := []string{"mock-device"}
 	pluginVersions := []string{"v0.0.1", "v0.0.2"}
 	h := newHarness(t, plugins)
-	defer h.cleanup()
 
 	logger := testlog.HCLogger(t)
 	logger.SetLevel(log.Trace)
@@ -309,7 +295,6 @@ func TestPluginLoader_External_Config(t *testing.T) {
 	plugins := []string{"mock-device", "mock-device-2"}
 	pluginVersions := []string{"v0.0.1", "v0.0.2"}
 	h := newHarness(t, plugins)
-	defer h.cleanup()
 
 	logger := testlog.HCLogger(t)
 	logger.SetLevel(log.Trace)
@@ -376,7 +361,6 @@ func TestPluginLoader_External_Config_Bad(t *testing.T) {
 	plugins := []string{"mock-device"}
 	pluginVersions := []string{"v0.0.1"}
 	h := newHarness(t, plugins)
-	defer h.cleanup()
 
 	logger := testlog.HCLogger(t)
 	logger.SetLevel(log.Trace)
@@ -411,7 +395,6 @@ func TestPluginLoader_External_VersionOverlap(t *testing.T) {
 	plugins := []string{"mock-device", "mock-device-2"}
 	pluginVersions := []string{"v0.0.1", "v0.0.2"}
 	h := newHarness(t, plugins)
-	defer h.cleanup()
 
 	logger := testlog.HCLogger(t)
 	logger.SetLevel(log.Trace)
@@ -461,7 +444,6 @@ func TestPluginLoader_Internal(t *testing.T) {
 
 	// Create the harness
 	h := newHarness(t, nil)
-	defer h.cleanup()
 
 	plugins := []string{"mock-device", "mock-device-2"}
 	pluginVersions := []string{"v0.0.1", "v0.0.2"}
@@ -525,7 +507,6 @@ func TestPluginLoader_Internal_ApiVersions(t *testing.T) {
 	plugins := []string{"mock-device", "mock-device-2", "mock-device-3"}
 	pluginVersions := []string{"v0.0.1", "v0.0.2"}
 	h := newHarness(t, nil)
-	defer h.cleanup()
 
 	logger := testlog.HCLogger(t)
 	logger.SetLevel(log.Trace)
@@ -607,7 +588,6 @@ func TestPluginLoader_Internal_NoApiVersion(t *testing.T) {
 	plugins := []string{"mock-device"}
 	pluginVersions := []string{"v0.0.1", "v0.0.2"}
 	h := newHarness(t, nil)
-	defer h.cleanup()
 
 	logger := testlog.HCLogger(t)
 	logger.SetLevel(log.Trace)
@@ -636,7 +616,6 @@ func TestPluginLoader_Internal_Config(t *testing.T) {
 
 	// Create the harness
 	h := newHarness(t, nil)
-	defer h.cleanup()
 
 	plugins := []string{"mock-device", "mock-device-2"}
 	pluginVersions := []string{"v0.0.1", "v0.0.2"}
@@ -707,7 +686,6 @@ func TestPluginLoader_Internal_ExternalConfig(t *testing.T) {
 
 	// Create the harness
 	h := newHarness(t, nil)
-	defer h.cleanup()
 
 	plugin := "mock-device"
 	pluginVersion := "v0.0.1"
@@ -778,7 +756,6 @@ func TestPluginLoader_Internal_Config_Bad(t *testing.T) {
 
 	// Create the harness
 	h := newHarness(t, nil)
-	defer h.cleanup()
 
 	plugins := []string{"mock-device"}
 	pluginVersions := []string{"v0.0.1"}
@@ -820,7 +797,6 @@ func TestPluginLoader_InternalOverrideExternal(t *testing.T) {
 	pluginApiVersions := []string{device.ApiVersion010}
 
 	h := newHarness(t, plugins)
-	defer h.cleanup()
 
 	logger := testlog.HCLogger(t)
 	logger.SetLevel(log.Trace)
@@ -877,7 +853,6 @@ func TestPluginLoader_ExternalOverrideInternal(t *testing.T) {
 	pluginApiVersions := []string{device.ApiVersion010}
 
 	h := newHarness(t, plugins)
-	defer h.cleanup()
 
 	logger := testlog.HCLogger(t)
 	logger.SetLevel(log.Trace)
@@ -932,7 +907,6 @@ func TestPluginLoader_Dispense_External(t *testing.T) {
 	plugin := "mock-device"
 	pluginVersion := "v0.0.1"
 	h := newHarness(t, []string{plugin})
-	defer h.cleanup()
 
 	expKey := "set_config_worked"
 
@@ -980,7 +954,6 @@ func TestPluginLoader_Dispense_Internal(t *testing.T) {
 	pluginVersion := "v0.0.1"
 	pluginApiVersions := []string{device.ApiVersion010}
 	h := newHarness(t, nil)
-	defer h.cleanup()
 
 	expKey := "set_config_worked"
 	expNomadConfig := &base.AgentConfig{
@@ -1038,7 +1011,6 @@ func TestPluginLoader_Dispense_NoConfigSchema_External(t *testing.T) {
 	plugin := "mock-device"
 	pluginVersion := "v0.0.1"
 	h := newHarness(t, []string{plugin})
-	defer h.cleanup()
 
 	expKey := "set_config_worked"
 
@@ -1087,7 +1059,6 @@ func TestPluginLoader_Dispense_NoConfigSchema_Internal(t *testing.T) {
 	pluginVersion := "v0.0.1"
 	pluginApiVersions := []string{device.ApiVersion010}
 	h := newHarness(t, nil)
-	defer h.cleanup()
 
 	expKey := "set_config_worked"
 
@@ -1137,7 +1108,6 @@ func TestPluginLoader_Reattach_External(t *testing.T) {
 	plugin := "mock-device"
 	pluginVersion := "v0.0.1"
 	h := newHarness(t, []string{plugin})
-	defer h.cleanup()
 
 	expKey := "set_config_worked"
 
@@ -1200,7 +1170,6 @@ func TestPluginLoader_Bad_Executable(t *testing.T) {
 	// Create a plugin
 	plugin := "mock-device"
 	h := newHarness(t, []string{plugin})
-	defer h.cleanup()
 
 	logger := testlog.HCLogger(t)
 	logger.SetLevel(log.Trace)
@@ -1233,7 +1202,6 @@ func TestPluginLoader_External_SkipBadFiles(t *testing.T) {
 	plugins := []string{"mock-device"}
 	pluginVersions := []string{"v0.0.1"}
 	h := newHarness(t, nil)
-	defer h.cleanup()
 
 	// Create a folder inside our plugin dir
 	require.NoError(os.Mkdir(filepath.Join(h.pluginDir(), "folder"), 0666))

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -3,7 +3,6 @@ package nomad
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1352,8 +1351,7 @@ func TestACLEndpoint_Bootstrap(t *testing.T) {
 
 func TestACLEndpoint_Bootstrap_Reset(t *testing.T) {
 	ci.Parallel(t)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.ACLEnabled = true
 		c.DataDir = dir

--- a/nomad/operator_endpoint_test.go
+++ b/nomad/operator_endpoint_test.go
@@ -539,9 +539,7 @@ func TestOperator_SnapshotSave(t *testing.T) {
 	ci.Parallel(t)
 
 	////// Nomad clusters topology - not specific to test
-	dir, err := ioutil.TempDir("", "nomadtest-operator-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	server1, cleanupLS := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 2
@@ -646,9 +644,7 @@ func TestOperator_SnapshotSave_ACL(t *testing.T) {
 	ci.Parallel(t)
 
 	////// Nomad clusters topology - not specific to test
-	dir, err := ioutil.TempDir("", "nomadtest-operator-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s, root, cleanupLS := TestACLServer(t, func(c *Config) {
 		c.BootstrapExpect = 1
@@ -741,9 +737,7 @@ func TestOperator_SnapshotRestore(t *testing.T) {
 }
 
 func generateSnapshot(t *testing.T) (*snapshot.Snapshot, *structs.Job) {
-	dir, err := ioutil.TempDir("", "nomadtest-operator-")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	dir := t.TempDir()
 
 	s, cleanup := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 1
@@ -762,7 +756,7 @@ func generateSnapshot(t *testing.T) (*snapshot.Snapshot, *structs.Job) {
 	}
 	var jobResp structs.JobRegisterResponse
 	codec := rpcClient(t, s)
-	err = msgpackrpc.CallWithCodec(codec, "Job.Register", jobReq, &jobResp)
+	err := msgpackrpc.CallWithCodec(codec, "Job.Register", jobReq, &jobResp)
 	require.NoError(t, err)
 
 	err = s.State().UpsertJob(structs.MsgTypeTestSetup, 1000, job)
@@ -780,9 +774,7 @@ func testRestoreSnapshot(t *testing.T, req *structs.SnapshotRestoreRequest, snap
 	assertionFn func(t *testing.T, server *Server)) {
 
 	////// Nomad clusters topology - not specific to test
-	dir, err := ioutil.TempDir("", "nomadtest-operator-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	server1, cleanupLS := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 2
@@ -886,9 +878,7 @@ func testRestoreSnapshot(t *testing.T, req *structs.SnapshotRestoreRequest, snap
 func TestOperator_SnapshotRestore_ACL(t *testing.T) {
 	ci.Parallel(t)
 
-	dir, err := ioutil.TempDir("", "nomadtest-operator-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	/////////  Actually run query now
 	cases := []struct {

--- a/nomad/rpc_test.go
+++ b/nomad/rpc_test.go
@@ -192,8 +192,7 @@ func TestRPC_PlaintextRPCSucceedsWhenInUpgradeMode(t *testing.T) {
 		foocert = "../helper/tlsutil/testdata/nomad-foo.pem"
 		fookey  = "../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.DataDir = path.Join(dir, "node1")
@@ -235,8 +234,7 @@ func TestRPC_PlaintextRPCFailsWhenNotInUpgradeMode(t *testing.T) {
 		foocert = "../helper/tlsutil/testdata/nomad-foo.pem"
 		fookey  = "../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.DataDir = path.Join(dir, "node1")
@@ -302,8 +300,7 @@ func TestRPC_streamingRpcConn_badMethod_TLS(t *testing.T) {
 		foocert = "../helper/tlsutil/testdata/nomad-foo.pem"
 		fookey  = "../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.Region = "regionFoo"
 		c.BootstrapExpect = 2
@@ -356,8 +353,7 @@ func TestRPC_streamingRpcConn_badMethod_TLS(t *testing.T) {
 func TestRPC_streamingRpcConn_goodMethod_Plaintext(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.Region = "regionFoo"
 		c.BootstrapExpect = 2
@@ -414,8 +410,7 @@ func TestRPC_streamingRpcConn_goodMethod_TLS(t *testing.T) {
 		foocert = "../helper/tlsutil/testdata/nomad-foo.pem"
 		fookey  = "../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.Region = "regionFoo"
 		c.BootstrapExpect = 2
@@ -1335,7 +1330,7 @@ func newTLSTestHelper(t *testing.T) tlsTestHelper {
 	var err error
 
 	h := tlsTestHelper{
-		dir:    tmpDir(t),
+		dir:    t.TempDir(),
 		nodeID: 1,
 	}
 

--- a/nomad/serf_test.go
+++ b/nomad/serf_test.go
@@ -2,7 +2,6 @@ package nomad
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"strings"
 	"sync/atomic"
@@ -102,8 +101,7 @@ func TestNomad_RemovePeer(t *testing.T) {
 func TestNomad_ReapPeer(t *testing.T) {
 	ci.Parallel(t)
 
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NodeName = "node1"
@@ -198,8 +196,7 @@ func TestNomad_ReapPeer(t *testing.T) {
 func TestNomad_BootstrapExpect(t *testing.T) {
 	ci.Parallel(t)
 
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 3
@@ -389,8 +386,7 @@ func TestNomad_BadExpect(t *testing.T) {
 func TestNomad_NonBootstraping_ShouldntBootstap(t *testing.T) {
 	ci.Parallel(t)
 
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 0

--- a/nomad/server_test.go
+++ b/nomad/server_test.go
@@ -3,8 +3,6 @@ package nomad
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path"
 	"strings"
 	"testing"
@@ -21,15 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func tmpDir(t *testing.T) string {
-	t.Helper()
-	dir, err := ioutil.TempDir("", "nomad")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	return dir
-}
 
 func TestServer_RPC(t *testing.T) {
 	ci.Parallel(t)
@@ -51,8 +40,7 @@ func TestServer_RPC_TLS(t *testing.T) {
 		foocert = "../helper/tlsutil/testdata/nomad-foo.pem"
 		fookey  = "../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.Region = "regionFoo"
@@ -117,8 +105,7 @@ func TestServer_RPC_MixedTLS(t *testing.T) {
 		foocert = "../helper/tlsutil/testdata/nomad-foo.pem"
 		fookey  = "../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.Region = "regionFoo"
@@ -252,8 +239,7 @@ func TestServer_Reload_TLSConnections_PlaintextToTLS(t *testing.T) {
 		foocert = "../helper/tlsutil/testdata/nomad-foo.pem"
 		fookey  = "../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.DataDir = path.Join(dir, "nodeA")
@@ -302,8 +288,7 @@ func TestServer_Reload_TLSConnections_TLSToPlaintext_RPC(t *testing.T) {
 		fookey  = "../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
 
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.DataDir = path.Join(dir, "nodeB")
@@ -349,8 +334,7 @@ func TestServer_Reload_TLSConnections_TLSToPlaintext_OnlyRPC(t *testing.T) {
 		fookey  = "../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
 
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.DataDir = path.Join(dir, "nodeB")
@@ -403,8 +387,7 @@ func TestServer_Reload_TLSConnections_PlaintextToTLS_OnlyRPC(t *testing.T) {
 		fookey  = "../helper/tlsutil/testdata/nomad-foo-key.pem"
 	)
 
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.DataDir = path.Join(dir, "nodeB")
@@ -460,8 +443,7 @@ func TestServer_Reload_TLSConnections_Raft(t *testing.T) {
 		barcert = "../dev/tls_cluster/certs/nomad.pem"
 		barkey  = "../dev/tls_cluster/certs/nomad-key.pem"
 	)
-	dir := tmpDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.BootstrapExpect = 2

--- a/testutil/wait_test.go
+++ b/testutil/wait_test.go
@@ -14,12 +14,7 @@ func TestWait_WaitForFilesUntil(t *testing.T) {
 
 	N := 10
 
-	tmpDir, err := os.MkdirTemp("", "waiter")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(tmpDir))
-	}()
+	tmpDir := t.TempDir()
 
 	var files []string
 	for i := 1; i < N; i++ {


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer require.NoError(t, os.RemoveAll(tmpDir))

	// now
	tmpDir := t.TempDir()
}
```