### PR TITLE
Don't buffer json logs on agent startup

### DIFF
--- a/.changelog/13076.txt
+++ b/.changelog/13076.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: logs are no longer buffered at startup when logging in JSON format
+```

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -703,6 +703,8 @@ func (c *Command) Run(args []string) int {
 	// Swap out UI implementation if json logging is enabled
 	if config.LogJson {
 		c.Ui = &logging.HcLogUI{Log: logger}
+		// Don't buffer json logs because they aren't reordered anyway.
+		logGate.Flush()
 	}
 
 	// Log config files


### PR DESCRIPTION
Fixes #13015.

There's no reason to buffer json logs on agent startup, since logs in this format already aren't reordered (see https://github.com/hashicorp/nomad/issues/13015#issuecomment-1129157784).
This PR adds an early `logGate.Flush()` where the UI implementation is swapped out for JSON logs, so they are no longer buffered.