### PR TITLE
Revert "Backport of sentinel: add support for Nomad ACL Token and Namespace into release/1.2.x"

### DIFF
--- a/.changelog/14171.txt
+++ b/.changelog/14171.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-sentinel: add the ability to reference the namespace and Nomad acl token in policies
-```

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -103,12 +103,12 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 
 	// Attach the Nomad token's accessor ID so that deploymentwatcher
 	// can reference the token later
-	nomadACLToken, err := j.srv.ResolveSecretToken(args.AuthToken)
+	tokenID, err := j.srv.ResolveSecretToken(args.AuthToken)
 	if err != nil {
 		return err
 	}
-	if nomadACLToken != nil {
-		args.Job.NomadTokenID = nomadACLToken.AccessorID
+	if tokenID != nil {
+		args.Job.NomadTokenID = tokenID.AccessorID
 	}
 
 	// Set the warning message
@@ -315,11 +315,7 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 
 	// Enforce Sentinel policies. Pass a copy of the job to prevent
 	// sentinel from altering it.
-	ns, err := snap.NamespaceByName(nil, args.RequestNamespace())
-	if err != nil {
-		return err
-	}
-	policyWarnings, err := j.enforceSubmitJob(args.PolicyOverride, args.Job.Copy(), nomadACLToken, ns)
+	policyWarnings, err := j.enforceSubmitJob(args.PolicyOverride, args.Job.Copy())
 	if err != nil {
 		return err
 	}
@@ -1706,28 +1702,20 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 		}
 	}
 
-	// Acquire a snapshot of the state
-	snap, err := j.srv.fsm.State().Snapshot()
-	if err != nil {
-		return err
-	}
-
 	// Enforce Sentinel policies
-	nomadACLToken, err := snap.ACLTokenBySecretID(nil, args.AuthToken)
-	if err != nil && !strings.Contains(err.Error(), "missing secret id") {
-		return err
-	}
-	ns, err := snap.NamespaceByName(nil, args.RequestNamespace())
-	if err != nil {
-		return err
-	}
-	policyWarnings, err := j.enforceSubmitJob(args.PolicyOverride, args.Job, nomadACLToken, ns)
+	policyWarnings, err := j.enforceSubmitJob(args.PolicyOverride, args.Job)
 	if err != nil {
 		return err
 	}
 	if policyWarnings != nil {
 		warnings = append(warnings, policyWarnings)
 		reply.Warnings = structs.MergeMultierrorWarnings(warnings...)
+	}
+
+	// Acquire a snapshot of the state
+	snap, err := j.srv.fsm.State().Snapshot()
+	if err != nil {
+		return err
 	}
 
 	// Interpolate the job for this region

--- a/nomad/job_endpoint_oss.go
+++ b/nomad/job_endpoint_oss.go
@@ -12,7 +12,7 @@ import (
 )
 
 // enforceSubmitJob is used to check any Sentinel policies for the submit-job scope
-func (j *Job) enforceSubmitJob(override bool, job *structs.Job, nomadACLToken *structs.ACLToken, ns *structs.Namespace) (error, error) {
+func (j *Job) enforceSubmitJob(override bool, job *structs.Job) (error, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Reverts hashicorp/nomad#14239