### PR TITLE
Use badge for <sup> tags in nav data JSON files

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1543,7 +1543,12 @@
             "href": "/plugins/drivers/community/pot"
           },
           {
-            "title": "Rkt <sup>Deprecated</sup> ",
+            "title": "Rkt",
+            "badge": {
+              "text": "Deprecated",
+              "type": "outlined",
+              "color": "neutral"
+            },
             "href": "/plugins/drivers/community/rkt"
           },
           {
@@ -1598,7 +1603,12 @@
             "href": "/plugins/devices/nvidia"
           },
           {
-            "title": "USB <sup>Beta</sup>",
+            "title": "USB",
+            "badge": {
+              "text": "Beta",
+              "type": "outlined",
+              "color": "neutral"
+            },
             "href": "/plugins/devices/community/usb"
           }
         ]

--- a/website/data/plugins-nav-data.json
+++ b/website/data/plugins-nav-data.json
@@ -42,7 +42,12 @@
             "path": "drivers/community/pot"
           },
           {
-            "title": "Rkt <sup>Deprecated</sup> ",
+            "title": "Rkt",
+            "badge": {
+              "text": "Deprecated",
+              "type": "outlined",
+              "color": "neutral"
+            },
             "path": "drivers/community/rkt"
           },
           {
@@ -97,7 +102,12 @@
             "path": "devices/community"
           },
           {
-            "title": "USB <sup>Beta</sup>",
+            "title": "USB",
+            "badge": {
+              "text": "Beta",
+              "type": "outlined",
+              "color": "neutral"
+            },
             "path": "devices/community/usb"
           }
         ]


### PR DESCRIPTION
Replaces the `<sup>` tags in nav data JSON files with a `badge` property. This is a new feature in DevDot, introduced in https://github.com/hashicorp/dev-portal/pull/562. Each badge has `type="outlined"` and `color="neutral"`.

Asana task: [[Nomad] Remove `<sup>` tags from nav data](https://app.asana.com/0/1202097197789424/1202707964020090/f)