### PR TITLE
docs (typo fix): removed extra 'end' in one of the code blocks in template stanza documentation

### DIFF
--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -388,7 +388,7 @@ template {
 # Configuration for 1 redis instances, as assigned via rendezvous hashing.
 {{$allocID := env "NOMAD_ALLOC_ID" -}}
 {{range nomadService 1 $allocID "redis"}}
-  server {{ .Address }}:{{ .Port }};{{- end }}
+  server {{ .Address }}:{{ .Port }};
 {{- end}}
 EOH
 }


### PR DESCRIPTION
In the example code block in [Simple Load Balancing with Nomad Services](https://developer.hashicorp.com/nomad/docs/job-specification/template#simple-load-balancing-with-nomad-services), there is an extra `{{- end }}` which will cause that snippet of code to produce an error