### PR TITLE
client: fixed a problem calculating a service namespace.

### DIFF
--- a/.changelog/13493.txt
+++ b/.changelog/13493.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a problem calculating a services namespace
+```

--- a/nomad/structs/alloc.go
+++ b/nomad/structs/alloc.go
@@ -43,9 +43,9 @@ func (a *Allocation) ServiceProviderNamespace() string {
 		}
 	}
 
-	if len(tg.Tasks) > 0 {
-		if len(tg.Tasks[0].Services) > 0 {
-			switch tg.Tasks[0].Services[0].Provider {
+	for _, task := range tg.Tasks {
+		if len(task.Services) > 0 {
+			switch task.Services[0].Provider {
 			case ServiceProviderNomad:
 				return a.Job.Namespace
 			default:

--- a/nomad/structs/alloc_test.go
+++ b/nomad/structs/alloc_test.go
@@ -103,6 +103,34 @@ func Test_Allocation_ServiceProviderNamespace(t *testing.T) {
 			expectedOutput: "platform",
 			name:           "nomad task service",
 		},
+		{
+			inputAllocation: &Allocation{
+				Job: &Job{
+					Namespace: "platform",
+					TaskGroups: []*TaskGroup{
+						{
+							Name: "test-group",
+							Tasks: []*Task{
+								{
+									Name: "task1",
+								},
+								{
+									Name: "task2",
+									Services: []*Service{
+										{
+											Provider: ServiceProviderNomad,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				TaskGroup: "test-group",
+			},
+			expectedOutput: "platform",
+			name:           "multiple tasks with service not in first",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
When calculating a services namespace for registration, the code
assumed the first task within the task array would include a
service block. This is incorrect as it is possible only a latter
task within the array contains a service definition.

This change fixes the logic, so we correctly search for a service
definition before identifying the namespace.

closes https://github.com/hashicorp/nomad/issues/13483