### PR TITLE
Custom job actions

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -86,7 +86,7 @@ func (a *Allocations) Info(allocID string, q *QueryOptions) (*Allocation, *Query
 // Nomad clients, set api.ClientConnTimeout to a small value (ex 1ms) to avoid
 // long pauses on this API call.
 func (a *Allocations) Exec(ctx context.Context,
-	alloc *Allocation, task string, tty bool, command []string,
+	alloc *Allocation, task string, tty bool, action string, command []string,
 	stdin io.Reader, stdout, stderr io.Writer,
 	terminalSizeCh <-chan TerminalSize, q *QueryOptions) (exitCode int, err error) {
 
@@ -96,6 +96,7 @@ func (a *Allocations) Exec(ctx context.Context,
 		task:    task,
 		tty:     tty,
 		command: command,
+		action:  action,
 
 		stdin:  stdin,
 		stdout: stdout,

--- a/api/allocations_exec.go
+++ b/api/allocations_exec.go
@@ -26,6 +26,7 @@ type execSession struct {
 	task    string
 	tty     bool
 	command []string
+	action  string
 
 	stdin  io.Reader
 	stdout io.Writer
@@ -84,6 +85,10 @@ func (s *execSession) startConnection() (*websocket.Conn, error) {
 		q.Params = make(map[string]string)
 	}
 
+	// if theres an action, look up its command and run it
+	fmt.Println("++> Has an action come in?")
+	fmt.Println(s.action)
+
 	commandBytes, err := json.Marshal(s.command)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal command: %W", err)
@@ -92,6 +97,7 @@ func (s *execSession) startConnection() (*websocket.Conn, error) {
 	q.Params["tty"] = strconv.FormatBool(s.tty)
 	q.Params["task"] = s.task
 	q.Params["command"] = string(commandBytes)
+	q.Params["action"] = s.action // TODO: probably does nothing
 
 	reqPath := fmt.Sprintf("/v1/client/allocation/%s/exec", s.alloc.ID)
 
@@ -253,3 +259,11 @@ func (s *execSession) startReceiving(ctx context.Context, conn *websocket.Conn) 
 
 	return exitCodeCh, errCh
 }
+
+// func validateActionExists(action string, alloc Allocation) (*Action, error) {
+// 	jobAction := alloc.Job.LookupAction(action)
+// 	if jobAction == nil {
+// 		return nil, fmt.Errorf("could not find action: %s", action)
+// 	}
+// 	return jobAction, nil
+// }

--- a/api/allocations_exec.go
+++ b/api/allocations_exec.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/gorilla/websocket"
 )
 
@@ -106,6 +107,14 @@ func (s *execSession) startConnection() (*websocket.Conn, error) {
 			return nil, err
 		}
 	}
+
+	fmt.Println("++> looking at conn")
+	spew.Dump(s.command)
+	fmt.Println("+++++++++++")
+	spew.Dump(commandBytes)
+	fmt.Println("+++++++++++")
+	spew.Dump(s.task)
+	fmt.Println("~~~~FIN~~~~")
 
 	return conn, nil
 }

--- a/api/allocations_exec.go
+++ b/api/allocations_exec.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/gorilla/websocket"
 )
 
@@ -85,10 +84,6 @@ func (s *execSession) startConnection() (*websocket.Conn, error) {
 		q.Params = make(map[string]string)
 	}
 
-	// if theres an action, look up its command and run it
-	fmt.Println("++> Has an action come in?")
-	fmt.Println(s.action)
-
 	commandBytes, err := json.Marshal(s.command)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal command: %W", err)
@@ -113,15 +108,6 @@ func (s *execSession) startConnection() (*websocket.Conn, error) {
 			return nil, err
 		}
 	}
-
-	fmt.Println("++> looking at conn")
-	spew.Dump(s.command)
-	fmt.Println("+++++++++++")
-	spew.Dump(commandBytes)
-	fmt.Println("+++++++++++")
-	spew.Dump(s.task)
-	fmt.Println("~~~~FIN~~~~")
-
 	return conn, nil
 }
 
@@ -259,11 +245,3 @@ func (s *execSession) startReceiving(ctx context.Context, conn *websocket.Conn) 
 
 	return exitCodeCh, errCh
 }
-
-// func validateActionExists(action string, alloc Allocation) (*Action, error) {
-// 	jobAction := alloc.Job.LookupAction(action)
-// 	if jobAction == nil {
-// 		return nil, fmt.Errorf("could not find action: %s", action)
-// 	}
-// 	return jobAction, nil
-// }

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -888,6 +888,7 @@ type Job struct {
 	Meta             map[string]string       `hcl:"meta,block"`
 	ConsulToken      *string                 `mapstructure:"consul_token" hcl:"consul_token,optional"`
 	VaultToken       *string                 `mapstructure:"vault_token" hcl:"vault_token,optional"`
+	Actions          []*Action               `hcl:"action,block"`
 
 	/* Fields set by server, not sourced from job config file */
 
@@ -1413,4 +1414,10 @@ type JobEvaluateRequest struct {
 // EvalOptions is used to encapsulate options when forcing a job evaluation
 type EvalOptions struct {
 	ForceReschedule bool
+}
+
+type Action struct {
+	Name    string   `hcl:"name,label"`
+	Command *string  `mapstructure:"command" hcl:"command"`
+	Args    []string `mapstructure:"args" hcl:"args,optional"`
 }

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -1026,20 +1026,6 @@ func (j *Job) LookupTaskGroup(name string) *TaskGroup {
 	return nil
 }
 
-// // LookupAction finds an action by name
-// func (j *Job) LookupAction(name string) *Action {
-// 	// fmt.Println(fmt.Sprintf("Looking up action %s", name))
-
-// 	for _, action := range j.Actions {
-// 		// fmt.Println(fmt.Sprintf("  -  is it %s?", action.Name))
-// 		if action.Name == name {
-// 			// fmt.Println(fmt.Sprintf("  -  Aye! it is %s!", action.Name))
-// 			return action
-// 		}
-// 	}
-// 	return nil
-// }
-
 // JobSummary summarizes the state of the allocations of a job
 type JobSummary struct {
 	JobID     string
@@ -1434,5 +1420,5 @@ type Action struct {
 	Name    string   `hcl:"name,label"`
 	Command *string  `mapstructure:"command" hcl:"command"`
 	Args    []string `mapstructure:"args" hcl:"args,optional"`
-	Type    *string  `hcl:"type,optional"`
+	Type    *string  `mapstructure:"type" hcl:"type,optional"`
 }

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -1026,6 +1026,20 @@ func (j *Job) LookupTaskGroup(name string) *TaskGroup {
 	return nil
 }
 
+// LookupAction finds an action by name
+func (j *Job) LookupAction(name string) *Action {
+	fmt.Println(fmt.Sprintf("Looking up action %s", name))
+
+	for _, action := range j.Actions {
+		fmt.Println(fmt.Sprintf("  -  is it %s?", action.Name))
+		if action.Name == name {
+			fmt.Println(fmt.Sprintf("  -  Aye! it is %s!", action.Name))
+			return action
+		}
+	}
+	return nil
+}
+
 // JobSummary summarizes the state of the allocations of a job
 type JobSummary struct {
 	JobID     string

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -1026,19 +1026,19 @@ func (j *Job) LookupTaskGroup(name string) *TaskGroup {
 	return nil
 }
 
-// LookupAction finds an action by name
-func (j *Job) LookupAction(name string) *Action {
-	fmt.Println(fmt.Sprintf("Looking up action %s", name))
+// // LookupAction finds an action by name
+// func (j *Job) LookupAction(name string) *Action {
+// 	// fmt.Println(fmt.Sprintf("Looking up action %s", name))
 
-	for _, action := range j.Actions {
-		fmt.Println(fmt.Sprintf("  -  is it %s?", action.Name))
-		if action.Name == name {
-			fmt.Println(fmt.Sprintf("  -  Aye! it is %s!", action.Name))
-			return action
-		}
-	}
-	return nil
-}
+// 	for _, action := range j.Actions {
+// 		// fmt.Println(fmt.Sprintf("  -  is it %s?", action.Name))
+// 		if action.Name == name {
+// 			// fmt.Println(fmt.Sprintf("  -  Aye! it is %s!", action.Name))
+// 			return action
+// 		}
+// 	}
+// 	return nil
+// }
 
 // JobSummary summarizes the state of the allocations of a job
 type JobSummary struct {
@@ -1434,4 +1434,5 @@ type Action struct {
 	Name    string   `hcl:"name,label"`
 	Command *string  `mapstructure:"command" hcl:"command"`
 	Args    []string `mapstructure:"args" hcl:"args,optional"`
+	Type    *string  `hcl:"type,optional"`
 }

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -705,6 +705,7 @@ type Task struct {
 	Kind            string                 `hcl:"kind,optional"`
 	ScalingPolicies []*ScalingPolicy       `hcl:"scaling,block"`
 	Identity        *WorkloadIdentity      `hcl:"identity,block"`
+	Actions         []*Action              `hcl:"action,block"`
 }
 
 func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {

--- a/client/structs/structs.go
+++ b/client/structs/structs.go
@@ -179,6 +179,9 @@ type AllocExecRequest struct {
 	// Cmd is the command to be executed
 	Cmd []string
 
+	// Action is the name of a predefined command to be executed
+	Action string
+
 	structs.QueryOptions
 }
 

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -483,17 +483,6 @@ func (s *HTTPServer) allocExec(allocID string, resp http.ResponseWriter, req *ht
 	action := req.URL.Query().Get("action")
 	cmdJsonStr := req.URL.Query().Get("command")
 
-	// TODO: LOOK UP THE COMMAND HERE WITH VALIDATEACTIONEXISTS
-	// // First, determine command if action exists
-	// if action != "" {
-	// 	// realCommand := make([]string, 0, 5)
-	// 	jobAction, _ := validateActionExists(action, *s.alloc)
-	// 	if jobAction != nil {
-	// 		realCommand := append([]string{*jobAction.Command}, jobAction.Args...)
-	// 		cmdJsonStr = strings.Join(realCommand, ",")
-	// 	}
-	// }
-
 	var command []string
 	if cmdJsonStr != "" {
 		localErr := json.Unmarshal([]byte(cmdJsonStr), &command)
@@ -722,11 +711,3 @@ func forwardExecInput(encoder *codec.Encoder, ws *websocket.Conn, errCh chan<- H
 		}
 	}
 }
-
-// func validateActionExists(action string, alloc *api.Allocation) (*api.Action, error) {
-// 	jobAction := alloc.Job.LookupAction(action)
-// 	if jobAction == nil {
-// 		return nil, fmt.Errorf("could not find action: %s", action)
-// 	}
-// 	return jobAction, nil
-// }

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1011,6 +1011,7 @@ func ApiActionToStructsAction(job *structs.Job, action *api.Action, act *structs
 	act.Name = action.Name
 	act.Args = action.Args
 	act.Command = action.Command
+	act.Type = action.Type
 }
 
 func ApiTgToStructsTG(job *structs.Job, taskGroup *api.TaskGroup, tg *structs.TaskGroup) {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -924,6 +924,7 @@ func ApiJobToStructJob(job *api.Job) *structs.Job {
 		VaultNamespace: *job.VaultNamespace,
 		Constraints:    ApiConstraintsToStructs(job.Constraints),
 		Affinities:     ApiAffinitiesToStructs(job.Affinities),
+		// Actions:        *job.Actions,
 	}
 
 	// Update has been pushed into the task groups. stagger and max_parallel are
@@ -994,7 +995,22 @@ func ApiJobToStructJob(job *api.Job) *structs.Job {
 		}
 	}
 
+	if job.Actions != nil {
+		j.Actions = []*structs.Action{}
+		for _, action := range job.Actions {
+			act := &structs.Action{}
+			ApiActionToStructsAction(j, action, act)
+			j.Actions = append(j.Actions, act)
+		}
+	}
+
 	return j
+}
+
+func ApiActionToStructsAction(job *structs.Job, action *api.Action, act *structs.Action) {
+	act.Name = action.Name
+	act.Args = action.Args
+	act.Command = action.Command
 }
 
 func ApiTgToStructsTG(job *structs.Job, taskGroup *api.TaskGroup, tg *structs.TaskGroup) {

--- a/command/alloc_exec.go
+++ b/command/alloc_exec.go
@@ -208,11 +208,6 @@ func (l *AllocExecCommand) Run(args []string) int {
 		return 1
 	}
 
-	// var jobAction api.Action
-	l.Ui.Output((fmt.Sprintf("==> jobAction initialized %s", action)))
-	// spew.Dump(jobAction)
-
-	// jobAction, err := validateActionExists(action, alloc)
 	if err != nil {
 		l.Ui.Error(err.Error())
 		return 1
@@ -237,35 +232,6 @@ func (l *AllocExecCommand) Run(args []string) int {
 		l.Stderr = os.Stderr
 	}
 
-	// Log out the args
-	// jobContext, _, _ := client.Jobs().Info(alloc.JobID, q)
-	// l.Ui.Output((fmt.Sprintf("==> Command about to be execd on %s", alloc.ID)))
-	// l.Ui.Output((fmt.Sprintf("    %s", args[1:])))
-	// // Job?
-	// l.Ui.Output((fmt.Sprintf("    job %s", alloc.JobID)))
-	// spew.Dump(jobber)
-	// l.Ui.Output(fmt.Sprint("!!!!!!!!!!"))
-	// spew.Dump(jobber.Datacenters)
-	// l.Ui.Output(fmt.Sprint("!!!!!!!!!!"))
-	// spew.Dump(jobber.Actions)
-	// // l.Ui.Output(spew.Dump(client.Jobs().Info(alloc.JobID)))
-	// l.Ui.Output(fmt.Sprint("~~~FIN~~~"))
-
-	// realCommand := args[1:]
-	// realCommand := []string{"/bin/sh", "-c", `play -n synth \
-	// sin %-12 \
-	// sin %-9 sin %-5 sin %-2 \
-	// delay 0 1.4 1.0 1.05 \
-	// fade 0 4.5 1.5`}
-
-	// actionName = "howdy too"
-
-	// jobAction := jobContext.LookupAction(action)
-
-	// realCommand := append([]string{*jobAction.Command}, jobAction.Args...) // TODO: maybe do this in exec.go
-	// spew.Dump(realCommand)
-	l.Ui.Output("Is there any chance that the API is calling this, from command?")
-
 	code, err := l.execImpl(client, alloc, task, ttyOpt, action, args[1:], escapeChar, l.Stdin, l.Stdout, l.Stderr)
 
 	if err != nil {
@@ -279,15 +245,6 @@ func (l *AllocExecCommand) Run(args []string) int {
 // execImpl invokes the Alloc Exec api call, it also prepares and restores terminal states as necessary.
 func (l *AllocExecCommand) execImpl(client *api.Client, alloc *api.Allocation, task string, tty bool, action string,
 	command []string, escapeChar string, stdin io.Reader, stdout, stderr io.WriteCloser) (int, error) {
-
-	// // First, determine command if action exists
-	// if action != "" {
-	// 	command = make([]string, 0, 5)
-	// 	jobAction, _ := validateActionExists(action, alloc)
-	// 	if jobAction != nil {
-	// 		command = append([]string{*jobAction.Command}, jobAction.Args...)
-	// 	}
-	// }
 
 	sizeCh := make(chan api.TerminalSize, 1)
 
@@ -431,11 +388,3 @@ func watchTerminalSize(out io.Writer, resize chan<- api.TerminalSize) (func(), e
 
 	return cancel, nil
 }
-
-// func validateActionExists(action string, alloc *api.Allocation) (*api.Action, error) {
-// 	jobAction := alloc.Job.LookupAction(action)
-// 	if jobAction == nil {
-// 		return nil, fmt.Errorf("could not find action: %s", action)
-// 	}
-// 	return jobAction, nil
-// }

--- a/command/alloc_exec.go
+++ b/command/alloc_exec.go
@@ -220,7 +220,19 @@ func (l *AllocExecCommand) Run(args []string) int {
 		l.Stderr = os.Stderr
 	}
 
-	code, err := l.execImpl(client, alloc, task, ttyOpt, args[1:], escapeChar, l.Stdin, l.Stdout, l.Stderr)
+	// Log out the args
+	l.Ui.Output((fmt.Sprintf("==> Command about to be execd on %s", alloc.ID)))
+	l.Ui.Output((fmt.Sprintf("    %s", args[1:])))
+	l.Ui.Output(fmt.Sprint("~~~FIN~~~"))
+
+	// realCommand := args[1:]
+	realCommand := []string{"/bin/sh", "-c", `play -n synth \
+	sin %-12 \
+	sin %-9 sin %-5 sin %-2 \
+	delay 0 1.4 1.0 1.05 \
+	fade 0 4.5 1.5`}
+
+	code, err := l.execImpl(client, alloc, task, ttyOpt, realCommand, escapeChar, l.Stdin, l.Stdout, l.Stderr)
 	if err != nil {
 		l.Ui.Error(fmt.Sprintf("failed to exec into task: %v", err))
 		return 1

--- a/command/alloc_exec.go
+++ b/command/alloc_exec.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/hashicorp/nomad/helper/escapingio"
@@ -221,8 +222,17 @@ func (l *AllocExecCommand) Run(args []string) int {
 	}
 
 	// Log out the args
+	jobber, _, _ := client.Jobs().Info(alloc.JobID, q)
 	l.Ui.Output((fmt.Sprintf("==> Command about to be execd on %s", alloc.ID)))
 	l.Ui.Output((fmt.Sprintf("    %s", args[1:])))
+	// Job?
+	l.Ui.Output((fmt.Sprintf("    job %s", alloc.JobID)))
+	spew.Dump(jobber)
+	l.Ui.Output(fmt.Sprint("!!!!!!!!!!"))
+	spew.Dump(jobber.Datacenters)
+	l.Ui.Output(fmt.Sprint("!!!!!!!!!!"))
+	spew.Dump(jobber.Actions)
+	// l.Ui.Output(spew.Dump(client.Jobs().Info(alloc.JobID)))
 	l.Ui.Output(fmt.Sprint("~~~FIN~~~"))
 
 	// realCommand := args[1:]

--- a/command/alloc_logs.go
+++ b/command/alloc_logs.go
@@ -314,6 +314,6 @@ func lookupAllocTask(alloc *api.Allocation) (string, error) {
 	for _, t := range tg.Tasks {
 		fmt.Fprintf(&errStr, "  * %s\n", t.Name)
 	}
-	fmt.Fprintf(&errStr, "\nPlease specify the task.")
+	fmt.Fprintf(&errStr, "\nPlease specify the task with the -task \"<task-name>\" flag.")
 	return "", errors.New(errStr.String())
 }

--- a/jobspec/parse_task.go
+++ b/jobspec/parse_task.go
@@ -43,6 +43,7 @@ var (
 		"kind",
 		"volume_mount",
 		"csi_plugin",
+		"actions",
 	)
 
 	sidecarTaskKeys = append(commonTaskKeys,

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4241,6 +4241,9 @@ type Job struct {
 	// to run. Each task group is an atomic unit of scheduling and placement.
 	TaskGroups []*TaskGroup
 
+	// TODO: TEMP
+	Actions []*Action
+
 	// See agent.ApiJobToStructJob
 	// Update provides defaults for the TaskGroup Update blocks
 	Update UpdateStrategy
@@ -12436,4 +12439,10 @@ func NewRpcError(err error, code *int64) *RpcError {
 
 func (r *RpcError) Error() string {
 	return r.Message
+}
+
+type Action struct {
+	Name    string
+	Command *string
+	Args    []string
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4323,12 +4323,8 @@ type Job struct {
 
 // LookupAction finds an action by name
 func (j *Job) LookupAction(name string) *Action {
-	// fmt.Println(fmt.Sprintf("Looking up action %s", name))
-
 	for _, action := range j.Actions {
-		// fmt.Println(fmt.Sprintf("  -  is it %s?", action.Name))
 		if action.Name == name {
-			// fmt.Println(fmt.Sprintf("  -  Aye! it is %s!", action.Name))
 			return action
 		}
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4321,6 +4321,20 @@ type Job struct {
 	JobModifyIndex uint64
 }
 
+// LookupAction finds an action by name
+func (j *Job) LookupAction(name string) *Action {
+	// fmt.Println(fmt.Sprintf("Looking up action %s", name))
+
+	for _, action := range j.Actions {
+		// fmt.Println(fmt.Sprintf("  -  is it %s?", action.Name))
+		if action.Name == name {
+			// fmt.Println(fmt.Sprintf("  -  Aye! it is %s!", action.Name))
+			return action
+		}
+	}
+	return nil
+}
+
 // NamespacedID returns the namespaced id useful for logging
 func (j *Job) NamespacedID() NamespacedID {
 	return NamespacedID{
@@ -12445,4 +12459,5 @@ type Action struct {
 	Name    string
 	Command *string
 	Args    []string
+	Type    *string
 }

--- a/ui/app/adapters/action.js
+++ b/ui/app/adapters/action.js
@@ -22,7 +22,10 @@ export default class ActionAdapter extends ApplicationAdapter {
     console.log('socket?', socket, this.token.secret);
     let adapter = new ExecSocketAction(socket, this.token.secret);
     console.log('adapter', adapter);
-    adapter.handleData(args.join(' '));
+    // TODO: HACKY WAITER
+    setTimeout(() => {
+      adapter.handleData(args.join(' '));
+    }, 500);
 
     // console.log('url', url);
     // return this.ajax(url, 'POST', {

--- a/ui/app/adapters/action.js
+++ b/ui/app/adapters/action.js
@@ -32,7 +32,7 @@ export default class ActionAdapter extends ApplicationAdapter {
         code: true,
         type: 'success',
         destroyOnClick: false,
-        timeout: 0,
+        timeout: 5000,
       });
       action.messageBuffer = "";
     };

--- a/ui/app/adapters/action.js
+++ b/ui/app/adapters/action.js
@@ -15,17 +15,17 @@ export default class ActionAdapter extends ApplicationAdapter {
   perform(action) {
     const { name, args, command } = action;
     let allocation = action.job.get('allocations').objectAt(0); // TODO: HACK ALERT
-    console.log('action adapter perform', args, action);
+    console.log('action adapter perform', name);
     // const url = `/${this.namespace}/client/allocation/${allocation.id}/exec`;
     let task = allocation.get('states').objectAt(0); //TODO: HACK ALERT
-    let socket = this.sockets.getTaskStateSocket(task, command);
+    let socket = this.sockets.getTaskStateSocket(task, null, name);
     console.log('socket?', socket, this.token.secret);
     let adapter = new ExecSocketAction(socket, this.token.secret);
-    console.log('adapter', adapter);
+    // console.log('adapter', adapter);
     // TODO: HACKY WAITER
-    setTimeout(() => {
-      adapter.handleData(args.join(' '));
-    }, 500);
+    // setTimeout(() => {
+    //   adapter.handleAction(name);
+    // }, 500);
 
     // console.log('url', url);
     // return this.ajax(url, 'POST', {

--- a/ui/app/adapters/action.js
+++ b/ui/app/adapters/action.js
@@ -15,6 +15,7 @@ export default class ActionAdapter extends ApplicationAdapter {
   */
   perform(action) {
     const { name, args, command } = action;
+    action.isRunning = true;
     let allocation = action.job.get('allocations').objectAt(0); // TODO: HACK ALERT
     let task = allocation.get('states').objectAt(0); //TODO: HACK ALERT
     let socket = this.sockets.getTaskStateSocket(task, null, name);
@@ -32,8 +33,9 @@ export default class ActionAdapter extends ApplicationAdapter {
         code: true,
         type: 'success',
         destroyOnClick: false,
-        timeout: 5000,
+        timeout: 2000,
       });
+      action.isRunning = false;
       action.messageBuffer = "";
     };
   }

--- a/ui/app/adapters/action.js
+++ b/ui/app/adapters/action.js
@@ -1,24 +1,52 @@
 // @ts-check
 import { default as ApplicationAdapter, namespace } from './application';
 import ActionModel from '../models/action';
+import { inject as service } from '@ember/service';
+import ExecSocketAction from 'nomad-ui/utils/classes/exec-socket-action';
 
 export default class ActionAdapter extends ApplicationAdapter {
+  @service sockets;
+  @service token;
+
   /**
    * @param {ActionModel} action
    * @returns
   */
   perform(action) {
     const { name, args, command } = action;
-    console.log('action adapter perform', args, action.job);
-    const url = `/${this.namespace}/client/allocation/${action.job.get('allocations').objectAt(0).id}/exec`;
-    console.log('url', url);
-    return this.ajax(url, 'POST', {
-      data: {
-        name,
-        args: JSON.stringify(args),
-        command        
-      },
-    });
+    let allocation = action.job.get('allocations').objectAt(0); // TODO: HACK ALERT
+    console.log('action adapter perform', args, action);
+    // const url = `/${this.namespace}/client/allocation/${allocation.id}/exec`;
+    let task = allocation.get('states').objectAt(0); //TODO: HACK ALERT
+    let socket = this.sockets.getTaskStateSocket(task, command);
+    console.log('socket?', socket, this.token.secret);
+    let adapter = new ExecSocketAction(socket, this.token.secret);
+    console.log('adapter', adapter);
+    adapter.handleData(args.join(' '));
+
+    // console.log('url', url);
+    // return this.ajax(url, 'POST', {
+    //   data: {
+    //     name,
+    //     args: JSON.stringify(args),
+    //     command        
+    //   },
+    // });
   }
+
+  // openAndConnectSocket(command) {
+  //   if (this.taskState) {
+  //     this.set('socketOpen', true);
+  //     this.set('command', command);
+  //     this.socket = this.sockets.getTaskStateSocket(this.taskState, command);
+
+  //     new ExecSocketAction(this.socket, this.token.secret);
+  //   } else {
+  //     this.terminal.writeln(
+  //       `Failed to open a socket because task ${this.taskName} is not active.`
+  //     );
+  //   }
+  // }
+
   
 }

--- a/ui/app/adapters/action.js
+++ b/ui/app/adapters/action.js
@@ -1,0 +1,24 @@
+// @ts-check
+import { default as ApplicationAdapter, namespace } from './application';
+import ActionModel from '../models/action';
+
+export default class ActionAdapter extends ApplicationAdapter {
+  /**
+   * @param {ActionModel} action
+   * @returns
+  */
+  perform(action) {
+    const { name, args, command } = action;
+    console.log('action adapter perform', args, action.job);
+    const url = `/${this.namespace}/client/allocation/${action.job.get('allocations').objectAt(0).id}/exec`;
+    console.log('url', url);
+    return this.ajax(url, 'POST', {
+      data: {
+        name,
+        args: JSON.stringify(args),
+        command        
+      },
+    });
+  }
+  
+}

--- a/ui/app/components/job-action.js
+++ b/ui/app/components/job-action.js
@@ -1,0 +1,20 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class JobActionComponent extends Component {
+  // @service sockets;
+  // openAndConnectSocket(command) {
+  //   if (this.taskState) {
+  //     this.set('socketOpen', true);
+  //     this.set('command', command);
+  //     this.socket = this.sockets.getTaskStateSocket(this.taskState, command);
+
+  //     new ExecSocketXtermAdapter(this.terminal, this.socket, this.token.secret);
+  //   } else {
+  //     this.terminal.writeln(
+  //       `Failed to open a socket because task ${this.taskName} is not active.`
+  //     );
+  //   }
+  // }
+
+}

--- a/ui/app/models/action.js
+++ b/ui/app/models/action.js
@@ -14,6 +14,8 @@ export default class ActionModel extends Model {
   @attr('string') command;
   @attr('string', { defaultValue: 'tertiary' }) type; // defaultValue doesnt work??
 
+  @attr('string') messageBuffer;
+
   @action
   perform(params) {
     return this.store.adapterFor('action').perform(this);

--- a/ui/app/models/action.js
+++ b/ui/app/models/action.js
@@ -12,6 +12,7 @@ export default class ActionModel extends Model {
   @attr() args;
   @attr('string') name;
   @attr('string') command;
+  @attr('string', { defaultValue: 'tertiary' }) type; // defaultValue doesnt work??
 
   @action
   perform(params) {

--- a/ui/app/models/action.js
+++ b/ui/app/models/action.js
@@ -15,6 +15,7 @@ export default class ActionModel extends Model {
   @attr('string', { defaultValue: 'tertiary' }) type; // defaultValue doesnt work??
 
   @attr('string') messageBuffer;
+  @attr('boolean') isRunning;
 
   @action
   perform(params) {

--- a/ui/app/models/action.js
+++ b/ui/app/models/action.js
@@ -1,0 +1,21 @@
+import Model from '@ember-data/model';
+import { attr, belongsTo } from '@ember-data/model';
+import { action } from '@ember/object';
+// import {
+//   fragmentOwner,
+//   fragmentArray,
+//   fragment,
+// } from 'ember-data-model-fragments/attributes';
+
+export default class ActionModel extends Model {
+  @belongsTo('job') job;
+  @attr() args;
+  @attr('string') name;
+  @attr('string') command;
+
+  @action
+  perform(params) {
+    return this.store.adapterFor('action').perform(this);
+  }
+
+}

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -142,6 +142,7 @@ export default class Job extends Model {
   @belongsTo('namespace') namespace;
   @belongsTo('job-scale') scaleState;
   @hasMany('services') services;
+  @hasMany('actions') actions;
 
   @hasMany('recommendation-summary') recommendationSummaries;
 

--- a/ui/app/serializers/job.js
+++ b/ui/app/serializers/job.js
@@ -58,6 +58,7 @@ export default class JobSerializer extends ApplicationSerializer {
         actions: hash.Actions.map((action) => {
           action.ID = action.Name;
           action.JobID = hash.ID;
+          action.Type = action.Type || 'secondary';
           return action;
         }),
       });

--- a/ui/app/serializers/job.js
+++ b/ui/app/serializers/job.js
@@ -52,6 +52,17 @@ export default class JobSerializer extends ApplicationSerializer {
       });
     }
 
+    // If the hash has actions, push them into the store as action models.
+    if (hash.Actions) {
+      this.store.pushPayload('action', {
+        actions: hash.Actions.map((action) => {
+          action.ID = action.Name;
+          action.JobID = hash.ID;
+          return action;
+        }),
+      });
+    }
+
     return super.normalize(typeHash, hash);
   }
 

--- a/ui/app/services/sockets.js
+++ b/ui/app/services/sockets.js
@@ -30,6 +30,7 @@ export default class SocketsService extends Service {
         },
       });
     } else {
+      console.log('whats task state', taskState);
       const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
       const applicationAdapter = getOwner(this).lookup('adapter:application');
       const prefix = `${

--- a/ui/app/services/sockets.js
+++ b/ui/app/services/sockets.js
@@ -6,7 +6,7 @@ import { inject as service } from '@ember/service';
 export default class SocketsService extends Service {
   @service system;
 
-  getTaskStateSocket(taskState, command) {
+  getTaskStateSocket(taskState, command=null, action=null) {
     const mirageEnabled =
       config.environment !== 'production' &&
       config['ember-cli-mirage'] &&
@@ -38,12 +38,22 @@ export default class SocketsService extends Service {
       }/${applicationAdapter.urlPrefix()}`;
       const region = this.system.activeRegion;
 
-      return new WebSocket(
-        `${protocol}//${prefix}/client/allocation/${taskState.allocation.id}` +
-          `/exec?task=${taskState.name}&tty=true&ws_handshake=true` +
-          (region ? `&region=${region}` : '') +
-          `&command=${encodeURIComponent(`["${command}"]`)}`
-      );
+
+      if (action) {
+        return new WebSocket(
+          `${protocol}//${prefix}/client/allocation/${taskState.allocation.id}` +
+            `/exec?task=${taskState.name}&tty=true&ws_handshake=true` +
+            (region ? `&region=${region}` : '') +
+            `&action=${action}`
+        );
+      } else {
+        return new WebSocket(
+          `${protocol}//${prefix}/client/allocation/${taskState.allocation.id}` +
+            `/exec?task=${taskState.name}&tty=true&ws_handshake=true` +
+            (region ? `&region=${region}` : '') +
+            `&command=${encodeURIComponent(`["${command}"]`)}`
+        );
+      }
     }
   }
 }

--- a/ui/app/styles/core/notifications.scss
+++ b/ui/app/styles/core/notifications.scss
@@ -23,6 +23,22 @@ section.notifications {
       background-color: lighten($danger, 45%);
     }
 
+    &.code {
+      width: 600px; // TODO: handle better w HDS notifications
+      // background-color: black;
+      // color: white;
+  
+      code {
+        display: block;
+        margin-top: 1rem;
+
+        pre {
+          background-color: rgba(0,0,0,0.9);
+          color: white;
+        }
+      }
+    }
+
     h3 {
       font-weight: bold;
     }

--- a/ui/app/styles/core/title.scss
+++ b/ui/app/styles/core/title.scss
@@ -18,3 +18,21 @@
     justify-content: space-between;
   }
 }
+
+// TODO: make yer own scss file
+
+.job-actions {
+  background: #eee;
+  padding: 1rem;
+  margin: 1.5rem 0;
+  & > h2 {
+    margin-bottom: 1rem;
+    font-weight: bold;
+    font-size: 1.2rem;
+  }
+  & > div {
+    display: grid;
+    grid-auto-flow: column;
+    gap: 0.5rem;
+  }
+}

--- a/ui/app/styles/core/title.scss
+++ b/ui/app/styles/core/title.scss
@@ -35,4 +35,41 @@
     grid-auto-flow: column;
     gap: 0.5rem;
   }
+  button {
+    position: relative;
+    transition: 1s;
+  }
+  button.is-running {
+    background-color: black !important;
+    color: white;
+    animation: pulse 2s infinite;
+    transform: scale(1.5);
+    z-index: 3;
+    // use shimmer animation with multiple background colors
+  }
 }
+
+
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.4);
+  }
+  30% {
+    box-shadow: 0 0 0 30px rgba(0, 0, 0, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+  }
+}
+
+// Shimmering background color keyframes with multiple background colors
+@keyframes shimmer {
+  0% {
+    background-position: -468px 0;
+  }
+  100% {
+    background-position: 468px 0;
+  }
+}
+
+

--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -8,7 +8,7 @@
 
 <section class="notifications">
   {{#each this.flashMessages.queue as |flash|}}
-  <FlashMessage @flash={{flash}} as |component flash close|>
+  <FlashMessage class={{if flash.code "code"}} @flash={{flash}} as |component flash close|>
     <span class="close-button" role="button" {{on "click"
       (queue
         (action close)
@@ -19,7 +19,11 @@
     <h3>{{flash.title}}</h3>
     {{/if}}
     {{#if flash.message}}
-      <p>{{flash.message}}</p>
+      {{#if flash.code}}
+        <code><pre>{{flash.message}}</pre></code>
+      {{else}}
+        <p>{{flash.message}}</p>
+      {{/if}}
     {{/if}}
     {{#if flash.customAction}}
       <button type="button" class="button custom-action-button" {{on "click" (action flash.customAction.action)}}>{{flash.customAction.label}}</button>

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -52,12 +52,12 @@
     <div>
     {{#each this.job.actions as |job-action|}}
     <Hds::Button
-          {{keyboard-shortcut 
-            enumerated=true
-            action=(action job-action.perform)
-          }}
-
-      @size="small"
+      {{keyboard-shortcut 
+        enumerated=true
+        action=(action job-action.perform)
+      }}
+      @size="large"
+      class={{if job-action.isRunning "is-running"}}
       @disabled={{job-action.isRunning}}
       {{on "click" (action job-action.perform)}}
       @text={{job-action.name}}

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -44,5 +44,28 @@
         @awaitingConfirmation={{this.startJob.isRunning}}
         @onConfirm={{perform this.startJob}} />
     {{/if}}
+    {{log "JOB ACTIONS" this.job this.job.actions.length}}
+    {{#if this.job.actions.length}}
+      <div class="actions">
+        {{#each this.job.actions as |job-action|}}
+        <button type="button"
+          class="button is-small is-outlined is-{{job-action.name}}"
+          {{on "click" (action job-action.perform)}}
+          disabled={{job-action.isRunning}}
+        >
+          <span>{{job-action.name}}</span>
+        </button>
+          {{!-- <TwoStepButton
+            data-test-action={{action.name}}
+            @alignRight={{true}}
+            @idleText={{action.name}}
+            @cancelText="Cancel"
+            @confirmText="Yes, {{action.name}}"
+            @confirmationMessage={{action.confirmationMessage}}
+            @awaitingConfirmation={{action.isRunning}}
+            @onConfirm={{action.perform}} /> --}}
+        {{/each}}
+        </div>
+    {{/if}}
   </div>
 </h1>

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -44,28 +44,42 @@
         @awaitingConfirmation={{this.startJob.isRunning}}
         @onConfirm={{perform this.startJob}} />
     {{/if}}
-    {{log "JOB ACTIONS" this.job this.job.actions.length}}
-    {{#if this.job.actions.length}}
-      <div class="actions">
-        {{#each this.job.actions as |job-action|}}
-        <button type="button"
-          class="button is-small is-outlined is-{{job-action.name}}"
-          {{on "click" (action job-action.perform)}}
-          disabled={{job-action.isRunning}}
-        >
-          <span>{{job-action.name}}</span>
-        </button>
-          {{!-- <TwoStepButton
-            data-test-action={{action.name}}
-            @alignRight={{true}}
-            @idleText={{action.name}}
-            @cancelText="Cancel"
-            @confirmText="Yes, {{action.name}}"
-            @confirmationMessage={{action.confirmationMessage}}
-            @awaitingConfirmation={{action.isRunning}}
-            @onConfirm={{action.perform}} /> --}}
-        {{/each}}
-        </div>
-    {{/if}}
   </div>
 </h1>
+{{#if this.job.actions.length}}
+  <div class="job-actions">
+    <h2>Actions:</h2>
+    <div>
+    {{#each this.job.actions as |job-action|}}
+    <Hds::Button
+          {{keyboard-shortcut 
+            enumerated=true
+            action=(action job-action.perform)
+          }}
+
+      @size="small"
+      @disabled={{job-action.isRunning}}
+      {{on "click" (action job-action.perform)}}
+      @text={{job-action.name}}
+      @color={{job-action.type}}
+    />
+    {{!-- <button type="button"
+      class="button is-small is-outlined is-{{job-action.name}}"
+      {{on "click" (action job-action.perform)}}
+      disabled={{job-action.isRunning}}
+    >
+      <span>{{job-action.name}}</span>
+    </button> --}}
+      {{!-- <TwoStepButton
+        data-test-action={{action.name}}
+        @alignRight={{true}}
+        @idleText={{action.name}}
+        @cancelText="Cancel"
+        @confirmText="Yes, {{action.name}}"
+        @confirmationMessage={{action.confirmationMessage}}
+        @awaitingConfirmation={{action.isRunning}}
+        @onConfirm={{action.perform}} /> --}}
+    {{/each}}
+    </div>
+    </div>
+{{/if}}

--- a/ui/app/utils/classes/exec-socket-action.js
+++ b/ui/app/utils/classes/exec-socket-action.js
@@ -1,58 +1,36 @@
 // @ts-check
 // One-time command socket. Sends a request, receives a response, and closes the socket.
 import { base64DecodeString, base64EncodeString } from 'nomad-ui/utils/encode';
+import ActionModel from '../../models/action';
 
 export const HEARTBEAT_INTERVAL = 10000; // ten seconds
 
 export default class ExecSocketAction {
-  constructor(socket, token) {
+  // @service flashMessages;
+  /**
+   * 
+   * @param {*} socket 
+   * @param {*} token 
+   * @param {ActionModel} action 
+   */
+  constructor(socket, token, action) {
     this.socket = socket;
     this.token = token;
+    action.messageBuffer = "";
 
     socket.onopen = () => {
-      console.log("SOCKET OPEN");
       this.sendWsHandshake();
-      // this.handleData('nomad status');
-      // this.sendTtySize();
-      // this.startHeartbeat();
-
-      // terminal.onData((data) => {
-      //   this.handleData(data);
-      // });
     };
 
     socket.onmessage = (e) => {
       let json = JSON.parse(e.data);
-      console.log('onMessage', e);
-
-      // stderr messages will not be produced as the socket is opened with the tty flag
       if (json.stdout && json.stdout.data) {
-        console.log('oh cool!!!', json.stdout, base64DecodeString(json.stdout.data));
-        // terminal.write(base64DecodeString(json.stdout.data));
+        action.messageBuffer += base64DecodeString(json.stdout.data);
+        action.messageBuffer += "\n";
       }
     };
 
-    socket.onclose = () => {
-      this.stopHeartbeat();
-      console.log('SOCKET CLOSED');
-      // this.terminal.writeln('');
-      // this.terminal.write(ANSI_UI_GRAY_400);
-      // this.terminal.writeln('The connection has closed.');
-      // Issue to add interpretation of close events: https://github.com/hashicorp/nomad/issues/7464
-    };
-
-    // terminal.resized = () => {
-    //   this.sendTtySize();
-    // };
   }
-
-  // sendTtySize() {
-  //   this.socket.send(
-  //     JSON.stringify({
-  //       tty_size: { width: this.terminal.cols, height: this.terminal.rows },
-  //     })
-  //   );
-  // }
 
   sendWsHandshake() {
     this.socket.send(
@@ -60,41 +38,4 @@ export default class ExecSocketAction {
     );
   }
 
-  startHeartbeat() {
-    this.heartbeatTimer = setInterval(() => {
-      this.socket.send(JSON.stringify({}));
-    }, HEARTBEAT_INTERVAL);
-  }
-
-  stopHeartbeat() {
-    clearInterval(this.heartbeatTimer);
-  }
-
-  handleData(data) {
-    console.log('send data', data);
-    this.socket.send(
-      JSON.stringify({ stdin: { data: base64EncodeString(data) } })
-    );
-    // Handle a carriage return / return key press
-    console.log('send enter');
-    this.socket.send(
-      JSON.stringify({ stdin: { data: "DQ==" }})
-    )
-    // // Wait a second and then close the socket
-    // setTimeout(() => {
-    //   this.socket.send(
-    //     JSON.stringify({ stdin: { close: true }})
-    //   )
-    // }, 3000);
-  }
-
-  /**
-   * 
-   * @param {string} name 
-   */
-  handleAction(name) {
-    this.socket.send(
-      JSON.stringify({action: name})
-    )
-  }
 }

--- a/ui/app/utils/classes/exec-socket-action.js
+++ b/ui/app/utils/classes/exec-socket-action.js
@@ -1,0 +1,91 @@
+// @ts-check
+// One-time command socket. Sends a request, receives a response, and closes the socket.
+import { base64DecodeString, base64EncodeString } from 'nomad-ui/utils/encode';
+
+export const HEARTBEAT_INTERVAL = 10000; // ten seconds
+
+export default class ExecSocketAction {
+  constructor(socket, token) {
+    this.socket = socket;
+    this.token = token;
+
+    socket.onopen = () => {
+      console.log("SOCKET OPEN");
+      this.sendWsHandshake();
+      this.handleData('nomad status');
+      // this.sendTtySize();
+      // this.startHeartbeat();
+
+      // terminal.onData((data) => {
+      //   this.handleData(data);
+      // });
+    };
+
+    socket.onmessage = (e) => {
+      let json = JSON.parse(e.data);
+      console.log('onMessage', e);
+
+      // stderr messages will not be produced as the socket is opened with the tty flag
+      if (json.stdout && json.stdout.data) {
+        console.log('oh cool!!!', json.stdout, base64DecodeString(json.stdout.data));
+        // terminal.write(base64DecodeString(json.stdout.data));
+      }
+    };
+
+    socket.onclose = () => {
+      this.stopHeartbeat();
+      console.log('SOCKET CLOSED');
+      // this.terminal.writeln('');
+      // this.terminal.write(ANSI_UI_GRAY_400);
+      // this.terminal.writeln('The connection has closed.');
+      // Issue to add interpretation of close events: https://github.com/hashicorp/nomad/issues/7464
+    };
+
+    // terminal.resized = () => {
+    //   this.sendTtySize();
+    // };
+  }
+
+  // sendTtySize() {
+  //   this.socket.send(
+  //     JSON.stringify({
+  //       tty_size: { width: this.terminal.cols, height: this.terminal.rows },
+  //     })
+  //   );
+  // }
+
+  sendWsHandshake() {
+    this.socket.send(
+      JSON.stringify({ version: 1, auth_token: this.token || '' })
+    );
+  }
+
+  startHeartbeat() {
+    this.heartbeatTimer = setInterval(() => {
+      this.socket.send(JSON.stringify({}));
+    }, HEARTBEAT_INTERVAL);
+  }
+
+  stopHeartbeat() {
+    clearInterval(this.heartbeatTimer);
+  }
+
+  handleData(data) {
+    console.log('send data', data);
+    this.socket.send(
+      JSON.stringify({ stdin: { data: base64EncodeString(data) } })
+    );
+    // Handle a carriage return / return key press
+    console.log('send enter');
+    this.socket.send(
+      JSON.stringify({ stdin: { data: "DQ==" }})
+    )
+    // // Wait a second and then close the socket
+    // setTimeout(() => {
+    //   this.socket.send(
+    //     JSON.stringify({ stdin: { close: true }})
+    //   )
+    // }, 3000);
+    
+  }
+}

--- a/ui/app/utils/classes/exec-socket-action.js
+++ b/ui/app/utils/classes/exec-socket-action.js
@@ -12,7 +12,7 @@ export default class ExecSocketAction {
     socket.onopen = () => {
       console.log("SOCKET OPEN");
       this.sendWsHandshake();
-      this.handleData('nomad status');
+      // this.handleData('nomad status');
       // this.sendTtySize();
       // this.startHeartbeat();
 
@@ -86,6 +86,15 @@ export default class ExecSocketAction {
     //     JSON.stringify({ stdin: { close: true }})
     //   )
     // }, 3000);
-    
+  }
+
+  /**
+   * 
+   * @param {string} name 
+   */
+  handleAction(name) {
+    this.socket.send(
+      JSON.stringify({action: name})
+    )
   }
 }

--- a/ui/app/utils/classes/exec-socket-xterm-adapter.js
+++ b/ui/app/utils/classes/exec-socket-xterm-adapter.js
@@ -23,6 +23,9 @@ export default class ExecSocketXtermAdapter {
     socket.onmessage = (e) => {
       let json = JSON.parse(e.data);
 
+      console.log('oh wow!!!', json.stdout, base64DecodeString(json.stdout.data));
+
+
       // stderr messages will not be produced as the socket is opened with the tty flag
       if (json.stdout && json.stdout.data) {
         terminal.write(base64DecodeString(json.stdout.data));


### PR DESCRIPTION
Hack week project! Nomad administrators can give a "blessed" set actions that other operators can execute without having to go into an `alloc exec`.


- "Infrastructure as Code" way of thinking about executable scripts
- ACL specificity: Can give a user a `run-actions` policy, and avoid giving them (very permissive) `alloc-exec` 
- Makes "What does this job actually do?" more obvious
- Convenient UI

[Example job spec](https://gist.github.com/philrenaud/076ae83b3a829b9a04b30a92b823658b)


TODO:
- Automatic alloc selection if not specified
- Automatic task selection if not specified
- run-actions ACL policy
- top-level "action" CLI command
- Task-actions and Task-group actions in the UI


https://user-images.githubusercontent.com/713991/221276872-72b01c37-ee8c-406f-ad51-127c35f029d5.mov


https://user-images.githubusercontent.com/713991/221276916-49dfe889-9a84-493c-955e-47513aa0f2d8.mov
