### PR TITLE
cli: ignore VaultToken when generating job diff

### DIFF
--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -69,7 +69,7 @@ func (j *Job) Diff(other *Job, contextual bool) (*JobDiff, error) {
 	diff := &JobDiff{Type: DiffTypeNone}
 	var oldPrimitiveFlat, newPrimitiveFlat map[string]string
 	filter := []string{"ID", "Status", "StatusDescription", "Version", "Stable", "CreateIndex",
-		"ModifyIndex", "JobModifyIndex", "Update", "SubmitTime", "NomadTokenID"}
+		"ModifyIndex", "JobModifyIndex", "Update", "SubmitTime", "NomadTokenID", "VaultToken"}
 
 	if j == nil && other == nil {
 		return diff, nil

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -1176,7 +1176,6 @@ func TestJobDiff(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			// Multiregion: region added
 			Old: &Job{
@@ -1319,6 +1318,21 @@ func TestJobDiff(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		{
+			// VaultToken is filtered
+			Old: &Job{
+				ID:         "vault-job",
+				VaultToken: "secret",
+			},
+			New: &Job{
+				ID:         "vault-job",
+				VaultToken: "new-secret",
+			},
+			Expected: &JobDiff{
+				Type: DiffTypeNone,
+				ID:   "vault-job",
 			},
 		},
 	}


### PR DESCRIPTION
Backport only to 1.3.x because that's when `-vault-token` flag was added to the  `plan` command.

From our [docs](https://www.nomadproject.io/docs/commands/job/run#vault-token):

> This token is cleared from the job after validating and cannot be used within the job executing environment.

So the token shouldn't be considered in the diff as it's not used internally.

Closes #14423