### PR TITLE
Introduces the post publish website event

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -225,3 +225,17 @@ event "promote-production-packaging" {
     on = "always"
   }
 }
+
+event "post-publish-website" {
+  depends = ["promote-production-packaging"]
+
+  action "post-publish-website" {
+    organization = "hashicorp"
+    repository   = "crt-workflows-common"
+    workflow     = "post-publish-website"
+  }
+
+  notification {
+    on = "always"
+  }
+}


### PR DESCRIPTION
This PR introduces a new CRT workflow event in the ci.hcl file, `post-publish-website` and this event handles the dispatching of an API call (HTTP POST) to the mktg-dev endpoint. This is responsible for automating the triggering of marketing-dev's versioned docs pipeline to release versioned docs for product repos. 

This only gets triggered as a post-publish event after you release your artifacts to production. The workflow should wait for the docs to be published and report passed/failed status.

This should not be merged into ENT repos as the versioned docs only live in OSS repos. (if you have an automated OSS-->ENT merge set up, please let me know to follow up with a PR to remove this event out of the ENT repo)  

I will merge this PR in next Monday (07/25) (unless there's any objections)-- this is a new event set up so feel free to reach out in #team-rel-eng if you notice your product's documentation does not get released on the website after releasing. 

Thanks!