### PR TITLE
artifact: enable reading system git/mercurial configuration

### DIFF
--- a/client/allocrunner/taskrunner/getter/util_linux.go
+++ b/client/allocrunner/taskrunner/getter/util_linux.go
@@ -3,6 +3,7 @@
 package getter
 
 import (
+	"os"
 	"path/filepath"
 	"syscall"
 
@@ -77,6 +78,34 @@ func lockdown(allocDir, taskDir string) error {
 		landlock.Dir(allocDir, "rwc"),
 		landlock.Dir(taskDir, "rwc"),
 	}
+	paths = append(paths, systemVersionControlGlobalConfigs()...)
 	locker := landlock.New(paths...)
 	return locker.Lock(landlock.Mandatory)
+}
+
+func systemVersionControlGlobalConfigs() []*landlock.Path {
+	const (
+		gitGlobalFile = "/etc/gitconfig"        // https://git-scm.com/docs/git-config#SCOPES
+		hgGlobalFile  = "/etc/mercurial/hgrc"   // https://www.mercurial-scm.org/doc/hgrc.5.html#files
+		hgGlobalDir   = "/etc/mercurial/hgrc.d" // https://www.mercurial-scm.org/doc/hgrc.5.html#files
+	)
+	return loadVersionControlGlobalConfigs(gitGlobalFile, hgGlobalFile, hgGlobalDir)
+}
+
+func loadVersionControlGlobalConfigs(gitGlobalFile, hgGlobalFile, hgGlobalDir string) []*landlock.Path {
+	exists := func(p string) bool {
+		_, err := os.Stat(p)
+		return err == nil
+	}
+	result := make([]*landlock.Path, 0, 3)
+	if exists(gitGlobalFile) {
+		result = append(result, landlock.File(gitGlobalFile, "r"))
+	}
+	if exists(hgGlobalFile) {
+		result = append(result, landlock.File(hgGlobalFile, "r"))
+	}
+	if exists(hgGlobalDir) {
+		result = append(result, landlock.Dir(hgGlobalDir, "r"))
+	}
+	return result
 }

--- a/client/allocrunner/taskrunner/getter/util_test.go
+++ b/client/allocrunner/taskrunner/getter/util_test.go
@@ -2,12 +2,15 @@ package getter
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/testutil"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/go-landlock"
 	"github.com/shoenig/test/must"
 )
 
@@ -182,4 +185,32 @@ func TestUtil_environment(t *testing.T) {
 			"TMPDIR=/a/b/c/tmp",
 		}, result)
 	})
+}
+
+func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
+	const filePerm = 0o644
+	const dirPerm = 0o755
+	fakeEtc := t.TempDir()
+
+	var (
+		gitFile = filepath.Join(fakeEtc, "gitconfig")
+		hgFile  = filepath.Join(fakeEtc, "hgrc")
+		hgDir   = filepath.Join(fakeEtc, "hgrc.d")
+	)
+
+	err := os.WriteFile(gitFile, []byte("git"), filePerm)
+	must.NoError(t, err)
+
+	err = os.WriteFile(hgFile, []byte("hg"), filePerm)
+	must.NoError(t, err)
+
+	err = os.Mkdir(hgDir, dirPerm)
+	must.NoError(t, err)
+
+	paths := loadVersionControlGlobalConfigs(gitFile, hgFile, hgDir)
+	must.SliceEqual(t, []*landlock.Path{
+		landlock.File(gitFile, "r"),
+		landlock.File(hgFile, "r"),
+		landlock.Dir(hgDir, "r"),
+	}, paths)
 }


### PR DESCRIPTION
This PR adjusts the artifact sandbox on Linux to enable reading from known
system-wide git or mercurial configuration, if they exist.

Folks doing something odd like specifying custom paths for global config will
need to use the standard locations, or disable artifact filesystem isolation.

Closes #15498
