### PR TITLE
Invoke FingerprintManager's Reload() func during agent's SIGHUP (Fixes #14614)

### DIFF
--- a/.changelog/14615.txt
+++ b/.changelog/14615.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where network fingerprinters were not reloaded when the client configuration was reloaded with SIGHUP
+```

--- a/client/client.go
+++ b/client/client.go
@@ -297,6 +297,9 @@ type Client struct {
 	endpoints     rpcEndpoints
 	streamingRpcs *structs.StreamingRpcRegistry
 
+	// fingerprintManager is the FingerprintManager registered by the client
+	fingerprintManager *FingerprintManager
+
 	// pluginManagers is the set of PluginManagers registered by the client
 	pluginManagers *pluginmanager.PluginGroup
 
@@ -440,14 +443,14 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 		return nil, fmt.Errorf("node setup failed: %v", err)
 	}
 
-	fingerprintManager := NewFingerprintManager(
+	c.fingerprintManager = NewFingerprintManager(
 		cfg.PluginSingletonLoader, c.GetConfig, cfg.Node,
 		c.shutdownCh, c.updateNodeFromFingerprint, c.logger)
 
 	c.pluginManagers = pluginmanager.New(c.logger)
 
 	// Fingerprint the node and scan for drivers
-	if err := fingerprintManager.Run(); err != nil {
+	if err := c.fingerprintManager.Run(); err != nil {
 		return nil, fmt.Errorf("fingerprinting failed: %v", err)
 	}
 
@@ -741,6 +744,8 @@ func (c *Client) Reload(newConfig *config.Config) error {
 	if shouldReloadTLS {
 		return c.reloadTLSConnections(newConfig.TLSConfig)
 	}
+
+	c.fingerprintManager.Reload()
 
 	return nil
 }


### PR DESCRIPTION
This PR addresses https://github.com/hashicorp/nomad/issues/14614, by adding the missing call to Fingerprint's Reload() method from within SIGHUP handling on agent's code.