### PR TITLE
Skip tests running locally without root access  

### DIFF
--- a/ci/skip_non_root.go
+++ b/ci/skip_non_root.go
@@ -1,0 +1,20 @@
+package ci
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+	"testing"
+)
+
+// SkipTestWithoutRootAccess will skip test t if it's not running in CI environment
+// and test is not running with Root access.
+func SkipTestWithoutRootAccess(t *testing.T) {
+	ciVar := os.Getenv("CI")
+	isCI, err := strconv.ParseBool(ciVar)
+	isCI = isCI && err == nil
+
+	if !isCI && syscall.Getuid() != 0 {
+		t.Skipf("Skipping test %s. To run this test, you should run it as root user", t.Name())
+	}
+}

--- a/client/allocrunner/taskrunner/artifact_hook_test.go
+++ b/client/allocrunner/taskrunner/artifact_hook_test.go
@@ -161,6 +161,7 @@ func TestTaskRunner_ArtifactHook_PartialDone(t *testing.T) {
 // TestTaskRunner_ArtifactHook_ConcurrentDownloadSuccess asserts that the artifact hook
 // download multiple files concurrently. this is a successful test without any errors.
 func TestTaskRunner_ArtifactHook_ConcurrentDownloadSuccess(t *testing.T) {
+	ci.SkipTestWithoutRootAccess(t)
 	t.Parallel()
 
 	me := &mockEmitter{}

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -1720,6 +1720,7 @@ func TestTaskRunner_DeriveToken_Unrecoverable(t *testing.T) {
 // TestTaskRunner_Download_RawExec asserts that downloaded artifacts may be
 // executed in a driver without filesystem isolation.
 func TestTaskRunner_Download_RawExec(t *testing.T) {
+	ci.SkipTestWithoutRootAccess(t)
 	ci.Parallel(t)
 
 	ts := httptest.NewServer(http.FileServer(http.Dir(filepath.Dir("."))))

--- a/drivers/exec/driver_unix_test.go
+++ b/drivers/exec/driver_unix_test.go
@@ -88,6 +88,7 @@ func TestExecDriver_StartWaitStop(t *testing.T) {
 }
 
 func TestExec_ExecTaskStreaming(t *testing.T) {
+	ci.SkipTestWithoutRootAccess(t)
 	ci.Parallel(t)
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
[After a short discussion](https://github.com/hashicorp/nomad/pull/16137#pullrequestreview-1301517321) with @tgross, I learned that some of the tests will fail if we run them locally and without root access.

This PR will add a functionality to skip tests if the tests:
- Are **not** running in CI environment (they are running locally)
- and if they are **not** running with Root access

Also it will log that the test is skipped, so if user wants to run them, she/he has to run it with root access.

In the current behavior, They are failing by saying something like: `operation not permitted`. 

**Note:** I used `make test | grep -C 5 "operation not permitted"` to find which tests require Root access, But it may not contain all of the tests which require root access.

Please let me know if anything is needed; Thanks.