### PR TITLE
ci: reduce number of ember-test-audit iterations

### DIFF
--- a/.github/workflows/ember-test-audit.yml
+++ b/.github/workflows/ember-test-audit.yml
@@ -2,6 +2,7 @@ name: Ember test audit comparison
 on:
   pull_request:
     paths:
+    - '.github/workflows/ember*'
     - 'ui/**'
 
 defaults:
@@ -24,7 +25,7 @@ jobs:
           node-version: '14'
       - run: yarn --frozen-lockfile
       - run: mkdir -p /tmp/test-reports
-      - run: npx ember-test-audit 3 --json --output ../base-audit.json
+      - run: npx ember-test-audit 1 --json --output ../base-audit.json
       - name: Upload result
         uses: actions/upload-artifact@v2
         with:
@@ -41,7 +42,7 @@ jobs:
           node-version: '14'
       - run: yarn --frozen-lockfile
       - run: mkdir -p /tmp/test-reports
-      - run: npx ember-test-audit 3 --json --output ../pr-audit.json
+      - run: npx ember-test-audit 1 --json --output ../pr-audit.json
       - name: Upload result
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Reduce the number of `ember-test-audit` iterations to speed up CI. With 3 iterations each run was about 40min long and we are not experiencing flaky tests so often.