### PR TITLE
deps: apply fixes after Docker update

### DIFF
--- a/client/pluginmanager/csimanager/volume.go
+++ b/client/pluginmanager/csimanager/volume.go
@@ -119,7 +119,11 @@ func (v *volumeManager) ensureAllocDir(vol *structs.CSIVolume, alloc *structs.Al
 	targetPath := v.targetForVolume(v.mountRoot, vol.ID, alloc.ID, usage)
 	m := mount.New()
 	isNotMount, err := m.IsNotAMountPoint(targetPath)
-	if err != nil {
+
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		// ignore; path does not exist and as such is not a mount
+	case err != nil:
 		return "", false, fmt.Errorf("mount point detection failed for volume (%s): %v", vol.ID, err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,8 @@ require (
 	github.com/mitchellh/hashstructure v1.0.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mitchellh/reflectwalk v1.0.2
-	github.com/moby/sys/mountinfo v0.6.2 // indirect
+	github.com/moby/sys/mount v0.3.3
+	github.com/moby/sys/mountinfo v0.6.2
 	github.com/opencontainers/runc v1.0.0-rc93
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d
 	github.com/pkg/errors v0.9.1
@@ -159,6 +160,7 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/bmatcuk/doublestar v1.1.5 // indirect
+	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/checkpoint-restore/go-criu/v4 v4.1.0 // indirect
@@ -168,6 +170,7 @@ require (
 	github.com/circonus-labs/circonusllhist v0.1.3 // indirect
 	github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4 // indirect
 	github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1 // indirect
+	github.com/containerd/cgroups v1.0.1 // indirect
 	github.com/containerd/console v1.0.2 // indirect
 	github.com/containerd/containerd v1.5.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
@@ -182,6 +185,7 @@ require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/envoyproxy/go-control-plane v0.10.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.6.2 // indirect
+	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/godbus/dbus/v5 v5.0.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -215,6 +219,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/moby/term v0.0.0-20200312100748-672ec06f55cd // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/mrunalp/fileutils v0.5.0 // indirect
 	github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2 // indirect
@@ -268,13 +273,5 @@ require (
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
-
-require (
-	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
-	github.com/containerd/cgroups v1.0.1 // indirect
-	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
-	github.com/moby/sys/mount v0.3.3 // indirect
-	github.com/moby/term v0.0.0-20200312100748-672ec06f55cd // indirect
 	gotest.tools/v3 v3.4.0 // indirect
 )

--- a/helper/mount/mount_linux.go
+++ b/helper/mount/mount_linux.go
@@ -4,7 +4,8 @@
 package mount
 
 import (
-	docker_mount "github.com/docker/docker/pkg/mount"
+	"github.com/moby/sys/mount"
+	"github.com/moby/sys/mountinfo"
 )
 
 // mounter provides the default implementation of mount.Mounter
@@ -21,12 +22,12 @@ func New() Mounter {
 // IsNotAMountPoint determines if a directory is not a mountpoint.
 // It does this by checking the path against the contents of /proc/self/mountinfo
 func (m *mounter) IsNotAMountPoint(path string) (bool, error) {
-	isMount, err := docker_mount.Mounted(path)
+	isMount, err := mountinfo.Mounted(path)
 	return !isMount, err
 }
 
 func (m *mounter) Mount(device, target, mountType, options string) error {
 	// Defer to the docker implementation of `Mount`, it's correct enough for our
 	// usecase and avoids us needing to shell out to the `mount` utility.
-	return docker_mount.Mount(device, target, mountType, options)
+	return mount.Mount(device, target, mountType, options)
 }


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/15229 updated Docker in `release/1.2.x`, but it had some breaking changes that [caused CI to fail](https://app.circleci.com/pipelines/github/hashicorp/nomad/35387/workflows/04f7a731-7f34-44dc-8d97-45173a34d6b2/jobs/391854). The fixes had already been done in https://github.com/hashicorp/nomad/pull/11872 for 1.3.0+, that's why only `release/1.2.x` fails. 

I applied the Docker-related changes here, I believe the other changes are related the `runc` update.