### PR TITLE
Add cpuset_mems to docker driver.

### DIFF
--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -341,6 +341,7 @@ var (
 		"cap_drop":       hclspec.NewAttr("cap_drop", "list(string)", false),
 		"command":        hclspec.NewAttr("command", "string", false),
 		"cpuset_cpus":    hclspec.NewAttr("cpuset_cpus", "string", false),
+		"cpuset_mems":    hclspec.NewAttr("cpuset_mems", "string", false),
 		"cpu_hard_limit": hclspec.NewAttr("cpu_hard_limit", "bool", false),
 		"cpu_cfs_period": hclspec.NewDefault(
 			hclspec.NewAttr("cpu_cfs_period", "number", false),
@@ -433,6 +434,7 @@ type TaskConfig struct {
 	CPUCFSPeriod      int64              `codec:"cpu_cfs_period"`
 	CPUHardLimit      bool               `codec:"cpu_hard_limit"`
 	CPUSetCPUs        string             `codec:"cpuset_cpus"`
+	CPUSetMEMs        string             `codec:"cpuset_mems"`
 	Devices           []DockerDevice     `codec:"devices"`
 	DNSSearchDomains  []string           `codec:"dns_search_domains"`
 	DNSOptions        []string           `codec:"dns_options"`

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -888,6 +888,13 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		hostConfig.CPUSetCPUs = driverConfig.CPUSetCPUs
 	}
 
+	// This translates to docker create/run --cpuset-mems option.
+	// --cpuset-mems is the list of memory nodes on which processes
+	// in this cpuset are allowed to allocate memory.
+	if driverConfig.CPUSetMEMs != "" {
+		hostConfig.CPUSetMEMs = driverConfig.CPUSetMEMs
+	}
+
 	// Enable tini (docker-init) init system.
 	if driverConfig.Init {
 		hostConfig.Init = driverConfig.Init

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -84,7 +84,7 @@ The `docker` driver supports the following configuration in the job spec. Only
   }
   ```
 
-- `cpuset_cpus` <sup>Beta</sup> - (Optional) CPUs in which to allow execution
+- `cpuset_cpus` - (Optional) CPUs in which to allow execution
   (0-3, 0,1). Limit the specific CPUs or cores a container can use. A
   comma-separated list or hyphen-separated range of CPUs a container can use, if
   you have more than one CPU. The first CPU is numbered 0. A valid value might
@@ -97,6 +97,22 @@ exclusive access to those CPUs.
 ```hcl
 config {
   cpuset_cpus = "0-3"
+}
+```
+
+- `cpuset_mems` - (Optional) MEMs in which to allow execution
+  (0-3, 0,1). Limit the specific memory nodes a container process is allowed
+  to allocate memory. A comma-separated list or hyphen-separated range of memory
+  nodes a container can use, if you have more than one memory node. The first
+  memory node is numbered 0. A valid value might be 0-3 (to use the first, second,
+  third, and fourth memory node) or 1,3 (to use the second and fourth memory node).
+
+Note: `cpuset_mems` pins the workload to the memory nodes but doesn't give the workload
+exclusive access to those memory nodes.
+
+```hcl
+config {
+  cpuset_mems = "0-3"
 }
 ```
 


### PR DESCRIPTION
Currently, we have NUMA support for CPU pinning in Nomad docker driver using [cpuset_cpus](https://developer.hashicorp.com/nomad/docs/drivers/docker#cpuset_cpus) option. However, we don't have support for pinning the workload to a particular set of memory nodes.

Without both (`cpuset_cpus` and `cpuset_mems`) the feature is not complete, as one can pin the workload to a particular NUMA node, however the memory can still spread across two NUMA nodes.

This PR will add support for pinning the workload to a particular set of memory nodes.

Added a unit test and updated nomad docker driver docs on the website.

<img width="1792" alt="cpuset_mems" src="https://user-images.githubusercontent.com/4207652/217071260-9b440c8e-39f1-4649-bac0-211edc7b3d20.png">

Signed-off-by: Shishir Mahajan <smahajan@roblox.com>