### PR TITLE
Use custom runners for building nomad

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - custom-runners
   workflow_dispatch:
     inputs:
       build-ref:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,7 @@ env:
 
 jobs:
   get-go-version:
-    runs-on: 
-      - custom
-      - linux
+    runs-on: ubuntu-20.04
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
@@ -41,9 +39,7 @@ jobs:
           echo "Building with Go $(cat .go-version)"
           echo "go-version=$(cat .go-version)" >> $GITHUB_OUTPUT
   get-product-version:
-    runs-on:
-      - custom
-      - linux
+    runs-on: ubuntu-20.04
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
     steps:
@@ -57,9 +53,7 @@ jobs:
           echo "product-version=$(make version)" >> $GITHUB_OUTPUT
   generate-metadata-file:
     needs: get-product-version
-    runs-on:
-      - custom
-      - linux
+    runs-on: ubuntu-20.04
     outputs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
@@ -82,9 +76,7 @@ jobs:
 
   build-other:
     needs: [get-go-version, get-product-version]
-    runs-on:
-      - custom
-      - linux
+    runs-on: [ custom, linux, xxl, 20.04 ]
     strategy:
       matrix:
         goos: [windows]
@@ -135,9 +127,7 @@ jobs:
 
   build-linux:
     needs: [get-go-version, get-product-version]
-    runs-on:
-      - custom
-      - linux
+    runs-on: [ custom, linux, xxl, 20.04 ]
     strategy:
       matrix:
         goos: [linux]
@@ -304,7 +294,7 @@ jobs:
   #   needs:
   #     - get-product-version
   #     - build
-  #   runs-on: ubuntu-20.04
+  #   runs-on: [ custom, linux, xxl, 20.04 ]
   #   strategy:
   #     matrix:
   #       arch: ["arm", "arm64", "386", "amd64"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+      - custom-runners
   workflow_dispatch:
     inputs:
       build-ref:
@@ -23,7 +24,9 @@ env:
 
 jobs:
   get-go-version:
-    runs-on: ubuntu-20.04
+    runs-on: 
+      - custom
+      - linux
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
@@ -38,7 +41,9 @@ jobs:
           echo "Building with Go $(cat .go-version)"
           echo "::set-output name=go-version::$(cat .go-version)"
   get-product-version:
-    runs-on: ubuntu-20.04
+    runs-on:
+      - custom
+      - linux
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
     steps:
@@ -52,7 +57,9 @@ jobs:
           echo "::set-output name=product-version::$(make version)"
   generate-metadata-file:
     needs: get-product-version
-    runs-on: ubuntu-20.04
+    runs-on:
+      - custom
+      - linux
     outputs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
@@ -75,7 +82,9 @@ jobs:
 
   build-other:
     needs: [get-go-version, get-product-version]
-    runs-on: ubuntu-20.04
+    runs-on:
+      - custom
+      - linux
     strategy:
       matrix:
         goos: [windows]
@@ -126,7 +135,9 @@ jobs:
 
   build-linux:
     needs: [get-go-version, get-product-version]
-    runs-on: ubuntu-20.04
+    runs-on:
+      - custom
+      - linux
     strategy:
       matrix:
         goos: [linux]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         # version, because "goenv" can react to it automatically.
         run: |
           echo "Building with Go $(cat .go-version)"
-          echo "::set-output name=go-version::$(cat .go-version)"
+          echo "go-version=$(cat .go-version)" >> $GITHUB_OUTPUT
   get-product-version:
     runs-on:
       - custom
@@ -54,7 +54,7 @@ jobs:
         id: get-product-version
         run: |
           make version
-          echo "::set-output name=product-version::$(make version)"
+          echo "product-version=$(make version)" >> $GITHUB_OUTPUT
   generate-metadata-file:
     needs: get-product-version
     runs-on:


### PR DESCRIPTION
- Use custom github hosted runners for building nomad on linux. These are version pinned to ubuntu 20.04, and only available to the repos `nomad` and `nomad-enterprise`. More context is available in https://github.com/hashicorp/nomad-enterprise/pull/969#issuecomment-1341641159

- Remove set-output deprecation warnings in each github actions run by following https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/