### PR TITLE
UI variables made to be unique by namespace and path

### DIFF
--- a/ui/app/adapters/variable.js
+++ b/ui/app/adapters/variable.js
@@ -11,7 +11,7 @@ export default class VariableAdapter extends ApplicationAdapter {
   createRecord(_store, _type, snapshot) {
     let data = this.serialize(snapshot);
     return this.ajax(
-      this.urlForFindRecord(snapshot.id, snapshot.modelName),
+      this.urlForFindRecord(data.Path, snapshot.modelName),
       'PUT',
       { data }
     );
@@ -27,21 +27,30 @@ export default class VariableAdapter extends ApplicationAdapter {
     return pluralize(baseUrl);
   }
 
-  urlForFindRecord(id, modelName, snapshot) {
-    const namespace = snapshot?.attr('namespace') || 'default';
-
-    let baseUrl = this.buildURL(modelName, snapshot.attr('plainId'), snapshot);
+  urlForFindRecord(identifier, modelName, snapshot) {
+    const { namespace, id } = _extractIDAndNamespace(identifier, snapshot);
+    let baseUrl = this.buildURL(modelName, id);
     return `${baseUrl}?namespace=${namespace}`;
   }
 
-  urlForUpdateRecord(id, modelName) {
-    return this.buildURL(modelName, id);
+  urlForUpdateRecord(identifier, modelName, snapshot) {
+    const { namespace, id } = _extractIDAndNamespace(identifier, snapshot);
+    let baseUrl = this.buildURL(modelName, id);
+    return `${baseUrl}?namespace=${namespace}`;
   }
 
-  urlForDeleteRecord(id, modelName, snapshot) {
-    const namespace = snapshot?.attr('namespace') || 'default';
-
+  urlForDeleteRecord(identifier, modelName, snapshot) {
+    const { namespace, id } = _extractIDAndNamespace(identifier, snapshot);
     const baseUrl = this.buildURL(modelName, id);
     return `${baseUrl}?namespace=${namespace}`;
   }
+}
+
+function _extractIDAndNamespace(identifier, snapshot) {
+  const namespace = snapshot?.attr('namespace') || 'default';
+  const id = snapshot?.attr('path') || identifier;
+  return {
+    namespace,
+    id,
+  };
 }

--- a/ui/app/adapters/variable.js
+++ b/ui/app/adapters/variable.js
@@ -10,7 +10,6 @@ export default class VariableAdapter extends ApplicationAdapter {
   // /v1/var instead of /v1/vars on create (urlForFindRecord)
   createRecord(_store, _type, snapshot) {
     let data = this.serialize(snapshot);
-    console.log('adapting', data);
     return this.ajax(
       this.urlForFindRecord(snapshot.id, snapshot.modelName),
       'PUT',
@@ -31,12 +30,11 @@ export default class VariableAdapter extends ApplicationAdapter {
   urlForFindRecord(id, modelName, snapshot) {
     const namespace = snapshot?.attr('namespace') || 'default';
 
-    let baseUrl = this.buildURL(modelName, id, snapshot);
+    let baseUrl = this.buildURL(modelName, snapshot.attr('plainId'), snapshot);
     return `${baseUrl}?namespace=${namespace}`;
   }
 
   urlForUpdateRecord(id, modelName) {
-    console.log('urlForUpdateRecord', id, modelName);
     return this.buildURL(modelName, id);
   }
 

--- a/ui/app/adapters/variable.js
+++ b/ui/app/adapters/variable.js
@@ -34,9 +34,9 @@ export default class VariableAdapter extends ApplicationAdapter {
   }
 
   urlForUpdateRecord(identifier, modelName, snapshot) {
-    const { namespace, id } = _extractIDAndNamespace(identifier, snapshot);
+    const { id } = _extractIDAndNamespace(identifier, snapshot);
     let baseUrl = this.buildURL(modelName, id);
-    return `${baseUrl}?namespace=${namespace}`;
+    return `${baseUrl}`;
   }
 
   urlForDeleteRecord(identifier, modelName, snapshot) {

--- a/ui/app/adapters/variable.js
+++ b/ui/app/adapters/variable.js
@@ -8,13 +8,10 @@ export default class VariableAdapter extends ApplicationAdapter {
 
   // PUT instead of POST on create;
   // /v1/var instead of /v1/vars on create (urlForFindRecord)
-  createRecord(_store, _type, snapshot) {
+  createRecord(_store, type, snapshot) {
     let data = this.serialize(snapshot);
-    return this.ajax(
-      this.urlForFindRecord(data.Path, snapshot.modelName),
-      'PUT',
-      { data }
-    );
+    let baseUrl = this.buildURL(type.modelName, data.ID);
+    return this.ajax(baseUrl, 'PUT', { data });
   }
 
   urlForFindAll(modelName) {

--- a/ui/app/adapters/variable.js
+++ b/ui/app/adapters/variable.js
@@ -10,6 +10,7 @@ export default class VariableAdapter extends ApplicationAdapter {
   // /v1/var instead of /v1/vars on create (urlForFindRecord)
   createRecord(_store, _type, snapshot) {
     let data = this.serialize(snapshot);
+    console.log('adapting', data);
     return this.ajax(
       this.urlForFindRecord(snapshot.id, snapshot.modelName),
       'PUT',
@@ -35,6 +36,7 @@ export default class VariableAdapter extends ApplicationAdapter {
   }
 
   urlForUpdateRecord(id, modelName) {
+    console.log('urlForUpdateRecord', id, modelName);
     return this.buildURL(modelName, id);
   }
 

--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -16,7 +16,7 @@
       </span>
       <Input
         @type="text"
-        @value={{@model.path}}
+        @value={{this.path}}
         placeholder="nomad/jobs/my-job/my-group/my-task"
         class="input path-input {{if this.duplicatePathWarning "error"}}"
         disabled={{not @model.isNew}}
@@ -26,7 +26,7 @@
       {{#if this.duplicatePathWarning}}
         <p class="duplicate-path-error help is-danger">
           There is already a Secure Variable located at
-          {{@model.path}}
+          {{this.path}}
           .
           <br />
           Please choose a different path, or

--- a/ui/app/components/secure-variable-form.hbs
+++ b/ui/app/components/secure-variable-form.hbs
@@ -20,7 +20,6 @@
         placeholder="nomad/jobs/my-job/my-group/my-task"
         class="input path-input {{if this.duplicatePathWarning "error"}}"
         disabled={{not @model.isNew}}
-        {{on "input" this.validatePath}}
         {{autofocus}}
         data-test-path-input
       />

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -6,7 +6,7 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { trimPath } from '../helpers/trim-path';
 import { copy } from 'ember-copy';
-import EmberObject, { computed, set } from '@ember/object';
+import EmberObject, { set, computed } from '@ember/object';
 // eslint-disable-next-line no-unused-vars
 import MutableArray from '@ember/array/mutable';
 import { A } from '@ember/array';

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -180,6 +180,7 @@ export default class SecureVariableFormComponent extends Component {
       });
       this.router.transitionTo('variables.variable', this.args.model.path);
     } catch (error) {
+      console.log('errrrrrrrr', error);
       this.flashMessages.add({
         title: `Error saving ${this.args.model.path}`,
         message: error,

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -178,7 +178,7 @@ export default class SecureVariableFormComponent extends Component {
         destroyOnClick: false,
         timeout: 5000,
       });
-      this.router.transitionTo('variables.variable', this.args.model.path);
+      this.router.transitionTo('variables.variable', this.args.model.id);
     } catch (error) {
       this.flashMessages.add({
         title: `Error saving ${this.args.model.path}`,

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -49,9 +49,8 @@ export default class SecureVariableFormComponent extends Component {
 
   get shouldDisableSave() {
     const disallowedPath =
-      this.args.model?.path?.startsWith('nomad/') &&
-      !this.args.model?.path?.startsWith('nomad/jobs');
-    return !!this.JSONError || !this.args.model?.path || disallowedPath;
+      this.path?.startsWith('nomad/') && !this.path?.startsWith('nomad/jobs');
+    return !!this.JSONError || !this.path || disallowedPath;
   }
 
   /**
@@ -99,7 +98,6 @@ export default class SecureVariableFormComponent extends Component {
   /**
    * @type {DuplicatePathWarning}
    */
-  // @computed('args.{model.path,existingVariables}', 'variableNamespace')
   get duplicatePathWarning() {
     const existingVariables = this.args.existingVariables || [];
     const pathValue = trimPath([this.path]);
@@ -175,12 +173,13 @@ export default class SecureVariableFormComponent extends Component {
       }
 
       this.args.model.set('keyValues', this.keyValues);
+      this.args.model.set('path', this.path);
       this.args.model.setAndTrimPath();
       await this.args.model.save();
 
       this.flashMessages.add({
         title: 'Secure Variable saved',
-        message: `${this.args.model.path} successfully saved`,
+        message: `${this.path} successfully saved`,
         type: 'success',
         destroyOnClick: false,
         timeout: 5000,
@@ -188,7 +187,7 @@ export default class SecureVariableFormComponent extends Component {
       this.router.transitionTo('variables.variable', this.args.model.id);
     } catch (error) {
       this.flashMessages.add({
-        title: `Error saving ${this.args.model.path}`,
+        title: `Error saving ${this.path}`,
         message: error,
         type: 'error',
         destroyOnClick: false,

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -145,7 +145,7 @@ export default class SecureVariableFormComponent extends Component {
     if (e.type === 'submit') {
       e.preventDefault();
     }
-    // TODO: temp, hacky way to force translation to tabular keyValues
+
     if (this.view === 'json') {
       this.translateAndValidateItems('table');
     }

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -180,7 +180,6 @@ export default class SecureVariableFormComponent extends Component {
       });
       this.router.transitionTo('variables.variable', this.args.model.path);
     } catch (error) {
-      console.log('errrrrrrrr', error);
       this.flashMessages.add({
         title: `Error saving ${this.args.model.path}`,
         message: error,

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -4,6 +4,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
+import { trimPath } from '../helpers/trim-path';
 import { copy } from 'ember-copy';
 import EmberObject, { computed, set } from '@ember/object';
 // eslint-disable-next-line no-unused-vars
@@ -95,12 +96,11 @@ export default class SecureVariableFormComponent extends Component {
   @computed('args.{model.path,existingVariables}', 'variableNamespace')
   get duplicatePathWarning() {
     const existingVariables = this.args.existingVariables || [];
+    const pathValue = trimPath([this.args.model.path]);
     let existingVariable = existingVariables
       .without(this.args.model)
       .find(
-        (v) =>
-          v.path === this.args.model.path &&
-          v.namespace === this.variableNamespace
+        (v) => v.path === pathValue && v.namespace === this.variableNamespace
       );
     if (existingVariable) {
       return {

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -4,7 +4,6 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
-import { trimPath } from '../helpers/trim-path';
 import { copy } from 'ember-copy';
 import EmberObject, { computed, set } from '@ember/object';
 // eslint-disable-next-line no-unused-vars
@@ -93,17 +92,16 @@ export default class SecureVariableFormComponent extends Component {
   /**
    * @type {DuplicatePathWarning}
    */
-  @computed('args.model.path', 'args.existingVariables', 'variableNamespace')
+  @computed('args.{model.path,existingVariables}', 'variableNamespace')
   get duplicatePathWarning() {
     const existingVariables = this.args.existingVariables || [];
     let existingVariable = existingVariables
       .without(this.args.model)
-      .find((v) => {
-        return (
+      .find(
+        (v) =>
           v.path === this.args.model.path &&
           v.namespace === this.variableNamespace
-        );
-      });
+      );
     if (existingVariable) {
       return {
         path: existingVariable.path,

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -6,7 +6,7 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { trimPath } from '../helpers/trim-path';
 import { copy } from 'ember-copy';
-import EmberObject, { set, computed } from '@ember/object';
+import EmberObject, { set } from '@ember/object';
 // eslint-disable-next-line no-unused-vars
 import MutableArray from '@ember/array/mutable';
 import { A } from '@ember/array';
@@ -25,6 +25,12 @@ export default class SecureVariableFormComponent extends Component {
 
   @tracked variableNamespace = null;
   @tracked namespaceOptions = null;
+
+  @tracked path = '';
+  constructor() {
+    super(...arguments);
+    set(this, 'path', this.args.model.path);
+  }
 
   @action
   setNamespace(namespace) {
@@ -93,10 +99,10 @@ export default class SecureVariableFormComponent extends Component {
   /**
    * @type {DuplicatePathWarning}
    */
-  @computed('args.{model.path,existingVariables}', 'variableNamespace')
+  // @computed('args.{model.path,existingVariables}', 'variableNamespace')
   get duplicatePathWarning() {
     const existingVariables = this.args.existingVariables || [];
-    const pathValue = trimPath([this.args.model.path]);
+    const pathValue = trimPath([this.path]);
     let existingVariable = existingVariables
       .without(this.args.model)
       .find(

--- a/ui/app/components/secure-variable-form.js
+++ b/ui/app/components/secure-variable-form.js
@@ -6,7 +6,7 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { trimPath } from '../helpers/trim-path';
 import { copy } from 'ember-copy';
-import EmberObject, { set } from '@ember/object';
+import EmberObject, { computed, set } from '@ember/object';
 // eslint-disable-next-line no-unused-vars
 import MutableArray from '@ember/array/mutable';
 import { A } from '@ember/array';
@@ -23,15 +23,6 @@ export default class SecureVariableFormComponent extends Component {
   @service router;
   @service store;
 
-  /**
-   * @typedef {Object} DuplicatePathWarning
-   * @property {string} path
-   */
-
-  /**
-   * @type {DuplicatePathWarning}
-   */
-  @tracked duplicatePathWarning = null;
   @tracked variableNamespace = null;
   @tracked namespaceOptions = null;
 
@@ -94,19 +85,31 @@ export default class SecureVariableFormComponent extends Component {
     ]);
   }
 
-  @action
-  validatePath(e) {
-    const value = trimPath([e.target.value]);
+  /**
+   * @typedef {Object} DuplicatePathWarning
+   * @property {string} path
+   */
+
+  /**
+   * @type {DuplicatePathWarning}
+   */
+  @computed('args.model.path', 'args.existingVariables', 'variableNamespace')
+  get duplicatePathWarning() {
     const existingVariables = this.args.existingVariables || [];
     let existingVariable = existingVariables
       .without(this.args.model)
-      .find((v) => v.path === value);
+      .find((v) => {
+        return (
+          v.path === this.args.model.path &&
+          v.namespace === this.variableNamespace
+        );
+      });
     if (existingVariable) {
-      this.duplicatePathWarning = {
+      return {
         path: existingVariable.path,
       };
     } else {
-      this.duplicatePathWarning = null;
+      return null;
     }
   }
 

--- a/ui/app/components/variable-paths.hbs
+++ b/ui/app/components/variable-paths.hbs
@@ -25,6 +25,7 @@
     {{/each}}
 
     {{#each this.files as |file|}}
+    {{log "FILE" file}}
       <tr
         data-test-file-row
         {{on "click" (fn this.handleFileClick file)}}
@@ -35,7 +36,7 @@
           {{#if (can "read variable" path=file.absoluteFilePath namespace=file.variable.namespace)}}
           <LinkTo
             @route="variables.variable"
-            @model={{file.absoluteFilePath}}
+            @model={{file.variable.id}}
             @query={{hash namespace="*"}}
           >
             {{file.name}}

--- a/ui/app/components/variable-paths.hbs
+++ b/ui/app/components/variable-paths.hbs
@@ -25,7 +25,6 @@
     {{/each}}
 
     {{#each this.files as |file|}}
-    {{log "FILE" file}}
       <tr
         data-test-file-row
         {{on "click" (fn this.handleFileClick file)}}

--- a/ui/app/components/variable-paths.js
+++ b/ui/app/components/variable-paths.js
@@ -26,7 +26,7 @@ export default class VariablePathsComponent extends Component {
   }
 
   @action
-  async handleFileClick({ path, namespace, variable: { id } }) {
+  async handleFileClick({ path, variable: { id, namespace } }) {
     if (this.can.can('read variable', null, { path, namespace })) {
       this.router.transitionTo('variables.variable', id);
     }

--- a/ui/app/components/variable-paths.js
+++ b/ui/app/components/variable-paths.js
@@ -26,7 +26,7 @@ export default class VariablePathsComponent extends Component {
   }
 
   @action
-  async handleFileClick({ path, id, variable: { namespace } }) {
+  async handleFileClick({ path, namespace, variable: { id } }) {
     if (this.can.can('read variable', null, { path, namespace })) {
       this.router.transitionTo('variables.variable', id);
     }

--- a/ui/app/components/variable-paths.js
+++ b/ui/app/components/variable-paths.js
@@ -26,9 +26,9 @@ export default class VariablePathsComponent extends Component {
   }
 
   @action
-  async handleFileClick({ path, variable: { namespace } }) {
+  async handleFileClick({ path, id, variable: { namespace } }) {
     if (this.can.can('read variable', null, { path, namespace })) {
-      this.router.transitionTo('variables.variable', path);
+      this.router.transitionTo('variables.variable', id);
     }
   }
 }

--- a/ui/app/controllers/variables/path.js
+++ b/ui/app/controllers/variables/path.js
@@ -4,16 +4,23 @@ import { action } from '@ember/object';
 const ALL_NAMESPACE_WILDCARD = '*';
 
 export default class VariablesPathController extends Controller {
+  get absolutePath() {
+    return this.model?.absolutePath || '';
+  }
   get breadcrumbs() {
-    let crumbs = [];
-    this.model.absolutePath.split('/').reduce((m, n) => {
-      crumbs.push({
-        label: n,
-        args: [`variables.path`, m + n],
-      });
-      return m + n + '/';
-    }, []);
-    return crumbs;
+    if (this.absolutePath) {
+      let crumbs = [];
+      this.absolutePath.split('/').reduce((m, n) => {
+        crumbs.push({
+          label: n,
+          args: [`variables.path`, m + n],
+        });
+        return m + n + '/';
+      }, []);
+      return crumbs;
+    } else {
+      return [];
+    }
   }
 
   @controller variables;

--- a/ui/app/controllers/variables/variable.js
+++ b/ui/app/controllers/variables/variable.js
@@ -3,7 +3,7 @@ import Controller from '@ember/controller';
 export default class VariablesVariableController extends Controller {
   get breadcrumbs() {
     let crumbs = [];
-    let id = this.params.id.split('@').slice(0, -1).join('@'); // remove namespace
+    let id = decodeURI(this.params.id.split('@').slice(0, -1).join('@')); // remove namespace
     let namespace = this.params.id.split('@').slice(-1)[0];
     id.split('/').reduce((m, n) => {
       crumbs.push({

--- a/ui/app/controllers/variables/variable.js
+++ b/ui/app/controllers/variables/variable.js
@@ -3,12 +3,14 @@ import Controller from '@ember/controller';
 export default class VariablesVariableController extends Controller {
   get breadcrumbs() {
     let crumbs = [];
-    this.params.path.split('/').reduce((m, n) => {
+    let id = this.params.id.split('@').slice(0, -1).join(''); // remove namespace
+    let namespace = this.params.id.split('@').slice(-1)[0];
+    id.split('/').reduce((m, n) => {
       crumbs.push({
         label: n,
         args:
-          m + n === this.params.path // If the last crumb, link to the var itself
-            ? [`variables.variable`, m + n]
+          m + n === id // If the last crumb, link to the var itself
+            ? [`variables.variable`, `${m + n}@${namespace}`]
             : [`variables.path`, m + n],
       });
       return m + n + '/';

--- a/ui/app/controllers/variables/variable.js
+++ b/ui/app/controllers/variables/variable.js
@@ -3,7 +3,7 @@ import Controller from '@ember/controller';
 export default class VariablesVariableController extends Controller {
   get breadcrumbs() {
     let crumbs = [];
-    let id = this.params.id.split('@').slice(0, -1).join(''); // remove namespace
+    let id = this.params.id.split('@').slice(0, -1).join('@'); // remove namespace
     let namespace = this.params.id.split('@').slice(-1)[0];
     id.split('/').reduce((m, n) => {
       crumbs.push({

--- a/ui/app/helpers/trim-path.js
+++ b/ui/app/helpers/trim-path.js
@@ -6,7 +6,8 @@ import Helper from '@ember/component/helper';
  * @param {Array<string>} params
  * @returns {string}
  */
-export function trimPath([path = '']) {
+export function trimPath([path]) {
+  if (!path) return;
   if (path.startsWith('/')) {
     path = trimPath([path.slice(1)]);
   }

--- a/ui/app/helpers/trim-path.js
+++ b/ui/app/helpers/trim-path.js
@@ -11,7 +11,7 @@ export function trimPath([path]) {
   if (path.startsWith('/')) {
     path = trimPath([path.slice(1)]);
   }
-  if (path.endsWith('/')) {
+  if (path?.endsWith('/')) {
     path = trimPath([path.slice(0, -1)]);
   }
   return path;

--- a/ui/app/models/variable.js
+++ b/ui/app/models/variable.js
@@ -62,6 +62,8 @@ export default class VariableModel extends Model {
     return folderPath.join('/');
   }
 
+  @attr('string', { defaultValue: '' }) plainId;
+
   /**
    * Removes starting and trailing slashes, pathLinkedEntitiesand sets the ID property
    */

--- a/ui/app/models/variable.js
+++ b/ui/app/models/variable.js
@@ -62,14 +62,14 @@ export default class VariableModel extends Model {
     return folderPath.join('/');
   }
 
-  @attr('string', { defaultValue: '' }) plainId;
-
   /**
    * Removes starting and trailing slashes, pathLinkedEntitiesand sets the ID property
    */
   setAndTrimPath() {
     this.set('path', trimPath([this.path]));
-    this.set('id', this.get('path'));
+    if (!this.get('id')) {
+      this.set('id', `${this.get('path')}@${this.get('namespace')}`);
+    }
   }
 
   /**

--- a/ui/app/router.js
+++ b/ui/app/router.js
@@ -84,7 +84,7 @@ Router.map(function () {
     this.route(
       'variable',
       {
-        path: '/var/*path',
+        path: '/var/*id',
       },
       function () {
         this.route('edit');

--- a/ui/app/routes/variables.js
+++ b/ui/app/routes/variables.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
-import notifyError from 'nomad-ui/utils/notify-error';
+import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 import PathTree from 'nomad-ui/utils/path-tree';
 
 export default class VariablesRoute extends Route.extend(WithForbiddenState) {
@@ -30,13 +30,13 @@ export default class VariablesRoute extends Route.extend(WithForbiddenState) {
         { namespace },
         { reload: true }
       );
-
       return {
         variables,
         pathTree: new PathTree(variables),
       };
     } catch (e) {
-      notifyError(this)(e);
+      notifyForbidden(this)(e);
+      return e;
     }
   }
 }

--- a/ui/app/routes/variables/index.js
+++ b/ui/app/routes/variables/index.js
@@ -1,11 +1,19 @@
 import Route from '@ember/routing/route';
+import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
+import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 
-export default class VariablesIndexRoute extends Route {
+export default class VariablesIndexRoute extends Route.extend(
+  WithForbiddenState
+) {
   model() {
-    const { variables, pathTree } = this.modelFor('variables');
-    return {
-      variables,
-      root: pathTree.paths.root,
-    };
+    if (this.modelFor('variables').errors) {
+      notifyForbidden(this)(this.modelFor('variables'));
+    } else {
+      const { variables, pathTree } = this.modelFor('variables');
+      return {
+        variables,
+        root: pathTree.paths.root,
+      };
+    }
   }
 }

--- a/ui/app/routes/variables/path.js
+++ b/ui/app/routes/variables/path.js
@@ -1,12 +1,20 @@
 import Route from '@ember/routing/route';
-export default class VariablesPathRoute extends Route {
+import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
+import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
+export default class VariablesPathRoute extends Route.extend(
+  WithForbiddenState
+) {
   model({ absolutePath }) {
-    const treeAtPath =
-      this.modelFor('variables').pathTree.findPath(absolutePath);
-    if (treeAtPath) {
-      return { treeAtPath, absolutePath };
+    if (this.modelFor('variables').errors) {
+      notifyForbidden(this)(this.modelFor('variables'));
     } else {
-      return { absolutePath };
+      const treeAtPath =
+        this.modelFor('variables').pathTree.findPath(absolutePath);
+      if (treeAtPath) {
+        return { treeAtPath, absolutePath };
+      } else {
+        return { absolutePath };
+      }
     }
   }
 }

--- a/ui/app/routes/variables/variable.js
+++ b/ui/app/routes/variables/variable.js
@@ -8,7 +8,6 @@ export default class VariablesVariableRoute extends Route.extend(
 ) {
   @service store;
   model(params) {
-    // console.log('paramas', params, this.store.findAll('variable'));
     return this.store
       .findRecord('variable', decodeURIComponent(params.id), {
         reload: true,

--- a/ui/app/routes/variables/variable.js
+++ b/ui/app/routes/variables/variable.js
@@ -8,8 +8,9 @@ export default class VariablesVariableRoute extends Route.extend(
 ) {
   @service store;
   model(params) {
+    // console.log('paramas', params, this.store.findAll('variable'));
     return this.store
-      .findRecord('variable', decodeURIComponent(params.path), {
+      .findRecord('variable', decodeURIComponent(params.id), {
         reload: true,
       })
       .catch(notifyForbidden(this));

--- a/ui/app/serializers/variable.js
+++ b/ui/app/serializers/variable.js
@@ -6,6 +6,15 @@ export default class VariableSerializer extends ApplicationSerializer {
   primaryKey = 'Path';
   separateNanos = ['CreateTime', 'ModifyTime'];
 
+  normalize(typeHash, hash) {
+    // hash.NamespaceID = hash.Namespace;
+
+    // ID is a composite of both the job ID and the namespace the job is in
+    hash.PlainId = hash.ID;
+    hash.ID = JSON.stringify([hash.Path, hash.Namespace || 'default']);
+    return super.normalize(typeHash, hash);
+  }
+
   // Transform API's Items object into an array of a KeyValue objects
   normalizeFindRecordResponse(store, typeClass, hash, id, ...args) {
     // TODO: prevent items-less saving at API layer
@@ -38,6 +47,7 @@ export default class VariableSerializer extends ApplicationSerializer {
     delete json.KeyValues;
     delete json.ModifyTime;
     delete json.CreateTime;
+    console.log('serializing', json);
     return json;
   }
 }

--- a/ui/app/serializers/variable.js
+++ b/ui/app/serializers/variable.js
@@ -3,7 +3,6 @@ import ApplicationSerializer from './application';
 
 @classic
 export default class VariableSerializer extends ApplicationSerializer {
-  // primaryKey = 'Path';
   separateNanos = ['CreateTime', 'ModifyTime'];
 
   normalize(typeHash, hash) {

--- a/ui/app/serializers/variable.js
+++ b/ui/app/serializers/variable.js
@@ -10,7 +10,6 @@ export default class VariableSerializer extends ApplicationSerializer {
     // hash.NamespaceID = hash.Namespace;
 
     // ID is a composite of both the job ID and the namespace the job is in
-    hash.PlainId = hash.Path;
     hash.ID = `${hash.Path}@${hash.Namespace || 'default'}`;
     return super.normalize(typeHash, hash);
   }
@@ -39,8 +38,8 @@ export default class VariableSerializer extends ApplicationSerializer {
 
   // Transform our KeyValues array into an Items object
   serialize(snapshot, options) {
-    console.log('about to serialize', snapshot);
     const json = super.serialize(snapshot, options);
+    json.ID = json.Path;
     json.Items = json.KeyValues.reduce((acc, { key, value }) => {
       acc[key] = value;
       return acc;
@@ -48,7 +47,6 @@ export default class VariableSerializer extends ApplicationSerializer {
     delete json.KeyValues;
     delete json.ModifyTime;
     delete json.CreateTime;
-    console.log('serializing', json);
     return json;
   }
 }

--- a/ui/app/serializers/variable.js
+++ b/ui/app/serializers/variable.js
@@ -7,8 +7,6 @@ export default class VariableSerializer extends ApplicationSerializer {
   separateNanos = ['CreateTime', 'ModifyTime'];
 
   normalize(typeHash, hash) {
-    // hash.NamespaceID = hash.Namespace;
-
     // ID is a composite of both the job ID and the namespace the job is in
     hash.ID = `${hash.Path}@${hash.Namespace || 'default'}`;
     return super.normalize(typeHash, hash);
@@ -16,7 +14,6 @@ export default class VariableSerializer extends ApplicationSerializer {
 
   // Transform API's Items object into an array of a KeyValue objects
   normalizeFindRecordResponse(store, typeClass, hash, id, ...args) {
-    // TODO: prevent items-less saving at API layer
     if (!hash.Items) {
       hash.Items = { '': '' };
     }

--- a/ui/app/serializers/variable.js
+++ b/ui/app/serializers/variable.js
@@ -3,15 +3,15 @@ import ApplicationSerializer from './application';
 
 @classic
 export default class VariableSerializer extends ApplicationSerializer {
-  primaryKey = 'Path';
+  // primaryKey = 'Path';
   separateNanos = ['CreateTime', 'ModifyTime'];
 
   normalize(typeHash, hash) {
     // hash.NamespaceID = hash.Namespace;
 
     // ID is a composite of both the job ID and the namespace the job is in
-    hash.PlainId = hash.ID;
-    hash.ID = JSON.stringify([hash.Path, hash.Namespace || 'default']);
+    hash.PlainId = hash.Path;
+    hash.ID = `${hash.Path}@${hash.Namespace || 'default'}`;
     return super.normalize(typeHash, hash);
   }
 
@@ -39,6 +39,7 @@ export default class VariableSerializer extends ApplicationSerializer {
 
   // Transform our KeyValues array into an Items object
   serialize(snapshot, options) {
+    console.log('about to serialize', snapshot);
     const json = super.serialize(snapshot, options);
     json.Items = json.KeyValues.reduce((acc, { key, value }) => {
       acc[key] = value;

--- a/ui/app/templates/variables/index.hbs
+++ b/ui/app/templates/variables/index.hbs
@@ -35,32 +35,36 @@
       </div>
     </div>
   </div>
-  {{#if this.hasVariables}}
-    <VariablePaths
-      @branch={{this.root}}
-    />
+  {{#if this.isForbidden}}
+    <ForbiddenMessage />
   {{else}}
-    <div class="empty-message">
-      {{#if (eq this.namespaceSelection "*")}}
-        <h3 data-test-empty-variables-list-headline class="empty-message-headline">
-          No Secure Variables
-        </h3>
-        {{#if (can "write variable" path="*" namespace=this.namespaceSelection)}}
+    {{#if this.hasVariables}}
+      <VariablePaths
+        @branch={{this.root}}
+      />
+    {{else}}
+      <div class="empty-message">
+        {{#if (eq this.namespaceSelection "*")}}
+          <h3 data-test-empty-variables-list-headline class="empty-message-headline">
+            No Secure Variables
+          </h3>
+          {{#if (can "write variable" path="*" namespace=this.namespaceSelection)}}
+            <p class="empty-message-body">
+              Get started by <LinkTo @route="variables.new">creating a new secure variable</LinkTo>
+            </p>
+          {{/if}}
+        {{else}}
+          <h3 data-test-no-matching-variables-list-headline class="empty-message-headline">
+            No Matches
+          </h3>
           <p class="empty-message-body">
-            Get started by <LinkTo @route="variables.new">creating a new secure variable</LinkTo>
+            No paths or variables match the namespace
+            <strong>
+              {{this.namespaceSelection}}
+            </strong>
           </p>
         {{/if}}
-      {{else}}
-        <h3 data-test-no-matching-variables-list-headline class="empty-message-headline">
-          No Matches
-        </h3>
-        <p class="empty-message-body">
-          No paths or variables match the namespace
-          <strong>
-            {{this.namespaceSelection}}
-          </strong>
-        </p>
-      {{/if}}
-    </div>
+      </div>
+    {{/if}}
   {{/if}}
 </section>

--- a/ui/app/templates/variables/path.hbs
+++ b/ui/app/templates/variables/path.hbs
@@ -1,4 +1,4 @@
-{{page-title "Secure Variables: " this.model.absolutePath}}
+{{page-title "Secure Variables: " this.absolutePath}}
 {{#each this.breadcrumbs as |crumb|}}
   <Breadcrumb @crumb={{crumb}} />
 {{/each}}
@@ -15,52 +15,55 @@
           />
         {{/if}}
         <div class="button-bar">
-        {{#if (can "write variable" path=(concat this.model.absolutePath "/") namespace=this.namespaceSelection)}}
-          <LinkTo
-            @route="variables.new"
-            @query={{hash path=(concat this.model.absolutePath "/")}}
-            class="button is-primary"
-          >
-            Create Secure Variable
-          </LinkTo>
-        {{else}}
-          <button
-            class="button is-primary is-disabled tooltip is-right-aligned"
-            aria-label="You don’t have sufficient permissions"
-            disabled
-            type="button"
-          >
-            Create Secure Variable
-          </button>
-        {{/if}}
-
+          {{#if (can "write variable" path=(concat this.absolutePath "/") namespace=this.namespaceSelection)}}
+            <LinkTo
+              @route="variables.new"
+              @query={{hash path=(concat this.absolutePath "/")}}
+              class="button is-primary"
+            >
+              Create Secure Variable
+            </LinkTo>
+          {{else}}
+            <button
+              class="button is-primary is-disabled tooltip is-right-aligned"
+              aria-label="You don’t have sufficient permissions"
+              disabled
+              type="button"
+            >
+              Create Secure Variable
+            </button>
+          {{/if}}
         </div>
       </div>
     </div>
-{{#if this.model.treeAtPath}}
-  <VariablePaths
-    @branch={{this.model.treeAtPath}}
-  />
-{{else}}
-  <div class="empty-message">
-    {{#if (eq this.namespaceSelection "*")}}
-      <h3 data-test-empty-variables-list-headline class="empty-message-headline">
-        Path /{{this.model.absolutePath}} contains no variables
-      </h3>
-      <p class="empty-message-body">
-        To get started, <LinkTo @route="variables.new" @query={{hash path=(concat this.model.absolutePath "/")}}>create a new secure variable here</LinkTo>, or <LinkTo @route="variables">go back to the Secure Variables root directory</LinkTo>.
-      </p>
+    {{#if this.isForbidden}}
+      <ForbiddenMessage />
     {{else}}
-      <h3 data-test-no-matching-variables-list-headline class="empty-message-headline">
-        No Matches
-      </h3>
-      <p class="empty-message-body">
-        No paths or variables match the namespace 
-        <strong>
-          {{this.namespaceSelection}}
-        </strong>
-      </p>
+      {{#if this.model.treeAtPath}}
+        <VariablePaths
+          @branch={{this.model.treeAtPath}}
+        />
+      {{else}}
+        <div class="empty-message">
+          {{#if (eq this.namespaceSelection "*")}}
+            <h3 data-test-empty-variables-list-headline class="empty-message-headline">
+              Path /{{this.absolutePath}} contains no variables
+            </h3>
+            <p class="empty-message-body">
+              To get started, <LinkTo @route="variables.new" @query={{hash path=(concat this.absolutePath "/")}}>create a new secure variable here</LinkTo>, or <LinkTo @route="variables">go back to the Secure Variables root directory</LinkTo>.
+            </p>
+          {{else}}
+            <h3 data-test-no-matching-variables-list-headline class="empty-message-headline">
+              No Matches
+            </h3>
+            <p class="empty-message-body">
+              No paths or variables match the namespace 
+              <strong>
+                {{this.namespaceSelection}}
+              </strong>
+            </p>
+          {{/if}}
+        </div>
+      {{/if}}
     {{/if}}
-  </div>
-{{/if}}
   </section>

--- a/ui/app/templates/variables/path.hbs
+++ b/ui/app/templates/variables/path.hbs
@@ -15,7 +15,7 @@
           />
         {{/if}}
         <div class="button-bar">
-        {{#if (can "write variable" path=this.model.absolutePath namespace=this.namespaceSelection)}}
+        {{#if (can "write variable" path=(concat this.model.absolutePath "/") namespace=this.namespaceSelection)}}
           <LinkTo
             @route="variables.new"
             @query={{hash path=(concat this.model.absolutePath "/")}}

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -853,9 +853,9 @@ export default function () {
   this.put('/var/:id', function (schema, request) {
     const { Path, Namespace, Items } = JSON.parse(request.requestBody);
     return server.create('variable', {
-      Path,
-      Namespace,
-      Items,
+      path: Path,
+      namespace: Namespace,
+      items: Items,
       id: Path,
     });
   });
@@ -863,7 +863,7 @@ export default function () {
   this.delete('/var/:id', function (schema, request) {
     const { id } = request.params;
     server.db.variables.remove(id);
-    return okEmpty();
+    return '';
   });
 
   //#endregion Secure Variables

--- a/ui/mirage/factories/variable.js
+++ b/ui/mirage/factories/variable.js
@@ -25,14 +25,10 @@ export default Factory.extend({
   },
 
   afterCreate(variable, server) {
-    if (!variable.namespaceId) {
+    if (!variable.namespace) {
       const namespace = pickOne(server.db.jobs)?.namespace || 'default';
       variable.update({
         namespace,
-      });
-    } else {
-      variable.update({
-        namespace: variable.namespaceId,
       });
     }
   },

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -80,17 +80,17 @@ function smallCluster(server) {
 
   server.create('variable', {
     id: `nomad/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}/${variableLinkedTask.name}`,
-    namespaceId: variableLinkedJob.namespace,
+    namespace: variableLinkedJob.namespace,
   });
 
   server.create('variable', {
     id: `nomad/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}`,
-    namespaceId: variableLinkedJob.namespace,
+    namespace: variableLinkedJob.namespace,
   });
 
   server.create('variable', {
     id: `nomad/jobs/${variableLinkedJob.id}`,
-    namespaceId: variableLinkedJob.namespace,
+    namespace: variableLinkedJob.namespace,
   });
 
   // #region evaluations
@@ -207,17 +207,17 @@ function variableTestCluster(server) {
 
   server.create('variable', {
     id: `nomad/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}/${variableLinkedTask.name}`,
-    namespaceId: variableLinkedJob.namespace,
+    namespace: variableLinkedJob.namespace,
   });
 
   server.create('variable', {
     id: `nomad/jobs/${variableLinkedJob.id}/${variableLinkedGroup.name}`,
-    namespaceId: variableLinkedJob.namespace,
+    namespace: variableLinkedJob.namespace,
   });
 
   server.create('variable', {
     id: `nomad/jobs/${variableLinkedJob.id}`,
-    namespaceId: variableLinkedJob.namespace,
+    namespace: variableLinkedJob.namespace,
   });
 }
 

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -200,9 +200,6 @@ function variableTestCluster(server) {
     'w/x/y/foo9',
     'w/x/y/z/foo10',
     'w/x/y/z/bar11',
-    'just some arbitrary file',
-    'another arbitrary file',
-    'another arbitrary file again',
   ].forEach((path) => server.create('variable', { id: path }));
 
   server.create('variable', {
@@ -218,6 +215,21 @@ function variableTestCluster(server) {
   server.create('variable', {
     id: `nomad/jobs/${variableLinkedJob.id}`,
     namespace: variableLinkedJob.namespace,
+  });
+
+  server.create('variable', {
+    id: 'just some arbitrary file',
+    namespace: 'namespace-2',
+  });
+
+  server.create('variable', {
+    id: 'another arbitrary file',
+    namespace: 'namespace-2',
+  });
+
+  server.create('variable', {
+    id: 'another arbitrary file again',
+    namespace: 'namespace-2',
   });
 }
 

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -335,7 +335,7 @@ module('Acceptance | secure variables', function (hooks) {
     await click('button[type="submit"]');
 
     assert.dom('.flash-message.alert-success').exists();
-    assert.equal(currentURL(), '/variables/var/foo/bar');
+    assert.equal(currentURL(), '/variables/var/foo/bar@default');
   });
 
   test('it passes an accessibility audit', async function (assert) {

--- a/ui/tests/acceptance/secure-variables-test.js
+++ b/ui/tests/acceptance/secure-variables-test.js
@@ -103,9 +103,8 @@ module('Acceptance | secure variables', function (hooks) {
     await percySnapshot(assert);
 
     await click(fooLink);
-    assert.equal(
-      currentURL(),
-      '/variables/var/a/b/c/foo0',
+    assert.ok(
+      currentURL().includes('/variables/var/a/b/c/foo0'),
       'correctly traverses to a deeply nested variable file'
     );
     const deleteButton = find('[data-test-delete-button] button');
@@ -173,9 +172,8 @@ module('Acceptance | secure variables', function (hooks) {
     assert.ok(nonJobLink, 'non-job file is present');
 
     await click(nonJobLink);
-    assert.equal(
-      currentURL(),
-      '/variables/var/just some arbitrary file',
+    assert.ok(
+      currentURL().includes('/variables/var/just some arbitrary file'),
       'correctly traverses to a non-job file'
     );
     let relatedEntitiesBox = find('.related-entities');
@@ -335,7 +333,10 @@ module('Acceptance | secure variables', function (hooks) {
     await click('button[type="submit"]');
 
     assert.dom('.flash-message.alert-success').exists();
-    assert.equal(currentURL(), '/variables/var/foo/bar@default');
+    assert.ok(
+      currentURL().includes('/variables/var/foo'),
+      'drops you back off to the parent page'
+    );
   });
 
   test('it passes an accessibility audit', async function (assert) {
@@ -514,7 +515,6 @@ module('Acceptance | secure variables', function (hooks) {
       await typeIn('[data-test-var-key]', 'kiki');
       await typeIn('[data-test-var-value]', 'do you love me');
       await click('[data-test-submit-var]');
-
       assert.equal(
         currentRouteName(),
         'variables.variable.index',

--- a/ui/tests/integration/components/variable-paths-test.js
+++ b/ui/tests/integration/components/variable-paths-test.js
@@ -6,26 +6,34 @@ import { hbs } from 'ember-cli-htmlbars';
 import { componentA11yAudit } from 'nomad-ui/tests/helpers/a11y-audit';
 import pathTree from 'nomad-ui/utils/path-tree';
 import Service from '@ember/service';
-
-const PATHSTRINGS = [
-  { path: '/foo/bar/baz' },
-  { path: '/foo/bar/bay' },
-  { path: '/foo/bar/bax' },
-  { path: '/a/b' },
-  { path: '/a/b/c' },
-  { path: '/a/b/canary' },
-  { path: '/a/b/canine' },
-  { path: '/a/b/chipmunk' },
-  { path: '/a/b/c/d' },
-  { path: '/a/b/c/dalmation/index' },
-  { path: '/a/b/c/doberman/index' },
-  { path: '/a/b/c/dachshund/index' },
-  { path: '/a/b/c/dachshund/poppy' },
-];
-const tree = new pathTree(PATHSTRINGS);
+let tree;
 
 module('Integration | Component | variable-paths', function (hooks) {
   setupRenderingTest(hooks);
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+
+    const PATHSTRINGS = [
+      { path: '/foo/bar/baz' },
+      { path: '/foo/bar/bay' },
+      { path: '/foo/bar/bax' },
+      { path: '/a/b' },
+      { path: '/a/b/c' },
+      { path: '/a/b/canary' },
+      { path: '/a/b/canine' },
+      { path: '/a/b/chipmunk' },
+      { path: '/a/b/c/d' },
+      { path: '/a/b/c/dalmation/index' },
+      { path: '/a/b/c/doberman/index' },
+      { path: '/a/b/c/dachshund/index' },
+      { path: '/a/b/c/dachshund/poppy' },
+    ].map((x) => {
+      const varInstance = this.store.createRecord('variable', x);
+      varInstance.setAndTrimPath();
+      return varInstance;
+    });
+    tree = new pathTree(PATHSTRINGS);
+  });
 
   test('it renders without data', async function (assert) {
     assert.expect(2);
@@ -109,21 +117,21 @@ module('Integration | Component | variable-paths', function (hooks) {
       .dom('tbody tr:first-child td:first-child a')
       .hasAttribute(
         'href',
-        '/ui/variables/var/foo/bar/baz',
+        '/ui/variables/var/foo/bar/baz@default',
         'Correctly links the first file'
       );
     assert
       .dom('tbody tr:nth-child(2) td:first-child a')
       .hasAttribute(
         'href',
-        '/ui/variables/var/foo/bar/bay',
+        '/ui/variables/var/foo/bar/bay@default',
         'Correctly links the second file'
       );
     assert
       .dom('tbody tr:nth-child(3) td:first-child a')
       .hasAttribute(
         'href',
-        '/ui/variables/var/foo/bar/bax',
+        '/ui/variables/var/foo/bar/bax@default',
         'Correctly links the third file'
       );
     assert

--- a/ui/tests/unit/adapters/variable-test.js
+++ b/ui/tests/unit/adapters/variable-test.js
@@ -12,7 +12,7 @@ module('Unit | Adapter | Variable', function (hooks) {
     // we're incorrectly passing an object with a `Model` interface
     // we should be passing a `Snapshot`
     // hacky fix to rectify the issue
-    newVariable.attr = () => 'default';
+    newVariable.attr = () => {};
 
     assert.equal(
       this.subject().urlForFindAll('variable'),


### PR DESCRIPTION
resolves #14066, #13950 and #14066

Adds namespaces to the stored identity of variables.

This means you can have multiple variables at `a/b/c/foo0` if their namespaces are different.

IDs are now stored in the browser as `<pathname>@<namespace>`, or `a/b/c/foo0@default` in the above case, and URLs reflect this:
![image](https://user-images.githubusercontent.com/713991/184234701-0754c399-3d67-462d-92c4-b46e75b2ca08.png)



Note that we now display same-pathed, different-namespaced variables alongside one another:
![image](https://user-images.githubusercontent.com/713991/184236007-e8c8fc91-1315-4cfa-8a55-a4bceee7811a.png)
