### PR TITLE
command/agent: fix dropped test errors

### DIFF
--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -1253,6 +1253,7 @@ func TestHTTPServer_Limits_OK(t *testing.T) {
 
 		// Create a new connection that will go over the connection limit.
 		limitConn, err := dial(t, addr, useTLS)
+		require.NoError(t, err)
 
 		response := "HTTP/1.1 429"
 		buf := make([]byte, len(response))

--- a/command/agent/secure_variable_endpoint_test.go
+++ b/command/agent/secure_variable_endpoint_test.go
@@ -313,6 +313,7 @@ func TestHTTP_SecureVariables(t *testing.T) {
 
 				// Make the request
 				obj, err := s.Server.SecureVariableSpecificRequest(respW, req)
+				require.NoError(t, err)
 				require.Equal(t, http.StatusConflict, respW.Result().StatusCode)
 
 				// Evaluate the conflict variable


### PR DESCRIPTION
This fixes two dropped test `err` variables in `command/agent`.