### PR TITLE
client: refactor service interpolation

### DIFF
--- a/client/allocrunner/group_service_hook.go
+++ b/client/allocrunner/group_service_hook.go
@@ -239,7 +239,7 @@ func (h *groupServiceHook) deregister() {
 
 func (h *groupServiceHook) getWorkloadServices() *serviceregistration.WorkloadServices {
 	// Interpolate with the task's environment
-	interpolatedServices := taskenv.InterpolateServices(h.taskEnvBuilder.Build(), h.services)
+	interpolatedServices := h.taskEnvBuilder.Build().InterpolateServices(h.services)
 
 	var netStatus *structs.AllocNetworkStatus
 	if h.networkStatus != nil {

--- a/client/allocrunner/taskrunner/envoy_bootstrap_hook.go
+++ b/client/allocrunner/taskrunner/envoy_bootstrap_hook.go
@@ -206,10 +206,8 @@ func (_ *envoyBootstrapHook) extractNameAndKind(kind structs.TaskKind) (string, 
 
 func (h *envoyBootstrapHook) lookupService(svcKind, svcName string, taskEnv *taskenv.TaskEnv) (*structs.Service, error) {
 	tg := h.alloc.Job.LookupTaskGroup(h.alloc.TaskGroup)
-	interpolatedServices := taskenv.InterpolateServices(taskEnv, tg.Services)
-
 	var service *structs.Service
-	for _, s := range interpolatedServices {
+	for _, s := range tg.InterpolatedServices(taskEnv) {
 		if s.Name == svcName {
 			service = s
 			break
@@ -427,8 +425,7 @@ func buildEnvoyBind(alloc *structs.Allocation, ifce, service, task string, taskE
 	port := basePort
 	switch tg.Networks[0].Mode {
 	case "host":
-		interpolatedServices := taskenv.InterpolateServices(taskEnv, tg.Services)
-		for _, svc := range interpolatedServices {
+		for _, svc := range tg.InterpolatedServices(taskEnv) {
 			if svc.Name == service {
 				mapping := tg.Networks.Port(svc.PortLabel)
 				port = mapping.Value

--- a/client/allocrunner/taskrunner/script_check_hook.go
+++ b/client/allocrunner/taskrunner/script_check_hook.go
@@ -176,8 +176,7 @@ func (h *scriptCheckHook) Stop(ctx context.Context, req *interfaces.TaskStopRequ
 
 func (h *scriptCheckHook) newScriptChecks() map[string]*scriptCheck {
 	scriptChecks := make(map[string]*scriptCheck)
-	interpolatedTaskServices := taskenv.InterpolateServices(h.taskEnv, h.task.Services)
-	for _, service := range interpolatedTaskServices {
+	for _, service := range h.task.InterpolatedServices(h.taskEnv) {
 		for _, check := range service.Checks {
 			if check.Type != structs.ServiceCheckScript {
 				continue
@@ -212,8 +211,7 @@ func (h *scriptCheckHook) newScriptChecks() map[string]*scriptCheck {
 	// service.check.task matches the task name. The service.check.task takes
 	// precedence.
 	tg := h.alloc.Job.LookupTaskGroup(h.alloc.TaskGroup)
-	interpolatedGroupServices := taskenv.InterpolateServices(h.taskEnv, tg.Services)
-	for _, service := range interpolatedGroupServices {
+	for _, service := range tg.InterpolatedServices(h.taskEnv) {
 		for _, check := range service.Checks {
 			if check.Type != structs.ServiceCheckScript {
 				continue

--- a/client/allocrunner/taskrunner/service_hook.go
+++ b/client/allocrunner/taskrunner/service_hook.go
@@ -219,7 +219,7 @@ func (h *serviceHook) Stop(ctx context.Context, req *interfaces.TaskStopRequest,
 
 func (h *serviceHook) getWorkloadServices() *serviceregistration.WorkloadServices {
 	// Interpolate with the task's environment
-	interpolatedServices := taskenv.InterpolateServices(h.taskEnv, h.services)
+	interpolatedServices := h.taskEnv.InterpolateServices(h.services)
 
 	info := structs.AllocInfo{
 		AllocID:   h.allocID,

--- a/client/taskenv/services.go
+++ b/client/taskenv/services.go
@@ -6,10 +6,10 @@ import (
 
 // InterpolateServices returns an interpolated copy of services and checks with
 // values from the task's environment.
-func InterpolateServices(taskEnv *TaskEnv, services []*structs.Service) []*structs.Service {
+func (t *TaskEnv) InterpolateServices(services []*structs.Service) []*structs.Service {
 	// Guard against not having a valid taskEnv. This can be the case if the
 	// PreKilling or Exited hook is run before Poststart.
-	if taskEnv == nil || len(services) == 0 {
+	if t == nil || len(services) == 0 {
 		return nil
 	}
 
@@ -21,28 +21,28 @@ func InterpolateServices(taskEnv *TaskEnv, services []*structs.Service) []*struc
 		service := origService.Copy()
 
 		for _, check := range service.Checks {
-			check.Name = taskEnv.ReplaceEnv(check.Name)
-			check.Type = taskEnv.ReplaceEnv(check.Type)
-			check.Command = taskEnv.ReplaceEnv(check.Command)
-			check.Args = taskEnv.ParseAndReplace(check.Args)
-			check.Path = taskEnv.ReplaceEnv(check.Path)
-			check.Protocol = taskEnv.ReplaceEnv(check.Protocol)
-			check.PortLabel = taskEnv.ReplaceEnv(check.PortLabel)
-			check.InitialStatus = taskEnv.ReplaceEnv(check.InitialStatus)
-			check.Method = taskEnv.ReplaceEnv(check.Method)
-			check.GRPCService = taskEnv.ReplaceEnv(check.GRPCService)
-			check.Header = interpolateMapStringSliceString(taskEnv, check.Header)
+			check.Name = t.ReplaceEnv(check.Name)
+			check.Type = t.ReplaceEnv(check.Type)
+			check.Command = t.ReplaceEnv(check.Command)
+			check.Args = t.ParseAndReplace(check.Args)
+			check.Path = t.ReplaceEnv(check.Path)
+			check.Protocol = t.ReplaceEnv(check.Protocol)
+			check.PortLabel = t.ReplaceEnv(check.PortLabel)
+			check.InitialStatus = t.ReplaceEnv(check.InitialStatus)
+			check.Method = t.ReplaceEnv(check.Method)
+			check.GRPCService = t.ReplaceEnv(check.GRPCService)
+			check.Header = interpolateMapStringSliceString(t, check.Header)
 		}
 
-		service.Name = taskEnv.ReplaceEnv(service.Name)
-		service.PortLabel = taskEnv.ReplaceEnv(service.PortLabel)
-		service.Address = taskEnv.ReplaceEnv(service.Address)
-		service.Tags = taskEnv.ParseAndReplace(service.Tags)
-		service.CanaryTags = taskEnv.ParseAndReplace(service.CanaryTags)
-		service.Meta = interpolateMapStringString(taskEnv, service.Meta)
-		service.CanaryMeta = interpolateMapStringString(taskEnv, service.CanaryMeta)
-		service.TaggedAddresses = interpolateMapStringString(taskEnv, service.TaggedAddresses)
-		interpolateConnect(taskEnv, service.Connect)
+		service.Name = t.ReplaceEnv(service.Name)
+		service.PortLabel = t.ReplaceEnv(service.PortLabel)
+		service.Address = t.ReplaceEnv(service.Address)
+		service.Tags = t.ParseAndReplace(service.Tags)
+		service.CanaryTags = t.ParseAndReplace(service.CanaryTags)
+		service.Meta = interpolateMapStringString(t, service.Meta)
+		service.CanaryMeta = interpolateMapStringString(t, service.CanaryMeta)
+		service.TaggedAddresses = interpolateMapStringString(t, service.TaggedAddresses)
+		interpolateConnect(t, service.Connect)
 
 		interpolated[i] = service
 	}

--- a/client/taskenv/services_test.go
+++ b/client/taskenv/services_test.go
@@ -74,7 +74,7 @@ func TestInterpolateServices(t *testing.T) {
 		},
 	}
 
-	interpolated := InterpolateServices(env, services)
+	interpolated := env.InterpolateServices(services)
 
 	exp := []*structs.Service{
 		{

--- a/command/agent/consul/structs.go
+++ b/command/agent/consul/structs.go
@@ -21,7 +21,7 @@ func BuildAllocServices(
 			AllocID: alloc.ID,
 			Group:   alloc.TaskGroup,
 		},
-		Services: taskenv.InterpolateServices(taskenv.NewBuilder(mock.Node(), alloc, nil, alloc.Job.Region).Build(), tg.Services),
+		Services: taskenv.NewBuilder(mock.Node(), alloc, nil, alloc.Job.Region).Build().InterpolateServices(tg.Services),
 		Networks: alloc.AllocatedResources.Shared.Networks,
 
 		//TODO(schmichael) there's probably a better way than hacking driver network

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -48,6 +48,15 @@ const (
 	minCheckTimeout = 1 * time.Second
 )
 
+// ServiceInterpolator is the interface that wraps methods used to interpolate
+// runtime values into services.
+//
+// Implementations must not mutate their input but rather act on and return
+// copies.
+type ServiceInterpolator interface {
+	InterpolateServices([]*Service) []*Service
+}
+
 // ServiceCheck represents a Nomad or Consul service health check.
 //
 // The fields available depend on the service provider the check is being


### PR DESCRIPTION
Services may reference runtime variables that must be interpolated in the client when reading them, otherwise any equality check fails because something like `${NOMAD_NAMESPACE}` is compared with its rendered value stored in the service catalog.

This change attempts to make this requirement easier to discover by providing methods in the `TaskGroup` and `Task` structs that return the interpolated services.

These methods take a `ServiceInterpolator` interface to avoid a circular dependency between the `structs` and `taskenv` packages.

No CHANGELOG because there are no user-facing changes.

-------

This was extracted from https://github.com/hashicorp/nomad/pull/16402 to help facilitate review and discussion. I think this change makes the need to interpolate services a little more clear, but not by much. I can easily be convinced that we don't need this 😅 