### PR TITLE
deps: remove deprecated net/context

### DIFF
--- a/client/logmon/server.go
+++ b/client/logmon/server.go
@@ -1,9 +1,9 @@
 package logmon
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
-	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/nomad/client/logmon/proto"
 )
 

--- a/drivers/docker/docklog/docker_logger.go
+++ b/drivers/docker/docklog/docker_logger.go
@@ -1,6 +1,7 @@
 package docklog
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math/rand"
@@ -9,10 +10,10 @@ import (
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
-	hclog "github.com/hashicorp/go-hclog"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-multierror"
+
 	"github.com/hashicorp/nomad/client/lib/fifo"
-	"golang.org/x/net/context"
 )
 
 // DockerLogger is a small utility to forward logs from a docker container to a target

--- a/drivers/docker/docklog/docker_logger_test.go
+++ b/drivers/docker/docklog/docker_logger_test.go
@@ -2,6 +2,7 @@ package docklog
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"runtime"
@@ -9,12 +10,12 @@ import (
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/nomad/ci"
 	ctu "github.com/hashicorp/nomad/client/testutil"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/testutil"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func testContainerDetails() (image string, imageName string, imageTag string) {

--- a/drivers/docker/docklog/server.go
+++ b/drivers/docker/docklog/server.go
@@ -1,9 +1,10 @@
 package docklog
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
-	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-plugin"
+
 	"github.com/hashicorp/nomad/drivers/docker/docklog/proto"
 )
 

--- a/drivers/docker/handle.go
+++ b/drivers/docker/handle.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"runtime"
@@ -12,12 +13,12 @@ import (
 	"github.com/armon/circbuf"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/hashicorp/consul-template/signals"
-	hclog "github.com/hashicorp/go-hclog"
-	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-plugin"
+
 	"github.com/hashicorp/nomad/drivers/docker/docklog"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	pstructs "github.com/hashicorp/nomad/plugins/shared/structs"
-	"golang.org/x/net/context"
 )
 
 type taskHandle struct {

--- a/drivers/shared/executor/grpc_server.go
+++ b/drivers/shared/executor/grpc_server.go
@@ -1,18 +1,19 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 	"syscall"
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/hashicorp/nomad/drivers/shared/executor/proto"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	sproto "github.com/hashicorp/nomad/plugins/shared/structs/proto"
-	"golang.org/x/net/context"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type grpcExecutorServer struct {

--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,6 @@ require (
 	go.uber.org/goleak v1.1.12
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
 	golang.org/x/exp v0.0.0-20220609121020-a51bd0440498
-	golang.org/x/net v0.0.0-20220225172249-27dd8689420f
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65
@@ -264,6 +263,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/plugins/base/server.go
+++ b/plugins/base/server.go
@@ -1,11 +1,11 @@
 package base
 
 import (
+	"context"
 	"fmt"
 
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/nomad/plugins/base/proto"
-	"golang.org/x/net/context"
 )
 
 // basePluginServer wraps a base plugin and exposes it via gRPC.

--- a/plugins/device/server.go
+++ b/plugins/device/server.go
@@ -1,13 +1,14 @@
 package device
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
-	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-plugin"
+
 	"github.com/hashicorp/nomad/plugins/device/proto"
-	context "golang.org/x/net/context"
 )
 
 // devicePluginServer wraps a device plugin and exposes it via gRPC.

--- a/plugins/drivers/server.go
+++ b/plugins/drivers/server.go
@@ -1,19 +1,20 @@
 package drivers
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math"
 
 	"github.com/golang/protobuf/ptypes"
-	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-plugin"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers/proto"
 	dstructs "github.com/hashicorp/nomad/plugins/shared/structs"
 	sproto "github.com/hashicorp/nomad/plugins/shared/structs/proto"
-	context "golang.org/x/net/context"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type driverPluginServer struct {


### PR DESCRIPTION
The `golang.org/x/net/context` package was merged into the stdlib as of go
1.7. Update the imports to use the identical stdlib version. Clean up import
blocks for the impacted files to remove unnecessary package aliasing.

(Note we still have a transitive dependency, but removing our copy will help.)