### PR TITLE
build: go.mod should require go1.19

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/nomad/api
 
-go 1.18
+go 1.19
 
 require (
 	github.com/docker/go-units v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/nomad
 
-go 1.18
+go 1.19
 
 // Pinned dependencies are noted in github.com/hashicorp/nomad/issues/11826
 replace (


### PR DESCRIPTION
Since we started using `atomic.Pointer`, we should specify the `go1.19`
requirement in our `go.mod` files.