### PR TITLE
ui: scope variables form footer style

### DIFF
--- a/ui/app/styles/components/variables.scss
+++ b/ui/app/styles/components/variables.scss
@@ -116,6 +116,18 @@
       margin: 1rem 0;
     }
   }
+
+  footer {
+    display: grid;
+    grid-auto-columns: max-content;
+    grid-auto-flow: column;
+    gap: 1rem;
+
+    .button.is-info.is-inverted.add-more[disabled] {
+      border-color: #dbdbdb;
+      box-shadow: 0 2px 0 0 rgb(122 122 122 / 20%);
+    }
+  }
 }
 
 table.path-tree {
@@ -178,17 +190,5 @@ table.variable-items {
   100% {
     top: 0px;
     opacity: 1;
-  }
-}
-
-footer {
-  display: grid;
-  grid-auto-columns: max-content;
-  grid-auto-flow: column;
-  gap: 1rem;
-
-  .button.is-info.is-inverted.add-more[disabled] {
-    border-color: #dbdbdb;
-    box-shadow: 0 2px 0 0 rgb(122 122 122 / 20%);
   }
 }


### PR DESCRIPTION
Scope the `footer` tag SCSS rule for the New Variable form to prevent it from affecting other `<footer>` elements, such as the gutter menu Nomad version section.

Currently `main` looks like this:
<img width="276" alt="image" src="https://user-images.githubusercontent.com/775380/214943746-b544cb9e-1946-45d7-83db-e2bba2d312b2.png">

With this change it centralizes properly again:
<img width="275" alt="image" src="https://user-images.githubusercontent.com/775380/214943870-00889e3f-6d69-4e71-951c-361da3dc8032.png">

No changelog or backport necessary since this is only in `main`.