### PR TITLE
agent: fix agent HTTP server audit event implementation access.

### DIFF
--- a/command/agent/event/event.go
+++ b/command/agent/event/event.go
@@ -6,10 +6,10 @@ import (
 
 // Auditor describes the interface that must be implemented by an eventer.
 type Auditor interface {
-	// Emit an event to the auditor
+	// Event emits an event to the auditor.
 	Event(ctx context.Context, eventType string, payload interface{}) error
 
-	// Specifies if the auditor is enabled or not
+	// Enabled details if the auditor is enabled or not.
 	Enabled() bool
 
 	// Reopen signals to auditor to reopen any files they have open.


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/15864 changed the way in which the agent is passed to the HTTP servers by wrapping it in an interface. This removed access to the audit eventer, which is used by the HTTP server to log events for the enterprise codebase.

This change therefore explicitly passes the `event.Auditor` interface to the agent HTTP servers for use. This change will be needed along with an enterprise specific one, to slightly alter the audit calls to use the new field.

Please see the internal nightly runs to see the original error. 