### PR TITLE
Fix Testutil for delve debugging API tests

### DIFF
--- a/api/internal/testutil/discover/discover.go
+++ b/api/internal/testutil/discover/discover.go
@@ -59,8 +59,17 @@ func NomadExecutable() (string, error) {
 }
 
 func isNomad(path, nomadExe string) bool {
-	if strings.HasSuffix(path, ".test") || strings.HasSuffix(path, ".test.exe") {
+	switch {
+	case strings.HasSuffix(path, ".test"):
 		return false
+	case strings.HasSuffix(path, ".test.exe"):
+		return false
+	// delve debug executable for debugging test
+	case strings.HasSuffix(path, "__debug_bin"):
+		return false
+	case strings.HasSuffix(path, "__debug_bin.exe"):
+		return false
+	default:
+		return true
 	}
-	return true
 }

--- a/api/internal/testutil/server.go
+++ b/api/internal/testutil/server.go
@@ -155,11 +155,10 @@ func NewTestServer(t testing.T, cb ServerConfigCallback) *TestServer {
 	}
 
 	// Check that we are actually running nomad
-	vcmd := exec.Command(path, "-version")
-	vcmd.Stdout = nil
-	vcmd.Stderr = nil
-	if err := vcmd.Run(); err != nil {
-		t.Skipf("nomad version failed: %v", err)
+	if out, err := exec.Command(path, "-version").CombinedOutput(); err != nil {
+		t.Logf("nomad version failed: %v", err)
+		t.Logf("nomad version output:\n%s", string(out))
+		t.Skip()
 	}
 
 	dataDir, err := ioutil.TempDir("", "nomad")


### PR DESCRIPTION
When running an API test in a debugger, the tests immediately "PASS" rather than run. This is because the discover code attempts to run the debug test executable _**as**_ the Nomad binary, which errors and then ends in the Skip pathway.