### PR TITLE
ci: replace hosted `semver` with an action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,21 +37,12 @@ jobs:
         run: |
           echo "::notice::Release v${{ github.event.inputs.version }} from branch ${{ github.ref_name }}"
 
-      - name: Install semver CLI
-        run: |
-          local_bin="${HOME}/.local/bin"
-          mkdir -p "${local_bin}"
-          curl -L --output "${local_bin}/semver" \
-            https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.3.0/src/semver
-          chmod +x "${local_bin}/semver"
-          echo "${local_bin}" >> $GITHUB_PATH
-
-      - name: Validate release version
-        run: |
-          if [ "$(semver validate ${{ github.event.inputs.version }})" == "invalid" ]; then
-            echo "::error::Version ${{ github.event.inputs.version }} is invalid"
-            exit 1
-          fi
+      - name: Parse the version
+        id: version
+        uses: madhead/semver-utils@v2.4.0
+        with:
+          version: ${{ github.event.inputs.version }}
+          lenient: false
 
       - uses: actions/checkout@v2
 
@@ -101,8 +92,8 @@ jobs:
       - name: Update version file
         run: |
           NOMAD_VERSION="${{ github.event.inputs.version }}"
-          NOMAD_MAIN_VERSION=$(semver get release "$NOMAD_VERSION")
-          NOMAD_PRERELEASE_VERSION=$(semver get prerel "$NOMAD_VERSION")
+          NOMAD_MAIN_VERSION=${{ steps.version.outputs.release }}
+          NOMAD_PRERELEASE_VERSION=${{ steps.version.outputs.prerelease }}
 
           echo "updating version to ${NOMAD_MAIN_VERSION}-${NOMAD_PRERELEASE_VERSION}"
 
@@ -165,8 +156,8 @@ jobs:
           # Only bump the Version value if this is not a pre-release.
           # For final releases we want `nomad -version` to display the next
           # version to indicate that the current release is done.
-          if [ -z "$(semver get prerel ${{ github.event.inputs.version }})" ]; then
-            next_version=$(semver bump patch ${{ github.event.inputs.version }})
+          if [ -z "${{ steps.version.outputs.prerelease }}" ]; then
+            next_version=${{ steps.version.outputs.inc-patch }}
             sed -i.bak -e "s|\(Version * = *\"\)[^\"]*|\1${next_version}|g" version/version.go
           fi
           # Set the VersionPrerelease variable back to dev.
@@ -178,7 +169,7 @@ jobs:
         run: |
           # LAST_RELEASE is used to generate the new CHANGELOG entries, so it's
           # only updated for final releases.
-          if [ -z "$(semver get prerel ${{ github.event.inputs.version }})" ]; then
+          if [ -z "${{ steps.version.outputs.prerelease }}" ]; then
             sed -i.bak -re "s|^(LAST_RELEASE\s+\?=\s+v).*$|\1${{ github.event.inputs.version }}|g" GNUmakefile
             rm -fr GNUmakefile.bak
             git diff --color=always GNUmakefile


### PR DESCRIPTION
I've noticed, that you are using a `curl` to download a [semver tool](https://github.com/fsaintjacques/semver-tool) from https://raw.githubusercontent.com to work with semantic versions.

I propose to use [my reusable GitHub Action](https://github.com/marketplace/actions/semver-utils) to accomplish the same task. Using the reusable action has, from my point of view, some benefits, like being more native and natural and less surprising way of doing things in GitHub Actions Workflows.

If you would like to ensure it works the same way as before, I've tested it in my fork:

- A successful run is [here](https://github.com/madhead/nomad/actions/runs/3101684238/jobs/5023285204#step:13:2), take a look at the way it parsed the input. It's identical to the old way, isn't it?
- The workflow I used for the check is [here](https://github.com/madhead/nomad/actions/runs/3101684238/workflow). I've commented some things out because they are optional for the purpose.
- Guarding against invalid input also [works](https://github.com/madhead/nomad/actions/runs/3101794529).

_Thank you!_