### PR TITLE
take maximum processor Mhz

### DIFF
--- a/.changelog/16740.txt
+++ b/.changelog/16740.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client/fingerprint: detect fastest cpu core during cpu performance fallback
+```

--- a/helper/stats/cpu.go
+++ b/helper/stats/cpu.go
@@ -66,7 +66,6 @@ func Init() error {
 				if uint64(infoStat.Mhz) > cpuPowerCoreMHz {
 					cpuPowerCoreMHz = uint64(infoStat.Mhz)
 				}
-				break
 			}
 
 			// compute ticks using only power core, until we add support for

--- a/helper/stats/cpu.go
+++ b/helper/stats/cpu.go
@@ -63,7 +63,9 @@ func Init() error {
 
 			for _, infoStat := range cpuInfoStats {
 				cpuModelName = infoStat.ModelName
-				cpuPowerCoreMHz = uint64(infoStat.Mhz)
+				if uint64(infoStat.Mhz) > cpuPowerCoreMHz {
+					cpuPowerCoreMHz = uint64(infoStat.Mhz)
+				}
 				break
 			}
 


### PR DESCRIPTION
Currently we take just first processor Mhz, and exit, assuming they are all the same.

We depend on 	"github.com/shoenig/go-m1cpu" to get the cpu data 

On linux platform this either uses maximum frequency https://github.com/shoenig/gopsutil/blob/master/cpu/cpu_linux.go#L88 from `cpuinfo_max_freq` (that would be correct)

However some machines lack this file, and then we fallback to real frequency https://github.com/shoenig/gopsutil/blob/master/cpu/cpu_linux.go#L175-L179

Real frequency can be much lower than maximal, and taking just first processor value can give incorrect data.

For example on my machine

```
[georgy@kf06 ~]$ cat /proc/cpuinfo  | grep "cpu MHz"
cpu MHz		: 2200.000
cpu MHz		: 2685.956
cpu MHz		: 2200.000
cpu MHz		: 2252.721
cpu MHz		: 2200.000
cpu MHz		: 2200.000
cpu MHz		: 2200.000
cpu MHz		: 2700.009
cpu MHz		: 2200.000
cpu MHz		: 2592.342
cpu MHz		: 1906.243
cpu MHz		: 2200.000
cpu MHz		: 2200.000
cpu MHz		: 2200.000
cpu MHz		: 2042.605
cpu MHz		: 2200.000
cpu MHz		: 1423.054
cpu MHz		: 2200.000
cpu MHz		: 2200.000
cpu MHz		: 2552.760
cpu MHz		: 1645.222
cpu MHz		: 2591.675
cpu MHz		: 1858.395
cpu MHz		: 2699.999
cpu MHz		: 1231.719
cpu MHz		: 2688.291
cpu MHz		: 2236.831
cpu MHz		: 2200.000
cpu MHz		: 1244.091
cpu MHz		: 2200.000
cpu MHz		: 2200.000
cpu MHz		: 2200.000
cpu MHz		: 2200.000
cpu MHz		: 2200.000
cpu MHz		: 2200.000
cpu MHz		: 2200.000
cpu MHz		: 2200.000
cpu MHz		: 2631.418
cpu MHz		: 2200.000
cpu MHz		: 2200.000
cpu MHz		: 2200.000
cpu MHz		: 2200.000
cpu MHz		: 1789.280
cpu MHz		: 2200.000
cpu MHz		: 1754.116
cpu MHz		: 2586.694
cpu MHz		: 1209.627
cpu MHz		: 2700.003
```

Would not taking the maximum value be better here?