### PR TITLE
build: always set osusergo

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,7 +21,7 @@ ifndef BIN
 BIN := $(GOPATH)/bin
 endif
 
-GO_TAGS ?= osusergo
+GO_TAGS := osusergo $(GO_TAGS)
 
 ifeq ($(CI),true)
 GO_TAGS := codegen_generated $(GO_TAGS)


### PR DESCRIPTION
The way this tag was previous declared would cause it to be overwritten when the GO_TAGS env var was set.