### PR TITLE
template: apply splay value on change_mode script

### DIFF
--- a/.changelog/14749.txt
+++ b/.changelog/14749.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+template: Fixed a bug where the `splay` timeout was not being applied when `change_mode` was set to `script`.
+```

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -463,52 +463,65 @@ func (tm *TaskTemplateManager) onTemplateRendered(handledRenders map[string]time
 		handling = append(handling, id)
 	}
 
-	if restart || len(signals) != 0 {
-		if splay != 0 {
-			ns := splay.Nanoseconds()
-			offset := rand.Int63n(ns)
-			t := time.Duration(offset)
+	shouldHandle := restart || len(signals) != 0 || len(scripts) != 0
+	if !shouldHandle {
+		return
+	}
 
-			select {
-			case <-time.After(t):
-			case <-tm.shutdownCh:
-				return
-			}
-		}
+	// Apply splay timeout to avoid applying change_mode too frequently.
+	if splay != 0 {
+		ns := splay.Nanoseconds()
+		offset := rand.Int63n(ns)
+		t := time.Duration(offset)
 
-		// Update handle time
-		for _, id := range handling {
-			handledRenders[id] = events[id].LastDidRender
-		}
-
-		if restart {
-			tm.config.Lifecycle.Restart(context.Background(),
-				structs.NewTaskEvent(structs.TaskRestartSignal).
-					SetDisplayMessage("Template with change_mode restart re-rendered"), false)
-		} else if len(signals) != 0 {
-			var mErr multierror.Error
-			for signal := range signals {
-				s := tm.signals[signal]
-				event := structs.NewTaskEvent(structs.TaskSignaling).SetTaskSignal(s).SetDisplayMessage("Template re-rendered")
-				if err := tm.config.Lifecycle.Signal(event, signal); err != nil {
-					_ = multierror.Append(&mErr, err)
-				}
-			}
-
-			if err := mErr.ErrorOrNil(); err != nil {
-				flat := make([]os.Signal, 0, len(signals))
-				for signal := range signals {
-					flat = append(flat, tm.signals[signal])
-				}
-
-				tm.config.Lifecycle.Kill(context.Background(),
-					structs.NewTaskEvent(structs.TaskKilling).
-						SetFailsTask().
-						SetDisplayMessage(fmt.Sprintf("Template failed to send signals %v: %v", flat, err)))
-			}
+		select {
+		case <-time.After(t):
+		case <-tm.shutdownCh:
+			return
 		}
 	}
 
+	// Update handle time
+	for _, id := range handling {
+		handledRenders[id] = events[id].LastDidRender
+	}
+
+	if restart {
+		tm.config.Lifecycle.Restart(context.Background(),
+			structs.NewTaskEvent(structs.TaskRestartSignal).
+				SetDisplayMessage("Template with change_mode restart re-rendered"), false)
+	} else {
+		// Handle signals and scripts since the task may have multiple
+		// templates with mixed change_mode values.
+		tm.handleChangeModeSignal(signals)
+		tm.handleChangeModeScript(scripts)
+	}
+}
+
+func (tm *TaskTemplateManager) handleChangeModeSignal(signals map[string]struct{}) {
+	var mErr multierror.Error
+	for signal := range signals {
+		s := tm.signals[signal]
+		event := structs.NewTaskEvent(structs.TaskSignaling).SetTaskSignal(s).SetDisplayMessage("Template re-rendered")
+		if err := tm.config.Lifecycle.Signal(event, signal); err != nil {
+			_ = multierror.Append(&mErr, err)
+		}
+	}
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		flat := make([]os.Signal, 0, len(signals))
+		for signal := range signals {
+			flat = append(flat, tm.signals[signal])
+		}
+
+		tm.config.Lifecycle.Kill(context.Background(),
+			structs.NewTaskEvent(structs.TaskKilling).
+				SetFailsTask().
+				SetDisplayMessage(fmt.Sprintf("Template failed to send signals %v: %v", flat, err)))
+	}
+}
+
+func (tm *TaskTemplateManager) handleChangeModeScript(scripts []*structs.ChangeScript) {
 	// process script execution concurrently
 	var wg sync.WaitGroup
 	for _, script := range scripts {


### PR DESCRIPTION
Previously, the splay timeout was only applied if a template re-render caused a restart or a signal action. The `change_mode = "script"` was running after the `if restart || len(signals) != 0` check, so it was invoked at all times.

This change refactors the logic so it's easier to notice that new `change_mode` options should start only after `splay` is applied.

Closes #14734