### PR TITLE
website: set dependabot assignees

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,9 @@ updates:
   - package-ecosystem: npm
     directory: "/website"
     schedule:
-      interval: daily
+      interval: weekly
+    assignees:
+      - @hashicorp/web-platform
     labels:
       - "theme/dependencies"
       - "theme/website"


### PR DESCRIPTION
The website build code has been moved out to another repository, so
what's remaining here is local development tooling. Assign these PRs to
the web platform team, but also cut down on the noise we're sending
their way.