### PR TITLE
acl: enable configuration and visualisation of token expiration for users 

### DIFF
--- a/api/acl.go
+++ b/api/acl.go
@@ -221,24 +221,40 @@ type ACLPolicy struct {
 
 // ACLToken represents a client token which is used to Authenticate
 type ACLToken struct {
-	AccessorID  string
-	SecretID    string
-	Name        string
-	Type        string
-	Policies    []string
-	Global      bool
-	CreateTime  time.Time
+	AccessorID string
+	SecretID   string
+	Name       string
+	Type       string
+	Policies   []string
+	Global     bool
+	CreateTime time.Time
+
+	// ExpirationTime represents the point after which a token should be
+	// considered revoked and is eligible for destruction. The zero value
+	ExpirationTime *time.Time `json:",omitempty"`
+
+	// ExpirationTTL is a convenience field for helping set ExpirationTime to a
+	// value of CreateTime+ExpirationTTL. This can only be set during token
+	// creation. This is a string version of a time.Duration like "2m".
+	ExpirationTTL time.Duration `json:",omitempty"`
+
 	CreateIndex uint64
 	ModifyIndex uint64
 }
 
 type ACLTokenListStub struct {
-	AccessorID  string
-	Name        string
-	Type        string
-	Policies    []string
-	Global      bool
-	CreateTime  time.Time
+	AccessorID string
+	Name       string
+	Type       string
+	Policies   []string
+	Global     bool
+	CreateTime time.Time
+
+	// ExpirationTime represents the point after which a token should be
+	// considered revoked and is eligible for destruction. A nil value
+	// indicates no expiration has been set on the token.
+	ExpirationTime *time.Time `json:"expiration_time,omitempty"`
+
 	CreateIndex uint64
 	ModifyIndex uint64
 }

--- a/command/acl_bootstrap.go
+++ b/command/acl_bootstrap.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/posener/complete"
@@ -163,8 +164,16 @@ func formatKVACLToken(token *api.ACLToken) string {
 	// Add the generic output
 	output = append(output,
 		fmt.Sprintf("Create Time|%v", token.CreateTime),
+		fmt.Sprintf("Expiry Time |%s", expiryTimeString(token.ExpirationTime)),
 		fmt.Sprintf("Create Index|%d", token.CreateIndex),
 		fmt.Sprintf("Modify Index|%d", token.ModifyIndex),
 	)
 	return formatKV(output)
+}
+
+func expiryTimeString(t *time.Time) string {
+	if t == nil || t.IsZero() {
+		return "never"
+	}
+	return t.String()
 }

--- a/command/acl_bootstrap_test.go
+++ b/command/acl_bootstrap_test.go
@@ -36,6 +36,7 @@ func TestACLBootstrapCommand(t *testing.T) {
 
 	out := ui.OutputWriter.String()
 	assert.Contains(out, "Secret ID")
+	require.Contains(t, out, "Expiry Time  = never")
 }
 
 // If a bootstrap token has already been created, attempts to create more should
@@ -116,6 +117,7 @@ func TestACLBootstrapCommand_WithOperatorFileBootstrapToken(t *testing.T) {
 
 	out := ui.OutputWriter.String()
 	assert.Contains(t, out, mockToken.SecretID)
+	require.Contains(t, out, "Expiry Time  = never")
 }
 
 // Attempting to bootstrap the server with an invalid operator provided token in a file should

--- a/command/acl_token_list.go
+++ b/command/acl_token_list.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/posener/complete"
@@ -108,9 +109,17 @@ func formatTokens(tokens []*api.ACLTokenListStub) string {
 	}
 
 	output := make([]string, 0, len(tokens)+1)
-	output = append(output, "Name|Type|Global|Accessor ID")
+	output = append(output, "Name|Type|Global|Accessor ID|Expired")
 	for _, p := range tokens {
-		output = append(output, fmt.Sprintf("%s|%s|%t|%s", p.Name, p.Type, p.Global, p.AccessorID))
+		expired := false
+		if p.ExpirationTime != nil && !p.ExpirationTime.IsZero() {
+			if p.ExpirationTime.Before(time.Now().UTC()) {
+				expired = true
+			}
+		}
+
+		output = append(output, fmt.Sprintf(
+			"%s|%s|%t|%s|%v", p.Name, p.Type, p.Global, p.AccessorID, expired))
 	}
 
 	return formatList(output)


### PR DESCRIPTION
related: https://github.com/hashicorp/nomad/issues/13120
targets: feature branch