### PR TITLE
build: update hclogvet

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -138,7 +138,7 @@ lint-deps: ## Install linter dependencies
 	@echo "==> Updating linter dependencies..."
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4
-	go install github.com/hashicorp/go-hclog/hclogvet@v0.1.5
+	go install github.com/hashicorp/go-hclog/hclogvet@v0.1.6
 
 .PHONY: git-hooks
 git-dir = $(shell git rev-parse --git-dir)


### PR DESCRIPTION
fixes a build failure 

```
==> Linting hclog statements...
Error: /home/runner/work/nomad/nomad/main.go:180:43: cmd.Synopsis undefined (type cli.Command has no field or method Synopsis)
hclogvet: analysis skipped due to errors in package
make: *** [GNUmakefile:155: check] Error 1
```