### PR TITLE
[WIP] consul-template: Add fault tolerant defaults

### DIFF
--- a/client/config/config.go
+++ b/client/config/config.go
@@ -717,8 +717,24 @@ func DefaultConfig() *Config {
 		NoHostUUID:              true,
 		DisableRemoteExec:       false,
 		TemplateConfig: &ClientTemplateConfig{
-			FunctionDenylist: DefaultTemplateFunctionDenylist,
-			DisableSandbox:   false,
+			FunctionDenylist:   DefaultTemplateFunctionDenylist,
+			DisableSandbox:     false,
+			BlockQueryWaitTime: helper.TimeToPtr(5 * time.Minute),   // match Consul default
+			MaxStale:           helper.TimeToPtr(87600 * time.Hour), // match Consul default
+			Wait: &WaitConfig{
+				Min: helper.TimeToPtr(5 * time.Second),
+				Max: helper.TimeToPtr(1 * time.Hour),
+			},
+			ConsulRetry: &RetryConfig{
+				Attempts:   helper.IntToPtr(0), // unlimited
+				Backoff:    helper.TimeToPtr(250 * time.Millisecond),
+				MaxBackoff: helper.TimeToPtr(1 * time.Minute),
+			},
+			VaultRetry: &RetryConfig{
+				Attempts:   helper.IntToPtr(0), // unlimited
+				Backoff:    helper.TimeToPtr(250 * time.Millisecond),
+				MaxBackoff: helper.TimeToPtr(1 * time.Minute),
+			},
 		},
 		RPCHoldTimeout:     5 * time.Second,
 		CNIPath:            "/opt/cni/bin",


### PR DESCRIPTION
** DO NOT MERGE **

This PR adds fault-tolerant defaults to the default agent config.

- `BlockQueryWaitTime`: defaults to 5 min, matching the [default](https://www.consul.io/api-docs/features/blocking#blocking-queries) value Consul uses
- `MaxStale`: defaults to 10 years matching the [default](https://www.consul.io/docs/agent/config/config-files#max_stale) value Consul uses
- `Wait.Min`: defaults to 5 seconds overriding the [default](https://github.com/hashicorp/consul-template/blob/9b0db8d7e76ee01ecde4db53fbd5c11f7eb9a6a8/config/wait.go#L90) of 0 that Consul Template uses
- `Wait.Max`: defaults to 4 minutes matching the [default](https://github.com/hashicorp/consul-template/blob/9b0db8d7e76ee01ecde4db53fbd5c11f7eb9a6a8/config/wait.go#L90) Consul Template uses
- `ConsulRetry.Attempts`: defaults to 0 which is the `unlimited` value - overrides the Consul Template [default](https://github.com/hashicorp/consul-template/blob/9b0db8d7e76ee01ecde4db53fbd5c11f7eb9a6a8/config/retry.go#L11) of 12
- `ConsulRetry.Backoff`: defaults to 250ms matching the [default](https://github.com/hashicorp/consul-template/blob/9b0db8d7e76ee01ecde4db53fbd5c11f7eb9a6a8/config/retry.go#L15) that Consul Template uses
- `ConsulRetry.MaxBackoff`: defaults to 1 minute matching [default](https://github.com/hashicorp/consul-template/blob/9b0db8d7e76ee01ecde4db53fbd5c11f7eb9a6a8/config/retry.go#L18) that Consul Template uses
- `VaultRetry.Attempts`: defaults to 0 which is the `unlimited` value - overrides the Consul Template [default](https://github.com/hashicorp/consul-template/blob/9b0db8d7e76ee01ecde4db53fbd5c11f7eb9a6a8/config/retry.go#L11) of 12
- `VaultRetry.Backoff`: defaults to 250ms matching the [default](https://github.com/hashicorp/consul-template/blob/9b0db8d7e76ee01ecde4db53fbd5c11f7eb9a6a8/config/retry.go#L15) that Consul Template uses
- `VaultRetry.MaxBackoff`: defaults to 1 minute matching [default](https://github.com/hashicorp/consul-template/blob/9b0db8d7e76ee01ecde4db53fbd5c11f7eb9a6a8/config/retry.go#L18) that Consul Template uses