### PR TITLE
ACL: disallow missing `path` in secure variable policy

### DIFF
--- a/acl/policy.go
+++ b/acl/policy.go
@@ -328,14 +328,17 @@ func Parse(rules string) (*Policy, error) {
 		}
 
 		if ns.SecureVariables != nil {
+			if len(ns.SecureVariables.Paths) == 0 {
+				return nil, fmt.Errorf("Invalid secure variable policy: no secure variable paths in namespace %s", ns.Name)
+			}
 			for _, pathPolicy := range ns.SecureVariables.Paths {
 				if pathPolicy.PathSpec == "" {
-					return nil, fmt.Errorf("Invalid missing secure variable path in namespace %#v", ns)
+					return nil, fmt.Errorf("Invalid missing secure variable path in namespace %s", ns.Name)
 				}
 				for _, cap := range pathPolicy.Capabilities {
 					if !isPathCapabilityValid(cap) {
 						return nil, fmt.Errorf(
-							"Invalid secure variable capability '%s' in namespace %#v", cap, ns)
+							"Invalid secure variable capability '%s' in namespace %s", cap, ns.Name)
 					}
 				}
 				pathPolicy.Capabilities = expandSecureVariablesCapabilities(pathPolicy.Capabilities)

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -200,6 +200,17 @@ func TestParse(t *testing.T) {
 		},
 		{
 			`
+			namespace "dev" {
+			  secure_variables "*" {
+			      capabilities = ["read", "write"]
+			  }
+			}
+			`,
+			"Invalid secure variable policy: no secure variable paths in namespace dev",
+			nil,
+		},
+		{
+			`
 			namespace "default" {
 				capabilities = ["deny", "foo"]
 			}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/14038

The HCL parser allows for labels that aren't needed, which makes it easy to
accidentally write a `secure_variable` block that has the intended path as the
label for that block instead of the innner `path` block. This can result in
silent failure to lock down variables if an incorrectly specified block was used
to reduce the scope of capabilities (for example, if another correctly-written
rule allows access to `*`).

We can't detect the extraneous label in the HCL API, but we can detect if we're
missing `path` blocks entirely. Use this to block obvious user errors.