### PR TITLE
core: move LicenseConfig.Copy to shared file

### DIFF
--- a/nomad/server_setup.go
+++ b/nomad/server_setup.go
@@ -1,0 +1,13 @@
+package nomad
+
+import "golang.org/x/exp/slices"
+
+func (c *LicenseConfig) Copy() *LicenseConfig {
+	if c == nil {
+		return nil
+	}
+
+	nc := *c
+	nc.AdditionalPubKeys = slices.Clone(c.AdditionalPubKeys)
+	return &nc
+}

--- a/nomad/server_setup.go
+++ b/nomad/server_setup.go
@@ -1,6 +1,24 @@
 package nomad
 
-import "golang.org/x/exp/slices"
+import (
+	"github.com/hashicorp/go-hclog"
+	"golang.org/x/exp/slices"
+)
+
+// LicenseConfig allows for tunable licensing config
+// primarily used for enterprise testing
+type LicenseConfig struct {
+	// LicenseEnvBytes is the license bytes to use for the server's license
+	LicenseEnvBytes string
+
+	// LicensePath is the path to use for the server's license
+	LicensePath string
+
+	// AdditionalPubKeys is a set of public keys to
+	AdditionalPubKeys []string
+
+	Logger hclog.InterceptLogger
+}
 
 func (c *LicenseConfig) Copy() *LicenseConfig {
 	if c == nil {

--- a/nomad/server_setup_oss.go
+++ b/nomad/server_setup_oss.go
@@ -7,12 +7,6 @@ import (
 	"github.com/hashicorp/consul/agent/consul/autopilot"
 )
 
-// LicenseConfig allows for tunable licensing config
-// primarily used for enterprise testing
-type LicenseConfig struct {
-	AdditionalPubKeys []string
-}
-
 type EnterpriseState struct{}
 
 func (es *EnterpriseState) Features() uint64 {

--- a/nomad/server_setup_oss.go
+++ b/nomad/server_setup_oss.go
@@ -5,23 +5,12 @@ package nomad
 
 import (
 	"github.com/hashicorp/consul/agent/consul/autopilot"
-	"golang.org/x/exp/slices"
 )
 
 // LicenseConfig allows for tunable licensing config
 // primarily used for enterprise testing
 type LicenseConfig struct {
 	AdditionalPubKeys []string
-}
-
-func (c *LicenseConfig) Copy() *LicenseConfig {
-	if c == nil {
-		return nil
-	}
-
-	nc := *c
-	nc.AdditionalPubKeys = slices.Clone(c.AdditionalPubKeys)
-	return &nc
 }
 
 type EnterpriseState struct{}


### PR DESCRIPTION
This moves LicenseConfig.Copy to a shared file so that enterprise can
use it as well.