### PR TITLE
[ui] Makes service tags wrap and look like tag items

### DIFF
--- a/.changelog/14832.txt
+++ b/.changelog/14832.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes an issue where service tags would bleed past the edge of the screen
+```

--- a/ui/app/components/allocation-service-sidebar.hbs
+++ b/ui/app/components/allocation-service-sidebar.hbs
@@ -65,16 +65,6 @@
 							{{this.address}}
 						</a>
 					</span>
-					{{#if @service.tags.length}}
-						<span class="pair is-wrappable">
-							<span class="term">
-								Tags
-							</span>
-              {{#each @service.tags as |tag|}}
-                <span class="tag">{{tag}}</span>
-              {{/each}}
-						</span>
-					{{/if}}
 					<span class="pair">
 						<span class="term">
 							Client
@@ -87,9 +77,17 @@
 								{{@allocation.node.shortId}}
 							</LinkTo>
 						</Tooltip>
-
 					</span>
-
+					{{#if @service.tags.length}}
+						<span class="pair is-wrappable">
+							<span class="term">
+								Tags
+							</span>
+              {{#each @service.tags as |tag|}}
+                <span class="tag">{{tag}}</span>
+              {{/each}}
+						</span>
+					{{/if}}
 				</div>
 			</div>
 		</div>

--- a/ui/app/components/allocation-service-sidebar.hbs
+++ b/ui/app/components/allocation-service-sidebar.hbs
@@ -66,11 +66,13 @@
 						</a>
 					</span>
 					{{#if @service.tags.length}}
-						<span class="pair">
+						<span class="pair is-wrappable">
 							<span class="term">
 								Tags
 							</span>
-							{{join ", " @service.tags}}
+              {{#each @service.tags as |tag|}}
+                <span class="tag">{{tag}}</span>
+              {{/each}}
 						</span>
 					{{/if}}
 					<span class="pair">

--- a/ui/app/styles/components/inline-definitions.scss
+++ b/ui/app/styles/components/inline-definitions.scss
@@ -19,6 +19,7 @@
 
     &.is-wrappable {
       white-space: normal;
+      display: block;
       .tag {
         vertical-align: middle;
       }

--- a/ui/app/styles/components/inline-definitions.scss
+++ b/ui/app/styles/components/inline-definitions.scss
@@ -19,6 +19,9 @@
 
     &.is-wrappable {
       white-space: normal;
+      .tag {
+        vertical-align: middle;
+      }
     }
 
     .term {

--- a/ui/app/styles/components/inline-definitions.scss
+++ b/ui/app/styles/components/inline-definitions.scss
@@ -17,6 +17,10 @@
     margin-right: 2em;
     white-space: nowrap;
 
+    &.is-wrappable {
+      white-space: normal;
+    }
+
     .term {
       font-weight: $weight-semibold;
       margin-right: 0.5em;


### PR DESCRIPTION
Resolves #14832 

Fixes an issue where, if there were many tags on a service, they would bleed off-page.

Now, we show them as ui-conventional tags and wrap them.

Gratuitous example:
![image](https://user-images.githubusercontent.com/713991/194409508-3fd37ccb-ac99-40b7-bd88-b3f3bdc4a8a5.png)
