### PR TITLE
artifact: git needs more files for private repositories

### DIFF
--- a/.changelog/16495.txt
+++ b/.changelog/16495.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+artifact: Fixed a bug where artifact downloading failed when using git-ssh
+```


### PR DESCRIPTION
This PR fixes artifact downloading so that git may work when cloning from
private repositories. It needs

- file read on `/etc/passwd`
- dir read on `/root/.ssh`
- file write on `/root/.ssh/known_hosts`

Add these rules to the landlock rules for the artifact sandbox.

Fixes https://github.com/hashicorp/nomad/issues/16477