### PR TITLE
ci: use the same go mod cache across test-core jobs

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -40,13 +40,14 @@ jobs:
       - uses: magnetikonline/action-golang-cache@v1
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-key-suffix: -checks
+          cache-key-suffix: -core
       - name: Run make check
         run: |
           make missing
           make bootstrap
           make check
   compile:
+    needs: [checks]
     strategy:
       fail-fast: false
       matrix:
@@ -58,7 +59,7 @@ jobs:
       - uses: magnetikonline/action-golang-cache@v1
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-key-suffix: -compile
+          cache-key-suffix: -core
       - name: Run make dev
         env:
           GOBIN: ${{env.GOROOT}}/bin # windows kludge
@@ -66,6 +67,7 @@ jobs:
           make bootstrap
           make dev
   tests-api:
+    needs: [checks]
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
@@ -73,7 +75,7 @@ jobs:
       - uses: magnetikonline/action-golang-cache@v1
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-key-suffix: -api
+          cache-key-suffix: -core
       - name: Run API tests
         env:
           GOTEST_MOD: api
@@ -83,6 +85,7 @@ jobs:
           sudo sed -i 's!Defaults!#Defaults!g' /etc/sudoers
           sudo -E env "PATH=$PATH" make test-nomad-module
   tests-pkgs:
+    needs: [checks]
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -139,7 +142,7 @@ jobs:
       - uses: magnetikonline/action-golang-cache@v1
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-key-suffix: -pkgs
+          cache-key-suffix: -core
       - name: Run Matrix Tests
         env:
           GOTEST_PKGS: ./${{matrix.pkg}}

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -30,6 +30,18 @@ env:
   NOMAD_SLOW_TEST: 0
   NOMAD_TEST_LOG_LEVEL: OFF
 jobs:
+  mods:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - uses: magnetikonline/action-golang-cache@v1
+        with:
+          go-version: ${{env.GO_VERSION}}
+      - name: Pre-cache Go modules
+        run: |
+          make tidy
+          make bootstrap
   checks:
     runs-on: ubuntu-22.04
     timeout-minutes: 10

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -43,6 +43,7 @@ jobs:
           make tidy
           make bootstrap
   checks:
+    needs: [mods]
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -59,7 +60,7 @@ jobs:
           make bootstrap
           make check
   compile:
-    needs: [checks]
+    needs: [mods]
     strategy:
       fail-fast: false
       matrix:
@@ -79,7 +80,7 @@ jobs:
           make bootstrap
           make dev
   tests-api:
-    needs: [checks]
+    needs: [mods]
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
@@ -97,7 +98,7 @@ jobs:
           sudo sed -i 's!Defaults!#Defaults!g' /etc/sudoers
           sudo -E env "PATH=$PATH" make test-nomad-module
   tests-pkgs:
-    needs: [checks]
+    needs: [mods]
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
This PR configures the `test-core` Action(?) with a new `mods` job on which the
other jobs depend on. The mods job just runs `mod tidy` and `bootstrap` to download
all the Go modules that will be needed and caches them. The dependent jobs then make
use of the same cache so they do not need to download / cache the near 1GB of modules
themselves.

Closes https://github.com/hashicorp/nomad/issues/15000