### PR TITLE
e2e: fixup oversubscription test case for jammy

### DIFF
--- a/e2e/oversubscription/testdata/docker.nomad
+++ b/e2e/oversubscription/testdata/docker.nomad
@@ -14,7 +14,7 @@ job "oversubscription-docker" {
       config {
         image   = "busybox:1.29.2"
         command = "/bin/sh"
-        args    = ["-c", "cat /sys/fs/cgroup/memory/memory.limit_in_bytes; sleep 1000"]
+        args    = ["-c", "cat /sys/fs/cgroup/memory.max; sleep 1000"]
       }
 
       resources {

--- a/e2e/oversubscription/testdata/docker.nomad
+++ b/e2e/oversubscription/testdata/docker.nomad
@@ -7,6 +7,12 @@ job "oversubscription-docker" {
     value     = "darwin,linux"
   }
 
+  constraint {
+    attribute = "${attr.unique.cgroup.version}"
+    operator  = "="
+    value     = "v2"
+  }
+
   group "group" {
     task "task" {
       driver = "docker"


### PR DESCRIPTION
jammy uses cgroups v2, need to lookup the max memory limit from the
unified heirarchy format
