### PR TITLE
changelog: fix entries for #15522 and #15819

### DIFF
--- a/.changelog/15522.txt
+++ b/.changelog/15522.txt
@@ -1,4 +1,7 @@
 ```release-note:improvement
 server: Added raft snapshot arguments to server config
+```
+
+```release-note:improvement
 server: Certain raft configuration elements can now be reloaded without restarting the server
 ```

--- a/.changelog/15819.txt
+++ b/.changelog/15819.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-"build: Added hyper-v isolation mode for docker on Windows"
+build: Added hyper-v isolation mode for docker on Windows
 ```

--- a/tools/cl-entry/main.go
+++ b/tools/cl-entry/main.go
@@ -29,7 +29,7 @@ const (
   Enter Note => `
 )
 
-var noteRe = regexp.MustCompile(`[a-z0-9/\s]+: .+`)
+var noteRe = regexp.MustCompile(`^[a-z0-9/\s]+: .+`)
 
 func main() {
 	pr, err := ask(pr)


### PR DESCRIPTION
I noticed these while previewing the changelog from `main`.