### PR TITLE
client: stop some taskrunner hooks when task exits

### DIFF
--- a/client/allocrunner/interfaces/task_lifecycle.go
+++ b/client/allocrunner/interfaces/task_lifecycle.go
@@ -148,6 +148,9 @@ type TaskExitedHook interface {
 
 	// Exited is called after a task exits and may or may not be restarted.
 	// Prestart may or may not have been called.
+	// Hooks that perform background work may need to implement this method to
+	// stop work when non-sidecar prestart and poststart exit, otherwise it
+	// will keep running until the job is stopped and the Stop hook is called.
 	//
 	// The context is cancelled if the task is killed.
 	Exited(context.Context, *TaskExitedRequest, *TaskExitedResponse) error

--- a/client/allocrunner/taskrunner/logmon_hook.go
+++ b/client/allocrunner/taskrunner/logmon_hook.go
@@ -193,6 +193,21 @@ func (h *logmonHook) prestartOneLoop(ctx context.Context, req *interfaces.TaskPr
 	return nil
 }
 
+// Exited runs when the task exits, but it may run again on restart.
+// Stop the logmong process but leave any final reattach cleanup for Stop.
+func (h *logmonHook) Exited(_ context.Context, _ *interfaces.TaskExitedRequest, _ *interfaces.TaskExitedResponse) error {
+	var err error
+	if h.logmon != nil {
+		err = h.logmon.Stop()
+	}
+
+	if h.logmonPluginClient != nil {
+		h.logmonPluginClient.Kill()
+	}
+
+	return err
+}
+
 func (h *logmonHook) Stop(_ context.Context, req *interfaces.TaskStopRequest, _ *interfaces.TaskStopResponse) error {
 
 	// It's possible that Stop was called without calling Prestart on agent

--- a/client/allocrunner/taskrunner/template_hook.go
+++ b/client/allocrunner/taskrunner/template_hook.go
@@ -161,6 +161,25 @@ func (h *templateHook) newManager() (unblock chan struct{}, err error) {
 	return unblock, nil
 }
 
+// Exited runs when the task exits, but it may run again on restart.
+// Stop the template manager to prevent updates to templates of exited tasks.
+func (h *templateHook) Exited(ctx context.Context, req *interfaces.TaskExitedRequest, resp *interfaces.TaskExitedResponse) error {
+	h.managerLock.Lock()
+	defer h.managerLock.Unlock()
+
+	// Shutdown any created template
+	if h.templateManager != nil {
+		h.templateManager.Stop()
+
+		// Set templateManager to nil so it's recreated by Prestart on restart.
+		h.templateManager = nil
+	}
+
+	return nil
+}
+
+// Stop is called when the tasks exits and will not start again. It is the only
+// hook guaranteed to be called so make sure the template is cleaned-up.
 func (h *templateHook) Stop(ctx context.Context, req *interfaces.TaskStopRequest, resp *interfaces.TaskStopResponse) error {
 	h.managerLock.Lock()
 	defer h.managerLock.Unlock()


### PR DESCRIPTION
Non-sidecar prestart and poststart tasks run to completion and exit, but their Stop hook are not called until the job is stopped. This leaves some background operations running even when the task itself is not running anymore.

Implementing the Exited hook stops these background processes on task exit. If the task is restarted their Prestart and Poststart hooks will run again and resume the background operations.

I skipped the Vault hook because token renewal has been quite finicky and trying to pause it could cause even more problems. Since it's just a goroutine that calls the Vault API not that frequently it doesn't consume much resources.

Closes #15419