### PR TITLE
E2E/UI: set `NOMAD_PROXY_ADDR` separately from `NOMAD_ADDR`

### DIFF
--- a/e2e/ui/README.md
+++ b/e2e/ui/README.md
@@ -1,0 +1,66 @@
+# E2E Tests for Nomad UI
+
+The test infrastructure here is primarily focused on running in our nightly E2E
+environment, but you should be able to run these tests against arbitrary
+development environments as well.
+
+## Nightly
+
+The nightly test runner executes on our CI provider, but the cluster under test
+is running on AWS infrastructure (see [./e2e/terraform][] for details). The
+cluster running on AWS is protected by mTLS. Generally speaking operators don't
+configure mTLS for the Nomad web UI, and instead configure a [reverse proxy][]
+so that's what we've done for nightly as well.
+
+The [./input/proxy.nomad][] job runs a reverse proxy on one of the client nodes,
+using the client's own mTLS cert to secure the backend. The front-end uses a
+self-signed cert, which is suitable for this testing use case.
+
+Because the test runner talks to both the HTTP API (mTLS) and the web UI (TLS
+only), it needs two different addresses. The test runner configuration in
+`run.sh` accepts the usual set of [`NOMAD_*` environment variables][] but also a
+`NOMAD_PROXY_ADDR` variable that should point to the address and port of the
+proxy job running on the cluster.
+
+```mermaid
+graph TD
+    A[Test runner] -->|setup tests<br>$NOMAD_ADDR| B(Nomad Server)
+    A[Test runner] -->|run tests<br>$NOMAD_PROXY_ADDR| C(Proxy Job)
+    C -->|proxy HTTP API<br>$NOMAD_ADDR| B
+```
+
+On nightly, the proxy deployment and `NOMAD_PROXY_ADDR` are set as shown below
+(this code lives in a private repo):
+
+```
+nomad namespace apply proxy
+nomad job run ./e2e/ui/input/proxy.nomad
+IP=$(nomad node status -json -verbose $(nomad operator api '/v1/allocations?namespace=proxy' | jq -r '.[] | select(.JobID == "nomad-proxy") | .NodeID') | jq -r '.Attributes."unique.platform.aws.public-ipv4"')
+export NOMAD_PROXY_ADDR="https://$IP:6464"
+```
+
+
+## Local Development with Docker or Vagrant
+
+If you're targeting a Nomad agent in your local development environment, you may
+not want or need mTLS and everything is a good bit easier. If you don't want to
+setup headless browsers for Playwright, you can use the same `./run.sh` script
+used in nightly and it'll run the tests inside a container. It will pick up the
+[`NOMAD_*` environment variables][] from your shell and set them correctly in
+the container.
+
+If you don't deploy the proxy job, you don't need to separately set the
+`NOMAD_PROXY_ADDR` address; it will automatically be set to the `NOMAD_ADDR` if
+unset.
+
+If you are running the test from Docker (especially Docker for Mac or Docker on
+a Vagrant host) against a Nomad agent running directly on your host, make sure
+you're setting the `-bind` address for Nomad so that it's visible to the test
+runner. Typically you'll need to set `-bind` to your host's IP address
+(available from `ifconfig` on macOS or `ip addr` on Linux).
+
+
+[./e2e/terraform]: https://github.com/hashicorp/nomad/tree/main/e2e/terraform
+[reverse proxy]: https://developer.hashicorp.com/nomad/tutorials/manage-clusters/reverse-proxy-ui
+[./input/proxy.nomad]: https://github.com/hashicorp/nomad/tree/main/e2e/ui/input/proxy.nomad
+[`NOMAD_*` environment variables]: https://developer.hashicorp.com/nomad/docs/commands#command-contexts

--- a/e2e/ui/api-client.js
+++ b/e2e/ui/api-client.js
@@ -25,9 +25,9 @@ export const client = async (
 ) => {
   const url = `${NOMAD_ADDR}/v1`.concat(path);
 
-  var httpsAgent = new https.Agent({keepAlive: true});
+  let httpsAgent = new https.Agent({keepAlive: true});
 
-  if (NOMAD_CLIENT_CERT != "") {
+  if (NOMAD_CLIENT_CERT !== "") {
     httpsAgent = new https.Agent({
       keepAlive: true,
       cert: fs.readFileSync(NOMAD_CLIENT_CERT),
@@ -47,7 +47,7 @@ export const client = async (
       "X-Nomad-Token": NOMAD_TOKEN,
       ...customHeaders,
     },
-    httpsAgent: httpsAgent,
+    httpsAgent,
     ...customConfig,
   };
 

--- a/e2e/ui/api-client.js
+++ b/e2e/ui/api-client.js
@@ -1,11 +1,21 @@
 import axios from "axios";
 
+export let NOMAD_PROXY_ADDR = process.env.NOMAD_PROXY_ADDR;
 export let NOMAD_ADDR = process.env.NOMAD_ADDR;
 export let NOMAD_TOKEN = process.env.NOMAD_TOKEN;
+export let NOMAD_CLIENT_CERT = process.env.NOMAD_CLIENT_CERT;
+export let NOMAD_CLIENT_KEY = process.env.NOMAD_CLIENT_KEY;
+export let NOMAD_CA_CERT = process.env.NOMAD_CA_CERT;
+export let NOMAD_TLS_SERVER_NAME = process.env.NOMAD_TLS_SERVER_NAME;
 
 if (NOMAD_ADDR == undefined || NOMAD_ADDR == "") {
   NOMAD_ADDR = "http://localhost:4646";
 }
+
+if (NOMAD_PROXY_ADDR == undefined || NOMAD_PROXY_ADDR == "") {
+  NOMAD_PROXY_ADDR = NOMAD_ADDR;
+}
+
 
 export const client = async (
   path,

--- a/e2e/ui/api-client.js
+++ b/e2e/ui/api-client.js
@@ -1,11 +1,13 @@
 import axios from "axios";
+import https from "https";
+import fs from "fs";
 
 export let NOMAD_PROXY_ADDR = process.env.NOMAD_PROXY_ADDR;
 export let NOMAD_ADDR = process.env.NOMAD_ADDR;
 export let NOMAD_TOKEN = process.env.NOMAD_TOKEN;
 export let NOMAD_CLIENT_CERT = process.env.NOMAD_CLIENT_CERT;
 export let NOMAD_CLIENT_KEY = process.env.NOMAD_CLIENT_KEY;
-export let NOMAD_CA_CERT = process.env.NOMAD_CA_CERT;
+export let NOMAD_CACERT = process.env.NOMAD_CACERT;
 export let NOMAD_TLS_SERVER_NAME = process.env.NOMAD_TLS_SERVER_NAME;
 
 if (NOMAD_ADDR == undefined || NOMAD_ADDR == "") {
@@ -16,13 +18,23 @@ if (NOMAD_PROXY_ADDR == undefined || NOMAD_PROXY_ADDR == "") {
   NOMAD_PROXY_ADDR = NOMAD_ADDR;
 }
 
-
 export const client = async (
   path,
   { data, method, headers: customHeaders, ...customConfig } = {},
   parameters
 ) => {
   const url = `${NOMAD_ADDR}/v1`.concat(path);
+
+  var httpsAgent = new https.Agent({keepAlive: true});
+
+  if (NOMAD_CLIENT_CERT != "") {
+    httpsAgent = new https.Agent({
+      keepAlive: true,
+      cert: fs.readFileSync(NOMAD_CLIENT_CERT),
+      key: fs.readFileSync(NOMAD_CLIENT_KEY),
+      ca: fs.readFileSync(NOMAD_CACERT),
+    });
+  }
 
   method = !!method ? method : data ? "post" : "get";
 
@@ -35,6 +47,7 @@ export const client = async (
       "X-Nomad-Token": NOMAD_TOKEN,
       ...customHeaders,
     },
+    httpsAgent: httpsAgent,
     ...customConfig,
   };
 

--- a/e2e/ui/global-setup.js
+++ b/e2e/ui/global-setup.js
@@ -1,6 +1,6 @@
 import fs from "fs";
 import { chromium } from "@playwright/test";
-import { client, NOMAD_PROXY_ADDR, NOMAD_ADDR, NOMAD_TOKEN } from "./api-client.js";
+import { client, NOMAD_PROXY_ADDR, NOMAD_TOKEN } from "./api-client.js";
 import {
   PROD_NAMESPACE,
   DEV_NAMESPACE,

--- a/e2e/ui/global-setup.js
+++ b/e2e/ui/global-setup.js
@@ -1,6 +1,6 @@
 import fs from "fs";
 import { chromium } from "@playwright/test";
-import { client, NOMAD_ADDR, NOMAD_TOKEN } from "./api-client.js";
+import { client, NOMAD_PROXY_ADDR, NOMAD_ADDR, NOMAD_TOKEN } from "./api-client.js";
 import {
   PROD_NAMESPACE,
   DEV_NAMESPACE,
@@ -20,7 +20,7 @@ async function globalSetup() {
     await client(`/namespace/dev`, { data: DEV_NAMESPACE });
     await client(`/acl/policy/operator`, { data: OPERATOR_POLICY_JSON });
     await client(`/acl/policy/dev`, { data: DEV_POLICY_JSON });
-    
+
     // Create Operator Token and save to local director to use in tests
     const {data: {SecretID: operatorToken}} = await client(`/acl/token`, {
       data: { Name: "Operator", Type: "client", Policies: ["operator"] },
@@ -39,7 +39,7 @@ async function globalSetup() {
   const browser = await chromium.launch();
   const context = await browser.newContext({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
-  await page.goto(NOMAD_ADDR + "/ui/settings/tokens");
+  await page.goto(NOMAD_PROXY_ADDR + "/ui/settings/tokens");
   await page.fill('input[id="token-input"]', NOMAD_TOKEN);
   await page.click('button:has-text("Set Token")', { strict: true });
 

--- a/e2e/ui/input/tokens/operator.js
+++ b/e2e/ui/input/tokens/operator.js
@@ -1,0 +1,1 @@
+export const token = null

--- a/e2e/ui/run.sh
+++ b/e2e/ui/run.sh
@@ -76,11 +76,11 @@ run_mtls() {
          -e NOMAD_TOKEN=$NOMAD_TOKEN \
          -e NOMAD_CLIENT_CERT=/etc/nomad-client.crt \
          -e NOMAD_CLIENT_KEY=/etc/nomad-client.key \
-         -e NOMAD_CA_CERT=/etc/nomad-ca.crt \
+         -e NOMAD_CACERT=/etc/nomad-ca.crt \
          -e NOMAD_TLS_SERVER_NAME=$NOMAD_TLS_SERVER_NAME \
          -v ${NOMAD_CLIENT_CERT}:/etc/nomad-client.crt \
          -v ${NOMAD_CLIENT_KEY}:/etc/nomad-client.key \
-         -v ${NOMAD_CA_CERT}:/etc/nomad-ca.crt \
+         -v ${NOMAD_CACERT}:/etc/nomad-ca.crt \
          --ipc=host \
          --net=host \
          "$IMAGE" \

--- a/e2e/ui/run.sh
+++ b/e2e/ui/run.sh
@@ -71,7 +71,7 @@ run_mtls() {
     exec docker run -it --rm \
          -v $(pwd):/src \
          -w /src \
-         -e NOMAD_PROXY_ADDR=$NOMAD_ADDR \
+         -e NOMAD_PROXY_ADDR=$NOMAD_PROXY_ADDR \
          -e NOMAD_ADDR=$NOMAD_ADDR \
          -e NOMAD_TOKEN=$NOMAD_TOKEN \
          -e NOMAD_CLIENT_CERT=/etc/nomad-client.crt \

--- a/e2e/ui/tests/download-logs.spec.js
+++ b/e2e/ui/tests/download-logs.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { client, NOMAD_ADDR } from "../api-client.js";
+import { client, NOMAD_PROXY_ADDR } from "../api-client.js";
 import { jobSpec } from "../input/jobs/service-discovery/service-discovery.js";
 import { token } from "../input/tokens/operator.js";
 
@@ -7,7 +7,7 @@ test.describe("Download Task Logs", () => {
   test.beforeEach(async ({ page }) => {
     // Go to the starting url before each test.
     await client(`/jobs`, { data: jobSpec });
-    await page.goto(NOMAD_ADDR + "/ui/settings/tokens");
+    await page.goto(NOMAD_PROXY_ADDR + "/ui/settings/tokens");
 
     // Set token
     await page
@@ -24,7 +24,7 @@ test.describe("Download Task Logs", () => {
 
     // Clear token
     await page.locator("text=ACL Tokens").click();
-    await expect(page).toHaveURL(NOMAD_ADDR + "/ui/settings/tokens");
+    await expect(page).toHaveURL(NOMAD_PROXY_ADDR + "/ui/settings/tokens");
     await page.locator("text=Clear Token").click();
   });
 
@@ -32,7 +32,7 @@ test.describe("Download Task Logs", () => {
     page,
   }) => {
     // Arrange -- Naviagate to Task Logs
-    await page.goto(NOMAD_ADDR + "/ui/jobs");
+    await page.goto(NOMAD_PROXY_ADDR + "/ui/jobs");
     await Promise.all([
       page.waitForNavigation(),
       page.locator("text=trying-multi-dupes").click(),
@@ -44,7 +44,7 @@ test.describe("Download Task Logs", () => {
       page.locator("text=Files").click(),
     ]);
     await page.locator("text=executor.out").click();
-    
+
     // Act - Download Log
     const [download] = await Promise.all([
       page.waitForEvent("download"),

--- a/e2e/ui/tests/example.spec.js
+++ b/e2e/ui/tests/example.spec.js
@@ -1,12 +1,12 @@
 import { test, expect } from "@playwright/test";
 
 test("authenticated users can see their policies", async ({ page }) => {
-  var NOMAD_ADDR = process.env.NOMAD_ADDR;
-  if (NOMAD_ADDR == undefined || NOMAD_ADDR == "") {
-    NOMAD_ADDR = "http://localhost:4646";
+  var NOMAD_PROXY_ADDR = process.env.NOMAD_PROXY_ADDR;
+  if (NOMAD_PROXY_ADDR == undefined || NOMAD_PROXY_ADDR == "") {
+    NOMAD_PROXY_ADDR = "http://localhost:4646";
   }
 
-  await page.goto(NOMAD_ADDR + "/ui/settings/tokens");
+  await page.goto(NOMAD_PROXY_ADDR + "/ui/settings/tokens");
 
   // smoke test that we reached the page
   const logo = page.locator("div.navbar-brand");


### PR DESCRIPTION
The Nomad UI will be proxied by the proxy job, but the test setup also requires making direct HTTP API requests that bypass the UI. For clusters with mTLS configured (ex. nightly), we need to bind-mount the user's mTLS certs picked up by the API client into the test runner.

Includes a new README that explains the topology of the test environments in detail and provides some advice for running locally.

---

Tested against both an E2E test cluster and local development environment. Once we've merged it I'll need to make a PR over in the [private test infra repo](https://github.com/hashicorp/nomad-e2e) to set the `NOMAD_PROXY_ADDR` value.

README preview link: https://github.com/hashicorp/nomad/blob/d24570eb342884e79535a64c8fb06055139859f1/e2e/ui/README.md
