### PR TITLE
Expanding nomad job init to accept a template flag

### DIFF
--- a/command/job_init.go
+++ b/command/job_init.go
@@ -39,10 +39,12 @@ Init Options:
     If the connect flag is set, the jobspec includes Consul Connect integration.
 
   -template
-    Specifies a predefined template to initialize. Must be a Nomad Variable that lives at nomad/job-templates/<template>
+    Specifies a predefined template to initialize. Must be a Nomad Variable that
+		lives at nomad/job-templates/<template>
 
   -list-templates
-    Display a list of possible job templates to pass to -template. Reads from all variables pathed at nomad/job-templates/<template>
+    Display a list of possible job templates to pass to -template. Reads from
+		all variables pathed at nomad/job-templates/<template>
 `
 	return strings.TrimSpace(helpText)
 }
@@ -122,7 +124,7 @@ func (c *JobInitCommand) Run(args []string) int {
 		// Get and list all variables at nomad/job-templates
 		vars, _, err := client.Variables().PrefixList("nomad/job-templates/", qo)
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error retrieving vars: %s", err))
+			c.Ui.Error(fmt.Sprintf("Error retrieving job templates from the server; unable to read variables at path nomad/job-templates/. Error: %s", err))
 			return 1
 		}
 
@@ -132,7 +134,7 @@ func (c *JobInitCommand) Run(args []string) int {
 		} else {
 			c.Ui.Output("Use nomad job init -template=<template> with any of the following:")
 			for _, v := range vars {
-				fmt.Println(strings.TrimPrefix(v.Path, "nomad/job-templates/"))
+				c.Ui.Output(fmt.Sprintf("  %s", strings.TrimPrefix(v.Path, "nomad/job-templates/")))
 			}
 		}
 		return 0
@@ -156,15 +158,15 @@ func (c *JobInitCommand) Run(args []string) int {
 			c.Ui.Error(fmt.Sprintf("Error retrieving variable: %s", err))
 			return 1
 		}
-		// If the user provided an item key, return that value instead of the whole
-		// object
+
 		if v, ok := sv.Items["template"]; ok {
 			c.Ui.Output(fmt.Sprintf("Initializing a job template from %s", template))
 			jobSpec = []byte(v)
 		} else {
-			c.Ui.Error(fmt.Sprintf("Variable does not contain %q item", args[1]))
+			c.Ui.Error(fmt.Sprintf("Job template %q is malformed and is missing a template field. Please visit the jobs/run/templates route in  the Nomad UI to add it", template))
 			return 1
 		}
+
 	} else {
 		switch {
 		case connect && !short:

--- a/command/job_init.go
+++ b/command/job_init.go
@@ -111,9 +111,14 @@ func (c *JobInitCommand) Run(args []string) int {
 	if listTemplates {
 		// Get the HTTP client
 		client, err := c.Meta.Client()
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+			return 1
+		}
 		qo := &api.QueryOptions{
 			Namespace: c.Meta.namespace,
 		}
+
 		// Get and list all variables at nomad/job-templates
 		vars, _, err := client.Variables().PrefixList("nomad/job-templates/", qo)
 		if err != nil {
@@ -122,10 +127,10 @@ func (c *JobInitCommand) Run(args []string) int {
 		}
 
 		if len(vars) == 0 {
-			c.Ui.Error(fmt.Sprintf("No variables in nomad/job-templates"))
+			c.Ui.Error("No variables in nomad/job-templates")
 			return 1
 		} else {
-			c.Ui.Output(fmt.Sprintf("Use nomad job init -template=<template> with any of the following:"))
+			c.Ui.Output("Use nomad job init -template=<template> with any of the following:")
 			for _, v := range vars {
 				fmt.Println(strings.TrimPrefix(v.Path, "nomad/job-templates/"))
 			}

--- a/command/job_init.go
+++ b/command/job_init.go
@@ -109,15 +109,15 @@ func (c *JobInitCommand) Run(args []string) int {
 	var jobSpec []byte
 
 	if listTemplates {
-
 		// Get the HTTP client
 		client, err := c.Meta.Client()
 		qo := &api.QueryOptions{
 			Namespace: c.Meta.namespace,
 		}
+		// Get and list all variables at nomad/job-templates
 		vars, _, err := client.Variables().PrefixList("nomad/job-templates/", qo)
 		if err != nil {
-			fmt.Println(err)
+			c.Ui.Error(fmt.Sprintf("Error retrieving vars: %s", err))
 			return 1
 		}
 
@@ -127,15 +127,9 @@ func (c *JobInitCommand) Run(args []string) int {
 		} else {
 			c.Ui.Output(fmt.Sprintf("Use nomad job init -template=<template> with any of the following:"))
 			for _, v := range vars {
-				fmt.Printf("%s", v.Path)
+				fmt.Println(strings.TrimPrefix(v.Path, "nomad/job-templates/"))
 			}
 		}
-
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error retrieving vars: %s", err))
-			return 1
-		}
-
 		return 0
 	} else if template != "" {
 		// Get the HTTP client

--- a/ui/app/components/variable-form.hbs
+++ b/ui/app/components/variable-form.hbs
@@ -74,42 +74,50 @@
       }}
     />
   </div>
-  {{#if (eq this.view "json")}}
-    <div
-      class="editor-wrapper boxed-section-body is-full-bleed
-        {{if this.JSONError 'error'}}"
-    >
-      <div
-        data-test-json-editor
-        {{code-mirror
-          content=this.JSONItems
-          onUpdate=this.updateCode
-          extraKeys=(hash Cmd-Enter=(action "save"))
-        }}
-      ></div>
-      {{#if this.JSONError}}
-        <p class="help is-danger">
-          {{this.JSONError}}
-        </p>
-      {{/if}}
-    </div>
+  {{#if this.isJobTemplateVariable}}
+    <VariableForm::JobTemplateEditor
+      {{!-- @description={{this.keyValues.description}}
+      @template={{this.keyValues.template}} --}}
+      @keyValues={{this.keyValues}}
+      @updateKeyValue={{this.updateKeyValue}}
+    />
   {{else}}
-    {{#each this.keyValues as |entry iter|}}
-      <div class="key-value">
-        <label>
-          <span>
-            Key
-          </span>
-          <Input
-            data-test-var-key
-            @type="text"
-            @value={{entry.key}}
-            class="input"
-            {{autofocus ignore=(eq iter 0)}}
-            {{on "input" (fn this.validateKey entry)}}
-          />
-        </label>
-        <VariableForm::InputGroup @entry={{entry}} />
+    {{#if (eq this.view "json")}}
+      <div
+        class="editor-wrapper boxed-section-body is-full-bleed
+          {{if this.JSONError 'error'}}"
+      >
+        <div
+          data-test-json-editor
+          {{code-mirror
+            content=this.JSONItems
+            onUpdate=this.updateCode
+            extraKeys=(hash Cmd-Enter=(action "save"))
+          }}
+        ></div>
+        {{#if this.JSONError}}
+          <p class="help is-danger">
+            {{this.JSONError}}
+          </p>
+        {{/if}}
+      </div>
+    {{else}}
+      {{#each this.keyValues as |entry iter|}}
+        <div class="key-value">
+          <label>
+            <span>
+              Key
+            </span>
+            <Input
+              data-test-var-key
+              @type="text"
+              @value={{entry.key}}
+              class="input"
+              {{autofocus ignore=(eq iter 0)}}
+              {{on "input" (fn this.validateKey entry)}}
+            />
+          </label>
+          <VariableForm::InputGroup @entry={{entry}} />
           <button
             class="delete-row button is-danger is-inverted"
             type="button"
@@ -117,13 +125,14 @@
           >
             Delete
           </button>
-        {{#each-in entry.warnings as |k v|}}
-          <span class="key-value-error help is-danger">
-            {{v}}
-          </span>
-        {{/each-in}}
-      </div>
-    {{/each}}
+          {{#each-in entry.warnings as |k v|}}
+            <span class="key-value-error help is-danger">
+              {{v}}
+            </span>
+          {{/each-in}}
+        </div>
+      {{/each}}
+    {{/if}}
   {{/if}}
 
   {{#if (and this.shouldShowLinkedEntities @model.isNew)}}
@@ -138,15 +147,17 @@
 
   <footer>
     {{#unless this.isJSONView}}
-    <button
-      class="add-more button is-info is-inverted"
-      type="button"
-      disabled={{not (and this.keyValues.lastObject.key this.keyValues.lastObject.value)}}
-      {{on "click" this.appendRow}}
-      data-test-add-kv
-    >
-      Add More
-    </button>
+      {{#unless this.isJobTemplateVariable}}
+        <button
+          class="add-more button is-info is-inverted"
+          type="button"
+          disabled={{not (and this.keyValues.lastObject.key this.keyValues.lastObject.value)}}
+          {{on "click" this.appendRow}}
+          data-test-add-kv
+        >
+          Add More
+        </button>
+      {{/unless}}
     {{/unless}}
     <button
       disabled={{this.shouldDisableSave}}

--- a/ui/app/components/variable-form.hbs
+++ b/ui/app/components/variable-form.hbs
@@ -3,10 +3,12 @@
 <form class="new-variables" autocomplete="off" {{on "submit" this.save}}>
 
   {{#if @model.isNew}}
-    <div class="related-entities related-entities-hint">
-      <p>Prefix your path with <code>nomad/jobs/</code> to automatically make your variable accessible to a specified job, task group, or task.<br />
-      Format: <code>nomad/jobs/&lt;jobname&gt;</code>, <code>nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;</code>, <code>nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;/&lt;taskname&gt;</code></p>
-    </div>
+    {{#unless this.isJobTemplateVariable}}
+      <div class="related-entities related-entities-hint">
+        <p>Prefix your path with <code>nomad/jobs/</code> to automatically make your variable accessible to a specified job, task group, or task.<br />
+        Format: <code>nomad/jobs/&lt;jobname&gt;</code>, <code>nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;</code>, <code>nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;/&lt;taskname&gt;</code></p>
+      </div>
+    {{/unless}}
   {{/if}}
 
   {{#if this.hasConflict}}
@@ -61,6 +63,16 @@
           .
         </p>
       {{/if}}
+      {{#if this.isJobTemplateVariable}}
+        <p class="help job-template-hint">
+          Use this variable to generate job templates with
+          <code>nomad job init -template={{this.jobTemplateName}}
+            <CopyButton
+              @clipboardText="nomad job init -template={{this.jobTemplateName}}"
+            />
+          </code>
+        </p>
+      {{/if}}
     </label>
     <VariableForm::NamespaceFilter 
       @data={{hash 
@@ -76,8 +88,6 @@
   </div>
   {{#if this.isJobTemplateVariable}}
     <VariableForm::JobTemplateEditor
-      {{!-- @description={{this.keyValues.description}}
-      @template={{this.keyValues.template}} --}}
       @keyValues={{this.keyValues}}
       @updateKeyValue={{this.updateKeyValue}}
     />

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -78,7 +78,7 @@ export default class VariableFormComponent extends Component {
   }
 
   get jobTemplateName() {
-    return trimPath([this.path]).split('/')[2];
+    return this.path.split('nomad/job-templates/').slice(-1);
   }
 
   /**
@@ -189,19 +189,16 @@ export default class VariableFormComponent extends Component {
     set(this.args.model, 'path', e.target.value);
   }
 
-  @action updateKeyValue(key, value, b, c, d) {
-    console.log('UKV', key, value, b, c, d);
+  @action updateKeyValue(key, value) {
     if (this.keyValues.find((kv) => kv.key === key)) {
       this.keyValues.find((kv) => kv.key === key).value = value;
     } else {
       this.keyValues.pushObject({ key, value, warnings: EmberObject.create() });
     }
-    console.log('after the fact', this.keyValues);
   }
 
   @action
   async save(e, overwrite = false) {
-    console.log('about to save my var and', this.keyValues);
     if (e.type === 'submit') {
       e.preventDefault();
     }

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -67,9 +67,14 @@ export default class VariableFormComponent extends Component {
       this.path?.startsWith('nomad/') &&
       !(
         this.path?.startsWith('nomad/jobs') ||
-        (this.path?.startsWith('nomad/job-templates') && trimPath([this.path]) !== "nomad/job-templates")
+        (this.path?.startsWith('nomad/job-templates') &&
+          trimPath([this.path]) !== 'nomad/job-templates')
       );
     return !!this.JSONError || !this.path || disallowedPath;
+  }
+
+  get isJobTemplateVariable() {
+    return this.path?.startsWith('nomad/job-templates/');
   }
 
   /**
@@ -180,8 +185,19 @@ export default class VariableFormComponent extends Component {
     set(this.args.model, 'path', e.target.value);
   }
 
+  @action updateKeyValue(key, value, b, c, d) {
+    console.log('UKV', key, value, b, c, d);
+    if (this.keyValues.find((kv) => kv.key === key)) {
+      this.keyValues.find((kv) => kv.key === key).value = value;
+    } else {
+      this.keyValues.pushObject({ key, value, warnings: EmberObject.create() });
+    }
+    console.log('after the fact', this.keyValues);
+  }
+
   @action
   async save(e, overwrite = false) {
+    console.log('about to save my var and', this.keyValues);
     if (e.type === 'submit') {
       e.preventDefault();
     }

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -77,6 +77,10 @@ export default class VariableFormComponent extends Component {
     return this.path?.startsWith('nomad/job-templates/');
   }
 
+  get jobTemplateName() {
+    return trimPath([this.path]).split('/')[2];
+  }
+
   /**
    * @type {MutableArray<{key: string, value: string, warnings: EmberObject}>}
    */

--- a/ui/app/components/variable-form/job-template-editor.hbs
+++ b/ui/app/components/variable-form/job-template-editor.hbs
@@ -1,0 +1,30 @@
+{{did-insert this.establishKeyValues}}
+<div class="key-value">
+  <label>
+    <span>
+      Description
+    </span>
+    <Input
+      @type="text"
+      @value={{this.description}}
+      {{on "input" this.updateDescription}}
+      class="input value-input"
+    />
+  </label>
+</div>
+<div class="key-value">
+  <label>
+    <span>
+      Job Template
+    </span>
+    <div
+      {{code-mirror
+        theme="hashi"
+        mode="ruby"
+        autofocus=false
+        content=this.template
+        onUpdate=(action this.updateTemplate)
+      }}
+    ></div>
+  </label>
+</div>

--- a/ui/app/components/variable-form/job-template-editor.hbs
+++ b/ui/app/components/variable-form/job-template-editor.hbs
@@ -1,5 +1,5 @@
 {{did-insert this.establishKeyValues}}
-<div class="key-value">
+<div>
   <label>
     <span>
       Description
@@ -12,7 +12,7 @@
     />
   </label>
 </div>
-<div class="key-value">
+<div>
   <label>
     <span>
       Job Template

--- a/ui/app/components/variable-form/job-template-editor.js
+++ b/ui/app/components/variable-form/job-template-editor.js
@@ -1,0 +1,26 @@
+// @ts-check
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class JobTemplateEditor extends Component {
+  // @tracked description = this.args.keyValues?.findBy('key', 'description')?.value;
+  // @tracked template = this.args.keyValues?.findBy('key', 'template')?.value;
+
+  @tracked description;
+  @tracked template;
+  @action
+  establishKeyValues() {
+    this.description = this.args.keyValues.findBy('key', 'description')?.value;
+    this.template = this.args.keyValues.findBy('key', 'template')?.value;
+  }
+
+  @action
+  updateDescription(event) {
+    this.args.updateKeyValue('description', event.target.value);
+  }
+  @action
+  updateTemplate(value) {
+    this.args.updateKeyValue('template', value);
+  }
+}

--- a/ui/app/components/variable-form/job-template-editor.js
+++ b/ui/app/components/variable-form/job-template-editor.js
@@ -4,9 +4,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class JobTemplateEditor extends Component {
-  // @tracked description = this.args.keyValues?.findBy('key', 'description')?.value;
-  // @tracked template = this.args.keyValues?.findBy('key', 'template')?.value;
-
   @tracked description;
   @tracked template;
   @action

--- a/ui/app/styles/components/variables.scss
+++ b/ui/app/styles/components/variables.scss
@@ -157,6 +157,25 @@ table.path-tree {
   }
 }
 
+.job-template-hint {
+  margin-top: 0.5rem;
+  code {
+    background-color: #eee;
+    padding: 0.25rem;
+  }
+  .copy-button {
+    display: inline-block;
+    padding-left: 0;
+    position: relative;
+    top: -5px;
+    button,
+    .button {
+      background-color: transparent;
+      padding-right: 0.25rem;
+    }
+  }
+}
+
 table.variable-items {
   // table-layout: fixed;
   td.value-cell {

--- a/ui/tests/acceptance/variables-test.js
+++ b/ui/tests/acceptance/variables-test.js
@@ -532,6 +532,39 @@ module('Acceptance | variables', function (hooks) {
       // Reset Token
       window.localStorage.nomadTokenSecret = null;
     });
+
+    test('shows a custom editor when editing a job template variable', async function (assert) {
+      // Arrange Test Set-up
+      allScenarios.variableTestCluster(server);
+      const variablesToken = server.db.tokens.find(VARIABLE_TOKEN_ID);
+      window.localStorage.nomadTokenSecret = variablesToken.secretId;
+      await Variables.visitNew();
+      // End Test Set-up
+
+      assert
+        .dom('.related-entities-hint')
+        .exists('Shows a hint about related entities by default');
+      assert.dom('.CodeMirror').doesNotExist();
+      await typeIn('[data-test-path-input]', 'nomad/job-templates/hello-world');
+      assert
+        .dom('.related-entities-hint')
+        .doesNotExist('Hides the hint when editing a job template variable');
+      assert
+        .dom('.job-template-hint')
+        .exists('Shows a hint about job templates');
+      assert
+        .dom('.CodeMirror')
+        .exists('Shows a custom editor for job templates');
+
+      document.querySelector('[data-test-path-input]').value = ''; // clear current input
+      await typeIn('[data-test-path-input]', 'hello-world-non-template');
+      assert
+        .dom('.related-entities-hint')
+        .exists('Shows a hint about related entities by default');
+      assert.dom('.CodeMirror').doesNotExist();
+      // Reset Token
+      window.localStorage.nomadTokenSecret = null;
+    });
   });
 
   module('edit flow', function () {


### PR DESCRIPTION
## Adds a new `-template` flag to `nomad job init`.
<img width="650" alt="image" src="https://user-images.githubusercontent.com/713991/210633571-9a281de0-7398-46e5-a2b9-5007ba795048.png">

---

## Adds a new `-list-templates` flag to `nomad job init`
reads from all variables at `nomad/job-templates/...` and lists them out. 
<img width="682" alt="image" src="https://user-images.githubusercontent.com/713991/210633817-ef4b69ec-cda9-4c96-8b4b-711742ed5e48.png">

---

## UI: Custom view
- changes the interface when editing a variable at `nomad/job-templates/...` to have an interface that's less free-form, and specifically supports only editing description and template.
![image](https://user-images.githubusercontent.com/713991/210633429-4e797f58-0d23-4cad-a400-1135cc52bd24.png)


Resolves #15563