### PR TITLE
docs: add `sysbatch` to scheduling internals

### DIFF
--- a/website/content/docs/internals/scheduling/scheduling.mdx
+++ b/website/content/docs/internals/scheduling/scheduling.mdx
@@ -39,9 +39,9 @@ Nomad servers run scheduling workers, defaulting to one per CPU core, which are
 used to process evaluations. The workers dequeue evaluations from the broker,
 and then invoke the appropriate scheduler as specified by the job. Nomad ships
 with a `service` scheduler that optimizes for long-lived services, a `batch`
-scheduler that is used for fast placement of batch jobs, a `system` scheduler
-that is used to run jobs on every node, and a `core` scheduler which is used
-for internal maintenance.
+scheduler that is used for fast placement of batch jobs, `system` and
+`sysbatch` schedulers that are used to run jobs on every node, and a `core`
+scheduler which is used for internal maintenance.
 
 Schedulers are responsible for processing an evaluation and generating an
 allocation _plan_. The plan is the set of allocations to evict, update, or


### PR DESCRIPTION
We could definitely write more about it here, but I just wanted to get the smallest possible correction out first.