### PR TITLE
ui:  remove toggle behavior in `JobEditor`

### DIFF
--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -152,7 +152,7 @@ export default class JobEditor extends Component {
       onReset: this.reset,
       onSaveAs: this.args.handleSaveAsTemplate,
       onSubmit: this.submit,
-      onToggle: this.args.onToggle,
+      onSelect: this.args.onSelect,
       onUpdate: this.updateCode,
       onUpload: this.uploadJobSpec,
     };

--- a/ui/app/controllers/jobs/job/definition.js
+++ b/ui/app/controllers/jobs/job/definition.js
@@ -10,19 +10,18 @@ import WithNamespaceResetting from 'nomad-ui/mixins/with-namespace-resetting';
 export default class DefinitionController extends Controller.extend(
   WithNamespaceResetting
 ) {
-  @tracked view = this.specification ? 'job-spec' : 'full-definition';
-  queryParams = ['view'];
-
   @alias('model.definition') definition;
   @alias('model.job') job;
   @alias('model.specification') specification;
 
+  @tracked view;
+  queryParams = ['view'];
+
   @service router;
 
   @action
-  toggleView() {
-    const opposite = this.view === 'job-spec' ? 'full-definition' : 'job-spec';
-    this.view = opposite;
+  selectView(selectedView) {
+    this.view = selectedView;
   }
 
   onSubmit() {

--- a/ui/app/routes/jobs/job/definition.js
+++ b/ui/app/routes/jobs/job/definition.js
@@ -28,4 +28,9 @@ export default class DefinitionRoute extends Route {
       controller.set('isEditing', false);
     }
   }
+
+  setupController(controller, model) {
+    super.setupController(controller, model);
+    controller.view = model.specification ? 'job-spec' : 'full-definition';
+  }
 }

--- a/ui/app/styles/components/codemirror.scss
+++ b/ui/app/styles/components/codemirror.scss
@@ -157,7 +157,7 @@ header.run-job-header {
   justify-content: space-between;
 }
 
-.job-definition-toggle {
+.job-definition-select {
   border: 1px solid $grey-blue;
   background: rgba(0, 0, 0, 0.05);
   border-radius: 2px;

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -3,19 +3,19 @@
     Job Definition
     <div class="pull-right" style="display: flex">
         {{#if @data.hasSpecification}}
-        <div class="job-definition-toggle" data-test-toggle={{@data.view}}>
+        <div class="job-definition-select" data-test-select={{@data.view}}>
             <button 
                 class="button is-small is-borderless {{if (eq @data.view "job-spec") "is-active"}}"
                 type="button"
-                {{on "click" @fns.onToggle}}
+                {{on "click" (fn @fns.onSelect "job-spec")}}
             >
                 Job Spec
             </button>
             <button 
                 class="button is-small is-borderless {{if (eq @data.view "full-definition") "is-active"}}"
                 type="button"
-                {{on "click" @fns.onToggle}}
-                data-test-toggle-full
+                {{on "click" (fn @fns.onSelect "full-definition")}}
+                data-test-select-full
             >
                 Full Definition
             </button>

--- a/ui/app/templates/jobs/job/definition.hbs
+++ b/ui/app/templates/jobs/job/definition.hbs
@@ -8,7 +8,7 @@
     @specification={{this.specification}}
     @view={{this.view}}
     @onSubmit={{action this.onSubmit}}
-    @onToggle={{this.toggleView}}
+    @onSelect={{this.selectView}}
     data-test-job-editor
   />
 </section>

--- a/ui/tests/acceptance/job-definition-test.js
+++ b/ui/tests/acceptance/job-definition-test.js
@@ -138,15 +138,15 @@ module('display and edit using full specification', function (hooks) {
     job = server.db.jobs[0];
   });
 
-  test('it allows users to toggle between full specification and JSON definition', async function (assert) {
+  test('it allows users to select between full specification and JSON definition', async function (assert) {
     assert.expect(3);
     server.get('/job/:id', () => JOB_JSON);
 
     await Definition.visit({ id: job.id });
 
     assert
-      .dom('[data-test-toggle="job-spec"]')
-      .exists('A toggle button exists and defaults to full definition');
+      .dom('[data-test-select="job-spec"]')
+      .exists('A select button exists and defaults to full definition');
     let codeMirror = getCodeMirrorInstance('[data-test-editor]');
     assert.equal(
       codeMirror.getValue(),
@@ -154,7 +154,7 @@ module('display and edit using full specification', function (hooks) {
       'Shows the full definition as written by the user'
     );
 
-    await click('[data-test-toggle-full]');
+    await click('[data-test-select-full]');
     codeMirror = getCodeMirrorInstance('[data-test-editor]');
     assert.propContains(JSON.parse(codeMirror.getValue()), JOB_JSON);
   });


### PR DESCRIPTION
This PR resolves #16694 to remove the toggle behavior in the `JobEditor` component and instead uses a select behavior.