### PR TITLE
core: numeric operands comparisons in constraints

### DIFF
--- a/.changelog/14722.txt
+++ b/.changelog/14722.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: constraint operands are now compared numerically if operands are numbers
+```

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -819,10 +819,7 @@ func checkConstraint(ctx Context, operand string, lVal, rVal interface{}, lFound
 	case "!=", "not":
 		return !reflect.DeepEqual(lVal, rVal)
 	case "<", "<=", ">", ">=":
-		if !lFound || !rFound {
-			return false
-		}
-		return checkOrder(operand, lVal, rVal)
+		return lFound && rFound && checkOrder(operand, lVal, rVal)
 	case structs.ConstraintAttributeIsSet:
 		return lFound
 	case structs.ConstraintAttributeIsNotSet:
@@ -873,11 +870,11 @@ func checkOrder(operand string, lVal, rVal any) bool {
 
 // checkIntegralOrder compares lVal and rVal as integers if possible, or false otherwise.
 func checkIntegralOrder(op, lVal, rVal string) (bool, bool) {
-	left, lErr := strconv.Atoi(lVal)
+	left, lErr := strconv.ParseInt(lVal, 10, 64)
 	if lErr != nil {
 		return false, false
 	}
-	right, rErr := strconv.Atoi(rVal)
+	right, rErr := strconv.ParseInt(rVal, 10, 64)
 	if rErr != nil {
 		return false, false
 	}

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	memdb "github.com/hashicorp/go-memdb"
-	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/helper/constraints/semver"
 	"github.com/hashicorp/nomad/nomad/structs"
 	psstructs "github.com/hashicorp/nomad/plugins/shared/structs"
@@ -57,7 +57,7 @@ type FeasibleIterator interface {
 	Reset()
 }
 
-// JobContextualIterator is an iterator that can have the job and task group set
+// ContextualIterator is an iterator that can have the job and task group set
 // on it.
 type ContextualIterator interface {
 	SetJob(*structs.Job)
@@ -878,7 +878,7 @@ func checkLexicalOrder(op string, lVal, rVal interface{}) bool {
 
 // checkVersionMatch is used to compare a version on the
 // left hand side with a set of constraints on the right hand side
-func checkVersionMatch(ctx Context, parse verConstraintParser, lVal, rVal interface{}) bool {
+func checkVersionMatch(_ Context, parse verConstraintParser, lVal, rVal interface{}) bool {
 	// Parse the version
 	var versionStr string
 	switch v := lVal.(type) {
@@ -914,7 +914,7 @@ func checkVersionMatch(ctx Context, parse verConstraintParser, lVal, rVal interf
 
 // checkAttributeVersionMatch is used to compare a version on the
 // left hand side with a set of constraints on the right hand side
-func checkAttributeVersionMatch(ctx Context, parse verConstraintParser, lVal, rVal *psstructs.Attribute) bool {
+func checkAttributeVersionMatch(_ Context, parse verConstraintParser, lVal, rVal *psstructs.Attribute) bool {
 	// Parse the version
 	var versionStr string
 	if s, ok := lVal.GetString(); ok {
@@ -982,7 +982,7 @@ func checkRegexpMatch(ctx Context, lVal, rVal interface{}) bool {
 
 // checkSetContainsAll is used to see if the left hand side contains the
 // string on the right hand side
-func checkSetContainsAll(ctx Context, lVal, rVal interface{}) bool {
+func checkSetContainsAll(_ Context, lVal, rVal interface{}) bool {
 	// Ensure left-hand is string
 	lStr, ok := lVal.(string)
 	if !ok {

--- a/website/content/docs/job-specification/constraint.mdx
+++ b/website/content/docs/job-specification/constraint.mdx
@@ -64,8 +64,9 @@ all groups (and tasks) in the job.
   to examine for the constraint. This can be any of the [Nomad interpolated
   values](/docs/runtime/interpolation#interpreted_node_vars).
 
-- `operator` `(string: "=")` - Specifies the comparison operator. The ordering is
-  compared lexically. Possible values include:
+- `operator` `(string: "=")` - Specifies the comparison operator. If the operator
+  is one of `>, >=, <, <=`, the ordering is compared numerically if the operands
+  are both integers or both floats, and lexically otherwise. Possible values include:
 
   ```text
   =

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -64,6 +64,12 @@ Nomad clients no longer have their Consul and Vault fingerprints cleared when
 connectivity is lost with Consul and Vault. To intentionally remove Consul and
 Vault from a client node, you will need to restart the Nomad client agent.
 
+#### Numeric Operand Comparisons in Constraints
+
+Prior to Nomad 1.4.0 the `<, <=, >, >=` operators in a constraint would always
+compare the operands lexically. This behavior has been changed so that the comparison
+is done numerically if both operands are integers or floats.
+
 ## Nomad 1.3.3
 
 Environments that don't support the use of [`uid`][template_uid] and


### PR DESCRIPTION
This PR changes constraint comparisons to be numeric rather than
lexical if both operands are integers or floats.

Inspiration #4856
Closes #4729
Closes #14719
