### PR TITLE
acl: update job eval requirement to `submit-job`

### DIFF
--- a/.changelog/16463.txt
+++ b/.changelog/16463.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+acl: Job evaluate endpoit now requires `submit-job` instead of `read-job` capability
+```

--- a/command/job_eval.go
+++ b/command/job_eval.go
@@ -23,9 +23,11 @@ Usage: nomad job eval [options] <job_id>
   operators to force the scheduler to create new allocations under certain
   scenarios.
 
-  When ACLs are enabled, this command requires a token with the 'read-job'
+  When ACLs are enabled, this command requires a token with the 'submit-job'
   capability for the job's namespace. The 'list-jobs' capability is required to
-  run the command with a job prefix instead of the exact job ID.
+  run the command with a job prefix instead of the exact job ID. The 'read-job'
+  capability is required to monitor the resulting evaluation when -detach is
+  not used.
 
 General Options:
 

--- a/command/job_eval_test.go
+++ b/command/job_eval_test.go
@@ -156,7 +156,7 @@ func TestJobEvalCommand_ACL(t *testing.T) {
 			expectedErr: api.PermissionDeniedErrorContent,
 		},
 		{
-			name: "missing read-job",
+			name: "missing submit-job",
 			aclPolicy: `
 namespace "default" {
 	capabilities = ["list-jobs"]
@@ -165,29 +165,48 @@ namespace "default" {
 			expectedErr: api.PermissionDeniedErrorContent,
 		},
 		{
-			name: "read-job allowed",
+			name: "submit-job allowed but can't monitor eval without read-job",
 			aclPolicy: `
 namespace "default" {
-	capabilities = ["read-job"]
+	capabilities = ["submit-job"]
+}
+`,
+			expectedErr: "No evaluation with id",
+		},
+		{
+			name: "submit-job allowed and can monitor eval with read-job",
+			aclPolicy: `
+namespace "default" {
+	capabilities = ["read-job", "submit-job"]
 }
 `,
 		},
 		{
-			name:      "job prefix requires list-job",
+			name:      "job prefix requires list-jobs",
 			jobPrefix: true,
 			aclPolicy: `
 namespace "default" {
-	capabilities = ["read-job"]
+	capabilities = ["submit-job"]
 }
 `,
 			expectedErr: "job not found",
 		},
 		{
-			name:      "job prefix works with list-job",
+			name:      "job prefix works with list-jobs but can't monitor eval without read-job",
 			jobPrefix: true,
 			aclPolicy: `
 namespace "default" {
-	capabilities = ["read-job", "list-jobs"]
+	capabilities = ["list-jobs", "submit-job"]
+}
+`,
+			expectedErr: "No evaluation with id",
+		},
+		{
+			name:      "job prefix works with list-jobs and can monitor eval with read-job",
+			jobPrefix: true,
+			aclPolicy: `
+namespace "default" {
+	capabilities = ["read-job", "list-jobs", "submit-job"]
 }
 `,
 		},

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -721,10 +721,10 @@ func (j *Job) Evaluate(args *structs.JobEvaluateRequest, reply *structs.JobRegis
 	}
 	defer metrics.MeasureSince([]string{"nomad", "job", "evaluate"}, time.Now())
 
-	// Check for read-job permissions
+	// Check for submit-job permissions
 	if aclObj, err := j.srv.ResolveACL(args); err != nil {
 		return err
-	} else if aclObj != nil && !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJob) {
+	} else if aclObj != nil && !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilitySubmitJob) {
 		return structs.ErrPermissionDenied
 	}
 

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -3163,7 +3163,7 @@ func TestJobEndpoint_Evaluate_ACL(t *testing.T) {
 
 	// Fetch the response with a valid token
 	validToken := mock.CreatePolicyAndToken(t, state, 1005, "test-valid",
-		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
+		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
 
 	reEval.AuthToken = validToken.SecretID
 	var validResp2 structs.JobRegisterResponse

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -1869,9 +1869,9 @@ The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
 [required ACLs](/nomad/api-docs#acls).
 
-| Blocking Queries | ACL Required         |
-| ---------------- | -------------------- |
-| `NO`             | `namespace:read-job` |
+| Blocking Queries | ACL Required           |
+| ---------------- | ---------------------- |
+| `NO`             | `namespace:submit-job` |
 
 ### Parameters
 

--- a/website/content/docs/commands/job/eval.mdx
+++ b/website/content/docs/commands/job/eval.mdx
@@ -20,9 +20,11 @@ The `job eval` command requires a single argument, specifying the job ID to
 evaluate. If there is an exact match based on the provided job ID, then the job
 will be evaluated, forcing a scheduler run.
 
-When ACLs are enabled, this command requires a token with the `read-job`
+When ACLs are enabled, this command requires a token with the `submit-job`
 capability for the job's namespace. The `list-jobs` capability is required to
-run the command with a job prefix instead of the exact job ID.
+run the command with a job prefix instead of the exact job ID. The `read-job`
+capability is required to monitor the resulting evaluation when `-detach` is
+not used.
 
 ## General Options
 

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -13,6 +13,18 @@ upgrade. However, specific versions of Nomad may have more details provided for
 their upgrades as a result of new features or changed behavior. This page is
 used to document those details separately from the standard upgrade flow.
 
+## Nomad 1.6.0
+
+#### Job Evaluate API Endpoint Requires `submit-job` Instead of `read-job`
+
+Nomad 1.6.0 updated the ACL capability requirement for the job evaluate
+endpoint from `read-job` to `submit-job` to better reflect that this operation
+writes state to Nomad. This endpoint is used by the `nomad job eval` CLI
+command and so the ACL requirements changed for the command as well. Users that
+called this endpoint or used this command using tokens with just the `read-job`
+capability or the `read` policy must update their tokens to use the
+`submit-job` capability or the `write` policy.
+
 ## Nomad 1.5.1
 
 #### Artifact Download Regression Fix


### PR DESCRIPTION
The job evaluate endpoint creates a new evaluation for the job which is a write operation. This change modifies the necessary capability from `read-job` to `submit-job` to better reflect this.

No backport since this is targeted for Nomad 1.6.0