### PR TITLE
ci: add -core suffix to mods action

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -38,6 +38,7 @@ jobs:
       - uses: magnetikonline/action-golang-cache@v1
         with:
           go-version: ${{env.GO_VERSION}}
+          cache-key-suffix: -core
       - name: Pre-cache Go modules
         run: |
           make tidy


### PR DESCRIPTION
Forgot to add this line to the new mods job; without it, it
creates a cache different from the one used by the other jobs. :facepalm: 
