### PR TITLE
ui: hide custom label if not text is provided

### DIFF
--- a/ui/app/templates/components/global-header.hbs
+++ b/ui/app/templates/components/global-header.hbs
@@ -12,7 +12,7 @@
     <LinkTo @route="jobs" class="navbar-item is-logo" aria-label="Home">
       <NomadLogo />
     </LinkTo>
-    {{#if this.system.agent.config.UI.Label}}
+    {{#if this.system.agent.config.UI.Label.Text}}
       <div class="custom-label" style={{this.labelStyles}}>
         {{this.system.agent.config.UI.Label.Text}}
       </div>


### PR DESCRIPTION
Running a simple `nomad agent -dev` results in an empty label because `this.system.agent.config.UI.Label` is an object shaped like this:

```
{
  "BackgroundColor": "",
  "Text": "",
  "TextColor": ""
}
```
<img width="195" alt="image" src="https://user-images.githubusercontent.com/775380/217904888-abcdeeb7-cd69-4a49-87fb-724b8353dbc1.png">

After the change the label is not displayed unless a text is provided:
<img width="158" alt="image" src="https://user-images.githubusercontent.com/775380/217905275-e8d8b46f-41fe-465b-a351-d3b2bfbb6938.png">
<img width="215" alt="image" src="https://user-images.githubusercontent.com/775380/217905557-3529b93b-b96f-466a-80ee-96eb01f7de62.png">

I wasn't able to figure out how to modify the label config to write a proper test 😅 
