### PR TITLE
ui:  move "add more" button in variable create and edit forms

### DIFF
--- a/ui/app/components/variable-form.hbs
+++ b/ui/app/components/variable-form.hbs
@@ -137,16 +137,17 @@
   {{/if}}
 
   <footer>
-    {{#if (eq this.view "table")}}
+    {{#unless (eq this.view "json")}}
     <button
       class="add-more button is-info is-inverted"
       type="button"
       disabled={{not (and this.keyValues.lastObject.key this.keyValues.lastObject.value)}}
       {{on "click" this.appendRow}}
+      data-test-add-kv
     >
       Add More
     </button>
-    {{/if}}
+    {{/unless}}
     <button
       disabled={{this.shouldDisableSave}}
       class="button is-primary save"

--- a/ui/app/components/variable-form.hbs
+++ b/ui/app/components/variable-form.hbs
@@ -146,7 +146,7 @@
           </button>
     <button
       disabled={{this.shouldDisableSave}}
-      class="button is-primary"
+      class="button is-primary save"
       type="submit"
       data-test-submit-var
     >

--- a/ui/app/components/variable-form.hbs
+++ b/ui/app/components/variable-form.hbs
@@ -137,7 +137,7 @@
   {{/if}}
 
   <footer>
-    {{#unless (eq this.view "json")}}
+    {{#unless this.isJSONView}}
     <button
       class="add-more button is-info is-inverted"
       type="button"

--- a/ui/app/components/variable-form.hbs
+++ b/ui/app/components/variable-form.hbs
@@ -110,16 +110,6 @@
           />
         </label>
         <VariableForm::InputGroup @entry={{entry}} />
-        {{#if (eq entry this.keyValues.lastObject)}}
-          <button
-            class="add-more button is-info is-inverted"
-            type="button"
-            disabled={{not (and entry.key entry.value)}}
-            {{on "click" this.appendRow}}
-          >
-            Add More
-          </button>
-        {{else}}
           <button
             class="delete-row button is-danger is-inverted"
             type="button"
@@ -127,7 +117,6 @@
           >
             Delete
           </button>
-        {{/if}}
         {{#each-in entry.warnings as |k v|}}
           <span class="key-value-error help is-danger">
             {{v}}
@@ -148,6 +137,13 @@
   {{/if}}
 
   <footer>
+              <button
+            class="add-more button is-info is-inverted"
+            type="button"
+            {{on "click" this.appendRow}}
+          >
+            Add More
+          </button>
     <button
       disabled={{this.shouldDisableSave}}
       class="button is-primary"

--- a/ui/app/components/variable-form.hbs
+++ b/ui/app/components/variable-form.hbs
@@ -4,53 +4,28 @@
 
   {{#if @model.isNew}}
     <div class="related-entities related-entities-hint">
-      <p>Prefix your path with
-        <code>nomad/jobs/</code>
-        to automatically make your variable accessible to a specified job, task
-        group, or task.<br />
-        Format:
-        <code>nomad/jobs/&lt;jobname&gt;</code>,
-        <code>nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;</code>,
-        <code
-        >nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;/&lt;taskname&gt;</code></p>
+      <p>Prefix your path with <code>nomad/jobs/</code> to automatically make your variable accessible to a specified job, task group, or task.<br />
+      Format: <code>nomad/jobs/&lt;jobname&gt;</code>, <code>nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;</code>, <code>nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;/&lt;taskname&gt;</code></p>
     </div>
   {{/if}}
 
   {{#if this.hasConflict}}
     <div class="notification conflict is-danger">
       <h3 class="title is-4">Heads up! Your variable has a conflict.</h3>
-      <p>This might be because someone else tried saving in the time since
-        you've had it open.</p>
+      <p>This might be because someone else tried saving in the time since you've had it open.</p>
       {{#if this.conflictingVariable.modifyTime}}
-        <span
-          class="tooltip"
-          aria-label="{{format-ts this.conflictingVariable.modifyTime}}"
-        >
+        <span class="tooltip" aria-label="{{format-ts this.conflictingVariable.modifyTime}}">
           {{moment-from-now this.conflictingVariable.modifyTime}}
         </span>
       {{/if}}
       {{#if this.conflictingVariable.items}}
-        <pre><code>{{stringify-object
-              this.conflictingVariable.items
-              whitespace=2
-            }}</code></pre>
+        <pre><code>{{stringify-object this.conflictingVariable.items whitespace=2}}</code></pre>
       {{else}}
-        <p>Your ACL token limits your ability to see further details about the
-          conflicting variable.</p>
+        <p>Your ACL token limits your ability to see further details about the conflicting variable.</p>
       {{/if}}
       <div class="options">
-        <button
-          data-test-refresh-button
-          type="button"
-          class="button"
-          {{on "click" this.refresh}}
-        >Refresh your browser</button>
-        <button
-          data-test-overwrite-button
-          type="button"
-          class="button is-danger"
-          {{on "click" this.saveWithOverwrite}}
-        >Overwrite anyway</button>
+        <button data-test-refresh-button type="button" class="button" {{on "click" this.refresh}}>Refresh your browser</button>
+        <button data-test-overwrite-button type="button" class="button is-danger" {{on "click" this.saveWithOverwrite}}>Overwrite anyway</button>
       </div>
     </div>
   {{/if}}
@@ -64,7 +39,7 @@
         @type="text"
         @value={{this.path}}
         placeholder="nomad/jobs/my-job/my-group/my-task"
-        class="input path-input {{if this.duplicatePathWarning 'error'}}"
+        class="input path-input {{if this.duplicatePathWarning "error"}}"
         {{on "input" this.setModelPath}}
         disabled={{not @model.isNew}}
         {{autofocus}}
@@ -87,8 +62,8 @@
         </p>
       {{/if}}
     </label>
-    <VariableForm::NamespaceFilter
-      @data={{hash
+    <VariableForm::NamespaceFilter 
+      @data={{hash 
         disabled=(not @model.isNew)
         selection=this.variableNamespace
         namespaceOptions=this.namespaceOptions
@@ -135,13 +110,13 @@
           />
         </label>
         <VariableForm::InputGroup @entry={{entry}} />
-        <button
-          class="delete-row button is-danger is-inverted"
-          type="button"
-          {{on "click" (action this.deleteRow entry)}}
-        >
-          Delete
-        </button>
+          <button
+            class="delete-row button is-danger is-inverted"
+            type="button"
+            {{on "click" (action this.deleteRow entry)}}
+          >
+            Delete
+          </button>
         {{#each-in entry.warnings as |k v|}}
           <span class="key-value-error help is-danger">
             {{v}}
@@ -162,13 +137,13 @@
   {{/if}}
 
   <footer>
-    <button
-      class="add-more button is-info is-inverted"
-      type="button"
-      {{on "click" this.appendRow}}
-    >
-      Add More
-    </button>
+              <button
+            class="add-more button is-info is-inverted"
+            type="button"
+            {{on "click" this.appendRow}}
+          >
+            Add More
+          </button>
     <button
       disabled={{this.shouldDisableSave}}
       class="button is-primary"

--- a/ui/app/components/variable-form.hbs
+++ b/ui/app/components/variable-form.hbs
@@ -4,28 +4,53 @@
 
   {{#if @model.isNew}}
     <div class="related-entities related-entities-hint">
-      <p>Prefix your path with <code>nomad/jobs/</code> to automatically make your variable accessible to a specified job, task group, or task.<br />
-      Format: <code>nomad/jobs/&lt;jobname&gt;</code>, <code>nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;</code>, <code>nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;/&lt;taskname&gt;</code></p>
+      <p>Prefix your path with
+        <code>nomad/jobs/</code>
+        to automatically make your variable accessible to a specified job, task
+        group, or task.<br />
+        Format:
+        <code>nomad/jobs/&lt;jobname&gt;</code>,
+        <code>nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;</code>,
+        <code
+        >nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;/&lt;taskname&gt;</code></p>
     </div>
   {{/if}}
 
   {{#if this.hasConflict}}
     <div class="notification conflict is-danger">
       <h3 class="title is-4">Heads up! Your variable has a conflict.</h3>
-      <p>This might be because someone else tried saving in the time since you've had it open.</p>
+      <p>This might be because someone else tried saving in the time since
+        you've had it open.</p>
       {{#if this.conflictingVariable.modifyTime}}
-        <span class="tooltip" aria-label="{{format-ts this.conflictingVariable.modifyTime}}">
+        <span
+          class="tooltip"
+          aria-label="{{format-ts this.conflictingVariable.modifyTime}}"
+        >
           {{moment-from-now this.conflictingVariable.modifyTime}}
         </span>
       {{/if}}
       {{#if this.conflictingVariable.items}}
-        <pre><code>{{stringify-object this.conflictingVariable.items whitespace=2}}</code></pre>
+        <pre><code>{{stringify-object
+              this.conflictingVariable.items
+              whitespace=2
+            }}</code></pre>
       {{else}}
-        <p>Your ACL token limits your ability to see further details about the conflicting variable.</p>
+        <p>Your ACL token limits your ability to see further details about the
+          conflicting variable.</p>
       {{/if}}
       <div class="options">
-        <button data-test-refresh-button type="button" class="button" {{on "click" this.refresh}}>Refresh your browser</button>
-        <button data-test-overwrite-button type="button" class="button is-danger" {{on "click" this.saveWithOverwrite}}>Overwrite anyway</button>
+        <button
+          data-test-refresh-button
+          type="button"
+          class="button"
+          {{on "click" this.refresh}}
+        >Refresh your browser</button>
+        <button
+          data-test-overwrite-button
+          type="button"
+          class="button is-danger"
+          {{on "click" this.saveWithOverwrite}}
+        >Overwrite anyway</button>
       </div>
     </div>
   {{/if}}
@@ -39,7 +64,7 @@
         @type="text"
         @value={{this.path}}
         placeholder="nomad/jobs/my-job/my-group/my-task"
-        class="input path-input {{if this.duplicatePathWarning "error"}}"
+        class="input path-input {{if this.duplicatePathWarning 'error'}}"
         {{on "input" this.setModelPath}}
         disabled={{not @model.isNew}}
         {{autofocus}}
@@ -62,8 +87,8 @@
         </p>
       {{/if}}
     </label>
-    <VariableForm::NamespaceFilter 
-      @data={{hash 
+    <VariableForm::NamespaceFilter
+      @data={{hash
         disabled=(not @model.isNew)
         selection=this.variableNamespace
         namespaceOptions=this.namespaceOptions
@@ -110,13 +135,13 @@
           />
         </label>
         <VariableForm::InputGroup @entry={{entry}} />
-          <button
-            class="delete-row button is-danger is-inverted"
-            type="button"
-            {{on "click" (action this.deleteRow entry)}}
-          >
-            Delete
-          </button>
+        <button
+          class="delete-row button is-danger is-inverted"
+          type="button"
+          {{on "click" (action this.deleteRow entry)}}
+        >
+          Delete
+        </button>
         {{#each-in entry.warnings as |k v|}}
           <span class="key-value-error help is-danger">
             {{v}}
@@ -137,13 +162,13 @@
   {{/if}}
 
   <footer>
-              <button
-            class="add-more button is-info is-inverted"
-            type="button"
-            {{on "click" this.appendRow}}
-          >
-            Add More
-          </button>
+    <button
+      class="add-more button is-info is-inverted"
+      type="button"
+      {{on "click" this.appendRow}}
+    >
+      Add More
+    </button>
     <button
       disabled={{this.shouldDisableSave}}
       class="button is-primary"

--- a/ui/app/components/variable-form.hbs
+++ b/ui/app/components/variable-form.hbs
@@ -137,13 +137,16 @@
   {{/if}}
 
   <footer>
-              <button
-            class="add-more button is-info is-inverted"
-            type="button"
-            {{on "click" this.appendRow}}
-          >
-            Add More
-          </button>
+    {{#if (eq this.view "table")}}
+    <button
+      class="add-more button is-info is-inverted"
+      type="button"
+      disabled={{not (and this.keyValues.lastObject.key this.keyValues.lastObject.value)}}
+      {{on "click" this.appendRow}}
+    >
+      Add More
+    </button>
+    {{/if}}
     <button
       disabled={{this.shouldDisableSave}}
       class="button is-primary save"

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -240,6 +240,11 @@ export default class VariableFormComponent extends Component {
   //#region JSON Editing
 
   view = this.args.view;
+
+  get isJSONView() {
+    return this.args.view === 'json';
+  }
+
   // Prevent duplicate onUpdate events when @view is set to its already-existing value,
   // which happens because parent's queryParams and toggle button both resolve independently.
   @action onViewChange([view]) {

--- a/ui/app/styles/components/variables.scss
+++ b/ui/app/styles/components/variables.scss
@@ -75,10 +75,6 @@
       border-color: $grey-blue;
     }
 
-    button.add-more[disabled] {
-      border-color: #dbdbdb;
-    }
-
     .key-value-error {
       grid-column: -1 / 1;
       position: relative;
@@ -188,5 +184,10 @@ table.variable-items {
 footer {
   .button.is-primary.save {
     margin-left: 8px;
+  }
+
+  .button.is-info.is-inverted.add-more[disabled] {
+    border-color: #dbdbdb;
+    box-shadow: 0 2px 0 0 rgb(122 122 122 / 20%);
   }
 }

--- a/ui/app/styles/components/variables.scss
+++ b/ui/app/styles/components/variables.scss
@@ -182,9 +182,10 @@ table.variable-items {
 }
 
 footer {
-  .button.is-primary.save {
-    margin-left: 8px;
-  }
+  display: grid;
+  grid-auto-columns: max-content;
+  grid-auto-flow: column;
+  gap: 1rem;
 
   .button.is-info.is-inverted.add-more[disabled] {
     border-color: #dbdbdb;

--- a/ui/app/styles/components/variables.scss
+++ b/ui/app/styles/components/variables.scss
@@ -184,3 +184,9 @@ table.variable-items {
     opacity: 1;
   }
 }
+
+footer {
+  .button.is-primary.save {
+    margin-left: 8px;
+  }
+}

--- a/ui/tests/integration/components/variable-form-test.js
+++ b/ui/tests/integration/components/variable-form-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | variable-form', function (hooks) {
     );
 
     assert
-      .dom('.key-value button.add-more')
+      .dom('[data-test-add-kv]')
       .isDisabled(
         'The "Add More" button is disabled until key and value are filled'
       );
@@ -55,7 +55,7 @@ module('Integration | Component | variable-form', function (hooks) {
     await typeIn('.key-value label:nth-child(1) input', 'foo');
 
     assert
-      .dom('.key-value button.add-more')
+      .dom('[data-test-add-kv]')
       .isDisabled(
         'The "Add More" button is still disabled with only key filled'
       );
@@ -63,12 +63,12 @@ module('Integration | Component | variable-form', function (hooks) {
     await typeIn('.key-value label:nth-child(2) input', 'bar');
 
     assert
-      .dom('.key-value button.add-more')
+      .dom('[data-test-add-kv]')
       .isNotDisabled(
         'The "Add More" button is no longer disabled after key and value are filled'
       );
 
-    await click('.key-value button.add-more');
+    await click('[data-test-add-kv]');
 
     assert.equal(
       findAll('div.key-value').length,
@@ -79,7 +79,7 @@ module('Integration | Component | variable-form', function (hooks) {
     await typeIn('.key-value:last-of-type label:nth-child(1) input', 'foo');
     await typeIn('.key-value:last-of-type label:nth-child(2) input', 'bar');
 
-    await click('.key-value button.add-more');
+    await click('[data-test-add-kv]');
 
     assert.equal(
       findAll('div.key-value').length,
@@ -109,7 +109,7 @@ module('Integration | Component | variable-form', function (hooks) {
       assert.expect(6);
 
       await render(hbs`<VariableForm @model={{this.mockedModel}} />`);
-      await click('.key-value button.add-more'); // add a second variable
+      await click('[data-test-add-kv]'); // add a second variable
 
       findAll('input.value-input').forEach((input, iter) => {
         assert.equal(
@@ -173,11 +173,11 @@ module('Integration | Component | variable-form', function (hooks) {
     );
     assert.equal(
       findAll('button.delete-row').length,
-      4,
-      'Shows "delete" for the first four rows'
+      5,
+      'Shows "delete" for all five rows'
     );
     assert.equal(
-      findAll('button.add-more').length,
+      findAll('[data-test-add-kv]').length,
       1,
       'Shows "add more" only on the last row'
     );
@@ -301,7 +301,7 @@ module('Integration | Component | variable-form', function (hooks) {
 
       await render(hbs`<VariableForm @model={{this.mockedModel}} />`);
 
-      await click('.key-value button.add-more');
+      await click('[data-test-add-kv]');
 
       const secondKey = document.querySelectorAll('[data-test-var-key]')[1];
       await typeIn(secondKey, 'myWonderfulKey');
@@ -380,7 +380,7 @@ module('Integration | Component | variable-form', function (hooks) {
 
       this.set('view', 'table');
 
-      await click('.key-value button.add-more');
+      await click('[data-test-add-kv]');
 
       await typeIn('.key-value:last-of-type label:nth-child(1) input', 'howdy');
       await typeIn(

--- a/ui/tests/integration/components/variable-form-test.js
+++ b/ui/tests/integration/components/variable-form-test.js
@@ -37,7 +37,7 @@ module('Integration | Component | variable-form', function (hooks) {
         keyValues: [{ key: '', value: '' }],
       })
     );
-    assert.expect(5);
+    assert.expect(7);
 
     await render(hbs`<VariableForm @model={{this.mockedModel}} />`);
     assert.equal(
@@ -46,17 +46,29 @@ module('Integration | Component | variable-form', function (hooks) {
       'A single KV row exists by default'
     );
 
+    assert
+      .dom('.key-value button.add-more')
+      .isDisabled(
+        'The "Add More" button is disabled until key and value are filled'
+      );
+
     await typeIn('.key-value label:nth-child(1) input', 'foo');
+
+    assert
+      .dom('.key-value button.add-more')
+      .isDisabled(
+        'The "Add More" button is still disabled with only key filled'
+      );
 
     await typeIn('.key-value label:nth-child(2) input', 'bar');
 
     assert
-      .dom('button.add-more')
+      .dom('.key-value button.add-more')
       .isNotDisabled(
         'The "Add More" button is no longer disabled after key and value are filled'
       );
 
-    await click('button.add-more');
+    await click('.key-value button.add-more');
 
     assert.equal(
       findAll('div.key-value').length,
@@ -67,7 +79,7 @@ module('Integration | Component | variable-form', function (hooks) {
     await typeIn('.key-value:last-of-type label:nth-child(1) input', 'foo');
     await typeIn('.key-value:last-of-type label:nth-child(2) input', 'bar');
 
-    await click('button.add-more');
+    await click('.key-value button.add-more');
 
     assert.equal(
       findAll('div.key-value').length,
@@ -97,7 +109,7 @@ module('Integration | Component | variable-form', function (hooks) {
       assert.expect(6);
 
       await render(hbs`<VariableForm @model={{this.mockedModel}} />`);
-      await click('button.add-more'); // add a second variable
+      await click('.key-value button.add-more'); // add a second variable
 
       findAll('input.value-input').forEach((input, iter) => {
         assert.equal(
@@ -137,7 +149,7 @@ module('Integration | Component | variable-form', function (hooks) {
   });
 
   test('Existing variable shows properties by default', async function (assert) {
-    assert.expect(12);
+    assert.expect(13);
     const keyValues = [
       { key: 'my-completely-normal-key', value: 'never' },
       { key: 'another key, but with spaces', value: 'gonna' },
@@ -161,8 +173,13 @@ module('Integration | Component | variable-form', function (hooks) {
     );
     assert.equal(
       findAll('button.delete-row').length,
-      5,
-      'Shows "delete" for the first five rows'
+      4,
+      'Shows "delete" for the first four rows'
+    );
+    assert.equal(
+      findAll('button.add-more').length,
+      1,
+      'Shows "add more" only on the last row'
     );
 
     findAll('div.key-value').forEach((row, idx) => {
@@ -284,7 +301,7 @@ module('Integration | Component | variable-form', function (hooks) {
 
       await render(hbs`<VariableForm @model={{this.mockedModel}} />`);
 
-      await click('button.add-more');
+      await click('.key-value button.add-more');
 
       const secondKey = document.querySelectorAll('[data-test-var-key]')[1];
       await typeIn(secondKey, 'myWonderfulKey');
@@ -363,7 +380,7 @@ module('Integration | Component | variable-form', function (hooks) {
 
       this.set('view', 'table');
 
-      await click('button.add-more');
+      await click('.key-value button.add-more');
 
       await typeIn('.key-value:last-of-type label:nth-child(1) input', 'howdy');
       await typeIn(

--- a/ui/tests/integration/components/variable-form-test.js
+++ b/ui/tests/integration/components/variable-form-test.js
@@ -37,7 +37,7 @@ module('Integration | Component | variable-form', function (hooks) {
         keyValues: [{ key: '', value: '' }],
       })
     );
-    assert.expect(7);
+    assert.expect(5);
 
     await render(hbs`<VariableForm @model={{this.mockedModel}} />`);
     assert.equal(
@@ -46,29 +46,17 @@ module('Integration | Component | variable-form', function (hooks) {
       'A single KV row exists by default'
     );
 
-    assert
-      .dom('.key-value button.add-more')
-      .isDisabled(
-        'The "Add More" button is disabled until key and value are filled'
-      );
-
     await typeIn('.key-value label:nth-child(1) input', 'foo');
-
-    assert
-      .dom('.key-value button.add-more')
-      .isDisabled(
-        'The "Add More" button is still disabled with only key filled'
-      );
 
     await typeIn('.key-value label:nth-child(2) input', 'bar');
 
     assert
-      .dom('.key-value button.add-more')
+      .dom('button.add-more')
       .isNotDisabled(
         'The "Add More" button is no longer disabled after key and value are filled'
       );
 
-    await click('.key-value button.add-more');
+    await click('button.add-more');
 
     assert.equal(
       findAll('div.key-value').length,
@@ -79,7 +67,7 @@ module('Integration | Component | variable-form', function (hooks) {
     await typeIn('.key-value:last-of-type label:nth-child(1) input', 'foo');
     await typeIn('.key-value:last-of-type label:nth-child(2) input', 'bar');
 
-    await click('.key-value button.add-more');
+    await click('button.add-more');
 
     assert.equal(
       findAll('div.key-value').length,
@@ -109,7 +97,7 @@ module('Integration | Component | variable-form', function (hooks) {
       assert.expect(6);
 
       await render(hbs`<VariableForm @model={{this.mockedModel}} />`);
-      await click('.key-value button.add-more'); // add a second variable
+      await click('button.add-more'); // add a second variable
 
       findAll('input.value-input').forEach((input, iter) => {
         assert.equal(
@@ -149,7 +137,7 @@ module('Integration | Component | variable-form', function (hooks) {
   });
 
   test('Existing variable shows properties by default', async function (assert) {
-    assert.expect(13);
+    assert.expect(12);
     const keyValues = [
       { key: 'my-completely-normal-key', value: 'never' },
       { key: 'another key, but with spaces', value: 'gonna' },
@@ -173,13 +161,8 @@ module('Integration | Component | variable-form', function (hooks) {
     );
     assert.equal(
       findAll('button.delete-row').length,
-      4,
-      'Shows "delete" for the first four rows'
-    );
-    assert.equal(
-      findAll('button.add-more').length,
-      1,
-      'Shows "add more" only on the last row'
+      5,
+      'Shows "delete" for the first five rows'
     );
 
     findAll('div.key-value').forEach((row, idx) => {
@@ -301,7 +284,7 @@ module('Integration | Component | variable-form', function (hooks) {
 
       await render(hbs`<VariableForm @model={{this.mockedModel}} />`);
 
-      await click('.key-value button.add-more');
+      await click('button.add-more');
 
       const secondKey = document.querySelectorAll('[data-test-var-key]')[1];
       await typeIn(secondKey, 'myWonderfulKey');
@@ -380,7 +363,7 @@ module('Integration | Component | variable-form', function (hooks) {
 
       this.set('view', 'table');
 
-      await click('.key-value button.add-more');
+      await click('button.add-more');
 
       await typeIn('.key-value:last-of-type label:nth-child(1) input', 'howdy');
       await typeIn(


### PR DESCRIPTION
Resolves [#15345](https://github.com/hashicorp/nomad/issues/15345) and [#15346](https://github.com/hashicorp/nomad/issues/15346).

Users are accidentally adding more variables when the mean to save the variable because of the placement of "add more" button.

### Edit Form
![image](https://user-images.githubusercontent.com/41024828/204886835-0afc4da9-ebcb-49a6-a776-eefeffa48403.png)

### Create Form
![image](https://user-images.githubusercontent.com/41024828/204886871-883bd011-58c6-40a0-a915-214bbe1deebd.png)
