### PR TITLE
ui:  handle namespace filtering for capabilities check

### DIFF
--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -41,21 +41,26 @@ export default class Variable extends AbstractAbility {
 
   @computed('rulesForNamespace.@each.capabilities', 'path')
   get policiesSupportVariableCreation() {
+    const matchingPath = this._nearestMatchingPath(this.path);
     return this.rulesForNamespace.some((rules) => {
-      const keyName = `SecureVariables.Path "${this.path}".Capabilities`;
+      const keyName = `SecureVariables.Path "${matchingPath}".Capabilities`;
       const capabilities = get(rules, keyName) || [];
       return capabilities.includes('create');
     });
   }
 
-  @computed('token.selfTokenPolicies.[]')
+  @computed('token.selfTokenPolicies.[]', '_namespace')
   get allPaths() {
-    return get(this, 'token.selfTokenPolicies')
+    return (get(this, 'token.selfTokenPolicies') || [])
       .toArray()
       .reduce((paths, policy) => {
-        const [variables] = get(policy, 'rulesJSON.Namespaces').mapBy(
-          'SecureVariables'
+        const matchingNamespace = this._findMatchingNamespace(
+          get(policy, 'rulesJSON.Namespaces'),
+          this._namespace
         );
+        const variables = get(policy, 'rulesJSON.Namespaces').find(
+          (namespace) => namespace.Name === matchingNamespace
+        )?.SecureVariables;
         paths = { ...paths, ...variables };
         return paths;
       }, {});

--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -55,10 +55,10 @@ export default class Variable extends AbstractAbility {
       .toArray()
       .reduce((paths, policy) => {
         const matchingNamespace = this._findMatchingNamespace(
-          get(policy, 'rulesJSON.Namespaces'),
+          get(policy, 'rulesJSON.Namespaces') || [],
           this._namespace
         );
-        const variables = get(policy, 'rulesJSON.Namespaces').find(
+        const variables = (get(policy, 'rulesJSON.Namespaces') || []).find(
           (namespace) => namespace.Name === matchingNamespace
         )?.SecureVariables;
         paths = { ...paths, ...variables };

--- a/ui/tests/unit/abilities/variable-test.js
+++ b/ui/tests/unit/abilities/variable-test.js
@@ -161,6 +161,45 @@ module('Unit | Ability | variable', function (hooks) {
 
       assert.ok(this.ability.canCreate);
     });
+
+    test('it handles namespace matching', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {
+                    'Path "foo/bar"': {
+                      Capabilities: ['list'],
+                    },
+                  },
+                },
+                {
+                  Name: 'pablo',
+                  Capabilities: [],
+                  SecureVariables: {
+                    'Path "foo/bar"': {
+                      Capabilities: ['create'],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+      this.ability.path = 'foo/bar';
+      this.ability.namespace = 'pablo';
+
+      assert.ok(this.ability.canCreate);
+    });
   });
 
   module('#_nearestMatchingPath', function () {


### PR DESCRIPTION
This PR is one of two PRs that will unblock [13447](https://github.com/hashicorp/nomad/pull/13447).

This PR specifically handles namespace filtering when handling path matching.