### PR TITLE
ui: remove `RSVP` instances in routes for `async/await`

### DIFF
--- a/ui/app/routes/allocations/allocation/fs.js
+++ b/ui/app/routes/allocations/allocation/fs.js
@@ -9,8 +9,9 @@ export default class FsRoute extends Route {
     if (!allocation) return;
 
     try {
-      const [statJson] = await Promise.all([
+      const [statJson, directoryEntries] = await Promise.all([
         allocation.stat(decodedPath),
+        allocation.ls(decodedPath),
         allocation.get('node'),
       ]);
 
@@ -19,7 +20,7 @@ export default class FsRoute extends Route {
           path: decodedPath,
           allocation,
           isFile: false,
-          directoryEntries: await allocation.ls(decodedPath),
+          directoryEntries,
         };
       } else {
         return {

--- a/ui/app/routes/allocations/allocation/fs.js
+++ b/ui/app/routes/allocations/allocation/fs.js
@@ -1,35 +1,37 @@
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
 import notifyError from 'nomad-ui/utils/notify-error';
 
 export default class FsRoute extends Route {
-  model({ path = '/' }) {
+  async model({ path = '/' }) {
     const decodedPath = decodeURIComponent(path);
     const allocation = this.modelFor('allocations.allocation');
 
     if (!allocation) return;
 
-    return RSVP.all([allocation.stat(decodedPath), allocation.get('node')])
-      .then(([statJson]) => {
-        if (statJson.IsDir) {
-          return RSVP.hash({
-            path: decodedPath,
-            allocation,
-            directoryEntries: allocation
-              .ls(decodedPath)
-              .catch(notifyError(this)),
-            isFile: false,
-          });
-        } else {
-          return {
-            path: decodedPath,
-            allocation,
-            isFile: true,
-            stat: statJson,
-          };
-        }
-      })
-      .catch(notifyError(this));
+    try {
+      const [statJson] = await Promise.all([
+        allocation.stat(decodedPath),
+        allocation.get('node'),
+      ]);
+
+      if (statJson.IsDir) {
+        return {
+          path: decodedPath,
+          allocation,
+          isFile: false,
+          directoryEntries: await allocation.ls(decodedPath),
+        };
+      } else {
+        return {
+          path: decodedPath,
+          allocation,
+          isFile: true,
+          stat: statJson,
+        };
+      }
+    } catch (e) {
+      notifyError(this)(e);
+    }
   }
 
   setupController(

--- a/ui/app/routes/allocations/allocation/task/fs.js
+++ b/ui/app/routes/allocations/allocation/task/fs.js
@@ -1,9 +1,8 @@
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
 import notifyError from 'nomad-ui/utils/notify-error';
 
 export default class FsRoute extends Route {
-  model({ path = '/' }) {
+  async model({ path = '/' }) {
     const decodedPath = decodeURIComponent(path);
     const taskState = this.modelFor('allocations.allocation.task');
 
@@ -14,30 +13,30 @@ export default class FsRoute extends Route {
       decodedPath.startsWith('/') ? '' : '/'
     }${decodedPath}`;
 
-    return RSVP.all([
-      allocation.stat(pathWithTaskName),
-      taskState.get('allocation.node'),
-    ])
-      .then(([statJson]) => {
-        if (statJson.IsDir) {
-          return RSVP.hash({
-            path: decodedPath,
-            taskState,
-            directoryEntries: allocation
-              .ls(pathWithTaskName)
-              .catch(notifyError(this)),
-            isFile: false,
-          });
-        } else {
-          return {
-            path: decodedPath,
-            taskState,
-            isFile: true,
-            stat: statJson,
-          };
-        }
-      })
-      .catch(notifyError(this));
+    try {
+      const [statJson] = await Promise.all([
+        allocation.stat(pathWithTaskName),
+        taskState.get('allocation.node'),
+      ]);
+
+      if (statJson.IsDir) {
+        return {
+          path: decodedPath,
+          taskState,
+          isFile: false,
+          directoryEntries: await allocation.ls(pathWithTaskName),
+        };
+      } else {
+        return {
+          path: decodedPath,
+          taskState,
+          isFile: true,
+          stat: statJson,
+        };
+      }
+    } catch (e) {
+      notifyError(this)(e);
+    }
   }
 
   setupController(

--- a/ui/app/routes/allocations/allocation/task/fs.js
+++ b/ui/app/routes/allocations/allocation/task/fs.js
@@ -14,8 +14,9 @@ export default class FsRoute extends Route {
     }${decodedPath}`;
 
     try {
-      const [statJson] = await Promise.all([
+      const [statJson, directoryEntries] = await Promise.all([
         allocation.stat(pathWithTaskName),
+        allocation.ls(pathWithTaskName),
         taskState.get('allocation.node'),
       ]);
 
@@ -24,7 +25,7 @@ export default class FsRoute extends Route {
           path: decodedPath,
           taskState,
           isFile: false,
-          directoryEntries: await allocation.ls(pathWithTaskName),
+          directoryEntries,
         };
       } else {
         return {

--- a/ui/app/routes/allocations/allocation/task/logs.js
+++ b/ui/app/routes/allocations/allocation/task/logs.js
@@ -1,8 +1,12 @@
 import Route from '@ember/routing/route';
 
 export default class LogsRoute extends Route {
-  model() {
+  async model() {
     const task = super.model(...arguments);
-    return task && task.get('allocation.node').then(() => task);
+
+    if (task) {
+      await task.get('allocation.node');
+      return task;
+    }
   }
 }

--- a/ui/app/routes/clients.js
+++ b/ui/app/routes/clients.js
@@ -1,6 +1,5 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
 import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
 import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 import classic from 'ember-classic-decorator';
@@ -14,10 +13,14 @@ export default class ClientsRoute extends Route.extend(WithForbiddenState) {
     return this.get('system.leader');
   }
 
-  model() {
-    return RSVP.hash({
-      nodes: this.store.findAll('node'),
-      agents: this.store.findAll('agent'),
-    }).catch(notifyForbidden(this));
+  async model() {
+    try {
+      return {
+        nodes: await this.store.findAll('node'),
+        agents: await this.store.findAll('agent'),
+      };
+    } catch (e) {
+      notifyForbidden(this)(e);
+    }
   }
 }

--- a/ui/app/routes/clients.js
+++ b/ui/app/routes/clients.js
@@ -15,9 +15,14 @@ export default class ClientsRoute extends Route.extend(WithForbiddenState) {
 
   async model() {
     try {
+      const [nodes, agents] = await Promise.all([
+        this.store.findAll('node'),
+        this.store.findAll('agent'),
+      ]);
+
       return {
-        nodes: await this.store.findAll('node'),
-        agents: await this.store.findAll('agent'),
+        nodes,
+        agents,
       };
     } catch (e) {
       notifyForbidden(this)(e);

--- a/ui/app/routes/clients/client.js
+++ b/ui/app/routes/clients/client.js
@@ -5,8 +5,12 @@ import notifyError from 'nomad-ui/utils/notify-error';
 export default class ClientRoute extends Route {
   @service store;
 
-  model() {
-    return super.model(...arguments).catch(notifyError(this));
+  async model() {
+    try {
+      return super.model(...arguments);
+    } catch (e) {
+      notifyError(this)(e);
+    }
   }
 
   afterModel(model) {

--- a/ui/app/routes/csi/plugins.js
+++ b/ui/app/routes/csi/plugins.js
@@ -6,9 +6,11 @@ import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 export default class PluginsRoute extends Route.extend(WithForbiddenState) {
   @service store;
 
-  model() {
-    return this.store
-      .query('plugin', { type: 'csi' })
-      .catch(notifyForbidden(this));
+  async model() {
+    try {
+      return this.store.query('plugin', { type: 'csi' });
+    } catch (e) {
+      notifyForbidden(this)(e);
+    }
   }
 }

--- a/ui/app/routes/csi/plugins/plugin.js
+++ b/ui/app/routes/csi/plugins/plugin.js
@@ -10,9 +10,11 @@ export default class PluginRoute extends Route {
     return { plugin_name: model.get('plainId') };
   }
 
-  model(params) {
-    return this.store
-      .findRecord('plugin', `csi/${params.plugin_name}`)
-      .catch(notifyError(this));
+  async model(params) {
+    try {
+      return this.store.findRecord('plugin', `csi/${params.plugin_name}`);
+    } catch (e) {
+      notifyError(this)(e);
+    }
   }
 }

--- a/ui/app/routes/csi/volumes/index.js
+++ b/ui/app/routes/csi/volumes/index.js
@@ -20,12 +20,17 @@ export default class IndexRoute extends Route.extend(
 
   async model(params) {
     try {
-      return {
-        volumes: await this.store.query('volume', {
+      const [volumes, namespaces] = await Promise.all([
+        this.store.query('volume', {
           type: 'csi',
           namespace: params.qpNamespace,
         }),
-        namespaces: await this.store.findAll('namespace'),
+        this.store.findAll('namespace'),
+      ]);
+
+      return {
+        volumes,
+        namespaces,
       };
     } catch (e) {
       notifyForbidden(this)(e);

--- a/ui/app/routes/csi/volumes/index.js
+++ b/ui/app/routes/csi/volumes/index.js
@@ -1,5 +1,4 @@
 import { inject as service } from '@ember/service';
-import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
 import { collect } from '@ember/object/computed';
 import { watchQuery, watchAll } from 'nomad-ui/utils/properties/watch';
@@ -19,13 +18,18 @@ export default class IndexRoute extends Route.extend(
     },
   };
 
-  model(params) {
-    return RSVP.hash({
-      volumes: this.store
-        .query('volume', { type: 'csi', namespace: params.qpNamespace })
-        .catch(notifyForbidden(this)),
-      namespaces: this.store.findAll('namespace'),
-    });
+  async model(params) {
+    try {
+      return {
+        volumes: await this.store.query('volume', {
+          type: 'csi',
+          namespace: params.qpNamespace,
+        }),
+        namespaces: await this.store.findAll('namespace'),
+      };
+    } catch (e) {
+      notifyForbidden(this)(e);
+    }
   }
 
   startWatchers(controller) {

--- a/ui/app/routes/csi/volumes/volume.js
+++ b/ui/app/routes/csi/volumes/volume.js
@@ -1,7 +1,6 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { collect } from '@ember/object/computed';
-import RSVP from 'rsvp';
 import notifyError from 'nomad-ui/utils/notify-error';
 import { watchRecord } from 'nomad-ui/utils/properties/watch';
 import WithWatchers from 'nomad-ui/mixins/with-watchers';
@@ -24,7 +23,7 @@ export default class VolumeRoute extends Route.extend(WithWatchers) {
     return { volume_name: JSON.parse(model.get('id')).join('@') };
   }
 
-  model(params) {
+  async model(params) {
     // Issue with naming collissions
     const url = params.volume_name.split('@');
     const namespace = url.pop();
@@ -32,12 +31,18 @@ export default class VolumeRoute extends Route.extend(WithWatchers) {
 
     const fullId = JSON.stringify([`csi/${name}`, namespace || 'default']);
 
-    return RSVP.hash({
-      volume: this.store.findRecord('volume', fullId, { reload: true }),
-      namespaces: this.store.findAll('namespace'),
-    })
-      .then((hash) => hash.volume)
-      .catch(notifyError(this));
+    try {
+      const [volume] = await Promise.all([
+        this.store.findRecord('volume', fullId, {
+          reload: true,
+        }),
+        this.store.findAll('namespace'),
+      ]);
+
+      return volume;
+    } catch (e) {
+      notifyError(this)(e);
+    }
   }
 
   // Since volume includes embedded records for allocations,

--- a/ui/app/routes/evaluations/index.js
+++ b/ui/app/routes/evaluations/index.js
@@ -28,7 +28,7 @@ export default class EvaluationsIndexRoute extends Route {
     },
   };
 
-  model({
+  async model({
     nextToken,
     pageSize,
     searchTerm,
@@ -90,7 +90,7 @@ export default class EvaluationsIndexRoute extends Route {
       return null;
     };
 
-    this.store.findAll('namespace');
+    await this.store.findAll('namespace');
 
     return this.store.query('evaluation', {
       namespace,

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -1,6 +1,5 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
 import { collect } from '@ember/object/computed';
 import { watchAll, watchQuery } from 'nomad-ui/utils/properties/watch';
 import WithWatchers from 'nomad-ui/mixins/with-watchers';
@@ -19,13 +18,15 @@ export default class IndexRoute extends Route.extend(
     },
   };
 
-  model(params) {
-    return RSVP.hash({
-      jobs: this.store
-        .query('job', { namespace: params.qpNamespace })
-        .catch(notifyForbidden(this)),
-      namespaces: this.store.findAll('namespace'),
-    });
+  async model(params) {
+    try {
+      return {
+        jobs: await this.store.query('job', { namespace: params.qpNamespace }),
+        namespaces: await this.store.findAll('namespace'),
+      };
+    } catch (e) {
+      notifyForbidden(this)(e);
+    }
   }
 
   startWatchers(controller) {

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -19,10 +19,15 @@ export default class IndexRoute extends Route.extend(
   };
 
   async model(params) {
+    const [jobs, namespaces] = await Promise.all([
+      this.store.query('job', { namespace: params.qpNamespace }),
+      this.store.findAll('namespace'),
+    ]);
+
     try {
       return {
-        jobs: await this.store.query('job', { namespace: params.qpNamespace }),
-        namespaces: await this.store.findAll('namespace'),
+        jobs,
+        namespaces,
       };
     } catch (e) {
       notifyForbidden(this)(e);

--- a/ui/app/routes/jobs/job.js
+++ b/ui/app/routes/jobs/job.js
@@ -1,6 +1,5 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
 import notifyError from 'nomad-ui/utils/notify-error';
 import classic from 'ember-classic-decorator';
 
@@ -15,7 +14,7 @@ export default class JobRoute extends Route {
     return { job_name: model.get('idWithNamespace') };
   }
 
-  model(params) {
+  async model(params) {
     let name,
       namespace = 'default';
     const { job_name } = params;
@@ -29,27 +28,29 @@ export default class JobRoute extends Route {
 
     const fullId = JSON.stringify([name, namespace]);
 
-    return this.store
-      .findRecord('job', fullId, { reload: true })
-      .then((job) => {
-        const relatedModelsQueries = [
-          job.get('allocations'),
-          job.get('evaluations'),
-          this.store.query('job', { namespace }),
-          this.store.findAll('namespace'),
-        ];
+    try {
+      const job = await this.store.findRecord('job', fullId, { reload: true });
 
-        if (this.can.can('accept recommendation')) {
-          relatedModelsQueries.push(job.get('recommendationSummaries'));
-        }
+      const relatedModelsQueries = [
+        job.get('allocations'),
+        job.get('evaluations'),
+        this.store.query('job', { namespace }),
+        this.store.findAll('namespace'),
+      ];
 
-        // Optimizing future node look ups by preemptively loading everything
-        if (job.get('hasClientStatus') && this.can.can('read client')) {
-          relatedModelsQueries.push(this.store.findAll('node'));
-        }
+      if (this.can.can('accept recommendation')) {
+        relatedModelsQueries.push(job.get('recommendationSummaries'));
+      }
 
-        return RSVP.all(relatedModelsQueries).then(() => job);
-      })
-      .catch(notifyError(this));
+      // Optimizing future node look ups by preemptively loading everything
+      if (job.get('hasClientStatus') && this.can.can('read client')) {
+        relatedModelsQueries.push(this.store.findAll('node'));
+      }
+
+      await Promise.all(relatedModelsQueries);
+      return job;
+    } catch (e) {
+      notifyError(this)(e);
+    }
   }
 }

--- a/ui/app/routes/jobs/job/allocations.js
+++ b/ui/app/routes/jobs/job/allocations.js
@@ -7,9 +7,13 @@ import { inject as service } from '@ember/service';
 export default class AllocationsRoute extends Route.extend(WithWatchers) {
   @service store;
 
-  model() {
+  async model() {
     const job = this.modelFor('jobs.job');
-    return job && job.get('allocations').then(() => job);
+
+    if (job) {
+      await job.get('allocations');
+      return job;
+    }
   }
 
   startWatchers(controller, model) {

--- a/ui/app/routes/jobs/job/definition.js
+++ b/ui/app/routes/jobs/job/definition.js
@@ -1,14 +1,16 @@
 import Route from '@ember/routing/route';
 
 export default class DefinitionRoute extends Route {
-  model() {
+  async model() {
     const job = this.modelFor('jobs.job');
     if (!job) return;
 
-    return job.fetchRawDefinition().then((definition) => ({
+    const definition = await job.fetchRawDefinition();
+
+    return {
       job,
       definition,
-    }));
+    };
   }
 
   resetController(controller, isExiting) {

--- a/ui/app/routes/jobs/job/deployments.js
+++ b/ui/app/routes/jobs/job/deployments.js
@@ -1,5 +1,4 @@
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
 import { collect } from '@ember/object/computed';
 import { watchRelationship } from 'nomad-ui/utils/properties/watch';
 import WithWatchers from 'nomad-ui/mixins/with-watchers';
@@ -8,12 +7,13 @@ import { inject as service } from '@ember/service';
 export default class DeploymentsRoute extends Route.extend(WithWatchers) {
   @service store;
 
-  model() {
+  async model() {
     const job = this.modelFor('jobs.job');
-    return (
-      job &&
-      RSVP.all([job.get('deployments'), job.get('versions')]).then(() => job)
-    );
+
+    if (job) {
+      await Promise.all([job.get('deployments'), job.get('versions')]);
+      return job;
+    }
   }
 
   startWatchers(controller, model) {

--- a/ui/app/routes/jobs/job/evaluations.js
+++ b/ui/app/routes/jobs/job/evaluations.js
@@ -7,9 +7,13 @@ import { inject as service } from '@ember/service';
 export default class EvaluationsRoute extends Route.extend(WithWatchers) {
   @service store;
 
-  model() {
+  async model() {
     const job = this.modelFor('jobs.job');
-    return job && job.get('evaluations').then(() => job);
+
+    if (job) {
+      await job.get('evaluations');
+      return job;
+    }
   }
 
   startWatchers(controller, model) {

--- a/ui/app/routes/jobs/job/services.js
+++ b/ui/app/routes/jobs/job/services.js
@@ -7,9 +7,13 @@ import {
 } from 'nomad-ui/utils/properties/watch';
 
 export default class JobsJobServicesRoute extends Route.extend(WithWatchers) {
-  model() {
+  async model() {
     const job = this.modelFor('jobs.job');
-    return job && job.get('services').then(() => job);
+
+    if (job) {
+      await job.get('services');
+      return job;
+    }
   }
 
   startWatchers(controller, model) {

--- a/ui/app/routes/jobs/job/task-group.js
+++ b/ui/app/routes/jobs/job/task-group.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
 import { collect } from '@ember/object/computed';
 import EmberError from '@ember/error';
-import { resolve, all } from 'rsvp';
 import {
   watchRecord,
   watchRelationship,
@@ -13,7 +12,7 @@ import { inject as service } from '@ember/service';
 export default class TaskGroupRoute extends Route.extend(WithWatchers) {
   @service store;
 
-  model({ name }) {
+  async model({ name }) {
     const job = this.modelFor('jobs.job');
 
     // If there is no job, then there is no task group.
@@ -22,25 +21,32 @@ export default class TaskGroupRoute extends Route.extend(WithWatchers) {
 
     // If the job is a partial (from the list request) it won't have task
     // groups. Reload the job to ensure task groups are present.
-    const reload = job.get('isPartial') ? job.reload() : resolve();
-    return reload
-      .then(() => {
-        const taskGroup = job.get('taskGroups').findBy('name', name);
-        if (!taskGroup) {
-          const err = new EmberError(
-            `Task group ${name} for job ${job.get('name')} not found`
-          );
-          err.code = '404';
-          throw err;
-        }
+    const isPartialJob = job.get('isPartial');
 
-        // Refresh job allocations before-hand (so page sort works on load)
-        return all([
-          job.hasMany('allocations').reload(),
-          job.get('scaleState'),
-        ]).then(() => taskGroup);
-      })
-      .catch(notifyError(this));
+    try {
+      if (isPartialJob) {
+        await job.reload();
+      }
+
+      const taskGroup = await job.get('taskGroups').findBy('name', name);
+
+      if (!taskGroup) {
+        const err = new EmberError(
+          `Task group ${name} for job ${job.get('name')} not found`
+        );
+        err.code = '404';
+        throw err;
+      }
+
+      await Promise.all([
+        job.hasMany('allocations').reload(),
+        job.get('scaleState'),
+      ]);
+
+      return taskGroup;
+    } catch (e) {
+      notifyError(this)(e);
+    }
   }
 
   startWatchers(controller, model) {

--- a/ui/app/routes/jobs/job/versions.js
+++ b/ui/app/routes/jobs/job/versions.js
@@ -10,9 +10,13 @@ import { inject as service } from '@ember/service';
 export default class VersionsRoute extends Route.extend(WithWatchers) {
   @service store;
 
-  model() {
+  async model() {
     const job = this.modelFor('jobs.job');
-    return job && job.get('versions').then(() => job);
+
+    if (job) {
+      await job.get('versions');
+      return job;
+    }
   }
 
   startWatchers(controller, model) {

--- a/ui/app/routes/jobs/run.js
+++ b/ui/app/routes/jobs/run.js
@@ -18,12 +18,11 @@ export default class RunRoute extends Route {
     }
   }
 
-  model() {
+  async model() {
     // When jobs are created with a namespace attribute, it is verified against
     // available namespaces to prevent redirecting to a non-existent namespace.
-    return this.store.findAll('namespace').then(() => {
-      return this.store.createRecord('job');
-    });
+    await this.store.findAll('namespace');
+    return this.store.createRecord('job');
   }
 
   resetController(controller, isExiting) {

--- a/ui/app/routes/servers.js
+++ b/ui/app/routes/servers.js
@@ -1,6 +1,5 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
 import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
 import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 import classic from 'ember-classic-decorator';
@@ -14,10 +13,14 @@ export default class ServersRoute extends Route.extend(WithForbiddenState) {
     return this.get('system.leader');
   }
 
-  model() {
-    return RSVP.hash({
-      nodes: this.store.findAll('node'),
-      agents: this.store.findAll('agent'),
-    }).catch(notifyForbidden(this));
+  async model() {
+    try {
+      return {
+        nodes: await this.store.findAll('node'),
+        agents: await this.store.findAll('agent'),
+      };
+    } catch (e) {
+      notifyForbidden(this)(e);
+    }
   }
 }

--- a/ui/app/routes/servers.js
+++ b/ui/app/routes/servers.js
@@ -15,9 +15,14 @@ export default class ServersRoute extends Route.extend(WithForbiddenState) {
 
   async model() {
     try {
+      const [nodes, agents] = await Promise.all([
+        this.store.findAll('node'),
+        this.store.findAll('agent'),
+      ]);
+
       return {
-        nodes: await this.store.findAll('node'),
-        agents: await this.store.findAll('agent'),
+        nodes,
+        agents,
       };
     } catch (e) {
       notifyForbidden(this)(e);

--- a/ui/app/routes/topology.js
+++ b/ui/app/routes/topology.js
@@ -11,14 +11,20 @@ export default class TopologyRoute extends Route.extend(WithForbiddenState) {
 
   async model() {
     try {
-      return {
-        jobs: await this.store.findAll('job'),
-        allocations: await this.store.query('allocation', {
+      const [jobs, allocations, nodes] = await Promise.all([
+        this.store.findAll('job'),
+        this.store.query('allocation', {
           resources: true,
           task_states: false,
           namespace: '*',
         }),
-        nodes: await this.store.query('node', { resources: true }),
+        this.store.query('node', { resources: true }),
+      ]);
+
+      return {
+        jobs,
+        allocations,
+        nodes,
       };
     } catch (e) {
       notifyForbidden(this)(e);

--- a/ui/app/routes/topology.js
+++ b/ui/app/routes/topology.js
@@ -3,23 +3,26 @@ import Route from '@ember/routing/route';
 import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
 import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 import classic from 'ember-classic-decorator';
-import RSVP from 'rsvp';
 
 @classic
 export default class TopologyRoute extends Route.extend(WithForbiddenState) {
   @service store;
   @service system;
 
-  model() {
-    return RSVP.hash({
-      jobs: this.store.findAll('job'),
-      allocations: this.store.query('allocation', {
-        resources: true,
-        task_states: false,
-        namespace: '*',
-      }),
-      nodes: this.store.query('node', { resources: true }),
-    }).catch(notifyForbidden(this));
+  async model() {
+    try {
+      return {
+        jobs: await this.store.findAll('job'),
+        allocations: await this.store.query('allocation', {
+          resources: true,
+          task_states: false,
+          namespace: '*',
+        }),
+        nodes: await this.store.query('node', { resources: true }),
+      };
+    } catch (e) {
+      notifyForbidden(this)(e);
+    }
   }
 
   setupController(controller, model) {

--- a/ui/app/routes/variables/variable.js
+++ b/ui/app/routes/variables/variable.js
@@ -7,13 +7,17 @@ export default class VariablesVariableRoute extends Route.extend(
   withForbiddenState
 ) {
   @service store;
-  model(params) {
-    return this.store
-      .findRecord('variable', decodeURIComponent(params.id), {
+
+  async model(params) {
+    try {
+      return this.store.findRecord('variable', decodeURIComponent(params.id), {
         reload: true,
-      })
-      .catch(notifyForbidden(this));
+      });
+    } catch (e) {
+      notifyForbidden(this)(e);
+    }
   }
+
   setupController(controller) {
     super.setupController(controller);
     controller.set('params', this.paramsFor('variables.variable'));

--- a/ui/tests/acceptance/task-logs-test.js
+++ b/ui/tests/acceptance/task-logs-test.js
@@ -75,9 +75,13 @@ module('Acceptance | task logs', function (hooks) {
       run.cancelTimers();
     }, 500);
 
-    await click('button.logs-sidebar-trigger');
+    const taskButton = document.querySelectorAll(
+      'button.logs-sidebar-trigger'
+    )[1];
+    await click(taskButton);
 
     assert.ok(TaskLogs.sidebarIsPresent, 'Sidebar is present');
+
     assert
       .dom('.task-context-sidebar h1.title')
       .includesText(task.name, 'Sidebar title is correct');


### PR DESCRIPTION
This PR updates the model hooks to move away from using `RSVP` to organize asynchronous code, and use the `async/await` syntactic sugar instead.