### PR TITLE
docs: clarify sysbatch supports count

### DIFF
--- a/website/content/docs/schedulers.mdx
+++ b/website/content/docs/schedulers.mdx
@@ -52,17 +52,15 @@ should be present on every node in the cluster. Since these tasks are
 managed by Nomad, they can take advantage of job updating,
 service discovery, and more.
 
-Since Nomad 0.9, the system scheduler will preempt eligible lower priority
-tasks running on a node if there isn't enough capacity to place a system job.
-See [preemption] for details on how tasks that get preempted are chosen.
+The system scheduler will preempt eligible lower priority tasks running on a
+node if there isn't enough capacity to place a system job.  See [preemption]
+for details on how tasks that get preempted are chosen.
 
 Systems jobs are intended to run until explicitly stopped either by an operator
 or [preemption]. If a system task exits it is considered a failure and handled
 according to the job's [restart] block; system jobs do not have rescheduling.
 
 ## System Batch
-
-~> System Batch scheduling is new in Nomad 1.2.
 
 The `sysbatch` scheduler is used to register jobs that should be run to completion
 on all clients that meet the job's constraints. The `sysbatch` scheduler will
@@ -81,6 +79,11 @@ get preempted are chosen.
 Sysbatch jobs are intended to run until successful completion, explicitly stopped
 by an operator, or evicted through [preemption]. Sysbatch tasks that exit with an
 error are handled according to the job's [restart] block.
+
+ Like the `batch` scheduler, system batch jobs may have a [`count`] greater
+ than 1 to control how many instances are run. Instances that cannot be
+ immediately placed will be scheduled when resources become available,
+ potentially on a node that has already run another instance of the same job.
 
 [borg]: https://research.google.com/pubs/pub43438.html
 [parameterized]: /nomad/docs/job-specification/parameterized

--- a/website/content/docs/schedulers.mdx
+++ b/website/content/docs/schedulers.mdx
@@ -80,8 +80,8 @@ Sysbatch jobs are intended to run until successful completion, explicitly stoppe
 by an operator, or evicted through [preemption]. Sysbatch tasks that exit with an
 error are handled according to the job's [restart] block.
 
- Like the `batch` scheduler, system batch jobs may have a [`count`] greater
- than 1 to control how many instances are run. Instances that cannot be
+ Like the `batch` scheduler, task groups in system batch jobs may have a `count` 
+ greater than 1 to control how many instances are run. Instances that cannot be
  immediately placed will be scheduled when resources become available,
  potentially on a node that has already run another instance of the same job.
 


### PR DESCRIPTION
Also remove old version indicators.

Inspired by discussion arising from #16097 -- specifically that I forgot sysbatch supported `count > 1`!

Not sure we have a best practice on when to remove version spam from our docs. Removing "Since Nomad 0.9" seems safe, but is it too soon to remove the `Nomad 1.2` note?