### PR TITLE
feat: add tooltip to storage volumes

### DIFF
--- a/ui/app/styles/core/table.scss
+++ b/ui/app/styles/core/table.scss
@@ -7,6 +7,11 @@
   border-collapse: separate;
   width: 100%;
 
+  @media #{$mq-table-overflow} {
+    display: block;
+    overflow-x: auto;
+  }
+
   &.is-fixed {
     table-layout: fixed;
 

--- a/ui/app/styles/core/variables.scss
+++ b/ui/app/styles/core/variables.scss
@@ -46,6 +46,7 @@ $breadcrumb-item-active-color: $white;
 $breadcrumb-item-separator-color: $primary;
 
 $mq-hidden-gutter: 'only screen and (max-width : 960px)';
+$mq-table-overflow: 'only screen and (max-width : 1100px)';
 
 $timing-fast: 150ms;
 $timing-medium: 300ms;

--- a/ui/app/templates/csi/volumes/index.hbs
+++ b/ui/app/templates/csi/volumes/index.hbs
@@ -71,13 +71,13 @@
             data-test-volume-row
             {{on "click" (action "gotoVolume" row.model)}}
           >
-            <Tooltip @text={{row.model.plainId}}>
-              <td data-test-volume-name
-                {{keyboard-shortcut 
-                  enumerated=true
-                  action=(action "gotoVolume" row.model)
-                }}
-              >
+            <td data-test-volume-name
+              {{keyboard-shortcut 
+                enumerated=true
+                action=(action "gotoVolume" row.model)
+              }}
+            >
+              <Tooltip @text={{row.model.plainId}}>
                 <LinkTo
                   @route="csi.volumes.volume"
                   @model={{row.model.idWithNamespace}}
@@ -85,8 +85,8 @@
                 >
                   {{row.model.name}}
                 </LinkTo>
-              </td>
-            </Tooltip>
+              </Tooltip>
+            </td>
             {{#if this.system.shouldShowNamespaces}}
               <td data-test-volume-namespace>
                 {{row.model.namespace.name}}

--- a/ui/app/templates/csi/volumes/index.hbs
+++ b/ui/app/templates/csi/volumes/index.hbs
@@ -71,20 +71,22 @@
             data-test-volume-row
             {{on "click" (action "gotoVolume" row.model)}}
           >
-            <td data-test-volume-name
-              {{keyboard-shortcut 
-                enumerated=true
-                action=(action "gotoVolume" row.model)
-              }}
-            >
-              <LinkTo
-                @route="csi.volumes.volume"
-                @model={{row.model.idWithNamespace}}
-                class="is-primary"
+            <Tooltip @text={{row.model.plainId}}>
+              <td data-test-volume-name
+                {{keyboard-shortcut 
+                  enumerated=true
+                  action=(action "gotoVolume" row.model)
+                }}
               >
-                {{row.model.name}}
-              </LinkTo>
-            </td>
+                <LinkTo
+                  @route="csi.volumes.volume"
+                  @model={{row.model.idWithNamespace}}
+                  class="is-primary"
+                >
+                  {{row.model.name}}
+                </LinkTo>
+              </td>
+            </Tooltip>
             {{#if this.system.shouldShowNamespaces}}
               <td data-test-volume-namespace>
                 {{row.model.namespace.name}}


### PR DESCRIPTION
Closes [13535](https://github.com/hashicorp/nomad/issues/13535).

Volume Names are not unique. Users may want to ensure that they're selecting the correct volume. A simple patch for us can be to provide a tooltip that shows the unique volume id.