### PR TITLE
[ui] Service health checks unique by allocation

### DIFF
--- a/ui/app/adapters/allocation.js
+++ b/ui/app/adapters/allocation.js
@@ -41,6 +41,11 @@ export default class AllocationAdapter extends Watchable {
       `/v1/client/allocation/${model.id}/checks`
     );
     const data = await res.json();
+    // Append allocation ID to each check
+    Object.values(data).forEach((check) => {
+      check.Alloc = model.id;
+      check.Timestamp = check.Timestamp * 1000; // Convert to milliseconds
+    });
     return data;
   }
 }

--- a/ui/app/components/allocation-service-sidebar.hbs
+++ b/ui/app/components/allocation-service-sidebar.hbs
@@ -103,11 +103,6 @@
 					<tr data-service-health={{row.model.Status}}>
 						<td class="name">
 							<span title={{row.model.Check}}>{{row.model.Check}}</span>
-							TODO: TEMP
-							{{format-ts
-								row.model.Timestamp
-							}}
-
 						</td>
 						<td class="status">
 							<span>

--- a/ui/app/components/allocation-service-sidebar.hbs
+++ b/ui/app/components/allocation-service-sidebar.hbs
@@ -1,5 +1,3 @@
-{{log "TODO: test" @service.healthChecks.length}}
-
 <div
 	class="sidebar has-subnav service-sidebar {{if this.isSideBarOpen "open"}}"
 	{{on-click-outside

--- a/ui/app/components/allocation-service-sidebar.hbs
+++ b/ui/app/components/allocation-service-sidebar.hbs
@@ -1,3 +1,5 @@
+{{log "TODO: test" @service.healthChecks.length}}
+
 <div
 	class="sidebar has-subnav service-sidebar {{if this.isSideBarOpen "open"}}"
 	{{on-click-outside
@@ -86,8 +88,8 @@
 				</div>
 			</div>
 		</div>
-		{{#if @service.mostRecentChecks.length}}
-			<ListTable class="health-checks" @source={{@service.mostRecentChecks}} as |t|>
+		{{#if this.checks.length}}
+			<ListTable class="health-checks" @source={{this.checks}} as |t|>
 				<t.head>
 					<th>
 						Name
@@ -103,6 +105,11 @@
 					<tr data-service-health={{row.model.Status}}>
 						<td class="name">
 							<span title={{row.model.Check}}>{{row.model.Check}}</span>
+							TODO: TEMP
+							{{format-ts
+								row.model.Timestamp
+							}}
+
 						</td>
 						<td class="status">
 							<span>

--- a/ui/app/components/allocation-service-sidebar.js
+++ b/ui/app/components/allocation-service-sidebar.js
@@ -32,9 +32,7 @@ export default class AllocationServiceSidebarComponent extends Component {
   }
 
   get aggregateStatus() {
-    return this.args.service?.mostRecentChecks?.any(
-      (check) => check.Status === 'failure'
-    )
+    return this.checks.any((check) => check.Status === 'failure')
       ? 'Unhealthy'
       : 'Healthy';
   }
@@ -45,7 +43,7 @@ export default class AllocationServiceSidebarComponent extends Component {
     // Our UI checks run every 2 seconds; but a check itself may only update every, say, minute.
     // Therefore, we'll have duplicate checks in a service's healthChecks array.
     // Only get the most recent check for each check.
-    return this.args.service.healthChecks
+    return (this.args.service.healthChecks || [])
       .filterBy('Alloc', allocID)
       .uniqBy('Timestamp')
       .sortBy('Timestamp')

--- a/ui/app/components/allocation-service-sidebar.js
+++ b/ui/app/components/allocation-service-sidebar.js
@@ -41,12 +41,16 @@ export default class AllocationServiceSidebarComponent extends Component {
 
   get checks() {
     if (!this.args.service || !this.args.allocation) return;
-    console.log('getting checks and', this.args.service);
     let allocID = this.args.allocation.id;
+    // Our UI checks run every 2 seconds; but a check itself may only update every, say, minute.
+    // Therefore, we'll have duplicate checks in a service's healthChecks array.
+    // Only get the most recent check for each check.
     return this.args.service.healthChecks
       .filterBy('Alloc', allocID)
+      .uniqBy('Timestamp')
       .sortBy('Timestamp')
-      .reverse();
-    // .uniqBy('Check');
+      .reverse()
+      .uniqBy('Check')
+      .sortBy('Check');
   }
 }

--- a/ui/app/components/allocation-service-sidebar.js
+++ b/ui/app/components/allocation-service-sidebar.js
@@ -38,14 +38,13 @@ export default class AllocationServiceSidebarComponent extends Component {
   }
 
   get checks() {
-    if (!this.args.service || !this.args.allocation) return null;
+    if (!this.args.service || !this.args.allocation) return [];
     let allocID = this.args.allocation.id;
     // Our UI checks run every 2 seconds; but a check itself may only update every, say, minute.
     // Therefore, we'll have duplicate checks in a service's healthChecks array.
     // Only get the most recent check for each check.
     return (this.args.service.healthChecks || [])
       .filterBy('Alloc', allocID)
-      .uniqBy('Timestamp')
       .sortBy('Timestamp')
       .reverse()
       .uniqBy('Check')

--- a/ui/app/components/allocation-service-sidebar.js
+++ b/ui/app/components/allocation-service-sidebar.js
@@ -38,4 +38,15 @@ export default class AllocationServiceSidebarComponent extends Component {
       ? 'Unhealthy'
       : 'Healthy';
   }
+
+  get checks() {
+    if (!this.args.service || !this.args.allocation) return;
+    console.log('getting checks and', this.args.service);
+    let allocID = this.args.allocation.id;
+    return this.args.service.healthChecks
+      .filterBy('Alloc', allocID)
+      .sortBy('Timestamp')
+      .reverse();
+    // .uniqBy('Check');
+  }
 }

--- a/ui/app/components/allocation-service-sidebar.js
+++ b/ui/app/components/allocation-service-sidebar.js
@@ -38,7 +38,7 @@ export default class AllocationServiceSidebarComponent extends Component {
   }
 
   get checks() {
-    if (!this.args.service || !this.args.allocation) return;
+    if (!this.args.service || !this.args.allocation) return null;
     let allocID = this.args.allocation.id;
     // Our UI checks run every 2 seconds; but a check itself may only update every, say, minute.
     // Therefore, we'll have duplicate checks in a service's healthChecks array.

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -71,7 +71,7 @@ export default class IndexController extends Controller.extend(Sortable) {
 
   @union('taskServices', 'groupServices') services;
 
-  @computed('model.healthChecks.{}', 'services')
+  @computed('model.{healthChecks,id}', 'services')
   get servicesWithHealthChecks() {
     return this.services.map((service) => {
       if (this.model.healthChecks) {

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -83,11 +83,15 @@ export default class IndexController extends Controller.extend(Sortable) {
             return currentServiceName === service.refID;
           }
         );
-        // Only append those healthchecks whose timestamps are not already found in service.healthChecks
         healthChecks.forEach((check) => {
           service.healthChecks.pushObject(check);
         });
       }
+      // Contextualize healthchecks for the allocation we're in
+      service.healthChecks = service.healthChecks.filterBy(
+        'Alloc',
+        this.model.id
+      );
       return service;
     });
   }

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -85,16 +85,7 @@ export default class IndexController extends Controller.extend(Sortable) {
         );
         // Only append those healthchecks whose timestamps are not already found in service.healthChecks
         healthChecks.forEach((check) => {
-          if (
-            !service.healthChecks.find(
-              (sc) =>
-                sc.Check === check.Check &&
-                sc.Timestamp === check.Timestamp &&
-                this.model.id === check.Alloc
-            )
-          ) {
-            service.healthChecks.pushObject(check);
-          }
+          service.healthChecks.pushObject(check);
         });
       }
       return service;

--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -88,11 +88,12 @@ export default class IndexController extends Controller.extend(Sortable) {
           if (
             !service.healthChecks.find(
               (sc) =>
-                sc.Check === check.Check && sc.Timestamp === check.Timestamp
+                sc.Check === check.Check &&
+                sc.Timestamp === check.Timestamp &&
+                this.model.id === check.Alloc
             )
           ) {
             service.healthChecks.pushObject(check);
-            service.healthChecks = [...service.healthChecks.slice(-10)];
           }
         });
       }

--- a/ui/app/serializers/service-fragment.js
+++ b/ui/app/serializers/service-fragment.js
@@ -3,9 +3,5 @@ import classic from 'ember-classic-decorator';
 
 @classic
 export default class ServiceFragmentSerializer extends ApplicationSerializer {
-  attrs = {
-    connect: 'Connect',
-  };
-
   arrayNullOverrides = ['Tags'];
 }

--- a/ui/app/serializers/task-group.js
+++ b/ui/app/serializers/task-group.js
@@ -9,6 +9,7 @@ export default class TaskGroup extends ApplicationSerializer {
 
   normalize(typeHash, hash) {
     if (hash.Services) {
+      console.log('yeah group has services, but what about allocs', hash);
       hash.Services.forEach((service) => {
         service.GroupName = hash.Name;
       });

--- a/ui/app/serializers/task-group.js
+++ b/ui/app/serializers/task-group.js
@@ -9,7 +9,6 @@ export default class TaskGroup extends ApplicationSerializer {
 
   normalize(typeHash, hash) {
     if (hash.Services) {
-      console.log('yeah group has services, but what about allocs', hash);
       hash.Services.forEach((service) => {
         service.GroupName = hash.Name;
       });

--- a/ui/tests/unit/controllers/allocations/allocation/index-test.js
+++ b/ui/tests/unit/controllers/allocations/allocation/index-test.js
@@ -9,8 +9,7 @@ module('Unit | Controller | allocations/allocation/index', function (hooks) {
       let controller = this.owner.lookup(
         'controller:allocations/allocation/index'
       );
-
-      controller.set('model', Allocation);
+      controller.set('model', JSON.parse(JSON.stringify(Allocation)));
 
       const groupFakePy = {
         refID: 'fakepy-group-fake-py',
@@ -95,12 +94,11 @@ module('Unit | Controller | allocations/allocation/index', function (hooks) {
       );
     });
 
-    test('it handles duplicate names', function (assert) {
+    test('it handles duplicate names', async function (assert) {
       let controller = this.owner.lookup(
         'controller:allocations/allocation/index'
       );
-
-      controller.set('model', Allocation);
+      controller.set('model', JSON.parse(JSON.stringify(Allocation)));
 
       const groupDupe = {
         refID: 'fakepy-duper',
@@ -229,6 +227,7 @@ var Allocation = {
   healthChecks: {
     c97fda942e772b43a5a537e5b0c8544c: {
       Check: 'service: "task-fake-py" check',
+      Alloc: 'my-alloc',
       Group: 'trying-multi-dupes.fakepy[1]',
       ID: 'c97fda942e772b43a5a537e5b0c8544c',
       Mode: 'healthiness',
@@ -241,6 +240,7 @@ var Allocation = {
     },
     '2e1bfc8ecc485ee86b972ae08e890152': {
       Check: 'task-happy',
+      Alloc: 'my-alloc',
       Group: 'trying-multi-dupes.fakepy[1]',
       ID: '2e1bfc8ecc485ee86b972ae08e890152',
       Mode: 'healthiness',
@@ -253,6 +253,7 @@ var Allocation = {
     },
     '6162723ab20b268c25eda69b400dc9c6': {
       Check: 'task-sad',
+      Alloc: 'my-alloc',
       Group: 'trying-multi-dupes.fakepy[1]',
       ID: '6162723ab20b268c25eda69b400dc9c6',
       Mode: 'healthiness',
@@ -266,6 +267,7 @@ var Allocation = {
     },
     a4a7050175a2b236edcf613cb3563753: {
       Check: 'task-sad2',
+      Alloc: 'my-alloc',
       Group: 'trying-multi-dupes.fakepy[1]',
       ID: 'a4a7050175a2b236edcf613cb3563753',
       Mode: 'healthiness',
@@ -279,6 +281,7 @@ var Allocation = {
     },
     '2dfe58eb841bdfa704f0ae9ef5b5af5e': {
       Check: 'tcp_probe',
+      Alloc: 'my-alloc',
       Group: 'trying-multi-dupes.fakepy[1]',
       ID: '2dfe58eb841bdfa704f0ae9ef5b5af5e',
       Mode: 'readiness',
@@ -290,6 +293,7 @@ var Allocation = {
     },
     '69021054964f4c461b3c4c4f456e16a8': {
       Check: 'happy',
+      Alloc: 'my-alloc',
       Group: 'trying-multi-dupes.fakepy[1]',
       ID: '69021054964f4c461b3c4c4f456e16a8',
       Mode: 'healthiness',
@@ -301,6 +305,7 @@ var Allocation = {
     },
     '913f5b725ceecdd5ff48a9a51ddf8513': {
       Check: 'sad',
+      Alloc: 'my-alloc',
       Group: 'trying-multi-dupes.fakepy[1]',
       ID: '913f5b725ceecdd5ff48a9a51ddf8513',
       Mode: 'healthiness',
@@ -313,6 +318,7 @@ var Allocation = {
     },
     bloop: {
       Check: 'is-alive',
+      Alloc: 'my-alloc',
       Group: 'trying-multi-dupes.fakepy[1]',
       ID: 'bloop',
       Mode: 'healthiness',
@@ -323,6 +329,7 @@ var Allocation = {
     },
     'group-dupe': {
       Check: 'is-alive',
+      Alloc: 'my-alloc',
       Group: 'trying-multi-dupes.fakepy[1]',
       ID: 'group-dupe',
       Mode: 'healthiness',
@@ -333,6 +340,7 @@ var Allocation = {
     },
     'task-dupe': {
       Check: 'is-alive',
+      Alloc: 'my-alloc',
       Group: 'trying-multi-dupes.fakepy[1]',
       ID: 'task-dupe',
       Mode: 'healthiness',
@@ -342,7 +350,7 @@ var Allocation = {
       Timestamp: 1662131947,
     },
   },
-
+  id: 'my-alloc',
   states: [
     {
       Name: 'http.server',


### PR DESCRIPTION
- Services/Service Fragments exist independent from a given allocation
- but service health checks exist within the context of an allocation
- and we still want some way to show all health checks for a given service

So, we bundle all health checks across all allocs into service.healthChecks, add an `Alloc` ID, and filter where we want to show that.

This gives us flexibility to show general service health in the future, plus a historical record of health within the confines of a given alloc.