### PR TITLE
ci: send notification when prepare is complete

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -37,7 +37,7 @@ event "prepare" {
   }
 
   notification {
-    on = "fail"
+    on = "always"
   }
 }
 


### PR DESCRIPTION
We used to get a notification whenever artifacts were ready for promotion, but after https://github.com/hashicorp/nomad/pull/15600 the message was not sent anymore because the previous [`verify` step that sent the notification](https://github.com/hashicorp/nomad/blob/949a6f60c729f4a9942cfca9598bea0257331ab6/.release/ci.hcl#L148-L160) is now part of `prepare`.