### PR TITLE
cleanup: rename Equals to Equal for consistency

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1566,7 +1566,7 @@ func (c *Client) updateNodeFromFingerprint(response *fingerprint.FingerprintResp
 		response.Resources.Networks = updateNetworks(
 			response.Resources.Networks,
 			newConfig)
-		if !newConfig.Node.Resources.Equals(response.Resources) {
+		if !newConfig.Node.Resources.Equal(response.Resources) {
 			newConfig.Node.Resources.Merge(response.Resources)
 			nodeHasChanged = true
 		}
@@ -1578,7 +1578,7 @@ func (c *Client) updateNodeFromFingerprint(response *fingerprint.FingerprintResp
 		response.NodeResources.Networks = updateNetworks(
 			response.NodeResources.Networks,
 			newConfig)
-		if !newConfig.Node.NodeResources.Equals(response.NodeResources) {
+		if !newConfig.Node.NodeResources.Equal(response.NodeResources) {
 			newConfig.Node.NodeResources.Merge(response.NodeResources)
 			nodeHasChanged = true
 		}

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -48,7 +48,7 @@ var (
 		"java",
 	}, ",")
 
-	// A mapping of directories on the host OS to attempt to embed inside each
+	// DefaultChrootEnv is a mapping of directories on the host OS to attempt to embed inside each
 	// task's chroot.
 	DefaultChrootEnv = map[string]string{
 		"/bin":            "/bin",
@@ -461,8 +461,8 @@ func (wc *WaitConfig) Copy() *WaitConfig {
 	return wc
 }
 
-// Equals returns the result of reflect.DeepEqual
-func (wc *WaitConfig) Equals(other *WaitConfig) bool {
+// Equal returns the result of reflect.DeepEqual
+func (wc *WaitConfig) Equal(other *WaitConfig) bool {
 	return reflect.DeepEqual(wc, other)
 }
 
@@ -471,7 +471,7 @@ func (wc *WaitConfig) IsEmpty() bool {
 	if wc == nil {
 		return true
 	}
-	return wc.Equals(&WaitConfig{})
+	return wc.Equal(&WaitConfig{})
 }
 
 // Validate returns an error  if the receiver is nil or empty or if Min is greater
@@ -596,8 +596,8 @@ func (rc *RetryConfig) Copy() *RetryConfig {
 	return nrc
 }
 
-// Equals returns the result of reflect.DeepEqual
-func (rc *RetryConfig) Equals(other *RetryConfig) bool {
+// Equal returns the result of reflect.DeepEqual
+func (rc *RetryConfig) Equal(other *RetryConfig) bool {
 	return reflect.DeepEqual(rc, other)
 }
 
@@ -607,7 +607,7 @@ func (rc *RetryConfig) IsEmpty() bool {
 		return true
 	}
 
-	return rc.Equals(&RetryConfig{})
+	return rc.Equal(&RetryConfig{})
 }
 
 // Validate returns an error if the receiver is nil or empty, or if Backoff

--- a/client/config/config_test.go
+++ b/client/config/config_test.go
@@ -92,7 +92,7 @@ func TestWaitConfig_Copy(t *testing.T) {
 
 	for _, _case := range cases {
 		t.Run(_case.Name, func(t *testing.T) {
-			result := _case.Expected.Equals(_case.Wait.Copy())
+			result := _case.Expected.Equal(_case.Wait.Copy())
 			if !result {
 				t.Logf("\nExpected %v\n   Found %v", _case.Expected, result)
 			}
@@ -175,7 +175,7 @@ func TestWaitConfig_IsEqual(t *testing.T) {
 
 	for _, _case := range cases {
 		t.Run(_case.Name, func(t *testing.T) {
-			require.Equal(t, _case.Expected, _case.Wait.Equals(_case.Other))
+			require.Equal(t, _case.Expected, _case.Wait.Equal(_case.Other))
 		})
 	}
 }
@@ -285,7 +285,7 @@ func TestWaitConfig_Merge(t *testing.T) {
 	for _, _case := range cases {
 		t.Run(_case.Name, func(t *testing.T) {
 			merged := _case.Target.Merge(_case.Other)
-			result := _case.Expected.Equals(merged)
+			result := _case.Expected.Equal(merged)
 			if !result {
 				t.Logf("\nExpected %v\n   Found %v", _case.Expected, merged)
 			}
@@ -391,7 +391,7 @@ func TestRetryConfig_Copy(t *testing.T) {
 
 	for _, _case := range cases {
 		t.Run(_case.Name, func(t *testing.T) {
-			result := _case.Expected.Equals(_case.Retry.Copy())
+			result := _case.Expected.Equal(_case.Retry.Copy())
 			if !result {
 				t.Logf("\nExpected %v\n   Found %v", _case.Expected, result)
 			}
@@ -519,7 +519,7 @@ func TestRetryConfig_IsEqual(t *testing.T) {
 
 	for _, _case := range cases {
 		t.Run(_case.Name, func(t *testing.T) {
-			require.Equal(t, _case.Expected, _case.Retry.Equals(_case.Other))
+			require.Equal(t, _case.Expected, _case.Retry.Equal(_case.Other))
 		})
 	}
 }
@@ -662,7 +662,7 @@ func TestRetryConfig_Merge(t *testing.T) {
 	for _, _case := range cases {
 		t.Run(_case.Name, func(t *testing.T) {
 			merged := _case.Target.Merge(_case.Other)
-			result := _case.Expected.Equals(merged)
+			result := _case.Expected.Equal(merged)
 			if !result {
 				t.Logf("\nExpected %v\n   Found %v", _case.Expected, merged)
 			}

--- a/client/lib/cgutil/cpuset_manager_v1_test.go
+++ b/client/lib/cgutil/cpuset_manager_v1_test.go
@@ -136,7 +136,7 @@ func TestCpusetManager_V1_RemoveAlloc(t *testing.T) {
 	require.NoError(t, err)
 	reservedCpus, err := cpuset.Parse(string(reservedCpusRaw))
 	require.NoError(t, err)
-	require.True(t, reservedCpus.Equals(alloc1Cpuset.Union(alloc2Cpuset)))
+	require.True(t, reservedCpus.Equal(alloc1Cpuset.Union(alloc2Cpuset)))
 
 	// remove first allocation
 	alloc1TaskPath := manager.cgroupInfo[alloc1.ID]["web"].CgroupPath
@@ -159,6 +159,6 @@ func TestCpusetManager_V1_RemoveAlloc(t *testing.T) {
 	require.NoError(t, err)
 	reservedCpus, err = cpuset.Parse(string(reservedCpusRaw))
 	require.NoError(t, err)
-	require.True(t, reservedCpus.Equals(alloc2Cpuset))
+	require.True(t, reservedCpus.Equal(alloc2Cpuset))
 
 }

--- a/command/agent/variable_endpoint_test.go
+++ b/command/agent/variable_endpoint_test.go
@@ -411,7 +411,7 @@ func TestHTTP_Variables(t *testing.T) {
 				require.NotNil(t, obj)
 				conflict, ok := obj.(*structs.VariableDecrypted)
 				require.True(t, ok, "Expected *structs.VariableDecrypted, got %T", obj)
-				require.True(t, sv.Equals(*conflict))
+				require.True(t, sv.Equal(*conflict))
 
 				// Check for the index
 				require.NotZero(t, respW.HeaderMap.Get("X-Nomad-Index"))

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -415,22 +415,22 @@ func IsMethodHTTP(s string) bool {
 	return true
 }
 
-// EqualsFunc represents a type implementing the Equals method.
-type EqualsFunc[A any] interface {
-	Equals(A) bool
+// EqualFunc represents a type implementing the Equal method.
+type EqualFunc[A any] interface {
+	Equal(A) bool
 }
 
-// ElementsEquals returns true if slices a and b contain the same elements (in
-// no particular order) using the Equals function defined on their type for
+// ElementsEqual returns true if slices a and b contain the same elements (in
+// no particular order) using the Equal function defined on their type for
 // comparison.
-func ElementsEquals[T EqualsFunc[T]](a, b []T) bool {
+func ElementsEqual[T EqualFunc[T]](a, b []T) bool {
 	if len(a) != len(b) {
 		return false
 	}
 OUTER:
 	for _, item := range a {
 		for _, other := range b {
-			if item.Equals(other) {
+			if item.Equal(other) {
 				continue OUTER
 			}
 		}
@@ -442,8 +442,8 @@ OUTER:
 // SliceSetEq returns true if slices a and b contain the same elements (in no
 // particular order), using '==' for comparison.
 //
-// Note: for pointers, consider implementing an Equals method and using
-// ElementsEquals instead.
+// Note: for pointers, consider implementing an Equal method and using
+// ElementsEqual instead.
 func SliceSetEq[T comparable](a, b []T) bool {
 	lenA, lenB := len(a), len(b)
 	if lenA != lenB {

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -448,7 +448,7 @@ type employee struct {
 	name string
 }
 
-func (e *employee) Equals(o *employee) bool {
+func (e *employee) Equal(o *employee) bool {
 	return e.id == o.id // name can be different
 }
 
@@ -456,29 +456,29 @@ func Test_ElementsEquals(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		a := []*employee(nil)
 		var b []*employee
-		must.True(t, ElementsEquals(a, b))
-		must.True(t, ElementsEquals(b, a))
+		must.True(t, ElementsEqual(a, b))
+		must.True(t, ElementsEqual(b, a))
 	})
 
 	t.Run("different sizes", func(t *testing.T) {
 		a := []*employee{{1, "mitchell"}, {2, "armon"}, {3, "jack"}}
 		b := []*employee{{1, "mitchell"}, {2, "armon"}}
-		must.False(t, ElementsEquals(a, b))
-		must.False(t, ElementsEquals(b, a))
+		must.False(t, ElementsEqual(a, b))
+		must.False(t, ElementsEqual(b, a))
 	})
 
 	t.Run("equal", func(t *testing.T) {
 		a := []*employee{{1, "mitchell"}, {2, "armon"}, {3, "jack"}}
 		b := []*employee{{1, "M.H."}, {2, "A.D."}, {3, "J.P."}}
-		must.True(t, ElementsEquals(a, b))
-		must.True(t, ElementsEquals(b, a))
+		must.True(t, ElementsEqual(a, b))
+		must.True(t, ElementsEqual(b, a))
 	})
 
 	t.Run("different", func(t *testing.T) {
 		a := []*employee{{1, "mitchell"}, {2, "armon"}, {3, "jack"}}
 		b := []*employee{{0, "mitchell."}, {2, "armon"}, {3, "jack"}}
-		must.False(t, ElementsEquals(a, b))
-		must.False(t, ElementsEquals(b, a))
+		must.False(t, ElementsEqual(a, b))
+		must.False(t, ElementsEqual(b, a))
 	})
 }
 

--- a/helper/pointer/pointer.go
+++ b/helper/pointer/pointer.go
@@ -29,7 +29,7 @@ type Primitive interface {
 //
 // May only be used on pointers to primitive types, where the comparison is
 // guaranteed to be sensible. For complex types (i.e. structs) consider implementing
-// an Equals method.
+// an Equal method.
 func Eq[P Primitive](a, b *P) bool {
 	if a == nil || b == nil {
 		return a == b

--- a/lib/cpuset/cpuset.go
+++ b/lib/cpuset/cpuset.go
@@ -142,8 +142,8 @@ func (c CPUSet) ContainsAny(other CPUSet) bool {
 	return false
 }
 
-// Equals tests the equality of the elements in the CPUSet
-func (c CPUSet) Equals(other CPUSet) bool {
+// Equal tests the equality of the elements in the CPUSet
+func (c CPUSet) Equal(other CPUSet) bool {
 	return reflect.DeepEqual(c.cpus, other.cpus)
 }
 

--- a/lib/cpuset/cpuset_test.go
+++ b/lib/cpuset/cpuset_test.go
@@ -45,7 +45,7 @@ func TestCPUSet_ToSlice(t *testing.T) {
 	}
 }
 
-func TestCPUSet_Equals(t *testing.T) {
+func TestCPUSet_Equal(t *testing.T) {
 	ci.Parallel(t)
 
 	cases := []struct {
@@ -66,7 +66,7 @@ func TestCPUSet_Equals(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		require.Equal(t, c.shouldEqual, c.a.Equals(c.b))
+		require.Equal(t, c.shouldEqual, c.a.Equal(c.b))
 	}
 }
 
@@ -201,7 +201,7 @@ func TestParse(t *testing.T) {
 	for _, c := range cases {
 		result, err := Parse(c.cpuset)
 		require.NoError(t, err)
-		require.True(t, result.Equals(c.expected))
+		require.True(t, result.Equal(c.expected))
 	}
 }
 
@@ -228,10 +228,10 @@ func TestCPUSet_Copy(t *testing.T) {
 
 	original := New(1, 2, 3, 4, 5)
 	copied := original.Copy()
-	require.True(t, original.Equals(copied))
+	require.True(t, original.Equal(copied))
 
 	delete(copied.cpus, 3)
-	require.False(t, original.Equals(copied))
-	require.True(t, original.Equals(New(1, 2, 3, 4, 5)))
-	require.True(t, copied.Equals(New(1, 2, 4, 5)))
+	require.False(t, original.Equal(copied))
+	require.True(t, original.Equal(New(1, 2, 3, 4, 5)))
+	require.True(t, copied.Equal(New(1, 2, 4, 5)))
 }

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -1959,7 +1959,7 @@ func TestACL_UpsertRoles(t *testing.T) {
 	err = msgpackrpc.CallWithCodec(codec, structs.ACLUpsertRolesRPCMethod, aclRoleReq3, &aclRoleResp3)
 	require.NoError(t, err)
 	require.Len(t, aclRoleResp3.ACLRoles, 1)
-	require.True(t, aclRole1.Equals(aclRoleResp3.ACLRoles[0]))
+	require.True(t, aclRole1.Equal(aclRoleResp3.ACLRoles[0]))
 
 	// Perform an update of the ACL role by removing a policy and changing the
 	// name.
@@ -1979,7 +1979,7 @@ func TestACL_UpsertRoles(t *testing.T) {
 	err = msgpackrpc.CallWithCodec(codec, structs.ACLUpsertRolesRPCMethod, aclRoleReq4, &aclRoleResp4)
 	require.NoError(t, err)
 	require.Len(t, aclRoleResp4.ACLRoles, 1)
-	require.True(t, aclRole1Copy.Equals(aclRoleResp4.ACLRoles[0]))
+	require.True(t, aclRole1Copy.Equal(aclRoleResp4.ACLRoles[0]))
 	require.Greater(t, aclRoleResp4.ACLRoles[0].ModifyIndex, aclRoleResp3.ACLRoles[0].ModifyIndex)
 
 	// Create another ACL role that will fail validation. Attempting to upsert
@@ -2073,7 +2073,7 @@ func TestACL_DeleteRolesByID(t *testing.T) {
 	}
 
 	require.Len(t, aclRolesLookup, 1)
-	require.True(t, aclRolesLookup[0].Equals(aclRoles[1]))
+	require.True(t, aclRolesLookup[0].Equal(aclRoles[1]))
 
 	// Try to delete the previously deleted ACL role, this should fail.
 	aclRoleReq3 := &structs.ACLRolesDeleteByIDRequest{
@@ -2368,7 +2368,7 @@ func TestACL_GetRoleByID(t *testing.T) {
 	var aclRoleResp3 structs.ACLRoleByIDResponse
 	err = msgpackrpc.CallWithCodec(codec, structs.ACLGetRoleByIDRPCMethod, aclRoleReq3, &aclRoleResp3)
 	require.NoError(t, err)
-	require.True(t, aclRoleResp3.ACLRole.Equals(aclRoles[0]))
+	require.True(t, aclRoleResp3.ACLRole.Equal(aclRoles[0]))
 
 	aclRoleReq4 := &structs.ACLRoleByIDRequest{
 		RoleID: aclRoles[1].ID,
@@ -2380,7 +2380,7 @@ func TestACL_GetRoleByID(t *testing.T) {
 	var aclRoleResp4 structs.ACLRoleByIDResponse
 	err = msgpackrpc.CallWithCodec(codec, structs.ACLGetRoleByIDRPCMethod, aclRoleReq4, &aclRoleResp4)
 	require.NoError(t, err)
-	require.True(t, aclRoleResp4.ACLRole.Equals(aclRoles[1]))
+	require.True(t, aclRoleResp4.ACLRole.Equal(aclRoles[1]))
 
 	// Generate and upsert an ACL Token which links to only one of the two
 	// roles within state.
@@ -2473,7 +2473,7 @@ func TestACL_GetRoleByName(t *testing.T) {
 	var aclRoleResp3 structs.ACLRoleByNameResponse
 	err = msgpackrpc.CallWithCodec(codec, structs.ACLGetRoleByNameRPCMethod, aclRoleReq3, &aclRoleResp3)
 	require.NoError(t, err)
-	require.True(t, aclRoleResp3.ACLRole.Equals(aclRoles[0]))
+	require.True(t, aclRoleResp3.ACLRole.Equal(aclRoles[0]))
 
 	aclRoleReq4 := &structs.ACLRoleByNameRequest{
 		RoleName: aclRoles[1].Name,
@@ -2485,7 +2485,7 @@ func TestACL_GetRoleByName(t *testing.T) {
 	var aclRoleResp4 structs.ACLRoleByNameResponse
 	err = msgpackrpc.CallWithCodec(codec, structs.ACLGetRoleByNameRPCMethod, aclRoleReq4, &aclRoleResp4)
 	require.NoError(t, err)
-	require.True(t, aclRoleResp4.ACLRole.Equals(aclRoles[1]))
+	require.True(t, aclRoleResp4.ACLRole.Equal(aclRoles[1]))
 
 	// Generate and upsert an ACL Token which links to only one of the two
 	// roles within state.

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -193,7 +193,7 @@ type constraintMatcher uint
 const (
 	// constraintMatcherFull ensures that a constraint is only considered found
 	// when they match totally. This check is performed using the
-	// structs.Constraint Equals function.
+	// structs.Constraint Equal function.
 	constraintMatcherFull constraintMatcher = iota
 
 	// constraintMatcherLeft ensure that a constraint is considered found if
@@ -214,7 +214,7 @@ func mutateConstraint(matcher constraintMatcher, taskGroup *structs.TaskGroup, c
 	switch matcher {
 	case constraintMatcherFull:
 		for _, c := range taskGroup.Constraints {
-			if c.Equals(constraint) {
+			if c.Equal(constraint) {
 				found = true
 				break
 			}

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -1680,7 +1680,7 @@ func TestJobEndpoint_Register_Vault_OverrideConstraint(t *testing.T) {
 	// Assert constraint was not overridden by the server
 	outConstraints := out.TaskGroups[0].Tasks[0].Constraints
 	require.Len(t, outConstraints, 1)
-	require.True(t, job.TaskGroups[0].Tasks[0].Constraints[0].Equals(outConstraints[0]))
+	require.True(t, job.TaskGroups[0].Tasks[0].Constraints[0].Equal(outConstraints[0]))
 }
 
 func TestJobEndpoint_Register_Vault_NoToken(t *testing.T) {

--- a/nomad/state/state_store_acl.go
+++ b/nomad/state/state_store_acl.go
@@ -139,7 +139,7 @@ func (s *StateStore) upsertACLRoleTxn(
 		// If the role already exists, check whether the update contains any
 		// difference. If it doesn't, we can avoid a state update as wel as
 		// updates to any blocking queries.
-		if existing.Equals(role) {
+		if existing.Equal(role) {
 			return false, nil
 		}
 

--- a/nomad/state/state_store_acl_test.go
+++ b/nomad/state/state_store_acl_test.go
@@ -335,7 +335,7 @@ func TestStateStore_DeleteACLRolesByID(t *testing.T) {
 	}
 
 	require.Len(t, aclRoles, 1, "incorrect number of ACL roles found")
-	require.True(t, aclRoles[0].Equals(mockedACLRoles[1]))
+	require.True(t, aclRoles[0].Equal(mockedACLRoles[1]))
 
 	// Delete the final remaining ACL role. This should succeed and modify the
 	// table index.

--- a/nomad/state/state_store_service_regisration_test.go
+++ b/nomad/state/state_store_service_regisration_test.go
@@ -139,7 +139,7 @@ func TestStateStore_UpsertServiceRegistrations(t *testing.T) {
 		}
 		require.Equal(t, insertIndex, serviceReg.CreateIndex, "incorrect create index", serviceReg.ID)
 		require.Equal(t, expectedModifyIndex, serviceReg.ModifyIndex, "incorrect modify index", serviceReg.ID)
-		require.True(t, expectedServiceReg.Equals(serviceReg))
+		require.True(t, expectedServiceReg.Equal(serviceReg))
 	}
 }
 

--- a/nomad/state/state_store_service_registration.go
+++ b/nomad/state/state_store_service_registration.go
@@ -60,7 +60,7 @@ func (s *StateStore) upsertServiceRegistrationTxn(
 	// Set up the indexes correctly to ensure existing indexes are maintained.
 	if existing != nil {
 		exist := existing.(*structs.ServiceRegistration)
-		if exist.Equals(service) {
+		if exist.Equal(service) {
 			return false, nil
 		}
 		service.CreateIndex = exist.CreateIndex

--- a/nomad/state/state_store_variables.go
+++ b/nomad/state/state_store_variables.go
@@ -206,7 +206,7 @@ func (s *StateStore) varSetTxn(tx WriteTxn, idx uint64, req *structs.VarApplySta
 		sv.CreateIndex = existing.CreateIndex
 		sv.CreateTime = existing.CreateTime
 
-		if existing.Equals(*sv) {
+		if existing.Equal(*sv) {
 			// Skip further writing in the state store if the entry is not actually
 			// changed. Nevertheless, the input's ModifyIndex should be reset
 			// since the TXN API returns a copy in the response.

--- a/nomad/state/state_store_variables_test.go
+++ b/nomad/state/state_store_variables_test.go
@@ -205,8 +205,8 @@ func TestStateStore_UpsertVariables(t *testing.T) {
 		require.Equal(t, svs[0].ModifyIndex, got[0].ModifyIndex)
 		require.Equal(t, update2Index, got[1].ModifyIndex)
 
-		require.True(t, svs[0].Equals(got[0]))
-		require.True(t, sv2.Equals(got[1]))
+		require.True(t, svs[0].Equal(got[0]))
+		require.True(t, sv2.Equal(got[1]))
 
 		quotaUsed, err := testState.VariablesQuotaByNamespace(ws, structs.DefaultNamespace)
 		require.NoError(t, err)

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -333,9 +333,9 @@ func (a *ACLRole) Canonicalize() {
 	}
 }
 
-// Equals performs an equality check on the two service registrations. It
+// Equal performs an equality check on the two service registrations. It
 // handles nil objects.
-func (a *ACLRole) Equals(o *ACLRole) bool {
+func (a *ACLRole) Equal(o *ACLRole) bool {
 	if a == nil || o == nil {
 		return a == o
 	}

--- a/nomad/structs/acl_test.go
+++ b/nomad/structs/acl_test.go
@@ -625,7 +625,7 @@ func TestACLRole_Equals(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualOutput := tc.composedACLRole.Equals(tc.inputACLRole)
+			actualOutput := tc.composedACLRole.Equal(tc.inputACLRole)
 			require.Equal(t, tc.expectedOutput, actualOutput)
 		})
 	}

--- a/nomad/structs/config/vault.go
+++ b/nomad/structs/config/vault.go
@@ -188,14 +188,9 @@ func (c *VaultConfig) Copy() *VaultConfig {
 	return nc
 }
 
-// Equal is a rename of Equals.
-func (c *VaultConfig) Equal(b *VaultConfig) bool {
-	return c.Equals(b)
-}
-
-// Equals compares two Vault configurations and returns a boolean indicating
+// Equal compares two Vault configurations and returns a boolean indicating
 // if they are equal.
-func (c *VaultConfig) Equals(b *VaultConfig) bool {
+func (c *VaultConfig) Equal(b *VaultConfig) bool {
 	if c == nil && b != nil {
 		return false
 	}

--- a/nomad/structs/consul.go
+++ b/nomad/structs/consul.go
@@ -16,8 +16,8 @@ func (c *Consul) Copy() *Consul {
 	}
 }
 
-// Equals returns whether c and o are the same.
-func (c *Consul) Equals(o *Consul) bool {
+// Equal returns whether c and o are the same.
+func (c *Consul) Equal(o *Consul) bool {
 	if c == nil || o == nil {
 		return c == o
 	}

--- a/nomad/structs/consul_test.go
+++ b/nomad/structs/consul_test.go
@@ -27,22 +27,22 @@ func TestConsul_Equals(t *testing.T) {
 	ci.Parallel(t)
 
 	t.Run("nil and nil", func(t *testing.T) {
-		result := (*Consul)(nil).Equals((*Consul)(nil))
+		result := (*Consul)(nil).Equal((*Consul)(nil))
 		require.True(t, result)
 	})
 
 	t.Run("nil and set", func(t *testing.T) {
-		result := (*Consul)(nil).Equals(&Consul{Namespace: "one"})
+		result := (*Consul)(nil).Equal(&Consul{Namespace: "one"})
 		require.False(t, result)
 	})
 
 	t.Run("same", func(t *testing.T) {
-		result := (&Consul{Namespace: "one"}).Equals(&Consul{Namespace: "one"})
+		result := (&Consul{Namespace: "one"}).Equal(&Consul{Namespace: "one"})
 		require.True(t, result)
 	})
 
 	t.Run("different", func(t *testing.T) {
-		result := (&Consul{Namespace: "one"}).Equals(&Consul{Namespace: "two"})
+		result := (&Consul{Namespace: "one"}).Equal(&Consul{Namespace: "two"})
 		require.False(t, result)
 	})
 }

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -1531,11 +1531,11 @@ func consulProxyUpstreamDiff(prev, next ConsulUpstream, contextual bool) *Object
 
 	if reflect.DeepEqual(prev, next) {
 		return nil
-	} else if prev.Equals(new(ConsulUpstream)) {
+	} else if prev.Equal(new(ConsulUpstream)) {
 		prev = ConsulUpstream{}
 		diff.Type = DiffTypeAdded
 		newPrimFlat = flatmap.Flatten(next, nil, true)
-	} else if next.Equals(new(ConsulUpstream)) {
+	} else if next.Equal(new(ConsulUpstream)) {
 		next = ConsulUpstream{}
 		diff.Type = DiffTypeDeleted
 		oldPrimFlat = flatmap.Flatten(prev, nil, true)

--- a/nomad/structs/service_registration.go
+++ b/nomad/structs/service_registration.go
@@ -106,9 +106,9 @@ func (s *ServiceRegistration) Copy() *ServiceRegistration {
 	return ns
 }
 
-// Equals performs an equality check on the two service registrations. It
+// Equal performs an equality check on the two service registrations. It
 // handles nil objects.
-func (s *ServiceRegistration) Equals(o *ServiceRegistration) bool {
+func (s *ServiceRegistration) Equal(o *ServiceRegistration) bool {
 	if s == nil || o == nil {
 		return s == o
 	}

--- a/nomad/structs/service_registration_test.go
+++ b/nomad/structs/service_registration_test.go
@@ -21,7 +21,7 @@ func TestServiceRegistration_Copy(t *testing.T) {
 		Port:        23813,
 	}
 	newSR := sr.Copy()
-	require.True(t, sr.Equals(newSR))
+	require.True(t, sr.Equal(newSR))
 }
 
 func TestServiceRegistration_Equal(t *testing.T) {
@@ -377,7 +377,7 @@ func TestServiceRegistration_Equal(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualOutput := tc.serviceReg1.Equals(tc.serviceReg2)
+			actualOutput := tc.serviceReg1.Equal(tc.serviceReg2)
 			require.Equal(t, tc.expectedOutput, actualOutput)
 		})
 	}

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -97,8 +97,8 @@ func (sc *ServiceCheck) Copy() *ServiceCheck {
 	return nsc
 }
 
-// Equals returns true if the structs are recursively equal.
-func (sc *ServiceCheck) Equals(o *ServiceCheck) bool {
+// Equal returns true if the structs are recursively equal.
+func (sc *ServiceCheck) Equal(o *ServiceCheck) bool {
 	if sc == nil || o == nil {
 		return sc == o
 	}
@@ -115,7 +115,7 @@ func (sc *ServiceCheck) Equals(o *ServiceCheck) bool {
 		return false
 	}
 
-	if !sc.CheckRestart.Equals(o.CheckRestart) {
+	if !sc.CheckRestart.Equal(o.CheckRestart) {
 		return false
 	}
 
@@ -883,8 +883,8 @@ func hashConfig(h hash.Hash, c map[string]interface{}) {
 	_, _ = fmt.Fprintf(h, "%v", c)
 }
 
-// Equals returns true if the structs are recursively equal.
-func (s *Service) Equals(o *Service) bool {
+// Equal returns true if the structs are recursively equal.
+func (s *Service) Equal(o *Service) bool {
 	if s == nil || o == nil {
 		return s == o
 	}
@@ -913,11 +913,11 @@ func (s *Service) Equals(o *Service) bool {
 		return false
 	}
 
-	if !helper.ElementsEquals(s.Checks, o.Checks) {
+	if !helper.ElementsEqual(s.Checks, o.Checks) {
 		return false
 	}
 
-	if !s.Connect.Equals(o.Connect) {
+	if !s.Connect.Equal(o.Connect) {
 		return false
 	}
 
@@ -981,8 +981,8 @@ func (c *ConsulConnect) Copy() *ConsulConnect {
 	}
 }
 
-// Equals returns true if the connect blocks are deeply equal.
-func (c *ConsulConnect) Equals(o *ConsulConnect) bool {
+// Equal returns true if the connect blocks are deeply equal.
+func (c *ConsulConnect) Equal(o *ConsulConnect) bool {
 	if c == nil || o == nil {
 		return c == o
 	}
@@ -991,15 +991,15 @@ func (c *ConsulConnect) Equals(o *ConsulConnect) bool {
 		return false
 	}
 
-	if !c.SidecarService.Equals(o.SidecarService) {
+	if !c.SidecarService.Equal(o.SidecarService) {
 		return false
 	}
 
-	if !c.SidecarTask.Equals(o.SidecarTask) {
+	if !c.SidecarTask.Equal(o.SidecarTask) {
 		return false
 	}
 
-	if !c.Gateway.Equals(o.Gateway) {
+	if !c.Gateway.Equal(o.Gateway) {
 		return false
 	}
 
@@ -1120,8 +1120,8 @@ func (s *ConsulSidecarService) Copy() *ConsulSidecarService {
 	}
 }
 
-// Equals returns true if the structs are recursively equal.
-func (s *ConsulSidecarService) Equals(o *ConsulSidecarService) bool {
+// Equal returns true if the structs are recursively equal.
+func (s *ConsulSidecarService) Equal(o *ConsulSidecarService) bool {
 	if s == nil || o == nil {
 		return s == o
 	}
@@ -1138,7 +1138,7 @@ func (s *ConsulSidecarService) Equals(o *ConsulSidecarService) bool {
 		return false
 	}
 
-	return s.Proxy.Equals(o.Proxy)
+	return s.Proxy.Equal(o.Proxy)
 }
 
 // SidecarTask represents a subset of Task fields that are able to be overridden
@@ -1183,7 +1183,7 @@ type SidecarTask struct {
 	KillSignal string
 }
 
-func (t *SidecarTask) Equals(o *SidecarTask) bool {
+func (t *SidecarTask) Equal(o *SidecarTask) bool {
 	if t == nil || o == nil {
 		return t == o
 	}
@@ -1209,7 +1209,7 @@ func (t *SidecarTask) Equals(o *SidecarTask) bool {
 		return false
 	}
 
-	if !t.Resources.Equals(o.Resources) {
+	if !t.Resources.Equal(o.Resources) {
 		return false
 	}
 
@@ -1221,7 +1221,7 @@ func (t *SidecarTask) Equals(o *SidecarTask) bool {
 		return false
 	}
 
-	if !t.LogConfig.Equals(o.LogConfig) {
+	if !t.LogConfig.Equal(o.LogConfig) {
 		return false
 	}
 
@@ -1388,8 +1388,8 @@ func opaqueMapsEqual(a, b map[string]interface{}) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-// Equals returns true if the structs are recursively equal.
-func (p *ConsulProxy) Equals(o *ConsulProxy) bool {
+// Equal returns true if the structs are recursively equal.
+func (p *ConsulProxy) Equal(o *ConsulProxy) bool {
 	if p == nil || o == nil {
 		return p == o
 	}
@@ -1402,7 +1402,7 @@ func (p *ConsulProxy) Equals(o *ConsulProxy) bool {
 		return false
 	}
 
-	if !p.Expose.Equals(o.Expose) {
+	if !p.Expose.Equal(o.Expose) {
 		return false
 	}
 
@@ -1442,7 +1442,7 @@ func (c *ConsulMeshGateway) Copy() ConsulMeshGateway {
 	}
 }
 
-func (c *ConsulMeshGateway) Equals(o ConsulMeshGateway) bool {
+func (c *ConsulMeshGateway) Equal(o ConsulMeshGateway) bool {
 	return c.Mode == o.Mode
 }
 
@@ -1483,8 +1483,8 @@ type ConsulUpstream struct {
 	MeshGateway ConsulMeshGateway
 }
 
-// Equals returns true if the structs are recursively equal.
-func (u *ConsulUpstream) Equals(o *ConsulUpstream) bool {
+// Equal returns true if the structs are recursively equal.
+func (u *ConsulUpstream) Equal(o *ConsulUpstream) bool {
 	if u == nil || o == nil {
 		return u == o
 	}
@@ -1524,8 +1524,8 @@ func (e *ConsulExposeConfig) Copy() *ConsulExposeConfig {
 	}
 }
 
-// Equals returns true if the structs are recursively equal.
-func (e *ConsulExposeConfig) Equals(o *ConsulExposeConfig) bool {
+// Equal returns true if the structs are recursively equal.
+func (e *ConsulExposeConfig) Equal(o *ConsulExposeConfig) bool {
 	if e == nil || o == nil {
 		return e == o
 	}
@@ -1571,24 +1571,24 @@ func (g *ConsulGateway) Copy() *ConsulGateway {
 	}
 }
 
-func (g *ConsulGateway) Equals(o *ConsulGateway) bool {
+func (g *ConsulGateway) Equal(o *ConsulGateway) bool {
 	if g == nil || o == nil {
 		return g == o
 	}
 
-	if !g.Proxy.Equals(o.Proxy) {
+	if !g.Proxy.Equal(o.Proxy) {
 		return false
 	}
 
-	if !g.Ingress.Equals(o.Ingress) {
+	if !g.Ingress.Equal(o.Ingress) {
 		return false
 	}
 
-	if !g.Terminating.Equals(o.Terminating) {
+	if !g.Terminating.Equal(o.Terminating) {
 		return false
 	}
 
-	if !g.Mesh.Equals(o.Mesh) {
+	if !g.Mesh.Equal(o.Mesh) {
 		return false
 	}
 
@@ -1641,7 +1641,7 @@ type ConsulGatewayBindAddress struct {
 	Port    int
 }
 
-func (a *ConsulGatewayBindAddress) Equals(o *ConsulGatewayBindAddress) bool {
+func (a *ConsulGatewayBindAddress) Equal(o *ConsulGatewayBindAddress) bool {
 	if a == nil || o == nil {
 		return a == o
 	}
@@ -1731,7 +1731,7 @@ func (p *ConsulGatewayProxy) equalBindAddresses(o map[string]*ConsulGatewayBindA
 	}
 
 	for listener, addr := range p.EnvoyGatewayBindAddresses {
-		if !o[listener].Equals(addr) {
+		if !o[listener].Equal(addr) {
 			return false
 		}
 	}
@@ -1739,7 +1739,7 @@ func (p *ConsulGatewayProxy) equalBindAddresses(o map[string]*ConsulGatewayBindA
 	return true
 }
 
-func (p *ConsulGatewayProxy) Equals(o *ConsulGatewayProxy) bool {
+func (p *ConsulGatewayProxy) Equal(o *ConsulGatewayProxy) bool {
 	if p == nil || o == nil {
 		return p == o
 	}
@@ -1823,7 +1823,7 @@ func (c *ConsulGatewayTLSConfig) Copy() *ConsulGatewayTLSConfig {
 	}
 }
 
-func (c *ConsulGatewayTLSConfig) Equals(o *ConsulGatewayTLSConfig) bool {
+func (c *ConsulGatewayTLSConfig) Equal(o *ConsulGatewayTLSConfig) bool {
 	if c == nil || o == nil {
 		return c == o
 	}
@@ -1857,7 +1857,7 @@ func (s *ConsulIngressService) Copy() *ConsulIngressService {
 	}
 }
 
-func (s *ConsulIngressService) Equals(o *ConsulIngressService) bool {
+func (s *ConsulIngressService) Equal(o *ConsulIngressService) bool {
 	if s == nil || o == nil {
 		return s == o
 	}
@@ -1931,7 +1931,7 @@ func (l *ConsulIngressListener) Copy() *ConsulIngressListener {
 	}
 }
 
-func (l *ConsulIngressListener) Equals(o *ConsulIngressListener) bool {
+func (l *ConsulIngressListener) Equal(o *ConsulIngressListener) bool {
 	if l == nil || o == nil {
 		return l == o
 	}
@@ -1975,7 +1975,7 @@ func (l *ConsulIngressListener) Validate() error {
 }
 
 func ingressServicesEqual(a, b []*ConsulIngressService) bool {
-	return helper.ElementsEquals(a, b)
+	return helper.ElementsEqual(a, b)
 }
 
 // ConsulIngressConfigEntry represents the Consul Configuration Entry type for
@@ -2006,12 +2006,12 @@ func (e *ConsulIngressConfigEntry) Copy() *ConsulIngressConfigEntry {
 	}
 }
 
-func (e *ConsulIngressConfigEntry) Equals(o *ConsulIngressConfigEntry) bool {
+func (e *ConsulIngressConfigEntry) Equal(o *ConsulIngressConfigEntry) bool {
 	if e == nil || o == nil {
 		return e == o
 	}
 
-	if !e.TLS.Equals(o.TLS) {
+	if !e.TLS.Equal(o.TLS) {
 		return false
 	}
 
@@ -2037,7 +2037,7 @@ func (e *ConsulIngressConfigEntry) Validate() error {
 }
 
 func ingressListenersEqual(a, b []*ConsulIngressListener) bool {
-	return helper.ElementsEquals(a, b)
+	return helper.ElementsEqual(a, b)
 }
 
 type ConsulLinkedService struct {
@@ -2062,7 +2062,7 @@ func (s *ConsulLinkedService) Copy() *ConsulLinkedService {
 	}
 }
 
-func (s *ConsulLinkedService) Equals(o *ConsulLinkedService) bool {
+func (s *ConsulLinkedService) Equal(o *ConsulLinkedService) bool {
 	if s == nil || o == nil {
 		return s == o
 	}
@@ -2113,7 +2113,7 @@ func (s *ConsulLinkedService) Validate() error {
 }
 
 func linkedServicesEqual(a, b []*ConsulLinkedService) bool {
-	return helper.ElementsEquals(a, b)
+	return helper.ElementsEqual(a, b)
 }
 
 type ConsulTerminatingConfigEntry struct {
@@ -2138,7 +2138,7 @@ func (e *ConsulTerminatingConfigEntry) Copy() *ConsulTerminatingConfigEntry {
 	}
 }
 
-func (e *ConsulTerminatingConfigEntry) Equals(o *ConsulTerminatingConfigEntry) bool {
+func (e *ConsulTerminatingConfigEntry) Equal(o *ConsulTerminatingConfigEntry) bool {
 	if e == nil || o == nil {
 		return e == o
 	}
@@ -2180,7 +2180,7 @@ func (e *ConsulMeshConfigEntry) Copy() *ConsulMeshConfigEntry {
 	return new(ConsulMeshConfigEntry)
 }
 
-func (e *ConsulMeshConfigEntry) Equals(o *ConsulMeshConfigEntry) bool {
+func (e *ConsulMeshConfigEntry) Equal(o *ConsulMeshConfigEntry) bool {
 	if e == nil || o == nil {
 		return e == o
 	}

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -499,7 +499,7 @@ func TestConsulConnect_Validate(t *testing.T) {
 	require.NoError(t, c.Validate())
 }
 
-func TestConsulConnect_CopyEquals(t *testing.T) {
+func TestConsulConnect_CopyEqual(t *testing.T) {
 	ci.Parallel(t)
 
 	c := &ConsulConnect{
@@ -532,13 +532,13 @@ func TestConsulConnect_CopyEquals(t *testing.T) {
 
 	// Copies should be equivalent
 	o := c.Copy()
-	require.True(t, c.Equals(o))
+	require.True(t, c.Equal(o))
 
 	o.SidecarService.Proxy.Upstreams = nil
-	require.False(t, c.Equals(o))
+	require.False(t, c.Equal(o))
 }
 
-func TestConsulConnect_GatewayProxy_CopyEquals(t *testing.T) {
+func TestConsulConnect_GatewayProxy_CopyEqual(t *testing.T) {
 	ci.Parallel(t)
 
 	c := &ConsulGatewayProxy{
@@ -552,7 +552,7 @@ func TestConsulConnect_GatewayProxy_CopyEquals(t *testing.T) {
 	// Copies should be equivalent
 	o := c.Copy()
 	require.Equal(t, c, o)
-	require.True(t, c.Equals(o))
+	require.True(t, c.Equal(o))
 }
 
 func TestSidecarTask_MergeIntoTask(t *testing.T) {
@@ -611,7 +611,7 @@ func TestSidecarTask_MergeIntoTask(t *testing.T) {
 	require.Exactly(t, expected, task)
 }
 
-func TestSidecarTask_Equals(t *testing.T) {
+func TestSidecarTask_Equal(t *testing.T) {
 	ci.Parallel(t)
 
 	original := &SidecarTask{
@@ -633,7 +633,7 @@ func TestSidecarTask_Equals(t *testing.T) {
 
 	t.Run("unmodified", func(t *testing.T) {
 		duplicate := original.Copy()
-		require.True(t, duplicate.Equals(original))
+		require.True(t, duplicate.Equal(original))
 	})
 
 	type st = SidecarTask
@@ -690,7 +690,7 @@ func TestSidecarTask_Equals(t *testing.T) {
 	})
 }
 
-func TestConsulUpstream_upstreamEquals(t *testing.T) {
+func TestConsulUpstream_upstreamEqual(t *testing.T) {
 	ci.Parallel(t)
 
 	up := func(name string, port int) ConsulUpstream {
@@ -793,15 +793,15 @@ func TestConsulExposeConfig_Copy(t *testing.T) {
 	}).Copy())
 }
 
-func TestConsulExposeConfig_Equals(t *testing.T) {
+func TestConsulExposeConfig_Equal(t *testing.T) {
 	ci.Parallel(t)
 
-	require.True(t, (*ConsulExposeConfig)(nil).Equals(nil))
+	require.True(t, (*ConsulExposeConfig)(nil).Equal(nil))
 	require.True(t, (&ConsulExposeConfig{
 		Paths: []ConsulExposePath{{
 			Path: "/health",
 		}},
-	}).Equals(&ConsulExposeConfig{
+	}).Equal(&ConsulExposeConfig{
 		Paths: []ConsulExposePath{{
 			Path: "/health",
 		}},
@@ -930,50 +930,50 @@ func TestConsulGateway_Copy(t *testing.T) {
 	t.Run("as ingress", func(t *testing.T) {
 		result := consulIngressGateway1.Copy()
 		require.Equal(t, consulIngressGateway1, result)
-		require.True(t, result.Equals(consulIngressGateway1))
-		require.True(t, consulIngressGateway1.Equals(result))
+		require.True(t, result.Equal(consulIngressGateway1))
+		require.True(t, consulIngressGateway1.Equal(result))
 	})
 
 	t.Run("as terminating", func(t *testing.T) {
 		result := consulTerminatingGateway1.Copy()
 		require.Equal(t, consulTerminatingGateway1, result)
-		require.True(t, result.Equals(consulTerminatingGateway1))
-		require.True(t, consulTerminatingGateway1.Equals(result))
+		require.True(t, result.Equal(consulTerminatingGateway1))
+		require.True(t, consulTerminatingGateway1.Equal(result))
 	})
 
 	t.Run("as mesh", func(t *testing.T) {
 		result := consulMeshGateway1.Copy()
 		require.Equal(t, consulMeshGateway1, result)
-		require.True(t, result.Equals(consulMeshGateway1))
-		require.True(t, consulMeshGateway1.Equals(result))
+		require.True(t, result.Equal(consulMeshGateway1))
+		require.True(t, consulMeshGateway1.Equal(result))
 	})
 }
 
-func TestConsulGateway_Equals_mesh(t *testing.T) {
+func TestConsulGateway_Equal_mesh(t *testing.T) {
 	ci.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
 		a := (*ConsulGateway)(nil)
 		b := (*ConsulGateway)(nil)
-		require.True(t, a.Equals(b))
-		require.False(t, a.Equals(consulMeshGateway1))
-		require.False(t, consulMeshGateway1.Equals(a))
+		require.True(t, a.Equal(b))
+		require.False(t, a.Equal(consulMeshGateway1))
+		require.False(t, consulMeshGateway1.Equal(a))
 	})
 
 	t.Run("reflexive", func(t *testing.T) {
-		require.True(t, consulMeshGateway1.Equals(consulMeshGateway1))
+		require.True(t, consulMeshGateway1.Equal(consulMeshGateway1))
 	})
 }
 
-func TestConsulGateway_Equals_ingress(t *testing.T) {
+func TestConsulGateway_Equal_ingress(t *testing.T) {
 	ci.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
 		a := (*ConsulGateway)(nil)
 		b := (*ConsulGateway)(nil)
-		require.True(t, a.Equals(b))
-		require.False(t, a.Equals(consulIngressGateway1))
-		require.False(t, consulIngressGateway1.Equals(a))
+		require.True(t, a.Equal(b))
+		require.False(t, a.Equal(consulIngressGateway1))
+		require.False(t, consulIngressGateway1.Equal(a))
 	})
 
 	original := consulIngressGateway1.Copy()
@@ -982,15 +982,15 @@ func TestConsulGateway_Equals_ingress(t *testing.T) {
 	type tweaker = func(g *cg)
 
 	t.Run("reflexive", func(t *testing.T) {
-		require.True(t, original.Equals(original))
+		require.True(t, original.Equal(original))
 	})
 
 	try := func(t *testing.T, tweak tweaker) {
 		modifiable := original.Copy()
 		tweak(modifiable)
-		require.False(t, original.Equals(modifiable))
-		require.False(t, modifiable.Equals(original))
-		require.True(t, modifiable.Equals(modifiable))
+		require.False(t, original.Equal(modifiable))
+		require.False(t, modifiable.Equal(original))
+		require.True(t, modifiable.Equal(modifiable))
 	}
 
 	// proxy stanza equality checks
@@ -1059,7 +1059,7 @@ func TestConsulGateway_Equals_ingress(t *testing.T) {
 	})
 }
 
-func TestConsulGateway_Equals_terminating(t *testing.T) {
+func TestConsulGateway_Equal_terminating(t *testing.T) {
 	ci.Parallel(t)
 
 	original := consulTerminatingGateway1.Copy()
@@ -1068,15 +1068,15 @@ func TestConsulGateway_Equals_terminating(t *testing.T) {
 	type tweaker = func(c *cg)
 
 	t.Run("reflexive", func(t *testing.T) {
-		require.True(t, original.Equals(original))
+		require.True(t, original.Equal(original))
 	})
 
 	try := func(t *testing.T, tweak tweaker) {
 		modifiable := original.Copy()
 		tweak(modifiable)
-		require.False(t, original.Equals(modifiable))
-		require.False(t, modifiable.Equals(original))
-		require.True(t, modifiable.Equals(modifiable))
+		require.False(t, original.Equal(modifiable))
+		require.False(t, modifiable.Equal(original))
+		require.True(t, modifiable.Equal(modifiable))
 	}
 
 	// proxy stanza equality checks
@@ -1645,15 +1645,15 @@ func TestConsulMeshGateway_Copy(t *testing.T) {
 	})
 }
 
-func TestConsulMeshGateway_Equals(t *testing.T) {
+func TestConsulMeshGateway_Equal(t *testing.T) {
 	ci.Parallel(t)
 
 	c := ConsulMeshGateway{Mode: "local"}
-	require.False(t, c.Equals(ConsulMeshGateway{}))
-	require.True(t, c.Equals(c))
+	require.False(t, c.Equal(ConsulMeshGateway{}))
+	require.True(t, c.Equal(c))
 
 	o := ConsulMeshGateway{Mode: "remote"}
-	require.False(t, c.Equals(o))
+	require.False(t, c.Equal(o))
 }
 
 func TestConsulMeshGateway_Validate(t *testing.T) {
@@ -1828,7 +1828,7 @@ func TestService_Validate_Address(t *testing.T) {
 	try("driver", "example.com", errors.New(`Service address_mode must be "auto" if address is set`))
 }
 
-func TestService_Equals(t *testing.T) {
+func TestService_Equal(t *testing.T) {
 	ci.Parallel(t)
 
 	s := Service{
@@ -1841,13 +1841,13 @@ func TestService_Equals(t *testing.T) {
 	o := s.Copy()
 
 	// Base service should be equal to copy of itself
-	require.True(t, s.Equals(o))
+	require.True(t, s.Equal(o))
 
 	// create a helper to assert a diff and reset the struct
 	assertDiff := func() {
-		require.False(t, s.Equals(o))
+		require.False(t, s.Equal(o))
 		o = s.Copy()
-		require.True(t, s.Equals(o), "bug in copy")
+		require.True(t, s.Equal(o), "bug in copy")
 	}
 
 	// Changing any field should cause inequality

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2329,10 +2329,10 @@ func (r *Resources) Merge(other *Resources) {
 	}
 }
 
-// Equals Resources.
+// Equal Resources.
 //
 // COMPAT(0.10): Remove in 0.10
-func (r *Resources) Equals(o *Resources) bool {
+func (r *Resources) Equal(o *Resources) bool {
 	if r == o {
 		return true
 	}
@@ -2345,8 +2345,8 @@ func (r *Resources) Equals(o *Resources) bool {
 		r.MemoryMaxMB == o.MemoryMaxMB &&
 		r.DiskMB == o.DiskMB &&
 		r.IOPS == o.IOPS &&
-		r.Networks.Equals(&o.Networks) &&
-		r.Devices.Equals(&o.Devices)
+		r.Networks.Equal(&o.Networks) &&
+		r.Devices.Equal(&o.Devices)
 }
 
 // ResourceDevices are part of Resources.
@@ -2354,10 +2354,10 @@ func (r *Resources) Equals(o *Resources) bool {
 // COMPAT(0.10): Remove in 0.10.
 type ResourceDevices []*RequestedDevice
 
-// Equals ResourceDevices as set keyed by Name.
+// Equal ResourceDevices as set keyed by Name.
 //
 // COMPAT(0.10): Remove in 0.10
-func (d *ResourceDevices) Equals(o *ResourceDevices) bool {
+func (d *ResourceDevices) Equal(o *ResourceDevices) bool {
 	if d == o {
 		return true
 	}
@@ -2373,7 +2373,7 @@ func (d *ResourceDevices) Equals(o *ResourceDevices) bool {
 	}
 	for _, oe := range *o {
 		de, ok := m[oe.Name]
-		if !ok || !de.Equals(oe) {
+		if !ok || !de.Equal(oe) {
 			return false
 		}
 	}
@@ -2490,7 +2490,7 @@ type NodeNetworkResource struct {
 	Addresses []NodeNetworkAddress // not valid for cni, for bridge there will only be 1 ip
 }
 
-func (n *NodeNetworkResource) Equals(o *NodeNetworkResource) bool {
+func (n *NodeNetworkResource) Equal(o *NodeNetworkResource) bool {
 	return reflect.DeepEqual(n, o)
 }
 
@@ -2621,7 +2621,7 @@ func (n *NetworkResource) Hash() uint32 {
 	return crc32.ChecksumIEEE(data)
 }
 
-func (n *NetworkResource) Equals(other *NetworkResource) bool {
+func (n *NetworkResource) Equal(other *NetworkResource) bool {
 	return n.Hash() == other.Hash()
 }
 
@@ -2769,7 +2769,7 @@ type RequestedDevice struct {
 	Affinities Affinities
 }
 
-func (r *RequestedDevice) Equals(o *RequestedDevice) bool {
+func (r *RequestedDevice) Equal(o *RequestedDevice) bool {
 	if r == o {
 		return true
 	}
@@ -2778,8 +2778,8 @@ func (r *RequestedDevice) Equals(o *RequestedDevice) bool {
 	}
 	return r.Name == o.Name &&
 		r.Count == o.Count &&
-		r.Constraints.Equals(&o.Constraints) &&
-		r.Affinities.Equals(&o.Affinities)
+		r.Constraints.Equal(&o.Constraints) &&
+		r.Affinities.Equal(&o.Affinities)
 }
 
 func (r *RequestedDevice) Copy() *RequestedDevice {
@@ -2966,7 +2966,7 @@ func lookupNetworkByDevice(nets []*NodeNetworkResource, name string) (int, *Node
 	return 0, nil
 }
 
-func (n *NodeResources) Equals(o *NodeResources) bool {
+func (n *NodeResources) Equal(o *NodeResources) bool {
 	if o == nil && n == nil {
 		return true
 	} else if o == nil {
@@ -2975,16 +2975,16 @@ func (n *NodeResources) Equals(o *NodeResources) bool {
 		return false
 	}
 
-	if !n.Cpu.Equals(&o.Cpu) {
+	if !n.Cpu.Equal(&o.Cpu) {
 		return false
 	}
-	if !n.Memory.Equals(&o.Memory) {
+	if !n.Memory.Equal(&o.Memory) {
 		return false
 	}
-	if !n.Disk.Equals(&o.Disk) {
+	if !n.Disk.Equal(&o.Disk) {
 		return false
 	}
-	if !n.Networks.Equals(&o.Networks) {
+	if !n.Networks.Equal(&o.Networks) {
 		return false
 	}
 
@@ -3000,8 +3000,8 @@ func (n *NodeResources) Equals(o *NodeResources) bool {
 	return true
 }
 
-// Equals equates Networks as a set
-func (ns *Networks) Equals(o *Networks) bool {
+// Equal equates Networks as a set
+func (ns *Networks) Equal(o *Networks) bool {
 	if ns == o {
 		return true
 	}
@@ -3014,7 +3014,7 @@ func (ns *Networks) Equals(o *Networks) bool {
 SETEQUALS:
 	for _, ne := range *ns {
 		for _, oe := range *o {
-			if ne.Equals(oe) {
+			if ne.Equal(oe) {
 				continue SETEQUALS
 			}
 		}
@@ -3033,7 +3033,7 @@ func DevicesEquals(d1, d2 []*NodeDeviceResource) bool {
 		idMap[*d.ID()] = d
 	}
 	for _, otherD := range d2 {
-		if d, ok := idMap[*otherD.ID()]; !ok || !d.Equals(otherD) {
+		if d, ok := idMap[*otherD.ID()]; !ok || !d.Equal(otherD) {
 			return false
 		}
 	}
@@ -3051,7 +3051,7 @@ func NodeNetworksEquals(n1, n2 []*NodeNetworkResource) bool {
 		netMap[n.Device] = n
 	}
 	for _, otherN := range n2 {
-		if n, ok := netMap[otherN.Device]; !ok || !n.Equals(otherN) {
+		if n, ok := netMap[otherN.Device]; !ok || !n.Equal(otherN) {
 			return false
 		}
 	}
@@ -3104,7 +3104,7 @@ func (n *NodeCpuResources) Merge(o *NodeCpuResources) {
 	}
 }
 
-func (n *NodeCpuResources) Equals(o *NodeCpuResources) bool {
+func (n *NodeCpuResources) Equal(o *NodeCpuResources) bool {
 	if o == nil && n == nil {
 		return true
 	} else if o == nil {
@@ -3152,7 +3152,7 @@ func (n *NodeMemoryResources) Merge(o *NodeMemoryResources) {
 	}
 }
 
-func (n *NodeMemoryResources) Equals(o *NodeMemoryResources) bool {
+func (n *NodeMemoryResources) Equal(o *NodeMemoryResources) bool {
 	if o == nil && n == nil {
 		return true
 	} else if o == nil {
@@ -3183,7 +3183,7 @@ func (n *NodeDiskResources) Merge(o *NodeDiskResources) {
 	}
 }
 
-func (n *NodeDiskResources) Equals(o *NodeDiskResources) bool {
+func (n *NodeDiskResources) Equal(o *NodeDiskResources) bool {
 	if o == nil && n == nil {
 		return true
 	} else if o == nil {
@@ -3235,8 +3235,8 @@ func (id *DeviceIdTuple) Matches(other *DeviceIdTuple) bool {
 	return true
 }
 
-// Equals returns if this Device ID is the same as the passed ID.
-func (id *DeviceIdTuple) Equals(o *DeviceIdTuple) bool {
+// Equal returns if this Device ID is the same as the passed ID.
+func (id *DeviceIdTuple) Equal(o *DeviceIdTuple) bool {
 	if id == nil && o == nil {
 		return true
 	} else if id == nil || o == nil {
@@ -3290,7 +3290,7 @@ func (n *NodeDeviceResource) Copy() *NodeDeviceResource {
 	return &nn
 }
 
-func (n *NodeDeviceResource) Equals(o *NodeDeviceResource) bool {
+func (n *NodeDeviceResource) Equal(o *NodeDeviceResource) bool {
 	if o == nil && n == nil {
 		return true
 	} else if o == nil {
@@ -3326,7 +3326,7 @@ func (n *NodeDeviceResource) Equals(o *NodeDeviceResource) bool {
 		idMap[d.ID] = d
 	}
 	for _, otherD := range o.Instances {
-		if d, ok := idMap[otherD.ID]; !ok || !d.Equals(otherD) {
+		if d, ok := idMap[otherD.ID]; !ok || !d.Equal(otherD) {
 			return false
 		}
 	}
@@ -3351,7 +3351,7 @@ type NodeDevice struct {
 	Locality *NodeDeviceLocality
 }
 
-func (n *NodeDevice) Equals(o *NodeDevice) bool {
+func (n *NodeDevice) Equal(o *NodeDevice) bool {
 	if o == nil && n == nil {
 		return true
 	} else if o == nil {
@@ -3366,7 +3366,7 @@ func (n *NodeDevice) Equals(o *NodeDevice) bool {
 		return false
 	} else if n.HealthDescription != o.HealthDescription {
 		return false
-	} else if !n.Locality.Equals(o.Locality) {
+	} else if !n.Locality.Equal(o.Locality) {
 		return false
 	}
 
@@ -3394,7 +3394,7 @@ type NodeDeviceLocality struct {
 	PciBusID string
 }
 
-func (n *NodeDeviceLocality) Equals(o *NodeDeviceLocality) bool {
+func (n *NodeDeviceLocality) Equal(o *NodeDeviceLocality) bool {
 	if o == nil && n == nil {
 		return true
 	} else if o == nil {
@@ -3884,7 +3884,7 @@ func (a AllocatedDevices) Index(d *AllocatedDeviceResource) int {
 	}
 
 	for i, o := range a {
-		if o.ID().Equals(d.ID()) {
+		if o.ID().Equal(d.ID()) {
 			return i
 		}
 	}
@@ -6863,7 +6863,7 @@ func (c *CheckRestart) Copy() *CheckRestart {
 	return nc
 }
 
-func (c *CheckRestart) Equals(o *CheckRestart) bool {
+func (c *CheckRestart) Equal(o *CheckRestart) bool {
 	if c == nil || o == nil {
 		return c == o
 	}
@@ -6912,7 +6912,7 @@ type LogConfig struct {
 	MaxFileSizeMB int
 }
 
-func (l *LogConfig) Equals(o *LogConfig) bool {
+func (l *LogConfig) Equal(o *LogConfig) bool {
 	if l == nil || o == nil {
 		return l == o
 	}
@@ -7898,7 +7898,7 @@ func (wc *WaitConfig) Copy() *WaitConfig {
 	return nwc
 }
 
-func (wc *WaitConfig) Equals(o *WaitConfig) bool {
+func (wc *WaitConfig) Equal(o *WaitConfig) bool {
 	if wc.Min == nil && o.Min != nil {
 		return false
 	}
@@ -8729,17 +8729,12 @@ type Constraint struct {
 	Operand string // Constraint operand (<=, <, =, !=, >, >=), contains, near
 }
 
-// Equals checks if two constraints are equal.
-func (c *Constraint) Equals(o *Constraint) bool {
+// Equal checks if two constraints are equal.
+func (c *Constraint) Equal(o *Constraint) bool {
 	return c == o ||
 		c.LTarget == o.LTarget &&
 			c.RTarget == o.RTarget &&
 			c.Operand == o.Operand
-}
-
-// Equal is like Equals but with one less s.
-func (c *Constraint) Equal(o *Constraint) bool {
-	return c.Equals(o)
 }
 
 func (c *Constraint) Copy() *Constraint {
@@ -8819,8 +8814,8 @@ func (c *Constraint) Validate() error {
 
 type Constraints []*Constraint
 
-// Equals compares Constraints as a set
-func (xs *Constraints) Equals(ys *Constraints) bool {
+// Equal compares Constraints as a set
+func (xs *Constraints) Equal(ys *Constraints) bool {
 	if xs == ys {
 		return true
 	}
@@ -8833,7 +8828,7 @@ func (xs *Constraints) Equals(ys *Constraints) bool {
 SETEQUALS:
 	for _, x := range *xs {
 		for _, y := range *ys {
-			if x.Equals(y) {
+			if x.Equal(y) {
 				continue SETEQUALS
 			}
 		}
@@ -8850,17 +8845,13 @@ type Affinity struct {
 	Weight  int8   // Weight applied to nodes that match the affinity. Can be negative
 }
 
-// Equals checks if two affinities are equal.
-func (a *Affinity) Equals(o *Affinity) bool {
+// Equal checks if two affinities are equal.
+func (a *Affinity) Equal(o *Affinity) bool {
 	return a == o ||
 		a.LTarget == o.LTarget &&
 			a.RTarget == o.RTarget &&
 			a.Operand == o.Operand &&
 			a.Weight == o.Weight
-}
-
-func (a *Affinity) Equal(o *Affinity) bool {
-	return a.Equals(o)
 }
 
 func (a *Affinity) Copy() *Affinity {
@@ -8946,8 +8937,8 @@ type Spread struct {
 
 type Affinities []*Affinity
 
-// Equals compares Affinities as a set
-func (xs *Affinities) Equals(ys *Affinities) bool {
+// Equal compares Affinities as a set
+func (xs *Affinities) Equal(ys *Affinities) bool {
 	if xs == ys {
 		return true
 	}
@@ -8960,7 +8951,7 @@ func (xs *Affinities) Equals(ys *Affinities) bool {
 SETEQUALS:
 	for _, x := range *xs {
 		for _, y := range *ys {
-			if x.Equals(y) {
+			if x.Equal(y) {
 				continue SETEQUALS
 			}
 		}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -863,12 +863,12 @@ func TestJob_PartEqual(t *testing.T) {
 	ci.Parallel(t)
 
 	ns := &Networks{}
-	require.True(t, ns.Equals(&Networks{}))
+	require.True(t, ns.Equal(&Networks{}))
 
 	ns = &Networks{
 		&NetworkResource{Device: "eth0"},
 	}
-	require.True(t, ns.Equals(&Networks{
+	require.True(t, ns.Equal(&Networks{
 		&NetworkResource{Device: "eth0"},
 	}))
 
@@ -877,7 +877,7 @@ func TestJob_PartEqual(t *testing.T) {
 		&NetworkResource{Device: "eth1"},
 		&NetworkResource{Device: "eth2"},
 	}
-	require.True(t, ns.Equals(&Networks{
+	require.True(t, ns.Equal(&Networks{
 		&NetworkResource{Device: "eth2"},
 		&NetworkResource{Device: "eth0"},
 		&NetworkResource{Device: "eth1"},
@@ -888,7 +888,7 @@ func TestJob_PartEqual(t *testing.T) {
 		&Constraint{"left1", "right1", "="},
 		&Constraint{"left2", "right2", "="},
 	}
-	require.True(t, cs.Equals(&Constraints{
+	require.True(t, cs.Equal(&Constraints{
 		&Constraint{"left0", "right0", "="},
 		&Constraint{"left2", "right2", "="},
 		&Constraint{"left1", "right1", "="},
@@ -899,7 +899,7 @@ func TestJob_PartEqual(t *testing.T) {
 		&Affinity{"left1", "right1", "=", 0},
 		&Affinity{"left2", "right2", "=", 0},
 	}
-	require.True(t, as.Equals(&Affinities{
+	require.True(t, as.Equal(&Affinities{
 		&Affinity{"left0", "right0", "=", 0},
 		&Affinity{"left2", "right2", "=", 0},
 		&Affinity{"left1", "right1", "=", 0},
@@ -2487,31 +2487,31 @@ func TestLogConfig_Equals(t *testing.T) {
 	t.Run("both nil", func(t *testing.T) {
 		a := (*LogConfig)(nil)
 		b := (*LogConfig)(nil)
-		require.True(t, a.Equals(b))
+		require.True(t, a.Equal(b))
 	})
 
 	t.Run("one nil", func(t *testing.T) {
 		a := new(LogConfig)
 		b := (*LogConfig)(nil)
-		require.False(t, a.Equals(b))
+		require.False(t, a.Equal(b))
 	})
 
 	t.Run("max files", func(t *testing.T) {
 		a := &LogConfig{MaxFiles: 1, MaxFileSizeMB: 200}
 		b := &LogConfig{MaxFiles: 2, MaxFileSizeMB: 200}
-		require.False(t, a.Equals(b))
+		require.False(t, a.Equal(b))
 	})
 
 	t.Run("max file size", func(t *testing.T) {
 		a := &LogConfig{MaxFiles: 1, MaxFileSizeMB: 100}
 		b := &LogConfig{MaxFiles: 1, MaxFileSizeMB: 200}
-		require.False(t, a.Equals(b))
+		require.False(t, a.Equal(b))
 	})
 
 	t.Run("same", func(t *testing.T) {
 		a := &LogConfig{MaxFiles: 1, MaxFileSizeMB: 200}
 		b := &LogConfig{MaxFiles: 1, MaxFileSizeMB: 200}
-		require.True(t, a.Equals(b))
+		require.True(t, a.Equal(b))
 	})
 }
 
@@ -2889,7 +2889,7 @@ func TestTaskWaitConfig_Equals(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.True(t, tc.config.Equals(tc.expected))
+			require.True(t, tc.config.Equal(tc.expected))
 		})
 	}
 }
@@ -6400,7 +6400,7 @@ func TestNetworkResourcesEquals(t *testing.T) {
 	for _, testCase := range networkResourcesTest {
 		first := testCase.input[0]
 		second := testCase.input[1]
-		require.Equal(testCase.expected, first.Equals(second), testCase.errorMsg)
+		require.Equal(testCase.expected, first.Equal(second), testCase.errorMsg)
 	}
 }
 

--- a/nomad/structs/variables.go
+++ b/nomad/structs/variables.go
@@ -24,7 +24,7 @@ const (
 	// Reply: VariablesListResponse
 	VariablesListRPCMethod = "Variables.List"
 
-	// VariablesGetServiceRPCMethod is the RPC method for fetching a variable
+	// VariablesReadRPCMethod is the RPC method for fetching a variable
 	// according to its namepace and path.
 	//
 	// Args: VariablesByNameRequest
@@ -83,34 +83,34 @@ func (svi VariableItems) Size() uint64 {
 	return out
 }
 
-// Equals checks both the metadata and items in a VariableDecrypted struct
-func (v1 VariableDecrypted) Equals(v2 VariableDecrypted) bool {
-	return v1.VariableMetadata.Equals(v2.VariableMetadata) &&
-		v1.Items.Equals(v2.Items)
+// Equal checks both the metadata and items in a VariableDecrypted struct
+func (v1 VariableDecrypted) Equal(v2 VariableDecrypted) bool {
+	return v1.VariableMetadata.Equal(v2.VariableMetadata) &&
+		v1.Items.Equal(v2.Items)
 }
 
-// Equals is a convenience method to provide similar equality checking syntax
+// Equal is a convenience method to provide similar equality checking syntax
 // for metadata and the VariablesData or VariableItems struct
-func (sv VariableMetadata) Equals(sv2 VariableMetadata) bool {
+func (sv VariableMetadata) Equal(sv2 VariableMetadata) bool {
 	return sv == sv2
 }
 
-// Equals performs deep equality checking on the cleartext items of a
+// Equal performs deep equality checking on the cleartext items of a
 // VariableDecrypted. Uses reflect.DeepEqual
-func (i1 VariableItems) Equals(i2 VariableItems) bool {
+func (i1 VariableItems) Equal(i2 VariableItems) bool {
 	return reflect.DeepEqual(i1, i2)
 }
 
-// Equals checks both the metadata and encrypted data for a VariableEncrypted
+// Equal checks both the metadata and encrypted data for a VariableEncrypted
 // struct
-func (v1 VariableEncrypted) Equals(v2 VariableEncrypted) bool {
-	return v1.VariableMetadata.Equals(v2.VariableMetadata) &&
-		v1.VariableData.Equals(v2.VariableData)
+func (v1 VariableEncrypted) Equal(v2 VariableEncrypted) bool {
+	return v1.VariableMetadata.Equal(v2.VariableMetadata) &&
+		v1.VariableData.Equal(v2.VariableData)
 }
 
-// Equals performs deep equality checking on the encrypted data part of a
+// Equal performs deep equality checking on the encrypted data part of a
 // VariableEncrypted
-func (d1 VariableData) Equals(d2 VariableData) bool {
+func (d1 VariableData) Equal(d2 VariableData) bool {
 	return d1.KeyID == d2.KeyID &&
 		bytes.Equal(d1.Data, d2.Data)
 }

--- a/nomad/structs/variables_test.go
+++ b/nomad/structs/variables_test.go
@@ -27,9 +27,9 @@ func TestStructs_VariableDecrypted_Copy(t *testing.T) {
 		},
 	}
 	sv2 := sv.Copy()
-	require.True(t, sv.Equals(sv2), "sv and sv2 should be equal")
+	require.True(t, sv.Equal(sv2), "sv and sv2 should be equal")
 	sv2.Items["new"] = "new"
-	require.False(t, sv.Equals(sv2), "sv and sv2 should not be equal")
+	require.False(t, sv.Equal(sv2), "sv and sv2 should not be equal")
 }
 
 func TestStructs_VariableDecrypted_Validate(t *testing.T) {

--- a/nomad/vault.go
+++ b/nomad/vault.go
@@ -374,7 +374,7 @@ func (v *vaultClient) SetConfig(config *config.VaultConfig) error {
 	defer v.l.Unlock()
 
 	// If reloading the same config, no-op
-	if v.config.Equals(config) {
+	if v.config.Equal(config) {
 		return nil
 	}
 

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -585,7 +585,7 @@ func tasksUpdated(jobA, jobB *structs.Job, taskGroup string) bool {
 			return true
 		} else if ar.MemoryMaxMB != br.MemoryMaxMB {
 			return true
-		} else if !ar.Devices.Equals(&br.Devices) {
+		} else if !ar.Devices.Equal(&br.Devices) {
 			return true
 		}
 	}
@@ -644,11 +644,11 @@ func connectUpdated(connectA, connectB *structs.ConsulConnect) bool {
 		return true
 	}
 
-	if !connectA.Gateway.Equals(connectB.Gateway) {
+	if !connectA.Gateway.Equal(connectB.Gateway) {
 		return true
 	}
 
-	if !connectA.SidecarTask.Equals(connectB.SidecarTask) {
+	if !connectA.SidecarTask.Equal(connectB.SidecarTask) {
 		return true
 	}
 


### PR DESCRIPTION
This PR aims to make equality comparisons of our structs consistent with modern Go convention. In the past we have used `Equals`, but the cool kids are all using `Equal`. 

Important example - `go-cmp` has special behavior to detect and use `Equal` when present.
https://github.com/google/go-cmp#package-for-equality-of-go-values
> Types that have an Equal method may use that method to determine equality. This allows package authors to determine the equality operation for the types that they define.

Likewise, the standard library is naming things with `Equal`
https://pkg.go.dev/bytes#Equal