### PR TITLE
core: add 50 hop limit to rpc forwarding

### DIFF
--- a/nomad/rpc.go
+++ b/nomad/rpc.go
@@ -535,6 +535,10 @@ func (r *rpcHandler) handleMultiplexV2(ctx context.Context, conn net.Conn, rpcCt
 // forward is used to forward to a remote region or to forward to the local leader
 // Returns a bool of if forwarding was performed, as well as any error
 func (r *rpcHandler) forward(method string, info structs.RPCInfo, args interface{}, reply interface{}) (bool, error) {
+	if info.NumHops() > 50 {
+		return true, fmt.Errorf("exceeded hop limit")
+	}
+
 	region := info.RequestRegion()
 	if region == "" {
 		return true, fmt.Errorf("missing region for target RPC")

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -228,6 +228,7 @@ type RPCInfo interface {
 	AllowStaleRead() bool
 	IsForwarded() bool
 	SetForwarded()
+	NumHops() int16
 	TimeToBlock() time.Duration
 	// SetTimeToBlock sets how long this request can block. The requested time may not be possible,
 	// so Callers should readback TimeToBlock. E.g. you cannot set time to block at all on WriteRequests
@@ -240,6 +241,11 @@ type RPCInfo interface {
 type InternalRpcInfo struct {
 	// Forwarded marks whether the RPC has been forwarded.
 	Forwarded bool
+	Hops      int16
+}
+
+func (i *InternalRpcInfo) NumHops() int16 {
+	return i.Hops
 }
 
 // IsForwarded returns whether the RPC is forwarded from another server.
@@ -250,6 +256,7 @@ func (i *InternalRpcInfo) IsForwarded() bool {
 // SetForwarded marks that the RPC is being forwarded from another server.
 func (i *InternalRpcInfo) SetForwarded() {
 	i.Forwarded = true
+	i.Hops++
 }
 
 // QueryOptions is used to specify various flags for read queries


### PR DESCRIPTION
If I add an infinite loop due to client RPCs as in #16517, I now get a hideous error message like this in **21ms**:

```
$ nomad node meta read -node-id 36
Error reading dynamic node metadata: Unexpected response code: 500 (rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: rpc error: exceeded hop limit)
```

I think this is probably a good failsafe, although making the error friendlier would be nice.

I should be able to test it by adding a custom _broken_ handler to a Server.

I think the maximum number of hops if everything goes well is **3** as HTTP->RPC isn't counted, and Client RPCs mostly aren't counted (although could be? :thinking:)

1. Intra-region stale read max hops (1): Server
2. Intra-region write max hops (2): Follower -> Leader
3. Inter-region stale read max hops (2): Region 1 Server -> R2 Server
4. Inter-region write max hops (3): Region 1 Server -> R2 Follower -> R2 Leader

That being said requests across leadership elections may get forwarded more than once, and I'd hate to set this so low it unexpectedly broke some future feature. 50 hops in 21ms (**locally**).