### PR TITLE
metrics: Add RPC rate metrics to endpoints that validate TLS names

### DIFF
--- a/.semgrep/rpc_metrics.yml
+++ b/.semgrep/rpc_metrics.yml
@@ -1,0 +1,18 @@
+rules:
+  # Check for server RPC endpoints without metrics
+  - id: "rpc-missing-metrics"
+    patterns:
+      - pattern: |
+          authErr := $A.$B.Authenticate($A.ctx, args)
+      - pattern-not-inside: |
+          authErr := $A.$B.Authenticate($A.ctx, args)
+          ...
+          $T.srv.MeasureRPCRate(...)
+          ...
+    message: "RPC method appears to be missing metrics"
+    languages:
+      - "go"
+    severity: "WARNING"
+    paths:
+      include:
+        - "nomad/*_endpoint.go"

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -197,14 +197,19 @@ func (a *Alloc) GetAlloc(args *structs.AllocSpecificRequest,
 func (a *Alloc) GetAllocs(args *structs.AllocsGetRequest,
 	reply *structs.AllocsGetResponse) error {
 
+	authErr := a.srv.Authenticate(a.ctx, args)
+
 	// Ensure the connection was initiated by a client if TLS is used.
 	err := validateTLSCertificateLevel(a.srv, a.ctx, tlsCertificateLevelClient)
 	if err != nil {
 		return err
 	}
-
 	if done, err := a.srv.forward("Alloc.GetAllocs", args, args, reply); done {
 		return err
+	}
+	a.srv.MeasureRPCRate("alloc", structs.RateMetricList, args)
+	if authErr != nil {
+		return structs.ErrPermissionDenied
 	}
 	defer metrics.MeasureSince([]string{"nomad", "alloc", "get_allocs"}, time.Now())
 

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -124,7 +124,6 @@ func (e *Eval) Dequeue(args *structs.EvalDequeueRequest,
 	if err != nil {
 		return err
 	}
-
 	if done, err := e.srv.forward("Eval.Dequeue", args, args, reply); done {
 		return err
 	}
@@ -132,7 +131,6 @@ func (e *Eval) Dequeue(args *structs.EvalDequeueRequest,
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}
-
 	defer metrics.MeasureSince([]string{"nomad", "eval", "dequeue"}, time.Now())
 
 	// Ensure there is at least one scheduler
@@ -233,14 +231,19 @@ func (e *Eval) getWaitIndex(namespace, job string, evalModifyIndex uint64) (uint
 func (e *Eval) Ack(args *structs.EvalAckRequest,
 	reply *structs.GenericResponse) error {
 
+	authErr := e.srv.Authenticate(e.ctx, args)
+
 	// Ensure the connection was initiated by another server if TLS is used.
 	err := validateTLSCertificateLevel(e.srv, e.ctx, tlsCertificateLevelServer)
 	if err != nil {
 		return err
 	}
-
 	if done, err := e.srv.forward("Eval.Ack", args, args, reply); done {
 		return err
+	}
+	e.srv.MeasureRPCRate("eval", structs.RateMetricWrite, args)
+	if authErr != nil {
+		return structs.ErrPermissionDenied
 	}
 	defer metrics.MeasureSince([]string{"nomad", "eval", "ack"}, time.Now())
 
@@ -263,14 +266,19 @@ func (e *Eval) Ack(args *structs.EvalAckRequest,
 func (e *Eval) Nack(args *structs.EvalAckRequest,
 	reply *structs.GenericResponse) error {
 
+	authErr := e.srv.Authenticate(e.ctx, args)
+
 	// Ensure the connection was initiated by another server if TLS is used.
 	err := validateTLSCertificateLevel(e.srv, e.ctx, tlsCertificateLevelServer)
 	if err != nil {
 		return err
 	}
-
 	if done, err := e.srv.forward("Eval.Nack", args, args, reply); done {
 		return err
+	}
+	e.srv.MeasureRPCRate("eval", structs.RateMetricWrite, args)
+	if authErr != nil {
+		return structs.ErrPermissionDenied
 	}
 	defer metrics.MeasureSince([]string{"nomad", "eval", "nack"}, time.Now())
 
@@ -285,14 +293,19 @@ func (e *Eval) Nack(args *structs.EvalAckRequest,
 func (e *Eval) Update(args *structs.EvalUpdateRequest,
 	reply *structs.GenericResponse) error {
 
+	authErr := e.srv.Authenticate(e.ctx, args)
+
 	// Ensure the connection was initiated by another server if TLS is used.
 	err := validateTLSCertificateLevel(e.srv, e.ctx, tlsCertificateLevelServer)
 	if err != nil {
 		return err
 	}
-
 	if done, err := e.srv.forward("Eval.Update", args, args, reply); done {
 		return err
+	}
+	e.srv.MeasureRPCRate("eval", structs.RateMetricWrite, args)
+	if authErr != nil {
+		return structs.ErrPermissionDenied
 	}
 	defer metrics.MeasureSince([]string{"nomad", "eval", "update"}, time.Now())
 
@@ -322,14 +335,19 @@ func (e *Eval) Update(args *structs.EvalUpdateRequest,
 func (e *Eval) Create(args *structs.EvalUpdateRequest,
 	reply *structs.GenericResponse) error {
 
+	authErr := e.srv.Authenticate(e.ctx, args)
+
 	// Ensure the connection was initiated by another server if TLS is used.
 	err := validateTLSCertificateLevel(e.srv, e.ctx, tlsCertificateLevelServer)
 	if err != nil {
 		return err
 	}
-
 	if done, err := e.srv.forward("Eval.Create", args, args, reply); done {
 		return err
+	}
+	e.srv.MeasureRPCRate("eval", structs.RateMetricWrite, args)
+	if authErr != nil {
+		return structs.ErrPermissionDenied
 	}
 	defer metrics.MeasureSince([]string{"nomad", "eval", "create"}, time.Now())
 
@@ -373,14 +391,20 @@ func (e *Eval) Create(args *structs.EvalUpdateRequest,
 // Reblock is used to reinsert an existing blocked evaluation into the blocked
 // evaluation tracker.
 func (e *Eval) Reblock(args *structs.EvalUpdateRequest, reply *structs.GenericResponse) error {
+
+	authErr := e.srv.Authenticate(e.ctx, args)
+
 	// Ensure the connection was initiated by another server if TLS is used.
 	err := validateTLSCertificateLevel(e.srv, e.ctx, tlsCertificateLevelServer)
 	if err != nil {
 		return err
 	}
-
 	if done, err := e.srv.forward("Eval.Reblock", args, args, reply); done {
 		return err
+	}
+	e.srv.MeasureRPCRate("eval", structs.RateMetricWrite, args)
+	if authErr != nil {
+		return structs.ErrPermissionDenied
 	}
 	defer metrics.MeasureSince([]string{"nomad", "eval", "reblock"}, time.Now())
 
@@ -422,14 +446,19 @@ func (e *Eval) Reblock(args *structs.EvalUpdateRequest, reply *structs.GenericRe
 func (e *Eval) Reap(args *structs.EvalReapRequest,
 	reply *structs.GenericResponse) error {
 
+	authErr := e.srv.Authenticate(e.ctx, args)
+
 	// Ensure the connection was initiated by another server if TLS is used.
 	err := validateTLSCertificateLevel(e.srv, e.ctx, tlsCertificateLevelServer)
 	if err != nil {
 		return err
 	}
-
 	if done, err := e.srv.forward("Eval.Reap", args, args, reply); done {
 		return err
+	}
+	e.srv.MeasureRPCRate("eval", structs.RateMetricWrite, args)
+	if authErr != nil {
+		return structs.ErrPermissionDenied
 	}
 	defer metrics.MeasureSince([]string{"nomad", "eval", "reap"}, time.Now())
 

--- a/nomad/plan_endpoint.go
+++ b/nomad/plan_endpoint.go
@@ -23,14 +23,20 @@ func NewPlanEndpoint(srv *Server, ctx *RPCContext) *Plan {
 
 // Submit is used to submit a plan to the leader
 func (p *Plan) Submit(args *structs.PlanRequest, reply *structs.PlanResponse) error {
+
+	authErr := p.srv.Authenticate(p.ctx, args)
+
 	// Ensure the connection was initiated by another server if TLS is used.
 	err := validateTLSCertificateLevel(p.srv, p.ctx, tlsCertificateLevelServer)
 	if err != nil {
 		return err
 	}
-
 	if done, err := p.srv.forward("Plan.Submit", args, args, reply); done {
 		return err
+	}
+	p.srv.MeasureRPCRate("plan", structs.RateMetricWrite, args)
+	if authErr != nil {
+		return structs.ErrPermissionDenied
 	}
 	defer metrics.MeasureSince([]string{"nomad", "plan", "submit"}, time.Now())
 


### PR DESCRIPTION
Continues the work done in #15876 by extending rate metrics measurement over the various RPCs that are authenticated via TLS name validation. This changeset also canonicalizes the order-of-operations between `Authenticate` and that validation. We call `Authenticate` first so that we get identity info like the remote IP address. This changeset doesn't change the existing behavior that drops the RPC before forwarding; I think that's worth having a discussion about but I didn't want to bloat this PR with behavior changes.