### PR TITLE
feat: add JSON output to server members command

### DIFF
--- a/command/server_members_test.go
+++ b/command/server_members_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -48,6 +49,29 @@ func TestServerMembersCommand_Run(t *testing.T) {
 	}
 	if out := ui.OutputWriter.String(); !strings.Contains(out, "Tags") {
 		t.Fatalf("expected tags in output, got: %s", out)
+	}
+	// Query members with JSON normal output
+	ui.OutputWriter.Reset()
+	ui.ErrorWriter.Reset()
+	var jsonMap []map[string]interface{}
+	var out string
+	if code := cmd.Run([]string{"-address=" + url, "-json"}); code != 0 {
+		t.Fatalf("expected exit 0, got: %d", code)
+	}
+	out = ui.OutputWriter.String()
+	if err = json.Unmarshal([]byte(out), &jsonMap); err != nil {
+		t.Fatalf("failed to parse JSON: %s", err)
+	}
+
+	// Query members with JSON verbose output
+	ui.OutputWriter.Reset()
+	ui.ErrorWriter.Reset()
+	if code := cmd.Run([]string{"-address=" + url, "-detailed", "-json"}); code != 0 {
+		t.Fatalf("expected exit 0, got: %d", code)
+	}
+	out = ui.OutputWriter.String()
+	if err = json.Unmarshal([]byte(out), &jsonMap); err != nil {
+		t.Fatalf("failed to parse JSON: %s", err)
 	}
 }
 

--- a/website/content/docs/commands/server/members.mdx
+++ b/website/content/docs/commands/server/members.mdx
@@ -36,6 +36,9 @@ capability.
   for each member. This mode reveals additional information not displayed in
   the standard output format.
 
+- `-json`: Output the Server members information in JSON format. Can be used both
+  for normal output and detailed output.
+
 ## Examples
 
 Default view:
@@ -56,4 +59,57 @@ Name             Address    Port  Status  Leader  Protocol  Raft Version  Build 
 server-1.global  10.0.0.8   4648  alive   true    2         3             1.3.0  dc1         global  id=46122039-7c4d-4647-673a-81786bce2c23,rpc_addr=10.0.0.8,role=nomad,region=global,raft_vsn=3,expect=3,dc=dc1,build=1.3.0,port=4647
 server-2.global  10.0.0.9   4648  alive   false   2         3             1.3.0  dc1         global  id=04594bee-fec9-4cec-f308-eebe82025ae7,dc=dc1,expect=3,rpc_addr=10.0.0.9,raft_vsn=3,port=4647,role=nomad,region=global,build=1.3.0
 server-3.global  10.0.0.10  4648  alive   false   2         3             1.3.0  dc1         global  region=global,dc=dc1,rpc_addr=10.0.0.10,raft_vsn=3,build=1.3.0,expect=3,id=59542f6c-fb0e-50f1-4c9f-98bb593e9fe8,role=nomad,port=4647
+```
+
+JSON view:
+
+```shell-session
+$ nomad server members -json
+[
+  {
+    "Leader": true,
+    "Raft Version": "3",
+    "Build": "1.5.1-dev",
+    "Region": "global",
+    "Name": "server-1.global",
+    "Status": "alive",
+    "Datacenter": "dc1",
+    "Address": "172.18.1.253",
+    "Port": 4648
+  }
+]
+```
+
+JSON verbose view:
+
+```shell-session
+$ nomad server members -verbose -json
+[
+  {
+    "Port": 4648,
+    "Leader": true,
+    "Protocol": 2,
+    "Datacenter": "dc1",
+    "Tags": {
+        "raft_vsn": "3",
+        "region": "global",
+        "build": "1.5.1-dev",
+        "bootstrap": "1",
+        "role": "nomad",
+        "expect": "1",
+        "dc": "dc1",
+        "rpc_addr": "172.18.1.253",
+        "revision": "b07af5761846a59ac91e4826c9a0f8e38c91f70b+CHANGES",
+        "id": "34385ed2-1dc8-ad7d-1a3a-ba665fda91c8",
+        "vsn": "1",
+        "port": "4647"
+    },
+    "Region": "global",
+    "Name": "server-1.global",
+    "Address": "172.18.1.253",
+    "Status": "alive",
+    "Raft Version": "3",
+    "Build": "1.5.1-dev"
+  }
+]
 ```


### PR DESCRIPTION
This pr is related to #15894.

Now we can pass `-json` argument to `nomad server members` command to get the output in JSON format.
It works both for Normal view and Verbose view.

Also related tests are added and documentation is here: `website/content/docs/commands/server/members.mdx`.

Please let me know if anything is needed.