### PR TITLE
cli: `wait` flag for use with `deployment status -monitor`

### DIFF
--- a/.changelog/15262.txt
+++ b/.changelog/15262.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Added `-wait` flag to `deployment status` for use with `-monitor` mode
+```

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -91,7 +91,7 @@ func (c *DeploymentStatusCommand) Name() string { return "deployment status" }
 
 func (c *DeploymentStatusCommand) Run(args []string) int {
 	var json, verbose, monitor bool
-	var waitTime time.Duration
+	var wait time.Duration
 	var tmpl string
 
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
@@ -100,7 +100,7 @@ func (c *DeploymentStatusCommand) Run(args []string) int {
 	flags.BoolVar(&json, "json", false, "")
 	flags.BoolVar(&monitor, "monitor", false, "")
 	flags.StringVar(&tmpl, "t", "", "")
-	flags.DurationVar(&waitTime, "wait", 2*time.Second, "")
+	flags.DurationVar(&wait, "wait", 2*time.Second, "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -178,7 +178,7 @@ func (c *DeploymentStatusCommand) Run(args []string) int {
 
 		c.Ui.Output(fmt.Sprintf("%s: Monitoring deployment %q",
 			formatTime(time.Now()), limit(deploy.ID, length)))
-		c.monitor(client, deploy.ID, meta.LastIndex, waitTime, verbose)
+		c.monitor(client, deploy.ID, meta.LastIndex, wait, verbose)
 
 		return 0
 	}

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -48,6 +48,9 @@ Status Options:
   -monitor
     Enter monitor mode to poll for updates to the deployment status.
 
+  -wait-time
+    How long to wait before polling an update, used in conjunction with monitor mode. Defaults to 2s.
+
   -t
     Format and display deployment using a Go template.
 `
@@ -95,6 +98,7 @@ func (c *DeploymentStatusCommand) Run(args []string) int {
 	flags.BoolVar(&json, "json", false, "")
 	flags.BoolVar(&monitor, "monitor", false, "")
 	flags.StringVar(&tmpl, "t", "", "")
+	flags.DurationVar(&waitTime, "wait-time", 2*time.Second, "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -48,8 +48,9 @@ Status Options:
   -monitor
     Enter monitor mode to poll for updates to the deployment status.
 
-  -wait-time
-    How long to wait before polling an update, used in conjunction with monitor mode. Defaults to 2s.
+-wait
+    How long to wait before polling an update, used in conjunction with monitor 
+    mode. Defaults to 2s.
 
   -t
     Format and display deployment using a Go template.

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -48,8 +48,8 @@ Status Options:
   -monitor
     Enter monitor mode to poll for updates to the deployment status.
 
--wait
-    How long to wait before polling an update, used in conjunction with monitor 
+  -wait
+    How long to wait before polling an update, used in conjunction with monitor
     mode. Defaults to 2s.
 
   -t
@@ -100,7 +100,7 @@ func (c *DeploymentStatusCommand) Run(args []string) int {
 	flags.BoolVar(&json, "json", false, "")
 	flags.BoolVar(&monitor, "monitor", false, "")
 	flags.StringVar(&tmpl, "t", "", "")
-	flags.DurationVar(&waitTime, "wait-time", 2*time.Second, "")
+	flags.DurationVar(&waitTime, "wait", 2*time.Second, "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -299,7 +299,7 @@ func (m *monitor) monitor(evalID string) int {
 		meta := new(Meta)
 		meta.Ui = m.ui
 		cmd := &DeploymentStatusCommand{Meta: *meta}
-		status, err := cmd.monitor(m.client, dID, 0, verbose)
+		status, err := cmd.monitor(m.client, dID, 0, m.state.wait, verbose)
 		if err != nil || status != api.DeploymentStatusSuccessful {
 			return 1
 		}

--- a/website/content/docs/commands/deployment/status.mdx
+++ b/website/content/docs/commands/deployment/status.mdx
@@ -20,8 +20,8 @@ nomad deployment status [options] <deployment id>
 The `deployment status` command requires a single argument, a deployment ID or
 prefix.
 
-A `-monitor` flag can be used to update the current deployment status until completion. 
-When combined with `-verbose`, it will also display the allocations for the given 
+A `-monitor` flag can be used to update the current deployment status until completion.
+When combined with `-verbose`, it will also display the allocations for the given
 deployment. If the deployment fails and [`auto_revert`] is set to `true`, it will monitor
 the entire process, showing the failure and then monitoring the deployment of the rollback.
 
@@ -38,6 +38,8 @@ capability for the deployment's namespace.
 - `-t` : Format and display the deployment using a Go template.
 - `-verbose`: Show full information.
 - `-monitor`: Enter monitor mode to poll for updates to the deployment status.
+- `-wait`: How long to wait before polling an update, used in conjunction with monitor
+    mode. Defaults to 2s.
 
 ## Examples
 


### PR DESCRIPTION
Addresses comments laid out in https://github.com/hashicorp/nomad/issues/11068
