### PR TITLE
api: fix a panic and tweak some exported types

### DIFF
--- a/.changelog/16237.txt
+++ b/.changelog/16237.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+api: Fixed a bug where Variables.GetItems would panic if variable did not exist
+```
+
+```release-note:deprecation
+api: Deprecated Variables.GetItems in favor of Variables.GetVariableItems to avoid returning a pointer to a map
+```
+
+```release-note:deprecation
+api: Deprecated ErrVariableNotFound in favor of ErrVariablePathNotFound to correctly represent an error type
+```

--- a/api/variables_test.go
+++ b/api/variables_test.go
@@ -101,7 +101,7 @@ func TestVariables_SimpleCRUD(t *testing.T) {
 		_, err := nsv.Delete(sv1.Path, nil)
 		must.NoError(t, err)
 		_, _, err = nsv.Read(sv1.Path, nil)
-		must.ErrorContains(t, err, ErrVariableNotFound)
+		must.ErrorIs(t, err, ErrVariablePathNotFound)
 	})
 
 	t.Run("7 list vars after delete", func(t *testing.T) {
@@ -187,14 +187,14 @@ func TestVariables_Read(t *testing.T) {
 	testCases := []struct {
 		name          string
 		path          string
-		expectedError string
+		expectedError error
 		checkValue    bool
 		expectedValue *Variable
 	}{
 		{
 			name:          "not found",
 			path:          tID + "/not/found",
-			expectedError: ErrVariableNotFound,
+			expectedError: ErrVariablePathNotFound,
 			checkValue:    true,
 			expectedValue: nil,
 		},
@@ -208,8 +208,67 @@ func TestVariables_Read(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			get, _, err := nsv.Read(tc.path, nil)
-			if tc.expectedError != "" {
-				must.EqError(t, err, tc.expectedError)
+			if tc.expectedError != nil {
+				must.ErrorIs(t, err, tc.expectedError)
+			} else {
+				must.NoError(t, err)
+			}
+			if tc.checkValue {
+				if tc.expectedValue != nil {
+					must.NotNil(t, get)
+					must.Eq(t, tc.expectedValue, get)
+				} else {
+					must.Nil(t, get)
+				}
+			}
+		})
+	}
+}
+
+func TestVariables_GetVariableItems(t *testing.T) {
+	testutil.Parallel(t)
+
+	c, s := makeClient(t, nil, nil)
+	defer s.Stop()
+
+	nsv := c.Variables()
+	tID := fmt.Sprint(time.Now().UTC().UnixNano())
+	sv1 := Variable{
+		Namespace: "default",
+		Path:      tID + "/sv1",
+		Items: map[string]string{
+			"kv1": "val1",
+			"kv2": "val2",
+		},
+	}
+	writeTestVariable(t, c, &sv1)
+
+	testCases := []struct {
+		name          string
+		path          string
+		expectedError error
+		checkValue    bool
+		expectedValue VariableItems
+	}{
+		{
+			name:          "not found",
+			path:          tID + "/not/found",
+			expectedError: ErrVariablePathNotFound,
+			checkValue:    true,
+			expectedValue: nil,
+		},
+		{
+			name:          "found",
+			path:          sv1.Path,
+			checkValue:    true,
+			expectedValue: sv1.Items,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			get, _, err := nsv.GetVariableItems(tc.path, nil)
+			if tc.expectedError != nil {
+				must.ErrorIs(t, err, tc.expectedError)
 			} else {
 				must.NoError(t, err)
 			}


### PR DESCRIPTION
This PR
 - fixes a panic in `GetItems` when looking up a variable that does not exist
 - deprecates `GetItems` in favor of `GetVariableItems` which avoids returning a pointer to a `map`
 - deprecates `ErrVariableNotFound` in favor of `ErrVariablePathNotFound` which is an actual `error` type
 - eliminates unused constant `ErrVariableMissingItems`
 - does some minor code cleanup to make linters happier

Fixes #16236
Fixes #16235
Fixes #16234

No backport - we don't tag the api module anyway