### PR TITLE
acl: never return auth errors for `ACL.Bootstrap` RPC

### DIFF
--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -425,14 +425,13 @@ func (a *ACL) Bootstrap(args *structs.ACLTokenBootstrapRequest, reply *structs.A
 	args.Region = a.srv.config.AuthoritativeRegion
 	providedTokenID := args.BootstrapSecret
 
-	authErr := a.srv.Authenticate(a.ctx, args)
+	// note: we're intentionally throwing away any auth error here and only
+	// authenticate so that we can measure rate metrics
+	a.srv.Authenticate(a.ctx, args)
 	if done, err := a.srv.forward("ACL.Bootstrap", args, args, reply); done {
 		return err
 	}
 	a.srv.MeasureRPCRate("acl", structs.RateMetricWrite, args)
-	if authErr != nil {
-		return structs.ErrPermissionDenied
-	}
 	defer metrics.MeasureSince([]string{"nomad", "acl", "bootstrap"}, time.Now())
 
 	// Always ignore the reset index from the arguments


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/16098 introduced in 1.5.0-beta.1

In #15901 we introduced pre-forwarding authentication for RPCs so that we can grab the identity for rate metrics. The `ACL.Bootstrap` RPC is an unauthenticated endpoint, so any error message from authentication is not particularly useful. This would be harmless, but if you try to bootstrap with your `NOMAD_TOKEN` already set (perhaps because you were talking to another cluster previously from the same shell session), you'll get an authentication error instead of just having the token be ignored. This is a regression from the existing behavior, so have this endpoint ignore auth errors the same way we do for every other unauthenticated endpoint (ex `Status.Peers`)