### PR TITLE
bugfix: corrected indentation for ACL auth method create CLI command

### DIFF
--- a/command/acl_auth_method_create.go
+++ b/command/acl_auth_method_create.go
@@ -64,9 +64,9 @@ ACL Auth Method Create Options:
     case no auth method is explicitly specified for a login command.
 
   -config
-	Auth method configuration in JSON format. May be prefixed with '@' to
-	indicate that the value is a file path to load the config from. '-' may
-	also be given to indicate that the config is available on stdin.
+    Auth method configuration in JSON format. May be prefixed with '@' to
+    indicate that the value is a file path to load the config from. '-' may also
+    be given to indicate that the config is available on stdin.
 `
 	return strings.TrimSpace(helpText)
 }


### PR DESCRIPTION
Corrected indentation for `-config` option:

```
ACL Auth Method Create Options:

  -name
    Sets the human readable name for the ACL auth method. The name must be
    between 1-128 characters and is a required parameter.

  -type
    Sets the type of the auth method. Currently the only supported type is
    'OIDC'.

  -max-token-ttl
    Sets the duration of time all tokens created by this auth method should be
    valid for.

  -token-locality
    Defines the kind of token that this auth method should produce. This can be
    either 'local' or 'global'.

  -default
    Specifies whether this auth method should be treated as a default one in
    case no auth method is explicitly specified for a login command.

  -config
    Auth method configuration in JSON format. May be prefixed with '@' to
    indicate that the value is a file path to load the config from. '-' may also
    be given to indicate that the config is available on stdin.
```

Relates to #13120 