### PR TITLE
Add disk_total_mb and disk_free_mb client config options

### DIFF
--- a/.changelog/15852.txt
+++ b/.changelog/15852.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client/fingerprint/storage: Added config options disk_total_mb and disk_free_mb to override detected disk space
+```

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -113,6 +113,14 @@ type Config struct {
 	// determined dynamically.
 	MemoryMB int
 
+	// DiskTotalMB is the default node total disk space in megabytes if it cannot be
+	// determined dynamically.
+	DiskTotalMB int
+
+	// DiskFreeMB is the default node free disk space in megabytes if it cannot be
+	// determined dynamically.
+	DiskFreeMB int
+
 	// MaxKillTimeout allows capping the user-specifiable KillTimeout. If the
 	// task's KillTimeout is greater than the MaxKillTimeout, MaxKillTimeout is
 	// used.

--- a/client/fingerprint/storage.go
+++ b/client/fingerprint/storage.go
@@ -42,10 +42,10 @@ func (f *StorageFingerprint) Fingerprint(req *FingerprintRequest, resp *Fingerpr
 	}
 
 	if cfg.DiskTotalMB > 0 {
-		total = uint64(cfg.DiskTotalMB) * 1024 * 1024
+		total = uint64(cfg.DiskTotalMB) * bytesPerMegabyte
 	}
 	if cfg.DiskFreeMB > 0 {
-		free = uint64(cfg.DiskFreeMB) * 1024 * 1024
+		free = uint64(cfg.DiskFreeMB) * bytesPerMegabyte
 	}
 
 	if total < free {

--- a/client/fingerprint/storage.go
+++ b/client/fingerprint/storage.go
@@ -41,6 +41,17 @@ func (f *StorageFingerprint) Fingerprint(req *FingerprintRequest, resp *Fingerpr
 		return fmt.Errorf("failed to determine disk space for %s: %v", storageDir, err)
 	}
 
+	if cfg.DiskTotalMB > 0 {
+		total = uint64(cfg.DiskTotalMB) * 1024 * 1024
+	}
+	if cfg.DiskFreeMB > 0 {
+		free = uint64(cfg.DiskFreeMB) * 1024 * 1024
+	}
+
+	if total < free {
+		return fmt.Errorf("detected more free disk space (%d) than total disk space (%d), use disk_total_mb and disk_free_mb to correct", free, total)
+	}
+
 	resp.AddAttribute("unique.storage.volume", volume)
 	resp.AddAttribute("unique.storage.bytestotal", strconv.FormatUint(total, 10))
 	resp.AddAttribute("unique.storage.bytesfree", strconv.FormatUint(free, 10))

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -668,6 +668,12 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	if agentConfig.Client.MemoryMB != 0 {
 		conf.MemoryMB = agentConfig.Client.MemoryMB
 	}
+	if agentConfig.Client.DiskTotalMB != 0 {
+		conf.DiskTotalMB = agentConfig.Client.DiskTotalMB
+	}
+	if agentConfig.Client.DiskFreeMB != 0 {
+		conf.DiskFreeMB = agentConfig.Client.DiskFreeMB
+	}
 	if agentConfig.Client.MaxKillTimeout != "" {
 		dur, err := time.ParseDuration(agentConfig.Client.MaxKillTimeout)
 		if err != nil {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -2012,6 +2012,12 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	if b.MemoryMB != 0 {
 		result.MemoryMB = b.MemoryMB
 	}
+	if b.DiskTotalMB != 0 {
+		result.DiskTotalMB = b.DiskTotalMB
+	}
+	if b.DiskFreeMB != 0 {
+		result.DiskFreeMB = b.DiskFreeMB
+	}
 	if b.MaxKillTimeout != "" {
 		result.MaxKillTimeout = b.MaxKillTimeout
 	}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -227,6 +227,12 @@ type ClientConfig struct {
 	// MemoryMB is used to override any detected or default total memory.
 	MemoryMB int `hcl:"memory_total_mb"`
 
+	// DiskTotalMB is used to override any detected or default total disk space.
+	DiskTotalMB int `hcl:"disk_total_mb"`
+
+	// DiskFreeMB is used to override any detected or default free disk space.
+	DiskFreeMB int `hcl:"disk_free_mb"`
+
 	// ReservableCores is used to override detected reservable cpu cores.
 	ReserveableCores string `hcl:"reservable_cores"`
 

--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -65,6 +65,12 @@ client {
 - `memory_total_mb` `(int:0)` - Specifies an override for the total memory. If set,
   this value overrides any detected memory.
 
+- `disk_total_mb` `(int:0)` - Specifies an override for the total disk space. If set,
+  this value overrides any detected total disk space.
+
+- `disk_free_mb` `(int:0)` - Specifies an override for the free disk space. If set,
+  this value overrides any detected free disk space. (Workaround for https://github.com/hashicorp/nomad/issues/6172)
+
 - `min_dynamic_port` `(int:20000)` - Specifies the minimum dynamic port to be
   assigned. Individual ports and ranges of ports may be excluded from dynamic
   port assignment via [`reserved`](#reserved-parameters) parameters.

--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -65,11 +65,14 @@ client {
 - `memory_total_mb` `(int:0)` - Specifies an override for the total memory. If set,
   this value overrides any detected memory.
 
-- `disk_total_mb` `(int:0)` - Specifies an override for the total disk space. If set,
-  this value overrides any detected total disk space.
+- `disk_total_mb` `(int:0)` - Specifies an override for the total disk space
+  fingerprint attribute. This value is not used by the scheduler unless you have
+  constraints set on the attribute `unique.storage.bytestotal`. The actual total
+  disk space can be determined via the [Read Stats API](https://github.com/api-docs/client#read-stats)
 
-- `disk_free_mb` `(int:0)` - Specifies an override for the free disk space. If set,
-  this value overrides any detected free disk space. (Workaround for https://github.com/hashicorp/nomad/issues/6172)
+- `disk_free_mb` `(int:0)` - Specifies the disk space free for scheduling
+  allocations. If set, this value overrides any detected free disk space. This
+  value can be seen in `nomad node status` under Allocated Resources.
 
 - `min_dynamic_port` `(int:20000)` - Specifies the minimum dynamic port to be
   assigned. Individual ports and ranges of ports may be excluded from dynamic


### PR DESCRIPTION
@tgross as suggested in https://github.com/hashicorp/nomad/issues/6172#issuecomment-1377479562 and in regard to your positive reply I implemented the config options `disk_total_mb` and `disk_free_mb`. This is my first PR to nomad and none of the checklists in the contributing folder seems to fit those changes. Therefore I'm not sure if something is missing or how to proceed. I'm looking forward to your feedback.