### PR TITLE
consul: do not re-register already registered services

### DIFF
--- a/.changelog/14917.txt
+++ b/.changelog/14917.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul: Fixed a bug where services continuously re-registered
+```


### PR DESCRIPTION
This PR updates Nomad's Consul service client to do map comparisons
using `maps.Equal` instead of `reflect.DeepEqual`. The bug fix is in how
`DeepEqual` treats nil slices different from empty slices, when actually
they should be treated the same.

Also, we need to avoid comparing `TaggedAddress` on agent registrations if
none are set on the Nomad side - because Consul will helpfully set that field
for us on its side.

And some drive-by cleanup `map[string]struct{}` for `set.Set`

Fixes #14914