### PR TITLE
testing: setting env var incompatible with parallel tests

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -117,7 +117,7 @@ func TestRequestTime(t *testing.T) {
 }
 
 func TestDefaultConfig_env(t *testing.T) {
-	testutil.Parallel(t)
+
 	testURL := "http://1.2.3.4:5678"
 	auth := []string{"nomaduser", "12345"}
 	region := "test"

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -1376,14 +1376,11 @@ BAR={{key "bar"}}
 // process environment variables.  nomad host process environment variables
 // are to be treated the same as not found environment variables.
 func TestTaskTemplateManager_FiltersEnvVars(t *testing.T) {
-	ci.Parallel(t)
 
-	defer os.Setenv("NOMAD_TASK_NAME", os.Getenv("NOMAD_TASK_NAME"))
-	os.Setenv("NOMAD_TASK_NAME", "should be overridden by task")
+	t.Setenv("NOMAD_TASK_NAME", "should be overridden by task")
 
 	testenv := "TESTENV_" + strings.ReplaceAll(uuid.Generate(), "-", "")
-	os.Setenv(testenv, "MY_TEST_VALUE")
-	defer os.Unsetenv(testenv)
+	t.Setenv(testenv, "MY_TEST_VALUE")
 
 	// Make a template that will render immediately
 	content := `Hello Nomad Task: {{env "NOMAD_TASK_NAME"}}

--- a/client/fingerprint/env_azure_test.go
+++ b/client/fingerprint/env_azure_test.go
@@ -5,20 +5,17 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 func TestAzureFingerprint_nonAzure(t *testing.T) {
-	ci.Parallel(t)
 
-	os.Setenv("AZURE_ENV_URL", "http://127.0.0.1/metadata/instance/")
+	t.Setenv("AZURE_ENV_URL", "http://127.0.0.1/metadata/instance/")
 	f := NewEnvAzureFingerprint(testlog.HCLogger(t))
 	node := &structs.Node{
 		Attributes: make(map[string]string),
@@ -95,7 +92,7 @@ func testFingerprint_Azure(t *testing.T, withExternalIp bool) {
 		}
 	}))
 	defer ts.Close()
-	os.Setenv("AZURE_ENV_URL", ts.URL+"/metadata/instance/")
+	t.Setenv("AZURE_ENV_URL", ts.URL+"/metadata/instance/")
 	f := NewEnvAzureFingerprint(testlog.HCLogger(t))
 
 	request := &FingerprintRequest{Config: &config.Config{}, Node: node}
@@ -208,19 +205,15 @@ const AZURE_routes = `
 		"uri": "/metadata/instance/network/interface/0/macAddress",
 		"content-type": "text/plain",
 		"body": "000D3AF806EC"
-	}       
+	}
   ]
 }
 `
 
 func TestFingerprint_AzureWithExternalIp(t *testing.T) {
-	ci.Parallel(t)
-
 	testFingerprint_Azure(t, true)
 }
 
 func TestFingerprint_AzureWithoutExternalIp(t *testing.T) {
-	ci.Parallel(t)
-
 	testFingerprint_Azure(t, false)
 }

--- a/client/fingerprint/env_digitalocean_test.go
+++ b/client/fingerprint/env_digitalocean_test.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -17,9 +15,8 @@ import (
 )
 
 func TestDigitalOceanFingerprint_nonDigitalOcean(t *testing.T) {
-	ci.Parallel(t)
 
-	os.Setenv("DO_ENV_URL", "http://127.0.0.1/metadata/v1/")
+	t.Setenv("DO_ENV_URL", "http://127.0.0.1/metadata/v1/")
 	f := NewEnvDigitalOceanFingerprint(testlog.HCLogger(t))
 	node := &structs.Node{
 		Attributes: make(map[string]string),
@@ -42,7 +39,6 @@ func TestDigitalOceanFingerprint_nonDigitalOcean(t *testing.T) {
 }
 
 func TestFingerprint_DigitalOcean(t *testing.T) {
-	ci.Parallel(t)
 
 	node := &structs.Node{
 		Attributes: make(map[string]string),
@@ -82,7 +78,7 @@ func TestFingerprint_DigitalOcean(t *testing.T) {
 		}
 	}))
 	defer ts.Close()
-	os.Setenv("DO_ENV_URL", ts.URL+"/metadata/v1/")
+	t.Setenv("DO_ENV_URL", ts.URL+"/metadata/v1/")
 	f := NewEnvDigitalOceanFingerprint(testlog.HCLogger(t))
 
 	request := &FingerprintRequest{Config: &config.Config{}, Node: node}

--- a/client/fingerprint/env_gce_test.go
+++ b/client/fingerprint/env_gce_test.go
@@ -5,20 +5,17 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 func TestGCEFingerprint_nonGCE(t *testing.T) {
-	ci.Parallel(t)
 
-	os.Setenv("GCE_ENV_URL", "http://127.0.0.1/computeMetadata/v1/instance/")
+	t.Setenv("GCE_ENV_URL", "http://127.0.0.1/computeMetadata/v1/instance/")
 	f := NewEnvGCEFingerprint(testlog.HCLogger(t))
 	node := &structs.Node{
 		Attributes: make(map[string]string),
@@ -92,7 +89,7 @@ func testFingerprint_GCE(t *testing.T, withExternalIp bool) {
 		}
 	}))
 	defer ts.Close()
-	os.Setenv("GCE_ENV_URL", ts.URL+"/computeMetadata/v1/instance/")
+	t.Setenv("GCE_ENV_URL", ts.URL+"/computeMetadata/v1/instance/")
 	f := NewEnvGCEFingerprint(testlog.HCLogger(t))
 
 	request := &FingerprintRequest{Config: &config.Config{}, Node: node}
@@ -210,13 +207,9 @@ const GCE_routes = `
 `
 
 func TestFingerprint_GCEWithExternalIp(t *testing.T) {
-	ci.Parallel(t)
-
 	testFingerprint_GCE(t, true)
 }
 
 func TestFingerprint_GCEWithoutExternalIp(t *testing.T) {
-	ci.Parallel(t)
-
 	testFingerprint_GCE(t, false)
 }

--- a/command/agent/host/host_test.go
+++ b/command/agent/host/host_test.go
@@ -1,10 +1,8 @@
 package host
 
 import (
-	"os"
 	"testing"
 
-	"github.com/hashicorp/nomad/ci"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,16 +17,11 @@ func TestHostUtils(t *testing.T) {
 }
 
 func TestMakeHostData(t *testing.T) {
-	ci.Parallel(t)
 
-	// setenv variables that should be redacted
-	prev := os.Getenv("VAULT_TOKEN")
-	os.Setenv("VAULT_TOKEN", "foo")
-	defer os.Setenv("VAULT_TOKEN", prev)
-
-	os.Setenv("BOGUS_TOKEN", "foo")
-	os.Setenv("BOGUS_SECRET", "foo")
-	os.Setenv("ryanSECRETS", "foo")
+	t.Setenv("VAULT_TOKEN", "foo")
+	t.Setenv("BOGUS_TOKEN", "foo")
+	t.Setenv("BOGUS_SECRET", "foo")
+	t.Setenv("ryanSECRETS", "foo")
 
 	host, err := MakeHostData()
 	require.NoError(t, err)

--- a/command/helpers_test.go
+++ b/command/helpers_test.go
@@ -332,7 +332,6 @@ func TestJobGetter_LocalFile_InvalidHCL2(t *testing.T) {
 // TestJobGetter_HCL2_Variables asserts variable arguments from CLI
 // and varfiles are both honored
 func TestJobGetter_HCL2_Variables(t *testing.T) {
-	ci.Parallel(t)
 
 	hcl := `
 variables {
@@ -346,7 +345,6 @@ job "example" {
   datacenters = ["${var.var1}", "${var.var2}", "${var.var3}", "${var.var4}"]
 }
 `
-
 	t.Setenv("NOMAD_VAR_var4", "from-envvar")
 
 	cliArgs := []string{`var2=from-cli`}
@@ -377,7 +375,6 @@ job "example" {
 }
 
 func TestJobGetter_HCL2_Variables_StrictFalse(t *testing.T) {
-	ci.Parallel(t)
 
 	hcl := `
 variables {
@@ -392,8 +389,7 @@ job "example" {
 }
 `
 
-	os.Setenv("NOMAD_VAR_var4", "from-envvar")
-	defer os.Unsetenv("NOMAD_VAR_var4")
+	t.Setenv("NOMAD_VAR_var4", "from-envvar")
 
 	// Both the CLI and var file contain variables that are not used with the
 	// template and therefore would error, if hcl2-strict was true.

--- a/command/job_plan_test.go
+++ b/command/job_plan_test.go
@@ -158,7 +158,6 @@ job "job1" {
 }
 
 func TestPlanCommand_From_Files(t *testing.T) {
-	ci.Parallel(t)
 
 	// Create a Vault server
 	v := testutil.NewTestVault(t)

--- a/command/job_validate_test.go
+++ b/command/job_validate_test.go
@@ -18,7 +18,6 @@ func TestValidateCommand_Implements(t *testing.T) {
 }
 
 func TestValidateCommand_Files(t *testing.T) {
-	ci.Parallel(t)
 
 	// Create a Vault server
 	v := testutil.NewTestVault(t)

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -62,7 +62,6 @@ func TestMeta_FlagSet(t *testing.T) {
 }
 
 func TestMeta_Colorize(t *testing.T) {
-	ci.Parallel(t)
 
 	type testCaseSetupFn func(*testing.T, *Meta)
 

--- a/command/ui_test.go
+++ b/command/ui_test.go
@@ -5,13 +5,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/nomad/ci"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCommand_Ui(t *testing.T) {
-	ci.Parallel(t)
 
 	type testCaseSetupFn func(*testing.T)
 

--- a/drivers/docker/driver_darwin_test.go
+++ b/drivers/docker/driver_darwin_test.go
@@ -18,7 +18,7 @@ import (
 func TestMain(m *testing.M) {
 	tmpdir := fmt.Sprintf("/tmp/nomad-docker-tests-%d", time.Now().Unix())
 
-	defer os.Setenv("TMPDIR", os.Getenv("TMPDIR"))
+	os.Setenv("TMPDIR", os.Getenv("TMPDIR"))
 	os.Setenv("TMPDIR", tmpdir)
 
 	os.MkdirAll(tmpdir, 0700)

--- a/drivers/docker/driver_linux_test.go
+++ b/drivers/docker/driver_linux_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestDockerDriver_authFromHelper(t *testing.T) {
-	ci.Parallel(t)
 	testutil.DockerCompatible(t)
 
 	dir := t.TempDir()


### PR DESCRIPTION
Neither the `os.Setenv` nor `t.Setenv` helper are safe to use in parallel tests
because environment variables are process-global. The stdlib panics if you try
to do this. Remove the `ci.Parallel()` call from all tests where we're setting
environment variables.

Switched to `t.Setenv` where possible to take advantage of automatic cleanup.
Fixes panics trying to run these tests locally with `go test ./$packagename`