### PR TITLE
CI: make `make check` clean on macOS

### DIFF
--- a/client/fingerprint/cgroup.go
+++ b/client/fingerprint/cgroup.go
@@ -8,8 +8,7 @@ import (
 )
 
 const (
-	cgroupAvailable   = "available"
-	cgroupUnavailable = "unavailable"
+	cgroupUnavailable = "unavailable" // "available" is over in cgroup_linux
 
 	cgroupMountPointAttribute = "unique.cgroup.mountpoint"
 	cgroupVersionAttribute    = "unique.cgroup.version"

--- a/client/fingerprint/cgroup_linux.go
+++ b/client/fingerprint/cgroup_linux.go
@@ -6,6 +6,10 @@ import (
 	"fmt"
 )
 
+const (
+	cgroupAvailable = "available"
+)
+
 // Fingerprint tries to find a valid cgroup mount point and the version of cgroups
 // if a mount-point is present.
 func (f *CGroupFingerprint) Fingerprint(req *FingerprintRequest, resp *FingerprintResponse) error {

--- a/client/lib/cgutil/cpuset_manager.go
+++ b/client/lib/cgutil/cpuset_manager.go
@@ -2,7 +2,6 @@ package cgutil
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -59,18 +58,6 @@ type TaskCgroupInfo struct {
 	RelativeCgroupPath string
 	Cpuset             cpuset.CPUSet
 	Error              error
-}
-
-// identity is the "<allocID>.<taskName>" string that uniquely identifies an
-// individual instance of a task within the flat cgroup namespace
-type identity string
-
-func makeID(allocID, task string) identity {
-	return identity(fmt.Sprintf("%s.%s", allocID, task))
-}
-
-func makeScope(id identity) string {
-	return string(id) + ".scope"
 }
 
 // SplitPath determines the parent and cgroup from p.

--- a/client/lib/cgutil/cpuset_manager_v2.go
+++ b/client/lib/cgutil/cpuset_manager_v2.go
@@ -4,6 +4,7 @@ package cgutil
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -313,4 +314,16 @@ func getCPUsFromCgroupV2(group string) ([]uint16, error) {
 		return nil, err
 	}
 	return set.ToSlice(), nil
+}
+
+// identity is the "<allocID>.<taskName>" string that uniquely identifies an
+// individual instance of a task within the flat cgroup namespace
+type identity string
+
+func makeID(allocID, task string) identity {
+	return identity(fmt.Sprintf("%s.%s", allocID, task))
+}
+
+func makeScope(id identity) string {
+	return string(id) + ".scope"
 }


### PR DESCRIPTION
Running `make check` on macOS identifies some dead code because the code is used only with the Linux build tag. Move this code into appropriately-tagged code files.