### PR TITLE
chore:  update tests

### DIFF
--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -470,7 +470,7 @@ module('Acceptance | secure variables', function (hooks) {
 
   module('edit flow', function () {
     test('allows a user with correct permissions to edit a secure variable', async function (assert) {
-      assert.expect(7);
+      assert.expect(8);
       // Arrange Test Set-up
       defaultScenario(server);
       server.createList('variable', 3);

--- a/ui/tests/integration/components/secure-variable-form-test.js
+++ b/ui/tests/integration/components/secure-variable-form-test.js
@@ -259,7 +259,7 @@ module('Integration | Component | secure-variable-form', function (hooks) {
       await typeIn('.key-value label:nth-child(1) input', 'superSecret');
       assert.dom('.key-value-error').doesNotExist();
 
-      find('.key-value:nth-child(2) label:nth-child(1) input').value = '';
+      find('.key-value label:nth-child(1) input').value = '';
 
       await typeIn('.key-value label:nth-child(1) input', 'super.secret');
       assert.dom('.key-value-error').exists();
@@ -277,15 +277,13 @@ module('Integration | Component | secure-variable-form', function (hooks) {
 
       await click('.key-value button.add-more');
 
-      await typeIn(
-        '.key-value:nth-child(3) label:nth-child(1) input',
-        'myWonderfulKey'
-      );
+      const secondKey = document.querySelectorAll('[data-test-var-key]')[1];
+      await typeIn(secondKey, 'myWonderfulKey');
       assert.dom('.key-value-error').doesNotExist();
 
-      find('.key-value:nth-child(3) label:nth-child(1) input').value = '';
+      secondKey.value = '';
 
-      await typeIn('.key-value:nth-child(3) label:nth-child(1) input', 'myKey');
+      await typeIn(secondKey, 'myKey');
       assert.dom('.key-value-error').exists();
     });
   });


### PR DESCRIPTION
We made a change to our markup in this commit [84401fe](https://github.com/hashicorp/nomad/pull/13618/commits/84401fe72f43869f31964569dc354e79ed2a6e12). Some of our tests are brittle and aren't taking advantage of `data-test-attributes` and relied on CSS selector that are dependent on the order of our markup causing the tests to fail.