### PR TITLE
[core] Do not start the plugin loader on non-clients

### DIFF
--- a/.changelog/16111.txt
+++ b/.changelog/16111.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Non-client nodes will now skip loading plugins
+```

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -142,10 +142,6 @@ func NewAgent(config *Config, logger log.InterceptLogger, logOutput io.Writer, i
 		return nil, fmt.Errorf("Failed to initialize Consul client: %v", err)
 	}
 
-	if err := a.setupPlugins(); err != nil {
-		return nil, err
-	}
-
 	if err := a.setupServer(); err != nil {
 		return nil, err
 	}
@@ -1001,6 +997,14 @@ func (a *Agent) setupClient() error {
 	if !a.config.Client.Enabled {
 		return nil
 	}
+
+	// Plugin setup must happen before the call to clientConfig, because it
+	// copies the pointers to the plugin loaders from the Agent to the
+	// Client config.
+	if err := a.setupPlugins(); err != nil {
+		return err
+	}
+
 	// Setup the configuration
 	conf, err := a.clientConfig()
 	if err != nil {

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -564,10 +564,6 @@ func (a *Agent) finalizeServerConfig(c *nomad.Config) {
 	// Setup the logging
 	c.Logger = a.logger
 	c.LogOutput = a.logOutput
-
-	// Setup the plugin loaders
-	c.PluginLoader = a.pluginLoader
-	c.PluginSingletonLoader = a.pluginSingletonLoader
 	c.AgentShutdown = func() error { return a.Shutdown() }
 }
 

--- a/command/agent/plugins.go
+++ b/command/agent/plugins.go
@@ -10,6 +10,10 @@ import (
 
 // setupPlugins is used to setup the plugin loaders.
 func (a *Agent) setupPlugins() error {
+	if a.GetConfig().Client == nil || !a.GetConfig().Client.Enabled {
+		a.logger.Debug("skipping plugin setup because node is not a client")
+		return nil
+	}
 	// Get our internal plugins
 	internal, err := a.internalPluginConfigs()
 	if err != nil {

--- a/command/agent/plugins.go
+++ b/command/agent/plugins.go
@@ -10,10 +10,6 @@ import (
 
 // setupPlugins is used to setup the plugin loaders.
 func (a *Agent) setupPlugins() error {
-	if a.GetConfig().Client == nil || !a.GetConfig().Client.Enabled {
-		a.logger.Debug("skipping plugin setup because node is not a client")
-		return nil
-	}
 	// Get our internal plugins
 	internal, err := a.internalPluginConfigs()
 	if err != nil {

--- a/command/agent/plugins_test.go
+++ b/command/agent/plugins_test.go
@@ -1,0 +1,36 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/helper/pointer"
+	"github.com/shoenig/test/must"
+)
+
+func TestPlugins_WhenNotClientSkip(t *testing.T) {
+	s, _, _ := testServer(t, false, func(c *Config) {
+		c.Server.NumSchedulers = pointer.Of(1)
+	})
+	must.Nil(t, s.Agent.pluginSingletonLoader)
+}
+
+func TestPlugins_WhenClientRun(t *testing.T) {
+	s, _, _ := testServer(t, true, nil)
+	must.NotNil(t, s.Agent.pluginSingletonLoader)
+}
+
+func testServer(t *testing.T, runClient bool, cb func(*Config)) (*TestAgent, *api.Client, string) {
+	// Make a new test server
+	a := NewTestAgent(t, t.Name(), func(config *Config) {
+		config.Client.Enabled = runClient
+
+		if cb != nil {
+			cb(config)
+		}
+	})
+	t.Cleanup(a.Shutdown)
+
+	c := a.Client()
+	return a, c, a.HTTPAddr()
+}

--- a/command/agent/plugins_test.go
+++ b/command/agent/plugins_test.go
@@ -4,14 +4,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/shoenig/test/must"
 )
 
 func TestPlugins_WhenNotClientSkip(t *testing.T) {
-	s, _, _ := testServer(t, false, func(c *Config) {
-		c.Server.NumSchedulers = pointer.Of(1)
-	})
+	s, _, _ := testServer(t, false, nil)
 	must.Nil(t, s.Agent.pluginSingletonLoader)
 }
 

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -11,7 +11,6 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/hashicorp/memberlist"
-	"github.com/hashicorp/nomad/helper/pluginutils/loader"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/deploymentwatcher"
@@ -372,13 +371,6 @@ type Config struct {
 	// Once the cluster is bootstrapped, and Raft persists the config (from here or through API)
 	// and this value is ignored.
 	DefaultSchedulerConfig structs.SchedulerConfiguration `hcl:"default_scheduler_config"`
-
-	// PluginLoader is used to load plugins.
-	PluginLoader loader.PluginCatalog
-
-	// PluginSingletonLoader is a plugin loader that will returns singleton
-	// instances of the plugins.
-	PluginSingletonLoader loader.PluginCatalog
 
 	// RPCHandshakeTimeout is the deadline by which RPC handshakes must
 	// complete. The RPC handshake includes the first byte read as well as

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/command/agent/consul"
-	"github.com/hashicorp/nomad/helper/pluginutils/catalog"
-	"github.com/hashicorp/nomad/helper/pluginutils/singleton"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -84,10 +82,6 @@ func TestServerErr(t *testing.T, cb func(*Config)) (*Server, func(), error) {
 	config.AutopilotConfig.ServerStabilizationTime = 100 * time.Millisecond
 	config.ServerHealthInterval = 50 * time.Millisecond
 	config.AutopilotInterval = 100 * time.Millisecond
-
-	// Set the plugin loaders
-	config.PluginLoader = catalog.TestPluginLoader(t)
-	config.PluginSingletonLoader = singleton.NewSingletonLoader(config.Logger, config.PluginLoader)
 
 	// Disable consul autojoining: tests typically join servers directly
 	config.ConsulConfig.ServerAutoJoin = &f


### PR DESCRIPTION
The plugin loader loads task and device driver plugins which are not
used on server nodes.
