### PR TITLE
[ui] fix typo ("alocations" -> "allocations")

### DIFF
--- a/ui/app/templates/jobs/job/services/index.hbs
+++ b/ui/app/templates/jobs/job/services/index.hbs
@@ -10,7 +10,7 @@
 				<t.sort-by @prop="name">Name</t.sort-by>
 				<t.sort-by @prop="level">Level</t.sort-by>
 				<th>Tags</th>
-				<t.sort-by @prop="numAllocs">Number of Alocations</t.sort-by>
+				<t.sort-by @prop="numAllocs">Number of Allocations</t.sort-by>
 			</t.head>
 			<t.body as |row|>
 				<JobServiceRow


### PR DESCRIPTION
Hi! I noticed this tiny typo in the Nomad services pane & thought y'all might like a fix for that. Thanks for all your hard work on Nomad! :heart: