### PR TITLE
refact: only reload job if job has no taskGroups

### DIFF
--- a/ui/app/components/allocation-row.js
+++ b/ui/app/components/allocation-row.js
@@ -106,7 +106,7 @@ async function qualifyAllocation() {
     // Make sure that the job record in the store for this allocation
     // is complete and not a partial from the list endpoint
     const job = allocation.get('job.content');
-    if (job) await job.reload();
+    if (job.isPartial) await job.reload();
   }
 
   this.fetchStats.perform();


### PR DESCRIPTION
Resolves #14644

This PR guards calling `job.reload` in the `AllocationRow` component by checking if the `job` on the `allocation` argument on the `AllocationRow` component is a `partial job` (a job without task groups).

The challenge we're trying to solve is an infinite loop of dispatching asynchronous requests reported in #14644.