### PR TITLE
test: disable docker OOM detection test on cgroups v2

### DIFF
--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -2383,9 +2383,9 @@ func TestDockerDriver_OOMKilled(t *testing.T) {
 	ci.Parallel(t)
 	testutil.DockerCompatible(t)
 
-	if runtime.GOOS == "windows" {
-		t.Skip("Windows does not support OOM Killer")
-	}
+	// waiting on upstream fix for cgroups v2
+	// see https://github.com/hashicorp/nomad/issues/13119
+	testutil.CgroupsCompatibleV1(t)
 
 	taskCfg := newTaskConfig("", []string{"sh", "-c", `sleep 2 && x=a && while true; do x="$x$x"; done`})
 	task := &drivers.TaskConfig{


### PR DESCRIPTION
OOM detection under cgroups v2 is flaky under versions of `containerd` before
v1.6.3, but our `containerd` dependency is transitive on `moby/moby`, who have
not yet updated. Disable this test for cgroups v2 environments until we can
update the dependency chain.

---

This removes the test flake from https://github.com/hashicorp/nomad/issues/13119, but we should leave that issue open even after this merges. The underlying problem is in the OOM detection and not in the test code.

On cgroups v2:

```
root@jammy# NOMAD_TEST_LOG_LEVEL=warn go test -v -count=1 ./drivers/docker -run TestDockerDriver_OOMKilled
=== RUN   TestDockerDriver_OOMKilled
=== PAUSE TestDockerDriver_OOMKilled
=== CONT  TestDockerDriver_OOMKilled
    docker.go:36: Successfully connected to docker daemon running version 20.10.17
    driver_compatible_linux.go:28: No cgroup.v1 mount point: running in cgroup.v2 mode
    driver_compatible_linux.go:20: Test requires cgroup.v1 support
--- SKIP: TestDockerDriver_OOMKilled (0.01s)
PASS
ok      github.com/hashicorp/nomad/drivers/docker       0.024s
```

On cgroups v1:

```
root@focal# NOMAD_TEST_LOG_LEVEL=warn go test -v -count=1 ./drivers/docker -run TestDockerDriver_OOMKilled
=== RUN   TestDockerDriver_OOMKilled
=== PAUSE TestDockerDriver_OOMKilled
=== CONT  TestDockerDriver_OOMKilled
    docker.go:36: Successfully connected to docker daemon running version 20.10.14
2022-07-28T14:31:33.877Z [WARN]  loader/init.go:224: plugin_loader: skipping external plugins since plugin_dir doesn't exist: plugin_dir=./plugins
--- PASS: TestDockerDriver_OOMKilled (2.43s)
PASS
ok      github.com/hashicorp/nomad/drivers/docker       2.451s
```
