### PR TITLE
core job for root key GC

### DIFF
--- a/nomad/config.go
+++ b/nomad/config.go
@@ -196,6 +196,14 @@ type Config struct {
 	// one-time tokens.
 	OneTimeTokenGCInterval time.Duration
 
+	// RootKeyGCInterval is how often we dispatch a job to GC
+	// encryption key metadata
+	RootKeyGCInterval time.Duration
+
+	// RootKeyGCThreshold is how "old" encryption key metadata must be
+	// to be eligible for GC.
+	RootKeyGCThreshold time.Duration
+
 	// EvalNackTimeout controls how long we allow a sub-scheduler to
 	// work on an evaluation before we consider it failed and Nack it.
 	// This allows that evaluation to be handed to another sub-scheduler
@@ -385,6 +393,8 @@ func DefaultConfig() *Config {
 		CSIVolumeClaimGCInterval:         5 * time.Minute,
 		CSIVolumeClaimGCThreshold:        5 * time.Minute,
 		OneTimeTokenGCInterval:           10 * time.Minute,
+		RootKeyGCInterval:                10 * time.Minute,
+		RootKeyGCThreshold:               1 * time.Hour,
 		EvalNackTimeout:                  60 * time.Second,
 		EvalDeliveryLimit:                3,
 		EvalNackInitialReenqueueDelay:    1 * time.Second,

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -2451,6 +2451,72 @@ func TestCoreScheduler_CSIBadState_ClaimGC(t *testing.T) {
 
 }
 
+// TestCoreScheduler_RootKeyGC exercises root key GC
+func TestCoreScheduler_RootKeyGC(t *testing.T) {
+	ci.Parallel(t)
+
+	srv, cleanup := TestServer(t, nil)
+	defer cleanup()
+	testutil.WaitForLeader(t, srv.RPC)
+
+	// reset the time table
+	srv.fsm.timetable.table = make([]TimeTableEntry, 1, 10)
+
+	store := srv.fsm.State()
+	key0, err := store.GetActiveRootKeyMeta(nil)
+	require.NotNil(t, key0, "expected keyring to be bootstapped")
+	require.NoError(t, err)
+
+	// insert an "old" and inactive key
+	key1 := structs.NewRootKeyMeta()
+	key1.Active = false
+	require.NoError(t, store.UpsertRootKeyMeta(500, key1))
+
+	// insert an "old" and inactive key with a variable that's using it
+	key2 := structs.NewRootKeyMeta()
+	key2.Active = false
+	require.NoError(t, store.UpsertRootKeyMeta(600, key2))
+
+	variable := mock.SecureVariable()
+	variable.EncryptedData.KeyID = key2.KeyID
+	require.NoError(t, store.UpsertSecureVariables(
+		structs.MsgTypeTestSetup, 601, []*structs.SecureVariable{variable}))
+
+	// insert a time table index between the two keys
+	tt := srv.fsm.TimeTable()
+	tt.Witness(1000, time.Now().UTC().Add(-1*srv.config.RootKeyGCThreshold))
+
+	// insert a "new" but inactive key
+	key3 := structs.NewRootKeyMeta()
+	key3.Active = false
+	require.NoError(t, store.UpsertRootKeyMeta(1500, key3))
+
+	// run the core job
+	snap, err := store.Snapshot()
+	require.NoError(t, err)
+	core := NewCoreScheduler(srv, snap)
+	eval := srv.coreJobEval(structs.CoreJobRootKeyGC, 2000)
+	c := core.(*CoreScheduler)
+	require.NoError(t, c.rootKeyGC(eval))
+
+	ws := memdb.NewWatchSet()
+	key, err := store.RootKeyMetaByID(ws, key0.KeyID)
+	require.NoError(t, err)
+	require.NotNil(t, key, "active key should not have been GCd")
+
+	key, err = store.RootKeyMetaByID(ws, key1.KeyID)
+	require.NoError(t, err)
+	require.Nil(t, key, "old key should have been GCd")
+
+	key, err = store.RootKeyMetaByID(ws, key2.KeyID)
+	require.NoError(t, err)
+	require.NotNil(t, key, "old key should not have been GCd if still in use")
+
+	key, err = store.RootKeyMetaByID(ws, key3.KeyID)
+	require.NoError(t, err)
+	require.NotNil(t, key, "new key should not have been GCd")
+}
+
 func TestCoreScheduler_FailLoop(t *testing.T) {
 	ci.Parallel(t)
 

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -767,6 +767,8 @@ func (s *Server) schedulePeriodic(stopCh chan struct{}) {
 	defer csiVolumeClaimGC.Stop()
 	oneTimeTokenGC := time.NewTicker(s.config.OneTimeTokenGCInterval)
 	defer oneTimeTokenGC.Stop()
+	rootKeyGC := time.NewTicker(s.config.RootKeyGCInterval)
+	defer rootKeyGC.Stop()
 
 	// getLatest grabs the latest index from the state store. It returns true if
 	// the index was retrieved successfully.
@@ -814,6 +816,10 @@ func (s *Server) schedulePeriodic(stopCh chan struct{}) {
 
 			if index, ok := getLatest(); ok {
 				s.evalBroker.Enqueue(s.coreJobEval(structs.CoreJobOneTimeTokenGC, index))
+			}
+		case <-rootKeyGC.C:
+			if index, ok := getLatest(); ok {
+				s.evalBroker.Enqueue(s.coreJobEval(structs.CoreJobRootKeyGC, index))
 			}
 		case <-stopCh:
 			return

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10731,6 +10731,10 @@ const (
 	// tokens. We periodically scan for expired tokens and delete them.
 	CoreJobOneTimeTokenGC = "one-time-token-gc"
 
+	// CoreJobRootKeyGC is used for the garbage collection of unused
+	// encryption keys.
+	CoreJobRootKeyGC = "root-key-gc"
+
 	// CoreJobForceGC is used to force garbage collection of all GCable objects.
 	CoreJobForceGC = "force-gc"
 )


### PR DESCRIPTION
Inactive and unused keys older than a threshold will be periodically
garbage collected.

This changeset only implements the GC job and not the full key rotation
job in order to keep the PR size reasonable. The configuration values are
not exposed in this PR either, as I'd like to do the whole configuration
as a single PR once we've got some of the remaining keyring items finished.