### PR TITLE
Add INFO task even log line and make logmon less noisy

### DIFF
--- a/.changelog/15842.txt
+++ b/.changelog/15842.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client: Log task events at INFO log level
+```

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -1256,8 +1256,6 @@ func (tr *TaskRunner) UpdateState(state string, event *structs.TaskEvent) {
 	tr.logger.Trace("setting task state", "state", state)
 
 	if event != nil {
-		tr.logger.Trace("appending task event", "state", state, "event", event.Type)
-
 		// Append the event
 		tr.appendEvent(event)
 	}
@@ -1369,6 +1367,8 @@ func (tr *TaskRunner) appendEvent(event *structs.TaskEvent) error {
 		tr.state.Restarts++
 		tr.state.LastRestart = time.Unix(0, event.Time)
 	}
+
+	tr.logger.Info("Task event", "type", event.Type, "msg", event.DisplayMessage, "failed", event.FailsTask)
 
 	// Append event to slice
 	appendTaskEvent(tr.state, event, tr.maxEvents)

--- a/client/logmon/logmon.go
+++ b/client/logmon/logmon.go
@@ -195,7 +195,7 @@ func (l *logRotatorWrapper) isRunning() bool {
 // newLogRotatorWrapper takes a rotator and returns a wrapper that has the
 // processOutWriter to attach to the stdout or stderr of a process.
 func newLogRotatorWrapper(path string, logger hclog.Logger, rotator io.WriteCloser) (*logRotatorWrapper, error) {
-	logger.Info("opening fifo", "path", path)
+	logger.Debug("opening fifo", "path", path)
 
 	var openFn func() (io.ReadCloser, error)
 	var err error


### PR DESCRIPTION
Fixes #15840

While this makes Nomad client agent logging noisier, I think it adds a lot of value. See #15840 for details.

Starting and stopping a task before this change (5 lines, 1011 bytes w/timestamps):

```
[INFO]  client: node registration complete
[INFO]  client.alloc_runner.task_runner.task_hook.logmon.nomad-1.4.3: opening fifo: alloc_id=701624a4-d78d-c5e7-bd17-47ce170d65ce task=sleepy @module=logmon path=/tmp/NomadClient582607065/701624a4-d78d-c5e7-bd17-47ce170d65ce/alloc/logs/.sleepy.stdout.fifo timestamp=2023-01-20T11:35:20.575-0800
[INFO]  client.alloc_runner.task_runner.task_hook.logmon.nomad-1.4.3: opening fifo: alloc_id=701624a4-d78d-c5e7-bd17-47ce170d65ce task=sleepy @module=logmon path=/tmp/NomadClient582607065/701624a4-d78d-c5e7-bd17-47ce170d65ce/alloc/logs/.sleepy.stderr.fifo timestamp=2023-01-20T11:35:20.575-0800
[INFO]  client.driver_mgr.raw_exec: starting task: driver=raw_exec driver_cfg="{Command:/bin/bash Args:[-c sleep 1000]}"
[INFO]  client.gc: marking allocation for GC: alloc_id=701624a4-d78d-c5e7-bd17-47ce170d65ce
```

Starting and stopping a task after these changes (13 lines, 2423 bytes w/timestamps):

```
[INFO]  client: node registration complete
[INFO]  client.alloc_runner.task_runner: Task event: alloc_id=768601e2-8140-1cf1-55a6-0120282354b9 task=sleepy type=Received msg="Task received by client" failed=false
[INFO]  client.alloc_runner.task_runner: Task event: alloc_id=768601e2-8140-1cf1-55a6-0120282354b9 task=sleepy type="Task Setup" msg="Building Task Directory" failed=false
[WARN]  client.alloc_runner.task_runner.task_hook.logmon: plugin configured with a nil SecureConfig: alloc_id=768601e2-8140-1cf1-55a6-0120282354b9 task=sleepy
[INFO]  client.driver_mgr.raw_exec: starting task: driver=raw_exec driver_cfg="{Command:/bin/bash Args:[-c sleep 1000]}"
[WARN]  client.driver_mgr.raw_exec.executor: plugin configured with a nil SecureConfig: alloc_id=768601e2-8140-1cf1-55a6-0120282354b9 driver=raw_exec task_name=sleepy
[INFO]  client.alloc_runner.task_runner: Task event: alloc_id=768601e2-8140-1cf1-55a6-0120282354b9 task=sleepy type=Started msg="Task started by client" failed=false
[INFO]  client.alloc_runner.task_runner: Task event: alloc_id=768601e2-8140-1cf1-55a6-0120282354b9 task=sleepy type=Killing msg="Sent interrupt. Waiting 5s before force killing" failed=false
[INFO]  client.driver_mgr.raw_exec.executor: plugin process exited: alloc_id=768601e2-8140-1cf1-55a6-0120282354b9 driver=raw_exec task_name=sleepy path=/home/schmichael/go/bin/nomad pid=30704
[INFO]  client.alloc_runner.task_runner: Task event: alloc_id=768601e2-8140-1cf1-55a6-0120282354b9 task=sleepy type=Terminated msg="Exit Code: 130, Signal: 2" failed=false
[INFO]  client.alloc_runner.task_runner: Task event: alloc_id=768601e2-8140-1cf1-55a6-0120282354b9 task=sleepy type=Killed msg="Task successfully killed" failed=false
[INFO]  client.alloc_runner.task_runner.task_hook.logmon: plugin process exited: alloc_id=768601e2-8140-1cf1-55a6-0120282354b9 task=sleepy path=/home/schmichael/go/bin/nomad pid=30688
[INFO]  client.gc: marking allocation for GC: alloc_id=768601e2-8140-1cf1-55a6-0120282354b9
```

(commits also include log snippets for each individual change)