### PR TITLE
[ui] Stabilize Percy tests for Exec and Logs Sidebar views

### DIFF
--- a/ui/tests/acceptance/exec-test.js
+++ b/ui/tests/acceptance/exec-test.js
@@ -297,7 +297,11 @@ module('Acceptance | exec', function (hooks) {
       } /bin/bash`
     );
 
-    await percySnapshot(assert);
+    const terminalTextRendered = assert.async();
+    setTimeout(async () => {
+      await percySnapshot(assert);
+      terminalTextRendered();
+    }, 1000);
   });
 
   test('an allocation can be specified', async function (assert) {

--- a/ui/tests/acceptance/task-logs-test.js
+++ b/ui/tests/acceptance/task-logs-test.js
@@ -84,7 +84,9 @@ module('Acceptance | task logs', function (hooks) {
     assert
       .dom('.task-context-sidebar h1.title')
       .includesText(task.state, 'Task state is correctly displayed');
-    await percySnapshot(assert);
+    await percySnapshot(assert, {
+      percyCSS: '.allocation-row td { display: none; }',
+    });
 
     await click('.sidebar button.close');
     assert.notOk(TaskLogs.sidebarIsPresent, 'Sidebar is not present');


### PR DESCRIPTION
Resolves #15349 

- Adds a 1-second timer to allow [xterm](https://xtermjs.org/) to finish writing our example lines for the Exec view
- Adds conditional CSS to hide the (highly variable) allocation created-at fields that were showing up in the background of our sidebar snapshot

The result should be no more default red Xs for percy tests on Nomad. At least until I accidentally add more volatile screenshots again in the future :)