### PR TITLE
variables: limit rekey eval to half the nack timeout

### DIFF
--- a/.changelog/15102.txt
+++ b/.changelog/15102.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+variables: Fixed a bug where a long-running rekey could hit the nack timeout
+```

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -1053,7 +1053,7 @@ func (c *CoreScheduler) rotateVariables(iter memdb.ResultIterator, eval *structs
 	//
 	// Instead, we'll rate limit RPC requests and have a timeout. If we still
 	// haven't finished the set by the timeout, emit a new eval.
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), c.srv.GetConfig().EvalNackTimeout/2)
 	defer cancel()
 	limiter := rate.NewLimiter(rate.Limit(100), 100)
 


### PR DESCRIPTION
In order to limit how much the rekey job can monopolize a scheduler worker, we limit how long it can run to 1min before stopping work and emitting a new eval. But this exactly matches the default nack timeout, so it'll fail the eval rather than getting a chance to emit a new one.

Set the timeout for the rekey eval to half the configured nack timeout.