### PR TITLE
build: rearrange go path order on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
       - run:
           name: Install golang dependencies
           command: |
-            export PATH=$PATH:/c/go/bin:/c/gopath/bin
+            export PATH=/c/go/bin:/c/gopath/bin:$PATH
             make deps
       - run:
           name: Pre-download docker test image
@@ -187,13 +187,13 @@ jobs:
       - run:
           name: Build nomad
           command: |
-            export PATH=$PATH:/c/go/bin:/c/gopath/bin
+            export PATH=/c/go/bin:/c/gopath/bin:$PATH
             go build -o $GOBIN\nomad.exe
       - run:
           name: Run tests with gotestsum
           command: |
             # Only test docker driver tests for now
-            export PATH=$PATH:/c/go/bin:/c/gopath/bin
+            export PATH=/c/go/bin:/c/gopath/bin:$PATH
             gotestsum --format=short-verbose \
               --junitfile $GOTESTSUM_PATH/results.xml \
               github.com/hashicorp/nomad/drivers/docker \


### PR DESCRIPTION
If PATH comes first, an older version of Go is used that cannot install
dependencies that use features of newer versions of Go, which we just
installed.
