### PR TITLE
test: fix concurrent map access in `TestStatsFetcher`

### DIFF
--- a/nomad/stats_fetcher_test.go
+++ b/nomad/stats_fetcher_test.go
@@ -71,7 +71,11 @@ func TestStatsFetcher(t *testing.T) {
 	// from it.
 	func() {
 		s1.statsFetcher.inflight[raft.ServerID(s3.config.NodeID)] = struct{}{}
-		defer delete(s1.statsFetcher.inflight, raft.ServerID(s3.config.NodeID))
+		defer func() {
+			s1.statsFetcher.inflightLock.Lock()
+			delete(s1.statsFetcher.inflight, raft.ServerID(s3.config.NodeID))
+			s1.statsFetcher.inflightLock.Unlock()
+		}()
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()


### PR DESCRIPTION
The map of in-flight RPCs gets cleared by a goroutine in the test without first locking it to make sure that it's not being accessed concurrently by the stats fetcher itself. This can cause a panic in tests.

I hit this panic while testing https://github.com/hashicorp/nomad/pull/14484. The line of code was last touched in https://github.com/hashicorp/nomad/pull/14441 (the autopilot migration) but that just changed the inputs, not the access pattern. We should probably fix this in backports too but I don't think I've ever seen the failure there so it may not be possible to hit without the new autopilot library.