### PR TITLE
sso: allow binding rules to create management ACL tokens.

### DIFF
--- a/api/acl.go
+++ b/api/acl.go
@@ -799,8 +799,8 @@ type ACLBindingRule struct {
 	Selector string
 
 	// BindType adjusts how this binding rule is applied at login time. The
-	// valid values are ACLBindingRuleBindTypeRole and
-	// ACLBindingRuleBindTypePolicy.
+	// valid values are ACLBindingRuleBindTypeRole,
+	// ACLBindingRuleBindTypePolicy, and ACLBindingRuleBindTypeManagement.
 	BindType string
 
 	// BindName is the target of the binding. Can be lightly templated using
@@ -826,6 +826,10 @@ const (
 	// within the ACLBindingRule.BindName parameter, and will be the policy
 	// name.
 	ACLBindingRuleBindTypePolicy = "policy"
+
+	// ACLBindingRuleBindTypeManagement is the ACL binding rule bind type that
+	// will generate management ACL tokens when matched.
+	ACLBindingRuleBindTypeManagement = "management"
 )
 
 // ACLBindingRuleListStub is the stub object returned when performing a listing

--- a/command/acl_binding_rule_create.go
+++ b/command/acl_binding_rule_create.go
@@ -53,11 +53,12 @@ Create Options:
 
   -bind-type
     Specifies adjusts how this binding rule is applied at login time to internal
-    Nomad objects. Valid options are "role" and "policy".
+    Nomad objects. Valid options are "role", "policy", or "management".
 
   -bind-name
     Specifies is the target of the binding used on selector match. This can be
-    lightly templated using HIL ${foo} syntax.
+    lightly templated using HIL ${foo} syntax. If the bind type is set to
+    "management", this should not be set.
 
   -json
     Output the ACL binding rule in a JSON format.
@@ -74,10 +75,14 @@ func (a *ACLBindingRuleCreateCommand) AutocompleteFlags() complete.Flags {
 			"-description": complete.PredictAnything,
 			"-auth-method": complete.PredictAnything,
 			"-selector":    complete.PredictAnything,
-			"-bind-type":   complete.PredictSet("role", "policy"),
-			"-bind-name":   complete.PredictAnything,
-			"-json":        complete.PredictNothing,
-			"-t":           complete.PredictAnything,
+			"-bind-type": complete.PredictSet(
+				api.ACLBindingRuleBindTypeRole,
+				api.ACLBindingRuleBindTypePolicy,
+				api.ACLBindingRuleBindTypeManagement,
+			),
+			"-bind-name": complete.PredictAnything,
+			"-json":      complete.PredictNothing,
+			"-t":         complete.PredictAnything,
 		})
 }
 
@@ -118,10 +123,6 @@ func (a *ACLBindingRuleCreateCommand) Run(args []string) int {
 	// to avoid sending API and RPC requests which will fail basic validation.
 	if a.authMethod == "" {
 		a.Ui.Error("ACL binding rule auth method must be specified using the -auth-method flag")
-		return 1
-	}
-	if a.bindName == "" {
-		a.Ui.Error("ACL binding rule bind name must be specified using the -bind-name flag")
 		return 1
 	}
 	if a.bindType == "" {

--- a/command/acl_binding_rule_create_test.go
+++ b/command/acl_binding_rule_create_test.go
@@ -48,13 +48,6 @@ func TestACLBindingRuleCreateCommand_Run(t *testing.T) {
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()
 
-	must.Eq(t, 1, cmd.Run([]string{"-address=" + url, "-auth-method=auth0"}))
-	must.StrContains(t, ui.ErrorWriter.String(),
-		"ACL binding rule bind name must be specified using the -bind-name flag")
-
-	ui.OutputWriter.Reset()
-	ui.ErrorWriter.Reset()
-
 	must.Eq(t, 1, cmd.Run([]string{"-address=" + url, "-auth-method=auth0", "-bind-name=engineering"}))
 	must.StrContains(t, ui.ErrorWriter.String(),
 		"ACL binding rule bind type must be specified using the -bind-type flag")

--- a/command/acl_binding_rule_update_test.go
+++ b/command/acl_binding_rule_update_test.go
@@ -76,7 +76,7 @@ func TestACLBindingRuleUpdateCommand_Run(t *testing.T) {
 	// Try a merge update without setting any parameters to update.
 	code = cmd.Run([]string{"-address=" + url, "-token=" + rootACLToken.SecretID, aclBindingRule.ID})
 	must.Eq(t, 1, code)
-	must.StrContains(t, ui.ErrorWriter.String(), "Please provide all required flags to update the ACL binding rule")
+	must.StrContains(t, ui.ErrorWriter.String(), "Please provide at least one update for the ACL binding rule")
 
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()
@@ -91,15 +91,6 @@ func TestACLBindingRuleUpdateCommand_Run(t *testing.T) {
 	must.StrContains(t, s, "acl-binding-rule-cli-test")
 	must.StrContains(t, s, "role")
 	must.StrContains(t, s, "engineering")
-
-	ui.OutputWriter.Reset()
-	ui.ErrorWriter.Reset()
-
-	// Try updating the role using no-merge without setting the required flags.
-	code = cmd.Run([]string{"-address=" + url, "-token=" + rootACLToken.SecretID, "-no-merge", aclBindingRule.ID})
-	must.Eq(t, 1, code)
-	must.StrContains(t, ui.ErrorWriter.String(),
-		"ACL binding rule bind name must be specified using the -bind-name flag")
 
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()

--- a/lib/auth/oidc/binder.go
+++ b/lib/auth/oidc/binder.go
@@ -35,8 +35,9 @@ type BinderStateStore interface {
 // Bindings contains the ACL roles and policies to be assigned to the created
 // token.
 type Bindings struct {
-	Roles    []*structs.ACLTokenRoleLink
-	Policies []string
+	Management bool
+	Roles      []*structs.ACLTokenRoleLink
+	Policies   []string
 }
 
 // None indicates that the resulting bindings would not give the created token
@@ -110,6 +111,11 @@ func (b *Binder) Bind(authMethod *structs.ACLAuthMethod, identity *Identity) (*B
 			if policy != nil {
 				bindings.Policies = append(bindings.Policies, policy.Name)
 			}
+		case structs.ACLBindingRuleBindTypeManagement:
+			bindings.Management = true
+			bindings.Policies = nil
+			bindings.Roles = nil
+			return &bindings, nil
 		}
 	}
 
@@ -134,6 +140,8 @@ func computeBindName(bindType, bindName string, claimMappings map[string]string)
 		valid = structs.ValidPolicyName.MatchString(bindName)
 	case structs.ACLBindingRuleBindTypeRole:
 		valid = structs.ValidACLRoleName.MatchString(bindName)
+	case structs.ACLManagementToken:
+		valid = true
 	default:
 		return "", false, fmt.Errorf("unknown binding rule bind type: %s", bindType)
 	}

--- a/nomad/structs/acl_test.go
+++ b/nomad/structs/acl_test.go
@@ -1,10 +1,12 @@
 package structs
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -1192,25 +1194,115 @@ func TestACLBindingRule_Canonicalize(t *testing.T) {
 func TestACLBindingRule_Validate(t *testing.T) {
 	ci.Parallel(t)
 
-	// Quite possibly the most invalid binding rule to have ever existed.
-	totallyInvalidACLBindingRule := ACLBindingRule{
-		Description: uuid.Generate() + uuid.Generate() + uuid.Generate() + uuid.Generate() +
-			uuid.Generate() + uuid.Generate() + uuid.Generate() + uuid.Generate(),
-		AuthMethod: "",
-		BindType:   "",
-		BindName:   "",
+	testCases := []struct {
+		name                string
+		inputACLBindingRule *ACLBindingRule
+		expectedError       error
+	}{
+		{
+			name: "valid policy type rule",
+			inputACLBindingRule: &ACLBindingRule{
+				Description: "some short description",
+				AuthMethod:  "auth0",
+				Selector:    "group-name in list.groups",
+				BindType:    ACLBindingRuleBindTypePolicy,
+				BindName:    "some-policy-name",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "invalid policy type rule",
+			inputACLBindingRule: &ACLBindingRule{
+				Description: "some short description",
+				AuthMethod:  "auth0",
+				Selector:    "group-name in list.groups",
+				BindType:    ACLBindingRuleBindTypePolicy,
+				BindName:    "",
+			},
+			expectedError: &multierror.Error{
+				Errors: []error{
+					errors.New("bind name is missing"),
+				},
+			},
+		},
+		{
+			name: "valid role type rule",
+			inputACLBindingRule: &ACLBindingRule{
+				Description: "some short description",
+				AuthMethod:  "auth0",
+				Selector:    "group-name in list.groups",
+				BindType:    ACLBindingRuleBindTypeRole,
+				BindName:    "some-role-name",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "invalid role type rule",
+			inputACLBindingRule: &ACLBindingRule{
+				Description: "some short description",
+				AuthMethod:  "auth0",
+				Selector:    "group-name in list.groups",
+				BindType:    ACLBindingRuleBindTypeRole,
+				BindName:    "",
+			},
+			expectedError: &multierror.Error{
+				Errors: []error{
+					errors.New("bind name is missing"),
+				},
+			},
+		},
+		{
+			name: "valid management type rule",
+			inputACLBindingRule: &ACLBindingRule{
+				Description: "some short description",
+				AuthMethod:  "auth0",
+				Selector:    "group-name in list.groups",
+				BindType:    ACLBindingRuleBindTypeManagement,
+				BindName:    "",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "invalid management type rule",
+			inputACLBindingRule: &ACLBindingRule{
+				Description: "some short description",
+				AuthMethod:  "auth0",
+				Selector:    "group-name in list.groups",
+				BindType:    ACLBindingRuleBindTypeManagement,
+				BindName:    "some-name",
+			},
+			expectedError: &multierror.Error{
+				Errors: []error{
+					errors.New("bind name should be empty"),
+				},
+			},
+		},
+		{
+			name: "invalid all",
+			inputACLBindingRule: &ACLBindingRule{
+				Description: uuid.Generate() + uuid.Generate() + uuid.Generate() +
+					uuid.Generate() + uuid.Generate() + uuid.Generate() +
+					uuid.Generate() + uuid.Generate(),
+				AuthMethod: "",
+				Selector:   "group-name in list.groups",
+				BindType:   "",
+				BindName:   "",
+			},
+			expectedError: &multierror.Error{
+				Errors: []error{
+					errors.New("auth method is missing"),
+					errors.New("description longer than 256"),
+					errors.New("bind type is missing"),
+				},
+			},
+		},
 	}
-	err := totallyInvalidACLBindingRule.Validate()
-	must.StrContains(t, err.Error(), "auth method is missing")
-	must.StrContains(t, err.Error(), "bind name is missing")
-	must.StrContains(t, err.Error(), "description longer than 256")
-	must.StrContains(t, err.Error(), "bind type is missing")
 
-	// Update the bind type, so we get the alternative error when this is not
-	// empty, but incorrectly set.
-	totallyInvalidACLBindingRule.BindType = "service"
-	err = totallyInvalidACLBindingRule.Validate()
-	must.StrContains(t, err.Error(), `unsupported bind type: "service"`)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			must.Eq(t, tc.expectedError, tc.inputACLBindingRule.Validate())
+		})
+	}
 }
 
 func TestACLBindingRule_Merge(t *testing.T) {

--- a/website/content/api-docs/acl/binding-rules.mdx
+++ b/website/content/api-docs/acl/binding-rules.mdx
@@ -130,11 +130,12 @@ The table below shows this endpoint's support for
   optional and when not set, provides a catch-all rule.
 
 - `BindType` `(string: <required>)` - Adjusts how this binding rule is applied
-  at login time. Valid values are `role` and `policy`.
+  at login time. Valid values are `role`, `policy`, and `management`.
 
 - `BindName` `(string: <required>)` - Target of the binding. Can be lightly
-  templated using HIL ${foo} syntax from available field names. How it is used
-  depends on the BindType. 
+  templated using HIL ${foo} syntax from available field names. If the bind
+  type is set to `management`, this should not be set. How it is used depends
+  on the BindType.
 
 ### Sample Payload
 
@@ -202,11 +203,11 @@ queries](/api-docs#blocking-queries) and [required ACLs](/api-docs#acls).
   optional and when not set, provides a catch-all rule.
 
 - `BindType` `(string: "")` - Adjusts how this binding rule is applied at login
-  time. Valid values are `role` and `policy`.
+  time. Valid values are `role`, `policy`, and `management`.
 
 - `BindName` `(string: "")` - Target of the binding. Can be lightly templated
   using HIL ${foo} syntax from available field names. How it is used depends on
-  the BindType. 
+  the BindType.
 
 ### Sample Payload
 

--- a/website/content/docs/commands/acl/binding-rule/create.mdx
+++ b/website/content/docs/commands/acl/binding-rule/create.mdx
@@ -33,10 +33,11 @@ via flags detailed below.
   attributes returned from the auth method during login.
 
 - `-bind-type`: Specifies adjusts how this binding rule is applied at login time
-  to internal Nomad objects. Valid options are `role` and `policy`.
+  to internal Nomad objects. Valid options are `role`, `policy`, and `management`.
 
 - `-bind-name`: Specifies is the target of the binding used on selector match.
-  This can be lightly templated using HIL `${foo}` syntax.
+  This can be lightly templated using HIL `${foo}` syntax. If the bind type is
+  set to `management`, this should not be set.
 
 - `-json`: Output the ACL binding-rule in a JSON format.
 

--- a/website/content/docs/commands/acl/binding-rule/update.mdx
+++ b/website/content/docs/commands/acl/binding-rule/update.mdx
@@ -29,10 +29,11 @@ The `acl binding-rule update` command requires an existing rule's ID.
   attributes returned from the binding rule during login.
 
 - `-bind-type`: Specifies adjusts how this binding rule is applied at login time
-  to internal Nomad objects. Valid options are `role` and `policy`.
+  to internal Nomad objects. Valid options are `role`, `policy`, and `management`.
 
 - `-bind-name`: Specifies is the target of the binding used on selector match.
-  This can be lightly templated using HIL `${foo}` syntax.
+  This can be lightly templated using HIL `${foo}` syntax. If the bind type is
+  set to `management`, this should not be set.
 
 - `-json`: Output the ACL binding-rule in a JSON format.
 


### PR DESCRIPTION
This change allows binding rules to be created with a new type
named management. When this binding rule matches against a users
SSO claims, the resulting token will be of type management and not
client.

A match will supercede previous role or policy matches. This is
required as all binding rules are evaluated on login via
an auth method. It would be highly complex for users to ensure
those with rights to management tokens, do not match any other
binding rules.

When creating a binding rule of management type, the bind name
must be empty. This is account for within the validation logic, so
errors are clear for operators.