### PR TITLE
Adds docker isolation option

### DIFF
--- a/.changelog/15819.txt
+++ b/.changelog/15819.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+"build: Added hyper-v isolation mode for docker on Windows"
+```

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -364,6 +364,7 @@ var (
 		"ipc_mode":           hclspec.NewAttr("ipc_mode", "string", false),
 		"ipv4_address":       hclspec.NewAttr("ipv4_address", "string", false),
 		"ipv6_address":       hclspec.NewAttr("ipv6_address", "string", false),
+		"isolation":          hclspec.NewAttr("isolation", "string", false)
 		"labels":             hclspec.NewAttr("labels", "list(map(string))", false),
 		"load":               hclspec.NewAttr("load", "string", false),
 		"logging": hclspec.NewBlock("logging", false, hclspec.NewObject(map[string]*hclspec.Spec{
@@ -446,6 +447,7 @@ type TaskConfig struct {
 	IPCMode           string             `codec:"ipc_mode"`
 	IPv4Address       string             `codec:"ipv4_address"`
 	IPv6Address       string             `codec:"ipv6_address"`
+	Isolation         string             `codec:"isolation"`
 	Labels            hclutils.MapStrStr `codec:"labels"`
 	LoadImage         string             `codec:"load"`
 	Logging           DockerLogging      `codec:"logging"`

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -364,7 +364,7 @@ var (
 		"ipc_mode":           hclspec.NewAttr("ipc_mode", "string", false),
 		"ipv4_address":       hclspec.NewAttr("ipv4_address", "string", false),
 		"ipv6_address":       hclspec.NewAttr("ipv6_address", "string", false),
-		"isolation":          hclspec.NewAttr("isolation", "string", false)
+		"isolation":          hclspec.NewAttr("isolation", "string", false),
 		"labels":             hclspec.NewAttr("labels", "list(map(string))", false),
 		"load":               hclspec.NewAttr("load", "string", false),
 		"logging": hclspec.NewBlock("logging", false, hclspec.NewObject(map[string]*hclspec.Spec{

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -837,8 +837,8 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 
 	// Only windows supports alternative isolations modes
 	isolationMode := driverConfig.Isolation
-	if runtime.GOOS != "windows" && driverConfig.Isolation != "process" {
-		return c, fmt.Errorf("Failed to create container configuration for image %q, cannot use isolation mode \"%v\" on %v", driverConfig.Image, isolationMode, runtime.GOOS)
+	if runtime.GOOS != "windows" && isolationMode != "" {
+		return c, fmt.Errorf("Failed to create container configuration, cannot use isolation mode \"%s\" on %s", isolationMode, runtime.GOOS)
 	}
 
 	memory, memoryReservation := memoryLimits(driverConfig.MemoryHardLimit, task.Resources.NomadResources.Memory)

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -835,6 +835,12 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		return c, fmt.Errorf("requested runtime %q is not allowed", containerRuntime)
 	}
 
+	// Only windows supports alternative isolations modes
+	isolationMode := driverConfig.Isolation
+	if runtime.GOOS != "windows" && driverConfig.Isolation != "process" {
+		return c, fmt.Errorf("Failed to create container configuration for image %q, cannot use isolation mode \"%v\" on %v", driverConfig.Image, isolationMode, runtime.GOOS)
+	}
+
 	memory, memoryReservation := memoryLimits(driverConfig.MemoryHardLimit, task.Resources.NomadResources.Memory)
 
 	var pidsLimit int64

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -865,6 +865,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		// used to share data between different tasks in the same task group.
 		Binds: binds,
 
+		Isolation:    driverConfig.Isolation,
 		StorageOpt:   driverConfig.StorageOpt,
 		VolumeDriver: driverConfig.VolumeDriver,
 

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -157,8 +157,8 @@ config {
 - `interactive` - (Optional) `true` or `false` (default). Keep STDIN open on
   the container.
 
-- `isolation` - (Optional) `hyper-v` or `process` (default). Enables [`Windows isolation`](https://learn.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container) 
-   modes.
+- `isolation` - (Optional) One of `"hyper-v"`, `"process"`, or `"default"`
+  (which is the same as `process`). Enables [Windows isolation][] modes.
 
 - `sysctl` - (Optional) A key-value map of sysctl configurations to set to the
   containers on start.

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -1211,3 +1211,4 @@ Windows is relatively new and rapidly evolving you may want to consult the
 [`bridge`]: /docs/job-specification/network#bridge
 [network stanza]: /docs/job-specification/network#bridge-mode
 [`pids_limit`]: /docs/drivers/docker#pids_limit
+[Windows isolation]: https://learn.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -157,6 +157,9 @@ config {
 - `interactive` - (Optional) `true` or `false` (default). Keep STDIN open on
   the container.
 
+- `isolation` - (Optional) `hyper-v` or `process` (default). Enables [`Windows isolation`](https://learn.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container) 
+   modes.
+
 - `sysctl` - (Optional) A key-value map of sysctl configurations to set to the
   containers on start.
 


### PR DESCRIPTION
This change enables the --isolation=hyper-v flag in the docker driver for Windows users. 

Prior to this change attempts to use the flag would cause an error in Nomad. 

