### PR TITLE
client/logmon: acquire executable in init block

### DIFF
--- a/.changelog/14297.txt
+++ b/.changelog/14297.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client/logmon: fixed a bug where logmon cannot find nomad executable
+```

--- a/client/logmon/plugin.go
+++ b/client/logmon/plugin.go
@@ -5,22 +5,27 @@ import (
 	"os"
 	"os/exec"
 
-	hclog "github.com/hashicorp/go-hclog"
-	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/nomad/client/logmon/proto"
 	"github.com/hashicorp/nomad/plugins/base"
 	"google.golang.org/grpc"
 )
 
+var bin = getBin()
+
+func getBin() string {
+	b, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
 // LaunchLogMon launches a new logmon or reattaches to an existing one.
 // TODO: Integrate with base plugin loader
 func LaunchLogMon(logger hclog.Logger, reattachConfig *plugin.ReattachConfig) (LogMon, *plugin.Client, error) {
 	logger = logger.Named("logmon")
-	bin, err := os.Executable()
-	if err != nil {
-		return nil, nil, err
-	}
-
 	conf := &plugin.ClientConfig{
 		HandshakeConfig: base.Handshake,
 		Plugins: map[string]plugin.Plugin{


### PR DESCRIPTION
This PR causes the logmon task runner to acquire the path of binary of the
Nomad executable file in an `init` block, so as to almost certainly acquire
the name while the nomad file still exists.

This is an attempt at fixing the case where a deleted Nomad file
(e.g. during upgrade) may be getting renamed with a suffix before the deletion
(maybe SELinux specific?).

If this doesn't work, as a last resort we can literally just trim the mystery string.

Fixes: #14079 
