### PR TITLE
docs: fix outstanding content conformance errors

### DIFF
--- a/website/content/docs/commands/operator/keyring.mdx
+++ b/website/content/docs/commands/operator/keyring.mdx
@@ -1,6 +1,10 @@
 ---
 layout: docs
 page_title: 'Commands: operator keyring'
+description: |-
+  The `operator keyring` command is used to examine and
+  modify the encryption keys used in Nomad server. It can
+  also distribute new keys and retire old ones.
 ---
 
 # Command: operator keyring

--- a/website/content/docs/commands/operator/metrics.mdx
+++ b/website/content/docs/commands/operator/metrics.mdx
@@ -1,6 +1,10 @@
 ---
 layout: docs
 page_title: 'Commands: operator metrics'
+description: |-
+  The `operator metrics` command queries the metrics API
+  endpoint for metrics data related to the current Nomad
+  process.
 ---
 
 # Command: operator metrics

--- a/website/content/docs/job-specification/hcl2/expressions.mdx
+++ b/website/content/docs/job-specification/hcl2/expressions.mdx
@@ -336,8 +336,8 @@ block. If you need to declare resource instances based on a nested data
 structure or combinations of elements from multiple data structures you can use
 expressions and functions to derive a suitable value. For some common examples
 of such situations, see the
-[`flatten`](/docs/job-specification/hcl2/functions/collection/flatten) and
-[`setproduct`](/docs/job-specification/hcl2/functions/collection/setproduct)
+[`flatten`](/nomad/docs/job-specification/hcl2/functions/collection/flatten) and
+[`setproduct`](/nomad/docs/job-specification/hcl2/functions/collection/setproduct)
 functions.
 
 ### Best Practices for `dynamic` Blocks


### PR DESCRIPTION
Addresses some outstanding content errors detected with our content checks.

```
content/docs/commands/operator/keyring.mdx
1:1 error Document does not have a description key in its frontmatter. Add a description key at the top of the document. ensure-valid-frontmatter

content/docs/commands/operator/metrics.mdx
1:1 error Document does not have a description key in its frontmatter. Add a description key at the top of the document. ensure-valid-frontmatter

content/docs/job-specification/hcl2/expressions.mdx
339:1-339:71 error Unexpected product-relative link: /docs/job-specification/hcl2/functions/collection/flatten. Ensure that relative links are fully-qualified Developer paths: /{productSlug}/docs/job-specification/hcl2/functions/collection/flatten ensure-valid-link-format
340:1-340:77 error Unexpected product-relative link: /docs/job-specification/hcl2/functions/collection/setproduct. Ensure that relative links are fully-qualified Developer paths: /{productSlug}/docs/job-specification/hcl2/functions/collection/setproduct ensure-valid-link-format

✖ 4 errors
```