### PR TITLE
ui:  handle path matching

### DIFF
--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -41,4 +41,24 @@ export default class Variable extends AbstractAbility {
       return capabilities.includes('create');
     });
   }
+
+  _nearestMatchingPath(path) {
+    const formattedPathKey = `Path "${path}"`;
+    const pathNames = Object.keys(this.allPaths);
+
+    if (pathNames.includes(formattedPathKey)) return path;
+  }
+
+  @computed('token.selfTokenPolicies.[]')
+  get allPaths() {
+    return get(this, 'token.selfTokenPolicies')
+      .toArray()
+      .reduce((paths, policy) => {
+        const [variables] = get(policy, 'rulesJSON.Namespaces').mapBy(
+          'SecureVariables'
+        );
+        paths = { ...paths, ...variables };
+        return paths;
+      }, {});
+  }
 }

--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -134,4 +134,40 @@ export default class Variable extends AbstractAbility {
       return matchingPath;
     });
   }
+
+  _doesMatchPattern(pattern, path) {
+    const parts = pattern?.split(WILDCARD_GLOB);
+    const hasLeadingGlob = pattern?.startsWith(WILDCARD_GLOB);
+    const hasTrailingGlob = pattern?.endsWith(WILDCARD_GLOB);
+    const lastPartOfPattern = parts[parts.length - 1];
+    const isPatternWithoutGlob = parts.length === 1 && !hasLeadingGlob;
+
+    if (!pattern || !path || isPatternWithoutGlob) {
+      return pattern === path;
+    }
+
+    if (pattern === WILDCARD_GLOB) {
+      return true;
+    }
+
+    let subPathToMatchOn = path;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      const idx = subPathToMatchOn?.indexOf(part);
+      const doesPathIncludeSubPattern = idx > -1;
+      const doesMatchOnFirstSubpattern = idx === 0;
+
+      if (i === 0 && !hasLeadingGlob && !doesMatchOnFirstSubpattern) {
+        return false;
+      }
+
+      if (!doesPathIncludeSubPattern) {
+        return false;
+      }
+
+      subPathToMatchOn = subPathToMatchOn.slice(0, idx + path.length);
+    }
+
+    return hasTrailingGlob || path.endsWith(lastPartOfPattern);
+  }
 }

--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -28,9 +28,9 @@ export default class Variable extends AbstractAbility {
   @or(
     'bypassAuthorization',
     'selfTokenIsManagement',
-    'policiesSupportVariableCreation'
+    'policiesSupportVariableWriting'
   )
-  canCreate;
+  canWrite;
 
   @computed('rulesForNamespace.@each.capabilities')
   get policiesSupportVariableView() {
@@ -40,12 +40,12 @@ export default class Variable extends AbstractAbility {
   }
 
   @computed('rulesForNamespace.@each.capabilities', 'path')
-  get policiesSupportVariableCreation() {
+  get policiesSupportVariableWriting() {
     const matchingPath = this._nearestMatchingPath(this.path);
     return this.rulesForNamespace.some((rules) => {
       const keyName = `SecureVariables.Path "${matchingPath}".Capabilities`;
       const capabilities = get(rules, keyName) || [];
-      return capabilities.includes('create');
+      return capabilities.includes('write');
     });
   }
 

--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -32,6 +32,13 @@ export default class Variable extends AbstractAbility {
   )
   canWrite;
 
+  @or(
+    'bypassAuthorization',
+    'selfTokenIsManagement',
+    'policiesSupportVariableDestroy'
+  )
+  canDestroy;
+
   @computed('rulesForNamespace.@each.capabilities')
   get policiesSupportVariableView() {
     return this.rulesForNamespace.some((rules) => {
@@ -46,6 +53,16 @@ export default class Variable extends AbstractAbility {
       const keyName = `SecureVariables.Path "${matchingPath}".Capabilities`;
       const capabilities = get(rules, keyName) || [];
       return capabilities.includes('write');
+    });
+  }
+
+  @computed('rulesForNamespace.@each.capabilities', 'path')
+  get policiesSupportVariableDestroy() {
+    const matchingPath = this._nearestMatchingPath(this.path);
+    return this.rulesForNamespace.some((rules) => {
+      const keyName = `SecureVariables.Path "${matchingPath}".Capabilities`;
+      const capabilities = get(rules, keyName) || [];
+      return capabilities.includes('destroy');
     });
   }
 

--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -15,6 +15,7 @@
         disabled={{not @model.isNew}}
         {{on "input" this.validatePath}}
         {{autofocus}}
+        data-test-path-input
       />
     </label>
     {{#if this.duplicatePathWarning}}
@@ -46,6 +47,7 @@
           class="input"
           {{autofocus ignore=(eq iter 0)}}
           {{on "input" (fn this.validateKey entry)}}
+          data-test-var-key
         />
       </label>
       <SecureVariableForm::InputGroup @entry={{entry}} />
@@ -79,6 +81,7 @@
       disabled={{this.shouldDisableSave}}
       class="button is-primary"
       type="submit"
+      data-test-submit-var
     >
       Save
       {{pluralize "Variable" @this.keyValues.length}}

--- a/ui/app/components/secure-variable-form/input-group.hbs
+++ b/ui/app/components/secure-variable-form/input-group.hbs
@@ -6,8 +6,9 @@
     @type={{this.inputType}}
     @value={{@entry.value}}
     class="input value-input"
-    autocomplete="new-password"
     {{! prevent auto-fill }}
+    autocomplete="new-password"
+    data-test-var-value
   />
   <button
     class="show-hide-values button is-light"

--- a/ui/app/templates/variables/index.hbs
+++ b/ui/app/templates/variables/index.hbs
@@ -16,6 +16,7 @@
         <LinkTo
           @route="variables.new"
           class="button is-primary"
+          data-test-create-var
         >
           Create Secure Variable
         </LinkTo>
@@ -25,6 +26,7 @@
           aria-label="You don’t have sufficient permissions"
           disabled
           type="button"
+          data-test-disabled-create-var
         >
           Create Secure Variable
         </button>

--- a/ui/app/templates/variables/index.hbs
+++ b/ui/app/templates/variables/index.hbs
@@ -12,7 +12,7 @@
     </div>
     <div class="toolbar-item is-right-aligned is-mobile-full-width">
       <div class="button-bar">
-      {{#if (can "create variable" path="*")}}
+      {{#if (can "write variable" path="*")}}
         <LinkTo
           @route="variables.new"
           class="button is-primary"

--- a/ui/app/templates/variables/path.hbs
+++ b/ui/app/templates/variables/path.hbs
@@ -6,7 +6,7 @@
     <div class="toolbar">
       <div class="toolbar-item is-right-aligned is-mobile-full-width">
         <div class="button-bar">
-        {{#if (can "create variable" path=this.model.absolutePath)}}
+        {{#if (can "write variable" path=this.model.absolutePath)}}
           <LinkTo
             @route="variables.new"
             @query={{hash path=(concat this.model.absolutePath "/")}}

--- a/ui/app/templates/variables/variable/index.hbs
+++ b/ui/app/templates/variables/variable/index.hbs
@@ -42,18 +42,20 @@
       </div>
       {{/if}}
     {{/unless}}
-    <TwoStepButton
-      data-test-delete-button
-      @alignRight={{true}}
-      @idleText="Delete"
-      @cancelText="Cancel"
-      @confirmText="Yes, delete"
-      @confirmationMessage="Are you sure you want to delete this variable and all its items?"
-      @awaitingConfirmation={{this.deleteVariableFile.isRunning}}
-      @onConfirm={{perform this.deleteVariableFile}}
-      @onPrompt={{this.onDeletePrompt}}
-      @onCancel={{this.onDeleteCancel}}
-    />
+    {{#if (can "destroy variable" path=this.model.absolutePath)}}
+      <TwoStepButton
+        data-test-delete-button
+        @alignRight={{true}}
+        @idleText="Delete"
+        @cancelText="Cancel"
+        @confirmText="Yes, delete"
+        @confirmationMessage="Are you sure you want to delete this variable and all its items?"
+        @awaitingConfirmation={{this.deleteVariableFile.isRunning}}
+        @onConfirm={{perform this.deleteVariableFile}}
+        @onPrompt={{this.onDeletePrompt}}
+        @onCancel={{this.onDeleteCancel}}
+      />
+    {{/if}}
   </div>
 </h1>
 <ListTable data-test-eval-table @source={{this.model.keyValues}} as |t|>

--- a/ui/app/templates/variables/variable/index.hbs
+++ b/ui/app/templates/variables/variable/index.hbs
@@ -31,6 +31,7 @@
     {{#unless this.isDeleting}}
       <div class="two-step-button">
         <LinkTo
+          data-test-edit-button
           class="button is-info is-inverted is-small"
           @model={{this.model}}
           @route="variables.variable.edit"
@@ -55,7 +56,7 @@
 </h1>
 <ListTable data-test-eval-table @source={{this.model.keyValues}} as |t|>
   <t.body as |row|>
-    <tr>
+    <tr data-test-var={{row.model.key}}>
       <td>
         {{row.model.key}}
       </td>

--- a/ui/app/templates/variables/variable/index.hbs
+++ b/ui/app/templates/variables/variable/index.hbs
@@ -29,6 +29,7 @@
   </div>
   <div>
     {{#unless this.isDeleting}}
+      {{#if (can "create variable" path=this.model.absolutePath)}}
       <div class="two-step-button">
         <LinkTo
           data-test-edit-button
@@ -39,6 +40,7 @@
           Edit
         </LinkTo>
       </div>
+      {{/if}}
     {{/unless}}
     <TwoStepButton
       data-test-delete-button

--- a/ui/app/templates/variables/variable/index.hbs
+++ b/ui/app/templates/variables/variable/index.hbs
@@ -29,7 +29,7 @@
   </div>
   <div>
     {{#unless this.isDeleting}}
-      {{#if (can "create variable" path=this.model.absolutePath)}}
+      {{#if (can "write variable" path=this.model.absolutePath)}}
       <div class="two-step-button">
         <LinkTo
           data-test-edit-button

--- a/ui/mirage/factories/token.js
+++ b/ui/mirage/factories/token.js
@@ -38,8 +38,19 @@ namespace "default" {
   policy = "read"
   capabilities = ["list-jobs", "alloc-exec", "read-logs"]
   secure_variables {
+    # full access to secrets in all project paths
+    path "blue/*" {
+      capabilities = ["write", "read", "destroy", "list"]
+    }
+
+    # full access to secrets in all project paths
     path "*" {
-      capabilities = ["list"]
+      capabilities = ["write", "read", "destroy", "list"]
+    }
+
+    # read/list access within a "system" path belonging to administrators
+    path "system/*" {
+      capabilities = ["read", "list"]
     }
   }
 }
@@ -55,12 +66,20 @@ node {
               Name: 'default',
               Capabilities: ['list-jobs', 'alloc-exec', 'read-logs'],
               SecureVariables: {
-                'Path "*"': {
-                  Capabilities: ['list', 'create'],
-                },
-                'Path "blue/berkshire"': {
-                  Capabilities: ['list', 'create', 'edit', 'delete'],
-                },
+                Paths: [
+                  {
+                    Capabilities: ['write', 'read', 'destroy', 'list'],
+                    PathSpec: 'blue/*',
+                  },
+                  {
+                    Capabilities: ['write', 'read', 'destroy', 'list'],
+                    PathSpec: '*',
+                  },
+                  {
+                    Capabilities: ['read', 'list'],
+                    PathSpec: 'system/*',
+                  },
+                ],
               },
             },
           ],

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -223,6 +223,9 @@ module('Acceptance | secure variables', function (hooks) {
       server.createList('variable', 3);
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
+      const policy = server.db.policies.find('Variable Maker');
+      policy.rulesJSON.Namespaces[0].SecureVariables['Path "*"'].Capabilities =
+        ['list', 'create'];
       await Variables.visit();
       await click('[data-test-file-row]');
       // End Test Set-up

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -309,7 +309,7 @@ module('Acceptance | secure variables', function (hooks) {
       assert
         .dom('[data-test-delete-button]')
         .exists('The delete button is enabled in the view.');
-      await click('[data-test-delete-button]');
+      await click('[data-test-idle-button]');
 
       assert
         .dom('[data-test-confirmation-message]')
@@ -319,7 +319,7 @@ module('Acceptance | secure variables', function (hooks) {
 
       assert.equal(
         currentRouteName(),
-        'variables',
+        'variables.index',
         'Navigates user back to variables list page after destroying a variable.'
       );
 

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -1,10 +1,16 @@
-import { module, test } from 'qunit';
-import { currentURL } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
+import {
+  currentRouteName,
+  currentURL,
+  click,
+  find,
+  findAll,
+  typeIn,
+} from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
 import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import defaultScenario from '../../mirage/scenarios/default';
-import { click, find, findAll, typeIn } from '@ember/test-helpers';
 
 import Variables from 'nomad-ui/tests/pages/variables';
 import Layout from 'nomad-ui/tests/pages/layout';
@@ -145,5 +151,136 @@ module('Acceptance | secure variables', function (hooks) {
     window.localStorage.nomadTokenSecret = variablesToken.secretId;
     await Variables.visit();
     await a11yAudit(assert);
+  });
+
+  module('create flow', function () {
+    test('allows a user with correct permissions to create a secure variable', async function (assert) {
+      // Arrange Test Set-up
+      defaultScenario(server);
+      server.createList('variable', 3);
+      const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
+      window.localStorage.nomadTokenSecret = variablesToken.secretId;
+      await Variables.visit();
+      // End Test Set-up
+
+      assert
+        .dom('[data-test-create-var]')
+        .exists(
+          'It should display an enabled button to create a secure variable'
+        );
+      await click('[data-test-create-var]');
+
+      assert.equal(currentRouteName(), 'variables.new');
+
+      await typeIn('[data-test-path-input]', 'foo/bar');
+      await typeIn('[data-test-var-key]', 'kiki');
+      await typeIn('[data-test-var-value]', 'do you love me');
+      await click('[data-test-submit-var]');
+
+      assert.equal(
+        currentRouteName(),
+        'variables.variable.index',
+        'Navigates user back to variables list page after creating variable.'
+      );
+      assert
+        .dom('.flash-message.alert.alert-success')
+        .exists('Shows a success toast notification on creation.');
+      assert
+        .dom('[data-test-var=kiki]')
+        .exists('The new variable key should appear in the list.');
+
+      // Reset Token
+      window.localStorage.nomadTokenSecret = null;
+    });
+
+    test('prevents users from creating a secure variable without proper permissions', async function (assert) {
+      // Arrange Test Set-up
+      defaultScenario(server);
+      server.createList('variable', 3);
+      const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
+      window.localStorage.nomadTokenSecret = variablesToken.secretId;
+      const policy = server.db.policies.find('Variable Maker');
+      policy.rulesJSON.Namespaces[0].SecureVariables['Path "*"'].Capabilities =
+        ['list'];
+      await Variables.visit();
+      // End Test Set-up
+
+      assert
+        .dom('[data-test-disabled-create-var]')
+        .exists(
+          'It should display an disabled button to create a secure variable on the main listings page'
+        );
+
+      // Reset Token
+      window.localStorage.nomadTokenSecret = null;
+    });
+  });
+
+  module('edit flow', function () {
+    test('allows a user with correct permissions to edit a secure variable', async function (assert) {
+      // Arrange Test Set-up
+      defaultScenario(server);
+      server.createList('variable', 3);
+      const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
+      window.localStorage.nomadTokenSecret = variablesToken.secretId;
+      await Variables.visit();
+      await click('[data-test-file-row]');
+      // End Test Set-up
+
+      assert.equal(currentRouteName(), 'variables.variable.index');
+      assert
+        .dom('[data-test-edit-button]')
+        .exists('The edit button is enabled in the view.');
+      await click('[data-test-edit-button]');
+      assert.equal(
+        currentRouteName(),
+        'variables.variable.edit',
+        'Clicking the button navigates you to editing view.'
+      );
+
+      assert.dom('[data-test-path-input]').isDisabled('Path cannot be edited');
+
+      document.querySelector('[data-test-var-key]').value = ''; // clear current input
+      await typeIn('[data-test-var-key]', 'kiki');
+      await typeIn('[data-test-var-value]', 'do you love me');
+      await click('[data-test-submit-var]');
+
+      assert.equal(
+        currentRouteName(),
+        'variables.variable.index',
+        'Navigates user back to variables list page after creating variable.'
+      );
+      assert
+        .dom('.flash-message.alert.alert-success')
+        .exists('Shows a success toast notification on edit.');
+      assert
+        .dom('[data-test-var=kiki]')
+        .exists('The edited variable key should appear in the list.');
+
+      // Reset Token
+      window.localStorage.nomadTokenSecret = null;
+    });
+
+    test('prevents users from editing a secure variable without proper permissions', async function (assert) {
+      // Arrange Test Set-up
+      defaultScenario(server);
+      server.createList('variable', 3);
+      const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
+      window.localStorage.nomadTokenSecret = variablesToken.secretId;
+      const policy = server.db.policies.find('Variable Maker');
+      policy.rulesJSON.Namespaces[0].SecureVariables['Path "*"'].Capabilities =
+        ['list'];
+      await Variables.visit();
+      await click('[data-test-file-row]');
+      // End Test Set-up
+
+      assert.equal(currentRouteName(), 'variables.variable.index');
+      assert
+        .dom('[data-test-edit-button]')
+        .doesNotExist('The edit button is hidden in the view.');
+
+      // Reset Token
+      window.localStorage.nomadTokenSecret = null;
+    });
   });
 });

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -200,8 +200,9 @@ module('Acceptance | secure variables', function (hooks) {
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
       const policy = server.db.policies.find('Variable Maker');
-      policy.rulesJSON.Namespaces[0].SecureVariables['Path "*"'].Capabilities =
-        ['list'];
+      policy.rulesJSON.Namespaces[0].SecureVariables.Paths.find(
+        (path) => path.PathSpec === '*'
+      ).Capabilities = ['list'];
       await Variables.visit();
       // End Test Set-up
 
@@ -224,8 +225,9 @@ module('Acceptance | secure variables', function (hooks) {
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
       const policy = server.db.policies.find('Variable Maker');
-      policy.rulesJSON.Namespaces[0].SecureVariables['Path "*"'].Capabilities =
-        ['list', 'create'];
+      policy.rulesJSON.Namespaces[0].SecureVariables.Paths.find(
+        (path) => path.PathSpec === '*'
+      ).Capabilities = ['list', 'write'];
       await Variables.visit();
       await click('[data-test-file-row]');
       // End Test Set-up
@@ -271,8 +273,9 @@ module('Acceptance | secure variables', function (hooks) {
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
       const policy = server.db.policies.find('Variable Maker');
-      policy.rulesJSON.Namespaces[0].SecureVariables['Path "*"'].Capabilities =
-        ['list'];
+      policy.rulesJSON.Namespaces[0].SecureVariables.Paths.find(
+        (path) => path.PathSpec === '*'
+      ).Capabilities = ['list'];
       await Variables.visit();
       await click('[data-test-file-row]');
       // End Test Set-up
@@ -281,6 +284,67 @@ module('Acceptance | secure variables', function (hooks) {
       assert
         .dom('[data-test-edit-button]')
         .doesNotExist('The edit button is hidden in the view.');
+
+      // Reset Token
+      window.localStorage.nomadTokenSecret = null;
+    });
+  });
+
+  module('delete flow', function () {
+    test('allows a user with correct permissions to delete a secure variable', async function (assert) {
+      // Arrange Test Set-up
+      defaultScenario(server);
+      server.createList('variable', 3);
+      const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
+      window.localStorage.nomadTokenSecret = variablesToken.secretId;
+      const policy = server.db.policies.find('Variable Maker');
+      policy.rulesJSON.Namespaces[0].SecureVariables.Paths.find(
+        (path) => path.PathSpec === '*'
+      ).Capabilities = ['list', 'destroy'];
+      await Variables.visit();
+      await click('[data-test-file-row]');
+      // End Test Set-up
+
+      assert.equal(currentRouteName(), 'variables.variable.index');
+      assert
+        .dom('[data-test-delete-button]')
+        .exists('The delete button is enabled in the view.');
+      await click('[data-test-delete-button]');
+
+      assert
+        .dom('[data-test-confirmation-message]')
+        .exists('Deleting a variable requires two-step confirmation.');
+
+      await click('[data-test-confirm-button]');
+
+      assert.equal(
+        currentRouteName(),
+        'variables',
+        'Navigates user back to variables list page after destroying a variable.'
+      );
+
+      // Reset Token
+      window.localStorage.nomadTokenSecret = null;
+    });
+
+    test('prevents users from delete a secure variable without proper permissions', async function (assert) {
+      // Arrange Test Set-up
+      defaultScenario(server);
+      server.createList('variable', 3);
+      const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
+      window.localStorage.nomadTokenSecret = variablesToken.secretId;
+      const policy = server.db.policies.find('Variable Maker');
+      policy.rulesJSON.Namespaces[0].SecureVariables.Paths.find(
+        (path) => path.PathSpec === '*'
+      ).Capabilities = ['list'];
+      await Variables.visit();
+      await click('[data-test-file-row]');
+      // End Test Set-up
+
+      assert.equal(currentRouteName(), 'variables.variable.index');
+      assert
+        .dom('[data-test-delete-button]')
+        .doesNotExist('The delete button is hidden in the view.');
 
       // Reset Token
       window.localStorage.nomadTokenSecret = null;

--- a/ui/tests/unit/abilities/variable-test.js
+++ b/ui/tests/unit/abilities/variable-test.js
@@ -425,4 +425,306 @@ module('Unit | Ability | variable', function (hooks) {
       );
     });
   });
+
+  module('#_doesMatchPattern', function () {
+    const edgeCaseTest = 'this is a ϗѾ test';
+
+    module('base cases', function () {
+      test('it handles an empty pattern', function (assert) {
+        // arrange
+        const pattern = '';
+        const emptyPath = '';
+        const nonEmptyPath = 'a';
+
+        // act
+        const matchingResult = this.ability._doesMatchPattern(
+          pattern,
+          emptyPath
+        );
+        const nonMatchingResult = this.ability._doesMatchPattern(
+          pattern,
+          nonEmptyPath
+        );
+
+        // assert
+        assert.ok(matchingResult, 'Empty pattern should match empty path');
+        assert.notOk(
+          nonMatchingResult,
+          'Empty pattern should not match non-empty path'
+        );
+      });
+
+      test('it handles an empty path', function (assert) {
+        // arrange
+        const emptyPath = '';
+        const emptyPattern = '';
+        const nonEmptyPattern = 'a';
+
+        // act
+        const matchingResult = this.ability._doesMatchPattern(
+          emptyPattern,
+          emptyPath
+        );
+        const nonMatchingResult = this.ability._doesMatchPattern(
+          nonEmptyPattern,
+          emptyPath
+        );
+
+        // assert
+        assert.ok(matchingResult, 'Empty path should match empty pattern');
+        assert.notOk(
+          nonMatchingResult,
+          'Empty path should not match non-empty pattern'
+        );
+      });
+
+      test('it handles a pattern without a glob', function (assert) {
+        // arrange
+        const path = '/foo';
+        const matchingPattern = '/foo';
+        const nonMatchingPattern = '/bar';
+
+        // act
+        const matchingResult = this.ability._doesMatchPattern(
+          matchingPattern,
+          path
+        );
+        const nonMatchingResult = this.ability._doesMatchPattern(
+          nonMatchingPattern,
+          path
+        );
+
+        // assert
+        assert.ok(matchingResult, 'Matches path correctly.');
+        assert.notOk(nonMatchingResult, 'Does not match non-matching path.');
+      });
+
+      test('it handles a pattern that is a lone glob', function (assert) {
+        // arrange
+        const path = '/foo';
+        const glob = '*';
+
+        // act
+        const matchingResult = this.ability._doesMatchPattern(glob, path);
+
+        // assert
+        assert.ok(matchingResult, 'Matches glob.');
+      });
+
+      test('it matches on leading glob', function (assert) {
+        // arrange
+        const pattern = '*bar';
+        const matchingPath = 'footbar';
+        const nonMatchingPath = 'rockthecasba';
+
+        // act
+        const matchingResult = this.ability._doesMatchPattern(
+          pattern,
+          matchingPath
+        );
+        const nonMatchingResult = this.ability._doesMatchPattern(
+          pattern,
+          nonMatchingPath
+        );
+
+        // assert
+        assert.ok(
+          matchingResult,
+          'Correctly matches when leading glob and matching path.'
+        );
+        assert.notOk(
+          nonMatchingResult,
+          'Does not match when leading glob and non-matching path.'
+        );
+      });
+
+      test('it matches on trailing glob', function (assert) {
+        // arrange
+        const pattern = 'foo*';
+        const matchingPath = 'footbar';
+        const nonMatchingPath = 'bar';
+
+        // act
+        const matchingResult = this.ability._doesMatchPattern(
+          pattern,
+          matchingPath
+        );
+        const nonMatchingResult = this.ability._doesMatchPattern(
+          pattern,
+          nonMatchingPath
+        );
+
+        // assert
+        assert.ok(matchingResult, 'Correctly matches on trailing glob.');
+        assert.notOk(
+          nonMatchingResult,
+          'Does not match on trailing glob if pattern does not match.'
+        );
+      });
+
+      test('it matches when glob is in middle', function (assert) {
+        // arrange
+        const pattern = 'foo*bar';
+        const matchingPath = 'footbar';
+        const nonMatchingPath = 'footba';
+
+        // act
+        const matchingResult = this.ability._doesMatchPattern(
+          pattern,
+          matchingPath
+        );
+        const nonMatchingResult = this.ability._doesMatchPattern(
+          pattern,
+          nonMatchingPath
+        );
+
+        // assert
+        assert.ok(
+          matchingResult,
+          'Correctly matches on glob in middle of path.'
+        );
+        assert.notOk(
+          nonMatchingResult,
+          'Does not match on glob in middle of path if not full pattern match.'
+        );
+      });
+    });
+
+    module('matching edge cases', function () {
+      test('it matches when string is between globs', function (assert) {
+        // arrange
+        const pattern = '*is *';
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+
+      test('it handles many non-consective globs', function (assert) {
+        // arrange
+        const pattern = '*is*a*';
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+
+      test('it handles double globs', function (assert) {
+        // arrange
+        const pattern = '**test**';
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+
+      test('it handles many consecutive globs', function (assert) {
+        // arrange
+        const pattern = '**is**a***test*';
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+
+      test('it handles white space between globs', function (assert) {
+        // arrange
+        const pattern = '* *';
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+
+      test('it handles a pattern of only globs', function (assert) {
+        // arrange
+        const pattern = '**********';
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+
+      test('it handles unicode characters', function (assert) {
+        // arrange
+        const pattern = `*Ѿ*`;
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+
+      test('it handles mixed ASCII codes', function (assert) {
+        // arrange
+        const pattern = `*is a ϗѾ *`;
+
+        // act
+        const result = this.ability._doesMatchPattern(pattern, edgeCaseTest);
+
+        // assert
+        assert.ok(result);
+      });
+    });
+
+    module('non-matching edge cases', function () {
+      const failingCases = [
+        {
+          case: 'test*',
+          message: 'Implicit substring match',
+        },
+        {
+          case: '*is',
+          message: 'Parial match',
+        },
+        {
+          case: '*no*',
+          message: 'Globs without match between them',
+        },
+        {
+          case: ' ',
+          message: 'Plain white space',
+        },
+        {
+          case: '* ',
+          message: 'Trailing white space',
+        },
+        {
+          case: ' *',
+          message: 'Leading white space',
+        },
+        {
+          case: '*ʤ*',
+          message: 'Non-matching unicode',
+        },
+        {
+          case: 'this*this is a test',
+          message: 'Repeated prefix',
+        },
+      ];
+
+      failingCases.forEach(({ case: failingPattern, message }) => {
+        test('should fail the specified cases', function (assert) {
+          const result = this.ability._doesMatchPattern(
+            failingPattern,
+            edgeCaseTest
+          );
+          assert.notOk(result, `${message} should not match.`);
+        });
+      });
+    });
+  });
 });

--- a/ui/tests/unit/abilities/variable-test.js
+++ b/ui/tests/unit/abilities/variable-test.js
@@ -727,4 +727,57 @@ module('Unit | Ability | variable', function (hooks) {
       });
     });
   });
+
+  module('#_computeLengthDiff', function () {
+    test('should return the difference in length between a path and a pattern', function (assert) {
+      // arrange
+      const path = 'foo';
+      const pattern = 'bar';
+
+      // act
+      const result = this.ability._computeLengthDiff(pattern, path);
+
+      // assert
+      assert.equal(
+        result,
+        0,
+        'it returns the difference in length between path and pattern'
+      );
+    });
+
+    test('should factor the number of globs into consideration', function (assert) {
+      // arrange
+      const pattern = 'foo*';
+      const path = 'bark';
+
+      // act
+      const result = this.ability._computeLengthDiff(pattern, path);
+
+      // assert
+      assert.equal(
+        result,
+        1,
+        'it adds the number of globs in the pattern to the difference'
+      );
+    });
+  });
+
+  module('#_smallestDifference', function () {
+    test('returns the smallest difference in the list', function (assert) {
+      // arrange
+      const path = 'foo/bar';
+      const matchingPath = 'foo/*';
+      const matches = ['*/baz', '*', matchingPath];
+
+      // act
+      const result = this.ability._smallestDifference(matches, path);
+
+      // assert
+      assert.equal(
+        result,
+        matchingPath,
+        'It should return the smallest difference path.'
+      );
+    });
+  });
 });

--- a/ui/tests/unit/abilities/variable-test.js
+++ b/ui/tests/unit/abilities/variable-test.js
@@ -161,6 +161,45 @@ module('Unit | Ability | variable', function (hooks) {
 
       assert.ok(this.ability.canCreate);
     });
+
+    test('it handles namespace matching', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {
+                    'Path "foo/bar"': {
+                      Capabilities: ['list'],
+                    },
+                  },
+                },
+                {
+                  Name: 'pablo',
+                  Capabilities: [],
+                  SecureVariables: {
+                    'Path "foo/bar"': {
+                      Capabilities: ['create'],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+      this.ability.path = 'foo/bar';
+      this.ability.namespace = 'pablo';
+
+      assert.ok(this.ability.canCreate);
+    });
   });
 
   module('#_nearestMatchingPath', function () {

--- a/ui/tests/unit/abilities/variable-test.js
+++ b/ui/tests/unit/abilities/variable-test.js
@@ -162,4 +162,56 @@ module('Unit | Ability | variable', function (hooks) {
       assert.ok(this.ability.canCreate);
     });
   });
+
+  module('#capabiltiesOfNearestPath', function () {
+    test('returns capabilities for an exact path match', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {
+                    'Path "foo"': {
+                      Capabilities: ['create'],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+      const path = 'foo';
+
+      const nearestMatchingPath = this.ability._nearestMatchingPath(path);
+
+      assert.equal(
+        nearestMatchingPath,
+        'foo',
+        'It should return the exact path match.'
+      );
+    });
+    test('returns capabilities for the nearest ancestor if no exact match', function (assert) {
+      assert.ok(false, 'Write an assertion message here.');
+    });
+    test('handles wildcard prefix matches', function (assert) {
+      assert.ok(false, 'Write an assertion message here.');
+    });
+    test('handles wildcard suffix matches', function (assert) {
+      assert.ok(false, 'Write an assertion message here.');
+    });
+    test('prioritizes wildcard prefix matches over wildcard suffix matches', function (assert) {
+      assert.ok(false, 'Write an assertion message here.');
+    });
+    test('defaults to the glob path if there is no exact match or wildcard matches', function (assert) {
+      assert.ok(false, 'Write an assertion message here.');
+    });
+  });
 });

--- a/ui/tests/unit/abilities/variable-test.js
+++ b/ui/tests/unit/abilities/variable-test.js
@@ -109,7 +109,7 @@ module('Unit | Ability | variable', function (hooks) {
 
       this.owner.register('service:token', mockToken);
 
-      assert.notOk(this.ability.canCreate);
+      assert.notOk(this.ability.canWrite);
     });
 
     test('it permits creating variables when token type is management', function (assert) {
@@ -120,7 +120,7 @@ module('Unit | Ability | variable', function (hooks) {
 
       this.owner.register('service:token', mockToken);
 
-      assert.ok(this.ability.canCreate);
+      assert.ok(this.ability.canWrite);
     });
 
     test('it permits creating variables when acl is disabled', function (assert) {
@@ -131,10 +131,10 @@ module('Unit | Ability | variable', function (hooks) {
 
       this.owner.register('service:token', mockToken);
 
-      assert.ok(this.ability.canCreate);
+      assert.ok(this.ability.canWrite);
     });
 
-    test('it permits creating variables when token has SecureVariables with create capabilities in its rules', function (assert) {
+    test('it permits creating variables when token has SecureVariables with write capabilities in its rules', function (assert) {
       const mockToken = Service.extend({
         aclEnabled: true,
         selfToken: { type: 'client' },
@@ -147,7 +147,7 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "*"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },
@@ -159,7 +159,7 @@ module('Unit | Ability | variable', function (hooks) {
 
       this.owner.register('service:token', mockToken);
 
-      assert.ok(this.ability.canCreate);
+      assert.ok(this.ability.canWrite);
     });
 
     test('it handles namespace matching', function (assert) {
@@ -184,7 +184,7 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "foo/bar"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },
@@ -198,7 +198,7 @@ module('Unit | Ability | variable', function (hooks) {
       this.ability.path = 'foo/bar';
       this.ability.namespace = 'pablo';
 
-      assert.ok(this.ability.canCreate);
+      assert.ok(this.ability.canWrite);
     });
   });
 
@@ -216,7 +216,7 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "foo"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },
@@ -251,10 +251,10 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "foo/*"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                     'Path "foo/bar/*"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },
@@ -289,7 +289,7 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "foo/*"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },
@@ -324,10 +324,10 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "*/bar"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                     'Path "*/bar/baz"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },
@@ -362,10 +362,10 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "*/bar"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                     'Path "foo/*"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },
@@ -400,10 +400,10 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "*"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                     'Path "foo"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },

--- a/ui/tests/unit/abilities/variable-test.js
+++ b/ui/tests/unit/abilities/variable-test.js
@@ -146,9 +146,7 @@ module('Unit | Ability | variable', function (hooks) {
                   Name: 'default',
                   Capabilities: [],
                   SecureVariables: {
-                    'Path "*"': {
-                      Capabilities: ['write'],
-                    },
+                    Paths: [{ Capabilities: ['write'], PathSpec: '*' }],
                   },
                 },
               ],
@@ -174,18 +172,14 @@ module('Unit | Ability | variable', function (hooks) {
                   Name: 'default',
                   Capabilities: [],
                   SecureVariables: {
-                    'Path "foo/bar"': {
-                      Capabilities: ['list'],
-                    },
+                    Paths: [{ Capabilities: ['list'], PathSpec: 'foo/bar' }],
                   },
                 },
                 {
                   Name: 'pablo',
                   Capabilities: [],
                   SecureVariables: {
-                    'Path "foo/bar"': {
-                      Capabilities: ['write'],
-                    },
+                    Paths: [{ Capabilities: ['write'], PathSpec: 'foo/bar' }],
                   },
                 },
               ],
@@ -210,7 +204,7 @@ module('Unit | Ability | variable', function (hooks) {
 
       this.owner.register('service:token', mockToken);
 
-      assert.notOk(this.ability.canWrite);
+      assert.notOk(this.ability.canDestroy);
     });
 
     test('it permits destroying variables when token type is management', function (assert) {
@@ -221,10 +215,10 @@ module('Unit | Ability | variable', function (hooks) {
 
       this.owner.register('service:token', mockToken);
 
-      assert.ok(this.ability.canWrite);
+      assert.ok(this.ability.canDestroy);
     });
 
-    test('it permits creating variables when acl is disabled', function (assert) {
+    test('it permits destroying variables when acl is disabled', function (assert) {
       const mockToken = Service.extend({
         aclEnabled: false,
         selfToken: { type: 'client' },
@@ -232,7 +226,7 @@ module('Unit | Ability | variable', function (hooks) {
 
       this.owner.register('service:token', mockToken);
 
-      assert.ok(this.ability.canWrite);
+      assert.ok(this.ability.canDestroy);
     });
 
     test('it permits destroying variables when token has SecureVariables with write capabilities in its rules', function (assert) {
@@ -247,9 +241,7 @@ module('Unit | Ability | variable', function (hooks) {
                   Name: 'default',
                   Capabilities: [],
                   SecureVariables: {
-                    'Path "*"': {
-                      Capabilities: ['destroy'],
-                    },
+                    Paths: [{ Capabilities: ['destroy'], PathSpec: '*' }],
                   },
                 },
               ],
@@ -275,18 +267,14 @@ module('Unit | Ability | variable', function (hooks) {
                   Name: 'default',
                   Capabilities: [],
                   SecureVariables: {
-                    'Path "foo/bar"': {
-                      Capabilities: ['list'],
-                    },
+                    Paths: [{ Capabilities: ['list'], PathSpec: 'foo/bar' }],
                   },
                 },
                 {
                   Name: 'pablo',
                   Capabilities: [],
                   SecureVariables: {
-                    'Path "foo/bar"': {
-                      Capabilities: ['destroy'],
-                    },
+                    Paths: [{ Capabilities: ['destroy'], PathSpec: 'foo/bar' }],
                   },
                 },
               ],
@@ -316,9 +304,7 @@ module('Unit | Ability | variable', function (hooks) {
                   Name: 'default',
                   Capabilities: [],
                   SecureVariables: {
-                    'Path "foo"': {
-                      Capabilities: ['write'],
-                    },
+                    Paths: [{ Capabilities: ['write'], PathSpec: 'foo' }],
                   },
                 },
               ],
@@ -339,7 +325,7 @@ module('Unit | Ability | variable', function (hooks) {
       );
     });
 
-    test('returns capabilities for the nearest ancestor if no exact match', function (assert) {
+    test('returns capabilities for the nearest fuzzy match if no exact match', function (assert) {
       const mockToken = Service.extend({
         aclEnabled: true,
         selfToken: { type: 'client' },
@@ -351,12 +337,10 @@ module('Unit | Ability | variable', function (hooks) {
                   Name: 'default',
                   Capabilities: [],
                   SecureVariables: {
-                    'Path "foo/*"': {
-                      Capabilities: ['write'],
-                    },
-                    'Path "foo/bar/*"': {
-                      Capabilities: ['write'],
-                    },
+                    Paths: [
+                      { Capabilities: ['write'], PathSpec: 'foo/*' },
+                      { Capabilities: ['write'], PathSpec: 'foo/bar/*' },
+                    ],
                   },
                 },
               ],
@@ -373,7 +357,7 @@ module('Unit | Ability | variable', function (hooks) {
       assert.equal(
         nearestMatchingPath,
         'foo/bar/*',
-        'It should return the nearest ancestor matching path.'
+        'It should return the nearest fuzzy matching path.'
       );
     });
 
@@ -389,9 +373,7 @@ module('Unit | Ability | variable', function (hooks) {
                   Name: 'default',
                   Capabilities: [],
                   SecureVariables: {
-                    'Path "foo/*"': {
-                      Capabilities: ['write'],
-                    },
+                    Paths: [{ Capabilities: ['write'], PathSpec: 'foo/*' }],
                   },
                 },
               ],
@@ -408,7 +390,7 @@ module('Unit | Ability | variable', function (hooks) {
       assert.equal(
         nearestMatchingPath,
         'foo/*',
-        'It should handle wildcard glob prefixes.'
+        'It should handle wildcard glob.'
       );
     });
 
@@ -424,12 +406,10 @@ module('Unit | Ability | variable', function (hooks) {
                   Name: 'default',
                   Capabilities: [],
                   SecureVariables: {
-                    'Path "*/bar"': {
-                      Capabilities: ['write'],
-                    },
-                    'Path "*/bar/baz"': {
-                      Capabilities: ['write'],
-                    },
+                    Paths: [
+                      { Capabilities: ['write'], PathSpec: '*/bar' },
+                      { Capabilities: ['write'], PathSpec: '*/bar/baz' },
+                    ],
                   },
                 },
               ],
@@ -462,12 +442,10 @@ module('Unit | Ability | variable', function (hooks) {
                   Name: 'default',
                   Capabilities: [],
                   SecureVariables: {
-                    'Path "*/bar"': {
-                      Capabilities: ['write'],
-                    },
-                    'Path "foo/*"': {
-                      Capabilities: ['write'],
-                    },
+                    Paths: [
+                      { Capabilities: ['write'], PathSpec: '*/bar' },
+                      { Capabilities: ['write'], PathSpec: 'foo/*' },
+                    ],
                   },
                 },
               ],


### PR DESCRIPTION
This PR is one of two PRs that will unblock  [#13447](https://github.com/hashicorp/nomad/pull/13447).

This PR specifically handle path matching when there is no exact match. However, this PR is not in use because there will be a follow-up PR for integrating namespaces as part of the path matching process.