### PR TITLE
changelog: update #16427 to improvement

### DIFF
--- a/.changelog/16427.txt
+++ b/.changelog/16427.txt
@@ -1,3 +1,3 @@
-```release-note:security
+```release-note:improvement
 build: Update to go1.20.2
 ```


### PR DESCRIPTION
The security fix in Go 1.20.2 does not apply to Nomad.