### PR TITLE
test: ensure leader is still valid in reelection test

### DIFF
--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -1190,8 +1190,10 @@ func TestLeader_Reelection(t *testing.T) {
 		}
 	}
 
-	// Shutdown the leader
+	// make sure we still have a leader, then shut it down
+	must.NotNil(t, leader, must.Sprint("expected there to be a leader"))
 	leader.Shutdown()
+
 	// Wait for new leader to elect
 	testutil.WaitForLeader(t, nonLeader.RPC)
 }


### PR DESCRIPTION
The `TestLeader_Reelection` test waits for a leader to be elected and then makes some other assertions. But it implcitly assumes that there's no failure of leadership before shutting down the leader, which can lead to a panic in the tests. Assert there's still a leader before the shutdown.