### PR TITLE
[manual backport] introduces the post publish website event

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -199,3 +199,17 @@ event "promote-production-packaging" {
     on = "always"
   }
 }
+
+event "post-publish-website" {
+  depends = ["promote-production-packaging"]
+
+  action "post-publish-website" {
+    organization = "hashicorp"
+    repository   = "crt-workflows-common"
+    workflow     = "post-publish-website"
+  }
+
+  notification {
+    on = "always"
+  }
+}


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/nomad/pull/13815. 