### PR TITLE
template: protect use of template manager with a lock

### DIFF
--- a/.changelog/15192.txt
+++ b/.changelog/15192.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+template: Fixed a bug where template could cause agent panic on startup
+```


### PR DESCRIPTION
This PR protects access to `templateHook.templateManager` with its lock. So
far we have not been able to reproduce the panic - but it seems either Poststart
is running without a Prestart being run first (should be impossible), or the
Update hook is running concurrently with Poststart, nil-ing out the templateManager
in a race with Poststart.

Fixes #15189

Backport only to 1.4.x and 1.3.x