### PR TITLE
docs: add version note to nomad services template

### DIFF
--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -282,6 +282,8 @@ task "task" {
 
 ### Nomad Services
 
+~> Nomad Services are new in Nomad 1.3.
+
 Nomad service registrations can be queried using the `nomadService` and
 `nomadServices` functions. The requests are tied to the same namespace as the
 job which contains the template stanza.


### PR DESCRIPTION
The current public docs site is showing features for 1.3.x (from main branch) despite viewing the 1.2.x. I think the doc sites also needs to be adjusted to show a tag for 1.2, but until then, a version note should help out. A similar note is found in the documentation for the CLI service command which is also visible on the public site.