### PR TITLE
build: set osusergo build tag by default

### DIFF
--- a/.changelog/14248.txt
+++ b/.changelog/14248.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where user lookups would hang or panic
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,7 +21,7 @@ ifndef BIN
 BIN := $(GOPATH)/bin
 endif
 
-GO_TAGS ?=
+GO_TAGS ?= osusergo
 
 ifeq ($(CI),true)
 GO_TAGS := codegen_generated $(GO_TAGS)


### PR DESCRIPTION
This PR activates the osuergo build tag in GNUMakefile. This forces the os/user
package to be compiled without CGO. Doing so seems to resolve a race condition
in `getpwnam_r` that causes alloc creation to hang or panic on `user.Lookup("nobody")`.

Fixes: https://github.com/hashicorp/nomad/issues/14235
Fixes: https://github.com/hashicorp/nomad/issues/14217
