### PR TITLE
lock closed issues and PRs after 120 days

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,23 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '50 1 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-comment: >
+            I'm going to lock this issue because it has been closed for _120 days_ ⏳. This helps our maintainers find and focus on the active issues.
+
+            If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+          issue-lock-inactive-days: '120'
+          pr-lock-comment: >
+            I'm going to lock this pull request because it has been closed for _120 days_ ⏳. This helps our maintainers find and focus on the active contributions.
+
+            If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+          pr-lock-inactive-days: '120'


### PR DESCRIPTION
When community members comment on long-closed issues, there's a number of failure modes that make for a bad experience for them:

* Their comments are often missed entirely because notification settings make it impractical for most developers to read comments on inactive issues.

* In our experience, the problem is only rarely a regression; because failures are complex, totally different code paths can result in symptoms that initially appear to be the same but turn out to be completely different under close examination. This is particularly the case for issues fixed in very old versions (sometimes 2 or more years old).

The Terraform core team uses a bot that locks issues after only 30 days. But because we typically close issues automatically on PR merge but don't have rolling releases, it'd frequently happen that unreleased fixes will have locked comments, which isn't a good experience either. I've looked through the pace of releases since Nomad 0.9.0 and the longest window between releases was 3 months. Set the window for the lock bot to 120 days to give us plenty of breathing room so it doesn't feel like we're shutting down discussion prematurely.

(_Note this is only for closed issues, this isn't the same as the stalebot which we previously decided to remove._)