### PR TITLE
Switch to the 'running' green for health checks

### DIFF
--- a/ui/app/components/service-status-bar.js
+++ b/ui/app/components/service-status-bar.js
@@ -22,7 +22,7 @@ export default class ServiceStatusBar extends DistributionBar {
     const failing = this.status.failure || 0;
     const success = this.status.success || 0;
 
-    const [grey, red, green] = ['queued', 'failed', 'complete'];
+    const [grey, red, green] = ['queued', 'failed', 'running'];
 
     return [
       {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/713991/193916827-5661acf8-f527-4979-927c-e1fb3f8afbab.png)


After: 
![image](https://user-images.githubusercontent.com/713991/193916742-ff329a98-01c7-4439-9cce-1e4a579a6c2d.png)


Compare to the Running vs Complete greens we use elsewhere:
![image](https://user-images.githubusercontent.com/713991/193916948-992c6555-1ec9-41b5-9aa7-8e19ac35882e.png)
