### PR TITLE
changelog: add changelog update for vendor label for linux packaging

### DIFF
--- a/.changelog/16071.txt
+++ b/.changelog/16071.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+build: Linux packages now have vendor label and set the default label to HashiCorp. This fix is implemented for any future releases, but will not be updated for historical releases
+```

--- a/.changelog/_14.txt
+++ b/.changelog/_14.txt
@@ -1,3 +1,0 @@
-```release-note: bug
-core: Linux packages now have vendor label and set the default label to HashiCorp. This fix is implemented for any future releases, but will not be updated for historical releases.
-```

--- a/.changelog/_14.txt
+++ b/.changelog/_14.txt
@@ -1,0 +1,3 @@
+```release-note: bug
+core: Linux packages now have vendor label and set the default label to HashiCorp. This fix is implemented for any future releases, but will not be updated for historical releases.
+```


### PR DESCRIPTION
This PR is just an update to the changelog to reflect a bug that was fixed in our [actions-packaging-linux](https://github.com/hashicorp/actions-packaging-linux) action. We received a report from a user stating that vendor labels were missing when downloading linux packages (for products that were released via CRT) We fixed this in [this PR](https://github.com/hashicorp/actions-packaging-linux/pull/14) and we added a vendor label and set the default to `HashiCorp` This will only affect future releases that go through our linux promotion pipeline -- historical releases will not have this vendor label. 