### PR TITLE
Update example license_path to match docs

### DIFF
--- a/.release/linux/package/etc/nomad.d/nomad.hcl
+++ b/.release/linux/package/etc/nomad.d/nomad.hcl
@@ -5,7 +5,7 @@ bind_addr = "0.0.0.0"
 
 server {
   # license_path is required as of Nomad v1.1.1+
-  #license_path = "/etc/nomad.d/nomad.hcl"
+  #license_path = "/opt/nomad/license.hclic"
   enabled          = true
   bootstrap_expect = 1
 }


### PR DESCRIPTION
When installing the `nomad` Debian package, the default `nomad.hcl` file shows a commented-out example `license_path` that points to the `nomad.hcl` file.  That sounds unnecessarily confusing, especially to a new user.  This PR updates the example `license_path` to match the [docs](https://www.nomadproject.io/docs/configuration/server#license_path), `/opt/nomad/license.hclic`.