### PR TITLE
core: add ACL role state schema and functionality.

### DIFF
--- a/helper/raftutil/msgtypes.go
+++ b/helper/raftutil/msgtypes.go
@@ -58,6 +58,8 @@ var msgTypeNames = map[structs.MessageType]string{
 	structs.SecureVariableDeleteRequestType:              "SecureVariableDeleteRequestType",
 	structs.RootKeyMetaUpsertRequestType:                 "RootKeyMetaUpsertRequestType",
 	structs.RootKeyMetaDeleteRequestType:                 "RootKeyMetaDeleteRequestType",
+	structs.ACLRolesUpsertRequestType:                    "ACLRolesUpsertRequestType",
+	structs.ACLRolesDeleteByIDRequestType:                "ACLRolesDeleteByIDRequestType",
 	structs.NamespaceUpsertRequestType:                   "NamespaceUpsertRequestType",
 	structs.NamespaceDeleteRequestType:                   "NamespaceDeleteRequestType",
 }

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -2893,6 +2893,43 @@ func TestFSM_SnapshotRestore_ServiceRegistrations(t *testing.T) {
 	require.ElementsMatch(t, restoredRegs, serviceRegs)
 }
 
+func TestFSM_SnapshotRestore_ACLRoles(t *testing.T) {
+	ci.Parallel(t)
+
+	// Create our initial FSM which will be snapshotted.
+	fsm := testFSM(t)
+	testState := fsm.State()
+
+	// Create the policies our ACL roles wants to link to.
+	policy1 := mock.ACLPolicy()
+	policy1.Name = "mocked-test-policy-1"
+	policy2 := mock.ACLPolicy()
+	policy2.Name = "mocked-test-policy-2"
+
+	require.NoError(t, testState.UpsertACLPolicies(
+		structs.MsgTypeTestSetup, 10, []*structs.ACLPolicy{policy1, policy2}))
+
+	// Generate and upsert some ACL roles.
+	aclRoles := []*structs.ACLRole{mock.ACLRole(), mock.ACLRole()}
+	require.NoError(t, testState.UpsertACLRoles(structs.MsgTypeTestSetup, 10, aclRoles))
+
+	// Perform a snapshot restore.
+	restoredFSM := testSnapshotRestore(t, fsm)
+	restoredState := restoredFSM.State()
+
+	// List the ACL roles from restored state and ensure everything is as
+	// expected.
+	iter, err := restoredState.GetACLRoles(memdb.NewWatchSet())
+	require.NoError(t, err)
+
+	var restoredACLRoles []*structs.ACLRole
+
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		restoredACLRoles = append(restoredACLRoles, raw.(*structs.ACLRole))
+	}
+	require.ElementsMatch(t, restoredACLRoles, aclRoles)
+}
+
 func TestFSM_ReconcileSummaries(t *testing.T) {
 	ci.Parallel(t)
 	// Add some state
@@ -3411,6 +3448,73 @@ func TestFSM_SnapshotRestore_SecureVariables(t *testing.T) {
 		restoredSVs = append(restoredSVs, raw.(*structs.SecureVariableEncrypted))
 	}
 	require.ElementsMatch(t, restoredSVs, svs)
+}
+
+func TestFSM_ApplyACLRolesUpsert(t *testing.T) {
+	ci.Parallel(t)
+	fsm := testFSM(t)
+
+	// Create the policies our ACL roles wants to link to.
+	policy1 := mock.ACLPolicy()
+	policy1.Name = "mocked-test-policy-1"
+	policy2 := mock.ACLPolicy()
+	policy2.Name = "mocked-test-policy-2"
+
+	require.NoError(t, fsm.State().UpsertACLPolicies(
+		structs.MsgTypeTestSetup, 10, []*structs.ACLPolicy{policy1, policy2}))
+
+	// Generate the upsert request and apply the change.
+	req := structs.ACLRolesUpsertRequest{
+		ACLRoles: []*structs.ACLRole{mock.ACLRole(), mock.ACLRole()},
+	}
+	buf, err := structs.Encode(structs.ACLRolesUpsertRequestType, req)
+	require.NoError(t, err)
+	require.Nil(t, fsm.Apply(makeLog(buf)))
+
+	// Read out both ACL roles and perform an equality check using the hash.
+	ws := memdb.NewWatchSet()
+	out, err := fsm.State().GetACLRoleByName(ws, req.ACLRoles[0].Name)
+	require.NoError(t, err)
+	require.Equal(t, req.ACLRoles[0].Hash, out.Hash)
+
+	out, err = fsm.State().GetACLRoleByName(ws, req.ACLRoles[1].Name)
+	require.NoError(t, err)
+	require.Equal(t, req.ACLRoles[1].Hash, out.Hash)
+}
+
+func TestFSM_ApplyACLRolesDeleteByID(t *testing.T) {
+	ci.Parallel(t)
+	fsm := testFSM(t)
+
+	// Create the policies our ACL roles wants to link to.
+	policy1 := mock.ACLPolicy()
+	policy1.Name = "mocked-test-policy-1"
+	policy2 := mock.ACLPolicy()
+	policy2.Name = "mocked-test-policy-2"
+
+	require.NoError(t, fsm.State().UpsertACLPolicies(
+		structs.MsgTypeTestSetup, 10, []*structs.ACLPolicy{policy1, policy2}))
+
+	// Generate and upsert two ACL roles.
+	aclRoles := []*structs.ACLRole{mock.ACLRole(), mock.ACLRole()}
+	require.NoError(t, fsm.State().UpsertACLRoles(structs.MsgTypeTestSetup, 10, aclRoles))
+
+	// Build and apply our message.
+	req := structs.ACLRolesDeleteByIDRequest{ACLRoleIDs: []string{aclRoles[0].ID, aclRoles[1].ID}}
+	buf, err := structs.Encode(structs.ACLRolesDeleteByIDRequestType, req)
+	require.NoError(t, err)
+	require.Nil(t, fsm.Apply(makeLog(buf)))
+
+	// List all ACL roles within state to ensure both have been removed.
+	ws := memdb.NewWatchSet()
+	iter, err := fsm.State().GetACLRoles(ws)
+	require.NoError(t, err)
+
+	var count int
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		count++
+	}
+	require.Equal(t, 0, count)
 }
 
 func TestFSM_ACLEvents(t *testing.T) {

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -2438,3 +2438,19 @@ func mockSecureVariableMetadata() structs.SecureVariableMetadata {
 	}
 	return out
 }
+
+func ACLRole() *structs.ACLRole {
+	role := structs.ACLRole{
+		ID:          uuid.Generate(),
+		Name:        fmt.Sprintf("acl-role-%s", uuid.Short()),
+		Description: "mocked-test-acl-role",
+		Policies: []*structs.ACLRolePolicyLink{
+			{Name: "mocked-test-policy-1"},
+			{Name: "mocked-test-policy-2"},
+		},
+		CreateIndex: 10,
+		ModifyIndex: 10,
+	}
+	role.SetHash()
+	return &role
+}

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -17,6 +17,7 @@ const (
 	TableSecureVariables       = "secure_variables"
 	TableSecureVariablesQuotas = "secure_variables_quota"
 	TableRootKeyMeta           = "secure_variables_root_key_meta"
+	TableACLRoles              = "acl_roles"
 )
 
 const (
@@ -29,6 +30,7 @@ const (
 	indexExpiresLocal  = "expires-local"
 	indexKeyID         = "key_id"
 	indexPath          = "path"
+	indexName          = "name"
 )
 
 var (
@@ -80,6 +82,7 @@ func init() {
 		secureVariablesTableSchema,
 		secureVariablesQuotasTableSchema,
 		secureVariablesRootKeyMetaSchema,
+		aclRolesTableSchema,
 	}...)
 }
 
@@ -1385,6 +1388,30 @@ func secureVariablesRootKeyMetaSchema() *memdb.TableSchema {
 				Indexer: &memdb.StringFieldIndex{
 					Field:     "KeyID",
 					Lowercase: true,
+				},
+			},
+		},
+	}
+}
+
+func aclRolesTableSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: TableACLRoles,
+		Indexes: map[string]*memdb.IndexSchema{
+			indexID: {
+				Name:         indexID,
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.StringFieldIndex{
+					Field: "ID",
+				},
+			},
+			indexName: {
+				Name:         indexName,
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.StringFieldIndex{
+					Field: "Name",
 				},
 			},
 		},

--- a/nomad/state/state_store_acl.go
+++ b/nomad/state/state_store_acl.go
@@ -88,8 +88,9 @@ func (s *StateStore) upsertACLRoleTxn(
 	}
 
 	// This validation also happens within the RPC handler, but Raft latency
-	// could mean that by the state call is invoked, another Raft update has
-	// deleted policies detailed in role. Therefore, check again.
+	// could mean that by the time the state call is invoked, another Raft
+	// update has deleted policies detailed in role. Therefore, check again
+	// while in our write txn.
 	if err := s.validateACLRolePolicyLinksTxn(txn, role); err != nil {
 		return false, err
 	}

--- a/nomad/state/state_store_acl.go
+++ b/nomad/state/state_store_acl.go
@@ -1,9 +1,11 @@
 package state
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 // ACLTokensByExpired returns an array accessor IDs of expired ACL tokens.
@@ -30,4 +32,198 @@ func expiresIndexName(global bool) string {
 		return indexExpiresGlobal
 	}
 	return indexExpiresLocal
+}
+
+// UpsertACLRoles is used to insert a number of ACL roles into the state store.
+// It uses a single write transaction for efficiency, however, any error means
+// no entries will be committed.
+func (s *StateStore) UpsertACLRoles(
+	msgType structs.MessageType, index uint64, roles []*structs.ACLRole) error {
+
+	// Grab a write transaction.
+	txn := s.db.WriteTxnMsgT(msgType, index)
+	defer txn.Abort()
+
+	// updated tracks whether any inserts have been made. This allows us to
+	// skip updating the index table if we do not need to.
+	var updated bool
+
+	// Iterate the array of roles. In the event of a single error, all inserts
+	// fail via the txn.Abort() defer.
+	for _, role := range roles {
+
+		roleUpdated, err := s.upsertACLRoleTxn(index, txn, role)
+		if err != nil {
+			return err
+		}
+
+		// Ensure we track whether any inserts have been made.
+		updated = updated || roleUpdated
+	}
+
+	// If we did not perform any inserts, exit early.
+	if !updated {
+		return nil
+	}
+
+	// Perform the index table update to mark the new insert.
+	if err := txn.Insert(tableIndex, &IndexEntry{TableACLRoles, index}); err != nil {
+		return fmt.Errorf("index update failed: %v", err)
+	}
+
+	return txn.Commit()
+}
+
+// upsertACLRoleTxn inserts a single ACL role into the state store using the
+// provided write transaction. It is the responsibility of the caller to update
+// the index table.
+func (s *StateStore) upsertACLRoleTxn(
+	index uint64, txn *txn, role *structs.ACLRole) (bool, error) {
+
+	// Ensure the role hash is not zero to provide defense in depth. This
+	// should be done outside the state store, so we do not spend time here
+	// and thus Raft, when it, can be avoided.
+	if len(role.Hash) == 0 {
+		role.SetHash()
+	}
+
+	// This validation also happens within the RPC handler, but Raft latency
+	// could mean that by the state call is invoked, another Raft update has
+	// deleted policies detailed in role. Therefore, check again.
+	if err := s.validateACLRolePolicyLinksTxn(txn, role); err != nil {
+		return false, err
+	}
+
+	existing, err := txn.First(TableACLRoles, indexID, role.ID)
+	if err != nil {
+		return false, fmt.Errorf("ACL role lookup failed: %v", err)
+	}
+
+	// Set up the indexes correctly to ensure existing indexes are maintained.
+	if existing != nil {
+		exist := existing.(*structs.ACLRole)
+		if exist.Equals(role) {
+			return false, nil
+		}
+		role.CreateIndex = exist.CreateIndex
+		role.ModifyIndex = index
+	} else {
+		role.CreateIndex = index
+		role.ModifyIndex = index
+	}
+
+	// Insert the role into the table.
+	if err := txn.Insert(TableACLRoles, role); err != nil {
+		return false, fmt.Errorf("ACL role insert failed: %v", err)
+	}
+	return true, nil
+}
+
+// ValidateACLRolePolicyLinks ensures all ACL policies linked to from the ACL
+// role exist within state.
+func (s *StateStore) ValidateACLRolePolicyLinks(role *structs.ACLRole) error {
+	txn := s.db.ReadTxn()
+	return s.validateACLRolePolicyLinksTxn(txn, role)
+}
+
+// validateACLRolePolicyLinksTxn is the same as ValidateACLRolePolicyLinks but
+// allows callers to pass their own transaction.
+func (s *StateStore) validateACLRolePolicyLinksTxn(txn *txn, role *structs.ACLRole) error {
+	for _, policyLink := range role.Policies {
+		_, existing, err := txn.FirstWatch("acl_policy", indexID, policyLink.Name)
+		if err != nil {
+			return fmt.Errorf("ACL policy lookup failed: %v", err)
+		}
+		if existing == nil {
+			return errors.New("ACL policy not found")
+		}
+	}
+	return nil
+}
+
+// DeleteACLRolesByID is responsible for batch deleting ACL roles based on
+// their ID. It uses a single write transaction for efficiency, however, any
+// error means no entries will be committed. An error is produced if a role is
+// not found within state which has been passed within the array.
+func (s *StateStore) DeleteACLRolesByID(
+	msgType structs.MessageType, index uint64, roleIDs []string) error {
+
+	txn := s.db.WriteTxnMsgT(msgType, index)
+	defer txn.Abort()
+
+	for _, roleID := range roleIDs {
+
+		existing, err := txn.First(TableACLRoles, indexID, roleID)
+		if err != nil {
+			return fmt.Errorf("ACL role lookup failed: %v", err)
+		}
+		if existing == nil {
+			return errors.New("ACL role not found")
+		}
+
+		// Delete the existing entry from the table.
+		if err := txn.Delete(TableACLRoles, existing); err != nil {
+			return fmt.Errorf("ACL role deletion failed: %v", err)
+		}
+	}
+
+	// Update the index table to indicate an update has occurred.
+	if err := txn.Insert(tableIndex, &IndexEntry{TableACLRoles, index}); err != nil {
+		return fmt.Errorf("index update failed: %v", err)
+	}
+
+	return txn.Commit()
+}
+
+// GetACLRoles returns an iterator that contains all ACL roles stored within
+// state.
+func (s *StateStore) GetACLRoles(ws memdb.WatchSet) (memdb.ResultIterator, error) {
+	txn := s.db.ReadTxn()
+
+	// Walk the entire table to get all ACL roles.
+	iter, err := txn.Get(TableACLRoles, indexID)
+	if err != nil {
+		return nil, fmt.Errorf("ACL role lookup failed: %v", err)
+	}
+	ws.Add(iter.WatchCh())
+
+	return iter, nil
+}
+
+// GetACLRoleByID returns a single ACL role specified by the input ID. The role
+// object will be nil, if no matching entry was found; it is the responsibility
+// of the caller to check for this.
+func (s *StateStore) GetACLRoleByID(ws memdb.WatchSet, roleID string) (*structs.ACLRole, error) {
+	txn := s.db.ReadTxn()
+
+	// Perform the ACL role lookup using the "id" index.
+	watchCh, existing, err := txn.FirstWatch(TableACLRoles, indexID, roleID)
+	if err != nil {
+		return nil, fmt.Errorf("ACL role lookup failed: %v", err)
+	}
+	ws.Add(watchCh)
+
+	if existing != nil {
+		return existing.(*structs.ACLRole), nil
+	}
+	return nil, nil
+}
+
+// GetACLRoleByName returns a single ACL role specified by the input name. The
+// role object will be nil, if no matching entry was found; it is the
+// responsibility of the caller to check for this.
+func (s *StateStore) GetACLRoleByName(ws memdb.WatchSet, roleName string) (*structs.ACLRole, error) {
+	txn := s.db.ReadTxn()
+
+	// Perform the ACL role lookup using the "name" index.
+	watchCh, existing, err := txn.FirstWatch(TableACLRoles, indexName, roleName)
+	if err != nil {
+		return nil, fmt.Errorf("ACL role lookup failed: %v", err)
+	}
+	ws.Add(watchCh)
+
+	if existing != nil {
+		return existing.(*structs.ACLRole), nil
+	}
+	return nil, nil
 }

--- a/nomad/state/state_store_acl_test.go
+++ b/nomad/state/state_store_acl_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
 
@@ -147,4 +148,298 @@ func Test_expiresIndexName(t *testing.T) {
 			require.Equal(t, tc.expectedOutput, actualOutput)
 		})
 	}
+}
+
+func TestStateStore_UpsertACLRoles(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Generate a mocked ACL role for testing and attempt to upsert this
+	// straight into state. It should fail because the ACL policies do not
+	// exist.
+	mockedACLRoles := []*structs.ACLRole{mock.ACLRole()}
+	err := testState.UpsertACLRoles(structs.MsgTypeTestSetup, 10, mockedACLRoles)
+	require.ErrorContains(t, err, "policy not found")
+
+	// Create the policies our ACL roles wants to link to and then try the
+	// upsert again.
+	policy1 := mock.ACLPolicy()
+	policy1.Name = "mocked-test-policy-1"
+	policy2 := mock.ACLPolicy()
+	policy2.Name = "mocked-test-policy-2"
+
+	require.NoError(t, testState.UpsertACLPolicies(
+		structs.MsgTypeTestSetup, 10, []*structs.ACLPolicy{policy1, policy2}))
+	require.NoError(t, testState.UpsertACLRoles(structs.MsgTypeTestSetup, 20, mockedACLRoles))
+
+	// Check that the index for the table was modified as expected.
+	initialIndex, err := testState.Index(TableACLRoles)
+	require.NoError(t, err)
+	must.Eq(t, 20, initialIndex)
+
+	// List all the ACL roles in the table, so we can perform a number of tests
+	// on the return array.
+	ws := memdb.NewWatchSet()
+	iter, err := testState.GetACLRoles(ws)
+	require.NoError(t, err)
+
+	// Count how many table entries we have, to ensure it is the expected
+	// number.
+	var count int
+
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		count++
+
+		// Ensure the create and modify indexes are populated correctly.
+		aclRole := raw.(*structs.ACLRole)
+		must.Eq(t, 20, aclRole.CreateIndex)
+		must.Eq(t, 20, aclRole.ModifyIndex)
+	}
+	require.Equal(t, 1, count, "incorrect number of ACL roles found")
+
+	// Try writing the same ACL roles to state which should not result in an
+	// update to the table index.
+	require.NoError(t, testState.UpsertACLRoles(structs.MsgTypeTestSetup, 30, mockedACLRoles))
+	reInsertActualIndex, err := testState.Index(TableACLRoles)
+	require.NoError(t, err)
+	must.Eq(t, 20, reInsertActualIndex)
+
+	// Make a change to one of the ACL roles and ensure this update is accepted
+	// and the table index is updated.
+	updatedMockedACLRole := mockedACLRoles[0].Copy()
+	updatedMockedACLRole.Policies = []*structs.ACLRolePolicyLink{{Name: "mocked-test-policy-1"}}
+	updatedMockedACLRole.SetHash()
+	require.NoError(t, testState.UpsertACLRoles(
+		structs.MsgTypeTestSetup, 30, []*structs.ACLRole{updatedMockedACLRole}))
+
+	// Check that the index for the table was modified as expected.
+	updatedIndex, err := testState.Index(TableACLRoles)
+	require.NoError(t, err)
+	must.Eq(t, 30, updatedIndex)
+
+	// List the ACL roles in state.
+	iter, err = testState.GetACLRoles(ws)
+	require.NoError(t, err)
+
+	// Count how many table entries we have, to ensure it is the expected
+	// number.
+	count = 0
+
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		count++
+
+		// Ensure the create and modify indexes are populated correctly.
+		aclRole := raw.(*structs.ACLRole)
+		must.Eq(t, 20, aclRole.CreateIndex)
+		must.Eq(t, 30, aclRole.ModifyIndex)
+	}
+	require.Equal(t, 1, count, "incorrect number of ACL roles found")
+}
+
+func TestStateStore_ValidateACLRolePolicyLinks(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Create our mocked role which includes two ACL policy links.
+	mockedACLRoles := []*structs.ACLRole{mock.ACLRole()}
+
+	// This should error as no policies exist within state.
+	err := testState.UpsertACLRoles(structs.MsgTypeTestSetup, 10, mockedACLRoles)
+	require.ErrorContains(t, err, "ACL policy not found")
+
+	// Upsert one ACL policy and retry the role which should still fail.
+	policy1 := mock.ACLPolicy()
+	policy1.Name = "mocked-test-policy-1"
+
+	require.NoError(t, testState.UpsertACLPolicies(structs.MsgTypeTestSetup, 10, []*structs.ACLPolicy{policy1}))
+	err = testState.UpsertACLRoles(structs.MsgTypeTestSetup, 20, mockedACLRoles)
+	require.ErrorContains(t, err, "ACL policy not found")
+
+	// Upsert the second ACL policy. The ACL role should now upsert into state
+	// without error.
+	policy2 := mock.ACLPolicy()
+	policy2.Name = "mocked-test-policy-2"
+
+	require.NoError(t, testState.UpsertACLPolicies(structs.MsgTypeTestSetup, 20, []*structs.ACLPolicy{policy2}))
+	require.NoError(t, testState.UpsertACLRoles(structs.MsgTypeTestSetup, 30, mockedACLRoles))
+}
+
+func TestStateStore_DeleteACLRolesByID(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Create the policies our ACL roles wants to link to.
+	policy1 := mock.ACLPolicy()
+	policy1.Name = "mocked-test-policy-1"
+	policy2 := mock.ACLPolicy()
+	policy2.Name = "mocked-test-policy-2"
+
+	require.NoError(t, testState.UpsertACLPolicies(
+		structs.MsgTypeTestSetup, 10, []*structs.ACLPolicy{policy1, policy2}))
+
+	// Generate a some mocked ACL roles for testing and upsert these straight
+	// into state.
+	mockedACLRoles := []*structs.ACLRole{mock.ACLRole(), mock.ACLRole()}
+	require.NoError(t, testState.UpsertACLRoles(structs.MsgTypeTestSetup, 10, mockedACLRoles))
+
+	// Try and delete a role using a name that doesn't exist. This should
+	// return an error and not change the index for the table.
+	err := testState.DeleteACLRolesByID(structs.MsgTypeTestSetup, 20, []string{"not-a-role"})
+	require.ErrorContains(t, err, "ACL role not found")
+
+	tableIndex, err := testState.Index(TableACLRoles)
+	require.NoError(t, err)
+	must.Eq(t, 10, tableIndex)
+
+	// Delete one of the previously upserted ACL roles. This should succeed
+	// and modify the table index.
+	err = testState.DeleteACLRolesByID(structs.MsgTypeTestSetup, 20, []string{mockedACLRoles[0].ID})
+	require.NoError(t, err)
+
+	tableIndex, err = testState.Index(TableACLRoles)
+	require.NoError(t, err)
+	must.Eq(t, 20, tableIndex)
+
+	// List the ACL roles and ensure we now only have one present and that it
+	// is the one we expect.
+	ws := memdb.NewWatchSet()
+	iter, err := testState.GetACLRoles(ws)
+	require.NoError(t, err)
+
+	var aclRoles []*structs.ACLRole
+
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		aclRoles = append(aclRoles, raw.(*structs.ACLRole))
+	}
+
+	require.Len(t, aclRoles, 1, "incorrect number of ACL roles found")
+	require.True(t, aclRoles[0].Equals(mockedACLRoles[1]))
+
+	// Delete the final remaining ACL role. This should succeed and modify the
+	// table index.
+	err = testState.DeleteACLRolesByID(structs.MsgTypeTestSetup, 30, []string{mockedACLRoles[1].ID})
+	require.NoError(t, err)
+
+	tableIndex, err = testState.Index(TableACLRoles)
+	require.NoError(t, err)
+	must.Eq(t, 30, tableIndex)
+
+	// List the ACL roles and ensure we have zero entries.
+	iter, err = testState.GetACLRoles(ws)
+	require.NoError(t, err)
+
+	aclRoles = []*structs.ACLRole{}
+
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		aclRoles = append(aclRoles, raw.(*structs.ACLRole))
+	}
+	require.Len(t, aclRoles, 0, "incorrect number of ACL roles found")
+}
+
+func TestStateStore_GetACLRoles(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Create the policies our ACL roles wants to link to.
+	policy1 := mock.ACLPolicy()
+	policy1.Name = "mocked-test-policy-1"
+	policy2 := mock.ACLPolicy()
+	policy2.Name = "mocked-test-policy-2"
+
+	require.NoError(t, testState.UpsertACLPolicies(
+		structs.MsgTypeTestSetup, 10, []*structs.ACLPolicy{policy1, policy2}))
+
+	// Generate a some mocked ACL roles for testing and upsert these straight
+	// into state.
+	mockedACLRoles := []*structs.ACLRole{mock.ACLRole(), mock.ACLRole()}
+	require.NoError(t, testState.UpsertACLRoles(structs.MsgTypeTestSetup, 10, mockedACLRoles))
+
+	// List the ACL roles and ensure they are exactly as we expect.
+	ws := memdb.NewWatchSet()
+	iter, err := testState.GetACLRoles(ws)
+	require.NoError(t, err)
+
+	var aclRoles []*structs.ACLRole
+
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		aclRoles = append(aclRoles, raw.(*structs.ACLRole))
+	}
+
+	expected := mockedACLRoles
+	for i := range expected {
+		expected[i].CreateIndex = 10
+		expected[i].ModifyIndex = 10
+	}
+
+	require.ElementsMatch(t, aclRoles, expected)
+}
+
+func TestStateStore_GetACLRoleByID(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Create the policies our ACL roles wants to link to.
+	policy1 := mock.ACLPolicy()
+	policy1.Name = "mocked-test-policy-1"
+	policy2 := mock.ACLPolicy()
+	policy2.Name = "mocked-test-policy-2"
+
+	require.NoError(t, testState.UpsertACLPolicies(
+		structs.MsgTypeTestSetup, 10, []*structs.ACLPolicy{policy1, policy2}))
+
+	// Generate a some mocked ACL roles for testing and upsert these straight
+	// into state.
+	mockedACLRoles := []*structs.ACLRole{mock.ACLRole(), mock.ACLRole()}
+	require.NoError(t, testState.UpsertACLRoles(structs.MsgTypeTestSetup, 10, mockedACLRoles))
+
+	ws := memdb.NewWatchSet()
+
+	// Try reading an ACL role that does not exist.
+	aclRole, err := testState.GetACLRoleByID(ws, "not-a-role")
+	require.NoError(t, err)
+	require.Nil(t, aclRole)
+
+	// Read the two ACL roles that we should find.
+	aclRole, err = testState.GetACLRoleByID(ws, mockedACLRoles[0].ID)
+	require.NoError(t, err)
+	require.Equal(t, mockedACLRoles[0], aclRole)
+
+	aclRole, err = testState.GetACLRoleByID(ws, mockedACLRoles[1].ID)
+	require.NoError(t, err)
+	require.Equal(t, mockedACLRoles[1], aclRole)
+}
+
+func TestStateStore_GetACLRoleByName(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Create the policies our ACL roles wants to link to.
+	policy1 := mock.ACLPolicy()
+	policy1.Name = "mocked-test-policy-1"
+	policy2 := mock.ACLPolicy()
+	policy2.Name = "mocked-test-policy-2"
+
+	require.NoError(t, testState.UpsertACLPolicies(
+		structs.MsgTypeTestSetup, 10, []*structs.ACLPolicy{policy1, policy2}))
+
+	// Generate a some mocked ACL roles for testing and upsert these straight
+	// into state.
+	mockedACLRoles := []*structs.ACLRole{mock.ACLRole(), mock.ACLRole()}
+	require.NoError(t, testState.UpsertACLRoles(structs.MsgTypeTestSetup, 10, mockedACLRoles))
+
+	ws := memdb.NewWatchSet()
+
+	// Try reading an ACL role that does not exist.
+	aclRole, err := testState.GetACLRoleByName(ws, "not-a-role")
+	require.NoError(t, err)
+	require.Nil(t, aclRole)
+
+	// Read the two ACL roles that we should find.
+	aclRole, err = testState.GetACLRoleByName(ws, mockedACLRoles[0].Name)
+	require.NoError(t, err)
+	require.Equal(t, mockedACLRoles[0], aclRole)
+
+	aclRole, err = testState.GetACLRoleByName(ws, mockedACLRoles[1].Name)
+	require.NoError(t, err)
+	require.Equal(t, mockedACLRoles[1], aclRole)
 }

--- a/nomad/state/state_store_restore.go
+++ b/nomad/state/state_store_restore.go
@@ -224,3 +224,12 @@ func (r *StateRestore) RootKeyMetaRestore(quota *structs.RootKeyMeta) error {
 	}
 	return nil
 }
+
+// ACLRoleRestore is used to restore a single ACL role into the acl_roles
+// table.
+func (r *StateRestore) ACLRoleRestore(aclRole *structs.ACLRole) error {
+	if err := r.txn.Insert(TableACLRoles, aclRole); err != nil {
+		return fmt.Errorf("ACL role insert failed: %v", err)
+	}
+	return nil
+}

--- a/nomad/state/state_store_restore_test.go
+++ b/nomad/state/state_store_restore_test.go
@@ -604,3 +604,26 @@ func TestStateStore_SecureVariablesRestore(t *testing.T) {
 		require.Equal(t, svs[i], out)
 	}
 }
+
+func TestStateStore_ACLRoleRestore(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Set up our test registrations and index.
+	expectedIndex := uint64(13)
+	aclRole := mock.ACLRole()
+	aclRole.CreateIndex = expectedIndex
+	aclRole.ModifyIndex = expectedIndex
+
+	restore, err := testState.Restore()
+	require.NoError(t, err)
+	require.NoError(t, restore.ACLRoleRestore(aclRole))
+	require.NoError(t, restore.Commit())
+
+	// Check the state is now populated as we expect and that we can find the
+	// restored registrations.
+	ws := memdb.NewWatchSet()
+	out, err := testState.GetACLRoleByName(ws, aclRole.Name)
+	require.NoError(t, err)
+	require.Equal(t, aclRole, out)
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -113,6 +113,8 @@ const (
 	SecureVariableDeleteRequestType              MessageType = 51
 	RootKeyMetaUpsertRequestType                 MessageType = 52
 	RootKeyMetaDeleteRequestType                 MessageType = 53
+	ACLRolesUpsertRequestType                    MessageType = 54
+	ACLRolesDeleteByIDRequestType                MessageType = 55
 
 	// Namespace types were moved from enterprise and therefore start at 64
 	NamespaceUpsertRequestType MessageType = 64


### PR DESCRIPTION
This commit includes the new state schema for ACL roles along with
state interaction functions for CRUD actions.

The change also includes snapshot persist and restore
functionality and the addition of FSM messages for Raft updates
which will come via RPC endpoints.

related: https://github.com/hashicorp/nomad/issues/13120
targets: feature branch