### PR TITLE
build: use new version of hc-install

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -137,7 +137,7 @@ deps:  ## Install build and development dependencies
 	go install github.com/bufbuild/buf/cmd/buf@v0.36.0
 	go install github.com/hashicorp/go-changelog/cmd/changelog-build@latest
 	go install golang.org/x/tools/cmd/stringer@v0.1.8
-	go install gophers.dev/cmds/hc-install/cmd/hc-install@v1.0.1
+	go install gophers.dev/cmds/hc-install/cmd/hc-install@v1.0.2
 
 .PHONY: lint-deps
 lint-deps: ## Install linter dependencies


### PR DESCRIPTION
https://github.com/shoenig/hc-install/pull/2

Uses new version of hc-install which supports the new
json content type reported by api.releases.hashicorp.com
