### PR TITLE
fix backport of #14310

### DIFF
--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1071,7 +1072,7 @@ func TestServer_Reload_VaultConfig(t *testing.T) {
 	})
 	defer agent.Shutdown()
 
-	newConfig := agent.GetConfig().Copy()
+	newConfig := agent.GetConfig()
 	newConfig.Vault = &config.VaultConfig{
 		Enabled:   pointer.Of(true),
 		Token:     "vault-token",


### PR DESCRIPTION
`must` was not imported in the file yet in `release/1.3.x` and `Config.Copy()` was added in https://github.com/hashicorp/nomad/pull/14139, which was not backported.

I wasn't sure how to deal with `Copy()`, I thought of just copying the function over to `release/1.3.x` but it seemed unnecessary for the test.

[CI errors](https://app.circleci.com/pipelines/github/hashicorp/nomad/30498/workflows/e84f203f-c4b2-41ab-a64a-bc8b54ae441a/jobs/340995).