### PR TITLE
Fixing placement groups for csi_plugin in docs

### DIFF
--- a/website/content/docs/job-specification/csi_plugin.mdx
+++ b/website/content/docs/job-specification/csi_plugin.mdx
@@ -8,7 +8,7 @@ description: >-
 
 # `csi_plugin` Stanza
 
-<Placement groups={['job', 'group', 'task', 'volume']} />
+<Placement groups={['job', 'group', 'task', 'csi_plugin']} />
 
 The "csi_plugin" stanza allows the task to specify it provides a
 Container Storage Interface plugin to the cluster. Nomad will


### PR DESCRIPTION
I _think_ the placement is incorrectly showing `volume` instead of `csi_plugin`.