### PR TITLE
cli: for systems with cgroups v2, fix alloation resource utilization showing 0 memory used

### DIFF
--- a/.changelog/14069.txt
+++ b/.changelog/14069.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a bug where the memory usage reported by Allocation Resource Utilization is zero on systems using cgroups v2
+```

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -964,7 +964,11 @@ func getActualResources(client *api.Client, runningAllocs []*api.Allocation, nod
 		}
 
 		cpu += stats.ResourceUsage.CpuStats.TotalTicks
-		mem += stats.ResourceUsage.MemoryStats.RSS
+		if stats.ResourceUsage.MemoryStats.Usage > 0 {
+			mem += stats.ResourceUsage.MemoryStats.Usage
+		} else {
+			mem += stats.ResourceUsage.MemoryStats.RSS
+		}
 	}
 
 	resources := make([]string, 2)


### PR DESCRIPTION
Follow up to https://github.com/hashicorp/nomad/pull/13670 which fixes the bug for the UI, but not using the CLI (`nomad node status`).