### PR TITLE
cli: prevent panic on `operator debug`

### DIFF
--- a/.changelog/14992.txt
+++ b/.changelog/14992.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: prevent a panic when the Nomad API returns an error while collecting a debug bundle
+```

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1404,7 +1404,7 @@ func writeResponseStreamOrErrorToFile[T any](obj []T, apiErr error, getWriterFn 
 	defer writer.Close()
 
 	if apiErr != nil {
-		wrapped := errorWrapper{Error: err.Error()}
+		wrapped := errorWrapper{Error: apiErr.Error()}
 		return writeJSON(wrapped, writer)
 	}
 


### PR DESCRIPTION
If the API returns an error during debug bundle collection the CLI was expanding the wrong error object, resulting in a panic since `err` is `nil`.

First spotted in https://app.circleci.com/pipelines/github/hashicorp/nomad/33328/workflows/763506a7-c0cc-4e23-b8c1-151d09b3af93/jobs/376622/steps?invite=true#step-108-860. Steps to reproduce:

1. start a 3 server Nomad cluster and wait for leadership
2. run `nomad operator debug`
3. stop 2 servers and wait for leadership to be lost