### PR TITLE
ui:  add can edit to variable capabilities

### DIFF
--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -32,6 +32,13 @@ export default class Variable extends AbstractAbility {
   )
   canCreate;
 
+  @or(
+    'bypassAuthorization',
+    'selfTokenIsManagement',
+    'policiesSupportVariableEditing'
+  )
+  canEdit;
+
   @computed('rulesForNamespace.@each.capabilities')
   get policiesSupportVariableView() {
     return this.rulesForNamespace.some((rules) => {
@@ -46,6 +53,16 @@ export default class Variable extends AbstractAbility {
       const keyName = `SecureVariables.Path "${matchingPath}".Capabilities`;
       const capabilities = get(rules, keyName) || [];
       return capabilities.includes('create');
+    });
+  }
+
+  @computed('rulesForNamespace.@each.capabilities', 'path')
+  get policiesSupportVariableEditing() {
+    const matchingPath = this._nearestMatchingPath(this.path);
+    return this.rulesForNamespace.some((rules) => {
+      const keyName = `SecureVariables.Path "${matchingPath}".Capabilities`;
+      const capabilities = get(rules, keyName) || [];
+      return capabilities.includes('edit');
     });
   }
 

--- a/ui/app/templates/variables/variable/index.hbs
+++ b/ui/app/templates/variables/variable/index.hbs
@@ -29,6 +29,7 @@
   </div>
   <div>
     {{#unless this.isDeleting}}
+      {{#if (can "edit variable" path=this.model.absolutePath)}}
       <div class="two-step-button">
         <LinkTo
           data-test-edit-button
@@ -39,6 +40,7 @@
           Edit
         </LinkTo>
       </div>
+      {{/if}}
     {{/unless}}
     <TwoStepButton
       data-test-delete-button

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -223,6 +223,9 @@ module('Acceptance | secure variables', function (hooks) {
       server.createList('variable', 3);
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
+      const policy = server.db.policies.find('Variable Maker');
+      policy.rulesJSON.Namespaces[0].SecureVariables['Path "*"'].Capabilities =
+        ['list', 'edit'];
       await Variables.visit();
       await click('[data-test-file-row]');
       // End Test Set-up


### PR DESCRIPTION
This PR creates a `can-edit` property in the Variable Ability class and adds an `ember-can` check in the `variables.variable.index` template to access the `Edit` button.