### PR TITLE
[ui] Service Discovery: provide a quick link to the Consul UI if available

### DIFF
--- a/ui/app/components/allocation-service-sidebar.hbs
+++ b/ui/app/components/allocation-service-sidebar.hbs
@@ -10,15 +10,17 @@
 		<header class="detail-header">
 			<h1 class="title">
 				{{@service.name}}
-				<span class="aggregate-status">
-					{{#if (eq this.aggregateStatus 'Unhealthy')}}
-						<FlightIcon @name="x-square-fill" @color="#c84034" />
-						Unhealthy
-					{{else}}
-						<FlightIcon @name="check-square-fill" @color="#25ba81" />
-						Healthy
-					{{/if}}
-				</span>
+				{{#if (not-eq @service.provider "consul")}}
+					<span class="aggregate-status">
+						{{#if (eq this.aggregateStatus 'Unhealthy')}}
+							<FlightIcon @name="x-square-fill" @color="#c84034" />
+							Unhealthy
+						{{else}}
+							<FlightIcon @name="check-square-fill" @color="#25ba81" />
+							Healthy
+						{{/if}}
+					</span>
+				{{/if}}
 			</h1>
 			<button
 				data-test-close-service-sidebar

--- a/ui/app/components/allocation-service-sidebar.hbs
+++ b/ui/app/components/allocation-service-sidebar.hbs
@@ -128,5 +128,12 @@
 				</t.body>
 			</ListTable>
 		{{/if}}
+		{{#if (and (eq @service.provider "consul") this.consulRedirectLink)}}
+		<div data-test-consul-link-notice class="notification is-info">
+			<p>
+				Nomad cannot read health check information from Consul services, but you can <a href={{this.consulRedirectLink}} target="_blank" rel="noopener noreferrer">view this information in your Consul UI</a>.
+			</p>
+		</div>
+		{{/if}}
 	{{/if}}
 </div>

--- a/ui/app/components/allocation-service-sidebar.js
+++ b/ui/app/components/allocation-service-sidebar.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default class AllocationServiceSidebarComponent extends Component {
   @service store;
+  @service system;
 
   get isSideBarOpen() {
     return !!this.args.service;
@@ -35,6 +36,10 @@ export default class AllocationServiceSidebarComponent extends Component {
     return this.checks.any((check) => check.Status === 'failure')
       ? 'Unhealthy'
       : 'Healthy';
+  }
+
+  get consulRedirectLink() {
+    return this.system.agent.get('config')?.UI?.Consul?.BaseUIURL;
   }
 
   get checks() {

--- a/ui/app/components/job-service-row.js
+++ b/ui/app/components/job-service-row.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 
 export default class JobServiceRowComponent extends Component {
   @service router;
+  @service system;
 
   @action
   gotoService(service) {
@@ -13,5 +14,9 @@ export default class JobServiceRowComponent extends Component {
         instances: service.instances,
       });
     }
+  }
+
+  get consulRedirectLink() {
+    return this.system.agent.get('config')?.UI?.Consul?.BaseUIURL;
   }
 }

--- a/ui/app/templates/components/job-service-row.hbs
+++ b/ui/app/templates/components/job-service-row.hbs
@@ -18,7 +18,13 @@
 			<LinkTo class="is-primary" @route="jobs.job.services.service" @model={{@service}} @query={{hash level=@service.level}}>{{@service.name}}</LinkTo>
 		{{else}}
 			<FlightIcon @name="consul-color" />
-			{{@service.name}}
+			{{#if (and (eq @service.provider "consul") this.consulRedirectLink)}}
+				<a class="is-primary" href={{this.consulRedirectLink}} target="_blank" rel="noopener noreferrer">
+					{{@service.name}}
+				</a>
+			{{else}}
+				{{@service.name}}
+			{{/if}}
 		{{/if}}
   </td>
 	<td>

--- a/ui/tests/integration/components/allocation-service-sidebar-test.js
+++ b/ui/tests/integration/components/allocation-service-sidebar-test.js
@@ -104,6 +104,8 @@ module(
       assert.dom('table.health-checks').doesNotExist();
       assert.dom('[data-test-consul-link-notice]').doesNotExist();
 
+      this.system.agent.config.UI.Consul.BaseUIURL = 'http://localhost:8500';
+
       await render(
         hbs`<AllocationServiceSidebar @service={{this.service}} @fns={{hash closeSidebar=this.closeSidebar}} />`
       );


### PR DESCRIPTION
If you pop open a Consul service, and you've configured your [UI stanza to have a consul link](https://www.nomadproject.io/docs/configuration/ui), use that link to redirect a user for better pathfinding.

Just a nice little quality of life thing. Resolves #14530

![image](https://user-images.githubusercontent.com/713991/189433356-19ace11a-1e80-4e3c-a3db-00f66303b1e2.png)
