### PR TITLE
[ui] Remove animation from task logs sidebar

### DIFF
--- a/.changelog/15146.txt
+++ b/.changelog/15146.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed a bug where the task log sidebar would close and re-open if the parent job state changed
+```

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -58,10 +58,6 @@ $subNavOffset: 49px;
 }
 
 .task-context-sidebar {
-  animation-name: slideFromRight;
-  animation-duration: 150ms;
-  animation-fill-mode: both;
-
   header {
     display: grid;
     justify-content: left;
@@ -120,14 +116,5 @@ $subNavOffset: 49px;
       100vh - $sidebarTopOffset - $sidebarInnerPadding - $sidebarHeaderOffset -
         $cliHeaderOffset
     );
-  }
-}
-
-@keyframes slideFromRight {
-  from {
-    transform: translateX(100%);
-  }
-  to {
-    transform: translateX(0%);
   }
 }


### PR DESCRIPTION
Resolves #15113 

Context: While our other sidebar portals (Evaluations, Services) are parent-contextual ("expand info on this already-existing child of my route"), Task logs are different: they fetch out-of-context information (logs for a task) from several different places (including a client index, or a job index).

Because of this:
- We opted to make the sidebars conditional elements within each of the `<TaskSubRow>` components, conditional upon that row being selected (having "View Logs" clicked)
- This means that the animation treatment was different for each; instead of depending on an "open" status, we always animated it in/out when it showed up in the DOM

This presents a problem: because the context can change (ie: job stops, client stops), the task log context also changes and gets "repainted" in the DOM. This caused the sidebar to "jitter" and fire its animation again as if it were a brand new element that needed to close and re-open again.

There is another way to solve this, involving moving the portal architecture for this to the application-level template (the html equivalent of global scope), but I've opted not to do this for maintainability reasons.

As such: hasta la vista to the sidebar animation. It now just pops open or closed upon clicking "View Logs"

![image](https://user-images.githubusercontent.com/713991/199999182-24b1878d-56c2-4e9c-8f75-a2fe09d994e0.png)
