### PR TITLE
Task API / Dynamic Node Metadata E2E test fixes

### DIFF
--- a/e2e/workload_id/input/api-auth.nomad.hcl
+++ b/e2e/workload_id/input/api-auth.nomad.hcl
@@ -1,5 +1,4 @@
 job "api-auth" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   constraint {

--- a/e2e/workload_id/input/api-auth.nomad.hcl
+++ b/e2e/workload_id/input/api-auth.nomad.hcl
@@ -1,5 +1,5 @@
 job "api-auth" {
-  type        = "batch"
+  type = "batch"
 
   constraint {
     attribute = "${attr.kernel.name}"

--- a/e2e/workload_id/input/api-win.nomad.hcl
+++ b/e2e/workload_id/input/api-win.nomad.hcl
@@ -1,5 +1,4 @@
 job "api-win" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   constraint {

--- a/e2e/workload_id/input/api-win.nomad.hcl
+++ b/e2e/workload_id/input/api-win.nomad.hcl
@@ -1,5 +1,5 @@
 job "api-win" {
-  type        = "batch"
+  type = "batch"
 
   constraint {
     attribute = "${attr.kernel.name}"

--- a/e2e/workload_id/input/node-meta.nomad.hcl
+++ b/e2e/workload_id/input/node-meta.nomad.hcl
@@ -23,8 +23,7 @@ variable "unset_constraint" {
 }
 
 job "node-meta" {
-  datacenters = ["dc1"]
-  type        = "batch"
+  type = "batch"
 
   constraint {
     attribute = "${attr.kernel.name}"


### PR DESCRIPTION
Fixes based on #16218 

Peeking at the commits is best, but there they're grouped by file neatly as well:

- TaskAPI middlewhere needs to turn RPC Permission Denied errors into Forbidden status codes to ensure acl.enabled=true behavior matches acl.enabled=false behavior. The e2e test covers this (and was failing as it should in our e2e environment!)
- Removed datacenters from all of my recent e2e jobspecs because I love the new default.
- I forgot to skip the Windows node in the Dynamic Node Metadata test. Fixed that.