### PR TITLE
docs/job-spec: Fix formatting in network page

### DIFF
--- a/website/content/docs/job-specification/network.mdx
+++ b/website/content/docs/job-specification/network.mdx
@@ -109,8 +109,7 @@ When the task starts, it will be passed the following environment variables:
 
 - <tt>NOMAD_IP_foo</tt> - The IP to bind on for the given port label.
 - <tt>NOMAD_PORT_foo</tt> - The port value for the given port label.
-- <tt>NOMAD_ADDR_foo</tt> - A combined
-  <tt>ip:port</tt> that can be used for convenience.
+- <tt>NOMAD_ADDR_foo</tt> - A combined <tt>ip:port</tt> that can be used for convenience.
 
 The label of the port is just text - it has no special meaning to Nomad.
 


### PR DESCRIPTION
This fixes a minor formatting issue with whitespacing.

## Before

![Screenshot 2022-06-06 at 11 20 43](https://user-images.githubusercontent.com/287584/172142986-c0032254-d273-4089-b381-61ad35258b6e.png)

## After

![Screenshot 2022-06-06 at 11 20 34](https://user-images.githubusercontent.com/287584/172143018-d32e9fc5-022d-4035-af16-da11b326259a.png)

