### PR TITLE
ACL: add ACL role functionality to ACL tokens

### DIFF
--- a/api/acl.go
+++ b/api/acl.go
@@ -317,6 +317,11 @@ type ACLToken struct {
 	Name       string
 	Type       string
 	Policies   []string
+
+	// Roles represents the ACL roles that this token is tied to. The token
+	// will inherit the permissions of all policies detailed within the role.
+	Roles []*ACLTokenRoleLink
+
 	Global     bool
 	CreateTime time.Time
 
@@ -335,11 +340,26 @@ type ACLToken struct {
 	ModifyIndex uint64
 }
 
+// ACLTokenRoleLink is used to link an ACL token to an ACL role. The ACL token
+// can therefore inherit all the ACL policy permissions that the ACL role
+// contains.
+type ACLTokenRoleLink struct {
+
+	// ID is the ACLRole.ID UUID. This field is immutable and represents the
+	// absolute truth for the link.
+	ID string
+
+	// Name is the human friendly identifier for the ACL role and is a
+	// convenience field for operators.
+	Name string
+}
+
 type ACLTokenListStub struct {
 	AccessorID string
 	Name       string
 	Type       string
 	Policies   []string
+	Roles      []*ACLTokenRoleLink
 	Global     bool
 	CreateTime time.Time
 

--- a/command/acl_bootstrap.go
+++ b/command/acl_bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
 )
 
@@ -127,7 +128,7 @@ func (c *ACLBootstrapCommand) Run(args []string) int {
 	}
 
 	// Format the output
-	c.Ui.Output(formatKVACLToken(token))
+	outputACLToken(c.Ui, token)
 	return 0
 }
 
@@ -143,32 +144,56 @@ func formatKVPolicy(policy *api.ACLPolicy) string {
 	return formatKV(output)
 }
 
-// formatKVACLToken returns a K/V formatted ACL token
-func formatKVACLToken(token *api.ACLToken) string {
-	// Add the fixed preamble
-	output := []string{
+// outputACLToken formats and outputs the ACL token via the UI in the correct
+// format.
+func outputACLToken(ui cli.Ui, token *api.ACLToken) {
+
+	// Build the initial KV output which is always the same not matter whether
+	// the token is a management or client type.
+	kvOutput := []string{
 		fmt.Sprintf("Accessor ID|%s", token.AccessorID),
 		fmt.Sprintf("Secret ID|%s", token.SecretID),
 		fmt.Sprintf("Name|%s", token.Name),
 		fmt.Sprintf("Type|%s", token.Type),
 		fmt.Sprintf("Global|%v", token.Global),
-	}
-
-	// Special case the policy output
-	if token.Type == "management" {
-		output = append(output, "Policies|n/a")
-	} else {
-		output = append(output, fmt.Sprintf("Policies|%v", token.Policies))
-	}
-
-	// Add the generic output
-	output = append(output,
 		fmt.Sprintf("Create Time|%v", token.CreateTime),
 		fmt.Sprintf("Expiry Time |%s", expiryTimeString(token.ExpirationTime)),
 		fmt.Sprintf("Create Index|%d", token.CreateIndex),
 		fmt.Sprintf("Modify Index|%d", token.ModifyIndex),
-	)
-	return formatKV(output)
+	}
+
+	// If the token is a management type, make it obvious that it is not
+	// possible to have policies or roles assigned to it and just output the
+	// KV data.
+	if token.Type == "management" {
+		kvOutput = append(kvOutput, "Policies|n/a", "Roles|n/a")
+		ui.Output(formatKV(kvOutput))
+	} else {
+
+		// Policies are only currently referenced by name, so keep the previous
+		// format. When/if policies gain an ID alongside name like roles, this
+		// output should follow that of the roles.
+		kvOutput = append(kvOutput, fmt.Sprintf("Policies|%v", token.Policies))
+
+		var roleOutput []string
+
+		// If we have linked roles, add the ID and name in a list format to the
+		// output. Otherwise, make it clear there are no linked roles.
+		if len(token.Roles) > 0 {
+			roleOutput = append(roleOutput, "ID|Name")
+			for _, roleLink := range token.Roles {
+				roleOutput = append(roleOutput, roleLink.ID+"|"+roleLink.Name)
+			}
+		} else {
+			roleOutput = append(roleOutput, "<none>")
+		}
+
+		// Output the mixed formats of data, ensuring there is a space between
+		// the KV and list data.
+		ui.Output(formatKV(kvOutput))
+		ui.Output("")
+		ui.Output(fmt.Sprintf("Roles\n%s", formatList(roleOutput)))
+	}
 }
 
 func expiryTimeString(t *time.Time) string {

--- a/command/acl_token_create.go
+++ b/command/acl_token_create.go
@@ -5,12 +5,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-set"
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/posener/complete"
 )
 
 type ACLTokenCreateCommand struct {
 	Meta
+
+	roleNames []string
+	roleIDs   []string
 }
 
 func (c *ACLTokenCreateCommand) Help() string {
@@ -38,6 +43,12 @@ Create Options:
     Specifies a policy to associate with the token. Can be specified multiple times,
     but only with client type tokens.
 
+  -role-id
+     ID of a role to use for this token. May be specified multiple times.
+
+  -role-name
+     Name of a role to use for this token. May be specified multiple times.
+
   -ttl
     Specifies the time-to-live of the created ACL token. This takes the form of
     a time duration such as "5m" and "1h". By default, tokens will be created
@@ -49,11 +60,13 @@ Create Options:
 func (c *ACLTokenCreateCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
-			"name":   complete.PredictAnything,
-			"type":   complete.PredictAnything,
-			"global": complete.PredictNothing,
-			"policy": complete.PredictAnything,
-			"ttl":    complete.PredictAnything,
+			"name":      complete.PredictAnything,
+			"type":      complete.PredictAnything,
+			"global":    complete.PredictNothing,
+			"policy":    complete.PredictAnything,
+			"role-id":   complete.PredictAnything,
+			"role-name": complete.PredictAnything,
+			"ttl":       complete.PredictAnything,
 		})
 }
 
@@ -81,6 +94,14 @@ func (c *ACLTokenCreateCommand) Run(args []string) int {
 		policies = append(policies, s)
 		return nil
 	}), "policy", "")
+	flags.Var((funcVar)(func(s string) error {
+		c.roleNames = append(c.roleNames, s)
+		return nil
+	}), "role-name", "")
+	flags.Var((funcVar)(func(s string) error {
+		c.roleIDs = append(c.roleIDs, s)
+		return nil
+	}), "role-id", "")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
@@ -93,11 +114,12 @@ func (c *ACLTokenCreateCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Setup the token
+	// Set up the token.
 	tk := &api.ACLToken{
 		Name:     name,
 		Type:     tokenType,
 		Policies: policies,
+		Roles:    generateACLTokenRoleLinks(c.roleNames, c.roleIDs),
 		Global:   global,
 	}
 
@@ -127,6 +149,24 @@ func (c *ACLTokenCreateCommand) Run(args []string) int {
 	}
 
 	// Format the output
-	c.Ui.Output(formatKVACLToken(token))
+	outputACLToken(c.Ui, token)
 	return 0
+}
+
+// generateACLTokenRoleLinks takes the command input role links by ID and name
+// and coverts this to the relevant API object. It handles de-duplicating
+// entries to the best effort, so this doesn't need to be done on the leader.
+func generateACLTokenRoleLinks(roleNames, roleIDs []string) []*api.ACLTokenRoleLink {
+	var tokenLinks []*api.ACLTokenRoleLink
+
+	roleNameSet := set.From[string](roleNames).List()
+	roleNameFn := func(name string) *api.ACLTokenRoleLink { return &api.ACLTokenRoleLink{Name: name} }
+
+	roleIDsSet := set.From[string](roleIDs).List()
+	roleIDFn := func(id string) *api.ACLTokenRoleLink { return &api.ACLTokenRoleLink{ID: id} }
+
+	tokenLinks = append(tokenLinks, helper.ConvertSlice(roleNameSet, roleNameFn)...)
+	tokenLinks = append(tokenLinks, helper.ConvertSlice(roleIDsSet, roleIDFn)...)
+
+	return tokenLinks
 }

--- a/command/acl_token_create_test.go
+++ b/command/acl_token_create_test.go
@@ -3,6 +3,7 @@ package command
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/mitchellh/cli"
@@ -49,4 +50,29 @@ func TestACLTokenCreateCommand(t *testing.T) {
 
 	out = ui.OutputWriter.String()
 	require.NotContains(t, out, "Expiry Time  = <never>")
+}
+
+func Test_generateACLTokenRoleLinks(t *testing.T) {
+	ci.Parallel(t)
+
+	inputRoleNames := []string{
+		"duplicate",
+		"policy1",
+		"policy2",
+		"duplicate",
+	}
+	inputRoleIDs := []string{
+		"77a780d8-2dee-7c7f-7822-6f5471c5cbb2",
+		"56850b06-a343-a772-1a5c-ad083fd8a50e",
+		"77a780d8-2dee-7c7f-7822-6f5471c5cbb2",
+		"77a780d8-2dee-7c7f-7822-6f5471c5cbb2",
+	}
+	expectedOutput := []*api.ACLTokenRoleLink{
+		{Name: "duplicate"},
+		{Name: "policy1"},
+		{Name: "policy2"},
+		{ID: "77a780d8-2dee-7c7f-7822-6f5471c5cbb2"},
+		{ID: "56850b06-a343-a772-1a5c-ad083fd8a50e"},
+	}
+	require.ElementsMatch(t, generateACLTokenRoleLinks(inputRoleNames, inputRoleIDs), expectedOutput)
 }

--- a/command/acl_token_info.go
+++ b/command/acl_token_info.go
@@ -71,6 +71,6 @@ func (c *ACLTokenInfoCommand) Run(args []string) int {
 	}
 
 	// Format the output
-	c.Ui.Output(formatKVACLToken(token))
+	outputACLToken(c.Ui, token)
 	return 0
 }

--- a/command/acl_token_self.go
+++ b/command/acl_token_self.go
@@ -68,6 +68,6 @@ func (c *ACLTokenSelfCommand) Run(args []string) int {
 	}
 
 	// Format the output
-	c.Ui.Output(formatKVACLToken(token))
+	outputACLToken(c.Ui, token)
 	return 0
 }

--- a/command/acl_token_update.go
+++ b/command/acl_token_update.go
@@ -127,6 +127,6 @@ func (c *ACLTokenUpdateCommand) Run(args []string) int {
 	}
 
 	// Format the output
-	c.Ui.Output(formatKVACLToken(updatedToken))
+	outputACLToken(c.Ui, updatedToken)
 	return 0
 }

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -718,3 +718,14 @@ func NewSafeTimer(duration time.Duration) (*time.Timer, StopFunc) {
 
 	return t, cancel
 }
+
+// ConvertSlice takes the input slice and generates a new one using the
+// supplied conversion function to covert the element. This is useful when
+// converting a slice of strings to a slice of structs which wraps the string.
+func ConvertSlice[A, B any](original []A, conversion func(a A) B) []B {
+	result := make([]B, len(original))
+	for i, element := range original {
+		result[i] = conversion(element)
+	}
+	return result
+}

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -546,3 +546,27 @@ func Test_NewSafeTimer(t *testing.T) {
 		<-timer.C
 	})
 }
+
+func Test_ConvertSlice(t *testing.T) {
+	t.Run("string wrapper", func(t *testing.T) {
+
+		type wrapper struct{ id string }
+		input := []string{"foo", "bar", "bad", "had"}
+		cFn := func(id string) *wrapper { return &wrapper{id: id} }
+
+		expectedOutput := []*wrapper{{id: "foo"}, {id: "bar"}, {id: "bad"}, {id: "had"}}
+		actualOutput := ConvertSlice(input, cFn)
+		require.ElementsMatch(t, expectedOutput, actualOutput)
+	})
+
+	t.Run("int wrapper", func(t *testing.T) {
+
+		type wrapper struct{ id int }
+		input := []int{10, 13, 1987, 2020}
+		cFn := func(id int) *wrapper { return &wrapper{id: id} }
+
+		expectedOutput := []*wrapper{{id: 10}, {id: 13}, {id: 1987}, {id: 2020}}
+		actualOutput := ConvertSlice(input, cFn)
+		require.ElementsMatch(t, expectedOutput, actualOutput)
+	})
+}

--- a/nomad/acl.go
+++ b/nomad/acl.go
@@ -82,9 +82,9 @@ func (s *Server) ResolveClaims(claims *structs.IdentityClaims) (*acl.ACL, error)
 	return aclObj, nil
 }
 
-// resolveTokenFromSnapshotCache is used to resolve an ACL object from a snapshot of state,
-// using a cache to avoid parsing and ACL construction when possible. It is split from resolveToken
-// to simplify testing.
+// resolveTokenFromSnapshotCache is used to resolve an ACL object from a
+// snapshot of state, using a cache to avoid parsing and ACL construction when
+// possible. It is split from resolveToken to simplify testing.
 func resolveTokenFromSnapshotCache(snap *state.StateSnapshot, cache *lru.TwoQueueCache, secretID string) (*acl.ACL, error) {
 	// Lookup the ACL Token
 	var token *structs.ACLToken
@@ -111,20 +111,59 @@ func resolveTokenFromSnapshotCache(snap *state.StateSnapshot, cache *lru.TwoQueu
 		return acl.ManagementACL, nil
 	}
 
-	// Get all associated policies
-	policies := make([]*structs.ACLPolicy, 0, len(token.Policies))
+	// Store all policies detailed in the token request, this includes the
+	// named policies and those referenced within the role link.
+	policies := make([]*structs.ACLPolicy, 0, len(token.Policies)+len(token.Roles))
+
+	// Iterate all the token policies and add these to our policy tracking
+	// array.
 	for _, policyName := range token.Policies {
 		policy, err := snap.ACLPolicyByName(nil, policyName)
 		if err != nil {
 			return nil, err
 		}
 		if policy == nil {
-			// Ignore policies that don't exist, since they don't grant any more privilege
+			// Ignore policies that don't exist, since they don't grant any
+			// more privilege.
 			continue
 		}
 
-		// Save the policy and update the cache key
+		// Add the policy to the tracking array.
 		policies = append(policies, policy)
+	}
+
+	// Iterate all the token role links, so we can unpack these and identify
+	// the ACL policies.
+	for _, roleLink := range token.Roles {
+
+		// Any error reading the role means we cannot move forward. We just
+		// ignore any roles that have been detailed but are not within our
+		// state.
+		role, err := snap.GetACLRoleByID(nil, roleLink.ID)
+		if err != nil {
+			return nil, err
+		}
+		if role == nil {
+			continue
+		}
+
+		// Unpack the policies held within the ACL role to form a single list
+		// of ACL policies that this token has available.
+		for _, policyLink := range role.Policies {
+			policy, err := snap.ACLPolicyByName(nil, policyLink.Name)
+			if err != nil {
+				return nil, err
+			}
+
+			// Ignore policies that don't exist, since they don't grant any
+			// more privilege.
+			if policy == nil {
+				continue
+			}
+
+			// Add the policy to the tracking array.
+			policies = append(policies, policy)
+		}
 	}
 
 	// Compile and cache the ACL object

--- a/nomad/structs/acl_test.go
+++ b/nomad/structs/acl_test.go
@@ -25,6 +25,7 @@ func TestACLToken_Canonicalize(t *testing.T) {
 					Name:        "my cool token " + uuid.Generate(),
 					Type:        "client",
 					Policies:    []string{"foo", "bar"},
+					Roles:       []*ACLTokenRoleLink{},
 					Global:      false,
 					CreateTime:  time.Now().UTC(),
 					CreateIndex: 10,
@@ -96,12 +97,12 @@ func TestACLTokenValidate(t *testing.T) {
 			expectedErrorContains: "client or management",
 		},
 		{
-			name: "missing policies",
+			name: "missing policies or roles",
 			inputACLToken: &ACLToken{
 				Type: ACLClientToken,
 			},
 			inputExistingACLToken: nil,
-			expectedErrorContains: "missing policies",
+			expectedErrorContains: "missing policies or roles",
 		},
 		{
 			name: "invalid policies",
@@ -110,7 +111,16 @@ func TestACLTokenValidate(t *testing.T) {
 				Policies: []string{"foo"},
 			},
 			inputExistingACLToken: nil,
-			expectedErrorContains: "associated with policies",
+			expectedErrorContains: "associated with policies or roles",
+		},
+		{
+			name: "invalid roles",
+			inputACLToken: &ACLToken{
+				Type:  ACLManagementToken,
+				Roles: []*ACLTokenRoleLink{{Name: "foo"}},
+			},
+			inputExistingACLToken: nil,
+			expectedErrorContains: "associated with policies or roles",
 		},
 		{
 			name: "name too long",


### PR DESCRIPTION
ACL tokens can now utilize ACL roles in order to provide API
authorization. Each ACL token can be created and linked to an
array of policies as well as an array of ACL role links. The link
can be provided via the role name or ID, but internally, is always
resolved to the ID as this is immutable whereas the name can be
changed by operators.

When resolving an ACL token, the policies linked from an ACL role
are unpacked and combined with the policy array to form the
complete auth set for the token.

The ACL token creation endpoint handles deduplicating ACL role
links as well as ensuring they exist within state.

When reading a token, Nomad will also ensure the ACL role link is
current. This handles ACL roles being deleted from under a token
from a UX standpoint.

The PR also includes adding the ability to create ACL tokens via
the CLI which link to ACL roles.

related: https://github.com/hashicorp/nomad/issues/13120
targets: feature branch