### PR TITLE
packaging: set limited permissions on nomad data directory

### DIFF
--- a/.release/linux/postinst
+++ b/.release/linux/postinst
@@ -2,6 +2,7 @@
 
 mkdir -p /opt/nomad/data
 chown nomad:nomad /opt/nomad/data
+chmod 0700 /opt/nomad/data
 chown -R nomad:nomad /etc/nomad.d
 
 if [ -d /run/systemd/system ]; then


### PR DESCRIPTION
Setting `0700` on the Nomad `data_dir` brings it in line with Nomad's production security hardening guide.

https://developer.hashicorp.com/nomad/docs/install/production/requirements#hardening-nomad