### PR TITLE
Backport #13530 to 1.2.x

### DIFF
--- a/.changelog/13552.txt
+++ b/.changelog/13552.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fix listing evaluations with the wildcard namespace and an ACL token
+```


### PR DESCRIPTION
Backport the API portion of #13530 to `release/1.2.x`. Wildcard namespace list support for the eval endpoint was added in 1.2.4, so this doesn't have to be backported to 1.1.x.