### PR TITLE
ui:  handle error messages for when filtering doesn't return matches

### DIFF
--- a/ui/app/templates/variables/index.hbs
+++ b/ui/app/templates/variables/index.hbs
@@ -41,12 +41,24 @@
     />
   {{else}}
     <div class="empty-message">
-      <h3 data-test-empty-variables-list-headline class="empty-message-headline">
-        No Secure Variables
-      </h3>
-      <p class="empty-message-body">
-        Get started by <LinkTo @route="variables.new">creating a new secure variable</LinkTo>
-      </p>
+      {{#if (eq this.namespaceSelection "*")}}
+        <h3 data-test-empty-variables-list-headline class="empty-message-headline">
+          No Secure Variables
+        </h3>
+        <p class="empty-message-body">
+          Get started by <LinkTo @route="variables.new">creating a new secure variable</LinkTo>
+        </p>
+      {{else}}
+        <h3 data-test-no-matching-variables-list-headline class="empty-message-headline">
+          No Matches
+        </h3>
+        <p class="empty-message-body">
+          No paths or variables match the namespace
+          <strong>
+            {{this.namespaceSelection}}
+          </strong>
+        </p>
+      {{/if}}
     </div>
   {{/if}}
 </section>

--- a/ui/app/templates/variables/path.hbs
+++ b/ui/app/templates/variables/path.hbs
@@ -43,12 +43,24 @@
   />
 {{else}}
   <div class="empty-message">
-    <h3 data-test-empty-variables-list-headline class="empty-message-headline">
-      Path /{{this.model.absolutePath}} contains no variables
-    </h3>
-    <p class="empty-message-body">
-      To get started, <LinkTo @route="variables.new" @query={{hash path=(concat this.model.absolutePath "/")}}>create a new secure variable here</LinkTo>, or <LinkTo @route="variables">go back to the Secure Variables root directory</LinkTo>.
-    </p>
+    {{#if (eq this.namespaceSelection "*")}}
+      <h3 data-test-empty-variables-list-headline class="empty-message-headline">
+        Path /{{this.model.absolutePath}} contains no variables
+      </h3>
+      <p class="empty-message-body">
+        To get started, <LinkTo @route="variables.new" @query={{hash path=(concat this.model.absolutePath "/")}}>create a new secure variable here</LinkTo>, or <LinkTo @route="variables">go back to the Secure Variables root directory</LinkTo>.
+      </p>
+    {{else}}
+      <h3 data-test-no-matching-variables-list-headline class="empty-message-headline">
+        No Matches
+      </h3>
+      <p class="empty-message-body">
+        No paths or variables match the namespace 
+        <strong>
+          {{this.namespaceSelection}}
+        </strong>
+      </p>
+    {{/if}}
   </div>
 {{/if}}
   </section>

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -648,7 +648,7 @@ module('Acceptance | secure variables', function (hooks) {
       await selectChoose('[data-test-variable-namespace-filter]', 'default');
 
       assert
-        .dom('[data-test-empty-variables-list-headline]')
+        .dom('[data-test-no-matching-variables-list-headline]')
         .exists('Renders an empty list.');
     });
 
@@ -710,7 +710,7 @@ module('Acceptance | secure variables', function (hooks) {
         await selectChoose('[data-test-variable-namespace-filter]', 'default');
 
         assert
-          .dom('[data-test-empty-variables-list-headline]')
+          .dom('[data-test-no-matching-variables-list-headline]')
           .exists('Renders an empty list.');
       });
 


### PR DESCRIPTION
Currently we show the wrong error message to users when they are filtering variables by namespace making them falsely believe that there are no variables or paths. We need a better error message that is consistent with how this behavior is handled in the rest of the Nomad UI.

Closes [13974](https://github.com/hashicorp/nomad/issues/13974)

### Current:
![image](https://user-images.githubusercontent.com/41024828/183443577-424b37ac-f9d0-4b8f-947d-7b6879755ae7.png)

### New:
![image](https://user-images.githubusercontent.com/41024828/183443602-64ae0c28-93d4-4652-9b35-b236e43f3505.png)

### Existing Nomad Pattern:
![image](https://user-images.githubusercontent.com/41024828/183443646-7ddf1acb-f969-4d8e-b443-e58c921d3007.png)
