### PR TITLE
variables: change spec file extension to match rename

### DIFF
--- a/command/var_init.go
+++ b/command/var_init.go
@@ -15,11 +15,11 @@ import (
 const (
 	// DefaultHclVarInitName is the default name we use when initializing the
 	// example var file in HCL format
-	DefaultHclVarInitName = "spec.nsv.hcl"
+	DefaultHclVarInitName = "spec.nv.hcl"
 
 	// DefaultHclVarInitName is the default name we use when initializing the
 	// example var file in JSON format
-	DefaultJsonVarInitName = "spec.nsv.json"
+	DefaultJsonVarInitName = "spec.nv.json"
 )
 
 // VarInitCommand generates a new variable specification
@@ -33,7 +33,7 @@ Usage: nomad var init <filename>
 
   Creates an example variable specification file that can be used as a starting
   point to customize further. When no filename is supplied, a default filename
-  of "spec.nsv.hcl" or "spec.nsv.json" will be used depending on the output
+  of "spec.nv.hcl" or "spec.nv.json" will be used depending on the output
   format.
 
 Init Options:

--- a/command/var_init_test.go
+++ b/command/var_init_test.go
@@ -40,10 +40,10 @@ func TestVarInitCommand_Run(t *testing.T) {
 		// Works if the file doesn't exist
 		ec = cmd.Run([]string{"-out", "hcl"})
 		require.Empty(t, ui.ErrorWriter.String())
-		require.Equal(t, "Example variable specification written to spec.nsv.hcl\n", ui.OutputWriter.String())
+		require.Equal(t, "Example variable specification written to spec.nv.hcl\n", ui.OutputWriter.String())
 		require.Zero(t, ec)
 		reset(ui)
-		t.Cleanup(func() { os.Remove(path.Join(dir, "spec.nsv.hcl")) })
+		t.Cleanup(func() { os.Remove(path.Join(dir, "spec.nv.hcl")) })
 
 		content, err := os.ReadFile(DefaultHclVarInitName)
 		require.NoError(t, err)
@@ -84,11 +84,11 @@ func TestVarInitCommand_Run(t *testing.T) {
 		// Works if the file doesn't exist
 		code = cmd.Run([]string{"-out", "json"})
 		require.Contains(t, ui.ErrorWriter.String(), "REMINDER: While keys")
-		require.Contains(t, ui.OutputWriter.String(), "Example variable specification written to spec.nsv.json\n")
+		require.Contains(t, ui.OutputWriter.String(), "Example variable specification written to spec.nv.json\n")
 		require.Zero(t, code)
 		reset(ui)
 
-		t.Cleanup(func() { os.Remove(path.Join(dir, "spec.nsv.json")) })
+		t.Cleanup(func() { os.Remove(path.Join(dir, "spec.nv.json")) })
 		content, err := os.ReadFile(DefaultJsonVarInitName)
 		require.NoError(t, err)
 		require.Equal(t, defaultJsonVarSpec, string(content))

--- a/command/var_put.go
+++ b/command/var_put.go
@@ -52,7 +52,7 @@ nomad var put [options] <path to store variable> [<variable spec file reference>
   with no additional processing and do not require the input format to be
   specified.
 
-  Values supplied as command line arguments supersede values provided in the
+  Values supplied as command line arguments supersede values provided in
   any variable specification piped into the command or loaded from file.
 
   If ACLs are enabled, this command requires the 'variables:write' capability


### PR DESCRIPTION
Also fixes a typo in the `var put` help text.