### PR TITLE
e2e: mark framework package as deprecated

### DIFF
--- a/e2e/framework/case.go
+++ b/e2e/framework/case.go
@@ -8,6 +8,8 @@ import (
 )
 
 // TestSuite defines a set of test cases and under what conditions to run them
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 type TestSuite struct {
 	Component string // Name of the component/system/feature tested
 
@@ -23,6 +25,8 @@ type TestSuite struct {
 }
 
 // Constraints that must be satisfied for a TestSuite to run
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 type Constraints struct {
 	Provider    string   // Cloud provider ex. 'aws', 'azure', 'gcp'
 	OS          string   // Operating system ex. 'windows', 'linux'
@@ -57,6 +61,8 @@ func (c Constraints) matches(env Environment) error {
 }
 
 // TC is the base test case which should be embedded in TestCase implementations.
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 type TC struct {
 	cluster *ClusterInfo
 }

--- a/e2e/framework/context.go
+++ b/e2e/framework/context.go
@@ -10,6 +10,8 @@ import (
 
 // F is the framework context that is passed to each test.
 // It is used to access the *testing.T context as well as testify helpers
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 type F struct {
 	id string
 	*require.Assertions
@@ -44,6 +46,8 @@ func newFWithID(id string, t *testing.T) *F {
 
 // Assert fetches an assert flavor of testify assertions
 // https://godoc.org/github.com/stretchr/testify/assert
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 func (f *F) Assert() *assert.Assertions {
 	return f.assert
 }

--- a/e2e/framework/doc.go
+++ b/e2e/framework/doc.go
@@ -120,4 +120,6 @@ string that is unique with in a test. Therefore, multiple tests with in the case
 can reliably create unique IDs between tests and setup/teardown. The string
 returned is 8 alpha numeric characters.
 */
+
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 package framework

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -58,6 +58,7 @@ var fArch = flag.String("env.arch", "",
 var fTags = flag.String("env.tags", "",
 	"comma delimited list of tags associated with the environment")
 
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 type Framework struct {
 	suites      []*TestSuite
 	provisioner Provisioner
@@ -71,6 +72,8 @@ type Framework struct {
 
 // Environment contains information about the test target environment, used
 // to constrain the set of tests run. See the environment flags above.
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 type Environment struct {
 	Name     string
 	Provider string
@@ -80,6 +83,8 @@ type Environment struct {
 }
 
 // New creates a Framework
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 func New() *Framework {
 	flag.Parse()
 	if *fHelp {
@@ -106,6 +111,8 @@ func New() *Framework {
 }
 
 // AddSuites adds a set of test suites to a Framework
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 func (f *Framework) AddSuites(s ...*TestSuite) *Framework {
 	f.suites = append(f.suites, s...)
 	return f
@@ -114,6 +121,8 @@ func (f *Framework) AddSuites(s ...*TestSuite) *Framework {
 var pkgSuites []*TestSuite
 
 // AddSuites adds a set of test suites to the package scoped Framework
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 func AddSuites(s ...*TestSuite) {
 	pkgSuites = append(pkgSuites, s...)
 }
@@ -141,6 +150,8 @@ func (f *Framework) Run(t *testing.T) {
 }
 
 // Run starts the package scoped Framework, running each TestSuite
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 func Run(t *testing.T) {
 	f := New()
 	f.AddSuites(pkgSuites...)

--- a/e2e/framework/interfaces.go
+++ b/e2e/framework/interfaces.go
@@ -3,6 +3,8 @@ package framework
 // TestCase is the interface which an E2E test case implements.
 // It is not meant to be implemented directly, instead the struct should embed
 // the 'framework.TC' struct
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 type TestCase interface {
 	internalTestCase
 
@@ -15,22 +17,30 @@ type internalTestCase interface {
 
 // BeforeAllTests is used to define a method to be called before the execution
 // of all tests.
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 type BeforeAllTests interface {
 	BeforeAll(*F)
 }
 
 // AfterAllTests is used to define a method to be called after the execution of
 // all tests.
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 type AfterAllTests interface {
 	AfterAll(*F)
 }
 
 // BeforeEachTest is used to define a method to be called before each test.
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 type BeforeEachTest interface {
 	BeforeEach(*F)
 }
 
 // AfterEachTest is used to define a method to be called after each test.
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 type AfterEachTest interface {
 	AfterEach(*F)
 }

--- a/e2e/framework/provisioner.go
+++ b/e2e/framework/provisioner.go
@@ -14,6 +14,8 @@ import (
 
 // ClusterInfo is a handle to a provisioned cluster, along with clients
 // a test run can use to connect to the cluster.
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 type ClusterInfo struct {
 	ID           string
 	Name         string
@@ -24,6 +26,8 @@ type ClusterInfo struct {
 
 // SetupOptions defines options to be given to the Provisioner when
 // calling Setup* methods.
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 type SetupOptions struct {
 	Name         string
 	ExpectConsul bool // If true, fails if a Consul client can't be configured
@@ -40,6 +44,8 @@ type SetupOptions struct {
 //
 // The TearDown* methods are hooks to clean up provisioned cluster state
 // that isn't covered by the test case's implementation of AfterEachTest.
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 type Provisioner interface {
 	// SetupTestRun is called at the start of the entire test run.
 	SetupTestRun(t *testing.T, opts SetupOptions) (*ClusterInfo, error)
@@ -70,6 +76,8 @@ type Provisioner interface {
 // DefaultProvisioner is a Provisioner that doesn't deploy a Nomad cluster
 // (because that's handled by Terraform elsewhere), but build clients from
 // environment variables.
+//
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 var DefaultProvisioner Provisioner = new(singleClusterProvisioner)
 
 type singleClusterProvisioner struct{}
@@ -128,6 +136,11 @@ func (p *singleClusterProvisioner) SetupTestCase(t *testing.T, opts SetupOptions
 
 // all TearDown* methods of the default provisioner leave the test environment in place
 
-func (p *singleClusterProvisioner) TearDownTestCase(_ *testing.T, _ string) error  { return nil }
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
+func (p *singleClusterProvisioner) TearDownTestCase(_ *testing.T, _ string) error { return nil }
+
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
 func (p *singleClusterProvisioner) TearDownTestSuite(_ *testing.T, _ string) error { return nil }
-func (p *singleClusterProvisioner) TearDownTestRun(_ *testing.T, _ string) error   { return nil }
+
+// Deprecated: no longer use e2e/framework for new tests; see TestExample for new e2e test structure.
+func (p *singleClusterProvisioner) TearDownTestRun(_ *testing.T, _ string) error { return nil }


### PR DESCRIPTION
Nothing more motivating than lots of deprecation warnings to get some code refactored.
