### PR TITLE
Disallow canaries with CSI single-node volume requests

### DIFF
--- a/nomad/structs/csi_test.go
+++ b/nomad/structs/csi_test.go
@@ -735,7 +735,7 @@ func TestCSIVolume_Merge(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc = tc
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.v.Merge(tc.update)
 			if tc.expected == "" {

--- a/nomad/structs/volume_test.go
+++ b/nomad/structs/volume_test.go
@@ -1,6 +1,7 @@
 package structs
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
@@ -27,6 +28,7 @@ func TestVolumeRequest_Validate(t *testing.T) {
 		{
 			name: "host volume with CSI volume config",
 			expected: []string{
+				"volume has an empty source",
 				"host volumes cannot have an access mode",
 				"host volumes cannot have an attachment mode",
 				"host volumes cannot have mount options",
@@ -47,6 +49,8 @@ func TestVolumeRequest_Validate(t *testing.T) {
 		{
 			name: "CSI volume multi-reader-single-writer access mode",
 			expected: []string{
+				"volume has an empty source",
+				"CSI volumes must have an attachment mode",
 				"volume with multi-node-single-writer access mode allows only one writer",
 			},
 			taskGroupCount: 2,
@@ -58,6 +62,8 @@ func TestVolumeRequest_Validate(t *testing.T) {
 		{
 			name: "CSI volume single reader access mode",
 			expected: []string{
+				"volume has an empty source",
+				"CSI volumes must have an attachment mode",
 				"volume with single-node-reader-only access mode allows only one reader",
 			},
 			taskGroupCount: 2,
@@ -68,24 +74,43 @@ func TestVolumeRequest_Validate(t *testing.T) {
 			},
 		},
 		{
-			name:          "CSI volume per-alloc with canaries",
-			expected:      []string{"volume cannot be per_alloc when canaries are in use"},
+			name: "CSI volume per-alloc with canaries",
+			expected: []string{
+				"volume has an empty source",
+				"CSI volumes must have an attachment mode",
+				"single-node-reader-only volumes must be read-only",
+				"volume with single-node-reader-only access mode does not support canaries",
+				"volume cannot be per_alloc when canaries are in use"},
 			canariesCount: 1,
 			req: &VolumeRequest{
-				Type:     VolumeTypeCSI,
-				PerAlloc: true,
+				Type:       VolumeTypeCSI,
+				AccessMode: CSIVolumeAccessModeSingleNodeReader,
+				PerAlloc:   true,
+			},
+		},
+		{
+			name: "CSI writer volume per-alloc with canaries",
+			expected: []string{
+				"volume has an empty source",
+				"CSI volumes must have an attachment mode",
+				"volume with single-node-writer access mode does not support canaries",
+				"volume cannot be per_alloc when canaries are in use"},
+			canariesCount: 1,
+			req: &VolumeRequest{
+				Type:       VolumeTypeCSI,
+				AccessMode: CSIVolumeAccessModeSingleNodeWriter,
+				PerAlloc:   true,
 			},
 		},
 	}
 
 	for _, tc := range testCases {
-		tc = tc
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.req.Validate(tc.taskGroupCount, tc.canariesCount)
-			for _, expected := range tc.expected {
-				require.Contains(t, err.Error(), expected)
-			}
+			errs := strings.Split(strings.TrimSpace(err.Error()), "\n\t* ")
+			errs = errs[1:]
+			require.ElementsMatch(t, errs, tc.expected)
 		})
 	}
-
 }

--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -154,10 +154,16 @@ func (v *VolumeRequest) Validate(taskGroupCount, canaries int) error {
 			if taskGroupCount > 1 && !v.PerAlloc {
 				addErr("volume with %s access mode allows only one reader", v.AccessMode)
 			}
+			if canaries > 0 {
+				addErr("volume with %s access mode does not support canaries", v.AccessMode)
+			}
 		case CSIVolumeAccessModeSingleNodeWriter:
 			// note: we allow read-only mount of this volume, but only one
 			if taskGroupCount > 1 && !v.PerAlloc {
 				addErr("volume with %s access mode allows only one reader or writer", v.AccessMode)
+			}
+			if canaries > 0 {
+				addErr("volume with %s access mode does not support canaries", v.AccessMode)
 			}
 		case CSIVolumeAccessModeMultiNodeReader:
 			if !v.ReadOnly {


### PR DESCRIPTION
Added validation to ensure that canaries and CSI single-node volume requests are prevented at submit time. Closes #13380
