### PR TITLE
[ui] Dynamic Node Metadata editing

### DIFF
--- a/ui/app/adapters/node.js
+++ b/ui/app/adapters/node.js
@@ -61,4 +61,16 @@ export default class NodeAdapter extends Watchable {
       },
     });
   }
+
+  getMeta(node) {
+    const url = `/v1/client/metadata?node_id=${node.id}`;
+    return this.ajax(url, 'GET');
+  }
+
+  addMeta(node, newMeta) {
+    const url = `/v1/client/metadata?node_id=${node.id}`;
+    return this.ajax(url, 'POST', {
+      data: {Meta: newMeta},
+    });
+  }
 }

--- a/ui/app/adapters/node.js
+++ b/ui/app/adapters/node.js
@@ -62,11 +62,6 @@ export default class NodeAdapter extends Watchable {
     });
   }
 
-  getMeta(node) {
-    const url = `/v1/client/metadata?node_id=${node.id}`;
-    return this.ajax(url, 'GET');
-  }
-
   addMeta(node, newMeta) {
     const url = `/v1/client/metadata?node_id=${node.id}`;
     return this.ajax(url, 'POST', {

--- a/ui/app/adapters/node.js
+++ b/ui/app/adapters/node.js
@@ -65,7 +65,7 @@ export default class NodeAdapter extends Watchable {
   addMeta(node, newMeta) {
     const url = `/v1/client/metadata?node_id=${node.id}`;
     return this.ajax(url, 'POST', {
-      data: {Meta: newMeta},
+      data: { Meta: newMeta },
     });
   }
 }

--- a/ui/app/components/metadata-editor.hbs
+++ b/ui/app/components/metadata-editor.hbs
@@ -1,0 +1,32 @@
+<form class="metadata-editor">
+  <h3 class="title is-6">Add Dynamic Metadata</h3>
+  <label>
+    <strong>Key</strong>
+    <Input
+      id="new-meta-key"
+      @type="text"
+      @value={{@kv.key}}
+      class="input"
+      {{on "input" (fn @onEdit @kv)}}
+    />
+  </label>
+  <label>
+    <strong>Value</strong>
+    <Input
+      @type="text"
+      @value={{@kv.value}}
+      class="input"
+      {{on "input" (fn @onEdit @kv)}}
+    />
+  </label>
+  <footer>
+    <button
+      disabled={{or (not @kv.key) (not @kv.value)}}
+      type="submit"
+      class="button is-primary"
+      {{on "click" (action @onSave)}}
+    >
+      Add {{@kv.key}} to node metadata
+    </button>
+  </footer>
+</form>

--- a/ui/app/components/metadata-editor.hbs
+++ b/ui/app/components/metadata-editor.hbs
@@ -1,32 +1,38 @@
 <form class="metadata-editor">
-  <h3 class="title is-6">Add Dynamic Metadata</h3>
   <label>
     <strong>Key</strong>
-    <Input
-      id="new-meta-key"
-      @type="text"
-      @value={{@kv.key}}
-      class="input"
-      {{on "input" (fn @onEdit @kv)}}
-    />
+    {{#if @constantKey}}
+      <span class="constant-key">{{@kv.key}}</span>
+    {{else}}
+      <Input
+        id="new-meta-key"
+        @type="text"
+        @value={{@kv.key}}
+        class="input"
+        {{on "input" (fn @onEdit @kv)}}
+      />
+    {{/if}}
   </label>
   <label>
     <strong>Value</strong>
-    <Input
-      @type="text"
-      @value={{@kv.value}}
-      class="input"
-      {{on "input" (fn @onEdit @kv)}}
-    />
+    {{#if @autofocusValue}}
+      <Input
+        @type="text"
+        @value={{@kv.value}}
+        class="input"
+        {{autofocus}}
+        {{on "input" (fn @onEdit @kv)}}
+      />
+    {{else}}
+      <Input
+        @type="text"
+        @value={{@kv.value}}
+        class="input"
+        {{on "input" (fn @onEdit @kv)}}
+      />
+    {{/if}}
   </label>
   <footer>
-    <button
-      disabled={{or (not @kv.key) (not @kv.value)}}
-      type="submit"
-      class="button is-primary"
-      {{on "click" (action @onSave)}}
-    >
-      Add {{@kv.key}} to node metadata
-    </button>
+    {{yield}}
   </footer>
 </form>

--- a/ui/app/components/metadata-editor.hbs
+++ b/ui/app/components/metadata-editor.hbs
@@ -5,6 +5,7 @@
       <span class="constant-key">{{@kv.key}}</span>
     {{else}}
       <Input
+        {{autofocus}}
         id="new-meta-key"
         @type="text"
         @value={{@kv.key}}

--- a/ui/app/components/metadata-editor.hbs
+++ b/ui/app/components/metadata-editor.hbs
@@ -10,7 +10,6 @@
         @type="text"
         @value={{@kv.key}}
         class="input"
-        {{on "input" (fn @onEdit @kv)}}
       />
     {{/if}}
   </label>
@@ -22,14 +21,12 @@
         @value={{@kv.value}}
         class="input"
         {{autofocus}}
-        {{on "input" (fn @onEdit @kv)}}
       />
     {{else}}
       <Input
         @type="text"
         @value={{@kv.value}}
         class="input"
-        {{on "input" (fn @onEdit @kv)}}
       />
     {{/if}}
   </label>

--- a/ui/app/components/metadata-editor.hbs
+++ b/ui/app/components/metadata-editor.hbs
@@ -18,6 +18,7 @@
     <strong>Value</strong>
     {{#if @autofocusValue}}
       <Input
+        data-test-metadata-editor-value
         @type="text"
         @value={{@kv.value}}
         class="input"
@@ -26,6 +27,7 @@
       />
     {{else}}
       <Input
+        data-test-metadata-editor-value
         @type="text"
         @value={{@kv.value}}
         class="input"

--- a/ui/app/components/metadata-editor.hbs
+++ b/ui/app/components/metadata-editor.hbs
@@ -10,6 +10,7 @@
         @type="text"
         @value={{@kv.key}}
         class="input"
+        {{on "keyup" @onEdit}}
       />
     {{/if}}
   </label>
@@ -21,12 +22,14 @@
         @value={{@kv.value}}
         class="input"
         {{autofocus}}
+        {{on "keyup" @onEdit}}
       />
     {{else}}
       <Input
         @type="text"
         @value={{@kv.value}}
         class="input"
+        {{on "keyup" @onEdit}}
       />
     {{/if}}
   </label>

--- a/ui/app/components/metadata-editor.js
+++ b/ui/app/components/metadata-editor.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+// import { tracked } from '@glimmer/tracking';
+
+export default class MetadataEditorComponent extends Component {
+  // Temporary, while-editing copy of the passed-in @kv.value
+  // @tracked value = this.args.kv.value;
+}

--- a/ui/app/components/metadata-editor.js
+++ b/ui/app/components/metadata-editor.js
@@ -1,7 +1,0 @@
-import Component from '@glimmer/component';
-// import { tracked } from '@glimmer/tracking';
-
-export default class MetadataEditorComponent extends Component {
-  // Temporary, while-editing copy of the passed-in @kv.value
-  // @tracked value = this.args.kv.value;
-}

--- a/ui/app/components/metadata-kv.hbs
+++ b/ui/app/components/metadata-kv.hbs
@@ -1,0 +1,57 @@
+<tr data-test-attributes-section>
+  {{#if this.editing}}
+    <td colspan="2">
+      <MetadataEditor
+        @kv={{hash key=@key value=@value}}
+        @onEdit={{fn @onKVEdit (hash key=@key value=@value)}}
+        @constantKey={{true}}
+        @autofocusValue={{true}}
+        >
+        <button
+          type="button"
+          class="button"
+          {{on "click" (action (mut this.editing) false)}}
+          {{!-- TODO: add an item to reinstate the pre-edited value --}}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="button is-danger"
+          {{on "click" (queue
+            (action @onKVSave (hash key=@key value=null))
+            (action (mut this.editing) false)
+          )}}
+        >
+          Fire out of a cannon into the sun
+        </button>
+        <button
+          disabled={{or (not @key) (not @value)}}
+          type="submit"
+          class="button is-primary"
+          {{on "click" (queue
+            (action @onKVSave (hash key=@key value=@value))
+            (action (mut this.editing) false)
+          )}}
+        >
+          Update {{@key}}
+        </button>
+
+        </MetadataEditor>
+    </td>
+  {{else}}
+    <td data-test-key>
+      {{#if @prefix}}<span class="is-faded" data-test-prefix>{{@prefix}}.</span>{{/if}}
+      {{~@key}}
+    </td>
+    <td data-test-value title="{{@value}}">
+      {{@value}}
+      {{#if @editable}}
+      <button class="button is-light is-compact edit-existing-metadata-button" type="button"
+        {{on "click" (action (mut this.editing) true)}}
+        
+      >Edit</button>
+      {{/if}}
+    </td>
+  {{/if}}
+</tr>

--- a/ui/app/components/metadata-kv.hbs
+++ b/ui/app/components/metadata-kv.hbs
@@ -3,7 +3,7 @@
     <td colspan="2">
       <MetadataEditor
         @kv={{hash key=this.prefixedKey value=this.value}}
-        @onEdit={{fn @onKVEdit (hash key=this.prefixedKey value=this.value)}}
+        @onEdit={{this.onEdit}}
         @constantKey={{true}}
         @autofocusValue={{true}}
         >

--- a/ui/app/components/metadata-kv.hbs
+++ b/ui/app/components/metadata-kv.hbs
@@ -8,16 +8,15 @@
         @autofocusValue={{true}}
         >
         <button
-          type="button"
-          class="button"
-          {{on "click" 
-            (queue
-              (action (mut this.editing) false)
-              (action (mut this.value) @value)
-            )
-          }}
+          disabled={{or (not @key) (not @value)}}
+          type="submit"
+          class="button is-primary"
+          {{on "click" (queue
+            (action @onKVSave (hash key=@key value=this.value))
+            (action (mut this.editing) false)
+          )}}
         >
-          Cancel
+          Update {{@key}}
         </button>
         <button
           type="button"
@@ -30,26 +29,26 @@
           Delete Property
         </button>
         <button
-          disabled={{or (not @key) (not @value)}}
-          type="submit"
-          class="button is-primary"
-          {{on "click" (queue
-            (action @onKVSave (hash key=@key value=this.value))
-            (action (mut this.editing) false)
-          )}}
+          type="button"
+          class="button"
+          {{on "click" 
+            (queue
+              (action (mut this.editing) false)
+              (action (mut this.value) @value)
+            )
+          }}
         >
-          Update {{@key}}
+          Cancel
         </button>
-
-        </MetadataEditor>
+      </MetadataEditor>
     </td>
   {{else}}
     <td data-test-key>
       {{#if @prefix}}<span class="is-faded" data-test-prefix>{{@prefix}}.</span>{{/if}}
       {{~@key}}
     </td>
-    <td data-test-value title="{{@value}}">
-      {{@value}}
+    <td title="{{@value}}">
+      <span data-test-value>{{@value}}</span>
       {{#if @editable}}
       <button class="button is-light is-compact edit-existing-metadata-button" type="button"
         {{on "click" (action (mut this.editing) true)}}

--- a/ui/app/components/metadata-kv.hbs
+++ b/ui/app/components/metadata-kv.hbs
@@ -2,8 +2,8 @@
   {{#if this.editing}}
     <td colspan="2">
       <MetadataEditor
-        @kv={{hash key=@key value=this.value}}
-        @onEdit={{fn @onKVEdit (hash key=@key value=this.value)}}
+        @kv={{hash key=this.prefixedKey value=this.value}}
+        @onEdit={{fn @onKVEdit (hash key=this.prefixedKey value=this.value)}}
         @constantKey={{true}}
         @autofocusValue={{true}}
         >
@@ -12,17 +12,17 @@
           type="submit"
           class="button is-primary"
           {{on "click" (queue
-            (action @onKVSave (hash key=@key value=this.value))
+            (action @onKVSave (hash key=this.prefixedKey value=this.value))
             (action (mut this.editing) false)
           )}}
         >
-          Update {{@key}}
+          Update {{this.prefixedKey}}
         </button>
         <button
           type="button"
           class="button is-danger"
           {{on "click" (queue
-            (action @onKVSave (hash key=@key value=null))
+            (action @onKVSave (hash key=this.prefixedKey value=null))
             (action (mut this.editing) false)
           )}}
         >

--- a/ui/app/components/metadata-kv.hbs
+++ b/ui/app/components/metadata-kv.hbs
@@ -8,6 +8,7 @@
         @autofocusValue={{true}}
         >
         <button
+          data-test-update-metadata
           disabled={{or (not @key) (not @value)}}
           type="submit"
           class="button is-primary"
@@ -19,6 +20,7 @@
           Update {{this.prefixedKey}}
         </button>
         <button
+          data-test-delete-metadata
           type="button"
           class="button is-danger"
           {{on "click" (queue
@@ -29,6 +31,7 @@
           Delete Property
         </button>
         <button
+          data-test-cancel-metadata
           type="button"
           class="button"
           {{on "click" 

--- a/ui/app/components/metadata-kv.hbs
+++ b/ui/app/components/metadata-kv.hbs
@@ -2,16 +2,20 @@
   {{#if this.editing}}
     <td colspan="2">
       <MetadataEditor
-        @kv={{hash key=@key value=@value}}
-        @onEdit={{fn @onKVEdit (hash key=@key value=@value)}}
+        @kv={{hash key=@key value=this.value}}
+        @onEdit={{fn @onKVEdit (hash key=@key value=this.value)}}
         @constantKey={{true}}
         @autofocusValue={{true}}
         >
         <button
           type="button"
           class="button"
-          {{on "click" (action (mut this.editing) false)}}
-          {{!-- TODO: add an item to reinstate the pre-edited value --}}
+          {{on "click" 
+            (queue
+              (action (mut this.editing) false)
+              (action (mut this.value) @value)
+            )
+          }}
         >
           Cancel
         </button>
@@ -23,14 +27,14 @@
             (action (mut this.editing) false)
           )}}
         >
-          Fire out of a cannon into the sun
+          Delete Property
         </button>
         <button
           disabled={{or (not @key) (not @value)}}
           type="submit"
           class="button is-primary"
           {{on "click" (queue
-            (action @onKVSave (hash key=@key value=@value))
+            (action @onKVSave (hash key=@key value=this.value))
             (action (mut this.editing) false)
           )}}
         >

--- a/ui/app/components/metadata-kv.js
+++ b/ui/app/components/metadata-kv.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class MetadataKvComponent extends Component {
+  editing = false;
+}

--- a/ui/app/components/metadata-kv.js
+++ b/ui/app/components/metadata-kv.js
@@ -1,5 +1,7 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 export default class MetadataKvComponent extends Component {
   editing = false;
+  @tracked value = this.args.value;
 }

--- a/ui/app/components/metadata-kv.js
+++ b/ui/app/components/metadata-kv.js
@@ -4,4 +4,9 @@ import { tracked } from '@glimmer/tracking';
 export default class MetadataKvComponent extends Component {
   editing = false;
   @tracked value = this.args.value;
+  get prefixedKey() {
+    return this.args.prefix
+      ? `${this.args.prefix}.${this.args.key}`
+      : this.args.key;
+  }
 }

--- a/ui/app/components/metadata-kv.js
+++ b/ui/app/components/metadata-kv.js
@@ -1,12 +1,19 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 export default class MetadataKvComponent extends Component {
-  editing = false;
+  @tracked editing = false;
   @tracked value = this.args.value;
   get prefixedKey() {
     return this.args.prefix
       ? `${this.args.prefix}.${this.args.key}`
       : this.args.key;
+  }
+
+  @action onEdit(event) {
+    if (event.key === 'Escape') {
+      this.editing = false;
+    }
   }
 }

--- a/ui/app/controllers/clients/client/index.js
+++ b/ui/app/controllers/clients/client/index.js
@@ -293,8 +293,9 @@ export default class ClientController extends Controller.extend(
     console.log("VALID KEY?", key, this.model.meta);
   }
 
-  @action async addDynamicMetaData() {
+  @action async addDynamicMetaData(e) {
     try {
+      e.preventDefault();
       await this.model.addMeta({[this.newMetaData.key]: this.newMetaData.value});
       // Clear newMetaData
       this.newMetaData = {

--- a/ui/app/controllers/clients/client/index.js
+++ b/ui/app/controllers/clients/client/index.js
@@ -16,12 +16,16 @@ import {
 } from 'nomad-ui/utils/qp-serialize';
 import classic from 'ember-classic-decorator';
 import localStorageProperty from 'nomad-ui/utils/properties/local-storage';
+import { inject as service } from '@ember/service';
 
 @classic
 export default class ClientController extends Controller.extend(
   Sortable,
   Searchable
 ) {
+
+  @service flashMessages;
+
   queryParams = [
     {
       currentPage: 'page',
@@ -277,4 +281,39 @@ export default class ClientController extends Controller.extend(
       this.set('activeTask', null);
     }
   }
+  
+  // #region metadata
+  newMetaData = {
+    key: '',
+    value: '',
+  }
+
+  @action validateKey(key) {
+    console.log("VALID KEY?", key, this.model.meta);
+  }
+
+  @action async addDynamicMetaData() {
+    try {
+      await this.model.addMeta({[this.newMetaData.key]: this.newMetaData.value});
+      this.flashMessages.add({
+        title: 'Metadata added',
+        message: `${this.newMetaData.key} successfully saved`,
+        type: 'success',
+        destroyOnClick: false,
+        timeout: 3000,
+      });
+
+    } catch (err) {
+      const error = messageFromAdapterError(err) || 'Could not save new dynamic metadata';
+      this.flashMessages.add({
+        title: `Error saving Metadata`,
+        message: error,
+        type: 'error',
+        destroyOnClick: false,
+        sticky: true,
+      });
+    }
+
+  }
+  // #endregion metadata
 }

--- a/ui/app/controllers/clients/client/index.js
+++ b/ui/app/controllers/clients/client/index.js
@@ -293,21 +293,26 @@ export default class ClientController extends Controller.extend(
     console.log("VALID KEY?", key, this.model.meta);
   }
 
-  @action async addDynamicMetaData(e) {
+  @action resetNewMetaData() {
+    this.newMetaData = {
+      key: '',
+      value: '',
+    };
+  }
+
+  @action focusNewMetadata() {
+    document.querySelector('#new-meta-key').focus();
+  }
+
+  @action async addDynamicMetaData({key, value}, e) {
+    console.log('addDynamicMetaData', e, key, value);
     try {
       e.preventDefault();
-      await this.model.addMeta({[this.newMetaData.key]: this.newMetaData.value});
-      // Clear newMetaData
-      this.newMetaData = {
-        key: '',
-        value: '',
-      };
+      await this.model.addMeta({[key]: value});
 
-      // focus key input
-      document.querySelector('#new-meta-key').focus();
       this.flashMessages.add({
         title: 'Metadata added',
-        message: `${this.newMetaData.key} successfully saved`,
+        message: `${key} successfully saved`,
         type: 'success',
         destroyOnClick: false,
         timeout: 3000,

--- a/ui/app/controllers/clients/client/index.js
+++ b/ui/app/controllers/clients/client/index.js
@@ -17,6 +17,7 @@ import {
 import classic from 'ember-classic-decorator';
 import localStorageProperty from 'nomad-ui/utils/properties/local-storage';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 @classic
 export default class ClientController extends Controller.extend(
@@ -283,7 +284,7 @@ export default class ClientController extends Controller.extend(
   }
   
   // #region metadata
-  newMetaData = {
+  @tracked newMetaData = {
     key: '',
     value: '',
   }
@@ -295,6 +296,14 @@ export default class ClientController extends Controller.extend(
   @action async addDynamicMetaData() {
     try {
       await this.model.addMeta({[this.newMetaData.key]: this.newMetaData.value});
+      // Clear newMetaData
+      this.newMetaData = {
+        key: '',
+        value: '',
+      };
+
+      // focus key input
+      document.querySelector('#new-meta-key').focus();
       this.flashMessages.add({
         title: 'Metadata added',
         message: `${this.newMetaData.key} successfully saved`,

--- a/ui/app/controllers/clients/client/index.js
+++ b/ui/app/controllers/clients/client/index.js
@@ -283,6 +283,13 @@ export default class ClientController extends Controller.extend(
   }
 
   // #region metadata
+
+  get hasMeta() {
+    return (
+      this.model.meta?.structured && Object.keys(this.model.meta?.structured)
+    );
+  }
+
   @tracked newMetaData = {
     key: '',
     value: '',

--- a/ui/app/controllers/clients/client/index.js
+++ b/ui/app/controllers/clients/client/index.js
@@ -288,7 +288,7 @@ export default class ClientController extends Controller.extend(
     value: '',
   };
 
-  @action validateKey(key) {
+  @action validateKey(/* key */) {
     // TODO: make sure key is valid
   }
 

--- a/ui/app/controllers/clients/client/index.js
+++ b/ui/app/controllers/clients/client/index.js
@@ -24,7 +24,6 @@ export default class ClientController extends Controller.extend(
   Sortable,
   Searchable
 ) {
-
   @service flashMessages;
 
   queryParams = [
@@ -282,15 +281,15 @@ export default class ClientController extends Controller.extend(
       this.set('activeTask', null);
     }
   }
-  
+
   // #region metadata
   @tracked newMetaData = {
     key: '',
     value: '',
-  }
+  };
 
   @action validateKey(key) {
-    console.log("VALID KEY?", key, this.model.meta);
+    // TODO: make sure key is valid
   }
 
   @action resetNewMetaData() {
@@ -300,15 +299,10 @@ export default class ClientController extends Controller.extend(
     };
   }
 
-  @action focusNewMetadata() {
-    document.querySelector('#new-meta-key').focus();
-  }
-
-  @action async addDynamicMetaData({key, value}, e) {
-    console.log('addDynamicMetaData', e, key, value);
+  @action async addDynamicMetaData({ key, value }, e) {
     try {
       e.preventDefault();
-      await this.model.addMeta({[key]: value});
+      await this.model.addMeta({ [key]: value });
 
       this.flashMessages.add({
         title: 'Metadata added',
@@ -317,9 +311,9 @@ export default class ClientController extends Controller.extend(
         destroyOnClick: false,
         timeout: 3000,
       });
-
     } catch (err) {
-      const error = messageFromAdapterError(err) || 'Could not save new dynamic metadata';
+      const error =
+        messageFromAdapterError(err) || 'Could not save new dynamic metadata';
       this.flashMessages.add({
         title: `Error saving Metadata`,
         message: error,
@@ -328,7 +322,6 @@ export default class ClientController extends Controller.extend(
         sticky: true,
       });
     }
-
   }
   // #endregion metadata
 }

--- a/ui/app/controllers/clients/client/index.js
+++ b/ui/app/controllers/clients/client/index.js
@@ -288,10 +288,6 @@ export default class ClientController extends Controller.extend(
     value: '',
   };
 
-  @action validateKey(/* key */) {
-    // TODO: make sure key is valid
-  }
-
   @action resetNewMetaData() {
     this.newMetaData = {
       key: '',

--- a/ui/app/controllers/clients/client/index.js
+++ b/ui/app/controllers/clients/client/index.js
@@ -284,6 +284,8 @@ export default class ClientController extends Controller.extend(
 
   // #region metadata
 
+  @tracked editingMetadata = false;
+
   get hasMeta() {
     return (
       this.model.meta?.structured && Object.keys(this.model.meta?.structured)
@@ -300,6 +302,14 @@ export default class ClientController extends Controller.extend(
       key: '',
       value: '',
     };
+  }
+
+  @action validateMetadata(event, b, c) {
+    console.log('validatin', event, b, c);
+    if (event.key === 'Escape') {
+      this.resetNewMetaData();
+      this.editingMetadata = false;
+    }
   }
 
   @action async addDynamicMetaData({ key, value }, e) {

--- a/ui/app/controllers/clients/client/index.js
+++ b/ui/app/controllers/clients/client/index.js
@@ -304,8 +304,7 @@ export default class ClientController extends Controller.extend(
     };
   }
 
-  @action validateMetadata(event, b, c) {
-    console.log('validatin', event, b, c);
+  @action validateMetadata(event) {
     if (event.key === 'Escape') {
       this.resetNewMetaData();
       this.editingMetadata = false;

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -153,4 +153,12 @@ export default class Node extends Model {
   cancelDrain() {
     return this.store.adapterFor('node').cancelDrain(this);
   }
+
+  getMeta() {
+    return this.store.adapterFor('node').getMeta(this);
+  }
+
+  addMeta(newMeta) {
+    return this.store.adapterFor('node').addMeta(this, newMeta);
+  }
 }

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -154,10 +154,6 @@ export default class Node extends Model {
     return this.store.adapterFor('node').cancelDrain(this);
   }
 
-  getMeta() {
-    return this.store.adapterFor('node').getMeta(this);
-  }
-
   async addMeta(newMeta) {
     let metaResponse = await this.store.adapterFor('node').addMeta(this, newMeta);
     this.meta.recomputeRawProperties(metaResponse.Meta);

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -155,7 +155,9 @@ export default class Node extends Model {
   }
 
   async addMeta(newMeta) {
-    let metaResponse = await this.store.adapterFor('node').addMeta(this, newMeta);
+    let metaResponse = await this.store
+      .adapterFor('node')
+      .addMeta(this, newMeta);
     this.meta.recomputeRawProperties(metaResponse.Meta);
     return metaResponse;
   }

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -158,6 +158,11 @@ export default class Node extends Model {
     let metaResponse = await this.store
       .adapterFor('node')
       .addMeta(this, newMeta);
+
+    if (!this.meta) {
+      this.set('meta', this.store.createFragment('structured-attributes'));
+    }
+
     this.meta.recomputeRawProperties(metaResponse.Meta);
     return metaResponse;
   }

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -158,7 +158,9 @@ export default class Node extends Model {
     return this.store.adapterFor('node').getMeta(this);
   }
 
-  addMeta(newMeta) {
-    return this.store.adapterFor('node').addMeta(this, newMeta);
+  async addMeta(newMeta) {
+    let metaResponse = await this.store.adapterFor('node').addMeta(this, newMeta);
+    this.meta.recomputeRawProperties(metaResponse.Meta);
+    return metaResponse;
   }
 }

--- a/ui/app/models/structured-attributes.js
+++ b/ui/app/models/structured-attributes.js
@@ -1,3 +1,4 @@
+import { set } from '@ember/object';
 import { get, computed } from '@ember/object';
 import { attr } from '@ember-data/model';
 import Fragment from 'ember-data-model-fragments/fragment';
@@ -9,8 +10,7 @@ export default class StructuredAttributes extends Fragment {
   @attr() raw;
 
   recomputeRawProperties(incoming) {
-    this.set('raw', incoming);
-    this.notifyPropertyChange('structured');
+    set(this, 'raw', incoming);
   }
 
   @computed('raw')

--- a/ui/app/models/structured-attributes.js
+++ b/ui/app/models/structured-attributes.js
@@ -8,6 +8,11 @@ const { unflatten } = flat;
 export default class StructuredAttributes extends Fragment {
   @attr() raw;
 
+  recomputeRawProperties(incoming) {
+    this.set('raw', incoming);
+    this.notifyPropertyChange('structured');
+  }
+
   @computed('raw')
   get structured() {
     const original = this.raw;

--- a/ui/app/styles/components.scss
+++ b/ui/app/styles/components.scss
@@ -52,3 +52,4 @@
 @import './components/task-sub-row';
 @import './components/authorization';
 @import './components/policies';
+@import './components/metadata-editor';

--- a/ui/app/styles/components/metadata-editor.scss
+++ b/ui/app/styles/components/metadata-editor.scss
@@ -1,13 +1,25 @@
-.metadata-editor {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.75rem;
+.add-dynamic-metadata {
   padding: 0.75rem;
   border: 1px solid $grey-blue;
   border-top-width: 0;
   margin-bottom: 3rem;
+}
 
-  h3, footer {
+.metadata-editor {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+
+  .constant-key {
+    display: block;
+  }
+
+  footer {
     grid-column: -1 / 1;
   }
 }
+
+.edit-existing-metadata-button {
+  float: right;
+}
+

--- a/ui/app/styles/components/metadata-editor.scss
+++ b/ui/app/styles/components/metadata-editor.scss
@@ -1,0 +1,13 @@
+.metadata-editor {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid $grey-blue;
+  border-top-width: 0;
+  margin-bottom: 3rem;
+
+  h3, footer {
+    grid-column: -1 / 1;
+  }
+}

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -847,6 +847,7 @@
                 <label>
                   <strong>Key</strong>
                   <Input
+                    id="new-meta-key"
                     @type="text"
                     @value={{this.newMetaData.key}}
                     class="input"

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -835,5 +835,54 @@
         </div>
       </div>
     {{/if}}
+    {{#if (can "write client")}}
+      <div class="boxed-section-head">
+        Meta
+      </div>
+      <div class="boxed-section-body is-full-bleed">
+        <table class="table is-striped is-fixed is-compact is-darkened">
+          <tbody>
+            <tr>
+              <td>
+                <label>
+                  <strong>Key</strong>
+                  <Input
+                    @type="text"
+                    @value={{this.newMetaData.key}}
+                    class="input"
+                    {{autofocus}}
+                    {{on "input" (fn this.validateKey this.newMetadata)}}
+                  />
+                </label>
+              </td>
+              <td>
+                <label>
+                  <strong>Value</strong>
+                  <Input
+                    @type="text"
+                    @value={{this.newMetaData.value}}
+                    class="input"
+                    {{on "input" (fn this.validateKey this.newMetadata)}}
+                  />
+                </label>
+              </td>
+            </tr>
+            <tr>
+              <td colspan="2">
+                <button
+                  type="button"
+                  class="button is-primary"
+                  {{on "click" (action this.addDynamicMetaData)}}
+                >
+                  Add {{this.newMetaData.key}} to node metadata
+                </button>
+              </td>
+            </tr>
+          </tbody>
+          <hr /><hr />TRACKING: {{this.newMetaData.key}}, {{this.newMetaData.value}}<hr /><hr />
+        </table>
+
+      </div>
+    {{/if}}
   </div>
 </section>

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -820,6 +820,9 @@
         <AttributesTable
           data-test-meta
           @attributePairs={{this.model.meta.structured}}
+          @editable={{can "write client"}}
+          @onKVEdit={{this.validateKey}}
+          @onKVSave={{this.addDynamicMetaData}}
           @class="attributes-table"
         />
       </div>
@@ -836,12 +839,26 @@
       </div>
     {{/if}}
     {{#if (can "write client")}}
-    <MetadataEditor
-      @kv={{this.newMetaData}}
-      @onEdit={{this.validateKey}}
-      @onSave={{this.addDynamicMetaData}}
-      {{!-- @onCancel={{this.cancelMeta}} --}}
-    />
+    <div class="add-dynamic-metadata">
+      <h3 class="title is-6">Add Dynamic Metadata</h3>
+      <MetadataEditor
+        @kv={{this.newMetaData}}
+        @onEdit={{this.validateKey}}
+      >
+        <button
+          disabled={{or (not this.newMetaData.key) (not this.newMetaData.value)}}
+          type="submit"
+          class="button is-primary"
+          {{on "click" (queue
+            (action this.addDynamicMetaData this.newMetaData)
+            this.resetNewMetaData
+            this.focusNewMetaData
+          )}}
+        >
+          Add {{this.newMetaData.key}} to node metadata
+        </button>
+      </MetadataEditor>
+    </div>
     {{/if}}
   </div>
 </section>

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -836,54 +836,12 @@
       </div>
     {{/if}}
     {{#if (can "write client")}}
-      <div class="boxed-section-head">
-        Meta
-      </div>
-      <div class="boxed-section-body is-full-bleed">
-        <table class="table is-striped is-fixed is-compact is-darkened">
-          <tbody>
-            <tr>
-              <td>
-                <label>
-                  <strong>Key</strong>
-                  <Input
-                    id="new-meta-key"
-                    @type="text"
-                    @value={{this.newMetaData.key}}
-                    class="input"
-                    {{autofocus}}
-                    {{on "input" (fn this.validateKey this.newMetadata)}}
-                  />
-                </label>
-              </td>
-              <td>
-                <label>
-                  <strong>Value</strong>
-                  <Input
-                    @type="text"
-                    @value={{this.newMetaData.value}}
-                    class="input"
-                    {{on "input" (fn this.validateKey this.newMetadata)}}
-                  />
-                </label>
-              </td>
-            </tr>
-            <tr>
-              <td colspan="2">
-                <button
-                  type="button"
-                  class="button is-primary"
-                  {{on "click" (action this.addDynamicMetaData)}}
-                >
-                  Add {{this.newMetaData.key}} to node metadata
-                </button>
-              </td>
-            </tr>
-          </tbody>
-          <hr /><hr />TRACKING: {{this.newMetaData.key}}, {{this.newMetaData.value}}<hr /><hr />
-        </table>
-
-      </div>
+    <MetadataEditor
+      @kv={{this.newMetaData}}
+      @onEdit={{this.validateKey}}
+      @onSave={{this.addDynamicMetaData}}
+      {{!-- @onCancel={{this.cancelMeta}} --}}
+    />
     {{/if}}
   </div>
 </section>

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -815,7 +815,7 @@
     <div class="boxed-section-head">
       Meta
     </div>
-    {{#if this.model.meta.structured}}
+    {{#if this.hasMeta}}
       <div class="boxed-section-body is-full-bleed">
         <AttributesTable
           data-test-meta
@@ -829,7 +829,6 @@
       <div class="boxed-section-body">
         <div data-test-empty-meta-message class="empty-message">
           <h3 class="empty-message-headline">
-            {{!-- TODO: handle ability to add new when no meta present --}}
             No Meta Attributes
           </h3>
           <p class="empty-message-body">

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -822,6 +822,7 @@
           @attributePairs={{this.model.meta.structured}}
           @editable={{can "write client"}}
           @onKVSave={{this.addDynamicMetaData}}
+          @onKVEdit={{this.validateMetadata}}
           @class="attributes-table"
         />
       </div>
@@ -843,6 +844,7 @@
           <h3 class="title is-6">Add Dynamic Metadata</h3>
           <MetadataEditor
             @kv={{this.newMetaData}}
+            @onEdit={{this.validateMetadata}}
           >
             <button
               disabled={{or (not this.newMetaData.key) (not this.newMetaData.value)}}

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -842,7 +842,6 @@
       {{#if this.editingMetadata}}
         <div class="add-dynamic-metadata">
           <h3 class="title is-6">Add Dynamic Metadata</h3>
-          {{!-- TODO: add a cancel button to drop out of editingMetadata --}}
           <MetadataEditor
             @kv={{this.newMetaData}}
             @onEdit={{this.validateKey}}
@@ -859,6 +858,18 @@
             >
               Add {{this.newMetaData.key}} to node metadata
             </button>
+
+            <button
+              type="button"
+              class="button is-secondary"
+              {{on "click" (queue
+                this.resetNewMetaData
+                (action (mut this.editingMetadata) false)
+              )}}
+            >
+              Cancel
+            </button>
+
           </MetadataEditor>
         </div>
       {{else}}

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -821,7 +821,6 @@
           data-test-meta
           @attributePairs={{this.model.meta.structured}}
           @editable={{can "write client"}}
-          @onKVEdit={{this.validateKey}}
           @onKVSave={{this.addDynamicMetaData}}
           @class="attributes-table"
         />
@@ -845,7 +844,6 @@
           <h3 class="title is-6">Add Dynamic Metadata</h3>
           <MetadataEditor
             @kv={{this.newMetaData}}
-            @onEdit={{this.validateKey}}
           >
             <button
               disabled={{or (not this.newMetaData.key) (not this.newMetaData.value)}}

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -830,6 +830,7 @@
       <div class="boxed-section-body">
         <div data-test-empty-meta-message class="empty-message">
           <h3 class="empty-message-headline">
+            {{!-- TODO: handle ability to add new when no meta present --}}
             No Meta Attributes
           </h3>
           <p class="empty-message-body">

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -842,6 +842,7 @@
       {{#if this.editingMetadata}}
         <div class="add-dynamic-metadata">
           <h3 class="title is-6">Add Dynamic Metadata</h3>
+          {{!-- TODO: add a cancel button to drop out of editingMetadata --}}
           <MetadataEditor
             @kv={{this.newMetaData}}
             @onEdit={{this.validateKey}}

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -839,26 +839,38 @@
       </div>
     {{/if}}
     {{#if (can "write client")}}
-    <div class="add-dynamic-metadata">
-      <h3 class="title is-6">Add Dynamic Metadata</h3>
-      <MetadataEditor
-        @kv={{this.newMetaData}}
-        @onEdit={{this.validateKey}}
-      >
-        <button
-          disabled={{or (not this.newMetaData.key) (not this.newMetaData.value)}}
-          type="submit"
-          class="button is-primary"
-          {{on "click" (queue
-            (action this.addDynamicMetaData this.newMetaData)
-            this.resetNewMetaData
-            this.focusNewMetaData
-          )}}
-        >
-          Add {{this.newMetaData.key}} to node metadata
-        </button>
-      </MetadataEditor>
-    </div>
+      {{#if this.editingMetadata}}
+        <div class="add-dynamic-metadata">
+          <h3 class="title is-6">Add Dynamic Metadata</h3>
+          <MetadataEditor
+            @kv={{this.newMetaData}}
+            @onEdit={{this.validateKey}}
+          >
+            <button
+              disabled={{or (not this.newMetaData.key) (not this.newMetaData.value)}}
+              type="submit"
+              class="button is-primary"
+              {{on "click" (queue
+                (action this.addDynamicMetaData this.newMetaData)
+                this.resetNewMetaData
+                (action (mut this.editingMetadata) false)
+              )}}
+            >
+              Add {{this.newMetaData.key}} to node metadata
+            </button>
+          </MetadataEditor>
+        </div>
+      {{else}}
+        <div class="add-dynamic-metadata">
+          <button
+            type="button"
+            class="button is-primary"
+            {{on "click" (action (mut this.editingMetadata) true)}}
+          >
+            Add new Dynamic Metadata
+          </button>
+        </div>
+      {{/if}}
     {{/if}}
   </div>
 </section>

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -847,6 +847,7 @@
             @onEdit={{this.validateMetadata}}
           >
             <button
+              data-test-new-metadata-button
               disabled={{or (not this.newMetaData.key) (not this.newMetaData.value)}}
               type="submit"
               class="button is-primary"

--- a/ui/app/templates/components/attributes-section.hbs
+++ b/ui/app/templates/components/attributes-section.hbs
@@ -7,12 +7,7 @@
     </tr>
     <AttributesSection @prefix={{if this.prefix (concat this.prefix "." key) key}} @attributes={{value}} />
   {{else}}
-    <tr data-test-attributes-section>
-      <td data-test-key>
-        {{#if this.prefix}}<span class="is-faded" data-test-prefix>{{this.prefix}}.</span>{{/if}}
-        {{~key}}
-      </td>
-      <td data-test-value title="{{value}}">{{value}}</td>
-    </tr>
+    <MetadataKv @prefix={{this.prefix}}
+    @key={{key}} @value={{value}} @editable={{@editable}} @onKVEdit={{@onKVEdit}} @onKVSave={{@onKVSave}} />
   {{/if}}
 {{/each-in}}

--- a/ui/app/templates/components/attributes-section.hbs
+++ b/ui/app/templates/components/attributes-section.hbs
@@ -8,7 +8,6 @@
     <AttributesSection @prefix={{if this.prefix (concat this.prefix "." key) key}} @attributes={{value}}
     @key={{key}} @value={{value}} @editable={{@editable}} @onKVEdit={{@onKVEdit}} @onKVSave={{@onKVSave}} />
   {{else}}
-  {{!-- TODO: handle prefix --}}
     <MetadataKv @prefix={{this.prefix}}
     @key={{key}} @value={{value}} @editable={{@editable}} @onKVEdit={{@onKVEdit}} @onKVSave={{@onKVSave}} />
   {{/if}}

--- a/ui/app/templates/components/attributes-section.hbs
+++ b/ui/app/templates/components/attributes-section.hbs
@@ -6,9 +6,9 @@
       </td>
     </tr>
     <AttributesSection @prefix={{if this.prefix (concat this.prefix "." key) key}} @attributes={{value}}
-    @key={{key}} @value={{value}} @editable={{@editable}} @onKVEdit={{@onKVEdit}} @onKVSave={{@onKVSave}} />
+    @key={{key}} @value={{value}} @editable={{@editable}} @onKVSave={{@onKVSave}} />
   {{else}}
     <MetadataKv @prefix={{this.prefix}}
-    @key={{key}} @value={{value}} @editable={{@editable}} @onKVEdit={{@onKVEdit}} @onKVSave={{@onKVSave}} />
+    @key={{key}} @value={{value}} @editable={{@editable}} @onKVSave={{@onKVSave}} />
   {{/if}}
 {{/each-in}}

--- a/ui/app/templates/components/attributes-section.hbs
+++ b/ui/app/templates/components/attributes-section.hbs
@@ -5,8 +5,10 @@
         {{#if this.prefix}}<span class="is-faded" data-test-prefix>{{this.prefix}}.</span>{{/if}}{{key}}
       </td>
     </tr>
-    <AttributesSection @prefix={{if this.prefix (concat this.prefix "." key) key}} @attributes={{value}} />
+    <AttributesSection @prefix={{if this.prefix (concat this.prefix "." key) key}} @attributes={{value}}
+    @key={{key}} @value={{value}} @editable={{@editable}} @onKVEdit={{@onKVEdit}} @onKVSave={{@onKVSave}} />
   {{else}}
+  {{!-- TODO: handle prefix --}}
     <MetadataKv @prefix={{this.prefix}}
     @key={{key}} @value={{value}} @editable={{@editable}} @onKVEdit={{@onKVEdit}} @onKVSave={{@onKVSave}} />
   {{/if}}

--- a/ui/app/templates/components/attributes-table.hbs
+++ b/ui/app/templates/components/attributes-table.hbs
@@ -1,4 +1,4 @@
-<table class="table is-striped is-fixed is-compact is-darkened" ...attributes>
+<table class="table is-striped is-fixed is-compact is-darkened no-mobile-condense" ...attributes>
   <thead>
     <tr>
       <th class="is-one-third">Name</th>

--- a/ui/app/templates/components/attributes-table.hbs
+++ b/ui/app/templates/components/attributes-table.hbs
@@ -6,6 +6,11 @@
     </tr>
   </thead>
   <tbody>
-    <AttributesSection @attributes={{@attributePairs}} />
+    <AttributesSection @attributes={{@attributePairs}}
+    @editable={{@editable}}
+    @onKVEdit={{@onKVEdit}}
+    @onKVSave={{@onKVSave}}
+
+    />
   </tbody>
 </table>

--- a/ui/app/templates/components/attributes-table.hbs
+++ b/ui/app/templates/components/attributes-table.hbs
@@ -7,10 +7,8 @@
   </thead>
   <tbody>
     <AttributesSection @attributes={{@attributePairs}}
-    @editable={{@editable}}
-    @onKVEdit={{@onKVEdit}}
-    @onKVSave={{@onKVSave}}
-
+      @editable={{@editable}}
+      @onKVSave={{@onKVSave}}
     />
   </tbody>
 </table>

--- a/ui/app/templates/components/attributes-table.hbs
+++ b/ui/app/templates/components/attributes-table.hbs
@@ -8,6 +8,7 @@
   <tbody>
     <AttributesSection @attributes={{@attributePairs}}
       @editable={{@editable}}
+      @onKVEdit={{@onKVEdit}}
       @onKVSave={{@onKVSave}}
     />
   </tbody>

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -726,6 +726,22 @@ export default function () {
     }
   });
 
+  // Metadata
+  this.post(
+    '/client/metadata',
+    function (schema, { queryParams: { node_id }, requestBody }) {
+      const attrs = JSON.parse(requestBody);
+      const node = schema.nodes.find(node_id);
+      Object.entries(attrs.Meta).forEach(([key, value]) => {
+        if (value === null) {
+          delete node.meta[key];
+          delete attrs.Meta[key];
+        }
+      });
+      return { Meta: { ...node.meta, ...attrs.Meta } };
+    }
+  );
+
   // TODO: in the future, this hack may be replaceable with dynamic host name
   // support in pretender: https://github.com/pretenderjs/pretender/issues/210
   HOSTS.forEach((host) => {

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -56,6 +56,7 @@ function smallCluster(server) {
     'node',
     {
       name: 'node-with-meta',
+      meta: { foo: 'bar', baz: 'qux' },
     },
     'withMeta'
   );

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -52,6 +52,13 @@ function smallCluster(server) {
   server.create('feature', { name: 'Dynamic Application Sizing' });
   server.createList('agent', 3, 'withConsulLink', 'withVaultLink');
   server.createList('node', 5);
+  server.create(
+    'node',
+    {
+      name: 'node-with-meta',
+    },
+    'withMeta'
+  );
   server.createList('job', 1, { createRecommendations: true });
   server.create('job', {
     withGroupServices: true,
@@ -227,10 +234,9 @@ function smallCluster(server) {
     volume.save();
   });
 
-  server.create('auth-method', {name: 'vault'});
-  server.create('auth-method', {name: 'auth0'});
-  server.create('auth-method', {name: 'cognito'});
-
+  server.create('auth-method', { name: 'vault' });
+  server.create('auth-method', { name: 'auth0' });
+  server.create('auth-method', { name: 'cognito' });
 }
 
 function mediumCluster(server) {
@@ -314,7 +320,6 @@ function policiesTestCluster(server) {
   createTokens(server);
   server.createList('agent', 3, 'withConsulLink', 'withVaultLink');
 }
-
 
 function servicesTestCluster(server) {
   faker.seed(1);

--- a/ui/tests/acceptance/client-detail-test.js
+++ b/ui/tests/acceptance/client-detail-test.js
@@ -1,7 +1,15 @@
 /* eslint-disable qunit/require-expect */
 /* eslint-disable qunit/no-conditional-assertions */
 /* Mirage fixtures are random so we can't expect a set number of assertions */
-import { currentURL, waitUntil, settled } from '@ember/test-helpers';
+import {
+  currentURL,
+  waitUntil,
+  settled,
+  click,
+  fillIn,
+  triggerEvent,
+  findAll,
+} from '@ember/test-helpers';
 import { assign } from '@ember/polyfills';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
@@ -403,6 +411,119 @@ module('Acceptance | client detail', function (hooks) {
       node.meta[firstMetaKey],
       'Meta attributes for the node are bound to the attributes table'
     );
+  });
+
+  test('node metadata is uneditable by default', async function (assert) {
+    window.localStorage.nomadTokenSecret = clientToken.secretId;
+    node = server.create('node', 'forceIPv4', 'withMeta');
+    await ClientDetail.visit({ id: node.id });
+
+    assert.dom('.edit-existing-metadata-button').exists({ count: 0 });
+    assert.dom('.add-dynamic-metadata').doesNotExist();
+  });
+
+  test('node metadata is editable by managers', async function (assert) {
+    window.localStorage.nomadTokenSecret = managementToken.secretId;
+    node = server.create('node', 'forceIPv4', 'withMeta');
+    await ClientDetail.visit({ id: node.id });
+
+    const numberOfExistingMetaKeys = Object.keys(node.meta).length;
+    assert
+      .dom('.edit-existing-metadata-button')
+      .exists({ count: numberOfExistingMetaKeys });
+    assert.dom('.add-dynamic-metadata').exists();
+  });
+
+  test('metadata can be added and removed', async function (assert) {
+    window.localStorage.nomadTokenSecret = managementToken.secretId;
+    node = server.create('node', 'forceIPv4', 'withMeta');
+    await ClientDetail.visit({ id: node.id });
+
+    const numberOfExistingMetaKeys = Object.keys(node.meta).length;
+    assert
+      .dom('.edit-existing-metadata-button')
+      .exists({ count: numberOfExistingMetaKeys });
+    assert.dom('.add-dynamic-metadata').exists();
+    await click('.add-dynamic-metadata button');
+    assert.dom('[data-test-new-metadata-button]').isDisabled();
+    await fillIn('#new-meta-key', 'newKey');
+    await fillIn('[data-test-metadata-editor-value]', 'newValue');
+    assert.dom('[data-test-new-metadata-button]').isNotDisabled();
+    await click('[data-test-new-metadata-button]');
+    assert
+      .dom('.edit-existing-metadata-button')
+      .exists(
+        { count: numberOfExistingMetaKeys + 1 },
+        'newly added item appears'
+      );
+
+    // find the newly added one and edit it
+    assert.dom('.metadata-editor').doesNotExist();
+    const newMetaRow = [...findAll('[data-test-attributes-section]')].filter(
+      (a) => a.textContent.includes('newKey')
+    )[0];
+
+    await click(newMetaRow.querySelector('.edit-existing-metadata-button'));
+    assert.dom('.metadata-editor').exists();
+    assert.dom('.constant-key').exists('existing key shown but uneditable');
+    await click('[data-test-delete-metadata]');
+    assert
+      .dom('.edit-existing-metadata-button')
+      .exists({ count: numberOfExistingMetaKeys }, 'newly added item is gone');
+  });
+
+  test('metadata can be edited', async function (assert) {
+    window.localStorage.nomadTokenSecret = managementToken.secretId;
+    node = server.create(
+      'node',
+      {
+        meta: {
+          existingKey: 'existingValue',
+          'existing.nested.foo': '1',
+          'existing.nested.bar': '2',
+        },
+      },
+      'forceIPv4',
+      'withMeta'
+    );
+    await ClientDetail.visit({ id: node.id });
+
+    const numberOfExistingMetaKeys = Object.keys(node.meta).length;
+    assert
+      .dom('.edit-existing-metadata-button')
+      .exists({ count: numberOfExistingMetaKeys });
+
+    const topLevelMetaRow = [
+      ...findAll('[data-test-attributes-section]'),
+    ].filter((a) => a.textContent.includes('existingKey'))[0];
+
+    await click(
+      topLevelMetaRow.querySelector('.edit-existing-metadata-button')
+    );
+    assert.dom('.metadata-editor').exists();
+    assert.dom('.constant-key').exists('existing key shown but uneditable');
+    assert.dom('[data-test-metadata-editor-value]').hasValue('existingValue');
+    await fillIn('[data-test-metadata-editor-value]', 'newValue');
+    await click('[data-test-update-metadata]');
+    assert.dom('.metadata-editor').doesNotExist();
+    const editedRow = [...findAll('[data-test-attributes-section]')].filter(
+      (a) => a.textContent.includes('existingKey')
+    )[0];
+    assert.dom(editedRow).containsText('newValue', 'value updated');
+
+    // Cancellable by click
+    await click(editedRow.querySelector('.edit-existing-metadata-button'));
+    assert.dom('.metadata-editor').exists();
+    await click('[data-test-cancel-metadata]');
+    assert.dom('.metadata-editor').doesNotExist();
+
+    // Cancellable by typing escape
+    await click(editedRow.querySelector('.edit-existing-metadata-button'));
+    assert.dom('.metadata-editor').exists();
+    await triggerEvent('[data-test-metadata-editor-value]', 'keyup', {
+      key: 'Escape',
+    });
+    assert.dom('.metadata-editor').doesNotExist();
   });
 
   test('/clients/:id shows an empty message when there is no meta data', async function (assert) {


### PR DESCRIPTION
Allows for editing node metadata via the Web UI. New metadata can be added and existing metadata can be edited or removed.

Some nice things like escape press within an input are handled as you'd expect.

Requires `can write node` access levels so, if testing against vercel/mirage, please "sign in" as a manager

![image](https://user-images.githubusercontent.com/713991/216699322-a6a8638b-52dd-4bea-873a-83f1a4b7df4e.png)