### PR TITLE
keyring: use nanos for `CreateTime` in key metadata

### DIFF
--- a/api/keyring.go
+++ b/api/keyring.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 	"net/url"
-	"time"
 )
 
 // Keyring is used to access the Secure Variables keyring
@@ -35,7 +34,7 @@ type RootKey struct {
 type RootKeyMeta struct {
 	KeyID       string // UUID
 	Algorithm   EncryptionAlgorithm
-	CreateTime  time.Time
+	CreateTime  int64
 	CreateIndex uint64
 	ModifyIndex uint64
 	State       RootKeyState

--- a/command/operator_secure_variables_keyring.go
+++ b/command/operator_secure_variables_keyring.go
@@ -80,7 +80,7 @@ func renderSecureVariablesKeysResponse(keys []*api.RootKeyMeta, verbose bool) st
 	i := 1
 	for _, k := range keys {
 		out[i] = fmt.Sprintf("%s|%v|%s",
-			k.KeyID[:length], k.State, formatTime(k.CreateTime))
+			k.KeyID[:length], k.State, formatUnixNanoTime(k.CreateTime))
 		i = i + 1
 	}
 	return formatList(out)

--- a/nomad/keyring_endpoint_test.go
+++ b/nomad/keyring_endpoint_test.go
@@ -78,7 +78,7 @@ func TestKeyringEndpoint_CRUD(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	updateReq.RootKey.Meta.CreateTime = time.Now()
+	updateReq.RootKey.Meta.CreateTime = time.Now().UTC().UnixNano()
 	err = msgpackrpc.CallWithCodec(codec, "Keyring.Update", updateReq, &updateResp)
 	require.NoError(t, err)
 	require.NotEqual(t, uint64(0), updateResp.Index)

--- a/nomad/structs/secure_variables.go
+++ b/nomad/structs/secure_variables.go
@@ -296,7 +296,7 @@ func NewRootKey(algorithm EncryptionAlgorithm) (*RootKey, error) {
 type RootKeyMeta struct {
 	KeyID       string // UUID
 	Algorithm   EncryptionAlgorithm
-	CreateTime  time.Time
+	CreateTime  int64
 	CreateIndex uint64
 	ModifyIndex uint64
 	State       RootKeyState
@@ -314,11 +314,12 @@ const (
 
 // NewRootKeyMeta returns a new RootKeyMeta with default values
 func NewRootKeyMeta() *RootKeyMeta {
+	now := time.Now().UTC().UnixNano()
 	return &RootKeyMeta{
 		KeyID:      uuid.Generate(),
 		Algorithm:  EncryptionAlgorithmAES256GCM,
 		State:      RootKeyStateInactive,
-		CreateTime: time.Now(),
+		CreateTime: now,
 	}
 }
 
@@ -329,7 +330,7 @@ func NewRootKeyMeta() *RootKeyMeta {
 type RootKeyMetaStub struct {
 	KeyID      string
 	Algorithm  EncryptionAlgorithm
-	CreateTime time.Time
+	CreateTime int64
 	State      RootKeyState
 }
 


### PR DESCRIPTION
Most of our objects use int64 timestamps derived from `UnixNano()` instead of
`time.Time` objects. Switch the keyring metadata to use `UnixNano()` for
consistency across the API.