### PR TITLE
artifact: use specific version link for zipbomb artifact

### DIFF
--- a/e2e/artifact/input/artifact_limits.nomad
+++ b/e2e/artifact/input/artifact_limits.nomad
@@ -22,7 +22,7 @@ job "linux" {
 
     task "zip_bomb" {
       artifact {
-        source      = "https://github.com/hashicorp/go-getter/raw/main/testdata/decompress-zip/bomb.zip"
+        source      = "https://github.com/hashicorp/go-getter/blob/v1.7.0/testdata/decompress-zip/bomb.zip"
         destination = "local/"
       }
 


### PR DESCRIPTION
Fix the e2e case where we download the go-getter bomb.zip test file, which
is being removed on main. We can still get it from the version tag - yay git!
