### PR TITLE
[draft, pending rebase] OIDC UI methods

### DIFF
--- a/ui/.ember-cli
+++ b/ui/.ember-cli
@@ -6,5 +6,8 @@
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
   "disableAnalytics": false,
-  "proxy": "http://127.0.0.1:4646"
+  "proxy": "http://127.0.0.1:4646",
+  "ssl": true,
+  "ssl-key": "localhost-key.pem",
+  "ssl-cert": "localhost.pem"
 }

--- a/ui/.ember-cli
+++ b/ui/.ember-cli
@@ -6,8 +6,5 @@
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
   "disableAnalytics": false,
-  "proxy": "http://127.0.0.1:4646",
-  "ssl": true,
-  "ssl-key": "localhost-key.pem",
-  "ssl-cert": "localhost.pem"
+  "proxy": "http://127.0.0.1:4646"
 }

--- a/ui/app/adapters/auth-method.js
+++ b/ui/app/adapters/auth-method.js
@@ -17,7 +17,7 @@ export default class AuthMethodAdapter extends ApplicationAdapter {
 
   /**
    * @typedef {Object} ACLOIDCAuthURLParams
-   * @property {string} AuthMethod
+   * @property {string} AuthMethodName
    * @property {string} RedirectUri
    * @property {string} ClientNonce
    * @property {Object[]} Meta // NOTE: unsure if array of objects or kv pairs
@@ -27,11 +27,11 @@ export default class AuthMethodAdapter extends ApplicationAdapter {
    * @param {ACLOIDCAuthURLParams} params
    * @returns
    */
-  getAuthURL({ AuthMethod, RedirectUri, ClientNonce, Meta }) {
+  getAuthURL({ AuthMethodName, RedirectUri, ClientNonce, Meta }) {
     const url = `/${this.namespace}/oidc/auth-url`;
     return this.ajax(url, 'POST', {
       data: {
-        AuthMethod,
+        AuthMethodName,
         RedirectUri,
         ClientNonce,
         Meta,

--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -136,12 +136,8 @@ export default class Tokens extends Controller {
 
     if (res.ok) {
       const data = await res.json();
-      console.log('data back', data);
       this.clearTokenProperties();
       this.token.set('secret', data.SecretID);
-      this.set('secret', null);
-      // this.verifyToken();
-      // TODO: replace verifyToken with one that takes the data from the data
       this.state = null;
       this.code = null;
 
@@ -152,23 +148,6 @@ export default class Tokens extends Controller {
 
       this.signInStatus = 'success';
       this.token.set('tokenNotFound', false);
-
-      // TokenAdapter.findSelf().then(
-      //   () => {
-      //     // Clear out all data to ensure only data the new token is privileged to see is shown
-      //     this.resetStore();
-
-      //     // Refetch the token and associated policies
-      //     this.get('token.fetchSelfTokenAndPolicies').perform().catch();
-
-      //     this.signInStatus = 'success';
-      //     this.token.set('tokenNotFound', false);
-      //   },
-      //   () => {
-      //     this.set('token.secret', undefined);
-      //     this.signInStatus = 'failure';
-      //   }
-      // );
     } else {
       this.state = 'failure';
       this.code = null;


### PR DESCRIPTION
- Corrects AuthMethod to AuthMethodName
- replaces the `verifyToken()` part of the tokens page controller

Note: this'll only work locally if you're running over https. Set up [mkcert](https://github.com/FiloSottile/mkcert#installation) to make the going less tough.

