### PR TITLE
refact:  update capability names

### DIFF
--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -28,9 +28,9 @@ export default class Variable extends AbstractAbility {
   @or(
     'bypassAuthorization',
     'selfTokenIsManagement',
-    'policiesSupportVariableCreation'
+    'policiesSupportVariableWriting'
   )
-  canCreate;
+  canWrite;
 
   @computed('rulesForNamespace.@each.capabilities')
   get policiesSupportVariableView() {
@@ -40,12 +40,12 @@ export default class Variable extends AbstractAbility {
   }
 
   @computed('rulesForNamespace.@each.capabilities', 'path')
-  get policiesSupportVariableCreation() {
+  get policiesSupportVariableWriting() {
     const matchingPath = this._nearestMatchingPath(this.path);
     return this.rulesForNamespace.some((rules) => {
       const keyName = `SecureVariables.Path "${matchingPath}".Capabilities`;
       const capabilities = get(rules, keyName) || [];
-      return capabilities.includes('create');
+      return capabilities.includes('write');
     });
   }
 

--- a/ui/app/templates/variables/index.hbs
+++ b/ui/app/templates/variables/index.hbs
@@ -12,7 +12,7 @@
     </div>
     <div class="toolbar-item is-right-aligned is-mobile-full-width">
       <div class="button-bar">
-      {{#if (can "create variable" path="*")}}
+      {{#if (can "write variable" path="*")}}
         <LinkTo
           @route="variables.new"
           class="button is-primary"

--- a/ui/app/templates/variables/path.hbs
+++ b/ui/app/templates/variables/path.hbs
@@ -6,7 +6,7 @@
     <div class="toolbar">
       <div class="toolbar-item is-right-aligned is-mobile-full-width">
         <div class="button-bar">
-        {{#if (can "create variable" path=this.model.absolutePath)}}
+        {{#if (can "write variable" path=this.model.absolutePath)}}
           <LinkTo
             @route="variables.new"
             @query={{hash path=(concat this.model.absolutePath "/")}}

--- a/ui/app/templates/variables/variable/index.hbs
+++ b/ui/app/templates/variables/variable/index.hbs
@@ -29,7 +29,7 @@
   </div>
   <div>
     {{#unless this.isDeleting}}
-      {{#if (can "create variable" path=this.model.absolutePath)}}
+      {{#if (can "write variable" path=this.model.absolutePath)}}
       <div class="two-step-button">
         <LinkTo
           data-test-edit-button

--- a/ui/mirage/factories/token.js
+++ b/ui/mirage/factories/token.js
@@ -39,7 +39,7 @@ namespace "default" {
   capabilities = ["list-jobs", "alloc-exec", "read-logs"]
   secure_variables {
     # full access to secrets in all project paths
-    path "project/*" {
+    path "blue/*" {
       capabilities = ["write", "read", "destroy", "list"]
     }
 

--- a/ui/tests/unit/abilities/variable-test.js
+++ b/ui/tests/unit/abilities/variable-test.js
@@ -109,7 +109,7 @@ module('Unit | Ability | variable', function (hooks) {
 
       this.owner.register('service:token', mockToken);
 
-      assert.notOk(this.ability.canCreate);
+      assert.notOk(this.ability.canWrite);
     });
 
     test('it permits creating variables when token type is management', function (assert) {
@@ -120,7 +120,7 @@ module('Unit | Ability | variable', function (hooks) {
 
       this.owner.register('service:token', mockToken);
 
-      assert.ok(this.ability.canCreate);
+      assert.ok(this.ability.canWrite);
     });
 
     test('it permits creating variables when acl is disabled', function (assert) {
@@ -131,10 +131,10 @@ module('Unit | Ability | variable', function (hooks) {
 
       this.owner.register('service:token', mockToken);
 
-      assert.ok(this.ability.canCreate);
+      assert.ok(this.ability.canWrite);
     });
 
-    test('it permits creating variables when token has SecureVariables with create capabilities in its rules', function (assert) {
+    test('it permits creating variables when token has SecureVariables with write capabilities in its rules', function (assert) {
       const mockToken = Service.extend({
         aclEnabled: true,
         selfToken: { type: 'client' },
@@ -147,7 +147,7 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "*"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },
@@ -159,7 +159,7 @@ module('Unit | Ability | variable', function (hooks) {
 
       this.owner.register('service:token', mockToken);
 
-      assert.ok(this.ability.canCreate);
+      assert.ok(this.ability.canWrite);
     });
 
     test('it handles namespace matching', function (assert) {
@@ -184,7 +184,7 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "foo/bar"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },
@@ -198,7 +198,7 @@ module('Unit | Ability | variable', function (hooks) {
       this.ability.path = 'foo/bar';
       this.ability.namespace = 'pablo';
 
-      assert.ok(this.ability.canCreate);
+      assert.ok(this.ability.canWrite);
     });
   });
 
@@ -216,7 +216,7 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "foo"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },
@@ -251,10 +251,10 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "foo/*"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                     'Path "foo/bar/*"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },
@@ -289,7 +289,7 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "foo/*"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },
@@ -324,10 +324,10 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "*/bar"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                     'Path "*/bar/baz"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },
@@ -362,10 +362,10 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "*/bar"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                     'Path "foo/*"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },
@@ -400,10 +400,10 @@ module('Unit | Ability | variable', function (hooks) {
                   Capabilities: [],
                   SecureVariables: {
                     'Path "*"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                     'Path "foo"': {
-                      Capabilities: ['create'],
+                      Capabilities: ['write'],
                     },
                   },
                 },


### PR DESCRIPTION
This PR reflects that capabilities have the following names:  `["write", "read", "destroy", "list"]`.

Originally, we designed around capabilities having the names:  `["create", "read", "edit", "delete", "list"]` per the original RFC.

Side Effect:  minor update to `rules` in `Token` factory to match `rulesJSON`.