### PR TITLE
docs: explain behavior of system gc command

### DIFF
--- a/website/content/docs/commands/system/gc.mdx
+++ b/website/content/docs/commands/system/gc.mdx
@@ -10,6 +10,20 @@ description: |
 Initializes a garbage collection of jobs, evaluations, allocations, and nodes.
 This is an asynchronous operation.
 
+Nomad periodically garbage collects jobs, evaluations, allocations, and nodes.
+The exact garbage collection logic varies by object, but in general Nomad only
+permanently deletes objects once they are terminal and no longer needed for
+future scheduling decisions. See [`gc` related server agent configuration
+parameters][gc_params] for details on tuning periodic garbage collection.
+
+[gc_params]: /docs/configuration/server#node_gc_threshold
+
+The `system gc` command bypasses these settings and immediately attempts to
+garbage collect dead objects regardless of any "threshold" or "interval" server
+settings. This is useful to quickly free memory on servers running low, but
+users should prefer tuning periodic garbage collection parameters to meet their
+needs instead of relying on manually running `system gc`.
+
 ## Usage
 
 ```plaintext


### PR DESCRIPTION
Thanks to @tbehling for pointing out how incomplete these docs were. I had forgotten `system gc` ignores the server's `threshold` configuration!

Rendered: 
![image](https://user-images.githubusercontent.com/113362/173161206-5f4c1c44-cca9-4568-aff9-c4d58614b078.png)
