### PR TITLE
fix: Make agent syslog log level inherit from Nomad agent log

### DIFF
--- a/.changelog/15625.txt
+++ b/.changelog/15625.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-fix: Make agent syslog log level follow log_level config
+agent: Make agent syslog log level follow log_level config
 ```

--- a/.changelog/15625.txt
+++ b/.changelog/15625.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+fix: Make agent syslog log level follow log_level config
+```

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -473,12 +473,14 @@ func SetupLoggers(ui cli.Ui, config *Config) (*logutils.LevelFilter, *gatedwrite
 	// Create a log writer, and wrap a logOutput around it
 	writers := []io.Writer{logFilter}
 	logLevelMap := map[string]gsyslog.Priority{
-		"OFF":   gsyslog.LOG_EMERG,
 		"ERROR": gsyslog.LOG_ERR,
 		"WARN":  gsyslog.LOG_WARNING,
 		"INFO":  gsyslog.LOG_INFO,
 		"DEBUG": gsyslog.LOG_DEBUG,
 		"TRACE": gsyslog.LOG_DEBUG,
+	}
+	if config.LogLevel == "OFF" {
+		config.EnableSyslog = false
 	}
 	// Check if syslog is enabled
 	if config.EnableSyslog {

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -472,10 +472,18 @@ func SetupLoggers(ui cli.Ui, config *Config) (*logutils.LevelFilter, *gatedwrite
 
 	// Create a log writer, and wrap a logOutput around it
 	writers := []io.Writer{logFilter}
-
+	logLevelMap := map[string]gsyslog.Priority{
+		"OFF":   gsyslog.LOG_EMERG,
+		"ERROR": gsyslog.LOG_ERR,
+		"WARN":  gsyslog.LOG_WARNING,
+		"INFO":  gsyslog.LOG_INFO,
+		"DEBUG": gsyslog.LOG_DEBUG,
+		"TRACE": gsyslog.LOG_DEBUG,
+	}
 	// Check if syslog is enabled
 	if config.EnableSyslog {
-		l, err := gsyslog.NewLogger(gsyslog.LOG_NOTICE, config.SyslogFacility, "nomad")
+		ui.Output(fmt.Sprintf("Config enable_syslog is `true` with log_level=%v", config.LogLevel))
+		l, err := gsyslog.NewLogger(logLevelMap[config.LogLevel], config.SyslogFacility, "nomad")
 		if err != nil {
 			ui.Error(fmt.Sprintf("Syslog setup failed: %v", err))
 			return nil, nil, nil

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -472,6 +472,7 @@ func SetupLoggers(ui cli.Ui, config *Config) (*logutils.LevelFilter, *gatedwrite
 
 	// Create a log writer, and wrap a logOutput around it
 	writers := []io.Writer{logFilter}
+	logLevel := strings.ToUpper(config.LogLevel)
 	logLevelMap := map[string]gsyslog.Priority{
 		"ERROR": gsyslog.LOG_ERR,
 		"WARN":  gsyslog.LOG_WARNING,
@@ -479,13 +480,13 @@ func SetupLoggers(ui cli.Ui, config *Config) (*logutils.LevelFilter, *gatedwrite
 		"DEBUG": gsyslog.LOG_DEBUG,
 		"TRACE": gsyslog.LOG_DEBUG,
 	}
-	if config.LogLevel == "OFF" {
+	if logLevel == "OFF" {
 		config.EnableSyslog = false
 	}
 	// Check if syslog is enabled
 	if config.EnableSyslog {
 		ui.Output(fmt.Sprintf("Config enable_syslog is `true` with log_level=%v", config.LogLevel))
-		l, err := gsyslog.NewLogger(logLevelMap[config.LogLevel], config.SyslogFacility, "nomad")
+		l, err := gsyslog.NewLogger(logLevelMap[logLevel], config.SyslogFacility, "nomad")
 		if err != nil {
 			ui.Error(fmt.Sprintf("Syslog setup failed: %v", err))
 			return nil, nil, nil

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -165,7 +165,8 @@ testing.
   diagnostic information about Nomad's internals.
 
 - `enable_syslog` `(bool: false)` - Specifies if the agent should log to syslog.
-  This option only works on Unix based systems.
+  This option only works on Unix based systems. The log level inherits from
+  the Nomad agent log set in `log_level`
 
 - `http_api_response_headers` `(map<string|string>: nil)` - Specifies
   user-defined headers to add to the HTTP API responses.


### PR DESCRIPTION
Fix issue : #15087

Hi Nomad Core Dev team,

Below is my attempt to fix the issue mentioned above. Imo, we can either make an extra argument for syslog log level or make it inherit from Nomad Agent existing one. This PR is using the latter approach because there is not need to use the former for a rarely used feature.

Would appreciate getting your feedback on this PR, especially on a few issues:
- On the mapping between gsyslog and Nomad Agent log, I'm not entirely sure about how `OFF` and `TRACE` in Nomad log_level maps to [gsyslog](https://pkg.go.dev/log/syslog) log level
- I attempted to write one similar to [TestCommand_Args()](https://github.com/hashicorp/nomad/blob/v1.4.3/command/agent/command_test.go#L26-L98) but the log is not captured by either `ui.ErrorWriter` or `ui.OutputWriter`. Please let me know if a unit test is needed or there are better ways to structure the unit test

