### PR TITLE
scheduler: correctly detect inplace update with wildcard datacenters

### DIFF
--- a/.changelog/16362.txt
+++ b/.changelog/16362.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Fixed a bug where allocs of system jobs with wildcard datacenters would be destructively updated
+```

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1620,11 +1620,8 @@ func (n *Node) createNodeEvals(node *structs.Node, nodeIndex uint64) ([]string, 
 		// here, but datacenter is a good optimization to start with as
 		// datacenter cardinality tends to be low so the check
 		// shouldn't add much work.
-		for _, dc := range job.Datacenters {
-			if node.IsInDC(dc) {
-				sysJobs = append(sysJobs, job)
-				break
-			}
+		if node.IsInAnyDC(job.Datacenters) {
+			sysJobs = append(sysJobs, job)
 		}
 	}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2311,8 +2311,13 @@ func (n *Node) ComparableResources() *ComparableResources {
 	}
 }
 
-func (n *Node) IsInDC(dc string) bool {
-	return glob.Glob(dc, n.Datacenter)
+func (n *Node) IsInAnyDC(datacenters []string) bool {
+	for _, dc := range datacenters {
+		if glob.Glob(dc, n.Datacenter) {
+			return true
+		}
+	}
+	return false
 }
 
 // Stub returns a summarized version of the node


### PR DESCRIPTION
Wildcard datacenters introduced a bug where a system job with any wildcard datacenters will always be treated as a destructive update when we check whether a datacenter has been removed from the jobspec.

Includes updating the helper so that callers don't have to loop over the job's datacenters.