### PR TITLE
populate Nomad token for task runner update hooks

### DIFF
--- a/.changelog/16266.txt
+++ b/.changelog/16266.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+template: Fixed a bug where the template runner's Nomad token would be erased by in-place updates to a task
+```

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -487,6 +487,7 @@ func (tr *TaskRunner) updateHooks() {
 
 		// Build the request
 		req := interfaces.TaskUpdateRequest{
+			NomadToken: tr.getNomadToken(),
 			VaultToken: tr.getVaultToken(),
 			Alloc:      alloc,
 			TaskEnv:    tr.envBuilder.Build(),


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/16259

The `TaskUpdateRequest` struct we send to task runner update hooks was not populating the Nomad token that we get from the task runner (which we do for the Vault token). This results in task runner hooks like the template hook overwriting the Nomad token with the zero value for the token. This causes in-place updates of a task to break templates (but not other uses that rely on identity but don't currently bother to update it, like the identity hook).