### PR TITLE
CSI: set group read permissions on csi paths

### DIFF
--- a/client/allocrunner/taskrunner/plugin_supervisor_hook.go
+++ b/client/allocrunner/taskrunner/plugin_supervisor_hook.go
@@ -140,7 +140,7 @@ func (h *csiPluginSupervisorHook) Prestart(ctx context.Context,
 
 	// Create the mount directory that the container will access if it doesn't
 	// already exist. Default to only nomad user access.
-	if err := os.MkdirAll(h.mountPoint, 0700); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(h.mountPoint, 0750); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("failed to create mount point: %v", err)
 	}
 

--- a/client/pluginmanager/csimanager/volume.go
+++ b/client/pluginmanager/csimanager/volume.go
@@ -86,7 +86,7 @@ func (v *volumeManager) ensureStagingDir(vol *structs.CSIVolume, usage *UsageOpt
 	stagingPath := v.stagingDirForVolume(v.mountRoot, vol.ID, usage)
 
 	// Make the staging path, owned by the Nomad User
-	if err := os.MkdirAll(stagingPath, 0700); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(stagingPath, 0750); err != nil && !os.IsExist(err) {
 		return "", false, fmt.Errorf("failed to create staging directory for volume (%s): %v", vol.ID, err)
 
 	}
@@ -111,7 +111,7 @@ func (v *volumeManager) ensureAllocDir(vol *structs.CSIVolume, alloc *structs.Al
 	allocPath := v.allocDirForVolume(v.mountRoot, vol.ID, alloc.ID)
 
 	// Make the alloc path, owned by the Nomad User
-	if err := os.MkdirAll(allocPath, 0700); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(allocPath, 0750); err != nil && !os.IsExist(err) {
 		return "", false, fmt.Errorf("failed to create allocation directory for volume (%s): %v", vol.ID, err)
 	}
 


### PR DESCRIPTION
  When running Docker with userns remap enabled we need to be able to have containers access
  their mounted CSI volumes. The idea here is that we can run Nomad with a primary group
  aligned with the remapped user group. This way the docker runtime can properly access
  the CSI volume paths for mounting. Apart from that we can run Nomad as an unprivileged
  user as well.

  There are a couple of prerequisites to get this to work properly along with this PR:
    * The nomad client process needs to run with a primary group set to a user that is equal to the
      userns mapped root user uid.
    * The nomad data directory needs to be owned by this group as well and it should get
      the setgid bit set so all childs will inherit the respective group.
    * The EBS CSI node driver needs to run with umask 002 to have the csi.sock created with
      write access for the primary group Nomad runs under. It also needs to run with `privileged`
      mode and `userns_mode = "host"`. It is important to `chown -R root:root /usr/bin /usr/sbin`
      as part of the entrypoint to override the userns remapped uid's on the filesystem, see:
      https://docs.docker.com/engine/security/userns-remap/#disable-namespace-remapping-for-a-container
      Otherwise the `mount` binary will execute with setuid set to the userns remapped uid.

  After this setup Nomad will be able to mount volumes properly with userns remapping enabled.
  There is however still one caveat. The EBS CSI driver runs under root (real uid=0) and generally performs
  the filesystem formatting. Because of this the root fs node will be owned by uid=0 making it impossible
  for containers to get access to the data volume. The only way to bypass this would be to run a
  prestart sidecar with `userns_mode = "host"` which is obviously not something we want.

  When using a filesystem like ext4 there's an option to pass an extended mke2fs option called
  `root_owner` but passing args for formatting isn't implemented in the CSI driver.
  Ideally Nomad would be able to perform a chown of the root of the data volume based on a certain job
  configuration setting, possibly part of `volume_mount`?

  Kubernetes seems to have this concept of Pod securityContexts which have an fsGroup + policy option.

  For now I'm running a sidecar next to ebs nodes plugin that polls /proc/mounts and performs the proper
  chown based on my configured UID. This works but is far from ideal, I'd rather have Nomad do this.