### PR TITLE
Tooltips for client (node) names

### DIFF
--- a/ui/app/components/allocation-service-sidebar.hbs
+++ b/ui/app/components/allocation-service-sidebar.hbs
@@ -77,12 +77,15 @@
 						<span class="term">
 							Client
 						</span>
-						<LinkTo
-							@route="clients.client"
-							@model={{@allocation.node}}
-						>
-							{{@allocation.node.shortId}}
-						</LinkTo>
+						<Tooltip @text={{@allocation.node.name}}>
+							<LinkTo
+								@route="clients.client"
+								@model={{@allocation.node}}
+							>
+								{{@allocation.node.shortId}}
+							</LinkTo>
+						</Tooltip>
+
 					</span>
 
 				</div>

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -114,13 +114,15 @@
         <span class="term">
           Client
         </span>
-        <LinkTo
-          @route="clients.client"
-          @model={{this.model.node}}
-          data-test-client-link
-        >
-          {{this.model.node.shortId}}
-        </LinkTo>
+        <Tooltip @text={{this.model.node.name}}>
+          <LinkTo
+            @route="clients.client"
+            @model={{this.model.node}}
+            data-test-client-link
+          >
+            {{this.model.node.shortId}}
+          </LinkTo>
+        </Tooltip>
       </span>
     </div>
   </div>

--- a/ui/app/templates/components/job-service-row.hbs
+++ b/ui/app/templates/components/job-service-row.hbs
@@ -31,7 +31,9 @@
 		{{@service.level}}
 	</td>
   <td>
-		<LinkTo @route="clients.client" @model={{@service.instances.0.node.id}}>{{@service.instances.0.node.shortId}}</LinkTo>
+		<Tooltip @text={{@service.instances.0.node.name}}>
+			<LinkTo @route="clients.client" @model={{@service.instances.0.node.id}}>{{@service.instances.0.node.shortId}}</LinkTo>
+		</Tooltip>
   </td>
   <td>
     {{#each @service.tags as |tag|}}


### PR DESCRIPTION
Resolves #14421 

Adds tooltips to a few places we only show node shortIDs

![image](https://user-images.githubusercontent.com/713991/189991795-7ac3de62-f0e3-43f6-95f0-8a502336b0b1.png)
