### PR TITLE
Extend variables under the nomad path prefix to allow for job-templates

### DIFF
--- a/nomad/structs/variables.go
+++ b/nomad/structs/variables.go
@@ -168,8 +168,8 @@ func (v VariableDecrypted) Validate() error {
 	switch {
 	case len(parts) == 1 && parts[0] == "nomad":
 		return fmt.Errorf("\"nomad\" is a reserved top-level directory path, but you may write variables to \"nomad/jobs\" or below")
-	case len(parts) >= 2 && parts[0] == "nomad" && parts[1] != "jobs":
-		return fmt.Errorf("only paths at \"nomad/jobs\" or below are valid paths under the top-level \"nomad\" directory")
+	case len(parts) >= 2 && parts[0] == "nomad" && parts[1] != "jobs" && parts[1] != "job-templates":
+		return fmt.Errorf("only paths at \"nomad/jobs\" or \"nomad/job-templates\" and below are valid paths under the top-level \"nomad\" directory")
 	}
 
 	if len(v.Items) == 0 {

--- a/nomad/structs/variables.go
+++ b/nomad/structs/variables.go
@@ -167,7 +167,7 @@ func (v VariableDecrypted) Validate() error {
 	parts := strings.Split(v.Path, "/")
 	switch {
 	case len(parts) == 1 && parts[0] == "nomad":
-		return fmt.Errorf("\"nomad\" is a reserved top-level directory path, but you may write variables to \"nomad/jobs\" or below")
+		return fmt.Errorf("\"nomad\" is a reserved top-level directory path, but you may write variables to \"nomad/jobs\", \"nomad/job-templates\", or below")
 	case len(parts) >= 2 && parts[0] == "nomad" && parts[1] != "jobs" && parts[1] != "job-templates":
 		return fmt.Errorf("only paths at \"nomad/jobs\" or \"nomad/job-templates\" and below are valid paths under the top-level \"nomad\" directory")
 	}

--- a/nomad/structs/variables_test.go
+++ b/nomad/structs/variables_test.go
@@ -54,6 +54,8 @@ func TestStructs_VariableDecrypted_Validate(t *testing.T) {
 		{path: "example/_-~/whatever", ok: true},
 		{path: "example/@whatever"},
 		{path: "example/what.ever"},
+		{path: "nomad/job-templates", ok: true},
+		{path: "nomad/job-templates/whatever", ok: true},
 	}
 	for _, tc := range testCases {
 		tc := tc

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -64,7 +64,11 @@ export default class VariableFormComponent extends Component {
 
   get shouldDisableSave() {
     const disallowedPath =
-      this.path?.startsWith('nomad/') && !this.path?.startsWith('nomad/jobs');
+      this.path?.startsWith('nomad/') &&
+      !(
+        this.path?.startsWith('nomad/jobs') ||
+        this.path?.startsWith('nomad/job-templates')
+      );
     return !!this.JSONError || !this.path || disallowedPath;
   }
 

--- a/ui/tests/acceptance/variables-test.js
+++ b/ui/tests/acceptance/variables-test.js
@@ -509,6 +509,26 @@ module('Acceptance | variables', function (hooks) {
           'Cannot submit a variable that begins with nomad/<not-jobs>/'
         );
 
+      document.querySelector('[data-test-path-input]').value = ''; // clear current input
+      await typeIn('[data-test-path-input]', 'nomad/jobs/');
+      assert
+        .dom('[data-test-submit-var]')
+        .isNotDisabled('Can submit a variable that begins with nomad/jobs/');
+
+      document.querySelector('[data-test-path-input]').value = ''; // clear current input
+      await typeIn('[data-test-path-input]', 'nomad/another-foo/');
+      assert
+        .dom('[data-test-submit-var]')
+        .isDisabled('Disabled state re-evaluated when path input changes');
+
+      document.querySelector('[data-test-path-input]').value = ''; // clear current input
+      await typeIn('[data-test-path-input]', 'nomad/jobs/job-templates/');
+      assert
+        .dom('[data-test-submit-var]')
+        .isNotDisabled(
+          'Can submit a variable that begins with nomad/job-templates/'
+        );
+
       // Reset Token
       window.localStorage.nomadTokenSecret = null;
     });


### PR DESCRIPTION
Sets the ability for Nomad Variables with paths that start with `nomad/` to include `job-templates`. Previously only variables at `nomad/jobs/____` were permitted.

---
Resolves #15569 