### PR TITLE
eval delete: move batching of deletes into RPC handler and state

### DIFF
--- a/.changelog/15117.txt
+++ b/.changelog/15117.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Improved performance of eval delete with large filter sets
+```

--- a/api/evaluations.go
+++ b/api/evaluations.go
@@ -62,6 +62,16 @@ func (e *Evaluations) Delete(evalIDs []string, w *WriteOptions) (*WriteMeta, err
 	return wm, nil
 }
 
+// DeleteOpts is used to batch delete evaluations using a filter.
+func (e *Evaluations) DeleteOpts(req *EvalDeleteRequest, w *WriteOptions) (*EvalDeleteResponse, *WriteMeta, error) {
+	resp := &EvalDeleteResponse{}
+	wm, err := e.client.delete("/v1/evaluations", &req, resp, w)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resp, wm, nil
+}
+
 // Allocations is used to retrieve a set of allocations given
 // an evaluation ID.
 func (e *Evaluations) Allocations(evalID string, q *QueryOptions) ([]*AllocationListStub, *QueryMeta, error) {
@@ -140,7 +150,12 @@ type EvaluationStub struct {
 
 type EvalDeleteRequest struct {
 	EvalIDs []string
+	Filter  string
 	WriteRequest
+}
+
+type EvalDeleteResponse struct {
+	Count int
 }
 
 type EvalCountResponse struct {

--- a/command/agent/eval_endpoint_test.go
+++ b/command/agent/eval_endpoint_test.go
@@ -138,7 +138,7 @@ func TestHTTP_EvalsDelete(t *testing.T) {
 					// Make the request and check the response.
 					obj, err := s.Server.EvalsRequest(respW, req)
 					require.Equal(t,
-						CodedError(http.StatusBadRequest, "request does not include any evaluation IDs"), err)
+						CodedError(http.StatusBadRequest, "evals must be deleted by either ID or filter"), err)
 					require.Nil(t, obj)
 				})
 			},
@@ -169,7 +169,7 @@ func TestHTTP_EvalsDelete(t *testing.T) {
 					obj, err := s.Server.EvalsRequest(respW, req)
 					require.Equal(t,
 						CodedError(http.StatusBadRequest,
-							"request includes 8000 evaluations IDs, must be 7281 or fewer"), err)
+							"request includes 8000 evaluation IDs, must be 7281 or fewer"), err)
 					require.Nil(t, obj)
 				})
 			},
@@ -223,8 +223,10 @@ func TestHTTP_EvalsDelete(t *testing.T) {
 
 					// Make the request and check the response.
 					obj, err := s.Server.EvalsRequest(respW, req)
-					require.Nil(t, err)
-					require.Nil(t, obj)
+					require.NoError(t, err)
+					require.NotNil(t, obj)
+					deleteResp := obj.(structs.EvalDeleteResponse)
+					require.Equal(t, deleteResp.Count, 1)
 
 					// Ensure the eval is not found.
 					readEval, err := s.Agent.server.State().EvalByID(nil, mockEval.ID)

--- a/command/eval_delete.go
+++ b/command/eval_delete.go
@@ -57,7 +57,9 @@ Eval Delete Options:
   -filter
     Specifies an expression used to filter evaluations by for deletion. When
     using this flag, it is advisable to ensure the syntax is correct using the
-    eval list command first.
+    eval list command first. Note that deleting evals by filter is imprecise:
+    for sets of evals larger than a single raft log batch, evals can be inserted
+    behind the cursor and therefore be missed.
 
   -yes
     Bypass the confirmation prompt if an evaluation ID was not provided.

--- a/command/eval_delete.go
+++ b/command/eval_delete.go
@@ -294,28 +294,26 @@ func correctGrammar(word string, num int) string {
 
 func (e *EvalDeleteCommand) handleDeleteByFilter(filterExpr string) (int, error) {
 
-	// TODO: querying for millions of evals is very expensive... can we add a count RPC?
-
-	// evals, _, err := e.client.Evaluations().List(&api.QueryOptions{
-	// 	Filter: filterExpr,
-	// })
-	// if err != nil {
-	// 	return 1, err
-	// }
-	// evals := []string{}
-
 	// If the user did not wish to bypass the confirmation step, ask this now
 	// and handle the response.
-	// if !e.yes && !e.deleteByArg {
-	// 	code, deleteEvals := e.askQuestion(fmt.Sprintf(
-	// 		"Are you sure you want to delete %v evals? [y/N]",
-	// 		len(evals)), "Cancelling eval deletion")
-	// 	e.Ui.Output("")
+	if !e.yes && !e.deleteByArg {
 
-	// 	if !deleteEvals {
-	// 		return code, nil
-	// 	}
-	// }
+		resp, _, err := e.client.Evaluations().Count(&api.QueryOptions{
+			Filter: filterExpr,
+		})
+		if err != nil {
+			return 1, err
+		}
+
+		code, deleteEvals := e.askQuestion(fmt.Sprintf(
+			"Are you sure you want to delete %d evals? [y/N]",
+			resp.Count), "Cancelling eval deletion")
+		e.Ui.Output("")
+
+		if !deleteEvals {
+			return code, nil
+		}
+	}
 
 	resp, _, err := e.client.Evaluations().DeleteOpts(&api.EvalDeleteRequest{
 		Filter: filterExpr,

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -536,11 +536,11 @@ func (e *Eval) deleteEvalsByFilter(args *structs.EvalDeleteRequest) (int, uint64
 		return count, index, err
 	}
 
-	// Note: this snapshot will be stale as soon as we start deleting. For small
-	// sets this doesn't matter because we'll delete in a single raft request,
-	// but for large sets we don't want reset our pagination state. For the
-	// intended use case it's ok if we miss a handful of evals if they're
-	// inserted behind the paginator's cursor.
+// Note that deleting evals by filter is imprecise: For sets of evals larger
+// than a single batch eval inserts may occur behind the cursor and therefore
+// be missed. This imprecision is not considered to hurt this endpoint's
+// purpose of reducing pressure on servers during periods of heavy scheduling
+// activity.
 	snap, err := e.srv.State().Snapshot()
 	if err != nil {
 		return count, index, fmt.Errorf("failed to lookup state snapshot: %v", err)

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -536,11 +536,11 @@ func (e *Eval) deleteEvalsByFilter(args *structs.EvalDeleteRequest) (int, uint64
 		return count, index, err
 	}
 
-// Note that deleting evals by filter is imprecise: For sets of evals larger
-// than a single batch eval inserts may occur behind the cursor and therefore
-// be missed. This imprecision is not considered to hurt this endpoint's
-// purpose of reducing pressure on servers during periods of heavy scheduling
-// activity.
+	// Note that deleting evals by filter is imprecise: For sets of evals larger
+	// than a single batch eval inserts may occur behind the cursor and therefore
+	// be missed. This imprecision is not considered to hurt this endpoint's
+	// purpose of reducing pressure on servers during periods of heavy scheduling
+	// activity.
 	snap, err := e.srv.State().Snapshot()
 	if err != nil {
 		return count, index, fmt.Errorf("failed to lookup state snapshot: %v", err)

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -438,10 +438,29 @@ func (e *Eval) Delete(
 		return structs.ErrPermissionDenied
 	}
 
+	if args.Filter != "" && len(args.EvalIDs) > 0 {
+		return fmt.Errorf("evals cannot be deleted by both ID and filter")
+	}
+	if args.Filter == "" && len(args.EvalIDs) == 0 {
+		return fmt.Errorf("evals must be deleted by either ID or filter")
+	}
+
 	// The eval broker must be disabled otherwise Nomad's state will likely get
 	// wild in a very un-fun way.
 	if e.srv.evalBroker.Enabled() {
 		return errors.New("eval broker is enabled; eval broker must be paused to delete evals")
+	}
+
+	if args.Filter != "" {
+		count, index, err := e.deleteEvalsByFilter(args)
+		if err != nil {
+			return err
+		}
+
+		// Update the index and return.
+		reply.Index = index
+		reply.Count = count
+		return nil
 	}
 
 	// Grab the state snapshot, so we can look up relevant eval information.
@@ -450,6 +469,8 @@ func (e *Eval) Delete(
 		return fmt.Errorf("failed to lookup state snapshot: %v", err)
 	}
 	ws := memdb.NewWatchSet()
+
+	count := 0
 
 	// Iterate the evaluations and ensure they are safe to delete. It is
 	// possible passed evals are not safe to delete and would make Nomads state
@@ -471,6 +492,7 @@ func (e *Eval) Delete(
 		if !ok {
 			return fmt.Errorf("eval %s is not safe to delete", evalInfo.ID)
 		}
+		count++
 	}
 
 	// Generate the Raft request object using the reap request object. This
@@ -490,7 +512,95 @@ func (e *Eval) Delete(
 
 	// Update the index and return.
 	reply.Index = index
+	reply.Count = count
 	return nil
+}
+
+// deleteEvalsByFilter deletes evaluations in batches based on the filter. It
+// returns a count, the index, and any error
+func (e *Eval) deleteEvalsByFilter(args *structs.EvalDeleteRequest) (int, uint64, error) {
+	count := 0
+	index := uint64(0)
+
+	filter, err := bexpr.CreateEvaluator(args.Filter)
+	if err != nil {
+		return count, index, err
+	}
+
+	// Note: this snapshot will be stale as soon as we start deleting. For small
+	// sets this doesn't matter because we'll delete in a single raft request,
+	// but for large sets we don't want reset our pagination state. For the
+	// intended use case it's ok if we miss a handful of evals if they're
+	// inserted behind the paginator's cursor.
+	snap, err := e.srv.State().Snapshot()
+	if err != nil {
+		return count, index, fmt.Errorf("failed to lookup state snapshot: %v", err)
+	}
+
+	iter, err := snap.Evals(nil, state.SortDefault)
+	if err != nil {
+		return count, index, err
+	}
+
+	// We *can* send larger raft logs but rough benchmarks for deleting 1M evals
+	// show that a smaller page size strikes a balance between throughput and
+	// time we block the FSM apply for other operations
+	perPage := structs.MaxUUIDsPerWriteRequest / 10
+
+	raftReq := structs.EvalReapRequest{
+		Filter:        args.Filter,
+		PerPage:       int32(perPage),
+		UserInitiated: true,
+		WriteRequest:  args.WriteRequest,
+	}
+
+	// Note: Paginator is designed around fetching a single page for a single
+	// RPC call and finalizes its state after that page. So we're doing our own
+	// pagination here.
+	pageCount := 0
+	lastToken := ""
+
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		eval := raw.(*structs.Evaluation)
+		deleteOk, err := snap.EvalIsUserDeleteSafe(nil, eval)
+		if !deleteOk || err != nil {
+			continue
+		}
+		match, err := filter.Evaluate(eval)
+		if !match || err != nil {
+			continue
+		}
+		pageCount++
+		lastToken = eval.ID
+
+		if pageCount >= perPage {
+			raftReq.PerPage = int32(pageCount)
+			_, index, err = e.srv.raftApply(structs.EvalDeleteRequestType, &raftReq)
+			if err != nil {
+				return count, index, err
+			}
+			count += pageCount
+
+			pageCount = 0
+			raftReq.NextToken = lastToken
+		}
+	}
+
+	// send last batch if it's partial
+	if pageCount > 0 {
+		raftReq.PerPage = int32(pageCount)
+		_, index, err = e.srv.raftApply(structs.EvalDeleteRequestType, &raftReq)
+		if err != nil {
+			return count, index, err
+		}
+		count += pageCount
+	}
+
+	return count, index, nil
 }
 
 // List is used to get a list of the evaluations in the system

--- a/nomad/eval_endpoint_test.go
+++ b/nomad/eval_endpoint_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-set"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/ci"
@@ -862,6 +863,94 @@ func TestEvalEndpoint_Delete(t *testing.T) {
 		var resp structs.EvalDeleteResponse
 		err := msgpackrpc.CallWithCodec(codec, structs.EvalDeleteRPCMethod, get, &resp)
 		must.EqError(t, err, structs.ErrPermissionDenied.Error())
+	})
+
+	t.Run("successful delete by filter", func(t *testing.T) {
+
+		testServer, rootToken, cleanup := setup(t)
+		defer cleanup()
+		codec := rpcClient(t, testServer)
+
+		// Ensure broker is disabled
+		setBrokerEnabled(t, testServer, false)
+
+		evalCount := 10000
+		index := uint64(100)
+
+		store := testServer.fsm.State()
+
+		// Create a large set of pending evaluations
+
+		evals := []*structs.Evaluation{}
+		for i := 0; i < evalCount; i++ {
+			mockEval := mock.Eval()
+			evals = append(evals, mockEval)
+		}
+		must.NoError(t, store.UpsertEvals(
+			structs.MsgTypeTestSetup, index, evals))
+
+		// Create some evaluations we don't want to delete
+
+		evalsToKeep := []*structs.Evaluation{}
+		for i := 0; i < 3; i++ {
+			mockEval := mock.Eval()
+			mockEval.JobID = "keepme"
+			evalsToKeep = append(evalsToKeep, mockEval)
+		}
+		index++
+		must.NoError(t, store.UpsertEvals(
+			structs.MsgTypeTestSetup, index, evalsToKeep))
+
+		// Create a job with running allocs and evaluations those allocs reference
+
+		job := mock.Job()
+		job.ID = "notsafetodelete"
+		job.Status = structs.JobStatusRunning
+		index++
+		must.NoError(t, store.UpsertJob(structs.MsgTypeTestSetup, index, job))
+
+		evalsNotSafeToDelete := []*structs.Evaluation{}
+		for i := 0; i < 3; i++ {
+			mockEval := mock.Eval()
+			mockEval.JobID = job.ID
+			evalsNotSafeToDelete = append(evalsNotSafeToDelete, mockEval)
+		}
+		index++
+		must.NoError(t, store.UpsertEvals(
+			structs.MsgTypeTestSetup, index, evalsNotSafeToDelete))
+
+		allocs := []*structs.Allocation{}
+		for i := 0; i < 3; i++ {
+			alloc := mock.Alloc()
+			alloc.ClientStatus = structs.AllocClientStatusRunning
+			alloc.EvalID = evalsNotSafeToDelete[i].ID
+			allocs = append(allocs, alloc)
+		}
+		index++
+		must.NoError(t, store.UpsertAllocs(structs.MsgTypeTestSetup, index, allocs))
+
+		// Delete all the unwanted evals
+
+		get := &structs.EvalDeleteRequest{
+			Filter:       "JobID != \"keepme\"",
+			WriteRequest: structs.WriteRequest{AuthToken: rootToken.SecretID, Region: "global"},
+		}
+		var resp structs.EvalDeleteResponse
+		must.NoError(t, msgpackrpc.CallWithCodec(codec, structs.EvalDeleteRPCMethod, get, &resp))
+		must.Eq(t, resp.Count, evalCount)
+
+		// Assert we didn't delete the filtered evals
+		gotKeptEvals, err := store.EvalsByJob(nil, job.Namespace, "keepme")
+		must.NoError(t, err)
+		must.Len(t, 3, gotKeptEvals)
+		must.Eq(t, set.From(evalsToKeep), set.From(gotKeptEvals))
+
+		// Assert we didn't delete the evals that were not safe to delete
+		gotNotSafeEvals, err := store.EvalsByJob(nil, job.Namespace, "notsafetodelete")
+		must.NoError(t, err)
+		must.Len(t, 3, gotNotSafeEvals)
+		must.Eq(t, set.From(evalsNotSafeToDelete), set.From(gotNotSafeEvals))
+
 	})
 
 }

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -803,6 +803,14 @@ func (n *nomadFSM) applyDeleteEval(buf []byte, index uint64) interface{} {
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
 
+	if req.Filter != "" {
+		if err := n.state.DeleteEvalsByFilter(index, req.Filter, req.NextToken, req.PerPage); err != nil {
+			n.logger.Error("DeleteEvalsByFilter failed", "error", err)
+			return err
+		}
+		return nil
+	}
+
 	if err := n.state.DeleteEval(index, req.Evals, req.Allocs, req.UserInitiated); err != nil {
 		n.logger.Error("DeleteEval failed", "error", err)
 		return err

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3172,7 +3172,6 @@ func (s *StateStore) DeleteEvalsByFilter(index uint64, filterExpr string, pageTo
 	// Note: Paginator imports this package for testing so we can't just use
 	// Paginator
 	pageCount := int32(0)
-	pageTokenFound := false
 
 	for {
 		if pageCount >= perPage {
@@ -3183,10 +3182,8 @@ func (s *StateStore) DeleteEvalsByFilter(index uint64, filterExpr string, pageTo
 			break
 		}
 		eval := raw.(*structs.Evaluation)
-		if !pageTokenFound {
-			if eval.ID < pageToken {
-				continue
-			}
+		if eval.ID < pageToken {
+			continue
 		}
 
 		deleteOk, err := s.EvalIsUserDeleteSafe(nil, eval)

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-bexpr"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
@@ -3141,6 +3142,69 @@ func (s *StateStore) updateEvalModifyIndex(txn *txn, index uint64, evalID string
 		return fmt.Errorf("index update failed: %v", err)
 	}
 	return nil
+}
+
+// DeleteEvalsByFilter is used to delete all evals that are both safe to delete
+// and match a filter.
+func (s *StateStore) DeleteEvalsByFilter(index uint64, filterExpr string, pageToken string, perPage int32) error {
+	txn := s.db.WriteTxn(index)
+	defer txn.Abort()
+
+	// These are always user-initiated, so ensure the eval broker is paused.
+	_, schedConfig, err := s.schedulerConfigTxn(txn)
+	if err != nil {
+		return err
+	}
+	if schedConfig == nil || !schedConfig.PauseEvalBroker {
+		return errors.New("eval broker is enabled; eval broker must be paused to delete evals")
+	}
+
+	filter, err := bexpr.CreateEvaluator(filterExpr)
+	if err != nil {
+		return err
+	}
+
+	iter, err := s.Evals(nil, SortDefault)
+	if err != nil {
+		return fmt.Errorf("failed to lookup evals: %v", err)
+	}
+
+	// Note: Paginator imports this package for testing so we can't just use
+	// Paginator
+	pageCount := int32(0)
+	pageTokenFound := false
+
+	for {
+		if pageCount >= perPage {
+			break
+		}
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		eval := raw.(*structs.Evaluation)
+		if !pageTokenFound {
+			if eval.ID < pageToken {
+				continue
+			}
+		}
+
+		deleteOk, err := s.EvalIsUserDeleteSafe(nil, eval)
+		if !deleteOk || err != nil {
+			continue
+		}
+		match, err := filter.Evaluate(eval)
+		if !match || err != nil {
+			continue
+		}
+		if err := txn.Delete("evals", eval); err != nil {
+			return fmt.Errorf("eval delete failed: %v", err)
+		}
+		pageCount++
+	}
+
+	err = txn.Commit()
+	return err
 }
 
 // EvalIsUserDeleteSafe ensures an evaluation is safe to delete based on its

--- a/nomad/structs/eval.go
+++ b/nomad/structs/eval.go
@@ -14,11 +14,17 @@ const (
 // not be greater than MaxEvalIDsPerDeleteRequest.
 type EvalDeleteRequest struct {
 	EvalIDs []string
+
+	// Filter specifies the go-bexpr filter expression to be used for deleting a
+	// set of evaluations that matches the filter
+	Filter string
+
 	WriteRequest
 }
 
 // EvalDeleteResponse is the response object when one or more evaluation are
 // deleted manually by an operator.
 type EvalDeleteResponse struct {
+	Count int // how many Evaluations were safe to delete and/or matched the filter
 	WriteMeta
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -847,8 +847,14 @@ type EvalUpdateRequest struct {
 // Eval.Delete use the same Raft message when performing deletes so we do not
 // need more Raft message types.
 type EvalReapRequest struct {
-	Evals  []string
-	Allocs []string
+	Evals  []string // slice of Evaluation IDs
+	Allocs []string // slice of Allocation IDs
+
+	// Filter specifies the go-bexpr filter expression to be used for
+	// filtering the data prior to returning a response
+	Filter    string
+	PerPage   int32
+	NextToken string
 
 	// UserInitiated tracks whether this reap request is the result of an
 	// operator request. If this is true, the FSM needs to ensure the eval

--- a/website/content/docs/commands/eval/delete.mdx
+++ b/website/content/docs/commands/eval/delete.mdx
@@ -36,7 +36,10 @@ When ACLs are enabled, this command requires a `management` token.
 ## Delete Options
 
 - `-filter`: Specifies an expression used to filter evaluations by for
-  deletion.
+  deletion. When using this flag, it is advisable to ensure the syntax is
+  correct using the eval list command first. Note that deleting evals by filter
+  is imprecise: for sets of evals larger than a single raft log batch, evals can
+  be inserted behind the cursor and therefore be missed.
 
 - `-yes`: Bypass the confirmation prompt if an evaluation ID was not provided.
 

--- a/website/content/docs/commands/eval/delete.mdx
+++ b/website/content/docs/commands/eval/delete.mdx
@@ -53,13 +53,6 @@ Delete all evaluations with status `pending` for the `example` job:
 
 ```shell-session
 $ nomad eval delete -filter='Stauts == "pending" and JobID == "example"'
-Do you want to list evals (3) before deletion? [y/N] y
-
-ID        Priority  Triggered By  Job ID   Namespace   Node ID   Status   Placement Failures
-cef92121  50        job-register  example  default     <none>    pending  false
-1c905ca0  50        job-register  example  default     <none>    pending  false
-b9e77692  50        job-register  example  default     <none>    pending  false
-
 Are you sure you want to delete 3 evals? [y/N] y
 
 Successfuly deleted 3 evaluations


### PR DESCRIPTION
During unusual outage recovery scenarios on large clusters, a backlog of millions of evaluatons can appear. In these cases, the `eval delete` command can put excessive load on the cluster by listing large sets of evals to extract the IDs and then sending larges batches of IDs. Although the command's batch size was carefully tuned, we still need to be JSON deserialize, reserialize to messagepack, send the log entries through raft, and get the FSM applied.

To improve performance of this recovery case, move the batching process into the RPC handler and the state store. The design here is a little weird, so let's look at the failed options first:

* A naive solution here would be to just send the filter as the raft request and let the FSM apply delete the whole set in a single operation. Benchmarking with 1M evals on a 3 node cluster demonstrated this can block the FSM apply for several minutes, which puts the cluster at risk if there's a leadership failover (the barrier write can't be made while this apply is in-flight).

* A less naive but still bad solution would be to have the RPC handler filter and paginate, and then hand a list of IDs to the existing raft log entry. Benchmarks showed this blocked the FSM apply for 20-30s at a time and took roughly an hour to complete.

Instead, we're filtering and paginating in the RPC handler to find a page token, and then passing both the filter and page token in the raft log. The FSM apply recreates the paginator using the filter and page token to get roughly the same page of evaluations, which it then deletes. The pagination process is fairly cheap (only about 5% of the total FSM apply time), so counter-intuitively this rework of the pagination ends up being much faster. A benchmark of 1M evaluations showed this blocked the FSM apply for 20-30ms at a time (typical for normal operations) and completes in less than 4 minutes.

Note that, as with the existing design, this delete is not consistent: a new evaluation inserted "behind" the cursor of the pagination will fail to be deleted.