### PR TITLE
Autofocus modifier and better Add More button UX

### DIFF
--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -10,17 +10,21 @@
           @type="text"
           @value={{this.path}}
           placeholder="/path/to/variable"
-          class="input" />
+          class="input"
+          {{autofocus}}
+          />
       </label>
     </div>
-    {{#each this.keyValues as |entry|}}
+    {{#each this.keyValues as |entry iter|}}
     <div class="key-value">
       <label>
         <span>Key</span>
         <Input
           @type="text"
           @value={{entry.key}}
-          class="input" />
+          class="input"
+          {{autofocus ignore=(eq iter 0)}}
+          />
       </label>
       <label>
         <span>Value</span>
@@ -29,9 +33,11 @@
           @value={{entry.value}}
           class="input" />
       </label>
-      <button
-        {{on "click" this.appendRow}}
-        class="button is-light is-borderless" type="button">Add More</button>
+      {{#if (eq entry this.keyValues.lastObject)}}
+        <button
+          {{on "click" this.appendRow}}
+          class="add-more button is-light is-borderless" type="button">Add More</button>
+      {{/if}}
     </div>
     {{/each}}
     <footer>

--- a/ui/app/modifiers/autofocus.js
+++ b/ui/app/modifiers/autofocus.js
@@ -1,0 +1,7 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier(function autofocus(element, _positional, named) {
+  const { ignore } = named;
+  if (ignore) return;
+  element.focus();
+});

--- a/ui/app/styles/components/secure-variables.scss
+++ b/ui/app/styles/components/secure-variables.scss
@@ -8,4 +8,8 @@
     gap: 1rem;
     align-items: end;
   }
+
+  .add-more:focus {
+    background-color: $grey-lighter;
+  }
 }

--- a/ui/tests/integration/modifiers/autofocus-test.js
+++ b/ui/tests/integration/modifiers/autofocus-test.js
@@ -1,0 +1,68 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Modifier | autofocus', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('Basic Usage', async function (assert) {
+    await render(hbs`
+    <form>
+      <label>
+        <input data-test-input-1 {{autofocus}} />
+      </label>
+    </form>`);
+
+    assert
+      .dom('[data-test-input-1]')
+      .isFocused('Autofocus on an element works');
+  });
+
+  test('Multiple foci', async function (assert) {
+    await render(hbs`
+    <form>
+      <label>
+        <input data-test-input-1 {{autofocus}} />
+      </label>
+      <label>
+        <input data-test-input-2 {{autofocus}} />
+      </label>
+    </form>`);
+
+    assert
+      .dom('[data-test-input-1]')
+      .isNotFocused('With multiple autofocus elements, priors are unfocused');
+    assert
+      .dom('[data-test-input-2]')
+      .isFocused('With multiple autofocus elements, posteriors are focused');
+  });
+
+  test('Ignore parameter', async function (assert) {
+    await render(hbs`
+    <form>
+    <label>
+        <input data-test-input-1 {{autofocus}} />
+      </label>
+      <label>
+        <input data-test-input-2 {{autofocus}} />
+      </label>
+      <label>
+        <input data-test-input-3 {{autofocus ignore=true}} />
+      </label>
+      <label>
+        <input data-test-input-4 {{autofocus ignore=true}} />
+      </label>
+    </form>`);
+
+    assert
+      .dom('[data-test-input-2]')
+      .isFocused('The last autofocus element without ignore is focused');
+    assert
+      .dom('[data-test-input-3]')
+      .isNotFocused('Ignore parameter is observed, prior');
+    assert
+      .dom('[data-test-input-4]')
+      .isNotFocused('Ignore parameter is observed, posterior');
+  });
+});


### PR DESCRIPTION
(Twig branch of #13069; resolves [13141](https://github.com/hashicorp/nomad/issues/13141))

- Introduces a new `autofocus` modifier for input elements
- Makes it so, when you add a new element to the variables/new form, its key is auto-focused for faster typing
- Slightly darken the focus state of the "Add more" button, as it was inaccessibly low-vis before