### PR TITLE
scheduler: Fix bug where the would treat multiregion jobs as paused for job types that don't use deployments

### DIFF
--- a/.changelog/14659.txt
+++ b/.changelog/14659.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-scheduler: Fixed bug where the would treat multiregion jobs as paused for job types that don't use deployments
+scheduler: Fixed bug where the scheduler would treat multiregion jobs as paused for job types that don't use deployments
 ```

--- a/.changelog/14659.txt
+++ b/.changelog/14659.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Fixed bug where the would treat multiregion jobs as paused for job types that don't use deployments
+```

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5746,6 +5746,17 @@ func (j *Job) GetScalingPolicies() []*ScalingPolicy {
 	return ret
 }
 
+// UsesDeployments returns a boolean indicating whether the job configuration
+// results in a deployment during scheduling.
+func (j *Job) UsesDeployments() bool {
+	switch j.Type {
+	case JobTypeService:
+		return true
+	default:
+		return false
+	}
+}
+
 // ScalingPolicyListStub is used to return a subset of scaling policy information
 // for the scaling policy list
 type ScalingPolicyListStub struct {

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -266,15 +266,15 @@ func (a *allocReconciler) computeDeploymentUpdates(deploymentComplete bool) {
 }
 
 // computeDeploymentPaused is responsible for setting flags on the
-// allocReconciler that indicates the state of the deployment if one
+// allocReconciler that indicate the state of the deployment if one
 // is required. The flags that are managed are:
 //  1. deploymentFailed: Did the current deployment fail just as named.
 //  2. deploymentPaused: Multiregion job types that use deployments run
-//     the deployment later during the fan-out stage. When it is created
-//     it will be in a pending state. If an invariant is violated during
-//     the coordination of deployments it will enter a paused state. This
-//     flag tells Compute we're paused or pending, so we should not make
-//     placements on the deployment.
+//     the deployments later during the fan-out stage. When the deployment
+//     is created it will be in a pending state. If an invariant violation
+//     is detected by the deploymentWatcher during it will enter a paused
+//     state. This flag tells Compute we're paused or pending, so we should
+//     not make placements on the deployment.
 func (a *allocReconciler) computeDeploymentPaused() {
 	if a.deployment != nil {
 		a.deploymentPaused = a.deployment.Status == structs.DeploymentStatusPaused ||

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -265,6 +265,16 @@ func (a *allocReconciler) computeDeploymentUpdates(deploymentComplete bool) {
 	}
 }
 
+// computeDeploymentPaused is responsible for setting flags on the
+// allocReconciler that indicates the state of the deployment if one
+// is required. The flags that are managed are:
+//  1. deploymentFailed: Did the current deployment fail just as named.
+//  2. deploymentPaused: Multiregion job types that use deployments run
+//     the deployment later during the fan-out stage. When it is created
+//     it will be in a pending state. If an invariant is violated during
+//     the coordination of deployments it will enter a paused state. This
+//     flag tells Compute we're paused or pending, so we should not make
+//     placements on the deployment.
 func (a *allocReconciler) computeDeploymentPaused() {
 	if a.deployment != nil {
 		a.deploymentPaused = a.deployment.Status == structs.DeploymentStatusPaused ||
@@ -272,10 +282,10 @@ func (a *allocReconciler) computeDeploymentPaused() {
 		a.deploymentFailed = a.deployment.Status == structs.DeploymentStatusFailed
 	}
 	if a.deployment == nil {
-		// When we create the deployment later, it will be in a pending
-		// state. But we also need to tell Compute we're paused, otherwise we
-		// make placements on the paused deployment.
-		if a.job.IsMultiregion() && !(a.job.IsPeriodic() || a.job.IsParameterized()) {
+		if a.job.IsMultiregion() &&
+			a.job.UsesDeployments() &&
+			!(a.job.IsPeriodic() || a.job.IsParameterized()) {
+
 			a.deploymentPaused = true
 		}
 	}


### PR DESCRIPTION
This PR fixes a bug in the `allocReconciler` where multiregion job types that don't support deployments would be flagged as paused. 

- `structs.Job` - Added a `UsesDeployments` function that can be expanded as more job types support deployments
- `scheduler.allocReconciler` - Added check to `computeDeploymentPaused` to guard against setting `deploymentPaused = true` if the job type doesn't use deployments.
- 