### PR TITLE
fix test flake for RPC TLS enforcement test

### DIFF
--- a/nomad/rpc_test.go
+++ b/nomad/rpc_test.go
@@ -1151,7 +1151,7 @@ func TestRPC_TLS_Enforcement_RPC(t *testing.T) {
 	defer tlsHelper.cleanup()
 
 	standardRPCs := map[string]interface{}{
-		"Status.Ping": struct{}{},
+		"Status.Ping": &structs.GenericRequest{},
 	}
 
 	localServersOnlyRPCs := map[string]interface{}{

--- a/nomad/rpc_test.go
+++ b/nomad/rpc_test.go
@@ -1409,6 +1409,7 @@ func newTLSTestHelper(t *testing.T) tlsTestHelper {
 			KeyFile:              h.serverCert + ".key",
 		}
 	})
+	testutil.WaitForLeader(t, h.nonVerifyServer.RPC)
 
 	return h
 }


### PR DESCRIPTION
The RPC TLS enforcement test was frequently failing with broken connections. The
most likely cause was that the tests started to run before the server had
started its RPC server. Wait until it self-elects to ensure that the RPC server
is up. This seems to have corrected the error; I ran this 3 times without a
failure (even accounting for `gotestsum` retries).

Also, fix a minor test bug that didn't impact the test but showed an incorrect
usage for `Status.Ping.`