### PR TITLE
fix blocking query for `Keyring.List` RPC

### DIFF
--- a/nomad/keyring_endpoint.go
+++ b/nomad/keyring_endpoint.go
@@ -107,14 +107,16 @@ func (k *Keyring) List(args *structs.KeyringListRootKeyMetaRequest, reply *struc
 				return err
 			}
 
+			keys := []*structs.RootKeyMeta{}
 			for {
 				raw := iter.Next()
 				if raw == nil {
 					break
 				}
 				keyMeta := raw.(*structs.RootKeyMeta)
-				reply.Keys = append(reply.Keys, keyMeta)
+				keys = append(keys, keyMeta)
 			}
+			reply.Keys = keys
 			return k.srv.replySetIndex(state.TableRootKeyMeta, &reply.QueryMeta)
 		},
 	}

--- a/nomad/keyring_endpoint_test.go
+++ b/nomad/keyring_endpoint_test.go
@@ -79,14 +79,13 @@ func TestKeyringEndpoint_CRUD(t *testing.T) {
 	}()
 
 	updateReq.RootKey.Meta.CreateTime = time.Now()
-
 	err = msgpackrpc.CallWithCodec(codec, "Keyring.Update", updateReq, &updateResp)
 	require.NoError(t, err)
 	require.NotEqual(t, uint64(0), updateResp.Index)
 
 	// wait for the blocking query to complete and check the response
 	wg.Wait()
-	require.Greater(t, listResp.Index, getResp.Index)
+	require.Equal(t, listResp.Index, updateResp.Index)
 	require.Len(t, listResp.Keys, 2) // bootstrap + new one
 
 	// Delete the key and verify that it's gone


### PR DESCRIPTION
The blocking query for `Keyring.List` appended the keys for each pass
through the blocking query to the response. This results in mulitple
copies of keys in the response. Overwrite the `reply.Keys` field on
each pass through the blocking query to ensure we only get the
expected page of responses.