### PR TITLE
[docs] Fixing yaml syntax in frontmatter

### DIFF
--- a/website/content/docs/commands/operator/client-state.mdx
+++ b/website/content/docs/commands/operator/client-state.mdx
@@ -2,8 +2,8 @@
 layout: docs
 page_title: 'Commands: operator client-state'
 description: >
-The `operator client-state` command generates a representation of the
-stored client state in JSON format.
+  The `operator client-state` command generates a representation of the
+  stored client state in JSON format.
 ---
 
 # Command: operator client-state


### PR DESCRIPTION
## What

Adds missing indentation from a frontmatter's `description`.

## Testing

- [ ] The Vercel build should pass
- [ ] The page should render as expected in the preview
