### PR TITLE
acl: add validation to binding rule selector on upsert.

### DIFF
--- a/api/acl_test.go
+++ b/api/acl_test.go
@@ -655,7 +655,6 @@ func TestACLBindingRules(t *testing.T) {
 	testClient, testServer, _ := makeACLClient(t, nil, nil)
 	defer testServer.Stop()
 
-	//
 	aclAuthMethod := ACLAuthMethod{
 		Name:          "auth0",
 		Type:          ACLAuthMethodTypeOIDC,
@@ -676,7 +675,7 @@ func TestACLBindingRules(t *testing.T) {
 	bindingRule := ACLBindingRule{
 		Description: "my-binding-rule",
 		AuthMethod:  "auth0",
-		Selector:    "nomad-engineering-team in list.groups",
+		Selector:    "nomad_engineering_team in list.groups",
 		BindType:    "role",
 		BindName:    "cluster-admin",
 	}

--- a/command/acl_binding_rule_create_test.go
+++ b/command/acl_binding_rule_create_test.go
@@ -72,14 +72,14 @@ func TestACLBindingRuleCreateCommand_Run(t *testing.T) {
 	// Create the ACL binding rule.
 	args := []string{
 		"-address=" + url, "-token=" + rootACLToken.SecretID, "-auth-method=acl-binding-rule-cli-test",
-		"-bind-name=engineering", "-bind-type=role", `-selector="nomad-engineering in list.groups"`,
+		"-bind-name=engineering", "-bind-type=role", "-selector=engineering in list.groups",
 	}
 	must.Eq(t, 0, cmd.Run(args))
 	s := ui.OutputWriter.String()
 	must.StrContains(t, s, "acl-binding-rule-cli-test")
 	must.StrContains(t, s, "role")
 	must.StrContains(t, s, "engineering")
-	must.StrContains(t, s, "nomad-engineering in list.groups")
+	must.StrContains(t, s, "engineering in list.groups")
 
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()

--- a/nomad/structs/acl_test.go
+++ b/nomad/structs/acl_test.go
@@ -1204,7 +1204,7 @@ func TestACLBindingRule_Validate(t *testing.T) {
 			inputACLBindingRule: &ACLBindingRule{
 				Description: "some short description",
 				AuthMethod:  "auth0",
-				Selector:    "group-name in list.groups",
+				Selector:    "group_name in list.groups",
 				BindType:    ACLBindingRuleBindTypePolicy,
 				BindName:    "some-policy-name",
 			},
@@ -1215,7 +1215,7 @@ func TestACLBindingRule_Validate(t *testing.T) {
 			inputACLBindingRule: &ACLBindingRule{
 				Description: "some short description",
 				AuthMethod:  "auth0",
-				Selector:    "group-name in list.groups",
+				Selector:    "group_name in list.groups",
 				BindType:    ACLBindingRuleBindTypePolicy,
 				BindName:    "",
 			},
@@ -1230,7 +1230,7 @@ func TestACLBindingRule_Validate(t *testing.T) {
 			inputACLBindingRule: &ACLBindingRule{
 				Description: "some short description",
 				AuthMethod:  "auth0",
-				Selector:    "group-name in list.groups",
+				Selector:    "group_name in list.groups",
 				BindType:    ACLBindingRuleBindTypeRole,
 				BindName:    "some-role-name",
 			},
@@ -1241,7 +1241,7 @@ func TestACLBindingRule_Validate(t *testing.T) {
 			inputACLBindingRule: &ACLBindingRule{
 				Description: "some short description",
 				AuthMethod:  "auth0",
-				Selector:    "group-name in list.groups",
+				Selector:    "group_name in list.groups",
 				BindType:    ACLBindingRuleBindTypeRole,
 				BindName:    "",
 			},
@@ -1256,7 +1256,7 @@ func TestACLBindingRule_Validate(t *testing.T) {
 			inputACLBindingRule: &ACLBindingRule{
 				Description: "some short description",
 				AuthMethod:  "auth0",
-				Selector:    "group-name in list.groups",
+				Selector:    "group_name in list.groups",
 				BindType:    ACLBindingRuleBindTypeManagement,
 				BindName:    "",
 			},
@@ -1267,13 +1267,28 @@ func TestACLBindingRule_Validate(t *testing.T) {
 			inputACLBindingRule: &ACLBindingRule{
 				Description: "some short description",
 				AuthMethod:  "auth0",
-				Selector:    "group-name in list.groups",
+				Selector:    "group_name in list.groups",
 				BindType:    ACLBindingRuleBindTypeManagement,
 				BindName:    "some-name",
 			},
 			expectedError: &multierror.Error{
 				Errors: []error{
 					errors.New("bind name should be empty"),
+				},
+			},
+		},
+		{
+			name: "invalid selector",
+			inputACLBindingRule: &ACLBindingRule{
+				Description: "some short description",
+				AuthMethod:  "auth0",
+				Selector:    "group-name in list.groups",
+				BindType:    ACLBindingRuleBindTypePolicy,
+				BindName:    "some-policy-name",
+			},
+			expectedError: &multierror.Error{
+				Errors: []error{
+					errors.New("selector is invalid: 1:6 (5): no match found, expected: \"!=\", \".\", \"==\", \"[\", [ \\t\\r\\n] or [a-zA-Z0-9_/]"),
 				},
 			},
 		},
@@ -1293,6 +1308,7 @@ func TestACLBindingRule_Validate(t *testing.T) {
 					errors.New("auth method is missing"),
 					errors.New("description longer than 256"),
 					errors.New("bind type is missing"),
+					errors.New("selector is invalid: 1:6 (5): no match found, expected: \"!=\", \".\", \"==\", \"[\", [ \\t\\r\\n] or [a-zA-Z0-9_/]"),
 				},
 			},
 		},

--- a/website/content/api-docs/acl/binding-rules.mdx
+++ b/website/content/api-docs/acl/binding-rules.mdx
@@ -127,7 +127,11 @@ The table below shows this endpoint's support for
 
 - `Selector` `(string: "")` - A boolean expression that matches against verified
   identity attributes returned from the auth method during login.  This is
-  optional and when not set, provides a catch-all rule.
+  optional and when not set, provides a catch-all rule. If set, it must be a
+  valid [go-bexpr][] expression; for example, a dash in the claim name will
+  require it to be encased in quotes and escaped such as
+  `"\"project-developer\" in list.roles"`.
+
 
 - `BindType` `(string: <required>)` - Adjusts how this binding rule is applied
   at login time. Valid values are `role`, `policy`, and `management`.
@@ -200,7 +204,10 @@ queries](/nomad/api-docs#blocking-queries) and [required ACLs](/nomad/api-docs#a
 
 - `Selector` `(string: "")` - A boolean expression that matches against verified
   identity attributes returned from the auth method during login.  This is
-  optional and when not set, provides a catch-all rule.
+  optional and when not set, provides a catch-all rule. If set, it must be a
+  valid [go-bexpr][] expression; for example, a dash in the claim name will
+  require it to be encased in quotes and escaped such as
+  `"\"project-developer\" in list.roles"`.
 
 - `BindType` `(string: "")` - Adjusts how this binding rule is applied at login
   time. Valid values are `role`, `policy`, and `management`.
@@ -274,3 +281,5 @@ $ curl \
     --header "X-Nomad-Token: <NOMAD_TOKEN_SECRET_ID>" \
     https://localhost:4646/v1/acl/binding-rule/5da76548-1a60-b8fb-f9be-c7736a5bca09
 ```
+
+[go-bexpr]: https://github.com/hashicorp/go-bexpr

--- a/website/content/docs/commands/acl/binding-rule/create.mdx
+++ b/website/content/docs/commands/acl/binding-rule/create.mdx
@@ -48,11 +48,37 @@ via flags detailed below.
 Create a new ACL Binding Rule:
 
 ```shell-session
-$ nomad acl binding-rule create -description "example binding rule" -auth-method "auth0" -bind-type "role" -bind-name "eng-ro" -selector "engineering in list.roles"
+$ nomad acl binding-rule create \
+    -description "example binding rule" \
+    -auth-method "auth0" \
+    -bind-type "role" \
+    -bind-name "eng-ro" \
+    -selector "engineering in list.roles"
 ID           = 698fdad6-dcb3-79dd-dc72-b43374057dea
 Description  = example binding rule
 Auth Method  = auth0
 Selector     = "engineering in list.roles"
+Bind Type    = role
+Bind Name    = eng-ro
+Create Time  = 2022-12-20 11:15:22.582568 +0000 UTC
+Modify Time  = 2022-12-20 11:15:22.582568 +0000 UTC
+Create Index = 14
+Modify Index = 14
+```
+
+Create a new ACL Binding Rule where the selector needs to be escaped:
+
+```shell-session
+$ nomad acl binding-rule create \
+    -description "example binding rule" \
+    -auth-method "auth0" \
+    -bind-type "role" \
+    -bind-name "eng-ro" \
+    -selector "\"product-developer\" in list.roles"
+ID           = 698fdad6-dcb3-79dd-dc72-b43374057dea
+Description  = example binding rule
+Auth Method  = auth0
+Selector     = "\"project-developer\" in list.roles"
 Bind Type    = role
 Bind Name    = eng-ro
 Create Time  = 2022-12-20 11:15:22.582568 +0000 UTC


### PR DESCRIPTION
The selector should be validated on upsert, otherwise an expression that is invalid will cause mapping failures at login which can be confusing to the user and operator. The docs have also been updated to include a little information about this and an example of dealing with claim names that include dashes.

This update targets an unreleased feature, so doesn't require a changelong entry.

Closes #16206 