### PR TITLE
Revert "Backport of build: set osusergo build tag by default into release/1.1.x"

### DIFF
--- a/.changelog/14248.txt
+++ b/.changelog/14248.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-client: Fixed a bug where user lookups would hang or panic
-```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,7 +15,7 @@ ifneq (MSYS_NT,$(THIS_OS))
 GOPATH=$(shell go env GOPATH | cut -d: -f1)
 endif
 
-GO_TAGS ?= osusergo
+GO_TAGS ?=
 
 ifeq ($(CI),true)
 GO_TAGS := codegen_generated $(GO_TAGS)


### PR DESCRIPTION
Reverts hashicorp/nomad#14276

This tag is not supported in the Go version used in `release/1.1.x`.