### PR TITLE
fix: correct Makefile to run unit tests locally

### DIFF
--- a/contributing/README.md
+++ b/contributing/README.md
@@ -44,10 +44,14 @@ Developing without Vagrant
    ```sh
    $ [ "$(ulimit -n)" -lt 1024 ] && ulimit -n 1024
    ```
-1. Verify you can run tests
+1. Verify you can run smoke tests
    ```sh
    $ make test
    ```
+   **Note:** You can think of this as a `smoke` test which runs a subset of
+   tests and some may fail because of `operation not permitted` error which
+   requires `root` access. You can use `go test` to test the specific subsystem
+   which you are working on and let the CI run rest of the tests for you.
 
 Running a development build
 ---


### PR DESCRIPTION
I wanted to run tests locally to start contributing to Nomad; So as [current documentation mentions](https://github.com/hashicorp/nomad/blob/main/contributing/README.md?plain=1#L49), I had to run `make test` to run the tests.
But after checking the [GNUMakefile](https://github.com/hashicorp/nomad/blob/main/GNUmakefile), found that it doesn't exist any more and documentation should be updated.

Also after trying to run the unit tests with `make test-nomad`, I found that it doesn't work properly as `GOTEST_GROUP` is not set in local run and it gets set in CI like [this](https://github.com/hashicorp/nomad/blob/main/.github/workflows/test-core.yaml#L110).

So this PR:

1. Fix the documentation regarding how to run the unit tests
2. Fix the Makefile so anyone can run the unit tests localy

I'm not sure if it was the correct place to fix the running unit tests locally; So please let me know if anything is needed. 