### PR TITLE
add service acct to codeowners for backport merging

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # release configuration
 
-/.release/                              @hashicorp/release-engineering
-/.github/workflows/build.yml            @hashicorp/release-engineering
+/.release/                              @hashicorp/release-engineering @hashicorp/github-nomad-core
+/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-nomad-core


### PR DESCRIPTION
Backports are failing with an error about a lack of admin access - we suspect that this can be patched by adding the nomad service acct as a codeowner. 