### PR TITLE
docs: Fix broken link on job-specification/checks page

### DIFF
--- a/website/content/docs/job-specification/check.mdx
+++ b/website/content/docs/job-specification/check.mdx
@@ -112,12 +112,12 @@ job "example" {
 - `path` `(string: <varies>)` - Specifies the path of the HTTP endpoint which
   will be queried to observe the health of a service. Nomad will automatically
   add the IP of the service and the port, so this is just the relative URL to
-  the health check endpoint. This is required for http-based health checks.
+  the health check endpoint. This is required for HTTP-based health checks.
 
 - `expose` `(bool: false)` - Specifies whether an [Expose Path](/nomad/docs/job-specification/expose#path-parameters)
   should be automatically generated for this check. Only compatible with
   Connect-enabled task-group services using the default Connect proxy. If set, check
-  [`type`][type] must be `http` or `grpc`, and check `name` must be set.
+  [`type`](#type) must be `http` or `grpc`, and check `name` must be set.
   Only supported in the Consul service provider.
 
 - `port` `(string: <varies>)` - Specifies the label of the port on which the
@@ -131,7 +131,7 @@ job "example" {
   ports by default. In Nomad 0.7.1 or later numeric ports may be used if
   `address_mode="driver"` is set on the check.
 
-- `protocol` `(string: "http")` - Specifies the protocol for the http-based
+- `protocol` `(string: "http")` - Specifies the protocol for the HTTP-based
   health checks. Valid options are `http` and `https`.
 
 - `task` `(string: "")` - Specifies the task associated with this
@@ -328,7 +328,7 @@ check {
 }
 ```
 
-### Healthiness vs. Readiness Checks
+### Healthiness versus Readiness Checks
 
 Multiple checks for a service can be composed to create healthiness and readiness
 checks by configuring [`on_update`][on_update] for the check.
@@ -369,11 +369,13 @@ For checks registered into the Nomad service provider, the status information of
 checks can be viewed per-allocation. The `alloc status` command now includes
 summary information for Nomad service checks.
 
-```
-➜ nomad alloc status <allocation-id>
+```shell-session
+$ nomad alloc status <allocation-id>
 ```
 
-```
+<CodeBlockConfig hideClipboard>
+
+```plaintext
 Nomad Service Checks:
 Service   Task     Name          Mode         Status
 database  task     db_tcp_probe  readiness    success
@@ -381,14 +383,18 @@ web       (group)  healthz       healthiness  failure
 web       (group)  index-page    healthiness  success
 ```
 
+</CodeBlockConfig>
+
 The `alloc checks` command can be used for viewing complete check status information
 for all checks in an allocation.
 
-```
-➜ noamd alloc checks <allocation-id>
+```shell-session
+$ nomad alloc checks <allocation-id>
 ```
 
-```
+<CodeBlockConfig hideClipboard>
+
+```plaintext
 Status of 3 Nomad Service Checks
 
 ID         =  d8651d93a50b9e28375a7beb9418c418
@@ -422,6 +428,8 @@ Mode       =  healthiness
 Timestamp  =  2022-08-22T10:41:23-05:00
 Output     =  nomad: Get "http://:9999/": dial tcp :9999: connect: connection refused
 ```
+
+</CodeBlockConfig>
 
 ---
 


### PR DESCRIPTION
Fixed a broken markdown link. While looking, spotted a typo and an opportunity to tidy up some of the codeblocks
