### PR TITLE
agent: only reload HTTP servers that use TLS

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1165,6 +1165,9 @@ func (a *Agent) Shutdown() error {
 		if err := a.client.Shutdown(); err != nil {
 			a.logger.Error("client shutdown failed", "error", err)
 		}
+
+		// Task API must be closed separately
+		a.builtinServer.Shutdown()
 	}
 	if a.server != nil {
 		if err := a.server.Shutdown(); err != nil {

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -115,9 +115,9 @@ type Agent struct {
 	builtinListener net.Listener
 	builtinDialer   *bufconndialer.BufConnWrapper
 
-	// builtinServer is an HTTP server for attaching per-task listeners. Always
+	// taskAPIServer is an HTTP server for attaching per-task listeners. Always
 	// requires auth.
-	builtinServer *builtinAPI
+	taskAPIServer *builtinAPI
 
 	inmemSink *metrics.InmemSink
 }
@@ -1050,10 +1050,10 @@ func (a *Agent) setupClient() error {
 	a.builtinListener, a.builtinDialer = bufconndialer.New()
 	conf.TemplateDialer = a.builtinDialer
 
-	// Initialize builtin API server here for use in the client, but it won't
-	// accept connections until the HTTP servers are created.
-	a.builtinServer = newBuiltinAPI()
-	conf.APIListenerRegistrar = a.builtinServer
+	// Initialize builtin Task API server here for use in the client, but it
+	// won't accept connections until the HTTP servers are created.
+	a.taskAPIServer = newBuiltinAPI()
+	conf.APIListenerRegistrar = a.taskAPIServer
 
 	nomadClient, err := client.NewClient(
 		conf, a.consulCatalog, a.consulProxies, a.consulService, nil)
@@ -1162,12 +1162,13 @@ func (a *Agent) Shutdown() error {
 
 	a.logger.Info("requesting shutdown")
 	if a.client != nil {
+		// Task API must be closed separately from other HTTP servers and should
+		// happen before the client is shutdown
+		a.taskAPIServer.Shutdown()
+
 		if err := a.client.Shutdown(); err != nil {
 			a.logger.Error("client shutdown failed", "error", err)
 		}
-
-		// Task API must be closed separately
-		a.builtinServer.Shutdown()
 	}
 	if a.server != nil {
 		if err := a.server.Shutdown(); err != nil {

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -222,7 +222,7 @@ func NewHTTPServers(agent *Agent, config *Config) ([]*HTTPServer, error) {
 			ErrorLog: newHTTPServerLogger(srv.logger),
 		}
 
-		agent.builtinServer.SetServer(&httpServer)
+		agent.taskAPIServer.SetServer(&httpServer)
 
 		go func() {
 			defer close(srv.listenerCh)

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/armon/go-metrics"
@@ -189,6 +190,15 @@ func NewHTTPServers(agent *Agent, config *Config) ([]*HTTPServer, error) {
 		srvs = append(srvs, srv)
 	}
 
+	// Return early on errors
+	if serverInitializationErrors != nil {
+		for _, srv := range srvs {
+			srv.Shutdown()
+		}
+
+		return srvs, serverInitializationErrors
+	}
+
 	// This HTTP server is only created when running in client mode, otherwise
 	// the builtinDialer and builtinListener will be nil.
 	if agent.builtinDialer != nil && agent.builtinListener != nil {
@@ -219,16 +229,11 @@ func NewHTTPServers(agent *Agent, config *Config) ([]*HTTPServer, error) {
 			httpServer.Serve(agent.builtinListener)
 		}()
 
-		srvs = append(srvs, srv)
+		// Don't append builtin servers to srvs as they don't need to be reloaded
+		// when TLS changes. This does mean they need to be shutdown independently.
 	}
 
-	if serverInitializationErrors != nil {
-		for _, srv := range srvs {
-			srv.Shutdown()
-		}
-	}
-
-	return srvs, serverInitializationErrors
+	return srvs, nil
 }
 
 // makeConnState returns a ConnState func for use in an http.Server. If
@@ -532,8 +537,13 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 // bufconndialer provides similar functionality to consul-template except it
 // satisfies the Dialer API as opposed to the Serve(Listener) API.
 type builtinAPI struct {
-	srv        *http.Server
+	// srvReadyCh is closed when srv is ready
 	srvReadyCh chan struct{}
+
+	// srv is a builtin http server. Must lock around setting as it could happen
+	// concurrently with shutting down.
+	srv     *http.Server
+	srvLock sync.Mutex
 }
 
 func newBuiltinAPI() *builtinAPI {
@@ -544,13 +554,17 @@ func newBuiltinAPI() *builtinAPI {
 
 // SetServer sets the API HTTP server for Serve to add listeners to.
 //
-// It must be called exactly once and will panic if called more than once.
+// It must be called exactly once and will noop on subsequent calls.
 func (b *builtinAPI) SetServer(srv *http.Server) {
 	select {
 	case <-b.srvReadyCh:
-		panic(fmt.Sprintf("SetServer called twice. first=%p second=%p", b.srv, srv))
+		return
 	default:
 	}
+
+	b.srvLock.Lock()
+	defer b.srvLock.Unlock()
+
 	b.srv = srv
 	close(b.srvReadyCh)
 }
@@ -569,6 +583,21 @@ func (b *builtinAPI) Serve(ctx context.Context, l net.Listener) error {
 	}
 
 	return b.srv.Serve(l)
+}
+
+func (b *builtinAPI) Shutdown() {
+	b.srvLock.Lock()
+	defer b.srvLock.Unlock()
+
+	if b.srv != nil {
+		b.srv.Close()
+	}
+
+	select {
+	case <-b.srvReadyCh:
+	default:
+		close(b.srvReadyCh)
+	}
 }
 
 // HTTPCodedError is used to provide the HTTP error code


### PR DESCRIPTION
Fixes #16239

In my original Task API code I expected `agent.NewHTTPServers` to only be called once, but it's called on SIGHUP when TLS certificates change.

There's no reason to touch non-TLS-enabled HTTP servers in this case, so I fixed the panic by not reloading those. I hate special casing things in already messy code like Agent/NewHTTPServers, but I think this is the best option without signfiicantly refactoring HTTP server setup.

Testing is awkward, but here's what I used locally to reproduce the panic and test the fix:

> tls.hcl
```hcl
tls {
  http      = true
  rpc       = true
  ca_file   = ".../tls/nomad-agent-ca.pem"
  cert_file = ".../tls/global-server-nomad.pem"
  key_file  = ".../tls/global-server-nomad-key.pem"
}
```

> generated certs with
```
$ cd .../tls
$ nomad tls cert create -server
```

> started a nomad dev agent (acl bit isn't required, but I try to include it by default)
```
$ sudo nomad agent -dev -config acl.hcl -config tls.hcl
```

> generate new certs in cert terminal and sighup nomad
```
$ rm *server*
$ nomad tls cert create -server
$ kill -HUP {{ pid of nomad }}
```

Before this PR that would panic. After this PR it does not. I tested that both the Task API and Template API (a name I just made up for the weird internal dialer we use for the `template` block) work after SIGHUP using this jobspec:

https://gist.github.com/schmichael/ac5fd122f7b358a879fcef8c74f6f40b

And poked at variables to ensure the template block still worked with:

```
$ nomad var put /nomad/jobs/example/cache/redis foo=bar
$ nomad var put -force /nomad/jobs/example/cache/redis foo=spam
$ consul kv put foo bar
$ consul kv put foo spam
```

