### PR TITLE
e2e: add `globalTeardown` script to not leak into other tests

### DIFF
--- a/e2e/ui/api-client.js
+++ b/e2e/ui/api-client.js
@@ -7,12 +7,14 @@ if (NOMAD_ADDR == undefined || NOMAD_ADDR == "") {
   NOMAD_ADDR = 'http://localhost:4646';
 }
 
-export const client = async (path, parameters, {data, headers: customHeaders, ...customConfig} = {}) => {
+export const client = async (path, parameters, {data, method, headers: customHeaders, ...customConfig} = {}) => {
     const url = `${NOMAD_ADDR}/v1`.concat(path);
+
+    const method = !!method ? method : data ? 'post' : 'get';
 
     const config = {
       url: parameters ? url : url.concat(parameters),
-      method: data ? 'post' : 'get',
+      method,
       data: data ? data : undefined,
       headers: {
         'content-type': 'application/json; charset=UTF-8',

--- a/e2e/ui/global-setup.js
+++ b/e2e/ui/global-setup.js
@@ -16,7 +16,6 @@ async function globalSetup() {
       await client(`/acl/token/operator`, {data: {Name: "Operator", Type: "client", Policies: ["operator"]}});
       await client(`/acl/token/dev`, {data: {Name: "Developer", Type: "client", Policies: ["dev"]}});
       await client(`/acl/token/anon`, {data: {Name: "Anonymous", Type: "client", Policies: ["anon"]}});
-
     } catch (e) {
       console.error('ERROR:  ', e)
     }  

--- a/e2e/ui/global-setup.js
+++ b/e2e/ui/global-setup.js
@@ -12,10 +12,8 @@ async function globalSetup() {
       await client(`/namespace/dev`, {data: DEV_NAMESPACE});
       await client(`/acl/policy/operator`, {data: OPERATOR_POLICY_JSON});
       await client(`/acl/policy/dev`, {data: DEV_POLICY_JSON});
-      await client(`/acl/policy/anon`, {data: ANON_POLICY_JSON});
       await client(`/acl/token/operator`, {data: {Name: "Operator", Type: "client", Policies: ["operator"]}});
       await client(`/acl/token/dev`, {data: {Name: "Developer", Type: "client", Policies: ["dev"]}});
-      await client(`/acl/token/anon`, {data: {Name: "Anonymous", Type: "client", Policies: ["anon"]}});
     } catch (e) {
       console.error('ERROR:  ', e)
     }  

--- a/e2e/ui/global-teardown.js
+++ b/e2e/ui/global-teardown.js
@@ -6,10 +6,8 @@ async function globalTeardown() {
       await client(`/namespace/dev`, {method: 'delete'});
       await client(`/acl/policy/operator`, {method: 'delete'});
       await client(`/acl/policy/dev`, {method: 'delete'});
-      await client(`/acl/policy/anon`, {method: 'delete'});
       await client(`/acl/token/operator`, {method: 'delete'});
       await client(`/acl/token/dev`, {method: 'delete'});
-      await client(`/acl/token/anon`, {method: 'delete'});
     } catch (e) {
       console.error('ERROR:  ', e)
     }  

--- a/e2e/ui/global-teardown.js
+++ b/e2e/ui/global-teardown.js
@@ -1,0 +1,18 @@
+import { client } from './api-client.js';
+
+async function globalTeardown() {
+  try {
+      await client(`/namespace/prod`, {method: 'delete'});
+      await client(`/namespace/dev`, {method: 'delete'});
+      await client(`/acl/policy/operator`, {method: 'delete'});
+      await client(`/acl/policy/dev`, {method: 'delete'});
+      await client(`/acl/policy/anon`, {method: 'delete'});
+      await client(`/acl/token/operator`, {method: 'delete'});
+      await client(`/acl/token/dev`, {method: 'delete'});
+      await client(`/acl/token/anon`, {method: 'delete'});
+    } catch (e) {
+      console.error('ERROR:  ', e)
+    }  
+};
+
+export default globalTeardown;

--- a/e2e/ui/playwright.config.js
+++ b/e2e/ui/playwright.config.js
@@ -11,6 +11,7 @@ const config = {
     ignoreHTTPSErrors: true,
   },
   globalSetup: 'global-setup.js',
+  globalTeardown: 'global-teardown.js',
   projects: [
     {
       name: 'chromium',


### PR DESCRIPTION
Adding a `globalTeardown` script to call `DELETE` on all `namespaces`, `policies` and `tokens` created by the E2E test suite.

Note: We may need to add an extra step in case one of these REST API calls fails to ensure that we bubble this back up to the test runner for the E2E suite. But that should be its own PR.