### PR TITLE
[CI-only] Use pattern matching for release_branches

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -13,10 +13,7 @@ project "nomad" {
 
     release_branches = [
       "main",
-      "release/1.0.x",
-      "release/1.1.x",
-      "release/1.2.x",
-      "release/1.3.x",
+      "release/**",
     ]
   }
 }


### PR DESCRIPTION
### Description
Pattern matching was [recently added](https://github.com/hashicorp/crt-orchestrator/pull/51) so that teams no longer have to explicitly list every branch that should trigger the CRT pipeline. This simplifies release preparation- anytime a new release branch is created, it will produce releasable artifacts and exercise the full pipeline.

### Testing & Reproduction steps
This has been tested in multiple projects since being rolled out. There are no nomad-specific tests that need to be done.

### Links
PR where this functionality was added: https://github.com/hashicorp/crt-orchestrator/pull/51

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [X] not a security concern