### PR TITLE
Backport of Use custom runners for building nomad into release/1.3.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     branches:
-      - "main"
+      - "release/1.3.x"
   workflow_dispatch:
     inputs:
       build-ref:
@@ -36,7 +36,7 @@ jobs:
         # version, because "goenv" can react to it automatically.
         run: |
           echo "Building with Go $(cat .go-version)"
-          echo "::set-output name=go-version::$(cat .go-version)"
+          echo "go-version=$(cat .go-version)" >> $GITHUB_OUTPUT
   get-product-version:
     runs-on: ubuntu-20.04
     outputs:
@@ -49,7 +49,7 @@ jobs:
         id: get-product-version
         run: |
           make version
-          echo "::set-output name=product-version::$(make version)"
+          echo "product-version=$(make version)" >> $GITHUB_OUTPUT
   generate-metadata-file:
     needs: get-product-version
     runs-on: ubuntu-20.04
@@ -75,7 +75,7 @@ jobs:
 
   build-other:
     needs: [get-go-version, get-product-version]
-    runs-on: ubuntu-20.04
+    runs-on: [ custom, linux, xxl, 20.04 ]
     strategy:
       matrix:
         goos: [windows]
@@ -126,7 +126,7 @@ jobs:
 
   build-linux:
     needs: [get-go-version, get-product-version]
-    runs-on: ubuntu-20.04
+    runs-on: [ custom, linux, xxl, 20.04 ]
     strategy:
       matrix:
         goos: [linux]
@@ -293,7 +293,7 @@ jobs:
   #   needs:
   #     - get-product-version
   #     - build
-  #   runs-on: ubuntu-20.04
+  #   runs-on: [ custom, linux, xxl, 20.04 ]
   #   strategy:
   #     matrix:
   #       arch: ["arm", "arm64", "386", "amd64"]


### PR DESCRIPTION
Backport of https://github.com/hashicorp/nomad/pull/15490

Note: The build workflow wasn't being kicked off on the `release/1.3.x branch`, so I updated that 🙏 