### PR TITLE
ui: add service health viz to table

### DIFF
--- a/ui/app/components/service-status-bar.js
+++ b/ui/app/components/service-status-bar.js
@@ -1,0 +1,45 @@
+import { computed } from '@ember/object';
+import DistributionBar from './distribution-bar';
+import { attributeBindings } from '@ember-decorators/component';
+import classic from 'ember-classic-decorator';
+
+@classic
+@attributeBindings('data-test-service-status-bar')
+export default class ServiceStatusBar extends DistributionBar {
+  layoutName = 'components/distribution-bar';
+
+  services = null;
+
+  'data-test-service-status-bar' = true;
+
+  @computed('services.@each.status')
+  get data() {
+    if (!this.services) {
+      return [];
+    }
+
+    const pending = this.services.filterBy('status', 'pending').length;
+    const failing = this.services.filterBy('status', 'failing').length;
+    const success = this.services.filterBy('status', 'success').length;
+
+    const [grey, red, green] = ['queued', 'failed', 'complete'];
+
+    return [
+      {
+        label: 'Pending',
+        value: pending,
+        className: grey,
+      },
+      {
+        label: 'Failing',
+        value: failing,
+        className: red,
+      },
+      {
+        label: 'Success',
+        value: success,
+        className: green,
+      },
+    ];
+  }
+}

--- a/ui/app/components/service-status-bar.js
+++ b/ui/app/components/service-status-bar.js
@@ -9,18 +9,21 @@ export default class ServiceStatusBar extends DistributionBar {
   layoutName = 'components/distribution-bar';
 
   services = null;
+  name = null;
 
   'data-test-service-status-bar' = true;
 
-  @computed('services.@each.status')
+  @computed('services.{}', 'name')
   get data() {
-    if (!this.services) {
+    const service = this.services && this.services.get(this.name);
+
+    if (!service) {
       return [];
     }
 
-    const pending = this.services.filterBy('status', 'pending').length;
-    const failing = this.services.filterBy('status', 'failing').length;
-    const success = this.services.filterBy('status', 'success').length;
+    const pending = service.pending || 0;
+    const failing = service.failure || 0;
+    const success = service.success || 0;
 
     const [grey, red, green] = ['queued', 'failed', 'complete'];
 

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -67,6 +67,35 @@ export default class IndexController extends Controller.extend(Sortable) {
 
   @union('taskServices', 'groupServices') services;
 
+  @computed('model.healthChecks.{}')
+  get serviceHealthStatuses() {
+    if (!this.model.healthChecks) return null;
+
+    let result = new Map();
+    Object.values(this.model.healthChecks)?.forEach((service) => {
+      const currentServiceStatus = service.Status;
+      const currentServiceName = service.Service;
+      const serviceStatuses = result.get(currentServiceName);
+      if (serviceStatuses) {
+        if (serviceStatuses[currentServiceStatus]) {
+          result.set(currentServiceName, {
+            ...serviceStatuses,
+            [currentServiceStatus]: serviceStatuses[currentServiceStatus]++,
+          });
+        } else {
+          result.set(currentServiceName, {
+            ...serviceStatuses,
+            [currentServiceStatus]: 1,
+          });
+        }
+      } else {
+        result.set(currentServiceName, {});
+      }
+    });
+
+    return result;
+  }
+
   onDismiss() {
     this.set('error', null);
   }

--- a/ui/app/routes/allocations/allocation.js
+++ b/ui/app/routes/allocations/allocation.js
@@ -13,6 +13,7 @@ export default class AllocationRoute extends Route.extend(WithWatchers) {
   startWatchers(controller, model) {
     if (model) {
       controller.set('watcher', this.watch.perform(model));
+      // TODO: Add conditional logic
       controller.set(
         'watchHealthChecks',
         this.watchHealthChecks.perform(model, 'getServiceHealth')

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -276,6 +276,9 @@
             <td>
               Upstreams
             </td>
+            <td>
+              Health Check Status
+            </td>
           </t.head>
           <t.body as |row|>
             <tr data-test-service>
@@ -300,6 +303,13 @@
                 }}
                   {{upstream.destinationName}}:{{upstream.localBindPort}}
                 {{/each}}
+              </td>
+              <td data-test-service-health>
+                {{#if (not row.model.connect)}}
+                  <div class="inline-chart">
+                    <ServiceStatusBar @services={{this.serviceHealthStatuses}} @name={{row.model.name}} />
+                  </div>
+                {{/if}}
               </td>
             </tr>
           </t.body>

--- a/ui/tests/integration/components/service-status-bar-test.js
+++ b/ui/tests/integration/components/service-status-bar-test.js
@@ -1,0 +1,47 @@
+import { A } from '@ember/array';
+import EmberObject from '@ember/object';
+import { findAll, render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+import { componentA11yAudit } from 'nomad-ui/tests/helpers/a11y-audit';
+
+module('Integration | Component | Service Status Bar', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('Visualizes aggregate status of a service', async function (assert) {
+    assert.expect(2);
+    const component = this;
+    await componentA11yAudit(component, assert);
+
+    const healthyService = EmberObject.create({
+      id: '1',
+      status: 'success',
+    });
+
+    const failingService = EmberObject.create({
+      id: '2',
+      status: 'failing',
+    });
+
+    const pendingService = EmberObject.create({
+      id: '3',
+      status: 'pending',
+    });
+
+    const services = A([healthyService, failingService, pendingService]);
+    this.set('services', services);
+
+    await render(hbs`
+      <div class="inline-chart">
+        <ServiceStatusBar
+          @services={{this.services}}  
+        />
+      </div>
+    `);
+
+    const bars = findAll('g > g').length;
+
+    assert.equal(bars, 3, 'It visualizes services by status');
+  });
+});


### PR DESCRIPTION
This PR handles visualizing Service Health statuses in the `allocations.allocation.index` view within the Services table.

https://files.slack.com/files-pri/TF1GCKJNM-F04020DCC9J/image.png

_This PR raises a concern about the response from `clients/allocations/:allocId/checks` endpoint. Highlighting an issue where all services in the allocation are not returning a status and sometimes the API returns `null`._