### PR TITLE
Windows fixes for e2e tests

### DIFF
--- a/e2e/ui/input/proxy.nomad
+++ b/e2e/ui/input/proxy.nomad
@@ -2,6 +2,11 @@ job "nomad-proxy" {
   datacenters = ["dc1", "dc2"]
   namespace   = "proxy"
 
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
   group "proxy" {
 
     network {


### PR DESCRIPTION
2 commits:

1. Skip Task API test if no new Windows boxes are available (awkward check, see #16591 for how to improve)
2. Don't try to run the proxy on Windows (it nicely reschedules and works, but takes a while)