### PR TITLE
Revert "Backport of core: Add client scheduling eligibility to heartbeat into release/1.1.x"

### DIFF
--- a/.changelog/14483.txt
+++ b/.changelog/14483.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-metrics: Update client `node_scheduling_eligibility` value with server heartbeats.
-```

--- a/client/client.go
+++ b/client/client.go
@@ -1870,14 +1870,6 @@ func (c *Client) updateNodeStatus() error {
 		}
 	}
 
-	// Check heartbeat response for information about the server-side scheduling
-	// state of this node
-	c.UpdateConfig(func(c *config.Config) {
-		if resp.SchedulingEligibility != "" {
-			c.Node.SchedulingEligibility = resp.SchedulingEligibility
-		}
-	})
-
 	// Update the number of nodes in the cluster so we can adjust our server
 	// rebalance rate.
 	c.servers.SetNumNodes(resp.NumNodes)

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -199,7 +199,7 @@ func (n *Node) Register(args *structs.NodeRegisterRequest, reply *structs.NodeUp
 
 	n.srv.peerLock.RLock()
 	defer n.srv.peerLock.RUnlock()
-	if err := n.constructNodeServerInfoResponse(args.Node.ID, snap, reply); err != nil {
+	if err := n.constructNodeServerInfoResponse(snap, reply); err != nil {
 		n.logger.Error("failed to populate NodeUpdateResponse", "error", err)
 		return err
 	}
@@ -258,7 +258,7 @@ func equalDevices(n1, n2 *structs.Node) bool {
 }
 
 // updateNodeUpdateResponse assumes the n.srv.peerLock is held for reading.
-func (n *Node) constructNodeServerInfoResponse(nodeID string, snap *state.StateSnapshot, reply *structs.NodeUpdateResponse) error {
+func (n *Node) constructNodeServerInfoResponse(snap *state.StateSnapshot, reply *structs.NodeUpdateResponse) error {
 	reply.LeaderRPCAddr = string(n.srv.raft.Leader())
 
 	// Reply with config information required for future RPC requests
@@ -272,10 +272,6 @@ func (n *Node) constructNodeServerInfoResponse(nodeID string, snap *state.StateS
 				Datacenter:       v.Datacenter,
 			})
 	}
-
-	// Add ClientStatus information to heartbeat response.
-	node, _ := snap.NodeByID(nil, nodeID)
-	reply.SchedulingEligibility = node.SchedulingEligibility
 
 	// TODO(sean@): Use an indexed node count instead
 	//
@@ -541,7 +537,7 @@ func (n *Node) UpdateStatus(args *structs.NodeUpdateStatusRequest, reply *struct
 	reply.Index = index
 	n.srv.peerLock.RLock()
 	defer n.srv.peerLock.RUnlock()
-	if err := n.constructNodeServerInfoResponse(node.GetID(), snap, reply); err != nil {
+	if err := n.constructNodeServerInfoResponse(snap, reply); err != nil {
 		n.logger.Error("failed to populate NodeUpdateResponse", "error", err)
 		return err
 	}
@@ -793,7 +789,7 @@ func (n *Node) Evaluate(args *structs.NodeEvaluateRequest, reply *structs.NodeUp
 
 	n.srv.peerLock.RLock()
 	defer n.srv.peerLock.RUnlock()
-	if err := n.constructNodeServerInfoResponse(node.GetID(), snap, reply); err != nil {
+	if err := n.constructNodeServerInfoResponse(snap, reply); err != nil {
 		n.logger.Error("failed to populate NodeUpdateResponse", "error", err)
 		return err
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1295,10 +1295,6 @@ type NodeUpdateResponse struct {
 	// region.
 	Servers []*NodeServerInfo
 
-	// SchedulingEligibility is used to inform clients what the server-side
-	// has for their scheduling status during heartbeats.
-	SchedulingEligibility string
-
 	QueryMeta
 }
 


### PR DESCRIPTION
Reverts hashicorp/nomad#14510