### PR TITLE
13553 secure vars linked from jobs

### DIFF
--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -328,4 +328,9 @@ export default class Job extends Model {
   // spec first. In order to preserve both the original HCL and the parsed response
   // that will be submitted to the create job endpoint, another prop is necessary.
   @attr('string') _newDefinitionJSON;
+
+  @computed('variables')
+  get pathLinkedVariable() {
+    return this.variables?.objectAt(0);
+  }
 }

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -138,6 +138,7 @@ export default class Job extends Model {
   @hasMany('allocations') allocations;
   @hasMany('deployments') deployments;
   @hasMany('evaluations') evaluations;
+  @hasMany('variables') variables;
   @belongsTo('namespace') namespace;
   @belongsTo('job-scale') scaleState;
 

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -329,8 +329,15 @@ export default class Job extends Model {
   // that will be submitted to the create job endpoint, another prop is necessary.
   @attr('string') _newDefinitionJSON;
 
-  @computed('variables')
+  @computed('variables', 'parent', 'plainId')
   get pathLinkedVariable() {
-    return this.variables?.objectAt(0);
+    if (this.parent.get('id')) {
+      return this.variables?.findBy(
+        'path',
+        `jobs/${JSON.parse(this.parent.get('id'))[0]}`
+      );
+    } else {
+      return this.variables?.findBy('path', `jobs/${this.plainId}`);
+    }
   }
 }

--- a/ui/app/models/task-group.js
+++ b/ui/app/models/task-group.js
@@ -18,7 +18,7 @@ export default class TaskGroup extends Fragment {
   @attr('string') name;
   @attr('number') count;
 
-  @computed('job.variables', 'job.parent', 'job.plainId')
+  @computed('job.{variables,parent,plainId}', 'name')
   get pathLinkedVariable() {
     if (this.job.parent.get('id')) {
       return this.job.variables?.findBy(

--- a/ui/app/models/task-group.js
+++ b/ui/app/models/task-group.js
@@ -18,6 +18,21 @@ export default class TaskGroup extends Fragment {
   @attr('string') name;
   @attr('number') count;
 
+  @computed('job.variables', 'job.parent', 'job.plainId')
+  get pathLinkedVariable() {
+    if (this.job.parent.get('id')) {
+      return this.job.variables?.findBy(
+        'path',
+        `jobs/${JSON.parse(this.job.parent.get('id'))[0]}/${this.name}`
+      );
+    } else {
+      return this.job.variables?.findBy(
+        'path',
+        `jobs/${this.job.plainId}/${this.name}`
+      );
+    }
+  }
+
   @fragmentArray('task') tasks;
 
   @fragmentArray('service') services;

--- a/ui/app/models/task.js
+++ b/ui/app/models/task.js
@@ -50,4 +50,27 @@ export default class Task extends Fragment {
   @attr('number') reservedEphemeralDisk;
 
   @fragmentArray('volume-mount', { defaultValue: () => [] }) volumeMounts;
+
+  async _fetchParentJob() {
+    let job = await this.store.findRecord('job', this.taskGroup.job.id, {
+      reload: true,
+    });
+    this._job = job;
+  }
+
+  get pathLinkedVariable() {
+    if (!this._job) {
+      this._fetchParentJob();
+      return null;
+    } else {
+      let jobID = this._job.plainId;
+      if (this._job.parent.get('plainId')) {
+        jobID = this._job.parent.get('plainId');
+      }
+      return this._job.variables?.findBy(
+        'path',
+        `jobs/${jobID}/${this.taskGroup.name}/${this.name}`
+      );
+    }
+  }
 }

--- a/ui/app/models/variable.js
+++ b/ui/app/models/variable.js
@@ -1,11 +1,11 @@
 // @ts-check
 import Model from '@ember-data/model';
-import { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 import classic from 'ember-classic-decorator';
 // eslint-disable-next-line no-unused-vars
 import MutableArray from '@ember/array/mutable';
 import { trimPath } from '../helpers/trim-path';
+import { attr, belongsTo } from '@ember-data/model';
 
 /**
  * @typedef KeyValue
@@ -54,6 +54,8 @@ export default class VariableModel extends Model {
   @attr('date') modifyTime;
   /** @type {string} */
   @attr('string', { defaultValue: 'default' }) namespace;
+
+  @belongsTo('job') job;
 
   @computed('path')
   get parentFolderPath() {

--- a/ui/app/models/variable.js
+++ b/ui/app/models/variable.js
@@ -5,7 +5,7 @@ import classic from 'ember-classic-decorator';
 // eslint-disable-next-line no-unused-vars
 import MutableArray from '@ember/array/mutable';
 import { trimPath } from '../helpers/trim-path';
-import { attr, belongsTo } from '@ember-data/model';
+import { attr } from '@ember-data/model';
 
 /**
  * @typedef KeyValue
@@ -55,8 +55,6 @@ export default class VariableModel extends Model {
   /** @type {string} */
   @attr('string', { defaultValue: 'default' }) namespace;
 
-  @belongsTo('job') job;
-
   @computed('path')
   get parentFolderPath() {
     const split = this.path.split('/');
@@ -99,7 +97,7 @@ export default class VariableModel extends Model {
   get pathLinkedEntities() {
     const entityTypes = ['job', 'group', 'task'];
     const emptyEntities = { job: '', group: '', task: '' };
-    if (this.path.startsWith('jobs/') && this.path.split('/').length <= 4) {
+    if (this.path?.startsWith('jobs/') && this.path?.split('/').length <= 4) {
       return this.path
         .split('/')
         .slice(1, 4)

--- a/ui/app/routes/variables.js
+++ b/ui/app/routes/variables.js
@@ -16,7 +16,7 @@ export default class VariablesRoute extends Route.extend(WithForbiddenState) {
   }
   async model() {
     try {
-      const variables = await this.store.findAll('variable');
+      const variables = await this.store.findAll('variable', { reload: true });
       return {
         variables,
         pathTree: new PathTree(variables),

--- a/ui/app/serializers/job.js
+++ b/ui/app/serializers/job.js
@@ -71,6 +71,10 @@ export default class JobSerializer extends ApplicationSerializer {
       .buildURL(modelName, hash.ID, hash, 'findRecord')
       .split('?');
 
+    const variableLookup = hash.ParentID
+      ? JSON.parse(hash.ParentID)[0]
+      : hash.PlainId;
+
     return assign(super.extractRelationships(...arguments), {
       allocations: {
         links: {
@@ -99,9 +103,9 @@ export default class JobSerializer extends ApplicationSerializer {
       },
       variables: {
         links: {
-          related: buildURL(
-            `/${apiNamespace}/vars?filter=SecureVariableMetadata.Path%3D%3D"jobs/${hash.PlainId}"`
-          ),
+          related: buildURL(`/${apiNamespace}/vars`, {
+            prefix: `jobs/${variableLookup}`,
+          }),
         },
       },
       scaleState: {

--- a/ui/app/serializers/job.js
+++ b/ui/app/serializers/job.js
@@ -97,6 +97,13 @@ export default class JobSerializer extends ApplicationSerializer {
           related: buildURL(`${jobURL}/evaluations`, { namespace }),
         },
       },
+      variables: {
+        links: {
+          related: buildURL(
+            `/${apiNamespace}/vars?filter=SecureVariableMetadata.Path%3D%3D"jobs/${hash.PlainId}"`
+          ),
+        },
+      },
       scaleState: {
         links: {
           related: buildURL(`${jobURL}/scale`, { namespace }),

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -98,7 +98,7 @@
         </span>
       </span>
 
-      {{#if this.model.task.pathLinkedVariable}}
+      {{#if (and (can "list variables") this.model.task.pathLinkedVariable)}}
         <span class="pair" data-test-task-group-stat="variables">
           <LinkTo @route="variables.variable" @model={{this.model.task.pathLinkedVariable.id}}>Variables</LinkTo>
         </span>

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -99,7 +99,7 @@
       </span>
 
       {{#if (and (can "list variables") this.model.task.pathLinkedVariable)}}
-        <span class="pair" data-test-task-group-stat="variables">
+        <span class="pair" data-test-task-stat="variables">
           <LinkTo @route="variables.variable" @model={{this.model.task.pathLinkedVariable.id}}>Variables</LinkTo>
         </span>
       {{/if}}

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -97,6 +97,13 @@
           {{this.model.task.lifecycleName}}
         </span>
       </span>
+
+      {{#if this.model.task.pathLinkedVariable}}
+        <span class="pair" data-test-task-group-stat="variables">
+          <LinkTo @route="variables.variable" @model={{this.model.task.pathLinkedVariable.id}}>Variables</LinkTo>
+        </span>
+      {{/if}}
+
     </div>
   </div>
   <div class="boxed-section">

--- a/ui/app/templates/components/job-page/parts/stats-box.hbs
+++ b/ui/app/templates/components/job-page/parts/stats-box.hbs
@@ -1,8 +1,4 @@
 {{! template-lint-disable no-inline-styles }}
-{{log "job vars" @job.variables.length @job.variables}}
-{{#each @job.variables as |var|}}
-  - {{var.path}}
-{{/each}}
 <div class="boxed-section is-small">
   <div class="boxed-section-body inline-definitions">
     <span class="label" style="width: 6.125rem;">Job Details</span>
@@ -20,8 +16,7 @@
     </span>
     {{#if @job.variables}}
     <span class="pair" data-test-job-stat="variables">
-      <span class="term">Variables</span>
-      {{@job.variables}}
+      <LinkTo @route="variables.variable" @model={{@job.pathLinkedVariable.id}}>Secure Variable</LinkTo>
     </span>
     {{/if}}
     {{yield to="before-namespace"}}

--- a/ui/app/templates/components/job-page/parts/stats-box.hbs
+++ b/ui/app/templates/components/job-page/parts/stats-box.hbs
@@ -1,4 +1,8 @@
 {{! template-lint-disable no-inline-styles }}
+{{log "job vars" @job.variables.length @job.variables}}
+{{#each @job.variables as |var|}}
+  - {{var.path}}
+{{/each}}
 <div class="boxed-section is-small">
   <div class="boxed-section-body inline-definitions">
     <span class="label" style="width: 6.125rem;">Job Details</span>
@@ -14,6 +18,12 @@
       <span class="term">Version</span>
       {{@job.version}}
     </span>
+    {{#if @job.variables}}
+    <span class="pair" data-test-job-stat="variables">
+      <span class="term">Variables</span>
+      {{@job.variables}}
+    </span>
+    {{/if}}
     {{yield to="before-namespace"}}
     {{#if (and @job.namespace this.system.shouldShowNamespaces)}}
       <span class="pair" data-test-job-stat="namespace">

--- a/ui/app/templates/components/job-page/parts/stats-box.hbs
+++ b/ui/app/templates/components/job-page/parts/stats-box.hbs
@@ -14,10 +14,10 @@
       <span class="term">Version</span>
       {{@job.version}}
     </span>
-    {{#if @job.variables}}
-    <span class="pair" data-test-job-stat="variables">
-      <LinkTo @route="variables.variable" @model={{@job.pathLinkedVariable.id}}>Secure Variable</LinkTo>
-    </span>
+    {{#if @job.pathLinkedVariable}}
+      <span class="pair" data-test-job-stat="variables">
+        <LinkTo @route="variables.variable" @model={{@job.pathLinkedVariable.id}}>Variables</LinkTo>
+      </span>
     {{/if}}
     {{yield to="before-namespace"}}
     {{#if (and @job.namespace this.system.shouldShowNamespaces)}}

--- a/ui/app/templates/components/job-page/parts/stats-box.hbs
+++ b/ui/app/templates/components/job-page/parts/stats-box.hbs
@@ -14,7 +14,7 @@
       <span class="term">Version</span>
       {{@job.version}}
     </span>
-    {{#if @job.pathLinkedVariable}}
+    {{#if (and (can "list variables") @job.pathLinkedVariable)}}
       <span class="pair" data-test-job-stat="variables">
         <LinkTo @route="variables.variable" @model={{@job.pathLinkedVariable.id}}>Variables</LinkTo>
       </span>

--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -87,7 +87,7 @@
           {{if this.model.scaling.policy "Yes" "No"}}
         </span>
       {{/if}}
-      {{#if this.model.pathLinkedVariable}}
+      {{#if (and (can "list variables") this.model.pathLinkedVariable)}}
         <span class="pair" data-test-task-group-stat="variables">
           <LinkTo @route="variables.variable" @model={{this.model.pathLinkedVariable.id}}>Variables</LinkTo>
         </span>

--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -87,6 +87,11 @@
           {{if this.model.scaling.policy "Yes" "No"}}
         </span>
       {{/if}}
+      {{#if this.model.pathLinkedVariable}}
+        <span class="pair" data-test-task-group-stat="variables">
+          <LinkTo @route="variables.variable" @model={{this.model.pathLinkedVariable.id}}>Variables</LinkTo>
+        </span>
+      {{/if}}
     </div>
   </div>
   <div class="boxed-section">

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -5,6 +5,7 @@ import {
   find,
   findAll,
   typeIn,
+  visit,
 } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
@@ -127,9 +128,21 @@ module('Acceptance | secure variables', function (hooks) {
   });
 
   test('variables prefixed with jobs/ correctly link to entities', async function (assert) {
-    assert.expect(16);
+    assert.expect(23);
     defaultScenario(server);
     const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
+
+    const variableLinkedJob = server.db.jobs[0];
+    const variableLinkedGroup = server.db.taskGroups.findBy({
+      jobId: variableLinkedJob.id,
+    });
+    const variableLinkedTask = server.db.tasks.findBy({
+      taskGroupId: variableLinkedGroup.id,
+    });
+    const variableLinkedTaskAlloc = server.db.allocations.filterBy(
+      'taskGroup',
+      variableLinkedGroup.name
+    )[1];
     window.localStorage.nomadTokenSecret = variablesToken.secretId;
 
     // Non-job variable
@@ -185,6 +198,18 @@ module('Acceptance | secure variables', function (hooks) {
       'Related Entities box is job-oriented'
     );
 
+    let relatedJobLink = find('.related-entities a');
+    await click(relatedJobLink);
+    assert
+      .dom('[data-test-job-stat="variables"]')
+      .exists('Link from Job to Variable exists');
+    let jobVariableLink = find('[data-test-job-stat="variables"] a');
+    await click(jobVariableLink);
+    assert.ok(
+      currentURL().startsWith(`/variables/var/jobs/${variableLinkedJob.id}`),
+      'correctly traverses from job to variable'
+    );
+
     // Group Variable
     await Variables.visit();
     jobsDirectoryLink = [...findAll('[data-test-folder-row]')].filter((a) =>
@@ -203,6 +228,20 @@ module('Acceptance | secure variables', function (hooks) {
         'This secure variable is accessible by group'
       ),
       'Related Entities box is group-oriented'
+    );
+
+    let relatedGroupLink = find('.related-entities a');
+    await click(relatedGroupLink);
+    assert
+      .dom('[data-test-task-group-stat="variables"]')
+      .exists('Link from Group to Variable exists');
+    let groupVariableLink = find('[data-test-task-group-stat="variables"] a');
+    await click(groupVariableLink);
+    assert.ok(
+      currentURL().startsWith(
+        `/variables/var/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}`
+      ),
+      'correctly traverses from group to variable'
     );
 
     // Task Variable
@@ -226,6 +265,30 @@ module('Acceptance | secure variables', function (hooks) {
       ),
       'Related Entities box is task-oriented'
     );
+
+    let relatedTaskLink = find('.related-entities a');
+    await click(relatedTaskLink);
+    // Gotta go the long way and click into the alloc/then task from here; but we know this one by virtue of stable test env.
+    await visit(
+      `/allocations/${variableLinkedTaskAlloc.id}/${variableLinkedTask.name}`
+    );
+    assert
+      .dom('[data-test-task-stat="variables"]')
+      .exists('Link from Task to Variable exists');
+    let taskVariableLink = find('[data-test-task-stat="variables"] a');
+    await click(taskVariableLink);
+    assert.ok(
+      currentURL().startsWith(
+        `/variables/var/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}/${variableLinkedTask.name}`
+      ),
+      'correctly traverses from task to variable'
+    );
+
+    // A non-variable-having job
+    await visit(`/jobs/${server.db.jobs[1].id}`);
+    assert
+      .dom('[data-test-task-stat="variables"]')
+      .doesNotExist('Link from Variable-less Job to Variable does not exist');
   });
 
   test('it does not allow you to save if you lack Items', async function (assert) {


### PR DESCRIPTION
Adds a relationship between a job and variables, defined by any variables that are prefixed with that job's name.

Further adds a model property of `pathLinkedVariable` for all jobs, task groups, and tasks, that look for an exact match against their (or their parent job's) variables. Displays this in the details bar:

![image](https://user-images.githubusercontent.com/713991/178579490-ccb1df46-c281-4a83-b198-218bdfae188a.png)
![image](https://user-images.githubusercontent.com/713991/178579513-98936ae5-9dc1-4de8-92f0-57333056380a.png)
![image](https://user-images.githubusercontent.com/713991/178579541-571aff01-ac12-4cdd-be10-a6823c4f40fb.png)
