### PR TITLE
website: enable setting custom tool for launching website dev container

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -1,5 +1,8 @@
 .DEFAULT_GOAL := website
 
+# Enable setting alternate docker tool, e.g. 'make DOCKER_CMD=podman'
+DOCKER_CMD ?= docker
+
 PWD=$$(pwd)
 DOCKER_IMAGE="hashicorp/dev-portal"
 DOCKER_IMAGE_LOCAL="dev-portal-local"
@@ -19,20 +22,20 @@ DOCKER_RUN_FLAGS=-it \
 .PHONY: website
 website:
 	@echo "==> Downloading latest Docker image..."
-	@docker pull $(DOCKER_IMAGE)
+	@$(DOCKER_CMD) pull $(DOCKER_IMAGE)
 	@echo "==> Starting website..."
-	@docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE)
+	@$(DOCKER_CMD) run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE)
 
 # Use this if you have run `website/build-local` to use the locally built image.
 .PHONY: website/local
 website/local:
 	@echo "==> Starting website from local image..."
-	@docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE_LOCAL)
+	@$(DOCKER_CMD) run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE_LOCAL)
 
 # Run this to generate a new local Docker image.
 .PHONY: website/build-local
 website/build-local:
 	@echo "==> Building local Docker image"
-	@docker build https://github.com/hashicorp/dev-portal.git\#main \
+	@$(DOCKER_CMD) build https://github.com/hashicorp/dev-portal.git\#main \
 		-t $(DOCKER_IMAGE_LOCAL)
 


### PR DESCRIPTION
When working in a podman environment, it's convenient to run the website development container using podman.
