### PR TITLE
acl: SSO auth methods API documentation

### DIFF
--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -39,7 +39,7 @@ The table below shows this endpoint's support for
   set to either "local" or "global"
 
 - `MaxTokenTTL` `(duration: <required>)` - Defines the maximum life of a token created
-  by this method. When set it will initialize the `ExpirationTime` field on all
+  by this method. When set, it will initialize the `ExpirationTime` field on all
   tokens to a value of `Token.CreateTime + AuthMethod.MaxTokenTTL`. This field is
   not persisted beyond its initial use. Can be specified in the form of `"60s"` or
   `"5m"` (i.e., 60 seconds or 5 minutes, respectively). 
@@ -107,7 +107,7 @@ The table below shows this endpoint's support for
       "http://example.com/last_name": "last_name"
     },
     "ListClaimMappings": {
-      "http://consul.com/groups": "groups"
+      "http://nomad.com/groups": "groups"
     }
   }
 }
@@ -149,7 +149,7 @@ $ curl \
             "http://example.com/last_name": "last_name"
         },
         "ListClaimMappings": {
-            "http://consul.com/groups": "groups"
+            "http://nomad.com/groups": "groups"
         }
     },
     "CreateTime": "0001-01-01T00:00:00Z",

--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -199,7 +199,8 @@ queries](/api-docs#blocking-queries) and [required ACLs](/api-docs#acls).
   set as default when running `nomad login` command.
 
 - `Config` `(ACLAuthMethodConfig: nil)` - The raw configuration to use for
-  the auth method.
+  the auth method. This parameter is part of the auth method configuration, not
+  specific to Nomad.
 
   - `OIDCDiscoveryURL` `(string: "")` - The OIDC Discovery URL, without
     any .well-known component (base path).
@@ -238,11 +239,29 @@ queries](/api-docs#blocking-queries) and [required ACLs](/api-docs#acls).
 
 ```json
 {
-    "name": "example-acl-auth-method",
-    "type": "OIDC",
-    "tokenlocality": "global",
-    "maxtokenttl": "1h0m0s",
-    "default": true
+  "Name": "example-acl-auth-method",
+  "Type": "OIDC",
+  "Tokenlocality": "global",
+  "Maxtokenttl": "1h0m0s",
+  "Default": true,
+  "Config": {
+    "OIDCDiscoveryURL": "https://my-corp-app-name.auth0.com/",
+    "OIDCClientID": "V1RPi2MYptMV1RPi2MYptMV1RPi2MYpt",
+    "OIDCClientSecret": "example-client-secret",
+    "BoundAudiences": [
+      "V1RPi2MYptMV1RPi2MYptMV1RPi2MYpt"
+    ],
+    "AllowedRedirectURIs": [
+      "http://localhost:4646/oidc/callback"
+    ],
+    "ClaimMappings": {
+      "http://example.com/first_name": "first_name",
+      "http://example.com/last_name": "last_name"
+    },
+    "ListClaimMappings": {
+      "http://nomad.com/groups": "groups"
+    }
+  }
 }
 ```
 
@@ -265,7 +284,24 @@ $ curl \
     "Type": "OIDC",
     "TokenLocality": "global",
     "Default": true,
-    "Config": null,
+    "Config": {
+        "OIDCDiscoveryURL": "https://my-corp-app-name.auth0.com/",
+        "OIDCClientID": "V1RPi2MYptMV1RPi2MYptMV1RPi2MYpt",
+        "OIDCClientSecret": "example-client-secret",
+        "BoundAudiences": [
+          "V1RPi2MYptMV1RPi2MYptMV1RPi2MYpt"
+        ],
+        "AllowedRedirectURIs": [
+          "http://localhost:4646/oidc/callback"
+        ],
+        "ClaimMappings": {
+          "http://example.com/first_name": "first_name",
+          "http://example.com/last_name": "last_name"
+        },
+        "ListClaimMappings": {
+          "http://nomad.com/groups": "groups"
+        }
+    }
     "CreateTime": "2022-12-08T11:04:43.46206Z",
     "ModifyTime": "2022-12-08T11:04:43.46206Z",
     "CreateIndex": 12,
@@ -288,8 +324,8 @@ The table below shows this endpoint's support for
 [required ACLs](/api-docs#acls).
 
 | Blocking Queries | Consistency Modes | ACL Required                                                                                                                             |
-| ---------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `YES`            | `all`             | `management` for all auth methods.<br />Output when given a non-management token will be limited to the auth methods on the token itself |
+| ---------------- | ----------------- | ---- |
+| `YES`            | `all`             | None |
 
 ### Sample Request
 
@@ -307,7 +343,8 @@ $ curl \
         "CreateIndex": 12,
         "Default": true,
         "ModifyIndex": 32,
-        "Name": "example-acl-auth-method"
+        "Name": "example-acl-auth-method",
+        "Type": "OIDC"
     }
 ]
 ```
@@ -327,9 +364,9 @@ The table below shows this endpoint's support for
 [consistency modes](/api-docs#consistency-modes) and
 [required ACLs](/api-docs#acls).
 
-| Blocking Queries | Consistency Modes | ACL Required                              |
-| ---------------- | ----------------- | ----------------------------------------- |
-| `YES`            | `all`             | `management` or token with access to role |
+| Blocking Queries | Consistency Modes | ACL Required       |
+| ---------------- | ----------------- | ------------------ |
+| `YES`            | `all`             | `management` token |
 
 ### Parameters
 
@@ -353,7 +390,24 @@ $ curl \
     "Type": "OIDC",
     "TokenLocality": "global",
     "Default": true,
-    "Config": null,
+    "Config": {
+      "OIDCDiscoveryURL": "https://my-corp-app-name.auth0.com/",
+      "OIDCClientID": "V1RPi2MYptMV1RPi2MYptMV1RPi2MYpt",
+      "OIDCClientSecret": "example-client-secret",
+      "BoundAudiences": [
+        "V1RPi2MYptMV1RPi2MYptMV1RPi2MYpt"
+      ],
+      "AllowedRedirectURIs": [
+        "http://localhost:4646/oidc/callback"
+      ],
+      "ClaimMappings": {
+        "http://example.com/first_name": "first_name",
+        "http://example.com/last_name": "last_name"
+      },
+      "ListClaimMappings": {
+        "http://nomad.com/groups": "groups"
+      }
+    },
     "CreateTime": "2022-12-08T11:04:43.46206Z",
     "ModifyTime": "2022-12-08T11:04:43.46206Z",
     "CreateIndex": 12,

--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -32,7 +32,7 @@ The table below shows this endpoint's support for
   This name must be unique and must not exceed 128 characters.
 
 - `Type` `(string: <required>)` - ACL Auth Role SSO identifier. Currently, the
-  only supported Type is "OIDC." 
+  only supported Type is "OIDC."
 
 - `TokenLocality` `(string: <required>)` - Defines whether the ACL Auth Method
   creates a local or global token when performing SSO login. This field must be
@@ -42,17 +42,18 @@ The table below shows this endpoint's support for
   by this method. When set, it will initialize the `ExpirationTime` field on all
   tokens to a value of `Token.CreateTime + AuthMethod.MaxTokenTTL`. This field is
   not persisted beyond its initial use. Can be specified in the form of `"60s"` or
-  `"5m"` (i.e., 60 seconds or 5 minutes, respectively). 
+  `"5m"` (i.e., 60 seconds or 5 minutes, respectively).
 
 - `Default` `(bool: false)` - Defines whether this ACL Auth Method is to be
-  set as default when running `nomad login` command. 
+  set as default when running `nomad login` command.
 
 - `Config` `(ACLAuthMethodConfig: <required>)` - The raw configuration to use for
-  the auth method.
+  the auth method. This parameter is part of the auth method configuration, not
+  specific to Nomad.
 
   - `OIDCDiscoveryURL` `(string: <required>)` - The OIDC Discovery URL, without
     any .well-known component (base path).
-  
+
   - `OIDCClientID` `(string: <required>)` - The OAuth Client ID configured with
     your OIDC provider.
 
@@ -64,7 +65,7 @@ The table below shows this endpoint's support for
 
   - `AllowedRedirectURIs` `(array<string>)` - A list of allowed values for
     redirect_uri. Must be non-empty.
-  
+
   - `DiscoveryCaPem` `(array<string>)` - PEM encoded CA certs for use by the TLS
     client used to talk with the OIDC Discovery URL. If not set, system
     certificates are used.
@@ -182,7 +183,7 @@ queries](/api-docs#blocking-queries) and [required ACLs](/api-docs#acls).
   This name must be unique and must not exceed 128 characters.
 
 - `Type` `(string: <required>)` - ACL Auth Role SSO identifier. Currently, the
-  only supported Type is "OIDC." 
+  only supported Type is "OIDC."
 
 - `TokenLocality` `(string: "")` - Defines whether the ACL Auth Method
   creates a local or global token when performing SSO login. This field must be
@@ -192,17 +193,17 @@ queries](/api-docs#blocking-queries) and [required ACLs](/api-docs#acls).
   by this method. When set it will initialize the `ExpirationTime` field on all
   tokens to a value of `Token.CreateTime + AuthMethod.MaxTokenTTL`. This field is
   not persisted beyond its initial use. Can be specified in the form of `"60s"` or
-  `"5m"` (i.e., 60 seconds or 5 minutes, respectively). 
+  `"5m"` (i.e., 60 seconds or 5 minutes, respectively).
 
 - `Default` `(bool: false)` - Defines whether this ACL Auth Method is to be
-  set as default when running `nomad login` command. 
+  set as default when running `nomad login` command.
 
 - `Config` `(ACLAuthMethodConfig: nil)` - The raw configuration to use for
   the auth method.
 
   - `OIDCDiscoveryURL` `(string: "")` - The OIDC Discovery URL, without
     any .well-known component (base path).
-  
+
   - `OIDCClientID` `(string: "")` - The OAuth Client ID configured with
     your OIDC provider.
 
@@ -214,7 +215,7 @@ queries](/api-docs#blocking-queries) and [required ACLs](/api-docs#acls).
 
   - `AllowedRedirectURIs` `(array<string>)` - A list of allowed values for
     redirect_uri. Must be non-empty.
-  
+
   - `DiscoveryCaPem` `(array<string>)` - PEM encoded CA certs for use by the TLS
     client used to talk with the OIDC Discovery URL. If not set, system
     certificates are used.

--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -1,0 +1,275 @@
+---
+layout: api
+page_title: ACL Auth Methods - HTTP API
+description: The /acl/auth-methods endpoints are used to configure and manage ACL auth methods.
+---
+
+# ACL Auth Methods HTTP API
+
+The `/acl/auth-methods` and `/acl/auth-method` endpoints are used to manage ACL Auth Methods.
+
+## Create Auth Method
+
+This endpoint creates an ACL Auth Method. The request is always forwarded to the
+authoritative region.
+
+| Method | Path               | Produces           |
+| ------ | ------------------ | ------------------ |
+| `POST` | `/acl/auth-method` | `application/json` |
+
+The table below shows this endpoint's support for
+[blocking queries](/api-docs#blocking-queries) and
+[required ACLs](/api-docs#acls).
+
+| Blocking Queries | ACL Required |
+| ---------------- | ------------ |
+| `NO`             | `management` |
+
+### Parameters
+
+- `Name` `(string: <required>)` - Names is the identifier of the ACL Auth
+  Method.  The name can contain alphanumeric characters, dashes, and underscores.
+  This name must be unique and must not exceed 128 characters.
+
+- `Type` `(string: <required>)` - ACL Auth Role SSO identifier. Currently, the
+  only supported Type is "OIDC." 
+
+- `TokenLocality` `(string: <required>)` - Defines whether the ACL Auth Method
+  creates a local or global token when performing SSO login. This field must be
+  set to either "local" or "global"
+
+- `MaxTokenTTL` `(duration: <required>)` - Defines the maximum life of a token created
+  by this method. When set it will initialize the `ExpirationTime` field on all
+  tokens to a value of `Token.CreateTime + AuthMethod.MaxTokenTTL`. This field is
+  not persisted beyond its initial use. Can be specified in the form of `"60s"` or
+  `"5m"` (i.e., 60 seconds or 5 minutes, respectively). 
+
+- `Default` `(bool: false)` - Defines whether this ACL Auth Method is to be
+  set as default when running `nomad login` command. 
+
+- `Config` `(ACLAuthMethodConfig: <required>)` - The raw configuration to use for
+  the auth method.
+
+  - `OIDCDiscoveryURL` `(string: <required>)` - The OIDC Discovery URL, without
+    any .well-known component (base path).
+  
+  - `OIDCClientID` `(string: <required>)` - The OAuth Client ID configured with
+    your OIDC provider.
+
+  - `OIDCClientSecret` `(string: <required>)` - The OAuth Client Secret
+    configured with your OIDC provider.
+
+  - `BoundAudiences` `(array<string>)` - List of aud claims that are valid for
+    login; any match is sufficient.
+
+  - `AllowedRedirectURIs` `(array<string>)` - A list of allowed values for
+    redirect_uri. Must be non-empty.
+  
+  - `DiscoveryCaPem` `(array<string>)` - PEM encoded CA certs for use by the TLS
+    client used to talk with the OIDC Discovery URL. If not set, system
+    certificates are used.
+
+  - `SigningAlgs` `(array<string>)` - A list of supported signing algorithms.
+    Defaults to `RS256`.
+
+  - `ClaimMappings` `(map[string]string)` - Mappings of claims (key) that will
+    be copied to a metadata field (value). Use this if the claim you are capturing
+    is singular (such as an attribute).
+
+    When mapped, the values in each list can be any of a number, string, or
+    boolean and will all be stringified when returned.
+
+  - `ListClaimMappings` `(map[string]string)` - Mappings of claims (key) will be
+    copied to a metadata field (value). Use this if the claim you are capturing is
+    list-like (such as groups).
+
+### Sample Payload
+
+```json
+{
+  "Name": "example-acl-auth-method",
+  "Type": "OIDC",
+  "TokenLocality": "local",
+  "MaxTokenTTL": "1h0m0s",
+  "Default": false,
+  "Config": {
+    "OIDCDiscoveryURL": "https://my-corp-app-name.auth0.com/",
+    "OIDCClientID": "V1RPi2MYptMV1RPi2MYptMV1RPi2MYpt",
+    "OIDCClientSecret": "example-client-secret",
+    "BoundAudiences": [
+      "V1RPi2MYptMV1RPi2MYptMV1RPi2MYpt"
+    ],
+    "AllowedRedirectURIs": [
+      "http://localhost:4646/oidc/callback"
+    ],
+    "ClaimMappings": {
+      "http://example.com/first_name": "first_name",
+      "http://example.com/last_name": "last_name"
+    },
+    "ListClaimMappings": {
+      "http://consul.com/groups": "groups"
+    }
+  }
+}
+```
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --request POST \
+    --header "X-Nomad-Token: <NOMAD_TOKEN_SECRET_ID>" \
+    --data @payload.json \
+    https://localhost:4646/v1/acl/auth-method
+```
+
+### Sample Response
+
+```json
+{
+    "MaxTokenTTL": "1h0m0s",
+    "Name": "example-acl-auth-method2",
+    "Type": "OIDC",
+    "TokenLocality": "local",
+    "Default": false,
+    "Config": {
+        "OIDCDiscoveryURL": "https://my-corp-app-name.auth0.com/",
+        "OIDCClientID": "v1rpi2myptmv1rpi2myptmv1rpi2mypt",
+        "OIDCClientSecret": "example-client-secret",
+        "BoundAudiences": [
+            "v1rpi2myptmv1rpi2myptmv1rpi2mypt"
+        ],
+        "AllowedRedirectURIs": [
+            "http://localhost:4646/oidc/callback"
+        ],
+        "DiscoveryCaPem": null,
+        "SigningAlgs": null,
+        "ClaimMappings": {
+            "http://example.com/first_name": "first_name",
+            "http://example.com/last_name": "last_name"
+        },
+        "ListClaimMappings": {
+            "http://consul.com/groups": "groups"
+        }
+    },
+    "Hash": "c6ulqdpQAdssP5d4vUn3MCvimoaSorxYSb8BySV0NSQ=",
+    "CreateTime": "0001-01-01T00:00:00Z",
+    "ModifyTime": "0001-01-01T00:00:00Z",
+    "CreateIndex": 12,
+    "ModifyIndex": 12
+}
+```
+
+## Update Auth Method
+
+This endpoint updates an existing ACL Auth Method. The request is always
+forwarded to the authoritative region.
+
+| Method | Path                            | Produces           |
+| ------ | ------------------------------- | ------------------ |
+| `POST` | `/acl/auth-method/:method_name` | `application/json` |
+
+The table below shows this endpoint's support for [blocking
+queries](/api-docs#blocking-queries) and [required ACLs](/api-docs#acls).
+
+| Blocking Queries | ACL Required |
+| ---------------- | ------------ |
+| `NO`             | `management` |
+
+### Parameters
+
+- `Name` `(string: <required>)` - Names is the identifier of the ACL Auth
+  Method.  The name can contain alphanumeric characters, dashes, and underscores.
+  This name must be unique and must not exceed 128 characters.
+
+- `Type` `(string: <required>)` - ACL Auth Role SSO identifier. Currently, the
+  only supported Type is "OIDC." 
+
+- `TokenLocality` `(string: "")` - Defines whether the ACL Auth Method
+  creates a local or global token when performing SSO login. This field must be
+  set to either "local" or "global"
+
+- `MaxTokenTTL` `(duration: <required>)` - Defines the maximum life of a token created
+  by this method. When set it will initialize the `ExpirationTime` field on all
+  tokens to a value of `Token.CreateTime + AuthMethod.MaxTokenTTL`. This field is
+  not persisted beyond its initial use. Can be specified in the form of `"60s"` or
+  `"5m"` (i.e., 60 seconds or 5 minutes, respectively). 
+
+- `Default` `(bool: false)` - Defines whether this ACL Auth Method is to be
+  set as default when running `nomad login` command. 
+
+- `Config` `(ACLAuthMethodConfig: nil)` - The raw configuration to use for
+  the auth method.
+
+  - `OIDCDiscoveryURL` `(string: "")` - The OIDC Discovery URL, without
+    any .well-known component (base path).
+  
+  - `OIDCClientID` `(string: "")` - The OAuth Client ID configured with
+    your OIDC provider.
+
+  - `OIDCClientSecret` `(string: "")` - The OAuth Client Secret
+    configured with your OIDC provider.
+
+  - `BoundAudiences` `(array<string>)` - List of aud claims that are valid for
+    login; any match is sufficient.
+
+  - `AllowedRedirectURIs` `(array<string>)` - A list of allowed values for
+    redirect_uri. Must be non-empty.
+  
+  - `DiscoveryCaPem` `(array<string>)` - PEM encoded CA certs for use by the TLS
+    client used to talk with the OIDC Discovery URL. If not set, system
+    certificates are used.
+
+  - `SigningAlgs` `(array<string>)` - A list of supported signing algorithms.
+    Defaults to `RS256`.
+
+  - `ClaimMappings` `(map[string]string)` - Mappings of claims (key) that will
+    be copied to a metadata field (value). Use this if the claim you are capturing
+    is singular (such as an attribute).
+
+    When mapped, the values in each list can be any of a number, string, or
+    boolean and will all be stringified when returned.
+
+  - `ListClaimMappings` `(map[string]string)` - Mappings of claims (key) will be
+    copied to a metadata field (value). Use this if the claim you are capturing is
+    list-like (such as groups).
+
+### Sample Payload
+
+```json
+{
+    "name": "example-acl-auth-method2",
+    "type": "OIDC",
+    "tokenlocality": "global",
+    "maxtokenttl": "1h0m0s",
+    "default": true
+}
+```
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --request POST \
+    --header "X-Nomad-Token: <NOMAD_TOKEN_SECRET_ID>" \
+    --data @payload.json \
+    https://localhost:4646/v1/acl/auth-method/example-acl-auth-method2
+```
+
+### Sample Response
+
+```json
+{
+    "MaxTokenTTL": "1h0m0s",
+    "Name": "example-acl-auth-method2",
+    "Type": "OIDC",
+    "TokenLocality": "global",
+    "Default": true,
+    "Config": null,
+    "Hash": "xE8JX1Ljdb7A5yTLl8lA25NdRu9s/h7uRAufSiFfeCw=",
+    "CreateTime": "0001-01-01T00:00:00Z",
+    "ModifyTime": "0001-01-01T00:00:00Z",
+    "CreateIndex": 12,
+    "ModifyIndex": 32
+}
+```

--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -128,7 +128,7 @@ $ curl \
 ```json
 {
     "MaxTokenTTL": "1h0m0s",
-    "Name": "example-acl-auth-method2",
+    "Name": "example-acl-auth-method",
     "Type": "OIDC",
     "TokenLocality": "local",
     "Default": false,
@@ -152,7 +152,6 @@ $ curl \
             "http://consul.com/groups": "groups"
         }
     },
-    "Hash": "c6ulqdpQAdssP5d4vUn3MCvimoaSorxYSb8BySV0NSQ=",
     "CreateTime": "0001-01-01T00:00:00Z",
     "ModifyTime": "0001-01-01T00:00:00Z",
     "CreateIndex": 12,
@@ -238,7 +237,7 @@ queries](/api-docs#blocking-queries) and [required ACLs](/api-docs#acls).
 
 ```json
 {
-    "name": "example-acl-auth-method2",
+    "name": "example-acl-auth-method",
     "type": "OIDC",
     "tokenlocality": "global",
     "maxtokenttl": "1h0m0s",
@@ -253,7 +252,7 @@ $ curl \
     --request POST \
     --header "X-Nomad-Token: <NOMAD_TOKEN_SECRET_ID>" \
     --data @payload.json \
-    https://localhost:4646/v1/acl/auth-method/example-acl-auth-method2
+    https://localhost:4646/v1/acl/auth-method/example-acl-auth-method
 ```
 
 ### Sample Response
@@ -261,15 +260,133 @@ $ curl \
 ```json
 {
     "MaxTokenTTL": "1h0m0s",
-    "Name": "example-acl-auth-method2",
+    "Name": "example-acl-auth-method",
     "Type": "OIDC",
     "TokenLocality": "global",
     "Default": true,
     "Config": null,
-    "Hash": "xE8JX1Ljdb7A5yTLl8lA25NdRu9s/h7uRAufSiFfeCw=",
     "CreateTime": "0001-01-01T00:00:00Z",
     "ModifyTime": "0001-01-01T00:00:00Z",
     "CreateIndex": 12,
     "ModifyIndex": 32
 }
+```
+
+## List Auth Methods
+
+This endpoint lists all ACL Auth Methods. This lists the auth methods that have
+been replicated to the region, and may lag behind the authoritative region.
+
+| Method | Path                | Produces           |
+| ------ | ------------------- | ------------------ |
+| `GET`  | `/acl/auth-methods` | `application/json` |
+
+The table below shows this endpoint's support for
+[blocking queries](/api-docs#blocking-queries),
+[consistency modes](/api-docs#consistency-modes) and
+[required ACLs](/api-docs#acls).
+
+| Blocking Queries | Consistency Modes | ACL Required                                                                                                                             |
+| ---------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `YES`            | `all`             | `management` for all auth methods.<br />Output when given a non-management token will be limited to the auth methods on the token itself |
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Nomad-Token: <NOMAD_TOKEN_SECRET_ID>" \
+    https://localhost:4646/v1/acl/auth-methods
+```
+
+### Sample Response
+
+```json
+[
+    {
+        "CreateIndex": 12,
+        "Default": true,
+        "ModifyIndex": 32,
+        "Name": "example-acl-auth-method"
+    }
+]
+```
+
+## Read Auth Method by Name
+
+This endpoint reads an ACL Auth Method with the given name. This queries the
+auth method that has been replicated to the region, and may lag behind the
+authoritative region.
+
+| Method | Path                            | Produces           |
+| ------ | ------------------------------- | ------------------ |
+| `GET`  | `/acl/auth-method/:method_name` | `application/json` |
+
+The table below shows this endpoint's support for
+[blocking queries](/api-docs#blocking-queries),
+[consistency modes](/api-docs#consistency-modes) and
+[required ACLs](/api-docs#acls).
+
+| Blocking Queries | Consistency Modes | ACL Required                              |
+| ---------------- | ----------------- | ----------------------------------------- |
+| `YES`            | `all`             | `management` or token with access to role |
+
+### Parameters
+
+- `:method_name` `(string: <required>)` - Specifies the name of the ACL Auth
+  Method. This is specified as part of the path.
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Nomad-Token: <NOMAD_TOKEN_SECRET_ID>" \
+    https://localhost:4646/v1/acl/auth-method/example-acl-auth-method
+```
+
+### Sample Response
+
+```json
+{
+    "MaxTokenTTL": "1h0m0s",
+    "Name": "example-acl-auth-method",
+    "Type": "OIDC",
+    "TokenLocality": "global",
+    "Default": true,
+    "Config": null,
+    "CreateTime": "0001-01-01T00:00:00Z",
+    "ModifyTime": "0001-01-01T00:00:00Z",
+    "CreateIndex": 12,
+    "ModifyIndex": 32
+}
+```
+
+## Delete Auth Method
+
+This endpoint deletes the ACL Auth Method as identified by its name. This
+request is always forwarded to the authoritative region.
+
+| Method   | Path                            | Produces       |
+| -------- | ------------------------------- | -------------- |
+| `DELETE` | `/acl/auth-method/:method_name` | `(empty body)` |
+
+The table below shows this endpoint's support for
+[blocking queries](/api-docs#blocking-queries) and
+[required ACLs](/api-docs#acls).
+
+| Blocking Queries | ACL Required |
+| ---------------- | ------------ |
+| `NO`             | `management` |
+
+### Parameters
+
+- `method_name` `(string: <required>)` - Specifies the name of auth method to
+  delete and is specified as part of the path.
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --request DELETE \
+    --header "X-Nomad-Token: <NOMAD_TOKEN_SECRET_ID>" \
+    https://localhost:4646/v1/acl/auth-method/example-acl-auth-method
 ```

--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -153,8 +153,8 @@ $ curl \
             "http://nomad.com/groups": "groups"
         }
     },
-    "CreateTime": "0001-01-01T00:00:00Z",
-    "ModifyTime": "0001-01-01T00:00:00Z",
+    "CreateTime": "2022-12-08T11:04:43.46206Z",
+    "ModifyTime": "2022-12-08T11:04:43.46206Z",
     "CreateIndex": 12,
     "ModifyIndex": 12
 }
@@ -266,8 +266,8 @@ $ curl \
     "TokenLocality": "global",
     "Default": true,
     "Config": null,
-    "CreateTime": "0001-01-01T00:00:00Z",
-    "ModifyTime": "0001-01-01T00:00:00Z",
+    "CreateTime": "2022-12-08T11:04:43.46206Z",
+    "ModifyTime": "2022-12-08T11:04:43.46206Z",
     "CreateIndex": 12,
     "ModifyIndex": 32
 }
@@ -354,8 +354,8 @@ $ curl \
     "TokenLocality": "global",
     "Default": true,
     "Config": null,
-    "CreateTime": "0001-01-01T00:00:00Z",
-    "ModifyTime": "0001-01-01T00:00:00Z",
+    "CreateTime": "2022-12-08T11:04:43.46206Z",
+    "ModifyTime": "2022-12-08T11:04:43.46206Z",
     "CreateIndex": 12,
     "ModifyIndex": 32
 }

--- a/website/content/api-docs/acl/index.mdx
+++ b/website/content/api-docs/acl/index.mdx
@@ -7,9 +7,9 @@ description: |-
 
 # ACL HTTP API
 
-The `/acl` endpoints provide access to the ACL subsystem which includes
-ACL bootstrapping, ACL Policies, ACL Roles, and ACL Tokens. For more details
-about ACLs, please see the
-[ACL Guide](https://learn.hashicorp.com/collections/nomad/access-control).
+The `/acl` endpoints provide access to the ACL subsystem which includes ACL
+bootstrapping, ACL Policies, ACL Roles, ACL Tokens, and ACL Auth Methods. For
+more details about ACLs, please see the [ACL
+Guide](https://learn.hashicorp.com/collections/nomad/access-control).
 
 Please choose a subsection in the navigation for more information.

--- a/website/data/api-docs-nav-data.json
+++ b/website/data/api-docs-nav-data.json
@@ -25,6 +25,10 @@
         "path": "acl"
       },
       {
+        "title": "Auth Methods",
+        "path": "acl/auth-methods"
+      },
+      {
         "title": "Policies",
         "path": "acl/policies"
       },


### PR DESCRIPTION
This PR provides documentation for the ACL Auth Methods API endpoints. 

Relates to #13120 