### PR TITLE
Variables-specific keyboard commands

### DIFF
--- a/ui/app/components/variable-paths.hbs
+++ b/ui/app/components/variable-paths.hbs
@@ -13,7 +13,12 @@
   <tbody>
     {{#each this.folders as |folder|}}
       <tr data-test-folder-row {{on "click" (fn this.handleFolderClick folder.data.absolutePath)}}>
-        <td colspan="3">
+        <td colspan="3"
+          {{keyboard-shortcut 
+            enumerated=true
+            action=(fn this.handleFolderClick folder.data.absolutePath)
+          }}
+        >
           <span>
             <FlightIcon @name="folder" />
             <LinkTo @route="variables.path" @model={{folder.data.absolutePath}} @query={{hash namespace="*"}}>
@@ -29,6 +34,10 @@
         data-test-file-row
         {{on "click" (fn this.handleFileClick file)}}
         class={{if (can "read variable" path=file.absoluteFilePath namespace=file.variable.namespace) "" "inaccessible"}}
+        {{keyboard-shortcut 
+          enumerated=true
+          action=(fn this.handleFileClick file)
+        }}
       >
         <td>
           <FlightIcon @name="file-text" />

--- a/ui/app/services/keyboard.js
+++ b/ui/app/services/keyboard.js
@@ -72,6 +72,7 @@ export default class KeyboardService extends Service {
   defaultPatterns = {
     'Go to Jobs': ['g', 'j'],
     'Go to Storage': ['g', 'r'],
+    'Go to Variables': ['g', 'v'],
     'Go to Servers': ['g', 's'],
     'Go to Clients': ['g', 'c'],
     'Go to Topology': ['g', 't'],
@@ -99,6 +100,10 @@ export default class KeyboardService extends Service {
         label: 'Go to Storage',
         action: () => this.router.transitionTo('csi.volumes'),
         rebindable: true,
+      },
+      {
+        label: 'Go to Variables',
+        action: () => this.router.transitionTo('variables'),
       },
       {
         label: 'Go to Servers',

--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -70,7 +70,7 @@
           </LinkTo>
         </li>
         {{#if (can "list variables")}}
-        <li>
+        <li {{keyboard-shortcut menuLevel=true pattern=(array "g" "v") }}>
           <LinkTo
             @route="variables"
             @activeClass="is-active"

--- a/ui/app/templates/variables/variable/index.hbs
+++ b/ui/app/templates/variables/variable/index.hbs
@@ -3,6 +3,11 @@
     <FlightIcon @name="file-text" />
     {{this.model.path}}
     <Toggle
+      {{keyboard-shortcut 
+        label="Toggle View (JSON/List)"
+        pattern=(array "j")
+        action=(action this.toggleView)
+      }}
       data-test-memory-toggle
       @isActive={{eq this.view "json"}}
       @onToggle={{action this.toggleView}}
@@ -87,6 +92,12 @@
               class="show-hide-values button is-borderless is-compact"
               type="button"
               {{on "click" (action this.toggleRowVisibility row.model)}}
+              {{keyboard-shortcut 
+                label="Toggle Variable Visibility"
+                pattern=(array "v")
+                action=(action this.toggleRowVisibility row.model)
+              }}
+
             >
               <FlightIcon
                 @name={{if row.model.isVisible "eye" "eye-off"}}

--- a/ui/app/templates/variables/variable/index.hbs
+++ b/ui/app/templates/variables/variable/index.hbs
@@ -19,6 +19,7 @@
       {{#if (can "write variable" path=this.model.path namespace=this.model.namespace)}}
       <div class="two-step-button">
         <LinkTo
+          {{autofocus}}
           data-test-edit-button
           class="button is-info is-inverted is-small"
           @model={{this.model}}


### PR DESCRIPTION
Adds variables-specific keyboard nav:
- `g v` to go to variables, globally
- `v` to show/hide values on a variable page
- `j` to switch to/from JSON mode when viewing or editing a variable
- `Shift + NUM` to enter a folder/file

![image](https://user-images.githubusercontent.com/713991/185203939-ceead3ba-c4bf-434d-8a4d-6ee02942f0c4.png)

( Port of https://github.com/hashicorp/nomad/pull/12831/commits/68e5999665041e267c5440ac5c1af81847eb098d and https://github.com/hashicorp/nomad/pull/12831/commits/357b3d73417497beabb76a921a704f56b0c3177f )
