### PR TITLE
e2e: disable disconnected clients test(s)

### DIFF
--- a/e2e/disconnectedclients/disconnectedclients_test.go
+++ b/e2e/disconnectedclients/disconnectedclients_test.go
@@ -26,6 +26,7 @@ type expectedAllocStatus struct {
 }
 
 func TestDisconnectedClients(t *testing.T) {
+	t.Skip("disconnected clients tests disabled for now")
 
 	nomad := e2eutil.NomadClient(t)
 	e2eutil.WaitForLeader(t, nomad)


### PR DESCRIPTION
The e2e suite is not in good shape right now; let's disable the tests that modify
agent / node state until we can get things working again. Also the one DC test
that was enabled still doesn't work anyway.
