### PR TITLE
ui: handle relative error text on form create

### DIFF
--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -1,7 +1,7 @@
 {{did-update this.onViewChange @view}}
 {{did-insert this.establishKeyValues}}
 <form class="new-secure-variables" autocomplete="off" {{on "submit" this.save}}>
-  <div class={{if this.namespaceOptions "path-namespace"}}>
+  <div class={{if (and this.namespaceOptions (not this.duplicatePathWarning)) "path-namespace"}}>
     <label>
       <span>
         Path
@@ -44,6 +44,7 @@
         disabled=(not @model.isNew)
         selection=this.variableNamespace
         namespaceOptions=this.namespaceOptions
+        shouldShowFilter=(and this.namespaceOptions (not this.duplicatePathWarning))
       }}
       @fns={{hash
         onSelect=this.setNamespace

--- a/ui/app/components/secure-variable-form/namespace-filter.hbs
+++ b/ui/app/components/secure-variable-form/namespace-filter.hbs
@@ -4,7 +4,7 @@
   {{! No Loading Behavior }}
   {{#if trigger.data.isSuccess}}
     {{#if trigger.data.result}}
-      {{#if @data.namespaceOptions}}
+      {{#if @data.shouldShowFilter}}
         <label>
           <span>
             Namespace


### PR DESCRIPTION
Currently, if we have namespaces and we also have a path validation error, the form's Grid layout can't handle the relative placement for the error text.

**Problem:**
![image](https://user-images.githubusercontent.com/41024828/180252634-8a9a5850-3721-40ba-94c2-50dc2235569a.png)


My solution is to conditionally render the namespace filter based on the error condition to avoid refactoring the Grid layout.

**Solution**
![image](https://user-images.githubusercontent.com/41024828/180252528-57a9334b-ad6f-4f2d-b00a-c2221124e6ed.png)
