### PR TITLE
Fix unsorted Node value in `nomad operator raft list-peers` command

### DIFF
--- a/.changelog/16221.txt
+++ b/.changelog/16221.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Sort output by Node name of the command `nomad operator raft list-peers`
+```

--- a/command/operator_raft_list.go
+++ b/command/operator_raft_list.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
@@ -84,6 +85,10 @@ func (c *OperatorRaftListCommand) Run(args []string) int {
 
 	// Format it as a nice table.
 	result := []string{"Node|ID|Address|State|Voter|RaftProtocol"}
+	sort.Slice(reply.Servers, func(i, j int) bool {
+		return reply.Servers[i].Node < reply.Servers[j].Node
+	})
+
 	for _, s := range reply.Servers {
 		state := "follower"
 		if s.Leader {


### PR DESCRIPTION
Hi team,

This PR presents a small fix to sort the Node value in `nomad operator raft list-peers` command.
It will resolve #13711