### PR TITLE
Set the requested PropagationMode for volumes

### DIFF
--- a/client/allocrunner/taskrunner/volume_hook.go
+++ b/client/allocrunner/taskrunner/volume_hook.go
@@ -79,9 +79,10 @@ func (h *volumeHook) hostVolumeMountConfigurations(taskMounts []*structs.VolumeM
 		}
 
 		mcfg := &drivers.MountConfig{
-			HostPath: hostVolume.Path,
-			TaskPath: m.Destination,
-			Readonly: hostVolume.ReadOnly || req.ReadOnly || m.ReadOnly,
+			HostPath:        hostVolume.Path,
+			TaskPath:        m.Destination,
+			Readonly:        hostVolume.ReadOnly || req.ReadOnly || m.ReadOnly,
+			PropagationMode: m.PropagationMode,
 		}
 		mounts = append(mounts, mcfg)
 	}
@@ -171,9 +172,10 @@ func (h *volumeHook) prepareCSIVolumes(req *interfaces.TaskPrestartRequest, volu
 
 		for _, m := range mountsForAlias {
 			mcfg := &drivers.MountConfig{
-				HostPath: csiMountPoint.Source,
-				TaskPath: m.Destination,
-				Readonly: request.ReadOnly || m.ReadOnly,
+				HostPath:        csiMountPoint.Source,
+				TaskPath:        m.Destination,
+				Readonly:        request.ReadOnly || m.ReadOnly,
+				PropagationMode: m.PropagationMode,
 			}
 			mounts = append(mounts, mcfg)
 		}


### PR DESCRIPTION
We have disabled docker volumes in our Nomad clients to force users to have to use host volumes since these are better controlled using ACL's.

For running cadvisor we need to expose the docker data directory to cadvisor, we do this by allowing the cadvisor job to mount a host volume with the docker data path and set propagationmode to "host-to-task" (rslave) as docker requires this, see error:

```
failed to create container:
  API error (400):
    invalid mount config:
      must use either propagation mode "rslave" or "rshared" when mount source is within the daemon root
```

Currently this wasn't applied for Host nor CSI volume mounts and I don't know why. This MR enables the option for both.