### PR TITLE
Ember patched for security release

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -110,7 +110,7 @@
     "ember-resolver": "^8.0.3",
     "ember-responsive": "^4.0.2",
     "ember-sinon": "^5.0.0",
-    "ember-source": "~3.28.8",
+    "ember-source": "~3.28.10",
     "ember-stargate": "^0.4.1",
     "ember-statecharts": "^0.13.2",
     "ember-template-lint": "^3.15.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -10372,10 +10372,10 @@ ember-source-channel-url@^3.0.0:
   dependencies:
     node-fetch "^2.6.0"
 
-ember-source@~3.28.8:
-  version "3.28.8"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.28.8.tgz#c58fd4a1538d6c4b9aebe76c764cabf5396c64d9"
-  integrity sha512-hA15oYzbRdi9983HIemeVzzX2iLcMmSPp6akUiMQhFZYWPrKksbPyLrO6YpZ4hNM8yBjQSDXEkZ1V3yxBRKjUA==
+ember-source@~3.28.10:
+  version "3.28.10"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.28.10.tgz#f4be7e2852d421a558f686505748f4c88f6d6ae6"
+  integrity sha512-TH8ug2rRUq6pLwqjciwvnuF8GDKBXNW2v5mvDkkf+k5S84XVHPjn3K0q2uGaR2W/mCDYg+mGmqu/PIGy0STx9Q==
   dependencies:
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/plugin-transform-block-scoping" "^7.8.3"


### PR DESCRIPTION
Updated to upgrade per https://blog.emberjs.com/ember-4-8-1-released/

Note: Although Nomad is not susceptible to prototype pollution as the Ember upgrade seeks to fix, we're including this upgrade now to keep up with Ember security updates.