### PR TITLE
[ui] Recompute Y Axis on data change

### DIFF
--- a/ui/app/components/line-chart.js
+++ b/ui/app/components/line-chart.js
@@ -357,6 +357,13 @@ export default class LineChart extends Component {
     }
   }
 
+  @action
+  recomputeYAxis(el) {
+    if (!this.isDestroyed && !this.isDestroying) {
+      d3.select(el.querySelector('.y-axis')).call(this.yAxis);
+    }
+  }
+
   mountD3Elements() {
     if (!this.isDestroyed && !this.isDestroying) {
       d3.select(this.element.querySelector('.x-axis')).call(this.xAxis);

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -4,6 +4,7 @@
   {{did-insert this.onInsert}}
   {{did-update this.renderChart}}
   {{did-update this.recomputeXAxis this.xScale}}
+  {{did-update this.recomputeYAxis this.yScale}}
   {{window-resize this.updateDimensions}}>
   <svg data-test-line-chart aria-labelledby="{{this.titleId}}" aria-describedby="{{this.descriptionId}}">
     <title id="{{this.titleId}}">{{this.title}}</title>


### PR DESCRIPTION
Resolves #15098 

---

Uses a `did-update` triggered on `yScale()` to manually re-call the yAxis scale formatter. Similar change to what we did in https://github.com/hashicorp/nomad/pull/14814. 

![image](https://user-images.githubusercontent.com/713991/203865114-fa9b2384-0952-4991-bdbd-3ec0eb9398e0.png)
