### PR TITLE
test: use port collision instead of cpu exhaustion

### DIFF
--- a/e2e/e2eutil/utils.go
+++ b/e2e/e2eutil/utils.go
@@ -335,29 +335,46 @@ var EvalTemplate = template.Must(template.New("dump_eval").Parse(
 	`{{.Index}}/{{.Total}} Job {{.Eval.JobID}} Eval {{.Eval.ID}}
   Type:         {{.Eval.Type}}
   TriggeredBy:  {{.Eval.TriggeredBy}}
+  {{- if .Eval.DeploymentID}}
   Deployment:   {{.Eval.DeploymentID}}
-  Status:       {{.Eval.Status}} ({{.Eval.StatusDescription}})
+  {{- end}}
+  Status:       {{.Eval.Status}} {{if .Eval.StatusDescription}}({{.Eval.StatusDescription}}){{end}}
+  {{- if .Eval.Wait}}
+  Wait:         {{.Eval.Wait}} <- DEPRECATED
+  {{- end}}
+  {{- if not .Eval.WaitUntil.IsZero}}
+  WaitUntil:    {{.Eval.WaitUntil}}
+  {{- end}}
+  {{- if .Eval.NextEval}}
   NextEval:     {{.Eval.NextEval}}
+  {{- end}}
+  {{- if .Eval.PreviousEval}}
   PrevEval:     {{.Eval.PreviousEval}}
+  {{- end}}
+  {{- if .Eval.BlockedEval}}
   BlockedEval:  {{.Eval.BlockedEval}}
+  {{- end}}
+  {{- if .Eval.FailedTGAllocs }}
+  Failed Allocs:
+  {{- end}}
   {{- range $k, $v := .Eval.FailedTGAllocs}}
     Failed Group: {{$k}}
       NodesEvaluated: {{$v.NodesEvaluated}}
-  		NodesFiltered:  {{$v.NodesFiltered}}
-  		NodesAvailable: {{range $dc, $n := $v.NodesAvailable}}{{$dc}}:{{$n}} {{end}}
-  		NodesExhausted: {{$v.NodesExhausted}}
-  		ClassFiltered:  {{len $v.ClassFiltered}}
-  		ConstraintFilt: {{len $v.ConstraintFiltered}}
-  		DimensionExhst: {{range $d, $n := $v.DimensionExhausted}}{{$d}}:{{$n}} {{end}}
-  		ResourcesExhst: {{range $r, $n := $v.ResourcesExhausted}}{{$r}}:{{$n}} {{end}}
-  		QuotaExhausted: {{range $i, $q := $v.QuotaExhausted}}{{$q}} {{end}}
-  		CoalescedFail:  {{$v.CoalescedFailures}}
-  		ScoreMetaDAta:  {{len $v.ScoreMetaData}}
-  		AllocationTime: {{$v.AllocationTime}}
-  {{- else}}
-   -- No placement failures --
+      NodesFiltered:  {{$v.NodesFiltered}}
+      NodesAvailable: {{range $dc, $n := $v.NodesAvailable}}{{$dc}}:{{$n}} {{end}}
+      NodesExhausted: {{$v.NodesExhausted}}
+      ClassFiltered:  {{len $v.ClassFiltered}}
+      ConstraintFilt: {{len $v.ConstraintFiltered}}
+      DimensionExhst: {{range $d, $n := $v.DimensionExhausted}}{{$d}}:{{$n}} {{end}}
+      ResourcesExhst: {{range $r, $n := $v.ResourcesExhausted}}{{$r}}:{{$n}} {{end}}
+      QuotaExhausted: {{range $i, $q := $v.QuotaExhausted}}{{$q}} {{end}}
+      CoalescedFail:  {{$v.CoalescedFailures}}
+      ScoreMetaData:  {{len $v.ScoreMetaData}}
+      AllocationTime: {{$v.AllocationTime}}
   {{- end}}
+  {{- if .Eval.QueuedAllocations}}
   QueuedAllocs: {{range $k, $n := .Eval.QueuedAllocations}}{{$k}}:{{$n}} {{end}}
+  {{- end}}
   SnapshotIdx:  {{.Eval.SnapshotIndex}}
   CreateIndex:  {{.Eval.CreateIndex}}
   ModifyIndex:  {{.Eval.ModifyIndex}}

--- a/e2e/overlap/testdata/overlap.nomad
+++ b/e2e/overlap/testdata/overlap.nomad
@@ -10,11 +10,19 @@ job "overlap" {
   group "overlap" {
     count = 1
 
+    network {
+      # Reserve a static port so that the subsequent job run is blocked until
+      # the port is freed
+      port "hack" {
+        static = 7234
+      }
+    }
+
     task "test" {
       driver = "raw_exec"
 
       # Delay shutdown to delay next placement
-      shutdown_delay = "10s"
+      shutdown_delay = "8s"
 
       config {
         command = "bash"
@@ -23,7 +31,7 @@ job "overlap" {
 
       resources {
         cpu    = "500"
-        memory = "50"
+        memory = "100"
       }
     }
   }


### PR DESCRIPTION
Originally this test relied on Job 1 blocking Job 2 until Job 1 had a terminal *ClientStatus.* Job 2 ensured it would get blocked using 2 mechanisms:

1. A constraint requiring it is placed on the same node as Job 1.
2. Job 2 would require all unreserved CPU on the node to ensure it would be blocked until Job 1's resources were free.

That 2nd assertion breaks if *any previous job is still running on the target node!* That seems very likely to happen in the flaky world of our e2e tests. In fact there may be some jobs we intentionally want running throughout; in hindsight it was never safe to assume my test would be the only thing scheduled when it ran.

*Ports to the rescue!* Reserving a static port means that both Job 2 will now block on Job 1 being terminal. It will only conflict with other tests if those tests use that port *on every node.* I ensured no existing tests were using the port I chose.

Other changes:
- Gave job a bit more breathing room resource-wise.
- Tightened timings a bit since previous failure ran into the `go test` time limit.
- Cleaned up the DumpEvals output. It's quite nice and handy now!