### PR TITLE
client: Add option to enable hairpinMode on Nomad bridge

### DIFF
--- a/.changelog/15961.txt
+++ b/.changelog/15961.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client: Add option to enable hairpinMode on Nomad bridge
+```

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -524,12 +524,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 				return ar.RestartAll(ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
-				"main":              structs.TaskState{State: "running", Restarts: 1},
-				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 1},
-				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 1},
-				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 1},
-				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 1},
-				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+				"main":              {State: "running", Restarts: 1},
+				"prestart-oneshot":  {State: "dead", Restarts: 1},
+				"prestart-sidecar":  {State: "running", Restarts: 1},
+				"poststart-oneshot": {State: "dead", Restarts: 1},
+				"poststart-sidecar": {State: "running", Restarts: 1},
+				"poststop":          {State: "pending", Restarts: 0},
 			},
 		},
 		{
@@ -538,12 +538,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 				return ar.RestartRunning(ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
-				"main":              structs.TaskState{State: "running", Restarts: 1},
-				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
-				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 1},
-				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 1},
-				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+				"main":              {State: "running", Restarts: 1},
+				"prestart-oneshot":  {State: "dead", Restarts: 0},
+				"prestart-sidecar":  {State: "running", Restarts: 1},
+				"poststart-oneshot": {State: "dead", Restarts: 0},
+				"poststart-sidecar": {State: "running", Restarts: 1},
+				"poststop":          {State: "pending", Restarts: 0},
 			},
 		},
 		{
@@ -561,12 +561,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 				return ar.RestartAll(ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
-				"main":              structs.TaskState{State: "running", Restarts: 1},
-				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 1},
-				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 1},
-				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 1},
-				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 1},
-				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+				"main":              {State: "running", Restarts: 1},
+				"prestart-oneshot":  {State: "dead", Restarts: 1},
+				"prestart-sidecar":  {State: "running", Restarts: 1},
+				"poststart-oneshot": {State: "dead", Restarts: 1},
+				"poststart-sidecar": {State: "running", Restarts: 1},
+				"poststop":          {State: "pending", Restarts: 0},
 			},
 		},
 		{
@@ -584,12 +584,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 				return ar.RestartRunning(ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
-				"main":              structs.TaskState{State: "running", Restarts: 1},
-				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
-				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 1},
-				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 1},
-				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+				"main":              {State: "running", Restarts: 1},
+				"prestart-oneshot":  {State: "dead", Restarts: 0},
+				"prestart-sidecar":  {State: "running", Restarts: 1},
+				"poststart-oneshot": {State: "dead", Restarts: 0},
+				"poststart-sidecar": {State: "running", Restarts: 1},
+				"poststop":          {State: "pending", Restarts: 0},
 			},
 		},
 		{
@@ -599,12 +599,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 				return ar.RestartAll(ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
-				"main":              structs.TaskState{State: "running", Restarts: 1},
-				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 1},
-				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 1},
-				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 1},
-				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 1},
-				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+				"main":              {State: "running", Restarts: 1},
+				"prestart-oneshot":  {State: "dead", Restarts: 1},
+				"prestart-sidecar":  {State: "running", Restarts: 1},
+				"poststart-oneshot": {State: "dead", Restarts: 1},
+				"poststart-sidecar": {State: "running", Restarts: 1},
+				"poststop":          {State: "pending", Restarts: 0},
 			},
 		},
 		{
@@ -616,12 +616,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 				return nil
 			},
 			expectedAfter: map[string]structs.TaskState{
-				"main":              structs.TaskState{State: "dead", Restarts: 0},
-				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
-				"prestart-sidecar":  structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-sidecar": structs.TaskState{State: "dead", Restarts: 0},
-				"poststop":          structs.TaskState{State: "dead", Restarts: 0},
+				"main":              {State: "dead", Restarts: 0},
+				"prestart-oneshot":  {State: "dead", Restarts: 0},
+				"prestart-sidecar":  {State: "dead", Restarts: 0},
+				"poststart-oneshot": {State: "dead", Restarts: 0},
+				"poststart-sidecar": {State: "dead", Restarts: 0},
+				"poststop":          {State: "dead", Restarts: 0},
 			},
 		},
 		{
@@ -630,12 +630,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 				return ar.RestartTask("main", ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
-				"main":              structs.TaskState{State: "running", Restarts: 1},
-				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
-				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 0},
-				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 0},
-				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+				"main":              {State: "running", Restarts: 1},
+				"prestart-oneshot":  {State: "dead", Restarts: 0},
+				"prestart-sidecar":  {State: "running", Restarts: 0},
+				"poststart-oneshot": {State: "dead", Restarts: 0},
+				"poststart-sidecar": {State: "running", Restarts: 0},
+				"poststop":          {State: "pending", Restarts: 0},
 			},
 		},
 		{
@@ -645,12 +645,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 				return ar.RestartTask("main", ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
-				"main":              structs.TaskState{State: "running", Restarts: 1},
-				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
-				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 0},
-				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 0},
-				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+				"main":              {State: "running", Restarts: 1},
+				"prestart-oneshot":  {State: "dead", Restarts: 0},
+				"prestart-sidecar":  {State: "running", Restarts: 0},
+				"poststart-oneshot": {State: "dead", Restarts: 0},
+				"poststart-sidecar": {State: "running", Restarts: 0},
+				"poststop":          {State: "pending", Restarts: 0},
 			},
 		},
 		{
@@ -668,12 +668,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 				return nil
 			},
 			expectedAfter: map[string]structs.TaskState{
-				"main":              structs.TaskState{State: "dead", Restarts: 1},
-				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
-				"prestart-sidecar":  structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-sidecar": structs.TaskState{State: "dead", Restarts: 0},
-				"poststop":          structs.TaskState{State: "dead", Restarts: 0},
+				"main":              {State: "dead", Restarts: 1},
+				"prestart-oneshot":  {State: "dead", Restarts: 0},
+				"prestart-sidecar":  {State: "dead", Restarts: 0},
+				"poststart-oneshot": {State: "dead", Restarts: 0},
+				"poststart-sidecar": {State: "dead", Restarts: 0},
+				"poststop":          {State: "dead", Restarts: 0},
 			},
 		},
 		{
@@ -692,12 +692,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 				return nil
 			},
 			expectedAfter: map[string]structs.TaskState{
-				"main":              structs.TaskState{State: "dead", Restarts: 1},
-				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
-				"prestart-sidecar":  structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-sidecar": structs.TaskState{State: "dead", Restarts: 0},
-				"poststop":          structs.TaskState{State: "dead", Restarts: 0},
+				"main":              {State: "dead", Restarts: 1},
+				"prestart-oneshot":  {State: "dead", Restarts: 0},
+				"prestart-sidecar":  {State: "dead", Restarts: 0},
+				"poststart-oneshot": {State: "dead", Restarts: 0},
+				"poststart-sidecar": {State: "dead", Restarts: 0},
+				"poststop":          {State: "dead", Restarts: 0},
 			},
 		},
 		{
@@ -715,12 +715,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 				return nil
 			},
 			expectedAfter: map[string]structs.TaskState{
-				"main":              structs.TaskState{State: "dead", Restarts: 1},
-				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
-				"prestart-sidecar":  structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-sidecar": structs.TaskState{State: "dead", Restarts: 0},
-				"poststop":          structs.TaskState{State: "dead", Restarts: 0},
+				"main":              {State: "dead", Restarts: 1},
+				"prestart-oneshot":  {State: "dead", Restarts: 0},
+				"prestart-sidecar":  {State: "dead", Restarts: 0},
+				"poststart-oneshot": {State: "dead", Restarts: 0},
+				"poststart-sidecar": {State: "dead", Restarts: 0},
+				"poststop":          {State: "dead", Restarts: 0},
 			},
 		},
 		{
@@ -738,12 +738,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 				return nil
 			},
 			expectedAfter: map[string]structs.TaskState{
-				"main":              structs.TaskState{State: "dead", Restarts: 1},
-				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
-				"prestart-sidecar":  structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-sidecar": structs.TaskState{State: "dead", Restarts: 0},
-				"poststop":          structs.TaskState{State: "dead", Restarts: 0},
+				"main":              {State: "dead", Restarts: 1},
+				"prestart-oneshot":  {State: "dead", Restarts: 0},
+				"prestart-sidecar":  {State: "dead", Restarts: 0},
+				"poststart-oneshot": {State: "dead", Restarts: 0},
+				"poststart-sidecar": {State: "dead", Restarts: 0},
+				"poststop":          {State: "dead", Restarts: 0},
 			},
 		},
 		{
@@ -764,12 +764,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 			},
 			expectedErr: "Task not running",
 			expectedAfter: map[string]structs.TaskState{
-				"main":              structs.TaskState{State: "dead", Restarts: 1},
-				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
-				"prestart-sidecar":  structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-sidecar": structs.TaskState{State: "dead", Restarts: 0},
-				"poststop":          structs.TaskState{State: "dead", Restarts: 0},
+				"main":              {State: "dead", Restarts: 1},
+				"prestart-oneshot":  {State: "dead", Restarts: 0},
+				"prestart-sidecar":  {State: "dead", Restarts: 0},
+				"poststart-oneshot": {State: "dead", Restarts: 0},
+				"poststart-sidecar": {State: "dead", Restarts: 0},
+				"poststop":          {State: "dead", Restarts: 0},
 			},
 		},
 		{
@@ -778,12 +778,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 				return ar.RestartTask("prestart-sidecar", ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
-				"main":              structs.TaskState{State: "running", Restarts: 0},
-				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
-				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 1},
-				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 0},
-				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+				"main":              {State: "running", Restarts: 0},
+				"prestart-oneshot":  {State: "dead", Restarts: 0},
+				"prestart-sidecar":  {State: "running", Restarts: 1},
+				"poststart-oneshot": {State: "dead", Restarts: 0},
+				"poststart-sidecar": {State: "running", Restarts: 0},
+				"poststop":          {State: "pending", Restarts: 0},
 			},
 		},
 		{
@@ -792,12 +792,12 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 				return ar.RestartTask("poststart-sidecar", ev)
 			},
 			expectedAfter: map[string]structs.TaskState{
-				"main":              structs.TaskState{State: "running", Restarts: 0},
-				"prestart-oneshot":  structs.TaskState{State: "dead", Restarts: 0},
-				"prestart-sidecar":  structs.TaskState{State: "running", Restarts: 0},
-				"poststart-oneshot": structs.TaskState{State: "dead", Restarts: 0},
-				"poststart-sidecar": structs.TaskState{State: "running", Restarts: 1},
-				"poststop":          structs.TaskState{State: "pending", Restarts: 0},
+				"main":              {State: "running", Restarts: 0},
+				"prestart-oneshot":  {State: "dead", Restarts: 0},
+				"prestart-sidecar":  {State: "running", Restarts: 0},
+				"poststart-oneshot": {State: "dead", Restarts: 0},
+				"poststart-sidecar": {State: "running", Restarts: 1},
+				"poststop":          {State: "pending", Restarts: 0},
 			},
 		},
 	}

--- a/client/allocrunner/network_manager_linux.go
+++ b/client/allocrunner/network_manager_linux.go
@@ -184,7 +184,7 @@ func newNetworkConfigurator(log hclog.Logger, alloc *structs.Allocation, config 
 
 	switch {
 	case netMode == "bridge":
-		c, err := newBridgeNetworkConfigurator(log, config.BridgeNetworkName, config.BridgeNetworkAllocSubnet, config.CNIPath, ignorePortMappingHostIP)
+		c, err := newBridgeNetworkConfigurator(log, config.BridgeNetworkName, config.BridgeNetworkAllocSubnet, config.BridgeNetworkHairpinMode, config.CNIPath, ignorePortMappingHostIP)
 		if err != nil {
 			return nil, err
 		}

--- a/client/allocrunner/networking_bridge_linux_test.go
+++ b/client/allocrunner/networking_bridge_linux_test.go
@@ -1,0 +1,45 @@
+package allocrunner
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_buildNomadBridgeNetConfig(t *testing.T) {
+	testCases := []struct {
+		name string
+		b    *bridgeNetworkConfigurator
+	}{
+		{
+			name: "empty",
+			b:    &bridgeNetworkConfigurator{},
+		},
+
+		{
+			name: "hairpin",
+			b: &bridgeNetworkConfigurator{
+				bridgeName:  defaultNomadBridgeName,
+				allocSubnet: defaultNomadAllocSubnet,
+				hairpinMode: true,
+			},
+		},
+		{
+			name: "bad_name",
+			b: &bridgeNetworkConfigurator{
+				bridgeName: `bad","foo":"bar`,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc := tc
+			var out []byte
+			require.NotPanics(t, func() { out = buildNomadBridgeNetConfig(*tc.b) })
+			if tc.name == "bad_name" {
+				fmt.Println(string(out))
+			}
+		})
+	}
+}

--- a/client/allocrunner/networking_bridge_linux_test.go
+++ b/client/allocrunner/networking_bridge_linux_test.go
@@ -1,13 +1,14 @@
 package allocrunner
 
 import (
-	"fmt"
 	"testing"
 
+	"github.com/hashicorp/nomad/ci"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_buildNomadBridgeNetConfig(t *testing.T) {
+	ci.Parallel(t)
 	testCases := []struct {
 		name string
 		b    *bridgeNetworkConfigurator
@@ -25,21 +26,12 @@ func Test_buildNomadBridgeNetConfig(t *testing.T) {
 				hairpinMode: true,
 			},
 		},
-		{
-			name: "bad_name",
-			b: &bridgeNetworkConfigurator{
-				bridgeName: `bad","foo":"bar`,
-			},
-		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ci.Parallel(t)
 			tc := tc
-			var out []byte
-			require.NotPanics(t, func() { out = buildNomadBridgeNetConfig(*tc.b) })
-			if tc.name == "bad_name" {
-				fmt.Println(string(out))
-			}
+			require.NotPanics(t, func() { _ = buildNomadBridgeNetConfig(*tc.b) })
 		})
 	}
 }

--- a/client/allocrunner/networking_bridge_linux_test.go
+++ b/client/allocrunner/networking_bridge_linux_test.go
@@ -1,10 +1,11 @@
 package allocrunner
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
-	"github.com/stretchr/testify/require"
+	"github.com/shoenig/test/must"
 )
 
 func Test_buildNomadBridgeNetConfig(t *testing.T) {
@@ -26,12 +27,22 @@ func Test_buildNomadBridgeNetConfig(t *testing.T) {
 				hairpinMode: true,
 			},
 		},
+		{
+			name: "bad_input",
+			b: &bridgeNetworkConfigurator{
+				bridgeName:  `bad"`,
+				allocSubnet: defaultNomadAllocSubnet,
+				hairpinMode: true,
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ci.Parallel(t)
 			tc := tc
-			require.NotPanics(t, func() { _ = buildNomadBridgeNetConfig(*tc.b) })
+			ci.Parallel(t)
+			bCfg := buildNomadBridgeNetConfig(*tc.b)
+			// Validate that the JSON created is rational
+			must.True(t, json.Valid(bCfg))
 		})
 	}
 }

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -261,6 +261,10 @@ type Config struct {
 	// networking mode. This defaults to 'nomad' if not set
 	BridgeNetworkName string
 
+	// BridgeNetworkHairpinMode is whether or not to enable hairpin mode on the
+	// internal bridge network
+	BridgeNetworkHairpinMode bool
+
 	// BridgeNetworkAllocSubnet is the IP subnet to use for address allocation
 	// for allocations in bridge networking mode. Subnet must be in CIDR
 	// notation

--- a/client/fingerprint/bridge_default.go
+++ b/client/fingerprint/bridge_default.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package fingerprint
 

--- a/client/fingerprint/bridge_linux.go
+++ b/client/fingerprint/bridge_linux.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package fingerprint
 
 import (
@@ -5,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -34,6 +37,9 @@ func (f *BridgeFingerprint) Fingerprint(req *FingerprintRequest, resp *Fingerpri
 			Device: req.Config.BridgeNetworkName,
 		}},
 	}
+
+	resp.AddAttribute("nomad.bridge.hairpin_mode",
+		strconv.FormatBool(req.Config.BridgeNetworkHairpinMode))
 
 	resp.Detected = true
 	return nil

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -781,6 +781,7 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	conf.CNIConfigDir = agentConfig.Client.CNIConfigDir
 	conf.BridgeNetworkName = agentConfig.Client.BridgeNetworkName
 	conf.BridgeNetworkAllocSubnet = agentConfig.Client.BridgeNetworkSubnet
+	conf.BridgeNetworkHairpinMode = agentConfig.Client.BridgeNetworkHairpinMode
 
 	for _, hn := range agentConfig.Client.HostNetworks {
 		conf.HostNetworks[hn.Name] = hn

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -315,6 +315,10 @@ type ClientConfig struct {
 	// the host
 	BridgeNetworkSubnet string `hcl:"bridge_network_subnet"`
 
+	// BridgeNetworkHairpinMode is whether or not to enable hairpin mode on the
+	// internal bridge network
+	BridgeNetworkHairpinMode bool `hcl:"bridge_network_hairpin_mode"`
+
 	// HostNetworks describes the different host networks available to the host
 	// if the host uses multiple interfaces
 	HostNetworks []*structs.ClientHostNetworkConfig `hcl:"host_network"`
@@ -2127,6 +2131,10 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	}
 	if b.BridgeNetworkSubnet != "" {
 		result.BridgeNetworkSubnet = b.BridgeNetworkSubnet
+	}
+
+	if b.BridgeNetworkHairpinMode {
+		result.BridgeNetworkHairpinMode = true
 	}
 
 	result.HostNetworks = a.HostNetworks

--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -155,9 +155,8 @@ client {
 
 - `bridge_network_hairpin_mode` `(bool: false)` - Specifies if hairpin mode
   is enabled on the network bridge created by Nomad for allocations running
-  with bridge networking mode on this client. This value is exposed to the
-  scheduler as a node attribute—`nomad.bridge.hairpin_mode`—for use in
-  constraints.
+  with bridge networking mode on this client. You may use the corresponding
+  node attribute `nomad.bridge.hairpin_mode` in constraints.
 
 - `artifact` <code>([Artifact](#artifact-parameters): varied)</code> -
   Specifies controls on the behavior of task

--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -147,11 +147,17 @@ client {
   configuration.
 
 - `bridge_network_name` `(string: "nomad")` - Sets the name of the bridge to be
-  created by nomad for allocations running with bridge networking mode on the
+  created by Nomad for allocations running with bridge networking mode on the
   client.
 
 - `bridge_network_subnet` `(string: "172.26.64.0/20")` - Specifies the subnet
   which the client will use to allocate IP addresses from.
+
+- `bridge_network_hairpin_mode` `(bool: false)` - Specifies if hairpin mode
+  is enabled on the network bridge created by Nomad for allocations running
+  with bridge networking mode on this client. This value is exposed to the
+  scheduler as a node attribute—`nomad.bridge.hairpin_mode`—for use in
+  constraints.
 
 - `artifact` <code>([Artifact](#artifact-parameters): varied)</code> -
   Specifies controls on the behavior of task


### PR DESCRIPTION
- Add `bridge_network_hairpin_mode` client config setting
- Add hairpin mode to bridge template; convert to go template
- add node attribute: nomad.bridge.hairpin_mode
- Add documentation
