### PR TITLE
csi: Fix parsing of '=' in secrets at command line and HTTP

### DIFF
--- a/.changelog/15670.txt
+++ b/.changelog/15670.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where secrets that include '=' were incorrectly rejected
+```

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -409,7 +409,7 @@ func parseCSISecrets(req *http.Request) structs.CSISecrets {
 	secrets := map[string]string{}
 	secretkvs := strings.Split(secretsHeader, ",")
 	for _, secretkv := range secretkvs {
-		kv := strings.Split(secretkv, "=")
+		kv := strings.SplitN(secretkv, "=", 2)
 		if len(kv) == 2 {
 			secrets[kv[0]] = kv[1]
 		}

--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -409,9 +409,8 @@ func parseCSISecrets(req *http.Request) structs.CSISecrets {
 	secrets := map[string]string{}
 	secretkvs := strings.Split(secretsHeader, ",")
 	for _, secretkv := range secretkvs {
-		kv := strings.SplitN(secretkv, "=", 2)
-		if len(kv) == 2 {
-			secrets[kv[0]] = kv[1]
+		if key, value, found := strings.Cut(secretkv, "="); found {
+			secrets[key] = value
 		}
 	}
 	if len(secrets) == 0 {

--- a/command/agent/csi_endpoint_test.go
+++ b/command/agent/csi_endpoint_test.go
@@ -59,6 +59,8 @@ func TestHTTP_CSIParseSecrets(t *testing.T) {
 			structs.CSISecrets(map[string]string{"one": "overwrite"})},
 		{"one=value_one,two=value_two",
 			structs.CSISecrets(map[string]string{"one": "value_one", "two": "value_two"})},
+		{"one=value_one=two,two=value_two",
+			structs.CSISecrets(map[string]string{"one": "value_one=two", "two": "value_two"})},
 	}
 	for _, tc := range testCases {
 		req, _ := http.NewRequest("GET", "/v1/plugin/csi/foo", nil)

--- a/command/volume_delete.go
+++ b/command/volume_delete.go
@@ -104,7 +104,7 @@ func (c *VolumeDeleteCommand) Run(args []string) int {
 
 	secrets := api.CSISecrets{}
 	for _, kv := range secretsArgs {
-		s := strings.Split(kv, "=")
+		s := strings.SplitN(kv, "=", 2)
 		if len(s) == 2 {
 			secrets[s[0]] = s[1]
 		} else {

--- a/command/volume_delete.go
+++ b/command/volume_delete.go
@@ -104,9 +104,8 @@ func (c *VolumeDeleteCommand) Run(args []string) int {
 
 	secrets := api.CSISecrets{}
 	for _, kv := range secretsArgs {
-		s := strings.SplitN(kv, "=", 2)
-		if len(s) == 2 {
-			secrets[s[0]] = s[1]
+		if key, value, found := strings.Cut(kv, "="); found {
+			secrets[key] = value
 		} else {
 			c.Ui.Error("Secret must be in the format: -secret key=value")
 			return 1

--- a/command/volume_snapshot_create.go
+++ b/command/volume_snapshot_create.go
@@ -117,9 +117,8 @@ func (c *VolumeSnapshotCreateCommand) Run(args []string) int {
 
 	secrets := api.CSISecrets{}
 	for _, kv := range secretsArgs {
-		s := strings.SplitN(kv, "=", 2)
-		if len(s) == 2 {
-			secrets[s[0]] = s[1]
+		if key, value, found := strings.Cut(kv, "="); found {
+			secrets[key] = value
 		} else {
 			c.Ui.Error("Secret must be in the format: -secret key=value")
 			return 1
@@ -128,9 +127,8 @@ func (c *VolumeSnapshotCreateCommand) Run(args []string) int {
 
 	params := map[string]string{}
 	for _, kv := range parametersArgs {
-		p := strings.SplitN(kv, "=", 2)
-		if len(p) == 2 {
-			params[p[0]] = p[1]
+		if key, value, found := strings.Cut(kv, "="); found {
+			params[key] = value
 		}
 	}
 

--- a/command/volume_snapshot_create.go
+++ b/command/volume_snapshot_create.go
@@ -117,7 +117,7 @@ func (c *VolumeSnapshotCreateCommand) Run(args []string) int {
 
 	secrets := api.CSISecrets{}
 	for _, kv := range secretsArgs {
-		s := strings.Split(kv, "=")
+		s := strings.SplitN(kv, "=", 2)
 		if len(s) == 2 {
 			secrets[s[0]] = s[1]
 		} else {
@@ -128,7 +128,7 @@ func (c *VolumeSnapshotCreateCommand) Run(args []string) int {
 
 	params := map[string]string{}
 	for _, kv := range parametersArgs {
-		p := strings.Split(kv, "=")
+		p := strings.SplitN(kv, "=", 2)
 		if len(p) == 2 {
 			params[p[0]] = p[1]
 		}

--- a/command/volume_snapshot_delete.go
+++ b/command/volume_snapshot_delete.go
@@ -94,9 +94,8 @@ func (c *VolumeSnapshotDeleteCommand) Run(args []string) int {
 
 	secrets := api.CSISecrets{}
 	for _, kv := range secretsArgs {
-		s := strings.SplitN(kv, "=", 2)
-		if len(s) == 2 {
-			secrets[s[0]] = s[1]
+		if key, value, found := strings.Cut(kv, "="); found {
+			secrets[key] = value
 		} else {
 			c.Ui.Error("Secret must be in the format: -secret key=value")
 			return 1

--- a/command/volume_snapshot_delete.go
+++ b/command/volume_snapshot_delete.go
@@ -94,7 +94,7 @@ func (c *VolumeSnapshotDeleteCommand) Run(args []string) int {
 
 	secrets := api.CSISecrets{}
 	for _, kv := range secretsArgs {
-		s := strings.Split(kv, "=")
+		s := strings.SplitN(kv, "=", 2)
 		if len(s) == 2 {
 			secrets[s[0]] = s[1]
 		} else {

--- a/command/volume_snapshot_list.go
+++ b/command/volume_snapshot_list.go
@@ -140,9 +140,8 @@ func (c *VolumeSnapshotListCommand) Run(args []string) int {
 
 	secrets := api.CSISecrets{}
 	for _, kv := range secretsArgs {
-		s := strings.SplitN(kv, "=", 2)
-		if len(s) == 2 {
-			secrets[s[0]] = s[1]
+		if key, value, found := strings.Cut(kv, "="); found {
+			secrets[key] = value
 		} else {
 			c.Ui.Error("Secret must be in the format: -secret key=value")
 			return 1

--- a/command/volume_snapshot_list.go
+++ b/command/volume_snapshot_list.go
@@ -140,7 +140,7 @@ func (c *VolumeSnapshotListCommand) Run(args []string) int {
 
 	secrets := api.CSISecrets{}
 	for _, kv := range secretsArgs {
-		s := strings.Split(kv, "=")
+		s := strings.SplitN(kv, "=", 2)
 		if len(s) == 2 {
 			secrets[s[0]] = s[1]
 		} else {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/15663

The command line flag parsing and the HTTP header parsing for CSI secrets incorrectly split at more than one '=' rune, making it impossible to use secrets that included that rune.