### PR TITLE
artifact: git needs more files for private repositories

### DIFF
--- a/.changelog/16495.txt
+++ b/.changelog/16495.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+artifact: Fixed a bug where artifact downloading failed when using git-ssh
+```

--- a/client/allocrunner/taskrunner/getter/util_linux.go
+++ b/client/allocrunner/taskrunner/getter/util_linux.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/shoenig/go-landlock"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -42,12 +43,35 @@ func credentials() (uint32, uint32) {
 	return userUID, userGID
 }
 
+// findHomeDir returns the home directory as provided by os.UserHomeDir. In case
+// os.UserHomeDir returns an error, we return /root if the current process is being
+// run by root, or /dev/null otherwise.
+func findHomeDir() string {
+	// When running as a systemd unit the process may not have the $HOME
+	// environment variable set, and os.UserHomeDir will return an error.
+
+	// if home is set, just use that
+	if home, err := os.UserHomeDir(); err == nil {
+		return home
+	}
+
+	// if we are the root user, use "/root"
+	if unix.Getuid() == 0 {
+		return "/root"
+	}
+
+	// nothing safe to do
+	return "/dev/null"
+}
+
 // defaultEnvironment is the default minimal environment variables for Linux.
 func defaultEnvironment(taskDir string) map[string]string {
 	tmpDir := filepath.Join(taskDir, "tmp")
+	homeDir := findHomeDir()
 	return map[string]string{
 		"PATH":   "/usr/local/bin:/usr/bin:/bin",
 		"TMPDIR": tmpDir,
+		"HOME":   homeDir,
 	}
 }
 
@@ -71,26 +95,60 @@ func lockdown(allocDir, taskDir string) error {
 		landlock.Dir(allocDir, "rwc"),
 		landlock.Dir(taskDir, "rwc"),
 	}
-	paths = append(paths, systemVersionControlGlobalConfigs()...)
+
+	paths = append(paths, additionalFilesForVCS()...)
 	locker := landlock.New(paths...)
 	return locker.Lock(landlock.Mandatory)
 }
 
-func systemVersionControlGlobalConfigs() []*landlock.Path {
+func additionalFilesForVCS() []*landlock.Path {
 	const (
+		sshDir        = ".ssh"                  // git ssh
+		knownHosts    = ".ssh/known_hosts"      // git ssh
+		etcPasswd     = "/etc/passwd"           // git ssh
 		gitGlobalFile = "/etc/gitconfig"        // https://git-scm.com/docs/git-config#SCOPES
 		hgGlobalFile  = "/etc/mercurial/hgrc"   // https://www.mercurial-scm.org/doc/hgrc.5.html#files
 		hgGlobalDir   = "/etc/mercurial/hgrc.d" // https://www.mercurial-scm.org/doc/hgrc.5.html#files
 	)
-	return loadVersionControlGlobalConfigs(gitGlobalFile, hgGlobalFile, hgGlobalDir)
+	return filesForVCS(
+		sshDir,
+		knownHosts,
+		etcPasswd,
+		gitGlobalFile,
+		hgGlobalFile,
+		hgGlobalDir,
+	)
 }
 
-func loadVersionControlGlobalConfigs(gitGlobalFile, hgGlobalFile, hgGlobalDir string) []*landlock.Path {
+func filesForVCS(
+	sshDir,
+	knownHosts,
+	etcPasswd,
+	gitGlobalFile,
+	hgGlobalFile,
+	hgGlobalDir string) []*landlock.Path {
+
+	// omit ssh if there is no home directory
+	home := findHomeDir()
+	sshDir = filepath.Join(home, sshDir)
+	knownHosts = filepath.Join(home, knownHosts)
+
+	// only add if a path exists
 	exists := func(p string) bool {
 		_, err := os.Stat(p)
 		return err == nil
 	}
-	result := make([]*landlock.Path, 0, 3)
+
+	result := make([]*landlock.Path, 0, 6)
+	if exists(sshDir) {
+		result = append(result, landlock.Dir(sshDir, "r"))
+	}
+	if exists(knownHosts) {
+		result = append(result, landlock.File(knownHosts, "rw"))
+	}
+	if exists(etcPasswd) {
+		result = append(result, landlock.File(etcPasswd, "r"))
+	}
 	if exists(gitGlobalFile) {
 		result = append(result, landlock.File(gitGlobalFile, "r"))
 	}

--- a/client/allocrunner/taskrunner/getter/util_linux.go
+++ b/client/allocrunner/taskrunner/getter/util_linux.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/shoenig/go-landlock"
 	"golang.org/x/sys/unix"
 )
@@ -51,7 +52,7 @@ func findHomeDir() string {
 	// environment variable set, and os.UserHomeDir will return an error.
 
 	// if home is set, just use that
-	if home, err := os.UserHomeDir(); err == nil {
+	if home, err := homedir.Dir(); err == nil {
 		return home
 	}
 

--- a/client/allocrunner/taskrunner/getter/util_linux.go
+++ b/client/allocrunner/taskrunner/getter/util_linux.go
@@ -61,7 +61,7 @@ func findHomeDir() string {
 	}
 
 	// nothing safe to do
-	return "/dev/null"
+	return "/nonexistent"
 }
 
 // defaultEnvironment is the default minimal environment variables for Linux.

--- a/client/allocrunner/taskrunner/getter/util_linux_test.go
+++ b/client/allocrunner/taskrunner/getter/util_linux_test.go
@@ -7,16 +7,24 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/shoenig/go-landlock"
 	"github.com/shoenig/test/must"
 )
 
 func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
+	// not parallel
+
 	const filePerm = 0o644
 	const dirPerm = 0o755
 
 	fakeEtc := t.TempDir()
 	fakeHome := t.TempDir()
+
+	homedir.DisableCache = true
+	t.Cleanup(func() {
+		homedir.DisableCache = false
+	})
 
 	t.Setenv("HOME", fakeHome)
 

--- a/client/allocrunner/taskrunner/getter/util_test.go
+++ b/client/allocrunner/taskrunner/getter/util_test.go
@@ -144,9 +144,12 @@ func TestUtil_environment(t *testing.T) {
 	// not parallel
 	testutil.RequireLinux(t)
 
+	t.Setenv("HOME", "/test")
+
 	t.Run("default", func(t *testing.T) {
 		result := environment("/a/b/c", "")
 		must.Eq(t, []string{
+			"HOME=/test",
 			"PATH=/usr/local/bin:/usr/bin:/bin",
 			"TMPDIR=/a/b/c/tmp",
 		}, result)
@@ -157,6 +160,7 @@ func TestUtil_environment(t *testing.T) {
 		t.Setenv("TWO", "2")
 		result := environment("/a/b/c", "ONE,TWO")
 		must.Eq(t, []string{
+			"HOME=/test",
 			"ONE=1",
 			"PATH=/usr/local/bin:/usr/bin:/bin",
 			"TMPDIR=/a/b/c/tmp",
@@ -169,6 +173,7 @@ func TestUtil_environment(t *testing.T) {
 		t.Setenv("TMPDIR", "/scratch")
 		result := environment("/a/b/c", "PATH,TMPDIR")
 		must.Eq(t, []string{
+			"HOME=/test",
 			"PATH=/opt/bin",
 			"TMPDIR=/scratch",
 		}, result)
@@ -178,6 +183,31 @@ func TestUtil_environment(t *testing.T) {
 		result := environment("/a/b/c", "DOES_NOT_EXIST")
 		must.Eq(t, []string{
 			"DOES_NOT_EXIST=",
+			"HOME=/test",
+			"PATH=/usr/local/bin:/usr/bin:/bin",
+			"TMPDIR=/a/b/c/tmp",
+		}, result)
+	})
+
+	t.Run("homeless non-root", func(t *testing.T) {
+		testutil.RequireNonRoot(t)
+		t.Setenv("HOME", "")
+
+		result := environment("/a/b/c", "")
+		must.Eq(t, []string{
+			"HOME=/dev/null",
+			"PATH=/usr/local/bin:/usr/bin:/bin",
+			"TMPDIR=/a/b/c/tmp",
+		}, result)
+	})
+
+	t.Run("homeless root", func(t *testing.T) {
+		testutil.RequireRoot(t)
+		t.Setenv("HOME", "")
+
+		result := environment("/a/b/c", "")
+		must.Eq(t, []string{
+			"HOME=/root",
 			"PATH=/usr/local/bin:/usr/bin:/bin",
 			"TMPDIR=/a/b/c/tmp",
 		}, result)

--- a/client/allocrunner/taskrunner/getter/util_test.go
+++ b/client/allocrunner/taskrunner/getter/util_test.go
@@ -220,6 +220,8 @@ func TestUtil_environment(t *testing.T) {
 	t.Run("homeless root", func(t *testing.T) {
 		testutil.RequireRoot(t)
 
+		t.Setenv("HOME", "/root") // fake running as full root
+
 		// assert we fallback via go-homdir ...
 		userHome, err := homedir.Dir()
 		must.NoError(t, err)

--- a/client/allocrunner/taskrunner/getter/util_test.go
+++ b/client/allocrunner/taskrunner/getter/util_test.go
@@ -3,7 +3,6 @@ package getter
 import (
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/go-getter"
@@ -204,7 +203,7 @@ func TestUtil_environment(t *testing.T) {
 		testutil.RequireNonRoot(t)
 
 		// assert we fallback via go-homdir ...
-		userHome, err := os.UserHomeDir()
+		userHome, err := homedir.Dir()
 		must.NoError(t, err)
 
 		// ... when HOME env var is not set, as is the case in some systemd setups
@@ -222,7 +221,7 @@ func TestUtil_environment(t *testing.T) {
 		testutil.RequireRoot(t)
 
 		// assert we fallback via go-homdir ...
-		userHome, err := os.UserHomeDir()
+		userHome, err := homedir.Dir()
 		must.NoError(t, err)
 
 		// ... when HOME env var is not set, as is the case in some systemd setups

--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/mitchellh/colorstring v0.0.0-20150917214807-8631ce90f286
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/go-glint v0.0.0-20210722152315-6515ceb4a127
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b
 	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/mitchellh/hashstructure v1.1.0
@@ -226,7 +227,6 @@ require (
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/mattn/go-runewidth v0.0.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/pointerstructure v1.2.1
 	github.com/morikuni/aec v1.0.0 // indirect


### PR DESCRIPTION
This PR fixes artifact downloading so that git may work when cloning from
private repositories. It needs

- file read on `/etc/passwd`
- dir read on `/root/.ssh`
- file write on `/root/.ssh/known_hosts`

Add these rules to the landlock rules for the artifact sandbox.

Fixes https://github.com/hashicorp/nomad/issues/16477