### PR TITLE
tests: fix assertion for slice length

### DIFF
--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -1537,7 +1537,7 @@ func TestJobs_Evaluations(t *testing.T) {
 	// Check that we got the evals back, evals are in order most recent to least recent
 	// so the last eval is the original registered eval
 	idx := len(evals) - 1
-	must.Len(t, 1, evals)
+	must.Positive(t, len(evals))
 	must.Eq(t, resp.EvalID, evals[idx].ID)
 }
 


### PR DESCRIPTION
This assertions got borked during the refactoring; should be at least one element, not exactly one element.

Closes https://github.com/hashicorp/nomad/issues/15671