### PR TITLE
client: add option to configure CSIVolumeClaimGCInterval

### DIFF
--- a/.changelog/16195.txt
+++ b/.changelog/16195.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+csi: Added server configuration for `csi_volume_claim_gc_interval`
+```

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -404,6 +404,13 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 		}
 		conf.DeploymentGCThreshold = dur
 	}
+	if gcInterval := agentConfig.Server.CSIVolumeClaimGCInterval; gcInterval != "" {
+		dur, err := time.ParseDuration(gcInterval)
+		if err != nil {
+			return nil, err
+		}
+		conf.CSIVolumeClaimGCInterval = dur
+	}
 	if gcThreshold := agentConfig.Server.CSIVolumeClaimGCThreshold; gcThreshold != "" {
 		dur, err := time.ParseDuration(gcThreshold)
 		if err != nil {

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -408,6 +408,8 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 		dur, err := time.ParseDuration(gcInterval)
 		if err != nil {
 			return nil, err
+		} else if dur <= time.Duration(0) {
+			return nil, fmt.Errorf("csi_volume_claim_gc_interval should be greater than 0s")
 		}
 		conf.CSIVolumeClaimGCInterval = dur
 	}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -490,6 +490,10 @@ type ServerConfig struct {
 	// GCed but the threshold can be used to filter by age.
 	DeploymentGCThreshold string `hcl:"deployment_gc_threshold"`
 
+	// CSIVolumeClaimGCInterval is how often we dispatch a job to GC
+	// volume claims.
+	CSIVolumeClaimGCInterval string `hcl:"csi_volume_claim_gc_interval"`
+
 	// CSIVolumeClaimGCThreshold controls how "old" a CSI volume must be to
 	// have its claims collected by GC.	Age is not the only requirement for
 	// a volume to be GCed but the threshold can be used to filter by age.
@@ -1875,6 +1879,9 @@ func (s *ServerConfig) Merge(b *ServerConfig) *ServerConfig {
 	}
 	if b.DeploymentGCThreshold != "" {
 		result.DeploymentGCThreshold = b.DeploymentGCThreshold
+	}
+	if b.CSIVolumeClaimGCInterval != "" {
+		result.CSIVolumeClaimGCInterval = b.CSIVolumeClaimGCInterval
 	}
 	if b.CSIVolumeClaimGCThreshold != "" {
 		result.CSIVolumeClaimGCThreshold = b.CSIVolumeClaimGCThreshold

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -105,6 +105,7 @@ var basicConfig = &Config{
 		JobGCInterval:             "3m",
 		JobGCThreshold:            "12h",
 		DeploymentGCThreshold:     "12h",
+		CSIVolumeClaimGCInterval:  "3m",
 		CSIVolumeClaimGCThreshold: "12h",
 		CSIPluginGCThreshold:      "12h",
 		ACLTokenGCThreshold:       "12h",

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -114,6 +114,7 @@ server {
   job_gc_threshold              = "12h"
   eval_gc_threshold             = "12h"
   deployment_gc_threshold       = "12h"
+  csi_volume_claim_gc_interval  = "3m"
   csi_volume_claim_gc_threshold = "12h"
   csi_plugin_gc_threshold       = "12h"
   acl_token_gc_threshold        = "12h"

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -273,6 +273,7 @@
       ],
       "encrypt": "abc",
       "eval_gc_threshold": "12h",
+      "csi_volume_claim_gc_interval": "3m",
       "heartbeat_grace": "30s",
       "job_gc_interval": "3m",
       "job_gc_threshold": "12h",

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -107,6 +107,9 @@ server {
   deployment must be in the terminal state before it is eligible for garbage
   collection. This is specified using a label suffix like "30s" or "1h".
 
+- `csi_volume_claim_gc_interval` `(string: "5m")` - Specifies the interval
+  between CSI volume claim garbage collections.
+
 - `csi_volume_claim_gc_threshold` `(string: "1h")` - Specifies the minimum age of
   a CSI volume before it is eligible to have its claims garbage collected.
   This is specified using a label suffix like "30s" or "1h".


### PR DESCRIPTION
The default setting is 5 minutes. If we lose an instance using an EBS volume with the CSI EBS volume plugin, it takes up to 5 minutes before the claims are GC'ed and we can get the job rescheduled. We would like to be able to configure this to be lower.