### PR TITLE
cli: remove network from `quota status` output

### DIFF
--- a/.changelog/14468.txt
+++ b/.changelog/14468.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Removed deprecated network quota fields from `quota status` output
+```

--- a/command/quota_status.go
+++ b/command/quota_status.go
@@ -158,7 +158,7 @@ func formatQuotaLimits(spec *api.QuotaSpec, usages map[string]*api.QuotaUsage) s
 	sort.Sort(api.QuotaLimitSort(spec.Limits))
 
 	limits := make([]string, len(spec.Limits)+1)
-	limits[0] = "Region|CPU Usage|Memory Usage|Memory Max Usage|Network Usage|Variables Usage"
+	limits[0] = "Region|CPU Usage|Memory Usage|Memory Max Usage|Variables Usage"
 	i := 0
 	for _, specLimit := range spec.Limits {
 		i++
@@ -174,20 +174,14 @@ func formatQuotaLimits(spec *api.QuotaSpec, usages map[string]*api.QuotaUsage) s
 			return used, ok
 		}
 
-		specBits := 0
-		if len(specLimit.RegionLimit.Networks) == 1 {
-			specBits = *specLimit.RegionLimit.Networks[0].MBits
-		}
-
 		used, ok := lookupUsage()
 		if !ok {
 			cpu := fmt.Sprintf("- / %s", formatQuotaLimitInt(specLimit.RegionLimit.CPU))
 			memory := fmt.Sprintf("- / %s", formatQuotaLimitInt(specLimit.RegionLimit.MemoryMB))
 			memoryMax := fmt.Sprintf("- / %s", formatQuotaLimitInt(specLimit.RegionLimit.MemoryMaxMB))
-			net := fmt.Sprintf("- / %s", formatQuotaLimitInt(&specBits))
 
 			vars := fmt.Sprintf("- / %s", formatQuotaLimitInt(specLimit.VariablesLimit))
-			limits[i] = fmt.Sprintf("%s|%s|%s|%s|%s|%s", specLimit.Region, cpu, memory, memoryMax, net, vars)
+			limits[i] = fmt.Sprintf("%s|%s|%s|%s|%s", specLimit.Region, cpu, memory, memoryMax, vars)
 			continue
 		}
 
@@ -202,13 +196,8 @@ func formatQuotaLimits(spec *api.QuotaSpec, usages map[string]*api.QuotaUsage) s
 		memory := fmt.Sprintf("%d / %s", orZero(used.RegionLimit.MemoryMB), formatQuotaLimitInt(specLimit.RegionLimit.MemoryMB))
 		memoryMax := fmt.Sprintf("%d / %s", orZero(used.RegionLimit.MemoryMaxMB), formatQuotaLimitInt(specLimit.RegionLimit.MemoryMaxMB))
 
-		net := fmt.Sprintf("- / %s", formatQuotaLimitInt(&specBits))
-		if len(used.RegionLimit.Networks) == 1 {
-			net = fmt.Sprintf("%d / %s", *used.RegionLimit.Networks[0].MBits, formatQuotaLimitInt(&specBits))
-		}
-
 		vars := fmt.Sprintf("%d / %s", orZero(used.VariablesLimit), formatQuotaLimitInt(specLimit.VariablesLimit))
-		limits[i] = fmt.Sprintf("%s|%s|%s|%s|%s|%s", specLimit.Region, cpu, memory, memoryMax, net, vars)
+		limits[i] = fmt.Sprintf("%s|%s|%s|%s|%s", specLimit.Region, cpu, memory, memoryMax, vars)
 	}
 
 	return formatList(limits)


### PR DESCRIPTION
As reported in https://github.com/hashicorp/nomad/issues/9920#issuecomment-1236376964

Network quotas were removed in Nomad 1.0.4. Remove the fields no longer in use
from the `quota status` output.

---

This PR won't run the test here because it's in the OSS repo, but I've verified the test passes locally in the ENT repo. Adding a `fmt.Println` to the test in the appropriate spot shows the following new output:

```
Name        = test
Description = <none>
Limits      = 1

Quota Limits
Region  CPU Usage  Memory Usage  Memory Max Usage  Variables Usage
global  0 / 100    0 / inf       0 / inf           0 / inf
```