### PR TITLE
[ui] Bugfix: reinstate the "this variable will be accessible by $job/$group/$task" notification

### DIFF
--- a/ui/app/components/variable-form.hbs
+++ b/ui/app/components/variable-form.hbs
@@ -40,6 +40,7 @@
         @value={{this.path}}
         placeholder="nomad/jobs/my-job/my-group/my-task"
         class="input path-input {{if this.duplicatePathWarning "error"}}"
+        {{on "input" this.setModelPath}}
         disabled={{not @model.isNew}}
         {{autofocus}}
         data-test-path-input

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -168,6 +168,10 @@ export default class VariableFormComponent extends Component {
     this.save(e, true);
   }
 
+  @action setModelPath() {
+    this.args.model.set('path', this.path);
+  }
+
   @action
   async save(e, overwrite = false) {
     if (e.type === 'submit') {

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -173,7 +173,7 @@ export default class VariableFormComponent extends Component {
    * @param {KeyboardEvent} e
    */
   @action setModelPath(e) {
-    this.args.model.set('path', e.target.value);
+    set(this.args.model, 'path', e.target.value);
   }
 
   @action

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -168,8 +168,12 @@ export default class VariableFormComponent extends Component {
     this.save(e, true);
   }
 
-  @action setModelPath() {
-    this.args.model.set('path', this.path);
+  /**
+   *
+   * @param {KeyboardEvent} e
+   */
+  @action setModelPath(e) {
+    this.args.model.set('path', e.target.value);
   }
 
   @action


### PR DESCRIPTION
When we isolated the variable form path to within its component for isolation reasons, we lost the model-level checks for related entities at type-time.

This reinstates the notification for variable-creating users that what they're about to create will be accessible by specific jobs/groups/paths as they type.

![image](https://user-images.githubusercontent.com/713991/192926043-d5534eab-1159-4e10-b5e2-b8713bca3c1b.png)
