### PR TITLE
Dynamic Node Metadata

### DIFF
--- a/api/acl.go
+++ b/api/acl.go
@@ -31,7 +31,7 @@ func (a *ACLPolicies) Upsert(policy *ACLPolicy, q *WriteOptions) (*WriteMeta, er
 	if policy == nil || policy.Name == "" {
 		return nil, errors.New("missing policy name")
 	}
-	wm, err := a.client.write("/v1/acl/policy/"+policy.Name, policy, nil, q)
+	wm, err := a.client.put("/v1/acl/policy/"+policy.Name, policy, nil, q)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (c *Client) ACLTokens() *ACLTokens {
 // Bootstrap is used to get the initial bootstrap token
 func (a *ACLTokens) Bootstrap(q *WriteOptions) (*ACLToken, *WriteMeta, error) {
 	var resp ACLToken
-	wm, err := a.client.write("/v1/acl/bootstrap", nil, &resp, q)
+	wm, err := a.client.put("/v1/acl/bootstrap", nil, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -94,7 +94,7 @@ func (a *ACLTokens) BootstrapOpts(btoken string, q *WriteOptions) (*ACLToken, *W
 	}
 
 	var resp ACLToken
-	wm, err := a.client.write("/v1/acl/bootstrap", req, &resp, q)
+	wm, err := a.client.put("/v1/acl/bootstrap", req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -117,7 +117,7 @@ func (a *ACLTokens) Create(token *ACLToken, q *WriteOptions) (*ACLToken, *WriteM
 		return nil, nil, errors.New("cannot specify Accessor ID")
 	}
 	var resp ACLToken
-	wm, err := a.client.write("/v1/acl/token", token, &resp, q)
+	wm, err := a.client.put("/v1/acl/token", token, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -130,7 +130,7 @@ func (a *ACLTokens) Update(token *ACLToken, q *WriteOptions) (*ACLToken, *WriteM
 		return nil, nil, errors.New("missing accessor ID")
 	}
 	var resp ACLToken
-	wm, err := a.client.write("/v1/acl/token/"+token.AccessorID,
+	wm, err := a.client.put("/v1/acl/token/"+token.AccessorID,
 		token, &resp, q)
 	if err != nil {
 		return nil, nil, err
@@ -176,7 +176,7 @@ func (a *ACLTokens) Self(q *QueryOptions) (*ACLToken, *QueryMeta, error) {
 // UpsertOneTimeToken is used to create a one-time token
 func (a *ACLTokens) UpsertOneTimeToken(q *WriteOptions) (*OneTimeToken, *WriteMeta, error) {
 	var resp *OneTimeTokenUpsertResponse
-	wm, err := a.client.write("/v1/acl/token/onetime", nil, &resp, q)
+	wm, err := a.client.put("/v1/acl/token/onetime", nil, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -193,7 +193,7 @@ func (a *ACLTokens) ExchangeOneTimeToken(secret string, q *WriteOptions) (*ACLTo
 	}
 	req := &OneTimeTokenExchangeRequest{OneTimeSecretID: secret}
 	var resp *OneTimeTokenExchangeResponse
-	wm, err := a.client.write("/v1/acl/token/onetime/exchange", req, &resp, q)
+	wm, err := a.client.put("/v1/acl/token/onetime/exchange", req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -243,7 +243,7 @@ func (a *ACLRoles) Create(role *ACLRole, w *WriteOptions) (*ACLRole, *WriteMeta,
 		return nil, nil, errors.New("cannot specify ACL role ID")
 	}
 	var resp ACLRole
-	wm, err := a.client.write("/v1/acl/role", role, &resp, w)
+	wm, err := a.client.put("/v1/acl/role", role, &resp, w)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -256,7 +256,7 @@ func (a *ACLRoles) Update(role *ACLRole, w *WriteOptions) (*ACLRole, *WriteMeta,
 		return nil, nil, errMissingACLRoleID
 	}
 	var resp ACLRole
-	wm, err := a.client.write("/v1/acl/role/"+role.ID, role, &resp, w)
+	wm, err := a.client.put("/v1/acl/role/"+role.ID, role, &resp, w)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -328,7 +328,7 @@ func (a *ACLAuthMethods) Create(authMethod *ACLAuthMethod, w *WriteOptions) (*AC
 		return nil, nil, errMissingACLAuthMethodName
 	}
 	var resp ACLAuthMethod
-	wm, err := a.client.write("/v1/acl/auth-method", authMethod, &resp, w)
+	wm, err := a.client.put("/v1/acl/auth-method", authMethod, &resp, w)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -341,7 +341,7 @@ func (a *ACLAuthMethods) Update(authMethod *ACLAuthMethod, w *WriteOptions) (*AC
 		return nil, nil, errMissingACLAuthMethodName
 	}
 	var resp ACLAuthMethod
-	wm, err := a.client.write("/v1/acl/auth-method/"+authMethod.Name, authMethod, &resp, w)
+	wm, err := a.client.put("/v1/acl/auth-method/"+authMethod.Name, authMethod, &resp, w)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -397,7 +397,7 @@ func (a *ACLBindingRules) List(q *QueryOptions) ([]*ACLBindingRuleListStub, *Que
 // Create is used to create an ACL binding rule.
 func (a *ACLBindingRules) Create(bindingRule *ACLBindingRule, w *WriteOptions) (*ACLBindingRule, *WriteMeta, error) {
 	var resp ACLBindingRule
-	wm, err := a.client.write("/v1/acl/binding-rule", bindingRule, &resp, w)
+	wm, err := a.client.put("/v1/acl/binding-rule", bindingRule, &resp, w)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -410,7 +410,7 @@ func (a *ACLBindingRules) Update(bindingRule *ACLBindingRule, w *WriteOptions) (
 		return nil, nil, errMissingACLBindingRuleID
 	}
 	var resp ACLBindingRule
-	wm, err := a.client.write("/v1/acl/binding-rule/"+bindingRule.ID, bindingRule, &resp, w)
+	wm, err := a.client.put("/v1/acl/binding-rule/"+bindingRule.ID, bindingRule, &resp, w)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api/acl.go
+++ b/api/acl.go
@@ -456,7 +456,7 @@ func (c *Client) ACLOIDC() *ACLOIDC {
 // be visited in order to sign in to the provider.
 func (a *ACLOIDC) GetAuthURL(req *ACLOIDCAuthURLRequest, q *WriteOptions) (*ACLOIDCAuthURLResponse, *WriteMeta, error) {
 	var resp ACLOIDCAuthURLResponse
-	wm, err := a.client.write("/v1/acl/oidc/auth-url", req, &resp, q)
+	wm, err := a.client.put("/v1/acl/oidc/auth-url", req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -467,7 +467,7 @@ func (a *ACLOIDC) GetAuthURL(req *ACLOIDCAuthURLRequest, q *WriteOptions) (*ACLO
 // appropriate claims attached.
 func (a *ACLOIDC) CompleteAuth(req *ACLOIDCCompleteAuthRequest, q *WriteOptions) (*ACLToken, *WriteMeta, error) {
 	var resp ACLToken
-	wm, err := a.client.write("/v1/acl/oidc/complete-auth", req, &resp, q)
+	wm, err := a.client.put("/v1/acl/oidc/complete-auth", req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api/agent.go
+++ b/api/agent.go
@@ -125,7 +125,7 @@ func (a *Agent) Join(addrs ...string) (int, error) {
 
 	// Send the join request
 	var resp joinResponse
-	_, err := a.client.write("/v1/agent/join?"+v.Encode(), nil, &resp, nil)
+	_, err := a.client.put("/v1/agent/join?"+v.Encode(), nil, &resp, nil)
 	if err != nil {
 		return 0, fmt.Errorf("failed joining: %s", err)
 	}
@@ -160,7 +160,7 @@ func (a *Agent) MembersOpts(opts *QueryOptions) (*ServerMembers, error) {
 
 // ForceLeave is used to eject an existing node from the cluster.
 func (a *Agent) ForceLeave(node string) error {
-	_, err := a.client.write("/v1/agent/force-leave?node="+node, nil, nil, nil)
+	_, err := a.client.put("/v1/agent/force-leave?node="+node, nil, nil, nil)
 	return err
 }
 
@@ -182,7 +182,7 @@ func (a *Agent) SetServers(addrs []string) error {
 		v.Add("address", addr)
 	}
 
-	_, err := a.client.write("/v1/agent/servers?"+v.Encode(), nil, nil, nil)
+	_, err := a.client.put("/v1/agent/servers?"+v.Encode(), nil, nil, nil)
 	return err
 }
 
@@ -202,7 +202,7 @@ func (a *Agent) InstallKey(key string) (*KeyringResponse, error) {
 		Key: key,
 	}
 	var resp KeyringResponse
-	_, err := a.client.write("/v1/agent/keyring/install", &args, &resp, nil)
+	_, err := a.client.put("/v1/agent/keyring/install", &args, &resp, nil)
 	return &resp, err
 }
 
@@ -212,7 +212,7 @@ func (a *Agent) UseKey(key string) (*KeyringResponse, error) {
 		Key: key,
 	}
 	var resp KeyringResponse
-	_, err := a.client.write("/v1/agent/keyring/use", &args, &resp, nil)
+	_, err := a.client.put("/v1/agent/keyring/use", &args, &resp, nil)
 	return &resp, err
 }
 
@@ -222,7 +222,7 @@ func (a *Agent) RemoveKey(key string) (*KeyringResponse, error) {
 		Key: key,
 	}
 	var resp KeyringResponse
-	_, err := a.client.write("/v1/agent/keyring/remove", &args, &resp, nil)
+	_, err := a.client.put("/v1/agent/keyring/remove", &args, &resp, nil)
 	return &resp, err
 }
 
@@ -511,7 +511,7 @@ func (a *Agent) SetSchedulerWorkerConfig(args SchedulerWorkerPoolArgs, q *WriteO
 	req := AgentSchedulerWorkerConfigRequest(args)
 	var resp AgentSchedulerWorkerConfigResponse
 
-	_, err := a.client.write("/v1/agent/schedulers/config", &req, &resp, q)
+	_, err := a.client.put("/v1/agent/schedulers/config", &req, &resp, q)
 	if err != nil {
 		return nil, err
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -963,10 +963,24 @@ func (c *Client) putQuery(endpoint string, in, out interface{}, q *QueryOptions)
 	return qm, nil
 }
 
-// write is used to do a PUT request against an endpoint
-// and serialize/deserialized using the standard Nomad conventions.
-func (c *Client) write(endpoint string, in, out interface{}, q *WriteOptions) (*WriteMeta, error) {
-	r, err := c.newRequest("PUT", endpoint)
+// put is used to do a PUT request against an endpoint and
+// serialize/deserialized using the standard Nomad conventions.
+func (c *Client) put(endpoint string, in, out interface{}, q *WriteOptions) (*WriteMeta, error) {
+	return c.write(http.MethodPut, endpoint, in, out, q)
+}
+
+// post is used to do a POST request against an endpoint and
+// serialize/deserialized using the standard Nomad conventions.
+func (c *Client) post(endpoint string, in, out interface{}, q *WriteOptions) (*WriteMeta, error) {
+	return c.write(http.MethodPost, endpoint, in, out, q)
+}
+
+// write is used to do a write request against an endpoint and
+// serialize/deserialized using the standard Nomad conventions.
+//
+// You probably want the delete, post, or put methods.
+func (c *Client) write(verb, endpoint string, in, out interface{}, q *WriteOptions) (*WriteMeta, error) {
+	r, err := c.newRequest(verb, endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -92,7 +92,7 @@ func TestRequestTime(t *testing.T) {
 		t.Errorf("bad request time: %d", qm.RequestTime)
 	}
 
-	wm, err := client.write("/", struct{ S string }{"input"}, &out, nil)
+	wm, err := client.put("/", struct{ S string }{"input"}, &out, nil)
 	if err != nil {
 		t.Fatalf("write err: %v", err)
 	}

--- a/api/csi.go
+++ b/api/csi.go
@@ -76,7 +76,7 @@ func (v *CSIVolumes) Register(vol *CSIVolume, w *WriteOptions) (*WriteMeta, erro
 	req := CSIVolumeRegisterRequest{
 		Volumes: []*CSIVolume{vol},
 	}
-	meta, err := v.client.write("/v1/volume/csi/"+vol.ID, req, nil, w)
+	meta, err := v.client.put("/v1/volume/csi/"+vol.ID, req, nil, w)
 	return meta, err
 }
 
@@ -95,7 +95,7 @@ func (v *CSIVolumes) Create(vol *CSIVolume, w *WriteOptions) ([]*CSIVolume, *Wri
 	}
 
 	resp := &CSIVolumeCreateResponse{}
-	meta, err := v.client.write(fmt.Sprintf("/v1/volume/csi/%v/create", vol.ID), req, resp, w)
+	meta, err := v.client.put(fmt.Sprintf("/v1/volume/csi/%v/create", vol.ID), req, resp, w)
 	return resp.Volumes, meta, err
 }
 
@@ -139,7 +139,7 @@ func (v *CSIVolumes) CreateSnapshot(snap *CSISnapshot, w *WriteOptions) (*CSISna
 	}
 	w.SetHeadersFromCSISecrets(snap.Secrets)
 	resp := &CSISnapshotCreateResponse{}
-	meta, err := v.client.write("/v1/volumes/snapshot", req, resp, w)
+	meta, err := v.client.put("/v1/volumes/snapshot", req, resp, w)
 	return resp, meta, err
 }
 

--- a/api/deployments.go
+++ b/api/deployments.go
@@ -58,7 +58,7 @@ func (d *Deployments) Fail(deploymentID string, q *WriteOptions) (*DeploymentUpd
 	req := &DeploymentFailRequest{
 		DeploymentID: deploymentID,
 	}
-	wm, err := d.client.write("/v1/deployment/fail/"+deploymentID, req, &resp, q)
+	wm, err := d.client.put("/v1/deployment/fail/"+deploymentID, req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -72,7 +72,7 @@ func (d *Deployments) Pause(deploymentID string, pause bool, q *WriteOptions) (*
 		DeploymentID: deploymentID,
 		Pause:        pause,
 	}
-	wm, err := d.client.write("/v1/deployment/pause/"+deploymentID, req, &resp, q)
+	wm, err := d.client.put("/v1/deployment/pause/"+deploymentID, req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -86,7 +86,7 @@ func (d *Deployments) PromoteAll(deploymentID string, q *WriteOptions) (*Deploym
 		DeploymentID: deploymentID,
 		All:          true,
 	}
-	wm, err := d.client.write("/v1/deployment/promote/"+deploymentID, req, &resp, q)
+	wm, err := d.client.put("/v1/deployment/promote/"+deploymentID, req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -100,7 +100,7 @@ func (d *Deployments) PromoteGroups(deploymentID string, groups []string, q *Wri
 		DeploymentID: deploymentID,
 		Groups:       groups,
 	}
-	wm, err := d.client.write("/v1/deployment/promote/"+deploymentID, req, &resp, q)
+	wm, err := d.client.put("/v1/deployment/promote/"+deploymentID, req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -113,7 +113,7 @@ func (d *Deployments) Unblock(deploymentID string, q *WriteOptions) (*Deployment
 	req := &DeploymentUnblockRequest{
 		DeploymentID: deploymentID,
 	}
-	wm, err := d.client.write("/v1/deployment/unblock/"+deploymentID, req, &resp, q)
+	wm, err := d.client.put("/v1/deployment/unblock/"+deploymentID, req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -129,7 +129,7 @@ func (d *Deployments) SetAllocHealth(deploymentID string, healthy, unhealthy []s
 		HealthyAllocationIDs:   healthy,
 		UnhealthyAllocationIDs: unhealthy,
 	}
-	wm, err := d.client.write("/v1/deployment/allocation-health/"+deploymentID, req, &resp, q)
+	wm, err := d.client.put("/v1/deployment/allocation-health/"+deploymentID, req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -95,7 +95,7 @@ func (j *Jobs) ParseHCL(jobHCL string, canonicalize bool) (*Job, error) {
 // ParseHCL is an alternative convenience API for HCLv2 users.
 func (j *Jobs) ParseHCLOpts(req *JobsParseRequest) (*Job, error) {
 	var job Job
-	_, err := j.client.write("/v1/jobs/parse", req, &job, nil)
+	_, err := j.client.put("/v1/jobs/parse", req, &job, nil)
 	return &job, err
 }
 
@@ -105,7 +105,7 @@ func (j *Jobs) Validate(job *Job, q *WriteOptions) (*JobValidateResponse, *Write
 	if q != nil {
 		req.WriteRequest = WriteRequest{Region: q.Region}
 	}
-	wm, err := j.client.write("/v1/validate/job", req, &resp, q)
+	wm, err := j.client.put("/v1/validate/job", req, &resp, q)
 	return &resp, wm, err
 }
 
@@ -148,7 +148,7 @@ func (j *Jobs) RegisterOpts(job *Job, opts *RegisterOptions, q *WriteOptions) (*
 	}
 
 	var resp JobRegisterResponse
-	wm, err := j.client.write("/v1/jobs", req, &resp, q)
+	wm, err := j.client.put("/v1/jobs", req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -223,7 +223,7 @@ func (j *Jobs) Scale(jobID, group string, count *int, message string, error bool
 		Meta:    meta,
 	}
 	var resp JobRegisterResponse
-	qm, err := j.client.write(fmt.Sprintf("/v1/job/%s/scale", url.PathEscape(jobID)), req, &resp, q)
+	qm, err := j.client.put(fmt.Sprintf("/v1/job/%s/scale", url.PathEscape(jobID)), req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -376,7 +376,7 @@ func (j *Jobs) DeregisterOpts(jobID string, opts *DeregisterOptions, q *WriteOpt
 // ForceEvaluate is used to force-evaluate an existing job.
 func (j *Jobs) ForceEvaluate(jobID string, q *WriteOptions) (string, *WriteMeta, error) {
 	var resp JobRegisterResponse
-	wm, err := j.client.write("/v1/job/"+url.PathEscape(jobID)+"/evaluate", nil, &resp, q)
+	wm, err := j.client.put("/v1/job/"+url.PathEscape(jobID)+"/evaluate", nil, &resp, q)
 	if err != nil {
 		return "", nil, err
 	}
@@ -392,7 +392,7 @@ func (j *Jobs) EvaluateWithOpts(jobID string, opts EvalOptions, q *WriteOptions)
 	}
 
 	var resp JobRegisterResponse
-	wm, err := j.client.write("/v1/job/"+url.PathEscape(jobID)+"/evaluate", req, &resp, q)
+	wm, err := j.client.put("/v1/job/"+url.PathEscape(jobID)+"/evaluate", req, &resp, q)
 	if err != nil {
 		return "", nil, err
 	}
@@ -402,7 +402,7 @@ func (j *Jobs) EvaluateWithOpts(jobID string, opts EvalOptions, q *WriteOptions)
 // PeriodicForce spawns a new instance of the periodic job and returns the eval ID
 func (j *Jobs) PeriodicForce(jobID string, q *WriteOptions) (string, *WriteMeta, error) {
 	var resp periodicForceResponse
-	wm, err := j.client.write("/v1/job/"+url.PathEscape(jobID)+"/periodic/force", nil, &resp, q)
+	wm, err := j.client.put("/v1/job/"+url.PathEscape(jobID)+"/periodic/force", nil, &resp, q)
 	if err != nil {
 		return "", nil, err
 	}
@@ -435,7 +435,7 @@ func (j *Jobs) PlanOpts(job *Job, opts *PlanOptions, q *WriteOptions) (*JobPlanR
 	}
 
 	var resp JobPlanResponse
-	wm, err := j.client.write("/v1/job/"+url.PathEscape(*job.ID)+"/plan", req, &resp, q)
+	wm, err := j.client.put("/v1/job/"+url.PathEscape(*job.ID)+"/plan", req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -460,7 +460,7 @@ func (j *Jobs) Dispatch(jobID string, meta map[string]string,
 		Payload:          payload,
 		IdPrefixTemplate: idPrefixTemplate,
 	}
-	wm, err := j.client.write("/v1/job/"+url.PathEscape(jobID)+"/dispatch", req, &resp, q)
+	wm, err := j.client.put("/v1/job/"+url.PathEscape(jobID)+"/dispatch", req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -481,7 +481,7 @@ func (j *Jobs) Revert(jobID string, version uint64, enforcePriorVersion *uint64,
 		ConsulToken:         consulToken,
 		VaultToken:          vaultToken,
 	}
-	wm, err := j.client.write("/v1/job/"+url.PathEscape(jobID)+"/revert", req, &resp, q)
+	wm, err := j.client.put("/v1/job/"+url.PathEscape(jobID)+"/revert", req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -498,7 +498,7 @@ func (j *Jobs) Stable(jobID string, version uint64, stable bool,
 		JobVersion: version,
 		Stable:     stable,
 	}
-	wm, err := j.client.write("/v1/job/"+url.PathEscape(jobID)+"/stable", req, &resp, q)
+	wm, err := j.client.put("/v1/job/"+url.PathEscape(jobID)+"/stable", req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api/keyring.go
+++ b/api/keyring.go
@@ -77,7 +77,7 @@ func (k *Keyring) Rotate(opts *KeyringRotateOptions, w *WriteOptions) (*RootKeyM
 		}
 	}
 	resp := &struct{ Key *RootKeyMeta }{}
-	wm, err := k.client.write("/v1/operator/keyring/rotate?"+qp.Encode(), nil, resp, w)
+	wm, err := k.client.put("/v1/operator/keyring/rotate?"+qp.Encode(), nil, resp, w)
 	return resp.Key, wm, err
 }
 

--- a/api/namespace.go
+++ b/api/namespace.go
@@ -49,7 +49,7 @@ func (n *Namespaces) Info(name string, q *QueryOptions) (*Namespace, *QueryMeta,
 
 // Register is used to register a namespace.
 func (n *Namespaces) Register(namespace *Namespace, q *WriteOptions) (*WriteMeta, error) {
-	wm, err := n.client.write("/v1/namespace", namespace, nil, q)
+	wm, err := n.client.put("/v1/namespace", namespace, nil, q)
 	if err != nil {
 		return nil, err
 	}

--- a/api/node_meta.go
+++ b/api/node_meta.go
@@ -25,7 +25,7 @@ func (n *Nodes) Meta() *NodeMeta {
 // receiving the request is modified.
 func (n *NodeMeta) Apply(meta *NodeMetaApplyRequest, qo *WriteOptions) (*NodeMetaResponse, error) {
 	var out NodeMetaResponse
-	_, err := n.client.write("/v1/client/metadata", meta, &out, qo)
+	_, err := n.client.post("/v1/client/metadata", meta, &out, qo)
 	if err != nil {
 		return nil, err
 	}

--- a/api/node_meta.go
+++ b/api/node_meta.go
@@ -1,0 +1,55 @@
+package api
+
+// NodeMetaApplyRequest contains the Node meta update.
+type NodeMetaApplyRequest struct {
+	NodeID string
+	Meta   map[string]*string
+}
+
+// NodeMetaResponse contains the merged Node metadata.
+type NodeMetaResponse struct {
+	Meta map[string]string
+}
+
+// NodeMeta is a client for manipulating dynamic Node metadata.
+type NodeMeta struct {
+	client *Client
+}
+
+// Meta returns a NodeMeta client.
+func (n *Nodes) Meta() *NodeMeta {
+	return &NodeMeta{client: n.client}
+}
+
+// Apply dynamic Node metadata updates to a Node. If NodeID is unset then Node
+// receiving the request is modified.
+func (n *NodeMeta) Apply(meta *NodeMetaApplyRequest, qo *WriteOptions) (*NodeMetaResponse, error) {
+	var out NodeMetaResponse
+	_, err := n.client.write("/v1/client/metadata", meta, &out, qo)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Read Node metadata (dynamic and static merged) from a Node directly. May
+// differ from Node.Info as dynamic Node metadata updates are batched and may
+// be delayed up to 10 seconds.
+//
+// If nodeID is empty then the metadata for the Node receiving the request is
+// returned.
+func (n *NodeMeta) Read(nodeID string, qo *QueryOptions) (*NodeMetaResponse, error) {
+	var out NodeMetaResponse
+
+	url := "/v1/client/metadata"
+	if nodeID != "" {
+		url += "?node_id=" + nodeID
+	}
+
+	_, err := n.client.query(url, &out, qo)
+	if err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}

--- a/api/node_meta.go
+++ b/api/node_meta.go
@@ -1,14 +1,18 @@
 package api
 
-// NodeMetaApplyRequest contains the Node meta update.
-type NodeMetaApplyRequest struct {
+// NodeMetaSetRequest contains the Node meta update.
+type NodeMetaSetRequest struct {
 	NodeID string
 	Meta   map[string]*string
 }
 
 // NodeMetaResponse contains the merged Node metadata.
 type NodeMetaResponse struct {
+	// Meta is the merged static + dynamic Node metadata
 	Meta map[string]string
+
+	// Dynamic is the dynamic Node metadata
+	Dynamic map[string]*string
 }
 
 // NodeMeta is a client for manipulating dynamic Node metadata.
@@ -21,9 +25,9 @@ func (n *Nodes) Meta() *NodeMeta {
 	return &NodeMeta{client: n.client}
 }
 
-// Apply dynamic Node metadata updates to a Node. If NodeID is unset then Node
+// Set dynamic Node metadata updates to a Node. If NodeID is unset then Node
 // receiving the request is modified.
-func (n *NodeMeta) Apply(meta *NodeMetaApplyRequest, qo *WriteOptions) (*NodeMetaResponse, error) {
+func (n *NodeMeta) Set(meta *NodeMetaSetRequest, qo *WriteOptions) (*NodeMetaResponse, error) {
 	var out NodeMetaResponse
 	_, err := n.client.post("/v1/client/metadata", meta, &out, qo)
 	if err != nil {

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -135,7 +135,7 @@ func (n *Nodes) UpdateDrainOpts(nodeID string, opts *DrainOptions, q *WriteOptio
 	}
 
 	var resp NodeDrainUpdateResponse
-	wm, err := n.client.write("/v1/node/"+nodeID+"/drain", req, &resp, q)
+	wm, err := n.client.put("/v1/node/"+nodeID+"/drain", req, &resp, q)
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +419,7 @@ func (n *Nodes) ToggleEligibility(nodeID string, eligible bool, q *WriteOptions)
 	}
 
 	var resp NodeEligibilityUpdateResponse
-	wm, err := n.client.write("/v1/node/"+nodeID+"/eligibility", req, &resp, q)
+	wm, err := n.client.put("/v1/node/"+nodeID+"/eligibility", req, &resp, q)
 	if err != nil {
 		return nil, err
 	}
@@ -451,7 +451,7 @@ func (n *Nodes) CSIVolumes(nodeID string, q *QueryOptions) ([]*CSIVolumeListStub
 // ForceEvaluate is used to force-evaluate an existing node.
 func (n *Nodes) ForceEvaluate(nodeID string, q *WriteOptions) (string, *WriteMeta, error) {
 	var resp nodeEvalResponse
-	wm, err := n.client.write("/v1/node/"+nodeID+"/evaluate", nil, &resp, q)
+	wm, err := n.client.put("/v1/node/"+nodeID+"/evaluate", nil, &resp, q)
 	if err != nil {
 		return "", nil, err
 	}
@@ -515,7 +515,7 @@ type HostVolumeInfo struct {
 	ReadOnly bool
 }
 
-//HostNetworkInfo is used to return metadata about a given HostNetwork
+// HostNetworkInfo is used to return metadata about a given HostNetwork
 type HostNetworkInfo struct {
 	Name          string
 	CIDR          string

--- a/api/operator.go
+++ b/api/operator.go
@@ -192,7 +192,7 @@ func (op *Operator) SchedulerGetConfiguration(q *QueryOptions) (*SchedulerConfig
 // SchedulerSetConfiguration is used to set the current Scheduler configuration.
 func (op *Operator) SchedulerSetConfiguration(conf *SchedulerConfiguration, q *WriteOptions) (*SchedulerSetConfigurationResponse, *WriteMeta, error) {
 	var out SchedulerSetConfigurationResponse
-	wm, err := op.c.write("/v1/operator/scheduler/configuration", conf, &out, q)
+	wm, err := op.c.put("/v1/operator/scheduler/configuration", conf, &out, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -204,7 +204,7 @@ func (op *Operator) SchedulerSetConfiguration(conf *SchedulerConfiguration, q *W
 // true on success or false on failures.
 func (op *Operator) SchedulerCASConfiguration(conf *SchedulerConfiguration, q *WriteOptions) (*SchedulerSetConfigurationResponse, *WriteMeta, error) {
 	var out SchedulerSetConfigurationResponse
-	wm, err := op.c.write("/v1/operator/scheduler/configuration?cas="+strconv.FormatUint(conf.ModifyIndex, 10), conf, &out, q)
+	wm, err := op.c.put("/v1/operator/scheduler/configuration?cas="+strconv.FormatUint(conf.ModifyIndex, 10), conf, &out, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -241,7 +241,7 @@ func (op *Operator) Snapshot(q *QueryOptions) (io.ReadCloser, error) {
 // SnapshotRestore is used to restore a running nomad cluster to an original
 // state.
 func (op *Operator) SnapshotRestore(in io.Reader, q *WriteOptions) (*WriteMeta, error) {
-	wm, err := op.c.write("/v1/operator/snapshot", in, nil, q)
+	wm, err := op.c.put("/v1/operator/snapshot", in, nil, q)
 	if err != nil {
 		return nil, err
 	}

--- a/api/operator_autopilot.go
+++ b/api/operator_autopilot.go
@@ -190,7 +190,7 @@ func (op *Operator) AutopilotGetConfiguration(q *QueryOptions) (*AutopilotConfig
 // AutopilotSetConfiguration is used to set the current Autopilot configuration.
 func (op *Operator) AutopilotSetConfiguration(conf *AutopilotConfiguration, q *WriteOptions) (*WriteMeta, error) {
 	var out bool
-	wm, err := op.c.write("/v1/operator/autopilot/configuration", conf, &out, q)
+	wm, err := op.c.put("/v1/operator/autopilot/configuration", conf, &out, q)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (op *Operator) AutopilotSetConfiguration(conf *AutopilotConfiguration, q *W
 // true on success or false on failures.
 func (op *Operator) AutopilotCASConfiguration(conf *AutopilotConfiguration, q *WriteOptions) (bool, *WriteMeta, error) {
 	var out bool
-	wm, err := op.c.write("/v1/operator/autopilot/configuration?cas="+strconv.FormatUint(conf.ModifyIndex, 10), conf, &out, q)
+	wm, err := op.c.put("/v1/operator/autopilot/configuration?cas="+strconv.FormatUint(conf.ModifyIndex, 10), conf, &out, q)
 	if err != nil {
 		return false, nil, err
 	}

--- a/api/quota.go
+++ b/api/quota.go
@@ -81,7 +81,7 @@ func (q *Quotas) Usage(name string, qo *QueryOptions) (*QuotaUsage, *QueryMeta, 
 
 // Register is used to register a quota spec.
 func (q *Quotas) Register(spec *QuotaSpec, qo *WriteOptions) (*WriteMeta, error) {
-	wm, err := q.client.write("/v1/quota", spec, nil, qo)
+	wm, err := q.client.put("/v1/quota", spec, nil, qo)
 	if err != nil {
 		return nil, err
 	}

--- a/api/raw.go
+++ b/api/raw.go
@@ -28,7 +28,7 @@ func (raw *Raw) Response(endpoint string, q *QueryOptions) (io.ReadCloser, error
 // Write is used to do a PUT request against an endpoint
 // and serialize/deserialized using the standard Nomad conventions.
 func (raw *Raw) Write(endpoint string, in, out interface{}, q *WriteOptions) (*WriteMeta, error) {
-	return raw.c.write(endpoint, in, out, q)
+	return raw.c.put(endpoint, in, out, q)
 }
 
 // Delete is used to do a DELETE request against an endpoint

--- a/api/recommendations.go
+++ b/api/recommendations.go
@@ -33,7 +33,7 @@ func (r *Recommendations) Info(id string, q *QueryOptions) (*Recommendation, *Qu
 // Upsert is used to create or update a recommendation
 func (r *Recommendations) Upsert(rec *Recommendation, q *WriteOptions) (*Recommendation, *WriteMeta, error) {
 	var resp Recommendation
-	wm, err := r.client.write("/v1/recommendation", rec, &resp, q)
+	wm, err := r.client.put("/v1/recommendation", rec, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -46,7 +46,7 @@ func (r *Recommendations) Delete(ids []string, q *WriteOptions) (*WriteMeta, err
 		Apply:   []string{},
 		Dismiss: ids,
 	}
-	wm, err := r.client.write("/v1/recommendations/apply", req, nil, q)
+	wm, err := r.client.put("/v1/recommendations/apply", req, nil, q)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (r *Recommendations) Apply(ids []string, policyOverride bool) (
 		PolicyOverride: policyOverride,
 	}
 	var resp RecommendationApplyResponse
-	wm, err := r.client.write("/v1/recommendations/apply", req, &resp, nil)
+	wm, err := r.client.put("/v1/recommendations/apply", req, &resp, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api/sentinel.go
+++ b/api/sentinel.go
@@ -29,7 +29,7 @@ func (a *SentinelPolicies) Upsert(policy *SentinelPolicy, q *WriteOptions) (*Wri
 	if policy == nil || policy.Name == "" {
 		return nil, errors.New("missing policy name")
 	}
-	wm, err := a.client.write("/v1/sentinel/policy/"+policy.Name, policy, nil, q)
+	wm, err := a.client.put("/v1/sentinel/policy/"+policy.Name, policy, nil, q)
 	if err != nil {
 		return nil, err
 	}

--- a/api/system.go
+++ b/api/system.go
@@ -12,12 +12,12 @@ func (c *Client) System() *System {
 
 func (s *System) GarbageCollect() error {
 	var req struct{}
-	_, err := s.client.write("/v1/system/gc", &req, nil, nil)
+	_, err := s.client.put("/v1/system/gc", &req, nil, nil)
 	return err
 }
 
 func (s *System) ReconcileSummaries() error {
 	var req struct{}
-	_, err := s.client.write("/v1/system/reconcile/summaries", &req, nil, nil)
+	_, err := s.client.put("/v1/system/reconcile/summaries", &req, nil, nil)
 	return err
 }

--- a/api/variables.go
+++ b/api/variables.go
@@ -31,7 +31,7 @@ func (sv *Variables) Create(v *Variable, qo *WriteOptions) (*Variable, *WriteMet
 
 	v.Path = cleanPathString(v.Path)
 	var out Variable
-	wm, err := sv.client.write("/v1/var/"+v.Path, v, &out, qo)
+	wm, err := sv.client.put("/v1/var/"+v.Path, v, &out, qo)
 	if err != nil {
 		return nil, wm, err
 	}
@@ -88,7 +88,7 @@ func (sv *Variables) Update(v *Variable, qo *WriteOptions) (*Variable, *WriteMet
 	v.Path = cleanPathString(v.Path)
 	var out Variable
 
-	wm, err := sv.client.write("/v1/var/"+v.Path, v, &out, qo)
+	wm, err := sv.client.put("/v1/var/"+v.Path, v, &out, qo)
 	if err != nil {
 		return nil, wm, err
 	}

--- a/api/variables_test.go
+++ b/api/variables_test.go
@@ -226,7 +226,7 @@ func TestVariables_Read(t *testing.T) {
 }
 
 func writeTestVariable(t *testing.T, c *Client, sv *Variable) {
-	_, err := c.write("/v1/var/"+sv.Path, sv, sv, nil)
+	_, err := c.put("/v1/var/"+sv.Path, sv, sv, nil)
 	must.NoError(t, err, must.Sprint("failed writing test variable"))
 	must.NoError(t, err, must.Sprint("failed writing test variable"))
 }

--- a/client/client.go
+++ b/client/client.go
@@ -733,7 +733,7 @@ func (c *Client) reloadTLSConnections(newConfig *nconfig.TLSConfig) error {
 	return nil
 }
 
-// Reload allows a client to reload its configuration on the fly
+// Reload allows a client to reload parts of its configuration on the fly
 func (c *Client) Reload(newConfig *config.Config) error {
 	existing := c.GetConfig()
 	shouldReloadTLS, err := tlsutil.ShouldReloadRPCConnections(existing.TLSConfig, newConfig.TLSConfig)
@@ -743,7 +743,9 @@ func (c *Client) Reload(newConfig *config.Config) error {
 	}
 
 	if shouldReloadTLS {
-		return c.reloadTLSConnections(newConfig.TLSConfig)
+		if err := c.reloadTLSConnections(newConfig.TLSConfig); err != nil {
+			return err
+		}
 	}
 
 	c.fingerprintManager.Reload()

--- a/client/client.go
+++ b/client/client.go
@@ -792,20 +792,15 @@ func (c *Client) UpdateNode(cb func(*structs.Node)) *structs.Node {
 	c.configLock.Lock()
 	defer c.configLock.Unlock()
 
-	//TODO(schmichael): is this necessary?
-	// Client synchronizes all access to c.config but not to any config
-	// fields, so we must make a shallow copy of the config to mutate
-	// config.Node.
-	newConfig := *c.config
-
-	// Create a new Node for updating as the shallow copy's Node may have
-	// concurrent readers
-	newNode := newConfig.Node.Copy()
+	// Create a new copy of Node for updating
+	newNode := c.config.Node.Copy()
 
 	// newNode is now a fresh unshared copy, mutate away!
 	cb(newNode)
 
-	// Copy back the mutated structs
+	// Shallow copy config before mutating Node pointer which might have
+	// concurrent readers
+	newConfig := *c.config
 	newConfig.Node = newNode
 	c.config = &newConfig
 

--- a/client/meta_endpoint.go
+++ b/client/meta_endpoint.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"time"
 
 	metrics "github.com/armon/go-metrics"
@@ -19,7 +20,20 @@ func newNodeMetaEndpoint(c *Client) *NodeMeta {
 func (n *NodeMeta) Apply(req *structs.NodeMetaApplyRequest, resp *structs.NodeMetaResponse) error {
 	defer metrics.MeasureSince([]string{"client", "node_meta", "apply"}, time.Now())
 
+	//TODO permissions check
+
+	var err error
+
 	newNode := n.c.UpdateNode(func(node *structs.Node) {
+		// First update the Client's state store. This must be done
+		// atomically with updating the metadata inmemory to avoid
+		// interleaving updates causing incoherency between the state
+		// store and inmemory.
+		if err := n.c.stateDB.MergeNodeMeta(req.Meta); err != nil {
+			err = fmt.Errorf("failed to apply dynamic node metadata: %w", err)
+			return
+		}
+
 		for k, v := range req.Meta {
 			if v == nil {
 				delete(node.Meta, k)
@@ -30,12 +44,18 @@ func (n *NodeMeta) Apply(req *structs.NodeMetaApplyRequest, resp *structs.NodeMe
 		}
 	})
 
+	if err != nil {
+		return err
+	}
+
 	resp.Meta = newNode.Meta
 	return nil
 }
 
-func (n *NodeMeta) Read(req *struct{}, resp *structs.NodeMetaResponse) error {
+func (n *NodeMeta) Read(req *structs.NodeSpecificRequest, resp *structs.NodeMetaResponse) error {
 	defer metrics.MeasureSince([]string{"client", "node_meta", "reaj"}, time.Now())
+
+	//TODO permissions check
 
 	resp.Meta = n.c.Node().Meta
 

--- a/client/meta_endpoint.go
+++ b/client/meta_endpoint.go
@@ -1,0 +1,43 @@
+package client
+
+import (
+	"time"
+
+	metrics "github.com/armon/go-metrics"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+type NodeMeta struct {
+	c *Client
+}
+
+func newNodeMetaEndpoint(c *Client) *NodeMeta {
+	n := &NodeMeta{c: c}
+	return n
+}
+
+func (n *NodeMeta) Apply(req *structs.NodeMetaApplyRequest, resp *structs.NodeMetaResponse) error {
+	defer metrics.MeasureSince([]string{"client", "node_meta", "apply"}, time.Now())
+
+	newNode := n.c.UpdateNode(func(node *structs.Node) {
+		for k, v := range req.Meta {
+			if v == nil {
+				delete(node.Meta, k)
+				continue
+			}
+
+			node.Meta[k] = *v
+		}
+	})
+
+	resp.Meta = newNode.Meta
+	return nil
+}
+
+func (n *NodeMeta) Read(req *struct{}, resp *structs.NodeMetaResponse) error {
+	defer metrics.MeasureSince([]string{"client", "node_meta", "reaj"}, time.Now())
+
+	resp.Meta = n.c.Node().Meta
+
+	return nil
+}

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -24,6 +24,7 @@ type rpcEndpoints struct {
 	FileSystem  *FileSystem
 	Allocations *Allocations
 	Agent       *Agent
+	NodeMeta    *NodeMeta
 }
 
 // ClientRPC is used to make a local, client only RPC call
@@ -268,6 +269,7 @@ func (c *Client) setupClientRpc(rpcs map[string]interface{}) {
 		c.endpoints.FileSystem = NewFileSystemEndpoint(c)
 		c.endpoints.Allocations = NewAllocationsEndpoint(c)
 		c.endpoints.Agent = NewAgentEndpoint(c)
+		c.endpoints.NodeMeta = newNodeMetaEndpoint(c)
 		c.setupClientRpcServer(c.rpcServer)
 	}
 
@@ -282,6 +284,7 @@ func (c *Client) setupClientRpcServer(server *rpc.Server) {
 	server.Register(c.endpoints.FileSystem)
 	server.Register(c.endpoints.Allocations)
 	server.Register(c.endpoints.Agent)
+	server.Register(c.endpoints.NodeMeta)
 }
 
 // rpcConnListener is a long lived function that listens for new connections

--- a/client/state/db_bolt.go
+++ b/client/state/db_bolt.go
@@ -815,28 +815,6 @@ func (s *BoltStateDB) PutNodeMeta(meta map[string]*string) error {
 	})
 }
 
-// MergeNodeMeta merges dynamic node metadata with existing dynamic node
-// metadata.
-func (s *BoltStateDB) MergeNodeMeta(meta map[string]*string) error {
-	return s.db.Update(func(tx *boltdd.Tx) error {
-		b, err := tx.CreateBucketIfNotExists(nodeMetaBucket)
-		if err != nil {
-			return err
-		}
-
-		// Before writing merge with existing dynamic node metadata
-		existing, err := getNodeMeta(b)
-		if err != nil {
-			return err
-		}
-
-		for k, v := range meta {
-			existing[k] = v
-		}
-		return b.Put(nodeMetaKey, existing)
-	})
-}
-
 // GetNodeMeta retrieves node metadata for merging with the copy from
 // the Client's config.
 func (s *BoltStateDB) GetNodeMeta() (m map[string]*string, err error) {

--- a/client/state/db_bolt.go
+++ b/client/state/db_bolt.go
@@ -43,6 +43,9 @@ drivermanager/
 
 dynamicplugins/
 |--> registry_state -> *dynamicplugins.RegistryState
+
+nodemeta/
+|--> meta -> map[string]*string
 */
 
 var (
@@ -102,6 +105,13 @@ var (
 
 	// registryStateKey is the key at which dynamic plugin registry state is stored
 	registryStateKey = []byte("registry_state")
+
+	// nodeMetaBucket is the bucket name in which dynamically updated node
+	// metadata is stored
+	nodeMetaBucket = []byte("nodemeta")
+
+	// nodeMetaKey is the key at which dynamic node metadata is stored.
+	nodeMetaKey = []byte("meta")
 )
 
 // taskBucketName returns the bucket name for the given task name.
@@ -788,6 +798,69 @@ func (s *BoltStateDB) PurgeCheckResults(allocID string) error {
 		}
 		return bkt.DeletePrefix([]byte(allocID + "_"))
 	})
+}
+
+// PutNodeMeta sets dynamic node metadata for merging with the copy from the
+// Client's config.
+//
+// This overwrites existing dynamic node metadata entirely.
+func (s *BoltStateDB) PutNodeMeta(meta map[string]*string) error {
+	return s.db.Update(func(tx *boltdd.Tx) error {
+		b, err := tx.CreateBucketIfNotExists(nodeMetaBucket)
+		if err != nil {
+			return err
+		}
+
+		return b.Put(nodeMetaKey, meta)
+	})
+}
+
+// MergeNodeMeta merges dynamic node metadata with existing dynamic node
+// metadata.
+func (s *BoltStateDB) MergeNodeMeta(meta map[string]*string) error {
+	return s.db.Update(func(tx *boltdd.Tx) error {
+		b, err := tx.CreateBucketIfNotExists(nodeMetaBucket)
+		if err != nil {
+			return err
+		}
+
+		// Before writing merge with existing dynamic node metadata
+		existing, err := getNodeMeta(b)
+		if err != nil {
+			return err
+		}
+
+		for k, v := range meta {
+			existing[k] = v
+		}
+		return b.Put(nodeMetaKey, existing)
+	})
+}
+
+// GetNodeMeta retrieves node metadata for merging with the copy from
+// the Client's config.
+func (s *BoltStateDB) GetNodeMeta() (m map[string]*string, err error) {
+	err = s.db.View(func(tx *boltdd.Tx) error {
+		b := tx.Bucket(nodeMetaBucket)
+		if b == nil {
+			return nil
+		}
+
+		m, err = getNodeMeta(b)
+		return err
+	})
+
+	return m, err
+}
+
+func getNodeMeta(b *boltdd.Bucket) (map[string]*string, error) {
+	m := make(map[string]*string)
+	if err := b.Get(nodeMetaKey, m); err != nil {
+		if !boltdd.IsErrNotFound(err) {
+			return nil, err
+		}
+	}
+	return m, nil
 }
 
 // init initializes metadata entries in a newly created state database.

--- a/client/state/db_noop.go
+++ b/client/state/db_noop.go
@@ -104,6 +104,18 @@ func (n NoopDB) PurgeCheckResults(allocID string) error {
 	return nil
 }
 
+func (n NoopDB) PutNodeMeta(map[string]*string) error {
+	return nil
+}
+
+func (n NoopDB) MergeNodeMeta(map[string]*string) error {
+	return nil
+}
+
+func (n NoopDB) GetNodeMeta() (map[string]*string, error) {
+	return nil, nil
+}
+
 func (n NoopDB) Close() error {
 	return nil
 }

--- a/client/state/db_noop.go
+++ b/client/state/db_noop.go
@@ -108,10 +108,6 @@ func (n NoopDB) PutNodeMeta(map[string]*string) error {
 	return nil
 }
 
-func (n NoopDB) MergeNodeMeta(map[string]*string) error {
-	return nil
-}
-
 func (n NoopDB) GetNodeMeta() (map[string]*string, error) {
 	return nil, nil
 }

--- a/client/state/interface.go
+++ b/client/state/interface.go
@@ -96,6 +96,20 @@ type StateDB interface {
 	// GetCheckResults is used to restore the set of check results on this Client.
 	GetCheckResults() (checks.ClientResults, error)
 
+	// PutNodeMeta sets dynamic node metadata for merging with the copy from the
+	// Client's config.
+	//
+	// This overwrites existing dynamic node metadata entirely.
+	PutNodeMeta(map[string]*string) error
+
+	// MergeNodeMeta merges dynamic node metadata with existing dynamic node
+	// metadata.
+	MergeNodeMeta(map[string]*string) error
+
+	// GetNodeMeta retrieves node metadata for merging with the copy from
+	// the Client's config.
+	GetNodeMeta() (map[string]*string, error)
+
 	// Close the database. Unsafe for further use after calling regardless
 	// of return value.
 	Close() error

--- a/client/state/interface.go
+++ b/client/state/interface.go
@@ -102,10 +102,6 @@ type StateDB interface {
 	// This overwrites existing dynamic node metadata entirely.
 	PutNodeMeta(map[string]*string) error
 
-	// MergeNodeMeta merges dynamic node metadata with existing dynamic node
-	// metadata.
-	MergeNodeMeta(map[string]*string) error
-
 	// GetNodeMeta retrieves node metadata for merging with the copy from
 	// the Client's config.
 	GetNodeMeta() (map[string]*string, error)

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -238,17 +238,14 @@ func (s *HTTPServer) ClientAllocRequest(resp http.ResponseWriter, req *http.Requ
 }
 
 func (s *HTTPServer) ClientGCRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	// Get the requested Node ID
-	requestedNode := req.URL.Query().Get("node_id")
 
-	// Build the request and parse the ACL token
-	args := structs.NodeSpecificRequest{
-		NodeID: requestedNode,
-	}
+	// Build the request and get the requested Node ID
+	args := structs.NodeSpecificRequest{}
 	s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
+	parseNode(req, &args.NodeID)
 
 	// Determine the handler to use
-	useLocalClient, useClientRPC, useServerRPC := s.rpcHandlerForNode(requestedNode)
+	useLocalClient, useClientRPC, useServerRPC := s.rpcHandlerForNode(args.NodeID)
 
 	// Make the RPC
 	var reply structs.GenericResponse

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -937,8 +937,9 @@ func parseReverse(req *http.Request, b *structs.QueryOptions) {
 
 // parseNode parses the node_id query parameter for node specific requests.
 func parseNode(req *http.Request, nodeID *string) {
-	n := req.URL.Query().Get("node_id")
-	nodeID = &n
+	if n := req.URL.Query().Get("node_id"); n != "" {
+		nodeID = &n
+	}
 }
 
 // parseWriteRequest is a convenience method for endpoints that need to parse a

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -935,6 +935,12 @@ func parseReverse(req *http.Request, b *structs.QueryOptions) {
 	b.Reverse = query.Get("reverse") == "true"
 }
 
+// parseNode parses the node_id query parameter for node specific requests.
+func parseNode(req *http.Request, nodeID *string) {
+	n := req.URL.Query().Get("node_id")
+	nodeID = &n
+}
+
 // parseWriteRequest is a convenience method for endpoints that need to parse a
 // write request.
 func (s *HTTPServer) parseWriteRequest(req *http.Request, w *structs.WriteRequest) {

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -405,6 +405,7 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/client/gc", s.wrap(s.ClientGCRequest))
 	s.mux.Handle("/v1/client/stats", wrapCORS(s.wrap(s.ClientStatsRequest)))
 	s.mux.Handle("/v1/client/allocation/", wrapCORS(s.wrap(s.ClientAllocRequest)))
+	s.mux.Handle("/v1/client/metadata", wrapCORS(s.wrap(s.NodeMetaRequest)))
 
 	s.mux.HandleFunc("/v1/agent/self", s.wrap(s.AgentSelfRequest))
 	s.mux.HandleFunc("/v1/agent/join", s.wrap(s.AgentJoinRequest))

--- a/command/agent/meta_endpoint.go
+++ b/command/agent/meta_endpoint.go
@@ -44,14 +44,52 @@ func (s *HTTPServer) nodeMetaGet(resp http.ResponseWriter, req *http.Request) (i
 		if structs.IsErrNoNodeConn(rpcErr) {
 			rpcErr = CodedError(404, rpcErr.Error())
 		}
+
+		return nil, rpcErr
 	}
 
-	return nil, rpcErr
+	return reply, nil
 }
 
 func (s *HTTPServer) nodeMetaApply(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	// Build the request by parsing all common parameters and node id
+	// Build the request by decoding body and then parsing all common
+	// parameters and node id
 	args := structs.NodeMetaApplyRequest{}
+	if err := decodeBody(req, &args); err != nil {
+		return nil, CodedError(http.StatusBadRequest, err.Error())
+	}
+	if len(args.Meta) == 0 {
+		return nil, CodedError(http.StatusBadRequest, "request missing required Meta object")
+	}
+
 	s.parseWriteRequest(req, &args.WriteRequest)
 	parseNode(req, &args.NodeID)
+
+	// Determine the handler to use
+	useLocalClient, useClientRPC, useServerRPC := s.rpcHandlerForNode(args.NodeID)
+
+	// Make the RPC
+	const rpc = "NodeMeta.Apply"
+	var reply structs.NodeMetaResponse
+	var rpcErr error
+	if useLocalClient {
+		rpcErr = s.agent.Client().ClientRPC(rpc, &args, &reply)
+	} else if useClientRPC {
+		rpcErr = s.agent.Client().RPC(rpc, &args, &reply)
+	} else if useServerRPC {
+		rpcErr = s.agent.Server().RPC(rpc, &args, &reply)
+	} else {
+		rpcErr = CodedError(400, "No local Node and node_id not provided")
+	}
+
+	if rpcErr != nil {
+		if structs.IsErrNoNodeConn(rpcErr) {
+			rpcErr = CodedError(404, rpcErr.Error())
+		}
+
+		return nil, rpcErr
+	}
+
+	return reply, nil
+
 }

--- a/command/agent/meta_endpoint.go
+++ b/command/agent/meta_endpoint.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+func (s *HTTPServer) NodeMetaRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	switch req.Method {
+	case http.MethodGet:
+		return s.nodeMetaGet(resp, req)
+	case http.MethodPost:
+		return s.nodeMetaApply(resp, req)
+	default:
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+}
+
+func (s *HTTPServer) nodeMetaGet(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	// Build the request by parsing all common parameters and node id
+	args := structs.NodeSpecificRequest{}
+	s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
+	parseNode(req, &args.NodeID)
+
+	// Determine the handler to use
+	useLocalClient, useClientRPC, useServerRPC := s.rpcHandlerForNode(args.NodeID)
+
+	// Make the RPC
+	const rpc = "NodeMeta.Read"
+	var reply structs.NodeMetaResponse
+	var rpcErr error
+	if useLocalClient {
+		rpcErr = s.agent.Client().ClientRPC(rpc, &args, &reply)
+	} else if useClientRPC {
+		rpcErr = s.agent.Client().RPC(rpc, &args, &reply)
+	} else if useServerRPC {
+		rpcErr = s.agent.Server().RPC(rpc, &args, &reply)
+	} else {
+		rpcErr = CodedError(400, "No local Node and node_id not provided")
+	}
+
+	if rpcErr != nil {
+		if structs.IsErrNoNodeConn(rpcErr) {
+			rpcErr = CodedError(404, rpcErr.Error())
+		}
+	}
+
+	return nil, rpcErr
+}
+
+func (s *HTTPServer) nodeMetaApply(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	// Build the request by parsing all common parameters and node id
+	args := structs.NodeMetaApplyRequest{}
+	s.parseWriteRequest(req, &args.WriteRequest)
+	parseNode(req, &args.NodeID)
+}

--- a/command/agent/stats_endpoint.go
+++ b/command/agent/stats_endpoint.go
@@ -9,17 +9,14 @@ import (
 )
 
 func (s *HTTPServer) ClientStatsRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	// Get the requested Node ID
-	requestedNode := req.URL.Query().Get("node_id")
 
-	// Build the request and parse the ACL token
-	args := structs.NodeSpecificRequest{
-		NodeID: requestedNode,
-	}
+	// Build the request and get the requested Node ID
+	args := structs.NodeSpecificRequest{}
 	s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
+	parseNode(req, &args.NodeID)
 
 	// Determine the handler to use
-	useLocalClient, useClientRPC, useServerRPC := s.rpcHandlerForNode(requestedNode)
+	useLocalClient, useClientRPC, useServerRPC := s.rpcHandlerForNode(args.NodeID)
 
 	// Make the RPC
 	var reply cstructs.ClientStatsResponse

--- a/command/agent_monitor.go
+++ b/command/agent_monitor.go
@@ -96,30 +96,12 @@ func (c *MonitorCommand) Run(args []string) int {
 	}
 
 	// Query the node info and lookup prefix
-	if len(nodeID) == 1 {
-		c.Ui.Error("Node identifier must contain at least two characters.")
-		return 1
-	}
-
 	if nodeID != "" {
-		nodeID = sanitizeUUIDPrefix(nodeID)
-		nodes, _, err := client.Nodes().PrefixList(nodeID)
+		nodeID, err = lookupNodeID(client.Nodes(), nodeID)
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error querying node: %v", err))
+			c.Ui.Error(err.Error())
 			return 1
 		}
-
-		if len(nodes) == 0 {
-			c.Ui.Error(fmt.Sprintf("No node(s) with prefix or id %q found", nodeID))
-			return 1
-		}
-
-		if len(nodes) > 1 {
-			out := formatNodeStubList(nodes, false)
-			c.Ui.Output(fmt.Sprintf("Prefix matched multiple nodes\n\n%s", out))
-			return 1
-		}
-		nodeID = nodes[0].ID
 	}
 
 	params := map[string]string{

--- a/command/commands.go
+++ b/command/commands.go
@@ -585,13 +585,13 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
-		"node meta apply": func() (cli.Command, error) {
-			return &NodeMetaApplyCommand{
+		"node meta get": func() (cli.Command, error) {
+			return &NodeMetaGetCommand{
 				Meta: meta,
 			}, nil
 		},
-		"node meta get": func() (cli.Command, error) {
-			return &NodeMetaGetCommand{
+		"node meta set": func() (cli.Command, error) {
+			return &NodeMetaSetCommand{
 				Meta: meta,
 			}, nil
 		},

--- a/command/commands.go
+++ b/command/commands.go
@@ -580,6 +580,21 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"node meta": func() (cli.Command, error) {
+			return &NodeMetaCommand{
+				Meta: meta,
+			}, nil
+		},
+		"node meta apply": func() (cli.Command, error) {
+			return &NodeMetaApplyCommand{
+				Meta: meta,
+			}, nil
+		},
+		"node meta get": func() (cli.Command, error) {
+			return &NodeMetaGetCommand{
+				Meta: meta,
+			}, nil
+		},
 		"node-status": func() (cli.Command, error) {
 			return &NodeStatusCommand{
 				Meta: meta,

--- a/command/node.go
+++ b/command/node.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
@@ -48,6 +49,25 @@ func (f *NodeCommand) Name() string { return "node" }
 
 func (f *NodeCommand) Run(args []string) int {
 	return cli.RunResultHelp
+}
+
+// formatNodeMeta is used to format node metadata in columns.
+func formatNodeMeta(meta map[string]string) string {
+	// Print the meta
+	keys := make([]string, 0, len(meta))
+	for k := range meta {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var rows []string
+	for _, k := range keys {
+		if k != "" {
+			rows = append(rows, fmt.Sprintf("%s|%s", k, meta[k]))
+		}
+	}
+
+	return formatKV(rows)
 }
 
 // lookupNodeID looks up a nodeID prefix and returns the full ID or an error.

--- a/command/node_config.go
+++ b/command/node_config.go
@@ -13,11 +13,11 @@ type NodeConfigCommand struct {
 
 func (c *NodeConfigCommand) Help() string {
 	helpText := `
-Usage: nomad node config [options]
+Usage: nomad node meta [options]
 
-  View or modify a client node's configuration details. This command only works
-  on client nodes, and can be used to update the running client configurations
-  it supports.
+  View or modify a client node's metadata. This command only works
+  on client nodes, and can be used to update the scheduling metadata the node
+  registers.
 
   The arguments behave differently depending on the flags given. See each
   flag's description for its specific requirements.

--- a/command/node_meta.go
+++ b/command/node_meta.go
@@ -1,0 +1,35 @@
+package command
+
+import (
+	"strings"
+
+	"github.com/mitchellh/cli"
+)
+
+type NodeMetaCommand struct {
+	Meta
+}
+
+func (c *NodeMetaCommand) Help() string {
+	helpText := `
+Usage: nomad node meta [subcommand]
+
+  Interact with a node's metadata. The apply subcommand allows for dynamically
+  updating node metadata. The get subcommand allows reading all of the metadata
+  set on the client. All commands interact directly with a client and allow
+  setting a custom target with the -node-id option.
+
+  Please see the individual subcommand help for detailed usage information.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *NodeMetaCommand) Synopsis() string {
+	return "Interact with node metadata"
+}
+
+func (c *NodeMetaCommand) Name() string { return "node meta" }
+
+func (c *NodeMetaCommand) Run(args []string) int {
+	return cli.RunResultHelp
+}

--- a/command/node_meta.go
+++ b/command/node_meta.go
@@ -14,7 +14,7 @@ func (c *NodeMetaCommand) Help() string {
 	helpText := `
 Usage: nomad node meta [subcommand]
 
-  Interact with a node's metadata. The apply subcommand allows for dynamically
+  Interact with a node's metadata. The set subcommand allows for dynamically
   updating node metadata. The get subcommand allows reading all of the metadata
   set on the client. All commands interact directly with a client and allow
   setting a custom target with the -node-id option.

--- a/command/node_meta_apply.go
+++ b/command/node_meta_apply.go
@@ -14,16 +14,13 @@ type NodeMetaApplyCommand struct {
 
 func (c *NodeMetaApplyCommand) Help() string {
 	helpText := `
-Usage: nomad node meta apply [-unset ...] key1=value1 ... keyN=valueN
+Usage: nomad node meta apply [-node-id ...] [-unset ...] key1=value1 ... kN=vN
 
-  Modify a client node's metadata. This command only works on client nodes, and
-  can be used to update the scheduling metadata the node registers.
+  Modify a node's metadata. This command only works on client agents, and can
+  be used to update the scheduling metadata the node registers.
 
   Changes are batched and may take up to 10 seconds to propagate to the
   servers and affect scheduling.
-
-  The arguments behave differently depending on the flags given. See each
-  flag's description for its specific requirements.
 
 General Options:
 
@@ -116,5 +113,5 @@ func (c *NodeMetaApplyCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *NodeMetaApplyCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictNothing
+	return complete.PredictAnything
 }

--- a/command/node_meta_apply.go
+++ b/command/node_meta_apply.go
@@ -1,0 +1,120 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/posener/complete"
+)
+
+type NodeMetaApplyCommand struct {
+	Meta
+}
+
+func (c *NodeMetaApplyCommand) Help() string {
+	helpText := `
+Usage: nomad node meta apply [-unset ...] key1=value1 ... keyN=valueN
+
+  Modify a client node's metadata. This command only works on client nodes, and
+  can be used to update the scheduling metadata the node registers.
+
+  Changes are batched and may take up to 10 seconds to propagate to the
+  servers and affect scheduling.
+
+  The arguments behave differently depending on the flags given. See each
+  flag's description for its specific requirements.
+
+General Options:
+
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
+
+Node Meta Options:
+
+  -node-id
+    Updates metadata on the specified node. If not specified the node receiving
+    the request will be used by default.
+
+  -unset key1,...,keyN
+    Unset the command separated list of keys.
+
+    Example:
+      $ nomad node meta apply -unset testing,tempvar ready=1 role=preinit-db
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *NodeMetaApplyCommand) Synopsis() string {
+	return "Modify node metadata"
+}
+
+func (c *NodeMetaApplyCommand) Name() string { return "node meta apply" }
+
+func (c *NodeMetaApplyCommand) Run(args []string) int {
+	var unset, nodeID string
+
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.StringVar(&unset, "unset", "", "")
+	flags.StringVar(&nodeID, "node-id", "", "")
+
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	args = flags.Args()
+
+	if unset == "" && len(args) == 0 {
+		c.Ui.Error("Must specify -unset or at least 1 key=value pair")
+		return 1
+	}
+
+	// Get the HTTP client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	// Lookup nodeID
+	if nodeID != "" {
+		nodeID, err = lookupNodeID(client.Nodes(), nodeID)
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+	}
+
+	// Parse parameters
+	meta := make(map[string]*string)
+	for _, pair := range args {
+		kv := strings.SplitN(pair, "=", 2)
+		meta[kv[0]] = &kv[1]
+	}
+	for _, k := range strings.Split(unset, ",") {
+		meta[k] = nil
+	}
+
+	req := api.NodeMetaApplyRequest{
+		NodeID: nodeID,
+		Meta:   meta,
+	}
+
+	if _, err := client.Nodes().Meta().Apply(&req, nil); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error applying dynamic node metadata: %s", err))
+		return 1
+	}
+
+	return 0
+}
+
+func (c *NodeMetaApplyCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-node-id": complete.PredictNothing,
+			"-unset":   complete.PredictNothing,
+		})
+}
+
+func (c *NodeMetaApplyCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}

--- a/command/node_meta_get.go
+++ b/command/node_meta_get.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/posener/complete"
@@ -100,7 +101,28 @@ func (c *NodeMetaGetCommand) Run(args []string) int {
 		return 0
 	}
 
+	c.Ui.Output(c.Colorize().Color("[bold]All Meta[reset]"))
 	c.Ui.Output(formatNodeMeta(meta.Meta))
+
+	// Print dynamic meta
+	c.Ui.Output(c.Colorize().Color("\n[bold]Dynamic Meta[reset]"))
+	keys := make([]string, 0, len(meta.Dynamic))
+	for k := range meta.Dynamic {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var rows []string
+	for _, k := range keys {
+		v := "<unset>"
+		if meta.Dynamic[k] != nil {
+			v = *meta.Dynamic[k]
+		}
+		rows = append(rows, fmt.Sprintf("%s|%s", k, v))
+	}
+
+	c.Ui.Output(formatKV(rows))
+
 	return 0
 }
 

--- a/command/node_meta_get.go
+++ b/command/node_meta_get.go
@@ -1,0 +1,118 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/posener/complete"
+)
+
+type NodeMetaGetCommand struct {
+	Meta
+}
+
+func (c *NodeMetaGetCommand) Help() string {
+	helpText := `
+Usage: nomad node meta get [-json] [-node-id ...]
+
+  Get a node's metadata. This command only works on client agents. The node
+  status command can be used to retrieve node metadata from any agent.
+
+  Changes via the "node meta apply" subcommand are batched and may take up to
+  10 seconds to propagate to the servers and affect scheduling. This command
+  will always return the most recent node metadata while the "node status"
+  command can be used to view the metadata that is currently being used for
+  scheduling.
+
+General Options:
+
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
+
+Node Meta Options:
+
+  -node-id
+    Gets metadata from the specified node. If not specified the node receiving
+    the request will be used by default.
+
+  -json
+    Output the node metadata in its JSON format.
+
+  -t
+    Format and display node metadata using a Go template.
+
+    Example:
+      $ nomad node meta get -node-id 3b58b0a6
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *NodeMetaGetCommand) Synopsis() string {
+	return "Get node metadata"
+}
+
+func (c *NodeMetaGetCommand) Name() string { return "node meta get" }
+
+func (c *NodeMetaGetCommand) Run(args []string) int {
+	var nodeID, tmpl string
+	var json bool
+
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.StringVar(&nodeID, "node-id", "", "")
+	flags.StringVar(&tmpl, "t", "", "")
+	flags.BoolVar(&json, "json", false, "")
+
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	args = flags.Args()
+
+	// Get the HTTP client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	// Lookup nodeID
+	if nodeID != "" {
+		nodeID, err = lookupNodeID(client.Nodes(), nodeID)
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+	}
+
+	meta, err := client.Nodes().Meta().Read(nodeID, nil)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error getting dynamic node metadata: %s", err))
+		return 1
+	}
+
+	if json || len(tmpl) > 0 {
+		out, err := Format(json, tmpl, meta)
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+
+		c.Ui.Output(out)
+		return 0
+	}
+
+	c.Ui.Output(formatNodeMeta(meta.Meta))
+	return 0
+}
+
+func (c *NodeMetaGetCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-node-id": complete.PredictAnything,
+			"-json":    complete.PredictNothing,
+			"-t":       complete.PredictAnything,
+		})
+}
+
+func (c *NodeMetaGetCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}

--- a/command/node_meta_set.go
+++ b/command/node_meta_set.go
@@ -8,13 +8,13 @@ import (
 	"github.com/posener/complete"
 )
 
-type NodeMetaApplyCommand struct {
+type NodeMetaSetCommand struct {
 	Meta
 }
 
-func (c *NodeMetaApplyCommand) Help() string {
+func (c *NodeMetaSetCommand) Help() string {
 	helpText := `
-Usage: nomad node meta apply [-node-id ...] [-unset ...] key1=value1 ... kN=vN
+Usage: nomad node meta set [-node-id ...] [-unset ...] key1=value1 ... kN=vN
 
   Modify a node's metadata. This command only works on client agents, and can
   be used to update the scheduling metadata the node registers.
@@ -26,7 +26,7 @@ General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
-Node Meta Options:
+Node Meta Set Options:
 
   -node-id
     Updates metadata on the specified node. If not specified the node receiving
@@ -36,18 +36,18 @@ Node Meta Options:
     Unset the command separated list of keys.
 
     Example:
-      $ nomad node meta apply -unset testing,tempvar ready=1 role=preinit-db
+      $ nomad node meta set -unset testing,tempvar ready=1 role=preinit-db
 `
 	return strings.TrimSpace(helpText)
 }
 
-func (c *NodeMetaApplyCommand) Synopsis() string {
+func (c *NodeMetaSetCommand) Synopsis() string {
 	return "Modify node metadata"
 }
 
-func (c *NodeMetaApplyCommand) Name() string { return "node meta apply" }
+func (c *NodeMetaSetCommand) Name() string { return "node meta set" }
 
-func (c *NodeMetaApplyCommand) Run(args []string) int {
+func (c *NodeMetaSetCommand) Run(args []string) int {
 	var unset, nodeID string
 
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
@@ -91,12 +91,12 @@ func (c *NodeMetaApplyCommand) Run(args []string) int {
 		meta[k] = nil
 	}
 
-	req := api.NodeMetaApplyRequest{
+	req := api.NodeMetaSetRequest{
 		NodeID: nodeID,
 		Meta:   meta,
 	}
 
-	if _, err := client.Nodes().Meta().Apply(&req, nil); err != nil {
+	if _, err := client.Nodes().Meta().Set(&req, nil); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error applying dynamic node metadata: %s", err))
 		return 1
 	}
@@ -104,7 +104,7 @@ func (c *NodeMetaApplyCommand) Run(args []string) int {
 	return 0
 }
 
-func (c *NodeMetaApplyCommand) AutocompleteFlags() complete.Flags {
+func (c *NodeMetaSetCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
 			"-node-id": complete.PredictNothing,
@@ -112,6 +112,6 @@ func (c *NodeMetaApplyCommand) AutocompleteFlags() complete.Flags {
 		})
 }
 
-func (c *NodeMetaApplyCommand) AutocompleteArgs() complete.Predictor {
+func (c *NodeMetaSetCommand) AutocompleteArgs() complete.Predictor {
 	return complete.PredictAnything
 }

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -831,21 +831,8 @@ func (c *NodeStatusCommand) formatDeviceAttributes(node *api.Node) {
 }
 
 func (c *NodeStatusCommand) formatMeta(node *api.Node) {
-	// Print the meta
-	keys := make([]string, 0, len(node.Meta))
-	for k := range node.Meta {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	var meta []string
-	for _, k := range keys {
-		if k != "" {
-			meta = append(meta, fmt.Sprintf("%s|%s", k, node.Meta[k]))
-		}
-	}
 	c.Ui.Output(c.Colorize().Color("\n[bold]Meta[reset]"))
-	c.Ui.Output(formatKV(meta))
+	c.Ui.Output(formatNodeMeta(node.Meta))
 }
 
 func (c *NodeStatusCommand) printCpuStats(hostStats *api.HostStats) {

--- a/nomad/client_meta_endpoint.go
+++ b/nomad/client_meta_endpoint.go
@@ -22,12 +22,12 @@ func newNodeMetaEndpoint(srv *Server) *NodeMeta {
 	return n
 }
 
-func (n *NodeMeta) Apply(args *structs.NodeMetaApplyRequest, reply *structs.NodeMetaResponse) error {
-	const method = "NodeMeta.Apply"
+func (n *NodeMeta) Set(args *structs.NodeMetaSetRequest, reply *structs.NodeMetaResponse) error {
+	const method = "NodeMeta.Set"
 	if done, err := n.srv.forward(method, args, args, reply); done {
 		return err
 	}
-	defer metrics.MeasureSince([]string{"nomad", "client_meta", "apply"}, time.Now())
+	defer metrics.MeasureSince([]string{"nomad", "client_meta", "Set"}, time.Now())
 
 	// Check node write permissions
 	if aclObj, err := n.srv.ResolveToken(args.AuthToken); err != nil {

--- a/nomad/client_meta_endpoint.go
+++ b/nomad/client_meta_endpoint.go
@@ -1,0 +1,57 @@
+package nomad
+
+import (
+	"time"
+
+	metrics "github.com/armon/go-metrics"
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/nomad/structs"
+	nstructs "github.com/hashicorp/nomad/nomad/structs"
+)
+
+type NodeMeta struct {
+	srv    *Server
+	logger log.Logger
+}
+
+func newNodeMetaEndpoint(srv *Server) *NodeMeta {
+	n := &NodeMeta{
+		srv:    srv,
+		logger: srv.logger.Named("client_meta"),
+	}
+	return n
+}
+
+func (n *NodeMeta) Apply(args *structs.NodeMetaApplyRequest, reply *structs.NodeMetaResponse) error {
+	const method = "NodeMeta.Apply"
+	if done, err := n.srv.forward(method, args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince([]string{"nomad", "client_meta", "apply"}, time.Now())
+
+	// Check node write permissions
+	if aclObj, err := n.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.AllowNodeWrite() {
+		return nstructs.ErrPermissionDenied
+	}
+
+	return n.srv.forwardClientRPC(method, args.NodeID, args, reply)
+}
+
+func (n *NodeMeta) Read(args *structs.NodeSpecificRequest, reply *structs.NodeMetaResponse) error {
+	const method = "NodeMeta.Read"
+	if done, err := n.srv.forward(method, args, args, reply); done {
+		return err
+	}
+	defer metrics.MeasureSince([]string{"nomad", "client_meta", "read"}, time.Now())
+
+	// Check node read permissions
+	if aclObj, err := n.srv.ResolveToken(args.AuthToken); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.AllowNodeRead() {
+		return nstructs.ErrPermissionDenied
+	}
+
+	return n.srv.forwardClientRPC(method, args.NodeID, args, reply)
+}

--- a/nomad/client_rpc.go
+++ b/nomad/client_rpc.go
@@ -212,6 +212,40 @@ func (s *Server) serverWithNodeConn(nodeID, region string) (*serverParts, error)
 	return mostRecentServer, nil
 }
 
+// forwardClientRPC forwards the RPC specified by method to the node specified
+// by nodeID. Must be done after region forwarding, metrics, and permissions
+// checks.
+//
+// This is a wrapper method for getNodeForRpc, getNodeConn, etc that Client
+// RPCs which only need Servers to forward requests can use.
+func (s *Server) forwardClientRPC(method, nodeID string, args, reply any) error {
+	if nodeID == "" {
+		return errors.New("missing NodeID")
+	}
+
+	// Check if the node even exists and is compatible with NodeRpc
+	snap, err := s.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
+	// Make sure Node is new enough to support RPC
+	_, err = getNodeForRpc(snap, nodeID)
+	if err != nil {
+		return err
+	}
+
+	// Get the connection to the client
+	state, ok := s.getNodeConn(nodeID)
+	if !ok {
+		// Make the RPC via another server
+		return findNodeConnAndForward(s, nodeID, method, args, reply)
+	}
+
+	// Make the RPC
+	return NodeRpc(state.Session, method, args, reply)
+}
+
 // NodeRpc is used to make an RPC call to a node. The method takes the
 // Yamux session for the node and the method to be called.
 func NodeRpc(session *yamux.Session, method string, args, reply interface{}) error {

--- a/nomad/client_stats_endpoint.go
+++ b/nomad/client_stats_endpoint.go
@@ -1,7 +1,6 @@
 package nomad
 
 import (
-	"errors"
 	"time"
 
 	metrics "github.com/armon/go-metrics"
@@ -41,40 +40,5 @@ func (s *ClientStats) Stats(args *nstructs.NodeSpecificRequest, reply *structs.C
 		return nstructs.ErrPermissionDenied
 	}
 
-	// Verify the arguments.
-	if args.NodeID == "" {
-		return errors.New("missing NodeID")
-	}
-
-	// Check if the node even exists and is compatible with NodeRpc
-	snap, err := s.srv.State().Snapshot()
-	if err != nil {
-		return err
-	}
-
-	// Make sure Node is new enough to support RPC
-	_, err = getNodeForRpc(snap, args.NodeID)
-	if err != nil {
-		return err
-	}
-
-	// Get the connection to the client
-	state, ok := s.srv.getNodeConn(args.NodeID)
-	if !ok {
-
-		// Determine the Server that has a connection to the node.
-		srv, err := s.srv.serverWithNodeConn(args.NodeID, s.srv.Region())
-		if err != nil {
-			return err
-		}
-
-		if srv == nil {
-			return nstructs.ErrNoNodeConn
-		}
-
-		return s.srv.forwardServer(srv, "ClientStats.Stats", args, reply)
-	}
-
-	// Make the RPC
-	return NodeRpc(state.Session, "ClientStats.Stats", args, reply)
+	return s.srv.forwardClientRPC("ClientStats.Stats", args.NodeID, args, reply)
 }

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1256,6 +1256,7 @@ func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) {
 	// These endpoints are client RPCs and don't include a connection context
 	_ = server.Register(NewClientCSIEndpoint(s))
 	_ = server.Register(NewClientStatsEndpoint(s))
+	_ = server.Register(newNodeMetaEndpoint(s))
 
 	// These endpoints have their streaming component registered in
 	// setupStreamingEndpoints, but their non-streaming RPCs are registered

--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -351,3 +351,21 @@ func (di *DriverInfo) HealthCheckEquals(other *DriverInfo) bool {
 
 	return true
 }
+
+// NodeMetaApplyRequest is used to update Node metadata on Client agents.
+type NodeMetaApplyRequest struct {
+	WriteRequest
+
+	// NodeID is the node being targeted by this request (or the node
+	// receiving this request if NodeID is empty).
+	NodeID string
+
+	// Meta is the new Node metadata being applied and differs slightly
+	// from Node.Meta as nil values are used to unset Node.Meta keys.
+	Meta map[string]*string
+}
+
+// NodeMetaResponse is used to read Node metadata directly from Client agents.
+type NodeMetaResponse struct {
+	Meta map[string]string
+}

--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -352,8 +352,8 @@ func (di *DriverInfo) HealthCheckEquals(other *DriverInfo) bool {
 	return true
 }
 
-// NodeMetaApplyRequest is used to update Node metadata on Client agents.
-type NodeMetaApplyRequest struct {
+// NodeMetaSetRequest is used to update Node metadata on Client agents.
+type NodeMetaSetRequest struct {
 	WriteRequest
 
 	// NodeID is the node being targeted by this request (or the node
@@ -367,5 +367,9 @@ type NodeMetaApplyRequest struct {
 
 // NodeMetaResponse is used to read Node metadata directly from Client agents.
 type NodeMetaResponse struct {
+	// Meta is the merged static + dynamic Node metadata
 	Meta map[string]string
+
+	// Dynamic is the dynamic Node metadata
+	Dynamic map[string]*string
 }


### PR DESCRIPTION
Fixes #14617

**WIP**

Dynamic Node Metadata allows Nomad users, and their jobs, to update Node metadata through an API. Currently Node metadata is only reloaded when a Client agent is restarted.

This is a draft implementation using a Client-agent API and state and is intended for use by node-local system jobs that provide extra monitoring and node annotation over Nomad's fingerprinting facilities.

Cons:
1. The Node being manipulated must be online.
2. There is up to 10 seconds of latency before schedulers use the new metadata.

Pros:
1. Servers are protected from DDoS if a whole fleet of system jobs start mutating metadata simultaneously or in a tight loop.
2. The API works even if the node is disconnected from servers, so a monitoring system job can continue to update the metadata locally and it will be propagated as soon as connectivity is restored. This is similar to Consul's Agent API anti-entropy.

**TODO**
* [ ] Docs
* [ ] Tests