### PR TITLE
handle `FSM.Apply` errors in `raftApply`

### DIFF
--- a/.changelog/16287.txt
+++ b/.changelog/16287.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+server: Fixed a bug where deregistering a job that was already garbage collected would create a new evaluation
+```
+
+```release-note:bug
+server: Fixed a bug where the `system reconcile summaries` command and API would not return any scheduler-related errors
+```
+
+```release-note:bug
+server: Fixed a bug where node updates that produced errors from service discovery or CSI plugin updates were not logged
+```

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -1554,7 +1554,7 @@ func TestJobs_Deregister(t *testing.T) {
 	must.NoError(t, err)
 	assertWriteMeta(t, wm)
 
-	// Attempting delete on non-existing job returns an error
+	// Attempting delete on non-existing job does not return an error
 	_, _, err = jobs.Deregister("nope", false, nil)
 	must.NoError(t, err)
 

--- a/api/nodes_test.go
+++ b/api/nodes_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func queryNodeList(t *testing.T, nodes *Nodes) ([]*NodeListStub, *QueryMeta) {
+	t.Helper()
 	var (
 		nodeListStub []*NodeListStub
 		queryMeta    *QueryMeta

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -1342,13 +1342,8 @@ func (a *ACL) UpsertRoles(
 	}
 
 	// Update via Raft.
-	out, index, err := a.srv.raftApply(structs.ACLRolesUpsertRequestType, args)
+	_, index, err := a.srv.raftApply(structs.ACLRolesUpsertRequestType, args)
 	if err != nil {
-		return err
-	}
-
-	// Check if the FSM response, which is an interface, contains an error.
-	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
 
@@ -1413,13 +1408,8 @@ func (a *ACL) DeleteRolesByID(
 	}
 
 	// Update via Raft.
-	out, index, err := a.srv.raftApply(structs.ACLRolesDeleteByIDRequestType, args)
+	_, index, err := a.srv.raftApply(structs.ACLRolesDeleteByIDRequestType, args)
 	if err != nil {
-		return err
-	}
-
-	// Check if the FSM response, which is an interface, contains an error.
-	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
 
@@ -1899,13 +1889,8 @@ func (a *ACL) UpsertAuthMethods(
 	}
 
 	// Update via Raft
-	out, index, err := a.srv.raftApply(structs.ACLAuthMethodsUpsertRequestType, args)
+	_, index, err := a.srv.raftApply(structs.ACLAuthMethodsUpsertRequestType, args)
 	if err != nil {
-		return err
-	}
-
-	// Check if the FSM response, which is an interface, contains an error.
-	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
 
@@ -1972,13 +1957,8 @@ func (a *ACL) DeleteAuthMethods(
 	}
 
 	// Update via Raft
-	out, index, err := a.srv.raftApply(structs.ACLAuthMethodsDeleteRequestType, args)
+	_, index, err := a.srv.raftApply(structs.ACLAuthMethodsDeleteRequestType, args)
 	if err != nil {
-		return err
-	}
-
-	// Check if the FSM response, which is an interface, contains an error.
-	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
 
@@ -2278,13 +2258,8 @@ func (a *ACL) UpsertBindingRules(
 	}
 
 	// Update via Raft.
-	out, index, err := a.srv.raftApply(structs.ACLBindingRulesUpsertRequestType, args)
+	_, index, err := a.srv.raftApply(structs.ACLBindingRulesUpsertRequestType, args)
 	if err != nil {
-		return err
-	}
-
-	// Check if the FSM response, which is an interface, contains an error.
-	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
 
@@ -2353,13 +2328,8 @@ func (a *ACL) DeleteBindingRules(
 	}
 
 	// Update via Raft.
-	out, index, err := a.srv.raftApply(structs.ACLBindingRulesDeleteRequestType, args)
+	_, index, err := a.srv.raftApply(structs.ACLBindingRulesDeleteRequestType, args)
 	if err != nil {
-		return err
-	}
-
-	// Check if the FSM response, which is an interface, contains an error.
-	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
 

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -354,13 +354,10 @@ func (v *CSIVolume) Register(args *structs.CSIVolumeRegisterRequest, reply *stru
 		}
 	}
 
-	resp, index, err := v.srv.raftApply(structs.CSIVolumeRegisterRequestType, args)
+	_, index, err := v.srv.raftApply(structs.CSIVolumeRegisterRequestType, args)
 	if err != nil {
 		v.logger.Error("csi raft apply failed", "error", err, "method", "register")
 		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
 	}
 
 	reply.Index = index
@@ -397,13 +394,10 @@ func (v *CSIVolume) Deregister(args *structs.CSIVolumeDeregisterRequest, reply *
 		return fmt.Errorf("missing volume IDs")
 	}
 
-	resp, index, err := v.srv.raftApply(structs.CSIVolumeDeregisterRequestType, args)
+	_, index, err := v.srv.raftApply(structs.CSIVolumeDeregisterRequestType, args)
 	if err != nil {
 		v.logger.Error("csi raft apply failed", "error", err, "method", "deregister")
 		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
 	}
 
 	reply.Index = index
@@ -458,13 +452,10 @@ func (v *CSIVolume) Claim(args *structs.CSIVolumeClaimRequest, reply *structs.CS
 		args.NodeID = alloc.NodeID
 	}
 
-	resp, index, err := v.srv.raftApply(structs.CSIVolumeClaimRequestType, args)
+	_, index, err := v.srv.raftApply(structs.CSIVolumeClaimRequestType, args)
 	if err != nil {
 		v.logger.Error("csi raft apply failed", "error", err, "method", "claim")
 		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
 	}
 
 	if isNewClaim {
@@ -931,13 +922,10 @@ func (v *CSIVolume) checkpointClaim(vol *structs.CSIVolume, claim *structs.CSIVo
 			Namespace: vol.Namespace,
 		},
 	}
-	resp, index, err := v.srv.raftApply(structs.CSIVolumeClaimRequestType, req)
+	_, index, err := v.srv.raftApply(structs.CSIVolumeClaimRequestType, req)
 	if err != nil {
 		v.logger.Error("csi raft apply failed", "error", err)
 		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
 	}
 	vol.ModifyIndex = index
 	return nil
@@ -1023,13 +1011,10 @@ func (v *CSIVolume) Create(args *structs.CSIVolumeCreateRequest, reply *structs.
 		}
 	}
 
-	resp, index, err := v.srv.raftApply(structs.CSIVolumeRegisterRequestType, regArgs)
+	_, index, err := v.srv.raftApply(structs.CSIVolumeRegisterRequestType, regArgs)
 	if err != nil {
 		v.logger.Error("csi raft apply failed", "error", err, "method", "register")
-		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		multierror.Append(&mErr, respErr)
+		multierror.Append(&mErr, err)
 	}
 
 	err = mErr.ErrorOrNil()
@@ -1123,13 +1108,10 @@ func (v *CSIVolume) Delete(args *structs.CSIVolumeDeleteRequest, reply *structs.
 		VolumeIDs:    args.VolumeIDs,
 		WriteRequest: args.WriteRequest,
 	}
-	resp, index, err := v.srv.raftApply(structs.CSIVolumeDeregisterRequestType, deregArgs)
+	_, index, err := v.srv.raftApply(structs.CSIVolumeDeregisterRequestType, deregArgs)
 	if err != nil {
 		v.logger.Error("csi raft apply failed", "error", err, "method", "deregister")
 		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
 	}
 
 	reply.Index = index
@@ -1611,14 +1593,10 @@ func (v *CSIPlugin) Delete(args *structs.CSIPluginDeleteRequest, reply *structs.
 		return fmt.Errorf("missing plugin ID")
 	}
 
-	resp, index, err := v.srv.raftApply(structs.CSIPluginDeleteRequestType, args)
+	_, index, err := v.srv.raftApply(structs.CSIPluginDeleteRequestType, args)
 	if err != nil {
 		v.logger.Error("csi raft apply failed", "error", err, "method", "delete")
 		return err
-	}
-
-	if respErr, ok := resp.(error); ok {
-		return respErr
 	}
 
 	reply.Index = index

--- a/nomad/drainer_shims.go
+++ b/nomad/drainer_shims.go
@@ -28,8 +28,8 @@ func (d drainerShim) NodesDrainComplete(nodes []string, event *structs.NodeEvent
 		}
 	}
 
-	resp, index, err := d.s.raftApply(structs.BatchNodeUpdateDrainRequestType, args)
-	return d.convertApplyErrors(resp, index, err)
+	_, index, err := d.s.raftApply(structs.BatchNodeUpdateDrainRequestType, args)
+	return index, err
 }
 
 func (d drainerShim) AllocUpdateDesiredTransition(allocs map[string]*structs.DesiredTransition, evals []*structs.Evaluation) (uint64, error) {
@@ -38,19 +38,6 @@ func (d drainerShim) AllocUpdateDesiredTransition(allocs map[string]*structs.Des
 		Evals:        evals,
 		WriteRequest: structs.WriteRequest{Region: d.s.config.Region},
 	}
-	resp, index, err := d.s.raftApply(structs.AllocUpdateDesiredTransitionRequestType, args)
-	return d.convertApplyErrors(resp, index, err)
-}
-
-// convertApplyErrors parses the results of a raftApply and returns the index at
-// which it was applied and any error that occurred. Raft Apply returns two
-// separate errors, Raft library errors and user returned errors from the FSM.
-// This helper, joins the errors by inspecting the applyResponse for an error.
-func (d drainerShim) convertApplyErrors(applyResp interface{}, index uint64, err error) (uint64, error) {
-	if applyResp != nil {
-		if fsmErr, ok := applyResp.(error); ok && fsmErr != nil {
-			return index, fsmErr
-		}
-	}
+	_, index, err := d.s.raftApply(structs.AllocUpdateDesiredTransitionRequestType, args)
 	return index, err
 }

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -846,6 +846,9 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 	if err != nil {
 		return err
 	}
+	if job == nil {
+		return nil
+	}
 
 	var eval *structs.Evaluation
 
@@ -854,7 +857,7 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 	now := time.Now().UnixNano()
 
 	// If the job is periodic or parameterized, we don't create an eval.
-	if job == nil || !(job.IsPeriodic() || job.IsParameterized()) {
+	if !(job.IsPeriodic() || job.IsParameterized()) {
 
 		// The evaluation priority is determined by several factors. It
 		// defaults to the job default priority and is overridden by the
@@ -863,7 +866,7 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 		// If the user supplied an eval priority override, we subsequently
 		// use this.
 		priority := structs.JobDefaultPriority
-		if job != nil {
+		if job.Priority > 0 {
 			priority = job.Priority
 		}
 		if args.EvalPriority > 0 {

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -376,13 +376,9 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 		args.Deployment = j.multiregionCreateDeployment(job, eval)
 
 		// Commit this update via Raft
-		fsmErr, index, err := j.srv.raftApply(structs.JobRegisterRequestType, args)
-		if err, ok := fsmErr.(error); ok && err != nil {
-			j.logger.Error("registering job failed", "error", err, "fsm", true)
-			return err
-		}
+		_, index, err := j.srv.raftApply(structs.JobRegisterRequestType, args)
 		if err != nil {
-			j.logger.Error("registering job failed", "error", err, "raft", true)
+			j.logger.Error("registering job failed", "error", err)
 			return err
 		}
 
@@ -2027,13 +2023,9 @@ func (j *Job) Dispatch(args *structs.JobDispatchRequest, reply *structs.JobDispa
 	}
 
 	// Commit this update via Raft
-	fsmErr, jobCreateIndex, err := j.srv.raftApply(structs.JobRegisterRequestType, regReq)
-	if err, ok := fsmErr.(error); ok && err != nil {
-		j.logger.Error("dispatched job register failed", "error", err, "fsm", true)
-		return err
-	}
+	_, jobCreateIndex, err := j.srv.raftApply(structs.JobRegisterRequestType, regReq)
 	if err != nil {
-		j.logger.Error("dispatched job register failed", "error", err, "raft", true)
+		j.logger.Error("dispatched job register failed", "error")
 		return err
 	}
 

--- a/nomad/keyring_endpoint.go
+++ b/nomad/keyring_endpoint.go
@@ -69,11 +69,8 @@ func (k *Keyring) Rotate(args *structs.KeyringRotateRootKeyRequest, reply *struc
 		Rekey:        args.Full,
 		WriteRequest: args.WriteRequest,
 	}
-	out, index, err := k.srv.raftApply(structs.RootKeyMetaUpsertRequestType, req)
+	_, index, err := k.srv.raftApply(structs.RootKeyMetaUpsertRequestType, req)
 	if err != nil {
-		return err
-	}
-	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
 	reply.Key = rootKey.Meta
@@ -197,11 +194,8 @@ func (k *Keyring) Update(args *structs.KeyringUpdateRootKeyRequest, reply *struc
 	}
 
 	// update the metadata via Raft
-	out, index, err := k.srv.raftApply(structs.RootKeyMetaUpsertRequestType, metaReq)
+	_, index, err := k.srv.raftApply(structs.RootKeyMetaUpsertRequestType, metaReq)
 	if err != nil {
-		return err
-	}
-	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
 
@@ -352,11 +346,8 @@ func (k *Keyring) Delete(args *structs.KeyringDeleteRootKeyRequest, reply *struc
 	}
 
 	// update via Raft
-	out, index, err := k.srv.raftApply(structs.RootKeyMetaDeleteRequestType, args)
+	_, index, err := k.srv.raftApply(structs.RootKeyMetaDeleteRequestType, args)
 	if err != nil {
-		return err
-	}
-	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
 

--- a/nomad/namespace_endpoint.go
+++ b/nomad/namespace_endpoint.go
@@ -60,13 +60,8 @@ func (n *Namespace) UpsertNamespaces(args *structs.NamespaceUpsertRequest,
 	}
 
 	// Update via Raft
-	out, index, err := n.srv.raftApply(structs.NamespaceUpsertRequestType, args)
+	_, index, err := n.srv.raftApply(structs.NamespaceUpsertRequestType, args)
 	if err != nil {
-		return err
-	}
-
-	// Check if there was an error when applying.
-	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
 
@@ -124,13 +119,8 @@ func (n *Namespace) DeleteNamespaces(args *structs.NamespaceDeleteRequest, reply
 	}
 
 	// Update via Raft
-	out, index, err := n.srv.raftApply(structs.NamespaceDeleteRequestType, args)
+	_, index, err := n.srv.raftApply(structs.NamespaceDeleteRequestType, args)
 	if err != nil {
-		return err
-	}
-
-	// Check if there was an error when applying.
-	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
 

--- a/nomad/operator_endpoint.go
+++ b/nomad/operator_endpoint.go
@@ -292,9 +292,6 @@ func (op *Operator) AutopilotSetConfiguration(args *structs.AutopilotSetConfigRe
 		op.logger.Error("failed applying AutoPilot configuration", "error", err)
 		return err
 	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
 
 	// Check if the return type is a bool.
 	if respBool, ok := resp.(bool); ok {
@@ -371,9 +368,8 @@ func (op *Operator) SchedulerSetConfiguration(args *structs.SchedulerSetConfigRe
 	if err != nil {
 		op.logger.Error("failed applying Scheduler configuration", "error", err)
 		return err
-	} else if respErr, ok := resp.(error); ok {
-		return respErr
 	}
+
 	//  If CAS request, raft returns a boolean indicating if the update was applied.
 	// Otherwise, assume success
 	reply.Updated = true

--- a/nomad/periodic.go
+++ b/nomad/periodic.go
@@ -68,10 +68,7 @@ func (s *Server) DispatchJob(job *structs.Job) (*structs.Evaluation, error) {
 			Namespace: job.Namespace,
 		},
 	}
-	fsmErr, index, err := s.raftApply(structs.JobRegisterRequestType, req)
-	if err, ok := fsmErr.(error); ok && err != nil {
-		return nil, err
-	}
+	_, index, err := s.raftApply(structs.JobRegisterRequestType, req)
 	if err != nil {
 		return nil, err
 	}

--- a/nomad/service_registration_endpoint.go
+++ b/nomad/service_registration_endpoint.go
@@ -86,13 +86,8 @@ func (s *ServiceRegistration) Upsert(
 	}
 
 	// Update via Raft.
-	out, index, err := s.srv.raftApply(structs.ServiceRegistrationUpsertRequestType, args)
+	_, index, err := s.srv.raftApply(structs.ServiceRegistrationUpsertRequestType, args)
 	if err != nil {
-		return err
-	}
-
-	// Check if the FSM response, which is an interface, contains an error.
-	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
 
@@ -164,13 +159,8 @@ func (s *ServiceRegistration) DeleteByID(
 	}
 
 	// Update via Raft.
-	out, index, err := s.srv.raftApply(structs.ServiceRegistrationDeleteByIDRequestType, args)
+	_, index, err := s.srv.raftApply(structs.ServiceRegistrationDeleteByIDRequestType, args)
 	if err != nil {
-		return err
-	}
-
-	// Check if the FSM response, which is an interface, contains an error.
-	if err, ok := out.(error); ok && err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The signature of the `raftApply` function requires that the caller unwrap the first returned value (the response from `FSM.Apply`) to see if it's an error. This puts the burden on the caller to remember to check two different places for errors, and we've done so inconsistently.

Update `raftApply` to do the unwrapping for us and return any `FSM.Apply` error as the error value. Similar work was done in Consul in https://github.com/hashicorp/consul/pull/9991. This eliminates some boilerplate and surfaces a few minor bugs in the process:

* job deregistrations of already-GC'd jobs were still emitting evals
* reconcile job summaries does not return scheduler errors
* node updates did not report errors associated with inconsistent service discovery or CSI plugin states

Note that although _most_ of the `FSM.Apply` functions return only errors (which makes it tempting to remove the first return value entirely), there are few that return `bool` for some reason and Variables relies on the response value for proper CAS checking.