### PR TITLE
Bumps max variable size to 64 KiB

### DIFF
--- a/.changelog/15983.txt
+++ b/.changelog/15983.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+variables: Increased maximum size to 64KiB
+```

--- a/nomad/structs/variables.go
+++ b/nomad/structs/variables.go
@@ -34,7 +34,7 @@ const (
 	// maxVariableSize is the maximum size of the unencrypted contents of a
 	// variable. This size is deliberately set low and is not configurable, to
 	// discourage DoS'ing the cluster
-	maxVariableSize = 16384
+	maxVariableSize = 65536
 )
 
 // VariableMetadata is the metadata envelope for a Variable, it is the list
@@ -176,7 +176,7 @@ func (v VariableDecrypted) Validate() error {
 		return errors.New("empty variables are invalid")
 	}
 	if v.Items.Size() > maxVariableSize {
-		return errors.New("variables are limited to 16KiB in total size")
+		return errors.New("variables are limited to 64KiB in total size")
 	}
 	if v.Namespace == AllNamespacesSentinel {
 		return errors.New("can not target wildcard (\"*\")namespace")

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -1663,7 +1663,7 @@ The table below shows this endpoint's support for
   URL query parameter.
 
 - `Payload` `(string: "")` - Specifies a base64 encoded string containing the
-  payload. This is limited to 16384 bytes (16KiB).
+  payload. This is limited to 65536 bytes (64KiB).
 
 - `Meta` `(meta<string|string>: nil)` - Specifies arbitrary metadata to pass to
   the job.

--- a/website/content/api-docs/variables.mdx
+++ b/website/content/api-docs/variables.mdx
@@ -158,7 +158,7 @@ includes alphanumeric characters and the special characters `-`, `_`, `~`, and
 `/`. Paths may be up to 128 bytes long. The following regex matches the allowed
 paths: `^[a-zA-Z0-9-_~/]{1,128}$`
 
-Variable items are restricted to 16KiB in size. This limit is calculated by
+Variable items are restricted to 64KiB in size. This limit is calculated by
 taking the sum of the length in bytes of all of the unencrypted keys and values
 in the `Items` field.
 

--- a/website/content/docs/commands/var/put.mdx
+++ b/website/content/docs/commands/var/put.mdx
@@ -51,7 +51,7 @@ template engine. Instead, they require the use of the `index` template function
 to directly access their values. This does not impact cases where the keys and
 values are read using the `range` function.
 
-Variable items are restricted to 16KiB in size. This limit is calculated by
+Variable items are restricted to 64KiB in size. This limit is calculated by
 taking the sum of the length in bytes of all of the unencrypted keys and values.
 
 ## General Options


### PR DESCRIPTION
16 was a little bit too little overhead for common tasks