### PR TITLE
bug:  enable `jobs.index` page to update in real-time

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -9,6 +9,10 @@ export default class JobAdapter extends WatchableNamespaceIDs {
     summary: '/summary',
   };
 
+  queryParamsToAttrs = {
+    namespace: 'namespace',
+  };
+
   fetchRawDefinition(job) {
     const url = this.urlForFindRecord(job.get('id'), 'job');
     return this.ajax(url, 'GET');

--- a/ui/app/adapters/watchable.js
+++ b/ui/app/adapters/watchable.js
@@ -143,7 +143,12 @@ export default class Watchable extends ApplicationAdapter {
         );
 
         matchingRecords.forEach((record) => {
-          removeRecord(store, record);
+          const IDValue = record.get('plainId') || record.get('id');
+          const storedRecordNotFoundInPayload =
+            IDValue && !payload.find((r) => r.ID === IDValue);
+          if (storedRecordNotFoundInPayload) {
+            removeRecord(store, record);
+          }
         });
 
         return payload;

--- a/ui/app/adapters/watchable.js
+++ b/ui/app/adapters/watchable.js
@@ -133,7 +133,8 @@ export default class Watchable extends ApplicationAdapter {
                 return true;
               } else if (mapping.attr === 'namespace') {
                 return (
-                  get(record, 'namespace.name') === query[mapping.queryParam]
+                  record.belongsTo('namespace').id() ===
+                  query[mapping.queryParam]
                 );
               }
             }

--- a/ui/app/adapters/watchable.js
+++ b/ui/app/adapters/watchable.js
@@ -125,16 +125,17 @@ export default class Watchable extends ApplicationAdapter {
 
       // Remove existing records that match this query. This way if server-side
       // deletes have occurred, the store won't have stale records.
-      store
-        .peekAll(type.modelName)
-        .filter((record) =>
-          queryParamsToAttrs.some(
-            (mapping) => get(record, mapping.attr) === query[mapping.queryParam]
-          )
-        )
-        .forEach((record) => {
-          removeRecord(store, record);
-        });
+      const matchingRecords = store.peekAll(type.modelName).filter((record) =>
+        queryParamsToAttrs.some((mapping) => {
+          if (mapping.queryParam === 'namespace' && query.namespace === '*')
+            return true;
+          return get(record, mapping.attr) === query[mapping.queryParam];
+        })
+      );
+
+      matchingRecords.forEach((record) => {
+        removeRecord(store, record);
+      });
 
       return payload;
     });

--- a/ui/app/adapters/watchable.js
+++ b/ui/app/adapters/watchable.js
@@ -128,8 +128,15 @@ export default class Watchable extends ApplicationAdapter {
         // deletes have occurred, the store won't have stale records.
         const matchingRecords = store.peekAll(type.modelName).filter((record) =>
           queryParamsToAttrs.some((mapping) => {
-            if (mapping.queryParam === 'namespace' && query.namespace === '*')
-              return true;
+            if (mapping.queryParam === 'namespace') {
+              if (query.namespace === '*') {
+                return true;
+              } else if (mapping.attr === 'namespace') {
+                return (
+                  get(record, 'namespace.name') === query[mapping.queryParam]
+                );
+              }
+            }
             return get(record, mapping.attr) === query[mapping.queryParam];
           })
         );

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -198,7 +198,7 @@ export default class IndexController extends Controller.extend(
     Visible jobs are those that match the selected namespace and aren't children
     of periodic or parameterized jobs.
   */
-  @computed('currentCount', 'model.jobs.@each.parent')
+  @computed('currentCount', 'model.jobs.@each.parent', 'qpNamespace')
   get visibleJobs() {
     let jobs = null;
     if (this.currentCount) {
@@ -207,9 +207,13 @@ export default class IndexController extends Controller.extend(
       jobs = this.model.jobs;
     }
 
-    if ((!this.model || !this.model.jobs) && jobs) return [];
+    if (!jobs) return [];
     return jobs
       .compact()
+      .filter((job) => {
+        if (this.qpNamespace === '*') return true;
+        return job.get('namespace.id') === this.qpNamespace;
+      })
       .filter((job) => !job.isNew)
       .filter((job) => !job.get('parent.content'));
   }

--- a/ui/app/services/watch-list.js
+++ b/ui/app/services/watch-list.js
@@ -1,11 +1,16 @@
-import { computed } from '@ember/object';
+import { computed, set } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
 import { copy } from 'ember-copy';
 import Service from '@ember/service';
 
 let list = {};
 
 export default class WatchListService extends Service {
+  @service store;
+
+  jobUpdateCount = 0;
+
   @computed
   get _list() {
     return copy(list, true);
@@ -24,5 +29,9 @@ export default class WatchListService extends Service {
 
   setIndexFor(url, value) {
     list[url] = +value;
+  }
+
+  notifyController() {
+    set(this, 'jobUpdateCount', this.jobUpdateCount + 1);
   }
 }


### PR DESCRIPTION
Resolves #10555

The `jobs.index` view is bound the model set on the `jobs.index` route. This model does not reactively update to changes in the `ember-data` store (instead it is subscribed to a set of `RecordIdenitfiers`... I believe).

That's why we're able to see job updates, but when a new job is added, our view does not update.

To fix the problem, we need to send a notification to the controller after the `query` and associated callback resolves meaning that our payload has successfully been added/updated to our `ember-date` store.

We also have one more challenge handling the wildcard (`*`) namespace which is a defacto `findAll` query. We have updated our `matchingRecord` algorithm to handle this case.