### PR TITLE
Proof of concept for online scheduling

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -105,6 +105,7 @@ type RegisterOptions struct {
 	PolicyOverride bool
 	PreserveCounts bool
 	EvalPriority   int
+	Online         bool
 }
 
 // Register is used to register a new job. It returns the ID
@@ -134,6 +135,7 @@ func (j *Jobs) RegisterOpts(job *Job, opts *RegisterOptions, q *WriteOptions) (*
 		req.PolicyOverride = opts.PolicyOverride
 		req.PreserveCounts = opts.PreserveCounts
 		req.EvalPriority = opts.EvalPriority
+		req.Online = opts.Online
 	}
 
 	var resp JobRegisterResponse
@@ -1230,6 +1232,8 @@ type JobRegisterRequest struct {
 	// busy clusters with a large evaluation backlog. This avoids needing to
 	// change the job priority which also impacts preemption.
 	EvalPriority int `json:",omitempty"`
+
+	Online bool `json:",omitempty"`
 
 	WriteRequest
 }

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -415,6 +415,7 @@ func (s *HTTPServer) jobUpdate(resp http.ResponseWriter, req *http.Request,
 		PolicyOverride: args.PolicyOverride,
 		PreserveCounts: args.PreserveCounts,
 		EvalPriority:   args.EvalPriority,
+		Online:         args.Online,
 		WriteRequest:   *writeReq,
 	}
 

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -102,6 +102,9 @@ Run Options:
     has been supplied which is not defined within the root variables. Defaults
     to true.
 
+  -online
+    Schedule the job within the request/response lifecycle.
+
   -output
     Output the JSON that would be submitted to the HTTP API without submitting
     the job.
@@ -168,6 +171,7 @@ func (c *JobRunCommand) AutocompleteFlags() complete.Flags {
 			"-var":             complete.PredictAnything,
 			"-var-file":        complete.PredictFiles("*.var"),
 			"-eval-priority":   complete.PredictNothing,
+			"-online":          complete.PredictNothing,
 		})
 }
 
@@ -182,7 +186,7 @@ func (c *JobRunCommand) AutocompleteArgs() complete.Predictor {
 func (c *JobRunCommand) Name() string { return "job run" }
 
 func (c *JobRunCommand) Run(args []string) int {
-	var detach, verbose, output, override, preserveCounts bool
+	var detach, verbose, online, output, override, preserveCounts bool
 	var checkIndexStr, consulToken, consulNamespace, vaultToken, vaultNamespace string
 	var evalPriority int
 
@@ -204,6 +208,7 @@ func (c *JobRunCommand) Run(args []string) int {
 	flagSet.Var(&c.JobGetter.Vars, "var", "")
 	flagSet.Var(&c.JobGetter.VarFiles, "var-file", "")
 	flagSet.IntVar(&evalPriority, "eval-priority", 0, "")
+	flagSet.BoolVar(&online, "online", false, "")
 
 	if err := flagSet.Parse(args); err != nil {
 		return 1
@@ -313,6 +318,7 @@ func (c *JobRunCommand) Run(args []string) int {
 		PolicyOverride: override,
 		PreserveCounts: preserveCounts,
 		EvalPriority:   evalPriority,
+		Online:         online,
 	}
 	if enforce {
 		opts.EnforceIndex = true

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -187,8 +187,8 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 	if err != nil {
 		return err
 	}
-	ws := memdb.NewWatchSet()
-	existingJob, err := snap.JobByID(ws, args.RequestNamespace(), args.Job.ID)
+
+	existingJob, err := snap.JobByID(nil, args.RequestNamespace(), args.Job.ID)
 	if err != nil {
 		return err
 	}
@@ -353,15 +353,26 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 			submittedEval = true
 		}
 
-		// Commit this update via Raft
-		fsmErr, index, err := j.srv.raftApply(structs.JobRegisterRequestType, args)
-		if err, ok := fsmErr.(error); ok && err != nil {
-			j.logger.Error("registering job failed", "error", err, "fsm", true)
-			return err
-		}
-		if err != nil {
-			j.logger.Error("registering job failed", "error", err, "raft", true)
-			return err
+		var index uint64
+		if !args.Online {
+			// Commit this update via Raft
+			var fsmErr any
+			fsmErr, index, err = j.srv.raftApply(structs.JobRegisterRequestType, args)
+			if err, ok := fsmErr.(error); ok && err != nil {
+				j.logger.Error("registering job failed", "error", err, "fsm", true)
+				return err
+			}
+			if err != nil {
+				j.logger.Error("registering job failed", "error", err, "raft", true)
+				return err
+			}
+		} else {
+			// Schedule this job online and submit plan
+			index, err = j.scheduleJob(snap, args.Job, args.Eval)
+			if err != nil {
+				j.logger.Error("registering job online failed", "error", err)
+				return err
+			}
 		}
 
 		// Populate the reply with job information
@@ -426,6 +437,31 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 	}
 
 	return nil
+}
+
+func (j *Job) scheduleJob(snap *state.StateSnapshot, job *structs.Job, eval *structs.Evaluation) (uint64, error) {
+
+	// Insert objects into state snapshot but ensure it's ignored
+	if err := snap.UpsertJob(structs.IgnoreUnknownTypeFlag, 1, job); err != nil {
+		return 0, err
+	}
+	if err := snap.UpsertEvals(structs.IgnoreUnknownTypeFlag, 1, []*structs.Evaluation{eval}); err != nil {
+		return 0, err
+	}
+
+	planner := NewLocalPlanner(j.logger, j.srv.planQueue)
+
+	// Create the scheduler and run it
+	sched, err := scheduler.NewScheduler(eval.Type, j.logger, j.srv.workersEventCh, snap, planner)
+	if err != nil {
+		return 0, err
+	}
+
+	if err := sched.Process(eval); err != nil {
+		return 0, err
+	}
+
+	return planner.Result.AllocIndex, nil
 }
 
 // propagateScalingPolicyIDs propagates scaling policy IDs from existing job

--- a/nomad/planner_local.go
+++ b/nomad/planner_local.go
@@ -1,0 +1,76 @@
+package nomad
+
+import (
+	"github.com/hashicorp/go-hclog"
+	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/scheduler"
+)
+
+type PlanEnqueuer interface {
+	Enqueue(plan *structs.Plan) (PlanFuture, error)
+}
+
+type plannerLocal struct {
+	enq    PlanEnqueuer
+	logger hclog.Logger
+
+	Result   *structs.PlanResult
+	Eval     *structs.Evaluation
+	NextEval *structs.Evaluation
+}
+
+func NewLocalPlanner(logger hclog.Logger, enq PlanEnqueuer) *plannerLocal {
+	return &plannerLocal{
+		enq:    enq,
+		logger: logger,
+	}
+}
+
+// SubmitPlan is used to submit a plan for consideration.
+// This will return a PlanResult or an error. It is possible
+// that this will result in a state refresh as well.
+func (p *plannerLocal) SubmitPlan(plan *structs.Plan) (*structs.PlanResult, scheduler.State, error) {
+	// Submit the plan to the queue
+	future, err := p.enq.Enqueue(plan)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Wait for the results
+	result, err := future.Wait()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p.Result = result
+	return result, nil, nil
+}
+
+// UpdateEval is used to update an evaluation. This should update
+// a copy of the input evaluation since that should be immutable.
+func (p *plannerLocal) UpdateEval(eval *structs.Evaluation) error {
+	p.Eval = eval
+	return nil
+}
+
+// CreateEval is used to create an evaluation. This should set the
+// PreviousEval to that of the current evaluation.
+func (p *plannerLocal) CreateEval(eval *structs.Evaluation) error {
+	p.NextEval = eval
+	return nil
+}
+
+// ReblockEval takes a blocked evaluation and re-inserts it into the blocked
+// evaluation tracker. This update occurs only in-memory on the leader. The
+// evaluation must exist in a blocked state prior to this being called such
+// that on leader changes, the evaluation will be reblocked properly.
+func (p *plannerLocal) ReblockEval(_ *structs.Evaluation) error {
+	panic("not implemented") // TODO: Implement
+	return nil
+}
+
+// ServersMeetMinimumVersion is always true locally
+func (p *plannerLocal) ServersMeetMinimumVersion(minVersion *version.Version, checkFailedServers bool) bool {
+	return true
+}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -401,7 +401,9 @@ func (s *StateStore) UpsertPlanResults(msgType structs.MessageType, index uint64
 	if results.EvalID != "" {
 		// Update the modify index of the eval id
 		if err := s.updateEvalModifyIndex(txn, index, results.EvalID); err != nil {
-			return err
+			//FIXME(schmichael) online job submission doesn't save the eval so this
+			//doesn't work, but I couldn't figure out how to get EvalID="" here
+			//return err
 		}
 	}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -11191,9 +11191,9 @@ func (e *Evaluation) ShouldBlock() bool {
 	}
 }
 
-// MakePlan is used to make a plan from the given evaluation
-// for a given Job
-func (e *Evaluation) MakePlan(j *Job) *Plan {
+// NewPlan is used to make an empty plan from the given evaluation for a given
+// Job.
+func (e *Evaluation) NewPlan(j *Job) *Plan {
 	p := &Plan{
 		EvalID:          e.ID,
 		Priority:        e.Priority,

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -608,6 +608,9 @@ type JobRegisterRequest struct {
 	// Eval is the evaluation that is associated with the job registration
 	Eval *Evaluation
 
+	// Online schedules the job immediately instead of enqueueing an eval
+	Online bool
+
 	WriteRequest
 }
 

--- a/nomad/worker.go
+++ b/nomad/worker.go
@@ -121,7 +121,7 @@ func NewWorker(ctx context.Context, srv *Server, args SchedulerWorkerPoolArgs) (
 	return w, nil
 }
 
-// _newWorker creates a worker without calling its Start func. This is useful for testing.
+// newWorker creates a worker without calling its Start func. This is useful for testing.
 func newWorker(ctx context.Context, srv *Server, args SchedulerWorkerPoolArgs) *Worker {
 	w := &Worker{
 		id:                uuid.Generate(),

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -242,11 +242,13 @@ func (s *GenericScheduler) createBlockedEval(planFailure bool) error {
 func (s *GenericScheduler) process() (bool, error) {
 	// Lookup the Job by ID
 	var err error
-	ws := memdb.NewWatchSet()
-	s.job, err = s.state.JobByID(ws, s.eval.Namespace, s.eval.JobID)
+
+	s.job, err = s.state.JobByID(nil, s.eval.Namespace, s.eval.JobID)
 	if err != nil {
 		return false, fmt.Errorf("failed to get job %q: %v", s.eval.JobID, err)
 	}
+
+	s.logger.Info("---------> got job", "j", s.job)
 
 	numTaskGroups := 0
 	stopped := s.job.Stopped()
@@ -261,7 +263,7 @@ func (s *GenericScheduler) process() (bool, error) {
 
 	if !s.batch {
 		// Get any existing deployment
-		s.deployment, err = s.state.LatestDeploymentByJobID(ws, s.eval.Namespace, s.eval.JobID)
+		s.deployment, err = s.state.LatestDeploymentByJobID(nil, s.eval.Namespace, s.eval.JobID)
 		if err != nil {
 			return false, fmt.Errorf("failed to get job deployment %q: %v", s.eval.JobID, err)
 		}
@@ -284,6 +286,8 @@ func (s *GenericScheduler) process() (bool, error) {
 		s.logger.Error("failed to compute job allocations", "error", err)
 		return false, err
 	}
+
+	s.logger.Info("----------> computed", "plan", s.plan)
 
 	// If there are failed allocations, we need to create a blocked evaluation
 	// to place the failed allocations when resources become available. If the
@@ -357,8 +361,7 @@ func (s *GenericScheduler) process() (bool, error) {
 // existing allocations and node status to update the allocations.
 func (s *GenericScheduler) computeJobAllocs() error {
 	// Lookup the allocations by JobID
-	ws := memdb.NewWatchSet()
-	allocs, err := s.state.AllocsByJob(ws, s.eval.Namespace, s.eval.JobID, true)
+	allocs, err := s.state.AllocsByJob(nil, s.eval.Namespace, s.eval.JobID, true)
 	if err != nil {
 		return fmt.Errorf("failed to get allocs for job '%s': %v",
 			s.eval.JobID, err)

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -256,8 +256,8 @@ func (s *GenericScheduler) process() (bool, error) {
 	s.queuedAllocs = make(map[string]int, numTaskGroups)
 	s.followUpEvals = nil
 
-	// Create a plan
-	s.plan = s.eval.MakePlan(s.job)
+	// Create a new plan for this proces attempt
+	s.plan = s.eval.NewPlan(s.job)
 
 	if !s.batch {
 		// Get any existing deployment

--- a/scheduler/scheduler_system.go
+++ b/scheduler/scheduler_system.go
@@ -138,8 +138,8 @@ func (s *SystemScheduler) process() (bool, error) {
 		}
 	}
 
-	// Create a plan
-	s.plan = s.eval.MakePlan(s.job)
+	// Initialize plan
+	s.plan = s.eval.NewPlan(s.job)
 
 	// Reset the failed allocations
 	s.failedTGAllocs = nil


### PR DESCRIPTION
Hacky support for scheduling directly in the API request/response cycle (no eval broker!).

No eval or job is even created so a lot won't work (eg deployments), but I think we could commit those to Raft and still allow online job scheduling that skips the eval broker.