### PR TITLE
e2e: use longer wait in template update triggers to avoid flake.

### DIFF
--- a/e2e/consultemplate/consultemplate.go
+++ b/e2e/consultemplate/consultemplate.go
@@ -163,7 +163,10 @@ job: {{ env "NOMAD_JOB_NAME" }}
 		"upstream":          "running",
 		"exec_downstream":   "running",
 		"docker_downstream": "running"}
-	f.NoError(waitForAllocStatusByGroup(jobID, ns, expected, nil))
+	f.NoError(waitForAllocStatusByGroup(jobID, ns, expected, &e2eutil.WaitConfig{
+		Interval: time.Millisecond * 300,
+		Retries:  100,
+	}))
 
 	// verify we've rendered the templates
 	for allocID := range downstreams {


### PR DESCRIPTION
The test has failed on/off recently and therefore this extends to wait period in hopes to fix this.