### PR TITLE
warn destructive update only when count > 1

### DIFF
--- a/.changelog/13103.txt
+++ b/.changelog/13103.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: warn destructive update only when count is greater than 1
+```

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6724,7 +6724,7 @@ func (tg *TaskGroup) Warnings(j *Job) error {
 	// Validate the update strategy
 	if u := tg.Update; u != nil {
 		// Check the counts are appropriate
-		if u.MaxParallel > tg.Count && !(j.IsMultiregion() && tg.Count == 0) {
+		if tg.Count > 1 && u.MaxParallel > tg.Count && !(j.IsMultiregion() && tg.Count == 0) {
 			mErr.Errors = append(mErr.Errors,
 				fmt.Errorf("Update max parallel count is greater than task group count (%d > %d). "+
 					"A destructive change would result in the simultaneous replacement of all allocations.", u.MaxParallel, tg.Count))

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -256,6 +256,36 @@ func TestJob_Warnings(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:     "Update.MaxParallel warning",
+			Expected: []string{"Update max parallel count is greater than task group count (5 > 2). A destructive change would result in the simultaneous replacement of all allocations."},
+			Job: &Job{
+				Type: JobTypeService,
+				TaskGroups: []*TaskGroup{
+					{
+						Count: 2,
+						Update: &UpdateStrategy{
+							MaxParallel: 5,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:     "Update.MaxParallel no warning",
+			Expected: []string{},
+			Job: &Job{
+				Type: JobTypeService,
+				TaskGroups: []*TaskGroup{
+					{
+						Count: 1,
+						Update: &UpdateStrategy{
+							MaxParallel: 5,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
The warning doesn't make sense when count is 0 or 1 (destructive anyway). It's distractive and may cause users to ignore useful warnings.