### PR TITLE
[ui] Warn users when they leave an edited but unsaved variable page

### DIFF
--- a/.changelog/14665.txt
+++ b/.changelog/14665.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: warn a user before they leave a Variables form page with unsaved information
+```

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -364,7 +364,8 @@ export default class VariableFormComponent extends Component {
   }
 
   confirmExit(transition) {
-    if (transition.isAborted) return;
+    const queryParamUpdateOnly = transition.to.name === transition.from.name;
+    if (transition.isAborted || queryParamUpdateOnly) return;
 
     if (this.hasUserModifiedAttributes) {
       if (

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -364,8 +364,7 @@ export default class VariableFormComponent extends Component {
   }
 
   confirmExit(transition) {
-    const queryParamUpdateOnly = transition.to.name === transition.from.name;
-    if (transition.isAborted || queryParamUpdateOnly) return;
+    if (transition.isAborted || transition.queryParamsOnly) return;
 
     if (this.hasUserModifiedAttributes) {
       if (
@@ -374,6 +373,8 @@ export default class VariableFormComponent extends Component {
         )
       ) {
         transition.abort();
+      } else {
+        this.removeExitHandler();
       }
     }
   }

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -95,7 +95,7 @@ export default class VariableFormComponent extends Component {
     if (!this.args.model?.isNew) {
       keyValues.pushObject(copy(EMPTY_KV));
     }
-    this.keyValues = keyValues;
+    set(this, 'keyValues', keyValues);
 
     this.JSONItems = stringifyObject([
       this.keyValues.reduce((acc, { key, value }) => {
@@ -332,7 +332,11 @@ export default class VariableFormComponent extends Component {
 
   //#region Unsaved Changes Confirmation
 
-  @computed('keyValues.@each.{key,value}', 'path')
+  @computed(
+    'args.model.{keyValues,path}',
+    'keyValues.@each.{key,value}',
+    'path'
+  )
   get hasUserModifiedAttributes() {
     const compactedBasicKVs = this.keyValues
       .map((kv) => ({ key: kv.key, value: kv.value }))
@@ -369,6 +373,7 @@ export default class VariableFormComponent extends Component {
   }
 
   willDestroy() {
+    super.willDestroy(...arguments);
     this.removeExitHandler();
   }
 

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -332,6 +332,8 @@ export default class VariableFormComponent extends Component {
 
   //#region Unsaved Changes Confirmation
 
+  hasRemovedExitHandler = false;
+
   @computed(
     'args.model.{keyValues,path}',
     'keyValues.@each.{key,value}',
@@ -355,7 +357,10 @@ export default class VariableFormComponent extends Component {
   }
 
   removeExitHandler() {
-    this.router.off('routeWillChange', this, this.confirmExit);
+    if (!this.hasRemovedExitHandler) {
+      this.router.off('routeWillChange', this, this.confirmExit);
+      this.hasRemovedExitHandler = true;
+    }
   }
 
   confirmExit(transition) {

--- a/ui/app/templates/variables/variable/edit.hbs
+++ b/ui/app/templates/variables/variable/edit.hbs
@@ -11,7 +11,7 @@
   Edit
   {{this.model.path}}
   <Toggle
-    data-test-memory-toggle
+    data-test-json-toggle
     @isActive={{eq this.view "json"}}
     @onToggle={{action this.toggleView}}
     title="JSON"


### PR DESCRIPTION
Performs an equality lookup for key values and path when attempting to leave the variables/new or variables/edit routes.

Note: early attempts at using `model.hasDirtyAttributes()` in parent routes proved to be really cumbersome — would have had to do it in a few places. @ChaiWithJai made a good suggestion to try it in the component and so here we are.

![image](https://user-images.githubusercontent.com/713991/191831174-9da1399c-b551-474c-8213-0020cf50b7a9.png)

### Limitation
This will not notify a user when they have changes in JSON mode, as we don't observe (nor want to observe) keystroke changes to that textarea. This could be done but the perf tradeoff would be non-trivial.

Resolves #14658 