### PR TITLE
cli: forward request for job validation to nomad leader

### DIFF
--- a/.changelog/14065.txt
+++ b/.changelog/14065.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a bug where job validation requeset was not sent to leader
+```

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -464,10 +464,8 @@ func getSignalConstraint(signals []string) *structs.Constraint {
 	}
 }
 
-// Summary retrieves the summary of a job
-func (j *Job) Summary(args *structs.JobSummaryRequest,
-	reply *structs.JobSummaryResponse) error {
-
+// Summary retrieves the summary of a job.
+func (j *Job) Summary(args *structs.JobSummaryRequest, reply *structs.JobSummaryResponse) error {
 	if done, err := j.srv.forward("Job.Summary", args, args, reply); done {
 		return err
 	}
@@ -511,8 +509,14 @@ func (j *Job) Summary(args *structs.JobSummaryRequest,
 	return j.srv.blockingRPC(&opts)
 }
 
-// Validate validates a job
+// Validate validates a job.
+//
+// Must forward to the leader, because only the leader will have a live Vault
+// client with which to validate vault tokens.
 func (j *Job) Validate(args *structs.JobValidateRequest, reply *structs.JobValidateResponse) error {
+	if done, err := j.srv.forward("Job.Validate", args, args, reply); done {
+		return err
+	}
 	defer metrics.MeasureSince([]string{"nomad", "job", "validate"}, time.Now())
 
 	// defensive check; http layer and RPC requester should ensure namespaces are set consistently

--- a/website/content/api-docs/validate.mdx
+++ b/website/content/api-docs/validate.mdx
@@ -14,7 +14,7 @@ types.
 ## Validate Job
 
 This endpoint validates a Nomad job file. The local Nomad agent forwards the
-request to a server. In the event a server can't be reached the agent verifies
+request to the leader. In the event the leader cannot be reached the agent verifies
 the job file locally but skips validating driver configurations.
 
 ~> This endpoint accepts a **JSON job file**, not an HCL job file.


### PR DESCRIPTION
This PR changes the behavior of 'nomad job validate' to forward the
request to the nomad leader, rather than responding from any server.

This is because we need the leader when validating Vault tokens, since
the leader is the only server with an active vault client.

Closes https://github.com/hashicorp/nomad/issues/13940