### PR TITLE
Backport client: fix data races in config handling (#14139) to 1.2.x

### DIFF
--- a/client/acl.go
+++ b/client/acl.go
@@ -81,7 +81,7 @@ func (c *Client) ResolveSecretToken(secretID string) (*structs.ACLToken, error) 
 
 func (c *Client) resolveTokenAndACL(secretID string) (*acl.ACL, *structs.ACLToken, error) {
 	// Fast-path if ACLs are disabled
-	if !c.config.ACLEnabled {
+	if !c.GetConfig().ACLEnabled {
 		return nil, nil, nil
 	}
 	defer metrics.MeasureSince([]string{"client", "acl", "resolve_token"}, time.Now())
@@ -127,7 +127,7 @@ func (c *Client) resolveTokenValue(secretID string) (*structs.ACLToken, error) {
 	raw, ok := c.tokenCache.Get(secretID)
 	if ok {
 		cached := raw.(*cachedACLValue)
-		if cached.Age() <= c.config.ACLTokenTTL {
+		if cached.Age() <= c.GetConfig().ACLTokenTTL {
 			return cached.Token, nil
 		}
 	}
@@ -179,7 +179,7 @@ func (c *Client) resolvePolicies(secretID string, policies []string) ([]*structs
 
 		// Check if the cached value is valid or expired
 		cached := raw.(*cachedACLValue)
-		if cached.Age() <= c.config.ACLPolicyTTL {
+		if cached.Age() <= c.GetConfig().ACLPolicyTTL {
 			out = append(out, cached.Policy)
 		} else {
 			expired = append(expired, cached.Policy)

--- a/client/agent_endpoint.go
+++ b/client/agent_endpoint.go
@@ -42,7 +42,7 @@ func (a *Agent) Profile(args *structs.AgentPprofRequest, reply *structs.AgentPpr
 	}
 
 	// If ACLs are disabled, EnableDebug must be enabled
-	if aclObj == nil && !a.c.config.EnableDebug {
+	if aclObj == nil && !a.c.GetConfig().EnableDebug {
 		return structs.ErrPermissionDenied
 	}
 
@@ -218,7 +218,7 @@ func (a *Agent) Host(args *structs.HostDataRequest, reply *structs.HostDataRespo
 		return err
 	}
 	if (aclObj != nil && !aclObj.AllowAgentRead()) ||
-		(aclObj == nil && !a.c.config.EnableDebug) {
+		(aclObj == nil && !a.c.GetConfig().EnableDebug) {
 		return structs.ErrPermissionDenied
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -168,15 +168,22 @@ type AllocRunner interface {
 // are expected to register as a schedulable node to the servers, and to
 // run allocations as determined by the servers.
 type Client struct {
-	config *config.Config
-	start  time.Time
+	start time.Time
 
 	// stateDB is used to efficiently store client state.
 	stateDB state.StateDB
 
-	// configCopy is a copy that should be passed to alloc-runners.
-	configCopy *config.Config
-	configLock sync.RWMutex
+	// config must only be accessed with lock held. To update the config, use the
+	// Client.UpdateConfig() helper. If you need more fine grained control use
+	// the following pattern:
+	//
+	// 	c.configLock.Lock()
+	// 	newConfig := c.config.Copy()
+	// 	// <mutate newConfig>
+	// 	c.config = newConfig
+	// 	c.configLock.Unlock()
+	config     *config.Config
+	configLock sync.Mutex
 
 	logger    hclog.InterceptLogger
 	rpcLogger hclog.Logger
@@ -417,14 +424,8 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 		return nil, fmt.Errorf("node setup failed: %v", err)
 	}
 
-	// Store the config copy before restoring state but after it has been
-	// initialized.
-	c.configLock.Lock()
-	c.configCopy = c.config.Copy()
-	c.configLock.Unlock()
-
 	fingerprintManager := NewFingerprintManager(
-		c.configCopy.PluginSingletonLoader, c.GetConfig, c.configCopy.Node,
+		cfg.PluginSingletonLoader, c.GetConfig, cfg.Node,
 		c.shutdownCh, c.updateNodeFromFingerprint, c.logger)
 
 	c.pluginManagers = pluginmanager.New(c.logger)
@@ -453,8 +454,8 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 	// Setup the driver manager
 	driverConfig := &drivermanager.Config{
 		Logger:              c.logger,
-		Loader:              c.configCopy.PluginSingletonLoader,
-		PluginConfig:        c.configCopy.NomadPluginConfig(),
+		Loader:              cfg.PluginSingletonLoader,
+		PluginConfig:        cfg.NomadPluginConfig(),
 		Updater:             c.batchNodeUpdates.updateNodeFromDriver,
 		EventHandlerFactory: c.GetTaskEventHandler,
 		State:               c.stateDB,
@@ -468,10 +469,10 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 	// Setup the device manager
 	devConfig := &devicemanager.Config{
 		Logger:        c.logger,
-		Loader:        c.configCopy.PluginSingletonLoader,
-		PluginConfig:  c.configCopy.NomadPluginConfig(),
+		Loader:        cfg.PluginSingletonLoader,
+		PluginConfig:  cfg.NomadPluginConfig(),
 		Updater:       c.batchNodeUpdates.updateNodeFromDevices,
-		StatsInterval: c.configCopy.StatsCollectionInterval,
+		StatsInterval: cfg.StatsCollectionInterval,
 		State:         c.stateDB,
 	}
 	devManager := devicemanager.New(devConfig)
@@ -491,7 +492,7 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 	go c.heartbeatStop.watch()
 
 	// Add the stats collector
-	statsCollector := stats.NewHostStatsCollector(c.logger, c.config.AllocDir, c.devicemanager.AllStats)
+	statsCollector := stats.NewHostStatsCollector(c.logger, cfg.AllocDir, c.devicemanager.AllStats)
 	c.hostStatsCollector = statsCollector
 
 	// Add the garbage collector
@@ -507,16 +508,14 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 	go c.garbageCollector.Run()
 
 	// Set the preconfigured list of static servers
-	c.configLock.RLock()
-	if len(c.configCopy.Servers) > 0 {
-		if _, err := c.setServersImpl(c.configCopy.Servers, true); err != nil {
+	if len(cfg.Servers) > 0 {
+		if _, err := c.setServersImpl(cfg.Servers, true); err != nil {
 			logger.Warn("none of the configured servers are valid", "error", err)
 		}
 	}
-	c.configLock.RUnlock()
 
 	// Setup Consul discovery if enabled
-	if c.configCopy.ConsulConfig.ClientAutoJoin != nil && *c.configCopy.ConsulConfig.ClientAutoJoin {
+	if cfg.ConsulConfig.ClientAutoJoin != nil && *cfg.ConsulConfig.ClientAutoJoin {
 		c.shutdownGroup.Go(c.consulDiscovery)
 		if c.servers.NumServers() == 0 {
 			// No configured servers; trigger discovery manually
@@ -550,7 +549,7 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 			"The safest way to proceed is to manually stop running task processes "+
 			"and remove Nomad's state and alloc directories before "+
 			"restarting. Lost allocations will be rescheduled.",
-			"state_dir", c.config.StateDir, "alloc_dir", c.config.AllocDir)
+			"state_dir", cfg.StateDir, "alloc_dir", cfg.AllocDir)
 		logger.Error("Corrupt state is often caused by a bug. Please " +
 			"report as much information as possible to " +
 			"https://github.com/hashicorp/nomad/issues")
@@ -584,8 +583,9 @@ func (c *Client) Ready() <-chan struct{} {
 // needed before we begin starting its various components.
 func (c *Client) init() error {
 	// Ensure the state dir exists if we have one
-	if c.config.StateDir != "" {
-		if err := os.MkdirAll(c.config.StateDir, 0700); err != nil {
+	conf := c.GetConfig()
+	if conf.StateDir != "" {
+		if err := os.MkdirAll(conf.StateDir, 0700); err != nil {
 			return fmt.Errorf("failed creating state dir: %s", err)
 		}
 
@@ -601,12 +601,14 @@ func (c *Client) init() error {
 			return fmt.Errorf("failed to find temporary directory for the StateDir: %v", err)
 		}
 
-		c.config.StateDir = p
+		conf = c.UpdateConfig(func(c *config.Config) {
+			c.StateDir = p
+		})
 	}
-	c.logger.Info("using state directory", "state_dir", c.config.StateDir)
+	c.logger.Info("using state directory", "state_dir", conf.StateDir)
 
 	// Open the state database
-	db, err := c.config.StateDBFactory(c.logger, c.config.StateDir)
+	db, err := conf.StateDBFactory(c.logger, conf.StateDir)
 	if err != nil {
 		return fmt.Errorf("failed to open state database: %v", err)
 	}
@@ -624,8 +626,8 @@ func (c *Client) init() error {
 	c.stateDB = db
 
 	// Ensure the alloc dir exists if we have one
-	if c.config.AllocDir != "" {
-		if err := os.MkdirAll(c.config.AllocDir, 0711); err != nil {
+	if conf.AllocDir != "" {
+		if err := os.MkdirAll(conf.AllocDir, 0711); err != nil {
 			return fmt.Errorf("failed creating alloc dir: %s", err)
 		}
 	} else {
@@ -645,20 +647,22 @@ func (c *Client) init() error {
 			return fmt.Errorf("failed to change directory permissions for the AllocDir: %v", err)
 		}
 
-		c.config.AllocDir = p
+		conf = c.UpdateConfig(func(c *config.Config) {
+			c.AllocDir = p
+		})
 	}
 
-	c.logger.Info("using alloc directory", "alloc_dir", c.config.AllocDir)
+	c.logger.Info("using alloc directory", "alloc_dir", conf.AllocDir)
 
 	reserved := "<none>"
-	if c.config.Node != nil && c.config.Node.ReservedResources != nil {
+	if conf.Node != nil && conf.Node.ReservedResources != nil {
 		// Node should always be non-nil due to initialization in the
 		// agent package, but don't risk a panic just for a long line.
-		reserved = c.config.Node.ReservedResources.Networks.ReservedHostPorts
+		reserved = conf.Node.ReservedResources.Networks.ReservedHostPorts
 	}
 	c.logger.Info("using dynamic ports",
-		"min", c.config.MinDynamicPort,
-		"max", c.config.MaxDynamicPort,
+		"min", conf.MinDynamicPort,
+		"max", conf.MaxDynamicPort,
 		"reserved", reserved,
 	)
 
@@ -699,9 +703,9 @@ func (c *Client) reloadTLSConnections(newConfig *nconfig.TLSConfig) error {
 
 	// Keep the client configuration up to date as we use configuration values to
 	// decide on what type of connections to accept
-	c.configLock.Lock()
-	c.config.TLSConfig = newConfig
-	c.configLock.Unlock()
+	c.UpdateConfig(func(c *config.Config) {
+		c.TLSConfig = newConfig
+	})
 
 	c.connPool.ReloadTLS(tlsWrap)
 
@@ -710,7 +714,8 @@ func (c *Client) reloadTLSConnections(newConfig *nconfig.TLSConfig) error {
 
 // Reload allows a client to reload its configuration on the fly
 func (c *Client) Reload(newConfig *config.Config) error {
-	shouldReloadTLS, err := tlsutil.ShouldReloadRPCConnections(c.config.TLSConfig, newConfig.TLSConfig)
+	existing := c.GetConfig()
+	shouldReloadTLS, err := tlsutil.ShouldReloadRPCConnections(existing.TLSConfig, newConfig.TLSConfig)
 	if err != nil {
 		c.logger.Error("error parsing TLS configuration", "error", err)
 		return err
@@ -729,31 +734,50 @@ func (c *Client) Leave() error {
 	return nil
 }
 
-// GetConfig returns the config of the client
+// GetConfig returns the config of the client. Do *not* mutate without first
+// calling Copy().
 func (c *Client) GetConfig() *config.Config {
 	c.configLock.Lock()
 	defer c.configLock.Unlock()
-	return c.configCopy
+	return c.config
+}
+
+// UpdateConfig allows mutating the configuration. The updated configuration is
+// returned.
+func (c *Client) UpdateConfig(cb func(*config.Config)) *config.Config {
+	c.configLock.Lock()
+	defer c.configLock.Unlock()
+
+	// Create a copy of the active config
+	newConfig := c.config.Copy()
+
+	// Pass the copy to the supplied callback for mutation
+	cb(newConfig)
+
+	// Set new config struct
+	c.config = newConfig
+
+	return newConfig
 }
 
 // Datacenter returns the datacenter for the given client
 func (c *Client) Datacenter() string {
-	return c.config.Node.Datacenter
+	return c.GetConfig().Node.Datacenter
 }
 
 // Region returns the region for the given client
 func (c *Client) Region() string {
-	return c.config.Region
+	return c.GetConfig().Region
 }
 
 // NodeID returns the node ID for the given client
 func (c *Client) NodeID() string {
-	return c.config.Node.ID
+	return c.GetConfig().Node.ID
 }
 
 // secretNodeID returns the secret node ID for the given client
 func (c *Client) secretNodeID() string {
-	return c.config.Node.SecretID
+	return c.GetConfig().Node.SecretID
 }
 
 // RPCMajorVersion returns the structs.ApiMajorVersion supported by the
@@ -788,7 +812,7 @@ func (c *Client) Shutdown() error {
 	c.garbageCollector.Stop()
 
 	arGroup := group{}
-	if c.config.DevMode {
+	if c.GetConfig().DevMode {
 		// In DevMode destroy all the running allocations.
 		for _, ar := range c.getAllocRunners() {
 			ar.Destroy()
@@ -890,9 +914,7 @@ func (c *Client) RestartAllocation(allocID, taskName string) error {
 
 // Node returns the locally registered node
 func (c *Client) Node() *structs.Node {
-	c.configLock.RLock()
-	defer c.configLock.RUnlock()
-	return c.configCopy.Node
+	return c.GetConfig().Node
 }
 
 // getAllocRunner returns an AllocRunner or an UnknownAllocation error if the
@@ -988,11 +1010,12 @@ func (c *Client) computeAllocatedDeviceGroupStats(devices []*structs.AllocatedDe
 // allocation, and has been created by a trusted party that has privileged
 // knowledge of the client's secret identifier
 func (c *Client) ValidateMigrateToken(allocID, migrateToken string) bool {
-	if !c.config.ACLEnabled {
+	conf := c.GetConfig()
+	if !conf.ACLEnabled {
 		return true
 	}
 
-	return structs.CompareMigrateToken(allocID, c.secretNodeID(), migrateToken)
+	return structs.CompareMigrateToken(allocID, conf.Node.SecretID, migrateToken)
 }
 
 // GetAllocFS returns the AllocFS interface for the alloc dir of an allocation
@@ -1095,7 +1118,8 @@ func (c *Client) setServersImpl(in []string, force bool) (int, error) {
 // If there are errors restoring a specific allocation it is marked
 // as failed whenever possible.
 func (c *Client) restoreState() error {
-	if c.config.DevMode {
+	conf := c.GetConfig()
+	if conf.DevMode {
 		return nil
 	}
 
@@ -1139,11 +1163,10 @@ func (c *Client) restoreState() error {
 		prevAllocWatcher := allocwatcher.NoopPrevAlloc{}
 		prevAllocMigrator := allocwatcher.NoopPrevAlloc{}
 
-		c.configLock.RLock()
 		arConf := &allocrunner.Config{
 			Alloc:               alloc,
 			Logger:              c.logger,
-			ClientConfig:        c.configCopy,
+			ClientConfig:        conf,
 			StateDB:             c.stateDB,
 			StateUpdater:        c,
 			DeviceStatsReporter: c,
@@ -1162,7 +1185,6 @@ func (c *Client) restoreState() error {
 			RPCClient:           c,
 			Getter:              c.getter,
 		}
-		c.configLock.RUnlock()
 
 		ar, err := allocrunner.NewAllocRunner(arConf)
 		if err != nil {
@@ -1306,13 +1328,13 @@ func (c *Client) NumAllocs() int {
 	return n
 }
 
-// nodeID restores, or generates if necessary, a unique node ID and SecretID.
-// The node ID is, if available, a persistent unique ID.  The secret ID is a
-// high-entropy random UUID.
-func (c *Client) nodeID() (id, secret string, err error) {
+// ensureNodeID restores, or generates if necessary, a unique node ID and
+// SecretID.  The node ID is, if available, a persistent unique ID.  The secret
+// ID is a high-entropy random UUID.
+func ensureNodeID(conf *config.Config) (id, secret string, err error) {
 	var hostID string
 	hostInfo, err := host.Info()
-	if !c.config.NoHostUUID && err == nil {
+	if !conf.NoHostUUID && err == nil {
 		if hashed, ok := helper.HashUUID(hostInfo.HostID); ok {
 			hostID = hashed
 		}
@@ -1325,19 +1347,19 @@ func (c *Client) nodeID() (id, secret string, err error) {
 	}
 
 	// Do not persist in dev mode
-	if c.config.DevMode {
+	if conf.DevMode {
 		return hostID, uuid.Generate(), nil
 	}
 
 	// Attempt to read existing ID
-	idPath := filepath.Join(c.config.StateDir, "client-id")
+	idPath := filepath.Join(conf.StateDir, "client-id")
 	idBuf, err := ioutil.ReadFile(idPath)
 	if err != nil && !os.IsNotExist(err) {
 		return "", "", err
 	}
 
 	// Attempt to read existing secret ID
-	secretPath := filepath.Join(c.config.StateDir, "secret-id")
+	secretPath := filepath.Join(conf.StateDir, "secret-id")
 	secretBuf, err := ioutil.ReadFile(secretPath)
 	if err != nil && !os.IsNotExist(err) {
 		return "", "", err
@@ -1372,13 +1394,18 @@ func (c *Client) nodeID() (id, secret string, err error) {
 
 // setupNode is used to setup the initial node
 func (c *Client) setupNode() error {
-	node := c.config.Node
+	c.configLock.Lock()
+	defer c.configLock.Unlock()
+
+	newConfig := c.config.Copy()
+	node := newConfig.Node
 	if node == nil {
 		node = &structs.Node{}
-		c.config.Node = node
+		newConfig.Node = node
 	}
+
 	// Generate an ID and secret for the node
-	id, secretID, err := c.nodeID()
+	id, secretID, err := ensureNodeID(newConfig)
 	if err != nil {
 		return fmt.Errorf("node ID setup failed: %v", err)
 	}
@@ -1405,8 +1432,8 @@ func (c *Client) setupNode() error {
 	}
 	if node.NodeResources == nil {
 		node.NodeResources = &structs.NodeResources{}
-		node.NodeResources.MinDynamicPort = c.config.MinDynamicPort
-		node.NodeResources.MaxDynamicPort = c.config.MaxDynamicPort
+		node.NodeResources.MinDynamicPort = newConfig.MinDynamicPort
+		node.NodeResources.MaxDynamicPort = newConfig.MaxDynamicPort
 	}
 	if node.ReservedResources == nil {
 		node.ReservedResources = &structs.NodeReservedResources{}
@@ -1424,9 +1451,9 @@ func (c *Client) setupNode() error {
 		node.Name, _ = os.Hostname()
 	}
 	if node.HostVolumes == nil {
-		if l := len(c.config.HostVolumes); l != 0 {
+		if l := len(newConfig.HostVolumes); l != 0 {
 			node.HostVolumes = make(map[string]*structs.ClientHostVolumeConfig, l)
-			for k, v := range c.config.HostVolumes {
+			for k, v := range newConfig.HostVolumes {
 				if _, err := os.Stat(v.Path); err != nil {
 					return fmt.Errorf("failed to validate volume %s, err: %v", v.Name, err)
 				}
@@ -1435,9 +1462,9 @@ func (c *Client) setupNode() error {
 		}
 	}
 	if node.HostNetworks == nil {
-		if l := len(c.config.HostNetworks); l != 0 {
+		if l := len(newConfig.HostNetworks); l != 0 {
 			node.HostNetworks = make(map[string]*structs.ClientHostNetworkConfig, l)
-			for k, v := range c.config.HostNetworks {
+			for k, v := range newConfig.HostNetworks {
 				node.HostNetworks[k] = v.Copy()
 			}
 		}
@@ -1462,6 +1489,7 @@ func (c *Client) setupNode() error {
 		node.Meta["connect.proxy_concurrency"] = defaultConnectProxyConcurrency
 	}
 
+	c.config = newConfig
 	return nil
 }
 
@@ -1472,34 +1500,35 @@ func (c *Client) updateNodeFromFingerprint(response *fingerprint.FingerprintResp
 	defer c.configLock.Unlock()
 
 	nodeHasChanged := false
+	newConfig := c.config.Copy()
 
 	for name, newVal := range response.Attributes {
-		oldVal := c.config.Node.Attributes[name]
+		oldVal := newConfig.Node.Attributes[name]
 		if oldVal == newVal {
 			continue
 		}
 
 		nodeHasChanged = true
 		if newVal == "" {
-			delete(c.config.Node.Attributes, name)
+			delete(newConfig.Node.Attributes, name)
 		} else {
-			c.config.Node.Attributes[name] = newVal
+			newConfig.Node.Attributes[name] = newVal
 		}
 	}
 
 	// update node links and resources from the diff created from
 	// fingerprinting
 	for name, newVal := range response.Links {
-		oldVal := c.config.Node.Links[name]
+		oldVal := newConfig.Node.Links[name]
 		if oldVal == newVal {
 			continue
 		}
 
 		nodeHasChanged = true
 		if newVal == "" {
-			delete(c.config.Node.Links, name)
+			delete(newConfig.Node.Links, name)
 		} else {
-			c.config.Node.Links[name] = newVal
+			newConfig.Node.Links[name] = newVal
 		}
 	}
 
@@ -1509,9 +1538,9 @@ func (c *Client) updateNodeFromFingerprint(response *fingerprint.FingerprintResp
 	if response.Resources != nil {
 		response.Resources.Networks = updateNetworks(
 			response.Resources.Networks,
-			c.config)
-		if !c.config.Node.Resources.Equals(response.Resources) {
-			c.config.Node.Resources.Merge(response.Resources)
+			newConfig)
+		if !newConfig.Node.Resources.Equals(response.Resources) {
+			newConfig.Node.Resources.Merge(response.Resources)
 			nodeHasChanged = true
 		}
 	}
@@ -1521,26 +1550,27 @@ func (c *Client) updateNodeFromFingerprint(response *fingerprint.FingerprintResp
 	if response.NodeResources != nil {
 		response.NodeResources.Networks = updateNetworks(
 			response.NodeResources.Networks,
-			c.config)
-		if !c.config.Node.NodeResources.Equals(response.NodeResources) {
-			c.config.Node.NodeResources.Merge(response.NodeResources)
+			newConfig)
+		if !newConfig.Node.NodeResources.Equals(response.NodeResources) {
+			newConfig.Node.NodeResources.Merge(response.NodeResources)
 			nodeHasChanged = true
 		}
 
-		response.NodeResources.MinDynamicPort = c.config.MinDynamicPort
-		response.NodeResources.MaxDynamicPort = c.config.MaxDynamicPort
-		if c.config.Node.NodeResources.MinDynamicPort != response.NodeResources.MinDynamicPort ||
-			c.config.Node.NodeResources.MaxDynamicPort != response.NodeResources.MaxDynamicPort {
+		response.NodeResources.MinDynamicPort = newConfig.MinDynamicPort
+		response.NodeResources.MaxDynamicPort = newConfig.MaxDynamicPort
+		if newConfig.Node.NodeResources.MinDynamicPort != response.NodeResources.MinDynamicPort ||
+			newConfig.Node.NodeResources.MaxDynamicPort != response.NodeResources.MaxDynamicPort {
 			nodeHasChanged = true
 		}
 
 	}
 
 	if nodeHasChanged {
-		c.updateNodeLocked()
+		c.config = newConfig
+		c.updateNode()
 	}
 
-	return c.configCopy.Node
+	return newConfig.Node
 }
 
 // updateNetworks filters and overrides network speed of host networks based
@@ -1581,7 +1611,7 @@ func updateNetworks(up structs.Networks, c *config.Config) structs.Networks {
 
 // retryIntv calculates a retry interval value given the base
 func (c *Client) retryIntv(base time.Duration) time.Duration {
-	if c.config.DevMode {
+	if c.GetConfig().DevMode {
 		return devModeRetryIntv
 	}
 	return base + lib.RandomStagger(base)
@@ -1603,7 +1633,7 @@ func (c *Client) registerAndHeartbeat() {
 	// we want to do this quickly. We want to do it extra quickly
 	// in development mode.
 	var heartbeat <-chan time.Time
-	if c.config.DevMode {
+	if c.GetConfig().DevMode {
 		heartbeat = time.After(0)
 	} else {
 		heartbeat = time.After(lib.RandomStagger(initialHeartbeatStagger))
@@ -1647,7 +1677,7 @@ func (c *Client) lastHeartbeat() time.Time {
 // getHeartbeatRetryIntv is used to retrieve the time to wait before attempting
 // another heartbeat.
 func (c *Client) getHeartbeatRetryIntv(err error) time.Duration {
-	if c.config.DevMode {
+	if c.GetConfig().DevMode {
 		return devModeRetryIntv
 	}
 
@@ -1833,9 +1863,8 @@ func (c *Client) retryRegisterNode() {
 
 // registerNode is used to register the node or update the registration
 func (c *Client) registerNode() error {
-	node := c.Node()
 	req := structs.NodeRegisterRequest{
-		Node:         node,
+		Node:         c.Node(),
 		WriteRequest: structs.WriteRequest{Region: c.Region()},
 	}
 	var resp structs.NodeUpdateResponse
@@ -1844,10 +1873,9 @@ func (c *Client) registerNode() error {
 	}
 
 	// Update the node status to ready after we register.
-	c.configLock.Lock()
-	node.Status = structs.NodeStatusReady
-	c.config.Node.Status = structs.NodeStatusReady
-	c.configLock.Unlock()
+	c.UpdateConfig(func(c *config.Config) {
+		c.Node.Status = structs.NodeStatusReady
+	})
 
 	c.logger.Info("node registration complete")
 	if len(resp.EvalIDs) != 0 {
@@ -2233,14 +2261,9 @@ OUTER:
 	}
 }
 
-// updateNode updates the Node copy and triggers the client to send the updated
-// Node to the server. This should be done while the caller holds the
-// configLock lock.
-func (c *Client) updateNodeLocked() {
-	// Update the config copy.
-	node := c.config.Node.Copy()
-	c.configCopy.Node = node
-
+// updateNode signals the client to send the updated
+// Node to the server.
+func (c *Client) updateNode() {
 	select {
 	case c.triggerNodeUpdate <- struct{}{}:
 		// Node update goroutine was released to execute
@@ -2461,20 +2484,16 @@ func (c *Client) addAlloc(alloc *structs.Allocation, migrateToken string) error 
 		PreviousRunner:   c.allocs[alloc.PreviousAllocation],
 		PreemptedRunners: preemptedAllocs,
 		RPC:              c,
-		Config:           c.configCopy,
+		Config:           c.GetConfig(),
 		MigrateToken:     migrateToken,
 		Logger:           c.logger,
 	}
 	prevAllocWatcher, prevAllocMigrator := allocwatcher.NewAllocWatcher(watcherConfig)
 
-	// Copy the config since the node can be swapped out as it is being updated.
-	// The long term fix is to pass in the config and node separately and then
-	// we don't have to do a copy.
-	c.configLock.RLock()
 	arConf := &allocrunner.Config{
 		Alloc:               alloc,
 		Logger:              c.logger,
-		ClientConfig:        c.configCopy,
+		ClientConfig:        c.GetConfig(),
 		StateDB:             c.stateDB,
 		Consul:              c.consulService,
 		ConsulProxies:       c.consulProxies,
@@ -2492,7 +2511,6 @@ func (c *Client) addAlloc(alloc *structs.Allocation, migrateToken string) error 
 		RPCClient:           c,
 		Getter:              c.getter,
 	}
-	c.configLock.RUnlock()
 
 	ar, err := allocrunner.NewAllocRunner(arConf)
 	if err != nil {
@@ -2521,7 +2539,7 @@ func (c *Client) setupConsulTokenClient() error {
 // with vault.
 func (c *Client) setupVaultClient() error {
 	var err error
-	c.vaultClient, err = vaultclient.NewVaultClient(c.config.VaultConfig, c.logger, c.deriveToken)
+	c.vaultClient, err = vaultclient.NewVaultClient(c.GetConfig().VaultConfig, c.logger, c.deriveToken)
 	if err != nil {
 		return err
 	}
@@ -2707,7 +2725,8 @@ func taskIsPresent(taskName string, tasks []*structs.Task) bool {
 
 // triggerDiscovery causes a Consul discovery to begin (if one hasn't already)
 func (c *Client) triggerDiscovery() {
-	if c.configCopy.ConsulConfig.ClientAutoJoin != nil && *c.configCopy.ConsulConfig.ClientAutoJoin {
+	config := c.GetConfig()
+	if config.ConsulConfig.ClientAutoJoin != nil && *config.ConsulConfig.ClientAutoJoin {
 		select {
 		case c.triggerDiscoveryCh <- struct{}{}:
 			// Discovery goroutine was released to execute
@@ -2760,7 +2779,7 @@ func (c *Client) consulDiscoveryImpl() error {
 		},
 	}
 
-	serviceName := c.configCopy.ConsulConfig.ServerServiceName
+	serviceName := c.GetConfig().ConsulConfig.ServerServiceName
 	var mErr multierror.Error
 	var nomadServers servers.Servers
 	consulLogger.Debug("bootstrap contacting Consul DCs", "consul_dcs", dcs)
@@ -2855,13 +2874,14 @@ func (c *Client) emitStats() {
 	next := time.NewTimer(0)
 	defer next.Stop()
 	for {
+		config := c.GetConfig()
 		select {
 		case <-next.C:
 			err := c.hostStatsCollector.Collect()
-			next.Reset(c.config.StatsCollectionInterval)
+			next.Reset(config.StatsCollectionInterval)
 			if err != nil {
 				c.logger.Warn("error fetching host resource usage stats", "error", err)
-			} else if c.config.PublishNodeMetrics {
+			} else if config.PublishNodeMetrics {
 				// Publish Node metrics if operator has opted in
 				c.emitHostStats()
 			}
@@ -2922,9 +2942,7 @@ func (c *Client) setGaugeForDiskStats(nodeID string, hStats *stats.HostStats, ba
 
 // setGaugeForAllocationStats proxies metrics for allocation specific statistics
 func (c *Client) setGaugeForAllocationStats(nodeID string, baseLabels []metrics.Label) {
-	c.configLock.RLock()
-	node := c.configCopy.Node
-	c.configLock.RUnlock()
+	node := c.GetConfig().Node
 	total := node.NodeResources
 	res := node.ReservedResources
 	allocated := c.getAllocatedResources(node)
@@ -3023,14 +3041,11 @@ func (c *Client) emitClientMetrics() {
 
 // labels takes the base labels and appends the node state
 func (c *Client) labels() []metrics.Label {
-	c.configLock.RLock()
-	nodeStatus := c.configCopy.Node.Status
-	nodeEligibility := c.configCopy.Node.SchedulingEligibility
-	c.configLock.RUnlock()
+	node := c.Node()
 
 	return append(c.baseLabels,
-		metrics.Label{Name: "node_status", Value: nodeStatus},
-		metrics.Label{Name: "node_scheduling_eligibility", Value: nodeEligibility},
+		metrics.Label{Name: "node_status", Value: node.Status},
+		metrics.Label{Name: "node_scheduling_eligibility", Value: node.SchedulingEligibility},
 	)
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -193,63 +193,55 @@ func TestClient_Fingerprint_Periodic(t *testing.T) {
 	})
 	defer cleanup()
 
-	node := c1.config.Node
-	{
-		// Ensure the mock driver is registered on the client
-		testutil.WaitForResult(func() (bool, error) {
-			c1.configLock.Lock()
-			defer c1.configLock.Unlock()
+	// Ensure the mock driver is registered on the client
+	testutil.WaitForResult(func() (bool, error) {
+		node := c1.Node()
 
-			// assert that the driver is set on the node attributes
-			mockDriverInfoAttr := node.Attributes["driver.mock_driver"]
-			if mockDriverInfoAttr == "" {
-				return false, fmt.Errorf("mock driver is empty when it should be set on the node attributes")
-			}
+		// assert that the driver is set on the node attributes
+		mockDriverInfoAttr := node.Attributes["driver.mock_driver"]
+		if mockDriverInfoAttr == "" {
+			return false, fmt.Errorf("mock driver is empty when it should be set on the node attributes")
+		}
 
-			mockDriverInfo := node.Drivers["mock_driver"]
+		mockDriverInfo := node.Drivers["mock_driver"]
 
-			// assert that the Driver information for the node is also set correctly
-			if mockDriverInfo == nil {
-				return false, fmt.Errorf("mock driver is nil when it should be set on node Drivers")
-			}
-			if !mockDriverInfo.Detected {
-				return false, fmt.Errorf("mock driver should be set as detected")
-			}
-			if !mockDriverInfo.Healthy {
-				return false, fmt.Errorf("mock driver should be set as healthy")
-			}
-			if mockDriverInfo.HealthDescription == "" {
-				return false, fmt.Errorf("mock driver description should not be empty")
-			}
-			return true, nil
-		}, func(err error) {
-			t.Fatalf("err: %v", err)
-		})
-	}
+		// assert that the Driver information for the node is also set correctly
+		if mockDriverInfo == nil {
+			return false, fmt.Errorf("mock driver is nil when it should be set on node Drivers")
+		}
+		if !mockDriverInfo.Detected {
+			return false, fmt.Errorf("mock driver should be set as detected")
+		}
+		if !mockDriverInfo.Healthy {
+			return false, fmt.Errorf("mock driver should be set as healthy")
+		}
+		if mockDriverInfo.HealthDescription == "" {
+			return false, fmt.Errorf("mock driver description should not be empty")
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
 
-	{
-		testutil.WaitForResult(func() (bool, error) {
-			c1.configLock.Lock()
-			defer c1.configLock.Unlock()
-			mockDriverInfo := node.Drivers["mock_driver"]
-			// assert that the Driver information for the node is also set correctly
-			if mockDriverInfo == nil {
-				return false, fmt.Errorf("mock driver is nil when it should be set on node Drivers")
-			}
-			if mockDriverInfo.Detected {
-				return false, fmt.Errorf("mock driver should not be set as detected")
-			}
-			if mockDriverInfo.Healthy {
-				return false, fmt.Errorf("mock driver should not be set as healthy")
-			}
-			if mockDriverInfo.HealthDescription == "" {
-				return false, fmt.Errorf("mock driver description should not be empty")
-			}
-			return true, nil
-		}, func(err error) {
-			t.Fatalf("err: %v", err)
-		})
-	}
+	testutil.WaitForResult(func() (bool, error) {
+		mockDriverInfo := c1.Node().Drivers["mock_driver"]
+		// assert that the Driver information for the node is also set correctly
+		if mockDriverInfo == nil {
+			return false, fmt.Errorf("mock driver is nil when it should be set on node Drivers")
+		}
+		if mockDriverInfo.Detected {
+			return false, fmt.Errorf("mock driver should not be set as detected")
+		}
+		if mockDriverInfo.Healthy {
+			return false, fmt.Errorf("mock driver should not be set as healthy")
+		}
+		if mockDriverInfo.HealthDescription == "" {
+			return false, fmt.Errorf("mock driver description should not be empty")
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
 }
 
 // TestClient_MixedTLS asserts that when a server is running with TLS enabled
@@ -1120,17 +1112,18 @@ func TestClient_UpdateNodeFromDevicesAccumulates(t *testing.T) {
 	})
 
 	// initial check
+	conf := client.GetConfig()
 	expectedResources := &structs.NodeResources{
 		// computed through test client initialization
-		Networks:     client.configCopy.Node.NodeResources.Networks,
-		NodeNetworks: client.configCopy.Node.NodeResources.NodeNetworks,
-		Disk:         client.configCopy.Node.NodeResources.Disk,
+		Networks:     conf.Node.NodeResources.Networks,
+		NodeNetworks: conf.Node.NodeResources.NodeNetworks,
+		Disk:         conf.Node.NodeResources.Disk,
 
 		// injected
 		Cpu: structs.NodeCpuResources{
 			CpuShares:          123,
-			ReservableCpuCores: client.configCopy.Node.NodeResources.Cpu.ReservableCpuCores,
-			TotalCpuCores:      client.configCopy.Node.NodeResources.Cpu.TotalCpuCores,
+			ReservableCpuCores: conf.Node.NodeResources.Cpu.ReservableCpuCores,
+			TotalCpuCores:      conf.Node.NodeResources.Cpu.TotalCpuCores,
 		},
 		Memory: structs.NodeMemoryResources{MemoryMB: 1024},
 		Devices: []*structs.NodeDeviceResource{
@@ -1141,7 +1134,7 @@ func TestClient_UpdateNodeFromDevicesAccumulates(t *testing.T) {
 		},
 	}
 
-	assert.EqualValues(t, expectedResources, client.configCopy.Node.NodeResources)
+	assert.EqualValues(t, expectedResources, conf.Node.NodeResources)
 
 	// overrides of values
 
@@ -1162,17 +1155,19 @@ func TestClient_UpdateNodeFromDevicesAccumulates(t *testing.T) {
 		},
 	})
 
+	conf = client.GetConfig()
+
 	expectedResources2 := &structs.NodeResources{
 		// computed through test client initialization
-		Networks:     client.configCopy.Node.NodeResources.Networks,
-		NodeNetworks: client.configCopy.Node.NodeResources.NodeNetworks,
-		Disk:         client.configCopy.Node.NodeResources.Disk,
+		Networks:     conf.Node.NodeResources.Networks,
+		NodeNetworks: conf.Node.NodeResources.NodeNetworks,
+		Disk:         conf.Node.NodeResources.Disk,
 
 		// injected
 		Cpu: structs.NodeCpuResources{
 			CpuShares:          123,
-			ReservableCpuCores: client.configCopy.Node.NodeResources.Cpu.ReservableCpuCores,
-			TotalCpuCores:      client.configCopy.Node.NodeResources.Cpu.TotalCpuCores,
+			ReservableCpuCores: conf.Node.NodeResources.Cpu.ReservableCpuCores,
+			TotalCpuCores:      conf.Node.NodeResources.Cpu.TotalCpuCores,
 		},
 		Memory: structs.NodeMemoryResources{MemoryMB: 2048},
 		Devices: []*structs.NodeDeviceResource{
@@ -1187,7 +1182,7 @@ func TestClient_UpdateNodeFromDevicesAccumulates(t *testing.T) {
 		},
 	}
 
-	assert.EqualValues(t, expectedResources2, client.configCopy.Node.NodeResources)
+	assert.EqualValues(t, expectedResources2, conf.Node.NodeResources)
 
 }
 

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/consul-template/config"
 	"github.com/hashicorp/nomad/client/lib/cgutil"
 	"github.com/hashicorp/nomad/command/agent/host"
+	"golang.org/x/exp/slices"
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/state"
@@ -735,8 +736,11 @@ func (rc *RetryConfig) ToConsulTemplate() (*config.RetryConfig, error) {
 }
 
 func (c *Config) Copy() *Config {
-	nc := new(Config)
-	*nc = *c
+	if c == nil {
+		return nil
+	}
+
+	nc := *c
 	nc.Node = nc.Node.Copy()
 	nc.Servers = helper.CopySliceString(nc.Servers)
 	nc.Options = helper.CopyMapStringString(nc.Options)
@@ -744,12 +748,9 @@ func (c *Config) Copy() *Config {
 	nc.ConsulConfig = c.ConsulConfig.Copy()
 	nc.VaultConfig = c.VaultConfig.Copy()
 	nc.TemplateConfig = c.TemplateConfig.Copy()
-	if c.ReservableCores != nil {
-		nc.ReservableCores = make([]uint16, len(c.ReservableCores))
-		copy(nc.ReservableCores, c.ReservableCores)
-	}
+	nc.ReservableCores = slices.Clone(c.ReservableCores)
 	nc.Artifact = c.Artifact.Copy()
-	return nc
+	return &nc
 }
 
 // DefaultConfig returns the default configuration

--- a/client/driver_manager_test.go
+++ b/client/driver_manager_test.go
@@ -22,10 +22,11 @@ func TestDriverManager_Fingerprint_Run(t *testing.T) {
 	testClient, cleanup := TestClient(t, nil)
 	defer cleanup()
 
+	conf := testClient.GetConfig()
 	dm := drivermanager.New(&drivermanager.Config{
 		Logger:              testClient.logger,
-		Loader:              testClient.config.PluginSingletonLoader,
-		PluginConfig:        testClient.configCopy.NomadPluginConfig(),
+		Loader:              conf.PluginSingletonLoader,
+		PluginConfig:        conf.NomadPluginConfig(),
 		Updater:             testClient.updateNodeFromDriver,
 		EventHandlerFactory: testClient.GetTaskEventHandler,
 		State:               testClient.stateDB,
@@ -35,7 +36,7 @@ func TestDriverManager_Fingerprint_Run(t *testing.T) {
 	defer dm.Shutdown()
 
 	testutil.WaitForResult(func() (bool, error) {
-		node := testClient.configCopy.Node
+		node := testClient.Node()
 
 		d, ok := node.Drivers["mock_driver"]
 		if !ok {
@@ -73,10 +74,11 @@ func TestDriverManager_Fingerprint_Periodic(t *testing.T) {
 	})
 	defer cleanup()
 
+	conf := testClient.GetConfig()
 	dm := drivermanager.New(&drivermanager.Config{
 		Logger:              testClient.logger,
-		Loader:              testClient.config.PluginSingletonLoader,
-		PluginConfig:        testClient.configCopy.NomadPluginConfig(),
+		Loader:              conf.PluginSingletonLoader,
+		PluginConfig:        conf.NomadPluginConfig(),
 		Updater:             testClient.updateNodeFromDriver,
 		EventHandlerFactory: testClient.GetTaskEventHandler,
 		State:               testClient.stateDB,
@@ -134,10 +136,11 @@ func TestDriverManager_NodeAttributes_Run(t *testing.T) {
 	})
 	defer cleanup()
 
+	conf := testClient.GetConfig()
 	dm := drivermanager.New(&drivermanager.Config{
 		Logger:              testClient.logger,
-		Loader:              testClient.config.PluginSingletonLoader,
-		PluginConfig:        testClient.configCopy.NomadPluginConfig(),
+		Loader:              conf.PluginSingletonLoader,
+		PluginConfig:        conf.NomadPluginConfig(),
 		Updater:             testClient.updateNodeFromDriver,
 		EventHandlerFactory: testClient.GetTaskEventHandler,
 		State:               testClient.stateDB,

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -47,9 +47,11 @@ func (c *Client) StreamingRpcHandler(method string) (structs.StreamingRpcHandler
 
 // RPC is used to forward an RPC call to a nomad server, or fail if no servers.
 func (c *Client) RPC(method string, args interface{}, reply interface{}) error {
+	conf := c.GetConfig()
+
 	// Invoke the RPCHandler if it exists
-	if c.config.RPCHandler != nil {
-		return c.config.RPCHandler.RPC(method, args, reply)
+	if conf.RPCHandler != nil {
+		return conf.RPCHandler.RPC(method, args, reply)
 	}
 
 	// We will try to automatically retry requests that fail due to things like server unavailability
@@ -60,7 +62,7 @@ func (c *Client) RPC(method string, args interface{}, reply interface{}) error {
 	// to the leader they may also allow for an RPCHoldTimeout while waiting for leader election.
 	// That's OK, we won't double up because we are using it here not as a sleep but
 	// as a hint to give up
-	deadline = deadline.Add(c.config.RPCHoldTimeout)
+	deadline = deadline.Add(conf.RPCHoldTimeout)
 
 	// If its a blocking query, allow the time specified by the request
 	if info, ok := args.(structs.RPCInfo); ok {
@@ -110,7 +112,7 @@ TRY:
 
 	// Wait to avoid thundering herd
 	select {
-	case <-time.After(lib.RandomStagger(c.config.RPCHoldTimeout / structs.JitterFraction)):
+	case <-time.After(lib.RandomStagger(conf.RPCHoldTimeout / structs.JitterFraction)):
 		// If we are going to retry a blocking query we need to update the time to block so it finishes by our deadline.
 		if info, ok := args.(structs.RPCInfo); ok && info.TimeToBlock() > 0 {
 			newBlockTime := time.Until(deadline)

--- a/client/testing.go
+++ b/client/testing.go
@@ -94,7 +94,6 @@ func TestRPCOnlyClient(t testing.T, srvAddr net.Addr, rpcs map[string]interface{
 
 	client := &Client{config: conf, logger: testlog.HCLogger(t)}
 	client.servers = servers.New(client.logger, client.shutdownCh, client)
-	client.configCopy = client.config.Copy()
 
 	client.rpcServer = rpc.NewServer()
 	for name, rpc := range rpcs {

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1113,15 +1113,17 @@ func (a *Agent) Reload(newConfig *Config) error {
 	a.configLock.Lock()
 	defer a.configLock.Unlock()
 
-	updatedLogging := newConfig != nil && (newConfig.LogLevel != a.config.LogLevel)
+	current := a.config.Copy()
+
+	updatedLogging := newConfig != nil && (newConfig.LogLevel != current.LogLevel)
 
 	if newConfig == nil || newConfig.TLSConfig == nil && !updatedLogging {
 		return fmt.Errorf("cannot reload agent with nil configuration")
 	}
 
 	if updatedLogging {
-		a.config.LogLevel = newConfig.LogLevel
-		a.logger.SetLevel(log.LevelFromString(newConfig.LogLevel))
+		current.LogLevel = newConfig.LogLevel
+		a.logger.SetLevel(log.LevelFromString(current.LogLevel))
 	}
 
 	// Update eventer config
@@ -1141,10 +1143,10 @@ func (a *Agent) Reload(newConfig *Config) error {
 		// Completely reload the agent's TLS configuration (moving from non-TLS to
 		// TLS, or vice versa)
 		// This does not handle errors in loading the new TLS configuration
-		a.config.TLSConfig = newConfig.TLSConfig.Copy()
+		current.TLSConfig = newConfig.TLSConfig.Copy()
 	}
 
-	if !a.config.TLSConfig.IsEmpty() && !newConfig.TLSConfig.IsEmpty() {
+	if !current.TLSConfig.IsEmpty() && !newConfig.TLSConfig.IsEmpty() {
 		// This is just a TLS configuration reload, we don't need to refresh
 		// existing network connections
 
@@ -1153,26 +1155,31 @@ func (a *Agent) Reload(newConfig *Config) error {
 		// as this allows us to dynamically reload configurations not only
 		// on the Agent but on the Server and Client too (they are
 		// referencing the same keyloader).
-		keyloader := a.config.TLSConfig.GetKeyLoader()
+		keyloader := current.TLSConfig.GetKeyLoader()
 		_, err := keyloader.LoadKeyPair(newConfig.TLSConfig.CertFile, newConfig.TLSConfig.KeyFile)
 		if err != nil {
 			return err
 		}
-		a.config.TLSConfig = newConfig.TLSConfig
-		a.config.TLSConfig.KeyLoader = keyloader
+
+		current.TLSConfig = newConfig.TLSConfig
+		current.TLSConfig.KeyLoader = keyloader
+		a.config = current
 		return nil
-	} else if newConfig.TLSConfig.IsEmpty() && !a.config.TLSConfig.IsEmpty() {
+	} else if newConfig.TLSConfig.IsEmpty() && !current.TLSConfig.IsEmpty() {
 		a.logger.Warn("downgrading agent's existing TLS configuration to plaintext")
 		fullUpdateTLSConfig()
-	} else if !newConfig.TLSConfig.IsEmpty() && a.config.TLSConfig.IsEmpty() {
+	} else if !newConfig.TLSConfig.IsEmpty() && current.TLSConfig.IsEmpty() {
 		a.logger.Info("upgrading from plaintext configuration to TLS")
 		fullUpdateTLSConfig()
 	}
 
+	// Set agent config to the updated config
+	a.config = current
 	return nil
 }
 
-// GetConfig creates a locked reference to the agent's config
+// GetConfig returns the current agent configuration. The Config should *not*
+// be mutated directly. First call Config.Copy.
 func (a *Agent) GetConfig() *Config {
 	a.configLock.Lock()
 	defer a.configLock.Unlock()

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/nomad/nomad"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/serf/serf"
-	"github.com/mitchellh/copystructure"
 )
 
 type Member struct {
@@ -81,11 +80,8 @@ func (s *HTTPServer) AgentSelfRequest(resp http.ResponseWriter, req *http.Reques
 		Member: nomadMember(member),
 		Stats:  s.agent.Stats(),
 	}
-	if ac, err := copystructure.Copy(s.agent.config); err != nil {
-		return nil, CodedError(500, err.Error())
-	} else {
-		self.Config = ac.(*Config)
-	}
+
+	self.Config = s.agent.GetConfig().Copy()
 
 	if self.Config != nil && self.Config.Vault != nil && self.Config.Vault.Token != "" {
 		self.Config.Vault.Token = "<redacted>"

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -741,9 +741,9 @@ func TestServer_Reload_TLS_Shared_Keyloader(t *testing.T) {
 	}
 
 	assert.Nil(agent.Reload(newConfig))
-	assert.Equal(agent.Config.TLSConfig.CertFile, newConfig.TLSConfig.CertFile)
-	assert.Equal(agent.Config.TLSConfig.KeyFile, newConfig.TLSConfig.KeyFile)
-	assert.Equal(agent.Config.TLSConfig.GetKeyLoader(), originalKeyloader)
+	assert.Equal(agent.Agent.config.TLSConfig.CertFile, newConfig.TLSConfig.CertFile)
+	assert.Equal(agent.Agent.config.TLSConfig.KeyFile, newConfig.TLSConfig.KeyFile)
+	assert.Equal(agent.Agent.config.TLSConfig.GetKeyLoader(), originalKeyloader)
 
 	// Assert is passed through on the server correctly
 	if assert.NotNil(agent.server.GetConfig().TLSConfig) {
@@ -983,7 +983,7 @@ func TestServer_Reload_TLS_DowngradeFromTLS(t *testing.T) {
 	err := agent.Reload(newConfig)
 	assert.Nil(err)
 
-	assert.True(agentConfig.TLSConfig.IsEmpty())
+	assert.True(agent.config.TLSConfig.IsEmpty())
 }
 
 func TestServer_Reload_VaultConfig(t *testing.T) {

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -997,7 +997,7 @@ func (c *Command) handleReload() {
 		}
 	}
 
-	if s := c.agent.Client(); s != nil {
+	if client := c.agent.Client(); client != nil {
 		c.agent.logger.Debug("starting reload of client config")
 		clientConfig, err := convertClientConfig(newConf)
 		if err != nil {
@@ -1011,7 +1011,7 @@ func (c *Command) handleReload() {
 			return
 		}
 
-		if err := c.agent.Client().Reload(clientConfig); err != nil {
+		if err := client.Reload(clientConfig); err != nil {
 			c.agent.logger.Error("reloading client config failed", "error", err)
 			return
 		}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -343,7 +343,6 @@ func (c *ClientConfig) Copy() *ClientConfig {
 	nc.ServerJoin = c.ServerJoin.Copy()
 	nc.HostVolumes = helper.CopySlice(c.HostVolumes)
 	nc.HostNetworks = helper.CopySlice(c.HostNetworks)
-	nc.NomadServiceDiscovery = pointer.Copy(c.NomadServiceDiscovery)
 	nc.Artifact = c.Artifact.Copy()
 	nc.ExtraKeysHCL = slices.Clone(c.ExtraKeysHCL)
 	return &nc
@@ -572,7 +571,6 @@ func (s *ServerConfig) Copy() *ServerConfig {
 	ns.RetryJoin = slices.Clone(s.RetryJoin)
 	ns.ServerJoin = s.ServerJoin.Copy()
 	ns.DefaultSchedulerConfig = s.DefaultSchedulerConfig.Copy()
-	ns.PlanRejectionTracker = s.PlanRejectionTracker.Copy()
 	ns.EnableEventBroker = pointer.Copy(s.EnableEventBroker)
 	ns.EventBufferSize = pointer.Copy(s.EventBufferSize)
 	ns.licenseAdditionalPublicKeys = slices.Clone(s.licenseAdditionalPublicKeys)

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -20,11 +20,13 @@ import (
 	"github.com/hashicorp/go-sockaddr/template"
 	client "github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/fingerprint"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/nomad"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/version"
+	"golang.org/x/exp/slices"
 )
 
 // Config is the configuration for the Nomad agent.
@@ -325,6 +327,28 @@ type ClientConfig struct {
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 }
 
+func (c *ClientConfig) Copy() *ClientConfig {
+	if c == nil {
+		return c
+	}
+
+	nc := *c
+	nc.Servers = slices.Clone(c.Servers)
+	nc.Options = helper.CopyMap(c.Options)
+	nc.Meta = helper.CopyMap(c.Meta)
+	nc.ChrootEnv = helper.CopyMap(c.ChrootEnv)
+	nc.Reserved = c.Reserved.Copy()
+	nc.NoHostUUID = pointer.Copy(c.NoHostUUID)
+	nc.TemplateConfig = c.TemplateConfig.Copy()
+	nc.ServerJoin = c.ServerJoin.Copy()
+	nc.HostVolumes = helper.CopySlice(c.HostVolumes)
+	nc.HostNetworks = helper.CopySlice(c.HostNetworks)
+	nc.NomadServiceDiscovery = pointer.Copy(c.NomadServiceDiscovery)
+	nc.Artifact = c.Artifact.Copy()
+	nc.ExtraKeysHCL = slices.Clone(c.ExtraKeysHCL)
+	return &nc
+}
+
 // ACLConfig is configuration specific to the ACL system
 type ACLConfig struct {
 	// Enabled controls if we are enforce and manage ACLs
@@ -351,6 +375,16 @@ type ACLConfig struct {
 
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
+}
+
+func (a *ACLConfig) Copy() *ACLConfig {
+	if a == nil {
+		return nil
+	}
+
+	na := *a
+	na.ExtraKeysHCL = slices.Clone(a.ExtraKeysHCL)
+	return &na
 }
 
 // ServerConfig is configuration specific to the server mode
@@ -525,6 +559,28 @@ type ServerConfig struct {
 	DeploymentQueryRateLimit float64 `hcl:"deploy_query_rate_limit"`
 }
 
+func (s *ServerConfig) Copy() *ServerConfig {
+	if s == nil {
+		return nil
+	}
+
+	ns := *s
+	ns.RaftMultiplier = pointer.Copy(s.RaftMultiplier)
+	ns.NumSchedulers = pointer.Copy(s.NumSchedulers)
+	ns.EnabledSchedulers = slices.Clone(s.EnabledSchedulers)
+	ns.StartJoin = slices.Clone(s.StartJoin)
+	ns.RetryJoin = slices.Clone(s.RetryJoin)
+	ns.ServerJoin = s.ServerJoin.Copy()
+	ns.DefaultSchedulerConfig = s.DefaultSchedulerConfig.Copy()
+	ns.PlanRejectionTracker = s.PlanRejectionTracker.Copy()
+	ns.EnableEventBroker = pointer.Copy(s.EnableEventBroker)
+	ns.EventBufferSize = pointer.Copy(s.EventBufferSize)
+	ns.licenseAdditionalPublicKeys = slices.Clone(s.licenseAdditionalPublicKeys)
+	ns.ExtraKeysHCL = slices.Clone(s.ExtraKeysHCL)
+	ns.Search = s.Search.Copy()
+	return &ns
+}
+
 // Search is used in servers to configure search API options.
 type Search struct {
 	// FuzzyEnabled toggles whether the FuzzySearch API is enabled. If not
@@ -561,6 +617,15 @@ type Search struct {
 	MinTermLength int `hcl:"min_term_length"`
 }
 
+func (s *Search) Copy() *Search {
+	if s == nil {
+		return nil
+	}
+
+	ns := *s
+	return &ns
+}
+
 // ServerJoin is used in both clients and servers to bootstrap connections to
 // servers
 type ServerJoin struct {
@@ -586,6 +651,18 @@ type ServerJoin struct {
 
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
+}
+
+func (s *ServerJoin) Copy() *ServerJoin {
+	if s == nil {
+		return nil
+	}
+
+	ns := *s
+	ns.StartJoin = slices.Clone(s.StartJoin)
+	ns.RetryJoin = slices.Clone(s.RetryJoin)
+	ns.ExtraKeysHCL = slices.Clone(s.ExtraKeysHCL)
+	return &ns
 }
 
 func (s *ServerJoin) Merge(b *ServerJoin) *ServerJoin {
@@ -722,6 +799,19 @@ type Telemetry struct {
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 }
 
+func (t *Telemetry) Copy() *Telemetry {
+	if t == nil {
+		return nil
+	}
+
+	nt := *t
+	nt.DataDogTags = slices.Clone(t.DataDogTags)
+	nt.PrefixFilter = slices.Clone(t.PrefixFilter)
+	nt.FilterDefault = pointer.Copy(t.FilterDefault)
+	nt.ExtraKeysHCL = slices.Clone(t.ExtraKeysHCL)
+	return &nt
+}
+
 // PrefixFilters parses the PrefixFilter field and returns a list of allowed and blocked filters
 func (a *Telemetry) PrefixFilters() (allowed, blocked []string, err error) {
 	for _, rule := range a.PrefixFilter {
@@ -750,6 +840,16 @@ type Ports struct {
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 }
 
+func (p *Ports) Copy() *Ports {
+	if p == nil {
+		return nil
+	}
+
+	np := *p
+	np.ExtraKeysHCL = slices.Clone(p.ExtraKeysHCL)
+	return &np
+}
+
 // Addresses encapsulates all of the addresses we bind to for various
 // network services. Everything is optional and defaults to BindAddr.
 type Addresses struct {
@@ -760,6 +860,16 @@ type Addresses struct {
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 }
 
+func (a *Addresses) Copy() *Addresses {
+	if a == nil {
+		return nil
+	}
+
+	na := *a
+	na.ExtraKeysHCL = slices.Clone(a.ExtraKeysHCL)
+	return &na
+}
+
 // AdvertiseAddrs is used to control the addresses we advertise out for
 // different network services. All are optional and default to BindAddr and
 // their default Port.
@@ -767,6 +877,16 @@ type NormalizedAddrs struct {
 	HTTP []string
 	RPC  string
 	Serf string
+}
+
+func (n *NormalizedAddrs) Copy() *NormalizedAddrs {
+	if n == nil {
+		return nil
+	}
+
+	nn := *n
+	nn.HTTP = slices.Clone(n.HTTP)
+	return &nn
 }
 
 // AdvertiseAddrs is used to control the addresses we advertise out for
@@ -780,6 +900,16 @@ type AdvertiseAddrs struct {
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 }
 
+func (a *AdvertiseAddrs) Copy() *AdvertiseAddrs {
+	if a == nil {
+		return nil
+	}
+
+	na := *a
+	na.ExtraKeysHCL = slices.Clone(a.ExtraKeysHCL)
+	return &na
+}
+
 type Resources struct {
 	CPU           int    `hcl:"cpu"`
 	MemoryMB      int    `hcl:"memory"`
@@ -788,6 +918,16 @@ type Resources struct {
 	Cores         string `hcl:"cores"`
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
+}
+
+func (r *Resources) Copy() *Resources {
+	if r == nil {
+		return nil
+	}
+
+	nr := *r
+	nr.ExtraKeysHCL = slices.Clone(r.ExtraKeysHCL)
+	return &nr
 }
 
 // devModeConfig holds the config for the -dev and -dev-connect flags
@@ -1213,6 +1353,42 @@ func (c *Config) Merge(b *Config) *Config {
 	result.Limits = c.Limits.Merge(b.Limits)
 
 	return &result
+}
+
+// Copy returns a deep copy safe for mutation.
+func (c *Config) Copy() *Config {
+	if c == nil {
+		return nil
+	}
+	nc := *c
+
+	nc.Ports = c.Ports.Copy()
+	nc.Addresses = c.Addresses.Copy()
+	nc.normalizedAddrs = c.normalizedAddrs.Copy()
+	nc.AdvertiseAddrs = c.AdvertiseAddrs.Copy()
+	nc.Client = c.Client.Copy()
+	nc.Server = c.Server.Copy()
+	nc.ACL = c.ACL.Copy()
+	nc.Telemetry = c.Telemetry.Copy()
+	nc.DisableUpdateCheck = pointer.Copy(c.DisableUpdateCheck)
+	nc.Consul = c.Consul.Copy()
+	nc.Vault = c.Vault.Copy()
+	nc.UI = c.UI.Copy()
+
+	nc.NomadConfig = c.NomadConfig.Copy()
+	nc.ClientConfig = c.ClientConfig.Copy()
+
+	nc.Version = c.Version.Copy()
+	nc.Files = slices.Clone(c.Files)
+	nc.TLSConfig = c.TLSConfig.Copy()
+	nc.HTTPAPIResponseHeaders = helper.CopyMap(c.HTTPAPIResponseHeaders)
+	nc.Sentinel = c.Sentinel.Copy()
+	nc.Autopilot = c.Autopilot.Copy()
+	nc.Plugins = helper.CopySlice(c.Plugins)
+	nc.Limits = c.Limits.Copy()
+	nc.Audit = c.Audit.Copy()
+	nc.ExtraKeysHCL = slices.Clone(c.ExtraKeysHCL)
+	return &nc
 }
 
 // normalizeAddrs normalizes Addresses and AdvertiseAddrs to always be

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -904,7 +904,7 @@ func TestHTTP_VerifyHTTPSClient_AfterConfigReload(t *testing.T) {
 	assert.Nil(err)
 
 	resp, err := client.Do(req)
-	if assert.Nil(err) {
+	if assert.NoError(err) {
 		resp.Body.Close()
 		assert.Equal(resp.StatusCode, 200)
 	}

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -78,7 +78,6 @@ func TestHTTP_PrefixJobsList(t *testing.T) {
 		"aabbbbbb-e8f7-fd38-c855-ab94ceb89706",
 		"aabbcccc-e8f7-fd38-c855-ab94ceb89706",
 	}
-	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		for i := 0; i < 3; i++ {
 			// Create the job
@@ -3597,7 +3596,7 @@ func TestConversion_apiConnectSidecarServiceProxyToStructs(t *testing.T) {
 	require.Equal(t, &structs.ConsulProxy{
 		LocalServiceAddress: "192.168.30.1",
 		LocalServicePort:    9000,
-		Config:              nil,
+		Config:              map[string]any{},
 		Upstreams: []structs.ConsulUpstream{{
 			DestinationName: "upstream",
 		}},

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -33,6 +33,10 @@ var invalidFilenameNonASCII = regexp.MustCompile(`[[:^ascii:]/\\<>:"|?*]`)
 // invalidFilenameStrict = invalidFilename plus additional punctuation
 var invalidFilenameStrict = regexp.MustCompile(`[/\\<>:"|?*$()+=[\];#@~,&']`)
 
+type Copyable[T any] interface {
+	Copy() T
+}
+
 // IsUUID returns true if the given string is a valid UUID.
 func IsUUID(str string) bool {
 	const uuidLen = 36
@@ -244,9 +248,9 @@ func CompareMapStringString(a, b map[string]string) bool {
 
 // CopyMap creates a copy of m. Struct values are not deep copies.
 //
-// If m is nil or contains no elements, the return value is nil.
+// If m is nil the return value is nil.
 func CopyMap[M ~map[K]V, K comparable, V any](m M) M {
-	if len(m) == 0 {
+	if m == nil {
 		return nil
 	}
 
@@ -257,16 +261,44 @@ func CopyMap[M ~map[K]V, K comparable, V any](m M) M {
 	return result
 }
 
+// DeepCopyMap creates a copy of m by calling Copy() on each value.
+//
+// If m is nil the return value is nil.
+func DeepCopyMap[M ~map[K]V, K comparable, V Copyable[V]](m M) M {
+	if m == nil {
+		return nil
+	}
+
+	result := make(M, len(m))
+	for k, v := range m {
+		result[k] = v.Copy()
+	}
+	return result
+}
+
+// CopySlice creates a deep copy of s. For slices with elements that do not
+// implement Copy(), use slices.Clone.
+func CopySlice[S ~[]E, E Copyable[E]](s S) S {
+	if s == nil {
+		return nil
+	}
+
+	result := make(S, len(s))
+	for i, v := range s {
+		result[i] = v.Copy()
+	}
+	return result
+}
+
 // CopyMapStringString creates a copy of m.
 //
 // Deprecated; use CopyMap instead.
 func CopyMapStringString(m map[string]string) map[string]string {
-	l := len(m)
-	if l == 0 {
+	if m == nil {
 		return nil
 	}
 
-	c := make(map[string]string, l)
+	c := make(map[string]string, len(m))
 	for k, v := range m {
 		c[k] = v
 	}
@@ -277,12 +309,11 @@ func CopyMapStringString(m map[string]string) map[string]string {
 //
 // Deprecated; use CopyMap instead.
 func CopyMapStringStruct(m map[string]struct{}) map[string]struct{} {
-	l := len(m)
-	if l == 0 {
+	if m == nil {
 		return nil
 	}
 
-	c := make(map[string]struct{}, l)
+	c := make(map[string]struct{}, len(m))
 	for k := range m {
 		c[k] = struct{}{}
 	}
@@ -293,12 +324,11 @@ func CopyMapStringStruct(m map[string]struct{}) map[string]struct{} {
 //
 // Deprecated; use CopyMap instead.
 func CopyMapStringInterface(m map[string]interface{}) map[string]interface{} {
-	l := len(m)
-	if l == 0 {
+	if m == nil {
 		return nil
 	}
 
-	c := make(map[string]interface{}, l)
+	c := make(map[string]interface{}, len(m))
 	for k, v := range m {
 		c[k] = v
 	}

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -66,7 +66,7 @@ func Test_CopyMap(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		m := make(map[string]int, 10)
 		result := CopyMap(m)
-		must.Nil(t, result)
+		must.MapEq(t, map[string]int{}, result)
 	})
 
 	t.Run("elements", func(t *testing.T) {

--- a/nomad/client_csi_endpoint_test.go
+++ b/nomad/client_csi_endpoint_test.go
@@ -541,8 +541,9 @@ func setupLocal(t *testing.T) (rpc.ClientCodec, func()) {
 		require.NoError(t, err, "could not setup test client")
 	}
 
-	node1 := c1.Node()
-	node1.Attributes["nomad.version"] = "0.11.0" // client RPCs not supported on early versions
+	node1 := c1.UpdateConfig(func(c *config.Config) {
+		c.Node.Attributes["nomad.version"] = "0.11.0" // client RPCs not supported on early versions
+	}).Node
 
 	req := &structs.NodeRegisterRequest{
 		Node:         node1,
@@ -568,7 +569,9 @@ func setupLocal(t *testing.T) (rpc.ClientCodec, func()) {
 	}
 
 	// update w/ plugin
-	node1.CSIControllerPlugins = plugins
+	node1 = c1.UpdateConfig(func(c *config.Config) {
+		c.Node.CSIControllerPlugins = plugins
+	}).Node
 	s1.fsm.state.UpsertNode(structs.MsgTypeTestSetup, 1000, node1)
 
 	cleanup := func() {

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -9,9 +9,11 @@ import (
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
+	"golang.org/x/exp/slices"
 
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/nomad/helper/pluginutils/loader"
+	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/deploymentwatcher"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -380,6 +382,36 @@ func (c *Config) CheckVersion() error {
 			c.ProtocolVersion, ProtocolVersionMin, ProtocolVersionMax)
 	}
 	return nil
+}
+
+func (c *Config) Copy() *Config {
+	if c == nil {
+		return nil
+	}
+
+	nc := *c
+
+	// Can't deep copy interfaces
+	// LogOutput io.Writer
+	// Logger log.InterceptLogger
+	// PluginLoader loader.PluginCatalog
+	// PluginSingletonLoader loader.PluginCatalog
+
+	nc.RPCAddr = pointer.Copy(c.RPCAddr)
+	nc.ClientRPCAdvertise = pointer.Copy(c.ClientRPCAdvertise)
+	nc.ServerRPCAdvertise = pointer.Copy(c.ServerRPCAdvertise)
+	nc.RaftConfig = pointer.Copy(c.RaftConfig)
+	nc.SerfConfig = pointer.Copy(c.SerfConfig)
+	nc.EnabledSchedulers = slices.Clone(c.EnabledSchedulers)
+	nc.ConsulConfig = c.ConsulConfig.Copy()
+	nc.VaultConfig = c.VaultConfig.Copy()
+	nc.TLSConfig = c.TLSConfig.Copy()
+	nc.SentinelConfig = c.SentinelConfig.Copy()
+	nc.AutopilotConfig = c.AutopilotConfig.Copy()
+	nc.LicenseConfig = c.LicenseConfig.Copy()
+	nc.SearchConfig = c.SearchConfig.Copy()
+
+	return &nc
 }
 
 // DefaultConfig returns the default configuration. Only used as the basis for

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -833,8 +833,10 @@ func TestCSIVolumeEndpoint_Create(t *testing.T) {
 	)
 	defer cleanup()
 
-	node := client.Node()
-	node.Attributes["nomad.version"] = "0.11.0" // client RPCs not supported on early versions
+	node := client.UpdateConfig(func(c *cconfig.Config) {
+		// client RPCs not supported on early versions
+		c.Node.Attributes["nomad.version"] = "0.11.0"
+	}).Node
 
 	req0 := &structs.NodeRegisterRequest{
 		Node:         node,
@@ -857,24 +859,26 @@ func TestCSIVolumeEndpoint_Create(t *testing.T) {
 	codec := rpcClient(t, srv)
 	index := uint64(1000)
 
-	node.CSIControllerPlugins = map[string]*structs.CSIInfo{
-		"minnie": {
-			PluginID: "minnie",
-			Healthy:  true,
-			ControllerInfo: &structs.CSIControllerInfo{
-				SupportsAttachDetach: true,
-				SupportsCreateDelete: true,
+	node = client.UpdateConfig(func(c *cconfig.Config) {
+		c.Node.CSIControllerPlugins = map[string]*structs.CSIInfo{
+			"minnie": {
+				PluginID: "minnie",
+				Healthy:  true,
+				ControllerInfo: &structs.CSIControllerInfo{
+					SupportsAttachDetach: true,
+					SupportsCreateDelete: true,
+				},
+				RequiresControllerPlugin: true,
 			},
-			RequiresControllerPlugin: true,
-		},
-	}
-	node.CSINodePlugins = map[string]*structs.CSIInfo{
-		"minnie": {
-			PluginID: "minnie",
-			Healthy:  true,
-			NodeInfo: &structs.CSINodeInfo{},
-		},
-	}
+		}
+		c.Node.CSINodePlugins = map[string]*structs.CSIInfo{
+			"minnie": {
+				PluginID: "minnie",
+				Healthy:  true,
+				NodeInfo: &structs.CSINodeInfo{},
+			},
+		}
+	}).Node
 	index++
 	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, index, node))
 
@@ -964,8 +968,10 @@ func TestCSIVolumeEndpoint_Delete(t *testing.T) {
 	)
 	defer cleanup()
 
-	node := client.Node()
-	node.Attributes["nomad.version"] = "0.11.0" // client RPCs not supported on early versions
+	node := client.UpdateConfig(func(c *cconfig.Config) {
+		// client RPCs not supported on early versions
+		c.Node.Attributes["nomad.version"] = "0.11.0"
+	}).Node
 
 	req0 := &structs.NodeRegisterRequest{
 		Node:         node,
@@ -988,23 +994,25 @@ func TestCSIVolumeEndpoint_Delete(t *testing.T) {
 	codec := rpcClient(t, srv)
 	index := uint64(1000)
 
-	node.CSIControllerPlugins = map[string]*structs.CSIInfo{
-		"minnie": {
-			PluginID: "minnie",
-			Healthy:  true,
-			ControllerInfo: &structs.CSIControllerInfo{
-				SupportsAttachDetach: true,
+	node = client.UpdateConfig(func(c *cconfig.Config) {
+		c.Node.CSIControllerPlugins = map[string]*structs.CSIInfo{
+			"minnie": {
+				PluginID: "minnie",
+				Healthy:  true,
+				ControllerInfo: &structs.CSIControllerInfo{
+					SupportsAttachDetach: true,
+				},
+				RequiresControllerPlugin: true,
 			},
-			RequiresControllerPlugin: true,
-		},
-	}
-	node.CSINodePlugins = map[string]*structs.CSIInfo{
-		"minnie": {
-			PluginID: "minnie",
-			Healthy:  true,
-			NodeInfo: &structs.CSINodeInfo{},
-		},
-	}
+		}
+		c.Node.CSINodePlugins = map[string]*structs.CSIInfo{
+			"minnie": {
+				PluginID: "minnie",
+				Healthy:  true,
+				NodeInfo: &structs.CSINodeInfo{},
+			},
+		}
+	}).Node
 	index++
 	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, index, node))
 
@@ -1098,8 +1106,10 @@ func TestCSIVolumeEndpoint_ListExternal(t *testing.T) {
 	)
 	defer cleanup()
 
-	node := client.Node()
-	node.Attributes["nomad.version"] = "0.11.0" // client RPCs not supported on early versions
+	node := client.UpdateConfig(func(c *cconfig.Config) {
+		// client RPCs not supported on early versions
+		c.Node.Attributes["nomad.version"] = "0.11.0"
+	}).Node
 
 	req0 := &structs.NodeRegisterRequest{
 		Node:         node,
@@ -1120,24 +1130,26 @@ func TestCSIVolumeEndpoint_ListExternal(t *testing.T) {
 	codec := rpcClient(t, srv)
 	index := uint64(1000)
 
-	node.CSIControllerPlugins = map[string]*structs.CSIInfo{
-		"minnie": {
-			PluginID: "minnie",
-			Healthy:  true,
-			ControllerInfo: &structs.CSIControllerInfo{
-				SupportsAttachDetach: true,
-				SupportsListVolumes:  true,
+	node = client.UpdateConfig(func(c *cconfig.Config) {
+		c.Node.CSIControllerPlugins = map[string]*structs.CSIInfo{
+			"minnie": {
+				PluginID: "minnie",
+				Healthy:  true,
+				ControllerInfo: &structs.CSIControllerInfo{
+					SupportsAttachDetach: true,
+					SupportsListVolumes:  true,
+				},
+				RequiresControllerPlugin: true,
 			},
-			RequiresControllerPlugin: true,
-		},
-	}
-	node.CSINodePlugins = map[string]*structs.CSIInfo{
-		"minnie": {
-			PluginID: "minnie",
-			Healthy:  true,
-			NodeInfo: &structs.CSINodeInfo{},
-		},
-	}
+		}
+		c.Node.CSINodePlugins = map[string]*structs.CSIInfo{
+			"minnie": {
+				PluginID: "minnie",
+				Healthy:  true,
+				NodeInfo: &structs.CSINodeInfo{},
+			},
+		}
+	}).Node
 	index++
 	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, index, node))
 
@@ -1191,10 +1203,8 @@ func TestCSIVolumeEndpoint_CreateSnapshot(t *testing.T) {
 	)
 	defer cleanup()
 
-	node := client.Node()
-
 	req0 := &structs.NodeRegisterRequest{
-		Node:         node,
+		Node:         client.Node(),
 		WriteRequest: structs.WriteRequest{Region: "global"},
 	}
 	var resp0 structs.NodeUpdateResponse
@@ -1214,16 +1224,18 @@ func TestCSIVolumeEndpoint_CreateSnapshot(t *testing.T) {
 	codec := rpcClient(t, srv)
 	index := uint64(1000)
 
-	node.CSIControllerPlugins = map[string]*structs.CSIInfo{
-		"minnie": {
-			PluginID: "minnie",
-			Healthy:  true,
-			ControllerInfo: &structs.CSIControllerInfo{
-				SupportsCreateDeleteSnapshot: true,
+	node := client.UpdateConfig(func(c *cconfig.Config) {
+		c.Node.CSIControllerPlugins = map[string]*structs.CSIInfo{
+			"minnie": {
+				PluginID: "minnie",
+				Healthy:  true,
+				ControllerInfo: &structs.CSIControllerInfo{
+					SupportsCreateDeleteSnapshot: true,
+				},
+				RequiresControllerPlugin: true,
 			},
-			RequiresControllerPlugin: true,
-		},
-	}
+		}
+	}).Node
 	index++
 	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, index, node))
 
@@ -1284,10 +1296,8 @@ func TestCSIVolumeEndpoint_DeleteSnapshot(t *testing.T) {
 	)
 	defer cleanup()
 
-	node := client.Node()
-
 	req0 := &structs.NodeRegisterRequest{
-		Node:         node,
+		Node:         client.Node(),
 		WriteRequest: structs.WriteRequest{Region: "global"},
 	}
 	var resp0 structs.NodeUpdateResponse
@@ -1307,16 +1317,18 @@ func TestCSIVolumeEndpoint_DeleteSnapshot(t *testing.T) {
 	codec := rpcClient(t, srv)
 	index := uint64(1000)
 
-	node.CSIControllerPlugins = map[string]*structs.CSIInfo{
-		"minnie": {
-			PluginID: "minnie",
-			Healthy:  true,
-			ControllerInfo: &structs.CSIControllerInfo{
-				SupportsCreateDeleteSnapshot: true,
+	node := client.UpdateConfig(func(c *cconfig.Config) {
+		c.Node.CSIControllerPlugins = map[string]*structs.CSIInfo{
+			"minnie": {
+				PluginID: "minnie",
+				Healthy:  true,
+				ControllerInfo: &structs.CSIControllerInfo{
+					SupportsCreateDeleteSnapshot: true,
+				},
+				RequiresControllerPlugin: true,
 			},
-			RequiresControllerPlugin: true,
-		},
-	}
+		}
+	}).Node
 	index++
 	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, index, node))
 
@@ -1383,9 +1395,8 @@ func TestCSIVolumeEndpoint_ListSnapshots(t *testing.T) {
 	)
 	defer cleanup()
 
-	node := client.Node()
 	req0 := &structs.NodeRegisterRequest{
-		Node:         node,
+		Node:         client.Node(),
 		WriteRequest: structs.WriteRequest{Region: "global"},
 	}
 	var resp0 structs.NodeUpdateResponse
@@ -1403,16 +1414,18 @@ func TestCSIVolumeEndpoint_ListSnapshots(t *testing.T) {
 	codec := rpcClient(t, srv)
 	index := uint64(1000)
 
-	node.CSIControllerPlugins = map[string]*structs.CSIInfo{
-		"minnie": {
-			PluginID: "minnie",
-			Healthy:  true,
-			ControllerInfo: &structs.CSIControllerInfo{
-				SupportsListSnapshots: true,
+	node := client.UpdateConfig(func(c *cconfig.Config) {
+		c.Node.CSIControllerPlugins = map[string]*structs.CSIInfo{
+			"minnie": {
+				PluginID: "minnie",
+				Healthy:  true,
+				ControllerInfo: &structs.CSIControllerInfo{
+					SupportsListSnapshots: true,
+				},
+				RequiresControllerPlugin: true,
 			},
-			RequiresControllerPlugin: true,
-		},
-	}
+		}
+	}).Node
 	index++
 	require.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, index, node))
 

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -541,7 +541,7 @@ func (n *Node) UpdateStatus(args *structs.NodeUpdateStatusRequest, reply *struct
 	reply.Index = index
 	n.srv.peerLock.RLock()
 	defer n.srv.peerLock.RUnlock()
-	if err := n.constructNodeServerInfoResponse(node.GetID(), snap, reply); err != nil {
+	if err := n.constructNodeServerInfoResponse(node.ID, snap, reply); err != nil {
 		n.logger.Error("failed to populate NodeUpdateResponse", "error", err)
 		return err
 	}
@@ -793,7 +793,7 @@ func (n *Node) Evaluate(args *structs.NodeEvaluateRequest, reply *structs.NodeUp
 
 	n.srv.peerLock.RLock()
 	defer n.srv.peerLock.RUnlock()
-	if err := n.constructNodeServerInfoResponse(node.GetID(), snap, reply); err != nil {
+	if err := n.constructNodeServerInfoResponse(node.ID, snap, reply); err != nil {
 		n.logger.Error("failed to populate NodeUpdateResponse", "error", err)
 		return err
 	}

--- a/nomad/server_setup_oss.go
+++ b/nomad/server_setup_oss.go
@@ -5,12 +5,23 @@ package nomad
 
 import (
 	"github.com/hashicorp/consul/agent/consul/autopilot"
+	"golang.org/x/exp/slices"
 )
 
 // LicenseConfig allows for tunable licensing config
 // primarily used for enterprise testing
 type LicenseConfig struct {
 	AdditionalPubKeys []string
+}
+
+func (c *LicenseConfig) Copy() *LicenseConfig {
+	if c == nil {
+		return nil
+	}
+
+	nc := *c
+	nc.AdditionalPubKeys = slices.Clone(c.AdditionalPubKeys)
+	return &nc
 }
 
 type EnterpriseState struct{}

--- a/nomad/structs/config/sentinel.go
+++ b/nomad/structs/config/sentinel.go
@@ -1,9 +1,24 @@
 package config
 
+import (
+	"github.com/hashicorp/nomad/helper"
+	"golang.org/x/exp/slices"
+)
+
 // SentinelConfig is configuration specific to Sentinel
 type SentinelConfig struct {
 	// Imports are the configured imports
 	Imports []*SentinelImport `hcl:"import,expand"`
+}
+
+func (s *SentinelConfig) Copy() *SentinelConfig {
+	if s == nil {
+		return nil
+	}
+
+	ns := *s
+	ns.Imports = helper.CopySlice(s.Imports)
+	return &ns
 }
 
 // SentinelImport is used per configured import
@@ -11,6 +26,16 @@ type SentinelImport struct {
 	Name string   `hcl:",key"`
 	Path string   `hcl:"path"`
 	Args []string `hcl:"args"`
+}
+
+func (s *SentinelImport) Copy() *SentinelImport {
+	if s == nil {
+		return nil
+	}
+
+	ns := *s
+	ns.Args = slices.Clone(s.Args)
+	return &ns
 }
 
 // Merge is used to merge two Sentinel configs together. The settings from the input always take precedence.

--- a/nomad/structs/config/tls.go
+++ b/nomad/structs/config/tls.go
@@ -125,16 +125,6 @@ func (k *KeyLoader) GetClientCertificate(*tls.CertificateRequestInfo) (*tls.Cert
 	return k.certificate, nil
 }
 
-func (k *KeyLoader) Copy() *KeyLoader {
-	if k == nil {
-		return nil
-	}
-
-	new := KeyLoader{}
-	new.certificate = k.certificate
-	return &new
-}
-
 // GetKeyLoader returns the keyloader for a TLSConfig object. If the keyloader
 // has not been initialized, it will first do so.
 func (t *TLSConfig) GetKeyLoader() *KeyLoader {
@@ -162,8 +152,12 @@ func (t *TLSConfig) Copy() *TLSConfig {
 	new.CAFile = t.CAFile
 	new.CertFile = t.CertFile
 
+	// Shallow copy the key loader as its GetOutgoingCertificate method is what
+	// is used by the HTTP server to retrieve the certificate. If we create a new
+	// KeyLoader struct, the HTTP server will still be calling the old
+	// GetOutgoingCertificate method.
 	t.keyloaderLock.Lock()
-	new.KeyLoader = t.KeyLoader.Copy()
+	new.KeyLoader = t.KeyLoader
 	t.keyloaderLock.Unlock()
 
 	new.KeyFile = t.KeyFile

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -125,6 +125,15 @@ type AutopilotConfig struct {
 	ModifyIndex uint64
 }
 
+func (a *AutopilotConfig) Copy() *AutopilotConfig {
+	if a == nil {
+		return nil
+	}
+
+	na := *a
+	return &na
+}
+
 // SchedulerAlgorithm is an enum string that encapsulates the valid options for a
 // SchedulerConfiguration stanza's SchedulerAlgorithm. These modes will allow the
 // scheduler to be user-selectable.
@@ -159,6 +168,15 @@ type SchedulerConfiguration struct {
 	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
 	CreateIndex uint64
 	ModifyIndex uint64
+}
+
+func (s *SchedulerConfiguration) Copy() *SchedulerConfiguration {
+	if s == nil {
+		return s
+	}
+
+	ns := *s
+	return &ns
 }
 
 func (s *SchedulerConfiguration) EffectiveSchedulerAlgorithm() SchedulerAlgorithm {

--- a/nomad/structs/search.go
+++ b/nomad/structs/search.go
@@ -58,6 +58,15 @@ type SearchConfig struct {
 	MinTermLength int `hcl:"min_term_length"`
 }
 
+func (s *SearchConfig) Copy() *SearchConfig {
+	if s == nil {
+		return nil
+	}
+
+	ns := *s
+	return &ns
+}
+
 // SearchResponse is used to return matches and information about whether
 // the match list is truncated specific to each type of Context.
 type SearchResponse struct {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2031,9 +2031,8 @@ func (n *Node) Copy() *Node {
 	if n == nil {
 		return nil
 	}
-	nn := new(Node)
-	*nn = *n
-	nn.Attributes = helper.CopyMapStringString(nn.Attributes)
+	nn := *n
+	nn.Attributes = helper.CopyMap(nn.Attributes)
 	nn.NodeResources = nn.NodeResources.Copy()
 	nn.ReservedResources = nn.ReservedResources.Copy()
 	nn.Resources = nn.Resources.Copy()
@@ -2041,87 +2040,14 @@ func (n *Node) Copy() *Node {
 	nn.Links = helper.CopyMapStringString(nn.Links)
 	nn.Meta = helper.CopyMapStringString(nn.Meta)
 	nn.DrainStrategy = nn.DrainStrategy.Copy()
-	nn.Events = copyNodeEvents(n.Events)
-	nn.Drivers = copyNodeDrivers(n.Drivers)
-	nn.CSIControllerPlugins = copyNodeCSI(nn.CSIControllerPlugins)
-	nn.CSINodePlugins = copyNodeCSI(nn.CSINodePlugins)
-	nn.HostVolumes = copyNodeHostVolumes(n.HostVolumes)
-	nn.HostNetworks = copyNodeHostNetworks(n.HostNetworks)
+	nn.Events = helper.CopySlice(n.Events)
+	nn.Drivers = helper.DeepCopyMap(n.Drivers)
+	nn.CSIControllerPlugins = helper.DeepCopyMap(nn.CSIControllerPlugins)
+	nn.CSINodePlugins = helper.DeepCopyMap(nn.CSINodePlugins)
+	nn.HostVolumes = helper.DeepCopyMap(n.HostVolumes)
+	nn.HostNetworks = helper.DeepCopyMap(n.HostNetworks)
 	nn.LastDrain = nn.LastDrain.Copy()
-	return nn
-}
-
-// copyNodeEvents is a helper to copy a list of NodeEvent's
-func copyNodeEvents(events []*NodeEvent) []*NodeEvent {
-	l := len(events)
-	if l == 0 {
-		return nil
-	}
-
-	c := make([]*NodeEvent, l)
-	for i, event := range events {
-		c[i] = event.Copy()
-	}
-	return c
-}
-
-// copyNodeCSI is a helper to copy a map of CSIInfo
-func copyNodeCSI(plugins map[string]*CSIInfo) map[string]*CSIInfo {
-	l := len(plugins)
-	if l == 0 {
-		return nil
-	}
-
-	c := make(map[string]*CSIInfo, l)
-	for plugin, info := range plugins {
-		c[plugin] = info.Copy()
-	}
-
-	return c
-}
-
-// copyNodeDrivers is a helper to copy a map of DriverInfo
-func copyNodeDrivers(drivers map[string]*DriverInfo) map[string]*DriverInfo {
-	l := len(drivers)
-	if l == 0 {
-		return nil
-	}
-
-	c := make(map[string]*DriverInfo, l)
-	for driver, info := range drivers {
-		c[driver] = info.Copy()
-	}
-	return c
-}
-
-// copyNodeHostVolumes is a helper to copy a map of string to Volume
-func copyNodeHostVolumes(volumes map[string]*ClientHostVolumeConfig) map[string]*ClientHostVolumeConfig {
-	l := len(volumes)
-	if l == 0 {
-		return nil
-	}
-
-	c := make(map[string]*ClientHostVolumeConfig, l)
-	for volume, v := range volumes {
-		c[volume] = v.Copy()
-	}
-
-	return c
-}
-
-// copyNodeHostVolumes is a helper to copy a map of string to HostNetwork
-func copyNodeHostNetworks(networks map[string]*ClientHostNetworkConfig) map[string]*ClientHostNetworkConfig {
-	l := len(networks)
-	if l == 0 {
-		return nil
-	}
-
-	c := make(map[string]*ClientHostNetworkConfig, l)
-	for network, v := range networks {
-		c[network] = v.Copy()
-	}
-
-	return c
+	return &nn
 }
 
 // TerminalStatus returns if the current status is terminal and

--- a/version/version.go
+++ b/version/version.go
@@ -30,6 +30,15 @@ type VersionInfo struct {
 	VersionMetadata   string
 }
 
+func (v *VersionInfo) Copy() *VersionInfo {
+	if v == nil {
+		return nil
+	}
+
+	nv := *v
+	return &nv
+}
+
 func GetVersion() *VersionInfo {
 	ver := Version
 	rel := VersionPrerelease


### PR DESCRIPTION
Before this change, Client had 2 copies of the config object: config and configCopy. There was no guidance around which to use where (other than configCopy's comment to pass it to alloc runners), both are shared among goroutines and mutated in data racy ways. At least at one point I think the idea was to have `config` be mutable and then grab a lock to overwrite `configCopy`'s pointer atomically. This would have allowed alloc runners to read their config copies in data race safe ways, but this isn't how the current implementation worked.

This change takes the following approach to safely handling configs in the client:

1. `Client.config` is the only copy of the config and all access must go through the `Client.configLock` mutex
2. Since the mutex *only protects the config pointer itself and not fields inside the Config struct:* all config mutation must be done on a *copy* of the config, and then Client's config pointer is overwritten while the mutex is acquired. Alloc runners and other goroutines with the old config pointer will not see config updates.
3. Deep copying is implemented on the Config struct to satisfy the previous approach. The TLS Keyloader is an exception because it has its own internal locking to support mutating in place. An unfortunate complication but one I couldn't find a way to untangle in a timely fashion.
4. To facilitate deep copying I made an *internally backward incompatible API change:* our `helper/funcs` used to turn containers (slices and maps) with 0 elements into nils. This probably saves a few memory allocations but makes it very easy to cause panics. Since my new config handling approach uses more copying, it became very difficult to ensure all code that used containers on configs could handle nils properly. Since this code has caused panics in the past, I fixed it: nil containers are copied as nil, but 0-element containers properly return a new 0-element container. No more "downgrading to nil!"