### PR TITLE
connect: interpolate task env in config values

### DIFF
--- a/.changelog/14445.txt
+++ b/.changelog/14445.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+consul: Allow interpolation of task environment values into Consul Service Mesh configuration
+```

--- a/client/taskenv/services.go
+++ b/client/taskenv/services.go
@@ -81,7 +81,12 @@ func interpolateMapStringInterface(taskEnv *TaskEnv, orig map[string]interface{}
 
 	m := make(map[string]interface{}, len(orig))
 	for k, v := range orig {
-		m[taskEnv.ReplaceEnv(k)] = v
+		envK := taskEnv.ReplaceEnv(k)
+		if vStr, ok := v.(string); ok {
+			m[envK] = taskEnv.ReplaceEnv(vStr)
+		} else {
+			m[envK] = v
+		}
 	}
 	return m
 }

--- a/client/taskenv/services_test.go
+++ b/client/taskenv/services_test.go
@@ -239,6 +239,7 @@ func TestInterpolate_interpolateConnect(t *testing.T) {
 				},
 				Config: map[string]interface{}{
 					"${config1}": 1,
+					"port":       "${port1}",
 				},
 			},
 		},
@@ -347,6 +348,7 @@ func TestInterpolate_interpolateConnect(t *testing.T) {
 				},
 				Config: map[string]interface{}{
 					"_config1": 1,
+					"port":     "12345",
 				},
 			},
 		},

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -80,6 +80,7 @@ envoy_gateway_bind_addresses "<service>" {
   This option applies to terminating gateways that route to services addressed by a
   hostname.
 - `config` `(map: nil)` - Escape hatch for [Advanced Configuration] of Envoy.
+  Keys and values support [runtime variable interpolation][interpolation].
 
 #### `address` Parameters
 
@@ -98,18 +99,18 @@ envoy_gateway_bind_addresses "<service>" {
   on the gateway. If TLS is enabled, then each host defined in the `host` field will
   be added as a DNSSAN to the gateway's x509 certificate.
 
-- `tls_min_version` `(string: optional)` - Set the default minimum TLS version 
+- `tls_min_version` `(string: optional)` - Set the default minimum TLS version
   supported by the gateway. Refer to
   [`TLSMinVersion`](https://www.consul.io/docs/connect/config-entries/ingress-gateway#tlsminversion)
   in the Consul documentation for supported versions.
 
-- `tls_max_version` `(string: optional)` - Set the default maximum TLS version 
-  supported by the gateway. Refer to 
+- `tls_max_version` `(string: optional)` - Set the default maximum TLS version
+  supported by the gateway. Refer to
   [`TLSMaxVersion`](https://www.consul.io/docs/connect/config-entries/ingress-gateway#tlsmaxversion)
   in the Consul documentation for supported versions.
 
-- `cipher_suites` `(array<string>: optional)` - Set the default list of TLS 
-  cipher suites for the gateway's listeners. Refer to 
+- `cipher_suites` `(array<string>: optional)` - Set the default list of TLS
+  cipher suites for the gateway's listeners. Refer to
   [`CipherSuites`](https://www.consul.io/docs/connect/config-entries/ingress-gateway#ciphersuites)
   in the Consul documentation for the supported cipher suites.
 
@@ -655,6 +656,7 @@ job "countdash-mesh-two" {
 [proxy]: /docs/job-specification/gateway#proxy-parameters
 [linked-service]: /docs/job-specification/gateway#service-parameters-1
 [listener]: /docs/job-specification/gateway#listener-parameters
+[interpolation]: /docs/runtime/interpolation
 [service]: /docs/job-specification/gateway#service-parameters
 [service-default]: https://www.consul.io/docs/agent/config-entries/service-defaults
 [sidecar_task]: /docs/job-specification/sidecar_task

--- a/website/content/docs/job-specification/proxy.mdx
+++ b/website/content/docs/job-specification/proxy.mdx
@@ -63,7 +63,7 @@ job "countdash" {
 - `config` `(map: nil)` - Proxy configuration that's opaque to Nomad and
   passed directly to Consul. See [Consul Connect's
   documentation](https://www.consul.io/docs/connect/proxies/envoy#dynamic-configuration)
-  for details.
+  for details. Keys and values support [runtime variable interpolation][interpolation].
 
 ## `proxy` Examples
 

--- a/website/content/docs/job-specification/sidecar_task.mdx
+++ b/website/content/docs/job-specification/sidecar_task.mdx
@@ -134,6 +134,7 @@ meta.connect.sidecar_image = custom/envoy-${NOMAD_envoy_version}:latest
   to the same user the Nomad client is being run as.
 
 - `config` `(map: nil)` - Configuration provided to the driver for initialization.
+  Keys and values support [runtime variable interpolation][interpolation].
 
 - `env` `(map: nil)` - Map of environment variables used by the driver.
 


### PR DESCRIPTION
When configuring Consul Service Mesh, it's sometimes necessary to
provide dynamic value that are only known to Nomad at runtime. By
interpolating configuration values (in addition to configuration keys),
user are able to pass these dynamic values to Consul from their Nomad
jobs.

Closes #14403 