### PR TITLE
template: set default UID/GID to -1

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -838,10 +838,10 @@ func (tmpl *Template) Canonicalize() {
 		tmpl.Perms = stringToPtr("0644")
 	}
 	if tmpl.Uid == nil {
-		tmpl.Uid = intToPtr(0)
+		tmpl.Uid = intToPtr(-1)
 	}
 	if tmpl.Gid == nil {
-		tmpl.Gid = intToPtr(0)
+		tmpl.Gid = intToPtr(-1)
 	}
 	if tmpl.LeftDelim == nil {
 		tmpl.LeftDelim = stringToPtr("{{")

--- a/jobspec/parse_task.go
+++ b/jobspec/parse_task.go
@@ -462,8 +462,8 @@ func parseTemplates(result *[]*api.Template, list *ast.ObjectList) error {
 			ChangeMode: stringToPtr("restart"),
 			Splay:      timeToPtr(5 * time.Second),
 			Perms:      stringToPtr("0644"),
-			Uid:        intToPtr(0),
-			Gid:        intToPtr(0),
+			Uid:        intToPtr(-1),
+			Gid:        intToPtr(-1),
 		}
 
 		dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{

--- a/jobspec2/parse_job.go
+++ b/jobspec2/parse_job.go
@@ -108,10 +108,10 @@ func normalizeTemplates(templates []*api.Template) {
 			t.Perms = stringToPtr("0644")
 		}
 		if t.Uid == nil {
-			t.Uid = intToPtr(0)
+			t.Uid = intToPtr(-1)
 		}
 		if t.Gid == nil {
-			t.Gid = intToPtr(0)
+			t.Gid = intToPtr(-1)
 		}
 		if t.Splay == nil {
 			t.Splay = durationToPtr(5 * time.Second)

--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -84,19 +84,21 @@ refer to the [Learn Go Template Syntax][gt_learn] Learn guide.
 - `perms` `(string: "644")` - Specifies the rendered template's permissions.
   File permissions are given as octal of the Unix file permissions `rwxrwxrwx`.
 
-- `uid` `(int: 0)` - Specifies the rendered template owner's user ID.
-  
-  ~> **Caveat:** Works only on Unix-based systems. Be careful when using
-  containerized drivers, suck as `docker` or `podman`, as groups and users
-  inside the container may have different IDs than on the host system. This
-  feature will also **not** work with Docker Desktop. 
-
-- `gid` `(int: 0)` - Specifies the rendered template owner's group ID.
+- `uid` `(int: -1)` - Specifies the rendered template owner's user ID. Negative
+  values will use the ID of the Nomad agent user.
 
   ~> **Caveat:** Works only on Unix-based systems. Be careful when using
   containerized drivers, suck as `docker` or `podman`, as groups and users
   inside the container may have different IDs than on the host system. This
-  feature will also **not** work with Docker Desktop. 
+  feature will also **not** work with Docker Desktop.
+
+- `gid` `(int: -1)` - Specifies the rendered template owner's group ID.
+  Negative values will use the ID of the Nomad agent group.
+
+  ~> **Caveat:** Works only on Unix-based systems. Be careful when using
+  containerized drivers, suck as `docker` or `podman`, as groups and users
+  inside the container may have different IDs than on the host system. This
+  feature will also **not** work with Docker Desktop.
 
 - `right_delimiter` `(string: "}}")` - Specifies the right delimiter to use in the
   template. The default is "}}" for some templates, it may be easier to use a


### PR DESCRIPTION
UID/GID 0 is usually reserved for the root user/group. While Nomad
clients are expected to run as root it may not always be the case.

Setting these values as -1 if not defined will fallback to the pervious
behaviour of not attempting to set file ownership and use whatever
UID/GID the Nomad agent is running as. It will also keep backwards
compatibility, which is specially important for platforms where this
feature is not supported, like Windows.