### PR TITLE
==> amazon-ebs: E: There were unauthenticated packages and -y was use…

### DIFF
--- a/terraform/shared/scripts/setup.sh
+++ b/terraform/shared/scripts/setup.sh
@@ -126,7 +126,7 @@ if [[ ! -z ${INSTALL_NVIDIA_DOCKER+x} ]]; then
     sudo tee /etc/apt/sources.list.d/nvidia-docker.list
 
   sudo apt-get update
-  sudo apt-get install -y nvidia-docker2
+  sudo apt-get install -y nvidia-docker2 --allow-unauthenticated
 fi
 
 # rkt

--- a/terraform/shared/scripts/setup.sh
+++ b/terraform/shared/scripts/setup.sh
@@ -114,7 +114,7 @@ if [[ ! -z ${INSTALL_NVIDIA_DOCKER+x} ]]; then
   # This is why we added gnupg-curl, otherwise, the following fails with "gpgkeys: protocol `https' not supported"
   sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub
   sudo sh -c 'echo "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64 /" > /etc/apt/sources.list.d/cuda.list'
-  sudo apt-get update && sudo apt-get install -y --no-install-recommends linux-headers-generic dkms cuda-drivers
+  sudo apt-get update && sudo apt-get install -y --no-install-recommends --allow-unauthenticated linux-headers-generic dkms cuda-drivers
 
   # Install nvidia-docker and nvidia-docker-plugin
   # from: https://github.com/NVIDIA/nvidia-docker#ubuntu-140416041804-debian-jessiestretch
@@ -126,7 +126,7 @@ if [[ ! -z ${INSTALL_NVIDIA_DOCKER+x} ]]; then
     sudo tee /etc/apt/sources.list.d/nvidia-docker.list
 
   sudo apt-get update
-  sudo apt-get install -y nvidia-docker2 --allow-unauthenticated
+  sudo apt-get install -y --allow-unauthenticated nvidia-docker2
 fi
 
 # rkt


### PR DESCRIPTION
The default process fails with this error:

==> amazon-ebs: E: There were unauthenticated packages and -y was used without --allow-unauthenticated