### PR TITLE
docs: remove reference to vSphere from CSI concepts docs

### DIFF
--- a/website/content/docs/concepts/plugins/csi.mdx
+++ b/website/content/docs/concepts/plugins/csi.mdx
@@ -22,15 +22,14 @@ inside the plugin's tasks.
 
 ## CSI Plugins
 
-Every storage vendor has its own APIs and workflows, and the
-industry-standard Container Storage Interface specification unifies
-these APIs in a way that's agnostic to both the storage vendor and the
-container orchestrator. Each storage provider can build its own CSI
-plugin. Jobs can claim storage volumes from AWS Elastic Block Storage
-(EBS) volumes, GCP persistent disks, Ceph, Portworx, vSphere, etc. The
-Nomad scheduler will be aware of volumes created by CSI plugins and
-schedule workloads based on the availability of volumes on a given
-Nomad client node.
+Every storage vendor has its own APIs and workflows, and the industry-standard
+Container Storage Interface specification unifies these APIs in a way that's
+agnostic to both the storage vendor and the container orchestrator. Each storage
+provider can build its own CSI plugin. Jobs can claim storage volumes from AWS
+Elastic Block Storage (EBS) volumes, GCP persistent disks, Ceph, Portworx,
+etc. The Nomad scheduler will be aware of volumes created by CSI plugins and
+schedule workloads based on the availability of volumes on a given Nomad client
+node.
 
 A list of available CSI plugins can be found in the [Kubernetes CSI
 documentation][csi-drivers-list]. Spec-compliant plugins should work with Nomad.


### PR DESCRIPTION
The vSphere plugin is exclusive to k8s because it relies on k8s-APIs (and crashes without them being present). Upstream unfortunately will not support Nomad, so we shouldn't refer to it in our concept docs here.