### PR TITLE
backport to 1.1.x: CSI: skip node unpublish on GC'd or down nodes

### DIFF
--- a/.changelog/14720.txt
+++ b/.changelog/14720.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where volume claims on lost or garbage collected nodes could not be freed
+```


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/13301 was supposed to have been backported to 1.1.x but there's no backport tag. Weirdly, https://github.com/hashicorp/nomad/pull/13311 refers to the code having been backported, and the test changes from #13301 are already here, just not the code changes. Not sure how that happened but #13301 was one of the PRs impacted by the weirdness around the 1.3.2 vs 1.3.5 release. In any case, this bug should get released in the next 1.1.x.

(2/2 PRs, the other was for 1.2.x)