### PR TITLE
test: simplify overlap job placement logic

### DIFF
--- a/e2e/overlap/testdata/overlap.nomad
+++ b/e2e/overlap/testdata/overlap.nomad
@@ -1,15 +1,10 @@
 job "overlap" {
-  datacenters = ["dc1"]
+  datacenters = ["dc1", "dc2"]
   type        = "service"
 
   constraint {
     attribute = "${attr.kernel.name}"
     value     = "linux"
-  }
-
-  constraint {
-    attribute = "${node.unique.id}"
-    value     = "<<Must be filled in by test>>"
   }
 
   group "overlap" {
@@ -27,8 +22,7 @@ job "overlap" {
       }
 
       resources {
-        # Must be filled in by test
-        cpu    = "0"
+        cpu    = "500"
         memory = "50"
       }
     }


### PR DESCRIPTION
Trying to fix #14806

Both the previous approach as well as this one worked on e2e clusters I spun up.

The old approach added a constraint to both the initial job and the followup job on a specific node. This would fail when a Windows node was selected and fixed in #14780. I have no idea why #14780 didn't fit it entirely though. It worked in my own e2e cluster.

But I realized I could simplify the test and make it more robust at the same time! Instead of picking a node before registering the job: let the initial job get placed, and then ensure the subsequent job has a constraint on that placement's node!