### PR TITLE
deps: use install from current HEAD for `hc-install`

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -146,7 +146,7 @@ jobs:
         run: |
           make bootstrap
           make generate-all
-          hc-install install -version ${{env.VAULT_VERSION}} vault
-          hc-install install -version ${{env.CONSUL_VERSION}} consul
+          sudo hc-install install -version ${{env.VAULT_VERSION}} -path /usr/local/bin/vault vault
+          sudo hc-install install -version ${{env.CONSUL_VERSION}} -path /usr/local/bin/vault consul
           sudo sed -i 's!Defaults!#Defaults!g' /etc/sudoers
           sudo -E env "PATH=$PATH" make test-nomad

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -146,7 +146,7 @@ jobs:
         run: |
           make bootstrap
           make generate-all
-          sudo hc-install install -version ${{env.VAULT_VERSION}} -path /usr/local/bin/vault vault
-          sudo hc-install install -version ${{env.CONSUL_VERSION}} -path /usr/local/bin/vault consul
+          sudo hc-install install -version ${{env.VAULT_VERSION}} -path /usr/local/bin vault
+          sudo hc-install install -version ${{env.CONSUL_VERSION}} -path /usr/local/bin consul
           sudo sed -i 's!Defaults!#Defaults!g' /etc/sudoers
           sudo -E env "PATH=$PATH" make test-nomad

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -146,8 +146,7 @@ jobs:
         run: |
           make bootstrap
           make generate-all
-          hc-install vault ${{env.VAULT_VERSION}}
-          hc-install consul ${{env.CONSUL_VERSION}}
+          hc-install install -version ${{env.VAULT_VERSION}} vault
+          hc-install install -version ${{env.CONSUL_VERSION}} consul
           sudo sed -i 's!Defaults!#Defaults!g' /etc/sudoers
           sudo -E env "PATH=$PATH" make test-nomad
-

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -137,7 +137,7 @@ deps:  ## Install build and development dependencies
 	go install github.com/bufbuild/buf/cmd/buf@v0.36.0
 	go install github.com/hashicorp/go-changelog/cmd/changelog-build@latest
 	go install golang.org/x/tools/cmd/stringer@v0.1.12
-	go install gophers.dev/cmds/hc-install/cmd/hc-install@v1.0.2
+	go install github.com/hashicorp/hc-install/cmd/hc-install@4487b02cbcbb92204e3416cef9852b6ad44487b2
 
 .PHONY: lint-deps
 lint-deps: ## Install linter dependencies


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/14785

The `hc-install` tool we're using needed a patch for a specific bug, but that's since been merged. We definitely want to switch to using a standard release from that project once one is shipped with the CLI, but pinning to HEAD should keep us for now.