### PR TITLE
docs: Correct driver name for 'Nomad Task Group' autoscaler target

### DIFF
--- a/website/content/tools/autoscaling/plugins/target/nomad.mdx
+++ b/website/content/tools/autoscaling/plugins/target/nomad.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: 'Autoscaling Plugins: Nomad'
-description: The "nomad" target plugin scales a task group count.
+description: The "nomad-target" target plugin scales a task group count.
 ---
 
 # Nomad Task Group Target
@@ -16,7 +16,7 @@ following setup is optional.
 
 ```hcl
 target "nomad" {
-  driver = "nomad"
+  driver = "nomad-target"
 }
 ```
 


### PR DESCRIPTION
This PR updates the Nomad Autoscaler documentation to correctly reference the Nomad Task Group target plugin as `nomad-target`. The current example references the plugin as `nomad`, which causes the Autoscaler agent to fail to start:

```
2022-09-13T19:24:07.280Z [ERROR] agent: failed to start agent:
  error=
  | failed to setup plugins: 1 error occurred:
  | 	* failed to dispense plugin nomad: failed to instantiate plugin nomad client: fork/exec /plugins/nomad: no such file or directory
  | 
  ```