### PR TITLE
docs: fix typos in task-api.mdx and workload-identity.mdx

### DIFF
--- a/website/content/api-docs/task-api.mdx
+++ b/website/content/api-docs/task-api.mdx
@@ -12,7 +12,7 @@ Nomad's Task API provides every task managed by Nomad with a Unix Domain Socket
 the Task API does *not* require [mTLS][], but *always* requires authentication.
 See below for details.
 
-The Unix Domain Socket is located at `${SECRETS_DIR}/api.sock`.
+The Unix Domain Socket is located at `${NOMAD_SECRETS_DIR}/api.sock`.
 
 ## Rationale
 

--- a/website/content/docs/concepts/workload-identity.mdx
+++ b/website/content/docs/concepts/workload-identity.mdx
@@ -36,7 +36,7 @@ task "example" {
     # Expose Workload Identity in NOMAD_TOKEN env var
     env = true
 
-    # Expose Workload Identity in ${SECRETS_DIR}/nomad_token file
+    # Expose Workload Identity in ${NOMAD_SECRETS_DIR}/nomad_token file
     file = true
   }
 


### PR DESCRIPTION
According to [envvars.mdx](https://github.com/hashicorp/nomad/blob/f89910d4650c47006838a7b6de17cbacdc62fe1c/website/content/partials/envvars.mdx), I don't think there is a `SECRETS_DIR` environment variable here, it should be `NOMAD_SECRETS_DIR`.