### PR TITLE
refactor index threshold calculation for core GC jobs

### DIFF
--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -99,20 +99,8 @@ func (c *CoreScheduler) jobGC(eval *structs.Evaluation) error {
 		return err
 	}
 
-	var oldThreshold uint64
-	if eval.JobID == structs.CoreJobForceGC {
-		// The GC was forced, so set the threshold to its maximum so everything
-		// will GC.
-		oldThreshold = math.MaxUint64
-		c.logger.Debug("forced job GC")
-	} else {
-		// Get the time table to calculate GC cutoffs.
-		tt := c.srv.fsm.TimeTable()
-		cutoff := time.Now().UTC().Add(-1 * c.srv.config.JobGCThreshold)
-		oldThreshold = tt.NearestIndex(cutoff)
-		c.logger.Debug("job GC scanning before cutoff index",
-			"index", oldThreshold, "job_gc_threshold", c.srv.config.JobGCThreshold)
-	}
+	oldThreshold := c.getThreshold(eval, "job",
+		"job_gc_threshold", c.srv.config.JobGCThreshold)
 
 	// Collect the allocations, evaluations and jobs to GC
 	var gcAlloc, gcEval []string
@@ -236,22 +224,8 @@ func (c *CoreScheduler) evalGC(eval *structs.Evaluation) error {
 		return err
 	}
 
-	var oldThreshold uint64
-	if eval.JobID == structs.CoreJobForceGC {
-		// The GC was forced, so set the threshold to its maximum so everything
-		// will GC.
-		oldThreshold = math.MaxUint64
-		c.logger.Debug("forced eval GC")
-	} else {
-		// Compute the old threshold limit for GC using the FSM
-		// time table.  This is a rough mapping of a time to the
-		// Raft index it belongs to.
-		tt := c.srv.fsm.TimeTable()
-		cutoff := time.Now().UTC().Add(-1 * c.srv.config.EvalGCThreshold)
-		oldThreshold = tt.NearestIndex(cutoff)
-		c.logger.Debug("eval GC scanning before cutoff index",
-			"index", oldThreshold, "eval_gc_threshold", c.srv.config.EvalGCThreshold)
-	}
+	oldThreshold := c.getThreshold(eval, "eval",
+		"eval_gc_threshold", c.srv.config.EvalGCThreshold)
 
 	// Collect the allocations and evaluations to GC
 	var gcAlloc, gcEval []string
@@ -439,22 +413,8 @@ func (c *CoreScheduler) nodeGC(eval *structs.Evaluation) error {
 		return err
 	}
 
-	var oldThreshold uint64
-	if eval.JobID == structs.CoreJobForceGC {
-		// The GC was forced, so set the threshold to its maximum so everything
-		// will GC.
-		oldThreshold = math.MaxUint64
-		c.logger.Debug("forced node GC")
-	} else {
-		// Compute the old threshold limit for GC using the FSM
-		// time table.  This is a rough mapping of a time to the
-		// Raft index it belongs to.
-		tt := c.srv.fsm.TimeTable()
-		cutoff := time.Now().UTC().Add(-1 * c.srv.config.NodeGCThreshold)
-		oldThreshold = tt.NearestIndex(cutoff)
-		c.logger.Debug("node GC scanning before cutoff index",
-			"index", oldThreshold, "node_gc_threshold", c.srv.config.NodeGCThreshold)
-	}
+	oldThreshold := c.getThreshold(eval, "node",
+		"node_gc_threshold", c.srv.config.NodeGCThreshold)
 
 	// Collect the nodes to GC
 	var gcNode []string
@@ -550,22 +510,8 @@ func (c *CoreScheduler) deploymentGC(eval *structs.Evaluation) error {
 		return err
 	}
 
-	var oldThreshold uint64
-	if eval.JobID == structs.CoreJobForceGC {
-		// The GC was forced, so set the threshold to its maximum so everything
-		// will GC.
-		oldThreshold = math.MaxUint64
-		c.logger.Debug("forced deployment GC")
-	} else {
-		// Compute the old threshold limit for GC using the FSM
-		// time table.  This is a rough mapping of a time to the
-		// Raft index it belongs to.
-		tt := c.srv.fsm.TimeTable()
-		cutoff := time.Now().UTC().Add(-1 * c.srv.config.DeploymentGCThreshold)
-		oldThreshold = tt.NearestIndex(cutoff)
-		c.logger.Debug("deployment GC scanning before cutoff index",
-			"index", oldThreshold, "deployment_gc_threshold", c.srv.config.DeploymentGCThreshold)
-	}
+	oldThreshold := c.getThreshold(eval, "deployment",
+		"deployment_gc_threshold", c.srv.config.DeploymentGCThreshold)
 
 	// Collect the deployments to GC
 	var gcDeployment []string
@@ -756,21 +702,8 @@ func (c *CoreScheduler) csiVolumeClaimGC(eval *structs.Evaluation) error {
 		return err
 	}
 
-	// Get the time table to calculate GC cutoffs.
-	var oldThreshold uint64
-	if eval.JobID == structs.CoreJobForceGC {
-		// The GC was forced, so set the threshold to its maximum so
-		// everything will GC.
-		oldThreshold = math.MaxUint64
-		c.logger.Debug("forced volume claim GC")
-	} else {
-		tt := c.srv.fsm.TimeTable()
-		cutoff := time.Now().UTC().Add(-1 * c.srv.config.CSIVolumeClaimGCThreshold)
-		oldThreshold = tt.NearestIndex(cutoff)
-		c.logger.Debug("CSI volume claim GC scanning before cutoff index",
-			"index", oldThreshold,
-			"csi_volume_claim_gc_threshold", c.srv.config.CSIVolumeClaimGCThreshold)
-	}
+	oldThreshold := c.getThreshold(eval, "CSI volume claim",
+		"csi_volume_claim_gc_threshold", c.srv.config.CSIVolumeClaimGCThreshold)
 
 	for i := iter.Next(); i != nil; i = iter.Next() {
 		vol := i.(*structs.CSIVolume)
@@ -809,20 +742,8 @@ func (c *CoreScheduler) csiPluginGC(eval *structs.Evaluation) error {
 		return err
 	}
 
-	// Get the time table to calculate GC cutoffs.
-	var oldThreshold uint64
-	if eval.JobID == structs.CoreJobForceGC {
-		// The GC was forced, so set the threshold to its maximum so
-		// everything will GC.
-		oldThreshold = math.MaxUint64
-		c.logger.Debug("forced plugin GC")
-	} else {
-		tt := c.srv.fsm.TimeTable()
-		cutoff := time.Now().UTC().Add(-1 * c.srv.config.CSIPluginGCThreshold)
-		oldThreshold = tt.NearestIndex(cutoff)
-		c.logger.Debug("CSI plugin GC scanning before cutoff index",
-			"index", oldThreshold, "csi_plugin_gc_threshold", c.srv.config.CSIPluginGCThreshold)
-	}
+	oldThreshold := c.getThreshold(eval, "CSI plugin",
+		"csi_plugin_gc_threshold", c.srv.config.CSIPluginGCThreshold)
 
 	for i := iter.Next(); i != nil; i = iter.Next() {
 		plugin := i.(*structs.CSIPlugin)
@@ -857,4 +778,28 @@ func (c *CoreScheduler) expiredOneTimeTokenGC(eval *structs.Evaluation) error {
 		},
 	}
 	return c.srv.RPC("ACL.ExpireOneTimeTokens", req, &structs.GenericResponse{})
+}
+
+// getThreshold returns the index threshold for determining whether an
+// object is old enough to GC
+func (c *CoreScheduler) getThreshold(eval *structs.Evaluation, objectName, configName string, configThreshold time.Duration) uint64 {
+	var oldThreshold uint64
+	if eval.JobID == structs.CoreJobForceGC {
+		// The GC was forced, so set the threshold to its maximum so
+		// everything will GC.
+		oldThreshold = math.MaxUint64
+		c.logger.Debug(fmt.Sprintf("forced %s GC", objectName))
+	} else {
+		// Compute the old threshold limit for GC using the FSM
+		// time table.  This is a rough mapping of a time to the
+		// Raft index it belongs to.
+		tt := c.srv.fsm.TimeTable()
+		cutoff := time.Now().UTC().Add(-1 * configThreshold)
+		oldThreshold = tt.NearestIndex(cutoff)
+		c.logger.Debug(
+			fmt.Sprintf("%s GC scanning before cutoff index", objectName),
+			"index", oldThreshold,
+			configName, configThreshold)
+	}
+	return oldThreshold
 }


### PR DESCRIPTION
Almost all GC jobs check the index of the objects being GC'd to see if
they're older than a configured threshold. This code was repeated six
times in `CoreScheduler` with only logging changes, so it seems safe
to extract it as its own method.

Ran into this while working on 2 new core jobs for Secure Variables, so
this changeset will eliminate the need for 2 more repetitions of this function.