### PR TITLE
fix minor unreachable code caused by t.Fatal

### DIFF
--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -4321,7 +4321,6 @@ func TestTaskArtifact_Validate_Checksum(t *testing.T) {
 		err := tc.Input.Validate()
 		if (err != nil) != tc.Err {
 			t.Fatalf("case %d: %v", i, err)
-			continue
 		}
 	}
 }
@@ -6669,7 +6668,6 @@ func TestNodeReservedNetworkResources_ParseReserved(t *testing.T) {
 		out, err := r.ParseReservedHostPorts()
 		if (err != nil) != tc.Err {
 			t.Fatalf("test case %d: %v", i, err)
-			continue
 		}
 
 		require.Equal(out, tc.Parsed)

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -34,8 +34,7 @@ func TestStaticIterator_Reset(t *testing.T) {
 
 		out := collectFeasible(static)
 		if len(out) != len(nodes) {
-			t.Fatalf("out: %#v", out)
-			t.Fatalf("missing nodes %d %#v", i, static)
+			t.Fatalf("out: %#v missing nodes %d %#v", out, i, static)
 		}
 
 		ids := make(map[string]struct{})

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -64,10 +64,11 @@ func TestServiceSched_JobRegister(t *testing.T) {
 
 	// Ensure the eval has no spawned blocked eval
 	if len(h.CreateEvals) != 0 {
-		t.Fatalf("bad: %#v", h.CreateEvals)
+		t.Errorf("bad: %#v", h.CreateEvals)
 		if h.Evals[0].BlockedEval != "" {
 			t.Fatalf("bad: %#v", h.Evals[0])
 		}
+		t.FailNow()
 	}
 
 	// Ensure the plan allocated
@@ -1517,10 +1518,11 @@ func TestServiceSched_EvaluateBlockedEval_Finished(t *testing.T) {
 
 	// Ensure the eval has no spawned blocked eval
 	if len(h.Evals) != 1 {
-		t.Fatalf("bad: %#v", h.Evals)
+		t.Errorf("bad: %#v", h.Evals)
 		if h.Evals[0].BlockedEval != "" {
 			t.Fatalf("bad: %#v", h.Evals[0])
 		}
+		t.FailNow()
 	}
 
 	// Ensure the plan allocated


### PR DESCRIPTION
https://pkg.go.dev/testing#T.Fatalf
> Fatalf is equivalent to Logf followed by FailNow.



see https://go.dev/play/p/I6MX-QOTC9n for example:
```go
package main

import (
	"testing"
)

func TestLastIndex(t *testing.T) {
	t.Errorf("first line")
	t.Errorf("second line")
	t.Fatalf("t.Fatalf will cause exit")
	t.Fatalf("so this line cant reach")
}

/* output:
=== RUN   TestLastIndex
    prog.go:8: first line
    prog.go:9: second line
    prog.go:10: t.Fatalf will cause exit
--- FAIL: TestLastIndex (0.00s)
FAIL

Program exited.
*/

```