### PR TITLE
remove most static RPC handlers

### DIFF
--- a/nomad/client_csi_endpoint_test.go
+++ b/nomad/client_csi_endpoint_test.go
@@ -427,7 +427,9 @@ func TestClientCSI_NodeForControllerPlugin(t *testing.T) {
 
 	plugin, err := state.CSIPluginByID(ws, "minnie")
 	require.NoError(t, err)
-	nodeIDs, err := srv.staticEndpoints.ClientCSI.clientIDsForController(plugin.ID)
+
+	clientCSI := NewClientCSIEndpoint(srv)
+	nodeIDs, err := clientCSI.clientIDsForController(plugin.ID)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(nodeIDs))
 	// only node1 has both the controller and a recent Nomad version

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -1950,7 +1950,7 @@ func TestCSI_RPCVolumeAndPluginLookup(t *testing.T) {
 	require.NoError(t, err)
 
 	// has controller
-	c := srv.staticEndpoints.CSIVolume
+	c := NewCSIVolumeEndpoint(srv, nil)
 	plugin, vol, err := c.volAndPluginLookup(structs.DefaultNamespace, id0)
 	require.NotNil(t, plugin)
 	require.NotNil(t, vol)

--- a/nomad/heartbeat.go
+++ b/nomad/heartbeat.go
@@ -168,7 +168,8 @@ func (h *nodeHeartbeater) invalidateHeartbeat(id string) {
 		req.Status = structs.NodeStatusDisconnected
 	}
 	var resp structs.NodeUpdateResponse
-	if err := h.staticEndpoints.Node.UpdateStatus(&req, &resp); err != nil {
+
+	if err := h.RPC("Node.UpdateStatus", &req, &resp); err != nil {
 		h.logger.Error("update node status failed", "error", err)
 	}
 }

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -911,7 +911,9 @@ func TestNode_UpdateStatus_ServiceRegistrations(t *testing.T) {
 	}
 
 	var reply structs.NodeUpdateResponse
-	require.NoError(t, testServer.staticEndpoints.Node.UpdateStatus(&args, &reply))
+
+	nodeEndpoint := NewNodeEndpoint(testServer, nil)
+	require.NoError(t, nodeEndpoint.UpdateStatus(&args, &reply))
 
 	// Query our state, to ensure the node service registrations have been
 	// removed.
@@ -2643,7 +2645,7 @@ func TestClientEndpoint_BatchUpdate(t *testing.T) {
 
 	// Call to do the batch update
 	bf := structs.NewBatchFuture()
-	endpoint := s1.staticEndpoints.Node
+	endpoint := NewNodeEndpoint(s1, nil)
 	endpoint.batchUpdate(bf, []*structs.Allocation{clientAlloc}, nil)
 	if err := bf.Wait(); err != nil {
 		t.Fatalf("err: %v", err)
@@ -2780,7 +2782,8 @@ func TestClientEndpoint_CreateNodeEvals(t *testing.T) {
 	idx++
 
 	// Create some evaluations
-	ids, index, err := s1.staticEndpoints.Node.createNodeEvals(node, 1)
+	nodeEndpoint := NewNodeEndpoint(s1, nil)
+	ids, index, err := nodeEndpoint.createNodeEvals(node, 1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2877,7 +2880,8 @@ func TestClientEndpoint_CreateNodeEvals_MultipleNSes(t *testing.T) {
 	idx++
 
 	// Create some evaluations
-	evalIDs, index, err := s1.staticEndpoints.Node.createNodeEvals(node, 1)
+	nodeEndpoint := NewNodeEndpoint(s1, nil)
+	evalIDs, index, err := nodeEndpoint.createNodeEvals(node, 1)
 	require.NoError(t, err)
 	require.NotZero(t, index)
 	require.Len(t, evalIDs, 2)
@@ -2937,7 +2941,8 @@ func TestClientEndpoint_CreateNodeEvals_MultipleDCes(t *testing.T) {
 	idx++
 
 	// Create evaluations
-	evalIDs, index, err := s1.staticEndpoints.Node.createNodeEvals(node, 1)
+	nodeEndpoint := NewNodeEndpoint(s1, nil)
+	evalIDs, index, err := nodeEndpoint.createNodeEvals(node, 1)
 	require.NoError(t, err)
 	require.NotZero(t, index)
 	require.Len(t, evalIDs, 1)

--- a/nomad/variables_endpoint_test.go
+++ b/nomad/variables_endpoint_test.go
@@ -106,8 +106,10 @@ func TestVariablesEndpoint_auth(t *testing.T) {
 	err = store.UpsertACLTokens(structs.MsgTypeTestSetup, 1150, []*structs.ACLToken{aclToken})
 	must.NoError(t, err)
 
+	variablesRPC := NewVariablesEndpoint(srv, nil, srv.encrypter)
+
 	t.Run("terminal alloc should be denied", func(t *testing.T) {
-		_, _, err = srv.staticEndpoints.Variables.handleMixedAuthEndpoint(
+		_, _, err := variablesRPC.handleMixedAuthEndpoint(
 			structs.QueryOptions{AuthToken: idToken, Namespace: ns}, acl.PolicyList,
 			fmt.Sprintf("nomad/jobs/%s/web/web", jobID))
 		must.EqError(t, err, structs.ErrPermissionDenied.Error())
@@ -119,7 +121,7 @@ func TestVariablesEndpoint_auth(t *testing.T) {
 		structs.MsgTypeTestSetup, 1200, []*structs.Allocation{alloc1}))
 
 	t.Run("wrong namespace should be denied", func(t *testing.T) {
-		_, _, err = srv.staticEndpoints.Variables.handleMixedAuthEndpoint(
+		_, _, err := variablesRPC.handleMixedAuthEndpoint(
 			structs.QueryOptions{AuthToken: idToken, Namespace: structs.DefaultNamespace}, acl.PolicyList,
 			fmt.Sprintf("nomad/jobs/%s/web/web", jobID))
 		must.EqError(t, err, structs.ErrPermissionDenied.Error())
@@ -349,7 +351,7 @@ func TestVariablesEndpoint_auth(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := srv.staticEndpoints.Variables.handleMixedAuthEndpoint(
+			_, _, err := variablesRPC.handleMixedAuthEndpoint(
 				structs.QueryOptions{AuthToken: tc.token, Namespace: ns}, tc.cap, tc.path)
 			if tc.expectedErr == nil {
 				must.NoError(t, err)


### PR DESCRIPTION
Nomad server components that aren't in the `nomad` package like the deployment watcher and volume watcher need to make RPC calls but can't import the Server struct to do so because it creates a circular reference. These components have a "shim" object that gets populated to pass a "static" handler that has no RPC context.

Most RPC handlers are never used in this way, but during server setup we were constructing a set of static handlers for most RPC endpoints anyways. This is slightly wasteful but also confusing to developers who end up being encouraged to just copy what was being done for previous RPCs.

This changeset includes the following refactorings:
* Remove the static handlers field on the server
* Instead construct just the specific static handlers we need to pass into the deployment watcher and volume watcher.
* Remove the unnecessary static handler from heartbeater
* Update various tests to avoid needing the static endpoints and instead use an endpoint constructed on the spot.
* Make sure every atypical handler is documented as such, so that it's obvious what the happy path is when creating new endpoints.

Follow-up work will examine whether we can remove the RPCs from deployment watcher and volume watcher entirely, falling back to raft applies like node drainer does currently. This PR does leave a nil `*RPCContext` in deployment watcher and volume watcher constructors, which would be nice to remove for safety.