### PR TITLE
docs: remove beta tag for CSI from sidebar

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1281,7 +1281,7 @@
         "path": "job-specification/constraint"
       },
       {
-        "title": "csi_plugin <sup>Beta</sup>",
+        "title": "csi_plugin",
         "path": "job-specification/csi_plugin"
       },
       {


### PR DESCRIPTION
I managed to remove this from the UI but missed it on the docs sidebar!