### PR TITLE
[ui] Show task events in the sidebar

### DIFF
--- a/.changelog/15733.txt
+++ b/.changelog/15733.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Show events alongside logs in the Task sidebar
+```

--- a/ui/app/components/task-context-sidebar.hbs
+++ b/ui/app/components/task-context-sidebar.hbs
@@ -1,6 +1,6 @@
 <Portal @target="log-sidebar-portal">
 	<div
-		class="sidebar task-context-sidebar has-subnav {{if this.isSideBarOpen "open"}}"
+		class="sidebar task-context-sidebar has-subnav {{if this.isSideBarOpen "open"}} {{if @task.events.length "has-events"}}"
 		{{on-click-outside
 			@fns.closeSidebar
 			capture=true
@@ -31,6 +31,51 @@
 				{{x-icon "cancel"}}
 			</button>
 		</header>
+		{{#if @task.events.length}}
+			<div class="boxed-section task-events">
+				<div class="boxed-section-head">
+					Recent Events
+				</div>
+				<div class="boxed-section-body is-full-bleed">
+					<ListTable
+						@source={{reverse @task.events}}
+						@class="is-striped" as |t|
+					>
+						<t.head>
+							<th class="is-3">
+								Time
+							</th>
+							<th class="is-1">
+								Type
+							</th>
+							<th>
+								Description
+							</th>
+						</t.head>
+						<t.body as |row|>
+							<tr data-test-task-event>
+								<td data-test-task-event-time>
+									{{format-ts row.model.time}}
+								</td>
+								<td data-test-task-event-type>
+									{{row.model.type}}
+								</td>
+								<td data-test-task-event-message>
+									{{#if row.model.message}}
+										{{row.model.message}}
+									{{else}}
+										<em>
+											No message
+										</em>
+									{{/if}}
+								</td>
+							</tr>
+						</t.body>
+					</ListTable>
+				</div>
+			</div>
+			<hr />
+		{{/if}}
 
 		<TaskLog
 			@allocation={{@task.allocation}}

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -105,16 +105,27 @@ $subNavOffset: 49px;
     }
   }
 
+  .task-events .boxed-section-body {
+    height: 250px;
+    overflow: auto;
+  }
+
   // Instead of trying to calculate on the fly with JS, let's use vh and offset nav and headers above.
   // We can make this a LOT more streamlined when CSS Container Queries are available.
   $sidebarTopOffset: 161px;
   $sidebarInnerPadding: 48px;
   $sidebarHeaderOffset: 74px;
   $cliHeaderOffset: 54.5px;
+  $offsetWithoutEvents: $sidebarTopOffset + $sidebarInnerPadding +
+    $sidebarHeaderOffset + $cliHeaderOffset;
+  $sidebarEventsHeight: 250px + 44px + 44px; // table + table header + horizontal rule
+
   .cli-window {
-    height: calc(
-      100vh - $sidebarTopOffset - $sidebarInnerPadding - $sidebarHeaderOffset -
-        $cliHeaderOffset
-    );
+    height: calc(100vh - $offsetWithoutEvents);
+  }
+  &.has-events {
+    .cli-window {
+      height: calc(100vh - $offsetWithoutEvents - $sidebarEventsHeight);
+    }
   }
 }

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -108,6 +108,9 @@ $subNavOffset: 49px;
   .task-events .boxed-section-body {
     height: 250px;
     overflow: auto;
+    table {
+      height: 100%;
+    }
   }
 
   // Instead of trying to calculate on the fly with JS, let's use vh and offset nav and headers above.


### PR DESCRIPTION
Shows Task Events in the Nomad UI sidebar. Accessible via Job or Task Group pages.
Resolves #15730

![image](https://user-images.githubusercontent.com/713991/211394829-4598ec03-38a7-4d39-bf83-204d254ab5fc.png)
