### PR TITLE
refact:  move `edit` state to controller

### DIFF
--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -13,15 +13,20 @@ export default class JobEditor extends Component {
 
   @tracked error = null;
   @tracked planOutput = null;
-  @tracked isEditing;
 
   constructor() {
     super(...arguments);
-    this.isEditing = !!(this.args.context === 'new');
+
+    if (this.args.definition) {
+      this.args.job.set(
+        '_newDefinition',
+        JSON.stringify(this.args.definition, null, 2)
+      );
+    }
   }
 
-  toggleEdit(bool) {
-    this.isEditing = bool || !this.isEditing;
+  get isEditing() {
+    return ['new', 'edit'].includes(this.args.context);
   }
 
   @action
@@ -30,12 +35,12 @@ export default class JobEditor extends Component {
       '_newDefinition',
       JSON.stringify(this.args.definition, null, 2)
     );
-    this.toggleEdit(true);
+    this.args.onToggleEdit(true);
   }
 
   @action
   onCancel() {
-    this.toggleEdit(false);
+    this.args.onToggleEdit(false);
   }
 
   get stage() {

--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -17,11 +17,8 @@ export default class JobEditor extends Component {
   constructor() {
     super(...arguments);
 
-    if (this.args.definition) {
-      this.args.job.set(
-        '_newDefinition',
-        JSON.stringify(this.args.definition, null, 2)
-      );
+    if (this.definition) {
+      this.setDefinitionOnModel();
     }
   }
 
@@ -30,11 +27,13 @@ export default class JobEditor extends Component {
   }
 
   @action
+  setDefinitionOnModel() {
+    this.args.job.set('_newDefinition', this.definition);
+  }
+
+  @action
   edit() {
-    this.args.job.set(
-      '_newDefinition',
-      JSON.stringify(this.args.definition, null, 2)
-    );
+    this.setDefinitionOnModel();
     this.args.onToggleEdit(true);
   }
 
@@ -111,9 +110,13 @@ export default class JobEditor extends Component {
   }
 
   @action
-  updateCode(value) {
+  updateCode(value, type = 'job') {
     if (!this.args.job.isDestroying && !this.args.job.isDestroyed) {
-      this.args.job.set('_newDefinition', value);
+      if (type === 'hclVars') {
+        this.args.job.set('_newDefinitionVariables', value);
+      } else {
+        this.args.job.set('_newDefinition', value);
+      }
     }
   }
 
@@ -130,7 +133,7 @@ export default class JobEditor extends Component {
 
   get definition() {
     if (this.args.view === 'full-definition') {
-      return this.args.definition;
+      return JSON.stringify(this.args.definition, null, 2);
     } else {
       return this.args.specification;
     }

--- a/ui/app/controllers/jobs/job/definition.js
+++ b/ui/app/controllers/jobs/job/definition.js
@@ -15,9 +15,19 @@ export default class DefinitionController extends Controller.extend(
   @alias('model.specification') specification;
 
   @tracked view;
-  queryParams = ['view'];
+  @tracked isEditing = false;
+  queryParams = ['isEditing', 'view'];
 
   @service router;
+
+  get context() {
+    return this.isEditing ? 'edit' : 'read';
+  }
+
+  @action
+  toggleEdit(bool) {
+    this.isEditing = bool || !this.isEditing;
+  }
 
   @action
   selectView(selectedView) {

--- a/ui/app/routes/jobs/job/definition.js
+++ b/ui/app/routes/jobs/job/definition.js
@@ -31,6 +31,12 @@ export default class DefinitionRoute extends Route {
 
   setupController(controller, model) {
     super.setupController(controller, model);
-    controller.view = model?.specification ? 'job-spec' : 'full-definition';
+
+    const view = controller.view
+      ? controller.view
+      : model?.specification
+      ? 'job-spec'
+      : 'full-definition';
+    controller.view = view;
   }
 }

--- a/ui/app/templates/components/job-editor.hbs
+++ b/ui/app/templates/components/job-editor.hbs
@@ -9,6 +9,6 @@
         Paste or author HCL or JSON to submit to your cluster, or select from a list of templates. A plan will be requested before the job is submitted. You can also attach a job spec by uploading a job file or dragging &amp; dropping a file to the editor.
       </p>
     </header>
-
+    {{did-update this.setDefinitionOnModel this.definition}}
     {{component (concat 'job-editor/' this.stage) data=this.data fns=this.fns}}
 </div>

--- a/ui/app/templates/components/job-editor/alert.hbs
+++ b/ui/app/templates/components/job-editor/alert.hbs
@@ -4,13 +4,19 @@
         <A.Description data-test-error-message>{{@data.error.message}}</A.Description>
     </Hds::Alert>
   {{/if}}
-  {{#if (and (eq @data.stage "read") @data.hasVariables)}}
+  {{#if (and (eq @data.stage "read") @data.hasVariables (eq @data.view "job-spec"))}}
     {{#if this.shouldShowAlert}}
       <Hds::Alert @type="inline" @onDismiss={{this.dismissAlert}} data-test-variable-notification as |A|>
         <A.Title>Job Variable Values Not Shown</A.Title>
         <A.Description>Please refer to Nomad CLI to see the current value of variables.</A.Description>
       </Hds::Alert>
     {{/if}}
+  {{/if}}
+  {{#if (and (eq @data.stage "edit") (eq @data.view "full-definition"))}}
+      <Hds::Alert @type="inline" @color="warning" data-test-json-warning as |A|>
+        <A.Title>Edit JSON</A.Title>
+        <A.Description>If you edit the JSON formation in the full definition, you will no longer be able to see job spec in HCL.</A.Description>
+      </Hds::Alert>
   {{/if}}
   {{#if (and (eq @data.stage "review") @data.shouldShowPlanMessage)}}
     <Hds::Alert @type="inline" @onDismiss={{fn (mut @data.showPlanMessage)}} as |A|>

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -13,17 +13,32 @@
     {{/if}}
     </div>
     <div class="boxed-section-body is-full-bleed">
-    <div
-        data-test-editor
-        {{code-mirror
-        screenReaderLabel="Job definition"
-        content=@data.job._newDefinition
-        theme="hashi"
-        onUpdate=@fns.onUpdate
-        mode="javascript"
-        }}
-    />
+        <div
+            data-test-editor
+            {{code-mirror
+            screenReaderLabel="Job definition"
+            content=@data.job._newDefinition
+            theme="hashi"
+            onUpdate=@fns.onUpdate
+            mode="javascript"
+            }}
+        />
     </div>
+    {{#if (eq @data.view "job-spec")}}
+    <div>
+        <h1 style="font-size: 2rem; font-weight: 600">Edit HCL Variables</h1>
+        <div
+            data-test-variable-editor
+            {{code-mirror
+            screenReaderLabel="HLC Variables for Job Spec"
+            content=""
+            theme="hashi"
+            onUpdate=(fn @fns.onUpdate "hclVars")
+            mode="ruby"
+            }}
+        />
+    </div>
+    {{/if}}
 </div>
 <div class="is-associative buttonset">
     <Hds::Button

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -44,7 +44,15 @@
             }} 
         />
     {{else}}
-        <JsonViewer data-test-definition-view @json={{@data.definition}} />
+        <div
+            data-test-json-viewer
+            {{code-mirror
+            content=@data.definition
+            theme="hashi-read-only"
+            readOnly=true
+            screenReaderLabel="JSON Viewer"
+            }}
+        />
     {{/if}}
     </div>
 </div>

--- a/ui/app/templates/jobs/job/definition.hbs
+++ b/ui/app/templates/jobs/job/definition.hbs
@@ -3,12 +3,14 @@
 <section class="section">
   <JobEditor
     @cancelable={{true}}
+    @context={{this.context}}
     @definition={{this.definition}}
     @job={{this.job}}
     @specification={{this.specification}}
     @view={{this.view}}
     @onSubmit={{action this.onSubmit}}
     @onSelect={{this.selectView}}
+    @onToggleEdit={{this.toggleEdit}}
     data-test-job-editor
   />
 </section>

--- a/ui/tests/integration/components/job-editor-test.js
+++ b/ui/tests/integration/components/job-editor-test.js
@@ -1,7 +1,7 @@
 import { assign } from '@ember/polyfills';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { create } from 'ember-cli-page-object';
 import sinon from 'sinon';
@@ -78,31 +78,17 @@ module('Integration | Component | job-editor', function (hooks) {
     <JobEditor
       @job={{job}}
       @context={{context}}
-      @onSubmit={{onSubmit}} 
-    />
-  `;
-
-  const cancelableTemplate = hbs`
-    <JobEditor
-      @job={{job}}
-      @context={{context}}
-      @cancelable={{true}}
       @onSubmit={{onSubmit}}
     />
   `;
 
   const renderNewJob = async (component, job) => {
-    component.setProperties({ job, onSubmit: sinon.spy(), context: 'new' });
-    await component.render(commonTemplate);
-  };
-
-  const renderEditJob = async (component, job) => {
     component.setProperties({
       job,
       onSubmit: sinon.spy(),
-      context: 'edit',
+      context: 'new',
     });
-    await component.render(cancelableTemplate);
+    await component.render(commonTemplate);
   };
 
   const planJob = async (spec) => {
@@ -346,8 +332,23 @@ module('Integration | Component | job-editor', function (hooks) {
     const spec = hclJob();
     const job = await this.store.createRecord('job');
 
-    await renderEditJob(this, job);
-    await click('[data-test-edit-job]');
+    this.set('job', job);
+
+    this.set('onToggleEdit', () => {});
+    this.set('onSubmit', () => {});
+    this.set('handleSaveAsTemplate', () => {});
+    this.set('onSelect', () => {});
+
+    await render(hbs`
+      <JobEditor
+        @context="edit"
+        @job={{this.job}}
+        @onToggleEdit={{this.onToggleEdit}}
+        @onSubmit={{this.onSubmit}}
+        @handleSaveAsTemplate={{this.handleSaveAsTemplate}}
+        @onSelect={{this.onSelect}}
+      />
+    `);
 
     await planJob(spec);
     await Editor.run();
@@ -411,22 +412,27 @@ module('Integration | Component | job-editor', function (hooks) {
 
     const job = await this.store.createRecord('job');
 
-    await renderEditJob(this, job);
-    await click('[data-test-edit-job]');
+    this.set('job', job);
+
+    this.set('onToggleEdit', () => {});
+    this.set('onSubmit', () => {});
+    this.set('handleSaveAsTemplate', () => {});
+    this.set('onSelect', () => {});
+
+    await render(hbs`
+      <JobEditor
+        @cancelable={{true}}
+        @context="new"
+        @job={{this.job}}
+        @onToggleEdit={{this.onToggleEdit}}
+        @onSubmit={{this.onSubmit}}
+        @handleSaveAsTemplate={{this.handleSaveAsTemplate}}
+        @onSelect={{this.onSelect}}
+      />
+    `);
 
     assert.ok(Editor.cancelEditingIsAvailable, 'Cancel editing button exists');
 
     await componentA11yAudit(this.element, assert);
-  });
-
-  test('when the job-editor cancel button is clicked, the onCancel hook is called', async function (assert) {
-    const job = await this.store.createRecord('job');
-
-    await renderEditJob(this, job);
-    await click('[data-test-edit-job]');
-    await click('[data-test-cancel-editing]');
-    assert
-      .dom('[data-test-json-viewer]')
-      .exists('We reset state to be in read only mode after hitting cancel.');
   });
 });


### PR DESCRIPTION
This PR is also pre-work for #16714. This PR moves the editing state of the `JobEditor` into the controller for the `Definition` view.

Loom Walk Through:  https://www.loom.com/share/c9290a770a1b4164a19d16a39e82d577