### PR TITLE
update `default` Mirage scenario

### DIFF
--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -12,12 +12,13 @@ export default class JobEditor extends Component {
 
   @tracked error = null;
   @tracked planOutput = null;
-  @tracked view = 'job-spec';
   @tracked isEditing;
+  @tracked view;
 
   constructor() {
     super(...arguments);
     this.isEditing = !!(this.args.context === 'new');
+    this.view = this.args.specification ? 'job-spec' : 'full-definition';
   }
 
   toggleEdit(bool) {
@@ -141,6 +142,7 @@ export default class JobEditor extends Component {
     return {
       cancelable: this.args.cancelable,
       definition: this.definition,
+      hasSpecification: !!this.args.specification,
       job: this.args.job,
       planOutput: this.planOutput,
       shouldShowPlanMessage: this.shouldShowPlanMessage,

--- a/ui/app/routes/jobs/job/definition.js
+++ b/ui/app/routes/jobs/job/definition.js
@@ -7,16 +7,15 @@ export default class DefinitionRoute extends Route {
 
     const definition = await job.fetchRawDefinition();
 
-    const definitionWithoutSpecification = { ...definition };
-    delete definitionWithoutSpecification.Specification;
+    const hasSpecification = !!definition?.Specification;
 
-    const specification = await new Blob([
-      definition?.Specification?.Definition,
-    ]).text();
+    const specification = hasSpecification
+      ? await new Blob([definition?.Specification?.Definition]).text()
+      : null;
 
     return {
       job,
-      definition: definitionWithoutSpecification,
+      definition,
       specification,
     };
   }

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -2,23 +2,25 @@
     <div class="boxed-section-head">
     Job Definition
     <div class="pull-right" style="display: flex">
+        {{#if @data.hasSpecification}}
         <div class="select-mode" data-test-toggle={{@data.view}}>
-        <button 
-            class="button is-small is-borderless {{if (eq @data.view "job-spec") "is-active"}}"
-            type="button"
-            {{on "click" @fns.onToggle}}
-        >
-            Job Spec
-        </button>
-        <button 
-            class="button is-small is-borderless {{if (eq @data.view "full-definition") "is-active"}}"
-            type="button"
-            {{on "click" @fns.onToggle}}
-            data-test-toggle-full
-        >
-            Full Definition
-        </button>
+            <button 
+                class="button is-small is-borderless {{if (eq @data.view "job-spec") "is-active"}}"
+                type="button"
+                {{on "click" @fns.onToggle}}
+            >
+                Job Spec
+            </button>
+            <button 
+                class="button is-small is-borderless {{if (eq @data.view "full-definition") "is-active"}}"
+                type="button"
+                {{on "click" @fns.onToggle}}
+                data-test-toggle-full
+            >
+                Full Definition
+            </button>
         </div>
+        {{/if}}
         <button
             class="button is-light is-compact"
             type="button"
@@ -27,7 +29,7 @@
         >
             Edit
         </button>
-    </div>
+        </div>
     </div>
     <div class="boxed-section-body is-full-bleed">
     {{#if (eq @data.view "job-spec")}}

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -68,6 +68,102 @@ function smallCluster(server) {
     id: 'service-haver',
     namespaceId: 'default',
   });
+  server.create('job', {
+    name: 'hcl-definition-job',
+    id: 'display-hcl',
+    namespaceId: 'default',
+    Specification: {
+      Definition: `# This declares a job named "docs". There can be exactly one job declaration per job file.
+    # This is a sample job for Mirage fixture purposes and not tied to anything.
+    job "docs" {
+      # Specify this job should run in the region named "us". Regions
+      # are defined by the Nomad servers' configuration.
+      region = "us"
+    
+      # Spread the tasks in this job between us-west-1 and us-east-1.
+      datacenters = ["us-west-1", "us-east-1"]
+    
+      # Run this job as a "service" type. Each job type has different
+      # properties. See the documentation below for more examples.
+      type = "service"
+    
+      # Specify this job to have rolling updates, two-at-a-time, with
+      # 30 second intervals.
+      update {
+        stagger      = "30s"
+        max_parallel = 2
+      }
+    
+    
+      # A group defines a series of tasks that should be co-located
+      # on the same client (host). All tasks within a group will be
+      # placed on the same host.
+      group "webs" {
+        # Specify the number of these tasks we want.
+        count = 5
+    
+        network {
+          # This requests a dynamic port named "http". This will
+          # be something like "46283", but we refer to it via the
+          # label "http".
+          port "http" {}
+    
+          # This requests a static port on 443 on the host. This
+          # will restrict this task to running once per host, since
+          # there is only one port 443 on each host.
+          port "https" {
+            static = 443
+          }
+        }
+    
+        # The service block tells Nomad how to register this service
+        # with Consul for service discovery and monitoring.
+        service {
+          # This tells Consul to monitor the service on the port
+          # labelled "http". Since Nomad allocates high dynamic port
+          # numbers, we use labels to refer to them.
+          port = "http"
+    
+          check {
+            type     = "http"
+            path     = "/health"
+            interval = "10s"
+            timeout  = "2s"
+          }
+        }
+    
+        # Create an individual task (unit of work). This particular
+        # task utilizes a Docker container to front a web application.
+        task "frontend" {
+          # Specify the driver to be "docker". Nomad supports
+          # multiple drivers.
+          driver = "docker"
+    
+          # Configuration is specific to each driver.
+          config {
+            image = "hashicorp/web-frontend"
+            ports = ["http", "https"]
+          }
+    
+          # It is possible to set environment variables which will be
+          # available to the task when it runs.
+          env {
+            DB_HOST = "db01.example.com"
+            DB_USER = "web"
+            DB_PASS = "loremipsum"
+          }
+    
+          # Specify the maximum resources required to run the task,
+          # include CPU and memory.
+          resources {
+            cpu    = 500 # MHz
+            memory = 128 # MB
+          }
+        }
+      }
+    }`,
+    },
+  });
   server.createList('allocFile', 5);
   server.create('allocFile', 'dir', { depth: 2 });
   server.createList('csi-plugin', 2);


### PR DESCRIPTION
This PR updates the `default` Mirage scenario to include a `Job` that has the new `Specification` field required to display HCL in the UI. Note:  Older jobs will not have this field.