### PR TITLE
agent: fix panic when logging about protocol version config use.

### DIFF
--- a/.changelog/12962.txt
+++ b/.changelog/12962.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: fixed a panic on startup when the `server.protocol_version` config parameter was set
+```

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -436,7 +436,7 @@ func (c *Command) IsValidConfig(config, cmdConfig *Config) bool {
 	// ProtocolVersion has never been used. Warn if it is set as someone
 	// has probably made a mistake.
 	if config.Server.ProtocolVersion != 0 {
-		c.agent.logger.Warn("Please remove deprecated protocol_version field from config.")
+		c.Ui.Warn("Please remove deprecated protocol_version field from config.")
 	}
 
 	return true


### PR DESCRIPTION
The log line comes before the agent logger has been setup,
therefore we need to use the UI logging to avoid panic.