### PR TITLE
vault_hook: build context from task_runner shutdown context

### DIFF
--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -84,7 +84,8 @@ func (tr *TaskRunner) initHooks() {
 
 	// If Vault is enabled, add the hook
 	if task.Vault != nil {
-		tr.runnerHooks = append(tr.runnerHooks, newVaultHook(&vaultHookConfig{
+		joinedCtx, joinedCancel := joincontext.Join(tr.killCtx, tr.shutdownCtx)
+		tr.runnerHooks = append(tr.runnerHooks, newVaultHook(joinedCtx, joinedCancel, &vaultHookConfig{
 			vaultStanza: task.Vault,
 			client:      tr.vaultClient,
 			events:      tr,
@@ -93,7 +94,6 @@ func (tr *TaskRunner) initHooks() {
 			logger:      hookLogger,
 			alloc:       tr.Alloc(),
 			task:        tr.taskName,
-			parentCtx:   tr.shutdownCtx,
 		}))
 	}
 

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -93,6 +93,7 @@ func (tr *TaskRunner) initHooks() {
 			logger:      hookLogger,
 			alloc:       tr.Alloc(),
 			task:        tr.taskName,
+			parentCtx:   tr.shutdownCtx,
 		}))
 	}
 

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -2571,6 +2571,7 @@ func TestTaskRunner_Shutdown_Stops_Vault_Token_Renewal(t *testing.T) {
 	// If the context cancellation worked we should only have 1 renew token and 1 stopped renew token.
 	require.Len(t, mockVaultClient.RenewTokens(), 1)
 	require.Len(t, mockVaultClient.StoppedTokens(), 1)
+	require.False(t, mockVaultClient.Running())
 }
 
 // TestTaskRunner_UnregisterConsul_Retries asserts a task is unregistered from

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -2509,7 +2509,7 @@ func TestTaskRunner_VaultManager_Signal(t *testing.T) {
 }
 
 // TestTaskRunner_Shutdown_Stops_Vault_Token_Renewal asserts that when the alloc completes,
-// the Vault hook detects that the shutdownCtx is canceled and stops the renewal process.
+// the Vault hook detects that the shutdownCtx or killCtx is canceled and stops the renewal process.
 func TestTaskRunner_Shutdown_Stops_Vault_Token_Renewal(t *testing.T) {
 	ci.Parallel(t)
 
@@ -2545,10 +2545,6 @@ func TestTaskRunner_Shutdown_Stops_Vault_Token_Renewal(t *testing.T) {
 		vltHook = hook.(*vaultHook)
 		break
 	}
-
-	//ctx, cancel := context.WithCancel(context.Background())
-	//vltHook.ctx = ctx
-	//vltHook.cancel = cancel
 
 	// Wait for a Vault token
 	var token string

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -2508,6 +2508,75 @@ func TestTaskRunner_VaultManager_Signal(t *testing.T) {
 
 }
 
+// TestTaskRunner_Shutdown_Stops_Vault_Token_Renewal asserts that when the alloc completes,
+// the Vault hook detects that the shutdownCtx is canceled and stops the renewal process.
+func TestTaskRunner_Shutdown_Stops_Vault_Token_Renewal(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Templates = []*structs.Template{
+		{
+			EmbeddedTmpl: `{{key "foo"}}`,
+			DestPath:     "local/test",
+			ChangeMode:   structs.TemplateChangeModeNoop,
+		},
+	}
+	task.Vault = &structs.Vault{Policies: []string{"default"}}
+
+	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name)
+	defer cleanup()
+
+	// Add our own mock vault client so that we can reference it later
+	mockVaultClient := vaultclient.NewMockVaultClient()
+	conf.Vault = mockVaultClient
+
+	tr, err := NewTaskRunner(conf)
+	require.NoError(t, err)
+	defer tr.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
+	go tr.Run()
+
+	var vltHook *vaultHook
+	for _, hook := range tr.runnerHooks {
+		if hook.Name() != "vault" {
+			continue
+		}
+
+		vltHook = hook.(*vaultHook)
+		break
+	}
+
+	//ctx, cancel := context.WithCancel(context.Background())
+	//vltHook.ctx = ctx
+	//vltHook.cancel = cancel
+
+	// Wait for a Vault token
+	var token string
+	testutil.WaitForResult(func() (bool, error) {
+		token = tr.getVaultToken()
+
+		if token == "" {
+			return false, fmt.Errorf("no Vault token")
+		}
+
+		return true, nil
+	}, func(err error) {
+		require.NoError(t, err)
+	})
+
+	require.NotEmpty(t, token)
+
+	tr.Shutdown()
+
+	require.NotNil(t, vltHook)
+	require.Error(t, vltHook.ctx.Err())
+	require.Equal(t, vltHook.ctx.Err().Error(), "context canceled")
+
+	// If the context cancellation worked we should only have 1 renew token and 1 stopped renew token.
+	require.Len(t, mockVaultClient.RenewTokens(), 1)
+	require.Len(t, mockVaultClient.StoppedTokens(), 1)
+}
+
 // TestTaskRunner_UnregisterConsul_Retries asserts a task is unregistered from
 // Consul when waiting to be retried.
 func TestTaskRunner_UnregisterConsul_Retries(t *testing.T) {

--- a/client/allocrunner/taskrunner/vault_hook.go
+++ b/client/allocrunner/taskrunner/vault_hook.go
@@ -53,6 +53,7 @@ type vaultHookConfig struct {
 	logger      log.Logger
 	alloc       *structs.Allocation
 	task        string
+	parentCtx   context.Context
 }
 
 type vaultHook struct {
@@ -95,7 +96,7 @@ type vaultHook struct {
 }
 
 func newVaultHook(config *vaultHookConfig) *vaultHook {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(config.parentCtx)
 	h := &vaultHook{
 		vaultStanza:  config.vaultStanza,
 		client:       config.client,

--- a/client/allocrunner/taskrunner/vault_hook.go
+++ b/client/allocrunner/taskrunner/vault_hook.go
@@ -172,9 +172,6 @@ func (h *vaultHook) Shutdown() {
 func (h *vaultHook) run(token string) {
 	// Helper for stopping token renewal
 	stopRenewal := func() {
-		// Stop the client renewal loop.
-		h.client.Stop()
-		// Remove the token from the heap.
 		if err := h.client.StopRenewToken(h.future.Get()); err != nil {
 			h.logger.Warn("failed to stop token renewal", "error", err)
 		}

--- a/client/allocrunner/taskrunner/vault_hook.go
+++ b/client/allocrunner/taskrunner/vault_hook.go
@@ -53,7 +53,6 @@ type vaultHookConfig struct {
 	logger      log.Logger
 	alloc       *structs.Allocation
 	task        string
-	parentCtx   context.Context
 }
 
 type vaultHook struct {
@@ -95,8 +94,7 @@ type vaultHook struct {
 	future *tokenFuture
 }
 
-func newVaultHook(config *vaultHookConfig) *vaultHook {
-	ctx, cancel := context.WithCancel(config.parentCtx)
+func newVaultHook(ctx context.Context, cancel context.CancelFunc, config *vaultHookConfig) *vaultHook {
 	h := &vaultHook{
 		vaultStanza:  config.vaultStanza,
 		client:       config.client,

--- a/client/allocrunner/taskrunner/vault_hook.go
+++ b/client/allocrunner/taskrunner/vault_hook.go
@@ -172,6 +172,9 @@ func (h *vaultHook) Shutdown() {
 func (h *vaultHook) run(token string) {
 	// Helper for stopping token renewal
 	stopRenewal := func() {
+		// Stop the client renewal loop.
+		h.client.Stop()
+		// Remove the token from the heap.
 		if err := h.client.StopRenewToken(h.future.Get()); err != nil {
 			h.logger.Warn("failed to stop token renewal", "error", err)
 		}

--- a/client/vaultclient/vaultclient_testing.go
+++ b/client/vaultclient/vaultclient_testing.go
@@ -31,6 +31,9 @@ type MockVaultClient struct {
 	// a token is generated and returned
 	DeriveTokenFn func(a *structs.Allocation, tasks []string) (map[string]string, error)
 
+	// running tracks whether the renewal loop is running
+	running bool
+
 	mu sync.Mutex
 }
 
@@ -111,9 +114,23 @@ func (vc *MockVaultClient) StopRenewToken(token string) error {
 	return nil
 }
 
-func (vc *MockVaultClient) Start() {}
+func (vc *MockVaultClient) Running() bool {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+	return vc.running
+}
 
-func (vc *MockVaultClient) Stop() {}
+func (vc *MockVaultClient) Start() {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+	vc.running = true
+}
+
+func (vc *MockVaultClient) Stop() {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+	vc.running = false
+}
 
 func (vc *MockVaultClient) GetConsulACL(string, string) (*vaultapi.Secret, error) { return nil, nil }
 


### PR DESCRIPTION
Closes: #12465

This PR addresses a defect where the Vault token renewal process may race with a task shutting down or being killed. The code has been modified in the following ways.

- `newTaskHook` now requires `context.Context` and a `context.CancelFunc` parameters and uses these passed values instead of `context.Background()`.
- `taskRunner.initHooks` calls `joincontext.Join` on `shutdownCtx` and `killCtx` and passes the result to `newTaskHook`

Since the passed context is a joined version of `shutdownCtx` and `killCtx`, either being cancelled will cause the `vaultHook.run` loop to stop the renewal and exit.