### PR TITLE
acl: sso auth method schema and store functions

### DIFF
--- a/.changelog/15191.txt
+++ b/.changelog/15191.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl: Added SSO authentication schema and state store functions
+```

--- a/helper/raftutil/msgtypes.go
+++ b/helper/raftutil/msgtypes.go
@@ -59,6 +59,8 @@ var msgTypeNames = map[structs.MessageType]string{
 	structs.RootKeyMetaDeleteRequestType:                 "RootKeyMetaDeleteRequestType",
 	structs.ACLRolesUpsertRequestType:                    "ACLRolesUpsertRequestType",
 	structs.ACLRolesDeleteByIDRequestType:                "ACLRolesDeleteByIDRequestType",
+	structs.ACLAuthMethodsUpsertRequestType:              "ACLAuthMethodsUpsertRequestType",
+	structs.ACLAuthMethodsDeleteRequestType:              "ACLAuthMethodsDeleteRequestType",
 	structs.NamespaceUpsertRequestType:                   "NamespaceUpsertRequestType",
 	structs.NamespaceDeleteRequestType:                   "NamespaceDeleteRequestType",
 }

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -59,6 +59,7 @@ const (
 	VariablesQuotaSnapshot               SnapshotType = 23
 	RootKeyMetaSnapshot                  SnapshotType = 24
 	ACLRoleSnapshot                      SnapshotType = 25
+	ACLAuthMethodSnapshot                SnapshotType = 26
 
 	// Namespace appliers were moved from enterprise and therefore start at 64
 	NamespaceSnapshot SnapshotType = 64
@@ -1767,6 +1768,17 @@ func (n *nomadFSM) restoreImpl(old io.ReadCloser, filter *FSMFilter) error {
 			if err := restore.ACLRoleRestore(aclRole); err != nil {
 				return err
 			}
+		case ACLAuthMethodSnapshot:
+			authMethod := new(structs.ACLAuthMethod)
+
+			if err := dec.Decode(authMethod); err != nil {
+				return err
+			}
+
+			// Perform the restoration.
+			if err := restore.ACLAuthMethodRestore(authMethod); err != nil {
+				return err
+			}
 
 		default:
 			// Check if this is an enterprise only object being restored
@@ -2259,6 +2271,10 @@ func (s *nomadSnapshot) Persist(sink raft.SnapshotSink) error {
 		return err
 	}
 	if err := s.persistACLRoles(sink, encoder); err != nil {
+		sink.Cancel()
+		return err
+	}
+	if err := s.persistACLAuthMethods(sink, encoder); err != nil {
 		sink.Cancel()
 		return err
 	}
@@ -2909,6 +2925,30 @@ func (s *nomadSnapshot) persistACLRoles(sink raft.SnapshotSink,
 			// Write out an ACL role snapshot.
 			sink.Write([]byte{byte(ACLRoleSnapshot)})
 			if err := encoder.Encode(role); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func (s *nomadSnapshot) persistACLAuthMethods(sink raft.SnapshotSink,
+	encoder *codec.Encoder) error {
+
+	// Get all the ACL Auth methods.
+	ws := memdb.NewWatchSet()
+	aclAuthMethodsIter, err := s.snap.GetACLAuthMethods(ws)
+	if err != nil {
+		return err
+	}
+
+	for {
+		for raw := aclAuthMethodsIter.Next(); raw != nil; raw = aclAuthMethodsIter.Next() {
+			method := raw.(*structs.ACLAuthMethod)
+
+			// write the snapshot
+			sink.Write([]byte{byte(ACLAuthMethodSnapshot)})
+			if err := encoder.Encode(method); err != nil {
 				return err
 			}
 		}

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -2915,21 +2915,19 @@ func (s *nomadSnapshot) persistACLRoles(sink raft.SnapshotSink,
 		return err
 	}
 
-	for {
-		// Get the next item.
-		for raw := aclRolesIter.Next(); raw != nil; raw = aclRolesIter.Next() {
+	// Get the next item.
+	for raw := aclRolesIter.Next(); raw != nil; raw = aclRolesIter.Next() {
 
-			// Prepare the request struct.
-			role := raw.(*structs.ACLRole)
+		// Prepare the request struct.
+		role := raw.(*structs.ACLRole)
 
-			// Write out an ACL role snapshot.
-			sink.Write([]byte{byte(ACLRoleSnapshot)})
-			if err := encoder.Encode(role); err != nil {
-				return err
-			}
+		// Write out an ACL role snapshot.
+		sink.Write([]byte{byte(ACLRoleSnapshot)})
+		if err := encoder.Encode(role); err != nil {
+			return err
 		}
-		return nil
 	}
+	return nil
 }
 
 func (s *nomadSnapshot) persistACLAuthMethods(sink raft.SnapshotSink,
@@ -2942,18 +2940,16 @@ func (s *nomadSnapshot) persistACLAuthMethods(sink raft.SnapshotSink,
 		return err
 	}
 
-	for {
-		for raw := aclAuthMethodsIter.Next(); raw != nil; raw = aclAuthMethodsIter.Next() {
-			method := raw.(*structs.ACLAuthMethod)
+	for raw := aclAuthMethodsIter.Next(); raw != nil; raw = aclAuthMethodsIter.Next() {
+		method := raw.(*structs.ACLAuthMethod)
 
-			// write the snapshot
-			sink.Write([]byte{byte(ACLAuthMethodSnapshot)})
-			if err := encoder.Encode(method); err != nil {
-				return err
-			}
+		// write the snapshot
+		sink.Write([]byte{byte(ACLAuthMethodSnapshot)})
+		if err := encoder.Encode(method); err != nil {
+			return err
 		}
-		return nil
 	}
+	return nil
 }
 
 // Release is a no-op, as we just need to GC the pointer

--- a/nomad/mock/acl.go
+++ b/nomad/mock/acl.go
@@ -226,7 +226,7 @@ func ACLAuthMethod() *structs.ACLAuthMethod {
 		TokenLocality: "locality",
 		MaxTokenTTL:   "3600s",
 		Default:       true,
-		Config: structs.ACLAuthMethodConfig{
+		Config: &structs.ACLAuthMethodConfig{
 			OIDCDiscoveryURL:    "http://example.com",
 			OIDCClientID:        "mock",
 			OIDCClientSecret:    "very secret secret",

--- a/nomad/mock/acl.go
+++ b/nomad/mock/acl.go
@@ -218,3 +218,29 @@ func ACLManagementToken() *structs.ACLToken {
 		ModifyIndex: 20,
 	}
 }
+
+func ACLAuthMethod() *structs.ACLAuthMethod {
+	method := structs.ACLAuthMethod{
+		Name:          fmt.Sprintf("acl-auth-method-%s", uuid.Short()),
+		Type:          "acl-auth-mock-type",
+		TokenLocality: "locality",
+		MaxTokenTTL:   "3600s",
+		Default:       true,
+		Config: structs.ACLAuthMethodConfig{
+			OIDCDiscoveryURL:    "http://example.com",
+			OIDCClientID:        "mock",
+			OIDCClientSecret:    "very secret secret",
+			BoundAudiences:      []string{"audience1", "audience2"},
+			AllowedRedirectURIs: []string{"foo", "bar"},
+			DiscoveryCaPem:      []string{"foo"},
+			SigningAlgs:         []string{"bar"},
+			ClaimMappings:       map[string]string{"foo": "bar"},
+			ListClaimMappings:   map[string]string{"foo": "bar"},
+		},
+		CreateTime:  time.Now().UTC(),
+		CreateIndex: 10,
+		ModifyIndex: 10,
+	}
+	method.SetHash()
+	return &method
+}

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -18,6 +18,7 @@ const (
 	TableVariablesQuotas      = "variables_quota"
 	TableRootKeyMeta          = "root_key_meta"
 	TableACLRoles             = "acl_roles"
+	TableACLAuthMethods       = "acl_auth_methods"
 	TableAllocs               = "allocs"
 )
 
@@ -85,6 +86,7 @@ func init() {
 		variablesQuotasTableSchema,
 		variablesRootKeyMetaSchema,
 		aclRolesTableSchema,
+		aclAuthMethodsTableSchema,
 	}...)
 }
 
@@ -1505,6 +1507,22 @@ func aclRolesTableSchema() *memdb.TableSchema {
 					Field: "ID",
 				},
 			},
+			indexName: {
+				Name:         indexName,
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.StringFieldIndex{
+					Field: "Name",
+				},
+			},
+		},
+	}
+}
+
+func aclAuthMethodsTableSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: TableACLAuthMethods,
+		Indexes: map[string]*memdb.IndexSchema{
 			indexName: {
 				Name:         indexName,
 				AllowMissing: false,

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -1523,8 +1523,8 @@ func aclAuthMethodsTableSchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
 		Name: TableACLAuthMethods,
 		Indexes: map[string]*memdb.IndexSchema{
-			indexName: {
-				Name:         indexName,
+			indexID: {
+				Name:         indexID,
 				AllowMissing: false,
 				Unique:       true,
 				Indexer: &memdb.StringFieldIndex{

--- a/nomad/state/state_store_acl_sso.go
+++ b/nomad/state/state_store_acl_sso.go
@@ -1,0 +1,173 @@
+package state
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// UpsertACLAuthMethods is used to insert a number of ACL auth methods into the
+// state store. It uses a single write transaction for efficiency, however, any
+// error means no entries will be committed.
+func (s *StateStore) UpsertACLAuthMethods(index uint64, aclAuthMethods []*structs.ACLAuthMethod) error {
+
+	// Grab a write transaction.
+	txn := s.db.WriteTxnMsgT(structs.ACLAuthMethodsUpsertRequestType, index)
+	defer txn.Abort()
+
+	// updated tracks whether any inserts have been made. This allows us to
+	// skip updating the index table if we do not need to.
+	var updated bool
+
+	// Iterate the array of methods. In the event of a single error, all inserts
+	// fail via the txn.Abort() defer.
+	for _, method := range aclAuthMethods {
+
+		roleUpdated, err := s.upsertACLAuthMethodTxn(index, txn, method)
+		if err != nil {
+			return err
+		}
+
+		// Ensure we track whether any inserts have been made.
+		updated = updated || roleUpdated
+	}
+
+	// If we did not perform any inserts, exit early.
+	if !updated {
+		return nil
+	}
+
+	// Perform the index table update to mark the new insert.
+	if err := txn.Insert(tableIndex, &IndexEntry{TableACLAuthMethods, index}); err != nil {
+		return fmt.Errorf("index update failed: %v", err)
+	}
+
+	return txn.Commit()
+}
+
+// upsertACLAuthMethodTxn inserts a single ACL auth method into the state store
+// using the provided write transaction. It is the responsibility of the caller
+// to update the index table.
+func (s *StateStore) upsertACLAuthMethodTxn(index uint64, txn *txn, method *structs.ACLAuthMethod) (bool, error) {
+
+	// Ensure the method hash is not zero to provide defense in depth. This
+	// should be done outside the state store, so we do not spend time here and
+	// thus Raft, when it can be avoided.
+	if len(method.Hash) == 0 {
+		method.SetHash()
+	}
+
+	// This validation also happens within the RPC handler, but Raft latency
+	// could mean that by the time the state call is invoked, another Raft
+	// update has already written a method with the same name. We therefore
+	// need to check we are not trying to create a method with an existing
+	// name.
+	existingRaw, err := txn.First(TableACLAuthMethods, indexName, method.Name)
+	if err != nil {
+		return false, fmt.Errorf("ACL auth method lookup failed: %v", err)
+	}
+
+	existing := existingRaw.(*structs.ACLAuthMethod)
+
+	// Depending on whether this is an initial create, or an update, we need to
+	// check and set certain parameters. The most important is to ensure any
+	// create index is carried over.
+	if existing != nil {
+
+		// If the method already exists, check whether the update contains any
+		// difference. If it doesn't, we can avoid a state update as well as
+		// updates to any blocking queries.
+		if existing.Equal(method) {
+			return false, nil
+		}
+
+		method.CreateIndex = existing.CreateIndex
+		method.ModifyIndex = index
+	} else {
+		method.CreateIndex = index
+		method.ModifyIndex = index
+	}
+
+	// Insert the auth method into the table.
+	if err := txn.Insert(TableACLAuthMethods, method); err != nil {
+		return false, fmt.Errorf("ACL auth method insert failed: %v", err)
+	}
+	return true, nil
+}
+
+// DeleteACLAuthMethods is responsible for batch deleting ACL methods. It uses
+// a single write transaction for efficiency, however, any error means no
+// entries will be committed. An error is produced if a method is not found
+// within state which has been passed within the array.
+func (s *StateStore) DeleteACLAuthMethods(index uint64, authMethodNames []string) error {
+	txn := s.db.WriteTxnMsgT(structs.ACLAuthMethodsDeleteRequestType, index)
+	defer txn.Abort()
+
+	for _, methodName := range authMethodNames {
+		if err := s.deleteACLAuthMethodTxn(txn, methodName); err != nil {
+			return err
+		}
+	}
+
+	// Update the index table to indicate an update has occurred.
+	if err := txn.Insert(tableIndex, &IndexEntry{TableACLAuthMethods, index}); err != nil {
+		return fmt.Errorf("index update failed: %v", err)
+	}
+
+	return txn.Commit()
+}
+
+// deleteACLAuthMethodTxn deletes a single ACL method name from the state store
+// using the provided write transaction. It is the responsibility of the caller
+// to update the index table.
+func (s *StateStore) deleteACLAuthMethodTxn(txn *txn, methodName string) error {
+	existing, err := txn.First(TableACLAuthMethods, indexID, methodName)
+	if err != nil {
+		return fmt.Errorf("ACL auth method lookup failed: %v", err)
+	}
+	if existing == nil {
+		return errors.New("ACL auth method not found")
+	}
+
+	// Delete the existing entry from the table.
+	if err := txn.Delete(TableACLAuthMethods, existing); err != nil {
+		return fmt.Errorf("ACL auth method deletion failed: %v", err)
+	}
+	return nil
+}
+
+// GetACLAuthMethods returns an iterator that contains all ACL auth methods
+// stored within state.
+func (s *StateStore) GetACLAuthMethods(ws memdb.WatchSet) (memdb.ResultIterator, error) {
+	txn := s.db.ReadTxn()
+
+	// Walk the entire table to get all ACL auth methods.
+	iter, err := txn.Get(TableACLAuthMethods, indexID)
+	if err != nil {
+		return nil, fmt.Errorf("ACL auth method lookup failed: %v", err)
+	}
+	ws.Add(iter.WatchCh())
+
+	return iter, nil
+}
+
+// GetACLAtuhMethodByName returns a single ACL auth method specified by the
+// input name. The auth method object will be nil, if no matching entry was
+// found; it is the responsibility of the caller to check for this.
+func (s *StateStore) GetACLAtuhMethodByName(ws memdb.WatchSet, authMethod string) (*structs.ACLAuthMethod, error) {
+	txn := s.db.ReadTxn()
+
+	// Perform the ACL auth method lookup using the "name" index.
+	watchCh, existing, err := txn.FirstWatch(TableACLAuthMethods, indexName, authMethod)
+	if err != nil {
+		return nil, fmt.Errorf("ACL auth method lookup failed: %v", err)
+	}
+	ws.Add(watchCh)
+
+	if existing != nil {
+		return existing.(*structs.ACLAuthMethod), nil
+	}
+	return nil, nil
+}

--- a/nomad/state/state_store_acl_sso.go
+++ b/nomad/state/state_store_acl_sso.go
@@ -159,8 +159,9 @@ func (s *StateStore) GetACLAuthMethods(ws memdb.WatchSet) (memdb.ResultIterator,
 func (s *StateStore) GetACLAtuhMethodByName(ws memdb.WatchSet, authMethod string) (*structs.ACLAuthMethod, error) {
 	txn := s.db.ReadTxn()
 
-	// Perform the ACL auth method lookup using the "name" index.
-	watchCh, existing, err := txn.FirstWatch(TableACLAuthMethods, indexName, authMethod)
+	// Perform the ACL auth method lookup using the "ID" index (which points to
+	// "Name" column)
+	watchCh, existing, err := txn.FirstWatch(TableACLAuthMethods, indexID, authMethod)
 	if err != nil {
 		return nil, fmt.Errorf("ACL auth method lookup failed: %v", err)
 	}

--- a/nomad/state/state_store_acl_sso.go
+++ b/nomad/state/state_store_acl_sso.go
@@ -156,10 +156,10 @@ func (s *StateStore) GetACLAuthMethods(ws memdb.WatchSet) (memdb.ResultIterator,
 	return iter, nil
 }
 
-// GetACLAtuhMethodByName returns a single ACL auth method specified by the
+// GetACLAuthMethodByName returns a single ACL auth method specified by the
 // input name. The auth method object will be nil, if no matching entry was
 // found; it is the responsibility of the caller to check for this.
-func (s *StateStore) GetACLAtuhMethodByName(ws memdb.WatchSet, authMethod string) (*structs.ACLAuthMethod, error) {
+func (s *StateStore) GetACLAuthMethodByName(ws memdb.WatchSet, authMethod string) (*structs.ACLAuthMethod, error) {
 	txn := s.db.ReadTxn()
 
 	// Perform the ACL auth method lookup using the "ID" index (which points to

--- a/nomad/state/state_store_acl_sso_test.go
+++ b/nomad/state/state_store_acl_sso_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/go-memdb"
 	"github.com/shoenig/test/must"
-	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -19,18 +18,18 @@ func TestStateStore_UpsertACLAuthMethods(t *testing.T) {
 	// Create mock auth methods
 	mockedACLAuthMethods := []*structs.ACLAuthMethod{mock.ACLAuthMethod(), mock.ACLAuthMethod()}
 
-	require.NoError(t, testState.UpsertACLAuthMethods(10, mockedACLAuthMethods))
+	must.NoError(t, testState.UpsertACLAuthMethods(10, mockedACLAuthMethods))
 
 	// Check that the index for the table was modified as expected.
 	initialIndex, err := testState.Index(TableACLAuthMethods)
-	require.NoError(t, err)
+	must.NoError(t, err)
 	must.Eq(t, 10, initialIndex)
 
 	// List all the auth methods in the table, so we can perform a number of
 	// tests on the return array.
 	ws := memdb.NewWatchSet()
 	iter, err := testState.GetACLAuthMethods(ws)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	// Count how many table entries we have, to ensure it is the expected
 	// number.
@@ -44,13 +43,13 @@ func TestStateStore_UpsertACLAuthMethods(t *testing.T) {
 		must.Eq(t, 10, authMethod.CreateIndex)
 		must.Eq(t, 10, authMethod.ModifyIndex)
 	}
-	require.Equal(t, 2, count, "incorrect number of ACL auth methods found")
+	must.Eq(t, 2, count)
 
 	// Try writing the same auth methods to state which should not result in an
 	// update to the table index.
-	require.NoError(t, testState.UpsertACLAuthMethods(20, mockedACLAuthMethods))
+	must.NoError(t, testState.UpsertACLAuthMethods(20, mockedACLAuthMethods))
 	reInsertActualIndex, err := testState.Index(TableACLAuthMethods)
-	require.NoError(t, err)
+	must.NoError(t, err)
 	must.Eq(t, 10, reInsertActualIndex)
 
 	// Make a change to the auth methods and ensure this update is accepted and
@@ -61,18 +60,18 @@ func TestStateStore_UpsertACLAuthMethods(t *testing.T) {
 	updatedMockedAuthMethod2 := mockedACLAuthMethods[1].Copy()
 	updatedMockedAuthMethod2.Type = "yet another new type"
 	updatedMockedAuthMethod2.SetHash()
-	require.NoError(t, testState.UpsertACLAuthMethods(20, []*structs.ACLAuthMethod{
+	must.NoError(t, testState.UpsertACLAuthMethods(20, []*structs.ACLAuthMethod{
 		updatedMockedAuthMethod1, updatedMockedAuthMethod2,
 	}))
 
 	// Check that the index for the table was modified as expected.
 	updatedIndex, err := testState.Index(TableACLAuthMethods)
-	require.NoError(t, err)
+	must.NoError(t, err)
 	must.Eq(t, 20, updatedIndex)
 
 	// List the ACL auth methods in state.
 	iter, err = testState.GetACLAuthMethods(ws)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	// Count how many table entries we have, to ensure it is the expected
 	// number.
@@ -86,7 +85,7 @@ func TestStateStore_UpsertACLAuthMethods(t *testing.T) {
 		must.Eq(t, 10, aclAuthMethod.CreateIndex)
 		must.Eq(t, 20, aclAuthMethod.ModifyIndex)
 	}
-	require.Equal(t, 2, count, "incorrect number of ACL auth methods found")
+	must.Eq(t, 2, count, must.Sprintf("incorrect number of ACL auth methods found"))
 
 	// Try adding a new auth method, which has a name clash with an existing
 	// entry.
@@ -95,11 +94,11 @@ func TestStateStore_UpsertACLAuthMethods(t *testing.T) {
 	dup.Type = mockedACLAuthMethods[0].Type
 
 	err = testState.UpsertACLAuthMethods(50, []*structs.ACLAuthMethod{dup})
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	// Get all the ACL auth methods from state.
 	iter, err = testState.GetACLAuthMethods(ws)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	// Count how many table entries we have, to ensure it is the expected
 	// number.
@@ -108,41 +107,41 @@ func TestStateStore_UpsertACLAuthMethods(t *testing.T) {
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {
 		count++
 	}
-	require.Equal(t, 2, count, "incorrect number of ACL auth methods found")
+	must.Eq(t, 2, count, must.Sprintf("incorrect number of ACL auth methods found"))
 }
 
 func TestStateStore_DeleteACLAuthMethods(t *testing.T) {
 	ci.Parallel(t)
 	testState := testStateStore(t)
 
-	// Generate a some mocked ACL auth methods for testing and upsert these
+	// Generate some mocked ACL auth methods for testing and upsert these
 	// straight into state.
 	mockedACLAuthMethods := []*structs.ACLAuthMethod{mock.ACLAuthMethod(), mock.ACLAuthMethod()}
-	require.NoError(t, testState.UpsertACLAuthMethods(10, mockedACLAuthMethods))
+	must.NoError(t, testState.UpsertACLAuthMethods(10, mockedACLAuthMethods))
 
 	// Try and delete a method using a name that doesn't exist. This should
 	// return an error and not change the index for the table.
 	err := testState.DeleteACLAuthMethods(20, []string{"not-a-method"})
-	require.ErrorContains(t, err, "ACL auth method not found")
+	must.EqError(t, err, "ACL auth method not found")
 
 	tableIndex, err := testState.Index(TableACLAuthMethods)
-	require.NoError(t, err)
+	must.NoError(t, err)
 	must.Eq(t, 10, tableIndex)
 
 	// Delete one of the previously upserted auth methods. This should succeed
 	// and modify the table index.
 	err = testState.DeleteACLAuthMethods(20, []string{mockedACLAuthMethods[0].Name})
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	tableIndex, err = testState.Index(TableACLAuthMethods)
-	require.NoError(t, err)
+	must.NoError(t, err)
 	must.Eq(t, 20, tableIndex)
 
 	// List the ACL auth methods and ensure we now only have one present and
 	// that it is the one we expect.
 	ws := memdb.NewWatchSet()
 	iter, err := testState.GetACLAuthMethods(ws)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	var aclAuthMethods []*structs.ACLAuthMethod
 
@@ -150,28 +149,28 @@ func TestStateStore_DeleteACLAuthMethods(t *testing.T) {
 		aclAuthMethods = append(aclAuthMethods, raw.(*structs.ACLAuthMethod))
 	}
 
-	require.Len(t, aclAuthMethods, 1, "incorrect number of auth methods found")
-	require.True(t, aclAuthMethods[0].Equal(mockedACLAuthMethods[1]))
+	must.Len(t, 1, aclAuthMethods, must.Sprintf("incorrect number of auth methods found"))
+	must.True(t, aclAuthMethods[0].Equal(mockedACLAuthMethods[1]))
 
 	// Delete the final remaining auth method. This should succeed and modify
 	// the table index.
 	err = testState.DeleteACLAuthMethods(30, []string{mockedACLAuthMethods[1].Name})
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	tableIndex, err = testState.Index(TableACLAuthMethods)
-	require.NoError(t, err)
+	must.NoError(t, err)
 	must.Eq(t, 30, tableIndex)
 
 	// List the auth methods and ensure we have zero entries.
 	iter, err = testState.GetACLAuthMethods(ws)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	aclAuthMethods = []*structs.ACLAuthMethod{}
 
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {
 		aclAuthMethods = append(aclAuthMethods, raw.(*structs.ACLAuthMethod))
 	}
-	require.Len(t, aclAuthMethods, 0, "incorrect number of ACL roles found")
+	must.Len(t, 0, aclAuthMethods, must.Sprintf("incorrect number of ACL roles found"))
 }
 
 func TestStateStore_GetACLAuthMethods(t *testing.T) {
@@ -181,12 +180,12 @@ func TestStateStore_GetACLAuthMethods(t *testing.T) {
 	// Generate a some mocked ACL auth methods for testing and upsert these
 	// straight into state.
 	mockedACLAuthMethods := []*structs.ACLAuthMethod{mock.ACLAuthMethod(), mock.ACLAuthMethod()}
-	require.NoError(t, testState.UpsertACLAuthMethods(10, mockedACLAuthMethods))
+	must.NoError(t, testState.UpsertACLAuthMethods(10, mockedACLAuthMethods))
 
 	// List the auth methods and ensure they are exactly as we expect.
 	ws := memdb.NewWatchSet()
 	iter, err := testState.GetACLAuthMethods(ws)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	var aclAuthMethods []*structs.ACLAuthMethod
 
@@ -200,7 +199,7 @@ func TestStateStore_GetACLAuthMethods(t *testing.T) {
 		expected[i].ModifyIndex = 10
 	}
 
-	require.ElementsMatch(t, aclAuthMethods, expected)
+	must.Eq(t, aclAuthMethods, expected)
 }
 
 func TestStateStore_GetACLAuthMethodByName(t *testing.T) {
@@ -210,21 +209,21 @@ func TestStateStore_GetACLAuthMethodByName(t *testing.T) {
 	// Generate a some mocked ACL auth methods for testing and upsert these
 	// straight into state.
 	mockedACLAuthMethods := []*structs.ACLAuthMethod{mock.ACLAuthMethod(), mock.ACLAuthMethod()}
-	require.NoError(t, testState.UpsertACLAuthMethods(10, mockedACLAuthMethods))
+	must.NoError(t, testState.UpsertACLAuthMethods(10, mockedACLAuthMethods))
 
 	ws := memdb.NewWatchSet()
 
 	// Try reading an auth method that does not exist.
 	authMethod, err := testState.GetACLAuthMethodByName(ws, "not-a-method")
-	require.NoError(t, err)
-	require.Nil(t, authMethod)
+	must.NoError(t, err)
+	must.Nil(t, authMethod)
 
 	// Read the two ACL roles that we should find.
 	authMethod, err = testState.GetACLAuthMethodByName(ws, mockedACLAuthMethods[0].Name)
-	require.NoError(t, err)
-	require.Equal(t, mockedACLAuthMethods[0], authMethod)
+	must.NoError(t, err)
+	must.Equal(t, mockedACLAuthMethods[0], authMethod)
 
 	authMethod, err = testState.GetACLAuthMethodByName(ws, mockedACLAuthMethods[1].Name)
-	require.NoError(t, err)
-	require.Equal(t, mockedACLAuthMethods[1], authMethod)
+	must.NoError(t, err)
+	must.Equal(t, mockedACLAuthMethods[1], authMethod)
 }

--- a/nomad/state/state_store_acl_sso_test.go
+++ b/nomad/state/state_store_acl_sso_test.go
@@ -199,7 +199,7 @@ func TestStateStore_GetACLAuthMethods(t *testing.T) {
 		expected[i].ModifyIndex = 10
 	}
 
-	must.Eq(t, aclAuthMethods, expected)
+	must.SliceContainsAll(t, aclAuthMethods, expected)
 }
 
 func TestStateStore_GetACLAuthMethodByName(t *testing.T) {

--- a/nomad/state/state_store_restore.go
+++ b/nomad/state/state_store_restore.go
@@ -233,3 +233,12 @@ func (r *StateRestore) ACLRoleRestore(aclRole *structs.ACLRole) error {
 	}
 	return nil
 }
+
+// ACLAuthMethodRestore is used to restore a single ACL auth method into the
+// acl_auth_methods table.
+func (r *StateRestore) ACLAuthMethodRestore(aclAuthMethod *structs.ACLAuthMethod) error {
+	if err := r.txn.Insert(TableACLAuthMethods, aclAuthMethod); err != nil {
+		return fmt.Errorf("ACL auth method insert failed: %v", err)
+	}
+	return nil
+}

--- a/nomad/state/state_store_restore_test.go
+++ b/nomad/state/state_store_restore_test.go
@@ -627,3 +627,26 @@ func TestStateStore_ACLRoleRestore(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, aclRole, out)
 }
+
+func TestStateStore_ACLAuthMethodRestore(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Set up our test registrations and index.
+	expectedIndex := uint64(13)
+	authMethod := mock.ACLAuthMethod()
+	authMethod.CreateIndex = expectedIndex
+	authMethod.ModifyIndex = expectedIndex
+
+	restore, err := testState.Restore()
+	require.NoError(t, err)
+	require.NoError(t, restore.ACLAuthMethodRestore(authMethod))
+	require.NoError(t, restore.Commit())
+
+	// Check the state is now populated as we expect and that we can find the
+	// restored registrations.
+	ws := memdb.NewWatchSet()
+	out, err := testState.GetACLAtuhMethodByName(ws, authMethod.Name)
+	require.NoError(t, err)
+	require.Equal(t, authMethod, out)
+}

--- a/nomad/state/state_store_restore_test.go
+++ b/nomad/state/state_store_restore_test.go
@@ -646,7 +646,7 @@ func TestStateStore_ACLAuthMethodRestore(t *testing.T) {
 	// Check the state is now populated as we expect and that we can find the
 	// restored registrations.
 	ws := memdb.NewWatchSet()
-	out, err := testState.GetACLAtuhMethodByName(ws, authMethod.Name)
+	out, err := testState.GetACLAuthMethodByName(ws, authMethod.Name)
 	require.NoError(t, err)
 	require.Equal(t, authMethod, out)
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -12223,17 +12223,7 @@ type ACLAuthMethod struct {
 	TokenLocality string
 	MaxTokenTTL   string
 	Default       bool
-	Config        struct {
-		OIDCDiscoveryURL    string
-		OIDCClientID        string
-		OIDCClientSecret    string
-		BoundAudiences      []string
-		AllowedRedirectURIs []string
-		DiscoveryCaPem      []string
-		SigningAlgs         []string
-		ClaimMappings       map[string]string
-		ListClaimMappings   map[string]string
-	}
+	Config        ACLAuthMethodConfig
 
 	Hash []byte
 
@@ -12241,6 +12231,18 @@ type ACLAuthMethod struct {
 	ModifyTime  time.Time
 	CreateIndex uint64
 	ModifyIndex uint64
+}
+
+type ACLAuthMethodConfig struct {
+	OIDCDiscoveryURL    string
+	OIDCClientID        string
+	OIDCClientSecret    string
+	BoundAudiences      []string
+	AllowedRedirectURIs []string
+	DiscoveryCaPem      []string
+	SigningAlgs         []string
+	ClaimMappings       map[string]string
+	ListClaimMappings   map[string]string
 }
 
 // SetHash is used to compute and set the hash of the ACL auth method. This

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -12243,6 +12243,31 @@ type ACLAuthMethod struct {
 	ModifyIndex uint64
 }
 
+// SetHash is used to compute and set the hash of the ACL auth method. This
+// should be called every and each time a user specified field on the method is
+// changed before updating the Nomad state store.
+func (a *ACLAuthMethod) SetHash() []byte {
+
+	// Initialize a 256bit Blake2 hash (32 bytes).
+	hash, err := blake2b.New256(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	_, _ = hash.Write([]byte(a.Name))
+
+	// Finalize the hash.
+	hashVal := hash.Sum(nil)
+
+	// Set and return the hash.
+	a.Hash = hashVal
+	return hashVal
+}
+
+func (a *ACLAuthMethod) Equal(other *ACLAuthMethod) bool {
+	return a.Name == other.Name
+}
+
 // OneTimeToken is used to log into the web UI using a token provided by the
 // command line.
 type OneTimeToken struct {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -12223,7 +12223,7 @@ type ACLAuthMethod struct {
 	TokenLocality string
 	MaxTokenTTL   string
 	Default       bool
-	Config        ACLAuthMethodConfig
+	Config        *ACLAuthMethodConfig
 
 	Hash []byte
 
@@ -12231,18 +12231,6 @@ type ACLAuthMethod struct {
 	ModifyTime  time.Time
 	CreateIndex uint64
 	ModifyIndex uint64
-}
-
-type ACLAuthMethodConfig struct {
-	OIDCDiscoveryURL    string
-	OIDCClientID        string
-	OIDCClientSecret    string
-	BoundAudiences      []string
-	AllowedRedirectURIs []string
-	DiscoveryCaPem      []string
-	SigningAlgs         []string
-	ClaimMappings       map[string]string
-	ListClaimMappings   map[string]string
 }
 
 // SetHash is used to compute and set the hash of the ACL auth method. This
@@ -12268,7 +12256,54 @@ func (a *ACLAuthMethod) SetHash() []byte {
 }
 
 func (a *ACLAuthMethod) Equal(other *ACLAuthMethod) bool {
-	return a.Name == other.Name
+	if a.Name == other.Name && a.Type == other.Type {
+		return true
+	}
+	return false
+}
+
+// Copy creates a deep copy of the ACL auth method. This copy can then be safely
+// modified. It handles nil objects.
+func (a *ACLAuthMethod) Copy() *ACLAuthMethod {
+	if a == nil {
+		return nil
+	}
+
+	c := new(ACLAuthMethod)
+	*c = *a
+
+	c.Hash = slices.Clone(a.Hash)
+	c.Config = a.Config.Copy()
+
+	return c
+}
+
+type ACLAuthMethodConfig struct {
+	OIDCDiscoveryURL    string
+	OIDCClientID        string
+	OIDCClientSecret    string
+	BoundAudiences      []string
+	AllowedRedirectURIs []string
+	DiscoveryCaPem      []string
+	SigningAlgs         []string
+	ClaimMappings       map[string]string
+	ListClaimMappings   map[string]string
+}
+
+func (a *ACLAuthMethodConfig) Copy() *ACLAuthMethodConfig {
+	if a == nil {
+		return nil
+	}
+
+	c := new(ACLAuthMethodConfig)
+	*c = *a
+
+	c.BoundAudiences = slices.Clone(a.BoundAudiences)
+	c.AllowedRedirectURIs = slices.Clone(a.AllowedRedirectURIs)
+	c.DiscoveryCaPem = slices.Clone(a.DiscoveryCaPem)
+	c.SigningAlgs = slices.Clone(a.SigningAlgs)
+
+	return c
 }
 
 // OneTimeToken is used to log into the web UI using a token provided by the

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -12217,10 +12217,12 @@ type ACLTokenUpsertResponse struct {
 	WriteMeta
 }
 
+// ACLAuthMethod is used to capture the properties of an authentication method
+// used for single sing-on
 type ACLAuthMethod struct {
 	Name          string
 	Type          string
-	TokenLocality string
+	TokenLocality string // is the token valid locally or globally?
 	MaxTokenTTL   string
 	Default       bool
 	Config        *ACLAuthMethodConfig
@@ -12246,6 +12248,35 @@ func (a *ACLAuthMethod) SetHash() []byte {
 
 	_, _ = hash.Write([]byte(a.Name))
 	_, _ = hash.Write([]byte(a.Type))
+	_, _ = hash.Write([]byte(a.TokenLocality))
+	_, _ = hash.Write([]byte(a.MaxTokenTTL))
+	_, _ = hash.Write([]byte(strconv.FormatBool(a.Default)))
+
+	if a.Config != nil {
+		_, _ = hash.Write([]byte(a.Config.OIDCDiscoveryURL))
+		_, _ = hash.Write([]byte(a.Config.OIDCClientID))
+		_, _ = hash.Write([]byte(a.Config.OIDCClientSecret))
+		for _, ba := range a.Config.BoundAudiences {
+			_, _ = hash.Write([]byte(ba))
+		}
+		for _, uri := range a.Config.AllowedRedirectURIs {
+			_, _ = hash.Write([]byte(uri))
+		}
+		for _, pem := range a.Config.DiscoveryCaPem {
+			_, _ = hash.Write([]byte(pem))
+		}
+		for _, sa := range a.Config.SigningAlgs {
+			_, _ = hash.Write([]byte(sa))
+		}
+		for k, v := range a.Config.ClaimMappings {
+			_, _ = hash.Write([]byte(k))
+			_, _ = hash.Write([]byte(v))
+		}
+		for k, v := range a.Config.ListClaimMappings {
+			_, _ = hash.Write([]byte(k))
+			_, _ = hash.Write([]byte(v))
+		}
+	}
 
 	// Finalize the hash.
 	hashVal := hash.Sum(nil)
@@ -12256,10 +12287,17 @@ func (a *ACLAuthMethod) SetHash() []byte {
 }
 
 func (a *ACLAuthMethod) Equal(other *ACLAuthMethod) bool {
-	if a.Name == other.Name && a.Type == other.Type {
-		return true
+	if a == nil || other == nil {
+		return a == other
 	}
-	return false
+	if len(a.Hash) == 0 {
+		a.SetHash()
+	}
+	if len(other.Hash) == 0 {
+		other.SetHash()
+	}
+	return bytes.Equal(a.Hash, other.Hash)
+
 }
 
 // Copy creates a deep copy of the ACL auth method. This copy can then be safely
@@ -12278,6 +12316,7 @@ func (a *ACLAuthMethod) Copy() *ACLAuthMethod {
 	return c
 }
 
+// ACLAuthMethodConfig is used to store configuration of an auth method
 type ACLAuthMethodConfig struct {
 	OIDCDiscoveryURL    string
 	OIDCClientID        string

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -117,6 +117,8 @@ const (
 	RootKeyMetaDeleteRequestType                 MessageType = 52
 	ACLRolesUpsertRequestType                    MessageType = 53
 	ACLRolesDeleteByIDRequestType                MessageType = 54
+	ACLAuthMethodsUpsertRequestType              MessageType = 55
+	ACLAuthMethodsDeleteRequestType              MessageType = 56
 
 	// Namespace types were moved from enterprise and therefore start at 64
 	NamespaceUpsertRequestType MessageType = 64
@@ -12213,6 +12215,32 @@ type ACLTokenUpsertRequest struct {
 type ACLTokenUpsertResponse struct {
 	Tokens []*ACLToken
 	WriteMeta
+}
+
+type ACLAuthMethod struct {
+	Name          string
+	Type          string
+	TokenLocality string
+	MaxTokenTTL   string
+	Default       bool
+	Config        struct {
+		OIDCDiscoveryURL    string
+		OIDCClientID        string
+		OIDCClientSecret    string
+		BoundAudiences      []string
+		AllowedRedirectURIs []string
+		DiscoveryCaPem      []string
+		SigningAlgs         []string
+		ClaimMappings       map[string]string
+		ListClaimMappings   map[string]string
+	}
+
+	Hash []byte
+
+	CreateTime  time.Time
+	ModifyTime  time.Time
+	CreateIndex uint64
+	ModifyIndex uint64
 }
 
 // OneTimeToken is used to log into the web UI using a token provided by the

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -12255,6 +12255,7 @@ func (a *ACLAuthMethod) SetHash() []byte {
 	}
 
 	_, _ = hash.Write([]byte(a.Name))
+	_, _ = hash.Write([]byte(a.Type))
 
 	// Finalize the hash.
 	hashVal := hash.Sum(nil)

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -6117,6 +6117,26 @@ func TestACLPolicySetHash(t *testing.T) {
 	assert.NotEqual(t, out1, out2)
 }
 
+func TestACLAuthMethodSetHash(t *testing.T) {
+	ci.Parallel(t)
+
+	am := &ACLAuthMethod{
+		Name: "foo",
+		Type: "bad type",
+	}
+	out1 := am.SetHash()
+	assert.NotNil(t, out1)
+	assert.NotNil(t, am.Hash)
+	assert.Equal(t, out1, am.Hash)
+
+	am.Type = "good type"
+	out2 := am.SetHash()
+	assert.NotNil(t, out2)
+	assert.NotNil(t, am.Hash)
+	assert.Equal(t, out2, am.Hash)
+	assert.NotEqual(t, out1, out2)
+}
+
 func TestTaskEventPopulate(t *testing.T) {
 	ci.Parallel(t)
 


### PR DESCRIPTION
This PR implements `ACLAuthMethod` type, `acl_auth_methods` table schema and crud state store methods. It also updates `nomadSnapshot.Persist` and `nomadSnapshot.Restore` methods in order for them to work with the new table, and adds two new Raft messages: `ACLAuthMethodsUpsertRequestType` and `ACLAuthMethodsDeleteRequestType`

This PR is part of the SSO work captured under ☂️ ticket #13120. 

Consult NMD-155 RFC for documentation details. 