### PR TITLE
api: ensure all request body decode error return a 400 status code.

### DIFF
--- a/.changelog/15252.txt
+++ b/.changelog/15252.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Ensure all request body decode errors return a 400 status code
+```

--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -73,7 +73,7 @@ func (s *HTTPServer) aclPolicyUpdate(resp http.ResponseWriter, req *http.Request
 	// Parse the policy
 	var policy structs.ACLPolicy
 	if err := decodeBody(req, &policy); err != nil {
-		return nil, CodedError(500, err.Error())
+		return nil, CodedError(http.StatusBadRequest, err.Error())
 	}
 
 	// Ensure the policy name matches
@@ -244,7 +244,7 @@ func (s *HTTPServer) aclTokenUpdate(resp http.ResponseWriter, req *http.Request,
 	// Parse the token
 	var token structs.ACLToken
 	if err := decodeBody(req, &token); err != nil {
-		return nil, CodedError(500, err.Error())
+		return nil, CodedError(http.StatusBadRequest, err.Error())
 	}
 
 	// Ensure the token accessor matches
@@ -311,7 +311,7 @@ func (s *HTTPServer) ExchangeOneTimeToken(resp http.ResponseWriter, req *http.Re
 
 	var args structs.OneTimeTokenExchangeRequest
 	if err := decodeBody(req, &args); err != nil {
-		return nil, CodedError(500, err.Error())
+		return nil, CodedError(http.StatusBadRequest, err.Error())
 	}
 
 	s.parseWriteRequest(req, &args.WriteRequest)

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -509,17 +509,17 @@ func (s *HTTPServer) KeyringOperationRequest(resp http.ResponseWriter, req *http
 		sresp, err = kmgr.ListKeys()
 	case "install":
 		if err := decodeBody(req, &args); err != nil {
-			return nil, CodedError(500, err.Error())
+			return nil, CodedError(http.StatusBadRequest, err.Error())
 		}
 		sresp, err = kmgr.InstallKey(args.Key)
 	case "use":
 		if err := decodeBody(req, &args); err != nil {
-			return nil, CodedError(500, err.Error())
+			return nil, CodedError(http.StatusBadRequest, err.Error())
 		}
 		sresp, err = kmgr.UseKey(args.Key)
 	case "remove":
 		if err := decodeBody(req, &args); err != nil {
-			return nil, CodedError(500, err.Error())
+			return nil, CodedError(http.StatusBadRequest, err.Error())
 		}
 		sresp, err = kmgr.RemoveKey(args.Key)
 	default:

--- a/command/agent/namespace_endpoint.go
+++ b/command/agent/namespace_endpoint.go
@@ -80,7 +80,7 @@ func (s *HTTPServer) namespaceUpdate(resp http.ResponseWriter, req *http.Request
 	// Parse the namespace
 	var namespace structs.Namespace
 	if err := decodeBody(req, &namespace); err != nil {
-		return nil, CodedError(500, err.Error())
+		return nil, CodedError(http.StatusBadRequest, err.Error())
 	}
 
 	// Ensure the namespace name matches


### PR DESCRIPTION
Related to #15253 but split, so this PR can be back-ported further.