### PR TITLE
docs: Update upgrade guide to reflect enterprise changes introduced in nomad-enterprise

### DIFF
--- a/.changelog/14212.txt
+++ b/.changelog/14212.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+audit (Enterprise): fixed inconsistency in event filter logic
+```

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -23,6 +23,13 @@ to version 3, and in Nomad 1.4.0 Nomad requires the use of raft protocol version
 3. If [`raft_protocol`] version is explicitly set, it must now be set to `3`.
 For more information see the [Upgrading to Raft Protocol 3] guide.
 
+#### Audit logs filtering logic changed
+
+Audit Log filtering in previous versions of Nomad handled `stages` and
+`operations` filters as `OR` filters. If _either_ condition was met, the logs
+would be filtered. As of 1.4.0, `stages` and `operations` are treated as `AND
+filters`. Logs will only be filtered if all filter conditions match.
+
 ## Nomad 1.3.3
 
 Environments that don't support the use of [`uid`][template_uid] and


### PR DESCRIPTION
This PR documents a change made in the enterprise version of nomad that addresses the following issue:

### Issue 

When a user tries to filter audit logs, they do so with a stanza that looks like the following:

```
audit {
  enabled = true

  filter "remove deletes" {
    type = "HTTPEvent"
    endpoints  = ["*"]
    stages = ["OperationComplete"]
    operations = ["DELETE"]
  }
}
```

When specifying both an "endpoint" and a "stage", the events with both matching a "endpoint" AND a matching "stage" will be filtered.

When specifying both an "endpoint" and an "operation" the events with both matching a "endpoint" AND a matching "operation" will be filtered.

When specifying both a "stage" and an "operation" the events with a matching a "stage" OR a matching "operation" will be filtered.

The "OR" logic with stages and operations is unexpected and doesn't allow customers to get specific on which events they want to filter. For instance the following use-case is impossible to achieve: "I want to filter out all OperationReceived events that have the DELETE verb".