### PR TITLE
api: trim space of error response output

### DIFF
--- a/.changelog/14145.txt
+++ b/.changelog/14145.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: cleanup whitespace from failed api response body
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -143,7 +143,7 @@ deps:  ## Install build and development dependencies
 lint-deps: ## Install linter dependencies
 ## Keep versions in sync with tools/go.mod (see https://github.com/golang/go/issues/30515)
 	@echo "==> Updating linter dependencies..."
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4
 	go install github.com/hashicorp/go-hclog/hclogvet@v0.1.4
 

--- a/api/api.go
+++ b/api/api.go
@@ -1098,9 +1098,10 @@ func requireOK(d time.Duration, resp *http.Response, e error) (time.Duration, *h
 	}
 	if resp.StatusCode != 200 {
 		var buf bytes.Buffer
-		io.Copy(&buf, resp.Body)
-		resp.Body.Close()
-		return d, nil, fmt.Errorf("Unexpected response code: %d (%s)", resp.StatusCode, buf.Bytes())
+		_, _ = io.Copy(&buf, resp.Body)
+		_ = resp.Body.Close()
+		body := strings.TrimSpace(buf.String())
+		return d, nil, fmt.Errorf("Unexpected response code: %d (%s)", resp.StatusCode, body)
 	}
 	return d, resp, nil
 }


### PR DESCRIPTION
This PR does a `strings.TrimSpace` on the response body of a failed API request, so that an error response is not extended with unwanted whitespace. 

before:
```
➜ nomad job run bad.nomad
Error submitting job: Unexpected response code: 500 (1 error occurred:
	* Task group cache validation failed: 1 error occurred:
	* Task group service validation failed: 1 error occurred:
	* Services are not unique: [group->foo]





)
```

after:
```
➜ nomad job run bad.nomad
Error submitting job: Unexpected response code: 500 (1 error occurred:
	* Task group cache validation failed: 1 error occurred:
	* Task group service validation failed: 1 error occurred:
	* Services are not unique: [group->foo])
```