### PR TITLE
Enable ACLs on E2E test clients

### DIFF
--- a/e2e/terraform/etc/nomad.d/base.hcl
+++ b/e2e/terraform/etc/nomad.d/base.hcl
@@ -7,6 +7,16 @@ audit {
   enabled = true
 }
 
+acl {
+  enabled = true
+
+  # These values are used by the testACLTokenExpiration test within the acl
+  # test suite. If these need to be updated, please ensure the new values are
+  # reflected within the test suite and do not break the tests. Thanks.
+  token_min_expiration_ttl = "1s"
+  token_max_expiration_ttl = "24h"
+}
+
 telemetry {
   collection_interval        = "1s"
   disable_hostname           = true

--- a/e2e/terraform/etc/nomad.d/server-linux.hcl
+++ b/e2e/terraform/etc/nomad.d/server-linux.hcl
@@ -2,13 +2,3 @@ server {
   enabled          = true
   bootstrap_expect = 3
 }
-
-acl {
-  enabled = true
-
-  # These values are used by the testACLTokenExpiration test within the acl
-  # test suite. If these need to be updated, please ensure the new values are
-  # reflected within the test suite and do not break the tests. Thanks.
-  token_min_expiration_ttl = "1s"
-  token_max_expiration_ttl = "24h"
-}

--- a/website/content/docs/configuration/acl.mdx
+++ b/website/content/docs/configuration/acl.mdx
@@ -26,10 +26,11 @@ acl {
 ## `acl` Parameters
 
 - `enabled` `(bool: false)` - Specifies if ACL enforcement is enabled. All other
-  ACL configuration options depend on this value. Note that the Nomad command
-  line client will send requests for client endpoints such as `alloc exec`
-  directly to Nomad clients whenever they are accessible. In this scenario, the
-  client will enforce ACLs, so both servers and clients should have ACLs enabled.
+  ACL configuration options depend on this value. All agents should have the
+  same value for this parameter. For example the Nomad command line will
+  send requests for client endpoints such as `alloc exec` directly to Nomad
+  clients whenever they are accessible. In this scenario, the client will
+  enforce ACLs, so both servers and clients should have ACLs enabled.
 
 - `token_ttl` `(string: "30s")` - Specifies the maximum time-to-live (TTL) for
   cached ACL tokens. This does not affect servers, since they do not cache tokens.


### PR DESCRIPTION
I also updated the docs to hopefully make it more clear that ACLs should be uniformly enabled or disabled on all nodes. I wouldn't mind making it bold or a note or something because I really don't want to give the impression we support a mixed-auth world. Hopefully in the near future it will be an auth-only world and this easy-get-wrong config will go away!