### PR TITLE
Check that JobPlanResponse Diff Type is None before checking for changes on getExitCode

### DIFF
--- a/.changelog/14492.txt
+++ b/.changelog/14492.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a bug where plans for periodic jobs would return exit code 1 when the job was already register
+```

--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -391,6 +391,10 @@ type namespaceIdPair struct {
 // * 0: No allocations created or destroyed.
 // * 1: Allocations created or destroyed.
 func getExitCode(resp *api.JobPlanResponse) int {
+	if resp.Diff.Type == "None" {
+		return 0
+	}
+
 	// Check for changes
 	for _, d := range resp.Annotations.DesiredTGUpdates {
 		if d.Stop+d.Place+d.Migrate+d.DestructiveUpdate+d.Canary > 0 {


### PR DESCRIPTION
Hi everyone! 

* This PR is strongly related to https://github.com/hashicorp/nomad/issues/2012, where if you:
`nomad plan ...`
and there are new allocations it should give an exit status code of 1.
* However if you do:
`nomad run ...`
and then:
`nomad plan ...`
It still returns an exit status code of 1.

These changes prevent that from happening, as if there wasn't any edits to the deployment file `resp.Diff.Type` is 'None', and it gives an exit status code of 0.
I'm wondering if this is the right solution for this problem or we are searching for a better one.
