### PR TITLE
Docs(job-specification/periodic): Add enabled toggle

### DIFF
--- a/website/content/docs/job-specification/periodic.mdx
+++ b/website/content/docs/job-specification/periodic.mdx
@@ -48,6 +48,10 @@ consistent evaluation when Nomad spans multiple time zones.
   be parsable by Golang's
   [LoadLocation](https://golang.org/pkg/time/#LoadLocation).
 
+- `enabled` `(bool: true)` - Specifies if this job should run. This not only
+  prevents this job from running on the `cron` schedule but prevents force
+  launches.
+
 ## `periodic` Examples
 
 The following examples only show the `periodic` stanzas. Remember that the


### PR DESCRIPTION
This is probably undocumented for a reason, but the `enabled` toggle in the `periodic` stanza is very useful so I figured I try adding it to the docs.

The feature has been secretly avaliable since #9142 and was [called out in that PR as being a dubious addition](https://github.com/hashicorp/nomad/pull/9142/files#r510132150), only added to avoid regressions in the update to hcl2.

The use case for disabling a periodic job in this way is to prevent it from running without modifying the schedule. Ideally Nomad would make it more clear that this was the case, and allow you to force a run of the job, but even with those rough edges I think users would benefit from knowing about this toggle.