### PR TITLE
devdot updates

### DIFF
--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -12,7 +12,7 @@ description: |-
 Welcome to the Nomad documentation. Nomad is a scheduler and workload
 orchestrator. This documentation is a reference for all
 available features and options of Nomad. If you are just getting started with
-Nomad, please start with the ["Getting Started" collection][gs]
+Nomad, please start with the [Getting Started collection][gs]
 instead.
 
 ~> Interested in talking with HashiCorp about your experience building, deploying,

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -12,7 +12,7 @@ description: |-
 Welcome to the Nomad documentation. Nomad is a scheduler and workload
 orchestrator. This documentation is a reference for all
 available features and options of Nomad. If you are just getting started with
-Nomad, please start with the [HashiCorp Learn "Getting Started" collection][gs]
+Nomad, please start with the ["Getting Started" collection][gs]
 instead.
 
 ~> Interested in talking with HashiCorp about your experience building, deploying,

--- a/website/content/docs/install/quickstart.mdx
+++ b/website/content/docs/install/quickstart.mdx
@@ -16,7 +16,7 @@ in production, please refer to the [Production Installation](/docs/install/produ
 <Tabs>
 <Tab heading="Interactive Online Environment">
 
-Experiment with Nomad in your browser via Learn guides containing embedded Katacoda interactive learning environments.
+Experiment with Nomad in your browser via guides containing embedded interactive learning environments.
 
 - [Interactive Labs](https://learn.hashicorp.com/collections/nomad/interactive)
 

--- a/website/content/docs/job-specification/lifecycle.mdx
+++ b/website/content/docs/job-specification/lifecycle.mdx
@@ -26,7 +26,7 @@ tasks or "sidecar" tasks that are expected to run for the duration of the main t
 The absence of the sidecar flag indicates that the task is ephemeral
 and should not be restarted if it completes successfully.
 
-Learn more about Nomad's task dependencies on the [HashiCorp Learn website][learn-taskdeps].
+Learn more about Nomad's task dependencies [here][learn-taskdeps].
 
 ## `lifecycle` Parameters
 

--- a/website/content/docs/job-specification/lifecycle.mdx
+++ b/website/content/docs/job-specification/lifecycle.mdx
@@ -26,7 +26,7 @@ tasks or "sidecar" tasks that are expected to run for the duration of the main t
 The absence of the sidecar flag indicates that the task is ephemeral
 and should not be restarted if it completes successfully.
 
-Learn more about Nomad's task dependencies [here][learn-taskdeps].
+Learn more about [Nomad's task dependencies][learn-taskdeps].
 
 ## `lifecycle` Parameters
 

--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -41,7 +41,7 @@ read as environment variables.
 
 For a full list of the API template functions, please refer to the [Consul
 Template documentation][ct_api]. For a an introduction to Go templates, please
-refer to the [Learn Go Template Syntax][gt_learn] Learn guide.
+refer to the [Learn Go Template Syntax][gt_learn] guide.
 
 ## `template` Parameters
 

--- a/website/content/intro/index.mdx
+++ b/website/content/intro/index.mdx
@@ -9,7 +9,7 @@ description: >-
 
 # Introduction to Nomad
 
-Welcome to the intro guide to Nomad. This guide is the best place to start with Nomad. We cover what Nomad is, what problems it can solve, how it compares to existing software, and how you can get started using it. If you are familiar with the basics of Nomad, the [documentation](/docs) and [HashiCorp Learn guides](https://learn.hashicorp.com/nomad) provides a more detailed reference of available features.
+Welcome to the intro guide to Nomad. This guide is the best place to start with Nomad. We cover what Nomad is, what problems it can solve, how it compares to existing software, and how you can get started using it. If you are familiar with the basics of Nomad, the [documentation](/docs) and [tutorials](https://learn.hashicorp.com/nomad) provide a more detailed reference of available features.
 
 <iframe
   src="https://www.youtube.com/embed/s_Fm9UtL4YU"


### PR DESCRIPTION
- References to HashiCorp Learn removed
- References to `nomadproject.io` checked (none found in text, just links)