### PR TITLE
Fix: missing Node Status "disconnected" in API

### DIFF
--- a/.changelog/16166.txt
+++ b/.changelog/16166.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Added missing node states to NodeStatus constants
+```

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -9,9 +9,10 @@ import (
 )
 
 const (
-	NodeStatusInit  = "initializing"
-	NodeStatusReady = "ready"
-	NodeStatusDown  = "down"
+	NodeStatusInit         = "initializing"
+	NodeStatusReady        = "ready"
+	NodeStatusDown         = "down"
+	NodeStatusDisconnected = "disconnected"
 
 	// NodeSchedulingEligible and Ineligible marks the node as eligible or not,
 	// respectively, for receiving allocations. This is orthogonal to the node


### PR DESCRIPTION
Looks like a new node status was introduced with nomad 1.3.x but this isn't reflected in the API