### PR TITLE
drivers/docker: do not set cgroup parent in v1 mode

### DIFF
--- a/.changelog/13058.txt
+++ b/.changelog/13058.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: Fixed a bug where cgroups-v1 parent was being set
+```

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -2844,6 +2844,32 @@ func TestDockerDriver_memoryLimits(t *testing.T) {
 	}
 }
 
+func TestDockerDriver_cgroupParent(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("v1", func(t *testing.T) {
+		testutil.CgroupsCompatibleV1(t)
+
+		parent := cgroupParent(&drivers.Resources{
+			LinuxResources: &drivers.LinuxResources{
+				CpusetCgroupPath: "/sys/fs/cgroup/cpuset/nomad",
+			},
+		})
+		require.Equal(t, "", parent)
+	})
+
+	t.Run("v2", func(t *testing.T) {
+		testutil.CgroupsCompatibleV2(t)
+
+		parent := cgroupParent(&drivers.Resources{
+			LinuxResources: &drivers.LinuxResources{
+				CpusetCgroupPath: "/sys/fs/cgroup/nomad.slice",
+			},
+		})
+		require.Equal(t, "nomad.slice", parent)
+	})
+}
+
 func TestDockerDriver_parseSignal(t *testing.T) {
 	ci.Parallel(t)
 


### PR DESCRIPTION
This PR fixes a bug where the `CgroupParent` on the docker
`HostConfig` struct was accidentally being set when running in
cgroups v1 mode.

Fixes https://github.com/hashicorp/nomad/issues/13031