### PR TITLE
Footer styles re-applied to job template footer

### DIFF
--- a/ui/app/styles/core/forms.scss
+++ b/ui/app/styles/core/forms.scss
@@ -124,6 +124,13 @@
     grid-template-columns: 6fr 1fr;
     gap: 0 1rem;
   }
+
+  footer {
+    display: grid;
+    grid-auto-columns: max-content;
+    grid-auto-flow: column;
+    gap: 1rem;
+  }
 }
 
 .mock-sso-provider {


### PR DESCRIPTION
Fixes a misalignment on job template form footer button group: 
![image](https://user-images.githubusercontent.com/713991/216440403-54ccb3c2-1093-406a-b3c4-db6c24f8c144.png)
