### PR TITLE
build: fix `test-nomad` make target when running locally.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -283,7 +283,7 @@ release: clean $(foreach t,$(ALL_TARGETS),pkg/$(t).zip) ## Build all release pac
 	@tree --dirsfirst $(PROJECT_ROOT)/pkg
 
 .PHONY: test-nomad
-test-nomad: GOTEST_PKGS=$(shell go run -modfile=tools/go.mod tools/missing/main.go ci/test-core.json $(GOTEST_GROUP))
+test-nomad: GOTEST_PKGS=$(foreach g,$(GOTEST_GROUP),$(shell go run -modfile=tools/go.mod tools/missing/main.go ci/test-core.json $(g)))
 test-nomad: # dev ## Run Nomad unit tests
 	@echo "==> Running Nomad unit tests $(GOTEST_GROUP)"
 	@echo "==> with packages $(GOTEST_PKGS)"


### PR DESCRIPTION
Previous to this change, Juanita and I were getting the following error when trying to run `make test-nomad`:

```
FAIL: usage: [filename] <group>
exit status 1
FAIL: usage: [filename] <group>
exit status 1
FAIL: usage: [filename] <group>
exit status 1
==> Running Nomad unit tests nomad client command drivers quick
==> with packages
gotestsum --format=testname --rerun-fails=3 --packages="" -- \
		-cover \
		-timeout=20m \
		-count=1 \
		-tags "ui " \

ERROR when go test args are used with --rerun-fails-max-attempts the list of packages to test must be specified by the --packages flag
make: *** [test-nomad] Error 3
```

Related: https://github.com/hashicorp/nomad/pull/16137