### PR TITLE
Backport volume spec page to release/1.2.x and release/1.1.x

### DIFF
--- a/website/content/docs/commands/volume/create.mdx
+++ b/website/content/docs/commands/volume/create.mdx
@@ -33,136 +33,38 @@ When ACLs are enabled, this command requires a token with the
 
 ## Volume Specification
 
-The file may be provided as either HCL or JSON. An example HCL configuration:
+<!--
+Redirection rules are applied server-side, so we can't redirect these sections
+that used to be located in this page since they use URL fragments. Creating
+these hidden anchors will at least point users to the new page, although not to
+the exact section.
+-->
 
-```hcl
-id           = "ebs_prod_db1"
-name         = "database"
-type         = "csi"
-plugin_id    = "ebs-prod"
-snapshot_id  = "snap-12345" # or clone_id, see below
-capacity_max = "200G"
-capacity_min = "100G"
+<span id="volume-specification-parameters" />
+<span id="id" />
+<span id="namespace-1" />
+<span id="name" />
+<span id="type" />
+<span id="plugin_id" />
+<span id="snapshot_id" />
+<span id="clone_id" />
+<span id="capacity_min" />
+<span id="capacity_max" />
+<span id="capability" />
+<span id="access_mode" />
+<span id="attachment_mode" />
+<span id="mount_options" />
+<span id="fs_type" />
+<span id="mount_flags" />
+<span id="secrets" />
+<span id="parameters" />
+<span id="segments" />
+<span id="unused-fields" />
 
-capability {
-  access_mode     = "single-node-reader-only"
-  attachment_mode = "file-system"
-}
-
-capability {
-  access_mode     = "single-node-writer"
-  attachment_mode = "file-system"
-}
-
-mount_options {
-  fs_type     = "ext4"
-  mount_flags = "noatime"
-}
-
-secrets {
-  example_secret = "xyzzy"
-}
-
-parameters {
-  skuname = "Premium_LRS"
-}
-```
-
-## Volume Specification Parameters
-
-- `id` `(string: <required>)` - The unique ID of the volume. This is how the
-  [`volume.source`][csi_volume_source] field in a job specification will refer
-  to the volume.
-
-- `name` `(string: <required>)` - The display name of the volume. This field
-  may be used by the external storage provider to tag the volume.
-
-- `type` `(string: <required>)` - The type of volume. Currently only `"csi"`
-  is supported.
-
-- `plugin_id` `(string: <required>)` - The ID of the [CSI plugin][csi_plugin]
-  that manages this volume.
-
-- `snapshot_id` `(string: <optional>)` - If the storage provider supports
-  snapshots, the external ID of the snapshot to restore when creating this
-  volume. If omitted, the volume will be created from scratch. The
-  `snapshot_id` cannot be set if the `clone_id` field is set.
-
-- `clone_id` `(string: <optional>)` - If the storage provider supports
-  cloning, the external ID of the volume to clone when creating this
-  volume. If omitted, the volume will be created from scratch. The
-  `clone_id` cannot be set if the `snapshot_id` field is set.
-
-- `capacity_min` `(string: <optional>)` - Option for requesting a
-  minimum capacity, in bytes. The capacity of a volume may be the
-  physical size of a disk, or a quota, depending on the storage
-  provider. The specific size of the resulting volume will be
-  somewhere between `capacity_min` and `capacity_max`; the exact
-  behavior is up to the storage provider. If you want to specify an
-  exact size, you should set `capacity_min` and `capacity_max` to the
-  same value. Accepts human-friendly suffixes such as `"100GiB"`. This
-  field may not be supported by all storage providers.
-
-- `capacity_max` `(string: <optional>)` - Option for requesting a
-  maximum capacity, in bytes. The capacity of a volume may be the
-  physical size of a disk, or a quota, depending on the storage
-  provider. The specific size of the resulting volume will be
-  somewhere between `capacity_min` and `capacity_max`; the exact
-  behavior is up to the storage provider. If you want to specify an
-  exact size, you should set `capacity_min` and `capacity_max` to the
-  same value. Accepts human-friendly suffixes such as `"100GiB"`. This
-  field may not be supported by all storage providers.
-
-- `capability` `(Capability: <required>)` - Option for validating the
-  capability of a volume. You must provide at least one `capability` block, and
-  you must provide a block for each capability you intend to use in a job's
-  [`volume`] block. Each `capability` block must have the following fields:
-
-  - `access_mode` `(string: <required>)` - Defines whether a volume should be
-    available concurrently. Can be one of `"single-node-reader-only"`,
-    `"single-node-writer"`, `"multi-node-reader-only"`,
-    `"multi-node-single-writer"`, or `"multi-node-multi-writer"`. Most CSI
-    plugins support only single-node modes. Consult the documentation of the
-    storage provider and CSI plugin.
-
-  - `attachment_mode` `(string: <required>)` - The storage API that will be used
-    by the volume. Most storage providers will support `"file-system"`, to mount
-    volumes using the CSI filesystem API. Some storage providers will support
-    `"block-device"`, which will mount the volume with the CSI block device API
-    within the container.
-
-- `mount_options` - Options for mounting `file-system` volumes that don't
-  already have a pre-formatted file system. This block will be validated
-  during volume creation against the `capability` field. The `mount_options`
-  provided in a job specification's [`volume`] block will override this
-  block. Consult the documentation for your storage provider and CSI plugin as
-  to whether these options are required or necessary.
-
-  - `fs_type` `(string <optional>)` - File system type (ex. `"ext4"`)
-  - `mount_flags` `([]string: <optional>)` - The flags passed to `mount`
-    (ex. `["ro", "noatime"]`)
-
-- `secrets` <code>(map<string|string>:nil)</code> - An optional
-  key-value map of strings used as credentials for publishing and
-  unpublishing volumes.
-
-- `parameters` <code>(map<string|string>:nil)</code> - An optional
-  key-value map of strings passed directly to the CSI plugin to
-  configure the volume. The details of these parameters are specific
-  to each storage provider, so please see the specific plugin
-  documentation for more information.
-
-### Unused Fields
-
-Note that several fields used in the [`volume register`] command are set
-automatically by the plugin when `volume create` is successful. You should not
-set the `external_id` or `context` fields described on that page.
+The volume specification is documented in the [Volume
+Specification][volume_specification] page.
 
 [csi]: https://github.com/container-storage-interface/spec
 [csi_plugins_internals]: /docs/internals/plugins/csi#csi-plugins
-[volume_specification]: #volume-specification
-[csi_plugin]: /docs/job-specification/csi_plugin
-[csi_volume_source]: /docs/job-specification/volume#source
 [registered]: /docs/commands/volume/register
-[`volume register`]: /docs/commands/volume/register
-[`volume`]: /docs/job-specification/volume
+[volume_specification]: /docs/other-specifications/volume

--- a/website/content/docs/commands/volume/register.mdx
+++ b/website/content/docs/commands/volume/register.mdx
@@ -22,11 +22,10 @@ nomad volume register [options] [file]
 ```
 
 The `volume register` command requires a single argument, specifying the path
-to a file containing a valid [volume
-specification][volume_specification]. This file will be read and the job will
-be submitted to Nomad for scheduling. If the supplied path is "-", the job
-file is read from STDIN. Otherwise it is read from the file at the supplied
-path.
+to a file containing a valid [volume specification][volume_specification]. This
+file will be read and the job will be submitted to Nomad for scheduling. If the
+supplied path is "-", the job file is read from STDIN. Otherwise it is read
+from the file at the supplied path.
 
 When ACLs are enabled, this command requires a token with the
 `csi-write-volume` capability for the volume's namespace.
@@ -37,116 +36,36 @@ When ACLs are enabled, this command requires a token with the
 
 ## Volume Specification
 
-The file may be provided as either HCL or JSON. An example HCL configuration:
+<!--
+Redirection rules are applied server-side, so we can't redirect these sections
+that used to be located in this page since they use URL fragments. Creating
+these hidden anchors will at least point users to the new page, although not to
+the exact section.
+-->
 
-```hcl
-id              = "ebs_prod_db1"
-name            = "database"
-type            = "csi"
-external_id     = "vol-23452345"
-plugin_id       = "ebs-prod"
+<span id="volume-specification-parameters" />
+<span id="id" />
+<span id="namespace-1" />
+<span id="name" />
+<span id="type" />
+<span id="external_id" />
+<span id="plugin_id" />
+<span id="capability" />
+<span id="access_mode" />
+<span id="attachment_mode" />
+<span id="mount_options" />
+<span id="fs_type" />
+<span id="mount_flags" />
+<span id="secrets" />
+<span id="parameters" />
+<span id="context" />
+<span id="segments" />
+<span id="unused-fields" />
 
-capability {
-  access_mode     = "single-node-reader-only"
-  attachment_mode = "file-system"
-}
-
-capability {
-  access_mode     = "single-node-writer"
-  attachment_mode = "file-system"
-}
-
-mount_options {
-  fs_type     = "ext4"
-  mount_flags = "noatime"
-}
-
-secrets {
-  example_secret = "xyzzy"
-}
-
-parameters {
-  skuname = "Premium_LRS"
-}
-
-context {
-  endpoint = "http://192.168.1.101:9425"
-}
-```
-
-## Volume Specification Parameters
-
-- `id` `(string: <required>)` - The unique ID of the volume. This is how the
-  [`volume.source`][csi_volume_source] field in a job specification will refer
-  to the volume.
-
-- `name` `(string: <required>)` - The display name of the volume.
-
-- `type` `(string: <required>)` - The type of volume. Currently only `"csi"`
-  is supported.
-
-- `external_id` `(string: <required>)` - The ID of the physical volume from
-  the storage provider. For example, the volume ID of an AWS EBS volume or
-  Digital Ocean volume.
-
-- `plugin_id` `(string: <required>)` - The ID of the [CSI plugin][csi_plugin]
-  that manages this volume.
-
-- `capability` `(Capability: <required>)` - Option for validating the
-  capability of a volume. You must provide at least one `capability` block, and
-  you must provide a block for each capability you intend to use in a job's
-  [`volume`] block. Each `capability` block must have the following fields:
-
-  - `access_mode` `(string: <required>)` - Defines whether a volume should be
-    available concurrently. Can be one of `"single-node-reader-only"`,
-    `"single-node-writer"`, `"multi-node-reader-only"`,
-    `"multi-node-single-writer"`, or `"multi-node-multi-writer"`. Most CSI
-    plugins support only single-node modes. Consult the documentation of the
-    storage provider and CSI plugin.
-
-  - `attachment_mode` `(string: <required>)` - The storage API that will be used
-    by the volume. Most storage providers will support `"file-system"`, to mount
-    volumes using the CSI filesystem API. Some storage providers will support
-    `"block-device"`, which will mount the volume with the CSI block device API
-    within the container.
-
-- `mount_options` - Options for mounting `file-system` volumes that don't
-  already have a pre-formatted file system. This block will be validated
-  during volume creation against the `capability` field. The `mount_options`
-  provided in a job specification's [`volume`] block will override this
-  block. Consult the documentation for your storage provider and CSI plugin as
-  to whether these options are required or necessary.
-
-  - `fs_type`: file system type (ex. `"ext4"`)
-  - `mount_flags`: the flags passed to `mount` (ex. `["ro", "noatime"]`)
-
-- `secrets` <code>(map<string|string>:nil)</code> - An optional
-  key-value map of strings used as credentials for publishing and
-  unpublishing volumes.
-
-- `parameters` <code>(map<string|string>:nil)</code> - An optional
-  key-value map of strings passed directly to the CSI plugin to
-  configure the volume. The details of these parameters are specific
-  to each storage provider, so please see the specific plugin
-  documentation for more information.
-
-- `context` <code>(map<string|string>:nil)</code> - An optional
-  key-value map of strings passed directly to the CSI plugin to
-  validate the volume. The details of these parameters are specific to
-  each storage provider, so please see the specific plugin
-  documentation for more information.
-
-### Unused Fields
-
-Note that several fields used in the [`volume create`] command are set
-automatically by the plugin when `volume create` is successful and cannot be
-set on a pre-existing volume. You should not set the `snapshot_id`,
-`clone_id`, `capacity_min`, or `capacity_max` fields described on that page.
+The volume specification is documented in the [Volume
+Specification][volume_specification] page.
 
 [csi]: https://github.com/container-storage-interface/spec
 [csi_plugins_internals]: /docs/internals/plugins/csi#csi-plugins
-[volume_specification]: #volume-specification
-[csi_plugin]: /docs/job-specification/csi_plugin
-[csi_volume_source]: /docs/job-specification/volume#source
-[`volume`]: /docs/job-specification/volume
+[volume_specification]: /docs/other-specifications/volume
 [`volume create`]: /docs/commands/volume/create

--- a/website/content/docs/other-specifications/index.mdx
+++ b/website/content/docs/other-specifications/index.mdx
@@ -1,0 +1,15 @@
+---
+layout: docs
+page_title: Other Specifications
+description: Learn about other specifications used in Nomad.
+---
+
+# Other Specifications
+
+In addition to [jobs][job_spec] there are other objects that can be specified
+in Nomad.
+
+- [Volume][volume_spec]
+
+[job_spec]: /docs/job-specification
+[volume_spec]: /docs/other-specifications/volume

--- a/website/content/docs/other-specifications/volume/capability.mdx
+++ b/website/content/docs/other-specifications/volume/capability.mdx
@@ -1,0 +1,72 @@
+---
+layout: docs
+page_title: capability Block - Volume Specification
+description: The "capability" block allows for validating the capability of a volume.
+---
+
+# `capability` Block
+
+<Placement
+  groups={[
+    ['volume', 'capability'],
+  ]}
+/>
+
+The `capability` block allows validating that a volume meets the requested
+capabilities.
+
+```hcl
+id           = "ebs_prod_db1"
+name         = "database"
+type         = "csi"
+plugin_id    = "ebs-prod"
+capacity_max = "200G"
+capacity_min = "100G"
+
+capability {
+  access_mode     = "single-node-reader-only"
+  attachment_mode = "file-system"
+}
+```
+
+You must provide at least one `capability` block, and you must provide a block
+for each capability you intend to use in a job's [`volume`] block.
+
+## `capability` Parameters
+
+- `access_mode` `(string: <required>)` - Defines whether a volume should be
+available concurrently. Can be one of `"single-node-reader-only"`,
+`"single-node-writer"`, `"multi-node-reader-only"`,
+`"multi-node-single-writer"`, or `"multi-node-multi-writer"`. Most CSI plugins
+support only single-node modes. Consult the documentation of the storage
+provider and CSI plugin.
+
+- `attachment_mode` `(string: <required>)` - The storage API that will be used
+by the volume. Most storage providers will support `"file-system"`, to mount
+volumes using the CSI filesystem API. Some storage providers will support
+`"block-device"`, which will mount the volume with the CSI block device API
+within the container.
+
+## `capability` Examples
+
+The following examples only show the `capability` blocks. Remember that the
+`capability` block is only valid in the placement shown above.
+
+### Multiple capabilities
+
+This examples shows a volume that must satisfy multiple capability
+requirements.
+
+```hcl
+capability {
+  access_mode     = "single-node-reader-only"
+  attachment_mode = "file-system"
+}
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}
+```
+
+[`volume`]: /docs/job-specification/volume

--- a/website/content/docs/other-specifications/volume/index.mdx
+++ b/website/content/docs/other-specifications/volume/index.mdx
@@ -1,0 +1,187 @@
+---
+layout: docs
+page_title: Volume Specification
+description: Learn about the Volume specification used to create and register volumes to Nomad.
+---
+
+# Volume Specification
+
+The Nomad volume specification defines the schema for creating and registering
+volumes using the [`volume create`] and [`volume register`] commands and the
+[`PUT /v1/volume/csi/:volume_id/create`][api_volume_create] and [`PUT
+/v1/volume/csi/:volume_id`][api_volume_register] API endpoints.
+
+Some attributes are only be supported by specific operation, while others may
+have a different meaning for each action, so read the documentation for each
+attribute carefully. The section [Differences Between Create and
+Register](#differences-between-create-and-register) provides a summary of the
+differences.
+
+The file may be provided as either HCL or JSON to the commands and as JSON to
+the API. An example HCL configuration for a `volume create` command:
+
+```hcl
+id           = "ebs_prod_db1"
+name         = "database"
+type         = "csi"
+plugin_id    = "ebs-prod"
+snapshot_id  = "snap-12345" # or clone_id, see below
+capacity_max = "200G"
+capacity_min = "100G"
+
+capability {
+  access_mode     = "single-node-reader-only"
+  attachment_mode = "file-system"
+}
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}
+
+mount_options {
+  fs_type     = "ext4"
+  mount_flags = ["noatime"]
+}
+
+secrets {
+  example_secret = "xyzzy"
+}
+
+parameters {
+  skuname = "Premium_LRS"
+}
+```
+
+## Volume Specification Parameters
+
+- `id` `(string: <required>)` - The unique ID of the volume. This is how the
+  [`volume.source`][csi_volume_source] field in a job specification will refer
+  to the volume.
+
+- `name` `(string: <required>)` - The display name of the volume. On **volume
+  creation**, this field may be used by the external storage provider to tag
+  the volume.
+
+- `type` `(string: <required>)` - The type of volume. Currently only `"csi"`
+  is supported.
+
+- `external_id` `(string: <required>)` - The ID of the physical volume from
+  the storage provider. For example, the volume ID of an AWS EBS volume or
+  Digital Ocean volume. Only allowed on **volume registration**.
+
+- `plugin_id` `(string: <required>)` - The ID of the [CSI plugin][csi_plugin]
+  that manages this volume.
+
+- `snapshot_id` `(string: <optional>)` - If the storage provider supports
+  snapshots, the external ID of the snapshot to restore when creating this
+  volume. If omitted, the volume will be created from scratch. The
+  `snapshot_id` cannot be set if the `clone_id` field is set. Only allowed on
+  **volume creation**.
+
+- `clone_id` `(string: <optional>)` - If the storage provider supports cloning,
+  the external ID of the volume to clone when creating this volume. If omitted,
+  the volume will be created from scratch. The `clone_id` cannot be set if the
+  `snapshot_id` field is set. Only allowed on **volume creation**.
+
+- `capacity_min` `(string: <optional>)` - Option for requesting a minimum
+  capacity, in bytes. The capacity of a volume may be the physical size of a
+  disk, or a quota, depending on the storage provider. The specific size of the
+  resulting volume will be somewhere between `capacity_min` and `capacity_max`;
+  the exact behavior is up to the storage provider. If you want to specify an
+  exact size, you should set `capacity_min` and `capacity_max` to the same
+  value. Accepts human-friendly suffixes such as `"100GiB"`. This field may not
+  be supported by all storage providers. Only allowed on **volume creation**.
+
+- `capacity_max` `(string: <optional>)` - Option for requesting a maximum
+  capacity, in bytes. The capacity of a volume may be the physical size of a
+  disk, or a quota, depending on the storage provider. The specific size of the
+  resulting volume will be somewhere between `capacity_min` and `capacity_max`;
+  the exact behavior is up to the storage provider. If you want to specify an
+  exact size, you should set `capacity_min` and `capacity_max` to the same
+  value. Accepts human-friendly suffixes such as `"100GiB"`. This field may not
+  be supported by all storage providers. Only allowed on **volume creation**.
+
+- `capability` <code>([Capability][capability]: &lt;required&gt;)</code> -
+  Option for validating the capability of a volume.
+
+- `mount_options` <code>([MountOptions][mount_options]: &lt;required&gt;)</code> -
+  Options for mounting `file-system` volumes that don't already have a
+  pre-formatted file system.
+
+- `secrets` <code>(map<string|string>:nil)</code> - An optional key-value map
+  of strings used as credentials for publishing and unpublishing volumes.
+
+- `parameters` <code>(map<string|string>:nil)</code> - An optional key-value
+  map of strings passed directly to the CSI plugin to configure the volume. The
+  details of these parameters are specific to each storage provider, so consult
+  the specific plugin documentation for more information.
+
+- `context` <code>(map<string|string>:nil)</code> - An optional key-value map
+  of strings passed directly to the CSI plugin to validate the volume. The
+  details of these parameters are specific to each storage provider, so consult
+  the specific plugin documentation for more information. Only allowed on
+  **volume registration**.
+
+## Differences Between Create and Register
+
+Several fields are set automatically by the plugin when `volume create` or
+`volume register` commands are successful and you should not set their values
+if they are not supported by the operation.
+
+You should not set the [`snapshot_id`](#snapshot_id), [`clone_id`](#clone_id),
+[`capacity_min`](#capacity_min), or [`capacity_max`](#capacity_max) fields on
+**volume registration**.
+
+And you should not set the [`external_id`](#external_id) or
+[`context`](#context) fields on **volume creation**.
+
+## Examples
+
+### Volume registration
+
+This is an example file used for the [`volume register`] commad.
+
+```hcl
+id              = "ebs_prod_db1"
+name            = "database"
+type            = "csi"
+external_id     = "vol-23452345"
+plugin_id       = "ebs-prod"
+
+capability {
+  access_mode     = "single-node-reader-only"
+  attachment_mode = "file-system"
+}
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}
+
+mount_options {
+  fs_type     = "ext4"
+  mount_flags = ["noatime"]
+}
+
+secrets {
+  example_secret = "xyzzy"
+}
+
+parameters {
+  skuname = "Premium_LRS"
+}
+
+context {
+  endpoint = "http://192.168.1.101:9425"
+}
+```
+
+[api_volume_create]: /api-docs/volumes#create-volume
+[api_volume_register]: /api-docs/volumes#register-volume
+[capability]: /docs/other-specifications/volume/capability
+[csi_plugin]: /docs/job-specification/csi_plugin
+[csi_volume_source]: /docs/job-specification/volume#source
+[mount_options]: /docs/other-specifications/volume/mount_options
+[`volume create`]: /docs/commands/volume/create
+[`volume register`]: /docs/commands/volume/register

--- a/website/content/docs/other-specifications/volume/mount_options.mdx
+++ b/website/content/docs/other-specifications/volume/mount_options.mdx
@@ -1,0 +1,43 @@
+---
+layout: docs
+page_title: mount_options Block - Volume Specification
+description: The "mount_options" block allows for configuring how a volume is mounted.
+---
+
+# `mount_options` Block
+
+<Placement
+  groups={[
+    ['volume', 'mount_options'],
+  ]}
+/>
+
+Options for mounting `file-system` volumes that don't already have a
+pre-formatted file system.
+
+```hcl
+id           = "ebs_prod_db1"
+name         = "database"
+type         = "csi"
+plugin_id    = "ebs-prod"
+capacity_max = "200G"
+capacity_min = "100G"
+
+mount_options {
+  fs_type     = "ext4"
+  mount_flags = ["noatime"]
+}
+```
+
+This block will be validated during volume creation against the `capability`
+field. The `mount_options` provided in a job specification's [`volume`] block
+will override this block. Consult the documentation for your storage provider
+and CSI plugin as to whether these options are required or necessary.
+
+## `mount_options` Parameters
+
+- `fs_type` `(string <optional>)` - File system type (ex. `"ext4"`)
+- `mount_flags` `([]string: <optional>)` - The flags passed to `mount` (ex.
+  `["ro", "noatime"]`)
+
+[`volume`]: /docs/job-specification/volume

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1377,6 +1377,32 @@
     ]
   },
   {
+    "title": "Other Specifications",
+    "routes": [
+      {
+        "title": "Overview",
+        "path": "other-specifications"
+      },
+      {
+        "title": "Volume",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "other-specifications/volume"
+          },
+          {
+            "title": "capability",
+            "path": "other-specifications/volume/capability"
+          },
+          {
+            "title": "mount_options",
+            "path": "other-specifications/volume/mount_options"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "title": "Task Drivers",
     "routes": [
       {


### PR DESCRIPTION
Backport #13353 to `release/1.2.x` and `release/1.1.x`. The only difference is the removal of references to `namesapce` and topologies.

I don't know how to do this on GitHub, but here's the output of `git diff main..HEAD content/docs/other-specifications/volume`: https://gist.github.com/lgfa29/6821befaea05d4359109487b569d2129#file-1_2-diff