### PR TITLE
secure vars: fix enterprise test by upserting the namespace

### DIFF
--- a/nomad/secure_variables_endpoint_test.go
+++ b/nomad/secure_variables_endpoint_test.go
@@ -40,8 +40,9 @@ func TestSecureVariablesEndpoint_auth(t *testing.T) {
 	alloc2.Namespace = ns
 
 	store := srv.fsm.State()
+	require.NoError(t, store.UpsertNamespaces(1000, []*structs.Namespace{{Name: ns}}))
 	require.NoError(t, store.UpsertAllocs(
-		structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1, alloc2}))
+		structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc1, alloc2}))
 
 	claims1 := alloc1.ToTaskIdentityClaims("web")
 	idToken, err := srv.encrypter.SignClaims(claims1)


### PR DESCRIPTION
In OSS we can upsert an allocation without worrying about whether that
alloc is in a namespace that actually exists, but in ENT that upsert
will add to the namespace's quotas. Ensure we're doing so in this
secure variables RPC test to fix the test breaking in the ENT repo.