### PR TITLE
On window blur, immediately hide keyboard hints

### DIFF
--- a/ui/app/components/keyboard-shortcuts-modal.js
+++ b/ui/app/components/keyboard-shortcuts-modal.js
@@ -8,6 +8,13 @@ export default class KeyboardShortcutsModalComponent extends Component {
   @service keyboard;
   @service config;
 
+  constructor() {
+    super(...arguments);
+    window.addEventListener('blur', (a, b, c) => {
+      this.keyboard.displayHints = false;
+    });
+  }
+
   escapeCommand = {
     label: 'Hide Keyboard Shortcuts',
     pattern: ['Escape'],

--- a/ui/app/components/keyboard-shortcuts-modal.js
+++ b/ui/app/components/keyboard-shortcuts-modal.js
@@ -1,3 +1,4 @@
+import { set } from '@ember/object';
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
@@ -10,8 +11,8 @@ export default class KeyboardShortcutsModalComponent extends Component {
 
   constructor() {
     super(...arguments);
-    window.addEventListener('blur', (a, b, c) => {
-      this.keyboard.displayHints = false;
+    window.addEventListener('blur', () => {
+      set(this, 'keyboard.displayHints', false);
     });
   }
 

--- a/ui/app/styles/components/keyboard-shortcuts-modal.scss
+++ b/ui/app/styles/components/keyboard-shortcuts-modal.scss
@@ -94,7 +94,6 @@
 
 // Global keyboard hint style
 
-// .display-hints {
 [data-shortcut] {
   background: lighten($nomad-green, 25%);
   border: 1px solid $nomad-green-dark;
@@ -113,7 +112,6 @@
     z-index: $z-tooltip;
   }
 }
-// }
 
 @keyframes slideIn {
   from {

--- a/ui/app/templates/csi/volumes/index.hbs
+++ b/ui/app/templates/csi/volumes/index.hbs
@@ -38,7 +38,7 @@
         @source={{p.list}}
         @sortProperty={{this.sortProperty}}
         @sortDescending={{this.sortDescending}}
-        @class="with-foot {{if this.keyboard.displayHints "display-hints"}}" as |t|
+        @class="with-foot" as |t|
       >
         <t.head>
           <t.sort-by @prop="name">


### PR DESCRIPTION
Resolves #14526

Solves an issue where you can have shift held and click away and hints are still shown.

This will **not** fix this for when you're taking screenshots, as cmd+shift+5 (and etc.) doesn't fire any window-or-document-detectable events, but it's still an improvement.