### PR TITLE
e2e: sleep to ensure logs are picked up

### DIFF
--- a/e2e/workload_id/input/identity.nomad
+++ b/e2e/workload_id/input/identity.nomad
@@ -14,7 +14,9 @@ job "identity" {
       driver = "docker"
       config {
         image = "bash:5"
-        args  = ["-c", "wc -c < secrets/nomad_token; env | grep NOMAD_TOKEN; echo done"]
+
+        #HACK(schmichael) without the ending `sleep 2` we seem to sometimes miss logs :(
+        args = ["-c", "wc -c < secrets/nomad_token; env | grep NOMAD_TOKEN; echo done; sleep 2"]
       }
       resources {
         cpu    = 16
@@ -31,7 +33,9 @@ job "identity" {
       driver = "docker"
       config {
         image = "bash:5"
-        args  = ["-c", "wc -c < secrets/nomad_token; env | grep NOMAD_TOKEN; echo done"]
+
+        #HACK(schmichael) without the ending `sleep 2` we seem to sometimes miss logs :(
+        args = ["-c", "wc -c < secrets/nomad_token; env | grep NOMAD_TOKEN; echo done; sleep 2"]
       }
       resources {
         cpu    = 16
@@ -51,7 +55,9 @@ job "identity" {
       driver = "docker"
       config {
         image = "bash:5"
-        args  = ["-c", "wc -c < secrets/nomad_token; env | grep NOMAD_TOKEN; echo done"]
+
+        #HACK(schmichael) without the ending `sleep 2` we seem to sometimes miss logs :(
+        args = ["-c", "wc -c < secrets/nomad_token; env | grep NOMAD_TOKEN; echo done; sleep 2"]
       }
       resources {
         cpu    = 16
@@ -70,7 +76,9 @@ job "identity" {
       driver = "docker"
       config {
         image = "bash:5"
-        args  = ["-c", "wc -c < secrets/nomad_token; env | grep NOMAD_TOKEN; echo done"]
+
+        #HACK(schmichael) without the ending `sleep 2` we seem to sometimes miss logs :(
+        args = ["-c", "wc -c < secrets/nomad_token; env | grep NOMAD_TOKEN; echo done; sleep 2"]
       }
       resources {
         cpu    = 16
@@ -90,7 +98,9 @@ job "identity" {
       driver = "docker"
       config {
         image = "bash:5"
-        args  = ["-c", "wc -c < secrets/nomad_token; env | grep NOMAD_TOKEN; echo done"]
+
+        #HACK(schmichael) without the ending `sleep 2` we seem to sometimes miss logs :(
+        args = ["-c", "wc -c < secrets/nomad_token; env | grep NOMAD_TOKEN; echo done; sleep 2"]
       }
       resources {
         cpu    = 16


### PR DESCRIPTION
This seems to fix these otherwise flaky tests, but I feel like it's an indication there's a bug in logmon. Should I file an issue and reference this test? :thinking: 