### PR TITLE
fingerprint: add node attr for reserverable cores

### DIFF
--- a/.changelog/14694.txt
+++ b/.changelog/14694.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+fingerprint: Add node attribute for number of reservable cores: `cpu.num_reservable_cores`
+```

--- a/client/fingerprint/cpu.go
+++ b/client/fingerprint/cpu.go
@@ -2,6 +2,7 @@ package fingerprint
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/nomad/lib/cpuset"
 
@@ -62,7 +63,7 @@ func (f *CPUFingerprint) Fingerprint(req *FingerprintRequest, resp *FingerprintR
 
 	var numCores int
 	if numCores = stats.CPUNumCores(); numCores > 0 {
-		resp.AddAttribute("cpu.numcores", fmt.Sprintf("%d", numCores))
+		resp.AddAttribute("cpu.numcores", strconv.Itoa(numCores))
 		f.logger.Debug("detected core count", "cores", numCores)
 	}
 
@@ -80,6 +81,7 @@ func (f *CPUFingerprint) Fingerprint(req *FingerprintRequest, resp *FingerprintR
 			f.logger.Debug("detected reservable cores", "cpuset", reservableCores)
 		}
 	}
+	resp.AddAttribute("cpu.num_reservable_cores", strconv.Itoa(len(reservableCores)))
 
 	tt := int(stats.TotalTicksAvailable())
 	if cfg.CpuCompute > 0 {

--- a/client/fingerprint/cpu.go
+++ b/client/fingerprint/cpu.go
@@ -81,7 +81,7 @@ func (f *CPUFingerprint) Fingerprint(req *FingerprintRequest, resp *FingerprintR
 			f.logger.Debug("detected reservable cores", "cpuset", reservableCores)
 		}
 	}
-	resp.AddAttribute("cpu.num_reservable_cores", strconv.Itoa(len(reservableCores)))
+	resp.AddAttribute("cpu.reservablecores", strconv.Itoa(len(reservableCores)))
 
 	tt := int(stats.TotalTicksAvailable())
 	if cfg.CpuCompute > 0 {

--- a/client/fingerprint/cpu_test.go
+++ b/client/fingerprint/cpu_test.go
@@ -84,8 +84,8 @@ func TestCPUFingerprint_OverrideCompute(t *testing.T) {
 			t.Fatalf("expected response to be applicable")
 		}
 
-		if attr := response.Attributes["cpu.num_reservable_cores"]; attr != "3" {
-			t.Fatalf("expected cpu.num_reservable_cores == 3 but found %s", attr)
+		if attr := response.Attributes["cpu.reservablecores"]; attr != "3" {
+			t.Fatalf("expected cpu.reservablecores == 3 but found %s", attr)
 		}
 
 		if response.Resources.CPU == 0 {
@@ -118,8 +118,8 @@ func TestCPUFingerprint_OverrideCompute(t *testing.T) {
 			t.Fatalf("expected override cpu.totalcompute of %d but found %s", cfg.CpuCompute, response.Attributes["cpu.totalcompute"])
 		}
 
-		if attr := response.Attributes["cpu.num_reservable_cores"]; attr != "3" {
-			t.Fatalf("expected cpu.num_reservable_cores == 3 but found %s", attr)
+		if attr := response.Attributes["cpu.reservablecores"]; attr != "3" {
+			t.Fatalf("expected cpu.reservablecores == 3 but found %s", attr)
 		}
 	}
 }

--- a/client/fingerprint/cpu_test.go
+++ b/client/fingerprint/cpu_test.go
@@ -67,7 +67,9 @@ func TestCPUFingerprint_OverrideCompute(t *testing.T) {
 	node := &structs.Node{
 		Attributes: make(map[string]string),
 	}
-	cfg := &config.Config{}
+	cfg := &config.Config{
+		ReservableCores: []uint16{0, 1, 2},
+	}
 	var originalCPU int
 
 	{
@@ -80,6 +82,10 @@ func TestCPUFingerprint_OverrideCompute(t *testing.T) {
 
 		if !response.Detected {
 			t.Fatalf("expected response to be applicable")
+		}
+
+		if attr := response.Attributes["cpu.num_reservable_cores"]; attr != "3" {
+			t.Fatalf("expected cpu.num_reservable_cores == 3 but found %s", attr)
 		}
 
 		if response.Resources.CPU == 0 {
@@ -110,6 +116,10 @@ func TestCPUFingerprint_OverrideCompute(t *testing.T) {
 		}
 		if response.Attributes["cpu.totalcompute"] != strconv.Itoa(cfg.CpuCompute) {
 			t.Fatalf("expected override cpu.totalcompute of %d but found %s", cfg.CpuCompute, response.Attributes["cpu.totalcompute"])
+		}
+
+		if attr := response.Attributes["cpu.num_reservable_cores"]; attr != "3" {
+			t.Fatalf("expected cpu.num_reservable_cores == 3 but found %s", attr)
 		}
 	}
 }

--- a/website/content/docs/runtime/interpolation.mdx
+++ b/website/content/docs/runtime/interpolation.mdx
@@ -169,7 +169,13 @@ Below is a table documenting common node properties:
       <td>
         <code>{'${attr.cpu.numcores}'}</code>
       </td>
-      <td>Number of CPU cores on the client</td>
+      <td>Number of CPU cores on the client. May differ from how many cores are available for reservation due to OS or configuration. See <code>cpu.num_reservable_cores</code>.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>{'${attr.cpu.num_reservable_cores}'}</code>
+      </td>
+      <td>Number of CPU cores on the client avaible for scheduling. Number of cores used by the scheduler when placing work with <code>resources.cores</code> set.</td>
     </tr>
     <tr>
       <td>

--- a/website/content/docs/runtime/interpolation.mdx
+++ b/website/content/docs/runtime/interpolation.mdx
@@ -169,11 +169,11 @@ Below is a table documenting common node properties:
       <td>
         <code>{'${attr.cpu.numcores}'}</code>
       </td>
-      <td>Number of CPU cores on the client. May differ from how many cores are available for reservation due to OS or configuration. See <code>cpu.num_reservable_cores</code>.</td>
+      <td>Number of CPU cores on the client. May differ from how many cores are available for reservation due to OS or configuration. See <code>cpu.reservablecores</code>.</td>
     </tr>
     <tr>
       <td>
-        <code>{'${attr.cpu.num_reservable_cores}'}</code>
+        <code>{'${attr.cpu.reservablecores}'}</code>
       </td>
       <td>Number of CPU cores on the client avaible for scheduling. Number of cores used by the scheduler when placing work with <code>resources.cores</code> set.</td>
     </tr>


### PR DESCRIPTION
Add an attribute for the number of reservable CPU cores as they may differ from the existing `cpu.numcores` due to client configuration or OS support.

Hopefully clarifies some confusion in #14676