### PR TITLE
build: update golangci-lint to v1.46.2

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -143,7 +143,7 @@ deps:  ## Install build and development dependencies
 lint-deps: ## Install linter dependencies
 ## Keep versions in sync with tools/go.mod (see https://github.com/golang/go/issues/30515)
 	@echo "==> Updating linter dependencies..."
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4
 	go install github.com/hashicorp/go-hclog/hclogvet@v0.1.4
 

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1699,9 +1699,7 @@ func (s *Server) setupNewWorkersLocked() error {
 	// make a copy of the s.workers array so we can safely stop those goroutines asynchronously
 	oldWorkers := make([]*Worker, len(s.workers))
 	defer s.stopOldWorkers(oldWorkers)
-	for i, w := range s.workers {
-		oldWorkers[i] = w
-	}
+	copy(oldWorkers, s.workers)
 	s.logger.Info(fmt.Sprintf("marking %v current schedulers for shutdown", len(oldWorkers)))
 
 	// build a clean backing array and call setupWorkersLocked like setupWorkers

--- a/nomad/structs/network.go
+++ b/nomad/structs/network.go
@@ -145,9 +145,7 @@ func copyAvailAddresses(a map[string][]NodeNetworkAddress) map[string][]NodeNetw
 			continue
 		}
 		c[k] = make([]NodeNetworkAddress, len(v))
-		for i, a := range v {
-			c[k][i] = a
-		}
+		copy(c[k], v)
 	}
 
 	return c

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -1476,9 +1476,7 @@ func (e *ConsulExposeConfig) Copy() *ConsulExposeConfig {
 		return nil
 	}
 	paths := make([]ConsulExposePath, len(e.Paths))
-	for i := 0; i < len(e.Paths); i++ {
-		paths[i] = e.Paths[i]
-	}
+	copy(paths, e.Paths)
 	return &ConsulExposeConfig{
 		Paths: paths,
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3961,10 +3961,7 @@ func (a *AllocatedDeviceResource) Copy() *AllocatedDeviceResource {
 
 	// Copy the devices
 	na.DeviceIDs = make([]string, len(a.DeviceIDs))
-	for i, id := range a.DeviceIDs {
-		na.DeviceIDs[i] = id
-	}
-
+	copy(na.DeviceIDs, a.DeviceIDs)
 	return &na
 }
 


### PR DESCRIPTION
This version of golangci-lint improves support for generics, but also
is more strict in copy vs. loop for slice copying.
