### PR TITLE
docs: add caveat on dynamic blocks

### DIFF
--- a/website/content/docs/job-specification/hcl2/expressions.mdx
+++ b/website/content/docs/job-specification/hcl2/expressions.mdx
@@ -297,7 +297,9 @@ job "example" {
 ```
 
 ~> **Caveat:** Dynamic blocks are not supported inside blocks that are opaque
-to Nomad, such as task [`config`][task_config] and group scaling
+to Nomad, such as the `config` attributes in [`task`][task_config],
+[`sidecar_task`][sidecar_task_config], [`proxy`][proxy_config], and
+[`gateway`][gateway_config], and the group scaling
 [`policy`][group_scaling_policy].
 
 A `dynamic` block acts much like a `for` expression, but produces nested blocks
@@ -429,5 +431,8 @@ Within quoted and heredoc string expressions, the sequences `${` and `%{` begin
 _template sequences_. Templates let you directly embed expressions into a string
 literal, to dynamically construct strings from other values.
 
-[task_config]: /nomad/docs/job-specification/task#config
+[gateway_config]: /nomad/docs/job-specification/gateway#config
 [group_scaling_policy]: /nomad/docs/job-specification/scaling#policy
+[proxy_config]: /nomad/docs/job-specification/proxy#config
+[sidecar_task_config]: /nomad/docs/job-specification/sidecar_task#config
+[task_config]: /nomad/docs/job-specification/task#config

--- a/website/content/docs/job-specification/hcl2/expressions.mdx
+++ b/website/content/docs/job-specification/hcl2/expressions.mdx
@@ -260,7 +260,7 @@ network {
 ```
 
 You can dynamically construct repeatable nested blocks like `port` using a
-special `dynamic` block type, which is supported anywhere, example:
+special `dynamic` block type, which is supported in most places, example:
 
 ```hcl
 locals {
@@ -295,6 +295,10 @@ job "example" {
     }
     ...
 ```
+
+~> **Caveat:** Dynamic blocks are not supported inside blocks that are opaque
+to Nomad, such as task [`config`][task_config] and group scaling
+[`policy`][group_scaling_policy].
 
 A `dynamic` block acts much like a `for` expression, but produces nested blocks
 instead of a complex typed value. It iterates over a given complex value, and
@@ -424,3 +428,6 @@ beginning a template sequence, double the leading character: `$${` or `%%{`.
 Within quoted and heredoc string expressions, the sequences `${` and `%{` begin
 _template sequences_. Templates let you directly embed expressions into a string
 literal, to dynamically construct strings from other values.
+
+[task_config]: /docs/job-specification/task#config
+[group_scaling_policy]: /docs/job-specification/scaling#policy

--- a/website/content/docs/job-specification/hcl2/expressions.mdx
+++ b/website/content/docs/job-specification/hcl2/expressions.mdx
@@ -429,5 +429,5 @@ Within quoted and heredoc string expressions, the sequences `${` and `%{` begin
 _template sequences_. Templates let you directly embed expressions into a string
 literal, to dynamically construct strings from other values.
 
-[task_config]: /docs/job-specification/task#config
-[group_scaling_policy]: /docs/job-specification/scaling#policy
+[task_config]: /nomad/docs/job-specification/task#config
+[group_scaling_policy]: /nomad/docs/job-specification/scaling#policy


### PR DESCRIPTION
Some values in the jobspec are opaque to Nomad, such as a task `config` or a scaling policy `policy` block. Since Nomad does not attempt to parse these fields it's not possible to use `dynamic` blocks inside them.

Closes #15850