### PR TITLE
deps: remove gophers.dev dependency

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -5,7 +5,6 @@ go 1.18
 require (
 	github.com/aws/aws-sdk-go v1.37.26
 	github.com/stretchr/testify v1.7.1
-	gophers.dev/pkgs/ignore v0.3.1
 	gopkg.in/yaml.v2 v2.2.8
 )
 

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -22,8 +22,6 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-gophers.dev/pkgs/ignore v0.3.1 h1:MmNywpk5VAxWQ7/Yz9E1NmEEHLTh0hRWLiHENdVy4Ls=
-gophers.dev/pkgs/ignore v0.3.1/go.mod h1:HwTn4Fc9oicp2TxFV/8P0CswwfsVQczZvG6ZTy2TRXA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=

--- a/tools/missing/main.go
+++ b/tools/missing/main.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	"gophers.dev/pkgs/ignore"
 	"gopkg.in/yaml.v2"
 )
 
@@ -42,7 +41,9 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
-	defer ignore.Close(f)
+	defer func() {
+		_ = f.Close()
+	}()
 
 	coverage, err := inMatrix(f)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/14785 by removing the dependency on `gophers.dev/pkg/ignore`. This package registry has a broken cert. The package is really our own @shoenig's https://github.com/shoenig/ignore, but the package is declared with the gophers.dev domain so we can't fix it directly (and he's on vacation :grin:). We're using a one-liner function from it, so to get all the tools build working again, just remove it and we can have a discussion about that when @shoenig gets back.