### PR TITLE
bootstrap: upgrade golangci-lint in prep for go1.20

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -136,7 +136,7 @@ deps:  ## Install build and development dependencies
 lint-deps: ## Install linter dependencies
 ## Keep versions in sync with tools/go.mod (see https://github.com/golang/go/issues/30515)
 	@echo "==> Updating linter dependencies..."
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4
 	go install github.com/hashicorp/go-hclog/hclogvet@v0.1.5
 

--- a/e2e/e2eutil/job.go
+++ b/e2e/e2eutil/job.go
@@ -29,9 +29,7 @@ func Register(jobID, jobFilePath string) error {
 func RegisterWithArgs(jobID, jobFilePath string, args ...string) error {
 
 	baseArgs := []string{"job", "run", "-detach"}
-	for i := range args {
-		baseArgs = append(baseArgs, args[i])
-	}
+	baseArgs = append(baseArgs, args...)
 	baseArgs = append(baseArgs, "-")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
@@ -224,9 +222,7 @@ func StopJob(jobID string, args ...string) error {
 	// Build our argument list in the correct order, ensuring the jobID is last
 	// and the Nomad subcommand are first.
 	baseArgs := []string{"job", "stop"}
-	for i := range args {
-		baseArgs = append(baseArgs, args[i])
-	}
+	baseArgs = append(baseArgs, args...)
 	baseArgs = append(baseArgs, jobID)
 
 	// Execute the command. We do not care about the stdout, only stderr.


### PR DESCRIPTION
This PR updates golangci-lint to work better with go1.20 - the previous
version would cause in oom on 'make check'.

The baseArgs tweak fixes something the linter now finds (useless for-loop vs. append)

Part of https://github.com/hashicorp/nomad/issues/16022