### PR TITLE
Fix goroutine leakage

### DIFF
--- a/.changelog/15180.txt
+++ b/.changelog/15180.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+drivers: Fixed a bug where one goroutine was leaked per task
+```

--- a/plugins/drivers/client.go
+++ b/plugins/drivers/client.go
@@ -187,7 +187,8 @@ func (d *driverPluginClient) handleWaitTask(ctx context.Context, id string, ch c
 	}
 
 	// Join the passed context and the shutdown context
-	joinedCtx, _ := joincontext.Join(ctx, d.doneCtx)
+	joinedCtx, joinedCtxCancel := joincontext.Join(ctx, d.doneCtx)
+	defer joinedCtxCancel()
 
 	resp, err := d.client.WaitTask(joinedCtx, req)
 	if err != nil {


### PR DESCRIPTION
Please see https://github.com/hashicorp/nomad/issues/15179 for a more detailed explanation. The call to `joincontext.Join` generates a `goroutine` which must be garbage collected (which means the context cleanup).