### PR TITLE
checks: don't validate task/check compatibility for Connect services

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6681,7 +6681,7 @@ func (tg *TaskGroup) validateServices() error {
 
 		for _, check := range service.Checks {
 			if check.TaskName != "" {
-				if check.Type != ServiceCheckScript && check.Type != ServiceCheckGRPC {
+				if service.Connect == nil && check.Type != ServiceCheckScript && check.Type != ServiceCheckGRPC {
 					mErr.Errors = append(mErr.Errors,
 						fmt.Errorf("Check %s invalid: only script and gRPC checks should have tasks", check.Name))
 				}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/14822

In Nomad 1.4.0 we plumbed-through a task name to all checks in order to support native service discovery. For Connect tasks with a non-script/gRPC check, this triggers a validation error that setting the task name on a check isn't compatible with http/tpc checks. Normally this is correct behavior but for Connect tasks we need to include the `task` field. Bypass this validation for Connect services.

Note to reviewers: see my comment in https://github.com/hashicorp/nomad/issues/14822#issuecomment-1271714556. I've tested that this fixes the immediate problem but I'm not familiar enough with the original changes for service disco checks yet to feel super confident that this is the right approach.