### PR TITLE
[ui] Fixes a bug for first-time SecVars users on namespaces

### DIFF
--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -107,7 +107,7 @@ export default class Variable extends AbstractAbility {
     });
   }
 
-  @computed('path', 'allPaths')
+  @computed('path', 'namespace', 'allPaths')
   get policiesSupportVariableWriting() {
     if (this.namespace === WILDCARD_GLOB && this.path === WILDCARD_GLOB) {
       // If you're checking if you can write from root, and you don't specify a namespace,

--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -107,7 +107,7 @@ export default class Variable extends AbstractAbility {
     });
   }
 
-  @computed('path', 'namespace', 'allPaths')
+  @computed('allPaths', 'namespace', 'path', 'token.selfTokenPolicies')
   get policiesSupportVariableWriting() {
     if (this.namespace === WILDCARD_GLOB && this.path === WILDCARD_GLOB) {
       // If you're checking if you can write from root, and you don't specify a namespace,

--- a/ui/app/templates/variables/index.hbs
+++ b/ui/app/templates/variables/index.hbs
@@ -12,7 +12,7 @@
           />
         {{/if}}
       <div class="button-bar">
-      {{#if (can "write variable" path="*")}}
+      {{#if (can "write variable" path="*" namespace=this.namespaceSelection)}}
         <LinkTo
           @route="variables.new"
           class="button is-primary"
@@ -45,9 +45,11 @@
         <h3 data-test-empty-variables-list-headline class="empty-message-headline">
           No Secure Variables
         </h3>
-        <p class="empty-message-body">
-          Get started by <LinkTo @route="variables.new">creating a new secure variable</LinkTo>
-        </p>
+        {{#if (can "write variable" path="*" namespace=this.namespaceSelection)}}
+          <p class="empty-message-body">
+            Get started by <LinkTo @route="variables.new">creating a new secure variable</LinkTo>
+          </p>
+        {{/if}}
       {{else}}
         <h3 data-test-no-matching-variables-list-headline class="empty-message-headline">
           No Matches

--- a/ui/app/templates/variables/path.hbs
+++ b/ui/app/templates/variables/path.hbs
@@ -15,7 +15,7 @@
           />
         {{/if}}
         <div class="button-bar">
-        {{#if (can "write variable" path=this.model.absolutePath namespace=this.model.namespace)}}
+        {{#if (can "write variable" path=this.model.absolutePath namespace=this.namespaceSelection)}}
           <LinkTo
             @route="variables.new"
             @query={{hash path=(concat this.model.absolutePath "/")}}


### PR DESCRIPTION
Resolves #13949 and #14061


Makes the empty-variables-list link adhere to the same rules as the create button
Adds a more permissive check when you're on * namespace and * path


Added a TODO for handling * namespace on a specific path. We're being too restricted about that currently and should consider modifying allPaths to account for checking against multiple namespaces at once.