### PR TITLE
ci: re-enable tests on main

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -1,9 +1,6 @@
 name: Core CI Tests
 on:
   push:
-    branches-ignore:
-      - main
-      - release-**
     paths-ignore:
       - 'README.md'
       - 'CHANGELOG.md'
@@ -128,4 +125,3 @@ jobs:
           sudo hc-install install -version ${{env.CONSUL_VERSION}} -path /usr/local/bin consul
           sudo sed -i 's!Defaults!#Defaults!g' /etc/sudoers
           sudo -E env "PATH=$PATH" make test-nomad
-


### PR DESCRIPTION
Now that the tests are grouped more tightly we don't use as many runners as before, so we can re-enable these without clogging the queue.