### PR TITLE
search: use secure vars ACL policy for secure vars context

### DIFF
--- a/acl/acl.go
+++ b/acl/acl.go
@@ -370,7 +370,27 @@ func (a *ACL) AllowSecureVariableOperation(ns, path, op string) bool {
 	}
 
 	return capabilities.Check(op)
+}
 
+// AllowSecureVariableSearch is a very loose check that the token has
+// *any* access to a secure variables path for the namespace, with an
+// expectation that the actual search result will be filtered by
+// specific paths
+func (a *ACL) AllowSecureVariableSearch(ns string) bool {
+	if a.management {
+		return true
+	}
+	iter := a.secureVariables.Root().Iterator()
+	iter.SeekPrefix([]byte(ns))
+	_, _, ok := iter.Next()
+	if ok {
+		return true
+	}
+
+	iter = a.wildcardSecureVariables.Root().Iterator()
+	iter.SeekPrefix([]byte(ns))
+	_, _, ok = iter.Next()
+	return ok
 }
 
 // matchingNamespaceCapabilitySet looks for a capabilitySet that matches the namespace,

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -600,6 +600,19 @@ func TestSecureVariablesMatching(t *testing.T) {
 			require.Equal(t, tc.allow, acl.AllowSecureVariableOperation(tc.ns, tc.path, tc.op))
 		})
 	}
+
+	t.Run("search over namespace", func(t *testing.T) {
+		policy, err := Parse(`namespace "ns" {
+					secure_variables { path "foo/bar" { capabilities = ["read"] }}}`)
+		require.NoError(t, err)
+		require.NotNil(t, policy.Namespaces[0].SecureVariables)
+
+		acl, err := NewACL(false, []*Policy{policy})
+		require.NoError(t, err)
+		require.True(t, acl.AllowSecureVariableSearch("ns"))
+		require.False(t, acl.AllowSecureVariableSearch("no-access"))
+	})
+
 }
 
 func TestACL_matchingCapabilitySet_returnsAllMatches(t *testing.T) {

--- a/nomad/search_endpoint.go
+++ b/nomad/search_endpoint.go
@@ -552,10 +552,10 @@ func (s *Search) PrefixSearch(args *structs.SearchRequest, reply *structs.Search
 	if err != nil {
 		return err
 	}
-
 	namespace := args.RequestNamespace()
 
-	// Require either node:read or namespace:read-job
+	// Require read permissions for the context, ex. node:read or
+	// namespace:read-job
 	if !sufficientSearchPerms(aclObj, namespace, args.Context) {
 		return structs.ErrPermissionDenied
 	}
@@ -643,8 +643,7 @@ func sufficientSearchPerms(aclObj *acl.ACL, namespace string, context structs.Co
 			acl.NamespaceCapabilityListJobs,
 			acl.NamespaceCapabilityReadJob)(aclObj, namespace)
 	case structs.SecureVariables:
-		// FIXME: Replace with real variables capability
-		return aclObj.AllowNsOp(namespace, acl.NamespaceCapabilityReadJob)
+		return aclObj.AllowSecureVariableSearch(namespace)
 	}
 
 	return true


### PR DESCRIPTION
The search RPC used a placeholder policy for searching within the secure
variables context. Now that we have ACL policies built for secure variables, we
can use them for search. Requires a new loose policy for checking if a token has
any secure variables access within a namespace, so that we can filter on
specific paths in the iterator.