### PR TITLE
docs: fix install instructions for apt

### DIFF
--- a/website/content/docs/install/index.mdx
+++ b/website/content/docs/install/index.mdx
@@ -90,7 +90,7 @@ $ wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /us
 Add the official HashiCorp Linux repository.
 
 ```shell-session
-echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+$ echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
 ```
 
 Update and install.

--- a/website/content/docs/install/index.mdx
+++ b/website/content/docs/install/index.mdx
@@ -74,16 +74,23 @@ distributions.
 <Tabs>
 <Tab heading="Ubuntu/Debian">
 
+Install the required packages.
+
+```shell-session
+$ sudo apt-get update && \
+  sudo apt-get install wget gpg coreutils
+```
+
 Add the HashiCorp [GPG key][gpg-key].
 
 ```shell-session
-$ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+$ wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
 ```
 
 Add the official HashiCorp Linux repository.
 
 ```shell-session
-$ sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
 ```
 
 Update and install.


### PR DESCRIPTION
The workflow described in the docs for apt installation is deprecated. Update to match the workflow described in the Tutorials and official packaging guide.