### PR TITLE
ui:  create `/services` nested route within `/jobs/:jobId` hierarchy

### DIFF
--- a/ui/app/router.js
+++ b/ui/app/router.js
@@ -24,6 +24,7 @@ Router.map(function () {
       this.route('evaluations');
       this.route('allocations');
       this.route('clients');
+      this.route('services');
     });
   });
 

--- a/ui/app/templates/components/job-page/parts/stats-box.hbs
+++ b/ui/app/templates/components/job-page/parts/stats-box.hbs
@@ -27,7 +27,13 @@
         <span class="term">
           Services
         </span>
-        {{@job.services.length}}
+        <LinkTo
+          @route="jobs.job.services"
+          @model={{@job}}
+          @activeClass="is-active"
+        >
+          {{@job.services.length}}
+        </LinkTo>
       </span>
     {{/if}}
     {{yield to="before-namespace"}}

--- a/ui/app/templates/components/job-subnav.hbs
+++ b/ui/app/templates/components/job-subnav.hbs
@@ -68,5 +68,16 @@
         </LinkTo>
       </li>
     {{/if}}
+    {{#if @job.services.length}}
+      <li data-test-tab="services">
+        <LinkTo
+          @route="jobs.job.services"
+          @model={{@job}}
+          @activeClass="is-active"
+        >
+          Services
+        </LinkTo>
+      </li>
+    {{/if}}
   </ul>
 </div>


### PR DESCRIPTION
This PR adds `/services` as a nested route within the `/jobs/:jobId` hierarchy.

Side Effect:  Update `StatsBox` to link to `/jobs/:jobId/services` and add Services link to `JobSubnav`.

This PR intentionally does not add:  Route, Controller or Template for `/services`. That will be handled in the following in #13200.

Expectation:
![image](https://user-images.githubusercontent.com/41024828/171481741-a7b6ab29-3d5c-4da6-be53-20dc65c67249.png)

Actual:
![image](https://user-images.githubusercontent.com/41024828/171481766-f6adcd8f-734a-4162-8bd2-88483abdd31e.png)

Note:  there's a discrepancy between `Services` value. Currently, we list a `Services ${servicesLength}` instead of `Services ${servicesLength} services`. Will iron this out with Design later on.