### PR TITLE
Percy-specific CSS to block out the exact token expiry time

### DIFF
--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -118,7 +118,7 @@
                 <div>AccessorID: <code>{{this.tokenRecord.accessor}}</code></div>
                 <div>SecretID: <code>{{this.tokenRecord.secret}}</code></div>
                 {{#if this.tokenRecord.expirationTime}}
-                  <div data-test-token-expiry>Expires: {{moment-from-now this.tokenRecord.expirationTime interval=1000}} ({{this.tokenRecord.expirationTime}})</div>
+                  <div data-test-token-expiry>Expires: {{moment-from-now this.tokenRecord.expirationTime interval=1000}} <span data-test-expiration-timestamp>({{this.tokenRecord.expirationTime}})</span></div>
                 {{/if}}
               </div>
               <div class="column is-minimum">

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -316,7 +316,10 @@ module('Acceptance | tokens', function (hooks) {
         .doesNotExist('No notification yet for a token with 10m5s left');
       notificationNotRendered();
       setTimeout(async () => {
-        await percySnapshot(assert);
+        await percySnapshot(assert, {
+          percyCSS: '[data-test-expiration-timestamp] { display: none; }',
+        });
+
         assert
           .dom('.flash-message.alert-error')
           .exists('Notification is rendered at the 10m mark');


### PR DESCRIPTION
Otherwise, all visual diff tests will fail, since the token expiry time is always 11 minutes after the test runs.
![image](https://user-images.githubusercontent.com/713991/204826813-58ec41d9-62ff-41d2-a20e-4cc49180fa79.png)
