### PR TITLE
acl: gate ACL role write and delete RPC usage on v1.4.0 or greater.

### DIFF
--- a/.changelog/14908.txt
+++ b/.changelog/14908.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+acl: Ensure all federated servers meet v.1.4.0 minimum before ACL roles can be written
+```

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -1097,6 +1097,13 @@ func (a *ACL) UpsertRoles(
 	}
 	defer metrics.MeasureSince([]string{"nomad", "acl", "upsert_roles"}, time.Now())
 
+	// ACL roles can only be used once all servers, in all federated regions
+	// have been upgraded to 1.4.0 or greater.
+	if !ServersMeetMinimumVersion(a.srv.Members(), AllRegions, minACLRoleVersion, false) {
+		return fmt.Errorf("all servers should be running version %v or later to use ACL roles",
+			minACLRoleVersion)
+	}
+
 	// Only tokens with management level permissions can create ACL roles.
 	if acl, err := a.srv.ResolveToken(args.AuthToken); err != nil {
 		return err
@@ -1232,6 +1239,13 @@ func (a *ACL) DeleteRolesByID(
 		return err
 	}
 	defer metrics.MeasureSince([]string{"nomad", "acl", "delete_roles"}, time.Now())
+
+	// ACL roles can only be used once all servers, in all federated regions
+	// have been upgraded to 1.4.0 or greater.
+	if !ServersMeetMinimumVersion(a.srv.Members(), AllRegions, minACLRoleVersion, false) {
+		return fmt.Errorf("all servers should be running version %v or later to use ACL roles",
+			minACLRoleVersion)
+	}
 
 	// Only tokens with management level permissions can create ACL roles.
 	if acl, err := a.srv.ResolveToken(args.AuthToken); err != nil {

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -49,6 +49,11 @@ var minJobRegisterAtomicEvalVersion = version.Must(version.NewVersion("0.12.1"))
 
 var minOneTimeAuthenticationTokenVersion = version.Must(version.NewVersion("1.1.0"))
 
+// minACLRoleVersion is the Nomad version at which the ACL role table was
+// introduced. It forms the minimum version all federated servers must meet
+// before the feature can be used.
+var minACLRoleVersion = version.Must(version.NewVersion("1.4.0"))
+
 // monitorLeadership is used to monitor if we acquire or lose our role
 // as the leader in the Raft cluster. There is some work the leader is
 // expected to do, so we must react to changes


### PR DESCRIPTION
This ensures all federated servers are running v1.4.0 or greater before the use of ACL roles is allowed.