### PR TITLE
acl: JWT as SSO auth method

### DIFF
--- a/.changelog/15897.txt
+++ b/.changelog/15897.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl: New auth-method type: JWT
+```

--- a/.semgrep/rpc_endpoint.yml
+++ b/.semgrep/rpc_endpoint.yml
@@ -99,6 +99,7 @@ rules:
             - pattern-not: 'structs.ACLListAuthMethodsRPCMethod'
             - pattern-not: 'structs.ACLOIDCAuthURLRPCMethod'
             - pattern-not: 'structs.ACLOIDCCompleteAuthRPCMethod'
+            - pattern-not: 'structs.ACLLoginRPCMethod'
             - pattern-not: '"CSIPlugin.Get"'
             - pattern-not: '"CSIPlugin.List"'
             - pattern-not: '"Status.Leader"'

--- a/api/acl.go
+++ b/api/acl.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -443,18 +444,33 @@ func (a *ACLBindingRules) Get(bindingRuleID string, q *QueryOptions) (*ACLBindin
 }
 
 // ACLOIDC is used to query the ACL OIDC endpoints.
+//
+// Deprecated: ACLOIDC is deprecated, use ACLAuth instead.
 type ACLOIDC struct {
 	client *Client
+	ACLAuth
 }
 
 // ACLOIDC returns a new handle on the ACL auth-methods API client.
+//
+// Deprecated: c.ACLOIDC() is deprecated, use c.ACLAuth() instead.
 func (c *Client) ACLOIDC() *ACLOIDC {
 	return &ACLOIDC{client: c}
 }
 
+// ACLAuth is used to query the ACL auth endpoints.
+type ACLAuth struct {
+	client *Client
+}
+
+// ACLAuth returns a new handle on the ACL auth-methods API client.
+func (c *Client) ACLAuth() *ACLAuth {
+	return &ACLAuth{client: c}
+}
+
 // GetAuthURL generates the OIDC provider authentication URL. This URL should
 // be visited in order to sign in to the provider.
-func (a *ACLOIDC) GetAuthURL(req *ACLOIDCAuthURLRequest, q *WriteOptions) (*ACLOIDCAuthURLResponse, *WriteMeta, error) {
+func (a *ACLAuth) GetAuthURL(req *ACLOIDCAuthURLRequest, q *WriteOptions) (*ACLOIDCAuthURLResponse, *WriteMeta, error) {
 	var resp ACLOIDCAuthURLResponse
 	wm, err := a.client.put("/v1/acl/oidc/auth-url", req, &resp, q)
 	if err != nil {
@@ -465,9 +481,20 @@ func (a *ACLOIDC) GetAuthURL(req *ACLOIDCAuthURLRequest, q *WriteOptions) (*ACLO
 
 // CompleteAuth exchanges the OIDC provider token for a Nomad token with the
 // appropriate claims attached.
-func (a *ACLOIDC) CompleteAuth(req *ACLOIDCCompleteAuthRequest, q *WriteOptions) (*ACLToken, *WriteMeta, error) {
+func (a *ACLAuth) CompleteAuth(req *ACLOIDCCompleteAuthRequest, q *WriteOptions) (*ACLToken, *WriteMeta, error) {
 	var resp ACLToken
 	wm, err := a.client.put("/v1/acl/oidc/complete-auth", req, &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &resp, wm, nil
+}
+
+// Login exchanges the third party token for a Nomad token with the appropriate
+// claims attached.
+func (a *ACLAuth) Login(req *ACLLoginRequest, q *WriteOptions) (*ACLToken, *WriteMeta, error) {
+	var resp ACLToken
+	wm, err := a.client.put("/v1/acl/login", req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -740,20 +767,6 @@ type ACLAuthMethod struct {
 	ModifyIndex uint64
 }
 
-// ACLAuthMethodConfig is used to store configuration of an auth method.
-type ACLAuthMethodConfig struct {
-	OIDCDiscoveryURL    string
-	OIDCClientID        string
-	OIDCClientSecret    string
-	OIDCScopes          []string
-	BoundAudiences      []string
-	AllowedRedirectURIs []string
-	DiscoveryCaPem      []string
-	SigningAlgs         []string
-	ClaimMappings       map[string]string
-	ListClaimMappings   map[string]string
-}
-
 // MarshalJSON implements the json.Marshaler interface and allows
 // ACLAuthMethod.MaxTokenTTL to be marshaled correctly.
 func (m *ACLAuthMethod) MarshalJSON() ([]byte, error) {
@@ -793,6 +806,138 @@ func (m *ACLAuthMethod) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// ACLAuthMethodConfig is used to store configuration of an auth method.
+type ACLAuthMethodConfig struct {
+	// A list of PEM-encoded public keys to use to authenticate signatures
+	// locally
+	JWTValidationPubKeys []string
+	// JSON Web Key Sets url for authenticating signatures
+	JWKSURL string
+	// The OIDC Discovery URL, without any .well-known component (base path)
+	OIDCDiscoveryURL string
+	// The OAuth Client ID configured with the OIDC provider
+	OIDCClientID string
+	// The OAuth Client Secret configured with the OIDC provider
+	OIDCClientSecret string
+	// List of OIDC scopes
+	OIDCScopes []string
+	// List of auth claims that are valid for login
+	BoundAudiences []string
+	// The value against which to match the iss claim in a JWT
+	BoundIssuer []string
+	// A list of allowed values for redirect_uri
+	AllowedRedirectURIs []string
+	// PEM encoded CA certs for use by the TLS client used to talk with the
+	// OIDC Discovery URL.
+	DiscoveryCaPem []string
+	// PEM encoded CA cert for use by the TLS client used to talk with the JWKS
+	// URL
+	JWKSCACert string
+	// A list of supported signing algorithms
+	SigningAlgs []string
+	// Duration in seconds of leeway when validating expiration of a token to
+	// account for clock skew
+	ExpirationLeeway time.Duration
+	// Duration in seconds of leeway when validating not before values of a
+	// token to account for clock skew.
+	NotBeforeLeeway time.Duration
+	// Duration in seconds of leeway when validating all claims to account for
+	// clock skew.
+	ClockSkewLeeway time.Duration
+	// Mappings of claims (key) that will be copied to a metadata field
+	// (value).
+	ClaimMappings     map[string]string
+	ListClaimMappings map[string]string
+}
+
+// MarshalJSON implements the json.Marshaler interface and allows
+// time.Duration fields to be marshaled correctly.
+func (c *ACLAuthMethodConfig) MarshalJSON() ([]byte, error) {
+	type Alias ACLAuthMethodConfig
+	exported := &struct {
+		ExpirationLeeway string
+		NotBeforeLeeway  string
+		ClockSkewLeeway  string
+		*Alias
+	}{
+		ExpirationLeeway: c.ExpirationLeeway.String(),
+		NotBeforeLeeway:  c.NotBeforeLeeway.String(),
+		ClockSkewLeeway:  c.ClockSkewLeeway.String(),
+		Alias:            (*Alias)(c),
+	}
+	if c.ExpirationLeeway == 0 {
+		exported.ExpirationLeeway = ""
+	}
+	if c.NotBeforeLeeway == 0 {
+		exported.NotBeforeLeeway = ""
+	}
+	if c.ClockSkewLeeway == 0 {
+		exported.ClockSkewLeeway = ""
+	}
+	return json.Marshal(exported)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface and allows
+// time.Duration fields to be unmarshalled correctly.
+func (c *ACLAuthMethodConfig) UnmarshalJSON(data []byte) error {
+	type Alias ACLAuthMethodConfig
+	aux := &struct {
+		ExpirationLeeway any
+		NotBeforeLeeway  any
+		ClockSkewLeeway  any
+		*Alias
+	}{
+		Alias: (*Alias)(c),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	var err error
+	if aux.ExpirationLeeway != nil {
+		switch v := aux.ExpirationLeeway.(type) {
+		case string:
+			if v != "" {
+				if c.ExpirationLeeway, err = time.ParseDuration(v); err != nil {
+					return err
+				}
+			}
+		case float64:
+			c.ExpirationLeeway = time.Duration(v)
+		default:
+			return fmt.Errorf("unexpected ExpirationLeeway type: %v", v)
+		}
+	}
+	if aux.NotBeforeLeeway != nil {
+		switch v := aux.NotBeforeLeeway.(type) {
+		case string:
+			if v != "" {
+				if c.NotBeforeLeeway, err = time.ParseDuration(v); err != nil {
+					return err
+				}
+			}
+		case float64:
+			c.NotBeforeLeeway = time.Duration(v)
+		default:
+			return fmt.Errorf("unexpected NotBeforeLeeway type: %v", v)
+		}
+	}
+	if aux.ClockSkewLeeway != nil {
+		switch v := aux.ClockSkewLeeway.(type) {
+		case string:
+			if v != "" {
+				if c.ClockSkewLeeway, err = time.ParseDuration(v); err != nil {
+					return err
+				}
+			}
+		case float64:
+			c.ClockSkewLeeway = time.Duration(v)
+		default:
+			return fmt.Errorf("unexpected ClockSkewLeeway type: %v", v)
+		}
+	}
+	return nil
+}
+
 // ACLAuthMethodListStub is the stub object returned when performing a listing
 // of ACL auth-methods. It is intentionally minimal due to the unauthenticated
 // nature of the list endpoint.
@@ -818,6 +963,10 @@ const (
 	// ACLAuthMethodTypeOIDC the ACLAuthMethod.Type and represents an
 	// auth-method which uses the OIDC protocol.
 	ACLAuthMethodTypeOIDC = "OIDC"
+
+	// ACLAuthMethodTypeJWT the ACLAuthMethod.Type and represents an auth-method
+	// which uses the JWT type.
+	ACLAuthMethodTypeJWT = "JWT"
 )
 
 // ACLBindingRule contains a direct relation to an ACLAuthMethod and represents
@@ -946,4 +1095,14 @@ type ACLOIDCCompleteAuthRequest struct {
 	// RedirectURI is the URL that authorization should redirect to. This is a
 	// required parameter.
 	RedirectURI string
+}
+
+// ACLLoginRequest is the request object to begin auth with an external bearer
+// token provider.
+type ACLLoginRequest struct {
+	// AuthMethodName is the name of the auth method being used to login. This
+	// is a required parameter.
+	AuthMethodName string
+	// LoginToken is the token used to login. This is a required parameter.
+	LoginToken string
 }

--- a/command/acl_auth_method.go
+++ b/command/acl_auth_method.go
@@ -84,14 +84,21 @@ func formatAuthMethod(authMethod *api.ACLAuthMethod) string {
 
 func formatAuthMethodConfig(config *api.ACLAuthMethodConfig) string {
 	out := []string{
+		fmt.Sprintf("JWT Validation Public Keys|%s", strings.Join(config.JWTValidationPubKeys, ",")),
+		fmt.Sprintf("JWKS URL|%s", config.JWKSURL),
 		fmt.Sprintf("OIDC Discovery URL|%s", config.OIDCDiscoveryURL),
 		fmt.Sprintf("OIDC Client ID|%s", config.OIDCClientID),
 		fmt.Sprintf("OIDC Client Secret|%s", config.OIDCClientSecret),
 		fmt.Sprintf("OIDC Scopes|%s", strings.Join(config.OIDCScopes, ",")),
 		fmt.Sprintf("Bound audiences|%s", strings.Join(config.BoundAudiences, ",")),
+		fmt.Sprintf("Bound issuer|%s", strings.Join(config.BoundIssuer, ",")),
 		fmt.Sprintf("Allowed redirects URIs|%s", strings.Join(config.AllowedRedirectURIs, ",")),
 		fmt.Sprintf("Discovery CA pem|%s", strings.Join(config.DiscoveryCaPem, ",")),
+		fmt.Sprintf("JWKS CA cert|%s", config.JWKSCACert),
 		fmt.Sprintf("Signing algorithms|%s", strings.Join(config.SigningAlgs, ",")),
+		fmt.Sprintf("Expiration Leeway|%s", config.ExpirationLeeway.String()),
+		fmt.Sprintf("NotBefore Leeway|%s", config.NotBeforeLeeway.String()),
+		fmt.Sprintf("ClockSkew Leeway|%s", config.ClockSkewLeeway.String()),
 		fmt.Sprintf("Claim mappings|%s", strings.Join(formatMap(config.ClaimMappings), "; ")),
 		fmt.Sprintf("List claim mappings|%s", strings.Join(formatMap(config.ListClaimMappings), "; ")),
 	}

--- a/command/acl_auth_method_create.go
+++ b/command/acl_auth_method_create.go
@@ -50,8 +50,7 @@ ACL Auth Method Create Options:
     between 1-128 characters and is a required parameter.
 
   -type
-    Sets the type of the auth method. Currently the only supported type is
-    'OIDC'.
+    Sets the type of the auth method. Supported types are 'OIDC' and 'JWT'.
 
   -max-token-ttl
     Sets the duration of time all tokens created by this auth method should be
@@ -83,7 +82,7 @@ func (a *ACLAuthMethodCreateCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(a.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
 			"-name":           complete.PredictAnything,
-			"-type":           complete.PredictSet("OIDC"),
+			"-type":           complete.PredictSet("OIDC", "JWT"),
 			"-max-token-ttl":  complete.PredictAnything,
 			"-token-locality": complete.PredictSet("local", "global"),
 			"-default":        complete.PredictSet("true", "false"),
@@ -140,8 +139,8 @@ func (a *ACLAuthMethodCreateCommand) Run(args []string) int {
 		a.Ui.Error("Max token TTL must be set to a value between min and max TTL configured for the server.")
 		return 1
 	}
-	if strings.ToUpper(a.methodType) != "OIDC" {
-		a.Ui.Error("ACL auth method type must be set to 'OIDC'")
+	if !slices.Contains([]string{"OIDC", "JWT"}, strings.ToUpper(a.methodType)) {
+		a.Ui.Error("ACL auth method type must be set to 'OIDC' or 'JWT'")
 		return 1
 	}
 	if len(a.config) == 0 {

--- a/command/acl_auth_method_create_test.go
+++ b/command/acl_auth_method_create_test.go
@@ -64,7 +64,7 @@ func TestACLAuthMethodCreateCommand_Run(t *testing.T) {
 	args := []string{
 		"-address=" + url, "-token=" + rootACLToken.SecretID, "-name=acl-auth-method-cli-test",
 		"-type=OIDC", "-token-locality=global", "-default=true", "-max-token-ttl=3600s",
-		"-config={\"OIDCDiscoveryURL\":\"http://example.com\"}",
+		"-config={\"OIDCDiscoveryURL\":\"http://example.com\", \"ExpirationLeeway\": \"1h\"}",
 	}
 	must.Eq(t, 0, cmd.Run(args))
 	s := ui.OutputWriter.String()

--- a/command/acl_auth_method_update.go
+++ b/command/acl_auth_method_update.go
@@ -46,8 +46,7 @@ General Options:
 ACL Auth Method Update Options:
 
   -type
-    Updates the type of the auth method. Currently the only supported type is
-    'OIDC'.
+    Updates the type of the auth method. Supported types are 'OIDC' and 'JWT'.
 
   -max-token-ttl
     Updates the duration of time all tokens created by this auth method should be
@@ -79,7 +78,7 @@ ACL Auth Method Update Options:
 func (a *ACLAuthMethodUpdateCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(a.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
-			"-type":           complete.PredictSet("OIDC"),
+			"-type":           complete.PredictSet("OIDC", "JWT"),
 			"-max-token-ttl":  complete.PredictAnything,
 			"-token-locality": complete.PredictSet("local", "global"),
 			"-default":        complete.PredictSet("true", "false"),
@@ -161,8 +160,8 @@ func (a *ACLAuthMethodUpdateCommand) Run(args []string) int {
 	}
 
 	if slices.Contains(setFlags, "type") {
-		if strings.ToLower(a.methodType) != "oidc" {
-			a.Ui.Error("ACL auth method type must be set to 'OIDC'")
+		if !slices.Contains([]string{"OIDC", "JWT"}, strings.ToUpper(a.methodType)) {
+			a.Ui.Error("ACL auth method type must be set to 'OIDC' or 'JWT'")
 			return 1
 		}
 		updatedMethod.Type = a.methodType

--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -874,3 +874,22 @@ func (s *HTTPServer) ACLOIDCCompleteAuthRequest(resp http.ResponseWriter, req *h
 	setIndex(resp, out.Index)
 	return out.ACLToken, nil
 }
+
+// ACLLoginRequest performs a non-interactive authentication request
+func (s *HTTPServer) ACLLoginRequest(resp http.ResponseWriter, req *http.Request) (any, error) {
+	// The endpoint only supports PUT or POST requests.
+	if req.Method != http.MethodPost && req.Method != http.MethodPut {
+		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
+	}
+	var args structs.ACLLoginRequest
+	s.parseWriteRequest(req, &args.WriteRequest)
+	if err := decodeBody(req, &args); err != nil {
+		return nil, CodedError(http.StatusBadRequest, err.Error())
+	}
+	var out structs.ACLLoginResponse
+	if err := s.agent.RPC(structs.ACLLoginRPCMethod, &args, &out); err != nil {
+		return nil, err
+	}
+	setIndex(resp, out.Index)
+	return out.ACLToken, nil
+}

--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -867,7 +867,7 @@ func (s *HTTPServer) ACLOIDCCompleteAuthRequest(resp http.ResponseWriter, req *h
 		return nil, CodedError(http.StatusBadRequest, err.Error())
 	}
 
-	var out structs.ACLOIDCCompleteAuthResponse
+	var out structs.ACLLoginResponse
 	if err := s.agent.RPC(structs.ACLOIDCCompleteAuthRPCMethod, &args, &out); err != nil {
 		return nil, err
 	}

--- a/command/agent/acl_endpoint_test.go
+++ b/command/agent/acl_endpoint_test.go
@@ -1122,7 +1122,7 @@ func TestHTTPServer_ACLAuthMethodListRequest(t *testing.T) {
 
 				// Upsert two auth-methods into state.
 				must.NoError(t, srv.server.State().UpsertACLAuthMethods(
-					10, []*structs.ACLAuthMethod{mock.ACLAuthMethod(), mock.ACLAuthMethod()}))
+					10, []*structs.ACLAuthMethod{mock.ACLOIDCAuthMethod(), mock.ACLOIDCAuthMethod()}))
 
 				// Build the HTTP request.
 				req, err := http.NewRequest(http.MethodGet, "/v1/acl/auth-methods", nil)
@@ -1198,7 +1198,7 @@ func TestHTTPServer_ACLAuthMethodRequest(t *testing.T) {
 			testFn: func(srv *TestAgent) {
 
 				// Create a mock auth-method to use in the request body.
-				mockACLAuthMethod := mock.ACLAuthMethod()
+				mockACLAuthMethod := mock.ACLOIDCAuthMethod()
 
 				// Build the HTTP request.
 				req, err := http.NewRequest(http.MethodPut, "/v1/acl/auth-method", encodeReq(mockACLAuthMethod))
@@ -1269,7 +1269,7 @@ func TestHTTPServer_ACLAuthMethodSpecificRequest(t *testing.T) {
 			testFn: func(srv *TestAgent) {
 
 				// Create a mock auth-method and put directly into state.
-				mockACLAuthMethod := mock.ACLAuthMethod()
+				mockACLAuthMethod := mock.ACLOIDCAuthMethod()
 				must.NoError(t, srv.server.State().UpsertACLAuthMethods(
 					20, []*structs.ACLAuthMethod{mockACLAuthMethod}))
 
@@ -1294,7 +1294,7 @@ func TestHTTPServer_ACLAuthMethodSpecificRequest(t *testing.T) {
 			testFn: func(srv *TestAgent) {
 
 				// Create a mock auth-method and put directly into state.
-				mockACLAuthMethod := mock.ACLAuthMethod()
+				mockACLAuthMethod := mock.ACLOIDCAuthMethod()
 				must.NoError(t, srv.server.State().UpsertACLAuthMethods(
 					20, []*structs.ACLAuthMethod{mockACLAuthMethod}))
 
@@ -1499,7 +1499,7 @@ func TestHTTPServer_ACLBindingRuleRequest(t *testing.T) {
 
 				// Upsert the auth method that the binding rule will associate
 				// with.
-				mockACLAuthMethod := mock.ACLAuthMethod()
+				mockACLAuthMethod := mock.ACLOIDCAuthMethod()
 				must.NoError(t, srv.server.State().UpsertACLAuthMethods(
 					10, []*structs.ACLAuthMethod{mockACLAuthMethod}))
 
@@ -1607,7 +1607,7 @@ func TestHTTPServer_ACLBindingRuleSpecificRequest(t *testing.T) {
 
 				// Upsert the auth method that the binding rule will associate
 				// with.
-				mockACLAuthMethod := mock.ACLAuthMethod()
+				mockACLAuthMethod := mock.ACLOIDCAuthMethod()
 				must.NoError(t, srv.server.State().UpsertACLAuthMethods(
 					10, []*structs.ACLAuthMethod{mockACLAuthMethod}))
 
@@ -1716,7 +1716,7 @@ func TestHTTPServer_ACLOIDCAuthURLRequest(t *testing.T) {
 
 				// Generate and upsert an ACL auth method for use. Certain values must be
 				// taken from the cap OIDC provider just like real world use.
-				mockedAuthMethod := mock.ACLAuthMethod()
+				mockedAuthMethod := mock.ACLOIDCAuthMethod()
 				mockedAuthMethod.Config.AllowedRedirectURIs = []string{"http://127.0.0.1:4649/oidc/callback"}
 				mockedAuthMethod.Config.OIDCDiscoveryURL = oidcTestProvider.Addr()
 				mockedAuthMethod.Config.SigningAlgs = []string{"ES256"}
@@ -1799,7 +1799,7 @@ func TestHTTPServer_ACLOIDCCompleteAuthRequest(t *testing.T) {
 
 				// Generate and upsert an ACL auth method for use. Certain values must be
 				// taken from the cap OIDC provider just like real world use.
-				mockedAuthMethod := mock.ACLAuthMethod()
+				mockedAuthMethod := mock.ACLOIDCAuthMethod()
 				mockedAuthMethod.Config.BoundAudiences = []string{"mock"}
 				mockedAuthMethod.Config.AllowedRedirectURIs = []string{"http://127.0.0.1:4649/oidc/callback"}
 				mockedAuthMethod.Config.OIDCDiscoveryURL = oidcTestProvider.Addr()

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -425,9 +425,10 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/acl/binding-rule", s.wrap(s.ACLBindingRuleRequest))
 	s.mux.HandleFunc("/v1/acl/binding-rule/", s.wrap(s.ACLBindingRuleSpecificRequest))
 
-	// Register out ACL OIDC SSO provider handlers.
+	// Register out ACL OIDC SSO and auth handlers.
 	s.mux.HandleFunc("/v1/acl/oidc/auth-url", s.wrap(s.ACLOIDCAuthURLRequest))
 	s.mux.HandleFunc("/v1/acl/oidc/complete-auth", s.wrap(s.ACLOIDCCompleteAuthRequest))
+	s.mux.HandleFunc("/v1/acl/login", s.wrap(s.ACLLoginRequest))
 
 	s.mux.Handle("/v1/client/fs/", wrapCORS(s.wrap(s.FsRequest)))
 	s.mux.HandleFunc("/v1/client/gc", s.wrap(s.ClientGCRequest))

--- a/command/login.go
+++ b/command/login.go
@@ -205,7 +205,7 @@ func (l *LoginCommand) loginOIDC(ctx context.Context, client *api.Client) (*api.
 		ClientNonce:    callbackServer.Nonce(),
 	}
 
-	getAuthURLResp, _, err := client.ACLOIDC().GetAuthURL(&getAuthArgs, nil)
+	getAuthURLResp, _, err := client.ACLAuth().GetAuthURL(&getAuthArgs, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +240,7 @@ func (l *LoginCommand) loginOIDC(ctx context.Context, client *api.Client) (*api.
 		State:          req.State,
 	}
 
-	token, _, err := client.ACLOIDC().CompleteAuth(&cbArgs, nil)
+	token, _, err := client.ACLAuth().CompleteAuth(&cbArgs, nil)
 	return token, err
 }
 

--- a/command/login.go
+++ b/command/login.go
@@ -25,6 +25,7 @@ type LoginCommand struct {
 	authMethodType string // deprecated in 1.5.2, left for backwards compat
 	authMethodName string
 	callbackAddr   string
+	loginToken     string
 
 	template string
 	json     bool
@@ -52,6 +53,10 @@ Login Options:
     The address to use for the local OIDC callback server. This should be given
     in the form of <IP>:<PORT> and defaults to "localhost:4649".
 
+  -login-token
+    Login token used for authentication that will be exchanged for a Nomad ACL
+    Token. It is only required if using auth method type other than OIDC. 
+
   -json
     Output the ACL token in JSON format.
 
@@ -71,6 +76,7 @@ func (l *LoginCommand) AutocompleteFlags() complete.Flags {
 		complete.Flags{
 			"-method":             complete.PredictAnything,
 			"-oidc-callback-addr": complete.PredictAnything,
+			"-login-token":        complete.PredictAnything,
 			"-json":               complete.PredictNothing,
 			"-t":                  complete.PredictAnything,
 		})
@@ -86,6 +92,7 @@ func (l *LoginCommand) Run(args []string) int {
 	flags.Usage = func() { l.Ui.Output(l.Help()) }
 	flags.StringVar(&l.authMethodName, "method", "", "")
 	flags.StringVar(&l.authMethodType, "type", "", "")
+	flags.StringVar(&l.loginToken, "login-token", "", "")
 	flags.StringVar(&l.callbackAddr, "oidc-callback-addr", "localhost:4649", "")
 	flags.BoolVar(&l.json, "json", false, "")
 	flags.StringVar(&l.template, "t", "", "")
@@ -154,6 +161,12 @@ func (l *LoginCommand) Run(args []string) int {
 		}
 	}
 
+	// Make sure we got the login token if we're not using OIDC
+	if methodType != api.ACLAuthMethodTypeOIDC && l.loginToken == "" {
+		l.Ui.Error("You need to provide a login token.")
+		return 1
+	}
+
 	// Each login type should implement a function which matches this signature
 	// for the specific login implementation. This allows the command to have
 	// reusable and generic handling of errors and outputs.
@@ -162,6 +175,8 @@ func (l *LoginCommand) Run(args []string) int {
 	switch methodType {
 	case api.ACLAuthMethodTypeOIDC:
 		authFn = l.loginOIDC
+	case api.ACLAuthMethodTypeJWT:
+		authFn = l.loginJWT
 	default:
 		l.Ui.Error(fmt.Sprintf("Unsupported authentication type %q", methodType))
 		return 1
@@ -241,6 +256,15 @@ func (l *LoginCommand) loginOIDC(ctx context.Context, client *api.Client) (*api.
 	}
 
 	token, _, err := client.ACLAuth().CompleteAuth(&cbArgs, nil)
+	return token, err
+}
+
+func (l *LoginCommand) loginJWT(ctx context.Context, client *api.Client) (*api.ACLToken, error) {
+	authArgs := api.ACLLoginRequest{
+		AuthMethodName: l.authMethodName,
+		LoginToken:     l.loginToken,
+	}
+	token, _, err := client.ACLAuth().Login(&authArgs, nil)
 	return token, err
 }
 

--- a/command/login_test.go
+++ b/command/login_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/command/agent"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/mitchellh/cli"
 	"github.com/shoenig/test/must"
@@ -48,6 +49,25 @@ func TestLoginCommand_Run(t *testing.T) {
 	must.Eq(t, 1, cmd.Run([]string{"-address=" + agentURL, "-method", "there-is-no-such-method"}))
 	must.StrContains(t, ui.ErrorWriter.String(), "Error: method there-is-no-such-method not found in the state store. ")
 
+	ui.OutputWriter.Reset()
+	ui.ErrorWriter.Reset()
+
+	// Store a default auth method
+	state := srv.Agent.Server().State()
+	method := &structs.ACLAuthMethod{
+		Name:    "test-auth-method",
+		Default: true,
+		Type:    "JWT",
+		Config: &structs.ACLAuthMethodConfig{
+			OIDCDiscoveryURL: "http://example.com",
+		},
+	}
+	method.SetHash()
+	must.NoError(t, state.UpsertACLAuthMethods(1000, []*structs.ACLAuthMethod{method}))
+
+	// Try logging in with non-OIDC method and no token (expected error)
+	must.Eq(t, 1, cmd.Run([]string{"-address=" + agentURL}))
+	must.StrContains(t, ui.ErrorWriter.String(), "You need to provide a login token.")
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()
 

--- a/internal/testing/apitests/acl_test.go
+++ b/internal/testing/apitests/acl_test.go
@@ -55,7 +55,7 @@ func TestACLOIDC_GetAuthURL(t *testing.T) {
 		ClientNonce:    "fpSPuaodKevKfDU3IeXb",
 	}
 
-	authURLResp, _, err := testClient.ACLOIDC().GetAuthURL(&authURLRequest, nil)
+	authURLResp, _, err := testClient.ACLAuth().GetAuthURL(&authURLRequest, nil)
 	must.NoError(t, err)
 
 	// The response URL comes encoded, so decode this and check we have each
@@ -170,7 +170,7 @@ func TestACLOIDC_CompleteAuth(t *testing.T) {
 		Code:           "codeABC",
 	}
 
-	completeAuthResp, _, err := testClient.ACLOIDC().CompleteAuth(&authURLRequest, nil)
+	completeAuthResp, _, err := testClient.ACLAuth().CompleteAuth(&authURLRequest, nil)
 	must.NoError(t, err)
 	must.NotNil(t, completeAuthResp)
 	must.Len(t, 1, completeAuthResp.Policies)

--- a/lib/auth/binder.go
+++ b/lib/auth/binder.go
@@ -1,4 +1,4 @@
-package oidc
+package auth
 
 import (
 	"fmt"
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/hil"
 	"github.com/hashicorp/hil/ast"
-
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 

--- a/lib/auth/binder_test.go
+++ b/lib/auth/binder_test.go
@@ -1,4 +1,4 @@
-package oidc
+package auth
 
 import (
 	"testing"
@@ -19,7 +19,7 @@ func TestBinder_Bind(t *testing.T) {
 	testBind := NewBinder(testStore)
 
 	// create an authMethod method and insert into the state store
-	authMethod := mock.ACLAuthMethod()
+	authMethod := mock.ACLOIDCAuthMethod()
 	must.NoError(t, testStore.UpsertACLAuthMethods(0, []*structs.ACLAuthMethod{authMethod}))
 
 	// create some roles and insert into the state store

--- a/lib/auth/claims.go
+++ b/lib/auth/claims.go
@@ -1,4 +1,4 @@
-package oidc
+package auth
 
 import (
 	"encoding/json"

--- a/lib/auth/claims_test.go
+++ b/lib/auth/claims_test.go
@@ -1,4 +1,4 @@
-package oidc
+package auth
 
 import (
 	"testing"

--- a/lib/auth/identity.go
+++ b/lib/auth/identity.go
@@ -1,4 +1,4 @@
-package oidc
+package auth
 
 import (
 	"github.com/hashicorp/nomad/nomad/structs"

--- a/lib/auth/identity_test.go
+++ b/lib/auth/identity_test.go
@@ -1,8 +1,9 @@
-package oidc
+package auth
 
 import (
-	"github.com/shoenig/test/must"
 	"testing"
+
+	"github.com/shoenig/test/must"
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/nomad/structs"

--- a/lib/auth/jwt/validator.go
+++ b/lib/auth/jwt/validator.go
@@ -1,0 +1,125 @@
+package jwt
+
+import (
+	"context"
+	"crypto"
+	"fmt"
+	"time"
+
+	"github.com/armon/go-metrics"
+	"github.com/hashicorp/cap/jwt"
+	"golang.org/x/exp/slices"
+
+	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// Validate performs token signature verification and JWT header validation,
+// and returns a list of claims or an error in case any validation or signature
+// verification fails.
+func Validate(ctx context.Context, token string, methodConf *structs.ACLAuthMethodConfig) (map[string]any, error) {
+	var (
+		keySet jwt.KeySet
+		err    error
+	)
+
+	// JWT validation can happen in 3 ways:
+	// - via embedded public keys, locally
+	// - via JWKS
+	// - or via OIDC provider
+	if len(methodConf.JWTValidationPubKeys) != 0 {
+		keySet, err = usingStaticKeys(methodConf.JWTValidationPubKeys)
+		if err != nil {
+			return nil, err
+		}
+	} else if methodConf.JWKSURL != "" {
+		keySet, err = usingJWKS(ctx, methodConf.JWKSURL, methodConf.JWKSCACert)
+		if err != nil {
+			return nil, err
+		}
+	} else if methodConf.OIDCDiscoveryURL != "" {
+		keySet, err = usingOIDC(ctx, methodConf.OIDCDiscoveryURL, methodConf.DiscoveryCaPem)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// SigningAlgs field is a string, we need to convert it to a type the go-jwt
+	// accepts in order to validate.
+	toAlgFn := func(m string) jwt.Alg { return jwt.Alg(m) }
+	algorithms := helper.ConvertSlice(methodConf.SigningAlgs, toAlgFn)
+
+	expected := jwt.Expected{
+		Audiences:         methodConf.BoundAudiences,
+		SigningAlgorithms: algorithms,
+		NotBeforeLeeway:   methodConf.NotBeforeLeeway,
+		ExpirationLeeway:  methodConf.ExpirationLeeway,
+		ClockSkewLeeway:   methodConf.ClockSkewLeeway,
+	}
+
+	validator, err := jwt.NewValidator(keySet)
+	if err != nil {
+		return nil, err
+	}
+
+	claims, err := validator.Validate(ctx, token, expected)
+	if err != nil {
+		return nil, fmt.Errorf("unable to verify signature of JWT token: %v", err)
+	}
+
+	// validate issuer manually, because we allow users to specify an array
+	if len(methodConf.BoundIssuer) > 0 {
+		if _, ok := claims["iss"]; !ok {
+			return nil, fmt.Errorf(
+				"auth method specifies BoundIssuers but the provided token does not contain issuer information",
+			)
+		}
+		if iss, ok := claims["iss"].(string); !ok {
+			return nil, fmt.Errorf("unable to read iss property of provided token")
+		} else if !slices.Contains(methodConf.BoundIssuer, iss) {
+			return nil, fmt.Errorf("invalid JWT issuer: %v", claims["iss"])
+		}
+	}
+
+	return claims, nil
+}
+
+func usingStaticKeys(keys []string) (jwt.KeySet, error) {
+	var parsedKeys []crypto.PublicKey
+	for _, v := range keys {
+		key, err := jwt.ParsePublicKeyPEM([]byte(v))
+		parsedKeys = append(parsedKeys, key)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse public key for JWT auth: %v", err)
+		}
+	}
+	return jwt.NewStaticKeySet(parsedKeys)
+}
+
+func usingJWKS(ctx context.Context, jwksurl, jwkscapem string) (jwt.KeySet, error) {
+	// Measure the JWKS endpoint performance.
+	defer metrics.MeasureSince([]string{"nomad", "acl", "jwt", "jwks"}, time.Now())
+
+	keySet, err := jwt.NewJSONWebKeySet(ctx, jwksurl, jwkscapem)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get validation keys from JWKS: %v", err)
+	}
+	return keySet, nil
+}
+
+func usingOIDC(ctx context.Context, oidcurl string, oidccapem []string) (jwt.KeySet, error) {
+	// Measure the OIDC endpoint performance.
+	defer metrics.MeasureSince([]string{"nomad", "acl", "jwt", "oidc_jwt"}, time.Now())
+
+	// TODO why do we have DiscoverCaPem as an array but JWKSCaPem as a single string?
+	pem := ""
+	if len(oidccapem) > 0 {
+		pem = oidccapem[0]
+	}
+
+	keySet, err := jwt.NewOIDCDiscoveryKeySet(ctx, oidcurl, pem)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get validation keys from OIDC provider: %v", err)
+	}
+	return keySet, nil
+}

--- a/lib/auth/jwt/validator_test.go
+++ b/lib/auth/jwt/validator_test.go
@@ -1,0 +1,142 @@
+package jwt
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/hashicorp/cap/oidc"
+	"github.com/shoenig/test/must"
+
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+func TestValidate(t *testing.T) {
+	iat := time.Now().Unix()
+	nbf := time.Now().Unix()
+	exp := time.Now().Add(time.Hour).Unix()
+
+	claims := jwt.MapClaims{
+		"foo":    "bar",
+		"issuer": "test suite",
+		"float":  3.14,
+		"iat":    iat,
+		"nbf":    nbf,
+		"exp":    exp,
+	}
+
+	wantedClaims := map[string]any{
+		"foo":    "bar",
+		"issuer": "test suite",
+		"float":  3.14,
+		"iat":    float64(iat),
+		"nbf":    float64(nbf),
+		"exp":    float64(exp),
+	}
+
+	// appended to JWKS test server URL
+	wellKnownJWKS := "/.well-known/jwks.json"
+
+	// generate a key pair, so that we can use it for consistent signing and
+	// set it as our test server key
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	must.NoError(t, err)
+
+	token, _, err := mock.SampleJWTokenWithKeys(claims, rsaKey)
+	must.NoError(t, err)
+	tokenWithNoClaims, pubKeyPem, err := mock.SampleJWTokenWithKeys(nil, rsaKey)
+	must.NoError(t, err)
+
+	// make an expired token...
+	expired := time.Now().Add(-time.Hour).Unix()
+	expiredClaims := jwt.MapClaims{"iat": iat, "nbf": nbf, "exp": expired}
+	expiredToken, _, err := mock.SampleJWTokenWithKeys(expiredClaims, rsaKey)
+	must.NoError(t, err)
+
+	// ...and one with invalid issuer, too
+	invalidIssuer := jwt.MapClaims{"iat": iat, "nbf": nbf, "exp": exp, "iss": "hashicorp vault"}
+	invalidIssuerToken, _, err := mock.SampleJWTokenWithKeys(invalidIssuer, rsaKey)
+	must.NoError(t, err)
+
+	testServer := oidc.StartTestProvider(t)
+	defer testServer.Stop()
+
+	keyID := strconv.Itoa(int(time.Now().Unix()))
+	testServer.SetSigningKeys(rsaKey, rsaKey.Public(), oidc.RS256, keyID)
+	tokenSignedWithRemoteServerKeys, _, err := mock.SampleJWTokenWithKeys(claims, rsaKey)
+	must.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		token   string
+		conf    *structs.ACLAuthMethodConfig
+		want    map[string]interface{}
+		wantErr bool
+	}{
+		{
+			name:    "valid signature, local verification",
+			token:   token,
+			conf:    &structs.ACLAuthMethodConfig{JWTValidationPubKeys: []string{pubKeyPem}},
+			want:    wantedClaims,
+			wantErr: false,
+		},
+		{
+			name:    "valid signature, local verification, no claims",
+			token:   tokenWithNoClaims,
+			conf:    &structs.ACLAuthMethodConfig{JWTValidationPubKeys: []string{pubKeyPem}},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:  "valid signature, JWKS verification",
+			token: tokenSignedWithRemoteServerKeys,
+			conf: &structs.ACLAuthMethodConfig{
+				JWKSURL:    testServer.Addr() + wellKnownJWKS,
+				JWKSCACert: testServer.CACert(),
+			},
+			want:    wantedClaims,
+			wantErr: false,
+		},
+		{
+			name:  "valid signature, OIDC verification",
+			token: tokenSignedWithRemoteServerKeys,
+			conf: &structs.ACLAuthMethodConfig{
+				OIDCDiscoveryURL: testServer.Addr(),
+				DiscoveryCaPem:   []string{testServer.CACert()},
+			},
+			want:    wantedClaims,
+			wantErr: false,
+		},
+		{
+			name:    "expired token, local verification",
+			token:   expiredToken,
+			conf:    &structs.ACLAuthMethodConfig{JWTValidationPubKeys: []string{pubKeyPem}},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:  "invalid issuer, local verification",
+			token: invalidIssuerToken,
+			conf: &structs.ACLAuthMethodConfig{
+				JWTValidationPubKeys: []string{pubKeyPem},
+				BoundIssuer:          []string{"test suite"},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Validate(context.Background(), tt.token, tt.conf)
+			if !tt.wantErr {
+				must.Nil(t, err, must.Sprint(err))
+			}
+			must.Eq(t, got, tt.want)
+		})
+	}
+}

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -2803,8 +2803,8 @@ func (a *ACL) Login(args *structs.ACLLoginRequest, reply *structs.ACLLoginRespon
 	defer metrics.MeasureSince([]string{"nomad", "acl", "login"}, time.Now())
 
 	// This endpoint can only be used once all servers in all federated regions
-	// have been upgraded to 1.5.2 or greater, since JWT Auth method was
-	// introduced then.
+	// have been upgraded to minACLJWTAuthMethodVersion or greater, since JWT Auth
+	// method was introduced then.
 	if !ServersMeetMinimumVersion(a.srv.Members(), AllRegions, minACLJWTAuthMethodVersion, false) {
 		return fmt.Errorf("all servers should be running version %v or later to use JWT ACL auth methods",
 			minACLJWTAuthMethodVersion)

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -19,6 +19,8 @@ import (
 	policy "github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/lib/auth"
+	"github.com/hashicorp/nomad/lib/auth/jwt"
 	"github.com/hashicorp/nomad/lib/auth/oidc"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/state/paginator"
@@ -43,6 +45,10 @@ const (
 	// aclOIDCCallbackRequestExpiryTime is the deadline used when obtaining an
 	// OIDC provider token. This is used for HTTP requests to external APIs.
 	aclOIDCCallbackRequestExpiryTime = 60 * time.Second
+
+	// aclLoginRequestExpiryTime is the deadline used when performing HTTP
+	// requests to external APIs during the validation of bearer tokens.
+	aclLoginRequestExpiryTime = 60 * time.Second
 )
 
 // ACL endpoint is used for manipulating ACL tokens and policies
@@ -2612,7 +2618,7 @@ func (a *ACL) OIDCAuthURL(args *structs.ACLOIDCAuthURLRequest, reply *structs.AC
 // provider token for a Nomad ACL token, using the configured ACL role and
 // policy claims to provide authorization.
 func (a *ACL) OIDCCompleteAuth(
-	args *structs.ACLOIDCCompleteAuthRequest, reply *structs.ACLOIDCCompleteAuthResponse) error {
+	args *structs.ACLOIDCCompleteAuthRequest, reply *structs.ACLLoginResponse) error {
 
 	// The OIDC flow can only be used when the Nomad cluster has ACL enabled.
 	if !a.srv.config.ACLEnabled {
@@ -2719,19 +2725,19 @@ func (a *ACL) OIDCCompleteAuth(
 
 	// Generate the data used by the go-bexpr selector that is an internal
 	// representation of the claims that can be understood by Nomad.
-	oidcInternalClaims, err := oidc.SelectorData(authMethod, idTokenClaims, userClaims)
+	oidcInternalClaims, err := auth.SelectorData(authMethod, idTokenClaims, userClaims)
 	if err != nil {
 		return err
 	}
 
 	// Create a new binder object based on the current state snapshot to
 	// provide consistency within the RPC handler.
-	oidcBinder := oidc.NewBinder(stateSnapshot)
+	oidcBinder := auth.NewBinder(stateSnapshot)
 
 	// Generate the role and policy bindings that will be assigned to the ACL
 	// token. Ensure we have at least 1 role or policy, otherwise the RPC will
 	// fail anyway.
-	tokenBindings, err := oidcBinder.Bind(authMethod, oidc.NewIdentity(authMethod.Config, oidcInternalClaims))
+	tokenBindings, err := oidcBinder.Bind(authMethod, auth.NewIdentity(authMethod.Config, oidcInternalClaims))
 	if err != nil {
 		return err
 	}
@@ -2775,5 +2781,154 @@ func (a *ACL) OIDCCompleteAuth(
 	// we will have exactly the same number of tokens returned as we sent. It
 	// is therefore safe to assume we have 1 token.
 	reply.ACLToken = tokenUpsertReply.Tokens[0]
+	return nil
+}
+
+// Login RPC performs non-interactive auth using a given AuthMethod. This method
+// can not be used for OIDC login flow.
+func (a *ACL) Login(args *structs.ACLLoginRequest, reply *structs.ACLLoginResponse) error {
+
+	// The login flow can only be used when the Nomad cluster has ACL enabled.
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
+
+	// Perform the initial forwarding within the region. This ensures we
+	// respect stale queries.
+	if done, err := a.srv.forward(structs.ACLLoginRPCMethod, args, args, reply); done {
+		return err
+	}
+
+	// Measure the login endpoint performance.
+	defer metrics.MeasureSince([]string{"nomad", "acl", "login"}, time.Now())
+
+	// This endpoint can only be used once all servers in all federated regions
+	// have been upgraded to 1.5.2 or greater, since JWT Auth method was
+	// introduced then.
+	if !ServersMeetMinimumVersion(a.srv.Members(), AllRegions, minACLJWTAuthMethodVersion, false) {
+		return fmt.Errorf("all servers should be running version %v or later to use JWT ACL auth methods",
+			minACLJWTAuthMethodVersion)
+	}
+
+	// Validate the request arguments to ensure it contains all the data it
+	// needs.
+	if err := args.Validate(); err != nil {
+		return structs.NewErrRPCCodedf(http.StatusBadRequest, "invalid login request: %v", err)
+	}
+
+	// Grab a snapshot of the state, so we can query it safely.
+	stateSnapshot, err := a.srv.fsm.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
+	// Lookup the auth method from state, so we have the entire object
+	// available to us. It's important to check for nil on the auth method
+	// object, as it is possible the request was made with an incorrectly named
+	// auth method.
+	authMethod, err := stateSnapshot.GetACLAuthMethodByName(nil, args.AuthMethodName)
+	if err != nil {
+		return err
+	}
+	if authMethod == nil {
+		return structs.NewErrRPCCodedf(
+			http.StatusBadRequest,
+			"auth-method %q not found",
+			args.AuthMethodName,
+		)
+	}
+
+	// If the authentication method generates global ACL tokens, we need to
+	// forward the request onto the authoritative regional leader.
+	if authMethod.TokenLocalityIsGlobal() {
+		args.Region = a.srv.config.AuthoritativeRegion
+
+		if done, err := a.srv.forward(structs.ACLLoginRPCMethod, args, args, reply); done {
+			return err
+		}
+	}
+
+	// Generate a context with a deadline. This is used when making remote HTTP
+	// requests.
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(aclLoginRequestExpiryTime))
+	defer cancel()
+
+	var claims map[string]interface{}
+
+	// Validate the token depending on its method type
+	switch authMethod.Type {
+	case structs.ACLAuthMethodTypeJWT:
+		claims, err = jwt.Validate(ctx, args.LoginToken, authMethod.Config)
+		if err != nil {
+			return structs.NewErrRPCCodedf(
+				http.StatusUnauthorized,
+				"unable to validate provided token: %v",
+				err,
+			)
+		}
+	default:
+		return structs.NewErrRPCCodedf(
+			http.StatusBadRequest,
+			"unsupported auth-method type: %s",
+			authMethod.Type,
+		)
+	}
+
+	// Create a new binder object based on the current state snapshot to
+	// provide consistency within the RPC handler.
+	jwtBinder := auth.NewBinder(stateSnapshot)
+
+	// Generate the data used by the go-bexpr selector that is an internal
+	// representation of the claims that can be understood by Nomad.
+	jwtClaims, err := auth.SelectorData(authMethod, claims, nil)
+	if err != nil {
+		return err
+	}
+
+	tokenBindings, err := jwtBinder.Bind(authMethod, auth.NewIdentity(authMethod.Config, jwtClaims))
+	if err != nil {
+		return err
+	}
+	if tokenBindings.None() && !tokenBindings.Management {
+		return structs.NewErrRPCCoded(http.StatusBadRequest, "no role or policy bindings matched")
+	}
+
+	// Build our token RPC request. The RPC handler includes a lot of specific
+	// logic, so we do not want to call Raft directly or copy that here. In the
+	// future we should try and extract out the logic into an interface, or at
+	// least a separate function.
+	token := structs.ACLToken{
+		Name:          "JWT-" + authMethod.Name,
+		Global:        authMethod.TokenLocalityIsGlobal(),
+		ExpirationTTL: authMethod.MaxTokenTTL,
+	}
+
+	if tokenBindings.Management {
+		token.Type = structs.ACLManagementToken
+	} else {
+		token.Type = structs.ACLClientToken
+		token.Policies = tokenBindings.Policies
+		token.Roles = tokenBindings.Roles
+	}
+
+	tokenUpsertRequest := structs.ACLTokenUpsertRequest{
+		Tokens: []*structs.ACLToken{&token},
+		WriteRequest: structs.WriteRequest{
+			Region:    a.srv.Region(),
+			AuthToken: a.srv.getLeaderAcl(),
+		},
+	}
+
+	var tokenUpsertReply structs.ACLTokenUpsertResponse
+
+	if err := a.srv.RPC(structs.ACLUpsertTokensRPCMethod, &tokenUpsertRequest, &tokenUpsertReply); err != nil {
+		return err
+	}
+
+	// The way the UpsertTokens RPC currently works, if we get no error, then
+	// we will have exactly the same number of tokens returned as we sent. It
+	// is therefore safe to assume we have 1 token.
+	reply.ACLToken = tokenUpsertReply.Tokens[0]
+
 	return nil
 }

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -2691,7 +2691,7 @@ func TestFSM_SnapshotRestore_ACLAuthMethods(t *testing.T) {
 	testState := fsm.State()
 
 	// Generate and upsert some ACL auth methods.
-	authMethods := []*structs.ACLAuthMethod{mock.ACLAuthMethod(), mock.ACLAuthMethod()}
+	authMethods := []*structs.ACLAuthMethod{mock.ACLOIDCAuthMethod(), mock.ACLOIDCAuthMethod()}
 	must.NoError(t, testState.UpsertACLAuthMethods(10, authMethods))
 
 	// Perform a snapshot restore.
@@ -3540,8 +3540,8 @@ func TestFSM_UpsertACLAuthMethods(t *testing.T) {
 	ci.Parallel(t)
 	fsm := testFSM(t)
 
-	am1 := mock.ACLAuthMethod()
-	am2 := mock.ACLAuthMethod()
+	am1 := mock.ACLOIDCAuthMethod()
+	am2 := mock.ACLOIDCAuthMethod()
 	req := structs.ACLAuthMethodUpsertRequest{
 		AuthMethods: []*structs.ACLAuthMethod{am1, am2},
 	}
@@ -3564,8 +3564,8 @@ func TestFSM_DeleteACLAuthMethods(t *testing.T) {
 	ci.Parallel(t)
 	fsm := testFSM(t)
 
-	am1 := mock.ACLAuthMethod()
-	am2 := mock.ACLAuthMethod()
+	am1 := mock.ACLOIDCAuthMethod()
+	am2 := mock.ACLOIDCAuthMethod()
 	must.Nil(t, fsm.State().UpsertACLAuthMethods(1000, []*structs.ACLAuthMethod{am1, am2}))
 
 	req := structs.ACLAuthMethodDeleteRequest{
@@ -3591,7 +3591,7 @@ func TestFSM_UpsertACLBindingRules(t *testing.T) {
 	fsm := testFSM(t)
 
 	// Create an auth method and upsert so the binding rules can link to this.
-	authMethod := mock.ACLAuthMethod()
+	authMethod := mock.ACLOIDCAuthMethod()
 	must.NoError(t, fsm.state.UpsertACLAuthMethods(10, []*structs.ACLAuthMethod{authMethod}))
 
 	aclBindingRule1 := mock.ACLBindingRule()

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -57,6 +57,14 @@ var minACLRoleVersion = version.Must(version.NewVersion("1.4.0"))
 // meet before the feature can be used.
 var minACLAuthMethodVersion = version.Must(version.NewVersion("1.5.0-beta.1"))
 
+// minACLJWTAuthMethodVersion is the Nomad version at which the ACL JWT auth method type
+// was introduced. It forms the minimum version all federated servers must
+// meet before the feature can be used.
+//
+// TODO: version constraint will be updated for until we reach 1.5.2, otherwise
+// it's hard to test the functionality
+var minACLJWTAuthMethodVersion = version.Must(version.NewVersion("1.4.4-dev"))
+
 // minACLBindingRuleVersion is the Nomad version at which the ACL binding rules
 // table was introduced. It forms the minimum version all federated servers
 // must meet before the feature can be used.

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -61,9 +61,9 @@ var minACLAuthMethodVersion = version.Must(version.NewVersion("1.5.0-beta.1"))
 // was introduced. It forms the minimum version all federated servers must
 // meet before the feature can be used.
 //
-// TODO: version constraint will be updated for until we reach 1.5.2, otherwise
+// TODO: version constraint will be updated for until we reach 1.5.3, otherwise
 // it's hard to test the functionality
-var minACLJWTAuthMethodVersion = version.Must(version.NewVersion("1.5.2-dev"))
+var minACLJWTAuthMethodVersion = version.Must(version.NewVersion("1.5.3-dev"))
 
 // minACLBindingRuleVersion is the Nomad version at which the ACL binding rules
 // table was introduced. It forms the minimum version all federated servers

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -60,10 +60,7 @@ var minACLAuthMethodVersion = version.Must(version.NewVersion("1.5.0-beta.1"))
 // minACLJWTAuthMethodVersion is the Nomad version at which the ACL JWT auth method type
 // was introduced. It forms the minimum version all federated servers must
 // meet before the feature can be used.
-//
-// TODO: version constraint will be updated for until we reach 1.5.3, otherwise
-// it's hard to test the functionality
-var minACLJWTAuthMethodVersion = version.Must(version.NewVersion("1.5.3-dev"))
+var minACLJWTAuthMethodVersion = version.Must(version.NewVersion("1.5.3"))
 
 // minACLBindingRuleVersion is the Nomad version at which the ACL binding rules
 // table was introduced. It forms the minimum version all federated servers

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -63,7 +63,7 @@ var minACLAuthMethodVersion = version.Must(version.NewVersion("1.5.0-beta.1"))
 //
 // TODO: version constraint will be updated for until we reach 1.5.2, otherwise
 // it's hard to test the functionality
-var minACLJWTAuthMethodVersion = version.Must(version.NewVersion("1.4.4-dev"))
+var minACLJWTAuthMethodVersion = version.Must(version.NewVersion("1.5.2-dev"))
 
 // minACLBindingRuleVersion is the Nomad version at which the ACL binding rules
 // table was introduced. It forms the minimum version all federated servers

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -1301,10 +1301,10 @@ func Test_diffACLAuthMethods(t *testing.T) {
 	stateStore := state.TestStateStore(t)
 
 	// Build an initial baseline of ACL auth-methods.
-	aclAuthMethod0 := mock.ACLAuthMethod()
-	aclAuthMethod1 := mock.ACLAuthMethod()
-	aclAuthMethod2 := mock.ACLAuthMethod()
-	aclAuthMethod3 := mock.ACLAuthMethod()
+	aclAuthMethod0 := mock.ACLOIDCAuthMethod()
+	aclAuthMethod1 := mock.ACLOIDCAuthMethod()
+	aclAuthMethod2 := mock.ACLOIDCAuthMethod()
+	aclAuthMethod3 := mock.ACLOIDCAuthMethod()
 
 	// Upsert these into our local state. Use copies, so we can alter the
 	// auth-methods directly and use within the diff func.
@@ -1318,7 +1318,7 @@ func Test_diffACLAuthMethods(t *testing.T) {
 	aclAuthMethod2.ModifyIndex = 50
 	aclAuthMethod3.ModifyIndex = 200
 	aclAuthMethod3.Hash = []byte{0, 1, 2, 3}
-	aclAuthMethod4 := mock.ACLAuthMethod()
+	aclAuthMethod4 := mock.ACLOIDCAuthMethod()
 
 	// Run the diff function and test the output.
 	toDelete, toUpdate := diffACLAuthMethods(stateStore, 50, []*structs.ACLAuthMethodStub{

--- a/nomad/mock/acl.go
+++ b/nomad/mock/acl.go
@@ -1,16 +1,21 @@
 package mock
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/golang-jwt/jwt/v4"
 	testing "github.com/mitchellh/go-testing-interface"
-
-	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 // StateStore defines the methods required from state.StateStore but avoids a
@@ -219,7 +224,7 @@ func ACLManagementToken() *structs.ACLToken {
 	}
 }
 
-func ACLAuthMethod() *structs.ACLAuthMethod {
+func ACLOIDCAuthMethod() *structs.ACLAuthMethod {
 	maxTokenTTL, _ := time.ParseDuration("3600s")
 	method := structs.ACLAuthMethod{
 		Name:          fmt.Sprintf("acl-auth-method-%s", uuid.Short()),
@@ -232,10 +237,10 @@ func ACLAuthMethod() *structs.ACLAuthMethod {
 			OIDCClientID:        "mock",
 			OIDCClientSecret:    "very secret secret",
 			OIDCScopes:          []string{"groups"},
-			BoundAudiences:      []string{"audience1", "audience2"},
+			BoundAudiences:      []string{"sales", "engineering"},
 			AllowedRedirectURIs: []string{"foo", "bar"},
 			DiscoveryCaPem:      []string{"foo"},
-			SigningAlgs:         []string{"bar"},
+			SigningAlgs:         []string{"RS256"},
 			ClaimMappings:       map[string]string{"foo": "bar"},
 			ListClaimMappings:   map[string]string{"foo": "bar"},
 		},
@@ -246,6 +251,73 @@ func ACLAuthMethod() *structs.ACLAuthMethod {
 	method.Canonicalize()
 	method.SetHash()
 	return &method
+}
+
+func ACLJWTAuthMethod() *structs.ACLAuthMethod {
+	maxTokenTTL, _ := time.ParseDuration("3600s")
+	method := structs.ACLAuthMethod{
+		Name:          fmt.Sprintf("acl-auth-method-%s", uuid.Short()),
+		Type:          "JWT",
+		TokenLocality: "local",
+		MaxTokenTTL:   maxTokenTTL,
+		Default:       false,
+		Config: &structs.ACLAuthMethodConfig{
+			JWTValidationPubKeys: []string{},
+			OIDCDiscoveryURL:     "http://example.com",
+			BoundAudiences:       []string{"sales", "engineering"},
+			DiscoveryCaPem:       []string{"foo"},
+			SigningAlgs:          []string{"RS256"},
+			ClaimMappings:        map[string]string{"foo": "bar"},
+			ListClaimMappings:    map[string]string{"foo": "bar"},
+		},
+		CreateTime:  time.Now().UTC(),
+		CreateIndex: 10,
+		ModifyIndex: 10,
+	}
+	method.SetHash()
+	method.Canonicalize()
+	return &method
+}
+
+// SampleJWTokenWithKeys takes a set of claims (can be nil) and optionally
+// a private RSA key that should be used for signing the JWT, and returns:
+// - a JWT signed with a randomly generated RSA key
+// - PEM string of the public part of that key that can be used for validation.
+func SampleJWTokenWithKeys(claims jwt.Claims, rsaKey *rsa.PrivateKey) (string, string, error) {
+	var token, pubkeyPem string
+
+	if rsaKey == nil {
+		var err error
+		rsaKey, err = rsa.GenerateKey(rand.Reader, 4096)
+		if err != nil {
+			return token, pubkeyPem, err
+		}
+	}
+
+	pubkeyBytes, err := x509.MarshalPKIXPublicKey(rsaKey.Public())
+	if err != nil {
+		return token, pubkeyPem, err
+	}
+	pubkeyPem = string(pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "RSA PUBLIC KEY",
+			Bytes: pubkeyBytes,
+		},
+	))
+
+	var rawToken *jwt.Token
+	if claims != nil {
+		rawToken = jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	} else {
+		rawToken = jwt.New(jwt.SigningMethodRS256)
+	}
+
+	token, err = rawToken.SignedString(rsaKey)
+	if err != nil {
+		return token, pubkeyPem, err
+	}
+
+	return token, pubkeyPem, nil
 }
 
 func ACLBindingRule() *structs.ACLBindingRule {

--- a/nomad/mock/acl.go
+++ b/nomad/mock/acl.go
@@ -274,8 +274,8 @@ func ACLJWTAuthMethod() *structs.ACLAuthMethod {
 		CreateIndex: 10,
 		ModifyIndex: 10,
 	}
-	method.SetHash()
 	method.Canonicalize()
+	method.SetHash()
 	return &method
 }
 

--- a/nomad/state/events_test.go
+++ b/nomad/state/events_test.go
@@ -1058,7 +1058,7 @@ func Test_eventsFromChanges_ACLAuthMethod(t *testing.T) {
 	defer testState.StopEventBroker()
 
 	// Generate a test ACL auth method
-	authMethod := mock.ACLAuthMethod()
+	authMethod := mock.ACLOIDCAuthMethod()
 
 	// Upsert the auth method straight into state
 	writeTxn := testState.db.WriteTxn(10)

--- a/nomad/state/state_store_acl_binding_rule_test.go
+++ b/nomad/state/state_store_acl_binding_rule_test.go
@@ -24,7 +24,7 @@ func TestStateStore_UpsertACLBindingRules(t *testing.T) {
 
 	// Create an auth method and ensure the binding rule is updated, so it is
 	// related to it.
-	authMethod := mock.ACLAuthMethod()
+	authMethod := mock.ACLOIDCAuthMethod()
 	mockedACLBindingRules[0].AuthMethod = authMethod.Name
 
 	must.NoError(t, testState.UpsertACLAuthMethods(10, []*structs.ACLAuthMethod{authMethod}))

--- a/nomad/state/state_store_acl_sso_test.go
+++ b/nomad/state/state_store_acl_sso_test.go
@@ -15,7 +15,7 @@ func TestStateStore_UpsertACLAuthMethods(t *testing.T) {
 	testState := testStateStore(t)
 
 	// Create mock auth methods
-	mockedACLAuthMethods := []*structs.ACLAuthMethod{mock.ACLAuthMethod(), mock.ACLAuthMethod()}
+	mockedACLAuthMethods := []*structs.ACLAuthMethod{mock.ACLOIDCAuthMethod(), mock.ACLOIDCAuthMethod()}
 
 	must.NoError(t, testState.UpsertACLAuthMethods(10, mockedACLAuthMethods))
 
@@ -88,7 +88,7 @@ func TestStateStore_UpsertACLAuthMethods(t *testing.T) {
 
 	// Try adding a new auth method, which has a name clash with an existing
 	// entry.
-	dup := mock.ACLAuthMethod()
+	dup := mock.ACLOIDCAuthMethod()
 	dup.Name = mockedACLAuthMethods[0].Name
 	dup.Type = mockedACLAuthMethods[0].Type
 
@@ -115,7 +115,7 @@ func TestStateStore_DeleteACLAuthMethods(t *testing.T) {
 
 	// Generate some mocked ACL auth methods for testing and upsert these
 	// straight into state.
-	mockedACLAuthMethods := []*structs.ACLAuthMethod{mock.ACLAuthMethod(), mock.ACLAuthMethod()}
+	mockedACLAuthMethods := []*structs.ACLAuthMethod{mock.ACLOIDCAuthMethod(), mock.ACLOIDCAuthMethod()}
 	must.NoError(t, testState.UpsertACLAuthMethods(10, mockedACLAuthMethods))
 
 	// Try and delete a method using a name that doesn't exist. This should
@@ -178,7 +178,7 @@ func TestStateStore_GetACLAuthMethods(t *testing.T) {
 
 	// Generate a some mocked ACL auth methods for testing and upsert these
 	// straight into state.
-	mockedACLAuthMethods := []*structs.ACLAuthMethod{mock.ACLAuthMethod(), mock.ACLAuthMethod()}
+	mockedACLAuthMethods := []*structs.ACLAuthMethod{mock.ACLOIDCAuthMethod(), mock.ACLOIDCAuthMethod()}
 	must.NoError(t, testState.UpsertACLAuthMethods(10, mockedACLAuthMethods))
 
 	// List the auth methods and ensure they are exactly as we expect.
@@ -207,7 +207,7 @@ func TestStateStore_GetACLAuthMethodByName(t *testing.T) {
 
 	// Generate a some mocked ACL auth methods for testing and upsert these
 	// straight into state.
-	mockedACLAuthMethods := []*structs.ACLAuthMethod{mock.ACLAuthMethod(), mock.ACLAuthMethod()}
+	mockedACLAuthMethods := []*structs.ACLAuthMethod{mock.ACLOIDCAuthMethod(), mock.ACLOIDCAuthMethod()}
 	must.NoError(t, testState.UpsertACLAuthMethods(10, mockedACLAuthMethods))
 
 	ws := memdb.NewWatchSet()
@@ -232,9 +232,9 @@ func TestStateStore_GetDefaultACLAuthMethod(t *testing.T) {
 	testState := testStateStore(t)
 
 	// Generate 2 auth methods, make one of them default
-	am1 := mock.ACLAuthMethod()
+	am1 := mock.ACLOIDCAuthMethod()
 	am1.Default = true
-	am2 := mock.ACLAuthMethod()
+	am2 := mock.ACLOIDCAuthMethod()
 
 	// upsert
 	mockedACLAuthMethods := []*structs.ACLAuthMethod{am1, am2}

--- a/nomad/state/state_store_restore_test.go
+++ b/nomad/state/state_store_restore_test.go
@@ -635,7 +635,7 @@ func TestStateStore_ACLAuthMethodRestore(t *testing.T) {
 
 	// Set up our test registrations and index.
 	expectedIndex := uint64(13)
-	authMethod := mock.ACLAuthMethod()
+	authMethod := mock.ACLOIDCAuthMethod()
 	authMethod.CreateIndex = expectedIndex
 	authMethod.ModifyIndex = expectedIndex
 

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -169,6 +169,14 @@ const (
 	// Args: ACLOIDCCompleteAuthRequest
 	// Reply: ACLOIDCCompleteAuthResponse
 	ACLOIDCCompleteAuthRPCMethod = "ACL.OIDCCompleteAuth"
+
+	// ACLLoginRPCMethod is the RPC method for performing a non-OIDC login
+	// workflow. It exchanges the provided token for a Nomad ACL token with
+	// roles as defined within the remote provider.
+	//
+	// Args: ACLLoginRequest
+	// Reply: ACLLoginResponse
+	ACLLoginRPCMethod = "ACL.Login"
 )
 
 const (
@@ -185,6 +193,23 @@ const (
 	// maxACLBindingRuleDescriptionLength limits an ACL binding rules
 	// description length and should be used to validate the object.
 	maxACLBindingRuleDescriptionLength = 256
+
+	// ACLAuthMethodTokenLocalityLocal is the ACLAuthMethod.TokenLocality that
+	// will generate ACL tokens which can only be used on the local cluster the
+	// request was made.
+	ACLAuthMethodTokenLocalityLocal = "local"
+
+	// ACLAuthMethodTokenLocalityGlobal is the ACLAuthMethod.TokenLocality that
+	// will generate ACL tokens which can be used on all federated clusters.
+	ACLAuthMethodTokenLocalityGlobal = "global"
+
+	// ACLAuthMethodTypeOIDC the ACLAuthMethod.Type and represents an
+	// auth-method which uses the OIDC protocol.
+	ACLAuthMethodTypeOIDC = "OIDC"
+
+	// ACLAuthMethodTypeJWT the ACLAuthMethod.Type and represents an auth-method
+	// which uses the JWT type.
+	ACLAuthMethodTypeJWT = "JWT"
 )
 
 var (
@@ -193,6 +218,9 @@ var (
 
 	// ValidACLAuthMethod is used to validate an ACL auth method name.
 	ValidACLAuthMethod = regexp.MustCompile("^[a-zA-Z0-9-]{1,128}$")
+
+	// ValitACLAuthMethodTypes lists supported auth method types.
+	ValidACLAuthMethodTypes = []string{ACLAuthMethodTypeOIDC, ACLAuthMethodTypeJWT}
 )
 
 type ACLCacheEntry[T any] lang.Pair[T, time.Time]
@@ -895,7 +923,7 @@ func (a *ACLAuthMethod) Validate(minTTL, maxTTL time.Duration) error {
 			mErr.Errors, fmt.Errorf("invalid token locality '%s'", a.TokenLocality))
 	}
 
-	if a.Type != "OIDC" {
+	if !slices.Contains(ValidACLAuthMethodTypes, a.Type) {
 		mErr.Errors = append(
 			mErr.Errors, fmt.Errorf("invalid token type '%s'", a.Type))
 	}
@@ -989,6 +1017,93 @@ func (a *ACLAuthMethodConfig) Copy() *ACLAuthMethodConfig {
 	c.SigningAlgs = slices.Clone(a.SigningAlgs)
 
 	return c
+}
+
+// MarshalJSON implements the json.Marshaler interface and allows
+// time.Diration fields to be marshaled correctly.
+func (a *ACLAuthMethodConfig) MarshalJSON() ([]byte, error) {
+	type Alias ACLAuthMethodConfig
+	exported := &struct {
+		ExpirationLeeway string
+		NotBeforeLeeway  string
+		ClockSkewLeeway  string
+		*Alias
+	}{
+		ExpirationLeeway: a.ExpirationLeeway.String(),
+		NotBeforeLeeway:  a.NotBeforeLeeway.String(),
+		ClockSkewLeeway:  a.ClockSkewLeeway.String(),
+		Alias:            (*Alias)(a),
+	}
+	if a.ExpirationLeeway == 0 {
+		exported.ExpirationLeeway = ""
+	}
+	if a.NotBeforeLeeway == 0 {
+		exported.NotBeforeLeeway = ""
+	}
+	if a.ClockSkewLeeway == 0 {
+		exported.ClockSkewLeeway = ""
+	}
+	return json.Marshal(exported)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface and allows
+// time.Duration fields to be unmarshalled correctly.
+func (a *ACLAuthMethodConfig) UnmarshalJSON(data []byte) (err error) {
+	type Alias ACLAuthMethodConfig
+	aux := &struct {
+		ExpirationLeeway any
+		NotBeforeLeeway  any
+		ClockSkewLeeway  any
+		*Alias
+	}{
+		Alias: (*Alias)(a),
+	}
+	if err = json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if aux.ExpirationLeeway != nil {
+		switch v := aux.ExpirationLeeway.(type) {
+		case string:
+			if v != "" {
+				if a.ExpirationLeeway, err = time.ParseDuration(v); err != nil {
+					return err
+				}
+			}
+		case float64:
+			a.ExpirationLeeway = time.Duration(v)
+		default:
+			return fmt.Errorf("unexpected ExpirationLeeway type: %v", v)
+		}
+	}
+	if aux.NotBeforeLeeway != nil {
+		switch v := aux.NotBeforeLeeway.(type) {
+		case string:
+			if v != "" {
+				if a.NotBeforeLeeway, err = time.ParseDuration(v); err != nil {
+					return err
+				}
+			}
+		case float64:
+			a.NotBeforeLeeway = time.Duration(v)
+		default:
+			return fmt.Errorf("unexpected NotBeforeLeeway type: %v", v)
+		}
+	}
+	if aux.ClockSkewLeeway != nil {
+		switch v := aux.ClockSkewLeeway.(type) {
+		case string:
+			if v != "" {
+				if a.ClockSkewLeeway, err = time.ParseDuration(v); err != nil {
+					return err
+				}
+			}
+		case float64:
+			a.ClockSkewLeeway = time.Duration(v)
+		default:
+			return fmt.Errorf("unexpected ClockSkewLeeway type: %v", v)
+		}
+	}
+	return nil
 }
 
 // ACLAuthClaims is the claim mapping of the OIDC auth method in a format that
@@ -1480,9 +1595,39 @@ func (a *ACLOIDCCompleteAuthRequest) Validate() error {
 	return mErr.ErrorOrNil()
 }
 
-// ACLOIDCCompleteAuthResponse is the response when the OIDC auth flow has been
+// ACLLoginResponse is the response when the auth flow has been
 // completed successfully.
-type ACLOIDCCompleteAuthResponse struct {
+type ACLLoginResponse struct {
 	ACLToken *ACLToken
 	WriteMeta
+}
+
+// ACLLoginRequest is the request object to begin auth with an external
+// token provider.
+type ACLLoginRequest struct {
+
+	// AuthMethodName is the name of the auth method being used to login. This
+	// is a required parameter.
+	AuthMethodName string
+
+	// LoginToken is the 3rd party token that we use to exchange for Nomad ACL
+	// Token in order to authenticate. This is a required parameter.
+	LoginToken string
+
+	WriteRequest
+}
+
+// Validate ensures the request object contains all the required fields in
+// order to complete the authentication flow.
+func (a *ACLLoginRequest) Validate() error {
+
+	var mErr multierror.Error
+
+	if a.AuthMethodName == "" {
+		mErr.Errors = append(mErr.Errors, errors.New("missing auth method name"))
+	}
+	if a.LoginToken == "" {
+		mErr.Errors = append(mErr.Errors, errors.New("missing login token"))
+	}
+	return mErr.ErrorOrNil()
 }

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -915,16 +915,61 @@ func (a *ACLAuthMethod) TokenLocalityIsGlobal() bool { return a.TokenLocality ==
 
 // ACLAuthMethodConfig is used to store configuration of an auth method
 type ACLAuthMethodConfig struct {
-	OIDCDiscoveryURL    string
-	OIDCClientID        string
-	OIDCClientSecret    string
-	OIDCScopes          []string
-	BoundAudiences      []string
+	// A list of PEM-encoded public keys to use to authenticate signatures
+	// locally
+	JWTValidationPubKeys []string
+
+	// JSON Web Key Sets url for authenticating signatures
+	JWKSURL string
+
+	// The OIDC Discovery URL, without any .well-known component (base path)
+	OIDCDiscoveryURL string
+
+	// The OAuth Client ID configured with the OIDC provider
+	OIDCClientID string
+
+	// The OAuth Client Secret configured with the OIDC provider
+	OIDCClientSecret string
+
+	// List of OIDC scopes
+	OIDCScopes []string
+
+	// List of auth claims that are valid for login
+	BoundAudiences []string
+
+	// The value against which to match the iss claim in a JWT
+	BoundIssuer []string
+
+	// A list of allowed values for redirect_uri
 	AllowedRedirectURIs []string
-	DiscoveryCaPem      []string
-	SigningAlgs         []string
-	ClaimMappings       map[string]string
-	ListClaimMappings   map[string]string
+
+	// PEM encoded CA certs for use by the TLS client used to talk with the
+	// OIDC Discovery URL.
+	DiscoveryCaPem []string
+
+	// PEM encoded CA cert for use by the TLS client used to talk with the JWKS
+	// URL
+	JWKSCACert string
+
+	// A list of supported signing algorithms
+	SigningAlgs []string
+
+	// Duration in seconds of leeway when validating expiration of a token to
+	// account for clock skew
+	ExpirationLeeway time.Duration
+
+	// Duration in seconds of leeway when validating not before values of a
+	// token to account for clock skew.
+	NotBeforeLeeway time.Duration
+
+	// Duration in seconds of leeway when validating all claims to account for
+	// clock skew.
+	ClockSkewLeeway time.Duration
+
+	// Mappings of claims (key) that will be copied to a metadata field
+	// (value).
+	ClaimMappings     map[string]string
+	ListClaimMappings map[string]string
 }
 
 func (a *ACLAuthMethodConfig) Copy() *ACLAuthMethodConfig {
@@ -935,8 +980,10 @@ func (a *ACLAuthMethodConfig) Copy() *ACLAuthMethodConfig {
 	c := new(ACLAuthMethodConfig)
 	*c = *a
 
+	c.JWTValidationPubKeys = slices.Clone(a.JWTValidationPubKeys)
 	c.OIDCScopes = slices.Clone(a.OIDCScopes)
 	c.BoundAudiences = slices.Clone(a.BoundAudiences)
+	c.BoundIssuer = slices.Clone(a.BoundIssuer)
 	c.AllowedRedirectURIs = slices.Clone(a.AllowedRedirectURIs)
 	c.DiscoveryCaPem = slices.Clone(a.DiscoveryCaPem)
 	c.SigningAlgs = slices.Clone(a.SigningAlgs)

--- a/ui/app/adapters/token.js
+++ b/ui/app/adapters/token.js
@@ -21,15 +21,23 @@ export default class TokenAdapter extends ApplicationAdapter {
     return `${this.buildURL()}/${singularize(modelName)}/${identifier}`;
   }
 
-  findSelf() {
-    return this.ajax(`${this.buildURL()}/token/self`, 'GET').then((token) => {
-      const store = this.store;
-      store.pushPayload('token', {
-        tokens: [token],
-      });
+  async findSelf() {
+    const response = await this.ajax(`${this.buildURL()}/token/self`, 'GET');
+    const normalized = this.store.normalize('token', response);
+    const tokenRecord = this.store.push(normalized);
+    return tokenRecord;
+  }
 
-      return store.peekRecord('token', store.normalize('token', token).data.id);
+  async loginJWT(LoginToken, AuthMethodName) {
+    const response = await this.ajax(`${this.buildURL()}/login`, 'POST', {
+      data: {
+        AuthMethodName,
+        LoginToken,
+      },
     });
+    const normalized = this.store.normalize('token', response);
+    const tokenRecord = this.store.push(normalized);
+    return tokenRecord;
   }
 
   exchangeOneTimeToken(oneTimeToken) {

--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -1,6 +1,5 @@
 // @ts-check
 import { inject as service } from '@ember/service';
-import { reads } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { getOwner } from '@ember/application';
 import { alias } from '@ember/object/computed';
@@ -9,18 +8,24 @@ import classic from 'ember-classic-decorator';
 import { tracked } from '@glimmer/tracking';
 import Ember from 'ember';
 
+/**
+ * @type {RegExp}
+ */
+const JWT_MATCH_EXPRESSION = /^[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+$/;
+
 @classic
 export default class Tokens extends Controller {
   @service token;
   @service store;
   @service router;
+  @service notifications;
 
-  queryParams = ['code', 'state'];
+  queryParams = ['code', 'state', 'jwtAuthMethod'];
 
-  @reads('token.secret') secret;
+  @tracked secret = this.token.secret;
 
   /**
-   * @type {(null | "success" | "failure")} signInStatus
+   * @type {(null | "success" | "failure" | "jwtFailure")} signInStatus
    */
   @tracked
   signInStatus = null;
@@ -44,35 +49,126 @@ export default class Tokens extends Controller {
     this.store.findAll('auth-method');
   }
 
+  /**
+   * @returns {import('@ember/array/mutable').default<import('../../models/auth-method').default>}
+   */
   get authMethods() {
-    return this.store.peekAll('auth-method');
+    return this.model?.authMethods || [];
+  }
+
+  get hasJWTAuthMethods() {
+    return this.authMethods.any((method) => method.type === 'JWT');
+  }
+
+  get nonTokenAuthMethods() {
+    return this.authMethods.rejectBy('type', 'JWT');
+  }
+
+  get JWTAuthMethods() {
+    return this.authMethods.filterBy('type', 'JWT');
+  }
+
+  get JWTAuthMethodOptions() {
+    return this.JWTAuthMethods.map((method) => ({
+      key: method.name,
+      label: method.name,
+    }));
+  }
+
+  get defaultJWTAuthMethod() {
+    return (
+      this.JWTAuthMethods.findBy('default', true) || this.JWTAuthMethods[0]
+    );
   }
 
   @action
-  verifyToken() {
+  setCurrentAuthMethod() {
+    if (!this.jwtAuthMethod) {
+      this.jwtAuthMethod = this.defaultJWTAuthMethod?.name;
+    }
+  }
+
+  /**
+   * @type {string}
+   */
+  @tracked jwtAuthMethod;
+
+  /**
+   * @type {boolean}
+   */
+  get currentSecretIsJWT() {
+    return this.secret?.length > 36 && this.secret.match(JWT_MATCH_EXPRESSION);
+  }
+
+  @action
+  async verifyToken() {
     const { secret } = this;
-    this.clearTokenProperties();
+    /**
+     * @type {import('../../adapters/token').default}
+     */
+
+    // Ember currently lacks types for getOwner: https://github.com/emberjs/ember.js/issues/19916
+    // @ts-ignore
     const TokenAdapter = getOwner(this).lookup('adapter:token');
 
-    this.set('token.secret', secret);
-    this.set('secret', null);
+    const isJWT = secret.length > 36 && secret.match(JWT_MATCH_EXPRESSION);
 
-    TokenAdapter.findSelf().then(
-      () => {
-        // Clear out all data to ensure only data the new token is privileged to see is shown
-        this.resetStore();
+    if (isJWT) {
+      const methodName = this.jwtAuthMethod;
 
-        // Refetch the token and associated policies
-        this.get('token.fetchSelfTokenAndPolicies').perform().catch();
-
-        this.signInStatus = 'success';
-        this.token.set('tokenNotFound', false);
-      },
-      () => {
-        this.set('token.secret', undefined);
-        this.signInStatus = 'failure';
+      // If user passes a JWT token, but there is no JWT auth method, throw an error
+      if (!methodName) {
+        this.token.set('secret', undefined);
+        this.signInStatus = 'jwtFailure';
+        return;
       }
-    );
+
+      this.clearTokenProperties();
+
+      // Set bearer token instead of findSelf etc.
+      TokenAdapter.loginJWT(secret, methodName).then(
+        (token) => {
+          this.token.setProperties({
+            secret: token.secret,
+            tokenNotFound: false,
+          });
+          this.set('secret', null);
+
+          // Clear out all data to ensure only data the new token is privileged to see is shown
+          this.resetStore();
+
+          // Refetch the token and associated policies
+          this.token.get('fetchSelfTokenAndPolicies').perform().catch();
+
+          this.signInStatus = 'success';
+        },
+        () => {
+          this.token.set('secret', undefined);
+          this.signInStatus = 'failure';
+        }
+      );
+    } else {
+      this.clearTokenProperties();
+      this.token.set('secret', secret);
+      this.set('secret', null);
+
+      TokenAdapter.findSelf().then(
+        () => {
+          // Clear out all data to ensure only data the new token is privileged to see is shown
+          this.resetStore();
+
+          // Refetch the token and associated policies
+          this.token.get('fetchSelfTokenAndPolicies').perform().catch();
+
+          this.signInStatus = 'success';
+          this.token.set('tokenNotFound', false);
+        },
+        () => {
+          this.token.set('secret', undefined);
+          this.signInStatus = 'failure';
+        }
+      );
+    }
   }
 
   // Generate a 20-char nonce, using window.crypto to
@@ -158,7 +254,7 @@ export default class Tokens extends Controller {
       this.code = null;
 
       // Refetch the token and associated policies
-      this.get('token.fetchSelfTokenAndPolicies').perform().catch();
+      this.token.get('fetchSelfTokenAndPolicies').perform().catch();
 
       this.signInStatus = 'success';
       this.token.set('tokenNotFound', false);

--- a/ui/app/models/auth-method.js
+++ b/ui/app/models/auth-method.js
@@ -4,6 +4,10 @@ import { attr } from '@ember-data/model';
 
 export default class AuthMethodModel extends Model {
   @attr('string') name;
+
+  /**
+   * @type {'JWT' | 'OIDC'}
+   */
   @attr('string') type;
   @attr('string') tokenLocality;
   @attr('string') maxTokenTTL;

--- a/ui/app/styles/components/authorization.scss
+++ b/ui/app/styles/components/authorization.scss
@@ -1,7 +1,7 @@
 .authorization-page {
-
   .sign-in-methods {
-    h3, p {
+    h3,
+    p {
       margin-bottom: 1.5rem;
     }
 
@@ -30,7 +30,7 @@
       border-bottom: 1px solid $ui-gray-200;
       position: relative;
       top: 50%;
-      content: "";
+      content: '';
       display: block;
       width: 100%;
       height: 0px;
@@ -46,5 +46,10 @@
       align-content: center;
       display: inline-grid;
     }
+  }
+
+  .control.with-jwt-selector {
+    display: flex;
+    gap: 0.5rem;
   }
 }

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -18,6 +18,17 @@
         </div>
       {{/if}}
 
+      {{#if (eq this.signInStatus "jwtFailure")}}
+        <div data-test-token-error class="notification is-danger">
+          <div class="columns">
+            <div class="column">
+              <h3 class="title is-4">JWT Failed to Authenticate</h3>
+              <p>You passed in a JWT, but no JWT auth methods were found</p>
+            </div>
+          </div>
+        </div>
+      {{/if}}
+
       {{#if this.tokenRecord.isExpired}}
         <div data-test-token-expired class="notification is-danger">
           <div class="columns">
@@ -72,11 +83,11 @@
     <div class="columns">
       {{#if this.canSignIn}}
         <div class="column is-half sign-in-methods">
-          {{#if this.authMethods.length}}
+          {{#if this.nonTokenAuthMethods.length}}
             <h3 class="title is-4">Sign in with SSO</h3>
             <p>Sign in to Nomad using the configured authorization provider. After logging in, the policies and rules for the token will be listed.</p>
             <div class="sso-auth-methods">
-              {{#each this.model.authMethods as |method|}}
+              {{#each this.nonTokenAuthMethods as |method|}}
                 <button
                   data-test-auth-method
                   class="button is-primary"
@@ -90,22 +101,40 @@
           {{/if}}
 
           <h3 class="title is-4">Sign in with token</h3>
-          <p>Clusters that use Access Control Lists require tokens to perform certain tasks. By providing a token Secret ID, each future request will be authenticated, potentially authorizing read access to additional information.</p>
-          <label class="label" for="token-input">Secret ID</label>
-          <div class="control">
+          <p>Clusters that use Access Control Lists require tokens to perform certain tasks. By providing a token Secret ID{{#if this.hasJWTAuthMethods}} or <a href="https://jwt.io/" target="_blank" rel="noopener noreferrer">JWT</a>{{/if}}, each future request will be authenticated, potentially authorizing read access to additional information.</p>
+          <label class="label" for="token-input">Secret ID{{#if this.hasJWTAuthMethods}} or JWT{{/if}}</label>
+          <div class="control {{if (and this.currentSecretIsJWT (gt this.JWTAuthMethods.length 1)) "with-jwt-selector"}}">
             <Input
               id="token-input"
               class="input"
               @type="text"
-              placeholder="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-              {{!-- FIXME this placeholder gets read out by VoiceOver sans dashes 😵 --}}
+              placeholder="{{if this.hasJWTAuthMethods "36-character token secret or JWT" "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"}}"
               {{autofocus}}
               {{on "input" (action (mut this.secret) value="target.value")}}
               @enter={{this.verifyToken}}
               data-test-token-secret />
+
+            {{#if this.currentSecretIsJWT}}
+              {{did-insert (action this.setCurrentAuthMethod)}}
+              {{#if (gt this.JWTAuthMethods.length 1)}}
+                <SingleSelectDropdown
+                  data-test-select-jwt
+                  @label="Sign-in method"
+                  @options={{this.JWTAuthMethodOptions}}
+                  @selection={{this.jwtAuthMethod}}
+                  @onSelect={{fn (mut this.jwtAuthMethod)}}
+                />
+              {{/if}}
+            {{/if}}
           </div>
           <p class="help">Sent with every request to determine authorization</p>
-          <button disabled={{not this.secret}} data-test-token-submit class="button is-primary" {{action "verifyToken"}} type="button">Set Token</button>
+          <button disabled={{not this.secret}} data-test-token-submit class="button is-primary" {{action "verifyToken"}} type="button">
+            {{#if this.currentSecretIsJWT}}
+              Sign in with JWT
+            {{else}}
+              Sign in with secret
+            {{/if}}
+          </button>
         </div>
       {{/if}}
 

--- a/ui/jsconfig.json
+++ b/ui/jsconfig.json
@@ -1,7 +1,7 @@
 {
-    "compilerOptions": {
-      "experimentalDecorators": true,
-      "target": "es5",
-    },
-
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "target": "es2015",
+    "moduleResolution": "node"
+  } 
 }

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -477,6 +477,23 @@ export default function () {
     return new Response(400, {}, null);
   });
 
+  this.post('/acl/login', function (schema, { requestBody }) {
+    const { LoginToken } = JSON.parse(requestBody);
+    const tokenType = LoginToken.endsWith('management')
+      ? 'management'
+      : 'client';
+    const isBad = LoginToken.endsWith('bad');
+
+    if (isBad) {
+      return new Response(403, {}, null);
+    } else {
+      const token = schema.tokens
+        .all()
+        .models.find((token) => token.type === tokenType);
+      return this.serialize(token);
+    }
+  });
+
   this.get('/acl/token/:id', function ({ tokens }, req) {
     const token = tokens.find(req.params.id);
     const secret = req.requestHeaders['X-Nomad-Token'];

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -238,6 +238,7 @@ function smallCluster(server) {
   server.create('auth-method', { name: 'vault' });
   server.create('auth-method', { name: 'auth0' });
   server.create('auth-method', { name: 'cognito' });
+  server.create('auth-method', { name: 'JWT-Local', type: 'JWT' });
 }
 
 function mediumCluster(server) {
@@ -570,6 +571,10 @@ Secret: ${token.secretId}
 Accessor: ${token.accessorId}
 
 `);
+
+    console.log(
+      'Alternatively, log in with a JWT. If it ends with `management`, you have full access. If it ends with `bad`, you`ll get an error. Otherwise, you`ll get a token with limited access.'
+    );
   });
 }
 

--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -61,7 +61,7 @@ The table below shows this endpoint's support for
 
   - `OIDCScopes` `(array<string>)` - List of OIDC scopes.
 
-  - `BoundAudiences` `(array<string>)` - List of auth claims that are valid for
+  - `BoundAudiences` `(array<string>)` - List of aud claims that are valid for
     login; any match is sufficient.
 
   - `AllowedRedirectURIs` `(array<string>)` - A list of allowed values for

--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -31,8 +31,7 @@ The table below shows this endpoint's support for
   Method.  The name can contain alphanumeric characters, dashes, and underscores.
   This name must be unique and must not exceed 128 characters.
 
-- `Type` `(string: <required>)` - ACL Auth Role SSO identifier. Currently, the
-  only supported Type is "OIDC."
+- `Type` `(string: <required>)` - ACL Auth Role SSO identifier.
 
 - `TokenLocality` `(string: <required>)` - Defines whether the ACL Auth Method
   creates a local or global token when performing SSO login. This field must be
@@ -62,7 +61,7 @@ The table below shows this endpoint's support for
 
   - `OIDCScopes` `(array<string>)` - List of OIDC scopes.
 
-  - `BoundAudiences` `(array<string>)` - List of aud claims that are valid for
+  - `BoundAudiences` `(array<string>)` - List of auth claims that are valid for
     login; any match is sufficient.
 
   - `AllowedRedirectURIs` `(array<string>)` - A list of allowed values for

--- a/website/content/docs/commands/acl/auth-method/create.mdx
+++ b/website/content/docs/commands/acl/auth-method/create.mdx
@@ -29,8 +29,7 @@ via flags detailed below.
 - `-description`: A free form text description of the auth-method that must not exceed
   256 characters.
 
-- `-type`: Sets the type of the auth method. Currently the only supported type
-  is `OIDC`.
+- `-type`: Sets the type of the auth method. Supported types are `OIDC` and `JWT`.
 
 - `-max-token-ttl`: Sets the duration of time all tokens created by this auth
   method should be valid for.

--- a/website/content/docs/commands/acl/auth-method/update.mdx
+++ b/website/content/docs/commands/acl/auth-method/update.mdx
@@ -37,8 +37,7 @@ The `acl auth-method update` command requires an existing method's name.
   to the command. Instead, overwrite all fields with the exception of the role
   ID which is immutable.
 
-- `-type`: Updates the type of the auth method. Currently the only supported
-  type is `OIDC`.
+- `-type`: Updates the type of the auth method. Supported types are `OIDC` and `JWT`.
 
 - `-max-token-ttl`: Updates the duration of time all tokens created by this auth
   method should be valid for.


### PR DESCRIPTION
This PR introduces a new ACL Auth Method: JWT, which allows users to exchange 3rd party JSON Web Tokens for Nomad ACL Tokens. We achieve this by:
- extending ACLAuthMethodConfig fields with JWT-specific properties
- a new RPC endpoint `ACL.Login`
- a new HTTP API endpoint `/v1/acl/login`
- adjustments to the CLI that allow for new `-type=JWT` when creating and updating auth methods, and to the `nomad login` command
- and adjustments to the sign in UI which now detects if there are JWT auth methods present, whether they are multiple and modifies the "sign in with token" field accordingly. 

All the changes mentioned above were described in [NMD-167](https://docs.google.com/document/d/1MqhdDpMqOYMT72PgdhxsGHmF0-WcK5425oxEBAkQRXo/edit), and all the commits in this pull request (except for changelog) were previously reviewed. 