### PR TITLE
servicedisco: implement check_restart support for nomad service checks

### DIFF
--- a/client/allocrunner/taskrunner/service_hook.go
+++ b/client/allocrunner/taskrunner/service_hook.go
@@ -46,6 +46,7 @@ type serviceHookConfig struct {
 type serviceHook struct {
 	allocID   string
 	jobID     string
+	groupName string
 	taskName  string
 	restarter serviceregistration.WorkloadRestarter
 	logger    log.Logger
@@ -84,6 +85,7 @@ func newServiceHook(c serviceHookConfig) *serviceHook {
 	h := &serviceHook{
 		allocID:           c.alloc.ID,
 		jobID:             c.alloc.JobID,
+		groupName:         c.alloc.TaskGroup,
 		taskName:          c.task.Name,
 		namespace:         c.namespace,
 		serviceRegWrapper: c.serviceRegWrapper,
@@ -221,6 +223,7 @@ func (h *serviceHook) getWorkloadServices() *serviceregistration.WorkloadService
 	return &serviceregistration.WorkloadServices{
 		AllocID:       h.allocID,
 		JobID:         h.jobID,
+		Group:         h.groupName,
 		Task:          h.taskName,
 		Namespace:     h.namespace,
 		Restarter:     h.restarter,

--- a/client/client.go
+++ b/client/client.go
@@ -691,7 +691,7 @@ func (c *Client) init() error {
 	// startup the CPUSet manager
 	c.cpusetManager.Init()
 
-	// setup the check store
+	// setup the nsd check store
 	c.checkStore = checkstore.NewStore(c.logger, c.stateDB)
 
 	return nil
@@ -2607,6 +2607,9 @@ func (c *Client) setupNomadServiceRegistrationHandler() {
 		NodeSecret: c.secretNodeID(),
 		Region:     c.Region(),
 		RPCFn:      c.RPC,
+		CheckWatcher: serviceregistration.NewCheckWatcher(
+			c.logger, nsd.NewStatusGetter(c.checkStore),
+		),
 	}
 	c.nomadService = nsd.NewServiceRegistrationHandler(c.logger, &cfg)
 }

--- a/client/serviceregistration/nsd/statuses.go
+++ b/client/serviceregistration/nsd/statuses.go
@@ -1,0 +1,25 @@
+package nsd
+
+import (
+	"github.com/hashicorp/nomad/client/serviceregistration/checks/checkstore"
+)
+
+func NewStatusGetter(shim checkstore.Shim) *StatusGetter {
+	return &StatusGetter{
+		shim: shim,
+	}
+}
+
+// StatusGetter is the implementation of CheckStatusGetter for Nomad services.
+type StatusGetter struct {
+	// Unlike consul we can simply query for check status information from our
+	// own Client state store.
+	shim checkstore.Shim
+}
+
+// Get returns current status of every live check in the Nomad service provider.
+//
+// returns checkID => checkStatus
+func (s StatusGetter) Get() (map[string]string, error) {
+	return s.shim.Snapshot(), nil
+}

--- a/client/serviceregistration/nsd/statuses_test.go
+++ b/client/serviceregistration/nsd/statuses_test.go
@@ -1,0 +1,48 @@
+package nsd
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/client/serviceregistration"
+	"github.com/hashicorp/nomad/client/serviceregistration/checks/checkstore"
+	"github.com/hashicorp/nomad/client/state"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+)
+
+var _ serviceregistration.CheckStatusGetter = (*StatusGetter)(nil)
+
+func TestStatusGetter_Get(t *testing.T) {
+	ci.Parallel(t)
+	logger := testlog.HCLogger(t)
+
+	db := state.NewMemDB(logger)
+	s := checkstore.NewStore(logger, db)
+
+	// setup some sample check results
+	id1, id2, id3 := uuid.Short(), uuid.Short(), uuid.Short()
+	must.NoError(t, s.Set("allocation1", &structs.CheckQueryResult{
+		ID:     structs.CheckID(id1),
+		Status: "passing",
+	}))
+	must.NoError(t, s.Set("allocation1", &structs.CheckQueryResult{
+		ID:     structs.CheckID(id2),
+		Status: "failing",
+	}))
+	must.NoError(t, s.Set("allocation2", &structs.CheckQueryResult{
+		ID:     structs.CheckID(id3),
+		Status: "passing",
+	}))
+
+	getter := StatusGetter{shim: s}
+	snap, err := getter.Get()
+	must.NoError(t, err)
+	must.MapEq(t, map[string]string{
+		id1: "passing",
+		id2: "failing",
+		id3: "passing",
+	}, snap)
+}

--- a/client/serviceregistration/watcher_test.go
+++ b/client/serviceregistration/watcher_test.go
@@ -107,19 +107,19 @@ type fakeCheckStatusGetter struct {
 	responses map[string][]response
 }
 
-func (g *fakeCheckStatusGetter) Get() (map[string]CheckStatus, error) {
+func (g *fakeCheckStatusGetter) Get() (map[string]string, error) {
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
 	now := time.Now()
-	result := make(map[string]CheckStatus)
+	result := make(map[string]string)
 	// use the newest response after now for the response
 	for k, vs := range g.responses {
 		for _, v := range vs {
 			if v.at.After(now) {
 				break
 			}
-			result[k] = CheckStatus{Status: v.status}
+			result[k] = v.status
 		}
 	}
 

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -419,7 +419,6 @@ type ServiceClient struct {
 	deregisterProbationExpiry time.Time
 
 	// checkWatcher restarts checks that are unhealthy.
-	// checkWatcher *checkWatcher
 	checkWatcher *serviceregistration.CheckWatcher
 
 	// isClientAgent specifies whether this Consul client is being used
@@ -433,14 +432,14 @@ type checkStatusGetter struct {
 	namespacesClient *NamespacesClient
 }
 
-func (csg *checkStatusGetter) Get() (map[string]serviceregistration.CheckStatus, error) {
+func (csg *checkStatusGetter) Get() (map[string]string, error) {
 	// Get the list of all namespaces so we can iterate them.
 	namespaces, err := csg.namespacesClient.List()
 	if err != nil {
 		return nil, err
 	}
 
-	results := make(map[string]serviceregistration.CheckStatus)
+	results := make(map[string]string)
 	for _, namespace := range namespaces {
 		resultsInNamespace, err := csg.agentAPI.ChecksWithFilterOpts("", &api.QueryOptions{Namespace: normalizeNamespace(namespace)})
 		if err != nil {
@@ -448,9 +447,7 @@ func (csg *checkStatusGetter) Get() (map[string]serviceregistration.CheckStatus,
 		}
 
 		for k, v := range resultsInNamespace {
-			results[k] = serviceregistration.CheckStatus{
-				Status: v.Status,
-			}
+			results[k] = v.Status
 		}
 	}
 	return results, nil

--- a/nomad/mock/checks.go
+++ b/nomad/mock/checks.go
@@ -28,3 +28,7 @@ func (s *CheckShim) Remove(allocID string, ids []structs.CheckID) error {
 func (s *CheckShim) Purge(allocID string) error {
 	return nil
 }
+
+func (s *CheckShim) Snapshot() map[string]string {
+	return nil
+}

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -346,9 +346,11 @@ func (sc *ServiceCheck) validateNomad() error {
 	// below are temporary limitations on checks in nomad
 	// https://github.com/hashicorp/team-nomad/issues/354
 
-	// check_restart not yet supported on nomad
+	// check_restart.ignore_warnings is not a thing in Nomad (which has no warnings in checks)
 	if sc.CheckRestart != nil {
-		return fmt.Errorf("check_restart may only be set for Consul service checks")
+		if sc.CheckRestart.IgnoreWarnings {
+			return fmt.Errorf("ignore_warnings on check_restart only supported for Consul service checks")
+		}
 	}
 
 	// address_mode="driver" not yet supported on nomad

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -281,7 +281,18 @@ func TestServiceCheck_validateNomad(t *testing.T) {
 				Timeout:      1 * time.Second,
 				CheckRestart: new(CheckRestart),
 			},
-			exp: `check_restart may only be set for Consul service checks`,
+		},
+		{
+			name: "check_restart ignore_warnings",
+			sc: &ServiceCheck{
+				Type:     ServiceCheckTCP,
+				Interval: 3 * time.Second,
+				Timeout:  1 * time.Second,
+				CheckRestart: &CheckRestart{
+					IgnoreWarnings: true,
+				},
+			},
+			exp: `ignore_warnings on check_restart only supported for Consul service checks`,
 		},
 		{
 			name: "address mode driver",


### PR DESCRIPTION
~Merge the check watcher refactor first: https://github.com/hashicorp/nomad/pull/14546~


This PR implements support for `check_restart` for checks registered in the Nomad service provider. The actual
monitoring/restarting logic is shared with the Consul provider, via the PR above. Here we just fill in the blank
for the `CheckStatusGetter` interface for the Nomad provider and plug it in.

Unlike Consul, Nomad service checks never report a `"warning"` status, and so the `check_restart.ignore_warnings` configuration is not valid for Nomad service checks.

Closes #14370

Note: the interface + mock refactoring I'll also take care of as part of the cleanup in https://github.com/hashicorp/nomad/issues/14548

Will also follow up with docs + e2e testing. 