### PR TITLE
docs: update example `license_path`

### DIFF
--- a/.release/linux/package/etc/nomad.d/nomad.hcl
+++ b/.release/linux/package/etc/nomad.d/nomad.hcl
@@ -4,8 +4,8 @@ data_dir  = "/opt/nomad/data"
 bind_addr = "0.0.0.0"
 
 server {
-  # license_path is required as of Nomad v1.1.1+
-  #license_path = "/opt/nomad/license.hclic"
+  # license_path is required for Nomad Enterprise as of Nomad v1.1.1+
+  #license_path = "/etc/nomad.d/license.hclic"
   enabled          = true
   bootstrap_expect = 1
 }

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -118,6 +118,6 @@ flags.
 #### Nomad Enterprise Licensing Environment Variables
 
 - `NOMAD_LICENSE_PATH` - An absolute path to a Nomad Enterprise license file,
-  for example `/opt/nomad/license.hclic`.
+  for example `/etc/nomad.d/license.hclic`.
 
 - `NOMAD_LICENSE` - The Nomad Enterprise license file contents as a string.

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -156,10 +156,11 @@ server {
   the number of CPU cores.
 
 - `license_path` `(string: "")` - Specifies the path to load a Nomad Enterprise
-  license from. This must be an absolute path (`/opt/nomad/license.hclic`). The
-  license can also be set by setting `NOMAD_LICENSE_PATH` or by setting
-  `NOMAD_LICENSE` as the entire license value. `license_path` has the highest
-  precedence, followed by `NOMAD_LICENSE` and then `NOMAD_LICENSE_PATH`.
+  license from. This must be an absolute path
+  (ex. `/etc/nomad.d/license.hclic`). The license can also be set by setting
+  `NOMAD_LICENSE_PATH` or by setting `NOMAD_LICENSE` as the entire license
+  value. `license_path` has the highest precedence, followed by `NOMAD_LICENSE`
+  and then `NOMAD_LICENSE_PATH`.
 
 - `plan_rejection_tracker` <code>([PlanRejectionTracker](#plan_rejection_tracker-parameters))</code> -
   Configuration for the plan rejection tracker that the Nomad leader uses to


### PR DESCRIPTION
In #13374 we updated the commented-out `license_path` in the packaged example configuration file to match the existing documentation. Although this config value was commented-out, it was reported that changing the value was confusing. Update the commented-out line to the previous value and update the documented examples to match that. This matches most of the examples for Consul/Vault licensing as well. I've double-checked the tutorials and it looks like it'd been left on the previous value there, so no additional work to be done.