### PR TITLE
cli: force periodic job if its id equals search prefix (#14116)

### DIFF
--- a/.changelog/14333.txt
+++ b/.changelog/14333.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a bug where forcing a periodic job would fail if the job ID prefix-matched other periodic jobs
+```

--- a/command/job_periodic_force.go
+++ b/command/job_periodic_force.go
@@ -129,7 +129,9 @@ func (c *JobPeriodicForceCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("No periodic job(s) with prefix or id %q found", jobID))
 		return 1
 	}
-	if len(periodicJobs) > 1 {
+	// preriodicJobs is sorted by job ID
+	// so if there is a job whose ID is equal to jobID then it must be the first item
+	if len(periodicJobs) > 1 && periodicJobs[0].ID != jobID {
 		c.Ui.Error(fmt.Sprintf("Prefix matched multiple periodic jobs\n\n%s", createStatusListOutput(periodicJobs, c.allNamespaces())))
 		return 1
 	}


### PR DESCRIPTION
Closes #14116 

If jobs PrefixList found more than one job, we need first check whether one of their IDs equals search prefix. If it is so, we should force this job.