### PR TITLE
exploratory refact:  update routes with `notifyError`

### DIFF
--- a/ui/app/mixins/with-model-error-handling.js
+++ b/ui/app/mixins/with-model-error-handling.js
@@ -1,9 +1,0 @@
-import Mixin from '@ember/object/mixin';
-import notifyError from 'nomad-ui/utils/notify-error';
-
-// eslint-disable-next-line ember/no-new-mixins
-export default Mixin.create({
-  model() {
-    return this._super(...arguments).catch(notifyError(this));
-  },
-});

--- a/ui/app/routes/allocations/allocation.js
+++ b/ui/app/routes/allocations/allocation.js
@@ -36,18 +36,18 @@ export default class AllocationRoute extends Route.extend(WithWatchers) {
     }
   }
 
-  model() {
-    // Preload the job for the allocation since it's required for the breadcrumb trail
-    return super
-      .model(...arguments)
-      .then((allocation) => {
-        const jobId = allocation.belongsTo('job').id();
-        return this.store
-          .findRecord('job', jobId)
-          .then(() => this.store.findAll('namespace')) // namespaces belong to a job and are an asynchronous relationship so we can peak them later on
-          .then(() => allocation);
-      })
-      .catch(notifyError(this));
+  async model() {
+    try {
+      // Preload the job for the allocation since it's required for the breadcrumb trail
+      const allocation = await super.model(...arguments);
+      const jobId = allocation?.belongsTo('job').id();
+      const getJob = this.store.findRecord('job', jobId);
+      const getNamespaces = this.store.findAll('namespace');
+      await Promise.all([getJob, getNamespaces]);
+      return allocation;
+    } catch (e) {
+      notifyError.call(this, e);
+    }
   }
 
   @watchRecord('allocation') watch;

--- a/ui/app/routes/clients/client.js
+++ b/ui/app/routes/clients/client.js
@@ -5,8 +5,12 @@ import notifyError from 'nomad-ui/utils/notify-error';
 export default class ClientRoute extends Route {
   @service store;
 
-  model() {
-    return super.model(...arguments).catch(notifyError(this));
+  async model() {
+    try {
+      return super.model(...arguments);
+    } catch (e) {
+      notifyError.call(this, e);
+    }
   }
 
   afterModel(model) {

--- a/ui/app/routes/csi/plugins/plugin.js
+++ b/ui/app/routes/csi/plugins/plugin.js
@@ -10,9 +10,11 @@ export default class PluginRoute extends Route {
     return { plugin_name: model.get('plainId') };
   }
 
-  model(params) {
-    return this.store
-      .findRecord('plugin', `csi/${params.plugin_name}`)
-      .catch(notifyError(this));
+  async model(params) {
+    try {
+      return this.store.findRecord('plugin', `csi/${params.plugin_name}`);
+    } catch (e) {
+      notifyError.call(this, e);
+    }
   }
 }

--- a/ui/app/routes/optimize/summary.js
+++ b/ui/app/routes/optimize/summary.js
@@ -13,7 +13,7 @@ export default class OptimizeSummaryRoute extends Route {
         `Unable to find summary for ${slug} in namespace ${jobNamespace}`
       );
       error.code = 404;
-      notifyError(this)(error);
+      notifyError.call(this, error);
     } else {
       return model;
     }

--- a/ui/app/routes/servers/server.js
+++ b/ui/app/routes/servers/server.js
@@ -1,4 +1,12 @@
 import Route from '@ember/routing/route';
-import WithModelErrorHandling from 'nomad-ui/mixins/with-model-error-handling';
+import notifyError from 'nomad-ui/utils/notify-error';
 
-export default class ServerRoute extends Route.extend(WithModelErrorHandling) {}
+export default class ServerRoute extends Route {
+  async model() {
+    try {
+      return super.model(...arguments);
+    } catch (e) {
+      notifyError.call(this, e);
+    }
+  }
+}

--- a/ui/app/utils/notify-error.js
+++ b/ui/app/utils/notify-error.js
@@ -2,8 +2,6 @@
 
 // An error handler to provide to a promise catch to set an error
 // on the application controller.
-export default function notifyError(route) {
-  return (error) => {
-    route.controllerFor('application').set('error', error);
-  };
+export default function notifyError(error) {
+  this.controllerFor('application').set('error', error);
 }


### PR DESCRIPTION
This PR is an exploratory refactoring of moving away from `RSVP` to native JavaScript Promises and `async/await` to make developer experience and future model refactorings much easier in anticipation of the redesign.