### PR TITLE
CSI: make plugin health_timeout configurable in csi_plugin stanza

### DIFF
--- a/.changelog/13340.txt
+++ b/.changelog/13340.txt
@@ -1,0 +1,3 @@
+```release-note:improvements
+csi: Made the CSI Plugin supervisor health check configurable with a new CSI Stanza health_timeout field
+```

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -1039,6 +1039,10 @@ type TaskCSIPluginConfig struct {
 	//
 	// Default is /csi.
 	MountDir string `mapstructure:"mount_dir" hcl:"mount_dir,optional"`
+
+	// HealthTimeout is the time after which the CSI plugin tasks will be killed
+	// if the CSI Plugin is not healthy.
+	HealthTimeout time.Duration `mapstructure:"health_timeout" hcl:"health_timeout,optional"`
 }
 
 func (t *TaskCSIPluginConfig) Canonicalize() {

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -1049,4 +1049,8 @@ func (t *TaskCSIPluginConfig) Canonicalize() {
 	if t.MountDir == "" {
 		t.MountDir = "/csi"
 	}
+
+	if t.HealthTimeout == 0 {
+		t.HealthTimeout = 30 * time.Second
+	}
 }

--- a/client/allocrunner/taskrunner/plugin_supervisor_hook.go
+++ b/client/allocrunner/taskrunner/plugin_supervisor_hook.go
@@ -253,7 +253,7 @@ func (h *csiPluginSupervisorHook) ensureSupervisorLoop(ctx context.Context) {
 
 	// We're in Poststart at this point, so if we can't connect within
 	// this deadline, assume it's broken so we can restart the task
-	startCtx, startCancelFn := context.WithTimeout(ctx, 30*time.Second)
+	startCtx, startCancelFn := context.WithTimeout(ctx, h.task.CSIPluginConfig.HealthTimeout)
 	defer startCancelFn()
 
 	var err error
@@ -441,7 +441,7 @@ func (h *csiPluginSupervisorHook) kill(ctx context.Context, reason error) {
 	if err := h.lifecycle.Kill(ctx,
 		structs.NewTaskEvent(structs.TaskKilling).
 			SetFailsTask().
-			SetDisplayMessage("CSI plugin did not become healthy before timeout"),
+			SetDisplayMessage(fmt.Sprintf("CSI plugin did not become healthy before configured %v health timeout", h.task.CSIPluginConfig.HealthTimeout.String())),
 	); err != nil {
 		h.logger.Error("failed to kill task", "kill_reason", reason, "error", err)
 	}

--- a/client/allocrunner/taskrunner/plugin_supervisor_hook.go
+++ b/client/allocrunner/taskrunner/plugin_supervisor_hook.go
@@ -103,6 +103,10 @@ func newCSIPluginSupervisorHook(config *csiPluginSupervisorHookConfig) *csiPlugi
 	socketMountPoint := filepath.Join(config.clientStateDirPath, "csi",
 		"plugins", config.runner.Alloc().ID)
 
+	if task.CSIPluginConfig.HealthTimeout == 0 {
+		task.CSIPluginConfig.HealthTimeout = 30 * time.Second
+	}
+
 	shutdownCtx, cancelFn := context.WithCancel(context.Background())
 
 	hook := &csiPluginSupervisorHook{

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1263,6 +1263,7 @@ func ApiCSIPluginConfigToStructsCSIPluginConfig(apiConfig *api.TaskCSIPluginConf
 	sc.ID = apiConfig.ID
 	sc.Type = structs.CSIPluginType(apiConfig.Type)
 	sc.MountDir = apiConfig.MountDir
+	sc.HealthTimeout = apiConfig.HealthTimeout
 	return sc
 }
 

--- a/jobspec/parse_task.go
+++ b/jobspec/parse_task.go
@@ -158,12 +158,20 @@ func parseTask(item *ast.ObjectItem, keys []string) (*api.Task, error) {
 		i := o.Elem().Items[0]
 
 		var m map[string]interface{}
+		var cfg api.TaskCSIPluginConfig
 		if err := hcl.DecodeObject(&m, i.Val); err != nil {
 			return nil, err
 		}
 
-		var cfg api.TaskCSIPluginConfig
-		if err := mapstructure.WeakDecode(m, &cfg); err != nil {
+		dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			DecodeHook:       mapstructure.StringToTimeDurationHookFunc(),
+			WeaklyTypedInput: true,
+			Result:           &cfg,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if err := dec.Decode(m); err != nil {
 			return nil, err
 		}
 

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -626,9 +626,10 @@ func TestParse(t *testing.T) {
 								Name:   "binstore",
 								Driver: "docker",
 								CSIPluginConfig: &api.TaskCSIPluginConfig{
-									ID:       "org.hashicorp.csi",
-									Type:     api.CSIPluginTypeMonolith,
-									MountDir: "/csi/test",
+									ID:            "org.hashicorp.csi",
+									Type:          api.CSIPluginTypeMonolith,
+									MountDir:      "/csi/test",
+									HealthTimeout: 1 * time.Minute,
 								},
 							},
 						},

--- a/jobspec/test-fixtures/csi-plugin.hcl
+++ b/jobspec/test-fixtures/csi-plugin.hcl
@@ -4,9 +4,10 @@ job "binstore-storagelocker" {
       driver = "docker"
 
       csi_plugin {
-        id        = "org.hashicorp.csi"
-        type      = "monolith"
-        mount_dir = "/csi/test"
+        id             = "org.hashicorp.csi"
+        type           = "monolith"
+        mount_dir      = "/csi/test"
+        health_timeout = "1m"
       }
     }
   }

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -67,6 +67,10 @@ type TaskCSIPluginConfig struct {
 	// to be created by the plugin, and will provide references into
 	// "MountDir/CSIIntermediaryDirname/{VolumeName}/{AllocID} for mounts.
 	MountDir string
+
+	// HealthTimeout is the time after which the CSI plugin tasks will be killed
+	// if the CSI Plugin is not healthy.
+	HealthTimeout time.Duration `mapstructure:"health_timeout" hcl:"health_timeout,optional"`
 }
 
 func (t *TaskCSIPluginConfig) Copy() *TaskCSIPluginConfig {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7255,6 +7255,10 @@ func (t *Task) Validate(ephemeralDisk *EphemeralDisk, jobType string, tgServices
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("CSIPluginConfig PluginType must be one of 'node', 'controller', or 'monolith', got: \"%s\"", t.CSIPluginConfig.Type))
 		}
 
+		if t.CSIPluginConfig.HealthTimeout == 0 {
+			t.CSIPluginConfig.HealthTimeout = 30 * time.Second
+		}
+
 		// TODO: Investigate validation of the PluginMountDir. Not much we can do apart from check IsAbs until after we understand its execution environment though :(
 	}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7255,10 +7255,6 @@ func (t *Task) Validate(ephemeralDisk *EphemeralDisk, jobType string, tgServices
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("CSIPluginConfig PluginType must be one of 'node', 'controller', or 'monolith', got: \"%s\"", t.CSIPluginConfig.Type))
 		}
 
-		if t.CSIPluginConfig.HealthTimeout == 0 {
-			t.CSIPluginConfig.HealthTimeout = 30 * time.Second
-		}
-
 		// TODO: Investigate validation of the PluginMountDir. Not much we can do apart from check IsAbs until after we understand its execution environment though :(
 	}
 

--- a/website/content/docs/job-specification/csi_plugin.mdx
+++ b/website/content/docs/job-specification/csi_plugin.mdx
@@ -17,9 +17,10 @@ to claim [volumes][csi_volumes].
 
 ```hcl
 csi_plugin {
-  id        = "csi-hostpath"
-  type      = "monolith"
-  mount_dir = "/csi"
+  id             = "csi-hostpath"
+  type           = "monolith"
+  mount_dir      = "/csi"
+  health_timeout = "30s"
 }
 ```
 
@@ -42,6 +43,11 @@ csi_plugin {
 - `mount_dir` `(string: <required>)` - The directory path inside the
   container where the plugin will expect a Unix domain socket for
   bidirectional communication with Nomad.
+
+- `health_timeout` `(duration: <optional>)` - The duration that 
+  the plugin supervisor will wait before restarting an unhealthy
+  CSI plugin. Must be a duration value such as `30s` or `2m`.
+  Defaults to `30s` if not set. 
 
 ~> **Note:** Plugins running as `node` or `monolith` require root
 privileges (or `CAP_SYS_ADMIN` on Linux) to mount volumes on the
@@ -111,10 +117,11 @@ job "plugin-efs" {
       }
 
       csi_plugin {
-        id        = "aws-efs0"
-        type      = "node"
-        mount_dir = "/csi"  # this path /csi matches the --endpoint
+        id             = "aws-efs0"
+        type           = "node"
+        mount_dir      = "/csi"  # this path /csi matches the --endpoint
                             # argument for the container
+        health_timeout = "30s"
       }
     }
   }


### PR DESCRIPTION
Fixes #13179 

Test results: Configured health_timeout as `5m` and introduced an artificial error to make sure Portworx was killed after 5m:
```
Recent Events:
Time                  Type                     Description
2022-06-10T20:05:40Z  Killed                   Task successfully killed
2022-06-10T20:05:40Z  Terminated               Exit Code: 2, Exit Message: "Docker container exited with non-zero exit code: 2"
2022-06-10T20:05:40Z  Killing                  CSI plugin did not become healthy before configured 5m0s health timeout
2022-06-10T20:05:40Z  Plugin became unhealthy  Error: CSI plugin failed probe: timeout while connecting to gRPC socket: failed to stat socket: stat /etc/nomad.d/client/csi/plugins/62bdddd8-3955-92d2-cc23-02b6f6204e62/csi.sock: no such file or directory
2022-06-10T19:58:15Z  Started                  Task started by client
2022-06-10T19:58:13Z  Task Setup               Building Task Directory
2022-06-10T19:58:13Z  Received                 Task received by client
```

Signed-off-by: Grant Griffiths <ggriffiths@purestorage.com>