### PR TITLE
docs: note that secrets dir is usually mounted `noexec`

### DIFF
--- a/website/content/docs/concepts/filesystem.mdx
+++ b/website/content/docs/concepts/filesystem.mdx
@@ -71,7 +71,8 @@ allocation directory like the one below.
   - **«taskname»/secrets/**: This directory is the location provided to the task as
     `NOMAD_SECRETS_DIR`. The contents of files in this directory cannot be read
     by the `nomad alloc fs` command. It can be used to store secret data that
-    should not be visible outside the task.
+    should not be visible outside the task. Where possible it is backed by an
+    in-memory filesystem and mounted `noexec`.
 
   - **«taskname»/tmp/**: A temporary directory used as scratch space by task drivers.
 

--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -73,7 +73,9 @@ refer to the [Learn Go Template Syntax][gt_learn] guide.
   that build a chroot in the task working directory (ex. `exec`) can render
   templates outside of the `NOMAD_ALLOC_DIR`, `NOMAD_TASK_DIR`, or
   `NOMAD_SECRETS_DIR`. For more details on how `destination` interacts with
-  task drivers, see the [Filesystem internals] documentation.
+  task drivers, see the [Filesystem internals][] documentation. Note that where
+  possible, the `NOMAD_SECRETS_DIR` is mounted `noexec`, so rendered templates
+  can't be used as self-executing scripts.
 
 - `env` `(bool: false)` - Specifies the template should be read back in as
   environment variables for the task ([example](#environment-variables)). To

--- a/website/content/docs/runtime/environment.mdx
+++ b/website/content/docs/runtime/environment.mdx
@@ -69,9 +69,9 @@ working directory:
 - `local/`: This directory is private to each task. It can be used to store
   arbitrary data that should not be shared by tasks in the task group.
 - `secrets/`: This directory is private to each task, not accessible via the
-  `nomad alloc fs` command or filesystem APIs and where possible backed by an
-  in-memory filesystem. It can be used to store secret data that should not be
-  visible outside the task.
+  `nomad alloc fs` command or filesystem APIs. Where possible it is backed by an
+  in-memory filesystem and mounted `noexec`. It can be used to store secret data
+  that should not be visible outside the task.
 
 These directories are persisted until the allocation is removed, which occurs
 hours after all the tasks in the task group enter terminal states. This gives
@@ -85,7 +85,7 @@ chroot. Regardless of how the directories are made available, the path to the
 directories can be read through the `NOMAD_ALLOC_DIR`, `NOMAD_TASK_DIR`, and
 `NOMAD_SECRETS_DIR` environment variables.
 
-For more details on the task directories, see the [Filesystem internals].
+For more details on the task directories, see the [Filesystem internals][].
 
 ## Meta
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/16308