### PR TITLE
bugfix: unit test for GetACLBindingRules

### DIFF
--- a/nomad/state/state_store_acl_binding_rule_test.go
+++ b/nomad/state/state_store_acl_binding_rule_test.go
@@ -190,7 +190,7 @@ func TestStateStore_GetACLBindingRules(t *testing.T) {
 		expected[i].ModifyIndex = 10
 	}
 
-	must.Eq(t, aclBindingRules, expected)
+	must.SliceContainsAll(t, aclBindingRules, expected)
 }
 
 func TestStateStore_GetACLBindingRule(t *testing.T) {


### PR DESCRIPTION
Unit test for GetACLBindingRules state store method would fail because we'd expect order of returned items.

vide discussion under #15580