### PR TITLE
refact: `JobEditor` reactive query parameters

### DIFF
--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -8,18 +8,16 @@ import localStorageProperty from 'nomad-ui/utils/properties/local-storage';
 import { tracked } from '@glimmer/tracking';
 
 export default class JobEditor extends Component {
-  @service store;
   @service config;
+  @service store;
 
   @tracked error = null;
   @tracked planOutput = null;
   @tracked isEditing;
-  @tracked view;
 
   constructor() {
     super(...arguments);
     this.isEditing = !!(this.args.context === 'new');
-    this.view = this.args.view;
   }
 
   toggleEdit(bool) {
@@ -125,14 +123,8 @@ export default class JobEditor extends Component {
     reader.readAsText(file);
   }
 
-  @action
-  toggleView() {
-    const opposite = this.view === 'job-spec' ? 'full-definition' : 'job-spec';
-    this.view = opposite;
-  }
-
   get definition() {
-    if (this.view === 'full-definition') {
+    if (this.args.view === 'full-definition') {
       return this.args.definition;
     } else {
       return this.args.specification;
@@ -148,7 +140,7 @@ export default class JobEditor extends Component {
       job: this.args.job,
       planOutput: this.planOutput,
       shouldShowPlanMessage: this.shouldShowPlanMessage,
-      view: this.view,
+      view: this.args.view,
     };
   }
 
@@ -160,7 +152,7 @@ export default class JobEditor extends Component {
       onReset: this.reset,
       onSaveAs: this.args.handleSaveAsTemplate,
       onSubmit: this.submit,
-      onToggle: this.toggleView,
+      onToggle: this.args.onToggle,
       onUpdate: this.updateCode,
       onUpload: this.uploadJobSpec,
     };

--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -19,7 +19,7 @@ export default class JobEditor extends Component {
   constructor() {
     super(...arguments);
     this.isEditing = !!(this.args.context === 'new');
-    this.view = this.args.specification ? 'job-spec' : 'full-definition';
+    this.view = this.args.view;
   }
 
   toggleEdit(bool) {

--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -13,29 +13,33 @@ export default class JobEditor extends Component {
 
   @tracked error = null;
   @tracked planOutput = null;
-  @tracked isEditing;
 
   constructor() {
     super(...arguments);
-    this.isEditing = !!(this.args.context === 'new');
+
+    if (this.definition) {
+      this.setDefinitionOnModel();
+    }
   }
 
-  toggleEdit(bool) {
-    this.isEditing = bool || !this.isEditing;
+  get isEditing() {
+    return ['new', 'edit'].includes(this.args.context);
+  }
+
+  @action
+  setDefinitionOnModel() {
+    this.args.job.set('_newDefinition', this.definition);
   }
 
   @action
   edit() {
-    this.args.job.set(
-      '_newDefinition',
-      JSON.stringify(this.args.definition, null, 2)
-    );
-    this.toggleEdit(true);
+    this.setDefinitionOnModel();
+    this.args.onToggleEdit(true);
   }
 
   @action
   onCancel() {
-    this.toggleEdit(false);
+    this.args.onToggleEdit(false);
   }
 
   get stage() {
@@ -106,9 +110,13 @@ export default class JobEditor extends Component {
   }
 
   @action
-  updateCode(value) {
+  updateCode(value, type = 'job') {
     if (!this.args.job.isDestroying && !this.args.job.isDestroyed) {
-      this.args.job.set('_newDefinition', value);
+      if (type === 'hclVars') {
+        this.args.job.set('_newDefinitionVariables', value);
+      } else {
+        this.args.job.set('_newDefinition', value);
+      }
     }
   }
 
@@ -125,7 +133,7 @@ export default class JobEditor extends Component {
 
   get definition() {
     if (this.args.view === 'full-definition') {
-      return this.args.definition;
+      return JSON.stringify(this.args.definition, null, 2);
     } else {
       return this.args.specification;
     }
@@ -152,7 +160,7 @@ export default class JobEditor extends Component {
       onReset: this.reset,
       onSaveAs: this.args.handleSaveAsTemplate,
       onSubmit: this.submit,
-      onToggle: this.args.onToggle,
+      onSelect: this.args.onSelect,
       onUpdate: this.updateCode,
       onUpload: this.uploadJobSpec,
     };

--- a/ui/app/components/job-editor/alert.js
+++ b/ui/app/components/job-editor/alert.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class Alert extends Component {
+  @tracked shouldShowAlert = true;
+
+  @action
+  dismissAlert() {
+    this.shouldShowAlert = false;
+  }
+}

--- a/ui/app/controllers/jobs/job/definition.js
+++ b/ui/app/controllers/jobs/job/definition.js
@@ -10,19 +10,28 @@ import WithNamespaceResetting from 'nomad-ui/mixins/with-namespace-resetting';
 export default class DefinitionController extends Controller.extend(
   WithNamespaceResetting
 ) {
-  @tracked view = this.specification ? 'job-spec' : 'full-definition';
-  queryParams = ['view'];
-
   @alias('model.definition') definition;
   @alias('model.job') job;
   @alias('model.specification') specification;
 
+  @tracked view;
+  @tracked isEditing = false;
+  queryParams = ['isEditing', 'view'];
+
   @service router;
 
+  get context() {
+    return this.isEditing ? 'edit' : 'read';
+  }
+
   @action
-  toggleView() {
-    const opposite = this.view === 'job-spec' ? 'full-definition' : 'job-spec';
-    this.view = opposite;
+  toggleEdit(bool) {
+    this.isEditing = bool || !this.isEditing;
+  }
+
+  @action
+  selectView(selectedView) {
+    this.view = selectedView;
   }
 
   onSubmit() {

--- a/ui/app/controllers/jobs/job/definition.js
+++ b/ui/app/controllers/jobs/job/definition.js
@@ -3,11 +3,15 @@ import WithNamespaceResetting from 'nomad-ui/mixins/with-namespace-resetting';
 import { alias } from '@ember/object/computed';
 import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 @classic
 export default class DefinitionController extends Controller.extend(
   WithNamespaceResetting
 ) {
+  @tracked view = 'job-spec';
+  queryParams = ['view'];
+
   @alias('model.definition') definition;
   @alias('model.job') job;
   @alias('model.specification') specification;

--- a/ui/app/controllers/jobs/job/definition.js
+++ b/ui/app/controllers/jobs/job/definition.js
@@ -1,15 +1,16 @@
 import Controller from '@ember/controller';
-import WithNamespaceResetting from 'nomad-ui/mixins/with-namespace-resetting';
+import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
-import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import classic from 'ember-classic-decorator';
+import WithNamespaceResetting from 'nomad-ui/mixins/with-namespace-resetting';
 
 @classic
 export default class DefinitionController extends Controller.extend(
   WithNamespaceResetting
 ) {
-  @tracked view = 'job-spec';
+  @tracked view = this.specification ? 'job-spec' : 'full-definition';
   queryParams = ['view'];
 
   @alias('model.definition') definition;
@@ -17,6 +18,12 @@ export default class DefinitionController extends Controller.extend(
   @alias('model.specification') specification;
 
   @service router;
+
+  @action
+  toggleView() {
+    const opposite = this.view === 'job-spec' ? 'full-definition' : 'job-spec';
+    this.view = opposite;
+  }
 
   onSubmit() {
     this.router.transitionTo('jobs.job', this.job.idWithNamespace);

--- a/ui/app/helpers/merge.js
+++ b/ui/app/helpers/merge.js
@@ -1,0 +1,10 @@
+import { helper } from '@ember/component/helper';
+
+function merge(positional) {
+  return positional.reduce((accum, val) => {
+    accum = { ...val, ...accum };
+    return accum;
+  }, {});
+}
+
+export default helper(merge);

--- a/ui/app/routes/jobs/job/definition.js
+++ b/ui/app/routes/jobs/job/definition.js
@@ -28,4 +28,15 @@ export default class DefinitionRoute extends Route {
       controller.set('isEditing', false);
     }
   }
+
+  setupController(controller, model) {
+    super.setupController(controller, model);
+
+    const view = controller.view
+      ? controller.view
+      : model?.specification
+      ? 'job-spec'
+      : 'full-definition';
+    controller.view = view;
+  }
 }

--- a/ui/app/styles/components/codemirror.scss
+++ b/ui/app/styles/components/codemirror.scss
@@ -133,7 +133,7 @@ $dark-bright: lighten($dark, 15%);
 header.run-job-header {
   display: grid;
   grid-template-columns: 1fr auto;
-  margin-bottom: 2rem;
+  margin: 2rem 0rem;
   gap: 0 1rem;
   & > h1 {
     grid-column: -1 / 1;
@@ -157,7 +157,7 @@ header.run-job-header {
   justify-content: space-between;
 }
 
-.job-definition-toggle {
+.job-definition-select {
   border: 1px solid $grey-blue;
   background: rgba(0, 0, 0, 0.05);
   border-radius: 2px;

--- a/ui/app/templates/components/job-editor.hbs
+++ b/ui/app/templates/components/job-editor.hbs
@@ -1,16 +1,7 @@
 <div>
-  {{#if this.error}}
-    <div data-test-error={{this.error.type}} class="notification is-danger">
-      <h3 class="title is-4" data-test-error-title>{{conditionally-capitalize this.error.type true}} Error</h3>
-      <p data-test-error-message>{{this.error.message}}</p>
-    </div>
-  {{/if}}
-  {{#if this.data.hasVariables}}
-    <div data-test-variable-notification class="notification">
-      <h3 class="title is-4">Job Variable Values Not Shown</h3>
-      <p>Please refer to Nomad CLI to see the current value of variables.</p>
-    </div>
-  {{/if}}
+  <JobEditor::Alert 
+    @data={{merge (hash error=this.error stage=this.stage) this.data}}
+  />
 
     <header class="run-job-header">
       <h1 class="title is-3">Run a job</h1>
@@ -18,6 +9,6 @@
         Paste or author HCL or JSON to submit to your cluster, or select from a list of templates. A plan will be requested before the job is submitted. You can also attach a job spec by uploading a job file or dragging &amp; dropping a file to the editor.
       </p>
     </header>
-
+    {{did-update this.setDefinitionOnModel this.definition}}
     {{component (concat 'job-editor/' this.stage) data=this.data fns=this.fns}}
 </div>

--- a/ui/app/templates/components/job-editor/alert.hbs
+++ b/ui/app/templates/components/job-editor/alert.hbs
@@ -1,0 +1,27 @@
+  {{#if @data.error}}
+    <Hds::Alert @type="inline" @color="critical" data-test-error={{@data.error.type}} as |A|>
+        <A.Title data-test-error-title>{{conditionally-capitalize @data.error.type true}}</A.Title>
+        <A.Description data-test-error-message>{{@data.error.message}}</A.Description>
+    </Hds::Alert>
+  {{/if}}
+  {{#if (and (eq @data.stage "read") @data.hasVariables (eq @data.view "job-spec"))}}
+    {{#if this.shouldShowAlert}}
+      <Hds::Alert @type="inline" @onDismiss={{this.dismissAlert}} data-test-variable-notification as |A|>
+        <A.Title>Job Variable Values Not Shown</A.Title>
+        <A.Description>Please refer to Nomad CLI to see the current value of variables.</A.Description>
+      </Hds::Alert>
+    {{/if}}
+  {{/if}}
+  {{#if (and (eq @data.stage "edit") (eq @data.view "full-definition"))}}
+      <Hds::Alert @type="inline" @color="warning" data-test-json-warning as |A|>
+        <A.Title>Edit JSON</A.Title>
+        <A.Description>If you edit the JSON formation in the full definition, you will no longer be able to see job spec in HCL.</A.Description>
+      </Hds::Alert>
+  {{/if}}
+  {{#if (and (eq @data.stage "review") @data.shouldShowPlanMessage)}}
+    <Hds::Alert @type="inline" @onDismiss={{fn (mut @data.showPlanMessage)}} as |A|>
+        <A.Title data-test-plan-help-title>Job Plan</A.Title>
+        <A.Description data-test-plan-help-message>This is the impact running this job will have on your cluster</A.Description>
+    </Hds::Alert>
+  {{/if}}
+  

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -13,17 +13,32 @@
     {{/if}}
     </div>
     <div class="boxed-section-body is-full-bleed">
-    <div
-        data-test-editor
-        {{code-mirror
-        screenReaderLabel="Job definition"
-        content=@data.job._newDefinition
-        theme="hashi"
-        onUpdate=@fns.onUpdate
-        mode="javascript"
-        }}
-    />
+        <div
+            data-test-editor
+            {{code-mirror
+            screenReaderLabel="Job definition"
+            content=@data.job._newDefinition
+            theme="hashi"
+            onUpdate=@fns.onUpdate
+            mode="javascript"
+            }}
+        />
     </div>
+    {{#if (eq @data.view "job-spec")}}
+    <div>
+        <h1 style="font-size: 2rem; font-weight: 600">Edit HCL Variables</h1>
+        <div
+            data-test-variable-editor
+            {{code-mirror
+            screenReaderLabel="HLC Variables for Job Spec"
+            content=""
+            theme="hashi"
+            onUpdate=(fn @fns.onUpdate "hclVars")
+            mode="ruby"
+            }}
+        />
+    </div>
+    {{/if}}
 </div>
 <div class="is-associative buttonset">
     <Hds::Button

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -3,19 +3,19 @@
     Job Definition
     <div class="pull-right" style="display: flex">
         {{#if @data.hasSpecification}}
-        <div class="job-definition-toggle" data-test-toggle={{@data.view}}>
+        <div class="job-definition-select" data-test-select={{@data.view}}>
             <button 
                 class="button is-small is-borderless {{if (eq @data.view "job-spec") "is-active"}}"
                 type="button"
-                {{on "click" @fns.onToggle}}
+                {{on "click" (fn @fns.onSelect "job-spec")}}
             >
                 Job Spec
             </button>
             <button 
                 class="button is-small is-borderless {{if (eq @data.view "full-definition") "is-active"}}"
                 type="button"
-                {{on "click" @fns.onToggle}}
-                data-test-toggle-full
+                {{on "click" (fn @fns.onSelect "full-definition")}}
+                data-test-select-full
             >
                 Full Definition
             </button>
@@ -44,7 +44,15 @@
             }} 
         />
     {{else}}
-        <JsonViewer data-test-definition-view @json={{@data.definition}} />
+        <div
+            data-test-json-viewer
+            {{code-mirror
+            content=@data.definition
+            theme="hashi-read-only"
+            readOnly=true
+            screenReaderLabel="JSON Viewer"
+            }}
+        />
     {{/if}}
     </div>
 </div>

--- a/ui/app/templates/components/job-editor/review.hbs
+++ b/ui/app/templates/components/job-editor/review.hbs
@@ -1,17 +1,3 @@
-{{#if @data.shouldShowPlanMessage}}
-    <div class="notification is-info">
-    <div class="columns">
-        <div class="column">
-        <h3 class="title is-4" data-test-plan-help-title>Job Plan</h3>
-        <p data-test-plan-help-message>This is the impact running this job
-            will have on your cluster.</p>
-        </div>
-        <div class="column is-centered is-minimum">
-        <Hds::Button @text="Okay" {{on "click" (toggle-action "showPlanMessage" this)}} data-test-plan-help-dismiss />
-        </div>
-    </div>
-    </div>
-{{/if}}
 <div class="boxed-section">
     <div class="boxed-section-head">Job Plan</div>
     <div class="boxed-section-body is-dark">

--- a/ui/app/templates/jobs/job/definition.hbs
+++ b/ui/app/templates/jobs/job/definition.hbs
@@ -6,6 +6,7 @@
     @definition={{this.definition}}
     @job={{this.job}}
     @specification={{this.specification}}
+    @view={{this.view}}
     @onSubmit={{action this.onSubmit}}
     data-test-job-editor
   />

--- a/ui/app/templates/jobs/job/definition.hbs
+++ b/ui/app/templates/jobs/job/definition.hbs
@@ -3,12 +3,14 @@
 <section class="section">
   <JobEditor
     @cancelable={{true}}
+    @context={{this.context}}
     @definition={{this.definition}}
     @job={{this.job}}
     @specification={{this.specification}}
     @view={{this.view}}
     @onSubmit={{action this.onSubmit}}
-    @onToggle={{this.toggleView}}
+    @onSelect={{this.selectView}}
+    @onToggleEdit={{this.toggleEdit}}
     data-test-job-editor
   />
 </section>

--- a/ui/app/templates/jobs/job/definition.hbs
+++ b/ui/app/templates/jobs/job/definition.hbs
@@ -8,6 +8,7 @@
     @specification={{this.specification}}
     @view={{this.view}}
     @onSubmit={{action this.onSubmit}}
+    @onToggle={{this.toggleView}}
     data-test-job-editor
   />
 </section>

--- a/ui/tests/acceptance/job-definition-test.js
+++ b/ui/tests/acceptance/job-definition-test.js
@@ -138,15 +138,15 @@ module('display and edit using full specification', function (hooks) {
     job = server.db.jobs[0];
   });
 
-  test('it allows users to toggle between full specification and JSON definition', async function (assert) {
+  test('it allows users to select between full specification and JSON definition', async function (assert) {
     assert.expect(3);
     server.get('/job/:id', () => JOB_JSON);
 
     await Definition.visit({ id: job.id });
 
     assert
-      .dom('[data-test-toggle="job-spec"]')
-      .exists('A toggle button exists and defaults to full definition');
+      .dom('[data-test-select="job-spec"]')
+      .exists('A select button exists and defaults to full definition');
     let codeMirror = getCodeMirrorInstance('[data-test-editor]');
     assert.equal(
       codeMirror.getValue(),
@@ -154,7 +154,7 @@ module('display and edit using full specification', function (hooks) {
       'Shows the full definition as written by the user'
     );
 
-    await click('[data-test-toggle-full]');
+    await click('[data-test-select-full]');
     codeMirror = getCodeMirrorInstance('[data-test-editor]');
     assert.propContains(JSON.parse(codeMirror.getValue()), JOB_JSON);
   });

--- a/ui/tests/acceptance/keyboard-test.js
+++ b/ui/tests/acceptance/keyboard-test.js
@@ -306,9 +306,8 @@ module('Acceptance | keyboard', function (hooks) {
       await triggerKeyEvent('.page-layout', 'keydown', 'ArrowRight', {
         shiftKey: true,
       });
-      assert.equal(
-        currentURL(),
-        `/jobs/${jobID}@default/definition`,
+      assert.ok(
+        currentURL().startsWith(`/jobs/${jobID}@default/definition`),
         'Shift+ArrowRight takes you to the next tab (Definition)'
       );
 

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -76,7 +76,7 @@ export default function moduleForJob(
         ? `/jobs/${job.name}@${job.namespace}/definition`
         : `/jobs/${job.name}/definition`;
 
-      assert.equal(decodeURIComponent(currentURL()), expectedURL);
+      assert.ok(decodeURIComponent(currentURL()).startsWith(expectedURL));
     });
 
     test('the subnav links to versions', async function (assert) {

--- a/ui/tests/integration/components/job-editor-test.js
+++ b/ui/tests/integration/components/job-editor-test.js
@@ -1,7 +1,7 @@
 import { assign } from '@ember/polyfills';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { create } from 'ember-cli-page-object';
 import sinon from 'sinon';
@@ -78,31 +78,17 @@ module('Integration | Component | job-editor', function (hooks) {
     <JobEditor
       @job={{job}}
       @context={{context}}
-      @onSubmit={{onSubmit}} 
-    />
-  `;
-
-  const cancelableTemplate = hbs`
-    <JobEditor
-      @job={{job}}
-      @context={{context}}
-      @cancelable={{true}}
       @onSubmit={{onSubmit}}
     />
   `;
 
   const renderNewJob = async (component, job) => {
-    component.setProperties({ job, onSubmit: sinon.spy(), context: 'new' });
-    await component.render(commonTemplate);
-  };
-
-  const renderEditJob = async (component, job) => {
     component.setProperties({
       job,
       onSubmit: sinon.spy(),
-      context: 'edit',
+      context: 'new',
     });
-    await component.render(cancelableTemplate);
+    await component.render(commonTemplate);
   };
 
   const planJob = async (spec) => {
@@ -346,8 +332,23 @@ module('Integration | Component | job-editor', function (hooks) {
     const spec = hclJob();
     const job = await this.store.createRecord('job');
 
-    await renderEditJob(this, job);
-    await click('[data-test-edit-job]');
+    this.set('job', job);
+
+    this.set('onToggleEdit', () => {});
+    this.set('onSubmit', () => {});
+    this.set('handleSaveAsTemplate', () => {});
+    this.set('onSelect', () => {});
+
+    await render(hbs`
+      <JobEditor
+        @context="edit"
+        @job={{this.job}}
+        @onToggleEdit={{this.onToggleEdit}}
+        @onSubmit={{this.onSubmit}}
+        @handleSaveAsTemplate={{this.handleSaveAsTemplate}}
+        @onSelect={{this.onSelect}}
+      />
+    `);
 
     await planJob(spec);
     await Editor.run();
@@ -411,22 +412,27 @@ module('Integration | Component | job-editor', function (hooks) {
 
     const job = await this.store.createRecord('job');
 
-    await renderEditJob(this, job);
-    await click('[data-test-edit-job]');
+    this.set('job', job);
+
+    this.set('onToggleEdit', () => {});
+    this.set('onSubmit', () => {});
+    this.set('handleSaveAsTemplate', () => {});
+    this.set('onSelect', () => {});
+
+    await render(hbs`
+      <JobEditor
+        @cancelable={{true}}
+        @context="new"
+        @job={{this.job}}
+        @onToggleEdit={{this.onToggleEdit}}
+        @onSubmit={{this.onSubmit}}
+        @handleSaveAsTemplate={{this.handleSaveAsTemplate}}
+        @onSelect={{this.onSelect}}
+      />
+    `);
 
     assert.ok(Editor.cancelEditingIsAvailable, 'Cancel editing button exists');
 
     await componentA11yAudit(this.element, assert);
-  });
-
-  test('when the job-editor cancel button is clicked, the onCancel hook is called', async function (assert) {
-    const job = await this.store.createRecord('job');
-
-    await renderEditJob(this, job);
-    await click('[data-test-edit-job]');
-    await click('[data-test-cancel-editing]');
-    assert
-      .dom('[data-test-json-viewer]')
-      .exists('We reset state to be in read only mode after hitting cancel.');
   });
 });


### PR DESCRIPTION
This PR resolves #16509.

This PR adds a query parameter to track the state of the view of the `JobEditor`.