### PR TITLE
Fix example job

### DIFF
--- a/website/content/docs/integrations/consul-connect.mdx
+++ b/website/content/docs/integrations/consul-connect.mdx
@@ -206,7 +206,7 @@ job "countdash" {
           proxy {
             upstreams {
               destination_name = "count-api"
-              local_bind_port  = 8080
+              local_bind_port  = 9001
             }
           }
         }


### PR DESCRIPTION
The count API works on port `9001`. Port `8080` routes to nothing and makes this example break