### PR TITLE
WI: set identity to client secret if missing

### DIFF
--- a/.changelog/15121.txt
+++ b/.changelog/15121.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+wi: Fixed a bug where clients running pre-1.4.0 allocations would erase the token used to query service registrations after upgrade
+```

--- a/client/allocrunner/taskrunner/identity_hook.go
+++ b/client/allocrunner/taskrunner/identity_hook.go
@@ -36,7 +36,9 @@ func (h *identityHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 	defer h.lock.Unlock()
 
 	token := h.tr.alloc.SignedIdentities[h.taskName]
-	h.tr.setNomadToken(token)
+	if token != "" {
+		h.tr.setNomadToken(token)
+	}
 	return nil
 }
 
@@ -45,6 +47,8 @@ func (h *identityHook) Update(_ context.Context, req *interfaces.TaskUpdateReque
 	defer h.lock.Unlock()
 
 	token := h.tr.alloc.SignedIdentities[h.taskName]
-	h.tr.setNomadToken(token)
+	if token != "" {
+		h.tr.setNomadToken(token)
+	}
 	return nil
 }

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -424,6 +424,10 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 		return nil, err
 	}
 
+	// Use the client secret only as the initial value; the identity hook will
+	// update this with a workload identity if one is available
+	tr.setNomadToken(config.ClientConfig.Node.SecretID)
+
 	// Initialize the runners hooks. Must come after initDriver so hooks
 	// can use tr.driverCapabilities
 	tr.initHooks()


### PR DESCRIPTION
For #15115

Allocations created before 1.4.0 will not have a workload identity token. When the client running these allocs is upgraded to 1.4.x, the identity hook will run and replace the node secret ID token used previously with an empty string. This causes service discovery queries to fail.

Fallback to the node's secret ID when the allocation doesn't have a signed identity. Note that pre-1.4.0 allocations won't have templates that read Variables, so there's no threat that this new node ID secret will be able to read data that the allocation shouldn't have access to.

I've smoke-tested this by creating a build of Nomad that doesn't sign identities in the plan applier, and verified that we can query service registrations as expected now.