### PR TITLE
changelog: update #14212 to breaking-change

### DIFF
--- a/.changelog/14212.txt
+++ b/.changelog/14212.txt
@@ -1,3 +1,3 @@
-```release-note:bug
+```release-note:breaking-change
 audit (Enterprise): fixed inconsistency in event filter logic
 ```


### PR DESCRIPTION
This change will cause event filters to behave differently from how they currently work, so marking it as breaking change to raise awareness when 1.4.0 comes out.