### PR TITLE
api: enable setting choose parameter

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -87,6 +87,12 @@ type QueryOptions struct {
 	// Currently only supported by specific endpoints.
 	Reverse bool
 
+	// Choose is used when selecting a subset of services from the normal
+	// complete list of services. Format is <count>|<key>, where the key is
+	// typically the allocation ID hashed with other service metadata associated
+	// with the requesting task.
+	Choose string
+
 	// ctx is an optional context pass through to the underlying HTTP
 	// request layer. Use Context() and WithContext() to manage this.
 	ctx context.Context
@@ -610,6 +616,9 @@ func (r *request) setQueryOptions(q *QueryOptions) {
 	}
 	if q.Filter != "" {
 		r.params.Set("filter", q.Filter)
+	}
+	if q.Choose != "" {
+		r.params.Set("choose", q.Choose)
 	}
 	if q.PerPage != 0 {
 		r.params.Set("per_page", fmt.Sprint(q.PerPage))


### PR DESCRIPTION
This is PR 1 of 4 in getting HRW enabled `chooseService` merged - things are complicated because `nomad` -depends-on-> `consul-template` -depends-on-> `nomad/api`, and `nomad{/api}` are the same repository :disappointed: 

1: changes to `nomad/api`
2: changes to CT (including `nomad/api` bump) (https://github.com/hashicorp/consul-template/pull/1579)
3: changes to nomad (including CT bump, so that it includes `nomad/api` changes) (https://github.com/hashicorp/nomad/pull/12862)
4: bump CT (to point at a tagged version of nomad)