### PR TITLE
fix: batchFirstFingerprints does not update device on node after v1.3.5

### DIFF
--- a/.changelog/15125.txt
+++ b/.changelog/15125.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+device: Fixed a bug where device plugins would not fingerprint on startup
+```

--- a/client/node_updater.go
+++ b/client/node_updater.go
@@ -76,6 +76,7 @@ SEND_BATCH:
 	var devicesChanged bool
 	c.batchNodeUpdates.batchDevicesUpdates(func(devices []*structs.NodeDeviceResource) {
 		if c.updateNodeFromDevicesLocked(devices) {
+			newConfig.Node.NodeResources.Devices = devices
 			devicesChanged = true
 		}
 	})


### PR DESCRIPTION
Fixes #14888

Hi, thanks for this awesome project. Recently when I use nomad with the plugin `nomad-device-nvidia`, I found that the plugin did not work well, then I found [this issue](https://github.com/hashicorp/nomad/issues/14888) reporting the same problem. By researching the code, I found that the Devices was not successfully updated in batchFirstFingerprints, maybe I try help fix it by this PR.

