### PR TITLE
dx:  update `canCreate` logic and token generation for secure var dev environment

### DIFF
--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -24,10 +24,11 @@ export default class extends AbstractAbility {
     });
   }
 
-  @computed('rulesForNamespace.@each.capabilities')
+  @computed('rulesForNamespace.@each.capabilities') // TODO:  edit computed property to be SecureVariables.Path "DYNAMIC PATH"
   get policiesSupportVariableCreation() {
     return this.rulesForNamespace.some((rules) => {
-      const capabilities = get(rules, 'SecureVariables.Path "*"') || [];
+      const keyName = `SecureVariables.Path "*".Capabilities`; // TODO:  add ability to edit path, however computed properties can't take parameters
+      const capabilities = get(rules, keyName) || [];
       return capabilities.includes('create');
     });
   }

--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -26,6 +26,9 @@ export default class extends AbstractAbility {
 
   @computed('rulesForNamespace.@each.capabilities')
   get policiesSupportVariableCreation() {
-    return true; // TODO: check SecureVariables.<path>.capabilities[]
+    return this.rulesForNamespace.some((rules) => {
+      const capabilities = get(rules, 'SecureVariables.Path "*"') || [];
+      return capabilities.includes('create');
+    });
   }
 }

--- a/ui/mirage/factories/token.js
+++ b/ui/mirage/factories/token.js
@@ -56,7 +56,7 @@ node {
               Capabilities: ['list-jobs', 'alloc-exec', 'read-logs'],
               SecureVariables: {
                 'Path "*"': {
-                  Capabilities: ['list'],
+                  Capabilities: ['list', 'create'],
                 },
               },
             },


### PR DESCRIPTION
This PR updates the logic in `policiesSupportVariableCreation` to read the capabilities of the Secure Variables wildcard and updates the ACL Token to add `create` permissions.

This is a developer environment improvement PR.