### PR TITLE
keystore serialization

### DIFF
--- a/api/keyring_test.go
+++ b/api/keyring_test.go
@@ -32,9 +32,9 @@ func TestKeyring_CRUD(t *testing.T) {
 
 	// Write a new active key, forcing a rotation
 	id := "fd77c376-9785-4c80-8e62-4ec3ab5f8b9a"
-	buf := make([]byte, 128)
+	buf := make([]byte, 32)
 	rand.Read(buf)
-	encodedKey := make([]byte, base64.StdEncoding.EncodedLen(128))
+	encodedKey := make([]byte, base64.StdEncoding.EncodedLen(32))
 	base64.StdEncoding.Encode(encodedKey, buf)
 
 	wm, err = kr.Update(&RootKey{

--- a/command/agent/keyring_endpoint.go
+++ b/command/agent/keyring_endpoint.go
@@ -94,8 +94,10 @@ func (s *HTTPServer) keyringUpsertRequest(resp http.ResponseWriter, req *http.Re
 		return nil, CodedError(400, "decoded key did not include metadata")
 	}
 
-	decodedKey := make([]byte, base64.StdEncoding.DecodedLen(len(key.Key)))
-	_, err := base64.StdEncoding.Decode(decodedKey, []byte(key.Key))
+	const keyLen = 32
+
+	decodedKey := make([]byte, keyLen)
+	_, err := base64.StdEncoding.Decode(decodedKey, []byte(key.Key)[:keyLen])
 	if err != nil {
 		return nil, CodedError(400, fmt.Sprintf("could not decode key: %v", err))
 	}

--- a/command/agent/keyring_endpoint_test.go
+++ b/command/agent/keyring_endpoint_test.go
@@ -46,9 +46,9 @@ func TestHTTP_Keyring_CRUD(t *testing.T) {
 		// Update
 
 		keyMeta := rotateResp.Key
-		keyBuf := make([]byte, 128)
+		keyBuf := make([]byte, 32)
 		rand.Read(keyBuf)
-		encodedKey := make([]byte, base64.StdEncoding.EncodedLen(128))
+		encodedKey := make([]byte, base64.StdEncoding.EncodedLen(32))
 		base64.StdEncoding.Encode(encodedKey, keyBuf)
 
 		newID := uuid.Generate()

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -20,6 +20,8 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
+const nomadKeystoreExtension = ".nks.json"
+
 // Encrypter is the keyring for secure variables.
 type Encrypter struct {
 	lock         sync.RWMutex
@@ -61,10 +63,10 @@ func encrypterFromKeystore(keystoreDirectory string) (*Encrypter, error) {
 		if path != keystoreDirectory && info.IsDir() {
 			return filepath.SkipDir
 		}
-		if !strings.HasSuffix(path, ".nks.json") {
+		if !strings.HasSuffix(path, nomadKeystoreExtension) {
 			return nil
 		}
-		id := strings.TrimSuffix(filepath.Base(path), ".nks.json")
+		id := strings.TrimSuffix(filepath.Base(path), nomadKeystoreExtension)
 		if !helper.IsUUID(id) {
 			return nil
 		}
@@ -190,7 +192,7 @@ func (e *Encrypter) saveKeyToStore(rootKey *structs.RootKey) error {
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(e.keystorePath, rootKey.Meta.KeyID+".nks.json")
+	path := filepath.Join(e.keystorePath, rootKey.Meta.KeyID+nomadKeystoreExtension)
 	err = os.WriteFile(path, buf.Bytes(), 0600)
 	if err != nil {
 		return err

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -2,37 +2,92 @@ package nomad
 
 import (
 	"bytes"
+	"crypto/aes"
 	"crypto/cipher"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 
 	"github.com/hashicorp/go-msgpack/codec"
+	"golang.org/x/crypto/chacha20poly1305"
+
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
+// Encrypter is the keyring for secure variables.
 type Encrypter struct {
-	ciphers      map[string]cipher.AEAD // map of key IDs to ciphers
+	lock         sync.RWMutex
+	keys         map[string]*structs.RootKey // map of key IDs to key material
+	ciphers      map[string]cipher.AEAD      // map of key IDs to ciphers
 	keystorePath string
 }
 
 // NewEncrypter loads or creates a new local keystore and returns an
 // encryption keyring with the keys it finds.
-func NewEncrypter(keystorePath string) *Encrypter {
+func NewEncrypter(keystorePath string) (*Encrypter, error) {
 	err := os.MkdirAll(keystorePath, 0700)
 	if err != nil {
-		panic(err) // TODO
+		return nil, err
 	}
+	encrypter, err := encrypterFromKeystore(keystorePath)
+	if err != nil {
+		return nil, err
+	}
+	return encrypter, nil
+}
+
+func encrypterFromKeystore(keystoreDirectory string) (*Encrypter, error) {
+
 	encrypter := &Encrypter{
 		ciphers:      make(map[string]cipher.AEAD),
-		keystorePath: keystorePath,
+		keys:         make(map[string]*structs.RootKey),
+		keystorePath: keystoreDirectory,
 	}
+
+	err := filepath.Walk(keystoreDirectory, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("could not read path %s from keystore: %v", path, err)
+		}
+
+		// skip over subdirectories and non-key files; they shouldn't
+		// be here but there's no reason to fail startup for it if the
+		// administrator has left something there
+		if path != keystoreDirectory && info.IsDir() {
+			return filepath.SkipDir
+		}
+		if filepath.Ext(path) != ".json" {
+			return nil
+		}
+		id := strings.TrimSuffix(filepath.Base(path), ".json")
+		if !helper.IsUUID(id) {
+			return nil
+		}
+
+		key, err := encrypter.LoadKeyFromStore(path)
+		if err != nil {
+			return fmt.Errorf("could not load key file %s from keystore: %v", path, err)
+		}
+		if key.Meta.KeyID != id {
+			return fmt.Errorf("root key ID %s must match key file %s", key.Meta.KeyID, path)
+		}
+
+		err = encrypter.AddKey(key)
+		if err != nil {
+			return fmt.Errorf("could not add key file %s to keystore: %v", path, err)
+		}
+		return nil
+	})
 	if err != nil {
-		panic(err) // TODO
+		return nil, err
 	}
-	return encrypter
+
+	return encrypter, nil
 }
 
 // Encrypt takes the serialized map[string][]byte from
@@ -40,6 +95,9 @@ func NewEncrypter(keystorePath string) *Encrypter {
 // for the algorithm, and encrypts the data with the ciper for the
 // CurrentRootKeyID. The buffer returned includes the nonce.
 func (e *Encrypter) Encrypt(unencryptedData []byte, keyID string) []byte {
+	e.lock.RLock()
+	defer e.lock.RUnlock()
+
 	// TODO: actually encrypt!
 	return unencryptedData
 }
@@ -47,18 +105,70 @@ func (e *Encrypter) Encrypt(unencryptedData []byte, keyID string) []byte {
 // Decrypt takes an encrypted buffer and then root key ID. It extracts
 // the nonce, decrypts the content, and returns the cleartext data.
 func (e *Encrypter) Decrypt(encryptedData []byte, keyID string) ([]byte, error) {
+	e.lock.RLock()
+	defer e.lock.RUnlock()
+
 	// TODO: actually decrypt!
 	return encryptedData, nil
 }
 
-// GenerateNewRootKey returns a new root key and its metadata.
-func (e *Encrypter) GenerateNewRootKey(algorithm structs.EncryptionAlgorithm) *structs.RootKey {
-	meta := structs.NewRootKeyMeta()
-	meta.Algorithm = algorithm
-	return &structs.RootKey{
-		Meta: meta,
-		Key:  []byte{}, // TODO: generate based on algorithm
+// AddKey stores the key in the keyring and creates a new cipher for it.
+func (e *Encrypter) AddKey(rootKey *structs.RootKey) error {
+
+	if rootKey.Meta == nil {
+		return fmt.Errorf("missing metadata")
 	}
+	var aead cipher.AEAD
+	var err error
+
+	switch rootKey.Meta.Algorithm {
+	case structs.EncryptionAlgorithmAES256GCM:
+		block, err := aes.NewCipher(rootKey.Key)
+		if err != nil {
+			return fmt.Errorf("could not create cipher: %v", err)
+		}
+		aead, err = cipher.NewGCM(block)
+		if err != nil {
+			return fmt.Errorf("could not create cipher: %v", err)
+		}
+	case structs.EncryptionAlgorithmXChaCha20:
+		aead, err = chacha20poly1305.NewX(rootKey.Key)
+		if err != nil {
+			return fmt.Errorf("could not create cipher: %v", err)
+		}
+	default:
+		return fmt.Errorf("invalid algorithm %s", rootKey.Meta.Algorithm)
+	}
+
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.ciphers[rootKey.Meta.KeyID] = aead
+	e.keys[rootKey.Meta.KeyID] = rootKey
+	return nil
+}
+
+// GetKey retrieves the key material by ID from the keyring
+func (e *Encrypter) GetKey(keyID string) ([]byte, error) {
+	e.lock.RLock()
+	defer e.lock.RUnlock()
+
+	key, ok := e.keys[keyID]
+	if !ok {
+		return []byte{}, fmt.Errorf("no such key %s in keyring", keyID)
+	}
+	return key.Key, nil
+}
+
+// RemoveKey removes a key by ID from the keyring
+func (e *Encrypter) RemoveKey(keyID string) error {
+	// TODO: should the server remove the serialized file here?
+	// TODO: given that it's irreverislbe, should the server *ever*
+	// remove the serialized file?
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	delete(e.ciphers, keyID)
+	delete(e.keys, keyID)
+	return nil
 }
 
 // SaveKeyToStore serializes a root key to the on-disk keystore.

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -29,12 +29,12 @@ func TestEncrypter_LoadSave(t *testing.T) {
 		t.Run(string(algo), func(t *testing.T) {
 			key, err := structs.NewRootKey(algo)
 			require.NoError(t, err)
-			require.NoError(t, encrypter.SaveKeyToStore(key))
+			require.NoError(t, encrypter.saveKeyToStore(key))
 
-			gotKey, err := encrypter.LoadKeyFromStore(
+			gotKey, err := encrypter.loadKeyFromStore(
 				filepath.Join(tmpDir, key.Meta.KeyID+".json"))
 			require.NoError(t, err)
-			require.NoError(t, encrypter.AddKey(gotKey))
+			require.NoError(t, encrypter.addCipher(gotKey))
 		})
 	}
 }

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -4,10 +4,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 )
 
 // TestEncrypter_LoadSave exercises round-tripping keys to disk
@@ -15,7 +17,8 @@ func TestEncrypter_LoadSave(t *testing.T) {
 	ci.Parallel(t)
 
 	tmpDir := t.TempDir()
-	encrypter := NewEncrypter(tmpDir)
+	encrypter, err := NewEncrypter(tmpDir)
+	require.NoError(t, err)
 
 	algos := []structs.EncryptionAlgorithm{
 		structs.EncryptionAlgorithmAES256GCM,
@@ -31,7 +34,68 @@ func TestEncrypter_LoadSave(t *testing.T) {
 			gotKey, err := encrypter.LoadKeyFromStore(
 				filepath.Join(tmpDir, key.Meta.KeyID+".json"))
 			require.NoError(t, err)
-			require.Len(t, gotKey.Key, 32)
+			require.NoError(t, encrypter.AddKey(gotKey))
 		})
 	}
+}
+
+// TestEncrypter_Restore exercises the entire reload of a keystore,
+// including pairing metadfata with key material
+func TestEncrypter_Restore(t *testing.T) {
+
+	ci.Parallel(t)
+
+	// use a known tempdir so that we can restore from it
+	tmpDir := t.TempDir()
+
+	srv, rootToken, shutdown := TestACLServer(t, func(c *Config) {
+		c.NodeName = "node1"
+		c.NumSchedulers = 0
+		c.DevMode = false
+		c.DataDir = tmpDir
+	})
+	defer shutdown()
+	testutil.WaitForLeader(t, srv.RPC)
+	codec := rpcClient(t, srv)
+
+	nodeID := srv.GetConfig().NodeID
+
+	// Send a few key rotations to add keys
+
+	rotateReq := &structs.KeyringRotateRootKeyRequest{
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			AuthToken: rootToken.SecretID,
+		},
+	}
+	var rotateResp structs.KeyringRotateRootKeyResponse
+	for i := 0; i < 4; i++ {
+		err := msgpackrpc.CallWithCodec(codec, "Keyring.Rotate", rotateReq, &rotateResp)
+		require.NoError(t, err)
+	}
+
+	shutdown()
+
+	srv2, rootToken, shutdown2 := TestACLServer(t, func(c *Config) {
+		c.NodeID = nodeID
+		c.NodeName = "node1"
+		c.NumSchedulers = 0
+		c.DevMode = false
+		c.DataDir = tmpDir
+	})
+	defer shutdown2()
+	testutil.WaitForLeader(t, srv2.RPC)
+	codec = rpcClient(t, srv2)
+
+	// Verify we've restored all the keys from the old keystore
+
+	listReq := &structs.KeyringListRootKeyMetaRequest{
+		QueryOptions: structs.QueryOptions{
+			Region: "global",
+		},
+	}
+	var listResp structs.KeyringListRootKeyMetaResponse
+	err := msgpackrpc.CallWithCodec(codec, "Keyring.List", listReq, &listResp)
+	require.NoError(t, err)
+	require.Len(t, listResp.Keys, 4)
 }

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -98,4 +98,20 @@ func TestEncrypter_Restore(t *testing.T) {
 	err := msgpackrpc.CallWithCodec(codec, "Keyring.List", listReq, &listResp)
 	require.NoError(t, err)
 	require.Len(t, listResp.Keys, 4)
+
+	for _, keyMeta := range listResp.Keys {
+
+		getReq := &structs.KeyringGetRootKeyRequest{
+			KeyID: keyMeta.KeyID,
+			QueryOptions: structs.QueryOptions{
+				Region: "global",
+			},
+		}
+		var getResp structs.KeyringGetRootKeyResponse
+		err = msgpackrpc.CallWithCodec(codec, "Keyring.Get", getReq, &getResp)
+		require.NoError(t, err)
+
+		gotKey := getResp.Key
+		require.Len(t, gotKey.Key, 32)
+	}
 }

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -32,7 +32,7 @@ func TestEncrypter_LoadSave(t *testing.T) {
 			require.NoError(t, encrypter.saveKeyToStore(key))
 
 			gotKey, err := encrypter.loadKeyFromStore(
-				filepath.Join(tmpDir, key.Meta.KeyID+".json"))
+				filepath.Join(tmpDir, key.Meta.KeyID+".nks.json"))
 			require.NoError(t, err)
 			require.NoError(t, encrypter.addCipher(gotKey))
 		})
@@ -40,7 +40,7 @@ func TestEncrypter_LoadSave(t *testing.T) {
 }
 
 // TestEncrypter_Restore exercises the entire reload of a keystore,
-// including pairing metadfata with key material
+// including pairing metadata with key material
 func TestEncrypter_Restore(t *testing.T) {
 
 	ci.Parallel(t)

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -1,0 +1,37 @@
+package nomad
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// TestEncrypter_LoadSave exercises round-tripping keys to disk
+func TestEncrypter_LoadSave(t *testing.T) {
+	ci.Parallel(t)
+
+	tmpDir := t.TempDir()
+	encrypter := NewEncrypter(tmpDir)
+
+	algos := []structs.EncryptionAlgorithm{
+		structs.EncryptionAlgorithmAES256GCM,
+		structs.EncryptionAlgorithmXChaCha20,
+	}
+
+	for _, algo := range algos {
+		t.Run(string(algo), func(t *testing.T) {
+			key, err := structs.NewRootKey(algo)
+			require.NoError(t, err)
+			require.NoError(t, encrypter.SaveKeyToStore(key))
+
+			gotKey, err := encrypter.LoadKeyFromStore(
+				filepath.Join(tmpDir, key.Meta.KeyID+".json"))
+			require.NoError(t, err)
+			require.Len(t, gotKey.Key, 32)
+		})
+	}
+}

--- a/nomad/keyring_endpoint.go
+++ b/nomad/keyring_endpoint.go
@@ -55,10 +55,6 @@ func (k *Keyring) Rotate(args *structs.KeyringRotateRootKeyRequest, reply *struc
 	if err != nil {
 		return err
 	}
-	err = k.encrypter.SaveKeyToStore(rootKey)
-	if err != nil {
-		return err
-	}
 
 	// Update metadata via Raft so followers can retrieve this key
 	req := structs.KeyringUpdateRootKeyMetaRequest{
@@ -150,10 +146,6 @@ func (k *Keyring) Update(args *structs.KeyringUpdateRootKeyRequest, reply *struc
 	// it to raft, so that followers don't try to Get a key that
 	// hasn't yet been written to disk
 	err = k.encrypter.AddKey(args.RootKey)
-	if err != nil {
-		return err
-	}
-	err = k.encrypter.SaveKeyToStore(args.RootKey)
 	if err != nil {
 		return err
 	}

--- a/nomad/keyring_endpoint.go
+++ b/nomad/keyring_endpoint.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
 
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -42,19 +41,28 @@ func (k *Keyring) Rotate(args *structs.KeyringRotateRootKeyRequest, reply *struc
 		args.Algorithm = structs.EncryptionAlgorithmXChaCha20
 	}
 
-	meta := structs.NewRootKeyMeta()
-	meta.Algorithm = args.Algorithm
-	meta.Active = true
+	rootKey, err := structs.NewRootKey(args.Algorithm)
+	if err != nil {
+		return err
+	}
 
-	// TODO: have the Encrypter generate and persist the actual key
-	// material. this is just here to silence the structcheck lint
-	for keyID := range k.encrypter.ciphers {
-		k.logger.Trace("TODO", "key", keyID)
+	rootKey.Meta.Active = true
+
+	// make sure it's been added to the local keystore before we write
+	// it to raft, so that followers don't try to Get a key that
+	// hasn't yet been written to disk
+	err = k.encrypter.AddKey(rootKey)
+	if err != nil {
+		return err
+	}
+	err = k.encrypter.SaveKeyToStore(rootKey)
+	if err != nil {
+		return err
 	}
 
 	// Update metadata via Raft so followers can retrieve this key
 	req := structs.KeyringUpdateRootKeyMetaRequest{
-		RootKeyMeta:  meta,
+		RootKeyMeta:  rootKey.Meta,
 		WriteRequest: args.WriteRequest,
 	}
 	out, index, err := k.srv.raftApply(structs.RootKeyMetaUpsertRequestType, req)
@@ -64,7 +72,7 @@ func (k *Keyring) Rotate(args *structs.KeyringRotateRootKeyRequest, reply *struc
 	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
-	reply.Key = meta
+	reply.Key = rootKey.Meta
 	reply.Index = index
 	return nil
 }
@@ -138,13 +146,25 @@ func (k *Keyring) Update(args *structs.KeyringUpdateRootKeyRequest, reply *struc
 		return err
 	}
 
+	// make sure it's been added to the local keystore before we write
+	// it to raft, so that followers don't try to Get a key that
+	// hasn't yet been written to disk
+	err = k.encrypter.AddKey(args.RootKey)
+	if err != nil {
+		return err
+	}
+	err = k.encrypter.SaveKeyToStore(args.RootKey)
+	if err != nil {
+		return err
+	}
+
 	// unwrap the request to turn it into a meta update only
 	metaReq := &structs.KeyringUpdateRootKeyMetaRequest{
 		RootKeyMeta:  args.RootKey.Meta,
 		WriteRequest: args.WriteRequest,
 	}
 
-	// update via Raft
+	// update the metadata via Raft
 	out, index, err := k.srv.raftApply(structs.RootKeyMetaUpsertRequestType, metaReq)
 	if err != nil {
 		return err
@@ -152,6 +172,7 @@ func (k *Keyring) Update(args *structs.KeyringUpdateRootKeyRequest, reply *struc
 	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
+
 	reply.Index = index
 	return nil
 }
@@ -160,20 +181,13 @@ func (k *Keyring) Update(args *structs.KeyringUpdateRootKeyRequest, reply *struc
 // existing key is valid
 func (k *Keyring) validateUpdate(args *structs.KeyringUpdateRootKeyRequest) error {
 
-	if args.RootKey.Meta == nil {
-		return fmt.Errorf("root key metadata is required")
+	err := args.RootKey.Meta.Validate()
+	if err != nil {
+		return err
 	}
-	if args.RootKey.Meta.KeyID == "" || !helper.IsUUID(args.RootKey.Meta.KeyID) {
-		return fmt.Errorf("root key UUID is required")
+	if len(args.RootKey.Key) == 0 {
+		return fmt.Errorf("root key material is required")
 	}
-	if args.RootKey.Meta.Algorithm == "" {
-		return fmt.Errorf("algorithm is required")
-	}
-
-	// TODO: once the encrypter is implemented
-	// if len(args.RootKey.Key) == 0 {
-	// 	return fmt.Errorf("root key material is required")
-	// }
 
 	// lookup any existing key and validate the update
 	snap, err := k.srv.fsm.State().Snapshot()
@@ -230,12 +244,16 @@ func (k *Keyring) Get(args *structs.KeyringGetRootKeyRequest, reply *structs.Key
 				return k.srv.replySetIndex(state.TableRootKeyMeta, &reply.QueryMeta)
 			}
 
-			// TODO: retrieve the key material from the keyring
-			key := &structs.RootKey{
-				Meta: keyMeta,
-				Key:  []byte{},
+			// retrieve the key material from the keyring
+			key, err := k.encrypter.GetKey(keyMeta.KeyID)
+			if err != nil {
+				return err
 			}
-			reply.Key = key
+			rootKey := &structs.RootKey{
+				Meta: keyMeta,
+				Key:  key,
+			}
+			reply.Key = rootKey
 			reply.Index = keyMeta.ModifyIndex
 			return nil
 		},
@@ -285,6 +303,10 @@ func (k *Keyring) Delete(args *structs.KeyringDeleteRootKeyRequest, reply *struc
 	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
+
+	// remove the key from the keyring too
+	k.encrypter.RemoveKey(args.KeyID)
+
 	reply.Index = index
 	return nil
 }

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1153,7 +1153,7 @@ func (s *Server) setupRPC(tlsWrap tlsutil.RegionWrapper) error {
 func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) error {
 
 	// Set up the keyring
-	encrypter, err := NewEncrypter(filepath.Join(s.config.DataDir, "server", "keystore"))
+	encrypter, err := NewEncrypter(filepath.Join(s.config.DataDir, "keystore"))
 	if err != nil {
 		return err
 	}

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1150,7 +1150,7 @@ func (s *Server) setupRPC(tlsWrap tlsutil.RegionWrapper) error {
 func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) {
 	// Add the static endpoints to the RPC server.
 
-	encrypter := NewEncrypter()
+	encrypter := NewEncrypter(os.TempDir()) // TODO
 
 	if s.staticEndpoints.Status == nil {
 		// Initialize the list just once

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -6644,6 +6644,11 @@ func (s *StateStore) UpsertRootKeyMeta(index uint64, rootKeyMeta *structs.RootKe
 		existing := raw.(*structs.RootKeyMeta)
 		rootKeyMeta.CreateIndex = existing.CreateIndex
 		rootKeyMeta.CreateTime = existing.CreateTime
+
+		// prevent resetting the encryptions count
+		if existing.EncryptionsCount > rootKeyMeta.EncryptionsCount {
+			rootKeyMeta.EncryptionsCount = existing.EncryptionsCount
+		}
 		isRotation = !existing.Active && rootKeyMeta.Active
 	} else {
 		rootKeyMeta.CreateIndex = index

--- a/nomad/structs/extensions.go
+++ b/nomad/structs/extensions.go
@@ -1,6 +1,7 @@
 package structs
 
 import (
+	"encoding/base64"
 	"reflect"
 )
 
@@ -12,6 +13,8 @@ var (
 		reflect.TypeOf(&Node{}):      nodeExt,
 		reflect.TypeOf(CSIVolume{}):  csiVolumeExt,
 		reflect.TypeOf(&CSIVolume{}): csiVolumeExt,
+		reflect.TypeOf(&RootKey{}):   rootKeyExt,
+		reflect.TypeOf(RootKey{}):    rootKeyExt,
 	}
 )
 
@@ -75,4 +78,24 @@ func csiVolumeExt(v interface{}) interface{} {
 	apiVol.Secrets = nil
 
 	return apiVol
+}
+
+// rootKeyExt safely serializes a RootKey by base64 encoding the key
+// material and extracting the metadata stub. We only store the root
+// key in the keystore and never in raft or return it via the API, so
+// by having this extension as the default we make it slightly harder
+// to misuse.
+func rootKeyExt(v interface{}) interface{} {
+	key := v.(*RootKey)
+
+	encodedKey := make([]byte, base64.StdEncoding.EncodedLen(len(key.Key)))
+	base64.StdEncoding.Encode(encodedKey, key.Key)
+
+	return &struct {
+		Meta *RootKeyMetaStub
+		Key  string
+	}{
+		Meta: key.Meta.Stub(),
+		Key:  string(encodedKey),
+	}
 }

--- a/nomad/structs/secure_variables.go
+++ b/nomad/structs/secure_variables.go
@@ -164,6 +164,30 @@ func NewRootKeyMeta() *RootKeyMeta {
 	}
 }
 
+// RootKeyMetaStub is for serializing root key metadata to the
+// keystore, not for the List API. It excludes frequently-changing
+// fields such as EncryptionsCount or ModifyIndex so we don't have to
+// sync them to the on-disk keystore when the fields are already in
+// raft.
+type RootKeyMetaStub struct {
+	KeyID      string
+	Algorithm  EncryptionAlgorithm
+	CreateTime time.Time
+	Active     bool
+}
+
+func (rkm *RootKeyMeta) Stub() *RootKeyMetaStub {
+	if rkm == nil {
+		return nil
+	}
+	return &RootKeyMetaStub{
+		KeyID:      rkm.KeyID,
+		Algorithm:  rkm.Algorithm,
+		CreateTime: rkm.CreateTime,
+		Active:     rkm.Active,
+	}
+
+}
 func (rkm *RootKeyMeta) Copy() *RootKeyMeta {
 	if rkm == nil {
 		return nil

--- a/nomad/structs/secure_variables.go
+++ b/nomad/structs/secure_variables.go
@@ -1,8 +1,16 @@
 package structs
 
 import (
+	"fmt"
 	"time"
 
+	// note: this is aliased so that it's more noticeable if someone
+	// accidentally swaps it out for math/rand via running goimports
+	cryptorand "crypto/rand"
+
+	"golang.org/x/crypto/chacha20poly1305"
+
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/uuid"
 )
 
@@ -143,6 +151,34 @@ type RootKey struct {
 	Key  []byte // serialized to keystore as base64 blob
 }
 
+// NewRootKey returns a new root key and its metadata.
+func NewRootKey(algorithm EncryptionAlgorithm) (*RootKey, error) {
+	meta := NewRootKeyMeta()
+	meta.Algorithm = algorithm
+
+	rootKey := &RootKey{
+		Meta: meta,
+	}
+
+	switch algorithm {
+	case EncryptionAlgorithmAES256GCM:
+		key := make([]byte, 32)
+		if _, err := cryptorand.Read(key); err != nil {
+			return nil, err
+		}
+		rootKey.Key = key
+
+	case EncryptionAlgorithmXChaCha20:
+		key := make([]byte, chacha20poly1305.KeySize)
+		if _, err := cryptorand.Read(key); err != nil {
+			return nil, err
+		}
+		rootKey.Key = key
+	}
+
+	return rootKey, nil
+}
+
 // RootKeyMeta is the metadata used to refer to a RootKey. It is
 // stored in raft.
 type RootKeyMeta struct {
@@ -194,6 +230,19 @@ func (rkm *RootKeyMeta) Copy() *RootKeyMeta {
 	}
 	out := *rkm
 	return &out
+}
+
+func (rkm *RootKeyMeta) Validate() error {
+	if rkm == nil {
+		return fmt.Errorf("root key metadata is required")
+	}
+	if rkm.KeyID == "" || !helper.IsUUID(rkm.KeyID) {
+		return fmt.Errorf("root key UUID is required")
+	}
+	if rkm.Algorithm == "" {
+		return fmt.Errorf("root key algorithm is required")
+	}
+	return nil
 }
 
 // EncryptionAlgorithm chooses which algorithm is used for

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -53,6 +53,7 @@ func TestServerErr(t *testing.T, cb func(*Config)) (*Server, func(), error) {
 
 	config.Build = version.Version + "+unittest"
 	config.DevMode = true
+	config.DataDir = t.TempDir()
 	config.EnableEventBroker = true
 	config.BootstrapExpect = 1
 	nodeNum := atomic.AddInt32(&nodeNumber, 1)


### PR DESCRIPTION
This changeset implements the keystore serialization/deserialization:

* Adds a JSON serialization extension for the `RootKey` struct, along with a metadata stub. When we serialize RootKey to the on-disk keystore, we want to base64 encode the key material but also exclude any frequently-changing fields which are stored in raft.
* Implements methods for loading/saving keys to the keystore.
* Implements methods for restoring the whole keystore from disk.
* Wires it all up with the `Keyring` RPC handlers and fixes up any fallout on tests.

Best reviewed commit-by-commit.