### PR TITLE
core job for secure variables re-key

### DIFF
--- a/api/keyring.go
+++ b/api/keyring.go
@@ -33,13 +33,23 @@ type RootKey struct {
 
 // RootKeyMeta is the metadata used to refer to a RootKey.
 type RootKeyMeta struct {
-	Active      bool
 	KeyID       string // UUID
 	Algorithm   EncryptionAlgorithm
 	CreateTime  time.Time
 	CreateIndex uint64
 	ModifyIndex uint64
+	State       RootKeyState
 }
+
+// RootKeyState enum describes the lifecycle of a root key.
+type RootKeyState string
+
+const (
+	RootKeyStateInactive   RootKeyState = "inactive"
+	RootKeyStateActive                  = "active"
+	RootKeyStateRekeying                = "rekeying"
+	RootKeyStateDeprecated              = "deprecated"
+)
 
 // List lists all the keyring metadata
 func (k *Keyring) List(q *QueryOptions) ([]*RootKeyMeta, *QueryMeta, error) {

--- a/api/keyring_test.go
+++ b/api/keyring_test.go
@@ -39,7 +39,7 @@ func TestKeyring_CRUD(t *testing.T) {
 		Key: encodedKey,
 		Meta: &RootKeyMeta{
 			KeyID:     id,
-			Active:    true,
+			State:     RootKeyStateActive,
 			Algorithm: EncryptionAlgorithmAES256GCM,
 		}}, nil)
 	require.NoError(t, err)
@@ -57,9 +57,11 @@ func TestKeyring_CRUD(t *testing.T) {
 	require.Len(t, keys, 2)
 	for _, key := range keys {
 		if key.KeyID == id {
-			require.True(t, key.Active, "new key should be active")
+			require.Equal(t, RootKeyState(RootKeyStateActive),
+				key.State, "new key should be active")
 		} else {
-			require.False(t, key.Active, "initial key should be inactive")
+			require.Equal(t, RootKeyState(RootKeyStateInactive),
+				key.State, "initial key should be inactive")
 		}
 	}
 }

--- a/command/agent/keyring_endpoint.go
+++ b/command/agent/keyring_endpoint.go
@@ -104,9 +104,9 @@ func (s *HTTPServer) keyringUpsertRequest(resp http.ResponseWriter, req *http.Re
 		RootKey: &structs.RootKey{
 			Key: decodedKey,
 			Meta: &structs.RootKeyMeta{
-				Active:    key.Meta.Active,
 				KeyID:     key.Meta.KeyID,
 				Algorithm: structs.EncryptionAlgorithm(key.Meta.Algorithm),
+				State:     structs.RootKeyState(key.Meta.State),
 			},
 		},
 	}

--- a/command/agent/keyring_endpoint_test.go
+++ b/command/agent/keyring_endpoint_test.go
@@ -31,7 +31,7 @@ func TestHTTP_Keyring_CRUD(t *testing.T) {
 		require.NotZero(t, respW.HeaderMap.Get("X-Nomad-Index"))
 		rotateResp := obj.(structs.KeyringRotateRootKeyResponse)
 		require.NotNil(t, rotateResp.Key)
-		require.True(t, rotateResp.Key.Active)
+		require.True(t, rotateResp.Key.Active())
 		newID1 := rotateResp.Key.KeyID
 
 		// List
@@ -44,9 +44,9 @@ func TestHTTP_Keyring_CRUD(t *testing.T) {
 		require.Len(t, listResp, 2)
 		for _, key := range listResp {
 			if key.KeyID == newID1 {
-				require.True(t, key.Active, "new key should be active")
+				require.True(t, key.Active(), "new key should be active")
 			} else {
-				require.False(t, key.Active, "initial key should be inactive")
+				require.False(t, key.Active(), "initial key should be inactive")
 			}
 		}
 
@@ -61,7 +61,7 @@ func TestHTTP_Keyring_CRUD(t *testing.T) {
 
 		key := &api.RootKey{
 			Meta: &api.RootKeyMeta{
-				Active:    true,
+				State:     api.RootKeyStateActive,
 				KeyID:     newID2,
 				Algorithm: api.EncryptionAlgorithm(keyMeta.Algorithm),
 			},
@@ -94,9 +94,9 @@ func TestHTTP_Keyring_CRUD(t *testing.T) {
 		for _, key := range listResp {
 			require.NotEqual(t, newID1, key.KeyID)
 			if key.KeyID == newID2 {
-				require.True(t, key.Active, "new key should be active")
+				require.True(t, key.Active(), "new key should be active")
 			} else {
-				require.False(t, key.Active, "initial key should be inactive")
+				require.False(t, key.Active(), "initial key should be inactive")
 			}
 		}
 	})

--- a/command/operator_secure_variables_keyring.go
+++ b/command/operator_secure_variables_keyring.go
@@ -76,11 +76,11 @@ func renderSecureVariablesKeysResponse(keys []*api.RootKeyMeta, verbose bool) st
 		length = 8
 	}
 	out := make([]string, len(keys)+1)
-	out[0] = "Key|Active|Create Time"
+	out[0] = "Key|State|Create Time"
 	i := 1
 	for _, k := range keys {
 		out[i] = fmt.Sprintf("%s|%v|%s",
-			k.KeyID[:length], k.Active, formatTime(k.CreateTime))
+			k.KeyID[:length], k.State, formatTime(k.CreateTime))
 		i = i + 1
 	}
 	return formatList(out)

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -208,6 +208,10 @@ type Config struct {
 	// before it's rotated
 	RootKeyRotationThreshold time.Duration
 
+	// SecureVariablesRekeyInterval is how often we dispatch a job to
+	// rekey any variables associated with a key in the Rekeying state
+	SecureVariablesRekeyInterval time.Duration
+
 	// EvalNackTimeout controls how long we allow a sub-scheduler to
 	// work on an evaluation before we consider it failed and Nack it.
 	// This allows that evaluation to be handed to another sub-scheduler
@@ -400,6 +404,7 @@ func DefaultConfig() *Config {
 		RootKeyGCInterval:                10 * time.Minute,
 		RootKeyGCThreshold:               1 * time.Hour,
 		RootKeyRotationThreshold:         720 * time.Hour, // 30 days
+		SecureVariablesRekeyInterval:     10 * time.Minute,
 		EvalNackTimeout:                  60 * time.Second,
 		EvalDeliveryLimit:                3,
 		EvalNackInitialReenqueueDelay:    1 * time.Second,

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -896,10 +896,10 @@ func (c *CoreScheduler) rootKeyRotation(eval *structs.Evaluation) (bool, error) 
 }
 
 // secureVariablesReKey is optionally run after rotating the active
-// root key. It iterates over all the variables for the non-active
-// keys, decrypts them, and re-encrypts them in batches with the
-// currently active key. This job does not GC the keys, which is
-// handled in the normal periodic GC job.
+// root key. It iterates over all the variables for the keys in the
+// re-keying state, decrypts them, and re-encrypts them in batches
+// with the currently active key. This job does not GC the keys, which
+// is handled in the normal periodic GC job.
 func (c *CoreScheduler) secureVariablesRekey(eval *structs.Evaluation) error {
 
 	ws := memdb.NewWatchSet()

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -2532,6 +2532,75 @@ func TestCoreScheduler_RootKeyGC(t *testing.T) {
 	require.NotNil(t, key, "new key should not have been GCd")
 }
 
+// TestCoreScheduler_SecureVariablesRekey exercises secure variables rekeying
+func TestCoreScheduler_SecureVariablesRekey(t *testing.T) {
+	ci.Parallel(t)
+
+	srv, cleanup := TestServer(t, nil)
+	defer cleanup()
+	testutil.WaitForLeader(t, srv.RPC)
+
+	store := srv.fsm.State()
+	key0, err := store.GetActiveRootKeyMeta(nil)
+	require.NotNil(t, key0, "expected keyring to be bootstapped")
+	require.NoError(t, err)
+
+	req := &structs.SecureVariablesUpsertRequest{
+		Data: []*structs.SecureVariableDecrypted{
+			mock.SecureVariable(),
+			mock.SecureVariable(),
+			mock.SecureVariable(),
+		},
+		WriteRequest: structs.WriteRequest{
+			Region: srv.config.Region,
+		},
+	}
+	resp := &structs.SecureVariablesUpsertResponse{}
+	require.NoError(t, srv.RPC("SecureVariables.Upsert", req, resp))
+
+	rotateReq := &structs.KeyringRotateRootKeyRequest{
+		WriteRequest: structs.WriteRequest{
+			Region: srv.config.Region,
+		},
+	}
+	var rotateResp structs.KeyringRotateRootKeyResponse
+	require.NoError(t, srv.RPC("Keyring.Rotate", rotateReq, &rotateResp))
+
+	req2 := &structs.SecureVariablesUpsertRequest{
+		Data: []*structs.SecureVariableDecrypted{
+			mock.SecureVariable(),
+			mock.SecureVariable(),
+			mock.SecureVariable(),
+		},
+		WriteRequest: structs.WriteRequest{
+			Region: srv.config.Region,
+		},
+	}
+	require.NoError(t, srv.RPC("SecureVariables.Upsert", req2, resp))
+
+	rotateReq.Full = true
+	require.NoError(t, srv.RPC("Keyring.Rotate", rotateReq, &rotateResp))
+	newKeyID := rotateResp.Key.KeyID
+
+	require.Eventually(t, func() bool {
+		ws := memdb.NewWatchSet()
+		iter, err := store.SecureVariables(ws)
+		require.NoError(t, err)
+		for {
+			raw := iter.Next()
+			if raw == nil {
+				break
+			}
+			variable := raw.(*structs.SecureVariableEncrypted)
+			if variable.KeyID != newKeyID {
+				return false
+			}
+		}
+		return true
+	}, time.Second*5, 100*time.Millisecond,
+		"secure variable rekey should be complete")
+}
+
 func TestCoreScheduler_FailLoop(t *testing.T) {
 	ci.Parallel(t)
 

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -348,7 +348,7 @@ func (e *Encrypter) loadKeyFromStore(path string) (*structs.RootKey, error) {
 	}
 
 	meta := &structs.RootKeyMeta{
-		Active:     storedKey.Meta.Active,
+		State:      storedKey.Meta.State,
 		KeyID:      storedKey.Meta.KeyID,
 		Algorithm:  storedKey.Meta.Algorithm,
 		CreateTime: storedKey.Meta.CreateTime,

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -2024,7 +2024,7 @@ func (n *nomadFSM) applyRootKeyMetaUpsert(msgType structs.MessageType, buf []byt
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
 
-	if err := n.state.UpsertRootKeyMeta(index, req.RootKeyMeta); err != nil {
+	if err := n.state.UpsertRootKeyMeta(index, req.RootKeyMeta, req.Rekey); err != nil {
 		n.logger.Error("UpsertRootKeyMeta failed", "error", err)
 		return err
 	}

--- a/nomad/keyring_endpoint_test.go
+++ b/nomad/keyring_endpoint_test.go
@@ -29,7 +29,7 @@ func TestKeyringEndpoint_CRUD(t *testing.T) {
 	key, err := structs.NewRootKey(structs.EncryptionAlgorithmAES256GCM)
 	require.NoError(t, err)
 	id := key.Meta.KeyID
-	key.Meta.Active = true
+	key.Meta.SetActive()
 
 	updateReq := &structs.KeyringUpdateRootKeyRequest{
 		RootKey:      key,
@@ -104,7 +104,7 @@ func TestKeyringEndpoint_CRUD(t *testing.T) {
 	require.EqualError(t, err, "active root key cannot be deleted - call rotate first")
 
 	// set inactive
-	updateReq.RootKey.Meta.Active = false
+	updateReq.RootKey.Meta.SetInactive()
 	err = msgpackrpc.CallWithCodec(codec, "Keyring.Update", updateReq, &updateResp)
 	require.NoError(t, err)
 
@@ -137,7 +137,7 @@ func TestKeyringEndpoint_InvalidUpdates(t *testing.T) {
 	key, err := structs.NewRootKey(structs.EncryptionAlgorithmAES256GCM)
 	require.NoError(t, err)
 	id := key.Meta.KeyID
-	key.Meta.Active = true
+	key.Meta.SetActive()
 
 	updateReq := &structs.KeyringUpdateRootKeyRequest{
 		RootKey: key,
@@ -171,14 +171,24 @@ func TestKeyringEndpoint_InvalidUpdates(t *testing.T) {
 				KeyID:     id,
 				Algorithm: structs.EncryptionAlgorithmAES256GCM,
 			}},
+			expectedErrMsg: "root key state \"\" is invalid",
+		},
+		{
+			key: &structs.RootKey{Meta: &structs.RootKeyMeta{
+				KeyID:     id,
+				Algorithm: structs.EncryptionAlgorithmAES256GCM,
+				State:     structs.RootKeyStateActive,
+			}},
 			expectedErrMsg: "root key material is required",
 		},
+
 		{
 			key: &structs.RootKey{
 				Key: []byte{0x01},
 				Meta: &structs.RootKeyMeta{
 					KeyID:     id,
 					Algorithm: "whatever",
+					State:     structs.RootKeyStateActive,
 				}},
 			expectedErrMsg: "root key algorithm cannot be changed after a key is created",
 		},
@@ -216,7 +226,7 @@ func TestKeyringEndpoint_Rotate(t *testing.T) {
 	// Setup an existing key
 	key, err := structs.NewRootKey(structs.EncryptionAlgorithmAES256GCM)
 	require.NoError(t, err)
-	key.Meta.Active = true
+	key.Meta.SetActive()
 
 	updateReq := &structs.KeyringUpdateRootKeyRequest{
 		RootKey: key,
@@ -263,9 +273,9 @@ func TestKeyringEndpoint_Rotate(t *testing.T) {
 
 	for _, keyMeta := range listResp.Keys {
 		if keyMeta.KeyID != newID {
-			require.False(t, keyMeta.Active, "expected old keys to be inactive")
+			require.False(t, keyMeta.Active(), "expected old keys to be inactive")
 		} else {
-			require.True(t, keyMeta.Active, "expected new key to be inactive")
+			require.True(t, keyMeta.Active(), "expected new key to be inactive")
 		}
 	}
 

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -1708,7 +1708,7 @@ func (s *Server) initializeKeyring() error {
 	s.logger.Named("core").Trace("initializing keyring")
 
 	rootKey, err := structs.NewRootKey(structs.EncryptionAlgorithmAES256GCM)
-	rootKey.Meta.Active = true
+	rootKey.Meta.SetActive()
 	if err != nil {
 		return fmt.Errorf("could not initialize keyring: %v", err)
 	}

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -769,6 +769,8 @@ func (s *Server) schedulePeriodic(stopCh chan struct{}) {
 	defer oneTimeTokenGC.Stop()
 	rootKeyGC := time.NewTicker(s.config.RootKeyGCInterval)
 	defer rootKeyGC.Stop()
+	secureVariablesRekey := time.NewTicker(s.config.SecureVariablesRekeyInterval)
+	defer secureVariablesRekey.Stop()
 
 	// getLatest grabs the latest index from the state store. It returns true if
 	// the index was retrieved successfully.
@@ -821,6 +823,11 @@ func (s *Server) schedulePeriodic(stopCh chan struct{}) {
 			if index, ok := getLatest(); ok {
 				s.evalBroker.Enqueue(s.coreJobEval(structs.CoreJobRootKeyRotateOrGC, index))
 			}
+		case <-secureVariablesRekey.C:
+			if index, ok := getLatest(); ok {
+				s.evalBroker.Enqueue(s.coreJobEval(structs.CoreJobSecureVariablesRekey, index))
+			}
+
 		case <-stopCh:
 			return
 		}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -6625,7 +6625,7 @@ func (s *StateStore) SecureVariablesQuotas(ws memdb.WatchSet) (memdb.ResultItera
 }
 
 // UpsertRootKeyMeta saves root key meta or updates it in-place.
-func (s *StateStore) UpsertRootKeyMeta(index uint64, rootKeyMeta *structs.RootKeyMeta) error {
+func (s *StateStore) UpsertRootKeyMeta(index uint64, rootKeyMeta *structs.RootKeyMeta, rekey bool) error {
 	txn := s.db.WriteTxn(index)
 	defer txn.Abort()
 
@@ -6641,13 +6641,17 @@ func (s *StateStore) UpsertRootKeyMeta(index uint64, rootKeyMeta *structs.RootKe
 		existing := raw.(*structs.RootKeyMeta)
 		rootKeyMeta.CreateIndex = existing.CreateIndex
 		rootKeyMeta.CreateTime = existing.CreateTime
-		isRotation = !existing.Active && rootKeyMeta.Active
+		isRotation = !existing.Active() && rootKeyMeta.Active()
 	} else {
 		rootKeyMeta.CreateIndex = index
 		rootKeyMeta.CreateTime = time.Now()
-		isRotation = rootKeyMeta.Active
+		isRotation = rootKeyMeta.Active()
 	}
 	rootKeyMeta.ModifyIndex = index
+
+	if rekey && !isRotation {
+		return fmt.Errorf("cannot rekey without setting the new key active")
+	}
 
 	// if the upsert is for a newly-active key, we need to set all the
 	// other keys as inactive in the same transaction.
@@ -6662,13 +6666,32 @@ func (s *StateStore) UpsertRootKeyMeta(index uint64, rootKeyMeta *structs.RootKe
 				break
 			}
 			key := raw.(*structs.RootKeyMeta)
-			if key.Active {
-				key.Active = false
+			modified := false
+
+			switch key.State {
+			case structs.RootKeyStateInactive:
+				if rekey {
+					key.SetRekeying()
+					modified = true
+				}
+			case structs.RootKeyStateActive:
+				if rekey {
+					key.SetRekeying()
+				} else {
+					key.SetInactive()
+				}
+				modified = true
+			case structs.RootKeyStateRekeying, structs.RootKeyStateDeprecated:
+				// nothing to do
+			}
+
+			if modified {
 				key.ModifyIndex = index
 				if err := txn.Insert(TableRootKeyMeta, key); err != nil {
 					return err
 				}
 			}
+
 		}
 	}
 
@@ -6754,7 +6777,7 @@ func (s *StateStore) GetActiveRootKeyMeta(ws memdb.WatchSet) (*structs.RootKeyMe
 			break
 		}
 		key := raw.(*structs.RootKeyMeta)
-		if key.Active {
+		if key.Active() {
 			return key, nil
 		}
 	}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -9877,10 +9877,10 @@ func TestStateStore_RootKeyMetaData_CRUD(t *testing.T) {
 		key := structs.NewRootKeyMeta()
 		keyIDs = append(keyIDs, key.KeyID)
 		if i == 0 {
-			key.Active = true
+			key.SetActive()
 		}
 		index++
-		require.NoError(t, store.UpsertRootKeyMeta(index, key))
+		require.NoError(t, store.UpsertRootKeyMeta(index, key, false))
 	}
 
 	// retrieve the active key
@@ -9894,9 +9894,9 @@ func TestStateStore_RootKeyMetaData_CRUD(t *testing.T) {
 	require.NotNil(t, inactiveKey)
 	oldCreateIndex := inactiveKey.CreateIndex
 	newlyActiveKey := inactiveKey.Copy()
-	newlyActiveKey.Active = true
+	newlyActiveKey.SetActive()
 	index++
-	require.NoError(t, store.UpsertRootKeyMeta(index, newlyActiveKey))
+	require.NoError(t, store.UpsertRootKeyMeta(index, newlyActiveKey, false))
 
 	iter, err := store.RootKeyMetas(nil)
 	require.NoError(t, err)
@@ -9907,10 +9907,10 @@ func TestStateStore_RootKeyMetaData_CRUD(t *testing.T) {
 		}
 		key := raw.(*structs.RootKeyMeta)
 		if key.KeyID == newlyActiveKey.KeyID {
-			require.True(t, key.Active, "expected updated key to be active")
+			require.True(t, key.Active(), "expected updated key to be active")
 			require.Equal(t, oldCreateIndex, key.CreateIndex)
 		} else {
-			require.False(t, key.Active, "expected other keys to be inactive")
+			require.False(t, key.Active(), "expected other keys to be inactive")
 		}
 	}
 
@@ -9928,7 +9928,7 @@ func TestStateStore_RootKeyMetaData_CRUD(t *testing.T) {
 		}
 		key := raw.(*structs.RootKeyMeta)
 		require.NotEqual(t, keyIDs[1], key.KeyID)
-		require.False(t, key.Active, "expected remaining keys to be inactive")
+		require.False(t, key.Active(), "expected remaining keys to be inactive")
 		found++
 	}
 	require.Equal(t, 2, found, "expected only 2 keys remaining")

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10777,6 +10777,11 @@ const (
 	// garbage collection of unused encryption keys.
 	CoreJobRootKeyRotateOrGC = "root-key-rotate-gc"
 
+	// CoreJobSecureVariablesRekey is used to fully rotate the
+	// encryption keys for secure variables by decrypting all secure
+	// variables and re-encrypting them with the active key
+	CoreJobSecureVariablesRekey = "secure-variables-rekey"
+
 	// CoreJobForceGC is used to force garbage collection of all GCable objects.
 	CoreJobForceGC = "force-gc"
 )


### PR DESCRIPTION
When the `Full` flag is passed for key rotation, we kick off a core
job to decrypt and re-encrypt all the secure variables so that they
use the new key.