### PR TITLE
docs: update task leader to explain shutdown sequence.

### DIFF
--- a/website/content/docs/job-specification/task.mdx
+++ b/website/content/docs/job-specification/task.mdx
@@ -65,11 +65,11 @@ job "docs" {
   drivers).
 
 - `leader` `(bool: false)` - Specifies whether the task is the leader task of
-  the task group. If set to true, when the leader task completes, all other
+  the task group. If set to `true`, when the leader task completes, all other
   tasks within the task group will be gracefully shutdown. The shutdown
-  process starts by firing any configured pre-kill hooks, then stops the
+  process starts by applying the `shutdown_delay` if configured. It then stops the
   the leader task first, followed by non-sidecar and non-poststop tasks,
-  and finally sidecar tasks. Once this process completes, post-stop hooks
+  and finally sidecar tasks. Once this process completes, post-stop tasks
   are triggered. See the [lifecycle][] documentation for a complete description
   of task lifecycle management.
 

--- a/website/content/docs/job-specification/task.mdx
+++ b/website/content/docs/job-specification/task.mdx
@@ -66,7 +66,12 @@ job "docs" {
 
 - `leader` `(bool: false)` - Specifies whether the task is the leader task of
   the task group. If set to true, when the leader task completes, all other
-  tasks within the task group will be gracefully shutdown.
+  tasks within the task group will be gracefully shutdown. The shutdown
+  process starts by firing any configured pre-kill hooks, then stops the
+  the leader task first, followed by non-sidecar and non-poststop tasks,
+  and finally sidecar tasks. Once this process completes, post-stop hooks
+  are triggered. See the [lifecycle][] documentation for a complete description
+  of task lifecycle management.
 
 - `lifecycle` <code>([Lifecycle][]: nil)</code> - Specifies when a task is run
   within the lifecycle of a task group. Added in Nomad v0.11.


### PR DESCRIPTION
Closes #9986

This PR expands the documentation for the `task.leader` field to explain the impact on shutdown processing. The issue suggests providing an explanation of `lifecycle`, but I've opted to link out to existing documentation rather than duplicating the text in multiple places.