### PR TITLE
naive solution

### DIFF
--- a/ui/app/templates/components/allocation-row.hbs
+++ b/ui/app/templates/components/allocation-row.hbs
@@ -33,7 +33,7 @@
 <td data-test-short-id>
   <LinkTo
     @route="allocations.allocation"
-    @model={{this.allocation}}
+    @model={{this.allocation.id}}
     class="is-primary"
   >
     {{this.allocation.shortId}}


### PR DESCRIPTION
This is a naive solution to resolve #14654.

The issue manifests itself where you navigate to the `allocations.allocation.index` view and you see `Ports`. Then navigate up using breadcrumbs back to `TaskGroup` and click on the same allocation, you'll notice that `Ports` are now gone.

Here's a [Replay](https://app.replay.io/recording/allocation-ig-bridge-demoingress-group0-nomad--677d0c42-4762-4f20-8bdd-64aa5529a101?point=26286002851075575564766773082326973&time=9634.27517294389&hasFrames=false) that captures this behavior.

This PR doesn't resolve the root cause of this issue:  some line of code somewhere is manipulating our `store`.

However, this PR ensures that every time we enter this route via `TaskGroup` that we will guarantee a API call to get the latest `Allocation` information. That's because the `LinkTo` component API skips calling the `model` hook if we pass a full model as an argument, and we definitely don't want that because we have real-time concerns. Editing the invocation of the `LinkTo` component to accept the `id` of our allocation instead of the full model will force us to call the `model` hook and make the appropriate API call which will include our `Ports` onto this view.