### PR TITLE
Backport #16030 System and sysbatch jobs always have zero index to 1.3.x

### DIFF
--- a/.changelog/16030.txt
+++ b/.changelog/16030.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+volumes: Fixed a bug where `per_alloc` was allowed for volume blocks on system and sysbatch jobs, which do not have an allocation index
+```

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6435,7 +6435,7 @@ func (tg *TaskGroup) Validate(j *Job) error {
 		canaries = tg.Update.Canary
 	}
 	for name, volReq := range tg.Volumes {
-		if err := volReq.Validate(tg.Count, canaries); err != nil {
+		if err := volReq.Validate(j.Type, tg.Count, canaries); err != nil {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf(
 				"Task group volume validation for %s failed: %v", name, err))
 		}

--- a/nomad/structs/volume_test.go
+++ b/nomad/structs/volume_test.go
@@ -68,8 +68,11 @@ func TestVolumeRequest_Validate(t *testing.T) {
 			},
 		},
 		{
-			name:          "CSI volume per-alloc with canaries",
-			expected:      []string{"volume cannot be per_alloc when canaries are in use"},
+			name: "CSI volume per-alloc with canaries",
+			expected: []string{
+				"volume cannot be per_alloc for system or sysbatch jobs",
+				"volume cannot be per_alloc when canaries are in use",
+			},
 			canariesCount: 1,
 			req: &VolumeRequest{
 				Type:     VolumeTypeCSI,
@@ -81,7 +84,7 @@ func TestVolumeRequest_Validate(t *testing.T) {
 	for _, tc := range testCases {
 		tc = tc
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.req.Validate(tc.taskGroupCount, tc.canariesCount)
+			err := tc.req.Validate(JobTypeSystem, tc.taskGroupCount, tc.canariesCount)
 			for _, expected := range tc.expected {
 				require.Contains(t, err.Error(), expected)
 			}

--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -102,7 +102,7 @@ type VolumeRequest struct {
 	PerAlloc       bool
 }
 
-func (v *VolumeRequest) Validate(taskGroupCount, canaries int) error {
+func (v *VolumeRequest) Validate(jobType string, taskGroupCount, canaries int) error {
 	if !(v.Type == VolumeTypeHost ||
 		v.Type == VolumeTypeCSI) {
 		return fmt.Errorf("volume has unrecognized type %s", v.Type)
@@ -170,9 +170,13 @@ func (v *VolumeRequest) Validate(taskGroupCount, canaries int) error {
 		case CSIVolumeAccessModeMultiNodeMultiWriter:
 			// note: we intentionally allow read-only mount of this mode
 		}
-
-		if v.PerAlloc && canaries > 0 {
-			addErr("volume cannot be per_alloc when canaries are in use")
+		if v.PerAlloc {
+			if jobType == JobTypeSystem || jobType == JobTypeSysBatch {
+				addErr("volume cannot be per_alloc for system or sysbatch jobs")
+			}
+			if canaries > 0 {
+				addErr("volume cannot be per_alloc when canaries are in use")
+			}
 		}
 
 	}

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -9,11 +9,13 @@ import (
 
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
@@ -89,6 +91,15 @@ func TestServiceSched_JobRegister(t *testing.T) {
 	if len(out) != 10 {
 		t.Fatalf("bad: %#v", out)
 	}
+
+	// Ensure allocations have unique names derived from Job.ID
+	allocNames := helper.ConvertSlice(out,
+		func(alloc *structs.Allocation) string { return alloc.Name })
+	expectAllocNames := []string{}
+	for i := 0; i < 10; i++ {
+		expectAllocNames = append(expectAllocNames, fmt.Sprintf("%s.web[%d]", job.ID, i))
+	}
+	must.SliceContainsAll(t, expectAllocNames, allocNames)
 
 	// Ensure different ports were used.
 	used := make(map[int]map[string]struct{})

--- a/scheduler/scheduler_sysbatch_test.go
+++ b/scheduler/scheduler_sysbatch_test.go
@@ -7,11 +7,13 @@ import (
 
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/kr/pretty"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,6 +65,15 @@ func TestSysBatch_JobRegister(t *testing.T) {
 
 	// Ensure all allocations placed
 	require.Len(t, out, 10)
+
+	// Note that all sysbatch allocations have the same name derived from Job.Name
+	allocNames := helper.ConvertSlice(out,
+		func(alloc *structs.Allocation) string { return alloc.Name })
+	expectAllocNames := []string{}
+	for i := 0; i < 10; i++ {
+		expectAllocNames = append(expectAllocNames, fmt.Sprintf("%s.pinger[0]", job.Name))
+	}
+	must.SliceContainsAll(t, expectAllocNames, allocNames)
 
 	// Check the available nodes
 	count, ok := out[0].Metrics.NodesAvailable["dc1"]

--- a/scheduler/scheduler_system_test.go
+++ b/scheduler/scheduler_system_test.go
@@ -9,6 +9,7 @@ import (
 
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -65,6 +66,15 @@ func TestSystemSched_JobRegister(t *testing.T) {
 
 	// Ensure all allocations placed
 	require.Len(t, out, 10)
+
+	// Note that all system allocations have the same name derived from Job.Name
+	allocNames := helper.ConvertSlice(out,
+		func(alloc *structs.Allocation) string { return alloc.Name })
+	expectAllocNames := []string{}
+	for i := 0; i < 10; i++ {
+		expectAllocNames = append(expectAllocNames, fmt.Sprintf("%s.web[0]", job.Name))
+	}
+	must.SliceContainsAll(t, expectAllocNames, allocNames)
 
 	// Check the available nodes
 	count, ok := out[0].Metrics.NodesAvailable["dc1"]

--- a/website/content/docs/job-specification/volume.mdx
+++ b/website/content/docs/job-specification/volume.mdx
@@ -99,6 +99,9 @@ The following fields are only valid for volumes with `type = "csi"`:
   = true`, the allocation named `myjob.mygroup.mytask[0]` will require a
   volume ID `myvolume[0]`.
 
+  The `per_alloc` field cannot be true for system jobs, sysbatch jobs, or jobs
+  that use canaries.
+
 - `mount_options` - Options for mounting CSI volumes that have the
   `file-system` [attachment mode]. These options override the `mount_options`
   field from [volume registration]. Consult the documentation for your storage

--- a/website/content/partials/envvars.mdx
+++ b/website/content/partials/envvars.mdx
@@ -1,392 +1,63 @@
-<table>
-  <thead>
-    <tr>
-      <th>Variable</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>NOMAD_ALLOC_DIR</code>
-      </td>
-      <td>
-        The path to the shared <code>alloc/</code> directory. See
-        <a href="/docs/runtime/environment#task-directories"> here</a> for more information.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_TASK_DIR</code>
-      </td>
-      <td>
-        The path to the task <code>local/</code> directory. See
-        <a href="/docs/runtime/environment#task-directories"> here</a> for more information.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_SECRETS_DIR</code>
-      </td>
-      <td>
-        Path to the task's secrets directory. See
-        <a href="/docs/runtime/environment#task-directories"> here</a> for more information.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_MEMORY_LIMIT</code>
-      </td>
-      <td>Memory limit in MB for the task</td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_MEMORY_MAX_LIMIT</code>
-      </td>
-      <td>
-        The maximum memory limit the task may use if client has excess memory
-        capacity, in MB. Omitted if task isn't configured with memory oversubscription.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_CPU_LIMIT</code>
-      </td>
-      <td>CPU limit in MHz for the task</td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_CPU_CORES</code>
-      </td>
-      <td>
-        The specific CPU cores reserved for the task in cpuset list notation.
-        Omitted if the the task does not request cpu cores. E.g. <code>0-2,7,12-14</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_ALLOC_ID</code>
-      </td>
-      <td>Allocation ID of the task</td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_SHORT_ALLOC_ID</code>
-      </td>
-      <td>The first 8 characters of the allocation ID of the task</td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_ALLOC_NAME</code>
-      </td>
-      <td>Allocation name of the task</td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_ALLOC_INDEX</code>
-      </td>
-      <td>
-        Allocation index; useful to distinguish instances of task groups. From 0
-        to (count - 1). The index is unique within a given version of a job, but
-        canaries or failed tasks in a deployment may reuse the index.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_TASK_NAME</code>
-      </td>
-      <td>Task's name</td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_GROUP_NAME</code>
-      </td>
-      <td>Group's name</td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_JOB_ID</code>
-      </td>
-      <td>
-        Job's ID, which is equal to the Job name when submitted through
-        CLI but can be different when using the API
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_JOB_NAME</code>
-      </td>
-      <td>Job's name</td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_JOB_PARENT_ID</code>
-      </td>
-      <td>ID of the Job's parent if it has one</td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_DC</code>
-      </td>
-      <td>Datacenter in which the allocation is running</td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_PARENT_CGROUP</code>
-      </td>
-      <td>The parent cgroup used to contain task cgroups (Linux only)</td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_NAMESPACE</code>
-      </td>
-      <td>Namespace in which the allocation is running</td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_REGION</code>
-      </td>
-      <td>Region in which the allocation is running</td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_META_&lt;key&gt;</code>
-      </td>
-      <td>
-        The metadata value given by <code>key</code> on the task's
-        metadata. Note that this is different from
-        <a href="/docs/runtime/interpolation#node-variables-">
-          <code>$&#123;meta.&lt;key&gt;&#125;</code>
-        </a>
-        which are keys in the node's metadata.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>VAULT_TOKEN</code>
-      </td>
-      <td>
-        The task's Vault token. See
-        <a href="/docs/vault-integration"> Vault Integration </a>
-        for more details
-      </td>
-    </tr>
-    <tr>
-      <th colSpan="2">Network-related Variables</th>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_IP_&lt;label&gt;</code>
-      </td>
-      <td>
-        Host IP for the given port <code>label</code>. See
-        <a href="/docs/job-specification/network"> here for more</a> information.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_PORT_&lt;label&gt;</code>
-      </td>
-      <td>
-        Port for the given port <code>label</code>. Driver-specified port when a
-        port map is used, otherwise the host's static or dynamic port
-        allocation. Services should bind to this port. See
-        <a href="/docs/job-specification/network"> here for more</a> information.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_ADDR_&lt;label&gt;</code>
-      </td>
-      <td>
-        Host <code>IP:Port</code> pair for the given port <code>label</code>.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_HOST_PORT_&lt;label&gt;</code>
-      </td>
-      <td>
-        Port on the host for the port <code>label</code>. See
-        <a href="/docs/job-specification/network#mapped-ports"> here</a> for more
-        information.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_IP_&lt;task&gt;_&lt;label&gt;</code>
-      </td>
-      <td>
-        <b>Deprecated</b>. Host IP for the given port <code>label</code>
-        and <code>task</code> for tasks in the same task group. Only available
-        when setting ports via the task resource network port mapping.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_PORT_&lt;task&gt;_&lt;label&gt;</code>
-      </td>
-      <td>
-        <b>Deprecated</b>. Port for the given port <code>label</code> and
-        <code>task</code> for tasks in the same task group. Driver-specified port
-        when a port map is used, otherwise the host's static or dynamic port
-        allocation. Services should bind to this port. Only available when setting
-        ports via the task resource network port mapping.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_ADDR_&lt;task&gt;_&lt;label&gt;</code>
-      </td>
-      <td>
-        <b>Deprecated</b>. Host <code>IP:Port</code> pair for the given port
-        <code>label</code> and <code>task</code> for tasks in the same task group.
-        Only available when setting ports via the task resource network port
-        mapping.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_HOST_PORT_&lt;task&gt;_&lt;label&gt;</code>
-      </td>
-      <td>
-        <b>Deprecated</b>. Port on the host for the port <code>label</code> and
-        <code>task</code> for tasks in the same task group. Only available when
-        setting ports via the task resource network port mapping.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_UPSTREAM_IP_&lt;service&gt;</code>
-      </td>
-      <td>
-        IP for the given <code>service</code> when defined as a Consul Connect
-        <a href="/docs/job-specification/upstreams"> upstream</a>.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_UPSTREAM_PORT_&lt;service&gt;</code>
-      </td>
-      <td>
-        Port for the given <code>service</code> when defined as a Consul Connect
-        <a href="/docs/job-specification/upstreams"> upstream</a>.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_UPSTREAM_ADDR_&lt;service&gt;</code>
-      </td>
-      <td>
-        Host <code>IP:Port</code> for the given <code>service</code> when
-        defined as a Consul Connect
-        <a href="/docs/job-specification/upstreams"> upstream</a>.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>NOMAD_ENVOY_ADMIN_ADDR_&lt;service&gt;</code>
-      </td>
-      <td>
-        Local address <code>127.0.0.2:Port</code> for the admin port of the
-        envoy sidecar for the given <code>service</code> when defined as a
-        Consul Connect enabled service. Envoy runs inside the group network
-        namespace unless configured for host networking.
-      </td>
-    </tr>
-      <tr>
-        <td>
-          <code>NOMAD_ENVOY_READY_ADDR_&lt;service&gt;</code>
-        </td>
-        <td>
-          Local address <code>127.0.0.1:Port</code> for the ready port of the
-          envoy sidecar for the given <code>service</code> when defined as a
-          Consul Connect enabled service. Envoy runs inside the group network
-          namespace unless configured for host networking.
-        </td>
-      </tr>
-    <tr>
-      <th colSpan="2">Consul-related Variables (only set for connect native tasks)</th>
-    </tr>
-    <tr>
-      <td>
-        <code>CONSUL_HTTP_ADDR</code>
-      </td>
-      <td>
-        Specifies the address to the local Consul agent. Will be automatically
-        set to a unix domain socket in bridge networking mode, or a tcp address in
-        host networking mode.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>CONSUL_HTTP_TOKEN</code>
-      </td>
-      <td>
-        Specifies the Consul ACL token used to authorize with Consul. Will be
-        automatically set to a generated Connect service identity token specific
-        to the service instance if Consul ACLs are enabled.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>CONSUL_HTTP_SSL</code>
-      </td>
-      <td>
-        Specifies whether HTTPS should be used when communicating with consul. Will
-        be automatically set to true if Nomad is configured to communicate with
-        Consul using TLS.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>CONSUL_HTTP_SSL_VERIFY</code>
-      </td>
-      <td>
-        Specifies whether the HTTPS connection with Consul should be mutually
-        verified. Will be automatically set to true if Nomad is configured to
-        verify TLS certificates.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>CONSUL_CACERT</code>
-      </td>
-      <td>
-        Specifies the path to the CA certificate used for Consul communication.
-        Will be automatically set if Nomad is configured with the <code>consul.share_ssl</code>
-        option.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>CONSUL_CLIENT_CERT</code>
-      </td>
-      <td>
-        Specifies the path to the Client certificate used for Consul communication.
-        Will be automatically set if Nomad is configured with the <code>consul.share_ssl</code>
-        option.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>CONSUL_CLIENT_KEY</code>
-      </td>
-      <td>
-        Specifies the path to the CLient Key certificate used for Consul communication.
-        Will be automatically set if Nomad is configured with the <code>consul.share_ssl</code>
-        option.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>CONSUL_TLS_SERVER_NAME</code>
-      </td>
-      <td>
-        Specifies the server name to use as the SNI host for Consul communication.
-        Will be automatically set if Consul is configured to use TLS and the task
-        is in a group using bridge networking mode.
-      </td>
-    </tr>
-  </tbody>
-</table>
+### Job-related variables
+
+| Variable                 | Description                                                                                                                                                                                                                                                                     |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `NOMAD_ALLOC_DIR`        | The path to the shared `alloc/` directory. See [here](/nomad/docs/runtime/environment#task-directories) for more information.                                                                                                                                                   |
+| `NOMAD_TASK_DIR`         | The path to the task `local/` directory. See [here](/nomad/docs/runtime/environment#task-directories) for more information.                                                                                                                                                     |
+| `NOMAD_SECRETS_DIR`      | Path to the task's secrets directory. See [here](/nomad/docs/runtime/environment#task-directories) for more information.                                                                                                                                                        |
+| `NOMAD_MEMORY_LIMIT`     | Memory limit in MB for the task                                                                                                                                                                                                                                                 |
+| `NOMAD_MEMORY_MAX_LIMIT` | The maximum memory limit the task may use if client has excess memory capacity, in MB. Omitted if task isn't configured with memory oversubscription.                                                                                                                           |
+| `NOMAD_CPU_LIMIT`        | CPU limit in MHz for the task                                                                                                                                                                                                                                                   |
+| `NOMAD_CPU_CORES`        | The specific CPU cores reserved for the task in cpuset list notation. Omitted if the task does not request cpu cores. E.g. `0-2,7,12-14`                                                                                                                                        |
+| `NOMAD_ALLOC_ID`         | Allocation ID of the task                                                                                                                                                                                                                                                       |
+| `NOMAD_SHORT_ALLOC_ID`   | The first 8 characters of the allocation ID of the task                                                                                                                                                                                                                         |
+| `NOMAD_ALLOC_NAME`       | Allocation name of the task. This is derived from the job name, task group name, and allocation index.                                                                                                                                                                          |
+| `NOMAD_ALLOC_INDEX`      | Allocation index; useful to distinguish instances of task groups. From 0 to (count - 1). For system jobs and sysbatch jobs, this value will always be 0. The index is unique within a given version of a job, but canaries or failed tasks in a deployment may reuse the index. |
+| `NOMAD_TASK_NAME`        | Task's name                                                                                                                                                                                                                                                                     |
+| `NOMAD_GROUP_NAME`       | Group's name                                                                                                                                                                                                                                                                    |
+| `NOMAD_JOB_ID`           | Job's ID, which is equal to the Job name when submitted through CLI but can be different when using the API                                                                                                                                                                     |
+| `NOMAD_JOB_NAME`         | Job's name                                                                                                                                                                                                                                                                      |
+| `NOMAD_JOB_PARENT_ID`    | ID of the Job's parent if it has one                                                                                                                                                                                                                                            |
+| `NOMAD_DC`               | Datacenter in which the allocation is running                                                                                                                                                                                                                                   |
+| `NOMAD_PARENT_CGROUP`    | The parent cgroup used to contain task cgroups (Linux only)                                                                                                                                                                                                                     |
+| `NOMAD_NAMESPACE`        | Namespace in which the allocation is running                                                                                                                                                                                                                                    |
+| `NOMAD_REGION`           | Region in which the allocation is running                                                                                                                                                                                                                                       |
+| `NOMAD_META_<key>`       | The metadata value given by `key` on the task's metadata. Note that this is different from [`${meta.<key>}`](/nomad/docs/runtime/interpolation#node-variables-) which are keys in the node's metadata.                                                                          |
+| `VAULT_TOKEN`            | The task's Vault token. See [Vault Integration](/nomad/docs/integrations/vault-integration) for more details                                                                                                                                                                    |
+
+### Network-related Variables
+
+| Variable                           | Description                                                                                                                                                                                                                                                                                                          |
+|------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `NOMAD_IP_<label>`                 | Host IP for the given port `label`. See [here for more](/docs/job-specification/network) information.                                                                                                                                                                                                                |
+| `NOMAD_PORT_<label>`               | Port for the given port `label`. Driver-specified port when a port map is used, otherwise the host's static or dynamic port allocation. Services should bind to this port. See [here for more](/docs/job-specification/network) information.                                                                         |
+| `NOMAD_ADDR_<label>`               | Host `IP:Port` pair for the given port `label`.                                                                                                                                                                                                                                                                      |
+| `NOMAD_HOST_PORT_<label>`          | Port on the host for the port `label`. See [here](/docs/job-specification/network#mapped-ports) for more information.                                                                                                                                                                                                |
+| `NOMAD_IP_<task>_<label>`          | **Deprecated**. Host IP for the given port `label` and `task` for tasks in the same task group. Only available when setting ports via the task resource network port mapping.                                                                                                                                        |
+| `NOMAD_PORT_<task>_<label>`        | **Deprecated**. Port for the given port `label` and `task` for tasks in the same task group. Driver-specified port when a port map is used, otherwise the host's static or dynamic port allocation. Services should bind to this port. Only available when setting ports via the task resource network port mapping. |
+| `NOMAD_ADDR_<task>_<label>`        | **Deprecated**. Host `IP:Port` pair for the given port `label` and `task` for tasks in the same task group. Only available when setting ports via the task resource network port mapping.                                                                                                                            |
+| `NOMAD_HOST_PORT_<task>_<label>`   | **Deprecated**.  Port on the host for the port `label` and `task` for tasks in the same task group. Only available when setting ports via the task resource network port mapping.                                                                                                                                    |
+| `NOMAD_UPSTREAM_IP_<service>`      | IP for the given `service` when defined as a Consul Connect [upstream](/docs/job-specification/upstreams).                                                                                                                                                                                                           |
+| `NOMAD_UPSTREAM_PORT_<service>`    | Port for the given `service` when defined as a Consul Connect [upstream](/docs/job-specification/upstreams).                                                                                                                                                                                                         |
+| `NOMAD_UPSTREAM_ADDR_<service>`    | Host `IP:Port` for the given `service` when defined as a Consul Connect [upstream](/docs/job-specification/upstreams).                                                                                                                                                                                               |
+| `NOMAD_ENVOY_ADMIN_ADDR_<service>` | Local address `127.0.0.2:Port` for the admin port of the envoy sidecar for the given `service` when defined as a Consul Connect enabled service. Envoy runs inside the group network namespace unless configured for host networking.                                                                                |
+| `NOMAD_ENVOY_READY_ADDR_<service>` | Local address `127.0.0.1:Port` for the ready port of the envoy sidecar for the given `service` when defined as a Consul Connect enabled service. Envoy runs inside the group network namespace unless configured for host networking.                                                                                |
+
+~> **Note:** Port labels and task names will have any non-alphanumeric or
+  underscore characters in their names replaced by underscores `_` when they're
+  used in environment variable names such as `NOMAD_ADDR_<task>_<label>`.
+
+### Consul-related Variables
+
+This variables are only set for Connect native tasks.
+
+| Variable                 | Description                                                                                                                                                                                        |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CONSUL_HTTP_ADDR`       | Specifies the address to the local Consul agent. Will be automatically set to a unix domain socket in bridge networking mode, or a tcp address in host networking mode.                            |
+| `CONSUL_HTTP_TOKEN`      | Specifies the Consul ACL token used to authorize with Consul. Will be automatically set to a generated Connect service identity token specific to the service instance if Consul ACLs are enabled. |
+| `CONSUL_HTTP_SSL`        | Specifies whether HTTPS should be used when communicating with consul. Will be automatically set to true if Nomad is configured to communicate with Consul using TLS.                              |
+| `CONSUL_HTTP_SSL_VERIFY` | Specifies whether the HTTPS connection with Consul should be mutually verified. Will be automatically set to true if Nomad is configured to verify TLS certificates.                               |
+| `CONSUL_CACERT`          | Specifies the path to the CA certificate used for Consul communication. Will be automatically set if Nomad is configured with the `consul.share_ssl` option.                                       |
+| `CONSUL_CLIENT_CERT`     | Specifies the path to the Client certificate used for Consul communication. Will be automatically set if Nomad is configured with the `consul.share_ssl` option.                                   |
+| `CONSUL_CLIENT_KEY`      | Specifies the path to the CLient Key certificate used for Consul communication. Will be automatically set if Nomad is configured with the `consul.share_ssl` option.                               |
+| `CONSUL_TLS_SERVER_NAME` | Specifies the server name to use as the SNI host for Consul communication. Will be automatically set if Consul is configured to use TLS and the task is in a group using bridge networking mode.   |


### PR DESCRIPTION
This hand-backports https://github.com/hashicorp/nomad/pull/16030 to 1.3.x, because the original PR touched some code that has a minor new feature for 1.5.0 (per_alloc host volumes) and because there are some significant conflicts over the env vars page, for which the new table syntax was never backported.

---

Service jobs should have unique allocation Names, derived from the Job.ID. System jobs do not have unique allocation Names because the index is intended to indicated the instance out of a desired count size. Because system jobs do not have an explicit count but the results are based on the targeted nodes, the index is less informative and this was intentionally omitted from the original design.

Update docs to make it clear that NOMAD_ALLOC_INDEX is always zero for system/sysbatch jobs

Validate that `volume.per_alloc` is incompatible with system/sysbatch jobs. System and sysbatch jobs always have a `NOMAD_ALLOC_INDEX` of 0. So interpolation via `per_alloc` will not work as soon as there's more than one allocation placed. Validate against this on job submission.