### PR TITLE
ci: remove any other versions of Node installed

### DIFF
--- a/scripts/vagrant-linux-unpriv-ui.sh
+++ b/scripts/vagrant-linux-unpriv-ui.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+export NODE_VERSION=14.19.2
+
 # Install NVM for simple node.js version management
 curl -sSL --fail -o- https://raw.githubusercontent.com/creationix/nvm/v0.36.0/install.sh | bash
 
@@ -10,8 +12,12 @@ export NVM_DIR="${HOME}/.nvm"
 
 # Install Node, Ember CLI, and Phantom for UI development
 # Use exact full version version (e.g. not 12) for reproducibility purposes
-nvm install 14.19.2
-nvm alias default 14.19.2
+nvm install "${NODE_VERSION}"
+nvm alias default "${NODE_VERSION}"
+
+# Remove any other version of node installed
+find ~/.nvm/versions/node -not -name "v${NODE_VERSION}" -depth 1 -exec rm -rf {} \;
+
 npm install -g ember-cli
 
 # Install Yarn for front-end dependency management


### PR DESCRIPTION
Remove other versions of Node installed in nvm to avoid issues where the
CI runner uses the wrong one.