### PR TITLE
12986 UI fails to load job when there is an "@" in job name in nomad 130

### DIFF
--- a/.changelog/13012.txt
+++ b/.changelog/13012.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixed a bug where links to jobs with "@" in their name would mis-identify namespace and 404
+```

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -37,13 +37,7 @@ export default class Job extends Model {
 
   @computed('plainId')
   get idWithNamespace() {
-    const namespaceId = this.belongsTo('namespace').id();
-
-    if (!namespaceId) {
-      return this.plainId;
-    } else {
-      return `${this.plainId}@${namespaceId}`;
-    }
+    return `${this.plainId}@${this.belongsTo('namespace').id()}`;
   }
 
   @computed('periodic', 'parameterized', 'dispatched')

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -39,7 +39,7 @@ export default class Job extends Model {
   get idWithNamespace() {
     const namespaceId = this.belongsTo('namespace').id();
 
-    if (!namespaceId || namespaceId === 'default') {
+    if (!namespaceId) {
       return this.plainId;
     } else {
       return `${this.plainId}@${namespaceId}`;

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -37,7 +37,7 @@ export default class Job extends Model {
 
   @computed('plainId')
   get idWithNamespace() {
-    return `${this.plainId}@${this.belongsTo('namespace').id()}`;
+    return `${this.plainId}@${this.belongsTo('namespace').id() ?? 'default'}`;
   }
 
   @computed('periodic', 'parameterized', 'dispatched')

--- a/ui/app/models/volume.js
+++ b/ui/app/models/volume.js
@@ -42,8 +42,6 @@ export default class Volume extends Model {
 
   @computed('plainId')
   get idWithNamespace() {
-    // does this handle default namespace -- I think the backend handles this for us
-    // but the client would always need to recreate that logic
     return `${this.plainId}@${this.belongsTo('namespace').id()}`;
   }
 

--- a/ui/app/routes/jobs/job.js
+++ b/ui/app/routes/jobs/job.js
@@ -9,6 +9,7 @@ export default class JobRoute extends Route {
   @service can;
   @service store;
   @service token;
+  @service router;
 
   serialize(model) {
     return { job_name: model.get('idWithNamespace') };
@@ -24,7 +25,7 @@ export default class JobRoute extends Route {
       namespace = job_name.slice(delimiter + 1);
     } else {
       name = job_name;
-      namespace = 'default';
+      this.router.transitionTo('jobs.job.index', `${name}@${namespace}`);
     }
 
     const fullId = JSON.stringify([name, namespace]);

--- a/ui/app/routes/jobs/job.js
+++ b/ui/app/routes/jobs/job.js
@@ -25,7 +25,6 @@ export default class JobRoute extends Route {
       namespace = job_name.slice(delimiter + 1);
     } else {
       name = job_name;
-      this.router.transitionTo('jobs.job.index', `${name}@${namespace}`);
     }
 
     const fullId = JSON.stringify([name, namespace]);

--- a/ui/app/routes/jobs/job.js
+++ b/ui/app/routes/jobs/job.js
@@ -15,7 +15,17 @@ export default class JobRoute extends Route {
   }
 
   model(params) {
-    const [name, namespace = 'default'] = params.job_name.split('@');
+    let name,
+      namespace = 'default';
+    const { job_name } = params;
+    const delimiter = job_name.lastIndexOf('@');
+    if (delimiter !== -1) {
+      name = job_name.slice(0, delimiter);
+      namespace = job_name.slice(delimiter + 1);
+    } else {
+      name = job_name;
+      namespace = 'default';
+    }
 
     const fullId = JSON.stringify([name, namespace]);
 

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -503,7 +503,7 @@ module('Acceptance | allocation detail (preemptions)', function (hooks) {
     await Allocation.preempter.visitJob();
     assert.equal(
       currentURL(),
-      `/jobs/${preempterJob.id}`,
+      `/jobs/${preempterJob.id}@default`,
       'Clicking the preempter job link navigates to the preempter job page'
     );
 

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -64,7 +64,7 @@ module('Acceptance | jobs list', function (hooks) {
 
     assert.equal(jobRow.name, job.name, 'Name');
     assert.notOk(jobRow.hasNamespace);
-    assert.equal(jobRow.link, `/ui/jobs/${job.id}`, 'Detail Link');
+    assert.equal(jobRow.link, `/ui/jobs/${job.id}@default`, 'Detail Link');
     assert.equal(jobRow.status, job.status, 'Status');
     assert.equal(jobRow.type, typeForJob(job), 'Type');
     assert.equal(jobRow.priority, job.priority, 'Priority');
@@ -78,7 +78,7 @@ module('Acceptance | jobs list', function (hooks) {
     await JobsList.visit();
     await JobsList.jobs.objectAt(0).clickName();
 
-    assert.equal(currentURL(), `/jobs/${job.id}`);
+    assert.equal(currentURL(), `/jobs/${job.id}@default`);
   });
 
   test('the new job button transitions to the new job page', async function (assert) {

--- a/ui/tests/acceptance/regions-test.js
+++ b/ui/tests/acceptance/regions-test.js
@@ -54,7 +54,11 @@ module('Acceptance | regions (only one)', function (hooks) {
 
     const jobId = JobsList.jobs.objectAt(0).id;
     await JobsList.jobs.objectAt(0).clickRow();
-    assert.equal(currentURL(), `/jobs/${jobId}`, 'No region query param');
+    assert.equal(
+      currentURL(),
+      `/jobs/${jobId}@default`,
+      'No region query param'
+    );
 
     await ClientsList.visit();
     assert.equal(currentURL(), '/clients', 'No region query param');

--- a/ui/tests/acceptance/task-detail-test.js
+++ b/ui/tests/acceptance/task-detail-test.js
@@ -104,7 +104,7 @@ module('Acceptance | task detail', function (hooks) {
     await Layout.breadcrumbFor('jobs.job.index').visit();
     assert.equal(
       currentURL(),
-      `/jobs/${job.id}`,
+      `/jobs/${job.id}@default`,
       'Job breadcrumb links correctly'
     );
 

--- a/ui/tests/acceptance/task-detail-test.js
+++ b/ui/tests/acceptance/task-detail-test.js
@@ -112,7 +112,7 @@ module('Acceptance | task detail', function (hooks) {
     await Layout.breadcrumbFor('jobs.job.task-group').visit();
     assert.equal(
       currentURL(),
-      `/jobs/${job.id}/${taskGroup}`,
+      `/jobs/${job.id}@default/${taskGroup}`,
       'Task Group breadcrumb links correctly'
     );
 

--- a/ui/tests/acceptance/topology-test.js
+++ b/ui/tests/acceptance/topology-test.js
@@ -184,7 +184,7 @@ module('Acceptance | topology', function (hooks) {
     await reset();
 
     await Topology.allocInfoPanel.visitJob();
-    assert.equal(currentURL(), `/jobs/${job.id}`);
+    assert.equal(currentURL(), `/jobs/${job.id}@default`);
 
     await reset();
 


### PR DESCRIPTION
Resolves a bug where we were mis-identifying the namespace of jobs with the "@" character in their names.

Now, we explicitly link to @default for any namespace-less links to jobs, and specifically look for the last "@" in a job name to determine namespace.

Resolves #12986 