### PR TITLE
Return evalID if `-detach` flag is passed to job revert

### DIFF
--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -164,7 +164,13 @@ func (c *JobRevertCommand) Run(args []string) int {
 
 	// Nothing to do
 	evalCreated := resp.EvalID != ""
-	if detach || !evalCreated {
+
+	if !evalCreated {
+		return 0
+	}
+
+	if detach {
+		c.Ui.Output("Evaluation ID: " + resp.EvalID)
 		return 0
 	}
 


### PR DESCRIPTION
Make `nomad job revert -detach` do what the docs say it does.