### PR TITLE
docs: fix path for quota/usage API

### DIFF
--- a/website/content/api-docs/quotas.mdx
+++ b/website/content/api-docs/quotas.mdx
@@ -316,7 +316,7 @@ The table below shows this endpoint's support for
 
 ```shell-session
 $ curl \
-    https://localhost:4646/v1/quota/shared-quota
+    https://localhost:4646/v1/quota/usage/shared-quota
 ```
 
 ### Sample Response


### PR DESCRIPTION
The example path in the quota API docs doesn't match the path in the actual API (or the table above it).