### PR TITLE
chore: backport go.work gitignore changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@ ui/dist/
 website/.bundle
 website/vendor
 
+# Go work files
+go.work
+go.work.sum
+
 # init outputs
 example.nomad
 spec.hcl


### PR DESCRIPTION
Backport the `.gitignore` changes to make `go.work` not get managed by git (target: release/1.3.x) 