### PR TITLE
cgutil: handle panic from runc helper method

### DIFF
--- a/.changelog/16180.txt
+++ b/.changelog/16180.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cgutil: handle panic coming from runc helper method
+```

--- a/client/lib/cgutil/cgutil_linux.go
+++ b/client/lib/cgutil/cgutil_linux.go
@@ -18,7 +18,19 @@ import (
 // cgroups.v1
 //
 // This is a read-only value.
-var UseV2 = cgroups.IsCgroup2UnifiedMode()
+var UseV2 = safelyDetectUnifiedMode()
+
+// Currently it is possible for the runc utility function to panic
+// https://github.com/opencontainers/runc/pull/3745
+func safelyDetectUnifiedMode() (result bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			result = false
+		}
+	}()
+	result = cgroups.IsCgroup2UnifiedMode()
+	return
+}
 
 // GetCgroupParent returns the mount point under the root cgroup in which Nomad
 // will create cgroups. If parent is not set, an appropriate name for the version


### PR DESCRIPTION
This PR wraps the `cgroups.IsCgroup2UnifiedMode()` helper method from
runc in a `defer/recover` block because it might panic in some cases.

Upstream fix in: https://github.com/opencontainers/runc/pull/3745

Closes #16179

Backports as far back as 1.3.x, when support for cgv2 was added. 