### PR TITLE
ui: long poll `/checks` endpoint

### DIFF
--- a/ui/app/adapters/allocation.js
+++ b/ui/app/adapters/allocation.js
@@ -29,6 +29,14 @@ export default class AllocationAdapter extends Watchable {
       )
       .then(handleFSResponse);
   }
+
+  async check(model) {
+    const res = await this.token.authorizedRequest(
+      `/v1/client/allocation/${model.id}/checks`
+    );
+    const data = await res.json();
+    return data;
+  }
 }
 
 async function handleFSResponse(response) {

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -4,6 +4,7 @@ import { equal, none } from '@ember/object/computed';
 import Model from '@ember-data/model';
 import { attr, belongsTo, hasMany } from '@ember-data/model';
 import { fragment, fragmentArray } from 'ember-data-model-fragments/attributes';
+import isEqual from 'lodash.isequal';
 import intersection from 'lodash.intersection';
 import shortUUIDProperty from '../utils/properties/short-uuid';
 import classic from 'ember-classic-decorator';
@@ -20,6 +21,7 @@ const STATUS_ORDER = {
 @classic
 export default class Allocation extends Model {
   @service token;
+  @service store;
 
   @shortUUIDProperty('id') shortId;
   @belongsTo('job') job;
@@ -39,6 +41,17 @@ export default class Allocation extends Model {
 
   @attr('string') clientStatus;
   @attr('string') desiredStatus;
+
+  @attr healthChecks;
+
+  async getServiceHealth() {
+    const data = await this.store.adapterFor('allocation').check(this);
+
+    // Compare Results
+    if (!isEqual(this.healthChecks, data)) {
+      this.set('healthChecks', data);
+    }
+  }
 
   @computed('')
   get plainJobId() {

--- a/ui/app/routes/allocations/allocation.js
+++ b/ui/app/routes/allocations/allocation.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { collect } from '@ember/object/computed';
-import { watchRecord } from 'nomad-ui/utils/properties/watch';
+import {
+  watchRecord,
+  watchNonStoreRecords,
+} from 'nomad-ui/utils/properties/watch';
 import WithWatchers from 'nomad-ui/mixins/with-watchers';
 import notifyError from 'nomad-ui/utils/notify-error';
 export default class AllocationRoute extends Route.extend(WithWatchers) {
@@ -10,6 +13,10 @@ export default class AllocationRoute extends Route.extend(WithWatchers) {
   startWatchers(controller, model) {
     if (model) {
       controller.set('watcher', this.watch.perform(model));
+      controller.set(
+        'watchHealthChecks',
+        this.watchHealthChecks.perform(model, 'getServiceHealth')
+      );
     }
   }
 
@@ -28,6 +35,7 @@ export default class AllocationRoute extends Route.extend(WithWatchers) {
   }
 
   @watchRecord('allocation') watch;
+  @watchNonStoreRecords('allocation') watchHealthChecks;
 
   @collect('watch') watchers;
 }

--- a/ui/app/utils/properties/watch.js
+++ b/ui/app/utils/properties/watch.js
@@ -68,6 +68,27 @@ export function watchRelationship(relationshipName, replace = false) {
   }).drop();
 }
 
+export function watchNonStoreRecords(modelName) {
+  return task(function* (model, asyncCallbackName, throttle = 5000) {
+    assert(
+      'To watch a non-store records, the adapter of the model provided to the watchNonStoreRecords task MUST extend Watchable',
+      this.store.adapterFor(modelName) instanceof Watchable
+    );
+    while (isEnabled && !Ember.testing) {
+      const controller = new AbortController();
+      try {
+        yield model[asyncCallbackName]();
+        yield wait(throttle);
+      } catch (e) {
+        yield e;
+        break;
+      } finally {
+        controller.abort();
+      }
+    }
+  }).drop();
+}
+
 export function watchAll(modelName) {
   return task(function* (throttle = 2000) {
     assert(

--- a/ui/package.json
+++ b/ui/package.json
@@ -133,6 +133,7 @@
     "jsonlint": "^1.6.3",
     "lint-staged": "^11.2.6",
     "loader.js": "^4.7.0",
+    "lodash.isequal": "^4.5.0",
     "lodash.intersection": "^4.4.0",
     "morgan": "^1.3.2",
     "npm-run-all": "^4.1.5",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -14205,7 +14205,7 @@ lodash.isempty@^4.4.0:
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
 
 lodash.isfunction@^3.0.9:
   version "3.0.9"


### PR DESCRIPTION
This PR handles long polling the `client/allocations/:allocId/checks` endpoint which is not stored in Ember Data. Instead we add the property directly onto the `Allocation` to visualize the Service Health information in real-time.

When doing real-time visualizations, we follow a pattern of skipping the Ember Data store because we expect a clean slate on every fetch.