### PR TITLE
test: add missing import to release/1.2.x

### DIFF
--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/pointer"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/15749 used `must` but this package was not imported in the `release/1.2.x` branch.