### PR TITLE
allow configuring hairpinning on default nomad bridge

### DIFF
--- a/client/allocrunner/network_manager_linux.go
+++ b/client/allocrunner/network_manager_linux.go
@@ -173,7 +173,7 @@ func newNetworkConfigurator(log hclog.Logger, alloc *structs.Allocation, config 
 
 	switch {
 	case netMode == "bridge":
-		c, err := newBridgeNetworkConfigurator(log, config.BridgeNetworkName, config.BridgeNetworkAllocSubnet, config.CNIPath, ignorePortMappingHostIP)
+		c, err := newBridgeNetworkConfigurator(log, config.BridgeNetworkName, config.BridgeNetworkAllocSubnet, config.CNIPath, ignorePortMappingHostIP, config.BridgeNetworkHairpin)
 		if err != nil {
 			return nil, err
 		}

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -255,6 +255,10 @@ type Config struct {
 	// networking mode. This defaults to 'nomad' if not set
 	BridgeNetworkName string
 
+	// BridgeNetworkHairpin sets wether the bridge allows hairpining, that is allow clients
+	// to connect to their own IP. This defaults to false if not set
+	BridgeNetworkHairpin bool
+
 	// BridgeNetworkAllocSubnet is the IP subnet to use for address allocation
 	// for allocations in bridge networking mode. Subnet must be in CIDR
 	// notation

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -712,6 +712,7 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	conf.CNIPath = agentConfig.Client.CNIPath
 	conf.CNIConfigDir = agentConfig.Client.CNIConfigDir
 	conf.BridgeNetworkName = agentConfig.Client.BridgeNetworkName
+	conf.BridgeNetworkHairpin = agentConfig.Client.BridgeNetworkHairpin
 	conf.BridgeNetworkAllocSubnet = agentConfig.Client.BridgeNetworkSubnet
 
 	for _, hn := range agentConfig.Client.HostNetworks {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -300,6 +300,9 @@ type ClientConfig struct {
 	// bridge network mode
 	BridgeNetworkName string `hcl:"bridge_network_name"`
 
+	// BridgeNetworkHairpin sets wether to allow hairpinning on the bridge
+	BridgeNetworkHairpin bool `hcl:"bridge_network_hairpin"`
+
 	// BridgeNetworkSubnet is the subnet to allocate IP addresses from when
 	// creating allocations with bridge networking mode. This range is local to
 	// the host
@@ -988,6 +991,7 @@ func DevConfig(mode *devModeConfig) *Config {
 		DisableSandbox:   false,
 	}
 	conf.Client.BindWildcardDefaultHostNetwork = true
+	conf.Client.BridgeNetworkHairpin = false
 	conf.Client.NomadServiceDiscovery = helper.BoolToPtr(true)
 	conf.Telemetry.PrometheusMetrics = true
 	conf.Telemetry.PublishAllocationMetrics = true
@@ -1038,6 +1042,7 @@ func DefaultConfig() *Config {
 				DisableSandbox:   false,
 			},
 			BindWildcardDefaultHostNetwork: true,
+			BridgeNetworkHairpin:           false,
 			CNIPath:                        "/opt/cni/bin",
 			CNIConfigDir:                   "/opt/cni/config",
 			NomadServiceDiscovery:          helper.BoolToPtr(true),
@@ -1840,6 +1845,9 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	}
 	if b.BridgeNetworkName != "" {
 		result.BridgeNetworkName = b.BridgeNetworkName
+	}
+	if b.BridgeNetworkHairpin {
+		result.BridgeNetworkHairpin = true
 	}
 	if b.BridgeNetworkSubnet != "" {
 		result.BridgeNetworkSubnet = b.BridgeNetworkSubnet

--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -142,6 +142,9 @@ client {
 - `bridge_network_subnet` `(string: "172.26.64.0/20")` - Specifies the subnet
   which the client will use to allocate IP addresses from.
 
+- `bridge_network_hairpin` `(bool: false)` - Specifies wether the bridge should
+  allow hairpinning.
+
 - `artifact` <code>([Artifact](#artifact-parameters): varied)</code> -
   Specifies controls on the behavior of task
   [`artifact`](/docs/job-specification/artifact) stanzas.


### PR DESCRIPTION
[Hairpinning](https://en.wikipedia.org/wiki/Network_address_translation#NAT_hairpinning) is required by a lot of clustering applications (eg. Grafana Loki).
These applications connect to all members of their cluster, including themselves.
Currently they cannot connect to themselves as hairpin-mode is not enabled on the default nomad bridge.

As suggested in https://github.com/hashicorp/nomad/issues/13352 I've added a configuration option that allows a user to enable hairpinning on the default nomad cni bridge.