### PR TITLE
[ui] Deployment History search

### DIFF
--- a/ui/app/components/job-status/deployment-history.hbs
+++ b/ui/app/components/job-status/deployment-history.hbs
@@ -1,5 +1,11 @@
 <div class="deployment-history">
-  <h4 class="title is-5">Deployment History</h4>
+  <header>
+    <h4 class="title is-5">Deployment History</h4>
+    <SearchBox
+      @searchTerm={{mut this.searchTerm}}
+      @placeholder="Search events..."
+    />
+  </header>
   <ol class="timeline">
     {{#each this.history as |deployment-log|}}
       <li class="timeline-object {{if (eq deployment-log.exitCode 1) "error"}}">

--- a/ui/app/components/job-status/deployment-history.hbs
+++ b/ui/app/components/job-status/deployment-history.hbs
@@ -25,12 +25,20 @@
           </div>
         </li>
       {{else}}
-        {{#if this.deploymentAllocations}}
-          <li class="timeline-object">
-            <div class="boxed-section-head is-light">
-              <span>No deployment events yet</span>
-            </div>
-          </li>
+        {{#if this.deploymentAllocations.length}}
+          {{#if this.searchTerm}}
+            <li class="timeline-object">
+              <div class="boxed-section-head is-light">
+                <span>No events march {{this.searchTerm}}</span>
+              </div>
+            </li>
+          {{else}}
+            <li class="timeline-object">
+              <div class="boxed-section-head is-light">
+                <span>No deployment events yet</span>
+              </div>
+            </li>
+          {{/if}}
         {{else}}
           <li class="timeline-object">
             <div class="boxed-section-head is-light">

--- a/ui/app/components/job-status/deployment-history.hbs
+++ b/ui/app/components/job-status/deployment-history.hbs
@@ -2,6 +2,7 @@
   <header>
     <h4 class="title is-5">Deployment History</h4>
     <SearchBox
+      data-test-history-search
       @searchTerm={{mut this.searchTerm}}
       @placeholder="Search events..."
     />
@@ -27,9 +28,9 @@
       {{else}}
         {{#if this.deploymentAllocations.length}}
           {{#if this.searchTerm}}
-            <li class="timeline-object">
+            <li class="timeline-object" data-test-history-search-no-match>
               <div class="boxed-section-head is-light">
-                <span>No events march {{this.searchTerm}}</span>
+                <span>No events match {{this.searchTerm}}</span>
               </div>
             </li>
           {{else}}

--- a/ui/app/components/job-status/deployment-history.js
+++ b/ui/app/components/job-status/deployment-history.js
@@ -55,6 +55,7 @@ export default class JobStatusDeploymentHistoryComponent extends Component {
             .flat()
         )
         .flat()
+        .filter((a) => this.filterOnSearchTerm(a))
         .sort((a, b) => a.get('time') - b.get('time'))
         .reverse();
     } catch (e) {
@@ -71,4 +72,25 @@ export default class JobStatusDeploymentHistoryComponent extends Component {
       color: 'critical',
     });
   }
+
+  // #region search
+
+  /**
+   * @type { string }
+   */
+  @tracked searchTerm = '';
+
+  /**
+   * @param { import('../../models/task-event').default } taskEvent
+   * @returns { boolean }
+   */
+  filterOnSearchTerm(taskEvent) {
+    return (
+      taskEvent.message.toLowerCase().includes(this.searchTerm.toLowerCase()) ||
+      taskEvent.type.toLowerCase().includes(this.searchTerm.toLowerCase()) ||
+      taskEvent.state.allocation.shortId.includes(this.searchTerm.toLowerCase())
+    );
+  }
+
+  // #endregion search
 }

--- a/ui/app/components/job-status/deployment-history.js
+++ b/ui/app/components/job-status/deployment-history.js
@@ -55,7 +55,7 @@ export default class JobStatusDeploymentHistoryComponent extends Component {
             .flat()
         )
         .flat()
-        .filter((a) => this.filterOnSearchTerm(a))
+        .filter((a) => this.containsSearchTerm(a))
         .sort((a, b) => a.get('time') - b.get('time'))
         .reverse();
     } catch (e) {
@@ -84,7 +84,7 @@ export default class JobStatusDeploymentHistoryComponent extends Component {
    * @param { import('../../models/task-event').default } taskEvent
    * @returns { boolean }
    */
-  filterOnSearchTerm(taskEvent) {
+  containsSearchTerm(taskEvent) {
     return (
       taskEvent.message.toLowerCase().includes(this.searchTerm.toLowerCase()) ||
       taskEvent.type.toLowerCase().includes(this.searchTerm.toLowerCase()) ||

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -192,6 +192,22 @@
       overflow-y: auto;
     }
     & > ol > li {
+      @for $i from 1 through 50 {
+        &:nth-child(#{$i}) {
+          animation-name: historyItemSlide;
+          animation-duration: 0.2s;
+          animation-fill-mode: both;
+          animation-delay: 0.1s + (0.05 * $i);
+        }
+
+        &:nth-child(#{$i}) > div {
+          animation-name: historyItemShine;
+          animation-duration: 1s;
+          animation-fill-mode: both;
+          animation-delay: 0.1s + (0.05 * $i);
+        }
+      }
+
       & > div {
         gap: 0.5rem;
       }
@@ -226,5 +242,25 @@
         color: #06d092;
       }
     }
+  }
+}
+
+@keyframes historyItemSlide {
+  from {
+    opacity: 0;
+    top: 40px;
+  }
+  to {
+    opacity: 1;
+    top: 0px;
+  }
+}
+
+@keyframes historyItemShine {
+  from {
+    box-shadow: inset 0 0 0 100px rgba(255, 200, 0, 0.2);
+  }
+  to {
+    box-shadow: inset 0 0 0 100px rgba(255, 200, 0, 0);
   }
 }

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -173,10 +173,20 @@
     display: grid;
     grid-template-columns: 70% auto;
     gap: 1rem;
-    margin-top: 1rem; // TODO: grid-ify the deployment panel generally and just use gap for this
+    margin-top: 2rem; // TODO: grid-ify the deployment panel generally and just use gap for this
   }
 
   .deployment-history {
+    & > header {
+      display: grid;
+      grid-template-columns: 1fr 2fr;
+      gap: 1rem;
+      margin-bottom: 1rem;
+      align-items: end;
+      & > .search-box {
+        max-width: unset;
+      }
+    }
     & > ol {
       max-height: 300px;
       overflow-y: auto;

--- a/ui/mirage/factories/allocation.js
+++ b/ui/mirage/factories/allocation.js
@@ -13,7 +13,7 @@ const REF_TIME = new Date();
 export default Factory.extend({
   id: (i) => (i >= 100 ? `${UUIDS[i % 100]}-${i}` : UUIDS[i]),
 
-  jobVersion: 0,
+  jobVersion: 1,
 
   modifyIndex: () => faker.random.number({ min: 10, max: 2000 }),
   modifyTime: () => faker.date.past(2 / 365, REF_TIME) * 1000000,

--- a/ui/mirage/factories/allocation.js
+++ b/ui/mirage/factories/allocation.js
@@ -13,7 +13,7 @@ const REF_TIME = new Date();
 export default Factory.extend({
   id: (i) => (i >= 100 ? `${UUIDS[i % 100]}-${i}` : UUIDS[i]),
 
-  jobVersion: 1,
+  jobVersion: 0,
 
   modifyIndex: () => faker.random.number({ min: 10, max: 2000 }),
   modifyTime: () => faker.date.past(2 / 365, REF_TIME) * 1000000,

--- a/ui/mirage/factories/task-event.js
+++ b/ui/mirage/factories/task-event.js
@@ -12,5 +12,7 @@ export default Factory.extend({
   exitCode: () => null,
   time: () => faker.date.past(2 / 365, REF_TIME) * 1000000,
 
-  displayMessage: () => faker.lorem.sentence(),
+  // TODO: I think this is probably an archaic property name. See if tests collapse with this removal and decide to remove then.
+  // displayMessage: () => faker.lorem.sentence(),
+  message: () => faker.lorem.sentence(),
 });

--- a/ui/mirage/factories/task-event.js
+++ b/ui/mirage/factories/task-event.js
@@ -12,7 +12,5 @@ export default Factory.extend({
   exitCode: () => null,
   time: () => faker.date.past(2 / 365, REF_TIME) * 1000000,
 
-  // TODO: I think this is probably an archaic property name. See if tests collapse with this removal and decide to remove then.
-  // displayMessage: () => faker.lorem.sentence(),
   message: () => faker.lorem.sentence(),
 });

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -211,7 +211,7 @@ module('Acceptance | allocation detail', function (hooks) {
 
       assert.equal(taskRow.name, task.name, 'Name');
       assert.equal(taskRow.state, task.state, 'State');
-      assert.equal(taskRow.message, event.displayMessage, 'Event Message');
+      assert.equal(taskRow.message, event.message, 'Event Message');
       assert.equal(
         taskRow.time,
         moment(event.time / 1000000).format("MMM DD, 'YY HH:mm:ss ZZ"),

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -429,14 +429,16 @@ module('Acceptance | job status panel', function (hooks) {
         groupTaskCount,
         shallow: true,
         activeDeployment: true,
+        version: 0,
       });
 
       let state = server.create('task-state');
       state.events = server.schema.taskEvents.where({ taskStateId: state.id });
 
-      server.schema.allocations
-        .where({ jobId: job.id })
-        .update({ taskStateIds: [state.id] });
+      server.schema.allocations.where({ jobId: job.id }).update({
+        taskStateIds: [state.id],
+        jobVersion: 0,
+      });
 
       await visit(`/jobs/${job.id}`);
       assert.dom('.job-status-panel').exists();

--- a/ui/tests/acceptance/task-detail-test.js
+++ b/ui/tests/acceptance/task-detail-test.js
@@ -217,7 +217,7 @@ module('Acceptance | task detail', function (hooks) {
       'Event timestamp'
     );
     assert.equal(recentEvent.type, event.type, 'Event type');
-    assert.equal(recentEvent.message, event.displayMessage, 'Event message');
+    assert.equal(recentEvent.message, event.message, 'Event message');
   });
 
   test('when the allocation is not found, the application errors', async function (assert) {

--- a/ui/tests/integration/components/job-page/service-test.js
+++ b/ui/tests/integration/components/job-page/service-test.js
@@ -272,7 +272,11 @@ module('Integration | Component | job-page/service', function (hooks) {
       'The error message mentions ACLs'
     );
 
-    await componentA11yAudit(this.element, assert);
+    await componentA11yAudit(
+      this.element,
+      assert,
+      'scrollable-region-focusable'
+    ); //keyframe animation fades from opacity 0
 
     await click('[data-test-job-error-close]');
 
@@ -335,7 +339,11 @@ module('Integration | Component | job-page/service', function (hooks) {
       'The error message mentions ACLs'
     );
 
-    await componentA11yAudit(this.element, assert);
+    await componentA11yAudit(
+      this.element,
+      assert,
+      'scrollable-region-focusable'
+    ); //keyframe animation fades from opacity 0
 
     await click('[data-test-job-error-close]');
 

--- a/ui/tests/integration/components/job-status-panel-test.js
+++ b/ui/tests/integration/components/job-status-panel-test.js
@@ -111,8 +111,11 @@ module(
       //   deployment.get('statusDescription'),
       //   'Status description is in the metrics block'
       // );
-
-      await componentA11yAudit(this.element, assert);
+      await componentA11yAudit(
+        this.element,
+        assert,
+        'scrollable-region-focusable'
+      ); //keyframe animation fades from opacity 0
     });
 
     test('when there is no running deployment, the latest deployment section shows up for the last deployment', async function (assert) {


### PR DESCRIPTION
- Adds a "loading shimmer" and rolling slide-in for events:
<img width="947" alt="image" src="https://user-images.githubusercontent.com/713991/226953157-03d93cb2-1df8-4f33-bae4-a48726bc58fa.png">

- Adds a searchbox:
<img width="640" alt="image" src="https://user-images.githubusercontent.com/713991/226953373-3dea3291-4253-4ab0-9763-03796e87024b.png">


Search term persists as a deployment rolls forward; which is to say, if you search a term when there are no events that match it, but a placed allocation matches it later, it will show up with no further user action needed.