### PR TITLE
docs: dispatch_payload and jobs api docs had some weirdness

### DIFF
--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -237,7 +237,7 @@ The table below shows this endpoint's support for
 
 - `HCLv1` `(bool: false)` - Use the legacy v1 HCL parser.
 
-## Sample Payload
+### Sample Payload
 
 ```json
 {

--- a/website/content/docs/job-specification/dispatch_payload.mdx
+++ b/website/content/docs/job-specification/dispatch_payload.mdx
@@ -3,7 +3,6 @@ layout: docs
 page_title: dispatch_payload Block - Job Specification
 description: |-
   The "dispatch_payload" block allows a task to access dispatch payloads.
-  to
 ---
 
 # `dispatch_payload` Block
@@ -34,12 +33,7 @@ job "docs" {
   dispatch payload to. The file is written relative to the [task's local
   directory][localdir].
 
-## `dispatch_payload` Examples
-
-The following examples only show the `dispatch_payload` blocks. Remember that the
-`dispatch_payload` block is only valid in the placements listed above.
-
-### Write Payload to a File
+## `dispatch_payload` Example
 
 This example shows a `dispatch_payload` block in a parameterized job that writes
 the payload to a `config.json` file.


### PR DESCRIPTION
* dispatch_payload - Docs said "Examples" when there was only 1 example. Not sure what the floating "to" in the description was for.
* jobs api docs just had an extra `#` for one heading