### PR TITLE
e2e: fix 1 of 4 client disconnect tests

### DIFF
--- a/e2e/e2eutil/input/disconnect-node.nomad
+++ b/e2e/e2eutil/input/disconnect-node.nomad
@@ -33,6 +33,7 @@ job "disconnect-node" {
 
     task "task" {
       driver = "raw_exec"
+      user   = "root"
       config {
         command = "/bin/sh"
         args = ["-c",

--- a/e2e/terraform/etc/nomad.d/client-linux.hcl
+++ b/e2e/terraform/etc/nomad.d/client-linux.hcl
@@ -2,6 +2,9 @@ plugin_dir = "/opt/nomad/plugins"
 
 client {
   enabled = true
+  options = {
+    "user.denylist" = "www-data"
+  }
 }
 
 plugin "nomad-driver-podman" {


### PR DESCRIPTION
This PR modifies the disconnect helper job to run as root, which is necesary
for manipulating iptables as it does. Also re-organizes the final test logic
to wait for client re-connect before looking for the replacement (3rd) allocation
in case that client was needed to run the alloc (also giving the sheduler more
time to do its thing).

Skips the other 3 tests, which fail and I cannot yet figure out what is going on.
