### PR TITLE
Provide mock secure variables implementation

### DIFF
--- a/command/agent/secure_variable_endpoint.go
+++ b/command/agent/secure_variable_endpoint.go
@@ -31,26 +31,26 @@ func (s *HTTPServer) SecureVariablesListRequest(resp http.ResponseWriter, req *h
 }
 
 func (s *HTTPServer) SecureVariableSpecificRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	name := strings.TrimPrefix(req.URL.Path, "/v1/var/")
-	if len(name) == 0 {
+	path := strings.TrimPrefix(req.URL.Path, "/v1/var/")
+	if len(path) == 0 {
 		return nil, CodedError(400, "Missing secure variable path")
 	}
 	switch req.Method {
 	case "GET":
-		return s.SecureVariableQuery(resp, req, name)
+		return s.secureVariableQuery(resp, req, path)
 	case "PUT", "POST":
-		return s.SecureVariableUpsert(resp, req, name)
+		return s.secureVariableUpsert(resp, req, path)
 	case "DELETE":
-		return s.SecureVariableDelete(resp, req, name)
+		return s.secureVariableDelete(resp, req, path)
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 }
 
-func (s *HTTPServer) SecureVariableQuery(resp http.ResponseWriter, req *http.Request,
-	SecureVariablePath string) (interface{}, error) {
+func (s *HTTPServer) secureVariableQuery(resp http.ResponseWriter, req *http.Request,
+	path string) (interface{}, error) {
 	args := structs.SecureVariablesReadRequest{
-		Path: SecureVariablePath,
+		Path: path,
 	}
 	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
 		return nil, nil
@@ -69,14 +69,14 @@ func (s *HTTPServer) SecureVariableQuery(resp http.ResponseWriter, req *http.Req
 	return out.Data, nil
 }
 
-func (s *HTTPServer) SecureVariableUpsert(resp http.ResponseWriter, req *http.Request,
-	SecureVariablePath string) (interface{}, error) {
+func (s *HTTPServer) secureVariableUpsert(resp http.ResponseWriter, req *http.Request,
+	path string) (interface{}, error) {
 	// Parse the SecureVariable
 	var SecureVariable structs.SecureVariable
 	if err := decodeBody(req, &SecureVariable); err != nil {
 		return nil, CodedError(http.StatusBadRequest, err.Error())
 	}
-	SecureVariable.Path = SecureVariablePath
+	SecureVariable.Path = path
 	// Format the request
 	args := structs.SecureVariablesUpsertRequest{
 		Data: &SecureVariable,
@@ -92,11 +92,11 @@ func (s *HTTPServer) SecureVariableUpsert(resp http.ResponseWriter, req *http.Re
 	return nil, nil
 }
 
-func (s *HTTPServer) SecureVariableDelete(resp http.ResponseWriter, req *http.Request,
-	SecureVariablePath string) (interface{}, error) {
+func (s *HTTPServer) secureVariableDelete(resp http.ResponseWriter, req *http.Request,
+	path string) (interface{}, error) {
 
 	args := structs.SecureVariablesDeleteRequest{
-		Path: SecureVariablePath,
+		Path: path,
 	}
 	s.parseWriteRequest(req, &args.WriteRequest)
 

--- a/command/agent/secure_variable_endpoint.go
+++ b/command/agent/secure_variable_endpoint.go
@@ -1,0 +1,109 @@
+package agent
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+func (s *HTTPServer) SecureVariablesListRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if req.Method != "GET" {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+	args := structs.SecureVariablesListRequest{}
+	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
+		return nil, nil
+	}
+
+	var out structs.SecureVariablesListResponse
+	if err := s.agent.RPC("SecureVariables.List", &args, &out); err != nil {
+		return nil, err
+	}
+
+	setMeta(resp, &out.QueryMeta)
+
+	if out.Data == nil {
+		out.Data = make([]*structs.SecureVariableStub, 0)
+	}
+	return out.Data, nil
+}
+
+func (s *HTTPServer) SecureVariableSpecificRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	name := strings.TrimPrefix(req.URL.Path, "/v1/var/")
+	if len(name) == 0 {
+		return nil, CodedError(400, "Missing secure variable path")
+	}
+	switch req.Method {
+	case "GET":
+		return s.SecureVariableQuery(resp, req, name)
+	case "PUT", "POST":
+		return s.SecureVariableUpsert(resp, req, name)
+	case "DELETE":
+		return s.SecureVariableDelete(resp, req, name)
+	default:
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+}
+
+func (s *HTTPServer) SecureVariableQuery(resp http.ResponseWriter, req *http.Request,
+	SecureVariablePath string) (interface{}, error) {
+	args := structs.SecureVariablesReadRequest{
+		Path: SecureVariablePath,
+	}
+	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
+		return nil, nil
+	}
+
+	var out structs.SecureVariablesReadResponse
+	if err := s.agent.RPC("SecureVariables.Read", &args, &out); err != nil {
+		return nil, err
+	}
+
+	setMeta(resp, &out.QueryMeta)
+
+	if out.Data == nil {
+		return nil, CodedError(404, "Secure variable not found")
+	}
+	return out.Data, nil
+}
+
+func (s *HTTPServer) SecureVariableUpsert(resp http.ResponseWriter, req *http.Request,
+	SecureVariablePath string) (interface{}, error) {
+	// Parse the SecureVariable
+	var SecureVariable structs.SecureVariable
+	if err := decodeBody(req, &SecureVariable); err != nil {
+		return nil, CodedError(http.StatusBadRequest, err.Error())
+	}
+	SecureVariable.Path = SecureVariablePath
+	// Format the request
+	args := structs.SecureVariablesUpsertRequest{
+		Data: &SecureVariable,
+	}
+	s.parseWriteRequest(req, &args.WriteRequest)
+
+	var out structs.SecureVariablesUpsertResponse
+	if err := s.agent.RPC("SecureVariables.Update", &args, &out); err != nil {
+		return nil, err
+	}
+	setIndex(resp, out.WriteMeta.Index)
+
+	return nil, nil
+}
+
+func (s *HTTPServer) SecureVariableDelete(resp http.ResponseWriter, req *http.Request,
+	SecureVariablePath string) (interface{}, error) {
+
+	args := structs.SecureVariablesDeleteRequest{
+		Path: SecureVariablePath,
+	}
+	s.parseWriteRequest(req, &args.WriteRequest)
+
+	var out structs.SecureVariablesDeleteResponse
+	if err := s.agent.RPC("SecureVariables.Delete", &args, &out); err != nil {
+		return nil, err
+	}
+	setIndex(resp, out.WriteMeta.Index)
+	return nil, nil
+}

--- a/command/agent/secure_variable_endpoint.go
+++ b/command/agent/secure_variable_endpoint.go
@@ -33,17 +33,17 @@ func (s *HTTPServer) SecureVariablesListRequest(resp http.ResponseWriter, req *h
 func (s *HTTPServer) SecureVariableSpecificRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	path := strings.TrimPrefix(req.URL.Path, "/v1/var/")
 	if len(path) == 0 {
-		return nil, CodedError(400, "Missing secure variable path")
+		return nil, CodedError(http.StatusBadRequest, "Missing secure variable path")
 	}
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		return s.secureVariableQuery(resp, req, path)
-	case "PUT", "POST":
+	case http.MethodPut, http.MethodPost:
 		return s.secureVariableUpsert(resp, req, path)
-	case "DELETE":
+	case http.MethodDelete:
 		return s.secureVariableDelete(resp, req, path)
 	default:
-		return nil, CodedError(405, ErrInvalidMethod)
+		return nil, CodedError(http.StatusBadRequest, ErrInvalidMethod)
 	}
 }
 

--- a/command/agent/secure_variable_endpoint_test.go
+++ b/command/agent/secure_variable_endpoint_test.go
@@ -1,0 +1,261 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTP_SecureVariableList(t *testing.T) {
+	//ci.Parallel(t)
+	cb := func(c *Config) {
+		var ns int
+		ns = 0
+		c.LogLevel = "ERROR"
+		c.Server.NumSchedulers = &ns
+	}
+	httpTest(t, cb, func(s *TestAgent) {
+		// Test the empty list case
+		req, err := http.NewRequest("GET", "/v1/vars", nil)
+		require.NoError(t, err)
+		respW := httptest.NewRecorder()
+
+		// Make the request
+		obj, err := s.Server.SecureVariablesListRequest(respW, req)
+		require.NoError(t, err)
+
+		// add vars and test a populated backend
+		sv1 := mock.SecureVariable()
+		sv2 := mock.SecureVariable()
+		sv3 := mock.SecureVariable()
+		sv4 := mock.SecureVariable()
+		sv4.Path = sv1.Path + "/child"
+		for _, sv := range []*structs.SecureVariable{sv1, sv2, sv3, sv4} {
+			args := structs.SecureVariablesUpsertRequest{
+				Data:         sv,
+				WriteRequest: structs.WriteRequest{Region: "global"},
+			}
+			spew.Config.Indent = "|  "
+			spew.Dump(args)
+			var resp structs.SecureVariablesUpsertResponse
+			require.Nil(t, s.Agent.RPC("SecureVariables.UpsertSecureVariables", &args, &resp))
+		}
+		// Make the HTTP request
+		req, err = http.NewRequest("GET", "/v1/vars", nil)
+		require.NoError(t, err)
+		respW = httptest.NewRecorder()
+
+		// Make the request
+		obj, err = s.Server.SecureVariablesListRequest(respW, req)
+		require.NoError(t, err)
+
+		// Check for the index
+		require.NotZero(t, respW.HeaderMap.Get("X-Nomad-Index"))
+		require.Equal(t, "true", respW.HeaderMap.Get("X-Nomad-KnownLeader"))
+		require.NotZero(t, respW.HeaderMap.Get("X-Nomad-LastContact"))
+
+		// Check the output (the 3 we register )
+		require.Len(t, obj.([]*structs.SecureVariableStub), 4)
+
+		// test prefix query
+		req, err = http.NewRequest("GET", "/v1/vars?prefix="+sv1.Path, nil)
+		require.NoError(t, err)
+		respW = httptest.NewRecorder()
+
+		// Make the request
+		obj, err = s.Server.SecureVariablesListRequest(respW, req)
+		require.NoError(t, err)
+		require.Len(t, obj.([]*structs.SecureVariableStub), 2)
+
+	})
+}
+
+func TestHTTP_SecureVariableQuery(t *testing.T) {
+	//ci.Parallel(t)
+	httpTest(t, nil, func(s *TestAgent) {
+		// Make a request for a non-existent variable
+		req, err := http.NewRequest("GET", "/v1/var/does/not/exist", nil)
+		require.NoError(t, err)
+		respW := httptest.NewRecorder()
+		obj, err := s.Server.SecureVariableSpecificRequest(respW, req)
+		require.EqualError(t, err, "Secure variable not found")
+
+		// Don't pass a path
+		req, err = http.NewRequest("GET", "/v1/var/", nil)
+		require.NoError(t, err)
+		respW = httptest.NewRecorder()
+		obj, err = s.Server.SecureVariableSpecificRequest(respW, req)
+		require.EqualError(t, err, "Missing secure variable path")
+
+		// Use an incorrect verb
+		req, err = http.NewRequest("LOLWUT", "/v1/var/foo", nil)
+		require.NoError(t, err)
+		respW = httptest.NewRecorder()
+		obj, err = s.Server.SecureVariableSpecificRequest(respW, req)
+		require.EqualError(t, err, ErrInvalidMethod)
+
+		// Use RPC to make testdata
+		sv1 := mock.SecureVariable()
+		args := structs.SecureVariablesUpsertRequest{
+			Data:         sv1,
+			WriteRequest: structs.WriteRequest{Region: "global"},
+		}
+		var resp structs.SecureVariablesUpsertResponse
+		require.Nil(t, s.Agent.RPC("SecureVariables.UpsertSecureVariables", &args, &resp))
+
+		// Query a variable
+		req, err = http.NewRequest("GET", "/v1/var/"+sv1.Path, nil)
+		require.NoError(t, err)
+		respW = httptest.NewRecorder()
+
+		// Make the request
+		obj, err = s.Server.SecureVariableSpecificRequest(respW, req)
+		require.NoError(t, err)
+
+		// Check for the index
+		require.NotZero(t, respW.HeaderMap.Get("X-Nomad-Index"))
+		require.Equal(t, "true", respW.HeaderMap.Get("X-Nomad-KnownLeader"))
+		require.NotZero(t, respW.HeaderMap.Get("X-Nomad-LastContact"))
+
+		// Check the output
+		require.Equal(t, sv1.Path, obj.(*structs.SecureVariable).Path)
+	})
+}
+
+func TestHTTP_SecureVariableCreate(t *testing.T) {
+	//ci.Parallel(t)
+	httpTest(t, nil, func(s *TestAgent) {
+		sv1 := mock.SecureVariable()
+		args := structs.SecureVariablesUpsertRequest{
+			Data:         sv1,
+			WriteRequest: structs.WriteRequest{Region: "global"},
+		}
+		var resp structs.SecureVariablesUpsertResponse
+		require.Nil(t, s.Agent.RPC("SecureVariables.UpsertSecureVariables", &args, &resp))
+
+		// Make a change for update
+		sv1U := sv1.Copy()
+		sv1U.UnencryptedData["newness"] = "awwyeah"
+
+		// Make the HTTP request
+		buf := encodeReq(&sv1U)
+		req, err := http.NewRequest("PUT", "/v1/var/"+sv1.Path, buf)
+		require.NoError(t, err)
+		respW := httptest.NewRecorder()
+
+		// Make the request
+		obj, err := s.Server.SecureVariableSpecificRequest(respW, req)
+		require.NoError(t, err)
+		require.Nil(t, obj)
+
+		// Check for the index
+		require.NotZero(t, respW.HeaderMap.Get("X-Nomad-Index"))
+
+		// Check the variable was created
+		checkArgs := structs.SecureVariablesReadRequest{Path: sv1.Path}
+		var checkResp structs.SecureVariablesReadResponse
+		require.Nil(t, s.Agent.RPC("SecureVariables.UpsertSecureVariables", &checkArgs, &checkResp))
+		require.NotNil(t, checkResp.Data)
+		out := checkResp.Data
+
+		sv1.CreateIndex, sv1.ModifyIndex = out.CreateIndex, out.ModifyIndex
+		require.Equal(t, sv1.Path, out.Path)
+		require.NotEqual(t, sv1, out)
+		require.Contains(t, out.UnencryptedData, "newness")
+
+		// break the request body
+		badBuf := encodeBrokenReq(&sv1U)
+
+		req, err = http.NewRequest("PUT", "/v1/var/"+sv1.Path, badBuf)
+		require.NoError(t, err)
+		respW = httptest.NewRecorder()
+
+		// Make the request
+		obj, err = s.Server.SecureVariableSpecificRequest(respW, req)
+		require.EqualError(t, err, "unexpected EOF")
+		var cErr HTTPCodedError
+		require.ErrorAs(t, err, &cErr)
+		require.Equal(t, http.StatusBadRequest, cErr.Code())
+	})
+}
+
+func TestHTTP_SecureVariableUpdate(t *testing.T) {
+	//ci.Parallel(t)
+	httpTest(t, nil, func(s *TestAgent) {
+		// Make the HTTP request
+		sv1 := *mock.SecureVariable()
+		buf := encodeReq(sv1)
+		req, err := http.NewRequest("PUT", "/v1/var/"+sv1.Path, buf)
+		require.NoError(t, err)
+		respW := httptest.NewRecorder()
+
+		// Make the request
+		obj, err := s.Server.SecureVariableSpecificRequest(respW, req)
+		require.NoError(t, err)
+		require.Nil(t, obj)
+
+		// Check for the index
+		require.NotZero(t, respW.HeaderMap.Get("X-Nomad-Index"))
+
+		// Check the variable was updated
+		checkArgs := structs.SecureVariablesReadRequest{Path: sv1.Path}
+		var checkResp structs.SecureVariablesReadResponse
+		require.Nil(t, s.Agent.RPC("SecureVariables.ReadSecureVariable", &checkArgs, &checkResp))
+		require.NotNil(t, checkResp.Data)
+		out := checkResp.Data
+
+		sv1.CreateIndex, sv1.ModifyIndex = out.CreateIndex, out.ModifyIndex
+		require.Equal(t, sv1.Path, out.Path)
+		require.Equal(t, sv1, out)
+	})
+}
+
+func TestHTTP_SecureVariableDelete(t *testing.T) {
+	//ci.Parallel(t)
+	httpTest(t, nil, func(s *TestAgent) {
+		sv1 := mock.SecureVariable()
+		args := structs.SecureVariablesUpsertRequest{
+			Data:         sv1,
+			WriteRequest: structs.WriteRequest{Region: "global"},
+		}
+		var resp structs.SecureVariablesUpsertResponse
+		require.Nil(t, s.Agent.RPC("SecureVariables.Update", &args, &resp))
+
+		// Make the HTTP request
+		req, err := http.NewRequest("DELETE", "/v1/var/"+sv1.Path, nil)
+		require.NoError(t, err)
+		respW := httptest.NewRecorder()
+
+		// Make the request
+		obj, err := s.Server.SecureVariableSpecificRequest(respW, req)
+		require.NoError(t, err)
+		require.Nil(t, obj)
+
+		// Check for the index
+		require.NotZero(t, respW.HeaderMap.Get("X-Nomad-Index"))
+
+		// Check variable bag was deleted
+		checkArgs := structs.SecureVariablesReadRequest{Path: sv1.Path}
+		var checkResp structs.SecureVariablesReadResponse
+		require.Nil(t, s.Agent.RPC("SecureVariables.UpsertSecureVariables", &checkArgs, &checkResp))
+		require.Nil(t, checkResp.Data)
+	})
+}
+
+func encodeBrokenReq(obj interface{}) io.ReadCloser {
+	// var buf *bytes.Buffer
+	// enc := json.NewEncoder(buf)
+	// enc.Encode(obj)
+	b, _ := json.Marshal(obj)
+	b = b[0 : len(b)-5] // strip newline and final }
+	return ioutil.NopCloser(bytes.NewReader(b))
+}

--- a/go.mod
+++ b/go.mod
@@ -160,6 +160,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.2.0 // indirect
 	github.com/bmatcuk/doublestar v1.1.5 // indirect
 	github.com/boltdb/bolt v1.3.1 // indirect
+	github.com/brianvoe/gofakeit/v6 v6.16.0
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,8 @@ github.com/bmatcuk/doublestar v1.1.5/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
+github.com/brianvoe/gofakeit/v6 v6.16.0 h1:EelCqtfArd8ppJ0z+TpOxXH8sVWNPBadPNdCDSMMw7k=
+github.com/brianvoe/gofakeit/v6 v6.16.0/go.mod h1:Ow6qC71xtwm79anlwKRlWZW6zVq9D2XHE4QSSMP/rU8=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=

--- a/helper/codec/inmem.go
+++ b/helper/codec/inmem.go
@@ -20,6 +20,9 @@ func (i *InmemCodec) ReadRequestHeader(req *rpc.Request) error {
 }
 
 func (i *InmemCodec) ReadRequestBody(args interface{}) error {
+	if args == nil {
+		return nil
+	}
 	sourceValue := reflect.Indirect(reflect.Indirect(reflect.ValueOf(i.Args)))
 	dst := reflect.Indirect(reflect.Indirect(reflect.ValueOf(args)))
 	dst.Set(sourceValue)

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -2309,7 +2309,8 @@ func SecureVariable() *structs.SecureVariable {
 	createIdx := uint64(rand.Intn(100) + 100)
 	createDT := fake.DateRange(time.Now().AddDate(0, -1, 0), time.Now())
 	sv := &structs.SecureVariable{
-		Path: path,
+		Path:      path,
+		Namespace: "default",
 		// CustomMeta: map[string]string{
 		// 	"owner_name":  owner.FirstName + " " + owner.LastName,
 		// 	"owner_email": fmt.Sprintf("%v%s@%s", owner.FirstName[0], owner.LastName, domain),

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -3,8 +3,10 @@ package mock
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
+	fake "github.com/brianvoe/gofakeit/v6"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/envoy"
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -2295,4 +2297,36 @@ func ServiceRegistrations() []*structs.ServiceRegistration {
 			Port:        29000,
 		},
 	}
+}
+
+func SecureVariable() *structs.SecureVariable {
+	envs := []string{"dev", "test", "prod"}
+	envIdx := rand.Intn(3)
+	env := envs[envIdx]
+	domain := fake.DomainName()
+	path := strings.ReplaceAll(env+"."+domain, ".", "/")
+	// owner := fake.Person()
+	createIdx := uint64(rand.Intn(100) + 100)
+	createDT := fake.DateRange(time.Now().AddDate(0, -1, 0), time.Now())
+	sv := &structs.SecureVariable{
+		Path: path,
+		// CustomMeta: map[string]string{
+		// 	"owner_name":  owner.FirstName + " " + owner.LastName,
+		// 	"owner_email": fmt.Sprintf("%v%s@%s", owner.FirstName[0], owner.LastName, domain),
+		// },
+		UnencryptedData: map[string]string{
+			"username": fake.Username(),
+			"password": fake.Password(true, true, true, true, false, 16),
+		},
+		CreateIndex: createIdx,
+		ModifyIndex: createIdx,
+		CreateTime:  createDT,
+		ModifyTime:  createDT,
+	}
+	// Flip a coin to see if we should return a "modified" object
+	if fake.Bool() {
+		sv.ModifyTime = fake.DateRange(sv.CreateTime, time.Now())
+		sv.ModifyIndex = sv.CreateIndex + uint64(rand.Intn(100))
+	}
+	return sv
 }

--- a/nomad/secure_variable_mock.go
+++ b/nomad/secure_variable_mock.go
@@ -1,0 +1,107 @@
+package nomad
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+var mvs MockVariableStore
+
+type MockVariableStore struct {
+	m          sync.RWMutex
+	backingMap map[string]*structs.SecureVariable
+}
+
+func (mvs *MockVariableStore) List(prefix string) []*structs.SecureVariableStub {
+	fmt.Println("***** List *****")
+	mvs.m.Lock()
+	mvs.m.Unlock()
+	if len(mvs.backingMap) == 0 {
+		return nil
+	}
+	vars := make([]*structs.SecureVariableStub, 0, len(mvs.backingMap))
+	for p, sVar := range mvs.backingMap {
+		if strings.HasPrefix(p, prefix) {
+			outVar := sVar.AsStub()
+			vars = append(vars, &outVar)
+		}
+	}
+	return vars
+}
+func (mvs *MockVariableStore) Add(p string, bag structs.SecureVariable) {
+	fmt.Println("***** Add *****")
+	mvs.m.Lock()
+	mvs.m.Unlock()
+	nv := bag.Copy()
+	mvs.backingMap[p] = &nv
+}
+
+func (mvs *MockVariableStore) Get(p string) *structs.SecureVariable {
+	fmt.Println("***** Get *****")
+	var out structs.SecureVariable
+	mvs.m.Lock()
+	defer mvs.m.Unlock()
+
+	if v, ok := mvs.backingMap[p]; ok {
+		out = v.Copy()
+	} else {
+		return nil
+	}
+	return &out
+}
+
+// Delete removes a key from the store. Removing a non-existent key is a no-op
+func (mvs *MockVariableStore) Delete(p string) {
+	fmt.Println("***** Delete *****")
+	mvs.m.Lock()
+	defer mvs.m.Unlock()
+	delete(mvs.backingMap, p)
+}
+
+// Delete removes a key from the store. Removing a non-existent key is a no-op
+func (mvs *MockVariableStore) Reset() {
+	fmt.Println("***** Reset *****")
+	mvs.m.Lock()
+	mvs.m.Unlock()
+	mvs.backingMap = make(map[string]*structs.SecureVariable)
+}
+
+func init() {
+	fmt.Println("***** Initializing mock variables backend *****")
+	mvs.m.Lock()
+	mvs.m.Unlock()
+	mvs.backingMap = make(map[string]*structs.SecureVariable)
+}
+
+func SV_List(args *structs.SecureVariablesListRequest, out *structs.SecureVariablesListResponse) {
+	out.Data = mvs.List(args.Prefix)
+	out.QueryMeta.KnownLeader = true
+	// TODO: Would be nice to at least have a forward moving number for index
+	// even in testing.
+	out.QueryMeta.Index = 999
+	out.QueryMeta.LastContact = 19
+}
+
+func SV_Upsert(args *structs.SecureVariablesUpsertRequest, out *structs.SecureVariablesUpsertResponse) {
+	nv := args.Data.Copy()
+	mvs.Add(nv.Path, nv)
+	// TODO: Would be nice to at least have a forward moving number for index
+	// even in testing.
+	out.WriteMeta.Index = 9999
+}
+func SV_Read(args *structs.SecureVariablesReadRequest, out *structs.SecureVariablesReadResponse) {
+	out.Data = mvs.Get(args.Path)
+	// TODO: Would be nice to at least have a forward moving number for index
+	// even in testing.
+	out.Index = 9999
+	out.QueryMeta.KnownLeader = true
+	out.QueryMeta.Index = 999
+	out.QueryMeta.LastContact = 19
+}
+func SV_Delete(args *structs.SecureVariablesDeleteRequest, out *structs.SecureVariablesDeleteResponse) {
+	mvs.Delete(args.Path)
+	out.WriteMeta.Index = 9999
+}

--- a/nomad/secure_variable_mock_test.go
+++ b/nomad/secure_variable_mock_test.go
@@ -1,0 +1,28 @@
+package nomad
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockVariables(t *testing.T) {
+	defer mvs.Reset()
+	sv1 := mock.SecureVariable()
+	mvs.Add(sv1.Path, *sv1)
+	out := mvs.List("")
+	require.NotNil(t, out)
+	require.Len(t, out, 1)
+}
+
+func TestDeleteMockVariables(t *testing.T) {
+	defer mvs.Reset()
+	sv1 := mock.SecureVariable()
+	mvs.Add(sv1.Path, *sv1)
+	out := mvs.List("")
+	require.NotNil(t, out)
+	require.Len(t, out, 1)
+	mvs.Delete(sv1.Path)
+	require.Empty(t, mvs.List(""))
+}

--- a/nomad/secure_variables_endpoint.go
+++ b/nomad/secure_variables_endpoint.go
@@ -43,6 +43,9 @@ func (sv *SecureVariables) Create(args *structs.SecureVariablesUpsertRequest, re
 	}
 	args.Data.EncryptedData.Data = sv.encrypter.Encrypt(buf.Bytes(), "TODO")
 
+	// TODO: implementation
+	SV_Upsert(args, reply)
+
 	return nil
 }
 
@@ -61,6 +64,7 @@ func (sv *SecureVariables) List(args *structs.SecureVariablesListRequest, reply 
 	}
 
 	// TODO: implementation
+	SV_List(args, reply)
 
 	return nil
 }
@@ -80,6 +84,7 @@ func (sv *SecureVariables) Read(args *structs.SecureVariablesReadRequest, reply 
 	}
 
 	// TODO: implementation
+	SV_Read(args, reply)
 
 	return nil
 }
@@ -99,6 +104,27 @@ func (sv *SecureVariables) Update(args *structs.SecureVariablesUpsertRequest, re
 	}
 
 	// TODO: implementation
+	SV_Upsert(args, reply)
+
+	return nil
+}
+
+func (sv *SecureVariables) Delete(args *structs.SecureVariablesDeleteRequest, reply *structs.SecureVariablesDeleteResponse) error {
+	if done, err := sv.srv.forward("SecureVariables.Delete", args, args, reply); done {
+		return err
+	}
+
+	defer metrics.MeasureSince([]string{"nomad", "secure_variables", "delete"}, time.Now())
+
+	// TODO: implement real ACL checks
+	if aclObj, err := sv.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
+	// TODO: implementation
+	SV_Delete(args, reply)
 
 	return nil
 }

--- a/nomad/secure_variables_endpoint.go
+++ b/nomad/secure_variables_endpoint.go
@@ -41,7 +41,10 @@ func (sv *SecureVariables) Create(args *structs.SecureVariablesUpsertRequest, re
 	if err != nil {
 		return err
 	}
-	args.Data.EncryptedData.Data = sv.encrypter.Encrypt(buf.Bytes(), "TODO")
+
+	args.Data.EncryptedData = &structs.SecureVariableData{}
+	args.Data.EncryptedData.KeyID = "TODO"
+	args.Data.EncryptedData.Data = sv.encrypter.Encrypt(buf.Bytes(), args.Data.EncryptedData.KeyID)
 
 	// TODO: implementation
 	SV_Upsert(args, reply)

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -279,6 +279,7 @@ type endpoints struct {
 	Enterprise          *EnterpriseEndpoints
 	Event               *Event
 	Namespace           *Namespace
+	SecureVariables     *SecureVariables
 	ServiceRegistration *ServiceRegistration
 
 	// Client endpoints
@@ -1159,6 +1160,7 @@ func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) {
 		s.staticEndpoints.System = &System{srv: s, logger: s.logger.Named("system")}
 		s.staticEndpoints.Search = &Search{srv: s, logger: s.logger.Named("search")}
 		s.staticEndpoints.Namespace = &Namespace{srv: s}
+		s.staticEndpoints.SecureVariables = &SecureVariables{srv: s, logger: s.logger.Named("search"), encrypter: NewEncrypter()}
 		s.staticEndpoints.Enterprise = NewEnterpriseEndpoints(s)
 
 		// These endpoints are dynamic because they need access to the
@@ -1206,6 +1208,7 @@ func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) {
 	server.Register(s.staticEndpoints.FileSystem)
 	server.Register(s.staticEndpoints.Agent)
 	server.Register(s.staticEndpoints.Namespace)
+	server.Register(s.staticEndpoints.SecureVariables)
 
 	// Create new dynamic endpoints and add them to the RPC server.
 	alloc := &Alloc{srv: s, ctx: ctx, logger: s.logger.Named("alloc")}

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1160,7 +1160,7 @@ func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) {
 		s.staticEndpoints.System = &System{srv: s, logger: s.logger.Named("system")}
 		s.staticEndpoints.Search = &Search{srv: s, logger: s.logger.Named("search")}
 		s.staticEndpoints.Namespace = &Namespace{srv: s}
-		s.staticEndpoints.SecureVariables = &SecureVariables{srv: s, logger: s.logger.Named("search"), encrypter: NewEncrypter()}
+		s.staticEndpoints.SecureVariables = &SecureVariables{srv: s, logger: s.logger.Named("secure_variables"), encrypter: NewEncrypter()}
 		s.staticEndpoints.Enterprise = NewEnterpriseEndpoints(s)
 
 		// These endpoints are dynamic because they need access to the

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -462,6 +462,10 @@ func NewServer(config *Config, consulCatalog consul.CatalogAPI, consulConfigEntr
 	// Start enterprise background workers
 	s.startEnterpriseBackground()
 
+	// FIXME: Remove once real implemenation exists
+	// Start Mock Secure Variables Server
+	go NewMockVariableStore(s, s.logger.Named("secure_variables"))
+
 	// Done
 	return s, nil
 }

--- a/nomad/structs/secure_variables.go
+++ b/nomad/structs/secure_variables.go
@@ -28,6 +28,24 @@ type SecureVariableData struct {
 	KeyID string // ID of root key used to encrypt this entry
 }
 
+// SecureVariableStub is the metadata envelope for a Secure Variable omitting
+// the actual data. Intended to be used in list operations.
+type SecureVariableStub struct {
+	Namespace   string
+	Path        string
+	CreateTime  time.Time
+	CreateIndex uint64
+	ModifyIndex uint64
+	ModifyTime  time.Time
+
+	// reserved for post-1.4.0 work
+	// LockIndex      uint64
+	// Session        string
+	// DeletedAt      time.Time
+	// Version        uint64
+	// CustomMetaData map[string]string
+}
+
 // SecureVariablesQuota is used to track the total size of secure
 // variables entries per namespace. The total length of
 // SecureVariable.EncryptedData will be added to the SecureVariablesQuota
@@ -54,7 +72,7 @@ type SecureVariablesListRequest struct {
 }
 
 type SecureVariablesListResponse struct {
-	Data []*SecureVariable
+	Data []*SecureVariableStub
 	QueryMeta
 }
 

--- a/nomad/structs/secure_variables.go
+++ b/nomad/structs/secure_variables.go
@@ -18,8 +18,8 @@ type SecureVariable struct {
 	// Version        uint64
 	// CustomMetaData map[string]string
 
-	EncryptedData   *SecureVariableData // removed during serialization
-	UnencryptedData map[string]string   // empty until serialized
+	EncryptedData   *SecureVariableData `json:"-"`     // removed during serialization
+	UnencryptedData map[string]string   `json:"Items"` // empty until serialized
 }
 
 // SecureVariableData is the secret data for a Secure Variable
@@ -39,17 +39,21 @@ func (sv SecureVariableData) Copy() *SecureVariableData {
 
 func (sv SecureVariable) Copy() SecureVariable {
 	out := SecureVariable{
-		Namespace:       sv.Namespace,
-		Path:            sv.Path,
-		CreateIndex:     sv.CreateIndex,
-		CreateTime:      sv.CreateTime,
-		ModifyIndex:     sv.ModifyIndex,
-		ModifyTime:      sv.ModifyTime,
-		UnencryptedData: make(map[string]string, len(sv.UnencryptedData)),
-		EncryptedData:   sv.EncryptedData.Copy(),
+		Namespace:   sv.Namespace,
+		Path:        sv.Path,
+		CreateIndex: sv.CreateIndex,
+		CreateTime:  sv.CreateTime,
+		ModifyIndex: sv.ModifyIndex,
+		ModifyTime:  sv.ModifyTime,
 	}
-	for k, v := range sv.UnencryptedData {
-		out.UnencryptedData[k] = v
+	if sv.UnencryptedData != nil {
+		out.UnencryptedData = make(map[string]string, len(sv.UnencryptedData))
+		for k, v := range sv.UnencryptedData {
+			out.UnencryptedData[k] = v
+		}
+	}
+	if sv.EncryptedData != nil {
+		out.EncryptedData = sv.EncryptedData.Copy()
 	}
 	return out
 }

--- a/nomad/structs/secure_variables.go
+++ b/nomad/structs/secure_variables.go
@@ -28,6 +28,43 @@ type SecureVariableData struct {
 	KeyID string // ID of root key used to encrypt this entry
 }
 
+func (sv SecureVariableData) Copy() *SecureVariableData {
+	out := make([]byte, len(sv.Data))
+	copy(out, sv.Data)
+	return &SecureVariableData{
+		Data:  out,
+		KeyID: sv.KeyID,
+	}
+}
+
+func (sv SecureVariable) Copy() SecureVariable {
+	out := SecureVariable{
+		Namespace:       sv.Namespace,
+		Path:            sv.Path,
+		CreateIndex:     sv.CreateIndex,
+		CreateTime:      sv.CreateTime,
+		ModifyIndex:     sv.ModifyIndex,
+		ModifyTime:      sv.ModifyTime,
+		UnencryptedData: make(map[string]string, len(sv.UnencryptedData)),
+		EncryptedData:   sv.EncryptedData.Copy(),
+	}
+	for k, v := range sv.UnencryptedData {
+		out.UnencryptedData[k] = v
+	}
+	return out
+}
+
+func (sv SecureVariable) AsStub() SecureVariableStub {
+	return SecureVariableStub{
+		Namespace:   sv.Namespace,
+		Path:        sv.Path,
+		CreateIndex: sv.CreateIndex,
+		CreateTime:  sv.CreateTime,
+		ModifyIndex: sv.ModifyIndex,
+		ModifyTime:  sv.ModifyTime,
+	}
+}
+
 // SecureVariableStub is the metadata envelope for a Secure Variable omitting
 // the actual data. Intended to be used in list operations.
 type SecureVariableStub struct {

--- a/nomad/structs/secure_variables.go
+++ b/nomad/structs/secure_variables.go
@@ -29,7 +29,7 @@ type SecureVariableData struct {
 }
 
 func (sv SecureVariableData) Copy() *SecureVariableData {
-	out := make([]byte, len(sv.Data))
+	out := make([]byte, 0, len(sv.Data))
 	copy(out, sv.Data)
 	return &SecureVariableData{
 		Data:  out,

--- a/nomad/structs/secure_variables.go
+++ b/nomad/structs/secure_variables.go
@@ -37,15 +37,11 @@ func (sv SecureVariableData) Copy() *SecureVariableData {
 	}
 }
 
-func (sv SecureVariable) Copy() SecureVariable {
-	out := SecureVariable{
-		Namespace:   sv.Namespace,
-		Path:        sv.Path,
-		CreateIndex: sv.CreateIndex,
-		CreateTime:  sv.CreateTime,
-		ModifyIndex: sv.ModifyIndex,
-		ModifyTime:  sv.ModifyTime,
+func (sv *SecureVariable) Copy() *SecureVariable {
+	if sv == nil {
+		return nil
 	}
+	out := *sv
 	if sv.UnencryptedData != nil {
 		out.UnencryptedData = make(map[string]string, len(sv.UnencryptedData))
 		for k, v := range sv.UnencryptedData {
@@ -55,10 +51,10 @@ func (sv SecureVariable) Copy() SecureVariable {
 	if sv.EncryptedData != nil {
 		out.EncryptedData = sv.EncryptedData.Copy()
 	}
-	return out
+	return &out
 }
 
-func (sv SecureVariable) AsStub() SecureVariableStub {
+func (sv SecureVariable) Stub() SecureVariableStub {
 	return SecureVariableStub{
 		Namespace:   sv.Namespace,
 		Path:        sv.Path,


### PR DESCRIPTION
This PR provides a minimal backend to test the secure variable API. 

 ⚠️ **Warning** ⚠️ 
Data in this mock backend will become irrational with leadership transitions, so it can not be used in any way other than to perform early work on the UI in a single node case.

- secure variables: initial state store (#12932)
- Add SecureVariable mock
- Add SecureVariableStub
- Add SecureVariable Copy and AsStub funcs
- Wire up secure variable mock interface
- Fix panic when not RPC endpoint not found
