### PR TITLE
implement quota tracking for secure variablees

### DIFF
--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -2308,13 +2308,12 @@ func SecureVariable() *structs.SecureVariableDecrypted {
 	env := envs[envIdx]
 	domain := fake.DomainName()
 	path := strings.ReplaceAll(env+"."+domain, ".", "/")
-	// owner := fake.Person()
 	createIdx := uint64(rand.Intn(100) + 100)
 	createDT := fake.DateRange(time.Now().AddDate(0, -1, 0), time.Now())
 	sv := &structs.SecureVariableDecrypted{
 		SecureVariableMetadata: structs.SecureVariableMetadata{
 			Path:        path,
-			Namespace:   "default",
+			Namespace:   structs.DefaultNamespace,
 			CreateIndex: createIdx,
 			ModifyIndex: createIdx,
 			CreateTime:  createDT,
@@ -2393,7 +2392,7 @@ func SecureVariableEncrypted() *structs.SecureVariableEncrypted {
 	sv := &structs.SecureVariableEncrypted{
 		SecureVariableMetadata: structs.SecureVariableMetadata{
 			Path:        path,
-			Namespace:   "default",
+			Namespace:   structs.DefaultNamespace,
 			CreateIndex: createIdx,
 			ModifyIndex: createIdx,
 			CreateTime:  createDT,

--- a/nomad/secure_variables_endpoint.go
+++ b/nomad/secure_variables_endpoint.go
@@ -76,6 +76,10 @@ func (sv *SecureVariables) Upsert(
 		return err
 	}
 
+	if err := sv.enforceQuota(uArgs); err != nil {
+		return err
+	}
+
 	// Update via Raft.
 	out, index, err := sv.srv.raftApply(structs.SecureVariableUpsertRequestType, uArgs)
 	if err != nil {

--- a/nomad/secure_variables_endpoint_oss.go
+++ b/nomad/secure_variables_endpoint_oss.go
@@ -1,0 +1,10 @@
+//go:build !ent
+// +build !ent
+
+package nomad
+
+import "github.com/hashicorp/nomad/nomad/structs"
+
+func (sv *SecureVariables) enforceQuota(uArgs structs.SecureVariablesEncryptedUpsertRequest) error {
+	return nil
+}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -6610,20 +6610,6 @@ func getPreemptedAllocDesiredDescription(preemptedByAllocID string) string {
 	return fmt.Sprintf("Preempted by alloc ID %v", preemptedByAllocID)
 }
 
-// SecureVariablesQuotas queries all the quotas and is used only for
-// snapshot/restore and key rotation
-func (s *StateStore) SecureVariablesQuotas(ws memdb.WatchSet) (memdb.ResultIterator, error) {
-	txn := s.db.ReadTxn()
-
-	iter, err := txn.Get(TableSecureVariablesQuotas, indexID)
-	if err != nil {
-		return nil, err
-	}
-
-	ws.Add(iter.WatchCh())
-	return iter, nil
-}
-
 // UpsertRootKeyMeta saves root key meta or updates it in-place.
 func (s *StateStore) UpsertRootKeyMeta(index uint64, rootKeyMeta *structs.RootKeyMeta) error {
 	txn := s.db.WriteTxn(index)

--- a/nomad/structs/secure_variables.go
+++ b/nomad/structs/secure_variables.go
@@ -166,6 +166,15 @@ type SecureVariablesQuota struct {
 	ModifyIndex uint64
 }
 
+func (svq *SecureVariablesQuota) Copy() *SecureVariablesQuota {
+	if svq == nil {
+		return nil
+	}
+	nq := new(SecureVariablesQuota)
+	*nq = *svq
+	return nq
+}
+
 type SecureVariablesUpsertRequest struct {
 	Data []*SecureVariableDecrypted
 	WriteRequest


### PR DESCRIPTION
We need to track per-namespace storage usage for secure variables even
in Nomad OSS so that a cluster can be seamlessly upgraded from OSS to
ENT without having to re-calculate quota usage.

Provide a hook in the upsert RPC for enforcement of quotas in
ENT. This will be a no-op in Nomad OSS.