### PR TITLE
cli: Fix a panic in `deployment status` when scheduling is slow

### DIFF
--- a/.changelog/16011.txt
+++ b/.changelog/16011.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a panic in `deployment status` when rollback deployments are slow to appear
+```

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -332,7 +332,7 @@ UPDATE:
 				// TODO We may want to find a more robust way of waiting for rollbacks to launch instead of
 				// just sleeping for 1 sec. If scheduling is slow, this will break update here instead of
 				// waiting for the (eventual) rollback
-				if rollback.ID == deploy.ID {
+				if rollback == nil || rollback.ID == deploy.ID {
 					break UPDATE
 				}
 
@@ -441,7 +441,7 @@ func (c *DeploymentStatusCommand) defaultMonitor(client *api.Client, deployID st
 				// TODO We may want to find a more robust way of waiting for rollbacks to launch instead of
 				// just sleeping for 1 sec. If scheduling is slow, this will break update here instead of
 				// waiting for the (eventual) rollback
-				if rollback.ID == deploy.ID {
+				if rollback == nil || rollback.ID == deploy.ID {
 					return
 				}
 				c.defaultMonitor(client, rollback.ID, index, wait, verbose)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/15235

If a deployment fails, the `deployment status` command can get a nil deployment when it checks for a rollback deployment if there isn't one (or at least not one at the time of the query). Fix the panic.

Note that I'm intentionally punting on solving the old TODO here, as it'd just take too long for me to page all this code in. Dropping a quick panic fix was a small win between other tasks :grin: 