### PR TITLE
[vars] Make `var list` flags match other var commands

### DIFF
--- a/command/var.go
+++ b/command/var.go
@@ -322,8 +322,10 @@ const (
 	errMissingTemplate             = `A template must be supplied using '-template' when using go-template formatting`
 	errUnexpectedTemplate          = `The '-template' flag is only valid when using 'go-template' formatting`
 	errVariableNotFound            = `Variable not found`
+	errNoMatchingVariables         = `No matching variables found`
 	errInvalidInFormat             = `Invalid value for "-in"; valid values are [hcl, json]`
 	errInvalidOutFormat            = `Invalid value for "-out"; valid values are [go-template, hcl, json, none, table]`
+	errInvalidListOutFormat        = `Invalid value for "-out"; valid values are [go-template, json, table, terse]`
 	errWildcardNamespaceNotAllowed = `The wildcard namespace ("*") is not valid for this command.`
 
 	msgfmtCASMismatch = `


### PR DESCRIPTION
Renames `-q` to `-out=terse`. Removed the combination of `-json` and `-q` since it was of uncertain value because the expectation is that json output would be post-processed anyway
