### PR TITLE
Secure Variables: show/hide functionality when adding new values

### DIFF
--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -29,7 +29,7 @@
           />
       </label>
 
-      <label>
+      <label class="value-label">
         <span>Value
         </span>
         <Input
@@ -38,24 +38,27 @@
           class="input value-input"
           autocomplete="new-password" {{!-- prevent auto-fill --}}
           />
+        <button
+          class="show-hide-values button is-light"
+          type="button"
+          tabindex="-1"
+          {{on "click" this.toggleShowHide}}
+        >
+          <FlightIcon
+            @name={{if this.shouldHideValues "eye-off" "eye"}}
+            @title={{if this.shouldHideValues "Show Values" "Hide Values"}}
+          />
+        </button>
       </label>
-
-      <button
-        class="show-hide-values button is-borderless"
-        type="button"
-        tabindex="-1"
-        {{on "click" this.toggleShowHide}}
-      >
-        <FlightIcon
-          @name={{if this.shouldHideValues "eye-off" "eye"}}
-          @title={{if this.shouldHideValues "Show Values" "Hide Values"}}
-        />
-      </button>
 
       {{#if (eq entry this.keyValues.lastObject)}}
         <button
           {{on "click" this.appendRow}}
-          class="add-more button is-light is-borderless" type="button">Add More</button>
+          class="add-more button is-info is-inverted" type="button">Add More</button>
+      {{else}}
+        <button
+          {{on "click" (action this.deleteRow entry)}}
+          class="add-more button is-danger is-inverted" type="button">Delete</button>
       {{/if}}
     </div>
     {{/each}}

--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -1,6 +1,7 @@
   <form
     class="new-secure-variables"
     {{on "submit" this.saveNewVariable}}
+    autocopmlete="off"
   >
     {{!-- TODO: {{if this.parseError 'is-danger'}} on inputs --}}
     <div>
@@ -27,11 +28,25 @@
           />
       </label>
       <label>
-        <span>Value</span>
+        <span>Value
+        <button
+          class="show-hide-values button is-borderless is-compact"
+          type="button"
+          tabindex="-1"
+          {{on "click" this.toggleShowHide}}
+        >
+          <FlightIcon
+            @name="{{if this.hideValues "eye-off" "eye"}}"
+            @title="{{if this.hideValues "Show Values" "Hide Values"}}"
+          />
+        </button>
+        </span>
         <Input
-          @type="text"
+          @type={{this.valueFieldType}}
           @value={{entry.value}}
-          class="input" />
+          class="input value-input"
+          autocomplete="new-password" {{!-- prevent auto-fill --}}
+          />
       </label>
       {{#if (eq entry this.keyValues.lastObject)}}
         <button

--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -47,8 +47,8 @@
         {{on "click" this.toggleShowHide}}
       >
         <FlightIcon
-          @name="{{if this.hideValues "eye-off" "eye"}}"
-          @title="{{if this.hideValues "Show Values" "Hide Values"}}"
+          @name={{if this.shouldHideValues "eye-off" "eye"}}
+          @title={{if this.shouldHideValues "Show Values" "Hide Values"}}
         />
       </button>
 

--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -58,7 +58,7 @@
       {{else}}
         <button
           {{on "click" (action this.deleteRow entry)}}
-          class="add-more button is-danger is-inverted" type="button">Delete</button>
+          class="delete-row button is-danger is-inverted" type="button">Delete</button>
       {{/if}}
     </div>
     {{/each}}

--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -1,7 +1,7 @@
   <form
     class="new-secure-variables"
     {{on "submit" this.saveNewVariable}}
-    autocopmlete="off"
+    autocomplete="off"
   >
     {{!-- TODO: {{if this.parseError 'is-danger'}} on inputs --}}
     <div>

--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -18,6 +18,7 @@
     </div>
     {{#each this.keyValues as |entry iter|}}
     <div class="key-value">
+
       <label>
         <span>Key</span>
         <Input
@@ -27,19 +28,9 @@
           {{autofocus ignore=(eq iter 0)}}
           />
       </label>
+
       <label>
         <span>Value
-        <button
-          class="show-hide-values button is-borderless is-compact"
-          type="button"
-          tabindex="-1"
-          {{on "click" this.toggleShowHide}}
-        >
-          <FlightIcon
-            @name="{{if this.hideValues "eye-off" "eye"}}"
-            @title="{{if this.hideValues "Show Values" "Hide Values"}}"
-          />
-        </button>
         </span>
         <Input
           @type={{this.valueFieldType}}
@@ -48,6 +39,19 @@
           autocomplete="new-password" {{!-- prevent auto-fill --}}
           />
       </label>
+
+      <button
+        class="show-hide-values button is-borderless"
+        type="button"
+        tabindex="-1"
+        {{on "click" this.toggleShowHide}}
+      >
+        <FlightIcon
+          @name="{{if this.hideValues "eye-off" "eye"}}"
+          @title="{{if this.hideValues "Show Values" "Hide Values"}}"
+        />
+      </button>
+
       {{#if (eq entry this.keyValues.lastObject)}}
         <button
           {{on "click" this.appendRow}}

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -4,6 +4,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
+// eslint-disable-next-line no-unused-vars
 import MutableArray from '@ember/array/mutable';
 
 /**

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -22,7 +22,6 @@ export default class SecureVariableFormComponent extends Component {
   }
 
   @action appendRow() {
-    this.keyValues.reverseObjects();
     this.keyValues.pushObject({
       key: '',
       value: '',

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -1,10 +1,28 @@
+// @ts-check
+
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { A } from '@ember/array';
 
 export default class SecureVariableFormComponent extends Component {
-  keyValues = [{ key: '', value: '' }];
+  path = '';
+  keyValues = A([{ key: '', value: '' }]);
+
+  @tracked
+  hideValues = true;
+
+  get valueFieldType() {
+    return this.hideValues ? 'password' : 'text';
+  }
+
+  @action
+  toggleShowHide() {
+    this.hideValues = !this.hideValues;
+  }
 
   @action appendRow() {
+    this.keyValues.reverseObjects();
     this.keyValues.pushObject({
       key: '',
       value: '',

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -4,9 +4,21 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
+import MutableArray from '@ember/array/mutable';
+
+/**
+ * @typedef SecureVariable
+ * @type {object}
+ * @property {string} key
+ * @property {string} value
+ */
 
 export default class SecureVariableFormComponent extends Component {
   path = '';
+
+  /**
+   * @type {MutableArray<SecureVariable>}
+   */
   keyValues = A([{ key: '', value: '' }]);
 
   @tracked
@@ -26,6 +38,14 @@ export default class SecureVariableFormComponent extends Component {
       key: '',
       value: '',
     });
+  }
+
+  /**
+   *
+   * @param {SecureVariable} row
+   */
+  @action deleteRow(row) {
+    this.keyValues.removeObject(row);
   }
 
   @action

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -10,15 +10,15 @@ export default class SecureVariableFormComponent extends Component {
   keyValues = A([{ key: '', value: '' }]);
 
   @tracked
-  hideValues = true;
+  shouldHideValues = true;
 
   get valueFieldType() {
-    return this.hideValues ? 'password' : 'text';
+    return this.shouldHideValues ? 'password' : 'text';
   }
 
   @action
   toggleShowHide() {
-    this.hideValues = !this.hideValues;
+    this.shouldHideValues = !this.shouldHideValues;
   }
 
   @action appendRow() {

--- a/ui/app/controllers/variables/new.js
+++ b/ui/app/controllers/variables/new.js
@@ -8,6 +8,9 @@ export default class VariablesNewController extends Controller {
   async saveNewVariable({ path, keyValues }) {
     // TODO: validation
 
+    // get rid of incomplete values before saving
+    keyValues = keyValues.reject((kv) => !kv.key);
+
     // Transform key value array into object
     const items = keyValues.reduce((acc, { key, value }) => {
       acc[key] = value;

--- a/ui/app/styles/components/secure-variables.scss
+++ b/ui/app/styles/components/secure-variables.scss
@@ -4,18 +4,22 @@
   }
   .key-value {
     display: grid;
-    grid-template-columns: 1fr 4fr auto auto;
+    grid-template-columns: 1fr 4fr 130px;
     gap: 1rem;
     align-items: end;
 
-    button.show-hide-values {
-      background-color: transparent;
-      border: none;
-      margin-left: -1rem;
-      box-shadow: none;
-      &:hover {
-        color: $nomad-green;
+    .value-label {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      & > span {
+        grid-column: -1 / 1;
       }
+    }
+
+    button.show-hide-values {
+      height: 100%;
+      box-shadow: none;
+      margin-left: -1px;
     }
   }
 

--- a/ui/app/styles/components/secure-variables.scss
+++ b/ui/app/styles/components/secure-variables.scss
@@ -19,11 +19,12 @@
     button.show-hide-values {
       height: 100%;
       box-shadow: none;
-      margin-left: -1px;
+      margin-left: -2px;
+      border-color: $grey-blue;
     }
   }
 
-  .add-more:focus {
-    background-color: $grey-lighter;
-  }
+  // .add-more:focus {
+  //   background-color: $grey-lighter;
+  // }
 }

--- a/ui/app/styles/components/secure-variables.scss
+++ b/ui/app/styles/components/secure-variables.scss
@@ -7,6 +7,21 @@
     grid-template-columns: 1fr 4fr auto;
     gap: 1rem;
     align-items: end;
+
+    span {
+      display: flex;
+      align-items: center;
+    }
+
+    button.show-hide-values {
+      pointer-events: none;
+      cursor: pointer;
+      background-color: transparent;
+      height: auto;
+      &:hover {
+        color: $nomad-green;
+      }
+    }
   }
 
   .add-more:focus {

--- a/ui/app/styles/components/secure-variables.scss
+++ b/ui/app/styles/components/secure-variables.scss
@@ -4,20 +4,15 @@
   }
   .key-value {
     display: grid;
-    grid-template-columns: 1fr 4fr auto;
+    grid-template-columns: 1fr 4fr auto auto;
     gap: 1rem;
     align-items: end;
 
-    span {
-      display: flex;
-      align-items: center;
-    }
-
     button.show-hide-values {
-      pointer-events: none;
-      cursor: pointer;
       background-color: transparent;
-      height: auto;
+      border: none;
+      margin-left: -1rem;
+      box-shadow: none;
       &:hover {
         color: $nomad-green;
       }

--- a/ui/jsconfig.json
+++ b/ui/jsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
-      "experimentalDecorators": true
-    }
+      "experimentalDecorators": true,
+      "target": "es5",
+    },
+
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -170,6 +170,7 @@
     ]
   },
   "dependencies": {
+    "@hashicorp/ember-flight-icons": "^2.0.5",
     "@percy/cli": "^1.1.0",
     "@percy/ember": "^3.0.0",
     "codemirror": "^5.56.0",

--- a/ui/tests/integration/components/secure-variable-form-test.js
+++ b/ui/tests/integration/components/secure-variable-form-test.js
@@ -13,8 +13,8 @@ module('Integration | Component | secure-variable-form', function (hooks) {
     await componentA11yAudit(this.element, assert);
   });
 
-  test('shows a single row by default and expands on "Add More"', async function (assert) {
-    assert.expect(3);
+  test('shows a single row by default and modifies on "Add More" and "Delete"', async function (assert) {
+    assert.expect(4);
 
     await render(hbs`<SecureVariableForm />`);
 
@@ -38,6 +38,14 @@ module('Integration | Component | secure-variable-form', function (hooks) {
       findAll('div.key-value').length,
       3,
       'A third KV row exists after adding a new one'
+    );
+
+    await click('.key-value button.delete-row');
+
+    assert.equal(
+      findAll('div.key-value').length,
+      2,
+      'Back down to two rows after hitting delete'
     );
   });
 

--- a/ui/tests/integration/components/secure-variable-form-test.js
+++ b/ui/tests/integration/components/secure-variable-form-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | secure-variable-form', function (hooks) {
   });
 
   test('shows a single row by default and expands on "Add More"', async function (assert) {
-    // assert.expect(6);
+    assert.expect(3);
 
     await render(hbs`<SecureVariableForm />`);
 
@@ -42,6 +42,8 @@ module('Integration | Component | secure-variable-form', function (hooks) {
   });
 
   test('Values can be toggled to show/hide', async function (assert) {
+    assert.expect(6);
+
     await render(hbs`<SecureVariableForm />`);
     await click('.key-value button.add-more'); // add a second variable
 

--- a/ui/tests/integration/components/secure-variable-form-test.js
+++ b/ui/tests/integration/components/secure-variable-form-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | secure-variable-form', function (hooks) {
       'A single KV row exists by default'
     );
 
-    await click('.key-value button');
+    await click('.key-value button.add-more');
 
     assert.equal(
       findAll('div.key-value').length,
@@ -32,12 +32,43 @@ module('Integration | Component | secure-variable-form', function (hooks) {
       'A second KV row exists after adding a new one'
     );
 
-    await click('.key-value button');
+    await click('.key-value button.add-more');
 
     assert.equal(
       findAll('div.key-value').length,
       3,
       'A third KV row exists after adding a new one'
     );
+  });
+
+  test('Values can be toggled to show/hide', async function (assert) {
+    await render(hbs`<SecureVariableForm />`);
+    await click('.key-value button.add-more'); // add a second variable
+
+    findAll('input.value-input').forEach((input, iter) => {
+      assert.equal(
+        input.getAttribute('type'),
+        'password',
+        `Value ${iter + 1} is hidden by default`
+      );
+    });
+
+    await click('.key-value button.show-hide-values');
+    findAll('input.value-input').forEach((input, iter) => {
+      assert.equal(
+        input.getAttribute('type'),
+        'text',
+        `Value ${iter + 1} is shown when toggled`
+      );
+    });
+
+    await click('.key-value button.show-hide-values');
+    findAll('input.value-input').forEach((input, iter) => {
+      assert.equal(
+        input.getAttribute('type'),
+        'password',
+        `Value ${iter + 1} is hidden when toggled again`
+      );
+    });
   });
 });

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3085,6 +3085,20 @@
   resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-1.1.0.tgz#d6dbc7574774b238114582410e8fee0dc3532bdf"
   integrity sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A==
 
+"@hashicorp/ember-flight-icons@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@hashicorp/ember-flight-icons/-/ember-flight-icons-2.0.5.tgz#a1edfdd24475ecd0cf07cd1f944e2e5bdb5e97cc"
+  integrity sha512-PXNk1aRBjYSGeoB4e2ovOBm6RhGKE554XjW8leYYK+y9yorHhJNNwWRkwjhDRLYWikLhNmfwp6nAYOJWl/IOgw==
+  dependencies:
+    "@hashicorp/flight-icons" "^2.3.1"
+    ember-cli-babel "^7.26.11"
+    ember-cli-htmlbars "^6.0.1"
+
+"@hashicorp/flight-icons@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-2.3.1.tgz#0b0dc259c0a4255c5613174db7192ab48523ca6f"
+  integrity sha512-WGCMMixkmYCP5Dyz4QW7XjW4zDhIc7njkVVucoj7Iv7abtfgQDWwm05Ja2aBJTxFHiP4jat9w9cbGNgC6QHmZQ==
+
 "@hashicorp/structure-icons@^1.3.0":
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/@hashicorp/structure-icons/-/structure-icons-1.9.2.tgz#c75f955b2eec414ecb92f3926c79b4ca01731d3c"


### PR DESCRIPTION
(Twig branch of #13069; resolves #13128)

- Hides values in the values field by default (shows them as stars, default password field behaviour)
- Allows the ability to toggle show/hide of those fields

### Side-effects
- Introduces HashiCorp's [Flight Icons](https://flight-hashicorp.vercel.app/) library. We'll probably move to this over x-icon across the app with time.
- Adds a target to our jsconfig to allow Glimmer type-checking to work. Otherwise, `//@ts-check` on ember files with `@action` or `get()` will throw type errors.


### Screenshots
Default
![image](https://user-images.githubusercontent.com/713991/170535311-cdd57f61-b200-488b-9544-6866cd1ad5db.png)

Toggled
![image](https://user-images.githubusercontent.com/713991/170535353-b638adcc-5aad-4910-89e6-e79c416b6e53.png)
