### PR TITLE
test: remove flaky Gate test

### DIFF
--- a/client/allocrunner/tasklifecycle/gate_test.go
+++ b/client/allocrunner/tasklifecycle/gate_test.go
@@ -62,23 +62,6 @@ func TestGate(t *testing.T) {
 				requireChannelPassing(t, g.WaitCh(), "second allow")
 			},
 		},
-		{
-			name: "concurrent access",
-			test: func(t *testing.T, g *Gate) {
-				x := 100
-				go func() {
-					for i := 0; i < x; i++ {
-						g.Open()
-					}
-				}()
-				go func() {
-					for i := 0; i < x/10; i++ {
-						g.Close()
-					}
-				}()
-				requireChannelPassing(t, g.WaitCh(), "gate should be open")
-			},
-		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
The concurrent gate access test is flaky since it depends on the order of operations of two concurrent goroutines. Despite the heavy bias towards one of the results, it's still possible to end the execution with a closed gate.

I believe this case was created to test an earlier implementation where the gate state was stored and mutated internally, so the access had to be protected by a lock. However, the final implementation changed this approach to be only channel-based, so there is no need for this flaky test anymore.