### PR TITLE
provide state store query for variables by key ID

### DIFF
--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -25,6 +25,7 @@ const (
 	indexNodeID      = "node_id"
 	indexAllocID     = "alloc_id"
 	indexServiceName = "service_name"
+	indexKeyID       = "key_id"
 )
 
 var (
@@ -1230,8 +1231,8 @@ func secureVariablesTableSchema() *memdb.TableSchema {
 					},
 				},
 			},
-			"key_id": {
-				Name:         "key_id",
+			indexKeyID: {
+				Name:         indexKeyID,
 				AllowMissing: false,
 				Indexer:      &secureVariableKeyIDFieldIndexer{},
 			},

--- a/nomad/state/state_store_secure_variables.go
+++ b/nomad/state/state_store_secure_variables.go
@@ -60,7 +60,7 @@ func (s *StateStore) GetSecureVariablesByKeyID(
 	ws memdb.WatchSet, keyID string) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
-	iter, err := txn.Get(TableSecureVariables, "key_id", keyID)
+	iter, err := txn.Get(TableSecureVariables, indexKeyID, keyID)
 	if err != nil {
 		return nil, fmt.Errorf("secure variable lookup failed: %v", err)
 	}

--- a/nomad/state/state_store_secure_variables.go
+++ b/nomad/state/state_store_secure_variables.go
@@ -54,6 +54,21 @@ func (s *StateStore) GetSecureVariablesByNamespaceAndPrefix(
 	return iter, nil
 }
 
+// GetSecureVariablesByKeyID returns an iterator that contains all
+// variables that were encrypted with a particular key
+func (s *StateStore) GetSecureVariablesByKeyID(
+	ws memdb.WatchSet, keyID string) (memdb.ResultIterator, error) {
+	txn := s.db.ReadTxn()
+
+	iter, err := txn.Get(TableSecureVariables, "key_id", keyID)
+	if err != nil {
+		return nil, fmt.Errorf("secure variable lookup failed: %v", err)
+	}
+	ws.Add(iter.WatchCh())
+
+	return iter, nil
+}
+
 // GetSecureVariable returns an single secure variable at a given namespace and
 // path.
 func (s *StateStore) GetSecureVariable(


### PR DESCRIPTION
The core jobs to garbage collect unused keys and perform full key
rotations will need to be able to query secure variables by key ID for
efficiency. Add an index to the state store and associated query
function and test.