### PR TITLE
[ui] Fix a bug where redirects after planning/editing a job didn't include namespace

### DIFF
--- a/ui/app/controllers/jobs/job/definition.js
+++ b/ui/app/controllers/jobs/job/definition.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import WithNamespaceResetting from 'nomad-ui/mixins/with-namespace-resetting';
 import { alias } from '@ember/object/computed';
 import classic from 'ember-classic-decorator';
+import { inject as service } from '@ember/service';
 
 @classic
 export default class DefinitionController extends Controller.extend(
@@ -9,6 +10,7 @@ export default class DefinitionController extends Controller.extend(
 ) {
   @alias('model.job') job;
   @alias('model.definition') definition;
+  @service router;
 
   isEditing = false;
 
@@ -21,9 +23,7 @@ export default class DefinitionController extends Controller.extend(
     this.set('isEditing', false);
   }
 
-  onSubmit(id, jobNamespace) {
-    this.transitionToRoute('jobs.job', id, {
-      queryParams: { jobNamespace },
-    });
+  onSubmit() {
+    this.router.transitionTo('jobs.job', this.job.idWithNamespace);
   }
 }

--- a/ui/app/controllers/jobs/run.js
+++ b/ui/app/controllers/jobs/run.js
@@ -1,9 +1,9 @@
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 
 export default class RunController extends Controller {
+  @service router;
   onSubmit(id, namespace) {
-    this.transitionToRoute('jobs.job', id, {
-      queryParams: { namespace },
-    });
+    this.router.transitionTo('jobs.job', `${id}@${namespace || 'default'}`);
   }
 }


### PR DESCRIPTION
Previously, we treated namespaces like query parameters; however, this caused the onSubmit redirects to 404 when planning a job.

Side-effect: also introduces router service transition instead of depending on the deprecated `transitionToRoute` method.

Resolves #13039