### PR TITLE
acl: CLI login command should not default to "OIDC" type

### DIFF
--- a/.changelog/15836.txt
+++ b/.changelog/15836.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl: CLI login command used for SSO no longer defaults to "OIDC" type
+```

--- a/command/login.go
+++ b/command/login.go
@@ -48,7 +48,7 @@ Login Options:
     has configured a default, this flag is optional.
 
   -type
-    Type of the auth method to login to. Defaults to "OIDC".
+    Type of the auth method to login to. 
 
   -oidc-callback-addr
     The address to use for the local OIDC callback server. This should be given
@@ -88,7 +88,7 @@ func (l *LoginCommand) Run(args []string) int {
 	flags := l.Meta.FlagSet(l.Name(), FlagSetClient)
 	flags.Usage = func() { l.Ui.Output(l.Help()) }
 	flags.StringVar(&l.authMethodName, "method", "", "")
-	flags.StringVar(&l.authMethodType, "type", "OIDC", "")
+	flags.StringVar(&l.authMethodType, "type", "", "")
 	flags.StringVar(&l.callbackAddr, "oidc-callback-addr", "localhost:4649", "")
 	flags.BoolVar(&l.json, "json", false, "")
 	flags.StringVar(&l.template, "t", "", "")

--- a/website/content/docs/commands/login.mdx
+++ b/website/content/docs/commands/login.mdx
@@ -28,8 +28,7 @@ requested auth method for a newly minted Nomad ACL token.
 - `-method`: The name of the ACL auth method to log in via. If the cluster
   administrator has configured a default, this flag is optional.
 
-- `-type`: Type of the auth method to log in via. Defaults to, and currently
-  only supports, "OIDC".
+- `-type`: Type of the auth method to log in via. Currently only supports, "OIDC".
 
 - `-oidc-callback-addr`: The address to use for the local OIDC callback server.
   This should be given in the form of `<IP>:<PORT>` and defaults to


### PR DESCRIPTION
Since we're expecting to be supporting more auth method types soon, we don't want the CLI to default to "OIDC." It would be poor UX if this behavior suddenly changed.

Relates to #13120 