### PR TITLE
acl: fix imports required due to backport of change #16005

### DIFF
--- a/api/acl.go
+++ b/api/acl.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"errors"
 	"time"
 )

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -2,6 +2,7 @@ package structs
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"


### PR DESCRIPTION
targets `release/1.4.x`
caused by #16005 
reason: imports present on main due to auth-method feature, not present in 1.4.x release branch