### PR TITLE
ui:  update `parse` method on `Job` model to accept variables

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -34,11 +34,12 @@ export default class JobAdapter extends WatchableNamespaceIDs {
     return this.ajax(url, 'DELETE');
   }
 
-  parse(spec) {
+  parse(spec, jobVars) {
     const url = addToPath(this.urlForFindAll('job'), '/parse?namespace=*');
     return this.ajax(url, 'POST', {
       data: {
         JobHCL: spec,
+        JobVariables: jobVars,
         Canonicalize: true,
       },
     });


### PR DESCRIPTION
Resolves #16589. This PR updates the `parse` adapter and model methods to enable passing `HCL Variables` to the `/parse` endpoint and also creates a new private property on the `Job` model to store `HCL Variables`.

Note:  We do not know the request schema for the `/parse` endpoint. We have not addressed how we'll handle complex data types like tuples, maps and etcetera when sending this request. That will be resolved in a later PR when its time to integrate the API.