### PR TITLE
ci: use `BACKPORT_MERGE_COMMIT` option

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -19,6 +19,7 @@ jobs:
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
           BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
+          BACKPORT_MERGE_COMMIT: true
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Backport changes to targeted release branch
         run: |
@@ -26,6 +27,7 @@ jobs:
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.[+\\w]+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
+          BACKPORT_MERGE_COMMIT: true
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
   handle-failure:
     needs:


### PR DESCRIPTION
Instead of attempting to pick each individual commit in a PR using `BACKPORT_MERGE_COMMIT` only picks the commit that was merged into `main`.

This reduces the amount of work done during a backport, generating cleaner merges and avoiding potential issues on specific commits.

With this setting PRs that are not squashed will fail to backport and must be handled manually, but those are considered exceptions.