### PR TITLE
sentinel: add support for Nomad ACL Token and Namespace

### DIFF
--- a/.changelog/14171.txt
+++ b/.changelog/14171.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+sentinel: add the ability to reference the namespace and Nomad acl token in policies
+```

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -104,12 +104,12 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 
 	// Attach the Nomad token's accessor ID so that deploymentwatcher
 	// can reference the token later
-	tokenID, err := j.srv.ResolveSecretToken(args.AuthToken)
+	nomadACLToken, err := j.srv.ResolveSecretToken(args.AuthToken)
 	if err != nil {
 		return err
 	}
-	if tokenID != nil {
-		args.Job.NomadTokenID = tokenID.AccessorID
+	if nomadACLToken != nil {
+		args.Job.NomadTokenID = nomadACLToken.AccessorID
 	}
 
 	// Set the warning message
@@ -273,7 +273,11 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 
 	// Enforce Sentinel policies. Pass a copy of the job to prevent
 	// sentinel from altering it.
-	policyWarnings, err := j.enforceSubmitJob(args.PolicyOverride, args.Job.Copy())
+	ns, err := snap.NamespaceByName(nil, args.RequestNamespace())
+	if err != nil {
+		return err
+	}
+	policyWarnings, err := j.enforceSubmitJob(args.PolicyOverride, args.Job.Copy(), nomadACLToken, ns)
 	if err != nil {
 		return err
 	}
@@ -1623,20 +1627,28 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 		}
 	}
 
+	// Acquire a snapshot of the state
+	snap, err := j.srv.fsm.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
 	// Enforce Sentinel policies
-	policyWarnings, err := j.enforceSubmitJob(args.PolicyOverride, args.Job)
+	nomadACLToken, err := snap.ACLTokenBySecretID(nil, args.AuthToken)
+	if err != nil && !strings.Contains(err.Error(), "missing secret id") {
+		return err
+	}
+	ns, err := snap.NamespaceByName(nil, args.RequestNamespace())
+	if err != nil {
+		return err
+	}
+	policyWarnings, err := j.enforceSubmitJob(args.PolicyOverride, args.Job, nomadACLToken, ns)
 	if err != nil {
 		return err
 	}
 	if policyWarnings != nil {
 		warnings = append(warnings, policyWarnings)
 		reply.Warnings = structs.MergeMultierrorWarnings(warnings...)
-	}
-
-	// Acquire a snapshot of the state
-	snap, err := j.srv.fsm.State().Snapshot()
-	if err != nil {
-		return err
 	}
 
 	// Interpolate the job for this region

--- a/nomad/job_endpoint_oss.go
+++ b/nomad/job_endpoint_oss.go
@@ -8,7 +8,7 @@ import (
 )
 
 // enforceSubmitJob is used to check any Sentinel policies for the submit-job scope
-func (j *Job) enforceSubmitJob(override bool, job *structs.Job) (error, error) {
+func (j *Job) enforceSubmitJob(override bool, job *structs.Job, nomadACLToken *structs.ACLToken, ns *structs.Namespace) (error, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
This PR synchronizes the Sentinel related changes required to support Nomad ACL Tokens and Namespaces when writing policies.