### PR TITLE
fix(#13844): canonicalize job to avoid nil pointer deference

### DIFF
--- a/.changelog/13845.txt
+++ b/.changelog/13845.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fixed a nil pointer dereference when periodic jobs are missing their periodic spec
+```

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -822,7 +822,7 @@ func (p *PeriodicConfig) Canonicalize() {
 // returned. The `time.Location` of the returned value matches that of the
 // passed time.
 func (p *PeriodicConfig) Next(fromTime time.Time) (time.Time, error) {
-	if *p.SpecType == PeriodicSpecCron {
+	if p != nil && *p.SpecType == PeriodicSpecCron {
 		e, err := cronexpr.Parse(*p.Spec)
 		if err != nil {
 			return time.Time{}, fmt.Errorf("failed parsing cron expression %q: %v", *p.Spec, err)

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -349,6 +349,9 @@ func (c *JobRunCommand) Run(args []string) int {
 
 	evalID := resp.EvalID
 
+	// #13844: canonicalize the job in case it was a partial API definition
+	job.Canonicalize()
+
 	// Check if we should enter monitor mode
 	if detach || periodic || paramjob || multiregion {
 		c.Ui.Output("Job registration successful")

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -349,9 +349,6 @@ func (c *JobRunCommand) Run(args []string) int {
 
 	evalID := resp.EvalID
 
-	// #13844: canonicalize the job in case it was a partial API definition
-	job.Canonicalize()
-
 	// Check if we should enter monitor mode
 	if detach || periodic || paramjob || multiregion {
 		c.Ui.Output("Job registration successful")


### PR DESCRIPTION
I am new to this codebase, so unsure I have the best approach, but this fixes my issue in #13844. I traced the issue down to the nil pointer [here](https://github.com/hashicorp/nomad/blob/208b68221184fe5712272c13f4f307373fb9117e/api/jobs.go#L792), which is called [from this path](https://github.com/hashicorp/nomad/blob/208b68221184fe5712272c13f4f307373fb9117e/command/job_run.go#L349-L355).

This code is called after the job registration succeeds on the server. I believe the root of the issue is that when submitting an API job via the CLI, it is canonicalized server-side, but not client-side. Registration succeeds on the server, and then this code path is called. It references paths that have not been canonicalized with their default values, and fails.

Another option would be to canonicalize the job before registration (maybe in the `JobGetter` when loading the job?), but being new to the codebase, I am wary of the unintended change in behavior that might create for endusers.