### PR TITLE
secure variables ACL policies

### DIFF
--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCapabilitySet(t *testing.T) {
@@ -379,6 +380,115 @@ func TestWildcardHostVolumeMatching(t *testing.T) {
 		})
 	}
 }
+
+func TestSecureVariablesMatching(t *testing.T) {
+	ci.Parallel(t)
+
+	tests := []struct {
+		name   string
+		policy string
+		ns     string
+		path   string
+		op     string
+		allow  bool
+	}{
+		{
+			name: "concrete namespace with concrete path matches",
+			policy: `namespace "ns" {
+					secure_variables { path "foo/bar" { capabilities = ["read"] }}}`,
+			ns:    "ns",
+			path:  "foo/bar",
+			op:    "read",
+			allow: true,
+		},
+		{
+			name: "concrete namespace with concrete path matches for expanded caps",
+			policy: `namespace "ns" {
+					secure_variables { path "foo/bar" { capabilities = ["read"] }}}`,
+			ns:    "ns",
+			path:  "foo/bar",
+			op:    "list",
+			allow: true,
+		},
+		{
+			name: "concrete namespace with wildcard path matches",
+			policy: `namespace "ns" {
+					secure_variables { path "foo/*" { capabilities = ["read"] }}}`,
+			ns:    "ns",
+			path:  "foo/bar",
+			op:    "read",
+			allow: true,
+		},
+		{
+			name: "concrete namespace with invalid concrete path fails",
+			policy: `namespace "ns" {
+					secure_variables { path "bar" { capabilities = ["read"] }}}`,
+			ns:    "ns",
+			path:  "foo/bar",
+			op:    "read",
+			allow: false,
+		},
+		{
+			name: "concrete namespace with invalid wildcard path fails",
+			policy: `namespace "ns" {
+					secure_variables { path "*/foo" { capabilities = ["read"] }}}`,
+			ns:    "ns",
+			path:  "foo/bar",
+			op:    "read",
+			allow: false,
+		},
+		{
+			name: "wildcard namespace with concrete path matches",
+			policy: `namespace "*" {
+					secure_variables { path "foo/bar" { capabilities = ["read"] }}}`,
+			ns:    "ns",
+			path:  "foo/bar",
+			op:    "read",
+			allow: true,
+		},
+		{
+			name: "wildcard namespace with invalid concrete path fails",
+			policy: `namespace "*" {
+					secure_variables { path "bar" { capabilities = ["read"] }}}`,
+			ns:    "ns",
+			path:  "foo/bar",
+			op:    "read",
+			allow: false,
+		},
+		{
+			name: "wildcard in user provided path fails",
+			policy: `namespace "ns" {
+					secure_variables { path "foo/bar" { capabilities = ["read"] }}}`,
+			ns:    "ns",
+			path:  "*",
+			op:    "read",
+			allow: false,
+		},
+		{
+			name: "wildcard attempt to bypass delimiter null byte fails",
+			policy: `namespace "ns" {
+					secure_variables { path "foo/bar" { capabilities = ["read"] }}}`,
+			ns:    "ns*",
+			path:  "bar",
+			op:    "read",
+			allow: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			policy, err := Parse(tc.policy)
+			require.NoError(t, err)
+			require.NotNil(t, policy.Namespaces[0].SecureVariables)
+
+			acl, err := NewACL(false, []*Policy{policy})
+			require.NoError(t, err)
+			require.Equal(t, tc.allow, acl.AllowSecureVariableOperation(tc.ns, tc.path, tc.op))
+		})
+	}
+}
+
 func TestACL_matchingCapabilitySet_returnsAllMatches(t *testing.T) {
 	ci.Parallel(t)
 

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -55,6 +55,19 @@ func TestParse(t *testing.T) {
 			namespace "secret" {
 				capabilities = ["deny", "read-logs"]
 			}
+			namespace "apps" {
+				secure_variables {
+					path "jobs/write-does-not-imply-read-or-delete" {
+						capabilities = ["write"]
+					}
+					path "project/read-implies-list" {
+						capabilities = ["read"]
+					}
+					path "project/explicit" {
+						capabilities = ["read", "list", "destroy"]
+					}
+				}
+			}
 			namespace "autoscaler" {
 				policy = "scale"
 			}
@@ -120,6 +133,32 @@ func TestParse(t *testing.T) {
 						Capabilities: []string{
 							NamespaceCapabilityDeny,
 							NamespaceCapabilityReadLogs,
+						},
+					},
+					{
+						Name: "apps",
+						SecureVariables: &SecureVariablesPolicy{
+							Paths: []*SecureVariablesPathPolicy{
+								{
+									PathSpec:     "jobs/write-does-not-imply-read-or-delete",
+									Capabilities: []string{SecureVariablesCapabilityWrite},
+								},
+								{
+									PathSpec: "project/read-implies-list",
+									Capabilities: []string{
+										SecureVariablesCapabilityRead,
+										SecureVariablesCapabilityList,
+									},
+								},
+								{
+									PathSpec: "project/explicit",
+									Capabilities: []string{
+										SecureVariablesCapabilityRead,
+										SecureVariablesCapabilityList,
+										SecureVariablesCapabilityDestroy,
+									},
+								},
+							},
 						},
 					},
 					{

--- a/nomad/acl.go
+++ b/nomad/acl.go
@@ -183,10 +183,10 @@ func (s *Server) resolvePoliciesForClaims(claims *structs.IdentityClaims) ([]*st
 	// Find any implicit policies associated with this task
 	policies := []*structs.ACLPolicy{}
 	implicitPolicyNames := []string{
-		fmt.Sprintf("_auto:%s/%s/%s/%s", alloc.Namespace, alloc.Job.ID, alloc.TaskGroup, claims.TaskName),
-		fmt.Sprintf("_auto:%s/%s/%s", alloc.Namespace, alloc.Job.ID, alloc.TaskGroup),
-		fmt.Sprintf("_auto:%s/%s", alloc.Namespace, alloc.Job.ID),
-		fmt.Sprintf("_auto:%s", alloc.Namespace),
+		fmt.Sprintf("_:%s/%s/%s/%s", alloc.Namespace, alloc.Job.ID, alloc.TaskGroup, claims.TaskName),
+		fmt.Sprintf("_:%s/%s/%s", alloc.Namespace, alloc.Job.ID, alloc.TaskGroup),
+		fmt.Sprintf("_:%s/%s", alloc.Namespace, alloc.Job.ID),
+		fmt.Sprintf("_:%s", alloc.Namespace),
 	}
 
 	for _, policyName := range implicitPolicyNames {

--- a/nomad/acl.go
+++ b/nomad/acl.go
@@ -64,8 +64,22 @@ func (s *Server) VerifyClaim(token string) (*structs.IdentityClaims, error) {
 	return claims, nil
 }
 
-func (s *Server) ResolveClaim(token string) (*structs.IdentityClaims, error) {
-	return s.encrypter.VerifyClaim(token)
+func (s *Server) ResolveClaims(claims *structs.IdentityClaims) (*acl.ACL, error) {
+
+	policies, err := s.resolvePoliciesForClaims(claims)
+	if err != nil {
+		return nil, err
+	}
+	if len(policies) == 0 {
+		return nil, nil
+	}
+
+	// Compile and cache the ACL object
+	aclObj, err := structs.CompileACLObject(s.aclCache, policies)
+	if err != nil {
+		return nil, err
+	}
+	return aclObj, nil
 }
 
 // resolveTokenFromSnapshotCache is used to resolve an ACL object from a snapshot of state,
@@ -150,4 +164,43 @@ func (s *Server) ResolveSecretToken(secretID string) (*structs.ACLToken, error) 
 	}
 
 	return token, nil
+}
+
+func (s *Server) resolvePoliciesForClaims(claims *structs.IdentityClaims) ([]*structs.ACLPolicy, error) {
+
+	snap, err := s.fsm.State().Snapshot()
+	if err != nil {
+		return nil, err
+	}
+	alloc, err := snap.AllocByID(nil, claims.AllocationID)
+	if err != nil {
+		return nil, err
+	}
+	if alloc == nil || alloc.Job == nil {
+		return nil, fmt.Errorf("allocation does not exist")
+	}
+
+	// Find any implicit policies associated with this task
+	policies := []*structs.ACLPolicy{}
+	implicitPolicyNames := []string{
+		fmt.Sprintf("_auto:%s/%s/%s/%s", alloc.Namespace, alloc.Job.ID, alloc.TaskGroup, claims.TaskName),
+		fmt.Sprintf("_auto:%s/%s/%s", alloc.Namespace, alloc.Job.ID, alloc.TaskGroup),
+		fmt.Sprintf("_auto:%s/%s", alloc.Namespace, alloc.Job.ID),
+		fmt.Sprintf("_auto:%s", alloc.Namespace),
+	}
+
+	for _, policyName := range implicitPolicyNames {
+		policy, err := snap.ACLPolicyByName(nil, policyName)
+		if err != nil {
+			return nil, err
+		}
+		if policy == nil {
+			// Ignore policies that don't exist, since they don't
+			// grant any more privilege
+			continue
+		}
+
+		policies = append(policies, policy)
+	}
+	return policies, nil
 }

--- a/nomad/secure_variables_endpoint_test.go
+++ b/nomad/secure_variables_endpoint_test.go
@@ -62,7 +62,7 @@ func TestSecureVariablesEndpoint_auth(t *testing.T) {
 	invalidIDToken := strings.Join(idTokenParts, ".")
 
 	policy := mock.ACLPolicy()
-	policy.Name = fmt.Sprintf("_auto:%s/%s/%s", ns, jobID, alloc1.TaskGroup)
+	policy.Name = fmt.Sprintf("_:%s/%s/%s", ns, jobID, alloc1.TaskGroup)
 	policy.Rules = `namespace "nondefault-namespace" {
 		secure_variables {
 		    path "jobs/*" { capabilities = ["read"] }

--- a/nomad/service_registration_endpoint.go
+++ b/nomad/service_registration_endpoint.go
@@ -456,7 +456,7 @@ func (s *ServiceRegistration) handleMixedAuthEndpoint(args structs.QueryOptions,
 		// identity claim if it's not a secret ID.
 		// COMPAT(1.4.0): we can remove this conditional in 1.5.0
 		if !helper.IsUUID(args.AuthToken) {
-			claims, err := s.srv.ResolveClaim(args.AuthToken)
+			claims, err := s.srv.VerifyClaim(args.AuthToken)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Adds a new policy block inside namespaces to control access to secure
variables on the basis of path, with support for globbing.

Adds a notion of implied policies for workload identities, where we'll
check for policies that might exist with particular well-known names,
and apply those policies to storage RPCs if they exist.

Refactors how we verify the token for the service registration RPCs so
that we can reuse the verification method. Best reviewed
commit-by-commit.