### PR TITLE
fix flaky `TestAgent_ProxyRPC_Dev` test

### DIFF
--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -9,15 +9,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shoenig/test/must"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/nomad/ci"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
-	"github.com/shoenig/test/must"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/hashicorp/nomad/testutil"
 )
 
 func TestAgent_RPC_Ping(t *testing.T) {
@@ -1421,10 +1423,17 @@ func TestAgent_ProxyRPC_Dev(t *testing.T) {
 		},
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	testutil.WaitForResultUntil(time.Second,
+		func() (bool, error) {
+			var resp cstructs.ClientStatsResponse
+			err := agent.RPC("ClientStats.Stats", req, &resp)
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		},
+		func(err error) {
+			t.Fatalf("was unable to read ClientStats.Stats RPC: %v", err)
+		})
 
-	var resp cstructs.ClientStatsResponse
-	if err := agent.RPC("ClientStats.Stats", req, &resp); err != nil {
-		t.Fatalf("err: %v", err)
-	}
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/13720

This test is a fairly trivial test of the agent RPC, but the test setup waits
for a short fixed window after the node starts to send the RPC. After looking at
detailed logs for recent test failures, it looks like the node registration for
the first node doesn't get a chance to happen before we make the RPC call. Use
`WaitForResultUntil` to give the test more time to run in slower test
environments, while allowing it to finish quickly if possible.