### PR TITLE
core: fix race mutating jobs in scaling api

### DIFF
--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1019,6 +1019,10 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 		return structs.NewErrRPCCoded(404, fmt.Sprintf("job %q not found", args.JobID))
 	}
 
+	// Since job is going to be mutated we must copy it since state store methods
+	// return a shared pointer.
+	job = job.Copy()
+
 	// Find target group in job TaskGroups
 	groupName := args.Target[structs.ScalingTargetGroup]
 	var group *structs.TaskGroup


### PR DESCRIPTION
Part 8/n of my effort to make agent tests race free. (Prev: #14188)

Since the state store returns a pointer to the shared job structs in
memdb we must always copy it before mutating it and applying the new
version via raft. Otherwise if the rpc fails before the mutated job is
committed to raft (either due to validation, bug, crash, or other exit
condition), the leader server will have an updated copy of the job that
other servers will not have.