### PR TITLE
docs: `mount_flags` takes a slice of strings

### DIFF
--- a/website/content/docs/commands/volume/register.mdx
+++ b/website/content/docs/commands/volume/register.mdx
@@ -129,7 +129,7 @@ context {
   to whether these options are required or necessary.
 
   - `fs_type`: file system type (ex. `"ext4"`)
-  - `mount_flags`: the flags passed to `mount` (ex. `"ro,noatime"`)
+  - `mount_flags`: the flags passed to `mount` (ex. `["ro", "noatime"]`)
 
 - `topology_request` <code>([TopologyRequest](#topology_request-parameters): nil)</code> -
   Specify locations (region, zone, rack, etc.)  where the provisioned


### PR DESCRIPTION
The description of `mount_flags` provides incorrect example
of the accepted value format.

This fixes the issue by changing the example from a string
`ro,noatime` to a slice of strings `["ro", "noatime"]`.