### PR TITLE
changelog: add feature entry for SSO OIDC

### DIFF
--- a/.changelog/15191.txt
+++ b/.changelog/15191.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-acl: Added SSO authentication schema and state store functions
-```

--- a/.changelog/15816.txt
+++ b/.changelog/15816.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+**SSO via OIDC***: Allow users to authenticate with Nomad via OIDC providers
+```


### PR DESCRIPTION
Removed the entry regarding auth method schema and state.
Adds feature entry for SSO via OIDC. I used the login PR as we need to link to a single entry; although this feature was the result of a large number of PRs.