### PR TITLE
Track plan rejection history and automatically mark clients as ineligible

### DIFF
--- a/.changelog/13421.txt
+++ b/.changelog/13421.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+core: automatically mark clients with recurring plan rejections as ineligible
+```
+
+```release-note:improvement
+metrics: emit `nomad.nomad.plan.rejection_tracker.node_score` metric for the number of times a node had a plan rejection within the past time window
+```

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -436,6 +436,17 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 		return nil, fmt.Errorf("deploy_query_rate_limit must be greater than 0")
 	}
 
+	// Set plan rejection tracker configuration.
+	if planRejectConf := agentConfig.Server.PlanRejectionTracker; planRejectConf != nil {
+		conf.NodePlanRejectionThreshold = planRejectConf.NodeThreshold
+
+		if planRejectConf.NodeWindow == 0 {
+			return nil, fmt.Errorf("plan_rejection_tracker.node_window must be greater than 0")
+		} else {
+			conf.NodePlanRejectionWindow = planRejectConf.NodeWindow
+		}
+	}
+
 	// Add Enterprise license configs
 	conf.LicenseEnv = agentConfig.Server.LicenseEnv
 	conf.LicensePath = agentConfig.Server.LicensePath

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -438,7 +438,9 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 
 	// Set plan rejection tracker configuration.
 	if planRejectConf := agentConfig.Server.PlanRejectionTracker; planRejectConf != nil {
-		conf.NodePlanRejectionEnabled = planRejectConf.Enabled
+		if planRejectConf.Enabled != nil {
+			conf.NodePlanRejectionEnabled = *planRejectConf.Enabled
+		}
 		conf.NodePlanRejectionThreshold = planRejectConf.NodeThreshold
 
 		if planRejectConf.NodeWindow == 0 {

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -438,6 +438,7 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 
 	// Set plan rejection tracker configuration.
 	if planRejectConf := agentConfig.Server.PlanRejectionTracker; planRejectConf != nil {
+		conf.NodePlanRejectionEnabled = planRejectConf.Enabled
 		conf.NodePlanRejectionThreshold = planRejectConf.NodeThreshold
 
 		if planRejectConf.NodeWindow == 0 {

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -378,8 +378,8 @@ func TestAgent_ServerConfig_PlanRejectionTracker(t *testing.T) {
 			name:          "default",
 			trackerConfig: nil,
 			expectedConfig: &PlanRejectionTracker{
-				NodeThreshold: 15,
-				NodeWindow:    10 * time.Minute,
+				NodeThreshold: 100,
+				NodeWindow:    5 * time.Minute,
 			},
 			expectedErr: "",
 		},

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -422,10 +422,12 @@ func TestAgent_ServerConfig_PlanRejectionTracker(t *testing.T) {
 				require.Contains(t, err.Error(), tc.expectedErr)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t,
-					tc.expectedConfig.Enabled,
-					serverConfig.NodePlanRejectionEnabled,
-				)
+				if tc.expectedConfig.Enabled != nil {
+					require.Equal(t,
+						*tc.expectedConfig.Enabled,
+						serverConfig.NodePlanRejectionEnabled,
+					)
+				}
 				require.Equal(t,
 					tc.expectedConfig.NodeThreshold,
 					serverConfig.NodePlanRejectionThreshold,

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -386,12 +386,12 @@ func TestAgent_ServerConfig_PlanRejectionTracker(t *testing.T) {
 		{
 			name: "valid config",
 			trackerConfig: &PlanRejectionTracker{
-				Enabled:       true,
+				Enabled:       helper.BoolToPtr(true),
 				NodeThreshold: 123,
 				NodeWindow:    17 * time.Minute,
 			},
 			expectedConfig: &PlanRejectionTracker{
-				Enabled:       true,
+				Enabled:       helper.BoolToPtr(true),
 				NodeThreshold: 123,
 				NodeWindow:    17 * time.Minute,
 			},

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -386,10 +386,12 @@ func TestAgent_ServerConfig_PlanRejectionTracker(t *testing.T) {
 		{
 			name: "valid config",
 			trackerConfig: &PlanRejectionTracker{
+				Enabled:       true,
 				NodeThreshold: 123,
 				NodeWindow:    17 * time.Minute,
 			},
 			expectedConfig: &PlanRejectionTracker{
+				Enabled:       true,
 				NodeThreshold: 123,
 				NodeWindow:    17 * time.Minute,
 			},
@@ -420,6 +422,10 @@ func TestAgent_ServerConfig_PlanRejectionTracker(t *testing.T) {
 				require.Contains(t, err.Error(), tc.expectedErr)
 			} else {
 				require.NoError(t, err)
+				require.Equal(t,
+					tc.expectedConfig.Enabled,
+					serverConfig.NodePlanRejectionEnabled,
+				)
 				require.Equal(t,
 					tc.expectedConfig.NodeThreshold,
 					serverConfig.NodePlanRejectionThreshold,

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -556,7 +556,7 @@ type RaftBoltConfig struct {
 // tracker.
 type PlanRejectionTracker struct {
 	// Enabled controls if the plan rejection tracker is active or not.
-	Enabled bool `hcl:"enabled"`
+	Enabled *bool `hcl:"enabled"`
 
 	// NodeThreshold is the number of times a node can have plan rejections
 	// before it is marked as ineligible.
@@ -582,8 +582,8 @@ func (p *PlanRejectionTracker) Merge(b *PlanRejectionTracker) *PlanRejectionTrac
 		return &result
 	}
 
-	if b.Enabled {
-		result.Enabled = true
+	if b.Enabled != nil {
+		result.Enabled = b.Enabled
 	}
 
 	if b.NodeThreshold != 0 {
@@ -1037,6 +1037,7 @@ func DefaultConfig() *Config {
 			RaftProtocol:      3,
 			StartJoin:         []string{},
 			PlanRejectionTracker: &PlanRejectionTracker{
+				Enabled:       helper.BoolToPtr(false),
 				NodeThreshold: 100,
 				NodeWindow:    5 * time.Minute,
 			},

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -503,6 +503,10 @@ type ServerConfig struct {
 	// This value is ignored.
 	DefaultSchedulerConfig *structs.SchedulerConfiguration `hcl:"default_scheduler_config"`
 
+	// PlanRejectionTracker configures the node plan rejection tracker that
+	// detects potentially bad nodes.
+	PlanRejectionTracker *PlanRejectionTracker `hcl:"plan_rejection_tracker"`
+
 	// EnableEventBroker configures whether this server's state store
 	// will generate events for its event stream.
 	EnableEventBroker *bool `hcl:"enable_event_broker"`
@@ -546,6 +550,46 @@ type RaftBoltConfig struct {
 	//
 	// Default: false.
 	NoFreelistSync bool `hcl:"no_freelist_sync"`
+}
+
+// PlanRejectionTracker is used in servers to configure the plan rejection
+// tracker.
+type PlanRejectionTracker struct {
+	// NodeThreshold is the number of times a node can have plan rejections
+	// before it is marked as ineligible.
+	NodeThreshold int `hcl:"node_threshold"`
+
+	// NodeWindow is the time window used to track active plan rejections for
+	// nodes.
+	NodeWindow    time.Duration
+	NodeWindowHCL string `hcl:"node_window" json:"-"`
+
+	// ExtraKeysHCL is used by hcl to surface unexpected keys
+	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
+}
+
+func (p *PlanRejectionTracker) Merge(b *PlanRejectionTracker) *PlanRejectionTracker {
+	if p == nil {
+		return b
+	}
+
+	result := *p
+
+	if b == nil {
+		return &result
+	}
+
+	if b.NodeThreshold != 0 {
+		result.NodeThreshold = b.NodeThreshold
+	}
+
+	if b.NodeWindow != 0 {
+		result.NodeWindow = b.NodeWindow
+	}
+	if b.NodeWindowHCL != "" {
+		result.NodeWindowHCL = b.NodeWindowHCL
+	}
+	return &result
 }
 
 // Search is used in servers to configure search API options.
@@ -985,6 +1029,10 @@ func DefaultConfig() *Config {
 			EventBufferSize:   helper.IntToPtr(100),
 			RaftProtocol:      3,
 			StartJoin:         []string{},
+			PlanRejectionTracker: &PlanRejectionTracker{
+				NodeThreshold: 15,
+				NodeWindow:    10 * time.Minute,
+			},
 			ServerJoin: &ServerJoin{
 				RetryJoin:        []string{},
 				RetryInterval:    30 * time.Second,
@@ -1584,6 +1632,10 @@ func (s *ServerConfig) Merge(b *ServerConfig) *ServerConfig {
 
 	if b.EventBufferSize != nil {
 		result.EventBufferSize = b.EventBufferSize
+	}
+
+	if b.PlanRejectionTracker != nil {
+		result.PlanRejectionTracker = result.PlanRejectionTracker.Merge(b.PlanRejectionTracker)
 	}
 
 	if b.DefaultSchedulerConfig != nil {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -555,6 +555,9 @@ type RaftBoltConfig struct {
 // PlanRejectionTracker is used in servers to configure the plan rejection
 // tracker.
 type PlanRejectionTracker struct {
+	// Enabled controls if the plan rejection tracker is active or not.
+	Enabled bool `hcl:"enabled"`
+
 	// NodeThreshold is the number of times a node can have plan rejections
 	// before it is marked as ineligible.
 	NodeThreshold int `hcl:"node_threshold"`
@@ -577,6 +580,10 @@ func (p *PlanRejectionTracker) Merge(b *PlanRejectionTracker) *PlanRejectionTrac
 
 	if b == nil {
 		return &result
+	}
+
+	if b.Enabled {
+		result.Enabled = true
 	}
 
 	if b.NodeThreshold != 0 {
@@ -1030,8 +1037,8 @@ func DefaultConfig() *Config {
 			RaftProtocol:      3,
 			StartJoin:         []string{},
 			PlanRejectionTracker: &PlanRejectionTracker{
-				NodeThreshold: 15,
-				NodeWindow:    10 * time.Minute,
+				NodeThreshold: 100,
+				NodeWindow:    5 * time.Minute,
 			},
 			ServerJoin: &ServerJoin{
 				RetryJoin:        []string{},

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -43,9 +43,12 @@ func ParseConfigFile(path string) (*Config, error) {
 				VaultRetry:  &client.RetryConfig{},
 			},
 		},
+		Server: &ServerConfig{
+			PlanRejectionTracker: &PlanRejectionTracker{},
+			ServerJoin:           &ServerJoin{},
+		},
 		ACL:       &ACLConfig{},
 		Audit:     &config.AuditConfig{},
-		Server:    &ServerConfig{ServerJoin: &ServerJoin{}},
 		Consul:    &config.ConsulConfig{},
 		Autopilot: &config.AutopilotConfig{},
 		Telemetry: &Telemetry{},
@@ -54,7 +57,7 @@ func ParseConfigFile(path string) (*Config, error) {
 
 	err = hcl.Decode(c, buf.String())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to decode HCL file %s: %v", path, err)
 	}
 
 	// convert strings to time.Durations
@@ -66,6 +69,7 @@ func ParseConfigFile(path string) (*Config, error) {
 		{"server.heartbeat_grace", &c.Server.HeartbeatGrace, &c.Server.HeartbeatGraceHCL, nil},
 		{"server.min_heartbeat_ttl", &c.Server.MinHeartbeatTTL, &c.Server.MinHeartbeatTTLHCL, nil},
 		{"server.failover_heartbeat_ttl", &c.Server.FailoverHeartbeatTTL, &c.Server.FailoverHeartbeatTTLHCL, nil},
+		{"server.plan_rejection_tracker.node_window", &c.Server.PlanRejectionTracker.NodeWindow, &c.Server.PlanRejectionTracker.NodeWindowHCL, nil},
 		{"server.retry_interval", &c.Server.RetryInterval, &c.Server.RetryIntervalHCL, nil},
 		{"server.server_join.retry_interval", &c.Server.ServerJoin.RetryInterval, &c.Server.ServerJoin.RetryIntervalHCL, nil},
 		{"consul.timeout", &c.Consul.Timeout, &c.Consul.TimeoutHCL, nil},

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -57,7 +57,7 @@ func ParseConfigFile(path string) (*Config, error) {
 
 	err = hcl.Decode(c, buf.String())
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode HCL file %s: %v", path, err)
+		return nil, fmt.Errorf("failed to decode HCL file %s: %w", path, err)
 	}
 
 	// convert strings to time.Durations

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -127,6 +127,7 @@ var basicConfig = &Config{
 		EnableEventBroker:         helper.BoolToPtr(false),
 		EventBufferSize:           helper.IntToPtr(200),
 		PlanRejectionTracker: &PlanRejectionTracker{
+			Enabled:       true,
 			NodeThreshold: 100,
 			NodeWindow:    41 * time.Minute,
 			NodeWindowHCL: "41m",

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -126,6 +126,11 @@ var basicConfig = &Config{
 		EncryptKey:                "abc",
 		EnableEventBroker:         helper.BoolToPtr(false),
 		EventBufferSize:           helper.IntToPtr(200),
+		PlanRejectionTracker: &PlanRejectionTracker{
+			NodeThreshold: 100,
+			NodeWindow:    41 * time.Minute,
+			NodeWindowHCL: "41m",
+		},
 		ServerJoin: &ServerJoin{
 			RetryJoin:        []string{"1.1.1.1", "2.2.2.2"},
 			RetryInterval:    time.Duration(15) * time.Second,
@@ -540,6 +545,9 @@ func (c *Config) addDefaults() {
 	if c.Server.ServerJoin == nil {
 		c.Server.ServerJoin = &ServerJoin{}
 	}
+	if c.Server.PlanRejectionTracker == nil {
+		c.Server.PlanRejectionTracker = &PlanRejectionTracker{}
+	}
 }
 
 // Tests for a panic parsing json with an object of exactly
@@ -617,6 +625,11 @@ var sample0 = &Config{
 		RetryJoin:       []string{"10.0.0.101", "10.0.0.102", "10.0.0.103"},
 		EncryptKey:      "sHck3WL6cxuhuY7Mso9BHA==",
 		ServerJoin:      &ServerJoin{},
+		PlanRejectionTracker: &PlanRejectionTracker{
+			NodeThreshold: 100,
+			NodeWindow:    31 * time.Minute,
+			NodeWindowHCL: "31m",
+		},
 	},
 	ACL: &ACLConfig{
 		Enabled: true,
@@ -707,6 +720,11 @@ var sample1 = &Config{
 		RetryJoin:       []string{"10.0.0.101", "10.0.0.102", "10.0.0.103"},
 		EncryptKey:      "sHck3WL6cxuhuY7Mso9BHA==",
 		ServerJoin:      &ServerJoin{},
+		PlanRejectionTracker: &PlanRejectionTracker{
+			NodeThreshold: 100,
+			NodeWindow:    31 * time.Minute,
+			NodeWindowHCL: "31m",
+		},
 	},
 	ACL: &ACLConfig{
 		Enabled: true,

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -127,7 +127,7 @@ var basicConfig = &Config{
 		EnableEventBroker:         helper.BoolToPtr(false),
 		EventBufferSize:           helper.IntToPtr(200),
 		PlanRejectionTracker: &PlanRejectionTracker{
-			Enabled:       true,
+			Enabled:       helper.BoolToPtr(true),
 			NodeThreshold: 100,
 			NodeWindow:    41 * time.Minute,
 			NodeWindowHCL: "41m",

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -149,7 +149,7 @@ func TestConfig_Merge(t *testing.T) {
 			EnableEventBroker:      helper.BoolToPtr(false),
 			EventBufferSize:        helper.IntToPtr(0),
 			PlanRejectionTracker: &PlanRejectionTracker{
-				Enabled:       true,
+				Enabled:       helper.BoolToPtr(true),
 				NodeThreshold: 100,
 				NodeWindow:    11 * time.Minute,
 			},
@@ -349,7 +349,7 @@ func TestConfig_Merge(t *testing.T) {
 			EnableEventBroker:      helper.BoolToPtr(true),
 			EventBufferSize:        helper.IntToPtr(100),
 			PlanRejectionTracker: &PlanRejectionTracker{
-				Enabled:       true,
+				Enabled:       helper.BoolToPtr(true),
 				NodeThreshold: 100,
 				NodeWindow:    11 * time.Minute,
 			},

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -148,6 +148,10 @@ func TestConfig_Merge(t *testing.T) {
 			UpgradeVersion:         "foo",
 			EnableEventBroker:      helper.BoolToPtr(false),
 			EventBufferSize:        helper.IntToPtr(0),
+			PlanRejectionTracker: &PlanRejectionTracker{
+				NodeThreshold: 100,
+				NodeWindow:    11 * time.Minute,
+			},
 		},
 		ACL: &ACLConfig{
 			Enabled:          true,
@@ -343,6 +347,10 @@ func TestConfig_Merge(t *testing.T) {
 			UpgradeVersion:         "bar",
 			EnableEventBroker:      helper.BoolToPtr(true),
 			EventBufferSize:        helper.IntToPtr(100),
+			PlanRejectionTracker: &PlanRejectionTracker{
+				NodeThreshold: 100,
+				NodeWindow:    11 * time.Minute,
+			},
 		},
 		ACL: &ACLConfig{
 			Enabled:          true,

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -149,6 +149,7 @@ func TestConfig_Merge(t *testing.T) {
 			EnableEventBroker:      helper.BoolToPtr(false),
 			EventBufferSize:        helper.IntToPtr(0),
 			PlanRejectionTracker: &PlanRejectionTracker{
+				Enabled:       true,
 				NodeThreshold: 100,
 				NodeWindow:    11 * time.Minute,
 			},
@@ -348,6 +349,7 @@ func TestConfig_Merge(t *testing.T) {
 			EnableEventBroker:      helper.BoolToPtr(true),
 			EventBufferSize:        helper.IntToPtr(100),
 			PlanRejectionTracker: &PlanRejectionTracker{
+				Enabled:       true,
 				NodeThreshold: 100,
 				NodeWindow:    11 * time.Minute,
 			},

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -134,6 +134,7 @@ server {
   event_buffer_size             = 200
 
   plan_rejection_tracker {
+    enabled        = true
     node_threshold = 100
     node_window    = "41m"
   }

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -133,6 +133,11 @@ server {
   enable_event_broker           = false
   event_buffer_size             = 200
 
+  plan_rejection_tracker {
+    node_threshold = 100
+    node_window    = "41m"
+  }
+
   server_join {
     retry_join     = ["1.1.1.1", "2.2.2.2"]
     retry_max      = 3

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -277,6 +277,10 @@
       "node_gc_threshold": "12h",
       "non_voting_server": true,
       "num_schedulers": 2,
+      "plan_rejection_tracker": {
+        "node_threshold": 100,
+        "node_window": "41m"
+      },
       "raft_protocol": 3,
       "raft_multiplier": 4,
       "redundancy_zone": "foo",

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -278,6 +278,7 @@
       "non_voting_server": true,
       "num_schedulers": 2,
       "plan_rejection_tracker": {
+        "enabled": true,
         "node_threshold": 100,
         "node_window": "41m"
       },

--- a/command/agent/testdata/sample0.json
+++ b/command/agent/testdata/sample0.json
@@ -55,6 +55,10 @@
     "bootstrap_expect": 3,
     "enabled": true,
     "encrypt": "sHck3WL6cxuhuY7Mso9BHA==",
+    "plan_rejection_tracker": {
+      "node_threshold": 100,
+      "node_window": "31m"
+    },
     "retry_join": [
       "10.0.0.101",
       "10.0.0.102",

--- a/command/agent/testdata/sample1/sample0.json
+++ b/command/agent/testdata/sample1/sample0.json
@@ -20,6 +20,10 @@
     "bootstrap_expect": 3,
     "enabled": true,
     "encrypt": "sHck3WL6cxuhuY7Mso9BHA==",
+    "plan_rejection_tracker": {
+      "node_threshold": 100,
+      "node_window": "31m"
+    },
     "retry_join": [
       "10.0.0.101",
       "10.0.0.102",

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -232,6 +232,9 @@ type Config struct {
 	// additional delay is selected from this range randomly.
 	EvalFailedFollowupDelayRange time.Duration
 
+	// NodePlanRejectionEnabled controls if node rejection tracker is enabled.
+	NodePlanRejectionEnabled bool
+
 	// NodePlanRejectionThreshold is the number of times a node must have a
 	// plan rejection before it is set as ineligible.
 	NodePlanRejectionThreshold int
@@ -403,6 +406,7 @@ func DefaultConfig() *Config {
 		MaxHeartbeatsPerSecond:           50.0,
 		HeartbeatGrace:                   10 * time.Second,
 		FailoverHeartbeatTTL:             300 * time.Second,
+		NodePlanRejectionEnabled:         false,
 		NodePlanRejectionThreshold:       15,
 		NodePlanRejectionWindow:          10 * time.Minute,
 		ConsulConfig:                     config.DefaultConsulConfig(),

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -232,6 +232,14 @@ type Config struct {
 	// additional delay is selected from this range randomly.
 	EvalFailedFollowupDelayRange time.Duration
 
+	// NodePlanRejectionThreshold is the number of times a node must have a
+	// plan rejection before it is set as ineligible.
+	NodePlanRejectionThreshold int
+
+	// NodePlanRejectionWindow is the time window used to track plan
+	// rejections for nodes.
+	NodePlanRejectionWindow time.Duration
+
 	// MinHeartbeatTTL is the minimum time between heartbeats.
 	// This is used as a floor to prevent excessive updates.
 	MinHeartbeatTTL time.Duration
@@ -395,6 +403,8 @@ func DefaultConfig() *Config {
 		MaxHeartbeatsPerSecond:           50.0,
 		HeartbeatGrace:                   10 * time.Second,
 		FailoverHeartbeatTTL:             300 * time.Second,
+		NodePlanRejectionThreshold:       15,
+		NodePlanRejectionWindow:          10 * time.Minute,
 		ConsulConfig:                     config.DefaultConsulConfig(),
 		VaultConfig:                      config.DefaultVaultConfig(),
 		RPCHoldTimeout:                   5 * time.Second,

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -234,6 +234,8 @@ func (p *planner) snapshotMinIndex(prevPlanResultIndex, planSnapshotIndex uint64
 
 // applyPlan is used to apply the plan result and to return the alloc index
 func (p *planner) applyPlan(plan *structs.Plan, result *structs.PlanResult, snap *state.StateSnapshot) (raft.ApplyFuture, error) {
+	now := time.Now().UTC().UnixNano()
+
 	// Setup the update request
 	req := structs.ApplyPlanResultsRequest{
 		AllocUpdateRequest: structs.AllocUpdateRequest{
@@ -243,10 +245,10 @@ func (p *planner) applyPlan(plan *structs.Plan, result *structs.PlanResult, snap
 		DeploymentUpdates: result.DeploymentUpdates,
 		IneligibleNodes:   result.IneligibleNodes,
 		EvalID:            plan.EvalID,
+		UpdatedAt:         now,
 	}
 
 	preemptedJobIDs := make(map[structs.NamespacedID]struct{})
-	now := time.Now().UTC().UnixNano()
 
 	if ServersMeetMinimumVersion(p.Members(), MinVersionPlanNormalization, true) {
 		// Initialize the allocs request using the new optimized log entry format.

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -25,20 +25,38 @@ type planner struct {
 	// planQueue is used to manage the submitted allocation
 	// plans that are waiting to be assessed by the leader
 	planQueue *PlanQueue
+
+	// badNodeTracker keeps a score for nodes that have plan rejections.
+	// Plan rejections are somewhat expected given Nomad's optimistic
+	// scheduling, but repeated rejections for the same node may indicate an
+	// undetected issue, so we need to track rejection history.
+	badNodeTracker *BadNodeTracker
 }
 
 // newPlanner returns a new planner to be used for managing allocation plans.
 func newPlanner(s *Server) (*planner, error) {
+	log := s.logger.Named("planner")
+
 	// Create a plan queue
 	planQueue, err := NewPlanQueue()
 	if err != nil {
 		return nil, err
 	}
 
+	// Create the bad node tracker.
+	size := 50
+	badNodeTracker, err := NewBadNodeTracker(log, size,
+		s.config.NodePlanRejectionWindow,
+		s.config.NodePlanRejectionThreshold)
+	if err != nil {
+		return nil, err
+	}
+
 	return &planner{
-		Server:    s,
-		log:       s.logger.Named("planner"),
-		planQueue: planQueue,
+		Server:         s,
+		log:            log,
+		planQueue:      planQueue,
+		badNodeTracker: badNodeTracker,
 	}, nil
 }
 
@@ -144,6 +162,14 @@ func (p *planner) planApply() {
 			continue
 		}
 
+		// Check if any of the rejected nodes should be made ineligible.
+		for _, nodeID := range result.RejectedNodes {
+			p.badNodeTracker.Add(nodeID)
+			if p.badNodeTracker.IsBad(nodeID) {
+				result.IneligibleNodes = append(result.IneligibleNodes, nodeID)
+			}
+		}
+
 		// Fast-path the response if there is nothing to do
 		if result.IsNoOp() {
 			pending.respond(result, nil)
@@ -209,6 +235,7 @@ func (p *planner) applyPlan(plan *structs.Plan, result *structs.PlanResult, snap
 		},
 		Deployment:        result.Deployment,
 		DeploymentUpdates: result.DeploymentUpdates,
+		IneligibleNodes:   result.IneligibleNodes,
 		EvalID:            plan.EvalID,
 	}
 
@@ -466,6 +493,7 @@ func evaluatePlanPlacements(pool *EvaluatePool, snap *state.StateSnapshot, plan 
 	// errors since we are processing in parallel.
 	var mErr multierror.Error
 	partialCommit := false
+	rejectedNodes := make(map[string]struct{}, 0)
 
 	// handleResult is used to process the result of evaluateNodePlan
 	handleResult := func(nodeID string, fit bool, reason string, err error) (cancel bool) {
@@ -489,8 +517,11 @@ func evaluatePlanPlacements(pool *EvaluatePool, snap *state.StateSnapshot, plan 
 					"node_id", nodeID, "reason", reason, "eval_id", plan.EvalID,
 					"namespace", plan.Job.Namespace)
 			}
-			// Set that this is a partial commit
+			// Set that this is a partial commit and store the node that was
+			// rejected so the plan applier can detect repeated plan rejections
+			// for the same node.
 			partialCommit = true
+			rejectedNodes[nodeID] = struct{}{}
 
 			// If we require all-at-once scheduling, there is no point
 			// to continue the evaluation, as we've already failed.
@@ -594,6 +625,10 @@ OUTER:
 		// deployment correct for any canary that may have been desired to be
 		// placed but wasn't actually placed
 		correctDeploymentCanaries(result)
+	}
+
+	for n := range rejectedNodes {
+		result.RejectedNodes = append(result.RejectedNodes, n)
 	}
 	return result, mErr.ErrorOrNil()
 }

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -171,8 +171,7 @@ func (p *planner) planApply() {
 
 		// Check if any of the rejected nodes should be made ineligible.
 		for _, nodeID := range result.RejectedNodes {
-			p.badNodeTracker.Add(nodeID)
-			if p.badNodeTracker.IsBad(nodeID) {
+			if p.badNodeTracker.Add(nodeID) {
 				result.IneligibleNodes = append(result.IneligibleNodes, nodeID)
 			}
 		}

--- a/nomad/plan_apply_node_tracker.go
+++ b/nomad/plan_apply_node_tracker.go
@@ -1,0 +1,141 @@
+package nomad
+
+import (
+	"fmt"
+	"time"
+
+	metrics "github.com/armon/go-metrics"
+	"github.com/hashicorp/go-hclog"
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/nomad/helper"
+)
+
+// BadNodeTracker keeps a record of nodes marked as bad by the plan applier.
+//
+// It takes a time window and a threshold value. Plan rejections for a node
+// will be registered with its timestamp. If the number of rejections within
+// the time window is greater than the threshold the node is reported as bad.
+//
+// The tracker uses a fixed size cache that evicts old entries based on access
+// frequency and recency.
+type BadNodeTracker struct {
+	logger    hclog.Logger
+	cache     *lru.TwoQueueCache
+	window    time.Duration
+	threshold int
+}
+
+// NewBadNodeTracker returns a new BadNodeTracker.
+func NewBadNodeTracker(logger hclog.Logger, size int, window time.Duration, threshold int) (*BadNodeTracker, error) {
+	cache, err := lru.New2Q(size)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new bad node tracker: %v", err)
+	}
+
+	return &BadNodeTracker{
+		logger: logger.Named("bad_node_tracker").
+			With("threshold", threshold).
+			With("window", window),
+		cache:     cache,
+		window:    window,
+		threshold: threshold,
+	}, nil
+}
+
+// IsBad returns true if the node has more rejections than the threshold within
+// the time window.
+func (t *BadNodeTracker) IsBad(nodeID string) bool {
+	value, ok := t.cache.Get(nodeID)
+	if !ok {
+		return false
+	}
+
+	stats := value.(*badNodeStats)
+	score := stats.score()
+
+	t.logger.Debug("checking if node is bad", "node_id", nodeID, "score", score)
+	return score > t.threshold
+}
+
+// Add records a new rejection for node. If it's the first time a node is added
+// it will be included in the internal cache. If the cache is full the least
+// recently updated or accessed node is evicted.
+func (t *BadNodeTracker) Add(nodeID string) {
+	value, ok := t.cache.Get(nodeID)
+	if !ok {
+		value = newBadNodeStats(t.window)
+		t.cache.Add(nodeID, value)
+	}
+
+	stats := value.(*badNodeStats)
+	score := stats.record()
+	t.logger.Debug("adding node plan rejection", "node_id", nodeID, "score", score)
+}
+
+// EmitStats generates metrics for the bad nodes being currently tracked. Must
+// be called in a goroutine.
+func (t *BadNodeTracker) EmitStats(period time.Duration, stopCh <-chan struct{}) {
+	timer, stop := helper.NewSafeTimer(period)
+	defer stop()
+
+	for {
+		timer.Reset(period)
+
+		select {
+		case <-timer.C:
+			t.emitStats()
+		case <-stopCh:
+			return
+		}
+	}
+}
+
+func (t *BadNodeTracker) emitStats() {
+	for _, k := range t.cache.Keys() {
+		value, _ := t.cache.Get(k)
+		stats := value.(*badNodeStats)
+		score := stats.score()
+
+		labels := []metrics.Label{
+			{Name: "node_id", Value: k.(string)},
+		}
+		metrics.SetGaugeWithLabels([]string{"nomad", "plan", "rejection_tracker", "node_score"}, float32(score), labels)
+	}
+}
+
+// badNodeStats represents a node being tracked by BadNodeTracker.
+type badNodeStats struct {
+	history []time.Time
+	window  time.Duration
+}
+
+// newBadNodeStats returns an empty badNodeStats.
+func newBadNodeStats(window time.Duration) *badNodeStats {
+	return &badNodeStats{
+		window: window,
+	}
+}
+
+// score returns the number of rejections within the past time window.
+func (s *badNodeStats) score() int {
+	count := 0
+	windowStart := time.Now().Add(-s.window)
+
+	for i := len(s.history) - 1; i >= 0; i-- {
+		ts := s.history[i]
+		if ts.Before(windowStart) {
+			// Since we start from the end of the history list, anything past
+			// this point will have happened before the time window.
+			break
+		}
+		count += 1
+	}
+	return count
+}
+
+// record adds a new entry to the stats history and returns the new score.
+func (s *badNodeStats) record() int {
+	now := time.Now()
+	s.history = append(s.history, now)
+	return s.score()
+}

--- a/nomad/plan_apply_node_tracker_test.go
+++ b/nomad/plan_apply_node_tracker_test.go
@@ -106,7 +106,7 @@ func TestBadNodeTracker_IsBad(t *testing.T) {
 func TestBadNodeTracker_RateLimit(t *testing.T) {
 	config := DefaultCachedBadNodeTrackerConfig()
 	config.Threshold = 3
-	config.RateLimit = float64(testutil.TestMultiplier())
+	config.RateLimit = float64(1) // Get a new token every second.
 	config.BurstSize = 3
 
 	tracker, err := NewCachedBadNodeTracker(hclog.NewNullLogger(), config)
@@ -125,7 +125,7 @@ func TestBadNodeTracker_RateLimit(t *testing.T) {
 	require.False(t, tracker.IsBad("node-1"))
 
 	// Wait for a new token.
-	time.Sleep(time.Duration(testutil.TestMultiplier()) * time.Second)
+	time.Sleep(time.Second)
 	require.True(t, tracker.IsBad("node-1"))
 	require.False(t, tracker.IsBad("node-1"))
 }

--- a/nomad/plan_apply_node_tracker_test.go
+++ b/nomad/plan_apply_node_tracker_test.go
@@ -1,0 +1,123 @@
+package nomad
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBadNodeTracker(t *testing.T) {
+	ci.Parallel(t)
+
+	cacheSize := 3
+	tracker, err := NewBadNodeTracker(
+		hclog.NewNullLogger(), cacheSize, time.Second, 10)
+	require.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		tracker.Add(fmt.Sprintf("node-%d", i+1))
+	}
+
+	require.Equal(t, cacheSize, tracker.cache.Len())
+
+	// Only track the most recent values.
+	expected := []string{"node-8", "node-9", "node-10"}
+	require.ElementsMatch(t, expected, tracker.cache.Keys())
+}
+
+func TestBadNodeTracker_IsBad(t *testing.T) {
+	ci.Parallel(t)
+
+	window := time.Duration(testutil.TestMultiplier()) * time.Second
+	tracker, err := NewBadNodeTracker(hclog.NewNullLogger(), 3, window, 4)
+	require.NoError(t, err)
+
+	// Populate cache.
+	tracker.Add("node-1")
+
+	tracker.Add("node-2")
+	tracker.Add("node-2")
+
+	tracker.Add("node-3")
+	tracker.Add("node-3")
+	tracker.Add("node-3")
+	tracker.Add("node-3")
+	tracker.Add("node-3")
+	tracker.Add("node-3")
+
+	testCases := []struct {
+		name   string
+		nodeID string
+		bad    bool
+	}{
+		{
+			name:   "node-1 is not bad",
+			nodeID: "node-1",
+			bad:    false,
+		},
+		{
+			name:   "node-3 is bad",
+			nodeID: "node-3",
+			bad:    true,
+		},
+		{
+			name:   "node not tracked is not bad",
+			nodeID: "node-1000",
+			bad:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tracker.IsBad(tc.nodeID)
+			require.Equal(t, tc.bad, got)
+		})
+	}
+
+	t.Run("cache expires", func(t *testing.T) {
+		time.Sleep(window)
+		require.False(t, tracker.IsBad("node-1"))
+		require.False(t, tracker.IsBad("node-2"))
+		require.False(t, tracker.IsBad("node-3"))
+	})
+
+	t.Run("IsBad updates cache", func(t *testing.T) {
+		// Don't access node-3 so it should be evicted when a new value is
+		// added and the tracker size overflows.
+		tracker.IsBad("node-1")
+		tracker.IsBad("node-2")
+		tracker.Add("node-4")
+
+		expected := []string{"node-1", "node-2", "node-4"}
+		require.ElementsMatch(t, expected, tracker.cache.Keys())
+	})
+}
+
+func TestBadNodeStats_score(t *testing.T) {
+	ci.Parallel(t)
+
+	window := time.Duration(testutil.TestMultiplier()) * time.Second
+	stats := newBadNodeStats(window)
+
+	require.Equal(t, 0, stats.score())
+
+	stats.record()
+	stats.record()
+	stats.record()
+	require.Equal(t, 3, stats.score())
+
+	time.Sleep(window / 2)
+	stats.record()
+	require.Equal(t, 4, stats.score())
+
+	time.Sleep(window / 2)
+	require.Equal(t, 1, stats.score())
+
+	time.Sleep(window / 2)
+	require.Equal(t, 0, stats.score())
+}

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -446,6 +446,9 @@ func NewServer(config *Config, consulCatalog consul.CatalogAPI, consulConfigEntr
 	// Emit metrics for the plan queue
 	go s.planQueue.EmitStats(time.Second, s.shutdownCh)
 
+	// Emit metrics for the planner's bad node tracker.
+	go s.planner.badNodeTracker.EmitStats(time.Second, s.shutdownCh)
+
 	// Emit metrics for the blocked eval tracker.
 	go s.blockedEvals.EmitStats(time.Second, s.shutdownCh)
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -43,7 +43,7 @@ const (
 	// the same node may indicate an underlying issue not detected by Nomad.
 	// The plan applier keeps track of plan rejection history and will mark
 	// nodes as ineligible if they cross a given threshold.
-	NodeEligibilityEventPlanRejectThreshold = "Node marked as ineligible for scheduling due to multiple plan rejections"
+	NodeEligibilityEventPlanRejectThreshold = "Node marked as ineligible for scheduling due to multiple plan rejections, refer to https://www.nomadproject.io/s/port-plan-failure for more information"
 
 	// NodeRegisterEventRegistered is the message used when the node becomes
 	// registered.

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -371,7 +371,6 @@ func (s *StateStore) UpsertPlanResults(msgType structs.MessageType, index uint64
 	defer txn.Abort()
 
 	// Mark nodes as ineligible.
-	now := time.Now().Unix()
 	for _, nodeID := range results.IneligibleNodes {
 		s.logger.Warn("marking node as ineligible due to multiple plan rejections, refer to https://www.nomadproject.io/s/port-plan-failure for more information", "node_id", nodeID)
 
@@ -380,7 +379,7 @@ func (s *StateStore) UpsertPlanResults(msgType structs.MessageType, index uint64
 			SetMessage(NodeEligibilityEventPlanRejectThreshold)
 
 		err := s.updateNodeEligibilityImpl(index, nodeID,
-			structs.NodeSchedulingIneligible, now, nodeEvent, txn)
+			structs.NodeSchedulingIneligible, results.UpdatedAt, nodeEvent, txn)
 		if err != nil {
 			return err
 		}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -34,6 +34,17 @@ const (
 )
 
 const (
+	// NodeEligibilityEventPlanRejectThreshold is the message used when the node
+	// is set to ineligible due to multiple plan failures.
+	// This is a preventive measure to signal scheduler workers to not consider
+	// the node for future placements.
+	// Plan rejections for a node are expected due to the optimistic and
+	// concurrent nature of the scheduling process, but repeated failures for
+	// the same node may indicate an underlying issue not detected by Nomad.
+	// The plan applier keeps track of plan rejection history and will mark
+	// nodes as ineligible if they cross a given threshold.
+	NodeEligibilityEventPlanRejectThreshold = "Node marked as ineligible for scheduling due to multiple plan rejections"
+
 	// NodeRegisterEventRegistered is the message used when the node becomes
 	// registered.
 	NodeRegisterEventRegistered = "Node registered"
@@ -358,6 +369,22 @@ func (s *StateStore) UpsertPlanResults(msgType structs.MessageType, index uint64
 
 	txn := s.db.WriteTxnMsgT(msgType, index)
 	defer txn.Abort()
+
+	// Mark nodes as ineligible.
+	now := time.Now().Unix()
+	for _, nodeID := range results.IneligibleNodes {
+		s.logger.Warn("marking node as ineligible due to multiple plan rejections, refer to https://www.nomadproject.io/s/port-plan-failure for more information", "node_id", nodeID)
+
+		nodeEvent := structs.NewNodeEvent().
+			SetSubsystem(structs.NodeEventSubsystemScheduler).
+			SetMessage(NodeEligibilityEventPlanRejectThreshold)
+
+		err := s.updateNodeEligibilityImpl(index, nodeID,
+			structs.NodeSchedulingIneligible, now, nodeEvent, txn)
+		if err != nil {
+			return err
+		}
+	}
 
 	// Upsert the newly created or updated deployment
 	if results.Deployment != nil {
@@ -1136,10 +1163,15 @@ func (s *StateStore) updateNodeDrainImpl(txn *txn, index uint64, nodeID string,
 
 // UpdateNodeEligibility is used to update the scheduling eligibility of a node
 func (s *StateStore) UpdateNodeEligibility(msgType structs.MessageType, index uint64, nodeID string, eligibility string, updatedAt int64, event *structs.NodeEvent) error {
-
 	txn := s.db.WriteTxnMsgT(msgType, index)
 	defer txn.Abort()
+	if err := s.updateNodeEligibilityImpl(index, nodeID, eligibility, updatedAt, event, txn); err != nil {
+		return err
+	}
+	return txn.Commit()
+}
 
+func (s *StateStore) updateNodeEligibilityImpl(index uint64, nodeID string, eligibility string, updatedAt int64, event *structs.NodeEvent, txn *txn) error {
 	// Lookup the node
 	existing, err := txn.First("nodes", "id", nodeID)
 	if err != nil {
@@ -1176,7 +1208,7 @@ func (s *StateStore) UpdateNodeEligibility(msgType structs.MessageType, index ui
 		return fmt.Errorf("index update failed: %v", err)
 	}
 
-	return txn.Commit()
+	return nil
 }
 
 // UpsertNodeEvents adds the node events to the nodes, rotating events as

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -918,6 +918,9 @@ type ApplyPlanResultsRequest struct {
 	// placements for and should therefore be considered ineligible by workers
 	// to avoid retrying them repeatedly.
 	IneligibleNodes []string
+
+	// UpdatedAt represents server time of receiving request.
+	UpdatedAt int64
 }
 
 // AllocUpdateRequest is used to submit changes to allocations, either

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -913,6 +913,11 @@ type ApplyPlanResultsRequest struct {
 	// PreemptionEvals is a slice of follow up evals for jobs whose allocations
 	// have been preempted to place allocs in this plan
 	PreemptionEvals []*Evaluation
+
+	// IneligibleNodes are nodes the plan applier has repeatedly rejected
+	// placements for and should therefore be considered ineligible by workers
+	// to avoid retrying them repeatedly.
+	IneligibleNodes []string
 }
 
 // AllocUpdateRequest is used to submit changes to allocations, either
@@ -1632,6 +1637,7 @@ const (
 	NodeEventSubsystemDriver    = "Driver"
 	NodeEventSubsystemHeartbeat = "Heartbeat"
 	NodeEventSubsystemCluster   = "Cluster"
+	NodeEventSubsystemScheduler = "Scheduler"
 	NodeEventSubsystemStorage   = "Storage"
 )
 
@@ -11390,6 +11396,16 @@ type PlanResult struct {
 	// as stopped.
 	NodePreemptions map[string][]*Allocation
 
+	// RejectedNodes are nodes the scheduler worker has rejected placements for
+	// and should be considered for ineligibility by the plan applier to avoid
+	// retrying them repeatedly.
+	RejectedNodes []string
+
+	// IneligibleNodes are nodes the plan applier has repeatedly rejected
+	// placements for and should therefore be considered ineligible by workers
+	// to avoid retrying them repeatedly.
+	IneligibleNodes []string
+
 	// RefreshIndex is the index the worker should refresh state up to.
 	// This allows all evictions and allocations to be materialized.
 	// If any allocations were rejected due to stale data (node state,
@@ -11403,8 +11419,9 @@ type PlanResult struct {
 
 // IsNoOp checks if this plan result would do nothing
 func (p *PlanResult) IsNoOp() bool {
-	return len(p.NodeUpdate) == 0 && len(p.NodeAllocation) == 0 &&
-		len(p.DeploymentUpdates) == 0 && p.Deployment == nil
+	return len(p.IneligibleNodes) == 0 && len(p.NodeUpdate) == 0 &&
+		len(p.NodeAllocation) == 0 && len(p.DeploymentUpdates) == 0 &&
+		p.Deployment == nil
 }
 
 // FullCommit is used to check if all the allocations in a plan

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -246,8 +246,8 @@ server {
 
 The leader plan rejection tracker can be adjusted to prevent evaluations from
 getting stuck due to always being scheduled to a client that may have an
-unexpected and undetected issues. Refer to [Monitoring
-Nomad][monitoring_nomad_progress] for more details.
+unexpected issue. Refer to [Monitoring Nomad][monitoring_nomad_progress] for
+more details.
 
 - `node_threshold` `(int: 15)` - The number of plan rejections for a node
   within the `node_window` to trigger a client to be set as ineligible.

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -156,6 +156,10 @@ server {
   disallow this server from making any scheduling decisions. This defaults to
   the number of CPU cores.
 
+- `plan_rejection_tracker` <code>([PlanRejectionTracker](#plan_rejection_tracker-parameters))</code> -
+  Configuration for the plan rejection tracker that the Nomad leader uses to
+  track the history of plan rejections.
+
 - `raft_boltdb` - This is a nested object that allows configuring options for
   Raft's BoltDB based log store.
     - `no_freelist_sync` - Setting this to `true` will disable syncing the BoltDB
@@ -237,6 +241,28 @@ server {
   format](/docs/configuration/server_join#server-address-format)
   section for more information on the format of the string. This field is
   deprecated in favor of the [server_join stanza][server-join].
+
+### `plan_rejection_tracker` Parameters
+
+The leader plan rejection tracker can be adjusted to prevent evaluations from
+getting stuck due to always being scheduled to a client that may have an
+unexpected and undetected issues. Refer to [Monitoring
+Nomad][monitoring_nomad_progress] for more details.
+
+- `node_threshold` `(int: 15)` - The number of plan rejections for a node
+  within the `node_window` to trigger a client to be set as ineligible.
+
+- `node_window` `(int: "10m")` - The time window for when plan rejections for a
+  node should be considered.
+
+If you observe too many false positives (clients being marked as ineligible
+even if they don't present any problem) you may want to increase
+`node_threshold`.
+
+Or if you are noticing jobs not being scheduled due to plan rejections for the
+same `node_id` and the client is not being set as ineligible you can try
+increasing the `node_window` so more historical rejections are taken into
+account.
 
 ## `server` Examples
 
@@ -331,5 +357,6 @@ server {
 [update-scheduler-config]: /api-docs/operator/scheduler#update-scheduler-configuration 'Scheduler Config'
 [bootstrapping a cluster]: /docs/faq#bootstrapping
 [rfc4648]: https://tools.ietf.org/html/rfc4648#section-5
+[monitoring_nomad_progress]: /docs/operations/monitoring-nomad#progress
 [`nomad operator keygen`]: /docs/commands/operator/keygen
 [search]: /docs/configuration/search

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -249,10 +249,12 @@ getting stuck due to always being scheduled to a client that may have an
 unexpected issue. Refer to [Monitoring Nomad][monitoring_nomad_progress] for
 more details.
 
-- `node_threshold` `(int: 15)` - The number of plan rejections for a node
+- `enabled` `(bool: false)` - Specifies if plan rejections should be tracked.
+
+- `node_threshold` `(int: 100)` - The number of plan rejections for a node
   within the `node_window` to trigger a client to be set as ineligible.
 
-- `node_window` `(int: "10m")` - The time window for when plan rejections for a
+- `node_window` `(int: "5m")` - The time window for when plan rejections for a
   node should be considered.
 
 If you observe too many false positives (clients being marked as ineligible

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -254,8 +254,8 @@ more details.
 - `node_threshold` `(int: 100)` - The number of plan rejections for a node
   within the `node_window` to trigger a client to be set as ineligible.
 
-- `node_window` `(int: "5m")` - The time window for when plan rejections for a
-  node should be considered.
+- `node_window` `(string: "5m")` - The time window for when plan rejections for
+  a node should be considered.
 
 If you observe too many false positives (clients being marked as ineligible
 even if they don't present any problem) you may want to increase

--- a/website/content/docs/operations/metrics-reference.mdx
+++ b/website/content/docs/operations/metrics-reference.mdx
@@ -394,6 +394,7 @@ those listed in [Key Metrics](#key-metrics) above.
 | `nomad.nomad.plan.apply`                             | Time elapsed to apply a plan                                                   | Nanoseconds          | Summary | host                                                    |
 | `nomad.nomad.plan.evaluate`                          | Time elapsed to evaluate a plan                                                | Nanoseconds          | Summary | host                                                    |
 | `nomad.nomad.plan.node_rejected`                     | Number of times a node has had a plan rejected                                 | Integer              | Counter | host, node_id                                           |
+| `nomad.nomad.plan.rejection_tracker.node_score`      | Number of times a node has had a plan rejected within the tracker window       | Integer              | Gauge   | host, node_id                                           |
 | `nomad.nomad.plan.queue_depth`                       | Count of evals in the plan queue                                               | Integer              | Gauge   | host                                                    |
 | `nomad.nomad.plan.submit`                            | Time elapsed for `Plan.Submit` RPC call                                        | Nanoseconds          | Summary | host                                                    |
 | `nomad.nomad.plan.wait_for_index`                    | Time elapsed that planner waits for the raft index of the plan to be processed | Nanoseconds          | Summary | host                                                    |
@@ -481,5 +482,3 @@ Raft database metrics are emitted by the `raft-boltdb` library.
 
 [tagged-metrics]: /docs/telemetry/metrics#tagged-metrics
 [s_port_plan_failure]: /s/port-plan-failure
-
-

--- a/website/content/docs/operations/monitoring-nomad.mdx
+++ b/website/content/docs/operations/monitoring-nomad.mdx
@@ -149,9 +149,28 @@ While it is possible for these log lines to occur infrequently due to normal
 cluster conditions, they should not appear repeatedly and prevent the job from
 eventually running (look up the evaluation ID logged to find the job).
 
-If this log *does* appear repeatedly with the same `node_id` referenced, try
+Nomad tracks the history of plan rejections per client and will mark it as
+ineligible for scheduling if the number of rejections goes above a given
+threshold within a time window. When this happens, the following node event is
+registered:
+
+```
+Node marked as ineligible for scheduling due to multiple plan rejections
+```
+
+Along with the log line:
+
+```
+[WARN]  nomad.state_store: marking node as ineligible due to multiple plan rejections: node_id=67af2541-5e96-6f54-9095-11089d627626
+```
+
+If a client is marked as ineligible due to repeated plan rejections, try
 [draining] the node and shutting it down. Misconfigurations not caught by
 validation can cause nodes to enter this state: [#11830][gh-11830].
+
+If the `plan for node rejected` log *does* appear repeatedly with the same
+`node_id` referenced but the client is not being set as ineligible you can try
+adjusting the [`plan_rejection_tracker`] configuration of servers.
 
 ### Performance
 
@@ -278,6 +297,7 @@ latency and packet loss for the [Serf] address.
 [metric-types]: /docs/telemetry/metrics#metric-types
 [metrics-api-endpoint]: /api-docs/metrics
 [prometheus-telem]: /docs/configuration/telemetry#prometheus
+[`plan_rejection_tracker`]: /docs/configuration/server#plan_rejection_tracker
 [serf]: /docs/configuration#serf-1
 [statsd-exporter]: https://github.com/prometheus/statsd_exporter
 [statsd-telem]: /docs/configuration/telemetry#statsd

--- a/website/content/docs/operations/monitoring-nomad.mdx
+++ b/website/content/docs/operations/monitoring-nomad.mdx
@@ -149,10 +149,15 @@ While it is possible for these log lines to occur infrequently due to normal
 cluster conditions, they should not appear repeatedly and prevent the job from
 eventually running (look up the evaluation ID logged to find the job).
 
-Nomad tracks the history of plan rejections per client and will mark it as
-ineligible for scheduling if the number of rejections goes above a given
-threshold within a time window. When this happens, the following node event is
-registered:
+#### Plan rejection tracker
+
+Nomad provides a mechanism to track the history of plan rejections per client
+and mark them as ineligible if the number goes above a given threshold within a
+time window. This functionality can be enabled using the
+[`plan_rejection_tracker`] server configuration.
+
+When a node is marked as ineligible due to excessive plan rejections, the
+following node event is registered:
 
 ```
 Node marked as ineligible for scheduling due to multiple plan rejections

--- a/website/content/docs/operations/monitoring-nomad.mdx
+++ b/website/content/docs/operations/monitoring-nomad.mdx
@@ -160,7 +160,7 @@ When a node is marked as ineligible due to excessive plan rejections, the
 following node event is registered:
 
 ```
-Node marked as ineligible for scheduling due to multiple plan rejections
+Node marked as ineligible for scheduling due to multiple plan rejections, refer to https://www.nomadproject.io/s/port-plan-failure for more information
 ```
 
 Along with the log line:


### PR DESCRIPTION
Plan rejections occur when the scheduler work and the leader plan
applier disagree on the feasibility of a plan. This may happen for valid
reasons: since Nomad does parallel scheduling, it is expected that
different workers will have a different state when computing placements.

As the final plan reaches the leader plan applier, it may no longer be
valid due to a concurrent scheduling taking up intended resources. In
these situations the plan applier will notify the worker that the plan
was rejected and that they should refresh their state before trying
again.

In some rare and unexpected circumstances it has been observed that
workers will repeatedly submit the same plan, even if they are always
rejected.

While the root cause is still unknown this mitigation has been put in
place. The plan applier will now track the history of plan rejections
per client and include in the plan result a list of node IDs that should
be set as ineligible if the number of rejections in a given time window
crosses a certain threshold. The window size and threshold value can be
adjusted in the server configuration.

Closes #13017
Closes #12920

-----------------------

_Note for reviewers:_ since we can't yet reliably reproduce this bug, the way I tested this was by applying [this patch](https://gist.github.com/lgfa29/44a3420fa588248fe39c942ee87131c0) that causes a plan to be rejected if it is evaluated by a server running the env var `CRASH` set it's for a client with a name that starts with `crash`.

So, after applying the patch, start a 3 server cluster with one of them having the `CRASH` env var set and make sure this server becomes the leader. Start a client with the name starting with `crash` and run a job.

Monitoring the log you should see the plan rejection messages and, after a few minutes, the client will become ineligible. You can then start a client without `crash` in the name to verify that the job scheduling will proceed to the new client.