### PR TITLE
jobspec: allow artifact headers in HCLv1 

### DIFF
--- a/.changelog/14637.txt
+++ b/.changelog/14637.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+jobspec: Fixed a bug where an `artifact` with `headers` configuration would fail to parse when using HCLv1
+```

--- a/jobspec/parse_task.go
+++ b/jobspec/parse_task.go
@@ -370,6 +370,7 @@ func parseArtifacts(result *[]*api.TaskArtifact, list *ast.ObjectList) error {
 		valid := []string{
 			"source",
 			"options",
+			"headers",
 			"mode",
 			"destination",
 		}

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -628,6 +628,13 @@ func TestParse(t *testing.T) {
 										GetterOptions: nil,
 										RelativeDest:  stringToPtr("var/foo"),
 									},
+									{
+										GetterSource: stringToPtr("https://example.com/file.txt"),
+										GetterHeaders: map[string]string{
+											"User-Agent":    "nomad",
+											"X-Nomad-Alloc": "alloc",
+										},
+									},
 								},
 							},
 						},

--- a/jobspec/test-fixtures/artifacts.hcl
+++ b/jobspec/test-fixtures/artifacts.hcl
@@ -25,8 +25,8 @@ job "binstore-storagelocker" {
         source = "https://example.com/file.txt"
 
         headers {
-          User-Agent    = "nomad-[${NOMAD_JOB_ID}]-[${NOMAD_GROUP_NAME}]-[${NOMAD_TASK_NAME}]"
-          X-Nomad-Alloc = "${NOMAD_ALLOC_ID}"
+          User-Agent    = "nomad"
+          X-Nomad-Alloc = "alloc"
         }
       }
     }

--- a/jobspec/test-fixtures/artifacts.hcl
+++ b/jobspec/test-fixtures/artifacts.hcl
@@ -20,6 +20,15 @@ job "binstore-storagelocker" {
         source      = "http://foo.com/bam"
         destination = "var/foo"
       }
+
+      artifact {
+        source = "https://example.com/file.txt"
+
+        headers {
+          User-Agent    = "nomad-[${NOMAD_JOB_ID}]-[${NOMAD_GROUP_NAME}]-[${NOMAD_TASK_NAME}]"
+          X-Nomad-Alloc = "${NOMAD_ALLOC_ID}"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This test fixture comes straight from the documentation and uncovers a failure in parsing the 'headers' key.

Closes #14657