### PR TITLE
cli: fix detach handling

### DIFF
--- a/.changelog/13405.txt
+++ b/.changelog/13405.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed remaining bugs where the evaluation ID was not printed when the `-detach` flag was passed
+``

--- a/command/deployment_fail.go
+++ b/command/deployment_fail.go
@@ -132,7 +132,12 @@ func (c *DeploymentFailCommand) Run(args []string) int {
 	evalCreated := u.EvalID != ""
 
 	// Nothing to do
-	if detach || !evalCreated {
+	if !evalCreated {
+		return 0
+	}
+
+	if detach {
+		c.Ui.Output("Evaluation ID: " + u.EvalID)
 		return 0
 	}
 

--- a/command/deployment_promote.go
+++ b/command/deployment_promote.go
@@ -140,9 +140,15 @@ func (c *DeploymentPromoteCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Nothing to do
 	evalCreated := u.EvalID != ""
-	if detach || !evalCreated {
+
+	// Nothing to do
+	if !evalCreated {
+		return 0
+	}
+
+	if detach {
+		c.Ui.Output("Evaluation ID: " + u.EvalID)
 		return 0
 	}
 

--- a/command/deployment_resume.go
+++ b/command/deployment_resume.go
@@ -124,7 +124,12 @@ func (c *DeploymentResumeCommand) Run(args []string) int {
 	evalCreated := u.EvalID != ""
 
 	// Nothing to do
-	if detach || !evalCreated {
+	if !evalCreated {
+		return 0
+	}
+
+	if detach {
+		c.Ui.Output("Evaluation ID: " + u.EvalID)
 		return 0
 	}
 

--- a/command/deployment_unblock.go
+++ b/command/deployment_unblock.go
@@ -124,7 +124,12 @@ func (c *DeploymentUnblockCommand) Run(args []string) int {
 	evalCreated := u.EvalID != ""
 
 	// Nothing to do
-	if detach || !evalCreated {
+	if !evalCreated {
+		return 0
+	}
+
+	if detach {
+		c.Ui.Output("Evaluation ID: " + u.EvalID)
 		return 0
 	}
 

--- a/command/job_promote.go
+++ b/command/job_promote.go
@@ -161,9 +161,15 @@ func (c *JobPromoteCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Nothing to do
 	evalCreated := u.EvalID != ""
-	if detach || !evalCreated {
+
+	// Nothing to do
+	if !evalCreated {
+		return 0
+	}
+
+	if detach {
+		c.Ui.Output("Evaluation ID: " + u.EvalID)
 		return 0
 	}
 


### PR DESCRIPTION
Closes: #13382

This PR includes fixes to several CLI commands that are not handling the detach flag correctly. In each case, the command should be printing an Eval ID before exiting. The affected commands are:

- `deployment fail`
- `deployment promote`
- `deployment resume`
- `deployment unblock`
- `job promote`