### PR TITLE
ui: fix alloc memory stats to match CLI output

### DIFF
--- a/.changelog/15909.txt
+++ b/.changelog/15909.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix allocation memory chart to display the same value as the CLI
+```

--- a/ui/tests/unit/utils/allocation-stats-tracker-test.js
+++ b/ui/tests/unit/utils/allocation-stats-tracker-test.js
@@ -54,7 +54,7 @@ module('Unit | Util | AllocationStatsTracker', function () {
       },
       MemoryStats: {
         RSS: (step + 400) * 1024 * 1024,
-        Usage: (step + 400) * 1024 * 1024,
+        Usage: (step + 800) * 1024 * 1024,
       },
     },
     Tasks: {
@@ -65,7 +65,7 @@ module('Unit | Util | AllocationStatsTracker', function () {
           },
           MemoryStats: {
             RSS: (step + 100) * 1024 * 1024,
-            Usage: (step + 100) * 1024 * 1024,
+            Usage: (step + 200) * 1024 * 1024,
           },
         },
         Timestamp: refDate + step,
@@ -77,7 +77,7 @@ module('Unit | Util | AllocationStatsTracker', function () {
           },
           MemoryStats: {
             RSS: (step + 50) * 1024 * 1024,
-            Usage: (step + 50) * 1024 * 1024,
+            Usage: (step + 100) * 1024 * 1024,
           },
         },
         Timestamp: refDate + step * 10,
@@ -89,7 +89,7 @@ module('Unit | Util | AllocationStatsTracker', function () {
           },
           MemoryStats: {
             RSS: (step + 51) * 1024 * 1024,
-            Usage: (step + 51) * 1024 * 1024,
+            Usage: (step + 101) * 1024 * 1024,
           },
         },
         Timestamp: refDate + step * 100,


### PR DESCRIPTION
Match memory usage logic with the [CLI](https://github.com/hashicorp/nomad/blob/v1.4.3/command/alloc_status.go#L623-L628).

Closes #15830