### PR TITLE
Fix s3 example URLs in the artifacts docs

### DIFF
--- a/website/content/docs/job-specification/artifact.mdx
+++ b/website/content/docs/job-specification/artifact.mdx
@@ -210,7 +210,7 @@ This example uses path-based notation on a publicly-accessible bucket:
 
 ```hcl
 artifact {
-  source = "my-bucket-example.s3-us-west-2.amazonaws.com/my_app.tar.gz"
+  source = "s3://my-bucket-example.s3-us-west-2.amazonaws.com/my_app.tar.gz"
 }
 ```
 
@@ -240,7 +240,7 @@ Alternatively you can use virtual hosted style:
 
 ```hcl
 artifact {
-  source = "my-bucket-example.s3-eu-west-1.amazonaws.com/my_app.tar.gz"
+  source = "s3://my-bucket-example.s3-eu-west-1.amazonaws.com/my_app.tar.gz"
 }
 ```
 

--- a/website/content/docs/job-specification/artifact.mdx
+++ b/website/content/docs/job-specification/artifact.mdx
@@ -210,7 +210,7 @@ This example uses path-based notation on a publicly-accessible bucket:
 
 ```hcl
 artifact {
-  source = "https://my-bucket-example.s3-us-west-2.amazonaws.com/my_app.tar.gz"
+  source = "my-bucket-example.s3-us-west-2.amazonaws.com/my_app.tar.gz"
 }
 ```
 
@@ -240,7 +240,7 @@ Alternatively you can use virtual hosted style:
 
 ```hcl
 artifact {
-  source = "https://my-bucket-example.s3-eu-west-1.amazonaws.com/my_app.tar.gz"
+  source = "my-bucket-example.s3-eu-west-1.amazonaws.com/my_app.tar.gz"
 }
 ```
 


### PR DESCRIPTION
Unfortunately, s3 urls prefixed with https:// do _NOT_ work with the underlying go-getter library. As such, this fixes the examples so that they are working examples that won't cause problems for people reading the docs. 

This is a known limitation of the go-getter lib since at least 2016 per https://github.com/hashicorp/nomad/issues/1113

I've also put up a PR with the underlying go-getter lib to fix their docs as well: https://github.com/hashicorp/go-getter/pull/394