### PR TITLE
test: fix concurrent map access in `TestStatsFetcher`

### DIFF
--- a/nomad/stats_fetcher_test.go
+++ b/nomad/stats_fetcher_test.go
@@ -69,7 +69,12 @@ func TestStatsFetcher(t *testing.T) {
 	// from it.
 	func() {
 		s1.statsFetcher.inflight[string(s3.config.NodeID)] = struct{}{}
-		defer delete(s1.statsFetcher.inflight, string(s3.config.NodeID))
+
+		defer func() {
+			s1.statsFetcher.inflightLock.Lock()
+			delete(s1.statsFetcher.inflight, string(s3.config.NodeID))
+			s1.statsFetcher.inflightLock.Unlock()
+		}()
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()


### PR DESCRIPTION
The map of in-flight RPCs gets cleared by a goroutine in the test without first locking it to make sure that it's not being accessed concurrently by the stats fetcher itself. This can cause a panic in tests.

Backport of #14496 to 1.2.x