### PR TITLE
docs: job-specification: Explain that priority has no effect on run order

### DIFF
--- a/website/content/docs/job-specification/job.mdx
+++ b/website/content/docs/job-specification/job.mdx
@@ -105,6 +105,8 @@ job "docs" {
 - `priority` `(int: 50)` - Specifies the job priority which is used to
   prioritize scheduling and access to resources. Must be between 1 and 100
   inclusively, with a larger value corresponding to a higher priority.
+  Priority currently only has an effect when job preemption is enabled.
+  It does not have an effect on which of multiple pending jobs is run first.
 
 - `region` `(string: "global")` - The region in which to execute the job.
 


### PR DESCRIPTION
PRing as suggested in https://github.com/hashicorp/nomad/issues/9845#issuecomment-1187324137 (CC @tgross).

Makes the issues from #9845 and #12792 less surprising to the user.

I think it would make Nomad much better to start batch jobs in prority order (see #12792), but at least this documents that it currently doesn't.