### PR TITLE
Add new Consul fields on ConsulIngressService

### DIFF
--- a/.changelog/16753.txt
+++ b/.changelog/16753.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Added support for TLS RequestHeaders ResponeHeaders Config on ingress service block
+```

--- a/api/consul.go
+++ b/api/consul.go
@@ -376,12 +376,29 @@ func (p *ConsulGatewayProxy) Copy() *ConsulGatewayProxy {
 	}
 }
 
+type ConsulGatewayTLSSDSConfig struct {
+	ClusterName  string `hcl:"cluster_name,optional" mapstructure:"cluster_name"`
+	CertResource string `hcl:"cert_resource,optional" mapstructure:"cert_resource"`
+}
+
+func (c *ConsulGatewayTLSSDSConfig) Copy() *ConsulGatewayTLSSDSConfig {
+	if c == nil {
+		return nil
+	}
+
+	return &ConsulGatewayTLSSDSConfig{
+		ClusterName:  c.ClusterName,
+		CertResource: c.CertResource,
+	}
+}
+
 // ConsulGatewayTLSConfig is used to configure TLS for a gateway.
 type ConsulGatewayTLSConfig struct {
-	Enabled       bool     `hcl:"enabled,optional"`
-	TLSMinVersion string   `hcl:"tls_min_version,optional" mapstructure:"tls_min_version"`
-	TLSMaxVersion string   `hcl:"tls_max_version,optional" mapstructure:"tls_max_version"`
-	CipherSuites  []string `hcl:"cipher_suites,optional" mapstructure:"cipher_suites"`
+	Enabled       bool                       `hcl:"enabled,optional"`
+	TLSMinVersion string                     `hcl:"tls_min_version,optional" mapstructure:"tls_min_version"`
+	TLSMaxVersion string                     `hcl:"tls_max_version,optional" mapstructure:"tls_max_version"`
+	CipherSuites  []string                   `hcl:"cipher_suites,optional" mapstructure:"cipher_suites"`
+	SDS           *ConsulGatewayTLSSDSConfig `hcl:"sds_config,block" mapstructure:"sds_config"`
 }
 
 func (tc *ConsulGatewayTLSConfig) Canonicalize() {
@@ -396,6 +413,7 @@ func (tc *ConsulGatewayTLSConfig) Copy() *ConsulGatewayTLSConfig {
 		Enabled:       tc.Enabled,
 		TLSMinVersion: tc.TLSMinVersion,
 		TLSMaxVersion: tc.TLSMaxVersion,
+		SDS:           tc.SDS.Copy(),
 	}
 	if len(tc.CipherSuites) != 0 {
 		cipherSuites := make([]string, len(tc.CipherSuites))

--- a/api/consul.go
+++ b/api/consul.go
@@ -424,13 +424,54 @@ func (tc *ConsulGatewayTLSConfig) Copy() *ConsulGatewayTLSConfig {
 	return result
 }
 
+// ConsulHTTPHeaderModifiers is a set of rules for HTTP header modification that
+// should be performed by proxies as the request passes through them. It can
+// operate on either request or response headers depending on the context in
+// which it is used.
+type ConsulHTTPHeaderModifiers struct {
+	// Add is a set of name -> value pairs that should be appended to the request
+	// or response (i.e. allowing duplicates if the same header already exists).
+	Add map[string]string `hcl:"add,block" mapstructure:"add"`
+
+	// Set is a set of name -> value pairs that should be added to the request or
+	// response, overwriting any existing header values of the same name.
+	Set map[string]string `hcl:"set,block" mapstructure:"set"`
+
+	// Remove is the set of header names that should be stripped from the request
+	// or response.
+	Remove []string `hcl:"remove,optional" mapstructure:"remove"`
+}
+
+func (h *ConsulHTTPHeaderModifiers) Copy() *ConsulHTTPHeaderModifiers {
+	if h == nil {
+		return nil
+	}
+
+	var remove []string
+	if n := len(h.Remove); n > 0 {
+		remove = make([]string, n)
+		copy(remove, h.Remove)
+	}
+
+	return &ConsulHTTPHeaderModifiers{
+		Add:    maps.Clone(h.Add),
+		Set:    maps.Clone(h.Set),
+		Remove: remove,
+	}
+}
+
 // ConsulIngressService is used to configure a service fronted by the ingress gateway.
 type ConsulIngressService struct {
 	// Namespace is not yet supported.
 	// Namespace string
-	Name string `hcl:"name,optional"`
-
-	Hosts []string `hcl:"hosts,optional"`
+	Name                  string                     `hcl:"name,optional"`
+	Hosts                 []string                   `hcl:"hosts,optional"`
+	TLS                   *ConsulGatewayTLSConfig    `hcl:"tls,block" mapstructure:"tls"`
+	RequestHeaders        *ConsulHTTPHeaderModifiers `hcl:"request_headers,block" mapstructure:"request_headers"`
+	ResponseHeaders       *ConsulHTTPHeaderModifiers `hcl:"response_headers,block" mapstructure:"response_headers"`
+	MaxConnections        *uint32                    `hcl:"max_connections,optional" mapstructure:"max_connections"`
+	MaxPendingRequests    *uint32                    `hcl:"max_pending_requests,optional" mapstructure:"max_pending_requests"`
+	MaxConcurrentRequests *uint32                    `hcl:"max_concurrent_requests,optional" mapstructure:"max_concurrent_requests"`
 }
 
 func (s *ConsulIngressService) Canonicalize() {
@@ -448,16 +489,34 @@ func (s *ConsulIngressService) Copy() *ConsulIngressService {
 		return nil
 	}
 
+	ns := new(ConsulIngressService)
+	*ns = *s
+
 	var hosts []string = nil
 	if n := len(s.Hosts); n > 0 {
 		hosts = make([]string, n)
 		copy(hosts, s.Hosts)
 	}
 
-	return &ConsulIngressService{
-		Name:  s.Name,
-		Hosts: hosts,
+	ns.Name = s.Name
+	ns.Hosts = hosts
+	ns.RequestHeaders = s.RequestHeaders.Copy()
+	ns.ResponseHeaders = s.ResponseHeaders.Copy()
+	ns.TLS = s.TLS.Copy()
+
+	if s.MaxConnections != nil {
+		ns.MaxConnections = pointerOf(*s.MaxConnections)
 	}
+
+	if s.MaxPendingRequests != nil {
+		ns.MaxPendingRequests = pointerOf(*s.MaxPendingRequests)
+	}
+
+	if s.MaxConcurrentRequests != nil {
+		ns.MaxConcurrentRequests = pointerOf(*s.MaxConcurrentRequests)
+	}
+
+	return ns
 }
 
 const (

--- a/api/consul_test.go
+++ b/api/consul_test.go
@@ -400,6 +400,33 @@ func TestConsulIngressConfigEntry_Copy(t *testing.T) {
 			Services: []*ConsulIngressService{{
 				Name:  "service1",
 				Hosts: []string{"1.1.1.1", "1.1.1.1:9000"},
+				TLS: &ConsulGatewayTLSConfig{
+					SDS: &ConsulGatewayTLSSDSConfig{
+						ClusterName:  "foo",
+						CertResource: "bar",
+					},
+				},
+				RequestHeaders: &ConsulHTTPHeaderModifiers{
+					Add: map[string]string{
+						"test": "testvalue",
+					},
+					Set: map[string]string{
+						"test1": "testvalue1",
+					},
+					Remove: []string{"test2"},
+				},
+				ResponseHeaders: &ConsulHTTPHeaderModifiers{
+					Add: map[string]string{
+						"test": "testvalue",
+					},
+					Set: map[string]string{
+						"test1": "testvalue1",
+					},
+					Remove: []string{"test2"},
+				},
+				MaxConnections:        pointerOf(uint32(5120)),
+				MaxPendingRequests:    pointerOf(uint32(512)),
+				MaxConcurrentRequests: pointerOf(uint32(2048)),
 			}, {
 				Name:  "service2",
 				Hosts: []string{"2.2.2.2"},

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1594,14 +1594,32 @@ func apiConnectIngressServicesToStructs(in []*api.ConsulIngressService) []*struc
 	return services
 }
 
+func apiConsulHTTPHeaderModifiersToStructs(in *api.ConsulHTTPHeaderModifiers) *structs.ConsulHTTPHeaderModifiers {
+	if in == nil {
+		return nil
+	}
+
+	return &structs.ConsulHTTPHeaderModifiers{
+		Add:    maps.Clone(in.Add),
+		Set:    maps.Clone(in.Set),
+		Remove: slices.Clone(in.Remove),
+	}
+}
+
 func apiConnectIngressServiceToStructs(in *api.ConsulIngressService) *structs.ConsulIngressService {
 	if in == nil {
 		return nil
 	}
 
 	return &structs.ConsulIngressService{
-		Name:  in.Name,
-		Hosts: slices.Clone(in.Hosts),
+		Name:                  in.Name,
+		Hosts:                 slices.Clone(in.Hosts),
+		TLS:                   apiConnectGatewayTLSConfig(in.TLS),
+		RequestHeaders:        apiConsulHTTPHeaderModifiersToStructs(in.RequestHeaders),
+		ResponseHeaders:       apiConsulHTTPHeaderModifiersToStructs(in.ResponseHeaders),
+		MaxConnections:        in.MaxConnections,
+		MaxPendingRequests:    in.MaxPendingRequests,
+		MaxConcurrentRequests: in.MaxConcurrentRequests,
 	}
 }
 

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1533,6 +1533,17 @@ func apiConnectIngressGatewayToStructs(in *api.ConsulIngressConfigEntry) *struct
 	}
 }
 
+func apiConnectGatewayTLSSDSConfig(in *api.ConsulGatewayTLSSDSConfig) *structs.ConsulGatewayTLSSDSConfig {
+	if in == nil {
+		return nil
+	}
+
+	return &structs.ConsulGatewayTLSSDSConfig{
+		ClusterName:  in.ClusterName,
+		CertResource: in.CertResource,
+	}
+}
+
 func apiConnectGatewayTLSConfig(in *api.ConsulGatewayTLSConfig) *structs.ConsulGatewayTLSConfig {
 	if in == nil {
 		return nil
@@ -1543,6 +1554,7 @@ func apiConnectGatewayTLSConfig(in *api.ConsulGatewayTLSConfig) *structs.ConsulG
 		TLSMinVersion: in.TLSMinVersion,
 		TLSMaxVersion: in.TLSMaxVersion,
 		CipherSuites:  slices.Clone(in.CipherSuites),
+		SDS:           apiConnectGatewayTLSSDSConfig(in.SDS),
 	}
 }
 

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -3861,6 +3861,33 @@ func TestConversion_ApiConsulConnectToStructs(t *testing.T) {
 						Services: []*structs.ConsulIngressService{{
 							Name:  "ingress1",
 							Hosts: []string{"host1"},
+							TLS: &structs.ConsulGatewayTLSConfig{
+								SDS: &structs.ConsulGatewayTLSSDSConfig{
+									ClusterName:  "foo",
+									CertResource: "bar",
+								},
+							},
+							RequestHeaders: &structs.ConsulHTTPHeaderModifiers{
+								Add: map[string]string{
+									"test": "testvalue",
+								},
+								Set: map[string]string{
+									"test1": "testvalue1",
+								},
+								Remove: []string{"test2"},
+							},
+							ResponseHeaders: &structs.ConsulHTTPHeaderModifiers{
+								Add: map[string]string{
+									"test": "testvalue",
+								},
+								Set: map[string]string{
+									"test1": "testvalue1",
+								},
+								Remove: []string{"test2"},
+							},
+							MaxConnections:        pointer.Of(uint32(5120)),
+							MaxPendingRequests:    pointer.Of(uint32(512)),
+							MaxConcurrentRequests: pointer.Of(uint32(2048)),
 						}},
 					}},
 				},
@@ -3881,6 +3908,33 @@ func TestConversion_ApiConsulConnectToStructs(t *testing.T) {
 							Services: []*api.ConsulIngressService{{
 								Name:  "ingress1",
 								Hosts: []string{"host1"},
+								TLS: &api.ConsulGatewayTLSConfig{
+									SDS: &api.ConsulGatewayTLSSDSConfig{
+										ClusterName:  "foo",
+										CertResource: "bar",
+									},
+								},
+								RequestHeaders: &api.ConsulHTTPHeaderModifiers{
+									Add: map[string]string{
+										"test": "testvalue",
+									},
+									Set: map[string]string{
+										"test1": "testvalue1",
+									},
+									Remove: []string{"test2"},
+								},
+								ResponseHeaders: &api.ConsulHTTPHeaderModifiers{
+									Add: map[string]string{
+										"test": "testvalue",
+									},
+									Set: map[string]string{
+										"test1": "testvalue1",
+									},
+									Remove: []string{"test2"},
+								},
+								MaxConnections:        pointer.Of(uint32(5120)),
+								MaxPendingRequests:    pointer.Of(uint32(512)),
+								MaxConcurrentRequests: pointer.Of(uint32(2048)),
 							}},
 						}},
 					},

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -9,6 +9,7 @@ import (
 	capi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1645,6 +1646,23 @@ func TestParse(t *testing.T) {
 											Hosts: []string{
 												"2.2.2.2:8080",
 											},
+											TLS: &api.ConsulGatewayTLSConfig{
+												SDS: &api.ConsulGatewayTLSSDSConfig{
+													ClusterName:  "foo",
+													CertResource: "bar",
+												},
+											},
+											RequestHeaders: &api.ConsulHTTPHeaderModifiers{
+												Add: map[string]string{
+													"test": "testvalue",
+												},
+											},
+											ResponseHeaders: &api.ConsulHTTPHeaderModifiers{
+												Remove: []string{"test2"},
+											},
+											MaxConnections:        pointer.Of(uint32(5120)),
+											MaxPendingRequests:    pointer.Of(uint32(512)),
+											MaxConcurrentRequests: pointer.Of(uint32(2048)),
 										}},
 									},
 									},

--- a/jobspec/test-fixtures/tg-service-connect-gateway-ingress.hcl
+++ b/jobspec/test-fixtures/tg-service-connect-gateway-ingress.hcl
@@ -47,6 +47,23 @@ job "connect_gateway_ingress" {
               service {
                 name  = "nginx"
                 hosts = ["2.2.2.2:8080"]
+                tls {
+                  sds_config {
+                    cluster_name  = "foo"
+                    cert_resource = "bar"
+                  }
+                }
+                request_headers {
+                  add {
+                    test = "testvalue"
+                  }
+                }
+                response_headers {
+                  remove = ["test2"]
+                }
+                max_connections         = 5120
+                max_pending_requests    = 512
+                max_concurrent_requests = 2048
               }
             }
           }

--- a/nomad/consul.go
+++ b/nomad/consul.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
@@ -581,9 +582,21 @@ func convertIngressCE(namespace, service string, entry *structs.ConsulIngressCon
 	for _, listener := range entry.Listeners {
 		var services []api.IngressService = nil
 		for _, s := range listener.Services {
+			var sds *api.GatewayTLSSDSConfig = nil
+			if s.TLS != nil {
+				sds = convertGatewayTLSSDSConfig(s.TLS.SDS)
+			}
 			services = append(services, api.IngressService{
-				Name:  s.Name,
-				Hosts: slices.Clone(s.Hosts),
+				Name:                  s.Name,
+				Hosts:                 slices.Clone(s.Hosts),
+				RequestHeaders:        convertHTTPHeaderModifiers(s.RequestHeaders),
+				ResponseHeaders:       convertHTTPHeaderModifiers(s.ResponseHeaders),
+				MaxConnections:        s.MaxConnections,
+				MaxPendingRequests:    s.MaxPendingRequests,
+				MaxConcurrentRequests: s.MaxConcurrentRequests,
+				TLS: &api.GatewayServiceTLSConfig{
+					SDS: sds,
+				},
 			})
 		}
 		listeners = append(listeners, api.IngressListener{
@@ -607,6 +620,18 @@ func convertIngressCE(namespace, service string, entry *structs.ConsulIngressCon
 		Name:      service,
 		TLS:       *convertGatewayTLSConfig(entry.TLS),
 		Listeners: listeners,
+	}
+}
+
+func convertHTTPHeaderModifiers(in *structs.ConsulHTTPHeaderModifiers) *api.HTTPHeaderModifiers {
+	if in != nil {
+		return &api.HTTPHeaderModifiers{
+			Add:    maps.Clone(in.Add),
+			Set:    maps.Clone(in.Set),
+			Remove: slices.Clone(in.Remove),
+		}
+	} else {
+		return &api.HTTPHeaderModifiers{}
 	}
 }
 

--- a/nomad/consul.go
+++ b/nomad/consul.go
@@ -605,8 +605,33 @@ func convertIngressCE(namespace, service string, entry *structs.ConsulIngressCon
 		Namespace: namespace,
 		Kind:      api.IngressGateway,
 		Name:      service,
-		TLS:       tls,
+		TLS:       *convertGatewayTLSConfig(entry.TLS),
 		Listeners: listeners,
+	}
+}
+
+func convertGatewayTLSConfig(in *structs.ConsulGatewayTLSConfig) *api.GatewayTLSConfig {
+	if in != nil {
+		return &api.GatewayTLSConfig{
+			Enabled:       in.Enabled,
+			TLSMinVersion: in.TLSMinVersion,
+			TLSMaxVersion: in.TLSMaxVersion,
+			CipherSuites:  slices.Clone(in.CipherSuites),
+			SDS:           convertGatewayTLSSDSConfig(in.SDS),
+		}
+	} else {
+		return &api.GatewayTLSConfig{}
+	}
+}
+
+func convertGatewayTLSSDSConfig(in *structs.ConsulGatewayTLSSDSConfig) *api.GatewayTLSSDSConfig {
+	if in != nil {
+		return &api.GatewayTLSSDSConfig{
+			ClusterName:  in.ClusterName,
+			CertResource: in.CertResource,
+		}
+	} else {
+		return &api.GatewayTLSSDSConfig{}
 	}
 }
 

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -1290,12 +1290,93 @@ func connectGatewayIngressServiceDiff(prev, next *ConsulIngressService, contextu
 		newPrimitiveFlat = flatmap.Flatten(next, nil, true)
 	}
 
+	// Diff pointer types.
+	if prev != nil {
+		if prev.MaxConnections != nil {
+			oldPrimitiveFlat["MaxConnections"] = fmt.Sprintf("%v", *prev.MaxConnections)
+		}
+	}
+	if next != nil {
+		if next.MaxConnections != nil {
+			newPrimitiveFlat["MaxConnections"] = fmt.Sprintf("%v", *next.MaxConnections)
+		}
+	}
+	if prev != nil {
+		if prev.MaxPendingRequests != nil {
+			oldPrimitiveFlat["MaxPendingRequests"] = fmt.Sprintf("%v", *prev.MaxPendingRequests)
+		}
+	}
+	if next != nil {
+		if next.MaxPendingRequests != nil {
+			newPrimitiveFlat["MaxPendingRequests"] = fmt.Sprintf("%v", *next.MaxPendingRequests)
+		}
+	}
+	if prev != nil {
+		if prev.MaxConcurrentRequests != nil {
+			oldPrimitiveFlat["MaxConcurrentRequests"] = fmt.Sprintf("%v", *prev.MaxConcurrentRequests)
+		}
+	}
+	if next != nil {
+		if next.MaxConcurrentRequests != nil {
+			newPrimitiveFlat["MaxConcurrentRequests"] = fmt.Sprintf("%v", *next.MaxConcurrentRequests)
+		}
+	}
+
 	// Diff the primitive fields.
 	diff.Fields = fieldDiffs(oldPrimitiveFlat, newPrimitiveFlat, contextual)
 
 	// Diff the hosts.
 	if hDiffs := stringSetDiff(prev.Hosts, next.Hosts, "Hosts", contextual); hDiffs != nil {
 		diff.Objects = append(diff.Objects, hDiffs)
+	}
+
+	// Diff the ConsulGatewayTLSConfig objects.
+	tlsConfigDiff := connectGatewayTLSConfigDiff(prev.TLS, next.TLS, contextual)
+	if tlsConfigDiff != nil {
+		diff.Objects = append(diff.Objects, tlsConfigDiff)
+	}
+
+	// Diff the ConsulHTTPHeaderModifiers objects (RequestHeaders).
+	reqModifiersDiff := connectGatewayHTTPHeaderModifiersDiff(prev.RequestHeaders, next.RequestHeaders, "RequestHeaders", contextual)
+	if reqModifiersDiff != nil {
+		diff.Objects = append(diff.Objects, reqModifiersDiff)
+	}
+
+	// Diff the ConsulHTTPHeaderModifiers objects (ResponseHeaders).
+	respModifiersDiff := connectGatewayHTTPHeaderModifiersDiff(prev.ResponseHeaders, next.ResponseHeaders, "ResponseHeaders", contextual)
+	if respModifiersDiff != nil {
+		diff.Objects = append(diff.Objects, respModifiersDiff)
+	}
+
+	return diff
+}
+
+func connectGatewayHTTPHeaderModifiersDiff(prev, next *ConsulHTTPHeaderModifiers, name string, contextual bool) *ObjectDiff {
+	diff := &ObjectDiff{Type: DiffTypeNone, Name: name}
+	var oldPrimitiveFlat, newPrimitiveFlat map[string]string
+
+	if reflect.DeepEqual(prev, next) {
+		return nil
+	} else if prev == nil {
+		prev = new(ConsulHTTPHeaderModifiers)
+		diff.Type = DiffTypeAdded
+		newPrimitiveFlat = flatmap.Flatten(next, nil, true)
+	} else if next == nil {
+		next = new(ConsulHTTPHeaderModifiers)
+		diff.Type = DiffTypeDeleted
+		oldPrimitiveFlat = flatmap.Flatten(prev, nil, true)
+	} else {
+		diff.Type = DiffTypeEdited
+		oldPrimitiveFlat = flatmap.Flatten(prev, nil, true)
+		newPrimitiveFlat = flatmap.Flatten(next, nil, true)
+	}
+
+	// Diff the primitive fields.
+	diff.Fields = fieldDiffs(oldPrimitiveFlat, newPrimitiveFlat, contextual)
+
+	// Diff the Remove Headers.
+	if rDiffs := stringSetDiff(prev.Remove, next.Remove, "Remove", contextual); rDiffs != nil {
+		diff.Objects = append(diff.Objects, rDiffs)
 	}
 
 	return diff

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -1156,6 +1156,11 @@ func connectGatewayTLSConfigDiff(prev, next *ConsulGatewayTLSConfig, contextual 
 	// Diff the primitive field.
 	diff.Fields = fieldDiffs(oldPrimitiveFlat, newPrimitiveFlat, contextual)
 
+	// Diff SDS object
+	if sdsDiff := primitiveObjectDiff(prev.SDS, next.SDS, nil, "SDS", contextual); sdsDiff != nil {
+		diff.Objects = append(diff.Objects, sdsDiff)
+	}
+
 	return diff
 }
 

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -1894,10 +1894,66 @@ func (c *ConsulGatewayTLSConfig) Equal(o *ConsulGatewayTLSConfig) bool {
 		c.SDS.Equal(o.SDS)
 }
 
+// ConsulHTTPHeaderModifiers is a set of rules for HTTP header modification that
+// should be performed by proxies as the request passes through them. It can
+// operate on either request or response headers depending on the context in
+// which it is used.
+type ConsulHTTPHeaderModifiers struct {
+	// Add is a set of name -> value pairs that should be appended to the request
+	// or response (i.e. allowing duplicates if the same header already exists).
+	Add map[string]string
+
+	// Set is a set of name -> value pairs that should be added to the request or
+	// response, overwriting any existing header values of the same name.
+	Set map[string]string
+
+	// Remove is the set of header names that should be stripped from the request
+	// or response.
+	Remove []string
+}
+
+func (h *ConsulHTTPHeaderModifiers) Copy() *ConsulHTTPHeaderModifiers {
+	if h == nil {
+		return nil
+	}
+
+	return &ConsulHTTPHeaderModifiers{
+		Add:    maps.Clone(h.Add),
+		Set:    maps.Clone(h.Set),
+		Remove: slices.Clone(h.Remove),
+	}
+}
+
+func (h *ConsulHTTPHeaderModifiers) Equal(o *ConsulHTTPHeaderModifiers) bool {
+	if h == nil || o == nil {
+		return h == o
+	}
+
+	if !maps.Equal(h.Add, o.Add) {
+		return false
+	}
+
+	if !maps.Equal(h.Set, o.Set) {
+		return false
+	}
+
+	if !helper.SliceSetEq(h.Remove, o.Remove) {
+		return false
+	}
+
+	return true
+}
+
 // ConsulIngressService is used to configure a service fronted by the ingress gateway.
 type ConsulIngressService struct {
-	Name  string
-	Hosts []string
+	Name                  string
+	Hosts                 []string
+	TLS                   *ConsulGatewayTLSConfig
+	RequestHeaders        *ConsulHTTPHeaderModifiers
+	ResponseHeaders       *ConsulHTTPHeaderModifiers
+	MaxConnections        *uint32
+	MaxPendingRequests    *uint32
+	MaxConcurrentRequests *uint32
 }
 
 func (s *ConsulIngressService) Copy() *ConsulIngressService {
@@ -1905,16 +1961,37 @@ func (s *ConsulIngressService) Copy() *ConsulIngressService {
 		return nil
 	}
 
+	ns := new(ConsulIngressService)
+	*ns = *s
+
 	var hosts []string = nil
 	if n := len(s.Hosts); n > 0 {
 		hosts = make([]string, n)
 		copy(hosts, s.Hosts)
 	}
 
-	return &ConsulIngressService{
-		Name:  s.Name,
-		Hosts: hosts,
+	ns.Name = s.Name
+	ns.Hosts = hosts
+	ns.RequestHeaders = s.RequestHeaders.Copy()
+	ns.ResponseHeaders = s.ResponseHeaders.Copy()
+
+	if s.TLS != nil {
+		ns.TLS = s.TLS.Copy()
 	}
+
+	if s.MaxConnections != nil {
+		ns.MaxConnections = pointer.Of(*s.MaxConnections)
+	}
+
+	if s.MaxPendingRequests != nil {
+		ns.MaxPendingRequests = pointer.Of(*s.MaxPendingRequests)
+	}
+
+	if s.MaxConcurrentRequests != nil {
+		ns.MaxConcurrentRequests = pointer.Of(*s.MaxConcurrentRequests)
+	}
+
+	return ns
 }
 
 func (s *ConsulIngressService) Equal(o *ConsulIngressService) bool {
@@ -1926,7 +2003,35 @@ func (s *ConsulIngressService) Equal(o *ConsulIngressService) bool {
 		return false
 	}
 
-	return helper.SliceSetEq(s.Hosts, o.Hosts)
+	if !helper.SliceSetEq(s.Hosts, o.Hosts) {
+		return false
+	}
+
+	if !s.TLS.Equal(o.TLS) {
+		return false
+	}
+
+	if !s.RequestHeaders.Equal(o.RequestHeaders) {
+		return false
+	}
+
+	if !s.ResponseHeaders.Equal(o.ResponseHeaders) {
+		return false
+	}
+
+	if !pointer.Eq(s.MaxConnections, o.MaxConnections) {
+		return false
+	}
+
+	if !pointer.Eq(s.MaxPendingRequests, o.MaxPendingRequests) {
+		return false
+	}
+
+	if !pointer.Eq(s.MaxConcurrentRequests, o.MaxConcurrentRequests) {
+		return false
+	}
+
+	return true
 }
 
 func (s *ConsulIngressService) Validate(protocol string) error {

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -1833,12 +1833,39 @@ func (p *ConsulGatewayProxy) Validate() error {
 	return nil
 }
 
+type ConsulGatewayTLSSDSConfig struct {
+	ClusterName  string
+	CertResource string
+}
+
+func (c *ConsulGatewayTLSSDSConfig) Copy() *ConsulGatewayTLSSDSConfig {
+	if c == nil {
+		return nil
+	}
+
+	return &ConsulGatewayTLSSDSConfig{
+		ClusterName:  c.ClusterName,
+		CertResource: c.CertResource,
+	}
+}
+
+func (c *ConsulGatewayTLSSDSConfig) Equal(o *ConsulGatewayTLSSDSConfig) bool {
+	if c == nil || o == nil {
+		return c == o
+	}
+
+	return c.ClusterName == o.ClusterName &&
+		c.CertResource == o.CertResource
+}
+
 // ConsulGatewayTLSConfig is used to configure TLS for a gateway.
 type ConsulGatewayTLSConfig struct {
 	Enabled       bool
 	TLSMinVersion string
 	TLSMaxVersion string
 	CipherSuites  []string
+	// SDS allows configuring TLS certificate from an SDS service.
+	SDS *ConsulGatewayTLSSDSConfig
 }
 
 func (c *ConsulGatewayTLSConfig) Copy() *ConsulGatewayTLSConfig {
@@ -1851,6 +1878,7 @@ func (c *ConsulGatewayTLSConfig) Copy() *ConsulGatewayTLSConfig {
 		TLSMinVersion: c.TLSMinVersion,
 		TLSMaxVersion: c.TLSMaxVersion,
 		CipherSuites:  slices.Clone(c.CipherSuites),
+		SDS:           c.SDS.Copy(),
 	}
 }
 
@@ -1862,7 +1890,8 @@ func (c *ConsulGatewayTLSConfig) Equal(o *ConsulGatewayTLSConfig) bool {
 	return c.Enabled == o.Enabled &&
 		c.TLSMinVersion == o.TLSMinVersion &&
 		c.TLSMaxVersion == o.TLSMaxVersion &&
-		helper.SliceSetEq(c.CipherSuites, o.CipherSuites)
+		helper.SliceSetEq(c.CipherSuites, o.CipherSuites) &&
+		c.SDS.Equal(o.SDS)
 }
 
 // ConsulIngressService is used to configure a service fronted by the ingress gateway.

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -114,6 +114,12 @@ envoy_gateway_bind_addresses "<service>" {
   [`CipherSuites`](/consul/docs/connect/config-entries/ingress-gateway#ciphersuites)
   in the Consul documentation for the supported cipher suites.
 
+- `sds` `(SDSConfig: <optional>)` - Defines a set of parameters that configures the listener to load TLS certificates from an external SDS service.
+
+  - `cluster_name` `(string)` - The SDS cluster name to connect to to retrieve certificates.
+
+  - `cert_resource` `(string)` - The SDS resource name to request when fetching the certificate from the SDS service.
+
 #### `listener` Parameters
 
 - `port` `(int: required)` - The port that the listener should receive traffic on.

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -180,8 +180,25 @@ envoy_gateway_bind_addresses "<service>" {
 - `key_file` `(string: <optional>)` - A file path to a PEM-encoded private key.
   The file must be accessible by the gateway task. The key is used with the certificate
   to verify the gateway's authenticity. It must be provided if a `cert_file` is provided.
+- `max_concurrent_requests` `(int: 0)` - overrides for the Defaults field
+- `max_connections` `(int: 0)` - overrides for the Defaults field
+- `max_pending_requests` `(int: 0)` - overrides for the Defaults field
+- `response_headers` `(HTTPHeaderModifiers: <optional>)` - A set of HTTP-specific header modification rules that 
+  will be applied to responses from this service. This cannot be used with a tcp listener.
+- `request_headers` `(HTTPHeaderModifiers: <optional>)` - A set of HTTP-specific header modification rules that
+  will be applied to requests routed to this service. This cannot be used with a tcp listener.
 - `sni` `(string: <optional>)` - An optional hostname or domain name to specify during
   the TLS handshake.
+- `tls` `(ServiceTLSConfig: <optional>)` - TLS configuration for this service.
+
+  - `sds` `(SDSConfig: <optional>)` - Defines a set of parameters that configures the SDS source 
+  for the certificate for this specific service. At least one custom host must be specified in Hosts. 
+  The certificate retrieved from SDS will be served for all requests identifying one of the Hosts values 
+  in the TLS Server Name Indication (SNI) header.
+
+    - `cluster_name` `(string)` - The SDS cluster name to connect to to retrieve certificates.
+
+    - `cert_resource` `(string)` - The SDS resource name to request when fetching the certificate from the SDS service.
 
 ### `mesh` Parameters
 


### PR DESCRIPTION
# Description

## Changes

- Added support for ConsulIngressService configuration in `nomad/structs/services.go` and `api/consul.go`.
  - Added new fields to `ConsulIngressService` structs and updated their receiver functions.
    - `TLS`
    - `RequestHeaders`
    - `ResponseHeaders`
    - `MaxConnections`
    - `MaxPendingRequests`
    - `MaxConcurrentRequests`
- Updated `jobspec/parse_service.go`
- Updated `command/agent/job_endpoint.go`
- Update related tests
- Update Nomad Documentation for ConsulIngressService struct.

## Testing Changes

To test these changes you need to build a Nomad binary and deploy a cluster with both Nomad and Consul agents and clients.  
When you have your cluster running you can run the following job-spec:

```terraform
# $ cat ig-http.nomad

job "ig-http" {

  datacenters = ["dc1"]

  group "ingress-group" {

    network {
      mode = "bridge"
      port "inbound" {
        static = 8080
        to     = 8080
      }
    }

    service {
      name = "my-ingress-service"
      port = "8080"

        connect {
            gateway {
                proxy {
                    connect_timeout = "500ms"
                }
                ingress {
                    listener {
                        port     = 8080
                        protocol = "http"
                        service {
                            name = "uuid-api"
                            hosts = ["example.com", "example.com:8080"]
                            # New Fields:
                            response_headers {
                                add {
                                    testAdd = "testAddV"
                                }
                                set {
                                    testSet = "testSetV"
                                }
                                remove = ["testRemove"]
                            }
                            request_headers {
                                add {
                                    testAdd = "testAddV"
                                }
                                set {
                                    testSet = "testSetV"
                                }
                                remove = ["testRemove"]
                            }
                            max_connections = 100
                            max_pending_requests = 100
                            max_concurrent_requests = 100
                            tls {
                                sds_config {
                                    cluster_name = "foo"
                                    cert_resource = "example.com-public-cert"
                                }
                            } 
                        }   
                    }
                }
            }
        }
    }
  }

  group "generator" {
    network {
      mode = "host"
      port "api" {}
    }

    service {
      name = "uuid-api"
      port = "${NOMAD_PORT_api}"

      connect {
        native = true
      }
    }

    task "generate" {
      driver = "docker"

      config {
        image        = "hashicorpnomad/uuid-api:v3"
        network_mode = "host"
      }

      env {
        BIND = "0.0.0.0"
        PORT = "${NOMAD_PORT_api}"
      }
    }
  }
}

```

Once the job is running and healthy, use Consul's API to get the terminating gateway's configuration:

```bash
curl --request GET http://127.0.0.1:8500/v1/config/ingress-gateway | json_pp
```

You will get the following JSON output:

```json
[
    {
        "Kind": "ingress-gateway",
        "Name": "my-ingress-service",
        "TLS": {
            "Enabled": false
        },
        "Listeners": [
            {
                "Port": 8080,
                "Protocol": "http",
                "TLS": {
                    "Enabled": false
                },
                "Services": [
                    {
                        "Name": "uuid-api",
                        "Hosts": [
                            "example.com",
                            "example.com:8080"
                        ],
                        "TLS": {
                            "SDS": {
                                "ClusterName": "foo",
                                "CertResource": "example.com-public-cert"
                            }
                        },
                        "RequestHeaders": {
                            "Add": {
                                "testAdd": "testAddV"
                            },
                            "Set": {
                                "testSet": "testSetV"
                            },
                            "Remove": [
                                "testRemove"
                            ]
                        },
                        "ResponseHeaders": {
                            "Add": {
                                "testAdd": "testAddV"
                            },
                            "Set": {
                                "testSet": "testSetV"
                            },
                            "Remove": [
                                "testRemove"
                            ]
                        },
                        "MaxConnections": 100,
                        "MaxPendingRequests": 100,
                        "MaxConcurrentRequests": 100
                    }
                ]
            }
        ],
        "Defaults": {
            "MaxConnections": 0,
            "MaxPendingRequests": 0,
            "MaxConcurrentRequests": 0
        },
        "CreateIndex": 51,
        "ModifyIndex": 960
    }
]

```

## Demo Video


https://user-images.githubusercontent.com/113113630/228625661-162049c4-6c95-4679-8db9-bcc7c4dd2299.mp4
