### PR TITLE
Minor tweaks to the service views

### DIFF
--- a/ui/app/components/allocation-service-sidebar.hbs
+++ b/ui/app/components/allocation-service-sidebar.hbs
@@ -95,7 +95,7 @@
 			<ListTable class="health-checks" @source={{this.checks}} as |t|>
 				<t.head>
 					<th class="name">
-						Name
+						Check Name
 					</th>
 					<th class="status">
 						Status

--- a/ui/app/styles/utils/z-indices.scss
+++ b/ui/app/styles/utils/z-indices.scss
@@ -1,3 +1,4 @@
+$z-modal: 300;
 $z-tooltip: 250;
 $z-gutter: 220;
 $z-gutter-backdrop: 219;
@@ -6,4 +7,3 @@ $z-subnav: 200;
 $z-popover: 150;
 $z-base: 100;
 $z-icon-decorators: 50;
-$z-modal: 60;

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -303,7 +303,7 @@
                   <FlightIcon @name="consul-color" />
                 {{/if}}
               </td>
-              <td data-test-service-name>
+              <td data-test-service-name class="is-long-text">
                 {{row.model.name}}
               </td>
               <td data-test-service-port>
@@ -314,7 +314,7 @@
                   <span class="tag">{{tag}}</span>
                 {{/each}}
               </td>
-              <td data-test-service-health>
+              <td data-test-service-health class="is-2">
                 {{#if (eq row.model.provider "nomad")}}
                   <div class="inline-chart">
                     <ServiceStatusBar @isNarrow={{true}} @status={{row.model.mostRecentCheckStatus}} />

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -274,6 +274,7 @@
       <div class="boxed-section-body is-full-bleed">
         <ListTable class="allocation-services-table" @source={{this.servicesWithHealthChecks}} as |t|>
           <t.head>
+            <th class="is-narrow"></th>
             <th>
               Name
             </th>
@@ -295,12 +296,14 @@
                 action=(fn this.handleServiceClick row.model)
               }}
             >
-              <td data-test-service-name>
+              <td class="is-narrow">
                 {{#if (eq row.model.provider "nomad")}}
                   <FlightIcon @name="nomad-color" />
                 {{else}}
                   <FlightIcon @name="consul-color" />
                 {{/if}}
+              </td>
+              <td data-test-service-name>
                 {{row.model.name}}
               </td>
               <td data-test-service-port>

--- a/ui/app/templates/components/job-service-row.hbs
+++ b/ui/app/templates/components/job-service-row.hbs
@@ -31,11 +31,6 @@
 		{{@service.level}}
 	</td>
   <td>
-		<Tooltip @text={{@service.instances.0.node.name}}>
-			<LinkTo @route="clients.client" @model={{@service.instances.0.node.id}}>{{@service.instances.0.node.shortId}}</LinkTo>
-		</Tooltip>
-  </td>
-  <td>
     {{#each @service.tags as |tag|}}
 			<span class="tag">{{tag}}</span>
     {{/each}}

--- a/ui/app/templates/jobs/job/services/index.hbs
+++ b/ui/app/templates/jobs/job/services/index.hbs
@@ -9,7 +9,6 @@
 			<t.head>
 				<t.sort-by @prop="name">Name</t.sort-by>
 				<t.sort-by @prop="level">Level</t.sort-by>
-				<t.sort-by @prop="client">Client</t.sort-by>
 				<th>Tags</th>
 				<t.sort-by @prop="numAllocs">Number of Alocations</t.sort-by>
 			</t.head>

--- a/ui/app/templates/jobs/job/services/service.hbs
+++ b/ui/app/templates/jobs/job/services/service.hbs
@@ -16,6 +16,7 @@
 	>
 		<t.head>
 			<th>Allocation</th>
+      <th>Client</th>
 			<th>IP Address &amp; Port</th>
 		</t.head>
 		<t.body as |row|>
@@ -28,6 +29,11 @@
 				>
 					<LinkTo @route="allocations.allocation" @model={{row.model.allocation}}>{{row.model.allocation.shortId}}</LinkTo>
 				</td>
+        <td>
+          <Tooltip @text={{row.model.node.name}}>
+            <LinkTo @route="clients.client" @model={{row.model.node.id}}>{{row.model.node.shortId}}</LinkTo>
+          </Tooltip>
+        </td>
 				<td>
 					{{row.model.address}}:{{row.model.port}}
 				</td>


### PR DESCRIPTION
Minor tweaks in the job service page and the service sidebar. I'm not sure if all the changes make sense so I tried to isolate them per commit.

7a4fa3da72463be3204f76709706637cbd48e041 adjust the z-index of elements so the sidebar renders above them.
**Before**
<img width="1410" alt="Screen Shot 2022-09-17 at 8 47 04 PM" src="https://user-images.githubusercontent.com/775380/191057865-47780014-1a21-4014-96c4-862a6d2d6a98.png">

**After**
<img width="1413" alt="Screen Shot 2022-09-17 at 8 47 30 PM" src="https://user-images.githubusercontent.com/775380/191057941-ed324d99-427a-4e21-b10a-56615844fe4d.png">

https://github.com/hashicorp/nomad/commit/b17611ee1244d8c018e4dfe78ed1a09f36494baa updates the column name in the service details sidebar so it's more clear that the table is about health checks (visible in the previous image as well).

https://github.com/hashicorp/nomad/commit/26b5bc8bd3ba4727d0d8ed46d8e979946b4689ee updates the service table so it uses the same pattern as other tables when displaying icons.

https://github.com/hashicorp/nomad/commit/e4749643bcbb02881d5f55f1f972adb9d5a30e88 restricts the length of the health status bar and also makes the check name column longer
**Before**
<img width="1415" alt="Screen Shot 2022-09-17 at 8 49 27 PM" src="https://user-images.githubusercontent.com/775380/191058658-cbd76070-5d95-4172-8289-347bfeda16f7.png">

**After**
<img width="1413" alt="Screen Shot 2022-09-17 at 8 49 37 PM" src="https://user-images.githubusercontent.com/775380/191058692-f6fc3c3b-c767-4d82-b143-10ffb0c1c10e.png">

https://github.com/hashicorp/nomad/commit/f51f6fdf98ef56d9b703fa7f168a58bde90606ed moves the `Client` column downwards into the service details table. This is because a service can be registered at multiple clients, so this information can only be properly displayed at the service instance level.
**Before**
<img width="1016" alt="Screen Shot 2022-09-17 at 9 02 44 PM" src="https://user-images.githubusercontent.com/775380/191059119-58fabe5c-7ba4-426d-b6a2-5956b0fe4498.png">
<img width="882" alt="Screen Shot 2022-09-17 at 9 02 52 PM" src="https://user-images.githubusercontent.com/775380/191059116-4ec5fba4-c592-4ef2-9271-4a1b8f3dfbac.png">

**After**
<img width="915" alt="Screen Shot 2022-09-17 at 9 03 04 PM" src="https://user-images.githubusercontent.com/775380/191059236-b2729044-e294-4b30-9fed-63e8f04fd051.png">
<img width="870" alt="Screen Shot 2022-09-17 at 9 02 58 PM" src="https://user-images.githubusercontent.com/775380/191059241-dea3e105-030d-49bc-b968-ed100deeeaa5.png">