### PR TITLE
driver/docker: Don't pull InfraImage if it exists

### DIFF
--- a/.changelog/13265.txt
+++ b/.changelog/13265.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+driver/docker: Eliminate excess Docker registry pulls for the `infra_image` when it already exists locally.
+```

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -981,7 +981,8 @@ host system.
 
 - `infra_image` - This is the Docker image to use when creating the parent
   container necessary when sharing network namespaces between tasks. Defaults to
-  `gcr.io/google_containers/pause-<goarch>:3.1`.
+  `gcr.io/google_containers/pause-<goarch>:3.1`. The image will only be pulled from
+  the container registry if its tag is `latest` or the image doesn't yet exist locally.
 
 - `infra_image_pull_timeout` - A time duration that controls how long Nomad will
   wait before cancelling an in-progress pull of the Docker image as specified in


### PR DESCRIPTION
This PR tweaks the behavior of Nomad's Docker driver during network setup.

When Nomad sets up a new Docker network, it establishes the network namespace by running a "no-op" container, internally called `InfraImage`.  By default the container's image is `gcr.io/google_containers/pause-amd64:3.1` (where `amd64` is the GOARCH).

Every time a network is set up, that container image is pulled from the Google Container Registry (or alternate image, if configured).  In a cluster with a high rate of Nomad job creation, the Docker pull is seen to intermittently fail (about 0.4%), perhaps due to rate limiting or normal transient network problems.

Because this image is versioned (tagged `3.1`, currently), it is not necessary to run a Docker pull on every use.  This PR proposes a refinement to the Docker driver's `CreateNetwork` function to first check if the image is present locally before pulling it.  The expectation is to improve resiliency of Nomad job launches, and to remove a bit of excess load from GCR (or other configured registry).

Fixes #11014
Fixes #11380
Fixes #10318
