### PR TITLE
scheduler: set job on system stack for CSI feasibility check

### DIFF
--- a/.changelog/15372.txt
+++ b/.changelog/15372.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where volumes in non-default namespaces could not be scheduled for system or sysbatch jobs
+```

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -300,6 +300,8 @@ func (s *SystemStack) SetJob(job *structs.Job) {
 	s.distinctPropertyConstraint.SetJob(job)
 	s.binPack.SetJob(job)
 	s.ctx.Eligibility().SetJob(job)
+	s.taskGroupCSIVolumes.SetNamespace(job.Namespace)
+	s.taskGroupCSIVolumes.SetJobID(job.ID)
 
 	if contextual, ok := s.quota.(ContextualIterator); ok {
 		contextual.SetJob(job)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/15094

When the scheduler checks feasibility of each node, it creates a "stack" which carries attributes of the job and task group it needs to check feasibility for. The `system` and `sysbatch` scheduler use a different stack than `service` and `batch` jobs. This stack was missing the call to set the job ID and namespace for the CSI check. This prevents CSI volumes from being scheduled for system jobs whenever the volume is in a non-default namespace.

Set the job ID and namespace to match the generic scheduler.