### PR TITLE
feat: show warning if policy doesn't exist

### DIFF
--- a/.changelog/16437.txt
+++ b/.changelog/16437.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: `acl token create` will now emit a warning if the token has a policy that does not yet exist
+```

--- a/command/acl_token_create.go
+++ b/command/acl_token_create.go
@@ -154,6 +154,14 @@ func (c *ACLTokenCreateCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Show warning if policy doesn't exist
+	for _, policy := range tk.Policies {
+		_, _, err := client.ACLPolicies().Info(policy, nil)
+		if err != nil {
+			c.Ui.Warn(fmt.Sprintf("Error fetching info on %s policy: %s", policy, err))
+		}
+	}
+
 	// Create the bootstrap token
 	token, _, err := client.ACLTokens().Create(tk, nil)
 	if err != nil {


### PR DESCRIPTION
This pr is related to #14058 .

I wanted to work on that issue, but as I saw still it's not quite obvious on how we are going to fix it, I decided to only show a warning so at-least user can be aware the policy he/she is referring to, doesn't exist at the moment.

Also I can continue fixing this one if the expected result is known now.
Thanks.

Fixes: #14058