### PR TITLE
packaging: restart nomad service after package update

### DIFF
--- a/.release/linux/postrm
+++ b/.release/linux/postrm
@@ -4,4 +4,9 @@ if [ "$1" = "purge" ]; then
   userdel nomad
 fi
 
+if [ "$1" == "upgrade" ] && [ -d /run/systemd/system ]; then
+  systemctl --system daemon-reload >/dev/null || true
+  systemctl restart nomad >/dev/null || true
+fi
+
 exit 0


### PR DESCRIPTION
Fixes #13739

This restarts the nomad systemd unit after the nomad package is updated

Documentation on how the postrm/upgrade event is handled can be found [here](https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html#details-of-unpack-phase-of-installation-or-upgrade)