### PR TITLE
e2e: explicitly wait on task status in chroot download exec test

### DIFF
--- a/e2e/isolation/chroot_test.go
+++ b/e2e/isolation/chroot_test.go
@@ -95,6 +95,17 @@ func testDownloadChrootExec(t *testing.T) {
 	// wait for allocation stopped
 	e2eutil.WaitForAllocsStopped(t, nomad, []string{allocID})
 
+	allocStatuses, err := e2eutil.AllocStatuses(jobID, "")
+	must.NoError(t, err)
+	t.Log("DEBUG", "job_id", jobID, "allocStatuses", allocStatuses)
+
+	allocEvents, err := e2eutil.AllocTaskEventsForJob(jobID, "")
+	must.NoError(t, err)
+	t.Log("DEBUG", "job_id", jobID, "allocEvents", allocEvents)
+
+	// wait for task complete (is the alloc stopped state not enough??)
+	e2eutil.WaitForAllocTaskComplete(t, nomad, allocID, "run-script")
+
 	// assert log contents
 	logs, err := e2eutil.AllocTaskLogs(allocID, "run-script", e2eutil.LogsStdOut)
 	must.NoError(t, err)


### PR DESCRIPTION
Also add some debug log lines for this test, because it doesn't make sense
for the allocation to be complete yet a task in the allocation to be not
started yet, which is what the test failures are implying.

Adds `WaitForAllocTaskComplete` for convenience. 