### PR TITLE
acl: add binding rule object state schema and functionality.

### DIFF
--- a/helper/raftutil/msgtypes.go
+++ b/helper/raftutil/msgtypes.go
@@ -61,6 +61,8 @@ var msgTypeNames = map[structs.MessageType]string{
 	structs.ACLRolesDeleteByIDRequestType:                "ACLRolesDeleteByIDRequestType",
 	structs.ACLAuthMethodsUpsertRequestType:              "ACLAuthMethodsUpsertRequestType",
 	structs.ACLAuthMethodsDeleteRequestType:              "ACLAuthMethodsDeleteRequestType",
+	structs.ACLBindingRulesUpsertRequestType:             "ACLBindingRulesUpsertRequestType",
+	structs.ACLBindingRulesDeleteRequestType:             "ACLBindingRulesDeleteRequestType",
 	structs.NamespaceUpsertRequestType:                   "NamespaceUpsertRequestType",
 	structs.NamespaceDeleteRequestType:                   "NamespaceDeleteRequestType",
 }

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -60,6 +60,7 @@ const (
 	RootKeyMetaSnapshot                  SnapshotType = 24
 	ACLRoleSnapshot                      SnapshotType = 25
 	ACLAuthMethodSnapshot                SnapshotType = 26
+	ACLBindingRuleSnapshot               SnapshotType = 27
 
 	// Namespace appliers were moved from enterprise and therefore start at 64
 	NamespaceSnapshot SnapshotType = 64
@@ -333,6 +334,10 @@ func (n *nomadFSM) Apply(log *raft.Log) interface{} {
 		return n.applyACLAuthMethodsUpsert(buf[1:], log.Index)
 	case structs.ACLAuthMethodsDeleteRequestType:
 		return n.applyACLAuthMethodsDelete(buf[1:], log.Index)
+	case structs.ACLBindingRulesUpsertRequestType:
+		return n.applyACLBindingRulesUpsert(buf[1:], log.Index)
+	case structs.ACLBindingRulesDeleteRequestType:
+		return n.applyACLBindingRulesDelete(buf[1:], log.Index)
 	}
 
 	// Check enterprise only message types.
@@ -1792,6 +1797,18 @@ func (n *nomadFSM) restoreImpl(old io.ReadCloser, filter *FSMFilter) error {
 				return err
 			}
 
+		case ACLBindingRuleSnapshot:
+			bindingRule := new(structs.ACLBindingRule)
+
+			if err := dec.Decode(bindingRule); err != nil {
+				return err
+			}
+
+			// Perform the restoration.
+			if err := restore.ACLBindingRuleRestore(bindingRule); err != nil {
+				return err
+			}
+
 		default:
 			// Check if this is an enterprise only object being restored
 			restorer, ok := n.enterpriseRestorers[snapType]
@@ -2111,6 +2128,36 @@ func (n *nomadFSM) applyACLAuthMethodsDelete(buf []byte, index uint64) interface
 	return nil
 }
 
+func (n *nomadFSM) applyACLBindingRulesUpsert(buf []byte, index uint64) interface{} {
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_acl_binding_rule_upsert"}, time.Now())
+	var req structs.ACLBindingRulesUpsertRequest
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+
+	if err := n.state.UpsertACLBindingRules(index, req.ACLBindingRules, false); err != nil {
+		n.logger.Error("UpsertACLAuthMethods failed", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+func (n *nomadFSM) applyACLBindingRulesDelete(buf []byte, index uint64) interface{} {
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_acl_binding_rule_delete"}, time.Now())
+	var req structs.ACLBindingRulesDeleteRequest
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+
+	if err := n.state.DeleteACLBindingRules(index, req.ACLBindingRuleIDs); err != nil {
+		n.logger.Error("DeleteACLAuthMethods failed", "error", err)
+		return err
+	}
+
+	return nil
+}
+
 type FSMFilter struct {
 	evaluator *bexpr.Evaluator
 }
@@ -2317,6 +2364,10 @@ func (s *nomadSnapshot) Persist(sink raft.SnapshotSink) error {
 		return err
 	}
 	if err := s.persistACLAuthMethods(sink, encoder); err != nil {
+		sink.Cancel()
+		return err
+	}
+	if err := s.persistACLBindingRules(sink, encoder); err != nil {
 		sink.Cancel()
 		return err
 	}
@@ -2987,6 +3038,27 @@ func (s *nomadSnapshot) persistACLAuthMethods(sink raft.SnapshotSink,
 
 		// write the snapshot
 		sink.Write([]byte{byte(ACLAuthMethodSnapshot)})
+		if err := encoder.Encode(method); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *nomadSnapshot) persistACLBindingRules(sink raft.SnapshotSink, encoder *codec.Encoder) error {
+
+	// Get all the ACL binding rules.
+	ws := memdb.NewWatchSet()
+	aclBindingRulesIter, err := s.snap.GetACLBindingRules(ws)
+	if err != nil {
+		return err
+	}
+
+	for raw := aclBindingRulesIter.Next(); raw != nil; raw = aclBindingRulesIter.Next() {
+		method := raw.(*structs.ACLBindingRule)
+
+		// write the snapshot
+		sink.Write([]byte{byte(ACLBindingRuleSnapshot)})
 		if err := encoder.Encode(method); err != nil {
 			return err
 		}

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -2136,7 +2136,7 @@ func (n *nomadFSM) applyACLBindingRulesUpsert(buf []byte, index uint64) interfac
 	}
 
 	if err := n.state.UpsertACLBindingRules(index, req.ACLBindingRules, false); err != nil {
-		n.logger.Error("UpsertACLAuthMethods failed", "error", err)
+		n.logger.Error("UpsertACLBindingRules failed", "error", err)
 		return err
 	}
 
@@ -2151,7 +2151,7 @@ func (n *nomadFSM) applyACLBindingRulesDelete(buf []byte, index uint64) interfac
 	}
 
 	if err := n.state.DeleteACLBindingRules(index, req.ACLBindingRuleIDs); err != nil {
-		n.logger.Error("DeleteACLAuthMethods failed", "error", err)
+		n.logger.Error("DeleteACLBindingRules failed", "error", err)
 		return err
 	}
 
@@ -3055,11 +3055,11 @@ func (s *nomadSnapshot) persistACLBindingRules(sink raft.SnapshotSink, encoder *
 	}
 
 	for raw := aclBindingRulesIter.Next(); raw != nil; raw = aclBindingRulesIter.Next() {
-		method := raw.(*structs.ACLBindingRule)
+		bindingRule := raw.(*structs.ACLBindingRule)
 
 		// write the snapshot
 		sink.Write([]byte{byte(ACLBindingRuleSnapshot)})
-		if err := encoder.Encode(method); err != nil {
+		if err := encoder.Encode(bindingRule); err != nil {
 			return err
 		}
 	}

--- a/nomad/mock/acl.go
+++ b/nomad/mock/acl.go
@@ -246,3 +246,18 @@ func ACLAuthMethod() *structs.ACLAuthMethod {
 	method.Canonicalize()
 	return &method
 }
+
+func ACLBindingRule() *structs.ACLBindingRule {
+	return &structs.ACLBindingRule{
+		ID:          uuid.Short(),
+		Description: "mocked-acl-binding-rule",
+		AuthMethod:  "auth0",
+		Selector:    "engineering in list.roles",
+		BindType:    "role",
+		BindName:    "eng-ro",
+		CreateTime:  time.Now().UTC(),
+		ModifyTime:  time.Now().UTC(),
+		CreateIndex: 10,
+		ModifyIndex: 10,
+	}
+}

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -19,6 +19,7 @@ const (
 	TableRootKeyMeta          = "root_key_meta"
 	TableACLRoles             = "acl_roles"
 	TableACLAuthMethods       = "acl_auth_methods"
+	TableACLBindingRules      = "acl_binding_rules"
 	TableAllocs               = "allocs"
 )
 
@@ -34,6 +35,7 @@ const (
 	indexPath          = "path"
 	indexName          = "name"
 	indexSigningKey    = "signing_key"
+	indexAuthMethod    = "auth_method"
 )
 
 var (
@@ -87,6 +89,7 @@ func init() {
 		variablesRootKeyMetaSchema,
 		aclRolesTableSchema,
 		aclAuthMethodsTableSchema,
+		bindingRulesTableSchema,
 	}...)
 }
 
@@ -1529,6 +1532,30 @@ func aclAuthMethodsTableSchema() *memdb.TableSchema {
 				Unique:       true,
 				Indexer: &memdb.StringFieldIndex{
 					Field: "Name",
+				},
+			},
+		},
+	}
+}
+
+func bindingRulesTableSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: TableACLBindingRules,
+		Indexes: map[string]*memdb.IndexSchema{
+			indexID: {
+				Name:         indexID,
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.StringFieldIndex{
+					Field: "ID",
+				},
+			},
+			indexAuthMethod: {
+				Name:         indexAuthMethod,
+				AllowMissing: false,
+				Unique:       false,
+				Indexer: &memdb.StringFieldIndex{
+					Field: "AuthMethod",
 				},
 			},
 		},

--- a/nomad/state/state_store_acl_binding_rule.go
+++ b/nomad/state/state_store_acl_binding_rule.go
@@ -1,0 +1,208 @@
+package state
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// UpsertACLBindingRules is used to insert a number of ACL binding rules into
+// the state store. It uses a single write transaction for efficiency, however,
+// any error means no entries will be committed.
+func (s *StateStore) UpsertACLBindingRules(
+	index uint64, bindingRules []*structs.ACLBindingRule, allowMissingAuthMethod bool) error {
+
+	// Grab a write transaction.
+	txn := s.db.WriteTxnMsgT(structs.ACLBindingRulesUpsertRequestType, index)
+	defer txn.Abort()
+
+	// updated tracks whether any inserts have been made. This allows us to
+	// skip updating the index table if we do not need to.
+	var updated bool
+
+	// Iterate the array of rules. In the event of a single error, all inserts
+	// fail via the txn.Abort() defer.
+	for _, rule := range bindingRules {
+
+		bindingRuleInserted, err := s.upsertACLBindingRuleTxn(index, txn, rule, allowMissingAuthMethod)
+		if err != nil {
+			return err
+		}
+
+		// Ensure we track whether any inserts have been made.
+		updated = updated || bindingRuleInserted
+	}
+
+	// If we did not perform any inserts, exit early.
+	if !updated {
+		return nil
+	}
+
+	// Perform the index table update to mark the new insert.
+	if err := txn.Insert(tableIndex, &IndexEntry{TableACLBindingRules, index}); err != nil {
+		return fmt.Errorf("index update failed: %v", err)
+	}
+
+	return txn.Commit()
+}
+
+// upsertACLBindingRuleTxn inserts a single ACL binding rule into the state
+// store using the provided write transaction. It is the responsibility of the
+// caller to update the index table.
+func (s *StateStore) upsertACLBindingRuleTxn(
+	index uint64, txn *txn, rule *structs.ACLBindingRule, allowMissingAuthMethod bool) (bool, error) {
+
+	// Ensure the rule hash is not zero to provide defense in depth. This
+	// should be done outside the state store, so we do not spend time here and
+	// thus Raft, when it can be avoided.
+	if len(rule.Hash) == 0 {
+		rule.SetHash()
+	}
+
+	// This validation also happens within the RPC handler, but Raft latency
+	// could mean that by the time the state call is invoked, another Raft
+	// update has the auth method detailed in binding rule. Therefore, check
+	// again while in our write txn.
+	if !allowMissingAuthMethod {
+		method, err := s.GetACLAuthMethodByName(nil, rule.AuthMethod)
+		if err != nil {
+			return false, fmt.Errorf("ACL auth method lookup failed: %v", err)
+		}
+		if method == nil {
+			return false, fmt.Errorf("ACL binding rule insert failed: ACL auth method not found")
+		}
+	}
+
+	// This validation also happens within the RPC handler, but Raft latency
+	// could mean that by the time the state call is invoked, another Raft
+	// update has already written a method with the same name. We therefore
+	// need to check we are not trying to create a rule with an existing ID.
+	existingRaw, err := txn.First(TableACLBindingRules, indexID, rule.ID)
+	if err != nil {
+		return false, fmt.Errorf("ACL binding rule lookup failed: %v", err)
+	}
+
+	var existing *structs.ACLBindingRule
+	if existingRaw != nil {
+		existing = existingRaw.(*structs.ACLBindingRule)
+	}
+
+	// Depending on whether this is an initial create, or an update, we need to
+	// check and set certain parameters. The most important is to ensure any
+	// create index is carried over.
+	if existing != nil {
+
+		// If the rule already exists, check whether the update contains any
+		// difference. If it doesn't, we can avoid a state update as well as
+		// updates to any blocking queries.
+		if existing.Equal(rule) {
+			return false, nil
+		}
+
+		rule.CreateIndex = existing.CreateIndex
+		rule.ModifyIndex = index
+		rule.CreateTime = existing.CreateTime
+	} else {
+		rule.CreateIndex = index
+		rule.ModifyIndex = index
+	}
+
+	// Insert the auth method into the table.
+	if err := txn.Insert(TableACLBindingRules, rule); err != nil {
+		return false, fmt.Errorf("ACL binding rule insert failed: %v", err)
+	}
+	return true, nil
+}
+
+// DeleteACLBindingRules is responsible for batch deleting ACL binding rules.
+// It uses a single write transaction for efficiency, however, any error means
+// no entries will be committed. An error is produced if a rule is not found
+// within state which has been passed within the array.
+func (s *StateStore) DeleteACLBindingRules(index uint64, bindingRuleIDs []string) error {
+	txn := s.db.WriteTxnMsgT(structs.ACLBindingRulesDeleteRequestType, index)
+	defer txn.Abort()
+
+	for _, ruleID := range bindingRuleIDs {
+		if err := s.deleteACLBindingRuleTxn(txn, ruleID); err != nil {
+			return err
+		}
+	}
+
+	// Update the index table to indicate an update has occurred.
+	if err := txn.Insert(tableIndex, &IndexEntry{TableACLBindingRules, index}); err != nil {
+		return fmt.Errorf("index update failed: %v", err)
+	}
+
+	return txn.Commit()
+}
+
+// deleteACLBindingRuleTxn deletes a single ACL binding rule from the state
+// store using the provided write transaction. It is the responsibility of the
+// caller to update the index table.
+func (s *StateStore) deleteACLBindingRuleTxn(txn *txn, ruleID string) error {
+	existing, err := txn.First(TableACLBindingRules, indexID, ruleID)
+	if err != nil {
+		return fmt.Errorf("ACL binding rule lookup failed: %v", err)
+	}
+	if existing == nil {
+		return errors.New("ACL binding rule not found")
+	}
+
+	// Delete the existing entry from the table.
+	if err := txn.Delete(TableACLBindingRules, existing); err != nil {
+		return fmt.Errorf("ACL binding rule deletion failed: %v", err)
+	}
+	return nil
+}
+
+// GetACLBindingRules returns an iterator that contains all ACL binding rules
+// stored within state.
+func (s *StateStore) GetACLBindingRules(ws memdb.WatchSet) (memdb.ResultIterator, error) {
+	txn := s.db.ReadTxn()
+
+	// Walk the entire table to get all ACL binding rules.
+	iter, err := txn.Get(TableACLBindingRules, indexID)
+	if err != nil {
+		return nil, fmt.Errorf("ACL binding rules lookup failed: %v", err)
+	}
+	ws.Add(iter.WatchCh())
+
+	return iter, nil
+}
+
+// GetACLBindingRule returns a single ACL binding rule specified by the input
+// ID. The binding rule object will be nil, if no matching entry was found; it
+// is the responsibility of the caller to check for this.
+func (s *StateStore) GetACLBindingRule(ws memdb.WatchSet, ruleID string) (*structs.ACLBindingRule, error) {
+	txn := s.db.ReadTxn()
+
+	// Perform the ACL binding rule lookup using the ID.
+	watchCh, existing, err := txn.FirstWatch(TableACLBindingRules, indexID, ruleID)
+	if err != nil {
+		return nil, fmt.Errorf("ACL binding rule lookup failed: %v", err)
+	}
+	ws.Add(watchCh)
+
+	if existing != nil {
+		return existing.(*structs.ACLBindingRule), nil
+	}
+	return nil, nil
+}
+
+// GetACLBindingRulesByAuthMethod returns an iterator with all binding rules
+// associated with the named authentication method.
+func (s *StateStore) GetACLBindingRulesByAuthMethod(
+	ws memdb.WatchSet, authMethod string) (memdb.ResultIterator, error) {
+
+	txn := s.db.ReadTxn()
+
+	iter, err := txn.Get(TableACLBindingRules, indexAuthMethod, authMethod)
+	if err != nil {
+		return nil, fmt.Errorf("ACL binding rule lookup failed: %v", err)
+	}
+	ws.Add(iter.WatchCh())
+
+	return iter, nil
+}

--- a/nomad/state/state_store_acl_binding_rule_test.go
+++ b/nomad/state/state_store_acl_binding_rule_test.go
@@ -1,0 +1,256 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+)
+
+func TestStateStore_UpsertACLBindingRules(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Generate a mocked ACL binding rule for testing and attempt to upsert
+	// this straight into state. It should fail because the auth method does
+	// not exist.
+	mockedACLBindingRules := []*structs.ACLBindingRule{mock.ACLBindingRule()}
+	err := testState.UpsertACLBindingRules(10, mockedACLBindingRules, false)
+	must.EqError(t, err, "ACL binding rule insert failed: ACL auth method not found")
+
+	// Create an auth method and ensure the binding rule is updated, so it is
+	// related to it.
+	authMethod := mock.ACLAuthMethod()
+	mockedACLBindingRules[0].AuthMethod = authMethod.Name
+
+	must.NoError(t, testState.UpsertACLAuthMethods(10, []*structs.ACLAuthMethod{authMethod}))
+	must.NoError(t, testState.UpsertACLBindingRules(20, mockedACLBindingRules, false))
+
+	// Check that the index for the table was modified as expected.
+	initialIndex, err := testState.Index(TableACLBindingRules)
+	must.NoError(t, err)
+	must.Eq(t, 20, initialIndex)
+
+	// List all the ACL binding rules in the table, so we can perform a number
+	// of tests on the return array.
+	ws := memdb.NewWatchSet()
+	iter, err := testState.GetACLBindingRules(ws)
+	must.NoError(t, err)
+
+	// Count how many table entries we have, to ensure it is the expected
+	// number.
+	var count int
+
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		count++
+
+		// Ensure the create and modify indexes are populated correctly.
+		aclRole := raw.(*structs.ACLBindingRule)
+		must.Eq(t, 20, aclRole.CreateIndex)
+		must.Eq(t, 20, aclRole.ModifyIndex)
+	}
+	must.Eq(t, 1, count)
+
+	// Try writing the same ACL binding rule to state which should not result
+	// in an update to the table index.
+	must.NoError(t, testState.UpsertACLBindingRules(20, mockedACLBindingRules, false))
+	reInsertActualIndex, err := testState.Index(TableACLBindingRules)
+	must.NoError(t, err)
+	must.Eq(t, 20, reInsertActualIndex)
+
+	// Make a change to the binding rule and ensure this update is accepted and
+	// the table index is updated.
+	updatedMockedACLBindingRule := mockedACLBindingRules[0].Copy()
+	updatedMockedACLBindingRule.BindType = "role-name"
+	updatedMockedACLBindingRule.SetHash()
+	must.NoError(t, testState.UpsertACLBindingRules(
+		30, []*structs.ACLBindingRule{updatedMockedACLBindingRule}, false))
+
+	// Check that the index for the table was modified as expected.
+	updatedIndex, err := testState.Index(TableACLBindingRules)
+	must.NoError(t, err)
+	must.Eq(t, 30, updatedIndex)
+
+	// List the ACL roles in state.
+	iter, err = testState.GetACLBindingRules(ws)
+	must.NoError(t, err)
+
+	// Count how many table entries we have, to ensure it is the expected
+	// number.
+	count = 0
+
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		count++
+
+		// Ensure the create and modify indexes are populated correctly.
+		aclRole := raw.(*structs.ACLBindingRule)
+		must.Eq(t, 20, aclRole.CreateIndex)
+		must.Eq(t, 30, aclRole.ModifyIndex)
+	}
+	must.Eq(t, 1, count)
+
+	// Now try inserting an ACL binding rule using the missing auth methods
+	// argument to simulate replication.
+	replicatedACLBindingRule := []*structs.ACLBindingRule{mock.ACLBindingRule()}
+	must.NoError(t, testState.UpsertACLBindingRules(40, replicatedACLBindingRule, true))
+
+	replicatedACLBindingRuleResp, err := testState.GetACLBindingRule(ws, replicatedACLBindingRule[0].ID)
+	must.NoError(t, err)
+	must.Eq(t, replicatedACLBindingRule[0].Hash, replicatedACLBindingRuleResp.Hash)
+}
+
+func TestStateStore_DeleteACLBindingRules(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Generate a some mocked ACL binding rules for testing and upsert these
+	// straight into state.
+	mockedACLBindingRoles := []*structs.ACLBindingRule{mock.ACLBindingRule(), mock.ACLBindingRule()}
+	must.NoError(t, testState.UpsertACLBindingRules(10, mockedACLBindingRoles, true))
+
+	// Try and delete a binding rule using an ID that doesn't exist. This
+	// should return an error and not change the index for the table.
+	err := testState.DeleteACLBindingRules(20, []string{uuid.Generate()})
+	must.EqError(t, err, "ACL binding rule not found")
+
+	tableIndex, err := testState.Index(TableACLBindingRules)
+	must.NoError(t, err)
+	must.Eq(t, 10, tableIndex)
+
+	// Delete one of the previously upserted ACL binding rules. This should
+	// succeed and modify the table index.
+	must.NoError(t, testState.DeleteACLBindingRules(20, []string{mockedACLBindingRoles[0].ID}))
+
+	tableIndex, err = testState.Index(TableACLBindingRules)
+	must.NoError(t, err)
+	must.Eq(t, 20, tableIndex)
+
+	// List the ACL binding rules and ensure we now only have one present and
+	// that it is the one we expect.
+	ws := memdb.NewWatchSet()
+	iter, err := testState.GetACLBindingRules(ws)
+	must.NoError(t, err)
+
+	var aclBindingRules []*structs.ACLBindingRule
+
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		aclBindingRules = append(aclBindingRules, raw.(*structs.ACLBindingRule))
+	}
+
+	must.Len(t, 1, aclBindingRules)
+	must.True(t, aclBindingRules[0].Equal(mockedACLBindingRoles[1]))
+
+	// Delete the final remaining ACL binding rule. This should succeed and
+	// modify the table index.
+	must.NoError(t, testState.DeleteACLBindingRules(30, []string{mockedACLBindingRoles[1].ID}))
+
+	tableIndex, err = testState.Index(TableACLBindingRules)
+	must.NoError(t, err)
+	must.Eq(t, 30, tableIndex)
+
+	// List the ACL binding rules and ensure we have zero entries.
+	iter, err = testState.GetACLBindingRules(ws)
+	must.NoError(t, err)
+
+	aclBindingRules = make([]*structs.ACLBindingRule, 0)
+
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		aclBindingRules = append(aclBindingRules, raw.(*structs.ACLBindingRule))
+	}
+	must.Len(t, 0, aclBindingRules)
+}
+
+func TestStateStore_GetACLBindingRules(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Generate a some mocked ACL binding rules for testing and upsert these
+	// straight into state.
+	mockedACLBindingRoles := []*structs.ACLBindingRule{mock.ACLBindingRule(), mock.ACLBindingRule()}
+	must.NoError(t, testState.UpsertACLBindingRules(10, mockedACLBindingRoles, true))
+
+	// List the ACL binding rules and ensure they are exactly as we expect.
+	ws := memdb.NewWatchSet()
+	iter, err := testState.GetACLBindingRules(ws)
+	must.NoError(t, err)
+
+	var aclBindingRules []*structs.ACLBindingRule
+
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		aclBindingRules = append(aclBindingRules, raw.(*structs.ACLBindingRule))
+	}
+
+	expected := mockedACLBindingRoles
+	for i := range expected {
+		expected[i].CreateIndex = 10
+		expected[i].ModifyIndex = 10
+	}
+
+	must.Eq(t, aclBindingRules, expected)
+}
+
+func TestStateStore_GetACLBindingRule(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Generate a some mocked ACL binding rules for testing and upsert these
+	// straight into state.
+	mockedACLBindingRoles := []*structs.ACLBindingRule{mock.ACLBindingRule(), mock.ACLBindingRule()}
+	must.NoError(t, testState.UpsertACLBindingRules(10, mockedACLBindingRoles, true))
+
+	ws := memdb.NewWatchSet()
+
+	// Try reading an ACL binding rule that does not exist.
+	aclBindingRule, err := testState.GetACLBindingRule(ws, uuid.Generate())
+	must.NoError(t, err)
+	must.Nil(t, aclBindingRule)
+
+	// Read the two ACL binding rules that we should find.
+	aclBindingRule, err = testState.GetACLBindingRule(ws, mockedACLBindingRoles[0].ID)
+	must.NoError(t, err)
+	must.Eq(t, mockedACLBindingRoles[0], aclBindingRule)
+
+	aclBindingRule, err = testState.GetACLBindingRule(ws, mockedACLBindingRoles[1].ID)
+	must.NoError(t, err)
+	must.Eq(t, mockedACLBindingRoles[1], aclBindingRule)
+}
+
+func TestStateStore_GetACLBindingRulesByAuthMethod(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Generate a some mocked ACL binding rules for testing and upsert these
+	// straight into state.
+	mockedACLBindingRoles := []*structs.ACLBindingRule{mock.ACLBindingRule(), mock.ACLBindingRule()}
+	must.NoError(t, testState.UpsertACLBindingRules(10, mockedACLBindingRoles, true))
+
+	ws := memdb.NewWatchSet()
+
+	// Lookup ACL binding rules using an auth method that is not referenced. We
+	// should not get any results within the iterator.
+	iter, err := testState.GetACLBindingRulesByAuthMethod(ws, "not-an-auth-method")
+	must.NoError(t, err)
+
+	var aclBindingRules []*structs.ACLBindingRule
+
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		aclBindingRules = append(aclBindingRules, raw.(*structs.ACLBindingRule))
+	}
+	must.Len(t, 0, aclBindingRules)
+
+	// Lookup ACL binding rules using an auth method that is referenced by both
+	// mocked rules. Ensure the results are as expected.
+	iter, err = testState.GetACLBindingRulesByAuthMethod(ws, mockedACLBindingRoles[0].AuthMethod)
+	must.NoError(t, err)
+
+	aclBindingRules = make([]*structs.ACLBindingRule, 0)
+
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		aclBindingRules = append(aclBindingRules, raw.(*structs.ACLBindingRule))
+	}
+	must.Len(t, 2, aclBindingRules)
+}

--- a/nomad/state/state_store_restore.go
+++ b/nomad/state/state_store_restore.go
@@ -242,3 +242,12 @@ func (r *StateRestore) ACLAuthMethodRestore(aclAuthMethod *structs.ACLAuthMethod
 	}
 	return nil
 }
+
+// ACLBindingRuleRestore is used to restore a single ACL binding rule into the
+// acl_binding_rules table.
+func (r *StateRestore) ACLBindingRuleRestore(aclBindingRule *structs.ACLBindingRule) error {
+	if err := r.txn.Insert(TableACLBindingRules, aclBindingRule); err != nil {
+		return fmt.Errorf("ACL binding rule insert failed: %v", err)
+	}
+	return nil
+}

--- a/nomad/state/state_store_restore_test.go
+++ b/nomad/state/state_store_restore_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -649,4 +650,27 @@ func TestStateStore_ACLAuthMethodRestore(t *testing.T) {
 	out, err := testState.GetACLAuthMethodByName(ws, authMethod.Name)
 	require.NoError(t, err)
 	require.Equal(t, authMethod, out)
+}
+
+func TestStateStore_ACLBindingRuleRestore(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Set up our test ACL binding rule and index.
+	expectedIndex := uint64(13)
+	aclBindingRule := mock.ACLBindingRule()
+	aclBindingRule.CreateIndex = expectedIndex
+	aclBindingRule.ModifyIndex = expectedIndex
+
+	restore, err := testState.Restore()
+	must.NoError(t, err)
+	must.NoError(t, restore.ACLBindingRuleRestore(aclBindingRule))
+	must.NoError(t, restore.Commit())
+
+	// Check the state is now populated as we expect and that we can find the
+	// restored ACL binding rule.
+	ws := memdb.NewWatchSet()
+	out, err := testState.GetACLBindingRule(ws, aclBindingRule.ID)
+	must.NoError(t, err)
+	must.Eq(t, aclBindingRule, out)
 }

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -114,6 +114,40 @@ const (
 	// Args: ACLAuthMethodsGetRequest
 	// Reply: ACLAuthMethodsGetResponse
 	ACLGetAuthMethodsRPCMethod = "ACL.GetAuthMethods"
+
+	// ACLUpsertBindingRulesRPCMethod is the RPC method for batch creating or
+	// modifying binding rules.
+	//
+	// Args: ACLAuthMethodsUpsertRequest
+	// Reply: ACLAuthMethodUpsertResponse
+	ACLUpsertBindingRulesRPCMethod = "ACL.UpsertBindingRules"
+
+	// ACLDeleteBindingRulesRPCMethod is the RPC method for batch deleting
+	// binding rules.
+	//
+	// Args: ACLBindingRulesDeleteRequest
+	// Reply: ACLBindingRulesDeleteResponse
+	ACLDeleteBindingRulesRPCMethod = "ACL.DeleteBindingRules"
+
+	// ACLListBindingRulesRPCMethod is the RPC method listing binding rules.
+	//
+	// Args: ACLBindingRulesListRequest
+	// Reply: ACLBindingRulesListResponse
+	ACLListBindingRulesRPCMethod = "ACL.ListBindingRules"
+
+	// ACLGetBindingRulesRPCMethod is the RPC method for getting multiple
+	// binding rules using their IDs.
+	//
+	// Args: ACLBindingRulesRequest
+	// Reply: ACLBindingRulesResponse
+	ACLGetBindingRulesRPCMethod = "ACL.GetBindingRules"
+
+	// ACLGetBindingRuleRPCMethod is the RPC method for detailing an individual
+	// binding rule using its ID.
+	//
+	// Args: ACLBindingRuleRequest
+	// Reply: ACLBindingRuleResponse
+	ACLGetBindingRuleRPCMethod = "ACL.GetBindingRule"
 )
 
 const (
@@ -126,6 +160,10 @@ const (
 
 	// maxACLRoleDescriptionLength limits an ACL roles description length.
 	maxACLRoleDescriptionLength = 256
+
+	// maxACLBindingRuleDescriptionLength limits an ACL binding rules
+	// description length and should be used to validate the object.
+	maxACLBindingRuleDescriptionLength = 256
 )
 
 var (
@@ -856,5 +894,277 @@ type ACLAuthMethodDeleteResponse struct {
 
 type ACLWhoAmIResponse struct {
 	Identity *AuthenticatedIdentity
+	QueryMeta
+}
+
+// ACLBindingRule contains a direct relation to an ACLAuthMethod and represents
+// a rule to apply when logging in via the named AuthMethod. This allows the
+// transformation of OIDC provider claims, to Nomad based ACL concepts such as
+// ACL Roles and Policies.
+type ACLBindingRule struct {
+
+	// ID is an internally generated UUID for this role and is controlled by
+	// Nomad.
+	ID string
+
+	// Description is a human-readable, operator set description that can
+	// provide additional context about the binding role. This is an
+	// operational field.
+	Description string
+
+	// AuthMethod is the name of the auth method for which this rule applies
+	// to. This is required and the method must exist within state before the
+	// cluster administrator can create the rule.
+	AuthMethod string
+
+	// Selector is an expression that matches against verified identity
+	// attributes returned from the auth method during login. This is optional
+	// and when not set, provides a catch-all rule.
+	Selector string
+
+	// BindType adjusts how this binding rule is applied at login time. The
+	// valid values are ACLBindingRuleBindTypeRole and
+	// ACLBindingRuleBindTypePolicy.
+	BindType string
+
+	// BindName is the target of the binding. Can be lightly templated using
+	// HIL ${foo} syntax from available field names. How it is used depends
+	// upon the BindType.
+	BindName string
+
+	// Hash is the hashed value of the binding rule and is generated using all
+	// fields from the full object except the create and modify times and
+	// indexes.
+	Hash []byte
+
+	CreateTime  time.Time
+	ModifyTime  time.Time
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+const (
+	// ACLBindingRuleBindTypeRole is the ACL binding rule bind type that only
+	// allows the binding rule to function if a role exists at login-time. The
+	// role will be specified within the ACLBindingRule.BindName parameter, and
+	// will identify whether this is an ID or Name.
+	ACLBindingRuleBindTypeRole = "role"
+
+	// ACLBindingRuleBindTypePolicy is the ACL binding rule bind type that
+	// assigns a policy to the generate ACL token. The role will be specified
+	// within the ACLBindingRule.BindName parameter, and will be the policy
+	// name.
+	ACLBindingRuleBindTypePolicy = "policy"
+)
+
+// Canonicalize performs basic canonicalization on the ACL token object. It is
+// important for callers to understand certain fields such as ID are set if it
+// is empty, so copies should be taken if needed before calling this function.
+func (a *ACLBindingRule) Canonicalize() {
+
+	now := time.Now().UTC()
+
+	// If the ID is empty, it means this is creation of a new binding rule,
+	// therefore we need to generate base information.
+	if a.ID == "" {
+		a.ID = uuid.Generate()
+		a.CreateTime = now
+	}
+
+	// The fact this function is being called indicates we are attempting an
+	// upsert into state. Therefore, update the modify time.
+	a.ModifyTime = now
+}
+
+// Validate ensures the ACL binding rule contains valid information which meets
+// Nomad's internal requirements.
+func (a *ACLBindingRule) Validate() error {
+
+	var mErr multierror.Error
+
+	if a.AuthMethod == "" {
+		mErr.Errors = append(mErr.Errors, errors.New("auth method is missing"))
+	}
+	if a.BindName == "" {
+		mErr.Errors = append(mErr.Errors, errors.New("bind name is missing"))
+	}
+	if len(a.Description) > maxACLBindingRuleDescriptionLength {
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("description longer than %d", maxACLRoleDescriptionLength))
+	}
+
+	// Be specific about the error as returning an error that includes an empty
+	// quote ("") can be a little confusing.
+	if a.BindType == "" {
+		mErr.Errors = append(mErr.Errors, errors.New("bind type is missing"))
+	} else {
+		switch a.BindType {
+		case ACLBindingRuleBindTypeRole, ACLBindingRuleBindTypePolicy: // fall-through.
+		default:
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("unsupported bind type: %q", a.BindType))
+		}
+	}
+
+	return mErr.ErrorOrNil()
+}
+
+// SetHash is used to compute and set the hash of the ACL binding rule. This
+// should be called every and each time a user specified field on the method is
+// changed before updating the Nomad state store.
+func (a *ACLBindingRule) SetHash() []byte {
+
+	// Initialize a 256bit Blake2 hash (32 bytes).
+	hash, err := blake2b.New256(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	_, _ = hash.Write([]byte(a.ID))
+	_, _ = hash.Write([]byte(a.Description))
+	_, _ = hash.Write([]byte(a.AuthMethod))
+	_, _ = hash.Write([]byte(a.Selector))
+	_, _ = hash.Write([]byte(a.BindType))
+	_, _ = hash.Write([]byte(a.BindName))
+
+	// Finalize the hash.
+	hashVal := hash.Sum(nil)
+
+	// Set and return the hash.
+	a.Hash = hashVal
+	return hashVal
+}
+
+// Equal performs an equality check on the two ACL binding rules. It handles
+// nil objects.
+func (a *ACLBindingRule) Equal(other *ACLBindingRule) bool {
+	if a == nil || other == nil {
+		return a == other
+	}
+	if len(a.Hash) == 0 {
+		a.SetHash()
+	}
+	if len(other.Hash) == 0 {
+		other.SetHash()
+	}
+	return bytes.Equal(a.Hash, other.Hash)
+}
+
+// Copy creates a deep copy of the ACL binding rule. This copy can then be
+// safely modified. It handles nil objects.
+func (a *ACLBindingRule) Copy() *ACLBindingRule {
+	if a == nil {
+		return nil
+	}
+
+	c := new(ACLBindingRule)
+	*c = *a
+	c.Hash = slices.Clone(a.Hash)
+
+	return c
+}
+
+// Stub converts the ACLBindingRule object into a ACLBindingRuleListStub
+// object.
+func (a *ACLBindingRule) Stub() *ACLBindingRuleListStub {
+	return &ACLBindingRuleListStub{
+		ID:          a.ID,
+		Description: a.Description,
+		AuthMethod:  a.AuthMethod,
+		Hash:        a.Hash,
+		CreateIndex: a.CreateIndex,
+		ModifyIndex: a.ModifyIndex,
+	}
+}
+
+// ACLBindingRuleListStub is the stub object returned when performing a listing
+// of ACL binding rules.
+type ACLBindingRuleListStub struct {
+
+	// ID is an internally generated UUID for this role and is controlled by
+	// Nomad.
+	ID string
+
+	// Description is a human-readable, operator set description that can
+	// provide additional context about the binding role. This is an
+	// operational field.
+	Description string
+
+	// AuthMethod is the name of the auth method for which this rule applies
+	// to. This is required and the method must exist within state before the
+	// cluster administrator can create the rule.
+	AuthMethod string
+
+	// Hash is the hashed value of the binding rule and is generated using all
+	// fields from the full object except the create and modify times and
+	// indexes.
+	Hash []byte
+
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+// ACLBindingRulesUpsertRequest is used to upsert a set of ACL binding rules.
+type ACLBindingRulesUpsertRequest struct {
+	ACLBindingRules []*ACLBindingRule
+	WriteRequest
+}
+
+// ACLBindingRulesUpsertResponse is a response of the upsert ACL binding rules
+// operation.
+type ACLBindingRulesUpsertResponse struct {
+	ACLBindingRules []*ACLBindingRule
+	WriteMeta
+}
+
+// ACLBindingRulesDeleteRequest is used to delete a set of ACL binding rules by
+// their IDs.
+type ACLBindingRulesDeleteRequest struct {
+	ACLBindingRuleIDs []string
+	WriteRequest
+}
+
+// ACLBindingRulesDeleteResponse is a response of the delete ACL binding rules
+// operation.
+type ACLBindingRulesDeleteResponse struct {
+	WriteMeta
+}
+
+// ACLBindingRulesListRequest  is the request object when performing ACL
+// binding rules listings.
+type ACLBindingRulesListRequest struct {
+	QueryOptions
+}
+
+// ACLBindingRulesListResponse is the response object when performing ACL
+// binding rule listings.
+type ACLBindingRulesListResponse struct {
+	ACLBindingRules []*ACLBindingRuleListStub
+	QueryMeta
+}
+
+// ACLBindingRulesRequest is the request object when performing a lookup of
+// multiple binding rules by the ID.
+type ACLBindingRulesRequest struct {
+	ACLBindingRuleIDs []string
+	QueryOptions
+}
+
+// ACLBindingRulesResponse is the response object when performing a lookup of
+// multiple binding rules by their IDs.
+type ACLBindingRulesResponse struct {
+	ACLBindingRules map[string]*ACLBindingRule
+	QueryMeta
+}
+
+// ACLBindingRuleRequest is the request object to perform a lookup of an ACL
+// binding rule using a specific ID.
+type ACLBindingRuleRequest struct {
+	ACLBindingRuleID string
+	QueryOptions
+}
+
+// ACLBindingRuleResponse is the response object when performing a lookup of an
+// ACL binding rule matching a specific ID.
+type ACLBindingRuleResponse struct {
+	ACLBindingRule *ACLBindingRule
 	QueryMeta
 }

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -118,8 +118,8 @@ const (
 	// ACLUpsertBindingRulesRPCMethod is the RPC method for batch creating or
 	// modifying binding rules.
 	//
-	// Args: ACLAuthMethodsUpsertRequest
-	// Reply: ACLAuthMethodUpsertResponse
+	// Args: ACLBindingRulesUpsertRequest
+	// Reply: ACLBindingRulesUpsertResponse
 	ACLUpsertBindingRulesRPCMethod = "ACL.UpsertBindingRules"
 
 	// ACLDeleteBindingRulesRPCMethod is the RPC method for batch deleting

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -119,6 +119,8 @@ const (
 	ACLRolesDeleteByIDRequestType                MessageType = 54
 	ACLAuthMethodsUpsertRequestType              MessageType = 55
 	ACLAuthMethodsDeleteRequestType              MessageType = 56
+	ACLBindingRulesUpsertRequestType             MessageType = 57
+	ACLBindingRulesDeleteRequestType             MessageType = 58
 
 	// Namespace types were moved from enterprise and therefore start at 64
 	NamespaceUpsertRequestType MessageType = 64


### PR DESCRIPTION
This change adds a new table that will store ACL binding rule objects. The two indexes allow fast lookups by their ID, or by which auth method they are linked to. Snapshot persist and restore functionality ensures this table can be saved and restored from snapshots.

In order to write and delete the object to state, new Raft messages have been added.

All RPC request and response structs, along with object functions such as diff and canonicalize have been included within this work as it is nicely separated from the other areas of work.

Related #13120 