### PR TITLE
[cli] var put - Add extension parsing to second argument when file

### DIFF
--- a/.changelog/16181.txt
+++ b/.changelog/16181.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: `var put`: when second arg is an @-reference, check extension for format
+```


### PR DESCRIPTION
This fixes an issue when providing a variable path to the command, but using an HCL variable specification for its items data.

## Before

```plaintext
$ nomad var put test @spec.nv.hcl
Failed to parse variable data: error unmarshaling json: invalid character '#' looking for beginning of value
```

## After

```plaintext
$ bin/nomad var put test @spec.nv.hcl
Created variable "test" with modify index 44954
```

