### PR TITLE
fix panic from keyring raft entries being written during upgrade

### DIFF
--- a/.changelog/14821.txt
+++ b/.changelog/14821.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+keyring: Fixed a panic that can occur during upgrades to 1.4.0 when initializing the keyring
+```

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -277,6 +277,9 @@ func (e *Encrypter) activeKeySetLocked() (*keyset, error) {
 	if err != nil {
 		return nil, err
 	}
+	if keyMeta == nil {
+		return nil, fmt.Errorf("keyring has not been initialized yet")
+	}
 
 	return e.keysetByIDLocked(keyMeta.KeyID)
 }

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -7,9 +7,7 @@ import (
 	"testing"
 	"time"
 
-	version "github.com/hashicorp/go-version"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/nomad/ci"
@@ -313,26 +311,4 @@ func TestEncrypter_SignVerify(t *testing.T) {
 	require.Equal(t, alloc.ID, got.AllocationID)
 	require.Equal(t, alloc.JobID, got.JobID)
 	require.Equal(t, "web", got.TaskName)
-}
-
-func TestEncrypter_VersionCheck(t *testing.T) {
-
-	validVersions := []string{"1.4.0", "1.4.1", "1.5.2", "1.4.0-dev", "1.4.0-beta.1"}
-	invalidVersions := []string{"1.3.5", "1.3.5-dev"}
-
-	for _, v := range validVersions {
-		memberVersion := version.Must(version.NewVersion(v))
-
-		must.True(t, memberVersion.Core().GreaterThanOrEqual(minVersionKeyring),
-			must.Sprintf("expected %v >= 1.4.0", v),
-		)
-	}
-
-	for _, v := range invalidVersions {
-		memberVersion := version.Must(version.NewVersion(v))
-		must.True(t, memberVersion.Core().LessThan(minVersionKeyring),
-			must.Sprintf("expected %v < 1.4.0", v),
-		)
-	}
-
 }

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 	"time"
 
+	version "github.com/hashicorp/go-version"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/nomad/ci"
@@ -311,4 +313,26 @@ func TestEncrypter_SignVerify(t *testing.T) {
 	require.Equal(t, alloc.ID, got.AllocationID)
 	require.Equal(t, alloc.JobID, got.JobID)
 	require.Equal(t, "web", got.TaskName)
+}
+
+func TestEncrypter_VersionCheck(t *testing.T) {
+
+	validVersions := []string{"1.4.0", "1.4.1", "1.5.2", "1.4.0-dev", "1.4.0-beta.1"}
+	invalidVersions := []string{"1.3.5", "1.3.5-dev"}
+
+	for _, v := range validVersions {
+		memberVersion := version.Must(version.NewVersion(v))
+
+		must.True(t, memberVersion.Core().GreaterThanOrEqual(minVersionKeyring),
+			must.Sprintf("expected %v >= 1.4.0", v),
+		)
+	}
+
+	for _, v := range invalidVersions {
+		memberVersion := version.Must(version.NewVersion(v))
+		must.True(t, memberVersion.Core().LessThan(minVersionKeyring),
+			must.Sprintf("expected %v < 1.4.0", v),
+		)
+	}
+
 }

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -1986,7 +1986,7 @@ func (s *Server) initializeKeyring(stopCh <-chan struct{}) error {
 		for _, member := range members {
 			build := member.Tags["build"]
 			memberVersion := version.Must(version.NewVersion(build))
-			if memberVersion.LessThan(minVersionKeyring) {
+			if memberVersion.Core().LessThan(minVersionKeyring) {
 				return false
 			}
 		}

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -1984,26 +1984,13 @@ func (s *Server) initializeKeyring(stopCh <-chan struct{}) {
 	}
 
 	logger.Trace("verifying cluster is ready to initialize keyring")
-
-	versionCheck := func() bool {
-		members := s.serf.Members()
-		for _, member := range members {
-			build := member.Tags["build"]
-			memberVersion := version.Must(version.NewVersion(build))
-			if memberVersion.Core().LessThan(minVersionKeyring) {
-				return false
-			}
-		}
-		return true
-	}
-
 	for {
 		select {
 		case <-stopCh:
 			return
 		default:
 		}
-		if versionCheck() {
+		if ServersMeetMinimumVersion(s.serf.Members(), minVersionKeyring, true) {
 			break
 		}
 	}

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -243,7 +243,7 @@ func TestPlanApply_applyPlanWithNormalizedAllocs(t *testing.T) {
 	ci.Parallel(t)
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
-		c.Build = "0.9.2"
+		c.Build = "1.4.0"
 	})
 	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)

--- a/nomad/worker_test.go
+++ b/nomad/worker_test.go
@@ -488,7 +488,7 @@ func TestWorker_SubmitPlanNormalizedAllocations(t *testing.T) {
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0
 		c.EnabledSchedulers = []string{structs.JobTypeService}
-		c.Build = "0.9.2"
+		c.Build = "1.4.0"
 	})
 	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/14819

During an upgrade to Nomad 1.4.0, if a server running 1.4.0 becomes the leader before one of the 1.3.x servers, the old server will crash because the keyring is initialized and writes a raft entry.

Wait until all members are on a version that supports the keyring before initializing it.