### PR TITLE
ui:  update `VariableSerializer` normalize method

### DIFF
--- a/ui/app/serializers/variable.js
+++ b/ui/app/serializers/variable.js
@@ -8,6 +8,14 @@ export default class VariableSerializer extends ApplicationSerializer {
   normalize(typeHash, hash) {
     // ID is a composite of both the job ID and the namespace the job is in
     hash.ID = `${hash.Path}@${hash.Namespace || 'default'}`;
+
+    hash.KeyValues = Object.entries(hash.Items).map(([key, value]) => {
+      return {
+        key,
+        value,
+      };
+    });
+
     return super.normalize(typeHash, hash);
   }
 


### PR DESCRIPTION
The `VariableSerializer` currently does not save key/value pairs when querying multiple `Variable` records. This PR updates the `normalize` method to use the same logic in the `serialize` method to extract the `key/value` attributes form the `Items` property on `Variable` so that we can use that logic in the `jobs.run.templates.index` view where we need to visualize this data.

![image](https://user-images.githubusercontent.com/41024828/209194611-46aebae3-273d-4031-bc49-75eca115ff10.png)
