### PR TITLE
secure variables: initial state store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,7 @@ require (
 	github.com/zclconf/go-cty-yaml v1.0.2
 	go.etcd.io/bbolt v1.3.5
 	go.uber.org/goleak v1.1.12
-	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd
+	golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86

--- a/go.sum
+++ b/go.sum
@@ -1349,8 +1349,8 @@ golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd h1:XcWmESyNjXJMLahc3mqVQJcgSTDxFxhETVlfk9uGc38=
-golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f h1:OeJjE6G4dgCY4PIXvIRQbE8+RX+uXZyGhUy/ksMGJoc=
+golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/helper/raftutil/msgtypes.go
+++ b/helper/raftutil/msgtypes.go
@@ -54,6 +54,10 @@ var msgTypeNames = map[structs.MessageType]string{
 	structs.ServiceRegistrationUpsertRequestType:         "ServiceRegistrationUpsertRequestType",
 	structs.ServiceRegistrationDeleteByIDRequestType:     "ServiceRegistrationDeleteByIDRequestType",
 	structs.ServiceRegistrationDeleteByNodeIDRequestType: "ServiceRegistrationDeleteByNodeIDRequestType",
+	structs.SecureVariableUpsertRequestType:              "SecureVariableUpsertRequestType",
+	structs.SecureVariableDeleteRequestType:              "SecureVariableDeleteRequestType",
+	structs.RootKeyMetaUpsertRequestType:                 "RootKeyMetaUpsertRequestType",
+	structs.RootKeyMetaDeleteRequestType:                 "RootKeyMetaDeleteRequestType",
 	structs.NamespaceUpsertRequestType:                   "NamespaceUpsertRequestType",
 	structs.NamespaceDeleteRequestType:                   "NamespaceDeleteRequestType",
 }

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -1,0 +1,29 @@
+package nomad
+
+import "crypto/cipher"
+
+type Encrypter struct {
+	ciphers map[string]cipher.AEAD // map of key IDs to ciphers
+}
+
+func NewEncrypter() *Encrypter {
+	return &Encrypter{
+		ciphers: make(map[string]cipher.AEAD),
+	}
+}
+
+// Encrypt takes the serialized map[string][]byte from
+// SecureVariable.UnencryptedData, generates an appropriately-sized nonce
+// for the algorithm, and encrypts the data with the ciper for the
+// CurrentRootKeyID. The buffer returned includes the nonce.
+func (e *Encrypter) Encrypt(unencryptedData []byte, keyID string) []byte {
+	// TODO: actually encrypt!
+	return unencryptedData
+}
+
+// Decrypt takes an encrypted buffer and then root key ID. It extracts
+// the nonce, decrypts the content, and returns the cleartext data.
+func (e *Encrypter) Decrypt(encryptedData []byte, keyID string) ([]byte, error) {
+	// TODO: actually decrypt!
+	return encryptedData, nil
+}

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -312,6 +312,14 @@ func (n *nomadFSM) Apply(log *raft.Log) interface{} {
 		return n.applyDeleteServiceRegistrationByID(msgType, buf[1:], log.Index)
 	case structs.ServiceRegistrationDeleteByNodeIDRequestType:
 		return n.applyDeleteServiceRegistrationByNodeID(msgType, buf[1:], log.Index)
+	case structs.SecureVariableUpsertRequestType:
+		return n.applySecureVariableUpsert(msgType, buf[1:], log.Index)
+	case structs.SecureVariableDeleteRequestType:
+		return n.applySecureVariableDelete(msgType, buf[1:], log.Index)
+	case structs.RootKeyMetaUpsertRequestType:
+		return n.applyRootKeyMetaUpsert(msgType, buf[1:], log.Index)
+	case structs.RootKeyMetaDeleteRequestType:
+		return n.applyRootKeyMetaDelete(msgType, buf[1:], log.Index)
 	}
 
 	// Check enterprise only message types.
@@ -1938,6 +1946,68 @@ func (n *nomadFSM) applyDeleteServiceRegistrationByNodeID(msgType structs.Messag
 
 	if err := n.state.DeleteServiceRegistrationByNodeID(msgType, index, req.NodeID); err != nil {
 		n.logger.Error("DeleteServiceRegistrationByNodeID failed", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (n *nomadFSM) applySecureVariableUpsert(msgType structs.MessageType, buf []byte, index uint64) interface{} {
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_secure_variable_upsert"}, time.Now())
+	var req structs.SecureVariablesUpsertRequest
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+
+	if err := n.state.UpsertSecureVariables(msgType, index, []*structs.DirEntry{req.Data}); err != nil {
+		n.logger.Error("UpsertSecureVariables failed", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (n *nomadFSM) applySecureVariableDelete(msgType structs.MessageType, buf []byte, index uint64) interface{} {
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_secure_variable_delete"}, time.Now())
+	var req structs.SecureVariablesDeleteRequest
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+
+	if err := n.state.DeleteSecureVariables(msgType, index, []string{req.Path}); err != nil {
+		n.logger.Error("DeleteSecureVariables failed", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (n *nomadFSM) applyRootKeyMetaUpsert(msgType structs.MessageType, buf []byte, index uint64) interface{} {
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_root_key_meta_upsert"}, time.Now())
+
+	var req structs.KeyringUpdateRootKeyMetaRequest
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+
+	if err := n.state.UpsertRootKeyMeta(index, req.RootKeyMeta); err != nil {
+		n.logger.Error("UpsertRootKeyMeta failed", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (n *nomadFSM) applyRootKeyMetaDelete(msgType structs.MessageType, buf []byte, index uint64) interface{} {
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_root_key_meta_delete"}, time.Now())
+
+	var req structs.KeyringDeleteRootKeyRequest
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+
+	if err := n.state.DeleteRootKeyMeta(index, req.KeyID); err != nil {
+		n.logger.Error("DeleteRootKeyMeta failed", "error", err)
 		return err
 	}
 

--- a/nomad/keyring_endpoint.go
+++ b/nomad/keyring_endpoint.go
@@ -1,0 +1,95 @@
+package nomad
+
+import (
+	"time"
+
+	metrics "github.com/armon/go-metrics"
+	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// KeyRing endpoint serves RPCs for secure variables key management
+type KeyRing struct {
+	srv       *Server
+	logger    hclog.Logger
+	encrypter *Encrypter
+}
+
+func (k *KeyRing) Rotate(args *structs.KeyringRotateRootKeyRequest, reply *structs.KeyringRotateRootKeyResponse) error {
+	if done, err := k.srv.forward("KeyRing.Rotate", args, args, reply); done {
+		return err
+	}
+
+	defer metrics.MeasureSince([]string{"nomad", "keyring", "rotate"}, time.Now())
+
+	// TODO: allow for servers to force rotation as well
+	if aclObj, err := k.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
+	// TODO: implementation; this just silences the structcheck lint
+	for keyID := range k.encrypter.ciphers {
+		k.logger.Trace("TODO", "key", keyID)
+	}
+	return nil
+}
+
+func (k *KeyRing) List(args *structs.KeyringListRootKeyMetaRequest, reply *structs.KeyringListRootKeyMetaResponse) error {
+	if done, err := k.srv.forward("KeyRing.List", args, args, reply); done {
+		return err
+	}
+
+	defer metrics.MeasureSince([]string{"nomad", "keyring", "list"}, time.Now())
+
+	// TODO: probably need to allow for servers to list keys as well, to support replication?
+	if aclObj, err := k.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
+	// TODO: implementation
+
+	return nil
+}
+
+func (k *KeyRing) Update(args *structs.KeyringUpdateRootKeyRequest, reply *structs.KeyringUpdateRootKeyResponse) error {
+	if done, err := k.srv.forward("KeyRing.Update", args, args, reply); done {
+		return err
+	}
+
+	defer metrics.MeasureSince([]string{"nomad", "keyring", "update"}, time.Now())
+
+	// TODO: need to allow for servers to update keys as well, to support replication
+	if aclObj, err := k.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
+	// TODO: implementation
+
+	return nil
+}
+
+func (k *KeyRing) Delete(args *structs.KeyringDeleteRootKeyRequest, reply *structs.KeyringDeleteRootKeyResponse) error {
+	if done, err := k.srv.forward("KeyRing.Delete", args, args, reply); done {
+		return err
+	}
+
+	defer metrics.MeasureSince([]string{"nomad", "keyring", "delete"}, time.Now())
+
+	// TODO: need to allow for servers to delete keys as well, to support replication
+	if aclObj, err := k.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
+	// TODO: implementation
+
+	return nil
+}

--- a/nomad/secure_variables_endpoint.go
+++ b/nomad/secure_variables_endpoint.go
@@ -1,0 +1,104 @@
+package nomad
+
+import (
+	"bytes"
+	"encoding/gob"
+	"time"
+
+	metrics "github.com/armon/go-metrics"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// SecureVariables endpoint serves RPCs for storing and retrieving
+// encrypted variables
+type SecureVariables struct {
+	srv       *Server
+	logger    hclog.Logger
+	encrypter *Encrypter
+}
+
+func (sv *SecureVariables) Create(args *structs.SecureVariablesUpsertRequest, reply *structs.SecureVariablesUpsertResponse) error {
+	if done, err := sv.srv.forward("SecureVariables.Create", args, args, reply); done {
+		return err
+	}
+
+	defer metrics.MeasureSince([]string{"nomad", "secure_variables", "create"}, time.Now())
+
+	// TODO: implement real ACL checks
+	if aclObj, err := sv.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
+	sv.logger.Trace("TODO") // silences structcheck lint
+
+	// TODO: placeholder for serialization and encryption
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	err := enc.Encode(args.Data.UnencryptedData)
+	if err != nil {
+		return err
+	}
+	args.Data.EncryptedData.Data = sv.encrypter.Encrypt(buf.Bytes(), "TODO")
+
+	return nil
+}
+
+func (sv *SecureVariables) List(args *structs.SecureVariablesListRequest, reply *structs.SecureVariablesListResponse) error {
+	if done, err := sv.srv.forward("SecureVariables.List", args, args, reply); done {
+		return err
+	}
+
+	defer metrics.MeasureSince([]string{"nomad", "secure_variables", "list"}, time.Now())
+
+	// TODO: implement real ACL checks
+	if aclObj, err := sv.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
+	// TODO: implementation
+
+	return nil
+}
+
+func (sv *SecureVariables) Read(args *structs.SecureVariablesReadRequest, reply *structs.SecureVariablesReadResponse) error {
+	if done, err := sv.srv.forward("SecureVariables.Read", args, args, reply); done {
+		return err
+	}
+
+	defer metrics.MeasureSince([]string{"nomad", "secure_variables", "read"}, time.Now())
+
+	// TODO: implement real ACL checks
+	if aclObj, err := sv.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
+	// TODO: implementation
+
+	return nil
+}
+
+func (sv *SecureVariables) Update(args *structs.SecureVariablesUpsertRequest, reply *structs.SecureVariablesUpsertResponse) error {
+	if done, err := sv.srv.forward("SecureVariables.Update", args, args, reply); done {
+		return err
+	}
+
+	defer metrics.MeasureSince([]string{"nomad", "secure_variables", "update"}, time.Now())
+
+	// TODO: implement real ACL checks
+	if aclObj, err := sv.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
+	// TODO: implementation
+
+	return nil
+}

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -12,8 +12,11 @@ import (
 const (
 	tableIndex = "index"
 
-	TableNamespaces           = "namespaces"
-	TableServiceRegistrations = "service_registrations"
+	TableNamespaces            = "namespaces"
+	TableServiceRegistrations  = "service_registrations"
+	TableSecureVariables       = "secure_variables"
+	TableSecureVariablesQuotas = "secure_variables_quota"
+	TableRootKeyMeta           = "secure_variables_root_key_meta"
 )
 
 const (
@@ -70,6 +73,9 @@ func init() {
 		scalingEventTableSchema,
 		namespaceTableSchema,
 		serviceRegistrationsTableSchema,
+		secureVariablesTableSchema,
+		secureVariablesQuotasTableSchema,
+		secureVariablesRootKeyMetaSchema,
 	}...)
 }
 
@@ -1197,6 +1203,69 @@ func serviceRegistrationsTableSchema() *memdb.TableSchema {
 				Unique:       false,
 				Indexer: &memdb.StringFieldIndex{
 					Field: "AllocID",
+				},
+			},
+		},
+	}
+}
+
+// secureVariablesTableSchema returns the MemDB schema for Nomad
+// secure variables.
+func secureVariablesTableSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: TableSecureVariables,
+		Indexes: map[string]*memdb.IndexSchema{
+			indexID: {
+				Name:         indexID,
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.CompoundIndex{
+					Indexes: []memdb.Indexer{
+						&memdb.StringFieldIndex{
+							Field: "Namespace",
+						},
+						&memdb.StringFieldIndex{
+							Field: "Path",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// secureVariablesQuotasTableSchema returns the MemDB schema for Nomad
+// secure variables quotas tracking
+func secureVariablesQuotasTableSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: TableSecureVariablesQuotas,
+		Indexes: map[string]*memdb.IndexSchema{
+			indexID: {
+				Name:         indexID,
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.StringFieldIndex{
+					Field:     "Namespace",
+					Lowercase: true,
+				},
+			},
+		},
+	}
+}
+
+// secureVariablesRootKeyMetaSchema returns the MemDB schema for Nomad
+// secure variables root keys
+func secureVariablesRootKeyMetaSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: TableRootKeyMeta,
+		Indexes: map[string]*memdb.IndexSchema{
+			indexID: {
+				Name:         indexID,
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.StringFieldIndex{
+					Field:     "KeyID",
+					Lowercase: true,
 				},
 			},
 		},

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -6590,3 +6590,19 @@ func (s *StateSnapshot) DenormalizeAllocationDiffSlice(allocDiffs []*structs.All
 func getPreemptedAllocDesiredDescription(preemptedByAllocID string) string {
 	return fmt.Sprintf("Preempted by alloc ID %v", preemptedByAllocID)
 }
+
+func (s *StateStore) UpsertSecureVariables(msgType structs.MessageType, index uint64, dirEntries []*structs.SecureVariable) error {
+	return nil
+}
+
+func (s *StateStore) DeleteSecureVariables(msgType structs.MessageType, index uint64, paths []string) error {
+	return nil
+}
+
+func (s *StateStore) UpsertRootKeyMeta(index uint64, rootKeyMeta *structs.RootKeyMeta) error {
+	return nil
+}
+
+func (s *StateStore) DeleteRootKeyMeta(index uint64, keyID string) error {
+	return nil
+}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -6591,6 +6591,20 @@ func getPreemptedAllocDesiredDescription(preemptedByAllocID string) string {
 	return fmt.Sprintf("Preempted by alloc ID %v", preemptedByAllocID)
 }
 
+// SecureVariables queries all the variables and is used only for
+// snapshot/restore and key rotation
+func (s *StateStore) SecureVariables(ws memdb.WatchSet) (memdb.ResultIterator, error) {
+	txn := s.db.ReadTxn()
+
+	iter, err := txn.Get(TableSecureVariables, indexID)
+	if err != nil {
+		return nil, err
+	}
+
+	ws.Add(iter.WatchCh())
+	return iter, nil
+}
+
 func (s *StateStore) UpsertSecureVariables(msgType structs.MessageType, index uint64, dirEntries []*structs.SecureVariable) error {
 	return nil
 }
@@ -6599,10 +6613,36 @@ func (s *StateStore) DeleteSecureVariables(msgType structs.MessageType, index ui
 	return nil
 }
 
+// SecureVariablesQuotas queries all the quotas and is used only for
+// snapshot/restore and key rotation
+func (s *StateStore) SecureVariablesQuotas(ws memdb.WatchSet) (memdb.ResultIterator, error) {
+	txn := s.db.ReadTxn()
+
+	iter, err := txn.Get(TableSecureVariablesQuotas, indexID)
+	if err != nil {
+		return nil, err
+	}
+
+	ws.Add(iter.WatchCh())
+	return iter, nil
+}
+
 func (s *StateStore) UpsertRootKeyMeta(index uint64, rootKeyMeta *structs.RootKeyMeta) error {
 	return nil
 }
 
 func (s *StateStore) DeleteRootKeyMeta(index uint64, keyID string) error {
 	return nil
+}
+
+func (s *StateStore) RootKeyMetas(ws memdb.WatchSet) (memdb.ResultIterator, error) {
+	txn := s.db.ReadTxn()
+
+	iter, err := txn.Get(TableRootKeyMeta, indexID)
+	if err != nil {
+		return nil, err
+	}
+
+	ws.Add(iter.WatchCh())
+	return iter, nil
 }

--- a/nomad/state/state_store_restore.go
+++ b/nomad/state/state_store_restore.go
@@ -197,3 +197,30 @@ func (r *StateRestore) ServiceRegistrationRestore(service *structs.ServiceRegist
 	}
 	return nil
 }
+
+// SecureVariablesRestore is used to restore a single secure variable
+// into the secure_variables table.
+func (r *StateRestore) SecureVariablesRestore(variable *structs.SecureVariable) error {
+	if err := r.txn.Insert(TableSecureVariables, variable); err != nil {
+		return fmt.Errorf("secure variable insert failed: %v", err)
+	}
+	return nil
+}
+
+// SecureVariablesQuotaRestore is used to restore a single secure variable quota
+// into the secure_variables_quota table.
+func (r *StateRestore) SecureVariablesQuotaRestore(quota *structs.SecureVariablesQuota) error {
+	if err := r.txn.Insert(TableSecureVariablesQuotas, quota); err != nil {
+		return fmt.Errorf("secure variable quota insert failed: %v", err)
+	}
+	return nil
+}
+
+// RootKeyMetaQuotaRestore is used to restore a single root key meta
+// into the secure_variables_root_key_meta table.
+func (r *StateRestore) RootKeyMetaRestore(quota *structs.RootKeyMeta) error {
+	if err := r.txn.Insert(TableRootKeyMeta, quota); err != nil {
+		return fmt.Errorf("root key meta insert failed: %v", err)
+	}
+	return nil
+}

--- a/nomad/structs/secure_variables.go
+++ b/nomad/structs/secure_variables.go
@@ -1,0 +1,68 @@
+package structs
+
+import "time"
+
+// SecureVariable is the metadata envelope for a Secure Variable
+type SecureVariable struct {
+	Namespace   string
+	Path        string
+	CreatedAt   time.Time
+	CreateIndex uint64
+	ModifyIndex uint64
+	ModifyTime  time.Time
+
+	// reserved for post-1.4.0 work
+	// LockIndex      uint64
+	// Session        string
+	// DeletedAt      time.Time
+	// Version        uint64
+	// CustomMetaData map[string]string
+
+	EncryptedData   *SecureVariableData // removed during serialization
+	UnencryptedData map[string]string   // empty until serialized
+}
+
+// SecureVariableData is the secret data for a Secure Variable
+type SecureVariableData struct {
+	Data  []byte // includes nonce
+	KeyID string // ID of root key used to encrypt this entry
+}
+
+// SecureVariablesQuota is used to track the total size of secure
+// variables entries per namespace. The total length of
+// SecureVariable.EncryptedData will be added to the SecureVariablesQuota
+// table in the same transaction as a write, update, or delete.
+type SecureVariablesQuota struct {
+	Namespace   string
+	Size        uint64
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+// RootKey is used to encrypt and decrypt secure variables. It is
+// never stored in raft.
+type RootKey struct {
+	Meta RootKeyMeta
+	Key  []byte // serialized to keystore as base64 blob
+}
+
+// RootKeyMeta is the metadata used to refer to a RootKey. It is
+// stored in raft.
+type RootKeyMeta struct {
+	Active           bool
+	KeyID            string // UUID
+	Algorithm        EncryptionAlgorithm
+	EncryptionsCount uint64
+	CreatedAt        time.Time
+	CreateIndex      uint64
+	ModifyIndex      uint64
+}
+
+// EncryptionAlgorithm chooses which algorithm is used for
+// encrypting / decrypting entries with this key
+type EncryptionAlgorithm string
+
+const (
+	EncryptionAlgorithmXChaCha20 EncryptionAlgorithm = "xchacha20"
+	EncryptionAlgorithmAES256GCM EncryptionAlgorithm = "aes256-gcm"
+)

--- a/nomad/structs/secure_variables.go
+++ b/nomad/structs/secure_variables.go
@@ -48,6 +48,26 @@ type SecureVariablesUpsertResponse struct {
 	WriteMeta
 }
 
+type SecureVariablesListRequest struct {
+	// TODO: do we need any fields here?
+	QueryOptions
+}
+
+type SecureVariablesListResponse struct {
+	Data []*SecureVariable
+	QueryMeta
+}
+
+type SecureVariablesReadRequest struct {
+	Path string
+	QueryOptions
+}
+
+type SecureVariablesReadResponse struct {
+	Data *SecureVariable
+	QueryMeta
+}
+
 type SecureVariablesDeleteRequest struct {
 	Path string
 	WriteRequest

--- a/nomad/structs/secure_variables.go
+++ b/nomad/structs/secure_variables.go
@@ -39,6 +39,24 @@ type SecureVariablesQuota struct {
 	ModifyIndex uint64
 }
 
+type SecureVariablesUpsertRequest struct {
+	Data *SecureVariable
+	WriteRequest
+}
+
+type SecureVariablesUpsertResponse struct {
+	WriteMeta
+}
+
+type SecureVariablesDeleteRequest struct {
+	Path string
+	WriteRequest
+}
+
+type SecureVariablesDeleteResponse struct {
+	WriteMeta
+}
+
 // RootKey is used to encrypt and decrypt secure variables. It is
 // never stored in raft.
 type RootKey struct {
@@ -66,3 +84,24 @@ const (
 	EncryptionAlgorithmXChaCha20 EncryptionAlgorithm = "xchacha20"
 	EncryptionAlgorithmAES256GCM EncryptionAlgorithm = "aes256-gcm"
 )
+
+// KeyringUpdateRootKeyMetaRequest is used internally for key
+// replication so that we have a request wrapper for writing the
+// metadata to the FSM without including the key material
+type KeyringUpdateRootKeyMetaRequest struct {
+	RootKeyMeta *RootKeyMeta
+	WriteRequest
+}
+
+type KeyringUpdateRootKeyMetaResponse struct {
+	WriteMeta
+}
+
+type KeyringDeleteRootKeyRequest struct {
+	KeyID string
+	WriteRequest
+}
+
+type KeyringDeleteRootKeyResponse struct {
+	WriteMeta
+}

--- a/nomad/structs/secure_variables.go
+++ b/nomad/structs/secure_variables.go
@@ -105,6 +105,41 @@ const (
 	EncryptionAlgorithmAES256GCM EncryptionAlgorithm = "aes256-gcm"
 )
 
+type KeyringRotateRootKeyRequest struct {
+	Algorithm EncryptionAlgorithm
+	Full      bool
+	WriteRequest
+}
+
+// KeyringRotateRootKeyResponse returns the full key metadata
+type KeyringRotateRootKeyResponse struct {
+	Key *RootKeyMeta
+	WriteMeta
+}
+
+type KeyringListRootKeyMetaRequest struct {
+	// TODO: do we need any fields here?
+	QueryOptions
+}
+
+type KeyringListRootKeyMetaResponse struct {
+	Keys []*RootKeyMeta
+	QueryMeta
+}
+
+// KeyringUpdateRootKeyRequest is used internally for key replication
+// only and for keyring restores. The RootKeyMeta will be extracted
+// for applying to the FSM with the KeyringUpdateRootKeyMetaRequest
+// (see below)
+type KeyringUpdateRootKeyRequest struct {
+	RootKey *RootKey
+	WriteRequest
+}
+
+type KeyringUpdateRootKeyResponse struct {
+	WriteMeta
+}
+
 // KeyringUpdateRootKeyMetaRequest is used internally for key
 // replication so that we have a request wrapper for writing the
 // metadata to the FSM without including the key material

--- a/nomad/structs/secure_variables.go
+++ b/nomad/structs/secure_variables.go
@@ -6,7 +6,7 @@ import "time"
 type SecureVariable struct {
 	Namespace   string
 	Path        string
-	CreatedAt   time.Time
+	CreateTime  time.Time
 	CreateIndex uint64
 	ModifyIndex uint64
 	ModifyTime  time.Time
@@ -91,7 +91,7 @@ type RootKeyMeta struct {
 	KeyID            string // UUID
 	Algorithm        EncryptionAlgorithm
 	EncryptionsCount uint64
-	CreatedAt        time.Time
+	CreateTime       time.Time
 	CreateIndex      uint64
 	ModifyIndex      uint64
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -108,6 +108,10 @@ const (
 	ServiceRegistrationUpsertRequestType         MessageType = 47
 	ServiceRegistrationDeleteByIDRequestType     MessageType = 48
 	ServiceRegistrationDeleteByNodeIDRequestType MessageType = 49
+	SecureVariableUpsertRequestType              MessageType = 50
+	SecureVariableDeleteRequestType              MessageType = 51
+	RootKeyMetaUpsertRequestType                 MessageType = 52
+	RootKeyMetaDeleteRequestType                 MessageType = 53
 
 	// Namespace types were moved from enterprise and therefore start at 64
 	NamespaceUpsertRequestType MessageType = 64


### PR DESCRIPTION
This changeset is a mostly-empty implementation of the memdb schema and state store operations we'll need for https://github.com/hashicorp/nomad/issues/12802. 

Nothing here has gone through RFC review yet, so it'll likely need to be revised, but this can serve as a skeleton for us to do little spikes as part of the design process. Implementations are largely incomplete.