### PR TITLE
[ui] Show a different message when there are no tasks in a job

### DIFF
--- a/.changelog/14071.txt
+++ b/.changelog/14071.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Display different message when trying to exec into a job with no task running.
+```

--- a/ui/app/controllers/exec.js
+++ b/ui/app/controllers/exec.js
@@ -47,7 +47,14 @@ export default class ExecController extends Controller {
     window.execTerminal = this.terminal; // Issue to improve: https://github.com/hashicorp/nomad/issues/7457
 
     this.terminal.write(ANSI_UI_GRAY_400);
-    this.terminal.writeln('Select a task to start your session.');
+
+    if (this.sortedTaskGroups.length > 0) {
+      this.terminal.writeln('Select a task to start your session.');
+    } else {
+      this.terminal.writeln(
+        'Run a job and then select a task to start your session.'
+      );
+    }
   }
 
   @alias('model.allocations') allocations;

--- a/ui/app/controllers/exec.js
+++ b/ui/app/controllers/exec.js
@@ -51,9 +51,7 @@ export default class ExecController extends Controller {
     if (this.sortedTaskGroups.length > 0) {
       this.terminal.writeln('Select a task to start your session.');
     } else {
-      this.terminal.writeln(
-        'Run a job and then select a task to start your session.'
-      );
+      this.terminal.writeln(`There are no tasks running for this job.`);
     }
   }
 


### PR DESCRIPTION
Show a different message in the terminal when there are no tasks in the job.

![1](https://user-images.githubusercontent.com/7998054/183773725-5eaf3280-ad00-485a-aa0a-872ebc67e2bb.PNG)

![2](https://user-images.githubusercontent.com/7998054/183773777-2a5afe28-5f94-4828-82e2-c324af01f24f.PNG)



Closes #10545



