### PR TITLE
[ui] Make the not-auth'd messages in the app less token-centric

### DIFF
--- a/ui/app/components/forbidden-message.js
+++ b/ui/app/components/forbidden-message.js
@@ -5,4 +5,9 @@ import { inject as service } from '@ember/service';
 @tagName('')
 export default class ForbiddenMessage extends Component {
   @service token;
+  @service store;
+
+  get authMethods() {
+    return this.store.findAll('auth-method');
+  }
 }

--- a/ui/app/helpers/conditionally-capitalize.js
+++ b/ui/app/helpers/conditionally-capitalize.js
@@ -1,0 +1,13 @@
+import Helper from '@ember/component/helper';
+
+/**
+ * If the condition is true, capitalize the first letter of the term.
+ * Otherwise, return the term in lowercase.
+ */
+export function conditionallyCapitalize([term, condition]) {
+  return condition
+    ? `${term.charAt(0).toUpperCase()}${term.substring(1)}`
+    : term.toLowerCase();
+}
+
+export default Helper.helper(conditionallyCapitalize);

--- a/ui/app/templates/components/forbidden-message.hbs
+++ b/ui/app/templates/components/forbidden-message.hbs
@@ -2,27 +2,38 @@
   <h3 data-test-error-title class="empty-message-headline">Not Authorized</h3>
   <p data-test-error-message class="empty-message-body">
     {{#if this.token.secret}}
-      Your <LinkTo @route="settings.tokens">ACL token</LinkTo> does not provide the
+      You currently lack the
       {{#if this.permission}}
         <code>{{this.permission}}</code>
       {{else}}
         required
       {{/if}}
-      permission. Contact your administrator if this is an error.
+      <LinkTo @route="settings.tokens">permission</LinkTo> for this resource.<br /> Contact your administrator if this is an error.
     {{else}}
-      Provide an <LinkTo @route="settings.tokens">ACL token</LinkTo> with the
+      {{#if this.authMethods}}
+        Sign in with
+        {{#each this.authMethods as |authMethod|}}
+          <LinkTo @route="settings.tokens">{{authMethod.name}}</LinkTo>, 
+        {{/each}}
+        or
+      {{/if}}
+
+      {{#if this.authMethods}}p{{else}}P{{/if}}rovide a <LinkTo @route="settings.tokens">token</LinkTo> with the
       {{#if this.permission}}
-      <code>{{this.permission}}</code>
+        <code>{{this.permission}}</code>
       {{else}}
         requisite
       {{/if}}
       permission to view this.
     {{/if}}
   </p>
-  <p class="empty-message-body">
-    If you have an ACL token configured for the CLI, authenticate with:
-    <div class='terminal-container'>
-      <pre class='terminal'><span class='prompt'>$</span> nomad ui -authenticate</pre>
-    </div>
-  </p>
+
+  {{#unless this.token.secret}}
+    <p class="empty-message-body">
+      If you have signed in via the Nomad CLI, authenticate with:
+      <div class='terminal-container'>
+        <pre class='terminal'><span class='prompt'>$</span> nomad ui -authenticate</pre>
+      </div>
+    </p>
+  {{/unless}}
 </div>

--- a/ui/app/templates/components/forbidden-message.hbs
+++ b/ui/app/templates/components/forbidden-message.hbs
@@ -18,7 +18,7 @@
         or
       {{/if}}
 
-      {{#if this.authMethods}}p{{else}}P{{/if}}rovide a <LinkTo @route="settings.tokens">token</LinkTo> with the
+      {{conditionally-capitalize "provide" (not this.authMethods.length)}} a <LinkTo @route="settings.tokens">token</LinkTo> with the
       {{#if this.permission}}
         <code>{{this.permission}}</code>
       {{else}}

--- a/ui/tests/integration/helpers/conditionally-capitalize-test.js
+++ b/ui/tests/integration/helpers/conditionally-capitalize-test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | conditionally-capitalize', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it capizalizes words correctly with a boolean condition', async function (assert) {
+    this.set('condition', true);
+    await render(hbs`{{conditionally-capitalize "tester" this.condition}}`);
+    assert.dom(this.element).hasText('Tester');
+    this.set('condition', false);
+    await render(hbs`{{conditionally-capitalize "tester" this.condition}}`);
+    assert.dom(this.element).hasText('tester');
+  });
+
+  test('it capizalizes words correctly with an existence condition', async function (assert) {
+    this.set('condition', {});
+    await render(hbs`{{conditionally-capitalize "tester" this.condition}}`);
+    assert.dom(this.element).hasText('Tester');
+    this.set('condition', null);
+    await render(hbs`{{conditionally-capitalize "tester" this.condition}}`);
+    assert.dom(this.element).hasText('tester');
+  });
+
+  test('it capizalizes words correctly with an numeric condition', async function (assert) {
+    this.set('condition', 1);
+    await render(hbs`{{conditionally-capitalize "tester" this.condition}}`);
+    assert.dom(this.element).hasText('Tester');
+    this.set('condition', 0);
+    await render(hbs`{{conditionally-capitalize "tester" this.condition}}`);
+    assert.dom(this.element).hasText('tester');
+  });
+});


### PR DESCRIPTION
Resolves https://github.com/hashicorp/nomad/issues/15556

Signed out, have auth-methods configured:
![image](https://user-images.githubusercontent.com/713991/207972494-e6b890e4-c9b6-4a77-a13f-9fb13920eaf9.png)

Signed out, no auth-methods:
![image](https://user-images.githubusercontent.com/713991/207972569-eb49603a-a9e6-4892-a283-f8982642e54e.png)

Signed in, but lacking permissions: 
![image](https://user-images.githubusercontent.com/713991/207972384-745c72e5-fdb1-4b76-afae-33bd3f36d055.png)

