### PR TITLE
search: enforce correct ACL for search over variables

### DIFF
--- a/command/agent/search_endpoint_test.go
+++ b/command/agent/search_endpoint_test.go
@@ -724,12 +724,12 @@ func TestHTTP_PrefixSearch_Variables_ACL(t *testing.T) {
 		defNSToken := mock.CreatePolicyAndToken(t, state, 8002, "default",
 			mock.NamespacePolicyWithVariables(
 				"default", "read", []string{},
-				map[string][]string{"*": []string{"read", "list"}}))
+				map[string][]string{"*": {"read", "list"}}))
 
 		ns1NSToken := mock.CreatePolicyAndToken(t, state, 8004, "ns-"+ns.Name,
 			mock.NamespacePolicyWithVariables(
 				ns.Name, "read", []string{},
-				map[string][]string{"*": []string{"read", "list"}}))
+				map[string][]string{"*": {"read", "list"}}))
 
 		denyToken := mock.CreatePolicyAndToken(t, state, 8006, "none",
 			mock.NamespacePolicy("default", "deny", nil))
@@ -834,9 +834,19 @@ func TestHTTP_FuzzySearch_Variables_ACL(t *testing.T) {
 		require.NoError(t, setResp.Error)
 
 		rootToken := s.RootToken
-		defNSToken := mock.CreatePolicyAndToken(t, state, 8002, "default", mock.NamespacePolicy("default", "read", nil))
-		ns1NSToken := mock.CreatePolicyAndToken(t, state, 8004, "ns-"+ns.Name, mock.NamespacePolicy(ns.Name, "read", nil))
-		denyToken := mock.CreatePolicyAndToken(t, state, 8006, "none", mock.NamespacePolicy("default", "deny", nil))
+
+		defNSToken := mock.CreatePolicyAndToken(t, state, 8002, "default",
+			mock.NamespacePolicyWithVariables(
+				"default", "read", []string{},
+				map[string][]string{"*": {"list"}}))
+
+		ns1NSToken := mock.CreatePolicyAndToken(t, state, 8004, "ns-"+ns.Name,
+			mock.NamespacePolicyWithVariables(
+				ns.Name, "read", []string{},
+				map[string][]string{"*": {"list"}}))
+
+		denyToken := mock.CreatePolicyAndToken(t, state, 8006, "none",
+			mock.NamespacePolicy("default", "deny", nil))
 
 		type testCase struct {
 			desc               string

--- a/nomad/search_endpoint.go
+++ b/nomad/search_endpoint.go
@@ -482,8 +482,7 @@ func nsCapFilter(aclObj *acl.ACL) memdb.FilterFunc {
 			return !aclObj.AllowNsOp(t.Namespace, acl.NamespaceCapabilityReadJob)
 
 		case *structs.VariableEncrypted:
-			// FIXME: Update to final implementation.
-			return !aclObj.AllowNsOp(t.Namespace, acl.NamespaceCapabilityReadJob)
+			return !aclObj.AllowVariableSearch(t.Namespace)
 
 		case *structs.Namespace:
 			return !aclObj.AllowNamespace(t.Name)


### PR DESCRIPTION
When the Search API was updated for variables, we didn't have the ACLs finished yet. We missed a spot when updating this endpoint for the updated ACLs.