### PR TITLE
core: allow deleting of evaluations

### DIFF
--- a/.changelog/13045.txt
+++ b/.changelog/13045.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+cli: Added `scheduler get-config` and `scheduler set-config` commands to the operator CLI
+```
+
+```release-note:improvement
+core: Added the ability to pause and un-pause the eval broker and blocked eval broker
+```

--- a/.changelog/13492.txt
+++ b/.changelog/13492.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+cli: Added `delete` command to the eval CLI
+```
+
+```release-note:improvement
+agent: Added delete support to the eval HTTP API
+```

--- a/api/acl.go
+++ b/api/acl.go
@@ -42,7 +42,7 @@ func (a *ACLPolicies) Delete(policyName string, q *WriteOptions) (*WriteMeta, er
 	if policyName == "" {
 		return nil, fmt.Errorf("missing policy name")
 	}
-	wm, err := a.client.delete("/v1/acl/policy/"+policyName, nil, q)
+	wm, err := a.client.delete("/v1/acl/policy/"+policyName, nil, nil, q)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func (a *ACLTokens) Delete(accessorID string, q *WriteOptions) (*WriteMeta, erro
 	if accessorID == "" {
 		return nil, fmt.Errorf("missing accessor ID")
 	}
-	wm, err := a.client.delete("/v1/acl/token/"+accessorID, nil, q)
+	wm, err := a.client.delete("/v1/acl/token/"+accessorID, nil, nil, q)
 	if err != nil {
 		return nil, err
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -982,14 +982,15 @@ func (c *Client) write(endpoint string, in, out interface{}, q *WriteOptions) (*
 	return wm, nil
 }
 
-// delete is used to do a DELETE request against an endpoint
-// and serialize/deserialized using the standard Nomad conventions.
-func (c *Client) delete(endpoint string, out interface{}, q *WriteOptions) (*WriteMeta, error) {
+// delete is used to do a DELETE request against an endpoint and
+// serialize/deserialized using the standard Nomad conventions.
+func (c *Client) delete(endpoint string, in, out interface{}, q *WriteOptions) (*WriteMeta, error) {
 	r, err := c.newRequest("DELETE", endpoint)
 	if err != nil {
 		return nil, err
 	}
 	r.setWriteOptions(q)
+	r.obj = in
 	rtt, resp, err := requireOK(c.doRequest(r))
 	if err != nil {
 		return nil, err

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -107,7 +107,7 @@ func TestRequestTime(t *testing.T) {
 		t.Errorf("bad request time: %d", wm.RequestTime)
 	}
 
-	wm, err = client.delete("/", &out, nil)
+	wm, err = client.delete("/", nil, &out, nil)
 	if err != nil {
 		t.Fatalf("delete err: %v", err)
 	}

--- a/api/csi.go
+++ b/api/csi.go
@@ -82,7 +82,7 @@ func (v *CSIVolumes) Register(vol *CSIVolume, w *WriteOptions) (*WriteMeta, erro
 
 // Deregister deregisters a single CSIVolume from Nomad. The volume will not be deleted from the external storage provider.
 func (v *CSIVolumes) Deregister(id string, force bool, w *WriteOptions) error {
-	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v?force=%t", url.PathEscape(id), force), nil, w)
+	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v?force=%t", url.PathEscape(id), force), nil, nil, w)
 	return err
 }
 
@@ -104,7 +104,7 @@ func (v *CSIVolumes) Create(vol *CSIVolume, w *WriteOptions) ([]*CSIVolume, *Wri
 // passed as an argument here is for the storage provider's ID, so a volume
 // that's already been deregistered can be deleted.
 func (v *CSIVolumes) Delete(externalVolID string, w *WriteOptions) error {
-	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v/delete", url.PathEscape(externalVolID)), nil, w)
+	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v/delete", url.PathEscape(externalVolID)), nil, nil, w)
 	return err
 }
 
@@ -117,7 +117,7 @@ func (v *CSIVolumes) DeleteOpts(req *CSIVolumeDeleteRequest, w *WriteOptions) er
 		w = &WriteOptions{}
 	}
 	w.SetHeadersFromCSISecrets(req.Secrets)
-	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v/delete", url.PathEscape(req.ExternalVolumeID)), nil, w)
+	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v/delete", url.PathEscape(req.ExternalVolumeID)), nil, nil, w)
 	return err
 }
 
@@ -125,7 +125,7 @@ func (v *CSIVolumes) DeleteOpts(req *CSIVolumeDeleteRequest, w *WriteOptions) er
 // node. This is used in the case that the node is temporarily lost and the
 // allocations are unable to drop their claims automatically.
 func (v *CSIVolumes) Detach(volID, nodeID string, w *WriteOptions) error {
-	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v/detach?node=%v", url.PathEscape(volID), nodeID), nil, w)
+	_, err := v.client.delete(fmt.Sprintf("/v1/volume/csi/%v/detach?node=%v", url.PathEscape(volID), nodeID), nil, nil, w)
 	return err
 }
 
@@ -152,7 +152,7 @@ func (v *CSIVolumes) DeleteSnapshot(snap *CSISnapshot, w *WriteOptions) error {
 		w = &WriteOptions{}
 	}
 	w.SetHeadersFromCSISecrets(snap.Secrets)
-	_, err := v.client.delete("/v1/volumes/snapshot?"+qp.Encode(), nil, w)
+	_, err := v.client.delete("/v1/volumes/snapshot?"+qp.Encode(), nil, nil, w)
 	return err
 }
 

--- a/api/evaluations.go
+++ b/api/evaluations.go
@@ -40,6 +40,18 @@ func (e *Evaluations) Info(evalID string, q *QueryOptions) (*Evaluation, *QueryM
 	return &resp, qm, nil
 }
 
+// Delete is used to batch delete evaluations using their IDs.
+func (e *Evaluations) Delete(evalIDs []string, w *WriteOptions) (*WriteMeta, error) {
+	req := EvalDeleteRequest{
+		EvalIDs: evalIDs,
+	}
+	wm, err := e.client.delete("/v1/evaluations", &req, nil, w)
+	if err != nil {
+		return nil, err
+	}
+	return wm, nil
+}
+
 // Allocations is used to retrieve a set of allocations given
 // an evaluation ID.
 func (e *Evaluations) Allocations(evalID string, q *QueryOptions) ([]*AllocationListStub, *QueryMeta, error) {
@@ -106,6 +118,11 @@ type EvaluationStub struct {
 	ModifyIndex       uint64
 	CreateTime        int64
 	ModifyTime        int64
+}
+
+type EvalDeleteRequest struct {
+	EvalIDs []string
+	WriteRequest
 }
 
 // EvalIndexSort is a wrapper to sort evaluations by CreateIndex.

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -288,7 +288,7 @@ func (j *Jobs) Evaluations(jobID string, q *QueryOptions) ([]*Evaluation, *Query
 // eventually GC'ed from the system. Most callers should not specify purge.
 func (j *Jobs) Deregister(jobID string, purge bool, q *WriteOptions) (string, *WriteMeta, error) {
 	var resp JobDeregisterResponse
-	wm, err := j.client.delete(fmt.Sprintf("/v1/job/%v?purge=%t", url.PathEscape(jobID), purge), &resp, q)
+	wm, err := j.client.delete(fmt.Sprintf("/v1/job/%v?purge=%t", url.PathEscape(jobID), purge), nil, &resp, q)
 	if err != nil {
 		return "", nil, err
 	}
@@ -334,7 +334,7 @@ func (j *Jobs) DeregisterOpts(jobID string, opts *DeregisterOptions, q *WriteOpt
 			opts.Purge, opts.Global, opts.EvalPriority, opts.NoShutdownDelay)
 	}
 
-	wm, err := j.client.delete(endpoint, &resp, q)
+	wm, err := j.client.delete(endpoint, nil, &resp, q)
 	if err != nil {
 		return "", nil, err
 	}

--- a/api/namespace.go
+++ b/api/namespace.go
@@ -58,7 +58,7 @@ func (n *Namespaces) Register(namespace *Namespace, q *WriteOptions) (*WriteMeta
 
 // Delete is used to delete a namespace
 func (n *Namespaces) Delete(namespace string, q *WriteOptions) (*WriteMeta, error) {
-	wm, err := n.client.delete(fmt.Sprintf("/v1/namespace/%s", namespace), nil, q)
+	wm, err := n.client.delete(fmt.Sprintf("/v1/namespace/%s", namespace), nil, nil, q)
 	if err != nil {
 		return nil, err
 	}

--- a/api/operator.go
+++ b/api/operator.go
@@ -134,6 +134,10 @@ type SchedulerConfiguration struct {
 	// management ACL token
 	RejectJobRegistration bool
 
+	// PauseEvalBroker stops the leader evaluation broker process from running
+	// until the configuration is updated and written to the Nomad servers.
+	PauseEvalBroker bool
+
 	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
 	CreateIndex uint64
 	ModifyIndex uint64

--- a/api/quota.go
+++ b/api/quota.go
@@ -90,7 +90,7 @@ func (q *Quotas) Register(spec *QuotaSpec, qo *WriteOptions) (*WriteMeta, error)
 
 // Delete is used to delete a quota spec
 func (q *Quotas) Delete(quota string, qo *WriteOptions) (*WriteMeta, error) {
-	wm, err := q.client.delete(fmt.Sprintf("/v1/quota/%s", quota), nil, qo)
+	wm, err := q.client.delete(fmt.Sprintf("/v1/quota/%s", quota), nil, nil, qo)
 	if err != nil {
 		return nil, err
 	}

--- a/api/raw.go
+++ b/api/raw.go
@@ -34,5 +34,5 @@ func (raw *Raw) Write(endpoint string, in, out interface{}, q *WriteOptions) (*W
 // Delete is used to do a DELETE request against an endpoint
 // and serialize/deserialized using the standard Nomad conventions.
 func (raw *Raw) Delete(endpoint string, out interface{}, q *WriteOptions) (*WriteMeta, error) {
-	return raw.c.delete(endpoint, out, q)
+	return raw.c.delete(endpoint, nil, out, q)
 }

--- a/api/sentinel.go
+++ b/api/sentinel.go
@@ -39,7 +39,7 @@ func (a *SentinelPolicies) Delete(policyName string, q *WriteOptions) (*WriteMet
 	if policyName == "" {
 		return nil, fmt.Errorf("missing policy name")
 	}
-	wm, err := a.client.delete("/v1/sentinel/policy/"+policyName, nil, q)
+	wm, err := a.client.delete("/v1/sentinel/policy/"+policyName, nil, nil, q)
 	if err != nil {
 		return nil, err
 	}

--- a/api/services.go
+++ b/api/services.go
@@ -122,7 +122,7 @@ func (s *Services) Get(serviceName string, q *QueryOptions) ([]*ServiceRegistrat
 // by its service name and service ID.
 func (s *Services) Delete(serviceName, serviceID string, q *WriteOptions) (*WriteMeta, error) {
 	path := fmt.Sprintf("/v1/service/%s/%s", url.PathEscape(serviceName), url.PathEscape(serviceID))
-	wm, err := s.client.delete(path, nil, q)
+	wm, err := s.client.delete(path, nil, nil, q)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -507,7 +507,7 @@ func TestClient_WatchAllocs(t *testing.T) {
 	})
 
 	// Delete one allocation
-	if err := state.DeleteEval(103, nil, []string{alloc1.ID}); err != nil {
+	if err := state.DeleteEval(103, nil, []string{alloc1.ID}, false); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -262,6 +262,7 @@ func (s *HTTPServer) schedulerUpdateConfig(resp http.ResponseWriter, req *http.R
 		SchedulerAlgorithm:            structs.SchedulerAlgorithm(conf.SchedulerAlgorithm),
 		MemoryOversubscriptionEnabled: conf.MemoryOversubscriptionEnabled,
 		RejectJobRegistration:         conf.RejectJobRegistration,
+		PauseEvalBroker:               conf.PauseEvalBroker,
 		PreemptionConfig: structs.PreemptionConfig{
 			SystemSchedulerEnabled:   conf.PreemptionConfig.SystemSchedulerEnabled,
 			SysBatchSchedulerEnabled: conf.PreemptionConfig.SysBatchSchedulerEnabled,

--- a/command/agent/operator_endpoint_test.go
+++ b/command/agent/operator_endpoint_test.go
@@ -272,32 +272,32 @@ func TestOperator_ServerHealth_Unhealthy(t *testing.T) {
 func TestOperator_SchedulerGetConfiguration(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
-		require := require.New(t)
 		body := bytes.NewBuffer(nil)
 		req, _ := http.NewRequest("GET", "/v1/operator/scheduler/configuration", body)
 		resp := httptest.NewRecorder()
 		obj, err := s.Server.OperatorSchedulerConfiguration(resp, req)
-		require.Nil(err)
-		require.Equal(200, resp.Code)
+		require.Nil(t, err)
+		require.Equal(t, 200, resp.Code)
 		out, ok := obj.(structs.SchedulerConfigurationResponse)
-		require.True(ok)
+		require.True(t, ok)
 
 		// Only system jobs can preempt other jobs by default.
-		require.True(out.SchedulerConfig.PreemptionConfig.SystemSchedulerEnabled)
-		require.False(out.SchedulerConfig.PreemptionConfig.SysBatchSchedulerEnabled)
-		require.False(out.SchedulerConfig.PreemptionConfig.BatchSchedulerEnabled)
-		require.False(out.SchedulerConfig.PreemptionConfig.ServiceSchedulerEnabled)
-		require.False(out.SchedulerConfig.MemoryOversubscriptionEnabled)
+		require.True(t, out.SchedulerConfig.PreemptionConfig.SystemSchedulerEnabled)
+		require.False(t, out.SchedulerConfig.PreemptionConfig.SysBatchSchedulerEnabled)
+		require.False(t, out.SchedulerConfig.PreemptionConfig.BatchSchedulerEnabled)
+		require.False(t, out.SchedulerConfig.PreemptionConfig.ServiceSchedulerEnabled)
+		require.False(t, out.SchedulerConfig.MemoryOversubscriptionEnabled)
+		require.False(t, out.SchedulerConfig.PauseEvalBroker)
 	})
 }
 
 func TestOperator_SchedulerSetConfiguration(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
-		require := require.New(t)
 		body := bytes.NewBuffer([]byte(`
 {
   "MemoryOversubscriptionEnabled": true,
+  "PauseEvalBroker": true,
   "PreemptionConfig": {
     "SystemSchedulerEnabled": true,
     "ServiceSchedulerEnabled": true
@@ -306,11 +306,11 @@ func TestOperator_SchedulerSetConfiguration(t *testing.T) {
 		req, _ := http.NewRequest("PUT", "/v1/operator/scheduler/configuration", body)
 		resp := httptest.NewRecorder()
 		setResp, err := s.Server.OperatorSchedulerConfiguration(resp, req)
-		require.Nil(err)
-		require.Equal(200, resp.Code)
+		require.Nil(t, err)
+		require.Equal(t, 200, resp.Code)
 		schedSetResp, ok := setResp.(structs.SchedulerSetConfigurationResponse)
-		require.True(ok)
-		require.NotZero(schedSetResp.Index)
+		require.True(t, ok)
+		require.NotZero(t, schedSetResp.Index)
 
 		args := structs.GenericRequest{
 			QueryOptions: structs.QueryOptions{
@@ -320,12 +320,13 @@ func TestOperator_SchedulerSetConfiguration(t *testing.T) {
 
 		var reply structs.SchedulerConfigurationResponse
 		err = s.RPC("Operator.SchedulerGetConfiguration", &args, &reply)
-		require.Nil(err)
-		require.True(reply.SchedulerConfig.PreemptionConfig.SystemSchedulerEnabled)
-		require.False(reply.SchedulerConfig.PreemptionConfig.SysBatchSchedulerEnabled)
-		require.False(reply.SchedulerConfig.PreemptionConfig.BatchSchedulerEnabled)
-		require.True(reply.SchedulerConfig.PreemptionConfig.ServiceSchedulerEnabled)
-		require.True(reply.SchedulerConfig.MemoryOversubscriptionEnabled)
+		require.Nil(t, err)
+		require.True(t, reply.SchedulerConfig.PreemptionConfig.SystemSchedulerEnabled)
+		require.False(t, reply.SchedulerConfig.PreemptionConfig.SysBatchSchedulerEnabled)
+		require.False(t, reply.SchedulerConfig.PreemptionConfig.BatchSchedulerEnabled)
+		require.True(t, reply.SchedulerConfig.PreemptionConfig.ServiceSchedulerEnabled)
+		require.True(t, reply.SchedulerConfig.MemoryOversubscriptionEnabled)
+		require.True(t, reply.SchedulerConfig.PauseEvalBroker)
 	})
 }
 

--- a/command/commands.go
+++ b/command/commands.go
@@ -571,7 +571,21 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
-
+		"operator scheduler": func() (cli.Command, error) {
+			return &OperatorSchedulerCommand{
+				Meta: meta,
+			}, nil
+		},
+		"operator scheduler get-config": func() (cli.Command, error) {
+			return &OperatorSchedulerGetConfig{
+				Meta: meta,
+			}, nil
+		},
+		"operator scheduler set-config": func() (cli.Command, error) {
+			return &OperatorSchedulerSetConfig{
+				Meta: meta,
+			}, nil
+		},
 		"operator snapshot": func() (cli.Command, error) {
 			return &OperatorSnapshotCommand{
 				Meta: meta,

--- a/command/commands.go
+++ b/command/commands.go
@@ -265,6 +265,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"eval delete": func() (cli.Command, error) {
+			return &EvalDeleteCommand{
+				Meta: meta,
+			}, nil
+		},
 		"eval list": func() (cli.Command, error) {
 			return &EvalListCommand{
 				Meta: meta,

--- a/command/eval.go
+++ b/command/eval.go
@@ -1,8 +1,10 @@
 package command
 
 import (
+	"fmt"
 	"strings"
 
+	"github.com/hashicorp/nomad/api"
 	"github.com/mitchellh/cli"
 )
 
@@ -19,9 +21,17 @@ Usage: nomad eval <subcommand> [options] [args]
   detail but can be useful for debugging placement failures when the cluster
   does not have the resources to run a given job.
 
+  List evaluations:
+
+      $ nomad eval list
+
   Examine an evaluations status:
 
       $ nomad eval status <eval-id>
+
+  Delete evaluations:
+
+      $ nomad eval delete <eval-id>
 
   Please see the individual subcommand help for detailed usage information.
 `
@@ -35,6 +45,24 @@ func (f *EvalCommand) Synopsis() string {
 
 func (f *EvalCommand) Name() string { return "eval" }
 
-func (f *EvalCommand) Run(args []string) int {
-	return cli.RunResultHelp
+func (f *EvalCommand) Run(_ []string) int { return cli.RunResultHelp }
+
+// outputEvalList is a helper which outputs an array of evaluations as a list
+// to the UI with key information such as ID and status.
+func outputEvalList(ui cli.Ui, evals []*api.Evaluation, length int) {
+
+	out := make([]string, len(evals)+1)
+	out[0] = "ID|Priority|Triggered By|Job ID|Status|Placement Failures"
+	for i, eval := range evals {
+		failures, _ := evalFailureStatus(eval)
+		out[i+1] = fmt.Sprintf("%s|%d|%s|%s|%s|%s",
+			limit(eval.ID, length),
+			eval.Priority,
+			eval.TriggeredBy,
+			eval.JobID,
+			eval.Status,
+			failures,
+		)
+	}
+	ui.Output(formatList(out))
 }

--- a/command/eval_delete.go
+++ b/command/eval_delete.go
@@ -1,0 +1,406 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
+)
+
+type EvalDeleteCommand struct {
+	Meta
+
+	filter string
+	yes    bool
+
+	// deleteByArg is set when the command is deleting an evaluation that has
+	// been passed as an argument. This avoids need for confirmation.
+	deleteByArg bool
+
+	// numDeleted tracks the total evaluations deleted in a single run of this
+	// command. It provides a way to output this information to the user at the
+	// command completion.
+	numDeleted int
+
+	// client is the lazy-loaded API client and is stored here, so we don't
+	// need to pass it to multiple functions.
+	client *api.Client
+}
+
+func (e *EvalDeleteCommand) Help() string {
+	helpText := `
+Usage: nomad eval delete [options] <evaluation>
+
+  Delete an evaluation by ID. If the evaluation ID is omitted, this command
+  will use the filter flag to identify and delete a set of evaluations. If ACLs
+  are enabled, this command requires a management ACL token.
+
+  This command should be used cautiously and only in outage situations where
+  there is a large backlog of evaluations not being processed. During most
+  normal and outage scenarios, Nomads reconciliation and state management will
+  handle evaluations as needed.
+
+  The eval broker is expected to be paused prior to running this command and
+  un-paused after. This can be done using the following two commands:
+    - nomad operator scheduler set-config -pause-eval-broker=true
+    - nomad operator scheduler set-config -pause-eval-broker=false
+
+General Options:
+
+  ` + generalOptionsUsage(usageOptsNoNamespace) + `
+
+Eval Delete Options:
+
+  -filter
+    Specifies an expression used to filter evaluations by for deletion. When
+    using this flag, it is advisable to ensure the syntax is correct using the
+    eval list command first.
+
+  -yes
+    Bypass the confirmation prompt if an evaluation ID was not provided.
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (e *EvalDeleteCommand) Synopsis() string {
+	return "Delete evaluations by ID or using a filter"
+}
+
+func (e *EvalDeleteCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(e.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-filter": complete.PredictAnything,
+			"-yes":    complete.PredictNothing,
+		})
+}
+
+func (e *EvalDeleteCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFunc(func(a complete.Args) []string {
+		client, err := e.Meta.Client()
+		if err != nil {
+			return nil
+		}
+
+		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Evals, nil)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Evals]
+	})
+}
+
+func (e *EvalDeleteCommand) Name() string { return "eval delete" }
+
+func (e *EvalDeleteCommand) Run(args []string) int {
+
+	flags := e.Meta.FlagSet(e.Name(), FlagSetClient)
+	flags.Usage = func() { e.Ui.Output(e.Help()) }
+	flags.StringVar(&e.filter, "filter", "", "")
+	flags.BoolVar(&e.yes, "yes", false, "")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	args = flags.Args()
+
+	if err := e.verifyArgsAndFlags(args); err != nil {
+		e.Ui.Error(fmt.Sprintf("Error validating command args and flags: %v", err))
+		return 1
+	}
+
+	// Get the HTTP client and store this for use across multiple functions.
+	client, err := e.Meta.Client()
+	if err != nil {
+		e.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+	e.client = client
+
+	// Ensure the eval broker is paused. This check happens multiple times on
+	// the leader, but this check means we can provide quick and actionable
+	// feedback.
+	schedulerConfig, _, err := e.client.Operator().SchedulerGetConfiguration(nil)
+	if err != nil {
+		e.Ui.Error(fmt.Sprintf("Error querying scheduler configuration: %s", err))
+		return 1
+	}
+
+	if !schedulerConfig.SchedulerConfig.PauseEvalBroker {
+		e.Ui.Error("Eval broker is not paused")
+		e.Ui.Output(`To delete evaluations you must first pause the eval broker by running "nomad operator scheduler set-config -pause-eval-broker=true"`)
+		e.Ui.Output(`After the deletion is complete, unpause the eval broker by running "nomad operator scheduler set-config -pause-eval-broker=false"`)
+		return 1
+	}
+
+	// Track the eventual exit code as there are a number of factors that
+	// influence this.
+	var exitCode int
+
+	// Call the correct function in order to handle the operator input
+	// correctly.
+	switch len(args) {
+	case 1:
+		e.deleteByArg = true
+		exitCode, err = e.handleEvalArgDelete(args[0])
+	default:
+
+		// Track the next token, so we can iterate all pages that match the
+		// passed filter.
+		var nextToken string
+
+		// It is possible the filter matches a large number of evaluations
+		// which means we need to run a number of batch deletes. Perform
+		// iteration here rather than recursion in later function, so we avoid
+		// any potential issues with stack size limits.
+		for {
+			exitCode, nextToken, err = e.handleFlagFilterDelete(nextToken)
+
+			// If there is another page of evaluations matching the filter,
+			// iterate the loop and delete the next batch of evals. We pause
+			// for a 500ms rather than just run as fast as the code and machine
+			// possibly can. This means deleting 13million evals will take
+			// roughly 13-15 mins, which seems reasonable. It is worth noting,
+			// we do not expect operators to delete this many evals in a single
+			// run and expect more careful filtering options to be used.
+			if nextToken != "" {
+				time.Sleep(500 * time.Millisecond)
+				continue
+			} else {
+				break
+			}
+		}
+	}
+
+	// Do not exit if we got an error as it's possible this was on the
+	// non-first iteration, and we have therefore deleted some evals.
+	if err != nil {
+		e.Ui.Error(fmt.Sprintf("Error deleting evaluations: %s", err))
+	}
+
+	// Depending on whether we deleted evaluations or not, output a message so
+	// this is clear.
+	if e.numDeleted > 0 {
+		e.Ui.Output(fmt.Sprintf("Successfully deleted %v %s",
+			e.numDeleted, correctGrammar("evaluation", e.numDeleted)))
+	} else if err == nil {
+		e.Ui.Output("No evaluations were deleted")
+	}
+
+	return exitCode
+}
+
+// verifyArgsAndFlags ensures the passed arguments and flags are valid for what
+// this command accepts and can take action on.
+func (e *EvalDeleteCommand) verifyArgsAndFlags(args []string) error {
+
+	numArgs := len(args)
+
+	// The command takes either an argument or filter, but not both.
+	if (e.filter == "" && numArgs < 1) || (e.filter != "" && numArgs > 0) {
+		return errors.New("evaluation ID or filter flag required")
+	}
+
+	// If an argument is supplied, we only accept a single eval ID.
+	if numArgs > 1 {
+		return fmt.Errorf("expected 1 argument, got %v", numArgs)
+	}
+
+	return nil
+}
+
+// handleEvalArgDelete handles deletion and evaluation which was passed via
+// it's ID as a command argument. This is the simplest route to take and
+// doesn't require filtering or batching.
+func (e *EvalDeleteCommand) handleEvalArgDelete(evalID string) (int, error) {
+	evalInfo, _, err := e.client.Evaluations().Info(evalID, nil)
+	if err != nil {
+		return 1, err
+	}
+
+	// Supplying an eval to delete by its ID will always skip verification, so
+	// we don't need to understand the boolean response.
+	code, _, err := e.batchDelete([]*api.Evaluation{evalInfo})
+	return code, err
+}
+
+// handleFlagFilterDelete handles deletion of evaluations discovered using
+// the filter. It is unknown how many will match the operator criteria so
+// this function batches lookup and delete requests into sensible numbers.
+func (e *EvalDeleteCommand) handleFlagFilterDelete(nt string) (int, string, error) {
+
+	evalsToDelete, nextToken, err := e.batchLookupEvals(nt)
+	if err != nil {
+		return 1, "", err
+	}
+
+	numEvalsToDelete := len(evalsToDelete)
+
+	// The filter flags are operator controlled, therefore ensure we
+	// actually found some evals to delete. Otherwise, inform the operator
+	// their flags are potentially incorrect.
+	if numEvalsToDelete == 0 {
+		if e.numDeleted > 0 {
+			return 0, "", nil
+		} else {
+			return 1, "", errors.New("failed to find any evals that matched filter criteria")
+		}
+	}
+
+	if code, actioned, err := e.batchDelete(evalsToDelete); err != nil {
+		return code, "", err
+	} else if !actioned {
+		return code, "", nil
+	}
+
+	e.Ui.Info(fmt.Sprintf("Successfully deleted batch of %v %s",
+		numEvalsToDelete, correctGrammar("evaluation", numEvalsToDelete)))
+
+	return 0, nextToken, nil
+}
+
+// batchLookupEvals handles batched lookup of evaluations using the operator
+// provided filter. The lookup is performed a maximum number of 3 times to
+// ensure their size is limited and the number of evals to delete doesn't exceed
+// the total allowable in a single call.
+//
+// The JSON serialized evaluation API object is 350-380B in size.
+// 2426 * 380B (3.8e-4 MB) = 0.92MB. We may want to make this configurable
+// in the future, but this is counteracted by the CLI logic which will loop
+// until the user tells it to exit, or all evals matching the filter are
+// deleted. 2426 * 3 falls below the maximum limit for eval IDs in a single
+// delete request (set by MaxEvalIDsPerDeleteRequest).
+func (e *EvalDeleteCommand) batchLookupEvals(nextToken string) ([]*api.Evaluation, string, error) {
+
+	var evalsToDelete []*api.Evaluation
+	currentNextToken := nextToken
+
+	// Call List 3 times to accumulate the maximum number if eval IDs supported
+	// in a single Delete request. See math above.
+	for i := 0; i < 3; i++ {
+
+		// Generate the query options using the passed next token and filter. The
+		// per page value is less than the total number we can include in a single
+		// delete request. This keeps the maximum size of the return object at a
+		// reasonable size.
+		opts := api.QueryOptions{
+			Filter:    e.filter,
+			PerPage:   2426,
+			NextToken: currentNextToken,
+		}
+
+		evalList, meta, err := e.client.Evaluations().List(&opts)
+		if err != nil {
+			return nil, "", err
+		}
+
+		if len(evalList) > 0 {
+			evalsToDelete = append(evalsToDelete, evalList...)
+		}
+
+		// Store the next token no matter if it is empty or populated.
+		currentNextToken = meta.NextToken
+
+		// If there is no next token, ensure we exit and avoid any new loops
+		// which will result in duplicate IDs.
+		if currentNextToken == "" {
+			break
+		}
+	}
+
+	return evalsToDelete, currentNextToken, nil
+}
+
+// batchDelete is responsible for deleting the passed evaluations and asking
+// any confirmation questions along the way. It will ask whether the operator
+// want to list the evals before deletion, and optionally ask for confirmation
+// before deleting based on input criteria.
+func (e *EvalDeleteCommand) batchDelete(evals []*api.Evaluation) (int, bool, error) {
+
+	// Ask whether the operator wants to see the list of evaluations before
+	// moving forward with deletion. This will only happen if filters are used
+	// and the confirmation step is not bypassed.
+	if !e.yes && !e.deleteByArg {
+		_, listEvals := e.askQuestion(fmt.Sprintf(
+			"Do you want to list evals (%v) before deletion? [y/N]",
+			len(evals)), "")
+
+		// List the evals for deletion is the user has requested this. It can
+		// be useful when the list is small and targeted, but is maybe best
+		// avoided when deleting large quantities of evals.
+		if listEvals {
+			e.Ui.Output("")
+			outputEvalList(e.Ui, evals, shortId)
+			e.Ui.Output("")
+		}
+	}
+
+	// Generate our list of eval IDs which is required for the API request.
+	ids := make([]string, len(evals))
+
+	for i, eval := range evals {
+		ids[i] = eval.ID
+	}
+
+	// If the user did not wish to bypass the confirmation step, ask this now
+	// and handle the response.
+	if !e.yes && !e.deleteByArg {
+		code, deleteEvals := e.askQuestion(fmt.Sprintf(
+			"Are you sure you want to delete %v evals? [y/N]",
+			len(evals)), "Cancelling eval deletion")
+		e.Ui.Output("")
+
+		if !deleteEvals {
+			return code, deleteEvals, nil
+		}
+	}
+
+	_, err := e.client.Evaluations().Delete(ids, nil)
+	if err != nil {
+		return 1, false, err
+	}
+
+	// Calculate how many total evaluations we have deleted, so we can output
+	// this at the end of the process.
+	curDeleted := e.numDeleted
+	e.numDeleted = curDeleted + len(ids)
+
+	return 0, true, nil
+}
+
+// askQuestion allows the command to ask the operator a question requiring a
+// y/n response. The optional noResp is used when the operator responds no to
+// a question.
+func (e *EvalDeleteCommand) askQuestion(question, noResp string) (int, bool) {
+
+	answer, err := e.Ui.Ask(question)
+	if err != nil {
+		e.Ui.Error(fmt.Sprintf("Failed to parse answer: %v", err))
+		return 1, false
+	}
+
+	if answer == "" || strings.ToLower(answer)[0] == 'n' {
+		if noResp != "" {
+			e.Ui.Output(noResp)
+		}
+		return 0, false
+	} else if strings.ToLower(answer)[0] == 'y' && len(answer) > 1 {
+		e.Ui.Output("For confirmation, an exact ‘y’ is required.")
+		return 0, false
+	} else if answer != "y" {
+		e.Ui.Output("No confirmation detected. For confirmation, an exact 'y' is required.")
+		return 1, false
+	}
+	return 0, true
+}
+
+func correctGrammar(word string, num int) string {
+	if num > 1 {
+		return word + "s"
+	}
+	return word
+}

--- a/command/eval_delete_test.go
+++ b/command/eval_delete_test.go
@@ -1,0 +1,184 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvalDeleteCommand_Run(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		testFn func()
+		name   string
+	}{
+		{
+			testFn: func() {
+
+				testServer, client, url := testServer(t, false, nil)
+				defer testServer.Shutdown()
+
+				// Create the UI and command.
+				ui := cli.NewMockUi()
+				cmd := &EvalDeleteCommand{
+					Meta: Meta{
+						Ui:          ui,
+						flagAddress: url,
+					},
+				}
+
+				// Test basic command input validation.
+				require.Equal(t, 1, cmd.Run([]string{"-address=" + url}))
+				require.Contains(t, ui.ErrorWriter.String(), "Error validating command args and flags")
+				ui.ErrorWriter.Reset()
+				ui.OutputWriter.Reset()
+
+				// Try running the command when the eval broker is not paused.
+				require.Equal(t, 1, cmd.Run([]string{"-address=" + url, "fa3a8c37-eac3-00c7-3410-5ba3f7318fd8"}))
+				require.Contains(t, ui.ErrorWriter.String(), "Eval broker is not paused")
+				ui.ErrorWriter.Reset()
+				ui.OutputWriter.Reset()
+
+				// Paused the eval broker, then try deleting with an eval that
+				// does not exist.
+				schedulerConfig, _, err := client.Operator().SchedulerGetConfiguration(nil)
+				require.NoError(t, err)
+				require.False(t, schedulerConfig.SchedulerConfig.PauseEvalBroker)
+
+				schedulerConfig.SchedulerConfig.PauseEvalBroker = true
+				_, _, err = client.Operator().SchedulerSetConfiguration(schedulerConfig.SchedulerConfig, nil)
+				require.NoError(t, err)
+				require.True(t, schedulerConfig.SchedulerConfig.PauseEvalBroker)
+
+				require.Equal(t, 1, cmd.Run([]string{"-address=" + url, "fa3a8c37-eac3-00c7-3410-5ba3f7318fd8"}))
+				require.Contains(t, ui.ErrorWriter.String(), "eval not found")
+				ui.ErrorWriter.Reset()
+				ui.OutputWriter.Reset()
+			},
+			name: "failure",
+		},
+		{
+			testFn: func() {
+
+				testServer, client, url := testServer(t, false, nil)
+				defer testServer.Shutdown()
+
+				// Create the UI and command.
+				ui := cli.NewMockUi()
+				cmd := &EvalDeleteCommand{
+					Meta: Meta{
+						Ui:          ui,
+						flagAddress: url,
+					},
+				}
+
+				// Paused the eval broker.
+				schedulerConfig, _, err := client.Operator().SchedulerGetConfiguration(nil)
+				require.NoError(t, err)
+				require.False(t, schedulerConfig.SchedulerConfig.PauseEvalBroker)
+
+				schedulerConfig.SchedulerConfig.PauseEvalBroker = true
+				_, _, err = client.Operator().SchedulerSetConfiguration(schedulerConfig.SchedulerConfig, nil)
+				require.NoError(t, err)
+				require.True(t, schedulerConfig.SchedulerConfig.PauseEvalBroker)
+
+				// With the eval broker paused, run a job register several times
+				// to generate evals that will not be acted on.
+				testJob := testJob("eval-delete")
+
+				evalIDs := make([]string, 3)
+				for i := 0; i < 3; i++ {
+					regResp, _, err := client.Jobs().Register(testJob, nil)
+					require.NoError(t, err)
+					require.NotNil(t, regResp)
+					require.NotEmpty(t, regResp.EvalID)
+					evalIDs[i] = regResp.EvalID
+				}
+
+				// Ensure we have three evaluations in state.
+				evalList, _, err := client.Evaluations().List(nil)
+				require.NoError(t, err)
+				require.Len(t, evalList, 3)
+
+				// Attempted to delete one eval using the ID.
+				require.Equal(t, 0, cmd.Run([]string{"-address=" + url, evalIDs[0]}))
+				require.Contains(t, ui.OutputWriter.String(), "Successfully deleted 1 evaluation")
+				ui.ErrorWriter.Reset()
+				ui.OutputWriter.Reset()
+
+				// We modify the number deleted on each command run, so we
+				// need to reset this in order to check the next command
+				// output.
+				cmd.numDeleted = 0
+
+				// Attempted to delete the remaining two evals using a filter
+				// expression.
+				expr := fmt.Sprintf("JobID == %q and Status == \"pending\" ", *testJob.Name)
+				require.Equal(t, 0, cmd.Run([]string{"-address=" + url, "-filter=" + expr}))
+				require.Contains(t, ui.OutputWriter.String(), "Successfully deleted 2 evaluations")
+				ui.ErrorWriter.Reset()
+				ui.OutputWriter.Reset()
+
+				// Ensure we have zero evaluations in state.
+				evalList, _, err = client.Evaluations().List(nil)
+				require.NoError(t, err)
+				require.Len(t, evalList, 0)
+			},
+			name: "successful",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.testFn()
+		})
+	}
+}
+
+func TestEvalDeleteCommand_verifyArgsAndFlags(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		inputEvalDeleteCommand *EvalDeleteCommand
+		inputArgs              []string
+		expectedError          error
+		name                   string
+	}{
+		{
+			inputEvalDeleteCommand: &EvalDeleteCommand{
+				filter: `Status == "Pending"`,
+			},
+			inputArgs:     []string{"fa3a8c37-eac3-00c7-3410-5ba3f7318fd8"},
+			expectedError: errors.New("evaluation ID or filter flag required"),
+			name:          "arg and flags",
+		},
+		{
+			inputEvalDeleteCommand: &EvalDeleteCommand{
+				filter: "",
+			},
+			inputArgs:     []string{},
+			expectedError: errors.New("evaluation ID or filter flag required"),
+			name:          "no arg or flags",
+		},
+		{
+			inputEvalDeleteCommand: &EvalDeleteCommand{
+				filter: "",
+			},
+			inputArgs:     []string{"fa3a8c37-eac3-00c7-3410-5ba3f7318fd8", "fa3a8c37-eac3-00c7-3410-5ba3f7318fd9"},
+			expectedError: errors.New("expected 1 argument, got 2"),
+			name:          "multiple args",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualError := tc.inputEvalDeleteCommand.verifyArgsAndFlags(tc.inputArgs)
+			require.Equal(t, tc.expectedError, actualError)
+		})
+	}
+}

--- a/command/eval_list.go
+++ b/command/eval_list.go
@@ -167,20 +167,7 @@ func (c *EvalListCommand) Run(args []string) int {
 		length = fullId
 	}
 
-	out := make([]string, len(evals)+1)
-	out[0] = "ID|Priority|Triggered By|Job ID|Status|Placement Failures"
-	for i, eval := range evals {
-		failures, _ := evalFailureStatus(eval)
-		out[i+1] = fmt.Sprintf("%s|%d|%s|%s|%s|%s",
-			limit(eval.ID, length),
-			eval.Priority,
-			eval.TriggeredBy,
-			eval.JobID,
-			eval.Status,
-			failures,
-		)
-	}
-	c.Ui.Output(formatList(out))
+	outputEvalList(c.Ui, evals, length)
 
 	if qm.NextToken != "" {
 		c.Ui.Output(fmt.Sprintf(`

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -186,6 +186,9 @@ func (m *monitor) monitor(evalID string) int {
 	// Add the initial pending state
 	m.update(newEvalState())
 
+	m.ui.Info(fmt.Sprintf("%s: Monitoring evaluation %q",
+		formatTime(time.Now()), limit(evalID, m.length)))
+
 	for {
 		// Query the evaluation
 		eval, _, err := m.client.Evaluations().Info(evalID, nil)
@@ -193,9 +196,6 @@ func (m *monitor) monitor(evalID string) int {
 			m.ui.Error(fmt.Sprintf("No evaluation with id %q found", evalID))
 			return 1
 		}
-
-		m.ui.Info(fmt.Sprintf("%s: Monitoring evaluation %q",
-			formatTime(time.Now()), limit(eval.ID, m.length)))
 
 		// Create the new eval state.
 		state := newEvalState()

--- a/command/operator_scheduler.go
+++ b/command/operator_scheduler.go
@@ -1,0 +1,42 @@
+package command
+
+import (
+	"strings"
+
+	"github.com/mitchellh/cli"
+)
+
+// Ensure OperatorSchedulerCommand satisfies the cli.Command interface.
+var _ cli.Command = &OperatorSchedulerCommand{}
+
+type OperatorSchedulerCommand struct {
+	Meta
+}
+
+func (o *OperatorSchedulerCommand) Help() string {
+	helpText := `
+Usage: nomad operator scheduler <subcommand> [options]
+
+  This command groups subcommands for interacting with Nomad's scheduler
+  subsystem.
+
+  Get the scheduler configuration:
+
+      $ nomad operator scheduler get-config
+
+  Set the scheduler to use the spread algorithm:
+
+      $ nomad operator scheduler set-config -scheduler-algorithm=spread
+
+  Please see the individual subcommand help for detailed usage information.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (o *OperatorSchedulerCommand) Synopsis() string {
+	return "Provides access to the scheduler configuration"
+}
+
+func (o *OperatorSchedulerCommand) Name() string { return "operator scheduler" }
+
+func (o *OperatorSchedulerCommand) Run(_ []string) int { return cli.RunResultHelp }

--- a/command/operator_scheduler_get_config.go
+++ b/command/operator_scheduler_get_config.go
@@ -1,0 +1,118 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+)
+
+// Ensure OperatorSchedulerGetConfig satisfies the cli.Command interface.
+var _ cli.Command = &OperatorSchedulerGetConfig{}
+
+type OperatorSchedulerGetConfig struct {
+	Meta
+
+	json bool
+	tmpl string
+}
+
+func (o *OperatorSchedulerGetConfig) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(o.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-json": complete.PredictNothing,
+			"-t":    complete.PredictAnything,
+		},
+	)
+}
+
+func (o *OperatorSchedulerGetConfig) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (o *OperatorSchedulerGetConfig) Name() string { return "operator scheduler get-config" }
+
+func (o *OperatorSchedulerGetConfig) Run(args []string) int {
+
+	flags := o.Meta.FlagSet("get-config", FlagSetClient)
+	flags.BoolVar(&o.json, "json", false, "")
+	flags.StringVar(&o.tmpl, "t", "", "")
+	flags.Usage = func() { o.Ui.Output(o.Help()) }
+
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	// Set up a client.
+	client, err := o.Meta.Client()
+	if err != nil {
+		o.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	// Fetch the current configuration.
+	resp, _, err := client.Operator().SchedulerGetConfiguration(nil)
+	if err != nil {
+		o.Ui.Error(fmt.Sprintf("Error querying scheduler configuration: %s", err))
+		return 1
+	}
+
+	// If the user has specified to output the scheduler config as JSON or
+	// using a template, perform this action for the entire object and exit the
+	// command.
+	if o.json || len(o.tmpl) > 0 {
+		out, err := Format(o.json, o.tmpl, resp)
+		if err != nil {
+			o.Ui.Error(err.Error())
+			return 1
+		}
+		o.Ui.Output(out)
+		return 0
+	}
+
+	schedConfig := resp.SchedulerConfig
+
+	// Output the information.
+	o.Ui.Output(formatKV([]string{
+		fmt.Sprintf("Scheduler Algorithm|%s", schedConfig.SchedulerAlgorithm),
+		fmt.Sprintf("Memory Oversubscription|%v", schedConfig.MemoryOversubscriptionEnabled),
+		fmt.Sprintf("Reject Job Registration|%v", schedConfig.RejectJobRegistration),
+		fmt.Sprintf("Pause Eval Broker|%v", schedConfig.PauseEvalBroker),
+		fmt.Sprintf("Preemption System Scheduler|%v", schedConfig.PreemptionConfig.SystemSchedulerEnabled),
+		fmt.Sprintf("Preemption Service Scheduler|%v", schedConfig.PreemptionConfig.ServiceSchedulerEnabled),
+		fmt.Sprintf("Preemption Batch Scheduler|%v", schedConfig.PreemptionConfig.BatchSchedulerEnabled),
+		fmt.Sprintf("Preemption SysBatch Scheduler|%v", schedConfig.PreemptionConfig.SysBatchSchedulerEnabled),
+		fmt.Sprintf("Modify Index|%v", resp.SchedulerConfig.ModifyIndex),
+	}))
+	return 0
+}
+
+func (o *OperatorSchedulerGetConfig) Synopsis() string {
+	return "Display the current scheduler configuration"
+}
+
+func (o *OperatorSchedulerGetConfig) Help() string {
+	helpText := `
+Usage: nomad operator scheduler get-config [options]
+
+  Displays the current scheduler configuration.
+
+  If ACLs are enabled, this command requires a token with the 'operator:read'
+  capability.
+
+General Options:
+
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
+
+Scheduler Get Config Options:
+
+  -json
+    Output the scheduler config in its JSON format.
+
+  -t
+    Format and display the scheduler config using a Go template.
+`
+
+	return strings.TrimSpace(helpText)
+}

--- a/command/operator_scheduler_get_config_test.go
+++ b/command/operator_scheduler_get_config_test.go
@@ -1,0 +1,47 @@
+package command
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/ci"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperatorSchedulerGetConfig_Run(t *testing.T) {
+	ci.Parallel(t)
+
+	srv, _, addr := testServer(t, false, nil)
+	defer srv.Shutdown()
+
+	ui := cli.NewMockUi()
+	c := &OperatorSchedulerGetConfig{Meta: Meta{Ui: ui}}
+
+	// Run the command, so we get the default output and test this.
+	require.EqualValues(t, 0, c.Run([]string{"-address=" + addr}))
+	s := ui.OutputWriter.String()
+	require.Contains(t, s, "Scheduler Algorithm           = binpack")
+	require.Contains(t, s, "Preemption SysBatch Scheduler = false")
+	ui.ErrorWriter.Reset()
+	ui.OutputWriter.Reset()
+
+	// Request JSON output and test.
+	require.EqualValues(t, 0, c.Run([]string{"-address=" + addr, "-json"}))
+	s = ui.OutputWriter.String()
+	var js api.SchedulerConfiguration
+	require.NoError(t, json.Unmarshal([]byte(s), &js))
+	ui.ErrorWriter.Reset()
+	ui.OutputWriter.Reset()
+
+	// Request a template output and test.
+	require.EqualValues(t, 0, c.Run([]string{"-address=" + addr, "-t='{{printf \"%s!!!\" .SchedulerConfig.SchedulerAlgorithm}}'"}))
+	require.Contains(t, ui.OutputWriter.String(), "binpack!!!")
+	ui.ErrorWriter.Reset()
+	ui.OutputWriter.Reset()
+
+	// Test an unsupported flag.
+	require.EqualValues(t, 1, c.Run([]string{"-address=" + addr, "-yaml"}))
+	require.Contains(t, ui.OutputWriter.String(), "Usage: nomad operator scheduler get-config")
+}

--- a/command/operator_scheduler_set_config.go
+++ b/command/operator_scheduler_set_config.go
@@ -1,0 +1,210 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+	flagHelper "github.com/hashicorp/nomad/helper/flags"
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+)
+
+// Ensure OperatorSchedulerSetConfig satisfies the cli.Command interface.
+var _ cli.Command = &OperatorSchedulerSetConfig{}
+
+type OperatorSchedulerSetConfig struct {
+	Meta
+
+	// The scheduler configuration flags allow us to tell whether the user set
+	// a value or not. This means we can safely merge the current configuration
+	// with user supplied, selective updates.
+	checkIndex               string
+	schedulerAlgorithm       string
+	memoryOversubscription   flagHelper.BoolValue
+	rejectJobRegistration    flagHelper.BoolValue
+	pauseEvalBroker          flagHelper.BoolValue
+	preemptBatchScheduler    flagHelper.BoolValue
+	preemptServiceScheduler  flagHelper.BoolValue
+	preemptSysBatchScheduler flagHelper.BoolValue
+	preemptSystemScheduler   flagHelper.BoolValue
+}
+
+func (o *OperatorSchedulerSetConfig) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(o.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-check-index": complete.PredictAnything,
+			"-scheduler-algorithm": complete.PredictSet(
+				string(api.SchedulerAlgorithmBinpack),
+				string(api.SchedulerAlgorithmSpread),
+			),
+			"-memory-oversubscription":    complete.PredictSet("true", "false"),
+			"-reject-job-registration":    complete.PredictSet("true", "false"),
+			"-pause-eval-broker":          complete.PredictSet("true", "false"),
+			"-preempt-batch-scheduler":    complete.PredictSet("true", "false"),
+			"-preempt-service-scheduler":  complete.PredictSet("true", "false"),
+			"-preempt-sysbatch-scheduler": complete.PredictSet("true", "false"),
+			"-preempt-system-scheduler":   complete.PredictSet("true", "false"),
+		},
+	)
+}
+
+func (o *OperatorSchedulerSetConfig) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (o *OperatorSchedulerSetConfig) Name() string { return "operator scheduler set-config" }
+
+func (o *OperatorSchedulerSetConfig) Run(args []string) int {
+
+	flags := o.Meta.FlagSet("set-config", FlagSetClient)
+	flags.Usage = func() { o.Ui.Output(o.Help()) }
+
+	flags.StringVar(&o.checkIndex, "check-index", "", "")
+	flags.StringVar(&o.schedulerAlgorithm, "scheduler-algorithm", "", "")
+	flags.Var(&o.memoryOversubscription, "memory-oversubscription", "")
+	flags.Var(&o.rejectJobRegistration, "reject-job-registration", "")
+	flags.Var(&o.pauseEvalBroker, "pause-eval-broker", "")
+	flags.Var(&o.preemptBatchScheduler, "preempt-batch-scheduler", "")
+	flags.Var(&o.preemptServiceScheduler, "preempt-service-scheduler", "")
+	flags.Var(&o.preemptSysBatchScheduler, "preempt-sysbatch-scheduler", "")
+	flags.Var(&o.preemptSystemScheduler, "preempt-system-scheduler", "")
+
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	// Set up a client.
+	client, err := o.Meta.Client()
+	if err != nil {
+		o.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	// Check that we got no arguments.
+	args = flags.Args()
+	if l := len(args); l != 0 {
+		o.Ui.Error("This command takes no arguments")
+		o.Ui.Error(commandErrorText(o))
+		return 1
+	}
+
+	// Convert the check index string and handle any errors before adding this
+	// to our request. This parsing handles empty values correctly.
+	checkIndex, _, err := parseCheckIndex(o.checkIndex)
+	if err != nil {
+		o.Ui.Error(fmt.Sprintf("Error parsing check-index value %q: %v", o.checkIndex, err))
+		return 1
+	}
+
+	// Fetch the current configuration. This will be used as a base to merge
+	// user configuration onto.
+	resp, _, err := client.Operator().SchedulerGetConfiguration(nil)
+	if err != nil {
+		o.Ui.Error(fmt.Sprintf("Error querying for scheduler configuration: %s", err))
+		return 1
+	}
+
+	if checkIndex > 0 && resp.SchedulerConfig.ModifyIndex != checkIndex {
+		errMsg := fmt.Sprintf("check-index %v does not match does not match current state value %v",
+			checkIndex, resp.SchedulerConfig.ModifyIndex)
+		o.Ui.Error(fmt.Sprintf("Error performing check index set: %s", errMsg))
+		return 1
+	}
+
+	schedulerConfig := resp.SchedulerConfig
+
+	// Overwrite the modification index if the user supplied one, otherwise we
+	// use what was included within the read response.
+	if checkIndex > 0 {
+		schedulerConfig.ModifyIndex = checkIndex
+	}
+
+	// Merge the current configuration with any values set by the operator.
+	if o.schedulerAlgorithm != "" {
+		schedulerConfig.SchedulerAlgorithm = api.SchedulerAlgorithm(o.schedulerAlgorithm)
+	}
+	o.memoryOversubscription.Merge(&schedulerConfig.MemoryOversubscriptionEnabled)
+	o.rejectJobRegistration.Merge(&schedulerConfig.RejectJobRegistration)
+	o.pauseEvalBroker.Merge(&schedulerConfig.PauseEvalBroker)
+	o.preemptBatchScheduler.Merge(&schedulerConfig.PreemptionConfig.BatchSchedulerEnabled)
+	o.preemptServiceScheduler.Merge(&schedulerConfig.PreemptionConfig.ServiceSchedulerEnabled)
+	o.preemptSysBatchScheduler.Merge(&schedulerConfig.PreemptionConfig.SysBatchSchedulerEnabled)
+	o.preemptSystemScheduler.Merge(&schedulerConfig.PreemptionConfig.SystemSchedulerEnabled)
+
+	// Check-and-set the new configuration.
+	result, _, err := client.Operator().SchedulerCASConfiguration(schedulerConfig, nil)
+	if err != nil {
+		o.Ui.Error(fmt.Sprintf("Error setting scheduler configuration: %s", err))
+		return 1
+	}
+	if result.Updated {
+		o.Ui.Output("Scheduler configuration updated!")
+		return 0
+	}
+	o.Ui.Output("Scheduler configuration could not be atomically updated, please try again")
+	return 1
+}
+
+func (o *OperatorSchedulerSetConfig) Synopsis() string {
+	return "Modify the current scheduler configuration"
+}
+
+func (o *OperatorSchedulerSetConfig) Help() string {
+	helpText := `
+Usage: nomad operator scheduler set-config [options]
+
+  Modifies the current scheduler configuration.
+
+  If ACLs are enabled, this command requires a token with the 'operator:write'
+  capability.
+
+General Options:
+
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
+
+Scheduler Set Config Options:
+
+  -check-index
+    If set, the scheduler config is only updated if the passed modify index
+    matches the current server side version. If a non-zero value is passed, it
+    ensures that the scheduler config is being updated from a known state.
+
+  -scheduler-algorithm=["binpack"|"spread"]
+    Specifies whether scheduler binpacks or spreads allocations on available
+    nodes.
+
+  -memory-oversubscription=[true|false]
+    When true, tasks may exceed their reserved memory limit, if the client has
+    excess memory capacity. Tasks must specify memory_max to take advantage of
+    memory oversubscription.
+
+  -reject-job-registration=[true|false]
+    When true, the server will return permission denied errors for job registration,
+    job dispatch, and job scale APIs, unless the ACL token for the request is a
+    management token. If ACLs are disabled, no user will be able to register jobs.
+    This allows operators to shed load from automated processes during incident
+    response.
+
+  -pause-eval-broker=[true|false]
+    When set to true, the eval broker which usually runs on the leader will be
+    disabled. This will prevent the scheduler workers from receiving new work.
+
+  -preempt-batch-scheduler=[true|false]
+    Specifies whether preemption for batch jobs is enabled. Note that if this
+    is set to true, then batch jobs can preempt any other jobs.
+
+  -preempt-service-scheduler=[true|false]
+    Specifies whether preemption for service jobs is enabled. Note that if this
+    is set to true, then service jobs can preempt any other jobs.
+
+  -preempt-sysbatch-scheduler=[true|false]
+    Specifies whether preemption for system batch jobs is enabled. Note that if
+    this is set to true, then system batch jobs can preempt any other jobs.
+
+  -preempt-system-scheduler=[true|false]
+    Specifies whether preemption for system jobs is enabled. Note that if this
+    is set to true, then system jobs can preempt any other jobs.
+`
+	return strings.TrimSpace(helpText)
+}

--- a/command/operator_scheduler_set_config_test.go
+++ b/command/operator_scheduler_set_config_test.go
@@ -1,0 +1,108 @@
+package command
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/ci"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperatorSchedulerSetConfig_Run(t *testing.T) {
+	ci.Parallel(t)
+
+	srv, _, addr := testServer(t, false, nil)
+	defer srv.Shutdown()
+
+	ui := cli.NewMockUi()
+	c := &OperatorSchedulerSetConfig{Meta: Meta{Ui: ui}}
+
+	bootstrappedConfig, _, err := srv.Client().Operator().SchedulerGetConfiguration(nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, bootstrappedConfig.SchedulerConfig)
+
+	// Run the command with zero value and ensure the configuration does not
+	// change.
+	require.EqualValues(t, 0, c.Run([]string{"-address=" + addr}))
+	ui.ErrorWriter.Reset()
+	ui.OutputWriter.Reset()
+
+	// Read the configuration again and test that nothing has changed which
+	// ensures our empty flags are working correctly.
+	nonModifiedConfig, _, err := srv.Client().Operator().SchedulerGetConfiguration(nil)
+	require.NoError(t, err)
+	schedulerConfigEquals(t, bootstrappedConfig.SchedulerConfig, nonModifiedConfig.SchedulerConfig)
+
+	// Modify every configuration parameter using the flags. This ensures the
+	// merging is working correctly and that operators can control the entire
+	// object via the CLI.
+	modifyingArgs := []string{
+		"-address=" + addr,
+		"-scheduler-algorithm=spread",
+		"-pause-eval-broker=true",
+		"-memory-oversubscription=true",
+		"-reject-job-registration=true",
+		"-preempt-batch-scheduler=true",
+		"-preempt-service-scheduler=true",
+		"-preempt-sysbatch-scheduler=true",
+		"-preempt-system-scheduler=false",
+	}
+	require.EqualValues(t, 0, c.Run(modifyingArgs))
+	s := ui.OutputWriter.String()
+	require.Contains(t, s, "Scheduler configuration updated!")
+
+	modifiedConfig, _, err := srv.Client().Operator().SchedulerGetConfiguration(nil)
+	require.NoError(t, err)
+	schedulerConfigEquals(t, &api.SchedulerConfiguration{
+		SchedulerAlgorithm: "spread",
+		PreemptionConfig: api.PreemptionConfig{
+			SystemSchedulerEnabled:   false,
+			SysBatchSchedulerEnabled: true,
+			BatchSchedulerEnabled:    true,
+			ServiceSchedulerEnabled:  true,
+		},
+		MemoryOversubscriptionEnabled: true,
+		RejectJobRegistration:         true,
+		PauseEvalBroker:               true,
+	}, modifiedConfig.SchedulerConfig)
+
+	ui.ErrorWriter.Reset()
+	ui.OutputWriter.Reset()
+
+	// Make a Freudian slip with one of the flags to ensure the usage is
+	// returned.
+	require.EqualValues(t, 1, c.Run([]string{"-address=" + addr, "-pause-evil-broker=true"}))
+	require.Contains(t, ui.OutputWriter.String(), "Usage: nomad operator scheduler set-config")
+	ui.ErrorWriter.Reset()
+	ui.OutputWriter.Reset()
+
+	// Try updating the config using an incorrect check-index value.
+	require.EqualValues(t, 1, c.Run([]string{
+		"-address=" + addr,
+		"-pause-eval-broker=false",
+		"-check-index=1000000",
+	}))
+	require.Contains(t, ui.ErrorWriter.String(), "check-index 1000000 does not match does not match current state")
+	ui.ErrorWriter.Reset()
+	ui.OutputWriter.Reset()
+
+	// Try updating the config using a correct check-index value.
+	require.EqualValues(t, 0, c.Run([]string{
+		"-address=" + addr,
+		"-pause-eval-broker=false",
+		"-check-index=" + strconv.FormatUint(modifiedConfig.SchedulerConfig.ModifyIndex, 10),
+	}))
+	require.Contains(t, ui.OutputWriter.String(), "Scheduler configuration updated!")
+	ui.ErrorWriter.Reset()
+	ui.OutputWriter.Reset()
+}
+
+func schedulerConfigEquals(t *testing.T, expected, actual *api.SchedulerConfiguration) {
+	require.Equal(t, expected.SchedulerAlgorithm, actual.SchedulerAlgorithm)
+	require.Equal(t, expected.RejectJobRegistration, actual.RejectJobRegistration)
+	require.Equal(t, expected.MemoryOversubscriptionEnabled, actual.MemoryOversubscriptionEnabled)
+	require.Equal(t, expected.PauseEvalBroker, actual.PauseEvalBroker)
+	require.Equal(t, expected.PreemptionConfig, actual.PreemptionConfig)
+}

--- a/e2e/operator_scheduler/doc.go
+++ b/e2e/operator_scheduler/doc.go
@@ -1,0 +1,6 @@
+// Package operator_scheduler provides end-to-end tests for the Nomad operator
+// scheduler functionality and configuration options.
+//
+// In order to run this test suite only, from the e2e directory you can trigger
+// go test -v -run '^TestOperatorScheduler' ./operator_scheduler
+package operator_scheduler

--- a/e2e/operator_scheduler/input/basic.nomad
+++ b/e2e/operator_scheduler/input/basic.nomad
@@ -1,0 +1,21 @@
+job "operator_scheduler" {
+  datacenters = ["dc1"]
+  type        = "batch"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "operator_scheduler" {
+
+    task "test" {
+      driver = "raw_exec"
+
+      config {
+        command = "bash"
+        args    = ["-c", "sleep 1"]
+      }
+    }
+  }
+}

--- a/e2e/operator_scheduler/operator_scheduler_test.go
+++ b/e2e/operator_scheduler/operator_scheduler_test.go
@@ -1,0 +1,117 @@
+package operator_scheduler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/e2e/e2eutil"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const jobBasic = "./input/basic.nomad"
+
+// TestOperatorScheduler runs the Nomad Operator Scheduler suit of tests which
+// focus on the behaviour of the /v1/operator/scheduler API.
+func TestOperatorScheduler(t *testing.T) {
+
+	// Wait until we have a usable cluster before running the tests.
+	nomadClient := e2eutil.NomadClient(t)
+	e2eutil.WaitForLeader(t, nomadClient)
+	e2eutil.WaitForNodesReady(t, nomadClient, 1)
+
+	// Run our test cases.
+	t.Run("TestOperatorScheduler_ConfigPauseEvalBroker", testConfigPauseEvalBroker)
+}
+
+// testConfig tests pausing and un-pausing the eval broker and ensures the
+// correct behaviour is observed at each stage.
+func testConfigPauseEvalBroker(t *testing.T) {
+
+	nomadClient := e2eutil.NomadClient(t)
+
+	// Generate our job ID which will be used for the entire test.
+	jobID := "operator-scheduler-config-pause-eval-broker-" + uuid.Generate()[:8]
+	jobIDs := []string{jobID}
+
+	// Defer a cleanup function to remove the job. This will trigger if the
+	// test fails, unless the cancel function is called.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer e2eutil.CleanupJobsAndGCWithContext(t, ctx, &jobIDs)
+
+	// Register the job and ensure the alloc reaches the running state before
+	// moving safely on.
+	allocStubs := e2eutil.RegisterAndWaitForAllocs(t, nomadClient, jobBasic, jobID, "")
+	require.Len(t, allocStubs, 1)
+	e2eutil.WaitForAllocRunning(t, nomadClient, allocStubs[0].ID)
+
+	// Get the current scheduler config object.
+	schedulerConfig, _, err := nomadClient.Operator().SchedulerGetConfiguration(nil)
+	require.NoError(t, err)
+	require.NotNil(t, schedulerConfig.SchedulerConfig)
+
+	// Set the eval broker to be paused.
+	schedulerConfig.SchedulerConfig.PauseEvalBroker = true
+
+	// Write the config back to Nomad.
+	schedulerConfigUpdate, _, err := nomadClient.Operator().SchedulerSetConfiguration(
+		schedulerConfig.SchedulerConfig, nil)
+	require.NoError(t, err)
+	require.True(t, schedulerConfigUpdate.Updated)
+
+	// Perform a deregister call. The call will succeed and create an
+	// evaluation. Do not use purge, so we can check the job status when
+	// dereigster happens.
+	evalID, _, err := nomadClient.Jobs().Deregister(jobID, false, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, evalID)
+
+	// Evaluation status is set to pending initially, so there isn't a great
+	// way to ensure it doesn't transition to another status other than polling
+	// for a long enough time to assume it won't change.
+	timedFn := func() error {
+
+		// 5 seconds should be more than enough time for an eval to change
+		// status unless the broker is disabled.
+		timer := time.NewTimer(5 * time.Second)
+		defer timer.Stop()
+
+		for {
+			select {
+			case <-timer.C:
+				return nil
+			default:
+				evalInfo, _, err := nomadClient.Evaluations().Info(evalID, nil)
+				if err != nil {
+					return err
+				}
+				if !assert.Equal(t, "pending", evalInfo.Status) {
+					return fmt.Errorf(`expected eval status "pending", got %q`, evalInfo.Status)
+				}
+				time.Sleep(1 * time.Second)
+			}
+		}
+	}
+	require.NoError(t, timedFn())
+
+	// Set the eval broker to be un-paused.
+	schedulerConfig.SchedulerConfig.PauseEvalBroker = false
+
+	// Write the config back to Nomad.
+	schedulerConfigUpdate, _, err = nomadClient.Operator().SchedulerSetConfiguration(
+		schedulerConfig.SchedulerConfig, nil)
+	require.NoError(t, err)
+	require.True(t, schedulerConfigUpdate.Updated)
+
+	// Ensure the job is stopped, then run the garbage collection to clear out
+	// all resources.
+	e2eutil.WaitForJobStopped(t, nomadClient, jobID)
+	_, err = e2eutil.Command("nomad", "system", "gc")
+	require.NoError(t, err)
+
+	// If we have reached this far, we do not need to run the cleanup function.
+	cancel()
+}

--- a/helper/broker/notify.go
+++ b/helper/broker/notify.go
@@ -1,0 +1,106 @@
+package broker
+
+import (
+	"time"
+
+	"github.com/hashicorp/nomad/helper"
+)
+
+// GenericNotifier allows a process to send updates to many subscribers in an
+// easy manner.
+type GenericNotifier struct {
+
+	// publishCh is the channel used to receive the update which will be sent
+	// to all subscribers.
+	publishCh chan interface{}
+
+	// subscribeCh and unsubscribeCh are the channels used to modify the
+	// subscription membership mapping.
+	subscribeCh   chan chan interface{}
+	unsubscribeCh chan chan interface{}
+}
+
+// NewGenericNotifier returns a generic notifier which can be used by a process
+// to notify many subscribers when a specific update is triggered.
+func NewGenericNotifier() *GenericNotifier {
+	return &GenericNotifier{
+		publishCh:     make(chan interface{}, 1),
+		subscribeCh:   make(chan chan interface{}, 1),
+		unsubscribeCh: make(chan chan interface{}, 1),
+	}
+}
+
+// Notify allows the implementer to notify all subscribers with a specific
+// update. There is no guarantee the order in which subscribers receive the
+// message which is sent linearly.
+func (g *GenericNotifier) Notify(msg interface{}) {
+	select {
+	case g.publishCh <- msg:
+	default:
+	}
+}
+
+// Run is a long-lived process which handles updating subscribers as well as
+// ensuring any update is sent to them. The passed stopCh is used to coordinate
+// shutdown.
+func (g *GenericNotifier) Run(stopCh <-chan struct{}) {
+
+	// Store our subscribers inline with a map. This map can only be accessed
+	// via a single channel update at a time, meaning we can manage without
+	// using a lock.
+	subscribers := map[chan interface{}]struct{}{}
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		case msgCh := <-g.subscribeCh:
+			subscribers[msgCh] = struct{}{}
+		case msgCh := <-g.unsubscribeCh:
+			delete(subscribers, msgCh)
+		case update := <-g.publishCh:
+			for subscriberCh := range subscribers {
+
+				// The subscribers channels are buffered, but ensure we don't
+				// block the whole process on this.
+				select {
+				case subscriberCh <- update:
+				default:
+				}
+			}
+		}
+	}
+}
+
+// WaitForChange allows a subscriber to wait until there is a notification
+// change, or the timeout is reached. The function will block until one
+// condition is met.
+func (g *GenericNotifier) WaitForChange(timeout time.Duration) interface{} {
+
+	// Create a channel and subscribe to any update. This channel is buffered
+	// to ensure we do not block the main broker process.
+	updateCh := make(chan interface{}, 1)
+	g.subscribeCh <- updateCh
+
+	// Create a timeout timer and use the helper to ensure this routine doesn't
+	// panic and making the stop call clear.
+	timeoutTimer, timeoutStop := helper.NewSafeTimer(timeout)
+
+	// Defer a function which performs all the required cleanup of the
+	// subscriber once it has been notified of a change, or reached its wait
+	// timeout.
+	defer func() {
+		g.unsubscribeCh <- updateCh
+		close(updateCh)
+		timeoutStop()
+	}()
+
+	// Enter the main loop which listens for an update or timeout and returns
+	// this information to the subscriber.
+	select {
+	case <-timeoutTimer.C:
+		return "wait timed out after " + timeout.String()
+	case update := <-updateCh:
+		return update
+	}
+}

--- a/helper/broker/notify_test.go
+++ b/helper/broker/notify_test.go
@@ -1,0 +1,55 @@
+package broker
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenericNotifier(t *testing.T) {
+	ci.Parallel(t)
+
+	// Create the new notifier.
+	stopChan := make(chan struct{})
+	defer close(stopChan)
+
+	notifier := NewGenericNotifier()
+	go notifier.Run(stopChan)
+
+	// Ensure we have buffered channels.
+	require.Equal(t, 1, cap(notifier.publishCh))
+	require.Equal(t, 1, cap(notifier.subscribeCh))
+	require.Equal(t, 1, cap(notifier.unsubscribeCh))
+
+	// Test that the timeout works.
+	var timeoutWG sync.WaitGroup
+
+	for i := 0; i < 6; i++ {
+		go func(wg *sync.WaitGroup) {
+			wg.Add(1)
+			msg := notifier.WaitForChange(100 * time.Millisecond)
+			require.Equal(t, "wait timed out after 100ms", msg)
+			wg.Done()
+		}(&timeoutWG)
+	}
+	timeoutWG.Wait()
+
+	// Test that all subscribers recieve an update when a single notification
+	// is sent.
+	var notifiedWG sync.WaitGroup
+
+	for i := 0; i < 6; i++ {
+		go func(wg *sync.WaitGroup) {
+			wg.Add(1)
+			msg := notifier.WaitForChange(3 * time.Second)
+			require.Equal(t, "we got an update and not a timeout", msg)
+			wg.Done()
+		}(&notifiedWG)
+	}
+
+	notifier.Notify("we got an update and not a timeout")
+	notifiedWG.Wait()
+}

--- a/nomad/eval_broker.go
+++ b/nomad/eval_broker.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"sync"
 	"time"
 
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/broker"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/lib/delayheap"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -48,8 +50,10 @@ type EvalBroker struct {
 	nackTimeout   time.Duration
 	deliveryLimit int
 
-	enabled bool
-	stats   *BrokerStats
+	enabled         bool
+	enabledNotifier *broker.GenericNotifier
+
+	stats *BrokerStats
 
 	// evals tracks queued evaluations by ID to de-duplicate enqueue.
 	// The counter is the number of times we've attempted delivery,
@@ -131,6 +135,7 @@ func NewEvalBroker(timeout, initialNackDelay, subsequentNackDelay time.Duration,
 		nackTimeout:          timeout,
 		deliveryLimit:        deliveryLimit,
 		enabled:              false,
+		enabledNotifier:      broker.NewGenericNotifier(),
 		stats:                new(BrokerStats),
 		evals:                make(map[string]int),
 		jobEvals:             make(map[structs.NamespacedID]string),
@@ -176,6 +181,9 @@ func (b *EvalBroker) SetEnabled(enabled bool) {
 	if !enabled {
 		b.flush()
 	}
+
+	// Notify all subscribers to state changes of the broker enabled value.
+	b.enabledNotifier.Notify("eval broker enabled status changed to " + strconv.FormatBool(enabled))
 }
 
 // Enqueue is used to enqueue a new evaluation

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -1,6 +1,7 @@
 package nomad
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -391,7 +392,7 @@ func (e *Eval) Reblock(args *structs.EvalUpdateRequest, reply *structs.GenericRe
 }
 
 // Reap is used to cleanup dead evaluations and allocations
-func (e *Eval) Reap(args *structs.EvalDeleteRequest,
+func (e *Eval) Reap(args *structs.EvalReapRequest,
 	reply *structs.GenericResponse) error {
 
 	// Ensure the connection was initiated by another server if TLS is used.
@@ -414,6 +415,150 @@ func (e *Eval) Reap(args *structs.EvalDeleteRequest,
 	// Update the index
 	reply.Index = index
 	return nil
+}
+
+// Delete is used by operators to delete evaluations during severe outages. It
+// differs from Reap while duplicating some behavior to ensure we have the
+// correct controls for user initiated deletions.
+func (e *Eval) Delete(
+	args *structs.EvalDeleteRequest,
+	reply *structs.EvalDeleteResponse) error {
+
+	if done, err := e.srv.forward(structs.EvalDeleteRPCMethod, args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince([]string{"nomad", "eval", "delete"}, time.Now())
+
+	// This RPC endpoint is very destructive and alters Nomad's core state,
+	// meaning only those with management tokens can call it.
+	if aclObj, err := e.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
+	// The eval broker must be disabled otherwise Nomad's state will likely get
+	// wild in a very un-fun way.
+	if e.srv.evalBroker.Enabled() {
+		return errors.New("eval broker is enabled; eval broker must be paused to delete evals")
+	}
+
+	// Grab the state snapshot, so we can look up relevant eval information.
+	serverStateSnapshot, err := e.srv.State().Snapshot()
+	if err != nil {
+		return fmt.Errorf("failed to lookup state snapshot: %v", err)
+	}
+	ws := memdb.NewWatchSet()
+
+	// Iterate the evaluations and ensure they are safe to delete. It is
+	// possible passed evals are not safe to delete and would make Nomads state
+	// a little wonky. The nature of the RPC return error, means a single
+	// unsafe eval ID fails the whole call.
+	for _, evalID := range args.EvalIDs {
+
+		evalInfo, err := serverStateSnapshot.EvalByID(ws, evalID)
+		if err != nil {
+			return fmt.Errorf("failed to lookup eval: %v", err)
+		}
+		if evalInfo == nil {
+			return errors.New("eval not found")
+		}
+
+		jobInfo, err := serverStateSnapshot.JobByID(ws, evalInfo.Namespace, evalInfo.JobID)
+		if err != nil {
+			return fmt.Errorf("failed to lookup eval job: %v", err)
+		}
+
+		allocs, err := serverStateSnapshot.AllocsByEval(ws, evalInfo.ID)
+		if err != nil {
+			return fmt.Errorf("failed to lookup eval allocs: %v", err)
+		}
+
+		if !evalDeleteSafe(allocs, jobInfo) {
+			return fmt.Errorf("eval %s is not safe to delete", evalID)
+		}
+	}
+
+	// Generate the Raft request object using the reap request object. This
+	// avoids adding new Raft messages types and follows the existing reap
+	// flow.
+	raftReq := structs.EvalReapRequest{
+		Evals:         args.EvalIDs,
+		UserInitiated: true,
+		WriteRequest:  args.WriteRequest,
+	}
+
+	// Update via Raft.
+	_, index, err := e.srv.raftApply(structs.EvalDeleteRequestType, &raftReq)
+	if err != nil {
+		return err
+	}
+
+	// Update the index and return.
+	reply.Index = index
+	return nil
+}
+
+// evalDeleteSafe ensures an evaluation is safe to delete based on its related
+// allocation and job information. This follows similar, but different rules to
+// the eval reap checking, to ensure evaluations for running allocs or allocs
+// which need the evaluation detail are not deleted.
+func evalDeleteSafe(allocs []*structs.Allocation, job *structs.Job) bool {
+
+	// If the job is deleted, stopped, or dead, all allocs are terminal and
+	// the eval can be deleted.
+	if job == nil || job.Stop || job.Status == structs.JobStatusDead {
+		return true
+	}
+
+	// Iterate the allocations associated to the eval, if any, and check
+	// whether we can delete the eval.
+	for _, alloc := range allocs {
+
+		// If the allocation is still classed as running on the client, or
+		// might be, we can't delete.
+		switch alloc.ClientStatus {
+		case structs.AllocClientStatusRunning, structs.AllocClientStatusUnknown:
+			return false
+		}
+
+		// If the alloc hasn't failed then we don't need to consider it for
+		// rescheduling. Rescheduling needs to copy over information from the
+		// previous alloc so that it can enforce the reschedule policy.
+		if alloc.ClientStatus != structs.AllocClientStatusFailed {
+			continue
+		}
+
+		var reschedulePolicy *structs.ReschedulePolicy
+		tg := job.LookupTaskGroup(alloc.TaskGroup)
+
+		if tg != nil {
+			reschedulePolicy = tg.ReschedulePolicy
+		}
+
+		// No reschedule policy or rescheduling is disabled
+		if reschedulePolicy == nil || (!reschedulePolicy.Unlimited && reschedulePolicy.Attempts == 0) {
+			continue
+		}
+
+		// The restart tracking information has not been carried forward.
+		if alloc.NextAllocation == "" {
+			return false
+		}
+
+		// This task has unlimited rescheduling and the alloc has not been
+		// replaced, so we can't delete the eval yet.
+		if reschedulePolicy.Unlimited {
+			return false
+		}
+
+		// No restarts have been attempted yet.
+		if alloc.RescheduleTracker == nil || len(alloc.RescheduleTracker.Events) == 0 {
+			return false
+		}
+	}
+
+	return true
 }
 
 // List is used to get a list of the evaluations in the system

--- a/nomad/eval_endpoint_test.go
+++ b/nomad/eval_endpoint_test.go
@@ -202,7 +202,7 @@ func TestEvalEndpoint_GetEval_Blocking(t *testing.T) {
 
 	// Eval delete triggers watches
 	time.AfterFunc(100*time.Millisecond, func() {
-		err := state.DeleteEval(300, []string{eval2.ID}, []string{})
+		err := state.DeleteEval(300, []string{eval2.ID}, []string{}, false)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -691,7 +691,7 @@ func TestEvalEndpoint_Reap(t *testing.T) {
 	s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1})
 
 	// Reap the eval
-	get := &structs.EvalDeleteRequest{
+	get := &structs.EvalReapRequest{
 		Evals:        []string{eval1.ID},
 		WriteRequest: structs.WriteRequest{Region: "global"},
 	}
@@ -711,6 +711,351 @@ func TestEvalEndpoint_Reap(t *testing.T) {
 	}
 	if outE != nil {
 		t.Fatalf("Bad: %#v", outE)
+	}
+}
+
+func TestEvalEndpoint_Delete(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		testFn func()
+		name   string
+	}{
+		{
+			testFn: func() {
+
+				testServer, testServerCleanup := TestServer(t, nil)
+				defer testServerCleanup()
+
+				codec := rpcClient(t, testServer)
+				testutil.WaitForLeader(t, testServer.RPC)
+
+				// Create and upsert an evaluation.
+				mockEval := mock.Eval()
+				require.NoError(t, testServer.fsm.State().UpsertEvals(
+					structs.MsgTypeTestSetup, 10, []*structs.Evaluation{mockEval}))
+
+				// Attempt to delete the eval, which should fail because the
+				// eval broker is not paused.
+				get := &structs.EvalDeleteRequest{
+					EvalIDs:      []string{mockEval.ID},
+					WriteRequest: structs.WriteRequest{Region: "global"},
+				}
+				var resp structs.EvalDeleteResponse
+				err := msgpackrpc.CallWithCodec(codec, structs.EvalDeleteRPCMethod, get, &resp)
+				require.Contains(t, err.Error(), "eval broker is enabled")
+			},
+			name: "unsuccessful delete broker enabled",
+		},
+		{
+			testFn: func() {
+
+				testServer, testServerCleanup := TestServer(t, func(c *Config) {
+					c.NumSchedulers = 0
+				})
+				defer testServerCleanup()
+
+				codec := rpcClient(t, testServer)
+				testutil.WaitForLeader(t, testServer.RPC)
+
+				// Pause the eval broker and update the scheduler config.
+				testServer.evalBroker.SetEnabled(false)
+
+				_, schedulerConfig, err := testServer.fsm.State().SchedulerConfig()
+				require.NoError(t, err)
+				require.NotNil(t, schedulerConfig)
+
+				schedulerConfig.PauseEvalBroker = true
+				require.NoError(t, testServer.fsm.State().SchedulerSetConfig(10, schedulerConfig))
+
+				// Create and upsert an evaluation.
+				mockEval := mock.Eval()
+				require.NoError(t, testServer.fsm.State().UpsertEvals(
+					structs.MsgTypeTestSetup, 10, []*structs.Evaluation{mockEval}))
+
+				// Attempt to delete the eval, which should succeed as the eval
+				// broker is disabled.
+				get := &structs.EvalDeleteRequest{
+					EvalIDs:      []string{mockEval.ID},
+					WriteRequest: structs.WriteRequest{Region: "global"},
+				}
+				var resp structs.EvalDeleteResponse
+				require.NoError(t, msgpackrpc.CallWithCodec(codec, structs.EvalDeleteRPCMethod, get, &resp))
+
+				// Attempt to read the eval from state; this should not be found.
+				ws := memdb.NewWatchSet()
+				respEval, err := testServer.fsm.State().EvalByID(ws, mockEval.ID)
+				require.Nil(t, err)
+				require.Nil(t, respEval)
+			},
+			name: "successful delete without ACLs",
+		},
+		{
+			testFn: func() {
+
+				testServer, rootToken, testServerCleanup := TestACLServer(t, func(c *Config) {
+					c.NumSchedulers = 0
+				})
+				defer testServerCleanup()
+
+				codec := rpcClient(t, testServer)
+				testutil.WaitForLeader(t, testServer.RPC)
+
+				// Pause the eval broker and update the scheduler config.
+				testServer.evalBroker.SetEnabled(false)
+
+				_, schedulerConfig, err := testServer.fsm.State().SchedulerConfig()
+				require.NoError(t, err)
+				require.NotNil(t, schedulerConfig)
+
+				schedulerConfig.PauseEvalBroker = true
+				require.NoError(t, testServer.fsm.State().SchedulerSetConfig(10, schedulerConfig))
+
+				// Create and upsert an evaluation.
+				mockEval := mock.Eval()
+				require.NoError(t, testServer.fsm.State().UpsertEvals(
+					structs.MsgTypeTestSetup, 20, []*structs.Evaluation{mockEval}))
+
+				// Attempt to delete the eval, which should succeed as the eval
+				// broker is disabled, and we are using a management token.
+				get := &structs.EvalDeleteRequest{
+					EvalIDs: []string{mockEval.ID},
+					WriteRequest: structs.WriteRequest{
+						AuthToken: rootToken.SecretID,
+						Region:    "global",
+					},
+				}
+				var resp structs.EvalDeleteResponse
+				require.NoError(t, msgpackrpc.CallWithCodec(codec, structs.EvalDeleteRPCMethod, get, &resp))
+
+				// Attempt to read the eval from state; this should not be found.
+				ws := memdb.NewWatchSet()
+				respEval, err := testServer.fsm.State().EvalByID(ws, mockEval.ID)
+				require.Nil(t, err)
+				require.Nil(t, respEval)
+			},
+			name: "successful delete with ACLs",
+		},
+		{
+			testFn: func() {
+
+				testServer, _, testServerCleanup := TestACLServer(t, func(c *Config) {
+					c.NumSchedulers = 0
+				})
+				defer testServerCleanup()
+
+				codec := rpcClient(t, testServer)
+				testutil.WaitForLeader(t, testServer.RPC)
+
+				// Pause the eval broker.
+				testServer.evalBroker.SetEnabled(false)
+
+				// Create and upsert an evaluation.
+				mockEval := mock.Eval()
+				require.NoError(t, testServer.fsm.State().UpsertEvals(
+					structs.MsgTypeTestSetup, 10, []*structs.Evaluation{mockEval}))
+
+				nonMgntToken := mock.CreatePolicyAndToken(t, testServer.State(), 20, "test-valid",
+					mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
+
+				// Attempt to delete the eval, which should not succeed as we
+				// are using a non-management token.
+				get := &structs.EvalDeleteRequest{
+					EvalIDs: []string{mockEval.ID},
+					WriteRequest: structs.WriteRequest{
+						AuthToken: nonMgntToken.SecretID,
+						Region:    "global",
+					},
+				}
+				var resp structs.EvalDeleteResponse
+				err := msgpackrpc.CallWithCodec(codec, structs.EvalDeleteRPCMethod, get, &resp)
+				require.Contains(t, err.Error(), structs.ErrPermissionDenied.Error())
+			},
+			name: "unsuccessful delete with ACLs incorrect token permissions",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.testFn()
+		})
+	}
+}
+
+func Test_evalDeleteSafe(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		inputAllocs    []*structs.Allocation
+		inputJob       *structs.Job
+		expectedResult bool
+		name           string
+	}{
+		{
+			inputAllocs:    nil,
+			inputJob:       nil,
+			expectedResult: true,
+			name:           "job not in state",
+		},
+		{
+			inputAllocs:    nil,
+			inputJob:       &structs.Job{Status: structs.JobStatusDead},
+			expectedResult: true,
+			name:           "job stopped",
+		},
+		{
+			inputAllocs:    nil,
+			inputJob:       &structs.Job{Stop: true},
+			expectedResult: true,
+			name:           "job dead",
+		},
+		{
+			inputAllocs:    []*structs.Allocation{},
+			inputJob:       &structs.Job{Status: structs.JobStatusRunning},
+			expectedResult: true,
+			name:           "no allocs for eval",
+		},
+		{
+			inputAllocs: []*structs.Allocation{
+				{ClientStatus: structs.AllocClientStatusComplete},
+				{ClientStatus: structs.AllocClientStatusRunning},
+			},
+			inputJob:       &structs.Job{Status: structs.JobStatusRunning},
+			expectedResult: false,
+			name:           "running alloc for eval",
+		},
+		{
+			inputAllocs: []*structs.Allocation{
+				{ClientStatus: structs.AllocClientStatusComplete},
+				{ClientStatus: structs.AllocClientStatusUnknown},
+			},
+			inputJob:       &structs.Job{Status: structs.JobStatusRunning},
+			expectedResult: false,
+			name:           "unknown alloc for eval",
+		},
+		{
+			inputAllocs: []*structs.Allocation{
+				{ClientStatus: structs.AllocClientStatusComplete},
+				{ClientStatus: structs.AllocClientStatusLost},
+			},
+			inputJob:       &structs.Job{Status: structs.JobStatusRunning},
+			expectedResult: true,
+			name:           "complete and lost allocs for eval",
+		},
+		{
+			inputAllocs: []*structs.Allocation{
+				{
+					ClientStatus: structs.AllocClientStatusFailed,
+					TaskGroup:    "test",
+				},
+			},
+			inputJob: &structs.Job{
+				Status: structs.JobStatusPending,
+				TaskGroups: []*structs.TaskGroup{
+					{
+						Name:             "test",
+						ReschedulePolicy: nil,
+					},
+				},
+			},
+			expectedResult: true,
+			name:           "failed alloc job without reschedule",
+		},
+		{
+			inputAllocs: []*structs.Allocation{
+				{
+					ClientStatus: structs.AllocClientStatusFailed,
+					TaskGroup:    "test",
+				},
+			},
+			inputJob: &structs.Job{
+				Status: structs.JobStatusPending,
+				TaskGroups: []*structs.TaskGroup{
+					{
+						Name: "test",
+						ReschedulePolicy: &structs.ReschedulePolicy{
+							Unlimited: false,
+							Attempts:  0,
+						},
+					},
+				},
+			},
+			expectedResult: true,
+			name:           "failed alloc job reschedule disabled",
+		},
+		{
+			inputAllocs: []*structs.Allocation{
+				{
+					ClientStatus: structs.AllocClientStatusFailed,
+					TaskGroup:    "test",
+				},
+			},
+			inputJob: &structs.Job{
+				Status: structs.JobStatusPending,
+				TaskGroups: []*structs.TaskGroup{
+					{
+						Name: "test",
+						ReschedulePolicy: &structs.ReschedulePolicy{
+							Unlimited: false,
+							Attempts:  3,
+						},
+					},
+				},
+			},
+			expectedResult: false,
+			name:           "failed alloc next alloc not set",
+		},
+		{
+			inputAllocs: []*structs.Allocation{
+				{
+					ClientStatus:   structs.AllocClientStatusFailed,
+					TaskGroup:      "test",
+					NextAllocation: "4aa4930a-8749-c95b-9c67-5ef29b0fc653",
+				},
+			},
+			inputJob: &structs.Job{
+				Status: structs.JobStatusPending,
+				TaskGroups: []*structs.TaskGroup{
+					{
+						Name: "test",
+						ReschedulePolicy: &structs.ReschedulePolicy{
+							Unlimited: false,
+							Attempts:  3,
+						},
+					},
+				},
+			},
+			expectedResult: false,
+			name:           "failed alloc next alloc set",
+		},
+		{
+			inputAllocs: []*structs.Allocation{
+				{
+					ClientStatus: structs.AllocClientStatusFailed,
+					TaskGroup:    "test",
+				},
+			},
+			inputJob: &structs.Job{
+				Status: structs.JobStatusPending,
+				TaskGroups: []*structs.TaskGroup{
+					{
+						Name: "test",
+						ReschedulePolicy: &structs.ReschedulePolicy{
+							Unlimited: true,
+						},
+					},
+				},
+			},
+			expectedResult: false,
+			name:           "failed alloc job reschedule unlimited",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualResult := evalDeleteSafe(tc.inputAllocs, tc.inputJob)
+			require.Equal(t, tc.expectedResult, actualResult)
+		})
 	}
 }
 
@@ -1002,7 +1347,7 @@ func TestEvalEndpoint_List_Blocking(t *testing.T) {
 
 	// Eval deletion triggers watches
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.DeleteEval(3, []string{eval.ID}, nil); err != nil {
+		if err := state.DeleteEval(3, []string{eval.ID}, nil, false); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -782,12 +782,12 @@ func (n *nomadFSM) handleUpsertedEval(eval *structs.Evaluation) {
 
 func (n *nomadFSM) applyDeleteEval(buf []byte, index uint64) interface{} {
 	defer metrics.MeasureSince([]string{"nomad", "fsm", "delete_eval"}, time.Now())
-	var req structs.EvalDeleteRequest
+	var req structs.EvalReapRequest
 	if err := structs.Decode(buf, &req); err != nil {
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
 
-	if err := n.state.DeleteEval(index, req.Evals, req.Allocs); err != nil {
+	if err := n.state.DeleteEval(index, req.Evals, req.Allocs, req.UserInitiated); err != nil {
 		n.logger.Error("DeleteEval failed", "error", err)
 		return err
 	}

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -1160,7 +1160,7 @@ func TestFSM_DeleteEval(t *testing.T) {
 		t.Fatalf("resp: %v", resp)
 	}
 
-	req2 := structs.EvalDeleteRequest{
+	req2 := structs.EvalReapRequest{
 		Evals: []string{eval.ID},
 	}
 	buf, err = structs.Encode(structs.EvalDeleteRequestType, req2)

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -2265,7 +2265,7 @@ func TestClientEndpoint_GetClientAllocs_Blocking_GC(t *testing.T) {
 
 	// Delete an allocation
 	time.AfterFunc(100*time.Millisecond, func() {
-		assert.Nil(state.DeleteEval(200, nil, []string{alloc2.ID}))
+		assert.Nil(state.DeleteEval(200, nil, []string{alloc2.ID}, false))
 	})
 
 	req.QueryOptions.MinQueryIndex = 150

--- a/nomad/rpc_test.go
+++ b/nomad/rpc_test.go
@@ -1141,7 +1141,7 @@ func TestRPC_TLS_Enforcement_RPC(t *testing.T) {
 		"Eval.Reblock": &structs.EvalUpdateRequest{
 			WriteRequest: structs.WriteRequest{Region: "global"},
 		},
-		"Eval.Reap": &structs.EvalDeleteRequest{
+		"Eval.Reap": &structs.EvalReapRequest{
 			WriteRequest: structs.WriteRequest{Region: "global"},
 		},
 		"Plan.Submit": &structs.PlanRequest{

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -3107,9 +3108,21 @@ func (s *StateStore) updateEvalModifyIndex(txn *txn, index uint64, evalID string
 }
 
 // DeleteEval is used to delete an evaluation
-func (s *StateStore) DeleteEval(index uint64, evals []string, allocs []string) error {
+func (s *StateStore) DeleteEval(index uint64, evals, allocs []string, userInitiated bool) error {
 	txn := s.db.WriteTxn(index)
 	defer txn.Abort()
+
+	// If this deletion has been initiated by an operator, ensure the eval
+	// broker is paused.
+	if userInitiated {
+		_, schedConfig, err := s.schedulerConfigTxn(txn)
+		if err != nil {
+			return err
+		}
+		if schedConfig == nil || !schedConfig.PauseEvalBroker {
+			return errors.New("eval broker is enabled; eval broker must be paused to delete evals")
+		}
+	}
 
 	jobs := make(map[structs.NamespacedID]string, len(evals))
 
@@ -5890,9 +5903,13 @@ func expiredOneTimeTokenFilter(now time.Time) func(interface{}) bool {
 func (s *StateStore) SchedulerConfig() (uint64, *structs.SchedulerConfiguration, error) {
 	tx := s.db.ReadTxn()
 	defer tx.Abort()
+	return s.schedulerConfigTxn(tx)
+}
+
+func (s *StateStore) schedulerConfigTxn(txn *txn) (uint64, *structs.SchedulerConfiguration, error) {
 
 	// Get the scheduler config
-	c, err := tx.First("scheduler_config", "id")
+	c, err := txn.First("scheduler_config", "id")
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed scheduler config lookup: %s", err)
 	}

--- a/nomad/structs/eval.go
+++ b/nomad/structs/eval.go
@@ -1,0 +1,24 @@
+package structs
+
+const (
+	// EvalDeleteRPCMethod is the RPC method for batch deleting evaluations
+	// using their IDs.
+	//
+	// Args: EvalDeleteRequest
+	// Reply: EvalDeleteResponse
+	EvalDeleteRPCMethod = "Eval.Delete"
+)
+
+// EvalDeleteRequest is the request object used when operators are manually
+// deleting evaluations. The number of evaluation IDs within the request must
+// not be greater than MaxEvalIDsPerDeleteRequest.
+type EvalDeleteRequest struct {
+	EvalIDs []string
+	WriteRequest
+}
+
+// EvalDeleteResponse is the response object when one or more evaluation are
+// deleted manually by an operator.
+type EvalDeleteResponse struct {
+	WriteMeta
+}

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -156,6 +156,12 @@ type SchedulerConfiguration struct {
 	// management ACL token
 	RejectJobRegistration bool `hcl:"reject_job_registration"`
 
+	// PauseEvalBroker is a boolean to control whether the evaluation broker
+	// should be paused on the cluster leader. Only a single broker runs per
+	// region, and it must be persisted to state so the parameter is consistent
+	// during leadership transitions.
+	PauseEvalBroker bool `hcl:"pause_eval_broker"`
+
 	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
 	CreateIndex uint64
 	ModifyIndex uint64

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -822,10 +822,20 @@ type EvalUpdateRequest struct {
 	WriteRequest
 }
 
-// EvalDeleteRequest is used for deleting an evaluation.
-type EvalDeleteRequest struct {
+// EvalReapRequest is used for reaping evaluations and allocation. This struct
+// is used by the Eval.Reap RPC endpoint as a request argument, and also when
+// performing eval reap or deletes via Raft. This is because Eval.Reap and
+// Eval.Delete use the same Raft message when performing deletes so we do not
+// need more Raft message types.
+type EvalReapRequest struct {
 	Evals  []string
 	Allocs []string
+
+	// UserInitiated tracks whether this reap request is the result of an
+	// operator request. If this is true, the FSM needs to ensure the eval
+	// broker is paused as the request can include non-terminal allocations.
+	UserInitiated bool
+
 	WriteRequest
 }
 

--- a/nomad/structs/uuid.go
+++ b/nomad/structs/uuid.go
@@ -1,0 +1,7 @@
+package structs
+
+// MaxUUIDsPerWriteRequest is the maximum number of UUIDs that can be included
+// within a single write request. This is to ensure that the Raft message does
+// not become too large. The resulting value corresponds to 0.25MB of IDs or
+// 7282 UUID strings.
+var MaxUUIDsPerWriteRequest = (1024 * 256) / 36

--- a/nomad/volumewatcher/volumes_watcher_test.go
+++ b/nomad/volumewatcher/volumes_watcher_test.go
@@ -108,7 +108,7 @@ func TestVolumeWatch_LeadershipTransition(t *testing.T) {
 
 	// allocation is now invalid
 	index++
-	err = srv.State().DeleteEval(index, []string{}, []string{alloc.ID})
+	err = srv.State().DeleteEval(index, []string{}, []string{alloc.ID}, false)
 	require.NoError(t, err)
 
 	// emit a GC so that we have a volume change that's dropped

--- a/website/content/api-docs/evaluations.mdx
+++ b/website/content/api-docs/evaluations.mdx
@@ -204,6 +204,55 @@ $ curl \
 }
 ```
 
+## Delete Evaluations
+
+This endpoint deletes evaluations. In order to utilise this endpoint the
+eval broker should be paused via the
+[update_scheduler_configuration][operator scheduler update configuration] API
+endpoint.
+
+This API endpoint should be used cautiously and only in outage situations where
+there is a large backlog of evaluations not being processed. During most normal
+and outage scenarios, Nomad's reconciliation and state management will handle
+evaluations as needed.
+
+| Method    | Path              | Produces           |
+| --------- | ----------------- | ------------------ |
+| `DELETE`  | `/v1/evaluations` | `application/json` |
+
+The table below shows this endpoint's support for
+[blocking queries](/api-docs#blocking-queries) and
+[required ACLs](/api-docs#acls).
+
+| Blocking Queries | ACL Required |
+| ---------------- | ------------ |
+| `NO`             | `management` |
+
+### Parameters
+
+- `EvalIDs` `(array<string>: <required>)`- An array of evaluation UUIDs to
+  delete. This must be a full length UUID and not a prefix.
+
+### Sample Payload
+
+```javascript
+{
+  "EvalIDs": [
+    "167ec27d-2e36-979a-280a-a6b920d382db",
+    "6c193955-ac66-42e2-f4c7-f1fc707f1f5e"
+  ]
+}
+```
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --request DELETE \
+    --data @payload.json \
+    https://localhost:4646/v1/evaluations
+```
+
 ## List Allocations for Evaluation
 
 This endpoint lists the allocations created or modified for the given
@@ -332,3 +381,5 @@ $ curl \
   }
 ]
 ```
+
+[update_scheduler_configuration]: api-docs/operator/scheduler#update-scheduler-configuration

--- a/website/content/api-docs/operator/scheduler.mdx
+++ b/website/content/api-docs/operator/scheduler.mdx
@@ -40,18 +40,20 @@ $ curl \
   "Index": 5,
   "KnownLeader": true,
   "LastContact": 0,
+  "NextToken": "",
   "SchedulerConfig": {
     "CreateIndex": 5,
+    "MemoryOversubscriptionEnabled": false,
     "ModifyIndex": 5,
-    "SchedulerAlgorithm": "spread",
-    "MemoryOversubscriptionEnabled": true,
-    "RejectJobRegistration": false,
+    "PauseEvalBroker": false,
     "PreemptionConfig": {
-      "SystemSchedulerEnabled": true,
-      "SysBatchSchedulerEnabled": false,
       "BatchSchedulerEnabled": false,
-      "ServiceSchedulerEnabled": false
-    }
+      "ServiceSchedulerEnabled": false,
+      "SysBatchSchedulerEnabled": false,
+      "SystemSchedulerEnabled": true
+    },
+    "RejectJobRegistration": false,
+    "SchedulerAlgorithm": "binpack"
   }
 }
 ```
@@ -64,9 +66,23 @@ $ curl \
 - `SchedulerConfig` `(SchedulerConfig)` - The returned `SchedulerConfig` object has configuration
   settings mentioned below.
 
-  - `SchedulerAlgorithm` `(string: "binpack")` - Specifies whether scheduler binpacks or spreads allocations on available nodes.
+  - `SchedulerAlgorithm` `(string: "binpack")` - Specifies whether scheduler
+    binpacks or spreads allocations on available nodes.
 
-  - `MemoryOversubscriptionEnabled` `(bool: false)` <sup>1.1 Beta</sup> - When `true`, tasks may exceed their reserved memory limit, if the client has excess memory capacity. Tasks must specify [`memory_max`](/docs/job-specification/resources#memory_max) to take advantage of memory oversubscription.
+  - `MemoryOversubscriptionEnabled` `(bool: false)` <sup>1.1 Beta</sup> - When
+    `true`, tasks may exceed their reserved memory limit, if the client has excess
+    memory capacity. Tasks must specify [`memory_max`](/docs/job-specification/resources#memory_max)
+    to take advantage of memory oversubscription.
+
+  - `RejectJobRegistration` `(bool: false)` - When `true`, the server will return
+    permission denied errors for job registration, job dispatch, and job scale APIs,
+    unless the ACL token for the request is a management token. If ACLs are disabled,
+    no user will be able to register jobs. This allows operators to shed load from
+    automated processes during incident response.
+
+  - `PauseEvalBroker` `(bool: false)` - When set to `true`, the eval broker which
+    usually runs on the leader will be disabled. This will prevent the scheduler
+    workers from receiving new work.
 
   - `PreemptionConfig` `(PreemptionConfig)` - Options to enable preemption for various schedulers.
 
@@ -120,6 +136,7 @@ server state is authoritative.
   "SchedulerAlgorithm": "spread",
   "MemoryOversubscriptionEnabled": false,
   "RejectJobRegistration": false,
+  "PauseEvalBroker": false,
   "PreemptionConfig": {
     "SystemSchedulerEnabled": true,
     "SysBatchSchedulerEnabled": false,
@@ -133,9 +150,20 @@ server state is authoritative.
   binpacks or spreads allocations on available nodes. Possible values are
   `"binpack"` and `"spread"`
 
-- `MemoryOversubscriptionEnabled` `(bool: false)` <sup>1.1 Beta</sup> - When `true`, tasks may exceed their reserved memory limit, if the client has excess memory capacity. Tasks must specify [`memory_max`](/docs/job-specification/resources#memory_max) to take advantage of memory oversubscription.
+- `MemoryOversubscriptionEnabled` `(bool: false)` <sup>1.1 Beta</sup> - When
+  `true`, tasks may exceed their reserved memory limit, if the client has excess
+  memory capacity. Tasks must specify [`memory_max`](/docs/job-specification/resources#memory_max)
+  to take advantage of memory oversubscription.
 
-- `RejectJobRegistration` `(bool: false)` - When `true`, the server will return permission denied errors for job registration, job dispatch, and job scale APIs, unless the ACL token for the request is a management token. If ACLs are disabled, no user will be able to register jobs. This allows operators to shed load from automated proceses during incident response.
+- `RejectJobRegistration` `(bool: false)` - When `true`, the server will return
+  permission denied errors for job registration, job dispatch, and job scale APIs,
+  unless the ACL token for the request is a management token. If ACLs are disabled,
+  no user will be able to register jobs. This allows operators to shed load from
+  automated processes during incident response.
+
+- `PauseEvalBroker` `(bool: false)` - When set to `true`, the eval broker which
+  usually runs on the leader will be disabled. This will prevent the scheduler
+  workers from receiving new work.
 
 - `PreemptionConfig` `(PreemptionConfig)` - Options to enable preemption for
   various schedulers.
@@ -143,9 +171,9 @@ server state is authoritative.
   - `SystemSchedulerEnabled` `(bool: true)` - Specifies whether preemption for
     system jobs is enabled. Note that if this is set to true, then system jobs
     can preempt any other jobs.
-    
-  - `SysBatchSchedulerEnabled` `(bool: false)` <sup>1.2</sup> - Specifies 
-    whether preemption for system batch jobs is enabled. Note that if this is 
+
+  - `SysBatchSchedulerEnabled` `(bool: false)` <sup>1.2</sup> - Specifies
+    whether preemption for system batch jobs is enabled. Note that if this is
     set to true, then system batch jobs can preempt any other jobs.
 
   - `BatchSchedulerEnabled` `(bool: false)` - Specifies

--- a/website/content/docs/commands/eval/delete.mdx
+++ b/website/content/docs/commands/eval/delete.mdx
@@ -1,0 +1,75 @@
+---
+layout: docs
+page_title: 'Commands: eval delete'
+description: |
+  The eval delete command is used to delete evaluations.
+---
+
+# Command: eval delete
+
+The `eval delete` command is used to delete evaluations. It should be used
+cautiously and only in outage situations where there is a large backlog of
+evaluations not being processed. During most normal and outage scenarios,
+Nomad's reconciliation and state management will handle evaluations as needed.
+
+The eval broker is expected to be paused prior to running this command and
+un-paused after. These actions can be performed by the
+[`operator scheduler get-config`][scheduler_get_config]
+and [`operator scheduler set-config`][scheduler_set_config] commands respectively.
+
+## Usage
+
+```plaintext
+nomad eval delete [options] [args]
+```
+
+It takes an optional argument which is the ID of the evaluation to delete. If
+the evaluation ID is omitted, this command will use the filter flag to identify
+and delete a set of evaluations.
+
+When ACLs are enabled, this command requires a `management` token.
+
+## General Options
+
+@include 'general_options.mdx'
+
+## Delete Options
+
+- `-filter`: Specifies an expression used to filter evaluations by for
+  deletion.
+
+- `-yes`: Bypass the confirmation prompt if an evaluation ID was not provided.
+
+## Examples
+
+Delete an evaluation using its ID:
+
+```shell-session
+$ nomad eval delete 9ecffbba-73be-d909-5d7e-ac2694c10e0c
+Successfuly deleted 1 evaluation
+```
+
+Delete all evaluations with status `pending` for the `example` job:
+```shell-session
+$ nomad eval delete -filter='Stauts == "pending" and JobID == "example"'
+Do you want to list evals (3) before deletion? [y/N] y
+
+ID        Priority  Triggered By  Job ID   Status   Placement Failures
+cef92121  50        job-register  example  pending  false
+1c905ca0  50        job-register  example  pending  false
+b9e77692  50        job-register  example  pending  false
+
+Are you sure you want to delete 3 evals? [y/N] y
+
+Successfuly deleted 3 evaluations
+```
+
+Delete all evaluations for the `system` and `service` whilst skipping all
+prompts:
+```shell-session
+$ nomad eval delete -filter='Scheduler == "system" or Scheduler == "service"' -yes
+Successfuly deleted 23 evaluations
+```
+
+[scheduler_get_config]: /docs/commands/operator/scheduler-get-config
+[scheduler_set_config]: /docs/commands/operator/scheduler-set-config

--- a/website/content/docs/commands/eval/index.mdx
+++ b/website/content/docs/commands/eval/index.mdx
@@ -15,9 +15,10 @@ Usage: `nomad eval <subcommand> [options]`
 
 Run `nomad eval <subcommand> -h` for help on that subcommand. The following
 subcommands are available:
-
+- [`eval delete`][delete] - Delete evals
 - [`eval list`][list] - List all evals
 - [`eval status`][status] - Display the status of a eval
 
+[delete]: /docs/commands/eval/delete 'Delete evals'
 [list]: /docs/commands/eval/list 'List all evals'
 [status]: /docs/commands/eval/status 'Display the status of a eval'

--- a/website/content/docs/commands/operator/index.mdx
+++ b/website/content/docs/commands/operator/index.mdx
@@ -42,6 +42,12 @@ The following subcommands are available:
 - [`operator raft remove-peer`][remove] - Remove a Nomad server from the Raft
   configuration
 
+- [`operator scheduler get-config`][scheduler-get-config] - Display the current
+  scheduler configuration
+
+- [`operator scheduler set-config`][scheduler-set-config] - Modify the scheduler
+  configuration
+
 - [`operator snapshot agent`][snapshot-agent] <EnterpriseAlert inline /> - Inspects a snapshot of the Nomad server state
 
 - [`operator snapshot save`][snapshot-save] - Saves a snapshot of the Nomad server state
@@ -63,3 +69,5 @@ The following subcommands are available:
 [snapshot-restore]: /docs/commands/operator/snapshot-restore 'Snapshot Restore command'
 [snapshot-inspect]: /docs/commands/operator/snapshot-inspect 'Snapshot Inspect command'
 [snapshot-agent]: /docs/commands/operator/snapshot-agent 'Snapshot Agent command'
+[scheduler-get-config]: /docs/commands/operator/scheduler-get-config 'Scheduler Get Config command'
+[scheduler-set-config]: /docs/commands/operator/scheduler-set-config 'Scheduler Set Config command'

--- a/website/content/docs/commands/operator/scheduler-get-config.mdx
+++ b/website/content/docs/commands/operator/scheduler-get-config.mdx
@@ -1,0 +1,47 @@
+---
+layout: docs
+page_title: 'Commands: operator scheduler get-config'
+description: |
+  Display the current scheduler configuration.
+---
+
+# Command: operator scheduler get-config
+
+The scheduler operator get-config command is used to view the current scheduler
+configuration.
+
+## Usage
+
+```plaintext
+nomad operator scheduler get-config [options]
+```
+
+If ACLs are enabled, this command requires a token with the `operator:read`
+capability.
+
+## General Options
+
+@include 'general_options_no_namespace.mdx'
+
+## Get Config Options
+
+- `-json`: Output the scheduler config in its JSON format.
+
+- `-t`: Format and display the scheduler config using a Go template.
+
+## Examples
+
+Display the current scheduler configuration:
+
+```shell-session
+$ nomad operator scheduler get-config
+Scheduler Algorithm           = binpack
+Memory Oversubscription       = false
+Reject Job Registration       = false
+Pause Eval Broker             = false
+Preemption System Scheduler   = true
+Preemption Service Scheduler  = false
+Preemption Batch Scheduler    = false
+Preemption SysBatch Scheduler = false
+Modify Index                  = 5
+```

--- a/website/content/docs/commands/operator/scheduler-set-config.mdx
+++ b/website/content/docs/commands/operator/scheduler-set-config.mdx
@@ -1,0 +1,82 @@
+---
+layout: docs
+page_title: 'Commands: operator scheduler set-config'
+description: |
+  Modify the scheduler configuration.
+---
+
+# Command: operator scheduler set-config
+
+The scheduler operator set-config command is used to modify the scheduler
+configuration.
+
+## Usage
+
+```plaintext
+nomad operator scheduler set-config [options]
+```
+
+If ACLs are enabled, this command requires a token with the `operator:write`
+capability.
+
+## General Options
+
+@include 'general_options_no_namespace.mdx'
+
+## Set Config Options
+
+- `-check-index` - If set, the scheduler config is only updated if the passed
+  modify index matches the current server side version. If a non-zero value is
+  passed, it ensures that the scheduler config is being updated from a known
+  state.
+
+- `-scheduler-algorithm` - Specifies whether scheduler binpacks or spreads
+  allocations on available nodes. Must be one of `["binpack"|"spread"]`.
+
+- `-memory-oversubscription` - When true, tasks may exceed their reserved memory
+  limit, if the client has excess memory capacity. Tasks must specify [`memory_max`]
+  to take advantage of memory oversubscription. Must be one of `[true|false]`.
+
+- `-reject-job-registration` - When true, the server will return permission denied
+  errors for job registration, job dispatch, and job scale APIs, unless the ACL
+  token for the request is a management token. If ACLs are disabled, no user
+  will be able to register jobs. This allows operators to shed load from automated
+  processes during incident response. Must be one of `[true|false]`.
+
+- `-pause-eval-broker` - When set to true, the eval broker which usually runs on
+  the leader will be disabled. This will prevent the scheduler workers from
+  receiving new work. Must be one of `[true|false]`.
+
+- `-preempt-batch-scheduler` - Specifies whether preemption for batch jobs
+  is enabled. Note that if this is set to true, then batch jobs can preempt any
+  other jobs. Must be one of `[true|false]`.
+
+- `-preempt-service-scheduler` - Specifies whether preemption for service jobs
+  is enabled. Note that if this is set to true, then service jobs can preempt any
+  other jobs. Must be one of `[true|false]`.
+
+- `-preempt-sysbatch-scheduler` - Specifies whether preemption for system batch
+  jobs is enabled. Note that if this is set to true, then system batch jobs can
+  preempt any other jobs. Must be one of `[true|false]`.
+
+- `-preempt-system-scheduler` - Specifies whether preemption for system jobs
+  is enabled. Note that if this is set to true, then system jobs can preempt any
+  other jobs. Must be one of `[true|false]`.
+
+## Examples
+
+Modify the scheduler algorithm to spread:
+
+```shell-session
+$ nomad operator scheduler set-config -scheduler-algorithm=spread
+Scheduler configuration updated!
+```
+
+Modify the scheduler algorithm to spread using the check index flag:
+
+```shell-session
+$ nomad operator scheduler set-config -scheduler-algorithm=spread -check-index=5
+Scheduler configuration updated!
+```
+
+[`memory_max`]: /docs/job-specification/resources#memory_max

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -311,11 +311,10 @@ job-type schedulers.
 ```hcl
 server {
   default_scheduler_config {
-    scheduler_algorithm = "spread"
-
+    scheduler_algorithm             = "spread"
     memory_oversubscription_enabled = true
-
-    reject_job_registration = false
+    reject_job_registration         = false
+    pause_eval_broker               = false # New in Nomad 1.3.2
 
     preemption_config {
       batch_scheduler_enabled    = true

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -586,6 +586,14 @@
             "path": "commands/operator/raft-state"
           },
           {
+            "title": "scheduler get-config",
+            "path": "commands/operator/scheduler-get-config"
+          },
+          {
+            "title": "scheduler set-config",
+            "path": "commands/operator/scheduler-set-config"
+          },
+          {
             "title": "snapshot agent",
             "path": "commands/operator/snapshot-agent"
           },

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -373,6 +373,10 @@
             "path": "commands/eval"
           },
           {
+            "title": "delete",
+            "path": "commands/eval/delete"
+          },
+          {
             "title": "list",
             "path": "commands/eval/list"
           },


### PR DESCRIPTION
This PR adds the ability to delete evals and adds to the work performed to allow the pausing of the eval and blocked eval brokers.

There is a change made to the signature of the eval reap RPC which we will want to backport in order to make future backport releases easier. Once this PR has been reviewed and approved, I will open this change as a PR separately.