### PR TITLE
scheduler: fix reconciliation of reconnecting allocs

### DIFF
--- a/.changelog/16609.txt
+++ b/.changelog/16609.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Fix reconciliation of reconnecting allocs when the replacement allocations are not running
+```

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -432,7 +432,7 @@ func (a *allocReconciler) computeGroup(groupName string, all allocSet) bool {
 	// their replacements first because there is specific logic when deciding
 	// which ones to keep that can only be applied when the client reconnects.
 	if len(reconnecting) > 0 {
-		// Pass all allocations becasue the replacements we need to find may be
+		// Pass all allocations because the replacements we need to find may be
 		// in any state, including themselves being reconnected.
 		reconnect, stop := a.reconcileReconnecting(reconnecting, all)
 

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -5713,7 +5713,7 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 							nextReplacement := replacement.Copy()
 							nextReplacement.ID = uuid.Generate()
 							nextReplacement.ClientStatus = structs.AllocClientStatusRunning
-							nextReplacement.DesiredStatus = structs.AllocClientStatusRunning
+							nextReplacement.DesiredStatus = structs.AllocDesiredStatusRun
 							nextReplacement.PreviousAllocation = replacement.ID
 
 							replacement.NextAllocation = nextReplacement.ID

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -520,19 +520,6 @@ func (a allocSet) filterByDeployment(id string) (match, nonmatch allocSet) {
 	return
 }
 
-// filterByFailedReconnect filters allocation into a set that have failed on the
-// client but do not have a terminal status at the server so that they can be
-// marked as stop at the server.
-func (a allocSet) filterByFailedReconnect() allocSet {
-	failed := make(allocSet)
-	for _, alloc := range a {
-		if !alloc.ServerTerminalStatus() && alloc.ClientStatus == structs.AllocClientStatusFailed {
-			failed[alloc.ID] = alloc
-		}
-	}
-	return failed
-}
-
 // delayByStopAfterClientDisconnect returns a delay for any lost allocation that's got a
 // stop_after_client_disconnect configured
 func (a allocSet) delayByStopAfterClientDisconnect() (later []*delayedRescheduleInfo) {


### PR DESCRIPTION
When a disconnect client reconnects the `allocReconciler` must find the
allocations that were created to replace the original disconnected
allocations.

This process was being done in only a subset of non-terminal untainted
allocations, meaning that, if the replacement allocations were not in
this state the reconciler didn't stop them, leaving the job in an
inconsistent state.

This inconsistency is only solved in a future job evaluation, but at
that point the allocation is considered reconnected and so the specific
reconnection logic was not applied, leading to unexpected outcomes.

This commit fixes the problem by running reconnecting allocation
reconciliation logic earlier into the process, leaving the rest of the
reconciler oblivious of reconnecting allocations.

It also uses the full set of allocations to search for replacements,
stopping them even if they are not in the `untainted` set.

The system `SystemScheduler` is not affected by this bug because
disconnected clients don't trigger replacements: every eligible client
is already running an allocation.

Closes https://github.com/hashicorp/nomad/issues/15483