### PR TITLE
ci: remove lint workflow from circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,17 +339,6 @@ jobs:
           path: /tmp/test-reports
       - store_artifacts:
           path: /tmp/test-reports
-  lint-go:
-    executor: go
-    steps:
-      - checkout
-      - run: apt-get update; apt-get install -y shellcheck sudo unzip
-      - install-buf
-      - install-circleci-local-cli
-      - run: make deps lint-deps
-      - run: make check
-      - run: make checkscripts
-      - run: mkdir -p ui/dist && make generate-all static-assets
   build-darwin-binaries:
     executor: go-macos
     steps:
@@ -510,18 +499,14 @@ workflows:
               ignore:
                 - stable-website
 
-      - lint-go:
-          # check branches are almost all the backend branches
-          filters: &backend_check_branches_filter
+      - test-e2e:
+          filters:
             branches:
               ignore:
                 - /^.-ui\b.*/
                 - /^docs-.*/
                 - /^backport/docs-.*/
                 - stable-website
-
-      - test-e2e:
-          filters: *backend_check_branches_filter
 
       - test-ui:
           filters:


### PR DESCRIPTION
This PR remove the lint-go workflow from circle; we already have the linting
covered in GHA and the circle stuff is just outdated anyway.
