### PR TITLE
cli: support `json` and `t` on `acl binding-rule info` command.

### DIFF
--- a/.changelog/16357.txt
+++ b/.changelog/16357.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a bug where the `-json` and `-t` flags were not respected on the `acl binding-rule info` command
+```

--- a/command/acl_binding_rule_info.go
+++ b/command/acl_binding_rule_info.go
@@ -95,6 +95,17 @@ func (a *ACLBindingRuleInfoCommand) Run(args []string) int {
 		return 1
 	}
 
+	if a.json || len(a.tmpl) > 0 {
+		out, err := Format(a.json, a.tmpl, aclBindingRule)
+		if err != nil {
+			a.Ui.Error(err.Error())
+			return 1
+		}
+
+		a.Ui.Output(out)
+		return 0
+	}
+
 	// Format the output.
 	a.Ui.Output(formatACLBindingRule(aclBindingRule))
 	return 0

--- a/command/acl_binding_rule_info_test.go
+++ b/command/acl_binding_rule_info_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
@@ -65,6 +66,24 @@ func TestACLBindingRuleInfoCommand_Run(t *testing.T) {
 	must.StrContains(t, s, "auth0")
 	must.StrContains(t, s, "role")
 	must.StrContains(t, s, "engineering")
+
+	ui.OutputWriter.Reset()
+	ui.ErrorWriter.Reset()
+
+	// Test that the JSON flag works in return a string that has JSON markers.
+	must.Eq(t, 0, cmd.Run([]string{"-address=" + url, "-token=" + rootACLToken.SecretID, "-json", aclBindingRule.ID}))
+	s = ui.OutputWriter.String()
+	must.StrContains(t, s, "{")
+	must.StrContains(t, s, "}")
+
+	ui.OutputWriter.Reset()
+	ui.ErrorWriter.Reset()
+
+	// Test that we can pass in a custom go template to format the output.
+	must.Eq(t, 0, cmd.Run([]string{
+		"-address=" + url, "-token=" + rootACLToken.SecretID, "-t", "Custom: {{ .ID }}", aclBindingRule.ID}))
+	s = ui.OutputWriter.String()
+	must.StrContains(t, s, fmt.Sprintf("Custom: %s", aclBindingRule.ID))
 
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()


### PR DESCRIPTION
closes #16342 