### PR TITLE
ui: remove extra space in menu footer

### DIFF
--- a/.changelog/14457.txt
+++ b/.changelog/14457.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Remove extra space when displaying the version in the menu footer.
+```

--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -131,8 +131,7 @@
     {{#if this.system.agent.version}}
       <footer class="gutter-footer">
         <span class="is-faded">
-          v
-          {{this.system.agent.version}}
+          v{{this.system.agent.version}}
         </span>
       </footer>
     {{/if}}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/775380/188228670-56ceb938-c329-4e8e-9722-6be7db17f0e2.png)

After:
![image](https://user-images.githubusercontent.com/775380/188228686-d12e3709-a372-44d0-b639-5f779edc9a76.png)
