### PR TITLE
docs: include path in ACL requirements for variables

### DIFF
--- a/command/var_get.go
+++ b/command/var_get.go
@@ -24,7 +24,7 @@ Usage: nomad var get [options] <path>
   The 'var get' command is used to get the contents of an existing variable.
 
   If ACLs are enabled, this command requires a token with the 'variables:read'
-  capability for the target variable's namespace.
+  capability for the target variable's namespace and path.
 
 General Options:
 

--- a/command/var_list.go
+++ b/command/var_list.go
@@ -33,7 +33,7 @@ Usage: nomad var list [options] <prefix>
   variables from that page.
 
   If ACLs are enabled, this command will only return variables stored in
-  namespaces where the token has the 'variables:list' capability.
+  namespaces and paths where the token has the 'variables:list' capability.
 
 General Options:
 

--- a/command/var_purge.go
+++ b/command/var_purge.go
@@ -21,7 +21,7 @@ Usage: nomad var purge [options] <path>
   Purge is used to permanently delete an existing variable.
 
   If ACLs are enabled, this command requires a token with the 'variables:destroy'
-  capability for the target variable's namespace.
+  capability for the target variable's namespace and path.
 
 General Options:
 

--- a/command/var_put.go
+++ b/command/var_put.go
@@ -56,7 +56,7 @@ nomad var put [options] <path to store variable> [<variable spec file reference>
   any variable specification piped into the command or loaded from file.
 
   If ACLs are enabled, this command requires the 'variables:write' capability
-  for the destination namespace.
+  for the destination namespace and path.
 
 General Options:
 

--- a/website/content/docs/commands/var/get.mdx
+++ b/website/content/docs/commands/var/get.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Command: var get
 
-The `var get` command is used to get the contents of an existing variable.
+The `var get` command is used to get the contents of an existing [variable][].
 
 ## Usage
 
@@ -17,7 +17,8 @@ nomad var get [options] <path>
 ```
 
 If ACLs are enabled, this command requires a token with the `variables:read`
-capability for the target variable's namespace.
+capability for the target variable's namespace and path. See the [ACL policy][]
+documentation for details.
 
 ## General Options
 
@@ -59,3 +60,6 @@ Return only the "passcode" item from the variable stored at "secret/creds":
 $ nomad var get -item=passcode secret/creds
 my-long-passcode
 ```
+
+[variable]: /docs/concepts/variables
+[ACL Policy]: /docs/other-specifications/acl-policy#variables

--- a/website/content/docs/commands/var/list.mdx
+++ b/website/content/docs/commands/var/list.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Command: var list
 
-The `var list` command returns a list of variable paths accessible to the
+The `var list` command returns a list of [variable][] paths accessible to the
 current user, optionally filtered to paths containing a provided prefix. Do not
 encode sensitive information in variable paths. The variable's items are not
 accessible via this command.
@@ -27,7 +27,8 @@ nomad var list [options] [<prefix>]
 ```
 
 If ACLs are enabled, this command requires the `variables:list` capability for
-the namespaces containing the variables to list.
+the namespaces and paths containing the variables to list. See the [ACL policy][]
+documentation for details.
 
 ## General Options
 
@@ -135,3 +136,6 @@ $ nomad var list -out=json -namespace="*" -per-page=1 nomad/jobs/variable/www
 
 As with the tabular version, provide the `QueryMeta.NextToken` value as the
 `-page-token` value to fetch the next page.
+
+[variable]: /docs/concepts/variables
+[ACL Policy]: /docs/other-specifications/acl-policy#variables

--- a/website/content/docs/commands/var/purge.mdx
+++ b/website/content/docs/commands/var/purge.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Command: var purge
 
-The `var purge` command permanently deletes an existing variable from Nomad's
+The `var purge` command permanently deletes an existing [variable][] from Nomad's
 variable storage.
 
 ## Usage
@@ -20,7 +20,8 @@ nomad var purge [options] <path>
 The `var purge` command requires the path to the variable.
 
 If ACLs are enabled, this command requires a token with the `variables:destroy`
-capability for the target variable's namespace.
+capability for the target variable's namespace and path. See the [ACL policy][]
+documentation for details.
 
 ## General Options
 
@@ -42,3 +43,6 @@ Purge the variable at the "secret/creds" path.
 $ nomad var purge -y secret/creds
 Successfully purged variable "secret/creds"!
 ```
+
+[variable]: /docs/concepts/variables
+[ACL Policy]: /docs/other-specifications/acl-policy#variables

--- a/website/content/docs/commands/var/put.mdx
+++ b/website/content/docs/commands/var/put.mdx
@@ -7,7 +7,7 @@ description: |-
 
 # Command: var put
 
-The `var put` command creates or updates an existing variable.
+The `var put` command creates or updates an existing [variable][].
 
 ## Usage
 
@@ -33,7 +33,8 @@ additional processing and do not require the input format to be specified.
 Values supplied as command line arguments supersede values provided in any
 variable specification piped into the command or loaded from file. If ACLs are
 enabled, this command requires the `variables:write` capability for the
-destination namespace.
+destination namespace and path. See the [ACL policy][] documentation for
+details.
 
 ## General Options
 
@@ -85,3 +86,7 @@ Or it can be read from standard input using the "-" symbol:
 ```shell-session
 $ echo "abcd1234" | vault var put secret/foo bar=-
 ```
+
+
+[variable]: /docs/concepts/variables
+[ACL Policy]: /docs/other-specifications/acl-policy#variables


### PR DESCRIPTION
Also add links to the ACL policy reference and variables concepts docs near the top of the page.