### PR TITLE
docs: add notes about keyring to snapshot restore

### DIFF
--- a/website/content/docs/commands/operator/snapshot/restore.mdx
+++ b/website/content/docs/commands/operator/snapshot/restore.mdx
@@ -15,6 +15,9 @@ designed to handle server failures during a restore. This command is primarily
 intended to be used when recovering from a disaster, restoring into a fresh
 cluster of Nomad servers.
 
+This command only restores the Raft snapshot. If you are recovering a cluster,
+you will also need to [restore the keyring][] onto at least one server.
+
 If ACLs are enabled, a management token must be supplied in order to perform
 snapshot operations.
 
@@ -35,3 +38,4 @@ nomad operator snapshot restore [options] <file>
 @include 'general_options_no_namespace.mdx'
 
 [outage recovery]: /nomad/tutorials/manage-clusters/outage-recovery
+[restore the keyring]: /nomad/docs/operations/key-management#restoring-the-keyring-from-backup

--- a/website/content/docs/commands/operator/snapshot/save.mdx
+++ b/website/content/docs/commands/operator/snapshot/save.mdx
@@ -27,6 +27,10 @@ leader is available):
 $ nomad operator snapshot save -stale backup.snap
 ```
 
+This command only saves a Raft snapshot. If you use this snapshot to recover a
+cluster, you will also need to [restore the keyring][] onto at least one server.
+
+
 ## Usage
 
 ```plaintext
@@ -45,3 +49,4 @@ nomad operator snapshot save [options] <file>
   server.
 
 [outage recovery]: /nomad/tutorials/manage-clusters/outage-recovery
+[restore the keyring]: /nomad/docs/operations/key-management#restoring-the-keyring-from-backu

--- a/website/content/docs/operations/key-management.mdx
+++ b/website/content/docs/operations/key-management.mdx
@@ -55,7 +55,12 @@ key files are needed to recover the cluster. Operators should include these
 files as part of your organization's backup and recovery strategy for the
 cluster.
 
+If you are recovering a Raft snapshot onto a new cluster without running
+workloads, you can skip restoring the keyring and run [`nomad operator root
+keyring rotate`][] once the servers have joined.
+
 [variables]: /nomad/docs/concepts/variables
 [workload identities]: /nomad/docs/concepts/workload-identity
 [data directory]: /nomad/docs/configuration#data_dir
 [`nomad operator root keyring rotate -full`]: /nomad/docs/commands/operator/root/keyring-rotate
+[`nomad operator root keyring rotate`]: /nomad/docs/commands/operator/root/keyring-rotate


### PR DESCRIPTION
When cluster administrators restore from Raft snapshot, they also need to ensure the keyring is in place. For on-prem users doing in-place upgrades this is less of a concern but for typical cloud workflows where the whole host is replaced, it's an important warning (at least until #14852 has been implemented).

Ref https://github.com/hashicorp/nomad/issues/16640