### PR TITLE
Fix unbold header `Device Group Attributes` and remove unused var in  func `nodeCSIVolumeNames`

### DIFF
--- a/.changelog/16138.txt
+++ b/.changelog/16138.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-cli: Fix unbolded header `Device Group Attributes` and remove unused var in function `nodeCSIVolumeNames`
+cli: Fix unbolded header `Device Group Attributes`
 ```

--- a/.changelog/16138.txt
+++ b/.changelog/16138.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix unbolded header `Device Group Attributes` and remove unused var in function `nodeCSIVolumeNames`
+```

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -399,7 +399,7 @@ func nodeCSINodeNames(n *api.Node) []string {
 	return names
 }
 
-func nodeCSIVolumeNames(n *api.Node, allocs []*api.Allocation) []string {
+func nodeCSIVolumeNames(allocs []*api.Allocation) []string {
 	var names []string
 	for _, alloc := range allocs {
 		tg := alloc.GetTaskGroup()
@@ -489,7 +489,7 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 	if c.short {
 		basic = append(basic, fmt.Sprintf("Host Volumes|%s", strings.Join(nodeVolumeNames(node), ",")))
 		basic = append(basic, fmt.Sprintf("Host Networks|%s", strings.Join(nodeNetworkNames(node), ",")))
-		basic = append(basic, fmt.Sprintf("CSI Volumes|%s", strings.Join(nodeCSIVolumeNames(node, runningAllocs), ",")))
+		basic = append(basic, fmt.Sprintf("CSI Volumes|%s", strings.Join(nodeCSIVolumeNames(runningAllocs), ",")))
 		basic = append(basic, fmt.Sprintf("Drivers|%s", strings.Join(nodeDrivers(node), ",")))
 		c.Ui.Output(c.Colorize().Color(formatKV(basic)))
 
@@ -518,7 +518,7 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 	if !c.verbose {
 		basic = append(basic, fmt.Sprintf("Host Volumes|%s", strings.Join(nodeVolumeNames(node), ",")))
 		basic = append(basic, fmt.Sprintf("Host Networks|%s", strings.Join(nodeNetworkNames(node), ",")))
-		basic = append(basic, fmt.Sprintf("CSI Volumes|%s", strings.Join(nodeCSIVolumeNames(node, runningAllocs), ",")))
+		basic = append(basic, fmt.Sprintf("CSI Volumes|%s", strings.Join(nodeCSIVolumeNames(runningAllocs), ",")))
 		driverStatus := fmt.Sprintf("Driver Status| %s", c.outputTruncatedNodeDriverInfo(node))
 		basic = append(basic, driverStatus)
 	}
@@ -821,7 +821,7 @@ func (c *NodeStatusCommand) formatDeviceAttributes(node *api.Node) {
 		}
 
 		if first {
-			c.Ui.Output("\nDevice Group Attributes")
+			c.Ui.Output("\n[bold]Device Group Attributes[reset]")
 			first = false
 		} else {
 			c.Ui.Output("")


### PR DESCRIPTION
Hi team,

This PR aims to fix #12816. I find unused variable in func `nodeCSIVolumeNames` so I removed it as well