### PR TITLE
[CI-only] Support fossa scanning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+      - "support-fossa-scanning"
   workflow_dispatch:
     inputs:
       build-ref:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "support-fossa-scanning"
   workflow_dispatch:
     inputs:
       build-ref:

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -14,7 +14,6 @@ project "nomad" {
       "release/1.1.x",
       "release/1.2.x",
       "release/1.3.x",
-      "support-fossa-scanning",
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -2,12 +2,15 @@ schema = "1"
 
 project "nomad" {
   team = "nomad"
+
   slack {
     notification_channel = "C03B5EWFW01"
   }
+
   github {
     organization = "hashicorp"
     repository   = "nomad"
+
     release_branches = [
       "main",
       "release/1.0.x",
@@ -19,12 +22,12 @@ project "nomad" {
 }
 
 event "merge" {
-  // "entrypoint" to use if build is not run automatically
-  // i.e. send "merge" complete signal to orchestrator to trigger build
+  // "entrypoint" to use if build is not run automatically  // i.e. send "merge" complete signal to orchestrator to trigger build
 }
 
 event "build" {
   depends = ["merge"]
+
   action "build" {
     organization = "hashicorp"
     repository   = "nomad"
@@ -34,6 +37,7 @@ event "build" {
 
 event "upload-dev" {
   depends = ["build"]
+
   action "upload-dev" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
@@ -47,6 +51,7 @@ event "upload-dev" {
 
 event "security-scan-binaries" {
   depends = ["upload-dev"]
+
   action "security-scan-binaries" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
@@ -61,6 +66,7 @@ event "security-scan-binaries" {
 
 event "notarize-darwin-amd64" {
   depends = ["security-scan-binaries"]
+
   action "notarize-darwin-amd64" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
@@ -74,6 +80,7 @@ event "notarize-darwin-amd64" {
 
 event "notarize-darwin-arm64" {
   depends = ["notarize-darwin-amd64"]
+
   action "notarize-darwin-arm64" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
@@ -87,6 +94,7 @@ event "notarize-darwin-arm64" {
 
 event "notarize-windows-386" {
   depends = ["notarize-darwin-arm64"]
+
   action "notarize-windows-386" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
@@ -100,6 +108,7 @@ event "notarize-windows-386" {
 
 event "notarize-windows-amd64" {
   depends = ["notarize-windows-386"]
+
   action "notarize-windows-amd64" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
@@ -113,6 +122,7 @@ event "notarize-windows-amd64" {
 
 event "sign" {
   depends = ["notarize-windows-amd64"]
+
   action "sign" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
@@ -126,6 +136,7 @@ event "sign" {
 
 event "sign-linux-rpms" {
   depends = ["sign"]
+
   action "sign-linux-rpms" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
@@ -139,6 +150,7 @@ event "sign-linux-rpms" {
 
 event "verify" {
   depends = ["sign-linux-rpms"]
+
   action "verify" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
@@ -152,10 +164,11 @@ event "verify" {
 
 event "fossa-scan" {
   depends = ["verify"]
+
   action "fossa-scan" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "fossa-scan"
+    repository   = "crt-workflows-common"
+    workflow     = "fossa-scan"
   }
 }
 
@@ -163,12 +176,12 @@ event "fossa-scan" {
 ## they should be added to the end of the file after the verify event stanza.
 
 event "trigger-staging" {
-  // This event is dispatched by the bob trigger-promotion command
-  // and is required - do not delete.
+  // This event is dispatched by the bob trigger-promotion command  // and is required - do not delete.
 }
 
 event "promote-staging" {
   depends = ["trigger-staging"]
+
   action "promote-staging" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
@@ -182,12 +195,12 @@ event "promote-staging" {
 }
 
 event "trigger-production" {
-  // This event is dispatched by the bob trigger-promotion command
-  // and is required - do not delete.
+  // This event is dispatched by the bob trigger-promotion command  // and is required - do not delete.
 }
 
 event "promote-production" {
   depends = ["trigger-production"]
+
   action "promote-production" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
@@ -201,6 +214,7 @@ event "promote-production" {
 
 event "promote-production-packaging" {
   depends = ["promote-production"]
+
   action "promote-production-packaging" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -14,6 +14,7 @@ project "nomad" {
       "release/1.1.x",
       "release/1.2.x",
       "release/1.3.x",
+      "support-fossa-scanning",
     ]
   }
 }
@@ -147,6 +148,15 @@ event "verify" {
 
   notification {
     on = "always"
+  }
+}
+
+event "fossa-scan" {
+  depends = ["verify"]
+  action "fossa-scan" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "fossa-scan"
   }
 }
 


### PR DESCRIPTION
### Description

This is a CI-only change that opts nomad into a new workflow in the CRT pipeline called fossa-scan. The fossa-scan workflow will pass regardless of any dependency licensing issues raised by fossa, but failures will be raised in #proj-oss-compliance-scanning. This will allow us to triage issues to share with the legal team, who will reach out to nomad directly if there are questions about any dependencies. 

### Testing & Reproduction steps

The fossa-scan workflow ran on the first commit here https://github.com/hashicorp/nomad/runs/7240033075 and this produced the fossa report available here https://app.fossa.com/projects/custom+23027%2fgithub.com%2fhashicorp%2fnomad/refs/branch/master/58c8bccf87515d09e56d78dce91389f25f38e659. The scan raised a few new issues that the legal team will look into here: https://hashicorp.slack.com/archives/C01JSHNP10B/p1657221287642169. 

The report links in fossa are available in the `run-fossa-scan` job- this [short recording](https://recordit.co/LhqLDmkMKz) walks through how to find the link and view the issues in fossa. Fossa access _should_ be available to everyone via Okta, but if you don't see the fossa tile on hashicorp.okta.com, sending a ticket to helpdesk will make that available to you/your team.