### PR TITLE
cli: remove deprecated `eval status -json` list behavior

### DIFF
--- a/.changelog/14651.txt
+++ b/.changelog/14651.txt
@@ -1,0 +1,3 @@
+```release-note:deprecation
+cli: `eval status -json` no longer supports listing all evals in JSON. Use `eval list -json`.
+```

--- a/command/eval_status.go
+++ b/command/eval_status.go
@@ -105,24 +105,6 @@ func (c *EvalStatusCommand) Run(args []string) int {
 		return 1
 	}
 
-	// If args not specified but output format is specified, format and output the evaluations data list
-	if len(args) == 0 && (json || len(tmpl) > 0) {
-		evals, _, err := client.Evaluations().List(nil)
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error querying evaluations: %v", err))
-			return 1
-		}
-
-		out, err := Format(json, tmpl, evals)
-		if err != nil {
-			c.Ui.Error(err.Error())
-			return 1
-		}
-
-		c.Ui.Output(out)
-		return 0
-	}
-
 	if len(args) != 1 {
 		c.Ui.Error("This command takes one argument")
 		c.Ui.Error(commandErrorText(c))
@@ -140,6 +122,11 @@ func (c *EvalStatusCommand) Run(args []string) int {
 	// Query the allocation info
 	if len(evalID) == 1 {
 		c.Ui.Error("Identifier must contain at least two characters.")
+		return 1
+	}
+
+	if json && len(tmpl) > 0 {
+		c.Ui.Error("Both json and template formatting are not allowed")
 		return 1
 	}
 

--- a/command/eval_status_test.go
+++ b/command/eval_status_test.go
@@ -53,7 +53,8 @@ func TestEvalStatusCommand_Fails(t *testing.T) {
 	ui.ErrorWriter.Reset()
 
 	// Failed on both -json and -t options are specified
-	if code := cmd.Run([]string{"-address=" + url, "-json", "-t", "{{.ID}}"}); code != 1 {
+	if code := cmd.Run([]string{"-address=" + url, "-json", "-t", "{{.ID}}",
+		"12345678-abcd-efab-cdef-123456789abc"}); code != 1 {
 		t.Fatalf("expected exit 1, got: %d", code)
 	}
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Both json and template formatting are not allowed") {

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -49,6 +49,15 @@ behavior to reserve for a major Nomad release and *not* be backported. Please
 report any negative side effects encountered as [new
 issues.][gh_issue]
 
+#### `nomad eval status -json` Without Evaluation ID Removed
+
+Using `nomad eval status -json` without providing an evaluation ID was
+deprecated in Nomad 1.2.4 with the intent to remove in Nomad 1.4.0. This option
+has been removed. You can use `nomad eval list` to get a list of evaluations and
+can use `nomad eval list -json` to get that list in JSON format. The `nomad eval
+status <eval ID>` command will format a specific evaluation in JSON format if
+the `-json` flag is provided.
+
 ## Nomad 1.3.3
 
 Environments that don't support the use of [`uid`][template_uid] and


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/13101

In Nomad 1.2.6 we shipped `eval list`, which accepts a `-json` flag, and deprecated the usage of `eval status` without an evaluation ID with an upgrade note that it would be removed in Nomad 1.4.0. This changeset completes that work.