### PR TITLE
service: fix regression in task access to list/read endpoint

### DIFF
--- a/.changelog/16316.txt
+++ b/.changelog/16316.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+service: Fixed a bug where attaching a policy to a job would prevent workload identities for the job from reading the service registration API
+```

--- a/nomad/service_registration_endpoint.go
+++ b/nomad/service_registration_endpoint.go
@@ -217,7 +217,8 @@ func (s *ServiceRegistration) List(
 	if err != nil {
 		return structs.ErrPermissionDenied
 	}
-	if !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJob) {
+	if args.GetIdentity().Claims == nil &&
+		!aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJob) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -381,7 +382,8 @@ func (s *ServiceRegistration) GetService(
 	if err != nil {
 		return structs.ErrPermissionDenied
 	}
-	if !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJob) {
+	if args.GetIdentity().Claims == nil &&
+		!aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJob) {
 		return structs.ErrPermissionDenied
 	}
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/16276

When native service discovery was added, we used the node secret as the auth token. Once Workload Identity was added in Nomad 1.4.x we needed to use the claim token for `template` blocks, and so we allowed valid claims to bypass the ACL policy check to preserve the existing behavior. (Invalid claims are still rejected, so this didn't widen any security boundary.)

In reworking authentication for 1.5.0, we unintentionally removed this bypass. For WIs without a policy attached to their job, everything works as expected because the resulting `acl.ACL` is nil. But once a policy is attached to the job the `acl.ACL` is no longer nil and this causes permissions errors.

Fix the regression by adding back the bypass for valid claims. In future work, we should strongly consider getting turning the implicit policies into real `ACLPolicy` objects (even if not stored in state) so that we don't have these kind of brittle exceptions to the auth code.