### PR TITLE
connect: ingress gateway validation for http hosts and wildcards

### DIFF
--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -1328,13 +1328,6 @@ func TestConsulIngressService_Validate(t *testing.T) {
 		require.EqualError(t, err, "Consul Ingress Service requires a name")
 	})
 
-	t.Run("http missing hosts", func(t *testing.T) {
-		err := (&ConsulIngressService{
-			Name: "service1",
-		}).Validate("http")
-		require.EqualError(t, err, `Consul Ingress Service requires one or more hosts when using "http" protocol`)
-	})
-
 	t.Run("tcp extraneous hosts", func(t *testing.T) {
 		err := (&ConsulIngressService{
 			Name:  "service1",
@@ -1343,25 +1336,10 @@ func TestConsulIngressService_Validate(t *testing.T) {
 		require.EqualError(t, err, `Consul Ingress Service doesn't support associating hosts to a service for the "tcp" protocol`)
 	})
 
-	t.Run("ok tcp", func(t *testing.T) {
+	t.Run("tcp ok", func(t *testing.T) {
 		err := (&ConsulIngressService{
 			Name: "service1",
 		}).Validate("tcp")
-		require.NoError(t, err)
-	})
-
-	t.Run("ok http", func(t *testing.T) {
-		err := (&ConsulIngressService{
-			Name:  "service1",
-			Hosts: []string{"host1"},
-		}).Validate("http")
-		require.NoError(t, err)
-	})
-
-	t.Run("http with wildcard service", func(t *testing.T) {
-		err := (&ConsulIngressService{
-			Name: "*",
-		}).Validate("http")
 		require.NoError(t, err)
 	})
 
@@ -1371,6 +1349,39 @@ func TestConsulIngressService_Validate(t *testing.T) {
 		}).Validate("tcp")
 		require.EqualError(t, err, `Consul Ingress Service doesn't support wildcard name for "tcp" protocol`)
 	})
+
+	// non-"tcp" protocols should be all treated the same.
+	for _, proto := range []string{"http", "http2", "grpc"} {
+		t.Run(proto+" ok", func(t *testing.T) {
+			err := (&ConsulIngressService{
+				Name:  "service1",
+				Hosts: []string{"host1"},
+			}).Validate(proto)
+			require.NoError(t, err)
+		})
+
+		t.Run(proto+" without hosts", func(t *testing.T) {
+			err := (&ConsulIngressService{
+				Name: "service1",
+			}).Validate(proto)
+			require.NoErrorf(t, err, `should not require hosts with "%s" protocol`, proto)
+		})
+
+		t.Run(proto+" wildcard service", func(t *testing.T) {
+			err := (&ConsulIngressService{
+				Name: "*",
+			}).Validate(proto)
+			require.NoErrorf(t, err, `should allow wildcard hosts with "%s" protocol`, proto)
+		})
+
+		t.Run(proto+" wildcard service and host", func(t *testing.T) {
+			err := (&ConsulIngressService{
+				Name:  "*",
+				Hosts: []string{"any"},
+			}).Validate(proto)
+			require.EqualError(t, err, `Consul Ingress Service with a wildcard "*" service name can not also specify hosts`)
+		})
+	}
 }
 
 func TestConsulIngressListener_Validate(t *testing.T) {


### PR DESCRIPTION
This makes code match the documentation, and reality 😋 

Applies to all non-"tcp" protocols: `http`, `http2`, and `grpc`, which support "hosts" and tests now cover all of them as well.  I could maybe be convinced to remove the extra test coverage if it seems superfluous, but it's intended to guard against potential future regressions.

per https://developer.hashicorp.com/nomad/docs/job-specification/gateway#service-parameters,

> `service` Parameters
> * [`hosts`](https://developer.hashicorp.com/nomad/docs/job-specification/gateway#hosts) `(array<string>: nil)` - A list of hosts that specify what requests will match this service. This cannot be used with a `tcp` listener, and cannot be specified alongside a wildcard (`*`) service name. If not specified, the default domain `<service-name>.ingress.*` will be used to match services.

<details><summary>e.g. this will now work:</summary>

```hcl
listener {
  port     = 8080
  protocol = "http"
  service {
    name  = "uuid-api"
    # hosts = no longer required
  }
}
```

and this will no longer work (by "work" I mean pass to consul, which errors less-specifically):

```hcl
listener {
  port     = 8080
  protocol = "http"
  service {
    name  = "*"
    hosts = ["anything"]
  }
}
```

error before:

> Error submitting job: Unexpected response code: 500 (Unexpected response code: 500 (Associating hosts to a wildcard service is not supported (listener on port 8080)))

error after:

> Error submitting job: Unexpected response code: 500 (1 error occurred:
        * Task group ingress-group validation failed: 1 error occurred:
        * Task group service validation failed: 1 error occurred:
        * Service[0] my-ingress-service validation failed: 1 error occurred:
        * Consul Ingress Service with a wildcard "*" service name can not also specify hosts)

</details>

Closes #10955 

Note: to use these non-"tcp" protocols, users will still need to manually write a service-defaults config entry as described in https://github.com/hashicorp/nomad/issues/8647#issuecomment-691279667