### PR TITLE
cli: support vault token in plan command

### DIFF
--- a/.changelog/14088.txt
+++ b/.changelog/14088.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a bug where vault token not respected in plan command
+```

--- a/website/content/docs/commands/job/plan.mdx
+++ b/website/content/docs/commands/job/plan.mdx
@@ -48,6 +48,10 @@ Plan will return one of the following exit codes:
 - 1: Allocations created or destroyed.
 - 255: Error determining plan results.
 
+The plan command will set the `vault_token` of the job based on the following
+precedence, going from highest to lowest: the `-vault-token` flag, the
+`$VAULT_TOKEN` environment variable and finally the value in the job file.
+
 When ACLs are enabled, this command requires a token with the `submit-job`
 capability for the job's namespace.
 
@@ -72,6 +76,20 @@ capability for the job's namespace.
 - `-hcl2-strict`: Whether an error should be produced from the HCL2 parser where
   a variable has been supplied which is not defined within the root variables.
   Defaults to true.
+
+- `-vault-token`: Used to validate if the user submitting the job has
+  permission to run the job according to its Vault policies. A Vault token must
+  be supplied if the [`vault` stanza `allow_unauthenticated`] is disabled in
+  the Nomad server configuration. If the `-vault-token` flag is set, the passed
+  Vault token is added to the jobspec before sending to the Nomad servers. This
+  allows passing the Vault token without storing it in the job file. This
+  overrides the token found in the `$VAULT_TOKEN` environment variable and the
+  [`vault_token`] field in the job file. This token is cleared from the job
+  after planning and cannot be used within the job executing environment. Use
+  the `vault` stanza when templating in a job with a Vault token.
+
+- `-vault-namespace`: If set, the passed Vault namespace is stored in the job
+  before sending to the Nomad servers.
 
 - `-var=<key=value>`: Variable for template, can be used multiple times.
 
@@ -241,3 +259,5 @@ if a change is detected.
 [`go-getter`]: https://github.com/hashicorp/go-getter
 [`nomad job run -check-index`]: /docs/commands/job/run#check-index
 [`tee`]: https://man7.org/linux/man-pages/man1/tee.1.html
+[`vault` stanza `allow_unauthenticated`]: /docs/configuration/vault#allow_unauthenticated
+[`vault_token`]: /docs/job-specification/job#vault_token


### PR DESCRIPTION
This PR fixes a regression where the 'job plan' command would not respect
a Vault token if set via --vault-token or $VAULT_TOKEN.

Basically the same bug/fix as for the validate command in https://github.com/hashicorp/nomad/issues/13062

Fixes https://github.com/hashicorp/nomad/issues/13939
