### PR TITLE
Add stage_publish_dir field to csi_plugin stanza of a job

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -1032,13 +1032,16 @@ type TaskCSIPluginConfig struct {
 	// CSIPluginType instructs Nomad on how to handle processing a plugin
 	Type CSIPluginType `mapstructure:"type" hcl:"type,optional"`
 
-	// MountDir is the destination that nomad should mount in its CSI
-	// directory for the plugin. It will then expect a file called CSISocketName
-	// to be created by the plugin, and will provide references into
-	// "MountDir/CSIIntermediaryDirname/VolumeName/AllocID for mounts.
-	//
-	// Default is /csi.
+	// MountDir is the directory (within its container) in which the plugin creates a
+	// socket (called CSISocketName) for communication with Nomad. Default is /csi.
 	MountDir string `mapstructure:"mount_dir" hcl:"mount_dir,optional"`
+
+	// StagePublishDir is the base directory (within its container) in which the plugin
+	// mounts volumes being staged and bind mounts volumes being published.
+	// e.g. staging_target_path = {StagePublishDir}/staging/{volume-id}/{usage-mode}
+	// e.g. target_path = {StagePublishDir}/per-alloc/{alloc-id}/{volume-id}/{usage-mode}
+	// Default is /local/csi.
+	StagePublishDir string `mapstructure:"stage_publish_dir" hcl:"stage_publish_dir,optional"`
 
 	// HealthTimeout is the time after which the CSI plugin tasks will be killed
 	// if the CSI Plugin is not healthy.
@@ -1048,6 +1051,10 @@ type TaskCSIPluginConfig struct {
 func (t *TaskCSIPluginConfig) Canonicalize() {
 	if t.MountDir == "" {
 		t.MountDir = "/csi"
+	}
+
+	if t.StagePublishDir == "" {
+		t.StagePublishDir = filepath.Join("/local", "csi")
 	}
 
 	if t.HealthTimeout == 0 {

--- a/client/allocrunner/taskrunner/plugin_supervisor_hook.go
+++ b/client/allocrunner/taskrunner/plugin_supervisor_hook.go
@@ -81,7 +81,7 @@ var _ interfaces.TaskStopHook = &csiPluginSupervisorHook{}
 //       Per-allocation directories of unix domain sockets used to communicate
 //       with the CSI plugin. Nomad creates the directory and the plugin creates
 //       the socket file. This directory is bind-mounted to the
-//       csi_plugin.mount_config dir in the plugin task.
+//       csi_plugin.mount_dir in the plugin task.
 //
 // {plugin-type}/{plugin-id}/
 //    staging/

--- a/client/allocrunner/taskrunner/plugin_supervisor_hook.go
+++ b/client/allocrunner/taskrunner/plugin_supervisor_hook.go
@@ -157,12 +157,12 @@ func (h *csiPluginSupervisorHook) Prestart(ctx context.Context,
 	}
 	// where the staging and per-alloc directories will be mounted
 	volumeStagingMounts := &drivers.MountConfig{
-		// TODO(tgross): add this TaskPath to the CSIPluginConfig as well
-		TaskPath:        "/local/csi",
+		TaskPath:        h.task.CSIPluginConfig.StagePublishDir,
 		HostPath:        h.mountPoint,
 		Readonly:        false,
 		PropagationMode: "bidirectional",
 	}
+	h.logger.Info("", "volumeStagingMounts", volumeStagingMounts) // TODO: Remove this before merge.
 	// devices from the host
 	devMount := &drivers.MountConfig{
 		TaskPath: "/dev",
@@ -360,7 +360,7 @@ func (h *csiPluginSupervisorHook) registerPlugin(client csi.CSIPlugin, socketPat
 			Options: map[string]string{
 				"Provider":            info.Name, // vendor name
 				"MountPoint":          h.mountPoint,
-				"ContainerMountPoint": "/local/csi",
+				"ContainerMountPoint": h.task.CSIPluginConfig.StagePublishDir,
 			},
 		}
 	}

--- a/client/allocrunner/taskrunner/plugin_supervisor_hook.go
+++ b/client/allocrunner/taskrunner/plugin_supervisor_hook.go
@@ -103,6 +103,16 @@ func newCSIPluginSupervisorHook(config *csiPluginSupervisorHookConfig) *csiPlugi
 	socketMountPoint := filepath.Join(config.clientStateDirPath, "csi",
 		"plugins", config.runner.Alloc().ID)
 
+	// In v1.3.0, Nomad started instructing CSI plugins to stage and publish 
+	// within /csi/local. Plugins deployed after the introduction of
+	// StagePublishDir default to StagePublishDir = /csi/local. However, 
+	// plugins deployed between v1.3.0 and the introduction of 
+	// StagePublishDir have StagePublishDir = "". Default to /csi/local here
+	// to avoid breaking plugins that aren't redeployed.
+	if task.CSIPluginConfig.StagePublishDir == "" {
+		task.CSIPluginConfig.StagePublishDir = filepath.Join("/local", "csi")
+	}
+	
 	if task.CSIPluginConfig.HealthTimeout == 0 {
 		task.CSIPluginConfig.HealthTimeout = 30 * time.Second
 	}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1263,6 +1263,7 @@ func ApiCSIPluginConfigToStructsCSIPluginConfig(apiConfig *api.TaskCSIPluginConf
 	sc.ID = apiConfig.ID
 	sc.Type = structs.CSIPluginType(apiConfig.Type)
 	sc.MountDir = apiConfig.MountDir
+	sc.StagePublishDir = apiConfig.StagePublishDir
 	sc.HealthTimeout = apiConfig.HealthTimeout
 	return sc
 }

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -62,11 +62,16 @@ type TaskCSIPluginConfig struct {
 	// Type instructs Nomad on how to handle processing a plugin
 	Type CSIPluginType
 
-	// MountDir is the destination that nomad should mount in its CSI
-	// directory for the plugin. It will then expect a file called CSISocketName
-	// to be created by the plugin, and will provide references into
-	// "MountDir/CSIIntermediaryDirname/{VolumeName}/{AllocID} for mounts.
+	// MountDir is the directory (within its container) in which the plugin creates a
+	// socket (called CSISocketName) for communication with Nomad. Default is /csi.
 	MountDir string
+
+	// StagePublishDir is the base directory (within its container) in which the plugin
+	// mounts volumes being staged and bind mount volumes being published.
+	// e.g. staging_target_path = {StagePublishDir}/staging/{volume-id}/{usage-mode}
+	// e.g. target_path = {StagePublishDir}/per-alloc/{alloc-id}/{volume-id}/{usage-mode}
+	// Default is /local/csi.
+	StagePublishDir string
 
 	// HealthTimeout is the time after which the CSI plugin tasks will be killed
 	// if the CSI Plugin is not healthy.

--- a/website/content/docs/concepts/plugins/csi.mdx
+++ b/website/content/docs/concepts/plugins/csi.mdx
@@ -38,9 +38,10 @@ A CSI plugin task requires the [`csi_plugin`][csi_plugin] block:
 
 ```hcl
 csi_plugin {
-  id        = "csi-hostpath"
-  type      = "monolith"
-  mount_dir = "/csi"
+  id                = "csi-hostpath"
+  type              = "monolith"
+  mount_dir         = "/csi"
+  stage_publish_dir = "/local/csi"
 }
 ```
 
@@ -73,7 +74,11 @@ Nomad exposes a Unix domain socket named `csi.sock` inside each CSI
 plugin task, and communicates over the gRPC protocol expected by the
 CSI specification. The `mount_dir` field tells Nomad where the plugin
 expects to find the socket file. The path to this socket is exposed in
-the container as the `CSI_ENDPOINT` environment variable.
+the container as the `CSI_ENDPOINT` environment variable. In
+addition, the `stage_publish_dir` field tells Nomad where the plugin
+wants to be instructed to mount volumes for staging and/or publishing.
+This field is generally not required and, like `mount_dir`, only
+affects the plugin container's internal view of the file system.
 
 ### Plugin Lifecycle and State
 

--- a/website/content/docs/job-specification/csi_plugin.mdx
+++ b/website/content/docs/job-specification/csi_plugin.mdx
@@ -17,10 +17,11 @@ to claim [volumes][csi_volumes].
 
 ```hcl
 csi_plugin {
-  id             = "csi-hostpath"
-  type           = "monolith"
-  mount_dir      = "/csi"
-  health_timeout = "30s"
+  id                = "csi-hostpath"
+  type              = "monolith"
+  mount_dir         = "/csi"
+  stage_publish_dir = "/local/csi"
+  health_timeout    = "30s"
 }
 ```
 
@@ -43,6 +44,10 @@ csi_plugin {
 - `mount_dir` `(string: <required>)` - The directory path inside the
   container where the plugin will expect a Unix domain socket for
   bidirectional communication with Nomad.
+
+- `stage_publish_dir` `(string: <optional>)` - The base directory 
+  path inside the container where the plugin will be instructed to
+  stage and publish volumes.
 
 - `health_timeout` `(duration: <optional>)` - The duration that 
   the plugin supervisor will wait before restarting an unhealthy


### PR DESCRIPTION
Resolves #13263.

This PR adds a new field to the csi_plugin stanza of a job that determines the base (inside a CSI plugin's container) of CSI staging_target_path and target_path directories.

This is my first PR to Nomad. I have attempted to go through the bullets in the checklist below. Some of the bullets are (I think) not applicable. For the docs, I tried to find all locations within /docs where CSI is mentioned and add the field as appropriate.

I updated comments on a couple of fields that I found to be confusing while trying to figure out where and how to get this implemented. I'm obviously open to reverting anything that the maintainers think is not an improvement.

## Code

* [x] Consider similar features in Consul, Kubernetes, and other tools. Is there prior art we should match? Terminology, structure, etc?
* [x] Add structs/fields to `api/` package
  * `api/` structs usually have Canonicalize and Copy methods
  * New fields should be added to existing Canonicalize, Copy methods
  * Test the structs/fields via methods mentioned above
* [x] Add structs/fields to `nomad/structs` package
  * `structs/` structs usually have Copy, Equals, and Validate methods
  * Validation happens in this package and _must_ be implemented
  * Note that analogous struct field names should match with `api/` package
  * Test the structs/fields via methods mentioned above
  * Implement and test other logical methods
* [x] Add conversion between `api/` and `nomad/structs/` in `command/agent/job_endpoint.go`
  * Add test for conversion
* [x] Determine JSON encoding strategy for responses from RPC (see "JSON Encoding" below)
  * [x] Write `nomad/structs/` to `api/` conversions if necessary and write tests
* [x] Implement diff logic for new structs/fields in `nomad/structs/diff.go`
  * Note that fields must be listed in alphabetical order in `FieldDiff` slices in `nomad/structs/diff_test.go`
  * Add test for diff of new structs/fields
* [x] Add change detection for new structs/fields in `scheduler/util.go/tasksUpdated`
  * Might be covered by `.Equals` but might not be, check.
  * Should return true if the task must be replaced as a result of the change.

## Docs

* [ ] Changelog
* [x] Jobspec entry https://www.nomadproject.io/docs/job-specification/index.html
* [ ] Jobspec sidebar entry https://github.com/hashicorp/nomad/blob/main/website/data/docs-navigation.js
* [ ] Job JSON API entry https://www.nomadproject.io/api/json-jobs.html
* [ ] Sample Response output in API https://www.nomadproject.io/api/jobs.html
* [ ] Consider if it needs a guide https://www.nomadproject.io/guides/index.html