### PR TITLE
secure vars: limit maximum size of variable data

### DIFF
--- a/nomad/structs/secure_variables.go
+++ b/nomad/structs/secure_variables.go
@@ -43,6 +43,11 @@ const (
 	// Args: SecureVariablesByNameRequest
 	// Reply: SecureVariablesByNameResponse
 	SecureVariablesReadRPCMethod = "SecureVariables.Read"
+
+	// maxVariableSize is the maximum size of the unencrypted contents of
+	// a variable. This size is deliberately set low and is not
+	// configurable, to discourage DoS'ing the cluster
+	maxVariableSize = 16384
 )
 
 // SecureVariableMetadata is the metadata envelope for a Secure Variable, it
@@ -81,6 +86,15 @@ type SecureVariableDecrypted struct {
 // SecureVariableItems are the actual secrets stored in a secure variable. They
 // are always encrypted and decrypted as a single unit.
 type SecureVariableItems map[string]string
+
+func (svi SecureVariableItems) Size() uint64 {
+	var out uint64
+	for k, v := range svi {
+		out += uint64(len(k))
+		out += uint64(len(v))
+	}
+	return out
+}
 
 // Equals checks both the metadata and items in a SecureVariableDecrypted
 // struct
@@ -150,6 +164,9 @@ func (sv SecureVariableData) Copy() SecureVariableData {
 func (sv SecureVariableDecrypted) Validate() error {
 	if len(sv.Items) == 0 {
 		return errors.New("empty variables are invalid")
+	}
+	if sv.Items.Size() > maxVariableSize {
+		return errors.New("variables are limited to 16KiB in total size")
 	}
 	if sv.Namespace == AllNamespacesSentinel {
 		return errors.New("can not target wildcard (\"*\")namespace")


### PR DESCRIPTION
To discourage accidentally DoS'ing the cluster with secure variables
data, we're providing a very low limit to the maximum size of a given
secure variable. This currently matches the limit for dispatch
payloads.

In future versions, we may increase this limit or make it
configurable, once we have better metrics from real-world operators.