### PR TITLE
ci: remove step that generates GO_LDFLAGS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,25 +72,9 @@ jobs:
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
-  generate-ld-flags:
-    needs: get-product-version
-    runs-on: ubuntu-latest
-    outputs:
-      ldflags: ${{ steps.generate-ld-flags.outputs.ldflags }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.build-ref }}
-      - name: "Generate ld flags"
-        id: generate-ld-flags
-        run: |
-          project="$(go list -m)"
-          sha="$(git rev-parse --short HEAD)"
-          echo "::set-output name=ldflags::"-s -w -X \'$project/version.Name=${{ env.PKG_NAME }}\' \
-          -X \'$project/version.GitDescribe=v$(make version base=1)\'""
 
   build-other:
-    needs: [get-go-version, get-product-version, generate-ld-flags]
+    needs: [get-go-version, get-product-version]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -131,7 +115,6 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           GO_TAGS: ${{ env.GO_TAGS }}
-          GO_LDFLAGS: ${{ needs.generate-ld-flags.outputs.ldflags }}
           CGO_ENABLED: 1
         run: |
           make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
@@ -142,7 +125,7 @@ jobs:
           path: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
 
   build-linux:
-    needs: [get-go-version, get-product-version, generate-ld-flags]
+    needs: [get-go-version, get-product-version]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -208,7 +191,6 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           GO_TAGS: ${{ env.GO_TAGS }}
-          GO_LDFLAGS: ${{ needs.generate-ld-flags.outputs.ldflags }}
           CGO_ENABLED: 1
         run: |
           make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
@@ -252,7 +234,7 @@ jobs:
           path: out/${{ env.DEB_PACKAGE }}
 
   build-darwin:
-    needs: [get-go-version, get-product-version, generate-ld-flags]
+    needs: [get-go-version, get-product-version]
     runs-on: macos-latest
     strategy:
       matrix:
@@ -294,7 +276,6 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           GO_TAGS: "${{ env.GO_TAGS }} netcgo"
-          GO_LDFLAGS: ${{ needs.generate-ld-flags.outputs.ldflags }}
           CGO_ENABLED: 1
         run: |
           make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip


### PR DESCRIPTION
These flags were not being used because GNUmakefile overwrites them with
another value. We also don't want to set `-s -w` since they remove
information that is important for production debug.

In other projects this variable is used to override the default `-dev`
prerelease that is set even if `VersionPrerelease` is empty, but in
Nomad this check is never actually done because this conditional in
`version/version.go` is always false:

```go
func GetVersion() *VersionInfo {
  // ...
  rel := VersionPrerelease
  // ...
  if GitDescribe == "" && rel == "" && VersionPrerelease != "" {
    rel = "dev"
  }
  // ...
}
```

This seems like some leftover from a previous release process, but I
decided the leave the code as is.