### PR TITLE
Add a forgotten comma to snapshot-specific CSS

### DIFF
--- a/ui/.percy.yml
+++ b/ui/.percy.yml
@@ -6,7 +6,7 @@ snapshot:
       display: none;
     }
     .related-evaluations path,
-    .related-evaluations circle
+    .related-evaluations circle,
     .dashboard-metric {
       visibility: hidden;
     }


### PR DESCRIPTION
Caused flakiness in our snapshot tests w/ Percy