### PR TITLE
[ui] Line charts: explicitly update X-axis whenever xScale changes

### DIFF
--- a/.changelog/14814.txt
+++ b/.changelog/14814.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed line charts to update x-axis (time) where relevant
+```

--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -350,6 +350,13 @@ export default class LineChart extends Component {
     });
   }
 
+  @action
+  recomputeXAxis(el) {
+    if (!this.isDestroyed && !this.isDestroying) {
+      d3.select(el.querySelector('.x-axis')).call(this.xAxis);
+    }
+  }
+
   mountD3Elements() {
     if (!this.isDestroyed && !this.isDestroying) {
       d3.select(this.element.querySelector('.x-axis')).call(this.xAxis);

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -3,6 +3,7 @@
   ...attributes
   {{did-insert this.onInsert}}
   {{did-update this.renderChart}}
+  {{did-update this.recomputeXAxis this.xScale}}
   {{window-resize this.updateDimensions}}>
   <svg data-test-line-chart aria-labelledby="{{this.titleId}}" aria-describedby="{{this.descriptionId}}">
     <title id="{{this.titleId}}">{{this.title}}</title>


### PR DESCRIPTION
Resolves #14808 

Previously (for quite awhile perhaps?) the chart line would move above the time x-axis, but the axis itself would never update.  While it is cool to rip a hole in space-time via client-side javascript, it's probably better that we scroll the ticks as new x-scale extents update.

Side-note: I am skeptical if the `{{did-update this.renderChart}}` does anything at all. `renderChart()` is also called, once removed, from the `onInsert` modifier-fired action. But I don't think the template modifier triggers at all. 