### PR TITLE
ci: update backport assitant workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,32 +15,14 @@ jobs:
     steps:
       - name: Backport changes to stable-website
         run: |
-          backport-assistant backport -automerge
+          backport-assistant backport -merge-method=squash -automerge
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
           BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      - name: Backport changes to latest release branch
-        run: |
-          resp=$(curl -f -s "https://api.github.com/repos/$GITHUB_REPOSITORY/labels?per_page=100")
-          ret="$?"
-          if [[ "$ret" -ne 0 ]]; then
-              echo "The GitHub API returned $ret"
-              exit $ret
-          fi
-          # get the latest backport label excluding any website labels, ex: `backport/0.3.x` and not `backport/website`
-          latest_backport_label=$(echo "$resp" | jq -r '.[] | select(.name | (startswith("backport/") and (contains("website") | not))) | .name' | sort -rV | head -n1)
-          echo "Latest backport label: $latest_backport_label"
-          # set BACKPORT_TARGET_TEMPLATE for backport-assistant
-          # trims backport/ from the beginning with parameter substitution
-          export BACKPORT_TARGET_TEMPLATE="release/${latest_backport_label#backport/}"
-          backport-assistant backport -automerge
-        env:
-          BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
-          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Backport changes to targeted release branch
         run: |
-          backport-assistant backport -automerge
+          backport-assistant backport -merge-method=squash -automerge
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.[+\\w]+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"


### PR DESCRIPTION
Remove the step to automatically backport `backport/website` PRs to the
latest release. This will be done manually by adding the proper tags.

Also use squash backports to match the pattern we use for `main`.