### PR TITLE
New variable creation adds the first namespace in your available list at variable creation time

### DIFF
--- a/.changelog/13991.txt
+++ b/.changelog/13991.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: when creating a secure variable, check against your namespaces rather than assuming default
+```

--- a/ui/app/routes/variables/new.js
+++ b/ui/app/routes/variables/new.js
@@ -1,8 +1,12 @@
 import Route from '@ember/routing/route';
 
 export default class VariablesNewRoute extends Route {
-  model(params) {
-    return this.store.createRecord('variable', { path: params.path });
+  async model(params) {
+    const namespaces = await this.store.peekAll('namespace');
+    return this.store.createRecord('variable', {
+      path: params.path,
+      namespace: namespaces.objectAt(0)?.id,
+    });
   }
   resetController(controller, isExiting) {
     // If the user navigates away from /new, clear the path


### PR DESCRIPTION
Resolves an issue where you don't have access to the `default` namespace but do have the ability to create variables on one of your other namespaces.

This is a very basic fix that prevents most cases from erroring on save, or showing a problem form state (see below image). A more robust fix would be to parse through your policy to see which namespaces have `write` access for Secure Variables. 

![image](https://user-images.githubusercontent.com/713991/182682507-bf3b9d64-3466-4e15-a47f-06cd761b55c7.png)
