### PR TITLE
test: extend timing and output of overlap e2e test

### DIFF
--- a/e2e/overlap/overlap_test.go
+++ b/e2e/overlap/overlap_test.go
@@ -37,10 +37,13 @@ func TestOverlap(t *testing.T) {
 
 	var origAlloc *api.AllocationListStub
 	testutil.Wait(t, func() (bool, error) {
+		time.Sleep(time.Second)
+
 		a, _, err := nomadClient.Jobs().Allocations(jobID1, false, nil)
 		must.NoError(t, err)
 		if n := len(a); n == 0 {
-			return false, fmt.Errorf("timed out before an allocation was found for %s", jobID1)
+			evalOut := e2eutil.DumpEvals(nomadClient, jobID1)
+			return false, fmt.Errorf("timed out before an allocation was found for %s. Evals:\n%s", jobID1, evalOut)
 		}
 		must.Len(t, 1, a)
 


### PR DESCRIPTION
Keeps failing in the nightly e2e test with unhelpful output like:
```
Failed
=== RUN   TestOverlap
    overlap_test.go:92: Followup job overlap93ee1d2b blocked. Sleeping for the rest of overlap48c26c39's shutdown_delay (9.2/10s)
    overlap_test.go:105: 1500/2000 retries reached for github.com/hashicorp/nomad/e2e/overlap.TestOverlap (err=timed out before an allocation was found for overlap93ee1d2b)
    overlap_test.go:105: timeout: timed out before an allocation was found for overlap93ee1d2b
--- FAIL: TestOverlap (38.96s)
```

I have not been able to replicate it in my own e2e cluster, so I added the EvalDump helper to add detailed eval information like:

```
=== RUN   TestOverlap
1/1 Job overlap7b0e90ec Eval c38c9919-a4f0-5baf-45f7-0702383c682a
  Type:         service
  TriggeredBy:  job-register
  Deployment:
  Status:       pending ()
  NextEval:
  PrevEval:
  BlockedEval:
   -- No placement failures --
  QueuedAllocs:
  SnapshotIdx:  0
  CreateIndex:  96
  ModifyIndex:  96

...
```

Hopefully helpful when debugging other tests as well!