### PR TITLE
Adds purge job button to UI

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -29,6 +29,11 @@ export default class JobAdapter extends WatchableNamespaceIDs {
     return this.ajax(url, 'DELETE');
   }
 
+  purge(job) {
+    const url = this.urlForFindRecord(job.get('id'), 'job') + '?purge=true';
+    return this.ajax(url, 'DELETE');
+  }
+
   parse(spec) {
     const url = addToPath(this.urlForFindAll('job'), '/parse?namespace=*');
     return this.ajax(url, 'POST', {

--- a/ui/app/components/job-page/parts/title.js
+++ b/ui/app/components/job-page/parts/title.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
+import { inject as service } from '@ember/service';
 import messageFromAdapterError from 'nomad-ui/utils/message-from-adapter-error';
 import { tagName } from '@ember-decorators/component';
 import classic from 'ember-classic-decorator';
@@ -7,6 +8,8 @@ import classic from 'ember-classic-decorator';
 @classic
 @tagName('')
 export default class Title extends Component {
+  @service router;
+
   job = null;
   title = null;
 
@@ -26,6 +29,27 @@ export default class Title extends Component {
     }
   })
   stopJob;
+
+  @task(function* () {
+    try {
+      const job = this.job;
+      yield job.purge();
+      this.flashMessages.add({
+        title: 'Job Purged',
+        message: `You have purged ${this.job.name}`,
+        type: 'success',
+        destroyOnClick: false,
+        timeout: 5000,
+      });
+      this.router.transitionTo('jobs');
+    } catch (err) {
+      this.handleError({
+        title: 'Error purging job',
+        description: messageFromAdapterError(err, 'purge jobs'),
+      });
+    }
+  })
+  purgeJob;
 
   @task(function* () {
     const job = this.job;

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -227,6 +227,10 @@ export default class Job extends Model {
     return this.store.adapterFor('job').stop(this);
   }
 
+  purge() {
+    return this.store.adapterFor('job').purge(this);
+  }
+
   plan() {
     assert('A job must be parsed before planned', this._newDefinitionJSON);
     return this.store.adapterFor('job').plan(this);

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -26,6 +26,15 @@
         @onConfirm={{perform this.stopJob}} />
     {{else}}
       <TwoStepButton
+        data-test-purge
+        @alignRight={{true}}
+        @idleText="Purge Job"
+        @cancelText="Cancel"
+        @confirmText="Yes, Purge Job"
+        @confirmationMessage="Are you sure? You cannot undo this action."
+        @awaitingConfirmation={{this.purgeJob.isRunning}}
+        @onConfirm={{perform this.purgeJob}} />
+      <TwoStepButton
         data-test-start
         @alignRight={{true}}
         @idleText="Start Job"

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -102,10 +102,12 @@ export default function moduleForJob(
     test('the title buttons are dependent on job status', async function (assert) {
       if (job.status === 'dead') {
         assert.ok(JobDetail.start.isPresent);
+        assert.ok(JobDetail.purge.isPresent);
         assert.notOk(JobDetail.stop.isPresent);
         assert.notOk(JobDetail.execButton.isPresent);
       } else {
         assert.notOk(JobDetail.start.isPresent);
+        assert.notOk(JobDetail.purge.isPresent);
         assert.ok(JobDetail.stop.isPresent);
         assert.ok(JobDetail.execButton.isPresent);
       }

--- a/ui/tests/integration/components/job-page/helpers.js
+++ b/ui/tests/integration/components/job-page/helpers.js
@@ -20,6 +20,11 @@ export async function startJob() {
   await click('[data-test-start] [data-test-confirm-button]');
 }
 
+export async function purgeJob() {
+  await click('[data-test-purge] [data-test-idle-button]');
+  await click('[data-test-purge] [data-test-confirm-button]');
+}
+
 export function expectStartRequest(assert, server, job) {
   const expectedURL = jobURL(job);
   const request = server.pretender.handledRequests
@@ -55,6 +60,17 @@ export async function expectError(assert, title) {
 
 export function expectDeleteRequest(assert, server, job) {
   const expectedURL = jobURL(job);
+
+  assert.ok(
+    server.pretender.handledRequests
+      .filterBy('method', 'DELETE')
+      .find((req) => req.url === expectedURL),
+    'DELETE URL was made correctly'
+  );
+}
+
+export function expectPurgeRequest(assert, server, job) {
+  const expectedURL = jobURL(job) + '?purge=true';
 
   assert.ok(
     server.pretender.handledRequests

--- a/ui/tests/integration/components/job-page/periodic-test.js
+++ b/ui/tests/integration/components/job-page/periodic-test.js
@@ -11,9 +11,11 @@ import {
   jobURL,
   stopJob,
   startJob,
+  purgeJob,
   expectError,
   expectDeleteRequest,
   expectStartRequest,
+  expectPurgeRequest,
 } from './helpers';
 import { componentA11yAudit } from 'nomad-ui/tests/helpers/a11y-audit';
 
@@ -224,6 +226,25 @@ module('Integration | Component | job-page/periodic', function (hooks) {
     await startJob();
 
     await expectError(assert, 'Could Not Start Job');
+  });
+
+  test('Purging a job sends a purge request for the job', async function (assert) {
+    assert.expect(1);
+
+    const mirageJob = this.server.create('job', 'periodic', {
+      childrenCount: 0,
+      createAllocations: false,
+      status: 'dead',
+    });
+    await this.store.findAll('job');
+
+    const job = this.store.peekAll('job').findBy('plainId', mirageJob.id);
+
+    this.setProperties(commonProperties(job));
+    await render(commonTemplate);
+
+    await purgeJob();
+    expectPurgeRequest(assert, this.server, job);
   });
 
   test('Each job row includes the submitted time', async function (assert) {

--- a/ui/tests/integration/components/job-page/service-test.js
+++ b/ui/tests/integration/components/job-page/service-test.js
@@ -7,9 +7,11 @@ import { startMirage } from 'nomad-ui/initializers/ember-cli-mirage';
 import {
   startJob,
   stopJob,
+  purgeJob,
   expectError,
   expectDeleteRequest,
   expectStartRequest,
+  expectPurgeRequest,
 } from './helpers';
 import Job from 'nomad-ui/tests/pages/jobs/detail';
 import { initialize as fragmentSerializerInitializer } from 'nomad-ui/initializers/fragment-serializer';
@@ -126,6 +128,21 @@ module('Integration | Component | job-page/service', function (hooks) {
     await startJob();
 
     await expectError(assert, 'Could Not Start Job');
+  });
+
+  test('Purging a job sends a purge request for the job', async function (assert) {
+    assert.expect(1);
+
+    const mirageJob = makeMirageJob(this.server, { status: 'dead' });
+    await this.store.findAll('job');
+
+    const job = this.store.peekAll('job').findBy('plainId', mirageJob.id);
+
+    this.setProperties(commonProperties(job));
+    await render(commonTemplate);
+
+    await purgeJob();
+    expectPurgeRequest(assert, this.server, job);
   });
 
   test('Recent allocations shows allocations in the job context', async function (assert) {

--- a/ui/tests/pages/jobs/detail.js
+++ b/ui/tests/pages/jobs/detail.js
@@ -37,6 +37,7 @@ export default create({
 
   stop: twoStepButton('[data-test-stop]'),
   start: twoStepButton('[data-test-start]'),
+  purge: twoStepButton('[data-test-purge]'),
 
   packTag: isPresent('[data-test-pack-tag]'),
   metaTable: isPresent('[data-test-meta]'),

--- a/ui/tests/unit/adapters/job-test.js
+++ b/ui/tests/unit/adapters/job-test.js
@@ -515,6 +515,20 @@ module('Unit | Adapter | Job', function (hooks) {
     assert.equal(request.method, 'DELETE');
   });
 
+  test('purge requests include the activeRegion', async function (assert) {
+    const region = 'region-2';
+    const job = await this.initializeWithJob({ region });
+
+    await this.subject().purge(job);
+
+    const request = this.server.pretender.handledRequests[0];
+    assert.equal(
+      request.url,
+      `/v1/job/${job.plainId}?purge=true&region=${region}`
+    );
+    assert.equal(request.method, 'DELETE');
+  });
+
   test('parse requests include the activeRegion', async function (assert) {
     const region = 'region-2';
     await this.initializeUI({ region });


### PR DESCRIPTION
This adds a "Purge Job" button + confirmation button to the Job show page.

The Purge Job button will only show up if the job is currently dead. This conditional was added because I did not want somebody to accidentally purge a running job and then have no way to restart it. The button is already a TwoStep button with confirmation, but this felt like it added additional friction to the purge in a good way.

![a](https://user-images.githubusercontent.com/2732204/195388016-08aa941d-b914-4552-aae1-b1169cd71cd7.gif)

Closes https://github.com/hashicorp/nomad/issues/14411