### PR TITLE
ui:  validate job specification file for variables

### DIFF
--- a/ui/app/utils/has-variable-declarations.js
+++ b/ui/app/utils/has-variable-declarations.js
@@ -1,0 +1,6 @@
+export default function hasVariableDeclarationsAndReferences(spec) {
+  const VAR_DECLARATION_AND_REFERENCE_PATTERN = '\\b(?:variable|var\\.)\\b';
+  const expression = new RegExp(VAR_DECLARATION_AND_REFERENCE_PATTERN);
+
+  return expression.test(spec);
+}

--- a/ui/tests/unit/utils/has-variable-declarations-test.js
+++ b/ui/tests/unit/utils/has-variable-declarations-test.js
@@ -1,0 +1,39 @@
+import hasVariableDeclarationsAndReferences from 'nomad-ui/utils/has-variable-declarations';
+import { module, test } from 'qunit';
+
+module(
+  'Unit | Util | #hasVariableDeclarationsAndReferences - HCL2 Variable Matching',
+  function () {
+    test('should match "variable" declarations', function (assert) {
+      const str = 'variable "datacenters" { type = list(string) }';
+      assert.ok(
+        hasVariableDeclarationsAndReferences(str),
+        'The string contains a "variable" declaration'
+      );
+    });
+
+    test('should match "var." references', function (assert) {
+      const str = 'datacenters = var.datacenters';
+      assert.ok(
+        hasVariableDeclarationsAndReferences(str),
+        'The string contains a "var." reference'
+      );
+    });
+
+    test('should not match other words containing "variable" or "var" without the dot', function (assert) {
+      const str = 'This is a variablerandomtext and varwithsometext.';
+      assert.notOk(
+        hasVariableDeclarationsAndReferences(str),
+        'The string does not contain a variable declaration or reference'
+      );
+    });
+
+    test('should not match an empty string', function (assert) {
+      const str = '';
+      assert.notOk(
+        hasVariableDeclarationsAndReferences(str),
+        'The string does not contain a variable declaration or reference'
+      );
+    });
+  }
+);


### PR DESCRIPTION
This PR kicks off the refactoring work required for #16666.

This PR specifically creates a utility function that will parse a string representation of a  job specification file that has a `variable` declaration or reference.