### PR TITLE
Add missing timer reset

### DIFF
--- a/.changelog/15134.txt
+++ b/.changelog/15134.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cleanup: fixed missing timer.Reset for plan queue stat emitter
+```

--- a/nomad/plan_queue.go
+++ b/nomad/plan_queue.go
@@ -201,6 +201,8 @@ func (q *PlanQueue) EmitStats(period time.Duration, stopCh <-chan struct{}) {
 	defer stop()
 
 	for {
+		timer.Reset(period)
+
 		select {
 		case <-timer.C:
 			stats := q.Stats()


### PR DESCRIPTION
In applying the fixes in #11983, a timer.Reset was missed for the Plan Queue's EmitStats function.

Fixes #15128 