### PR TITLE
template: restore driver handle on update

### DIFF
--- a/.changelog/15915.txt
+++ b/.changelog/15915.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+template: Fixed a bug that caused the chage script to fail to run
+```


### PR DESCRIPTION
When the template hook Update() method is called it may recreate the template manager if the Nomad or Vault token has been updated.

This caused the new template manager did not have a driver handler because this was only being set on the Poststart hook, which is not called for inplace updates.

Closes #15851