### PR TITLE
docs: link s/port-plan-failure to more helpful doc

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -198,7 +198,7 @@ module.exports = [
   // change its destination in the future.
   {
     source: '/s/port-plan-failure',
-    destination: 'https://github.com/hashicorp/nomad/issues/9506',
+    destination: '/docs/operations/monitoring-nomad#progress',
     permanent: false,
   },
 


### PR DESCRIPTION
The shortlink /s/port-plan-failure is logged when a plan for a node is
rejected to help users debug and mitigate repeated `plan for node
rejected` failures.

The current link to #9506 is... less than useful. It is not clear to
users what steps they should take to either fix their cluster or
contribute to the issue.

While .[../monitoring-nomad#progess](https://www.nomadproject.io/docs/operations/monitoring-nomad#progress) isn't as comprehensive as it could
be, it's a much more gentle introduction to the class of bug than the
original issue.

(Thanks to @mmcquillan for pointing this out!)