### PR TITLE
Respect `MinQueryIndex` in `QueryOptions` on getting state snapshot

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2706,11 +2706,15 @@ func (c *Client) deriveSIToken(alloc *structs.Allocation, taskNames []string) (m
 	}
 
 	req := &structs.DeriveSITokenRequest{
-		NodeID:       c.NodeID(),
-		SecretID:     c.secretNodeID(),
-		AllocID:      alloc.ID,
-		Tasks:        tasks,
-		QueryOptions: structs.QueryOptions{Region: c.Region()},
+		NodeID:   c.NodeID(),
+		SecretID: c.secretNodeID(),
+		AllocID:  alloc.ID,
+		Tasks:    tasks,
+		QueryOptions: structs.QueryOptions{
+			Region:        c.Region(),
+			AllowStale:    false,
+			MinQueryIndex: alloc.CreateIndex,
+		},
 	}
 
 	// Nicely ask Nomad Server for the tokens.


### PR DESCRIPTION
In an effort to fix the problems leading to https://github.com/hashicorp/nomad/issues/12261#issuecomment-1235367464 this uses `SnapshotMinIndex` instead of `Snapshot` with a minimum index from the `QueryOptions` provided. Is this approach reasonable, or is my understanding of the state snapshotting way off base?

I have had trouble reliably reproducing the behaviour described in #12261 in a test environment.