### PR TITLE
autopilot: include only servers from the same region

### DIFF
--- a/.changelog/15290.txt
+++ b/.changelog/15290.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+autopilot: Fixed a bug where autopilot would try to fetch raft stats from other regions
+```

--- a/nomad/autopilot.go
+++ b/nomad/autopilot.go
@@ -195,7 +195,7 @@ func (s *Server) autopilotServers() map[raft.ServerID]*autopilot.Server {
 			s.logger.Warn("Error parsing server info", "name", member.Name, "error", err)
 			continue
 		} else if srv == nil {
-			// this member was a client
+			// this member was a client or in another region
 			continue
 		}
 
@@ -208,6 +208,9 @@ func (s *Server) autopilotServers() map[raft.ServerID]*autopilot.Server {
 func (s *Server) autopilotServer(m serf.Member) (*autopilot.Server, error) {
 	ok, srv := isNomadServer(m)
 	if !ok {
+		return nil, nil
+	}
+	if srv.Region != s.Region() {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/15085

When we migrated to the updated autopilot library in Nomad 1.4.0, the interface for finding servers changed. Previously autopilot would get the serf members and call `IsServer` on each of them, leaving it up to the implementor to filter out clients (and in Nomad's case, other regions). But in the "new" autopilot library, the equivalent interface is `KnownServers` for which we did not filter by region. This causes spurious attempts for the cross-region stats fetching, which results in TLS errors and a lot of log noise.

Filter the member set by region to fix the regression.

---

Compare old caller (in Consul, which we imported directly): [autopilot.go#L215](https://github.com/hashicorp/consul/blob/v1.7.0/agent/consul/autopilot/autopilot.go#L215)
vs new caller (in the library): [reconcile.go#L180](https://github.com/hashicorp/raft-autopilot/blob/master/reconcile.go#L180)