### PR TITLE
ui: task lifecycle restart all tasks

### DIFF
--- a/.changelog/14223.txt
+++ b/.changelog/14223.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Add button to restart all tasks in an allocation.
+```

--- a/ui/app/adapters/allocation.js
+++ b/ui/app/adapters/allocation.js
@@ -6,12 +6,17 @@ import classic from 'ember-classic-decorator';
 export default class AllocationAdapter extends Watchable {
   stop = adapterAction('/stop');
 
-  restart(allocation, taskName) {
+  restart(allocation, taskName, allTasks) {
     const prefix = `${this.host || '/'}${this.urlPrefix()}`;
     const url = `${prefix}/client/allocation/${allocation.id}/restart`;
-    return this.ajax(url, 'PUT', {
-      data: taskName && { TaskName: taskName },
-    });
+    let data = {};
+    if (taskName) {
+      data.TaskName = taskName;
+    }
+    if (allTasks) {
+      data.AllTasks = !!allTasks;
+    }
+    return this.ajax(url, 'PUT', { data });
   }
 
   ls(model, path) {

--- a/ui/app/adapters/allocation.js
+++ b/ui/app/adapters/allocation.js
@@ -6,17 +6,18 @@ import classic from 'ember-classic-decorator';
 export default class AllocationAdapter extends Watchable {
   stop = adapterAction('/stop');
 
-  restart(allocation, taskName, allTasks) {
+  restart(allocation, taskName) {
     const prefix = `${this.host || '/'}${this.urlPrefix()}`;
     const url = `${prefix}/client/allocation/${allocation.id}/restart`;
-    let data = {};
-    if (taskName) {
-      data.TaskName = taskName;
-    }
-    if (allTasks) {
-      data.AllTasks = !!allTasks;
-    }
-    return this.ajax(url, 'PUT', { data });
+    return this.ajax(url, 'PUT', {
+      data: taskName && { TaskName: taskName },
+    });
+  }
+
+  restartAll(allocation) {
+    const prefix = `${this.host || '/'}${this.urlPrefix()}`;
+    const url = `${prefix}/client/allocation/${allocation.id}/restart`;
+    return this.ajax(url, 'PUT', { data: { AllTasks: true } });
   }
 
   ls(model, path) {

--- a/ui/app/components/lifecycle-chart-row.js
+++ b/ui/app/components/lifecycle-chart-row.js
@@ -15,9 +15,9 @@ export default class LifecycleChartRow extends Component {
     return undefined;
   }
 
-  @computed('taskState.finishedAt')
+  @computed('taskState.state')
   get finishedClass() {
-    if (this.taskState && this.taskState.finishedAt) {
+    if (this.taskState && this.taskState.state === 'dead') {
       return 'is-finished';
     }
 

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -97,9 +97,9 @@ export default class IndexController extends Controller.extend(Sortable) {
   })
   stopAllocation;
 
-  @task(function* () {
+  @task(function* (allTasks) {
     try {
-      yield this.model.restart();
+      yield this.model.restart('', allTasks);
     } catch (err) {
       this.set('error', {
         title: 'Could Not Restart Allocation',

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -97,9 +97,9 @@ export default class IndexController extends Controller.extend(Sortable) {
   })
   stopAllocation;
 
-  @task(function* (allTasks) {
+  @task(function* () {
     try {
-      yield this.model.restart('', allTasks);
+      yield this.model.restart('');
     } catch (err) {
       this.set('error', {
         title: 'Could Not Restart Allocation',
@@ -108,6 +108,19 @@ export default class IndexController extends Controller.extend(Sortable) {
     }
   })
   restartAllocation;
+
+  @task(function* () {
+    try {
+      yield this.model.restartAll();
+    } catch (err) {
+      this.set('error', {
+        title: 'Could Not Restart All Tasks',
+        description: messageForError(err, 'manage allocation lifecycle'),
+      });
+      console.error(err);
+    }
+  })
+  restartAll;
 
   @action
   gotoTask(allocation, task) {

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -99,7 +99,7 @@ export default class IndexController extends Controller.extend(Sortable) {
 
   @task(function* () {
     try {
-      yield this.model.restart('');
+      yield this.model.restart();
     } catch (err) {
       this.set('error', {
         title: 'Could Not Restart Allocation',

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -153,8 +153,10 @@ export default class Allocation extends Model {
     return this.store.adapterFor('allocation').stop(this);
   }
 
-  restart(taskName) {
-    return this.store.adapterFor('allocation').restart(this, taskName);
+  restart(taskName, allTasks) {
+    return this.store
+      .adapterFor('allocation')
+      .restart(this, taskName, allTasks);
   }
 
   ls(path) {

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -153,10 +153,12 @@ export default class Allocation extends Model {
     return this.store.adapterFor('allocation').stop(this);
   }
 
-  restart(taskName, allTasks) {
-    return this.store
-      .adapterFor('allocation')
-      .restart(this, taskName, allTasks);
+  restart(taskName) {
+    return this.store.adapterFor('allocation').restart(this, taskName);
+  }
+
+  restartAll() {
+    return this.store.adapterFor('allocation').restartAll(this);
   }
 
   ls(path) {

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -67,7 +67,7 @@
             this.stopAllocation.isRunning
             this.restartAllocation.isRunning
           }}
-          @onConfirm={{perform this.restartAllocation false}}
+          @onConfirm={{perform this.restartAllocation}}
         />
         <TwoStepButton
           data-test-restart-all
@@ -81,7 +81,7 @@
             this.stopAllocation.isRunning
             this.restartAllocation.isRunning
           }}
-          @onConfirm={{perform this.restartAllocation true}}
+          @onConfirm={{perform this.restartAll}}
         />
       {{/if}}
     </div>
@@ -198,7 +198,7 @@
           </t.head>
           <t.body as |row|>
             <TaskRow
-              {{keyboard-shortcut 
+              {{keyboard-shortcut
                 enumerated=true
                 action=(action "taskClick" row.model.allocation row.model)
               }}

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -61,13 +61,27 @@
           @idleText="Restart Alloc"
           @cancelText="Cancel Restart"
           @confirmText="Yes, Restart Alloc"
-          @confirmationMessage="Are you sure? This will restart the allocation in-place."
+          @confirmationMessage="Are you sure? This will restart the tasks that are currently running in-place."
           @awaitingConfirmation={{this.restartAllocation.isRunning}}
           @disabled={{or
             this.stopAllocation.isRunning
             this.restartAllocation.isRunning
           }}
-          @onConfirm={{perform this.restartAllocation}}
+          @onConfirm={{perform this.restartAllocation false}}
+        />
+        <TwoStepButton
+          data-test-restart-all
+          @alignRight={{true}}
+          @idleText="Restart All Tasks"
+          @cancelText="Cancel Restart"
+          @confirmText="Yes, Restart All Tasks"
+          @confirmationMessage="Are you sure? This will restart all tasks in-place."
+          @awaitingConfirmation={{this.restartAllocation.isRunning}}
+          @disabled={{or
+            this.stopAllocation.isRunning
+            this.restartAllocation.isRunning
+          }}
+          @onConfirm={{perform this.restartAllocation true}}
         />
       {{/if}}
     </div>

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -380,6 +380,7 @@ module('Acceptance | allocation detail', function (hooks) {
   });
 
   test('allocation can be restarted', async function (assert) {
+    await Allocation.restartAll.idle();
     await Allocation.restart.idle();
     await Allocation.restart.confirm();
 
@@ -387,6 +388,18 @@ module('Acceptance | allocation detail', function (hooks) {
       server.pretender.handledRequests.findBy('method', 'PUT').url,
       `/v1/client/allocation/${allocation.id}/restart`,
       'Restart request is made for the allocation'
+    );
+
+    await Allocation.restart.idle();
+    await Allocation.restartAll.idle();
+    await Allocation.restartAll.confirm();
+
+    assert.ok(
+      server.pretender.handledRequests.filterBy(
+        'requestBody',
+        JSON.stringify({ AllTasks: true })
+      ),
+      'Restart all tasks request is made for the allocation'
     );
   });
 
@@ -398,6 +411,7 @@ module('Acceptance | allocation detail', function (hooks) {
     run.later(() => {
       assert.ok(Allocation.stop.isRunning, 'Stop is loading');
       assert.ok(Allocation.restart.isDisabled, 'Restart is disabled');
+      assert.ok(Allocation.restartAll.isDisabled, 'Restart All is disabled');
       server.pretender.resolve(server.pretender.requestReferences[0].request);
     }, 500);
 
@@ -478,6 +492,7 @@ module('Acceptance | allocation detail (not running)', function (hooks) {
     assert.notOk(Allocation.execButton.isPresent);
     assert.notOk(Allocation.stop.isPresent);
     assert.notOk(Allocation.restart.isPresent);
+    assert.notOk(Allocation.restartAll.isPresent);
   });
 });
 

--- a/ui/tests/integration/components/lifecycle-chart-test.js
+++ b/ui/tests/integration/components/lifecycle-chart-test.js
@@ -146,6 +146,7 @@ module('Integration | Component | lifecycle-chart', function (hooks) {
     );
 
     this.set('taskStates.4.finishedAt', new Date());
+    this.set('taskStates.4.state', 'dead');
     await settled();
 
     assert.ok(Chart.tasks[5].isFinished);

--- a/ui/tests/pages/allocations/detail.js
+++ b/ui/tests/pages/allocations/detail.js
@@ -19,6 +19,7 @@ export default create({
 
   stop: twoStepButton('[data-test-stop]'),
   restart: twoStepButton('[data-test-restart]'),
+  restartAll: twoStepButton('[data-test-restart-all]'),
 
   execButton: {
     scope: '[data-test-exec-button]',


### PR DESCRIPTION
This PR adds the option to restart all tasks in an allocation and fixes a CSS rule that was defined by a task `finishedAt` value. Since tasks that finished running can now be restarted, this check caused the lifecycle element to be rendered with the wrong class.

After/Before:
<img width="1912" alt="image" src="https://user-images.githubusercontent.com/775380/186030207-1850a05d-913f-4015-86f2-2040003b0ff1.png">
