### PR TITLE
acl: modify update endpoints behavior

### DIFF
--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -485,3 +485,12 @@ func WithLock(lock sync.Locker, f func()) {
 	defer lock.Unlock()
 	f()
 }
+
+// Merge takes two variables and returns variable b in case a has zero value.
+func Merge[T comparable](a, b T) T {
+	var zero T
+	if a == zero {
+		return b
+	}
+	return a
+}

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -487,6 +487,7 @@ func WithLock(lock sync.Locker, f func()) {
 }
 
 // Merge takes two variables and returns variable b in case a has zero value.
+// For pointer values please use pointer.Merge.
 func Merge[T comparable](a, b T) T {
 	var zero T
 	if a == zero {

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -1716,7 +1716,15 @@ func (a *ACL) UpsertAuthMethods(
 	}
 
 	// Validate each auth method, canonicalize, and compute hash
+	// merge methods in case we're doing an update
 	for idx, authMethod := range args.AuthMethods {
+		// if there's an existing method with the same name, we treat this as
+		// an update
+		existingMethod, _ := stateSnapshot.GetACLAuthMethodByName(nil, authMethod.Name)
+		if existingMethod != nil {
+			authMethod.Merge(existingMethod)
+		}
+
 		if err := authMethod.Validate(
 			a.srv.config.ACLTokenMinExpirationTTL,
 			a.srv.config.ACLTokenMaxExpirationTTL); err != nil {
@@ -2051,10 +2059,6 @@ func (a *ACL) UpsertBindingRules(
 	// Validate each binding rules and compute the hash.
 	for idx, bindingRule := range args.ACLBindingRules {
 
-		if err := bindingRule.Validate(); err != nil {
-			return structs.NewErrRPCCodedf(http.StatusBadRequest, "binding rule %d invalid: %v", idx, err)
-		}
-
 		// If the caller has passed a rule ID, this call is considered an
 		// update to an existing rule. We should therefore ensure it is found
 		// within state.
@@ -2068,6 +2072,19 @@ func (a *ACL) UpsertBindingRules(
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "cannot find binding rule %s", bindingRule.ID)
 			}
+
+			// merge
+			if err := bindingRule.Merge(existingBindingRule); err != nil {
+				return structs.NewErrRPCCodedf(
+					http.StatusBadRequest, "tried to merge the update with an existing binding rule, but failed: %v", err,
+				)
+			}
+			bindingRule.AuthMethod = existingBindingRule.AuthMethod
+		}
+
+		// Validate only if it's not an update
+		if err := bindingRule.Validate(); err != nil {
+			return structs.NewErrRPCCodedf(http.StatusBadRequest, "binding rule %d invalid: %v", idx, err)
 		}
 
 		// Ensure the auth method linked to exists within state.

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -1721,9 +1721,7 @@ func (a *ACL) UpsertAuthMethods(
 		// if there's an existing method with the same name, we treat this as
 		// an update
 		existingMethod, _ := stateSnapshot.GetACLAuthMethodByName(nil, authMethod.Name)
-		if existingMethod != nil {
-			authMethod.Merge(existingMethod)
-		}
+		authMethod.Merge(existingMethod)
 
 		if err := authMethod.Validate(
 			a.srv.config.ACLTokenMinExpirationTTL,

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -2074,9 +2074,12 @@ func (a *ACL) UpsertBindingRules(
 			}
 
 			// merge
-			if err := bindingRule.Merge(existingBindingRule); err != nil {
-				return structs.NewErrRPCCodedf(
-					http.StatusBadRequest, "tried to merge the update with an existing binding rule, but failed: %v", err,
+			bindingRule.Merge(existingBindingRule)
+
+			// Auth methods cannot be changed
+			if bindingRule.AuthMethod != existingBindingRule.AuthMethod {
+				return structs.NewErrRPCCoded(
+					http.StatusBadRequest, "cannot update auth method for binding rule, create a new rule instead",
 				)
 			}
 			bindingRule.AuthMethod = existingBindingRule.AuthMethod

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -3056,6 +3056,18 @@ func TestACLEndpoint_UpsertACLAuthMethods(t *testing.T) {
 	}
 	// We expect this to err since there's already a default method of the same type
 	must.Error(t, msgpackrpc.CallWithCodec(codec, structs.ACLUpsertAuthMethodsRPCMethod, req, &resp))
+
+	// Update token locality
+	am3 := &structs.ACLAuthMethod{Name: am1.Name, TokenLocality: "global"}
+	req = &structs.ACLAuthMethodUpsertRequest{
+		AuthMethods: []*structs.ACLAuthMethod{am3},
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			AuthToken: root.SecretID,
+		},
+	}
+	must.NoError(t, msgpackrpc.CallWithCodec(codec, structs.ACLUpsertAuthMethodsRPCMethod, req, &resp))
+	must.Eq(t, resp.AuthMethods[0].TokenLocality, am3.TokenLocality)
 }
 
 func TestACL_UpsertBindingRules(t *testing.T) {

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"golang.org/x/crypto/blake2b"
@@ -758,6 +759,16 @@ func (a *ACLAuthMethod) Canonicalize() {
 	a.ModifyTime = t
 }
 
+// Merge merges auth method a with method b. It sets all required empty fields
+// of method a to corresponding values of method b, except for "default" and
+// "name."
+func (a *ACLAuthMethod) Merge(b *ACLAuthMethod) {
+	a.Type = helper.Merge(a.Type, b.Type)
+	a.TokenLocality = helper.Merge(a.TokenLocality, b.TokenLocality)
+	a.MaxTokenTTL = helper.Merge(a.MaxTokenTTL, b.MaxTokenTTL)
+	a.Config = helper.Merge(a.Config, b.Config)
+}
+
 // Validate returns an error is the ACLAuthMethod is invalid.
 //
 // TODO revisit possible other validity conditions in the future
@@ -992,8 +1003,6 @@ func (a *ACLBindingRule) Validate() error {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("description longer than %d", maxACLRoleDescriptionLength))
 	}
 
-	// Be specific about the error as returning an error that includes an empty
-	// quote ("") can be a little confusing.
 	if a.BindType == "" {
 		mErr.Errors = append(mErr.Errors, errors.New("bind type is missing"))
 	} else {
@@ -1005,6 +1014,19 @@ func (a *ACLBindingRule) Validate() error {
 	}
 
 	return mErr.ErrorOrNil()
+}
+
+// Merge merges binding rule a with b. It sets all required empty fields of rule
+// a to corresponding values of rule b, except for "ID" which must be provided,
+// and "authMethod" which is immutable.
+func (a *ACLBindingRule) Merge(b *ACLBindingRule) error {
+	a.Description = helper.Merge(a.Description, b.Description)
+	a.BindName = helper.Merge(a.BindName, b.BindName)
+	a.BindType = helper.Merge(a.BindType, b.BindType)
+	if a.AuthMethod != "" {
+		return fmt.Errorf("auth method is immutable, in order to change it, delete the exisitng binding rule and create a new one")
+	}
+	return nil
 }
 
 // SetHash is used to compute and set the hash of the ACL binding rule. This

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -1024,7 +1024,7 @@ func (a *ACLBindingRule) Merge(b *ACLBindingRule) error {
 	a.BindName = helper.Merge(a.BindName, b.BindName)
 	a.BindType = helper.Merge(a.BindType, b.BindType)
 	if a.AuthMethod != "" {
-		return fmt.Errorf("auth method is immutable, in order to change it, delete the exisitng binding rule and create a new one")
+		return fmt.Errorf("auth method is immutable, in order to change it, delete the existing binding rule and create a new one")
 	}
 	return nil
 }

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -763,10 +763,12 @@ func (a *ACLAuthMethod) Canonicalize() {
 // of method a to corresponding values of method b, except for "default" and
 // "name."
 func (a *ACLAuthMethod) Merge(b *ACLAuthMethod) {
-	a.Type = helper.Merge(a.Type, b.Type)
-	a.TokenLocality = helper.Merge(a.TokenLocality, b.TokenLocality)
-	a.MaxTokenTTL = helper.Merge(a.MaxTokenTTL, b.MaxTokenTTL)
-	a.Config = helper.Merge(a.Config, b.Config)
+	if b != nil {
+		a.Type = helper.Merge(a.Type, b.Type)
+		a.TokenLocality = helper.Merge(a.TokenLocality, b.TokenLocality)
+		a.MaxTokenTTL = helper.Merge(a.MaxTokenTTL, b.MaxTokenTTL)
+		a.Config = helper.Merge(a.Config, b.Config)
+	}
 }
 
 // Validate returns an error is the ACLAuthMethod is invalid.

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -1017,16 +1017,11 @@ func (a *ACLBindingRule) Validate() error {
 }
 
 // Merge merges binding rule a with b. It sets all required empty fields of rule
-// a to corresponding values of rule b, except for "ID" which must be provided,
-// and "authMethod" which is immutable.
-func (a *ACLBindingRule) Merge(b *ACLBindingRule) error {
-	a.Description = helper.Merge(a.Description, b.Description)
+// a to corresponding values of rule b, except for "ID" which must be provided.
+func (a *ACLBindingRule) Merge(b *ACLBindingRule) {
 	a.BindName = helper.Merge(a.BindName, b.BindName)
 	a.BindType = helper.Merge(a.BindType, b.BindType)
-	if a.AuthMethod != b.AuthMethod {
-		return fmt.Errorf("auth method is immutable, in order to change it, delete the existing binding rule and create a new one")
-	}
-	return nil
+	a.AuthMethod = helper.Merge(a.AuthMethod, b.AuthMethod)
 }
 
 // SetHash is used to compute and set the hash of the ACL binding rule. This

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -1023,7 +1023,7 @@ func (a *ACLBindingRule) Merge(b *ACLBindingRule) error {
 	a.Description = helper.Merge(a.Description, b.Description)
 	a.BindName = helper.Merge(a.BindName, b.BindName)
 	a.BindType = helper.Merge(a.BindType, b.BindType)
-	if a.AuthMethod != "" {
+	if a.AuthMethod != b.AuthMethod {
 		return fmt.Errorf("auth method is immutable, in order to change it, delete the existing binding rule and create a new one")
 	}
 	return nil

--- a/nomad/structs/acl_test.go
+++ b/nomad/structs/acl_test.go
@@ -1222,15 +1222,9 @@ func TestACLBindingRule_Merge(t *testing.T) {
 		ID:          id,
 		Description: "new description",
 	}
-	must.NoError(t, br_description_update.Merge(br))
+	br_description_update.Merge(br)
 	must.Eq(t, br_description_update.Description, "new description")
 	must.Eq(t, br_description_update.BindType, "rule")
-
-	// attempt an auth method update
-	br_auth_method_update := &ACLBindingRule{
-		AuthMethod: "new auth method",
-	}
-	must.Error(t, br_auth_method_update.Merge(br))
 }
 
 func TestACLBindingRule_SetHash(t *testing.T) {

--- a/nomad/structs/acl_test.go
+++ b/nomad/structs/acl_test.go
@@ -713,7 +713,7 @@ func TestACLRole_Copy(t *testing.T) {
 		{
 			name: "general 1",
 			inputACLRole: &ACLRole{
-				Name:        fmt.Sprintf("acl-role"),
+				Name:        "acl-role",
 				Description: "mocked-test-acl-role",
 				Policies: []*ACLRolePolicyLink{
 					{Name: "mocked-test-policy-1"},
@@ -1039,6 +1039,45 @@ func TestACLAuthMethod_Validate(t *testing.T) {
 	}
 }
 
+func TestACLAuthMethod_Merge(t *testing.T) {
+	ci.Parallel(t)
+
+	name := fmt.Sprintf("acl-auth-method-%s", uuid.Short())
+
+	maxTokenTTL, _ := time.ParseDuration("3600s")
+	am1 := &ACLAuthMethod{
+		Name:          name,
+		TokenLocality: "global",
+	}
+	am2 := &ACLAuthMethod{
+		Name:          name,
+		Type:          "OIDC",
+		TokenLocality: "locality",
+		MaxTokenTTL:   maxTokenTTL,
+		Default:       true,
+		Config: &ACLAuthMethodConfig{
+			OIDCDiscoveryURL:    "http://example.com",
+			OIDCClientID:        "mock",
+			OIDCClientSecret:    "very secret secret",
+			BoundAudiences:      []string{"audience1", "audience2"},
+			AllowedRedirectURIs: []string{"foo", "bar"},
+			DiscoveryCaPem:      []string{"foo"},
+			SigningAlgs:         []string{"bar"},
+			ClaimMappings:       map[string]string{"foo": "bar"},
+			ListClaimMappings:   map[string]string{"foo": "bar"},
+		},
+		CreateTime:  time.Now().UTC(),
+		CreateIndex: 10,
+		ModifyIndex: 10,
+	}
+
+	am1.Merge(am2)
+	must.Eq(t, am1.TokenLocality, "global")
+	minTTL, _ := time.ParseDuration("10s")
+	maxTTL, _ := time.ParseDuration("10h")
+	must.NoError(t, am1.Validate(minTTL, maxTTL))
+}
+
 func TestACLAuthMethodConfig_Copy(t *testing.T) {
 	ci.Parallel(t)
 
@@ -1161,6 +1200,37 @@ func TestACLBindingRule_Validate(t *testing.T) {
 	totallyInvalidACLBindingRule.BindType = "service"
 	err = totallyInvalidACLBindingRule.Validate()
 	must.StrContains(t, err.Error(), `unsupported bind type: "service"`)
+}
+
+func TestACLBindingRule_Merge(t *testing.T) {
+	ci.Parallel(t)
+
+	id := uuid.Short()
+	br := &ACLBindingRule{
+		ID:          id,
+		Description: "old description",
+		AuthMethod:  "example-acl-auth-method",
+		BindType:    "rule",
+		BindName:    "bind name",
+		CreateTime:  time.Now().UTC(),
+		CreateIndex: 10,
+		ModifyIndex: 10,
+	}
+
+	// make a description update
+	br_description_update := &ACLBindingRule{
+		ID:          id,
+		Description: "new description",
+	}
+	must.NoError(t, br_description_update.Merge(br))
+	must.Eq(t, br_description_update.Description, "new description")
+	must.Eq(t, br_description_update.BindType, "rule")
+
+	// attempt an auth method update
+	br_auth_method_update := &ACLBindingRule{
+		AuthMethod: "new auth method",
+	}
+	must.Error(t, br_auth_method_update.Merge(br))
 }
 
 func TestACLBindingRule_SetHash(t *testing.T) {


### PR DESCRIPTION
API and RPC endpoints for `ACLAuthMethod`s and `ACLBindingRule`s should allow users to send incomplete objects in order to, e.g., update single fields. This PR provides "merging" functionality for these endpoints. 

Relates to #13120 