### PR TITLE
cli: nomad login command should not require a -type flag and should respect default auth method

### DIFF
--- a/.changelog/16504.txt
+++ b/.changelog/16504.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a bug in the login command that did not checked if there was a default ACL Auth Method
+```

--- a/.changelog/16504.txt
+++ b/.changelog/16504.txt
@@ -1,3 +1,6 @@
-```release-note:bug
-cli: Fixed a bug in the login command that did not checked if there was a default ACL Auth Method
+```release-note:breaking-change
+cli: Changed the behavior of nomad login command. It no longer requires a
+"type" flag, since auth method names are globally unique. This also fixes the
+reported bug where nomad login would disregard existence of the default auth
+method if no method name or type was provided.
 ```

--- a/.changelog/16504.txt
+++ b/.changelog/16504.txt
@@ -1,6 +1,7 @@
 ```release-note:breaking-change
-cli: Changed the behavior of nomad login command. It no longer requires a
-"type" flag, since auth method names are globally unique. This also fixes the
-reported bug where nomad login would disregard existence of the default auth
-method if no method name or type was provided.
+cli: nomad login no longer requires -type flag, since auth method names are globally unique.
+```
+
+```release-note:bug
+cli: nomad login no longer ignores default auth method if they are present.
 ```

--- a/command/login.go
+++ b/command/login.go
@@ -149,7 +149,7 @@ func (l *LoginCommand) Run(args []string) int {
 		}
 	}
 
-	if l.authMethodType != defaultMethod.Type {
+	if defaultMethodAvailable && l.authMethodType != defaultMethod.Type {
 		l.Ui.Error(fmt.Sprintf(
 			"Specified type: %s does not match the type of the default method: %s",
 			l.authMethodType, defaultMethod.Type,

--- a/command/login.go
+++ b/command/login.go
@@ -144,6 +144,7 @@ func (l *LoginCommand) Run(args []string) int {
 				"Error: method %s not found in the state store. ",
 				l.authMethodName,
 			))
+			return 1
 		}
 	}
 
@@ -151,14 +152,6 @@ func (l *LoginCommand) Run(args []string) int {
 	// for the specific login implementation. This allows the command to have
 	// reusable and generic handling of errors and outputs.
 	var authFn func(context.Context, *api.Client) (*api.ACLToken, error)
-
-	switch methodType {
-	case api.ACLAuthMethodTypeOIDC:
-		authFn = l.loginOIDC
-	default:
-		l.Ui.Error(fmt.Sprintf("Unsupported authentication type %q", methodType))
-		return 1
-	}
 
 	ctx, cancel := contextWithInterrupt()
 	defer cancel()

--- a/command/login.go
+++ b/command/login.go
@@ -22,6 +22,7 @@ var _ cli.Command = &LoginCommand{}
 type LoginCommand struct {
 	Meta
 
+	authMethodType string // deprecated in 1.5.2, left for backwards compat
 	authMethodName string
 	callbackAddr   string
 
@@ -84,6 +85,7 @@ func (l *LoginCommand) Run(args []string) int {
 	flags := l.Meta.FlagSet(l.Name(), FlagSetClient)
 	flags.Usage = func() { l.Ui.Output(l.Help()) }
 	flags.StringVar(&l.authMethodName, "method", "", "")
+	flags.StringVar(&l.authMethodType, "type", "", "")
 	flags.StringVar(&l.callbackAddr, "oidc-callback-addr", "localhost:4649", "")
 	flags.BoolVar(&l.json, "json", false, "")
 	flags.StringVar(&l.template, "t", "", "")
@@ -108,6 +110,10 @@ func (l *LoginCommand) Run(args []string) int {
 		defaultMethod *api.ACLAuthMethodListStub
 		methodType    string
 	)
+
+	if l.authMethodType != "" {
+		l.Ui.Warn("warning: '-type' flag has been deprecated for nomad login command and will be ignored.")
+	}
 
 	authMethodList, _, err := client.ACLAuthMethods().List(nil)
 	if err != nil {

--- a/command/login.go
+++ b/command/login.go
@@ -153,6 +153,14 @@ func (l *LoginCommand) Run(args []string) int {
 	// reusable and generic handling of errors and outputs.
 	var authFn func(context.Context, *api.Client) (*api.ACLToken, error)
 
+	switch methodType {
+	case api.ACLAuthMethodTypeOIDC:
+		authFn = l.loginOIDC
+	default:
+		l.Ui.Error(fmt.Sprintf("Unsupported authentication type %q", methodType))
+		return 1
+	}
+
 	ctx, cancel := contextWithInterrupt()
 	defer cancel()
 

--- a/command/login_test.go
+++ b/command/login_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/command/agent"
-	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/mitchellh/cli"
 	"github.com/shoenig/test/must"
@@ -45,22 +44,9 @@ func TestLoginCommand_Run(t *testing.T) {
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()
 
-	// Store a default auth method
-	state := srv.Agent.Server().State()
-	method := &structs.ACLAuthMethod{
-		Name:    "test-auth-method",
-		Default: true,
-		Type:    "SAML",
-		Config: &structs.ACLAuthMethodConfig{
-			OIDCDiscoveryURL: "http://example.com",
-		},
-	}
-	method.SetHash()
-	must.NoError(t, state.UpsertACLAuthMethods(1000, []*structs.ACLAuthMethod{method}))
-
-	// Attempt to login using an unsupported type
-	must.Eq(t, 1, cmd.Run([]string{"-address=" + agentURL}))
-	must.StrContains(t, ui.ErrorWriter.String(), "Unsupported authentication type \"SAML\"")
+	// Attempt to login using a non-existing method
+	must.Eq(t, 1, cmd.Run([]string{"-address=" + agentURL, "-method", "there-is-no-such-method"}))
+	must.StrContains(t, ui.ErrorWriter.String(), "Error: method there-is-no-such-method not found in the state store. ")
 
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()

--- a/command/login_test.go
+++ b/command/login_test.go
@@ -39,16 +39,16 @@ func TestLoginCommand_Run(t *testing.T) {
 	ui.ErrorWriter.Reset()
 
 	// Attempt to call it with an unsupported method type.
-	must.Eq(t, 1, cmd.Run([]string{"-address=" + agentURL, "-type=SAML"}))
+	must.Eq(t, 1, cmd.Run([]string{"-address=" + agentURL, "-method=test-auth-method", "-type=SAML"}))
 	must.StrContains(t, ui.ErrorWriter.String(), `Unsupported authentication type "SAML"`)
 
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()
 
-	// Use a valid method type but with incorrect casing so we can ensure this
+	// Use a valid method type but with incorrect casing, so we can ensure this
 	// is handled.
 	must.Eq(t, 1, cmd.Run([]string{"-address=" + agentURL, "-type=oIdC"}))
-	must.StrContains(t, ui.ErrorWriter.String(), "Must specify an auth method name and type, no default found")
+	must.StrContains(t, ui.ErrorWriter.String(), "Must specify an auth method name, no default found")
 
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()

--- a/website/content/docs/commands/login.mdx
+++ b/website/content/docs/commands/login.mdx
@@ -28,10 +28,6 @@ requested auth method for a newly minted Nomad ACL token.
 - `-method`: The name of the ACL auth method to log in via. If the cluster
   administrator has configured a default, this flag is optional.
 
-- `-type`: Type of the auth method to log in via. If the cluster administrator
-  has configured a default, this flag is optional. Currently only supports
-  "OIDC".
-
 - `-oidc-callback-addr`: The address to use for the local OIDC callback server.
   This should be given in the form of `<IP>:<PORT>` and defaults to
   `localhost:4649`.
@@ -45,7 +41,7 @@ requested auth method for a newly minted Nomad ACL token.
 Login using an OIDC provider:
 
 ```shell-session
-$ nomad login -type=OIDC -method=auth0
+$ nomad login -method=auth0
 Successfully logged in via OIDC and auth0
 
 Accessor ID  = 68123fee-1e8b-7ecc-5b34-505ecd2dcb80


### PR DESCRIPTION
`nomad login` command does not need to know ACL Auth Method's type, since all method names are unique. I discovered this while fixing a bug in which `login` ignored the existence of default auth method and errored when users didn't provide a method name or type. I believe this bug comes from the fact that originally we intended to have default-per-type design, and later we decided it's better UX to have global-default auth methods. 

Closes #16501.