### PR TITLE
main: remove deprecated uses of rand.Seed

### DIFF
--- a/.changelog/16074.txt
+++ b/.changelog/16074.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Eliminate deprecated practice of seeding rand package
+```

--- a/client/servers/manager_internal_test.go
+++ b/client/servers/manager_internal_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/hashicorp/nomad/helper/testlog"
 )
 
-func init() {
-	// Seed the random number generator
-	rand.Seed(time.Now().UnixNano())
-}
-
 type fauxAddr struct {
 	Addr string
 }

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -27,10 +27,6 @@ import (
 	"github.com/hashicorp/nomad/testutil"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano()) // seed random number generator
-}
-
 // TempDir defines the base dir for temporary directories.
 var TempDir = os.TempDir()
 

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/rs/cors v1.8.3
 	github.com/ryanuber/columnize v2.1.2+incompatible
 	github.com/ryanuber/go-glob v1.0.0
-	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529
+	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	github.com/shirou/gopsutil/v3 v3.22.12
 	github.com/shoenig/go-landlock v0.1.4
 	github.com/shoenig/test v0.6.1

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,6 @@ require (
 	github.com/rs/cors v1.8.3
 	github.com/ryanuber/columnize v2.1.2+incompatible
 	github.com/ryanuber/go-glob v1.0.0
-	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	github.com/shirou/gopsutil/v3 v3.22.12
 	github.com/shoenig/go-landlock v0.1.4
 	github.com/shoenig/test v0.6.1
@@ -252,6 +251,7 @@ require (
 	github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	github.com/seccomp/libseccomp-golang v0.10.0 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect

--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/nomad/command"
 	"github.com/hashicorp/nomad/version"
 	"github.com/mitchellh/cli"
-	"github.com/sean-/seed"
 )
 
 var (
@@ -76,19 +75,11 @@ var (
 	}
 )
 
-func init() {
-	seed.Init()
-}
-
 func main() {
 	os.Exit(Run(os.Args[1:]))
 }
 
 func Run(args []string) int {
-	return RunCustom(args)
-}
-
-func RunCustom(args []string) int {
 	// Create the meta object
 	metaPtr := new(command.Meta)
 	metaPtr.SetupUi(args)

--- a/nomad/periodic_test.go
+++ b/nomad/periodic_test.go
@@ -618,7 +618,6 @@ func TestPeriodicDispatch_Complex(t *testing.T) {
 }
 
 func shuffle(jobs []*structs.Job) {
-	rand.Seed(time.Now().Unix())
 	for i := range jobs {
 		j := rand.Intn(len(jobs))
 		jobs[i], jobs[j] = jobs[j], jobs[i]

--- a/scheduler/spread_test.go
+++ b/scheduler/spread_test.go
@@ -691,13 +691,13 @@ func generateUnevenRacks(t *testing.T, nodes int, rackCount int) map[string]int 
 
 	// print this so that any future test flakes can be more easily
 	// reproduced
-	seed := time.Now().UnixNano()
-	rand.Seed(seed)
+	seed := time.Now().Unix()
+	random := rand.NewSource(seed)
 	t.Logf("nodes=%d racks=%d seed=%d\n", nodes, rackCount, seed)
 
 	racks := map[string]int{}
 	for i := 0; i < nodes; i++ {
-		idx := rand.Intn(len(rackNames))
+		idx := int(random.Int63()) % len(rackNames)
 		racks[rackNames[idx]]++
 	}
 	return racks


### PR DESCRIPTION
go1.20 deprecates rand.Seed, and seeds the rand package automatically. Remove cases where we seed the random package, and cleanup the one test case where we intentionally create a known random source.

https://pkg.go.dev/math/rand#Seed
https://go.dev/doc/go1.20