### PR TITLE
drain: use client status to determine drain is complete

### DIFF
--- a/nomad/drainer/draining_node.go
+++ b/nomad/drainer/draining_node.go
@@ -73,7 +73,7 @@ func (n *drainingNode) IsDone() (bool, error) {
 		}
 
 		// If there is a non-terminal we aren't done
-		if !alloc.TerminalStatus() {
+		if !alloc.ClientTerminalStatus() {
 			return false, nil
 		}
 	}

--- a/nomad/drainer/watch_jobs.go
+++ b/nomad/drainer/watch_jobs.go
@@ -363,6 +363,10 @@ func handleTaskGroup(snap *state.StateSnapshot, batch bool, tg *structs.TaskGrou
 			drainingNodes[alloc.NodeID] = onDrainingNode
 		}
 
+		if onDrainingNode && !alloc.ClientTerminalStatus() {
+			result.done = false
+		}
+
 		// Check if the alloc should be considered migrated. A migrated
 		// allocation is one that is terminal, is on a draining
 		// allocation, and has only happened since our last handled index to


### PR DESCRIPTION
WIP for https://github.com/hashicorp/nomad/issues/14293

If an allocation is slow to stop because of `kill_timeout`, the node drain is
marked as complete prematurely, even though drain monitoring will continue to
report allocation migrations. This impacts the UI or API clients that monitor
node draining to shut down nodes.