### PR TITLE
api: ensure ACL role upsert decode error returns a 400 status code.

### DIFF
--- a/.semgrep/http_endpoint.yml
+++ b/.semgrep/http_endpoint.yml
@@ -1,0 +1,22 @@
+rules:
+  - id: "http-endpoint-request-decode-error-code"
+    patterns:
+      - pattern: |
+          if err := decodeBody(...); err != nil {
+          	return nil, CodedError(...)
+          }
+      - pattern-not-inside: |
+          if err := decodeBody(...); err != nil {
+          	return nil, CodedError(400, ...)
+          }
+      - pattern-not-inside: |
+          if err := decodeBody(...); err != nil {
+          	return nil, CodedError(http.StatusBadRequest, ...)
+          }
+    message: "HTTP endpoint request decode should return http.StatusBadRequest"
+    languages:
+      - "go"
+    severity: "ERROR"
+    paths:
+      include:
+        - "command/agent/*_endpoint.go"

--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -477,7 +477,7 @@ func (s *HTTPServer) aclRoleUpsertRequest(
 	// Decode the ACL role.
 	var aclRole structs.ACLRole
 	if err := decodeBody(req, &aclRole); err != nil {
-		return nil, CodedError(http.StatusInternalServerError, err.Error())
+		return nil, CodedError(http.StatusBadRequest, err.Error())
 	}
 
 	// Ensure the request path ID matches the ACL role ID that was decoded.


### PR DESCRIPTION
Related to #15252 and forms the changes that will be back-ported into 1.4.x. This was built from the mentioned PR, and therefore that should be merged first.

It also includes a semgrep rule to catch this behaviour moving forward.