### PR TITLE
block deleting namespace if it contains a secure variable

### DIFF
--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -6352,6 +6352,17 @@ func (s *StateStore) DeleteNamespaces(index uint64, names []string) error {
 				"All CSI volumes in namespace must be deleted before it can be deleted", name, vol.ID)
 		}
 
+		varIter, err := s.getSecureVariablesByNamespaceImpl(txn, nil, name)
+		if err != nil {
+			return err
+		}
+		if varIter.Next() != nil {
+			// unlike job/volume, don't show the path here because the user may
+			// not have List permissions on the secure vars in this namespace
+			return fmt.Errorf("namespace %q contains at least one secure variable. "+
+				"All secure variables in namespace must be deleted before it can be deleted", name)
+		}
+
 		// Delete the namespace
 		if err := txn.Delete(TableNamespaces, existing); err != nil {
 			return fmt.Errorf("namespace deletion failed: %v", err)

--- a/nomad/state/state_store_secure_variables.go
+++ b/nomad/state/state_store_secure_variables.go
@@ -29,7 +29,11 @@ func (s *StateStore) SecureVariables(ws memdb.WatchSet) (memdb.ResultIterator, e
 func (s *StateStore) GetSecureVariablesByNamespace(
 	ws memdb.WatchSet, namespace string) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
+	return s.getSecureVariablesByNamespaceImpl(txn, ws, namespace)
+}
 
+func (s *StateStore) getSecureVariablesByNamespaceImpl(
+	txn *txn, ws memdb.WatchSet, namespace string) (memdb.ResultIterator, error) {
 	// Walk the entire table.
 	iter, err := txn.Get(TableSecureVariables, indexID+"_prefix", namespace, "")
 	if err != nil {


### PR DESCRIPTION
When we delete a namespace, we check to ensure that there are no non-terminal
jobs or CSI volume, which also covers evals, allocs, etc. Secure variables are
also namespaces, so extend this check to them as well.