### PR TITLE
Task lifecycle restart

### DIFF
--- a/.changelog/14127.txt
+++ b/.changelog/14127.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+client: add option to restart all tasks of an allocation, even if the task already run, such as non-sidecar prestart and poststart tasks.
+```
+
+```release-note:improvement
+client: only start poststop tasks after poststart tasks are done.
+```

--- a/.changelog/14127.txt
+++ b/.changelog/14127.txt
@@ -1,5 +1,5 @@
 ```release-note:improvement
-client: add option to restart all tasks of an allocation, even if the task already run, such as non-sidecar prestart and poststart tasks.
+client: add option to restart all tasks of an allocation, regardless of lifecycle type or state.
 ```
 
 ```release-note:improvement

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -156,6 +156,16 @@ func (a *Allocations) Restart(alloc *Allocation, taskName string, q *QueryOption
 	return err
 }
 
+func (a *Allocations) RestartAllTasks(alloc *Allocation, q *QueryOptions) error {
+	req := AllocationRestartRequest{
+		AllTasks: true,
+	}
+
+	var resp struct{}
+	_, err := a.client.putQuery("/v1/client/allocation/"+alloc.ID+"/restart", &req, &resp, q)
+	return err
+}
+
 // Stop stops an allocation.
 //
 // Note: for cluster topologies where API consumers don't have network access to
@@ -447,6 +457,7 @@ func (a Allocation) RescheduleInfo(t time.Time) (int, int) {
 
 type AllocationRestartRequest struct {
 	TaskName string
+	AllTasks bool
 }
 
 type AllocSignalRequest struct {

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -141,7 +141,9 @@ func (a *Allocations) GC(alloc *Allocation, q *QueryOptions) error {
 	return err
 }
 
-// Restart restarts an allocation.
+// Restart restarts the tasks that are currently running or a specific task if
+// taskName is provided. An error is returned if the task to be restarted is
+// not running.
 //
 // Note: for cluster topologies where API consumers don't have network access to
 // Nomad clients, set api.ClientConnTimeout to a small value (ex 1ms) to avoid
@@ -156,6 +158,12 @@ func (a *Allocations) Restart(alloc *Allocation, taskName string, q *QueryOption
 	return err
 }
 
+// RestartAllTasks restarts all tasks in the allocation, regardless of
+// lifecycle type or state. Tasks will restart following their lifecycle order.
+//
+// Note: for cluster topologies where API consumers don't have network access to
+// Nomad clients, set api.ClientConnTimeout to a small value (ex 1ms) to avoid
+// long pauses on this API call.
 func (a *Allocations) RestartAllTasks(alloc *Allocation, q *QueryOptions) error {
 	req := AllocationRestartRequest{
 		AllTasks: true,

--- a/client/alloc_endpoint.go
+++ b/client/alloc_endpoint.go
@@ -102,7 +102,7 @@ func (a *Allocations) Restart(args *nstructs.AllocRestartRequest, reply *nstruct
 		return nstructs.ErrPermissionDenied
 	}
 
-	return a.c.RestartAllocation(args.AllocID, args.TaskName)
+	return a.c.RestartAllocation(args.AllocID, args.TaskName, args.AllTasks)
 }
 
 // Stats is used to collect allocation statistics

--- a/client/alloc_endpoint_test.go
+++ b/client/alloc_endpoint_test.go
@@ -68,6 +68,45 @@ func TestAllocations_Restart(t *testing.T) {
 	})
 }
 
+func TestAllocations_RestartAllTasks(t *testing.T) {
+	ci.Parallel(t)
+
+	require := require.New(t)
+	client, cleanup := TestClient(t, nil)
+	defer cleanup()
+
+	alloc := mock.LifecycleAlloc()
+	require.Nil(client.addAlloc(alloc, ""))
+
+	// Can't restart all tasks while specifying a task name.
+	req := &nstructs.AllocRestartRequest{
+		AllocID:  alloc.ID,
+		AllTasks: true,
+		TaskName: "web",
+	}
+	var resp nstructs.GenericResponse
+	err := client.ClientRPC("Allocations.Restart", &req, &resp)
+	require.Error(err)
+
+	// Good request.
+	req = &nstructs.AllocRestartRequest{
+		AllocID:  alloc.ID,
+		AllTasks: true,
+	}
+
+	testutil.WaitForResult(func() (bool, error) {
+		var resp2 nstructs.GenericResponse
+		err := client.ClientRPC("Allocations.Restart", &req, &resp2)
+		if err != nil && strings.Contains(err.Error(), "not running") {
+			return false, err
+		}
+
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+}
+
 func TestAllocations_Restart_ACL(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -546,40 +546,63 @@ func (ar *allocRunner) handleTaskStateUpdates() {
 			}
 		}
 
-		// if all live runners are sidecars - kill alloc
-		if killEvent == nil && hasSidecars && !hasNonSidecarTasks(liveRunners) {
-			killEvent = structs.NewTaskEvent(structs.TaskMainDead)
-		}
-
-		// If there's a kill event set and live runners, kill them
-		if killEvent != nil && len(liveRunners) > 0 {
-
-			// Log kill reason
-			switch killEvent.Type {
-			case structs.TaskLeaderDead:
-				ar.logger.Debug("leader task dead, destroying all tasks", "leader_task", killTask)
-			case structs.TaskMainDead:
-				ar.logger.Debug("main tasks dead, destroying all sidecar tasks")
-			default:
-				ar.logger.Debug("task failure, destroying all tasks", "failed_task", killTask)
+		if len(liveRunners) > 0 {
+			// if all live runners are sidecars - kill alloc
+			if killEvent == nil && hasSidecars && !hasNonSidecarTasks(liveRunners) {
+				killEvent = structs.NewTaskEvent(structs.TaskMainDead)
 			}
 
-			// Emit kill event for live runners
-			for _, tr := range liveRunners {
-				tr.EmitEvent(killEvent)
+			// If there's a kill event set and live runners, kill them
+			if killEvent != nil {
+
+				// Log kill reason
+				switch killEvent.Type {
+				case structs.TaskLeaderDead:
+					ar.logger.Debug("leader task dead, destroying all tasks", "leader_task", killTask)
+				case structs.TaskMainDead:
+					ar.logger.Debug("main tasks dead, destroying all sidecar tasks")
+				default:
+					ar.logger.Debug("task failure, destroying all tasks", "failed_task", killTask)
+				}
+
+				// Emit kill event for live runners
+				for _, tr := range liveRunners {
+					tr.EmitEvent(killEvent)
+				}
+
+				// Kill 'em all
+				states = ar.killTasks()
+
+				// Wait for TaskRunners to exit before continuing to
+				// prevent looping before TaskRunners have transitioned
+				// to Dead.
+				for _, tr := range liveRunners {
+					ar.logger.Info("killing task", "task", tr.Task().Name)
+					select {
+					case <-tr.WaitCh():
+					case <-ar.waitCh:
+					}
+				}
 			}
+		} else {
+			// If there are no live runners left kill all non-poststop task
+			// runners to unblock them from the alloc restart loop.
+			for _, tr := range ar.tasks {
+				if tr.IsPoststopTask() {
+					continue
+				}
 
-			// Kill 'em all
-			states = ar.killTasks()
-
-			// Wait for TaskRunners to exit before continuing to
-			// prevent looping before TaskRunners have transitioned
-			// to Dead.
-			for _, tr := range liveRunners {
-				ar.logger.Info("killing task", "task", tr.Task().Name)
 				select {
 				case <-tr.WaitCh():
 				case <-ar.waitCh:
+				default:
+					// Kill task runner without setting an event because the
+					// task is already dead, it's just waiting in the alloc
+					// restart loop.
+					err := tr.Kill(context.TODO(), nil)
+					if err != nil {
+						ar.logger.Warn("failed to kill task", "task", tr.Task().Name, "error", err)
+					}
 				}
 			}
 		}

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -548,8 +548,8 @@ func (ar *allocRunner) handleTaskStateUpdates() {
 
 		if len(liveRunners) > 0 {
 			// if all live runners are sidecars - kill alloc
-			hasLiveSidecars := hasSidecars && !hasNonSidecarTasks(liveRunners)
-			if killEvent == nil && hasLiveSidecars {
+			onlySidecarsRemaining := hasSidecars && !hasNonSidecarTasks(liveRunners)
+			if killEvent == nil && onlySidecarsRemaining {
 				killEvent = structs.NewTaskEvent(structs.TaskMainDead)
 			}
 

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -1676,11 +1676,7 @@ func TestAllocRunner_MoveAllocDir(t *testing.T) {
 	ar.Run()
 	defer destroy(ar)
 
-	testutil.WaitForResult(func() (bool, error) {
-		return ar.AllocState().ClientStatus == structs.AllocClientStatusComplete, nil
-	}, func(_ error) {
-		t.Fatalf("expected alloc to be complete")
-	})
+	WaitForClientState(t, ar, structs.AllocClientStatusComplete)
 
 	// Step 2. Modify its directory
 	task := alloc.Job.TaskGroups[0].Tasks[0]
@@ -1708,11 +1704,7 @@ func TestAllocRunner_MoveAllocDir(t *testing.T) {
 	ar2.Run()
 	defer destroy(ar2)
 
-	testutil.WaitForResult(func() (bool, error) {
-		return ar.AllocState().ClientStatus == structs.AllocClientStatusComplete, nil
-	}, func(_ error) {
-		t.Fatalf("expected alloc to be complete")
-	})
+	WaitForClientState(t, ar, structs.AllocClientStatusComplete)
 
 	// Ensure that data from ar was moved to ar2
 	dataFile = filepath.Join(ar2.allocDir.SharedDir, "data", "data_file")

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -1213,7 +1213,11 @@ func TestAllocRunner_MoveAllocDir(t *testing.T) {
 	ar.Run()
 	defer destroy(ar)
 
-	require.Equal(t, structs.AllocClientStatusComplete, ar.AllocState().ClientStatus)
+	testutil.WaitForResult(func() (bool, error) {
+		return ar.AllocState().ClientStatus == structs.AllocClientStatusComplete, nil
+	}, func(_ error) {
+		t.Fatalf("expected alloc to be complete")
+	})
 
 	// Step 2. Modify its directory
 	task := alloc.Job.TaskGroups[0].Tasks[0]
@@ -1241,7 +1245,11 @@ func TestAllocRunner_MoveAllocDir(t *testing.T) {
 	ar2.Run()
 	defer destroy(ar2)
 
-	require.Equal(t, structs.AllocClientStatusComplete, ar2.AllocState().ClientStatus)
+	testutil.WaitForResult(func() (bool, error) {
+		return ar.AllocState().ClientStatus == structs.AllocClientStatusComplete, nil
+	}, func(_ error) {
+		t.Fatalf("expected alloc to be complete")
+	})
 
 	// Ensure that data from ar was moved to ar2
 	dataFile = filepath.Join(ar2.allocDir.SharedDir, "data", "data_file")

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/api"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/allochealth"
 	"github.com/hashicorp/nomad/client/allocrunner/tasklifecycle"
@@ -481,6 +482,468 @@ func TestAllocRunner_Lifecycle_Poststop(t *testing.T) {
 		t.Fatalf("error waiting for initial state:\n%v", err)
 	})
 
+}
+
+func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
+	ci.Parallel(t)
+
+	// test cases can use this default or override w/ taskDefs param
+	alloc := mock.LifecycleAllocFromTasks([]mock.LifecycleTaskDef{
+		{"main", "100s", 0, "", false},
+		{"prestart-oneshot", "1s", 0, "prestart", false},
+		{"prestart-sidecar", "100s", 0, "prestart", true},
+		{"poststart-oneshot", "1s", 0, "poststart", false},
+		{"poststart-sidecar", "100s", 0, "poststart", true},
+		{"poststop", "1s", 0, "poststop", false},
+	})
+	alloc.Job.Type = structs.JobTypeService
+	rp := &structs.RestartPolicy{
+		Attempts: 1,
+		Interval: 10 * time.Minute,
+		Delay:    1 * time.Nanosecond,
+		Mode:     structs.RestartPolicyModeFail,
+	}
+
+	testCases := []struct {
+		name          string
+		taskDefs      []mock.LifecycleTaskDef
+		isBatch       bool
+		hasLeader     bool
+		action        func(*allocRunner, *structs.Allocation) error
+		expectedErr   string
+		expectedAfter map[string]structs.TaskState
+	}{
+		{
+			name: "restart entire allocation",
+			action: func(ar *allocRunner, alloc *structs.Allocation) error {
+				ev := &structs.TaskEvent{Type: structs.TaskRestartAllSignal}
+				return ar.RestartAll(ev)
+			},
+			expectedAfter: map[string]structs.TaskState{
+				"main":              structs.TaskState{State: "running", Restarts: 1},
+				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 1},
+				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 1},
+				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 1},
+				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 1},
+				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+			},
+		},
+		{
+			name: "restart only running tasks",
+			action: func(ar *allocRunner, alloc *structs.Allocation) error {
+				ev := &structs.TaskEvent{Type: structs.TaskRestartRunningSignal}
+				return ar.RestartRunning(ev)
+			},
+			expectedAfter: map[string]structs.TaskState{
+				"main":              structs.TaskState{State: "running", Restarts: 1},
+				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
+				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 1},
+				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 1},
+				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+			},
+		},
+		{
+			name: "batch job restart entire allocation",
+			taskDefs: []mock.LifecycleTaskDef{
+				{"main", "100s", 1, "", false},
+				{"prestart-oneshot", "1s", 0, "prestart", false},
+				{"prestart-sidecar", "100s", 0, "prestart", true},
+				{"poststart-oneshot", "1s", 0, "poststart", false},
+				{"poststart-sidecar", "100s", 0, "poststart", true},
+				{"poststop", "1s", 0, "poststop", false},
+			},
+			isBatch: true,
+			action: func(ar *allocRunner, alloc *structs.Allocation) error {
+				ev := &structs.TaskEvent{Type: structs.TaskRestartAllSignal}
+				return ar.RestartAll(ev)
+			},
+			expectedAfter: map[string]structs.TaskState{
+				"main":              structs.TaskState{State: "running", Restarts: 1},
+				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 1},
+				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 1},
+				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 1},
+				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 1},
+				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+			},
+		},
+		{
+			name: "batch job restart only running tasks ",
+			taskDefs: []mock.LifecycleTaskDef{
+				{"main", "100s", 1, "", false},
+				{"prestart-oneshot", "1s", 0, "prestart", false},
+				{"prestart-sidecar", "100s", 0, "prestart", true},
+				{"poststart-oneshot", "1s", 0, "poststart", false},
+				{"poststart-sidecar", "100s", 0, "poststart", true},
+				{"poststop", "1s", 0, "poststop", false},
+			},
+			isBatch: true,
+			action: func(ar *allocRunner, alloc *structs.Allocation) error {
+				ev := &structs.TaskEvent{Type: structs.TaskRestartRunningSignal}
+				return ar.RestartRunning(ev)
+			},
+			expectedAfter: map[string]structs.TaskState{
+				"main":              structs.TaskState{State: "running", Restarts: 1},
+				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
+				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 1},
+				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 1},
+				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+			},
+		},
+		{
+			name:      "restart entire allocation with leader",
+			hasLeader: true,
+			action: func(ar *allocRunner, alloc *structs.Allocation) error {
+				ev := &structs.TaskEvent{Type: structs.TaskRestartAllSignal}
+				return ar.RestartAll(ev)
+			},
+			expectedAfter: map[string]structs.TaskState{
+				"main":              structs.TaskState{State: "running", Restarts: 1},
+				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 1},
+				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 1},
+				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 1},
+				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 1},
+				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+			},
+		},
+		{
+			name: "stop from server",
+			action: func(ar *allocRunner, alloc *structs.Allocation) error {
+				stopAlloc := alloc.Copy()
+				stopAlloc.DesiredStatus = structs.AllocDesiredStatusStop
+				ar.Update(stopAlloc)
+				return nil
+			},
+			expectedAfter: map[string]structs.TaskState{
+				"main":              structs.TaskState{State: "dead", Restarts: 0},
+				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
+				"prestart-sidecar":  structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-sidecar": structs.TaskState{State: "dead", Restarts: 0},
+				"poststop":          structs.TaskState{State: "dead", Restarts: 0},
+			},
+		},
+		{
+			name: "restart main task",
+			action: func(ar *allocRunner, alloc *structs.Allocation) error {
+				ev := &structs.TaskEvent{Type: structs.TaskRestartSignal}
+				return ar.RestartTask("main", ev)
+			},
+			expectedAfter: map[string]structs.TaskState{
+				"main":              structs.TaskState{State: "running", Restarts: 1},
+				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
+				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 0},
+				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 0},
+				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+			},
+		},
+		{
+			name:      "restart leader main task",
+			hasLeader: true,
+			action: func(ar *allocRunner, alloc *structs.Allocation) error {
+				return ar.RestartTask("main", &structs.TaskEvent{Type: structs.TaskRestartSignal})
+			},
+			expectedAfter: map[string]structs.TaskState{
+				"main":              structs.TaskState{State: "running", Restarts: 1},
+				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
+				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 0},
+				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 0},
+				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+			},
+		},
+		{
+			name: "main task fails and restarts once",
+			taskDefs: []mock.LifecycleTaskDef{
+				{"main", "2s", 1, "", false},
+				{"prestart-oneshot", "1s", 0, "prestart", false},
+				{"prestart-sidecar", "100s", 0, "prestart", true},
+				{"poststart-oneshot", "1s", 0, "poststart", false},
+				{"poststart-sidecar", "100s", 0, "poststart", true},
+				{"poststop", "1s", 0, "poststop", false},
+			},
+			action: func(ar *allocRunner, alloc *structs.Allocation) error {
+				time.Sleep(3 * time.Second) // make sure main task has exited
+				return nil
+			},
+			expectedAfter: map[string]structs.TaskState{
+				"main":              structs.TaskState{State: "dead", Restarts: 1},
+				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
+				"prestart-sidecar":  structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-sidecar": structs.TaskState{State: "dead", Restarts: 0},
+				"poststop":          structs.TaskState{State: "dead", Restarts: 0},
+			},
+		},
+		{
+			name: "leader main task fails and restarts once",
+			taskDefs: []mock.LifecycleTaskDef{
+				{"main", "2s", 1, "", false},
+				{"prestart-oneshot", "1s", 0, "prestart", false},
+				{"prestart-sidecar", "100s", 0, "prestart", true},
+				{"poststart-oneshot", "1s", 0, "poststart", false},
+				{"poststart-sidecar", "100s", 0, "poststart", true},
+				{"poststop", "1s", 0, "poststop", false},
+			},
+			hasLeader: true,
+			action: func(ar *allocRunner, alloc *structs.Allocation) error {
+				time.Sleep(3 * time.Second) // make sure main task has exited
+				return nil
+			},
+			expectedAfter: map[string]structs.TaskState{
+				"main":              structs.TaskState{State: "dead", Restarts: 1},
+				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
+				"prestart-sidecar":  structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-sidecar": structs.TaskState{State: "dead", Restarts: 0},
+				"poststop":          structs.TaskState{State: "dead", Restarts: 0},
+			},
+		},
+		{
+			name: "main stopped unexpectedly and restarts once",
+			taskDefs: []mock.LifecycleTaskDef{
+				{"main", "2s", 0, "", false},
+				{"prestart-oneshot", "1s", 0, "prestart", false},
+				{"prestart-sidecar", "100s", 0, "prestart", true},
+				{"poststart-oneshot", "1s", 0, "poststart", false},
+				{"poststart-sidecar", "100s", 0, "poststart", true},
+				{"poststop", "1s", 0, "poststop", false},
+			},
+			action: func(ar *allocRunner, alloc *structs.Allocation) error {
+				time.Sleep(3 * time.Second) // make sure main task has exited
+				return nil
+			},
+			expectedAfter: map[string]structs.TaskState{
+				"main":              structs.TaskState{State: "dead", Restarts: 1},
+				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
+				"prestart-sidecar":  structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-sidecar": structs.TaskState{State: "dead", Restarts: 0},
+				"poststop":          structs.TaskState{State: "dead", Restarts: 0},
+			},
+		},
+		{
+			name: "leader main stopped unexpectedly and restarts once",
+			taskDefs: []mock.LifecycleTaskDef{
+				{"main", "2s", 0, "", false},
+				{"prestart-oneshot", "1s", 0, "prestart", false},
+				{"prestart-sidecar", "100s", 0, "prestart", true},
+				{"poststart-oneshot", "1s", 0, "poststart", false},
+				{"poststart-sidecar", "100s", 0, "poststart", true},
+				{"poststop", "1s", 0, "poststop", false},
+			},
+			action: func(ar *allocRunner, alloc *structs.Allocation) error {
+				time.Sleep(3 * time.Second) // make sure main task has exited
+				return nil
+			},
+			expectedAfter: map[string]structs.TaskState{
+				"main":              structs.TaskState{State: "dead", Restarts: 1},
+				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
+				"prestart-sidecar":  structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-sidecar": structs.TaskState{State: "dead", Restarts: 0},
+				"poststop":          structs.TaskState{State: "dead", Restarts: 0},
+			},
+		},
+		{
+			name: "failed main task cannot be restarted",
+			taskDefs: []mock.LifecycleTaskDef{
+				{"main", "2s", 1, "", false},
+				{"prestart-oneshot", "1s", 0, "prestart", false},
+				{"prestart-sidecar", "100s", 0, "prestart", true},
+				{"poststart-oneshot", "1s", 0, "poststart", false},
+				{"poststart-sidecar", "100s", 0, "poststart", true},
+				{"poststop", "1s", 0, "poststop", false},
+			},
+			action: func(ar *allocRunner, alloc *structs.Allocation) error {
+				// make sure main task has had a chance to restart once on its
+				// own and fail again before we try to manually restart it
+				time.Sleep(5 * time.Second)
+				return ar.RestartTask("main", &structs.TaskEvent{Type: structs.TaskRestartSignal})
+			},
+			expectedErr: "Task not running",
+			expectedAfter: map[string]structs.TaskState{
+				"main":              structs.TaskState{State: "dead", Restarts: 1},
+				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
+				"prestart-sidecar":  structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-sidecar": structs.TaskState{State: "dead", Restarts: 0},
+				"poststop":          structs.TaskState{State: "dead", Restarts: 0},
+			},
+		},
+		{
+			name: "restart prestart-sidecar task",
+			action: func(ar *allocRunner, alloc *structs.Allocation) error {
+				return ar.RestartTask("prestart-sidecar", &structs.TaskEvent{Type: structs.TaskRestartSignal})
+			},
+			expectedAfter: map[string]structs.TaskState{
+				"main":              structs.TaskState{State: "running", Restarts: 0},
+				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
+				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 1},
+				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 0},
+				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+			},
+		},
+		{
+			name: "restart poststart-sidecar task",
+			action: func(ar *allocRunner, alloc *structs.Allocation) error {
+				return ar.RestartTask("poststart-sidecar", &structs.TaskEvent{Type: structs.TaskRestartSignal})
+			},
+			expectedAfter: map[string]structs.TaskState{
+				"main":              structs.TaskState{State: "running", Restarts: 0},
+				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
+				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 0},
+				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
+				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 1},
+				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ci.Parallel(t)
+
+			alloc := alloc.Copy()
+			alloc.Job.TaskGroups[0].RestartPolicy = rp
+			if tc.taskDefs != nil {
+				alloc = mock.LifecycleAllocFromTasks(tc.taskDefs)
+				alloc.Job.Type = structs.JobTypeService
+			}
+			for _, task := range alloc.Job.TaskGroups[0].Tasks {
+				task.RestartPolicy = rp // tasks inherit the group policy
+			}
+			if tc.hasLeader {
+				for _, task := range alloc.Job.TaskGroups[0].Tasks {
+					if task.Name == "main" {
+						task.Leader = true
+					}
+				}
+			}
+			if tc.isBatch {
+				alloc.Job.Type = structs.JobTypeBatch
+			}
+
+			conf, cleanup := testAllocRunnerConfig(t, alloc)
+			defer cleanup()
+			ar, err := NewAllocRunner(conf)
+			require.NoError(t, err)
+			defer destroy(ar)
+			go ar.Run()
+
+			upd := conf.StateUpdater.(*MockStateUpdater)
+
+			// assert our "before" states:
+			// - all one-shot tasks should be dead but not failed
+			// - all main tasks and sidecars should be running
+			// - no tasks should have restarted
+			testutil.WaitForResult(func() (bool, error) {
+				last := upd.Last()
+				if last == nil {
+					return false, fmt.Errorf("no update")
+				}
+				if last.ClientStatus != structs.AllocClientStatusRunning {
+					return false, fmt.Errorf(
+						"expected alloc to be running not %s", last.ClientStatus)
+				}
+				var errs *multierror.Error
+
+				expectedBefore := map[string]string{
+					"main":              "running",
+					"prestart-oneshot":  "dead",
+					"prestart-sidecar":  "running",
+					"poststart-oneshot": "dead",
+					"poststart-sidecar": "running",
+					"poststop":          "pending",
+				}
+
+				for task, expected := range expectedBefore {
+					got, ok := last.TaskStates[task]
+					if !ok {
+						continue
+					}
+					if got.State != expected {
+						errs = multierror.Append(errs, fmt.Errorf(
+							"expected initial state of task %q to be %q not %q",
+							task, expected, got.State))
+					}
+					if got.Restarts != 0 {
+						errs = multierror.Append(errs, fmt.Errorf(
+							"expected no initial restarts of task %q, not %q",
+							task, got.Restarts))
+					}
+					if expected == "dead" && got.Failed {
+						errs = multierror.Append(errs, fmt.Errorf(
+							"expected ephemeral task %q to be dead but not failed",
+							task))
+					}
+
+				}
+				if errs.ErrorOrNil() != nil {
+					return false, errs.ErrorOrNil()
+				}
+				return true, nil
+			}, func(err error) {
+				require.NoError(t, err, "error waiting for initial state")
+			})
+
+			// perform the action
+			err = tc.action(ar, alloc.Copy())
+			if tc.expectedErr != "" {
+				require.EqualError(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// assert our "after" states
+			testutil.WaitForResult(func() (bool, error) {
+				last := upd.Last()
+				if last == nil {
+					return false, fmt.Errorf("no update")
+				}
+				var errs *multierror.Error
+				for task, expected := range tc.expectedAfter {
+					got, ok := last.TaskStates[task]
+					if !ok {
+						errs = multierror.Append(errs, fmt.Errorf(
+							"no final state found for task %q", task,
+						))
+					}
+					if got.State != expected.State {
+						errs = multierror.Append(errs, fmt.Errorf(
+							"expected final state of task %q to be %q not %q",
+							task, expected.State, got.State))
+					}
+					if expected.State == "dead" {
+						if got.FinishedAt.IsZero() || got.StartedAt.IsZero() {
+							errs = multierror.Append(errs, fmt.Errorf(
+								"expected final state of task %q to have start and finish time", task))
+						}
+						if len(got.Events) < 2 {
+							errs = multierror.Append(errs, fmt.Errorf(
+								"expected final state of task %q to include at least 2 tasks", task))
+						}
+					}
+
+					if got.Restarts != expected.Restarts {
+						errs = multierror.Append(errs, fmt.Errorf(
+							"expected final restarts of task %q to be %v not %v",
+							task, expected.Restarts, got.Restarts))
+					}
+				}
+				if errs.ErrorOrNil() != nil {
+					return false, errs.ErrorOrNil()
+				}
+				return true, nil
+			}, func(err error) {
+				require.NoError(t, err, "error waiting for final state")
+			})
+		})
+	}
 }
 
 func TestAllocRunner_TaskGroup_ShutdownDelay(t *testing.T) {

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -504,6 +504,8 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 		Mode:     structs.RestartPolicyModeFail,
 	}
 
+	ev := &structs.TaskEvent{Type: structs.TaskRestartSignal}
+
 	testCases := []struct {
 		name          string
 		taskDefs      []mock.LifecycleTaskDef
@@ -516,7 +518,6 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 		{
 			name: "restart entire allocation",
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
-				ev := &structs.TaskEvent{Type: structs.TaskRestartAllSignal}
 				return ar.RestartAll(ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
@@ -531,7 +532,6 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 		{
 			name: "restart only running tasks",
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
-				ev := &structs.TaskEvent{Type: structs.TaskRestartRunningSignal}
 				return ar.RestartRunning(ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
@@ -555,7 +555,6 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 			},
 			isBatch: true,
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
-				ev := &structs.TaskEvent{Type: structs.TaskRestartAllSignal}
 				return ar.RestartAll(ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
@@ -579,7 +578,6 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 			},
 			isBatch: true,
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
-				ev := &structs.TaskEvent{Type: structs.TaskRestartRunningSignal}
 				return ar.RestartRunning(ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
@@ -595,7 +593,6 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 			name:      "restart entire allocation with leader",
 			hasLeader: true,
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
-				ev := &structs.TaskEvent{Type: structs.TaskRestartAllSignal}
 				return ar.RestartAll(ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
@@ -627,7 +624,6 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 		{
 			name: "restart main task",
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
-				ev := &structs.TaskEvent{Type: structs.TaskRestartSignal}
 				return ar.RestartTask("main", ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
@@ -643,7 +639,7 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 			name:      "restart leader main task",
 			hasLeader: true,
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
-				return ar.RestartTask("main", &structs.TaskEvent{Type: structs.TaskRestartSignal})
+				return ar.RestartTask("main", ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
 				"main":              structs.TaskState{State: "running", Restarts: 1},
@@ -761,7 +757,7 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 				// make sure main task has had a chance to restart once on its
 				// own and fail again before we try to manually restart it
 				time.Sleep(5 * time.Second)
-				return ar.RestartTask("main", &structs.TaskEvent{Type: structs.TaskRestartSignal})
+				return ar.RestartTask("main", ev)
 			},
 			expectedErr: "Task not running",
 			expectedAfter: map[string]structs.TaskState{
@@ -776,7 +772,7 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 		{
 			name: "restart prestart-sidecar task",
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
-				return ar.RestartTask("prestart-sidecar", &structs.TaskEvent{Type: structs.TaskRestartSignal})
+				return ar.RestartTask("prestart-sidecar", ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
 				"main":              structs.TaskState{State: "running", Restarts: 0},
@@ -790,7 +786,7 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 		{
 			name: "restart poststart-sidecar task",
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
-				return ar.RestartTask("poststart-sidecar", &structs.TaskEvent{Type: structs.TaskRestartSignal})
+				return ar.RestartTask("poststart-sidecar", ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
 				"main":              structs.TaskState{State: "running", Restarts: 0},

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -489,12 +489,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 
 	// test cases can use this default or override w/ taskDefs param
 	alloc := mock.LifecycleAllocFromTasks([]mock.LifecycleTaskDef{
-		{"main", "100s", 0, "", false},
-		{"prestart-oneshot", "1s", 0, "prestart", false},
-		{"prestart-sidecar", "100s", 0, "prestart", true},
-		{"poststart-oneshot", "1s", 0, "poststart", false},
-		{"poststart-sidecar", "100s", 0, "poststart", true},
-		{"poststop", "1s", 0, "poststop", false},
+		{Name: "main", RunFor: "100s", ExitCode: 0, Hook: "", IsSidecar: false},
+		{Name: "prestart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "prestart", IsSidecar: false},
+		{Name: "prestart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "prestart", IsSidecar: true},
+		{Name: "poststart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "poststart", IsSidecar: false},
+		{Name: "poststart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "poststart", IsSidecar: true},
+		{Name: "poststop", RunFor: "1s", ExitCode: 0, Hook: "poststop", IsSidecar: false},
 	})
 	alloc.Job.Type = structs.JobTypeService
 	rp := &structs.RestartPolicy{
@@ -546,12 +546,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 		{
 			name: "batch job restart entire allocation",
 			taskDefs: []mock.LifecycleTaskDef{
-				{"main", "100s", 1, "", false},
-				{"prestart-oneshot", "1s", 0, "prestart", false},
-				{"prestart-sidecar", "100s", 0, "prestart", true},
-				{"poststart-oneshot", "1s", 0, "poststart", false},
-				{"poststart-sidecar", "100s", 0, "poststart", true},
-				{"poststop", "1s", 0, "poststop", false},
+				{Name: "main", RunFor: "100s", ExitCode: 1, Hook: "", IsSidecar: false},
+				{Name: "prestart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "prestart", IsSidecar: false},
+				{Name: "prestart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "prestart", IsSidecar: true},
+				{Name: "poststart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "poststart", IsSidecar: false},
+				{Name: "poststart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "poststart", IsSidecar: true},
+				{Name: "poststop", RunFor: "1s", ExitCode: 0, Hook: "poststop", IsSidecar: false},
 			},
 			isBatch: true,
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
@@ -570,12 +570,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 		{
 			name: "batch job restart only running tasks ",
 			taskDefs: []mock.LifecycleTaskDef{
-				{"main", "100s", 1, "", false},
-				{"prestart-oneshot", "1s", 0, "prestart", false},
-				{"prestart-sidecar", "100s", 0, "prestart", true},
-				{"poststart-oneshot", "1s", 0, "poststart", false},
-				{"poststart-sidecar", "100s", 0, "poststart", true},
-				{"poststop", "1s", 0, "poststop", false},
+				{Name: "main", RunFor: "100s", ExitCode: 1, Hook: "", IsSidecar: false},
+				{Name: "prestart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "prestart", IsSidecar: false},
+				{Name: "prestart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "prestart", IsSidecar: true},
+				{Name: "poststart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "poststart", IsSidecar: false},
+				{Name: "poststart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "poststart", IsSidecar: true},
+				{Name: "poststop", RunFor: "1s", ExitCode: 0, Hook: "poststop", IsSidecar: false},
 			},
 			isBatch: true,
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
@@ -657,12 +657,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 		{
 			name: "main task fails and restarts once",
 			taskDefs: []mock.LifecycleTaskDef{
-				{"main", "2s", 1, "", false},
-				{"prestart-oneshot", "1s", 0, "prestart", false},
-				{"prestart-sidecar", "100s", 0, "prestart", true},
-				{"poststart-oneshot", "1s", 0, "poststart", false},
-				{"poststart-sidecar", "100s", 0, "poststart", true},
-				{"poststop", "1s", 0, "poststop", false},
+				{Name: "main", RunFor: "2s", ExitCode: 1, Hook: "", IsSidecar: false},
+				{Name: "prestart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "prestart", IsSidecar: false},
+				{Name: "prestart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "prestart", IsSidecar: true},
+				{Name: "poststart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "poststart", IsSidecar: false},
+				{Name: "poststart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "poststart", IsSidecar: true},
+				{Name: "poststop", RunFor: "1s", ExitCode: 0, Hook: "poststop", IsSidecar: false},
 			},
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
 				time.Sleep(3 * time.Second) // make sure main task has exited
@@ -680,12 +680,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 		{
 			name: "leader main task fails and restarts once",
 			taskDefs: []mock.LifecycleTaskDef{
-				{"main", "2s", 1, "", false},
-				{"prestart-oneshot", "1s", 0, "prestart", false},
-				{"prestart-sidecar", "100s", 0, "prestart", true},
-				{"poststart-oneshot", "1s", 0, "poststart", false},
-				{"poststart-sidecar", "100s", 0, "poststart", true},
-				{"poststop", "1s", 0, "poststop", false},
+				{Name: "main", RunFor: "2s", ExitCode: 1, Hook: "", IsSidecar: false},
+				{Name: "prestart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "prestart", IsSidecar: false},
+				{Name: "prestart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "prestart", IsSidecar: true},
+				{Name: "poststart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "poststart", IsSidecar: false},
+				{Name: "poststart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "poststart", IsSidecar: true},
+				{Name: "poststop", RunFor: "1s", ExitCode: 0, Hook: "poststop", IsSidecar: false},
 			},
 			hasLeader: true,
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
@@ -704,12 +704,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 		{
 			name: "main stopped unexpectedly and restarts once",
 			taskDefs: []mock.LifecycleTaskDef{
-				{"main", "2s", 0, "", false},
-				{"prestart-oneshot", "1s", 0, "prestart", false},
-				{"prestart-sidecar", "100s", 0, "prestart", true},
-				{"poststart-oneshot", "1s", 0, "poststart", false},
-				{"poststart-sidecar", "100s", 0, "poststart", true},
-				{"poststop", "1s", 0, "poststop", false},
+				{Name: "main", RunFor: "2s", ExitCode: 0, Hook: "", IsSidecar: false},
+				{Name: "prestart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "prestart", IsSidecar: false},
+				{Name: "prestart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "prestart", IsSidecar: true},
+				{Name: "poststart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "poststart", IsSidecar: false},
+				{Name: "poststart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "poststart", IsSidecar: true},
+				{Name: "poststop", RunFor: "1s", ExitCode: 0, Hook: "poststop", IsSidecar: false},
 			},
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
 				time.Sleep(3 * time.Second) // make sure main task has exited
@@ -727,12 +727,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 		{
 			name: "leader main stopped unexpectedly and restarts once",
 			taskDefs: []mock.LifecycleTaskDef{
-				{"main", "2s", 0, "", false},
-				{"prestart-oneshot", "1s", 0, "prestart", false},
-				{"prestart-sidecar", "100s", 0, "prestart", true},
-				{"poststart-oneshot", "1s", 0, "poststart", false},
-				{"poststart-sidecar", "100s", 0, "poststart", true},
-				{"poststop", "1s", 0, "poststop", false},
+				{Name: "main", RunFor: "2s", ExitCode: 0, Hook: "", IsSidecar: false},
+				{Name: "prestart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "prestart", IsSidecar: false},
+				{Name: "prestart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "prestart", IsSidecar: true},
+				{Name: "poststart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "poststart", IsSidecar: false},
+				{Name: "poststart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "poststart", IsSidecar: true},
+				{Name: "poststop", RunFor: "1s", ExitCode: 0, Hook: "poststop", IsSidecar: false},
 			},
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
 				time.Sleep(3 * time.Second) // make sure main task has exited
@@ -750,12 +750,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 		{
 			name: "failed main task cannot be restarted",
 			taskDefs: []mock.LifecycleTaskDef{
-				{"main", "2s", 1, "", false},
-				{"prestart-oneshot", "1s", 0, "prestart", false},
-				{"prestart-sidecar", "100s", 0, "prestart", true},
-				{"poststart-oneshot", "1s", 0, "poststart", false},
-				{"poststart-sidecar", "100s", 0, "poststart", true},
-				{"poststop", "1s", 0, "poststop", false},
+				{Name: "main", RunFor: "2s", ExitCode: 1, Hook: "", IsSidecar: false},
+				{Name: "prestart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "prestart", IsSidecar: false},
+				{Name: "prestart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "prestart", IsSidecar: true},
+				{Name: "poststart-oneshot", RunFor: "1s", ExitCode: 0, Hook: "poststart", IsSidecar: false},
+				{Name: "poststart-sidecar", RunFor: "100s", ExitCode: 0, Hook: "poststart", IsSidecar: true},
+				{Name: "poststop", RunFor: "1s", ExitCode: 0, Hook: "poststop", IsSidecar: false},
 			},
 			action: func(ar *allocRunner, alloc *structs.Allocation) error {
 				// make sure main task has had a chance to restart once on its

--- a/client/allocrunner/alloc_runner_unix_test.go
+++ b/client/allocrunner/alloc_runner_unix_test.go
@@ -154,10 +154,9 @@ func TestAllocRunner_Restore_CompletedBatch(t *testing.T) {
 	alloc := mock.Alloc()
 	alloc.Job.Type = structs.JobTypeBatch
 	task := alloc.Job.TaskGroups[0].Tasks[0]
-	task.Driver = "raw_exec"
+	task.Driver = "mock_driver"
 	task.Config = map[string]interface{}{
-		"command": "sleep",
-		"args":    []string{"2"},
+		"run_for": "2ms",
 	}
 
 	conf, cleanup := testAllocRunnerConfig(t, alloc.Copy())

--- a/client/allocrunner/tasklifecycle/coordinator.go
+++ b/client/allocrunner/tasklifecycle/coordinator.go
@@ -109,6 +109,15 @@ func NewCoordinator(logger hclog.Logger, tasks []*structs.Task, shutdownCh <-cha
 	return c
 }
 
+// Restart sets the Coordinator state back to "init" and is used to coordinate
+// a full alloc restart. Since all tasks will run again they need to be pending
+// before they are allowed to proceed.
+func (c *Coordinator) Restart() {
+	c.currentStateLock.Lock()
+	defer c.currentStateLock.Unlock()
+	c.enterStateLocked(coordinatorStateInit)
+}
+
 // Restore is used to set the Coordinator FSM to the correct state when an
 // alloc is restored. Must be called before the allocrunner is running.
 func (c *Coordinator) Restore(states map[string]*structs.TaskState) {

--- a/client/allocrunner/tasklifecycle/coordinator.go
+++ b/client/allocrunner/tasklifecycle/coordinator.go
@@ -284,7 +284,7 @@ func (c *Coordinator) isInitDone(states map[string]*structs.TaskState) bool {
 
 // isPrestartDone returns true when the following conditions are met:
 //   - there is at least one prestart task
-//   - all ephemeral prestart tasks are in the "dead" state.
+//   - all ephemeral prestart tasks are successful.
 //   - no ephemeral prestart task has failed.
 //   - all prestart sidecar tasks are running.
 func (c *Coordinator) isPrestartDone(states map[string]*structs.TaskState) bool {
@@ -293,7 +293,7 @@ func (c *Coordinator) isPrestartDone(states map[string]*structs.TaskState) bool 
 	}
 
 	for _, task := range c.tasksByLifecycle[lifecycleStagePrestartEphemeral] {
-		if states[task].State != structs.TaskStateDead || states[task].Failed {
+		if !states[task].Successful() {
 			return false
 		}
 	}

--- a/client/allocrunner/tasklifecycle/coordinator_test.go
+++ b/client/allocrunner/tasklifecycle/coordinator_test.go
@@ -58,6 +58,9 @@ func TestCoordinator_PrestartRunsBeforeMain(t *testing.T) {
 	sideTask := tasks[1]
 	initTask := tasks[2]
 
+	// Only use the tasks that we care about.
+	tasks = []*structs.Task{mainTask, sideTask, initTask}
+
 	shutdownCh := make(chan struct{})
 	defer close(shutdownCh)
 	coord := NewCoordinator(logger, tasks, shutdownCh)
@@ -161,6 +164,9 @@ func TestCoordinator_MainRunsAfterManyInitTasks(t *testing.T) {
 	init1Task := tasks[1]
 	init2Task := tasks[2]
 
+	// Only use the tasks that we care about.
+	tasks = []*structs.Task{mainTask, init1Task, init2Task}
+
 	shutdownCh := make(chan struct{})
 	defer close(shutdownCh)
 	coord := NewCoordinator(logger, tasks, shutdownCh)
@@ -227,6 +233,9 @@ func TestCoordinator_FailedInitTask(t *testing.T) {
 	init1Task := tasks[1]
 	init2Task := tasks[2]
 
+	// Only use the tasks that we care about.
+	tasks = []*structs.Task{mainTask, init1Task, init2Task}
+
 	shutdownCh := make(chan struct{})
 	defer close(shutdownCh)
 	coord := NewCoordinator(logger, tasks, shutdownCh)
@@ -292,6 +301,9 @@ func TestCoordinator_SidecarNeverStarts(t *testing.T) {
 	sideTask := tasks[1]
 	initTask := tasks[2]
 
+	// Only use the tasks that we care about.
+	tasks = []*structs.Task{mainTask, sideTask, initTask}
+
 	shutdownCh := make(chan struct{})
 	defer close(shutdownCh)
 	coord := NewCoordinator(logger, tasks, shutdownCh)
@@ -355,6 +367,9 @@ func TestCoordinator_PoststartStartsAfterMain(t *testing.T) {
 	mainTask := tasks[0]
 	sideTask := tasks[1]
 	postTask := tasks[2]
+
+	// Only use the tasks that we care about.
+	tasks = []*structs.Task{mainTask, sideTask, postTask}
 
 	// Make the the third task is a poststart hook
 	postTask.Lifecycle.Hook = structs.TaskLifecycleHookPoststart

--- a/client/allocrunner/taskrunner/lifecycle.go
+++ b/client/allocrunner/taskrunner/lifecycle.go
@@ -100,14 +100,17 @@ func (tr *TaskRunner) Signal(event *structs.TaskEvent, s string) error {
 // Kill a task. Blocks until task exits or context is canceled. State is set to
 // dead.
 func (tr *TaskRunner) Kill(ctx context.Context, event *structs.TaskEvent) error {
-	tr.logger.Trace("Kill requested", "event_type", event.Type, "event_reason", event.KillReason)
+	tr.logger.Trace("Kill requested")
 
 	// Cancel the task runner to break out of restart delay or the main run
 	// loop.
 	tr.killCtxCancel()
 
 	// Emit kill event
-	tr.EmitEvent(event)
+	if event != nil {
+		tr.logger.Trace("Kill event", "event_type", event.Type, "event_reason", event.KillReason)
+		tr.EmitEvent(event)
+	}
 
 	select {
 	case <-tr.WaitCh():

--- a/client/allocrunner/taskrunner/sids_hook_test.go
+++ b/client/allocrunner/taskrunner/sids_hook_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
@@ -297,11 +296,7 @@ func TestTaskRunner_DeriveSIToken_UnWritableTokenFile(t *testing.T) {
 	go tr.Run()
 
 	// wait for task runner to finish running
-	select {
-	case <-tr.WaitCh():
-	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
-		r.Fail("timed out waiting for task runner")
-	}
+	testWaitForTaskToDie(t, tr)
 
 	// assert task exited un-successfully
 	finalState := tr.TaskState()

--- a/client/allocrunner/taskrunner/state/state.go
+++ b/client/allocrunner/taskrunner/state/state.go
@@ -16,6 +16,11 @@ type LocalState struct {
 
 	// TaskHandle is the handle used to reattach to the task during recovery
 	TaskHandle *drivers.TaskHandle
+
+	// RunComplete is set to true when the TaskRunner.Run() method finishes.
+	// It is used to distinguish between a dead task that could be restarted
+	// and one that will never run again.
+	RunComplete bool
 }
 
 func NewLocalState() *LocalState {
@@ -52,6 +57,7 @@ func (s *LocalState) Copy() *LocalState {
 		Hooks:         make(map[string]*HookState, len(s.Hooks)),
 		DriverNetwork: s.DriverNetwork.Copy(),
 		TaskHandle:    s.TaskHandle.Copy(),
+		RunComplete:   s.RunComplete,
 	}
 
 	// Copy the hook state

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -335,7 +335,7 @@ func TestTaskRunner_Restore_Running(t *testing.T) {
 	defer newTR.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
 
 	// Wait for new task runner to exit when the process does
-	<-newTR.WaitCh()
+	testWaitForTaskToDie(t, newTR)
 
 	// Assert that the process was only started once
 	started := 0
@@ -603,11 +603,7 @@ func TestTaskRunner_TaskEnv_Interpolated(t *testing.T) {
 	defer cleanup()
 
 	// Wait for task to complete
-	select {
-	case <-tr.WaitCh():
-	case <-time.After(3 * time.Second):
-		require.Fail("timeout waiting for task to exit")
-	}
+	testWaitForTaskToDie(t, tr)
 
 	// Get the mock driver plugin
 	driverPlugin, err := conf.DriverManager.Dispense(mockdriver.PluginID.Name)
@@ -654,7 +650,9 @@ func TestTaskRunner_TaskEnv_Chroot(t *testing.T) {
 	go tr.Run()
 	defer tr.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
 
-	// Wait for task to exit
+	// Wait for task to exit and kill the task runner to run the stop hooks.
+	testWaitForTaskToDie(t, tr)
+	tr.Kill(context.Background(), structs.NewTaskEvent("kill"))
 	timeout := 15 * time.Second
 	if testutil.IsCI() {
 		timeout = 120 * time.Second
@@ -703,7 +701,9 @@ func TestTaskRunner_TaskEnv_Image(t *testing.T) {
 	tr, conf, cleanup := runTestTaskRunner(t, alloc, task.Name)
 	defer cleanup()
 
-	// Wait for task to exit
+	// Wait for task to exit and kill task runner to run the stop hooks.
+	testWaitForTaskToDie(t, tr)
+	tr.Kill(context.Background(), structs.NewTaskEvent("kill"))
 	select {
 	case <-tr.WaitCh():
 	case <-time.After(15 * time.Second):
@@ -750,7 +750,9 @@ func TestTaskRunner_TaskEnv_None(t *testing.T) {
 %s
 `, root, taskDir, taskDir, os.Getenv("PATH"))
 
-	// Wait for task to exit
+	// Wait for task to exit and kill the task runner to run the stop hooks.
+	testWaitForTaskToDie(t, tr)
+	tr.Kill(context.Background(), structs.NewTaskEvent("kill"))
 	select {
 	case <-tr.WaitCh():
 	case <-time.After(15 * time.Second):
@@ -818,10 +820,7 @@ func TestTaskRunner_DevicePropogation(t *testing.T) {
 	defer tr.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
 
 	// Wait for task to complete
-	select {
-	case <-tr.WaitCh():
-	case <-time.After(3 * time.Second):
-	}
+	testWaitForTaskToDie(t, tr)
 
 	// Get the mock driver plugin
 	driverPlugin, err := conf.DriverManager.Dispense(mockdriver.PluginID.Name)
@@ -1306,15 +1305,15 @@ func TestTaskRunner_CheckWatcher_Restart(t *testing.T) {
 		"Received",
 		"Task Setup",
 		"Started",
-		"Restart Signaled",
+		"Restart Running Signaled",
 		"Terminated",
 		"Restarting",
 		"Started",
-		"Restart Signaled",
+		"Restart Running Signaled",
 		"Terminated",
 		"Restarting",
 		"Started",
-		"Restart Signaled",
+		"Restart Running Signaled",
 		"Terminated",
 		"Not Restarting",
 	}
@@ -1328,11 +1327,7 @@ func TestTaskRunner_CheckWatcher_Restart(t *testing.T) {
 	// Wait until the task exits. Don't simply wait for it to run as it may
 	// get restarted and terminated before the test is able to observe it
 	// running.
-	select {
-	case <-tr.WaitCh():
-	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
-		require.Fail(t, "timeout")
-	}
+	testWaitForTaskToDie(t, tr)
 
 	state := tr.TaskState()
 	actualEvents := make([]string, len(state.Events))
@@ -1421,11 +1416,7 @@ func TestTaskRunner_BlockForSIDSToken(t *testing.T) {
 
 	// task runner should exit now that it has been unblocked and it is a batch
 	// job with a zero sleep time
-	select {
-	case <-tr.WaitCh():
-	case <-time.After(15 * time.Second * time.Duration(testutil.TestMultiplier())):
-		r.Fail("timed out waiting for batch task to exist")
-	}
+	testWaitForTaskToDie(t, tr)
 
 	// assert task exited successfully
 	finalState := tr.TaskState()
@@ -1478,11 +1469,7 @@ func TestTaskRunner_DeriveSIToken_Retry(t *testing.T) {
 	go tr.Run()
 
 	// assert task runner blocks on SI token
-	select {
-	case <-tr.WaitCh():
-	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
-		r.Fail("timed out waiting for task runner")
-	}
+	testWaitForTaskToDie(t, tr)
 
 	// assert task exited successfully
 	finalState := tr.TaskState()
@@ -1598,11 +1585,7 @@ func TestTaskRunner_BlockForVaultToken(t *testing.T) {
 
 	// TR should exit now that it's unblocked by vault as its a batch job
 	// with 0 sleeping.
-	select {
-	case <-tr.WaitCh():
-	case <-time.After(15 * time.Second * time.Duration(testutil.TestMultiplier())):
-		require.Fail(t, "timed out waiting for batch task to exit")
-	}
+	testWaitForTaskToDie(t, tr)
 
 	// Assert task exited successfully
 	finalState := tr.TaskState()
@@ -1614,6 +1597,14 @@ func TestTaskRunner_BlockForVaultToken(t *testing.T) {
 	data, err := ioutil.ReadFile(tokenPath)
 	require.NoError(t, err)
 	require.Equal(t, token, string(data))
+
+	// Kill task runner to trigger stop hooks
+	tr.Kill(context.Background(), structs.NewTaskEvent("kill"))
+	select {
+	case <-tr.WaitCh():
+	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+		require.Fail(t, "timed out waiting for task runner to exit")
+	}
 
 	// Check the token was revoked
 	testutil.WaitForResult(func() (bool, error) {
@@ -1661,16 +1652,20 @@ func TestTaskRunner_DeriveToken_Retry(t *testing.T) {
 	defer tr.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
 	go tr.Run()
 
-	// Wait for TR to exit and check its state
+	// Wait for TR to die and check its state
+	testWaitForTaskToDie(t, tr)
+
+	state := tr.TaskState()
+	require.Equal(t, structs.TaskStateDead, state.State)
+	require.False(t, state.Failed)
+
+	// Kill task runner to trigger stop hooks
+	tr.Kill(context.Background(), structs.NewTaskEvent("kill"))
 	select {
 	case <-tr.WaitCh():
 	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
 		require.Fail(t, "timed out waiting for task runner to exit")
 	}
-
-	state := tr.TaskState()
-	require.Equal(t, structs.TaskStateDead, state.State)
-	require.False(t, state.Failed)
 
 	require.Equal(t, 1, count)
 
@@ -1771,11 +1766,7 @@ func TestTaskRunner_Download_ChrootExec(t *testing.T) {
 	defer cleanup()
 
 	// Wait for task to run and exit
-	select {
-	case <-tr.WaitCh():
-	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
-		require.Fail(t, "timed out waiting for task runner to exit")
-	}
+	testWaitForTaskToDie(t, tr)
 
 	state := tr.TaskState()
 	require.Equal(t, structs.TaskStateDead, state.State)
@@ -1816,11 +1807,7 @@ func TestTaskRunner_Download_RawExec(t *testing.T) {
 	defer cleanup()
 
 	// Wait for task to run and exit
-	select {
-	case <-tr.WaitCh():
-	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
-		require.Fail(t, "timed out waiting for task runner to exit")
-	}
+	testWaitForTaskToDie(t, tr)
 
 	state := tr.TaskState()
 	require.Equal(t, structs.TaskStateDead, state.State)
@@ -1851,11 +1838,7 @@ func TestTaskRunner_Download_List(t *testing.T) {
 	defer cleanup()
 
 	// Wait for task to run and exit
-	select {
-	case <-tr.WaitCh():
-	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
-		require.Fail(t, "timed out waiting for task runner to exit")
-	}
+	testWaitForTaskToDie(t, tr)
 
 	state := tr.TaskState()
 	require.Equal(t, structs.TaskStateDead, state.State)
@@ -1902,11 +1885,7 @@ func TestTaskRunner_Download_Retries(t *testing.T) {
 	tr, _, cleanup := runTestTaskRunner(t, alloc, task.Name)
 	defer cleanup()
 
-	select {
-	case <-tr.WaitCh():
-	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
-		require.Fail(t, "timed out waiting for task to exit")
-	}
+	testWaitForTaskToDie(t, tr)
 
 	state := tr.TaskState()
 	require.Equal(t, structs.TaskStateDead, state.State)
@@ -2100,6 +2079,8 @@ func TestTaskRunner_RestartSignalTask_NotRunning(t *testing.T) {
 	case <-time.After(1 * time.Second):
 	}
 
+	require.Equal(t, structs.TaskStatePending, tr.TaskState().State)
+
 	// Send a signal and restart
 	err = tr.Signal(structs.NewTaskEvent("don't panic"), "QUIT")
 	require.EqualError(t, err, ErrTaskNotRunning.Error())
@@ -2110,12 +2091,7 @@ func TestTaskRunner_RestartSignalTask_NotRunning(t *testing.T) {
 
 	// Unblock and let it finish
 	waitCh <- struct{}{}
-
-	select {
-	case <-tr.WaitCh():
-	case <-time.After(10 * time.Second):
-		require.Fail(t, "timed out waiting for task to complete")
-	}
+	testWaitForTaskToDie(t, tr)
 
 	// Assert the task ran and never restarted
 	state := tr.TaskState()
@@ -2153,11 +2129,7 @@ func TestTaskRunner_Run_RecoverableStartError(t *testing.T) {
 	tr, _, cleanup := runTestTaskRunner(t, alloc, task.Name)
 	defer cleanup()
 
-	select {
-	case <-tr.WaitCh():
-	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
-		require.Fail(t, "timed out waiting for task to exit")
-	}
+	testWaitForTaskToDie(t, tr)
 
 	state := tr.TaskState()
 	require.Equal(t, structs.TaskStateDead, state.State)
@@ -2202,11 +2174,7 @@ func TestTaskRunner_Template_Artifact(t *testing.T) {
 	go tr.Run()
 
 	// Wait for task to run and exit
-	select {
-	case <-tr.WaitCh():
-	case <-time.After(15 * time.Second * time.Duration(testutil.TestMultiplier())):
-		require.Fail(t, "timed out waiting for task runner to exit")
-	}
+	testWaitForTaskToDie(t, tr)
 
 	state := tr.TaskState()
 	require.Equal(t, structs.TaskStateDead, state.State)
@@ -2536,7 +2504,9 @@ func TestTaskRunner_UnregisterConsul_Retries(t *testing.T) {
 	tr, err := NewTaskRunner(conf)
 	require.NoError(t, err)
 	defer tr.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
-	tr.Run()
+	go tr.Run()
+
+	testWaitForTaskToDie(t, tr)
 
 	state := tr.TaskState()
 	require.Equal(t, structs.TaskStateDead, state.State)
@@ -2562,7 +2532,17 @@ func TestTaskRunner_UnregisterConsul_Retries(t *testing.T) {
 func testWaitForTaskToStart(t *testing.T, tr *TaskRunner) {
 	testutil.WaitForResult(func() (bool, error) {
 		ts := tr.TaskState()
-		return ts.State == structs.TaskStateRunning, fmt.Errorf("%v", ts.State)
+		return ts.State == structs.TaskStateRunning, fmt.Errorf("expected task to be runnig, got %v", ts.State)
+	}, func(err error) {
+		require.NoError(t, err)
+	})
+}
+
+// testWaitForTaskToDie waits for the task to die or fails the test
+func testWaitForTaskToDie(t *testing.T, tr *TaskRunner) {
+	testutil.WaitForResult(func() (bool, error) {
+		ts := tr.TaskState()
+		return ts.State == structs.TaskStateDead, fmt.Errorf("expected task to be dead, got %v", ts.State)
 	}, func(err error) {
 		require.NoError(t, err)
 	})

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -397,8 +397,8 @@ func TestTaskRunner_Restore_Dead(t *testing.T) {
 	// Verify that we can restart task.
 	// Retry a few times as the newTR.Run() may not have started yet.
 	testutil.WaitForResult(func() (bool, error) {
-		ev := &structs.TaskEvent{Type: structs.TaskRestartAllSignal}
-		err = newTR.Restart(context.Background(), ev, false)
+		ev := &structs.TaskEvent{Type: structs.TaskRestartSignal}
+		err = newTR.Rerun(context.Background(), ev, false)
 		return err == nil, err
 	}, func(err error) {
 		require.NoError(t, err)
@@ -425,8 +425,8 @@ func TestTaskRunner_Restore_Dead(t *testing.T) {
 	go newTR2.Run()
 	defer newTR2.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
 
-	ev := &structs.TaskEvent{Type: structs.TaskRestartAllSignal}
-	err = newTR2.Restart(context.Background(), ev, false)
+	ev := &structs.TaskEvent{Type: structs.TaskRestartSignal}
+	err = newTR2.Rerun(context.Background(), ev, false)
 	require.Equal(t, err, ErrTaskNotRunning)
 }
 

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -398,7 +398,7 @@ func TestTaskRunner_Restore_Dead(t *testing.T) {
 	// Retry a few times as the newTR.Run() may not have started yet.
 	testutil.WaitForResult(func() (bool, error) {
 		ev := &structs.TaskEvent{Type: structs.TaskRestartSignal}
-		err = newTR.Rerun(context.Background(), ev, false)
+		err = newTR.ForceRestart(context.Background(), ev, false)
 		return err == nil, err
 	}, func(err error) {
 		require.NoError(t, err)
@@ -426,7 +426,7 @@ func TestTaskRunner_Restore_Dead(t *testing.T) {
 	defer newTR2.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
 
 	ev := &structs.TaskEvent{Type: structs.TaskRestartSignal}
-	err = newTR2.Rerun(context.Background(), ev, false)
+	err = newTR2.ForceRestart(context.Background(), ev, false)
 	require.Equal(t, err, ErrTaskNotRunning)
 }
 
@@ -1386,15 +1386,15 @@ func TestTaskRunner_CheckWatcher_Restart(t *testing.T) {
 		"Received",
 		"Task Setup",
 		"Started",
-		"Restart Running Signaled",
+		"Restart Signaled",
 		"Terminated",
 		"Restarting",
 		"Started",
-		"Restart Running Signaled",
+		"Restart Signaled",
 		"Terminated",
 		"Restarting",
 		"Started",
-		"Restart Running Signaled",
+		"Restart Signaled",
 		"Terminated",
 		"Not Restarting",
 	}

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -2613,7 +2613,7 @@ func TestTaskRunner_UnregisterConsul_Retries(t *testing.T) {
 func testWaitForTaskToStart(t *testing.T, tr *TaskRunner) {
 	testutil.WaitForResult(func() (bool, error) {
 		ts := tr.TaskState()
-		return ts.State == structs.TaskStateRunning, fmt.Errorf("expected task to be runnig, got %v", ts.State)
+		return ts.State == structs.TaskStateRunning, fmt.Errorf("expected task to be running, got %v", ts.State)
 	}, func(err error) {
 		require.NoError(t, err)
 	})

--- a/client/allocrunner/testing.go
+++ b/client/allocrunner/testing.go
@@ -4,6 +4,7 @@
 package allocrunner
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/client/vaultclient"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -103,4 +105,14 @@ func TestAllocRunnerFromAlloc(t *testing.T, alloc *structs.Allocation) (*allocRu
 	}
 
 	return ar, cleanup
+}
+
+func WaitForClientState(t *testing.T, ar *allocRunner, state string) {
+	testutil.WaitForResult(func() (bool, error) {
+		got := ar.AllocState().ClientStatus
+		return got == state,
+			fmt.Errorf("expected alloc runner to be in state %s, got %s", state, got)
+	}, func(err error) {
+		require.NoError(t, err)
+	})
 }

--- a/client/client.go
+++ b/client/client.go
@@ -926,20 +926,31 @@ func (c *Client) CollectAllAllocs() {
 	c.garbageCollector.CollectAll()
 }
 
-func (c *Client) RestartAllocation(allocID, taskName string) error {
+func (c *Client) RestartAllocation(allocID, taskName string, allTasks bool) error {
+	if allTasks && taskName != "" {
+		return fmt.Errorf("task name cannot be set when restarting all tasks")
+	}
+
 	ar, err := c.getAllocRunner(allocID)
 	if err != nil {
 		return err
 	}
 
-	event := structs.NewTaskEvent(structs.TaskRestartSignal).
-		SetRestartReason("User requested restart")
-
 	if taskName != "" {
+		event := structs.NewTaskEvent(structs.TaskRestartSignal).
+			SetRestartReason("User requested task to restart")
 		return ar.RestartTask(taskName, event)
 	}
 
-	return ar.RestartAll(event)
+	if allTasks {
+		event := structs.NewTaskEvent(structs.TaskRestartAllSignal).
+			SetRestartReason("User requested all tasks to restart")
+		return ar.RestartAll(event)
+	}
+
+	event := structs.NewTaskEvent(structs.TaskRestartRunningSignal).
+		SetRestartReason("User requested running tasks to restart")
+	return ar.RestartRunning(event)
 }
 
 // Node returns the locally registered node

--- a/client/client.go
+++ b/client/client.go
@@ -160,6 +160,7 @@ type AllocRunner interface {
 	PersistState() error
 
 	RestartTask(taskName string, taskEvent *structs.TaskEvent) error
+	RestartRunning(taskEvent *structs.TaskEvent) error
 	RestartAll(taskEvent *structs.TaskEvent) error
 	Reconnect(update *structs.Allocation) error
 

--- a/client/client.go
+++ b/client/client.go
@@ -943,12 +943,12 @@ func (c *Client) RestartAllocation(allocID, taskName string, allTasks bool) erro
 	}
 
 	if allTasks {
-		event := structs.NewTaskEvent(structs.TaskRestartAllSignal).
+		event := structs.NewTaskEvent(structs.TaskRestartSignal).
 			SetRestartReason("User requested all tasks to restart")
 		return ar.RestartAll(event)
 	}
 
-	event := structs.NewTaskEvent(structs.TaskRestartRunningSignal).
+	event := structs.NewTaskEvent(structs.TaskRestartSignal).
 		SetRestartReason("User requested running tasks to restart")
 	return ar.RestartRunning(event)
 }

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -283,6 +283,7 @@ func (s *HTTPServer) allocRestart(allocID string, resp http.ResponseWriter, req 
 	// Explicitly parse the body separately to disallow overriding AllocID in req Body.
 	var reqBody struct {
 		TaskName string
+		AllTasks bool
 	}
 	err := json.NewDecoder(req.Body).Decode(&reqBody)
 	if err != nil && err != io.EOF {
@@ -290,6 +291,9 @@ func (s *HTTPServer) allocRestart(allocID string, resp http.ResponseWriter, req 
 	}
 	if reqBody.TaskName != "" {
 		args.TaskName = reqBody.TaskName
+	}
+	if reqBody.AllTasks {
+		args.AllTasks = reqBody.AllTasks
 	}
 
 	// Determine the handler to use

--- a/command/agent/consul/check_watcher.go
+++ b/command/agent/consul/check_watcher.go
@@ -103,7 +103,7 @@ func (c *checkRestart) apply(ctx context.Context, now time.Time, status string) 
 
 		// Tell TaskRunner to restart due to failure
 		reason := fmt.Sprintf("healthcheck: check %q unhealthy", c.checkName)
-		event := structs.NewTaskEvent(structs.TaskRestartSignal).SetRestartReason(reason)
+		event := structs.NewTaskEvent(structs.TaskRestartRunningSignal).SetRestartReason(reason)
 		go asyncRestart(ctx, c.logger, c.task, event)
 		return true
 	}

--- a/command/agent/consul/check_watcher.go
+++ b/command/agent/consul/check_watcher.go
@@ -103,7 +103,7 @@ func (c *checkRestart) apply(ctx context.Context, now time.Time, status string) 
 
 		// Tell TaskRunner to restart due to failure
 		reason := fmt.Sprintf("healthcheck: check %q unhealthy", c.checkName)
-		event := structs.NewTaskEvent(structs.TaskRestartRunningSignal).SetRestartReason(reason)
+		event := structs.NewTaskEvent(structs.TaskRestartSignal).SetRestartReason(reason)
 		go asyncRestart(ctx, c.logger, c.task, event)
 		return true
 	}

--- a/command/alloc_restart.go
+++ b/command/alloc_restart.go
@@ -36,7 +36,8 @@ Restart Specific Options:
 
   -all-tasks
     If set, all tasks in the allocation will be restarted, even the ones that
-    already ran. This option cannot be used if a task is defined.
+    already ran. This option cannot be used with '-task' or the '<task>'
+    argument.
 
   -task <task-name>
     Specify the individual task to restart. If task name is given with both an

--- a/command/alloc_restart.go
+++ b/command/alloc_restart.go
@@ -18,8 +18,11 @@ func (c *AllocRestartCommand) Help() string {
 Usage: nomad alloc restart [options] <allocation> <task>
 
   Restart an existing allocation. This command is used to restart a specific alloc
-  and its tasks. If no task is provided then all of the allocation's tasks will
-  be restarted.
+  and its tasks. If no task is provided then all of the allocation's tasks that
+  are currently running will be restarted.
+
+  Use the option '-all-tasks' to restart tasks that have already run, such as
+  non-sidecar prestart and poststart tasks.
 
   When ACLs are enabled, this command requires a token with the
   'alloc-lifecycle', 'read-job', and 'list-jobs' capabilities for the
@@ -31,9 +34,14 @@ General Options:
 
 Restart Specific Options:
 
+  -all-tasks
+    If set, all tasks in the allocation will be restarted, even the ones that
+    already ran. This option cannot be used if a task is defined.
+
   -task <task-name>
-    Specify the individual task to restart. If task name is given with both an 
+    Specify the individual task to restart. If task name is given with both an
     argument and the '-task' option, preference is given to the '-task' option.
+    This option cannot be used with '-all-tasks'.
 
   -verbose
     Show full information.
@@ -44,11 +52,12 @@ Restart Specific Options:
 func (c *AllocRestartCommand) Name() string { return "alloc restart" }
 
 func (c *AllocRestartCommand) Run(args []string) int {
-	var verbose bool
+	var allTasks, verbose bool
 	var task string
 
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.BoolVar(&allTasks, "all-tasks", false, "")
 	flags.BoolVar(&verbose, "verbose", false, "")
 	flags.StringVar(&task, "task", "", "")
 
@@ -65,6 +74,17 @@ func (c *AllocRestartCommand) Run(args []string) int {
 	}
 
 	allocID := args[0]
+
+	// If -task isn't provided fallback to reading the task name
+	// from args.
+	if task == "" && len(args) >= 2 {
+		task = args[1]
+	}
+
+	if allTasks && task != "" {
+		c.Ui.Error("The -all-tasks option is not allowed when restarting a specific task.")
+		return 1
+	}
 
 	// Truncate the id unless full length is requested
 	length := shortId
@@ -113,12 +133,6 @@ func (c *AllocRestartCommand) Run(args []string) int {
 		return 1
 	}
 
-	// If -task isn't provided fallback to reading the task name
-	// from args.
-	if task == "" && len(args) >= 2 {
-		task = args[1]
-	}
-
 	if task != "" {
 		err := validateTaskExistsInAllocation(task, alloc)
 		if err != nil {
@@ -127,9 +141,17 @@ func (c *AllocRestartCommand) Run(args []string) int {
 		}
 	}
 
-	err = client.Allocations().Restart(alloc, task, nil)
+	if allTasks {
+		err = client.Allocations().RestartAllTasks(alloc, nil)
+	} else {
+		err = client.Allocations().Restart(alloc, task, nil)
+	}
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to restart allocation:\n\n%s", err.Error()))
+		target := "allocation"
+		if task != "" {
+			target = "task"
+		}
+		c.Ui.Error(fmt.Sprintf("Failed to restart %s:\n\n%s", target, err.Error()))
 		return 1
 	}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1028,6 +1028,7 @@ type AllocsGetRequest struct {
 type AllocRestartRequest struct {
 	AllocID  string
 	TaskName string
+	AllTasks bool
 
 	QueryOptions
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8017,9 +8017,17 @@ const (
 	// restarted because it has exceeded its restart policy.
 	TaskNotRestarting = "Not Restarting"
 
-	// TaskRestartSignal indicates that the task has been signalled to be
+	// TaskRestartSignal indicates that the task has been signaled to be
 	// restarted
 	TaskRestartSignal = "Restart Signaled"
+
+	// TaskRestartRunningSignal indicates that all tasks in the allocation that
+	// are currently running have been signaled to be restarted.
+	TaskRestartRunningSignal = "Restart Running Signaled"
+
+	// TaskRestartAllSignal indicates that all tasks in the allocation have
+	// been signaled to be restarted, even the ones that have already run.
+	TaskRestartAllSignal = "Restart All Signaled"
 
 	// TaskSignaling indicates that the task is being signalled.
 	TaskSignaling = "Signaling"
@@ -8278,6 +8286,18 @@ func (e *TaskEvent) PopulateEventDisplayMessage() {
 		} else {
 			desc = "Task signaled to restart"
 		}
+	case TaskRestartRunningSignal:
+		if e.RestartReason != "" {
+			desc = e.RestartReason
+		} else {
+			desc = "Running tasks signaled to restart"
+		}
+	case TaskRestartAllSignal:
+		if e.RestartReason != "" {
+			desc = e.RestartReason
+		} else {
+			desc = "All tasks signaled to restart"
+		}
 	case TaskDriverMessage:
 		desc = e.DriverMessage
 	case TaskLeaderDead:
@@ -8294,6 +8314,9 @@ func (e *TaskEvent) PopulateEventDisplayMessage() {
 }
 
 func (e *TaskEvent) GoString() string {
+	if e == nil {
+		return ""
+	}
 	return fmt.Sprintf("%v - %v", e.Time, e.Type)
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8022,14 +8022,6 @@ const (
 	// restarted
 	TaskRestartSignal = "Restart Signaled"
 
-	// TaskRestartRunningSignal indicates that all tasks in the allocation that
-	// are currently running have been signaled to be restarted.
-	TaskRestartRunningSignal = "Restart Running Signaled"
-
-	// TaskRestartAllSignal indicates that all tasks in the allocation have
-	// been signaled to be restarted, even the ones that have already run.
-	TaskRestartAllSignal = "Restart All Signaled"
-
 	// TaskSignaling indicates that the task is being signalled.
 	TaskSignaling = "Signaling"
 
@@ -8286,18 +8278,6 @@ func (e *TaskEvent) PopulateEventDisplayMessage() {
 			desc = e.RestartReason
 		} else {
 			desc = "Task signaled to restart"
-		}
-	case TaskRestartRunningSignal:
-		if e.RestartReason != "" {
-			desc = e.RestartReason
-		} else {
-			desc = "Running tasks signaled to restart"
-		}
-	case TaskRestartAllSignal:
-		if e.RestartReason != "" {
-			desc = e.RestartReason
-		} else {
-			desc = "All tasks signaled to restart"
 		}
 	case TaskDriverMessage:
 		desc = e.DriverMessage

--- a/website/content/api-docs/allocations.mdx
+++ b/website/content/api-docs/allocations.mdx
@@ -731,6 +731,13 @@ The table below shows this endpoint's support for
   must be the full UUID, not the short 8-character one. This is specified as
   part of the path.
 
+- `TaskName` `(string: "")` - Specifies the individual task to restart. Cannot
+  be used with `AllTasks` set to `true`.
+
+- `AllTasks` `(bool: false)` -  If set to `true` all tasks in the allocation
+  will be restarted, even the ones that already ran. Cannot be set to `true` if
+  `TaskName` is defined.
+
 ### Sample Payload
 
 ```json

--- a/website/content/docs/commands/alloc/restart.mdx
+++ b/website/content/docs/commands/alloc/restart.mdx
@@ -18,11 +18,15 @@ nomad alloc restart [options] <allocation> <task>
 
 This command accepts a single allocation ID and a task name. The task name must
 be part of the allocation and the task must be currently running. The task name
-is optional and if omitted every task in the allocation will be restarted.
+is optional and if omitted all tasks that are currently running will be
+restarted.
 
-Task name may also be specified using the `-task` option rather than a command 
-argument. If task name is given with both an argument and the `-task` option, 
+Task name may also be specified using the `-task` option rather than a command
+argument. If task name is given with both an argument and the `-task` option,
 preference is given to the `-task` option.
+
+Use the option `-all-tasks` to restart tasks that have already run, such as
+non-sidecar prestart and poststart tasks.
 
 When ACLs are enabled, this command requires a token with the
 `alloc-lifecycle`, `read-job`, and `list-jobs` capabilities for the
@@ -34,7 +38,11 @@ allocation's namespace.
 
 ## Restart Options
 
-- `-task`: Specify the individual task to restart.
+- `-all-tasks`: If set, all tasks in the allocation will be restarted, even the
+  ones that already ran. This option cannot be used if a task is defined.
+
+- `-task`: Specify the individual task to restart. This option cannot be used
+  with `-all-tasks`.
 
 - `-verbose`: Display verbose output.
 

--- a/website/content/docs/commands/alloc/restart.mdx
+++ b/website/content/docs/commands/alloc/restart.mdx
@@ -39,7 +39,8 @@ allocation's namespace.
 ## Restart Options
 
 - `-all-tasks`: If set, all tasks in the allocation will be restarted, even the
-  ones that already ran. This option cannot be used if a task is defined.
+  ones that already ran. This option cannot be used with `-task` or the
+  `<task>` argument.
 
 - `-task`: Specify the individual task to restart. This option cannot be used
   with `-all-tasks`.


### PR DESCRIPTION
Following-up on the work done in #14009, this PR implements a new restart mode that allows for all tasks of an allocation to be restarted, even those that have already run, such as non-sidecar prestart or poststop tasks.

It also solves some related issues, such as the restart command failing with `Task not running` due to dead tasks in the allocation. These errors are now ignore when restarting the allocation (restarting a dead task with `-task` will still result in this error).

Closes #9464
Closes #9688
Closes #9841

-----------

_Note to reviewers_: The internal RFC proposed a new task state (`complete`) to differentiate between a task that is really `dead` (and would never run again) from that a task that finished running, but is waiting for a restart. 

But during implementation I noticed that there are quite a few places where the `dead` state was being checked, but then I also noticed that it didn't really matter if the task was `dead` or `complete` so I was able to implement this functionally without the need for the extra state.