### PR TITLE
variables: fix ENT-only test failure in command tests

### DIFF
--- a/command/var_get_test.go
+++ b/command/var_get_test.go
@@ -179,7 +179,7 @@ func TestVarGetCommand(t *testing.T) {
 
 		sv := testVariable()
 		sv.Path = "special/variable"
-		sv.Namespace = t.Name()
+		sv.Namespace = testNS
 		sv, _, err = client.Variables().Create(sv, nil)
 		require.NoError(t, err)
 		t.Cleanup(func() { client.Variables().Delete(sv.Path, nil) })


### PR DESCRIPTION
The `TestVarGetCommand` test uses the wrong namespace in the autocomplete test. The namespace only gets validated against if we have quota enforcement (or more typically by ACL checks), so the test only fails in the ENT repo test runs.

(Arguably we should always be belt-and-suspenders enforcing a namespace exists but none of our other endpoints do, and it turns out this gets indirectly handled by ACLs anyways, but we can revisit that discussion in follow-up PRs once we get the beta out.)