### PR TITLE
build: print installed go version in cricle on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,11 @@ jobs:
             mkdir -p $GOTESTSUM_PATH
       - install-golang:
           target_directory: "c:"
-      - run: go version
+      - run:
+          name: Show installed Go version
+          command: |
+            export PATH=/c/go/bin:/c/gopath/bin:$PATH
+            go version
       - install-vault:
           version: $VAULT_VERSION
       - run: vault version


### PR DESCRIPTION
This PR fixes the circle workflow step on windows where we print
the go version. Like the other commands that use Go, we must
inject the install path into PATH first.
