### PR TITLE
[docs] Adjusting links for rewrite project

### DIFF
--- a/website/content/docs/faq.mdx
+++ b/website/content/docs/faq.mdx
@@ -97,7 +97,7 @@ $ curl http://192.168.0.10:8080
 ```
 
 [consul_dc]: https://developer.hashicorp.com/consul/docs/agent/config/config-files#datacenter
-[consul_fed]: https://learn.hashicorp.com/tutorials/consul/federarion-gossip-wan
+[consul_fed]: https://learn.hashicorp.com/tutorials/consul/federation-gossip-wan
 [nomad_region]: /docs/configuration#datacenter
 [`bootstrap_expect`]: /docs/configuration/server#bootstrap_expect
 [`default_scheduler_config`]: /docs/configuration/server#default_scheduler_config

--- a/website/content/docs/install/index.mdx
+++ b/website/content/docs/install/index.mdx
@@ -264,7 +264,7 @@ as a copy of [`git`](https://www.git-scm.com/) in your `PATH`.
    $ make dev
    ```
 
-[consul-dev]: https://learn.hashicorp.com/consul/getting-started/agent#starting-the-agent
+[consul-dev]: /consul/tutorials/certification-associate-tutorials/get-started-agent#start-the-agent
 
 [consul-download]: https://developer.hashicorp.com/consul/downloads
 

--- a/website/content/docs/job-specification/upstreams.mdx
+++ b/website/content/docs/job-specification/upstreams.mdx
@@ -26,7 +26,7 @@ Connect](/docs/integrations/consul-connect) proxy routes to. It
 is valid only within the context of a `proxy` stanza.
 
 For Consul-specific details see the [Consul Connect
-Guide](https://learn.hashicorp.com/consul/getting-started/connect#register-a-dependent-service-and-proxy).
+Guide](/consul/tutorials/get-started-vms/virtual-machine-gs-service-discovery).
 
 ```hcl
 job "countdash" {

--- a/website/content/docs/partnerships.mdx
+++ b/website/content/docs/partnerships.mdx
@@ -16,7 +16,7 @@ This program is intended to be largely a self-service process with links and gui
 
 ## Types of Nomad Integrations
 
-Nomad is a simple and flexible orchestrator to deploy and manage containers and non-containerized applications across on-premises and cloud environments at scale. Nomad is widely adopted and used in production by organizations like Cloudflare, Roblox, Q2, Pandora, and more. For a full description of the current features please refer to the [Nomad Website](/). The diagram below depicts the key Nomad integration categories and types.
+Nomad is a simple and flexible orchestrator to deploy and manage containers and non-containerized applications across on-premises and cloud environments at scale. Nomad is widely adopted and used in production by organizations like Cloudflare, Roblox, Q2, Pandora, and more. See the [Introduction](/nomad/intro) page for a full description of the current features. The diagram below depicts the key Nomad integration categories and types.
 
 ![Integration Categories](/img/nomad-workload.png)
 

--- a/website/content/plugins/drivers/remote/index.mdx
+++ b/website/content/plugins/drivers/remote/index.mdx
@@ -96,7 +96,7 @@ behavior of the following features is completely driver dependent:
 - [`connect`][connect] - since group networks and sidecars are local to the
   Nomad node, Consul Connect sidecars will not work as expected.
 
-[artifact]:  /docs/job-specification/artifact
+[artifact]: /docs/job-specification/artifact
 [connect]: /docs/job-specification/connect
 [dispatch-payload]: /docs/job-specification/dispatch_payload
 [drain]: /docs/commands/node/drain


### PR DESCRIPTION
## What

- Fixes a typo in a tutorial link in `website/content/docs/faq.mdx`
- Updates two old `learn.hashicorp.com` links that redirect to their devdot paths
- Updates a link in `website/content/docs/partnerships.mdx` to go to `/nomad/intro` instead of `/` (which was previously the nomadproject.io hompage)
- Removes an extra space from a definition in `website/content/plugins/drivers/remote/index.mdx`
