### PR TITLE
e2e: fix permissions on nomad data directory

### DIFF
--- a/e2e/terraform/provision-nomad/install-linux.tf
+++ b/e2e/terraform/provision-nomad/install-linux.tf
@@ -78,6 +78,7 @@ resource "null_resource" "install_nomad_configs_linux" {
     inline = [
       "mkdir -p /etc/nomad.d",
       "mkdir -p /opt/nomad/data",
+      "sudo chmod 0700 /opt/nomad/data",
       "sudo rm -rf /etc/nomad.d/*",
       "sudo mv /tmp/consul.hcl /etc/nomad.d/consul.hcl",
       "sudo mv /tmp/vault.hcl /etc/nomad.d/vault.hcl",


### PR DESCRIPTION
This PR updates the provisioning step where we create /opt/nomad/data,
such that it is with 0700 permissions in line with our security guidance.

Should be followed up shortly by https://github.com/hashicorp/nomad/pull/16375 which fixes Nomad Client to work with this directory structure. 