### PR TITLE
Throw an error if you try to save a Secure Variable with no items

### DIFF
--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -77,9 +77,19 @@ export default class SecureVariableFormComponent extends Component {
   async save(e) {
     e.preventDefault();
     try {
+      const nonEmptyItems = this.keyValues.filter(
+        (item) => item.key && item.value
+      );
+      if (!nonEmptyItems.length) {
+        throw new Error('Please provide at least one key/value pair.');
+      } else {
+        this.keyValues = nonEmptyItems;
+      }
+
       this.args.model.set('keyValues', this.keyValues);
       this.args.model.setAndTrimPath();
       await this.args.model.save();
+
       this.flashMessages.add({
         title: 'Secure Variable saved',
         message: `${this.args.model.path} successfully saved`,
@@ -88,6 +98,8 @@ export default class SecureVariableFormComponent extends Component {
         timeout: 5000,
         showProgress: true,
       });
+
+      this.router.transitionTo('variables.variable', this.args.model.path);
     } catch (error) {
       this.flashMessages.add({
         title: `Error saving ${this.args.model.path}`,
@@ -97,6 +109,5 @@ export default class SecureVariableFormComponent extends Component {
         sticky: true,
       });
     }
-    this.router.transitionTo('variables.variable', this.args.model.path);
   }
 }

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -98,7 +98,6 @@ export default class SecureVariableFormComponent extends Component {
         timeout: 5000,
         showProgress: true,
       });
-
       this.router.transitionTo('variables.variable', this.args.model.path);
     } catch (error) {
       this.flashMessages.add({

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -78,7 +78,7 @@ export default class SecureVariableFormComponent extends Component {
     e.preventDefault();
     try {
       const nonEmptyItems = this.keyValues.filter(
-        (item) => item.key && item.value
+        (item) => item.key.trim() && item.value
       );
       if (!nonEmptyItems.length) {
         throw new Error('Please provide at least one key/value pair.');

--- a/ui/app/models/variable.js
+++ b/ui/app/models/variable.js
@@ -67,6 +67,6 @@ export default class VariableModel extends Model {
    */
   setAndTrimPath() {
     this.set('path', trimPath([this.path]));
-    this.id = this.path;
+    this.set('id', this.get('path'));
   }
 }

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -848,13 +848,12 @@ export default function () {
 
   this.put('/var/:id', function (schema, request) {
     const { Path, Namespace, Items } = JSON.parse(request.requestBody);
-    const newVar = server.create('variable', {
+    return server.create('variable', {
       Path,
       Namespace,
       Items,
       id: Path,
     });
-    return newVar;
   });
 
   this.delete('/var/:id', function (schema, request) {

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -848,13 +848,13 @@ export default function () {
 
   this.put('/var/:id', function (schema, request) {
     const { Path, Namespace, Items } = JSON.parse(request.requestBody);
-    server.create('variable', {
+    const newVar = server.create('variable', {
       Path,
       Namespace,
       Items,
       id: Path,
     });
-    return okEmpty(); // TODO: consider returning the created object.
+    return newVar;
   });
 
   this.delete('/var/:id', function (schema, request) {

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -4,7 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import defaultScenario from '../../mirage/scenarios/default';
-import { click, find, findAll } from '@ember/test-helpers';
+import { click, find, findAll, typeIn } from '@ember/test-helpers';
 
 import Variables from 'nomad-ui/tests/pages/variables';
 import Layout from 'nomad-ui/tests/pages/layout';
@@ -83,7 +83,7 @@ module('Acceptance | secure variables', function (hooks) {
     await click(fooLink);
     assert.equal(
       currentURL(),
-      '/variables/a/b/c/foo0',
+      '/variables/var/a/b/c/foo0',
       'correctly traverses to a deeply nested variable file'
     );
     const deleteButton = find('[data-test-delete-button] button');
@@ -117,6 +117,25 @@ module('Acceptance | secure variables', function (hooks) {
     )[0];
 
     assert.notOk(fooLink, 'foo0 file is no longer present');
+  });
+
+  test('it does not allow you to save if you lack Items', async function (assert) {
+    defaultScenario(server);
+    window.localStorage.nomadTokenSecret = server.db.tokens[0].secretId;
+    await Variables.visitNew();
+    assert.equal(currentURL(), '/variables/new');
+    await typeIn('.path-input', 'foo/bar');
+    await click('button[type="submit"]');
+    assert.dom('.flash-message.alert-error').exists();
+    await click('.flash-message.alert-error .close-button');
+    assert.dom('.flash-message.alert-error').doesNotExist();
+
+    await typeIn('.key-value label:nth-child(1) input', 'myKey');
+    await typeIn('.key-value label:nth-child(2) input', 'superSecret');
+    await click('button[type="submit"]');
+
+    assert.dom('.flash-message.alert-success').exists();
+    assert.equal(currentURL(), '/variables/var/foo/bar');
   });
 
   test('it passes an accessibility audit', async function (assert) {

--- a/ui/tests/integration/components/variable-paths-test.js
+++ b/ui/tests/integration/components/variable-paths-test.js
@@ -77,21 +77,21 @@ module('Integration | Component | variable-paths', function (hooks) {
       .dom('tbody tr:first-child td:first-child a')
       .hasAttribute(
         'href',
-        '/ui/variables/foo/bar/baz',
+        '/ui/variables/var/foo/bar/baz',
         'Correctly links the first file'
       );
     assert
       .dom('tbody tr:nth-child(2) td:first-child a')
       .hasAttribute(
         'href',
-        '/ui/variables/foo/bar/bay',
+        '/ui/variables/var/foo/bar/bay',
         'Correctly links the second file'
       );
     assert
       .dom('tbody tr:nth-child(3) td:first-child a')
       .hasAttribute(
         'href',
-        '/ui/variables/foo/bar/bax',
+        '/ui/variables/var/foo/bar/bax',
         'Correctly links the third file'
       );
     assert

--- a/ui/tests/pages/variables.js
+++ b/ui/tests/pages/variables.js
@@ -2,4 +2,5 @@ import { create, visitable } from 'ember-cli-page-object';
 
 export default create({
   visit: visitable('/variables'),
+  visitNew: visitable('/variables/new'),
 });

--- a/ui/tests/test-helper.js
+++ b/ui/tests/test-helper.js
@@ -5,6 +5,7 @@ import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import start from 'ember-exam/test-support/start';
 import { setup } from 'qunit-dom';
+import './helpers/flash-message';
 
 setApplication(Application.create(config.APP));
 


### PR DESCRIPTION
Resolves #13393

1. Compacts items (key/values) by filtering out those with no key/value
2. Throws an error message to the user if they attempt to save a Secure Variable with no items