### PR TITLE
docs: link to client reqs section for added clarity

### DIFF
--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -334,9 +334,9 @@ config {
   working directory] is prevented by default and limits volumes to directories
   that exist inside the allocation working directory. You can allow mounting
   host paths outside of the [allocation working directory] on individual clients
-  by setting the `docker.volumes.enabled` option to `true` in the client's
-  configuration. We recommend using [`mount`](#mount) if you wish to have more
-  control over volume definitions.
+  by setting the `docker.volumes.enabled` option to `true` in the
+  [client's configuration](#client-requirements). We recommend using
+  [`mount`](#mount) if you wish to have more control over volume definitions.
 
   ```hcl
   config {


### PR DESCRIPTION
When I first read the docs, it wasn't clear to me what `docker.volumes.enabled` refers to. I'm proposing this minor addition of a link to (hopefully) make it more obvious.

I know that the name probably refers more to the way it's represented in the dot-separated hierarchy of the client attributes (along with other fingerprinted data), but the relationship between those and the agent HCL configuration wasn't clear to me at first.
