### PR TITLE
command: fixup tests concerning multi job stop

### DIFF
--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -96,14 +96,15 @@ type TestAgent struct {
 // configuration. The caller should call Shutdown() to stop the agent and
 // remove temporary directories.
 func NewTestAgent(t testing.TB, name string, configCallback func(*Config)) *TestAgent {
+	logger := testlog.HCLogger(t)
+	logger.SetLevel(testlog.HCLoggerTestLevel())
 	a := &TestAgent{
 		T:              t,
 		Name:           name,
 		ConfigCallback: configCallback,
 		Enterprise:     EnterpriseTestAgent,
-		logger:         testlog.HCLogger(t),
+		logger:         logger,
 	}
-
 	a.Start()
 	return a
 }

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -554,7 +554,7 @@ func sanitizeUUIDPrefix(prefix string) string {
 	return prefix[:len(prefix)-remainder]
 }
 
-// commandErrorText is used to easily render the same messaging across commads
+// commandErrorText is used to easily render the same messaging across commands
 // when an error is printed.
 func commandErrorText(cmd NamedCommand) string {
 	return fmt.Sprintf("For additional help try 'nomad %s -help'", cmd.Name())

--- a/command/helpers_test.go
+++ b/command/helpers_test.go
@@ -209,7 +209,7 @@ func TestHelpers_LineLimitReader_TimeLimit(t *testing.T) {
 }
 
 const (
-	job = `job "job1" {
+	job1 = `job "job1" {
   type        = "service"
   datacenters = ["dc1"]
   group "group1" {
@@ -263,7 +263,7 @@ func TestJobGetter_LocalFile(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	defer os.Remove(fh.Name())
-	_, err = fh.WriteString(job)
+	_, err = fh.WriteString(job1)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -427,7 +427,7 @@ unsedVar2 = "from-varfile"
 func TestJobGetter_HTTPServer(t *testing.T) {
 	ci.Parallel(t)
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, job)
+		fmt.Fprintf(w, job1)
 	})
 	go http.ListenAndServe("127.0.0.1:12345", nil)
 

--- a/command/job_stop_test.go
+++ b/command/job_stop_test.go
@@ -102,30 +102,29 @@ func TestStopCommand_Fails(t *testing.T) {
 	cmd := &JobStopCommand{Meta: Meta{Ui: ui}}
 
 	// Fails on misuse
-	if code := cmd.Run([]string{"some", "bad", "args"}); code != 1 {
-		t.Fatalf("expected exit code 1, got: %d", code)
-	}
-	if out := ui.ErrorWriter.String(); !strings.Contains(out, commandErrorText(cmd)) {
-		t.Fatalf("expected help output, got: %s", out)
-	}
+	code := cmd.Run([]string{"-some", "-bad", "-args"})
+	must.One(t, code)
+
+	out := ui.ErrorWriter.String()
+	must.StrContains(t, out, "flag provided but not defined: -some")
+
 	ui.ErrorWriter.Reset()
 
 	// Fails on nonexistent job ID
-	if code := cmd.Run([]string{"-address=" + url, "nope"}); code != 1 {
-		t.Fatalf("expect exit 1, got: %d", code)
-	}
-	if out := ui.ErrorWriter.String(); !strings.Contains(out, "No job(s) with prefix or id") {
-		t.Fatalf("expect not found error, got: %s", out)
-	}
+	code = cmd.Run([]string{"-address=" + url, "nope"})
+	must.One(t, code)
+
+	out = ui.ErrorWriter.String()
+	must.StrContains(t, out, "No job(s) with prefix or id")
+
 	ui.ErrorWriter.Reset()
 
 	// Fails on connection failure
-	if code := cmd.Run([]string{"-address=nope", "nope"}); code != 1 {
-		t.Fatalf("expected exit code 1, got: %d", code)
-	}
-	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Error deregistering job") {
-		t.Fatalf("expected failed query error, got: %s", out)
-	}
+	code = cmd.Run([]string{"-address=nope", "nope"})
+	must.One(t, code)
+
+	out = ui.ErrorWriter.String()
+	must.StrContains(t, out, "Error finding jobs with prefix: nope")
 }
 
 func TestStopCommand_AutocompleteArgs(t *testing.T) {

--- a/command/job_stop_test.go
+++ b/command/job_stop_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
 	"github.com/shoenig/test/must"
-	"github.com/stretchr/testify/assert"
 )
 
 var _ cli.Command = (*JobStopCommand)(nil)
@@ -118,7 +117,6 @@ func TestStopCommand_Fails(t *testing.T) {
 
 func TestStopCommand_AutocompleteArgs(t *testing.T) {
 	ci.Parallel(t)
-	assert := assert.New(t)
 
 	srv, _, url := testServer(t, true, nil)
 	defer srv.Shutdown()
@@ -129,13 +127,13 @@ func TestStopCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}
 	predictor := cmd.AutocompleteArgs()
 
 	res := predictor.Predict(args)
-	assert.Equal(1, len(res))
-	assert.Equal(j.ID, res[0])
+	must.Len(t, 1, res)
+	must.Eq(t, j.ID, res[0])
 }


### PR DESCRIPTION
This PR refactors / fixes the StopCommand test that runs 10 jobs and then
passes them all to one invokation of 'job stop'. Never actually dug into why
the previous test implementation was failing, but I didn't like the async setup
hoop jumping anyway.

Also fixes `TestStopCommand_Fails` failures, where the error messages from `job stop` 
are different now (also due to https://github.com/hashicorp/nomad/pull/12582)

Closes https://github.com/hashicorp/nomad/issues/15575