### PR TITLE
users: eliminate LookupGroupId and its one use case

### DIFF
--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -2560,9 +2560,6 @@ func TestTaskTemplateManager_writeToFile(t *testing.T) {
 	cu, err := users.Current()
 	require.NoError(t, err)
 
-	cg, err := users.LookupGroupId(cu.Gid)
-	require.NoError(t, err)
-
 	file := "my.tmpl"
 	template := &structs.Template{
 		// EmbeddedTmpl set below as it needs the taskDir
@@ -2574,7 +2571,7 @@ func TestTaskTemplateManager_writeToFile(t *testing.T) {
 
 	// Add template now that we know the taskDir
 	harness.templates[0].EmbeddedTmpl = fmt.Sprintf(`Testing writeToFile...
-{{ "hello" | writeToFile "%s" "`+cu.Username+`" "`+cg.Name+`" "0644" }}
+{{ "hello" | writeToFile "%s" "`+cu.Username+`" "`+cu.Gid+`" "0644" }}
 ...done
 `, filepath.Join(harness.taskDir, "writetofile.out"))
 

--- a/helper/users/lookup.go
+++ b/helper/users/lookup.go
@@ -23,13 +23,6 @@ func Lookup(username string) (*user.User, error) {
 	return user.Lookup(username)
 }
 
-// LookupGroupId while holding a global process lock.
-func LookupGroupId(gid string) (*user.Group, error) {
-	lock.Lock()
-	defer lock.Unlock()
-	return user.LookupGroupId(gid)
-}
-
 // Current returns the current user, acquired while holding a global process
 // lock.
 func Current() (*user.User, error) {


### PR DESCRIPTION
This PR deletes the `user.LookupGroupId` function as it was only being used
in a single test case, and its value was not important to the test.

Prep for https://github.com/hashicorp/nomad/issues/16010

No CL - only affects test case