### PR TITLE
consul/connect: use block not optional for opaque map

### DIFF
--- a/api/consul.go
+++ b/api/consul.go
@@ -205,7 +205,7 @@ type ConsulUpstream struct {
 	Datacenter           string             `mapstructure:"datacenter" hcl:"datacenter,optional"`
 	LocalBindAddress     string             `mapstructure:"local_bind_address" hcl:"local_bind_address,optional"`
 	MeshGateway          *ConsulMeshGateway `mapstructure:"mesh_gateway" hcl:"mesh_gateway,block"`
-	Config               map[string]any     `mapstructure:"config" hcl:"config,optional"`
+	Config               map[string]any     `mapstructure:"config" hcl:"config,block"`
 }
 
 func (cu *ConsulUpstream) Copy() *ConsulUpstream {

--- a/jobspec2/parse_test.go
+++ b/jobspec2/parse_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/jobspec"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,6 +62,21 @@ func TestEquivalentToHCL1_ComplexConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, job1, job2)
+}
+
+func TestParse_ConnectJob(t *testing.T) {
+	ci.Parallel(t)
+
+	name := "./test-fixtures/connect-example.hcl"
+	f, err := os.Open(name)
+	must.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+
+	job2, err := Parse(name, f)
+	must.NoError(t, err)
+
+	timeout := job2.TaskGroups[0].Services[0].Connect.SidecarService.Proxy.Upstreams[0].Config["connect_timeout_ms"]
+	must.Eq(t, 9999, timeout)
 }
 
 func TestParse_VarsAndFunctions(t *testing.T) {

--- a/jobspec2/test-fixtures/connect-example.hcl
+++ b/jobspec2/test-fixtures/connect-example.hcl
@@ -1,0 +1,43 @@
+job "web" {
+  datacenters = ["dc1"]
+  group "web" {
+    network {
+      mode = "bridge"
+
+      port "http" {
+        static = 80
+        to     = 8080
+      }
+    }
+
+    service {
+      name = "website"
+      port = "8080"
+
+      connect {
+        sidecar_service {
+          proxy {
+            upstreams {
+              destination_name = "database"
+              local_bind_port  = 5432
+              config {
+                connect_timeout_ms = 9999
+              }
+            }
+          }
+        }
+      }
+    }
+
+    task "httpserver" {
+      driver = "docker"
+      env {
+        COUNTING_SERVICE_URL = "http://${NOMAD_UPSTREAM_ADDR_database}"
+      }
+      config {
+        image          = "hashicorp/website:v1"
+        auth_soft_fail = true
+      }
+    }
+  }
+}


### PR DESCRIPTION
I forgot that I created an uncommitted change while testing https://github.com/hashicorp/nomad/pull/15761. Adds the fix and adds a relevant parsing test too.