### PR TITLE
Tokens page styles

### DIFF
--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -19,8 +19,11 @@ export default class Tokens extends Controller {
 
   @reads('token.secret') secret;
 
-  successfulSignIn = false;
-  unsuccessfulSignIn = false;
+  /**
+   * @type {(null | "success" | "failure")} signInStatus
+   */
+  @tracked
+  signInStatus = null;
 
   @alias('token.selfToken') tokenRecord;
 
@@ -34,10 +37,7 @@ export default class Tokens extends Controller {
       secret: undefined,
       tokenNotFound: false,
     });
-    this.setProperties({
-      successfulSignIn: false,
-      unsuccessfulSignIn: false,
-    });
+    this.signInStatus = null;
     // Clear out all data to ensure only data the anonymous token is privileged to see is shown
     this.resetStore();
     this.token.reset();
@@ -65,18 +65,12 @@ export default class Tokens extends Controller {
         // Refetch the token and associated policies
         this.get('token.fetchSelfTokenAndPolicies').perform().catch();
 
-        this.setProperties({
-          successfulSignIn: true,
-          unsuccessfulSignIn: false,
-        });
+        this.signInStatus = 'success';
         this.token.set('tokenNotFound', false);
       },
       () => {
         this.set('token.secret', undefined);
-        this.setProperties({
-          successfulSignIn: false,
-          unsuccessfulSignIn: true,
-        });
+        this.signInStatus = 'failure';
       }
     );
   }

--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -51,6 +51,7 @@ export default class Tokens extends Controller {
   @action
   verifyToken() {
     const { secret } = this;
+    if (!secret) return;
     const TokenAdapter = getOwner(this).lookup('adapter:token');
 
     this.set('token.secret', secret);
@@ -145,7 +146,7 @@ export default class Tokens extends Controller {
       this.state = null;
       this.code = null;
     } else {
-      this.state = "failure";
+      this.state = 'failure';
       this.code = null;
     }
   }
@@ -161,5 +162,4 @@ export default class Tokens extends Controller {
   get shouldShowPolicies() {
     return this.tokenRecord;
   }
-
 }

--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -51,7 +51,7 @@ export default class Tokens extends Controller {
   @action
   verifyToken() {
     const { secret } = this;
-    if (!secret) return;
+    this.clearTokenProperties();
     const TokenAdapter = getOwner(this).lookup('adapter:token');
 
     this.set('token.secret', secret);

--- a/ui/app/styles/components.scss
+++ b/ui/app/styles/components.scss
@@ -50,3 +50,4 @@
 @import './components/keyboard-shortcuts-modal';
 @import './components/services';
 @import './components/task-sub-row';
+@import './components/authorization';

--- a/ui/app/styles/components/authorization.scss
+++ b/ui/app/styles/components/authorization.scss
@@ -13,6 +13,9 @@
   }
 
   .status-notifications {
+    &.is-half {
+      width: 50%;
+    }
     margin-bottom: 1.5rem;
   }
 

--- a/ui/app/styles/components/authorization.scss
+++ b/ui/app/styles/components/authorization.scss
@@ -1,0 +1,47 @@
+.authorization-page {
+
+  .sign-in-methods {
+    h3, p {
+      margin-bottom: 1.5rem;
+    }
+
+    .sso-auth-methods {
+      display: flex;
+      flex-flow: wrap;
+      gap: 0.5rem;
+    }
+  }
+
+  .status-notifications {
+    margin-bottom: 1.5rem;
+  }
+
+  .or-divider {
+    display: block;
+    width: 100%;
+    text-align: center;
+    margin: 2rem 0;
+    height: 2rem;
+
+    &:before {
+      border-bottom: 1px solid $ui-gray-200;
+      position: relative;
+      top: 50%;
+      content: "";
+      display: block;
+      width: 100%;
+      height: 0px;
+    }
+
+    span {
+      color: $ui-gray-700;
+      background-color: white;
+      padding: 0 1rem;
+      text-transform: uppercase;
+      position: relative;
+      height: 100%;
+      align-content: center;
+      display: inline-grid;
+    }
+  }
+}

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -6,44 +6,6 @@
     <h1 class="title">Authorization and access control</h1>
 
     <div class="status-notifications">
-      {{#if this.tokenRecord.isExpired}}
-        <div data-test-token-expired class="notification is-danger">
-          <div class="columns">
-            <div class="column">
-              <h3 class="title is-4">Your token has expired</h3>
-              <p>Expired {{moment-from-now this.tokenRecord.expirationTime interval=1000}} ({{this.tokenRecord.expirationTime}})</p>
-            </div>
-            <div class="column is-centered is-minimum">
-              <button data-test-token-clear class="button" {{action "clearTokenProperties"}} type="button">Clear Token</button>
-            </div>
-          </div>
-        </div>
-      {{/if}}
-
-      {{#if this.token.tokenNotFound}}
-        <div data-test-token-not-found class="notification is-danger">
-          <div class="columns">
-            <div class="column">
-              <h3 class="title is-4">Your token was not found</h3>
-              <p>It may have expired, or been entered incorrectly.</p>
-            </div>
-            <div class="column is-centered is-minimum">
-              <button data-test-token-clear class="button" {{action "clearTokenProperties"}} type="button">Clear Token</button>
-            </div>
-          </div>
-        </div>
-      {{/if}}
-
-      {{#if this.successfulSignIn}}
-        <div data-test-token-success class="notification is-success">
-          <div class="columns">
-            <div class="column">
-              <h3 class="title is-4">Token Authenticated!</h3>
-              <p>Your token is valid and authorized for the following policies.</p>
-            </div>
-          </div>
-        </div>
-      {{/if}}
 
       {{#if this.unsuccessfulSignIn}}
         <div data-test-token-error class="notification is-danger">
@@ -56,8 +18,47 @@
         </div>
       {{/if}}
 
+      {{#if this.tokenRecord.isExpired}}
+        <div data-test-token-expired class="notification is-danger">
+          <div class="columns">
+            <div class="column">
+              <h3 class="title is-4">Your authentication has expired</h3>
+              <p>Expired {{moment-from-now this.tokenRecord.expirationTime interval=1000}} ({{this.tokenRecord.expirationTime}})</p>
+            </div>
+            <div class="column is-centered is-minimum">
+              <button data-test-token-clear class="button" {{action "clearTokenProperties"}} type="button">Sign In Again</button>
+            </div>
+          </div>
+        </div>
+      {{else}}
+        {{#if this.successfulSignIn}}
+          <div data-test-token-success class="notification is-success">
+            <div class="columns">
+              <div class="column">
+                <h3 class="title is-4">Token Authenticated!</h3>
+                <p>Your token is valid and authorized for the following policies.</p>
+              </div>
+            </div>
+          </div>
+        {{/if}}
+      {{/if}}
+
+      {{#if this.token.tokenNotFound}}
+        <div data-test-token-not-found class="notification is-danger">
+          <div class="columns">
+            <div class="column">
+              <h3 class="title is-4">Your token was not found</h3>
+              <p>It may have expired, or been entered incorrectly.</p>
+            </div>
+            <div class="column is-centered is-minimum">
+              <button data-test-token-clear class="button" {{action "clearTokenProperties"}} type="button">Sign In Again</button>
+            </div>
+          </div>
+        </div>
+      {{/if}}
+
       {{#if this.SSOFailure}}
-        <div data-test-sso-error class="notification is-danger column is-half">
+        <div data-test-sso-error class="notification is-danger column">
           <div class="columns">
             <div class="column">
               <h3 class="title is-4">Failed to sign in with SSO</h3>
@@ -95,15 +96,17 @@
           <p>Clusters that use Access Control Lists require tokens to perform certain tasks. By providing a token Secret ID, each future request will be authenticated, potentially authorizing read access to additional information.</p>
           <label class="label" for="token-input">Secret ID</label>
           <div class="control">
-            <input
+            <Input
               id="token-input"
               class="input"
-              type="text"
+              @type="text"
               placeholder="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
               {{!-- FIXME this placeholder gets read out by VoiceOver sans dashes 😵 --}}
-              value={{this.token.secret}}
-              oninput={{action (mut this.secret) value="target.value"}}
-              data-test-token-secret>
+              @value={{this.token.secret}}
+              {{autofocus}}
+              {{on "input" (action (mut this.secret) value="target.value")}}
+              @enter={{this.verifyToken}}
+              data-test-token-secret />
           </div>
           <p class="help">Sent with every request to determine authorization</p>
           <button disabled={{not this.secret}} data-test-token-submit class="button is-primary" {{action "verifyToken"}} type="button">Set Token</button>
@@ -156,69 +159,6 @@
         </div>
       {{/if}}
     </div>
-
-{{!-- 
-      <div class="column is-two-thirds">
-        {{#if this.tokenRecord.isExpired}}
-          <div data-test-token-expired class="notification is-danger">
-            <div class="columns">
-              <div class="column">
-                <h3 class="title is-4">Your token has expired</h3>
-                <p>Expired {{moment-from-now this.tokenRecord.expirationTime interval=1000}} ({{this.tokenRecord.expirationTime}})</p>
-              </div>
-              <div class="column is-centered is-minimum">
-                <button data-test-token-clear class="button" {{action "clearTokenProperties"}} type="button">Clear Token</button>
-              </div>
-            </div>
-          </div>
-        {{else if this.token.tokenNotFound}}
-          <div data-test-token-not-found class="notification is-danger">
-            <div class="columns">
-              <div class="column">
-                <h3 class="title is-4">Your token was not found</h3>
-                <p>It may have expired, or been entered incorrectly.</p>
-              </div>
-              <div class="column is-centered is-minimum">
-                <button data-test-token-clear class="button" {{action "clearTokenProperties"}} type="button">Clear Token</button>
-              </div>
-            </div>
-          </div>
-        {{else}}
-
-          {{#unless this.tokenIsValid}}
-            <div class="field">
-              <label class="label" for="token-input">Secret ID</label>
-              <div class="control">
-                <input
-                  id="token-input"
-                  class="input"
-                  type="text"
-                  placeholder="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-                  value={{this.token.secret}}
-                  oninput={{action (mut this.secret) value="target.value"}}
-                  data-test-token-secret>
-              </div>
-              <p class="help">Sent with every request to determine authorization</p>
-            </div>
-
-            <p class="content"><button data-test-token-submit class="button is-primary" {{action "verifyToken"}} type="button">Set Token</button></p>
-            {{#if this.authMethods}}
-              <h3 class="title is-4">Sign in with SSO</h3>
-              <p>Sign in to Nomad using the configured authorization provider. After logging in, the policies and rules for the token will be listed.</p>
-              {{#each this.model.authMethods as |method|}}
-                <button
-                  data-test-auth-method
-                  class="button is-info"
-                  onclick={{action "redirectToSSO" method}}
-                  type="button"
-                >Sign in with with {{method.name}}
-                </button>
-              {{/each}}
-            {{/if}}
-          {{/unless}}
-
-        {{/if}}
-      </div> --}}
 
   {{/if}}
 </section>

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -1,14 +1,164 @@
-{{page-title "Tokens"}}
-<section class="section">
+{{page-title "Authorization"}}
+<section class="section authorization-page">
   {{#if this.isValidatingToken}}
-    Sec, validating your token
-    <button type="button" {{on "click" (action (mut this.code) null)}}>Cancel</button>
+    <LoadingSpinner />
   {{else}}
-    <h1 class="title">Access Control Tokens</h1>
-    <div class="columns">
-      <div class="column is-two-thirds">
-        <p class="message">Clusters that use Access Control Lists require tokens to perform certain tasks. By providing a token <strong>Secret ID</strong>, each future request will be authenticated, potentially authorizing read access to additional information. By providing a token <strong>Accessor ID</strong>, the policies and rules for the token will be listed.</p>
+    <h1 class="title">Authorization and access control</h1>
 
+    <div class="status-notifications">
+      {{#if this.tokenRecord.isExpired}}
+        <div data-test-token-expired class="notification is-danger">
+          <div class="columns">
+            <div class="column">
+              <h3 class="title is-4">Your token has expired</h3>
+              <p>Expired {{moment-from-now this.tokenRecord.expirationTime interval=1000}} ({{this.tokenRecord.expirationTime}})</p>
+            </div>
+            <div class="column is-centered is-minimum">
+              <button data-test-token-clear class="button" {{action "clearTokenProperties"}} type="button">Clear Token</button>
+            </div>
+          </div>
+        </div>
+      {{/if}}
+
+      {{#if this.token.tokenNotFound}}
+        <div data-test-token-not-found class="notification is-danger">
+          <div class="columns">
+            <div class="column">
+              <h3 class="title is-4">Your token was not found</h3>
+              <p>It may have expired, or been entered incorrectly.</p>
+            </div>
+            <div class="column is-centered is-minimum">
+              <button data-test-token-clear class="button" {{action "clearTokenProperties"}} type="button">Clear Token</button>
+            </div>
+          </div>
+        </div>
+      {{/if}}
+
+      {{#if this.successfulSignIn}}
+        <div data-test-token-success class="notification is-success">
+          <div class="columns">
+            <div class="column">
+              <h3 class="title is-4">Token Authenticated!</h3>
+              <p>Your token is valid and authorized for the following policies.</p>
+            </div>
+          </div>
+        </div>
+      {{/if}}
+
+      {{#if this.unsuccessfulSignIn}}
+        <div data-test-token-error class="notification is-danger">
+          <div class="columns">
+            <div class="column">
+              <h3 class="title is-4">Token Failed to Authenticate</h3>
+              <p>The token secret you have provided does not match an existing token, or has expired.</p>
+            </div>
+          </div>
+        </div>
+      {{/if}}
+
+      {{#if this.SSOFailure}}
+        <div data-test-sso-error class="notification is-danger column is-half">
+          <div class="columns">
+            <div class="column">
+              <h3 class="title is-4">Failed to sign in with SSO</h3>
+              <p>Your OIDC provider has failed on sign in; please try again or contact your SSO administrator.</p>
+            </div>
+            <div class="column is-centered is-minimum">
+              <button data-test-sso-error-clear class="button" {{action (mut this.state)}} type="button">Clear</button>
+            </div>
+          </div>
+        </div>
+      {{/if}}
+    </div>
+
+    <div class="columns">
+      {{#if this.canSignIn}}
+        <div class="column is-half sign-in-methods">
+          {{#if this.authMethods.length}}
+            <h3 class="title is-4">Sign in with SSO</h3>
+            <p>Sign in to Nomad using the configured authorization provider. After logging in, the policies and rules for the token will be listed.</p>
+            <div class="sso-auth-methods">
+              {{#each this.model.authMethods as |method|}}
+                <button
+                  data-test-auth-method
+                  class="button is-primary"
+                  onclick={{action "redirectToSSO" method}}
+                  type="button"
+                >Sign in with with {{method.name}}
+                </button>
+              {{/each}}
+            </div>
+            <span class="or-divider"><span>Or</span></span>
+          {{/if}}
+
+          <h3 class="title is-4">Sign in with token</h3>
+          <p>Clusters that use Access Control Lists require tokens to perform certain tasks. By providing a token Secret ID, each future request will be authenticated, potentially authorizing read access to additional information.</p>
+          <label class="label" for="token-input">Secret ID</label>
+          <div class="control">
+            <input
+              id="token-input"
+              class="input"
+              type="text"
+              placeholder="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+              {{!-- FIXME this placeholder gets read out by VoiceOver sans dashes 😵 --}}
+              value={{this.token.secret}}
+              oninput={{action (mut this.secret) value="target.value"}}
+              data-test-token-secret>
+          </div>
+          <p class="help">Sent with every request to determine authorization</p>
+          <button disabled={{not this.secret}} data-test-token-submit class="button is-primary" {{action "verifyToken"}} type="button">Set Token</button>
+        </div>
+      {{/if}}
+
+      {{#if this.shouldShowPolicies}}
+        <div class="column">
+          {{#unless this.tokenRecord.isExpired}}
+            <div class="columns">
+              <div class="column">
+                <h3 data-test-token-name class="title is-4">Token: {{this.tokenRecord.name}}</h3>
+                <div>AccessorID: <code>{{this.tokenRecord.accessor}}</code></div>
+                <div>SecretID: <code>{{this.tokenRecord.secret}}</code></div>
+                {{#if this.tokenRecord.expirationTime}}
+                  <div data-test-token-expiry>Expires: {{moment-from-now this.tokenRecord.expirationTime interval=1000}} ({{this.tokenRecord.expirationTime}})</div>
+                {{/if}}
+              </div>
+              <div class="column is-minimum">
+                <button data-test-token-clear class="button is-primary" {{action "clearTokenProperties"}} type="button">Sign Out</button>
+              </div>
+            </div>
+            <h3 class="title is-4">Policies</h3>
+            {{#if (eq this.tokenRecord.type "management")}}
+              <div data-test-token-management-message class="boxed-section">
+                <div class="boxed-section-body has-centered-text">
+                  The management token has all permissions
+                </div>
+              </div>
+            {{else}}
+              {{#each this.tokenRecord.policies as |policy|}}
+                <div data-test-token-policy class="boxed-section">
+                  <div data-test-policy-name class="boxed-section-head">
+                    {{policy.name}}
+                  </div>
+                  <div class="boxed-section-body">
+                    <p data-test-policy-description class="content">
+                      {{#if policy.description}}
+                        {{policy.description}}
+                      {{else}}
+                        <em>No description</em>
+                      {{/if}}
+                    </p>
+                    <pre><code data-test-policy-rules>{{policy.rules}}</code></pre>
+                  </div>
+                </div>
+              {{/each}}
+            {{/if}}
+          {{/unless}}
+        </div>
+      {{/if}}
+    </div>
+
+{{!-- 
+      <div class="column is-two-thirds">
         {{#if this.tokenRecord.isExpired}}
           <div data-test-token-expired class="notification is-danger">
             <div class="columns">
@@ -44,7 +194,6 @@
                   class="input"
                   type="text"
                   placeholder="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-                  {{!-- FIXME this placeholder gets read out by VoiceOver sans dashes 😵 --}}
                   value={{this.token.secret}}
                   oninput={{action (mut this.secret) value="target.value"}}
                   data-test-token-secret>
@@ -68,97 +217,8 @@
             {{/if}}
           {{/unless}}
 
-          {{#if this.tokenIsValid}}
-            <div data-test-token-success class="notification is-success">
-              <div class="columns">
-                <div class="column">
-                  <h3 class="title is-4">Token Authenticated!</h3>
-                  <p>Your token is valid and authorized for the following policies.</p>
-                </div>
-              </div>
-            </div>
-          {{/if}}
-
-          {{#if this.tokenIsInvalid}}
-            <div data-test-token-error class="notification is-danger">
-              <div class="columns">
-                <div class="column">
-                  <h3 class="title is-4">Token Failed to Authenticate</h3>
-                  <p>The token secret you have provided does not match an existing token, or has expired.</p>
-                </div>
-              </div>
-            </div>
-          {{/if}}
-
-          {{#if this.SSOFailure}}
-            <div data-test-sso-error class="notification is-danger">
-              <div class="columns">
-                <div class="column">
-                  <h3 class="title is-4">Failed to sign in with SSO</h3>
-                  <p>Your OIDC provider has failed on sign in; please try again or contact your SSO administrator.</p>
-                </div>
-                <div class="column is-centered is-minimum">
-                  <button data-test-sso-error-clear class="button is-info" {{action (mut this.state)}} type="button">Clear</button>
-                </div>
-              </div>
-            </div>
-          {{/if}}
-
         {{/if}}
-
-        {{#if this.tokenRecord}}
-
-          <div class="notification is-info">
-            <div class="columns">
-              <div class="column">
-                <h3 class="title is-4">Token Storage</h3>
-                <p>Tokens are stored client-side in <a target="_blank" rel="noopener noreferrer" href="https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage">local storage</a>. This will persist your token across sessions. You can manually clear your token here.</p>
-              </div>
-              <div class="column is-centered is-minimum">
-                <button data-test-token-clear class="button is-info" {{action "clearTokenProperties"}} type="button">Clear Token</button>
-              </div>
-            </div>
-          </div>
-
-          {{#unless this.tokenRecord.isExpired}}
-            <h3 data-test-token-name class="title is-4">Token: {{this.tokenRecord.name}}</h3>
-            <div class="content">
-              <div>AccessorID: <code>{{this.tokenRecord.accessor}}</code></div>
-              <div>SecretID: <code>{{this.tokenRecord.secret}}</code></div>
-              {{#if this.tokenRecord.expirationTime}}
-                <div data-test-token-expiry>Expires: {{moment-from-now this.tokenRecord.expirationTime interval=1000}} ({{this.tokenRecord.expirationTime}})</div>
-              {{/if}}
-            </div>
-            <h3 class="title is-4">Policies</h3>
-            {{#if (eq this.tokenRecord.type "management")}}
-              <div data-test-token-management-message class="boxed-section">
-                <div class="boxed-section-body has-centered-text">
-                  The management token has all permissions
-                </div>
-              </div>
-            {{else}}
-              {{#each this.tokenRecord.policies as |policy|}}
-                <div data-test-token-policy class="boxed-section">
-                  <div data-test-policy-name class="boxed-section-head">
-                    {{policy.name}}
-                  </div>
-                  <div class="boxed-section-body">
-                    <p data-test-policy-description class="content">
-                      {{#if policy.description}}
-                        {{policy.description}}
-                      {{else}}
-                        <em>No description</em>
-                      {{/if}}
-                    </p>
-                    <pre><code data-test-policy-rules>{{policy.rules}}</code></pre>
-                  </div>
-                </div>
-              {{/each}}
-            {{/if}}
-          {{/unless}}
-        {{/if}}
-      </div>
-    </div>
+      </div> --}}
 
   {{/if}}
 </section>

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -5,7 +5,7 @@
   {{else}}
     <h1 class="title">Authorization and access control</h1>
 
-    <div class="status-notifications">
+    <div class="status-notifications {{if this.canSignIn "is-half"}}">
 
       {{#if this.unsuccessfulSignIn}}
         <div data-test-token-error class="notification is-danger">
@@ -49,9 +49,6 @@
             <div class="column">
               <h3 class="title is-4">Your token was not found</h3>
               <p>It may have expired, or been entered incorrectly.</p>
-            </div>
-            <div class="column is-centered is-minimum">
-              <button data-test-token-clear class="button" {{action "clearTokenProperties"}} type="button">Sign In Again</button>
             </div>
           </div>
         </div>
@@ -102,7 +99,6 @@
               @type="text"
               placeholder="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
               {{!-- FIXME this placeholder gets read out by VoiceOver sans dashes 😵 --}}
-              @value={{this.token.secret}}
               {{autofocus}}
               {{on "input" (action (mut this.secret) value="target.value")}}
               @enter={{this.verifyToken}}

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -7,7 +7,7 @@
 
     <div class="status-notifications {{if this.canSignIn "is-half"}}">
 
-      {{#if this.unsuccessfulSignIn}}
+      {{#if (eq this.signInStatus "failure")}}
         <div data-test-token-error class="notification is-danger">
           <div class="columns">
             <div class="column">
@@ -31,7 +31,7 @@
           </div>
         </div>
       {{else}}
-        {{#if this.successfulSignIn}}
+        {{#if (eq this.signInStatus "success")}}
           <div data-test-token-success class="notification is-success">
             <div class="columns">
               <div class="column">

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -346,7 +346,7 @@ module('Acceptance | tokens', function (hooks) {
     );
   });
 
-  test('SSO Sign-in flow', async function (assert) {
+  test('SSO Sign-in flow: Manager', async function (assert) {
     server.create('auth-method', { name: 'vault' });
     server.create('auth-method', { name: 'cognito' });
     server.create('token', { name: 'Thelonious' });
@@ -360,18 +360,22 @@ module('Acceptance | tokens', function (hooks) {
     )[0];
 
     assert.dom(managerButton).exists();
+    await click(managerButton);
 
     await percySnapshot(assert);
 
-    await click(managerButton);
-
     assert.ok(currentURL().startsWith('/settings/tokens'));
     assert.dom('[data-test-token-name]').includesText('Token: Manager');
-    await Tokens.clear();
+  });
 
+  test('SSO Sign-in flow: Regular User', async function (assert) {
+    server.create('auth-method', { name: 'vault' });
+    server.create('token', { name: 'Thelonious' });
+
+    await Tokens.visit();
+    assert.dom('[data-test-auth-method]').exists({ count: 1 });
     await click('button[data-test-auth-method]');
     assert.ok(currentURL().startsWith('/oidc-mock'));
-
     let newTokenButton = [...findAll('button')].filter((btn) =>
       btn.textContent.includes('Sign In as Thelonious')
     )[0];

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -50,7 +50,7 @@ module('Acceptance | tokens', function (hooks) {
       null,
       'No token secret set'
     );
-    assert.equal(document.title, 'Tokens - Nomad');
+    assert.equal(document.title, 'Authorization - Nomad');
 
     await Tokens.secret(secretId).submit();
     assert.equal(


### PR DESCRIPTION
Resolves #15269 

- Renames a few computed properties to be more clear: `tokenIsValid` to `successfulSignIn` (because it only fires immediately upon auth request), `this.tokenRecord` to `this.shouldShowPolicies`, etc.
- Modify styles to match intended designs: stacked notifications -> tokens -> sso
![image](https://user-images.githubusercontent.com/713991/202757668-e0a09c94-844c-4827-91fd-ff75fbb8af80.png)
