### PR TITLE
cli: update default redis and use nomad service discovery

### DIFF
--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -576,7 +576,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 								Name:   "redis",
 								Driver: "docker",
 								Config: map[string]interface{}{
-									"image": "redis:3.2",
+									"image": "redis:7",
 									"port_map": []map[string]int{{
 										"db": 6379,
 									}},
@@ -708,7 +708,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 								Name:   "redis",
 								Driver: "docker",
 								Config: map[string]interface{}{
-									"image": "redis:3.2",
+									"image": "redis:7",
 									"port_map": []map[string]int{{
 										"db": 6379,
 									}},

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -681,7 +681,7 @@ func TestTaskRunner_TaskEnv_Image(t *testing.T) {
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "docker"
 	task.Config = map[string]interface{}{
-		"image":        "redis:3.2-alpine",
+		"image":        "redis:7-alpine",
 		"network_mode": "none",
 		"command":      "sh",
 		"args": []string{"-c", "echo $NOMAD_ALLOC_DIR; " +

--- a/command/assets/example-short.nomad
+++ b/command/assets/example-short.nomad
@@ -12,7 +12,7 @@ job "example" {
       driver = "docker"
 
       config {
-        image          = "redis:3.2"
+        image          = "redis:7"
         ports          = ["db"]
         auth_soft_fail = true
       }

--- a/command/assets/example.nomad
+++ b/command/assets/example.nomad
@@ -157,8 +157,8 @@ job "example" {
     }
 
     # The "service" stanza instructs Nomad to register this task as a service
-    # in the service discovery engine, which is currently Consul. This will
-    # make the service addressable after Nomad has placed it on a host and
+    # in the service discovery engine, which is currently Nomad or Consul. This
+    # will make the service discoverable after Nomad has placed it on a host and
     # port.
     #
     # For more information and examples on the "service" stanza, please see
@@ -167,9 +167,10 @@ job "example" {
     #     https://www.nomadproject.io/docs/job-specification/service
     #
     service {
-      name = "redis-cache"
-      tags = ["global", "cache"]
-      port = "db"
+      name     = "redis-cache"
+      tags     = ["global", "cache"]
+      port     = "db"
+      provider = "nomad"
 
       # The "check" stanza instructs Nomad to create a Consul health check for
       # this service. A sample check is provided here for your convenience;
@@ -302,7 +303,7 @@ job "example" {
       # are specific to each driver, so please see specific driver
       # documentation for more information.
       config {
-        image = "redis:3.2"
+        image = "redis:7"
         ports = ["db"]
 
         # The "auth_soft_fail" configuration instructs Nomad to try public

--- a/command/testdata/example-short-bad.json
+++ b/command/testdata/example-short-bad.json
@@ -23,7 +23,7 @@
                         "Lifecycle": null,
                         "Config": {
                             "auth_soft_fail": true,
-                            "image": "redis:3.2",
+                            "image": "redis:7",
                             "ports": [
                                 "db"
                             ]

--- a/command/testdata/example-short.json
+++ b/command/testdata/example-short.json
@@ -26,7 +26,7 @@
                         "Lifecycle": null,
                         "Config": {
                             "auth_soft_fail": true,
-                            "image": "redis:3.2",
+                            "image": "redis:7",
                             "ports": [
                                 "db"
                             ]

--- a/demo/csi/digitalocean/volume-job.nomad
+++ b/demo/csi/digitalocean/volume-job.nomad
@@ -13,7 +13,7 @@ job "example" {
       driver = "docker"
 
       config {
-        image = "redis:3.2"
+        image = "redis:7"
 
         port_map {
           db = 6379

--- a/demo/csi/hostpath/redis.nomad
+++ b/demo/csi/hostpath/redis.nomad
@@ -24,7 +24,7 @@ job "example" {
       driver = "docker"
 
       config {
-        image = "redis:3.2"
+        image = "redis:7"
         ports = ["db"]
       }
 

--- a/drivers/docker/config_test.go
+++ b/drivers/docker/config_test.go
@@ -21,10 +21,10 @@ func TestConfig_ParseHCL(t *testing.T) {
 		{
 			"basic image",
 			`config {
-				image = "redis:3.2"
+				image = "redis:7"
 			}`,
 			&TaskConfig{
-				Image:            "redis:3.2",
+				Image:            "redis:7",
 				Devices:          []DockerDevice{},
 				Mounts:           []DockerMount{},
 				MountsList:       []DockerMount{},
@@ -196,7 +196,7 @@ func TestConfig_ParseAllHCL(t *testing.T) {
 
 	cfgStr := `
 config {
-  image = "redis:3.2"
+  image = "redis:7"
   image_pull_timeout = "15m"
   advertise_ipv6_address = true
   args = ["command_arg1", "command_arg2"]
@@ -342,7 +342,7 @@ config {
 }`
 
 	expected := &TaskConfig{
-		Image:             "redis:3.2",
+		Image:             "redis:7",
 		ImagePullTimeout:  "15m",
 		AdvertiseIPv6Addr: true,
 		Args:              []string{"command_arg1", "command_arg2"},

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -2292,7 +2292,7 @@ func TestDockerDriver_AuthConfiguration(t *testing.T) {
 			AuthConfig: nil,
 		},
 		{
-			Repo: "redis:3.2",
+			Repo: "redis:7",
 			AuthConfig: &docker.AuthConfiguration{
 				Username:      "test",
 				Password:      "1234",
@@ -2301,7 +2301,7 @@ func TestDockerDriver_AuthConfiguration(t *testing.T) {
 			},
 		},
 		{
-			Repo: "quay.io/redis:3.2",
+			Repo: "quay.io/redis:7",
 			AuthConfig: &docker.AuthConfiguration{
 				Username:      "test",
 				Password:      "5678",
@@ -2310,7 +2310,7 @@ func TestDockerDriver_AuthConfiguration(t *testing.T) {
 			},
 		},
 		{
-			Repo: "other.io/redis:3.2",
+			Repo: "other.io/redis:7",
 			AuthConfig: &docker.AuthConfiguration{
 				Username:      "test",
 				Password:      "abcd",

--- a/drivers/docker/test-resources/docker/reconciler_containers_list.json
+++ b/drivers/docker/test-resources/docker/reconciler_containers_list.json
@@ -4,7 +4,7 @@
     "Names": [
       "/redis-72bfa388-024e-a903-45b8-2bc28b74ed69"
     ],
-    "Image": "redis:3.2",
+    "Image": "redis:7",
     "ImageID": "sha256:87856cc39862cec77541d68382e4867d7ccb29a85a17221446c857ddaebca916",
     "Command": "docker-entrypoint.sh redis-server",
     "Created": 1568383081,

--- a/helper/pluginutils/hclutils/util_test.go
+++ b/helper/pluginutils/hclutils/util_test.go
@@ -38,11 +38,11 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			name: "single string attr",
 			config: hclutils.HclConfigToInterface(t, `
 			config {
-				image = "redis:3.2"
+				image = "redis:7"
 			}`),
 			spec: dockerDecSpec,
 			expected: &docker.TaskConfig{
-				Image:            "redis:3.2",
+				Image:            "redis:7",
 				Devices:          []docker.DockerDevice{},
 				Mounts:           []docker.DockerMount{},
 				MountsList:       []docker.DockerMount{},
@@ -56,12 +56,12 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			config: hclutils.JsonConfigToInterface(t, `
 						{
 							"Config": {
-								"image": "redis:3.2"
+								"image": "redis:7"
 			                }
 						}`),
 			spec: dockerDecSpec,
 			expected: &docker.TaskConfig{
-				Image:            "redis:3.2",
+				Image:            "redis:7",
 				Devices:          []docker.DockerDevice{},
 				Mounts:           []docker.DockerMount{},
 				MountsList:       []docker.DockerMount{},
@@ -74,12 +74,12 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			name: "number attr",
 			config: hclutils.HclConfigToInterface(t, `
 						config {
-							image = "redis:3.2"
+							image = "redis:7"
 							pids_limit  = 2
 						}`),
 			spec: dockerDecSpec,
 			expected: &docker.TaskConfig{
-				Image:            "redis:3.2",
+				Image:            "redis:7",
 				PidsLimit:        2,
 				Devices:          []docker.DockerDevice{},
 				Mounts:           []docker.DockerMount{},
@@ -94,13 +94,13 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			config: hclutils.JsonConfigToInterface(t, `
 						{
 							"Config": {
-								"image": "redis:3.2",
+								"image": "redis:7",
 								"pids_limit": "2"
 			                }
 						}`),
 			spec: dockerDecSpec,
 			expected: &docker.TaskConfig{
-				Image:            "redis:3.2",
+				Image:            "redis:7",
 				PidsLimit:        2,
 				Devices:          []docker.DockerDevice{},
 				Mounts:           []docker.DockerMount{},
@@ -114,12 +114,12 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			name: "number attr interpolated",
 			config: hclutils.HclConfigToInterface(t, `
 						config {
-							image = "redis:3.2"
+							image = "redis:7"
 							pids_limit  = "${2 + 2}"
 						}`),
 			spec: dockerDecSpec,
 			expected: &docker.TaskConfig{
-				Image:            "redis:3.2",
+				Image:            "redis:7",
 				PidsLimit:        4,
 				Devices:          []docker.DockerDevice{},
 				Mounts:           []docker.DockerMount{},
@@ -134,13 +134,13 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			config: hclutils.JsonConfigToInterface(t, `
 						{
 							"Config": {
-								"image": "redis:3.2",
+								"image": "redis:7",
 								"pids_limit": "${2 + 2}"
 			                }
 						}`),
 			spec: dockerDecSpec,
 			expected: &docker.TaskConfig{
-				Image:            "redis:3.2",
+				Image:            "redis:7",
 				PidsLimit:        4,
 				Devices:          []docker.DockerDevice{},
 				Mounts:           []docker.DockerMount{},
@@ -154,12 +154,12 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			name: "multi attr",
 			config: hclutils.HclConfigToInterface(t, `
 						config {
-							image = "redis:3.2"
+							image = "redis:7"
 							args = ["foo", "bar"]
 						}`),
 			spec: dockerDecSpec,
 			expected: &docker.TaskConfig{
-				Image:            "redis:3.2",
+				Image:            "redis:7",
 				Args:             []string{"foo", "bar"},
 				Devices:          []docker.DockerDevice{},
 				Mounts:           []docker.DockerMount{},
@@ -174,13 +174,13 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			config: hclutils.JsonConfigToInterface(t, `
 						{
 							"Config": {
-								"image": "redis:3.2",
+								"image": "redis:7",
 								"args": ["foo", "bar"]
 			                }
 						}`),
 			spec: dockerDecSpec,
 			expected: &docker.TaskConfig{
-				Image:            "redis:3.2",
+				Image:            "redis:7",
 				Args:             []string{"foo", "bar"},
 				Devices:          []docker.DockerDevice{},
 				Mounts:           []docker.DockerMount{},
@@ -194,14 +194,14 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			name: "multi attr variables",
 			config: hclutils.HclConfigToInterface(t, `
 						config {
-							image = "redis:3.2"
+							image = "redis:7"
 							args = ["${NOMAD_META_hello}", "${NOMAD_ALLOC_INDEX}"]
 							pids_limit = "${NOMAD_ALLOC_INDEX + 2}"
 						}`),
 			spec: dockerDecSpec,
 			vars: vars,
 			expected: &docker.TaskConfig{
-				Image:            "redis:3.2",
+				Image:            "redis:7",
 				Args:             []string{"world", "2"},
 				PidsLimit:        4,
 				Devices:          []docker.DockerDevice{},
@@ -217,13 +217,13 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			config: hclutils.JsonConfigToInterface(t, `
 						{
 							"Config": {
-								"image": "redis:3.2",
+								"image": "redis:7",
 								"args": ["foo", "bar"]
 			                }
 						}`),
 			spec: dockerDecSpec,
 			expected: &docker.TaskConfig{
-				Image:            "redis:3.2",
+				Image:            "redis:7",
 				Args:             []string{"foo", "bar"},
 				Devices:          []docker.DockerDevice{},
 				Mounts:           []docker.DockerMount{},
@@ -237,7 +237,7 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			name: "port_map",
 			config: hclutils.HclConfigToInterface(t, `
 			config {
-				image = "redis:3.2"
+				image = "redis:7"
 				port_map {
 					foo = 1234
 					bar = 5678
@@ -245,7 +245,7 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			}`),
 			spec: dockerDecSpec,
 			expected: &docker.TaskConfig{
-				Image: "redis:3.2",
+				Image: "redis:7",
 				PortMap: map[string]int{
 					"foo": 1234,
 					"bar": 5678,
@@ -263,7 +263,7 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			config: hclutils.JsonConfigToInterface(t, `
 							{
 								"Config": {
-									"image": "redis:3.2",
+									"image": "redis:7",
 									"port_map": [{
 										"foo": 1234,
 										"bar": 5678
@@ -272,7 +272,7 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 							}`),
 			spec: dockerDecSpec,
 			expected: &docker.TaskConfig{
-				Image: "redis:3.2",
+				Image: "redis:7",
 				PortMap: map[string]int{
 					"foo": 1234,
 					"bar": 5678,
@@ -289,7 +289,7 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			name: "devices",
 			config: hclutils.HclConfigToInterface(t, `
 						config {
-							image = "redis:3.2"
+							image = "redis:7"
 							devices = [
 								{
 									host_path = "/dev/sda1"
@@ -304,7 +304,7 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 						}`),
 			spec: dockerDecSpec,
 			expected: &docker.TaskConfig{
-				Image: "redis:3.2",
+				Image: "redis:7",
 				Devices: []docker.DockerDevice{
 					{
 						HostPath:          "/dev/sda1",
@@ -327,7 +327,7 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			name: "docker_logging",
 			config: hclutils.HclConfigToInterface(t, `
 				config {
-					image = "redis:3.2"
+					image = "redis:7"
 					network_mode = "host"
 					dns_servers = ["169.254.1.1"]
 					logging {
@@ -339,7 +339,7 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 				}`),
 			spec: dockerDecSpec,
 			expected: &docker.TaskConfig{
-				Image:       "redis:3.2",
+				Image:       "redis:7",
 				NetworkMode: "host",
 				DNSServers:  []string{"169.254.1.1"},
 				Logging: docker.DockerLogging{
@@ -361,7 +361,7 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 			config: hclutils.JsonConfigToInterface(t, `
 					{
 						"Config": {
-							"image": "redis:3.2",
+							"image": "redis:7",
 							"devices": [
 								{
 									"host_path": "/dev/sda1",
@@ -377,7 +377,7 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 					}`),
 			spec: dockerDecSpec,
 			expected: &docker.TaskConfig{
-				Image: "redis:3.2",
+				Image: "redis:7",
 				Devices: []docker.DockerDevice{
 					{
 						HostPath:          "/dev/sda1",
@@ -565,7 +565,7 @@ func TestParseInvalid(t *testing.T) {
 	}{
 		{
 			"invalid_field",
-			`config { image = "redis:3.2" bad_key = "whatever"}`,
+			`config { image = "redis:7" bad_key = "whatever"}`,
 		},
 	}
 

--- a/scripts/example_weave.bash
+++ b/scripts/example_weave.bash
@@ -42,7 +42,7 @@ job "weave-example" {
     task "redis" {
       driver = "docker"
       config {
-        image = "redis:3.2"
+        image = "redis:7"
         port_map {
           db = 6379
         }

--- a/ui/stories/components/diff-viewer.stories.js
+++ b/ui/stories/components/diff-viewer.stories.js
@@ -187,7 +187,7 @@ export let DiffViewerWithManyChanges = () => {
                         Annotations: null,
                         Name: 'image',
                         New: 'redis:3.4',
-                        Old: 'redis:3.2',
+                        Old: 'redis:7',
                         Type: 'Edited',
                       },
                       {
@@ -595,7 +595,7 @@ export let DiffViewerWithManyChanges = () => {
                       {
                         Annotations: null,
                         Name: 'image',
-                        New: 'redis:3.2',
+                        New: 'redis:7',
                         Old: '',
                         Type: 'Added',
                       },

--- a/website/content/api-docs/allocations.mdx
+++ b/website/content/api-docs/allocations.mdx
@@ -299,7 +299,7 @@ $ curl \
                   "db": 6379
                 }
               ],
-              "image": "redis:3.2"
+              "image": "redis:7"
             },
             "Env": null,
             "Services": [
@@ -506,7 +506,7 @@ $ curl \
           "VaultError": "",
           "TaskSignalReason": "",
           "TaskSignal": "",
-          "DriverMessage": "Downloading image redis:3.2"
+          "DriverMessage": "Downloading image redis:7"
         },
         {
           "Type": "Started",

--- a/website/content/api-docs/evaluations.mdx
+++ b/website/content/api-docs/evaluations.mdx
@@ -298,7 +298,7 @@ $ curl \
             "VaultError": "",
             "TaskSignalReason": "",
             "TaskSignal": "",
-            "DriverMessage": "Downloading image redis:3.2"
+            "DriverMessage": "Downloading image redis:7"
           },
           {
             "Type": "Started",

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -168,7 +168,7 @@ The table below shows this endpoint's support for
         "Tasks": [
           {
             "Config": {
-              "image": "redis:3.2",
+              "image": "redis:7",
               "ports": ["db"]
             },
             "Driver": "docker",
@@ -667,7 +667,7 @@ $ curl \
               "Artifacts": null,
               "CSIPluginConfig": null,
               "Config": {
-                "image": "redis:3.2",
+                "image": "redis:7",
                 "ports": ["db"]
               },
               "Constraints": null,
@@ -881,7 +881,7 @@ $ curl \
               "Artifacts": null,
               "CSIPluginConfig": null,
               "Config": {
-                "image": "redis:3.2",
+                "image": "redis:7",
                 "ports": [
                   "db"
                 ]
@@ -1049,7 +1049,7 @@ $ curl \
               "Artifacts": null,
               "CSIPluginConfig": null,
               "Config": {
-                "image": "redis:3.2",
+                "image": "redis:7",
                 "ports": [
                   "db"
                 ]
@@ -1259,7 +1259,7 @@ $ curl \
             "VaultError": "",
             "TaskSignalReason": "",
             "TaskSignal": "",
-            "DriverMessage": "Downloading image redis:3.2"
+            "DriverMessage": "Downloading image redis:7"
           },
           {
             "Type": "Started",

--- a/website/content/api-docs/json-jobs.mdx
+++ b/website/content/api-docs/json-jobs.mdx
@@ -77,7 +77,7 @@ $ nomad job run -output example.nomad
             "User": "",
             "Lifecycle": null,
             "Config": {
-              "image": "redis:3.2",
+              "image": "redis:7",
               "ports": [
                 "db"
               ]

--- a/website/content/api-docs/volumes.mdx
+++ b/website/content/api-docs/volumes.mdx
@@ -220,7 +220,7 @@ $ curl \
               "VaultError": "",
               "TaskSignalReason": "",
               "TaskSignal": "",
-              "DriverMessage": "Downloading image redis:3.2"
+              "DriverMessage": "Downloading image redis:7"
             },
             {
               "Type": "Started",

--- a/website/content/docs/commands/job/plan.mdx
+++ b/website/content/docs/commands/job/plan.mdx
@@ -138,7 +138,7 @@ $ nomad job plan example.nomad
 +/- Task Group: "cache" (3 create/destroy update)
   +/- Task: "redis" (forces create/destroy update)
     +/- Config {
-      +/- image:           "redis:2.8" => "redis:3.2"
+      +/- image:           "redis:2.8" => "redis:7"
           port_map[0][db]: "6379"
     }
 

--- a/website/content/docs/commands/job/revert.mdx
+++ b/website/content/docs/commands/job/revert.mdx
@@ -71,7 +71,7 @@ Diff        =
 +/- Task Group: "cache"
   +/- Task: "redis"
     +/- Config {
-      +/- image:           "redis:3.2" => "redis:4.0"
+      +/- image:           "redis:7" => "redis:4.0"
           port_map[0][db]: "6379"
         }
 
@@ -96,7 +96,7 @@ Diff        =
 +/- Task Group: "cache"
   +/- Task: "redis"
     +/- Config {
-      +/- image:           "redis:4.0" => "redis:3.2"
+      +/- image:           "redis:4.0" => "redis:7"
           port_map[0][db]: "6379"
         }
 
@@ -108,7 +108,7 @@ Diff        =
 +/- Task Group: "cache"
   +/- Task: "redis"
     +/- Config {
-      +/- image:           "redis:3.2" => "redis:4.0"
+      +/- image:           "redis:7" => "redis:4.0"
           port_map[0][db]: "6379"
         }
 

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -22,7 +22,7 @@ task "webservice" {
   driver = "docker"
 
   config {
-    image = "redis:3.2"
+    image = "redis:7"
     labels {
       group = "webservice-cache"
     }
@@ -42,7 +42,7 @@ The `docker` driver supports the following configuration in the job spec. Only
 
   ```hcl
   config {
-    image = "https://hub.docker.internal/redis:3.2"
+    image = "https://hub.docker.internal/redis:7"
   }
   ```
 

--- a/website/content/docs/job-specification/scaling.mdx
+++ b/website/content/docs/job-specification/scaling.mdx
@@ -57,7 +57,7 @@ job "example" {
       driver = "docker"
 
       config {
-        image = "redis:3.2"
+        image = "redis:7"
       }
 
       resources {

--- a/website/content/docs/job-specification/service.mdx
+++ b/website/content/docs/job-specification/service.mdx
@@ -620,7 +620,7 @@ job "example" {
       driver = "docker"
 
       config {
-        image = "redis:3.2"
+        image = "redis:7"
         network_mode = "weave"
         ports = ["db"]
       }
@@ -671,7 +671,7 @@ job "example" {
       driver = "docker"
 
       config {
-        image = "redis:3.2"
+        image = "redis:7"
         network_mode = "weave"
         # No port map required.
       }
@@ -736,7 +736,7 @@ job "example" {
       driver = "docker"
 
       config {
-        image = "redis:3.2"
+        image = "redis:7"
         advertise_ipv6_address = true
         ports = ["db"]
       }
@@ -775,7 +775,7 @@ job "example" {
       driver = "docker"
 
       config {
-        image = "redis:3.2"
+        image = "redis:7"
         advertise_ipv6_address = true
         # No port map required.
       }

--- a/website/content/docs/job-specification/volume.mdx
+++ b/website/content/docs/job-specification/volume.mdx
@@ -147,7 +147,7 @@ job "example" {
     task "redis" {
       driver = "docker"
       config {
-        image = "redis:3.2"
+        image = "redis:7"
         ports = ["db"]
       }
       resources {

--- a/website/content/docs/runtime/interpolation.mdx
+++ b/website/content/docs/runtime/interpolation.mdx
@@ -334,7 +334,7 @@ syntax:
 task "redis" {
   driver = "docker"
   config {
-    image  = "redis:3.2"
+    image  = "redis:7"
     labels {
       label1 = "${env["invalid...name"]}"
       label2 = "${env["valid.name"]}"

--- a/website/content/plugins/drivers/community/rkt.mdx
+++ b/website/content/plugins/drivers/community/rkt.mdx
@@ -28,7 +28,7 @@ task "webservice" {
   driver = "rkt"
 
   config {
-    image = "redis:3.2"
+    image = "redis:7"
   }
 }
 ```
@@ -40,7 +40,7 @@ The `rkt` driver supports the following configuration in the job spec:
 
   ```hcl
   config {
-    image = "https://hub.docker.internal/redis:3.2"
+    image = "https://hub.docker.internal/redis:7"
   }
   ```
 


### PR DESCRIPTION
This PR updates the version of redis used in our examples from 3.2 to 7.
The old version is very not supported anymore, and we should be setting
a good example by using a supported version.

The long-form example job is now fixed so that the service stanza uses
nomad as the service discovery provider, and so now the job runs without
a requirement of having Consul running and configured.

Closes #12927
Closes #12958
