### PR TITLE
api: set last index and request time on alloc stop

### DIFF
--- a/.changelog/16319.txt
+++ b/.changelog/16319.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fix `Allocations().Stop()` method to properly set the request `LastIndex` and `RequestTime` in the response
+```

--- a/.changelog/16319.txt
+++ b/.changelog/16319.txt
@@ -1,3 +1,11 @@
 ```release-note:bug
 api: Fix `Allocations().Stop()` method to properly set the request `LastIndex` and `RequestTime` in the response
 ```
+
+```release-note:deprecation
+api: The `Restart()`, `Stop()`, and `Signal()` methods in the `Allocations` struct will have their signatures modified in Nomad 1.6.0
+```
+
+```release-note:deprecation
+api: The `RestartAllTasks()` method in the `Allocations` struct will be removed in Nomad 1.6.0
+```

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -148,6 +148,9 @@ func (a *Allocations) GC(alloc *Allocation, q *QueryOptions) error {
 // Note: for cluster topologies where API consumers don't have network access to
 // Nomad clients, set api.ClientConnTimeout to a small value (ex 1ms) to avoid
 // long pauses on this API call.
+//
+// BREAKING: This method will have the following signature in 1.6.0
+// func (a *Allocations) Restart(allocID string, taskName string, w *WriteOptions) (*WriteMeta, error) {
 func (a *Allocations) Restart(alloc *Allocation, taskName string, q *QueryOptions) error {
 	req := AllocationRestartRequest{
 		TaskName: taskName,
@@ -164,6 +167,9 @@ func (a *Allocations) Restart(alloc *Allocation, taskName string, q *QueryOption
 // Note: for cluster topologies where API consumers don't have network access to
 // Nomad clients, set api.ClientConnTimeout to a small value (ex 1ms) to avoid
 // long pauses on this API call.
+//
+// BREAKING: This method will have the following signature in 1.6.0
+// func (a *Allocations) RestartAllTasks(allocID string, w *WriteOptions) (*WriteMeta, error) {
 func (a *Allocations) RestartAllTasks(alloc *Allocation, q *QueryOptions) error {
 	req := AllocationRestartRequest{
 		AllTasks: true,
@@ -179,9 +185,27 @@ func (a *Allocations) RestartAllTasks(alloc *Allocation, q *QueryOptions) error 
 // Note: for cluster topologies where API consumers don't have network access to
 // Nomad clients, set api.ClientConnTimeout to a small value (ex 1ms) to avoid
 // long pauses on this API call.
+//
+// BREAKING: This method will have the following signature in 1.6.0
+// func (a *Allocations) Stop(allocID string, w *WriteOptions) (*AllocStopResponse, error) {
 func (a *Allocations) Stop(alloc *Allocation, q *QueryOptions) (*AllocStopResponse, error) {
+	// COMPAT: Remove in 1.6.0
+	var w *WriteOptions
+	if q != nil {
+		w = &WriteOptions{
+			Region:    q.Region,
+			Namespace: q.Namespace,
+			AuthToken: q.AuthToken,
+			Headers:   q.Headers,
+			ctx:       q.ctx,
+		}
+	}
+
 	var resp AllocStopResponse
-	_, err := a.client.putQuery("/v1/allocation/"+alloc.ID+"/stop", nil, &resp, q)
+	wm, err := a.client.put("/v1/allocation/"+alloc.ID+"/stop", nil, &resp, w)
+	resp.LastIndex = wm.LastIndex
+	resp.RequestTime = wm.RequestTime
+
 	return &resp, err
 }
 
@@ -198,6 +222,9 @@ type AllocStopResponse struct {
 // Note: for cluster topologies where API consumers don't have network access to
 // Nomad clients, set api.ClientConnTimeout to a small value (ex 1ms) to avoid
 // long pauses on this API call.
+//
+// BREAKING: This method will have the following signature in 1.6.0
+// func (a *Allocations) Signal(allocID string, task string, signal string, w *WriteOptions) (*WriteMeta, error) {
 func (a *Allocations) Signal(alloc *Allocation, q *QueryOptions, task, signal string) error {
 	req := AllocSignalRequest{
 		Signal: signal,

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -150,7 +150,7 @@ func (a *Allocations) GC(alloc *Allocation, q *QueryOptions) error {
 // long pauses on this API call.
 //
 // BREAKING: This method will have the following signature in 1.6.0
-// func (a *Allocations) Restart(allocID string, taskName string, w *WriteOptions) (*WriteMeta, error) {
+// func (a *Allocations) Restart(allocID string, taskName string, allTasks bool, w *WriteOptions) (*WriteMeta, error) {
 func (a *Allocations) Restart(alloc *Allocation, taskName string, q *QueryOptions) error {
 	req := AllocationRestartRequest{
 		TaskName: taskName,
@@ -168,8 +168,7 @@ func (a *Allocations) Restart(alloc *Allocation, taskName string, q *QueryOption
 // Nomad clients, set api.ClientConnTimeout to a small value (ex 1ms) to avoid
 // long pauses on this API call.
 //
-// BREAKING: This method will have the following signature in 1.6.0
-// func (a *Allocations) RestartAllTasks(allocID string, w *WriteOptions) (*WriteMeta, error) {
+// DEPRECATED: This method will be removed in 1.6.0
 func (a *Allocations) RestartAllTasks(alloc *Allocation, q *QueryOptions) error {
 	req := AllocationRestartRequest{
 		AllTasks: true,

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -203,8 +203,10 @@ func (a *Allocations) Stop(alloc *Allocation, q *QueryOptions) (*AllocStopRespon
 
 	var resp AllocStopResponse
 	wm, err := a.client.put("/v1/allocation/"+alloc.ID+"/stop", nil, &resp, w)
-	resp.LastIndex = wm.LastIndex
-	resp.RequestTime = wm.RequestTime
+	if wm != nil {
+		resp.LastIndex = wm.LastIndex
+		resp.RequestTime = wm.RequestTime
+	}
 
 	return &resp, err
 }

--- a/api/allocations_test.go
+++ b/api/allocations_test.go
@@ -290,17 +290,20 @@ func TestAllocations_Stop(t *testing.T) {
 	_, wm, err := c.Jobs().Register(job, nil)
 	must.NoError(t, err)
 
+	// List allocations.
 	stubs, qm, err := a.List(&QueryOptions{WaitIndex: wm.LastIndex})
 	must.NoError(t, err)
 	must.SliceLen(t, 1, stubs)
 
-	alloc, qm, err := a.Info(stubs[0].ID, &QueryOptions{WaitIndex: qm.LastIndex})
-	must.NoError(t, err)
-
-	resp, err := a.Stop(alloc, &QueryOptions{WaitIndex: qm.LastIndex})
+	// Stop the first allocation.
+	resp, err := a.Stop(&Allocation{ID: stubs[0].ID}, &QueryOptions{WaitIndex: qm.LastIndex})
 	must.NoError(t, err)
 	test.UUIDv4(t, resp.EvalID)
 	test.NonZero(t, resp.LastIndex)
+
+	// Stop allocation that doesn't exist.
+	resp, err = a.Stop(&Allocation{ID: "invalid"}, &QueryOptions{WaitIndex: qm.LastIndex})
+	must.Error(t, err)
 }
 
 // TestAllocations_ExecErrors ensures errors are properly formatted


### PR DESCRIPTION
Some of the methods in `Allocations()` incorrectly use the `putQuery` in API calls where `put` is more appropriate since they are not reading information back. These methods are also not returning request metadata such as `LastIndex` back to callers, which can be useful to have in some scenarios.

They also provide poor developer experience as they take an `*api.Allocation` struct when only the allocation ID is necessary. This can lead consumers to make unnecessary API calls to fetch the full allocation.

Fixing these problems require updating the methods' signatures so they take `*WriteOptions` instead of `*QueryOptions` and return `*WriteMeta`, but this is a breaking change that requires advanced notice to consumers.

This commit adds a future breaking change notice and also fixes the `Stop` method so it properly returns request metadata in a backwards compatible way.