### PR TITLE
CSI: avoid a nil pointer when handling plugin events

### DIFF
--- a/.changelog/15518.txt
+++ b/.changelog/15518.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where a crashing plugin could panic the Nomad client
+```

--- a/client/dynamicplugins/registry.go
+++ b/client/dynamicplugins/registry.go
@@ -269,12 +269,14 @@ func (d *dynamicRegistry) DeregisterPlugin(ptype, name, allocID string) error {
 		}
 	}
 
-	broadcaster := d.broadcasterForPluginType(ptype)
-	event := &PluginUpdateEvent{
-		EventType: EventTypeDeregistered,
-		Info:      info,
+	if info != nil {
+		broadcaster := d.broadcasterForPluginType(ptype)
+		event := &PluginUpdateEvent{
+			EventType: EventTypeDeregistered,
+			Info:      info,
+		}
+		broadcaster.broadcast(event)
 	}
-	broadcaster.broadcast(event)
 
 	return d.sync()
 }

--- a/client/pluginmanager/csimanager/manager.go
+++ b/client/pluginmanager/csimanager/manager.go
@@ -149,7 +149,7 @@ func (c *csiManager) resyncPluginsFromRegistry(ptype string) {
 
 // handlePluginEvent syncs a single event against the plugin registry
 func (c *csiManager) handlePluginEvent(event *dynamicplugins.PluginUpdateEvent) {
-	if event == nil {
+	if event == nil || event.Info == nil {
 		return
 	}
 	c.logger.Trace("dynamic plugin event",


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/15478

If a plugin crashes quickly enough, we can get into a situation where the deregister function is called before it's ever registered. Safely handle the resulting nil pointer in the dynamic registry by not emitting a plugin event, but also update the plugin event handler to tolerate nil pointers in case we wire it up elsewhere in the future.