### PR TITLE
Update version string for 1.4.0 beta.1 release

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -16,7 +16,7 @@ var (
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = "beta.1"
 
 	// VersionMetadata is metadata further describing the build type.
 	VersionMetadata = ""


### PR DESCRIPTION
Artifacts will be named `1.4.0-beta.1` rather than `1.4.0-dev`