### PR TITLE
core: verify leadership before marking clients down via heartbeating

### DIFF
--- a/.changelog/14481.txt
+++ b/.changelog/14481.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fixed a bug where unresponsive nodes could be evicted by non-leader
+```

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1964,7 +1964,7 @@ type Node struct {
 	StatusDescription string
 
 	// StatusUpdatedAt is the time stamp at which the state of the node was
-	// updated
+	// updated (unix seconds)
 	StatusUpdatedAt int64
 
 	// Events is the most recent set of events generated for the node,


### PR DESCRIPTION
This PR changes failed hearbeat processing so that we use `.VerifyLeader()`
to ensure the server is still the leader, instead of `.IsLeader()`. The
difference is that the later is a cached value indicating the raft state
for the agent, and the former enforces raft-read consensus.

With this, we can create an FSM snapshot and lookup the latest Node
status for the node that failed to update its node status in time,
just to make sure we didn't receive an update in the interim.

A more extreme version of this idea would be to use `.Barrier()`, which
enforces a write through the raft concensus, ensuring that all preceding
raft operations are processed before moving forward. This might be
useful in the case where the leader has a large queue of raft operations
to process, and node updates are stuck waiting in the queue while heartbeat
timers are being processed async regardless.
