### PR TITLE
bugfix: make sure streaming endpoints are only registered once

### DIFF
--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1132,10 +1132,10 @@ func (s *Server) setupVaultClient() error {
 // setupRPC is used to setup the RPC listener
 func (s *Server) setupRPC(tlsWrap tlsutil.RegionWrapper) error {
 	// Populate the static RPC server
-	err := s.setupRpcServer(s.rpcServer, nil)
-	if err != nil {
-		return err
-	}
+	s.setupRpcServer(s.rpcServer, nil)
+
+	// Setup streaming endpoints
+	s.setupStreamingEndpoints(s.rpcServer, nil)
 
 	listener, err := s.createRPCListener()
 	if err != nil {
@@ -1193,62 +1193,41 @@ func (s *Server) setupRPC(tlsWrap tlsutil.RegionWrapper) error {
 	return nil
 }
 
-// setupRpcServer is used to populate an RPC server with endpoints. This gets
-// called at startup but also once for every new RPC connection so that RPC
-// handlers can have per-connection context.
-func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) error {
-
+// setupStreamingEndpoints is used to populate an RPC server with streaming
+// endpoints. This only gets called at server startup.
+func (s *Server) setupStreamingEndpoints(server *rpc.Server, ctx *RPCContext) {
 	// The endpoints are client RPCs and don't include a connection
 	// context. They also need to be registered as streaming endpoints in their
 	// register() methods.
-	//
-	// Streaming RPCs should only be registered once, so before we register
-	// them, we make a check if they haven't been already registered.
 
 	clientAllocs := NewClientAllocationsEndpoint(s)
+	clientAllocs.register()
+	_ = server.Register(clientAllocs)
+
 	fsEndpoint := NewFileSystemEndpoint(s)
+	fsEndpoint.register()
+	_ = server.Register(fsEndpoint)
+
 	agentEndpoint := NewAgentEndpoint(s)
+	agentEndpoint.register()
+	_ = server.Register(agentEndpoint)
 
 	// Event is a streaming-only endpoint so we don't want to register it as a
 	// normal RPC
 	eventEndpoint := NewEventEndpoint(s)
+	eventEndpoint.register()
 
 	// Operator takes a RPC context but also has a streaming RPC that needs to
 	// be registered
 	operatorEndpoint := NewOperatorEndpoint(s, ctx)
-
-	// streamingEndpoint is a helper interface to make working with endpoint
-	// structs easier
-	type streamingEndpoint interface {
-		register()
-	}
-
-	streaming_endpoints := map[string]streamingEndpoint{
-		"Allocations.Exec": clientAllocs,
-		"Agent.Monitor":    agentEndpoint,
-		// fsEndpoint registers "FileSystem.Logs" and "FileSystem.Stream", but
-		// if at least one of them is registered we know the method's been
-		// called
-		"FileSystem.Logs": fsEndpoint,
-		"Event.Stream":    eventEndpoint,
-		// operatorEndpoint registers "Operator.SnapshotSave" and
-		// "Operator.SnapshotRestore"
-		"Operator.SnapshotSave": operatorEndpoint,
-	}
-
-	// If we haven't registered the streaming endpoints before, register them
-	// now.
-	for method, endpoint := range streaming_endpoints {
-		if _, err := s.streamingRpcs.GetHandler(method); err != nil {
-			endpoint.register()
-		}
-	}
-
-	_ = server.Register(clientAllocs)
-	_ = server.Register(fsEndpoint)
-	_ = server.Register(agentEndpoint)
+	operatorEndpoint.register()
 	_ = server.Register(NewOperatorEndpoint(s, ctx))
+}
 
+// setupRpcServer is used to populate an RPC server with endpoints. This gets
+// called at startup but also once for every new RPC connection so that RPC
+// handlers can have per-connection context.
+func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) {
 	// These endpoints are client RPCs and don't include a connection context
 	_ = server.Register(NewClientCSIEndpoint(s))
 	_ = server.Register(NewClientStatsEndpoint(s))
@@ -1278,8 +1257,6 @@ func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) error {
 
 	ent := NewEnterpriseEndpoints(s, ctx)
 	ent.Register(server)
-
-	return nil
 }
 
 // setupRaft is used to setup and initialize Raft

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1234,7 +1234,7 @@ func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) {
 	_ = server.Register(NewClientAllocationsEndpoint(s))
 	_ = server.Register(NewFileSystemEndpoint(s))
 	_ = server.Register(NewAgentEndpoint(s))
-	_ = server.Register(NewOperatorEndpoint(s, nil))
+	_ = server.Register(NewOperatorEndpoint(s, ctx))
 
 	// All other endpoints include the connection context and don't need to be
 	// registered as streaming endpoints


### PR DESCRIPTION
Streaming RPCs should only be registered once, not on every RPC call, because they set keys in [`StreamingRpcRegistry.registry` map](https://github.com/hashicorp/nomad/blob/main/nomad/structs/streaming_rpc.go#L42). This PR fixes it by checking whether endpoints are already registered before calling `.register()` method. Fixes #15474