### PR TITLE
core: reschedule evicted batch job when resources become available

### DIFF
--- a/.changelog/13205.txt
+++ b/.changelog/13205.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fixed a bug where an evicted batch job would not be rescheduled
+```

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -292,7 +292,8 @@ func (a allocSet) filterByRescheduleable(isBatch bool, now time.Time, evalID str
 	return
 }
 
-// shouldFilter returns whether the alloc should be ignored or considered untainted
+// shouldFilter returns whether the alloc should be ignored or considered untainted.
+//
 // Ignored allocs are filtered out.
 // Untainted allocs count against the desired total.
 // Filtering logic for batch jobs:
@@ -309,10 +310,12 @@ func shouldFilter(alloc *structs.Allocation, isBatch bool) (untainted, ignore bo
 	// complete but not failed, they shouldn't be replaced.
 	if isBatch {
 		switch alloc.DesiredStatus {
-		case structs.AllocDesiredStatusStop, structs.AllocDesiredStatusEvict:
+		case structs.AllocDesiredStatusStop:
 			if alloc.RanSuccessfully() {
 				return true, false
 			}
+			return false, true
+		case structs.AllocDesiredStatusEvict:
 			return false, true
 		default:
 		}


### PR DESCRIPTION
This is second attempt at the cherry-pick of https://github.com/hashicorp/nomad/pull/13209 onto `release/1.2.x` (where I botched the rebase and got confused)