### PR TITLE
ui:  update  component api to accept callback fns to be fired on cancel/prompt

### DIFF
--- a/ui/app/components/two-step-button.js
+++ b/ui/app/components/two-step-button.js
@@ -24,6 +24,7 @@ export default class TwoStepButton extends Component {
   inlineText = false;
   onConfirm() {}
   onCancel() {}
+  onPrompt() {}
 
   state = 'idle';
   @equal('state', 'idle') isIdle;
@@ -42,11 +43,19 @@ export default class TwoStepButton extends Component {
   @action
   setToIdle() {
     this.set('state', 'idle');
+
+    if (this.onCancel) {
+      this.onCancel();
+    }
+
     this.cancelOnClickOutside.cancelAll();
   }
 
   @action
   promptForConfirmation() {
+    if (this.onPrompt) {
+      this.onPrompt();
+    }
     this.set('state', 'prompt');
     next(() => {
       this.cancelOnClickOutside.perform();

--- a/ui/app/components/two-step-button.js
+++ b/ui/app/components/two-step-button.js
@@ -34,6 +34,9 @@ export default class TwoStepButton extends Component {
     while (true) {
       let ev = yield waitForEvent(document.body, 'click');
       if (!this.element.contains(ev.target) && !this.awaitingConfirmation) {
+        if (this.onCancel) {
+          this.onCancel();
+        }
         this.send('setToIdle');
       }
     }
@@ -43,11 +46,6 @@ export default class TwoStepButton extends Component {
   @action
   setToIdle() {
     this.set('state', 'idle');
-
-    if (this.onCancel) {
-      this.onCancel();
-    }
-
     this.cancelOnClickOutside.cancelAll();
   }
 

--- a/ui/app/controllers/variables/variable/index.js
+++ b/ui/app/controllers/variables/variable/index.js
@@ -1,4 +1,5 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
 import messageForError from '../../../utils/message-from-adapter-error';
 import { inject as service } from '@ember/service';
@@ -9,6 +10,18 @@ export default class VariablesVariableIndexController extends Controller {
 
   @tracked
   error = null;
+
+  @tracked isDeleting = false;
+
+  @action
+  onDeletePrompt() {
+    this.isDeleting = true;
+  }
+
+  @action
+  onCancel() {
+    this.isDeleting = false;
+  }
 
   @task(function* () {
     try {

--- a/ui/app/controllers/variables/variable/index.js
+++ b/ui/app/controllers/variables/variable/index.js
@@ -19,7 +19,7 @@ export default class VariablesVariableIndexController extends Controller {
   }
 
   @action
-  onCancel() {
+  onDeleteCancel() {
     this.isDeleting = false;
   }
 

--- a/ui/app/templates/variables/variable/index.hbs
+++ b/ui/app/templates/variables/variable/index.hbs
@@ -49,7 +49,7 @@
       @awaitingConfirmation={{this.deleteVariableFile.isRunning}}
       @onConfirm={{perform this.deleteVariableFile}}
       @onPrompt={{this.onDeletePrompt}}
-      @onCancel={{this.onCancel}}
+      @onCancel={{this.onDeleteCancel}}
     />
   </div>
 </h1>

--- a/ui/app/templates/variables/variable/index.hbs
+++ b/ui/app/templates/variables/variable/index.hbs
@@ -22,23 +22,23 @@
     </div>
   </div>
 {{/if}}
-
 <h1 class="title with-flex">
   <div>
     <FlightIcon @name="file-text" />
     {{this.model.path}}
   </div>
   <div>
-    <div class="two-step-button">
-    <LinkTo
-      class="button is-info is-inverted is-small"
-      @model={{this.model}}
-      @route="variables.variable.edit"
-    >
-      Edit
-    </LinkTo>
-    </div>
-
+    {{#unless this.isDeleting}}
+      <div class="two-step-button">
+        <LinkTo
+          class="button is-info is-inverted is-small"
+          @model={{this.model}}
+          @route="variables.variable.edit"
+        >
+          Edit
+        </LinkTo>
+      </div>
+    {{/unless}}
     <TwoStepButton
       data-test-delete-button
       @alignRight={{true}}
@@ -47,15 +47,21 @@
       @confirmText="Yes, delete"
       @confirmationMessage="Are you sure you want to delete this variable and all its items?"
       @awaitingConfirmation={{this.deleteVariableFile.isRunning}}
-      @onConfirm={{perform this.deleteVariableFile}} />
+      @onConfirm={{perform this.deleteVariableFile}}
+      @onPrompt={{this.onDeletePrompt}}
+      @onCancel={{this.onCancel}}
+    />
   </div>
 </h1>
-
 <ListTable data-test-eval-table @source={{this.model.keyValues}} as |t|>
   <t.body as |row|>
     <tr>
-    <td>{{row.model.key}}</td>
-    <td>{{row.model.value}}</td>
+      <td>
+        {{row.model.key}}
+      </td>
+      <td>
+        {{row.model.value}}
+      </td>
     </tr>
   </t.body>
 </ListTable>


### PR DESCRIPTION
This PR removes the `Edit` `LinkTo` component from the template when the `Delete` button is clicked.

![image](https://user-images.githubusercontent.com/41024828/174323674-7bbd1fff-e68b-433a-9554-93c34845a787.png)

Side Effect:  This PR updates the `TwoStepButton` component API to accept an `onPrompt` callback function to be fired with the `promptForConfirmation` action and adds logic for the `onCancel` callback function to be fired when the `TwoStepButton` registers on outside click event.