### PR TITLE
Add LocalServiceSocketPath on ConsulProxy

### DIFF
--- a/.changelog/16744.txt
+++ b/.changelog/16744.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Added support for LocalServiceSocketPath field on proxy block
+```

--- a/api/consul.go
+++ b/api/consul.go
@@ -140,12 +140,13 @@ func (st *SidecarTask) Canonicalize() {
 
 // ConsulProxy represents a Consul Connect sidecar proxy jobspec block.
 type ConsulProxy struct {
-	LocalServiceAddress string                 `mapstructure:"local_service_address" hcl:"local_service_address,optional"`
-	LocalServicePort    int                    `mapstructure:"local_service_port" hcl:"local_service_port,optional"`
-	Expose              *ConsulExposeConfig    `mapstructure:"expose" hcl:"expose,block"`
-	ExposeConfig        *ConsulExposeConfig    // Deprecated: only to maintain backwards compatibility. Use Expose instead.
-	Upstreams           []*ConsulUpstream      `hcl:"upstreams,block"`
-	Config              map[string]interface{} `hcl:"config,block"`
+	LocalServiceAddress    string                 `mapstructure:"local_service_address" hcl:"local_service_address,optional"`
+	LocalServicePort       int                    `mapstructure:"local_service_port" hcl:"local_service_port,optional"`
+	LocalServiceSocketPath string                 `mapstructure:"local_service_socket_path" hcl:"local_service_socket_path,optional"`
+	Expose                 *ConsulExposeConfig    `mapstructure:"expose" hcl:"expose,block"`
+	ExposeConfig           *ConsulExposeConfig    // Deprecated: only to maintain backwards compatibility. Use Expose instead.
+	Upstreams              []*ConsulUpstream      `hcl:"upstreams,block"`
+	Config                 map[string]interface{} `hcl:"config,block"`
 }
 
 func (cp *ConsulProxy) Canonicalize() {

--- a/api/consul_test.go
+++ b/api/consul_test.go
@@ -104,8 +104,9 @@ func TestConsulSidecarService_Canonicalize(t *testing.T) {
 			Tags: make([]string, 0),
 			Port: "port",
 			Proxy: &ConsulProxy{
-				LocalServiceAddress: "lsa",
-				LocalServicePort:    80,
+				LocalServiceAddress:    "lsa",
+				LocalServicePort:       80,
+				LocalServiceSocketPath: "/run/test.sock",
 			},
 			Meta: map[string]string{
 				"test-key": "test-value",
@@ -116,8 +117,9 @@ func TestConsulSidecarService_Canonicalize(t *testing.T) {
 			Tags: nil,
 			Port: "port",
 			Proxy: &ConsulProxy{
-				LocalServiceAddress: "lsa",
-				LocalServicePort:    80},
+				LocalServiceAddress:    "lsa",
+				LocalServicePort:       80,
+				LocalServiceSocketPath: "/run/test.sock"},
 			Meta: map[string]string{
 				"test-key": "test-value",
 			},
@@ -139,6 +141,7 @@ func TestConsulProxy_Canonicalize(t *testing.T) {
 		cp.Canonicalize()
 		must.Eq(t, "", cp.LocalServiceAddress)
 		must.Zero(t, cp.LocalServicePort)
+		must.Eq(t, "", cp.LocalServiceSocketPath)
 		must.Nil(t, cp.Expose)
 		must.Nil(t, cp.Upstreams)
 		must.MapEmpty(t, cp.Config)
@@ -146,15 +149,17 @@ func TestConsulProxy_Canonicalize(t *testing.T) {
 
 	t.Run("non empty proxy", func(t *testing.T) {
 		cp := &ConsulProxy{
-			LocalServiceAddress: "127.0.0.1",
-			LocalServicePort:    80,
-			Expose:              new(ConsulExposeConfig),
-			Upstreams:           make([]*ConsulUpstream, 0),
-			Config:              make(map[string]interface{}),
+			LocalServiceAddress:    "127.0.0.1",
+			LocalServicePort:       80,
+			LocalServiceSocketPath: "/run/test.sock",
+			Expose:                 new(ConsulExposeConfig),
+			Upstreams:              make([]*ConsulUpstream, 0),
+			Config:                 make(map[string]interface{}),
 		}
 		cp.Canonicalize()
 		must.Eq(t, "127.0.0.1", cp.LocalServiceAddress)
 		must.Eq(t, 80, cp.LocalServicePort)
+		must.Eq(t, "/run/test.sock", cp.LocalServiceSocketPath)
 		must.Eq(t, &ConsulExposeConfig{}, cp.Expose)
 		must.Nil(t, cp.Upstreams)
 		must.Nil(t, cp.Config)

--- a/command/agent/consul/connect.go
+++ b/command/agent/consul/connect.go
@@ -144,11 +144,12 @@ func connectSidecarProxy(info structs.AllocInfo, proxy *structs.ConsulProxy, cPo
 	}
 
 	return &api.AgentServiceConnectProxyConfig{
-		LocalServiceAddress: proxy.LocalServiceAddress,
-		LocalServicePort:    proxy.LocalServicePort,
-		Config:              connectProxyConfig(proxy.Config, cPort, info),
-		Upstreams:           connectUpstreams(proxy.Upstreams),
-		Expose:              expose,
+		LocalServiceAddress:    proxy.LocalServiceAddress,
+		LocalServicePort:       proxy.LocalServicePort,
+		LocalServiceSocketPath: proxy.LocalServiceSocketPath,
+		Config:                 connectProxyConfig(proxy.Config, cPort, info),
+		Upstreams:              connectUpstreams(proxy.Upstreams),
+		Expose:                 expose,
 	}, nil
 }
 

--- a/command/agent/consul/connect_test.go
+++ b/command/agent/consul/connect_test.go
@@ -204,10 +204,11 @@ func TestConnect_connectProxy(t *testing.T) {
 		proxy, err := connectSidecarProxy(info, nil, 2000, testConnectNetwork)
 		require.NoError(t, err)
 		require.Equal(t, &api.AgentServiceConnectProxyConfig{
-			LocalServiceAddress: "",
-			LocalServicePort:    0,
-			Upstreams:           nil,
-			Expose:              api.ExposeConfig{},
+			LocalServiceAddress:    "",
+			LocalServicePort:       0,
+			LocalServiceSocketPath: "",
+			Upstreams:              nil,
+			Expose:                 api.ExposeConfig{},
 			Config: map[string]interface{}{
 				"bind_address":     "0.0.0.0",
 				"bind_port":        2000,
@@ -233,9 +234,10 @@ func TestConnect_connectProxy(t *testing.T) {
 
 	t.Run("normal", func(t *testing.T) {
 		proxy, err := connectSidecarProxy(info, &structs.ConsulProxy{
-			LocalServiceAddress: "0.0.0.0",
-			LocalServicePort:    2000,
-			Upstreams:           nil,
+			LocalServiceAddress:    "0.0.0.0",
+			LocalServicePort:       2000,
+			LocalServiceSocketPath: "dev/null",
+			Upstreams:              nil,
 			Expose: &structs.ConsulExposeConfig{
 				Paths: []structs.ConsulExposePath{{
 					Path:          "/health",
@@ -248,9 +250,10 @@ func TestConnect_connectProxy(t *testing.T) {
 		}, 2000, testConnectNetwork)
 		require.NoError(t, err)
 		require.Equal(t, &api.AgentServiceConnectProxyConfig{
-			LocalServiceAddress: "0.0.0.0",
-			LocalServicePort:    2000,
-			Upstreams:           nil,
+			LocalServiceAddress:    "0.0.0.0",
+			LocalServicePort:       2000,
+			LocalServiceSocketPath: "dev/null",
+			Upstreams:              nil,
 			Expose: api.ExposeConfig{
 				Paths: []api.ExposePath{{
 					Path:          "/health",

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1661,11 +1661,12 @@ func apiConnectSidecarServiceProxyToStructs(in *api.ConsulProxy) *structs.Consul
 	}
 
 	return &structs.ConsulProxy{
-		LocalServiceAddress: in.LocalServiceAddress,
-		LocalServicePort:    in.LocalServicePort,
-		Upstreams:           apiUpstreamsToStructs(in.Upstreams),
-		Expose:              apiConsulExposeConfigToStructs(expose),
-		Config:              maps.Clone(in.Config),
+		LocalServiceAddress:    in.LocalServiceAddress,
+		LocalServicePort:       in.LocalServicePort,
+		LocalServiceSocketPath: in.LocalServiceSocketPath,
+		Upstreams:              apiUpstreamsToStructs(in.Upstreams),
+		Expose:                 apiConsulExposeConfigToStructs(expose),
+		Config:                 maps.Clone(in.Config),
 	}
 }
 

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -3739,9 +3739,10 @@ func TestConversion_apiConnectSidecarServiceProxyToStructs(t *testing.T) {
 	require.Nil(t, apiConnectSidecarServiceProxyToStructs(nil))
 	config := make(map[string]interface{})
 	require.Equal(t, &structs.ConsulProxy{
-		LocalServiceAddress: "192.168.30.1",
-		LocalServicePort:    9000,
-		Config:              map[string]any{},
+		LocalServiceAddress:    "192.168.30.1",
+		LocalServicePort:       9000,
+		LocalServiceSocketPath: "/run/test.sock",
+		Config:                 map[string]any{},
 		Upstreams: []structs.ConsulUpstream{{
 			DestinationName: "upstream",
 		}},
@@ -3749,9 +3750,10 @@ func TestConversion_apiConnectSidecarServiceProxyToStructs(t *testing.T) {
 			Paths: []structs.ConsulExposePath{{Path: "/health"}},
 		},
 	}, apiConnectSidecarServiceProxyToStructs(&api.ConsulProxy{
-		LocalServiceAddress: "192.168.30.1",
-		LocalServicePort:    9000,
-		Config:              config,
+		LocalServiceAddress:    "192.168.30.1",
+		LocalServicePort:       9000,
+		LocalServiceSocketPath: "/run/test.sock",
+		Config:                 config,
 		Upstreams: []*api.ConsulUpstream{{
 			DestinationName: "upstream",
 		}},
@@ -3770,7 +3772,8 @@ func TestConversion_apiConnectSidecarServiceToStructs(t *testing.T) {
 		Tags: []string{"foo"},
 		Port: "myPort",
 		Proxy: &structs.ConsulProxy{
-			LocalServiceAddress: "192.168.30.1",
+			LocalServiceAddress:    "192.168.30.1",
+			LocalServiceSocketPath: "/run/test.sock",
 		},
 		Meta: map[string]string{
 			"test-key": "test-value",
@@ -3779,7 +3782,8 @@ func TestConversion_apiConnectSidecarServiceToStructs(t *testing.T) {
 		Tags: []string{"foo"},
 		Port: "myPort",
 		Proxy: &api.ConsulProxy{
-			LocalServiceAddress: "192.168.30.1",
+			LocalServiceAddress:    "192.168.30.1",
+			LocalServiceSocketPath: "/run/test.sock",
 		},
 		Meta: map[string]string{
 			"test-key": "test-value",

--- a/jobspec/parse_service.go
+++ b/jobspec/parse_service.go
@@ -764,6 +764,7 @@ func parseProxy(o *ast.ObjectItem) (*api.ConsulProxy, error) {
 	valid := []string{
 		"local_service_address",
 		"local_service_port",
+		"local_service_socket_path",
 		"upstreams",
 		"expose",
 		"config",

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -1409,8 +1409,9 @@ func TestParse(t *testing.T) {
 							Native: false,
 							SidecarService: &api.ConsulSidecarService{
 								Proxy: &api.ConsulProxy{
-									LocalServiceAddress: "10.0.1.2",
-									LocalServicePort:    8080,
+									LocalServiceAddress:    "10.0.1.2",
+									LocalServicePort:       8080,
+									LocalServiceSocketPath: "/run/test.sock",
 									Expose: &api.ConsulExposeConfig{
 										Paths: []*api.ConsulExposePath{{
 											Path:          "/metrics",
@@ -1456,8 +1457,9 @@ func TestParse(t *testing.T) {
 							Native: false,
 							SidecarService: &api.ConsulSidecarService{
 								Proxy: &api.ConsulProxy{
-									LocalServiceAddress: "10.0.1.2",
-									LocalServicePort:    9876,
+									LocalServiceAddress:    "10.0.1.2",
+									LocalServicePort:       9876,
+									LocalServiceSocketPath: "/run/test.sock",
 								},
 							},
 						},

--- a/jobspec/test-fixtures/tg-service-connect-local-service.hcl
+++ b/jobspec/test-fixtures/tg-service-connect-local-service.hcl
@@ -8,8 +8,9 @@ job "connect-proxy-local-service" {
       connect {
         sidecar_service {
           proxy {
-            local_service_port    = 9876
-            local_service_address = "10.0.1.2"
+            local_service_port        = 9876
+            local_service_address     = "10.0.1.2"
+            local_service_socket_path = "/run/test.sock"
           }
         }
       }

--- a/jobspec/test-fixtures/tg-service-connect-proxy.hcl
+++ b/jobspec/test-fixtures/tg-service-connect-proxy.hcl
@@ -8,8 +8,9 @@ job "service-connect-proxy" {
       connect {
         sidecar_service {
           proxy {
-            local_service_port    = 8080
-            local_service_address = "10.0.1.2"
+            local_service_port        = 8080
+            local_service_address     = "10.0.1.2"
+            local_service_socket_path = "/run/test.sock"
 
             upstreams {
               destination_name = "upstream1"

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -2783,8 +2783,9 @@ func TestTaskGroupDiff(t *testing.T) {
 							SidecarService: &ConsulSidecarService{
 								Port: "http",
 								Proxy: &ConsulProxy{
-									LocalServiceAddress: "127.0.0.1",
-									LocalServicePort:    8080,
+									LocalServiceAddress:    "127.0.0.1",
+									LocalServicePort:       8080,
+									LocalServiceSocketPath: "/run/test.sock",
 									Upstreams: []ConsulUpstream{
 										{
 											DestinationName:      "foo",
@@ -3097,6 +3098,12 @@ func TestTaskGroupDiff(t *testing.T) {
 														Name: "LocalServicePort",
 														Old:  "",
 														New:  "8080",
+													},
+													{
+														Type: DiffTypeAdded,
+														Name: "LocalServiceSocketPath",
+														Old:  "",
+														New:  "/run/test.sock",
 													},
 												},
 												Objects: []*ObjectDiff{

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -850,6 +850,7 @@ func hashConnect(h hash.Hash, connect *ConsulConnect) {
 		if p := connect.SidecarService.Proxy; p != nil {
 			hashString(h, p.LocalServiceAddress)
 			hashString(h, strconv.Itoa(p.LocalServicePort))
+			hashString(h, p.LocalServiceSocketPath)
 			hashConfig(h, p.Config)
 			for _, upstream := range p.Upstreams {
 				hashString(h, upstream.DestinationName)
@@ -1361,6 +1362,8 @@ type ConsulProxy struct {
 	// in clusters with mixed Connect and non-Connect services
 	LocalServicePort int
 
+	LocalServiceSocketPath string
+
 	// Upstreams configures the upstream services this service intends to
 	// connect to.
 	Upstreams []ConsulUpstream
@@ -1381,11 +1384,12 @@ func (p *ConsulProxy) Copy() *ConsulProxy {
 	}
 
 	return &ConsulProxy{
-		LocalServiceAddress: p.LocalServiceAddress,
-		LocalServicePort:    p.LocalServicePort,
-		Expose:              p.Expose.Copy(),
-		Upstreams:           slices.Clone(p.Upstreams),
-		Config:              maps.Clone(p.Config),
+		LocalServiceAddress:    p.LocalServiceAddress,
+		LocalServicePort:       p.LocalServicePort,
+		LocalServiceSocketPath: p.LocalServiceSocketPath,
+		Expose:                 p.Expose.Copy(),
+		Upstreams:              slices.Clone(p.Upstreams),
+		Config:                 maps.Clone(p.Config),
 	}
 }
 
@@ -1400,6 +1404,10 @@ func (p *ConsulProxy) Equal(o *ConsulProxy) bool {
 	}
 
 	if p.LocalServicePort != o.LocalServicePort {
+		return false
+	}
+
+	if p.LocalServiceSocketPath != o.LocalServiceSocketPath {
 		return false
 	}
 

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -380,9 +380,10 @@ func TestService_Hash(t *testing.T) {
 				Tags: []string{"original", "sidecar", "tags"},
 				Port: "9000",
 				Proxy: &ConsulProxy{
-					LocalServiceAddress: "127.0.0.1",
-					LocalServicePort:    24000,
-					Config:              map[string]any{"foo": "bar"},
+					LocalServiceAddress:    "127.0.0.1",
+					LocalServicePort:       24000,
+					LocalServiceSocketPath: "/run/test.sock",
+					Config:                 map[string]any{"foo": "bar"},
 					Upstreams: []ConsulUpstream{{
 						DestinationName:      "upstream1",
 						DestinationNamespace: "ns2",
@@ -467,6 +468,10 @@ func TestService_Hash(t *testing.T) {
 		try(t, func(s *svc) { s.Connect.SidecarService.Proxy.LocalServicePort = 9999 })
 	})
 
+	t.Run("mod connect sidecar proxy local service socket path", func(t *testing.T) {
+		try(t, func(s *svc) { s.Connect.SidecarService.Proxy.LocalServiceSocketPath = "/run/newTest.sock" })
+	})
+
 	t.Run("mod connect sidecar proxy config", func(t *testing.T) {
 		try(t, func(s *svc) { s.Connect.SidecarService.Proxy.Config = map[string]interface{}{"foo": "baz"} })
 	})
@@ -515,8 +520,9 @@ func TestConsulConnect_CopyEqual(t *testing.T) {
 			Tags: []string{"tag1", "tag2"},
 			Port: "9001",
 			Proxy: &ConsulProxy{
-				LocalServiceAddress: "127.0.0.1",
-				LocalServicePort:    8080,
+				LocalServiceAddress:    "127.0.0.1",
+				LocalServicePort:       8080,
+				LocalServiceSocketPath: "/run/test.sock",
 				Upstreams: []ConsulUpstream{
 					{
 						DestinationName:      "up1",

--- a/website/content/docs/job-specification/proxy.mdx
+++ b/website/content/docs/job-specification/proxy.mdx
@@ -55,6 +55,8 @@ job "countdash" {
 - `local_service_port` `(int: <varies>)` - The port the local service binds to.
   Usually the same as the parent service's port, it is useful to customize in clusters with mixed
   Connect and non-Connect services.
+- `local_service_socket_path` `(string: nil)` - String value that specifies the path of a Unix domain
+  socket for connecting to the local application instance.
 - `upstreams` <code>([upstreams][]: nil)</code> - Used to configure details of each upstream service that
   this sidecar proxy communicates with.
 - `expose` <code>([expose]: nil)</code> - Used to configure expose path configuration for Envoy.


### PR DESCRIPTION
# Description

## Changes

- Added `LocalServiceSocketPath` field to `ConsulProxy` struct and updated its receiver functions.
- Updated `jobspec/parse_service.go`
- Updated `command/agent/job_endpoint.go`
- Update related tests
- Update Nomad Documentation for ConsulProxy struct.

## Testing Changes

To test these changes you need to build a Nomad binary and deploy a cluster with both Nomad and Consul agents and clients.  
When you have your cluster running you can run the following job-spec:

```terraform
job "example" {
  datacenters = ["dc1"]

  group "dashboard" {
     network {
       mode ="bridge"
       port "http" {
         static = 9002
         to     = 9002
       }
     }

     service {
       name = "count-dashboard"
       port = "9002"

       connect {
         sidecar_service {
           proxy {
             # New field
             local_service_socket_path = "/dev/null"
             upstreams {
               destination_name = "count-api"
               local_bind_port = 8080
             }
           }
         }
       }
     }

     task "dashboard" {
       driver = "docker"
       env {
         COUNTING_SERVICE_URL = "http://${NOMAD_UPSTREAM_ADDR_count_api}"
       }
       config {
         image = "hashicorpnomad/counter-dashboard:v1"
       }
     }
   }
}

```

Once the job is running and healthy, use Consul's API to get the terminating gateway's configuration:

```bash
curl --request GET http://127.0.0.1:8500/v1/catalog/service/count-dashboard-sidecar-proxy | json_pp
```

You will get the following JSON output:

```json
[
    {
        "ID": "8ab7d765-a8ad-ca56-4934-cc69b17cae0f",
        "Node": "ip-172-31-5-89",
        "Address": "172.31.5.89",
        "Datacenter": "dc1",
        "TaggedAddresses": {
            "lan": "172.31.5.89",
            "lan_ipv4": "172.31.5.89",
            "wan": "172.31.5.89",
            "wan_ipv4": "172.31.5.89"
        },
        "NodeMeta": {
            "consul-network-segment": ""
        },
        "ServiceKind": "connect-proxy",
        "ServiceID": "_nomad-task-013ebc58-a374-f428-a152-21363d72b904-group-dashboard-count-dashboard-9002-sidecar-proxy",
        "ServiceName": "count-dashboard-sidecar-proxy",
        "ServiceTags": [],
        "ServiceAddress": "172.31.5.89",
        "ServiceTaggedAddresses": {
            "consul-virtual": {
                "Address": "240.0.0.1",
                "Port": 29949
            },
            "lan_ipv4": {
                "Address": "172.31.5.89",
                "Port": 29949
            },
            "wan_ipv4": {
                "Address": "172.31.5.89",
                "Port": 29949
            }
        },
        "ServiceWeights": {
            "Passing": 1,
            "Warning": 1
        },
        "ServiceMeta": {
            "external-source": "nomad"
        },
        "ServicePort": 29949,
        "ServiceSocketPath": "",
        "ServiceEnableTagOverride": false,
        "ServiceProxy": {
            "DestinationServiceName": "count-dashboard",
            "DestinationServiceID": "_nomad-task-013ebc58-a374-f428-a152-21363d72b904-group-dashboard-count-dashboard-9002",
            "LocalServiceSocketPath": "/dev/null",
            "Mode": "",
            "Config": {
                "bind_address": "0.0.0.0",
                "bind_port": 29949,
                "envoy_stats_tags": [
                    "nomad.alloc_id=013ebc58-a374-f428-a152-21363d72b904",
                    "nomad.group=dashboard",
                    "nomad.job=expose-example",
                    "nomad.namespace=default"
                ]
            },
            "Upstreams": [
                {
                    "DestinationType": "service",
                    "DestinationName": "count-api",
                    "Datacenter": "",
                    "LocalBindPort": 8080,
                    "MeshGateway": {}
                }
            ],
            "MeshGateway": {},
            "Expose": {}
        },
        "ServiceConnect": {},
        "CreateIndex": 7375,
        "ModifyIndex": 7375
    }
]
```

## Demo Video

https://user-images.githubusercontent.com/74208929/226930551-13881823-8567-49a0-953b-85d86c171544.mp4

