### PR TITLE
ui:  only long poll `/checks` endpoint when route is active

### DIFF
--- a/ui/app/routes/allocations/allocation.js
+++ b/ui/app/routes/allocations/allocation.js
@@ -48,5 +48,5 @@ export default class AllocationRoute extends Route.extend(WithWatchers) {
   @watchRecord('allocation') watch;
   @watchNonStoreRecords('allocation') watchHealthChecks;
 
-  @collect('watch') watchers;
+  @collect('watch', 'watchHealthChecks') watchers;
 }


### PR DESCRIPTION
Closes [14471](https://github.com/hashicorp/nomad/issues/14471).