### PR TITLE
CI: run tests on pull_request and push to main/release

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -1,6 +1,6 @@
 name: Core CI Tests
 on:
-  push:
+  pull_request:
     paths-ignore:
       - 'README.md'
       - 'CHANGELOG.md'
@@ -17,6 +17,27 @@ on:
       - 'terraform/**'
       - 'ui/**'
       - 'website/**'
+  push:
+    branches:
+      - main
+      - release/**
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.changelog/**'
+      - '.tours/**'
+      - 'contributing/**'
+      - 'demo/**'
+      - 'dev/**'
+      - 'e2e/terraform/**'
+      - 'e2e/ui/**'
+      - 'integrations/**'
+      - 'pkg/**'
+      - 'scripts/**'
+      - 'terraform/**'
+      - 'ui/**'
+      - 'website/**'
+
 env:
   VERBOSE: 1
   GOTESTARCH: amd64


### PR DESCRIPTION
Running tests `on: push` prevents GitHub from showing the workflow approval button, which prevents tests from being run on community-contributed (or even just non-Nomad HashiCorp folks) PRs. Running `on: pull_request` automatically picks up opened, reopened, and synchronize hooks (where "synchronize" means a push to HEAD on the PR's branch, so that'll pick up rebases and updates).

But we also want to run tests on `main` and the various `release` backport
branches, so retain a `on: push` for those.

Closes https://github.com/hashicorp/nomad/issues/15632