### PR TITLE
qemu: restore monitor socket path

### DIFF
--- a/.changelog/14000.txt
+++ b/.changelog/14000.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+qemu: restore the monitor socket path when restoring a QEMU task.
+```

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -304,9 +305,19 @@ func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 		return fmt.Errorf("failed to reattach to executor: %v", err)
 	}
 
+	// Try to restore monitor socket path.
+	taskDir := filepath.Join(handle.Config.AllocDir, handle.Config.Name)
+	monitorPath := filepath.Join(taskDir, qemuMonitorSocketName)
+	if _, err := os.Stat(monitorPath); err == nil {
+		d.logger.Debug("found existing monitor socket", "monitor", monitorPath)
+	} else {
+		monitorPath = ""
+	}
+
 	h := &taskHandle{
 		exec:         execImpl,
 		pid:          taskState.Pid,
+		monitorPath:  monitorPath,
 		pluginClient: pluginClient,
 		taskConfig:   taskState.TaskConfig,
 		procState:    drivers.TaskStateRunning,


### PR DESCRIPTION
When a QEMU task is recovered the monitor socket path was not being
restored into the task handler, so the `graceful_shutdown` configuration
was effectively ignored if the client restarted.