### PR TITLE
e2e: convert flaky exec download in chroot unit test into e2e test

### DIFF
--- a/e2e/isolation/input/chroot_dl_exec.nomad
+++ b/e2e/isolation/input/chroot_dl_exec.nomad
@@ -1,0 +1,67 @@
+job "chroot_dl_exec" {
+  datacenters = ["dc1"]
+  type        = "batch"
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+  group "group" {
+    network {
+      mode = "host"
+      port "http" {}
+    }
+    task "script-writer" {
+      driver = "raw_exec"
+      config {
+        command = "/bin/bash"
+        args = [
+          "-c",
+          "cd ${NOMAD_ALLOC_DIR} && chmod +x script.sh && tar -czf script.tar.gz script.sh"
+        ]
+      }
+      resources {
+        cpu    = 10
+        memory = 12
+      }
+      template {
+        data        = <<EOH
+#!/bin/sh
+echo this output is from a script
+EOH
+        destination = "${NOMAD_ALLOC_DIR}/script.sh"
+      }
+      lifecycle {
+        hook    = "prestart"
+        sidecar = false
+      }
+    }
+    task "file-server" {
+      driver = "raw_exec"
+      config {
+        command = "/usr/bin/python3"
+        args    = ["-m", "http.server", "${NOMAD_PORT_http}", "--directory", "${NOMAD_ALLOC_DIR}"]
+      }
+      resources {
+        cpu    = 10
+        memory = 32
+      }
+      lifecycle {
+        hook    = "prestart"
+        sidecar = true
+      }
+    }
+    task "run-script" {
+      driver = "exec"
+      config {
+        command = "local/script.sh"
+      }
+      resources {
+        cpu    = 10
+        memory = 12
+      }
+      artifact {
+        source = "http://localhost:${NOMAD_PORT_http}/script.tar.gz"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Similar to https://github.com/hashicorp/nomad/pull/14710, convert flaky `TestTaskRunner_Download_ChrootExec` into e2e test.

This job
1. Creates an executable script and creates a tar (prestart task)
2. Starts an http server to serve the tar (prestart sidecar task)
3. Runs the script as the command of an exec task 

The e2e test then checks the output from the script is present in the task logs.
