### PR TITLE
docs: Fix missing `namespace`  query parameter in job doc

### DIFF
--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -571,6 +571,10 @@ The table below shows this endpoint's support for
 - `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
 
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+enabled, this value must match a namespace that the token is allowed to
+access. This is specified as a query string parameter.
+
 ### Sample Request
 
 ```shell-session
@@ -1160,7 +1164,11 @@ The table below shows this endpoint's support for
 
 - `all` `(bool: false)` - Specifies whether the list of allocations should
   include allocations from a previously registered job with the same ID. This is
-  possible if the job is deregistered and reregistered.
+  possible if the job is deregistered and re-registered.
+
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+enabled, this value must match a namespace that the token is allowed to
+access. This is specified as a query string parameter.
 
 ### Sample Request
 
@@ -1327,6 +1335,10 @@ The table below shows this endpoint's support for
 - `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
 
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+enabled, this value must match a namespace that the token is allowed to
+access. This is specified as a query string parameter.
+
 ### Sample Request
 
 ```shell-session
@@ -1390,7 +1402,11 @@ The table below shows this endpoint's support for
 
 - `all` `(bool: false)` - Specifies whether the list of deployments should
   include deployments from a previously registered job with the same ID. This is
-  possible if the job is deregistered and reregistered.
+  possible if the job is deregistered and re-registered.
+
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+enabled, this value must match a namespace that the token is allowed to
+access. This is specified as a query string parameter.
 
 ### Sample Request
 
@@ -1476,6 +1492,10 @@ The table below shows this endpoint's support for
 - `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
 
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+enabled, this value must match a namespace that the token is allowed to
+access. This is specified as a query string parameter.
+
 ### Sample Request
 
 ```shell-session
@@ -1534,6 +1554,10 @@ The table below shows this endpoint's support for
 
 - `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
+
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+enabled, this value must match a namespace that the token is allowed to
+access. This is specified as a query string parameter.
 
 ### Sample Request
 
@@ -1606,6 +1630,10 @@ The table below shows this endpoint's support for
   will be overridden. This allows a job to be registered when it would be denied
   by policy.
 
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+enabled, this value must match a namespace that the token is allowed to
+access. This is specified as a query string parameter.
+
 ### Sample Payload
 
 ```javascript
@@ -1667,6 +1695,10 @@ The table below shows this endpoint's support for
 
 - `Meta` `(meta<string|string>: nil)` - Specifies arbitrary metadata to pass to
   the job.
+
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+enabled, this value must match a namespace that the token is allowed to
+access. This is specified as a query string parameter.
 
 ### Sample Payload
 
@@ -1733,6 +1765,10 @@ The table below shows this endpoint's support for
 - `VaultToken` `(string: "")` - Optional value specifying the [vault token](/nomad/docs/commands/job/revert)
   used for Vault [policy authentication checking](/nomad/docs/configuration/vault#allow_unauthenticated).
 
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+enabled, this value must match a namespace that the token is allowed to
+access. This is specified as a query string parameter.
+
 ### Sample Payload
 
 ```json
@@ -1786,6 +1822,10 @@ The table below shows this endpoint's support for
 
 - `Stable` `(bool: false)` - Specifies whether the job should be marked as
   stable or not.
+
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+enabled, this value must match a namespace that the token is allowed to
+access. This is specified as a query string parameter.
 
 ### Sample Payload
 
@@ -1843,7 +1883,11 @@ The table below shows this endpoint's support for
 - `EvalOptions` `(<optional>)` - Specify additional options to be used during the forced evaluation.
   - `ForceReschedule` `(bool: false)` - If set, failed allocations of the job are rescheduled
     immediately. This is useful for operators to force immediate placement even if the failed allocations are past
-    their reschedule limit, or are delayed by several hours because the allocation's reschedule policy has exponential delay.
+    their rescheduling limit, or are delayed by several hours because the allocation's reschedule policy has exponential delay.
+
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+enabled, this value must match a namespace that the token is allowed to
+access. This is specified as a query string parameter.
 
 ### Sample Payload
 
@@ -1905,6 +1949,10 @@ The table below shows this endpoint's support for
 - `PolicyOverride` `(bool: false)` - If set, any soft mandatory Sentinel policies
   will be overridden. This allows a job to be registered when it would be denied
   by policy.
+
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+enabled, this value must match a namespace that the token is allowed to
+access. This is specified as a query string parameter.
 
 ### Sample Payload
 
@@ -2151,6 +2199,10 @@ The table below shows this endpoint's support for
   immediately. This means the job will not be queryable after being stopped. If
   not set, the job will be purged by the garbage collector.
 
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+enabled, this value must match a namespace that the token is allowed to
+access. This is specified as a query string parameter.
+
 ### Sample Request
 
 ```shell-session
@@ -2189,6 +2241,10 @@ The table below shows this endpoint's support for
 
 - `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
+
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+enabled, this value must match a namespace that the token is allowed to
+access. This is specified as a query string parameter.
 
 ### Sample Request
 
@@ -2258,6 +2314,10 @@ The table below shows this endpoint's support for
 - `PolicyOverride` `(bool: false)` - If set, any soft mandatory Sentinel policies
   will be overridden. This allows a job to be scaled when it would be denied
   by policy.
+
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+enabled, this value must match a namespace that the token is allowed to
+access. This is specified as a query string parameter.
 
 ### Sample Payload
 


### PR DESCRIPTION
Hi team,
This MR will fix the missing `namespace` query parameter in job doc
Closes #14197 