### PR TITLE
Fix error handling in Client consulDiscoveryImpl

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2869,6 +2869,7 @@ DISCOLOOP:
 				addr, err := net.ResolveTCPAddr("tcp", p)
 				if err != nil {
 					mErr.Errors = append(mErr.Errors, err)
+					continue
 				}
 				srv := &servers.Server{Addr: addr}
 				nomadServers = append(nomadServers, srv)


### PR DESCRIPTION
Trivial one-liner fix, added a missing `continue` on non-nil error to avoid accidentally using a bad peer.

I ran into this while updating a single server test cluster to raft version 3 (https://www.nomadproject.io/docs/upgrade#upgrading-a-single-server-cluster-to-raft-version-3) by creating a `raft.peers` file manually and forgetting to include the port in the `address` field. This resulted in clients discovering via Consul to appear to successfully detect a server, but then later failing with errors like this:

```
client.rpc: error performing RPC to server: error="rpc error: failed to get conn: dial tcp: address <nil>: missing port in address" rpc=Node.GetClientAllocs server=<nil>
```

This fix will allow allow the client to check for other servers with functional `Status.Peers` responses, or in the absence of a functional server at least return a relevant error in the right place.