### PR TITLE
ui: fix ability checking when anon policy is missing namespace

### DIFF
--- a/ui/app/abilities/job.js
+++ b/ui/app/abilities/job.js
@@ -31,6 +31,7 @@ export default class Job extends AbstractAbility {
     // For each policy record, extract all policies of all namespaces
     const allNamespacePolicies = policies
       .toArray()
+      .filter((policy) => get(policy, 'rulesJSON.Namespaces'))
       .map((policy) => get(policy, 'rulesJSON.Namespaces'))
       .flat()
       .map((namespace = {}) => {

--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -81,6 +81,7 @@ export default class Variable extends AbstractAbility {
   ) {
     const namespacesWithSecureVariableCapabilities = policies
       .toArray()
+      .filter((policy) => get(policy, 'rulesJSON.Namespaces'))
       .map((policy) => get(policy, 'rulesJSON.Namespaces'))
       .flat()
       .map((namespace = {}) => {


### PR DESCRIPTION
ACL Policies aren't required to have any `namespace` blocks, and this is
particularly common with the anonymous policy. If a user visits the web UI
without a token already in their local storage and the anonymous policy has no
`namespace` blocks, the UI will hit unhandled exceptions when rendering the
sidebar or jobs page.

Filter for the case where there's no `namespace` block.