### PR TITLE
[ui] Allow for multiple JWT auth methods in the UI

### DIFF
--- a/ui/app/models/auth-method.js
+++ b/ui/app/models/auth-method.js
@@ -4,6 +4,10 @@ import { attr } from '@ember-data/model';
 
 export default class AuthMethodModel extends Model {
   @attr('string') name;
+
+  /**
+   * @type {'JWT' | 'OIDC'}
+   */
   @attr('string') type;
   @attr('string') tokenLocality;
   @attr('string') maxTokenTTL;

--- a/ui/app/styles/components/authorization.scss
+++ b/ui/app/styles/components/authorization.scss
@@ -1,7 +1,7 @@
 .authorization-page {
-
   .sign-in-methods {
-    h3, p {
+    h3,
+    p {
       margin-bottom: 1.5rem;
     }
 
@@ -30,7 +30,7 @@
       border-bottom: 1px solid $ui-gray-200;
       position: relative;
       top: 50%;
-      content: "";
+      content: '';
       display: block;
       width: 100%;
       height: 0px;
@@ -46,5 +46,10 @@
       align-content: center;
       display: inline-grid;
     }
+  }
+
+  .control.with-jwt-selector {
+    display: flex;
+    gap: 0.5rem;
   }
 }

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -115,7 +115,25 @@
               data-test-token-secret />
           </div>
           <p class="help">Sent with every request to determine authorization</p>
-          <button disabled={{not this.secret}} data-test-token-submit class="button is-primary" {{action "verifyToken"}} type="button">Sign in with token</button>
+          <button disabled={{not this.secret}} data-test-token-submit class="button is-primary" {{action "verifyToken"}} type="button">
+            {{#if this.currentSecretIsJWT}}
+              Sign in with JWT
+            {{else}}
+              Sign in with secret
+            {{/if}}
+          </button>
+          {{#if this.currentSecretIsJWT}}
+            {{did-insert (action this.setCurrentAuthMethod)}}
+            {{#if (gt this.JWTAuthMethods.length 1)}}
+              <SingleSelectDropdown
+                data-test-select-jwt
+                @label="Sign-in method"
+                @options={{this.JWTAuthMethodOptions}}
+                @selection={{this.jwtAuthMethod}}
+                @onSelect={{fn (mut this.jwtAuthMethod)}}
+              />
+            {{/if}}
+          {{/if}}
         </div>
       {{/if}}
 

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -103,7 +103,7 @@
           <h3 class="title is-4">Sign in with token</h3>
           <p>Clusters that use Access Control Lists require tokens to perform certain tasks. By providing a token Secret ID{{#if this.hasJWTAuthMethods}} or <a href="https://jwt.io/" target="_blank" rel="noopener noreferrer">JWT</a>{{/if}}, each future request will be authenticated, potentially authorizing read access to additional information.</p>
           <label class="label" for="token-input">Secret ID{{#if this.hasJWTAuthMethods}} or JWT{{/if}}</label>
-          <div class="control">
+          <div class="control {{if (and this.currentSecretIsJWT (gt this.JWTAuthMethods.length 1)) "with-jwt-selector"}}">
             <Input
               id="token-input"
               class="input"
@@ -113,6 +113,19 @@
               {{on "input" (action (mut this.secret) value="target.value")}}
               @enter={{this.verifyToken}}
               data-test-token-secret />
+
+            {{#if this.currentSecretIsJWT}}
+              {{did-insert (action this.setCurrentAuthMethod)}}
+              {{#if (gt this.JWTAuthMethods.length 1)}}
+                <SingleSelectDropdown
+                  data-test-select-jwt
+                  @label="Sign-in method"
+                  @options={{this.JWTAuthMethodOptions}}
+                  @selection={{this.jwtAuthMethod}}
+                  @onSelect={{fn (mut this.jwtAuthMethod)}}
+                />
+              {{/if}}
+            {{/if}}
           </div>
           <p class="help">Sent with every request to determine authorization</p>
           <button disabled={{not this.secret}} data-test-token-submit class="button is-primary" {{action "verifyToken"}} type="button">
@@ -122,18 +135,6 @@
               Sign in with secret
             {{/if}}
           </button>
-          {{#if this.currentSecretIsJWT}}
-            {{did-insert (action this.setCurrentAuthMethod)}}
-            {{#if (gt this.JWTAuthMethods.length 1)}}
-              <SingleSelectDropdown
-                data-test-select-jwt
-                @label="Sign-in method"
-                @options={{this.JWTAuthMethodOptions}}
-                @selection={{this.jwtAuthMethod}}
-                @onSelect={{fn (mut this.jwtAuthMethod)}}
-              />
-            {{/if}}
-          {{/if}}
         </div>
       {{/if}}
 

--- a/ui/jsconfig.json
+++ b/ui/jsconfig.json
@@ -1,7 +1,7 @@
 {
-    "compilerOptions": {
-      "experimentalDecorators": true,
-      "target": "es5",
-    },
-
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "target": "es2015",
+    "moduleResolution": "node"
+  } 
 }

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -14,6 +14,10 @@ import faker from 'nomad-ui/mirage/faker';
 import moment from 'moment';
 import { run } from '@ember/runloop';
 import { allScenarios } from '../../mirage/scenarios/default';
+import {
+  selectChoose,
+  clickTrigger,
+} from 'ember-power-select/test-support/helpers';
 
 let job;
 let node;
@@ -472,6 +476,97 @@ module('Acceptance | tokens', function (hooks) {
     ).submit();
     assert.ok(currentURL().startsWith('/settings/tokens'));
     assert.dom('[data-test-token-error]').exists();
+  });
+
+  test('JWT Sign-in flow: JWT Method Selector, Single JWT', async function (assert) {
+    server.create('auth-method', { name: 'Vault', type: 'OIDC' });
+    server.create('auth-method', { name: 'Auth0', type: 'OIDC' });
+    server.create('auth-method', { name: 'JWT-Local', type: 'JWT' });
+    await Tokens.visit();
+    assert
+      .dom('[data-test-token-submit]')
+      .exists(
+        { count: 1 },
+        'Submit token/JWT button exists with only a single JWT '
+      );
+    assert
+      .dom('[data-test-token-submit]')
+      .hasText(
+        'Sign in with secret',
+        'Submit token/JWT button has correct text with only a single JWT '
+      );
+    await Tokens.secret('very-short-secret');
+    assert
+      .dom('[data-test-token-submit]')
+      .hasText(
+        'Sign in with secret',
+        'A short secret still shows the "secret" verbiage on the button'
+      );
+    await Tokens.secret(
+      'aaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.whateverlol'
+    );
+    assert
+      .dom('[data-test-token-submit]')
+      .hasText(
+        'Sign in with JWT',
+        'A JWT-shaped secret will change button text to reflect JWT sign-in'
+      );
+
+    assert
+      .dom('[data-test-select-jwt]')
+      .doesNotExist('No JWT selector shown with only a single method');
+  });
+
+  test('JWT Sign-in flow: JWT Method Selector, Multiple JWT', async function (assert) {
+    server.create('auth-method', { name: 'Vault', type: 'OIDC' });
+    server.create('auth-method', { name: 'Auth0', type: 'OIDC' });
+    server.create('auth-method', {
+      name: 'JWT-Local',
+      type: 'JWT',
+      default: false,
+    });
+    server.create('auth-method', {
+      name: 'JWT-Regional',
+      type: 'JWT',
+      default: false,
+    });
+    server.create('auth-method', {
+      name: 'JWT-Global',
+      type: 'JWT',
+      default: true,
+    });
+    await Tokens.visit();
+    assert
+      .dom('[data-test-token-submit]')
+      .exists(
+        { count: 1 },
+        'Submit token/JWT button exists with only a single JWT '
+      );
+    assert
+      .dom('[data-test-select-jwt]')
+      .doesNotExist('No JWT selector shown with an empty token/secret');
+    await Tokens.secret(
+      'aaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.whateverlol'
+    );
+    assert
+      .dom('[data-test-select-jwt]')
+      .exists({ count: 1 }, 'JWT selector shown with multiple JWT methods');
+
+    assert.equal(
+      currentURL(),
+      '/settings/tokens?jwtAuthMethod=JWT-Global',
+      'Default JWT method is selected'
+    );
+    await clickTrigger('[data-test-select-jwt]');
+    assert.dom('.dropdown-options').exists('Dropdown options are shown');
+
+    await selectChoose('[data-test-select-jwt]', 'JWT-Regional');
+    console.log(currentURL());
+    assert.equal(
+      currentURL(),
+      '/settings/tokens?jwtAuthMethod=JWT-Regional',
+      'Selected JWT method is shown'
+    );
   });
 
   test('when the ott exchange fails an error is shown', async function (assert) {


### PR DESCRIPTION
In #16625 , we allow a user to sign in using a JWT. However, this only looks for the first `authMethod` of type JWT and assumes that's good enough.

This PR allows the user to have multiple JWTs and select from among them upon token input.

The select dropdown does not appear until the secret provided is "JWT-shaped", at which point it will give options if more than one JWT auth method exists.

## Side-effects:
- updated our jsconfig to let us do more type-safety and module interpretative type work. Your editor should give you good type hinting for any authMethods, etc. in this file and others, using in-comment type imports.

### Screenshots
3 JWT auth methods, but the token provided is not JWT: 
![image](https://user-images.githubusercontent.com/713991/228054370-28f8ecb7-f244-4b36-8b80-570791910552.png)

3 JWT auth methods, token provided is JWT-shaped:
![image](https://user-images.githubusercontent.com/713991/228054469-d8866512-1273-4cc7-9565-33631792ccca.png)

User can modify the method upon form submission:
![image](https://user-images.githubusercontent.com/713991/228054704-f49538b9-d8ea-49ce-a22a-a0d68ae3f0f1.png)
