### PR TITLE
api: enable support for setting original job source

### DIFF
--- a/.changelog/16763.txt
+++ b/.changelog/16763.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: enable support for storing original job source
+```

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -1312,6 +1312,7 @@ type JobRevertRequest struct {
 type JobRegisterRequest struct {
 	Submission *JobSubmission
 	Job        *Job
+
 	// If EnforceIndex is set then the job will only be registered if the passed
 	// JobModifyIndex matches the current Jobs index. If the index is zero, the
 	// register only occurs if the job is new.

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/cronexpr"
+	"golang.org/x/exp/maps"
 )
 
 const (
@@ -68,6 +69,11 @@ type JobsParseRequest struct {
 	// HCLv1 indicates whether the JobHCL should be parsed with the hcl v1 parser
 	HCLv1 bool `json:"hclv1,omitempty"`
 
+	// Variables are HCL2 variables associated with the job. Only works with hcl2.
+	//
+	// Interpreted as if it were the content of a variables file.
+	Variables string
+
 	// Canonicalize is a flag as to if the server should return default values
 	// for unset fields
 	Canonicalize bool
@@ -78,7 +84,7 @@ func (c *Client) Jobs() *Jobs {
 	return &Jobs{client: c}
 }
 
-// ParseHCL is used to convert the HCL repesentation of a Job to JSON server side.
+// ParseHCL is used to convert the HCL representation of a Job to JSON server side.
 // To parse the HCL client side see package github.com/hashicorp/nomad/jobspec
 // Use ParseHCLOpts if you need to customize JobsParseRequest.
 func (j *Jobs) ParseHCL(jobHCL string, canonicalize bool) (*Job, error) {
@@ -89,10 +95,8 @@ func (j *Jobs) ParseHCL(jobHCL string, canonicalize bool) (*Job, error) {
 	return j.ParseHCLOpts(req)
 }
 
-// ParseHCLOpts is used to convert the HCL representation of a Job to JSON
-// server side. To parse the HCL client side see package
-// github.com/hashicorp/nomad/jobspec.
-// ParseHCL is an alternative convenience API for HCLv2 users.
+// ParseHCLOpts is used to request the server convert the HCL representation of a
+// Job to JSON on our behalf. Accepts HCL1 or HCL2 jobs as input.
 func (j *Jobs) ParseHCLOpts(req *JobsParseRequest) (*Job, error) {
 	var job Job
 	_, err := j.client.put("/v1/jobs/parse", req, &job, nil)
@@ -116,6 +120,7 @@ type RegisterOptions struct {
 	PolicyOverride bool
 	PreserveCounts bool
 	EvalPriority   int
+	Submission     *JobSubmission
 }
 
 // Register is used to register a new job. It returns the ID
@@ -134,9 +139,7 @@ func (j *Jobs) EnforceRegister(job *Job, modifyIndex uint64, q *WriteOptions) (*
 // returns the ID of the evaluation, along with any errors encountered.
 func (j *Jobs) RegisterOpts(job *Job, opts *RegisterOptions, q *WriteOptions) (*JobRegisterResponse, *WriteMeta, error) {
 	// Format the request
-	req := &JobRegisterRequest{
-		Job: job,
-	}
+	req := &JobRegisterRequest{Job: job}
 	if opts != nil {
 		if opts.EnforceIndex {
 			req.EnforceIndex = true
@@ -145,6 +148,7 @@ func (j *Jobs) RegisterOpts(job *Job, opts *RegisterOptions, q *WriteOptions) (*
 		req.PolicyOverride = opts.PolicyOverride
 		req.PreserveCounts = opts.PreserveCounts
 		req.EvalPriority = opts.EvalPriority
+		req.Submission = opts.Submission
 	}
 
 	var resp JobRegisterResponse
@@ -250,6 +254,19 @@ func (j *Jobs) Versions(jobID string, diffs bool, q *QueryOptions) ([]*Job, []*J
 		return nil, nil, nil, err
 	}
 	return resp.Versions, resp.Diffs, qm, nil
+}
+
+// Submission is used to retrieve the original submitted source of a job given its
+// namespace, jobID, and version number. The original source might not be available,
+// which case nil is returned with no error.
+func (j *Jobs) Submission(jobID string, version int, q *QueryOptions) (*JobSubmission, *QueryMeta, error) {
+	var sub JobSubmission
+	s := fmt.Sprintf("/v1/job/%s/submission?version=%d", url.PathEscape(jobID), version)
+	qm, err := j.client.query(s, &sub, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &sub, qm, nil
 }
 
 // Allocations is used to return the allocs for a given job ID.
@@ -863,6 +880,51 @@ type ParameterizedJobConfig struct {
 	MetaOptional []string `mapstructure:"meta_optional" hcl:"meta_optional,optional"`
 }
 
+// JobSubmission is used to hold information about the original content of a job
+// specification being submitted to Nomad.
+//
+// At any time a JobSubmission may be nil, indicating no information is known about
+// the job submission.
+type JobSubmission struct {
+	// Source contains the original job definition (may be in the format of
+	// hcl1, hcl2, or json).
+	Source string
+
+	// Format indicates what the Source content was (hcl1, hcl2, or json).
+	Format string
+
+	// VariableFlags contains the CLI "-var" flag arguments as submitted with the
+	// job (hcl2 only).
+	VariableFlags map[string]string
+
+	// Variables contains the opaque variables configuration as coming from
+	// a var-file or the WebUI variables input (hcl2 only).
+	Variables string
+}
+
+func (js *JobSubmission) Canonicalize() {
+	if js == nil {
+		return
+	}
+
+	if len(js.VariableFlags) == 0 {
+		js.VariableFlags = nil
+	}
+}
+
+func (js *JobSubmission) Copy() *JobSubmission {
+	if js == nil {
+		return nil
+	}
+
+	return &JobSubmission{
+		Source:        js.Source,
+		Format:        js.Format,
+		VariableFlags: maps.Clone(js.VariableFlags),
+		Variables:     js.Variables,
+	}
+}
+
 // Job is used to serialize a job.
 type Job struct {
 	/* Fields parsed from HCL config */
@@ -1248,7 +1310,8 @@ type JobRevertRequest struct {
 
 // JobRegisterRequest is used to update a job
 type JobRegisterRequest struct {
-	Job *Job
+	Submission *JobSubmission
+	Job        *Job
 	// If EnforceIndex is set then the job will only be registered if the passed
 	// JobModifyIndex matches the current Jobs index. If the index is zero, the
 	// register only occurs if the job is new.
@@ -1383,6 +1446,12 @@ type JobDispatchResponse struct {
 type JobVersionsResponse struct {
 	Versions []*Job
 	Diffs    []*JobDiff
+	QueryMeta
+}
+
+// JobSubmissionResponse is used for a job get submission request
+type JobSubmissionResponse struct {
+	Submission *JobSubmission
 	QueryMeta
 }
 

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -1436,6 +1436,301 @@ func TestJobs_Versions(t *testing.T) {
 	must.Eq(t, *job.ID, *result[0].ID)
 }
 
+func TestJobs_JobSubmission_Canonicalize(t *testing.T) {
+	testutil.Parallel(t)
+
+	t.Run("nil", func(t *testing.T) {
+		var js *JobSubmission
+		js.Canonicalize()
+		must.Nil(t, js)
+	})
+
+	t.Run("empty variable flags", func(t *testing.T) {
+		js := &JobSubmission{
+			Source:        "abc123",
+			Format:        "hcl2",
+			VariableFlags: make(map[string]string),
+		}
+		js.Canonicalize()
+		must.Nil(t, js.VariableFlags)
+	})
+}
+
+func TestJobs_JobSubmission_Copy(t *testing.T) {
+	testutil.Parallel(t)
+
+	t.Run("nil", func(t *testing.T) {
+		var js *JobSubmission
+		c := js.Copy()
+		must.Nil(t, c)
+	})
+
+	t.Run("copy", func(t *testing.T) {
+		js := &JobSubmission{
+			Source:        "source",
+			Format:        "format",
+			VariableFlags: map[string]string{"foo": "bar"},
+			Variables:     "variables",
+		}
+		c := js.Copy()
+		c.Source = "source2"
+		c.Format = "format2"
+		c.VariableFlags["foo"] = "baz"
+		c.Variables = "variables2"
+		must.Eq(t, &JobSubmission{
+			Source:        "source",
+			Format:        "format",
+			VariableFlags: map[string]string{"foo": "bar"},
+			Variables:     "variables",
+		}, js)
+	})
+}
+
+func TestJobs_Submission_versions(t *testing.T) {
+	testutil.Parallel(t)
+
+	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) { c.DevMode = true })
+	t.Cleanup(s.Stop)
+
+	jobs := c.Jobs()
+
+	job := testJob()
+	jobID := *job.ID                       // job1
+	job.TaskGroups[0].Count = pointerOf(0) // no need to actually run
+
+	// trying to retrieve a version before job is submitted returns a Not Found
+	_, _, nfErr := jobs.Submission(jobID, 0, nil)
+	must.ErrorContains(t, nfErr, "job source not found")
+
+	// register our test job at version 0
+	job.Meta = map[string]string{"v": "0"}
+	_, wm, regErr := jobs.RegisterOpts(job, &RegisterOptions{
+		Submission: &JobSubmission{
+			Source:        "the job source v0",
+			Format:        "hcl2",
+			VariableFlags: map[string]string{"X": "x", "Y": "42", "Z": "true"},
+			Variables:     "var file content",
+		},
+	}, nil)
+	must.NoError(t, regErr)
+	assertWriteMeta(t, wm)
+
+	expectSubmission := func(sub *JobSubmission, format, source, vars string, flags map[string]string) {
+		must.NotNil(t, sub, must.Sprintf("expected a non-nil job submission for job %s @ version %d", jobID, 0))
+		must.Eq(t, format, sub.Format)
+		must.Eq(t, source, sub.Source)
+		must.Eq(t, vars, sub.Variables)
+		must.MapEq(t, flags, sub.VariableFlags)
+	}
+
+	// we should have a version 0 now
+	sub, _, err := jobs.Submission(jobID, 0, nil)
+	must.NoError(t, err)
+	expectSubmission(sub, "hcl2", "the job source v0", "var file content", map[string]string{"X": "x", "Y": "42", "Z": "true"})
+
+	// register our test job at version 1
+	job.Meta = map[string]string{"v": "1"}
+	_, wm, regErr = jobs.RegisterOpts(job, &RegisterOptions{
+		Submission: &JobSubmission{
+			Source:        "the job source v1",
+			Format:        "hcl2",
+			VariableFlags: nil,
+			Variables:     "different var content",
+		},
+	}, nil)
+	must.NoError(t, regErr)
+	assertWriteMeta(t, wm)
+
+	// we should have a version 1 now
+	sub, _, err = jobs.Submission(jobID, 1, nil)
+	must.NoError(t, err)
+	expectSubmission(sub, "hcl2", "the job source v1", "different var content", nil)
+
+	// if we query for version 0 we should still have it
+	sub, _, err = jobs.Submission(jobID, 0, nil)
+	must.NoError(t, err)
+	expectSubmission(sub, "hcl2", "the job source v0", "var file content", map[string]string{"X": "x", "Y": "42", "Z": "true"})
+
+	// deregister (and purge) the job
+	_, _, err = jobs.Deregister(jobID, true, &WriteOptions{Namespace: "default"})
+	must.NoError(t, err)
+
+	// now if we query for a submission of v0 it will be gone
+	sub, _, err = jobs.Submission(jobID, 0, nil)
+	must.ErrorContains(t, err, "job source not found")
+	must.Nil(t, sub)
+
+	// same for the v1 submission
+	sub, _, err = jobs.Submission(jobID, 1, nil)
+	must.ErrorContains(t, err, "job source not found")
+	must.Nil(t, sub)
+}
+
+func TestJobs_Submission_namespaces(t *testing.T) {
+	testutil.Parallel(t)
+
+	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) { c.DevMode = true })
+	t.Cleanup(s.Stop)
+
+	first := &Namespace{
+		Name:        "first",
+		Description: "first namespace",
+	}
+
+	second := &Namespace{
+		Name:        "second",
+		Description: "second namespace",
+	}
+
+	// create two namespaces
+	namespaces := c.Namespaces()
+	_, err := namespaces.Register(first, nil)
+	must.NoError(t, err)
+	_, err = namespaces.Register(second, nil)
+	must.NoError(t, err)
+
+	jobs := c.Jobs()
+
+	// use the same jobID to prove we can query submissions of the same ID but
+	// in different namespaces
+	commonJobID := "common"
+
+	job := testJob()
+	job.ID = pointerOf(commonJobID)
+	job.TaskGroups[0].Count = pointerOf(0)
+
+	// register our test job into first namespace
+	_, wm, err := jobs.RegisterOpts(job, &RegisterOptions{
+		Submission: &JobSubmission{
+			Source: "the job source",
+			Format: "hcl2",
+		},
+	}, &WriteOptions{Namespace: "first"})
+	must.NoError(t, err)
+	assertWriteMeta(t, wm)
+
+	// if we query in the default namespace the submission should not exist
+	sub, _, err := jobs.Submission(commonJobID, 0, nil)
+	must.ErrorContains(t, err, "not found")
+	must.Nil(t, sub)
+
+	// if we query in the first namespace we expect to get the submission
+	sub, _, err = jobs.Submission(commonJobID, 0, &QueryOptions{Namespace: "first"})
+	must.NoError(t, err)
+	must.Eq(t, "the job source", sub.Source)
+
+	// if we query in the second namespace we expect the submission should not exist
+	sub, _, err = jobs.Submission(commonJobID, 0, &QueryOptions{Namespace: "second"})
+	must.ErrorContains(t, err, "not found")
+	must.Nil(t, sub)
+
+	// create a second test job for our second namespace
+	job2 := testJob()
+	job2.ID = pointerOf(commonJobID)
+	// keep job name redis to prove we write to correct namespace
+	job.TaskGroups[0].Count = pointerOf(0)
+
+	// register our second job into the second namespace
+	_, wm, err = jobs.RegisterOpts(job2, &RegisterOptions{
+		Submission: &JobSubmission{
+			Source: "second job source",
+			Format: "hcl1",
+		},
+	}, &WriteOptions{Namespace: "second"})
+	must.NoError(t, err)
+	assertWriteMeta(t, wm)
+
+	// if we query in the default namespace the submission should not exist
+	sub, _, err = jobs.Submission(commonJobID, 0, nil)
+	must.ErrorContains(t, err, "not found")
+	must.Nil(t, sub)
+
+	// if we query in the first namespace we expect to get the first job submission
+	sub, _, err = jobs.Submission(commonJobID, 0, &QueryOptions{Namespace: "first"})
+	must.NoError(t, err)
+	must.Eq(t, "the job source", sub.Source)
+
+	// if we query in the second namespace we expect the second job submission
+	sub, _, err = jobs.Submission(commonJobID, 0, &QueryOptions{Namespace: "second"})
+	must.NoError(t, err)
+	must.Eq(t, "second job source", sub.Source)
+
+	// if we query v1 in the first namespace we expect nothing
+	sub, _, err = jobs.Submission(commonJobID, 1, &QueryOptions{Namespace: "first"})
+	must.ErrorContains(t, err, "not found")
+	must.Nil(t, sub)
+
+	// if we query v1 in the second namespace we expect nothing
+	sub, _, err = jobs.Submission(commonJobID, 1, &QueryOptions{Namespace: "second"})
+	must.ErrorContains(t, err, "not found")
+	must.Nil(t, sub)
+}
+
+func TestJobs_Submission_delete(t *testing.T) {
+	testutil.Parallel(t)
+
+	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) { c.DevMode = true })
+	t.Cleanup(s.Stop)
+
+	first := &Namespace{
+		Name:        "first",
+		Description: "first namespace",
+	}
+
+	namespaces := c.Namespaces()
+	_, err := namespaces.Register(first, nil)
+	must.NoError(t, err)
+
+	jobs := c.Jobs()
+	job := testJob()
+	jobID := *job.ID
+	job.TaskGroups[0].Count = pointerOf(0)
+	job.Meta = map[string]string{"version": "0"}
+
+	// register our test job into first namespace
+	_, wm, err := jobs.RegisterOpts(job, &RegisterOptions{
+		Submission: &JobSubmission{
+			Source: "the job source v0",
+			Format: "hcl2",
+		},
+	}, &WriteOptions{Namespace: "first"})
+	must.NoError(t, err)
+	assertWriteMeta(t, wm)
+
+	// modify the job and register it again
+	job.Meta["version"] = "1"
+	_, wm, err = jobs.RegisterOpts(job, &RegisterOptions{
+		Submission: &JobSubmission{
+			Source: "the job source v1",
+			Format: "hcl2",
+		},
+	}, &WriteOptions{Namespace: "first"})
+	must.NoError(t, err)
+	assertWriteMeta(t, wm)
+
+	// ensure we have our submissions for both versions
+	sub, _, err := jobs.Submission(jobID, 0, &QueryOptions{Namespace: "first"})
+	must.NoError(t, err)
+	must.Eq(t, "the job source v0", sub.Source)
+
+	sub, _, err = jobs.Submission(jobID, 1, &QueryOptions{Namespace: "first"})
+	must.NoError(t, err)
+	must.Eq(t, "the job source v1", sub.Source)
+
+	// deregister (and purge) the job
+	_, _, err = jobs.Deregister(jobID, true, &WriteOptions{Namespace: "first"})
+	must.NoError(t, err)
+
+	// ensure all submissions for the job are gone
+	sub, _, err = jobs.Submission(jobID, 0, &QueryOptions{Namespace: "first"})
+	must.ErrorContains(t, err, "job source not found")
+	must.Nil(t, sub)
+
+	sub, _, err = jobs.Submission(jobID, 1, &QueryOptions{Namespace: "first"})
+	must.ErrorContains(t, err, "job source not found")
+	must.Nil(t, sub)
+}
+
 func TestJobs_PrefixList(t *testing.T) {
 	testutil.Parallel(t)
 

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -17,9 +17,7 @@ func assertQueryMeta(t *testing.T, qm *QueryMeta) {
 
 func assertWriteMeta(t *testing.T, wm *WriteMeta) {
 	t.Helper()
-	if wm.LastIndex == 0 {
-		t.Fatalf("bad index: %d", wm.LastIndex)
-	}
+	must.Positive(t, wm.LastIndex, must.Sprint("expected WriteMeta.LastIndex to be > 0"))
 }
 
 func testJob() *Job {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -478,7 +478,7 @@ func TestClient_WatchAllocs(t *testing.T) {
 	alloc2.Job = job
 
 	state := s1.State()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.UpsertJobSummary(101, mock.JobSummary(alloc1.JobID)); err != nil {
@@ -575,7 +575,7 @@ func TestClient_SaveRestoreState(t *testing.T) {
 	alloc1.ClientStatus = structs.AllocClientStatusRunning
 
 	state := s1.State()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.UpsertJobSummary(101, mock.JobSummary(alloc1.JobID)); err != nil {
@@ -681,7 +681,7 @@ func TestClient_AddAllocError(t *testing.T) {
 	alloc1.TaskResources = nil
 
 	state := s1.State()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job)
 	require.Nil(err)
 
 	err = state.UpsertJobSummary(101, mock.JobSummary(alloc1.JobID))
@@ -1736,7 +1736,7 @@ func TestClient_ReconnectAllocs(t *testing.T) {
 	runningAlloc.ClientStatus = structs.AllocClientStatusPending
 
 	state := s1.State()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job)
 	require.NoError(t, err)
 
 	err = state.UpsertJobSummary(101, mock.JobSummary(runningAlloc.JobID))

--- a/client/gc_test.go
+++ b/client/gc_test.go
@@ -394,7 +394,7 @@ func TestAllocGarbageCollector_MakeRoomFor_MaxAllocs(t *testing.T) {
 
 	upsertJobFn := func(server *nomad.Server, j *structs.Job) {
 		state := server.State()
-		require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, nextIndex(), j))
+		require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, nextIndex(), nil, j))
 		require.NoError(state.UpsertJobSummary(nextIndex(), mock.JobSummary(j.ID)))
 	}
 

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	metrics "github.com/armon/go-metrics"
+	"github.com/dustin/go-humanize"
 	consulapi "github.com/hashicorp/consul/api"
 	log "github.com/hashicorp/go-hclog"
 	uuidparse "github.com/hashicorp/go-uuid"
@@ -26,6 +27,7 @@ import (
 	"github.com/hashicorp/nomad/helper/bufconndialer"
 	"github.com/hashicorp/nomad/helper/escapingfs"
 	"github.com/hashicorp/nomad/helper/pluginutils/loader"
+	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/lib/cpuset"
 	"github.com/hashicorp/nomad/nomad"
@@ -160,7 +162,7 @@ func NewAgent(config *Config, logger log.InterceptLogger, logOutput io.Writer, i
 
 // convertServerConfig takes an agent config and log output and returns a Nomad
 // Config. There may be missing fields that must be set by the agent. To do this
-// call finalizeServerConfig
+// call finalizeServerConfig.
 func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	conf := agentConfig.NomadConfig
 	if conf == nil {
@@ -571,6 +573,16 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 		conf.RaftBoltNoFreelistSync = bolt.NoFreelistSync
 	}
 
+	// Interpret job_max_source_size as bytes from string value
+	if agentConfig.Server.JobMaxSourceSize == nil {
+		agentConfig.Server.JobMaxSourceSize = pointer.Of("1M")
+	}
+	jobMaxSourceBytes, err := humanize.ParseBytes(*agentConfig.Server.JobMaxSourceSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse max job source bytes: %w", err)
+	}
+	conf.JobMaxSourceSize = int(jobMaxSourceBytes)
+
 	return conf, nil
 }
 
@@ -603,7 +615,7 @@ func (a *Agent) clientConfig() (*clientconfig.Config, error) {
 		return nil, err
 	}
 
-	if err := a.finalizeClientConfig(c); err != nil {
+	if err = a.finalizeClientConfig(c); err != nil {
 		return nil, err
 	}
 

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -675,7 +675,7 @@ func TestAgent_ServerConfig_RaftProtocol_3(t *testing.T) {
 	}
 }
 
-func TestAgent_ClientConfig(t *testing.T) {
+func TestAgent_ClientConfig_discovery(t *testing.T) {
 	ci.Parallel(t)
 	conf := DefaultConfig()
 	conf.Client.Enabled = true
@@ -727,6 +727,21 @@ func TestAgent_ClientConfig(t *testing.T) {
 	require.False(t, c.NomadServiceDiscovery)
 }
 
+func TestAgent_ClientConfig_JobMaxSourceSize(t *testing.T) {
+	ci.Parallel(t)
+
+	conf := DevConfig(nil)
+	must.Eq(t, conf.Server.JobMaxSourceSize, pointer.Of("1M"))
+	must.NoError(t, conf.normalizeAddrs())
+
+	// config conversion ensures value is set
+	conf.Server.JobMaxSourceSize = nil
+	agent := &Agent{config: conf}
+	serverConf, err := agent.serverConfig()
+	must.NoError(t, err)
+	must.Eq(t, 1e6, serverConf.JobMaxSourceSize)
+}
+
 func TestAgent_ClientConfig_ReservedCores(t *testing.T) {
 	ci.Parallel(t)
 	conf := DefaultConfig()
@@ -735,16 +750,14 @@ func TestAgent_ClientConfig_ReservedCores(t *testing.T) {
 	conf.Client.Reserved.Cores = "0,2-3"
 	a := &Agent{config: conf}
 	c, err := a.clientConfig()
-	require.NoError(t, err)
-	require.Exactly(t, []uint16{0, 1, 2, 3, 4, 5, 6, 7}, c.ReservableCores)
-	require.Exactly(t, []uint16{0, 2, 3}, c.Node.ReservedResources.Cpu.ReservedCpuCores)
+	must.NoError(t, err)
+	must.Eq(t, []uint16{0, 1, 2, 3, 4, 5, 6, 7}, c.ReservableCores)
+	must.Eq(t, []uint16{0, 2, 3}, c.Node.ReservedResources.Cpu.ReservedCpuCores)
 }
 
 // Clients should inherit telemetry configuration
 func TestAgent_Client_TelemetryConfiguration(t *testing.T) {
 	ci.Parallel(t)
-
-	assert := assert.New(t)
 
 	conf := DefaultConfig()
 	conf.DevMode = true
@@ -752,13 +765,13 @@ func TestAgent_Client_TelemetryConfiguration(t *testing.T) {
 	a := &Agent{config: conf}
 
 	c, err := a.clientConfig()
-	assert.Nil(err)
+	must.NoError(t, err)
 
 	telemetry := conf.Telemetry
 
-	assert.Equal(c.StatsCollectionInterval, telemetry.collectionInterval)
-	assert.Equal(c.PublishNodeMetrics, telemetry.PublishNodeMetrics)
-	assert.Equal(c.PublishAllocationMetrics, telemetry.PublishAllocationMetrics)
+	must.Eq(t, c.StatsCollectionInterval, telemetry.collectionInterval)
+	must.Eq(t, c.PublishNodeMetrics, telemetry.PublishNodeMetrics)
+	must.Eq(t, c.PublishAllocationMetrics, telemetry.PublishAllocationMetrics)
 }
 
 // TestAgent_HTTPCheck asserts Agent.agentHTTPCheck properly alters the HTTP

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -606,6 +606,11 @@ type ServerConfig struct {
 	// for the EventBufferSize is 1.
 	EventBufferSize *int `hcl:"event_buffer_size"`
 
+	// JobMaxSourceSize limits the maximum size of a jobs source hcl/json
+	// before being discarded automatically. If unset, the maximum size defaults
+	// to 1 MiB. If the value is zero, no job sources will be stored.
+	JobMaxSourceSize *string `hcl:"max_job_source_size"`
+
 	// LicensePath is the path to search for an enterprise license.
 	LicensePath string `hcl:"license_path"`
 
@@ -672,6 +677,7 @@ func (s *ServerConfig) Copy() *ServerConfig {
 	ns.PlanRejectionTracker = s.PlanRejectionTracker.Copy()
 	ns.EnableEventBroker = pointer.Copy(s.EnableEventBroker)
 	ns.EventBufferSize = pointer.Copy(s.EventBufferSize)
+	ns.JobMaxSourceSize = pointer.Copy(s.JobMaxSourceSize)
 	ns.licenseAdditionalPublicKeys = slices.Clone(s.licenseAdditionalPublicKeys)
 	ns.ExtraKeysHCL = slices.Clone(s.ExtraKeysHCL)
 	ns.Search = s.Search.Copy()
@@ -1057,7 +1063,7 @@ func (a *Addresses) Copy() *Addresses {
 	return &na
 }
 
-// AdvertiseAddrs is used to control the addresses we advertise out for
+// NormalizedAddrs is used to control the addresses we advertise out for
 // different network services. All are optional and default to BindAddr and
 // their default Port.
 type NormalizedAddrs struct {
@@ -1306,6 +1312,7 @@ func DefaultConfig() *Config {
 				LimitResults:  100,
 				MinTermLength: 2,
 			},
+			JobMaxSourceSize: pointer.Of("1M"),
 		},
 		ACL: &ACLConfig{
 			Enabled:   false,
@@ -1974,6 +1981,8 @@ func (s *ServerConfig) Merge(b *ServerConfig) *ServerConfig {
 	if b.EventBufferSize != nil {
 		result.EventBufferSize = b.EventBufferSize
 	}
+
+	result.JobMaxSourceSize = pointer.Merge(s.JobMaxSourceSize, b.JobMaxSourceSize)
 
 	if b.PlanRejectionTracker != nil {
 		result.PlanRejectionTracker = result.PlanRejectionTracker.Merge(b.PlanRejectionTracker)

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -608,7 +608,7 @@ type ServerConfig struct {
 
 	// JobMaxSourceSize limits the maximum size of a jobs source hcl/json
 	// before being discarded automatically. If unset, the maximum size defaults
-	// to 1 MiB. If the value is zero, no job sources will be stored.
+	// to 1 MB. If the value is zero, no job sources will be stored.
 	JobMaxSourceSize *string `hcl:"max_job_source_size"`
 
 	// LicensePath is the path to search for an enterprise license.

--- a/command/agent/deployment_endpoint_test.go
+++ b/command/agent/deployment_endpoint_test.go
@@ -108,7 +108,7 @@ func TestHTTP_DeploymentAllocations(t *testing.T) {
 		a2.TaskStates = make(map[string]*structs.TaskState)
 		a2.TaskStates["test"] = taskState2
 
-		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
+		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, nil, j), "UpsertJob")
 		assert.Nil(state.UpsertDeployment(999, d), "UpsertDeployment")
 		assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a1, a2}), "UpsertAllocs")
 
@@ -175,7 +175,7 @@ func TestHTTP_DeploymentPause(t *testing.T) {
 		j := mock.Job()
 		d := mock.Deployment()
 		d.JobID = j.ID
-		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
+		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), "UpsertJob")
 		assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 		// Create the pause request
@@ -216,7 +216,7 @@ func TestHTTP_DeploymentPromote(t *testing.T) {
 		j := mock.Job()
 		d := mock.Deployment()
 		d.JobID = j.ID
-		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
+		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), "UpsertJob")
 		assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 		// Create the pause request
@@ -260,7 +260,7 @@ func TestHTTP_DeploymentAllocHealth(t *testing.T) {
 		a := mock.Alloc()
 		a.JobID = j.ID
 		a.DeploymentID = d.ID
-		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
+		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, nil, j), "UpsertJob")
 		assert.Nil(state.UpsertDeployment(999, d), "UpsertDeployment")
 		assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -302,7 +302,7 @@ func TestHTTP_DeploymentFail(t *testing.T) {
 		j := mock.Job()
 		d := mock.Deployment()
 		d.JobID = j.ID
-		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
+		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, nil, j), "UpsertJob")
 		assert.Nil(state.UpsertDeployment(999, d), "UpsertDeployment")
 
 		// Make the HTTP request

--- a/command/agent/fs_endpoint_test.go
+++ b/command/agent/fs_endpoint_test.go
@@ -63,7 +63,7 @@ func addAllocToClient(agent *TestAgent, alloc *structs.Allocation, wait clientAl
 
 	// Upsert the allocation
 	state := agent.server.State()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, alloc.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{alloc}))
 
 	if wait == noWaitClientAlloc {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
@@ -104,6 +105,9 @@ func (s *HTTPServer) JobSpecificRequest(resp http.ResponseWriter, req *http.Requ
 	case strings.HasSuffix(path, "/services"):
 		jobID := strings.TrimSuffix(path, "/services")
 		return s.jobServiceRegistrations(resp, req, jobID)
+	case strings.HasSuffix(path, "/submission"):
+		jobID := strings.TrimSuffix(path, "/submission")
+		return s.jobSubmissionCRUD(resp, req, jobID)
 	default:
 		return s.jobCRUD(resp, req, path)
 	}
@@ -327,6 +331,42 @@ func (s *HTTPServer) jobLatestDeployment(resp http.ResponseWriter, req *http.Req
 	return out.Deployment, nil
 }
 
+func (s *HTTPServer) jobSubmissionCRUD(resp http.ResponseWriter, req *http.Request, jobID string) (*structs.JobSubmission, error) {
+	version, err := strconv.ParseUint(req.URL.Query().Get("version"), 10, 64)
+	if err != nil {
+		return nil, CodedError(400, "Unable to parse job submission version parameter")
+	}
+	switch req.Method {
+	case "GET":
+		return s.jobSubmissionQuery(resp, req, jobID, version)
+	default:
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+}
+
+func (s *HTTPServer) jobSubmissionQuery(resp http.ResponseWriter, req *http.Request, jobID string, version uint64) (*structs.JobSubmission, error) {
+	args := structs.JobSubmissionRequest{
+		JobID:   jobID,
+		Version: version,
+	}
+
+	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
+		return nil, nil
+	}
+
+	var out structs.JobSubmissionResponse
+	if err := s.agent.RPC("Job.GetJobSubmission", &args, &out); err != nil {
+		return nil, err
+	}
+
+	setMeta(resp, &out.QueryMeta)
+	if out.Submission == nil {
+		return nil, CodedError(404, "job source not found")
+	}
+
+	return out.Submission, nil
+}
+
 func (s *HTTPServer) jobCRUD(resp http.ResponseWriter, req *http.Request, jobID string) (interface{}, error) {
 	switch req.Method {
 	case "GET":
@@ -410,8 +450,13 @@ func (s *HTTPServer) jobUpdate(resp http.ResponseWriter, req *http.Request, jobI
 	}
 
 	sJob, writeReq := s.apiJobAndRequestToStructs(args.Job, req, args.WriteRequest)
+	maxSubmissionSize := s.agent.Server().GetConfig().JobMaxSourceSize
+	submission := apiJobSubmissionToStructs(args.Submission, maxSubmissionSize)
+
 	regReq := structs.JobRegisterRequest{
-		Job:            sJob,
+		Job:        sJob,
+		Submission: submission,
+
 		EnforceIndex:   args.EnforceIndex,
 		JobModifyIndex: args.JobModifyIndex,
 		PolicyOverride: args.PolicyOverride,
@@ -702,6 +747,37 @@ func (s *HTTPServer) jobDispatchRequest(resp http.ResponseWriter, req *http.Requ
 	return out, nil
 }
 
+// writeVariablesFile writes content to a temporary file that is to be read by
+// the hcl parser. If content is empty nothing is written and nil is returned.
+// The return value is otherwise a one element slice with the filename of the
+// temporary file. Also returned is a cleanup function that must be called by
+// the caller for removing the temporary file once it is no longer needed.
+func writeVariablesFile(content string) ([]string, func(), error) {
+	// nothing to do if there is no variables content
+	if content == "" {
+		return nil, func() {}, nil
+	}
+
+	// write variables content to a tmp file and return the filename and cleanup
+	// helper function for removing the tmp file
+	f, err := os.CreateTemp("", "hcl-") // uses 0600
+	if err != nil {
+		return nil, nil, err
+	}
+	if _, err = f.WriteString(content); err != nil {
+		return nil, nil, err
+	}
+	if err = f.Sync(); err != nil {
+		return nil, nil, err
+	}
+	if err = f.Close(); err != nil {
+		return nil, nil, err
+	}
+	return []string{f.Name()}, func() {
+		_ = os.Remove(f.Name())
+	}, nil
+}
+
 // JobsParseRequest parses a hcl jobspec and returns a api.Job
 func (s *HTTPServer) JobsParseRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if req.Method != http.MethodPut && req.Method != http.MethodPost {
@@ -739,11 +815,20 @@ func (s *HTTPServer) JobsParseRequest(resp http.ResponseWriter, req *http.Reques
 	if args.HCLv1 {
 		jobStruct, err = jobspec.Parse(strings.NewReader(args.JobHCL))
 	} else {
+		varsFile, cleanupVarsFile, varsErr := writeVariablesFile(args.Variables)
+		if varsErr != nil {
+			return nil, CodedError(400, "Failed to write HCL variables file")
+		}
+		defer cleanupVarsFile()
 		jobStruct, err = jobspec2.ParseWithConfig(&jobspec2.ParseConfig{
-			Path:    "input.hcl",
-			Body:    []byte(args.JobHCL),
-			AllowFS: false,
+			Path:     "input.hcl",
+			Body:     []byte(args.JobHCL),
+			AllowFS:  false,
+			VarFiles: varsFile,
 		})
+		if err != nil {
+			return nil, CodedError(400, fmt.Sprintf("Failed to parse job: %v", err))
+		}
 	}
 	if err != nil {
 		return nil, CodedError(400, err.Error())
@@ -785,6 +870,32 @@ func (s *HTTPServer) jobServiceRegistrations(resp http.ResponseWriter, req *http
 		return nil, CodedError(http.StatusNotFound, jobNotFoundErr)
 	}
 	return reply.Services, nil
+}
+
+func apiJobSubmissionToStructs(submission *api.JobSubmission, maxSize int) *structs.JobSubmission {
+	if submission == nil {
+		return nil
+	}
+
+	// discard the submission if the source + variables is larger than the maximum
+	// allowable size as set by client config
+	totalSize := len(submission.Source)
+	totalSize += len(submission.Variables)
+	for key, value := range submission.VariableFlags {
+		totalSize += len(key)
+		totalSize += len(value)
+	}
+
+	if totalSize > maxSize {
+		return nil
+	}
+
+	return &structs.JobSubmission{
+		Source:        submission.Source,
+		Format:        submission.Format,
+		VariableFlags: submission.VariableFlags,
+		Variables:     submission.Variables,
+	}
 }
 
 // apiJobAndRequestToStructs parses the query params from the incoming

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -449,8 +449,7 @@ func (s *HTTPServer) jobUpdate(resp http.ResponseWriter, req *http.Request, jobI
 	}
 
 	sJob, writeReq := s.apiJobAndRequestToStructs(args.Job, req, args.WriteRequest)
-	maxSubmissionSize := s.agent.Server().GetConfig().JobMaxSourceSize
-	submission := apiJobSubmissionToStructs(args.Submission, maxSubmissionSize)
+	submission := apiJobSubmissionToStructs(args.Submission)
 
 	regReq := structs.JobRegisterRequest{
 		Job:        sJob,
@@ -835,24 +834,10 @@ func (s *HTTPServer) jobServiceRegistrations(resp http.ResponseWriter, req *http
 	return reply.Services, nil
 }
 
-func apiJobSubmissionToStructs(submission *api.JobSubmission, maxSize int) *structs.JobSubmission {
+func apiJobSubmissionToStructs(submission *api.JobSubmission) *structs.JobSubmission {
 	if submission == nil {
 		return nil
 	}
-
-	// discard the submission if the source + variables is larger than the maximum
-	// allowable size as set by client config
-	totalSize := len(submission.Source)
-	totalSize += len(submission.Variables)
-	for key, value := range submission.VariableFlags {
-		totalSize += len(key)
-		totalSize += len(value)
-	}
-
-	if totalSize > maxSize {
-		return nil
-	}
-
 	return &structs.JobSubmission{
 		Source:        submission.Source,
 		Format:        submission.Format,

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"testing"
@@ -4032,32 +4030,5 @@ func TestConversion_ApiConsulConnectToStructs(t *testing.T) {
 		}, ApiConsulConnectToStructs(&api.ConsulConnect{
 			Native: true,
 		}))
-	})
-}
-
-func TestSubmission_writeVariablesFile(t *testing.T) {
-	// no parallel
-
-	tmpDir := t.TempDir()
-	t.Setenv("TMPDIR", tmpDir)
-
-	t.Run("no content", func(t *testing.T) {
-		files, cleanup, err := writeVariablesFile("")
-		must.NoError(t, err)
-		must.Nil(t, files)
-		cleanup() // noop
-	})
-
-	t.Run("with content", func(t *testing.T) {
-		files, cleanup, err := writeVariablesFile("key = value")
-		must.NoError(t, err)
-		fmt.Println("files", files, "tmpDir", tmpDir)
-		must.Eq(t, tmpDir, filepath.Dir(files[0]))
-		must.NotNil(t, cleanup)
-		must.FileContains(t, files[0], "key = value")
-		cleanup()
-		// todo: must.FileNotExist is broken
-		_, err = os.Stat(files[0])
-		must.ErrorContains(t, err, "no such file")
 	})
 }

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -3693,27 +3693,17 @@ func TestConversion_apiJobSubmissionToStructs(t *testing.T) {
 	ci.Parallel(t)
 
 	t.Run("nil", func(t *testing.T) {
-		result := apiJobSubmissionToStructs(nil, 0)
+		result := apiJobSubmissionToStructs(nil)
 		must.Nil(t, result)
 	})
 
-	t.Run("over max size", func(t *testing.T) {
+	t.Run("not nil", func(t *testing.T) {
 		result := apiJobSubmissionToStructs(&api.JobSubmission{
 			Source:        "source",
 			Format:        "hcl2",
 			VariableFlags: map[string]string{"foo": "bar"},
 			Variables:     "variable",
-		}, 1)
-		must.Nil(t, result)
-	})
-
-	t.Run("under max size", func(t *testing.T) {
-		result := apiJobSubmissionToStructs(&api.JobSubmission{
-			Source:        "source",
-			Format:        "hcl2",
-			VariableFlags: map[string]string{"foo": "bar"},
-			Variables:     "variable",
-		}, 1024)
+		})
 		must.Eq(t, &structs.JobSubmission{
 			Source:        "source",
 			Format:        "hcl2",

--- a/command/agent/search_endpoint_test.go
+++ b/command/agent/search_endpoint_test.go
@@ -22,7 +22,7 @@ func createJobForTest(jobID string, s *TestAgent, t *testing.T) {
 	job.ID = jobID
 	job.TaskGroups[0].Count = 1
 	state := s.Agent.server.State()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.NoError(t, err)
 }
 
@@ -58,7 +58,7 @@ func createCmdJobForTest(name, cmd string, s *TestAgent, t *testing.T) *structs.
 	job.TaskGroups[0].Tasks[0].Config["command"] = cmd
 	job.TaskGroups[0].Count = 1
 	state := s.Agent.server.State()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.NoError(t, err)
 	return job
 }

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -20,8 +20,13 @@ import (
 	"github.com/kr/text"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
-
 	"github.com/ryanuber/columnize"
+)
+
+const (
+	formatJSON = "json"
+	formatHCL1 = "hcl1"
+	formatHCL2 = "hcl2"
 )
 
 // maxLineLength is the maximum width of any line.
@@ -422,19 +427,11 @@ func (j *JobGetter) Validate() error {
 }
 
 // ApiJob returns the Job struct from jobfile.
-func (j *JobGetter) ApiJob(jpath string) (*api.Job, error) {
-	return j.ApiJobWithArgs(jpath, nil, nil, true)
-}
-
-func (j *JobGetter) ApiJobWithArgs(jpath string, vars []string, varfiles []string, strict bool) (*api.Job, error) {
-	j.Vars = vars
-	j.VarFiles = varfiles
-	j.Strict = strict
-
+func (j *JobGetter) ApiJob(jpath string) (*api.JobSubmission, *api.Job, error) {
 	return j.Get(jpath)
 }
 
-func (j *JobGetter) Get(jpath string) (*api.Job, error) {
+func (j *JobGetter) Get(jpath string) (*api.JobSubmission, *api.Job, error) {
 	var jobfile io.Reader
 	pathName := filepath.Base(jpath)
 	switch jpath {
@@ -447,23 +444,23 @@ func (j *JobGetter) Get(jpath string) (*api.Job, error) {
 		pathName = "stdin"
 	default:
 		if len(jpath) == 0 {
-			return nil, fmt.Errorf("Error jobfile path has to be specified.")
+			return nil, nil, fmt.Errorf("Error jobfile path has to be specified.")
 		}
 
 		jobFile, err := os.CreateTemp("", "jobfile")
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		defer os.Remove(jobFile.Name())
 
 		if err := jobFile.Close(); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		// Get the pwd
 		pwd, err := os.Getwd()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		client := &gg.Client{
@@ -476,11 +473,11 @@ func (j *JobGetter) Get(jpath string) (*api.Job, error) {
 		}
 
 		if err := client.Get(); err != nil {
-			return nil, fmt.Errorf("Error getting jobfile from %q: %v", jpath, err)
+			return nil, nil, fmt.Errorf("Error getting jobfile from %q: %v", jpath, err)
 		} else {
 			file, err := os.Open(jobFile.Name())
 			if err != nil {
-				return nil, fmt.Errorf("Error opening file %q: %v", jpath, err)
+				return nil, nil, fmt.Errorf("Error opening file %q: %v", jpath, err)
 			}
 			defer file.Close()
 			jobfile = file
@@ -488,12 +485,22 @@ func (j *JobGetter) Get(jpath string) (*api.Job, error) {
 	}
 
 	// Parse the JobFile
-	var jobStruct *api.Job
+	var jobStruct *api.Job               // deserialized destination
+	var source bytes.Buffer              // tee the original
+	var jobSubmission *api.JobSubmission // store the original and format
+	jobfile = io.TeeReader(jobfile, &source)
 	var err error
 	switch {
 	case j.HCL1:
 		jobStruct, err = jobspec.Parse(jobfile)
+
+		// include the hcl1 source as the submission
+		jobSubmission = &api.JobSubmission{
+			Source: source.String(),
+			Format: formatHCL1,
+		}
 	case j.JSON:
+
 		// Support JSON files with both a top-level Job key as well as
 		// ones without.
 		eitherJob := struct {
@@ -502,7 +509,7 @@ func (j *JobGetter) Get(jpath string) (*api.Job, error) {
 		}{}
 
 		if err := json.NewDecoder(jobfile).Decode(&eitherJob); err != nil {
-			return nil, fmt.Errorf("Failed to parse JSON job: %w", err)
+			return nil, nil, fmt.Errorf("Failed to parse JSON job: %w", err)
 		}
 
 		if eitherJob.NestedJob != nil {
@@ -510,15 +517,21 @@ func (j *JobGetter) Get(jpath string) (*api.Job, error) {
 		} else {
 			jobStruct = &eitherJob.Job
 		}
-	default:
-		var buf bytes.Buffer
-		_, err = io.Copy(&buf, jobfile)
-		if err != nil {
-			return nil, fmt.Errorf("Error reading job file from %s: %v", jpath, err)
+
+		// include the json source as the submission
+		jobSubmission = &api.JobSubmission{
+			Source: source.String(),
+			Format: formatJSON,
 		}
+	default:
+		if _, err = io.Copy(&source, jobfile); err != nil {
+			return nil, nil, fmt.Errorf("Failed to parse HCL job: %w", err)
+		}
+
+		// we are parsing HCL2, whether from a file or stdio
 		jobStruct, err = jobspec2.ParseWithConfig(&jobspec2.ParseConfig{
 			Path:     pathName,
-			Body:     buf.Bytes(),
+			Body:     source.Bytes(),
 			ArgVars:  j.Vars,
 			AllowFS:  true,
 			VarFiles: j.VarFiles,
@@ -526,18 +539,39 @@ func (j *JobGetter) Get(jpath string) (*api.Job, error) {
 			Strict:   j.Strict,
 		})
 
+		// submit the job with the submission with content from -var flags
+		jobSubmission = &api.JobSubmission{
+			VariableFlags: extractVarFlags(j.Vars),
+			Source:        source.String(),
+			Format:        formatHCL2,
+		}
 		if err != nil {
-			if _, merr := jobspec.Parse(&buf); merr == nil {
-				return nil, fmt.Errorf("Failed to parse using HCL 2. Use the HCL 1 parser with `nomad run -hcl1`, or address the following issues:\n%v", err)
+			if _, merr := jobspec.Parse(&source); merr == nil {
+				return nil, nil, fmt.Errorf("Failed to parse using HCL 2. Use the HCL 1 parser with `nomad run -hcl1`, or address the following issues:\n%v", err)
 			}
 		}
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing job file from %s:\n%v", jpath, err)
+		return nil, nil, fmt.Errorf("Error parsing job file from %s:\n%v", jpath, err)
 	}
 
-	return jobStruct, nil
+	return jobSubmission, jobStruct, nil
+}
+
+// extractVarFlags is used to parse the values of -var command line arguments
+// and turn them into a map to be used for submission. The result is never
+// nil for convenience.
+func extractVarFlags(slice []string) map[string]string {
+	m := make(map[string]string, len(slice))
+	for _, s := range slice {
+		if tokens := strings.SplitN(s, "=", 2); len(tokens) == 1 {
+			m[tokens[0]] = ""
+		} else {
+			m[tokens[0]] = tokens[1]
+		}
+	}
+	return m
 }
 
 // mergeAutocompleteFlags is used to join multiple flag completion sets.

--- a/command/helpers_test.go
+++ b/command/helpers_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/kr/pretty"
 	"github.com/mitchellh/cli"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
 
@@ -268,7 +269,7 @@ func TestJobGetter_LocalFile(t *testing.T) {
 	}
 
 	j := &JobGetter{}
-	aj, err := j.ApiJob(fh.Name())
+	_, aj, err := j.ApiJob(fh.Name())
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -315,7 +316,7 @@ func TestJobGetter_LocalFile_InvalidHCL2(t *testing.T) {
 			require.NoError(t, err)
 
 			j := &JobGetter{}
-			_, err = j.ApiJob(fh.Name())
+			_, _, err = j.ApiJob(fh.Name())
 			require.Error(t, err)
 
 			exptMessage := "Failed to parse using HCL 2. Use the HCL 1"
@@ -366,7 +367,13 @@ job "example" {
 	_, err = vf.WriteString(fileVars + "\n")
 	require.NoError(t, err)
 
-	j, err := (&JobGetter{}).ApiJobWithArgs(hclf.Name(), cliArgs, []string{vf.Name()}, true)
+	jg := &JobGetter{
+		Vars:     cliArgs,
+		VarFiles: []string{vf.Name()},
+		Strict:   true,
+	}
+
+	_, j, err := jg.Get(hclf.Name())
 	require.NoError(t, err)
 
 	require.NotNil(t, j)
@@ -415,7 +422,13 @@ unsedVar2 = "from-varfile"
 	_, err = vf.WriteString(fileVars + "\n")
 	require.NoError(t, err)
 
-	j, err := (&JobGetter{}).ApiJobWithArgs(hclf.Name(), cliArgs, []string{vf.Name()}, false)
+	jg := &JobGetter{
+		Vars:     cliArgs,
+		VarFiles: []string{vf.Name()},
+		Strict:   false,
+	}
+
+	_, j, err := jg.Get(hclf.Name())
 	require.NoError(t, err)
 
 	require.NotNil(t, j)
@@ -434,7 +447,7 @@ func TestJobGetter_HTTPServer(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	j := &JobGetter{}
-	aj, err := j.ApiJob("http://127.0.0.1:12345/")
+	_, aj, err := j.ApiJob("http://127.0.0.1:12345/")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -611,4 +624,22 @@ func TestUiErrorWriter(t *testing.T) {
 
 	expectedErr += "and thensome more\n"
 	require.Equal(t, expectedErr, errBuf.String())
+}
+
+func Test_extractVarFlags(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("nil", func(t *testing.T) {
+		result := extractVarFlags(nil)
+		must.MapEmpty(t, result)
+	})
+
+	t.Run("complete", func(t *testing.T) {
+		result := extractVarFlags([]string{"one=1", "two=2", "three"})
+		must.Eq(t, map[string]string{
+			"one":   "1",
+			"two":   "2",
+			"three": "",
+		}, result)
+	})
 }

--- a/command/job_allocs_test.go
+++ b/command/job_allocs_test.go
@@ -63,7 +63,7 @@ func TestJobAllocsCommand_Run(t *testing.T) {
 	// Create a job without an allocation
 	job := mock.Job()
 	state := srv.Agent.Server().State()
-	require.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 100, job))
+	require.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job))
 
 	// Should display no match if the job doesn't have allocations
 	code := cmd.Run([]string{"-address=" + url, job.ID})
@@ -106,7 +106,7 @@ func TestJobAllocsCommand_Template(t *testing.T) {
 	// Create a job
 	job := mock.Job()
 	state := srv.Agent.Server().State()
-	require.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 100, job))
+	require.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job))
 
 	// Inject a running allocation
 	a := mock.Alloc()
@@ -165,7 +165,7 @@ func TestJobAllocsCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	require.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
+	require.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}
@@ -188,7 +188,7 @@ func TestJobAllocsCommand_ACL(t *testing.T) {
 	// Create a job with an alloc.
 	job := mock.Job()
 	state := srv.Agent.Server().State()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job)
 	must.NoError(t, err)
 
 	a := mock.Alloc()

--- a/command/job_deployments_test.go
+++ b/command/job_deployments_test.go
@@ -61,7 +61,7 @@ func TestJobDeploymentsCommand_Run(t *testing.T) {
 	// Create a job without a deployment
 	job := mock.Job()
 	state := srv.Agent.Server().State()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 100, job))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job))
 
 	// Should display no match if the job doesn't have deployments
 	if code := cmd.Run([]string{"-address=" + url, job.ID}); code != 0 {
@@ -105,7 +105,7 @@ func TestJobDeploymentsCommand_Run_Latest(t *testing.T) {
 	// Create a job without a deployment
 	job := mock.Job()
 	state := srv.Agent.Server().State()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 100, job))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job))
 
 	// Should display no match if the job doesn't have deployments
 	if code := cmd.Run([]string{"-address=" + url, "-latest", job.ID}); code != 0 {
@@ -145,7 +145,7 @@ func TestJobDeploymentsCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}
@@ -168,7 +168,7 @@ func TestJobDeploymentsCommand_ACL(t *testing.T) {
 	// Create a job with a deployment.
 	job := mock.Job()
 	state := srv.Agent.Server().State()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job)
 	must.NoError(t, err)
 
 	d := mock.Deployment()

--- a/command/job_dispatch_test.go
+++ b/command/job_dispatch_test.go
@@ -64,7 +64,7 @@ func TestJobDispatchCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	require.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
+	require.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}
@@ -77,7 +77,7 @@ func TestJobDispatchCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake parameterized job
 	j1 := mock.Job()
 	j1.ParameterizedJob = &structs.ParameterizedJobConfig{}
-	require.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 2000, j1))
+	require.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 2000, nil, j1))
 
 	prefix = j1.ID[:len(j1.ID)-5]
 	args = complete.Args{Last: prefix}
@@ -103,7 +103,7 @@ func TestJobDispatchCommand_ACL(t *testing.T) {
 	job.Type = "batch"
 	job.ParameterizedJob = &structs.ParameterizedJobConfig{}
 	state := srv.Agent.Server().State()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job)
 	must.NoError(t, err)
 
 	testCases := []struct {

--- a/command/job_eval_test.go
+++ b/command/job_eval_test.go
@@ -77,7 +77,7 @@ func TestJobEvalCommand_Run(t *testing.T) {
 
 	// Create a job
 	job := mock.Job()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 11, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 11, nil, job)
 	require.Nil(err)
 
 	job, err = state.JobByID(nil, structs.DefaultNamespace, job.ID)
@@ -118,7 +118,7 @@ func TestJobEvalCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}
@@ -141,7 +141,7 @@ func TestJobEvalCommand_ACL(t *testing.T) {
 	// Create a job.
 	job := mock.MinJob()
 	state := srv.Agent.Server().State()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job)
 	must.NoError(t, err)
 
 	testCases := []struct {

--- a/command/job_history_test.go
+++ b/command/job_history_test.go
@@ -56,7 +56,7 @@ func TestJobHistoryCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}
@@ -79,7 +79,7 @@ func TestJobHistoryCommand_ACL(t *testing.T) {
 	// Create a job.
 	job := mock.MinJob()
 	state := srv.Agent.Server().State()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job)
 	must.NoError(t, err)
 
 	testCases := []struct {

--- a/command/job_inspect_test.go
+++ b/command/job_inspect_test.go
@@ -76,7 +76,7 @@ func TestInspectCommand_AutocompleteArgs(t *testing.T) {
 
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}
@@ -99,7 +99,7 @@ func TestJobInspectCommand_ACL(t *testing.T) {
 	// Create a job
 	job := mock.MinJob()
 	state := srv.Agent.Server().State()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job)
 	must.NoError(t, err)
 
 	testCases := []struct {

--- a/command/job_periodic_force_test.go
+++ b/command/job_periodic_force_test.go
@@ -52,7 +52,7 @@ func TestJobPeriodicForceCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job, not periodic
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j))
 
 	predictor := cmd.AutocompleteArgs()
 
@@ -69,7 +69,7 @@ func TestJobPeriodicForceCommand_AutocompleteArgs(t *testing.T) {
 		ProhibitOverlap: true,
 		TimeZone:        "test zone",
 	}
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, j2))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j2))
 
 	res = predictor.Predict(complete.Args{Last: j2.ID[:len(j.ID)-5]})
 	require.Equal(t, []string{j2.ID}, res)

--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -194,7 +194,7 @@ func (c *JobPlanCommand) Run(args []string) int {
 
 	path := args[0]
 	// Get Job struct from Jobfile
-	job, err := c.JobGetter.Get(path)
+	_, job, err := c.JobGetter.Get(path)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error getting job struct: %s", err))
 		return 255

--- a/command/job_promote_test.go
+++ b/command/job_promote_test.go
@@ -57,7 +57,7 @@ func TestJobPromoteCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}
@@ -80,7 +80,7 @@ func TestJobPromoteCommand_ACL(t *testing.T) {
 	// Create a job.
 	job := mock.MinJob()
 	state := srv.Agent.Server().State()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job)
 	must.NoError(t, err)
 
 	testCases := []struct {

--- a/command/job_revert_test.go
+++ b/command/job_revert_test.go
@@ -56,7 +56,7 @@ func TestJobRevertCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}
@@ -155,7 +155,7 @@ namespace "default" {
 			// Create a job.
 			job := mock.MinJob()
 			state := srv.Agent.Server().State()
-			err := state.UpsertJob(structs.MsgTypeTestSetup, uint64(300+i), job)
+			err := state.UpsertJob(structs.MsgTypeTestSetup, uint64(300+i), nil, job)
 			must.NoError(t, err)
 			defer func() {
 				client.Jobs().Deregister(job.ID, true, &api.WriteOptions{
@@ -169,7 +169,7 @@ namespace "default" {
 				"test": tc.name,
 			}
 			newJob.Version = uint64(i)
-			err = state.UpsertJob(structs.MsgTypeTestSetup, uint64(301+i), newJob)
+			err = state.UpsertJob(structs.MsgTypeTestSetup, uint64(301+i), nil, newJob)
 			must.NoError(t, err)
 
 			if tc.aclPolicy != "" {

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -233,7 +233,7 @@ func (c *JobRunCommand) Run(args []string) int {
 	}
 
 	// Get Job struct from Jobfile
-	job, err := c.JobGetter.Get(args[0])
+	sub, job, err := c.JobGetter.Get(args[0])
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error getting job struct: %s", err))
 		return 1
@@ -317,6 +317,7 @@ func (c *JobRunCommand) Run(args []string) int {
 		PolicyOverride: override,
 		PreserveCounts: preserveCounts,
 		EvalPriority:   evalPriority,
+		Submission:     sub,
 	}
 	if enforce {
 		opts.EnforceIndex = true

--- a/command/job_scale_test.go
+++ b/command/job_scale_test.go
@@ -241,7 +241,7 @@ namespace "default" {
 			// Create a job.
 			job := mock.MinJob()
 			state := srv.Agent.Server().State()
-			err := state.UpsertJob(structs.MsgTypeTestSetup, uint64(300+i), job)
+			err := state.UpsertJob(structs.MsgTypeTestSetup, uint64(300+i), nil, job)
 			must.NoError(t, err)
 			defer func() {
 				client.Jobs().Deregister(job.ID, true, &api.WriteOptions{

--- a/command/job_scaling_events_test.go
+++ b/command/job_scaling_events_test.go
@@ -107,7 +107,7 @@ func TestJobScalingEventsCommand_ACL(t *testing.T) {
 	// Create a job.
 	job := mock.MinJob()
 	state := srv.Agent.Server().State()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job)
 	must.NoError(t, err)
 
 	testCases := []struct {

--- a/command/job_status_test.go
+++ b/command/job_status_test.go
@@ -262,7 +262,7 @@ func TestJobStatusCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}
@@ -369,7 +369,7 @@ func TestJobStatusCommand_RescheduleEvals(t *testing.T) {
 
 	// Create state store objects for job, alloc and followup eval with a future WaitUntil value
 	j := mock.Job()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 900, j))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 900, nil, j))
 
 	e := mock.Eval()
 	e.WaitUntil = time.Now().Add(1 * time.Hour)
@@ -405,7 +405,7 @@ func TestJobStatusCommand_ACL(t *testing.T) {
 	// Create a job.
 	job := mock.MinJob()
 	state := srv.Agent.Server().State()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job)
 	must.NoError(t, err)
 
 	testCases := []struct {

--- a/command/job_stop_test.go
+++ b/command/job_stop_test.go
@@ -139,7 +139,7 @@ func TestStopCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j))
 
 	prefix := j.ID[:len(j.ID)-5]
 	args := complete.Args{Last: prefix}
@@ -229,7 +229,7 @@ namespace "default" {
 			// Create a job.
 			job := mock.MinJob()
 			state := srv.Agent.Server().State()
-			err := state.UpsertJob(structs.MsgTypeTestSetup, uint64(300+i), job)
+			err := state.UpsertJob(structs.MsgTypeTestSetup, uint64(300+i), nil, job)
 			must.NoError(t, err)
 			defer func() {
 				client.Jobs().Deregister(job.ID, true, &api.WriteOptions{

--- a/command/job_validate.go
+++ b/command/job_validate.go
@@ -141,7 +141,7 @@ func (c *JobValidateCommand) Run(args []string) int {
 	}
 
 	// Get Job struct from Jobfile
-	job, err := c.JobGetter.Get(args[0])
+	_, job, err := c.JobGetter.Get(args[0])
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error getting job struct: %s", err))
 		return 1

--- a/command/status_test.go
+++ b/command/status_test.go
@@ -29,7 +29,7 @@ func TestStatusCommand_Run_JobStatus(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	j := mock.Job()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j))
 
 	// Query to check the job status
 	if code := cmd.Run([]string{"-address=" + url, j.ID}); code != 0 {
@@ -57,8 +57,8 @@ func TestStatusCommand_Run_JobStatus_MultiMatch(t *testing.T) {
 	j := mock.Job()
 	j2 := mock.Job()
 	j2.ID = fmt.Sprintf("%s-more", j.ID)
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j))
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1001, j2))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, j2))
 
 	// Query to check the job status
 	if code := cmd.Run([]string{"-address=" + url, j.ID}); code != 0 {
@@ -201,7 +201,7 @@ func TestStatusCommand_Run_NoPrefix(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	job := mock.Job()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, job))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job))
 
 	// Query to check status
 	if code := cmd.Run([]string{"-address=" + url}); code != 0 {
@@ -227,7 +227,7 @@ func TestStatusCommand_AutocompleteArgs(t *testing.T) {
 	// Create a fake job
 	state := srv.Agent.Server().State()
 	job := mock.Job()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, job))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job))
 
 	prefix := job.ID[:len(job.ID)-5]
 	args := complete.Args{Last: prefix}

--- a/jobspec2/parse.go
+++ b/jobspec2/parse.go
@@ -56,7 +56,7 @@ type ParseConfig struct {
 	// Body is the HCL body
 	Body []byte
 
-	// AllowFS enables HCL functions that require file system accecss
+	// AllowFS enables HCL functions that require file system access
 	AllowFS bool
 
 	// ArgVars is the CLI -var arguments

--- a/jobspec2/parse.go
+++ b/jobspec2/parse.go
@@ -62,8 +62,13 @@ type ParseConfig struct {
 	// ArgVars is the CLI -var arguments
 	ArgVars []string
 
-	// VarFiles is the paths of variable data files
+	// VarFiles is the paths of variable data files that should be read during
+	// parsing.
 	VarFiles []string
+
+	// VarContent is the content of variable data known without reading an
+	// actual var file during parsing.
+	VarContent string
 
 	// Envs represent process environment variable
 	Envs []string
@@ -93,6 +98,14 @@ func decode(c *jobConfig) error {
 
 		config.parsedVarFiles = append(config.parsedVarFiles, parsedVarFile)
 		diags = append(diags, ds...)
+	}
+
+	if config.VarContent != "" {
+		hclFile, hclDiagnostics := parseHCLOrJSON([]byte(config.VarContent), "input.hcl")
+		if hclDiagnostics.HasErrors() {
+			return fmt.Errorf("unable to parse var content: %v", hclDiagnostics.Error())
+		}
+		config.parsedVarFiles = append(config.parsedVarFiles, hclFile)
 	}
 
 	// Return early if the input job or variable files are not valid.

--- a/nomad/client_alloc_endpoint_test.go
+++ b/nomad/client_alloc_endpoint_test.go
@@ -324,7 +324,7 @@ func TestClientAllocations_GarbageCollect_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state.UpsertJob(nstructs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*nstructs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -382,7 +382,7 @@ func TestClientAllocations_GarbageCollect_Local_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(nstructs.MsgTypeTestSetup, 1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(nstructs.MsgTypeTestSetup, 1010, nil, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1011, []*nstructs.Allocation{alloc}))
 
 	cases := []struct {
@@ -492,9 +492,9 @@ func TestClientAllocations_GarbageCollect_Remote(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state1.UpsertJob(nstructs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state1.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*nstructs.Allocation{a}))
-	require.Nil(state2.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state2.UpsertJob(nstructs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state2.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*nstructs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -613,7 +613,7 @@ func TestClientAllocations_Stats_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state.UpsertJob(nstructs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*nstructs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -672,7 +672,7 @@ func TestClientAllocations_Stats_Local_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(nstructs.MsgTypeTestSetup, 1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(nstructs.MsgTypeTestSetup, 1010, nil, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1011, []*nstructs.Allocation{alloc}))
 
 	cases := []struct {
@@ -769,9 +769,9 @@ func TestClientAllocations_Stats_Remote(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state1.UpsertJob(nstructs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state1.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*nstructs.Allocation{a}))
-	require.Nil(state2.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state2.UpsertJob(nstructs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state2.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*nstructs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -853,7 +853,7 @@ func TestClientAllocations_Restart_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state.UpsertJob(nstructs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*nstructs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -967,9 +967,9 @@ func TestClientAllocations_Restart_Remote(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state1.UpsertJob(nstructs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state1.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*nstructs.Allocation{a}))
-	require.Nil(state2.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state2.UpsertJob(nstructs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state2.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*nstructs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -1028,7 +1028,7 @@ func TestClientAllocations_Restart_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(nstructs.MsgTypeTestSetup, 1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(nstructs.MsgTypeTestSetup, 1010, nil, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(nstructs.MsgTypeTestSetup, 1011, []*nstructs.Allocation{alloc}))
 
 	cases := []struct {
@@ -1136,10 +1136,10 @@ func TestAlloc_ExecStreaming(t *testing.T) {
 
 	// Upsert the allocation
 	localState := localServer.State()
-	require.Nil(t, localState.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(t, localState.UpsertJob(nstructs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(t, localState.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*nstructs.Allocation{a}))
 	remoteState := remoteServer.State()
-	require.Nil(t, remoteState.UpsertJob(nstructs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(t, remoteState.UpsertJob(nstructs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(t, remoteState.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*nstructs.Allocation{a}))
 
 	// Wait for the client to run the allocation

--- a/nomad/client_fs_endpoint_test.go
+++ b/nomad/client_fs_endpoint_test.go
@@ -65,7 +65,7 @@ func TestClientFS_List_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -125,7 +125,7 @@ func TestClientFS_List_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, nil, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
@@ -225,9 +225,9 @@ func TestClientFS_List_Remote(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
-	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -341,7 +341,7 @@ func TestClientFS_Stat_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -401,7 +401,7 @@ func TestClientFS_Stat_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, nil, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
@@ -501,9 +501,9 @@ func TestClientFS_Stat_Remote(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
-	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -633,7 +633,7 @@ func TestClientFS_Streaming_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, nil, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
@@ -774,7 +774,7 @@ func TestClientFS_Streaming_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -910,7 +910,7 @@ func TestClientFS_Streaming_Local_Follow(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -1053,9 +1053,9 @@ func TestClientFS_Streaming_Remote_Server(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
-	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -1199,7 +1199,7 @@ func TestClientFS_Streaming_Remote_Region(t *testing.T) {
 
 	// Upsert the allocation
 	state2 := s2.State()
-	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -1462,7 +1462,7 @@ func TestClientFS_Logs_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, nil, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	cases := []struct {
@@ -1603,7 +1603,7 @@ func TestClientFS_Logs_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -1740,7 +1740,7 @@ func TestClientFS_Logs_Local_Follow(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -1884,9 +1884,9 @@ func TestClientFS_Logs_Remote_Server(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
-	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation
@@ -2031,7 +2031,7 @@ func TestClientFS_Logs_Remote_Region(t *testing.T) {
 
 	// Upsert the allocation
 	state2 := s2.State()
-	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, a.Job))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
 	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
 
 	// Wait for the client to run the allocation

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -64,6 +64,11 @@ type Config struct {
 	// EventBufferSize is the amount of events to hold in memory.
 	EventBufferSize int64
 
+	// JobMaxSourceSize limits the maximum size of a jobs source hcl/json
+	// before being discarded automatically. A value of zero indicates no job
+	// sources will be stored.
+	JobMaxSourceSize int
+
 	// LogOutput is the location to write logs to. If this is not set,
 	// logs will go to stderr.
 	LogOutput io.Writer

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -44,7 +44,7 @@ func TestCoreScheduler_EvalGC(t *testing.T) {
 		Attempts: 0,
 		Interval: 0 * time.Second,
 	}
-	err = store.UpsertJob(structs.MsgTypeTestSetup, 1001, job)
+	err = store.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job)
 	require.Nil(t, err)
 
 	// Insert "dead" alloc
@@ -141,7 +141,7 @@ func TestCoreScheduler_EvalGC_ReschedulingAllocs(t *testing.T) {
 	job := mock.Job()
 	job.ID = eval.JobID
 
-	err = store.UpsertJob(structs.MsgTypeTestSetup, 1001, job)
+	err = store.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job)
 	require.Nil(t, err)
 
 	// Insert failed alloc with an old reschedule attempt, can be GCed
@@ -239,7 +239,7 @@ func TestCoreScheduler_EvalGC_StoppedJob_Reschedulable(t *testing.T) {
 	job.ID = eval.JobID
 	job.Stop = true
 
-	err = store.UpsertJob(structs.MsgTypeTestSetup, 1001, job)
+	err = store.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job)
 	require.Nil(t, err)
 
 	// Insert failed alloc with a recent reschedule attempt
@@ -318,7 +318,7 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 		Attempts: 0,
 		Interval: 0 * time.Second,
 	}
-	err := store.UpsertJob(structs.MsgTypeTestSetup, jobModifyIdx+1, stoppedJob)
+	err := store.UpsertJob(structs.MsgTypeTestSetup, jobModifyIdx+1, nil, stoppedJob)
 	must.NoError(t, err)
 
 	stoppedJobEval := mock.Eval()
@@ -352,7 +352,7 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 	deadJob := mock.Job()
 	deadJob.Type = structs.JobTypeBatch
 	deadJob.Status = structs.JobStatusDead
-	err = store.UpsertJob(structs.MsgTypeTestSetup, jobModifyIdx, deadJob)
+	err = store.UpsertJob(structs.MsgTypeTestSetup, jobModifyIdx, nil, deadJob)
 	must.NoError(t, err)
 
 	deadJobEval := mock.Eval()
@@ -390,7 +390,7 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 	activeJob := mock.Job()
 	activeJob.Type = structs.JobTypeBatch
 	activeJob.Status = structs.JobStatusDead
-	err = store.UpsertJob(structs.MsgTypeTestSetup, jobModifyIdx, activeJob)
+	err = store.UpsertJob(structs.MsgTypeTestSetup, jobModifyIdx, nil, activeJob)
 	must.NoError(t, err)
 
 	activeJobEval := mock.Eval()
@@ -438,7 +438,7 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 	purgedJob := mock.Job()
 	purgedJob.Type = structs.JobTypeBatch
 	purgedJob.Status = structs.JobStatusDead
-	err = store.UpsertJob(structs.MsgTypeTestSetup, jobModifyIdx, purgedJob)
+	err = store.UpsertJob(structs.MsgTypeTestSetup, jobModifyIdx, nil, purgedJob)
 	must.NoError(t, err)
 
 	purgedJobEval := mock.Eval()
@@ -670,7 +670,7 @@ func TestCoreScheduler_EvalGC_Partial(t *testing.T) {
 		Attempts: 0,
 		Interval: 0 * time.Second,
 	}
-	err = store.UpsertJob(structs.MsgTypeTestSetup, 1001, job)
+	err = store.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job)
 	require.Nil(t, err)
 
 	// Update the time tables to make this work
@@ -761,7 +761,7 @@ func TestCoreScheduler_EvalGC_Force(t *testing.T) {
 				Attempts: 0,
 				Interval: 0 * time.Second,
 			}
-			err = store.UpsertJob(structs.MsgTypeTestSetup, 1001, job)
+			err = store.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job)
 			require.Nil(t, err)
 
 			// Insert "dead" alloc
@@ -1040,7 +1040,7 @@ func TestCoreScheduler_JobGC_OutstandingEvals(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.Status = structs.JobStatusDead
-	err := store.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := store.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1168,7 +1168,7 @@ func TestCoreScheduler_JobGC_OutstandingAllocs(t *testing.T) {
 		Attempts: 0,
 		Interval: 0 * time.Second,
 	}
-	err := store.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := store.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1309,7 +1309,7 @@ func TestCoreScheduler_JobGC_OneShot(t *testing.T) {
 	store := s1.fsm.State()
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
-	err := store.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := store.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1426,7 +1426,7 @@ func TestCoreScheduler_JobGC_Stopped(t *testing.T) {
 		Attempts: 0,
 		Interval: 0 * time.Second,
 	}
-	err := store.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := store.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1531,7 +1531,7 @@ func TestCoreScheduler_JobGC_Force(t *testing.T) {
 			job := mock.Job()
 			job.Type = structs.JobTypeBatch
 			job.Status = structs.JobStatusDead
-			err := store.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+			err := store.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -1599,7 +1599,7 @@ func TestCoreScheduler_JobGC_Parameterized(t *testing.T) {
 	job.ParameterizedJob = &structs.ParameterizedJobConfig{
 		Payload: structs.DispatchPayloadRequired,
 	}
-	err := store.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := store.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1631,7 +1631,7 @@ func TestCoreScheduler_JobGC_Parameterized(t *testing.T) {
 	// Mark the job as stopped and try again
 	job2 := job.Copy()
 	job2.Stop = true
-	err = store.UpsertJob(structs.MsgTypeTestSetup, 2000, job2)
+	err = store.UpsertJob(structs.MsgTypeTestSetup, 2000, nil, job2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1674,7 +1674,7 @@ func TestCoreScheduler_JobGC_Periodic(t *testing.T) {
 	// Insert a parameterized job.
 	store := s1.fsm.State()
 	job := mock.PeriodicJob()
-	err := store.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := store.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1706,7 +1706,7 @@ func TestCoreScheduler_JobGC_Periodic(t *testing.T) {
 	// Mark the job as stopped and try again
 	job2 := job.Copy()
 	job2.Stop = true
-	err = store.UpsertJob(structs.MsgTypeTestSetup, 2000, job2)
+	err = store.UpsertJob(structs.MsgTypeTestSetup, 2000, nil, job2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2311,7 +2311,7 @@ func TestCoreScheduler_CSIVolumeClaimGC(t *testing.T) {
 	job.ID = eval.JobID
 	job.Status = structs.JobStatusRunning
 	index++
-	err = store.UpsertJob(structs.MsgTypeTestSetup, index, job)
+	err = store.UpsertJob(structs.MsgTypeTestSetup, index, nil, job)
 	require.NoError(t, err)
 
 	alloc1, alloc2 := mock.Alloc(), mock.Alloc()

--- a/nomad/deployment_endpoint_test.go
+++ b/nomad/deployment_endpoint_test.go
@@ -32,7 +32,7 @@ func TestDeploymentEndpoint_GetDeployment(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Lookup the deployments
@@ -64,7 +64,7 @@ func TestDeploymentEndpoint_GetDeployment_ACL(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Create the namespace policy and tokens
@@ -121,8 +121,8 @@ func TestDeploymentEndpoint_GetDeployment_Blocking(t *testing.T) {
 	d2 := mock.Deployment()
 	d2.JobID = j2.ID
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 98, j1), "UpsertJob")
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 99, j2), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 98, nil, j1), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 99, nil, j2), "UpsertJob")
 
 	// Upsert a deployment we are not interested in first.
 	time.AfterFunc(100*time.Millisecond, func() {
@@ -170,7 +170,7 @@ func TestDeploymentEndpoint_Fail(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Mark the deployment as failed
@@ -220,7 +220,7 @@ func TestDeploymentEndpoint_Fail_ACL(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Create the namespace policy and tokens
@@ -297,7 +297,7 @@ func TestDeploymentEndpoint_Fail_Rollback(t *testing.T) {
 	j.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
 	j.TaskGroups[0].Update.MaxParallel = 2
 	j.TaskGroups[0].Update.AutoRevert = true
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, nil, j), "UpsertJob")
 
 	// Create the second job, deployment and alloc
 	j2 := j.Copy()
@@ -314,7 +314,7 @@ func TestDeploymentEndpoint_Fail_Rollback(t *testing.T) {
 	a.JobID = j.ID
 	a.DeploymentID = d.ID
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j2), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j2), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -374,7 +374,7 @@ func TestDeploymentEndpoint_Pause(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Mark the deployment as failed
@@ -417,7 +417,7 @@ func TestDeploymentEndpoint_Pause_ACL(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Create the namespace policy and tokens
@@ -496,7 +496,7 @@ func TestDeploymentEndpoint_Promote(t *testing.T) {
 	}
 
 	state := s1.fsm.State()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -561,7 +561,7 @@ func TestDeploymentEndpoint_Promote_ACL(t *testing.T) {
 	}
 
 	state := s1.fsm.State()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -647,7 +647,7 @@ func TestDeploymentEndpoint_SetAllocHealth(t *testing.T) {
 	a.DeploymentID = d.ID
 
 	state := s1.fsm.State()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -715,7 +715,7 @@ func TestDeploymentEndpoint_SetAllocHealth_ACL(t *testing.T) {
 	a.DeploymentID = d.ID
 
 	state := s1.fsm.State()
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -805,7 +805,7 @@ func TestDeploymentEndpoint_SetAllocHealth_Rollback(t *testing.T) {
 	j.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
 	j.TaskGroups[0].Update.MaxParallel = 2
 	j.TaskGroups[0].Update.AutoRevert = true
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, nil, j), "UpsertJob")
 
 	// Create the second job, deployment and alloc
 	j2 := j.Copy()
@@ -821,7 +821,7 @@ func TestDeploymentEndpoint_SetAllocHealth_Rollback(t *testing.T) {
 	a.JobID = j.ID
 	a.DeploymentID = d.ID
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j2), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j2), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -895,7 +895,7 @@ func TestDeploymentEndpoint_SetAllocHealth_NoRollback(t *testing.T) {
 	j.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
 	j.TaskGroups[0].Update.MaxParallel = 2
 	j.TaskGroups[0].Update.AutoRevert = true
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, nil, j), "UpsertJob")
 
 	// Create the second job, deployment and alloc. Job has same spec as original
 	j2 := j.Copy()
@@ -910,7 +910,7 @@ func TestDeploymentEndpoint_SetAllocHealth_NoRollback(t *testing.T) {
 	a.JobID = j.ID
 	a.DeploymentID = d.ID
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j2), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j2), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -979,7 +979,7 @@ func TestDeploymentEndpoint_List(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Lookup the deployments
@@ -1018,7 +1018,7 @@ func TestDeploymentEndpoint_List(t *testing.T) {
 	d2.Namespace = "prod"
 	d2.JobID = j2.ID
 	assert.Nil(state.UpsertNamespaces(1001, []*structs.Namespace{{Name: "prod"}}))
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1002, j2), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1002, nil, j2), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1003, d2), "UpsertDeployment")
 
 	// Lookup the deployments with wildcard namespace
@@ -1136,7 +1136,7 @@ func TestDeploymentEndpoint_List_ACL(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 	// Create the namespace policy and tokens
@@ -1205,7 +1205,7 @@ func TestDeploymentEndpoint_List_Blocking(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), "UpsertJob")
 
 	// Upsert alloc triggers watches
 	time.AfterFunc(100*time.Millisecond, func() {
@@ -1482,7 +1482,7 @@ func TestDeploymentEndpoint_Allocations(t *testing.T) {
 	summary := mock.JobSummary(a.JobID)
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, nil, j), "UpsertJob")
 	assert.Nil(state.UpsertJobSummary(999, summary), "UpsertJobSummary")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
@@ -1520,7 +1520,7 @@ func TestDeploymentEndpoint_Allocations_ACL(t *testing.T) {
 	summary := mock.JobSummary(a.JobID)
 	state := s1.fsm.State()
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 998, nil, j), "UpsertJob")
 	assert.Nil(state.UpsertJobSummary(999, summary), "UpsertJobSummary")
 	assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 	assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{a}), "UpsertAllocs")
@@ -1595,7 +1595,7 @@ func TestDeploymentEndpoint_Allocations_Blocking(t *testing.T) {
 	a.DeploymentID = d.ID
 	summary := mock.JobSummary(a.JobID)
 
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1, j), "UpsertJob")
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1, nil, j), "UpsertJob")
 	assert.Nil(state.UpsertDeployment(2, d), "UpsertDeployment")
 	assert.Nil(state.UpsertJobSummary(3, summary), "UpsertJobSummary")
 

--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -40,9 +40,9 @@ func TestWatcher_WatchDeployments(t *testing.T) {
 
 	// Create three jobs
 	j1, j2, j3 := mock.Job(), mock.Job(), mock.Job()
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, 100, j1))
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, 101, j2))
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, 102, j3))
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, j1))
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, 101, nil, j2))
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, 102, nil, j3))
 
 	// Create three deployments all running
 	d1, d2, d3 := mock.Deployment(), mock.Deployment(), mock.Deployment()
@@ -155,7 +155,7 @@ func TestWatcher_SetAllocHealth_Unknown(t *testing.T) {
 	j := mock.Job()
 	d := mock.Deployment()
 	d.JobID = j.ID
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// require that we get a call to UpsertDeploymentAllocHealth
@@ -201,7 +201,7 @@ func TestWatcher_SetAllocHealth_Healthy(t *testing.T) {
 	d.JobID = j.ID
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -246,7 +246,7 @@ func TestWatcher_SetAllocHealth_Unhealthy(t *testing.T) {
 	d.JobID = j.ID
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -304,7 +304,7 @@ func TestWatcher_SetAllocHealth_Unhealthy_Rollback(t *testing.T) {
 	d.TaskGroups["web"].AutoRevert = true
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -314,7 +314,7 @@ func TestWatcher_SetAllocHealth_Unhealthy_Rollback(t *testing.T) {
 	// Modify the job to make its specification different
 	j2.Meta["foo"] = "bar"
 
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j2), "UpsertJob2")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j2), "UpsertJob2")
 
 	// require that we get a call to UpsertDeploymentAllocHealth
 	matchConfig := &matchDeploymentAllocHealthRequestConfig{
@@ -371,7 +371,7 @@ func TestWatcher_SetAllocHealth_Unhealthy_NoRollback(t *testing.T) {
 	d.TaskGroups["web"].AutoRevert = true
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -379,7 +379,7 @@ func TestWatcher_SetAllocHealth_Unhealthy_NoRollback(t *testing.T) {
 	j2 := j.Copy()
 	j2.Stable = false
 
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j2), "UpsertJob2")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j2), "UpsertJob2")
 
 	// require that we get a call to UpsertDeploymentAllocHealth
 	matchConfig := &matchDeploymentAllocHealthRequestConfig{
@@ -439,7 +439,7 @@ func TestWatcher_PromoteDeployment_HealthyCanaries(t *testing.T) {
 		Healthy: pointer.Of(true),
 	}
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -496,7 +496,7 @@ func TestWatcher_PromoteDeployment_UnhealthyCanaries(t *testing.T) {
 	d.TaskGroups[a.TaskGroup].PlacedCanaries = []string{a.ID}
 	d.TaskGroups[a.TaskGroup].DesiredCanaries = 2
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -607,7 +607,7 @@ func TestWatcher_AutoPromoteDeployment(t *testing.T) {
 	d.TaskGroups[ca1.TaskGroup].PlacedCanaries = []string{ca1.ID, ca2.ID}
 	d.TaskGroups[ca1.TaskGroup].DesiredCanaries = 2
 	d.TaskGroups[ra1.TaskGroup].PlacedAllocs = 2
-	require.NoError(t, m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.NoError(t, m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.NoError(t, m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.NoError(t, m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{ca1, ca2, ra1, ra2}), "UpsertAllocs")
 
@@ -742,7 +742,7 @@ func TestWatcher_AutoPromoteDeployment_UnhealthyCanaries(t *testing.T) {
 
 	d.TaskGroups[ca1.TaskGroup].PlacedCanaries = []string{ca1.ID, ca2.ID, ca3.ID}
 	d.TaskGroups[ca1.TaskGroup].DesiredCanaries = 2
-	require.NoError(t, m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.NoError(t, m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.NoError(t, m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.NoError(t, m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{ca1, ca2, ca3}), "UpsertAllocs")
 
@@ -845,7 +845,7 @@ func TestWatcher_PauseDeployment_Pause_Running(t *testing.T) {
 	j := mock.Job()
 	d := mock.Deployment()
 	d.JobID = j.ID
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// require that we get a call to UpsertDeploymentStatusUpdate
@@ -888,7 +888,7 @@ func TestWatcher_PauseDeployment_Pause_Paused(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 	d.Status = structs.DeploymentStatusPaused
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// require that we get a call to UpsertDeploymentStatusUpdate
@@ -928,7 +928,7 @@ func TestWatcher_PauseDeployment_Unpause_Paused(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 	d.Status = structs.DeploymentStatusPaused
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// require that we get a call to UpsertDeploymentStatusUpdate
@@ -968,7 +968,7 @@ func TestWatcher_PauseDeployment_Unpause_Running(t *testing.T) {
 	j := mock.Job()
 	d := mock.Deployment()
 	d.JobID = j.ID
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// require that we get a call to UpsertDeploymentStatusUpdate
@@ -1008,7 +1008,7 @@ func TestWatcher_FailDeployment_Running(t *testing.T) {
 	j := mock.Job()
 	d := mock.Deployment()
 	d.JobID = j.ID
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	// require that we get a call to UpsertDeploymentStatusUpdate
@@ -1056,7 +1056,7 @@ func TestDeploymentWatcher_Watch_NoProgressDeadline(t *testing.T) {
 	d.TaskGroups["web"].AutoRevert = true
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -1065,7 +1065,7 @@ func TestDeploymentWatcher_Watch_NoProgressDeadline(t *testing.T) {
 	// Modify the job to make its specification different
 	j2.Meta["foo"] = "bar"
 	j2.Stable = false
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j2), "UpsertJob2")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j2), "UpsertJob2")
 
 	// require that we will get a update allocation call only once. This will
 	// verify that the watcher is batching allocation changes
@@ -1178,7 +1178,7 @@ func TestDeploymentWatcher_Watch_ProgressDeadline(t *testing.T) {
 	a.CreateTime = now.UnixNano()
 	a.ModifyTime = now.UnixNano()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -1273,7 +1273,7 @@ func TestDeploymentWatcher_ProgressCutoff(t *testing.T) {
 	a2.ModifyTime = now.UnixNano()
 	a2.DeploymentID = d.ID
 
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a, a2}), "UpsertAllocs")
 
@@ -1367,7 +1367,7 @@ func TestDeploymentWatcher_Watch_ProgressDeadline_Canaries(t *testing.T) {
 	a.CreateTime = now.UnixNano()
 	a.ModifyTime = now.UnixNano()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -1459,7 +1459,7 @@ func TestDeploymentWatcher_PromotedCanary_UpdatedAllocs(t *testing.T) {
 		Healthy:   pointer.Of(true),
 		Timestamp: now,
 	}
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -1559,7 +1559,7 @@ func TestDeploymentWatcher_ProgressDeadline_LatePromote(t *testing.T) {
 		},
 	}
 
-	require.NoError(m.state.UpsertJob(mtype, m.nextIndex(), j))
+	require.NoError(m.state.UpsertJob(mtype, m.nextIndex(), nil, j))
 	require.NoError(m.state.UpsertDeployment(m.nextIndex(), d))
 
 	// require that we get a call to UpsertDeploymentPromotion
@@ -1738,7 +1738,7 @@ func TestDeploymentWatcher_Watch_StartWithoutProgressDeadline(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 
 	a := mock.Alloc()
@@ -1799,7 +1799,7 @@ func TestDeploymentWatcher_RollbackFailed(t *testing.T) {
 	d.TaskGroups["web"].AutoRevert = true
 	a := mock.Alloc()
 	a.DeploymentID = d.ID
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
 
@@ -1807,7 +1807,7 @@ func TestDeploymentWatcher_RollbackFailed(t *testing.T) {
 	j2 := j.Copy()
 	// Modify the job to make its specification different
 	j2.Stable = false
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j2), "UpsertJob2")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j2), "UpsertJob2")
 
 	// require that we will get a createEvaluation call only once. This will
 	// verify that the watcher is batching allocation changes
@@ -1922,8 +1922,8 @@ func TestWatcher_BatchAllocUpdates(t *testing.T) {
 	a2.JobID = j2.ID
 	a2.DeploymentID = d2.ID
 
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j1), "UpsertJob")
-	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j2), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j1), "UpsertJob")
+	require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j2), "UpsertJob")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d1), "UpsertDeployment")
 	require.Nil(m.state.UpsertDeployment(m.nextIndex(), d2), "UpsertDeployment")
 	require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a1}), "UpsertAllocs")

--- a/nomad/deploymentwatcher/testutil_test.go
+++ b/nomad/deploymentwatcher/testutil_test.go
@@ -89,7 +89,7 @@ func matchUpdateAllocDesiredTransitionReschedule(allocIDs []string) func(update 
 func (m *mockBackend) UpsertJob(job *structs.Job) (uint64, error) {
 	m.Called(job)
 	i := m.nextIndex()
-	return i, m.state.UpsertJob(structs.MsgTypeTestSetup, i, job)
+	return i, m.state.UpsertJob(structs.MsgTypeTestSetup, i, nil, job)
 }
 
 func (m *mockBackend) UpdateDeploymentStatus(u *structs.DeploymentStatusUpdateRequest) (uint64, error) {

--- a/nomad/drainer/draining_node_test.go
+++ b/nomad/drainer/draining_node_test.go
@@ -69,7 +69,7 @@ func TestDrainingNode_Table(t *testing.T) {
 			setup: func(t *testing.T, dn *drainingNode) {
 				alloc := mock.BatchAlloc()
 				alloc.NodeID = dn.node.ID
-				require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, alloc.Job))
+				require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, nil, alloc.Job))
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, []*structs.Allocation{alloc}))
 			},
 		},
@@ -81,7 +81,7 @@ func TestDrainingNode_Table(t *testing.T) {
 			setup: func(t *testing.T, dn *drainingNode) {
 				alloc := mock.Alloc()
 				alloc.NodeID = dn.node.ID
-				require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, alloc.Job))
+				require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, nil, alloc.Job))
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, []*structs.Allocation{alloc}))
 			},
 		},
@@ -93,7 +93,7 @@ func TestDrainingNode_Table(t *testing.T) {
 			setup: func(t *testing.T, dn *drainingNode) {
 				alloc := mock.SystemAlloc()
 				alloc.NodeID = dn.node.ID
-				require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, alloc.Job))
+				require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, nil, alloc.Job))
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, []*structs.Allocation{alloc}))
 			},
 		},
@@ -106,7 +106,7 @@ func TestDrainingNode_Table(t *testing.T) {
 				allocs := []*structs.Allocation{mock.Alloc(), mock.BatchAlloc(), mock.SystemAlloc()}
 				for _, a := range allocs {
 					a.NodeID = dn.node.ID
-					require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, a.Job))
+					require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, nil, a.Job))
 				}
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 
@@ -128,7 +128,7 @@ func TestDrainingNode_Table(t *testing.T) {
 				allocs := []*structs.Allocation{mock.Alloc(), mock.BatchAlloc(), mock.SystemAlloc()}
 				for _, a := range allocs {
 					a.NodeID = dn.node.ID
-					require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, a.Job))
+					require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, nil, a.Job))
 				}
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 
@@ -146,7 +146,7 @@ func TestDrainingNode_Table(t *testing.T) {
 				allocs := []*structs.Allocation{mock.Alloc(), mock.BatchAlloc(), mock.SystemAlloc()}
 				for _, a := range allocs {
 					a.NodeID = dn.node.ID
-					require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, a.Job))
+					require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, nil, a.Job))
 				}
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 
@@ -165,7 +165,7 @@ func TestDrainingNode_Table(t *testing.T) {
 				allocs := []*structs.Allocation{mock.Alloc(), mock.BatchAlloc(), mock.SystemAlloc()}
 				for _, a := range allocs {
 					a.NodeID = dn.node.ID
-					require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, a.Job))
+					require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, nil, a.Job))
 				}
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 
@@ -191,7 +191,7 @@ func TestDrainingNode_Table(t *testing.T) {
 				}
 				for _, a := range allocs {
 					a.NodeID = dn.node.ID
-					require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, a.Job))
+					require.Nil(t, dn.state.UpsertJob(structs.MsgTypeTestSetup, 101, nil, a.Job))
 				}
 				require.Nil(t, dn.state.UpsertAllocs(structs.MsgTypeTestSetup, 102, allocs))
 

--- a/nomad/drainer/watch_jobs_test.go
+++ b/nomad/drainer/watch_jobs_test.go
@@ -131,7 +131,7 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 		jnss[i] = structs.NamespacedID{Namespace: job.Namespace, ID: job.ID}
 		job.TaskGroups[0].Migrate.MaxParallel = 3
 		job.TaskGroups[0].Count = count
-		require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, index, job))
+		require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, index, nil, job))
 		index++
 
 		var allocs []*structs.Allocation
@@ -568,7 +568,7 @@ func testHandleTaskGroup(t *testing.T, tc handleTaskGroupTestCase) {
 	if tc.MaxParallel > 0 {
 		job.TaskGroups[0].Migrate.MaxParallel = tc.MaxParallel
 	}
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 102, job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 102, nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -620,7 +620,7 @@ func TestHandleTaskGroup_Migrations(t *testing.T) {
 	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 100, n))
 
 	job := mock.Job()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 101, job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 101, nil, job))
 
 	// Create 10 done allocs
 	var allocs []*structs.Allocation
@@ -689,7 +689,7 @@ func TestHandleTaskGroup_GarbageCollectedNode(t *testing.T) {
 	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 100, n))
 
 	job := mock.Job()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 101, job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 101, nil, job))
 
 	// Create 10 done allocs
 	var allocs []*structs.Allocation

--- a/nomad/drainer/watch_nodes_test.go
+++ b/nomad/drainer/watch_nodes_test.go
@@ -34,7 +34,7 @@ func TestNodeDrainWatcher_AddNodes(t *testing.T) {
 	// Create a job with a running alloc on each node
 	job := mock.Job()
 	jobID := structs.NamespacedID{Namespace: job.Namespace, ID: job.ID}
-	must.NoError(t, store.UpsertJob(structs.MsgTypeTestSetup, 101, job))
+	must.NoError(t, store.UpsertJob(structs.MsgTypeTestSetup, 101, nil, job))
 
 	alloc1 := mock.Alloc()
 	alloc1.JobID = job.ID
@@ -208,7 +208,7 @@ func testNodeDrainWatcherSetup(
 	job := mock.Job()
 	jobID := structs.NamespacedID{Namespace: job.Namespace, ID: job.ID}
 	index++
-	must.NoError(t, store.UpsertJob(structs.MsgTypeTestSetup, index, job))
+	must.NoError(t, store.UpsertJob(structs.MsgTypeTestSetup, index, nil, job))
 
 	// Create draining nodes, each with its own alloc for the job running on that node
 	node := mock.Node()

--- a/nomad/eval_endpoint_test.go
+++ b/nomad/eval_endpoint_test.go
@@ -378,7 +378,7 @@ func TestEvalEndpoint_Dequeue_UpdateWaitIndex(t *testing.T) {
 
 	state := s1.fsm.State()
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -907,7 +907,7 @@ func TestEvalEndpoint_Delete(t *testing.T) {
 		job.ID = "notsafetodelete"
 		job.Status = structs.JobStatusRunning
 		index++
-		must.NoError(t, store.UpsertJob(structs.MsgTypeTestSetup, index, job))
+		must.NoError(t, store.UpsertJob(structs.MsgTypeTestSetup, index, nil, job))
 
 		evalsNotSafeToDelete := []*structs.Evaluation{}
 		for i := 0; i < 3; i++ {

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -544,7 +544,7 @@ func (n *nomadFSM) applyUpsertJob(msgType structs.MessageType, buf []byte, index
 	 */
 	req.Job.Canonicalize()
 
-	if err := n.state.UpsertJob(msgType, index, req.Job); err != nil {
+	if err := n.state.UpsertJob(msgType, index, req.Submission, req.Job); err != nil {
 		n.logger.Error("UpsertJob failed", "error", err)
 		return err
 	}
@@ -783,7 +783,7 @@ func (n *nomadFSM) handleJobDeregister(index uint64, jobID, namespace string, pu
 		stopped := current.Copy()
 		stopped.Stop = true
 
-		if err := n.state.UpsertJobTxn(index, stopped, tx); err != nil {
+		if err := n.state.UpsertJobTxn(index, nil, stopped, tx); err != nil {
 			return fmt.Errorf("UpsertJob failed: %w", err)
 		}
 	}

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -1763,7 +1763,7 @@ func TestFSM_JobStabilityUpdate(t *testing.T) {
 
 	// Upsert a deployment
 	job := mock.Job()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, nil, job); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -1808,7 +1808,7 @@ func TestFSM_DeploymentPromotion(t *testing.T) {
 	tg2 := tg1.Copy()
 	tg2.Name = "foo"
 	j.TaskGroups = append(j.TaskGroups, tg2)
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, j); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, nil, j); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -2256,9 +2256,9 @@ func TestFSM_SnapshotRestore_Jobs(t *testing.T) {
 	fsm := testFSM(t)
 	state := fsm.State()
 	job1 := mock.Job()
-	state.UpsertJob(structs.MsgTypeTestSetup, 1000, job1)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job1)
 	job2 := mock.Job()
-	state.UpsertJob(structs.MsgTypeTestSetup, 1001, job2)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job2)
 
 	// Verify the contents
 	ws := memdb.NewWatchSet()
@@ -2436,12 +2436,12 @@ func TestFSM_SnapshotRestore_JobSummary(t *testing.T) {
 	state := fsm.State()
 
 	job1 := mock.Job()
-	state.UpsertJob(structs.MsgTypeTestSetup, 1000, job1)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job1)
 	ws := memdb.NewWatchSet()
 	js1, _ := state.JobSummaryByID(ws, job1.Namespace, job1.ID)
 
 	job2 := mock.Job()
-	state.UpsertJob(structs.MsgTypeTestSetup, 1001, job2)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job2)
 	js2, _ := state.JobSummaryByID(ws, job2.Namespace, job2.ID)
 
 	// Verify the contents
@@ -2486,10 +2486,10 @@ func TestFSM_SnapshotRestore_JobVersions(t *testing.T) {
 	fsm := testFSM(t)
 	state := fsm.State()
 	job1 := mock.Job()
-	state.UpsertJob(structs.MsgTypeTestSetup, 1000, job1)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job1)
 	job2 := mock.Job()
 	job2.ID = job1.ID
-	state.UpsertJob(structs.MsgTypeTestSetup, 1001, job2)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job2)
 
 	// Verify the contents
 	ws := memdb.NewWatchSet()
@@ -2520,7 +2520,7 @@ func TestFSM_SnapshotRestore_Deployments(t *testing.T) {
 	d1.JobID = j.ID
 	d2.JobID = j.ID
 
-	state.UpsertJob(structs.MsgTypeTestSetup, 999, j)
+	state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j)
 	state.UpsertDeployment(1000, d1)
 	state.UpsertDeployment(1001, d2)
 
@@ -2752,12 +2752,12 @@ func TestFSM_ReconcileSummaries(t *testing.T) {
 	// Make a job so that none of the tasks can be placed
 	job1 := mock.Job()
 	job1.TaskGroups[0].Tasks[0].Resources.CPU = 5000
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, job1))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job1))
 
 	// make a job which can make partial progress
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, alloc.Job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, nil, alloc.Job))
 	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
 
 	// Delete the summaries
@@ -2838,7 +2838,7 @@ func TestFSM_ReconcileParentJobSummary(t *testing.T) {
 		Payload: "random",
 	}
 	job1.TaskGroups[0].Count = 1
-	state.UpsertJob(structs.MsgTypeTestSetup, 1000, job1)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job1)
 
 	// Make a child job
 	childJob := job1.Copy()
@@ -2854,7 +2854,7 @@ func TestFSM_ReconcileParentJobSummary(t *testing.T) {
 	alloc.JobID = childJob.ID
 	alloc.ClientStatus = structs.AllocClientStatusRunning
 
-	state.UpsertJob(structs.MsgTypeTestSetup, 1010, childJob)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1010, nil, childJob)
 	state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc})
 
 	// Make the summary incorrect in the state store

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1218,7 +1218,7 @@ func (j *Job) GetJobSubmission(args *structs.JobSubmissionRequest, reply *struct
 			reply.Submission = out
 			if out != nil {
 				// associate with the index of the job this submission originates from
-				reply.Index = out.JobIndex
+				reply.Index = out.JobModifyIndex
 			} else {
 				// if there is no submission context, associate with no index
 				reply.Index = 0

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -110,6 +110,9 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 	}
 	args.Job = job
 
+	// Run the submission controller
+	warnings = append(warnings, j.submissionController(args))
+
 	// Attach the Nomad token's accessor ID so that deploymentwatcher
 	// can reference the token later
 	nomadACLToken, err := j.srv.ResolveSecretToken(args.AuthToken)

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-set"
-
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"
@@ -1183,6 +1182,52 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	return nil
 }
 
+func (j *Job) GetJobSubmission(args *structs.JobSubmissionRequest, reply *structs.JobSubmissionResponse) error {
+	authErr := j.srv.Authenticate(j.ctx, args)
+	if done, err := j.srv.forward("Job.GetJobSubmission", args, args, reply); done {
+		return err
+	}
+	j.srv.MeasureRPCRate("job_submission", structs.RateMetricRead, args)
+	if authErr != nil {
+		return structs.ErrPermissionDenied
+	}
+	defer metrics.MeasureSince([]string{"nomad", "job", "get_job_submission"}, time.Now())
+
+	// Check for read-job permissions
+	if aclObj, err := j.srv.ResolveACL(args); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJob) {
+		return structs.ErrPermissionDenied
+	}
+
+	// Setup the blocking query
+	opts := blockingOptions{
+		queryOpts: &args.QueryOptions,
+		queryMeta: &reply.QueryMeta,
+		run: func(ws memdb.WatchSet, state *state.StateStore) error {
+			// Look for the submission
+			out, err := state.JobSubmission(ws, args.RequestNamespace(), args.JobID, args.Version)
+			if err != nil {
+				return err
+			}
+
+			// Setup the output
+			reply.Submission = out
+			if out != nil {
+				// associate with the index of the job this submission originates from
+				reply.Index = out.JobIndex
+			} else {
+				// if there is no submission context, associate with no index
+				reply.Index = 0
+			}
+
+			// Set the query response
+			j.srv.setQueryMeta(&reply.QueryMeta)
+			return nil
+		}}
+	return j.srv.blockingRPC(&opts)
+}
+
 // GetJob is used to request information about a specific job
 func (j *Job) GetJob(args *structs.JobSpecificRequest,
 	reply *structs.SingleJobResponse) error {
@@ -1754,13 +1799,13 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 		if oldJob.SpecChanged(args.Job) {
 			// Insert the updated Job into the snapshot
 			updatedIndex = oldJob.JobModifyIndex + 1
-			if err := snap.UpsertJob(structs.IgnoreUnknownTypeFlag, updatedIndex, args.Job); err != nil {
+			if err := snap.UpsertJob(structs.IgnoreUnknownTypeFlag, updatedIndex, nil, args.Job); err != nil {
 				return err
 			}
 		}
 	} else if oldJob == nil {
 		// Insert the updated Job into the snapshot
-		err := snap.UpsertJob(structs.IgnoreUnknownTypeFlag, 100, args.Job)
+		err := snap.UpsertJob(structs.IgnoreUnknownTypeFlag, 100, nil, args.Job)
 		if err != nil {
 			return err
 		}

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -340,6 +340,10 @@ func (v *memoryOversubscriptionValidate) Validate(job *structs.Job) (warnings []
 // Such jobs will have their source discarded and emit a warning, but the job
 // itself will still continue with being registered.
 func (j *Job) submissionController(args *structs.JobRegisterRequest) error {
+	if args.Submission == nil {
+		return nil
+	}
+
 	maxSize := j.srv.GetConfig().JobMaxSourceSize
 	submission := args.Submission
 	// discard the submission if the source + variables is larger than the maximum

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -343,7 +343,6 @@ func (j *Job) submissionController(args *structs.JobRegisterRequest) error {
 	if args.Submission == nil {
 		return nil
 	}
-
 	maxSize := j.srv.GetConfig().JobMaxSourceSize
 	submission := args.Submission
 	// discard the submission if the source + variables is larger than the maximum

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -766,3 +766,31 @@ func Test_jobCanonicalizer_Mutate(t *testing.T) {
 		})
 	}
 }
+
+func TestJob_submissionController(t *testing.T) {
+	ci.Parallel(t)
+	args := &structs.JobRegisterRequest{
+		Submission: &structs.JobSubmission{
+			Source:    "this is some hcl content",
+			Format:    "hcl2",
+			Variables: "variables",
+		},
+	}
+	t.Run("under max size", func(t *testing.T) {
+		j := &Job{srv: &Server{
+			config: &Config{JobMaxSourceSize: 1024},
+		}}
+		err := j.submissionController(args)
+		must.NoError(t, err)
+		must.NotNil(t, args.Submission)
+	})
+
+	t.Run("over max size", func(t *testing.T) {
+		j := &Job{srv: &Server{
+			config: &Config{JobMaxSourceSize: 1},
+		}}
+		err := j.submissionController(args)
+		must.ErrorContains(t, err, "job source size of 33 B exceeds maximum of 1 B and will be discarded")
+		must.Nil(t, args.Submission)
+	})
+}

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -776,6 +776,15 @@ func TestJob_submissionController(t *testing.T) {
 			Variables: "variables",
 		},
 	}
+	t.Run("nil", func(t *testing.T) {
+		j := &Job{srv: &Server{
+			config: &Config{JobMaxSourceSize: 1024},
+		}}
+		err := j.submissionController(&structs.JobRegisterRequest{
+			Submission: nil,
+		})
+		must.NoError(t, err)
+	})
 	t.Run("under max size", func(t *testing.T) {
 		j := &Job{srv: &Server{
 			config: &Config{JobMaxSourceSize: 1024},

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-memdb"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/ci"
@@ -2768,12 +2768,12 @@ func TestJobEndpoint_Revert_ACL(t *testing.T) {
 
 	// Create the jobs
 	job := mock.Job()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 300, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 300, nil, job)
 	require.Nil(err)
 
 	job2 := job.Copy()
 	job2.Priority = 1
-	err = state.UpsertJob(structs.MsgTypeTestSetup, 400, job2)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 400, nil, job2)
 	require.Nil(err)
 
 	// Create revert request and enforcing it be at the current version
@@ -2896,7 +2896,7 @@ func TestJobEndpoint_Stable_ACL(t *testing.T) {
 
 	// Register the job
 	job := mock.Job()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.Nil(err)
 
 	// Create stability request
@@ -3127,7 +3127,7 @@ func TestJobEndpoint_Evaluate_ACL(t *testing.T) {
 
 	// Create the job
 	job := mock.Job()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 300, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 300, nil, job)
 	require.Nil(err)
 
 	// Force a re-evaluation
@@ -3381,7 +3381,7 @@ func TestJobEndpoint_Deregister_ACL(t *testing.T) {
 
 	// Create and register a job
 	job := mock.Job()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job)
 	require.Nil(err)
 
 	// Deregister and purge
@@ -3920,8 +3920,8 @@ func TestJobEndpoint_BatchDeregister_ACL(t *testing.T) {
 
 	// Create and register a job
 	job, job2 := mock.Job(), mock.Job()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 100, job))
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 101, job2))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 101, nil, job2))
 
 	// Deregister
 	req := &structs.JobBatchDeregisterRequest{
@@ -3990,7 +3990,7 @@ func TestJobEndpoint_Deregister_Priority(t *testing.T) {
 	// Create a job which a custom priority and register this.
 	job := mock.Job()
 	job.Priority = 90
-	err := fsmState.UpsertJob(structs.MsgTypeTestSetup, 100, job)
+	err := fsmState.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job)
 	requireAssertion.Nil(err)
 
 	// Deregister.
@@ -4115,7 +4115,7 @@ func TestJobEndpoint_GetJob_ACL(t *testing.T) {
 
 	// Create the job
 	job := mock.Job()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.Nil(err)
 
 	// Lookup the job
@@ -4176,14 +4176,14 @@ func TestJobEndpoint_GetJob_Blocking(t *testing.T) {
 
 	// Upsert a job we are not interested in first.
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job1); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job1); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
 
 	// Upsert another job later which should trigger the watch.
 	time.AfterFunc(200*time.Millisecond, func() {
-		if err := state.UpsertJob(structs.MsgTypeTestSetup, 200, job2); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 200, nil, job2); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -4311,6 +4311,208 @@ func TestJobEndpoint_GetJobVersions(t *testing.T) {
 	}
 }
 
+func TestJobEndpoint_GetJobSubmission(t *testing.T) {
+	ci.Parallel(t)
+
+	s1, cleanupS1 := TestServer(t, nil)
+	t.Cleanup(cleanupS1)
+
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeaders(t, s1.RPC)
+
+	// create a job to register and make queries about
+	job := mock.Job()
+	registerRequest := &structs.JobRegisterRequest{
+		Job: job,
+		Submission: &structs.JobSubmission{
+			Source:        "job \"my-job\" { group \"g1\" {} }",
+			Format:        "hcl2",
+			VariableFlags: map[string]string{"one": "1"},
+			Variables:     "two = 2",
+		},
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// register the job first ime
+	var registerResponse structs.JobRegisterResponse
+	err := msgpackrpc.CallWithCodec(codec, "Job.Register", registerRequest, &registerResponse)
+	must.NoError(t, err)
+	indexV0 := registerResponse.Index
+
+	// register the job a second time, creating another version (v0, v1)
+	// with a new job source file and variables
+	job.Priority++ // trigger new version
+	registerRequest.Submission = &structs.JobSubmission{
+		Source:        "job \"my-job\" { group \"g2\" {} }",
+		Format:        "hcl2",
+		VariableFlags: map[string]string{"three": "3"},
+		Variables:     "four = 4",
+	}
+	err = msgpackrpc.CallWithCodec(codec, "Job.Register", registerRequest, &registerResponse)
+	must.NoError(t, err)
+	indexV1 := registerResponse.Index
+
+	// lookup the submission for v0
+	submissionRequestV0 := &structs.JobSubmissionRequest{
+		JobID:   job.ID,
+		Version: 0,
+		QueryOptions: structs.QueryOptions{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	var submissionResponse structs.JobSubmissionResponse
+	err = msgpackrpc.CallWithCodec(codec, "Job.GetJobSubmission", submissionRequestV0, &submissionResponse)
+	must.NoError(t, err)
+
+	sub := submissionResponse.Submission
+	must.StrContains(t, sub.Source, "g1")
+	must.Eq(t, "hcl2", sub.Format)
+	must.Eq(t, map[string]string{"one": "1"}, sub.VariableFlags)
+	must.Eq(t, "two = 2", sub.Variables)
+	must.Eq(t, job.Namespace, sub.Namespace)
+	must.Eq(t, indexV0, sub.JobIndex)
+
+	// lookup the submission for v1
+	submissionRequestV1 := &structs.JobSubmissionRequest{
+		JobID:   job.ID,
+		Version: 1,
+		QueryOptions: structs.QueryOptions{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	var submissionResponseV1 structs.JobSubmissionResponse
+	err = msgpackrpc.CallWithCodec(codec, "Job.GetJobSubmission", submissionRequestV1, &submissionResponseV1)
+	must.NoError(t, err)
+
+	sub = submissionResponseV1.Submission
+	must.StrContains(t, sub.Source, "g2")
+	must.Eq(t, "hcl2", sub.Format)
+	must.Eq(t, map[string]string{"three": "3"}, sub.VariableFlags)
+	must.Eq(t, "four = 4", sub.Variables)
+	must.Eq(t, job.Namespace, sub.Namespace)
+	must.Eq(t, indexV1, sub.JobIndex)
+
+	// lookup non-existent submission v2
+	submissionRequestV2 := &structs.JobSubmissionRequest{
+		JobID:   job.ID,
+		Version: 2,
+		QueryOptions: structs.QueryOptions{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	var submissionResponseV2 structs.JobSubmissionResponse
+	err = msgpackrpc.CallWithCodec(codec, "Job.GetJobSubmission", submissionRequestV2, &submissionResponseV2)
+	must.NoError(t, err)
+	must.Nil(t, submissionResponseV2.Submission)
+
+	// create a deregister request
+	deRegisterRequest := &structs.JobDeregisterRequest{
+		JobID: job.ID,
+		Purge: true, // force gc
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	var deRegisterResponse structs.JobDeregisterResponse
+	err = msgpackrpc.CallWithCodec(codec, "Job.Deregister", deRegisterRequest, &deRegisterResponse)
+	must.NoError(t, err)
+
+	// lookup the submission for v0 again
+	submissionRequestV0 = &structs.JobSubmissionRequest{
+		JobID:   job.ID,
+		Version: 0,
+		QueryOptions: structs.QueryOptions{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+
+	// should no longer exist
+	var submissionResponseGone structs.JobSubmissionResponse
+	err = msgpackrpc.CallWithCodec(codec, "Job.GetJobSubmission", submissionRequestV0, &submissionResponseGone)
+	must.NoError(t, err)
+	must.Nil(t, submissionResponseGone.Submission, must.Sprintf("got sub: %#v", submissionResponseGone.Submission))
+}
+
+func TestJobEndpoint_GetJobSubmission_ACL(t *testing.T) {
+	ci.Parallel(t)
+
+	s1, root, cleanupS1 := TestACLServer(t, nil)
+	t.Cleanup(cleanupS1)
+
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeaders(t, s1.RPC)
+
+	// create a namespace to upsert
+	namespaceUpsertRequest := &structs.NamespaceUpsertRequest{
+		Namespaces: []*structs.Namespace{{
+			Name:        "hashicorp",
+			Description: "My Namespace",
+		}},
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			AuthToken: root.SecretID,
+		},
+	}
+
+	var namespaceUpsertResponse structs.GenericResponse
+	err := msgpackrpc.CallWithCodec(codec, "Namespace.UpsertNamespaces", namespaceUpsertRequest, &namespaceUpsertResponse)
+	must.NoError(t, err)
+
+	// create a job to register and make queries about
+	job := mock.Job()
+	job.Namespace = "hashicorp"
+	registerRequest := &structs.JobRegisterRequest{
+		Job: job,
+		Submission: &structs.JobSubmission{
+			Source:        "job \"my-job\" { group \"g1\" {} }",
+			Format:        "hcl2",
+			VariableFlags: map[string]string{"one": "1"},
+			Variables:     "two = 2",
+		},
+		WriteRequest: structs.WriteRequest{
+			Region:    "global",
+			Namespace: job.Namespace,
+			AuthToken: root.SecretID,
+		},
+	}
+
+	// register the job
+	var registerResponse structs.JobRegisterResponse
+	err = msgpackrpc.CallWithCodec(codec, "Job.Register", registerRequest, &registerResponse)
+	must.NoError(t, err)
+
+	// make a request with no token set
+	submissionRequest := &structs.JobSubmissionRequest{
+		JobID:   job.ID,
+		Version: 0,
+		QueryOptions: structs.QueryOptions{
+			Region:    "global",
+			Namespace: job.Namespace,
+		},
+	}
+	var submissionResponse structs.JobSubmissionResponse
+	err = msgpackrpc.CallWithCodec(codec, "Job.GetJobSubmission", submissionRequest, &submissionResponse)
+	must.ErrorContains(t, err, "Permission denied")
+
+	// make request with token set
+	submissionRequest.QueryOptions.AuthToken = root.SecretID
+	var submissionResponse2 structs.JobSubmissionResponse
+	err = msgpackrpc.CallWithCodec(codec, "Job.GetJobSubmission", submissionRequest, &submissionResponse2)
+	must.NoError(t, err)
+}
+
 func TestJobEndpoint_GetJobVersions_ACL(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
@@ -4324,11 +4526,11 @@ func TestJobEndpoint_GetJobVersions_ACL(t *testing.T) {
 	// Create two versions of a job with different priorities
 	job := mock.Job()
 	job.Priority = 88
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 10, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 10, nil, job)
 	require.Nil(err)
 
 	job.Priority = 100
-	err = state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job)
 	require.Nil(err)
 
 	// Lookup the job
@@ -4493,14 +4695,14 @@ func TestJobEndpoint_GetJobVersions_Blocking(t *testing.T) {
 
 	// Upsert a job we are not interested in first.
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job1); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job1); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
 
 	// Upsert another job later which should trigger the watch.
 	time.AfterFunc(200*time.Millisecond, func() {
-		if err := state.UpsertJob(structs.MsgTypeTestSetup, 200, job2); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 200, nil, job2); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -4531,7 +4733,7 @@ func TestJobEndpoint_GetJobVersions_Blocking(t *testing.T) {
 
 	// Upsert the job again which should trigger the watch.
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.UpsertJob(structs.MsgTypeTestSetup, 300, job3); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 300, nil, job3); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -4722,7 +4924,7 @@ func TestJobEndpoint_GetJobSummary_Blocking(t *testing.T) {
 	// Create a job and insert it
 	job1 := mock.Job()
 	time.AfterFunc(200*time.Millisecond, func() {
-		if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job1); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job1); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -4815,7 +5017,7 @@ func TestJobEndpoint_ListJobs(t *testing.T) {
 	// Create the register request
 	job := mock.Job()
 	state := s1.fsm.State()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.NoError(t, err)
 
 	// Lookup the jobs
@@ -4880,7 +5082,7 @@ func TestJobEndpoint_ListJobs_AllNamespaces_OSS(t *testing.T) {
 	// Create the register request
 	job := mock.Job()
 	state := s1.fsm.State()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4947,7 +5149,7 @@ func TestJobEndpoint_ListJobs_WithACL(t *testing.T) {
 
 	// Create the register request
 	job := mock.Job()
-	err = state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.Nil(err)
 
 	req := &structs.JobListRequest{
@@ -5005,7 +5207,7 @@ func TestJobEndpoint_ListJobs_Blocking(t *testing.T) {
 
 	// Upsert job triggers watches
 	time.AfterFunc(100*time.Millisecond, func() {
-		if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -5100,7 +5302,7 @@ func TestJobEndpoint_ListJobs_PaginationFiltering(t *testing.T) {
 			job.Namespace = m.namespace
 		}
 		job.CreateIndex = index
-		require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, index, job))
+		require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, index, nil, job))
 	}
 
 	aclToken := mock.CreatePolicyAndToken(t, state, 1100, "test-valid-read",
@@ -5592,7 +5794,7 @@ func TestJobEndpoint_Deployments(t *testing.T) {
 	d2 := mock.Deployment()
 	d1.JobID = j.ID
 	d2.JobID = j.ID
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j), "UpsertJob")
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j), "UpsertJob")
 	d1.JobCreateIndex = j.CreateIndex
 	d2.JobCreateIndex = j.CreateIndex
 
@@ -5629,7 +5831,7 @@ func TestJobEndpoint_Deployments_ACL(t *testing.T) {
 	d2 := mock.Deployment()
 	d1.JobID = j.ID
 	d2.JobID = j.ID
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j), "UpsertJob")
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j), "UpsertJob")
 	d1.JobCreateIndex = j.CreateIndex
 	d2.JobCreateIndex = j.CreateIndex
 	require.Nil(state.UpsertDeployment(1001, d1), "UpsertDeployment")
@@ -5692,7 +5894,7 @@ func TestJobEndpoint_Deployments_Blocking(t *testing.T) {
 	d1 := mock.Deployment()
 	d2 := mock.Deployment()
 	d2.JobID = j.ID
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 50, j), "UpsertJob")
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 50, nil, j), "UpsertJob")
 	d2.JobCreateIndex = j.CreateIndex
 	// First upsert an unrelated eval
 	time.AfterFunc(100*time.Millisecond, func() {
@@ -5742,7 +5944,7 @@ func TestJobEndpoint_LatestDeployment(t *testing.T) {
 	d2.JobID = j.ID
 	d2.CreateIndex = d1.CreateIndex + 100
 	d2.ModifyIndex = d2.CreateIndex + 100
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j), "UpsertJob")
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j), "UpsertJob")
 	d1.JobCreateIndex = j.CreateIndex
 	d2.JobCreateIndex = j.CreateIndex
 	require.Nil(state.UpsertDeployment(1001, d1), "UpsertDeployment")
@@ -5781,7 +5983,7 @@ func TestJobEndpoint_LatestDeployment_ACL(t *testing.T) {
 	d2.JobID = j.ID
 	d2.CreateIndex = d1.CreateIndex + 100
 	d2.ModifyIndex = d2.CreateIndex + 100
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, j), "UpsertJob")
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j), "UpsertJob")
 	d1.JobCreateIndex = j.CreateIndex
 	d2.JobCreateIndex = j.CreateIndex
 	require.Nil(state.UpsertDeployment(1001, d1), "UpsertDeployment")
@@ -5847,7 +6049,7 @@ func TestJobEndpoint_LatestDeployment_Blocking(t *testing.T) {
 	d1 := mock.Deployment()
 	d2 := mock.Deployment()
 	d2.JobID = j.ID
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 50, j), "UpsertJob")
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 50, nil, j), "UpsertJob")
 	d2.JobCreateIndex = j.CreateIndex
 
 	// First upsert an unrelated eval
@@ -6440,7 +6642,7 @@ func TestJobEndpoint_Dispatch_ACL(t *testing.T) {
 	// Create a parameterized job
 	job := mock.BatchJob()
 	job.ParameterizedJob = &structs.ParameterizedJobConfig{}
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 400, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 400, nil, job)
 	require.Nil(err)
 
 	req := &structs.JobDispatchRequest{
@@ -6969,7 +7171,7 @@ func TestJobEndpoint_Dispatch_ACL_RejectedBySchedulerConfig(t *testing.T) {
 	job := mock.BatchJob()
 	job.ParameterizedJob = &structs.ParameterizedJobConfig{}
 
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.NoError(t, err)
 
 	dispatch := &structs.JobDispatchRequest{
@@ -7059,7 +7261,7 @@ func TestJobEndpoint_Scale(t *testing.T) {
 
 	job := mock.Job()
 	originalCount := job.TaskGroups[0].Count
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.Nil(err)
 
 	groupName := job.TaskGroups[0].Name
@@ -7116,7 +7318,7 @@ func TestJobEndpoint_Scale_DeploymentBlocking(t *testing.T) {
 	for _, tc := range cases {
 		// create a job with a deployment history
 		job := mock.Job()
-		require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, job), "UpsertJob")
+		require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job), "UpsertJob")
 		d1 := mock.Deployment()
 		d1.Status = structs.DeploymentStatusCancelled
 		d1.StatusDescription = structs.DeploymentStatusDescriptionNewerJob
@@ -7195,7 +7397,7 @@ func TestJobEndpoint_Scale_InformationalEventsShouldNotBeBlocked(t *testing.T) {
 	for _, tc := range cases {
 		// create a job with a deployment history
 		job := mock.Job()
-		require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, job), "UpsertJob")
+		require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job), "UpsertJob")
 		d1 := mock.Deployment()
 		d1.Status = structs.DeploymentStatusCancelled
 		d1.StatusDescription = structs.DeploymentStatusDescriptionNewerJob
@@ -7261,7 +7463,7 @@ func TestJobEndpoint_Scale_ACL(t *testing.T) {
 	state := s1.fsm.State()
 
 	job := mock.Job()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.Nil(err)
 
 	scale := &structs.JobScaleRequest{
@@ -7344,7 +7546,7 @@ func TestJobEndpoint_Scale_ACL_RejectedBySchedulerConfig(t *testing.T) {
 	state := s1.fsm.State()
 
 	job := mock.Job()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.NoError(t, err)
 
 	scale := &structs.JobScaleRequest{
@@ -7466,7 +7668,7 @@ func TestJobEndpoint_Scale_Invalid(t *testing.T) {
 	require.Contains(err.Error(), "not found")
 
 	// register the job
-	err = state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.Nil(err)
 
 	scale.Count = pointer.Of(int64(10))
@@ -7493,7 +7695,7 @@ func TestJobEndpoint_Scale_OutOfBounds(t *testing.T) {
 	job.TaskGroups[0].Count = 5
 
 	// register the job
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.Nil(err)
 
 	var resp structs.JobRegisterResponse
@@ -7599,7 +7801,7 @@ func TestJobEndpoint_Scale_Priority(t *testing.T) {
 	job := mock.Job()
 	job.Priority = 90
 	originalCount := job.TaskGroups[0].Count
-	err := fsmState.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := fsmState.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	requireAssertion.Nil(err)
 
 	groupName := job.TaskGroups[0].Name
@@ -7646,7 +7848,7 @@ func TestJobEndpoint_InvalidCount(t *testing.T) {
 	state := s1.fsm.State()
 
 	job := mock.Job()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.Nil(err)
 
 	scale := &structs.JobScaleRequest{
@@ -7691,7 +7893,7 @@ func TestJobEndpoint_GetScaleStatus(t *testing.T) {
 	require.Nil(resp2.JobScaleStatus)
 
 	// stopped (previous version)
-	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 1000, jobV1), "UpsertJob")
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, jobV1), "UpsertJob")
 	a0 := mock.Alloc()
 	a0.Job = jobV1
 	a0.Namespace = jobV1.Namespace
@@ -7700,7 +7902,7 @@ func TestJobEndpoint_GetScaleStatus(t *testing.T) {
 	require.NoError(state.UpsertAllocs(structs.MsgTypeTestSetup, 1010, []*structs.Allocation{a0}), "UpsertAllocs")
 
 	jobV2 := jobV1.Copy()
-	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 1100, jobV2), "UpsertJob")
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 1100, nil, jobV2), "UpsertJob")
 	a1 := mock.Alloc()
 	a1.Job = jobV2
 	a1.Namespace = jobV2.Namespace
@@ -7793,7 +7995,7 @@ func TestJobEndpoint_GetScaleStatus_ACL(t *testing.T) {
 
 	// Create the job
 	job := mock.Job()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.Nil(err)
 
 	// Get the job scale status
@@ -7876,7 +8078,7 @@ func TestJob_GetServiceRegistrations(t *testing.T) {
 	correctSetupFn := func(s *Server) (error, string, *structs.ServiceRegistration) {
 		// Generate an upsert a job.
 		job := mock.Job()
-		err := s.State().UpsertJob(structs.MsgTypeTestSetup, 10, job)
+		err := s.State().UpsertJob(structs.MsgTypeTestSetup, 10, nil, job)
 		if err != nil {
 			return nil, "", nil
 		}
@@ -7964,7 +8166,7 @@ func TestJob_GetServiceRegistrations(t *testing.T) {
 
 				// Generate an upsert a job.
 				job := mock.Job()
-				require.NoError(t, s.State().UpsertJob(structs.MsgTypeTestSetup, 10, job))
+				require.NoError(t, s.State().UpsertJob(structs.MsgTypeTestSetup, 10, nil, job))
 
 				// Perform a lookup and test the response.
 				serviceRegReq := &structs.JobServiceRegistrationsRequest{

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -4375,7 +4375,7 @@ func TestJobEndpoint_GetJobSubmission(t *testing.T) {
 	must.Eq(t, map[string]string{"one": "1"}, sub.VariableFlags)
 	must.Eq(t, "two = 2", sub.Variables)
 	must.Eq(t, job.Namespace, sub.Namespace)
-	must.Eq(t, indexV0, sub.JobIndex)
+	must.Eq(t, indexV0, sub.JobModifyIndex)
 
 	// lookup the submission for v1
 	submissionRequestV1 := &structs.JobSubmissionRequest{
@@ -4397,7 +4397,7 @@ func TestJobEndpoint_GetJobSubmission(t *testing.T) {
 	must.Eq(t, map[string]string{"three": "3"}, sub.VariableFlags)
 	must.Eq(t, "four = 4", sub.Variables)
 	must.Eq(t, job.Namespace, sub.Namespace)
-	must.Eq(t, indexV1, sub.JobIndex)
+	must.Eq(t, indexV1, sub.JobModifyIndex)
 
 	// lookup non-existent submission v2
 	submissionRequestV2 := &structs.JobSubmissionRequest{

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -40,6 +40,50 @@ func HCL() string {
 `
 }
 
+// HCLVar returns a the HCL of job that requires a HCL variables S, N,
+// and B to be set. Also returns the content of a vars-file to satisfy
+// those variables.
+func HCLVar() (string, string) {
+	return `
+variable "S" {
+  type = string
+}
+
+variable "N" {
+  type = number
+}
+
+variable "B" {
+  type = bool
+}
+
+job "var-job" {
+	type = "batch"
+	constraint {
+		attribute = "${attr.kernel.name}"
+		value = "linux"
+	}
+	group "group" {
+		task "task" {
+			driver = "raw_exec"
+			config {
+				command = "echo"
+                args = ["S is ${var.S}, N is ${var.N}, B is ${var.B}"]
+			}
+			resources {
+				cpu = 10
+				memory = 32
+			}
+		}
+	}
+}
+`, `
+S = "stringy"
+N = 42
+B = true
+`
+}
+
 func Eval() *structs.Evaluation {
 	now := time.Now().UTC().UnixNano()
 	eval := &structs.Evaluation{

--- a/nomad/namespace_endpoint_test.go
+++ b/nomad/namespace_endpoint_test.go
@@ -499,7 +499,7 @@ func TestNamespaceEndpoint_DeleteNamespaces_NonTerminal_Local(t *testing.T) {
 	// Create a job in one
 	j := mock.Job()
 	j.Namespace = ns1.Name
-	assert.Nil(s1.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 1001, j))
+	assert.Nil(s1.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 1001, nil, j))
 
 	// Lookup the namespaces
 	req := &structs.NamespaceDeleteRequest{
@@ -550,7 +550,7 @@ func TestNamespaceEndpoint_DeleteNamespaces_NonTerminal_Federated_ACL(t *testing
 	// Create a job in the namespace on the non-authority
 	j := mock.Job()
 	j.Namespace = ns1.Name
-	assert.Nil(s2.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 1001, j))
+	assert.Nil(s2.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 1001, nil, j))
 
 	// Delete the namespaces without the correct permissions
 	req := &structs.NamespaceDeleteRequest{

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -775,7 +775,7 @@ func TestClientEndpoint_Register_GetEvals(t *testing.T) {
 	// Register a system job.
 	job := mock.SystemJob()
 	state := s1.fsm.State()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, nil, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -866,7 +866,7 @@ func TestClientEndpoint_UpdateStatus_GetEvals(t *testing.T) {
 	// Register a system job.
 	job := mock.SystemJob()
 	state := s1.fsm.State()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, nil, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -1188,7 +1188,7 @@ func TestClientEndpoint_UpdateDrain(t *testing.T) {
 
 	// Register a system job
 	job := mock.SystemJob()
-	require.Nil(s1.State().UpsertJob(structs.MsgTypeTestSetup, 10, job))
+	require.Nil(s1.State().UpsertJob(structs.MsgTypeTestSetup, 10, nil, job))
 
 	// Update the eligibility and expect evals
 	dereg.DrainStrategy = nil
@@ -1652,7 +1652,7 @@ func TestClientEndpoint_UpdateEligibility(t *testing.T) {
 
 	// Register a system job
 	job := mock.SystemJob()
-	require.Nil(s1.State().UpsertJob(structs.MsgTypeTestSetup, 10, job))
+	require.Nil(s1.State().UpsertJob(structs.MsgTypeTestSetup, 10, nil, job))
 
 	// Update the eligibility and expect evals
 	elig.Eligibility = structs.NodeSchedulingEligible
@@ -2649,7 +2649,7 @@ func TestClientEndpoint_UpdateAlloc(t *testing.T) {
 	// Inject mock job
 	job := mock.Job()
 	job.ID = "mytestjob"
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 101, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 101, nil, job)
 	require.Nil(err)
 
 	// Inject fake allocations
@@ -2737,7 +2737,7 @@ func TestClientEndpoint_UpdateAlloc_NodeNotReady(t *testing.T) {
 	state := s1.fsm.State()
 
 	job := mock.Job()
-	err = state.UpsertJob(structs.MsgTypeTestSetup, 101, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 101, nil, job)
 	require.NoError(t, err)
 
 	alloc := mock.Alloc()
@@ -2894,7 +2894,7 @@ func TestClientEndpoint_UpdateAlloc_Vault(t *testing.T) {
 	// Inject mock job
 	job := mock.Job()
 	job.ID = alloc.JobID
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 101, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 101, nil, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2961,7 +2961,7 @@ func TestClientEndpoint_CreateNodeEvals(t *testing.T) {
 
 	// Inject a fake system job.
 	job := mock.SystemJob()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, idx, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, idx, nil, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	idx++
@@ -3053,14 +3053,14 @@ func TestClientEndpoint_CreateNodeEvals_MultipleNSes(t *testing.T) {
 
 	// Inject a fake system job.
 	defaultJob := mock.SystemJob()
-	err = state.UpsertJob(structs.MsgTypeTestSetup, idx, defaultJob)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, idx, nil, defaultJob)
 	require.NoError(t, err)
 	idx++
 
 	nsJob := mock.SystemJob()
 	nsJob.ID = defaultJob.ID
 	nsJob.Namespace = ns1.Name
-	err = state.UpsertJob(structs.MsgTypeTestSetup, idx, nsJob)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, idx, nil, nsJob)
 	require.NoError(t, err)
 	idx++
 
@@ -3114,14 +3114,14 @@ func TestClientEndpoint_CreateNodeEvals_MultipleDCes(t *testing.T) {
 	// Inject a fake system job in the same dc
 	defaultJob := mock.SystemJob()
 	defaultJob.Datacenters = []string{"test1", "test2"}
-	err = state.UpsertJob(structs.MsgTypeTestSetup, idx, defaultJob)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, idx, nil, defaultJob)
 	require.NoError(t, err)
 	idx++
 
 	// Inject a fake system job in a different dc
 	nsJob := mock.SystemJob()
 	nsJob.Datacenters = []string{"test2", "test3"}
-	err = state.UpsertJob(structs.MsgTypeTestSetup, idx, nsJob)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, idx, nil, nsJob)
 	require.NoError(t, err)
 	idx++
 
@@ -4198,7 +4198,7 @@ func TestClientEndpoint_UpdateAlloc_Evals_ByTrigger(t *testing.T) {
 			job.ID = tc.name + "-test-job"
 
 			if !tc.missingJob {
-				err = fsmState.UpsertJob(structs.MsgTypeTestSetup, 101, job)
+				err = fsmState.UpsertJob(structs.MsgTypeTestSetup, 101, nil, job)
 				require.NoError(t, err)
 			}
 

--- a/nomad/operator_endpoint_test.go
+++ b/nomad/operator_endpoint_test.go
@@ -756,7 +756,7 @@ func generateSnapshot(t *testing.T) (*snapshot.Snapshot, *structs.Job) {
 	err := msgpackrpc.CallWithCodec(codec, "Job.Register", jobReq, &jobResp)
 	require.NoError(t, err)
 
-	err = s.State().UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err = s.State().UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.NoError(t, err)
 
 	snapshot, err := snapshot.New(s.logger, s.raft)

--- a/nomad/periodic_endpoint_test.go
+++ b/nomad/periodic_endpoint_test.go
@@ -27,7 +27,7 @@ func TestPeriodicEndpoint_Force(t *testing.T) {
 	// Create and insert a periodic job.
 	job := mock.PeriodicJob()
 	job.Periodic.ProhibitOverlap = true // Shouldn't affect anything.
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	s1.periodicDispatcher.Add(job)
@@ -79,7 +79,7 @@ func TestPeriodicEndpoint_Force_ACL(t *testing.T) {
 	// Create and insert a periodic job.
 	job := mock.PeriodicJob()
 	job.Periodic.ProhibitOverlap = true // Shouldn't affect anything.
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 100, job))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job))
 	err := s1.periodicDispatcher.Add(job)
 	assert.Nil(err)
 
@@ -176,7 +176,7 @@ func TestPeriodicEndpoint_Force_NonPeriodic(t *testing.T) {
 
 	// Create and insert a non-periodic job.
 	job := mock.Job()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/nomad/periodic_test.go
+++ b/nomad/periodic_test.go
@@ -672,7 +672,7 @@ func TestPeriodicDispatch_RunningChildren_NoEvals(t *testing.T) {
 	// Insert job.
 	state := s1.fsm.State()
 	job := mock.PeriodicJob()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job); err != nil {
 		t.Fatalf("UpsertJob failed: %v", err)
 	}
 
@@ -696,12 +696,12 @@ func TestPeriodicDispatch_RunningChildren_ActiveEvals(t *testing.T) {
 	// Insert periodic job and child.
 	state := s1.fsm.State()
 	job := mock.PeriodicJob()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job); err != nil {
 		t.Fatalf("UpsertJob failed: %v", err)
 	}
 
 	childjob := deriveChildJob(job)
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1001, childjob); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, childjob); err != nil {
 		t.Fatalf("UpsertJob failed: %v", err)
 	}
 
@@ -733,12 +733,12 @@ func TestPeriodicDispatch_RunningChildren_ActiveAllocs(t *testing.T) {
 	// Insert periodic job and child.
 	state := s1.fsm.State()
 	job := mock.PeriodicJob()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job); err != nil {
 		t.Fatalf("UpsertJob failed: %v", err)
 	}
 
 	childjob := deriveChildJob(job)
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1001, childjob); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, childjob); err != nil {
 		t.Fatalf("UpsertJob failed: %v", err)
 	}
 

--- a/nomad/scaling_endpoint_test.go
+++ b/nomad/scaling_endpoint_test.go
@@ -170,8 +170,8 @@ func TestScalingEndpoint_ListPolicies(t *testing.T) {
 	j2polH.Type = "horizontal"
 	j2polH.TargetTaskGroup(j2, j2.TaskGroups[0])
 
-	s1.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 1000, j1)
-	s1.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 1000, j2)
+	s1.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j1)
+	s1.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j2)
 
 	pols := []*structs.ScalingPolicy{j1polV, j1polH, j2polH}
 	s1.fsm.State().UpsertScalingPolicies(1000, pols)

--- a/nomad/search_endpoint_test.go
+++ b/nomad/search_endpoint_test.go
@@ -28,7 +28,7 @@ func registerMockJob(s *Server, t *testing.T, prefix string, counter int) *struc
 
 func registerJob(s *Server, t *testing.T, job *structs.Job) {
 	fsmState := s.fsm.State()
-	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, jobIndex, job))
+	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, jobIndex, nil, job))
 }
 
 func mockAlloc() *structs.Allocation {
@@ -803,11 +803,11 @@ func TestSearch_PrefixSearch_Namespace_ACL(t *testing.T) {
 	require.NoError(t, fsmState.UpsertNamespaces(500, []*structs.Namespace{ns}))
 
 	job1 := mock.Job()
-	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, 502, job1))
+	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, 502, nil, job1))
 
 	job2 := mock.Job()
 	job2.Namespace = ns.Name
-	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, 504, job2))
+	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, 504, nil, job2))
 
 	require.NoError(t, fsmState.UpsertNode(structs.MsgTypeTestSetup, 1001, mock.Node()))
 
@@ -928,7 +928,7 @@ func TestSearch_PrefixSearch_ScalingPolicy(t *testing.T) {
 	prefix := policy.ID
 	fsmState := s.fsm.State()
 
-	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, jobIndex, job))
+	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, jobIndex, nil, job))
 
 	req := &structs.SearchRequest{
 		Prefix:  prefix,
@@ -1447,7 +1447,7 @@ func TestSearch_FuzzySearch_ScalingPolicy(t *testing.T) {
 	job, policy := mock.JobWithScalingPolicy()
 	fsmState := s.fsm.State()
 
-	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, jobIndex, job))
+	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, jobIndex, nil, job))
 
 	req := &structs.FuzzySearchRequest{
 		Text:    policy.ID[0:3], // scaling policies are prefix searched
@@ -1488,11 +1488,11 @@ func TestSearch_FuzzySearch_Namespace_ACL(t *testing.T) {
 	require.NoError(t, fsmState.UpsertNamespaces(500, []*structs.Namespace{ns}))
 
 	job1 := mock.Job()
-	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, 502, job1))
+	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, 502, nil, job1))
 
 	job2 := mock.Job()
 	job2.Namespace = ns.Name
-	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, 504, job2))
+	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, 504, nil, job2))
 
 	node := mock.Node()
 	node.Name = "run-jobs"
@@ -1626,19 +1626,19 @@ func TestSearch_FuzzySearch_MultiNamespace_ACL(t *testing.T) {
 	job1.Name = "teamA-job1"
 	job1.ID = "job1"
 	job1.Namespace = "teamA"
-	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, inc(), job1))
+	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, inc(), nil, job1))
 
 	job2 := mock.Job()
 	job2.Name = "teamB-job2"
 	job2.ID = "job2"
 	job2.Namespace = "teamB"
-	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, inc(), job2))
+	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, inc(), nil, job2))
 
 	job3 := mock.Job()
 	job3.Name = "teamC-job3"
 	job3.ID = "job3"
 	job3.Namespace = "teamC"
-	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, inc(), job3))
+	require.NoError(t, fsmState.UpsertJob(structs.MsgTypeTestSetup, inc(), nil, job3))
 
 	// Upsert a node
 	node := mock.Node()

--- a/nomad/service_registration_endpoint_test.go
+++ b/nomad/service_registration_endpoint_test.go
@@ -884,7 +884,7 @@ func TestServiceRegistration_List(t *testing.T) {
 				job := allocs[0].Job
 				job.Namespace = "platform"
 				allocs[0].Namespace = "platform"
-				require.NoError(t, s.State().UpsertJob(structs.MsgTypeTestSetup, 10, job))
+				require.NoError(t, s.State().UpsertJob(structs.MsgTypeTestSetup, 10, nil, job))
 				s.signAllocIdentities(job, allocs)
 				require.NoError(t, s.State().UpsertAllocs(structs.MsgTypeTestSetup, 15, allocs))
 
@@ -1171,7 +1171,7 @@ func TestServiceRegistration_GetService(t *testing.T) {
 				// Generate an allocation with a signed identity
 				allocs := []*structs.Allocation{mock.Alloc()}
 				job := allocs[0].Job
-				require.NoError(t, s.State().UpsertJob(structs.MsgTypeTestSetup, 10, job))
+				require.NoError(t, s.State().UpsertJob(structs.MsgTypeTestSetup, 10, nil, job))
 				s.signAllocIdentities(job, allocs)
 				require.NoError(t, s.State().UpsertAllocs(structs.MsgTypeTestSetup, 15, allocs))
 

--- a/nomad/state/deployment_events_test.go
+++ b/nomad/state/deployment_events_test.go
@@ -27,7 +27,7 @@ func TestDeploymentEventFromChanges(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 
-	require.NoError(t, s.upsertJobImpl(10, j, false, setupTx))
+	require.NoError(t, s.upsertJobImpl(10, nil, j, false, setupTx))
 	require.NoError(t, s.upsertDeploymentImpl(10, d, setupTx))
 
 	setupTx.Txn.Commit()

--- a/nomad/state/events_test.go
+++ b/nomad/state/events_test.go
@@ -111,7 +111,7 @@ func TestEventsFromChanges_DeploymentUpdate(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 
-	require.NoError(t, s.upsertJobImpl(10, j, false, setupTx))
+	require.NoError(t, s.upsertJobImpl(10, nil, j, false, setupTx))
 	require.NoError(t, s.upsertDeploymentImpl(10, d, setupTx))
 
 	setupTx.Txn.Commit()
@@ -155,7 +155,7 @@ func TestEventsFromChanges_DeploymentPromotion(t *testing.T) {
 	tg2 := tg1.Copy()
 	tg2.Name = "foo"
 	j.TaskGroups = append(j.TaskGroups, tg2)
-	require.NoError(t, s.upsertJobImpl(10, j, false, setupTx))
+	require.NoError(t, s.upsertJobImpl(10, nil, j, false, setupTx))
 
 	d := mock.Deployment()
 	d.StatusDescription = structs.DeploymentStatusDescriptionRunningNeedsPromotion
@@ -232,7 +232,7 @@ func TestEventsFromChanges_DeploymentAllocHealthRequestType(t *testing.T) {
 	tg2 := tg1.Copy()
 	tg2.Name = "foo"
 	j.TaskGroups = append(j.TaskGroups, tg2)
-	require.NoError(t, s.upsertJobImpl(10, j, false, setupTx))
+	require.NoError(t, s.upsertJobImpl(10, nil, j, false, setupTx))
 
 	d := mock.Deployment()
 	d.StatusDescription = structs.DeploymentStatusDescriptionRunningNeedsPromotion
@@ -437,7 +437,7 @@ func TestEventsFromChanges_ApplyPlanResultsRequestType(t *testing.T) {
 	alloc.DeploymentID = d.ID
 	alloc2.DeploymentID = d.ID
 
-	require.NoError(t, s.UpsertJob(structs.MsgTypeTestSetup, 9, job))
+	require.NoError(t, s.UpsertJob(structs.MsgTypeTestSetup, 9, nil, job))
 
 	eval := mock.Eval()
 	eval.JobID = job.ID
@@ -584,7 +584,7 @@ func TestEventsFromChanges_AllocUpdateDesiredTransitionRequestType(t *testing.T)
 
 	alloc := mock.Alloc()
 
-	require.Nil(t, s.UpsertJob(structs.MsgTypeTestSetup, 10, alloc.Job))
+	require.Nil(t, s.UpsertJob(structs.MsgTypeTestSetup, 10, nil, alloc.Job))
 	require.Nil(t, s.UpsertAllocs(structs.MsgTypeTestSetup, 11, []*structs.Allocation{alloc}))
 
 	msgType := structs.AllocUpdateDesiredTransitionRequestType

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/nomad/state/indexer"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -66,6 +66,7 @@ func init() {
 		jobTableSchema,
 		jobSummarySchema,
 		jobVersionSchema,
+		jobSubmissionSchema,
 		deploymentSchema,
 		periodicLaunchTableSchema,
 		evalTableSchema,
@@ -269,6 +270,52 @@ func jobVersionSchema() *memdb.TableSchema {
 
 						&memdb.UintFieldIndex{
 							Field: "Version",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// jobSubmissionSchema returns the memdb table schema of job submissions
+// which contain the original source material of each job, per version.
+// Unique index by Namespace, JobID, and Version.
+func jobSubmissionSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: "job_submission",
+		Indexes: map[string]*memdb.IndexSchema{
+			"id": {
+				Name:         "id",
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.CompoundIndex{
+					Indexes: []memdb.Indexer{
+						&memdb.StringFieldIndex{
+							Field: "Namespace",
+						},
+						&memdb.StringFieldIndex{
+							Field:     "JobID",
+							Lowercase: true,
+						},
+						&memdb.UintFieldIndex{
+							Field: "Version",
+						},
+					},
+				},
+			},
+			"by_jobID": {
+				Name:         "by_jobID",
+				AllowMissing: false,
+				Unique:       false,
+				Indexer: &memdb.CompoundIndex{
+					Indexes: []memdb.Indexer{
+						&memdb.StringFieldIndex{
+							Field: "Namespace",
+						},
+						&memdb.StringFieldIndex{
+							Field:     "JobID",
+							Lowercase: true,
 						},
 					},
 				},

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -5354,14 +5354,20 @@ func (s *StateStore) updateJobScalingPolicies(index uint64, job *structs.Job, tx
 // job structure originates from. It is up to the job submitter to include the source
 // material, and as such sub may be nil, in which case nothing is stored.
 func (s *StateStore) updateJobSubmission(index uint64, sub *structs.JobSubmission, namespace, jobID string, version uint64, txn *txn) error {
-	if sub == nil || namespace == "" || jobID == "" {
+	switch {
+	case sub == nil:
 		return nil
+	case namespace == "":
+		return errors.New("job_submission requires a namespace")
+	case jobID == "":
+		return errors.New("job_submission requires a jobID")
+	default:
+		sub.Namespace = namespace
+		sub.JobID = jobID
+		sub.JobIndex = index
+		sub.Version = version
+		return txn.Insert("job_submission", sub)
 	}
-	sub.Namespace = namespace
-	sub.JobID = jobID
-	sub.JobIndex = index
-	sub.Version = version
-	return txn.Insert("job_submission", sub)
 }
 
 // updateJobCSIPlugins runs on job update, and indexes the job in the plugin

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -5364,7 +5364,7 @@ func (s *StateStore) updateJobSubmission(index uint64, sub *structs.JobSubmissio
 	default:
 		sub.Namespace = namespace
 		sub.JobID = jobID
-		sub.JobIndex = index
+		sub.JobModifyIndex = index
 		sub.Version = version
 		return txn.Insert("job_submission", sub)
 	}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -107,7 +107,7 @@ func TestStateStore_UpsertPlanResults_AllocationsCreated_Denormalized(t *testing
 	job := alloc.Job
 	alloc.Job = nil
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -178,13 +178,13 @@ func TestStateStore_UpsertPlanResults_AllocationsDenormalized(t *testing.T) {
 
 	require := require.New(t)
 	require.NoError(state.UpsertAllocs(structs.MsgTypeTestSetup, 900, []*structs.Allocation{stoppedAlloc, preemptedAlloc}))
-	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 999, job))
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, job))
 
 	// modify job and ensure that stopped and preempted alloc point to original Job
 	mJob := job.Copy()
 	mJob.TaskGroups[0].Name = "other"
 
-	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 1001, mJob))
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, mJob))
 
 	eval := mock.Eval()
 	eval.JobID = job.ID
@@ -263,7 +263,7 @@ func TestStateStore_UpsertPlanResults_Deployment(t *testing.T) {
 	alloc.DeploymentID = d.ID
 	alloc2.DeploymentID = d.ID
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -366,7 +366,7 @@ func TestStateStore_UpsertPlanResults_PreemptedAllocs(t *testing.T) {
 	alloc.Job = nil
 
 	// Insert job
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 999, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, job)
 	require.NoError(err)
 
 	// Create an eval
@@ -443,7 +443,7 @@ func TestStateStore_UpsertPlanResults_DeploymentUpdates(t *testing.T) {
 
 	// Create a job that applies to all
 	job := mock.Job()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 998, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 998, nil, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -571,7 +571,7 @@ func TestStateStore_OldDeployment(t *testing.T) {
 	state := testStateStore(t)
 	job := mock.Job()
 	job.ID = "job1"
-	state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 
 	deploy1 := mock.Deployment()
 	deploy1.JobID = job.ID
@@ -987,7 +987,7 @@ func TestStateStore_DeleteNamespaces_NonTerminalJobs(t *testing.T) {
 
 	job := mock.Job()
 	job.Namespace = ns.Name
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1001, job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job))
 
 	// Create a watchset so we can test that delete fires the watch
 	ws := memdb.NewWatchSet()
@@ -1906,7 +1906,7 @@ func TestStateStore_UpsertJob_Job(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if !watchFired(ws) {
@@ -1986,14 +1986,14 @@ func TestStateStore_UpdateUpsertJob_Job(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	job2 := mock.Job()
 	job2.ID = job.ID
 	job2.AllAtOnce = true
-	err = state.UpsertJob(structs.MsgTypeTestSetup, 1001, job2)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2091,7 +2091,7 @@ func TestStateStore_UpdateUpsertJob_PeriodicJob(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2099,7 +2099,7 @@ func TestStateStore_UpdateUpsertJob_PeriodicJob(t *testing.T) {
 	job2 := job.Copy()
 	job2.Periodic = nil
 	job2.ID = fmt.Sprintf("%v/%s-1490635020", job.ID, structs.PeriodicLaunchSuffix)
-	err = state.UpsertJob(structs.MsgTypeTestSetup, 1001, job2)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2113,7 +2113,7 @@ func TestStateStore_UpdateUpsertJob_PeriodicJob(t *testing.T) {
 
 	job3 := job.Copy()
 	job3.TaskGroups[0].Tasks[0].Name = "new name"
-	err = state.UpsertJob(structs.MsgTypeTestSetup, 1003, job3)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1003, nil, job3)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2142,7 +2142,7 @@ func TestStateStore_UpsertJob_BadNamespace(t *testing.T) {
 	job := mock.Job()
 	job.Namespace = "foo"
 
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	assert.Contains(err.Error(), "nonexistent namespace")
 
 	ws := memdb.NewWatchSet()
@@ -2166,14 +2166,14 @@ func TestStateStore_UpsertJob_ChildJob(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, parent); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, parent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	child := mock.Job()
 	child.Status = ""
 	child.ParentID = parent.ID
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1001, child); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, child); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2215,7 +2215,7 @@ func TestStateStore_UpdateUpsertJob_JobVersion(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2228,7 +2228,7 @@ func TestStateStore_UpdateUpsertJob_JobVersion(t *testing.T) {
 		finalJob = mock.Job()
 		finalJob.ID = job.ID
 		finalJob.Name = fmt.Sprintf("%d", i)
-		err = state.UpsertJob(structs.MsgTypeTestSetup, uint64(1000+i), finalJob)
+		err = state.UpsertJob(structs.MsgTypeTestSetup, uint64(1000+i), nil, finalJob)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -2295,7 +2295,7 @@ func TestStateStore_DeleteJob_Job(t *testing.T) {
 	state := testStateStore(t)
 	job := mock.Job()
 
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2385,7 +2385,7 @@ func TestStateStore_DeleteJobTxn_BatchDeletes(t *testing.T) {
 		stateIndex++
 		job := mock.BatchJob()
 
-		err := state.UpsertJob(structs.MsgTypeTestSetup, stateIndex, job)
+		err := state.UpsertJob(structs.MsgTypeTestSetup, stateIndex, nil, job)
 		require.NoError(t, err)
 
 		jobs[i] = job
@@ -2399,7 +2399,7 @@ func TestStateStore_DeleteJobTxn_BatchDeletes(t *testing.T) {
 				"Version": fmt.Sprintf("%d", vi),
 			}
 
-			require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, stateIndex, job))
+			require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, stateIndex, nil, job))
 		}
 	}
 
@@ -2456,7 +2456,7 @@ func TestStateStore_DeleteJob_MultipleVersions(t *testing.T) {
 	ws := memdb.NewWatchSet()
 	_, err := state.JobVersionsByID(ws, job.Namespace, job.ID)
 	assert.Nil(err)
-	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, job))
+	assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job))
 	assert.True(watchFired(ws))
 
 	var finalJob *structs.Job
@@ -2464,7 +2464,7 @@ func TestStateStore_DeleteJob_MultipleVersions(t *testing.T) {
 		finalJob = mock.Job()
 		finalJob.ID = job.ID
 		finalJob.Priority = i
-		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, uint64(1000+i), finalJob))
+		assert.Nil(state.UpsertJob(structs.MsgTypeTestSetup, uint64(1000+i), nil, finalJob))
 	}
 
 	assert.Nil(state.DeleteJob(1020, job.Namespace, job.ID))
@@ -2504,7 +2504,7 @@ func TestStateStore_DeleteJob_ChildJob(t *testing.T) {
 	state := testStateStore(t)
 
 	parent := mock.Job()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 998, parent); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 998, nil, parent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2512,7 +2512,7 @@ func TestStateStore_DeleteJob_ChildJob(t *testing.T) {
 	child.Status = ""
 	child.ParentID = parent.ID
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, child); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, child); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2562,7 +2562,7 @@ func TestStateStore_Jobs(t *testing.T) {
 		job := mock.Job()
 		jobs = append(jobs, job)
 
-		err := state.UpsertJob(structs.MsgTypeTestSetup, 1000+uint64(i), job)
+		err := state.UpsertJob(structs.MsgTypeTestSetup, 1000+uint64(i), nil, job)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -2604,7 +2604,7 @@ func TestStateStore_JobVersions(t *testing.T) {
 		job := mock.Job()
 		jobs = append(jobs, job)
 
-		err := state.UpsertJob(structs.MsgTypeTestSetup, 1000+uint64(i), job)
+		err := state.UpsertJob(structs.MsgTypeTestSetup, 1000+uint64(i), nil, job)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -2643,7 +2643,7 @@ func TestStateStore_JobsByIDPrefix(t *testing.T) {
 	job := mock.Job()
 
 	job.ID = "redis"
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2686,7 +2686,7 @@ func TestStateStore_JobsByIDPrefix(t *testing.T) {
 
 	job = mock.Job()
 	job.ID = "riak"
-	err = state.UpsertJob(structs.MsgTypeTestSetup, 1001, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2739,8 +2739,8 @@ func TestStateStore_JobsByIDPrefix_Namespaces(t *testing.T) {
 	job2.Namespace = ns2.Name
 
 	require.NoError(t, state.UpsertNamespaces(998, []*structs.Namespace{ns1, ns2}))
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, job1))
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1001, job2))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job1))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job2))
 
 	gatherJobs := func(iter memdb.ResultIterator) []*structs.Job {
 		var jobs []*structs.Job
@@ -2781,7 +2781,7 @@ func TestStateStore_JobsByIDPrefix_Namespaces(t *testing.T) {
 	job3 := mock.Job()
 	job3.ID = "riak"
 	job3.Namespace = ns1.Name
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1003, job3))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1003, nil, job3))
 	require.True(t, watchFired(ws))
 
 	ws = memdb.NewWatchSet()
@@ -2830,10 +2830,10 @@ func TestStateStore_JobsByNamespace(t *testing.T) {
 	_, err = state.JobsByNamespace(watches[1], ns2.Name)
 	require.NoError(t, err)
 
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1001, job1))
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1002, job2))
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1003, job3))
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1004, job4))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job1))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1002, nil, job2))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1003, nil, job3))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1004, nil, job4))
 	require.True(t, watchFired(watches[0]))
 	require.True(t, watchFired(watches[1]))
 
@@ -2887,7 +2887,7 @@ func TestStateStore_JobsByPeriodic(t *testing.T) {
 		job := mock.Job()
 		nonPeriodic = append(nonPeriodic, job)
 
-		err := state.UpsertJob(structs.MsgTypeTestSetup, 1000+uint64(i), job)
+		err := state.UpsertJob(structs.MsgTypeTestSetup, 1000+uint64(i), nil, job)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -2897,7 +2897,7 @@ func TestStateStore_JobsByPeriodic(t *testing.T) {
 		job := mock.PeriodicJob()
 		periodic = append(periodic, job)
 
-		err := state.UpsertJob(structs.MsgTypeTestSetup, 2000+uint64(i), job)
+		err := state.UpsertJob(structs.MsgTypeTestSetup, 2000+uint64(i), nil, job)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -2960,7 +2960,7 @@ func TestStateStore_JobsByScheduler(t *testing.T) {
 		job := mock.Job()
 		serviceJobs = append(serviceJobs, job)
 
-		err := state.UpsertJob(structs.MsgTypeTestSetup, 1000+uint64(i), job)
+		err := state.UpsertJob(structs.MsgTypeTestSetup, 1000+uint64(i), nil, job)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -2971,7 +2971,7 @@ func TestStateStore_JobsByScheduler(t *testing.T) {
 		job.Status = structs.JobStatusRunning
 		sysJobs = append(sysJobs, job)
 
-		err := state.UpsertJob(structs.MsgTypeTestSetup, 2000+uint64(i), job)
+		err := state.UpsertJob(structs.MsgTypeTestSetup, 2000+uint64(i), nil, job)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -3038,7 +3038,7 @@ func TestStateStore_JobsByGC(t *testing.T) {
 		}
 		nonGc[job.ID] = struct{}{}
 
-		if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000+uint64(i), job); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000+uint64(i), nil, job); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	}
@@ -3048,7 +3048,7 @@ func TestStateStore_JobsByGC(t *testing.T) {
 		job.Type = structs.JobTypeBatch
 		gc[job.ID] = struct{}{}
 
-		if err := state.UpsertJob(structs.MsgTypeTestSetup, 2000+uint64(i), job); err != nil {
+		if err := state.UpsertJob(structs.MsgTypeTestSetup, 2000+uint64(i), nil, job); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -3642,11 +3642,11 @@ func TestStateStore_CSIPlugin_Lifecycle(t *testing.T) {
 
 		controllerJob := mock.CSIPluginJob(structs.CSIPluginTypeController, plugID)
 		controllerJobID = controllerJob.ID
-		err = store.UpsertJob(structs.MsgTypeTestSetup, nextIndex(store), controllerJob)
+		err = store.UpsertJob(structs.MsgTypeTestSetup, nextIndex(store), nil, controllerJob)
 
 		nodeJob := mock.CSIPluginJob(structs.CSIPluginTypeNode, plugID)
 		nodeJobID = nodeJob.ID
-		err = store.UpsertJob(structs.MsgTypeTestSetup, nextIndex(store), nodeJob)
+		err = store.UpsertJob(structs.MsgTypeTestSetup, nextIndex(store), nil, nodeJob)
 
 		// plugins created, but no fingerprints or allocs yet
 		// note: there's no job summary yet, but we know the task
@@ -3976,7 +3976,7 @@ func TestStateStore_LatestIndex(t *testing.T) {
 	}
 
 	exp := uint64(2000)
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, exp, mock.Job()); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, exp, nil, mock.Job()); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4257,7 +4257,7 @@ func TestStateStore_UpsertEvals_Eval_ChildJob(t *testing.T) {
 	state := testStateStore(t)
 
 	parent := mock.Job()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 998, parent); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 998, nil, parent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4265,7 +4265,7 @@ func TestStateStore_UpsertEvals_Eval_ChildJob(t *testing.T) {
 	child.Status = ""
 	child.ParentID = parent.ID
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, child); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, child); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4495,7 +4495,7 @@ func TestStateStore_DeleteEval_ChildJob(t *testing.T) {
 	state := testStateStore(t)
 
 	parent := mock.Job()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 998, parent); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 998, nil, parent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4503,7 +4503,7 @@ func TestStateStore_DeleteEval_ChildJob(t *testing.T) {
 	child.Status = ""
 	child.ParentID = parent.ID
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, child); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, child); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -5194,12 +5194,12 @@ func TestStateStore_UpdateAllocsFromClient(t *testing.T) {
 	must.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 997, node))
 
 	parent := mock.Job()
-	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 998, parent))
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 998, nil, parent))
 
 	child := mock.Job()
 	child.Status = ""
 	child.ParentID = parent.ID
-	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, child))
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, child))
 
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
@@ -5264,8 +5264,8 @@ func TestStateStore_UpdateAllocsFromClient_ChildJob(t *testing.T) {
 	alloc2.NodeID = node.ID
 
 	must.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 998, node))
-	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc1.Job))
-	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc2.Job))
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, alloc1.Job))
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, alloc2.Job))
 	must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1, alloc2}))
 
 	// Create watchsets so we can test that update fires the watch
@@ -5369,7 +5369,7 @@ func TestStateStore_UpdateMultipleAllocsFromClient(t *testing.T) {
 	alloc.NodeID = node.ID
 
 	must.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 998, node))
-	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job))
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, alloc.Job))
 	must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc}))
 
 	// Create the delta updates
@@ -5439,7 +5439,7 @@ func TestStateStore_UpdateAllocsFromClient_Deployment(t *testing.T) {
 	alloc.DeploymentID = deployment.ID
 
 	must.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 998, node))
-	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job))
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, alloc.Job))
 	must.NoError(t, state.UpsertDeployment(1000, deployment))
 	must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc}))
 
@@ -5491,7 +5491,7 @@ func TestStateStore_UpdateAllocsFromClient_DeploymentStateMerges(t *testing.T) {
 	}
 
 	must.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 998, node))
-	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job))
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, alloc.Job))
 	must.NoError(t, state.UpsertDeployment(1000, deployment))
 	must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc}))
 
@@ -5539,8 +5539,8 @@ func TestStateStore_UpdateAllocsFromClient_UpdateNodes(t *testing.T) {
 	must.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1000, node1))
 	must.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1001, node2))
 	must.NoError(t, state.UpsertNode(structs.MsgTypeTestSetup, 1002, node3))
-	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1003, alloc1.Job))
-	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1004, alloc2.Job))
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1003, nil, alloc1.Job))
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1004, nil, alloc2.Job))
 	must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1005, []*structs.Allocation{alloc1, alloc2, alloc3}))
 
 	// Create watches to make sure they fire when nodes are updated.
@@ -5617,7 +5617,7 @@ func TestStateStore_UpsertAlloc_Alloc(t *testing.T) {
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, alloc.Job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -5700,7 +5700,7 @@ func TestStateStore_UpsertAlloc_Deployment(t *testing.T) {
 	deployment.TaskGroups[alloc.TaskGroup].ProgressDeadline = pdeadline
 	alloc.DeploymentID = deployment.ID
 
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, alloc.Job))
 	require.Nil(state.UpsertDeployment(1000, deployment))
 
 	// Create a watch set so we can test that update fires the watch
@@ -5762,8 +5762,8 @@ func TestStateStore_UpsertAlloc_AllocsByNamespace(t *testing.T) {
 	alloc4.Job.Namespace = ns2.Name
 
 	require.NoError(t, state.UpsertNamespaces(998, []*structs.Namespace{ns1, ns2}))
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc1.Job))
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, alloc3.Job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, alloc1.Job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, alloc3.Job))
 
 	// Create watchsets so we can test that update fires the watch
 	watches := []memdb.WatchSet{memdb.NewWatchSet(), memdb.NewWatchSet()}
@@ -5837,13 +5837,13 @@ func TestStateStore_UpsertAlloc_ChildJob(t *testing.T) {
 	state := testStateStore(t)
 
 	parent := mock.Job()
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 998, parent))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 998, nil, parent))
 
 	child := mock.Job()
 	child.Status = ""
 	child.ParentID = parent.ID
 
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, child))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, child))
 
 	alloc := mock.Alloc()
 	alloc.JobID = child.ID
@@ -5880,7 +5880,7 @@ func TestStateStore_UpdateAlloc_Alloc(t *testing.T) {
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, alloc.Job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -5982,7 +5982,7 @@ func TestStateStore_UpdateAlloc_Lost(t *testing.T) {
 	alloc := mock.Alloc()
 	alloc.ClientStatus = "foo"
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, alloc.Job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -6020,7 +6020,7 @@ func TestStateStore_UpdateAlloc_NoJob(t *testing.T) {
 
 	// Upsert a job
 	state.UpsertJobSummary(998, mock.JobSummary(alloc.JobID))
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, alloc.Job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -6063,7 +6063,7 @@ func TestStateStore_UpdateAllocDesiredTransition(t *testing.T) {
 	state := testStateStore(t)
 	alloc := mock.Alloc()
 
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, alloc.Job))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc}))
 
 	t1 := &structs.DesiredTransition{
@@ -6131,7 +6131,7 @@ func TestStateStore_JobSummary(t *testing.T) {
 
 	// Add a job
 	job := mock.Job()
-	state.UpsertJob(structs.MsgTypeTestSetup, 900, job)
+	state.UpsertJob(structs.MsgTypeTestSetup, 900, nil, job)
 
 	// Get the job back
 	ws := memdb.NewWatchSet()
@@ -6213,7 +6213,7 @@ func TestStateStore_JobSummary(t *testing.T) {
 	// Re-register the same job
 	job1 := mock.Job()
 	job1.ID = job.ID
-	state.UpsertJob(structs.MsgTypeTestSetup, 1000, job1)
+	state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job1)
 	outJob2, _ := state.JobByID(ws, job1.Namespace, job1.ID)
 	if outJob2.CreateIndex != 1000 {
 		t.Fatalf("bad create index: %v", outJob2.CreateIndex)
@@ -6260,7 +6260,7 @@ func TestStateStore_ReconcileJobSummary(t *testing.T) {
 	tg2 := alloc.Job.TaskGroups[0].Copy()
 	tg2.Name = "db"
 	alloc.Job.TaskGroups = append(alloc.Job.TaskGroups, tg2)
-	state.UpsertJob(structs.MsgTypeTestSetup, 100, alloc.Job)
+	state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, alloc.Job)
 
 	// Create one more alloc for the db task group
 	alloc2 := mock.Alloc()
@@ -6363,7 +6363,7 @@ func TestStateStore_ReconcileParentJobSummary(t *testing.T) {
 		Payload: "random",
 	}
 	job1.TaskGroups[0].Count = 1
-	state.UpsertJob(structs.MsgTypeTestSetup, 100, job1)
+	state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job1)
 
 	// Make a child job
 	childJob := job1.Copy()
@@ -6385,7 +6385,7 @@ func TestStateStore_ReconcileParentJobSummary(t *testing.T) {
 	alloc2.JobID = childJob.ID
 	alloc2.ClientStatus = structs.AllocClientStatusFailed
 
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 110, childJob))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 110, nil, childJob))
 	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 111, []*structs.Allocation{alloc, alloc2}))
 
 	// Make the summary incorrect in the state store
@@ -6442,7 +6442,7 @@ func TestStateStore_UpdateAlloc_JobNotPresent(t *testing.T) {
 	state := testStateStore(t)
 
 	alloc := mock.Alloc()
-	state.UpsertJob(structs.MsgTypeTestSetup, 100, alloc.Job)
+	state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, alloc.Job)
 	state.UpsertAllocs(structs.MsgTypeTestSetup, 200, []*structs.Allocation{alloc})
 
 	// Delete the job
@@ -6458,7 +6458,7 @@ func TestStateStore_UpdateAlloc_JobNotPresent(t *testing.T) {
 	}
 
 	// Re-Register the job
-	state.UpsertJob(structs.MsgTypeTestSetup, 500, alloc.Job)
+	state.UpsertJob(structs.MsgTypeTestSetup, 500, nil, alloc.Job)
 
 	// Update the alloc again
 	alloc2 := alloc.Copy()
@@ -6672,7 +6672,7 @@ func TestStateStore_AllocsForRegisteredJob(t *testing.T) {
 
 	job := mock.Job()
 	job.ID = "foo"
-	state.UpsertJob(structs.MsgTypeTestSetup, 100, job)
+	state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job)
 	for i := 0; i < 3; i++ {
 		alloc := mock.Alloc()
 		alloc.Job = job
@@ -6690,7 +6690,7 @@ func TestStateStore_AllocsForRegisteredJob(t *testing.T) {
 	job1 := mock.Job()
 	job1.ID = "foo"
 	job1.CreateIndex = 50
-	state.UpsertJob(structs.MsgTypeTestSetup, 300, job1)
+	state.UpsertJob(structs.MsgTypeTestSetup, 300, nil, job1)
 	for i := 0; i < 4; i++ {
 		alloc := mock.Alloc()
 		alloc.Job = job1
@@ -7325,7 +7325,7 @@ func TestStateJobSummary_UpdateJobCount(t *testing.T) {
 		t.Fatalf("bad: %v", err)
 	}
 
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -7458,7 +7458,7 @@ func TestJobSummary_UpdateClientStatus(t *testing.T) {
 	alloc3.Job = job
 	alloc3.JobID = job.ID
 
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -7634,7 +7634,7 @@ func TestStateStore_UpsertDeploymentStatusUpdate_Successful(t *testing.T) {
 
 	// Insert a job
 	job := mock.Job()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, nil, job); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -7691,9 +7691,9 @@ func TestStateStore_UpdateJobStability(t *testing.T) {
 
 	// Insert a job twice to get two versions
 	job := mock.Job()
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1, job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1, nil, job))
 
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 2, job.Copy()))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 2, nil, job.Copy()))
 
 	// Update the stability to true
 	err := state.UpdateJobStability(3, job.Namespace, job.ID, 0, true)
@@ -7774,7 +7774,7 @@ func TestStateStore_UpsertDeploymentPromotion_Unhealthy(t *testing.T) {
 
 	// Create a job
 	j := mock.Job()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1, j))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1, nil, j))
 
 	// Create a deployment
 	d := mock.Deployment()
@@ -7823,7 +7823,7 @@ func TestStateStore_UpsertDeploymentPromotion_NoCanaries(t *testing.T) {
 
 	// Create a job
 	j := mock.Job()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1, j))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1, nil, j))
 
 	// Create a deployment
 	d := mock.Deployment()
@@ -7855,7 +7855,7 @@ func TestStateStore_UpsertDeploymentPromotion_All(t *testing.T) {
 	tg2 := tg1.Copy()
 	tg2.Name = "foo"
 	j.TaskGroups = append(j.TaskGroups, tg2)
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, j); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1, nil, j); err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -7955,7 +7955,7 @@ func TestStateStore_UpsertDeploymentPromotion_Subset(t *testing.T) {
 	tg2 := tg1.Copy()
 	tg2.Name = "foo"
 	j.TaskGroups = append(j.TaskGroups, tg2)
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1, j))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 1, nil, j))
 
 	// Create a deployment
 	d := mock.Deployment()
@@ -8128,7 +8128,7 @@ func TestStateStore_UpsertDeploymentAlloc_Canaries(t *testing.T) {
 
 	// Create a Job
 	job := mock.Job()
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 3, job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 3, nil, job))
 
 	// Create alloc with canary status
 	a := mock.Alloc()
@@ -8198,7 +8198,7 @@ func TestStateStore_UpsertDeploymentAlloc_NoCanaries(t *testing.T) {
 
 	// Create a Job
 	job := mock.Job()
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 3, job))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 3, nil, job))
 
 	// Create alloc with canary status
 	a := mock.Alloc()
@@ -9635,7 +9635,7 @@ func TestStateStore_UpsertJob_PreserveScalingPolicyIDsAndIndex(t *testing.T) {
 	job, policy := mock.JobWithScalingPolicy()
 
 	var newIndex uint64 = 1000
-	err := state.UpsertJob(structs.MsgTypeTestSetup, newIndex, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, newIndex, nil, job)
 	require.NoError(err)
 
 	ws := memdb.NewWatchSet()
@@ -9653,7 +9653,7 @@ func TestStateStore_UpsertJob_PreserveScalingPolicyIDsAndIndex(t *testing.T) {
 	// update the job
 	job.Meta["new-meta"] = "new-value"
 	newIndex += 100
-	err = state.UpsertJob(structs.MsgTypeTestSetup, newIndex, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, newIndex, nil, job)
 	require.NoError(err)
 	require.False(watchFired(ws), "watch should not have fired")
 
@@ -9680,7 +9680,7 @@ func TestStateStore_UpsertJob_UpdateScalingPolicy(t *testing.T) {
 	job, policy := mock.JobWithScalingPolicy()
 
 	var oldIndex uint64 = 1000
-	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, oldIndex, job))
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, oldIndex, nil, job))
 
 	ws := memdb.NewWatchSet()
 	p1, err := state.ScalingPolicyByTargetAndType(ws, policy.Target, policy.Type)
@@ -9699,7 +9699,7 @@ func TestStateStore_UpsertJob_UpdateScalingPolicy(t *testing.T) {
 	newPolicy := p1.Copy()
 	newPolicy.Policy["new-field"] = "new-value"
 	job.TaskGroups[0].Scaling = newPolicy
-	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, oldIndex+100, job))
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, oldIndex+100, nil, job))
 	require.True(watchFired(ws), "watch should have fired")
 
 	p2, err := state.ScalingPolicyByTargetAndType(nil, policy.Target, policy.Type)
@@ -9779,7 +9779,7 @@ func TestStateStore_StopJob_DeleteScalingPolicies(t *testing.T) {
 
 	job := mock.Job()
 
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.NoError(err)
 
 	policy := mock.ScalingPolicy()
@@ -9800,7 +9800,7 @@ func TestStateStore_StopJob_DeleteScalingPolicies(t *testing.T) {
 	job, err = state.JobByID(nil, job.Namespace, job.ID)
 	require.NoError(err)
 	job.Stop = true
-	err = state.UpsertJob(structs.MsgTypeTestSetup, 1200, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1200, nil, job)
 	require.NoError(err)
 
 	// Ensure:
@@ -9834,7 +9834,7 @@ func TestStateStore_UnstopJob_UpsertScalingPolicies(t *testing.T) {
 	require.Nil(list.Next())
 
 	// upsert a stopped job, verify that we don't fire the watcher or add any scaling policies
-	err = state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.NoError(err)
 	require.True(watchFired(ws))
 	list, err = state.ScalingPolicies(ws)
@@ -9847,7 +9847,7 @@ func TestStateStore_UnstopJob_UpsertScalingPolicies(t *testing.T) {
 	require.NoError(err)
 	// Unstop this job, say you'll run it again...
 	job.Stop = false
-	err = state.UpsertJob(structs.MsgTypeTestSetup, 1100, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1100, nil, job)
 	require.NoError(err)
 
 	// Ensure the scaling policy still exists, watch was not fired, index was not advanced
@@ -9869,7 +9869,7 @@ func TestStateStore_DeleteJob_DeleteScalingPolicies(t *testing.T) {
 
 	job := mock.Job()
 
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.NoError(err)
 
 	policy := mock.ScalingPolicy()
@@ -9899,10 +9899,10 @@ func TestStateStore_DeleteJob_DeleteScalingPoliciesPrefixBug(t *testing.T) {
 	state := testStateStore(t)
 
 	job := mock.Job()
-	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 1000, job))
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job))
 	job2 := job.Copy()
 	job2.ID = job.ID + "-but-longer"
-	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 1001, job2))
+	require.NoError(state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job2))
 
 	policy := mock.ScalingPolicy()
 	policy.Target[structs.ScalingTargetJob] = job.ID
@@ -9937,7 +9937,7 @@ func TestStateStore_DeleteJob_ScalingPolicyIndexNoop(t *testing.T) {
 	prevIndex, err := state.Index("scaling_policy")
 	require.NoError(err)
 
-	err = state.UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	require.NoError(err)
 
 	newIndex, err := state.Index("scaling_policy")
@@ -10455,7 +10455,7 @@ func TestStateSnapshot_DenormalizeAllocationDiffSlice_AllocDoesNotExist(t *testi
 	require := require.New(t)
 
 	// Insert job
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 999, alloc.Job)
+	err := state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, alloc.Job)
 	require.NoError(err)
 
 	allocDiffs := []*structs.AllocationDiff{

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4298,10 +4298,10 @@ type JobSubmission struct {
 	// The version of the Job this submission is associated with.
 	Version uint64
 
-	// JobIndex is managed internally, not set.
+	// JobModifyIndex is managed internally, not set.
 	//
 	// The raft index the Job this submission is associated with.
-	JobIndex uint64
+	JobModifyIndex uint64
 }
 
 // Job is the scope of a scheduling request to Nomad. It is the largest

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -691,6 +691,9 @@ type NodeSpecificRequest struct {
 // JobRegisterRequest is used for Job.Register endpoint
 // to register a job as being a schedulable entity.
 type JobRegisterRequest struct {
+	Submission *JobSubmission
+
+	// Job is the parsed job, no matter what form the input was in.
 	Job *Job
 
 	// If EnforceIndex is set then the job will only be registered if the passed
@@ -787,6 +790,23 @@ type JobEvaluateRequest struct {
 // EvalOptions is used to encapsulate options when forcing a job evaluation
 type EvalOptions struct {
 	ForceReschedule bool
+}
+
+// JobSubmissionRequest is used to query a JobSubmission object associated with a
+// job at a specific version.
+type JobSubmissionRequest struct {
+	JobID   string
+	Version uint64
+
+	QueryOptions
+}
+
+// JobSubmissionResponse contains a JobSubmission object, which may be nil
+// if no submission data is available.
+type JobSubmissionResponse struct {
+	Submission *JobSubmission
+
+	QueryMeta
 }
 
 // JobSpecificRequest is used when we just need to specify a target job
@@ -4245,6 +4265,44 @@ const (
 	// kept for a single task group.
 	JobTrackedScalingEvents = 20
 )
+
+// A JobSubmission contains the original job specification, along with the Variables
+// submitted with the job.
+type JobSubmission struct {
+	// Source contains the original job definition (may be hc1, hcl2, or json)
+	Source string
+
+	// Format indicates whether the original job was hcl1, hcl2, or json.
+	Format string
+
+	// VariableFlags contain the CLI "-var" flag arguments as submitted with the
+	// job (hcl2 only).
+	VariableFlags map[string]string
+
+	// Variables contains the opaque variable blob that was input from the
+	// webUI (hcl2 only).
+	Variables string
+
+	// Namespace is managed internally, do not set.
+	//
+	// The namespace the associated job belongs to.
+	Namespace string
+
+	// JobID is managed internally, not set.
+	//
+	// The job.ID field.
+	JobID string
+
+	// Version is managed internally, not set.
+	//
+	// The version of the Job this submission is associated with.
+	Version uint64
+
+	// JobIndex is managed internally, not set.
+	//
+	// The raft index the Job this submission is associated with.
+	JobIndex uint64
+}
 
 // Job is the scope of a scheduling request to Nomad. It is the largest
 // scoped object, and is a named collection of task groups. Each task group

--- a/nomad/system_endpoint_test.go
+++ b/nomad/system_endpoint_test.go
@@ -28,7 +28,7 @@ func TestSystemEndpoint_GarbageCollect(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.Stop = true
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job); err != nil {
 		t.Fatalf("UpsertJob() failed: %v", err)
 	}
 
@@ -123,7 +123,7 @@ func TestSystemEndpoint_ReconcileSummaries(t *testing.T) {
 	state := s1.fsm.State()
 	s1.fsm.State()
 	job := mock.Job()
-	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, job); err != nil {
+	if err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job); err != nil {
 		t.Fatalf("UpsertJob() failed: %v", err)
 	}
 

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -106,6 +106,9 @@ func TestConfigForServer(t testing.T) *Config {
 	}
 	config.SerfConfig.MemberlistConfig.BindPort = ports[1]
 
+	// max job submission source size
+	config.JobMaxSourceSize = 1e6
+
 	return config
 }
 

--- a/nomad/volumewatcher/volumes_watcher_test.go
+++ b/nomad/volumewatcher/volumes_watcher_test.go
@@ -166,7 +166,7 @@ func TestVolumeWatch_StartStop(t *testing.T) {
 	alloc2.Job = alloc1.Job
 	alloc2.ClientStatus = structs.AllocClientStatusRunning
 	index++
-	err := srv.State().UpsertJob(structs.MsgTypeTestSetup, index, alloc1.Job)
+	err := srv.State().UpsertJob(structs.MsgTypeTestSetup, index, nil, alloc1.Job)
 	require.NoError(t, err)
 	index++
 	err = srv.State().UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc1, alloc2})

--- a/nomad/worker_test.go
+++ b/nomad/worker_test.go
@@ -468,7 +468,7 @@ func TestWorker_SubmitPlan(t *testing.T) {
 	job := mock.Job()
 	eval1 := mock.Eval()
 	eval1.JobID = job.ID
-	s1.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	s1.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 	s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval1})
 
 	// Create the register request
@@ -538,7 +538,7 @@ func TestWorker_SubmitPlanNormalizedAllocations(t *testing.T) {
 	job := mock.Job()
 	eval1 := mock.Eval()
 	eval1.JobID = job.ID
-	s1.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 0, job)
+	s1.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 0, nil, job)
 	s1.fsm.State().UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{eval1})
 
 	stoppedAlloc := mock.Alloc()
@@ -589,7 +589,7 @@ func TestWorker_SubmitPlan_MissingNodeRefresh(t *testing.T) {
 
 	// Create the job
 	job := mock.Job()
-	s1.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 1000, job)
+	s1.fsm.State().UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
 
 	// Create the register request
 	eval1 := mock.Eval()

--- a/scheduler/benchmarks/benchmarks_test.go
+++ b/scheduler/benchmarks/benchmarks_test.go
@@ -124,7 +124,7 @@ func BenchmarkServiceScheduler(b *testing.B) {
 }
 
 func upsertJob(h *scheduler.Harness, job *structs.Job) *structs.Evaluation {
-	err := h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job)
+	err := h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job)
 	if err != nil {
 		panic(err)
 	}

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -397,7 +397,7 @@ func TestCSIVolumeChecker(t *testing.T) {
 			Source: vid2,
 		},
 	}
-	err = state.UpsertJob(structs.MsgTypeTestSetup, index, alloc.Job)
+	err = state.UpsertJob(structs.MsgTypeTestSetup, index, nil, alloc.Job)
 	require.NoError(t, err)
 	index++
 	summary := mock.JobSummary(alloc.JobID)

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -34,7 +34,7 @@ func TestServiceSched_JobRegister(t *testing.T) {
 
 	// Create a job
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -188,7 +188,7 @@ func TestServiceSched_JobRegister_MemoryMaxHonored(t *testing.T) {
 				node := mock.Node()
 				require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 			}
-			require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+			require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 			// Create a mock evaluation to register the job
 			eval := &structs.Evaluation{
@@ -248,7 +248,7 @@ func TestServiceSched_JobRegister_StickyAllocs(t *testing.T) {
 	// Create a job
 	job := mock.Job()
 	job.TaskGroups[0].EphemeralDisk.Sticky = true
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -281,7 +281,7 @@ func TestServiceSched_JobRegister_StickyAllocs(t *testing.T) {
 	// Update the job to force a rolling upgrade
 	updated := job.Copy()
 	updated.TaskGroups[0].Tasks[0].Resources.CPU += 10
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), updated))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, updated))
 
 	// Create a mock evaluation to handle the update
 	eval = &structs.Evaluation{
@@ -342,7 +342,7 @@ func TestServiceSched_JobRegister_DiskConstraints(t *testing.T) {
 	job := mock.Job()
 	job.TaskGroups[0].Count = 2
 	job.TaskGroups[0].EphemeralDisk.SizeMB = 88 * 1024
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -420,7 +420,7 @@ func TestServiceSched_JobRegister_DistinctHosts(t *testing.T) {
 	job := mock.Job()
 	job.TaskGroups[0].Count = 11
 	job.Constraints = append(job.Constraints, &structs.Constraint{Operand: structs.ConstraintDistinctHosts})
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -514,7 +514,7 @@ func TestServiceSched_JobRegister_DistinctProperty(t *testing.T) {
 			LTarget: "${meta.rack}",
 			RTarget: "2",
 		})
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -611,7 +611,7 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup(t *testing.T) {
 
 	job.TaskGroups[1].Name = "tg2"
 	job.TaskGroups[1].Count = 2
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -682,7 +682,7 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup_Incr(t *testing.T) 
 			Operand: structs.ConstraintDistinctProperty,
 			LTarget: "${node.unique.id}",
 		})
-	assert.Nil(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job), "UpsertJob")
+	assert.Nil(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job), "UpsertJob")
 
 	// Create some nodes
 	var nodes []*structs.Node
@@ -707,7 +707,7 @@ func TestServiceSched_JobRegister_DistinctProperty_TaskGroup_Incr(t *testing.T) 
 	// Update the count
 	job2 := job.Copy()
 	job2.TaskGroups[0].Count = 6
-	assert.Nil(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2), "UpsertJob")
+	assert.Nil(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2), "UpsertJob")
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -784,7 +784,7 @@ func TestServiceSched_Spread(t *testing.T) {
 						},
 					},
 				})
-			assert.Nil(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job), "UpsertJob")
+			assert.Nil(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job), "UpsertJob")
 			// Create some nodes, half in dc2
 			var nodes []*structs.Node
 			nodeMap := make(map[string]*structs.Node)
@@ -867,7 +867,7 @@ func TestServiceSched_EvenSpread(t *testing.T) {
 			Attribute: "${node.datacenter}",
 			Weight:    100,
 		})
-	assert.Nil(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job), "UpsertJob")
+	assert.Nil(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job), "UpsertJob")
 	// Create some nodes, half in dc2
 	var nodes []*structs.Node
 	nodeMap := make(map[string]*structs.Node)
@@ -940,7 +940,7 @@ func TestServiceSched_JobRegister_Annotate(t *testing.T) {
 
 	// Create a job
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -1022,7 +1022,7 @@ func TestServiceSched_JobRegister_CountZero(t *testing.T) {
 	// Create a job and set the task group count to zero.
 	job := mock.Job()
 	job.TaskGroups[0].Count = 0
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -1067,7 +1067,7 @@ func TestServiceSched_JobRegister_AllocFail(t *testing.T) {
 	// Create NO nodes
 	// Create a job
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -1157,7 +1157,7 @@ func TestServiceSched_JobRegister_CreateBlockedEval(t *testing.T) {
 
 	// Create a jobs
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -1259,7 +1259,7 @@ func TestServiceSched_JobRegister_FeasibleAndInfeasibleTG(t *testing.T) {
 	tg2.Name = "web2"
 	tg2.Constraints[1].RTarget = "class_1"
 	job.TaskGroups = append(job.TaskGroups, tg2)
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -1338,7 +1338,7 @@ func TestServiceSched_EvaluateMaxPlanEval(t *testing.T) {
 	// Create a job and set the task group count to zero.
 	job := mock.Job()
 	job.TaskGroups[0].Count = 0
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock blocked evaluation
 	eval := &structs.Evaluation{
@@ -1381,7 +1381,7 @@ func TestServiceSched_Plan_Partial_Progress(t *testing.T) {
 	job := mock.Job()
 	job.TaskGroups[0].Count = 3
 	job.TaskGroups[0].Tasks[0].Resources.CPU = 3600
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -1446,7 +1446,7 @@ func TestServiceSched_EvaluateBlockedEval(t *testing.T) {
 
 	// Create a job
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock blocked evaluation
 	eval := &structs.Evaluation{
@@ -1499,7 +1499,7 @@ func TestServiceSched_EvaluateBlockedEval_Finished(t *testing.T) {
 
 	// Create a job and set the task group count to zero.
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock blocked evaluation
 	eval := &structs.Evaluation{
@@ -1588,7 +1588,7 @@ func TestServiceSched_JobModify(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -1621,7 +1621,7 @@ func TestServiceSched_JobModify(t *testing.T) {
 
 	// Update the task, such that it cannot be done in-place
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -1698,7 +1698,7 @@ func TestServiceSched_JobModify_Datacenters(t *testing.T) {
 	job := mock.Job()
 	job.TaskGroups[0].Count = 3
 	job.Datacenters = []string{"dc1", "dc2", "dc3"}
-	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 3; i++ {
@@ -1715,7 +1715,7 @@ func TestServiceSched_JobModify_Datacenters(t *testing.T) {
 	job2 := job.Copy()
 	job2.TaskGroups[0].Count = 4
 	job2.Datacenters = []string{"dc1", "dc2"}
-	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -1774,7 +1774,7 @@ func TestServiceSched_JobModify_IncrCount_NodeLimit(t *testing.T) {
 	job := mock.Job()
 	job.TaskGroups[0].Tasks[0].Resources.CPU = 256
 	job2 := job.Copy()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	alloc := mock.Alloc()
@@ -1788,7 +1788,7 @@ func TestServiceSched_JobModify_IncrCount_NodeLimit(t *testing.T) {
 
 	// Update the job to count 3
 	job2.TaskGroups[0].Count = 3
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -1869,7 +1869,7 @@ func TestServiceSched_JobModify_CountZero(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -1899,7 +1899,7 @@ func TestServiceSched_JobModify_CountZero(t *testing.T) {
 	job2 := mock.Job()
 	job2.ID = job.ID
 	job2.TaskGroups[0].Count = 0
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -1971,7 +1971,7 @@ func TestServiceSched_JobModify_Rolling(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -1997,7 +1997,7 @@ func TestServiceSched_JobModify_Rolling(t *testing.T) {
 
 	// Update the task, such that it cannot be done in-place
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -2100,7 +2100,7 @@ func TestServiceSched_JobModify_Rolling_FullNode(t *testing.T) {
 	job := mock.Job()
 	job.TaskGroups[0].Count = 1
 	job.TaskGroups[0].Tasks[0].Resources = request
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	alloc := mock.Alloc()
 	alloc.AllocatedResources = allocated
@@ -2124,7 +2124,7 @@ func TestServiceSched_JobModify_Rolling_FullNode(t *testing.T) {
 
 	// Update the task, such that it cannot be done in-place
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	eval := &structs.Evaluation{
 		Namespace:   structs.DefaultNamespace,
@@ -2201,7 +2201,7 @@ func TestServiceSched_JobModify_Canaries(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -2228,7 +2228,7 @@ func TestServiceSched_JobModify_Canaries(t *testing.T) {
 
 	// Update the task, such that it cannot be done in-place
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -2329,7 +2329,7 @@ func TestServiceSched_JobModify_InPlace(t *testing.T) {
 	job := mock.Job()
 	d := mock.Deployment()
 	d.JobID = job.ID
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 	require.NoError(t, h.State.UpsertDeployment(h.NextIndex(), d))
 
 	taskName := job.TaskGroups[0].Tasks[0].Name
@@ -2371,7 +2371,7 @@ func TestServiceSched_JobModify_InPlace(t *testing.T) {
 		MinHealthyTime:  10 * time.Second,
 		HealthyDeadline: 10 * time.Minute,
 	}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -2478,7 +2478,7 @@ func TestServiceSched_JobModify_InPlace08(t *testing.T) {
 	// Generate a fake job with 0.8 allocations
 	job := mock.Job()
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create 0.8 alloc
 	alloc := mock.Alloc()
@@ -2492,7 +2492,7 @@ func TestServiceSched_JobModify_InPlace08(t *testing.T) {
 	job2 := job.Copy()
 
 	job2.TaskGroups[0].Tasks[0].Services[0].Tags[0] = "newtag"
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation
 	eval := &structs.Evaluation{
@@ -2568,7 +2568,7 @@ func TestServiceSched_JobModify_DistinctProperty(t *testing.T) {
 			Operand: structs.ConstraintDistinctProperty,
 			LTarget: "${meta.rack}",
 		})
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	oldJob := job.Copy()
 	oldJob.JobModifyIndex -= 1
@@ -2686,7 +2686,7 @@ func TestServiceSched_JobModify_NodeReschedulePenalty(t *testing.T) {
 	tgName := job.TaskGroups[0].Name
 	now := time.Now()
 
-	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 2; i++ {
@@ -2753,7 +2753,7 @@ func TestServiceSched_JobModify_NodeReschedulePenalty(t *testing.T) {
 	// Update the job, such that it cannot be done in-place
 	job2 := job.Copy()
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create and process a mock evaluation
 	eval = &structs.Evaluation{
@@ -2866,7 +2866,7 @@ func TestServiceSched_JobDeregister_Stopped(t *testing.T) {
 	// Generate a fake job with allocations
 	job := mock.Job()
 	job.Stop = true
-	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -2989,7 +2989,7 @@ func TestServiceSched_NodeDown(t *testing.T) {
 
 			// Generate a fake job with allocations and an update policy.
 			job := mock.Job()
-			require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+			require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 			alloc := mock.Alloc()
 			alloc.Job = job
@@ -3089,7 +3089,7 @@ func TestServiceSched_StopAfterClientDisconnect(t *testing.T) {
 			job := mock.Job()
 			job.TaskGroups[0].Count = 1
 			job.TaskGroups[0].StopAfterClientDisconnect = &tc.stop
-			require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+			require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 			// Alloc for the running group
 			alloc := mock.Alloc()
@@ -3223,7 +3223,7 @@ func TestServiceSched_NodeUpdate(t *testing.T) {
 
 	// Generate a fake job with allocations and an update policy.
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -3285,7 +3285,7 @@ func TestServiceSched_NodeDrain(t *testing.T) {
 
 	// Generate a fake job with allocations and an update policy.
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -3363,7 +3363,7 @@ func TestServiceSched_NodeDrain_Down(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -3477,7 +3477,7 @@ func TestServiceSched_NodeDrain_Queued_Allocations(t *testing.T) {
 	// Generate a fake job with allocations and an update policy.
 	job := mock.Job()
 	job.TaskGroups[0].Count = 2
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 2; i++ {
@@ -3536,7 +3536,7 @@ func TestServiceSched_NodeDrain_TaskHandle(t *testing.T) {
 
 	// Generate a fake job with allocations and an update policy.
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -3626,7 +3626,7 @@ func TestServiceSched_RetryLimit(t *testing.T) {
 
 	// Create a job
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -3690,7 +3690,7 @@ func TestServiceSched_Reschedule_OnceNow(t *testing.T) {
 	tgName := job.TaskGroups[0].Name
 	now := time.Now()
 
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 2; i++ {
@@ -3805,7 +3805,7 @@ func TestServiceSched_Reschedule_Later(t *testing.T) {
 	tgName := job.TaskGroups[0].Name
 	now := time.Now()
 
-	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 2; i++ {
@@ -3894,7 +3894,7 @@ func TestServiceSched_Reschedule_MultipleNow(t *testing.T) {
 	tgName := job.TaskGroups[0].Name
 	now := time.Now()
 
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 2; i++ {
@@ -4033,7 +4033,7 @@ func TestServiceSched_Reschedule_PruneEvents(t *testing.T) {
 		Delay:         5 * time.Second,
 		Unlimited:     true,
 	}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 2; i++ {
@@ -4167,7 +4167,7 @@ func TestDeployment_FailedAllocs_Reschedule(t *testing.T) {
 				Interval: 15 * time.Minute,
 			}
 			jobIndex := h.NextIndex()
-			require.Nil(h.State.UpsertJob(structs.MsgTypeTestSetup, jobIndex, job))
+			require.Nil(h.State.UpsertJob(structs.MsgTypeTestSetup, jobIndex, nil, job))
 
 			deployment := mock.Deployment()
 			deployment.JobID = job.ID
@@ -4245,7 +4245,7 @@ func TestBatchSched_Run_CompleteAlloc(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a complete alloc
 	alloc := mock.Alloc()
@@ -4304,7 +4304,7 @@ func TestBatchSched_Run_FailedAlloc(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	tgName := job.TaskGroups[0].Name
 	now := time.Now()
@@ -4377,7 +4377,7 @@ func TestBatchSched_Run_LostAlloc(t *testing.T) {
 	job.ID = "my-job"
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 3
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Desired = 3
 	// Mark one as lost and then schedule
@@ -4464,7 +4464,7 @@ func TestBatchSched_Run_FailedAllocQueuedAllocations(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	tgName := job.TaskGroups[0].Name
 	now := time.Now()
@@ -4522,7 +4522,7 @@ func TestBatchSched_ReRun_SuccessfullyFinishedAlloc(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a successful alloc
 	alloc := mock.Alloc()
@@ -4597,7 +4597,7 @@ func TestBatchSched_JobModify_InPlace_Terminal(t *testing.T) {
 	// Generate a fake job with allocations
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -4651,7 +4651,7 @@ func TestBatchSched_JobModify_Destructive_Terminal(t *testing.T) {
 	// Generate a fake job with allocations
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < 10; i++ {
@@ -4671,7 +4671,7 @@ func TestBatchSched_JobModify_Destructive_Terminal(t *testing.T) {
 	job2.Type = structs.JobTypeBatch
 	job2.Version++
 	job2.TaskGroups[0].Tasks[0].Env = map[string]string{"foo": "bar"}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	allocs = nil
 	for i := 0; i < 10; i++ {
@@ -4737,7 +4737,7 @@ func TestBatchSched_NodeDrain_Running_OldJob(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a running alloc
 	alloc := mock.Alloc()
@@ -4752,7 +4752,7 @@ func TestBatchSched_NodeDrain_Running_OldJob(t *testing.T) {
 	job2 := job.Copy()
 	job2.TaskGroups[0].Tasks[0].Env = map[string]string{"foo": "bar"}
 	job2.Version++
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -4810,7 +4810,7 @@ func TestBatchSched_NodeDrain_Complete(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a complete alloc
 	alloc := mock.Alloc()
@@ -4873,7 +4873,7 @@ func TestBatchSched_ScaleDown_SameName(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.TaskGroups[0].Count = 1
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	scoreMetric := &structs.AllocMetric{
 		NodesEvaluated: 10,
@@ -4903,7 +4903,7 @@ func TestBatchSched_ScaleDown_SameName(t *testing.T) {
 	// Update the job's modify index to force an inplace upgrade
 	updatedJob := job.Copy()
 	updatedJob.JobModifyIndex = job.JobModifyIndex + 1
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), updatedJob))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, updatedJob))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -5026,7 +5026,7 @@ func TestGenericSched_AllocFit_Lifecycle(t *testing.T) {
 			// Create a job with sidecar & init tasks
 			job := mock.VariableLifecycleJob(testCase.TaskResources, testCase.MainTaskCount, testCase.InitTaskCount, testCase.SideTaskCount)
 
-			require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+			require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 			// Create a mock evaluation to register the job
 			eval := &structs.Evaluation{
@@ -5079,7 +5079,7 @@ func TestGenericSched_AllocFit_MemoryOversubscription(t *testing.T) {
 	job.TaskGroups[0].Tasks[0].Resources.MemoryMB = 200
 	job.TaskGroups[0].Tasks[0].Resources.MemoryMaxMB = 500
 	job.TaskGroups[0].Tasks[0].Resources.DiskMB = 1
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -5123,7 +5123,7 @@ func TestGenericSched_ChainedAlloc(t *testing.T) {
 
 	// Create a job
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -5154,7 +5154,7 @@ func TestGenericSched_ChainedAlloc(t *testing.T) {
 	job1.ID = job.ID
 	job1.TaskGroups[0].Tasks[0].Env["foo"] = "bar"
 	job1.TaskGroups[0].Count = 12
-	require.NoError(t, h1.State.UpsertJob(structs.MsgTypeTestSetup, h1.NextIndex(), job1))
+	require.NoError(t, h1.State.UpsertJob(structs.MsgTypeTestSetup, h1.NextIndex(), nil, job1))
 
 	// Create a mock evaluation to update the job
 	eval1 := &structs.Evaluation{
@@ -5217,7 +5217,7 @@ func TestServiceSched_NodeDrain_Sticky(t *testing.T) {
 	alloc.Job.TaskGroups[0].Count = 1
 	alloc.Job.TaskGroups[0].EphemeralDisk.Sticky = true
 	alloc.DesiredTransition.Migrate = pointer.Of(true)
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), alloc.Job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, alloc.Job))
 	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
 
 	// Create a mock evaluation to deal with drain
@@ -5274,7 +5274,7 @@ func TestServiceSched_CancelDeployment_Stopped(t *testing.T) {
 	job.JobModifyIndex = job.CreateIndex + 1
 	job.ModifyIndex = job.CreateIndex + 1
 	job.Stop = true
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a deployment
 	d := mock.Deployment()
@@ -5347,7 +5347,7 @@ func TestServiceSched_CancelDeployment_NewerJob(t *testing.T) {
 
 	// Generate a fake job
 	job := mock.Job()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a deployment for an old version of the job
 	d := mock.Deployment()
@@ -5355,7 +5355,7 @@ func TestServiceSched_CancelDeployment_NewerJob(t *testing.T) {
 	require.NoError(t, h.State.UpsertDeployment(h.NextIndex(), d))
 
 	// Upsert again to bump job version
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to kick the job
 	eval := &structs.Evaluation{
@@ -5702,7 +5702,7 @@ func TestServiceSched_Preemption(t *testing.T) {
 	r1 := job1.TaskGroups[0].Tasks[0].Resources
 	r1.CPU = 500
 	r1.MemoryMB = 1024
-	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job1))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job1))
 
 	job2 := mock.Job()
 	job2.TaskGroups[0].Count = 1
@@ -5711,7 +5711,7 @@ func TestServiceSched_Preemption(t *testing.T) {
 	r2 := job2.TaskGroups[0].Tasks[0].Resources
 	r2.CPU = 350
 	r2.MemoryMB = 512
-	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation to register the jobs
 	eval1 := &structs.Evaluation{
@@ -5765,7 +5765,7 @@ func TestServiceSched_Preemption(t *testing.T) {
 	r3 := job3.TaskGroups[0].Tasks[0].Resources
 	r3.CPU = 900
 	r3.MemoryMB = 1700
-	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job3))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job3))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -5827,7 +5827,7 @@ func TestServiceSched_Migrate_NonCanary(t *testing.T) {
 		MaxParallel: 1,
 		Canary:      1,
 	}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	deployment := &structs.Deployment{
 		ID:             uuid.Generate(),
@@ -5902,7 +5902,7 @@ func TestServiceSched_Migrate_CanaryStatus(t *testing.T) {
 		MaxParallel: 1,
 		Canary:      desiredCanaries,
 	}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	deployment := &structs.Deployment{
 		ID:             uuid.Generate(),
@@ -5934,7 +5934,7 @@ func TestServiceSched_Migrate_CanaryStatus(t *testing.T) {
 	job2 := job.Copy()
 	job2.Stable = false
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation
 	eval := &structs.Evaluation{
@@ -6097,7 +6097,7 @@ func TestDowngradedJobForPlacement_PicksTheLatest(t *testing.T) {
 	job := mock.Job()
 	job.Version = 0
 	job.Stable = true
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	initDeployment := &structs.Deployment{
 		ID:             uuid.Generate(),
@@ -6126,7 +6126,7 @@ func TestDowngradedJobForPlacement_PicksTheLatest(t *testing.T) {
 			nj.Version = u.version
 			nj.TaskGroups[0].Tasks[0].Env["version"] = fmt.Sprintf("%v", u.version)
 			nj.TaskGroups[0].Count = 1
-			require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nj))
+			require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, nj))
 
 			desiredCanaries := 1
 			if !u.requireCanaries {
@@ -6186,7 +6186,7 @@ func TestServiceSched_RunningWithNextAllocation(t *testing.T) {
 	job.Stable = true
 	job.TaskGroups[0].Count = totalCount
 	job.TaskGroups[0].Update = nil
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for i := 0; i < totalCount+1; i++ {
@@ -6207,7 +6207,7 @@ func TestServiceSched_RunningWithNextAllocation(t *testing.T) {
 	job2 := job.Copy()
 	job2.Version = 1
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation
 	eval := &structs.Evaluation{
@@ -6307,7 +6307,7 @@ func TestServiceSched_CSIVolumesPerAlloc(t *testing.T) {
 		},
 	}
 
-	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -6357,7 +6357,7 @@ func TestServiceSched_CSIVolumesPerAlloc(t *testing.T) {
 
 	// Update the job to 5 instances
 	job.TaskGroups[0].Count = 5
-	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a new eval and process it. It should not create a new plan.
 	eval.ID = uuid.Generate()
@@ -6474,7 +6474,7 @@ func TestServiceSched_CSITopology(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -6712,7 +6712,7 @@ func initNodeAndAllocs(t *testing.T, h *Harness, allocCount int,
 	job := mock.Job()
 	job.TaskGroups[0].Count = allocCount
 	job.TaskGroups[0].MaxClientDisconnect = &maxClientDisconnect
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	allocs := make([]*structs.Allocation, allocCount)
 	for i := 0; i < allocCount; i++ {

--- a/scheduler/preemption_test.go
+++ b/scheduler/preemption_test.go
@@ -1463,7 +1463,7 @@ func TestPreemptionMultiple(t *testing.T) {
 		Name:  "gpu",
 		Count: 1,
 	}}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), lowPrioJob))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, lowPrioJob))
 
 	allocs := []*structs.Allocation{}
 	allocIDs := map[string]struct{}{}
@@ -1492,7 +1492,7 @@ func TestPreemptionMultiple(t *testing.T) {
 		Name:  "gpu",
 		Count: 2,
 	}}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), highPrioJob))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, highPrioJob))
 
 	// schedule
 	eval := &structs.Evaluation{

--- a/scheduler/scheduler_sysbatch_test.go
+++ b/scheduler/scheduler_sysbatch_test.go
@@ -27,7 +27,7 @@ func TestSysBatch_JobRegister(t *testing.T) {
 
 	// Create a job
 	job := mock.SystemBatchJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
@@ -97,7 +97,7 @@ func TestSysBatch_JobRegister_AddNode_Running(t *testing.T) {
 
 	// Generate a fake sysbatch job with allocations
 	job := mock.SystemBatchJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -175,7 +175,7 @@ func TestSysBatch_JobRegister_AddNode_Dead(t *testing.T) {
 	// Generate a dead sysbatch job with complete allocations
 	job := mock.SystemBatchJob()
 	job.Status = structs.JobStatusDead // job is dead but not stopped
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -252,7 +252,7 @@ func TestSysBatch_JobModify(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.SystemBatchJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -285,7 +285,7 @@ func TestSysBatch_JobModify(t *testing.T) {
 
 	// Update the task, such that it cannot be done in-place
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -341,7 +341,7 @@ func TestSysBatch_JobModify_InPlace(t *testing.T) {
 	nodes := createNodes(t, h, 10)
 
 	job := mock.SystemBatchJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -357,7 +357,7 @@ func TestSysBatch_JobModify_InPlace(t *testing.T) {
 	// Update the job
 	job2 := mock.SystemBatchJob()
 	job2.ID = job.ID
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation to deal with update
 	eval := &structs.Evaluation{
@@ -478,7 +478,7 @@ func TestSysBatch_JobDeregister_Stopped(t *testing.T) {
 	// Generate a stopped sysbatch job with allocations
 	job := mock.SystemBatchJob()
 	job.Stop = true
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -542,7 +542,7 @@ func TestSysBatch_NodeDown(t *testing.T) {
 
 	// Generate a sysbatch job allocated on that node
 	job := mock.SystemBatchJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	alloc := mock.SysBatchAlloc()
 	alloc.Job = job
@@ -603,7 +603,7 @@ func TestSysBatch_NodeDrain_Down(t *testing.T) {
 
 	// Generate a sysbatch job allocated on that node.
 	job := mock.SystemBatchJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	alloc := mock.SysBatchAlloc()
 	alloc.Job = job
@@ -656,7 +656,7 @@ func TestSysBatch_NodeDrain(t *testing.T) {
 
 	// Generate a sysbatch job allocated on that node.
 	job := mock.SystemBatchJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	alloc := mock.SysBatchAlloc()
 	alloc.Job = job
@@ -713,7 +713,7 @@ func TestSysBatch_NodeUpdate(t *testing.T) {
 
 	// Generate a sysbatch job allocated on that node.
 	job := mock.SystemBatchJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	alloc := mock.SysBatchAlloc()
 	alloc.Job = job
@@ -757,7 +757,7 @@ func TestSysBatch_RetryLimit(t *testing.T) {
 
 	// Create a job
 	job := mock.SystemBatchJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register
 	eval := &structs.Evaluation{
@@ -808,7 +808,7 @@ func TestSysBatch_Queued_With_Constraints(t *testing.T) {
 			Operand: "=",
 		},
 	}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to deal with the node update
 	eval := &structs.Evaluation{
@@ -855,7 +855,7 @@ func TestSysBatch_Queued_With_Constraints_PartialMatch(t *testing.T) {
 
 	// Generate a sysbatch job which can't be placed on the node
 	job := mock.SystemBatchJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to deal with the node update
 	eval := &structs.Evaluation{
@@ -926,7 +926,7 @@ func TestSysBatch_JobConstraint_AddNode(t *testing.T) {
 
 	// Upsert Job
 	job.TaskGroups = []*structs.TaskGroup{tgA, tgB}
-	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Evaluate the job
 	eval := &structs.Evaluation{
@@ -1050,7 +1050,7 @@ func TestSysBatch_ExistingAllocNoNodes(t *testing.T) {
 	// Make a sysbatch job
 	job := mock.SystemBatchJob()
 	job.Meta = map[string]string{"version": "1"}
-	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Evaluate the job
 	eval := &structs.Evaluation{
@@ -1094,7 +1094,7 @@ func TestSysBatch_ExistingAllocNoNodes(t *testing.T) {
 	// Create a new job version, deploy
 	job2 := job.Copy()
 	job2.Meta["version"] = "2"
-	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Run evaluation as a plan
 	eval3 := &structs.Evaluation{
@@ -1146,7 +1146,7 @@ func TestSysBatch_ConstraintErrors(t *testing.T) {
 			Operand: "=",
 		})
 
-	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Evaluate the job
 	eval := &structs.Evaluation{
@@ -1202,7 +1202,7 @@ func TestSysBatch_ChainedAlloc(t *testing.T) {
 
 	// Create a sysbatch job
 	job := mock.SystemBatchJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -1233,7 +1233,7 @@ func TestSysBatch_ChainedAlloc(t *testing.T) {
 	job1.ID = job.ID
 	job1.TaskGroups[0].Tasks[0].Env = make(map[string]string)
 	job1.TaskGroups[0].Tasks[0].Env["foo"] = "bar"
-	require.NoError(t, h1.State.UpsertJob(structs.MsgTypeTestSetup, h1.NextIndex(), job1))
+	require.NoError(t, h1.State.UpsertJob(structs.MsgTypeTestSetup, h1.NextIndex(), nil, job1))
 
 	// Insert two more nodes
 	for i := 0; i < 2; i++ {
@@ -1311,7 +1311,7 @@ func TestSysBatch_PlanWithDrainedNode(t *testing.T) {
 	tg2.Name = "pinger2"
 	tg2.Constraints[0].RTarget = "blue"
 	job.TaskGroups = append(job.TaskGroups, tg2)
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create an allocation on each node
 	alloc := mock.SysBatchAlloc()
@@ -1393,7 +1393,7 @@ func TestSysBatch_QueuedAllocsMultTG(t *testing.T) {
 	tg2.Name = "pinger2"
 	tg2.Constraints[0].RTarget = "blue"
 	job.TaskGroups = append(job.TaskGroups, tg2)
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -1509,7 +1509,7 @@ func TestSysBatch_Preemption(t *testing.T) {
 		},
 		Shared: structs.AllocatedSharedResources{DiskMB: 5 * 1024},
 	}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job1))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job1))
 
 	job2 := mock.BatchJob()
 	job2.Type = structs.JobTypeBatch
@@ -1540,7 +1540,7 @@ func TestSysBatch_Preemption(t *testing.T) {
 		},
 		Shared: structs.AllocatedSharedResources{DiskMB: 5 * 1024},
 	}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	job3 := mock.Job()
 	job3.Type = structs.JobTypeBatch
@@ -1617,7 +1617,7 @@ func TestSysBatch_Preemption(t *testing.T) {
 			DiskMB: 2 * 1024,
 		},
 	}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job4))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job4))
 	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc4}))
 
 	// Create a system job such that it would need to preempt both allocs to succeed
@@ -1631,7 +1631,7 @@ func TestSysBatch_Preemption(t *testing.T) {
 			DynamicPorts: []structs.Port{{Label: "http"}},
 		}},
 	}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{

--- a/scheduler/scheduler_system_test.go
+++ b/scheduler/scheduler_system_test.go
@@ -28,7 +28,7 @@ func TestSystemSched_JobRegister(t *testing.T) {
 
 	// Create a job
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
@@ -99,7 +99,7 @@ func TestSystemSched_JobRegister_StickyAllocs(t *testing.T) {
 	// Create a job
 	job := mock.SystemJob()
 	job.TaskGroups[0].EphemeralDisk.Sticky = true
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -175,13 +175,13 @@ func TestSystemSched_JobRegister_EphemeralDiskConstraint(t *testing.T) {
 	// Create a job
 	job := mock.SystemJob()
 	job.TaskGroups[0].EphemeralDisk.SizeMB = 60 * 1024
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create another job with a lot of disk resource ask so that it doesn't fit
 	// the node
 	job1 := mock.SystemJob()
 	job1.TaskGroups[0].EphemeralDisk.SizeMB = 60 * 1024
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job1))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job1))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -254,7 +254,7 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 	svcJob := mock.Job()
 	svcJob.TaskGroups[0].Count = 1
 	svcJob.TaskGroups[0].Tasks[0].Resources.CPU = 3600
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), svcJob))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, svcJob))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -274,7 +274,7 @@ func TestSystemSched_ExhaustResources(t *testing.T) {
 
 	// Create a system job
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval1 := &structs.Evaluation{
@@ -339,7 +339,7 @@ func TestSystemSched_JobRegister_Annotate(t *testing.T) {
 		Operand: "==",
 	}
 	job.Constraints = append(job.Constraints, fooConstraint)
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to deregister the job
 	eval := &structs.Evaluation{
@@ -422,7 +422,7 @@ func TestSystemSched_JobRegister_AddNode(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -500,7 +500,7 @@ func TestSystemSched_JobRegister_AllocFail(t *testing.T) {
 	// Create NO nodes
 	// Create a job
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -536,7 +536,7 @@ func TestSystemSched_JobModify(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -568,7 +568,7 @@ func TestSystemSched_JobModify(t *testing.T) {
 
 	// Update the task, such that it cannot be done in-place
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -625,7 +625,7 @@ func TestSystemSched_JobModify_Rolling(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -648,7 +648,7 @@ func TestSystemSched_JobModify_Rolling(t *testing.T) {
 
 	// Update the task, such that it cannot be done in-place
 	job2.TaskGroups[0].Tasks[0].Config["command"] = "/bin/other"
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -725,7 +725,7 @@ func TestSystemSched_JobModify_InPlace(t *testing.T) {
 
 	// Generate a fake job with allocations
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -740,7 +740,7 @@ func TestSystemSched_JobModify_InPlace(t *testing.T) {
 	// Update the job
 	job2 := mock.SystemJob()
 	job2.ID = job.ID
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation to deal with update
 	eval := &structs.Evaluation{
@@ -818,7 +818,7 @@ func TestSystemSched_JobModify_RemoveDC(t *testing.T) {
 	// Generate a fake job with allocations
 	job := mock.SystemJob()
 	job.Datacenters = []string{"dc1", "dc2"}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -834,7 +834,7 @@ func TestSystemSched_JobModify_RemoveDC(t *testing.T) {
 	// Update the job
 	job2 := job.Copy()
 	job2.Datacenters = []string{"dc1"}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Create a mock evaluation to deal with update
 	eval := &structs.Evaluation{
@@ -956,7 +956,7 @@ func TestSystemSched_JobDeregister_Stopped(t *testing.T) {
 	// Generate a fake job with allocations
 	job := mock.SystemJob()
 	job.Stop = true
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	var allocs []*structs.Allocation
 	for _, node := range nodes {
@@ -1020,7 +1020,7 @@ func TestSystemSched_NodeDown(t *testing.T) {
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	alloc := mock.Alloc()
 	alloc.Job = job
@@ -1081,7 +1081,7 @@ func TestSystemSched_NodeDrain_Down(t *testing.T) {
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	alloc := mock.Alloc()
 	alloc.Job = job
@@ -1134,7 +1134,7 @@ func TestSystemSched_NodeDrain(t *testing.T) {
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	alloc := mock.Alloc()
 	alloc.Job = job
@@ -1191,7 +1191,7 @@ func TestSystemSched_NodeUpdate(t *testing.T) {
 
 	// Generate a fake job allocated on that node.
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	alloc := mock.Alloc()
 	alloc.Job = job
@@ -1235,7 +1235,7 @@ func TestSystemSched_RetryLimit(t *testing.T) {
 
 	// Create a job
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -1282,7 +1282,7 @@ func TestSystemSched_Queued_With_Constraints(t *testing.T) {
 
 	// Generate a system job which can't be placed on the node
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to deal with the node update
 	eval := &structs.Evaluation{
@@ -1352,7 +1352,7 @@ func TestSystemSched_JobConstraint_AddNode(t *testing.T) {
 
 	// Upsert Job
 	job.TaskGroups = []*structs.TaskGroup{tgA, tgB}
-	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Evaluate the job
 	eval := &structs.Evaluation{
@@ -1473,7 +1473,7 @@ func TestSystemSched_ExistingAllocNoNodes(t *testing.T) {
 
 	// Make a job
 	job := mock.SystemJob()
-	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Evaluate the job
 	eval := &structs.Evaluation{
@@ -1517,7 +1517,7 @@ func TestSystemSched_ExistingAllocNoNodes(t *testing.T) {
 	// Create a new job version, deploy
 	job2 := job.Copy()
 	job2.Meta["version"] = "2"
-	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	// Run evaluation as a plan
 	eval3 := &structs.Evaluation{
@@ -1569,7 +1569,7 @@ func TestSystemSched_ConstraintErrors(t *testing.T) {
 			Operand: "=",
 		})
 
-	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.Nil(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Evaluate the job
 	eval := &structs.Evaluation{
@@ -1624,7 +1624,7 @@ func TestSystemSched_ChainedAlloc(t *testing.T) {
 
 	// Create a job
 	job := mock.SystemJob()
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -1655,7 +1655,7 @@ func TestSystemSched_ChainedAlloc(t *testing.T) {
 	job1.ID = job.ID
 	job1.TaskGroups[0].Tasks[0].Env = make(map[string]string)
 	job1.TaskGroups[0].Tasks[0].Env["foo"] = "bar"
-	require.NoError(t, h1.State.UpsertJob(structs.MsgTypeTestSetup, h1.NextIndex(), job1))
+	require.NoError(t, h1.State.UpsertJob(structs.MsgTypeTestSetup, h1.NextIndex(), nil, job1))
 
 	// Insert two more nodes
 	for i := 0; i < 2; i++ {
@@ -1734,7 +1734,7 @@ func TestSystemSched_PlanWithDrainedNode(t *testing.T) {
 	tg2.Name = "web2"
 	tg2.Constraints[0].RTarget = "blue"
 	job.TaskGroups = append(job.TaskGroups, tg2)
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create an allocation on each node
 	alloc := mock.Alloc()
@@ -1816,7 +1816,7 @@ func TestSystemSched_QueuedAllocsMultTG(t *testing.T) {
 	tg2.Name = "web2"
 	tg2.Constraints[0].RTarget = "blue"
 	job.TaskGroups = append(job.TaskGroups, tg2)
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to deal with drain
 	eval := &structs.Evaluation{
@@ -1932,7 +1932,7 @@ func TestSystemSched_Preemption(t *testing.T) {
 		},
 		Shared: structs.AllocatedSharedResources{DiskMB: 5 * 1024},
 	}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job1))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job1))
 
 	job2 := mock.BatchJob()
 	job2.Type = structs.JobTypeBatch
@@ -1963,7 +1963,7 @@ func TestSystemSched_Preemption(t *testing.T) {
 		},
 		Shared: structs.AllocatedSharedResources{DiskMB: 5 * 1024},
 	}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
 
 	job3 := mock.Job()
 	job3.Type = structs.JobTypeBatch
@@ -2040,7 +2040,7 @@ func TestSystemSched_Preemption(t *testing.T) {
 			DiskMB: 2 * 1024,
 		},
 	}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job4))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job4))
 	require.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc4}))
 
 	// Create a system job such that it would need to preempt both allocs to succeed
@@ -2053,7 +2053,7 @@ func TestSystemSched_Preemption(t *testing.T) {
 			DynamicPorts: []structs.Port{{Label: "http"}},
 		}},
 	}
-	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{
@@ -2894,7 +2894,7 @@ func TestSystemSched_NodeDisconnected(t *testing.T) {
 				job.Datacenters = []string{"not-targeted"}
 			}
 
-			require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+			require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 			alloc.Job = job.Copy()
 			alloc.JobID = job.ID
@@ -2917,7 +2917,7 @@ func TestSystemSched_NodeDisconnected(t *testing.T) {
 				if tc.jobType == structs.JobTypeSysBatch {
 					alloc.Job.TaskGroups[0].Tasks[0].Driver = "raw_exec"
 				}
-				require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+				require.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 			}
 
 			if tc.previousTerminal {
@@ -3056,7 +3056,7 @@ func TestSystemSched_CSITopology(t *testing.T) {
 		},
 	}
 
-	must.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job))
+	must.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	// Create a mock evaluation to register the job
 	eval := &structs.Evaluation{

--- a/scheduler/spread_test.go
+++ b/scheduler/spread_test.go
@@ -746,7 +746,7 @@ func generateJob(jobSize int) *structs.Job {
 }
 
 func upsertJob(h *Harness, job *structs.Job) (*structs.Evaluation, error) {
-	err := h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job)
+	err := h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job)
 	if err != nil {
 		return nil, err
 	}
@@ -867,7 +867,7 @@ func TestSpreadPanicDowngrade(t *testing.T) {
 
 	job1.Version = 1
 	job1.TaskGroups[0].Count = 5
-	err := h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job1)
+	err := h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job1)
 	require.NoError(t, err)
 
 	allocs := []*structs.Allocation{}
@@ -899,7 +899,7 @@ func TestSpreadPanicDowngrade(t *testing.T) {
 	job2 := job1.Copy()
 	job2.Version = 2
 	job2.Spreads = nil
-	err = h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), job2)
+	err = h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2)
 	require.NoError(t, err)
 
 	eval := &structs.Evaluation{

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -122,6 +122,10 @@ The table below shows this endpoint's support for
 
 - `Job` `(Job: <required>)` - Specifies the JSON definition of the job.
 
+- `Submission` `(JobSubmission: <optional>)` - Specifies the original HCL/HCL2/JSON
+  definition of the job. This data is useful for reference only, it is not considered
+  for the actual registration of `Job`.
+
 - `EnforceIndex` `(bool: false)` - If set, the job will only be registered if the
   passed `JobModifyIndex` matches the current job's index. If the index is zero,
   the register only occurs if the job is new. This paradigm allows check-and-set
@@ -234,6 +238,12 @@ The table below shows this endpoint's support for
 
 - `Canonicalize` `(bool: false)` - Flag to enable setting any unset fields to
   their default values.
+
+- `Variables` `(string: "")` - Specifies HCL2 variables to use during parsing of
+  the job in the var file format.
+
+- `VariableFlags` `(map[string]string: nil)` - Specifies HCL2 variables to use
+  during parsing of the job in key = value format.q
 
 - `HCLv1` `(bool: false)` - Use the legacy v1 HCL parser.
 
@@ -547,6 +557,62 @@ $ curl \
   - `batch`: Allocations are intended to exit.
   - `system`: Each client gets an allocation.
 
+## Read Job Submission
+
+This endpoint reads original source information about a specific version of a single
+job. The data this endpoint provides is only available if it was provided with the
+original job during job registration.
+
+| Method | Path                           | Produces           |
+| ------ | ------------------------------ | ------------------ |
+|`GET`   | `/v1/job/:job_id/submission`   | `application/json` |
+
+### Parameters
+
+- `:job_id` `(string: <required>)` - Specifies the ID of the job. This is
+   specified as part of the path.
+- `version` `(int: <required>)` - Specifies the version number of the job for which
+  to retrieve the original source information. This is specified as a query string
+  parameter.
+- `namespace` `(string: "default")` - Specifies the target namespace. If ACL is
+  enabled, this value must match a namespace that the token is allowed to access.
+  This is specified as a query string parameter.
+
+### Sample Request
+
+```shell-session
+nomad operator api /v1/job/my-job/submission?version=42
+```
+
+### Sample Response
+
+```json
+{
+  "Format": "hcl2",
+  "JobIndex": 11,
+  "JobID": "myjob",
+  "Namespace": "default",
+  "Source": "variable \"X\" {\n  type = string\n}\n\nvariable \"Y\" {\n  type = number\n}\n\nvariable \"Z\" {\n  type = bool\n}\n  \njob \"myjob\" {\n  type = \"sysbatch\"\n  \n  meta {\n    nomad_discard_job_source = false\n  }\n\n  group \"group\" {\n    task \"task\" {\n      driver = \"raw_exec\"\n\n      config {\n        command = \"echo\"\n        args = [\"X ${var.X}, Y ${var.Y}, Z ${var.Z}\"]\n      }\n\n      resources {\n        cpu    = 10\n        memory = 16\n      }\n    }\n  }\n}\n",
+  "VariableFlags": {
+    "Z": "true",
+    "X": "x",
+    "Y": "2"
+  },
+  "Variables": "",
+  "Version": 0
+}
+```
+
+#### Field Reference
+
+- `JobID`: The ID of the job associated with the original job file.
+- `Format`: The file format of the original job file. One of `hcl2`, `hcl1`, or `json`.
+- `Source`: The literal content of the original job file.
+- `VariableFlags`: The key-value pairs of HCL variables as submitted via `-var` command
+  line arguments when submitting the job via CLI.
+- `Variables`: The content of the variables form when submitting the job via the WebUI.
+- `Version`: The version of the job this submission source is associated with.
+
 ## List Job Versions
 
 This endpoint reads information about all versions of a job.
@@ -762,8 +828,7 @@ $ curl \
     https://localhost:4646/v1/job/my-job/versions?diffs=true
 ```
 
-```
-
+```json
 {
   "Diffs": [
     {

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -243,7 +243,7 @@ The table below shows this endpoint's support for
   the job in the var file format.
 
 - `VariableFlags` `(map[string]string: nil)` - Specifies HCL2 variables to use
-  during parsing of the job in key = value format.q
+  during parsing of the job in key = value format.
 
 - `HCLv1` `(bool: false)` - Use the legacy v1 HCL parser.
 
@@ -561,7 +561,8 @@ $ curl \
 
 This endpoint reads original source information about a specific version of a single
 job. The data this endpoint provides is only available if it was provided with the
-original job during job registration.
+original job during job registration. Only the most recent 6 job source files are
+retained.
 
 | Method | Path                           | Produces           |
 | ------ | ------------------------------ | ------------------ |

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -124,7 +124,7 @@ The table below shows this endpoint's support for
 
 - `Submission` `(JobSubmission: <optional>)` - Specifies the original HCL/HCL2/JSON
   definition of the job. This data is useful for reference only, it is not considered
-  for the actual registration of `Job`.
+  for the actual scheduling of `Job`.
 
 - `EnforceIndex` `(bool: false)` - If set, the job will only be registered if the
   passed `JobModifyIndex` matches the current job's index. If the index is zero,

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -259,6 +259,11 @@ server {
 - `job_default_priority` `(int: 50)` - Specifies the default priority assigned to a job.
    A valid value must be between `50` and `job_max_priority`.
 
+- `job_max_source_size` `(string: "1M")` - Specifies the size limit of the associated
+  job source content when registering a job. Note this is not a limit on the actual
+  size of a job. If the limit is exceeded, the original source is simply discarded
+  and no error is returned from the job API.
+
 ### Deprecated Parameters
 
 - `retry_join` `(array<string>: [])` - Specifies a list of server addresses to


### PR DESCRIPTION
Note to reviewers: this PR isn't as large as it looks - most file changes are just due to `UpsertJob` getting a new signature, and that is used in many, many tests.

This PR adds support for setting job source material along with the registration of a job.

This includes a new HTTP endpoint and a new RPC endpoint for making queries for the original source of a job. The HTTP endpoint is `/v1/job/<id>/submission?version=<version>` and the RPC method is `Job.GetJobSubmission`. This endpoint is limited by ACLs with `read-job` capability. It is quite similar to the JobVersions endpoint, in that data is upserted and removed along with a Job, but queryable through a separate endpoint.

The job source (if submitted, and doing so is always optional), is stored in the `job_submission` memdb table, separately from the actual job. This way we do not incur overhead of reading the potentially huge string field throughout normal job operations.

The server config now includes `job_max_source_size` for configuring the maximum size the job source may be, before the server simply drops the source material. This should help prevent Bad Things from happening when huge jobs are submitted. If the value is set to 0, all job source material will be dropped.

Will add e2e tests in a followup PR, this one is already too large.

No backports, this is for a 1.6 feature.