### PR TITLE
client: defer `nobody` user lookup so Windows doesn't panic

### DIFF
--- a/client/allocdir/fs_unix.go
+++ b/client/allocdir/fs_unix.go
@@ -40,14 +40,17 @@ func dropDirPermissions(path string, desired os.FileMode) error {
 		return nil
 	}
 
-	nobody := users.Nobody()
-
-	uid, err := getUid(&nobody)
+	nobody, err := users.Nobody()
 	if err != nil {
 		return err
 	}
 
-	gid, err := getGid(&nobody)
+	uid, err := getUid(nobody)
+	if err != nil {
+		return err
+	}
+
+	gid, err := getGid(nobody)
 	if err != nil {
 		return err
 	}

--- a/helper/users/lookup.go
+++ b/helper/users/lookup.go
@@ -21,7 +21,7 @@ func Nobody() (*user.User, error) {
 	if nobody != nil {
 		return nobody, nil
 	}
-	u, err := Lookup("nobody")
+	u, err := user.Lookup("nobody")
 	nobody = u
 	return u, err
 }

--- a/helper/users/lookup.go
+++ b/helper/users/lookup.go
@@ -7,7 +7,7 @@ import (
 
 // lock is used to serialize all user lookup at the process level, because
 // some NSS implementations are not concurrency safe
-var lock *sync.Mutex
+var lock sync.Mutex
 
 // nobody is a cached copy of the nobody user, which is going to be looked-up
 // frequently and is unlikely to be modified on the underlying system.
@@ -24,10 +24,6 @@ func Nobody() (*user.User, error) {
 	u, err := Lookup("nobody")
 	nobody = u
 	return u, err
-}
-
-func init() {
-	lock = new(sync.Mutex)
 }
 
 // Lookup username while holding a global process lock.


### PR DESCRIPTION
In #14742 we introduced a cached lookup of the `nobody` user, which is only ever called on Unixish machines. But the initial caching was being done in an `init` block, which meant it was being run on Windows as well. This prevents the Nomad agent from starting on Windows.

An alternative fix here would be to have a separate `init` block for Windows and Unix, but this potentially masks incorrect behavior if we accidentally added a call to the `Nobody()` method on Windows later. This way we're forced to handle the error in the caller.

---

Before:

```
C:\opt> C:\opt\nomad.exe agent -config C:\etc\nomad.d"
panic: unable to lookup the nobody user: No mapping between account names and security IDs was done.

goroutine 1 [running]:
github.com/hashicorp/nomad/helper/users.init.0()
        github.com/hashicorp/nomad/helper/users/lookup.go:28 +0xfd
```

After:

```
C:\opt> C:\opt\nomad.exe agent -config C:\etc\nomad.d
==> Loaded configuration from C:\etc\nomad.d\base.hcl, C:\etc\nomad.d\client-windows-0.hcl, C:\etc\no
mad.d\client-windows.hcl, C:\etc\nomad.d\consul.hcl, C:\etc\nomad.d\tls.hcl, C:\etc\nomad.d\vault.hcl
==> Starting Nomad agent...
...
```