### PR TITLE
Path Tree compaction refactor

### DIFF
--- a/ui/app/components/variable-paths.js
+++ b/ui/app/components/variable-paths.js
@@ -10,10 +10,7 @@ export default class VariablePathsComponent extends Component {
    * @returns {Array<Object.<string, Object>>}
    */
   get folders() {
-    return Object.entries(this.args.branch.children).map(([name, data]) => {
-      console.log('checking to see if I can compact', name);
-      console.log(compactPath(this.args.branch.children[name], name));
-      // return { name, data };
+    return Object.entries(this.args.branch.children).map(([name]) => {
       return compactPath(this.args.branch.children[name], name);
     });
   }

--- a/ui/app/components/variable-paths.js
+++ b/ui/app/components/variable-paths.js
@@ -2,7 +2,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-
+import compactPath from '../utils/compact-path';
 export default class VariablePathsComponent extends Component {
   @service router;
 
@@ -11,7 +11,10 @@ export default class VariablePathsComponent extends Component {
    */
   get folders() {
     return Object.entries(this.args.branch.children).map(([name, data]) => {
-      return { name, data };
+      console.log('checking to see if I can compact', name);
+      console.log(compactPath(this.args.branch.children[name], name));
+      // return { name, data };
+      return compactPath(this.args.branch.children[name], name);
     });
   }
 

--- a/ui/app/controllers/variables/variable/index.js
+++ b/ui/app/controllers/variables/variable/index.js
@@ -14,8 +14,8 @@ export default class VariablesVariableIndexController extends Controller {
     try {
       yield this.model.deleteRecord();
       yield this.model.save();
-      if (this.model.folderPath) {
-        this.router.transitionTo('variables.path', this.model.folderPath);
+      if (this.model.parentFolderPath) {
+        this.router.transitionTo('variables.path', this.model.parentFolderPath);
       } else {
         this.router.transitionTo('variables');
       }

--- a/ui/app/models/variable.js
+++ b/ui/app/models/variable.js
@@ -6,7 +6,6 @@ import classic from 'ember-classic-decorator';
 // eslint-disable-next-line no-unused-vars
 import MutableArray from '@ember/array/mutable';
 import { trimPath } from '../helpers/trim-path';
-import { pathToObject } from '../utils/path-tree';
 
 /**
  * @typedef KeyValue
@@ -57,8 +56,10 @@ export default class VariableModel extends Model {
   @attr('string') namespace;
 
   @computed('path')
-  get folderPath() {
-    return pathToObject(this.path).path;
+  get parentFolderPath() {
+    const split = this.path.split('/');
+    const [, ...folderPath] = [split.pop(), ...split];
+    return folderPath.join('/');
   }
 
   /**

--- a/ui/app/routes/variables/path.js
+++ b/ui/app/routes/variables/path.js
@@ -1,5 +1,4 @@
 import Route from '@ember/routing/route';
-
 export default class VariablesPathRoute extends Route {
   model({ absolutePath }) {
     const treeAtPath =

--- a/ui/app/utils/compact-path.js
+++ b/ui/app/utils/compact-path.js
@@ -5,8 +5,6 @@
  * @returns
  */
 export default function compactPath(branch, name = '') {
-  // console.log('lup', branch);
-  // name = `${name}/${branch.name}`;
   let { children, files } = branch;
   if (children && Object.keys(children).length === 1 && !files.length) {
     const [key] = Object.keys(children);
@@ -18,17 +16,3 @@ export default function compactPath(branch, name = '') {
     data: branch,
   };
 }
-
-// if (branch.children && Object.keys(branch.children).length === 1) {
-//   const [name, child] = Object.entries(branch.children)[0];
-//   console.log('true and', name, child, child.children, !Object.keys(child.children).length);
-//   if (child.files.length && !Object.keys(child.children).length) {
-//     console.log('also true!');
-//     return {
-//       name,
-//       absolutePath: branch.absolutePath,
-//       files: child.files,
-//     };
-//   }
-// }
-// return branch;

--- a/ui/app/utils/compact-path.js
+++ b/ui/app/utils/compact-path.js
@@ -1,0 +1,34 @@
+/**
+ * Takes a branch created by our path-tree, and if it has only a single directory as descendent and no files, compacts it down to its terminal folder (the first descendent folder with either files or branching directories)
+ * Uses tail recursion
+ * @param {import("./path-tree").NestedPathTreeNode} branch
+ * @returns
+ */
+export default function compactPath(branch, name = '') {
+  // console.log('lup', branch);
+  // name = `${name}/${branch.name}`;
+  let { children, files } = branch;
+  if (children && Object.keys(children).length === 1 && !files.length) {
+    const [key] = Object.keys(children);
+    const child = children[key];
+    return compactPath(child, `${name}/${key}`);
+  }
+  return {
+    name,
+    data: branch,
+  };
+}
+
+// if (branch.children && Object.keys(branch.children).length === 1) {
+//   const [name, child] = Object.entries(branch.children)[0];
+//   console.log('true and', name, child, child.children, !Object.keys(child.children).length);
+//   if (child.files.length && !Object.keys(child.children).length) {
+//     console.log('also true!');
+//     return {
+//       name,
+//       absolutePath: branch.absolutePath,
+//       files: child.files,
+//     };
+//   }
+// }
+// return branch;

--- a/ui/app/utils/path-tree.js
+++ b/ui/app/utils/path-tree.js
@@ -35,24 +35,24 @@ export function pathToObject(path) {
   };
 }
 
-/**
- * Compacts an object of path:file key-values so any same-common-ancestor paths are collapsed into a single path.
- * @param {NestedPathTreeNode} vars
- * @returns {void}}
- */
-function COMPACT_EMPTY_DIRS(vars) {
-  Object.keys(vars).map((pathString) => {
-    const encompasser = Object.keys(vars).find(
-      (ps) => ps !== pathString && pathString.startsWith(ps)
-    );
-    if (encompasser) {
-      vars[encompasser].children[pathString.replace(encompasser, '')] =
-        vars[pathString];
-      delete vars[pathString];
-      COMPACT_EMPTY_DIRS(vars[encompasser].children);
-    }
-  });
-}
+// /**
+//  * Compacts an object of path:file key-values so any same-common-ancestor paths are collapsed into a single path.
+//  * @param {NestedPathTreeNode} vars
+//  * @returns {void}}
+//  */
+// function COMPACT_EMPTY_DIRS(vars) {
+//   Object.keys(vars).map((pathString) => {
+//     const encompasser = Object.keys(vars).find(
+//       (ps) => ps !== pathString && pathString.startsWith(ps)
+//     );
+//     if (encompasser) {
+//       vars[encompasser].children[pathString.replace(encompasser, '')] =
+//         vars[pathString];
+//       delete vars[pathString];
+//       COMPACT_EMPTY_DIRS(vars[encompasser].children);
+//     }
+//   });
+// }
 
 /**
  * @returns {NestedPathTreeNode}
@@ -78,8 +78,8 @@ export default class PathTree {
       // const fileName = path.pop();
       // console.log('thus path', path, fileName);
       path.reduce((acc, segment, index, arr) => {
-        console.log('abacus', segment, index, arr);
         if (index === arr.length - 1) {
+          // If it's a file (end of the segment array)
           acc.files.push({
             name: segment,
             absoluteFilePath: path.join('/'),
@@ -87,6 +87,7 @@ export default class PathTree {
             variable,
           });
         } else {
+          // Otherwise, it's a folder
           if (!acc.children[segment]) {
             acc.children[segment] = {
               children: {},

--- a/ui/app/utils/path-tree.js
+++ b/ui/app/utils/path-tree.js
@@ -63,43 +63,74 @@ export default class PathTree {
    */
   constructor(variables) {
     this.variables = variables;
-    this.paths = this.generatePaths();
+    this.paths = this.generatePaths(variables);
   }
+
+  root = { children: {}, files: [], absolutePath: '' };
 
   /**
    * Takes our variables array and groups them by common path
    * @returns {NestedPathTreeNode}
    */
-  generatePaths = () => {
-    const paths = this.variables
-      .map((variable) => trimPath([variable.path]))
-      .map(pathToObject)
-      .reduce(
-        (acc, cur) => {
-          const { name, absoluteFilePath } = cur;
-          if (cur.path) {
-            acc.root.children[cur.path]
-              ? acc.root.children[cur.path].files.push({
-                  name,
-                  absoluteFilePath,
-                })
-              : (acc.root.children[cur.path] = {
-                  files: [{ name, absoluteFilePath }],
-                  children: {},
-                });
-            acc.root.children[cur.path].absolutePath = cur.path;
-          } else {
-            acc.root.files
-              ? acc.root.files.push({ name, absoluteFilePath })
-              : (acc.root.files = [{ name, absoluteFilePath }]);
+  generatePaths = (variables) => {
+    variables.forEach((variable) => {
+      const path = trimPath([variable.path]).split('/');
+      // const fileName = path.pop();
+      // console.log('thus path', path, fileName);
+      path.reduce((acc, segment, index, arr) => {
+        console.log('abacus', segment, index, arr);
+        if (index === arr.length - 1) {
+          acc.files.push({
+            name: segment,
+            absoluteFilePath: path.join('/'),
+            path: arr.slice(0, index + 1).join('/'),
+            variable,
+          });
+        } else {
+          if (!acc.children[segment]) {
+            acc.children[segment] = {
+              children: {},
+              files: [],
+              absolutePath: trimPath([`${acc.absolutePath || ''}/${segment}`]),
+            };
           }
-          return acc;
-        },
-        { root: { files: [], children: {}, absolutePath: '' } }
-      );
+        }
+        return acc.children[segment];
+      }, this.root);
+    });
+    console.log('and done', this.root);
+    return { root: this.root };
 
-    COMPACT_EMPTY_DIRS(paths.root.children);
-    return paths;
+    //     const paths = this.variables
+    //       .map((variable) => trimPath([variable.path]))
+    //       .map(pathToObject)
+    //       .reduce(
+    //         (acc, cur) => {
+    //           const { name, absoluteFilePath } = cur;
+    //           if (cur.path) {
+    //             acc.root.children[cur.path]
+    //               ? acc.root.children[cur.path].files.push({
+    //                   name,
+    //                   absoluteFilePath,
+    //                 })
+    //               : (acc.root.children[cur.path] = {
+    //                   files: [{ name, absoluteFilePath }],
+    //                   children: {},
+    //                 });
+    //             acc.root.children[cur.path].absolutePath = cur.path;
+    //           } else {
+    //             acc.root.files
+    //               ? acc.root.files.push({ name, absoluteFilePath })
+    //               : (acc.root.files = [{ name, absoluteFilePath }]);
+    //           }
+    //           return acc;
+    //         },
+    //         { root: { files: [], children: {}, absolutePath: '' } }
+    //       );
+
+    //     console.log("checking before compaction", paths);
+    //     COMPACT_EMPTY_DIRS(paths.root.children);
+    //     return paths;
   };
 
   /**

--- a/ui/tests/unit/utils/compact-path-test.js
+++ b/ui/tests/unit/utils/compact-path-test.js
@@ -31,12 +31,12 @@ module('Unit | Utility | compact-path', function () {
       'Path z/y is compacted to y/x, since it has a single child'
     );
     assert.equal(
-      compactPath(tree.findPath('z/y/x'), 'x'),
+      compactPath(tree.findPath('z/y/x'), 'x').name,
       'x',
       'Path z/y/x is uncompacted, since it has multiple children'
     );
     assert.equal(
-      compactPath(tree.findPath('a/b/c/d/e/z'), 'z'),
+      compactPath(tree.findPath('a/b/c/d/e/z'), 'z').name,
       'z/z/z/z/z/z/z/z/z/z',
       'Long path is recursively compacted'
     );

--- a/ui/tests/unit/utils/compact-path-test.js
+++ b/ui/tests/unit/utils/compact-path-test.js
@@ -16,27 +16,28 @@ const PATHSTRINGS = [
 module('Unit | Utility | compact-path', function () {
   test('it compacts empty folders correctly', function (assert) {
     const tree = new pathTree(PATHSTRINGS);
-    console.log('tree', tree, compactPath(tree.root.children['a'], 'a'));
     assert.ok(
       'a' in tree.paths.root.children,
       'root.a exists in the path tree despite having no files and only a single path'
     );
-    assert.ok(
-      compactPath(tree.root.children['a'], 'a').name === 'a/b/c/d/e',
+    assert.equal(
+      compactPath(tree.root.children['a'], 'a').name,
+      'a/b/c/d/e',
       'but root.a is displayed compacted down to /e from its root level folder'
     );
-    assert.ok(
-      compactPath(tree.findPath('z/y'), 'y').name === 'y/x',
+    assert.equal(
+      compactPath(tree.findPath('z/y'), 'y').name,
+      'y/x',
       'Path z/y is compacted to y/x, since it has a single child'
     );
-    assert.ok(
-      compactPath(tree.findPath('z/y/x'), 'x').name === 'x',
+    assert.equal(
+      compactPath(tree.findPath('z/y/x'), 'x'),
+      'x',
       'Path z/y/x is uncompacted, since it has multiple children'
     );
-    console.log('ah fuck', compactPath(tree.findPath('a/b/c/d/e/z'), 'z'));
-    assert.ok(
-      compactPath(tree.findPath('a/b/c/d/e/z'), 'z').name ===
-        'z/z/z/z/z/z/z/z/z/z',
+    assert.equal(
+      compactPath(tree.findPath('a/b/c/d/e/z'), 'z'),
+      'z/z/z/z/z/z/z/z/z/z',
       'Long path is recursively compacted'
     );
   });

--- a/ui/tests/unit/utils/compact-path-test.js
+++ b/ui/tests/unit/utils/compact-path-test.js
@@ -1,10 +1,43 @@
 import compactPath from 'nomad-ui/utils/compact-path';
+import pathTree from 'nomad-ui/utils/path-tree';
 import { module, test } from 'qunit';
 
+const PATHSTRINGS = [
+  { path: 'a/b/c/d/e/foo0' },
+  { path: 'a/b/c/d/e/bar1' },
+  { path: 'a/b/c/d/e/baz2' },
+  { path: 'a/b/c/d/e/z/z/z/z/z/z/z/z/z/z/foo3' },
+  { path: 'z/y/x/dalmation/index' },
+  { path: 'z/y/x/doberman/index' },
+  { path: 'z/y/x/dachshund/index' },
+  { path: 'z/y/x/dachshund/poppy' },
+];
+
 module('Unit | Utility | compact-path', function () {
-  // TODO: Replace this with your real tests.
-  test('it works', function (assert) {
-    let result = compactPath();
-    assert.ok(result);
+  test('it compacts empty folders correctly', function (assert) {
+    const tree = new pathTree(PATHSTRINGS);
+    console.log('tree', tree, compactPath(tree.root.children['a'], 'a'));
+    assert.ok(
+      'a' in tree.paths.root.children,
+      'root.a exists in the path tree despite having no files and only a single path'
+    );
+    assert.ok(
+      compactPath(tree.root.children['a'], 'a').name === 'a/b/c/d/e',
+      'but root.a is displayed compacted down to /e from its root level folder'
+    );
+    assert.ok(
+      compactPath(tree.findPath('z/y'), 'y').name === 'y/x',
+      'Path z/y is compacted to y/x, since it has a single child'
+    );
+    assert.ok(
+      compactPath(tree.findPath('z/y/x'), 'x').name === 'x',
+      'Path z/y/x is uncompacted, since it has multiple children'
+    );
+    console.log('ah fuck', compactPath(tree.findPath('a/b/c/d/e/z'), 'z'));
+    assert.ok(
+      compactPath(tree.findPath('a/b/c/d/e/z'), 'z').name ===
+        'z/z/z/z/z/z/z/z/z/z',
+      'Long path is recursively compacted'
+    );
   });
 });

--- a/ui/tests/unit/utils/compact-path-test.js
+++ b/ui/tests/unit/utils/compact-path-test.js
@@ -1,0 +1,10 @@
+import compactPath from 'nomad-ui/utils/compact-path';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | compact-path', function () {
+  // TODO: Replace this with your real tests.
+  test('it works', function (assert) {
+    let result = compactPath();
+    assert.ok(result);
+  });
+});

--- a/ui/tests/unit/utils/path-tree-test.js
+++ b/ui/tests/unit/utils/path-tree-test.js
@@ -32,27 +32,6 @@ module('Unit | Utility | path-tree', function () {
     );
   });
 
-  test('it compacts empty folders correctly', function (assert) {
-    const tree = new pathTree(PATHSTRINGS);
-    assert.ok(
-      'a' in tree.paths.root.children,
-      'root.a is uncompacted since it contains a file (b)'
-    );
-    assert.notOk(
-      'foo' in tree.paths.root.children,
-      'root.foo does not exist since it contains no files'
-    );
-    assert.ok(
-      'foo/bar' in tree.paths.root.children,
-      'root.foo/bar is compacted since the only child from foo is bar'
-    );
-    assert.equal(
-      tree.paths.root.children['foo/bar'].files.length,
-      3,
-      'A compacted directory contains all terminal files'
-    );
-  });
-
   test('it allows for node-based search and traversal', function (assert) {
     const tree = new pathTree(PATHSTRINGS);
     assert.deepEqual(
@@ -60,10 +39,10 @@ module('Unit | Utility | path-tree', function () {
       tree.findPath(''),
       'Returns tree root on default findPath'
     );
-    assert.notOk(
+    assert.ok(
       tree.findPath('foo'),
-      'No path found at the first part of a concatenated folder'
-    ); // TODO: but maybe we want this to work eventually, so if this test fails because you add mid-tree traversal? Great!
+      'Path found at the first part of a concatenated folder'
+    );
     assert.ok(
       tree.findPath('foo/bar'),
       'Finds a path at the concatenated folder path'


### PR DESCRIPTION
- Moves folder compaction (listing folder "foo" in a directory as "foo/bar" when it only has one child descendent named "bar") to render time instead of compute time
- Removes secondary functions from the Path Tree util (compact paths, pathToObject) and standardizes its types

In practice, this lets you traverse the directory tree structure for variables at a compacted path without issue.

So if you have a single variable at `a/b/c/d/e/myVar`, you previously would only be able to see anything at `a/b/c/d/e`; now you could traverse to `a/b/c` if you so chose, and `d/e/` would be listed therein.