### PR TITLE
docs: remove link to HCL2 `timestamp` function

### DIFF
--- a/website/content/docs/job-specification/hcl2/functions/datetime/formatdate.mdx
+++ b/website/content/docs/job-specification/hcl2/functions/datetime/formatdate.mdx
@@ -102,5 +102,3 @@ configuration as needed:
 
 - [`format`](/docs/job-specification/hcl2/functions/string/format) is a more general formatting function for arbitrary
   data.
-- [`timestamp`](/docs/job-specification/hcl2/functions/datetime/timestamp) returns the current date and time in a format
-  suitable for input to `formatdate`.


### PR DESCRIPTION
The `timestamp` HCL2 function was never part of the set of supported
functions.