### PR TITLE
build/cli: Add BuildDate

### DIFF
--- a/.changelog/16216.txt
+++ b/.changelog/16216.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: multi-line `nomad version` output, add BuildDate
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,15 +3,15 @@ PROJECT_ROOT := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 THIS_OS := $(shell uname | cut -d- -f1)
 THIS_ARCH := $(shell uname -m)
 
-REPO = github.com/hashicorp/nomad
+GO_MODULE = github.com/hashicorp/nomad
 
 GIT_COMMIT := $(shell git rev-parse HEAD)
 GIT_DIRTY := $(if $(shell git status --porcelain),+CHANGES)
-GIT_COMMIT_FLAG = $(REPO)/version.GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)
+GIT_COMMIT_FLAG = $(GO_MODULE)/version.GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)
 
 # build date is based on most recent commit, in RFC3339 format
 BUILD_DATE ?= $(shell TZ=UTC0 git show -s --format=%cd --date=format-local:'%Y-%m-%dT%H:%M:%SZ' HEAD)
-BUILD_DATE_FLAG = $(REPO)/version.BuildDate=$(BUILD_DATE)
+BUILD_DATE_FLAG = $(GO_MODULE)/version.BuildDate=$(BUILD_DATE)
 
 GO_LDFLAGS = -X $(GIT_COMMIT_FLAG) -X $(BUILD_DATE_FLAG)
 

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -171,6 +171,7 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	conf.EnableDebug = agentConfig.EnableDebug
 
 	conf.Build = agentConfig.Version.VersionNumber()
+	conf.BuildDate = agentConfig.Version.BuildDate
 	conf.Revision = agentConfig.Version.Revision
 	if agentConfig.Region != "" {
 		conf.Region = agentConfig.Region

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -127,6 +127,9 @@ type Config struct {
 	// operators track which versions are actively deployed
 	Build string
 
+	// BuildDate is the time of the git commit used to build the program.
+	BuildDate time.Time
+
 	// Revision is a string that carries the version.GitCommit of Nomad that
 	// was compiled.
 	Revision string

--- a/nomad/server_setup.go
+++ b/nomad/server_setup.go
@@ -1,6 +1,8 @@
 package nomad
 
 import (
+	"time"
+
 	"github.com/hashicorp/go-hclog"
 	"golang.org/x/exp/slices"
 )
@@ -8,6 +10,9 @@ import (
 // LicenseConfig allows for tunable licensing config
 // primarily used for enterprise testing
 type LicenseConfig struct {
+	// BuildDate is the time of the git commit used to build the program.
+	BuildDate time.Time
+
 	// LicenseEnvBytes is the license bytes to use for the server's license
 	LicenseEnvBytes string
 

--- a/version/version.go
+++ b/version/version.go
@@ -3,9 +3,14 @@ package version
 import (
 	"bytes"
 	"fmt"
+	"time"
 )
 
 var (
+	// BuildDate is the time of the git commit used to build the program,
+	// in RFC3339 format. It is filled in by the compiler via makefile.
+	BuildDate string
+
 	// The git commit that was compiled. This will be filled in by the compiler.
 	GitCommit   string
 	GitDescribe string
@@ -24,6 +29,7 @@ var (
 
 // VersionInfo
 type VersionInfo struct {
+	BuildDate         time.Time
 	Revision          string
 	Version           string
 	VersionPrerelease string
@@ -50,7 +56,11 @@ func GetVersion() *VersionInfo {
 		rel = "dev"
 	}
 
+	// on parse error, will be zero value time.Time{}
+	built, _ := time.Parse(time.RFC3339, BuildDate)
+
 	return &VersionInfo{
+		BuildDate:         built,
 		Revision:          GitCommit,
 		Version:           ver,
 		VersionPrerelease: rel,

--- a/version/version.go
+++ b/version/version.go
@@ -94,8 +94,12 @@ func (c *VersionInfo) FullVersionNumber(rev bool) string {
 		fmt.Fprintf(&versionString, "+%s", c.VersionMetadata)
 	}
 
+	if !c.BuildDate.IsZero() {
+		fmt.Fprintf(&versionString, "\nBuildDate %s", c.BuildDate.Format(time.RFC3339))
+	}
+
 	if rev && c.Revision != "" {
-		fmt.Fprintf(&versionString, " (%s)", c.Revision)
+		fmt.Fprintf(&versionString, "\nRevision %s", c.Revision)
 	}
 
 	return versionString.String()

--- a/website/content/docs/commands/version.mdx
+++ b/website/content/docs/commands/version.mdx
@@ -8,7 +8,7 @@ description: |
 # Command: version
 
 The `version` command displays build information about the running binary,
-including the release version and the exact revision.
+including the release version, build date, and the exact revision.
 
 ## Usage
 
@@ -18,13 +18,18 @@ nomad version
 
 ## Output
 
-This command prints both the version number as well as the exact commit SHA used
-during the build. The SHA may also have the string `+CHANGES` appended to the
-end, indicating that local, uncommitted changes were detected at build time.
+This command prints the version number and info about the git commit that was
+used to build the binary. `BuildDate` is when the commit was made,
+and `Revision` is the exact commit SHA.
+
+The SHA may also have the string `+CHANGES` appended to the end,
+indicating that local, uncommitted changes were detected at build time.
 
 ## Examples
 
 ```shell-session
 $ nomad version
-Nomad v0.0.0-615-gcf3c6aa-dev (cf3c6aa8a75a689987b689d75ae2ba73458465cb+CHANGES)
+Nomad v1.5.0
+BuildDate 2023-02-17T19:29:26Z
+Revision a536284ebcfb4ff26065955abae446d81cc92b87+CHANGES
 ```


### PR DESCRIPTION
Populate a new `BuildDate` value based on the latest commit at build time.

Using commit time instead of a simple `$(date)` to be consistent across multiple builds, as done in Consul and Vault.

`BuildDate` will be used in Enterprise to compare to license expiration time, but here in OSS it only changes the output of `nomad version`. I could be convinced to revert that if we don't want to futz with it here, but I can imagine cases where it would be nice for folks to have available.

Relates to: hashicorp/nomad-enterprise#855