### PR TITLE
Make keyboard nav disableable

### DIFF
--- a/ui/app/components/keyboard-shortcuts-modal.hbs
+++ b/ui/app/components/keyboard-shortcuts-modal.hbs
@@ -1,16 +1,20 @@
 {{#if this.keyboard.shortcutsVisible}}
   {{keyboard-commands (array this.escapeCommand)}}
-  <ul class="keyboard-shortcuts">
-    <button
-      class="button is-borderless dismiss"
-      type="button"
-      {{on "click" (toggle "keyboard.shortcutsVisible" this)}}
-    >
-      {{x-icon "cancel"}}
-    </button>
+  <div class="keyboard-shortcuts {{unless this.keyboard.shortcutsEnabled "shortcuts-disabled"}}">
+    <header>
+      <h2>Keyboard Shortcuts</h2>
+      <button
+        class="button is-borderless dismiss"
+        type="button"
+        {{on "click" (toggle "keyboard.shortcutsVisible" this)}}
+      >
+        {{x-icon "cancel"}}
+      </button>
+    </header>
+    <ul>
     {{#each this.commands as |command|}}
       <li>
-        <strong>{{command.label}}</strong>
+        <span>{{command.label}}</span>
         <span class="keys">
           {{#each command.pattern as |key|}}
             <span>{{key}}</span>
@@ -19,6 +23,15 @@
       </li>
     {{/each}}
   </ul>
+  <footer>
+    <span>Keyboard shortcuts {{if this.keyboard.shortcutsEnabled "enabled" "disabled"}}</span>
+    <Toggle
+      @isActive={{this.keyboard.shortcutsEnabled}}
+      @onToggle={{toggle "keyboard.shortcutsEnabled" this}}
+      title="Enable/Disable Keyboard Shortcuts"
+    />
+  </footer>
+  </div>
 {{/if}}
 
 {{#if this.keyboard.displayHints}}

--- a/ui/app/services/keyboard.js
+++ b/ui/app/services/keyboard.js
@@ -36,6 +36,7 @@ export default class KeyboardService extends Service {
   @tracked shortcutsVisible = false;
   @tracked buffer = A([]);
   @tracked displayHints = false;
+  @tracked shortcutsEnabled = true;
 
   keyCommands = [
     {
@@ -269,7 +270,9 @@ export default class KeyboardService extends Service {
         if (key !== 'Shift') {
           this.addKeyToBuffer.perform(key, shifted);
         } else {
-          this.displayHints = true;
+          if (this.shortcutsEnabled) {
+            this.displayHints = true;
+          }
         }
       } else if (type === 'release') {
         if (key === 'Shift') {
@@ -291,7 +294,15 @@ export default class KeyboardService extends Service {
     }
     this.buffer.pushObject(shifted ? `Shift+${key}` : key);
     if (this.matchedCommands.length) {
-      this.matchedCommands.forEach((command) => command.action());
+      this.matchedCommands.forEach((command) => {
+        if (
+          this.shortcutsEnabled ||
+          command.label === 'Show Keyboard Shortcuts' ||
+          command.label === 'Hide Keyboard Shortcuts'
+        ) {
+          command.action();
+        }
+      });
 
       // TODO: Temporary dev log
       if (this.config.isDev) {

--- a/ui/app/styles/components/keyboard-shortcuts-modal.scss
+++ b/ui/app/styles/components/keyboard-shortcuts-modal.scss
@@ -11,13 +11,6 @@
   animation-duration: 0.2s;
   animation-fill-mode: both;
 
-  button.dismiss {
-    width: 100%;
-    justify-content: right;
-    font-size: 0.7rem;
-    margin-bottom: 1rem;
-  }
-
   li {
     list-style-type: none;
     padding: 0.5rem 0;
@@ -30,9 +23,38 @@
       text-align: right;
       span {
         background-color: #eee;
-        margin: 0 0.25rem;
-        padding: 0 0.25rem;
+        margin: 0.1rem;
+        padding: 0.3rem;
+        line-height: 100%;
+        display: inline-block;
       }
+    }
+  }
+
+  header {
+    margin-bottom: 1rem;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 600;
+    }
+    button.dismiss {
+      font-size: 0.7rem;
+    }
+  }
+
+  footer {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    padding: 2rem;
+    background: #eee;
+    margin: 2rem -2rem -2rem;
+  }
+
+  &.shortcuts-disabled {
+    li {
+      opacity: 0.25;
     }
   }
 }


### PR DESCRIPTION
- Changes to the modal style
- Ability to disable/enable keyboard nav. Only thing it won't disable is `?` and `ESC` to open/close the nav itself.
- TODO: save to localstorage for persistence

![image](https://user-images.githubusercontent.com/713991/168871663-911c5c5d-ee9c-4973-a79a-b276f1e8e236.png)
