### PR TITLE
Add Checks on ConsulExposeConfig

### DIFF
--- a/api/consul.go
+++ b/api/consul.go
@@ -240,8 +240,9 @@ func (cu *ConsulUpstream) Canonicalize() {
 }
 
 type ConsulExposeConfig struct {
-	Paths []*ConsulExposePath `mapstructure:"path" hcl:"path,block"`
-	Path  []*ConsulExposePath // Deprecated: only to maintain backwards compatibility. Use Paths instead.
+	Checks bool                `mapstructure:"checks" hcl:"checks,optional"`
+	Paths  []*ConsulExposePath `mapstructure:"path" hcl:"path,block"`
+	Path   []*ConsulExposePath // Deprecated: only to maintain backwards compatibility. Use Paths instead.
 }
 
 func (cec *ConsulExposeConfig) Canonicalize() {

--- a/command/agent/consul/connect.go
+++ b/command/agent/consul/connect.go
@@ -163,7 +163,7 @@ func connectProxyExpose(expose *structs.ConsulExposeConfig, networks structs.Net
 	}
 
 	return api.ExposeConfig{
-		Checks: false,
+		Checks: expose.Checks,
 		Paths:  paths,
 	}, nil
 }

--- a/command/agent/consul/connect_test.go
+++ b/command/agent/consul/connect_test.go
@@ -237,6 +237,7 @@ func TestConnect_connectProxy(t *testing.T) {
 			LocalServicePort:    2000,
 			Upstreams:           nil,
 			Expose: &structs.ConsulExposeConfig{
+				Checks: true,
 				Paths: []structs.ConsulExposePath{{
 					Path:          "/health",
 					Protocol:      "http",
@@ -252,6 +253,7 @@ func TestConnect_connectProxy(t *testing.T) {
 			LocalServicePort:    2000,
 			Upstreams:           nil,
 			Expose: api.ExposeConfig{
+				Checks: true,
 				Paths: []api.ExposePath{{
 					Path:          "/health",
 					Protocol:      "http",

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1708,7 +1708,8 @@ func apiConsulExposeConfigToStructs(in *api.ConsulExposeConfig) *structs.ConsulE
 	}
 
 	return &structs.ConsulExposeConfig{
-		Paths: apiConsulExposePathsToStructs(paths),
+		Checks: in.Checks,
+		Paths:  apiConsulExposePathsToStructs(paths),
 	}
 }
 

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -3700,9 +3700,11 @@ func TestConversion_apiConsulExposeConfigToStructs(t *testing.T) {
 	ci.Parallel(t)
 	require.Nil(t, apiConsulExposeConfigToStructs(nil))
 	require.Equal(t, &structs.ConsulExposeConfig{
-		Paths: []structs.ConsulExposePath{{Path: "/health"}},
+		Checks: true,
+		Paths:  []structs.ConsulExposePath{{Path: "/health"}},
 	}, apiConsulExposeConfigToStructs(&api.ConsulExposeConfig{
-		Paths: []*api.ConsulExposePath{{Path: "/health"}},
+		Checks: true,
+		Paths:  []*api.ConsulExposePath{{Path: "/health"}},
 	}))
 }
 
@@ -3746,7 +3748,8 @@ func TestConversion_apiConnectSidecarServiceProxyToStructs(t *testing.T) {
 			DestinationName: "upstream",
 		}},
 		Expose: &structs.ConsulExposeConfig{
-			Paths: []structs.ConsulExposePath{{Path: "/health"}},
+			Checks: true,
+			Paths:  []structs.ConsulExposePath{{Path: "/health"}},
 		},
 	}, apiConnectSidecarServiceProxyToStructs(&api.ConsulProxy{
 		LocalServiceAddress: "192.168.30.1",
@@ -3756,6 +3759,7 @@ func TestConversion_apiConnectSidecarServiceProxyToStructs(t *testing.T) {
 			DestinationName: "upstream",
 		}},
 		Expose: &api.ConsulExposeConfig{
+			Checks: true,
 			Paths: []*api.ConsulExposePath{{
 				Path: "/health",
 			}},

--- a/jobspec/parse_service.go
+++ b/jobspec/parse_service.go
@@ -851,6 +851,7 @@ func parseProxy(o *ast.ObjectItem) (*api.ConsulProxy, error) {
 
 func parseExpose(eo *ast.ObjectItem) (*api.ConsulExposeConfig, error) {
 	valid := []string{
+		"checks",
 		"path", // an array of path blocks
 	}
 

--- a/jobspec/parse_service.go
+++ b/jobspec/parse_service.go
@@ -860,6 +860,23 @@ func parseExpose(eo *ast.ObjectItem) (*api.ConsulExposeConfig, error) {
 	}
 
 	var expose api.ConsulExposeConfig
+	var m map[string]interface{}
+	if err := hcl.DecodeObject(&m, eo.Val); err != nil {
+		return nil, err
+	}
+
+	delete(m, "path")
+
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result: &expose,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := dec.Decode(m); err != nil {
+		return nil, err
+	}
 
 	var listVal *ast.ObjectList
 	if eoType, ok := eo.Val.(*ast.ObjectType); ok {

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -1283,6 +1283,7 @@ func TestParse(t *testing.T) {
 							SidecarService: &api.ConsulSidecarService{
 								Proxy: &api.ConsulProxy{
 									Expose: &api.ConsulExposeConfig{
+										Checks: true,
 										Paths: []*api.ConsulExposePath{{
 											Path:          "/health",
 											Protocol:      "http",
@@ -1412,6 +1413,7 @@ func TestParse(t *testing.T) {
 									LocalServiceAddress: "10.0.1.2",
 									LocalServicePort:    8080,
 									Expose: &api.ConsulExposeConfig{
+										Checks: true,
 										Paths: []*api.ConsulExposePath{{
 											Path:          "/metrics",
 											Protocol:      "http",

--- a/jobspec/test-fixtures/tg-service-connect-proxy.hcl
+++ b/jobspec/test-fixtures/tg-service-connect-proxy.hcl
@@ -22,6 +22,7 @@ job "service-connect-proxy" {
             }
 
             expose {
+              checks = true
               path {
                 path            = "/metrics"
                 protocol        = "http"

--- a/jobspec/test-fixtures/tg-service-proxy-expose.hcl
+++ b/jobspec/test-fixtures/tg-service-proxy-expose.hcl
@@ -7,6 +7,7 @@ job "group_service_proxy_expose" {
         sidecar_service {
           proxy {
             expose {
+              checks = true
               path {
                 path            = "/health"
                 protocol        = "http"

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -1527,7 +1527,14 @@ func upstreamsEquals(a, b []ConsulUpstream) bool {
 }
 
 // ConsulExposeConfig represents a Consul Connect expose jobspec block.
+// ExposeConfig describes HTTP paths to expose through Envoy outside of Connect.
+// Users can expose individual paths and/or all HTTP/GRPC paths for checks.
 type ConsulExposeConfig struct {
+	// Checks defines whether paths associated with Consul checks will be exposed.
+	// This flag triggers exposing all HTTP and GRPC check paths registered for the service.
+	Checks bool
+
+	// Paths is the list of paths exposed through the proxy.
 	Paths []ConsulExposePath
 }
 
@@ -1550,7 +1557,8 @@ func (e *ConsulExposeConfig) Copy() *ConsulExposeConfig {
 	paths := make([]ConsulExposePath, len(e.Paths))
 	copy(paths, e.Paths)
 	return &ConsulExposeConfig{
-		Paths: paths,
+		Checks: e.Checks,
+		Paths:  paths,
 	}
 }
 
@@ -1559,7 +1567,16 @@ func (e *ConsulExposeConfig) Equal(o *ConsulExposeConfig) bool {
 	if e == nil || o == nil {
 		return e == o
 	}
-	return exposePathsEqual(e.Paths, o.Paths)
+
+	if e.Checks != o.Checks {
+		return false
+	}
+
+	if !exposePathsEqual(e.Paths, o.Paths) {
+		return false
+	}
+
+	return true
 }
 
 // ConsulGateway is used to configure one of the Consul Connect Gateway types.

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -800,10 +800,12 @@ func TestConsulExposeConfig_Copy(t *testing.T) {
 
 	require.Nil(t, (*ConsulExposeConfig)(nil).Copy())
 	require.Equal(t, &ConsulExposeConfig{
+		Checks: true,
 		Paths: []ConsulExposePath{{
 			Path: "/health",
 		}},
 	}, (&ConsulExposeConfig{
+		Checks: true,
 		Paths: []ConsulExposePath{{
 			Path: "/health",
 		}},
@@ -815,10 +817,12 @@ func TestConsulExposeConfig_Equal(t *testing.T) {
 
 	require.True(t, (*ConsulExposeConfig)(nil).Equal(nil))
 	require.True(t, (&ConsulExposeConfig{
+		Checks: true,
 		Paths: []ConsulExposePath{{
 			Path: "/health",
 		}},
 	}).Equal(&ConsulExposeConfig{
+		Checks: true,
 		Paths: []ConsulExposePath{{
 			Path: "/health",
 		}},

--- a/website/content/docs/job-specification/expose.mdx
+++ b/website/content/docs/job-specification/expose.mdx
@@ -133,6 +133,13 @@ job "expose-example" {
 
 ## `expose` Parameters
 
+- `checks` `(bool: false)` - If enabled, all HTTP and gRPC checks registered with the agent are exposed through Envoy.
+  Envoy will expose listeners for these checks and will only accept connections originating from localhost
+  or Consul's [`advertise address`](/consul/docs/agent/config/config-files#advertise).
+  The port for these listeners are dynamically allocated from
+  [`expose_min_port`](/consul/docs/agent/config/config-files#expose_min_port)
+  to [`expose_max_port`](/consul/docs/agent/config/config-files#expose_max_port).
+
 - `path` <code>([Path]: nil)</code> - A list of [Envoy Expose Path Configurations][expose_path]
   to expose through Envoy.
 


### PR DESCRIPTION
# Description

## Changes

- Added the `Checks`  bool field to the ConsulExposeConfig struct in `nomad/structs/services.go` and `api/consul.go`.
- Updated parser in `jobspec/parse_service.go`.
- Updated `command/agent/job_endpoint.go`.
- Updated related tests.
- Update Nomad Documentation for ConsulExposeConfig struct.

## Testing Changes

To test these changes you need to build a Nomad binary and deploy a cluster with both Nomad and Consul agents and clients.  
When you have your cluster running you can run the following job-spec:  

```terraform
job "expose-example" {
  datacenters = ["dc1"]

  group "api" {
    network {
      mode = "bridge"

      port "api_expose_healthcheck" {
        to = -1
      }
    }

    service {
      name = "count-api"
      port = "9001"

      connect {
        sidecar_service {
          proxy {
            expose {
              # New field
              checks = true
              path {
                path            = "/health"
                protocol        = "http"
                local_path_port = 9001
                listener_port   = "api_expose_healthcheck"
              }
            }
          }
        }
      }

      check {
        name     = "api-health"
        type     = "http"
        path     = "/health"
        port     = "api_expose_healthcheck"
        interval = "10s"
        timeout  = "3s"
      }
    }

    task "web" {
      driver = "docker"

      config {
        image = "hashicorpdev/counter-api:v3"
      }     
    }
  }
}
```

Once the job is deployed, use Consul's API to get the sidecar proxy's configuration:

```bash
curl --request GET http://127.0.0.1:8500/v1/catalog/service/count-api-sidecar-proxy | json_pp
```

You will get the following JSON output:

```json
[
   {
      "ID" : "9cab1f92-ea84-fe9a-9fd4-699c5dcef3a9",
      "CreateIndex" : 7927,
      "ServiceTags" : [],
      "ServiceConnect" : {},
      "Node" : "ip-172-31-21-166",
      "NodeMeta" : {
         "consul-network-segment" : ""
      },
      "ServiceName" : "count-api-sidecar-proxy",
      "Address" : "172.31.21.166",
      "ServiceID" : "_nomad-task-9340260f-0a0a-d6e9-ccf5-d0bc491068f3-group-api-count-api-9001-sidecar-proxy",
      "ServiceMeta" : {
         "external-source" : "nomad"
      },
      "ServiceProxy" : {
         "Expose" : {
            "Paths" : [
               {
                  "Path" : "/health",
                  "Protocol" : "http",
                  "LocalPathPort" : 9001,
                  "ListenerPort" : 26767
               }
            ],
            "Checks" : true
         },
         "DestinationServiceID" : "_nomad-task-9340260f-0a0a-d6e9-ccf5-d0bc491068f3-group-api-count-api-9001",
         "LocalServicePort" : 9001,
         "LocalServiceAddress" : "127.0.0.1",
         "Mode" : "",
         "Config" : {
            "bind_address" : "0.0.0.0",
            "envoy_stats_tags" : [
               "nomad.alloc_id=9340260f-0a0a-d6e9-ccf5-d0bc491068f3",
               "nomad.group=api",
               "nomad.job=expose-example",
               "nomad.namespace=default"
            ],
            "bind_port" : 23167
         },
         "DestinationServiceName" : "count-api",
         "MeshGateway" : {}
      },
      "Datacenter" : "dc1",
      "TaggedAddresses" : {
         "lan_ipv4" : "172.31.21.166",
         "wan_ipv4" : "172.31.21.166",
         "lan" : "172.31.21.166",
         "wan" : "172.31.21.166"
      },
      "ServiceTaggedAddresses" : {
         "consul-virtual" : {
            "Port" : 23167,
            "Address" : "240.0.0.1"
         },
         "wan_ipv4" : {
            "Address" : "172.31.21.166",
            "Port" : 23167
         },
         "lan_ipv4" : {
            "Address" : "172.31.21.166",
            "Port" : 23167
         }
      },      
      "ServiceSocketPath" : "",
      "ServiceWeights" : {
         "Warning" : 1,
         "Passing" : 1
      },
      "ServiceEnableTagOverride" : false,
      "ServicePort" : 23167,
      "ModifyIndex" : 7927,
      "ServiceKind" : "connect-proxy",
      "ServiceAddress" : "172.31.21.166"
   }
]
```

## Demo Video

https://user-images.githubusercontent.com/74208929/226931441-d80c99e2-ff6d-4c8e-8639-852852a28c2e.mp4

