### PR TITLE
Change path-linked-variables to start with nomad/jobs/, instead of jobs/

### DIFF
--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -8,14 +8,14 @@
       </span>
       {{#if @model.isNew}}
       <div class="related-entities related-entities-hint">
-        <p>Prefix your path with <code>jobs/</code> to automatically make your secure variable accessible to a specified job, task group, or task.<br />
-        Format: <code>jobs/&lt;jobname&gt;</code>, <code>jobs/&lt;jobname&gt;/&lt;groupname&gt;</code>, <code>jobs/&lt;jobname&gt;/&lt;groupname&gt;/&lt;taskname&gt;</code></p>
+        <p>Prefix your path with <code>nomad/jobs/</code> to automatically make your secure variable accessible to a specified job, task group, or task.<br />
+        Format: <code>nomad/jobs/&lt;jobname&gt;</code>, <code>nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;</code>, <code>nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;/&lt;taskname&gt;</code></p>
       </div>
       {{/if}}
       <Input
         @type="text"
         @value={{@model.path}}
-        placeholder="jobs/my-job/my-group/my-task"
+        placeholder="nomad/jobs/my-job/my-group/my-task"
         class="input path-input {{if this.duplicatePathWarning "error"}}"
         disabled={{not @model.isNew}}
         {{on "input" this.validatePath}}

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -34,8 +34,8 @@ export default class SecureVariableFormComponent extends Component {
 
   get shouldDisableSave() {
     const disallowedPath =
-      this.args.model?.path.startsWith('nomad/') &&
-      !this.args.model?.path.startsWith('nomad/jobs/');
+      this.args.model?.path?.startsWith('nomad/') &&
+      !this.args.model?.path?.startsWith('nomad/jobs/');
     return !!this.JSONError || !this.args.model?.path || disallowedPath;
   }
 

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -35,7 +35,7 @@ export default class SecureVariableFormComponent extends Component {
   get shouldDisableSave() {
     const disallowedPath =
       this.args.model?.path?.startsWith('nomad/') &&
-      !this.args.model?.path?.startsWith('nomad/jobs/');
+      !this.args.model?.path?.startsWith('nomad/jobs');
     return !!this.JSONError || !this.args.model?.path || disallowedPath;
   }
 

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -33,7 +33,10 @@ export default class SecureVariableFormComponent extends Component {
   @tracked duplicatePathWarning = null;
 
   get shouldDisableSave() {
-    return !!this.JSONError || !this.args.model?.path;
+    const disallowedPath =
+      this.args.model?.path.startsWith('nomad/') &&
+      !this.args.model?.path.startsWith('nomad/jobs/');
+    return !!this.JSONError || !this.args.model?.path || disallowedPath;
   }
 
   /**

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -334,10 +334,10 @@ export default class Job extends Model {
     if (this.parent.get('id')) {
       return this.variables?.findBy(
         'path',
-        `jobs/${JSON.parse(this.parent.get('id'))[0]}`
+        `nomad/jobs/${JSON.parse(this.parent.get('id'))[0]}`
       );
     } else {
-      return this.variables?.findBy('path', `jobs/${this.plainId}`);
+      return this.variables?.findBy('path', `nomad/jobs/${this.plainId}`);
     }
   }
 }

--- a/ui/app/models/task-group.js
+++ b/ui/app/models/task-group.js
@@ -23,12 +23,12 @@ export default class TaskGroup extends Fragment {
     if (this.job.parent.get('id')) {
       return this.job.variables?.findBy(
         'path',
-        `jobs/${JSON.parse(this.job.parent.get('id'))[0]}/${this.name}`
+        `nomad/jobs/${JSON.parse(this.job.parent.get('id'))[0]}/${this.name}`
       );
     } else {
       return this.job.variables?.findBy(
         'path',
-        `jobs/${this.job.plainId}/${this.name}`
+        `nomad/jobs/${this.job.plainId}/${this.name}`
       );
     }
   }

--- a/ui/app/models/task.js
+++ b/ui/app/models/task.js
@@ -69,7 +69,7 @@ export default class Task extends Fragment {
       }
       return this._job.variables?.findBy(
         'path',
-        `jobs/${jobID}/${this.taskGroup.name}/${this.name}`
+        `nomad/jobs/${jobID}/${this.taskGroup.name}/${this.name}`
       );
     }
   }

--- a/ui/app/models/variable.js
+++ b/ui/app/models/variable.js
@@ -97,10 +97,13 @@ export default class VariableModel extends Model {
   get pathLinkedEntities() {
     const entityTypes = ['job', 'group', 'task'];
     const emptyEntities = { job: '', group: '', task: '' };
-    if (this.path?.startsWith('jobs/') && this.path?.split('/').length <= 4) {
+    if (
+      this.path?.startsWith('nomad/jobs/') &&
+      this.path?.split('/').length <= 5
+    ) {
       return this.path
         .split('/')
-        .slice(1, 4)
+        .slice(2, 5)
         .reduce((acc, pathPart, index) => {
           acc[entityTypes[index]] = pathPart;
           return acc;

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -75,9 +75,9 @@ function smallCluster(server) {
     'just some arbitrary file',
     'another arbitrary file',
     'another arbitrary file again',
-    `jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}/${variableLinkedTask.name}`,
-    `jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}`,
-    `jobs/${variableLinkedJob.id}`,
+    `nomad/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}/${variableLinkedTask.name}`,
+    `nomad/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}`,
+    `nomad/jobs/${variableLinkedJob.id}`,
   ].forEach((path) => server.create('variable', { id: path }));
 
   // #region evaluations

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -133,7 +133,7 @@ module('Acceptance | secure variables', function (hooks) {
     assert.notOk(fooLink, 'foo0 file is no longer present');
   });
 
-  test('variables prefixed with jobs/ correctly link to entities', async function (assert) {
+  test('variables prefixed with nomad/jobs/ correctly link to entities', async function (assert) {
     assert.expect(23);
     defaultScenario(server);
     const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
@@ -183,7 +183,7 @@ module('Acceptance | secure variables', function (hooks) {
 
     assert.equal(
       currentURL(),
-      '/variables/path/jobs',
+      '/variables/path/nomad/jobs',
       'correctly traverses to the jobs directory'
     );
     let jobFileLink = find('[data-test-file-row]');
@@ -192,7 +192,7 @@ module('Acceptance | secure variables', function (hooks) {
 
     await click(jobFileLink);
     assert.ok(
-      currentURL().startsWith('/variables/var/jobs/'),
+      currentURL().startsWith('/variables/var/nomad/jobs/'),
       'correctly traverses to a job file'
     );
     relatedEntitiesBox = find('.related-entities');
@@ -214,7 +214,9 @@ module('Acceptance | secure variables', function (hooks) {
     let jobVariableLink = find('[data-test-job-stat="variables"] a');
     await click(jobVariableLink);
     assert.ok(
-      currentURL().startsWith(`/variables/var/jobs/${variableLinkedJob.id}`),
+      currentURL().startsWith(
+        `/variables/var/nomad/jobs/${variableLinkedJob.id}`
+      ),
       'correctly traverses from job to variable'
     );
 
@@ -249,7 +251,7 @@ module('Acceptance | secure variables', function (hooks) {
     await click(groupVariableLink);
     assert.ok(
       currentURL().startsWith(
-        `/variables/var/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}`
+        `/variables/var/nomad/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}`
       ),
       'correctly traverses from group to variable'
     );
@@ -291,7 +293,7 @@ module('Acceptance | secure variables', function (hooks) {
     await click(taskVariableLink);
     assert.ok(
       currentURL().startsWith(
-        `/variables/var/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}/${variableLinkedTask.name}`
+        `/variables/var/nomad/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}/${variableLinkedTask.name}`
       ),
       'correctly traverses from task to variable'
     );

--- a/ui/tests/unit/models/variable-test.js
+++ b/ui/tests/unit/models/variable-test.js
@@ -54,7 +54,7 @@ module('Unit | Model | variable', function (hooks) {
 
     let model = store.createRecord('variable');
     model.setProperties({
-      path: 'jobs/my-job-name/my-group-name/my-task-name',
+      path: 'nomad/jobs/my-job-name/my-group-name/my-task-name',
     });
     assert.ok(model.pathLinkedEntities, 'generates a linked entities object');
     assert.equal(
@@ -74,7 +74,7 @@ module('Unit | Model | variable', function (hooks) {
     );
 
     model.setProperties({
-      path: 'jobs/my-job-name/my-group-name/my-task-name/too-long/oh-no',
+      path: 'nomad/jobs/my-job-name/my-group-name/my-task-name/too-long/oh-no',
     });
     assert.equal(
       model.pathLinkedEntities.job,
@@ -99,17 +99,17 @@ module('Unit | Model | variable', function (hooks) {
     assert.equal(
       model.pathLinkedEntities.job,
       '',
-      'entities object lacks a job name if not prefixed with jobs/'
+      'entities object lacks a job name if not prefixed with nomad/jobs/'
     );
     assert.equal(
       model.pathLinkedEntities.group,
       '',
-      'entities object lacks a group name if not prefixed with jobs/'
+      'entities object lacks a group name if not prefixed with nomad/jobs/'
     );
     assert.equal(
       model.pathLinkedEntities.task,
       '',
-      'entities object lacks a task name if not prefixed with jobs/'
+      'entities object lacks a task name if not prefixed with nomad/jobs/'
     );
   });
 });


### PR DESCRIPTION
Updates references to `/jobs` for path-linked-entities to `nomad/jobs/`, and disallows anything like `nomad/foo/` from letting you submit your job.

![image](https://user-images.githubusercontent.com/713991/180015338-6b224f39-85f8-4e2a-a9eb-0d2640b97adf.png)
---
![image](https://user-images.githubusercontent.com/713991/180015642-c01e2e6c-4f3e-4821-849f-601eb6fa6fde.png)
---
![image](https://user-images.githubusercontent.com/713991/180015685-d40a90fe-8633-4ae9-be09-7d90deda0379.png)
