### PR TITLE
[bug] Return a spec on reconnect

### DIFF
--- a/.changelog/15214.txt
+++ b/.changelog/15214.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: fixed a bug where non-`docker` tasks with network isolation would leak network namespaces and iptables rules if the client was restarted while they were running
+```

--- a/client/allocrunner/network_manager_linux.go
+++ b/client/allocrunner/network_manager_linux.go
@@ -122,7 +122,18 @@ func (*defaultNetworkManager) CreateNetwork(allocID string, _ *drivers.NetworkCr
 			nsPath := path.Join(nsutil.NetNSRunDir, allocID)
 			_, err := os.Stat(nsPath)
 			if err == nil {
-				return nil, false, nil
+				// Let's return a spec that points to the tested nspath, but indicate
+				// that we didn't make the namespace. That will stop the network_hook
+				// from calling its networkConfigurator.Setup function in the reconnect
+				// case, but provide the spec value necessary for the network_hook's
+				// Postrun function to not fast exit.
+				spec := &drivers.NetworkIsolationSpec{
+					Mode:   drivers.NetIsolationModeGroup,
+					Path:   nsPath,
+					Labels: make(map[string]string),
+				}
+
+				return spec, false, nil
 			}
 		}
 		return nil, false, err


### PR DESCRIPTION
This PR changes the behavior on reconnect from the behavior introduced in #9757. 
https://github.com/hashicorp/nomad/blob/83b31ea44f7153a482de85992dcf77b52057047d/client/allocrunner/network_manager_linux.go#L100-L104

If the client enters this case and is returned a nil spec. When the network_hook's Postrun func is called to clean things up, the nil spec causes a fast exit.

https://github.com/hashicorp/nomad/blob/83b31ea44f7153a482de85992dcf77b52057047d/client/allocrunner/network_hook.go#L115-L118

This PR changes the behavior when we encounter the existing network namespace to return the spec so that the Postrun behavior will run properly to reap the namespace. 
 
Fixes #11096