### PR TITLE
[ui] Add namespaces to exec window

### DIFF
--- a/.changelog/15454.txt
+++ b/.changelog/15454.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed a bug where the exec window would not maintain namespace upon refresh
+```

--- a/ui/app/controllers/exec.js
+++ b/ui/app/controllers/exec.js
@@ -17,7 +17,7 @@ export default class ExecController extends Controller {
   @service system;
   @service token;
 
-  queryParams = ['allocation'];
+  queryParams = ['allocation', 'namespace'];
 
   @localStorageProperty('nomadExecCommand', '/bin/bash') command;
   socketOpen = false;


### PR DESCRIPTION
Fixes an issue where namespaces weren't being respected in Exec window URLs upon refresh (they were on initial load, by virtue of having the full job object passed in via openExecUrl). 

![image](https://user-images.githubusercontent.com/713991/205334712-1a080a4a-359f-42f9-8be6-29772902ef7d.png)
![image](https://user-images.githubusercontent.com/713991/205334790-85c0597c-7d8a-4791-a2d2-3b7964137ebe.png)

Resolves #13921 