### PR TITLE
ui:  conditionally render toggle in `jobs.job.definition`

### DIFF
--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -12,12 +12,13 @@ export default class JobEditor extends Component {
 
   @tracked error = null;
   @tracked planOutput = null;
-  @tracked view = 'job-spec';
   @tracked isEditing;
+  @tracked view;
 
   constructor() {
     super(...arguments);
     this.isEditing = !!(this.args.context === 'new');
+    this.view = this.args.specification ? 'job-spec' : 'full-definition';
   }
 
   toggleEdit(bool) {
@@ -141,6 +142,7 @@ export default class JobEditor extends Component {
     return {
       cancelable: this.args.cancelable,
       definition: this.definition,
+      hasSpecification: !!this.args.specification,
       job: this.args.job,
       planOutput: this.planOutput,
       shouldShowPlanMessage: this.shouldShowPlanMessage,

--- a/ui/app/routes/jobs/job/definition.js
+++ b/ui/app/routes/jobs/job/definition.js
@@ -7,16 +7,15 @@ export default class DefinitionRoute extends Route {
 
     const definition = await job.fetchRawDefinition();
 
-    const definitionWithoutSpecification = { ...definition };
-    delete definitionWithoutSpecification.Specification;
+    const hasSpecification = !!definition?.Specification;
 
-    const specification = await new Blob([
-      definition?.Specification?.Definition,
-    ]).text();
+    const specification = hasSpecification
+      ? await new Blob([definition?.Specification?.Definition]).text()
+      : null;
 
     return {
       job,
-      definition: definitionWithoutSpecification,
+      definition,
       specification,
     };
   }

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -2,23 +2,25 @@
     <div class="boxed-section-head">
     Job Definition
     <div class="pull-right" style="display: flex">
+        {{#if @data.hasSpecification}}
         <div class="select-mode" data-test-toggle={{@data.view}}>
-        <button 
-            class="button is-small is-borderless {{if (eq @data.view "job-spec") "is-active"}}"
-            type="button"
-            {{on "click" @fns.onToggle}}
-        >
-            Job Spec
-        </button>
-        <button 
-            class="button is-small is-borderless {{if (eq @data.view "full-definition") "is-active"}}"
-            type="button"
-            {{on "click" @fns.onToggle}}
-            data-test-toggle-full
-        >
-            Full Definition
-        </button>
+            <button 
+                class="button is-small is-borderless {{if (eq @data.view "job-spec") "is-active"}}"
+                type="button"
+                {{on "click" @fns.onToggle}}
+            >
+                Job Spec
+            </button>
+            <button 
+                class="button is-small is-borderless {{if (eq @data.view "full-definition") "is-active"}}"
+                type="button"
+                {{on "click" @fns.onToggle}}
+                data-test-toggle-full
+            >
+                Full Definition
+            </button>
         </div>
+        {{/if}}
         <button
             class="button is-light is-compact"
             type="button"
@@ -27,7 +29,7 @@
         >
             Edit
         </button>
-    </div>
+        </div>
     </div>
     <div class="boxed-section-body is-full-bleed">
     {{#if (eq @data.view "job-spec")}}


### PR DESCRIPTION
Older jobs do not have a `Specification` field. Therefore, we'll need to conditionally render the toggle button.

![image](https://user-images.githubusercontent.com/41024828/225129850-4d13af81-536b-419a-880c-c3ab89caf8fe.png)
