### PR TITLE
Append an empty item when editing an existing Secure Variable

### DIFF
--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -1,4 +1,6 @@
-<form class="new-secure-variables" autocomplete="off" {{on "submit" this.save}}>
+<form class="new-secure-variables" autocomplete="off" {{on "submit" this.save}}
+  {{did-insert this.appendItemIfEditing}}
+>
   {{!-- TODO: {{if this.parseError 'is-danger'}} on inputs --}}
   <div>
     <label>

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -105,7 +105,7 @@ export default class SecureVariableFormComponent extends Component {
    * This will allow it to auto-focus and make all other rows deletable
    */
   @action appendItemIfEditing() {
-    if (!this.args.model.isNew) {
+    if (!this.args.model?.isNew) {
       this.appendRow();
     }
   }

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -99,4 +99,14 @@ export default class SecureVariableFormComponent extends Component {
     }
     this.router.transitionTo('variables.variable', this.args.model.path);
   }
+
+  /**
+   * Appends a row to the end of the Items list if you're editing an existing variable.
+   * This will allow it to auto-focus and make all other rows deletable
+   */
+  @action appendItemIfEditing() {
+    if (!this.args.model.isNew) {
+      this.appendRow();
+    }
+  }
 }

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -26,7 +26,7 @@ export default class SecureVariableFormComponent extends Component {
     return !this.args.model?.path;
   }
 
-  @tracked keyValues = copy(this.args.model?.keyValues)?.map((kv) => {
+  @tracked keyValues = copy(this.args.model?.keyValues || [])?.map((kv) => {
     return {
       key: kv.key,
       value: kv.value,


### PR DESCRIPTION
Resolves #13394

Appends an empty row to the end of your Items array when you modify an existing Secure Variable.

This ensures that all previous rows are deletable, and with https://github.com/hashicorp/nomad/pull/13424, will compact/remove empty items on save.