### PR TITLE
test: set BuildDate in default TestAgent config

### DIFF
--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -340,6 +340,7 @@ func (a *TestAgent) pickRandomPorts(c *Config) {
 // TestConfig returns a unique default configuration for testing an agent.
 func (a *TestAgent) config() *Config {
 	conf := DevConfig(nil)
+	conf.Version.BuildDate = time.Now()
 
 	// Customize the server configuration
 	config := nomad.DefaultConfig()


### PR DESCRIPTION
Without this, various enterprise tests will fail due to the default zero time being guarded against in an upcoming enterprise change.  Here it should do nothing.

relates to: hashicorp/nomad-enterprise#855