### PR TITLE
client: fix RPC forwarding when querying checks for alloc.

### DIFF
--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -461,9 +461,9 @@ func (s *HTTPServer) allocChecks(allocID string, resp http.ResponseWriter, req *
 	case useLocalClient:
 		rpcErr = s.agent.Client().ClientRPC("Allocations.Checks", &args, &reply)
 	case useClientRPC:
-		rpcErr = s.agent.Client().RPC("Allocations.Checks", &args, &reply)
+		rpcErr = s.agent.Client().RPC("ClientAllocations.Checks", &args, &reply)
 	case useServerRPC:
-		rpcErr = s.agent.Server().RPC("Allocations.Checks", &args, &reply)
+		rpcErr = s.agent.Server().RPC("ClientAllocations.Checks", &args, &reply)
 	default:
 		rpcErr = CodedError(400, "No local Node and node_id not provided")
 	}


### PR DESCRIPTION
When querying the checks for an allocation, the request must be forwarded to the agent that is running the allocation. If the initial request is made to a server agent, the request can be made directly to the client agent running the allocation. If the request is made to a client agent not running the alloc, the request needs to be forwarded to a server and then the correct client.

I'll look into adding additional tests as a follow up PR so this can unblock E2E testing.