### PR TITLE
cleanup: consul mesh gateway type need not be pointer

### DIFF
--- a/command/agent/consul/connect.go
+++ b/command/agent/consul/connect.go
@@ -209,13 +209,9 @@ func connectUpstreams(in []structs.ConsulUpstream) []api.Upstream {
 // connectMeshGateway creates an api.MeshGatewayConfig from the nomad upstream
 // block. A non-existent config or unsupported gateway mode will default to the
 // Consul default mode.
-func connectMeshGateway(in *structs.ConsulMeshGateway) api.MeshGatewayConfig {
+func connectMeshGateway(in structs.ConsulMeshGateway) api.MeshGatewayConfig {
 	gw := api.MeshGatewayConfig{
 		Mode: api.MeshGatewayModeDefault,
-	}
-
-	if in == nil {
-		return gw
 	}
 
 	switch in.Mode {

--- a/command/agent/consul/connect_test.go
+++ b/command/agent/consul/connect_test.go
@@ -568,28 +568,28 @@ func TestConnect_newConnectGateway(t *testing.T) {
 func Test_connectMeshGateway(t *testing.T) {
 	ci.Parallel(t)
 
-	t.Run("nil", func(t *testing.T) {
-		result := connectMeshGateway(nil)
+	t.Run("empty", func(t *testing.T) {
+		result := connectMeshGateway(structs.ConsulMeshGateway{})
 		require.Equal(t, api.MeshGatewayConfig{Mode: api.MeshGatewayModeDefault}, result)
 	})
 
 	t.Run("local", func(t *testing.T) {
-		result := connectMeshGateway(&structs.ConsulMeshGateway{Mode: "local"})
+		result := connectMeshGateway(structs.ConsulMeshGateway{Mode: "local"})
 		require.Equal(t, api.MeshGatewayConfig{Mode: api.MeshGatewayModeLocal}, result)
 	})
 
 	t.Run("remote", func(t *testing.T) {
-		result := connectMeshGateway(&structs.ConsulMeshGateway{Mode: "remote"})
+		result := connectMeshGateway(structs.ConsulMeshGateway{Mode: "remote"})
 		require.Equal(t, api.MeshGatewayConfig{Mode: api.MeshGatewayModeRemote}, result)
 	})
 
 	t.Run("none", func(t *testing.T) {
-		result := connectMeshGateway(&structs.ConsulMeshGateway{Mode: "none"})
+		result := connectMeshGateway(structs.ConsulMeshGateway{Mode: "none"})
 		require.Equal(t, api.MeshGatewayConfig{Mode: api.MeshGatewayModeNone}, result)
 	})
 
 	t.Run("nonsense", func(t *testing.T) {
-		result := connectMeshGateway(nil)
+		result := connectMeshGateway(structs.ConsulMeshGateway{})
 		require.Equal(t, api.MeshGatewayConfig{Mode: api.MeshGatewayModeDefault}, result)
 	})
 }

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1655,13 +1655,12 @@ func apiUpstreamsToStructs(in []*api.ConsulUpstream) []structs.ConsulUpstream {
 	return upstreams
 }
 
-func apiMeshGatewayToStructs(in *api.ConsulMeshGateway) *structs.ConsulMeshGateway {
-	if in == nil {
-		return nil
+func apiMeshGatewayToStructs(in *api.ConsulMeshGateway) structs.ConsulMeshGateway {
+	var gw structs.ConsulMeshGateway
+	if in != nil {
+		gw.Mode = in.Mode
 	}
-	return &structs.ConsulMeshGateway{
-		Mode: in.Mode,
-	}
+	return gw
 }
 
 func apiConsulExposeConfigToStructs(in *api.ConsulExposeConfig) *structs.ConsulExposeConfig {

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -3486,6 +3486,7 @@ func TestJobs_ApiJobToStructsJobUpdate(t *testing.T) {
 }
 
 // TestJobs_Matching_Resources asserts:
+//
 //	api.{Default,Min}Resources == structs.{Default,Min}Resources
 //
 // While this is an odd place to test that, this is where both are imported,
@@ -3694,7 +3695,7 @@ func TestConversion_apiUpstreamsToStructs(t *testing.T) {
 		LocalBindPort:        8000,
 		Datacenter:           "dc2",
 		LocalBindAddress:     "127.0.0.2",
-		MeshGateway:          &structs.ConsulMeshGateway{Mode: "local"},
+		MeshGateway:          structs.ConsulMeshGateway{Mode: "local"},
 	}}, apiUpstreamsToStructs([]*api.ConsulUpstream{{
 		DestinationName:      "upstream",
 		DestinationNamespace: "ns2",
@@ -3707,8 +3708,8 @@ func TestConversion_apiUpstreamsToStructs(t *testing.T) {
 
 func TestConversion_apiConsulMeshGatewayToStructs(t *testing.T) {
 	ci.Parallel(t)
-	require.Nil(t, apiMeshGatewayToStructs(nil))
-	require.Equal(t, &structs.ConsulMeshGateway{Mode: "remote"},
+	require.Equal(t, structs.ConsulMeshGateway{}, apiMeshGatewayToStructs(nil))
+	require.Equal(t, structs.ConsulMeshGateway{Mode: "remote"},
 		apiMeshGatewayToStructs(&api.ConsulMeshGateway{Mode: "remote"}))
 }
 

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -2778,7 +2778,7 @@ func TestTaskGroupDiff(t *testing.T) {
 											LocalBindPort:        8000,
 											Datacenter:           "dc2",
 											LocalBindAddress:     "127.0.0.2",
-											MeshGateway: &ConsulMeshGateway{
+											MeshGateway: ConsulMeshGateway{
 												Mode: "remote",
 											},
 										},

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -1457,21 +1457,13 @@ type ConsulMeshGateway struct {
 	Mode string
 }
 
-func (c *ConsulMeshGateway) Copy() *ConsulMeshGateway {
-	if c == nil {
-		return nil
-	}
-
-	return &ConsulMeshGateway{
+func (c *ConsulMeshGateway) Copy() ConsulMeshGateway {
+	return ConsulMeshGateway{
 		Mode: c.Mode,
 	}
 }
 
-func (c *ConsulMeshGateway) Equals(o *ConsulMeshGateway) bool {
-	if c == nil || o == nil {
-		return c == o
-	}
-
+func (c *ConsulMeshGateway) Equals(o ConsulMeshGateway) bool {
 	return c.Mode == o.Mode
 }
 
@@ -1509,7 +1501,7 @@ type ConsulUpstream struct {
 
 	// MeshGateway is the optional configuration of the mesh gateway for this
 	// upstream to use.
-	MeshGateway *ConsulMeshGateway
+	MeshGateway ConsulMeshGateway
 }
 
 func upstreamsEquals(a, b []ConsulUpstream) bool {

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -712,8 +712,8 @@ func TestConsulUpstream_upstreamEquals(t *testing.T) {
 	})
 
 	t.Run("different mesh_gateway", func(t *testing.T) {
-		a := []ConsulUpstream{{DestinationName: "foo", MeshGateway: &ConsulMeshGateway{Mode: "local"}}}
-		b := []ConsulUpstream{{DestinationName: "foo", MeshGateway: &ConsulMeshGateway{Mode: "remote"}}}
+		a := []ConsulUpstream{{DestinationName: "foo", MeshGateway: ConsulMeshGateway{Mode: "local"}}}
+		b := []ConsulUpstream{{DestinationName: "foo", MeshGateway: ConsulMeshGateway{Mode: "remote"}}}
 		require.False(t, upstreamsEquals(a, b))
 	})
 
@@ -1637,11 +1637,11 @@ func TestConsulMeshGateway_Copy(t *testing.T) {
 func TestConsulMeshGateway_Equals(t *testing.T) {
 	ci.Parallel(t)
 
-	c := &ConsulMeshGateway{Mode: "local"}
-	require.False(t, c.Equals(nil))
+	c := ConsulMeshGateway{Mode: "local"}
+	require.False(t, c.Equals(ConsulMeshGateway{}))
 	require.True(t, c.Equals(c))
 
-	o := &ConsulMeshGateway{Mode: "remote"}
+	o := ConsulMeshGateway{Mode: "remote"}
 	require.False(t, c.Equals(o))
 }
 


### PR DESCRIPTION
This PR changes the use of `structs.ConsulMeshGateway` to value types instead of via pointers. This makes it more consistent and will help in a follow up PR where we cleanup a lot of custom comparison code with helper functions instead.
