### PR TITLE
ui:  Toggle for `read-only` view

### DIFF
--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -12,6 +12,21 @@ export default class JobEditor extends Component {
 
   @tracked error = null;
   @tracked planOutput = null;
+  @tracked view = 'job-spec';
+  @tracked isEditing = false;
+
+  @action
+  edit() {
+    this.args.job.set(
+      '_newDefinition',
+      JSON.stringify(this.args.definition, null, 2)
+    );
+    this.isEditing = true;
+  }
+
+  onCancel() {
+    this.isEditing = false;
+  }
 
   get stage() {
     return this.planOutput ? 'plan' : 'editor';
@@ -94,5 +109,34 @@ export default class JobEditor extends Component {
 
     const [file] = event.target.files;
     reader.readAsText(file);
+  }
+
+  @action
+  toggleView() {
+    const opposite = this.view === 'job-spec' ? 'full-definition' : 'job-spec';
+    this.view = opposite;
+  }
+
+  get definition() {
+    if (this.view === 'full-definition') {
+      return this.args.definition;
+    } else {
+      return this.args.specification;
+    }
+  }
+
+  get data() {
+    return {
+      view: this.view,
+      definition: this.definition,
+      job: this.args.job,
+    };
+  }
+
+  get fns() {
+    return {
+      onEdit: this.edit,
+      onToggle: this.toggleView,
+    };
   }
 }

--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -12,12 +12,13 @@ export default class JobEditor extends Component {
 
   @tracked error = null;
   @tracked planOutput = null;
-  @tracked view = 'job-spec';
   @tracked isEditing;
+  @tracked view;
 
   constructor() {
     super(...arguments);
     this.isEditing = !!(this.args.context === 'new');
+    this.view = this.args.specification ? 'job-spec' : 'full-definition';
   }
 
   toggleEdit(bool) {
@@ -141,6 +142,7 @@ export default class JobEditor extends Component {
     return {
       cancelable: this.args.cancelable,
       definition: this.definition,
+      hasSpecification: !!this.args.specification,
       job: this.args.job,
       planOutput: this.planOutput,
       shouldShowPlanMessage: this.shouldShowPlanMessage,

--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -30,7 +30,7 @@ export default class JobEditor extends Component {
   }
 
   get stage() {
-    if (this.planOutput) return 'plan';
+    if (this.planOutput) return 'review';
     if (this.isEditing) return 'edit';
     else return 'read';
   }
@@ -135,7 +135,6 @@ export default class JobEditor extends Component {
       job: this.args.job,
       planOutput: this.planOutput,
       shouldShowPlanMessage: this.shouldShowPlanMessage,
-      stage: this.stage,
       view: this.view,
     };
   }

--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -13,7 +13,16 @@ export default class JobEditor extends Component {
   @tracked error = null;
   @tracked planOutput = null;
   @tracked view = 'job-spec';
-  @tracked isEditing = false;
+  @tracked isEditing;
+
+  constructor() {
+    super(...arguments);
+    this.isEditing = !!(this.args.context === 'new');
+  }
+
+  toggleEdit(bool) {
+    this.isEditing = bool || !this.isEditing;
+  }
 
   @action
   edit() {
@@ -21,12 +30,12 @@ export default class JobEditor extends Component {
       '_newDefinition',
       JSON.stringify(this.args.definition, null, 2)
     );
-    this.isEditing = true;
+    this.toggleEdit(true);
   }
 
   @action
   onCancel() {
-    this.isEditing = false;
+    this.toggleEdit(false);
   }
 
   get stage() {

--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -24,15 +24,18 @@ export default class JobEditor extends Component {
     this.isEditing = true;
   }
 
+  @action
   onCancel() {
     this.isEditing = false;
   }
 
   get stage() {
-    return this.planOutput ? 'plan' : 'editor';
+    if (this.planOutput) return 'plan';
+    if (this.isEditing) return 'edit';
+    else return 'read';
   }
 
-  @localStorageProperty('nomadMessageJobPlan', true) showPlanMessage;
+  @localStorageProperty('nomadMessageJobPlan', true) shouldShowPlanMessage;
 
   @(task(function* () {
     this.reset();
@@ -127,16 +130,27 @@ export default class JobEditor extends Component {
 
   get data() {
     return {
-      view: this.view,
+      cancelable: this.args.cancelable,
       definition: this.definition,
       job: this.args.job,
+      planOutput: this.planOutput,
+      shouldShowPlanMessage: this.shouldShowPlanMessage,
+      stage: this.stage,
+      view: this.view,
     };
   }
 
   get fns() {
     return {
+      onCancel: this.onCancel,
       onEdit: this.edit,
+      onPlan: this.plan,
+      onReset: this.reset,
+      onSaveAs: this.args.handleSaveAsTemplate,
+      onSubmit: this.submit,
       onToggle: this.toggleView,
+      onUpdate: this.updateCode,
+      onUpload: this.uploadJobSpec,
     };
   }
 }

--- a/ui/app/controllers/jobs/job/definition.js
+++ b/ui/app/controllers/jobs/job/definition.js
@@ -8,20 +8,11 @@ import { inject as service } from '@ember/service';
 export default class DefinitionController extends Controller.extend(
   WithNamespaceResetting
 ) {
-  @alias('model.job') job;
   @alias('model.definition') definition;
+  @alias('model.job') job;
+  @alias('model.specification') specification;
+
   @service router;
-
-  isEditing = false;
-
-  edit() {
-    this.job.set('_newDefinition', JSON.stringify(this.definition, null, 2));
-    this.set('isEditing', true);
-  }
-
-  onCancel() {
-    this.set('isEditing', false);
-  }
 
   onSubmit() {
     this.router.transitionTo('jobs.job', this.job.idWithNamespace);

--- a/ui/app/routes/jobs/job/definition.js
+++ b/ui/app/routes/jobs/job/definition.js
@@ -7,16 +7,15 @@ export default class DefinitionRoute extends Route {
 
     const definition = await job.fetchRawDefinition();
 
-    const definitionWithoutSpecification = { ...definition };
-    delete definitionWithoutSpecification.Specification;
+    const hasSpecification = !!definition?.Specification;
 
-    const specification = await new Blob([
-      definition?.Specification?.Definition,
-    ]).text();
+    const specification = hasSpecification
+      ? await new Blob([definition?.Specification?.Definition]).text()
+      : null;
 
     return {
       job,
-      definition: definitionWithoutSpecification,
+      definition,
       specification,
     };
   }

--- a/ui/app/routes/jobs/job/definition.js
+++ b/ui/app/routes/jobs/job/definition.js
@@ -1,14 +1,24 @@
 import Route from '@ember/routing/route';
 
 export default class DefinitionRoute extends Route {
-  model() {
+  async model() {
     const job = this.modelFor('jobs.job');
     if (!job) return;
 
-    return job.fetchRawDefinition().then((definition) => ({
+    const definition = await job.fetchRawDefinition();
+
+    const definitionWithoutSpecification = { ...definition };
+    delete definitionWithoutSpecification.Specification;
+
+    const specification = await new Blob([
+      definition?.Specification?.Definition,
+    ]).text();
+
+    return {
       job,
-      definition,
-    }));
+      definition: definitionWithoutSpecification,
+      specification,
+    };
   }
 
   resetController(controller, isExiting) {

--- a/ui/app/styles/components/codemirror.scss
+++ b/ui/app/styles/components/codemirror.scss
@@ -156,3 +156,29 @@ header.run-job-header {
   display: flex;
   justify-content: space-between;
 }
+
+.select-mode {
+  border: 1px solid $grey-blue;
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 2px;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: 1fr 1fr;
+  padding: 0.25rem 0.5rem;
+  margin: 0rem 1rem;
+
+  button {
+    height: auto;
+    padding: 0 0.5rem;
+    background: transparent;
+    transition: 0.1s;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.5);
+    }
+
+    &.is-active {
+      background: $white;
+    }
+  }
+}

--- a/ui/app/styles/components/codemirror.scss
+++ b/ui/app/styles/components/codemirror.scss
@@ -157,7 +157,7 @@ header.run-job-header {
   justify-content: space-between;
 }
 
-.select-mode {
+.job-definition-toggle {
   border: 1px solid $grey-blue;
   background: rgba(0, 0, 0, 0.05);
   border-radius: 2px;

--- a/ui/app/templates/components/job-editor.hbs
+++ b/ui/app/templates/components/job-editor.hbs
@@ -5,7 +5,6 @@
       <p data-test-error-message>{{this.error.message}}</p>
     </div>
   {{/if}}
-  {{#if (eq this.stage "editor")}}
 
     <header class="run-job-header">
       <h1 class="title is-3">Run a job</h1>
@@ -14,134 +13,7 @@
       </p>
     </header>
 
-    <div class="boxed-section">
-      <div class="boxed-section-head">
-        Job Definition
-        {{#if @cancelable}}
-          <button
-            class="button is-light is-compact pull-right"
-            onclick={{action @onCancel}}
-            data-test-cancel-editing
-            type="button"
-          >Cancel</button>
-        {{/if}}
-      </div>
-      <div class="boxed-section-body is-full-bleed">
-        <div
-          data-test-editor
-          {{code-mirror
-            screenReaderLabel="Job definition"
-            content=@job._newDefinition
-            theme="hashi"
-            onUpdate=this.updateCode
-            mode="javascript"
-          }}
-        />
-      </div>
-    </div>
-
-    <div class="is-associative buttonset">
-      <Hds::Button
-        {{on "click" (perform this.plan)}}
-        disabled={{or this.plan.isRunning (not @job._newDefinition)}}
-        data-test-plan
-        @text="Plan"
-      />
-      {{#if @job.isNew}}
-        <Hds::ButtonSet>
-          <label class="job-spec-upload hds-button hds-button--color-secondary hds-button--size-medium">
-            <div class="hds-button__text">Upload file</div>
-            <input type="file" onchange={{action this.uploadJobSpec}} accept=".hcl,.json,.nomad" />
-          </label>
-          {{#if (can "write variable" path="*" namespace="*")}}
-            <Hds::Button @icon="file-plus" @text="Save as template" @color="tertiary" @route="jobs.run.templates.new"  {{on "click" @handleSaveAsTemplate}} data-test-save-as-template />
-            <Hds::Button @icon="file-text" @text="Choose from a template" @color="tertiary" @route="jobs.run.templates" data-test-choose-template />
-          {{/if}}
-        </Hds::ButtonSet>
-      {{/if}}
-    </div>
-  {{/if}}
-
-  {{#if (eq this.stage "plan")}}
-    {{#if this.showPlanMessage}}
-      <div class="notification is-info">
-        <div class="columns">
-          <div class="column">
-            <h3 class="title is-4" data-test-plan-help-title>Job Plan</h3>
-            <p data-test-plan-help-message>This is the impact running this job
-              will have on your cluster.</p>
-          </div>
-          <div class="column is-centered is-minimum">
-            <Hds::Button @text="Okay" {{on "click" (toggle-action "showPlanMessage" this)}} data-test-plan-help-dismiss />
-          </div>
-        </div>
-      </div>
-    {{/if}}
-    <div class="boxed-section">
-      <div class="boxed-section-head">Job Plan</div>
-      <div class="boxed-section-body is-dark">
-        <JobDiff
-          data-test-plan-output
-          @diff={{this.planOutput.diff}}
-          @verbose={{false}}
-        />
-      </div>
-    </div>
-    <div
-      class="boxed-section
-        {{if this.planOutput.failedTGAllocs 'is-warning' 'is-primary'}}"
-      data-test-dry-run-message
-    >
-      <div class="boxed-section-head" data-test-dry-run-title>Scheduler dry-run</div>
-      <div class="boxed-section-body" data-test-dry-run-body>
-        {{#if this.planOutput.failedTGAllocs}}
-          {{#each this.planOutput.failedTGAllocs as |placementFailure|}}
-            <PlacementFailure @failedTGAlloc={{placementFailure}} />
-          {{/each}}
-        {{else}}
-          All tasks successfully allocated.
-        {{/if}}
-      </div>
-    </div>
-    {{#if
-      (and
-        this.planOutput.preemptions.isFulfilled this.planOutput.preemptions.length
-      )
-    }}
-      <div class="boxed-section is-warning" data-test-preemptions>
-        <div class="boxed-section-head" data-test-preemptions-title>
-          Preemptions (if you choose to run this job, these allocations will be
-          stopped)
-        </div>
-        <div class="boxed-section-body" data-test-preemptions-body>
-          <ListTable
-            @source={{this.planOutput.preemptions}}
-            @class="allocations is-isolated"
-            as |t|
-          >
-            <t.head>
-              <th class="is-narrow"></th>
-              <th>ID</th>
-              <th>Task Group</th>
-              <th>Created</th>
-              <th>Modified</th>
-              <th>Status</th>
-              <th>Version</th>
-              <th>Node</th>
-              <th>Volume</th>
-              <th>CPU</th>
-              <th>Memory</th>
-            </t.head>
-            <t.body as |row|>
-              <AllocationRow @allocation={{row.model}} @context="job" />
-            </t.body>
-          </ListTable>
-        </div>
-      </div>
-    {{/if}}
-    <Hds::ButtonSet class="is-associative">
-      <Hds::Button @text="Run" {{on "click" (perform this.submit)}} disabled={{this.submit.isRunning}} data-test-run />
-      <Hds::Button @color="secondary" @text="Cancel" {{on "click" this.reset}} disabled={{this.submit.isRunning}} data-test-cancel />
-    </Hds::ButtonSet>
-  {{/if}}
+  <JobEditor::Read @data={{this.data}} @fns={{this.fns}} />
+  <JobEditor::Edit />
+  <JobEditor::Review />
 </div>

--- a/ui/app/templates/components/job-editor.hbs
+++ b/ui/app/templates/components/job-editor.hbs
@@ -13,7 +13,11 @@
       </p>
     </header>
 
-  <JobEditor::Read @data={{this.data}} @fns={{this.fns}} />
-  <JobEditor::Edit />
-  <JobEditor::Review />
+  {{#if (eq this.stage "read")}}
+    <JobEditor::Read @data={{this.data}} @fns={{this.fns}} />
+  {{else if (eq this.stage "edit")}}
+    <JobEditor::Edit @data={{this.data}} @fns={{this.fns}} />
+  {{else}}
+    <JobEditor::Review @data={{this.data}} @fns={{this.fns}} />
+  {{/if}}
 </div>

--- a/ui/app/templates/components/job-editor.hbs
+++ b/ui/app/templates/components/job-editor.hbs
@@ -13,11 +13,5 @@
       </p>
     </header>
 
-  {{#if (eq this.stage "read")}}
-    <JobEditor::Read @data={{this.data}} @fns={{this.fns}} />
-  {{else if (eq this.stage "edit")}}
-    <JobEditor::Edit @data={{this.data}} @fns={{this.fns}} />
-  {{else}}
-    <JobEditor::Review @data={{this.data}} @fns={{this.fns}} />
-  {{/if}}
+    {{component (concat 'job-editor/' this.stage) data=this.data fns=this.fns}}
 </div>

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -1,47 +1,47 @@
-{{#if (eq this.stage "editor")}}
-    <div class="boxed-section">
-        <div class="boxed-section-head">
-        Job Definition
-        {{#if @cancelable}}
-            <button
+<div class="boxed-section">
+    <div class="boxed-section-head">
+    Job Definition
+    {{#if @data.cancelable}}
+        <button
             class="button is-light is-compact pull-right"
-            onclick={{action @onCancel}}
-            data-test-cancel-editing
+            onclick={{fn @fns.onCancel}}
             type="button"
-            >Cancel</button>
-        {{/if}}
-        </div>
-        <div class="boxed-section-body is-full-bleed">
-        <div
-            data-test-editor
-            {{code-mirror
-            screenReaderLabel="Job definition"
-            content=@job._newDefinition
-            theme="hashi"
-            onUpdate=this.updateCode
-            mode="javascript"
-            }}
-        />
-        </div>
+            data-test-cancel-editing
+        >
+            Cancel
+        </button>
+    {{/if}}
     </div>
-    <div class="is-associative buttonset">
-        <Hds::Button
-        {{on "click" (perform this.plan)}}
-        disabled={{or this.plan.isRunning (not @job._newDefinition)}}
-        data-test-plan
-        @text="Plan"
-        />
-        {{#if @job.isNew}}
-        <Hds::ButtonSet>
-            <label class="job-spec-upload hds-button hds-button--color-secondary hds-button--size-medium">
-            <div class="hds-button__text">Upload file</div>
-            <input type="file" onchange={{action this.uploadJobSpec}} accept=".hcl,.json,.nomad" />
-            </label>
-            {{#if (can "write variable" path="*" namespace="*")}}
-            <Hds::Button @icon="file-plus" @text="Save as template" @color="tertiary" @route="jobs.run.templates.new"  {{on "click" @handleSaveAsTemplate}} data-test-save-as-template />
-            <Hds::Button @icon="file-text" @text="Choose from a template" @color="tertiary" @route="jobs.run.templates" data-test-choose-template />
-            {{/if}}
-        </Hds::ButtonSet>
-        {{/if}}
+    <div class="boxed-section-body is-full-bleed">
+    <div
+        data-test-editor
+        {{code-mirror
+        screenReaderLabel="Job definition"
+        content=@data.job._newDefinition
+        theme="hashi"
+        onUpdate=@fns.onUpdate
+        mode="javascript"
+        }}
+    />
     </div>
-{{/if}}
+</div>
+<div class="is-associative buttonset">
+    <Hds::Button
+    {{on "click" (perform @fns.onPlan)}}
+    disabled={{or @fns.onPlan.isRunning (not @data.job._newDefinition)}}
+    data-test-plan
+    @text="Plan"
+    />
+    {{#if @job.isNew}}
+    <Hds::ButtonSet>
+        <label class="job-spec-upload hds-button hds-button--color-secondary hds-button--size-medium">
+        <div class="hds-button__text">Upload file</div>
+        <input type="file" onchange={{action @fns.onUpload}} accept=".hcl,.json,.nomad" />
+        </label>
+        {{#if (can "write variable" path="*" namespace="*")}}
+        <Hds::Button @icon="file-plus" @text="Save as template" @color="tertiary" @route="jobs.run.templates.new"  {{on "click" @fns.onSaveAs}} data-test-save-as-template />
+        <Hds::Button @icon="file-text" @text="Choose from a template" @color="tertiary" @route="jobs.run.templates" data-test-choose-template />
+        {{/if}}
+    </Hds::ButtonSet>
+    {{/if}}
+</div>

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -1,0 +1,47 @@
+{{#if (eq this.stage "editor")}}
+    <div class="boxed-section">
+        <div class="boxed-section-head">
+        Job Definition
+        {{#if @cancelable}}
+            <button
+            class="button is-light is-compact pull-right"
+            onclick={{action @onCancel}}
+            data-test-cancel-editing
+            type="button"
+            >Cancel</button>
+        {{/if}}
+        </div>
+        <div class="boxed-section-body is-full-bleed">
+        <div
+            data-test-editor
+            {{code-mirror
+            screenReaderLabel="Job definition"
+            content=@job._newDefinition
+            theme="hashi"
+            onUpdate=this.updateCode
+            mode="javascript"
+            }}
+        />
+        </div>
+    </div>
+    <div class="is-associative buttonset">
+        <Hds::Button
+        {{on "click" (perform this.plan)}}
+        disabled={{or this.plan.isRunning (not @job._newDefinition)}}
+        data-test-plan
+        @text="Plan"
+        />
+        {{#if @job.isNew}}
+        <Hds::ButtonSet>
+            <label class="job-spec-upload hds-button hds-button--color-secondary hds-button--size-medium">
+            <div class="hds-button__text">Upload file</div>
+            <input type="file" onchange={{action this.uploadJobSpec}} accept=".hcl,.json,.nomad" />
+            </label>
+            {{#if (can "write variable" path="*" namespace="*")}}
+            <Hds::Button @icon="file-plus" @text="Save as template" @color="tertiary" @route="jobs.run.templates.new"  {{on "click" @handleSaveAsTemplate}} data-test-save-as-template />
+            <Hds::Button @icon="file-text" @text="Choose from a template" @color="tertiary" @route="jobs.run.templates" data-test-choose-template />
+            {{/if}}
+        </Hds::ButtonSet>
+        {{/if}}
+    </div>
+{{/if}}

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -32,7 +32,7 @@
     data-test-plan
     @text="Plan"
     />
-    {{#if @job.isNew}}
+    {{#if @data.job.isNew}}
     <Hds::ButtonSet>
         <label class="job-spec-upload hds-button hds-button--color-secondary hds-button--size-medium">
         <div class="hds-button__text">Upload file</div>

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -4,7 +4,7 @@
     {{#if @data.cancelable}}
         <button
             class="button is-light is-compact pull-right"
-            onclick={{fn @fns.onCancel}}
+            onclick={{@fns.onCancel}}
             type="button"
             data-test-cancel-editing
         >

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -1,0 +1,43 @@
+<div class="boxed-section">
+    <div class="boxed-section-head">
+    Job Definition
+    <div class="pull-right" style="display: flex">
+        <div class="select-mode" data-test-toggle={{@data.view}}>
+        <button 
+            class="button is-small is-borderless {{if (eq @data.view "job-spec") "is-active"}}"
+            type="button"
+            {{on "click" @fns.onToggle}}
+        >
+            Job Spec
+        </button>
+        <button 
+            class="button is-small is-borderless {{if (eq @data.view "full-definition") "is-active"}}"
+            type="button"
+            {{on "click" @fns.onToggle}}
+            data-test-toggle-full
+        >
+            Full Definition
+        </button>
+        </div>
+        <button
+            class="button is-light is-compact"
+            type="button"
+            {{on "click" @fns.onEdit}}
+            data-test-edit-job
+        >
+            Edit
+        </button>
+    </div>
+    </div>
+    <div class="boxed-section-body is-full-bleed">
+    {{#if (eq @data.view "job-spec")}}
+    <div {{code-mirror           
+            theme="hashi"
+            mode="ruby"
+            content=@data.definition
+        }} />
+    {{else}}
+        <JsonViewer data-test-definition-view @json={{@data.definition}} />
+    {{/if}}
+    </div>
+</div>

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -2,23 +2,25 @@
     <div class="boxed-section-head">
     Job Definition
     <div class="pull-right" style="display: flex">
+        {{#if @data.hasSpecification}}
         <div class="select-mode" data-test-toggle={{@data.view}}>
-        <button 
-            class="button is-small is-borderless {{if (eq @data.view "job-spec") "is-active"}}"
-            type="button"
-            {{on "click" @fns.onToggle}}
-        >
-            Job Spec
-        </button>
-        <button 
-            class="button is-small is-borderless {{if (eq @data.view "full-definition") "is-active"}}"
-            type="button"
-            {{on "click" @fns.onToggle}}
-            data-test-toggle-full
-        >
-            Full Definition
-        </button>
+            <button 
+                class="button is-small is-borderless {{if (eq @data.view "job-spec") "is-active"}}"
+                type="button"
+                {{on "click" @fns.onToggle}}
+            >
+                Job Spec
+            </button>
+            <button 
+                class="button is-small is-borderless {{if (eq @data.view "full-definition") "is-active"}}"
+                type="button"
+                {{on "click" @fns.onToggle}}
+                data-test-toggle-full
+            >
+                Full Definition
+            </button>
         </div>
+        {{/if}}
         <button
             class="button is-light is-compact"
             type="button"
@@ -27,7 +29,7 @@
         >
             Edit
         </button>
-    </div>
+        </div>
     </div>
     <div class="boxed-section-body is-full-bleed">
     {{#if (eq @data.view "job-spec")}}

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -3,7 +3,7 @@
     Job Definition
     <div class="pull-right" style="display: flex">
         {{#if @data.hasSpecification}}
-        <div class="select-mode" data-test-toggle={{@data.view}}>
+        <div class="job-definition-toggle" data-test-toggle={{@data.view}}>
             <button 
                 class="button is-small is-borderless {{if (eq @data.view "job-spec") "is-active"}}"
                 type="button"

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -31,11 +31,16 @@
     </div>
     <div class="boxed-section-body is-full-bleed">
     {{#if (eq @data.view "job-spec")}}
-    <div {{code-mirror           
-            theme="hashi"
-            mode="ruby"
+        <div 
+            data-test-job-spec-view 
+            {{code-mirror
             content=@data.definition
-        }} />
+            mode="ruby"
+            readOnly=true
+            screenReaderLabel="Job specification"          
+            theme="hashi"
+            }} 
+        />
     {{else}}
         <JsonViewer data-test-definition-view @json={{@data.definition}} />
     {{/if}}

--- a/ui/app/templates/components/job-editor/review.hbs
+++ b/ui/app/templates/components/job-editor/review.hbs
@@ -1,0 +1,82 @@
+{{#if (eq this.stage "plan")}}
+{{#if this.showPlanMessage}}
+    <div class="notification is-info">
+    <div class="columns">
+        <div class="column">
+        <h3 class="title is-4" data-test-plan-help-title>Job Plan</h3>
+        <p data-test-plan-help-message>This is the impact running this job
+            will have on your cluster.</p>
+        </div>
+        <div class="column is-centered is-minimum">
+        <Hds::Button @text="Okay" {{on "click" (toggle-action "showPlanMessage" this)}} data-test-plan-help-dismiss />
+        </div>
+    </div>
+    </div>
+{{/if}}
+<div class="boxed-section">
+    <div class="boxed-section-head">Job Plan</div>
+    <div class="boxed-section-body is-dark">
+    <JobDiff
+        data-test-plan-output
+        @diff={{this.planOutput.diff}}
+        @verbose={{false}}
+    />
+    </div>
+</div>
+<div
+    class="boxed-section
+    {{if this.planOutput.failedTGAllocs 'is-warning' 'is-primary'}}"
+    data-test-dry-run-message
+>
+    <div class="boxed-section-head" data-test-dry-run-title>Scheduler dry-run</div>
+    <div class="boxed-section-body" data-test-dry-run-body>
+    {{#if this.planOutput.failedTGAllocs}}
+        {{#each this.planOutput.failedTGAllocs as |placementFailure|}}
+        <PlacementFailure @failedTGAlloc={{placementFailure}} />
+        {{/each}}
+    {{else}}
+        All tasks successfully allocated.
+    {{/if}}
+    </div>
+</div>
+{{#if
+    (and
+    this.planOutput.preemptions.isFulfilled this.planOutput.preemptions.length
+    )
+}}
+    <div class="boxed-section is-warning" data-test-preemptions>
+    <div class="boxed-section-head" data-test-preemptions-title>
+        Preemptions (if you choose to run this job, these allocations will be
+        stopped)
+    </div>
+    <div class="boxed-section-body" data-test-preemptions-body>
+        <ListTable
+        @source={{this.planOutput.preemptions}}
+        @class="allocations is-isolated"
+        as |t|
+        >
+        <t.head>
+            <th class="is-narrow"></th>
+            <th>ID</th>
+            <th>Task Group</th>
+            <th>Created</th>
+            <th>Modified</th>
+            <th>Status</th>
+            <th>Version</th>
+            <th>Node</th>
+            <th>Volume</th>
+            <th>CPU</th>
+            <th>Memory</th>
+        </t.head>
+        <t.body as |row|>
+            <AllocationRow @allocation={{row.model}} @context="job" />
+        </t.body>
+        </ListTable>
+    </div>
+    </div>
+{{/if}}
+<Hds::ButtonSet class="is-associative">
+    <Hds::Button @text="Run" {{on "click" (perform this.submit)}} disabled={{this.submit.isRunning}} data-test-run />
+    <Hds::Button @color="secondary" @text="Cancel" {{on "click" this.reset}} disabled={{this.submit.isRunning}} data-test-cancel />
+</Hds::ButtonSet>
+{{/if}}

--- a/ui/app/templates/components/job-editor/review.hbs
+++ b/ui/app/templates/components/job-editor/review.hbs
@@ -1,5 +1,4 @@
-{{#if (eq this.stage "plan")}}
-{{#if this.showPlanMessage}}
+{{#if @data.shouldShowPlanMessage}}
     <div class="notification is-info">
     <div class="columns">
         <div class="column">
@@ -18,20 +17,20 @@
     <div class="boxed-section-body is-dark">
     <JobDiff
         data-test-plan-output
-        @diff={{this.planOutput.diff}}
+        @diff={{@data.planOutput.diff}}
         @verbose={{false}}
     />
     </div>
 </div>
 <div
     class="boxed-section
-    {{if this.planOutput.failedTGAllocs 'is-warning' 'is-primary'}}"
+    {{if @data.planOutput.failedTGAllocs 'is-warning' 'is-primary'}}"
     data-test-dry-run-message
 >
     <div class="boxed-section-head" data-test-dry-run-title>Scheduler dry-run</div>
     <div class="boxed-section-body" data-test-dry-run-body>
-    {{#if this.planOutput.failedTGAllocs}}
-        {{#each this.planOutput.failedTGAllocs as |placementFailure|}}
+    {{#if @data.planOutput.failedTGAllocs}}
+        {{#each @data.planOutput.failedTGAllocs as |placementFailure|}}
         <PlacementFailure @failedTGAlloc={{placementFailure}} />
         {{/each}}
     {{else}}
@@ -41,7 +40,7 @@
 </div>
 {{#if
     (and
-    this.planOutput.preemptions.isFulfilled this.planOutput.preemptions.length
+    @data.planOutput.preemptions.isFulfilled @data.planOutput.preemptions.length
     )
 }}
     <div class="boxed-section is-warning" data-test-preemptions>
@@ -51,7 +50,7 @@
     </div>
     <div class="boxed-section-body" data-test-preemptions-body>
         <ListTable
-        @source={{this.planOutput.preemptions}}
+        @source={{@data.planOutput.preemptions}}
         @class="allocations is-isolated"
         as |t|
         >
@@ -76,7 +75,6 @@
     </div>
 {{/if}}
 <Hds::ButtonSet class="is-associative">
-    <Hds::Button @text="Run" {{on "click" (perform this.submit)}} disabled={{this.submit.isRunning}} data-test-run />
-    <Hds::Button @color="secondary" @text="Cancel" {{on "click" this.reset}} disabled={{this.submit.isRunning}} data-test-cancel />
+    <Hds::Button @text="Run" {{on "click" (perform @fns.onSubmit)}} disabled={{@fns.onSubmit.isRunning}} data-test-run />
+    <Hds::Button @color="secondary" @text="Cancel" {{on "click" @fns.onReset}} disabled={{@fns.onSubmit.isRunning}} data-test-cancel />
 </Hds::ButtonSet>
-{{/if}}

--- a/ui/app/templates/jobs/job/definition.hbs
+++ b/ui/app/templates/jobs/job/definition.hbs
@@ -1,29 +1,12 @@
 {{page-title "Job " this.job.name " definition"}}
 <JobSubnav @job={{this.job}} />
 <section class="section">
-  {{#if this.isEditing}}
-    <JobEditor
-      @job={{this.job}}
-      @cancelable={{true}}
-      @context="edit"
-      @onCancel={{action this.onCancel}}
-      @onSubmit={{action this.onSubmit}}
-      data-test-job-editor
-    />
-  {{else}}
-    <div class="boxed-section">
-      <div class="boxed-section-head">
-        Job Definition
-        <button
-          class="button is-light is-compact pull-right"
-          type="button"
-          onclick={{action this.edit}}
-          data-test-edit-job
-        >Edit</button>
-      </div>
-      <div class="boxed-section-body is-full-bleed">
-        <JsonViewer data-test-definition-view @json={{this.definition}} />
-      </div>
-    </div>
-  {{/if}}
+  <JobEditor
+    @cancelable={{true}}
+    @definition={{this.definition}}
+    @job={{this.job}}
+    @specification={{this.specification}}
+    @onSubmit={{action this.onSubmit}}
+    data-test-job-editor
+  />
 </section>

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -68,6 +68,102 @@ function smallCluster(server) {
     id: 'service-haver',
     namespaceId: 'default',
   });
+  server.create('job', {
+    name: 'hcl-definition-job',
+    id: 'display-hcl',
+    namespaceId: 'default',
+    Specification: {
+      Definition: `# This declares a job named "docs". There can be exactly one job declaration per job file.
+    # This is a sample job for Mirage fixture purposes and not tied to anything.
+    job "docs" {
+      # Specify this job should run in the region named "us". Regions
+      # are defined by the Nomad servers' configuration.
+      region = "us"
+    
+      # Spread the tasks in this job between us-west-1 and us-east-1.
+      datacenters = ["us-west-1", "us-east-1"]
+    
+      # Run this job as a "service" type. Each job type has different
+      # properties. See the documentation below for more examples.
+      type = "service"
+    
+      # Specify this job to have rolling updates, two-at-a-time, with
+      # 30 second intervals.
+      update {
+        stagger      = "30s"
+        max_parallel = 2
+      }
+    
+    
+      # A group defines a series of tasks that should be co-located
+      # on the same client (host). All tasks within a group will be
+      # placed on the same host.
+      group "webs" {
+        # Specify the number of these tasks we want.
+        count = 5
+    
+        network {
+          # This requests a dynamic port named "http". This will
+          # be something like "46283", but we refer to it via the
+          # label "http".
+          port "http" {}
+    
+          # This requests a static port on 443 on the host. This
+          # will restrict this task to running once per host, since
+          # there is only one port 443 on each host.
+          port "https" {
+            static = 443
+          }
+        }
+    
+        # The service block tells Nomad how to register this service
+        # with Consul for service discovery and monitoring.
+        service {
+          # This tells Consul to monitor the service on the port
+          # labelled "http". Since Nomad allocates high dynamic port
+          # numbers, we use labels to refer to them.
+          port = "http"
+    
+          check {
+            type     = "http"
+            path     = "/health"
+            interval = "10s"
+            timeout  = "2s"
+          }
+        }
+    
+        # Create an individual task (unit of work). This particular
+        # task utilizes a Docker container to front a web application.
+        task "frontend" {
+          # Specify the driver to be "docker". Nomad supports
+          # multiple drivers.
+          driver = "docker"
+    
+          # Configuration is specific to each driver.
+          config {
+            image = "hashicorp/web-frontend"
+            ports = ["http", "https"]
+          }
+    
+          # It is possible to set environment variables which will be
+          # available to the task when it runs.
+          env {
+            DB_HOST = "db01.example.com"
+            DB_USER = "web"
+            DB_PASS = "loremipsum"
+          }
+    
+          # Specify the maximum resources required to run the task,
+          # include CPU and memory.
+          resources {
+            cpu    = 500 # MHz
+            memory = 128 # MB
+          }
+        }
+      }
+    }`,
+    },
+  });
   server.createList('allocFile', 5);
   server.create('allocFile', 'dir', { depth: 2 });
   server.createList('csi-plugin', 2);

--- a/ui/tests/acceptance/job-definition-test.js
+++ b/ui/tests/acceptance/job-definition-test.js
@@ -581,8 +581,8 @@ module('Acceptance | job definition', function (hooks) {
     assert.equal(document.title, `Job ${job.name} definition - Nomad`);
   });
 
-  test('the job definition page contains a json viewer component', async function (assert) {
-    assert.ok(Definition.jsonViewer, 'JSON viewer found');
+  test('the job definition page starts in read-only view', async function (assert) {
+    assert.dom('[data-test-job-spec-view]').exists('Read-only Editor appears.');
   });
 
   test('the job definition page requests the job to display in an unmutated form', async function (assert) {
@@ -615,7 +615,7 @@ module('Acceptance | job definition', function (hooks) {
     await Definition.edit();
 
     await Definition.editor.cancelEditing();
-    assert.ok(Definition.jsonViewer, 'The JSON Viewer is back');
+    assert.dom('[data-test-job-spec-view]').exists('Read-only Editor appears.');
     assert.dom('[data-test-job-editor]').doesNotExist('The editor is gone');
   });
 
@@ -702,6 +702,8 @@ module('display and edit using full specification', function (hooks) {
       JOB_JSON.Specification.Definition,
       'Shows the full definition as written by the user'
     );
+
+    // TODO -- ADD FEATURE
     assert
       .dom('[data-test-job-variables]')
       .exists('A table showing job variables appears');
@@ -711,6 +713,8 @@ module('display and edit using full specification', function (hooks) {
     delete code.Specification;
     codeMirror = getCodeMirrorInstance('[data-test-editor]');
     assert.propContains(codeMirror.getValue(), JSON.parse(code));
+
+    // TODO -- ADD FEATURE
     assert
       .dom('[data-test-job-variables]')
       .doesNotExist('A table showing job variables appears');

--- a/ui/tests/acceptance/job-definition-test.js
+++ b/ui/tests/acceptance/job-definition-test.js
@@ -1,4 +1,4 @@
-import { currentURL } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -7,6 +7,556 @@ import setupCodeMirror from 'nomad-ui/tests/helpers/codemirror';
 import Definition from 'nomad-ui/tests/pages/jobs/job/definition';
 
 let job;
+
+const JOB_JSON = {
+  Shallow: false,
+  CreateRecommendations: true,
+  WithTaskServices: false,
+  WithGroupServices: false,
+  WithRescheduling: false,
+  NoHostVolumes: false,
+  NoFailedPlacements: false,
+  FailedPlacements: false,
+  NoDeployments: false,
+  ActiveDeployment: false,
+  NoActiveDeployment: false,
+  CreateAllocations: true,
+  ModifyIndex: 1201,
+  CreateIndex: 0,
+  Meta: null,
+  ChildrenCount: 1,
+  Datacenters: ['cl12'],
+  Status: 'running',
+  AllAtOnce: true,
+  Priority: 73,
+  Type: 'service',
+  Region: 'global',
+  ResourceSpec: null,
+  GroupsCount: 2,
+  SubmitTime: 1676365074506000000,
+  Version: 1,
+  ID: 'hdd-panel-0',
+  Name: 'hdd-panel-0',
+  Namespace: 'namespace-1',
+  NamespaceID: 'namespace-1',
+  TaskGroups: [
+    {
+      ResourceSpec: null,
+      Shallow: false,
+      CreateRecommendations: true,
+      WithTaskServices: false,
+      WithServices: false,
+      WithRescheduling: false,
+      CreateAllocations: true,
+      Volumes: {
+        mazie: {
+          Name: 'mazie',
+          Type: 'host',
+          Source: 'claire',
+          ReadOnly: false,
+        },
+        leora: {
+          Name: 'leora',
+          Type: 'host',
+          Source: 'jamil',
+          ReadOnly: false,
+        },
+      },
+      WithScaling: false,
+      EphemeralDisk: {
+        Sticky: true,
+        SizeMB: 5000,
+        Migrate: false,
+      },
+      Count: 2,
+      Name: 'pixel-g-0',
+      ID: '1',
+      Services: null,
+      Tasks: [
+        {
+          TaskGroupID: '1',
+          Lifecycle: null,
+          OriginalResources: {
+            Cpu: {
+              CpuShares: 250,
+            },
+            Memory: {
+              MemoryMB: 1024,
+              MemoryMaxMB: 8192,
+            },
+            Disk: {
+              DiskMB: 0,
+            },
+            Networks: [
+              {
+                Device: 'eth4',
+                CIDR: '',
+                IP: '116.206.32.192',
+                MBits: 10,
+                Mode: 'bridge',
+                ReservedPorts: [],
+                DynamicPorts: [
+                  {
+                    Label: 'sensor',
+                    Value: 43123,
+                    To: 29512,
+                  },
+                ],
+              },
+              {
+                Device: 'eth3',
+                CIDR: '',
+                IP: '172.75.114.89',
+                MBits: 10,
+                Mode: 'host',
+                ReservedPorts: [],
+                DynamicPorts: [
+                  {
+                    Label: 'firewall',
+                    Value: 43343,
+                    To: 38426,
+                  },
+                  {
+                    Label: 'pixel',
+                    Value: 16314,
+                    To: 13304,
+                  },
+                ],
+              },
+              {
+                Device: 'eth5',
+                CIDR: '',
+                IP: '194.36.199.184',
+                MBits: 10,
+                Mode: 'host',
+                ReservedPorts: [
+                  {
+                    Label: 'program',
+                    Value: 48937,
+                    To: 14717,
+                  },
+                ],
+                DynamicPorts: [
+                  {
+                    Label: 'interface',
+                    Value: 44940,
+                    To: 22631,
+                  },
+                ],
+              },
+            ],
+            Ports: [
+              {
+                Label: 'transmitter',
+                Value: 40616,
+                To: 38744,
+                HostIP: 'c760:161f:5d3e:d49a:b973:1234:7835:07bd',
+              },
+            ],
+          },
+          Resources: {
+            CPU: 250,
+            MemoryMB: 1024,
+            MemoryMaxMB: 8192,
+            DiskMB: 0,
+          },
+          Driver: 'java',
+          Name: 'task-hard-drive-0',
+          JobID: '',
+          VolumeMounts: [
+            {
+              Volume: 'leora',
+              Destination: '/Andreanne_Gulgowski94/jordane/#442118',
+              PropagationMode: '',
+              ReadOnly: true,
+            },
+            {
+              Volume: 'mazie',
+              Destination: '/Nicholaus43/erna/#377517',
+              PropagationMode: '',
+              ReadOnly: true,
+            },
+          ],
+          GroupNames: [],
+          WithServices: false,
+          CreateRecommendations: true,
+          ID: '1',
+          Services: [],
+        },
+        {
+          TaskGroupID: '1',
+          Lifecycle: {
+            Hook: 'prestart',
+            Sidecar: false,
+          },
+          OriginalResources: {
+            Cpu: {
+              CpuShares: 250,
+            },
+            Memory: {
+              MemoryMB: 2048,
+              MemoryMaxMB: 0,
+            },
+            Disk: {
+              DiskMB: 0,
+            },
+            Networks: [
+              {
+                Device: 'eth0',
+                CIDR: '',
+                IP: '124.146.107.83',
+                MBits: 10,
+                Mode: 'bridge',
+                ReservedPorts: [],
+                DynamicPorts: [
+                  {
+                    Label: 'alarm',
+                    Value: 6224,
+                    To: 42238,
+                  },
+                  {
+                    Label: 'transmitter',
+                    Value: 37450,
+                    To: 15365,
+                  },
+                ],
+              },
+              {
+                Device: 'eth2',
+                CIDR: '',
+                IP: '175.247.90.51',
+                MBits: 10,
+                Mode: 'host',
+                ReservedPorts: [
+                  {
+                    Label: 'bandwidth',
+                    Value: 20203,
+                    To: 15316,
+                  },
+                ],
+                DynamicPorts: [
+                  {
+                    Label: 'circuit',
+                    Value: 18394,
+                    To: 37087,
+                  },
+                  {
+                    Label: 'protocol',
+                    Value: 22008,
+                    To: 12761,
+                  },
+                ],
+              },
+              {
+                Device: 'eth0',
+                CIDR: '',
+                IP: '21.58.85.37',
+                MBits: 10,
+                Mode: 'bridge',
+                ReservedPorts: [],
+                DynamicPorts: [
+                  {
+                    Label: 'circuit',
+                    Value: 12116,
+                    To: 53021,
+                  },
+                  {
+                    Label: 'application',
+                    Value: 43516,
+                    To: 19386,
+                  },
+                ],
+              },
+            ],
+            Ports: [
+              {
+                Label: 'bandwidth',
+                Value: 50493,
+                To: 58903,
+                HostIP: '7534:4ef6:c704:0e86:643b:7311:2dab:b933',
+              },
+            ],
+          },
+          Resources: {
+            CPU: 250,
+            MemoryMB: 2048,
+            MemoryMaxMB: 0,
+            DiskMB: 0,
+          },
+          Driver: 'qemu',
+          Name: 'task-transmitter-1',
+          JobID: '',
+          VolumeMounts: [
+            {
+              Volume: 'mazie',
+              Destination: '/Sylvan79/marjorie/#407369',
+              PropagationMode: '',
+              ReadOnly: false,
+            },
+            {
+              Volume: 'leora',
+              Destination: '/Jeanie.Thiel75/ross/#365510',
+              PropagationMode: '',
+              ReadOnly: false,
+            },
+          ],
+          GroupNames: [],
+          WithServices: false,
+          CreateRecommendations: true,
+          ID: '2',
+          Services: [],
+        },
+      ],
+    },
+    {
+      ResourceSpec: null,
+      Shallow: false,
+      CreateRecommendations: true,
+      WithTaskServices: false,
+      WithServices: false,
+      WithRescheduling: false,
+      CreateAllocations: true,
+      Volumes: {
+        mazie: {
+          Name: 'mazie',
+          Type: 'host',
+          Source: 'claire',
+          ReadOnly: false,
+        },
+        leora: {
+          Name: 'leora',
+          Type: 'host',
+          Source: 'jamil',
+          ReadOnly: false,
+        },
+      },
+      WithScaling: true,
+      EphemeralDisk: {
+        Sticky: false,
+        SizeMB: 500,
+        Migrate: false,
+      },
+      Count: 2,
+      Name: 'protocol-g-1',
+      ID: '2',
+      Scaling: {
+        Min: 1,
+        Max: 5,
+        Policy: false,
+      },
+      Services: null,
+      Tasks: [
+        {
+          TaskGroupID: '2',
+          Lifecycle: {
+            Hook: 'prestart',
+            Sidecar: true,
+          },
+          OriginalResources: {
+            Cpu: {
+              CpuShares: 4000,
+            },
+            Memory: {
+              MemoryMB: 4096,
+              MemoryMaxMB: 8192,
+            },
+            Disk: {
+              DiskMB: 0,
+            },
+            Networks: [
+              {
+                Device: 'eth1',
+                CIDR: '',
+                IP: '203.214.83.7',
+                MBits: 10,
+                Mode: 'bridge',
+                ReservedPorts: [],
+                DynamicPorts: [
+                  {
+                    Label: 'bus',
+                    Value: 58731,
+                    To: 43657,
+                  },
+                  {
+                    Label: 'firewall',
+                    Value: 31480,
+                    To: 57357,
+                  },
+                ],
+              },
+            ],
+            Ports: [
+              {
+                Label: 'circuit',
+                Value: 53773,
+                To: 33492,
+                HostIP: '55b9:739b:f8cb:591f:238c:6ec3:e925:defc',
+              },
+            ],
+          },
+          Resources: {
+            CPU: 4000,
+            MemoryMB: 4096,
+            MemoryMaxMB: 8192,
+            DiskMB: 0,
+          },
+          Driver: 'docker',
+          Name: 'task-firewall-2',
+          JobID: '',
+          VolumeMounts: [
+            {
+              Volume: 'mazie',
+              Destination: '/Wanda21/ronaldo/#315877',
+              PropagationMode: '',
+              ReadOnly: false,
+            },
+          ],
+          GroupNames: [],
+          WithServices: false,
+          CreateRecommendations: true,
+          ID: '3',
+          Services: [],
+        },
+        {
+          TaskGroupID: '2',
+          Lifecycle: {
+            Hook: 'poststart',
+            Sidecar: false,
+          },
+          OriginalResources: {
+            Cpu: {
+              CpuShares: 2000,
+            },
+            Memory: {
+              MemoryMB: 1024,
+              MemoryMaxMB: 0,
+            },
+            Disk: {
+              DiskMB: 0,
+            },
+            Networks: [
+              {
+                Device: 'eth1',
+                CIDR: '',
+                IP: '126.161.123.8',
+                MBits: 10,
+                Mode: 'bridge',
+                ReservedPorts: [
+                  {
+                    Label: 'alarm',
+                    Value: 52478,
+                    To: 11878,
+                  },
+                ],
+                DynamicPorts: [
+                  {
+                    Label: 'application',
+                    Value: 5543,
+                    To: 22670,
+                  },
+                  {
+                    Label: 'port',
+                    Value: 19767,
+                    To: 17311,
+                  },
+                ],
+              },
+              {
+                Device: 'eth0',
+                CIDR: '',
+                IP: '12.228.2.247',
+                MBits: 10,
+                Mode: 'bridge',
+                ReservedPorts: [],
+                DynamicPorts: [],
+              },
+              {
+                Device: 'eth1',
+                CIDR: '',
+                IP: '71.92.163.164',
+                MBits: 10,
+                Mode: 'bridge',
+                ReservedPorts: [],
+                DynamicPorts: [],
+              },
+            ],
+            Ports: [
+              {
+                Label: 'pixel',
+                Value: 32161,
+                To: 25929,
+                HostIP: 'b778:a055:4422:e3ca:fd2d:e5e8:464d:8f2b',
+              },
+            ],
+          },
+          Resources: {
+            CPU: 2000,
+            MemoryMB: 1024,
+            MemoryMaxMB: 0,
+            DiskMB: 0,
+          },
+          Driver: 'qemu',
+          Name: 'task-microchip-3',
+          JobID: '',
+          VolumeMounts: [
+            {
+              Volume: 'mazie',
+              Destination: '/Vella.OReilly/dudley/#4b403a',
+              PropagationMode: '',
+              ReadOnly: true,
+            },
+            {
+              Volume: 'leora',
+              Destination: '/Tressa_Brown/ian/#6d666c',
+              PropagationMode: '',
+              ReadOnly: false,
+            },
+          ],
+          GroupNames: [],
+          WithServices: false,
+          CreateRecommendations: true,
+          ID: '4',
+          Services: [],
+        },
+      ],
+    },
+  ],
+  JobSummary: {
+    GroupNames: ['pixel-g-0', 'protocol-g-1'],
+    Summary: {
+      'pixel-g-0': {
+        Queued: 10,
+        Complete: 10,
+        Failed: 6,
+        Running: 7,
+        Starting: 4,
+        Lost: 8,
+        Unknown: 1,
+      },
+      'protocol-g-1': {
+        Queued: 4,
+        Complete: 7,
+        Failed: 2,
+        Running: 0,
+        Starting: 7,
+        Lost: 3,
+        Unknown: 5,
+      },
+    },
+    Namespace: 'namespace-1',
+    ID: '1',
+    JobID: 'hdd-panel-0',
+  },
+  Specification: {
+    Definition:
+      'job "docs" {\n  namespace = "madness"\n  group "example" {\n    task "server" {\n      service {\n        tags = ["leader", "mysql"]\n\n        port = "db"\n\n        meta {\n          meta = "for your service"\n        }\n\n        check {\n          type     = "tcp"\n          port     = "db"\n          interval = "10s"\n          timeout  = "2s"\n        }\n\n        check {\n          type     = "script"\n          name     = "check_table"\n          command  = "/usr/local/bin/check_mysql_table_status"\n          args     = ["--verbose"]\n          interval = "60s"\n          timeout  = "5s"\n\n          check_restart {\n            limit = 3\n            grace = "90s"\n            ignore_warnings = false\n          }\n        }\n      }\n    }\n  }\n}\n',
+    Type: 'hcl',
+    Variables: {
+      datacenters: ['west'],
+      external_port: 4000,
+    },
+  },
+};
 
 module('Acceptance | job definition', function (hooks) {
   setupApplicationTest(hooks);
@@ -123,5 +673,46 @@ module('Acceptance | job definition', function (hooks) {
       'Not Found',
       'Error message is for 404'
     );
+  });
+});
+
+module('display and edit using full specification', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupCodeMirror(hooks);
+
+  hooks.beforeEach(async function () {
+    server.create('node');
+    server.create('job');
+    job = server.db.jobs[0];
+  });
+
+  test('it allows users to toggle between full specification and JSON definition', async function (assert) {
+    assert.expect(5);
+    server.get('/job/:id', () => JOB_JSON);
+
+    await Definition.visit({ id: job.id });
+
+    assert
+      .dom('[data-test-toggle="job-spec"]')
+      .exists('A toggle button exists and defaults to full definition');
+    let codeMirror = getCodeMirrorInstance('[data-test-editor]');
+    assert.equal(
+      codeMirror.getValue(),
+      JOB_JSON.Specification.Definition,
+      'Shows the full definition as written by the user'
+    );
+    assert
+      .dom('[data-test-job-variables]')
+      .exists('A table showing job variables appears');
+
+    await click('[data-test-toggle-full]');
+    let code = { ...JOB_JSON };
+    delete code.Specification;
+    codeMirror = getCodeMirrorInstance('[data-test-editor]');
+    assert.propContains(codeMirror.getValue(), JSON.parse(code));
+    assert
+      .dom('[data-test-job-variables]')
+      .doesNotExist('A table showing job variables appears');
   });
 });

--- a/ui/tests/integration/components/job-editor-test.js
+++ b/ui/tests/integration/components/job-editor-test.js
@@ -127,8 +127,6 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
-    await click('[data-test-toggle-full]');
-    await click('[data-test-edit-job]');
 
     const cm = getCodeMirrorInstance(['data-test-editor']);
     cm.setValue(spec);
@@ -150,7 +148,6 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
-    await click('[data-test-edit-job]');
 
     await planJob(spec);
     const requests = this.server.pretender.handledRequests.mapBy('url');
@@ -176,7 +173,6 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
-    await click('[data-test-edit-job]');
 
     await planJob(spec);
     assert.ok(Editor.planOutput, 'The plan is outputted');
@@ -196,7 +192,6 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
-    await click('[data-test-edit-job]');
 
     await planJob(spec);
     await Editor.cancel();
@@ -218,7 +213,6 @@ module('Integration | Component | job-editor', function (hooks) {
     this.server.pretender.post('/v1/jobs/parse', () => [400, {}, errorMessage]);
 
     await renderNewJob(this, job);
-    await click('[data-test-edit-job]');
 
     await planJob(spec);
     assert
@@ -252,7 +246,6 @@ module('Integration | Component | job-editor', function (hooks) {
     ]);
 
     await renderNewJob(this, job);
-    await click('[data-test-edit-job]');
 
     await planJob(spec);
     assert
@@ -282,7 +275,6 @@ module('Integration | Component | job-editor', function (hooks) {
     this.server.pretender.post('/v1/jobs', () => [400, {}, errorMessage]);
 
     await renderNewJob(this, job);
-    await click('[data-test-edit-job]');
 
     await planJob(spec);
     await Editor.run();
@@ -311,8 +303,6 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
-    await click('[data-test-toggle-full]');
-    await click('[data-test-edit-job]');
 
     await planJob(spec);
     assert.ok(
@@ -338,7 +328,6 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
-    await click('[data-test-edit-job]');
 
     await planJob(spec);
     assert.ok(
@@ -380,7 +369,6 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
-    await click('[data-test-edit-job]');
 
     await planJob(spec);
     await Editor.run();
@@ -402,7 +390,6 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
-    await click('[data-test-edit-job]');
 
     await planJob(spec);
     await Editor.run();
@@ -437,7 +424,6 @@ module('Integration | Component | job-editor', function (hooks) {
 
     await renderEditJob(this, job);
     await click('[data-test-edit-job]');
-
     await Editor.cancelEditing();
     assert
       .dom('[data-test-job-spec-view]')

--- a/ui/tests/integration/components/job-editor-test.js
+++ b/ui/tests/integration/components/job-editor-test.js
@@ -1,6 +1,7 @@
 import { assign } from '@ember/polyfills';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
+import { click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { create } from 'ember-cli-page-object';
 import sinon from 'sinon';
@@ -77,7 +78,8 @@ module('Integration | Component | job-editor', function (hooks) {
     <JobEditor
       @job={{job}}
       @context={{context}}
-      @onSubmit={{onSubmit}} />
+      @onSubmit={{onSubmit}} 
+    />
   `;
 
   const cancelableTemplate = hbs`
@@ -86,7 +88,7 @@ module('Integration | Component | job-editor', function (hooks) {
       @context={{context}}
       @cancelable={{true}}
       @onSubmit={{onSubmit}}
-      @onCancel={{onCancel}} />
+    />
   `;
 
   const renderNewJob = async (component, job) => {
@@ -98,7 +100,6 @@ module('Integration | Component | job-editor', function (hooks) {
     component.setProperties({
       job,
       onSubmit: sinon.spy(),
-      onCancel: sinon.spy(),
       context: 'edit',
     });
     await component.render(cancelableTemplate);
@@ -116,7 +117,7 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
-    assert.ok(Editor.editor.isPresent, 'Editor is present');
+    assert.ok('[data-test-job-editor]', 'Editor is present');
 
     await componentA11yAudit(this.element, assert);
   });
@@ -126,8 +127,13 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
-    await planJob(spec);
-    console.log('wait');
+    await click('[data-test-toggle-full]');
+    await click('[data-test-edit-job]');
+
+    const cm = getCodeMirrorInstance(['data-test-editor']);
+    cm.setValue(spec);
+    await Editor.plan();
+
     const requests = this.server.pretender.handledRequests.mapBy('url');
     assert.notOk(
       requests.includes('/v1/jobs/parse'),
@@ -144,6 +150,8 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
+    await click('[data-test-edit-job]');
+
     await planJob(spec);
     const requests = this.server.pretender.handledRequests.mapBy('url');
     assert.ok(
@@ -168,13 +176,17 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
+    await click('[data-test-edit-job]');
+
     await planJob(spec);
     assert.ok(Editor.planOutput, 'The plan is outputted');
     assert.notOk(
       Editor.editor.isPresent,
       'The editor is replaced with the plan output'
     );
-    assert.ok(Editor.planHelp.isPresent, 'The plan explanation popup is shown');
+    assert
+      .dom('[data-test-plan-help-title]')
+      .exists('The plan explanation popup is shown');
 
     await componentA11yAudit(this.element, assert);
   });
@@ -184,6 +196,8 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
+    await click('[data-test-edit-job]');
+
     await planJob(spec);
     await Editor.cancel();
     assert.ok(Editor.editor.isPresent, 'The editor is shown again');
@@ -204,6 +218,8 @@ module('Integration | Component | job-editor', function (hooks) {
     this.server.pretender.post('/v1/jobs/parse', () => [400, {}, errorMessage]);
 
     await renderNewJob(this, job);
+    await click('[data-test-edit-job]');
+
     await planJob(spec);
     assert
       .dom('[data-test-error="plan"]')
@@ -236,6 +252,8 @@ module('Integration | Component | job-editor', function (hooks) {
     ]);
 
     await renderNewJob(this, job);
+    await click('[data-test-edit-job]');
+
     await planJob(spec);
     assert
       .dom('[data-test-error="parse"]')
@@ -264,8 +282,11 @@ module('Integration | Component | job-editor', function (hooks) {
     this.server.pretender.post('/v1/jobs', () => [400, {}, errorMessage]);
 
     await renderNewJob(this, job);
+    await click('[data-test-edit-job]');
+
     await planJob(spec);
     await Editor.run();
+
     assert
       .dom('[data-test-error="plan"]')
       .doesNotExist('Plan error is not shown');
@@ -273,7 +294,7 @@ module('Integration | Component | job-editor', function (hooks) {
       .dom('[data-test-error="parse"]')
       .doesNotExist('Parse error is not shown');
 
-    assert.ok(Editor.runError.isPresent, 'Run error is shown');
+    assert.dom('[data-test-error="run"]').exists('Run error is shown');
     assert.equal(
       Editor.runError.message,
       errorMessage,
@@ -290,6 +311,9 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
+    await click('[data-test-toggle-full]');
+    await click('[data-test-edit-job]');
+
     await planJob(spec);
     assert.ok(
       Editor.dryRunMessage.errored,
@@ -314,6 +338,8 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
+    await click('[data-test-edit-job]');
+
     await planJob(spec);
     assert.ok(
       Editor.dryRunMessage.succeeded,
@@ -332,6 +358,8 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderEditJob(this, job);
+    await click('[data-test-edit-job]');
+
     await planJob(spec);
     await Editor.run();
     const requests = this.server.pretender.handledRequests
@@ -352,6 +380,8 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
+    await click('[data-test-edit-job]');
+
     await planJob(spec);
     await Editor.run();
     const requests = this.server.pretender.handledRequests
@@ -372,6 +402,8 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderNewJob(this, job);
+    await click('[data-test-edit-job]');
+
     await planJob(spec);
     await Editor.run();
     assert.ok(
@@ -393,6 +425,8 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderEditJob(this, job);
+    await click('[data-test-edit-job]');
+
     assert.ok(Editor.cancelEditingIsAvailable, 'Cancel editing button exists');
 
     await componentA11yAudit(this.element, assert);
@@ -402,7 +436,11 @@ module('Integration | Component | job-editor', function (hooks) {
     const job = await this.store.createRecord('job');
 
     await renderEditJob(this, job);
+    await click('[data-test-edit-job]');
+
     await Editor.cancelEditing();
-    assert.ok(this.onCancel.calledOnce, 'The onCancel hook was called');
+    assert
+      .dom('[data-test-job-spec-view]')
+      .exists('We reset state to be in read only mode after hitting cancel.');
   });
 });


### PR DESCRIPTION
Closes #16269 for creating a Toggle Button to display both the Job Specification and Full Definition.

**Functional Changes**
This PR adds a toggle button when the `JobEditor` component is in a read-only state. 

**Refactoring**
This PR refactors the JobEditor component to improve its flexibility and maintainability. The original code tightly coupled the component's state with its rendering logic, which made it difficult to modify and extend. This PR introduces several improvements to make the code more modular and easier to understand.

**Changes**
- Uses Ember's `component helper` to dynamically render the appropriate child component based on the value of the stage property.
- Reorganizes the code to separate the component state from the rendering logic, which makes the component more modular and easier to test.