### PR TITLE
ui:  add service count to `StatBox`

### DIFF
--- a/.changelog/13188.txt
+++ b/.changelog/13188.txt
@@ -1,0 +1,1 @@
+ui:  add service count to `StatBox` in `JobDetailOverview` page.

--- a/ui/app/templates/components/job-page/parts/stats-box.hbs
+++ b/ui/app/templates/components/job-page/parts/stats-box.hbs
@@ -1,51 +1,70 @@
 {{! template-lint-disable no-inline-styles }}
 <div class="boxed-section is-small">
   <div class="boxed-section-body inline-definitions">
-    <span class="label" style="width: 6.125rem;">Job Details</span>
+    <span class="label" style="width: 6.125rem;">
+      Job Details
+    </span>
     <span class="pair" data-test-job-stat="type">
-      <span class="term">Type</span>
+      <span class="term">
+        Type
+      </span>
       {{@job.type}}
     </span>
     <span class="pair" data-test-job-stat="priority">
-      <span class="term">Priority</span>
+      <span class="term">
+        Priority
+      </span>
       {{@job.priority}}
     </span>
     <span class="pair" data-test-job-stat="version">
-      <span class="term">Version</span>
+      <span class="term">
+        Version
+      </span>
       {{@job.version}}
     </span>
     {{yield to="before-namespace"}}
     {{#if (and @job.namespace this.system.shouldShowNamespaces)}}
       <span class="pair" data-test-job-stat="namespace">
-        <span class="term">Namespace</span>
+        <span class="term">
+          Namespace
+        </span>
         {{@job.namespace.name}}
       </span>
     {{/if}}
     {{yield to="after-namespace"}}
   </div>
-
   {{#if @job.meta.structured.pack.name}}
     <div class="boxed-section-body inline-definitions">
-      <span class="label" style="width: 6.125rem;">Pack Details</span>
+      <span class="label" style="width: 6.125rem;">
+        Pack Details
+      </span>
       <span class="pair" data-test-pack-stat="name">
-        <span class="term">Name</span>
+        <span class="term">
+          Name
+        </span>
         {{@job.meta.structured.pack.name}}
       </span>
       {{#if @job.meta.structured.pack.registry}}
         <span class="pair" data-test-pack-stat="registry">
-          <span class="term">Registry</span>
+          <span class="term">
+            Registry
+          </span>
           {{@job.meta.structured.pack.registry}}
         </span>
       {{/if}}
       {{#if @job.meta.structured.pack.version}}
         <span class="pair" data-test-pack-stat="version">
-          <span class="term">Version</span>
+          <span class="term">
+            Version
+          </span>
           {{@job.meta.structured.pack.version}}
         </span>
       {{/if}}
       {{#if @job.meta.structured.pack.revision}}
         <span class="pair" data-test-pack-stat="revision">
-          <span class="term">Revision</span>
+          <span class="term">
+            Revision
+          </span>
           {{@job.meta.structured.pack.revision}}
         </span>
       {{/if}}

--- a/ui/app/templates/components/job-page/parts/stats-box.hbs
+++ b/ui/app/templates/components/job-page/parts/stats-box.hbs
@@ -22,12 +22,14 @@
       </span>
       {{@job.version}}
     </span>
-    <span class="pair" data-test-job-stat="service">
-      <span class="term">
-        Service
+    {{#if @job.services.length}}
+      <span class="pair" data-test-job-stat="service">
+        <span class="term">
+          Services
+        </span>
+        {{@job.services.length}}
       </span>
-      {{@job.services.length}}
-    </span>
+    {{/if}}
     {{yield to="before-namespace"}}
     {{#if (and @job.namespace this.system.shouldShowNamespaces)}}
       <span class="pair" data-test-job-stat="namespace">

--- a/ui/app/templates/components/job-page/parts/stats-box.hbs
+++ b/ui/app/templates/components/job-page/parts/stats-box.hbs
@@ -22,6 +22,12 @@
       </span>
       {{@job.version}}
     </span>
+    <span class="pair" data-test-job-stat="service">
+      <span class="term">
+        Service
+      </span>
+      {{@job.services.length}}
+    </span>
     {{yield to="before-namespace"}}
     {{#if (and @job.namespace this.system.shouldShowNamespaces)}}
       <span class="pair" data-test-job-stat="namespace">


### PR DESCRIPTION
This PR adds the total count of services from the `job` model to the `StatBox` in the Job Detail Overview page.