### PR TITLE
add default_ineligible configuration option

### DIFF
--- a/.changelog/27965.txt
+++ b/.changelog/27965.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client: Adds default_ineligible configuration option
+```

--- a/client/client.go
+++ b/client/client.go
@@ -1750,6 +1750,12 @@ func (c *Client) setupNode() error {
 		return fmt.Errorf("error syncing dynamic node metadata: %w", err)
 	}
 
+	if c.config.DefaultIneligible {
+		node.SchedulingEligibility = structs.NodeSchedulingIneligible
+	} else {
+		node.SchedulingEligibility = structs.NodeSchedulingEligible
+	}
+
 	c.config = newConfig
 	return nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2304,6 +2304,7 @@ func TestClient_DefaultIneligible(t *testing.T) {
 	testutil.WaitForLeader(t, s1.RPC)
 
 	c1, cleanupC1 := TestClient(t, func(c *config.Config) {
+		c.DevMode = false
 		c.DefaultIneligible = true
 		c.RPCHandler = s1
 	})
@@ -2328,6 +2329,74 @@ func TestClient_DefaultIneligible(t *testing.T) {
 		}
 		must.Eq(t, structs.NodeSchedulingIneligible, out.Node.SchedulingEligibility)
 		return out.Node.ID == req.NodeID, nil
+	}, func(err error) {
+		must.NoError(t, err)
+	})
+
+	req2 := structs.NodeUpdateEligibilityRequest{
+		NodeID:       c1.Node().ID,
+		Eligibility:  structs.NodeSchedulingEligible,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+	var out2 structs.NodeEligibilityUpdateResponse
+
+	// Set node as eligible and restart, should return as eligible
+
+	// Update eligibility should succeed
+	testutil.WaitForResult(func() (bool, error) {
+		err := s1.RPC("Node.UpdateEligibility", &req2, &out2)
+		if err != nil {
+			return false, err
+		}
+		return out2.NodeModifyIndex != 0, nil
+	}, func(err error) {
+		must.NoError(t, err)
+	})
+
+	// Query node to confirm eligibility was toggled on
+	var out3 structs.SingleNodeResponse
+	testutil.WaitForResult(func() (bool, error) {
+		err := s1.RPC("Node.GetNode", &req, &out3)
+		if err != nil {
+			return false, err
+		}
+		if out.Node == nil {
+			return false, fmt.Errorf("missing reg")
+		}
+		must.Eq(t, structs.NodeSchedulingEligible, out3.Node.SchedulingEligibility)
+		return out3.Node.ID == req.NodeID, nil
+	}, func(err error) {
+		must.NoError(t, err)
+	})
+
+	// Restart Client
+	c1Config := c1.config.Copy()
+	must.NoError(t, c1.Shutdown())
+
+	// actually make and start the client
+	c2, err := NewClient(c1Config, c1.consulCatalog, nil, c1.consulServices, nil)
+	must.NoError(t, err)
+	t.Cleanup(func() {
+		test.NoError(t, c2.Shutdown())
+	})
+
+	req4 := structs.NodeSpecificRequest{
+		NodeID:       c2.Node().ID,
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
+	var out4 structs.SingleNodeResponse
+
+	// Should still be eligible
+	testutil.WaitForResult(func() (bool, error) {
+		err := s1.RPC("Node.GetNode", &req4, &out4)
+		if err != nil {
+			return false, err
+		}
+		if out.Node == nil {
+			return false, fmt.Errorf("missing reg")
+		}
+		must.Eq(t, structs.NodeSchedulingEligible, out4.Node.SchedulingEligibility)
+		return out4.Node.ID == req.NodeID, nil
 	}, func(err error) {
 		must.NoError(t, err)
 	})

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2343,63 +2343,67 @@ func TestClient_DefaultIneligible(t *testing.T) {
 	// Set node as eligible and restart, should return as eligible
 
 	// Update eligibility should succeed
-	testutil.WaitForResult(func() (bool, error) {
-		err := s1.RPC("Node.UpdateEligibility", &req2, &out2)
-		if err != nil {
-			return false, err
-		}
-		return out2.NodeModifyIndex != 0, nil
-	}, func(err error) {
-		must.NoError(t, err)
-	})
+	must.Wait(t, wait.InitialSuccess(
+		wait.ErrorFunc(func() error {
+			err := s1.RPC("Node.UpdateEligibility", &req2, &out2)
+			if err != nil {
+				return err
+			}
+			must.NotEq(t, out2.NodeModifyIndex, out.Index)
+			return nil
+		}),
+	))
 
 	// Query node to confirm eligibility was toggled on
+	req3 := structs.NodeSpecificRequest{
+		NodeID:       c1.Node().ID,
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
 	var out3 structs.SingleNodeResponse
-	testutil.WaitForResult(func() (bool, error) {
-		err := s1.RPC("Node.GetNode", &req, &out3)
-		if err != nil {
-			return false, err
-		}
-		if out.Node == nil {
-			return false, fmt.Errorf("missing reg")
-		}
-		must.Eq(t, structs.NodeSchedulingEligible, out3.Node.SchedulingEligibility)
-		return out3.Node.ID == req.NodeID, nil
-	}, func(err error) {
-		must.NoError(t, err)
-	})
+	must.Wait(t, wait.InitialSuccess(
+		wait.ErrorFunc(func() error {
+			err := s1.RPC("Node.GetNode", &req3, &out3)
+			if err != nil {
+				return err
+			}
+			must.Eq(t, structs.NodeSchedulingEligible, out3.Node.SchedulingEligibility)
+			return nil
+		}),
+		wait.Timeout(time.Second*1),
+		wait.Gap(time.Millisecond*30),
+	))
 
-	// Restart Client
+	// Save client config, shutdown and start new client
 	c1Config := c1.config.Copy()
 	must.NoError(t, c1.Shutdown())
-
-	// actually make and start the client
 	c2, err := NewClient(c1Config, c1.consulCatalog, nil, c1.consulServices, nil)
 	must.NoError(t, err)
 	t.Cleanup(func() {
 		test.NoError(t, c2.Shutdown())
 	})
 
+	// Assert new client and old client are same node
+	must.Eq(t, c1.NodeID(), c2.NodeID())
+
+	// Query to confirm restarted node is still be eligible
 	req4 := structs.NodeSpecificRequest{
 		NodeID:       c2.Node().ID,
 		QueryOptions: structs.QueryOptions{Region: "global"},
 	}
 	var out4 structs.SingleNodeResponse
+	must.Wait(t, wait.InitialSuccess(
+		wait.ErrorFunc(func() error {
+			err := s1.RPC("Node.GetNode", &req4, &out4)
+			if err != nil {
+				return err
+			}
+			must.Eq(t, structs.NodeSchedulingEligible, out4.Node.SchedulingEligibility)
+			return nil
+		}),
+		wait.Timeout(time.Second*1),
+		wait.Gap(time.Millisecond*30),
+	))
 
-	// Should still be eligible
-	testutil.WaitForResult(func() (bool, error) {
-		err := s1.RPC("Node.GetNode", &req4, &out4)
-		if err != nil {
-			return false, err
-		}
-		if out.Node == nil {
-			return false, fmt.Errorf("missing reg")
-		}
-		must.Eq(t, structs.NodeSchedulingEligible, out4.Node.SchedulingEligibility)
-		return out4.Node.ID == req.NodeID, nil
-	}, func(err error) {
-		must.NoError(t, err)
-	})
 }
 
 // TestClient_AllocPrerunErrorDuringRestore ensures that a running allocation,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2296,6 +2296,43 @@ func TestClient_ReconnectAllocs(t *testing.T) {
 	require.Equal(t, unknownAlloc.AllocModifyIndex, finalAlloc.AllocModifyIndex)
 }
 
+func TestClient_DefaultIneligible(t *testing.T) {
+	ci.Parallel(t)
+
+	s1, _, cleanupS1 := testServer(t, nil)
+	defer cleanupS1()
+	testutil.WaitForLeader(t, s1.RPC)
+
+	c1, cleanupC1 := TestClient(t, func(c *config.Config) {
+		c.DefaultIneligible = true
+		c.RPCHandler = s1
+	})
+	defer cleanupC1()
+
+	must.Eq(t, structs.NodeSchedulingIneligible, c1.Node().SchedulingEligibility)
+
+	req := structs.NodeSpecificRequest{
+		NodeID:       c1.Node().ID,
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
+	var out structs.SingleNodeResponse
+
+	// Register should succeed
+	testutil.WaitForResult(func() (bool, error) {
+		err := s1.RPC("Node.GetNode", &req, &out)
+		if err != nil {
+			return false, err
+		}
+		if out.Node == nil {
+			return false, fmt.Errorf("missing reg")
+		}
+		must.Eq(t, structs.NodeSchedulingIneligible, out.Node.SchedulingEligibility)
+		return out.Node.ID == req.NodeID, nil
+	}, func(err error) {
+		must.NoError(t, err)
+	})
+}
+
 // TestClient_AllocPrerunErrorDuringRestore ensures that a running allocation,
 // which fails Prerun during Restore on client restart, should be killed.
 func TestClient_AllocPrerunErrorDuringRestore(t *testing.T) {

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -374,6 +374,9 @@ type Config struct {
 	// used for template functions which require access to the Nomad API.
 	TemplateDialer *bufconndialer.BufConnWrapper
 
+	// DefaultIneligible disables scheduling eligibility for newly-created nodes.
+	DefaultIneligible bool
+
 	// APIListenerRegistrar allows the client to register listeners created at
 	// runtime (eg the Task API) with the agent's HTTP server. Since the agent
 	// creates the HTTP *after* the client starts, we have to use this shim to

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1161,6 +1161,8 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	}
 
 	conf.LogFile = agentConfig.LogFile
+	conf.DefaultIneligible = agentConfig.Client.DefaultIneligible
+
 	return conf, nil
 }
 

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -447,6 +447,9 @@ type ClientConfig struct {
 	// internal use.
 	Fingerprinters []*client.Fingerprint `hcl:"fingerprint"`
 
+	// DefaultIneligible disables scheduling eligibility for newly-created nodes.
+	DefaultIneligible bool `hcl:"default_ineligible"`
+
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 }
@@ -3014,6 +3017,10 @@ func (c *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	// supplied an override value.
 	if b.NomadServiceDiscovery != nil {
 		result.NomadServiceDiscovery = b.NomadServiceDiscovery
+	}
+
+	if b.DefaultIneligible {
+		result.DefaultIneligible = true
 	}
 
 	if b.CgroupParent != "" {


### PR DESCRIPTION
Specifies if scheduling eligibility should be disabled by default for new client nodes.

Fixes #13081, see this issue for discussion of the use-case.