### PR TITLE
[ui] Variables: time formats in mirage mocks should match server-returned microsecond time

### DIFF
--- a/ui/mirage/factories/variable.js
+++ b/ui/mirage/factories/variable.js
@@ -9,8 +9,8 @@ export default Factory.extend({
   namespace: null,
   createdIndex: 100,
   modifiedIndex: 100,
-  createTime: () => faker.date.past(15),
-  modifyTime: () => faker.date.recent(1),
+  createTime: () => faker.date.past(15) * 1000000,
+  modifyTime: () => faker.date.recent(1) * 1000000,
   items() {
     return (
       this.Items || {


### PR DESCRIPTION
Resolves #13853