### PR TITLE
Task API via Unix Domain Socket

### DIFF
--- a/.changelog/15864.txt
+++ b/.changelog/15864.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client: added http api access for tasks via unix socket
+```

--- a/client/allocrunner/interfaces/task_lifecycle.go
+++ b/client/allocrunner/interfaces/task_lifecycle.go
@@ -186,6 +186,9 @@ type TaskStopRequest struct {
 	// ExistingState is previously set hook data and should only be
 	// read. Stop hooks cannot alter state.
 	ExistingState map[string]string
+
+	// TaskDir contains the task's directory tree on the host
+	TaskDir *allocdir.TaskDir
 }
 
 type TaskStopResponse struct{}

--- a/client/allocrunner/interfaces/task_lifecycle.go
+++ b/client/allocrunner/interfaces/task_lifecycle.go
@@ -33,8 +33,6 @@ import (
                                   +-----------+
                                      *Kill
                                 (forces terminal)
-
-Link: http://stable.ascii-flow.appspot.com/#Draw4489375405966393064/1824429135
 */
 
 // TaskHook is a lifecycle hook into the life cycle of a task runner.

--- a/client/allocrunner/taskrunner/api_hook.go
+++ b/client/allocrunner/taskrunner/api_hook.go
@@ -1,0 +1,83 @@
+package taskrunner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/client/config"
+)
+
+type apiHook struct {
+	srv    config.APIListenerRegistrar
+	logger log.Logger
+	ln     net.Listener
+}
+
+func newAPIHook(srv config.APIListenerRegistrar, logger log.Logger) *apiHook {
+	h := &apiHook{
+		srv: srv,
+	}
+	h.logger = logger.Named(h.Name())
+	return h
+}
+
+func (*apiHook) Name() string {
+	return "api"
+}
+
+func (h *apiHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
+	if h.ln != nil {
+		//TODO(schmichael) remove me
+		h.logger.Trace("huh, called apiHook.Prestart twice")
+		return nil
+	}
+
+	//TODO(schmichael) what dir & perms
+	udsDir := filepath.Join(req.TaskDir.SecretsDir, "run")
+	if err := os.MkdirAll(udsDir, 0o775); err != nil {
+		return fmt.Errorf("error creating api socket directory: %w", err)
+	}
+
+	//TODO(schmichael) what name
+	udsPath := filepath.Join(udsDir, "nomad.socket")
+	if err := os.RemoveAll(udsPath); err != nil {
+		return fmt.Errorf("could not remove existing api socket: %w", err)
+	}
+
+	udsln, err := net.Listen("unix", udsPath)
+	if err != nil {
+		return fmt.Errorf("could not create api socket: %w", err)
+	}
+
+	go func() {
+		if err := h.srv.Serve(ctx, udsln); err != nil {
+			//TODO(schmichael) probably ignore http.ErrServerClosed
+			h.logger.Warn("error serving api", "error", err)
+		}
+	}()
+
+	h.ln = udsln
+	return nil
+}
+
+func (h *apiHook) Stop(ctx context.Context, req *interfaces.TaskStopRequest, resp *interfaces.TaskStopResponse) error {
+	if h.ln == nil {
+		//TODO(schmichael) remove me
+		h.logger.Trace("huh, no listener")
+		return nil
+	}
+
+	if err := h.ln.Close(); err != nil {
+		if errors.Is(err, net.ErrClosed) {
+			return nil
+		}
+		h.logger.Trace("error closing task listener: %v", err)
+	}
+	return nil
+}

--- a/client/allocrunner/taskrunner/api_hook.go
+++ b/client/allocrunner/taskrunner/api_hook.go
@@ -46,6 +46,11 @@ func (*apiHook) Name() string {
 }
 
 func (h *apiHook) Prestart(_ context.Context, req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
+	if h.ln != nil {
+		// Listener already set. Task is probably restarting.
+		return nil
+	}
+
 	udsPath := apiSocketPath(req.TaskDir)
 	if err := os.RemoveAll(udsPath); err != nil {
 		h.logger.Warn("error removing task api socket", "path", udsPath, "error", err)

--- a/client/allocrunner/taskrunner/api_hook.go
+++ b/client/allocrunner/taskrunner/api_hook.go
@@ -62,6 +62,10 @@ func (h *apiHook) Prestart(_ context.Context, req *interfaces.TaskPrestartReques
 		return nil
 	}
 
+	if err := os.Chmod(udsPath, 0o777); err != nil {
+		h.logger.Warn("error setting task api socket permissions", "path", udsPath, "error", err)
+	}
+
 	go func() {
 		// Cannot use Prestart's context as it is closed after all prestart hooks
 		// have been closed, but we do want to try to cleanup on shutdown.

--- a/client/allocrunner/taskrunner/api_hook_test.go
+++ b/client/allocrunner/taskrunner/api_hook_test.go
@@ -1,0 +1,140 @@
+package taskrunner
+
+import (
+	"context"
+	"io/fs"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/client/allocdir"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/shoenig/test/must"
+)
+
+type testAPIListenerRegistrar struct {
+	cb func(net.Listener) error
+}
+
+func (n testAPIListenerRegistrar) Serve(_ context.Context, ln net.Listener) error {
+	if n.cb != nil {
+		return n.cb(ln)
+	}
+	return nil
+}
+
+// TestAPIHook_SoftFail asserts that the Task API Hook soft fails and does not
+// return errors.
+func TestAPIHook_SoftFail(t *testing.T) {
+	ci.Parallel(t)
+
+	// Use a SecretsDir that will always exceed Unix socket path length
+	// limits (sun_path)
+	dst := filepath.Join(t.TempDir(), strings.Repeat("_NOMAD_TEST_", 500))
+
+	ctx := context.Background()
+	srv := testAPIListenerRegistrar{}
+	logger := testlog.HCLogger(t)
+	h := newAPIHook(ctx, srv, logger)
+
+	req := &interfaces.TaskPrestartRequest{
+		TaskDir: &allocdir.TaskDir{
+			SecretsDir: dst,
+		},
+	}
+	resp := &interfaces.TaskPrestartResponse{}
+
+	err := h.Prestart(ctx, req, resp)
+	must.NoError(t, err)
+
+	// listener should not have been set
+	must.Nil(t, h.ln)
+
+	// File should not have been created
+	_, err = os.Stat(dst)
+	must.Error(t, err)
+
+	// Assert stop also soft-fails
+	stopReq := &interfaces.TaskStopRequest{
+		TaskDir: req.TaskDir,
+	}
+	stopResp := &interfaces.TaskStopResponse{}
+	err = h.Stop(ctx, stopReq, stopResp)
+	must.NoError(t, err)
+
+	// File should not have been created
+	_, err = os.Stat(dst)
+	must.Error(t, err)
+}
+
+// TestAPIHook_Ok asserts that the Task API Hook creates and cleans up a
+// socket.
+func TestAPIHook_Ok(t *testing.T) {
+	ci.Parallel(t)
+
+	// If this test fails it may be because TempDir() + /api.sock is longer than
+	// the unix socket path length limit (sun_path) in which case the test should
+	// use a different temporary directory on that platform.
+	dst := t.TempDir()
+
+	// Write "ok" and close the connection and listener
+	srv := testAPIListenerRegistrar{
+		cb: func(ln net.Listener) error {
+			conn, err := ln.Accept()
+			if err != nil {
+				return err
+			}
+			if _, err = conn.Write([]byte("ok")); err != nil {
+				return err
+			}
+			conn.Close()
+			return nil
+		},
+	}
+
+	ctx := context.Background()
+	logger := testlog.HCLogger(t)
+	h := newAPIHook(ctx, srv, logger)
+
+	req := &interfaces.TaskPrestartRequest{
+		TaskDir: &allocdir.TaskDir{
+			SecretsDir: dst,
+		},
+	}
+	resp := &interfaces.TaskPrestartResponse{}
+
+	err := h.Prestart(ctx, req, resp)
+	must.NoError(t, err)
+
+	// File should have been created
+	sockDst := apiSocketPath(req.TaskDir)
+	stat, err := os.Stat(sockDst)
+	must.NoError(t, err)
+	must.True(t, stat.Mode()&fs.ModeSocket != 0,
+		must.Sprintf("expected %q to be a unix socket but got %s", sockDst, stat.Mode()))
+
+	// Assert the listener is working
+	conn, err := net.Dial("unix", sockDst)
+	must.NoError(t, err)
+	buf := make([]byte, 2)
+	_, err = conn.Read(buf)
+	must.NoError(t, err)
+	must.Eq(t, []byte("ok"), buf)
+	conn.Close()
+
+	// Assert stop cleans up
+	stopReq := &interfaces.TaskStopRequest{
+		TaskDir: req.TaskDir,
+	}
+	stopResp := &interfaces.TaskStopResponse{}
+	err = h.Stop(ctx, stopReq, stopResp)
+	must.NoError(t, err)
+
+	// File should be gone
+	_, err = net.Dial("unix", sockDst)
+	must.Error(t, err)
+}

--- a/client/allocrunner/taskrunner/api_hook_test.go
+++ b/client/allocrunner/taskrunner/api_hook_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -112,10 +113,14 @@ func TestAPIHook_Ok(t *testing.T) {
 
 	// File should have been created
 	sockDst := apiSocketPath(req.TaskDir)
-	stat, err := os.Stat(sockDst)
-	must.NoError(t, err)
-	must.True(t, stat.Mode()&fs.ModeSocket != 0,
-		must.Sprintf("expected %q to be a unix socket but got %s", sockDst, stat.Mode()))
+
+	// Stat on Windows fails on sockets
+	if runtime.GOOS != "windows" {
+		stat, err := os.Stat(sockDst)
+		must.NoError(t, err)
+		must.True(t, stat.Mode()&fs.ModeSocket != 0,
+			must.Sprintf("expected %q to be a unix socket but got %s", sockDst, stat.Mode()))
+	}
 
 	// Assert the listener is working
 	conn, err := net.Dial("unix", sockDst)

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -426,7 +426,11 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 
 	// Use the client secret only as the initial value; the identity hook will
 	// update this with a workload identity if one is available
-	tr.setNomadToken(config.ClientConfig.Node.SecretID)
+	//TODO(schmichael) can we remove this entirely? seems like a huge
+	//security problem if we use accidentally use it instead of the
+	//workload identity
+	//tr.setNomadToken(config.ClientConfig.Node.SecretID)
+	tr.setNomadToken("Hi, this is a fake token that should never work or be used! Remove me.")
 
 	// Initialize the runners hooks. Must come after initDriver so hooks
 	// can use tr.driverCapabilities

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -426,11 +426,7 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 
 	// Use the client secret only as the initial value; the identity hook will
 	// update this with a workload identity if one is available
-	//TODO(schmichael) can we remove this entirely? seems like a huge
-	//security problem if we use accidentally use it instead of the
-	//workload identity
-	//tr.setNomadToken(config.ClientConfig.Node.SecretID)
-	tr.setNomadToken("Hi, this is a fake token that should never work or be used! Remove me.")
+	tr.setNomadToken(config.ClientConfig.Node.SecretID)
 
 	// Initialize the runners hooks. Must come after initDriver so hooks
 	// can use tr.driverCapabilities

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -68,7 +68,7 @@ func (tr *TaskRunner) initHooks() {
 		newArtifactHook(tr, tr.getter, hookLogger),
 		newStatsHook(tr, tr.clientConfig.StatsCollectionInterval, hookLogger),
 		newDeviceHook(tr.devicemanager, hookLogger),
-		newAPIHook(tr.clientConfig.APIListenerRegistrar, hookLogger),
+		newAPIHook(tr.shutdownCtx, tr.clientConfig.APIListenerRegistrar, hookLogger),
 	}
 
 	// If the task has a CSI block, add the hook.

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -432,7 +432,9 @@ func (tr *TaskRunner) stop() error {
 			tr.logger.Trace("running stop hook", "name", name, "start", start)
 		}
 
-		req := interfaces.TaskStopRequest{}
+		req := interfaces.TaskStopRequest{
+			TaskDir: tr.taskDir,
+		}
 
 		origHookState := tr.hookState(name)
 		if origHookState != nil {

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -68,6 +68,7 @@ func (tr *TaskRunner) initHooks() {
 		newArtifactHook(tr, tr.getter, hookLogger),
 		newStatsHook(tr, tr.clientConfig.StatsCollectionInterval, hookLogger),
 		newDeviceHook(tr.devicemanager, hookLogger),
+		newAPIHook(tr.clientConfig.APIListenerRegistrar, hookLogger),
 	}
 
 	// If the task has a CSI block, add the hook.

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -311,15 +311,13 @@ type Config struct {
 }
 
 type APIListenerRegistrar interface {
-	// Serve the HTTP API on the provided listener. The returned channel may be
-	// used to receive errors and is closed when the listener is no longer being
-	// served. If the agent is shutting down the error will be
-	// http.ErrServerClosed.
+	// Serve the HTTP API on the provided listener. If the agent is shutting down
+	// the error will be http.ErrServerClosed.
 	//
 	// The context is because Serve may be called before the HTTP server has been
 	// initialized. If the context is canceled before the HTTP server is
-	// initialized, the context's error will be returned on the chan.
-	Serve(context.Context, net.Listener) chan error
+	// initialized, the context's error will be returned.
+	Serve(context.Context, net.Listener) error
 }
 
 // ClientTemplateConfig is configuration on the client specific to template

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -311,8 +311,7 @@ type Config struct {
 }
 
 type APIListenerRegistrar interface {
-	// Serve the HTTP API on the provided listener. If the agent is shutting down
-	// the error will be http.ErrServerClosed.
+	// Serve the HTTP API on the provided listener.
 	//
 	// The context is because Serve may be called before the HTTP server has been
 	// initialized. If the context is canceled before the HTTP server is

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net"
 	"reflect"
 	"strconv"
 	"strings"
@@ -301,8 +303,23 @@ type Config struct {
 	// used for template functions which require access to the Nomad API.
 	TemplateDialer *bufconndialer.BufConnWrapper
 
+	//TODO(schmichael) write something
+	APIListenerRegistrar APIListenerRegistrar
+
 	// Artifact configuration from the agent's config file.
 	Artifact *ArtifactConfig
+}
+
+type APIListenerRegistrar interface {
+	// Serve the HTTP API on the provided listener. The returned channel may be
+	// used to receive errors and is closed when the listener is no longer being
+	// served. If the agent is shutting down the error will be
+	// http.ErrServerClosed.
+	//
+	// The context is because Serve may be called before the HTTP server has been
+	// initialized. If the context is canceled before the HTTP server is
+	// initialized, the context's error will be returned on the chan.
+	Serve(context.Context, net.Listener) chan error
 }
 
 // ClientTemplateConfig is configuration on the client specific to template

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -303,7 +303,12 @@ type Config struct {
 	// used for template functions which require access to the Nomad API.
 	TemplateDialer *bufconndialer.BufConnWrapper
 
-	//TODO(schmichael) write something
+	// APIListenerRegistrar allows the client to registers listeners created at
+	// runtime (eg the Task API) with the agent's HTTP server. Since the agent
+	// creates the HTTP *after* the client starts, we have to use this shim to
+	// pass listeners back to the agent.
+	// This is the same design as the bufconndialer but for the
+	// http.Serve(listener) API instead of the net.Dial API.
 	APIListenerRegistrar APIListenerRegistrar
 
 	// Artifact configuration from the agent's config file.

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -303,7 +303,7 @@ type Config struct {
 	// used for template functions which require access to the Nomad API.
 	TemplateDialer *bufconndialer.BufConnWrapper
 
-	// APIListenerRegistrar allows the client to registers listeners created at
+	// APIListenerRegistrar allows the client to register listeners created at
 	// runtime (eg the Task API) with the agent's HTTP server. Since the agent
 	// creates the HTTP *after* the client starts, we have to use this shim to
 	// pass listeners back to the agent.

--- a/client/config/testing.go
+++ b/client/config/testing.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"context"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -74,5 +76,14 @@ func TestClientConfig(t testing.T) (*Config, func()) {
 	// Same as default; necessary for task Event messages
 	conf.MaxKillTimeout = 30 * time.Second
 
+	// Provide a stub APIListenerRegistrar implementation
+	conf.APIListenerRegistrar = noopAPIListenerRegistrar{}
+
 	return conf, cleanup
+}
+
+type noopAPIListenerRegistrar struct{}
+
+func (noopAPIListenerRegistrar) Serve(_ context.Context, _ net.Listener) error {
+	return nil
 }

--- a/client/config/testing.go
+++ b/client/config/testing.go
@@ -77,13 +77,13 @@ func TestClientConfig(t testing.T) (*Config, func()) {
 	conf.MaxKillTimeout = 30 * time.Second
 
 	// Provide a stub APIListenerRegistrar implementation
-	conf.APIListenerRegistrar = noopAPIListenerRegistrar{}
+	conf.APIListenerRegistrar = NoopAPIListenerRegistrar{}
 
 	return conf, cleanup
 }
 
-type noopAPIListenerRegistrar struct{}
+type NoopAPIListenerRegistrar struct{}
 
-func (noopAPIListenerRegistrar) Serve(_ context.Context, _ net.Listener) error {
+func (NoopAPIListenerRegistrar) Serve(_ context.Context, _ net.Listener) error {
 	return nil
 }

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -115,8 +115,8 @@ type Agent struct {
 	builtinListener net.Listener
 	builtinDialer   *bufconndialer.BufConnWrapper
 
-	//TODO(schmichael) builtinServer is an HTTP server for attaching
-	//per-task listeners. Always requires auth.
+	// builtinServer is an HTTP server for attaching per-task listeners. Always
+	// requires auth.
 	builtinServer *builtinAPI
 
 	inmemSink *metrics.InmemSink
@@ -1021,7 +1021,6 @@ func (a *Agent) setupClient() error {
 	// running consul-template functions that utilize the Nomad API. We lazy
 	// load this into the client config, therefore this needs to happen before
 	// we call NewClient.
-	//TODO migrate to APIListenerRegistrar
 	a.builtinListener, a.builtinDialer = bufconndialer.New()
 	conf.TemplateDialer = a.builtinDialer
 

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -440,7 +440,7 @@ func (s *HTTPServer) listServers(resp http.ResponseWriter, req *http.Request) (i
 		return nil, structs.ErrPermissionDenied
 	}
 
-	peers := s.agent.client.GetServers()
+	peers := client.GetServers()
 	sort.Strings(peers)
 	return peers, nil
 }
@@ -468,9 +468,9 @@ func (s *HTTPServer) updateServers(resp http.ResponseWriter, req *http.Request) 
 	}
 
 	// Set the servers list into the client
-	s.agent.logger.Trace("adding servers to the client's primary server list", "servers", servers, "path", "/v1/agent/servers", "method", "PUT")
+	s.logger.Trace("adding servers to the client's primary server list", "servers", servers, "path", "/v1/agent/servers", "method", "PUT")
 	if _, err := client.SetServers(servers); err != nil {
-		s.agent.logger.Error("failed adding servers to client's server list", "servers", servers, "error", err, "path", "/v1/agent/servers", "method", "PUT")
+		s.logger.Error("failed adding servers to client's server list", "servers", servers, "error", err, "path", "/v1/agent/servers", "method", "PUT")
 		//TODO is this the right error to return?
 		return nil, CodedError(400, err.Error())
 	}
@@ -708,7 +708,7 @@ func (s *HTTPServer) AgentHostRequest(resp http.ResponseWriter, req *http.Reques
 	// The RPC endpoint actually forwards the request to the correct
 	// agent, but we need to use the correct RPC interface.
 	localClient, remoteClient, localServer := s.rpcHandlerForNode(lookupNodeID)
-	s.agent.logger.Debug("s.rpcHandlerForNode()", "lookupNodeID", lookupNodeID, "serverID", serverID, "nodeID", nodeID, "localClient", localClient, "remoteClient", remoteClient, "localServer", localServer)
+	s.logger.Debug("s.rpcHandlerForNode()", "lookupNodeID", lookupNodeID, "serverID", serverID, "nodeID", nodeID, "localClient", localClient, "remoteClient", remoteClient, "localServer", localServer)
 
 	// Make the RPC call
 	if localClient {

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -222,7 +222,7 @@ func (s *HTTPServer) ClientAllocRequest(resp http.ResponseWriter, req *http.Requ
 	case "exec":
 		return s.allocExec(allocID, resp, req)
 	case "snapshot":
-		if s.agent.client == nil {
+		if s.agent.Client() == nil {
 			return nil, clientNotRunning
 		}
 		return s.allocSnapshot(allocID, resp, req)

--- a/command/agent/consul/int_test.go
+++ b/command/agent/consul/int_test.go
@@ -46,7 +46,7 @@ func TestConsul_Integration(t *testing.T) {
 
 	// Create an embedded Consul server
 	testconsul, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
-		c.Peering = nil  // fix for older versions of Consul (<1.13.0) that don't support peering
+		c.Peering = nil // fix for older versions of Consul (<1.13.0) that don't support peering
 		// If -v wasn't specified squelch consul logging
 		if !testing.Verbose() {
 			c.Stdout = ioutil.Discard
@@ -152,19 +152,20 @@ func TestConsul_Integration(t *testing.T) {
 
 	// Build the config
 	config := &taskrunner.Config{
-		Alloc:               alloc,
-		ClientConfig:        conf,
-		Consul:              serviceClient,
-		Task:                task,
-		TaskDir:             taskDir,
-		Logger:              logger,
-		Vault:               vclient,
-		StateDB:             state.NoopDB{},
-		StateUpdater:        logUpdate,
-		DeviceManager:       devicemanager.NoopMockManager(),
-		DriverManager:       drivermanager.TestDriverManager(t),
-		StartConditionMetCh: closedCh,
-		ServiceRegWrapper:   wrapper.NewHandlerWrapper(logger, serviceClient, regMock.NewServiceRegistrationHandler(logger)),
+		Alloc:                alloc,
+		ClientConfig:         conf,
+		Consul:               serviceClient,
+		Task:                 task,
+		TaskDir:              taskDir,
+		Logger:               logger,
+		Vault:                vclient,
+		StateDB:              state.NoopDB{},
+		StateUpdater:         logUpdate,
+		DeviceManager:        devicemanager.NoopMockManager(),
+		DriverManager:        drivermanager.TestDriverManager(t),
+		StartConditionMetCh:  closedCh,
+		ServiceRegWrapper:    wrapper.NewHandlerWrapper(logger, serviceClient, regMock.NewServiceRegistrationHandler(logger)),
+		APIListenerRegistrar: config.NoopAPIListenerRegistrar{},
 	}
 
 	tr, err := taskrunner.NewTaskRunner(config)

--- a/command/agent/consul/int_test.go
+++ b/command/agent/consul/int_test.go
@@ -61,6 +61,7 @@ func TestConsul_Integration(t *testing.T) {
 	conf := config.DefaultConfig()
 	conf.Node = mock.Node()
 	conf.ConsulConfig.Addr = testconsul.HTTPAddr
+	conf.APIListenerRegistrar = config.NoopAPIListenerRegistrar{}
 	consulConfig, err := conf.ConsulConfig.ApiConfig()
 	if err != nil {
 		t.Fatalf("error generating consul config: %v", err)
@@ -152,20 +153,19 @@ func TestConsul_Integration(t *testing.T) {
 
 	// Build the config
 	config := &taskrunner.Config{
-		Alloc:                alloc,
-		ClientConfig:         conf,
-		Consul:               serviceClient,
-		Task:                 task,
-		TaskDir:              taskDir,
-		Logger:               logger,
-		Vault:                vclient,
-		StateDB:              state.NoopDB{},
-		StateUpdater:         logUpdate,
-		DeviceManager:        devicemanager.NoopMockManager(),
-		DriverManager:        drivermanager.TestDriverManager(t),
-		StartConditionMetCh:  closedCh,
-		ServiceRegWrapper:    wrapper.NewHandlerWrapper(logger, serviceClient, regMock.NewServiceRegistrationHandler(logger)),
-		APIListenerRegistrar: config.NoopAPIListenerRegistrar{},
+		Alloc:               alloc,
+		ClientConfig:        conf,
+		Consul:              serviceClient,
+		Task:                task,
+		TaskDir:             taskDir,
+		Logger:              logger,
+		Vault:               vclient,
+		StateDB:             state.NoopDB{},
+		StateUpdater:        logUpdate,
+		DeviceManager:       devicemanager.NoopMockManager(),
+		DriverManager:       drivermanager.TestDriverManager(t),
+		StartConditionMetCh: closedCh,
+		ServiceRegWrapper:   wrapper.NewHandlerWrapper(logger, serviceClient, regMock.NewServiceRegistrationHandler(logger)),
 	}
 
 	tr, err := taskrunner.NewTaskRunner(config)

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -1063,14 +1063,14 @@ func (a *authMiddleware) ServeHTTP(resp http.ResponseWriter, req *http.Request) 
 	if a.srv.parse(resp, req, &args.Region, &args.QueryOptions) {
 		// Error parsing request, 400
 		resp.WriteHeader(http.StatusBadRequest)
-		resp.Write([]byte("Invalid request parameters\n"))
+		resp.Write([]byte(http.StatusText(http.StatusBadRequest)))
 		return
 	}
 
 	if args.AuthToken == "" {
 		// 401 instead of 403 since no token was present.
 		resp.WriteHeader(http.StatusUnauthorized)
-		resp.Write([]byte("Authorization required\n"))
+		resp.Write([]byte(http.StatusText(http.StatusUnauthorized)))
 		return
 	}
 
@@ -1085,7 +1085,7 @@ func (a *authMiddleware) ServeHTTP(resp http.ResponseWriter, req *http.Request) 
 	if reply.Identity == nil || (reply.Identity.ACLToken == nil && reply.Identity.Claims == nil) {
 		a.srv.logger.Debug("Failed to authenticated Task API request", "method", req.Method, "url", req.URL)
 		resp.WriteHeader(http.StatusForbidden)
-		resp.Write([]byte("Forbidden\n"))
+		resp.Write([]byte(http.StatusText(http.StatusForbidden)))
 		return
 	}
 

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -1091,5 +1091,4 @@ func (a *authMiddleware) ServeHTTP(resp http.ResponseWriter, req *http.Request) 
 
 	a.srv.logger.Trace("Authenticated request", "id", reply.Identity, "method", req.Method, "url", req.URL)
 	a.wrapped.ServeHTTP(resp, req)
-	return
 }

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -214,8 +214,6 @@ func NewHTTPServers(agent *Agent, config *Config) ([]*HTTPServer, error) {
 		srvs = append(srvs, srv)
 	}
 
-	// This HTTP server is only
-
 	if serverInitializationErrors != nil {
 		for _, srv := range srvs {
 			srv.Shutdown()
@@ -1043,8 +1041,10 @@ func wrapCORSWithAllowedMethods(f func(http.ResponseWriter, *http.Request), meth
 	return allowCORSWithMethods(methods...).Handler(http.HandlerFunc(f))
 }
 
-// TODO(schmichael) caching - see client/acl.go
-// TODO(schmichael) where should this thing live
+// authMiddleware implements the http.Handler interface to enforce
+// authentication for *all* requests. Even with ACLs enabled there are
+// endpoints which are accessible without authenticating. This middleware is
+// used for the Task API to enfoce authentication for all API access.
 type authMiddleware struct {
 	srv     *HTTPServer
 	wrapped http.Handler

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -819,7 +819,7 @@ func (s *HTTPServer) apiJobAndRequestToStructs(job *api.Job, req *http.Request, 
 
 	queryRegion := req.URL.Query().Get("region")
 	requestRegion, jobRegion := regionForJob(
-		job, queryRegion, writeReq.Region, s.agent.config.Region,
+		job, queryRegion, writeReq.Region, s.agent.GetConfig().Region,
 	)
 
 	sJob := ApiJobToStructJob(job)

--- a/command/agent/metrics_endpoint.go
+++ b/command/agent/metrics_endpoint.go
@@ -25,14 +25,14 @@ func (s *HTTPServer) MetricsRequest(resp http.ResponseWriter, req *http.Request)
 
 		// Only return Prometheus formatted metrics if the user has enabled
 		// this functionality.
-		if !s.agent.config.Telemetry.PrometheusMetrics {
+		if !s.agent.GetConfig().Telemetry.PrometheusMetrics {
 			return nil, CodedError(http.StatusUnsupportedMediaType, "Prometheus is not enabled")
 		}
 		s.prometheusHandler().ServeHTTP(resp, req)
 		return nil, nil
 	}
 
-	return s.agent.InmemSink.DisplayMetrics(resp, req)
+	return s.agent.GetMetricsSink().DisplayMetrics(resp, req)
 }
 
 func (s *HTTPServer) prometheusHandler() http.Handler {

--- a/command/agent/variable_endpoint.go
+++ b/command/agent/variable_endpoint.go
@@ -16,7 +16,8 @@ func (s *HTTPServer) VariablesListRequest(resp http.ResponseWriter, req *http.Re
 
 	args := structs.VariablesListRequest{}
 	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
-		return nil, nil
+		//TODO(schmichael) shouldn't we return something here?!
+		return nil, CodedError(http.StatusBadRequest, "failed to parse parameters")
 	}
 
 	var out structs.VariablesListResponse

--- a/e2e/workload_id/input/api-auth.nomad.hcl
+++ b/e2e/workload_id/input/api-auth.nomad.hcl
@@ -14,7 +14,7 @@ job "api-auth" {
       driver = "docker"
       config {
         image = "curlimages/curl:7.87.0"
-        args  = [
+        args = [
           "--unix-socket", "${NOMAD_SECRETS_DIR}/api.sock",
           "-v",
           "localhost/v1/agent/health",
@@ -32,7 +32,7 @@ job "api-auth" {
       driver = "docker"
       config {
         image = "curlimages/curl:7.87.0"
-        args  = [
+        args = [
           "--unix-socket", "${NOMAD_SECRETS_DIR}/api.sock",
           "-H", "X-Nomad-Token: 37297754-3b87-41da-9ac7-d98fd934deed",
           "-v",
@@ -52,7 +52,7 @@ job "api-auth" {
 
       config {
         image = "curlimages/curl:7.87.0"
-        args  = [
+        args = [
           "--unix-socket", "${NOMAD_SECRETS_DIR}/api.sock",
           "-H", "Authorization: Bearer ${NOMAD_TOKEN}",
           "-v",

--- a/e2e/workload_id/input/api-auth.nomad.hcl
+++ b/e2e/workload_id/input/api-auth.nomad.hcl
@@ -1,0 +1,99 @@
+job "api-auth" {
+  datacenters = ["dc1"]
+  type        = "batch"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "api-auth" {
+
+    # none task should get a 401 response
+    task "none" {
+      driver = "docker"
+      config {
+        image = "curlimages/curl:7.87.0"
+        args  = [
+          "--unix-socket", "${NOMAD_SECRETS_DIR}/api.sock",
+          "-v",
+          "localhost/v1/agent/health",
+        ]
+      }
+      resources {
+        cpu    = 16
+        memory = 32
+        disk   = 64
+      }
+    }
+
+    # bad task should get a 403 response
+    task "bad" {
+      driver = "docker"
+      config {
+        image = "curlimages/curl:7.87.0"
+        args  = [
+          "--unix-socket", "${NOMAD_SECRETS_DIR}/api.sock",
+          "-H", "X-Nomad-Token: 37297754-3b87-41da-9ac7-d98fd934deed",
+          "-v",
+          "localhost/v1/agent/health",
+        ]
+      }
+      resources {
+        cpu    = 16
+        memory = 32
+        disk   = 64
+      }
+    }
+
+    # docker-wid task should succeed due to using workload identity
+    task "docker-wid" {
+      driver = "docker"
+
+      config {
+        image = "curlimages/curl:7.87.0"
+        args  = [
+          "--unix-socket", "${NOMAD_SECRETS_DIR}/api.sock",
+          "-H", "Authorization: Bearer ${NOMAD_TOKEN}",
+          "-v",
+          "localhost/v1/agent/health",
+        ]
+      }
+
+      identity {
+        env = true
+      }
+
+      resources {
+        cpu    = 16
+        memory = 32
+        disk   = 64
+      }
+    }
+
+    # exec-wid task should succeed due to using workload identity
+    task "exec-wid" {
+      driver = "exec"
+
+      config {
+        command = "curl"
+        args = [
+          "-H", "Authorization: Bearer ${NOMAD_TOKEN}",
+          "--unix-socket", "${NOMAD_SECRETS_DIR}/api.sock",
+          "-v",
+          "localhost/v1/agent/health",
+        ]
+      }
+
+      identity {
+        env = true
+      }
+
+      resources {
+        cpu    = 16
+        memory = 32
+        disk   = 64
+      }
+    }
+  }
+}

--- a/e2e/workload_id/input/api-win.nomad.hcl
+++ b/e2e/workload_id/input/api-win.nomad.hcl
@@ -1,0 +1,36 @@
+job "api-win" {
+  datacenters = ["dc1"]
+  type        = "batch"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "windows"
+  }
+
+  constraint {
+    attribute = "${attr.cpu.arch}"
+    value     = "amd64"
+  }
+
+  group "api-win" {
+
+    task "win" {
+      driver = "raw_exec"
+      config {
+        command = "powershell"
+        args    = ["local/curl-7.87.0_4-win64-mingw/bin/curl.exe -H \"Authorization: Bearer $env:NOMAD_TOKEN\" --unix-socket $env:NOMAD_SECRETS_DIR/api.sock -v localhost:4646/v1/agent/health"]
+      }
+      artifact {
+        source = "https://curl.se/windows/dl-7.87.0_4/curl-7.87.0_4-win64-mingw.zip"
+      }
+      identity {
+        env = true
+      }
+      resources {
+        cpu    = 16
+        memory = 32
+        disk   = 64
+      }
+    }
+  }
+}

--- a/e2e/workload_id/taskapi_test.go
+++ b/e2e/workload_id/taskapi_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/nomad/e2e/e2eutil"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/shoenig/test"
+	"github.com/shoenig/test/must"
+)
+
+// TestTaskAPI runs subtets exercising the Task API related functionality.
+// Bundled with Workload Identity as that's a prereq for the Task API to work.
+func TestTaskAPI(t *testing.T) {
+	nomad := e2eutil.NomadClient(t)
+
+	e2eutil.WaitForLeader(t, nomad)
+	e2eutil.WaitForNodesReady(t, nomad, 1)
+
+	t.Run("testTaskAPI_Auth", testTaskAPIAuth)
+	t.Run("testTaskAPI_Windows", testTaskAPIWindows)
+}
+
+func testTaskAPIAuth(t *testing.T) {
+	nomad := e2eutil.NomadClient(t)
+	jobID := "api-auth-" + uuid.Short()
+	jobIDs := []string{jobID}
+	t.Cleanup(e2eutil.CleanupJobsAndGC(t, &jobIDs))
+
+	// start job
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, nomad, "./input/api-auth.nomad.hcl", jobID, "")
+	must.Len(t, 1, allocs)
+	allocID := allocs[0].ID
+
+	// wait for batch alloc to complete
+	alloc := e2eutil.WaitForAllocStopped(t, nomad, allocID)
+	must.Eq(t, alloc.ClientStatus, "complete")
+
+	assertions := []struct {
+		task   string
+		suffix string
+	}{
+		{
+			task:   "none",
+			suffix: http.StatusText(http.StatusUnauthorized),
+		},
+		{
+			task:   "bad",
+			suffix: http.StatusText(http.StatusForbidden),
+		},
+		{
+			task:   "docker-wid",
+			suffix: `"ok":true}}`,
+		},
+		{
+			task:   "exec-wid",
+			suffix: `"ok":true}}`,
+		},
+	}
+
+	// Ensure the assertions and input file match
+	must.Len(t, len(assertions), alloc.Job.TaskGroups[0].Tasks,
+		must.Sprintf("test and jobspec mismatch"))
+
+	for _, tc := range assertions {
+		logFile := fmt.Sprintf("alloc/logs/%s.stdout.0", tc.task)
+		fd, err := nomad.AllocFS().Cat(alloc, logFile, nil)
+		must.NoError(t, err)
+		logBytes, err := io.ReadAll(fd)
+		must.NoError(t, err)
+		logs := string(logBytes)
+
+		ps := must.Sprintf("Task: %s Logs: <<EOF\n%sEOF", tc.task, logs)
+
+		must.StrHasSuffix(t, tc.suffix, logs, ps)
+	}
+}
+
+func testTaskAPIWindows(t *testing.T) {
+	nomad := e2eutil.NomadClient(t)
+	winNodes, err := e2eutil.ListWindowsClientNodes(nomad)
+	must.NoError(t, err)
+	if len(winNodes) == 0 {
+		t.Skip("no Windows clients")
+	}
+
+	jobID := "api-win-" + uuid.Short()
+	jobIDs := []string{jobID}
+	t.Cleanup(e2eutil.CleanupJobsAndGC(t, &jobIDs))
+
+	// start job
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, nomad, "./input/api-win.nomad.hcl", jobID, "")
+	must.Len(t, 1, allocs)
+	allocID := allocs[0].ID
+
+	// wait for batch alloc to complete
+	alloc := e2eutil.WaitForAllocStopped(t, nomad, allocID)
+	test.Eq(t, alloc.ClientStatus, "complete")
+
+	logFile := "alloc/logs/win.stdout.0"
+	fd, err := nomad.AllocFS().Cat(alloc, logFile, nil)
+	must.NoError(t, err)
+	logBytes, err := io.ReadAll(fd)
+	must.NoError(t, err)
+	logs := string(logBytes)
+
+	must.StrHasSuffix(t, `"ok":true}}`, logs)
+}

--- a/helper/users/lookup_windows_test.go
+++ b/helper/users/lookup_windows_test.go
@@ -44,7 +44,23 @@ func TestWriteFileFor_Windows(t *testing.T) {
 	stat, err := os.Lstat(path)
 	must.NoError(t, err)
 	must.True(t, stat.Mode().IsRegular(),
-		must.Sprintf("expected %s to be a normal file but found %#o", path, stat.Mode()))
+		must.Sprintf("expected %s to be a regular file but found %#o", path, stat.Mode()))
+
+	// Assert Windows hits the fallback world-accessible case
+	must.Eq(t, 0o666, stat.Mode().Perm())
+}
+
+// TestSocketFileFor_Windows asserts that socket files cannot be chowned on
+// windows.
+func TestSocketFileFor_Windows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "api.sock")
+
+	ln, err := SocketFileFor(testlog.HCLogger(t), path, "Administrator")
+	must.NoError(t, err)
+	must.NotNil(t, ln)
+	defer ln.Close()
+	stat, err := os.Lstat(path)
+	must.NoError(t, err)
 
 	// Assert Windows hits the fallback world-accessible case
 	must.Eq(t, 0o666, stat.Mode().Perm())

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -501,12 +501,6 @@ func (ai *AuthenticatedIdentity) GetClaims() *IdentityClaims {
 	return ai.Claims
 }
 
-type RequestWithIdentity interface {
-	GetAuthToken() string
-	SetIdentity(identity *AuthenticatedIdentity)
-	GetIdentity() *AuthenticatedIdentity
-}
-
 func (ai *AuthenticatedIdentity) String() string {
 	if ai == nil {
 		return "unauthenticated"
@@ -521,6 +515,12 @@ func (ai *AuthenticatedIdentity) String() string {
 		return fmt.Sprintf("client:%s", ai.ClientID)
 	}
 	return fmt.Sprintf("%s:%s", ai.TLSName, ai.RemoteIP.String())
+}
+
+type RequestWithIdentity interface {
+	GetAuthToken() string
+	SetIdentity(identity *AuthenticatedIdentity)
+	GetIdentity() *AuthenticatedIdentity
 }
 
 // QueryMeta allows a query response to include potentially

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10632,6 +10632,14 @@ type IdentityClaims struct {
 	jwt.RegisteredClaims
 }
 
+// TODO(schmichael) this is just for debugging, feel free to remove
+// String version of the identity. No secrets, safe for display.
+func (ic *IdentityClaims) String() string {
+	//TODO(schmichael) use "jwt" or something vendor specific like "nwi"
+	//for Nomad Workload Identity here?
+	return fmt.Sprintf("jwt:%s/%s/%s/%s", ic.Namespace, ic.JobID, ic.AllocationID, ic.TaskName)
+}
+
 // AllocationDiff is another named type for Allocation (to use the same fields),
 // which is used to represent the delta for an Allocation. If you need a method
 // defined on the al

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10632,14 +10632,6 @@ type IdentityClaims struct {
 	jwt.RegisteredClaims
 }
 
-// TODO(schmichael) this is just for debugging, feel free to remove
-// String version of the identity. No secrets, safe for display.
-func (ic *IdentityClaims) String() string {
-	//TODO(schmichael) use "jwt" or something vendor specific like "nwi"
-	//for Nomad Workload Identity here?
-	return fmt.Sprintf("jwt:%s/%s/%s/%s", ic.Namespace, ic.JobID, ic.AllocationID, ic.TaskName)
-}
-
 // AllocationDiff is another named type for Allocation (to use the same fields),
 // which is used to represent the delta for an Allocation. If you need a method
 // defined on the al


### PR DESCRIPTION
The goal of this PR is to provide universal workload access to Nomad's HTTP API via Unix Domain Sockets (UDS).

Dynamic Node Metadata #15844 is one potential use case.

Inspired by https://github.com/hashicorp/nomad/commit/e90807ec080c72025c434eb7ba7247e6adb84304

TODO
- [ ] docs - might do in a followup since dynamic node metadata / task api / workload id all need to interlink
- [ ] Unit tests for auth middleware
- [ ] Caching for auth middleware
- [ ] Rate limiting on negative lookups for auth middleware