### PR TITLE
servicedisco: fix a bug where service registrations would be lost

### DIFF
--- a/.changelog/13838.txt
+++ b/.changelog/13838.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+servicedisco: Fixed a bug where service registrations of same name would be lost
+```

--- a/client/allocrunner/taskrunner/script_check_hook.go
+++ b/client/allocrunner/taskrunner/script_check_hook.go
@@ -90,7 +90,7 @@ func (h *scriptCheckHook) Prestart(ctx context.Context, req *interfaces.TaskPres
 	return nil
 }
 
-// PostStart implements interfaces.TaskPoststartHook. It creates new
+// Poststart implements interfaces.TaskPoststartHook. It creates new
 // script checks with the current task context (driver and env), and
 // starts up the scripts.
 func (h *scriptCheckHook) Poststart(ctx context.Context, req *interfaces.TaskPoststartRequest, _ *interfaces.TaskPoststartResponse) error {
@@ -107,7 +107,7 @@ func (h *scriptCheckHook) Poststart(ctx context.Context, req *interfaces.TaskPos
 	return h.upsertChecks()
 }
 
-// Updated implements interfaces.TaskUpdateHook. It creates new
+// Update implements interfaces.TaskUpdateHook. It creates new
 // script checks with the current task context (driver and env and possibly
 // new structs.Task), and starts up the scripts.
 func (h *scriptCheckHook) Update(ctx context.Context, req *interfaces.TaskUpdateRequest, _ *interfaces.TaskUpdateResponse) error {
@@ -182,8 +182,8 @@ func (h *scriptCheckHook) newScriptChecks() map[string]*scriptCheck {
 			if check.Type != structs.ServiceCheckScript {
 				continue
 			}
-			serviceID := serviceregistration.MakeAllocServiceID(
-				h.alloc.ID, h.task.Name, service)
+			label := h.task.Name
+			serviceID := serviceregistration.MakeAllocServiceID(h.alloc.ID, label, service)
 			sc := newScriptCheck(&scriptCheckConfig{
 				consulNamespace: h.consulNamespace,
 				allocID:         h.alloc.ID,
@@ -221,13 +221,13 @@ func (h *scriptCheckHook) newScriptChecks() map[string]*scriptCheck {
 			if !h.associated(h.task.Name, service.TaskName, check.TaskName) {
 				continue
 			}
-			groupTaskName := "group-" + tg.Name
+			label := "group-" + tg.Name
 			serviceID := serviceregistration.MakeAllocServiceID(
-				h.alloc.ID, groupTaskName, service)
+				h.alloc.ID, label, service)
 			sc := newScriptCheck(&scriptCheckConfig{
 				consulNamespace: h.consulNamespace,
 				allocID:         h.alloc.ID,
-				taskName:        groupTaskName,
+				taskName:        label,
 				check:           check,
 				serviceID:       serviceID,
 				ttlUpdater:      h.consul,

--- a/client/serviceregistration/id.go
+++ b/client/serviceregistration/id.go
@@ -1,7 +1,9 @@
 package serviceregistration
 
 import (
+	"crypto/md5"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -12,16 +14,37 @@ const (
 	nomadServicePrefix = "_nomad"
 
 	// nomadTaskPrefix is the prefix that scopes Nomad registered services
-	// for tasks.
-	nomadTaskPrefix = nomadServicePrefix + "-task-"
+	// for tasks (must match service_client.go for consul sync).
+	nomadTaskPrefix = nomadServicePrefix + "-task"
 )
 
 // MakeAllocServiceID creates a unique ID for identifying an alloc service in
 // a service registration provider. Both Nomad and Consul solutions use the
 // same ID format to provide consistency.
 //
-// Example Service ID: _nomad-task-b4e61df9-b095-d64e-f241-23860da1375f-redis-http-http
-func MakeAllocServiceID(allocID, taskName string, service *structs.Service) string {
-	return fmt.Sprintf("%s%s-%s-%s-%s",
-		nomadTaskPrefix, allocID, taskName, service.Name, service.PortLabel)
+// Format: _nomad-task-allocID-<task|`group`>-service<-port_label><-tags_hash>
+//
+// Example ID: _nomad-group-7f3eb69d-3a84-a0e7-2681-5f962ef522b0-database-db-tcp-f97c5d
+func MakeAllocServiceID(allocID, name string, service *structs.Service) string {
+	if name == "" {
+		if name = service.TaskName; name == "" {
+			name = "group"
+		}
+	}
+
+	parts := []string{nomadTaskPrefix, allocID, name, service.Name}
+	if service.PortLabel != "" {
+		parts = append(parts, service.PortLabel)
+	}
+
+	if len(service.Tags) > 0 {
+		h := md5.New()
+		for _, tag := range service.Tags {
+			h.Write([]byte(tag))
+		}
+		short := fmt.Sprintf("%x", h.Sum(nil))[0:6]
+		parts = append(parts, short)
+	}
+
+	return strings.Join(parts, "-")
 }

--- a/client/serviceregistration/id_test.go
+++ b/client/serviceregistration/id_test.go
@@ -4,33 +4,72 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/stretchr/testify/require"
+	"github.com/shoenig/test/must"
 )
 
 func Test_MakeAllocServiceID(t *testing.T) {
 	testCases := []struct {
-		inputAllocID   string
-		inputTaskName  string
-		inputService   *structs.Service
-		expectedOutput string
-		name           string
+		name    string
+		allocID string
+		label   string
+		service *structs.Service
+		exp     string
 	}{
 		{
-			inputAllocID:  "7ac7c672-1824-6f06-644c-4c249e1578b9",
-			inputTaskName: "cache",
-			inputService: &structs.Service{
+			name:    "no label - no port - no tags",
+			allocID: "7ac7c672-1824-6f06-644c-4c249e1578b9",
+			service: &structs.Service{
+				Name: "redis",
+			},
+			exp: "_nomad-task-7ac7c672-1824-6f06-644c-4c249e1578b9-group-redis",
+		},
+		{
+			name:    "with label - no port - no tags",
+			allocID: "7ac7c672-1824-6f06-644c-4c249e1578b9",
+			label:   "cache",
+			service: &structs.Service{
+				Name: "redis",
+			},
+			exp: "_nomad-task-7ac7c672-1824-6f06-644c-4c249e1578b9-cache-redis",
+		},
+		{
+			name:    "with label - with port - no tags",
+			allocID: "7ac7c672-1824-6f06-644c-4c249e1578b9",
+			label:   "cache",
+			service: &structs.Service{
 				Name:      "redis",
 				PortLabel: "db",
 			},
-			expectedOutput: "_nomad-task-7ac7c672-1824-6f06-644c-4c249e1578b9-cache-redis-db",
-			name:           "generic 1",
+			exp: "_nomad-task-7ac7c672-1824-6f06-644c-4c249e1578b9-cache-redis-db",
+		},
+		{
+			name:    "with label - with port - one tag",
+			allocID: "7ac7c672-1824-6f06-644c-4c249e1578b9",
+			label:   "cache",
+			service: &structs.Service{
+				Name:      "redis",
+				PortLabel: "db",
+				Tags:      []string{"one"},
+			},
+			exp: "_nomad-task-7ac7c672-1824-6f06-644c-4c249e1578b9-cache-redis-db-f97c5d",
+		},
+		{
+			name:    "with label - with port - two tags",
+			allocID: "7ac7c672-1824-6f06-644c-4c249e1578b9",
+			label:   "cache",
+			service: &structs.Service{
+				Name:      "redis",
+				PortLabel: "db",
+				Tags:      []string{"one", "two"},
+			},
+			exp: "_nomad-task-7ac7c672-1824-6f06-644c-4c249e1578b9-cache-redis-db-5b9164",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualOutput := MakeAllocServiceID(tc.inputAllocID, tc.inputTaskName, tc.inputService)
-			require.Equal(t, tc.expectedOutput, actualOutput)
+			actualOutput := MakeAllocServiceID(tc.allocID, tc.label, tc.service)
+			must.Eq(t, tc.exp, actualOutput)
 		})
 	}
 }

--- a/client/serviceregistration/wrapper/wrapper.go
+++ b/client/serviceregistration/wrapper/wrapper.go
@@ -43,7 +43,6 @@ func NewHandlerWrapper(
 // workload unless the provider is unknown, in which case an error will be
 // returned.
 func (h *HandlerWrapper) RegisterWorkload(workload *serviceregistration.WorkloadServices) error {
-
 	// Don't rely on callers to check there are no services to register.
 	if len(workload.Services) == 0 {
 		return nil

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -1172,9 +1172,9 @@ func (c *ServiceClient) UpdateWorkload(old, newWorkload *serviceregistration.Wor
 	// Loop over existing Services to see if they have been removed
 	for _, existingSvc := range old.Services {
 		existingID := serviceregistration.MakeAllocServiceID(old.AllocID, old.Name(), existingSvc)
-		newSvc, ok := newIDs[existingID]
+		newSvc, exists := newIDs[existingID]
 
-		if !ok {
+		if !exists {
 			// Existing service entry removed
 			ops.deregServices = append(ops.deregServices, existingID)
 			for _, check := range existingSvc.Checks {

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -4,8 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	memdb "github.com/hashicorp/go-memdb"
-
+	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 


### PR DESCRIPTION
This PR fixes a bug where service registrations can be lost when registering
services of the same name into the same group (but with different tags). The
implementation of `MakeAllocServiceID` does not take tags into account when
creating what should be unique IDs for such services. This helper is used for
both Nomad and Consul service registrations.

For example,
    
```hcl
group "group" {
    service {
      name     = "db"
      tags     = ["one"]
      provider = "nomad"
    }

    service {
      name     = "db"
      tags     = ["two"]
      provider = "nomad"
    }
}
```
    
In this case only one service would remain registered - as the second one in
the list would upsert and thus overwrite the first, because they share the
same ID generated by that helper function.

The fix is to take `Tags` into account in the helper function.