### PR TITLE
docs: add warning about changing region config

### DIFF
--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -301,6 +301,12 @@ testing.
   with potentially multiple zones, which map to [datacenters](#datacenter) such
   as `us-west` and `us-east`.
 
+  !> **Be Careful!** Changing the `region` of an agent with data stored in its
+  `data_dir` may result in overwrite and data loss in the new region so avoid
+  modifying this value after the agent starts. If you must change it, make sure
+  no local state remains from the previous region before running the agent
+  again.
+
 - `sentinel` `(`[`Sentinel`]`: nil)` - Specifies configuration for Sentinel
   policies.
 


### PR DESCRIPTION
As pointed out in #14429, changing an agent's `region` while it still has local state can result in data loss, so we should warn about this in our documentation.

Preview:
![image](https://user-images.githubusercontent.com/775380/187992695-2b6ff6c0-cdad-4754-8de4-607393654dd4.png)
