### PR TITLE
api: apply new ACL check for wildcard namespace

### DIFF
--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -35,29 +35,16 @@ func (a *Alloc) List(args *structs.AllocListRequest, reply *structs.AllocListRes
 	defer metrics.MeasureSince([]string{"nomad", "alloc", "list"}, time.Now())
 
 	namespace := args.RequestNamespace()
-	var allow func(string) bool
 
 	// Check namespace read-job permissions
 	aclObj, err := a.srv.ResolveToken(args.AuthToken)
-
-	switch {
-	case err != nil:
+	if err != nil {
 		return err
-	case aclObj == nil:
-		allow = func(string) bool {
-			return true
-		}
-	case namespace == structs.AllNamespacesSentinel:
-		allow = func(ns string) bool {
-			return aclObj.AllowNsOp(ns, acl.NamespaceCapabilityReadJob)
-		}
-	case !aclObj.AllowNsOp(namespace, acl.NamespaceCapabilityReadJob):
-		return structs.ErrPermissionDenied
-	default:
-		allow = func(string) bool {
-			return true
-		}
 	}
+	if !aclObj.AllowNsOp(namespace, acl.NamespaceCapabilityReadJob) {
+		return structs.ErrPermissionDenied
+	}
+	allow := aclObj.AllowNsOpFunc(acl.NamespaceCapabilityReadJob)
 
 	// Setup the blocking query
 	sort := state.SortOption(args.Reverse)

--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -1284,8 +1284,9 @@ func TestAllocEndpoint_List_AllNamespaces_ACL_OSS(t *testing.T) {
 		{
 			Label:     "all namespaces with insufficient token",
 			Namespace: "*",
-			Allocs:    []*structs.Allocation{},
 			Token:     ns1tokenInsufficient.SecretID,
+			Error:     true,
+			Message:   structs.ErrPermissionDenied.Error(),
 		},
 		{
 			Label:     "ns1 with ns1 token",


### PR DESCRIPTION
In #13606 the ACL check was refactored to better support the all
namespaces wildcard (`*`). This commit applies the changes to the jobs
and alloc list endpoints.