### PR TITLE
Ensure infra_image gets proper label used for reconciliation

### DIFF
--- a/.changelog/15898.txt
+++ b/.changelog/15898.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: Fixed a bug where infra_image did not get alloc_id label
+```

--- a/drivers/docker/network.go
+++ b/drivers/docker/network.go
@@ -119,12 +119,14 @@ func (d *Driver) DestroyNetwork(allocID string, spec *drivers.NetworkIsolationSp
 // createSandboxContainerConfig creates a docker container configuration which
 // starts a container with an empty network namespace.
 func (d *Driver) createSandboxContainerConfig(allocID string, createSpec *drivers.NetworkCreateRequest) (*docker.CreateContainerOptions, error) {
-
 	return &docker.CreateContainerOptions{
 		Name: fmt.Sprintf("nomad_init_%s", allocID),
 		Config: &docker.Config{
 			Image:    d.config.InfraImage,
 			Hostname: createSpec.Hostname,
+			Labels: map[string]string{
+				dockerLabelAllocID: allocID,
+			},
 		},
 		HostConfig: &docker.HostConfig{
 			// Set the network mode to none which creates a network namespace

--- a/drivers/docker/network_test.go
+++ b/drivers/docker/network_test.go
@@ -26,6 +26,9 @@ func TestDriver_createSandboxContainerConfig(t *testing.T) {
 				Name: "nomad_init_768b5e8c-a52e-825c-d564-51100230eb62",
 				Config: &docker.Config{
 					Image: "gcr.io/google_containers/pause-amd64:3.1",
+					Labels: map[string]string{
+						dockerLabelAllocID: "768b5e8c-a52e-825c-d564-51100230eb62",
+					},
 				},
 				HostConfig: &docker.HostConfig{
 					NetworkMode:   "none",
@@ -44,6 +47,9 @@ func TestDriver_createSandboxContainerConfig(t *testing.T) {
 				Config: &docker.Config{
 					Image:    "gcr.io/google_containers/pause-amd64:3.1",
 					Hostname: "linux",
+					Labels: map[string]string{
+						dockerLabelAllocID: "768b5e8c-a52e-825c-d564-51100230eb62",
+					},
 				},
 				HostConfig: &docker.HostConfig{
 					NetworkMode:   "none",


### PR DESCRIPTION
Currently infra containers are not cleaned up as part of the dangling container cleanup routine. The reason is that Nomad checks if a container is a Nomad owned container by verifying the existence of the: `com.hashicorp.nomad.alloc_id` label.

Ensure we set this label on the infra container as well.