### PR TITLE
enhancement: UpdateTask when Task is waiting for ShutdownDelay

### DIFF
--- a/.changelog/14775.txt
+++ b/.changelog/14775.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client: Added a TaskEvent when task shutdown is waiting on shutdown_delay
+```

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -982,6 +982,10 @@ func (tr *TaskRunner) handleKill(resultCh <-chan *drivers.ExitResult) *drivers.E
 	if delay := tr.Task().ShutdownDelay; delay != 0 {
 		tr.logger.Debug("waiting before killing task", "shutdown_delay", delay)
 
+		ev := structs.NewTaskEvent(structs.TaskWaitingShuttingDownDelay).
+			SetDisplayMessage(fmt.Sprintf("Waiting for shutdown_delay of %s before killing the task.", delay))
+		tr.UpdateState(structs.TaskStatePending, ev)
+
 		select {
 		case result := <-resultCh:
 			return result

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8153,6 +8153,10 @@ const (
 
 	// TaskClientReconnected indicates that the client running the task disconnected.
 	TaskClientReconnected = "Reconnected"
+
+	// TaskWaitingShuttingDownDelay indicates that the task is waiting for
+	// shutdown delay before being TaskKilled
+	TaskWaitingShuttingDownDelay = "Waiting for shutdown delay"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data


### PR DESCRIPTION
Signed-off-by: Hemanth Krishna <hkpdev008@gmail.com>

- Fixes #14170 
- Adds a new Task Event named `TaskWaitingShuttingDownDelay ` (Open to suggestions)