### PR TITLE
metrics: measure rate of RPC requests that serve API

### DIFF
--- a/.changelog/15876.txt
+++ b/.changelog/15876.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+metrics: Added metrics for rate of RPC requests
+```

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -79,6 +79,7 @@ func (a *ACL) UpsertPolicies(args *structs.ACLPolicyUpsertRequest, reply *struct
 	if done, err := a.srv.forward("ACL.UpsertPolicies", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -127,6 +128,7 @@ func (a *ACL) DeletePolicies(args *structs.ACLPolicyDeleteRequest, reply *struct
 	if done, err := a.srv.forward("ACL.DeletePolicies", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -164,6 +166,7 @@ func (a *ACL) ListPolicies(args *structs.ACLPolicyListRequest, reply *structs.AC
 	if done, err := a.srv.forward("ACL.ListPolicies", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -257,6 +260,7 @@ func (a *ACL) GetPolicy(args *structs.ACLPolicySpecificRequest, reply *structs.S
 	if done, err := a.srv.forward("ACL.GetPolicy", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -560,6 +564,7 @@ func (a *ACL) UpsertTokens(args *structs.ACLTokenUpsertRequest, reply *structs.A
 	if done, err := a.srv.forward(structs.ACLUpsertTokensRPCMethod, args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -701,6 +706,7 @@ func (a *ACL) DeleteTokens(args *structs.ACLTokenDeleteRequest, reply *structs.G
 	if done, err := a.srv.forward("ACL.DeleteTokens", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -778,6 +784,7 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 	if done, err := a.srv.forward("ACL.ListTokens", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -866,6 +873,7 @@ func (a *ACL) GetToken(args *structs.ACLTokenSpecificRequest, reply *structs.Sin
 	if done, err := a.srv.forward("ACL.GetToken", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricRead, args)
 	if authErr != nil {
 		return authErr
 	}
@@ -931,6 +939,7 @@ func (a *ACL) GetTokens(args *structs.ACLTokenSetRequest, reply *structs.ACLToke
 	if done, err := a.srv.forward("ACL.GetTokens", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricList, args)
 	if authErr != nil {
 		return authErr
 	}
@@ -1175,6 +1184,7 @@ func (a *ACL) UpsertRoles(
 	if done, err := a.srv.forward(structs.ACLUpsertRolesRPCMethod, args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1323,6 +1333,7 @@ func (a *ACL) DeleteRolesByID(
 	if done, err := a.srv.forward(structs.ACLDeleteRolesByIDRPCMethod, args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1375,6 +1386,7 @@ func (a *ACL) ListRoles(
 	if done, err := a.srv.forward(structs.ACLListRolesRPCMethod, args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1530,6 +1542,7 @@ func (a *ACL) GetRoleByID(
 	if done, err := a.srv.forward(structs.ACLGetRoleByIDRPCMethod, args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1618,6 +1631,7 @@ func (a *ACL) GetRoleByName(
 	if done, err := a.srv.forward(structs.ACLGetRoleByNameRPCMethod, args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1764,6 +1778,7 @@ func (a *ACL) UpsertAuthMethods(
 	if done, err := a.srv.forward(structs.ACLUpsertAuthMethodsRPCMethod, args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1871,6 +1886,7 @@ func (a *ACL) DeleteAuthMethods(
 		structs.ACLDeleteAuthMethodsRPCMethod, args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1971,6 +1987,7 @@ func (a *ACL) GetAuthMethod(
 		structs.ACLGetAuthMethodRPCMethod, args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -2105,6 +2122,7 @@ func (a *ACL) UpsertBindingRules(
 	if done, err := a.srv.forward(structs.ACLUpsertBindingRulesRPCMethod, args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -2236,6 +2254,7 @@ func (a *ACL) DeleteBindingRules(
 	if done, err := a.srv.forward(structs.ACLDeleteBindingRulesRPCMethod, args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -2289,6 +2308,7 @@ func (a *ACL) ListBindingRules(
 	if done, err := a.srv.forward(structs.ACLListBindingRulesRPCMethod, args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -2347,6 +2367,7 @@ func (a *ACL) GetBindingRules(
 	if done, err := a.srv.forward(structs.ACLGetBindingRulesRPCMethod, args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -2401,6 +2422,7 @@ func (a *ACL) GetBindingRule(
 	if done, err := a.srv.forward(structs.ACLGetBindingRuleRPCMethod, args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -34,6 +34,7 @@ func (a *Alloc) List(args *structs.AllocListRequest, reply *structs.AllocListRes
 	if done, err := a.srv.forward("Alloc.List", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("alloc", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -143,6 +144,7 @@ func (a *Alloc) GetAlloc(args *structs.AllocSpecificRequest,
 	if done, err := a.srv.forward("Alloc.GetAlloc", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("alloc", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -270,6 +272,7 @@ func (a *Alloc) Stop(args *structs.AllocStopRequest, reply *structs.AllocStopRes
 	if done, err := a.srv.forward("Alloc.Stop", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("alloc", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -334,6 +337,7 @@ func (a *Alloc) UpdateDesiredTransition(args *structs.AllocUpdateDesiredTransiti
 	if done, err := a.srv.forward("Alloc.UpdateDesiredTransition", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("alloc", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -374,6 +378,7 @@ func (a *Alloc) GetServiceRegistrations(
 	if done, err := a.srv.forward(structs.AllocServiceRegistrationsRPCMethod, args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("alloc", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/client_agent_endpoint.go
+++ b/nomad/client_agent_endpoint.go
@@ -36,6 +36,7 @@ func (a *Agent) register() {
 
 func (a *Agent) Profile(args *structs.AgentPprofRequest, reply *structs.AgentPprofResponse) error {
 	authErr := a.srv.Authenticate(nil, args)
+	a.srv.MeasureRPCRate("agent", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -134,6 +135,7 @@ func (a *Agent) monitor(conn io.ReadWriteCloser) {
 		return
 	}
 	authErr := a.srv.Authenticate(nil, &args)
+	a.srv.MeasureRPCRate("agent", structs.RateMetricRead, &args)
 	if authErr != nil {
 		handleStreamResultError(structs.ErrPermissionDenied, nil, encoder)
 		return
@@ -409,6 +411,7 @@ func (a *Agent) forwardProfileClient(args *structs.AgentPprofRequest, reply *str
 // Host returns data about the agent's host system for the `debug` command.
 func (a *Agent) Host(args *structs.HostDataRequest, reply *structs.HostDataResponse) error {
 	authErr := a.srv.Authenticate(nil, args)
+	a.srv.MeasureRPCRate("agent", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/client_alloc_endpoint.go
+++ b/nomad/client_alloc_endpoint.go
@@ -45,6 +45,7 @@ func (a *ClientAllocations) GarbageCollectAll(args *structs.NodeSpecificRequest,
 	if done, err := a.srv.forward("ClientAllocations.GarbageCollectAll", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("client_allocations", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -96,6 +97,7 @@ func (a *ClientAllocations) Signal(args *structs.AllocSignalRequest, reply *stru
 	if done, err := a.srv.forward("ClientAllocations.Signal", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("client_allocations", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -153,6 +155,7 @@ func (a *ClientAllocations) GarbageCollect(args *structs.AllocSpecificRequest, r
 	if done, err := a.srv.forward("ClientAllocations.GarbageCollect", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("client_allocations", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -210,6 +213,7 @@ func (a *ClientAllocations) Restart(args *structs.AllocRestartRequest, reply *st
 	if done, err := a.srv.forward("ClientAllocations.Restart", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("client_allocations", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -262,6 +266,7 @@ func (a *ClientAllocations) Stats(args *cstructs.AllocStatsRequest, reply *cstru
 	if done, err := a.srv.forward("ClientAllocations.Stats", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("client_allocations", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -318,6 +323,7 @@ func (a *ClientAllocations) Checks(args *cstructs.AllocChecksRequest, reply *cst
 	if done, err := a.srv.forward("ClientAllocations.Checks", args, args, reply); done {
 		return err
 	}
+	a.srv.MeasureRPCRate("client_allocations", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -382,6 +388,7 @@ func (a *ClientAllocations) exec(conn io.ReadWriteCloser) {
 			args.AllocID, &args.QueryOptions)
 		return
 	}
+	a.srv.MeasureRPCRate("client_allocations", structs.RateMetricWrite, &args)
 	if authErr != nil {
 		handleStreamResultError(structs.ErrPermissionDenied, nil, encoder)
 		return

--- a/nomad/client_fs_endpoint.go
+++ b/nomad/client_fs_endpoint.go
@@ -112,6 +112,7 @@ func (f *FileSystem) List(args *cstructs.FsListRequest, reply *cstructs.FsListRe
 	if done, err := f.srv.forward("FileSystem.List", args, args, reply); done {
 		return err
 	}
+	f.srv.MeasureRPCRate("file_system", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -171,6 +172,7 @@ func (f *FileSystem) Stat(args *cstructs.FsStatRequest, reply *cstructs.FsStatRe
 	if done, err := f.srv.forward("FileSystem.Stat", args, args, reply); done {
 		return err
 	}
+	f.srv.MeasureRPCRate("file_system", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -239,6 +241,7 @@ func (f *FileSystem) stream(conn io.ReadWriteCloser) {
 			args.AllocID, &args.QueryOptions)
 		return
 	}
+	f.srv.MeasureRPCRate("file_system", structs.RateMetricRead, &args)
 	if authErr != nil {
 		handleStreamResultError(structs.ErrPermissionDenied, nil, encoder)
 		return
@@ -363,6 +366,7 @@ func (f *FileSystem) logs(conn io.ReadWriteCloser) {
 			args.AllocID, &args.QueryOptions)
 		return
 	}
+	f.srv.MeasureRPCRate("file_system", structs.RateMetricRead, &args)
 	if authErr != nil {
 		handleStreamResultError(structs.ErrPermissionDenied, nil, encoder)
 		return

--- a/nomad/client_stats_endpoint.go
+++ b/nomad/client_stats_endpoint.go
@@ -34,6 +34,7 @@ func (s *ClientStats) Stats(args *nstructs.NodeSpecificRequest, reply *structs.C
 	if done, err := s.srv.forward("ClientStats.Stats", args, args, reply); done {
 		return err
 	}
+	s.srv.MeasureRPCRate("client_stats", nstructs.RateMetricRead, args)
 	if authErr != nil {
 		return nstructs.ErrPermissionDenied
 	}

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -56,6 +56,7 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 	if done, err := v.srv.forward("CSIVolume.List", args, args, reply); done {
 		return err
 	}
+	v.srv.MeasureRPCRate("csi_volume", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -173,6 +174,7 @@ func (v *CSIVolume) Get(args *structs.CSIVolumeGetRequest, reply *structs.CSIVol
 	if done, err := v.srv.forward("CSIVolume.Get", args, args, reply); done {
 		return err
 	}
+	v.srv.MeasureRPCRate("csi_volume", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -276,6 +278,7 @@ func (v *CSIVolume) Register(args *structs.CSIVolumeRegisterRequest, reply *stru
 	if done, err := v.srv.forward("CSIVolume.Register", args, args, reply); done {
 		return err
 	}
+	v.srv.MeasureRPCRate("csi_volume", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -372,6 +375,7 @@ func (v *CSIVolume) Deregister(args *structs.CSIVolumeDeregisterRequest, reply *
 	if done, err := v.srv.forward("CSIVolume.Deregister", args, args, reply); done {
 		return err
 	}
+	v.srv.MeasureRPCRate("csi_volume", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -414,6 +418,7 @@ func (v *CSIVolume) Claim(args *structs.CSIVolumeClaimRequest, reply *structs.CS
 	if done, err := v.srv.forward("CSIVolume.Claim", args, args, reply); done {
 		return err
 	}
+	v.srv.MeasureRPCRate("csi_volume", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -601,6 +606,7 @@ func (v *CSIVolume) Unpublish(args *structs.CSIVolumeUnpublishRequest, reply *st
 	if done, err := v.srv.forward("CSIVolume.Unpublish", args, args, reply); done {
 		return err
 	}
+	v.srv.MeasureRPCRate("csi_volume", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -943,6 +949,7 @@ func (v *CSIVolume) Create(args *structs.CSIVolumeCreateRequest, reply *structs.
 	if done, err := v.srv.forward("CSIVolume.Create", args, args, reply); done {
 		return err
 	}
+	v.srv.MeasureRPCRate("csi_volume", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1071,6 +1078,7 @@ func (v *CSIVolume) Delete(args *structs.CSIVolumeDeleteRequest, reply *structs.
 	if done, err := v.srv.forward("CSIVolume.Delete", args, args, reply); done {
 		return err
 	}
+	v.srv.MeasureRPCRate("csi_volume", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1154,6 +1162,7 @@ func (v *CSIVolume) ListExternal(args *structs.CSIVolumeExternalListRequest, rep
 	if done, err := v.srv.forward("CSIVolume.ListExternal", args, args, reply); done {
 		return err
 	}
+	v.srv.MeasureRPCRate("csi_volume", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1218,6 +1227,7 @@ func (v *CSIVolume) CreateSnapshot(args *structs.CSISnapshotCreateRequest, reply
 	if done, err := v.srv.forward("CSIVolume.CreateSnapshot", args, args, reply); done {
 		return err
 	}
+	v.srv.MeasureRPCRate("csi_volume", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1313,6 +1323,7 @@ func (v *CSIVolume) DeleteSnapshot(args *structs.CSISnapshotDeleteRequest, reply
 	if done, err := v.srv.forward("CSIVolume.DeleteSnapshot", args, args, reply); done {
 		return err
 	}
+	v.srv.MeasureRPCRate("csi_volume", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1377,6 +1388,7 @@ func (v *CSIVolume) ListSnapshots(args *structs.CSISnapshotListRequest, reply *s
 	if done, err := v.srv.forward("CSIVolume.ListSnapshots", args, args, reply); done {
 		return err
 	}
+	v.srv.MeasureRPCRate("csi_volume", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1454,6 +1466,7 @@ func (v *CSIPlugin) List(args *structs.CSIPluginListRequest, reply *structs.CSIP
 	if done, err := v.srv.forward("CSIPlugin.List", args, args, reply); done {
 		return err
 	}
+	v.srv.MeasureRPCRate("csi_plugin", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1512,6 +1525,7 @@ func (v *CSIPlugin) Get(args *structs.CSIPluginGetRequest, reply *structs.CSIPlu
 	if done, err := v.srv.forward("CSIPlugin.Get", args, args, reply); done {
 		return err
 	}
+	v.srv.MeasureRPCRate("csi_plugin", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1580,6 +1594,7 @@ func (v *CSIPlugin) Delete(args *structs.CSIPluginDeleteRequest, reply *structs.
 	if done, err := v.srv.forward("CSIPlugin.Delete", args, args, reply); done {
 		return err
 	}
+	v.srv.MeasureRPCRate("csi_plugin", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -34,6 +34,7 @@ func (d *Deployment) GetDeployment(args *structs.DeploymentSpecificRequest,
 	if done, err := d.srv.forward("Deployment.GetDeployment", args, args, reply); done {
 		return err
 	}
+	d.srv.MeasureRPCRate("deployment", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -98,6 +99,7 @@ func (d *Deployment) Fail(args *structs.DeploymentFailRequest, reply *structs.De
 	if done, err := d.srv.forward("Deployment.Fail", args, args, reply); done {
 		return err
 	}
+	d.srv.MeasureRPCRate("deployment", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -144,6 +146,7 @@ func (d *Deployment) Pause(args *structs.DeploymentPauseRequest, reply *structs.
 	if done, err := d.srv.forward("Deployment.Pause", args, args, reply); done {
 		return err
 	}
+	d.srv.MeasureRPCRate("deployment", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -194,6 +197,7 @@ func (d *Deployment) Promote(args *structs.DeploymentPromoteRequest, reply *stru
 	if done, err := d.srv.forward("Deployment.Promote", args, args, reply); done {
 		return err
 	}
+	d.srv.MeasureRPCRate("deployment", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -240,6 +244,7 @@ func (d *Deployment) Run(args *structs.DeploymentRunRequest, reply *structs.Depl
 	if done, err := d.srv.forward("Deployment.Run", args, args, reply); done {
 		return err
 	}
+	d.srv.MeasureRPCRate("deployment", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -286,6 +291,7 @@ func (d *Deployment) Unblock(args *structs.DeploymentUnblockRequest, reply *stru
 	if done, err := d.srv.forward("Deployment.Unblock", args, args, reply); done {
 		return err
 	}
+	d.srv.MeasureRPCRate("deployment", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -332,6 +338,7 @@ func (d *Deployment) Cancel(args *structs.DeploymentCancelRequest, reply *struct
 	if done, err := d.srv.forward("Deployment.Cancel", args, args, reply); done {
 		return err
 	}
+	d.srv.MeasureRPCRate("deployment", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -379,6 +386,7 @@ func (d *Deployment) SetAllocHealth(args *structs.DeploymentAllocHealthRequest, 
 	if done, err := d.srv.forward("Deployment.SetAllocHealth", args, args, reply); done {
 		return err
 	}
+	d.srv.MeasureRPCRate("deployment", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -429,6 +437,7 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 	if done, err := d.srv.forward("Deployment.List", args, args, reply); done {
 		return err
 	}
+	d.srv.MeasureRPCRate("deployment", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -520,6 +529,7 @@ func (d *Deployment) Allocations(args *structs.DeploymentSpecificRequest, reply 
 	if done, err := d.srv.forward("Deployment.Allocations", args, args, reply); done {
 		return err
 	}
+	d.srv.MeasureRPCRate("deployment", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -46,6 +46,7 @@ func (e *Eval) GetEval(args *structs.EvalSpecificRequest,
 	if done, err := e.srv.forward("Eval.GetEval", args, args, reply); done {
 		return err
 	}
+	e.srv.MeasureRPCRate("eval", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -127,6 +128,7 @@ func (e *Eval) Dequeue(args *structs.EvalDequeueRequest,
 	if done, err := e.srv.forward("Eval.Dequeue", args, args, reply); done {
 		return err
 	}
+	e.srv.MeasureRPCRate("eval", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -453,6 +455,7 @@ func (e *Eval) Delete(
 	if done, err := e.srv.forward(structs.EvalDeleteRPCMethod, args, args, reply); done {
 		return err
 	}
+	e.srv.MeasureRPCRate("eval", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -644,6 +647,7 @@ func (e *Eval) List(args *structs.EvalListRequest, reply *structs.EvalListRespon
 	if done, err := e.srv.forward("Eval.List", args, args, reply); done {
 		return err
 	}
+	e.srv.MeasureRPCRate("eval", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -768,6 +772,7 @@ func (e *Eval) Count(args *structs.EvalCountRequest, reply *structs.EvalCountRes
 	if done, err := e.srv.forward("Eval.Count", args, args, reply); done {
 		return err
 	}
+	e.srv.MeasureRPCRate("eval", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -872,6 +877,7 @@ func (e *Eval) Allocations(args *structs.EvalSpecificRequest,
 	if done, err := e.srv.forward("Eval.Allocations", args, args, reply); done {
 		return err
 	}
+	e.srv.MeasureRPCRate("eval", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/event_endpoint.go
+++ b/nomad/event_endpoint.go
@@ -48,6 +48,7 @@ func (e *Event) stream(conn io.ReadWriteCloser) {
 		return
 	}
 
+	e.srv.MeasureRPCRate("event", structs.RateMetricRead, &args)
 	if authErr != nil {
 		handleJsonResultError(structs.ErrPermissionDenied, pointer.Of(int64(403)), encoder)
 	}

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -88,6 +88,7 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 	if done, err := j.srv.forward("Job.Register", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -491,6 +492,7 @@ func (j *Job) Summary(args *structs.JobSummaryRequest, reply *structs.JobSummary
 	if done, err := j.srv.forward("Job.Summary", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -543,6 +545,7 @@ func (j *Job) Validate(args *structs.JobValidateRequest, reply *structs.JobValid
 	if done, err := j.srv.forward("Job.Validate", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -594,6 +597,7 @@ func (j *Job) Revert(args *structs.JobRevertRequest, reply *structs.JobRegisterR
 	if done, err := j.srv.forward("Job.Revert", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -666,6 +670,7 @@ func (j *Job) Stable(args *structs.JobStabilityRequest, reply *structs.JobStabil
 	if done, err := j.srv.forward("Job.Stable", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -716,6 +721,7 @@ func (j *Job) Evaluate(args *structs.JobEvaluateRequest, reply *structs.JobRegis
 	if done, err := j.srv.forward("Job.Evaluate", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -816,6 +822,7 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 	if done, err := j.srv.forward("Job.Deregister", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -933,6 +940,7 @@ func (j *Job) BatchDeregister(args *structs.JobBatchDeregisterRequest, reply *st
 	if done, err := j.srv.forward("Job.BatchDeregister", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1022,6 +1030,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	if done, err := j.srv.forward("Job.Scale", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1208,6 +1217,7 @@ func (j *Job) GetJob(args *structs.JobSpecificRequest,
 	if done, err := j.srv.forward("Job.GetJob", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1258,6 +1268,7 @@ func (j *Job) GetJobVersions(args *structs.JobVersionsRequest,
 	if done, err := j.srv.forward("Job.GetJobVersions", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1364,6 +1375,7 @@ func (j *Job) List(args *structs.JobListRequest, reply *structs.JobListResponse)
 	if done, err := j.srv.forward("Job.List", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1474,6 +1486,7 @@ func (j *Job) Allocations(args *structs.JobSpecificRequest,
 	if done, err := j.srv.forward("Job.Allocations", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1533,6 +1546,7 @@ func (j *Job) Evaluations(args *structs.JobSpecificRequest,
 	if done, err := j.srv.forward("Job.Evaluations", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1579,6 +1593,7 @@ func (j *Job) Deployments(args *structs.JobSpecificRequest,
 	if done, err := j.srv.forward("Job.Deployments", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1625,6 +1640,7 @@ func (j *Job) LatestDeployment(args *structs.JobSpecificRequest,
 	if done, err := j.srv.forward("Job.LatestDeployment", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1676,6 +1692,7 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 	if done, err := j.srv.forward("Job.Plan", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1895,6 +1912,7 @@ func (j *Job) Dispatch(args *structs.JobDispatchRequest, reply *structs.JobDispa
 	if done, err := j.srv.forward("Job.Dispatch", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -2134,6 +2152,7 @@ func (j *Job) ScaleStatus(args *structs.JobScaleStatusRequest,
 	if done, err := j.srv.forward("Job.ScaleStatus", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -2253,6 +2272,7 @@ func (j *Job) GetServiceRegistrations(
 	if done, err := j.srv.forward(structs.JobServiceRegistrationsRPCMethod, args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/keyring_endpoint.go
+++ b/nomad/keyring_endpoint.go
@@ -32,6 +32,7 @@ func (k *Keyring) Rotate(args *structs.KeyringRotateRootKeyRequest, reply *struc
 	if done, err := k.srv.forward("Keyring.Rotate", args, args, reply); done {
 		return err
 	}
+	k.srv.MeasureRPCRate("keyring", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -104,6 +105,7 @@ func (k *Keyring) List(args *structs.KeyringListRootKeyMetaRequest, reply *struc
 	if done, err := k.srv.forward("Keyring.List", args, args, reply); done {
 		return err
 	}
+	k.srv.MeasureRPCRate("keyring", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -162,6 +164,7 @@ func (k *Keyring) Update(args *structs.KeyringUpdateRootKeyRequest, reply *struc
 	if done, err := k.srv.forward("Keyring.Update", args, args, reply); done {
 		return err
 	}
+	k.srv.MeasureRPCRate("keyring", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -309,6 +312,7 @@ func (k *Keyring) Delete(args *structs.KeyringDeleteRootKeyRequest, reply *struc
 	if done, err := k.srv.forward("Keyring.Delete", args, args, reply); done {
 		return err
 	}
+	k.srv.MeasureRPCRate("keyring", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/namespace_endpoint.go
+++ b/nomad/namespace_endpoint.go
@@ -31,6 +31,7 @@ func (n *Namespace) UpsertNamespaces(args *structs.NamespaceUpsertRequest,
 	if done, err := n.srv.forward("Namespace.UpsertNamespaces", args, args, reply); done {
 		return err
 	}
+	n.srv.MeasureRPCRate("namespace", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -82,6 +83,7 @@ func (n *Namespace) DeleteNamespaces(args *structs.NamespaceDeleteRequest, reply
 	if done, err := n.srv.forward("Namespace.DeleteNamespaces", args, args, reply); done {
 		return err
 	}
+	n.srv.MeasureRPCRate("namespace", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -235,6 +237,7 @@ func (n *Namespace) ListNamespaces(args *structs.NamespaceListRequest, reply *st
 	if done, err := n.srv.forward("Namespace.ListNamespaces", args, args, reply); done {
 		return err
 	}
+	n.srv.MeasureRPCRate("namespace", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -301,6 +304,7 @@ func (n *Namespace) GetNamespace(args *structs.NamespaceSpecificRequest, reply *
 	if done, err := n.srv.forward("Namespace.GetNamespace", args, args, reply); done {
 		return err
 	}
+	n.srv.MeasureRPCRate("namespace", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -354,6 +358,7 @@ func (n *Namespace) GetNamespaces(args *structs.NamespaceSetRequest, reply *stru
 	if done, err := n.srv.forward("Namespace.GetNamespaces", args, args, reply); done {
 		return err
 	}
+	n.srv.MeasureRPCRate("namespace", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -106,6 +106,7 @@ func (n *Node) Register(args *structs.NodeRegisterRequest, reply *structs.NodeUp
 
 		return err
 	}
+	n.srv.MeasureRPCRate("node", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -323,6 +324,7 @@ func (n *Node) Deregister(args *structs.NodeDeregisterRequest, reply *structs.No
 	if done, err := n.srv.forward("Node.Deregister", args, args, reply); done {
 		return err
 	}
+	n.srv.MeasureRPCRate("node", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -349,6 +351,7 @@ func (n *Node) BatchDeregister(args *structs.NodeBatchDeregisterRequest, reply *
 	if done, err := n.srv.forward("Node.BatchDeregister", args, args, reply); done {
 		return err
 	}
+	n.srv.MeasureRPCRate("node", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -465,6 +468,7 @@ func (n *Node) UpdateStatus(args *structs.NodeUpdateStatusRequest, reply *struct
 
 		return err
 	}
+	n.srv.MeasureRPCRate("node", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -627,6 +631,7 @@ func (n *Node) UpdateDrain(args *structs.NodeUpdateDrainRequest,
 	if done, err := n.srv.forward("Node.UpdateDrain", args, args, reply); done {
 		return err
 	}
+	n.srv.MeasureRPCRate("node", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -726,6 +731,7 @@ func (n *Node) UpdateEligibility(args *structs.NodeUpdateEligibilityRequest,
 	if done, err := n.srv.forward("Node.UpdateEligibility", args, args, reply); done {
 		return err
 	}
+	n.srv.MeasureRPCRate("node", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -828,6 +834,7 @@ func (n *Node) Evaluate(args *structs.NodeEvaluateRequest, reply *structs.NodeUp
 	if done, err := n.srv.forward("Node.Evaluate", args, args, reply); done {
 		return err
 	}
+	n.srv.MeasureRPCRate("node", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -888,6 +895,7 @@ func (n *Node) GetNode(args *structs.NodeSpecificRequest,
 	if done, err := n.srv.forward("Node.GetNode", args, args, reply); done {
 		return err
 	}
+	n.srv.MeasureRPCRate("node", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -948,6 +956,7 @@ func (n *Node) GetAllocs(args *structs.NodeSpecificRequest,
 	if done, err := n.srv.forward("Node.GetAllocs", args, args, reply); done {
 		return err
 	}
+	n.srv.MeasureRPCRate("node", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1191,6 +1200,7 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 	if done, err := n.srv.forward("Node.UpdateAlloc", args, args, reply); done {
 		return err
 	}
+	n.srv.MeasureRPCRate("node", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -1453,6 +1463,7 @@ func (n *Node) List(args *structs.NodeListRequest,
 	if done, err := n.srv.forward("Node.List", args, args, reply); done {
 		return err
 	}
+	n.srv.MeasureRPCRate("node", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/operator_endpoint.go
+++ b/nomad/operator_endpoint.go
@@ -40,6 +40,7 @@ func (op *Operator) RaftGetConfiguration(args *structs.GenericRequest, reply *st
 	if done, err := op.srv.forward("Operator.RaftGetConfiguration", args, args, reply); done {
 		return err
 	}
+	op.srv.MeasureRPCRate("operator", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -106,6 +107,7 @@ func (op *Operator) RaftRemovePeerByAddress(args *structs.RaftPeerByAddressReque
 	if done, err := op.srv.forward("Operator.RaftRemovePeerByAddress", args, args, reply); done {
 		return err
 	}
+	op.srv.MeasureRPCRate("operator", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -163,6 +165,7 @@ func (op *Operator) RaftRemovePeerByID(args *structs.RaftPeerByIDRequest, reply 
 	if done, err := op.srv.forward("Operator.RaftRemovePeerByID", args, args, reply); done {
 		return err
 	}
+	op.srv.MeasureRPCRate("operator", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -229,6 +232,7 @@ func (op *Operator) AutopilotGetConfiguration(args *structs.GenericRequest, repl
 	if done, err := op.srv.forward("Operator.AutopilotGetConfiguration", args, args, reply); done {
 		return err
 	}
+	op.srv.MeasureRPCRate("operator", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -263,6 +267,7 @@ func (op *Operator) AutopilotSetConfiguration(args *structs.AutopilotSetConfigRe
 	if done, err := op.srv.forward("Operator.AutopilotSetConfiguration", args, args, reply); done {
 		return err
 	}
+	op.srv.MeasureRPCRate("operator", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -308,6 +313,7 @@ func (op *Operator) ServerHealth(args *structs.GenericRequest, reply *structs.Op
 	if done, err := op.srv.forward("Operator.ServerHealth", args, args, reply); done {
 		return err
 	}
+	op.srv.MeasureRPCRate("operator", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -342,6 +348,7 @@ func (op *Operator) SchedulerSetConfiguration(args *structs.SchedulerSetConfigRe
 	if done, err := op.srv.forward("Operator.SchedulerSetConfiguration", args, args, reply); done {
 		return err
 	}
+	op.srv.MeasureRPCRate("operator", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -396,6 +403,7 @@ func (op *Operator) SchedulerGetConfiguration(args *structs.GenericRequest, repl
 	if done, err := op.srv.forward("Operator.SchedulerGetConfiguration", args, args, reply); done {
 		return err
 	}
+	op.srv.MeasureRPCRate("operator", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -497,6 +505,7 @@ func (op *Operator) snapshotSave(conn io.ReadWriteCloser) {
 		}
 	}
 
+	op.srv.MeasureRPCRate("operator", structs.RateMetricWrite, &args)
 	if authErr != nil {
 		handleFailure(403, structs.ErrPermissionDenied)
 	}
@@ -583,6 +592,7 @@ func (op *Operator) snapshotRestore(conn io.ReadWriteCloser) {
 
 	}
 
+	op.srv.MeasureRPCRate("operator", structs.RateMetricWrite, &args)
 	if authErr != nil {
 		handleFailure(403, structs.ErrPermissionDenied)
 	}

--- a/nomad/periodic_endpoint.go
+++ b/nomad/periodic_endpoint.go
@@ -30,6 +30,7 @@ func (p *Periodic) Force(args *structs.PeriodicForceRequest, reply *structs.Peri
 	if done, err := p.srv.forward("Periodic.Force", args, args, reply); done {
 		return err
 	}
+	p.srv.MeasureRPCRate("periodic", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/scaling_endpoint.go
+++ b/nomad/scaling_endpoint.go
@@ -32,6 +32,7 @@ func (p *Scaling) ListPolicies(args *structs.ScalingPolicyListRequest, reply *st
 	if done, err := p.srv.forward("Scaling.ListPolicies", args, args, reply); done {
 		return err
 	}
+	p.srv.MeasureRPCRate("scaling", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -103,6 +104,7 @@ func (p *Scaling) GetPolicy(args *structs.ScalingPolicySpecificRequest,
 	if done, err := p.srv.forward("Scaling.GetPolicy", args, args, reply); done {
 		return err
 	}
+	p.srv.MeasureRPCRate("scaling", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/search_endpoint.go
+++ b/nomad/search_endpoint.go
@@ -553,6 +553,7 @@ func (s *Search) PrefixSearch(args *structs.SearchRequest, reply *structs.Search
 	if done, err := s.srv.forward("Search.PrefixSearch", args, args, reply); done {
 		return err
 	}
+	s.srv.MeasureRPCRate("search", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -686,6 +687,7 @@ func (s *Search) FuzzySearch(args *structs.FuzzySearchRequest, reply *structs.Fu
 	if done, err := s.srv.forward("Search.FuzzySearch", args, args, reply); done {
 		return err
 	}
+	s.srv.MeasureRPCRate("search", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/service_registration_endpoint.go
+++ b/nomad/service_registration_endpoint.go
@@ -108,6 +108,7 @@ func (s *ServiceRegistration) DeleteByID(
 	if done, err := s.srv.forward(structs.ServiceRegistrationDeleteByIDRPCMethod, args, args, reply); done {
 		return err
 	}
+	s.srv.MeasureRPCRate("service_registration", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -205,6 +206,7 @@ func (s *ServiceRegistration) List(
 	if done, err := s.srv.forward(structs.ServiceRegistrationListRPCMethod, args, args, reply); done {
 		return err
 	}
+	s.srv.MeasureRPCRate("service_registration", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -374,6 +376,7 @@ func (s *ServiceRegistration) GetService(
 	if done, err := s.srv.forward(structs.ServiceRegistrationGetServiceRPCMethod, args, args, reply); done {
 		return err
 	}
+	s.srv.MeasureRPCRate("service_registration", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/status_endpoint.go
+++ b/nomad/status_endpoint.go
@@ -71,6 +71,7 @@ func (s *Status) Peers(args *structs.GenericRequest, reply *[]string) error {
 // aware of
 func (s *Status) Members(args *structs.GenericRequest, reply *structs.ServerMembersResponse) error {
 	authErr := s.srv.Authenticate(s.ctx, args)
+	s.srv.MeasureRPCRate("status", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/system_endpoint.go
+++ b/nomad/system_endpoint.go
@@ -27,6 +27,7 @@ func (s *System) GarbageCollect(args *structs.GenericRequest, reply *structs.Gen
 	if done, err := s.srv.forward("System.GarbageCollect", args, args, reply); done {
 		return err
 	}
+	s.srv.MeasureRPCRate("system", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -56,6 +57,7 @@ func (s *System) ReconcileJobSummaries(args *structs.GenericRequest, reply *stru
 	if done, err := s.srv.forward("System.ReconcileJobSummaries", args, args, reply); done {
 		return err
 	}
+	s.srv.MeasureRPCRate("system", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -39,6 +39,7 @@ func (sv *Variables) Apply(args *structs.VariablesApplyRequest, reply *structs.V
 	if done, err := sv.srv.forward(structs.VariablesApplyRPCMethod, args, args, reply); done {
 		return err
 	}
+	sv.srv.MeasureRPCRate("variables", structs.RateMetricWrite, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -229,6 +230,7 @@ func (sv *Variables) Read(args *structs.VariablesReadRequest, reply *structs.Var
 	if done, err := sv.srv.forward(structs.VariablesReadRPCMethod, args, args, reply); done {
 		return err
 	}
+	sv.srv.MeasureRPCRate("variables", structs.RateMetricRead, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
@@ -279,6 +281,7 @@ func (sv *Variables) List(
 	if done, err := sv.srv.forward(structs.VariablesListRPCMethod, args, args, reply); done {
 		return err
 	}
+	sv.srv.MeasureRPCRate("variables", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}


### PR DESCRIPTION
This changeset configures the RPC rate metrics that were added in #15515 to all the RPCs that support authenticated HTTP API requests. These endpoints already configured with pre-forwarding authentication in #15870, and a handful of others were done already as part of the proof-of-concept work. So this changeset is entirely copy-and-pasting one method call into a whole mess of handlers.

Upcoming PRs will wire up pre-forwarding auth and rate metrics for the remaining set of RPCs that have no API consumers or aren't authenticated, in smaller chunks that can be more thoughtfully reviewed. (And add the metrics reference docs update.)