### PR TITLE
Disallows variables at exactly nomad/job-templates

### DIFF
--- a/nomad/structs/variables.go
+++ b/nomad/structs/variables.go
@@ -168,6 +168,8 @@ func (v VariableDecrypted) Validate() error {
 	switch {
 	case len(parts) == 1 && parts[0] == "nomad":
 		return fmt.Errorf("\"nomad\" is a reserved top-level directory path, but you may write variables to \"nomad/jobs\", \"nomad/job-templates\", or below")
+	case len(parts) == 2 && parts[0] == "nomad" && parts[1] == "job-templates":
+		return fmt.Errorf("\"nomad/job-templates\" is a reserved directory path, but you may write variables to below, for example, \"nomad/job-templates/template-name\"")
 	case len(parts) >= 2 && parts[0] == "nomad" && parts[1] != "jobs" && parts[1] != "job-templates":
 		return fmt.Errorf("only paths at \"nomad/jobs\" or \"nomad/job-templates\" and below are valid paths under the top-level \"nomad\" directory")
 	}

--- a/nomad/structs/variables.go
+++ b/nomad/structs/variables.go
@@ -157,21 +157,8 @@ var (
 
 func (v VariableDecrypted) Validate() error {
 
-	if len(v.Path) == 0 {
-		return fmt.Errorf("variable requires path")
-	}
-	if !validVariablePath.MatchString(v.Path) {
-		return fmt.Errorf("invalid path %q", v.Path)
-	}
-
-	parts := strings.Split(v.Path, "/")
-	switch {
-	case len(parts) == 1 && parts[0] == "nomad":
-		return fmt.Errorf("\"nomad\" is a reserved top-level directory path, but you may write variables to \"nomad/jobs\", \"nomad/job-templates\", or below")
-	case len(parts) == 2 && parts[0] == "nomad" && parts[1] == "job-templates":
-		return fmt.Errorf("\"nomad/job-templates\" is a reserved directory path, but you may write variables to below, for example, \"nomad/job-templates/template-name\"")
-	case len(parts) >= 2 && parts[0] == "nomad" && parts[1] != "jobs" && parts[1] != "job-templates":
-		return fmt.Errorf("only paths at \"nomad/jobs\" or \"nomad/job-templates\" and below are valid paths under the top-level \"nomad\" directory")
+	if v.Namespace == AllNamespacesSentinel {
+		return errors.New("can not target wildcard (\"*\")namespace")
 	}
 
 	if len(v.Items) == 0 {
@@ -180,10 +167,47 @@ func (v VariableDecrypted) Validate() error {
 	if v.Items.Size() > maxVariableSize {
 		return errors.New("variables are limited to 16KiB in total size")
 	}
-	if v.Namespace == AllNamespacesSentinel {
-		return errors.New("can not target wildcard (\"*\")namespace")
+
+	if err := validatePath(v.Path); err != nil {
+		return err
 	}
+
 	return nil
+}
+
+func validatePath(path string) error {
+	if len(path) == 0 {
+		return fmt.Errorf("variable requires path")
+	}
+	if !validVariablePath.MatchString(path) {
+		return fmt.Errorf("invalid path %q", path)
+	}
+
+	parts := strings.Split(path, "/")
+
+	if parts[0] != "nomad" {
+		return nil
+	}
+
+	// Don't allow a variable with path "nomad"
+	if len(parts) == 1 {
+		return fmt.Errorf("\"nomad\" is a reserved top-level directory path, but you may write variables to \"nomad/jobs\", \"nomad/job-templates\", or below")
+	}
+
+	switch {
+	case parts[1] == "jobs":
+		// Any path including "nomad/jobs" is valid
+		return nil
+	case parts[1] == "job-templates" && len(parts) == 3:
+		// Paths including "nomad/job-templates" is valid, provided they have single further path part
+		return nil
+	case parts[1] == "job-templates":
+		// Disallow exactly nomad/job-templates with no further paths
+		return fmt.Errorf("\"nomad/job-templates\" is a reserved directory path, but you may write variables at the level below it, for example, \"nomad/job-templates/template-name\"")
+	default:
+		// Disallow arbitrary sub-paths beneath nomad/
+		return fmt.Errorf("only paths at \"nomad/jobs\" or \"nomad/job-templates\" and below are valid paths under the top-level \"nomad\" directory")
+	}
 }
 
 func (sv *VariableDecrypted) Canonicalize() {

--- a/nomad/structs/variables_test.go
+++ b/nomad/structs/variables_test.go
@@ -54,7 +54,7 @@ func TestStructs_VariableDecrypted_Validate(t *testing.T) {
 		{path: "example/_-~/whatever", ok: true},
 		{path: "example/@whatever"},
 		{path: "example/what.ever"},
-		{path: "nomad/job-templates", ok: true},
+		{path: "nomad/job-templates"},
 		{path: "nomad/job-templates/whatever", ok: true},
 	}
 	for _, tc := range testCases {

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -67,7 +67,7 @@ export default class VariableFormComponent extends Component {
       this.path?.startsWith('nomad/') &&
       !(
         this.path?.startsWith('nomad/jobs') ||
-        this.path?.startsWith('nomad/job-templates')
+        (this.path?.startsWith('nomad/job-templates') && trimPath([this.path]) !== "nomad/job-templates")
       );
     return !!this.JSONError || !this.path || disallowedPath;
   }


### PR DESCRIPTION
Realized the existing code would let you write to `nomad/job-templates` with no suffix. This disallows writing there but allows you to write to `nomad/job-templates/foo`.

In so doing, refactored the switch statement for path name error handling.