### PR TITLE
connect: support for configuration upstream destination type

### DIFF
--- a/.changelog/13143.txt
+++ b/.changelog/13143.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: added support for setting upstream destination type
+```

--- a/api/consul.go
+++ b/api/consul.go
@@ -197,6 +197,7 @@ func (c *ConsulMeshGateway) Copy() *ConsulMeshGateway {
 type ConsulUpstream struct {
 	DestinationName      string             `mapstructure:"destination_name" hcl:"destination_name,optional"`
 	DestinationNamespace string             `mapstructure:"destination_namespace" hcl:"destination_namespace,optional"`
+	DestinationType      string             `mapstructure:"destination_type" hcl:"destination_type,optional"`
 	LocalBindPort        int                `mapstructure:"local_bind_port" hcl:"local_bind_port,optional"`
 	Datacenter           string             `mapstructure:"datacenter" hcl:"datacenter,optional"`
 	LocalBindAddress     string             `mapstructure:"local_bind_address" hcl:"local_bind_address,optional"`
@@ -210,6 +211,7 @@ func (cu *ConsulUpstream) Copy() *ConsulUpstream {
 	return &ConsulUpstream{
 		DestinationName:      cu.DestinationName,
 		DestinationNamespace: cu.DestinationNamespace,
+		DestinationType:      cu.DestinationType,
 		LocalBindPort:        cu.LocalBindPort,
 		Datacenter:           cu.Datacenter,
 		LocalBindAddress:     cu.LocalBindAddress,

--- a/api/consul_test.go
+++ b/api/consul_test.go
@@ -165,6 +165,7 @@ func TestConsulUpstream_Copy(t *testing.T) {
 		cu := &ConsulUpstream{
 			DestinationName:      "dest1",
 			DestinationNamespace: "ns2",
+			DestinationType:      "prepared_query",
 			Datacenter:           "dc2",
 			LocalBindPort:        2000,
 			LocalBindAddress:     "10.0.0.1",
@@ -188,6 +189,7 @@ func TestConsulUpstream_Canonicalize(t *testing.T) {
 		cu := &ConsulUpstream{
 			DestinationName:      "dest1",
 			DestinationNamespace: "ns2",
+			DestinationType:      "prepared_query",
 			Datacenter:           "dc2",
 			LocalBindPort:        2000,
 			LocalBindAddress:     "10.0.0.1",
@@ -197,6 +199,7 @@ func TestConsulUpstream_Canonicalize(t *testing.T) {
 		require.Equal(t, &ConsulUpstream{
 			DestinationName:      "dest1",
 			DestinationNamespace: "ns2",
+			DestinationType:      "prepared_query",
 			Datacenter:           "dc2",
 			LocalBindPort:        2000,
 			LocalBindAddress:     "10.0.0.1",

--- a/command/agent/consul/connect.go
+++ b/command/agent/consul/connect.go
@@ -197,6 +197,7 @@ func connectUpstreams(in []structs.ConsulUpstream) []api.Upstream {
 		upstreams[i] = api.Upstream{
 			DestinationName:      upstream.DestinationName,
 			DestinationNamespace: upstream.DestinationNamespace,
+			DestinationType:      api.UpstreamDestType(upstream.DestinationType),
 			LocalBindPort:        upstream.LocalBindPort,
 			Datacenter:           upstream.Datacenter,
 			LocalBindAddress:     upstream.LocalBindAddress,

--- a/command/agent/consul/connect_test.go
+++ b/command/agent/consul/connect_test.go
@@ -362,6 +362,7 @@ func TestConnect_connectUpstreams(t *testing.T) {
 			}, {
 				DestinationName:      "bar",
 				DestinationNamespace: "ns2",
+				DestinationType:      "prepared_query",
 				LocalBindPort:        9000,
 				Datacenter:           "dc2",
 				LocalBindAddress:     "127.0.0.2",
@@ -372,6 +373,7 @@ func TestConnect_connectUpstreams(t *testing.T) {
 			}, {
 				DestinationName:      "bar",
 				DestinationNamespace: "ns2",
+				DestinationType:      "prepared_query",
 				LocalBindPort:        9000,
 				Datacenter:           "dc2",
 				LocalBindAddress:     "127.0.0.2",

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1630,6 +1630,7 @@ func apiUpstreamsToStructs(in []*api.ConsulUpstream) []structs.ConsulUpstream {
 		upstreams[i] = structs.ConsulUpstream{
 			DestinationName:      upstream.DestinationName,
 			DestinationNamespace: upstream.DestinationNamespace,
+			DestinationType:      upstream.DestinationType,
 			LocalBindPort:        upstream.LocalBindPort,
 			Datacenter:           upstream.Datacenter,
 			LocalBindAddress:     upstream.LocalBindAddress,

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -3681,6 +3681,7 @@ func TestConversion_apiUpstreamsToStructs(t *testing.T) {
 	require.Equal(t, []structs.ConsulUpstream{{
 		DestinationName:      "upstream",
 		DestinationNamespace: "ns2",
+		DestinationType:      "prepared_query",
 		LocalBindPort:        8000,
 		Datacenter:           "dc2",
 		LocalBindAddress:     "127.0.0.2",
@@ -3688,6 +3689,7 @@ func TestConversion_apiUpstreamsToStructs(t *testing.T) {
 	}}, apiUpstreamsToStructs([]*api.ConsulUpstream{{
 		DestinationName:      "upstream",
 		DestinationNamespace: "ns2",
+		DestinationType:      "prepared_query",
 		LocalBindPort:        8000,
 		Datacenter:           "dc2",
 		LocalBindAddress:     "127.0.0.2",

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -2775,6 +2775,7 @@ func TestTaskGroupDiff(t *testing.T) {
 										{
 											DestinationName:      "foo",
 											DestinationNamespace: "ns2",
+											DestinationType:      "prepared_query",
 											LocalBindPort:        8000,
 											Datacenter:           "dc2",
 											LocalBindAddress:     "127.0.0.2",
@@ -3107,6 +3108,12 @@ func TestTaskGroupDiff(t *testing.T) {
 																Name: "DestinationNamespace",
 																Old:  "",
 																New:  "ns2",
+															},
+															{
+																Type: DiffTypeAdded,
+																Name: "DestinationType",
+																Old:  "",
+																New:  "prepared_query",
 															},
 															{
 																Type: DiffTypeAdded,

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -603,6 +603,37 @@ func TestConsulExposePath_exposePathsEqual(t *testing.T) {
 	})
 }
 
+func TestConsulUpstream_Validate(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("nil", func(t *testing.T) {
+		require.NoError(t, (*ConsulUpstream)(nil).Validate())
+	})
+
+	t.Run("missing destination_name", func(t *testing.T) {
+		err := (&ConsulUpstream{
+			DestinationName: "",
+		}).Validate()
+		require.EqualError(t, err, "upstream.destination_name must be set")
+	})
+
+	t.Run("invalid destination_type", func(t *testing.T) {
+		err := (&ConsulUpstream{
+			DestinationName: "example",
+			DestinationType: "banana",
+		}).Validate()
+		require.EqualError(t, err, `upstream.destination_type must be "service" or "prepared_query", got "banana"`)
+	})
+
+	t.Run("normal", func(t *testing.T) {
+		err := (&ConsulUpstream{
+			DestinationName: "example",
+			DestinationType: "prepared_query",
+		}).Validate()
+		require.NoError(t, err)
+	})
+}
+
 func TestConsulExposeConfig_Copy(t *testing.T) {
 	ci.Parallel(t)
 

--- a/website/content/docs/job-specification/upstreams.mdx
+++ b/website/content/docs/job-specification/upstreams.mdx
@@ -83,6 +83,9 @@ job "countdash" {
 
 - `destination_name` `(string: <required>)` - Name of the upstream service.
 - `destination_namespace` `(string: <required>)` - Name of the upstream Consul namespace.
+- `destination_type` `(string: "service")` - Specifies the type of discovery query
+  the proxy should use for finding service mesh instances. Must be either `"service"`
+  or `"prepared_query"`.
 - `local_bind_port` - `(int: <required>)` - The port the proxy will receive
   connections for the upstream on.
 - `datacenter` `(string: "")` - The Consul datacenter in which to issue the


### PR DESCRIPTION
This PR adds support for setting a Connect `upstream.destination_type`,
which can be either `"service"` or `"prepared_query"`, defaulting to `"service"`.

https://www.consul.io/docs/connect/registration/service-registration#proxy-parameters

https://www.consul.io/api-docs/query#create-prepared-query


