### PR TITLE
additional ACL Policy tests

### DIFF
--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -429,11 +429,11 @@ func TestSecureVariablesMatching(t *testing.T) {
 			allow: true,
 		},
 		{
-			name: "concrete namespace with overlapping wildcard path first matches",
+			name: "concrete namespace with overlapping wildcard path prefix over suffix matches",
 			policy: `namespace "ns" {
 					secure_variables {
-						path "foo/*" { capabilities = ["write"] }
 						path "*/bar" { capabilities = ["list"] }
+						path "foo/*" { capabilities = ["write"] }
 					}}`,
 			ns:    "ns",
 			path:  "foo/bar",
@@ -441,11 +441,11 @@ func TestSecureVariablesMatching(t *testing.T) {
 			allow: true,
 		},
 		{
-			name: "concrete namespace with overlapping wildcard path second denied",
+			name: "concrete namespace with overlapping wildcard path prefix over suffix denied",
 			policy: `namespace "ns" {
 					secure_variables {
-						path "foo/*" { capabilities = ["write"] }
 						path "*/bar" { capabilities = ["list"] }
+						path "foo/*" { capabilities = ["write"] }
 					}}`,
 			ns:    "ns",
 			path:  "foo/bar",

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -420,6 +420,15 @@ func TestSecureVariablesMatching(t *testing.T) {
 			allow: true,
 		},
 		{
+			name: "concrete namespace with non-prefix wildcard path matches",
+			policy: `namespace "ns" {
+					secure_variables { path "*/bar" { capabilities = ["read"] }}}`,
+			ns:    "ns",
+			path:  "foo/bar",
+			op:    "read",
+			allow: true,
+		},
+		{
 			name: "concrete namespace with wildcard path matches most specific only",
 			policy: `namespace "ns" {
 					secure_variables {

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -429,6 +429,30 @@ func TestSecureVariablesMatching(t *testing.T) {
 			allow: true,
 		},
 		{
+			name: "concrete namespace with overlapping wildcard path first matches",
+			policy: `namespace "ns" {
+					secure_variables {
+						path "foo/*" { capabilities = ["write"] }
+						path "*/bar" { capabilities = ["list"] }
+					}}`,
+			ns:    "ns",
+			path:  "foo/bar",
+			op:    "write",
+			allow: true,
+		},
+		{
+			name: "concrete namespace with overlapping wildcard path second denied",
+			policy: `namespace "ns" {
+					secure_variables {
+						path "foo/*" { capabilities = ["write"] }
+						path "*/bar" { capabilities = ["list"] }
+					}}`,
+			ns:    "ns",
+			path:  "foo/bar",
+			op:    "list",
+			allow: false,
+		},
+		{
 			name: "concrete namespace with wildcard path matches most specific only",
 			policy: `namespace "ns" {
 					secure_variables {

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -420,6 +420,19 @@ func TestSecureVariablesMatching(t *testing.T) {
 			allow: true,
 		},
 		{
+			name: "concrete namespace with wildcard path matches most specific only",
+			policy: `namespace "ns" {
+					secure_variables {
+						path "*" { capabilities = ["read"] }
+						path "foo/*" { capabilities = ["read"] }
+						path "foo/bar" { capabilities = ["list"] }
+					}}`,
+			ns:    "ns",
+			path:  "foo/bar",
+			op:    "read",
+			allow: false,
+		},
+		{
 			name: "concrete namespace with invalid concrete path fails",
 			policy: `namespace "ns" {
 					secure_variables { path "bar" { capabilities = ["read"] }}}`,


### PR DESCRIPTION
This changeset includes some additional unit tests for secure
variables ACL policies, so that we have explicit coverage of edge
cases we're discussing with the UI folks.