### PR TITLE
ci: revert file changes and add some checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,11 +94,9 @@ jobs:
         id: notification-channel
         if: ${{ github.event.inputs.notification-channel != '' }}
         run: |
-          previous_channel=$(sed -n 's|notification_channel * = *"\([^"]*\)"|\1|p' .release/ci.hcl | xargs)
           sed -i.bak -e 's|\(notification_channel * = *"\)[^"]*|\1${{ github.event.inputs.notification-channel }}|g' .release/ci.hcl
           rm -rf .release/ci.hcl.bak
           git diff --color=always .release/ci.hcl
-          echo "::set-output name=prev-channel::$previous_channel"
 
       - name: Update version file
         run: |
@@ -153,22 +151,33 @@ jobs:
       - name: Revert notification channel
         if: ${{ github.event.inputs.notification-channel != '' }}
         run: |
-          sed -i.bak -e 's|\(notification_channel * = *"\)[^"]*|\1${{ steps.notification-channel.outputs.prev-channel }}|g' .release/ci.hcl
-          rm -rf .release/ci.hcl.bak
-          git diff --color=always .release/ci.hcl
+          git reset ${{ github.sha }} -- .release/ci.hcl
 
-      - name: Revert version prerelease and bump version number
+          # git reset will place the original file content in the staging area
+          # and leave the changes since then unstaged, so call git restore to
+          # discard these changes and use --cached to display the diff in the
+          # staging area.
+          git restore .release/ci.hcl
+          git diff --cached --color=always .release/ci.hcl
+
+      - name: Update version file
         run: |
+          # Only bump the Version value if this is not a pre-release.
+          # For final releases we want `nomad -version` to display the next
+          # version to indicate that the current release is done.
           if [ -z "$(semver get prerel ${{ github.event.inputs.version }})" ]; then
             next_version=$(semver bump patch ${{ github.event.inputs.version }})
             sed -i.bak -e "s|\(Version * = *\"\)[^\"]*|\1${next_version}|g" version/version.go
           fi
+          # Set the VersionPrerelease variable back to dev.
           sed -i.bak -e "s|\(VersionPrerelease * = *\"\)[^\"]*|\1dev|g" version/version.go
           rm -rf version/version.go.bak
           git diff --color=always version/version.go
 
       - name: Update LAST_RELEASE
         run: |
+          # LAST_RELEASE is used to generate the new CHANGELOG entries, so it's
+          # only updated for final releases.
           if [ -z "$(semver get prerel ${{ github.event.inputs.version }})" ]; then
             sed -i.bak -re "s|^(LAST_RELEASE\s+\?=\s+v).*$|\1${{ github.event.inputs.version }}|g" GNUmakefile
             rm -fr GNUmakefile.bak
@@ -179,7 +188,8 @@ jobs:
 
       - name: Commit post-release changes
         run: |
-          git diff --color=always
+          # Display stated and unstaged diffs.
+          git diff --color=always HEAD
           git add -A .
           if ! git diff-index --quiet HEAD --; then
             git commit --message 'Prepare for next release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
         description: 'Update CHANGELOG'
         required: true
         type: boolean
-        default: true
+        default: false
       notification-channel:
         description: 'Slack channel to use for notifications'
         required: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,47 @@ env:
   GO_TAGS: "release"
 
 jobs:
-  get-go-version:
+  prepare-release:
     runs-on: ubuntu-latest
     outputs:
-      go-version: ${{ steps.get-go-version.outputs.go-version }}
+      build-ref: ${{ steps.commit-change-push.outputs.build-ref }}
     steps:
+      - name: Prevent running from main
+        if: ${{ github.ref_name == 'main' }}
+        run: |
+          echo "::error::Workflow not allowed to run from ${{ github.ref_name }}"
+          exit 1
+
+      - name: Print release info
+        run: |
+          echo "::notice::Release v${{ github.event.inputs.version }} from branch ${{ github.ref_name }}"
+
+      - name: Install semver CLI
+        run: |
+          local_bin="${HOME}/.local/bin"
+          mkdir -p "${local_bin}"
+          curl -L --output "${local_bin}/semver" \
+            https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.3.0/src/semver
+          chmod +x "${local_bin}/semver"
+          echo "${local_bin}" >> $GITHUB_PATH
+
+      - name: Validate release version
+        run: |
+          if [ "$(semver validate ${{ github.event.inputs.version }})" == "invalid" ]; then
+            echo "::error::Version ${{ github.event.inputs.version }} is invalid"
+            exit 1
+          fi
+
       - uses: actions/checkout@v2
+
+      - name: Setup Git
+        run: |
+          if [ "${{ secrets.ELEVATED_GITHUB_TOKEN }}" ]; then
+            git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com/".insteadOf "https://github.com"
+          fi
+          git config --global user.email "github-team-nomad-core@hashicorp.com"
+          git config --global user.name "hc-github-team-nomad-core"
+
       - name: Determine Go version
         id: get-go-version
         # We use .go-version as our source of truth for current Go
@@ -36,18 +71,10 @@ jobs:
           echo "Building with Go $(cat .go-version)"
           echo "::set-output name=go-version::$(cat .go-version)"
 
-  prepare-release:
-    needs: get-go-version
-    runs-on: ubuntu-latest
-    outputs:
-      build-ref: ${{ steps.commit-change-push.outputs.build-ref }}
-    steps:
-      - uses: actions/checkout@v2
-
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ needs.get-go-version.outputs.go-version }}
+          go-version: ${{ steps.get-go-version.outputs.go-version }}
 
       - name: Setup node and yarn
         uses: actions/setup-node@v2
@@ -64,17 +91,20 @@ jobs:
           make deps
 
       - name: Update notification channel
+        id: notification-channel
         if: ${{ github.event.inputs.notification-channel != '' }}
         run: |
+          previous_channel=$(sed -n 's|notification_channel * = *"\([^"]*\)"|\1|p' .release/ci.hcl | xargs)
           sed -i.bak -e 's|\(notification_channel * = *"\)[^"]*|\1${{ github.event.inputs.notification-channel }}|g' .release/ci.hcl
           rm -rf .release/ci.hcl.bak
           git diff --color=always .release/ci.hcl
+          echo "::set-output name=prev-channel::$previous_channel"
 
       - name: Update version file
         run: |
           NOMAD_VERSION="${{ github.event.inputs.version }}"
-          NOMAD_MAIN_VERSION=$(echo "$NOMAD_VERSION" | cut -d- -f1)
-          NOMAD_PRERELEASE_VERSION=$(echo "$NOMAD_VERSION" | sed 's|^[^-]*-\{0,1\}||g')
+          NOMAD_MAIN_VERSION=$(semver get release "$NOMAD_VERSION")
+          NOMAD_PRERELEASE_VERSION=$(semver get prerel "$NOMAD_VERSION")
 
           echo "updating version to ${NOMAD_MAIN_VERSION}-${NOMAD_PRERELEASE_VERSION}"
 
@@ -103,10 +133,7 @@ jobs:
         run: |
           git add -A .
           find . -name '*.generated.go' -not -path './vendor/*' -exec git add -f '{}' \;
-          if ! git diff-index --quiet HEAD --;
-          then
-            git config --global user.email "github-team-nomad-core@hashicorp.com"
-            git config --global user.name "hc-github-team-nomad-core"
+          if ! git diff-index --quiet HEAD --; then
             git commit --message "Generate files for ${{ github.event.inputs.version }} release"
             git push origin "$(git rev-parse --abbrev-ref HEAD)"
             echo "committing generated files"
@@ -122,3 +149,41 @@ jobs:
           token: ${{ secrets.ELEVATED_GITHUB_TOKEN}}
           inputs: '{"build-ref": "${{ steps.commit-change-push.outputs.build-ref }}", "make-prerelease": "false"}'
           ref: ${{ needs.prepare-release.outputs.build-ref }}
+
+      - name: Revert notification channel
+        if: ${{ github.event.inputs.notification-channel != '' }}
+        run: |
+          sed -i.bak -e 's|\(notification_channel * = *"\)[^"]*|\1${{ steps.notification-channel.outputs.prev-channel }}|g' .release/ci.hcl
+          rm -rf .release/ci.hcl.bak
+          git diff --color=always .release/ci.hcl
+
+      - name: Revert version prerelease and bump version number
+        run: |
+          if [ -z "$(semver get prerel ${{ github.event.inputs.version }})" ]; then
+            next_version=$(semver bump patch ${{ github.event.inputs.version }})
+            sed -i.bak -e "s|\(Version * = *\"\)[^\"]*|\1${next_version}|g" version/version.go
+          fi
+          sed -i.bak -e "s|\(VersionPrerelease * = *\"\)[^\"]*|\1dev|g" version/version.go
+          rm -rf version/version.go.bak
+          git diff --color=always version/version.go
+
+      - name: Update LAST_RELEASE
+        run: |
+          if [ -z "$(semver get prerel ${{ github.event.inputs.version }})" ]; then
+            sed -i.bak -re "s|^(LAST_RELEASE\s+\?=\s+v).*$|\1${{ github.event.inputs.version }}|g" GNUmakefile
+            rm -fr GNUmakefile.bak
+            git diff --color=always GNUmakefile
+          else
+            echo "Version ${{ github.event.inputs.version }} is a prerelease, skipping update of LAST_RELEASE"
+          fi
+
+      - name: Commit post-release changes
+        run: |
+          git diff --color=always
+          git add -A .
+          if ! git diff-index --quiet HEAD --; then
+            git commit --message 'Prepare for next release'
+            git push origin "$(git rev-parse --abbrev-ref HEAD)"
+          else
+            echo "no files were updated"
+          fi

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -3,10 +3,7 @@ schema = "1"
 project "nomad" {
   team = "nomad"
   slack {
-    // #feed-nomad-releases
     notification_channel = "C03B5EWFW01"
-    // #proj-nomad-releases
-    // notification_channel = "CUYKT2A73"
   }
   github {
     organization = "hashicorp"


### PR DESCRIPTION
During the release there are several files that need to be modified:

  - .release/ci.hcl: the notification channel needs to be updated to a
    channel with greater team visibility during the release.
  - version/version.go: the Version and VersionPrerelease variables
    need to be set so they match the release version.

After the release these files need to be reverted.

For GA releases the following additional changes also need to happen:

  - version/version.go: the Version variable needs to be bumped to the
    next version number.
  - GNUMakefile: the LAST_RELEASE variable needs to be set to the
    version that was just released.

Since the release process will commit file changes to the branch being
used for the release, it should _never_ run on main, so the first step
is now to protect against that.

It also adds a validation to make the user input version is correct.