### PR TITLE
docs: clarify how to access task meta values in templates

### DIFF
--- a/website/content/docs/job-specification/meta.mdx
+++ b/website/content/docs/job-specification/meta.mdx
@@ -91,6 +91,22 @@ meta = {
 }
 ```
 
+## `meta` Usage Examples
+
+### Templates
+
+To make use of a `meta` value in a template, refer to its environment variable
+form.
+
+```hcl
+template {
+  destination = "local/out.txt"
+  data = <<EOH
+  {{ env "NOMAD_META_mykey" }}
+EOH
+}
+```
+
 [job]: /docs/job-specification/job 'Nomad job Job Specification'
 [group]: /docs/job-specification/group 'Nomad group Job Specification'
 [task]: /docs/job-specification/task 'Nomad task Job Specification'

--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -201,10 +201,27 @@ template {
 }
 ```
 
+### Task `meta` values
+
+To render values from a task's `meta` config, use the environment variable form
+of the meta variable name.
+
+```hcl
+meta {
+  mykey = "some_value"
+}
+
+template {
+  data = <<EOH
+  {{ env "NOMAD_META_mykey" }}
+EOH
+}
+```
+
 ### Node Variables
 
 Use the `env` function to access the Node's attributes and metadata inside a
-template.
+template. Note the `meta.` syntax here applies only to node meta fields.
 
 ```hcl
 template {


### PR DESCRIPTION
This PR updates template and meta docs pages to give examples of accessing
meta values in templates. To do so one must use the environment variable form
of the meta key name, which isn't obvious and wasn't yet documented.
