### PR TITLE
client: cannot use generic Min func in backport

### DIFF
--- a/client/allocrunner/taskrunner/driver_handle.go
+++ b/client/allocrunner/taskrunner/driver_handle.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	cstructs "github.com/hashicorp/nomad/client/structs"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
 )
@@ -18,12 +17,18 @@ func NewDriverHandle(
 	task *structs.Task,
 	maxKillTimeout time.Duration,
 	net *drivers.DriverNetwork) *DriverHandle {
+
+	timeout := task.KillTimeout
+	if maxKillTimeout < timeout {
+		timeout = maxKillTimeout
+	}
+
 	return &DriverHandle{
 		driver:      driver,
 		net:         net,
 		taskID:      taskID,
 		killSignal:  task.KillSignal,
-		killTimeout: helper.Min(task.KillTimeout, maxKillTimeout),
+		killTimeout: timeout,
 	}
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8065,9 +8065,13 @@ func (e *TaskEvent) SetValidationError(err error) *TaskEvent {
 }
 
 func (e *TaskEvent) SetKillTimeout(timeout, maxTimeout time.Duration) *TaskEvent {
-	actual := helper.Min(timeout, maxTimeout)
-	e.KillTimeout = actual
-	e.Details["kill_timeout"] = actual.String()
+	lower := timeout
+	if maxTimeout < lower {
+		lower = maxTimeout
+	}
+
+	e.KillTimeout = lower
+	e.Details["kill_timeout"] = lower.String()
 	return e
 }
 


### PR DESCRIPTION
Only for `release/1.1.x`, cannot use `helper.Min` because it does not exist yet