### PR TITLE
docs: fix an anchor link in secure vars docs

### DIFF
--- a/website/content/docs/concepts/secure-variables.mdx
+++ b/website/content/docs/concepts/secure-variables.mdx
@@ -153,11 +153,11 @@ nomad acl policy apply \
    redis-policy ./policy.hcl
 ```
 
-See [Implicit Access to ACL Policies] for more details.
+See [Workload Associated ACL Policies] for more details.
 
 [HashiCorp Consul]: https://consul.io
 [HashiCorp Vault]: https://vaultproject.io
 [ACL policy specification]: docs/other-specifications/acl-policy
 [`template`]: /docs/job-specification/template
 [workload identity]: /docs/concepts/workload-identity
-[Implicit Access to ACL Policies]: /docs/concepts/workload-identity#implicit-access-to-acl-policies
+[Workload Associated ACL Policies]: /docs/concepts/workload-identity#workload-associated-acl-policies

--- a/website/content/docs/concepts/secure-variables.mdx
+++ b/website/content/docs/concepts/secure-variables.mdx
@@ -157,7 +157,7 @@ See [Workload Associated ACL Policies] for more details.
 
 [HashiCorp Consul]: https://consul.io
 [HashiCorp Vault]: https://vaultproject.io
-[ACL policy specification]: docs/other-specifications/acl-policy
+[ACL policy specification]: /docs/other-specifications/acl-policy
 [`template`]: /docs/job-specification/template
 [workload identity]: /docs/concepts/workload-identity
 [Workload Associated ACL Policies]: /docs/concepts/workload-identity#workload-associated-acl-policies


### PR DESCRIPTION
This link was missed in https://github.com/hashicorp/nomad/pull/14140