### PR TITLE
Visual diff tests seed-stabilized by default

### DIFF
--- a/ui/.percy.yml
+++ b/ui/.percy.yml
@@ -5,6 +5,8 @@ snapshot:
     .topo-viz { 
       display: none;
     }
-    .related-evaluations path, .related-evaluations circle {
+    .related-evaluations path,
+    .related-evaluations circle
+    .dashboard-metric {
       visibility: hidden;
     }

--- a/ui/.percy.yml
+++ b/ui/.percy.yml
@@ -2,6 +2,9 @@ version: 1
 snapshot:
   # Hide high-variability data from Percy snapshots; helps make sure that randomized data doesn't cause a visual diff.
   percy-css: | 
-    topo-viz { 
+    .topo-viz { 
       display: none;
+    }
+    .related-evaluations path, .related-evaluations circle {
+      visibility: hidden;
     }

--- a/ui/.percy.yml
+++ b/ui/.percy.yml
@@ -1,4 +1,7 @@
 version: 1
 snapshot:
   # Hide high-variability data from Percy snapshots; helps make sure that randomized data doesn't cause a visual diff.
-  percy-css: ""
+  percy-css: | 
+    topo-viz { 
+      display: none;
+    }

--- a/ui/.percy.yml
+++ b/ui/.percy.yml
@@ -1,7 +1,4 @@
 version: 1
 snapshot:
   # Hide high-variability data from Percy snapshots; helps make sure that randomized data doesn't cause a visual diff.
-  percy-css: | 
-    table td { 
-      visibility: hidden;
-    }
+  percy-css: ""

--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -6,6 +6,12 @@ if (process.env.USE_MIRAGE) {
   USE_MIRAGE = process.env.USE_MIRAGE == 'true';
 }
 
+let USE_PERCY = true;
+
+if (process.env.USE_PERCY) {
+  USE_PERCY = process.env.USE_PERCY == 'true';
+}
+
 module.exports = function (environment) {
   let ENV = {
     modulePrefix: 'nomad-ui',
@@ -30,6 +36,10 @@ module.exports = function (environment) {
       mirageWithTokens: true,
       mirageWithRegions: true,
       showStorybookLink: process.env.STORYBOOK_LINK === 'true',
+    },
+
+    percy: {
+      enabled: USE_PERCY,
     },
   };
 

--- a/ui/mirage/faker.js
+++ b/ui/mirage/faker.js
@@ -3,7 +3,11 @@ import config from 'nomad-ui/config/environment';
 
 const searchIncludesSeed = window.location.search.includes('faker-seed');
 
-if (config.environment !== 'test' || searchIncludesSeed) {
+if (
+  config.environment !== 'test' ||
+  config.percy.enabled ||
+  searchIncludesSeed
+) {
   if (searchIncludesSeed) {
     const params = new URLSearchParams(window.location.search);
     const seed = parseInt(params.get('faker-seed'));

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,6 +21,7 @@
     "storybook": "STORYBOOK=true start-storybook -p 6006 -s dist",
     "test": "npm-run-all lint test:*",
     "test:ember": "percy exec -- ember test",
+    "test:ember-seedless": "USE_PERCY=false ember test",
     "local:qunitdom": "ember test --server --query=dockcontainer",
     "local:exam": "ember exam --server --load-balance --parallel=4"
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,9 +21,9 @@
     "storybook": "STORYBOOK=true start-storybook -p 6006 -s dist",
     "test": "npm-run-all lint test:*",
     "test:ember": "percy exec -- ember test",
-    "test:ember-seedless": "USE_PERCY=false ember test",
     "local:qunitdom": "ember test --server --query=dockcontainer",
-    "local:exam": "ember exam --server --load-balance --parallel=4"
+    "local:exam": "ember exam --server --load-balance --parallel=4",
+    "seedless-test": "USE_PERCY=false ember test"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Resolves #12964

- Sets a seed on test fixtures to get visual diff tests running with the same dataset
- Removes percy-css (previous attempt at stabilization)
- Introduces a `USE_PERCY` environment variable that can be set for local runs, and `test:ember-seedless` to ~still run our test suite~ be run locally as needed with random data (but without Percy snapshots)

## Why remove fixture/stub randomization?

Our UI tests straddle a line between "Be reliable and idempotent" and "Catch bugs with randomization". Last week, when we pushed our Percy visual diff tests up, we opted to maintain randomized test data in order to allow for more potential style bugs to be found.

We overcame the random differences in tests by applying `percy-css` to our test config, that would grey-out all tables (the main sources of conflicting visuals). Not only is this a hedge away from randomization (tables were where we might have caught more bugs), but it was also insufficient: random data in tables means that they might have been taller or wider in some test runs than others.

This proved to be the case, and after a week in production, visual differences are still happening in ~50% of our snapshots for ~100% of our tests.

Thus, the default test run for `test-ui` will now run with a set seed, so data will no longer be randomized.

## Two more paths forward

~This PR maintains a test using randomized data, that runs in addition to a seeded test. The randomized one, however, does not run Percy/visual-diff snapshots.~

~The thing to watch for here is if this extends our test run significantly. test-ui is currently a 12 minute runtime. Hoping that test:ember-seedless does not impact this too badly.~

^--- after a test run: this increases run time by ~10 minutes, which is too long. I'm dropping the randomized tests from the `test:*` suite, and leaving it available to be run locally if desired.
