### PR TITLE
bootstrap keyring

### DIFF
--- a/api/keyring_test.go
+++ b/api/keyring_test.go
@@ -27,8 +27,7 @@ func TestKeyring_CRUD(t *testing.T) {
 	keys, qm, err := kr.List(&QueryOptions{WaitIndex: key.CreateIndex})
 	require.NoError(t, err)
 	assertQueryMeta(t, qm)
-	// TODO: there'll be 2 keys here once we get bootstrapping done
-	require.Len(t, keys, 1)
+	require.Len(t, keys, 2)
 
 	// Write a new active key, forcing a rotation
 	id := "fd77c376-9785-4c80-8e62-4ec3ab5f8b9a"
@@ -57,8 +56,12 @@ func TestKeyring_CRUD(t *testing.T) {
 	keys, qm, err = kr.List(&QueryOptions{WaitIndex: key.CreateIndex})
 	require.NoError(t, err)
 	assertQueryMeta(t, qm)
-	// TODO: there'll be 2 keys here once we get bootstrapping done
-	require.Len(t, keys, 1)
-	require.Equal(t, id, keys[0].KeyID)
-
+	require.Len(t, keys, 2)
+	for _, key := range keys {
+		if key.KeyID == id {
+			require.True(t, key.Active, "new key should be active")
+		} else {
+			require.False(t, key.Active, "initial key should be inactive")
+		}
+	}
 }

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -292,6 +292,12 @@ func (s *Server) establishLeadership(stopCh chan struct{}) error {
 	// Initialize scheduler configuration
 	s.getOrCreateSchedulerConfig()
 
+	// Create the first root key if it doesn't already exist
+	err := s.initializeKeyring()
+	if err != nil {
+		return err
+	}
+
 	// Initialize the ClusterID
 	_, _ = s.ClusterID()
 	// todo: use cluster ID for stuff, later!
@@ -1676,6 +1682,46 @@ func (s *Server) getOrCreateSchedulerConfig() *structs.SchedulerConfiguration {
 	}
 
 	return config
+}
+
+// initializeKeyring creates the first root key if the leader doesn't
+// already have one. The metadata will be replicated via raft and then
+// the followers will get the key material from their own key
+// replication.
+func (s *Server) initializeKeyring() error {
+
+	store := s.fsm.State()
+	keyMeta, err := store.GetActiveRootKeyMeta(nil)
+	if err != nil {
+		return err
+	}
+	if keyMeta != nil {
+		return nil
+	}
+
+	s.logger.Named("core").Trace("initializing keyring")
+
+	// TODO: algorithm should be set from config
+	rootKey, err := structs.NewRootKey(structs.EncryptionAlgorithmXChaCha20)
+	rootKey.Meta.Active = true
+	if err != nil {
+		return fmt.Errorf("could not initialize keyring: %v", err)
+	}
+
+	err = s.staticEndpoints.Keyring.encrypter.AddKey(rootKey)
+	if err != nil {
+		return fmt.Errorf("could not add initial key to keyring: %v", err)
+	}
+
+	if _, _, err = s.raftApply(structs.RootKeyMetaUpsertRequestType,
+		structs.KeyringUpdateRootKeyMetaRequest{
+			RootKeyMeta: rootKey.Meta,
+		}); err != nil {
+		return fmt.Errorf("could not initialize keyring: %v", err)
+	}
+
+	s.logger.Named("core").Info("initialized keyring", "id", rootKey.Meta.KeyID)
+	return nil
 }
 
 func (s *Server) generateClusterID() (string, error) {

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1176,6 +1176,7 @@ func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) error {
 		s.staticEndpoints.Search = &Search{srv: s, logger: s.logger.Named("search")}
 		s.staticEndpoints.Namespace = &Namespace{srv: s}
 		s.staticEndpoints.SecureVariables = &SecureVariables{srv: s, logger: s.logger.Named("secure_variables"), encrypter: encrypter}
+		s.staticEndpoints.Keyring = &Keyring{srv: s, logger: s.logger.Named("keyring"), encrypter: encrypter}
 
 		s.staticEndpoints.Enterprise = NewEnterpriseEndpoints(s)
 
@@ -1233,7 +1234,7 @@ func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) error {
 	node := &Node{srv: s, ctx: ctx, logger: s.logger.Named("client")}
 	plan := &Plan{srv: s, ctx: ctx, logger: s.logger.Named("plan")}
 	serviceReg := &ServiceRegistration{srv: s, ctx: ctx}
-	keyringReg := &Keyring{srv: s, logger: s.logger.Named("keyring"), encrypter: encrypter}
+	keyringReg := &Keyring{srv: s, ctx: ctx, logger: s.logger.Named("keyring"), encrypter: encrypter}
 
 	// Register the dynamic endpoints
 	server.Register(alloc)


### PR DESCRIPTION
When a server becomes leader, it will check if there are any keys in
the state store, and create one if there is not. The key metadata will
be replicated via raft to all followers, who will then get the key
material via key replication (not implemented in this changeset).

---

I had to update a bunch of tests because we now have an extra key available. I've also tested with a real server. Here it is immediately after boot:

```
$ nomad operator api /v1/operator/keyring/keys | jq .
[
  {
    "Active": true,
    "Algorithm": "xchacha20",
    "CreateIndex": 6,
    "CreateTime": "2022-05-25T19:25:39.063326305Z",
    "EncryptionsCount": 0,
    "KeyID": "c7ad1921-0fab-48f7-71df-fda1300ee248",
    "ModifyIndex": 6
  }
]

$ nomad operator api -X POST /v1/operator/keyring/rotate | jq .
{
  "Index": 11,
  "Key": {
    "Active": true,
    "Algorithm": "xchacha20",
    "CreateIndex": 0,
    "CreateTime": "2022-05-25T19:26:26.144456955Z",
    "EncryptionsCount": 0,
    "KeyID": "d1a1675c-dc26-0daa-0e0f-132c92470c97",
    "ModifyIndex": 0
  }
}
```

Restart the server. It'll restore from raft and the key material in the keystore:

```
$ sudo tree /var/nomad/data/server/keystore
/var/nomad/data/server/keystore
├── c7ad1921-0fab-48f7-71df-fda1300ee248.nks.json
└── d1a1675c-dc26-0daa-0e0f-132c92470c97.nks.json

0 directories, 2 files

$ nomad operator api /v1/operator/keyring/keys | jq .
[
  {
    "Active": false,
    "Algorithm": "xchacha20",
    "CreateIndex": 6,
    "CreateTime": "2022-05-25T19:25:39.063326305Z",
    "EncryptionsCount": 0,
    "KeyID": "c7ad1921-0fab-48f7-71df-fda1300ee248",
    "ModifyIndex": 11
  },
  {
    "Active": true,
    "Algorithm": "xchacha20",
    "CreateIndex": 11,
    "CreateTime": "2022-05-25T19:26:26.145603078Z",
    "EncryptionsCount": 0,
    "KeyID": "d1a1675c-dc26-0daa-0e0f-132c92470c97",
    "ModifyIndex": 11
  }
]

$ sudo cat /var/nomad/data/server/keystore/c7ad1921-0fab-48f7-71df-fda1300ee248.nks.json | jq .
{
  "Key": "gSj9Lf/9+QgH5+aH4FEmCROjBLhRMHSuAAAAAAAAAAA=",
  "Meta": {
    "Active": true,
    "Algorithm": "xchacha20",
    "CreateTime": "2022-05-25T19:25:39.061972801Z",
    "KeyID": "c7ad1921-0fab-48f7-71df-fda1300ee248"
  }
}
```