### PR TITLE
API for `Eval.Count`

### DIFF
--- a/.changelog/15147.txt
+++ b/.changelog/15147.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Added an API for counting evaluations that match a filter
+```

--- a/api/evaluations.go
+++ b/api/evaluations.go
@@ -30,6 +30,16 @@ func (e *Evaluations) PrefixList(prefix string) ([]*Evaluation, *QueryMeta, erro
 	return e.List(&QueryOptions{Prefix: prefix})
 }
 
+// Count is used to get a count of evaluations.
+func (e *Evaluations) Count(q *QueryOptions) (*EvalCountResponse, *QueryMeta, error) {
+	var resp *EvalCountResponse
+	qm, err := e.client.query("/v1/evaluations/count", &resp, q)
+	if err != nil {
+		return resp, nil, err
+	}
+	return resp, qm, nil
+}
+
 // Info is used to query a single evaluation by its ID.
 func (e *Evaluations) Info(evalID string, q *QueryOptions) (*Evaluation, *QueryMeta, error) {
 	var resp Evaluation
@@ -131,6 +141,11 @@ type EvaluationStub struct {
 type EvalDeleteRequest struct {
 	EvalIDs []string
 	WriteRequest
+}
+
+type EvalCountResponse struct {
+	Count int
+	QueryMeta
 }
 
 // EvalIndexSort is a wrapper to sort evaluations by CreateIndex.

--- a/command/agent/eval_endpoint.go
+++ b/command/agent/eval_endpoint.go
@@ -138,3 +138,22 @@ func (s *HTTPServer) evalQuery(resp http.ResponseWriter, req *http.Request, eval
 	}
 	return out.Eval, nil
 }
+
+func (s *HTTPServer) EvalsCountRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if req.Method != http.MethodGet {
+		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
+	}
+
+	args := structs.EvalCountRequest{}
+	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
+		return nil, nil
+	}
+
+	var out structs.EvalCountResponse
+	if err := s.agent.RPC("Eval.Count", &args, &out); err != nil {
+		return nil, err
+	}
+
+	setMeta(resp, &out.QueryMeta)
+	return &out, nil
+}

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -359,6 +359,7 @@ func (s HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/allocation/", s.wrap(s.AllocSpecificRequest))
 
 	s.mux.HandleFunc("/v1/evaluations", s.wrap(s.EvalsRequest))
+	s.mux.HandleFunc("/v1/evaluations/count", s.wrap(s.EvalsCountRequest))
 	s.mux.HandleFunc("/v1/evaluation/", s.wrap(s.EvalSpecificRequest))
 
 	s.mux.HandleFunc("/v1/deployments", s.wrap(s.DeploymentsRequest))

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -899,6 +899,11 @@ func (req *EvalListRequest) ShouldBeFiltered(e *Evaluation) bool {
 	return false
 }
 
+// EvalCountRequest is used to count evaluations
+type EvalCountRequest struct {
+	QueryOptions
+}
+
 // PlanRequest is used to submit an allocation plan to the leader
 type PlanRequest struct {
 	Plan *Plan
@@ -1596,6 +1601,12 @@ type DeploymentListResponse struct {
 // EvalListResponse is used for a list request
 type EvalListResponse struct {
 	Evaluations []*Evaluation
+	QueryMeta
+}
+
+// EvalCountResponse is used for a count request
+type EvalCountResponse struct {
+	Count int
 	QueryMeta
 }
 

--- a/website/content/api-docs/evaluations.mdx
+++ b/website/content/api-docs/evaluations.mdx
@@ -382,4 +382,65 @@ $ curl \
 ]
 ```
 
+## Count Evaluations
+
+This endpoint counts evaluations. Note that Nomad's state store architecture
+makes calculating this count unexpectedly expensive (similar in cost to the List
+API), and this API was designed for use during recovery operations with the
+`nomad eval delete` command. It is not recommended to use this API for
+monitoring. The `nomad.nomad.broker.*`  metrics are better for that use
+case. See the [metrics reference][] for details.
+
+
+| Method | Path                    | Produces           |
+|--------|-------------------------|--------------------|
+| `GET`  | `/v1/evaluations/count` | `application/json` |
+
+The table below shows this endpoint's support for
+[blocking queries](/api-docs#blocking-queries) and
+[required ACLs](/api-docs#acls).
+
+| Blocking Queries | ACL Required         |
+| ---------------- | -------------------- |
+| `YES`            | `namespace:read-job` |
+
+### Parameters
+
+- `prefix` `(string: "")`- Specifies a string to filter evaluations based on an
+  ID prefix. Because the value is decoded to bytes, the prefix must have an even
+  number of hexadecimal characters (0-9a-f). This is specified as a query string
+  parameter and is used before any `filter` expression is applied.
+
+- `filter` `(string: "")` - Specifies the [expression](/api-docs#filtering) used
+  to filter the results.
+
+- `namespace` `(string: "default")` - Specifies the target namespace.
+  Specifying `*` will return all evaluations across all authorized namespaces.
+  This parameter is used before any `filter` expression is applied.
+
+### Sample Request
+
+```shell-session
+$ curl \
+    https://localhost:4646/v1/evaluations/count
+```
+
+```shell-session
+$ curl \
+    https://localhost:4646/v1/evaluations/count?prefix=25ba81
+```
+
+### Sample Response
+
+```json
+{
+  "Count": 36
+  "Index": 133,
+  "KnownLeader": true,
+  "LastContact": 0,
+  "NextToken": ""
+}
+```
+
 [update_scheduler_configuration]: /api-docs/operator/scheduler#update-scheduler-configuration
+[metrics reference]: /docs/operations/metrics-reference


### PR DESCRIPTION
Add a new `Eval.Count` RPC and associated HTTP API endpoints. This API is designed to support interactive use in the `nomad eval delete` command to get a count of evals expected to be deleted before doing so. (ref https://github.com/hashicorp/nomad/pull/15117)

The state store operations to do this sort of thing are somewhat expensive, but it's cheaper than serializing a big list of evals to JSON. Note that although it seems like this could be done as an extra parameter and response field on `Eval.List`, having it as its own endpoint avoids having to change the response body shape and lets us avoid handling the legacy filter params supported by `Eval.List`.