### PR TITLE
test: update test coverage for `parse` model method

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -34,11 +34,12 @@ export default class JobAdapter extends WatchableNamespaceIDs {
     return this.ajax(url, 'DELETE');
   }
 
-  parse(spec) {
+  parse(spec, jobVars) {
     const url = addToPath(this.urlForFindAll('job'), '/parse?namespace=*');
     return this.ajax(url, 'POST', {
       data: {
         JobHCL: spec,
+        JobVariables: jobVars,
         Canonicalize: true,
       },
     });

--- a/ui/tests/unit/models/job-test.js
+++ b/ui/tests/unit/models/job-test.js
@@ -1,6 +1,7 @@
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Model | job', function (hooks) {
   setupTest(hooks);
@@ -131,5 +132,63 @@ module('Unit | Model | job', function (hooks) {
         .reduce((sum, allocs) => sum + allocs, 0),
       'lostAllocs is the sum of all group lostAllocs'
     );
+  });
+
+  module('#parse', function () {
+    test('it parses JSON', async function (assert) {
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('job');
+
+      model.set('_newDefinition', '{"name": "Tomster"}');
+
+      const setIdByPayloadSpy = sinon.spy(model, 'setIdByPayload');
+
+      const result = await model.parse();
+
+      assert.deepEqual(
+        model.get('_newDefinitionJSON'),
+        { name: 'Tomster' },
+        'Sets _newDefinitionJSON correctly'
+      );
+      assert.ok(
+        setIdByPayloadSpy.calledWith({ name: 'Tomster' }),
+        'setIdByPayload is called with the parsed JSON'
+      );
+      assert.deepEqual(result, '{"name": "Tomster"}', 'Returns the JSON input');
+    });
+
+    test('it dispatches a POST request to the /parse endpoint (eagerly assumes HCL specification) if JSON parse method errors', async function (assert) {
+      assert.expect(3);
+
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('job');
+
+      model.set('_newDefinition', 'invalidJSON');
+
+      const adapter = store.adapterFor('job');
+      adapter.parse = sinon.stub().rejects(new Error('Invalid JSON'));
+
+      const setIdByPayloadSpy = sinon.spy(model, 'setIdByPayload');
+
+      try {
+        await model.parse();
+        assert.ok(false, 'Should have thrown an error');
+      } catch (error) {
+        assert.ok(
+          setIdByPayloadSpy.notCalled,
+          'setIdByPayload should not be called'
+        );
+        assert.equal(
+          error.message,
+          'Invalid JSON',
+          'Error message should match the expected error'
+        );
+        assert.deepEqual(
+          model.get('_newDefinitionJSON'),
+          undefined,
+          '_newDefinitionJSON is not set'
+        );
+      }
+    });
   });
 });


### PR DESCRIPTION
This PR is part of a larger block of work for #16589 to refactor the `Job` model to enable parsing HCL specifications that include variables.