### PR TITLE
docs: fix alloc stop `no_shutdown_delay`

### DIFF
--- a/command/alloc_stop.go
+++ b/command/alloc_stop.go
@@ -39,7 +39,7 @@ Stop Specific Options:
     eval-status command.
 
   -no-shutdown-delay
-	Ignore the the group and task shutdown_delay configuration so there is no
+    Ignore the the group and task shutdown_delay configuration so there is no
     delay between service deregistration and task shutdown. Note that using
     this flag will result in failed network connections to the allocation
     being stopped.

--- a/website/content/api-docs/allocations.mdx
+++ b/website/content/api-docs/allocations.mdx
@@ -647,6 +647,11 @@ The table below shows this endpoint's support for
   must be the full UUID, not the short 8-character one. This is specified as
   part of the path.
 
+- `no_shutdown_delay` `(bool: false)` - Ignore the group and task
+  [`shutdown_delay`] configuration so that there is no delay between service
+  deregistration and task shutdown. Note that using this parameter will result
+  in failed network connections to the allocation being stopped.
+
 ### Sample Request
 
 ```shell-session
@@ -905,3 +910,5 @@ $ curl \
   }
 ]
 ```
+
+[`shutdown_delay`]: /nomad/docs/job-specification/group#shutdown_delay


### PR DESCRIPTION
Document and remove the tab from CLI help output.