### PR TITLE
Solves a harsh bug where you have namespace access but no secvars access

### DIFF
--- a/ui/app/controllers/variables/path.js
+++ b/ui/app/controllers/variables/path.js
@@ -4,16 +4,21 @@ import { action } from '@ember/object';
 const ALL_NAMESPACE_WILDCARD = '*';
 
 export default class VariablesPathController extends Controller {
+  get absolutePath() {
+    return this.model?.absolutePath || '';
+  }
   get breadcrumbs() {
-    let crumbs = [];
-    this.model.absolutePath.split('/').reduce((m, n) => {
-      crumbs.push({
-        label: n,
-        args: [`variables.path`, m + n],
-      });
-      return m + n + '/';
-    }, []);
-    return crumbs;
+    if (this.absolutePath) {
+      let crumbs = [];
+      this.absolutePath.split('/').reduce((m, n) => {
+        crumbs.push({
+          label: n,
+          args: [`variables.path`, m + n],
+        });
+        return m + n + '/';
+      }, []);
+      return crumbs;
+    }
   }
 
   @controller variables;

--- a/ui/app/controllers/variables/path.js
+++ b/ui/app/controllers/variables/path.js
@@ -18,6 +18,8 @@ export default class VariablesPathController extends Controller {
         return m + n + '/';
       }, []);
       return crumbs;
+    } else {
+      return [];
     }
   }
 

--- a/ui/app/helpers/trim-path.js
+++ b/ui/app/helpers/trim-path.js
@@ -11,7 +11,7 @@ export function trimPath([path]) {
   if (path.startsWith('/')) {
     path = trimPath([path.slice(1)]);
   }
-  if (path.endsWith('/')) {
+  if (path?.endsWith('/')) {
     path = trimPath([path.slice(0, -1)]);
   }
   return path;

--- a/ui/app/routes/variables.js
+++ b/ui/app/routes/variables.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
 import notifyError from 'nomad-ui/utils/notify-error';
+import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 import PathTree from 'nomad-ui/utils/path-tree';
 
 export default class VariablesRoute extends Route.extend(WithForbiddenState) {
@@ -30,13 +31,13 @@ export default class VariablesRoute extends Route.extend(WithForbiddenState) {
         { namespace },
         { reload: true }
       );
-
       return {
         variables,
         pathTree: new PathTree(variables),
       };
     } catch (e) {
-      notifyError(this)(e);
+      notifyForbidden(this)(e);
+      return e;
     }
   }
 }

--- a/ui/app/routes/variables.js
+++ b/ui/app/routes/variables.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
-import notifyError from 'nomad-ui/utils/notify-error';
 import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 import PathTree from 'nomad-ui/utils/path-tree';
 

--- a/ui/app/routes/variables/index.js
+++ b/ui/app/routes/variables/index.js
@@ -1,11 +1,19 @@
 import Route from '@ember/routing/route';
+import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
+import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 
-export default class VariablesIndexRoute extends Route {
+export default class VariablesIndexRoute extends Route.extend(
+  WithForbiddenState
+) {
   model() {
-    const { variables, pathTree } = this.modelFor('variables');
-    return {
-      variables,
-      root: pathTree.paths.root,
-    };
+    if (this.modelFor('variables').errors) {
+      notifyForbidden(this)(this.modelFor('variables'));
+    } else {
+      const { variables, pathTree } = this.modelFor('variables');
+      return {
+        variables,
+        root: pathTree.paths.root,
+      };
+    }
   }
 }

--- a/ui/app/routes/variables/path.js
+++ b/ui/app/routes/variables/path.js
@@ -1,12 +1,20 @@
 import Route from '@ember/routing/route';
-export default class VariablesPathRoute extends Route {
+import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
+import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
+export default class VariablesPathRoute extends Route.extend(
+  WithForbiddenState
+) {
   model({ absolutePath }) {
-    const treeAtPath =
-      this.modelFor('variables').pathTree.findPath(absolutePath);
-    if (treeAtPath) {
-      return { treeAtPath, absolutePath };
+    if (this.modelFor('variables').errors) {
+      notifyForbidden(this)(this.modelFor('variables'));
     } else {
-      return { absolutePath };
+      const treeAtPath =
+        this.modelFor('variables').pathTree.findPath(absolutePath);
+      if (treeAtPath) {
+        return { treeAtPath, absolutePath };
+      } else {
+        return { absolutePath };
+      }
     }
   }
 }

--- a/ui/app/templates/variables/index.hbs
+++ b/ui/app/templates/variables/index.hbs
@@ -35,32 +35,36 @@
       </div>
     </div>
   </div>
-  {{#if this.hasVariables}}
-    <VariablePaths
-      @branch={{this.root}}
-    />
+  {{#if this.isForbidden}}
+    <ForbiddenMessage />
   {{else}}
-    <div class="empty-message">
-      {{#if (eq this.namespaceSelection "*")}}
-        <h3 data-test-empty-variables-list-headline class="empty-message-headline">
-          No Secure Variables
-        </h3>
-        {{#if (can "write variable" path="*" namespace=this.namespaceSelection)}}
+    {{#if this.hasVariables}}
+      <VariablePaths
+        @branch={{this.root}}
+      />
+    {{else}}
+      <div class="empty-message">
+        {{#if (eq this.namespaceSelection "*")}}
+          <h3 data-test-empty-variables-list-headline class="empty-message-headline">
+            No Secure Variables
+          </h3>
+          {{#if (can "write variable" path="*" namespace=this.namespaceSelection)}}
+            <p class="empty-message-body">
+              Get started by <LinkTo @route="variables.new">creating a new secure variable</LinkTo>
+            </p>
+          {{/if}}
+        {{else}}
+          <h3 data-test-no-matching-variables-list-headline class="empty-message-headline">
+            No Matches
+          </h3>
           <p class="empty-message-body">
-            Get started by <LinkTo @route="variables.new">creating a new secure variable</LinkTo>
+            No paths or variables match the namespace
+            <strong>
+              {{this.namespaceSelection}}
+            </strong>
           </p>
         {{/if}}
-      {{else}}
-        <h3 data-test-no-matching-variables-list-headline class="empty-message-headline">
-          No Matches
-        </h3>
-        <p class="empty-message-body">
-          No paths or variables match the namespace
-          <strong>
-            {{this.namespaceSelection}}
-          </strong>
-        </p>
-      {{/if}}
-    </div>
+      </div>
+    {{/if}}
   {{/if}}
 </section>

--- a/ui/app/templates/variables/path.hbs
+++ b/ui/app/templates/variables/path.hbs
@@ -15,12 +15,7 @@
           />
         {{/if}}
         <div class="button-bar">
-          {{#if 
-            (and
-              (can "write variable" path=(concat this.absolutePath "/") namespace=this.namespaceSelection)
-              (not this.isForbidden)
-            )
-          }}
+          {{#if (can "write variable" path=(concat this.absolutePath "/") namespace=this.namespaceSelection)}}
             <LinkTo
               @route="variables.new"
               @query={{hash path=(concat this.absolutePath "/")}}

--- a/ui/app/templates/variables/path.hbs
+++ b/ui/app/templates/variables/path.hbs
@@ -1,4 +1,4 @@
-{{page-title "Secure Variables: " this.model.absolutePath}}
+{{page-title "Secure Variables: " this.absolutePath}}
 {{#each this.breadcrumbs as |crumb|}}
   <Breadcrumb @crumb={{crumb}} />
 {{/each}}
@@ -15,52 +15,60 @@
           />
         {{/if}}
         <div class="button-bar">
-        {{#if (can "write variable" path=(concat this.model.absolutePath "/") namespace=this.namespaceSelection)}}
-          <LinkTo
-            @route="variables.new"
-            @query={{hash path=(concat this.model.absolutePath "/")}}
-            class="button is-primary"
-          >
-            Create Secure Variable
-          </LinkTo>
-        {{else}}
-          <button
-            class="button is-primary is-disabled tooltip is-right-aligned"
-            aria-label="You don’t have sufficient permissions"
-            disabled
-            type="button"
-          >
-            Create Secure Variable
-          </button>
-        {{/if}}
-
+          {{#if 
+            (and
+              (can "write variable" path=(concat this.absolutePath "/") namespace=this.namespaceSelection)
+              (not this.isForbidden)
+            )
+          }}
+            <LinkTo
+              @route="variables.new"
+              @query={{hash path=(concat this.absolutePath "/")}}
+              class="button is-primary"
+            >
+              Create Secure Variable
+            </LinkTo>
+          {{else}}
+            <button
+              class="button is-primary is-disabled tooltip is-right-aligned"
+              aria-label="You don’t have sufficient permissions"
+              disabled
+              type="button"
+            >
+              Create Secure Variable
+            </button>
+          {{/if}}
         </div>
       </div>
     </div>
-{{#if this.model.treeAtPath}}
-  <VariablePaths
-    @branch={{this.model.treeAtPath}}
-  />
-{{else}}
-  <div class="empty-message">
-    {{#if (eq this.namespaceSelection "*")}}
-      <h3 data-test-empty-variables-list-headline class="empty-message-headline">
-        Path /{{this.model.absolutePath}} contains no variables
-      </h3>
-      <p class="empty-message-body">
-        To get started, <LinkTo @route="variables.new" @query={{hash path=(concat this.model.absolutePath "/")}}>create a new secure variable here</LinkTo>, or <LinkTo @route="variables">go back to the Secure Variables root directory</LinkTo>.
-      </p>
+    {{#if this.isForbidden}}
+      <ForbiddenMessage />
     {{else}}
-      <h3 data-test-no-matching-variables-list-headline class="empty-message-headline">
-        No Matches
-      </h3>
-      <p class="empty-message-body">
-        No paths or variables match the namespace 
-        <strong>
-          {{this.namespaceSelection}}
-        </strong>
-      </p>
+      {{#if this.model.treeAtPath}}
+        <VariablePaths
+          @branch={{this.model.treeAtPath}}
+        />
+      {{else}}
+        <div class="empty-message">
+          {{#if (eq this.namespaceSelection "*")}}
+            <h3 data-test-empty-variables-list-headline class="empty-message-headline">
+              Path /{{this.absolutePath}} contains no variables
+            </h3>
+            <p class="empty-message-body">
+              To get started, <LinkTo @route="variables.new" @query={{hash path=(concat this.absolutePath "/")}}>create a new secure variable here</LinkTo>, or <LinkTo @route="variables">go back to the Secure Variables root directory</LinkTo>.
+            </p>
+          {{else}}
+            <h3 data-test-no-matching-variables-list-headline class="empty-message-headline">
+              No Matches
+            </h3>
+            <p class="empty-message-body">
+              No paths or variables match the namespace 
+              <strong>
+                {{this.namespaceSelection}}
+              </strong>
+            </p>
+          {{/if}}
+        </div>
+      {{/if}}
     {{/if}}
-  </div>
-{{/if}}
   </section>


### PR DESCRIPTION
Twig branch: Solves an issue where you have a policy like this:

```
namespace "*" {
  policy = "read"
  secure_variables {
    # full access to secrets in all project paths
    path "*" {
      capabilities = ["list"]
    }
  }
}

namespace "mad*" {
  policy = "read"
  secure_variables {
    path "*" {
      capabilities = []
    }
  }
}

namespace "nonsense" {
  policy = "write"
  secure_variables {
    # full access to secrets in all project paths
    path "*" {
      capabilities = ["write", "read", "destroy", "list"]
    }
  }
}
```

This makes it so we correctly return the forbidden state error to the user, rather than throw a fatal exception like we were doing before, when they switch to the `madness` namespace. Applies at both index and path levels.

![image](https://user-images.githubusercontent.com/713991/184378664-2407bd1f-6683-4bcb-a1de-ed51f8eae312.png)
