### PR TITLE
ui:  create dummy template for `jobs/:jobId/services` route

### DIFF
--- a/ui/app/routes/jobs/job/services.js
+++ b/ui/app/routes/jobs/job/services.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class IndexRoute extends Route {
+  model() {
+    return this.modelFor('jobs.job');
+  }
+}

--- a/ui/app/styles/core/tag.scss
+++ b/ui/app/styles/core/tag.scss
@@ -68,6 +68,11 @@
     vertical-align: 2px;
   }
 
+  &.is-service-tag {
+    background: darken($grey-blue, 20%);
+    color: $primary-invert;
+  }
+
   .icon {
     height: 1rem;
     width: 1rem;

--- a/ui/app/templates/jobs/job/services.hbs
+++ b/ui/app/templates/jobs/job/services.hbs
@@ -1,0 +1,54 @@
+{{page-title "Job " this.model.name " services"}}
+<JobSubnav @job={{this.model}} />
+<section class="section">
+  {{#if this.model.services.length}}
+    <ListTable
+      @source={{this.model.services}}
+      @sortProperty={{this.sortProperty}}
+      @sortDescending={{this.sortDescending}}
+      @class="with-foot" as |t|
+    >
+      <t.head>
+        <t.sort-by @prop="name">
+          Name
+        </t.sort-by>
+        <t.sort-by @prop="tags">
+          Tags
+        </t.sort-by>
+      </t.head>
+      <t.body as |row|>
+        <tr>
+          <td>
+            <span>
+              <b>
+                redis-cache-db
+              </b>
+            </span>
+          </td>
+          <td>
+            <span class="tag is-service-tag" data-test-service-tag>
+              Web
+            </span>
+            <span class="tag is-service-tag" data-test-service-tag>
+              Global
+            </span>
+          </td>
+        </tr>
+      </t.body>
+    </ListTable>
+  {{else}}
+    <div class="boxed-section-body">
+      <div class="empty-message" data-test-empty-services-list>
+        <h3
+          class="empty-message-headline"
+          data-test-empty-services-list-headline
+        >
+          No Services
+        </h3>
+        <p class="empty-message-body">
+          No services have been set-up.
+        </p>
+      </div>
+    </div>
+  {{/if}}
+</section>


### PR DESCRIPTION
This PR creates a dummy template. Notably, missing from the table is the `Number of Allocations` column. We're currently unsure if this column is tenable given the API schema for services lists `AllocID:  string` instead of `Allocations: string[]`. The API schema per NMD-130 suggests there's a one-to-one relationship which will require some clarity.

Expected:
![image](https://user-images.githubusercontent.com/41024828/171918284-587dd6a3-7b5a-4513-a321-4ccef571e156.png)

Actual:
![image](https://user-images.githubusercontent.com/41024828/171918302-8d09ebbf-b25e-46a4-b75c-c791de83edbf.png)
