### PR TITLE
ensure engineering has merge authority on build pipeline

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # release configuration
 
-/.release/                              @hashicorp/release-engineering @hashicorp/github-nomad-core
-/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-nomad-core
+/.release/                              @hashicorp/release-engineering @hashicorp/github-nomad-core @hashicorp/nomad-eng
+/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-nomad-core @hashicorp/nomad-eng


### PR DESCRIPTION
Adds @hashicorp/nomad-eng to the codeowners list for the build and release workflow files, so that we can fix problems that arise without being bottlenecked on another team.