### PR TITLE
boltdd: add iterate and prefix deletion helpers

### DIFF
--- a/helper/boltdd/boltdd.go
+++ b/helper/boltdd/boltdd.go
@@ -353,6 +353,35 @@ func (b *Bucket) Get(key []byte, obj interface{}) error {
 	return nil
 }
 
+// Iterate iterates each key in Bucket b that starts with prefix. fn is called on
+// the key and msg-pack decoded value. If prefix is empty or nil, all keys in the
+// bucket are iterated.
+func Iterate[T any](b *Bucket, prefix []byte, fn func([]byte, T)) error {
+	c := b.boltBucket.Cursor()
+	for k, data := c.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, data = c.Next() {
+		var obj T
+		if err := codec.NewDecoderBytes(data, structs.MsgpackHandle).Decode(&obj); err != nil {
+			return fmt.Errorf("failed to decode data into passed object: %v", err)
+		}
+		fn(k, obj)
+	}
+	return nil
+}
+
+// DeletePrefix removes all keys starting with prefix from the bucket. If no keys
+// with prefix exist then nothing is done and a nil error is returned. Returns an
+// error if the bucket was created from a read-only transaction.
+func (b *Bucket) DeletePrefix(prefix []byte) error {
+	c := b.boltBucket.Cursor()
+	for k, _ := c.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, _ = c.Next() {
+		if err := c.Delete(); err != nil {
+			return err
+		}
+		b.bm.delHash(string(k))
+	}
+	return nil
+}
+
 // Delete removes a key from the bucket. If the key does not exist then nothing
 // is done and a nil error is returned. Returns an error if the bucket was
 // created from a read-only transaction.


### PR DESCRIPTION
This PR adds 2 helper functions to the `helpers/bbolt` package

  - `Iterate`: iterate every key in a bucket starting with prefix. Automatically decodes the
  msg pack value into the provided value argument.


- `DeletePrefix`: deletes every key in a bucket starting with a
given prefix. Manages the wrapper's hash values accordingly. Uses
a cursor & sync to operate efficiently.

Need these changes for nomad service check persistence stuff, but pulled into a separate PR because I got carried away cleaning up these tests. 