### PR TITLE
block deleting namespaces if the namespace contains a volume

### DIFF
--- a/.changelog/13880.txt
+++ b/.changelog/13880.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+namespaces: Fixed a bug that allowed deleting a namespace that contained a CSI volume
+```


### PR DESCRIPTION
When we delete a namespace, we check to ensure that there are no non-terminal
jobs, which effectively covers evals, allocs, etc. CSI volumes are also
namespaced, so extend this check to cover CSI volumes.

We'll also need to add this check for Secure Variables, but this is in a separate
PR because it'll need to be backported.