### PR TITLE
[chore] Move TestUtil_loadVersionControlGlobalConfigs into build flagged file

### DIFF
--- a/client/allocrunner/taskrunner/getter/util_linux_test.go
+++ b/client/allocrunner/taskrunner/getter/util_linux_test.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package getter
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/go-getter"
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/client/testutil"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/go-landlock"
+	"github.com/shoenig/test/must"
+)
+
+func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
+	const filePerm = 0o644
+	const dirPerm = 0o755
+	fakeEtc := t.TempDir()
+
+	var (
+		gitFile = filepath.Join(fakeEtc, "gitconfig")
+		hgFile  = filepath.Join(fakeEtc, "hgrc")
+		hgDir   = filepath.Join(fakeEtc, "hgrc.d")
+	)
+
+	err := os.WriteFile(gitFile, []byte("git"), filePerm)
+	must.NoError(t, err)
+
+	err = os.WriteFile(hgFile, []byte("hg"), filePerm)
+	must.NoError(t, err)
+
+	err = os.Mkdir(hgDir, dirPerm)
+	must.NoError(t, err)
+
+	paths := loadVersionControlGlobalConfigs(gitFile, hgFile, hgDir)
+	must.SliceEqual(t, []*landlock.Path{
+		landlock.File(gitFile, "r"),
+		landlock.File(hgFile, "r"),
+		landlock.Dir(hgDir, "r"),
+	}, paths)
+}

--- a/client/allocrunner/taskrunner/getter/util_linux_test.go
+++ b/client/allocrunner/taskrunner/getter/util_linux_test.go
@@ -3,15 +3,10 @@
 package getter
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/hashicorp/go-getter"
-	"github.com/hashicorp/nomad/ci"
-	"github.com/hashicorp/nomad/client/testutil"
-	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/shoenig/go-landlock"
 	"github.com/shoenig/test/must"
 )

--- a/client/allocrunner/taskrunner/getter/util_test.go
+++ b/client/allocrunner/taskrunner/getter/util_test.go
@@ -2,15 +2,12 @@ package getter
 
 import (
 	"errors"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/testutil"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/shoenig/go-landlock"
 	"github.com/shoenig/test/must"
 )
 
@@ -185,32 +182,4 @@ func TestUtil_environment(t *testing.T) {
 			"TMPDIR=/a/b/c/tmp",
 		}, result)
 	})
-}
-
-func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
-	const filePerm = 0o644
-	const dirPerm = 0o755
-	fakeEtc := t.TempDir()
-
-	var (
-		gitFile = filepath.Join(fakeEtc, "gitconfig")
-		hgFile  = filepath.Join(fakeEtc, "hgrc")
-		hgDir   = filepath.Join(fakeEtc, "hgrc.d")
-	)
-
-	err := os.WriteFile(gitFile, []byte("git"), filePerm)
-	must.NoError(t, err)
-
-	err = os.WriteFile(hgFile, []byte("hg"), filePerm)
-	must.NoError(t, err)
-
-	err = os.Mkdir(hgDir, dirPerm)
-	must.NoError(t, err)
-
-	paths := loadVersionControlGlobalConfigs(gitFile, hgFile, hgDir)
-	must.SliceEqual(t, []*landlock.Path{
-		landlock.File(gitFile, "r"),
-		landlock.File(hgFile, "r"),
-		landlock.Dir(hgDir, "r"),
-	}, paths)
 }

--- a/client/allocrunner/taskrunner/getter/util_test.go
+++ b/client/allocrunner/taskrunner/getter/util_test.go
@@ -117,7 +117,7 @@ func TestUtil_getHeaders(t *testing.T) {
 		must.Nil(t, result)
 	})
 
-	t.Run("replacments", func(t *testing.T) {
+	t.Run("replacements", func(t *testing.T) {
 		result := getHeaders(env, &structs.TaskArtifact{
 			GetterHeaders: map[string]string{
 				"color":  "red",


### PR DESCRIPTION
Since this test tests a function that in a file controlled by a build flag, when not on Linux, the implementation is not found by the Go language server and makes IDEs sad.
