### PR TITLE
style: Remove "is-primary" class from TaskRow

### DIFF
--- a/ui/app/templates/components/task-row.hbs
+++ b/ui/app/templates/components/task-row.hbs
@@ -13,7 +13,6 @@
   <LinkTo
     @route="allocations.allocation.task"
     @models={{array this.task.allocation this.task}}
-    class="is-primary"
   >
     {{this.task.name}}
     {{#if this.task.isConnectProxy}}


### PR DESCRIPTION
Resolves #12881 

The task row is clickable however since it was not formatted like a hyperlink users report that its not obvious that its clickable.

This PR removes the "is-primary" class on the task id which is overriding the default a tag styling. This PR follows the linking pattern in the HashiCorp Design System.

Here's the current appearance:
![image](https://user-images.githubusercontent.com/90055250/204929179-539e5d01-747f-4ea6-9a61-dd25ad35c839.png)

Here's how linking is in the HashiCorp Design System:
<img width="1035" alt="Screenshot 2022-11-30 at 6 22 57 PM" src="https://user-images.githubusercontent.com/90055250/204929315-91c13e23-7288-43ea-9fbb-e5a9737edfeb.png">

PS: I'd love an internship with the HashiCorp Design System team!