### PR TITLE
scheduler: allow using device ID as attribute

### DIFF
--- a/.changelog/15455.txt
+++ b/.changelog/15455.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+scheduler: allow using device IDs in `affinity` and `constraint`
+```

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -1373,6 +1373,13 @@ func resolveDeviceTarget(target string, d *structs.NodeDeviceResource) (*psstruc
 
 	// Handle the interpolations
 	switch {
+	case "${device.ids}" == target:
+		ids := make([]string, len(d.Instances))
+		for i, device := range d.Instances {
+			ids[i] = device.ID
+		}
+		return psstructs.NewStringAttribute(strings.Join(ids, ",")), true
+
 	case "${device.model}" == target:
 		return psstructs.NewStringAttribute(d.Name), true
 

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -2682,6 +2682,11 @@ func TestDeviceChecker(t *testing.T) {
 							LTarget: "${device.attr.cores_clock}",
 							RTarget: "800MHz",
 						},
+						{
+							Operand: "set_contains",
+							LTarget: "${device.ids}",
+							RTarget: nvidia.Instances[0].ID,
+						},
 					},
 				},
 			},
@@ -2714,6 +2719,11 @@ func TestDeviceChecker(t *testing.T) {
 							Operand: "=",
 							LTarget: "${device.attr.cores_clock}",
 							RTarget: "800MHz",
+						},
+						{
+							Operand: "set_contains",
+							LTarget: "${device.ids}",
+							RTarget: fmt.Sprintf("%s,%s", nvidia.Instances[1].ID, nvidia.Instances[0].ID),
 						},
 					},
 				},
@@ -2813,6 +2823,24 @@ func TestDeviceChecker(t *testing.T) {
 							Operand: "=",
 							LTarget: "${device.attr.cores_clock}",
 							RTarget: "800MHz",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "does not meet ID constraint",
+			Result:      false,
+			NodeDevices: []*structs.NodeDeviceResource{nvidia},
+			RequestedDevices: []*structs.RequestedDevice{
+				{
+					Name:  "nvidia/gpu",
+					Count: 1,
+					Constraints: []*structs.Constraint{
+						{
+							Operand: "set_contains",
+							LTarget: "${device.ids}",
+							RTarget: "not_valid",
 						},
 					},
 				},

--- a/website/content/docs/job-specification/device.mdx
+++ b/website/content/docs/job-specification/device.mdx
@@ -105,6 +105,15 @@ follows:
   <tbody>
     <tr>
       <td>
+        <code>{'${device.ids}'}</code>
+      </td>
+      <td>Comma separated list of device IDs in the group</td>
+      <td>
+        <code>9afa5da1-8f39-25a2-48dc-ba31fd7c0023,c248b547-fed7-4d67-ade5-73a27d280ac4</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <code>{'${device.type}'}</code>
       </td>
       <td>The type of device</td>
@@ -294,6 +303,23 @@ device "nvidia/gpu" {
     operator  = ">="
     value     = "1500 MiB"
     weight    = 75
+  }
+}
+```
+
+### Affinity Towards Specific GPU Devices
+
+This example uses affinity to indicate scheduling preference towards specific
+GPU devices, using their UUID as selection criteria. Since devices are
+fingerprinted as a group, you may specify multiple IDs as a comma separated
+list.
+
+```hcl
+device "nvidia/gpu" {
+  affinity {
+    attribute = "${device.ids}"
+    operator  = "set_contains"
+    value     = "9afa5da1-8f39-25a2-48dc-ba31fd7c0023,c248b547-fed7-4d67-ade5-73a27d280ac4"
   }
 }
 ```


### PR DESCRIPTION
Devices are fingerprinted as groups of similar devices. This prevented specifying specific device by their ID in constraint and affinity rules.

This commit introduces the `${device.ids}` attribute that returns a comma separated list of IDs that are part of the device group. Users can then use the set operators to write rules.

Closes https://github.com/hashicorp/nomad-device-nvidia/issues/11