### PR TITLE
fix enterprise endpoint registration

### DIFF
--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1282,7 +1282,8 @@ func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) error {
 	_ = server.Register(NewSystemEndpoint(s, ctx))
 	_ = server.Register(NewVariablesEndpoint(s, ctx, s.encrypter))
 
-	_ = server.Register(NewEnterpriseEndpoints(s, ctx))
+	ent := NewEnterpriseEndpoints(s, ctx)
+	ent.Register(server)
 
 	return nil
 }


### PR DESCRIPTION
In #15430 we refactored the RPC endpoint configuration to make adding the RPC context easier. But when implementing the change on the Enterprise side, I discovered that the registration of enterprise endpoints was being done incorrectly -- this doesn't show up on OSS because the registration is always a no-op here.