### PR TITLE
docs: add autoscaling debug

### DIFF
--- a/website/content/tools/autoscaling/agent.mdx
+++ b/website/content/tools/autoscaling/agent.mdx
@@ -78,6 +78,10 @@ following actions.
 
 ## General Parameters
 
+- `enable_debug` `(bool: false)` - Specifies if the debugging HTTP endpoints
+  should be enabled. These endpoints can be used with profiling tools to dump
+  diagnostic information about the Nomad Autoscaler's internals.
+
 - `log_level` `(string: "INFO")` - Specify the verbosity level of Nomad
   Autoscaler's logs. Valid values include DEBUG, INFO, and WARN, in decreasing
   order of verbosity.

--- a/website/content/tools/autoscaling/api.mdx
+++ b/website/content/tools/autoscaling/api.mdx
@@ -9,6 +9,44 @@ description: Learn about the Nomad Autoscaler HTTP API.
 The Nomad Autoscaler exposes a small, simple API to be used for health checking
 the agent and obtaining metric data.
 
+## Agent Runtime Profiles
+
+This endpoint can be used to retrieve runtime profile information for the Nomad
+Autoscaler. They are only available when [`enable_debug`][agent_enable_debug]
+is set to `true`. Refer to [Go's documentation][go_debug] for a list of
+available profiles.
+
+| Method | Path                           | Produces                   |
+| ------ | ------------------------------ | -------------------------- |
+| `GET`  | `/debug/pprof`                 | `text/html`                |
+| `GET`  | `/debug/pprof/cmdline`         | `text/plain`               |
+| `GET`  | `/debug/pprof/symbol`          | `text/plain`               |
+| `GET`  | `/debug/pprof/profile`         | `application/octet-stream` |
+| `GET`  | `/debug/pprof/trace`           | `application/octet-stream` |
+| `GET`  | `/debug/pprof/<pprof profile>` | `application/octet-stream` |
+
+### Parameters
+
+- `seconds` `(int: 3)` - Specifies the amount of time to run a profile or trace
+  request for.
+
+- `debug` `(int: 0)` - Specifies if a given pprof profile should be returned as
+  human readable plain text instead of the pprof binary format. Defaults to 0,
+  setting to 1 enables human readable plain text.
+
+### Sample Request
+
+```shell-session
+$ curl -O "http://localhost:8080/debug/pprof/goroutine"
+$ go tool pprof goroutine
+
+$ curl -O "http://localhost:8080/debug/pprof/profile?seconds=3"
+$ go tool pprof profile
+
+$ curl -O "http://localhost:8080/debug/pprof/trace?&seconds=5"
+$ go tool trace trace
+```
+
 ## Health API
 
 This endpoint can be used to query the Nomad Autoscaler agent aliveness. If the
@@ -120,3 +158,6 @@ $ curl https://localhost:8080/v1/metrics?format=prometheus
   "Timestamp": "2020-08-25 10:25:20 +0000 UTC"
 }
 ```
+
+[agent_enable_debug]: /tools/autoscaling/agent#enable_debug
+[go_debug]: https://golang.org/pkg/runtime/pprof/#Profile

--- a/website/content/tools/autoscaling/cli.mdx
+++ b/website/content/tools/autoscaling/cli.mdx
@@ -39,6 +39,9 @@ passed in via CLI arguments. The `agent` command accepts the following arguments
 - `-http-bind-port=<port>`: The port that the health server will bind to. The
   default is `8080`.
 
+- `-enable-debug`: Enable the agent debugging HTTP endpoints. The default is
+  false.
+
 - `-nomad-address=<addr>`: The address of the Nomad server in the form of
   `protocol://addr:port`. The default is `http://127.0.0.1:4646`.
 


### PR DESCRIPTION
Document the debug endpoints which is similar to https://www.nomadproject.io/api-docs/agent#agent-runtime-profiles.

(Note: the second commit is temporary change to make preview links work with the new devDot website)

Preview links:
- API docs: https://nomad-fu98cud5d-hashicorp.vercel.app//nomad/tools/autoscaling/api#agent-runtime-profiles
- Config value: https://nomad-fu98cud5d-hashicorp.vercel.app//nomad/tools/autoscaling/agent#general-parameters
- CLI flag: https://nomad-fu98cud5d-hashicorp.vercel.app//nomad/tools/autoscaling/cli#enable-debug