### PR TITLE
e2e: add test to exercise ACL tokens with role and policy links.

### DIFF
--- a/e2e/acl/acl_test.go
+++ b/e2e/acl/acl_test.go
@@ -11,14 +11,18 @@ import (
 
 func TestACL(t *testing.T) {
 
-	// Wait until we have a usable cluster before running the tests. The tests
-	// do not currently need a running client.
+	// Wait until we have a usable cluster before running the tests. While the
+	// test does not run client workload, some do perform listings of nodes. It
+	// is therefore better to wait until we have a node, so these tests can
+	// check for a non-empty node list response object.
 	nomadClient := e2eutil.NomadClient(t)
 	e2eutil.WaitForLeader(t, nomadClient)
+	e2eutil.WaitForNodesReady(t, nomadClient, 1)
 
 	// Run our test cases.
 	t.Run("TestACL_Role", testACLRole)
 	t.Run("TestACL_TokenExpiration", testACLTokenExpiration)
+	t.Run("TestACL_TokenRolePolicyAssignment", testACLTokenRolePolicyAssignment)
 }
 
 // testResourceType indicates what the resource is so the cleanup process can


### PR DESCRIPTION
Related #13120 