### PR TITLE
styling: add overflow-x to section

### DIFF
--- a/ui/app/styles/core/section.scss
+++ b/ui/app/styles/core/section.scss
@@ -1,6 +1,7 @@
 .section {
   padding: 1.5rem;
   max-width: 1200px;
+  overflow-x: auto;
 
   &.with-headspace {
     margin-top: 1.5rem;

--- a/ui/app/styles/core/section.scss
+++ b/ui/app/styles/core/section.scss
@@ -1,7 +1,6 @@
 .section {
   padding: 1.5rem;
   max-width: 1200px;
-  overflow-x: auto;
 
   &.with-headspace {
     margin-top: 1.5rem;

--- a/ui/app/styles/core/table.scss
+++ b/ui/app/styles/core/table.scss
@@ -7,6 +7,11 @@
   border-collapse: separate;
   width: 100%;
 
+  @media #{$mq-table-overflow} {
+    display: block;
+    overflow-x: auto;
+  }
+
   &.is-fixed {
     table-layout: fixed;
 

--- a/ui/app/styles/core/variables.scss
+++ b/ui/app/styles/core/variables.scss
@@ -46,6 +46,7 @@ $breadcrumb-item-active-color: $white;
 $breadcrumb-item-separator-color: $primary;
 
 $mq-hidden-gutter: 'only screen and (max-width : 960px)';
+$mq-table-overflow: 'only screen and (max-width : 1100px)';
 
 $timing-fast: 150ms;
 $timing-medium: 300ms;


### PR DESCRIPTION
Closes [15207](https://github.com/hashicorp/nomad/issues/15207).

When using the Nomad UI, once your screen width goes under 1100px (most screens are about 1400px width, so anytime a user wants to use two windows e.g. having a terminal and browser on the same screen -- common use case even for me), information on tables becomes inaccessible. This happens everywhere that we use a table.

The simplest solution would be to enable horizontal scrolling when information is too wide for our screen.

**Problem**
![image](https://user-images.githubusercontent.com/41024828/201707757-ca42a2cf-a020-42d9-9a76-1ec2d2968ae9.png)

![image](https://user-images.githubusercontent.com/41024828/201707773-59011cfa-552f-498a-9a25-d62606ca11d5.png)

**Solution**
![image](https://user-images.githubusercontent.com/41024828/201708192-8297ad9e-1d5e-44ae-9348-57ca50263002.png)
