### PR TITLE
Revert "refact: conditional checks for token secret before fetch"

### DIFF
--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -1,7 +1,6 @@
 import Service, { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
-import Ember from 'ember';
 import PromiseObject from '../utils/classes/promise-object';
 import PromiseArray from '../utils/classes/promise-array';
 import { namespace } from '../adapters/application';
@@ -17,78 +16,64 @@ export default class SystemService extends Service {
   @computed('activeRegion')
   get leader() {
     const token = this.token;
-    if (token.secret || Ember.testing) {
-      return PromiseObject.create({
-        promise: token
-          .authorizedRequest(`/${namespace}/status/leader`)
-          .then((res) => res.json())
-          .then((rpcAddr) => ({ rpcAddr }))
-          .then((leader) => {
-            // Dirty self so leader can be used as a dependent key
-            this.notifyPropertyChange('leader.rpcAddr');
-            return leader;
-          }),
-      });
-    }
-    return null;
+
+    return PromiseObject.create({
+      promise: token
+        .authorizedRequest(`/${namespace}/status/leader`)
+        .then((res) => res.json())
+        .then((rpcAddr) => ({ rpcAddr }))
+        .then((leader) => {
+          // Dirty self so leader can be used as a dependent key
+          this.notifyPropertyChange('leader.rpcAddr');
+          return leader;
+        }),
+    });
   }
 
   @computed
   get agent() {
     const token = this.token;
-
-    if (token.secret || Ember.testing) {
-      return PromiseObject.create({
-        promise: token
-          .authorizedRawRequest(`/${namespace}/agent/self`)
-          .then(jsonWithDefault({}))
-          .then((agent) => {
-            if (agent?.config?.Version) {
-              const { Version, VersionPrerelease, VersionMetadata } =
-                agent.config.Version;
-              agent.version = Version;
-              if (VersionPrerelease)
-                agent.version = `${agent.version}-${VersionPrerelease}`;
-              if (VersionMetadata)
-                agent.version = `${agent.version}+${VersionMetadata}`;
-            }
-            return agent;
-          }),
-      });
-    }
-    return null;
+    return PromiseObject.create({
+      promise: token
+        .authorizedRawRequest(`/${namespace}/agent/self`)
+        .then(jsonWithDefault({}))
+        .then((agent) => {
+          if (agent?.config?.Version) {
+            const { Version, VersionPrerelease, VersionMetadata } =
+              agent.config.Version;
+            agent.version = Version;
+            if (VersionPrerelease)
+              agent.version = `${agent.version}-${VersionPrerelease}`;
+            if (VersionMetadata)
+              agent.version = `${agent.version}+${VersionMetadata}`;
+          }
+          return agent;
+        }),
+    });
   }
 
   @computed
   get defaultRegion() {
     const token = this.token;
-
-    if (token.secret || Ember.testing) {
-      return PromiseObject.create({
-        promise: token
-          .authorizedRawRequest(`/${namespace}/agent/members`)
-          .then(jsonWithDefault({}))
-          .then((json) => {
-            return { region: json.ServerRegion };
-          }),
-      });
-    }
-    return null;
+    return PromiseObject.create({
+      promise: token
+        .authorizedRawRequest(`/${namespace}/agent/members`)
+        .then(jsonWithDefault({}))
+        .then((json) => {
+          return { region: json.ServerRegion };
+        }),
+    });
   }
 
   @computed
   get regions() {
     const token = this.token;
 
-    if (token.secret || Ember.testing) {
-      return PromiseArray.create({
-        promise: token
-          .authorizedRawRequest(`/${namespace}/regions`)
-          .then(jsonWithDefault([])),
-      });
-    }
-
-    return null;
+    return PromiseArray.create({
+      promise: token
+        .authorizedRawRequest(`/${namespace}/regions`)
+        .then(jsonWithDefault([])),
+    });
   }
 
   @computed('regions.[]')

--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -3,7 +3,6 @@ import { computed } from '@ember/object';
 import { alias, reads } from '@ember/object/computed';
 import { getOwner } from '@ember/application';
 import { assign } from '@ember/polyfills';
-import Ember from 'ember';
 import { task } from 'ember-concurrency';
 import queryString from 'query-string';
 import fetch from 'nomad-ui/utils/fetch';
@@ -32,11 +31,9 @@ export default class TokenService extends Service {
   @task(function* () {
     const TokenAdapter = getOwner(this).lookup('adapter:token');
     try {
-      if (this.secret || Ember.testing) {
-        var token = yield TokenAdapter.findSelf();
-        this.secret = token.secret;
-        return token;
-      }
+      var token = yield TokenAdapter.findSelf();
+      this.secret = token.secret;
+      return token;
     } catch (e) {
       const errors = e.errors ? e.errors.mapBy('detail') : [];
       if (errors.find((error) => error === 'ACL support disabled')) {
@@ -89,8 +86,6 @@ export default class TokenService extends Service {
     const credentials = 'include';
     const headers = {};
     const token = this.secret;
-
-    if (!token && !Ember.testing) return null;
 
     if (token) {
       headers['X-Nomad-Token'] = token;


### PR DESCRIPTION
Reverts hashicorp/nomad#14134

In a cluster where ACLs are not enabled, this change results in several errors in the UI.