### PR TITLE
ui:  fix placement of filter in `SecureVariablesForm`

### DIFF
--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -1,7 +1,7 @@
 {{did-update this.onViewChange @view}}
 {{did-insert this.establishKeyValues}}
 <form class="new-secure-variables" autocomplete="off" {{on "submit" this.save}}>
-  <div class="path-namespace">
+  <div class={{if this.namespaceOptions "path-namespace"}}>
     <label>
       <span>
         Path

--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -7,7 +7,7 @@
         Path
       </span>
       {{#if @model.isNew}}
-      <div class="related-entities related-entities-hint">
+      <div class="related-entities-hint">
         <p>Prefix your path with <code>jobs/</code> to automatically make your secure variable accessible to a specified job, task group, or task.<br />
         Format: <code>jobs/&lt;jobname&gt;</code>, <code>jobs/&lt;jobname&gt;/&lt;groupname&gt;</code>, <code>jobs/&lt;jobname&gt;/&lt;groupname&gt;/&lt;taskname&gt;</code></p>
       </div>

--- a/ui/app/styles/components/secure-variables.scss
+++ b/ui/app/styles/components/secure-variables.scss
@@ -27,6 +27,8 @@
   }
 
   .path-input {
+    height: 2.25em;
+
     &:disabled {
       background-color: #f5f5f5;
     }
@@ -45,6 +47,7 @@
     display: grid;
     grid-template-columns: 6fr 1fr;
     gap: 0 1rem;
+    align-items: end;
   }
 
   .key-value {


### PR DESCRIPTION
This PR resolves an issue where the namespace filter:

1. Always rendered a 2 column grid, regardless of where the filter is rendered.
2. Placement of the namespace filter when the form is in create mode.

Side Effect:  remove unused `related-entities` CSS property. There is no `.related-entities` property that is a standalone CSS class. Maybe it was confused with `.notification.related-entities`?