### PR TITLE
generate serialization code for IdentityClaims

### DIFF
--- a/nomad/structs/generate.sh
+++ b/nomad/structs/generate.sh
@@ -8,5 +8,4 @@ codecgen \
     -d 100 \
     -t codegen_generated \
     -o structs.generated.go \
-    -nr="^IdentityClaims$" \
     ${FILES}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10622,7 +10622,7 @@ func (a *Allocation) ToTaskIdentityClaims(job *Job, taskName string) *IdentityCl
 }
 
 // IdentityClaims are the input to a JWT identifying a workload. It
-// should never be serialized to msgpack unsigned.
+// normally should not be serialized except as a signed JWT blob (except for WhoAmI)
 type IdentityClaims struct {
 	Namespace    string `json:"nomad_namespace"`
 	JobID        string `json:"nomad_job_id"`


### PR DESCRIPTION
Originally IdentityClaims never were passed over the wire, but they're now used for the `ACL.WhoAmI` endpoint. Generate the serialization code for that.