### PR TITLE
docs: add docs for simple load balancing nomad services

### DIFF
--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -312,6 +312,33 @@ EOF
   }
 ```
 
+### Simple Load Balancing with Nomad Services
+
+~> Simple load balancing with Nomad Services is new in Nomad 1.3.2.
+
+The `nomadService` function now supports simple load balancing by selecting
+instances of a service via [rendezvous hashing][rhash].
+To enable simple load balancing, the `nomadService` function requires 3 arguments.
+
+- The number of services to select
+- The hashing key (should be unique, but consistent per requester)
+- The service name
+
+By using `NOMAD_ALLOC_ID` as the hashing key, the selected instances will remain mostly
+stable for the allocation, even as instances of the service are added or removed.
+
+```hcl
+template {
+  data        = <<EOH
+{{$allocID := env "NOMAD_ALLOC_ID" -}}
+# Configuration for 3 redis instances, as assigned via rendezvous hashing.
+{{range nomadService 3 $allocID "redis"}}
+  server {{ .Address }}:{{ .Port }};{{- end }}
+{{- end}}
+EOH
+}
+```
+
 ## Consul Integration
 
 ### Consul KV
@@ -530,3 +557,4 @@ options](/docs/configuration/client#options):
 [task working directory]: /docs/runtime/environment#task-directories 'Task Directories'
 [filesystem internals]: /docs/internals/filesystem#templates-artifacts-and-dispatch-payloads
 [`client.template.wait_bounds`]: /docs/configuration/client#wait_bounds
+[rhash]: https://en.wikipedia.org/wiki/Rendezvous_hashing


### PR DESCRIPTION
This PR adds a section to template docs for simple load balancing with nomad servicse.
