### PR TITLE
[ui] "can list variables" capability refactor

### DIFF
--- a/.changelog/13996.txt
+++ b/.changelog/13996.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: when determining whether to let a user see Secure Variables, check against all paths in all namespaces.
+```

--- a/.changelog/13996.txt
+++ b/.changelog/13996.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-ui: when determining whether to let a user see Secure Variables, check against all paths in all namespaces.
-```

--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { computed, get } from '@ember/object';
 import { or } from '@ember/object/computed';
 import AbstractAbility from './abstract';
@@ -40,8 +41,46 @@ export default class Variable extends AbstractAbility {
 
   @computed('rulesForNamespace.@each.capabilities')
   get policiesSupportVariableView() {
-    return this.rulesForNamespace.some((rules) => {
-      return get(rules, 'SecureVariables');
+    return this.policyNamespacesIncludeSecureVariablesCapabilities(
+      this.token.selfTokenPolicies,
+      ['list', 'read', 'write', 'destroy']
+    );
+  }
+
+  /**
+   *
+   * Map to your policy's namespaces,
+   * and each of their SecureVariables blocks' paths,
+   * and each of their capabilities.
+   * Then, check to see if any of the permissions you're looking for
+   * are contained within at least one of them.
+   *
+   * @param {Object} policies
+   * @param {string[]} capabilities
+   * @returns {boolean}
+   */
+  policyNamespacesIncludeSecureVariablesCapabilities(
+    policies = [],
+    capabilities = []
+  ) {
+    const namespacesWithSecureVariableCapabilities = policies
+      .toArray()
+      .map((policy) => get(policy, 'rulesJSON.Namespaces'))
+      .flat()
+      .map((namespace = {}) => {
+        return namespace.SecureVariables?.Paths;
+      })
+      .flat()
+      .compact()
+      .map((secVarsBlock = {}) => {
+        return secVarsBlock.Capabilities;
+      })
+      .flat()
+      .compact();
+
+    // Check for requested permissions
+    return namespacesWithSecureVariableCapabilities.some((abilityList) => {
+      return capabilities.includes(abilityList);
     });
   }
 

--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -39,7 +39,7 @@ export default class Variable extends AbstractAbility {
   )
   canDestroy;
 
-  @computed('rulesForNamespace.@each.capabilities', 'token.selfTokenPolicies')
+  @computed('token.selfTokenPolicies')
   get policiesSupportVariableList() {
     return this.policyNamespacesIncludeSecureVariablesCapabilities(
       this.token.selfTokenPolicies,

--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -21,7 +21,7 @@ export default class Variable extends AbstractAbility {
   @or(
     'bypassAuthorization',
     'selfTokenIsManagement',
-    'policiesSupportVariableView'
+    'policiesSupportVariableList'
   )
   canList;
 
@@ -39,8 +39,8 @@ export default class Variable extends AbstractAbility {
   )
   canDestroy;
 
-  @computed('rulesForNamespace.@each.capabilities')
-  get policiesSupportVariableView() {
+  @computed('rulesForNamespace.@each.capabilities', 'token.selfTokenPolicies')
+  get policiesSupportVariableList() {
     return this.policyNamespacesIncludeSecureVariablesCapabilities(
       this.token.selfTokenPolicies,
       ['list', 'read', 'write', 'destroy']

--- a/ui/tests/unit/abilities/variable-test.js
+++ b/ui/tests/unit/abilities/variable-test.js
@@ -60,9 +60,7 @@ module('Unit | Ability | variable', function (hooks) {
                   Name: 'default',
                   Capabilities: [],
                   SecureVariables: {
-                    'Path "*"': {
-                      Capabilities: ['list'],
-                    },
+                    Paths: [{ Capabilities: ['list'], PathSpec: '*' }],
                   },
                 },
               ],
@@ -76,7 +74,7 @@ module('Unit | Ability | variable', function (hooks) {
       assert.ok(this.ability.canList);
     });
 
-    test('it permits listing variables when token has SecureVariables alone in its rules', function (assert) {
+    test('it does not permit listing variables when token has SecureVariables alone in its rules', function (assert) {
       const mockToken = Service.extend({
         aclEnabled: true,
         selfToken: { type: 'client' },
@@ -88,6 +86,123 @@ module('Unit | Ability | variable', function (hooks) {
                   Name: 'default',
                   Capabilities: [],
                   SecureVariables: {},
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+
+      assert.notOk(this.ability.canList);
+    });
+
+    test('it does not permit listing variables when token has a null SecureVariables block', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: null,
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+
+      assert.notOk(this.ability.canList);
+    });
+
+    test('it does not permit listing variables when token has a SecureVariables block where paths are without capabilities', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: {
+                    Paths: [
+                      { Capabilities: [], PathSpec: '*' },
+                      { Capabilities: [], PathSpec: 'foo' },
+                      { Capabilities: [], PathSpec: 'foo/bar' },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+
+      assert.notOk(this.ability.canList);
+    });
+
+    test('it does not permit listing variables when token has no SecureVariables block', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      this.owner.register('service:token', mockToken);
+
+      assert.notOk(this.ability.canList);
+    });
+
+    test('it permits listing variables when token multiple namespaces, only one of which having a SecureVariables block', function (assert) {
+      const mockToken = Service.extend({
+        aclEnabled: true,
+        selfToken: { type: 'client' },
+        selfTokenPolicies: [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: 'default',
+                  Capabilities: [],
+                  SecureVariables: null,
+                },
+                {
+                  Name: 'nonsense',
+                  Capabilities: [],
+                  SecureVariables: {
+                    Paths: [{ Capabilities: [], PathSpec: '*' }],
+                  },
+                },
+                {
+                  Name: 'shenanigans',
+                  Capabilities: [],
+                  SecureVariables: {
+                    Paths: [
+                      { Capabilities: ['list'], PathSpec: 'foo/bar/baz' },
+                    ],
+                  },
                 },
               ],
             },


### PR DESCRIPTION
In order to determine if you should list variables / be able to access the variables route at all, check against all your policies' namespaces' secvars' paths' capabilties to see if any of them contain `write`, `read`, `list`, or `destroy` capabilities (in other words, any of the possible capabilities).

If any of your paths, from within any of your namespaces' SecureVariables blocks, contains any of those abilities, you get a link to the route in your nav.

Created a generic lookup function to pave the way for future lookups along the lines of `can view variable` etc.