### PR TITLE
Crt builder script

### DIFF
--- a/.github/workflows/build-nomad-oss.yml
+++ b/.github/workflows/build-nomad-oss.yml
@@ -1,0 +1,170 @@
+---
+name: build_nomad
+
+# This workflow is intended to be called by the build workflow for each Nomad
+# binary that needs to be built and packaged. The ci make targets that are
+# utilized automatically determine build metadata and handle building and
+# packing Nomad.
+
+on:
+  workflow_call:
+    inputs:
+      bundle-path:
+        required: false
+        type: string
+      cgo-enabled:
+        type: string
+        default: 1
+      create-packages:
+        type: boolean
+        default: true
+      goos:
+        required: true
+        type: string
+      goarch:
+        required: true
+        type: string
+      go-tags:
+        type: string
+      go-version:
+        type: string
+      package-name:
+        type: string
+        default: nomad
+      nomad-version:
+        type: string
+        required: true
+      build-ref:
+        description: 'The git ref to build from'
+        type: string
+        default: ''
+        required: false
+      make-prerelease:
+        description: "Run prerelease to generate files"
+        type: "boolean"
+        required: false
+        default: true
+
+jobs:
+  determine-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.get-runner.outputs.runner }}
+    steps:
+      - name: Get runner
+        id: get-runner
+        run: |
+          RUNNER=""
+          if [ "${{ inputs.goos }}" == "darwin" ]; then
+            RUNNER=macos-latest
+          else
+            RUNNER="custom-linux-xxl-nomad-20.04"
+          fi
+          echo "::set-output name=runner::$RUNNER"
+      - name: Verify runner
+        run: |
+          echo "Runner: ${{ steps.get-runner.outputs.runner }}"
+
+  build:
+    needs: determine-runner
+    runs-on: ${{ needs.determine-runner.outputs.runner }}
+    name: Nomad ${{ inputs.goos }} ${{ inputs.goarch }} v${{ inputs.nomad-version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.build-ref }}
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ inputs.go-version }}
+      - name: Build Dependencies 
+        run: make deps
+      - name: Set up node and yarn
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: yarn
+          cache-dependency-path: ui/yarn.lock
+      - name: Install Yarn
+        run: |
+          npm install -g yarn
+      - name: Build prerelease
+        run: make prerelease
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.make-prerelease == 'true' }}
+      - name: Install Linux Build Utilities
+        if: ${{ inputs.goos == 'linux' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y \
+            libc6-dev-i386 \
+            libpcre3-dev \
+            linux-libc-dev:i386
+          sudo apt-get install -y \
+            binutils-aarch64-linux-gnu \
+            binutils-arm-linux-gnueabihf \
+            gcc-aarch64-linux-gnu \
+            gcc-arm-linux-gnueabihf \
+            gcc-multilib-arm-linux-gnueabihf
+      - name: Set GCC for Linux Builds
+        if: ${{ inputs.goos == 'linux' }}
+        run: |
+          if [ "${{ inputs.goarch }}" == "arm" ]; then
+            echo "CC=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
+          elif [ "${{ inputs.goarch }}" == "arm64" ]; then
+            echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          fi
+      - name: Build UI
+        run: make crt-build-ui
+      - name: Build Nomad
+        env:
+          CGO_ENABLED: ${{ inputs.cgo-enabled }}
+          GOARCH: ${{ inputs.goarch }}
+          GOOS: ${{ inputs.goos }}
+          GO_TAGS: ${{ inputs.go-tags }}
+        run: |
+          make crt-build
+          BUNDLE_PATH="${{ inputs.package-name }}_${{ inputs.nomad-version }}_${{ inputs.goos }}_${{ inputs.goarch }}.zip"
+          echo "--> Bundling pkg/* to $BUNDLE_PATH"
+          zip -r -j "$BUNDLE_PATH" pkg/
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ inputs.package-name }}_${{ inputs.nomad-version }}_${{ inputs.goos }}_${{ inputs.goarch }}.zip
+          path: ${{ inputs.package-name }}_${{ inputs.nomad-version }}_${{ inputs.goos }}_${{ inputs.goarch }}.zip
+          if-no-files-found: error
+      - name: Package Linux
+        if: ${{ inputs.goos == 'linux' }}
+        uses: hashicorp/actions-packaging-linux@v1
+        with:
+          name: ${{ github.event.repository.name }}
+          description: Nomad is an easy-to-use, flexible, and performant workload orchestrator that can deploy a mix of microservice, batch, containerized, and non-containerized applications.
+          arch: ${{ inputs.goarch }}
+          version: ${{ inputs.nomad-version }}
+          maintainer: HashiCorp
+          homepage: https://github.com/hashicorp/nomad
+          license: MPL-2.0
+          binary: "pkg/${{ inputs.package-name }}"
+          deb_depends: openssl
+          rpm_depends: openssl
+          config_dir: .release/linux/package/
+          preinstall: .release/linux/preinst
+          postinstall: .release/linux/postinst
+          postremove: .release/linux/postrm
+      - if: ${{ inputs.goos == 'linux' }}
+        name: Determine package file names
+        run: |
+          echo "RPM_PACKAGE=$(basename out/*.rpm)" >> $GITHUB_ENV
+          echo "DEB_PACKAGE=$(basename out/*.deb)" >> $GITHUB_ENV
+      - if: ${{ inputs.goos == 'linux' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.RPM_PACKAGE }}
+          path: out/${{ env.RPM_PACKAGE }}
+          if-no-files-found: error
+      - if: ${{ inputs.goos == 'linux' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.DEB_PACKAGE }}
+          path: out/${{ env.DEB_PACKAGE }}
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,3 +133,41 @@ jobs:
         package-name: ${{ needs.product-metadata.outputs.package-name }}
         nomad-version: ${{ needs.product-metadata.outputs.nomad-version }}
       secrets: inherit
+
+  # This placed here for when the Nomad team is ready to build docker images.
+  # Please reach out the RDX team for assistance or refer to the CRT Self-Serve Onboarding doc.
+
+  # build-docker-default:
+  #   name: Docker ${{ matrix.arch }} default release build
+  #   needs:
+  #     - get-product-version
+  #     - build
+  #   runs-on: [ custom, linux, xxl, 20.04 ]
+  #   strategy:
+  #     matrix:
+  #       arch: ["arm", "arm64", "386", "amd64"]
+  #   env:
+  #     repo: ${{github.event.repository.name}}
+  #     version: ${{needs.get-product-version.outputs.product-version}}
+
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Docker Build (Action)
+  #       uses: hashicorp/actions-docker-build@v1
+  #       with:
+  #         # Add smoke test here. Below is a sample smoke test that runs the built image
+  #         # and validates the version.
+  #         smoke_test: |
+  #           TEST_VERSION="$(docker run "${IMAGE_NAME}" | awk '/CLI version/{print $3}')"
+  #           if [ "${TEST_VERSION}" != "${version}" ]; then
+  #             echo "Test FAILED"
+  #             exit 1
+  #           fi
+  #           echo "Test PASSED"
+  #         version: ${{env.version}}
+  #         target: release-default
+  #         arch: ${{matrix.arch}}
+  #         tags: |
+  #           docker.io/hashicorp/${{env.repo}}:${{env.version}}
+  #           986891699432.dkr.ecr.us-east-1.amazonaws.com/hashicorp/${{env.repo}}:${{env.version}}
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,48 +82,17 @@ jobs:
         goos: [windows]
         goarch: ["386", "amd64"]
       fail-fast: true
-
-    name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.build-ref }}
-      - name: Setup go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ needs.get-go-version.outputs.go-version }}
-
-      - name: Build dependencies
-        run: make deps
-
-      - name: Setup node and yarn
-        uses: actions/setup-node@v2
-        with:
-          node-version: "14"
-          cache-dependency-path: "ui/yarn.lock"
-
-      - name: Install Yarn
-        run: |
-          npm install -g yarn
-
-      - name: Build prerelease
-        run: make prerelease
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.make-prerelease == 'true' }}
-
-      - name: Build
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          GO_TAGS: ${{ env.GO_TAGS }}
-          CGO_ENABLED: 1
-        run: |
-          make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          mv pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          path: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+    uses: ./.github/workflows/build-nomad-oss.yml
+    with:
+      create-packages: false
+      goarch: ${{ matrix.goarch }}
+      goos: ${{ matrix.goos }}
+      cgo-enabled: 1
+      go-tags: release
+      go-version: ${{ needs.product-metadata.outputs.go-version }}
+      package-name: ${{ needs.product-metadata.outputs.package-name }}
+      nomad-version: ${{ needs.product-metadata.outputs.nomad-version }}
+    secrets: inherit
 
   build-linux:
     needs: [get-go-version, get-product-version]
@@ -131,194 +100,36 @@ jobs:
     strategy:
       matrix:
         goos: [linux]
-        goarch: ["arm", "arm64", "386", "amd64"]
+        goarch: [arm, arm64, 386, amd64]
       fail-fast: true
 
-    name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.build-ref }}
-      - name: Setup go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ needs.get-go-version.outputs.go-version }}
-
-      - name: Build dependencies
-        run: make deps
-
-      - name: Setup node and yarn
-        uses: actions/setup-node@v2
-        with:
-          node-version: "14"
-          cache-dependency-path: "ui/yarn.lock"
-
-      - name: Install Yarn
-        run: |
-          npm install -g yarn
-
-      - name: Build prerelease
-        run: make prerelease
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.make-prerelease == 'true' }}
-
-      - name: Install Linux build utilties
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y software-properties-common
-          sudo dpkg --add-architecture i386
-          sudo apt-get update
-          sudo apt-get install -y \
-            libc6-dev-i386 \
-            libpcre3-dev \
-            linux-libc-dev:i386
-          sudo apt-get install -y \
-            binutils-aarch64-linux-gnu \
-            binutils-arm-linux-gnueabihf \
-            gcc-aarch64-linux-gnu \
-            gcc-arm-linux-gnueabihf \
-            gcc-multilib-arm-linux-gnueabihf
-
-      - name: Set gcc
-        run: |
-          if [ "${{ matrix.goarch }}" == "arm" ]; then
-            echo "CC=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
-          elif [ "${{ matrix.goarch }}" == "arm64" ]; then
-            echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-          fi
-
-      - name: Build
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          GO_TAGS: ${{ env.GO_TAGS }}
-          CGO_ENABLED: 1
-        run: |
-          make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          mv pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          path: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-
-      - name: Package
-        uses: hashicorp/actions-packaging-linux@v1
-        with:
-          name: ${{ env.PKG_NAME }}
-          description: "Nomad is an easy-to-use, flexible, and performant workload orchestrator that can deploy a mix of microservice, batch, containerized, and non-containerized applications."
-          arch: ${{ matrix.goarch }}
-          version: ${{ needs.get-product-version.outputs.product-version }}
-          maintainer: "HashiCorp"
-          homepage: "https://github.com/hashicorp/nomad"
-          license: "MPL-2.0"
-          binary: "pkg/${{ matrix.goos }}_${{ matrix.goarch }}/${{ env.PKG_NAME }}"
-          deb_depends: "openssl"
-          rpm_depends: "openssl"
-          config_dir: ".release/linux/package/"
-          preinstall: ".release/linux/preinst"
-          postinstall: ".release/linux/postinst"
-          postremove: ".release/linux/postrm"
-
-      - name: Set Package Names
-        run: |
-          echo "RPM_PACKAGE=$(basename out/*.rpm)" >> $GITHUB_ENV
-          echo "DEB_PACKAGE=$(basename out/*.deb)" >> $GITHUB_ENV
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.RPM_PACKAGE }}
-          path: out/${{ env.RPM_PACKAGE }}
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.DEB_PACKAGE }}
-          path: out/${{ env.DEB_PACKAGE }}
+    uses: ./.github/workflows/build-nomad-oss.yml
+    with:
+      goarch: ${{ matrix.goarch }}
+      goos: ${{ matrix.goos }}
+      go-tags: release
+      cgo-enabled: 1
+      go-version: ${{ needs.product-metadata.outputs.go-version }}
+      package-name: ${{ needs.product-metadata.outputs.package-name }}
+      nomad-version: ${{ needs.product-metadata.outputs.nomad-version }}
+    secrets: inherit
 
   build-darwin:
-    needs: [get-go-version, get-product-version]
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        goos: [darwin]
-        goarch: ["arm64", "amd64"]
-      fail-fast: true
-
-    name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.build-ref }}
-
-      - name: Setup go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ needs.get-go-version.outputs.go-version }}
-
-      - name: Build dependencies
-        run: make deps
-
-      - name: Setup node and yarn
-        uses: actions/setup-node@v2
-        with:
-          node-version: "14"
-          cache-dependency-path: "ui/yarn.lock"
-
-      - name: Install Yarn
-        run: |
-          npm install -g yarn
-
-      - name: Build prerelease
-        run: make prerelease
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.make-prerelease == 'true' }}
-
-      - name: Build
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          GO_TAGS: "${{ env.GO_TAGS }} netcgo"
-          CGO_ENABLED: 1
-        run: |
-          make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          mv pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          path: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-
-  # This placed here for when the Nomad team is ready to build docker images.
-  # Please reach out the RDX team for assistance or refer to the CRT Self-Serve Onboarding doc.
-
-  # build-docker-default:
-  #   name: Docker ${{ matrix.arch }} default release build
-  #   needs:
-  #     - get-product-version
-  #     - build
-  #   runs-on: [ custom, linux, xxl, 20.04 ]
-  #   strategy:
-  #     matrix:
-  #       arch: ["arm", "arm64", "386", "amd64"]
-  #   env:
-  #     repo: ${{github.event.repository.name}}
-  #     version: ${{needs.get-product-version.outputs.product-version}}
-
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Docker Build (Action)
-  #       uses: hashicorp/actions-docker-build@v1
-  #       with:
-  #         # Add smoke test here. Below is a sample smoke test that runs the built image
-  #         # and validates the version.
-  #         smoke_test: |
-  #           TEST_VERSION="$(docker run "${IMAGE_NAME}" | awk '/CLI version/{print $3}')"
-  #           if [ "${TEST_VERSION}" != "${version}" ]; then
-  #             echo "Test FAILED"
-  #             exit 1
-  #           fi
-  #           echo "Test PASSED"
-  #         version: ${{env.version}}
-  #         target: release-default
-  #         arch: ${{matrix.arch}}
-  #         tags: |
-  #           docker.io/hashicorp/${{env.repo}}:${{env.version}}
-  #           986891699432.dkr.ecr.us-east-1.amazonaws.com/hashicorp/${{env.repo}}:${{env.version}}
+      name: Build Nomad Darwin
+      needs: product-metadata
+      strategy:
+        matrix:
+          goos: [darwin]
+          goarch: [arm64, amd64]
+        fail-fast: true
+      uses: ./.github/workflows/build-nomad-oss.yml
+      with:
+        create-packages: false
+        goarch: ${{ matrix.goarch }}
+        goos: ${{ matrix.goos }}
+        go-tags: release netcgo
+        cgo-enabled: 1
+        go-version: ${{ needs.product-metadata.outputs.go-version }}
+        package-name: ${{ needs.product-metadata.outputs.package-name }}
+        nomad-version: ${{ needs.product-metadata.outputs.nomad-version }}
+      secrets: inherit

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -14,6 +14,7 @@ project "nomad" {
     release_branches = [
       "main",
       "release/**",
+      "crt-builder-script",
     ]
   }
 }

--- a/scripts/crt-builder.sh
+++ b/scripts/crt-builder.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+
+# The crt-builder is used to detemine build metadata and create Nomad builds.
+# We use it in build-nomad.yml for building release artifacts with CRT. 
+
+set -euo pipefail
+
+# We don't want to get stuck in some kind of interactive pager
+export GIT_PAGER=cat
+
+# Get the full version information
+function version() {
+  local version
+  local prerelease
+  local metadata
+
+  version=$(version_base)
+  prerelease=$(version_pre)
+  metadata=$(version_metadata)
+
+  if [ -n "$metadata" ] && [ -n "$prerelease" ]; then
+    echo "$version-$prerelease+$metadata"
+  elif [ -n "$metadata" ]; then
+    echo "$version+$metadata"
+  elif [ -n "$prerelease" ]; then
+    echo "$version-$prerelease"
+  else
+    echo "$version"
+  fi
+}
+
+# Get the base version
+function version_base() {
+  : "${NOMAD_VERSION:=""}"
+
+  if [ -n "$NOMAD_VERSION" ]; then
+    echo "$NOMAD_VERSION"
+    return
+  fi
+
+  : "${VERSION_FILE:=$(repo_root)/version/version.go}"
+  awk '$1 == "Version" && $2 == "=" { gsub(/"/, "", $3); print $3 }' < "$VERSION_FILE"
+}
+
+# Get the version pre-release
+function version_pre() {
+  : "${NOMAD_PRERELEASE:=""}"
+
+  if [ -n "$NOMAD_PRERELEASE" ]; then
+    echo "$NOMAD_PRERELEASE"
+    return
+  fi
+
+  : "${VERSION_FILE:=$(repo_root)/version/version.go}"
+  awk '$1 == "VersionPrerelease" && $2 == "=" { gsub(/"/, "", $3); print $3 }' < "$VERSION_FILE"
+}
+
+# Get the version metadata, which is commonly the edition
+function version_metadata() {
+  : "${NOMAD_METADATA:=""}"
+
+  if [ -n "$NOMAD_METADATA" ]; then
+    echo "$NOMAD_METADATA"
+    return
+  fi
+
+  : "${VERSION_FILE:=$(repo_root)/version/version.go}"
+  awk '$1 == "VersionMetadata" && $2 == "=" { gsub(/"/, "", $3); print $3 }' < "$VERSION_FILE"
+}
+
+# Get the build date from the latest commit since it can be used across all
+# builds
+function build_date() {
+  # It's tricky to do an RFC3339 format in a cross platform way, so we hardcode UTC
+  : "${DATE_FORMAT:="%Y-%m-%dT%H:%M:%SZ"}"
+  git show --no-show-signature -s --format=%cd --date=format:"$DATE_FORMAT" HEAD
+}
+
+# Get the revision, which is the latest commit SHA
+function build_revision() {
+  git rev-parse HEAD
+}
+
+# Determine our repository by looking at our origin URL
+function repo() {
+  basename -s .git "$(git config --get remote.origin.url)"
+}
+
+# Determine the root directory of the repository
+function repo_root() {
+  git rev-parse --show-toplevel
+}
+
+# Determine the artifact basename based on metadata
+function artifact_basename() {
+  : "${PKG_NAME:="nomad"}"
+  : "${GOOS:=$(go env GOOS)}"
+  : "${GOARCH:=$(go env GOARCH)}"
+
+  echo "${PKG_NAME}_$(version)_${GOOS}_${GOARCH}"
+}
+
+# Build the UI
+function build_ui() {
+  local repo_root
+  repo_root=$(repo_root)
+
+  pushd "$repo_root"
+  mkdir -p ui/
+  popd
+  pushd "$repo_root/ui"
+  npm install -g yarn
+  popd
+}
+
+# Build Nomad
+function build() {
+  local version
+  local revision
+  local prerelease
+  local build_date
+  local ldflags
+  local msg
+
+  # Get or set our basic build metadata
+  version=$(version_base)
+  revision=$(build_revision)
+  metadata=$(version_metadata)
+  prerelease=$(version_pre)
+  build_date=$(build_date)
+  : "${GO_TAGS:=""}"
+  : "${KEEP_SYMBOLS:=""}"
+
+  # Build our ldflags
+  msg="--> Building Nomad v$version, revision $revision, built $build_date"
+
+  # Strip the symbol and dwarf information by default
+  if [ -n "$KEEP_SYMBOLS" ]; then
+    ldflags=""
+  else
+    ldflags="-s -w "
+  fi
+
+  ldflags="${ldflags}-X github.com/hashicorp/nomad/version.Version=$version -X github.com/hashicorp/nomad/version.GitCommit=$revision -X github.com/hashicorp/nomad/version.BuildDate=$build_date"
+
+  if [ -n "$prerelease" ]; then
+    msg="${msg}, prerelease ${prerelease}"
+    ldflags="${ldflags} -X github.com/hashicorp/nomad/version.VersionPrerelease=$prerelease"
+  fi
+
+  if [ -n "$metadata" ]; then
+    msg="${msg}, metadata ${NOMAD_METADATA}"
+    ldflags="${ldflags} -X github.com/hashicorp/nomad/version.VersionMetadata=$metadata"
+  fi
+
+  # Build Nomad
+  echo "$msg"
+  pushd "$(repo_root)"
+  mkdir -p pkg
+  mkdir -p out
+  set -x
+  go build -v -tags "$GO_TAGS" -ldflags "$ldflags" -o pkg/
+  echo "HERE"
+  contents=$(ls pkg)
+  echo "Contents: $contents"
+  set +x
+  popd
+}
+
+# Bundle the pkg directory
+function bundle() {
+  : "${BUNDLE_PATH:=$(repo_root)/nomad.zip}"
+  echo "--> Bundling pkg/* to $BUNDLE_PATH"
+  zip -r -j "$BUNDLE_PATH" pkg/
+}
+
+# Prepare legal requirements for packaging
+function prepare_legal() {
+  : "${PKG_NAME:="nomad"}"
+
+  pushd "$(repo_root)"
+  mkdir -p pkg
+  curl -o pkg/EULA.txt https://eula.hashicorp.com/EULA.txt
+  curl -o pkg/TermsOfEvaluation.txt https://eula.hashicorp.com/TermsOfEvaluation.txt
+  mkdir -p ".release/linux/package/usr/share/doc/$PKG_NAME"
+  cp pkg/EULA.txt ".release/linux/package/usr/share/doc/$PKG_NAME/EULA.txt"
+  cp pkg/TermsOfEvaluation.txt ".release/linux/package/usr/share/doc/$PKG_NAME/TermsOfEvaluation.txt"
+  popd
+}
+
+# Run the CRT Builder
+function main() {
+  case $1 in
+  artifact-basename)
+    artifact_basename
+  ;;
+  build)
+    build
+  ;;
+  build-ui)
+    build_ui
+  ;;
+  bundle)
+    bundle $2
+  ;;
+  date)
+    build_date
+  ;;
+  prepare-legal)
+    prepare_legal
+  ;;
+  revision)
+    build_revision
+  ;;
+  version)
+    version
+  ;;
+  version-base)
+    version_base
+  ;;
+  version-pre)
+    version_pre
+  ;;
+  version-meta)
+    version_metadata
+  ;;
+  *)
+    echo "unknown sub-command" >&2
+    exit 1
+  ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
### Justification

Reduces oss->ent merge conflicts by separating oss and ent builds into separate build workflow files and to be able to run builds with the same instructions locally and in CI via the `crt-builder` script. See [JIRA](https://hashicorp.atlassian.net/browse/RELENG-329) context.

### Summary

This PR includes refactoring build logic from `build.yml` into separate build files for oss and ent: `build-nomad-oss.yml` and `build-nomad-ent.yml`, calling respective build processes from `build.yml`, and refactoring build logic into `scripts/crt-builder.sh` for use by a make target. 

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [x] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_