### PR TITLE
keyring: update handle to state inside replication loop

### DIFF
--- a/.changelog/15227.txt
+++ b/.changelog/15227.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+keyring: Fixed a bug where replication would stop after snapshot restores
+```


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/14981

When keyring replication starts, we take a handle to the state store. But whenever a snapshot is restored, this handle is invalidated and no longer points to a state store that is receiving new keys. This leaks a bunch of memory too!

In addition to operator-initiated restores, when fresh servers are added to existing clusters with large-enough state, the keyring replication can get started quickly enough that it's running before the snapshot from the existing clusters have been restored.

Fix this by updating the handle to the state store when we query.