### PR TITLE
api: use testing.T.Setenv to set env vars in tests

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
-	rootcerts "github.com/hashicorp/go-rootcerts"
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/go-rootcerts"
 )
 
 var (

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -119,31 +118,22 @@ func TestRequestTime(t *testing.T) {
 
 func TestDefaultConfig_env(t *testing.T) {
 	testutil.Parallel(t)
-	url := "http://1.2.3.4:5678"
+	testURL := "http://1.2.3.4:5678"
 	auth := []string{"nomaduser", "12345"}
 	region := "test"
 	namespace := "dev"
 	token := "foobar"
 
-	os.Setenv("NOMAD_ADDR", url)
-	defer os.Setenv("NOMAD_ADDR", "")
-
-	os.Setenv("NOMAD_REGION", region)
-	defer os.Setenv("NOMAD_REGION", "")
-
-	os.Setenv("NOMAD_NAMESPACE", namespace)
-	defer os.Setenv("NOMAD_NAMESPACE", "")
-
-	os.Setenv("NOMAD_HTTP_AUTH", strings.Join(auth, ":"))
-	defer os.Setenv("NOMAD_HTTP_AUTH", "")
-
-	os.Setenv("NOMAD_TOKEN", token)
-	defer os.Setenv("NOMAD_TOKEN", "")
+	t.Setenv("NOMAD_ADDR", testURL)
+	t.Setenv("NOMAD_REGION", region)
+	t.Setenv("NOMAD_NAMESPACE", namespace)
+	t.Setenv("NOMAD_HTTP_AUTH", strings.Join(auth, ":"))
+	t.Setenv("NOMAD_TOKEN", token)
 
 	config := DefaultConfig()
 
-	if config.Address != url {
-		t.Errorf("expected %q to be %q", config.Address, url)
+	if config.Address != testURL {
+		t.Errorf("expected %q to be %q", config.Address, testURL)
 	}
 
 	if config.Region != region {


### PR DESCRIPTION
Just minor cleanup to use `T.Setenv` instead of `os.Setenv` + `defer`. 