### PR TITLE
[ui] Keyboard shortcuts for widening and narrowing task sidebar

### DIFF
--- a/ui/app/components/task-context-sidebar.hbs
+++ b/ui/app/components/task-context-sidebar.hbs
@@ -89,6 +89,11 @@
 			type="button"
 			{{on "click" this.toggleWide}}
 		>
+			{{#if this.wide}}
+				{{keyboard-commands (array this.narrowCommand)}}
+			{{else}}
+				{{keyboard-commands (array this.widenCommand)}}
+			{{/if}}
 			{{x-icon (if this.wide "arrow-right" "arrow-left")}}
 		</button>
 	</div>

--- a/ui/app/components/task-context-sidebar.js
+++ b/ui/app/components/task-context-sidebar.js
@@ -16,6 +16,18 @@ export default class TaskContextSidebarComponent extends Component {
     },
   ];
 
+  narrowCommand = {
+    label: 'Narrow Sidebar',
+    pattern: ['ArrowRight', 'ArrowRight'],
+    action: () => this.toggleWide(),
+  };
+
+  widenCommand = {
+    label: 'Widen Sidebar',
+    pattern: ['ArrowLeft', 'ArrowLeft'],
+    action: () => this.toggleWide(),
+  };
+
   @tracked wide = false;
   @action toggleWide() {
     this.wide = !this.wide;


### PR DESCRIPTION
Uses handlebars helpers to swap widen/narrow from within our template. LL to widen, RR to narrow again.

