### PR TITLE
client: ensure minimal cgroup controllers enabled

### DIFF
--- a/.changelog/15027.txt
+++ b/.changelog/15027.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where Nomad could not detect cores on recent RHEL systems
+```

--- a/client/lib/cgutil/cpuset_manager_v2.go
+++ b/client/lib/cgutil/cpuset_manager_v2.go
@@ -87,11 +87,7 @@ func NewCpusetManagerV2(parent string, reservable []uint16, logger hclog.Logger)
 }
 
 // minimumControllers sets the minimum set of required controllers on the
-// /sys/fs/cgroup/cgroup.subtree_control file. Some systems like Ubuntu turn on
-// all controllers by default, and will be unaffected. Other systems like RHEL,
-// CentOS, Fedora turn of most controllers, and provide a default that excludes
-// controllers needed by Nomad. This helper ensures all of:
-// [cpuset, cpu, io, memory, pids]
+// /sys/fs/cgroup/cgroup.subtree_control file - ensuring [cpuset, cpu, io, memory, pids]
 // are enabled.
 func minimumRootControllers() error {
 	e := new(editor)


### PR DESCRIPTION
This PR fixes a bug where Nomad could not operate properly on operating
systems that set the root `cgroup.subtree_control` to a set of controllers that
do not include the minimal set of controllers needed by Nomad.

Nomad needs these controllers enabled to operate:
- cpuset
- cpu
- io
- memory
- pids

Now, Nomad will ensure these controllers are enabled during Client initialization,
adding them to `cgroup.subtree_control` as necessary. This should be particularly
helpful on the RHEL/CentOS/Fedora family of system. Ubuntu systems should be
unaffected as they enable all controllers by default.

Fixes: https://github.com/hashicorp/nomad/issues/14494

Backports to 1.4.x and 1.3.x (1.2.x predates cgroups v2 support)