### PR TITLE
acl: make listing RPC and HTTP API a stub return object.

### DIFF
--- a/api/acl.go
+++ b/api/acl.go
@@ -220,8 +220,8 @@ func (c *Client) ACLRoles() *ACLRoles {
 }
 
 // List is used to detail all the ACL roles currently stored within state.
-func (a *ACLRoles) List(q *QueryOptions) ([]*ACLRole, *QueryMeta, error) {
-	var resp []*ACLRole
+func (a *ACLRoles) List(q *QueryOptions) ([]*ACLRoleListStub, *QueryMeta, error) {
+	var resp []*ACLRoleListStub
 	qm, err := a.client.query("/v1/acl/roles", &resp, q)
 	if err != nil {
 		return nil, nil, err
@@ -434,4 +434,35 @@ type ACLRolePolicyLink struct {
 
 	// Name is the ACLPolicy.Name value which will be linked to the ACL role.
 	Name string
+}
+
+// ACLRoleListStub is the stub object returned when performing a listing of ACL
+// roles. While it might not currently be different to the full response
+// object, it allows us to future-proof the RPC in the event the ACLRole object
+// grows over time.
+type ACLRoleListStub struct {
+
+	// ID is an internally generated UUID for this role and is controlled by
+	// Nomad.
+	ID string
+
+	// Name is unique across the entire set of federated clusters and is
+	// supplied by the operator on role creation. The name can be modified by
+	// updating the role and including the Nomad generated ID. This update will
+	// not affect tokens created and linked to this role. This is a required
+	// field.
+	Name string
+
+	// Description is a human-readable, operator set description that can
+	// provide additional context about the role. This is an operational field.
+	Description string
+
+	// Policies is an array of ACL policy links. Although currently policies
+	// can only be linked using their name, in the future we will want to add
+	// IDs also and thus allow operators to specify either a name, an ID, or
+	// both.
+	Policies []*ACLRolePolicyLink
+
+	CreateIndex uint64
+	ModifyIndex uint64
 }

--- a/command/acl_role_list.go
+++ b/command/acl_role_list.go
@@ -106,7 +106,7 @@ func (a *ACLRoleListCommand) Run(args []string) int {
 	return 0
 }
 
-func formatACLRoles(roles []*api.ACLRole) string {
+func formatACLRoles(roles []*api.ACLRoleListStub) string {
 	if len(roles) == 0 {
 		return "No ACL roles found"
 	}

--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -349,7 +349,7 @@ func (s *HTTPServer) ACLRoleListRequest(resp http.ResponseWriter, req *http.Requ
 	setMeta(resp, &reply.QueryMeta)
 
 	if reply.ACLRoles == nil {
-		reply.ACLRoles = make([]*structs.ACLRole, 0)
+		reply.ACLRoles = make([]*structs.ACLRoleListStub, 0)
 	}
 	return reply.ACLRoles, nil
 }

--- a/command/agent/acl_endpoint_test.go
+++ b/command/agent/acl_endpoint_test.go
@@ -618,7 +618,7 @@ func TestHTTPServer_ACLRoleListRequest(t *testing.T) {
 				// Send the HTTP request.
 				obj, err := srv.Server.ACLRoleListRequest(respW, req)
 				require.NoError(t, err)
-				require.Empty(t, obj.([]*structs.ACLRole))
+				require.Empty(t, obj.([]*structs.ACLRoleListStub))
 			},
 		},
 		{
@@ -649,7 +649,7 @@ func TestHTTPServer_ACLRoleListRequest(t *testing.T) {
 				// Send the HTTP request.
 				obj, err := srv.Server.ACLRoleListRequest(respW, req)
 				require.NoError(t, err)
-				require.Len(t, obj.([]*structs.ACLRole), 2)
+				require.Len(t, obj.([]*structs.ACLRoleListStub), 2)
 			},
 		},
 		{
@@ -682,8 +682,8 @@ func TestHTTPServer_ACLRoleListRequest(t *testing.T) {
 				// Send the HTTP request.
 				obj, err := srv.Server.ACLRoleListRequest(respW, req)
 				require.NoError(t, err)
-				require.Len(t, obj.([]*structs.ACLRole), 1)
-				require.Contains(t, obj.([]*structs.ACLRole)[0].ID, "badger-badger-badger")
+				require.Len(t, obj.([]*structs.ACLRoleListStub), 1)
+				require.Contains(t, obj.([]*structs.ACLRoleListStub)[0].ID, "badger-badger-badger")
 			},
 		},
 	}

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -1300,11 +1300,9 @@ func (a *ACL) ListRoles(
 				return err
 			}
 
-			// Iterate all the results and add these to our reply object. There
-			// is no stub object for an ACL role and the hash is needed by the
-			// replication process.
+			// Iterate all the results and add these to our reply object.
 			for raw := iter.Next(); raw != nil; raw = iter.Next() {
-				reply.ACLRoles = append(reply.ACLRoles, raw.(*structs.ACLRole))
+				reply.ACLRoles = append(reply.ACLRoles, raw.(*structs.ACLRole).Stub())
 			}
 
 			// Use the index table to populate the query meta as we have no way

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -1862,7 +1862,7 @@ func (s *Server) replicationBackoffContinue(stopCh chan struct{}) bool {
 // and the remote Roles to determine which tokens need to be deleted or
 // updated. The returned array's contain ACL Role IDs.
 func diffACLRoles(
-	store *state.StateStore, minIndex uint64, remoteList []*structs.ACLRole) (
+	store *state.StateStore, minIndex uint64, remoteList []*structs.ACLRoleListStub) (
 	delete []string, update []string) {
 
 	// The local ACL role tracking is keyed by the role ID and the value is the

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -1128,7 +1128,8 @@ func Test_diffACLRoles(t *testing.T) {
 	aclRole4 := mock.ACLRole()
 
 	// Run the diff function and test the output.
-	toDelete, toUpdate := diffACLRoles(stateStore, 50, []*structs.ACLRole{aclRole2, aclRole3, aclRole4})
+	toDelete, toUpdate := diffACLRoles(stateStore, 50, []*structs.ACLRoleListStub{
+		aclRole2.Stub(), aclRole3.Stub(), aclRole4.Stub()})
 	require.ElementsMatch(t, []string{aclRole0.ID, aclRole1.ID}, toDelete)
 	require.ElementsMatch(t, []string{aclRole3.ID, aclRole4.ID}, toUpdate)
 }

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -364,6 +364,54 @@ func (a *ACLRole) Copy() *ACLRole {
 	return c
 }
 
+// Stub converts the ACLRole object into a ACLRoleListStub object.
+func (a *ACLRole) Stub() *ACLRoleListStub {
+	return &ACLRoleListStub{
+		ID:          a.ID,
+		Name:        a.Name,
+		Description: a.Description,
+		Policies:    a.Policies,
+		Hash:        a.Hash,
+		CreateIndex: a.CreateIndex,
+		ModifyIndex: a.ModifyIndex,
+	}
+}
+
+// ACLRoleListStub is the stub object returned when performing a listing of ACL
+// roles. While it might not currently be different to the full response
+// object, it allows us to future-proof the RPC in the event the ACLRole object
+// grows over time.
+type ACLRoleListStub struct {
+
+	// ID is an internally generated UUID for this role and is controlled by
+	// Nomad.
+	ID string
+
+	// Name is unique across the entire set of federated clusters and is
+	// supplied by the operator on role creation. The name can be modified by
+	// updating the role and including the Nomad generated ID. This update will
+	// not affect tokens created and linked to this role. This is a required
+	// field.
+	Name string
+
+	// Description is a human-readable, operator set description that can
+	// provide additional context about the role. This is an operational field.
+	Description string
+
+	// Policies is an array of ACL policy links. Although currently policies
+	// can only be linked using their name, in the future we will want to add
+	// IDs also and thus allow operators to specify either a name, an ID, or
+	// both.
+	Policies []*ACLRolePolicyLink
+
+	// Hash is the hashed value of the role and is generated using all fields
+	// above this point.
+	Hash []byte
+
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
 // ACLRolesUpsertRequest is the request object used to upsert one or more ACL
 // roles.
 type ACLRolesUpsertRequest struct {
@@ -405,7 +453,7 @@ type ACLRolesListRequest struct {
 // ACLRolesListResponse is the response object when performing ACL role
 // listings.
 type ACLRolesListResponse struct {
-	ACLRoles []*ACLRole
+	ACLRoles []*ACLRoleListStub
 	QueryMeta
 }
 

--- a/nomad/structs/acl_test.go
+++ b/nomad/structs/acl_test.go
@@ -667,6 +667,72 @@ func TestACLRole_Copy(t *testing.T) {
 	}
 }
 
+func TestACLRole_Stub(t *testing.T) {
+	testCases := []struct {
+		name           string
+		inputACLRole   *ACLRole
+		expectedOutput *ACLRoleListStub
+	}{
+		{
+			name: "partially hydrated",
+			inputACLRole: &ACLRole{
+				ID:          "1d6332c8-02d7-325e-f675-a9bb4aff0c51",
+				Name:        "my-lovely-role",
+				Description: "",
+				Policies: []*ACLRolePolicyLink{
+					{Name: "my-lovely-policy"},
+				},
+				Hash:        []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+				CreateIndex: 24,
+				ModifyIndex: 24,
+			},
+			expectedOutput: &ACLRoleListStub{
+				ID:          "1d6332c8-02d7-325e-f675-a9bb4aff0c51",
+				Name:        "my-lovely-role",
+				Description: "",
+				Policies: []*ACLRolePolicyLink{
+					{Name: "my-lovely-policy"},
+				},
+				Hash:        []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+				CreateIndex: 24,
+				ModifyIndex: 24,
+			},
+		},
+		{
+			name: "hully hydrated",
+			inputACLRole: &ACLRole{
+				ID:          "1d6332c8-02d7-325e-f675-a9bb4aff0c51",
+				Name:        "my-lovely-role",
+				Description: "this-is-my-lovely-role",
+				Policies: []*ACLRolePolicyLink{
+					{Name: "my-lovely-policy"},
+				},
+				Hash:        []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+				CreateIndex: 24,
+				ModifyIndex: 24,
+			},
+			expectedOutput: &ACLRoleListStub{
+				ID:          "1d6332c8-02d7-325e-f675-a9bb4aff0c51",
+				Name:        "my-lovely-role",
+				Description: "this-is-my-lovely-role",
+				Policies: []*ACLRolePolicyLink{
+					{Name: "my-lovely-policy"},
+				},
+				Hash:        []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+				CreateIndex: 24,
+				ModifyIndex: 24,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := tc.inputACLRole.Stub()
+			require.Equal(t, tc.expectedOutput, actualOutput)
+		})
+	}
+}
+
 func Test_ACLRolesUpsertRequest(t *testing.T) {
 	req := ACLRolesUpsertRequest{}
 	require.False(t, req.IsRead())


### PR DESCRIPTION
Making the ACL Role listing return object a stub future-proofs the
endpoint. In the event the role object grows, we are not bound by
having to return all fields within the list endpoint or change the
signature of the endpoint to reduce the list return size.

related: https://github.com/hashicorp/nomad/issues/13120
targets: feature branch