### PR TITLE
acl: fix a bug in token creation when parsing expiration TTLs. 

### DIFF
--- a/.changelog/15999.txt
+++ b/.changelog/15999.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+acl: Fixed a bug in token creation which failed to parse expiration TTLs correctly
+```

--- a/api/acl.go
+++ b/api/acl.go
@@ -545,6 +545,53 @@ type ACLTokenRoleLink struct {
 	Name string
 }
 
+// MarshalJSON implements the json.Marshaler interface and allows
+// ACLToken.ExpirationTTL to be marshaled correctly.
+func (a *ACLToken) MarshalJSON() ([]byte, error) {
+	type Alias ACLToken
+	exported := &struct {
+		ExpirationTTL string
+		*Alias
+	}{
+		ExpirationTTL: a.ExpirationTTL.String(),
+		Alias:         (*Alias)(a),
+	}
+	if a.ExpirationTTL == 0 {
+		exported.ExpirationTTL = ""
+	}
+	return json.Marshal(exported)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface and allows
+// ACLToken.ExpirationTTL to be unmarshalled correctly.
+func (a *ACLToken) UnmarshalJSON(data []byte) (err error) {
+	type Alias ACLToken
+	aux := &struct {
+		ExpirationTTL interface{}
+		*Alias
+	}{
+		Alias: (*Alias)(a),
+	}
+
+	if err = json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if aux.ExpirationTTL != nil {
+		switch v := aux.ExpirationTTL.(type) {
+		case string:
+			if v != "" {
+				if a.ExpirationTTL, err = time.ParseDuration(v); err != nil {
+					return err
+				}
+			}
+		case float64:
+			a.ExpirationTTL = time.Duration(v)
+		}
+
+	}
+	return nil
+}
+
 type ACLTokenListStub struct {
 	AccessorID string
 	Name       string

--- a/api/acl.go
+++ b/api/acl.go
@@ -567,7 +567,7 @@ func (a *ACLToken) MarshalJSON() ([]byte, error) {
 func (a *ACLToken) UnmarshalJSON(data []byte) (err error) {
 	type Alias ACLToken
 	aux := &struct {
-		ExpirationTTL interface{}
+		ExpirationTTL any
 		*Alias
 	}{
 		Alias: (*Alias)(a),

--- a/command/agent/acl_endpoint_test.go
+++ b/command/agent/acl_endpoint_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -453,6 +454,48 @@ func TestHTTP_ACLTokenCreate(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, out)
 		assert.Equal(t, outTK, out)
+	})
+}
+
+func TestHTTP_ACLTokenCreateExpirationTTL(t *testing.T) {
+	ci.Parallel(t)
+	httpACLTest(t, nil, func(s *TestAgent) {
+
+		// Generate an example token which has an expiration TTL in string
+		// format.
+		aclToken := `
+{
+  "Name": "Readonly token",
+  "Type": "client",
+  "Policies": ["readonly"],
+  "ExpirationTTL": "10h",
+  "Global": false
+}`
+
+		req, err := http.NewRequest("PUT", "/v1/acl/token", bytes.NewReader([]byte(aclToken)))
+		must.NoError(t, err)
+
+		respW := httptest.NewRecorder()
+		setToken(req, s.RootToken)
+
+		// Make the request.
+		obj, err := s.Server.ACLTokenSpecificRequest(respW, req)
+		must.NoError(t, err)
+		must.NotNil(t, obj)
+
+		// Ensure the returned token includes expiration.
+		createdTokenResp := obj.(*structs.ACLToken)
+		must.Eq(t, "10h0m0s", createdTokenResp.ExpirationTTL.String())
+		must.False(t, createdTokenResp.CreateTime.IsZero())
+
+		// Check for the index.
+		must.StrNotEqFold(t, "", respW.Result().Header.Get("X-Nomad-Index"))
+
+		// Check token was created and stored properly within state.
+		out, err := s.Agent.server.State().ACLTokenByAccessorID(nil, createdTokenResp.AccessorID)
+		must.NoError(t, err)
+		must.NotNil(t, out)
+		must.Eq(t, createdTokenResp, out)
 	})
 }
 

--- a/website/content/api-docs/acl/tokens.mdx
+++ b/website/content/api-docs/acl/tokens.mdx
@@ -201,7 +201,8 @@ The table below shows this endpoint's support for
 
 - `ExpirationTTL` `(duration: 0s)` - This is a convenience field and if set will
   initialize the `ExpirationTime` field to a value of `CreateTime` +
-  `ExpirationTTL`.
+  `ExpirationTTL`. This value must be between the [`token_min_expiration_ttl`][]
+  and [`token_max_expiration_ttl`][] ACL configuration parameters.
 
 ### Sample Payload
 
@@ -499,3 +500,6 @@ $ curl \
   }
 }
 ```
+
+[`token_min_expiration_ttl`]: /nomad/docs/configuration/acl#token_min_expiration_ttl
+[`token_max_expiration_ttl`]: /nomad/docs/configuration/acl#token_max_expiration_ttl


### PR DESCRIPTION
The ACL token decoding was not correctly handling time duration
syntax such as "1h" which forced people to use the nanosecond
representation via the HTTP API.

The change adds an unmarshal function which allows this syntax to
be used, along with other styles correctly.

It also includes a docs clarification on the validation params used for
TTL values.

closes #15960 