### PR TITLE
docs: correct "User" attribute in Podman Task Driver Docs

### DIFF
--- a/website/content/plugins/drivers/podman.mdx
+++ b/website/content/plugins/drivers/podman.mdx
@@ -362,8 +362,9 @@ The `podman` driver implements the following [capabilities](/docs/concepts/plugi
   container. Refer to [task configuration][task].
 
   ```hcl
+  user = "nobody"
+  
   config {
-    user = "nobody"
   }
   ```
 

--- a/website/content/plugins/drivers/podman.mdx
+++ b/website/content/plugins/drivers/podman.mdx
@@ -358,16 +358,6 @@ The `podman` driver implements the following [capabilities](/docs/concepts/plugi
 - `tty` - (Optional) `true` or `false` (default). Allocate a pseudo-TTY for the
   container.
 
-- `user` - (Optional) Run the command as a specific user/uid within the
-  container. Refer to [task configuration][task].
-
-  ```hcl
-  user = "nobody"
-  
-  config {
-  }
-  ```
-
 - `volumes` - (Optional) A list of `host_path:container_path:options` strings
   to bind host paths to container paths. Named volumes are not supported.
 
@@ -399,6 +389,9 @@ The `podman` driver implements the following [capabilities](/docs/concepts/plugi
     }
   }
   ```
+
+Additionally, the Podman driver supports customization of the container's user
+through the task's [`user` option](/nomad/docs/job-specification/task#user).
 
 ## Network Configuration
 


### PR DESCRIPTION
The Podman task driver implements the `user` attribute outside of the task config stanza, however the current Nomad docs have the task within the task config stanza.  This PR corrects this error.

https://github.com/hashicorp/nomad-driver-podman