### PR TITLE
client: recover from getter panics

### DIFF
--- a/client/allocrunner/taskrunner/getter/getter_test.go
+++ b/client/allocrunner/taskrunner/getter/getter_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	gg "github.com/hashicorp/go-getter"
+	"github.com/hashicorp/go-hclog"
 	clientconfig "github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/interfaces"
 	"github.com/hashicorp/nomad/client/taskenv"
@@ -56,6 +57,19 @@ func noopTaskEnv(taskDir string) interfaces.EnvReplacer {
 	}
 }
 
+// panicReplacer is a version of taskenv.TaskEnv.ReplaceEnv that panics.
+type panicReplacer struct{}
+
+func (panicReplacer) ReplaceEnv(_ string) string {
+	panic("panic")
+}
+func (panicReplacer) ClientPath(_ string, _ bool) (string, bool) {
+	panic("panic")
+}
+func panicTaskEnv() interfaces.EnvReplacer {
+	return panicReplacer{}
+}
+
 // upperReplacer is a version of taskenv.TaskEnv.ReplaceEnv that upper-cases
 // the given input.
 type upperReplacer struct {
@@ -72,7 +86,7 @@ func (u upperReplacer) ClientPath(p string, join bool) (string, bool) {
 }
 
 func TestGetter_getClient(t *testing.T) {
-	getter := NewGetter(&clientconfig.ArtifactConfig{
+	getter := NewGetter(hclog.NewNullLogger(), &clientconfig.ArtifactConfig{
 		HTTPReadTimeout: time.Minute,
 		HTTPMaxBytes:    100_000,
 		GCSTimeout:      1 * time.Minute,
@@ -434,6 +448,15 @@ func TestGetArtifact_Setuid(t *testing.T) {
 		o := s.Mode()
 		require.Equalf(t, p, o, "%s expected %o found %o", file, p, o)
 	}
+}
+
+// TestGetArtifact_handlePanic tests that a panic during the getter execution
+// does not cause its goroutine to crash.
+func TestGetArtifact_handlePanic(t *testing.T) {
+	getter := TestDefaultGetter(t)
+	err := getter.GetArtifact(panicTaskEnv(), &structs.TaskArtifact{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "panic")
 }
 
 func TestGetGetterUrl_Queries(t *testing.T) {

--- a/client/allocrunner/taskrunner/getter/testing.go
+++ b/client/allocrunner/taskrunner/getter/testing.go
@@ -6,6 +6,7 @@ package getter
 import (
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	clientconfig "github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/stretchr/testify/require"
@@ -14,5 +15,5 @@ import (
 func TestDefaultGetter(t *testing.T) *Getter {
 	getterConf, err := clientconfig.ArtifactConfigFromAgent(config.DefaultArtifactConfig())
 	require.NoError(t, err)
-	return NewGetter(getterConf)
+	return NewGetter(hclog.NewNullLogger(), getterConf)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -396,7 +396,7 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 		serversContactedCh:   make(chan struct{}),
 		serversContactedOnce: sync.Once{},
 		cpusetManager:        cgutil.CreateCPUSetManager(cfg.CgroupParent, cfg.ReservableCores, logger),
-		getter:               getter.NewGetter(cfg.Artifact),
+		getter:               getter.NewGetter(logger.Named("artifact_getter"), cfg.Artifact),
 		EnterpriseClient:     newEnterpriseClient(logger),
 	}
 


### PR DESCRIPTION
The artifact getter uses the go-getter library to fetch files from different sources. Any bug in this library that results in a panic can cause the entire Nomad client to crash due to a single file download attempt.

This change aims to guard against this types of crashes by recovering from panics when the getter attempts to download an artifact. The resulting panic is converted to an error that is stored as a task event for operator visibility and the panic stack trace is logged to the client's log.