### PR TITLE
acl: replicate auth-methods from federated cluster leaders.

### DIFF
--- a/api/acl_test.go
+++ b/api/acl_test.go
@@ -618,6 +618,7 @@ func TestACLAuthMethods(t *testing.T) {
 	must.Len(t, 1, aclAuthMethodsListResp)
 	must.Eq(t, authMethod.Name, aclAuthMethodsListResp[0].Name)
 	must.True(t, aclAuthMethodsListResp[0].Default)
+	must.SliceNotEmpty(t, aclAuthMethodsListResp[0].Hash)
 	assertQueryMeta(t, queryMeta)
 
 	// Read the auth-method.

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -1135,6 +1135,38 @@ func Test_diffACLRoles(t *testing.T) {
 	require.ElementsMatch(t, []string{aclRole3.ID, aclRole4.ID}, toUpdate)
 }
 
+func Test_diffACLAuthMethods(t *testing.T) {
+	ci.Parallel(t)
+
+	stateStore := state.TestStateStore(t)
+
+	// Build an initial baseline of ACL auth-methods.
+	aclAuthMethod0 := mock.ACLAuthMethod()
+	aclAuthMethod1 := mock.ACLAuthMethod()
+	aclAuthMethod2 := mock.ACLAuthMethod()
+	aclAuthMethod3 := mock.ACLAuthMethod()
+
+	// Upsert these into our local state. Use copies, so we can alter the
+	// auth-methods directly and use within the diff func.
+	err := stateStore.UpsertACLAuthMethods(50,
+		[]*structs.ACLAuthMethod{aclAuthMethod0.Copy(), aclAuthMethod1.Copy(),
+			aclAuthMethod2.Copy(), aclAuthMethod3.Copy()})
+	must.NoError(t, err)
+
+	// Modify the ACL auth-methods to create a number of differences. These
+	// methods represent the state of the authoritative region.
+	aclAuthMethod2.ModifyIndex = 50
+	aclAuthMethod3.ModifyIndex = 200
+	aclAuthMethod3.Hash = []byte{0, 1, 2, 3}
+	aclAuthMethod4 := mock.ACLAuthMethod()
+
+	// Run the diff function and test the output.
+	toDelete, toUpdate := diffACLAuthMethods(stateStore, 50, []*structs.ACLAuthMethodStub{
+		aclAuthMethod2.Stub(), aclAuthMethod3.Stub(), aclAuthMethod4.Stub()})
+	require.ElementsMatch(t, []string{aclAuthMethod0.Name, aclAuthMethod1.Name}, toDelete)
+	require.ElementsMatch(t, []string{aclAuthMethod3.Name, aclAuthMethod4.Name}, toUpdate)
+}
+
 func TestLeader_Reelection(t *testing.T) {
 	ci.Parallel(t)
 

--- a/nomad/structs/acl_test.go
+++ b/nomad/structs/acl_test.go
@@ -889,7 +889,14 @@ func TestACLAuthMethod_Stub(t *testing.T) {
 		ModifyIndex: 10,
 	}
 	am.SetHash()
-	must.Eq(t, am.Stub(), &ACLAuthMethodStub{am.Name, am.Default})
+
+	must.Eq(t, am.Stub(), &ACLAuthMethodStub{
+		Name:        am.Name,
+		Default:     am.Default,
+		Hash:        am.Hash,
+		CreateIndex: am.CreateIndex,
+		ModifyIndex: am.ModifyIndex,
+	})
 
 	nilAuthMethod := &ACLAuthMethod{}
 	must.Eq(t, nilAuthMethod.Stub(), &ACLAuthMethodStub{})


### PR DESCRIPTION
I rejigged some on the leader code so it was easier and made more sense when scrolling.

The hash has been added to the stub object so this can be used when performing replication diffs as is done with other ACL objects. It also now includes the create and modify indexes.

The auth method struct object has JSON marhsal/unmarshal implementations to allow for the time.Duration parameter.

Related https://github.com/hashicorp/nomad/issues/13120