### PR TITLE
make eval cancelation async with `Eval.Ack`

### DIFF
--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -234,10 +234,9 @@ func (e *Eval) Ack(args *structs.EvalAckRequest,
 		return err
 	}
 
-	// It's not necessary to cancel evals before Ack returns, but it's done here
-	// to commit canceled evals as close to the Ack'd eval being committed as
-	// possible.
-	return cancelCancelableEvals(e.srv)
+	// Wake up the eval cancelation reaper
+	e.srv.reapCancelableEvalsCh <- struct{}{}
+	return nil
 }
 
 // Nack is used to negative acknowledge completion of a dequeued evaluation.


### PR DESCRIPTION
In #14621 we added an eval canelation reaper goroutine with a channel that allowed us to wake it up. But we forgot to actually send on this channel from `Eval.Ack` and are still committing the cancelations synchronously. Fix this by sending on the buffered channel to wake up the reaper instead.

(ref https://github.com/hashicorp/nomad/pull/14621/files#r1025630828)