### PR TITLE
acl: make sure there is only one default Auth Method per type

### DIFF
--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -1726,15 +1726,12 @@ func (a *ACL) UpsertAuthMethods(
 		// Are we trying to upsert a default auth method? Check if there isn't
 		// a default one for that very type already.
 		if authMethod.Default {
-			existingMethods, _ := stateSnapshot.GetACLAuthMethods(nil)
-			for raw := existingMethods.Next(); raw != nil; raw = existingMethods.Next() {
-				method := raw.(*structs.ACLAuthMethod)
-				if method.Type == authMethod.Type && method.Default {
-					return structs.NewErrRPCCodedf(
-						http.StatusBadRequest,
-						"default method of type %s already exists: %v", authMethod.Type, method.Name,
-					)
-				}
+			existingMethodsDefaultmethod, _ := stateSnapshot.GetDefaultACLAuthMethodByType(nil, authMethod.Type)
+			if existingMethodsDefaultmethod != nil {
+				return structs.NewErrRPCCodedf(
+					http.StatusBadRequest,
+					"default method for type %s already exists: %v", authMethod.Type, existingMethodsDefaultmethod.Name,
+				)
 			}
 		}
 		authMethod.Canonicalize()

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -1709,12 +1709,33 @@ func (a *ACL) UpsertAuthMethods(
 		return structs.NewErrRPCCoded(http.StatusBadRequest, "must specify as least one auth method")
 	}
 
+	// Snapshot the state so we can make lookups to verify default method
+	stateSnapshot, err := a.srv.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
 	// Validate each auth method, canonicalize, and compute hash
 	for idx, authMethod := range args.AuthMethods {
 		if err := authMethod.Validate(
 			a.srv.config.ACLTokenMinExpirationTTL,
 			a.srv.config.ACLTokenMaxExpirationTTL); err != nil {
 			return structs.NewErrRPCCodedf(http.StatusBadRequest, "auth method %d invalid: %v", idx, err)
+		}
+
+		// Are we trying to upsert a default auth method? Check if there isn't
+		// a default one for that very type already.
+		if authMethod.Default {
+			existingMethods, _ := stateSnapshot.GetACLAuthMethods(nil)
+			for raw := existingMethods.Next(); raw != nil; raw = existingMethods.Next() {
+				method := raw.(*structs.ACLAuthMethod)
+				if method.Type == authMethod.Type && method.Default {
+					return structs.NewErrRPCCodedf(
+						http.StatusBadRequest,
+						"default method of type %s already exists: %v", authMethod.Type, method.Name,
+					)
+				}
+			}
 		}
 		authMethod.Canonicalize()
 		authMethod.SetHash()
@@ -1733,7 +1754,7 @@ func (a *ACL) UpsertAuthMethods(
 
 	// Populate the response. We do a lookup against the state to pick up the
 	// proper create / modify times.
-	stateSnapshot, err := a.srv.State().Snapshot()
+	stateSnapshot, err = a.srv.State().Snapshot()
 	if err != nil {
 		return err
 	}

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -3022,6 +3022,7 @@ func TestACLEndpoint_UpsertACLAuthMethods(t *testing.T) {
 
 	// Create the register request
 	am1 := mock.ACLAuthMethod()
+	am1.Default = true // make sure it's going to be a default method
 
 	// Lookup the authMethods
 	req := &structs.ACLAuthMethodUpsertRequest{
@@ -3032,14 +3033,26 @@ func TestACLEndpoint_UpsertACLAuthMethods(t *testing.T) {
 		},
 	}
 	var resp structs.ACLAuthMethodUpsertResponse
-	if err := msgpackrpc.CallWithCodec(codec, structs.ACLUpsertAuthMethodsRPCMethod, req, &resp); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	must.NoError(t, msgpackrpc.CallWithCodec(codec, structs.ACLUpsertAuthMethodsRPCMethod, req, &resp))
 	must.NotEq(t, uint64(0), resp.Index)
 
 	// Check we created the authMethod
 	out, err := s1.fsm.State().GetACLAuthMethodByName(nil, am1.Name)
 	must.Nil(t, err)
 	must.NotNil(t, out)
+	must.NotEq(t, 0, len(resp.AuthMethods))
 	must.True(t, am1.Equal(resp.AuthMethods[0]))
+
+	// Try to insert another default authMethod
+	am2 := mock.ACLAuthMethod()
+	am2.Default = true
+	req = &structs.ACLAuthMethodUpsertRequest{
+		AuthMethods: []*structs.ACLAuthMethod{am2},
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			AuthToken: root.SecretID,
+		},
+	}
+	// We expect this to err since there's already a default method of the same type
+	must.Error(t, msgpackrpc.CallWithCodec(codec, structs.ACLUpsertAuthMethodsRPCMethod, req, &resp))
 }

--- a/nomad/mock/acl.go
+++ b/nomad/mock/acl.go
@@ -226,7 +226,7 @@ func ACLAuthMethod() *structs.ACLAuthMethod {
 		Type:          "OIDC",
 		TokenLocality: "local",
 		MaxTokenTTL:   maxTokenTTL,
-		Default:       true,
+		Default:       false,
 		Config: &structs.ACLAuthMethodConfig{
 			OIDCDiscoveryURL:    "http://example.com",
 			OIDCClientID:        "mock",

--- a/nomad/state/state_store_acl_sso_test.go
+++ b/nomad/state/state_store_acl_sso_test.go
@@ -4,11 +4,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-memdb"
-	"github.com/shoenig/test/must"
-
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
 )
 
 func TestStateStore_UpsertACLAuthMethods(t *testing.T) {
@@ -226,4 +225,31 @@ func TestStateStore_GetACLAuthMethodByName(t *testing.T) {
 	authMethod, err = testState.GetACLAuthMethodByName(ws, mockedACLAuthMethods[1].Name)
 	must.NoError(t, err)
 	must.Equal(t, mockedACLAuthMethods[1], authMethod)
+}
+
+func TestStateStore_GetDefaultACLAuthMethodByType(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Generate 2 auth methods, make one of them default
+	am1 := mock.ACLAuthMethod()
+	am1.Default = true
+	am2 := mock.ACLAuthMethod()
+
+	// upsert
+	mockedACLAuthMethods := []*structs.ACLAuthMethod{am1, am2}
+	must.NoError(t, testState.UpsertACLAuthMethods(10, mockedACLAuthMethods))
+
+	// Get the default method for OIDC
+	ws := memdb.NewWatchSet()
+	defaultOIDCMethod, err := testState.GetDefaultACLAuthMethodByType(ws, "OIDC")
+	must.NoError(t, err)
+
+	must.True(t, defaultOIDCMethod.Default)
+	must.Eq(t, am1, defaultOIDCMethod)
+
+	// Get the default method for jwt (should not return anything)
+	defaultJWTMethod, err := testState.GetDefaultACLAuthMethodByType(ws, "JWT")
+	must.NoError(t, err)
+	must.Nil(t, defaultJWTMethod)
 }


### PR DESCRIPTION
This PR adds a check that makes sure we don't insert a duplicate `default` ACL auth method for a given type. 
Relates to #13120 