### PR TITLE
Accept Workload Identities for Client RPCs

### DIFF
--- a/e2e/e2eutil/acl.go
+++ b/e2e/e2eutil/acl.go
@@ -1,0 +1,49 @@
+package e2eutil
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	api "github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/shoenig/test"
+	"github.com/shoenig/test/must"
+)
+
+// ApplyJobPolicy applies an ACL job policy or noops if ACLs are disabled.
+// Registers a cleanup function to delete the policy.
+func ApplyJobPolicy(t *testing.T, nomad *api.Client, ns, j, g, task, rules string) *api.ACLPolicy {
+
+	policy := &api.ACLPolicy{
+		Name: j + uuid.Short(),
+		Description: fmt.Sprintf("Policy for test=%s ns=%s job=%s group=%s task=%s rules=%s",
+			t.Name(), ns, j, g, task, rules),
+		Rules: rules,
+		JobACL: &api.JobACL{
+			Namespace: ns,
+			JobID:     j,
+			Group:     g,
+			Task:      task,
+		},
+	}
+
+	wm, err := nomad.ACLPolicies().Upsert(policy, nil)
+	if err != nil {
+		if strings.Contains(err.Error(), "ACL support disabled") {
+			t.Logf("ACL support disabled. Skipping ApplyJobPolicy(t, c, %q, %q, %q, %q, %q)",
+				ns, j, g, task, rules)
+			return nil
+		}
+		must.NoError(t, err)
+	}
+
+	t.Cleanup(func() {
+		_, err := nomad.ACLPolicies().Delete(policy.Name, nil)
+		test.NoError(t, err)
+	})
+
+	policy.CreateIndex = wm.LastIndex
+	policy.ModifyIndex = wm.LastIndex
+	return policy
+}

--- a/e2e/workload_id/nodemeta_test.go
+++ b/e2e/workload_id/nodemeta_test.go
@@ -70,6 +70,20 @@ func testDynamicNodeMetadata(t *testing.T) {
 	})
 	must.NoError(t, err)
 	job.ID = pointer.Of(jobID)
+
+	// Setup ACLs
+	for _, task := range job.TaskGroups[0].Tasks {
+		p := e2eutil.ApplyJobPolicy(t, nomad, "default",
+			jobID, *job.TaskGroups[0].Name, task.Name, `node { policy = "write" }`)
+
+		if p == nil {
+			t.Logf("skipping policy for %s as ACLs are disabled", task.Name)
+		} else {
+			t.Logf("created policy %s for %s", p.Name, task.Name)
+		}
+	}
+
+	// Register job
 	_, _, err = nomad.Jobs().Register(job, nil)
 	must.NoError(t, err)
 

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -416,6 +416,48 @@ func (a *ACL) GetPolicies(args *structs.ACLPolicySetRequest, reply *structs.ACLP
 	return a.srv.blockingRPC(&opts)
 }
 
+// GetClaimPolicies return the ACLPolicy objects for a workload identity.
+// Similar to GetPolicies except an error will *not* be returned if ACLs are
+// disabled.
+func (a *ACL) GetClaimPolicies(args *structs.GenericRequest, reply *structs.ACLPolicySetResponse) error {
+	authErr := a.srv.Authenticate(a.ctx, args)
+	if done, err := a.srv.forward("ACL.GetClaimPolicies", args, args, reply); done {
+		return err
+	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricList, args)
+	if authErr != nil {
+		return structs.ErrPermissionDenied
+	}
+	defer metrics.MeasureSince([]string{"nomad", "acl", "get_claim_policies"}, time.Now())
+
+	// Should only be called using a workload identity
+	claims := args.GetIdentity().Claims
+	if claims == nil {
+		// Calling this RPC without a workload identity is either a bug or an
+		// attacker as this RPC is not exposed to users directly.
+		a.logger.Debug("ACL.GetClaimPolicies called without a workload identity", "id", args.GetIdentity())
+		return structs.ErrPermissionDenied
+	}
+
+	policies, err := a.srv.resolvePoliciesForClaims(claims)
+	if err != nil {
+		// Likely only hit if a job/alloc has been GC'd on the server but the
+		// client hasn't stopped it yet. Return Permission Denied as there's no way
+		// this call should error that leaves the claims valid.
+		a.logger.Warn("Policies could not be resolved for claims", "error", err, "id", args.GetIdentity())
+		return structs.ErrPermissionDenied
+	}
+
+	reply.Policies = make(map[string]*structs.ACLPolicy, len(policies))
+	for _, p := range policies {
+		if p.ModifyIndex > reply.QueryMeta.Index {
+			reply.QueryMeta.Index = p.ModifyIndex
+		}
+		reply.Policies[p.Name] = p
+	}
+	return nil
+}
+
 // Bootstrap is used to bootstrap the initial token
 func (a *ACL) Bootstrap(args *structs.ACLTokenBootstrapRequest, reply *structs.ACLTokenUpsertResponse) error {
 	// Ensure ACLs are enabled, and always flow modification requests to the authoritative region

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -481,8 +481,13 @@ func (w WriteRequest) GetIdentity() *AuthenticatedIdentity {
 // ACLToken makes the original of the credential clear to RPC handlers, who may
 // have different behavior for internal vs external origins.
 type AuthenticatedIdentity struct {
+	// ACLToken authenticated. Claims will be nil if this is set.
 	ACLToken *ACLToken
-	Claims   *IdentityClaims
+
+	// Claims authenticated by workload identity. ACLToken will be nil if this is
+	// set.
+	Claims *IdentityClaims
+
 	ClientID string
 	TLSName  string
 	RemoteIP net.IP

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -281,7 +281,8 @@ type QueryOptions struct {
 	// If set, used as prefix for resource list searches
 	Prefix string
 
-	// AuthToken is secret portion of the ACL token used for the request
+	// AuthToken is secret portion of the ACL token or workload identity used for
+	// the request.
 	AuthToken string
 
 	// Filter specifies the go-bexpr filter expression to be used for
@@ -515,6 +516,16 @@ func (ai *AuthenticatedIdentity) String() string {
 		return fmt.Sprintf("client:%s", ai.ClientID)
 	}
 	return fmt.Sprintf("%s:%s", ai.TLSName, ai.RemoteIP.String())
+}
+
+func (ai *AuthenticatedIdentity) IsExpired(now time.Time) bool {
+	// Only ACLTokens currently support expiry so return unexpired if there isn't
+	// one.
+	if ai.ACLToken == nil {
+		return false
+	}
+
+	return ai.ACLToken.IsExpired(now)
 }
 
 type RequestWithIdentity interface {


### PR DESCRIPTION
Nomad 1.5.0-beta.1 was missing the ability to use workload identities for authorization when calling client RPCs like Dynamic Node Metadata. _Authentication_ using workload identity worked in the Task API, but if ACLs were enabled and the client RPCs tried to _authorize_ the workload identity... they had no idea how to turn a JWT into policies.

So that's what this does: Client RPCs can now turn JWTs -> Policies. The general approach is:

1. Treat JWTs like an ACL Token and look them up via `ACL.WhoAmI` instead of the ACLToken-specific `ACL.ResolveToken`
2. When using a JWT, call the new `ACL.GetClaimPolicies` RPC to retrieve policies instead of the ACLToken-specific `ACL.GetPolicies`

I tried stuffing policies into the `ACL.WhoAmI` response or even the `AuthenticatedIdentity` itself, but went with the separate RPC approach for to avoid having to maintain policies in those structs forever. Maybe we'll put policy names in the JWT someday (1.6 even?) and can use pre-1.5 ACL RPCs to resolve them? If so we just have to live with the new `GetClaimPolicies` RPC instead of having to live with deprecated fields in otherwise commonly used structs like `AuthenticatedIdentity`.

Put another way: adding a new RPC seemed like the lowest risk approach at the cost of performance.

Let me know if you want to discuss it over zoom as it's pretty subtle stuff that took me a lot of tries to settle on.

Sorry for the messy names/comments. I didn't want to devote too much time to prettying up if we didn't like the overall approach.

TODO
- [ ] Remove TODOs
- [ ] Fix and update tests
- [ ] Caching (or file an issue to add re-evaluate caching in 1.5.x)