### PR TITLE
ui:  create variable permission logic

### DIFF
--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -1,10 +1,16 @@
 import { computed, get } from '@ember/object';
 import { or } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
 import AbstractAbility from './abstract';
 
 export default class Variable extends AbstractAbility {
-  @service router;
+  // Pass in a namespace to `can` or `cannot` calls to override
+  // https://github.com/minutebase/ember-can#additional-attributes
+  path = '*';
+
+  get _path() {
+    if (!this.path) return '*';
+    return this.path;
+  }
 
   @or(
     'bypassAuthorization',
@@ -27,14 +33,10 @@ export default class Variable extends AbstractAbility {
     });
   }
 
-  @computed(
-    'rulesForNamespace.@each.capabilities',
-    'router.currentRoute.params.absolutePath'
-  )
+  @computed('rulesForNamespace.@each.capabilities', 'path')
   get policiesSupportVariableCreation() {
-    const path = get(this, 'router.currentRoute.params.absolutePath') || '*';
     return this.rulesForNamespace.some((rules) => {
-      const keyName = `SecureVariables.Path "${path}".Capabilities`;
+      const keyName = `SecureVariables.Path "${this.path}".Capabilities`;
       const capabilities = get(rules, keyName) || [];
       return capabilities.includes('create');
     });

--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -2,6 +2,11 @@ import { computed, get } from '@ember/object';
 import { or } from '@ember/object/computed';
 import AbstractAbility from './abstract';
 
+const WILDCARD_GLOB = '*';
+const WILDCARD_PATTERN = '/';
+const GLOBAL_FLAG = 'g';
+const WILDCARD_PATTERN_REGEX = new RegExp(WILDCARD_PATTERN, GLOBAL_FLAG);
+
 export default class Variable extends AbstractAbility {
   // Pass in a namespace to `can` or `cannot` calls to override
   // https://github.com/minutebase/ember-can#additional-attributes
@@ -22,9 +27,16 @@ export default class Variable extends AbstractAbility {
   @or(
     'bypassAuthorization',
     'selfTokenIsManagement',
-    'policiesSupportVariableCreation'
+    'policiesSupportVariableWriting'
   )
-  canCreate;
+  canWrite;
+
+  @or(
+    'bypassAuthorization',
+    'selfTokenIsManagement',
+    'policiesSupportVariableDestroy'
+  )
+  canDestroy;
 
   @computed('rulesForNamespace.@each.capabilities')
   get policiesSupportVariableView() {
@@ -33,12 +45,143 @@ export default class Variable extends AbstractAbility {
     });
   }
 
-  @computed('rulesForNamespace.@each.capabilities', 'path')
-  get policiesSupportVariableCreation() {
-    return this.rulesForNamespace.some((rules) => {
-      const keyName = `SecureVariables.Path "${this.path}".Capabilities`;
-      const capabilities = get(rules, keyName) || [];
-      return capabilities.includes('create');
-    });
+  @computed('path', 'allPaths')
+  get policiesSupportVariableWriting() {
+    const matchingPath = this._nearestMatchingPath(this.path);
+    return this.allPaths
+      .find((path) => path.name === matchingPath)
+      ?.capabilities?.includes('write');
+  }
+
+  @computed('path', 'allPaths')
+  get policiesSupportVariableDestroy() {
+    const matchingPath = this._nearestMatchingPath(this.path);
+    return this.allPaths
+      .find((path) => path.name === matchingPath)
+      ?.capabilities?.includes('destroy');
+  }
+
+  @computed('token.selfTokenPolicies.[]', '_namespace')
+  get allPaths() {
+    return (get(this, 'token.selfTokenPolicies') || [])
+      .toArray()
+      .reduce((paths, policy) => {
+        const matchingNamespace = this._findMatchingNamespace(
+          get(policy, 'rulesJSON.Namespaces') || [],
+          this._namespace
+        );
+
+        const variables = (get(policy, 'rulesJSON.Namespaces') || []).find(
+          (namespace) => namespace.Name === matchingNamespace
+        )?.SecureVariables;
+
+        const pathNames = variables?.Paths?.map((path) => ({
+          name: path.PathSpec,
+          capabilities: path.Capabilities,
+        }));
+
+        if (pathNames) {
+          paths = [...paths, ...pathNames];
+        }
+
+        return paths;
+      }, []);
+  }
+
+  _formatMatchingPathRegEx(path, wildCardPlacement = 'end') {
+    const replacer = () => '\\/';
+    if (wildCardPlacement === 'end') {
+      const trimmedPath = path.slice(0, path.length - 1);
+      const pattern = trimmedPath.replace(WILDCARD_PATTERN_REGEX, replacer);
+      return pattern;
+    } else {
+      const trimmedPath = path.slice(1, path.length);
+      const pattern = trimmedPath.replace(WILDCARD_PATTERN_REGEX, replacer);
+      return pattern;
+    }
+  }
+
+  _computeAllMatchingPaths(pathNames, path) {
+    const matches = [];
+
+    for (const pathName of pathNames) {
+      if (this._doesMatchPattern(pathName, path)) matches.push(pathName);
+    }
+
+    return matches;
+  }
+
+  _nearestMatchingPath(path) {
+    const pathNames = this.allPaths.map((path) => path.name);
+
+    if (pathNames.includes(path)) {
+      return path;
+    }
+
+    const allMatchingPaths = this._computeAllMatchingPaths(pathNames, path);
+
+    if (!allMatchingPaths.length) return WILDCARD_GLOB;
+
+    return this._smallestDifference(allMatchingPaths, path);
+  }
+
+  _doesMatchPattern(pattern, path) {
+    const parts = pattern?.split(WILDCARD_GLOB);
+    const hasLeadingGlob = pattern?.startsWith(WILDCARD_GLOB);
+    const hasTrailingGlob = pattern?.endsWith(WILDCARD_GLOB);
+    const lastPartOfPattern = parts[parts.length - 1];
+    const isPatternWithoutGlob = parts.length === 1 && !hasLeadingGlob;
+
+    if (!pattern || !path || isPatternWithoutGlob) {
+      return pattern === path;
+    }
+
+    if (pattern === WILDCARD_GLOB) {
+      return true;
+    }
+
+    let subPathToMatchOn = path;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      const idx = subPathToMatchOn?.indexOf(part);
+      const doesPathIncludeSubPattern = idx > -1;
+      const doesMatchOnFirstSubpattern = idx === 0;
+
+      if (i === 0 && !hasLeadingGlob && !doesMatchOnFirstSubpattern) {
+        return false;
+      }
+
+      if (!doesPathIncludeSubPattern) {
+        return false;
+      }
+
+      subPathToMatchOn = subPathToMatchOn.slice(0, idx + path.length);
+    }
+
+    return hasTrailingGlob || path.endsWith(lastPartOfPattern);
+  }
+
+  _computeLengthDiff(pattern, path) {
+    const countGlobsInPattern = pattern
+      ?.split('')
+      .filter((el) => el === WILDCARD_GLOB).length;
+
+    return path?.length - pattern?.length + countGlobsInPattern;
+  }
+
+  _smallestDifference(matches, path) {
+    const sortingCallBack = (patternA, patternB) =>
+      this._computeLengthDiff(patternA, path) -
+      this._computeLengthDiff(patternB, path);
+
+    const sortedMatches = matches?.sort(sortingCallBack);
+    const isTie =
+      this._computeLengthDiff(sortedMatches[0], path) ===
+      this._computeLengthDiff(sortedMatches[1], path);
+    const doesFirstMatchHaveLeadingGlob = sortedMatches[0][0] === WILDCARD_GLOB;
+
+    return isTie && doesFirstMatchHaveLeadingGlob
+      ? sortedMatches[1]
+      : sortedMatches[0];
   }
 }

--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -1,8 +1,11 @@
-import AbstractAbility from './abstract';
 import { computed, get } from '@ember/object';
 import { or } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+import AbstractAbility from './abstract';
 
-export default class extends AbstractAbility {
+export default class Variable extends AbstractAbility {
+  @service router;
+
   @or(
     'bypassAuthorization',
     'selfTokenIsManagement',
@@ -24,10 +27,14 @@ export default class extends AbstractAbility {
     });
   }
 
-  @computed('rulesForNamespace.@each.capabilities') // TODO:  edit computed property to be SecureVariables.Path "DYNAMIC PATH"
+  @computed(
+    'rulesForNamespace.@each.capabilities',
+    'router.currentRoute.params.absolutePath'
+  )
   get policiesSupportVariableCreation() {
+    const path = get(this, 'router.currentRoute.params.absolutePath') || '*';
     return this.rulesForNamespace.some((rules) => {
-      const keyName = `SecureVariables.Path "*".Capabilities`; // TODO:  add ability to edit path, however computed properties can't take parameters
+      const keyName = `SecureVariables.Path "${path}".Capabilities`;
       const capabilities = get(rules, keyName) || [];
       return capabilities.includes('create');
     });

--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -14,6 +14,7 @@
         disabled={{not @model.isNew}}
         {{on "input" this.validatePath}}
         {{autofocus}}
+        data-test-path-input
       />
     </label>
     {{#if this.duplicatePathWarning}}
@@ -57,6 +58,7 @@
             Key
           </span>
           <Input
+            data-test-var-key
             @type="text"
             @value={{entry.key}}
             class="input"
@@ -96,6 +98,7 @@
       disabled={{this.shouldDisableSave}}
       class="button is-primary"
       type="submit"
+      data-test-submit-var
     >
       Save
       {{pluralize "Variable" @this.keyValues.length}}

--- a/ui/app/components/secure-variable-form/input-group.hbs
+++ b/ui/app/components/secure-variable-form/input-group.hbs
@@ -6,8 +6,9 @@
     @type={{this.inputType}}
     @value={{@entry.value}}
     class="input value-input"
-    autocomplete="new-password"
     {{! prevent auto-fill }}
+    autocomplete="new-password"
+    data-test-var-value
   />
   <button
     class="show-hide-values button is-light"

--- a/ui/app/templates/variables/index.hbs
+++ b/ui/app/templates/variables/index.hbs
@@ -12,7 +12,7 @@
     </div>
     <div class="toolbar-item is-right-aligned is-mobile-full-width">
       <div class="button-bar">
-      {{#if (can "create variable")}}
+      {{#if (can "create variable" path="*")}}
         <LinkTo
           @route="variables.new"
           class="button is-primary"

--- a/ui/app/templates/variables/index.hbs
+++ b/ui/app/templates/variables/index.hbs
@@ -12,10 +12,9 @@
     </div>
     <div class="toolbar-item is-right-aligned is-mobile-full-width">
       <div class="button-bar">
-      {{#if (can "create variable" namespace=this.qpNamespace)}}
+      {{#if (can "create variable")}}
         <LinkTo
           @route="variables.new"
-          @query={{hash namespace=this.qpNamespace}}
           class="button is-primary"
         >
           Create Secure Variable

--- a/ui/app/templates/variables/index.hbs
+++ b/ui/app/templates/variables/index.hbs
@@ -12,10 +12,11 @@
     </div>
     <div class="toolbar-item is-right-aligned is-mobile-full-width">
       <div class="button-bar">
-      {{#if (can "create variable" path="*")}}
+      {{#if (can "write variable" path="*")}}
         <LinkTo
           @route="variables.new"
           class="button is-primary"
+          data-test-create-var
         >
           Create Secure Variable
         </LinkTo>
@@ -25,6 +26,7 @@
           aria-label="You don’t have sufficient permissions"
           disabled
           type="button"
+          data-test-disabled-create-var
         >
           Create Secure Variable
         </button>

--- a/ui/app/templates/variables/path.hbs
+++ b/ui/app/templates/variables/path.hbs
@@ -7,10 +7,10 @@
       <div class="toolbar-item is-right-aligned is-mobile-full-width">
         <div class="button-bar">
         {{!-- TODO: make sure qpNamespace persists to here --}}
-        {{#if (can "create variable" namespace=this.qpNamespace)}}
+        {{#if (can "create variable")}}
           <LinkTo
             @route="variables.new"
-            @query={{hash namespace=this.qpNamespace path=(concat this.model.absolutePath "/")}}
+            @query={{hash path=(concat this.model.absolutePath "/")}}
             class="button is-primary"
           >
             Create Secure Variable

--- a/ui/app/templates/variables/path.hbs
+++ b/ui/app/templates/variables/path.hbs
@@ -6,8 +6,7 @@
     <div class="toolbar">
       <div class="toolbar-item is-right-aligned is-mobile-full-width">
         <div class="button-bar">
-        {{!-- TODO: make sure qpNamespace persists to here --}}
-        {{#if (can "create variable")}}
+        {{#if (can "create variable" path=this.model.absolutePath)}}
           <LinkTo
             @route="variables.new"
             @query={{hash path=(concat this.model.absolutePath "/")}}

--- a/ui/app/templates/variables/path.hbs
+++ b/ui/app/templates/variables/path.hbs
@@ -6,7 +6,7 @@
     <div class="toolbar">
       <div class="toolbar-item is-right-aligned is-mobile-full-width">
         <div class="button-bar">
-        {{#if (can "create variable" path=this.model.absolutePath)}}
+        {{#if (can "write variable" path=this.model.absolutePath)}}
           <LinkTo
             @route="variables.new"
             @query={{hash path=(concat this.model.absolutePath "/")}}

--- a/ui/app/templates/variables/variable/index.hbs
+++ b/ui/app/templates/variables/variable/index.hbs
@@ -36,8 +36,10 @@
   </div>
   <div>
     {{#unless this.isDeleting}}
+      {{#if (can "write variable" path=this.model.absolutePath)}}
       <div class="two-step-button">
         <LinkTo
+          data-test-edit-button
           class="button is-info is-inverted is-small"
           @model={{this.model}}
           @route="variables.variable.edit"
@@ -46,19 +48,22 @@
           Edit
         </LinkTo>
       </div>
+      {{/if}}
     {{/unless}}
-    <TwoStepButton
-      data-test-delete-button
-      @alignRight={{true}}
-      @idleText="Delete"
-      @cancelText="Cancel"
-      @confirmText="Yes, delete"
-      @confirmationMessage="Are you sure you want to delete this variable and all its items?"
-      @awaitingConfirmation={{this.deleteVariableFile.isRunning}}
-      @onConfirm={{perform this.deleteVariableFile}}
-      @onPrompt={{this.onDeletePrompt}}
-      @onCancel={{this.onDeleteCancel}}
-    />
+    {{#if (can "destroy variable" path=this.model.absolutePath)}}
+      <TwoStepButton
+        data-test-delete-button
+        @alignRight={{true}}
+        @idleText="Delete"
+        @cancelText="Cancel"
+        @confirmText="Yes, delete"
+        @confirmationMessage="Are you sure you want to delete this variable and all its items?"
+        @awaitingConfirmation={{this.deleteVariableFile.isRunning}}
+        @onConfirm={{perform this.deleteVariableFile}}
+        @onPrompt={{this.onDeletePrompt}}
+        @onCancel={{this.onDeleteCancel}}
+      />
+    {{/if}}
   </div>
 </h1>
 {{#if (eq this.view "json")}}
@@ -79,7 +84,7 @@
 {{else}}
   <ListTable data-test-eval-table @source={{this.model.keyValues}} as |t|>
     <t.body as |row|>
-      <tr>
+      <tr data-test-var={{row.model.key}}>
         <td>
           {{row.model.key}}
         </td>

--- a/ui/mirage/factories/token.js
+++ b/ui/mirage/factories/token.js
@@ -38,8 +38,19 @@ namespace "default" {
   policy = "read"
   capabilities = ["list-jobs", "alloc-exec", "read-logs"]
   secure_variables {
+    # full access to secrets in all project paths
+    path "blue/*" {
+      capabilities = ["write", "read", "destroy", "list"]
+    }
+
+    # full access to secrets in all project paths
     path "*" {
-      capabilities = ["list"]
+      capabilities = ["write", "read", "destroy", "list"]
+    }
+
+    # read/list access within a "system" path belonging to administrators
+    path "system/*" {
+      capabilities = ["read", "list"]
     }
   }
 }
@@ -55,12 +66,20 @@ node {
               Name: 'default',
               Capabilities: ['list-jobs', 'alloc-exec', 'read-logs'],
               SecureVariables: {
-                'Path "*"': {
-                  Capabilities: ['list', 'create'],
-                },
-                'Path "blue/berkshire"': {
-                  Capabilities: ['list', 'create', 'edit', 'delete'],
-                },
+                Paths: [
+                  {
+                    Capabilities: ['write', 'read', 'destroy', 'list'],
+                    PathSpec: 'blue/*',
+                  },
+                  {
+                    Capabilities: ['write', 'read', 'destroy', 'list'],
+                    PathSpec: '*',
+                  },
+                  {
+                    Capabilities: ['read', 'list'],
+                    PathSpec: 'system/*',
+                  },
+                ],
               },
             },
           ],

--- a/ui/mirage/factories/token.js
+++ b/ui/mirage/factories/token.js
@@ -59,7 +59,7 @@ node {
                   Capabilities: ['list', 'create'],
                 },
                 'Path "blue/berkshire"': {
-                  Capabilities: ['create'],
+                  Capabilities: ['list', 'create', 'edit', 'delete'],
                 },
               },
             },

--- a/ui/mirage/factories/token.js
+++ b/ui/mirage/factories/token.js
@@ -58,6 +58,9 @@ node {
                 'Path "*"': {
                   Capabilities: ['list', 'create'],
                 },
+                'Path "blue/berkshire"': {
+                  Capabilities: ['create'],
+                },
               },
             },
           ],

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -1,10 +1,16 @@
-import { module, test } from 'qunit';
-import { currentURL } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
+import {
+  currentRouteName,
+  currentURL,
+  click,
+  find,
+  findAll,
+  typeIn,
+} from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
 import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import defaultScenario from '../../mirage/scenarios/default';
-import { click, find, findAll, typeIn } from '@ember/test-helpers';
 
 import Variables from 'nomad-ui/tests/pages/variables';
 import Layout from 'nomad-ui/tests/pages/layout';
@@ -145,5 +151,203 @@ module('Acceptance | secure variables', function (hooks) {
     window.localStorage.nomadTokenSecret = variablesToken.secretId;
     await Variables.visit();
     await a11yAudit(assert);
+  });
+
+  module('create flow', function () {
+    test('allows a user with correct permissions to create a secure variable', async function (assert) {
+      // Arrange Test Set-up
+      defaultScenario(server);
+      server.createList('variable', 3);
+      const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
+      window.localStorage.nomadTokenSecret = variablesToken.secretId;
+      await Variables.visit();
+      // End Test Set-up
+
+      assert
+        .dom('[data-test-create-var]')
+        .exists(
+          'It should display an enabled button to create a secure variable'
+        );
+      await click('[data-test-create-var]');
+
+      assert.equal(currentRouteName(), 'variables.new');
+
+      await typeIn('[data-test-path-input]', 'foo/bar');
+      await typeIn('[data-test-var-key]', 'kiki');
+      await typeIn('[data-test-var-value]', 'do you love me');
+      await click('[data-test-submit-var]');
+
+      assert.equal(
+        currentRouteName(),
+        'variables.variable.index',
+        'Navigates user back to variables list page after creating variable.'
+      );
+      assert
+        .dom('.flash-message.alert.alert-success')
+        .exists('Shows a success toast notification on creation.');
+      assert
+        .dom('[data-test-var=kiki]')
+        .exists('The new variable key should appear in the list.');
+
+      // Reset Token
+      window.localStorage.nomadTokenSecret = null;
+    });
+
+    test('prevents users from creating a secure variable without proper permissions', async function (assert) {
+      // Arrange Test Set-up
+      defaultScenario(server);
+      server.createList('variable', 3);
+      const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
+      window.localStorage.nomadTokenSecret = variablesToken.secretId;
+      const policy = server.db.policies.find('Variable Maker');
+      policy.rulesJSON.Namespaces[0].SecureVariables.Paths.find(
+        (path) => path.PathSpec === '*'
+      ).Capabilities = ['list'];
+      await Variables.visit();
+      // End Test Set-up
+
+      assert
+        .dom('[data-test-disabled-create-var]')
+        .exists(
+          'It should display an disabled button to create a secure variable on the main listings page'
+        );
+
+      // Reset Token
+      window.localStorage.nomadTokenSecret = null;
+    });
+  });
+
+  module('edit flow', function () {
+    test('allows a user with correct permissions to edit a secure variable', async function (assert) {
+      // Arrange Test Set-up
+      defaultScenario(server);
+      server.createList('variable', 3);
+      const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
+      window.localStorage.nomadTokenSecret = variablesToken.secretId;
+      const policy = server.db.policies.find('Variable Maker');
+      policy.rulesJSON.Namespaces[0].SecureVariables.Paths.find(
+        (path) => path.PathSpec === '*'
+      ).Capabilities = ['list', 'write'];
+      await Variables.visit();
+      await click('[data-test-file-row]');
+      // End Test Set-up
+
+      assert.equal(currentRouteName(), 'variables.variable.index');
+      assert
+        .dom('[data-test-edit-button]')
+        .exists('The edit button is enabled in the view.');
+      await click('[data-test-edit-button]');
+      assert.equal(
+        currentRouteName(),
+        'variables.variable.edit',
+        'Clicking the button navigates you to editing view.'
+      );
+
+      assert.dom('[data-test-path-input]').isDisabled('Path cannot be edited');
+
+      document.querySelector('[data-test-var-key]').value = ''; // clear current input
+      await typeIn('[data-test-var-key]', 'kiki');
+      await typeIn('[data-test-var-value]', 'do you love me');
+      await click('[data-test-submit-var]');
+
+      assert.equal(
+        currentRouteName(),
+        'variables.variable.index',
+        'Navigates user back to variables list page after creating variable.'
+      );
+      assert
+        .dom('.flash-message.alert.alert-success')
+        .exists('Shows a success toast notification on edit.');
+      assert
+        .dom('[data-test-var=kiki]')
+        .exists('The edited variable key should appear in the list.');
+
+      // Reset Token
+      window.localStorage.nomadTokenSecret = null;
+    });
+
+    test('prevents users from editing a secure variable without proper permissions', async function (assert) {
+      // Arrange Test Set-up
+      defaultScenario(server);
+      server.createList('variable', 3);
+      const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
+      window.localStorage.nomadTokenSecret = variablesToken.secretId;
+      const policy = server.db.policies.find('Variable Maker');
+      policy.rulesJSON.Namespaces[0].SecureVariables.Paths.find(
+        (path) => path.PathSpec === '*'
+      ).Capabilities = ['list'];
+      await Variables.visit();
+      await click('[data-test-file-row]');
+      // End Test Set-up
+
+      assert.equal(currentRouteName(), 'variables.variable.index');
+      assert
+        .dom('[data-test-edit-button]')
+        .doesNotExist('The edit button is hidden in the view.');
+
+      // Reset Token
+      window.localStorage.nomadTokenSecret = null;
+    });
+  });
+
+  module('delete flow', function () {
+    test('allows a user with correct permissions to delete a secure variable', async function (assert) {
+      // Arrange Test Set-up
+      defaultScenario(server);
+      server.createList('variable', 3);
+      const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
+      window.localStorage.nomadTokenSecret = variablesToken.secretId;
+      const policy = server.db.policies.find('Variable Maker');
+      policy.rulesJSON.Namespaces[0].SecureVariables.Paths.find(
+        (path) => path.PathSpec === '*'
+      ).Capabilities = ['list', 'destroy'];
+      await Variables.visit();
+      await click('[data-test-file-row]');
+      // End Test Set-up
+
+      assert.equal(currentRouteName(), 'variables.variable.index');
+      assert
+        .dom('[data-test-delete-button]')
+        .exists('The delete button is enabled in the view.');
+      await click('[data-test-idle-button]');
+
+      assert
+        .dom('[data-test-confirmation-message]')
+        .exists('Deleting a variable requires two-step confirmation.');
+
+      await click('[data-test-confirm-button]');
+
+      assert.equal(
+        currentRouteName(),
+        'variables.index',
+        'Navigates user back to variables list page after destroying a variable.'
+      );
+
+      // Reset Token
+      window.localStorage.nomadTokenSecret = null;
+    });
+
+    test('prevents users from delete a secure variable without proper permissions', async function (assert) {
+      // Arrange Test Set-up
+      defaultScenario(server);
+      server.createList('variable', 3);
+      const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
+      window.localStorage.nomadTokenSecret = variablesToken.secretId;
+      const policy = server.db.policies.find('Variable Maker');
+      policy.rulesJSON.Namespaces[0].SecureVariables.Paths.find(
+        (path) => path.PathSpec === '*'
+      ).Capabilities = ['list'];
+      await Variables.visit();
+      await click('[data-test-file-row]');
+      // End Test Set-up
+
+      assert.equal(currentRouteName(), 'variables.variable.index');
+      assert
+        .dom('[data-test-delete-button]')
+        .doesNotExist('The delete button is hidden in the view.');
+
+      // Reset Token
+      window.localStorage.nomadTokenSecret = null;
+    });
   });
 });

--- a/ui/tests/unit/abilities/variable-test.js
+++ b/ui/tests/unit/abilities/variable-test.js
@@ -15,87 +15,151 @@ module('Unit | Ability | variable', function (hooks) {
     this.owner.register('service:system', mockSystem);
   });
 
-  test('it does not permit listing variables by default', function (assert) {
-    const mockToken = Service.extend({
-      aclEnabled: true,
+  module('#list', function () {
+    test('it does not permit listing variables by default', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+      });
+
+      this.owner.register('service:token', mockToken);
+
+      assert.notOk(this.ability.canList);
     });
 
-    this.owner.register('service:token', mockToken);
+    test('it does not permit listing variables when token type is client', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+      });
 
-    assert.notOk(this.ability.canList);
-  });
+      this.owner.register('service:token', mockToken);
 
-  test('it does not permit listing variables when token type is client', function (assert) {
-    const mockToken = Service.extend({
-      aclEnabled: true,
-      selfToken: { type: 'client' },
+      assert.notOk(this.ability.canList);
     });
 
-    this.owner.register('service:token', mockToken);
+    test('it permits listing variables when token type is management', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'management' },
+      });
 
-    assert.notOk(this.ability.canList);
-  });
+      this.owner.register('service:token', mockToken);
 
-  test('it permits listing variables when token type is management', function (assert) {
-    const mockToken = Service.extend({
-      aclEnabled: true,
-      selfToken: { type: 'management' },
+      assert.ok(this.ability.canList);
     });
 
-    this.owner.register('service:token', mockToken);
-
-    assert.ok(this.ability.canList);
-  });
-
-  test('it permits listing variables when token has SecureVariables with list capabilities in its rules', function (assert) {
-    const mockToken = Service.extend({
-      aclEnabled: true,
-      selfToken: { type: 'client' },
-      selfTokenPolicies: [
-        {
-          rulesJSON: {
-            Namespaces: [
-              {
-                Name: 'default',
-                Capabilities: [],
-                SecureVariables: {
-                  'Path "*"': {
-                    Capabilities: ['list'],
+    test('it permits listing variables when token has SecureVariables with list capabilities in its rules', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {
+                    'Path "*"': {
+                      Capabilities: ['list'],
+                    },
                   },
                 },
-              },
-            ],
+              ],
+            },
           },
-        },
-      ],
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+
+      assert.ok(this.ability.canList);
     });
 
-    this.owner.register('service:token', mockToken);
+    test('it permits listing variables when token has SecureVariables alone in its rules', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {},
+                },
+              ],
+            },
+          },
+        ],
+      });
 
-    assert.ok(this.ability.canList);
+      this.owner.register('service:token', mockToken);
+
+      assert.ok(this.ability.canList);
+    });
   });
 
-  test('it permits listing variables when token has SecureVariables alone in its rules', function (assert) {
-    const mockToken = Service.extend({
-      aclEnabled: true,
-      selfToken: { type: 'client' },
-      selfTokenPolicies: [
-        {
-          rulesJSON: {
-            Namespaces: [
-              {
-                Name: 'default',
-                Capabilities: [],
-                SecureVariables: {},
-              },
-            ],
-          },
-        },
-      ],
+  module('#create', function () {
+    test('it does not permit creating variables by default', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+      });
+
+      this.owner.register('service:token', mockToken);
+
+      assert.notOk(this.ability.canCreate);
     });
 
-    this.owner.register('service:token', mockToken);
+    test('it permits creating variables when token type is management', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'management' },
+      });
 
-    assert.ok(this.ability.canList);
+      this.owner.register('service:token', mockToken);
+
+      assert.ok(this.ability.canCreate);
+    });
+
+    test('it permits creating variables when acl is disabled', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: false,
+        selfToken: { type: 'client' },
+      });
+
+      this.owner.register('service:token', mockToken);
+
+      assert.ok(this.ability.canCreate);
+    });
+
+    test('it permits creating variables when token has SecureVariables with create capabilities in its rules', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {
+                    'Path "*"': {
+                      Capabilities: ['create'],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+
+      assert.ok(this.ability.canCreate);
+    });
   });
 });

--- a/ui/tests/unit/abilities/variable-test.js
+++ b/ui/tests/unit/abilities/variable-test.js
@@ -109,7 +109,7 @@ module('Unit | Ability | variable', function (hooks) {
 
       this.owner.register('service:token', mockToken);
 
-      assert.notOk(this.ability.canCreate);
+      assert.notOk(this.ability.canWrite);
     });
 
     test('it permits creating variables when token type is management', function (assert) {
@@ -120,7 +120,7 @@ module('Unit | Ability | variable', function (hooks) {
 
       this.owner.register('service:token', mockToken);
 
-      assert.ok(this.ability.canCreate);
+      assert.ok(this.ability.canWrite);
     });
 
     test('it permits creating variables when acl is disabled', function (assert) {
@@ -131,10 +131,342 @@ module('Unit | Ability | variable', function (hooks) {
 
       this.owner.register('service:token', mockToken);
 
-      assert.ok(this.ability.canCreate);
+      assert.ok(this.ability.canWrite);
     });
 
-    test('it permits creating variables when token has SecureVariables with create capabilities in its rules', function (assert) {
+    test('it permits creating variables when token has SecureVariables with write capabilities in its rules', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {
+                    Paths: [{ Capabilities: ['write'], PathSpec: '*' }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+
+      assert.ok(this.ability.canWrite);
+    });
+
+    test('it handles namespace matching', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {
+                    Paths: [{ Capabilities: ['list'], PathSpec: 'foo/bar' }],
+                  },
+                },
+                {
+                  Name: 'pablo',
+                  Capabilities: [],
+                  SecureVariables: {
+                    Paths: [{ Capabilities: ['write'], PathSpec: 'foo/bar' }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+      this.ability.path = 'foo/bar';
+      this.ability.namespace = 'pablo';
+
+      assert.ok(this.ability.canWrite);
+    });
+  });
+
+  module('#destroy', function () {
+    test('it does not permit destroying variables by default', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+      });
+
+      this.owner.register('service:token', mockToken);
+
+      assert.notOk(this.ability.canDestroy);
+    });
+
+    test('it permits destroying variables when token type is management', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'management' },
+      });
+
+      this.owner.register('service:token', mockToken);
+
+      assert.ok(this.ability.canDestroy);
+    });
+
+    test('it permits destroying variables when acl is disabled', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: false,
+        selfToken: { type: 'client' },
+      });
+
+      this.owner.register('service:token', mockToken);
+
+      assert.ok(this.ability.canDestroy);
+    });
+
+    test('it permits destroying variables when token has SecureVariables with write capabilities in its rules', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {
+                    Paths: [{ Capabilities: ['destroy'], PathSpec: '*' }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+
+      assert.ok(this.ability.canDestroy);
+    });
+
+    test('it handles namespace matching', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {
+                    Paths: [{ Capabilities: ['list'], PathSpec: 'foo/bar' }],
+                  },
+                },
+                {
+                  Name: 'pablo',
+                  Capabilities: [],
+                  SecureVariables: {
+                    Paths: [{ Capabilities: ['destroy'], PathSpec: 'foo/bar' }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+      this.ability.path = 'foo/bar';
+      this.ability.namespace = 'pablo';
+
+      assert.ok(this.ability.canDestroy);
+    });
+  });
+
+  module('#_nearestMatchingPath', function () {
+    test('returns capabilities for an exact path match', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {
+                    Paths: [{ Capabilities: ['write'], PathSpec: 'foo' }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+      const path = 'foo';
+
+      const nearestMatchingPath = this.ability._nearestMatchingPath(path);
+
+      assert.equal(
+        nearestMatchingPath,
+        'foo',
+        'It should return the exact path match.'
+      );
+    });
+
+    test('returns capabilities for the nearest fuzzy match if no exact match', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {
+                    Paths: [
+                      { Capabilities: ['write'], PathSpec: 'foo/*' },
+                      { Capabilities: ['write'], PathSpec: 'foo/bar/*' },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+      const path = 'foo/bar/baz';
+
+      const nearestMatchingPath = this.ability._nearestMatchingPath(path);
+
+      assert.equal(
+        nearestMatchingPath,
+        'foo/bar/*',
+        'It should return the nearest fuzzy matching path.'
+      );
+    });
+
+    test('handles wildcard prefix matches', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {
+                    Paths: [{ Capabilities: ['write'], PathSpec: 'foo/*' }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+      const path = 'foo/bar/baz';
+
+      const nearestMatchingPath = this.ability._nearestMatchingPath(path);
+
+      assert.equal(
+        nearestMatchingPath,
+        'foo/*',
+        'It should handle wildcard glob.'
+      );
+    });
+
+    test('handles wildcard suffix matches', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {
+                    Paths: [
+                      { Capabilities: ['write'], PathSpec: '*/bar' },
+                      { Capabilities: ['write'], PathSpec: '*/bar/baz' },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+      const path = 'foo/bar/baz';
+
+      const nearestMatchingPath = this.ability._nearestMatchingPath(path);
+
+      assert.equal(
+        nearestMatchingPath,
+        '*/bar/baz',
+        'It should return the nearest ancestor matching path.'
+      );
+    });
+
+    test('prioritizes wildcard suffix matches over wildcard prefix matches', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {
+                    Paths: [
+                      { Capabilities: ['write'], PathSpec: '*/bar' },
+                      { Capabilities: ['write'], PathSpec: 'foo/*' },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+      const path = 'foo/bar/baz';
+
+      const nearestMatchingPath = this.ability._nearestMatchingPath(path);
+
+      assert.equal(
+        nearestMatchingPath,
+        'foo/*',
+        'It should prioritize suffix glob wildcard of prefix glob wildcard.'
+      );
+    });
+
+    test('defaults to the glob path if there is no exact match or wildcard matches', function (assert) {
       const mockToken = Service.extend({
         aclEnabled: true,
         selfToken: { type: 'client' },
@@ -147,7 +479,10 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "*"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
+                    },
+                    'Path "foo"': {
+                      Capabilities: ['write'],
                     },
                   },
                 },
@@ -158,8 +493,370 @@ module('Unit | Ability | variable', function (hooks) {
       });
 
       this.owner.register('service:token', mockToken);
+      const path = 'foo/bar/baz';
 
-      assert.ok(this.ability.canCreate);
+      const nearestMatchingPath = this.ability._nearestMatchingPath(path);
+
+      assert.equal(
+        nearestMatchingPath,
+        '*',
+        'It should default to glob wildcard if no matches.'
+      );
+    });
+  });
+
+  module('#_doesMatchPattern', function () {
+    const edgeCaseTest = 'this is a ϗѾ test';
+
+    module('base cases', function () {
+      test('it handles an empty pattern', function (assert) {
+        // arrange
+        const pattern = '';
+        const emptyPath = '';
+        const nonEmptyPath = 'a';
+
+        // act
+        const matchingResult = this.ability._doesMatchPattern(
+          pattern,
+          emptyPath
+        );
+        const nonMatchingResult = this.ability._doesMatchPattern(
+          pattern,
+          nonEmptyPath
+        );
+
+        // assert
+        assert.ok(matchingResult, 'Empty pattern should match empty path');
+        assert.notOk(
+          nonMatchingResult,
+          'Empty pattern should not match non-empty path'
+        );
+      });
+
+      test('it handles an empty path', function (assert) {
+        // arrange
+        const emptyPath = '';
+        const emptyPattern = '';
+        const nonEmptyPattern = 'a';
+
+        // act
+        const matchingResult = this.ability._doesMatchPattern(
+          emptyPattern,
+          emptyPath
+        );
+        const nonMatchingResult = this.ability._doesMatchPattern(
+          nonEmptyPattern,
+          emptyPath
+        );
+
+        // assert
+        assert.ok(matchingResult, 'Empty path should match empty pattern');
+        assert.notOk(
+          nonMatchingResult,
+          'Empty path should not match non-empty pattern'
+        );
+      });
+
+      test('it handles a pattern without a glob', function (assert) {
+        // arrange
+        const path = '/foo';
+        const matchingPattern = '/foo';
+        const nonMatchingPattern = '/bar';
+
+        // act
+        const matchingResult = this.ability._doesMatchPattern(
+          matchingPattern,
+          path
+        );
+        const nonMatchingResult = this.ability._doesMatchPattern(
+          nonMatchingPattern,
+          path
+        );
+
+        // assert
+        assert.ok(matchingResult, 'Matches path correctly.');
+        assert.notOk(nonMatchingResult, 'Does not match non-matching path.');
+      });
+
+      test('it handles a pattern that is a lone glob', function (assert) {
+        // arrange
+        const path = '/foo';
+        const glob = '*';
+
+        // act
+        const matchingResult = this.ability._doesMatchPattern(glob, path);
+
+        // assert
+        assert.ok(matchingResult, 'Matches glob.');
+      });
+
+      test('it matches on leading glob', function (assert) {
+        // arrange
+        const pattern = '*bar';
+        const matchingPath = 'footbar';
+        const nonMatchingPath = 'rockthecasba';
+
+        // act
+        const matchingResult = this.ability._doesMatchPattern(
+          pattern,
+          matchingPath
+        );
+        const nonMatchingResult = this.ability._doesMatchPattern(
+          pattern,
+          nonMatchingPath
+        );
+
+        // assert
+        assert.ok(
+          matchingResult,
+          'Correctly matches when leading glob and matching path.'
+        );
+        assert.notOk(
+          nonMatchingResult,
+          'Does not match when leading glob and non-matching path.'
+        );
+      });
+
+      test('it matches on trailing glob', function (assert) {
+        // arrange
+        const pattern = 'foo*';
+        const matchingPath = 'footbar';
+        const nonMatchingPath = 'bar';
+
+        // act
+        const matchingResult = this.ability._doesMatchPattern(
+          pattern,
+          matchingPath
+        );
+        const nonMatchingResult = this.ability._doesMatchPattern(
+          pattern,
+          nonMatchingPath
+        );
+
+        // assert
+        assert.ok(matchingResult, 'Correctly matches on trailing glob.');
+        assert.notOk(
+          nonMatchingResult,
+          'Does not match on trailing glob if pattern does not match.'
+        );
+      });
+
+      test('it matches when glob is in middle', function (assert) {
+        // arrange
+        const pattern = 'foo*bar';
+        const matchingPath = 'footbar';
+        const nonMatchingPath = 'footba';
+
+        // act
+        const matchingResult = this.ability._doesMatchPattern(
+          pattern,
+          matchingPath
+        );
+        const nonMatchingResult = this.ability._doesMatchPattern(
+          pattern,
+          nonMatchingPath
+        );
+
+        // assert
+        assert.ok(
+          matchingResult,
+          'Correctly matches on glob in middle of path.'
+        );
+        assert.notOk(
+          nonMatchingResult,
+          'Does not match on glob in middle of path if not full pattern match.'
+        );
+      });
+    });
+
+    module('matching edge cases', function () {
+      test('it matches when string is between globs', function (assert) {
+        // arrange
+        const pattern = '*is *';
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+
+      test('it handles many non-consective globs', function (assert) {
+        // arrange
+        const pattern = '*is*a*';
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+
+      test('it handles double globs', function (assert) {
+        // arrange
+        const pattern = '**test**';
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+
+      test('it handles many consecutive globs', function (assert) {
+        // arrange
+        const pattern = '**is**a***test*';
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+
+      test('it handles white space between globs', function (assert) {
+        // arrange
+        const pattern = '* *';
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+
+      test('it handles a pattern of only globs', function (assert) {
+        // arrange
+        const pattern = '**********';
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+
+      test('it handles unicode characters', function (assert) {
+        // arrange
+        const pattern = `*Ѿ*`;
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+
+      test('it handles mixed ASCII codes', function (assert) {
+        // arrange
+        const pattern = `*is a ϗѾ *`;
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+    });
+
+    module('non-matching edge cases', function () {
+      const failingCases = [
+        {
+          case: 'test*',
+          message: 'Implicit substring match',
+        },
+        {
+          case: '*is',
+          message: 'Parial match',
+        },
+        {
+          case: '*no*',
+          message: 'Globs without match between them',
+        },
+        {
+          case: ' ',
+          message: 'Plain white space',
+        },
+        {
+          case: '* ',
+          message: 'Trailing white space',
+        },
+        {
+          case: ' *',
+          message: 'Leading white space',
+        },
+        {
+          case: '*ʤ*',
+          message: 'Non-matching unicode',
+        },
+        {
+          case: 'this*this is a test',
+          message: 'Repeated prefix',
+        },
+      ];
+
+      failingCases.forEach(({ case: failingPattern, message }) => {
+        test('should fail the specified cases', function (assert) {
+          const result = this.ability._doesMatchPattern(
+            failingPattern,
+            edgeCaseTest
+          );
+          assert.notOk(result, `${message} should not match.`);
+        });
+      });
+    });
+  });
+
+  module('#_computeLengthDiff', function () {
+    test('should return the difference in length between a path and a pattern', function (assert) {
+      // arrange
+      const path = 'foo';
+      const pattern = 'bar';
+
+      // act
+      const result = this.ability._computeLengthDiff(pattern, path);
+
+      // assert
+      assert.equal(
+        result,
+        0,
+        'it returns the difference in length between path and pattern'
+      );
+    });
+
+    test('should factor the number of globs into consideration', function (assert) {
+      // arrange
+      const pattern = 'foo*';
+      const path = 'bark';
+
+      // act
+      const result = this.ability._computeLengthDiff(pattern, path);
+
+      // assert
+      assert.equal(
+        result,
+        1,
+        'it adds the number of globs in the pattern to the difference'
+      );
+    });
+  });
+
+  module('#_smallestDifference', function () {
+    test('returns the smallest difference in the list', function (assert) {
+      // arrange
+      const path = 'foo/bar';
+      const matchingPath = 'foo/*';
+      const matches = ['*/baz', '*', matchingPath];
+
+      // act
+      const result = this.ability._smallestDifference(matches, path);
+
+      // assert
+      assert.equal(
+        result,
+        matchingPath,
+        'It should return the smallest difference path.'
+      );
     });
   });
 });


### PR DESCRIPTION
This PR creates logic for the `canCreate` permission, updates templates to properly check for this ability.

Closes [#13435](https://github.com/hashicorp/nomad/issues/13435).

Side Effect:  Update `Token` factory to enable `blue/berkshire` path to have `create` ability by default.

Enabled:
![image](https://user-images.githubusercontent.com/41024828/174805465-30e1ad84-8c86-489d-851b-f70d2bf1b1a6.png)

Disabled:
![image](https://user-images.githubusercontent.com/41024828/174805579-2a397b01-4bc2-4a02-be67-f17de7cc5cdc.png)
