### PR TITLE
Add client scheduling eligibility to heartbeat

### DIFF
--- a/.changelog/14483.txt
+++ b/.changelog/14483.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+metrics: Update client `node_scheduling_eligibility` value with server heartbeats.
+```

--- a/client/client.go
+++ b/client/client.go
@@ -1954,11 +1954,12 @@ func (c *Client) updateNodeStatus() error {
 				"req_latency", end.Sub(start), "heartbeat_ttl", oldTTL, "since_last_heartbeat", time.Since(last))
 		}
 	}
+
 	// Check heartbeat response for information about the server-side scheduling
 	// state of this node
 	c.UpdateConfig(func(c *config.Config) {
-		if resp.ClientStatus != nil {
-			c.Node.SchedulingEligibility = resp.ClientStatus.SchedulingEligibility
+		if resp.SchedulingEligibility != "" {
+			c.Node.SchedulingEligibility = resp.SchedulingEligibility
 		}
 	})
 

--- a/client/client.go
+++ b/client/client.go
@@ -1957,7 +1957,9 @@ func (c *Client) updateNodeStatus() error {
 	// Check heartbeat response for information about the server-side scheduling
 	// state of this node
 	c.UpdateConfig(func(c *config.Config) {
-		c.Node.SchedulingEligibility = resp.ClientStatus.SchedulingEligibility
+		if resp.ClientStatus != nil {
+			c.Node.SchedulingEligibility = resp.ClientStatus.SchedulingEligibility
+		}
 	})
 
 	// Update the number of nodes in the cluster so we can adjust our server

--- a/client/client.go
+++ b/client/client.go
@@ -1954,6 +1954,11 @@ func (c *Client) updateNodeStatus() error {
 				"req_latency", end.Sub(start), "heartbeat_ttl", oldTTL, "since_last_heartbeat", time.Since(last))
 		}
 	}
+	// Check heartbeat response for information about the server-side scheduling
+	// state of this node
+	c.UpdateConfig(func(c *config.Config) {
+		c.Node.SchedulingEligibility = resp.ClientStatus.SchedulingEligibility
+	})
 
 	// Update the number of nodes in the cluster so we can adjust our server
 	// rebalance rate.

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -199,7 +199,7 @@ func (n *Node) Register(args *structs.NodeRegisterRequest, reply *structs.NodeUp
 
 	n.srv.peerLock.RLock()
 	defer n.srv.peerLock.RUnlock()
-	if err := n.constructNodeServerInfoResponse(snap, reply); err != nil {
+	if err := n.constructNodeServerInfoResponse(args.Node.ID, snap, reply); err != nil {
 		n.logger.Error("failed to populate NodeUpdateResponse", "error", err)
 		return err
 	}
@@ -258,7 +258,7 @@ func equalDevices(n1, n2 *structs.Node) bool {
 }
 
 // updateNodeUpdateResponse assumes the n.srv.peerLock is held for reading.
-func (n *Node) constructNodeServerInfoResponse(snap *state.StateSnapshot, reply *structs.NodeUpdateResponse) error {
+func (n *Node) constructNodeServerInfoResponse(nodeID string, snap *state.StateSnapshot, reply *structs.NodeUpdateResponse) error {
 	reply.LeaderRPCAddr = string(n.srv.raft.Leader())
 
 	// Reply with config information required for future RPC requests
@@ -269,6 +269,12 @@ func (n *Node) constructNodeServerInfoResponse(snap *state.StateSnapshot, reply 
 				RPCAdvertiseAddr: v.RPCAddr.String(),
 				Datacenter:       v.Datacenter,
 			})
+	}
+
+	// Add ClientStatus information to heartbeat response.
+	node, _ := snap.NodeByID(nil, nodeID)
+	reply.ClientStatus = &structs.ClientStatus{
+		SchedulingEligibility: node.SchedulingEligibility,
 	}
 
 	// TODO(sean@): Use an indexed node count instead
@@ -564,7 +570,7 @@ func (n *Node) UpdateStatus(args *structs.NodeUpdateStatusRequest, reply *struct
 	reply.Index = index
 	n.srv.peerLock.RLock()
 	defer n.srv.peerLock.RUnlock()
-	if err := n.constructNodeServerInfoResponse(snap, reply); err != nil {
+	if err := n.constructNodeServerInfoResponse(node.GetID(), snap, reply); err != nil {
 		n.logger.Error("failed to populate NodeUpdateResponse", "error", err)
 		return err
 	}
@@ -821,7 +827,7 @@ func (n *Node) Evaluate(args *structs.NodeEvaluateRequest, reply *structs.NodeUp
 
 	n.srv.peerLock.RLock()
 	defer n.srv.peerLock.RUnlock()
-	if err := n.constructNodeServerInfoResponse(snap, reply); err != nil {
+	if err := n.constructNodeServerInfoResponse(node.GetID(), snap, reply); err != nil {
 		n.logger.Error("failed to populate NodeUpdateResponse", "error", err)
 		return err
 	}

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -273,9 +273,7 @@ func (n *Node) constructNodeServerInfoResponse(nodeID string, snap *state.StateS
 
 	// Add ClientStatus information to heartbeat response.
 	node, _ := snap.NodeByID(nil, nodeID)
-	reply.ClientStatus = &structs.ClientStatus{
-		SchedulingEligibility: node.SchedulingEligibility,
-	}
+	reply.SchedulingEligibility = node.SchedulingEligibility
 
 	// TODO(sean@): Use an indexed node count instead
 	//

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1361,7 +1361,17 @@ type NodeUpdateResponse struct {
 	// region.
 	Servers []*NodeServerInfo
 
+	// ClientStatus is used to inform clients what the server-side
+	// has for their scheduling status during heartbeats.
+	ClientStatus *ClientStatus
+
 	QueryMeta
+}
+
+// ClientStatus is used to inform clients what the server-side
+// has for their scheduling status during heartbeats.
+type ClientStatus struct {
+	SchedulingEligibility string
 }
 
 // NodeDrainUpdateResponse is used to respond to a node drain update

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1361,17 +1361,11 @@ type NodeUpdateResponse struct {
 	// region.
 	Servers []*NodeServerInfo
 
-	// ClientStatus is used to inform clients what the server-side
+	// SchedulingEligibility is used to inform clients what the server-side
 	// has for their scheduling status during heartbeats.
-	ClientStatus *ClientStatus
+	SchedulingEligibility string
 
 	QueryMeta
-}
-
-// ClientStatus is used to inform clients what the server-side
-// has for their scheduling status during heartbeats.
-type ClientStatus struct {
-	SchedulingEligibility string
 }
 
 // NodeDrainUpdateResponse is used to respond to a node drain update


### PR DESCRIPTION
Adds the client's scheduling eligibility to the NodeUpdateResponse so that the client is made aware of the server-side value. Takes a heartbeat to get the data to the client and one metrics window to shed the value with the former label, but it appears to be a net improvement over the current behavior.

Fixes #8965 