### PR TITLE
metrics: Add rate metrics to Client CSI endpoints

### DIFF
--- a/nomad/client_csi_endpoint_test.go
+++ b/nomad/client_csi_endpoint_test.go
@@ -428,7 +428,7 @@ func TestClientCSI_NodeForControllerPlugin(t *testing.T) {
 	plugin, err := state.CSIPluginByID(ws, "minnie")
 	require.NoError(t, err)
 
-	clientCSI := NewClientCSIEndpoint(srv)
+	clientCSI := NewClientCSIEndpoint(srv, nil)
 	nodeIDs, err := clientCSI.clientIDsForController(plugin.ID)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(nodeIDs))

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1254,7 +1254,6 @@ func (s *Server) setupStreamingEndpoints(server *rpc.Server) {
 // handlers can have per-connection context.
 func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) {
 	// These endpoints are client RPCs and don't include a connection context
-	_ = server.Register(NewClientCSIEndpoint(s))
 	_ = server.Register(NewClientStatsEndpoint(s))
 
 	// These endpoints have their streaming component registered in
@@ -1270,6 +1269,7 @@ func (s *Server) setupRpcServer(server *rpc.Server, ctx *RPCContext) {
 
 	_ = server.Register(NewACLEndpoint(s, ctx))
 	_ = server.Register(NewAllocEndpoint(s, ctx))
+	_ = server.Register(NewClientCSIEndpoint(s, ctx))
 	_ = server.Register(NewCSIVolumeEndpoint(s, ctx))
 	_ = server.Register(NewCSIPluginEndpoint(s, ctx))
 	_ = server.Register(NewDeploymentEndpoint(s, ctx))


### PR DESCRIPTION
Continues the work done in https://github.com/hashicorp/nomad/pull/15876 by extending rate metrics measurement over client CSI endpoints (the last batch of stuff!)

Also tightens up authentication for these endpoints by enforcing the server certificate name is valid. We protect these endpoints currently by mTLS and can't use an auth token because these endpoints are (uniquely) called by the leader and followers for a given node won't have the leader's ephemeral ACL token. Add a certificate name check that requests come from a server and not a client, because no client should ever send these RPCs directly.