### PR TITLE
cleanup: create interface for check watcher and mock it in nsd tests

### DIFF
--- a/client/serviceregistration/nsd/nsd.go
+++ b/client/serviceregistration/nsd/nsd.go
@@ -18,7 +18,7 @@ type ServiceRegistrationHandler struct {
 
 	// checkWatcher watches checks of services in the Nomad service provider,
 	// and restarts associated tasks in accordance with their check_restart stanza.
-	checkWatcher *serviceregistration.CheckWatcher
+	checkWatcher serviceregistration.CheckWatcher
 
 	// registrationEnabled tracks whether this handler is enabled for
 	// registrations. This is needed as it's possible a client has its config
@@ -57,7 +57,7 @@ type ServiceRegistrationHandlerCfg struct {
 
 	// CheckWatcher watches checks of services in the Nomad service provider,
 	// and restarts associated tasks in accordance with their check_restart stanza.
-	CheckWatcher *serviceregistration.CheckWatcher
+	CheckWatcher serviceregistration.CheckWatcher
 }
 
 // NewServiceRegistrationHandler returns a ready to use

--- a/client/serviceregistration/watcher.go
+++ b/client/serviceregistration/watcher.go
@@ -131,8 +131,17 @@ type checkWatchUpdate struct {
 // A CheckWatcher watches for check failures and restarts tasks according to
 // their check_restart policy.
 type CheckWatcher interface {
+	// Run the CheckWatcher. Maintains a background process to continuously
+	// monitor active checks. Must be called before Watch or Unwatch. Must be
+	// called as a goroutine.
 	Run(ctx context.Context)
+
+	// Watch the given check. If the check status enters a failing state, the
+	// task associated with the check will be restarted according to its check_restart
+	// policy via wr.
 	Watch(allocID, taskName, checkID string, check *structs.ServiceCheck, wr WorkloadRestarter)
+
+	// Unwatch will cause the CheckWatcher to no longer monitor the check of given checkID.
 	Unwatch(checkID string)
 }
 

--- a/client/serviceregistration/watcher.go
+++ b/client/serviceregistration/watcher.go
@@ -51,8 +51,10 @@ func (r *restarter) apply(ctx context.Context, now time.Time, status string) boo
 		}
 	}
 	switch status {
-	case "critical", "failure", "pending":
-	case "warning":
+	case "critical": // consul
+	case string(structs.CheckFailure): // nomad
+	case string(structs.CheckPending): // nomad
+	case "warning": // consul
 		if r.ignoreWarnings {
 			// Warnings are ignored, reset state and exit
 			healthy()
@@ -126,7 +128,17 @@ type checkWatchUpdate struct {
 	restart *restarter
 }
 
-type CheckWatcher struct {
+// A CheckWatcher watches for check failures and restarts tasks according to
+// their check_restart policy.
+type CheckWatcher interface {
+	Run(ctx context.Context)
+	Watch(allocID, taskName, checkID string, check *structs.ServiceCheck, wr WorkloadRestarter)
+	Unwatch(checkID string)
+}
+
+// UniversalCheckWatcher is an implementation of CheckWatcher capable of watching
+// checks in the Nomad or Consul service providers.
+type UniversalCheckWatcher struct {
 	logger hclog.Logger
 	getter CheckStatusGetter
 
@@ -144,8 +156,8 @@ type CheckWatcher struct {
 	failedPreviousInterval bool
 }
 
-func NewCheckWatcher(logger hclog.Logger, getter CheckStatusGetter) *CheckWatcher {
-	return &CheckWatcher{
+func NewCheckWatcher(logger hclog.Logger, getter CheckStatusGetter) *UniversalCheckWatcher {
+	return &UniversalCheckWatcher{
 		logger:        logger.ResetNamed("watch.checks"),
 		getter:        getter,
 		pollFrequency: 1 * time.Second,
@@ -155,7 +167,7 @@ func NewCheckWatcher(logger hclog.Logger, getter CheckStatusGetter) *CheckWatche
 }
 
 // Watch a check and restart its task if unhealthy.
-func (w *CheckWatcher) Watch(allocID, taskName, checkID string, check *structs.ServiceCheck, wr WorkloadRestarter) {
+func (w *UniversalCheckWatcher) Watch(allocID, taskName, checkID string, check *structs.ServiceCheck, wr WorkloadRestarter) {
 	if !check.TriggersRestarts() {
 		return // check_restart not set; no-op
 	}
@@ -185,7 +197,7 @@ func (w *CheckWatcher) Watch(allocID, taskName, checkID string, check *structs.S
 }
 
 // Unwatch a check.
-func (w *CheckWatcher) Unwatch(checkID string) {
+func (w *UniversalCheckWatcher) Unwatch(checkID string) {
 	select {
 	case w.checkUpdateCh <- checkWatchUpdate{
 		checkID: checkID,
@@ -195,7 +207,7 @@ func (w *CheckWatcher) Unwatch(checkID string) {
 	}
 }
 
-func (w *CheckWatcher) Run(ctx context.Context) {
+func (w *UniversalCheckWatcher) Run(ctx context.Context) {
 	defer close(w.done)
 
 	// map of checkID to their restarter handle (contains only checks we are watching)
@@ -253,7 +265,7 @@ func (w *CheckWatcher) Run(ctx context.Context) {
 	}
 }
 
-func (w *CheckWatcher) interval(ctx context.Context, now time.Time, watched map[string]*restarter) {
+func (w *UniversalCheckWatcher) interval(ctx context.Context, now time.Time, watched map[string]*restarter) {
 	statuses, err := w.getter.Get()
 	if err != nil && !w.failedPreviousInterval {
 		w.failedPreviousInterval = true

--- a/client/serviceregistration/watcher_test.go
+++ b/client/serviceregistration/watcher_test.go
@@ -29,7 +29,7 @@ type fakeWorkloadRestarter struct {
 	restarts []restartRecord
 
 	// need the checkWatcher to re-Watch restarted tasks like TaskRunner
-	watcher *CheckWatcher
+	watcher *UniversalCheckWatcher
 
 	// check to re-Watch on restarts
 	check     *structs.ServiceCheck
@@ -41,7 +41,7 @@ type fakeWorkloadRestarter struct {
 }
 
 // newFakeCheckRestart creates a new mock WorkloadRestarter.
-func newFakeWorkloadRestarter(w *CheckWatcher, allocID, taskName, checkName string, c *structs.ServiceCheck) *fakeWorkloadRestarter {
+func newFakeWorkloadRestarter(w *UniversalCheckWatcher, allocID, taskName, checkName string, c *structs.ServiceCheck) *fakeWorkloadRestarter {
 	return &fakeWorkloadRestarter{
 		watcher:   w,
 		check:     c,
@@ -150,7 +150,7 @@ func testCheck() *structs.ServiceCheck {
 
 // testWatcherSetup sets up a fakeChecksAPI and a real checkWatcher with a test
 // logger and faster poll frequency.
-func testWatcherSetup(t *testing.T) (*fakeCheckStatusGetter, *CheckWatcher) {
+func testWatcherSetup(t *testing.T) (*fakeCheckStatusGetter, *UniversalCheckWatcher) {
 	logger := testlog.HCLogger(t)
 	getter := new(fakeCheckStatusGetter)
 	cw := NewCheckWatcher(logger, getter)

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -419,7 +419,7 @@ type ServiceClient struct {
 	deregisterProbationExpiry time.Time
 
 	// checkWatcher restarts checks that are unhealthy.
-	checkWatcher *serviceregistration.CheckWatcher
+	checkWatcher *serviceregistration.UniversalCheckWatcher
 
 	// isClientAgent specifies whether this Consul client is being used
 	// by a Nomad client.


### PR DESCRIPTION
This PR refactors `serviceregistration.CheckWatcher` to be an interface, that we then mock in some service registration tests where we can keep a tally of `Watch` and `Unwatch` calls, making sure they meet expectations.