### PR TITLE
agent: trim space when parsing X-Nomad-Token header

### DIFF
--- a/.changelog/16469.txt
+++ b/.changelog/16469.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: trim leading and trailing spaces when parsing `X-Nomad-Token` header
+```

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -969,7 +969,7 @@ func parseInt(req *http.Request, field string) (*int, error) {
 // parseToken is used to parse the X-Nomad-Token param
 func (s *HTTPServer) parseToken(req *http.Request, token *string) {
 	if other := req.Header.Get("X-Nomad-Token"); other != "" {
-		*token = other
+		*token = strings.TrimSpace(other)
 		return
 	}
 

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -552,7 +552,7 @@ func TestParseToken(t *testing.T) {
 		{
 			Name:          "Parses token from X-Nomad-Token",
 			HeaderKey:     "X-Nomad-Token",
-			HeaderValue:   "foobar",
+			HeaderValue:   " foobar",
 			ExpectedToken: "foobar",
 		},
 		{


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/11898 and will replace https://github.com/hashicorp/nomad/pull/11897

Our auth token parsing code trims space around the `Authorization` header but not around `X-Nomad-Token`. When using the UI, it's easy to accidentally introduce a leading or trailing space, which results in spurious authentication errors. Some browsers fix this automatically, but apparently not all do. Trim the space at the HTTP server.