### PR TITLE
docker: configure restart policy for networking pause container

### DIFF
--- a/.changelog/15732.txt
+++ b/.changelog/15732.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: configure restart policy for bridge network pause container
+```

--- a/drivers/docker/network.go
+++ b/drivers/docker/network.go
@@ -130,6 +130,12 @@ func (d *Driver) createSandboxContainerConfig(allocID string, createSpec *driver
 			// Set the network mode to none which creates a network namespace
 			// with only a loopback interface.
 			NetworkMode: "none",
+
+			// Set the restart policy to unless-stopped. The pause container should
+			// never not be running until Nomad issues a stop.
+			//
+			// https://docs.docker.com/engine/reference/run/#restart-policies---restart
+			RestartPolicy: docker.RestartUnlessStopped(),
 		},
 	}, nil
 }

--- a/drivers/docker/network_test.go
+++ b/drivers/docker/network_test.go
@@ -28,7 +28,8 @@ func TestDriver_createSandboxContainerConfig(t *testing.T) {
 					Image: "gcr.io/google_containers/pause-amd64:3.1",
 				},
 				HostConfig: &docker.HostConfig{
-					NetworkMode: "none",
+					NetworkMode:   "none",
+					RestartPolicy: docker.RestartUnlessStopped(),
 				},
 			},
 			name: "no input hostname",
@@ -45,7 +46,8 @@ func TestDriver_createSandboxContainerConfig(t *testing.T) {
 					Hostname: "linux",
 				},
 				HostConfig: &docker.HostConfig{
-					NetworkMode: "none",
+					NetworkMode:   "none",
+					RestartPolicy: docker.RestartUnlessStopped(),
 				},
 			},
 			name: "supplied input hostname",


### PR DESCRIPTION
This PR modifies the configuration of the networking pause contaier to include the "unless-stopped" restart policy. The pause container should always be restored into a running state until Nomad itself issues a stop command for the container.

This is not a _perfect_ fix for #12216 but it should cover the 99% use case - where a pause container gets accidentally killed / exits for some reason. There is still a possibility where the pause container and main task container are stopped and started in the order where the bad behavior persists, but this is fundamentally unavoidable due to how docker itself abstracts and manages the underlying network namespace referenced by the containers.

Closes #12216