### PR TITLE
agent: ensure all HTTP Server methods are pointer receivers.

### DIFF
--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -347,7 +347,7 @@ func (s *HTTPServer) ResolveToken(req *http.Request) (*acl.ACL, error) {
 }
 
 // registerHandlers is used to attach our handlers to the mux
-func (s HTTPServer) registerHandlers(enableDebug bool) {
+func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/jobs", s.wrap(s.JobsRequest))
 	s.mux.HandleFunc("/v1/jobs/parse", s.wrap(s.JobsParseRequest))
 	s.mux.HandleFunc("/v1/job/", s.wrap(s.JobSpecificRequest))


### PR DESCRIPTION
Per https://go.dev/doc/faq#methods_on_values_or_pointers

> If some of the methods of the type must have pointer receivers, the rest should too, so the method set is consistent regardless of how the type is used.