### PR TITLE
[draft] Update Jobs index to watch store, not model

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -9,6 +9,10 @@ export default class JobAdapter extends WatchableNamespaceIDs {
     summary: '/summary',
   };
 
+  queryParamsToAttrs = {
+    namespace: 'namespace',
+  };
+
   fetchRawDefinition(job) {
     const url = this.urlForFindRecord(job.get('id'), 'job');
     return this.ajax(url, 'GET');

--- a/ui/app/adapters/watchable.js
+++ b/ui/app/adapters/watchable.js
@@ -125,16 +125,44 @@ export default class Watchable extends ApplicationAdapter {
 
       // Remove existing records that match this query. This way if server-side
       // deletes have occurred, the store won't have stale records.
-      store
+      console.log(
+        'watcher.query has been thenned; about to make a peekAll and filter out'
+      );
+      const matchingStoreEntries = store
         .peekAll(type.modelName)
-        .filter((record) =>
-          queryParamsToAttrs.some(
-            (mapping) => get(record, mapping.attr) === query[mapping.queryParam]
-          )
-        )
-        .forEach((record) => {
-          removeRecord(store, record);
+        .filter((record) => {
+          console.log('reco', queryParamsToAttrs, record);
+          return queryParamsToAttrs.some((mapping) => {
+            console.log(
+              'SOME?',
+              mapping.attr,
+              query[mapping.queryParam],
+              get(get(record, mapping.attr), 'id')
+            );
+            return (
+              get(record, mapping.attr) === query[mapping.queryParam] ||
+              get(get(record, mapping.attr), 'id') === query[mapping.queryParam]
+            );
+          });
         });
+      console.log('=========', matchingStoreEntries);
+
+      matchingStoreEntries.forEach((record) => {
+        removeRecord(store, record);
+      });
+
+      console.log('type', type.modelName, payload);
+
+      // payload.forEach((record) => {
+      //   store.pushPayload(type.modelName, {
+      //     [`${type.modelName}s`]: record
+      //   });
+      // });
+      console.log(
+        'payload',
+        store.peekAll(type.modelName),
+        matchingStoreEntries
+      );
 
       return payload;
     });

--- a/ui/app/adapters/watchable.js
+++ b/ui/app/adapters/watchable.js
@@ -127,13 +127,9 @@ export default class Watchable extends ApplicationAdapter {
 
       // Remove existing records that match this query. This way if server-side
       // deletes have occurred, the store won't have stale records.
-      console.log(
-        'watcher.query has been thenned; about to make a peekAll and filter out'
-      );
       const matchingStoreEntries = store
         .peekAll(type.modelName)
         .filter((record) => {
-          console.log('reco', queryParamsToAttrs, record);
           return queryParamsToAttrs.some((mapping) => {
             // Special consideration for * queries, like "All jobs with * namespace":
             // entities will generally have "default" instead of "*" as their value for these sorts of properties.
@@ -141,51 +137,23 @@ export default class Watchable extends ApplicationAdapter {
               query[mapping.queryParam] === '*'
                 ? 'default'
                 : query[mapping.queryParam];
-            console.log(
-              'SOME?',
-              mapping.attr,
-              query[mapping.queryParam],
-              queryValue,
-              get(record, mapping.attr),
-              get(get(record, mapping.attr), 'id')
-            );
             return (
               get(record, mapping.attr) === queryValue ||
               get(get(record, mapping.attr), 'id') === queryValue
             );
           });
         });
-      console.log('=========', matchingStoreEntries);
 
       if (isPseudoFindAll) {
         matchingStoreEntries.forEach((record) => {
           const IDValue = record.get('plainId') || record.get('id');
           const storedRecordNotFoundInPayload =
             IDValue && !payload.find((r) => r.ID === IDValue);
-          console.log(
-            'storedRecordNotFoundInPayload for',
-            record.id,
-            payload.mapBy('ID'),
-            storedRecordNotFoundInPayload
-          );
           if (storedRecordNotFoundInPayload) {
             removeRecord(store, record);
           }
         });
       }
-
-      console.log('type', type.modelName, payload);
-
-      // payload.forEach((record) => {
-      //   store.pushPayload(type.modelName, {
-      //     [`${type.modelName}s`]: record
-      //   });
-      // });
-      console.log(
-        'payload',
-        store.peekAll(type.modelName),
-        matchingStoreEntries
-      );
 
       return payload;
     });

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -191,18 +191,15 @@ export default class IndexController extends Controller.extend(
     Visible jobs are those that match the selected namespace and aren't children
     of periodic or parameterized jobs.
   */
-  @computed(
-    'model.jobs.@each.parent',
-    'model.jobs.[]',
-    'model.jobs.length',
-    'storedJobs.[]'
-  )
+  @computed('model.jobs.@each.parent', 'model.jobs.[]', 'storedJobs.[]')
   get visibleJobs() {
-    console.log('visibleJobs refire', this.model.jobs);
     if (!this.model || !this.model.jobs) return [];
-    // return this.model.jobs
     return this.store
       .peekAll('job')
+      .filter((job) => {
+        if (this.qpNamespace === '*') return true;
+        return job.get('namespace.id') === this.qpNamespace;
+      })
       .compact()
       .filter((job) => !job.isNew)
       .filter((job) => !job.get('parent.content'));
@@ -222,8 +219,6 @@ export default class IndexController extends Controller.extend(
       selectionDatacenter: datacenters,
       selectionPrefix: prefixes,
     } = this;
-
-    console.log('filtered jobs refire');
 
     // A job must match ALL filter facets, but it can match ANY selection within a facet
     // Always return early to prevent unnecessary facet predicates.
@@ -259,22 +254,8 @@ export default class IndexController extends Controller.extend(
   @alias('listSorted') listToSearch;
   @alias('listSearched') sortedJobs;
 
-  // @computed('listSearched')
-  // get sortedJobs() {
-  //   console.log('&&&& sortedJobs refire', this.listSeached, this.listToSearch);
-  //   // return this.listSeached;
-  //   return this.listToSearch;
-  // }
-
   get storedJobs() {
-    console.log('!!!!!!!!!!!!!!!!1storedJobs refire!!!');
     return this.store.peekAll('job');
-  }
-
-  @computed('sortedJobs.[]', 'sortedJobs.length')
-  get jobsFromStore() {
-    console.log('&&&&&&&& jobsFromStore refire');
-    return this.sortedJobs;
   }
 
   isShowingDeploymentDetails = false;

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -191,11 +191,18 @@ export default class IndexController extends Controller.extend(
     Visible jobs are those that match the selected namespace and aren't children
     of periodic or parameterized jobs.
   */
-  @computed('model.jobs.@each.parent', 'model.jobs.[]', 'model.jobs.length')
+  @computed(
+    'model.jobs.@each.parent',
+    'model.jobs.[]',
+    'model.jobs.length',
+    'storedJobs.[]'
+  )
   get visibleJobs() {
     console.log('visibleJobs refire', this.model.jobs);
     if (!this.model || !this.model.jobs) return [];
-    return this.model.jobs
+    // return this.model.jobs
+    return this.store
+      .peekAll('job')
       .compact()
       .filter((job) => !job.isNew)
       .filter((job) => !job.get('parent.content'));
@@ -251,6 +258,24 @@ export default class IndexController extends Controller.extend(
   @alias('filteredJobs') listToSort;
   @alias('listSorted') listToSearch;
   @alias('listSearched') sortedJobs;
+
+  // @computed('listSearched')
+  // get sortedJobs() {
+  //   console.log('&&&& sortedJobs refire', this.listSeached, this.listToSearch);
+  //   // return this.listSeached;
+  //   return this.listToSearch;
+  // }
+
+  get storedJobs() {
+    console.log('!!!!!!!!!!!!!!!!1storedJobs refire!!!');
+    return this.store.peekAll('job');
+  }
+
+  @computed('sortedJobs.[]', 'sortedJobs.length')
+  get jobsFromStore() {
+    console.log('&&&&&&&& jobsFromStore refire');
+    return this.sortedJobs;
+  }
 
   isShowingDeploymentDetails = false;
 

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -191,8 +191,9 @@ export default class IndexController extends Controller.extend(
     Visible jobs are those that match the selected namespace and aren't children
     of periodic or parameterized jobs.
   */
-  @computed('model.jobs.@each.parent')
+  @computed('model.jobs.@each.parent', 'model.jobs.[]', 'model.jobs.length')
   get visibleJobs() {
+    console.log('visibleJobs refire', this.model.jobs);
     if (!this.model || !this.model.jobs) return [];
     return this.model.jobs
       .compact()
@@ -214,6 +215,8 @@ export default class IndexController extends Controller.extend(
       selectionDatacenter: datacenters,
       selectionPrefix: prefixes,
     } = this;
+
+    console.log('filtered jobs refire');
 
     // A job must match ALL filter facets, but it can match ANY selection within a facet
     // Always return early to prevent unnecessary facet predicates.

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -191,7 +191,7 @@ export default class IndexController extends Controller.extend(
     Visible jobs are those that match the selected namespace and aren't children
     of periodic or parameterized jobs.
   */
-  @computed('model.jobs.@each.parent', 'model.jobs.[]', 'storedJobs.[]')
+  @computed('model.jobs.@each.parent', 'qpNamespace', 'store', 'storedJobs.[]')
   get visibleJobs() {
     if (!this.model || !this.model.jobs) return [];
     return this.store

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -30,7 +30,6 @@ export default class IndexRoute extends Route.extend(
 
   startWatchers(controller) {
     controller.set('namespacesWatch', this.watchNamespaces.perform());
-    console.log('QPN', controller.qpNamespace);
     controller.set(
       'modelWatch',
       this.watchJobs.perform({ namespace: controller.qpNamespace })

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -30,9 +30,10 @@ export default class IndexRoute extends Route.extend(
 
   startWatchers(controller) {
     controller.set('namespacesWatch', this.watchNamespaces.perform());
+    console.log('QPN', controller.qpNamespace);
     controller.set(
       'modelWatch',
-      this.watchJobs.perform({ namespace: controller.qpNamesapce })
+      this.watchJobs.perform({ namespace: controller.qpNamespace })
     );
   }
 

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -1,6 +1,4 @@
 {{page-title "Jobs"}}
-aaa{{this.modelWatch.value}}bbb{{this.modelWatch.state}}ccc{{this.storedJobs.length}}ddd
-{{log "MODELWATCH" this.modelWatch}}
 <section class="section">
   <div class="toolbar">
     <div class="toolbar-item">
@@ -105,9 +103,9 @@ aaa{{this.modelWatch.value}}bbb{{this.modelWatch.state}}ccc{{this.storedJobs.len
   </div>
   {{#if this.isForbidden}}
     <ForbiddenMessage />
-  {{else if this.jobsFromStore}}
+  {{else if this.sortedJobs}}
     <ListPagination
-      @source={{this.jobsFromStore}}
+      @source={{this.sortedJobs}}
       @size={{this.pageSize}}
       @page={{this.currentPage}}
       as |p|
@@ -156,11 +154,11 @@ aaa{{this.modelWatch.value}}bbb{{this.modelWatch.state}}ccc{{this.storedJobs.len
             –
             {{p.endsAt}}
             of
-            {{this.jobsFromStore.length}}
+            {{this.sortedJobs.length}}
             {{#if this.searchTerm}}
               <em>
                 (
-                {{dec this.jobsFromStore.length this.filteredJobs.length}}
+                {{dec this.sortedJobs.length this.filteredJobs.length}}
                 hidden by search term)
               </em>
             {{/if}}

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -1,4 +1,6 @@
 {{page-title "Jobs"}}
+aaa{{this.modelWatch.value}}bbb{{this.modelWatch.state}}ccc
+{{log "MODELWATCH" this.modelWatch}}
 <section class="section">
   <div class="toolbar">
     <div class="toolbar-item">

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -1,5 +1,5 @@
 {{page-title "Jobs"}}
-aaa{{this.modelWatch.value}}bbb{{this.modelWatch.state}}ccc
+aaa{{this.modelWatch.value}}bbb{{this.modelWatch.state}}ccc{{this.storedJobs.length}}ddd
 {{log "MODELWATCH" this.modelWatch}}
 <section class="section">
   <div class="toolbar">
@@ -105,9 +105,9 @@ aaa{{this.modelWatch.value}}bbb{{this.modelWatch.state}}ccc
   </div>
   {{#if this.isForbidden}}
     <ForbiddenMessage />
-  {{else if this.sortedJobs}}
+  {{else if this.jobsFromStore}}
     <ListPagination
-      @source={{this.sortedJobs}}
+      @source={{this.jobsFromStore}}
       @size={{this.pageSize}}
       @page={{this.currentPage}}
       as |p|
@@ -156,11 +156,11 @@ aaa{{this.modelWatch.value}}bbb{{this.modelWatch.state}}ccc
             –
             {{p.endsAt}}
             of
-            {{this.sortedJobs.length}}
+            {{this.jobsFromStore.length}}
             {{#if this.searchTerm}}
               <em>
                 (
-                {{dec this.sortedJobs.length this.filteredJobs.length}}
+                {{dec this.jobsFromStore.length this.filteredJobs.length}}
                 hidden by search term)
               </em>
             {{/if}}


### PR DESCRIPTION
Resolves #10555 

Looking for a review in spite of draft state, just to make sure I'm not way off-course.

Problem: Our watcher system's query method doesn't adequately delete or repopulate the store when jobs are started or stopped+purged.

This PR adds some logic to ensure that the query method adequately deletes a record of a purged entity, and disregards the route model once within the controller, opting to query against the live-updating Ember Data store instead.