### PR TITLE
artifact: do not set process attributes on darwin

### DIFF
--- a/client/allocrunner/taskrunner/getter/util_default.go
+++ b/client/allocrunner/taskrunner/getter/util_default.go
@@ -7,23 +7,19 @@ import (
 	"syscall"
 )
 
-// attributes returns the system process attributes to run
-// the sandbox process with
+// attributes is not implemented by default
 func attributes() *syscall.SysProcAttr {
-	uid, gid := credentials()
-	return &syscall.SysProcAttr{
-		Credential: &syscall.Credential{
-			Uid: uid,
-			Gid: gid,
-		},
-	}
+	return nil
 }
 
-// credentials returns the credentials of the user Nomad is running as
+// credentials is not implemented by default
 func credentials() (uint32, uint32) {
-	uid := syscall.Getuid()
-	gid := syscall.Getgid()
-	return uint32(uid), uint32(gid)
+	return 0, 0
+}
+
+// lockdown is not implemented by default
+func lockdown(string, string) error {
+	return nil
 }
 
 // defaultEnvironment is the default minimal environment variables for Unix-like
@@ -34,9 +30,4 @@ func defaultEnvironment(taskDir string) map[string]string {
 		"PATH":   "/usr/local/bin:/usr/bin:/bin",
 		"TMPDIR": tmpDir,
 	}
-}
-
-// lockdown applies only to Linux
-func lockdown(string, string) error {
-	return nil
 }

--- a/client/allocrunner/taskrunner/getter/util_windows.go
+++ b/client/allocrunner/taskrunner/getter/util_windows.go
@@ -8,17 +8,17 @@ import (
 	"syscall"
 )
 
-// attributes returns the system process attributes to run
-// the sandbox process with
+// attributes is not implemented on Windows
 func attributes() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{}
+	return nil
 }
 
+// credentials is not implemented on Windows
 func credentials() (uint32, uint32) {
 	return 0, 0
 }
 
-// lockdown has no effect on windows
+// lockdown is not implemented on Windows
 func lockdown(string, string) error {
 	return nil
 }


### PR DESCRIPTION
This PR fixes the non-root macOS use case where artifact downloads
stopped working. It seems setting a Credential on a SysProcAttr
used by the exec package will always cause fork/exec to fail -
even if the credential contains our own UID/GID or nil UID/GID.

Technically we do not need to set this as the child process will
inherit the parent UID/GID anyway... and not setting it makes
things work again ... /shrug
