### PR TITLE
keyring: upserting key metadata in FSM must be deterministic

### DIFF
--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -6679,7 +6679,6 @@ func (s *StateStore) UpsertRootKeyMeta(index uint64, rootKeyMeta *structs.RootKe
 		isRotation = !existing.Active() && rootKeyMeta.Active()
 	} else {
 		rootKeyMeta.CreateIndex = index
-		rootKeyMeta.CreateTime = time.Now()
 		isRotation = rootKeyMeta.Active()
 	}
 	rootKeyMeta.ModifyIndex = index


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/pull/13725 for the secure variables keyring. This hasn't shipped in a release of Nomad, so that's why it's in its own PR with no changelog.