### PR TITLE
docs: add post-install steps for CNI to main install docs page

### DIFF
--- a/website/content/docs/install/index.mdx
+++ b/website/content/docs/install/index.mdx
@@ -13,7 +13,7 @@ operating systems. You can also [build Nomad from source](#from-source).
 [Quickstart](/nomad/docs/install/quickstart) for options to get started with Nomad.
 
 <Tabs>
-<Tab heading="Manual installation">
+<Tab heading="Manual installation" group="manual">
 
 You can download a [precompiled binary](/nomad/downloads) and
 run it on your machine locally. You can also verify the binary using the
@@ -21,34 +21,52 @@ available SHA-256 sums. After downloading Nomad, unzip the package. Make sure
 that the `nomad` binary is available on your `PATH` before continuing with the
 other guides.
 
-You can check the locations available on your path by running this command.
+</Tab>
+<Tab heading="Homebrew on macOS" group="homebrew">
+
+[Homebrew](https://brew.sh) is a free and open source package management system
+for Mac OS X. Install the official [Nomad
+formula](https://github.com/hashicorp/homebrew-tap) from the terminal.
+
+First, install the HashiCorp tap, a repository of all of the HashiCorp Homebrew
+packages.
 
 ```shell-session
-$ echo $PATH
-
-/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+$ brew tap hashicorp/tap
 ```
 
-The output is a list of locations separated by colons. You can make Nomad
-available by moving the binary to one of the listed locations, or by adding
-Nomad's location to your `PATH`.
+Now, install Nomad with `hashicorp/tap/nomad`.
 
--> **Tip (Linux-based or Mac):** Permanently add a new location to your path by
-editing your shell's settings file (usually called something like `~/.bashrc`,
-where the part of the file name after the `.` and before `rc` is the name of
-your shell). In that file you will see a line that starts with `export PATH=`,
-followed by a colon-separated list of locations. Add the location of the Nomad
-binary to that list and save the file. Then reload your shell's configuration
-with the command `source ~/.bashrc`, replacing `bash` with the name of your
-shell.
+```shell-session
+$ brew install hashicorp/tap/nomad
+```
 
--> **Tip (Windows):** Add a location to your path via the GUI by navigating to
-`Environment Variables` in your system settings, and looking for the variable
-called `PATH`. You will see a semicolon-separated list of locations. Add the
-Nomad binary's location to that list and then launch a new console window.
+~> **NOTE:** This installs a signed binary and is automatically updated with
+every new official release.
+
+To update to the latest, run
+
+```shell-session
+$ brew upgrade hashicorp/tap/nomad
+```
 
 </Tab>
-<Tab heading="Linux Packages">
+<Tab heading="Chocolatey on Windows" group="chocolatey">
+
+[Chocolatey](https://chocolatey.org/) is a free and open-source package
+management system for Windows. Install the [Nomad
+package](https://chocolatey.org/packages/nomad) from the command-line.
+
+```shell-session
+$ choco install nomad
+```
+
+~> **NOTE:** Chocolatey and the Nomad package are **NOT** directly maintained
+by HashiCorp. The latest version of Nomad is always available by manual
+installation.
+
+</Tab>
+<Tab heading="Linux Packages" group="linux">
 
 HashiCorp officially maintains and signs packages for the following Linux
 distributions.
@@ -145,53 +163,139 @@ $ sudo yum -y install nomad
 [Vault](/vault/tutorials) with the same command.
 
 </Tab>
-<Tab heading="Homebrew (macOS)">
-
-[Homebrew](https://brew.sh) is a free and open source package management system
-for Mac OS X. Install the official [Nomad
-formula](https://github.com/hashicorp/homebrew-tap) from the terminal.
-
-First, install the HashiCorp tap, a repository of all of the HashiCorp Homebrew
-packages.
-
-```shell-session
-$ brew tap hashicorp/tap
-```
-
-Now, install Nomad with `hashicorp/tap/nomad`.
-
-```shell-session
-$ brew install hashicorp/tap/nomad
-```
-
-~> **NOTE:** This installs a signed binary and is automatically updated with
-every new official release.
-
-To update to the latest, run
-
-```shell-session
-$ brew upgrade hashicorp/tap/nomad
-```
-
-</Tab>
-<Tab heading="Chocolatey (Windows)">
-
-[Chocolatey](https://chocolatey.org/) is a free and open-source package
-management system for Windows. Install the [Nomad
-package](https://chocolatey.org/packages/nomad) from the command-line.
-
-```shell-session
-$ choco install nomad
-```
-
-~> **NOTE:** Chocolatey and the Nomad package are **NOT** directly maintained
-by HashiCorp. The latest version of Nomad is always available by manual
-installation.
-
-</Tab>
 </Tabs>
 
----
+## Post-installation steps
+
+These steps are considered optional but can be helpful for running Nomad and to
+take advantage of additional Nomad functionalities.
+
+<Tabs>
+<Tab heading="Manual installation" group="manual">
+
+<Tabs>
+<Tab heading="Linux">
+<h3>Add the Nomad binary to your system path</h3>
+
+Permanently add a new location to your path by editing your shell's settings
+file (usually called something like `~/.bashrc`, where the part of the filename
+after the `.` and before `rc` is the name of your shell). In that file you
+should see a line that starts with `export PATH=`, followed by a
+colon-separated list of locations. Add the location of the Nomad binary to that
+list and save the file. Then reload your shell's configuration with the command
+`source ~/.bashrc`, replacing `bash` with the name of your shell.
+
+<h3>Install CNI plugins</h3>
+
+Nomad uses CNI plugins to configure network namespaces when using the `bridge`
+network mode. All Linux Nomad client nodes using network namespaces must have
+CNI plugins installed.
+
+The following commands install the CNI reference plugins.
+
+```shell-session
+$ curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/releases/download/v1.0.0/cni-plugins-linux-$( [ $(uname -m) = aarch64 ] && echo arm64 || echo amd64)"-v1.0.0.tgz && \
+  sudo mkdir -p /opt/cni/bin && \
+  sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
+```
+
+Ensure your Linux operating system distribution has been configured to allow
+container traffic through the bridge network to be routed via iptables. These
+tunables can be set as follows.
+
+```shell-session
+$ echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-arptables && \
+  echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-ip6tables && \
+  echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables
+```
+
+To preserve these settings on startup of a client node, add a file including the
+following to `/etc/sysctl.d/` or remove the file your Linux distribution puts in
+that directory.
+
+<CodeBlockConfig filename="/etc/sysctl.d/bridge.conf">
+
+```ini
+net.bridge.bridge-nf-call-arptables = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+```
+
+</CodeBlockConfig>
+</Tab>
+
+<Tab heading="macOS">
+<h3>Add the Nomad binary to your system path</h3>
+
+Permanently add a new location to your path by editing your shell's settings
+file (usually called something like `~/.bashrc`, where the part of the filename
+after the `.` and before `rc` is the name of your shell). In that file you
+should see a line that starts with `export PATH=`, followed by a
+colon-separated list of locations. Add the location of the Nomad binary to that
+list and save the file. Then reload your shell's configuration with the command
+`source ~/.bashrc`, replacing `bash` with the name of your shell.
+</Tab>
+
+<Tab heading="Windows">
+
+<h3>Add the Nomad binary to your system path</h3>
+
+Add a location to your path via the GUI by navigating to `Environment
+Variables` in your system settings, and looking for the variable called `PATH`.
+You should see a semicolon-separated list of locations. Add the Nomad binary's
+location to that list and then launch a new console window.
+</Tab>
+</Tabs>
+</Tab>
+
+<Tab heading="Homebrew on macOS" group="homebrew">
+No additional steps necessary after installing Nomad using Homebrew.
+</Tab>
+
+<Tab heading="Chocolatey on Windows" group="chocolatey">
+No additional steps necessary after installing Nomad using Chocolatey.
+</Tab>
+
+<Tab heading="Linux" group="linux">
+<h3>Install CNI plugins</h3>
+
+Nomad uses CNI plugins to configure network namespaces when using the `bridge`
+network mode. All Linux Nomad client nodes using network namespaces must have
+CNI plugins installed.
+
+The following commands install the CNI reference plugins.
+
+```shell-session
+$ curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/releases/download/v1.0.0/cni-plugins-linux-$( [ $(uname -m) = aarch64 ] && echo arm64 || echo amd64)"-v1.0.0.tgz && \
+  sudo mkdir -p /opt/cni/bin && \
+  sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
+```
+
+Ensure your Linux operating system distribution has been configured to allow
+container traffic through the bridge network to be routed via iptables. These
+tunables can be set as follows.
+
+```shell-session
+$ echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-arptables && \
+  echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-ip6tables && \
+  echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables
+```
+
+To preserve these settings on startup of a client node, add a file including the
+following to `/etc/sysctl.d/` or remove the file your Linux distribution puts in
+that directory.
+
+<CodeBlockConfig filename="/etc/sysctl.d/bridge.conf">
+
+```ini
+net.bridge.bridge-nf-call-arptables = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+```
+
+</CodeBlockConfig>
+</Tab>
+</Tabs>
 
 ## Verify the Installation
 

--- a/website/content/docs/install/index.mdx
+++ b/website/content/docs/install/index.mdx
@@ -174,7 +174,7 @@ take advantage of additional Nomad functionalities.
 <Tab heading="Manual installation" group="manual">
 
 <Tabs>
-<Tab heading="Linux">
+<Tab heading="Linux Packages">
 <h3>Add the Nomad binary to your system path</h3>
 
 Permanently add a new location to your path by editing your shell's settings


### PR DESCRIPTION
The getting started Tutorial has a post-installation steps section that includes installing CNI plugins. Many users will want to use `bridge` networking right out of the gate, so adding these same post-install instructions to the main docs will be a better Day 0 experience for them.