### PR TITLE
Remove namespace cache

### DIFF
--- a/.changelog/10808.txt
+++ b/.changelog/10808.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-ui: Namespace filter query paramters are now isolated by route
+cli: Added `nomad operator api` command to ease querying Nomad's HTTP API.
 ```

--- a/.changelog/10808.txt
+++ b/.changelog/10808.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-cli: Added `nomad operator api` command to ease querying Nomad's HTTP API.
+ui: Namespace filter query paramters are now isolated by route
 ```

--- a/.changelog/13679.txt
+++ b/.changelog/13679.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Namespace filter query paramters are now isolated by route
+```

--- a/ui/app/controllers/csi/volumes/index.js
+++ b/ui/app/controllers/csi/volumes/index.js
@@ -64,7 +64,7 @@ export default class IndexController extends Controller.extend(
 
   fuzzySearchEnabled = true;
 
-  @computed('qpNamespace', 'model.namespaces.[]', 'system.cachedNamespace')
+  @computed('qpNamespace', 'model.namespaces.[]')
   get optionsNamespaces() {
     const availableNamespaces = this.model.namespaces.map((namespace) => ({
       key: namespace.name,
@@ -81,7 +81,7 @@ export default class IndexController extends Controller.extend(
       // eslint-disable-next-line ember/no-incorrect-calls-with-inline-anonymous-functions
       scheduleOnce('actions', () => {
         // eslint-disable-next-line ember/no-side-effects
-        this.set('qpNamespace', this.system.cachedNamespace || '*');
+        this.set('qpNamespace', '*');
       });
     }
 
@@ -100,11 +100,6 @@ export default class IndexController extends Controller.extend(
   @alias('visibleVolumes') listToSort;
   @alias('listSorted') listToSearch;
   @alias('listSearched') sortedVolumes;
-
-  @action
-  cacheNamespace(namespace) {
-    set(this, 'system.cachedNamespace', namespace);
-  }
 
   setFacetQueryParam(queryParam, selection) {
     this.set(queryParam, serialize(selection));

--- a/ui/app/controllers/csi/volumes/index.js
+++ b/ui/app/controllers/csi/volumes/index.js
@@ -1,4 +1,3 @@
-import { set } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { action, computed } from '@ember/object';
 import { alias, readOnly } from '@ember/object/computed';

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -1,9 +1,8 @@
 /* eslint-disable ember/no-incorrect-calls-with-inline-anonymous-functions */
-import { set } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { alias, readOnly } from '@ember/object/computed';
 import Controller from '@ember/controller';
-import { action, computed } from '@ember/object';
+import { computed } from '@ember/object';
 import { scheduleOnce } from '@ember/runloop';
 import intersection from 'lodash.intersection';
 import Sortable from 'nomad-ui/mixins/sortable';

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -165,7 +165,7 @@ export default class IndexController extends Controller.extend(
     }));
   }
 
-  @computed('qpNamespace', 'model.namespaces.[]', 'system.cachedNamespace')
+  @computed('qpNamespace', 'model.namespaces.[]')
   get optionsNamespaces() {
     const availableNamespaces = this.model.namespaces.map((namespace) => ({
       key: namespace.name,
@@ -181,7 +181,7 @@ export default class IndexController extends Controller.extend(
     if (!availableNamespaces.mapBy('key').includes(this.qpNamespace)) {
       scheduleOnce('actions', () => {
         // eslint-disable-next-line ember/no-side-effects
-        this.set('qpNamespace', this.system.cachedNamespace || '*');
+        this.set('qpNamespace', '*');
       });
     }
 
@@ -251,11 +251,6 @@ export default class IndexController extends Controller.extend(
   @alias('listSearched') sortedJobs;
 
   isShowingDeploymentDetails = false;
-
-  @action
-  cacheNamespace(namespace) {
-    set(this, 'system.cachedNamespace', namespace);
-  }
 
   setFacetQueryParam(queryParam, selection) {
     this.set(queryParam, serialize(selection));

--- a/ui/app/controllers/optimize.js
+++ b/ui/app/controllers/optimize.js
@@ -87,7 +87,7 @@ export default class OptimizeController extends Controller {
     if (!availableNamespaces.mapBy('key').includes(this.qpNamespace)) {
       scheduleOnce('actions', () => {
         // eslint-disable-next-line ember/no-side-effects
-        this.qpNamespace = this.system.cachedNamespace || '*';
+        this.qpNamespace = '*';
       });
     }
 
@@ -245,11 +245,6 @@ export default class OptimizeController extends Controller {
     this.transitionToRoute('optimize.summary', summary.slug, {
       queryParams: { jobNamespace: summary.jobNamespace },
     });
-  }
-
-  @action
-  cacheNamespace(namespace) {
-    this.system.cachedNamespace = namespace;
   }
 
   @action

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -132,12 +132,6 @@ export default class SystemService extends Service {
     );
   }
 
-  // The cachedNamespace is set on pages that have a namespaces filter.
-  // It is set so other pages that have a namespaces filter can default to
-  // what the previous namespaces filter page used rather than defaulting
-  // to 'default' or '*'.
-  @tracked cachedNamespace = null;
-
   @task(function* () {
     const emptyLicense = { License: { Features: [] } };
 

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -1,6 +1,5 @@
 import Service, { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 import { alias } from '@ember/object/computed';
 import PromiseObject from '../utils/classes/promise-object';
 import PromiseArray from '../utils/classes/promise-array';

--- a/ui/app/templates/csi/volumes/index.hbs
+++ b/ui/app/templates/csi/volumes/index.hbs
@@ -33,9 +33,7 @@
             @label="Namespace"
             @options={{this.optionsNamespaces}}
             @selection={{this.qpNamespace}}
-            @onSelect={{action
-              (queue (action this.cacheNamespace) (action this.setFacetQueryParam "qpNamespace"))
-            }}
+            @onSelect={{action this.setFacetQueryParam "qpNamespace"}}
           />
         </div>
       </div>

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -43,12 +43,7 @@
             @label="Namespace"
             @options={{this.optionsNamespaces}}
             @selection={{this.qpNamespace}}
-            @onSelect={{action
-              (queue
-                (action this.cacheNamespace)
-                (action this.setFacetQueryParam "qpNamespace")
-              )
-            }}
+            @onSelect={{action this.setFacetQueryParam "qpNamespace"}}
           />
         {{/if}}
         <MultiSelectDropdown

--- a/ui/app/templates/optimize.hbs
+++ b/ui/app/templates/optimize.hbs
@@ -23,12 +23,7 @@
                 @label="Namespace"
                 @options={{this.optionsNamespaces}}
                 @selection={{this.qpNamespace}}
-                @onSelect={{action
-                  (queue
-                    (action this.cacheNamespace)
-                    (action this.setFacetQueryParam "qpNamespace")
-                  )
-                }}
+                @onSelect={{action this.setFacetQueryParam "qpNamespace"}}
               />
             {{/if}}
             <MultiSelectDropdown

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -423,19 +423,6 @@ module('Acceptance | jobs list', function (hooks) {
     );
   });
 
-  test('the active namespace is carried over to the storage pages', async function (assert) {
-    server.createList('namespace', 2);
-
-    const namespace = server.db.namespaces[1];
-    await JobsList.visit();
-    await JobsList.facets.namespace.toggle();
-    await JobsList.facets.namespace.options.objectAt(2).select();
-
-    await Layout.gutter.visitStorage();
-
-    assert.equal(currentURL(), `/csi/volumes?namespace=${namespace.id}`);
-  });
-
   test('when the user has a client token that has a namespace with a policy to run a job', async function (assert) {
     const READ_AND_WRITE_NAMESPACE = 'read-and-write-namespace';
     const READ_ONLY_NAMESPACE = 'read-only-namespace';

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -6,7 +6,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import pageSizeSelect from './behaviors/page-size-select';
 import JobsList from 'nomad-ui/tests/pages/jobs/list';
-import Layout from 'nomad-ui/tests/pages/layout';
 import percySnapshot from '@percy/ember';
 
 let managementToken, clientToken;

--- a/ui/tests/acceptance/optimize-test.js
+++ b/ui/tests/acceptance/optimize-test.js
@@ -76,6 +76,12 @@ module('Acceptance | optimize', function (hooks) {
       .flat()
       .find((r) => r.resource === 'CPU');
 
+    const currentTaskGroupHasMemoryRecommendation =
+      currentTaskGroup.tasks.models
+        .mapBy('recommendations.models')
+        .flat()
+        .find((r) => r.resource === 'MemoryMB');
+
     // If no CPU recommendation, will not be able to accept recommendation with all memory recommendations turned off
 
     if (!currentTaskGroupHasCPURecommendation) {
@@ -83,6 +89,13 @@ module('Acceptance | optimize', function (hooks) {
       this.server.create('recommendation', {
         task: currentTaskGroupTask,
         resource: 'CPU',
+      });
+    }
+    if (!currentTaskGroupHasMemoryRecommendation) {
+      const currentTaskGroupTask = currentTaskGroup.tasks.models[0];
+      this.server.create('recommendation', {
+        task: currentTaskGroupTask,
+        resource: 'MemoryMB',
       });
     }
 

--- a/ui/tests/acceptance/optimize-test.js
+++ b/ui/tests/acceptance/optimize-test.js
@@ -213,7 +213,7 @@ module('Acceptance | optimize', function (hooks) {
     let toggledAnything = true;
 
     // Toggle off all memory
-    if (Optimize.card.togglesTable.toggleAllMemory.isPresent) {
+    if (Optimize.card.togglesTable.toggleAllMemory) {
       await Optimize.card.togglesTable.toggleAllMemory.toggle();
       assert.notOk(Optimize.card.togglesTable.tasks[0].memory.isActive);
       assert.notOk(Optimize.card.togglesTable.tasks[1].memory.isActive);

--- a/ui/tests/acceptance/optimize-test.js
+++ b/ui/tests/acceptance/optimize-test.js
@@ -226,8 +226,9 @@ module('Acceptance | optimize', function (hooks) {
     let toggledAnything = true;
 
     // Toggle off all memory
-    if (Optimize.card.togglesTable.toggleAllMemory) {
+    if (Optimize.card.togglesTable.toggleAllMemory.isPresent) {
       await Optimize.card.togglesTable.toggleAllMemory.toggle();
+
       assert.notOk(Optimize.card.togglesTable.tasks[0].memory.isActive);
       assert.notOk(Optimize.card.togglesTable.tasks[1].memory.isActive);
     } else if (!Optimize.card.togglesTable.tasks[0].cpu.isDisabled) {

--- a/ui/tests/acceptance/optimize-test.js
+++ b/ui/tests/acceptance/optimize-test.js
@@ -215,7 +215,6 @@ module('Acceptance | optimize', function (hooks) {
     // Toggle off all memory
     if (Optimize.card.togglesTable.toggleAllMemory.isPresent) {
       await Optimize.card.togglesTable.toggleAllMemory.toggle();
-
       assert.notOk(Optimize.card.togglesTable.tasks[0].memory.isActive);
       assert.notOk(Optimize.card.togglesTable.tasks[1].memory.isActive);
     } else if (!Optimize.card.togglesTable.tasks[0].cpu.isDisabled) {

--- a/ui/tests/acceptance/volumes-list-test.js
+++ b/ui/tests/acceptance/volumes-list-test.js
@@ -7,7 +7,6 @@ import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import pageSizeSelect from './behaviors/page-size-select';
 import VolumesList from 'nomad-ui/tests/pages/storage/volumes/list';
 import percySnapshot from '@percy/ember';
-
 const assignWriteAlloc = (volume, alloc) => {
   volume.writeAllocs.add(alloc);
   volume.allocations.add(alloc);

--- a/ui/tests/acceptance/volumes-list-test.js
+++ b/ui/tests/acceptance/volumes-list-test.js
@@ -193,19 +193,6 @@ module('Acceptance | volumes list', function (hooks) {
     assert.equal(VolumesList.volumes.objectAt(0).name, volume2.id);
   });
 
-  test('the active namespace is carried over to the jobs pages', async function (assert) {
-    server.createList('namespace', 2);
-
-    const namespace = server.db.namespaces[1];
-    await VolumesList.visit();
-    await VolumesList.facets.namespace.toggle();
-    await VolumesList.facets.namespace.options.objectAt(2).select();
-
-    await Layout.gutter.visitJobs();
-
-    assert.equal(currentURL(), `/jobs?namespace=${namespace.id}`);
-  });
-
   test('when accessing volumes is forbidden, a message is shown with a link to the tokens page', async function (assert) {
     server.pretender.get('/v1/volumes', () => [403, {}, null]);
 

--- a/ui/tests/acceptance/volumes-list-test.js
+++ b/ui/tests/acceptance/volumes-list-test.js
@@ -6,7 +6,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import pageSizeSelect from './behaviors/page-size-select';
 import VolumesList from 'nomad-ui/tests/pages/storage/volumes/list';
-import Layout from 'nomad-ui/tests/pages/layout';
 import percySnapshot from '@percy/ember';
 
 const assignWriteAlloc = (volume, alloc) => {


### PR DESCRIPTION
Removes the "namespace" query parameter between routes (jobs, optimize, volumes) to keep that filter isolated (you may not want to filter across all entity types).

This more closely aligns to the behaviour of our current Evaluations page