### PR TITLE
tests: reduce timeout on test-api

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -88,7 +88,7 @@ jobs:
   tests-api:
     needs: [mods]
     runs-on: [custom, xl, 22.04]
-    timeout-minutes: 30
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-golang@v1


### PR DESCRIPTION
Sometimes GHA gets wedged, and there is no need to waste 30 minutes
on a job that usually takes < 3.

e.g. stuck loading module cache, which is out of our control
https://github.com/hashicorp/nomad/actions/runs/4135098558/jobs/7147128419
