### PR TITLE
build: bump circleci macos version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -475,7 +475,7 @@ executors:
   go-macos:
     working_directory: ~/go/src/github.com/hashicorp/nomad
     macos:
-      xcode: 12.4.0
+      xcode: 13.4.1
     environment:
       <<: *common_envs
       GOPATH: /Users/distiller/go


### PR DESCRIPTION
Got an email from Circle about removing the version we are currently
using; bump to the latest stable version

https://circleci.com/docs/2.0/testing-ios

```
We’re reaching out to you to let you know that we have deprecated the following macOS images on CircleCI and will be removing them from our platform on Tuesday, August 2, 2022:

Xcode 10.3.0
Xcode 11.4.1
Xcode 11.5.0
Xcode 11.6.0
Xcode 12.0.1
Xcode 12.1.1
Xcode 12.2.0
Xcode 12.3.0
Xcode 12.4.0

In the last four weeks, you have used the above images on the following project(s):

nomad
```