### PR TITLE
Allow jobs not requiring network resources with network fingerprinter disabled

### DIFF
--- a/.changelog/14300.txt
+++ b/.changelog/14300.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+scheduler: Allow jobs not requiring network resources even when no network is fingerprinted
+```

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -381,6 +381,11 @@ func (c *NetworkChecker) SetNetwork(network *structs.NetworkResource) {
 }
 
 func (c *NetworkChecker) Feasible(option *structs.Node) bool {
+	// Allow jobs not requiring any network resources
+	if c.networkMode == "none" {
+		return true
+	}
+
 	if !c.hasNetwork(option) {
 
 		// special case - if the client is running a version older than 0.12 but


### PR DESCRIPTION
Jobs not requiring any network resources should be allowed even when the network fingerprinter is disabled.

My use-case: Nomad Client running on a host with thousands of virtual network interfaces where the `network` fingerprinter takes a long time (several minutes), and the job definitions aren't allocating any network resources. I would like to add `network` to the `fingerprint.denylist` option, but this makes the scheduler fail to place any job because the current `NetworkChecker` fails if the node doesn't have any network. Allowing jobs not requiring any network resources would let me disable the `network` fingerprinter while still placing jobs properly.