### PR TITLE
[release/1.4.0-beta.1] Temporarily turn off binary secret scanning

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -13,6 +13,6 @@ binary {
   nvd        = false
 
   secrets {
-    all = true
+    all = false
   }
 }


### PR DESCRIPTION
Temporarily turn off binary secret scanning until false negatives are resolved