### PR TITLE
cgv1: do not disable cpuset manager if reserved interface already exists

### DIFF
--- a/.changelog/16467.txt
+++ b/.changelog/16467.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where cpuset initialization fails after Client restart
+```


### PR DESCRIPTION
This PR fixes a bug where restarting a Nomad Client on a machine using cgroups
v1 (e.g. Ubuntu 20.04 or earlier) would cause the cpuset cgroups manager to disable itself.

This is being caused by incorrectly interpreting a "file exists" error as
problematic when ensuring the reserved cpuset exists. If we get a "file exists"
error, that just means there is nothing to do, and the cpuset manager should continue
initializing normally.

Note that a machine reboot would fix the issue - the interfaces are ephemeral.

Fixes https://github.com/hashicorp/nomad/issues/16291
