### PR TITLE
workload identity: use parent ID for dispatch/periodic jobs

### DIFF
--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -298,7 +298,7 @@ func TestEncrypter_SignVerify(t *testing.T) {
 	testutil.WaitForLeader(t, srv.RPC)
 
 	alloc := mock.Alloc()
-	claim := alloc.ToTaskIdentityClaims("web")
+	claim := alloc.ToTaskIdentityClaims(nil, "web")
 	e := srv.encrypter
 
 	out, err := e.SignClaims(claim)

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -415,7 +415,7 @@ func (p *planner) signAllocIdentities(job *structs.Job, allocations []*structs.A
 		alloc.SignedIdentities = map[string]string{}
 		tg := job.LookupTaskGroup(alloc.TaskGroup)
 		for _, task := range tg.Tasks {
-			claims := alloc.ToTaskIdentityClaims(task.Name)
+			claims := alloc.ToTaskIdentityClaims(job, task.Name)
 			token, err := encrypter.SignClaims(claims)
 			if err != nil {
 				return err

--- a/nomad/secure_variables_endpoint.go
+++ b/nomad/secure_variables_endpoint.go
@@ -515,7 +515,7 @@ func (sv *SecureVariables) authValidatePrefix(claims *structs.IdentityClaims, ns
 	}
 
 	parts := strings.Split(pathOrPrefix, "/")
-	expect := []string{"nomad", "jobs", alloc.Job.ID, alloc.TaskGroup, claims.TaskName}
+	expect := []string{"nomad", "jobs", claims.JobID, alloc.TaskGroup, claims.TaskName}
 	if len(parts) > len(expect) {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10312,9 +10312,9 @@ func (a *Allocation) Reconnected() (bool, bool) {
 	return true, a.Expired(lastReconnect)
 }
 
-func (a *Allocation) ToIdentityClaims() *IdentityClaims {
+func (a *Allocation) ToIdentityClaims(job *Job) *IdentityClaims {
 	now := jwt.NewNumericDate(time.Now().UTC())
-	return &IdentityClaims{
+	claims := &IdentityClaims{
 		Namespace:    a.Namespace,
 		JobID:        a.JobID,
 		AllocationID: a.ID,
@@ -10327,10 +10327,14 @@ func (a *Allocation) ToIdentityClaims() *IdentityClaims {
 			IssuedAt:  now,
 		},
 	}
+	if job != nil && job.ParentID != "" {
+		claims.JobID = job.ParentID
+	}
+	return claims
 }
 
-func (a *Allocation) ToTaskIdentityClaims(taskName string) *IdentityClaims {
-	claims := a.ToIdentityClaims()
+func (a *Allocation) ToTaskIdentityClaims(job *Job, taskName string) *IdentityClaims {
+	claims := a.ToIdentityClaims(job)
 	if claims != nil {
 		claims.TaskName = taskName
 	}


### PR DESCRIPTION
Workload identities grant implicit access to policies, and operators
will not want to craft separate policies for each invocation of a
periodic or dispatch job. Use the parent job's ID as the JobID claim.

Tagging @philrenaud just as an FYI, as he noticed this problem.