### PR TITLE
Add nomad env to envoy bootstrap

### DIFF
--- a/.changelog/12959.txt
+++ b/.changelog/12959.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: add nomad environment variables to envoy bootstrap
+```

--- a/client/allocrunner/taskrunner/envoy_bootstrap_hook.go
+++ b/client/allocrunner/taskrunner/envoy_bootstrap_hook.go
@@ -292,6 +292,8 @@ func (h *envoyBootstrapHook) Prestart(ctx context.Context, req *ifs.TaskPrestart
 
 	// Create environment
 	bootstrapEnv := bootstrap.env(os.Environ())
+	// append nomad environment variables to the bootstrap environment
+	bootstrapEnv = append(bootstrapEnv, h.groupEnv()...)
 
 	// Write env to file for debugging
 	envFile, err := os.Create(bootstrapEnvPath)
@@ -375,6 +377,19 @@ func (h *envoyBootstrapHook) Prestart(ctx context.Context, req *ifs.TaskPrestart
 	}
 
 	return nil
+}
+
+func (h *envoyBootstrapHook) groupEnv() []string {
+	return []string{
+		fmt.Sprintf("%s=%s", taskenv.AllocID, h.alloc.ID),
+		fmt.Sprintf("%s=%s", taskenv.ShortAllocID, h.alloc.ID[:8]),
+		fmt.Sprintf("%s=%s", taskenv.AllocName, h.alloc.Name),
+		fmt.Sprintf("%s=%s", taskenv.GroupName, h.alloc.TaskGroup),
+		fmt.Sprintf("%s=%s", taskenv.JobName, h.alloc.Job.Name),
+		fmt.Sprintf("%s=%s", taskenv.JobID, h.alloc.Job.ID),
+		fmt.Sprintf("%s=%s", taskenv.Namespace, h.alloc.Namespace),
+		fmt.Sprintf("%s=%s", taskenv.Region, h.alloc.Job.Region),
+	}
 }
 
 // buildEnvoyAdminBind determines a unique port for use by the envoy admin listener.


### PR DESCRIPTION
Just saw #12543 .We are doing things a bit different in a fork we have. This PR takes a different aproach and adds enviroment variables to the envoy boostrap hook. This along with https://github.com/hashicorp/consul/pull/13049 allow us to configure things like the following in the consul configuration:

```
kind = "proxy-defaults"
name = "global"

Config {
      envoy_dogstatsd_url = "udp://172.26.64.1:9125"
      envoy_stats_tags = [
        "alloc_id=${NOMAD_ALLOC_ID}",
        "nomad_group=${NOMAD_GROUP_NAME}",
        "nomad_job=${NOMAD_JOB_NAME}",
        "nomad_namespace=${NOMAD_NAMESPACE}",
      ]
}
```
This can also be set on the nomad sidecar configuration.
