### PR TITLE
Fix Exec not working with reverse proxy X-Nomad-Token

### DIFF
--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -31,7 +31,7 @@ export default class TokenService extends Service {
   @task(function* () {
     const TokenAdapter = getOwner(this).lookup('adapter:token');
     try {
-      var token = yield TokenAdapter.findSelf()
+      var token = yield TokenAdapter.findSelf();
       this.secret = token.secret;
       return token;
     } catch (e) {

--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -31,7 +31,9 @@ export default class TokenService extends Service {
   @task(function* () {
     const TokenAdapter = getOwner(this).lookup('adapter:token');
     try {
-      return yield TokenAdapter.findSelf();
+      var token = yield TokenAdapter.findSelf()
+      this.secret = token.secret;
+      return token;
     } catch (e) {
       const errors = e.errors ? e.errors.mapBy('detail') : [];
       if (errors.find((error) => error === 'ACL support disabled')) {

--- a/ui/tests/acceptance/proxy-test.js
+++ b/ui/tests/acceptance/proxy-test.js
@@ -17,17 +17,36 @@ module('Acceptance | reverse proxy', function (hooks) {
     server.create('agent');
     managementToken = server.create('token');
 
+    // Prepare a setRequestHeader that accumulate headers already set. This is to avoid double setting X-Nomad-Token
+    this._originalXMLHttpRequestSetRequestHeader = XMLHttpRequest.prototype.setRequestHeader;
+    (function (setRequestHeader) {
+      XMLHttpRequest.prototype.setRequestHeader = function (header, value) {
+        if (!this.headers) {
+          this.headers = {};
+        }
+        if (!this.headers[header]) {
+          this.headers[header] = [];
+        }
+        // Add the value to the header
+        this.headers[header].push(value);
+        setRequestHeader.call(this, header, value);
+      };
+    })(this._originalXMLHttpRequestSetRequestHeader);
+
     // Simulate a reverse proxy injecting X-Nomad-Token header for all requests
     this._originalXMLHttpRequestSend = XMLHttpRequest.prototype.send;
     (function (send) {
       XMLHttpRequest.prototype.send = function (data) {
-        this.setRequestHeader('X-Nomad-Token', managementToken.secretId);
+        if (!this.headers || !('X-Nomad-Token' in this.headers)) {
+          this.setRequestHeader('X-Nomad-Token', managementToken.secretId);
+        } 
         send.call(this, data);
       };
     })(this._originalXMLHttpRequestSend);
   });
 
   hooks.afterEach(function () {
+    XMLHttpRequest.prototype.setRequestHeader = this._originalXMLHttpRequestSetRequestHeader;
     XMLHttpRequest.prototype.send = this._originalXMLHttpRequestSend;
   });
 
@@ -38,8 +57,8 @@ module('Acceptance | reverse proxy', function (hooks) {
     await Jobs.visit();
     assert.equal(
       window.localStorage.nomadTokenSecret,
-      null,
-      'No token secret set'
+      secretId,
+      'Token secret was set'
     );
 
     // Make sure that server received the header

--- a/ui/tests/acceptance/proxy-test.js
+++ b/ui/tests/acceptance/proxy-test.js
@@ -18,7 +18,8 @@ module('Acceptance | reverse proxy', function (hooks) {
     managementToken = server.create('token');
 
     // Prepare a setRequestHeader that accumulate headers already set. This is to avoid double setting X-Nomad-Token
-    this._originalXMLHttpRequestSetRequestHeader = XMLHttpRequest.prototype.setRequestHeader;
+    this._originalXMLHttpRequestSetRequestHeader =
+      XMLHttpRequest.prototype.setRequestHeader;
     (function (setRequestHeader) {
       XMLHttpRequest.prototype.setRequestHeader = function (header, value) {
         if (!this.headers) {
@@ -39,14 +40,15 @@ module('Acceptance | reverse proxy', function (hooks) {
       XMLHttpRequest.prototype.send = function (data) {
         if (!this.headers || !('X-Nomad-Token' in this.headers)) {
           this.setRequestHeader('X-Nomad-Token', managementToken.secretId);
-        } 
+        }
         send.call(this, data);
       };
     })(this._originalXMLHttpRequestSend);
   });
 
   hooks.afterEach(function () {
-    XMLHttpRequest.prototype.setRequestHeader = this._originalXMLHttpRequestSetRequestHeader;
+    XMLHttpRequest.prototype.setRequestHeader =
+      this._originalXMLHttpRequestSetRequestHeader;
     XMLHttpRequest.prototype.send = this._originalXMLHttpRequestSend;
   });
 


### PR DESCRIPTION
This fixes an issue with Exec feature not working when a reverse proxy is used to automatically inject X-Nomad-Token.