### PR TITLE
Fix documentation for `meta` block: string replacement in key from `-` to `_`

### DIFF
--- a/.changelog/15940.txt
+++ b/.changelog/15940.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docs: Added further explanation that any `-` string in key in `meta` block will be replaced with `_`
+```

--- a/.changelog/15940.txt
+++ b/.changelog/15940.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-docs: Added further explanation that any `-` string in key in `meta` block will be replaced with `_`
-```

--- a/website/content/docs/job-specification/meta.mdx
+++ b/website/content/docs/job-specification/meta.mdx
@@ -47,7 +47,8 @@ Meta values are made available inside tasks as [runtime environment variables][e
 
 The "parameters" for the `meta` stanza can be any key-value. The keys and values
 are both of type `string`, but they can be specified as other types. They will
-automatically be converted to strings.
+automatically be converted to strings. Any `-` character existing in the key
+will also be converted to `_`.
 
 ## `meta` Examples
 


### PR DESCRIPTION
Hi team,

This PR will solve the issue #15359