### PR TITLE
e2e fixes: cli output, timing issue, and some cleanups

### DIFF
--- a/e2e/isolation/chroot_test.go
+++ b/e2e/isolation/chroot_test.go
@@ -28,13 +28,9 @@ func testExecUsesChroot(t *testing.T) {
 	t.Cleanup(e2eutil.CleanupJobsAndGC(t, &jobIDs))
 
 	// start job
-	e2eutil.RegisterAndWaitForAllocs(t, nomad, "./input/chroot_exec.nomad", jobID, "")
-
-	// get allocation
-	allocations, err := e2eutil.AllocsForJob(jobID, "")
-	must.NoError(t, err)
-	must.Len(t, 1, allocations)
-	allocID := allocations[0]["ID"]
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, nomad, "./input/chroot_exec.nomad", jobID, "")
+	must.Len(t, 1, allocs)
+	allocID := allocs[0].ID
 
 	// wait for allocation stopped
 	e2eutil.WaitForAllocsStopped(t, nomad, []string{allocID})
@@ -56,13 +52,9 @@ func testImageUsesChroot(t *testing.T) {
 	t.Cleanup(e2eutil.CleanupJobsAndGC(t, &jobIDs))
 
 	// start job
-	e2eutil.RegisterAndWaitForAllocs(t, nomad, "./input/chroot_docker.nomad", jobID, "")
-
-	// get allocation
-	allocations, err := e2eutil.AllocsForJob(jobID, "")
-	must.NoError(t, err)
-	must.Len(t, 1, allocations)
-	allocID := allocations[0]["ID"]
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, nomad, "./input/chroot_docker.nomad", jobID, "")
+	must.Len(t, 1, allocs)
+	allocID := allocs[0].ID
 
 	// wait for allocation stopped
 	e2eutil.WaitForAllocsStopped(t, nomad, []string{allocID})
@@ -84,13 +76,9 @@ func testDownloadChrootExec(t *testing.T) {
 	t.Cleanup(e2eutil.CleanupJobsAndGC(t, &jobIDs))
 
 	// start job
-	e2eutil.RegisterAndWaitForAllocs(t, nomad, "./input/chroot_dl_exec.nomad", jobID, "")
-
-	// get allocation
-	allocations, err := e2eutil.AllocsForJob(jobID, "")
-	must.NoError(t, err)
-	must.Len(t, 1, allocations)
-	allocID := allocations[0]["ID"]
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, nomad, "./input/chroot_dl_exec.nomad", jobID, "")
+	must.Len(t, 1, allocs)
+	allocID := allocs[0].ID
 
 	// wait for allocation stopped
 	e2eutil.WaitForAllocsStopped(t, nomad, []string{allocID})

--- a/e2e/isolation/input/chroot_dl_exec.nomad
+++ b/e2e/isolation/input/chroot_dl_exec.nomad
@@ -1,15 +1,17 @@
 job "chroot_dl_exec" {
-  datacenters = ["dc1"]
-  type        = "batch"
+  type = "batch"
+
   constraint {
     attribute = "${attr.kernel.name}"
     value     = "linux"
   }
+
   group "group" {
     network {
       mode = "host"
       port "http" {}
     }
+
     task "script-writer" {
       driver = "raw_exec"
       config {
@@ -19,10 +21,12 @@ job "chroot_dl_exec" {
           "cd ${NOMAD_ALLOC_DIR} && chmod +x script.sh && tar -czf script.tar.gz script.sh"
         ]
       }
+
       resources {
-        cpu    = 10
-        memory = 12
+        cpu    = 50
+        memory = 50
       }
+
       template {
         data        = <<EOH
 #!/bin/sh
@@ -35,29 +39,32 @@ EOH
         sidecar = false
       }
     }
+
     task "file-server" {
       driver = "raw_exec"
       config {
         command = "/usr/bin/python3"
         args    = ["-m", "http.server", "${NOMAD_PORT_http}", "--directory", "${NOMAD_ALLOC_DIR}"]
       }
+
       resources {
-        cpu    = 10
-        memory = 32
+        cpu    = 50
+        memory = 50
       }
       lifecycle {
         hook    = "prestart"
         sidecar = true
       }
     }
+
     task "run-script" {
       driver = "exec"
       config {
         command = "local/script.sh"
       }
       resources {
-        cpu    = 10
-        memory = 12
+        cpu    = 50
+        memory = 50
       }
       artifact {
         source = "http://localhost:${NOMAD_PORT_http}/script.tar.gz"

--- a/e2e/isolation/input/chroot_docker.nomad
+++ b/e2e/isolation/input/chroot_docker.nomad
@@ -1,5 +1,5 @@
 job "chroot_docker" {
-  type        = "batch"
+  type = "batch"
 
   constraint {
     attribute = "${attr.kernel.name}"

--- a/e2e/isolation/input/chroot_docker.nomad
+++ b/e2e/isolation/input/chroot_docker.nomad
@@ -1,5 +1,4 @@
 job "chroot_docker" {
-  datacenters = ["dc1"]
   type        = "batch"
 
   constraint {
@@ -20,7 +19,7 @@ job "chroot_docker" {
       }
       resources {
         cpu    = 50
-        memory = 32
+        memory = 50
       }
     }
   }

--- a/e2e/isolation/input/chroot_exec.nomad
+++ b/e2e/isolation/input/chroot_exec.nomad
@@ -1,10 +1,11 @@
 job "chroot_exec" {
-  datacenters = ["dc1"]
-  type        = "batch"
+  type = "batch"
+
   constraint {
     attribute = "${attr.kernel.name}"
     value     = "linux"
   }
+
   group "print" {
     task "env" {
       driver = "exec"
@@ -15,9 +16,10 @@ job "chroot_exec" {
           "echo $NOMAD_ALLOC_DIR; echo $NOMAD_TASK_DIR; echo $NOMAD_SECRETS_DIR; echo $PATH"
         ]
       }
+
       resources {
-        cpu    = 10
-        memory = 16
+        cpu    = 50
+        memory = 50
       }
     }
   }

--- a/e2e/namespaces/namespaces_test.go
+++ b/e2e/namespaces/namespaces_test.go
@@ -146,7 +146,7 @@ func TestNamespacesFiltering(t *testing.T) {
 	must.Eq(t, rows[0]["Job ID"], jobDefault)
 
 	out, err = e2eutil.Command("nomad", "job", "stop", jobA)
-	must.Eq(t, fmt.Sprintf("No job(s) with prefix or id %q found\n", jobA), out)
+	must.Eq(t, fmt.Sprintf("No job(s) with prefix or ID %q found\n", jobA), out)
 	must.StrContains(t, err.Error(), "exit status 1")
 
 	err = e2eutil.StopJob(jobA, "-namespace", "NamespaceA")

--- a/e2e/operator_scheduler/input/basic.nomad
+++ b/e2e/operator_scheduler/input/basic.nomad
@@ -14,7 +14,7 @@ job "operator_scheduler" {
 
       config {
         command = "bash"
-        args    = ["-c", "sleep 1"]
+        args    = ["-c", "sleep 30"]
       }
     }
   }


### PR DESCRIPTION
See individual commits for details but basically:

### `chroot_test.go`

Failed last night, but I couldn't find a cause. Its allocs were stuck in pending along with a lot of other unexpected failures, so I suspect something went wrong with the client setup last night? Unsure.

Gave its jobs more resources and datacenters, but I doubt that will fix whatever happened last night.

### namespaces_test.go

Expected output changed in #16306. I fixed the test to match the new CLI output.

###  operator_scheduler

Test expects to find it running, but the job only sleeps for 1s. Lengthened the time to be safe (does *not* lengthen the overall test time). However I suspect this hit the "bad client" issue like chroot and all the others last night.