### PR TITLE
website: add autoscaler agent enable_debug config detail.

### DIFF
--- a/website/content/tools/autoscaling/agent.mdx
+++ b/website/content/tools/autoscaling/agent.mdx
@@ -87,6 +87,9 @@ following actions.
 - `plugin_dir` `(string: "./plugins")` - The plugin directory is used to
   discover Nomad Autoscaler plugins.
 
+- `enable_debug` `(bool: false)` - Enable debugging HTTP endpoints for the Nomad
+  Autoscaler agent.
+
 [hcl_v2]: https://github.com/hashicorp/hcl/tree/hcl2
 [nomad_namespaces]: https://learn.hashicorp.com/tutorials/nomad/namespaces
 [nomad_acls]: https://learn.hashicorp.com/collections/nomad/access-control


### PR DESCRIPTION
I was going to add detail on the pprof endpoints, but it seems we do not have this data for Nomad either. I therefore thought this would be a good docs followup which would be useful to both Nomad and the Nomad Autoscaler.