### PR TITLE
taskapi: use HasSuffix to detect errors from rpcs

### DIFF
--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -1122,7 +1122,7 @@ func (a *authMiddleware) ServeHTTP(resp http.ResponseWriter, req *http.Request) 
 	if err := a.srv.agent.RPC("ACL.WhoAmI", &args, &reply); err != nil {
 		// When ACLs are enabled, WhoAmI returns ErrPermissionDenied on bad
 		// credentials, so convert it to a Forbidden response code.
-		if err.Error() == structs.ErrPermissionDenied.Error() {
+		if strings.HasSuffix(err.Error(), structs.ErrPermissionDenied.Error()) {
 			a.srv.logger.Debug("Failed to authenticated Task API request", "method", req.Method, "url", req.URL)
 			resp.WriteHeader(http.StatusForbidden)
 			resp.Write([]byte(http.StatusText(http.StatusForbidden)))


### PR DESCRIPTION
Matches the "normal" HTTP error detection logic in the same file.

Tested by `TestTaskAPI/testTaskAPI_Auth` (which is currently failing in the nightly run, but passes against this patch).