### PR TITLE
services: ensure task group is set on service hook

### DIFF
--- a/.changelog/16240.txt
+++ b/.changelog/16240.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+services: Fixed a bug where check_restart on nomad services on tasks failed with incorrect CheckIDs
+```

--- a/client/allocrunner/taskrunner/script_check_hook_test.go
+++ b/client/allocrunner/taskrunner/script_check_hook_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/api"
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/interfaces"
 	"github.com/hashicorp/nomad/client/serviceregistration"
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
 
@@ -271,14 +272,17 @@ func TestScript_TaskEnvInterpolation(t *testing.T) {
 	scHook.taskEnv = env
 	scHook.driverExec = exec
 
-	expectedSvc := svcHook.getWorkloadServices().Services[0]
+	workload := svcHook.getWorkloadServices()
+	must.Eq(t, "web", workload.AllocInfo.Group)
+
+	expectedSvc := workload.Services[0]
 	expected := agentconsul.MakeCheckID(serviceregistration.MakeAllocServiceID(
 		alloc.ID, task.Name, expectedSvc), expectedSvc.Checks[0])
 
 	actual := scHook.newScriptChecks()
 	check, ok := actual[expected]
-	require.True(t, ok)
-	require.Equal(t, "my-job-frontend-check", check.check.Name)
+	must.True(t, ok)
+	must.Eq(t, "my-job-frontend-check", check.check.Name)
 
 	// emulate an update
 	env = taskenv.NewBuilder(mock.Node(), alloc, task, "global").SetHookEnv(
@@ -293,8 +297,8 @@ func TestScript_TaskEnvInterpolation(t *testing.T) {
 
 	actual = scHook.newScriptChecks()
 	check, ok = actual[expected]
-	require.True(t, ok)
-	require.Equal(t, "my-job-backend-check", check.check.Name)
+	must.True(t, ok)
+	must.Eq(t, "my-job-backend-check", check.check.Name)
 }
 
 func TestScript_associated(t *testing.T) {

--- a/client/allocrunner/taskrunner/service_hook.go
+++ b/client/allocrunner/taskrunner/service_hook.go
@@ -224,6 +224,7 @@ func (h *serviceHook) getWorkloadServices() *serviceregistration.WorkloadService
 	info := structs.AllocInfo{
 		AllocID:   h.allocID,
 		JobID:     h.jobID,
+		Group:     h.groupName,
 		Task:      h.taskName,
 		Namespace: h.namespace,
 	}


### PR DESCRIPTION
This PR fixes a bug where the task group information was not being set
on the `serviceHook.AllocInfo` struct, which is needed later on for calculating
the `CheckID` of a nomad service check. The `CheckID` is calculated independently
from multiple callsites, and the information being passed in must be consistent,
including the group name.

The `workload.AllocInfo.Group` was not set at this callsite, due to the bug fixed in this PR.
 https://github.com/hashicorp/nomad/blob/main/client/serviceregistration/nsd/nsd.go#L114

Fixes #16238

I suspect the bug was introduced as part of https://github.com/hashicorp/nomad/pull/14311

Backport only to 1.4.x (when NSD checks were introduced).