### PR TITLE
refact: remove unused API

### DIFF
--- a/ui/app/routes/topology.js
+++ b/ui/app/routes/topology.js
@@ -12,7 +12,6 @@ export default class TopologyRoute extends Route.extend(WithForbiddenState) {
 
   model() {
     return RSVP.hash({
-      jobs: this.store.findAll('job'),
       allocations: this.store.query('allocation', {
         resources: true,
         task_states: false,
@@ -26,7 +25,6 @@ export default class TopologyRoute extends Route.extend(WithForbiddenState) {
     // When the model throws, make sure the interface expected by the controller is consistent.
     if (!model) {
       controller.model = {
-        jobs: [],
         allocations: [],
         nodes: [],
       };


### PR DESCRIPTION
Related to [10830](https://github.com/hashicorp/nomad/issues/10830).

The Topology Visualization makes a request to the `/jobs` endpoint and by default, requests all jobs in the `default` namespace. Upon investigating the issue, there is no usage of `model.jobs` in the controller, nor the template. It appears that we may not need this API call.