### PR TITLE
pin build/release pipeline to ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   get-go-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
@@ -38,7 +38,7 @@ jobs:
           echo "Building with Go $(cat .go-version)"
           echo "::set-output name=go-version::$(cat .go-version)"
   get-product-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
     steps:
@@ -52,7 +52,7 @@ jobs:
           echo "::set-output name=product-version::$(make version)"
   generate-metadata-file:
     needs: get-product-version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
@@ -75,7 +75,7 @@ jobs:
 
   build-other:
     needs: [get-go-version, get-product-version]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         goos: [windows]
@@ -126,7 +126,7 @@ jobs:
 
   build-linux:
     needs: [get-go-version, get-product-version]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         goos: [linux]
@@ -293,7 +293,7 @@ jobs:
   #   needs:
   #     - get-product-version
   #     - build
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-20.04
   #   strategy:
   #     matrix:
   #       arch: ["arm", "arm64", "386", "amd64"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   prepare-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       build-ref: ${{ steps.commit-change-push.outputs.build-ref }}
     steps:


### PR DESCRIPTION
The `ubuntu-latest` runner has been migrated to Ubuntu 22.04, which doesn't have all the same multilib packages as 20.04. Although we'll probably want to migrate eventually, we should ship Nomad 1.4.3 with the same toolchain as we did previously so that we're not introducing new issues. This is currently blocking the 1.4.3 release (and backports).