### PR TITLE
docs: fix template retry attempts default documentation

### DIFF
--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -470,7 +470,7 @@ see the [drivers documentation](/nomad/docs/drivers).
   "blocking queries". A blocking query is used to wait for a potential change
   using long polling.
 
-- `consul_retry` `(map: { attempts = 0 backoff = "250ms" max_backoff = "1m" })`-
+- `consul_retry` `(map: { attempts = 12 backoff = "250ms" max_backoff = "1m" })`-
   This controls the retry behavior when an error is returned from Consul. The template
   runner will not exit in the face of failure. Instead, it uses exponential back-off
   and retry functions to wait for the Consul cluster to become available, as is
@@ -481,7 +481,7 @@ see the [drivers documentation](/nomad/docs/drivers).
     # This specifies the number of attempts to make before giving up. Each
     # attempt adds the exponential backoff sleep time. Setting this to
     # zero will implement an unlimited number of retries.
-    attempts = 0
+    attempts = 12
     # This is the base amount of time to sleep between retry attempts. Each
     # retry sleeps for an exponent of 2 longer than this base. For 5 retries,
     # the sleep times would be: 250ms, 500ms, 1s, 2s, then 4s.
@@ -495,7 +495,7 @@ see the [drivers documentation](/nomad/docs/drivers).
   }
   ```
 
-- `vault_retry` `(map: { attempts = 0 backoff = "250ms" max_backoff = "1m" })` -
+- `vault_retry` `(map: { attempts = 12 backoff = "250ms" max_backoff = "1m" })` -
   This controls the retry behavior when an error is returned from Vault. Consul
   Template is highly fault tolerant, meaning it does not exit in the face of failure.
   Instead, it uses exponential back-off and retry functions to wait for the cluster
@@ -506,7 +506,7 @@ see the [drivers documentation](/nomad/docs/drivers).
     # This specifies the number of attempts to make before giving up. Each
     # attempt adds the exponential backoff sleep time. Setting this to
     # zero will implement an unlimited number of retries.
-    attempts = 0
+    attempts = 12
     # This is the base amount of time to sleep between retry attempts. Each
     # retry sleeps for an exponent of 2 longer than this base. For 5 retries,
     # the sleep times would be: 250ms, 500ms, 1s, 2s, then 4s.
@@ -520,7 +520,7 @@ see the [drivers documentation](/nomad/docs/drivers).
   }
   ```
 
-- `nomad_retry` `(map: { attempts = 0 backoff = "250ms" max_backoff = "1m" })` -
+- `nomad_retry` `(map: { attempts = 12 backoff = "250ms" max_backoff = "1m" })` -
   This controls the retry behavior when an error is returned from Nomad. Consul
   Template is highly fault tolerant, meaning it does not exit in the face of failure.
   Instead, it uses exponential back-off and retry functions to wait for the cluster
@@ -531,7 +531,7 @@ see the [drivers documentation](/nomad/docs/drivers).
     # This specifies the number of attempts to make before giving up. Each
     # attempt adds the exponential backoff sleep time. Setting this to
     # zero will implement an unlimited number of retries.
-    attempts = 0
+    attempts = 12
     # This is the base amount of time to sleep between retry attempts. Each
     # retry sleeps for an exponent of 2 longer than this base. For 5 retries,
     # the sleep times would be: 250ms, 500ms, 1s, 2s, then 4s.


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/16656

The configuration docs for `client.template.vault_retry`, `consul_retry`, and `nomad_retry` incorrectly document the default number of attempts to be unlimited (0). When we added these config blocks, we defaulted the fields to `nil` for backwards compatibility, which causes them to fall back to the default consul-template configuration values.