### PR TITLE
semgrep: add MeasureSinceWithLabels to FSM time rule

### DIFF
--- a/.semgrep/fsm_time.yml
+++ b/.semgrep/fsm_time.yml
@@ -7,6 +7,10 @@ rules:
       - pattern-not-inside: |
           defer metrics.MeasureSince(...)
 
+      # Metric state is local to the server and therefore must use time.
+      - pattern-not-inside: |
+          defer metrics.MeasureSinceWithLabels(...)
+
       # The timetable's whole point is to roughly track timestamps for Raft log
       # indexes, so it must use time.
       - pattern-not-inside: |


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/14028

Metrics state is local to the server and needs to use time, which is normally forbidden in the FSM code. We have a bypass for this rule for `metrics.MeasureSince` but needed one for `metrics.MeasureSinceWithLabels` as well.