### PR TITLE
Multiple instances of a periodic job are run simultaneously, when prohibit_overlap is true

### DIFF
--- a/.changelog/16583.txt
+++ b/.changelog/16583.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server: Added verification of cron jobs already running before forcing new evals right after leader change
+```

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -780,7 +780,6 @@ func (s *Server) restorePeriodicDispatcher() error {
 		if err != nil {
 			return fmt.Errorf("failed to get job status: %v", err)
 		}
-
 		if !needed {
 			continue
 		}

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -799,7 +799,6 @@ func (s *Server) restorePeriodicDispatcher() error {
 // instances of the job running in order to determine if a new evaluation needs to
 // be created upon periodic dispatcher restore
 func (s *Server) cronJobOverlapAllowed(job *structs.Job) (bool, error) {
-
 	if job.Periodic.ProhibitOverlap {
 		running, err := s.periodicDispatcher.dispatcher.RunningChildren(job)
 		if err != nil {

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -776,11 +776,11 @@ func (s *Server) restorePeriodicDispatcher() error {
 
 		// We skip if the job doesn't allow overlap and there are already
 		// instances running
-		needed, err := s.isNewEvalNeeded(job)
+		allowed, err := s.cronJobOverlapAllowed(job)
 		if err != nil {
 			return fmt.Errorf("failed to get job status: %v", err)
 		}
-		if !needed {
+		if !allowed {
 			continue
 		}
 
@@ -795,10 +795,10 @@ func (s *Server) restorePeriodicDispatcher() error {
 	return nil
 }
 
-// isNewEvalNeeded checks if the job allows for overlap and if there are already
+// cronJobOverlapAllowed checks if the job allows for overlap and if there are already
 // instances of the job running in order to determine if a new evaluation needs to
 // be created upon periodic dispatcher restore
-func (s *Server) isNewEvalNeeded(job *structs.Job) (bool, error) {
+func (s *Server) cronJobOverlapAllowed(job *structs.Job) (bool, error) {
 
 	if job.Periodic.ProhibitOverlap {
 		running, err := s.periodicDispatcher.dispatcher.RunningChildren(job)

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -790,7 +790,7 @@ func (s *Server) restorePeriodicDispatcher() error {
 			return fmt.Errorf("force run of periodic job %q failed: %v", job.NamespacedID(), err)
 		}
 
-		logger.Debug("periodic job force runned during leadership establishment", "job", job.NamespacedID())
+		logger.Debug("periodic job force run during leadership establishment", "job", job.NamespacedID())
 	}
 
 	return nil
@@ -800,8 +800,9 @@ func (s *Server) restorePeriodicDispatcher() error {
 // instances of the job running in order to determine if a new evaluation needs to
 // be created upon periodic dispatcher restore
 func (s *Server) isNewEvalNeeded(job *structs.Job) (bool, error) {
+
 	if job.Periodic.ProhibitOverlap {
-		running, err := s.RunningChildren(job)
+		running, err := s.periodicDispatcher.dispatcher.RunningChildren(job)
 		if err != nil {
 			return false, fmt.Errorf("failed to determine if periodic job has running children %q error %q", job.NamespacedID(), err)
 		}

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -774,11 +774,15 @@ func (s *Server) restorePeriodicDispatcher() error {
 			continue
 		}
 
-		if _, err := s.periodicDispatcher.ForceEval(job.Namespace, job.ID); err != nil {
+		eval, err := s.periodicDispatcher.ForceRunIfNotRunning(job)
+		if err != nil {
 			logger.Error("force run of periodic job failed", "job", job.NamespacedID(), "error", err)
 			return fmt.Errorf("force run of periodic job %q failed: %v", job.NamespacedID(), err)
 		}
-		logger.Debug("periodic job force runned during leadership establishment", "job", job.NamespacedID())
+
+		if eval != nil {
+			logger.Debug("periodic job force ran during leadership establishment", "job", job.NamespacedID())
+		}
 	}
 
 	return nil

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -784,7 +784,7 @@ func (s *Server) restorePeriodicDispatcher() error {
 			continue
 		}
 
-		if _, err := s.periodicDispatcher.ForceRun(job.Namespace, job.ID); err != nil {
+		if _, err := s.periodicDispatcher.ForceEval(job.Namespace, job.ID); err != nil {
 			logger.Error("force run of periodic job failed", "job", job.NamespacedID(), "error", err)
 			return fmt.Errorf("force run of periodic job %q failed: %v", job.NamespacedID(), err)
 		}

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -411,7 +411,7 @@ func TestLeader_PeriodicDispatcher_Restore_NoEvals(t *testing.T) {
 	now := time.Now()
 
 	// Sleep till after the job should have been launched.
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// Restore the periodic dispatcher.
 	s1.periodicDispatcher.SetEnabled(true)
@@ -571,7 +571,7 @@ func TestLeader_PeriodicDispatcher_No_Overlaps_No_Running_Job(t *testing.T) {
 	s1.periodicDispatcher.SetEnabled(false)
 
 	// Sleep till after the job should have been launched.
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// Restore the periodic dispatcher.
 	s1.periodicDispatcher.SetEnabled(true)
@@ -644,7 +644,7 @@ func TestLeader_PeriodicDispatcher_No_Overlaps_Running_Job(t *testing.T) {
 	s1.periodicDispatcher.SetEnabled(false)
 
 	// Sleep till after the job should have been launched.
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// Restore the periodic dispatcher.
 	s1.periodicDispatcher.SetEnabled(true)

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -444,7 +444,7 @@ type mockJobEvalDispatcher struct {
 	JobEvalDispatcher
 }
 
-func (mjed *mockJobEvalDispatcher) DispatchJob(job *structs.Job) (*structs.Evaluation, error) {
+func (mjed *mockJobEvalDispatcher) DispatchJob(_ *structs.Job) (*structs.Evaluation, error) {
 	mjed.forceEvalCalled = true
 	return mjed.evalToReturn, nil
 }

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -622,9 +622,7 @@ func TestLeader_PeriodicDispatcher_No_Overlaps_Running_Job(t *testing.T) {
 		},
 	}
 	_, _, err := s1.raftApply(structs.JobRegisterRequestType, req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	must.NoError(t, err)
 
 	// Create an eval for the past launch.
 	eval, err := s1.periodicDispatcher.createEval(job, past)

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -527,9 +527,7 @@ func TestLeader_PeriodicDispatcher_Restore_Evals(t *testing.T) {
 		t.Fatalf("restorePeriodicDispatcher did not force launch")
 	}
 
-	if md.forceEvalCalled != true {
-		t.Fatalf("failed to force job evaluation")
-	}
+	must.True(t, md.forceEvalCalled, must.Sprint("failed to force job evaluation"))
 }
 
 func TestLeader_PeriodicDispatcher_No_Overlaps_No_Running_Job(t *testing.T) {

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -595,9 +595,7 @@ func TestLeader_PeriodicDispatcher_No_Overlaps_No_Running_Job(t *testing.T) {
 		t.Fatalf("restorePeriodicDispatcher did not force launch")
 	}
 
-	if md.forceEvalCalled != true {
-		t.Fatalf("failed to force job evaluation")
-	}
+	must.True(t, md.forceEvalCalled, must.Sprint("failed to force job evaluation"))
 	t.Fail()
 }
 

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -649,9 +649,7 @@ func TestLeader_PeriodicDispatcher_No_Overlaps_Running_Job(t *testing.T) {
 		ID:        job.ID,
 		Namespace: job.Namespace,
 	}
-	if _, tracked := s1.periodicDispatcher.tracked[tuple]; !tracked {
-		t.Fatalf("periodic job not restored")
-	}
+	must.MapContainsKey(t, s1.periodicDispatcher.tracked, tuple, must.Sprint("periodic job not restored"))
 
 	if md.forceEvalCalled != false {
 		t.Fatalf("evaluation forced with job already running")

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -573,7 +573,7 @@ func TestLeader_PeriodicDispatcher_No_Overlaps_No_Running_Job(t *testing.T) {
 
 	// Restore the periodic dispatcher.
 	s1.periodicDispatcher.SetEnabled(true)
-	s1.restorePeriodicDispatcher()
+	must.NoError(t, s1.restorePeriodicDispatcher())
 
 	// Ensure the job is tracked.
 	tuple := structs.NamespacedID{

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -651,9 +651,7 @@ func TestLeader_PeriodicDispatcher_No_Overlaps_Running_Job(t *testing.T) {
 	}
 	must.MapContainsKey(t, s1.periodicDispatcher.tracked, tuple, must.Sprint("periodic job not restored"))
 
-	if md.forceEvalCalled != false {
-		t.Fatalf("evaluation forced with job already running")
-	}
+	must.False(t, md.forceEvalCalled, must.Sprint("evaluation forced with job already running"))
 }
 
 func TestLeader_PeriodicDispatch(t *testing.T) {

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -580,9 +580,7 @@ func TestLeader_PeriodicDispatcher_No_Overlaps_No_Running_Job(t *testing.T) {
 		ID:        job.ID,
 		Namespace: job.Namespace,
 	}
-	if _, tracked := s1.periodicDispatcher.tracked[tuple]; !tracked {
-		t.Fatalf("periodic job not restored")
-	}
+	must.MapContainsKey(t, s1.periodicDispatcher.tracked, tuple, must.Sprint("periodic job not restored"))
 
 	// Check that an eval was made.
 	ws := memdb.NewWatchSet()

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -595,7 +595,6 @@ func TestLeader_PeriodicDispatcher_No_Overlaps_No_Running_Job(t *testing.T) {
 	}
 
 	must.True(t, md.forceEvalCalled, must.Sprint("failed to force job evaluation"))
-	t.Fail()
 }
 
 func TestLeader_PeriodicDispatcher_No_Overlaps_Running_Job(t *testing.T) {

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -449,7 +449,7 @@ func (mjed *mockJobEvalDispatcher) DispatchJob(_ *structs.Job) (*structs.Evaluat
 	return mjed.evalToReturn, nil
 }
 
-func (mjed *mockJobEvalDispatcher) RunningChildren(job *structs.Job) (bool, error) {
+func (mjed *mockJobEvalDispatcher) RunningChildren(_ *structs.Job) (bool, error) {
 	return mjed.children, nil
 }
 

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -590,9 +590,7 @@ func TestLeader_PeriodicDispatcher_No_Overlaps_No_Running_Job(t *testing.T) {
 	must.NoError(t, err)
 	must.NotNil(t, last)
 
-	if last.Launch == past {
-		t.Fatalf("restorePeriodicDispatcher did not force launch")
-	}
+	must.NotEq(t, last.Launch, past, must.Sprint("restorePeriodicDispatcher did not force launch"))
 
 	must.True(t, md.forceEvalCalled, must.Sprint("failed to force job evaluation"))
 }

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -487,7 +487,8 @@ func TestLeader_PeriodicDispatcher_Restore_Evals(t *testing.T) {
 	}
 
 	// Create an eval for the past launch.
-	eval, _ := s1.periodicDispatcher.createEval(job, past)
+	eval, err := s1.periodicDispatcher.createEval(job, past)
+	must.NoError(t, err)
 
 	md := &mockJobEvalDispatcher{
 		children:          false,
@@ -556,7 +557,8 @@ func TestLeader_PeriodicDispatcher_No_Overlaps_No_Running_Job(t *testing.T) {
 	must.NoError(t, err)
 
 	// Create an eval for the past launch.
-	eval, _ := s1.periodicDispatcher.createEval(job, past)
+	eval, err := s1.periodicDispatcher.createEval(job, past)
+	must.NoError(t, err)
 
 	md := &mockJobEvalDispatcher{
 		children:     false,
@@ -625,7 +627,8 @@ func TestLeader_PeriodicDispatcher_No_Overlaps_Running_Job(t *testing.T) {
 	}
 
 	// Create an eval for the past launch.
-	eval, _ := s1.periodicDispatcher.createEval(job, past)
+	eval, err := s1.periodicDispatcher.createEval(job, past)
+	must.NoError(t, err)
 
 	md := &mockJobEvalDispatcher{
 		children:     true,

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -553,9 +553,7 @@ func TestLeader_PeriodicDispatcher_No_Overlaps_No_Running_Job(t *testing.T) {
 		},
 	}
 	_, _, err := s1.raftApply(structs.JobRegisterRequestType, req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	must.NoError(t, err)
 
 	// Create an eval for the past launch.
 	eval, _ := s1.periodicDispatcher.createEval(job, past)

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -642,7 +642,7 @@ func TestLeader_PeriodicDispatcher_No_Overlaps_Running_Job(t *testing.T) {
 
 	// Restore the periodic dispatcher.
 	s1.periodicDispatcher.SetEnabled(true)
-	s1.restorePeriodicDispatcher()
+	must.NoError(t, s1.restorePeriodicDispatcher())
 
 	// Ensure the job is tracked.
 	tuple := structs.NamespacedID{

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -587,9 +587,8 @@ func TestLeader_PeriodicDispatcher_No_Overlaps_No_Running_Job(t *testing.T) {
 	// Check that an eval was made.
 	ws := memdb.NewWatchSet()
 	last, err := s1.fsm.State().PeriodicLaunchByID(ws, job.Namespace, job.ID)
-	if err != nil || last == nil {
-		t.Fatalf("failed to get periodic launch time: %v", err)
-	}
+	must.NoError(t, err)
+	must.NotNil(t, last)
 
 	if last.Launch == past {
 		t.Fatalf("restorePeriodicDispatcher did not force launch")

--- a/nomad/periodic.go
+++ b/nomad/periodic.go
@@ -274,8 +274,9 @@ func (p *PeriodicDispatch) removeLocked(jobID structs.NamespacedID) error {
 	return nil
 }
 
+// ForceRunIfNotRunning causes the periodic job to be evaluated only if there are
+// no overlap constrains in the definition and there are no jobs running already
 func (p *PeriodicDispatch) ForceRunIfNotRunning(job *structs.Job) (*structs.Evaluation, error) {
-
 	if job.Periodic.ProhibitOverlap {
 		running, err := p.dispatcher.RunningChildren(job)
 		if err != nil {

--- a/nomad/periodic.go
+++ b/nomad/periodic.go
@@ -274,7 +274,7 @@ func (p *PeriodicDispatch) removeLocked(jobID structs.NamespacedID) error {
 	return nil
 }
 
-// ForceRun causes the periodic job to be evaluated immediately and returns the
+// ForceEval causes the periodic job to be evaluated immediately and returns the
 // subsequent eval.
 func (p *PeriodicDispatch) ForceEval(namespace, jobID string) (*structs.Evaluation, error) {
 	p.l.Lock()

--- a/nomad/periodic.go
+++ b/nomad/periodic.go
@@ -274,25 +274,6 @@ func (p *PeriodicDispatch) removeLocked(jobID structs.NamespacedID) error {
 	return nil
 }
 
-// ForceRunIfNotRunning causes the periodic job to be evaluated only if there are
-// no overlap constrains in the definition and there are no jobs running already
-func (p *PeriodicDispatch) ForceRunIfNotRunning(job *structs.Job) (*structs.Evaluation, error) {
-	if job.Periodic.ProhibitOverlap {
-		running, err := p.dispatcher.RunningChildren(job)
-		if err != nil {
-			p.logger.Error("failed to determine if periodic job has running children", "job", job.NamespacedID(), "error", err)
-			return nil, nil
-		}
-
-		if running {
-			p.logger.Debug("skipping launch of periodic job because job prohibits overlap", "job", job.NamespacedID())
-			return nil, nil
-		}
-	}
-
-	return p.ForceRun(job.Namespace, job.ID)
-}
-
 // ForceRun causes the periodic job to be evaluated immediately and returns the
 // subsequent eval.
 func (p *PeriodicDispatch) ForceEval(namespace, jobID string) (*structs.Evaluation, error) {

--- a/nomad/periodic.go
+++ b/nomad/periodic.go
@@ -274,14 +274,32 @@ func (p *PeriodicDispatch) removeLocked(jobID structs.NamespacedID) error {
 	return nil
 }
 
-// ForceEval causes the periodic job to be evaluated immediately and returns the
+func (p *PeriodicDispatch) ForceRunIfNotRunning(job *structs.Job) (*structs.Evaluation, error) {
+
+	if job.Periodic.ProhibitOverlap {
+		running, err := p.dispatcher.RunningChildren(job)
+		if err != nil {
+			p.logger.Error("failed to determine if periodic job has running children", "job", job.NamespacedID(), "error", err)
+			return nil, nil
+		}
+
+		if running {
+			p.logger.Debug("skipping launch of periodic job because job prohibits overlap", "job", job.NamespacedID())
+			return nil, nil
+		}
+	}
+
+	return p.ForceRun(job.Namespace, job.ID)
+}
+
+// ForceRun causes the periodic job to be evaluated immediately and returns the
 // subsequent eval.
 func (p *PeriodicDispatch) ForceEval(namespace, jobID string) (*structs.Evaluation, error) {
 	p.l.Lock()
+	defer p.l.Unlock()
 
 	// Do nothing if not enabled
 	if !p.enabled {
-		p.l.Unlock()
 		return nil, fmt.Errorf("periodic dispatch disabled")
 	}
 
@@ -291,11 +309,9 @@ func (p *PeriodicDispatch) ForceEval(namespace, jobID string) (*structs.Evaluati
 	}
 	job, tracked := p.tracked[tuple]
 	if !tracked {
-		p.l.Unlock()
 		return nil, fmt.Errorf("can't force run non-tracked job %q (%s)", jobID, namespace)
 	}
 
-	p.l.Unlock()
 	return p.createEval(job, time.Now().In(job.Periodic.GetLocation()))
 }
 
@@ -335,6 +351,7 @@ func (p *PeriodicDispatch) run(ctx context.Context, updateCh <-chan struct{}) {
 // based on the passed launch time.
 func (p *PeriodicDispatch) dispatch(job *structs.Job, launchTime time.Time) {
 	p.l.Lock()
+	defer p.l.Unlock()
 
 	nextLaunch, err := job.Periodic.Next(launchTime)
 	if err != nil {
@@ -349,19 +366,16 @@ func (p *PeriodicDispatch) dispatch(job *structs.Job, launchTime time.Time) {
 		running, err := p.dispatcher.RunningChildren(job)
 		if err != nil {
 			p.logger.Error("failed to determine if periodic job has running children", "job", job.NamespacedID(), "error", err)
-			p.l.Unlock()
 			return
 		}
 
 		if running {
 			p.logger.Debug("skipping launch of periodic job because job prohibits overlap", "job", job.NamespacedID())
-			p.l.Unlock()
 			return
 		}
 	}
 
 	p.logger.Debug(" launching job", "job", job.NamespacedID(), "launch_time", launchTime)
-	p.l.Unlock()
 	p.createEval(job, launchTime)
 }
 


### PR DESCRIPTION
This PR addresses the bug reported on [#11052](https://github.com/hashicorp/nomad/issues/11052) 

When a leader change happens, the periodic dispatcher on the new leader starts by re running all periodic jobs by force, without checking if there is an instance of the said job already. 
A new check is introduced that skips the job if prohibit_overlap is set and there is already a instance running.