### PR TITLE
docs: clarify total_escaped is just an optimization

### DIFF
--- a/website/content/docs/operations/metrics-reference.mdx
+++ b/website/content/docs/operations/metrics-reference.mdx
@@ -259,7 +259,7 @@ those listed in [Key Metrics](#key-metrics) above.
 | `nomad.nomad.blocked_evals.job.cpu`                  | Amount of CPU shares requested by blocked evals of a job                       | Integer              | Gauge   | host, job, namespace                                    |
 | `nomad.nomad.blocked_evals.job.memory`               | Amount of memory requested by blocked evals of a job                           | Integer              | Gauge   | host, job, namespace                                    |
 | `nomad.nomad.blocked_evals.total_blocked`            | Count of evals in the blocked state                                            | Integer              | Gauge   | host                                                    |
-| `nomad.nomad.blocked_evals.total_escaped`            | Count of evals that have escaped computed node classes                         | Integer              | Gauge   | host                                                    |
+| `nomad.nomad.blocked_evals.total_escaped`            | Count of evals that have escaped computed node classes. This indicates a scheduler optimization was skipped and is not usually a source of concern. | Integer | Gauge | host |
 | `nomad.nomad.blocked_evals.total_quota_limit`        | Count of blocked evals due to quota limits                                     | Integer              | Gauge   | host                                                    |
 | `nomad.nomad.broker.batch_ready`                     | Count of batch evals ready to be scheduled                                     | Integer              | Gauge   | host                                                    |
 | `nomad.nomad.broker.batch_unacked`                   | Count of unacknowledged batch evals                                            | Integer              | Gauge   | host                                                    |
@@ -481,5 +481,3 @@ Raft database metrics are emitted by the `raft-boltdb` library.
 
 [tagged-metrics]: /docs/telemetry/metrics#tagged-metrics
 [s_port_plan_failure]: /s/port-plan-failure
-
-


### PR DESCRIPTION
I'm not attached to this PR, so we can throw it out if you think trying to cram in more details about a subtle metrics only confuses things further.

Also I didn't see how best to format long content in mdx tables, so we can throw it out based purely on ugliness of source. :sweat_smile: A `Metrics Codex` where we could actually write more than one sentence for a metric would be nice as I feel we end up relying on engineer's memory and code spelunking to get any nuanced meaning for metrics.