### PR TITLE
Label for the Web UI

### DIFF
--- a/.changelog/16006.txt
+++ b/.changelog/16006.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Added a ui.label block to agent config, letting operators set a visual label and color for their Nomad instance
+```

--- a/nomad/structs/config/ui.go
+++ b/nomad/structs/config/ui.go
@@ -13,6 +13,9 @@ type UIConfig struct {
 
 	// Vault configures deep links for Vault UI
 	Vault *VaultUIConfig `hcl:"vault"`
+
+	Label      string `hcl:"label"`
+	LabelColor string `hcl:"label_color"`
 }
 
 // ConsulUIConfig configures deep links to this cluster's Consul
@@ -34,9 +37,11 @@ type VaultUIConfig struct {
 // `ui` configuration.
 func DefaultUIConfig() *UIConfig {
 	return &UIConfig{
-		Enabled: true,
-		Consul:  &ConsulUIConfig{},
-		Vault:   &VaultUIConfig{},
+		Enabled:    true,
+		Consul:     &ConsulUIConfig{},
+		Vault:      &VaultUIConfig{},
+		Label:      "",
+		LabelColor: "#000000",
 	}
 }
 
@@ -69,6 +74,8 @@ func (old *UIConfig) Merge(other *UIConfig) *UIConfig {
 	result.Enabled = other.Enabled
 	result.Consul = result.Consul.Merge(other.Consul)
 	result.Vault = result.Vault.Merge(other.Vault)
+	result.Label = other.Label
+	result.LabelColor = other.LabelColor
 
 	return result
 }

--- a/nomad/structs/config/ui.go
+++ b/nomad/structs/config/ui.go
@@ -14,8 +14,8 @@ type UIConfig struct {
 	// Vault configures deep links for Vault UI
 	Vault *VaultUIConfig `hcl:"vault"`
 
-	Label      string `hcl:"label"`
-	LabelColor string `hcl:"label_color"`
+	// Label configures UI label styles
+	Label *LabelUIConfig `hcl:"label"`
 }
 
 // ConsulUIConfig configures deep links to this cluster's Consul
@@ -33,15 +33,21 @@ type VaultUIConfig struct {
 	BaseUIURL string `hcl:"ui_url"`
 }
 
+// Label configures UI label styles
+type LabelUIConfig struct {
+	Text            string `hcl:"text"`
+	BackgroundColor string `hcl:"background_color"`
+	TextColor       string `hcl:"text_color"`
+}
+
 // DefaultUIConfig returns the canonical defaults for the Nomad
 // `ui` configuration.
 func DefaultUIConfig() *UIConfig {
 	return &UIConfig{
-		Enabled:    true,
-		Consul:     &ConsulUIConfig{},
-		Vault:      &VaultUIConfig{},
-		Label:      "",
-		LabelColor: "#000000",
+		Enabled: true,
+		Consul:  &ConsulUIConfig{},
+		Vault:   &VaultUIConfig{},
+		Label:   &LabelUIConfig{},
 	}
 }
 
@@ -74,8 +80,7 @@ func (old *UIConfig) Merge(other *UIConfig) *UIConfig {
 	result.Enabled = other.Enabled
 	result.Consul = result.Consul.Merge(other.Consul)
 	result.Vault = result.Vault.Merge(other.Vault)
-	result.Label = other.Label
-	result.LabelColor = other.LabelColor
+	result.Label = result.Label.Merge(other.Label)
 
 	return result
 }
@@ -132,6 +137,40 @@ func (old *VaultUIConfig) Merge(other *VaultUIConfig) *VaultUIConfig {
 
 	if other.BaseUIURL != "" {
 		result.BaseUIURL = other.BaseUIURL
+	}
+	return result
+}
+
+// Copy returns a copy of this Label UI config.
+func (old *LabelUIConfig) Copy() *LabelUIConfig {
+	if old == nil {
+		return nil
+	}
+
+	nc := new(LabelUIConfig)
+	*nc = *old
+	return nc
+}
+
+// Merge returns a new Label UI configuration by merging another Label UI
+// configuration into this one
+func (old *LabelUIConfig) Merge(other *LabelUIConfig) *LabelUIConfig {
+	result := old.Copy()
+	if result == nil {
+		result = &LabelUIConfig{}
+	}
+	if other == nil {
+		return result
+	}
+
+	if other.Text != "" {
+		result.Text = other.Text
+	}
+	if other.BackgroundColor != "" {
+		result.BackgroundColor = other.BackgroundColor
+	}
+	if other.TextColor != "" {
+		result.TextColor = other.TextColor
 	}
 	return result
 }

--- a/nomad/structs/config/ui_test.go
+++ b/nomad/structs/config/ui_test.go
@@ -18,6 +18,11 @@ func TestUIConfig_Merge(t *testing.T) {
 		Vault: &VaultUIConfig{
 			BaseUIURL: "http://vault.example.com:8200",
 		},
+		Label: &LabelUIConfig{
+			Text:            "Example Cluster",
+			BackgroundColor: "blue",
+			TextColor:       "#fff",
+		},
 	}
 
 	testCases := []struct {
@@ -64,6 +69,7 @@ func TestUIConfig_Merge(t *testing.T) {
 					BaseUIURL: "http://consul-other.example.com:8500",
 				},
 				Vault: &VaultUIConfig{},
+				Label: &LabelUIConfig{},
 			},
 		},
 	}

--- a/ui/app/components/global-header.js
+++ b/ui/app/components/global-header.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
 import { attributeBindings } from '@ember-decorators/component';
+import { htmlSafe } from '@ember/template';
 
 @classic
 @attributeBindings('data-test-global-header')
@@ -20,6 +21,17 @@ export default class GlobalHeader extends Component {
     return (
       !this.system.agent?.get('config') ||
       this.system.agent?.get('config.ACL.Enabled') === true
+    );
+  }
+
+  get labelStyles() {
+    return htmlSafe(
+      `
+        color: ${this.system.agent.get('config')?.UI?.Label?.TextColor};
+        background-color: ${
+          this.system.agent.get('config')?.UI?.Label?.BackgroundColor
+        };
+      `
     );
   }
 }

--- a/ui/app/styles/core/navbar.scss
+++ b/ui/app/styles/core/navbar.scss
@@ -174,4 +174,27 @@
       border-top-color: white;
     }
   }
+
+  .custom-label {
+    border-radius: 1rem;
+    padding: 0.25rem 1rem;
+    background: black;
+    display: grid;
+    grid-template-columns: auto auto;
+    gap: 0.5rem;
+    align-self: center;
+    align-items: center;
+    margin-left: 1rem;
+    & > strong {
+      color: white;
+      font-weight: normal;
+    }
+    & > span {
+      border-radius: 4px;
+      height: 8px;
+      width: 8px;
+      display: block;
+      float: left;
+    }
+  }
 }

--- a/ui/app/styles/core/navbar.scss
+++ b/ui/app/styles/core/navbar.scss
@@ -179,22 +179,8 @@
     border-radius: 1rem;
     padding: 0.25rem 1rem;
     background: black;
+    color: white;
     display: grid;
-    grid-template-columns: auto auto;
-    gap: 0.5rem;
     align-self: center;
-    align-items: center;
-    margin-left: 1rem;
-    & > strong {
-      color: white;
-      font-weight: normal;
-    }
-    & > span {
-      border-radius: 4px;
-      height: 8px;
-      width: 8px;
-      display: block;
-      float: left;
-    }
   }
 }

--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -1,5 +1,6 @@
 {{page-title
   (if this.system.shouldShowRegions (concat this.system.activeRegion " - "))
+  (if this.system.agent.config.UI.Label (concat this.system.agent.config.UI.Label " - "))
   "Nomad"
   separator=" - "
 }}

--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -1,6 +1,6 @@
 {{page-title
   (if this.system.shouldShowRegions (concat this.system.activeRegion " - "))
-  (if this.system.agent.config.UI.Label (concat this.system.agent.config.UI.Label " - "))
+  (if this.system.agent.config.UI.Label.Text (concat this.system.agent.config.UI.Label.Text " - "))
   "Nomad"
   separator=" - "
 }}

--- a/ui/app/templates/components/global-header.hbs
+++ b/ui/app/templates/components/global-header.hbs
@@ -12,6 +12,12 @@
     <LinkTo @route="jobs" class="navbar-item is-logo" aria-label="Home">
       <NomadLogo />
     </LinkTo>
+    {{#if this.system.agent.config.UI.Label}}
+      <div class="custom-label">
+        <span style="background-color: {{this.system.agent.config.UI.LabelColor}}" />
+        <strong>{{this.system.agent.config.UI.Label}}</strong>
+      </div>
+    {{/if}}
   </div>
   {{#if this.system.fuzzySearchEnabled}}
     {{! template-lint-disable simple-unless }}

--- a/ui/app/templates/components/global-header.hbs
+++ b/ui/app/templates/components/global-header.hbs
@@ -13,9 +13,8 @@
       <NomadLogo />
     </LinkTo>
     {{#if this.system.agent.config.UI.Label}}
-      <div class="custom-label">
-        <span style="background-color: {{this.system.agent.config.UI.LabelColor}}" />
-        <strong>{{this.system.agent.config.UI.Label}}</strong>
+      <div class="custom-label" style={{this.labelStyles}}>
+        {{this.system.agent.config.UI.Label.Text}}
       </div>
     {{/if}}
   </div>

--- a/ui/mirage/factories/agent.js
+++ b/ui/mirage/factories/agent.js
@@ -5,19 +5,25 @@ import { DATACENTERS } from '../common';
 
 const UUIDS = provide(100, faker.random.uuid.bind(faker.random));
 const AGENT_STATUSES = ['alive', 'leaving', 'left', 'failed'];
-const AGENT_BUILDS = ['1.1.0-beta', '1.0.2-alpha+ent', ...provide(5, faker.system.semver)];
+const AGENT_BUILDS = [
+  '1.1.0-beta',
+  '1.0.2-alpha+ent',
+  ...provide(5, faker.system.semver),
+];
 
 export default Factory.extend({
-  id: i => (i / 100 >= 1 ? `${UUIDS[i]}-${i}` : UUIDS[i]),
+  id: (i) => (i / 100 >= 1 ? `${UUIDS[i]}-${i}` : UUIDS[i]),
 
   name: () => generateName(),
 
   config: {
     UI: {
       Enabled: true,
+      Label: 'Mirage Mocked',
+      LabelColor: 'hotpink',
     },
     ACL: {
-      Enabled: true
+      Enabled: true,
     },
     Version: {
       Version: '1.1.0',
@@ -59,7 +65,9 @@ export default Factory.extend({
 });
 
 function generateName() {
-  return `nomad@${faker.random.boolean() ? faker.internet.ip() : faker.internet.ipv6()}`;
+  return `nomad@${
+    faker.random.boolean() ? faker.internet.ip() : faker.internet.ipv6()
+  }`;
 }
 
 function generateAddress(name) {
@@ -69,7 +77,8 @@ function generateAddress(name) {
 function generateTags(serfPort) {
   const rpcPortCandidate = faker.random.number({ min: 4000, max: 4999 });
   return {
-    port: rpcPortCandidate === serfPort ? rpcPortCandidate + 1 : rpcPortCandidate,
+    port:
+      rpcPortCandidate === serfPort ? rpcPortCandidate + 1 : rpcPortCandidate,
     dc: faker.helpers.randomize(DATACENTERS),
     build: faker.helpers.randomize(AGENT_BUILDS),
   };

--- a/ui/mirage/factories/agent.js
+++ b/ui/mirage/factories/agent.js
@@ -22,7 +22,7 @@ export default Factory.extend({
       Label: {
         TextColor: 'white',
         BackgroundColor: 'hotpink',
-        Text: 'Mirage Mocked',
+        Text: 'Mirage',
       },
     },
     ACL: {

--- a/ui/mirage/factories/agent.js
+++ b/ui/mirage/factories/agent.js
@@ -19,8 +19,11 @@ export default Factory.extend({
   config: {
     UI: {
       Enabled: true,
-      Label: 'Mirage Mocked',
-      LabelColor: 'hotpink',
+      Label: {
+        TextColor: 'white',
+        BackgroundColor: 'hotpink',
+        Text: 'Mirage Mocked',
+      },
     },
     ACL: {
       Enabled: true,

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -78,7 +78,10 @@ module('Acceptance | allocation detail', function (hooks) {
     );
     assert.ok(Allocation.execButton.isPresent);
 
-    assert.equal(document.title, `Allocation ${allocation.name} - Nomad`);
+    assert.equal(
+      document.title,
+      `Allocation ${allocation.name} - Mirage - Nomad`
+    );
 
     await Allocation.details.visitJob();
     assert.equal(

--- a/ui/tests/acceptance/behaviors/fs.js
+++ b/ui/tests/acceptance/behaviors/fs.js
@@ -87,7 +87,7 @@ export default function browseFilesystem({
         `${pathWithLeadingSlash} - ${getTitleComponent({
           allocation: this.allocation,
           task: this.task,
-        })} - Nomad`
+        })} - Mirage - Nomad`
       );
       assert.equal(
         FS.breadcrumbsText,

--- a/ui/tests/acceptance/client-detail-test.js
+++ b/ui/tests/acceptance/client-detail-test.js
@@ -62,7 +62,7 @@ module('Acceptance | client detail', function (hooks) {
   test('/clients/:id should have a breadcrumb trail linking back to clients', async function (assert) {
     await ClientDetail.visit({ id: node.id });
 
-    assert.equal(document.title, `Client ${node.name} - Nomad`);
+    assert.equal(document.title, `Client ${node.name} - Mirage - Nomad`);
 
     assert.equal(
       Layout.breadcrumbFor('clients.index').text,

--- a/ui/tests/acceptance/clients-list-test.js
+++ b/ui/tests/acceptance/clients-list-test.js
@@ -51,7 +51,7 @@ module('Acceptance | clients list', function (hooks) {
       );
     });
 
-    assert.equal(document.title, 'Clients - Nomad');
+    assert.equal(document.title, 'Clients - Mirage - Nomad');
   });
 
   test('each client record should show high-level info of the client', async function (assert) {

--- a/ui/tests/acceptance/exec-test.js
+++ b/ui/tests/acceptance/exec-test.js
@@ -67,7 +67,7 @@ module('Acceptance | exec', function (hooks) {
       region: 'region-2',
     });
 
-    assert.equal(document.title, 'Exec - region-2 - Nomad');
+    assert.equal(document.title, 'Exec - region-2 - Mirage - Nomad');
 
     assert.equal(Exec.header.region.text, this.job.region);
     assert.equal(Exec.header.namespace.text, this.job.namespace);

--- a/ui/tests/acceptance/regions-test.js
+++ b/ui/tests/acceptance/regions-test.js
@@ -35,7 +35,7 @@ module('Acceptance | regions (only one)', function (hooks) {
     await JobsList.visit();
 
     assert.notOk(Layout.navbar.regionSwitcher.isPresent, 'No region switcher');
-    assert.equal(document.title, 'Jobs - Nomad');
+    assert.equal(document.title, 'Jobs - Mirage - Nomad');
   });
 
   test('when the only region is not named "global", the region switcher still is not shown', async function (assert) {
@@ -100,7 +100,7 @@ module('Acceptance | regions (many)', function (hooks) {
       Layout.navbar.regionSwitcher.isPresent,
       'Region switcher is shown'
     );
-    assert.equal(document.title, 'Jobs - global - Nomad');
+    assert.equal(document.title, 'Jobs - global - Mirage - Nomad');
   });
 
   test('when on the default region, pages do not include the region query param', async function (assert) {

--- a/ui/tests/acceptance/server-detail-test.js
+++ b/ui/tests/acceptance/server-detail-test.js
@@ -25,7 +25,7 @@ module('Acceptance | server detail', function (hooks) {
 
   test('visiting /servers/:server_name', async function (assert) {
     assert.equal(currentURL(), `/servers/${encodeURIComponent(agent.name)}`);
-    assert.equal(document.title, `Server ${agent.name} - Nomad`);
+    assert.equal(document.title, `Server ${agent.name} - Mirage - Nomad`);
   });
 
   test('when the server is the leader, the title shows a leader badge', async function (assert) {

--- a/ui/tests/acceptance/servers-list-test.js
+++ b/ui/tests/acceptance/servers-list-test.js
@@ -61,7 +61,7 @@ module('Acceptance | servers list', function (hooks) {
       );
     });
 
-    assert.equal(document.title, 'Servers - Nomad');
+    assert.equal(document.title, 'Servers - Mirage - Nomad');
   });
 
   test('each server should show high-level info of the server', async function (assert) {

--- a/ui/tests/acceptance/task-detail-test.js
+++ b/ui/tests/acceptance/task-detail-test.js
@@ -65,7 +65,7 @@ module('Acceptance | task detail', function (hooks) {
 
     assert.equal(Task.lifecycle, lifecycleName);
 
-    assert.equal(document.title, `Task ${task.name} - Nomad`);
+    assert.equal(document.title, `Task ${task.name} - Mirage - Nomad`);
   });
 
   test('breadcrumbs match jobs / job / task group / allocation / task', async function (assert) {

--- a/ui/tests/acceptance/task-group-detail-test.js
+++ b/ui/tests/acceptance/task-group-detail-test.js
@@ -123,7 +123,7 @@ module('Acceptance | task group detail', function (hooks) {
 
     assert.equal(
       document.title,
-      `Task group ${taskGroup.name} - Job ${job.name} - Nomad`
+      `Task group ${taskGroup.name} - Job ${job.name} - Mirage - Nomad`
     );
   });
 

--- a/ui/tests/acceptance/task-logs-test.js
+++ b/ui/tests/acceptance/task-logs-test.js
@@ -46,7 +46,7 @@ module('Acceptance | task logs', function (hooks) {
       'No redirect'
     );
     assert.ok(TaskLogs.hasTaskLog, 'Task log component found');
-    assert.equal(document.title, `Task ${task.name} logs - Nomad`);
+    assert.equal(document.title, `Task ${task.name} logs - Mirage - Nomad`);
   });
 
   test('the stdout log immediately starts streaming', async function (assert) {

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -51,7 +51,7 @@ module('Acceptance | tokens', function (hooks) {
       null,
       'No token secret set'
     );
-    assert.equal(document.title, 'Authorization - Nomad');
+    assert.equal(document.title, 'Authorization - Mirage - Nomad');
 
     await Tokens.secret(secretId).submit();
     assert.equal(

--- a/website/content/docs/configuration/ui.mdx
+++ b/website/content/docs/configuration/ui.mdx
@@ -23,6 +23,12 @@ ui {
   vault {
     ui_url = "https://vault.example.com:8200/ui"
   }
+
+  label {
+    text             = "Staging Cluster"
+    background_color = "yellow"
+    text_color       = "#000000"
+  }
 }
 ```
 
@@ -38,6 +44,9 @@ and the configuration is individual to each agent.
 
 - `vault` <code>([Vault]: nil)</code> - Configures integrations
   between the Nomad web UI and the Vault web UI.
+
+- `label` <code>([Label]: nil)</code> - Configures a user-defined
+  label to display in the Nomad Web UI header.
 
 ## `consul` Parameters
 
@@ -61,9 +70,20 @@ and the configuration is individual to each agent.
   `ui.vault.ui_url` is the URL you'll visit in your browser. If
   this field is omitted, this integration will be disabled.
 
+## `label` Parameters
+
+- `text` `(string: "")` - Specifies the text of the label that will be
+  displayed in the header of the Web UI.
+- `background_color` `(string: "")` - The background color of the label to
+  be displayed. The Web UI will default to a black background.
+- `text_color` `(string: "")` - The text color of the label to be displayed.
+  The Web UI will default to white text.
+
+
 
 [web UI]: /nomad/tutorials/web-ui
 [Consul]: /nomad/docs/configuration/ui#consul-parameters
 [Vault]: /nomad/docs/configuration/ui#vault-parameters
+[Label]: /nomad/docs/configuration/ui#label-parameters
 [`consul.address`]: /nomad/docs/configuration/consul#address
 [`vault.address`]: /nomad/docs/configuration/vault#address


### PR DESCRIPTION
Resolves #10813

Adds a label block to the Nomad agent config:

```
ui {
  label {
    text             = "Miami Datacenter"
    background_color = "palegreen"
    text_color       = "hotpink"
  }
}
```
![image](https://user-images.githubusercontent.com/713991/216126969-87305492-e800-4f13-9c7a-29281fab9c2e.png)

Also shows up in the `<title>` attribute for browser tabs etc.