### PR TITLE
Variables CLI documentation

### DIFF
--- a/website/content/docs/commands/var/get.mdx
+++ b/website/content/docs/commands/var/get.mdx
@@ -16,7 +16,7 @@ The `var get` command is used to get the contents of an existing variable.
 nomad var get [options] <path>
 ```
 
-If ACLs are enabled, this command requires a token with the 'variables:read'
+If ACLs are enabled, this command requires a token with the `variables:read`
 capability for the target variable's namespace.
 
 ## General Options

--- a/website/content/docs/commands/var/get.mdx
+++ b/website/content/docs/commands/var/get.mdx
@@ -1,0 +1,69 @@
+---
+layout: docs
+page_title: "Command: var get"
+description: |-
+  The "var get" command retrieves the secure variable at the given path from
+  Nomad. If no variable exists at that path, an error is returned.
+---
+
+# Command: var get
+
+The `var get` command retrieves the secure variable from Nomad. If the path
+does not exist the command will return a configurable exit code.
+
+## Usage
+
+```plaintext
+nomad var get [options] <path> [<item key>]
+```
+
+When ACLs are enabled, this command requires a token with the
+`secure-variable:read` capability for the variable's namespace and path.
+
+
+## General Options
+
+@include 'general_options.mdx'
+
+## Output Options
+
+- `-field` `(string: "")`: Print only the field with the given name. Specifying
+  this option will take precedence over other formatting directives. The result
+  will not have a trailing newline making it ideal for piping to other processes.
+
+- `-of` `(enum: table|json|hcl|go-template)`: Output format to render the secure
+  variable data in. When this flag is set to `go-template`, provide the template
+  content using the `-template` option. Defaults to `table` when the output is
+  sent to standard output and `json` when the output is redirected.
+
+- `-template` `(string: "")`: Template to render output with. Valid only when
+  the output format is set to `go-template`.
+
+- `-q`: Silence all non-error output
+
+## Command Options
+
+- `-exit-code-not-found` `(int: 1)`: Exit code to set if the secure variable is
+   not found. Defaults to 1.
+
+## Examples
+
+Retrieve the variable stored at path "secret/creds":
+
+```shell-session
+$ nomad var get secret/creds
+Namespace   = default
+Path        = secret/creds
+Create Time = 2022-08-23 11:14:37.189939 -0400 EDT
+Check Index = 116
+
+Items
+passcode = my-long-passcode
+```
+
+Return only the "passcode" item from the variable stored at "secret/creds":
+
+```shell-session
+$ nomad var get -field=passcode secret/creds
+my-long-passcode
+```

--- a/website/content/docs/commands/var/get.mdx
+++ b/website/content/docs/commands/var/get.mdx
@@ -46,7 +46,7 @@ Retrieve the variable stored at path "secret/creds":
 $ nomad var get secret/creds
 Namespace   = default
 Path        = secret/creds
-Create Time = 2022-08-23 11:14:37.189939 -0400 EDT
+Create Time = 2022-08-23T11:14:37-04:00
 Check Index = 116
 
 Items

--- a/website/content/docs/commands/var/get.mdx
+++ b/website/content/docs/commands/var/get.mdx
@@ -2,24 +2,22 @@
 layout: docs
 page_title: "Command: var get"
 description: |-
-  The "var get" command retrieves the secure variable at the given path from
+  The "var get" command retrieves the variable at the given path from
   Nomad. If no variable exists at that path, an error is returned.
 ---
 
 # Command: var get
 
-The `var get` command retrieves the secure variable from Nomad. If the path
-does not exist the command will return a configurable exit code.
+The `var get` command is used to get the contents of an existing variable.
 
 ## Usage
 
 ```plaintext
-nomad var get [options] <path> [<item key>]
+nomad var get [options] <path>
 ```
 
-When ACLs are enabled, this command requires a token with the
-`secure-variable:read` capability for the variable's namespace and path.
-
+If ACLs are enabled, this command requires a token with the 'variables:read'
+capability for the target variable's namespace.
 
 ## General Options
 
@@ -27,24 +25,18 @@ When ACLs are enabled, this command requires a token with the
 
 ## Output Options
 
-- `-field` `(string: "")`: Print only the field with the given name. Specifying
-  this option will take precedence over other formatting directives. The result
-  will not have a trailing newline making it ideal for piping to other processes.
+- `-item` `(string: "")`: Print only the value of the given item. Specifying
+   this option will take precedence over other formatting directives. The result
+   will not have a trailing newline making it ideal for piping to other
+   processes.
 
-- `-of` `(enum: table|json|hcl|go-template)`: Output format to render the secure
-  variable data in. When this flag is set to `go-template`, provide the template
-  content using the `-template` option. Defaults to `table` when the output is
-  sent to standard output and `json` when the output is redirected.
+- `-out` `(enum: go-template | hcl | json | none | table )`: Format to render the
+  variable in. When using "go-template", you must provide the template content
+  with the `-template` option. Defaults to "table" when stdout is a terminal and
+  to "json" when stdout is redirected.
 
-- `-template` `(string: "")`: Template to render output with. Valid only when
-  the output format is set to `go-template`.
-
-- `-q`: Silence all non-error output
-
-## Command Options
-
-- `-exit-code-not-found` `(int: 1)`: Exit code to set if the secure variable is
-   not found. Defaults to 1.
+- `-template` `(string: "")` Template to render output with. Required when
+  output is "go-template".
 
 ## Examples
 
@@ -64,6 +56,6 @@ passcode = my-long-passcode
 Return only the "passcode" item from the variable stored at "secret/creds":
 
 ```shell-session
-$ nomad var get -field=passcode secret/creds
+$ nomad var get -item=passcode secret/creds
 my-long-passcode
 ```

--- a/website/content/docs/commands/var/index.mdx
+++ b/website/content/docs/commands/var/index.mdx
@@ -1,0 +1,65 @@
+---
+layout: docs
+page_title: "Commands: var"
+description: |-
+  The "var" command groups subcommands for interacting with Vault's key/value
+  secret engine.
+---
+
+# Command: var
+
+The `var` command is used to interact with Nomad's secure variable storage.
+
+## Usage
+
+Usage: `nomad var <subcommand> [options] [args]`
+
+Run `nomad var <subcommand> -h` for help on that subcommand. The following
+subcommands are available:
+
+- [`var init`][init] - Create a secure variable specification file
+- [`var list`][list] - List secure variables the user has access to
+- [`var get`][get] - Retrieve a secure variable
+- [`var put`][put] - Insert or update a secure variable
+- [`var purge`][purge] - Permanently delete a secure variable
+
+## Examples
+
+Create or update the variable stored at the path "secret/creds", which contains
+an item named `passcode` with the value `my-logn-passcode`.
+
+```shell-session
+$ nomad var put secret/creds passcode=my-long-passcode
+Successfully created secure variable "secret/creds"!
+
+Namespace   = default
+Path        = secret/creds
+Create Time = 2022-08-23 11:14:37.189939 -0400 EDT
+Check Index = 116
+
+Items
+passcode = my-long-passcode
+```
+
+Update a value:
+```shell-session
+$ nomad var get -format=json secret/creds | nomad var put - user=dba
+Reading whole JSON variable specification from stdin
+Successfully updated secure variable "secret/creds"!
+
+Namespace   = default
+Path        = secret/creds
+Create Time = 2022-08-23 11:14:37.189939 -0400 EDT
+Check Index = 116
+
+Items
+passcode = my-long-passcode
+user     = dba
+```
+
+
+[init]: /docs/commands/var/init
+[get]: /docs/commands/var/get
+[list]: /docs/commands/var/list
+[put]: /docs/commands/var/put
+[purge]: /docs/commands/var/purge

--- a/website/content/docs/commands/var/index.mdx
+++ b/website/content/docs/commands/var/index.mdx
@@ -2,13 +2,12 @@
 layout: docs
 page_title: "Commands: var"
 description: |-
-  The "var" command groups subcommands for interacting with Vault's key/value
-  secret engine.
+  The "var" command groups subcommands for interacting with Nomad variables.
 ---
 
 # Command: var
 
-The `var` command is used to interact with Nomad's secure variable storage.
+The `var` command is used to interact with Nomad [variables].
 
 ## Usage
 
@@ -17,20 +16,20 @@ Usage: `nomad var <subcommand> [options] [args]`
 Run `nomad var <subcommand> -h` for help on that subcommand. The following
 subcommands are available:
 
-- [`var init`][init] - Create a secure variable specification file
-- [`var list`][list] - List secure variables the user has access to
-- [`var get`][get] - Retrieve a secure variable
-- [`var put`][put] - Insert or update a secure variable
-- [`var purge`][purge] - Permanently delete a secure variable
+- [`var init`][init] - Create a variable specification file
+- [`var list`][list] - List variables the user has access to
+- [`var get`][get] - Retrieve a variable
+- [`var put`][put] - Insert or update a variable
+- [`var purge`][purge] - Permanently delete a variable
 
 ## Examples
 
 Create or update the variable stored at the path "secret/creds", which contains
-an item named `passcode` with the value `my-logn-passcode`.
+an item named `passcode` with the value `my-long-passcode`.
 
 ```shell-session
 $ nomad var put secret/creds passcode=my-long-passcode
-Successfully created secure variable "secret/creds"!
+Successfully created variable "secret/creds"!
 
 Namespace   = default
 Path        = secret/creds
@@ -43,9 +42,9 @@ passcode = my-long-passcode
 
 Update a value:
 ```shell-session
-$ nomad var get -format=json secret/creds | nomad var put - user=dba
+$ nomad var get secret/creds | nomad var put -in=json -v - user=dba
 Reading whole JSON variable specification from stdin
-Successfully updated secure variable "secret/creds"!
+Successfully updated variable "secret/creds"!
 
 Namespace   = default
 Path        = secret/creds
@@ -57,7 +56,7 @@ passcode = my-long-passcode
 user     = dba
 ```
 
-
+[variables]: /docs/concepts/variables
 [init]: /docs/commands/var/init
 [get]: /docs/commands/var/get
 [list]: /docs/commands/var/list

--- a/website/content/docs/commands/var/index.mdx
+++ b/website/content/docs/commands/var/index.mdx
@@ -28,12 +28,12 @@ Create or update the variable stored at the path "secret/creds", which contains
 an item named `passcode` with the value `my-long-passcode`.
 
 ```shell-session
-$ nomad var put secret/creds passcode=my-long-passcode
+$ nomad var put -out=table secret/creds passcode=my-long-passcode
 Successfully created variable "secret/creds"!
 
 Namespace   = default
 Path        = secret/creds
-Create Time = 2022-08-23 11:14:37.189939 -0400 EDT
+Create Time = 2022-08-23T11:14:37-04:00
 Check Index = 116
 
 Items
@@ -42,13 +42,13 @@ passcode = my-long-passcode
 
 Update a value:
 ```shell-session
-$ nomad var get secret/creds | nomad var put -in=json -v - user=dba
+$ nomad var get secret/creds | nomad var put -in=json -out=table -v - user=dba
 Reading whole JSON variable specification from stdin
 Successfully updated variable "secret/creds"!
 
 Namespace   = default
 Path        = secret/creds
-Create Time = 2022-08-23 11:14:37.189939 -0400 EDT
+Create Time = 2022-08-23T11:14:37-04:00
 Check Index = 116
 
 Items

--- a/website/content/docs/commands/var/init.mdx
+++ b/website/content/docs/commands/var/init.mdx
@@ -2,32 +2,33 @@
 layout: docs
 page_title: 'Commands: var init'
 description: |
-  Generate an example var specification.
+  Generate an example variable specification.
 ---
 
 # Command: var init
 
-The `var init` command is used to create an example secure variable
-specification file that can be used as a starting point for further
-customization.
+The `var init` creates an example variable specification file that can be used
+as a starting point to customize further.
 
 ## Usage
 
 ```plaintext
-nomad var init
+nomad var init <filename>
 ```
+
+When no filename is supplied, a default filename of "spec.nsv.hcl" or
+"spec.nsv.json" will be used depending on the output format.
 
 ## Init Options
 
-
-- `-of` `(enum: json|hcl)`: Output format to render the secure variable
-  specification in. Defaults to `json`.
+- `-out` `(enum: hcl | json)`: Format of generated variable
+  specification. Defaults to `hcl`.
 
 ## Examples
 
-Create an example quota specification:
+Create an example variable specification:
 
 ```shell-session
 $ nomad var init
-Example secure variable specification written to spec.nsv.json
+Example variable specification written to spec.nsv.hcl
 ```

--- a/website/content/docs/commands/var/init.mdx
+++ b/website/content/docs/commands/var/init.mdx
@@ -1,0 +1,33 @@
+---
+layout: docs
+page_title: 'Commands: var init'
+description: |
+  Generate an example var specification.
+---
+
+# Command: var init
+
+The `var init` command is used to create an example secure variable
+specification file that can be used as a starting point for further
+customization.
+
+## Usage
+
+```plaintext
+nomad var init
+```
+
+## Init Options
+
+
+- `-of` `(enum: json|hcl)`: Output format to render the secure variable
+  specification in. Defaults to `json`.
+
+## Examples
+
+Create an example quota specification:
+
+```shell-session
+$ nomad var init
+Example secure variable specification written to spec.nsv.json
+```

--- a/website/content/docs/commands/var/init.mdx
+++ b/website/content/docs/commands/var/init.mdx
@@ -16,8 +16,8 @@ as a starting point to customize further.
 nomad var init <filename>
 ```
 
-When no filename is supplied, a default filename of "spec.nsv.hcl" or
-"spec.nsv.json" will be used depending on the output format.
+When no filename is supplied, a default filename of "spec.nv.hcl" or
+"spec.nv.json" will be used depending on the output format.
 
 ## Init Options
 
@@ -30,5 +30,5 @@ Create an example variable specification:
 
 ```shell-session
 $ nomad var init
-Example variable specification written to spec.nsv.hcl
+Example variable specification written to spec.nv.hcl
 ```

--- a/website/content/docs/commands/var/list.mdx
+++ b/website/content/docs/commands/var/list.mdx
@@ -36,7 +36,7 @@ the namespaces containing the variables to list.
   results. Queries using this option are less efficient than using the prefix
   parameter; therefore, the prefix parameter should be used whenever possible.
 
-- `-out` `(enum: go-template | hcl | json | none | table )`: Format to render the
+- `-out` `(enum: go-template | json | table | terse )`: Format to render the
   variable in. When using "go-template", you must provide the template content
   with the `-template` option. Defaults to "table" when stdout is a terminal and
   to "json" when stdout is redirected.
@@ -51,10 +51,10 @@ List values under the key "nomad/jobs":
 ```shell-session
 $ nomad var list nomad/jobs
 Namespace  Path                           Last Updated
-default    nomad/jobs/example             2022-08-23 10:35:47.441518 -0400 EDT
-default    nomad/jobs/variable            2022-08-23 10:24:45.795348 -0400 EDT
-default    nomad/jobs/variable/www        2022-08-23 10:24:45.984175 -0400 EDT
-default    nomad/jobs/variable/www/nginx  2022-08-23 10:24:46.179808 -0400 EDT
+default    nomad/jobs/example             2022-08-23T10:35:47-04:00
+default    nomad/jobs/variable            2022-08-23T10:24:45-04:00
+default    nomad/jobs/variable/www        2022-08-23T10:24:45-04:00
+default    nomad/jobs/variable/www/nginx  2022-08-23T10:24:46-04:00
 ```
 
 List values under the key "nomad/jobs/variable/www" in JSON format:

--- a/website/content/docs/commands/var/list.mdx
+++ b/website/content/docs/commands/var/list.mdx
@@ -13,6 +13,13 @@ current user, optionally filtered to paths containing a provided prefix. Do not
 encode sensitive information in variable paths. The variable's items are not
 accessible via this command.
 
+When using pagination, the next page token is provided as part of the output of
+the command. When the output format is JSON, the returned variable list is
+wrapped with additional metadata that contains the next page token. For non-JSON
+output, the next page token is printed as a message to standard error and
+standard output contains the variables from the specifically requested page.
+
+
 ## Usage
 
 ```plaintext
@@ -80,3 +87,51 @@ $ nomad var list -out=json -namespace="*" nomad/jobs/variable/www
   }
 ]
 ```
+
+Perform a paginated query:
+
+```shell-session
+$ nomad var list -per-page=3
+Namespace  Path                           Last Updated
+default    nomad/jobs/example             2022-08-23T10:35:47-04:00
+default    nomad/jobs/variable            2022-08-23T10:24:45-04:00
+default    nomad/jobs/variable/www        2022-08-23T10:24:45-04:00
+Next page token: default.nomad/jobs/variable/www/nginx
+```
+
+To fetch the next page :
+
+```shell-session
+$ nomad var list -per-page=3 \
+  -page-token=default.nomad/jobs/variable/www/nginx
+Namespace  Path                 Last Updated
+default    nomad/jobs/variable/www/nginx  2022-08-23T10:24:46-04:00
+```
+
+Perform a paginated query with JSON formatting:
+
+```shell-session
+$ nomad var list -out=json -namespace="*" -per-page=1 nomad/jobs/variable/www
+{
+    "Data": [
+        {
+           "Namespace": "default",
+            "Path": "nomad/jobs/variable/www",
+            "CreateIndex": 1457,
+            "ModifyIndex": 1457,
+            "CreateTime": 1662061225600373000,
+            "ModifyTime": 1662061225600373000
+        }
+    ],
+    "QueryMeta": {
+        "KnownLeader": true,
+        "LastContact": 0,
+        "LastIndex": 43,
+        "NextToken": "default.nomad/jobs/variable/www/nginx",
+        "RequestTime": 875792
+    }
+}
+```
+
+As with the tabular version, provide the `QueryMeta.NextToken` value as the
+`-page-token` value to fetch the next page.

--- a/website/content/docs/commands/var/list.mdx
+++ b/website/content/docs/commands/var/list.mdx
@@ -2,16 +2,16 @@
 layout: docs
 page_title: "Command: var list"
 description: |-
-  The "var list" command lists data from Nomad's secure variables datastore at
+  The "var list" command lists data from Nomad's variables datastore at
   or beginning with the given prefix.
 ---
 
 # Command: var list
 
-The `var list` command returns a list of secure variable paths accessible to the
+The `var list` command returns a list of variable paths accessible to the
 current user, optionally filtered to paths containing a provided prefix. Do not
-encode sensitive information in secure variable paths. The secure variable's
-items are not accessible via this command.
+encode sensitive information in variable paths. The variable's items are not
+accessible via this command.
 
 ## Usage
 
@@ -19,21 +19,30 @@ items are not accessible via this command.
 nomad var list [options] [<prefix>]
 ```
 
-If ACLs are enabled, this command requires a token with the
-`secure_variable:list` capability on the namespaces containing the variables to
-list.
+If ACLs are enabled, this command requires the `variables:list` capability for
+the namespaces containing the variables to list.
 
 ## General Options
 
 @include 'general_options.mdx'
 
-## Output Options
+## List Options
 
-- `-of` `(enum: terse|table|json|go-template")`: Print the output in the
-  specified format. Valid formats are `terse`, `table`, `json`, or
-  `go-template`. The `terse` format only outputs paths. If the `-namespace`
-  option is set to `*`, the variable paths will have `@` and the namespace
-  appended to them.
+- `-per-page` `(int: <unset>)`: How many results to show per page.
+
+- `-page-token` `(string: "")`: Where to start pagination.
+
+- `-filter` `(string: "")`: Specifies an expression used to filter query
+  results. Queries using this option are less efficient than using the prefix
+  parameter; therefore, the prefix parameter should be used whenever possible.
+
+- `-out` `(enum: go-template | hcl | json | none | table )`: Format to render the
+  variable in. When using "go-template", you must provide the template content
+  with the `-template` option. Defaults to "table" when stdout is a terminal and
+  to "json" when stdout is redirected.
+
+- `-template` `(string: "")` Template to render output with. Required when
+  output is "go-template".
 
 ## Examples
 
@@ -48,10 +57,26 @@ default    nomad/jobs/variable/www        2022-08-23 10:24:45.984175 -0400 EDT
 default    nomad/jobs/variable/www/nginx  2022-08-23 10:24:46.179808 -0400 EDT
 ```
 
+List values under the key "nomad/jobs/variable/www" in JSON format:
+
 ```shell-session
-$ nomad var list -of=terse -namespace="*" nomad/jobs
-nomad/jobs/example@default
-nomad/jobs/variable@default
-nomad/jobs/variable/www@default
-nomad/jobs/variable/www/nginx@default
+$ nomad var list -out=json -namespace="*" nomad/jobs/variable/www
+[
+  {
+    "Namespace": "default",
+    "Path": "nomad/jobs/variable/www",
+    "CreateIndex": 1457,
+    "ModifyIndex": 1457,
+    "CreateTime": 1662061225600373000,
+    "ModifyTime": 1662061225600373000
+  },
+  {
+    "Namespace": "default",
+    "Path": "nomad/jobs/variable/www/nginx",
+    "CreateIndex": 800,
+    "ModifyIndex": 1000,
+    "CreateTime": 1662061717905426000,
+    "ModifyTime": 1662062162982630000
+  }
+]
 ```

--- a/website/content/docs/commands/var/list.mdx
+++ b/website/content/docs/commands/var/list.mdx
@@ -1,0 +1,57 @@
+---
+layout: docs
+page_title: "Command: var list"
+description: |-
+  The "var list" command lists data from Nomad's secure variables datastore at
+  or beginning with the given prefix.
+---
+
+# Command: var list
+
+The `var list` command returns a list of secure variable paths accessible to the
+current user, optionally filtered to paths containing a provided prefix. Do not
+encode sensitive information in secure variable paths. The secure variable's
+items are not accessible via this command.
+
+## Usage
+
+```plaintext
+nomad var list [options] [<prefix>]
+```
+
+If ACLs are enabled, this command requires a token with the
+`secure_variable:list` capability on the namespaces containing the variables to
+list.
+
+## General Options
+
+@include 'general_options.mdx'
+
+## Output Options
+
+- `-of` `(enum: terse|table|json|go-template")`: Print the output in the
+  specified format. Valid formats are `terse`, `table`, `json`, or
+  `go-template`. The `terse` format only outputs paths. If the `-namespace`
+  option is set to `*`, the variable paths will have `@` and the namespace
+  appended to them.
+
+## Examples
+
+List values under the key "nomad/jobs":
+
+```shell-session
+$ nomad var list nomad/jobs
+Namespace  Path                           Last Updated
+default    nomad/jobs/example             2022-08-23 10:35:47.441518 -0400 EDT
+default    nomad/jobs/variable            2022-08-23 10:24:45.795348 -0400 EDT
+default    nomad/jobs/variable/www        2022-08-23 10:24:45.984175 -0400 EDT
+default    nomad/jobs/variable/www/nginx  2022-08-23 10:24:46.179808 -0400 EDT
+```
+
+```shell-session
+$ nomad var list -of=terse -namespace="*" nomad/jobs
+nomad/jobs/example@default
+nomad/jobs/variable@default
+nomad/jobs/variable/www@default
+nomad/jobs/variable/www/nginx@default
+```

--- a/website/content/docs/commands/var/purge.mdx
+++ b/website/content/docs/commands/var/purge.mdx
@@ -2,15 +2,14 @@
 layout: docs
 page_title: "Command: var purge"
 description: |-
-  The "var purge" command permanently removes the specified secure variable
+  The "var purge" command permanently removes the specified variable
   from Nomad.
 ---
 
 # Command: var purge
 
-The `var purge` command permanently removes the variable at the provided path
-from Nomad's secure variable storage. If no key exists at the path, no action
-is taken and the command will exit with a configurable exit code.
+The `var purge` command permanently deletes an existing variable from Nomad's
+variable storage.
 
 ## Usage
 
@@ -18,46 +17,28 @@ is taken and the command will exit with a configurable exit code.
 nomad var purge [options] <path>
 ```
 
-The `var purge` command requires the path to the specification file. The
-specification can be read from standard input by setting the path to `-`.
+The `var purge` command requires the path to the variable.
 
-If ACLs are enabled, this command requires a token with the
-`secure-variable:purge` capability for the namespace and path of the secure
-variable to be purged.
+If ACLs are enabled, this command requires a token with the `variables:destroy`
+capability for the target variable's namespace.
 
 ## General Options
 
 @include 'general_options.mdx'
 
-## Output Options
-
-- `-of` `(string: varies)`: Specify the format to print the secure variable that
-  was purged. Valid formats are `none`, `table`, `json`, `hcl`, or `go-template`.
-  Defaults to `none` when the output is a terminal; defaults to `json` when the
-  output is redirected.
-
-- `-q`: Quiet output; silences all non-error output. This flag overrides any
-  value set using the `-of` option.
-
-
 ## Command Options
 
-- `-check-index` `(int: varies)`: If set, the secure variable is only updated if
-  the provided index matches the server-side version's modify index. This value
-  defaults to the value provided in the variable specification or should be
-  manually provided when a specification is not provided.
-
-- `-exit-code-not-found` `(int: 1)`: Exit code to set if the secure variable is
-   not found. Defaults to 1.
-
-- `-y`: Answer yes to all confirmation prompts.
-
+- `-check-index` `(int: <unset>)`: If set, the variable is only acted upon if
+  the server-side version's index matches the provided value. When a variable
+  specification contains a modify index, that modify index is used as the
+  check-index for the check-and-set operation and can be overridden using thi
+  flag.
 
 ## Examples
 
-Purge the secure variable at the "secret/creds" path.
+Purge the variable at the "secret/creds" path.
 
 ```shell-session
 $ nomad var purge -y secret/creds
-Successfully purged secure variable "secret/creds"!
+Successfully purged variable "secret/creds"!
 ```

--- a/website/content/docs/commands/var/purge.mdx
+++ b/website/content/docs/commands/var/purge.mdx
@@ -1,0 +1,63 @@
+---
+layout: docs
+page_title: "Command: var purge"
+description: |-
+  The "var purge" command permanently removes the specified secure variable
+  from Nomad.
+---
+
+# Command: var purge
+
+The `var purge` command permanently removes the variable at the provided path
+from Nomad's secure variable storage. If no key exists at the path, no action
+is taken and the command will exit with a configurable exit code.
+
+## Usage
+
+```plaintext
+nomad var purge [options] <path>
+```
+
+The `var purge` command requires the path to the specification file. The
+specification can be read from standard input by setting the path to `-`.
+
+If ACLs are enabled, this command requires a token with the
+`secure-variable:purge` capability for the namespace and path of the secure
+variable to be purged.
+
+## General Options
+
+@include 'general_options.mdx'
+
+## Output Options
+
+- `-of` `(string: varies)`: Specify the format to print the secure variable that
+  was purged. Valid formats are `none`, `table`, `json`, `hcl`, or `go-template`.
+  Defaults to `none` when the output is a terminal; defaults to `json` when the
+  output is redirected.
+
+- `-q`: Quiet output; silences all non-error output. This flag overrides any
+  value set using the `-of` option.
+
+
+## Command Options
+
+- `-check-index` `(int: varies)`: If set, the secure variable is only updated if
+  the provided index matches the server-side version's modify index. This value
+  defaults to the value provided in the variable specification or should be
+  manually provided when a specification is not provided.
+
+- `-exit-code-not-found` `(int: 1)`: Exit code to set if the secure variable is
+   not found. Defaults to 1.
+
+- `-y`: Answer yes to all confirmation prompts.
+
+
+## Examples
+
+Purge the secure variable at the "secret/creds" path.
+
+```shell-session
+$ nomad var purge -y secret/creds
+Successfully purged secure variable "secret/creds"!
+```

--- a/website/content/docs/commands/var/purge.mdx
+++ b/website/content/docs/commands/var/purge.mdx
@@ -31,7 +31,7 @@ capability for the target variable's namespace.
 - `-check-index` `(int: <unset>)`: If set, the variable is only acted upon if
   the server-side version's index matches the provided value. When a variable
   specification contains a modify index, that modify index is used as the
-  check-index for the check-and-set operation and can be overridden using thi
+  check-index for the check-and-set operation and can be overridden using this
   flag.
 
 ## Examples

--- a/website/content/docs/commands/var/put.mdx
+++ b/website/content/docs/commands/var/put.mdx
@@ -21,8 +21,8 @@ using command arguments, or by a combination of the two techniques. An entire
 variable specification can be provided to the command via standard input (stdin)
 by setting the first argument to "-" or from a file by using an @-prefixed path
 to a variable specification file. When providing variable data via stdin, you
-must provide the `-in` flag with the format of the specification, either "hcl"
-or "json"
+must provide the `-in` flag with the format of the specification, which must be
+either "hcl" or "json".
 
 Items to be stored in the variable can be supplied using the specification, as a
 series of key-value pairs, or both. The value for a key-value pair can be a
@@ -30,7 +30,7 @@ string, an @-prefixed file reference, or a '-' to get the value from stdin. Item
 values provided from file references or stdin are consumed as-is with no
 additional processing and do not require the input format to be specified.
 
-Values supplied as command line arguments supersede values provided in the any
+Values supplied as command line arguments supersede values provided in any
 variable specification piped into the command or loaded from file. If ACLs are
 enabled, this command requires the `variables:write` capability for the
 destination namespace.
@@ -77,7 +77,7 @@ symbol. For example, you can store a variable using a specification created with
 the `nomad var init` command.
 
 ```shell-session
-$ nomad var put secret/foo @spec.nsv.json
+$ nomad var put secret/foo @spec.nv.json
 ```
 
 Or it can be read from standard input using the "-" symbol:

--- a/website/content/docs/commands/var/put.mdx
+++ b/website/content/docs/commands/var/put.mdx
@@ -9,7 +9,7 @@ description: |-
 
 The `var put` command creates or updates an existing variable.
 
-## Usage:
+## Usage
 
 ```plaintext
 nomad var put [options] <variable spec file reference> [<key>=<value>]...
@@ -17,7 +17,7 @@ nomad var put [options] <path to store variable> [<variable spec file reference>
 ```
 
 Variable metadata and items can be supplied using a variable specification, by
-using command arguments, or by a combination of the two techniques.  An entire
+using command arguments, or by a combination of the two techniques. An entire
 variable specification can be provided to the command via standard input (stdin)
 by setting the first argument to "-" or from a file by using an @-prefixed path
 to a variable specification file. When providing variable data via stdin, you
@@ -31,7 +31,7 @@ values provided from file references or stdin are consumed as-is with no
 additional processing and do not require the input format to be specified.
 
 Values supplied as command line arguments supersede values provided in the any
-variable specification piped into the command or loaded from file.  If ACLs are
+variable specification piped into the command or loaded from file. If ACLs are
 enabled, this command requires the `variables:write` capability for the
 destination namespace.
 
@@ -39,12 +39,12 @@ destination namespace.
 
 @include 'general_options.mdx'
 
-## Put Options:
+## Put Options
 
 - `-check-index` `(int: <unset>)`: If set, the variable is only acted upon if
   the server-side version's index matches the provided value. When a variable
   specification contains a modify index, that modify index is used as the
-  check-index for the check-and-set operation and can be overridden using thi
+  check-index for the check-and-set operation and can be overridden using this
   flag.
 
 - `-force`: Perform this operation regardless of the state or index of the

--- a/website/content/docs/commands/var/put.mdx
+++ b/website/content/docs/commands/var/put.mdx
@@ -2,57 +2,67 @@
 layout: docs
 page_title: "Command: var put"
 description: |-
-  The "var put" command writes a secure variable to the given path in Nomad.
+  The "var put" command writes a variable to the given path in Nomad.
 ---
 
 # Command: var put
 
-The `var put` command writes the secure variable to the given path in Nomad.
-Items to be stored in the variable can be provided as key-value pairs after the
-path or using one of the file input options—standard input or @-prefixed
-filenames.
+The `var put` command creates or updates an existing variable.
 
-## Usage
+## Usage:
 
 ```plaintext
-nomad var put [options] <path> [<key>=value]...
+nomad var put [options] <variable spec file reference> [<key>=<value>]...
+nomad var put [options] <path to store variable> [<variable spec file reference>] [<key>=<value>]...
 ```
 
-If ACLs are enabled, this command requires a management ACL token or a token
-that has a capability associated with the namespace.
+Variable metadata and items can be supplied using a variable specification, by
+using command arguments, or by a combination of the two techniques.  An entire
+variable specification can be provided to the command via standard input (stdin)
+by setting the first argument to "-" or from a file by using an @-prefixed path
+to a variable specification file. When providing variable data via stdin, you
+must provide the `-in` flag with the format of the specification, either "hcl"
+or "json"
+
+Items to be stored in the variable can be supplied using the specification, as a
+series of key-value pairs, or both. The value for a key-value pair can be a
+string, an @-prefixed file reference, or a '-' to get the value from stdin. Item
+values provided from file references or stdin are consumed as-is with no
+additional processing and do not require the input format to be specified.
+
+Values supplied as command line arguments supersede values provided in the any
+variable specification piped into the command or loaded from file.  If ACLs are
+enabled, this command requires the `variables:write` capability for the
+destination namespace.
 
 ## General Options
 
 @include 'general_options.mdx'
 
-## Output Options
+## Put Options:
 
-- `-field` `(string: "")`: Print only the field with the given name. Specifying
-  this option will take precedence over other formatting directives. The result
-  will not have a trailing newline making it ideal for piping to other
-  processes.
+- `-check-index` `(int: <unset>)`: If set, the variable is only acted upon if
+  the server-side version's index matches the provided value. When a variable
+  specification contains a modify index, that modify index is used as the
+  check-index for the check-and-set operation and can be overridden using thi
+  flag.
 
-- `-of` `(string: varies)`: Print the output in the given format. Valid
-  formats are `none`, `table`, `json`, `hcl`, or `go-template`. Defaults to
-  `none` when the output is a terminal; defaults to `json` when the output is
-  redirected.
+- `-force`: Perform this operation regardless of the state or index of the
+  variable on the server-side.
 
-- `-q` - Silence all non-error output. This flag overrides any value set using
-  the `-of` option.
+- `-in` `(enum: hcl | json)`: Parser to use for data supplied via standard input
+  or when the variable specification's type can not be known using the file
+  extension. Defaults to "json".
 
-## Command Options
+- `-out` `(enum: go-template | hcl | json | none | table)`: Format to render
+  created or updated variable. Defaults to "none" when stdout is a terminal and
+  "json" when the output is redirected.
 
-- `-check-index` `(int: varies)`: If set, the secure variable is only updated if
-  the provided index matches the server side version's modify index. If a
-  check-index value of zero is set, the secure variable is only inserted if it
-  does not yet exist. This value defaults to the value provided in the variable
-  specification or to zero when a specification is not provided.
+- `-template` `(string: "")`: Template to render output with. Required when
+  format is "go-template", invalid for other formats.
 
-- `-if` `(string: "json")`: Specify the format of data read from standard input
-  and from files without the format-specifying extensions, ".hcl" or ".json".
-  Valid formats are `json` or `hcl`.
-
-- `-y`: Answer yes to all confirmation prompts.
+- `-verbose`: Provides additional information via standard error to preserve
+  standard output (stdout) for redirected output.
 
 ## Examples
 
@@ -63,8 +73,8 @@ $ nomad var put secret/creds passcode=my-long-passcode
 ```
 
 The data can also be consumed from a file on disk by prefixing with the "@"
-symbol. For example, you can store a variable using a specification created
-with the `nomad var init` command.
+symbol. For example, you can store a variable using a specification created with
+the `nomad var init` command.
 
 ```shell-session
 $ nomad var put secret/foo @spec.nsv.json

--- a/website/content/docs/commands/var/put.mdx
+++ b/website/content/docs/commands/var/put.mdx
@@ -1,0 +1,77 @@
+---
+layout: docs
+page_title: "Command: var put"
+description: |-
+  The "var put" command writes a secure variable to the given path in Nomad.
+---
+
+# Command: var put
+
+The `var put` command writes the secure variable to the given path in Nomad.
+Items to be stored in the variable can be provided as key-value pairs after the
+path or using one of the file input options—standard input or @-prefixed
+filenames.
+
+## Usage
+
+```plaintext
+nomad var put [options] <path> [<key>=value]...
+```
+
+If ACLs are enabled, this command requires a management ACL token or a token
+that has a capability associated with the namespace.
+
+## General Options
+
+@include 'general_options.mdx'
+
+## Output Options
+
+- `-field` `(string: "")`: Print only the field with the given name. Specifying
+  this option will take precedence over other formatting directives. The result
+  will not have a trailing newline making it ideal for piping to other
+  processes.
+
+- `-of` `(string: varies)`: Print the output in the given format. Valid
+  formats are `none`, `table`, `json`, `hcl`, or `go-template`. Defaults to
+  `none` when the output is a terminal; defaults to `json` when the output is
+  redirected.
+
+- `-q` - Silence all non-error output. This flag overrides any value set using
+  the `-of` option.
+
+## Command Options
+
+- `-check-index` `(int: varies)`: If set, the secure variable is only updated if
+  the provided index matches the server side version's modify index. If a
+  check-index value of zero is set, the secure variable is only inserted if it
+  does not yet exist. This value defaults to the value provided in the variable
+  specification or to zero when a specification is not provided.
+
+- `-if` `(string: "json")`: Specify the format of data read from standard input
+  and from files without the format-specifying extensions, ".hcl" or ".json".
+  Valid formats are `json` or `hcl`.
+
+- `-y`: Answer yes to all confirmation prompts.
+
+## Examples
+
+Writes the data to the path "secret/creds":
+
+```shell-session
+$ nomad var put secret/creds passcode=my-long-passcode
+```
+
+The data can also be consumed from a file on disk by prefixing with the "@"
+symbol. For example, you can store a variable using a specification created
+with the `nomad var init` command.
+
+```shell-session
+$ nomad var put secret/foo @spec.nsv.json
+```
+
+Or it can be read from standard input using the "-" symbol:
+
+```shell-session
+$ echo "abcd1234" | vault var put secret/foo bar=-
+```

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -905,6 +905,35 @@
         "path": "commands/ui"
       },
       {
+        "title": "var",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "commands/var"
+          },
+          {
+            "title": "get",
+            "path": "commands/var/get"
+          },
+          {
+            "title": "init",
+            "path": "commands/var/init"
+          },
+          {
+            "title": "list",
+            "path": "commands/var/list"
+          },
+          {
+            "title": "put",
+            "path": "commands/var/put"
+          },
+          {
+            "title": "purge",
+            "path": "commands/var/purge"
+          }
+        ]
+      },
+      {
         "title": "version",
         "path": "commands/version"
       },


### PR DESCRIPTION
In the Nomad Secure Variables CLI, there are some new flags that I am proposing we adopt for managing input and output formatting. This PR presents these flags as they would appear in the documentation so that we can discuss these as potential updates.

Of specific note, are the `-if` and `-of` flags which are meant to manage the input and output format respectively. Invocations of the `nomad var put` command, might need to set both of these values since secure variable data can come from stdin and put has the option of returning the value once set.

Another option that seemed to have value as I was writing up the commands was `-exit-code-not-found`, which would allow users to override the default exit code of 1 in cases where the variable was not found.

[Preview Website Link](https://nomad-itc2rd315-hashicorp.vercel.app/docs/commands/var)