### PR TITLE
job parsing: fix panic when variable validation is missing condition

### DIFF
--- a/.changelog/16018.txt
+++ b/.changelog/16018.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+parser: Fixed a panic in the job spec parser when a variable validation block was missing its condition
+```

--- a/jobspec2/types.variables.go
+++ b/jobspec2/types.variables.go
@@ -95,6 +95,17 @@ func (v *Variable) validateValue(val VariableAssignment) (diags hcl.Diagnostics)
 	for _, validation := range v.Validations {
 		const errInvalidCondition = "Invalid variable validation result"
 
+		if validation.Condition == nil {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity:    hcl.DiagError,
+				Summary:     "Invalid variable validation specification",
+				Detail:      "validation requires a condition.",
+				Subject:     validation.DeclRange.Ptr(),
+				EvalContext: hclCtx,
+			})
+			continue
+		}
+
 		result, moreDiags := validation.Condition.Value(hclCtx)
 		diags = append(diags, moreDiags...)
 		if !result.IsKnown() {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/12513

---

Test using the example jobspec from #12513:

```
$ nomad job run -var 'image_id=foo-' example.nomad
Error getting job struct: Error parsing job file from example.nomad:
example.nomad:5,14-14: Missing required argument; The argument "condition" is required, but no definition was found.
example.nomad:5,3-13: Invalid variable validation specification; validation requires a condition.
```