### PR TITLE
api: provide more detail on ACL bootstrap request error

### DIFF
--- a/.github/14629.txt
+++ b/.github/14629.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: return a more descriptive error when /v1/acl/bootstrap fails to decode request body
+```

--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -142,7 +143,7 @@ func (s *HTTPServer) ACLTokenBootstrap(resp http.ResponseWriter, req *http.Reque
 
 	if req.ContentLength != 0 {
 		if err := decodeBody(req, &args); err != nil {
-			return nil, CodedError(400, err.Error())
+			return nil, CodedError(400, fmt.Sprintf("failed to decode request body: %s", err))
 		}
 	}
 


### PR DESCRIPTION
JSON decode error messages can be quite cryptic and hard to pinpoint, so this provides more context that the error happen while trying to decode the request body.