### PR TITLE
Minor post-1.5-beta1 API, code, and docs cleanups

### DIFF
--- a/command/agent/variable_endpoint.go
+++ b/command/agent/variable_endpoint.go
@@ -16,7 +16,6 @@ func (s *HTTPServer) VariablesListRequest(resp http.ResponseWriter, req *http.Re
 
 	args := structs.VariablesListRequest{}
 	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
-		//TODO(schmichael) shouldn't we return something here?!
 		return nil, CodedError(http.StatusBadRequest, "failed to parse parameters")
 	}
 
@@ -56,7 +55,7 @@ func (s *HTTPServer) variableQuery(resp http.ResponseWriter, req *http.Request,
 		Path: path,
 	}
 	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
-		return nil, nil
+		return nil, CodedError(http.StatusBadRequest, "failed to parse parameters")
 	}
 	var out structs.VariablesReadResponse
 	if err := s.agent.RPC(structs.VariablesReadRPCMethod, &args, &out); err != nil {

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -496,7 +496,7 @@ func (sv *Variables) decrypt(v *structs.VariableEncrypted) (*structs.VariableDec
 
 // handleMixedAuthEndpoint is a helper to handle auth on RPC endpoints that can
 // either be called by external clients or by workload identity
-func (sv *Variables) handleMixedAuthEndpoint(args structs.QueryOptions, cap, pathOrPrefix string) (*acl.ACL, *structs.IdentityClaims, error) {
+func (sv *Variables) handleMixedAuthEndpoint(args structs.QueryOptions, policy, pathOrPrefix string) (*acl.ACL, *structs.IdentityClaims, error) {
 
 	var aclObj *acl.ACL
 	var err error
@@ -509,7 +509,7 @@ func (sv *Variables) handleMixedAuthEndpoint(args structs.QueryOptions, cap, pat
 	}
 	claims := args.GetIdentity().GetClaims()
 
-	err = sv.authorize(aclObj, claims, args.RequestNamespace(), cap, pathOrPrefix)
+	err = sv.authorize(aclObj, claims, args.RequestNamespace(), policy, pathOrPrefix)
 	if err != nil {
 		return aclObj, claims, err
 	}
@@ -517,7 +517,7 @@ func (sv *Variables) handleMixedAuthEndpoint(args structs.QueryOptions, cap, pat
 	return aclObj, claims, nil
 }
 
-func (sv *Variables) authorize(aclObj *acl.ACL, claims *structs.IdentityClaims, ns, cap, pathOrPrefix string) error {
+func (sv *Variables) authorize(aclObj *acl.ACL, claims *structs.IdentityClaims, ns, policy, pathOrPrefix string) error {
 
 	if aclObj == nil && claims == nil {
 		return nil // ACLs aren't enabled
@@ -526,7 +526,7 @@ func (sv *Variables) authorize(aclObj *acl.ACL, claims *structs.IdentityClaims, 
 	// Perform normal ACL validation. If the ACL object is nil, that means we're
 	// working with an identity claim.
 	if aclObj != nil {
-		if !aclObj.AllowVariableOperation(ns, pathOrPrefix, cap) {
+		if !aclObj.AllowVariableOperation(ns, pathOrPrefix, policy) {
 			return structs.ErrPermissionDenied
 		}
 		return nil
@@ -547,7 +547,7 @@ func (sv *Variables) authorize(aclObj *acl.ACL, claims *structs.IdentityClaims, 
 			return err // this only returns an error when the state store has gone wrong
 		}
 		if aclObj != nil && aclObj.AllowVariableOperation(
-			ns, pathOrPrefix, cap) {
+			ns, pathOrPrefix, policy) {
 			return nil
 		}
 	}

--- a/website/content/api-docs/task-api.mdx
+++ b/website/content/api-docs/task-api.mdx
@@ -31,10 +31,11 @@ to Nomad.
 
 Unlike the agent's HTTP API, the Task API *always requires authentication* even
 if [ACLs][acl] are disabled.  This allows Nomad to always make the Task API
-available even if the workload is untrusted.
+available even if the workload is untrusted. If ACLs are enabled, the [anonymous
+policy][anon] is not available via the Task API.
 
 Both [ACL Tokens][acl-tokens] and [Workload Identities][workload-id] are
-accepted. Once the Task API has authneticated the credentials, the normal
+accepted. Once the Task API has authenticated the credentials, the normal
 endpoint-specific authorization is applied when ACLs are enabled.
 
 The Workload Identity should be used by tasks accessing the Task API.
@@ -94,6 +95,7 @@ $ nomad node status -filter 'Meta.example == "Hello World!"'
 [acl]: /nomad/docs/concepts/acl
 [acl-tokens]: /nomad/docs/concepts/acl#token
 [alloc-exec]: /nomad/docs/commands/alloc/exec
+[anon]: /nomad/tutorials/access-control/access-control#acl-policies
 [bind_addr]: /nomad/docs/configuration
 [mTLS]: /nomad/tutorials/transport-security/security-enable-tls
 [task-user]: /nomad/docs/job-specification/task#user

--- a/website/content/docs/concepts/workload-identity.mdx
+++ b/website/content/docs/concepts/workload-identity.mdx
@@ -90,13 +90,7 @@ nomad acl policy apply \
    redis-policy ./policy.hcl
 ```
 
-## Using Workload Identity
-
-In Nomad 1.4.0 the workload identity is used only for `template`
-access to [Variables][] and not exposed outside of Nomad.
-
 [allocation]: /nomad/docs/concepts/architecture#allocation
 [identity-block]: /nomad/docs/job-specification/identity
 [plan applier]: /nomad/docs/concepts/scheduling/scheduling
-[Variables]: /nomad/docs/concepts/variables
 [JSON Web Token (JWT)]: https://datatracker.ietf.org/doc/html/rfc7519


### PR DESCRIPTION
1. Remove `TODO` that isn't going to get addressed
2. Return an error when `parse` fails
3. Rename `cap -> policy` because `cap` is a builtin, and the variables we pass in are called `SomethingPolicy`
4. Fix a misspelling
5. Mention anonymous policy doesn't work for task api
6. Remove old `Using WI` section