### PR TITLE
snapshot restore-from-archive streaming and filtering

### DIFF
--- a/.changelog/13658.txt
+++ b/.changelog/13658.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: `operator snapshot state` supports `-filter` expressions and stream decompresses snapshots to avoid writing large temporary files
+```

--- a/.changelog/13658.txt
+++ b/.changelog/13658.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-cli: `operator snapshot state` supports `-filter` expressions and stream decompresses snapshots to avoid writing large temporary files
+cli: `operator snapshot state` supports `-filter` expressions and avoids writing large temporary files
 ```

--- a/command/operator_snapshot_state.go
+++ b/command/operator_snapshot_state.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"strings"
 
+	flaghelper "github.com/hashicorp/nomad/helper/flags"
 	"github.com/hashicorp/nomad/helper/raftutil"
+	"github.com/hashicorp/nomad/nomad"
 	"github.com/posener/complete"
 )
 
@@ -16,13 +18,19 @@ type OperatorSnapshotStateCommand struct {
 
 func (c *OperatorSnapshotStateCommand) Help() string {
 	helpText := `
-Usage: nomad operator snapshot state <file>
+Usage: nomad operator snapshot state [options] <file>
 
   Displays a JSON representation of state in the snapshot.
 
   To inspect the file "backup.snap":
 
     $ nomad operator snapshot state backup.snap
+
+Snapshot State Options:
+
+  -filter
+    Specifies an expression used to filter query results.
+
 `
 	return strings.TrimSpace(helpText)
 }
@@ -42,14 +50,31 @@ func (c *OperatorSnapshotStateCommand) Synopsis() string {
 func (c *OperatorSnapshotStateCommand) Name() string { return "operator snapshot state" }
 
 func (c *OperatorSnapshotStateCommand) Run(args []string) int {
+	var filterExpr flaghelper.StringFlag
+
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+
+	flags.Var(&filterExpr, "filter", "")
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to parse args: %v", err))
+		return 1
+	}
+
+	filter, err := nomad.NewFSMFilter(filterExpr.String())
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Invalid filter expression %q: %s", filterExpr, err))
+		return 1
+	}
+
 	// Check that we either got no filename or exactly one.
-	if len(args) != 1 {
+	if len(flags.Args()) != 1 {
 		c.Ui.Error("This command takes one argument: <file>")
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}
 
-	path := args[0]
+	path := flags.Args()[0]
 	f, err := os.Open(path)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error opening snapshot file: %s", err))
@@ -57,7 +82,7 @@ func (c *OperatorSnapshotStateCommand) Run(args []string) int {
 	}
 	defer f.Close()
 
-	state, meta, err := raftutil.RestoreFromArchive(f)
+	state, meta, err := raftutil.RestoreFromArchive(f, filter)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to read archive file: %s", err))
 		return 1

--- a/helper/raftutil/fsm.go
+++ b/helper/raftutil/fsm.go
@@ -20,6 +20,7 @@ type nomadFSM interface {
 	raft.FSM
 	State() *state.StateStore
 	Restore(io.ReadCloser) error
+	RestoreWithFilter(io.ReadCloser, *nomad.FSMFilter) error
 }
 
 type FSMHelper struct {

--- a/helper/raftutil/snapshot.go
+++ b/helper/raftutil/snapshot.go
@@ -3,13 +3,12 @@ package raftutil
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
-	"os"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/raft"
+
 	"github.com/hashicorp/nomad/helper/snapshot"
 	"github.com/hashicorp/nomad/nomad/state"
-	"github.com/hashicorp/raft"
 )
 
 func RestoreFromArchive(archive io.Reader) (*state.StateStore, *raft.SnapshotMeta, error) {
@@ -20,27 +19,31 @@ func RestoreFromArchive(archive io.Reader) (*state.StateStore, *raft.SnapshotMet
 		return nil, nil, fmt.Errorf("failed to create FSM: %w", err)
 	}
 
-	snap, err := ioutil.TempFile("", "snap-")
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create a temp file: %w", err)
-	}
-	defer os.Remove(snap.Name())
-	defer snap.Close()
+	// r is closed by Restore, w is closed by CopySnapshot
+	r, w := io.Pipe()
 
-	meta, err := snapshot.CopySnapshot(archive, snap)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read snapshot: %w", err)
-	}
+	errCh := make(chan error)
+	metaCh := make(chan *raft.SnapshotMeta)
 
-	_, err = snap.Seek(0, 0)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to seek: %w", err)
-	}
+	go func() {
+		meta, err := snapshot.CopySnapshot(archive, w)
+		if err != nil {
+			errCh <- fmt.Errorf("failed to read snapshot: %w", err)
+		}
+		if meta != nil {
+			metaCh <- meta
+		}
+	}()
 
-	err = fsm.Restore(snap)
+	err = fsm.Restore(r)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to restore from snapshot: %w", err)
 	}
 
-	return fsm.State(), meta, nil
+	select {
+	case err := <-errCh:
+		return nil, nil, err
+	case meta := <-metaCh:
+		return fsm.State(), meta, nil
+	}
 }

--- a/helper/raftutil/snapshot.go
+++ b/helper/raftutil/snapshot.go
@@ -30,8 +30,7 @@ func RestoreFromArchive(archive io.Reader, filter *nomad.FSMFilter) (*state.Stat
 		meta, err := snapshot.CopySnapshot(archive, w)
 		if err != nil {
 			errCh <- fmt.Errorf("failed to read snapshot: %w", err)
-		}
-		if meta != nil {
+		} else {
 			metaCh <- meta
 		}
 	}()

--- a/helper/snapshot/snapshot.go
+++ b/helper/snapshot/snapshot.go
@@ -138,13 +138,22 @@ func (s *Snapshot) Close() error {
 	return os.Remove(s.file.Name())
 }
 
-// Verify takes the snapshot from the reader and verifies its contents.
-func Verify(in io.Reader) (*raft.SnapshotMeta, error) {
-	return CopySnapshot(in, ioutil.Discard)
+type Discard struct {
+	io.Writer
 }
 
-// CopySnapshot copies the snapshot content from snapshot archive to dest
-func CopySnapshot(in io.Reader, dest io.Writer) (*raft.SnapshotMeta, error) {
+func (dc Discard) Close() error { return nil }
+
+// Verify takes the snapshot from the reader and verifies its contents.
+func Verify(in io.Reader) (*raft.SnapshotMeta, error) {
+	return CopySnapshot(in, Discard{Writer: io.Discard})
+}
+
+// CopySnapshot copies the snapshot content from snapshot archive to dest.
+// It will close the destination once complete.
+func CopySnapshot(in io.Reader, dest io.WriteCloser) (*raft.SnapshotMeta, error) {
+	defer dest.Close()
+
 	// Wrap the reader in a gzip decompressor.
 	decomp, err := gzip.NewReader(in)
 	if err != nil {

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1490,8 +1490,7 @@ func (n *nomadFSM) restoreImpl(old io.ReadCloser, filter *FSMFilter) error {
 				/* Handle upgrade paths:
 				 * - Empty maps and slices should be treated as nil to avoid
 				 *   un-intended destructive updates in scheduler since we use
-				 *   reflect.DeepEqual. Starting Nomad 0.4.1, job submission sanitizes
-				 *   the incoming job.
+				 *   reflect.DeepEqual. Job submission sanitizes the incoming job.
 				 * - Migrate from old style upgrade stanza that used only a stagger.
 				 */
 				job.Canonicalize()

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/hashicorp/go-bexpr"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-msgpack/codec"
@@ -54,6 +55,7 @@ const (
 	ScalingEventsSnapshot                SnapshotType = 19
 	EventSinkSnapshot                    SnapshotType = 20
 	ServiceRegistrationSnapshot          SnapshotType = 21
+
 	// Namespace appliers were moved from enterprise and therefore start at 64
 	NamespaceSnapshot SnapshotType = 64
 )
@@ -1404,7 +1406,20 @@ func (n *nomadFSM) Snapshot() (raft.FSMSnapshot, error) {
 	return ns, nil
 }
 
+// Restore implements the raft.FSM interface, which doesn't support a
+// filtering parameter
 func (n *nomadFSM) Restore(old io.ReadCloser) error {
+	return n.restoreImpl(old, nil)
+}
+
+// RestoreWithFilter includes a set of bexpr filter evaluators, so
+// that we can create a FSM that excludes a portion of a snapshot
+// (typically for debugging and testing)
+func (n *nomadFSM) RestoreWithFilter(old io.ReadCloser, filter *FSMFilter) error {
+	return n.restoreImpl(old, filter)
+}
+
+func (n *nomadFSM) restoreImpl(old io.ReadCloser, filter *FSMFilter) error {
 	defer old.Close()
 
 	// Create a new state store
@@ -1459,12 +1474,11 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(node); err != nil {
 				return err
 			}
-
-			// Handle upgrade paths
-			node.Canonicalize()
-
-			if err := restore.NodeRestore(node); err != nil {
-				return err
+			if filter.Include(node) {
+				node.Canonicalize() // Handle upgrade paths
+				if err := restore.NodeRestore(node); err != nil {
+					return err
+				}
 			}
 
 		case JobSnapshot:
@@ -1472,18 +1486,18 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(job); err != nil {
 				return err
 			}
-
-			/* Handle upgrade paths:
-			 * - Empty maps and slices should be treated as nil to avoid
-			 *   un-intended destructive updates in scheduler since we use
-			 *   reflect.DeepEqual. Starting Nomad 0.4.1, job submission sanitizes
-			 *   the incoming job.
-			 * - Migrate from old style upgrade stanza that used only a stagger.
-			 */
-			job.Canonicalize()
-
-			if err := restore.JobRestore(job); err != nil {
-				return err
+			if filter.Include(job) {
+				/* Handle upgrade paths:
+				 * - Empty maps and slices should be treated as nil to avoid
+				 *   un-intended destructive updates in scheduler since we use
+				 *   reflect.DeepEqual. Starting Nomad 0.4.1, job submission sanitizes
+				 *   the incoming job.
+				 * - Migrate from old style upgrade stanza that used only a stagger.
+				 */
+				job.Canonicalize()
+				if err := restore.JobRestore(job); err != nil {
+					return err
+				}
 			}
 
 		case EvalSnapshot:
@@ -1491,9 +1505,10 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(eval); err != nil {
 				return err
 			}
-
-			if err := restore.EvalRestore(eval); err != nil {
-				return err
+			if filter.Include(eval) {
+				if err := restore.EvalRestore(eval); err != nil {
+					return err
+				}
 			}
 
 		case AllocSnapshot:
@@ -1501,12 +1516,11 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(alloc); err != nil {
 				return err
 			}
-
-			// Handle upgrade path
-			alloc.Canonicalize()
-
-			if err := restore.AllocRestore(alloc); err != nil {
-				return err
+			if filter.Include(alloc) {
+				alloc.Canonicalize() // Handle upgrade path
+				if err := restore.AllocRestore(alloc); err != nil {
+					return err
+				}
 			}
 
 		case IndexSnapshot:
@@ -1523,9 +1537,10 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(launch); err != nil {
 				return err
 			}
-
-			if err := restore.PeriodicLaunchRestore(launch); err != nil {
-				return err
+			if filter.Include(launch) {
+				if err := restore.PeriodicLaunchRestore(launch); err != nil {
+					return err
+				}
 			}
 
 		case JobSummarySnapshot:
@@ -1533,9 +1548,10 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(summary); err != nil {
 				return err
 			}
-
-			if err := restore.JobSummaryRestore(summary); err != nil {
-				return err
+			if filter.Include(summary) {
+				if err := restore.JobSummaryRestore(summary); err != nil {
+					return err
+				}
 			}
 
 		case VaultAccessorSnapshot:
@@ -1543,8 +1559,10 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(accessor); err != nil {
 				return err
 			}
-			if err := restore.VaultAccessorRestore(accessor); err != nil {
-				return err
+			if filter.Include(accessor) {
+				if err := restore.VaultAccessorRestore(accessor); err != nil {
+					return err
+				}
 			}
 
 		case ServiceIdentityTokenAccessorSnapshot:
@@ -1552,8 +1570,10 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(accessor); err != nil {
 				return err
 			}
-			if err := restore.SITokenAccessorRestore(accessor); err != nil {
-				return err
+			if filter.Include(accessor) {
+				if err := restore.SITokenAccessorRestore(accessor); err != nil {
+					return err
+				}
 			}
 
 		case JobVersionSnapshot:
@@ -1561,9 +1581,10 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(version); err != nil {
 				return err
 			}
-
-			if err := restore.JobVersionRestore(version); err != nil {
-				return err
+			if filter.Include(version) {
+				if err := restore.JobVersionRestore(version); err != nil {
+					return err
+				}
 			}
 
 		case DeploymentSnapshot:
@@ -1571,9 +1592,10 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(deployment); err != nil {
 				return err
 			}
-
-			if err := restore.DeploymentRestore(deployment); err != nil {
-				return err
+			if filter.Include(deployment) {
+				if err := restore.DeploymentRestore(deployment); err != nil {
+					return err
+				}
 			}
 
 		case ACLPolicySnapshot:
@@ -1581,8 +1603,10 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(policy); err != nil {
 				return err
 			}
-			if err := restore.ACLPolicyRestore(policy); err != nil {
-				return err
+			if filter.Include(policy) {
+				if err := restore.ACLPolicyRestore(policy); err != nil {
+					return err
+				}
 			}
 
 		case ACLTokenSnapshot:
@@ -1590,8 +1614,10 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(token); err != nil {
 				return err
 			}
-			if err := restore.ACLTokenRestore(token); err != nil {
-				return err
+			if filter.Include(token) {
+				if err := restore.ACLTokenRestore(token); err != nil {
+					return err
+				}
 			}
 
 		case SchedulerConfigSnapshot:
@@ -1618,9 +1644,10 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(jobScalingEvents); err != nil {
 				return err
 			}
-
-			if err := restore.ScalingEventsRestore(jobScalingEvents); err != nil {
-				return err
+			if filter.Include(jobScalingEvents) {
+				if err := restore.ScalingEventsRestore(jobScalingEvents); err != nil {
+					return err
+				}
 			}
 
 		case ScalingPolicySnapshot:
@@ -1628,13 +1655,13 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(scalingPolicy); err != nil {
 				return err
 			}
-
-			// Handle upgrade path:
-			//   - Set policy type if empty
-			scalingPolicy.Canonicalize()
-
-			if err := restore.ScalingPolicyRestore(scalingPolicy); err != nil {
-				return err
+			if filter.Include(scalingPolicy) {
+				// Handle upgrade path:
+				//   - Set policy type if empty
+				scalingPolicy.Canonicalize()
+				if err := restore.ScalingPolicyRestore(scalingPolicy); err != nil {
+					return err
+				}
 			}
 
 		case CSIPluginSnapshot:
@@ -1642,19 +1669,21 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			if err := dec.Decode(plugin); err != nil {
 				return err
 			}
-
-			if err := restore.CSIPluginRestore(plugin); err != nil {
-				return err
+			if filter.Include(plugin) {
+				if err := restore.CSIPluginRestore(plugin); err != nil {
+					return err
+				}
 			}
 
 		case CSIVolumeSnapshot:
-			plugin := new(structs.CSIVolume)
-			if err := dec.Decode(plugin); err != nil {
+			volume := new(structs.CSIVolume)
+			if err := dec.Decode(volume); err != nil {
 				return err
 			}
-
-			if err := restore.CSIVolumeRestore(plugin); err != nil {
-				return err
+			if filter.Include(volume) {
+				if err := restore.CSIVolumeRestore(volume); err != nil {
+					return err
+				}
 			}
 
 		case NamespaceSnapshot:
@@ -1671,18 +1700,15 @@ func (n *nomadFSM) Restore(old io.ReadCloser) error {
 			return nil
 
 		case ServiceRegistrationSnapshot:
-
-			// Create a new ServiceRegistration object, so we can decode the
-			// message into it.
 			serviceRegistration := new(structs.ServiceRegistration)
-
 			if err := dec.Decode(serviceRegistration); err != nil {
 				return err
 			}
-
-			// Perform the restoration.
-			if err := restore.ServiceRegistrationRestore(serviceRegistration); err != nil {
-				return err
+			if filter.Include(serviceRegistration) {
+				// Perform the restoration.
+				if err := restore.ServiceRegistrationRestore(serviceRegistration); err != nil {
+					return err
+				}
 			}
 
 		default:
@@ -1942,6 +1968,32 @@ func (n *nomadFSM) applyDeleteServiceRegistrationByNodeID(msgType structs.Messag
 	}
 
 	return nil
+}
+
+type FSMFilter struct {
+	evaluator *bexpr.Evaluator
+}
+
+func NewFSMFilter(expr string) (*FSMFilter, error) {
+	if expr == "" {
+		return nil, nil
+	}
+	evaluator, err := bexpr.CreateEvaluator(expr)
+	if err != nil {
+		return nil, err
+	}
+	return &FSMFilter{evaluator: evaluator}, nil
+}
+
+func (f *FSMFilter) Include(item interface{}) bool {
+	if f == nil {
+		return true
+	}
+	ok, err := f.evaluator.Evaluate(item)
+	if !ok || err != nil {
+		return false
+	}
+	return true
 }
 
 func (s *nomadSnapshot) Persist(sink raft.SnapshotSink) error {

--- a/scheduler/benchmarks/helpers_test.go
+++ b/scheduler/benchmarks/helpers_test.go
@@ -70,7 +70,7 @@ func NewHarnessFromSnapshot(t testing.TB, snapshotPath string) (*scheduler.Harne
 	}
 	defer f.Close()
 
-	state, _, err := raftutil.RestoreFromArchive(f)
+	state, _, err := raftutil.RestoreFromArchive(f, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This changeset implements two improvements to restoring FSM snapshots from archives:
* The existing implementation decompresses the archive to a temporary file before reading it in to the FSM. For large snapshots this performs a lot of disk IO. Stream decompress the snapshot as we read it, without first writing to a temporary file. This also moves some of the work to a second core.
* Add bexpr filters to the `RestoreFromArchive` helper. The operator can pass these as `-filter` arguments to `nomad operator snapshot state` (and other commands in the future) to include only desired data when reading the snapshot.

Deferred for this PR: the `nomad operator snapshot state` command still has to load everything that's been filtered into the FSM before writing it out to a large JSON blob. We should provide a tool that streams the decoded objects directly to an encoder without loading into the FSM, so that we can emit NDJSON, write out to a sqlite DB, etc.

---

Example:

Starting with a 439MB snapshot (~13GiB uncompressed), I want to filter for all objects associated with 3 different jobs and 3 different nodes:

```
time nomad operator snapshot state -filter '
    JobID == "job1" or
    JobID == "job2" or
    JobID == "job3" or
    NodeID == "3b3471d7-c519-8e3c-d7fd-dc692ca44744" or
    NodeID == "455775de-b4b4-0cb6-75eb-6c534618a005" or
    NodeID == "0d8e2a62-2712-cb4c-fb15-9831fdac57fe" or
    ID == "job1" or
    ID == "job2" or
    ID == "job3" or
    ID == "3b3471d7-c519-8e3c-d7fd-dc692ca44744" or
    ID == "455775de-b4b4-0cb6-75eb-6c534618a005" or
    ID == "0d8e2a62-2712-cb4c-fb15-9831fdac57fe"
' \
      ./nomad_operator_snapshot_save_2022_05_12_1543-0700.snap \
      > filtered-state.json

real    24m15.805s
user    29m55.036s
sys     7m50.618s

$ cat filtered-state.json| jq '.Allocs | length'
5490
$ cat filtered-state.json| jq '.Evals | length'
667
```

Previously this would write ~13GiB to disk, read 14GiB from disk, and saturate 1 core for over an hour before running out of memory on my machine (16GiB) and crashing.

With this change, the command reads ~450MiB from disk, only writes the 197MiB JSON blob to disk, and uses about 150% CPU, maxing out memory usage around 330MB.