### PR TITLE
variables: restrict allowed paths for variables

### DIFF
--- a/nomad/structs/variables_test.go
+++ b/nomad/structs/variables_test.go
@@ -51,6 +51,9 @@ func TestStructs_VariableDecrypted_Validate(t *testing.T) {
 		{path: "nomad/jobs", ok: true},
 		{path: "nomadjobs", ok: true},
 		{path: "nomad/jobs/whatever", ok: true},
+		{path: "example/_-~/whatever", ok: true},
+		{path: "example/@whatever"},
+		{path: "example/what.ever"},
 	}
 	for _, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/14244

Restrict variable paths to RFC3986 URL-safe characters that don't conflict with the use of characters "@" and "." in `template` blocks. This prevents users from writing variables that will require tricky templating syntax or that they simply won't be able to use.

Also restrict the length so that a user can't make queries in the state store unusually expensive (as they are O(k) on the key length).