### PR TITLE
ent: move all license info into LicenseConfig{}

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -170,7 +170,6 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	conf.EnableDebug = agentConfig.EnableDebug
 
 	conf.Build = agentConfig.Version.VersionNumber()
-	conf.BuildDate = agentConfig.Version.BuildDate
 	conf.Revision = agentConfig.Version.Revision
 	if agentConfig.Region != "" {
 		conf.Region = agentConfig.Region
@@ -550,9 +549,12 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	}
 
 	// Add Enterprise license configs
-	conf.LicenseEnv = agentConfig.Server.LicenseEnv
-	conf.LicensePath = agentConfig.Server.LicensePath
-	conf.LicenseConfig.AdditionalPubKeys = agentConfig.Server.licenseAdditionalPublicKeys
+	conf.LicenseConfig = &nomad.LicenseConfig{
+		BuildDate:         agentConfig.Version.BuildDate,
+		AdditionalPubKeys: agentConfig.Server.licenseAdditionalPublicKeys,
+		LicenseEnvBytes:   agentConfig.Server.LicenseEnv,
+		LicensePath:       agentConfig.Server.LicensePath,
+	}
 
 	// Add the search configuration
 	if search := agentConfig.Server.Search; search != nil {

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -127,9 +127,6 @@ type Config struct {
 	// operators track which versions are actively deployed
 	Build string
 
-	// BuildDate is the time of the git commit used to build the program.
-	BuildDate time.Time
-
 	// Revision is a string that carries the version.GitCommit of Nomad that
 	// was compiled.
 	Revision string
@@ -389,10 +386,8 @@ type Config struct {
 	// connections from a single IP address. nil/0 means no limit.
 	RPCMaxConnsPerClient int
 
-	// LicenseConfig is a tunable knob for enterprise license testing.
+	// LicenseConfig stored information about the Enterprise license loaded for the server.
 	LicenseConfig *LicenseConfig
-	LicenseEnv    string
-	LicensePath   string
 
 	// SearchConfig provides knobs for Search API.
 	SearchConfig *structs.SearchConfig

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -386,7 +386,7 @@ type Config struct {
 	// connections from a single IP address. nil/0 means no limit.
 	RPCMaxConnsPerClient int
 
-	// LicenseConfig stored information about the Enterprise license loaded for the server.
+	// LicenseConfig stores information about the Enterprise license loaded for the server.
 	LicenseConfig *LicenseConfig
 
 	// SearchConfig provides knobs for Search API.

--- a/nomad/license_config.go
+++ b/nomad/license_config.go
@@ -3,7 +3,6 @@ package nomad
 import (
 	"time"
 
-	"github.com/hashicorp/go-hclog"
 	"golang.org/x/exp/slices"
 )
 
@@ -21,8 +20,6 @@ type LicenseConfig struct {
 
 	// AdditionalPubKeys is a set of public keys to
 	AdditionalPubKeys []string
-
-	Logger hclog.InterceptLogger
 }
 
 func (c *LicenseConfig) Copy() *LicenseConfig {

--- a/nomad/license_config_oss.go
+++ b/nomad/license_config_oss.go
@@ -1,0 +1,7 @@
+//go:build !ent
+
+package nomad
+
+func (c *LicenseConfig) Validate() error {
+	return nil
+}

--- a/nomad/server_setup_oss.go
+++ b/nomad/server_setup_oss.go
@@ -1,5 +1,4 @@
 //go:build !ent
-// +build !ent
 
 package nomad
 


### PR DESCRIPTION
and add new `TestConfigForServer()` to get a valid `nomad.Config` to use in tests.

Should be noop here in OSS.

Relates to hashicorp/nomad-enterprise#855
These OSS files originated in ent PR hashicorp/nomad-enterprise#1060