### PR TITLE
Use the postinstall script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,6 +233,7 @@ jobs:
           rpm_depends: "openssl"
           config_dir: ".release/linux/package/"
           preinstall: ".release/linux/preinst"
+          postinstall: ".release/linux/postinst"
           postremove: ".release/linux/postrm"
 
       - name: Set Package Names


### PR DESCRIPTION
## Issue
Fixes https://github.com/hashicorp/nomad/issues/13067

## Summary
The linux postinstall script was created as part of https://github.com/hashicorp/nomad/pull/12276 but wasn't actually used. This sets the reference so the script will actually be used.
The primary benefit is that the following lines are run automatically as part of the install instead of requiring users to create it themselves
```
mkdir -p /opt/nomad/data
chown nomad:nomad /opt/nomad/data
chown -R nomad:nomad /etc/nomad.d
```
