### PR TITLE
cleanup: first pass at fixing command package warnings

### DIFF
--- a/command/acl_policy_delete_test.go
+++ b/command/acl_policy_delete_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/acl"
@@ -11,23 +10,23 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
+	"github.com/shoenig/test/must"
 )
 
 func TestACLPolicyDeleteCommand(t *testing.T) {
 	ci.Parallel(t)
-	assert := assert.New(t)
 	config := func(c *agent.Config) {
 		c.ACL.Enabled = true
 	}
 
 	srv, _, url := testServer(t, true, config)
+	defer stopTestAgent(srv)
+
 	state := srv.Agent.Server().State()
-	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
 	token := srv.RootToken
-	assert.NotNil(token, "failed to bootstrap ACL token")
+	must.NotNil(t, token)
 
 	// Create a test ACLPolicy
 	policy := &structs.ACLPolicy{
@@ -35,7 +34,7 @@ func TestACLPolicyDeleteCommand(t *testing.T) {
 		Rules: acl.PolicyWrite,
 	}
 	policy.SetHash()
-	assert.Nil(state.UpsertACLPolicies(structs.MsgTypeTestSetup, 1000, []*structs.ACLPolicy{policy}))
+	must.NoError(t, state.UpsertACLPolicies(structs.MsgTypeTestSetup, 1000, []*structs.ACLPolicy{policy}))
 
 	ui := cli.NewMockUi()
 	cmd := &ACLPolicyDeleteCommand{Meta: Meta{Ui: ui, flagAddress: url}}
@@ -43,15 +42,13 @@ func TestACLPolicyDeleteCommand(t *testing.T) {
 	// Delete the policy without a valid token fails
 	invalidToken := mock.ACLToken()
 	code := cmd.Run([]string{"-address=" + url, "-token=" + invalidToken.SecretID, policy.Name})
-	assert.Equal(1, code)
+	must.One(t, code)
 
 	// Delete the policy with a valid management token
 	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, policy.Name})
-	assert.Equal(0, code)
+	must.Zero(t, code)
 
 	// Check the output
 	out := ui.OutputWriter.String()
-	if !strings.Contains(out, fmt.Sprintf("Successfully deleted %s policy", policy.Name)) {
-		t.Fatalf("bad: %v", out)
-	}
+	must.StrContains(t, out, fmt.Sprintf("Successfully deleted %s policy", policy.Name))
 }

--- a/command/acl_policy_info_test.go
+++ b/command/acl_policy_info_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
@@ -9,23 +8,23 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
+	"github.com/shoenig/test/must"
 )
 
 func TestACLPolicyInfoCommand(t *testing.T) {
 	ci.Parallel(t)
-	assert := assert.New(t)
+
 	config := func(c *agent.Config) {
 		c.ACL.Enabled = true
 	}
 
 	srv, _, url := testServer(t, true, config)
 	state := srv.Agent.Server().State()
-	defer srv.Shutdown()
+	defer stopTestAgent(srv)
 
 	// Bootstrap an initial ACL token
 	token := srv.RootToken
-	assert.NotNil(token, "failed to bootstrap ACL token")
+	must.NotNil(t, token)
 
 	// Create a test ACLPolicy
 	policy := &structs.ACLPolicy{
@@ -33,7 +32,7 @@ func TestACLPolicyInfoCommand(t *testing.T) {
 		Rules: "node { policy = \"read\" }",
 	}
 	policy.SetHash()
-	assert.Nil(state.UpsertACLPolicies(structs.MsgTypeTestSetup, 1000, []*structs.ACLPolicy{policy}))
+	must.NoError(t, state.UpsertACLPolicies(structs.MsgTypeTestSetup, 1000, []*structs.ACLPolicy{policy}))
 
 	ui := cli.NewMockUi()
 	cmd := &ACLPolicyInfoCommand{Meta: Meta{Ui: ui, flagAddress: url}}
@@ -41,15 +40,13 @@ func TestACLPolicyInfoCommand(t *testing.T) {
 	// Attempt to apply a policy without a valid management token
 	invalidToken := mock.ACLToken()
 	code := cmd.Run([]string{"-address=" + url, "-token=" + invalidToken.SecretID, policy.Name})
-	assert.Equal(1, code)
+	must.One(t, code)
 
 	// Apply a policy with a valid management token
 	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, policy.Name})
-	assert.Equal(0, code)
+	must.Zero(t, code)
 
 	// Check the output
 	out := ui.OutputWriter.String()
-	if !strings.Contains(out, policy.Name) {
-		t.Fatalf("bad: %v", out)
-	}
+	must.StrContains(t, out, policy.Name)
 }

--- a/command/acl_token_create_test.go
+++ b/command/acl_token_create_test.go
@@ -1,43 +1,40 @@
 package command
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
+	"github.com/shoenig/test/must"
 )
 
 func TestACLTokenCreateCommand(t *testing.T) {
 	ci.Parallel(t)
-	assert := assert.New(t)
+
 	config := func(c *agent.Config) {
 		c.ACL.Enabled = true
 	}
 
 	srv, _, url := testServer(t, true, config)
-	defer srv.Shutdown()
+	defer stopTestAgent(srv)
 
 	// Bootstrap an initial ACL token
 	token := srv.RootToken
-	assert.NotNil(token, "failed to bootstrap ACL token")
+	must.NotNil(t, token)
 
 	ui := cli.NewMockUi()
 	cmd := &ACLTokenCreateCommand{Meta: Meta{Ui: ui, flagAddress: url}}
 
 	// Request to create a new token without providing a valid management token
 	code := cmd.Run([]string{"-address=" + url, "-token=foo", "-policy=foo", "-type=client"})
-	assert.Equal(1, code)
+	must.One(t, code)
 
 	// Request to create a new token with a valid management token
 	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, "-policy=foo", "-type=client"})
-	assert.Equal(0, code)
+	must.Zero(t, code)
 
 	// Check the output
 	out := ui.OutputWriter.String()
-	if !strings.Contains(out, "[foo]") {
-		t.Fatalf("bad: %v", out)
-	}
+	must.StrContains(t, out, "[foo]")
 }

--- a/command/acl_token_info_test.go
+++ b/command/acl_token_info_test.go
@@ -1,35 +1,29 @@
 package command
 
 import (
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/acl"
-	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
+	"github.com/shoenig/test/must"
 )
 
 func TestACLTokenInfoCommand_ViaEnvVar(t *testing.T) {
-	ci.Parallel(t)
-	defer os.Setenv("NOMAD_TOKEN", os.Getenv("NOMAD_TOKEN"))
-
-	assert := assert.New(t)
 	config := func(c *agent.Config) {
 		c.ACL.Enabled = true
 	}
 
 	srv, _, url := testServer(t, true, config)
-	defer srv.Shutdown()
+	defer stopTestAgent(srv)
+
 	state := srv.Agent.Server().State()
 
 	// Bootstrap an initial ACL token
 	token := srv.RootToken
-	assert.NotNil(token, "failed to bootstrap ACL token")
+	must.NotNil(t, token)
 
 	ui := cli.NewMockUi()
 	cmd := &ACLTokenInfoCommand{Meta: Meta{Ui: ui, flagAddress: url}}
@@ -38,28 +32,26 @@ func TestACLTokenInfoCommand_ViaEnvVar(t *testing.T) {
 	mockToken := mock.ACLToken()
 	mockToken.Policies = []string{acl.PolicyWrite}
 	mockToken.SetHash()
-	assert.Nil(state.UpsertACLTokens(structs.MsgTypeTestSetup, 1000, []*structs.ACLToken{mockToken}))
+	must.NoError(t, state.UpsertACLTokens(structs.MsgTypeTestSetup, 1000, []*structs.ACLToken{mockToken}))
 
 	// Attempt to fetch info on a token without providing a valid management
 	// token
 	invalidToken := mock.ACLToken()
-	os.Setenv("NOMAD_TOKEN", invalidToken.SecretID)
+	t.Setenv("NOMAD_TOKEN", invalidToken.SecretID)
 	code := cmd.Run([]string{"-address=" + url, mockToken.AccessorID})
-	assert.Equal(1, code)
+	must.One(t, code)
 
 	// Fetch info on a token with a valid management token
-	os.Setenv("NOMAD_TOKEN", token.SecretID)
+	t.Setenv("NOMAD_TOKEN", token.SecretID)
 	code = cmd.Run([]string{"-address=" + url, mockToken.AccessorID})
-	assert.Equal(0, code)
+	must.Zero(t, code)
 
 	// Fetch info on a token with a valid management token via a CLI option
-	os.Setenv("NOMAD_TOKEN", "")
+	t.Setenv("NOMAD_TOKEN", "")
 	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, mockToken.AccessorID})
-	assert.Equal(0, code)
+	must.Zero(t, code)
 
 	// Check the output
 	out := ui.OutputWriter.String()
-	if !strings.Contains(out, mockToken.AccessorID) {
-		t.Fatalf("bad: %v", out)
-	}
+	must.StrContains(t, out, mockToken.AccessorID)
 }

--- a/command/acl_token_list_test.go
+++ b/command/acl_token_list_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/acl"
@@ -10,29 +9,30 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
+	"github.com/shoenig/test/must"
 )
 
 func TestACLTokenListCommand(t *testing.T) {
 	ci.Parallel(t)
-	assert := assert.New(t)
+
 	config := func(c *agent.Config) {
 		c.ACL.Enabled = true
 	}
 
 	srv, _, url := testServer(t, true, config)
+	defer stopTestAgent(srv)
+
 	state := srv.Agent.Server().State()
-	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
 	token := srv.RootToken
-	assert.NotNil(token, "failed to bootstrap ACL token")
+	must.NotNil(t, token)
 
 	// Create a valid token
 	mockToken := mock.ACLToken()
 	mockToken.Policies = []string{acl.PolicyWrite}
 	mockToken.SetHash()
-	assert.Nil(state.UpsertACLTokens(structs.MsgTypeTestSetup, 1000, []*structs.ACLToken{mockToken}))
+	must.NoError(t, state.UpsertACLTokens(structs.MsgTypeTestSetup, 1000, []*structs.ACLToken{mockToken}))
 
 	ui := cli.NewMockUi()
 	cmd := &ACLTokenListCommand{Meta: Meta{Ui: ui, flagAddress: url}}
@@ -40,25 +40,20 @@ func TestACLTokenListCommand(t *testing.T) {
 	// Attempt to list tokens without a valid management token
 	invalidToken := mock.ACLToken()
 	code := cmd.Run([]string{"-address=" + url, "-token=" + invalidToken.SecretID})
-	assert.Equal(1, code)
+	must.One(t, code)
 
 	// Apply a token with a valid management token
 	code = cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID})
-	assert.Equal(0, code)
+	must.Zero(t, code)
 
 	// Check the output
 	out := ui.OutputWriter.String()
-	if !strings.Contains(out, mockToken.Name) {
-		t.Fatalf("bad: %v", out)
-	}
+	must.StrContains(t, out, mockToken.Name)
 
 	// List json
-	if code := cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, "-json"}); code != 0 {
-		t.Fatalf("expected exit 0, got: %d; %v", code, ui.ErrorWriter.String())
-	}
+	must.Zero(t, cmd.Run([]string{"-address=" + url, "-token=" + token.SecretID, "-json"}))
+
 	out = ui.OutputWriter.String()
-	if !strings.Contains(out, "CreateIndex") {
-		t.Fatalf("expected json output, got: %s", out)
-	}
+	must.StrContains(t, out, "CreateIndex")
 	ui.OutputWriter.Reset()
 }

--- a/command/acl_token_self_test.go
+++ b/command/acl_token_self_test.go
@@ -1,35 +1,29 @@
 package command
 
 import (
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/acl"
-	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
+	"github.com/shoenig/test/must"
 )
 
 func TestACLTokenSelfCommand_ViaEnvVar(t *testing.T) {
-	ci.Parallel(t)
-	defer os.Setenv("NOMAD_TOKEN", os.Getenv("NOMAD_TOKEN"))
-
-	assert := assert.New(t)
 	config := func(c *agent.Config) {
 		c.ACL.Enabled = true
 	}
 
 	srv, _, url := testServer(t, true, config)
-	defer srv.Shutdown()
+	defer stopTestAgent(srv)
+
 	state := srv.Agent.Server().State()
 
 	// Bootstrap an initial ACL token
 	token := srv.RootToken
-	assert.NotNil(token, "failed to bootstrap ACL token")
+	must.NotNil(t, token)
 
 	ui := cli.NewMockUi()
 	cmd := &ACLTokenSelfCommand{Meta: Meta{Ui: ui, flagAddress: url}}
@@ -38,23 +32,21 @@ func TestACLTokenSelfCommand_ViaEnvVar(t *testing.T) {
 	mockToken := mock.ACLToken()
 	mockToken.Policies = []string{acl.PolicyWrite}
 	mockToken.SetHash()
-	assert.Nil(state.UpsertACLTokens(structs.MsgTypeTestSetup, 1000, []*structs.ACLToken{mockToken}))
+	must.NoError(t, state.UpsertACLTokens(structs.MsgTypeTestSetup, 1000, []*structs.ACLToken{mockToken}))
 
 	// Attempt to fetch info on a token without providing a valid management
 	// token
 	invalidToken := mock.ACLToken()
-	os.Setenv("NOMAD_TOKEN", invalidToken.SecretID)
+	t.Setenv("NOMAD_TOKEN", invalidToken.SecretID)
 	code := cmd.Run([]string{"-address=" + url})
-	assert.Equal(1, code)
+	must.One(t, code)
 
 	// Fetch info on a token with a valid token
-	os.Setenv("NOMAD_TOKEN", mockToken.SecretID)
+	t.Setenv("NOMAD_TOKEN", mockToken.SecretID)
 	code = cmd.Run([]string{"-address=" + url})
-	assert.Equal(0, code)
+	must.Zero(t, code)
 
 	// Check the output
 	out := ui.OutputWriter.String()
-	if !strings.Contains(out, mockToken.AccessorID) {
-		t.Fatalf("bad: %v", out)
-	}
+	must.StrContains(t, out, mockToken.AccessorID)
 }

--- a/command/acl_token_update_test.go
+++ b/command/acl_token_update_test.go
@@ -9,23 +9,22 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/assert"
+	"github.com/shoenig/test/must"
 )
 
 func TestACLTokenUpdateCommand(t *testing.T) {
 	ci.Parallel(t)
 
-	assert := assert.New(t)
 	config := func(c *agent.Config) {
 		c.ACL.Enabled = true
 	}
 
 	srv, _, url := testServer(t, true, config)
-	defer srv.Shutdown()
+	defer stopTestAgent(srv)
 
 	// Bootstrap an initial ACL token
 	token := srv.RootToken
-	assert.NotNil(token, "failed to bootstrap ACL token")
+	must.NotNil(t, token)
 
 	ui := cli.NewMockUi()
 	cmd := &ACLTokenUpdateCommand{Meta: Meta{Ui: ui, flagAddress: url}}
@@ -35,19 +34,19 @@ func TestACLTokenUpdateCommand(t *testing.T) {
 	mockToken := mock.ACLToken()
 	mockToken.Policies = []string{acl.PolicyWrite}
 	mockToken.SetHash()
-	assert.Nil(state.UpsertACLTokens(structs.MsgTypeTestSetup, 1000, []*structs.ACLToken{mockToken}))
+	must.NoError(t, state.UpsertACLTokens(structs.MsgTypeTestSetup, 1000, []*structs.ACLToken{mockToken}))
 
 	// Request to update a new token without providing a valid management token
 	invalidToken := mock.ACLToken()
 	code := cmd.Run([]string{"--token=" + invalidToken.SecretID, "-address=" + url, "-name=bar", mockToken.AccessorID})
-	assert.Equal(1, code)
+	must.One(t, code)
 
 	// Request to update a new token with a valid management token
 	code = cmd.Run([]string{"--token=" + token.SecretID, "-address=" + url, "-name=bar", mockToken.AccessorID})
-	assert.Equal(0, code)
+	must.Zero(t, code)
 
 	// Check the output
 	out := ui.OutputWriter.String()
-	assert.Contains(out, mockToken.AccessorID)
-	assert.Contains(out, "bar")
+	must.StrContains(t, out, mockToken.AccessorID)
+	must.StrContains(t, out, "bar")
 }

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	humanize "github.com/dustin/go-humanize"
+	"github.com/dustin/go-humanize"
 	"github.com/posener/complete"
 
 	"github.com/hashicorp/nomad/api"

--- a/command/helpers_test.go
+++ b/command/helpers_test.go
@@ -347,7 +347,7 @@ job "example" {
 }
 `
 
-	setEnv(t, "NOMAD_VAR_var4", "from-envvar")
+	t.Setenv("NOMAD_VAR_var4", "from-envvar")
 
 	cliArgs := []string{`var2=from-cli`}
 	fileVars := `var3 = "from-varfile"`

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -92,7 +92,7 @@ func TestMeta_Colorize(t *testing.T) {
 		{
 			Name: "disable colors via env var",
 			SetupFn: func(t *testing.T, m *Meta) {
-				setEnv(t, EnvNomadCLINoColor, "1")
+				t.Setenv(EnvNomadCLINoColor, "1")
 				m.SetupUi([]string{})
 			},
 			ExpectColor: false,
@@ -107,7 +107,7 @@ func TestMeta_Colorize(t *testing.T) {
 		{
 			Name: "force colors via env var",
 			SetupFn: func(t *testing.T, m *Meta) {
-				setEnv(t, EnvNomadCLIForceColor, "1")
+				t.Setenv(EnvNomadCLIForceColor, "1")
 				m.SetupUi([]string{})
 			},
 			ExpectColor: true,
@@ -122,7 +122,7 @@ func TestMeta_Colorize(t *testing.T) {
 		{
 			Name: "no color take predecence over force color via env var",
 			SetupFn: func(t *testing.T, m *Meta) {
-				setEnv(t, EnvNomadCLINoColor, "1")
+				t.Setenv(EnvNomadCLINoColor, "1")
 				m.SetupUi([]string{"-force-color"})
 			},
 			ExpectColor: false,
@@ -141,8 +141,8 @@ func TestMeta_Colorize(t *testing.T) {
 			os.Stdout = tty
 
 			// Make sure color related environment variables are clean.
-			setEnv(t, EnvNomadCLIForceColor, "")
-			setEnv(t, EnvNomadCLINoColor, "")
+			t.Setenv(EnvNomadCLIForceColor, "")
+			t.Setenv(EnvNomadCLINoColor, "")
 
 			// Run test case.
 			m := &Meta{}

--- a/command/ui_test.go
+++ b/command/ui_test.go
@@ -43,38 +43,38 @@ func TestCommand_Ui(t *testing.T) {
 		{
 			Name: "set namespace via env var",
 			SetupFn: func(t *testing.T) {
-				setEnv(t, "NOMAD_NAMESPACE", "dev")
+				t.Setenv("NOMAD_NAMESPACE", "dev")
 			},
 			ExpectedURL: "http://127.0.0.1:4646?namespace=dev",
 		},
 		{
 			Name: "set region via env var",
 			SetupFn: func(t *testing.T) {
-				setEnv(t, "NOMAD_REGION", "earth")
+				t.Setenv("NOMAD_REGION", "earth")
 			},
 			ExpectedURL: "http://127.0.0.1:4646?region=earth",
 		},
 		{
 			Name: "set region and namespace via env var",
 			SetupFn: func(t *testing.T) {
-				setEnv(t, "NOMAD_REGION", "earth")
-				setEnv(t, "NOMAD_NAMESPACE", "dev")
+				t.Setenv("NOMAD_REGION", "earth")
+				t.Setenv("NOMAD_NAMESPACE", "dev")
 			},
 			ExpectedURL: "http://127.0.0.1:4646?namespace=dev&region=earth",
 		},
 		{
 			Name: "set region and namespace via env var",
 			SetupFn: func(t *testing.T) {
-				setEnv(t, "NOMAD_REGION", "earth")
-				setEnv(t, "NOMAD_NAMESPACE", "dev")
+				t.Setenv("NOMAD_REGION", "earth")
+				t.Setenv("NOMAD_NAMESPACE", "dev")
 			},
 			ExpectedURL: "http://127.0.0.1:4646?namespace=dev&region=earth",
 		},
 		{
 			Name: "flags have higher precedence",
 			SetupFn: func(t *testing.T) {
-				setEnv(t, "NOMAD_REGION", "earth")
-				setEnv(t, "NOMAD_NAMESPACE", "dev")
+				t.Setenv("NOMAD_REGION", "earth")
+				t.Setenv("NOMAD_NAMESPACE", "dev")
 			},
 			Args: []string{
 				"-region=mars",
@@ -87,8 +87,8 @@ func TestCommand_Ui(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			// Make sure environment variables are clean.
-			setEnv(t, "NOMAD_NAMESPACE", "")
-			setEnv(t, "NOMAD_REGION", "")
+			t.Setenv("NOMAD_NAMESPACE", "")
+			t.Setenv("NOMAD_REGION", "")
 
 			// Setup fake CLI UI and test case
 			ui := cli.NewMockUi()

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529
 	github.com/shirou/gopsutil/v3 v3.21.12
-	github.com/shoenig/test v0.3.0
+	github.com/shoenig/test v0.3.1
 	github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c
 	github.com/stretchr/testify v1.8.0
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635

--- a/go.sum
+++ b/go.sum
@@ -1199,8 +1199,8 @@ github.com/shirou/gopsutil v0.0.0-20181107111621-48177ef5f880/go.mod h1:5b4v6he4
 github.com/shirou/gopsutil/v3 v3.21.12 h1:VoGxEW2hpmz0Vt3wUvHIl9fquzYLNpVpgNNB7pGJimA=
 github.com/shirou/gopsutil/v3 v3.21.12/go.mod h1:BToYZVTlSVlfazpDDYFnsVZLaoRG+g8ufT6fPQLdJzA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
-github.com/shoenig/test v0.3.0 h1:H6tfSvgLrPHRR5NH9S40+lOfoyeH2PbswBr4twgn9Po=
-github.com/shoenig/test v0.3.0/go.mod h1:xYtyGBC5Q3kzCNyJg/SjgNpfAa2kvmgA0i5+lQso8x0=
+github.com/shoenig/test v0.3.1 h1:dhGZztS6nQuvJ0o0RtUiQHaEO4hhArh/WmWwik3Ols0=
+github.com/shoenig/test v0.3.1/go.mod h1:xYtyGBC5Q3kzCNyJg/SjgNpfAa2kvmgA0i5+lQso8x0=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=


### PR DESCRIPTION
This PR is the first of several for cleaning up warnings, and refactoring
bits of code in the command package. First pass is over acl_ files and
gets some helpers in place.
