### PR TITLE
Add meta and default on ConsulIngressConfigEntry

### DIFF
--- a/.changelog/16751.txt
+++ b/.changelog/16751.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Added support for meta and defaults on ingress block
+```

--- a/api/consul.go
+++ b/api/consul.go
@@ -376,12 +376,29 @@ func (p *ConsulGatewayProxy) Copy() *ConsulGatewayProxy {
 	}
 }
 
+type ConsulGatewayTLSSDSConfig struct {
+	ClusterName  string `hcl:"cluster_name,optional" mapstructure:"cluster_name"`
+	CertResource string `hcl:"cert_resource,optional" mapstructure:"cert_resource"`
+}
+
+func (c *ConsulGatewayTLSSDSConfig) Copy() *ConsulGatewayTLSSDSConfig {
+	if c == nil {
+		return nil
+	}
+
+	return &ConsulGatewayTLSSDSConfig{
+		ClusterName:  c.ClusterName,
+		CertResource: c.CertResource,
+	}
+}
+
 // ConsulGatewayTLSConfig is used to configure TLS for a gateway.
 type ConsulGatewayTLSConfig struct {
-	Enabled       bool     `hcl:"enabled,optional"`
-	TLSMinVersion string   `hcl:"tls_min_version,optional" mapstructure:"tls_min_version"`
-	TLSMaxVersion string   `hcl:"tls_max_version,optional" mapstructure:"tls_max_version"`
-	CipherSuites  []string `hcl:"cipher_suites,optional" mapstructure:"cipher_suites"`
+	Enabled       bool                       `hcl:"enabled,optional"`
+	TLSMinVersion string                     `hcl:"tls_min_version,optional" mapstructure:"tls_min_version"`
+	TLSMaxVersion string                     `hcl:"tls_max_version,optional" mapstructure:"tls_max_version"`
+	CipherSuites  []string                   `hcl:"cipher_suites,optional" mapstructure:"cipher_suites"`
+	SDS           *ConsulGatewayTLSSDSConfig `hcl:"sds_config,block" mapstructure:"sds_config"`
 }
 
 func (tc *ConsulGatewayTLSConfig) Canonicalize() {
@@ -396,6 +413,7 @@ func (tc *ConsulGatewayTLSConfig) Copy() *ConsulGatewayTLSConfig {
 		Enabled:       tc.Enabled,
 		TLSMinVersion: tc.TLSMinVersion,
 		TLSMaxVersion: tc.TLSMaxVersion,
+		SDS:           tc.SDS.Copy(),
 	}
 	if len(tc.CipherSuites) != 0 {
 		cipherSuites := make([]string, len(tc.CipherSuites))

--- a/api/consul_test.go
+++ b/api/consul_test.go
@@ -322,6 +322,12 @@ func TestConsulGateway_Copy(t *testing.T) {
 					}},
 				}},
 			},
+			Meta: map[string]string{
+				"testKey": "testValue",
+			},
+			Defaults: &ConsulIngressServiceConfig{
+				MaxConnections: pointerOf(uint32(5120)),
+			},
 		},
 		Terminating: &ConsulTerminatingConfigEntry{
 			Services: []*ConsulLinkedService{{
@@ -349,6 +355,8 @@ func TestConsulIngressConfigEntry_Canonicalize(t *testing.T) {
 		c := &ConsulIngressConfigEntry{
 			TLS:       nil,
 			Listeners: []*ConsulIngressListener{},
+			Meta:      map[string]string{},
+			Defaults:  nil,
 		}
 		c.Canonicalize()
 		must.Nil(t, c.TLS)
@@ -366,6 +374,12 @@ func TestConsulIngressConfigEntry_Canonicalize(t *testing.T) {
 					Hosts: []string{"1.1.1.1"},
 				}},
 			}},
+			Meta: map[string]string{
+				"testKey": "testValue",
+			},
+			Defaults: &ConsulIngressServiceConfig{
+				MaxConnections: pointerOf(uint32(5120)),
+			},
 		}
 		c.Canonicalize()
 		must.Eq(t, &ConsulIngressConfigEntry{
@@ -378,6 +392,12 @@ func TestConsulIngressConfigEntry_Canonicalize(t *testing.T) {
 					Hosts: []string{"1.1.1.1"},
 				}},
 			}},
+			Meta: map[string]string{
+				"testKey": "testValue",
+			},
+			Defaults: &ConsulIngressServiceConfig{
+				MaxConnections: pointerOf(uint32(5120)),
+			},
 		}, c)
 	})
 }

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1533,6 +1533,17 @@ func apiConnectIngressGatewayToStructs(in *api.ConsulIngressConfigEntry) *struct
 	}
 }
 
+func apiConnectGatewayTLSSDSConfig(in *api.ConsulGatewayTLSSDSConfig) *structs.ConsulGatewayTLSSDSConfig {
+	if in == nil {
+		return nil
+	}
+
+	return &structs.ConsulGatewayTLSSDSConfig{
+		ClusterName:  in.ClusterName,
+		CertResource: in.CertResource,
+	}
+}
+
 func apiConnectGatewayTLSConfig(in *api.ConsulGatewayTLSConfig) *structs.ConsulGatewayTLSConfig {
 	if in == nil {
 		return nil
@@ -1543,6 +1554,7 @@ func apiConnectGatewayTLSConfig(in *api.ConsulGatewayTLSConfig) *structs.ConsulG
 		TLSMinVersion: in.TLSMinVersion,
 		TLSMaxVersion: in.TLSMaxVersion,
 		CipherSuites:  slices.Clone(in.CipherSuites),
+		SDS:           apiConnectGatewayTLSSDSConfig(in.SDS),
 	}
 }
 

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1522,6 +1522,18 @@ func apiConnectGatewayProxyToStructs(in *api.ConsulGatewayProxy) *structs.Consul
 	}
 }
 
+func apiConsulIngressServiceConfigToStructs(in *api.ConsulIngressServiceConfig) *structs.ConsulIngressServiceConfig {
+	if in == nil {
+		return nil
+	}
+
+	return &structs.ConsulIngressServiceConfig{
+		MaxConnections:        in.MaxConnections,
+		MaxPendingRequests:    in.MaxPendingRequests,
+		MaxConcurrentRequests: in.MaxConcurrentRequests,
+	}
+}
+
 func apiConnectIngressGatewayToStructs(in *api.ConsulIngressConfigEntry) *structs.ConsulIngressConfigEntry {
 	if in == nil {
 		return nil
@@ -1530,6 +1542,8 @@ func apiConnectIngressGatewayToStructs(in *api.ConsulIngressConfigEntry) *struct
 	return &structs.ConsulIngressConfigEntry{
 		TLS:       apiConnectGatewayTLSConfig(in.TLS),
 		Listeners: apiConnectIngressListenersToStructs(in.Listeners),
+		Meta:      maps.Clone(in.Meta),
+		Defaults:  apiConsulIngressServiceConfigToStructs(in.Defaults),
 	}
 }
 

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -3863,6 +3863,12 @@ func TestConversion_ApiConsulConnectToStructs(t *testing.T) {
 							Hosts: []string{"host1"},
 						}},
 					}},
+					Meta: map[string]string{
+						"testKey": "testValue",
+					},
+					Defaults: &structs.ConsulIngressServiceConfig{
+						MaxConnections: pointer.Of(uint32(5120)),
+					},
 				},
 			},
 		}, ApiConsulConnectToStructs(
@@ -3883,6 +3889,12 @@ func TestConversion_ApiConsulConnectToStructs(t *testing.T) {
 								Hosts: []string{"host1"},
 							}},
 						}},
+						Meta: map[string]string{
+							"testKey": "testValue",
+						},
+						Defaults: &api.ConsulIngressServiceConfig{
+							MaxConnections: pointer.Of(uint32(5120)),
+						},
 					},
 				},
 			},

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -9,6 +9,7 @@ import (
 	capi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1647,6 +1648,12 @@ func TestParse(t *testing.T) {
 											},
 										}},
 									},
+									},
+									Meta: map[string]string{
+										"testKey": "testValue",
+									},
+									Defaults: &api.ConsulIngressServiceConfig{
+										MaxConnections: pointer.Of(uint32(5120)),
 									},
 								},
 							},

--- a/jobspec/test-fixtures/tg-service-connect-gateway-ingress.hcl
+++ b/jobspec/test-fixtures/tg-service-connect-gateway-ingress.hcl
@@ -28,6 +28,13 @@ job "connect_gateway_ingress" {
               cipher_suites   = ["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"]
             }
 
+            meta {
+              testKey = "testValue"
+            }
+            defaults {
+              max_connections = 5120
+            }
+
             listener {
               port     = 8001
               protocol = "tcp"

--- a/nomad/consul.go
+++ b/nomad/consul.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
@@ -607,6 +608,8 @@ func convertIngressCE(namespace, service string, entry *structs.ConsulIngressCon
 		Name:      service,
 		TLS:       *convertGatewayTLSConfig(entry.TLS),
 		Listeners: listeners,
+		Defaults:  convertIngressServiceConfig(entry.Defaults),
+		Meta:      maps.Clone(entry.Meta),
 	}
 }
 
@@ -632,6 +635,18 @@ func convertGatewayTLSSDSConfig(in *structs.ConsulGatewayTLSSDSConfig) *api.Gate
 		}
 	} else {
 		return &api.GatewayTLSSDSConfig{}
+	}
+}
+
+func convertIngressServiceConfig(in *structs.ConsulIngressServiceConfig) *api.IngressServiceConfig {
+	if in != nil {
+		return &api.IngressServiceConfig{
+			MaxConnections:        in.MaxConnections,
+			MaxPendingRequests:    in.MaxPendingRequests,
+			MaxConcurrentRequests: in.MaxConcurrentRequests,
+		}
+	} else {
+		return &api.IngressServiceConfig{}
 	}
 }
 

--- a/nomad/consul.go
+++ b/nomad/consul.go
@@ -605,8 +605,33 @@ func convertIngressCE(namespace, service string, entry *structs.ConsulIngressCon
 		Namespace: namespace,
 		Kind:      api.IngressGateway,
 		Name:      service,
-		TLS:       tls,
+		TLS:       *convertGatewayTLSConfig(entry.TLS),
 		Listeners: listeners,
+	}
+}
+
+func convertGatewayTLSConfig(in *structs.ConsulGatewayTLSConfig) *api.GatewayTLSConfig {
+	if in != nil {
+		return &api.GatewayTLSConfig{
+			Enabled:       in.Enabled,
+			TLSMinVersion: in.TLSMinVersion,
+			TLSMaxVersion: in.TLSMaxVersion,
+			CipherSuites:  slices.Clone(in.CipherSuites),
+			SDS:           convertGatewayTLSSDSConfig(in.SDS),
+		}
+	} else {
+		return &api.GatewayTLSConfig{}
+	}
+}
+
+func convertGatewayTLSSDSConfig(in *structs.ConsulGatewayTLSSDSConfig) *api.GatewayTLSSDSConfig {
+	if in != nil {
+		return &api.GatewayTLSSDSConfig{
+			ClusterName:  in.ClusterName,
+			CertResource: in.CertResource,
+		}
+	} else {
+		return &api.GatewayTLSSDSConfig{}
 	}
 }
 

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -1156,6 +1156,11 @@ func connectGatewayTLSConfigDiff(prev, next *ConsulGatewayTLSConfig, contextual 
 	// Diff the primitive field.
 	diff.Fields = fieldDiffs(oldPrimitiveFlat, newPrimitiveFlat, contextual)
 
+	// Diff SDS object
+	if sdsDiff := primitiveObjectDiff(prev.SDS, next.SDS, nil, "SDS", contextual); sdsDiff != nil {
+		diff.Objects = append(diff.Objects, sdsDiff)
+	}
+
 	return diff
 }
 

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -1032,6 +1032,70 @@ func connectGatewayIngressDiff(prev, next *ConsulIngressConfigEntry, contextual 
 		diff.Objects = append(diff.Objects, gatewayIngressListenersDiff...)
 	}
 
+	// Diff the ConsulIngressServiceConfig objects.
+	infressServiceConfigDiff := connectGatewayIngressServiceConfigDiff(prev.Defaults, next.Defaults, contextual)
+	if infressServiceConfigDiff != nil {
+		diff.Objects = append(diff.Objects, infressServiceConfigDiff)
+	}
+
+	return diff
+}
+
+func connectGatewayIngressServiceConfigDiff(prev, next *ConsulIngressServiceConfig, contextual bool) *ObjectDiff {
+	diff := &ObjectDiff{Type: DiffTypeNone, Name: "IngressServiceConfig"}
+	var oldPrimitiveFlat, newPrimitiveFlat map[string]string
+
+	if reflect.DeepEqual(prev, next) {
+		return nil
+	} else if prev == nil {
+		prev = new(ConsulIngressServiceConfig)
+		diff.Type = DiffTypeAdded
+		newPrimitiveFlat = flatmap.Flatten(next, nil, true)
+	} else if next == nil {
+		next = new(ConsulIngressServiceConfig)
+		diff.Type = DiffTypeDeleted
+		oldPrimitiveFlat = flatmap.Flatten(prev, nil, true)
+	} else {
+		diff.Type = DiffTypeEdited
+		oldPrimitiveFlat = flatmap.Flatten(prev, nil, true)
+		newPrimitiveFlat = flatmap.Flatten(next, nil, true)
+	}
+
+	// Diff pointer types.
+	if prev != nil {
+		if prev.MaxConnections != nil {
+			oldPrimitiveFlat["MaxConnections"] = fmt.Sprintf("%v", *prev.MaxConnections)
+		}
+	}
+	if next != nil {
+		if next.MaxConnections != nil {
+			newPrimitiveFlat["MaxConnections"] = fmt.Sprintf("%v", *next.MaxConnections)
+		}
+	}
+	if prev != nil {
+		if prev.MaxPendingRequests != nil {
+			oldPrimitiveFlat["MaxPendingRequests"] = fmt.Sprintf("%v", *prev.MaxPendingRequests)
+		}
+	}
+	if next != nil {
+		if next.MaxPendingRequests != nil {
+			newPrimitiveFlat["MaxPendingRequests"] = fmt.Sprintf("%v", *next.MaxPendingRequests)
+		}
+	}
+	if prev != nil {
+		if prev.MaxConcurrentRequests != nil {
+			oldPrimitiveFlat["MaxConcurrentRequests"] = fmt.Sprintf("%v", *prev.MaxConcurrentRequests)
+		}
+	}
+	if next != nil {
+		if next.MaxConcurrentRequests != nil {
+			newPrimitiveFlat["MaxConcurrentRequests"] = fmt.Sprintf("%v", *next.MaxConcurrentRequests)
+		}
+	}
+
+	// Diff the primitive fields.
+	diff.Fields = fieldDiffs(oldPrimitiveFlat, newPrimitiveFlat, contextual)
+
 	return diff
 }
 

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -2034,6 +2034,54 @@ func ingressServicesEqual(a, b []*ConsulIngressService) bool {
 	return helper.ElementsEqual(a, b)
 }
 
+type ConsulIngressServiceConfig struct {
+	MaxConnections        *uint32
+	MaxPendingRequests    *uint32
+	MaxConcurrentRequests *uint32
+}
+
+func (c *ConsulIngressServiceConfig) Copy() *ConsulIngressServiceConfig {
+	if c == nil {
+		return nil
+	}
+	nc := new(ConsulIngressServiceConfig)
+	*nc = *c
+
+	if c.MaxConnections != nil {
+		nc.MaxConnections = pointer.Of(*c.MaxConnections)
+	}
+
+	if c.MaxPendingRequests != nil {
+		nc.MaxPendingRequests = pointer.Of(*c.MaxPendingRequests)
+	}
+
+	if c.MaxConcurrentRequests != nil {
+		nc.MaxConcurrentRequests = pointer.Of(*c.MaxConcurrentRequests)
+	}
+
+	return nc
+}
+
+func (c *ConsulIngressServiceConfig) Equal(o *ConsulIngressServiceConfig) bool {
+	if c == nil || o == nil {
+		return c == o
+	}
+
+	if !pointer.Eq(c.MaxConnections, o.MaxConnections) {
+		return false
+	}
+
+	if !pointer.Eq(c.MaxPendingRequests, o.MaxPendingRequests) {
+		return false
+	}
+
+	if !pointer.Eq(c.MaxConcurrentRequests, o.MaxConcurrentRequests) {
+		return false
+	}
+
+	return true
+}
+
 // ConsulIngressConfigEntry represents the Consul Configuration Entry type for
 // an Ingress Gateway.
 //
@@ -2041,6 +2089,8 @@ func ingressServicesEqual(a, b []*ConsulIngressService) bool {
 type ConsulIngressConfigEntry struct {
 	TLS       *ConsulGatewayTLSConfig
 	Listeners []*ConsulIngressListener
+	Meta      map[string]string
+	Defaults  *ConsulIngressServiceConfig
 }
 
 func (e *ConsulIngressConfigEntry) Copy() *ConsulIngressConfigEntry {
@@ -2059,6 +2109,8 @@ func (e *ConsulIngressConfigEntry) Copy() *ConsulIngressConfigEntry {
 	return &ConsulIngressConfigEntry{
 		TLS:       e.TLS.Copy(),
 		Listeners: listeners,
+		Meta:      maps.Clone(e.Meta),
+		Defaults:  e.Defaults.Copy(),
 	}
 }
 
@@ -2068,6 +2120,14 @@ func (e *ConsulIngressConfigEntry) Equal(o *ConsulIngressConfigEntry) bool {
 	}
 
 	if !e.TLS.Equal(o.TLS) {
+		return false
+	}
+
+	if !maps.Equal(e.Meta, o.Meta) {
+		return false
+	}
+
+	if !e.Defaults.Equal(o.Defaults) {
 		return false
 	}
 

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -1833,12 +1833,39 @@ func (p *ConsulGatewayProxy) Validate() error {
 	return nil
 }
 
+type ConsulGatewayTLSSDSConfig struct {
+	ClusterName  string
+	CertResource string
+}
+
+func (c *ConsulGatewayTLSSDSConfig) Copy() *ConsulGatewayTLSSDSConfig {
+	if c == nil {
+		return nil
+	}
+
+	return &ConsulGatewayTLSSDSConfig{
+		ClusterName:  c.ClusterName,
+		CertResource: c.CertResource,
+	}
+}
+
+func (c *ConsulGatewayTLSSDSConfig) Equal(o *ConsulGatewayTLSSDSConfig) bool {
+	if c == nil || o == nil {
+		return c == o
+	}
+
+	return c.ClusterName == o.ClusterName &&
+		c.CertResource == o.CertResource
+}
+
 // ConsulGatewayTLSConfig is used to configure TLS for a gateway.
 type ConsulGatewayTLSConfig struct {
 	Enabled       bool
 	TLSMinVersion string
 	TLSMaxVersion string
 	CipherSuites  []string
+	// SDS allows configuring TLS certificate from an SDS service.
+	SDS *ConsulGatewayTLSSDSConfig
 }
 
 func (c *ConsulGatewayTLSConfig) Copy() *ConsulGatewayTLSConfig {
@@ -1851,6 +1878,7 @@ func (c *ConsulGatewayTLSConfig) Copy() *ConsulGatewayTLSConfig {
 		TLSMinVersion: c.TLSMinVersion,
 		TLSMaxVersion: c.TLSMaxVersion,
 		CipherSuites:  slices.Clone(c.CipherSuites),
+		SDS:           c.SDS.Copy(),
 	}
 }
 
@@ -1862,7 +1890,8 @@ func (c *ConsulGatewayTLSConfig) Equal(o *ConsulGatewayTLSConfig) bool {
 	return c.Enabled == o.Enabled &&
 		c.TLSMinVersion == o.TLSMinVersion &&
 		c.TLSMaxVersion == o.TLSMaxVersion &&
-		helper.SliceSetEq(c.CipherSuites, o.CipherSuites)
+		helper.SliceSetEq(c.CipherSuites, o.CipherSuites) &&
+		c.SDS.Equal(o.SDS)
 }
 
 // ConsulIngressService is used to configure a service fronted by the ingress gateway.

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -890,6 +890,12 @@ var (
 					Name: "service3",
 				}},
 			}},
+			Meta: map[string]string{
+				"testKey": "testValue",
+			},
+			Defaults: &ConsulIngressServiceConfig{
+				MaxConnections: pointer.Of(uint32(5120)),
+			},
 		},
 	}
 
@@ -1051,6 +1057,14 @@ func TestConsulGateway_Equal_ingress(t *testing.T) {
 	t.Run("mod ingress tls", func(t *testing.T) {
 		try(t, func(g *cg) { g.Ingress.TLS = nil })
 		try(t, func(g *cg) { g.Ingress.TLS.Enabled = false })
+	})
+
+	t.Run("mod ingress meta", func(t *testing.T) {
+		try(t, func(g *cg) { g.Ingress.Meta = map[string]string{"newTestKey": "newTestValue"} })
+	})
+
+	t.Run("mod ingress defaults", func(t *testing.T) {
+		try(t, func(g *cg) { g.Ingress.Defaults.MaxConnections = pointer.Of(uint32(6040)) })
 	})
 
 	t.Run("mod ingress listeners count", func(t *testing.T) {

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -89,9 +89,26 @@ envoy_gateway_bind_addresses "<service>" {
 
 ### `ingress` Parameters
 
-- `tls` <code>([tls]: nil)</code> - TLS configuration for this gateway.
-- `listener` <code>(array<[listener]> : required)</code> - One or more listeners that the
+- `defaults` `(IngressServiceConfig: <optional>)` - Default configuration that applies to all upstreams.
+
+    - `max_connections` `(int: 0)` - The maximum number of connections a service instance will be allowed
+    to establish against the given upstream.
+    - `max_pending_requests` `(int: 0)` - The maximum number of requests that will be queued while waiting
+    for a connection to be established.
+    - `max_concurrent_requests` `(int: 0)` - The maximum number of concurrent requests that will be allowed
+    at a single point in time.
+    - `passive_health_check` `(PassiveHealthCheck: <optional>)` - Passive health checks remove hosts from
+    the upstream cluster that are unreachable or that return errors.
+
+      - `internal` `(int: <optional>)` - The time in nanosecond between checks.
+      - `max_failures` `(int: <optional>)` - The number of consecutive failures that cause a host to be
+      removed from the upstream cluster.
+      - `enforcing_consecutive_5xx` `(int: <optional>)` - A percentage representing the chance that a host
+      will be actually ejected when the proxy detects an outlier status through consecutive errors in the 500 code range.
+- `listener` <code>(array&lt;[listener]&gt; : required)</code> - One or more listeners that the
   ingress gateway should setup, uniquely identified by their port number.
+- `meta` `(map<string|string>: nil)` - Specifies arbitrary KV metadata pairs.
+- `tls` <code>([tls]: nil)</code> - TLS configuration for this gateway.
 
 #### `tls` Parameters
 

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -114,6 +114,12 @@ envoy_gateway_bind_addresses "<service>" {
   [`CipherSuites`](/consul/docs/connect/config-entries/ingress-gateway#ciphersuites)
   in the Consul documentation for the supported cipher suites.
 
+- `sds` `(SDSConfig: <optional>)` - Defines a set of parameters that configures the listener to load TLS certificates from an external SDS service.
+
+  - `cluster_name` `(string)` - The SDS cluster name to connect to to retrieve certificates.
+
+  - `cert_resource` `(string)` - The SDS resource name to request when fetching the certificate from the SDS service.
+
 #### `listener` Parameters
 
 - `port` `(int: required)` - The port that the listener should receive traffic on.


### PR DESCRIPTION
# Description

## Changes

- Added support for ConsulIngressConfigEntry configuration in `nomad/structs/services.go` and `api/consul.go`.
  - Added new fields to `ConsulIngressConfigEntry` structs and updated their receiver functions.
    - `Meta`
    - `Defaults`
- Updated `jobspec/parse_service.go`
- Updated `command/agent/job_endpoint.go`
- Update related tests
- Update Nomad Documentation for ConsulIngressConfigEntry struct.

## Testing Changes

To test these changes you need to build a Nomad binary and deploy a cluster with both Nomad and Consul agents and clients.  
When you have your cluster running you can run the following job-spec:

```terraform
job "ingress-demo" {

  datacenters = ["dc1"]

  # This group will have a task providing the ingress gateway automatically
  # created by Nomad. The ingress gateway is based on the Envoy proxy being
  # managed by the docker driver.
  group "ingress-group" {

    network {
      mode = "bridge"

      # This example will enable plain HTTP traffic to access the uuid-api connect
      # native example service on port 8080.
      port "inbound" {
        static = 8080
        to     = 8080
      }
    }

    service {
      name = "my-ingress-service"
      port = "8080"

      connect {
        gateway {

          # Consul gateway [envoy] proxy options.
          proxy {
            # The following options are automatically set by Nomad if not
            # explicitly configured when using bridge networking.
            #
            # envoy_gateway_no_default_bind = true
            # envoy_gateway_bind_addresses "uuid-api" {
            #   address = "0.0.0.0"
            #   port    = <associated listener.port>
            # }
            #
            # Additional options are documented at
            # https://www.nomadproject.io/docs/job-specification/gateway#proxy-parameters
          }

          # Consul Ingress Gateway Configuration Entry.
          ingress {
            # Nomad will automatically manage the Configuration Entry in Consul
            # given the parameters in the ingress block.
            #
            # Additional options are documented at
            # https://www.nomadproject.io/docs/job-specification/gateway#ingress-parameters
            tls {
              sds_config {
                  cluster_name = "foo"
                  cert_resource = "example.com-public-cert"
              }
            }  
            listener {
              port     = 8080
              protocol = "tcp"
              service {
                name = "uuid-api"
              }
            }
            # New fields:
            meta {
                testKey = "testValue"
            }
            defaults {
                max_connections = 100
                max_pending_requests = 100
            }
          }
        }
      }
    }
  }

  # The UUID generator from the connect-native demo is used as an example service.
  # The ingress gateway above makes access to the service possible over normal HTTP.
  # For example,
  #
  # $ curl $(dig +short @127.0.0.1 -p 8600 uuid-api.ingress.dc1.consul. ANY):8080
  group "generator" {
    network {
      mode = "host"
      port "api" {}
    }

    service {
      name = "uuid-api"
      port = "api"

      connect {
        native = true
      }
    }

    task "generate" {
      driver = "docker"

      config {
        image        = "hashicorpdev/uuid-api:v5"
        network_mode = "host"
      }

      env {
        BIND = "0.0.0.0"
        PORT = "${NOMAD_PORT_api}"
      }
    }
  }
}

```

Once the job is running and healthy, use Consul's API to get the terminating gateway's configuration:

```bash
curl --request GET http://127.0.0.1:8500/v1/config/ingress-gateway | json_pp
```

You will get the following JSON output:

```json
[
    {
          "Kind": "ingress-gateway",
          "Name": "my-ingress-service",
          "TLS": {
              "Enabled": false,
              "SDS": {
                  "ClusterName": "foo",
                  "CertResource": "example.com-pulic-cert"
              }
          },
          "Listeners": [
              {
                  "Port": 8080,
                  "Protocol": "tcp",
                  "TLS": {
                      "Enabled": false
                  },
                  "Services": [
                      {
                          "Name": "uuid-api",
                          "Hosts": null,
                          "TLS": {},
                          "RequestHeaders": {},
                          "ResponseHeaders": {}
                      }
                  ]
              }
          ],
          "Defaults": {
              "MaxConnections": 100,
              "MaxPendingRequests": 100,
              "MaxConcurrentRequests": 0
          },
          "Meta": {
              "testKey": "testValue"
          },
          "CreateIndex": 51,
          "ModifyIndex": 233
    }
]

```

## Demo Video


https://user-images.githubusercontent.com/113113630/228616336-30ff9da9-e9cb-4dba-91f6-b67565529375.mp4




