### PR TITLE
Revert "Backport of test: disable docker OOM detection test on cgroups v2 into release/1.1.x"

### DIFF
--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -2366,9 +2366,9 @@ func TestDockerDriver_OOMKilled(t *testing.T) {
 	ci.Parallel(t)
 	testutil.DockerCompatible(t)
 
-	// waiting on upstream fix for cgroups v2
-	// see https://github.com/hashicorp/nomad/issues/13119
-	testutil.CgroupsCompatibleV1(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not support OOM Killer")
+	}
 
 	taskCfg := newTaskConfig("", []string{"sh", "-c", `sleep 2 && x=a && while true; do x="$x$x"; done`})
 	task := &drivers.TaskConfig{


### PR DESCRIPTION
Reverts hashicorp/nomad#13985