### PR TITLE
fingerprint: lengthen Vault check after seen

### DIFF
--- a/client/fingerprint/vault.go
+++ b/client/fingerprint/vault.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/helper"
 	vapi "github.com/hashicorp/vault/api"
 )
 
@@ -78,5 +79,11 @@ func (f *VaultFingerprint) Fingerprint(req *FingerprintRequest, resp *Fingerprin
 }
 
 func (f *VaultFingerprint) Periodic() (bool, time.Duration) {
+	if f.lastState == vaultAvailable {
+		// Fingerprint infrequently once Vault is initially discovered with wide
+		// jitter to avoid thundering herds of fingerprints against central Vault
+		// servers.
+		return true, (30 * time.Second) + helper.RandomStagger(90*time.Second)
+	}
 	return true, 15 * time.Second
 }

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -62,7 +62,7 @@ the `-json` flag is provided.
 
 Nomad clients no longer have their Consul and Vault fingerprints cleared when
 connectivity is lost with Consul and Vault. To intentionally remove Consul and
-Vault from a client node, you will need to restart the client.
+Vault from a client node, you will need to restart the Nomad client agent.
 
 ## Nomad 1.3.3
 


### PR DESCRIPTION
@tgross Yikes! #14673 made me realize how pathological the Vault fingerprinting was. What do you think about going a step further and backing off fingerprints as long as Vault is available?

-- Original commit message --

Extension of #14673

Once Vault is initially fingerprinted, extend the period since changes should be infrequent and the fingerprint is relatively expensive since it is contacting a central Vault server.

Also move the period timer reset *after* the fingerprint. This is similar to #9435 where the idea is to ensure the retry period starts *after* the operation is attempted. 15s will be the *minimum* time between fingerprints now instead of the *maximum* time between fingerprints.

In the case of Vault fingerprinting, the original behavior might cause the following:

1. Timer is reset to 15s
2. Fingerprint takes 16s
3. Timer has already elapsed so we immediately Fingerprint again

Even if fingerprinting Vault only takes a few seconds, that may very well be due to excessive load and backing off our fingerprints is desirable. The new bevahior ensures we always wait at least 15s between fingerprint attempts and should allow some natural jittering based on server load and network latency.