### PR TITLE
ui:  allow namespaces to be set in forms

### DIFF
--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -1,7 +1,7 @@
 {{did-update this.onViewChange @view}}
 {{did-insert this.establishKeyValues}}
 <form class="new-secure-variables" autocomplete="off" {{on "submit" this.save}}>
-  <div>
+  <div class="path-namespace">
     <label>
       <span>
         Path
@@ -39,9 +39,23 @@
         .
       </p>
     {{/if}}
+    <SecureVariableForm::NamespaceFilter 
+      @data={{hash 
+        disabled=(not @model.isNew)
+        selection=this.variableNamespace
+        namespaceOptions=this.namespaceOptions
+      }}
+      @fns={{hash
+        onSelect=this.setNamespace
+        setNamespaceOptions=this.setNamespaceOptions
+      }}
+    />
   </div>
   {{#if (eq this.view "json")}}
-    <div class="editor-wrapper boxed-section-body is-full-bleed {{if this.JSONError "error"}}">
+    <div
+      class="editor-wrapper boxed-section-body is-full-bleed
+        {{if this.JSONError 'error'}}"
+    >
       <div
         data-test-json-editor
         {{code-mirror
@@ -49,7 +63,7 @@
           onUpdate=this.updateCode
           extraKeys=(hash Cmd-Enter=(action "save"))
         }}
-      />
+      ></div>
       {{#if this.JSONError}}
         <p class="help is-danger">
           {{this.JSONError}}

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -31,6 +31,18 @@ export default class SecureVariableFormComponent extends Component {
    * @type {DuplicatePathWarning}
    */
   @tracked duplicatePathWarning = null;
+  @tracked variableNamespace = 'default';
+  @tracked namespaceOptions = null;
+
+  @action
+  setNamespace(namespace) {
+    this.variableNamespace = namespace;
+  }
+
+  @action
+  setNamespaceOptions(options) {
+    this.namespaceOptions = options;
+  }
 
   get shouldDisableSave() {
     return !!this.JSONError || !this.args.model?.path;
@@ -135,6 +147,15 @@ export default class SecureVariableFormComponent extends Component {
         throw new Error('Please provide at least one key/value pair.');
       } else {
         this.keyValues = nonEmptyItems;
+      }
+
+      if (this.args.model?.isNew) {
+        if (this.namespaceOptions) {
+          this.args.model.set('namespace', this.variableNamespace);
+        } else {
+          const [namespace] = this.store.peekAll('namespace');
+          this.args.model.set('namespace', namespace);
+        }
       }
 
       this.args.model.set('keyValues', this.keyValues);

--- a/ui/app/components/secure-variable-form/namespace-filter.hbs
+++ b/ui/app/components/secure-variable-form/namespace-filter.hbs
@@ -1,0 +1,24 @@
+<Trigger @do={{this.fetchNamespaces}} @onSuccess={{this.formatAndSetNamespaces}} as |trigger|>
+  {{did-insert trigger.fns.do}}
+  {{! No-op on Error}}
+  {{! No Loading Behavior }}
+  {{#if trigger.data.isSuccess}}
+    {{#if trigger.data.result}}
+      {{#if @data.namespaceOptions}}
+        <label>
+          <span>
+            Namespace
+          </span>
+          <SingleSelectDropdown
+            data-test-variable-namespace-filter
+            @label="Namespace"
+            @disabled={{@data.disabled}}
+            @options={{@data.namespaceOptions}}
+            @selection={{@data.selection}}
+            @onSelect={{@fns.onSelect}}
+          />
+        </label>
+      {{/if}}
+    {{/if}}
+  {{/if}}
+</Trigger>

--- a/ui/app/components/secure-variable-form/namespace-filter.js
+++ b/ui/app/components/secure-variable-form/namespace-filter.js
@@ -1,0 +1,26 @@
+// @ts-check
+
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class NamespaceFilter extends Component {
+  @service store;
+
+  @action
+  async fetchNamespaces() {
+    return this.store.findAll('namespace');
+  }
+
+  @action
+  formatAndSetNamespaces() {
+    // Triggered on the promise in fetchNamespaces resolving
+    const namespaces = this.store
+      .peekAll('namespace')
+      .map(({ name }) => ({ key: name, label: name }));
+
+    if (namespaces.length <= 1) return null;
+
+    this.args.fns.setNamespaceOptions(namespaces);
+  }
+}

--- a/ui/app/components/single-select-dropdown/index.hbs
+++ b/ui/app/components/single-select-dropdown/index.hbs
@@ -1,6 +1,7 @@
 <div data-test-single-select-dropdown class="dropdown" ...attributes>
   <PowerSelect
     @options={{@options}}
+    @disabled={{@disabled}}
     @selected={{this.activeOption}}
     @searchEnabled={{gt @options.length 10}}
     @searchField="label"

--- a/ui/app/styles/components/secure-variables.scss
+++ b/ui/app/styles/components/secure-variables.scss
@@ -41,6 +41,12 @@
     animation: slide-in 0.3s ease-out;
   }
 
+  .path-namespace {
+    display: grid;
+    grid-template-columns: 6fr 1fr;
+    gap: 0 1rem;
+  }
+
   .key-value {
     display: grid;
     grid-template-columns: 1fr 4fr 130px;

--- a/ui/mirage/factories/variable.js
+++ b/ui/mirage/factories/variable.js
@@ -1,6 +1,6 @@
 import { Factory } from 'ember-cli-mirage';
 import faker from 'nomad-ui/mirage/faker';
-import { pickOne } from '../utils';
+
 export default Factory.extend({
   id: () => faker.random.words(3).split(' ').join('/').toLowerCase(),
   path() {
@@ -29,6 +29,10 @@ export default Factory.extend({
         (server.db.jobs && server.db.jobs[0]?.namespace) || 'default';
       variable.update({
         namespace,
+      });
+    } else {
+      variable.update({
+        namespace: variable.namespaceId,
       });
     }
   },

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -343,6 +343,14 @@ module('Acceptance | secure variables', function (hooks) {
       assert.equal(currentRouteName(), 'variables.new');
 
       await typeIn('[data-test-path-input]', 'foo/bar');
+      await clickTrigger('[data-test-variable-namespace-filter]');
+
+      assert.dom('.dropdown-options').exists('Namespace can be edited.');
+
+      await selectChoose(
+        '[data-test-variable-namespace-filter]',
+        'namespace-1'
+      );
       await typeIn('[data-test-var-key]', 'kiki');
       await typeIn('[data-test-var-value]', 'do you love me');
       await click('[data-test-submit-var]');
@@ -414,6 +422,10 @@ module('Acceptance | secure variables', function (hooks) {
       );
 
       assert.dom('[data-test-path-input]').isDisabled('Path cannot be edited');
+      await clickTrigger('[data-test-variable-namespace-filter]');
+      assert
+        .dom('.dropdown-options')
+        .doesNotExist('Namespace cannot be edited.');
 
       document.querySelector('[data-test-var-key]').value = ''; // clear current input
       await typeIn('[data-test-var-key]', 'kiki');


### PR DESCRIPTION
This PR handles setting a namespace in the create secure variables form.

Actual:
![image](https://user-images.githubusercontent.com/41024828/177835703-7dd31953-21fc-40bc-b8b5-b53e12b82369.png)

Figma:
![image](https://user-images.githubusercontent.com/41024828/177835729-ed239c5a-3dee-4719-9786-1ee855578c50.png)
