### PR TITLE
core: add expired token garbage collection periodic jobs.

### DIFF
--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -24,6 +24,22 @@ const (
 	// Args: ACLTokenUpsertRequest
 	// Reply: ACLTokenUpsertResponse
 	ACLUpsertTokensRPCMethod = "ACL.UpsertTokens"
+
+	// ACLDeleteTokensRPCMethod is the RPC method for batch deleting ACL
+	// tokens.
+	//
+	// Args: ACLTokenDeleteRequest
+	// Reply: GenericResponse
+	ACLDeleteTokensRPCMethod = "ACL.DeleteTokens"
+)
+
+const (
+	// ACLMaxExpiredBatchSize is the maximum number of expired ACL tokens that
+	// will be garbage collected in a single trigger. This number helps limit
+	// the replication pressure due to expired token deletion. If there are a
+	// large number of expired tokens pending garbage collection, this value is
+	// a potential limiting factor.
+	ACLMaxExpiredBatchSize = 4096
 )
 
 // Canonicalize performs basic canonicalization on the ACL token object. It is

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10741,6 +10741,16 @@ const (
 	// tokens. We periodically scan for expired tokens and delete them.
 	CoreJobOneTimeTokenGC = "one-time-token-gc"
 
+	// CoreJobLocalTokenExpiredGC is used for the garbage collection of
+	// expired local ACL tokens. We periodically scan for expired tokens and
+	// delete them.
+	CoreJobLocalTokenExpiredGC = "local-token-expired-gc"
+
+	// CoreJobGlobalTokenExpiredGC is used for the garbage collection of
+	// expired global ACL tokens. We periodically scan for expired tokens and
+	// delete them.
+	CoreJobGlobalTokenExpiredGC = "global-token-expired-gc"
+
 	// CoreJobForceGC is used to force garbage collection of all GCable objects.
 	CoreJobForceGC = "force-gc"
 )


### PR DESCRIPTION
Two new periodic core jobs have been added which handle removing
expired local and global tokens from state. The local core job is
run on every leader; the global core job is only run on the leader
within the authoritative region.

related: https://github.com/hashicorp/nomad/issues/13120
targets: feature branch