### PR TITLE
docs: add nomad-pipeline to community tools page

### DIFF
--- a/website/content/tools/index.mdx
+++ b/website/content/tools/index.mdx
@@ -38,7 +38,7 @@ The following external tools are currently available for Nomad and maintained by
 - [Nomad events sink](https://github.com/mr-karan/nomad-events-sink) - An events collection agent which processes Nomad Events and dumps to external sink providers like HTTP
 - [Nomad Firehose](https://github.com/seatgeek/nomad-firehose) - A tool to enable teams to quickly build logic around nomad task events without hooking into Nomad API
 - [Nomad Helper](https://github.com/seatgeek/nomad-helper) - A Nomad helper binary. Reevaluate jobs, force garbage collection, drain nodes, export/import count information
-- [Nomad Pipeline](https://github.com/HyperBadger/nomad-pipeline) - A tool to make running pipeline-type workloads on Nomad
+- [Nomad Pipeline](https://github.com/HyperBadger/nomad-pipeline) - A tool to make running pipeline-style workloads on Nomad
 - [Nomad Toast](https://github.com/jrasell/nomad-toast) - A tool for receiving notifications based on HashiCorp Nomad events
 - [Nomad Watcher](https://github.com/blalor/nomad-watcher) - A simple service that watches Nomad's nodes, jobs, deployments, evaluations, allocations, and task states, and writes the events to a file
 - [Nomadgen](https://github.com/smintz/nomadgen) - Craft your Hashicorp's Nomad job specs in python.

--- a/website/content/tools/index.mdx
+++ b/website/content/tools/index.mdx
@@ -38,6 +38,7 @@ The following external tools are currently available for Nomad and maintained by
 - [Nomad events sink](https://github.com/mr-karan/nomad-events-sink) - An events collection agent which processes Nomad Events and dumps to external sink providers like HTTP
 - [Nomad Firehose](https://github.com/seatgeek/nomad-firehose) - A tool to enable teams to quickly build logic around nomad task events without hooking into Nomad API
 - [Nomad Helper](https://github.com/seatgeek/nomad-helper) - A Nomad helper binary. Reevaluate jobs, force garbage collection, drain nodes, export/import count information
+- [Nomad Pipeline](https://github.com/HyperBadger/nomad-pipeline) - A tool to make running pipeline-type workloads on Nomad
 - [Nomad Toast](https://github.com/jrasell/nomad-toast) - A tool for receiving notifications based on HashiCorp Nomad events
 - [Nomad Watcher](https://github.com/blalor/nomad-watcher) - A simple service that watches Nomad's nodes, jobs, deployments, evaluations, allocations, and task states, and writes the events to a file
 - [Nomadgen](https://github.com/smintz/nomadgen) - Craft your Hashicorp's Nomad job specs in python.


### PR DESCRIPTION
Nomad Pipeline is a tool I have been working on and using at work. It is a bit hacky but I thought it would be cool to have it in this list for others that might be looking for "pipelines on Nomad".