### PR TITLE
docs: fix system sample request

### DIFF
--- a/website/content/api-docs/system.mdx
+++ b/website/content/api-docs/system.mdx
@@ -54,5 +54,6 @@ The table below shows this endpoint's support for
 
 ```shell-session
 $ curl \
+    --request PUT \
     https://localhost:4646/v1/system/reconcile/summaries
 ```


### PR DESCRIPTION
added the missing PUT http method for /v1/system/reconcile/summaries
