### PR TITLE
deps: upgrade to hashicorp/golang-lru/v2

### DIFF
--- a/.changelog/16085.txt
+++ b/.changelog/16085.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl: refactor ACL cache based on golang-lru/v2
+```

--- a/client/acl_test.go
+++ b/client/acl_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 func Test_clientACLResolver_init(t *testing.T) {
-	resolver := &clientACLResolver{}
-	must.NoError(t, resolver.init())
+	resolver := new(clientACLResolver)
+	resolver.init()
 	must.NotNil(t, resolver.aclCache)
 	must.NotNil(t, resolver.policyCache)
 	must.NotNil(t, resolver.tokenCache)

--- a/client/client.go
+++ b/client/client.go
@@ -441,9 +441,7 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 	c.setupClientRpc(rpcs)
 
 	// Initialize the ACL state
-	if err := c.clientACLResolver.init(); err != nil {
-		return nil, fmt.Errorf("failed to initialize ACL state: %v", err)
-	}
+	c.clientACLResolver.init()
 
 	// Setup the node
 	if err := c.setupNode(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
-	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/hashicorp/hcl v1.0.1-vault-3
 	github.com/hashicorp/hcl/v2 v2.9.2-0.20220525143345-ab3cae0737bc
 	github.com/hashicorp/hil v0.0.0-20210521165536-27a72121fd40
@@ -214,7 +214,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1 // indirect
 	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.2 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/mdns v1.0.4 // indirect
 	github.com/hashicorp/vault/api/auth/kubernetes v0.3.0 // indirect
 	github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443 // indirect

--- a/go.sum
+++ b/go.sum
@@ -732,8 +732,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/golang-lru/v2 v2.0.0 h1:Lf+9eD8m5pncvHAOCQj49GSN6aQI8XGfI5OpXNkoWaA=
-github.com/hashicorp/golang-lru/v2 v2.0.0/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/hashicorp/golang-lru/v2 v2.0.1 h1:5pv5N1lT1fjLg2VQ5KWc7kmucp2x/kvFOnxuVTqZ6x4=
+github.com/hashicorp/golang-lru/v2 v2.0.1/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.1-0.20201016140508-a07e7d50bbee h1:8B4HqvMUtYSjsGkYjiQGStc9pXffY2J+Z2SPQAj+wMY=
 github.com/hashicorp/hcl v1.0.1-0.20201016140508-a07e7d50bbee/go.mod h1:gwlu9+/P9MmKtYrMsHeFRZPXj2CTPm11TDnMeaRHS7g=
 github.com/hashicorp/hcl/v2 v2.9.2-0.20220525143345-ab3cae0737bc h1:32lGaCPq5JPYNgFFTjl/cTIar9UWWxCbimCs5G2hMHg=

--- a/lib/lang/doc.go
+++ b/lib/lang/doc.go
@@ -1,0 +1,2 @@
+// Package lang provides some features that really 'ought to be part of the Go language
+package lang

--- a/lib/lang/pair.go
+++ b/lib/lang/pair.go
@@ -1,0 +1,7 @@
+package lang
+
+// Pair associates two arbitrary types together.
+type Pair[T, U any] struct {
+	First  T
+	Second U
+}

--- a/nomad/acl.go
+++ b/nomad/acl.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	metrics "github.com/armon/go-metrics"
-	lru "github.com/hashicorp/golang-lru"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/state"
@@ -283,7 +282,7 @@ func (s *Server) ResolveClaims(claims *structs.IdentityClaims) (*acl.ACL, error)
 // resolveTokenFromSnapshotCache is used to resolve an ACL object from a
 // snapshot of state, using a cache to avoid parsing and ACL construction when
 // possible. It is split from resolveToken to simplify testing.
-func resolveTokenFromSnapshotCache(snap *state.StateSnapshot, cache *lru.TwoQueueCache, secretID string) (*acl.ACL, error) {
+func resolveTokenFromSnapshotCache(snap *state.StateSnapshot, cache *structs.ACLCache[*acl.ACL], secretID string) (*acl.ACL, error) {
 	// Lookup the ACL Token
 	var token *structs.ACLToken
 	var err error
@@ -308,7 +307,7 @@ func resolveTokenFromSnapshotCache(snap *state.StateSnapshot, cache *lru.TwoQueu
 
 }
 
-func resolveACLFromToken(snap *state.StateSnapshot, cache *lru.TwoQueueCache, token *structs.ACLToken) (*acl.ACL, error) {
+func resolveACLFromToken(snap *state.StateSnapshot, cache *structs.ACLCache[*acl.ACL], token *structs.ACLToken) (*acl.ACL, error) {
 
 	// Check if this is a management token
 	if token.Type == structs.ACLManagementToken {

--- a/nomad/plan_apply_node_tracker_test.go
+++ b/nomad/plan_apply_node_tracker_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TesCachedtBadNodeTracker(t *testing.T) {
+func TestCachedtBadNodeTracker(t *testing.T) {
 	ci.Parallel(t)
 
 	config := DefaultCachedBadNodeTrackerConfig()
@@ -74,11 +74,10 @@ func TestCachedBadNodeTracker_isBad(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Read value from cached.
-			v, ok := tracker.cache.Get(tc.nodeID)
+			stats, ok := tracker.cache.Get(tc.nodeID)
 			require.True(t, ok)
 
 			// Check if it's bad.
-			stats := v.(*badNodeStats)
 			got := tracker.isBad(now, stats)
 			require.Equal(t, tc.bad, got)
 		})
@@ -88,10 +87,9 @@ func TestCachedBadNodeTracker_isBad(t *testing.T) {
 	nodes := []string{"node-1", "node-2", "node-3"}
 	for _, n := range nodes {
 		t.Run(fmt.Sprintf("%s cache expires", n), func(t *testing.T) {
-			v, ok := tracker.cache.Get(n)
+			stats, ok := tracker.cache.Get(n)
 			require.True(t, ok)
 
-			stats := v.(*badNodeStats)
 			bad := tracker.isBad(future, stats)
 			require.False(t, bad)
 		})
@@ -115,10 +113,8 @@ func TesCachedtBadNodeTracker_rateLimit(t *testing.T) {
 	tracker.Add("node-1")
 	tracker.Add("node-1")
 
-	v, ok := tracker.cache.Get("node-1")
+	stats, ok := tracker.cache.Get("node-1")
 	require.True(t, ok)
-
-	stats := v.(*badNodeStats)
 
 	// Burst allows for max 3 operations.
 	now := time.Now()

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -23,7 +23,7 @@ import (
 	consulapi "github.com/hashicorp/consul/api"
 	log "github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
-	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/raft"
 	autopilot "github.com/hashicorp/raft-autopilot"
 	raftboltdb "github.com/hashicorp/raft-boltdb/v2"
@@ -254,7 +254,7 @@ type Server struct {
 	workersEventCh   chan interface{}
 
 	// aclCache is used to maintain the parsed ACL objects
-	aclCache *lru.TwoQueueCache
+	aclCache *structs.ACLCache[*acl.ACL]
 
 	// oidcProviderCache maintains a cache of OIDC providers. This is useful as
 	// the provider performs background HTTP requests. When the Nomad server is
@@ -341,10 +341,7 @@ func NewServer(config *Config, consulCatalog consul.CatalogAPI, consulConfigEntr
 	}
 
 	// Create the ACL object cache
-	aclCache, err := lru.New2Q(aclCacheSize)
-	if err != nil {
-		return nil, err
-	}
+	aclCache := structs.NewACLCache[*acl.ACL](aclCacheSize)
 
 	// Create the logger
 	logger := config.Logger.ResetNamedIntercept("nomad")

--- a/nomad/stream/event_broker.go
+++ b/nomad/stream/event_broker.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-memdb"
-	lru "github.com/hashicorp/golang-lru"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/nomad/structs"
 
@@ -42,7 +41,7 @@ type EventBroker struct {
 	publishCh chan *structs.Events
 
 	aclDelegate ACLDelegate
-	aclCache    *lru.TwoQueueCache
+	aclCache    *structs.ACLCache[*acl.ACL]
 
 	aclCh chan structs.Event
 
@@ -63,11 +62,6 @@ func NewEventBroker(ctx context.Context, aclDelegate ACLDelegate, cfg EventBroke
 		cfg.EventBufferSize = 100
 	}
 
-	aclCache, err := lru.New2Q(aclCacheSize)
-	if err != nil {
-		return nil, err
-	}
-
 	buffer := newEventBuffer(cfg.EventBufferSize)
 	e := &EventBroker{
 		logger:      cfg.Logger.Named("event_broker"),
@@ -75,7 +69,7 @@ func NewEventBroker(ctx context.Context, aclDelegate ACLDelegate, cfg EventBroke
 		publishCh:   make(chan *structs.Events, 64),
 		aclCh:       make(chan structs.Event, 10),
 		aclDelegate: aclDelegate,
-		aclCache:    aclCache,
+		aclCache:    structs.NewACLCache[*acl.ACL](aclCacheSize),
 		subscriptions: &subscriptions{
 			byToken: make(map[string]map[*SubscribeRequest]*Subscription),
 		},
@@ -277,7 +271,7 @@ func (e *EventBroker) checkSubscriptionsAgainstACLChange() {
 }
 
 func aclObjFromSnapshotForTokenSecretID(
-	aclSnapshot ACLTokenProvider, aclCache *lru.TwoQueueCache, tokenSecretID string) (
+	aclSnapshot ACLTokenProvider, aclCache *structs.ACLCache[*acl.ACL], tokenSecretID string) (
 	*acl.ACL, *time.Time, error) {
 
 	aclToken, err := aclSnapshot.ACLTokenBySecretID(nil, tokenSecretID)

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -10,9 +10,8 @@ import (
 	"strconv"
 	"strings"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-set"
-	lru "github.com/hashicorp/golang-lru"
 	"github.com/hashicorp/nomad/acl"
 	"golang.org/x/crypto/blake2b"
 )
@@ -436,7 +435,7 @@ func ACLPolicyListHash(policies []*ACLPolicy) string {
 }
 
 // CompileACLObject compiles a set of ACL policies into an ACL object with a cache
-func CompileACLObject(cache *lru.TwoQueueCache, policies []*ACLPolicy) (*acl.ACL, error) {
+func CompileACLObject(cache *ACLCache[*acl.ACL], policies []*ACLPolicy) (*acl.ACL, error) {
 	// Sort the policies to ensure consistent ordering
 	sort.Slice(policies, func(i, j int) bool {
 		return policies[i].Name < policies[j].Name
@@ -444,9 +443,9 @@ func CompileACLObject(cache *lru.TwoQueueCache, policies []*ACLPolicy) (*acl.ACL
 
 	// Determine the cache key
 	cacheKey := ACLPolicyListHash(policies)
-	aclRaw, ok := cache.Get(cacheKey)
+	entry, ok := cache.Get(cacheKey)
 	if ok {
-		return aclRaw.(*acl.ACL), nil
+		return entry.Get(), nil
 	}
 
 	// Parse the policies

--- a/nomad/structs/funcs_test.go
+++ b/nomad/structs/funcs_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/stretchr/testify/assert"
@@ -1007,8 +1007,7 @@ func TestCompileACLObject(t *testing.T) {
 	p2.Name = fmt.Sprintf("policy-%s", uuid.Generate())
 
 	// Create a small cache
-	cache, err := lru.New2Q(16)
-	assert.Nil(t, err)
+	cache := NewACLCache[*acl.ACL](10)
 
 	// Test compilation
 	aclObj, err := CompileACLObject(cache, []*ACLPolicy{p1})

--- a/nomad/structs/generate.sh
+++ b/nomad/structs/generate.sh
@@ -8,5 +8,5 @@ codecgen \
     -d 100 \
     -t codegen_generated \
     -o structs.generated.go \
-    -nr="^IdentityClaims$" \
+    -nr="(^ACLCache$)|(^IdentityClaims$)" \
     ${FILES}


### PR DESCRIPTION
Upgrade to hashicorp/golang-lru/v2, and refactor the ACL cache to leverage all the generics. Previously each cache entry contained 3 pointers, only one of which would be in use - so we should get some space savings out of that (not that the cache sizes are large).