### PR TITLE
Fix rejoin_after_leave behavior

### DIFF
--- a/.changelog/15552.txt
+++ b/.changelog/15552.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server: Fixed a bug where rejoin_after_leave config was not being respected
+```

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -309,6 +309,7 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	conf.RPCAddr.IP = rpcAddr.IP
 	conf.SerfConfig.MemberlistConfig.BindPort = serfAddr.Port
 	conf.SerfConfig.MemberlistConfig.BindAddr = serfAddr.IP.String()
+	conf.SerfConfig.RejoinAfterLeave = agentConfig.Server.RejoinAfterLeave
 
 	// Set up the advertise addresses
 	rpcAddr, err = net.ResolveTCPAddr("tcp", agentConfig.AdvertiseAddrs.RPC)

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -547,7 +547,7 @@ type ServerConfig struct {
 	RetryIntervalHCL string `hcl:"retry_interval" json:"-"`
 
 	// RejoinAfterLeave controls our interaction with the cluster after leave.
-	// When set to false (default), a leave causes Consul to not rejoin
+	// When set to false (default), a leave causes Nomad to not rejoin
 	// the cluster until an explicit join is received. If this is set to
 	// true, we ignore the leave, and rejoin the cluster on start.
 	RejoinAfterLeave bool `hcl:"rejoin_after_leave"`

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1531,7 +1531,6 @@ func (s *Server) setupSerf(conf *serf.Config, ch chan serf.Event, path string) (
 			return nil, err
 		}
 	}
-	conf.RejoinAfterLeave = true
 	// LeavePropagateDelay is used to make sure broadcasted leave intents propagate
 	// This value was tuned using https://www.serf.io/docs/internals/simulator.html to
 	// allow for convergence in 99.9% of nodes in a 10 node cluster

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -62,8 +62,6 @@ from the Nomad client by setting [`set_environment_variables`][artifact_env].
 The use of filesystem isolation can be disabled in Client configuration by
 setting [`disable_filesystem_isolation`][artifact_fs_isolation].
 
-## Nomad 1.4.4
-
 #### Server `rejoin_after_leave` (default: `false`) now enforced
 
 All Nomad versions prior to v1.4.4 have incorrectly ignored the Server [`rejoin_after_leave`][rejoin_after_leave]

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -64,10 +64,10 @@ setting [`disable_filesystem_isolation`][artifact_fs_isolation].
 
 #### Server `rejoin_after_leave` (default: `false`) now enforced
 
-All Nomad versions prior to v1.4.4 have incorrectly ignored the Server [`rejoin_after_leave`]
-configuration option. This bug has been fixed in Nomad version v1.4.4.
+All Nomad versions prior to v1.5.0 have incorrectly ignored the Server [`rejoin_after_leave`]
+configuration option. This bug has been fixed in Nomad version v1.5.0.
 
-Previous to v1.4.4 the behavior of Nomad `rejoin_after_leave` was always `true`, regardless of 
+Previous to v1.5.0 the behavior of Nomad `rejoin_after_leave` was always `true`, regardless of 
 Nomad server configuration, while the documentation incorrectly indicated a default of `false`.
 
 Cluster operators should be aware that explicit `leave` events (such as `nomad server force-leave`) 

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -62,6 +62,20 @@ from the Nomad client by setting [`set_environment_variables`][artifact_env].
 The use of filesystem isolation can be disabled in Client configuration by
 setting [`disable_filesystem_isolation`][artifact_fs_isolation].
 
+## Nomad 1.4.4
+
+#### Server `rejoin_after_leave` (default: `false`) now enforced
+
+All Nomad versions prior to v1.4.4 have incorrectly ignored the Server [`rejoin_after_leave`][rejoin_after_leave]
+configuration option. This bug has been fixed in Nomad version v1.4.4.
+
+Previous to v1.4.4 the behavior of Nomad `rejoin_after_leave` was always `true`, regardless of 
+Nomad server configuration, while the documentation incorrectly indicated a default of `false`.
+
+Cluster operators should be aware that explicit `leave` events (such as `nomad server force-leave`) 
+will now result in behavior which matches this configuration, and should review whether they
+were inadvertently relying on the buggy behavior.
+
 ## Nomad 1.4.0
 
 #### Possible Panic During Upgrades

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -64,7 +64,7 @@ setting [`disable_filesystem_isolation`][artifact_fs_isolation].
 
 #### Server `rejoin_after_leave` (default: `false`) now enforced
 
-All Nomad versions prior to v1.4.4 have incorrectly ignored the Server [`rejoin_after_leave`][rejoin_after_leave]
+All Nomad versions prior to v1.4.4 have incorrectly ignored the Server [`rejoin_after_leave`]
 configuration option. This bug has been fixed in Nomad version v1.4.4.
 
 Previous to v1.4.4 the behavior of Nomad `rejoin_after_leave` was always `true`, regardless of 
@@ -1557,6 +1557,7 @@ deleted and then Nomad 0.3.0 can be launched.
 [`sidecar_task.config`]: /docs/job-specification/sidecar_task#config
 [`raft_protocol`]: /docs/configuration/server#raft_protocol
 [`raft protocol`]: /docs/configuration/server#raft_protocol
+[`rejoin_after_leave`]: /docs/configuration/server#rejoin_after_leave
 [reserved]: /docs/configuration/client#reserved-parameters
 [task-config]: /docs/job-specification/task#config
 [tls-guide]: https://learn.hashicorp.com/tutorials/nomad/security-enable-tls


### PR DESCRIPTION
This will effectively change the default behavior of Serf to _not_ rejoin after leave, which (I believe...) is actually the documented behavior. But this could be perceived as a breaking change by some cluster operators who may be accustomed to server nodes ignoring leave events.

Alternative approaches which would not change the default behavior would be
* use a bool pointer in this config field in order to be able to discern `nil` (not configured) from intentionally `false`, and default to `true` as exists today
* introduce a new config field `disable_rejoin_after_leave` which would default to `false` and therefore continue to produce the current behavior

In any case, docs probably need to be updated here and if necessary, a behavior change be communicated out.
