### PR TITLE
doc: Update `nomad fmt` doc to run against non-deprecated HCL2 jobspec only

### DIFF
--- a/website/content/docs/commands/fmt.mdx
+++ b/website/content/docs/commands/fmt.mdx
@@ -24,6 +24,11 @@ extensions in the directory.
 If you provide a single dash (-) as argument, fmt will read from standard input
 (STDIN) and output the processed output to standard output (STDOUT).
 
+Note that, this command will check the syntax against
+[HCL2](https://github.com/hashicorp/hcl/blob/hcl2/README.md), the second
+generation of Hashicorp Configuration Language. Running this command with
+Deprecated HCL1 jobspec will result in errors.
+
 ## Format Options:
 
 - `-check`: Check if the files are valid HCL files. If not, exit status of the
@@ -31,7 +36,7 @@ If you provide a single dash (-) as argument, fmt will read from standard input
   overrides any `-write` flag value.
 - `-list`: List the files which contain formatting inconsistencies. Defaults to
   `-list=true`.
-- `-recursive`: Process files in subdirectories. By default only the given (or
+- `-recursive`: Process files in subdirectories. By default, only the given (or
 	current) directory is processed.
 - `-write`: Overwrite the input files. Defaults to `-write=true`.
 

--- a/website/content/docs/commands/fmt.mdx
+++ b/website/content/docs/commands/fmt.mdx
@@ -27,7 +27,7 @@ If you provide a single dash (-) as argument, fmt will read from standard input
 Note that, this command will check the syntax against
 [HCL2](https://github.com/hashicorp/hcl/blob/hcl2/README.md), the second
 generation of Hashicorp Configuration Language. Running this command with
-Deprecated HCL1 jobspec will result in errors.
+deprecated HCL1 jobspec will result in errors.
 
 ## Format Options:
 


### PR DESCRIPTION
Hi team,

This PR updates the `nomad fmt` doc for further clarification on non-deprecated HCL2 syntax

Will close #16312 and #15072