### PR TITLE
api: Add TaskClient() convenience helper for tasks making use of Nomad API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -481,6 +482,70 @@ func NewClient(config *Config) (*Client, error) {
 		httpClient: httpClient,
 	}
 	return client, nil
+}
+
+func nomadTaskSocketPath() string {
+	secretsDir := os.Getenv("NOMAD_SECRETS_DIR")
+	if secretsDir == "" {
+		return ""
+	}
+	socketPath := filepath.Join(secretsDir, "api.sock")
+	if _, err := os.Stat(socketPath); err != nil {
+		return ""
+	}
+	return socketPath
+}
+
+// ModifyConfigFunc is used to modify a Config.
+type ModifyConfigFunc func(c *Config)
+
+// TaskClient returns a client with default configuration for use by a Nomad task
+// leveraging Workload Identity and the unix domain socket Nomad creates for such tasks.
+//
+// Must only be used in the context of a Nomad Task with Workload Identity enabled.
+func TaskClient(f ModifyConfigFunc) *Client {
+	// lookup our workload identity token; if it is not set then just return
+	// nil because we are not running in the context of a nomad task with identity
+	token := os.Getenv("NOMAD_TOKEN")
+	if token == "" {
+		return nil
+	}
+
+	// find our socket file; it it's not there just return nil because we are
+	// not running in the context of a nomad task with identity
+	socket := nomadTaskSocketPath()
+	if socket == "" {
+		return nil
+	}
+
+	// create a default config with an address and headers suitable for talking over
+	// the Task API
+	config := Config{
+		Address:  "http://nomad" + socket,
+		SecretID: token,
+		Headers: map[string][]string{
+			"Authorization": {fmt.Sprintf("Bearer %s", token)},
+		},
+	}
+
+	// apply the config modification callback if set
+	if f != nil {
+		f(&config)
+	}
+
+	// create an http client with a transport attuned to our API socket
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", socket)
+			},
+		},
+	}
+
+	return &Client{
+		config:     config,
+		httpClient: httpClient,
+	}
 }
 
 // Close closes the client's idle keep-alived connections. The default

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -19,9 +21,7 @@ import (
 	"github.com/shoenig/test/must"
 )
 
-type configCallback func(c *Config)
-
-func makeACLClient(t *testing.T, cb1 configCallback,
+func makeACLClient(t *testing.T, cb1 ModifyConfigFunc,
 	cb2 testutil.ServerConfigCallback) (*Client, *testutil.TestServer, *ACLToken) {
 	client, server := makeClient(t, cb1, func(c *testutil.TestServerConfig) {
 		c.ACL.Enabled = true
@@ -39,7 +39,7 @@ func makeACLClient(t *testing.T, cb1 configCallback,
 	return client, server, root
 }
 
-func makeClient(t *testing.T, cb1 configCallback,
+func makeClient(t *testing.T, cb1 ModifyConfigFunc,
 	cb2 testutil.ServerConfigCallback) (*Client, *testutil.TestServer) {
 	// Make client config
 	conf := DefaultConfig()
@@ -591,4 +591,47 @@ func TestClient_autoUnzip(t *testing.T) {
 		Header: http.Header{"Content-Encoding": []string{"gzip"}},
 		Body:   io.NopCloser(&b),
 	}, nil)
+}
+
+func Test_TaskClient(t *testing.T) {
+	// setup a fake secrets dir and api socket
+	secretsDir := t.TempDir()
+	fakeSocketPath := filepath.Join(secretsDir, "api.sock")
+	_, err := os.OpenFile(fakeSocketPath, os.O_RDONLY|os.O_CREATE, 0o640)
+	must.NoError(t, err)
+
+	t.Run("missing socket", func(t *testing.T) {
+		t.Setenv("NOMAD_TOKEN", "e6b1233c-3faa-e04d-8c74-5ce8760e0b2b")
+		client := TaskClient(nil)
+		must.Nil(t, client)
+	})
+
+	t.Run("missing token", func(t *testing.T) {
+		t.Setenv("NOMAD_SECRETS_DIR", secretsDir)
+		client := TaskClient(nil)
+		must.Nil(t, client)
+	})
+
+	t.Run("defaults", func(t *testing.T) {
+		t.Setenv("NOMAD_SECRETS_DIR", secretsDir)
+		t.Setenv("NOMAD_TOKEN", "e6b1233c-3faa-e04d-8c74-5ce8760e0b2b")
+		client := TaskClient(nil)
+		must.NotNil(t, client)
+		must.Eq(t, "http://nomad"+fakeSocketPath, client.config.Address)
+		must.Eq(t, map[string][]string{
+			"Authorization": {
+				fmt.Sprintf("Bearer %s", "e6b1233c-3faa-e04d-8c74-5ce8760e0b2b"),
+			},
+		}, client.config.Headers)
+	})
+
+	t.Run("modify", func(t *testing.T) {
+		t.Setenv("NOMAD_SECRETS_DIR", secretsDir)
+		t.Setenv("NOMAD_TOKEN", "e6b1233c-3faa-e04d-8c74-5ce8760e0b2b")
+		client := TaskClient(func(c *Config) {
+			c.Namespace = "myns"
+		})
+		must.NotNil(t, client)
+		must.Eq(t, "myns", client.config.Namespace)
+	})
 }


### PR DESCRIPTION
This PR adds `api.TaskClient(ConfigModifyFunc)` helper method for use by
applications that are running as Nomad Tasks capable of making use of
Task API and workload identity. The resulting `Client` is automatically
properly configured to communicate with Nomad over the Task API unix
domain socket, as well as setting the necessary `Authorization` header.

Folks who need to further configure the `Client` may provide a `ConfigModifyFunc`
for modifying the underlying Config of the `Client`. This is done this
way because unlike with `NewClient`, in the 90% use case touching the
`Config` should not be necessary.
