### PR TITLE
client: don't emit task shutdown delay event if not waiting

### DIFF
--- a/.changelog/16281.txt
+++ b/.changelog/16281.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Don't emit shutdown delay task event when the shutdown operation is configured to skip the delay
+```

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -1108,6 +1108,16 @@ func TestTaskRunner_NoShutdownDelay(t *testing.T) {
 
 	err := <-killed
 	require.NoError(t, err, "killing task returned unexpected error")
+
+	// Check that we only emit the expected events.
+	hasEvent := false
+	for _, ev := range tr.state.Events {
+		require.NotEqual(t, structs.TaskWaitingShuttingDownDelay, ev.Type)
+		if ev.Type == structs.TaskSkippingShutdownDelay {
+			hasEvent = true
+		}
+	}
+	require.True(t, hasEvent)
 }
 
 // TestTaskRunner_Dispatch_Payload asserts that a dispatch job runs and the

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -1107,17 +1107,17 @@ func TestTaskRunner_NoShutdownDelay(t *testing.T) {
 	}
 
 	err := <-killed
-	require.NoError(t, err, "killing task returned unexpected error")
+	must.NoError(t, err)
 
 	// Check that we only emit the expected events.
 	hasEvent := false
 	for _, ev := range tr.state.Events {
-		require.NotEqual(t, structs.TaskWaitingShuttingDownDelay, ev.Type)
+		must.NotEq(t, structs.TaskWaitingShuttingDownDelay, ev.Type)
 		if ev.Type == structs.TaskSkippingShutdownDelay {
 			hasEvent = true
 		}
 	}
-	require.True(t, hasEvent)
+	must.True(t, hasEvent)
 }
 
 // TestTaskRunner_Dispatch_Payload asserts that a dispatch job runs and the

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8348,6 +8348,10 @@ const (
 	// TaskWaitingShuttingDownDelay indicates that the task is waiting for
 	// shutdown delay before being TaskKilled
 	TaskWaitingShuttingDownDelay = "Waiting for shutdown delay"
+
+	// TaskSkippingShutdownDelay indicates that the task operation was
+	// configured to ignore the shutdown delay value set for the tas.
+	TaskSkippingShutdownDelay = "Skipping shutdown delay"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/14775 introduced a new task event when the task runner is waiting for the `shutdown_delay`, but some requests can be configured to [ignore the `shutdown_delay`](https://developer.hashicorp.com/nomad/docs/commands/alloc/stop#no-shutdown-delay), in which case it can confusing to have this event, so emit one that notes the delay is being skipped instead.

~No changelog or backports necessary since #14775 has not being released yet.~

I just realized that I should've merged this for 1.5.0 🤦 

Not big deal, but I added a changelog entry now.