### PR TITLE
chore: add mirage fixture

### DIFF
--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -162,6 +162,10 @@ function smallCluster(server) {
         }
       }
     }`,
+      Variables: {
+        datacenters: ['west'],
+        external_port: 4000,
+      },
     },
   });
   server.createList('allocFile', 5);


### PR DESCRIPTION
This PR adds a variable table so the Vercel deployment displays a variables table.