### PR TITLE
cni: add loopback to linux bridge

### DIFF
--- a/.changelog/13428.txt
+++ b/.changelog/13428.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cni: Fixed a bug where loopback address was not set for all drivers
+```

--- a/client/allocrunner/networking_bridge_linux.go
+++ b/client/allocrunner/networking_bridge_linux.go
@@ -143,6 +143,9 @@ const nomadCNIConfigTemplate = `{
 	"name": "nomad",
 	"plugins": [
 		{
+			"type": "loopback"
+		},
+		{
 			"type": "bridge",
 			"bridge": "%s",
 			"ipMasq": true,


### PR DESCRIPTION
CNI changed how to bring up the interface in v0.2.0.
Support was moved to a new loopback plugin.

https://github.com/containernetworking/cni/pull/121

Fixes  #10014 