### PR TITLE
remove end-user algorithm selection

### DIFF
--- a/api/keyring.go
+++ b/api/keyring.go
@@ -21,7 +21,6 @@ func (c *Client) Keyring() *Keyring {
 type EncryptionAlgorithm string
 
 const (
-	EncryptionAlgorithmXChaCha20 EncryptionAlgorithm = "xchacha20"
 	EncryptionAlgorithmAES256GCM EncryptionAlgorithm = "aes256-gcm"
 )
 
@@ -34,13 +33,12 @@ type RootKey struct {
 
 // RootKeyMeta is the metadata used to refer to a RootKey.
 type RootKeyMeta struct {
-	Active           bool
-	KeyID            string // UUID
-	Algorithm        EncryptionAlgorithm
-	EncryptionsCount uint64
-	CreateTime       time.Time
-	CreateIndex      uint64
-	ModifyIndex      uint64
+	Active      bool
+	KeyID       string // UUID
+	Algorithm   EncryptionAlgorithm
+	CreateTime  time.Time
+	CreateIndex uint64
+	ModifyIndex uint64
 }
 
 // List lists all the keyring metadata

--- a/api/keyring_test.go
+++ b/api/keyring_test.go
@@ -33,11 +33,10 @@ func TestKeyring_CRUD(t *testing.T) {
 	id := "fd77c376-9785-4c80-8e62-4ec3ab5f8b9a"
 	buf := make([]byte, 32)
 	rand.Read(buf)
-	encodedKey := make([]byte, base64.StdEncoding.EncodedLen(32))
-	base64.StdEncoding.Encode(encodedKey, buf)
+	encodedKey := base64.StdEncoding.EncodeToString(buf)
 
 	wm, err = kr.Update(&RootKey{
-		Key: string(encodedKey),
+		Key: encodedKey,
 		Meta: &RootKeyMeta{
 			KeyID:     id,
 			Active:    true,

--- a/api/keyring_test.go
+++ b/api/keyring_test.go
@@ -39,10 +39,9 @@ func TestKeyring_CRUD(t *testing.T) {
 	wm, err = kr.Update(&RootKey{
 		Key: string(encodedKey),
 		Meta: &RootKeyMeta{
-			KeyID:            id,
-			Active:           true,
-			Algorithm:        EncryptionAlgorithmAES256GCM,
-			EncryptionsCount: 100,
+			KeyID:     id,
+			Active:    true,
+			Algorithm: EncryptionAlgorithmAES256GCM,
 		}}, nil)
 	require.NoError(t, err)
 	assertWriteMeta(t, wm)

--- a/command/agent/keyring_endpoint.go
+++ b/command/agent/keyring_endpoint.go
@@ -68,8 +68,6 @@ func (s *HTTPServer) keyringRotateRequest(resp http.ResponseWriter, req *http.Re
 	switch query.Get("algo") {
 	case string(structs.EncryptionAlgorithmAES256GCM):
 		args.Algorithm = structs.EncryptionAlgorithmAES256GCM
-	case string(structs.EncryptionAlgorithmXChaCha20):
-		args.Algorithm = structs.EncryptionAlgorithmXChaCha20
 	}
 
 	if _, ok := query["full"]; ok {
@@ -106,10 +104,9 @@ func (s *HTTPServer) keyringUpsertRequest(resp http.ResponseWriter, req *http.Re
 		RootKey: &structs.RootKey{
 			Key: decodedKey,
 			Meta: &structs.RootKeyMeta{
-				Active:           key.Meta.Active,
-				KeyID:            key.Meta.KeyID,
-				Algorithm:        structs.EncryptionAlgorithm(key.Meta.Algorithm),
-				EncryptionsCount: key.Meta.EncryptionsCount,
+				Active:    key.Meta.Active,
+				KeyID:     key.Meta.KeyID,
+				Algorithm: structs.EncryptionAlgorithm(key.Meta.Algorithm),
 			},
 		},
 	}

--- a/command/agent/keyring_endpoint_test.go
+++ b/command/agent/keyring_endpoint_test.go
@@ -62,10 +62,9 @@ func TestHTTP_Keyring_CRUD(t *testing.T) {
 
 		key := &api.RootKey{
 			Meta: &api.RootKeyMeta{
-				Active:           true,
-				KeyID:            newID2,
-				Algorithm:        api.EncryptionAlgorithm(keyMeta.Algorithm),
-				EncryptionsCount: 500,
+				Active:    true,
+				KeyID:     newID2,
+				Algorithm: api.EncryptionAlgorithm(keyMeta.Algorithm),
 			},
 			Key: string(encodedKey),
 		}

--- a/command/agent/keyring_endpoint_test.go
+++ b/command/agent/keyring_endpoint_test.go
@@ -55,8 +55,7 @@ func TestHTTP_Keyring_CRUD(t *testing.T) {
 		keyMeta := rotateResp.Key
 		keyBuf := make([]byte, 32)
 		rand.Read(keyBuf)
-		encodedKey := make([]byte, base64.StdEncoding.EncodedLen(32))
-		base64.StdEncoding.Encode(encodedKey, keyBuf)
+		encodedKey := base64.StdEncoding.EncodeToString(keyBuf)
 
 		newID2 := uuid.Generate()
 
@@ -66,7 +65,7 @@ func TestHTTP_Keyring_CRUD(t *testing.T) {
 				KeyID:     newID2,
 				Algorithm: api.EncryptionAlgorithm(keyMeta.Algorithm),
 			},
-			Key: string(encodedKey),
+			Key: encodedKey,
 		}
 		reqBuf := encodeReq(key)
 

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -219,20 +219,7 @@ func (e *Encrypter) loadKeyFromStore(path string) (*structs.RootKey, error) {
 		return nil, err
 	}
 
-	// Note: we expect to have null bytes for padding, but we don't
-	// want to use RawStdEncoding which breaks a lot of command line
-	// tools. So we'll truncate the key to the expected length.
-	var keyLen int
-	switch storedKey.Meta.Algorithm {
-	case structs.EncryptionAlgorithmAES256GCM:
-		keyLen = 32
-	default:
-		return nil, fmt.Errorf("invalid algorithm")
-	}
-
-	key := make([]byte, keyLen)
-	encodedKeyLen := base64.StdEncoding.EncodedLen(keyLen)
-	_, err = base64.StdEncoding.Decode(key, []byte(storedKey.Key)[:encodedKeyLen])
+	key, err := base64.StdEncoding.DecodeString(storedKey.Key)
 	if err != nil {
 		return nil, fmt.Errorf("could not decode key: %v", err)
 	}

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-msgpack/codec"
-	"golang.org/x/crypto/chacha20poly1305"
 
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -132,7 +131,6 @@ func (e *Encrypter) addCipher(rootKey *structs.RootKey) error {
 		return fmt.Errorf("missing metadata")
 	}
 	var aead cipher.AEAD
-	var err error
 
 	switch rootKey.Meta.Algorithm {
 	case structs.EncryptionAlgorithmAES256GCM:
@@ -141,11 +139,6 @@ func (e *Encrypter) addCipher(rootKey *structs.RootKey) error {
 			return fmt.Errorf("could not create cipher: %v", err)
 		}
 		aead, err = cipher.NewGCM(block)
-		if err != nil {
-			return fmt.Errorf("could not create cipher: %v", err)
-		}
-	case structs.EncryptionAlgorithmXChaCha20:
-		aead, err = chacha20poly1305.NewX(rootKey.Key)
 		if err != nil {
 			return fmt.Errorf("could not create cipher: %v", err)
 		}
@@ -231,7 +224,7 @@ func (e *Encrypter) loadKeyFromStore(path string) (*structs.RootKey, error) {
 	// tools. So we'll truncate the key to the expected length.
 	var keyLen int
 	switch storedKey.Meta.Algorithm {
-	case structs.EncryptionAlgorithmXChaCha20, structs.EncryptionAlgorithmAES256GCM:
+	case structs.EncryptionAlgorithmAES256GCM:
 		keyLen = 32
 	default:
 		return nil, fmt.Errorf("invalid algorithm")

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -231,7 +231,8 @@ func (e *Encrypter) loadKeyFromStore(path string) (*structs.RootKey, error) {
 	}
 
 	key := make([]byte, keyLen)
-	_, err = base64.StdEncoding.Decode(key, []byte(storedKey.Key)[:keyLen])
+	encodedKeyLen := base64.StdEncoding.EncodedLen(keyLen)
+	_, err = base64.StdEncoding.Decode(key, []byte(storedKey.Key)[:encodedKeyLen])
 	if err != nil {
 		return nil, fmt.Errorf("could not decode key: %v", err)
 	}

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -22,7 +22,6 @@ func TestEncrypter_LoadSave(t *testing.T) {
 
 	algos := []structs.EncryptionAlgorithm{
 		structs.EncryptionAlgorithmAES256GCM,
-		structs.EncryptionAlgorithmXChaCha20,
 	}
 
 	for _, algo := range algos {

--- a/nomad/keyring_endpoint.go
+++ b/nomad/keyring_endpoint.go
@@ -37,8 +37,7 @@ func (k *Keyring) Rotate(args *structs.KeyringRotateRootKeyRequest, reply *struc
 		// TODO: implement full key rotation via a core job
 	}
 	if args.Algorithm == "" {
-		// TODO: set this default value from server config
-		args.Algorithm = structs.EncryptionAlgorithmXChaCha20
+		args.Algorithm = structs.EncryptionAlgorithmAES256GCM
 	}
 
 	rootKey, err := structs.NewRootKey(args.Algorithm)

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -1701,8 +1701,7 @@ func (s *Server) initializeKeyring() error {
 
 	s.logger.Named("core").Trace("initializing keyring")
 
-	// TODO: algorithm should be set from config
-	rootKey, err := structs.NewRootKey(structs.EncryptionAlgorithmXChaCha20)
+	rootKey, err := structs.NewRootKey(structs.EncryptionAlgorithmAES256GCM)
 	rootKey.Meta.Active = true
 	if err != nil {
 		return fmt.Errorf("could not initialize keyring: %v", err)

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -6622,11 +6622,6 @@ func (s *StateStore) UpsertRootKeyMeta(index uint64, rootKeyMeta *structs.RootKe
 		existing := raw.(*structs.RootKeyMeta)
 		rootKeyMeta.CreateIndex = existing.CreateIndex
 		rootKeyMeta.CreateTime = existing.CreateTime
-
-		// prevent resetting the encryptions count
-		if existing.EncryptionsCount > rootKeyMeta.EncryptionsCount {
-			rootKeyMeta.EncryptionsCount = existing.EncryptionsCount
-		}
 		isRotation = !existing.Active && rootKeyMeta.Active
 	} else {
 		rootKeyMeta.CreateIndex = index

--- a/nomad/structs/extensions.go
+++ b/nomad/structs/extensions.go
@@ -87,15 +87,13 @@ func csiVolumeExt(v interface{}) interface{} {
 // to misuse.
 func rootKeyExt(v interface{}) interface{} {
 	key := v.(*RootKey)
-
-	encodedKey := make([]byte, base64.StdEncoding.EncodedLen(len(key.Key)))
-	base64.StdEncoding.Encode(encodedKey, key.Key)
+	encodedKey := base64.StdEncoding.EncodeToString(key.Key)
 
 	return &struct {
 		Meta *RootKeyMetaStub
 		Key  string
 	}{
 		Meta: key.Meta.Stub(),
-		Key:  string(encodedKey),
+		Key:  encodedKey,
 	}
 }


### PR DESCRIPTION
After internal design review, we decided to remove exposing algorithm
choice to the end-user for the initial release. We'll solve nonce
rotation by forcing rotations automatically on key GC (in a core job,
not included in this changeset). Default to AES-256 GCM for the
following criteria:

* faster implementation when hardware acceleration is available
* FIPS compliant
* implementation in pure go
* post-quantum resistance