### PR TITLE
nsd: add support for setting request body in http checks

### DIFF
--- a/client/serviceregistration/checks/client.go
+++ b/client/serviceregistration/checks/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-cleanhttp"
@@ -163,6 +164,7 @@ func (c *checker) checkHTTP(ctx context.Context, qc *QueryContext, q *Query) *st
 		return qr
 	}
 	request.Header = q.Headers
+	request.Body = io.NopCloser(strings.NewReader(q.Body))
 	request = request.WithContext(ctx)
 
 	result, err := c.httpClient.Do(request)

--- a/client/serviceregistration/checks/client_test.go
+++ b/client/serviceregistration/checks/client_test.go
@@ -269,6 +269,12 @@ func TestChecker_Do_HTTP_extras(t *testing.T) {
 				[2]string{"Authorization", "Basic ZWxhc3RpYzpjaGFuZ2VtZQ=="},
 			),
 		},
+		{
+			name:    "with body",
+			method:  "POST",
+			headers: makeHeaders(encoding, agent),
+			body:    "some payload",
+		},
 	}
 
 	for _, tc := range cases {
@@ -295,6 +301,7 @@ func TestChecker_Do_HTTP_extras(t *testing.T) {
 			Path:        "/",
 			Method:      tc.method,
 			Headers:     tc.headers,
+			Body:        tc.body,
 		}
 
 		t.Run(tc.name, func(t *testing.T) {

--- a/client/serviceregistration/checks/result.go
+++ b/client/serviceregistration/checks/result.go
@@ -24,6 +24,7 @@ func GetCheckQuery(c *structs.ServiceCheck) *Query {
 		Path:        c.Path,
 		Method:      c.Method,
 		Headers:     helper.CopyMap(c.Header),
+		Body:        c.Body,
 	}
 }
 
@@ -42,6 +43,7 @@ type Query struct {
 	Path     string      // http checks only
 	Method   string      // http checks only
 	Headers  http.Header // http checks only
+	Body     string      // http checks only
 }
 
 // A QueryContext contains allocation and service parameters necessary for

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -350,11 +350,6 @@ func (sc *ServiceCheck) validateNomad() error {
 		if sc.Method != "" && !helper.IsMethodHTTP(sc.Method) {
 			return fmt.Errorf("method type %q not supported in Nomad http check", sc.Method)
 		}
-
-		// todo(shoenig) support body
-		if len(sc.Body) > 0 {
-			return fmt.Errorf("http checks may not set Body in Nomad services")
-		}
 	}
 
 	// success_before_passing is consul only

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -336,10 +336,9 @@ func TestServiceCheck_validateNomad(t *testing.T) {
 				Interval: 3 * time.Second,
 				Timeout:  1 * time.Second,
 				Path:     "/health",
-				Method:   "GET",
-				Body:     "blah",
+				Method:   "POST",
+				Body:     "this is a request payload!",
 			},
-			exp: `http checks may not set Body in Nomad services`,
 		},
 	}
 


### PR DESCRIPTION
This PR adds support for settings check.body in checks of services
making use of Nomad's service provider.

Closes #13945