### PR TITLE
Add semgrep rule to catch non-determinism in FSM

### DIFF
--- a/.semgrep/fsm_time.yml
+++ b/.semgrep/fsm_time.yml
@@ -1,0 +1,26 @@
+rules:
+  - id: "no-time-in-fsm"
+    patterns:
+      - pattern: time.Now()
+
+      # Metric state is local to the server and therefore must use time.
+      - pattern-not-inside: |
+          defer metrics.MeasureSince(..., time.Now())
+
+      # The timetable's whole point is to roughly track timestamps for Raft log
+      # indexes, so it must use time.
+      - pattern-not-inside: |
+          $N.timetable.Witness(log.Index, time.Now().UTC())
+    message: |
+      time.Now() should not be called from within the Server's FSM. Apply Raft
+      log messages to the State Store must be deterministic so that each server
+      contains exactly the same state. Since time drifts between nodes, it must
+      be set before the Raft log message is applied so that all Raft members
+      see the same timestamp.
+    languages:
+      - "go"
+    severity: "WARNING"
+    paths:
+      include:
+        - "nomad/fsm.*"
+        - "nomad/state/state_store.*"

--- a/.semgrep/fsm_time.yml
+++ b/.semgrep/fsm_time.yml
@@ -5,12 +5,12 @@ rules:
 
       # Metric state is local to the server and therefore must use time.
       - pattern-not-inside: |
-          defer metrics.MeasureSince(..., time.Now())
+          defer metrics.MeasureSince(...)
 
       # The timetable's whole point is to roughly track timestamps for Raft log
       # indexes, so it must use time.
       - pattern-not-inside: |
-          $N.timetable.Witness(log.Index, time.Now().UTC())
+          $N.timetable.Witness(...)
     message: |
       time.Now() should not be called from within the Server's FSM. Apply Raft
       log messages to the State Store must be deterministic so that each server


### PR DESCRIPTION
See `message:` in rule for details.

This catches a few uses that should be cleaned up:

```
$ semgrep scan -c .semgrep/fsm_time.yml nomad
... 

nomad/fsm.go
     semgrep.no-time-in-fsm
        time.Now() should not be called from within the Server's FSM. Apply Raft log messages to the
        State Store must be deterministic so that each server contains exactly the same state. Since
        time drifts between nodes, it must be set before the Raft log message is applied so that all
        Raft members see the same timestamp.

        568┆ Launch:    time.Now(),


  nomad/state/state_store.go
     semgrep.no-time-in-fsm
        time.Now() should not be called from within the Server's FSM. Apply Raft log messages to the
        State Store must be deterministic so that each server contains exactly the same state. Since
        time drifts between nodes, it must be set before the Raft log message is applied so that all
        Raft members see the same timestamp.

       4450┆ status.RequireProgressBy = time.Now().Add(status.ProgressDeadline)
          ⋮┆----------------------------------------
       5866┆ iter = memdb.NewFilterIterator(iter, expiredOneTimeTokenFilter(time.Now()))
          ⋮┆----------------------------------------
       6651┆ rootKeyMeta.CreateTime = time.Now()
```