### PR TITLE
Replacing nav-data Learn links with DevDot ones

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -23,11 +23,11 @@
           },
           {
             "title": "Reference Architecture",
-            "href": "https://learn.hashicorp.com/tutorials/nomad/production-reference-architecture-vm-with-consul"
+            "href": "/nomad/tutorials/enterprise/production-reference-architecture-vm-with-consul"
           },
           {
             "title": "Deployment Guide",
-            "href": "https://learn.hashicorp.com/tutorials/nomad/production-deployment-guide-vm-with-consul"
+            "href": "/nomad/tutorials/enterprise/production-deployment-guide-vm-with-consul"
           }
         ]
       },
@@ -2003,15 +2003,15 @@
       },
       {
         "title": "Cluster Management",
-        "href": "https://learn.hashicorp.com/collections/nomad/manage-clusters"
+        "href": "/nomad/tutorials/manage-clusters"
       },
       {
         "title": "Transport Security",
-        "href": "https://learn.hashicorp.com/collections/nomad/transport-security"
+        "href": "/nomad/tutorials/transport-security"
       },
       {
         "title": "Access Control",
-        "href": "https://learn.hashicorp.com/collections/nomad/access-control"
+        "href": "/nomad/tutorials/access-control"
       },
       {
         "title": "Key Management",

--- a/website/data/intro-nav-data.json
+++ b/website/data/intro-nav-data.json
@@ -29,27 +29,23 @@
     "routes": [
       {
         "title": "Overview",
-        "href": "https://learn.hashicorp.com/collections/nomad/get-started"
+        "href": "/nomad/tutorials/get-started"
       },
       {
         "title": "Running Nomad",
-        "href": "https://learn.hashicorp.com/tutorials/nomad/get-started-run"
+        "href": "/nomad/tutorials/get-started/get-started-run"
       },
       {
         "title": "Jobs",
-        "href": "https://learn.hashicorp.com/tutorials/nomad/get-started-jobs"
-      },
-      {
-        "title": "Clustering",
-        "href": "https://learn.hashicorp.com/tutorials/nomad/get-started-cluster"
+        "href": "/nomad/tutorials/get-started/get-started-jobs"
       },
       {
         "title": "Web UI",
-        "href": "https://learn.hashicorp.com/tutorials/nomad/get-started-ui"
+        "href": "/nomad/tutorials/get-started/get-started-ui"
       },
       {
         "title": "Next Steps",
-        "href": "https://learn.hashicorp.com/tutorials/nomad/get-started-learn-more"
+        "href": "/nomad/tutorials/get-started/get-started-learn-more"
       }
     ]
   }


### PR DESCRIPTION
## What

Replaces `learn.hashicorp.com` links in nav-data JSON files with paths internal to DevDot

## Why

DevDot needs these links to point to internal collection/tutorial pages rather than external ones.