### PR TITLE
cli: use localhost for default login callback address.

### DIFF
--- a/command/login.go
+++ b/command/login.go
@@ -52,7 +52,7 @@ Login Options:
 
   -oidc-callback-addr
     The address to use for the local OIDC callback server. This should be given
-    in the form of <IP>:<PORT> and defaults to "127.0.0.1:4649".
+    in the form of <IP>:<PORT> and defaults to "localhost:4649".
 
   -json
     Output the ACL token in JSON format.
@@ -89,7 +89,7 @@ func (l *LoginCommand) Run(args []string) int {
 	flags.Usage = func() { l.Ui.Output(l.Help()) }
 	flags.StringVar(&l.authMethodName, "method", "", "")
 	flags.StringVar(&l.authMethodType, "type", "OIDC", "")
-	flags.StringVar(&l.callbackAddr, "oidc-callback-addr", "127.0.0.1:4649", "")
+	flags.StringVar(&l.callbackAddr, "oidc-callback-addr", "localhost:4649", "")
 	flags.BoolVar(&l.json, "json", false, "")
 	flags.StringVar(&l.template, "t", "", "")
 	if err := flags.Parse(args); err != nil {

--- a/lib/auth/oidc/server.go
+++ b/lib/auth/oidc/server.go
@@ -36,7 +36,7 @@ func NewCallbackServer(addr string) (*CallbackServer, error) {
 
 	// Initialize our callback server
 	srv := &CallbackServer{
-		url:         fmt.Sprintf("http://%s/oidc/callback", ln.Addr().String()),
+		url:         fmt.Sprintf("http://%s/oidc/callback", addr),
 		ln:          ln,
 		clientNonce: nonce,
 		errCh:       make(chan error, 5),

--- a/lib/auth/oidc/server_test.go
+++ b/lib/auth/oidc/server_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestCallbackServer(t *testing.T) {
 
-	testCallbackServer, err := NewCallbackServer("127.0.0.1:4649")
+	testCallbackServer, err := NewCallbackServer("localhost:4649")
 	must.NoError(t, err)
 	must.NotNil(t, testCallbackServer)
 
@@ -16,5 +16,5 @@ func TestCallbackServer(t *testing.T) {
 		must.NoError(t, testCallbackServer.Close())
 	}()
 	must.StrNotEqFold(t, "", testCallbackServer.Nonce())
-	must.StrNotEqFold(t, "", testCallbackServer.RedirectURI())
+	must.Eq(t, "http://localhost:4649/oidc/callback", testCallbackServer.RedirectURI())
 }


### PR DESCRIPTION
The change also impacts the callback server and ensures that the URL it returns is true to what was passed. Without this change, passing `localhost` would always mean the callback would return the IP translated address from the `RedirectURI` func.