### PR TITLE
CSI: skip node unpublish on GC'd or down nodes

### DIFF
--- a/.changelog/13301.txt
+++ b/.changelog/13301.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where volume claims on lost or garbage collected nodes could not be freed
+```


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/13264

If the node has been GC'd or is down, we can't send it a node
unpublish. The CSI spec requires that we don't send the controller
unpublish before the node unpublish, but in the case where a node is
gone we can't know the final fate of the node unpublish step.

The `csi_hook` on the client will unpublish if the allocation has
stopped and if the host is terminated there's no mount for the volume
anyways. So we'll now assume that the node has unpublished at its
end. If it hasn't, any controller unpublish will potentially hang or
error and need to be retried.

(Note that while this behavior isn't ideal, it appears to match user
expectations and the behavior reported by k8s users.)