### PR TITLE
state: only update index on change when deleting evals.

### DIFF
--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -4300,6 +4300,19 @@ func TestStateStore_DeleteEval_Eval(t *testing.T) {
 	if watchFired(ws) {
 		t.Fatalf("bad")
 	}
+
+	// Call the eval delete function with zero length eval and alloc ID arrays.
+	// This should result in the table indexes both staying the same, rather
+	// than updating without cause.
+	require.NoError(t, state.DeleteEval(1010, []string{}, []string{}))
+
+	allocsIndex, err := state.Index("allocs")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1002), allocsIndex)
+
+	evalsIndex, err := state.Index("evals")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1002), evalsIndex)
 }
 
 func TestStateStore_DeleteEval_ChildJob(t *testing.T) {


### PR DESCRIPTION
When deleting evaluations and allocations during a reap event, the
index table entries for evals and allocs was updated irregardless
of whether changes were made.

This change modifies the state logic so that the index table is
only modified when the corresponding table has actually been
modified. Along with matching expected behaviour, this change has
the potential to reduce the number of times blocking queries will
return without any real state change.