### PR TITLE
Add Meta on ConsulTerminatingConfigEntry 

### DIFF
--- a/.changelog/16749.txt
+++ b/.changelog/16749.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Added support for Meta field on Terminating block
+```

--- a/api/consul.go
+++ b/api/consul.go
@@ -570,12 +570,17 @@ type ConsulTerminatingConfigEntry struct {
 	// Namespace is not yet supported.
 	// Namespace string
 
+	Meta     map[string]string      `hcl:"meta,block"`
 	Services []*ConsulLinkedService `hcl:"service,block"`
 }
 
 func (e *ConsulTerminatingConfigEntry) Canonicalize() {
 	if e == nil {
 		return
+	}
+
+	if len(e.Meta) == 0 {
+		e.Meta = nil
 	}
 
 	if len(e.Services) == 0 {
@@ -601,6 +606,7 @@ func (e *ConsulTerminatingConfigEntry) Copy() *ConsulTerminatingConfigEntry {
 	}
 
 	return &ConsulTerminatingConfigEntry{
+		Meta:     maps.Clone(e.Meta),
 		Services: services,
 	}
 }

--- a/api/consul_test.go
+++ b/api/consul_test.go
@@ -429,6 +429,15 @@ func TestConsulTerminatingConfigEntry_Canonicalize(t *testing.T) {
 		c.Canonicalize()
 		must.Nil(t, c.Services)
 	})
+
+	t.Run("empty meta", func(t *testing.T) {
+		c := &ConsulTerminatingConfigEntry{
+			Meta:     make(map[string]string),
+			Services: []*ConsulLinkedService{},
+		}
+		c.Canonicalize()
+		must.Nil(t, c.Meta)
+	})
 }
 
 func TestConsulTerminatingConfigEntry_Copy(t *testing.T) {
@@ -440,6 +449,9 @@ func TestConsulTerminatingConfigEntry_Copy(t *testing.T) {
 	})
 
 	entry := &ConsulTerminatingConfigEntry{
+		Meta: map[string]string{
+			"test-key": "test-value",
+		},
 		Services: []*ConsulLinkedService{{
 			Name: "servic1",
 		}, {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1599,6 +1599,7 @@ func apiConnectTerminatingGatewayToStructs(in *api.ConsulTerminatingConfigEntry)
 	}
 
 	return &structs.ConsulTerminatingConfigEntry{
+		Meta:     in.Meta,
 		Services: apiConnectTerminatingServicesToStructs(in.Services),
 	}
 }

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -3893,6 +3893,9 @@ func TestConversion_ApiConsulConnectToStructs(t *testing.T) {
 		require.Equal(t, &structs.ConsulConnect{
 			Gateway: &structs.ConsulGateway{
 				Terminating: &structs.ConsulTerminatingConfigEntry{
+					Meta: map[string]string{
+						"test-key": "test-value",
+					},
 					Services: []*structs.ConsulLinkedService{{
 						Name:     "linked-service",
 						CAFile:   "ca.pem",
@@ -3905,6 +3908,9 @@ func TestConversion_ApiConsulConnectToStructs(t *testing.T) {
 		}, ApiConsulConnectToStructs(&api.ConsulConnect{
 			Gateway: &api.ConsulGateway{
 				Terminating: &api.ConsulTerminatingConfigEntry{
+					Meta: map[string]string{
+						"test-key": "test-value",
+					},
 					Services: []*api.ConsulLinkedService{{
 						Name:     "linked-service",
 						CAFile:   "ca.pem",

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -1679,6 +1679,11 @@ func TestParse(t *testing.T) {
 									Config:                    map[string]interface{}{"foo": "bar"},
 								},
 								Terminating: &api.ConsulTerminatingConfigEntry{
+									Meta: map[string]string{
+										"test-key":  "test-value",
+										"test-key1": "test-value1",
+										"test-key2": "test-value2",
+									},
 									Services: []*api.ConsulLinkedService{{
 										Name:     "service1",
 										CAFile:   "ca.pem",

--- a/jobspec/test-fixtures/tg-service-connect-gateway-terminating.hcl
+++ b/jobspec/test-fixtures/tg-service-connect-gateway-terminating.hcl
@@ -28,6 +28,12 @@ job "connect_gateway_terminating" {
           }
 
           terminating {
+            meta {
+              test-key  = "test-value"
+              test-key1 = "test-value1"
+              test-key2 = "test-value2"
+            }
+
             service {
               name      = "service1"
               ca_file   = "ca.pem"

--- a/nomad/consul.go
+++ b/nomad/consul.go
@@ -14,10 +14,10 @@ import (
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
-	"golang.org/x/exp/maps"
 )
 
 const (

--- a/nomad/consul.go
+++ b/nomad/consul.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
+	"golang.org/x/exp/maps"
 )
 
 const (
@@ -625,6 +626,7 @@ func convertTerminatingCE(namespace, service string, entry *structs.ConsulTermin
 		Namespace: namespace,
 		Kind:      api.TerminatingGateway,
 		Name:      service,
+		Meta:      maps.Clone(entry.Meta),
 		Services:  linked,
 	}
 }

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -2737,6 +2737,9 @@ func TestTaskGroupDiff(t *testing.T) {
 									}},
 								},
 								Terminating: &ConsulTerminatingConfigEntry{
+									Meta: map[string]string{
+										"foo": "qux",
+									},
 									Services: []*ConsulLinkedService{{
 										Name:     "linked1",
 										CAFile:   "ca1.pem",
@@ -2832,6 +2835,10 @@ func TestTaskGroupDiff(t *testing.T) {
 									}},
 								},
 								Terminating: &ConsulTerminatingConfigEntry{
+									Meta: map[string]string{
+										"foo":     "var",
+										"testKey": "testValue",
+									},
 									Services: []*ConsulLinkedService{{
 										Name:     "linked2",
 										CAFile:   "ca2.pem",
@@ -3454,6 +3461,22 @@ func TestTaskGroupDiff(t *testing.T) {
 																New:  "",
 															},
 														},
+													},
+												},
+												Fields: []*FieldDiff{
+													{
+														Type:        DiffTypeEdited,
+														Name:        "Meta[foo]",
+														Old:         "qux",
+														New:         "var",
+														Annotations: nil,
+													},
+													{
+														Type:        DiffTypeAdded,
+														Name:        "Meta[testKey]",
+														Old:         "",
+														New:         "testValue",
+														Annotations: nil,
 													},
 												},
 											},

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -2144,6 +2144,7 @@ func linkedServicesEqual(a, b []*ConsulLinkedService) bool {
 }
 
 type ConsulTerminatingConfigEntry struct {
+	Meta     map[string]string
 	Services []*ConsulLinkedService
 }
 
@@ -2161,6 +2162,7 @@ func (e *ConsulTerminatingConfigEntry) Copy() *ConsulTerminatingConfigEntry {
 	}
 
 	return &ConsulTerminatingConfigEntry{
+		Meta:     maps.Clone(e.Meta),
 		Services: services,
 	}
 }
@@ -2170,7 +2172,15 @@ func (e *ConsulTerminatingConfigEntry) Equal(o *ConsulTerminatingConfigEntry) bo
 		return e == o
 	}
 
-	return linkedServicesEqual(e.Services, o.Services)
+	if !linkedServicesEqual(e.Services, o.Services) {
+		return false
+	}
+
+	if !maps.Equal(e.Meta, o.Meta) {
+		return false
+	}
+
+	return true
 }
 
 func (e *ConsulTerminatingConfigEntry) Validate() error {

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -900,6 +900,9 @@ var (
 			EnvoyGatewayBindAddresses: nil,
 		},
 		Terminating: &ConsulTerminatingConfigEntry{
+			Meta: map[string]string{
+				"test-key": "test-value",
+			},
 			Services: []*ConsulLinkedService{{
 				Name:     "linked-service1",
 				CAFile:   "ca.pem",
@@ -1634,6 +1637,79 @@ func TestConsulLinkedService_linkedServicesEqual(t *testing.T) {
 	require.False(t, linkedServicesEqual(services, different))
 }
 
+func TestConsulTerminatingConfigEntry_Copy(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("nil", func(t *testing.T) {
+		new := (*ConsulTerminatingConfigEntry)(nil).Copy()
+		require.Nil(t, new)
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		original := &ConsulTerminatingConfigEntry{
+			Services: []*ConsulLinkedService{{
+				Name: "service1",
+			}},
+			Meta: map[string]string{
+				"test-key": "test-value",
+			},
+		}
+		new := original.Copy()
+		require.Equal(t, new, original)
+	})
+}
+
+func TestConsulTerminatingConfigEntry_Equal(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("nil", func(t *testing.T) {
+		res := (*ConsulTerminatingConfigEntry)(nil).Equal((*ConsulTerminatingConfigEntry)(nil))
+		require.True(t, res)
+	})
+
+	t.Run("not equal", func(t *testing.T) {
+		original := &ConsulTerminatingConfigEntry{
+			Services: []*ConsulLinkedService{{
+				Name: "service1",
+			}},
+			Meta: map[string]string{
+				"test-key": "test-value",
+			},
+		}
+		new := &ConsulTerminatingConfigEntry{
+			Services: []*ConsulLinkedService{{
+				Name: "service2",
+			}},
+			Meta: map[string]string{
+				"test-key": "test-value2",
+			},
+		}
+		res := original.Equal(new)
+		require.False(t, res)
+	})
+
+	t.Run("equal", func(t *testing.T) {
+		original := &ConsulTerminatingConfigEntry{
+			Services: []*ConsulLinkedService{{
+				Name: "service1",
+			}},
+			Meta: map[string]string{
+				"test-key": "test-value",
+			},
+		}
+		new := &ConsulTerminatingConfigEntry{
+			Services: []*ConsulLinkedService{{
+				Name: "service1",
+			}},
+			Meta: map[string]string{
+				"test-key": "test-value",
+			},
+		}
+		res := original.Equal(new)
+		require.True(t, res)
+	})
+}
+
 func TestConsulTerminatingConfigEntry_Validate(t *testing.T) {
 	ci.Parallel(t)
 
@@ -1660,6 +1736,9 @@ func TestConsulTerminatingConfigEntry_Validate(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		err := (&ConsulTerminatingConfigEntry{
+			Meta: map[string]string{
+				"test-key": "test-value",
+			},
 			Services: []*ConsulLinkedService{{
 				Name: "service1",
 			}},

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -150,6 +150,8 @@ envoy_gateway_bind_addresses "<service>" {
 
 ### `terminating` Parameters
 
+- `meta` <code>(map&lt;string|string&gt;: nil)</code> - Specifies arbitrary KV metadata pairs.
+
 - `service` <code>(array<[linked-service]>: required)</code> - One or more services to be
   linked with the gateway. The gateway will proxy traffic to these services. These
   linked services must be registered with Consul for the gateway to discover their


### PR DESCRIPTION
# Description

## Changes

- Added support for ConsulTerminatingConfigEntry meta configuration:
  - Added Meta field to ConsulTerminatingConfigEntry struct and updated its receiver functions.
- Updated jobspec/parse_service.go
- Update related tests
- Update Nomad Documentation for ConsulTerminatingConfigEntry struct.

## Testing Changes

To test these changes you need to build a Nomad binary and deploy a cluster with both Nomad and Consul agents and clients.  
When you have your cluster running you can run the following job-spec:

```terraform
job "countdash-terminating" {

  datacenters = ["dc1"]

  group "api" {
    network {
      mode = "host"
      port "port" {
        static = "9001"
      }
    }
    
    service {
      name = "count-api"
      port = "port"
    }

    task "api" {
      driver = "docker"

      config {
        image        = "hashicorpdev/counter-api:v3"
        network_mode = "host"
      }
    }
  }

  group "gateway" {
    network {
      mode = "bridge"
    }

    service {
      name = "api-gateway"

      connect {
        gateway {          
          proxy {}     
         
          terminating {          
            service {
              name = "count-api"
            }
            
            # New Fields:
            meta {
              test-key = "test-value"
              test-key1 = "test-value1"
              test-key2 = "test-value2"
            }
          }
        }
      }
    }
  }
  group "dashboard" {
    network {
      mode = "bridge"

      port "http" {
        static = 9002
        to     = 9002
      }
    }

    service {
      name = "count-dashboard"
      port = "9002"

      connect {
        sidecar_service {
          proxy {
            upstreams {              
              destination_name = "count-api"
              local_bind_port  = 8080
            }
          }
        }
      }
    }

    task "dashboard" {
      driver = "docker"

      env {
        COUNTING_SERVICE_URL = "http://${NOMAD_UPSTREAM_ADDR_count_api}"
      }

      config {
        image = "hashicorpdev/counter-dashboard:v3"
      }
    }
  }
}
```

Once the job is running and healthy, use Consul's API to get the terminating gateway's configuration:

```bash
curl --request GET http://127.0.0.1:8500/v1/config/terminating-gateway | json_pp
```

You will get the following JSON output:

```json
[
   {
      "Meta" : {
         "test-key" : "test-value",
         "test-key1" : "test-value1",
         "test-key2" : "test-value2"
      },
      "Name" : "api-gateway",
      "Services" : [
         {
            "Name" : "count-api"
         }
      ],
      "CreateIndex" : 155,
      "Kind" : "terminating-gateway",
      "ModifyIndex" : 155
   }
]
```

## Demo Video

https://user-images.githubusercontent.com/74208929/226930924-81d538e7-ca1c-4d4a-b874-83c33f008b3c.mp4

