### PR TITLE
tests: add a space between node name and timestamp

### DIFF
--- a/helper/testlog/testlog.go
+++ b/helper/testlog/testlog.go
@@ -74,7 +74,7 @@ func HCLoggerTestLevel() hclog.Level {
 func HCLoggerNode(t LogPrinter, node int32) (hclog.InterceptLogger, io.Writer) {
 	var output io.Writer = os.Stderr
 	if node > -1 {
-		output = NewPrefixWriter(t, fmt.Sprintf("node-%03d", node))
+		output = NewPrefixWriter(t, fmt.Sprintf("node-%03d ", node))
 	}
 	opts := &hclog.LoggerOptions{
 		Level:           HCLoggerTestLevel(),


### PR DESCRIPTION
A minor improvement to make server logs in testing outputs more readable, which I ran into while debugging https://github.com/hashicorp/nomad/pull/13749

Before:
> node-2832022-07-13T12:57:04.242Z [INFO]  raft@v1.3.5/raft.go:369: nomad.raft: entering leader state: leader="Node at 127.0.0.1:9268 [Leader]"

After:
> node-283 2022-07-13T12:57:04.242Z [INFO]  raft@v1.3.5/raft.go:369: nomad.raft: entering leader state: leader="Node at 127.0.0.1:9268 [Leader]"

