### PR TITLE
Revert "Backport of sentinel: add support for Nomad ACL Token and Namespace into release/1.1.x"

### DIFF
--- a/.changelog/14171.txt
+++ b/.changelog/14171.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-sentinel: add the ability to reference the namespace and Nomad acl token in policies
-```

--- a/nomad/job_endpoint_oss.go
+++ b/nomad/job_endpoint_oss.go
@@ -11,7 +11,7 @@ import (
 )
 
 // enforceSubmitJob is used to check any Sentinel policies for the submit-job scope
-func (j *Job) enforceSubmitJob(override bool, job *structs.Job, nomadACLToken *structs.ACLToken, ns *structs.Namespace) (error, error) {
+func (j *Job) enforceSubmitJob(override bool, job *structs.Job) (error, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Reverts hashicorp/nomad#14237