### PR TITLE
[testing] Set RequireRoot to be a test helper

### DIFF
--- a/api/internal/testutil/slow.go
+++ b/api/internal/testutil/slow.go
@@ -26,6 +26,7 @@ func Parallel(t *testing.T) {
 }
 
 func RequireRoot(t *testing.T) {
+	t.Helper()
 	if syscall.Getuid() != 0 {
 		t.Skip("test requires root")
 	}


### PR DESCRIPTION
Noticed that it was logging RequireRoot's line number and not the test.