### PR TITLE
[ui] Token management interface on policy pages

### DIFF
--- a/.changelog/15435.txt
+++ b/.changelog/15435.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: The web UI now provides a Token Management interface for management users on policy pages
+```

--- a/ui/app/abilities/token.js
+++ b/ui/app/abilities/token.js
@@ -1,0 +1,10 @@
+import AbstractAbility from './abstract';
+import { alias } from '@ember/object/computed';
+
+export default class extends AbstractAbility {
+  @alias('selfTokenIsManagement') canRead;
+  @alias('selfTokenIsManagement') canList;
+  @alias('selfTokenIsManagement') canWrite;
+  @alias('selfTokenIsManagement') canUpdate;
+  @alias('selfTokenIsManagement') canDestroy;
+}

--- a/ui/app/adapters/token.js
+++ b/ui/app/adapters/token.js
@@ -2,12 +2,20 @@ import { inject as service } from '@ember/service';
 import { default as ApplicationAdapter, namespace } from './application';
 import OTTExchangeError from '../utils/ott-exchange-error';
 import classic from 'ember-classic-decorator';
+import { singularize } from 'ember-inflector';
 
 @classic
 export default class TokenAdapter extends ApplicationAdapter {
   @service store;
 
   namespace = namespace + '/acl';
+
+  createRecord(_store, type, snapshot) {
+    let data = this.serialize(snapshot);
+    console.log('DATA GOING OUT', data);
+    data.Policies = data.PolicyIDs; // TODO: temp hack
+    return this.ajax(`${this.buildURL()}/token`, 'POST', { data });
+  }
 
   findSelf() {
     return this.ajax(`${this.buildURL()}/token/self`, 'GET').then((token) => {

--- a/ui/app/adapters/token.js
+++ b/ui/app/adapters/token.js
@@ -2,6 +2,7 @@ import { inject as service } from '@ember/service';
 import { default as ApplicationAdapter, namespace } from './application';
 import OTTExchangeError from '../utils/ott-exchange-error';
 import classic from 'ember-classic-decorator';
+import { singularize } from 'ember-inflector';
 
 @classic
 export default class TokenAdapter extends ApplicationAdapter {
@@ -11,9 +12,13 @@ export default class TokenAdapter extends ApplicationAdapter {
 
   createRecord(_store, type, snapshot) {
     let data = this.serialize(snapshot);
-    console.log('DATA GOING OUT', data);
-    data.Policies = data.PolicyIDs; // TODO: temp hack
+    data.Policies = data.PolicyIDs;
     return this.ajax(`${this.buildURL()}/token`, 'POST', { data });
+  }
+
+  // Delete at /token instead of /tokens
+  urlForDeleteRecord(identifier, modelName) {
+    return `${this.buildURL()}/${singularize(modelName)}/${identifier}`;
   }
 
   findSelf() {

--- a/ui/app/adapters/token.js
+++ b/ui/app/adapters/token.js
@@ -2,7 +2,6 @@ import { inject as service } from '@ember/service';
 import { default as ApplicationAdapter, namespace } from './application';
 import OTTExchangeError from '../utils/ott-exchange-error';
 import classic from 'ember-classic-decorator';
-import { singularize } from 'ember-inflector';
 
 @classic
 export default class TokenAdapter extends ApplicationAdapter {

--- a/ui/app/components/policy-editor.js
+++ b/ui/app/components/policy-editor.js
@@ -25,9 +25,10 @@ export default class PolicyEditorComponent extends Component {
         throw {
           errors: [
             {
-              detail: 'Policy name must be 1-128 characters long and can only contain letters, numbers, and dashes.'
-            }
-          ]
+              detail:
+                'Policy name must be 1-128 characters long and can only contain letters, numbers, and dashes.',
+            },
+          ],
         };
       }
 

--- a/ui/app/components/policy-editor.js
+++ b/ui/app/components/policy-editor.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';
-import messageForError from 'nomad-ui/utils/message-from-adapter-error';
 
 export default class PolicyEditorComponent extends Component {
   @service flashMessages;
@@ -22,14 +21,9 @@ export default class PolicyEditorComponent extends Component {
     try {
       const nameRegex = '^[a-zA-Z0-9-]{1,128}$';
       if (!this.policy.name?.match(nameRegex)) {
-        throw {
-          errors: [
-            {
-              detail:
-                'Policy name must be 1-128 characters long and can only contain letters, numbers, and dashes.',
-            },
-          ],
-        };
+        throw new Error(
+          `Policy name must be 1-128 characters long and can only contain letters, numbers, and dashes.`
+        );
       }
 
       const shouldRedirectAfterSave = this.policy.isNew;
@@ -60,7 +54,7 @@ export default class PolicyEditorComponent extends Component {
     } catch (error) {
       this.flashMessages.add({
         title: `Error creating Policy ${this.policy.name}`,
-        message: messageForError(error),
+        message: error,
         type: 'error',
         destroyOnClick: false,
         sticky: true,

--- a/ui/app/components/policy-editor.js
+++ b/ui/app/components/policy-editor.js
@@ -32,6 +32,8 @@ export default class PolicyEditorComponent extends Component {
         };
       }
 
+      const shouldRedirectAfterSave = this.policy.isNew;
+
       if (
         this.policy.isNew &&
         this.store.peekRecord('policy', this.policy.name)
@@ -52,7 +54,9 @@ export default class PolicyEditorComponent extends Component {
         timeout: 5000,
       });
 
-      this.router.transitionTo('policies');
+      if (shouldRedirectAfterSave) {
+        this.router.transitionTo('policies.policy', this.policy.id);
+      }
     } catch (error) {
       this.flashMessages.add({
         title: `Error creating Policy ${this.policy.name}`,

--- a/ui/app/components/policy-editor.js
+++ b/ui/app/components/policy-editor.js
@@ -22,9 +22,13 @@ export default class PolicyEditorComponent extends Component {
     try {
       const nameRegex = '^[a-zA-Z0-9-]{1,128}$';
       if (!this.policy.name?.match(nameRegex)) {
-        throw new Error(
-          'Policy name must be 1-128 characters long and can only contain letters, numbers, and dashes.'
-        );
+        throw {
+          errors: [
+            {
+              detail: 'Policy name must be 1-128 characters long and can only contain letters, numbers, and dashes.'
+            }
+          ]
+        };
       }
 
       if (
@@ -49,7 +53,6 @@ export default class PolicyEditorComponent extends Component {
 
       this.router.transitionTo('policies');
     } catch (error) {
-      console.log('error and its', error);
       this.flashMessages.add({
         title: `Error creating Policy ${this.policy.name}`,
         message: messageForError(error),

--- a/ui/app/components/tooltip.js
+++ b/ui/app/components/tooltip.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 export default class Tooltip extends Component {
   get text() {
-    const inputText = this.args.text;
+    const inputText = this.args.text?.toString();
     if (!inputText || inputText.length < 30) {
       return inputText;
     }

--- a/ui/app/controllers/policies/index.js
+++ b/ui/app/controllers/policies/index.js
@@ -6,7 +6,7 @@ export default class PoliciesIndexController extends Controller {
   @service router;
   get policies() {
     return this.model.policies.map((policy) => {
-      policy.tokens = this.model.tokens.filter((token) => {
+      policy.tokens = (this.model.tokens || []).filter((token) => {
         return token.policies.includes(policy);
       });
       return policy;

--- a/ui/app/controllers/policies/policy.js
+++ b/ui/app/controllers/policies/policy.js
@@ -18,6 +18,10 @@ export default class PoliciesPolicyController extends Controller {
 
   @tracked isDeleting = false;
 
+  get newTokenString() {
+    return `nomad acl token create -name="<TOKEN_NAME>" -policy=${this.policy.name} -type=client -ttl=<8h>`
+  }
+
   @action
   onDeletePrompt() {
     this.isDeleting = true;

--- a/ui/app/controllers/policies/policy.js
+++ b/ui/app/controllers/policies/policy.js
@@ -20,7 +20,7 @@ export default class PoliciesPolicyController extends Controller {
   @tracked isDeleting = false;
 
   get newTokenString() {
-    return `nomad acl token create -name="<TOKEN_NAME>" -policy=${this.policy.name} -type=client -ttl=<8h>`;
+    return `nomad acl token create -name="<TOKEN_NAME>" -policy="${this.policy.name}" -type=client -ttl=<8h>`;
   }
 
   @action
@@ -80,7 +80,13 @@ export default class PoliciesPolicyController extends Controller {
         message: `${newToken.accessor}`,
         type: 'success',
         destroyOnClick: false,
-        timeout: 60000,
+        timeout: 30000,
+        customAction: {
+          label: 'Copy to Clipboard',
+          action: () => {
+            navigator.clipboard.writeText(newToken.accessor);
+          },
+        },
       });
     } catch (err) {
       this.error = {
@@ -102,7 +108,7 @@ export default class PoliciesPolicyController extends Controller {
         title: 'Token successfully deleted',
         type: 'success',
         destroyOnClick: false,
-        timeout: 60000,
+        timeout: 5000,
       });
     } catch (err) {
       this.error = {

--- a/ui/app/controllers/policies/policy.js
+++ b/ui/app/controllers/policies/policy.js
@@ -10,6 +10,9 @@ export default class PoliciesPolicyController extends Controller {
   @service flashMessages;
   @service router;
 
+  @alias ('model.policy') policy;
+  @alias ('model.tokens') tokens;
+
   @tracked
   error = null;
 
@@ -27,8 +30,8 @@ export default class PoliciesPolicyController extends Controller {
 
   @task(function* () {
     try {
-      yield this.model.deleteRecord();
-      yield this.model.save();
+      yield this.policy.deleteRecord();
+      yield this.policy.save();
       this.flashMessages.add({
         title: 'Policy Deleted',
         type: 'success',
@@ -38,7 +41,7 @@ export default class PoliciesPolicyController extends Controller {
       this.router.transitionTo('policies');
     } catch (err) {
       this.flashMessages.add({
-        title: `Error deleting Policy ${this.model.name}`,
+        title: `Error deleting Policy ${this.policy.name}`,
         message: err,
         type: 'error',
         destroyOnClick: false,

--- a/ui/app/controllers/policies/policy.js
+++ b/ui/app/controllers/policies/policy.js
@@ -3,11 +3,15 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { alias } from '@ember/object/computed';
 import { task } from 'ember-concurrency';
 
 export default class PoliciesPolicyController extends Controller {
   @service flashMessages;
   @service router;
+
+  @tracked
+  error = null;
 
   @tracked isDeleting = false;
 
@@ -43,4 +47,37 @@ export default class PoliciesPolicyController extends Controller {
     }
   })
   deletePolicy;
+
+  @task(function* () {
+    try {
+
+      const newToken = this.store.createRecord('token', {
+        name: `Example Token for ${this.policy.name}`,
+        policies: [this.policy],
+        // New date 10 minutes into the future
+        expirationTime: new Date(Date.now() + 10 * 60 * 1000),
+        type: "client"
+      });
+      yield newToken.save();
+      console.table(newToken.toJSON())
+      console.log('Accessor:', newToken.accessor)
+      this.flashMessages.add({
+        title: 'Example Token Created',
+        message: `${newToken.accessor}`,
+        type: 'success',
+        destroyOnClick: false,
+        timeout: 60000,
+      });
+    } catch (err) {
+      this.error = {
+        title: 'Error creating new token',
+        description: err,
+      };
+
+      throw err;
+    }
+  }) createTestToken;
+
+
 }
+

--- a/ui/app/controllers/policies/policy.js
+++ b/ui/app/controllers/policies/policy.js
@@ -10,8 +10,8 @@ export default class PoliciesPolicyController extends Controller {
   @service flashMessages;
   @service router;
 
-  @alias ('model.policy') policy;
-  @alias ('model.tokens') tokens;
+  @alias('model.policy') policy;
+  @alias('model.tokens') tokens;
 
   @tracked
   error = null;
@@ -53,17 +53,16 @@ export default class PoliciesPolicyController extends Controller {
 
   @task(function* () {
     try {
-
       const newToken = this.store.createRecord('token', {
         name: `Example Token for ${this.policy.name}`,
         policies: [this.policy],
         // New date 10 minutes into the future
         expirationTime: new Date(Date.now() + 10 * 60 * 1000),
-        type: "client"
+        type: 'client',
       });
       yield newToken.save();
-      console.table(newToken.toJSON())
-      console.log('Accessor:', newToken.accessor)
+      console.table(newToken.toJSON());
+      console.log('Accessor:', newToken.accessor);
       this.flashMessages.add({
         title: 'Example Token Created',
         message: `${newToken.accessor}`,
@@ -79,8 +78,6 @@ export default class PoliciesPolicyController extends Controller {
 
       throw err;
     }
-  }) createTestToken;
-
-
+  })
+  createTestToken;
 }
-

--- a/ui/app/controllers/policies/policy.js
+++ b/ui/app/controllers/policies/policy.js
@@ -92,4 +92,26 @@ export default class PoliciesPolicyController extends Controller {
     }
   })
   createTestToken;
+
+  @task(function* (token) {
+    try {
+      yield token.deleteRecord();
+      yield token.save();
+      this.refreshTokens();
+      this.flashMessages.add({
+        title: 'Token successfully deleted',
+        type: 'success',
+        destroyOnClick: false,
+        timeout: 60000,
+      });
+    } catch (err) {
+      this.error = {
+        title: 'Error deleting token',
+        description: err,
+      };
+
+      throw err;
+    }
+  })
+  deleteToken;
 }

--- a/ui/app/controllers/policies/policy.js
+++ b/ui/app/controllers/policies/policy.js
@@ -74,7 +74,7 @@ export default class PoliciesPolicyController extends Controller {
         type: 'client',
       });
       yield newToken.save();
-      this.refreshTokens();
+      yield this.refreshTokens();
       this.flashMessages.add({
         title: 'Example Token Created',
         message: `${newToken.secret}`,
@@ -103,7 +103,7 @@ export default class PoliciesPolicyController extends Controller {
     try {
       yield token.deleteRecord();
       yield token.save();
-      this.refreshTokens();
+      yield this.refreshTokens();
       this.flashMessages.add({
         title: 'Token successfully deleted',
         type: 'success',

--- a/ui/app/controllers/policies/policy.js
+++ b/ui/app/controllers/policies/policy.js
@@ -77,14 +77,14 @@ export default class PoliciesPolicyController extends Controller {
       this.refreshTokens();
       this.flashMessages.add({
         title: 'Example Token Created',
-        message: `${newToken.accessor}`,
+        message: `${newToken.secret}`,
         type: 'success',
         destroyOnClick: false,
         timeout: 30000,
         customAction: {
           label: 'Copy to Clipboard',
           action: () => {
-            navigator.clipboard.writeText(newToken.accessor);
+            navigator.clipboard.writeText(newToken.secret);
           },
         },
       });

--- a/ui/app/routes/policies.js
+++ b/ui/app/routes/policies.js
@@ -21,7 +21,9 @@ export default class PoliciesRoute extends Route.extend(
   async model() {
     return await hash({
       policies: this.store.query('policy', { reload: true }),
-      tokens: this.store.query('token', { reload: true }),
+      tokens:
+        this.can.can('list tokens') &&
+        this.store.query('token', { reload: true }),
     });
   }
 }

--- a/ui/app/routes/policies/policy.js
+++ b/ui/app/routes/policies/policy.js
@@ -14,7 +14,11 @@ export default class PoliciesPolicyRoute extends Route.extend(
       policy: this.store.findRecord('policy', decodeURIComponent(params.name), {
         reload: true,
       }),
-      tokens: this.store.peekAll('token').filter(token => token.policyNames?.includes(decodeURIComponent(params.name))),
+      tokens: this.store
+        .peekAll('token')
+        .filter((token) =>
+          token.policyNames?.includes(decodeURIComponent(params.name))
+        ),
     });
   }
 }

--- a/ui/app/routes/policies/policy.js
+++ b/ui/app/routes/policies/policy.js
@@ -8,9 +8,11 @@ export default class PoliciesPolicyRoute extends Route.extend(
   WithModelErrorHandling
 ) {
   @service store;
-  model(params) {
-    return this.store.findRecord('policy', decodeURIComponent(params.name), {
+  async model(params) {
+    const policy = await this.store.findRecord('policy', decodeURIComponent(params.name), {
       reload: true,
     });
+    const tokens = this.store.peekAll('token').filter(token => token.policyNames?.includes(policy.name));
+    return { policy, tokens };
   }
 }

--- a/ui/app/routes/policies/policy.js
+++ b/ui/app/routes/policies/policy.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import withForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
 import WithModelErrorHandling from 'nomad-ui/mixins/with-model-error-handling';
 import { inject as service } from '@ember/service';
+import { hash } from 'rsvp';
 
 export default class PoliciesPolicyRoute extends Route.extend(
   withForbiddenState,
@@ -9,10 +10,11 @@ export default class PoliciesPolicyRoute extends Route.extend(
 ) {
   @service store;
   async model(params) {
-    const policy = await this.store.findRecord('policy', decodeURIComponent(params.name), {
-      reload: true,
+    return await hash({
+      policy: this.store.findRecord('policy', decodeURIComponent(params.name), {
+        reload: true,
+      }),
+      tokens: this.store.peekAll('token').filter(token => token.policyNames?.includes(decodeURIComponent(params.name))),
     });
-    const tokens = this.store.peekAll('token').filter(token => token.policyNames?.includes(policy.name));
-    return { policy, tokens };
   }
 }

--- a/ui/app/routes/policies/policy.js
+++ b/ui/app/routes/policies/policy.js
@@ -10,7 +10,7 @@ export default class PoliciesPolicyRoute extends Route.extend(
 ) {
   @service store;
   async model(params) {
-    return await hash({
+    return hash({
       policy: this.store.findRecord('policy', decodeURIComponent(params.name), {
         reload: true,
       }),

--- a/ui/app/styles/components/policies.scss
+++ b/ui/app/styles/components/policies.scss
@@ -29,16 +29,31 @@ table.policies {
 .token-operations {
   margin-bottom: 3rem;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-auto-flow: column;
+  grid-template-columns: repeat(auto-fit, 50%);
   grid-auto-rows: minmax(100px, auto);
   gap: 1rem;
 
-  .notification {
-    padding: 1rem;
+  .boxed-section {
+    padding: 0;
     margin: 0;
+    display: grid;
+    grid-template-rows: auto 1fr;
 
-    button, pre {
+    button.create-test-token, pre {
       margin-top: 1rem;
     }
+
+    pre {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      align-content: flex-start;
+      white-space: normal;
+      overflow: visible;
+    }
   }
+}
+
+table.tokens {
+  margin-bottom: 3rem;
 }

--- a/ui/app/styles/components/policies.scss
+++ b/ui/app/styles/components/policies.scss
@@ -26,9 +26,19 @@ table.policies {
   }
 }
 
-.create-test-token {
-  pre {
-    background-color: black;
-    color: white;
+.token-operations {
+  margin-bottom: 3rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-auto-rows: minmax(100px, auto);
+  gap: 1rem;
+
+  .notification {
+    padding: 1rem;
+    margin: 0;
+
+    button, pre {
+      margin-top: 1rem;
+    }
   }
 }

--- a/ui/app/styles/components/policies.scss
+++ b/ui/app/styles/components/policies.scss
@@ -25,3 +25,10 @@ table.policies {
     margin-bottom: 1rem;
   }
 }
+
+.create-test-token {
+  pre {
+    background-color: black;
+    color: white;
+  }
+}

--- a/ui/app/styles/components/policies.scss
+++ b/ui/app/styles/components/policies.scss
@@ -40,6 +40,11 @@ table.policies {
     display: grid;
     grid-template-rows: auto 1fr;
 
+    .external-link svg {
+      position: relative;
+      top: 3px;  
+    }
+
     button.create-test-token, pre {
       margin-top: 1rem;
     }
@@ -53,6 +58,14 @@ table.policies {
     }
   }
 }
+
+@media #{$mq-hidden-gutter} {
+  .token-operations {
+    grid-auto-flow: row;
+    grid-template-columns: 1fr;
+  }
+}
+
 
 table.tokens {
   margin-bottom: 3rem;

--- a/ui/app/templates/policies/index.hbs
+++ b/ui/app/templates/policies/index.hbs
@@ -32,7 +32,9 @@
       @class="policies no-mobile-condense" as |t|>
       <t.head>
         <th>Policy Name</th>
-        <th>Tokens</th>
+        {{#if (can "list token")}}
+          <th>Tokens</th>
+        {{/if}}
       </t.head>
       <t.body as |row|>
         <tr data-test-policy-row {{on "click" (action "openPolicy" row.model)}}
@@ -43,14 +45,16 @@
           <td data-test-policy-name>
 						<LinkTo @route="policies.policy" @model={{row.model.name}}>{{row.model.name}}</LinkTo>
 					</td>
-          <td data-test-policy-token-count>
-						<span>
-              {{row.model.tokens.length}}
-              {{#if (filter-by "isExpired" row.model.tokens)}}
-                <span class="number-expired">({{get (filter-by "isExpired" row.model.tokens) "length"}} expired)</span>
-              {{/if}}
-            </span>
-					</td>
+          {{#if (can "list token")}}
+            <td data-test-policy-token-count>
+              <span>
+                {{row.model.tokens.length}}
+                {{#if (filter-by "isExpired" row.model.tokens)}}
+                  <span class="number-expired">({{get (filter-by "isExpired" row.model.tokens) "length"}} expired)</span>
+                {{/if}}
+              </span>
+            </td>
+          {{/if}}
         </tr>
       </t.body>
     </ListTable>

--- a/ui/app/templates/policies/index.hbs
+++ b/ui/app/templates/policies/index.hbs
@@ -48,9 +48,9 @@
           {{#if (can "list token")}}
             <td data-test-policy-token-count>
               <span>
-                {{row.model.tokens.length}}
+                <span data-test-policy-total-tokens>{{row.model.tokens.length}}</span>
                 {{#if (filter-by "isExpired" row.model.tokens)}}
-                  <span class="number-expired">({{get (filter-by "isExpired" row.model.tokens) "length"}} expired)</span>
+                  <span data-test-policy-expired-tokens class="number-expired">({{get (filter-by "isExpired" row.model.tokens) "length"}} expired)</span>
                 {{/if}}
               </span>
             </td>

--- a/ui/app/templates/policies/policy.hbs
+++ b/ui/app/templates/policies/policy.hbs
@@ -32,42 +32,44 @@
       Tokens
     </h2>
 
-    <div class="token-operations">
-      <div class="boxed-section">
-        <div class="boxed-section-head">
-          <h3>Create a Test Token</h3>
+    {{#if (can "write token")}}
+      <div class="token-operations">
+        <div class="boxed-section">
+          <div class="boxed-section-head">
+            <h3>Create a Test Token</h3>
+          </div>
+          <div class="boxed-section-body">
+            <p class="is-info">Create a test token that expires in 10 minutes for testing purposes.</p>
+            <label>
+              <button
+                type="button"
+                class="button is-info is-outlined create-test-token"
+                data-test-create-test-token
+                {{on "click" (perform this.createTestToken)}}
+                >Create Test Token</button>
+            </label>
+          </div>
         </div>
-        <div class="boxed-section-body">
-          <p class="is-info">Create a test token that expires in 10 minutes for testing purposes.</p>
-          <label>
-            <button
-              type="button"
-              class="button is-info is-outlined create-test-token"
-              data-test-create-test-token
-              {{on "click" (perform this.createTestToken)}}
-              >Create Test Token</button>
-          </label>
+        <div class="boxed-section">
+          <div class="boxed-section-head">
+            <h3>Create Tokens from the Nomad CLI</h3>
+          </div>
+          <div class="boxed-section-body">
+            <p>When you're ready to create more tokens, you can do so via the <a class="external-link" href="https://developer.hashicorp.com/nomad/docs/commands" target="_blank" rel="noopener noreferrer">Nomad CLI <FlightIcon @name="external-link" /></a> with the following:
+              <pre>
+                <code>{{this.newTokenString}}</code>
+                <CopyButton
+                  data-test-copy-button
+                  @clipboardText={{this.newTokenString}}
+                  @compact={{true}}
+                >
+                </CopyButton>
+              </pre>
+            </p>
+          </div>
         </div>
       </div>
-      <div class="boxed-section">
-        <div class="boxed-section-head">
-          <h3>Create Tokens from the Nomad CLI</h3>
-        </div>
-        <div class="boxed-section-body">
-          <p>When you're ready to create more tokens, you can do so via the <a class="external-link" href="https://developer.hashicorp.com/nomad/docs/commands" target="_blank" rel="noopener noreferrer">Nomad CLI <FlightIcon @name="external-link" /></a> with the following:
-            <pre>
-              <code>{{this.newTokenString}}</code>
-              <CopyButton
-                data-test-copy-button
-                @clipboardText={{this.newTokenString}}
-                @compact={{true}}
-              >
-              </CopyButton>
-            </pre>
-          </p>
-        </div>
-      </div>
-    </div>
+    {{/if}}
 
     {{#if this.tokens.length}}
       <ListTable
@@ -77,7 +79,9 @@
           <th>Name</th>
           <th>Created</th>
           <th>Expires</th>
-          <th>Delete</th>
+          {{#if (can "destroy token")}}
+            <th>Delete</th>
+          {{/if}}
         </t.head>
         <t.body as |row|>
           <tr data-test-policy-token-row>
@@ -98,22 +102,24 @@
                 <span class="has-text-grey">Never</span>
               {{/if}}
             </td>
-            <td class="is-200px">
-              <TwoStepButton
-                data-test-delete-token-button
-                @idleText="Delete"
-                @cancelText="Cancel"
-                @confirmText="Yes, delete"
-                @confirmationMessage="Are you sure?"
-                @awaitingConfirmation={{row.model.isPendingDeletion}}
-                @onConfirm={{perform this.deleteToken row.model}}
-                @inlineText={{true}}
-                @classes={{hash
-                  idleButton="is-danger is-outlined"
-                  confirmButton="is-danger"
-                }}
-              />
-            </td>
+            {{#if (can "destroy token")}}
+              <td class="is-200px">
+                <TwoStepButton
+                  data-test-delete-token-button
+                  @idleText="Delete"
+                  @cancelText="Cancel"
+                  @confirmText="Yes, delete"
+                  @confirmationMessage="Are you sure?"
+                  @awaitingConfirmation={{row.model.isPendingDeletion}}
+                  @onConfirm={{perform this.deleteToken row.model}}
+                  @inlineText={{true}}
+                  @classes={{hash
+                    idleButton="is-danger is-outlined"
+                    confirmButton="is-danger"
+                  }}
+                />
+              </td>
+            {{/if}}
           </tr>
         </t.body>
       </ListTable>

--- a/ui/app/templates/policies/policy.hbs
+++ b/ui/app/templates/policies/policy.hbs
@@ -1,5 +1,5 @@
 <Breadcrumb @crumb={{hash label=this.policy.name args=(array "policies.policy" this.policy.name)}} />
-
+{{log "uhhh" this.policy}}
 {{page-title "Policy"}}
 <section class="section">
 	<h1 class="title with-flex" data-test-title>
@@ -10,7 +10,7 @@
 			<div>
 				<TwoStepButton
 					data-test-delete-button
-					@idleText="Delete"
+					@idleText="Delete this policy"
 					@cancelText="Cancel"
 					@confirmText="Yes, delete"
 					@confirmationMessage="Are you sure?"
@@ -27,25 +27,10 @@
 	/>
 
 	<hr />
-	<section class="create-test-token">
-		<div class="title with-flex is-2">
-			<h2 class="title">Create a test token for this policy</h2>
-			<button
-				class="button is-primary"
-				data-test-create-test-token
-				{{on "click" (perform this.createTestToken)}}
-				>Create Test Token</button>
-		</div>
-		<p class="is-info">Create a test token that expires in 10 minutes for testing purposes.</p>
-		<p>When you're ready to create more tokens, you can do so in your terminal with
-			<pre><code>nomad acl token create -name="&lt;TOKEN_NAME&gt;" -policy={{this.policy.name}} -type=client -ttl=&lt;8h&gt;</code></pre>
-		</p>
-	</section>
 
-	<hr />
-	<h1 class="title">
+	<h2 class="title">
 		Tokens for {{this.policy.name}}
-	</h1>
+	</h2>
   {{#if this.tokens.length}}
     <ListTable
       @source={{this.tokens}}
@@ -53,8 +38,7 @@
       <t.head>
         <th>Name</th>
         <th>Created</th>
-				<th>Expires</th>
-				<th>Extend</th>
+				<th>Expiry</th>
 				<th>Delete</th>
       </t.head>
       <t.body as |row|>
@@ -76,29 +60,7 @@
 							<span class="has-text-grey">Never</span>
 						{{/if}}
 					</td>
-					<td>
-						{{#if row.model.expirationTime}}
-							{{#if row.model.isExpired}}
-								<span class="has-text-grey">Expired</span>
-							{{else}}
-								<TwoStepButton
-									@idleText="Extend by 8 hours"
-									@cancelText="Cancel"
-									@confirmText="Yes, extend"
-									@confirmationMessage="Are you sure?"
-									@awaitingConfirmation={{row.model.isPendingExtension}}
-									@onConfirm={{perform this.extendToken row.model}}
-									@classes={{hash
-										idleButton="is-info"
-										confirmButton="is-info"
-									}}
-								/>
-							{{/if}}
-						{{else}}
-							<span class="has-text-grey">N/A</span>
-						{{/if}}
-					</td>
-					<td>
+					<td class="is-200px">
 						<TwoStepButton
 							@idleText="Delete"
 							@cancelText="Cancel"
@@ -106,8 +68,9 @@
 							@confirmationMessage="Are you sure?"
 							@awaitingConfirmation={{row.model.isPendingDeletion}}
 							@onConfirm={{perform this.deleteToken row.model}}
+							@inlineText={{true}}
 							@classes={{hash
-								idleButton="is-danger"
+								idleButton="is-danger is-outlined"
 								confirmButton="is-danger"
 							}}
 						/>
@@ -125,6 +88,47 @@
 			</p>
 		</div>
 	{{/if}}
+
+	<hr />
+	<div class="token-operations">
+		<div class="notification">
+      <h3 class="title is-4">Create a Test Token</h3>
+      <p class="is-info">Create a test token that expires in 10 minutes for testing purposes.</p>
+			<label>
+				<button
+					type="button"
+					class="button is-primary"
+					data-test-create-test-token
+					{{on "click" (perform this.createTestToken)}}
+					>Create Test Token</button>
+			</label>
+		</div>
+		<div class="notification">
+      <h3 class="title is-4">Create Tokens from the Nomad CLI</h3>
+      <p>When you're ready to create more tokens, you can do so in your terminal with
+        <pre><code>nomad acl token create -name="&lt;TOKEN_NAME&gt;" -policy={{this.policy.name}} -type=client -ttl=&lt;8h&gt;</code></pre>
+      </p>
+		</div>
+	</div>
+
+	{{!-- <section class="create-test-token">
+		<h2 class="title with-flex">
+			<div>Tokens for {{this.policy.name}}</div>
+			<label>
+				<button
+					type="button"
+					class="button is-primary"
+					data-test-create-test-token
+					{{on "click" (perform this.createTestToken)}}
+					>Create Test Token</button>
+			</label>
+		</h2>
+		<p>When you're ready to create more tokens, you can do so in your terminal with
+			<pre><code>nomad acl token create -name="&lt;TOKEN_NAME&gt;" -policy={{this.policy.name}} -type=client -ttl=&lt;8h&gt;</code></pre>
+		</p>
+	</section> --}}
+
+
 </section>
 
 {{outlet}}

--- a/ui/app/templates/policies/policy.hbs
+++ b/ui/app/templates/policies/policy.hbs
@@ -77,7 +77,7 @@
       <t.head>
         <th>Name</th>
         <th>Created</th>
-				<th>Expiry</th>
+				<th>Expires</th>
 				<th>Delete</th>
       </t.head>
       <t.body as |row|>

--- a/ui/app/templates/policies/policy.hbs
+++ b/ui/app/templates/policies/policy.hbs
@@ -10,7 +10,7 @@
 			<div>
 				<TwoStepButton
 					data-test-delete-button
-					@idleText="Delete this policy"
+					@idleText="Delete policy"
 					@cancelText="Cancel"
 					@confirmText="Yes, delete"
 					@confirmationMessage="Are you sure?"
@@ -29,8 +29,47 @@
 	<hr />
 
 	<h2 class="title">
-		Tokens for {{this.policy.name}}
+		Tokens
 	</h2>
+
+
+	<div class="token-operations">
+		<div class="boxed-section">
+      <div class="boxed-section-head">
+        <h3>Create a Test Token</h3>
+      </div>
+      <div class="boxed-section-body">
+        <p class="is-info">Create a test token that expires in 10 minutes for testing purposes.</p>
+        <label>
+          <button
+            type="button"
+            class="button is-info is-outlined create-test-token"
+            data-test-create-test-token
+            {{on "click" (perform this.createTestToken)}}
+            >Create Test Token</button>
+        </label>
+      </div>
+		</div>
+		<div class="boxed-section">
+      <div class="boxed-section-head">
+        <h3>Create Tokens from the Nomad CLI</h3>
+      </div>
+      <div class="boxed-section-body">
+        <p>When you're ready to create more tokens, you can do so in your terminal with
+          <pre>
+            <code>nomad acl token create -name="&lt;TOKEN_NAME&gt;" -policy={{this.policy.name}} -type=client -ttl=&lt;8h&gt;</code>
+            <CopyButton
+              data-test-copy-button
+              @clipboardText='nomad acl token create -name="&lt;TOKEN_NAME&gt;" -policy={{this.policy.name}} -type=client -ttl=&lt;8h&gt;'
+              @compact={{true}}
+            >
+            </CopyButton>
+          </pre>
+        </p>
+      </div>
+		</div>
+	</div>
+
   {{#if this.tokens.length}}
     <ListTable
       @source={{this.tokens}}
@@ -88,46 +127,6 @@
 			</p>
 		</div>
 	{{/if}}
-
-	<hr />
-	<div class="token-operations">
-		<div class="notification">
-      <h3 class="title is-4">Create a Test Token</h3>
-      <p class="is-info">Create a test token that expires in 10 minutes for testing purposes.</p>
-			<label>
-				<button
-					type="button"
-					class="button is-primary"
-					data-test-create-test-token
-					{{on "click" (perform this.createTestToken)}}
-					>Create Test Token</button>
-			</label>
-		</div>
-		<div class="notification">
-      <h3 class="title is-4">Create Tokens from the Nomad CLI</h3>
-      <p>When you're ready to create more tokens, you can do so in your terminal with
-        <pre><code>nomad acl token create -name="&lt;TOKEN_NAME&gt;" -policy={{this.policy.name}} -type=client -ttl=&lt;8h&gt;</code></pre>
-      </p>
-		</div>
-	</div>
-
-	{{!-- <section class="create-test-token">
-		<h2 class="title with-flex">
-			<div>Tokens for {{this.policy.name}}</div>
-			<label>
-				<button
-					type="button"
-					class="button is-primary"
-					data-test-create-test-token
-					{{on "click" (perform this.createTestToken)}}
-					>Create Test Token</button>
-			</label>
-		</h2>
-		<p>When you're ready to create more tokens, you can do so in your terminal with
-			<pre><code>nomad acl token create -name="&lt;TOKEN_NAME&gt;" -policy={{this.policy.name}} -type=client -ttl=&lt;8h&gt;</code></pre>
-		</p>
-	</section> --}}
-
 
 </section>
 

--- a/ui/app/templates/policies/policy.hbs
+++ b/ui/app/templates/policies/policy.hbs
@@ -80,8 +80,8 @@
           <th>Delete</th>
         </t.head>
         <t.body as |row|>
-          <tr>
-            <td>
+          <tr data-test-policy-token-row>
+            <td data-test-token-name>
               <Tooltip @text={{row.model.id}}>
                 {{row.model.name}}
               </Tooltip>
@@ -92,7 +92,7 @@
             <td>
               {{#if row.model.expirationTime}}
                 <Tooltip @text={{row.model.expirationTime}}>
-                  <span class="{{if row.model.isExpired "has-text-danger"}}">{{moment-from-now row.model.expirationTime interval=1000}}</span>
+                  <span data-test-token-expiration-time class="{{if row.model.isExpired "has-text-danger"}}">{{moment-from-now row.model.expirationTime interval=1000}}</span>
                 </Tooltip>
               {{else}}
                 <span class="has-text-grey">Never</span>
@@ -100,6 +100,7 @@
             </td>
             <td class="is-200px">
               <TwoStepButton
+                data-test-delete-token-button
                 @idleText="Delete"
                 @cancelText="Cancel"
                 @confirmText="Yes, delete"

--- a/ui/app/templates/policies/policy.hbs
+++ b/ui/app/templates/policies/policy.hbs
@@ -1,10 +1,10 @@
-<Breadcrumb @crumb={{hash label=this.model.name args=(array "policies.policy" this.model.name)}} />
+<Breadcrumb @crumb={{hash label=this.policy.name args=(array "policies.policy" this.policy.name)}} />
 
 {{page-title "Policy"}}
 <section class="section">
 	<h1 class="title with-flex" data-test-title>
 		<div>
-			{{this.model.name}}
+			{{this.policy.name}}
 		</div>
 		{{#if (can "destroy policy")}}
 			<div>
@@ -23,7 +23,108 @@
 		{{/if}}
 	</h1>
 	<PolicyEditor
-		@policy={{this.model}}
+		@policy={{this.policy}}
 	/>
+
+	<hr />
+	<section class="create-test-token">
+		<div class="title with-flex is-2">
+			<h2 class="title">Create a test token for this policy</h2>
+			<button
+				class="button is-primary"
+				data-test-create-test-token
+				{{on "click" (perform this.createTestToken)}}
+				>Create Test Token</button>
+		</div>
+		<p class="is-info">Create a test token that expires in 10 minutes for testing purposes.</p>
+		<p>When you're ready to create more tokens, you can do so in your terminal with
+			<pre><code>nomad acl token create -name="&lt;TOKEN_NAME&gt;" -policy={{this.policy.name}} -type=client -ttl=&lt;8h&gt;</code></pre>
+		</p>
+	</section>
+
+	<hr />
+	<h1 class="title">
+		Tokens for {{this.policy.name}}
+	</h1>
+  {{#if this.tokens.length}}
+    <ListTable
+      @source={{this.tokens}}
+      @class="tokens" as |t|>
+      <t.head>
+        <th>Name</th>
+        <th>Created</th>
+				<th>Expires</th>
+				<th>Extend</th>
+				<th>Delete</th>
+      </t.head>
+      <t.body as |row|>
+        <tr>
+          <td>
+						<Tooltip @text={{row.model.id}}>
+							{{row.model.name}}
+						</Tooltip>
+					</td>
+          <td>
+						{{moment-from-now row.model.createTime interval=1000}}
+					</td>
+					<td>
+						{{#if row.model.expirationTime}}
+							<Tooltip @text={{row.model.expirationTime}}>
+								<span class="{{if row.model.isExpired "has-text-danger"}}">{{moment-from-now row.model.expirationTime interval=1000}}</span>
+							</Tooltip>
+						{{else}}
+							<span class="has-text-grey">Never</span>
+						{{/if}}
+					</td>
+					<td>
+						{{#if row.model.expirationTime}}
+							{{#if row.model.isExpired}}
+								<span class="has-text-grey">Expired</span>
+							{{else}}
+								<TwoStepButton
+									@idleText="Extend by 8 hours"
+									@cancelText="Cancel"
+									@confirmText="Yes, extend"
+									@confirmationMessage="Are you sure?"
+									@awaitingConfirmation={{row.model.isPendingExtension}}
+									@onConfirm={{perform this.extendToken row.model}}
+									@classes={{hash
+										idleButton="is-info"
+										confirmButton="is-info"
+									}}
+								/>
+							{{/if}}
+						{{else}}
+							<span class="has-text-grey">N/A</span>
+						{{/if}}
+					</td>
+					<td>
+						<TwoStepButton
+							@idleText="Delete"
+							@cancelText="Cancel"
+							@confirmText="Yes, delete"
+							@confirmationMessage="Are you sure?"
+							@awaitingConfirmation={{row.model.isPendingDeletion}}
+							@onConfirm={{perform this.deleteToken row.model}}
+							@classes={{hash
+								idleButton="is-danger"
+								confirmButton="is-danger"
+							}}
+						/>
+					</td>
+        </tr>
+      </t.body>
+    </ListTable>
+	{{else}}
+		<div class="empty-message">
+			<h3 data-test-empty-policies-list-headline class="empty-message-headline">
+				No Tokens
+			</h3>
+			<p class="empty-message-body">
+				No tokens are using this policy.
+			</p>
+		</div>
+	{{/if}}
 </section>
+
 {{outlet}}

--- a/ui/app/templates/policies/policy.hbs
+++ b/ui/app/templates/policies/policy.hbs
@@ -55,12 +55,12 @@
         <h3>Create Tokens from the Nomad CLI</h3>
       </div>
       <div class="boxed-section-body">
-        <p>When you're ready to create more tokens, you can do so in your terminal with
+        <p>When you're ready to create more tokens, you can do so via the <a class="external-link" href="https://developer.hashicorp.com/nomad/docs/commands" target="_blank" rel="noopener noreferrer">Nomad CLI <FlightIcon @name="external-link" /></a> with the following:
           <pre>
-            <code>nomad acl token create -name="&lt;TOKEN_NAME&gt;" -policy={{this.policy.name}} -type=client -ttl=&lt;8h&gt;</code>
+            <code>{{this.newTokenString}}</code>
             <CopyButton
               data-test-copy-button
-              @clipboardText='nomad acl token create -name="&lt;TOKEN_NAME&gt;" -policy={{this.policy.name}} -type=client -ttl=&lt;8h&gt;'
+              @clipboardText={{this.newTokenString}}
               @compact={{true}}
             >
             </CopyButton>
@@ -73,7 +73,7 @@
   {{#if this.tokens.length}}
     <ListTable
       @source={{this.tokens}}
-      @class="tokens" as |t|>
+      @class="tokens no-mobile-condense" as |t|>
       <t.head>
         <th>Name</th>
         <th>Created</th>

--- a/ui/app/templates/policies/policy.hbs
+++ b/ui/app/templates/policies/policy.hbs
@@ -1,5 +1,4 @@
 <Breadcrumb @crumb={{hash label=this.policy.name args=(array "policies.policy" this.policy.name)}} />
-{{log "uhhh" this.policy}}
 {{page-title "Policy"}}
 <section class="section">
 	<h1 class="title with-flex" data-test-title>
@@ -26,107 +25,108 @@
 		@policy={{this.policy}}
 	/>
 
-	<hr />
+  {{#if (can "list token")}}
+    <hr />
 
-	<h2 class="title">
-		Tokens
-	</h2>
+    <h2 class="title">
+      Tokens
+    </h2>
 
+    <div class="token-operations">
+      <div class="boxed-section">
+        <div class="boxed-section-head">
+          <h3>Create a Test Token</h3>
+        </div>
+        <div class="boxed-section-body">
+          <p class="is-info">Create a test token that expires in 10 minutes for testing purposes.</p>
+          <label>
+            <button
+              type="button"
+              class="button is-info is-outlined create-test-token"
+              data-test-create-test-token
+              {{on "click" (perform this.createTestToken)}}
+              >Create Test Token</button>
+          </label>
+        </div>
+      </div>
+      <div class="boxed-section">
+        <div class="boxed-section-head">
+          <h3>Create Tokens from the Nomad CLI</h3>
+        </div>
+        <div class="boxed-section-body">
+          <p>When you're ready to create more tokens, you can do so via the <a class="external-link" href="https://developer.hashicorp.com/nomad/docs/commands" target="_blank" rel="noopener noreferrer">Nomad CLI <FlightIcon @name="external-link" /></a> with the following:
+            <pre>
+              <code>{{this.newTokenString}}</code>
+              <CopyButton
+                data-test-copy-button
+                @clipboardText={{this.newTokenString}}
+                @compact={{true}}
+              >
+              </CopyButton>
+            </pre>
+          </p>
+        </div>
+      </div>
+    </div>
 
-	<div class="token-operations">
-		<div class="boxed-section">
-      <div class="boxed-section-head">
-        <h3>Create a Test Token</h3>
-      </div>
-      <div class="boxed-section-body">
-        <p class="is-info">Create a test token that expires in 10 minutes for testing purposes.</p>
-        <label>
-          <button
-            type="button"
-            class="button is-info is-outlined create-test-token"
-            data-test-create-test-token
-            {{on "click" (perform this.createTestToken)}}
-            >Create Test Token</button>
-        </label>
-      </div>
-		</div>
-		<div class="boxed-section">
-      <div class="boxed-section-head">
-        <h3>Create Tokens from the Nomad CLI</h3>
-      </div>
-      <div class="boxed-section-body">
-        <p>When you're ready to create more tokens, you can do so via the <a class="external-link" href="https://developer.hashicorp.com/nomad/docs/commands" target="_blank" rel="noopener noreferrer">Nomad CLI <FlightIcon @name="external-link" /></a> with the following:
-          <pre>
-            <code>{{this.newTokenString}}</code>
-            <CopyButton
-              data-test-copy-button
-              @clipboardText={{this.newTokenString}}
-              @compact={{true}}
-            >
-            </CopyButton>
-          </pre>
+    {{#if this.tokens.length}}
+      <ListTable
+        @source={{this.tokens}}
+        @class="tokens no-mobile-condense" as |t|>
+        <t.head>
+          <th>Name</th>
+          <th>Created</th>
+          <th>Expires</th>
+          <th>Delete</th>
+        </t.head>
+        <t.body as |row|>
+          <tr>
+            <td>
+              <Tooltip @text={{row.model.id}}>
+                {{row.model.name}}
+              </Tooltip>
+            </td>
+            <td>
+              {{moment-from-now row.model.createTime interval=1000}}
+            </td>
+            <td>
+              {{#if row.model.expirationTime}}
+                <Tooltip @text={{row.model.expirationTime}}>
+                  <span class="{{if row.model.isExpired "has-text-danger"}}">{{moment-from-now row.model.expirationTime interval=1000}}</span>
+                </Tooltip>
+              {{else}}
+                <span class="has-text-grey">Never</span>
+              {{/if}}
+            </td>
+            <td class="is-200px">
+              <TwoStepButton
+                @idleText="Delete"
+                @cancelText="Cancel"
+                @confirmText="Yes, delete"
+                @confirmationMessage="Are you sure?"
+                @awaitingConfirmation={{row.model.isPendingDeletion}}
+                @onConfirm={{perform this.deleteToken row.model}}
+                @inlineText={{true}}
+                @classes={{hash
+                  idleButton="is-danger is-outlined"
+                  confirmButton="is-danger"
+                }}
+              />
+            </td>
+          </tr>
+        </t.body>
+      </ListTable>
+    {{else}}
+      <div class="empty-message">
+        <h3 data-test-empty-policies-list-headline class="empty-message-headline">
+          No Tokens
+        </h3>
+        <p class="empty-message-body">
+          No tokens are using this policy.
         </p>
       </div>
-		</div>
-	</div>
-
-  {{#if this.tokens.length}}
-    <ListTable
-      @source={{this.tokens}}
-      @class="tokens no-mobile-condense" as |t|>
-      <t.head>
-        <th>Name</th>
-        <th>Created</th>
-				<th>Expires</th>
-				<th>Delete</th>
-      </t.head>
-      <t.body as |row|>
-        <tr>
-          <td>
-						<Tooltip @text={{row.model.id}}>
-							{{row.model.name}}
-						</Tooltip>
-					</td>
-          <td>
-						{{moment-from-now row.model.createTime interval=1000}}
-					</td>
-					<td>
-						{{#if row.model.expirationTime}}
-							<Tooltip @text={{row.model.expirationTime}}>
-								<span class="{{if row.model.isExpired "has-text-danger"}}">{{moment-from-now row.model.expirationTime interval=1000}}</span>
-							</Tooltip>
-						{{else}}
-							<span class="has-text-grey">Never</span>
-						{{/if}}
-					</td>
-					<td class="is-200px">
-						<TwoStepButton
-							@idleText="Delete"
-							@cancelText="Cancel"
-							@confirmText="Yes, delete"
-							@confirmationMessage="Are you sure?"
-							@awaitingConfirmation={{row.model.isPendingDeletion}}
-							@onConfirm={{perform this.deleteToken row.model}}
-							@inlineText={{true}}
-							@classes={{hash
-								idleButton="is-danger is-outlined"
-								confirmButton="is-danger"
-							}}
-						/>
-					</td>
-        </tr>
-      </t.body>
-    </ListTable>
-	{{else}}
-		<div class="empty-message">
-			<h3 data-test-empty-policies-list-headline class="empty-message-headline">
-				No Tokens
-			</h3>
-			<p class="empty-message-body">
-				No tokens are using this policy.
-			</p>
-		</div>
-	{{/if}}
+    {{/if}}
+  {{/if}}
 
 </section>
 

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -447,6 +447,23 @@ export default function () {
     return this.serialize(tokens.all());
   });
 
+  this.delete('/acl/token/:id', function (schema, request) {
+    const { id } = request.params;
+    server.db.tokens.remove(id);
+    return '';
+  });
+
+  this.post('/acl/token', function (schema, request) {
+    const { Name, Policies, Type } = JSON.parse(request.requestBody);
+    return server.create('token', {
+      name: Name,
+      policyIds: Policies,
+      type: Type,
+      id: faker.random.uuid(),
+      createTime: new Date().toISOString(),
+    });
+  });
+
   this.get('/acl/token/self', function ({ tokens }, req) {
     const secret = req.requestHeaders['X-Nomad-Token'];
     const tokenForSecret = tokens.findBy({ secretId: secret });

--- a/ui/mirage/factories/token.js
+++ b/ui/mirage/factories/token.js
@@ -14,6 +14,7 @@ export default Factory.extend({
   oneTimeSecret: () => faker.random.uuid(),
 
   afterCreate(token, server) {
+    if (token.policyIds && token.policyIds.length) return;
     const policyIds = Array(faker.random.number({ min: 1, max: 5 }))
       .fill(0)
       .map(() => faker.hacker.verb())

--- a/ui/tests/acceptance/policies-test.js
+++ b/ui/tests/acceptance/policies-test.js
@@ -46,7 +46,11 @@ module('Acceptance | policies', function (hooks) {
     assert.dom('[data-test-title]').includesText(server.db.policies[0].name);
     await click('button[type="submit"]');
     assert.dom('.flash-message.alert-success').exists();
-    assert.equal(currentURL(), `/policies/${server.db.policies[0].name}`, 'remain on page after save');
+    assert.equal(
+      currentURL(),
+      `/policies/${server.db.policies[0].name}`,
+      'remain on page after save'
+    );
     // Reset Token
     window.localStorage.nomadTokenSecret = null;
   });
@@ -68,7 +72,11 @@ module('Acceptance | policies', function (hooks) {
     await typeIn('[data-test-policy-name-input]', 'My-Fun-Policy');
     await click('button[type="submit"]');
     assert.dom('.flash-message.alert-success').exists();
-    assert.equal(currentURL(), '/policies/My-Fun-Policy', 'redirected to the now-created policy');
+    assert.equal(
+      currentURL(),
+      '/policies/My-Fun-Policy',
+      'redirected to the now-created policy'
+    );
     await visit('/policies');
     const newPolicy = [...findAll('[data-test-policy-name]')].filter((a) =>
       a.textContent.includes('My-Fun-Policy')

--- a/ui/tests/acceptance/policies-test.js
+++ b/ui/tests/acceptance/policies-test.js
@@ -46,7 +46,7 @@ module('Acceptance | policies', function (hooks) {
     assert.dom('[data-test-title]').includesText(server.db.policies[0].name);
     await click('button[type="submit"]');
     assert.dom('.flash-message.alert-success').exists();
-    assert.equal(currentURL(), '/policies');
+    assert.equal(currentURL(), `/policies/${server.db.policies[0].name}`, 'remain on page after save');
     // Reset Token
     window.localStorage.nomadTokenSecret = null;
   });
@@ -68,7 +68,8 @@ module('Acceptance | policies', function (hooks) {
     await typeIn('[data-test-policy-name-input]', 'My-Fun-Policy');
     await click('button[type="submit"]');
     assert.dom('.flash-message.alert-success').exists();
-    assert.equal(currentURL(), '/policies');
+    assert.equal(currentURL(), '/policies/My-Fun-Policy', 'redirected to the now-created policy');
+    await visit('/policies');
     const newPolicy = [...findAll('[data-test-policy-name]')].filter((a) =>
       a.textContent.includes('My-Fun-Policy')
     )[0];

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -432,17 +432,19 @@ module('Acceptance | tokens', function (hooks) {
       name: 'Expired Token',
       id: 'just-expired',
       policyIds: [server.db.policies[0].name],
-      expirationTime: new Date(new Date().getTime() -10 * 60 * 1000), // 10 minutes ago
+      expirationTime: new Date(new Date().getTime() - 10 * 60 * 1000), // 10 minutes ago
     });
-  
+
     window.localStorage.nomadTokenSecret = server.db.tokens[0].secretId;
     await visit('/policies');
-    assert.dom('[data-test-policy-token-count').exists();
+    assert.dom('[data-test-policy-token-count]').exists();
     const expectedFirstPolicyTokens = server.db.tokens.filter((token) => {
       return token.policyIds.includes(server.db.policies[0].name);
     });
-    assert.dom('[data-test-policy-total-tokens]').hasText(expectedFirstPolicyTokens.length.toString());
-    assert.dom('[data-test-policy-expired-tokens]').hasText("(1 expired)");
+    assert
+      .dom('[data-test-policy-total-tokens]')
+      .hasText(expectedFirstPolicyTokens.length.toString());
+    assert.dom('[data-test-policy-expired-tokens]').hasText('(1 expired)');
     window.localStorage.nomadTokenSecret = null;
   });
 
@@ -453,7 +455,7 @@ module('Acceptance | tokens', function (hooks) {
       name: 'Expired Token',
       id: 'just-expired',
       policyIds: [server.db.policies[0].name],
-      expirationTime: new Date(new Date().getTime() -10 * 60 * 1000), // 10 minutes ago
+      expirationTime: new Date(new Date().getTime() - 10 * 60 * 1000), // 10 minutes ago
     });
 
     window.localStorage.nomadTokenSecret = server.db.tokens[0].secretId;
@@ -466,12 +468,16 @@ module('Acceptance | tokens', function (hooks) {
       return token.policyIds.includes(server.db.policies[0].name);
     });
 
-    assert.dom('[data-test-policy-token-row]').exists({ count: expectedFirstPolicyTokens.length }, 'Expected number of tokens are shown');
+    assert
+      .dom('[data-test-policy-token-row]')
+      .exists(
+        { count: expectedFirstPolicyTokens.length },
+        'Expected number of tokens are shown'
+      );
     assert.dom('[data-test-token-expiration-time]').hasText('10 minutes ago');
 
     window.localStorage.nomadTokenSecret = null;
   });
-
 
   test('Tokens Deletion', async function (assert) {
     allScenarios.policiesTestCluster(server);
@@ -488,19 +494,25 @@ module('Acceptance | tokens', function (hooks) {
     await click('[data-test-policy-row]:first-child');
     assert.equal(currentURL(), `/policies/${server.db.policies[0].name}`);
 
-    assert.dom('[data-test-policy-token-row]').exists({ count: 3 }, 'Expected number of tokens are shown');
+    assert
+      .dom('[data-test-policy-token-row]')
+      .exists({ count: 3 }, 'Expected number of tokens are shown');
 
-    const doomedTokenRow = [...findAll('[data-test-policy-token-row]')].find((a) =>
-      a.textContent.includes('Doomed Token')
+    const doomedTokenRow = [...findAll('[data-test-policy-token-row]')].find(
+      (a) => a.textContent.includes('Doomed Token')
     );
 
     assert.dom(doomedTokenRow).exists();
 
     await click(doomedTokenRow.querySelector('button'));
-    assert.dom(doomedTokenRow.querySelector('[data-test-confirm-button]')).exists();
+    assert
+      .dom(doomedTokenRow.querySelector('[data-test-confirm-button]'))
+      .exists();
     await click(doomedTokenRow.querySelector('[data-test-confirm-button]'));
     assert.dom('.flash-message.alert-success').exists();
-    assert.dom('[data-test-policy-token-row]').exists({ count: 2 }, 'One fewer token after deletion');
+    assert
+      .dom('[data-test-policy-token-row]')
+      .exists({ count: 2 }, 'One fewer token after deletion');
     await percySnapshot(assert);
     window.localStorage.nomadTokenSecret = null;
   });
@@ -514,12 +526,18 @@ module('Acceptance | tokens', function (hooks) {
     await click('[data-test-policy-row]:first-child');
     assert.equal(currentURL(), `/policies/${server.db.policies[0].name}`);
 
-    assert.dom('[data-test-policy-token-row]').exists({ count: 2 }, 'Expected number of tokens are shown');
+    assert
+      .dom('[data-test-policy-token-row]')
+      .exists({ count: 2 }, 'Expected number of tokens are shown');
 
     await click('[data-test-create-test-token]');
     assert.dom('.flash-message.alert-success').exists();
-    assert.dom('[data-test-policy-token-row]').exists({ count: 3 }, 'One more token after test token creation');
-    assert.dom('[data-test-policy-token-row]:last-child [data-test-token-name]').hasText(`Example Token for ${server.db.policies[0].name}`);
+    assert
+      .dom('[data-test-policy-token-row]')
+      .exists({ count: 3 }, 'One more token after test token creation');
+    assert
+      .dom('[data-test-policy-token-row]:last-child [data-test-token-name]')
+      .hasText(`Example Token for ${server.db.policies[0].name}`);
     await percySnapshot(assert);
     window.localStorage.nomadTokenSecret = null;
   });

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -13,6 +13,7 @@ import percySnapshot from '@percy/ember';
 import faker from 'nomad-ui/mirage/faker';
 import moment from 'moment';
 import { run } from '@ember/runloop';
+import { allScenarios } from '../../mirage/scenarios/default';
 
 let job;
 let node;
@@ -422,6 +423,104 @@ module('Acceptance | tokens', function (hooks) {
       Layout.error.message,
       'Failed to exchange the one-time token.'
     );
+  });
+
+  test('Tokens are shown on the policies index page', async function (assert) {
+    allScenarios.policiesTestCluster(server);
+    // Create an expired token
+    server.create('token', {
+      name: 'Expired Token',
+      id: 'just-expired',
+      policyIds: [server.db.policies[0].name],
+      expirationTime: new Date(new Date().getTime() -10 * 60 * 1000), // 10 minutes ago
+    });
+  
+    window.localStorage.nomadTokenSecret = server.db.tokens[0].secretId;
+    await visit('/policies');
+    assert.dom('[data-test-policy-token-count').exists();
+    const expectedFirstPolicyTokens = server.db.tokens.filter((token) => {
+      return token.policyIds.includes(server.db.policies[0].name);
+    });
+    assert.dom('[data-test-policy-total-tokens]').hasText(expectedFirstPolicyTokens.length.toString());
+    assert.dom('[data-test-policy-expired-tokens]').hasText("(1 expired)");
+    window.localStorage.nomadTokenSecret = null;
+  });
+
+  test('Tokens are shown on a policy page', async function (assert) {
+    allScenarios.policiesTestCluster(server);
+    // Create an expired token
+    server.create('token', {
+      name: 'Expired Token',
+      id: 'just-expired',
+      policyIds: [server.db.policies[0].name],
+      expirationTime: new Date(new Date().getTime() -10 * 60 * 1000), // 10 minutes ago
+    });
+
+    window.localStorage.nomadTokenSecret = server.db.tokens[0].secretId;
+    await visit('/policies');
+
+    await click('[data-test-policy-row]:first-child');
+    assert.equal(currentURL(), `/policies/${server.db.policies[0].name}`);
+
+    const expectedFirstPolicyTokens = server.db.tokens.filter((token) => {
+      return token.policyIds.includes(server.db.policies[0].name);
+    });
+
+    assert.dom('[data-test-policy-token-row]').exists({ count: expectedFirstPolicyTokens.length }, 'Expected number of tokens are shown');
+    assert.dom('[data-test-token-expiration-time]').hasText('10 minutes ago');
+
+    window.localStorage.nomadTokenSecret = null;
+  });
+
+
+  test('Tokens Deletion', async function (assert) {
+    allScenarios.policiesTestCluster(server);
+    // Create an expired token
+    server.create('token', {
+      name: 'Doomed Token',
+      id: 'enjoying-my-day-here',
+      policyIds: [server.db.policies[0].name],
+    });
+
+    window.localStorage.nomadTokenSecret = server.db.tokens[0].secretId;
+    await visit('/policies');
+
+    await click('[data-test-policy-row]:first-child');
+    assert.equal(currentURL(), `/policies/${server.db.policies[0].name}`);
+
+    assert.dom('[data-test-policy-token-row]').exists({ count: 3 }, 'Expected number of tokens are shown');
+
+    const doomedTokenRow = [...findAll('[data-test-policy-token-row]')].find((a) =>
+      a.textContent.includes('Doomed Token')
+    );
+
+    assert.dom(doomedTokenRow).exists();
+
+    await click(doomedTokenRow.querySelector('button'));
+    assert.dom(doomedTokenRow.querySelector('[data-test-confirm-button]')).exists();
+    await click(doomedTokenRow.querySelector('[data-test-confirm-button]'));
+    assert.dom('.flash-message.alert-success').exists();
+    assert.dom('[data-test-policy-token-row]').exists({ count: 2 }, 'One fewer token after deletion');
+    window.localStorage.nomadTokenSecret = null;
+  });
+
+  test('Test Token Creation', async function (assert) {
+    allScenarios.policiesTestCluster(server);
+
+    window.localStorage.nomadTokenSecret = server.db.tokens[0].secretId;
+    await visit('/policies');
+
+    await click('[data-test-policy-row]:first-child');
+    assert.equal(currentURL(), `/policies/${server.db.policies[0].name}`);
+
+    assert.dom('[data-test-policy-token-row]').exists({ count: 2 }, 'Expected number of tokens are shown');
+
+    await click('[data-test-create-test-token]');
+    assert.dom('.flash-message.alert-success').exists();
+    assert.dom('[data-test-policy-token-row]').exists({ count: 3 }, 'One more token after test token creation');
+    assert.dom('[data-test-policy-token-row]:last-child [data-test-token-name]').hasText(`Example Token for ${server.db.policies[0].name}`);
+
+    window.localStorage.nomadTokenSecret = null;
   });
 
   function getHeader({ requestHeaders }, name) {

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -501,6 +501,7 @@ module('Acceptance | tokens', function (hooks) {
     await click(doomedTokenRow.querySelector('[data-test-confirm-button]'));
     assert.dom('.flash-message.alert-success').exists();
     assert.dom('[data-test-policy-token-row]').exists({ count: 2 }, 'One fewer token after deletion');
+    await percySnapshot(assert);
     window.localStorage.nomadTokenSecret = null;
   });
 
@@ -519,7 +520,7 @@ module('Acceptance | tokens', function (hooks) {
     assert.dom('.flash-message.alert-success').exists();
     assert.dom('[data-test-policy-token-row]').exists({ count: 3 }, 'One more token after test token creation');
     assert.dom('[data-test-policy-token-row]:last-child [data-test-token-name]').hasText(`Example Token for ${server.db.policies[0].name}`);
-
+    await percySnapshot(assert);
     window.localStorage.nomadTokenSecret = null;
   });
 

--- a/ui/tests/unit/abilities/token-test.js
+++ b/ui/tests/unit/abilities/token-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Ability | token', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const ability = this.owner.lookup('ability:token');
+    assert.ok(ability);
+  });
+});

--- a/ui/tests/unit/abilities/token-test.js
+++ b/ui/tests/unit/abilities/token-test.js
@@ -1,4 +1,4 @@
-// @ts-check
+/* eslint-disable ember/avoid-leaking-state-in-ember-objects */
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
@@ -36,7 +36,7 @@ module('Unit | Ability | token', function (hooks) {
 
   test('A non-ACL agent (bypassAuthorization) does not allow anything', function (assert) {
     const mockToken = Service.extend({
-      aclEnabled: false
+      aclEnabled: false,
     });
     this.owner.register('service:token', mockToken);
     assert.notOk(this.ability.canRead);
@@ -45,6 +45,4 @@ module('Unit | Ability | token', function (hooks) {
     assert.notOk(this.ability.canUpdate);
     assert.notOk(this.ability.canDestroy);
   });
-
-
 });

--- a/ui/tests/unit/abilities/token-test.js
+++ b/ui/tests/unit/abilities/token-test.js
@@ -1,11 +1,50 @@
+// @ts-check
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+import setupAbility from 'nomad-ui/tests/helpers/setup-ability';
 
 module('Unit | Ability | token', function (hooks) {
   setupTest(hooks);
+  setupAbility('token')(hooks);
 
-  test('it exists', function (assert) {
-    const ability = this.owner.lookup('ability:token');
-    assert.ok(ability);
+  test('A non-management user can do nothing with tokens', function (assert) {
+    const mockToken = Service.extend({
+      aclEnabled: true,
+      selfToken: { type: 'client' },
+    });
+    this.owner.register('service:token', mockToken);
+    assert.notOk(this.ability.canRead);
+    assert.notOk(this.ability.canList);
+    assert.notOk(this.ability.canWrite);
+    assert.notOk(this.ability.canUpdate);
+    assert.notOk(this.ability.canDestroy);
   });
+
+  test('A management user can do everything with tokens', function (assert) {
+    const mockToken = Service.extend({
+      aclEnabled: true,
+      selfToken: { type: 'management' },
+    });
+    this.owner.register('service:token', mockToken);
+    assert.ok(this.ability.canRead);
+    assert.ok(this.ability.canList);
+    assert.ok(this.ability.canWrite);
+    assert.ok(this.ability.canUpdate);
+    assert.ok(this.ability.canDestroy);
+  });
+
+  test('A non-ACL agent (bypassAuthorization) does not allow anything', function (assert) {
+    const mockToken = Service.extend({
+      aclEnabled: false
+    });
+    this.owner.register('service:token', mockToken);
+    assert.notOk(this.ability.canRead);
+    assert.notOk(this.ability.canList);
+    assert.notOk(this.ability.canWrite);
+    assert.notOk(this.ability.canUpdate);
+    assert.notOk(this.ability.canDestroy);
+  });
+
+
 });


### PR DESCRIPTION
Adds the ability to view, delete, and create tokens associated with a given policy in the new [Policies UI](https://github.com/hashicorp/nomad/pull/13976).

Ability to do any of this is available only to `manager` tokens only.

![image](https://user-images.githubusercontent.com/713991/206574930-27ff40ea-6393-4414-9400-aa0f9fda53fc.png)
