### PR TITLE
Rename `nomad.broker.total_blocked` metric

### DIFF
--- a/.changelog/15835.txt
+++ b/.changelog/15835.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+metrics: The metric `nomad.nomad.broker.total_blocked` has been renamed to `nomad.nomad.broker.total_pending` to reduce confusion with the `nomad.blocked_eval.total_blocked` metric.
+```

--- a/nomad/eval_broker_test.go
+++ b/nomad/eval_broker_test.go
@@ -1383,9 +1383,9 @@ func TestEvalBroker_NamespacedJobs(t *testing.T) {
 
 }
 
-func TestEvalBroker_PendingEvals_Ordering(t *testing.T) {
+func TestEvalBroker_ReadyEvals_Ordering(t *testing.T) {
 
-	ready := PendingEvaluations{}
+	ready := ReadyEvaluations{}
 
 	newEval := func(jobID, evalID string, priority int, index uint64) *structs.Evaluation {
 		eval := mock.Eval()

--- a/nomad/eval_broker_test.go
+++ b/nomad/eval_broker_test.go
@@ -1435,18 +1435,18 @@ func TestEvalBroker_PendingEval_Ordering(t *testing.T) {
 	heap.Push(&pending, newEval("eval02", 100, 2))
 	heap.Push(&pending, newEval("eval01", 50, 1))
 
-	unpending := heap.Pop(&pending).(*structs.Evaluation)
-	test.Eq(t, "eval02", unpending.ID,
-		test.Sprint("expected eval with highest priority to get unpending"))
+	next := heap.Pop(&pending).(*structs.Evaluation)
+	test.Eq(t, "eval02", next.ID,
+		test.Sprint("expected eval with highest priority to be next"))
 
-	unpending = heap.Pop(&pending).(*structs.Evaluation)
-	test.Eq(t, "eval03", unpending.ID,
-		test.Sprint("expected eval with highest modify index to get unpending"))
+	next = heap.Pop(&pending).(*structs.Evaluation)
+	test.Eq(t, "eval03", next.ID,
+		test.Sprint("expected eval with highest modify index to be next"))
 
 	heap.Push(&pending, newEval("eval04", 30, 4))
-	unpending = heap.Pop(&pending).(*structs.Evaluation)
-	test.Eq(t, "eval01", unpending.ID,
-		test.Sprint("expected eval with highest priority to get unpending"))
+	next = heap.Pop(&pending).(*structs.Evaluation)
+	test.Eq(t, "eval01", next.ID,
+		test.Sprint("expected eval with highest priority to be nexct"))
 
 }
 

--- a/nomad/eval_broker_test.go
+++ b/nomad/eval_broker_test.go
@@ -434,7 +434,7 @@ func TestEvalBroker_Serialize_DuplicateJobID(t *testing.T) {
 	}
 
 	must.Eq(t, BrokerStats{TotalReady: 2, TotalUnacked: 0,
-		TotalBlocked: 5, TotalCancelable: 0}, getStats())
+		TotalPending: 5, TotalCancelable: 0}, getStats())
 
 	// Dequeue should get 1st eval
 	out, token, err := b.Dequeue(defaultSched, time.Second)
@@ -442,7 +442,7 @@ func TestEvalBroker_Serialize_DuplicateJobID(t *testing.T) {
 	must.Eq(t, out, eval1, must.Sprint("expected 1st eval"))
 
 	must.Eq(t, BrokerStats{TotalReady: 1, TotalUnacked: 1,
-		TotalBlocked: 5, TotalCancelable: 0}, getStats())
+		TotalPending: 5, TotalCancelable: 0}, getStats())
 
 	// Current wait index should be 4 but Ack to exercise behavior
 	// when worker's Eval.getWaitIndex gets a stale index
@@ -450,25 +450,25 @@ func TestEvalBroker_Serialize_DuplicateJobID(t *testing.T) {
 	must.NoError(t, err)
 
 	must.Eq(t, BrokerStats{TotalReady: 2, TotalUnacked: 0,
-		TotalBlocked: 2, TotalCancelable: 2}, getStats())
+		TotalPending: 2, TotalCancelable: 2}, getStats())
 
 	// eval4 and eval5 are ready
-	// eval6 and eval7 are blocked
+	// eval6 and eval7 are pending
 	// Dequeue should get 4th eval
 	out, token, err = b.Dequeue(defaultSched, time.Second)
 	must.NoError(t, err)
 	must.Eq(t, out, eval4, must.Sprint("expected 4th eval"))
 
 	must.Eq(t, BrokerStats{TotalReady: 1, TotalUnacked: 1,
-		TotalBlocked: 2, TotalCancelable: 2}, getStats())
+		TotalPending: 2, TotalCancelable: 2}, getStats())
 
-	// Ack should clear the rest of namespace-one blocked but leave
+	// Ack should clear the rest of namespace-one pending but leave
 	// namespace-two untouched
 	err = b.Ack(eval4.ID, token)
 	must.NoError(t, err)
 
 	must.Eq(t, BrokerStats{TotalReady: 1, TotalUnacked: 0,
-		TotalBlocked: 2, TotalCancelable: 2}, getStats())
+		TotalPending: 2, TotalCancelable: 2}, getStats())
 
 	// Dequeue should get 5th eval
 	out, token, err = b.Dequeue(defaultSched, time.Second)
@@ -476,14 +476,14 @@ func TestEvalBroker_Serialize_DuplicateJobID(t *testing.T) {
 	must.Eq(t, out, eval5, must.Sprint("expected 5th eval"))
 
 	must.Eq(t, BrokerStats{TotalReady: 0, TotalUnacked: 1,
-		TotalBlocked: 2, TotalCancelable: 2}, getStats())
+		TotalPending: 2, TotalCancelable: 2}, getStats())
 
-	// Ack should clear remaining namespace-two blocked evals
+	// Ack should clear remaining namespace-two pending evals
 	err = b.Ack(eval5.ID, token)
 	must.NoError(t, err)
 
 	must.Eq(t, BrokerStats{TotalReady: 1, TotalUnacked: 0,
-		TotalBlocked: 0, TotalCancelable: 3}, getStats())
+		TotalPending: 0, TotalCancelable: 3}, getStats())
 
 	// Dequeue should get 7th eval because that's all that's left
 	out, token, err = b.Dequeue(defaultSched, time.Second)
@@ -491,14 +491,14 @@ func TestEvalBroker_Serialize_DuplicateJobID(t *testing.T) {
 	must.Eq(t, out, eval7, must.Sprint("expected 7th eval"))
 
 	must.Eq(t, BrokerStats{TotalReady: 0, TotalUnacked: 1,
-		TotalBlocked: 0, TotalCancelable: 3}, getStats())
+		TotalPending: 0, TotalCancelable: 3}, getStats())
 
 	// Last ack should leave the broker empty except for cancels
 	err = b.Ack(eval7.ID, token)
 	must.NoError(t, err)
 
 	must.Eq(t, BrokerStats{TotalReady: 0, TotalUnacked: 0,
-		TotalBlocked: 0, TotalCancelable: 3}, getStats())
+		TotalPending: 0, TotalCancelable: 3}, getStats())
 }
 
 func TestEvalBroker_Enqueue_Disable(t *testing.T) {
@@ -553,7 +553,7 @@ func TestEvalBroker_Enqueue_Disable_Delay(t *testing.T) {
 		stats := b.Stats()
 		require.Equal(t, 0, stats.TotalReady, "Expected ready to be flushed")
 		require.Equal(t, 0, stats.TotalWaiting, "Expected waiting to be flushed")
-		require.Equal(t, 0, stats.TotalBlocked, "Expected blocked to be flushed")
+		require.Equal(t, 0, stats.TotalPending, "Expected pending to be flushed")
 		require.Equal(t, 0, stats.TotalUnacked, "Expected unacked to be flushed")
 		_, ok := stats.ByScheduler[baseEval.Type]
 		require.False(t, ok, "Expected scheduler to have no stats")
@@ -577,7 +577,7 @@ func TestEvalBroker_Enqueue_Disable_Delay(t *testing.T) {
 		stats := b.Stats()
 		require.Equal(t, 0, stats.TotalReady, "Expected ready to be flushed")
 		require.Equal(t, 0, stats.TotalWaiting, "Expected waiting to be flushed")
-		require.Equal(t, 0, stats.TotalBlocked, "Expected blocked to be flushed")
+		require.Equal(t, 0, stats.TotalPending, "Expected pending to be flushed")
 		require.Equal(t, 0, stats.TotalUnacked, "Expected unacked to be flushed")
 		_, ok := stats.ByScheduler[baseEval.Type]
 		require.False(t, ok, "Expected scheduler to have no stats")
@@ -1379,7 +1379,7 @@ func TestEvalBroker_NamespacedJobs(t *testing.T) {
 	require.Nil(err)
 	require.Nil(out3)
 
-	require.Equal(1, len(b.blocked))
+	require.Equal(1, len(b.pending))
 
 }
 
@@ -1418,8 +1418,8 @@ func TestEvalBroker_ReadyEvals_Ordering(t *testing.T) {
 
 }
 
-func TestEvalBroker_BlockedEval_Ordering(t *testing.T) {
-	blocked := BlockedEvaluations{}
+func TestEvalBroker_PendingEval_Ordering(t *testing.T) {
+	pending := PendingEvaluations{}
 
 	newEval := func(evalID string, priority int, index uint64) *structs.Evaluation {
 		eval := mock.Eval()
@@ -1431,29 +1431,29 @@ func TestEvalBroker_BlockedEval_Ordering(t *testing.T) {
 
 	// note: we're intentionally pushing these out-of-order to assert we're
 	// getting them back out in the intended order and not just as inserted
-	heap.Push(&blocked, newEval("eval03", 50, 3))
-	heap.Push(&blocked, newEval("eval02", 100, 2))
-	heap.Push(&blocked, newEval("eval01", 50, 1))
+	heap.Push(&pending, newEval("eval03", 50, 3))
+	heap.Push(&pending, newEval("eval02", 100, 2))
+	heap.Push(&pending, newEval("eval01", 50, 1))
 
-	unblocked := heap.Pop(&blocked).(*structs.Evaluation)
-	test.Eq(t, "eval02", unblocked.ID,
-		test.Sprint("expected eval with highest priority to get unblocked"))
+	unpending := heap.Pop(&pending).(*structs.Evaluation)
+	test.Eq(t, "eval02", unpending.ID,
+		test.Sprint("expected eval with highest priority to get unpending"))
 
-	unblocked = heap.Pop(&blocked).(*structs.Evaluation)
-	test.Eq(t, "eval03", unblocked.ID,
-		test.Sprint("expected eval with highest modify index to get unblocked"))
+	unpending = heap.Pop(&pending).(*structs.Evaluation)
+	test.Eq(t, "eval03", unpending.ID,
+		test.Sprint("expected eval with highest modify index to get unpending"))
 
-	heap.Push(&blocked, newEval("eval04", 30, 4))
-	unblocked = heap.Pop(&blocked).(*structs.Evaluation)
-	test.Eq(t, "eval01", unblocked.ID,
-		test.Sprint("expected eval with highest priority to get unblocked"))
+	heap.Push(&pending, newEval("eval04", 30, 4))
+	unpending = heap.Pop(&pending).(*structs.Evaluation)
+	test.Eq(t, "eval01", unpending.ID,
+		test.Sprint("expected eval with highest priority to get unpending"))
 
 }
 
-func TestEvalBroker_BlockedEvals_MarkForCancel(t *testing.T) {
+func TestEvalBroker_PendingEvals_MarkForCancel(t *testing.T) {
 	ci.Parallel(t)
 
-	blocked := BlockedEvaluations{}
+	pending := PendingEvaluations{}
 
 	// note: we're intentionally pushing these out-of-order to assert we're
 	// getting them back out in the intended order and not just as inserted
@@ -1462,14 +1462,14 @@ func TestEvalBroker_BlockedEvals_MarkForCancel(t *testing.T) {
 		eval.JobID = "example"
 		eval.CreateIndex = uint64(i)
 		eval.ModifyIndex = uint64(i)
-		heap.Push(&blocked, eval)
+		heap.Push(&pending, eval)
 	}
 
-	canceled := blocked.MarkForCancel()
+	canceled := pending.MarkForCancel()
 	must.Eq(t, 9, len(canceled))
-	must.Eq(t, 1, blocked.Len())
+	must.Eq(t, 1, pending.Len())
 
-	raw := heap.Pop(&blocked)
+	raw := heap.Pop(&pending)
 	must.NotNil(t, raw)
 	eval := raw.(*structs.Evaluation)
 	must.Eq(t, 100, eval.ModifyIndex)
@@ -1560,7 +1560,7 @@ func TestEvalBroker_IntegrationTest(t *testing.T) {
 
 	must.Eq(t, map[string]int{structs.EvalStatusPending: 11}, getEvalStatuses())
 	must.Eq(t, BrokerStats{TotalReady: 1, TotalUnacked: 0,
-		TotalBlocked: 10, TotalCancelable: 0}, getStats())
+		TotalPending: 10, TotalCancelable: 0}, getStats())
 
 	// start schedulers: all the evals are for a single job so there should only
 	// be one eval processesed at a time no matter how many schedulers we run
@@ -1579,5 +1579,5 @@ func TestEvalBroker_IntegrationTest(t *testing.T) {
 	}, 2*time.Second, time.Millisecond*100)
 
 	must.Eq(t, BrokerStats{TotalReady: 0, TotalUnacked: 0,
-		TotalBlocked: 0, TotalCancelable: 0}, getStats())
+		TotalPending: 0, TotalCancelable: 0}, getStats())
 }

--- a/website/content/docs/operations/metrics-reference.mdx
+++ b/website/content/docs/operations/metrics-reference.mdx
@@ -30,7 +30,7 @@ configuration](/docs/configuration/telemetry).
 Below is sample output of a telemetry dump:
 
 ```text
-[2015-09-17 16:59:40 -0700 PDT][G] 'nomad.nomad.broker.total_blocked': 0.000
+[2015-09-17 16:59:40 -0700 PDT][G] 'nomad.nomad.broker.total_pending': 0.000
 [2015-09-17 16:59:40 -0700 PDT][G] 'nomad.nomad.plan.queue_depth': 0.000
 [2015-09-17 16:59:40 -0700 PDT][G] 'nomad.runtime.malloc_count': 7568.000
 [2015-09-17 16:59:40 -0700 PDT][G] 'nomad.runtime.total_gc_runs': 8.000
@@ -97,7 +97,7 @@ signals.
 | `nomad.runtime.alloc_bytes`                  | Memory utilization                                                                                                                                                                                                | # of bytes                     | Gauge   |
 | `nomad.runtime.heap_objects`                 | Number of objects on the heap. General memory pressure indicator                                                                                                                                                  | # of heap objects              | Gauge   |
 | `nomad.runtime.num_goroutines`               | Number of goroutines and general load pressure indicator                                                                                                                                                          | # of goroutines                | Gauge   |
-| `nomad.nomad.broker.total_blocked`           | Evaluations that are blocked until an existing evaluation for the same job completes                                                                                                                              | # of evaluations               | Gauge   |
+| `nomad.nomad.broker.total_pending`           | Evaluations that are pending until an existing evaluation for the same job completes                                                                                                                              | # of evaluations               | Gauge   |
 | `nomad.nomad.broker.total_ready`             | Number of evaluations ready to be processed                                                                                                                                                                       | # of evaluations               | Gauge   |
 | `nomad.nomad.broker.total_unacked`           | Evaluations dispatched for processing but incomplete                                                                                                                                                              | # of evaluations               | Gauge   |
 | `nomad.nomad.heartbeat.active`               | Number of active heartbeat timers. Each timer represents a Nomad Client connection                                                                                                                                | # of heartbeat timers          | Gauge   |

--- a/website/content/docs/operations/monitoring-nomad.mdx
+++ b/website/content/docs/operations/monitoring-nomad.mdx
@@ -187,16 +187,14 @@ points in the scheduling process.
   evaluation at a time, entirely in-memory. If this metric increases,
   examine the CPU and memory resources of the scheduler.
 
-- **nomad.broker.total_blocked** - The number of blocked
+- **nomad.blocked_evals.total_blocked** - The number of blocked
   evaluations. Blocked evaluations are created when the scheduler
   cannot place all allocations as part of a plan. Blocked evaluations
   will be re-evaluated so that changes in cluster resources can be
   used for the blocked evaluation's allocations. An increase in
   blocked evaluations may mean that the cluster's clients are low in
   resources or that job have been submitted that can never have all
-  their allocations placed. Nomad also emits a similar metric for each
-  individual scheduler. For example `nomad.broker.batch_blocked` shows
-  the number of blocked evaluations for the batch scheduler.
+  their allocations placed.
 
 - **nomad.broker.total_unacked** - The number of unacknowledged
   evaluations. When an evaluation has been processed, the worker sends
@@ -210,6 +208,12 @@ points in the scheduling process.
   each individual scheduler. For example `nomad.broker.batch_unacked`
   shows the number of unacknowledged evaluations for the batch
   scheduler.
+
+- **nomad.broker.total_pending** - The number of pending evaluations in the eval
+  broker. Nomad processes only one evaluation for a given job concurrently. When
+  an unacked evaluation is acknowledged, Nomad will discard all but the latest
+  evaluation for a job. An increase in this metric may mean that the cluster
+  state is changing more rapidly than the schedulers can keep up.
 
 - **nomad.plan.evaluate** - The time to evaluate a scheduler plan
   submitted by a worker. This operation happens on the leader to

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -64,15 +64,25 @@ setting [`disable_filesystem_isolation`][artifact_fs_isolation].
 
 #### Server `rejoin_after_leave` (default: `false`) now enforced
 
-All Nomad versions prior to v1.5.0 have incorrectly ignored the Server [`rejoin_after_leave`]
-configuration option. This bug has been fixed in Nomad version v1.5.0.
+All Nomad versions prior to v1.5.0 have incorrectly ignored the Server
+[`rejoin_after_leave`] configuration option. This bug has been fixed in Nomad
+version v1.5.0.
 
-Previous to v1.5.0 the behavior of Nomad `rejoin_after_leave` was always `true`, regardless of 
-Nomad server configuration, while the documentation incorrectly indicated a default of `false`.
+Previous to v1.5.0 the behavior of Nomad `rejoin_after_leave` was always `true`,
+regardless of Nomad server configuration, while the documentation incorrectly
+indicated a default of `false`.
 
-Cluster operators should be aware that explicit `leave` events (such as `nomad server force-leave`) 
-will now result in behavior which matches this configuration, and should review whether they
-were inadvertently relying on the buggy behavior.
+Cluster operators should be aware that explicit `leave` events (such as `nomad
+server force-leave`) will now result in behavior which matches this
+configuration, and should review whether they were inadvertently relying on the
+buggy behavior.
+
+#### Changes to eval broker metrics
+
+The metric `nomad.nomad.broker.total_blocked` has been changed to
+`nomad.nomad.broker.total_pending`. This state refers to internal state of the
+leader's broker, and this is easily confused with the unrelated evaluation
+status `"blocked"` in the Nomad API.
 
 ## Nomad 1.4.0
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/6480 and addresses comments from https://github.com/hashicorp/nomad/pull/14621#discussion_r1023293596

This changeset fixes a long-standing point of confusion in metrics emitted by the eval broker. The eval broker has a queue of "blocked" evals that are waiting for an in-flight ("unacked") eval of the same job to be completed. But this "blocked" state is not the same as the `blocked` status that we write to raft and expose in the Nomad API to end users. There's a second metric `nomad.blocked_eval.total_blocked` that refers to evaluations in that state. This has caused ongoing confusion in major customer incidents and even in our own documentation! (Fixed in this PR.)

There's little functional change in this PR aside from the name of the metric emitted, but there's a bit refactoring to clean up the names in `eval_broker.go` so that there aren't name collisions and multiple names for the same state. Changes included are:
* Everything that was previously called "pending" referred to entities that were associated witht he "ready" metric. These are all now called "ready" to match the metric.
* Everything named "blocked" in `eval_broker.go` is now named "pending", except for a couple of comments that actually refer to blocked RPCs.
* Added a note to the upgrade guide docs for 1.5.0.
* Fixed the [scheduling performance metrics](https://developer.hashicorp.com/nomad/docs/operations/monitoring-nomad#performance) docs because the description for `nomad.broker.total_blocked` was actually the description for `nomad.blocked_eval.total_blocked`.

Once this is reviewed I'll open a second PR backporting just the docs fixes.
