### PR TITLE
implement pre-forwarding auth on select RPCs

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -95,7 +95,7 @@ func TestClient_RPC(t *testing.T) {
 	// RPC should succeed
 	testutil.WaitForResult(func() (bool, error) {
 		var out struct{}
-		err := c1.RPC("Status.Ping", struct{}{}, &out)
+		err := c1.RPC("Status.Ping", &structs.GenericRequest{}, &out)
 		return err == nil, err
 	}, func(err error) {
 		t.Fatalf("err: %v", err)
@@ -118,7 +118,7 @@ func TestClient_RPC_FireRetryWatchers(t *testing.T) {
 	// RPC should succeed
 	testutil.WaitForResult(func() (bool, error) {
 		var out struct{}
-		err := c1.RPC("Status.Ping", struct{}{}, &out)
+		err := c1.RPC("Status.Ping", &structs.GenericRequest{}, &out)
 		return err == nil, err
 	}, func(err error) {
 		t.Fatalf("err: %v", err)
@@ -145,7 +145,7 @@ func TestClient_RPC_Passthrough(t *testing.T) {
 	// RPC should succeed
 	testutil.WaitForResult(func() (bool, error) {
 		var out struct{}
-		err := c1.RPC("Status.Ping", struct{}{}, &out)
+		err := c1.RPC("Status.Ping", &structs.GenericRequest{}, &out)
 		return err == nil, err
 	}, func(err error) {
 		t.Fatalf("err: %v", err)

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -435,7 +435,7 @@ func resolveServer(s string) (net.Addr, error) {
 // a potential error.
 func (c *Client) Ping(srv net.Addr) error {
 	var reply struct{}
-	err := c.connPool.RPC(c.Region(), srv, "Status.Ping", struct{}{}, &reply)
+	err := c.connPool.RPC(c.Region(), srv, "Status.Ping", &structs.GenericRequest{}, &reply)
 	return err
 }
 

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -431,11 +431,15 @@ func resolveServer(s string) (net.Addr, error) {
 	return net.ResolveTCPAddr("tcp", net.JoinHostPort(host, port))
 }
 
+// Ping never mutates the request, so reuse a singleton to avoid the extra
+// malloc
+var pingRequest = &structs.GenericRequest{}
+
 // Ping is used to ping a particular server and returns whether it is healthy or
 // a potential error.
 func (c *Client) Ping(srv net.Addr) error {
 	var reply struct{}
-	err := c.connPool.RPC(c.Region(), srv, "Status.Ping", &structs.GenericRequest{}, &reply)
+	err := c.connPool.RPC(c.Region(), srv, "Status.Ping", pingRequest, &reply)
 	return err
 }
 

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -28,7 +28,7 @@ func TestAgent_RPC_Ping(t *testing.T) {
 	defer agent.Shutdown()
 
 	var out struct{}
-	if err := agent.RPC("Status.Ping", struct{}{}, &out); err != nil {
+	if err := agent.RPC("Status.Ping", &structs.GenericRequest{}, &out); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 }

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -111,6 +111,11 @@ func (e *Eval) GetEval(args *structs.EvalSpecificRequest,
 func (e *Eval) Dequeue(args *structs.EvalDequeueRequest,
 	reply *structs.EvalDequeueResponse) error {
 
+	authErr := e.srv.Authenticate(e.ctx, args)
+	if authErr != nil {
+		return authErr
+	}
+
 	// Ensure the connection was initiated by another server if TLS is used.
 	err := validateTLSCertificateLevel(e.srv, e.ctx, tlsCertificateLevelServer)
 	if err != nil {

--- a/nomad/namespace_endpoint.go
+++ b/nomad/namespace_endpoint.go
@@ -27,14 +27,14 @@ func (n *Namespace) UpsertNamespaces(args *structs.NamespaceUpsertRequest,
 	reply *structs.GenericResponse) error {
 
 	authErr := n.srv.Authenticate(n.ctx, args)
-	if authErr != nil {
-		return authErr
-	}
-
 	args.Region = n.srv.config.AuthoritativeRegion
 	if done, err := n.srv.forward("Namespace.UpsertNamespaces", args, args, reply); done {
 		return err
 	}
+	if authErr != nil {
+		return authErr
+	}
+
 	defer metrics.MeasureSince([]string{"nomad", "namespace", "upsert_namespaces"}, time.Now())
 
 	// Check management permissions

--- a/nomad/rpc_test.go
+++ b/nomad/rpc_test.go
@@ -102,7 +102,7 @@ func TestRPC_forwardLeader(t *testing.T) {
 
 	if remote != nil {
 		var out struct{}
-		err := s1.forwardLeader(remote, "Status.Ping", struct{}{}, &out)
+		err := s1.forwardLeader(remote, "Status.Ping", &structs.GenericRequest{}, &out)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -115,7 +115,7 @@ func TestRPC_forwardLeader(t *testing.T) {
 
 	if remote != nil {
 		var out struct{}
-		err := s2.forwardLeader(remote, "Status.Ping", struct{}{}, &out)
+		err := s2.forwardLeader(remote, "Status.Ping", &structs.GenericRequest{}, &out)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -178,12 +178,12 @@ func TestRPC_forwardRegion(t *testing.T) {
 	testutil.WaitForLeader(t, s2.RPC)
 
 	var out struct{}
-	err := s1.forwardRegion("global", "Status.Ping", struct{}{}, &out)
+	err := s1.forwardRegion("global", "Status.Ping", &structs.GenericRequest{}, &out)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	err = s2.forwardRegion("global", "Status.Ping", struct{}{}, &out)
+	err = s2.forwardRegion("global", "Status.Ping", &structs.GenericRequest{}, &out)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/nomad/server_test.go
+++ b/nomad/server_test.go
@@ -27,7 +27,7 @@ func TestServer_RPC(t *testing.T) {
 	defer cleanupS1()
 
 	var out struct{}
-	if err := s1.RPC("Status.Ping", struct{}{}, &out); err != nil {
+	if err := s1.RPC("Status.Ping", &structs.GenericRequest{}, &out); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 }

--- a/nomad/status_endpoint.go
+++ b/nomad/status_endpoint.go
@@ -22,7 +22,10 @@ func NewStatusEndpoint(srv *Server, ctx *RPCContext) *Status {
 }
 
 // Ping is used to just check for connectivity
-func (s *Status) Ping(args struct{}, reply *struct{}) error {
+func (s *Status) Ping(args structs.GenericRequest, reply *struct{}) error {
+	// note: we're intentionally throwing away any auth error here and only
+	// authenticate so that we can measure rate metrics
+	s.srv.Authenticate(s.ctx, &args)
 	return nil
 }
 

--- a/nomad/status_endpoint_test.go
+++ b/nomad/status_endpoint_test.go
@@ -21,7 +21,7 @@ func TestStatusPing(t *testing.T) {
 	defer cleanupS1()
 	codec := rpcClient(t, s1)
 
-	arg := struct{}{}
+	arg := &structs.GenericRequest{}
 	var out struct{}
 	if err := msgpackrpc.CallWithCodec(codec, "Status.Ping", arg, &out); err != nil {
 		t.Fatalf("err: %v", err)

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-memdb"
 
 	"github.com/hashicorp/nomad/acl"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/state/paginator"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -35,9 +34,15 @@ func NewVariablesEndpoint(srv *Server, ctx *RPCContext, enc *Encrypter) *Variabl
 
 // Apply is used to apply a SV update request to the data store.
 func (sv *Variables) Apply(args *structs.VariablesApplyRequest, reply *structs.VariablesApplyResponse) error {
+
+	authErr := sv.srv.Authenticate(sv.ctx, args)
 	if done, err := sv.srv.forward(structs.VariablesApplyRPCMethod, args, args, reply); done {
 		return err
 	}
+	if authErr != nil {
+		return authErr
+	}
+
 	defer metrics.MeasureSince([]string{
 		"nomad", "variables", "apply", string(args.Op)}, time.Now())
 
@@ -219,9 +224,15 @@ func (sv *Variables) makeVariablesApplyResponse(
 
 // Read is used to get a specific variable
 func (sv *Variables) Read(args *structs.VariablesReadRequest, reply *structs.VariablesReadResponse) error {
+
+	authErr := sv.srv.Authenticate(sv.ctx, args)
 	if done, err := sv.srv.forward(structs.VariablesReadRPCMethod, args, args, reply); done {
 		return err
 	}
+	if authErr != nil {
+		return authErr
+	}
+
 	defer metrics.MeasureSince([]string{"nomad", "variables", "read"}, time.Now())
 
 	_, _, err := sv.handleMixedAuthEndpoint(args.QueryOptions,
@@ -264,9 +275,14 @@ func (sv *Variables) List(
 	args *structs.VariablesListRequest,
 	reply *structs.VariablesListResponse) error {
 
+	authErr := sv.srv.Authenticate(sv.ctx, args)
 	if done, err := sv.srv.forward(structs.VariablesListRPCMethod, args, args, reply); done {
 		return err
 	}
+	if authErr != nil {
+		return authErr
+	}
+
 	defer metrics.MeasureSince([]string{"nomad", "variables", "list"}, time.Now())
 
 	// If the caller has requested to list variables across all namespaces, use
@@ -275,10 +291,16 @@ func (sv *Variables) List(
 		return sv.listAllVariables(args, reply)
 	}
 
-	aclObj, claims, err := sv.authenticate(args.QueryOptions)
-	if err != nil {
-		return err
+	var aclObj *acl.ACL
+	var err error
+	aclToken := args.GetIdentity().GetACLToken()
+	if aclToken != nil {
+		aclObj, err = sv.srv.ResolveACL(args.GetIdentity().GetACLToken())
+		if err != nil {
+			return err
+		}
 	}
+	claims := args.GetIdentity().GetClaims()
 
 	// Set up and return the blocking query.
 	return sv.srv.blockingRPC(&blockingOptions{
@@ -359,10 +381,16 @@ func (sv *Variables) listAllVariables(
 
 	// Perform token resolution. The request already goes through forwarding
 	// and metrics setup before being called.
-	aclObj, claims, err := sv.authenticate(args.QueryOptions)
-	if err != nil {
-		return err
+	var aclObj *acl.ACL
+	var err error
+	aclToken := args.GetIdentity().GetACLToken()
+	if aclToken != nil {
+		aclObj, err = sv.srv.ResolveACL(args.GetIdentity().GetACLToken())
+		if err != nil {
+			return err
+		}
 	}
+	claims := args.GetIdentity().GetClaims()
 
 	// Set up and return the blocking query.
 	return sv.srv.blockingRPC(&blockingOptions{
@@ -467,41 +495,23 @@ func (sv *Variables) decrypt(v *structs.VariableEncrypted) (*structs.VariableDec
 // either be called by external clients or by workload identity
 func (sv *Variables) handleMixedAuthEndpoint(args structs.QueryOptions, cap, pathOrPrefix string) (*acl.ACL, *structs.IdentityClaims, error) {
 
-	aclObj, claims, err := sv.authenticate(args)
-	if err != nil {
-		return aclObj, claims, err
+	var aclObj *acl.ACL
+	var err error
+	aclToken := args.GetIdentity().GetACLToken()
+	if aclToken != nil {
+		aclObj, err = sv.srv.ResolveACL(args.GetIdentity().GetACLToken())
+		if err != nil {
+			return nil, nil, err
+		}
 	}
+	claims := args.GetIdentity().GetClaims()
+
 	err = sv.authorize(aclObj, claims, args.RequestNamespace(), cap, pathOrPrefix)
 	if err != nil {
 		return aclObj, claims, err
 	}
 
 	return aclObj, claims, nil
-}
-
-func (sv *Variables) authenticate(args structs.QueryOptions) (*acl.ACL, *structs.IdentityClaims, error) {
-
-	// Perform the initial token resolution.
-	aclObj, err := sv.srv.ResolveToken(args.AuthToken)
-	if err == nil {
-		return aclObj, nil, nil
-	}
-	if helper.IsUUID(args.AuthToken) {
-		// early return for ErrNotFound or other errors if it's formed
-		// like an ACLToken.SecretID
-		return nil, nil, err
-	}
-
-	// Attempt to verify the token as a JWT with a workload
-	// identity claim
-	claims, err := sv.srv.VerifyClaim(args.AuthToken)
-	if err != nil {
-		metrics.IncrCounter([]string{
-			"nomad", "variables", "invalid_allocation_identity"}, 1)
-		sv.logger.Trace("allocation identity was not valid", "error", err)
-		return nil, nil, structs.ErrPermissionDenied
-	}
-	return nil, claims, nil
 }
 
 func (sv *Variables) authorize(aclObj *acl.ACL, claims *structs.IdentityClaims, ns, cap, pathOrPrefix string) error {

--- a/nomad/variables_endpoint_test.go
+++ b/nomad/variables_endpoint_test.go
@@ -107,9 +107,19 @@ func TestVariablesEndpoint_auth(t *testing.T) {
 
 	variablesRPC := NewVariablesEndpoint(srv, nil, srv.encrypter)
 
+	testFn := func(args *structs.QueryOptions, cap, path string) error {
+		err := srv.Authenticate(nil, args)
+		if err != nil {
+			return structs.ErrPermissionDenied
+		}
+		_, _, err = variablesRPC.handleMixedAuthEndpoint(
+			*args, cap, path)
+		return err
+	}
+
 	t.Run("terminal alloc should be denied", func(t *testing.T) {
-		_, _, err := variablesRPC.handleMixedAuthEndpoint(
-			structs.QueryOptions{AuthToken: idToken, Namespace: ns}, acl.PolicyList,
+		err := testFn(
+			&structs.QueryOptions{AuthToken: idToken, Namespace: ns}, acl.PolicyList,
 			fmt.Sprintf("nomad/jobs/%s/web/web", jobID))
 		must.EqError(t, err, structs.ErrPermissionDenied.Error())
 	})
@@ -120,8 +130,8 @@ func TestVariablesEndpoint_auth(t *testing.T) {
 		structs.MsgTypeTestSetup, 1200, []*structs.Allocation{alloc1}))
 
 	t.Run("wrong namespace should be denied", func(t *testing.T) {
-		_, _, err := variablesRPC.handleMixedAuthEndpoint(
-			structs.QueryOptions{AuthToken: idToken, Namespace: structs.DefaultNamespace}, acl.PolicyList,
+		err := testFn(&structs.QueryOptions{
+			AuthToken: idToken, Namespace: structs.DefaultNamespace}, acl.PolicyList,
 			fmt.Sprintf("nomad/jobs/%s/web/web", jobID))
 		must.EqError(t, err, structs.ErrPermissionDenied.Error())
 	})
@@ -350,8 +360,9 @@ func TestVariablesEndpoint_auth(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := variablesRPC.handleMixedAuthEndpoint(
-				structs.QueryOptions{AuthToken: tc.token, Namespace: ns}, tc.cap, tc.path)
+			err := testFn(
+				&structs.QueryOptions{AuthToken: tc.token, Namespace: ns},
+				tc.cap, tc.path)
 			if tc.expectedErr == nil {
 				must.NoError(t, err)
 			} else {


### PR DESCRIPTION
In #15417 we added a new `Authenticate` method to the server that returns an `AuthenticatedIdentity` struct. This changeset implements this method for a small number of RPC endpoints that together represent all the various ways in which RPCs are sent, so that we can validate that we're happy with this approach.

A follow-up PR will do all the dirty work of adding this everywhere else.