### PR TITLE
[ui] Reinstate Meta and Payload sections to Parameterized Child Jobs

### DIFF
--- a/ui/app/components/job-page/parameterized-child.js
+++ b/ui/app/components/job-page/parameterized-child.js
@@ -3,7 +3,7 @@ import { alias } from '@ember/object/computed';
 import Component from '@glimmer/component';
 
 export default class ParameterizedChild extends Component {
-  @alias('job.decodedPayload') payload;
+  @alias('args.job.decodedPayload') payload;
 
   @computed('payload')
   get payloadJSON() {

--- a/ui/app/templates/components/job-page/parameterized-child.hbs
+++ b/ui/app/templates/components/job-page/parameterized-child.hbs
@@ -24,12 +24,12 @@
     <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}} />
     <jobPage.ui.RecentAllocations />
     <div class="boxed-section">
-      <div class="boxed-section-head">
-        Meta
-      </div>
-      {{#if @job.definition.Meta}}
+      {{#if @job.meta}}
         <jobPage.ui.Meta />
       {{else}}
+        <div class="boxed-section-head">
+          Meta
+        </div>
         <div class="boxed-section-body">
           <div data-test-empty-meta-message class="empty-message">
             <h3 class="empty-message-headline">


### PR DESCRIPTION
Resolves #13360
Resolves #7096
Alternate fix to #11954

---

This reinstates Meta and Payload sections to dispatched children of parameterized jobs.

- The `payload` alias was missing an `args` prefix, probably because job was a former computed or injected property, but is now passed in via argument.
- the `meta` information does not exist on `@job.definition.Meta`, but is instead found at `@job.meta` — I'm unsure when this change took place, but I've given it a smoke test and it seems to show up as expected now.