### PR TITLE
docs: clarify shutdown_delay jobspec param and service behaviour.

### DIFF
--- a/website/content/docs/job-specification/group.mdx
+++ b/website/content/docs/job-specification/group.mdx
@@ -66,20 +66,21 @@ job "docs" {
   all tasks in this group. If omitted, a default policy exists for each job
   type, which can be found in the [restart stanza documentation][restart].
 
-- `service` <code>([Service][]: nil)</code> - Specifies integrations with
-  [Consul](/docs/configuration/consul) for service discovery.
-  Nomad automatically registers each service when an allocation
-  is started and de-registers them when the allocation is destroyed.
+- `service` <code>([Service][]: nil)</code> - Specifies integrations with Nomad
+  or [Consul](/docs/configuration/consul) for service discovery. Nomad
+  automatically registers each service when an allocation is started and
+  de-registers them when the allocation is destroyed.
 
 - `shutdown_delay` `(string: "0s")` - Specifies the duration to wait when
-  stopping a group's tasks. The delay occurs between Consul deregistration
-  and sending each task a shutdown signal. Ideally, services would fail
-  healthchecks once they receive a shutdown signal. Alternatively
+  stopping a group's tasks. The delay occurs between Consul or Nomad service
+  deregistration and sending each task a shutdown signal. Ideally, services
+  would fail health checks once they receive a shutdown signal. Alternatively,
   `shutdown_delay` may be set to give in-flight requests time to complete
   before shutting down. A group level `shutdown_delay` will run regardless
-  if there are any defined group services. In addition, tasks may have their
-  own [`shutdown_delay`](/docs/job-specification/task#shutdown_delay)
-  which waits between deregistering task services and stopping the task.
+  if there are any defined group [services](/docs/job-specification/group#service)
+  and only applies to these services. In addition, tasks may have their own
+  [`shutdown_delay`](/docs/job-specification/task#shutdown_delay) which waits
+  between de-registering task services and stopping the task.
 
 - `stop_after_client_disconnect` `(string: "")` - Specifies a duration after
   which a Nomad client will stop allocations, if it cannot communicate with the

--- a/website/content/docs/job-specification/task.mdx
+++ b/website/content/docs/job-specification/task.mdx
@@ -85,17 +85,19 @@ job "docs" {
 - `resources` <code>([Resources][]: &lt;required&gt;)</code> - Specifies the minimum
   resource requirements such as RAM, CPU and devices.
 
-- `service` <code>([Service][]: nil)</code> - Specifies integrations with
-  [Consul][] for service discovery. Nomad automatically registers when a task
+- `service` <code>([Service][]: nil)</code> - Specifies integrations with Nomad
+  or [Consul][] for service discovery. Nomad automatically registers when a task
   is started and de-registers it when the task dies.
 
 - `shutdown_delay` `(string: "0s")` - Specifies the duration to wait when
-  killing a task between removing it from Consul and sending it a shutdown
-  signal. Ideally services would fail healthchecks once they receive a shutdown
-  signal. Alternatively `shutdown_delay` may be set to give in flight requests
-  time to complete before shutting down. In addition, task groups may have their
-  own [`shutdown_delay`](/docs/job-specification/group#shutdown_delay)
-  which waits between deregistering group services and stopping tasks.
+  killing a task between removing its service registrations from Consul or Nomad,
+  and sending it a shutdown signal. Ideally services would fail health checks
+  once they receive a shutdown signal. Alternatively, `shutdown_delay` may be
+  set to give in flight requests time to complete before shutting down. This
+  `shutdown_delay` only applies to services defined at the task level by the
+  [`service`](/docs/job-specification/task#service) block. In addition, task
+  groups have their own [`shutdown_delay`](/docs/job-specification/group#shutdown_delay)
+  which waits between de-registering group services and stopping tasks.
 
 - `user` `(string: <varies>)` - Specifies the user that will run the task.
   Defaults to `nobody` for the [`exec`][exec] and [`java`][java] drivers.


### PR DESCRIPTION
Clarifies that the task and group level `shutdown_delay` parameters do not influence each other and that they apply to both Nomad and Consul service registrations.

The change also clarifies that service blocks apply to both Nomad and Consul service registrations.

Closes #15602 