### PR TITLE
test: fix panics in api package

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -115,7 +115,6 @@ func TestRequestTime(t *testing.T) {
 }
 
 func TestDefaultConfig_env(t *testing.T) {
-	t.Parallel()
 	testURL := "http://1.2.3.4:5678"
 	auth := []string{"nomaduser", "12345"}
 	region := "test"

--- a/api/evaluations_test.go
+++ b/api/evaluations_test.go
@@ -75,7 +75,7 @@ func TestEvaluations_List(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	if len(result) != 1 {
-		t.Fatalf("expected no evals after last one but got %v", result[0])
+		t.Fatalf("expected no evals after last one but got %v", result)
 	}
 }
 


### PR DESCRIPTION
When running the `api` tests in parallel the following panics could
happen:

```
--- FAIL: TestEvaluations_List (1.62s)
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0

goroutine 114 [running]:
testing.tRunner.func1.2({0x7e6a80, 0xc00001c1c8})
        /usr/local/go/src/testing/testing.go:1389 +0x24e
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1392 +0x39f
panic({0x7e6a80, 0xc00001c1c8})
        /usr/local/go/src/runtime/panic.go:838 +0x207
github.com/hashicorp/nomad/api.TestEvaluations_List(0xc0001ac680)
        /home/vagrant/src/hashicorp/nomad-oss/api/evaluations_test.go:78 +0x765
testing.tRunner(0xc0001ac680, 0x843220)
        /usr/local/go/src/testing/testing.go:1439 +0x102
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1486 +0x35f
FAIL    github.com/hashicorp/nomad/api  132.163s
FAIL
```

```
--- FAIL: TestDefaultConfig_env (0.00s)
panic: testing: t.Setenv called after t.Parallel; cannot set environment variables in parallel tests [recovered]
        panic: testing: t.Setenv called after t.Parallel; cannot set environment variables in parallel tests

goroutine 111 [running]:
testing.tRunner.func1.2({0x138e6c0, 0x14c0050})
        /nix/store/rp4bldd4vkzjfz42m2wlb1f37r6w0g32-go-1.18.3/share/go/src/testing/testing.go:1389 +0x24e
testing.tRunner.func1()
        /nix/store/rp4bldd4vkzjfz42m2wlb1f37r6w0g32-go-1.18.3/share/go/src/testing/testing.go:1392 +0x39f
panic({0x138e6c0, 0x14c0050})
        /nix/store/rp4bldd4vkzjfz42m2wlb1f37r6w0g32-go-1.18.3/share/go/src/runtime/panic.go:838 +0x207
testing.(*T).Setenv(...)
        /nix/store/rp4bldd4vkzjfz42m2wlb1f37r6w0g32-go-1.18.3/share/go/src/testing/testing.go:1282
github.com/hashicorp/nomad/api.TestDefaultConfig_env(0xc00009eea0)
        /Users/laoqui/go/src/github.com/hashicorp/nomad/api/api_test.go:125 +0x5cb
testing.tRunner(0xc00009eea0, 0x14428a8)
        /nix/store/rp4bldd4vkzjfz42m2wlb1f37r6w0g32-go-1.18.3/share/go/src/testing/testing.go:1439 +0x102
created by testing.(*T).Run
        /nix/store/rp4bldd4vkzjfz42m2wlb1f37r6w0g32-go-1.18.3/share/go/src/testing/testing.go:1486 +0x35f
exit status 2
FAIL    github.com/hashicorp/nomad/api  13.442s
```