### PR TITLE
2 small data race fixes in logmon and check tests

### DIFF
--- a/client/logmon/logging/rotator.go
+++ b/client/logmon/logging/rotator.go
@@ -38,10 +38,13 @@ type FileRotator struct {
 	MaxFiles int   // MaxFiles is the maximum number of rotated files allowed in a path
 	FileSize int64 // FileSize is the size a rotated file is allowed to grow
 
-	path             string // path is the path on the file system where the rotated set of files are opened
-	baseFileName     string // baseFileName is the base file name of the rotated files
-	logFileIdx       int    // logFileIdx is the current index of the rotated files
-	oldestLogFileIdx int    // oldestLogFileIdx is the index of the oldest log file in a path
+	path         string // path is the path on the file system where the rotated set of files are opened
+	baseFileName string // baseFileName is the base file name of the rotated files
+	logFileIdx   int    // logFileIdx is the current index of the rotated files
+
+	oldestLogFileIdx int // oldestLogFileIdx is the index of the oldest log file in a path
+	closed           bool
+	fileLock         sync.Mutex
 
 	currentFile *os.File // currentFile is the file that is currently getting written
 	currentWr   int64    // currentWr is the number of bytes written to the current file
@@ -52,9 +55,6 @@ type FileRotator struct {
 	logger      hclog.Logger
 	purgeCh     chan struct{}
 	doneCh      chan struct{}
-
-	closed     bool
-	closedLock sync.Mutex // also used to guard oldestLogFileIdx
 }
 
 // NewFileRotator returns a new file rotator
@@ -176,8 +176,8 @@ func (f *FileRotator) nextFile() error {
 		break
 	}
 	// Purge old files if we have more files than MaxFiles
-	f.closedLock.Lock()
-	defer f.closedLock.Unlock()
+	f.fileLock.Lock()
+	defer f.fileLock.Unlock()
 	if f.logFileIdx-f.oldestLogFileIdx >= f.MaxFiles && !f.closed {
 		select {
 		case f.purgeCh <- struct{}{}:
@@ -250,8 +250,8 @@ func (f *FileRotator) flushPeriodically() {
 
 // Close flushes and closes the rotator. It never returns an error.
 func (f *FileRotator) Close() error {
-	f.closedLock.Lock()
-	defer f.closedLock.Unlock()
+	f.fileLock.Lock()
+	defer f.fileLock.Unlock()
 
 	// Stop the ticker and flush for one last time
 	f.flushTicker.Stop()
@@ -311,9 +311,9 @@ func (f *FileRotator) purgeOldFiles() {
 				}
 			}
 
-			f.closedLock.Lock()
+			f.fileLock.Lock()
 			f.oldestLogFileIdx = fIndexes[0]
-			f.closedLock.Unlock()
+			f.fileLock.Unlock()
 		case <-f.doneCh:
 			return
 		}

--- a/client/logmon/logging/rotator.go
+++ b/client/logmon/logging/rotator.go
@@ -54,7 +54,7 @@ type FileRotator struct {
 	doneCh      chan struct{}
 
 	closed     bool
-	closedLock sync.Mutex
+	closedLock sync.Mutex // also used to guard oldestLogFileIdx
 }
 
 // NewFileRotator returns a new file rotator
@@ -310,7 +310,10 @@ func (f *FileRotator) purgeOldFiles() {
 					f.logger.Error("error removing file", "filename", fname, "error", err)
 				}
 			}
+
+			f.closedLock.Lock()
 			f.oldestLogFileIdx = fIndexes[0]
+			f.closedLock.Unlock()
 		case <-f.doneCh:
 			return
 		}

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
@@ -708,4 +709,11 @@ OUTER:
 		return false
 	}
 	return true
+}
+
+// WithLock executes a function while holding a lock.
+func WithLock(lock sync.Locker, f func()) {
+	lock.Lock()
+	defer lock.Unlock()
+	f()
 }


### PR DESCRIPTION
Trying to make some progress on #14236

While the logmon race is in runtime code, I don't think it could account for any logging related issues I see. I think the worst it could do is cause purging to happen too often or not often enough, but unless the *other* logic is wrong in purgeOldFiles that shouldn't cause logging to fail. Just use too much disk space or not as much as it could.

The WithLock helper really shouldn't be used outside of tests where we often "peek into" the state of structs that require locking semantics. I could move it into `testutil` if you think that's a better idea.