### PR TITLE
scheduler: add simple benchmark for tasksUpdated

### DIFF
--- a/nomad/mock/job.go
+++ b/nomad/mock/job.go
@@ -568,3 +568,93 @@ func MaxParallelJob() *structs.Job {
 	job.Canonicalize()
 	return job
 }
+
+// BigBenchmarkJob creates a job with many fields set, ideal for benchmarking
+// stuff involving jobs.
+//
+// Should not be used outside of benchmarking - folks should feel free to add
+// more fields without risk of breaking test cases down the line.
+func BigBenchmarkJob() *structs.Job {
+	job := MultiTaskGroupJob()
+
+	// job affinities
+	job.Affinities = structs.Affinities{{
+		LTarget: "left",
+		RTarget: "right",
+		Operand: "!=",
+		Weight:  100,
+	}, {
+		LTarget: "a",
+		RTarget: "b",
+		Operand: "<",
+		Weight:  50,
+	}}
+
+	// job spreads
+	job.Spreads = []*structs.Spread{{
+		Attribute: "foo.x",
+		Weight:    100,
+		SpreadTarget: []*structs.SpreadTarget{{
+			Value:   "x",
+			Percent: 90,
+		}, {
+			Value:   "x2",
+			Percent: 99,
+		}},
+	}, {
+		Attribute: "foo.y",
+		Weight:    90,
+		SpreadTarget: []*structs.SpreadTarget{{
+			Value:   "y",
+			Percent: 10,
+		}},
+	}}
+
+	// group affinities
+	job.TaskGroups[0].Affinities = structs.Affinities{{
+		LTarget: "L",
+		RTarget: "R",
+		Operand: "!=",
+		Weight:  100,
+	}, {
+		LTarget: "b",
+		RTarget: "a",
+		Operand: ">",
+		Weight:  50,
+	}}
+
+	// group spreads
+	job.TaskGroups[0].Spreads = []*structs.Spread{{
+		Attribute: "bar.x",
+		Weight:    100,
+		SpreadTarget: []*structs.SpreadTarget{{
+			Value:   "x",
+			Percent: 90,
+		}, {
+			Value:   "x2",
+			Percent: 99,
+		}},
+	}, {
+		Attribute: "bar.y",
+		Weight:    90,
+		SpreadTarget: []*structs.SpreadTarget{{
+			Value:   "y",
+			Percent: 10,
+		}},
+	}}
+
+	// task affinities
+	job.TaskGroups[0].Tasks[0].Affinities = structs.Affinities{{
+		LTarget: "Left",
+		RTarget: "Right",
+		Operand: "!=",
+		Weight:  100,
+	}, {
+		LTarget: "A",
+		RTarget: "B",
+		Operand: "<",
+		Weight:  50,
+	}}
+
+	return job
+}

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -17,6 +17,17 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
+func BenchmarkTasksUpdated(b *testing.B) {
+	jobA := mock.BigBenchmarkJob()
+	jobB := jobA.Copy()
+	group := jobA.TaskGroups[0].Name
+	for n := 0; n < b.N; n++ {
+		if tasksUpdated(jobA, jobB, group) {
+			b.Fatal("tasks should be the same")
+		}
+	}
+}
+
 func newNode(name string) *structs.Node {
 	n := mock.Node()
 	n.Name = name


### PR DESCRIPTION
In preperation for some refactoring to `tasksUpdated`, add a benchmark to the
old code so it's easy to compare with the changes, making sure nothing goes
off the rails for performance.

inaugural run:

```
➜ go test -count=3 -bench=BenchmarkTasksUpdated -run BenchmarkTasksUpdated
BenchmarkTasksUpdated-24           91621             15052 ns/op
BenchmarkTasksUpdated-24           80002             15023 ns/op
BenchmarkTasksUpdated-24           78248             15514 ns/op
```