### PR TITLE
fixup changelog entry for backported regression fix

### DIFF
--- a/.changelog/13340.txt
+++ b/.changelog/13340.txt
@@ -1,3 +1,3 @@
-```release-note:improvements
-csi: Made the CSI Plugin supervisor health check configurable with a new CSI Stanza health_timeout field
+```release-note:bug
+csi: Fixed a regression where a timeout was introduced that prevented some plugins from running by marking them as unhealthy after 30s by introducing a configurable `health_timeout` field
 ```


### PR DESCRIPTION
The changelog entry for #13340 indicated it was an improvement. But on
discussion, it was determined that this was a workaround for a
regression. Update the changelog to make this clear.