### PR TITLE
[ui] Allocation route services table: show task-level services

### DIFF
--- a/.changelog/14199.txt
+++ b/.changelog/14199.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+[ui] Services table: Display task-level services in addition to group-level services.
+```

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -50,7 +50,7 @@ export default class IndexController extends Controller.extend(Sortable) {
   @computed('model.states.@each.task')
   get tasks() {
     return this.get('model.states').mapBy('task') || [];
-  };
+  }
 
   @computed('tasks.@each.services')
   get taskServices() {

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -47,19 +47,22 @@ export default class IndexController extends Controller.extend(Sortable) {
     return (this.get('model.allocatedResources.ports') || []).sortBy('label');
   }
 
+  @computed('model.states.@each.task')
+  get tasks() {
+    return this.get('model.states').mapBy('task') || [];
+  };
+
+  @computed('tasks.@each.services')
+  get taskServices() {
+    return this.get('tasks')
+      .map((t) => (t.get('services') || []).toArray())
+      .flat()
+      .compact();
+  }
+
   @computed('model.taskGroup.services.@each.name')
   get groupServices() {
     return (this.get('model.taskGroup.services') || []).sortBy('name');
-  }
-
-  @computed('model.states.@each.services')
-  get taskServices() {
-    const allTaskServicesFragments =
-      this.get('model.states').mapBy('task.services').compact() || [];
-    const allTaskServices = allTaskServicesFragments
-      .map((frag) => frag.toArray())
-      .flat();
-    return allTaskServices.sortBy('name');
   }
 
   @union('taskServices', 'groupServices') services;

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -52,11 +52,14 @@ export default class IndexController extends Controller.extend(Sortable) {
     return (this.get('model.taskGroup.services') || []).sortBy('name');
   }
 
-  @computed('model.states.@each.services.@each.name')
+  @computed('model.states.@each.services')
   get taskServices() {
-    const allTaskServicesFragments = this.get('model.states').mapBy('task.services').compact() || [];
-    const allTaskServices = allTaskServicesFragments.map(frag => frag.toArray()).flat();
-    return (allTaskServices).sortBy('name');
+    const allTaskServicesFragments =
+      this.get('model.states').mapBy('task.services').compact() || [];
+    const allTaskServices = allTaskServicesFragments
+      .map((frag) => frag.toArray())
+      .flat();
+    return allTaskServices.sortBy('name');
   }
 
   @union('taskServices', 'groupServices') services;

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -11,6 +11,7 @@ import { lazyClick } from 'nomad-ui/helpers/lazy-click';
 import { watchRecord } from 'nomad-ui/utils/properties/watch';
 import messageForError from 'nomad-ui/utils/message-from-adapter-error';
 import classic from 'ember-classic-decorator';
+import { union } from '@ember/object/computed';
 
 @classic
 export default class IndexController extends Controller.extend(Sortable) {
@@ -47,9 +48,18 @@ export default class IndexController extends Controller.extend(Sortable) {
   }
 
   @computed('model.taskGroup.services.@each.name')
-  get services() {
+  get groupServices() {
     return (this.get('model.taskGroup.services') || []).sortBy('name');
   }
+
+  @computed('model.states.@each.services.@each.name')
+  get taskServices() {
+    const allTaskServicesFragments = this.get('model.states').mapBy('task.services').compact() || [];
+    const allTaskServices = allTaskServicesFragments.map(frag => frag.toArray()).flat();
+    return (allTaskServices).sortBy('name');
+  }
+
+  @union('taskServices', 'groupServices') services;
 
   onDismiss() {
     this.set('error', null);

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -55,7 +55,7 @@ export default class IndexController extends Controller.extend(Sortable) {
   @computed('tasks.@each.services')
   get taskServices() {
     return this.get('tasks')
-      .map((t) => (t.get('services') || []).toArray())
+      .map((t) => (t && t.get('services') || []).toArray())
       .flat()
       .compact();
   }

--- a/ui/app/models/task.js
+++ b/ui/app/models/task.js
@@ -48,6 +48,7 @@ export default class Task extends Fragment {
   @attr('number') reservedCPU;
   @attr('number') reservedDisk;
   @attr('number') reservedEphemeralDisk;
+  @fragmentArray('service') services;
 
   @fragmentArray('volume-mount', { defaultValue: () => [] }) volumeMounts;
 

--- a/ui/tests/acceptance/regions-test.js
+++ b/ui/tests/acceptance/regions-test.js
@@ -155,6 +155,7 @@ module('Acceptance | regions (many)', function (hooks) {
     const newRegion = server.db.regions[1].id;
 
     await Allocation.visit({ id: server.db.allocations[0].id });
+    await this.pauseTest();
 
     await selectChoose('[data-test-region-switcher-parent]', newRegion);
 


### PR DESCRIPTION
(resolves #14198)

Adds service fragments to allocations and union taskGroup and task services. Works with both Consul and Nomad service providers.

### Before (Nomad)
![image](https://user-images.githubusercontent.com/713991/185695413-fcf5e60b-6e11-4897-bdb7-3fbdc2e11e38.png)


### After (Nomad)
![image](https://user-images.githubusercontent.com/713991/185695330-ec878697-9cdf-42f3-a719-d87997f2bc86.png)

### After (Consul)
![image](https://user-images.githubusercontent.com/713991/185695633-bebc6438-71db-49a1-bea6-ab0ba407ca0e.png)
