### PR TITLE
refact: default dropdown option based on model

### DIFF
--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -46,7 +46,7 @@ export default class SecureVariableFormComponent extends Component {
 
     // Set first namespace option
     if (options.length) {
-      this.variableNamespace = options[0].key;
+      this.variableNamespace = this.args.model.namespace;
     }
   }
 


### PR DESCRIPTION
Closes [#13855](https://github.com/hashicorp/nomad/issues/13855).

Sets the default dropdown option when the component is invoked to be based on the `Variable` model.