### PR TITLE
nsd: add support for specifying check.method in nomad service checks

### DIFF
--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"crypto/sha512"
 	"fmt"
+	"net/http"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -715,4 +716,22 @@ func NewSafeTimer(duration time.Duration) (*time.Timer, StopFunc) {
 	}
 
 	return t, cancel
+}
+
+// IsMethodHTTP returns whether s is a known HTTP method, ignoring case.
+func IsMethodHTTP(s string) bool {
+	switch strings.ToUpper(s) {
+	case http.MethodGet:
+	case http.MethodHead:
+	case http.MethodPost:
+	case http.MethodPut:
+	case http.MethodPatch:
+	case http.MethodDelete:
+	case http.MethodConnect:
+	case http.MethodOptions:
+	case http.MethodTrace:
+	default:
+		return false
+	}
+	return true
 }

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -546,3 +546,31 @@ func Test_NewSafeTimer(t *testing.T) {
 		<-timer.C
 	})
 }
+
+func Test_IsMethodHTTP(t *testing.T) {
+	t.Run("is method", func(t *testing.T) {
+		cases := []string{
+			"GET", "Get", "get",
+			"HEAD", "Head", "head",
+			"POST", "Post", "post",
+			"PUT", "Put", "put",
+			"PATCH", "Patch", "patch",
+			"DELETE", "Delete", "delete",
+			"CONNECT", "Connect", "connect",
+			"OPTIONS", "Options", "options",
+			"TRACE", "Trace", "trace",
+		}
+		for _, tc := range cases {
+			result := IsMethodHTTP(tc)
+			must.True(t, result)
+		}
+	})
+
+	t.Run("is not method", func(t *testing.T) {
+		not := []string{"GETTER", "!GET", ""}
+		for _, tc := range not {
+			result := IsMethodHTTP(tc)
+			must.False(t, result)
+		}
+	})
+}

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -200,6 +200,7 @@ func (sc *ServiceCheck) Canonicalize(serviceName string) {
 		sc.Args = nil
 	}
 
+	// Ensure empty slices are nil
 	if len(sc.Header) == 0 {
 		sc.Header = nil
 	} else {
@@ -210,10 +211,12 @@ func (sc *ServiceCheck) Canonicalize(serviceName string) {
 		}
 	}
 
+	// Ensure a default name for the check
 	if sc.Name == "" {
 		sc.Name = fmt.Sprintf("service: %q check", serviceName)
 	}
 
+	// Ensure OnUpdate defaults to require_healthy (i.e. healthiness check)
 	if sc.OnUpdate == "" {
 		sc.OnUpdate = OnUpdateRequireHealthy
 	}
@@ -344,15 +347,16 @@ func (sc *ServiceCheck) validateNomad() error {
 	}
 
 	if sc.Type == "http" {
-		if sc.Method != "" && sc.Method != "GET" {
-			// unset turns into GET
-			return fmt.Errorf("http checks may only use GET method in Nomad services")
+		if sc.Method != "" && !helper.IsMethodHTTP(sc.Method) {
+			return fmt.Errorf("method type %q not supported in Nomad http check", sc.Method)
 		}
 
+		// todo(shoenig) support headers
 		if len(sc.Header) > 0 {
 			return fmt.Errorf("http checks may not set headers in Nomad services")
 		}
 
+		// todo(shoenig) support body
 		if len(sc.Body) > 0 {
 			return fmt.Errorf("http checks may not set Body in Nomad services")
 		}


### PR DESCRIPTION
Unblock `check.method` in service validation. Add tests around making sure this value gets plumbed through.

Part of https://github.com/hashicorp/nomad/issues/13945