### PR TITLE
agent: ensure rand package is seeded

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ var (
 )
 
 func init() {
-	seed.Init()
+	seed.MustInit()
 }
 
 func main() {


### PR DESCRIPTION
This PR uses `rand.MustInit` to ensure the Nomad agent initializes the Go
PRNG without issue, or prevents the agent from starting.
