### PR TITLE
[ui] "Can Read" checks on individual Secure Variables

### DIFF
--- a/.changelog/13996.txt
+++ b/.changelog/13996.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: when determining whether to let a user see Secure Variables, check against all paths in all namespaces.
+```

--- a/.changelog/13996.txt
+++ b/.changelog/13996.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-ui: when determining whether to let a user see Secure Variables, check against all paths in all namespaces.
-```

--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -130,15 +130,6 @@ export default class Variable extends AbstractAbility {
           (namespace) => namespace.Name === matchingNamespace
         )?.SecureVariables;
 
-        // TODO: temporary fix while https://github.com/hashicorp/nomad/issues/14034 is in flight
-        if (!variables) {
-          variables = (get(policy, 'rulesJSON.Namespaces') || []).find(
-            (namespace) => {
-              return namespace.Name.includes('*');
-            }
-          )?.SecureVariables;
-        }
-
         const pathNames = variables?.Paths?.map((path) => ({
           name: path.PathSpec,
           capabilities: path.Capabilities,

--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -39,12 +39,27 @@ export default class Variable extends AbstractAbility {
   )
   canDestroy;
 
+  @or(
+    'bypassAuthorization',
+    'selfTokenIsManagement',
+    'policiesSupportVariableRead'
+  )
+  canRead;
+
   @computed('token.selfTokenPolicies')
   get policiesSupportVariableList() {
     return this.policyNamespacesIncludeSecureVariablesCapabilities(
       this.token.selfTokenPolicies,
       ['list', 'read', 'write', 'destroy']
     );
+  }
+
+  @computed('path', 'allPaths')
+  get policiesSupportVariableRead() {
+    const matchingPath = this._nearestMatchingPath(this.path);
+    return this.allPaths
+      .find((path) => path.name === matchingPath)
+      ?.capabilities?.includes('read');
   }
 
   /**
@@ -159,7 +174,6 @@ export default class Variable extends AbstractAbility {
 
   _nearestMatchingPath(path) {
     const pathNames = this.allPaths.map((path) => path.name);
-
     if (pathNames.includes(path)) {
       return path;
     }

--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -130,6 +130,15 @@ export default class Variable extends AbstractAbility {
           (namespace) => namespace.Name === matchingNamespace
         )?.SecureVariables;
 
+        // TODO: temporary fix while https://github.com/hashicorp/nomad/issues/14034 is in flight
+        if (!variables) {
+          variables = (get(policy, 'rulesJSON.Namespaces') || []).find(
+            (namespace) => {
+              return namespace.Name.includes('*');
+            }
+          )?.SecureVariables;
+        }
+
         const pathNames = variables?.Paths?.map((path) => ({
           name: path.PathSpec,
           capabilities: path.Capabilities,

--- a/ui/app/components/variable-paths.hbs
+++ b/ui/app/components/variable-paths.hbs
@@ -25,7 +25,11 @@
     {{/each}}
 
     {{#each this.files as |file|}}
-      <tr data-test-file-row {{on "click" (fn this.handleFileClick file)}}>
+      <tr
+        data-test-file-row
+        {{on "click" (fn this.handleFileClick file)}}
+        class={{if (can "read variable" path=file.absoluteFilePath namespace=file.variable.namespace) "" "inaccessible"}}
+      >
         <td>
           <FlightIcon @name="file-text" />
           {{#if (can "read variable" path=file.absoluteFilePath namespace=file.variable.namespace)}}
@@ -37,7 +41,7 @@
             {{file.name}}
           </LinkTo>
           {{else}}
-            <span title="Your access policy does not allow you to view the contents of {{file.name}}" class="inaccessible">{{file.name}}</span>
+            <span title="Your access policy does not allow you to view the contents of {{file.name}}">{{file.name}}</span>
           {{/if}}
         </td>
         <td>

--- a/ui/app/components/variable-paths.hbs
+++ b/ui/app/components/variable-paths.hbs
@@ -25,9 +25,10 @@
     {{/each}}
 
     {{#each this.files as |file|}}
-      <tr data-test-file-row {{on "click" (fn this.handleFileClick file.absoluteFilePath)}}>
+      <tr data-test-file-row {{on "click" (fn this.handleFileClick file)}}>
         <td>
           <FlightIcon @name="file-text" />
+          {{#if (can "read variable" path=file.absoluteFilePath namespace=file.variable.namespace)}}
           <LinkTo
             @route="variables.variable"
             @model={{file.absoluteFilePath}}
@@ -35,6 +36,9 @@
           >
             {{file.name}}
           </LinkTo>
+          {{else}}
+            <span title="Your access policy does not allow you to view the contents of {{file.name}}" class="inaccessible">{{file.name}}</span>
+          {{/if}}
         </td>
         <td>
           {{file.variable.namespace}}

--- a/ui/app/components/variable-paths.js
+++ b/ui/app/components/variable-paths.js
@@ -5,6 +5,7 @@ import { inject as service } from '@ember/service';
 import compactPath from '../utils/compact-path';
 export default class VariablePathsComponent extends Component {
   @service router;
+  @service can;
 
   /**
    * @returns {Array<Object.<string, Object>>}
@@ -25,7 +26,9 @@ export default class VariablePathsComponent extends Component {
   }
 
   @action
-  async handleFileClick(path) {
-    this.router.transitionTo('variables.variable', path);
+  async handleFileClick({ path, variable: { namespace } }) {
+    if (this.can.can('read variable', null, { path, namespace })) {
+      this.router.transitionTo('variables.variable', path);
+    }
   }
 }

--- a/ui/app/controllers/variables/variable.js
+++ b/ui/app/controllers/variables/variable.js
@@ -3,11 +3,11 @@ import Controller from '@ember/controller';
 export default class VariablesVariableController extends Controller {
   get breadcrumbs() {
     let crumbs = [];
-    this.model.path.split('/').reduce((m, n) => {
+    this.params.path.split('/').reduce((m, n) => {
       crumbs.push({
         label: n,
         args:
-          m + n === this.model.path // If the last crumb, link to the var itself
+          m + n === this.params.path // If the last crumb, link to the var itself
             ? [`variables.variable`, m + n]
             : [`variables.path`, m + n],
       });

--- a/ui/app/routes/variables/variable.js
+++ b/ui/app/routes/variables/variable.js
@@ -1,16 +1,21 @@
 import Route from '@ember/routing/route';
 import withForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
-import WithModelErrorHandling from 'nomad-ui/mixins/with-model-error-handling';
 import { inject as service } from '@ember/service';
+import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 
 export default class VariablesVariableRoute extends Route.extend(
-  withForbiddenState,
-  WithModelErrorHandling
+  withForbiddenState
 ) {
   @service store;
   model(params) {
-    return this.store.findRecord('variable', decodeURIComponent(params.path), {
-      reload: true,
-    });
+    return this.store
+      .findRecord('variable', decodeURIComponent(params.path), {
+        reload: true,
+      })
+      .catch(notifyForbidden(this));
+  }
+  setupController(controller) {
+    super.setupController(controller);
+    controller.set('params', this.paramsFor('variables.variable'));
   }
 }

--- a/ui/app/styles/components/secure-variables.scss
+++ b/ui/app/styles/components/secure-variables.scss
@@ -103,10 +103,6 @@
 table.path-tree {
   tr {
     cursor: pointer;
-    a {
-      color: #0a0a0a;
-      text-decoration: none;
-    }
     svg {
       margin-bottom: -2px;
       margin-right: 10px;

--- a/ui/app/styles/components/secure-variables.scss
+++ b/ui/app/styles/components/secure-variables.scss
@@ -103,6 +103,9 @@
 table.path-tree {
   tr {
     cursor: pointer;
+    &.inaccessible {
+      cursor: not-allowed;
+    }
     svg {
       margin-bottom: -2px;
       margin-right: 10px;

--- a/ui/app/templates/variables/variable.hbs
+++ b/ui/app/templates/variables/variable.hbs
@@ -6,7 +6,6 @@
   {{#if this.isForbidden}}
     <ForbiddenMessage />
   {{else}}
-  elsey
     {{outlet}}
   {{/if}}
 </section>

--- a/ui/app/templates/variables/variable.hbs
+++ b/ui/app/templates/variables/variable.hbs
@@ -3,6 +3,11 @@
   <Breadcrumb @crumb={{crumb}} />
 {{/each}}
 <section class="section single-variable">
-  {{outlet}}
+  {{#if this.isForbidden}}
+    <ForbiddenMessage />
+  {{else}}
+  elsey
+    {{outlet}}
+  {{/if}}
 </section>
  

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -838,8 +838,12 @@ export default function () {
 
   //#region Secure Variables
 
-  this.get('/vars', function (schema) {
-    return schema.variables.all();
+  this.get('/vars', function (schema, { queryParams: { namespace } }) {
+    if (namespace && namespace !== '*') {
+      return schema.variables.all().filter((v) => v.namespace === namespace);
+    } else {
+      return schema.variables.all();
+    }
   });
 
   this.get('/var/:id', function ({ variables }, { params }) {

--- a/ui/mirage/factories/token.js
+++ b/ui/mirage/factories/token.js
@@ -34,23 +34,13 @@ export default Factory.extend({
         id: 'Variable Maker',
         rules: `
 # Allow read only access to the default namespace
-namespace "default" {
+namespace "*" {
   policy = "read"
   capabilities = ["list-jobs", "alloc-exec", "read-logs"]
   secure_variables {
-    # full access to secrets in all project paths
-    path "blue/*" {
-      capabilities = ["write", "read", "destroy", "list"]
-    }
-
-    # full access to secrets in all project paths
+    # Base access is to all abilities for all secure variables
     path "*" {
-      capabilities = ["write", "read", "destroy", "list"]
-    }
-
-    # read/list access within a "system" path belonging to administrators
-    path "system/*" {
-      capabilities = ["read", "list"]
+      capabilities = ["list", "read", "destroy", "create"]
     }
   }
 }
@@ -63,21 +53,13 @@ node {
         rulesJSON: {
           Namespaces: [
             {
-              Name: 'default',
+              Name: '*',
               Capabilities: ['list-jobs', 'alloc-exec', 'read-logs'],
               SecureVariables: {
                 Paths: [
                   {
                     Capabilities: ['write', 'read', 'destroy', 'list'],
-                    PathSpec: 'blue/*',
-                  },
-                  {
-                    Capabilities: ['write', 'read', 'destroy', 'list'],
                     PathSpec: '*',
-                  },
-                  {
-                    Capabilities: ['read', 'list'],
-                    PathSpec: 'system/*',
                   },
                 ],
               },
@@ -87,6 +69,100 @@ node {
       };
       server.create('policy', variableMakerPolicy);
       token.policyIds.push(variableMakerPolicy.id);
+    }
+    if (token.id === 'f3w3r-53cur3-v4r14bl35') {
+      const variableViewerPolicy = {
+        id: 'Variable Viewer',
+        rules: `
+# Allow read only access to the default namespace
+namespace "*" {
+  policy = "read"
+  capabilities = ["list-jobs", "alloc-exec", "read-logs"]
+  secure_variables {
+    # Base access is to all abilities for all secure variables
+    path "*" {
+      capabilities = ["list"]
+    }
+  }
+}
+
+namespace "namespace-1" {
+  policy = "read"
+  capabilities = ["list-jobs", "alloc-exec", "read-logs"]
+  secure_variables {
+    # Base access is to all abilities for all secure variables
+    path "*" {
+      capabilities = ["list", "read", "destroy", "create"]
+    }
+  }
+}
+
+namespace "namespace-2" {
+  policy = "read"
+  capabilities = ["list-jobs", "alloc-exec", "read-logs"]
+  secure_variables {
+    # Base access is to all abilities for all secure variables
+    path "blue/*" {
+      capabilities = ["list", "read", "destroy", "create"]
+    }
+    path "nomad/jobs/*" {
+      capabilities = ["list", "read", "create"]
+    }
+  }
+}
+
+node {
+  policy = "read"
+}
+      `,
+
+        rulesJSON: {
+          Namespaces: [
+            {
+              Name: '*',
+              Capabilities: ['list-jobs', 'alloc-exec', 'read-logs'],
+              SecureVariables: {
+                Paths: [
+                  {
+                    Capabilities: ['list'],
+                    PathSpec: '*',
+                  },
+                ],
+              },
+            },
+            {
+              Name: 'namespace-1',
+              Capabilities: ['list-jobs', 'alloc-exec', 'read-logs'],
+              SecureVariables: {
+                Paths: [
+                  {
+                    Capabilities: ['list', 'read', 'destroy', 'create'],
+                    PathSpec: '*',
+                  },
+                ],
+              },
+            },
+            {
+              Name: 'namespace-2',
+              Capabilities: ['list-jobs', 'alloc-exec', 'read-logs'],
+              SecureVariables: {
+                Paths: [
+                  {
+                    Capabilities: ['list', 'read', 'destroy', 'create'],
+                    PathSpec: 'blue/*',
+                  },
+                  {
+                    Capabilities: ['list', 'read', 'create'],
+                    PathSpec: 'nomad/jobs/*',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      };
+      server.create('policy', variableViewerPolicy);
+      token.policyIds.push(variableViewerPolicy.id);
     }
   },
 });

--- a/ui/mirage/factories/variable.js
+++ b/ui/mirage/factories/variable.js
@@ -26,12 +26,7 @@ export default Factory.extend({
 
   afterCreate(variable, server) {
     if (!variable.namespaceId) {
-      Ember.assert(
-        '[Mirage] No jobs! make sure jobs are created before variables',
-        server.db.jobs.length
-      );
-
-      const namespace = pickOne(server.db.jobs).namespace || 'default';
+      const namespace = pickOne(server.db.jobs)?.namespace || 'default';
       variable.update({
         namespace,
       });

--- a/ui/mirage/factories/variable.js
+++ b/ui/mirage/factories/variable.js
@@ -1,5 +1,6 @@
 import { Factory } from 'ember-cli-mirage';
 import faker from 'nomad-ui/mirage/faker';
+import { provide, pickOne } from '../utils';
 
 export default Factory.extend({
   id: () => faker.random.words(3).split(' ').join('/').toLowerCase(),
@@ -25,8 +26,12 @@ export default Factory.extend({
 
   afterCreate(variable, server) {
     if (!variable.namespaceId) {
-      const namespace =
-        (server.db.jobs && server.db.jobs[0]?.namespace) || 'default';
+      Ember.assert(
+        '[Mirage] No jobs! make sure jobs are created before variables',
+        server.db.jobs.length
+      );
+
+      const namespace = pickOne(server.db.jobs).namespace || 'default';
       variable.update({
         namespace,
       });

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -75,10 +75,22 @@ function smallCluster(server) {
     'just some arbitrary file',
     'another arbitrary file',
     'another arbitrary file again',
-    `nomad/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}/${variableLinkedTask.name}`,
-    `nomad/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}`,
-    `nomad/jobs/${variableLinkedJob.id}`,
   ].forEach((path) => server.create('variable', { id: path }));
+
+  server.create('variable', {
+    id: `nomad/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}/${variableLinkedTask.name}`,
+    namespaceId: variableLinkedJob.namespace,
+  });
+
+  server.create('variable', {
+    id: `nomad/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}`,
+    namespaceId: variableLinkedJob.namespace,
+  });
+
+  server.create('variable', {
+    id: `nomad/jobs/${variableLinkedJob.id}`,
+    namespaceId: variableLinkedJob.namespace,
+  });
 
   // #region evaluations
 

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -238,6 +238,10 @@ function createTokens(server) {
     name: 'Secure McVariables',
     id: '53cur3-v4r14bl35',
   });
+  server.create('token', {
+    name: "Safe O'Constants",
+    id: 'f3w3r-53cur3-v4r14bl35',
+  });
   logTokens(server);
 }
 

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -347,7 +347,7 @@ module('Acceptance | secure variables', function (hooks) {
     await a11yAudit(assert);
   });
 
-  module('create flow', function () {
+  module.skip('create flow', function () {
     test('allows a user with correct permissions to create a secure variable', async function (assert) {
       // Arrange Test Set-up
       defaultScenario(server);

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -214,7 +214,7 @@ module('Acceptance | secure variables', function (hooks) {
       'Related Entities box is job-oriented'
     );
 
-    await percySnapshot(assert);
+    await percySnapshot('related entities box for job variable');
 
     let relatedJobLink = find('.related-entities a');
     await click(relatedJobLink);
@@ -288,14 +288,10 @@ module('Acceptance | secure variables', function (hooks) {
       'Related Entities box is task-oriented'
     );
 
-    await percySnapshot(assert);
+    await percySnapshot('related entities box for task variable');
 
     let relatedTaskLink = find('.related-entities a');
     await click(relatedTaskLink);
-    // console.log('long way', variableLinkedTaskAlloc, variableLinkedTask, server.db.allocations.mapBy('taskGroup'));
-    // console.log('variableLinkedGroup', variableLinkedGroup);
-    // console.log('variableLinkedJob', variableLinkedJob);
-    // await this.pauseTest();
     // Gotta go the long way and click into the alloc/then task from here; but we know this one by virtue of stable test env.
     await visit(
       `/allocations/${variableLinkedTaskAlloc.id}/${variableLinkedTask.name}`

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -158,7 +158,7 @@ module('Acceptance | secure variables', function (hooks) {
     const variableLinkedTaskAlloc = server.db.allocations.filterBy(
       'taskGroup',
       variableLinkedGroup.name
-    )[1];
+    )[0];
     window.localStorage.nomadTokenSecret = variablesToken.secretId;
 
     // Non-job variable

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -111,7 +111,7 @@ module('Acceptance | secure variables', function (hooks) {
     const deleteButton = find('[data-test-delete-button] button');
     assert.dom(deleteButton).exists('delete button is present');
 
-    await percySnapshot(assert);
+    await percySnapshot('deeply nested variable');
 
     await click(deleteButton);
     assert
@@ -250,7 +250,7 @@ module('Acceptance | secure variables', function (hooks) {
       'Related Entities box is group-oriented'
     );
 
-    await percySnapshot(assert);
+    await percySnapshot('related entities box for group variable');
 
     let relatedGroupLink = find('.related-entities a');
     await click(relatedGroupLink);

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -643,6 +643,10 @@ module('Acceptance | secure variables', function (hooks) {
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
       await Variables.visit();
 
+      server.db.variables.forEach((v) => {
+        console.log('variable exists', v.id);
+      });
+
       assert
         .dom('[data-test-file-row].inaccessible')
         .exists(

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -29,8 +29,6 @@ module('Acceptance | secure variables', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   hooks.beforeEach(async function () {
-    server.create('node');
-    server.createList('job', 3);
     server.createList('variable', 3);
   });
 

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -155,10 +155,10 @@ module('Acceptance | secure variables', function (hooks) {
     const variableLinkedTask = server.db.tasks.findBy({
       taskGroupId: variableLinkedGroup.id,
     });
-    const variableLinkedTaskAlloc = server.db.allocations.filterBy(
-      'taskGroup',
-      variableLinkedGroup.name
-    )[0];
+    const variableLinkedTaskAlloc = server.db.allocations
+      .filterBy('taskGroup', variableLinkedGroup.name)
+      ?.find((alloc) => alloc.taskStateIds.length);
+
     window.localStorage.nomadTokenSecret = variablesToken.secretId;
 
     // Non-job variable

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -15,7 +15,7 @@ import {
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
-import defaultScenario from '../../mirage/scenarios/default';
+import { allScenarios } from '../../mirage/scenarios/default';
 import cleanWhitespace from '../utils/clean-whitespace';
 import percySnapshot from '@percy/ember';
 
@@ -39,7 +39,7 @@ module('Acceptance | secure variables', function (hooks) {
   });
 
   test('it allows access for management level tokens', async function (assert) {
-    defaultScenario(server);
+    allScenarios.variableTestCluster(server);
     window.localStorage.nomadTokenSecret = server.db.tokens[0].secretId;
     await Variables.visit();
     assert.equal(currentURL(), '/variables');
@@ -48,7 +48,7 @@ module('Acceptance | secure variables', function (hooks) {
 
   test('it allows access for list-variables allowed ACL rules', async function (assert) {
     assert.expect(2);
-    defaultScenario(server);
+    allScenarios.variableTestCluster(server);
     const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
     window.localStorage.nomadTokenSecret = variablesToken.secretId;
 
@@ -60,7 +60,7 @@ module('Acceptance | secure variables', function (hooks) {
 
   test('it correctly traverses to and deletes a variable', async function (assert) {
     assert.expect(13);
-    defaultScenario(server);
+    allScenarios.variableTestCluster(server);
     const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
     window.localStorage.nomadTokenSecret = variablesToken.secretId;
     server.db.variables.update({ namespace: 'default' });
@@ -145,7 +145,7 @@ module('Acceptance | secure variables', function (hooks) {
 
   test('variables prefixed with nomad/jobs/ correctly link to entities', async function (assert) {
     assert.expect(23);
-    defaultScenario(server);
+    allScenarios.variableTestCluster(server);
     const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
 
     const variableLinkedJob = server.db.jobs[0];
@@ -292,6 +292,10 @@ module('Acceptance | secure variables', function (hooks) {
 
     let relatedTaskLink = find('.related-entities a');
     await click(relatedTaskLink);
+    // console.log('long way', variableLinkedTaskAlloc, variableLinkedTask, server.db.allocations.mapBy('taskGroup'));
+    // console.log('variableLinkedGroup', variableLinkedGroup);
+    // console.log('variableLinkedJob', variableLinkedJob);
+    // await this.pauseTest();
     // Gotta go the long way and click into the alloc/then task from here; but we know this one by virtue of stable test env.
     await visit(
       `/allocations/${variableLinkedTaskAlloc.id}/${variableLinkedTask.name}`
@@ -317,7 +321,7 @@ module('Acceptance | secure variables', function (hooks) {
 
   test('it does not allow you to save if you lack Items', async function (assert) {
     assert.expect(5);
-    defaultScenario(server);
+    allScenarios.variableTestCluster(server);
     window.localStorage.nomadTokenSecret = server.db.tokens[0].secretId;
     await Variables.visitNew();
     assert.equal(currentURL(), '/variables/new');
@@ -340,17 +344,17 @@ module('Acceptance | secure variables', function (hooks) {
 
   test('it passes an accessibility audit', async function (assert) {
     assert.expect(1);
-    defaultScenario(server);
+    allScenarios.variableTestCluster(server);
     const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
     window.localStorage.nomadTokenSecret = variablesToken.secretId;
     await Variables.visit();
     await a11yAudit(assert);
   });
 
-  module.skip('create flow', function () {
+  module('create flow', function () {
     test('allows a user with correct permissions to create a secure variable', async function (assert) {
       // Arrange Test Set-up
-      defaultScenario(server);
+      allScenarios.variableTestCluster(server);
       server.createList('variable', 3);
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
@@ -403,7 +407,7 @@ module('Acceptance | secure variables', function (hooks) {
 
     test('prevents users from creating a secure variable without proper permissions', async function (assert) {
       // Arrange Test Set-up
-      defaultScenario(server);
+      allScenarios.variableTestCluster(server);
       server.createList('variable', 3);
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
@@ -426,7 +430,7 @@ module('Acceptance | secure variables', function (hooks) {
 
     test('allows creating a variable that starts with nomad/jobs/', async function (assert) {
       // Arrange Test Set-up
-      defaultScenario(server);
+      allScenarios.variableTestCluster(server);
       server.createList('variable', 3);
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
@@ -453,7 +457,7 @@ module('Acceptance | secure variables', function (hooks) {
 
     test('disallows creating a variable that starts with nomad/<something-other-than-jobs>/', async function (assert) {
       // Arrange Test Set-up
-      defaultScenario(server);
+      allScenarios.variableTestCluster(server);
       server.createList('variable', 3);
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
@@ -478,7 +482,7 @@ module('Acceptance | secure variables', function (hooks) {
     test('allows a user with correct permissions to edit a secure variable', async function (assert) {
       assert.expect(8);
       // Arrange Test Set-up
-      defaultScenario(server);
+      allScenarios.variableTestCluster(server);
       server.createList('variable', 3);
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
@@ -533,7 +537,7 @@ module('Acceptance | secure variables', function (hooks) {
 
     test('prevents users from editing a secure variable without proper permissions', async function (assert) {
       // Arrange Test Set-up
-      defaultScenario(server);
+      allScenarios.variableTestCluster(server);
       server.createList('variable', 3);
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
@@ -555,10 +559,10 @@ module('Acceptance | secure variables', function (hooks) {
     });
   });
 
-  module.skip('delete flow', function () {
+  module('delete flow', function () {
     test('allows a user with correct permissions to delete a secure variable', async function (assert) {
       // Arrange Test Set-up
-      defaultScenario(server);
+      allScenarios.variableTestCluster(server);
       server.createList('variable', 3);
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
@@ -594,7 +598,7 @@ module('Acceptance | secure variables', function (hooks) {
 
     test('prevents users from delete a secure variable without proper permissions', async function (assert) {
       // Arrange Test Set-up
-      defaultScenario(server);
+      allScenarios.variableTestCluster(server);
       server.createList('variable', 3);
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
@@ -618,7 +622,7 @@ module('Acceptance | secure variables', function (hooks) {
 
   module('read flow', function () {
     test('allows a user with correct permissions to read a secure variable', async function (assert) {
-      defaultScenario(server);
+      allScenarios.variableTestCluster(server);
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
       await Variables.visit();
@@ -638,14 +642,10 @@ module('Acceptance | secure variables', function (hooks) {
     });
 
     test('prevents users from reading a secure variable without proper permissions', async function (assert) {
-      defaultScenario(server);
+      allScenarios.variableTestCluster(server);
       const variablesToken = server.db.tokens.find(LIMITED_SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
       await Variables.visit();
-
-      server.db.variables.forEach((v) => {
-        console.log('variable exists', v.id);
-      });
 
       assert
         .dom('[data-test-file-row].inaccessible')
@@ -664,7 +664,7 @@ module('Acceptance | secure variables', function (hooks) {
       assert.expect(3);
 
       // Arrange
-      defaultScenario(server);
+      allScenarios.variableTestCluster(server);
       server.createList('variable', 3);
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
@@ -696,7 +696,7 @@ module('Acceptance | secure variables', function (hooks) {
     });
 
     test('does not show namespace filtering if the user only has access to one namespace', async function (assert) {
-      defaultScenario(server);
+      allScenarios.variableTestCluster(server);
       server.createList('variable', 3);
       const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;
@@ -719,7 +719,7 @@ module('Acceptance | secure variables', function (hooks) {
         assert.expect(4);
 
         // Arrange
-        defaultScenario(server);
+        allScenarios.variableTestCluster(server);
         server.createList('variable', 3);
         const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
         window.localStorage.nomadTokenSecret = variablesToken.secretId;
@@ -758,7 +758,7 @@ module('Acceptance | secure variables', function (hooks) {
       });
 
       test('does not show namespace filtering if the user only has access to one namespace', async function (assert) {
-        defaultScenario(server);
+        allScenarios.variableTestCluster(server);
         server.createList('variable', 3);
         const variablesToken = server.db.tokens.find(SECURE_TOKEN_ID);
         window.localStorage.nomadTokenSecret = variablesToken.secretId;

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -555,7 +555,7 @@ module('Acceptance | secure variables', function (hooks) {
     });
   });
 
-  module('delete flow', function () {
+  module.skip('delete flow', function () {
     test('allows a user with correct permissions to delete a secure variable', async function (assert) {
       // Arrange Test Set-up
       defaultScenario(server);

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -28,6 +28,8 @@ module('Acceptance | secure variables', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   hooks.beforeEach(async function () {
+    server.create('node');
+    server.createList('job', 3);
     server.createList('variable', 3);
   });
 
@@ -484,7 +486,7 @@ module('Acceptance | secure variables', function (hooks) {
       const policy = server.db.policies.find('Variable Maker');
       policy.rulesJSON.Namespaces[0].SecureVariables.Paths.find(
         (path) => path.PathSpec === '*'
-      ).Capabilities = ['list', 'write'];
+      ).Capabilities = ['list', 'read', 'write'];
       server.db.variables.update({ namespace: 'default' });
       await Variables.visit();
       await click('[data-test-file-row]');
@@ -539,7 +541,7 @@ module('Acceptance | secure variables', function (hooks) {
       const policy = server.db.policies.find('Variable Maker');
       policy.rulesJSON.Namespaces[0].SecureVariables.Paths.find(
         (path) => path.PathSpec === '*'
-      ).Capabilities = ['list'];
+      ).Capabilities = ['list', 'read'];
       await Variables.visit();
       await click('[data-test-file-row]');
       // End Test Set-up
@@ -564,12 +566,11 @@ module('Acceptance | secure variables', function (hooks) {
       const policy = server.db.policies.find('Variable Maker');
       policy.rulesJSON.Namespaces[0].SecureVariables.Paths.find(
         (path) => path.PathSpec === '*'
-      ).Capabilities = ['list', 'destroy'];
+      ).Capabilities = ['list', 'read', 'destroy'];
       server.db.variables.update({ namespace: 'default' });
       await Variables.visit();
       await click('[data-test-file-row]');
       // End Test Set-up
-
       assert.equal(currentRouteName(), 'variables.variable.index');
       assert
         .dom('[data-test-delete-button]')
@@ -601,7 +602,7 @@ module('Acceptance | secure variables', function (hooks) {
       const policy = server.db.policies.find('Variable Maker');
       policy.rulesJSON.Namespaces[0].SecureVariables.Paths.find(
         (path) => path.PathSpec === '*'
-      ).Capabilities = ['list'];
+      ).Capabilities = ['list', 'read'];
       await Variables.visit();
       await click('[data-test-file-row]');
       // End Test Set-up

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -637,7 +637,7 @@ module('Acceptance | secure variables', function (hooks) {
       window.localStorage.nomadTokenSecret = null;
     });
 
-    test('prevents users from delete a secure variable without proper permissions', async function (assert) {
+    test('prevents users from reading a secure variable without proper permissions', async function (assert) {
       defaultScenario(server);
       const variablesToken = server.db.tokens.find(LIMITED_SECURE_TOKEN_ID);
       window.localStorage.nomadTokenSecret = variablesToken.secretId;

--- a/ui/tests/integration/components/variable-paths-test.js
+++ b/ui/tests/integration/components/variable-paths-test.js
@@ -4,6 +4,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { componentA11yAudit } from 'nomad-ui/tests/helpers/a11y-audit';
 import pathTree from 'nomad-ui/utils/path-tree';
+import Service from '@ember/service';
 
 const PATHSTRINGS = [
   { path: '/foo/bar/baz' },
@@ -69,6 +70,36 @@ module('Integration | Component | variable-paths', function (hooks) {
   });
 
   test('it allows for traversal: Files', async function (assert) {
+    // Arrange Test Set-up
+    const mockToken = Service.extend({
+      selfTokenPolicies: [
+        [
+          {
+            rulesJSON: {
+              Namespaces: [
+                {
+                  Name: '*',
+                  Capabilities: ['list-jobs', 'alloc-exec', 'read-logs'],
+                  SecureVariables: {
+                    Paths: [
+                      {
+                        Capabilities: ['list', 'read'],
+                        PathSpec: '*',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      ],
+    });
+
+    this.owner.register('service:token', mockToken);
+
+    // End Test Set-up
+
     assert.expect(5);
 
     this.set('tree', tree.findPath('foo/bar'));

--- a/ui/tests/integration/components/variable-paths-test.js
+++ b/ui/tests/integration/components/variable-paths-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable ember/avoid-leaking-state-in-ember-objects */
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';


### PR DESCRIPTION
Resolves #13744 
---
- Adds a path/namespace-aware check for whether individual variables can be accessed via the ui: links become unclickable and not-link-coloured.
- Adds an Unauthorized banner if you do end up on a variable page for which you do not have access (403). Say, you copied it from your machine where you have management access, and you sent it to your network-connected, touchscreen-enabled fridge and clicked it via the tiny touchpad. In this scenario you now have the ability to scowl at your kitchen appliance and read instructions for contacting your administrator.


### Side-effects:
- Made clickable links, both folders and files, blue and underlined to emphasize the difference. (cc @juliezzhou who suggested it)
- Breadcrumb creation in the variables/variable controller now depends on `params` rather than `model`, since we will sometimes still want to render the route without resolving the model (403), and we'd still want a breadcrumb in that scenario.

### TODOs:
- [x] Mirage fixture for a user with fewer SecVars privileges to makes testing easier
- [x] Unit tests for "can read"
- [x] Acceptance tests for paths page

![image](https://user-images.githubusercontent.com/713991/182949927-5227195e-587c-4c91-bab2-f0a7b1ec37fe.png)
