### PR TITLE
acl: add replication to ACL Roles from authoritative region.

### DIFF
--- a/command/acl_role_delete_test.go
+++ b/command/acl_role_delete_test.go
@@ -68,7 +68,7 @@ func TestACLRoleDeleteCommand_Run(t *testing.T) {
 		Policies: []*structs.ACLRolePolicyLink{{Name: aclPolicy.Name}},
 	}
 	err = srv.Agent.Server().State().UpsertACLRoles(
-		structs.MsgTypeTestSetup, 20, []*structs.ACLRole{&aclRole})
+		structs.MsgTypeTestSetup, 20, []*structs.ACLRole{&aclRole}, false)
 	require.NoError(t, err)
 
 	// Delete the existing ACL role.

--- a/command/acl_role_info_test.go
+++ b/command/acl_role_info_test.go
@@ -68,7 +68,7 @@ func TestACLRoleInfoCommand_Run(t *testing.T) {
 		Policies: []*structs.ACLRolePolicyLink{{Name: aclPolicy.Name}},
 	}
 	err = srv.Agent.Server().State().UpsertACLRoles(
-		structs.MsgTypeTestSetup, 20, []*structs.ACLRole{&aclRole})
+		structs.MsgTypeTestSetup, 20, []*structs.ACLRole{&aclRole}, false)
 	require.NoError(t, err)
 
 	// Look up the ACL role using its ID.

--- a/command/acl_role_list_test.go
+++ b/command/acl_role_list_test.go
@@ -60,7 +60,7 @@ func TestACLRoleListCommand_Run(t *testing.T) {
 		Policies: []*structs.ACLRolePolicyLink{{Name: aclPolicy.Name}},
 	}
 	err = srv.Agent.Server().State().UpsertACLRoles(
-		structs.MsgTypeTestSetup, 20, []*structs.ACLRole{&aclRole})
+		structs.MsgTypeTestSetup, 20, []*structs.ACLRole{&aclRole}, false)
 	require.NoError(t, err)
 
 	// Perform a listing to get the created role.

--- a/command/acl_role_update_test.go
+++ b/command/acl_role_update_test.go
@@ -71,7 +71,7 @@ func TestACLRoleUpdateCommand_Run(t *testing.T) {
 	}
 
 	err = srv.Agent.Server().State().UpsertACLRoles(
-		structs.MsgTypeTestSetup, 20, []*structs.ACLRole{&aclRole})
+		structs.MsgTypeTestSetup, 20, []*structs.ACLRole{&aclRole}, false)
 	require.NoError(t, err)
 
 	// Try a merge update without setting any parameters to update.

--- a/command/agent/acl_endpoint_test.go
+++ b/command/agent/acl_endpoint_test.go
@@ -636,7 +636,7 @@ func TestHTTPServer_ACLRoleListRequest(t *testing.T) {
 
 				// Create two ACL roles and put these directly into state.
 				aclRoles := []*structs.ACLRole{mock.ACLRole(), mock.ACLRole()}
-				require.NoError(t, srv.server.State().UpsertACLRoles(structs.MsgTypeTestSetup, 20, aclRoles))
+				require.NoError(t, srv.server.State().UpsertACLRoles(structs.MsgTypeTestSetup, 20, aclRoles, false))
 
 				// Build the HTTP request.
 				req, err := http.NewRequest(http.MethodGet, "/v1/acl/roles", nil)
@@ -669,7 +669,7 @@ func TestHTTPServer_ACLRoleListRequest(t *testing.T) {
 				// using a custom prefix.
 				aclRoles := []*structs.ACLRole{mock.ACLRole(), mock.ACLRole()}
 				aclRoles[1].ID = "badger-badger-badger-" + uuid.Generate()
-				require.NoError(t, srv.server.State().UpsertACLRoles(structs.MsgTypeTestSetup, 20, aclRoles))
+				require.NoError(t, srv.server.State().UpsertACLRoles(structs.MsgTypeTestSetup, 20, aclRoles, false))
 
 				// Build the HTTP request.
 				req, err := http.NewRequest(http.MethodGet, "/v1/acl/roles?prefix=badger-badger-badger", nil)
@@ -901,7 +901,7 @@ func TestHTTPServer_ACLRoleSpecificRequest(t *testing.T) {
 				// Create a mock role and put directly into state.
 				mockACLRole := mock.ACLRole()
 				require.NoError(t, srv.server.State().UpsertACLRoles(
-					structs.MsgTypeTestSetup, 20, []*structs.ACLRole{mockACLRole}))
+					structs.MsgTypeTestSetup, 20, []*structs.ACLRole{mockACLRole}, false))
 
 				url := fmt.Sprintf("/v1/acl/role/name/%s", mockACLRole.Name)
 
@@ -935,7 +935,7 @@ func TestHTTPServer_ACLRoleSpecificRequest(t *testing.T) {
 				// Create a mock role and put directly into state.
 				mockACLRole := mock.ACLRole()
 				require.NoError(t, srv.server.State().UpsertACLRoles(
-					structs.MsgTypeTestSetup, 20, []*structs.ACLRole{mockACLRole}))
+					structs.MsgTypeTestSetup, 20, []*structs.ACLRole{mockACLRole}, false))
 
 				url := fmt.Sprintf("/v1/acl/role/%s", mockACLRole.ID)
 

--- a/nomad/acl_test.go
+++ b/nomad/acl_test.go
@@ -195,7 +195,7 @@ func TestResolveACLToken(t *testing.T) {
 					{Name: policy2.Name},
 				}
 				err = testServer.State().UpsertACLRoles(
-					structs.MsgTypeTestSetup, 30, []*structs.ACLRole{aclRole})
+					structs.MsgTypeTestSetup, 30, []*structs.ACLRole{aclRole}, false)
 				require.NoError(t, err)
 
 				clientToken := mock.ACLToken()
@@ -221,7 +221,7 @@ func TestResolveACLToken(t *testing.T) {
 				// permissions are updated.
 				aclRole.Policies = []*structs.ACLRolePolicyLink{}
 				err = testServer.State().UpsertACLRoles(
-					structs.MsgTypeTestSetup, 40, []*structs.ACLRole{aclRole})
+					structs.MsgTypeTestSetup, 40, []*structs.ACLRole{aclRole}, false)
 				require.NoError(t, err)
 
 				aclResp, err = testServer.ResolveToken(clientToken.SecretID)
@@ -265,7 +265,7 @@ func TestResolveACLToken(t *testing.T) {
 				aclRole := mock.ACLRole()
 				aclRole.Policies = []*structs.ACLRolePolicyLink{{Name: policy2.Name}}
 				err = testServer.State().UpsertACLRoles(
-					structs.MsgTypeTestSetup, 20, []*structs.ACLRole{aclRole})
+					structs.MsgTypeTestSetup, 20, []*structs.ACLRole{aclRole}, false)
 				require.NoError(t, err)
 
 				// Create a token which references the policy and role.

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -2036,7 +2036,7 @@ func (n *nomadFSM) applyACLRolesUpsert(msgType structs.MessageType, buf []byte, 
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
 
-	if err := n.state.UpsertACLRoles(msgType, index, req.ACLRoles); err != nil {
+	if err := n.state.UpsertACLRoles(msgType, index, req.ACLRoles, req.AllowMissingPolicies); err != nil {
 		n.logger.Error("UpsertACLRoles failed", "error", err)
 		return err
 	}

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -2911,7 +2911,7 @@ func TestFSM_SnapshotRestore_ACLRoles(t *testing.T) {
 
 	// Generate and upsert some ACL roles.
 	aclRoles := []*structs.ACLRole{mock.ACLRole(), mock.ACLRole()}
-	require.NoError(t, testState.UpsertACLRoles(structs.MsgTypeTestSetup, 10, aclRoles))
+	require.NoError(t, testState.UpsertACLRoles(structs.MsgTypeTestSetup, 10, aclRoles, false))
 
 	// Perform a snapshot restore.
 	restoredFSM := testSnapshotRestore(t, fsm)
@@ -3497,7 +3497,7 @@ func TestFSM_ApplyACLRolesDeleteByID(t *testing.T) {
 
 	// Generate and upsert two ACL roles.
 	aclRoles := []*structs.ACLRole{mock.ACLRole(), mock.ACLRole()}
-	require.NoError(t, fsm.State().UpsertACLRoles(structs.MsgTypeTestSetup, 10, aclRoles))
+	require.NoError(t, fsm.State().UpsertACLRoles(structs.MsgTypeTestSetup, 10, aclRoles, false))
 
 	// Build and apply our message.
 	req := structs.ACLRolesDeleteByIDRequest{ACLRoleIDs: []string{aclRoles[0].ID, aclRoles[1].ID}}

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -1026,6 +1026,113 @@ func TestLeader_DiffACLTokens(t *testing.T) {
 	assert.Equal(t, []string{p3.AccessorID, p4.AccessorID}, update)
 }
 
+func TestServer_replicationBackoffContinue(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name   string
+		testFn func()
+	}{
+		{
+			name: "leadership lost",
+			testFn: func() {
+
+				// Create a test server with a long enough backoff that we will
+				// be able to close the channel before it fires, but not too
+				// long that the test having problems means CI will hang
+				// forever.
+				testServer, testServerCleanup := TestServer(t, func(c *Config) {
+					c.ReplicationBackoff = 5 * time.Second
+				})
+				defer testServerCleanup()
+
+				// Create our stop channel which is used by the server to
+				// indicate leadership loss.
+				stopCh := make(chan struct{})
+
+				// The resultCh is used to block and collect the output from
+				// the test routine.
+				resultCh := make(chan bool, 1)
+
+				// Run a routine to collect the result and close the channel
+				// straight away.
+				go func() {
+					output := testServer.replicationBackoffContinue(stopCh)
+					resultCh <- output
+				}()
+
+				close(stopCh)
+
+				actualResult := <-resultCh
+				require.False(t, actualResult)
+			},
+		},
+		{
+			name: "backoff continue",
+			testFn: func() {
+
+				// Create a test server with a short backoff.
+				testServer, testServerCleanup := TestServer(t, func(c *Config) {
+					c.ReplicationBackoff = 10 * time.Nanosecond
+				})
+				defer testServerCleanup()
+
+				// Create our stop channel which is used by the server to
+				// indicate leadership loss.
+				stopCh := make(chan struct{})
+
+				// The resultCh is used to block and collect the output from
+				// the test routine.
+				resultCh := make(chan bool, 1)
+
+				// Run a routine to collect the result without closing stopCh.
+				go func() {
+					output := testServer.replicationBackoffContinue(stopCh)
+					resultCh <- output
+				}()
+
+				actualResult := <-resultCh
+				require.True(t, actualResult)
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.testFn()
+		})
+	}
+}
+
+func Test_diffACLRoles(t *testing.T) {
+	ci.Parallel(t)
+
+	stateStore := state.TestStateStore(t)
+
+	// Build an initial baseline of ACL Roles.
+	aclRole0 := mock.ACLRole()
+	aclRole1 := mock.ACLRole()
+	aclRole2 := mock.ACLRole()
+	aclRole3 := mock.ACLRole()
+
+	// Upsert these into our local state. Use copies, so we can alter the roles
+	// directly and use within the diff func.
+	err := stateStore.UpsertACLRoles(structs.MsgTypeTestSetup, 50,
+		[]*structs.ACLRole{aclRole0.Copy(), aclRole1.Copy(), aclRole2.Copy(), aclRole3.Copy()}, true)
+	require.NoError(t, err)
+
+	// Modify the ACL roles to create a number of differences. These roles
+	// represent the state of the authoritative region.
+	aclRole2.ModifyIndex = 50
+	aclRole3.ModifyIndex = 200
+	aclRole3.Hash = []byte{0, 1, 2, 3}
+	aclRole4 := mock.ACLRole()
+
+	// Run the diff function and test the output.
+	toDelete, toUpdate := diffACLRoles(stateStore, 50, []*structs.ACLRole{aclRole2, aclRole3, aclRole4})
+	require.ElementsMatch(t, []string{aclRole0.ID, aclRole1.ID}, toDelete)
+	require.ElementsMatch(t, []string{aclRole3.ID, aclRole4.ID}, toUpdate)
+}
+
 func TestLeader_UpgradeRaftVersion(t *testing.T) {
 	ci.Parallel(t)
 

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -56,6 +56,14 @@ const (
 	// Reply: ACLRolesListResponse
 	ACLListRolesRPCMethod = "ACL.ListRoles"
 
+	// ACLGetRolesByIDRPCMethod is the RPC method for detailing a number of ACL
+	// roles using their ID. This is an internal only RPC endpoint and used by
+	// the ACL Role replication process.
+	//
+	// Args: ACLRolesByIDRequest
+	// Reply: ACLRolesByIDResponse
+	ACLGetRolesByIDRPCMethod = "ACL.GetRolesByID"
+
 	// ACLGetRoleByIDRPCMethod is the RPC method for detailing an individual
 	// ACL role using its ID.
 	//
@@ -360,6 +368,12 @@ func (a *ACLRole) Copy() *ACLRole {
 // roles.
 type ACLRolesUpsertRequest struct {
 	ACLRoles []*ACLRole
+
+	// AllowMissingPolicies skips the ACL Role policy link verification and is
+	// used by the replication process. The replication cannot ensure policies
+	// are present before ACL Roles are replicated.
+	AllowMissingPolicies bool
+
 	WriteRequest
 }
 
@@ -392,6 +406,20 @@ type ACLRolesListRequest struct {
 // listings.
 type ACLRolesListResponse struct {
 	ACLRoles []*ACLRole
+	QueryMeta
+}
+
+// ACLRolesByIDRequest is the request object when performing a lookup of
+// multiple roles by the ID.
+type ACLRolesByIDRequest struct {
+	ACLRoleIDs []string
+	QueryOptions
+}
+
+// ACLRolesByIDResponse is the response object when performing a lookup of
+// multiple roles by their IDs.
+type ACLRolesByIDResponse struct {
+	ACLRoles map[string]*ACLRole
 	QueryMeta
 }
 

--- a/nomad/structs/acl_test.go
+++ b/nomad/structs/acl_test.go
@@ -682,6 +682,11 @@ func Test_ACLRolesListRequest(t *testing.T) {
 	require.True(t, req.IsRead())
 }
 
+func Test_ACLRolesByIDRequest(t *testing.T) {
+	req := ACLRolesByIDRequest{}
+	require.True(t, req.IsRead())
+}
+
 func Test_ACLRoleByIDRequest(t *testing.T) {
 	req := ACLRoleByIDRequest{}
 	require.True(t, req.IsRead())


### PR DESCRIPTION
ACL Roles along with policies and global token will be replicated
from the authoritative region to all federated regions. This
involves a new replication loop running on the federated leader.

Policies and roles may be replicated at different times, meaning
the policies and role references may not be present within the
local state upon replication upsert. In order to bypass the RPC
and state check, a new RPC request parameter has been added. This
is used by the replication process; all other callers will trigger
the ACL role policy validation check.

There is a new ACL RPC endpoint to allow the reading of a set of
ACL Roles which is required by the replication process and matches
ACL Policies and Tokens. A bug within the ACL Role listing RPC has
also been fixed which returned incorrect data during blocking
queries where a deletion had occurred.

related: https://github.com/hashicorp/nomad/issues/13120
targets: feature branch