### PR TITLE
tests: do not return error from testagent shutdown

### DIFF
--- a/command/acl_auth_method_delete_test.go
+++ b/command/acl_auth_method_delete_test.go
@@ -19,7 +19,7 @@ func TestACLAuthMethodDeleteCommand(t *testing.T) {
 	}
 
 	srv, _, url := testServer(t, true, config)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	state := srv.Agent.Server().State()
 

--- a/command/acl_auth_method_info_test.go
+++ b/command/acl_auth_method_info_test.go
@@ -20,7 +20,7 @@ func TestACLAuthMethodInfoCommand(t *testing.T) {
 
 	srv, _, url := testServer(t, true, config)
 	state := srv.Agent.Server().State()
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
 	token := srv.RootToken

--- a/command/acl_auth_method_list_test.go
+++ b/command/acl_auth_method_list_test.go
@@ -20,7 +20,7 @@ func TestACLAuthMethodListCommand(t *testing.T) {
 
 	srv, _, url := testServer(t, true, config)
 	state := srv.Agent.Server().State()
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
 	token := srv.RootToken

--- a/command/acl_bootstrap_test.go
+++ b/command/acl_bootstrap_test.go
@@ -22,7 +22,7 @@ func TestACLBootstrapCommand(t *testing.T) {
 	}
 
 	srv, _, url := testServer(t, true, config)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	must.Nil(t, srv.RootToken)
 
@@ -47,7 +47,7 @@ func TestACLBootstrapCommand_ExistingBootstrapToken(t *testing.T) {
 	}
 
 	srv, _, url := testServer(t, true, config)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	must.NotNil(t, srv.RootToken)
 
@@ -66,7 +66,7 @@ func TestACLBootstrapCommand_NonACLServer(t *testing.T) {
 	ci.Parallel(t)
 
 	srv, _, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &ACLBootstrapCommand{Meta: Meta{Ui: ui, flagAddress: url}}
@@ -100,7 +100,7 @@ func TestACLBootstrapCommand_WithOperatorFileBootstrapToken(t *testing.T) {
 	must.NoError(t, err)
 
 	srv, _, url := testServer(t, true, config)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	must.Nil(t, srv.RootToken)
 
@@ -138,7 +138,7 @@ func TestACLBootstrapCommand_WithBadOperatorFileBootstrapToken(t *testing.T) {
 	must.NoError(t, err)
 
 	srv, _, url := testServer(t, true, config)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	must.Nil(t, srv.RootToken)
 

--- a/command/acl_policy_apply_test.go
+++ b/command/acl_policy_apply_test.go
@@ -19,7 +19,7 @@ func TestACLPolicyApplyCommand(t *testing.T) {
 	}
 
 	srv, _, url := testServer(t, true, config)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
 	token := srv.RootToken

--- a/command/acl_policy_delete_test.go
+++ b/command/acl_policy_delete_test.go
@@ -20,7 +20,7 @@ func TestACLPolicyDeleteCommand(t *testing.T) {
 	}
 
 	srv, _, url := testServer(t, true, config)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	state := srv.Agent.Server().State()
 

--- a/command/acl_policy_info_test.go
+++ b/command/acl_policy_info_test.go
@@ -20,7 +20,7 @@ func TestACLPolicyInfoCommand(t *testing.T) {
 
 	srv, _, url := testServer(t, true, config)
 	state := srv.Agent.Server().State()
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
 	token := srv.RootToken

--- a/command/acl_policy_list_test.go
+++ b/command/acl_policy_list_test.go
@@ -20,8 +20,9 @@ func TestACLPolicyListCommand(t *testing.T) {
 	}
 
 	srv, _, url := testServer(t, true, config)
+	defer srv.Shutdown()
+
 	state := srv.Agent.Server().State()
-	defer stopTestAgent(srv)
 
 	// Bootstrap an initial ACL token
 	token := srv.RootToken

--- a/command/acl_token_create_test.go
+++ b/command/acl_token_create_test.go
@@ -19,7 +19,7 @@ func TestACLTokenCreateCommand(t *testing.T) {
 	}
 
 	srv, _, url := testServer(t, true, config)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
 	token := srv.RootToken

--- a/command/acl_token_delete_test.go
+++ b/command/acl_token_delete_test.go
@@ -21,7 +21,7 @@ func TestACLTokenDeleteCommand_ViaEnvVariable(t *testing.T) {
 	}
 
 	srv, _, url := testServer(t, true, config)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
 	token := srv.RootToken

--- a/command/acl_token_info_test.go
+++ b/command/acl_token_info_test.go
@@ -17,7 +17,7 @@ func TestACLTokenInfoCommand_ViaEnvVar(t *testing.T) {
 	}
 
 	srv, _, url := testServer(t, true, config)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	state := srv.Agent.Server().State()
 

--- a/command/acl_token_list_test.go
+++ b/command/acl_token_list_test.go
@@ -20,7 +20,7 @@ func TestACLTokenListCommand(t *testing.T) {
 	}
 
 	srv, _, url := testServer(t, true, config)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	state := srv.Agent.Server().State()
 

--- a/command/acl_token_self_test.go
+++ b/command/acl_token_self_test.go
@@ -17,7 +17,7 @@ func TestACLTokenSelfCommand_ViaEnvVar(t *testing.T) {
 	}
 
 	srv, _, url := testServer(t, true, config)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	state := srv.Agent.Server().State()
 

--- a/command/acl_token_update_test.go
+++ b/command/acl_token_update_test.go
@@ -20,7 +20,7 @@ func TestACLTokenUpdateCommand(t *testing.T) {
 	}
 
 	srv, _, url := testServer(t, true, config)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	// Bootstrap an initial ACL token
 	token := srv.RootToken

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -1302,9 +1302,7 @@ func TestHTTPServer_Limits_OK(t *testing.T) {
 				c.Limits.HTTPMaxConnsPerClient = tc.limit
 				c.LogLevel = "ERROR"
 			})
-			defer func() {
-				require.NoError(t, s.Shutdown())
-			}()
+			defer s.Shutdown()
 
 			assertTimeout(t, s, tc.assertTimeout, tc.timeout)
 

--- a/command/agent_info_test.go
+++ b/command/agent_info_test.go
@@ -16,7 +16,7 @@ func TestAgentInfoCommand_Implements(t *testing.T) {
 func TestAgentInfoCommand_Run(t *testing.T) {
 	ci.Parallel(t)
 	srv, _, url := testServer(t, false, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AgentInfoCommand{Meta: Meta{Ui: ui}}
@@ -28,7 +28,7 @@ func TestAgentInfoCommand_Run(t *testing.T) {
 func TestAgentInfoCommand_Run_JSON(t *testing.T) {
 	ci.Parallel(t)
 	srv, _, url := testServer(t, false, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AgentInfoCommand{Meta: Meta{Ui: ui}}
@@ -43,7 +43,7 @@ func TestAgentInfoCommand_Run_JSON(t *testing.T) {
 func TestAgentInfoCommand_Run_Gotemplate(t *testing.T) {
 	ci.Parallel(t)
 	srv, _, url := testServer(t, false, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AgentInfoCommand{Meta: Meta{Ui: ui}}

--- a/command/agent_monitor_test.go
+++ b/command/agent_monitor_test.go
@@ -16,7 +16,7 @@ func TestMonitorCommand_Implements(t *testing.T) {
 func TestMonitorCommand_Fails(t *testing.T) {
 	ci.Parallel(t)
 	srv, _, url := testServer(t, false, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &MonitorCommand{Meta: Meta{Ui: ui}}

--- a/command/alloc_checks_test.go
+++ b/command/alloc_checks_test.go
@@ -19,9 +19,7 @@ func TestAllocChecksCommand_Implements(t *testing.T) {
 func TestAllocChecksCommand_Fails(t *testing.T) {
 	ci.Parallel(t)
 	srv, _, url := testServer(t, false, nil)
-	t.Cleanup(func() {
-		_ = srv.Shutdown()
-	})
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AllocChecksCommand{Meta: Meta{Ui: ui}}
@@ -63,7 +61,7 @@ func TestAllocChecksCommand_AutocompleteArgs(t *testing.T) {
 	ci.Parallel(t)
 
 	srv, _, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AllocChecksCommand{Meta: Meta{Ui: ui, flagAddress: url}}
@@ -85,7 +83,7 @@ func TestAllocChecksCommand_AutocompleteArgs(t *testing.T) {
 func TestAllocChecksCommand_Run(t *testing.T) {
 	ci.Parallel(t)
 	srv, client, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	// wait for nodes
 	waitForNodes(t, client)

--- a/command/alloc_exec_test.go
+++ b/command/alloc_exec_test.go
@@ -22,7 +22,7 @@ var _ cli.Command = &AllocExecCommand{}
 func TestAllocExecCommand_Fails(t *testing.T) {
 	ci.Parallel(t)
 	srv, client, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	cases := []struct {
 		name          string
@@ -142,7 +142,7 @@ func TestAllocExecCommand_AutocompleteArgs(t *testing.T) {
 	ci.Parallel(t)
 
 	srv, _, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AllocExecCommand{Meta: Meta{Ui: ui, flagAddress: url}}
@@ -164,7 +164,7 @@ func TestAllocExecCommand_AutocompleteArgs(t *testing.T) {
 func TestAllocExecCommand_Run(t *testing.T) {
 	ci.Parallel(t)
 	srv, client, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	// Wait for a node to be ready
 	waitForNodes(t, client)

--- a/command/alloc_fs_test.go
+++ b/command/alloc_fs_test.go
@@ -19,7 +19,7 @@ func TestFSCommand_Implements(t *testing.T) {
 func TestFSCommand_Fails(t *testing.T) {
 	ci.Parallel(t)
 	srv, _, url := testServer(t, false, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AllocFSCommand{Meta: Meta{Ui: ui}}
@@ -90,7 +90,7 @@ func TestFSCommand_AutocompleteArgs(t *testing.T) {
 	ci.Parallel(t)
 
 	srv, _, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AllocFSCommand{Meta: Meta{Ui: ui, flagAddress: url}}

--- a/command/alloc_logs_test.go
+++ b/command/alloc_logs_test.go
@@ -11,15 +11,12 @@ import (
 	"github.com/shoenig/test/must"
 )
 
-func TestLogsCommand_Implements(t *testing.T) {
-	ci.Parallel(t)
-	var _ cli.Command = &AllocLogsCommand{}
-}
+var _ cli.Command = (*AllocLogsCommand)(nil)
 
 func TestLogsCommand_Fails(t *testing.T) {
 	ci.Parallel(t)
 	srv, _, url := testServer(t, false, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AllocLogsCommand{Meta: Meta{Ui: ui}}
@@ -72,7 +69,7 @@ func TestLogsCommand_AutocompleteArgs(t *testing.T) {
 	ci.Parallel(t)
 
 	srv, _, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AllocLogsCommand{Meta: Meta{Ui: ui, flagAddress: url}}

--- a/command/alloc_restart_test.go
+++ b/command/alloc_restart_test.go
@@ -19,7 +19,7 @@ func TestAllocRestartCommand_Fails(t *testing.T) {
 	ci.Parallel(t)
 
 	srv, client, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AllocRestartCommand{Meta: Meta{Ui: ui}}
@@ -103,7 +103,7 @@ func TestAllocRestartCommand_Run(t *testing.T) {
 	ci.Parallel(t)
 
 	srv, client, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	// Wait for a node to be ready
 	waitForNodes(t, client)
@@ -141,7 +141,7 @@ func TestAllocRestartCommand_AutocompleteArgs(t *testing.T) {
 	ci.Parallel(t)
 
 	srv, _, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AllocRestartCommand{Meta: Meta{Ui: ui, flagAddress: url}}

--- a/command/alloc_signal_test.go
+++ b/command/alloc_signal_test.go
@@ -19,7 +19,7 @@ func TestAllocSignalCommand_Implements(t *testing.T) {
 func TestAllocSignalCommand_Fails(t *testing.T) {
 	ci.Parallel(t)
 	srv, _, url := testServer(t, false, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AllocSignalCommand{Meta: Meta{Ui: ui}}
@@ -74,7 +74,7 @@ func TestAllocSignalCommand_AutocompleteArgs(t *testing.T) {
 	ci.Parallel(t)
 
 	srv, _, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AllocSignalCommand{Meta: Meta{Ui: ui, flagAddress: url}}
@@ -98,7 +98,7 @@ func TestAllocSignalCommand_Run(t *testing.T) {
 	ci.Parallel(t)
 
 	srv, client, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	// Wait for a node to be ready
 	waitForNodes(t, client)

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -24,7 +24,7 @@ func TestAllocStatusCommand_Implements(t *testing.T) {
 func TestAllocStatusCommand_Fails(t *testing.T) {
 	ci.Parallel(t)
 	srv, _, url := testServer(t, false, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AllocStatusCommand{Meta: Meta{Ui: ui}}
@@ -86,7 +86,7 @@ func TestAllocStatusCommand_LifecycleInfo(t *testing.T) {
 	ci.Parallel(t)
 
 	srv, client, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	waitForNodes(t, client)
 
@@ -134,7 +134,7 @@ func TestAllocStatusCommand_LifecycleInfo(t *testing.T) {
 func TestAllocStatusCommand_Run(t *testing.T) {
 	ci.Parallel(t)
 	srv, client, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	waitForNodes(t, client)
 
@@ -202,7 +202,7 @@ func TestAllocStatusCommand_Run(t *testing.T) {
 func TestAllocStatusCommand_RescheduleInfo(t *testing.T) {
 	ci.Parallel(t)
 	srv, client, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	waitForNodes(t, client)
 
@@ -236,7 +236,7 @@ func TestAllocStatusCommand_RescheduleInfo(t *testing.T) {
 func TestAllocStatusCommand_ScoreMetrics(t *testing.T) {
 	ci.Parallel(t)
 	srv, client, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	waitForNodes(t, client)
 
@@ -285,7 +285,7 @@ func TestAllocStatusCommand_AutocompleteArgs(t *testing.T) {
 	ci.Parallel(t)
 
 	srv, _, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AllocStatusCommand{Meta: Meta{Ui: ui, flagAddress: url}}
@@ -320,7 +320,7 @@ func TestAllocStatusCommand_HostVolumes(t *testing.T) {
 			},
 		}
 	})
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	state := srv.Agent.Server().State()
 
@@ -372,7 +372,7 @@ func TestAllocStatusCommand_HostVolumes(t *testing.T) {
 func TestAllocStatusCommand_CSIVolumes(t *testing.T) {
 	ci.Parallel(t)
 	srv, _, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	state := srv.Agent.Server().State()
 
@@ -448,7 +448,7 @@ func TestAllocStatusCommand_CSIVolumes(t *testing.T) {
 func TestAllocStatusCommand_NSD_Checks(t *testing.T) {
 	ci.Parallel(t)
 	srv, client, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	// wait for nodes
 	waitForNodes(t, client)

--- a/command/alloc_stop_test.go
+++ b/command/alloc_stop_test.go
@@ -8,14 +8,11 @@ import (
 	"github.com/shoenig/test/must"
 )
 
-func TestAllocStopCommand_Implements(t *testing.T) {
-	ci.Parallel(t)
-	var _ cli.Command = &AllocStopCommand{}
-}
+var _ cli.Command = (*AllocStopCommand)(nil)
 
 func TestAllocStop_Fails(t *testing.T) {
 	srv, _, url := testServer(t, false, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AllocStopCommand{Meta: Meta{Ui: ui}}
@@ -66,7 +63,7 @@ func TestAllocStop_Run(t *testing.T) {
 	ci.Parallel(t)
 
 	srv, client, url := testServer(t, true, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	// Wait for a node to be ready
 	waitForNodes(t, client)

--- a/command/check_test.go
+++ b/command/check_test.go
@@ -12,7 +12,7 @@ import (
 func TestAgentCheckCommand_ServerHealth(t *testing.T) {
 	ci.Parallel(t)
 	srv, _, url := testServer(t, false, nil)
-	defer stopTestAgent(srv)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &AgentCheckCommand{Meta: Meta{Ui: ui}}

--- a/command/testing_test.go
+++ b/command/testing_test.go
@@ -23,7 +23,7 @@ func testServer(t *testing.T, runClient bool, cb func(*agent.Config)) (*agent.Te
 			cb(config)
 		}
 	})
-	t.Cleanup(func() { _ = a.Shutdown() })
+	t.Cleanup(a.Shutdown)
 
 	c := a.Client()
 	return a, c, a.HTTPAddr()
@@ -38,7 +38,7 @@ func testClient(t *testing.T, name string, cb func(*agent.Config)) (*agent.TestA
 			cb(config)
 		}
 	})
-	t.Cleanup(func() { _ = a.Shutdown() })
+	t.Cleanup(a.Shutdown)
 
 	c := a.Client()
 	t.Logf("Waiting for client %s to join server(s) %s", name, a.GetConfig().Client.Servers)
@@ -193,10 +193,6 @@ func getAllocFromJob(t *testing.T, client *api.Client, jobID string) string {
 	}
 	must.NotEq(t, "", allocID, must.Sprint("expected to find an evaluation after running job", jobID))
 	return allocID
-}
-
-func stopTestAgent(a *agent.TestAgent) {
-	_ = a.Shutdown()
 }
 
 func getTempFile(t *testing.T, name string) (string, func()) {

--- a/command/var_get_test.go
+++ b/command/var_get_test.go
@@ -65,9 +65,7 @@ func TestVarGetCommand(t *testing.T) {
 
 	// Create a server
 	srv, client, url := testServer(t, true, nil)
-	t.Cleanup(func() {
-		srv.Shutdown()
-	})
+	defer srv.Shutdown()
 
 	testCases := []struct {
 		name     string
@@ -111,7 +109,7 @@ func TestVarGetCommand(t *testing.T) {
 			_, err = client.Namespaces().Register(&api.Namespace{Name: testNS}, nil)
 			require.NoError(t, err)
 			t.Cleanup(func() {
-				client.Namespaces().Delete(testNS, nil)
+				_, _ = client.Namespaces().Delete(testNS, nil)
 			})
 
 			// Create a var to get
@@ -165,8 +163,6 @@ func TestVarGetCommand(t *testing.T) {
 	}
 	t.Run("Autocomplete", func(t *testing.T) {
 		ci.Parallel(t)
-		_, client, url, shutdownFn := testAPIClient(t)
-		defer shutdownFn()
 
 		ui := cli.NewMockUi()
 		cmd := &VarGetCommand{Meta: Meta{Ui: ui, flagAddress: url}}
@@ -175,14 +171,18 @@ func TestVarGetCommand(t *testing.T) {
 		testNS := strings.Map(validNS, t.Name())
 		_, err := client.Namespaces().Register(&api.Namespace{Name: testNS}, nil)
 		require.NoError(t, err)
-		t.Cleanup(func() { client.Namespaces().Delete(testNS, nil) })
+		t.Cleanup(func() {
+			_, _ = client.Namespaces().Delete(testNS, nil)
+		})
 
 		sv := testVariable()
 		sv.Path = "special/variable"
 		sv.Namespace = testNS
 		sv, _, err = client.Variables().Create(sv, nil)
 		require.NoError(t, err)
-		t.Cleanup(func() { client.Variables().Delete(sv.Path, nil) })
+		t.Cleanup(func() {
+			_, _ = client.Variables().Delete(sv.Path, nil)
+		})
 
 		args := complete.Args{Last: "s"}
 		predictor := cmd.AutocompleteArgs()

--- a/command/var_purge_test.go
+++ b/command/var_purge_test.go
@@ -64,9 +64,7 @@ func TestVarPurgeCommand_Online(t *testing.T) {
 
 	// Create a server
 	srv, client, url := testServer(t, true, nil)
-	t.Cleanup(func() {
-		srv.Shutdown()
-	})
+	defer srv.Shutdown()
 
 	t.Run("unchecked", func(t *testing.T) {
 		ui := cli.NewMockUi()

--- a/command/var_put_test.go
+++ b/command/var_put_test.go
@@ -103,8 +103,8 @@ func TestVarPutCommand_GoodJson(t *testing.T) {
 
 func TestVarPutCommand_AutocompleteArgs(t *testing.T) {
 	ci.Parallel(t)
-	_, client, url, shutdownFn := testAPIClient(t)
-	defer shutdownFn()
+	srv, client, url := testServer(t, true, nil)
+	defer srv.Shutdown()
 
 	ui := cli.NewMockUi()
 	cmd := &VarPutCommand{Meta: Meta{Ui: ui, flagAddress: url}}

--- a/command/var_test.go
+++ b/command/var_test.go
@@ -1,10 +1,7 @@
 package command
 
 import (
-	"testing"
-
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/command/agent"
 )
 
 // testVariable returns a test variable spec
@@ -17,10 +14,4 @@ func testVariable() *api.Variable {
 			"keyB": "valueB",
 		},
 	}
-}
-
-func testAPIClient(t *testing.T) (srv *agent.TestAgent, client *api.Client, url string, shutdownFn func() error) {
-	srv, client, url = testServer(t, true, nil)
-	shutdownFn = srv.Shutdown
-	return
 }


### PR DESCRIPTION
This PR changes the signature of `TestAgent.Shutdown` to return nothing, making it directly compatible with `defer`. We usually ignore the error even though we shouldn't, so instead now we call Fatal if the agent fails to shutdown or times out while doing so.

Extracting this cleanup out of fixing https://github.com/hashicorp/nomad/issues/15575