### PR TITLE
e2e: fixup windows artifact download test cases

### DIFF
--- a/e2e/artifact/artifact_test.go
+++ b/e2e/artifact/artifact_test.go
@@ -65,7 +65,10 @@ func testWindows(t *testing.T) {
 	check("rawexec", "rawexec_file_custom")
 	check("rawexec", "rawexec_zip_default")
 	check("rawexec", "rawexec_zip_custom")
-	check("rawexec", "rawexec_git_custom")
+
+	// todo(shoenig) needs git on windows
+	// https://github.com/hashicorp/nomad/issues/15505
+	// check("rawexec", "rawexec_git_custom")
 }
 
 func testLinux(t *testing.T) {

--- a/e2e/artifact/input/artifact_windows.nomad
+++ b/e2e/artifact/input/artifact_windows.nomad
@@ -8,7 +8,7 @@ job "windows" {
   }
 
   group "rawexec" {
-    task "rawexec" {
+    task "rawexec_file_default" {
       artifact {
         source = "https://raw.githubusercontent.com/hashicorp/go-set/main/go.mod"
       }
@@ -75,6 +75,7 @@ job "windows" {
     }
 
     # TODO(shoenig) setup git in our Windows e2e client
+    # https://github.com/hashicorp/nomad/issues/15505
     #    task "rawexec_git_custom" {
     #      artifact {
     #        source      = "git::https://github.com/hashicorp/go-set"


### PR DESCRIPTION
- fix wrong task name for one case
- comment out git windows test (still need to setup git on e2e windows client)
