### PR TITLE
ui:  remove `variables` table from `read-only` view

### DIFF
--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -47,16 +47,4 @@
         <JsonViewer data-test-definition-view @json={{@data.definition}} />
     {{/if}}
     </div>
-    {{#if (and @data.hasVariables (eq @data.view "job-spec"))}}
-        <h1 class="title is-3">HCL Variables:  current version</h1>
-        <div 
-            data-test-job-variables
-            {{code-mirror
-            content=(stringify-object @data.variables)
-            readOnly=true
-            screenReaderLabel="Job specification variables"          
-            theme="hashi-read-only"
-            }} 
-        />
-    {{/if}}
 </div>

--- a/ui/tests/acceptance/job-definition-test.js
+++ b/ui/tests/acceptance/job-definition-test.js
@@ -139,7 +139,7 @@ module('display and edit using full specification', function (hooks) {
   });
 
   test('it allows users to toggle between full specification and JSON definition', async function (assert) {
-    assert.expect(5);
+    assert.expect(3);
     server.get('/job/:id', () => JOB_JSON);
 
     await Definition.visit({ id: job.id });
@@ -154,16 +154,8 @@ module('display and edit using full specification', function (hooks) {
       'Shows the full definition as written by the user'
     );
 
-    assert
-      .dom('[data-test-job-variables]')
-      .exists('A table showing job variables appears');
-
     await click('[data-test-toggle-full]');
     codeMirror = getCodeMirrorInstance('[data-test-editor]');
     assert.propContains(JSON.parse(codeMirror.getValue()), JOB_JSON);
-
-    assert
-      .dom('[data-test-job-variables]')
-      .doesNotExist('A table showing job variables appears');
   });
 });


### PR DESCRIPTION
This PR is part of #16666 and is specifically responsible for removing the Variables table.

The following PR will include the information label based on the regular expression to detect variables.