### PR TITLE
docs: clarify CSI plugin compatibility

### DIFF
--- a/website/content/docs/concepts/plugins/csi.mdx
+++ b/website/content/docs/concepts/plugins/csi.mdx
@@ -33,11 +33,12 @@ schedule workloads based on the availability of volumes on a given
 Nomad client node.
 
 A list of available CSI plugins can be found in the [Kubernetes CSI
-documentation][csi-drivers-list]. Any of these plugins should work with Nomad
-out of the box, but it's some plugin vendors have implemented their plugins in a
-way that makes Kubernetes API calls or is otherwise non-compliant with the CSI
-specification. You should verify plugin compatibility with Nomad before adopting
-in production.
+documentation][csi-drivers-list]. Spec-compliant plugins should work with Nomad.
+However, it is possible a plugin vendor has implemented their plugin to make
+Kubernetes API calls, or is otherwise non-compliant with the CSI
+specification. In those situations the plugin may not function correctly in a
+Nomad environment. You should verify plugin compatibility with Nomad before
+deploying in production.
 
 A CSI plugin task requires the [`csi_plugin`][csi_plugin] block:
 

--- a/website/content/docs/concepts/plugins/csi.mdx
+++ b/website/content/docs/concepts/plugins/csi.mdx
@@ -30,9 +30,14 @@ plugin. Jobs can claim storage volumes from AWS Elastic Block Storage
 (EBS) volumes, GCP persistent disks, Ceph, Portworx, vSphere, etc. The
 Nomad scheduler will be aware of volumes created by CSI plugins and
 schedule workloads based on the availability of volumes on a given
-Nomad client node. A list of available CSI plugins can be found in the
-[Kubernetes CSI documentation][csi-drivers-list]. Any of these plugins
-should work with Nomad out of the box.
+Nomad client node.
+
+A list of available CSI plugins can be found in the [Kubernetes CSI
+documentation][csi-drivers-list]. Any of these plugins should work with Nomad
+out of the box, but it's some plugin vendors have implemented their plugins in a
+way that makes Kubernetes API calls or is otherwise non-compliant with the CSI
+specification. You should verify plugin compatibility with Nomad before adopting
+in production.
 
 A CSI plugin task requires the [`csi_plugin`][csi_plugin] block:
 


### PR DESCRIPTION
Nomad is generally compliant with the CSI specification for Container
Orchestrators (CO), except for unimplemented features. However, some storage
vendors have built CSI plugins that are not compliant with the specification or
which expect that they're only deployed on Kubernetes. Nomad cannot vouch for
the compatibility of any particular plugin, so clarify this in the docs.