### PR TITLE
E2E: fix events tests

### DIFF
--- a/e2e/events/events.go
+++ b/e2e/events/events.go
@@ -87,7 +87,7 @@ func (tc *EventsTest) TestDeploymentEvents(f *framework.F) {
 	e2eutil.RegisterAndWaitForAllocs(t, nomadClient, "events/input/initial.nomad", jobID, "")
 
 	// update job
-	e2eutil.RegisterAllocs(t, nomadClient, "events/input/deploy.nomad", jobID, "")
+	e2eutil.RegisterAndWaitForAllocs(t, nomadClient, "events/input/deploy.nomad", jobID, "")
 
 	ds := e2eutil.DeploymentsForJob(t, nomadClient, jobID)
 	require.Equal(t, 2, len(ds))

--- a/e2e/events/input/deploy.nomad
+++ b/e2e/events/input/deploy.nomad
@@ -18,12 +18,12 @@ job "deployment_auto.nomad" {
 
     network {
       port "db" {
-        static = 9000
+        to = 1234
       }
     }
 
     task "one" {
-      driver = "raw_exec"
+      driver = "docker"
 
       env {
         version = "1"
@@ -32,10 +32,8 @@ job "deployment_auto.nomad" {
       config {
         image   = "busybox:1"
         command = "nc"
-
-        # change args to update the job, the only changes
-        args  = ["-ll", "-p", "1234", "-e", "/bin/cat"]
-        ports = ["db"]
+        args    = ["-ll", "-p", "1234", "-e", "/bin/cat"]
+        ports   = ["db"]
       }
 
       resources {

--- a/e2e/events/input/initial.nomad
+++ b/e2e/events/input/initial.nomad
@@ -10,14 +10,15 @@ job "deployment_auto.nomad" {
     count = 3
 
     update {
-      max_parallel = 3
-      auto_promote = true
-      canary       = 2
+      max_parallel     = 3
+      auto_promote     = true
+      canary           = 2
+      min_healthy_time = "1s"
     }
 
     network {
       port "db" {
-        static = 9000
+        to = 1234
       }
     }
 
@@ -27,13 +28,12 @@ job "deployment_auto.nomad" {
       env {
         version = "0"
       }
+
       config {
         image   = "busybox:1"
         command = "nc"
-
-        # change args to update the job, the only changes
-        args  = ["-ll", "-p", "1234", "-e", "/bin/cat"]
-        ports = ["db"]
+        args    = ["-ll", "-p", "1234", "-e", "/bin/cat"]
+        ports   = ["db"]
       }
 
       resources {


### PR DESCRIPTION
In #12916 we updated the events test as part of a larger set of changes around mapstructure serialization fixes. But the changes to the jobs we're deploying in the tests had invalid task configs so they never result in good deployments and the test will always fail. Make the before/after jobs identical (except for the version bump) and make them valid. Also wait for allocations for the 2nd job run to appear before checking the deployment list, so that we don't race with the scheduler.