### PR TITLE
[ui] Splitting deployment allocs by status, health, and canary status

### DIFF
--- a/ui/app/components/conditional-link-to.hbs
+++ b/ui/app/components/conditional-link-to.hbs
@@ -1,0 +1,9 @@
+{{#if @condition}}
+  <LinkTo @route={{@route}} @model={{@model}} @query={{this.query}} class={{@class}} aria-label={{@label}}>
+    {{yield}}
+  </LinkTo>
+{{else}}
+  <span class={{@class}}>
+    {{yield}}
+  </span>
+{{/if}}

--- a/ui/app/components/conditional-link-to.js
+++ b/ui/app/components/conditional-link-to.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class ConditionalLinkToComponent extends Component {
+  get query() {
+    return this.args.query || {};
+  }
+}

--- a/ui/app/components/job-status/allocation-status-block.hbs
+++ b/ui/app/components/job-status/allocation-status-block.hbs
@@ -4,8 +4,14 @@
 >
   {{#if this.countToShow}}
     <div class="ungrouped-allocs">
-      {{#each (range 0 this.countToShow)}}
-        <span class="represented-allocation {{@status}} {{@health}} {{@canary}}">
+      {{#each (range 0 this.countToShow) as |i|}}
+        <ConditionalLinkTo
+          @condition={{not (eq @status "unplaced")}}
+          @route="allocations.allocation"
+          @model={{get @allocs i}}
+          @class="represented-allocation {{@status}} {{@health}} {{@canary}}"
+          @label="View allocation"
+        >
           {{#unless @steady}}
             {{#if (eq @status "running")}}
               <span class="alloc-health-indicator">
@@ -17,12 +23,20 @@
               </span>
             {{/if}}
           {{/unless}}
-        </span>
+        </ConditionalLinkTo>
       {{/each}}
     </div>
   {{/if}}
   {{#if this.remaining}}
-    <span class="represented-allocation rest {{@status}} {{@health}} {{@canary}}">
+
+    <ConditionalLinkTo
+      @condition={{not (eq @status "unplaced")}}
+      @route="jobs.job.allocations"
+      @model={{@allocs.0.job}}
+      @query={{hash status=(concat '["' @status '"]') version=(concat '[' @allocs.0.jobVersion ']')}}
+      @class="represented-allocation rest {{@status}} {{@health}} {{@canary}}"
+      @label="View all {{@status}} allocations"
+    >
       <span class="rest-count">{{#if this.countToShow}}+{{/if}}{{this.remaining}}</span>
       {{#unless @steady}}
         {{#if (eq @canary "canary")}}
@@ -38,6 +52,6 @@
           </span>
         {{/if}}
       {{/unless}}
-    </span>
+    </ConditionalLinkTo>
   {{/if}}
 </div>

--- a/ui/app/components/job-status/allocation-status-block.hbs
+++ b/ui/app/components/job-status/allocation-status-block.hbs
@@ -12,17 +12,15 @@
           @class="represented-allocation {{@status}} {{@health}} {{@canary}}"
           @label="View allocation"
         >
-          {{#unless @steady}}
-            {{#if (eq @status "running")}}
-              <span class="alloc-health-indicator">
-                {{#if (eq @health "healthy")}}
-                  <FlightIcon @name="check" @color="white" />
-                {{else}}
-                  <FlightIcon @name="running" @color="white" />
-                {{/if}}
-              </span>
-            {{/if}}
-          {{/unless}}
+          {{#if (and (eq @status "running") (not @steady))}}
+            <span class="alloc-health-indicator">
+              {{#if (eq @health "healthy")}}
+                <FlightIcon @name="check" @color="white" />
+              {{else}}
+                <FlightIcon @name="running" @color="white" />
+              {{/if}}
+            </span>
+          {{/if}}
         </ConditionalLinkTo>
       {{/each}}
     </div>

--- a/ui/app/components/job-status/allocation-status-block.hbs
+++ b/ui/app/components/job-status/allocation-status-block.hbs
@@ -6,15 +6,17 @@
     <div class="ungrouped-allocs">
       {{#each (range 0 this.countToShow)}}
         <span class="represented-allocation {{@status}} {{@health}} {{@canary}}">
-          {{#if (eq @status "running")}}
-            <span class="alloc-health-indicator">
-              {{#if (eq @health "healthy")}}
-                <FlightIcon @name="check" @color="white" />
-              {{else}}
-                <FlightIcon @name="running" @color="white" />
-              {{/if}}
-            </span>
-          {{/if}}
+          {{#unless @steady}}
+            {{#if (eq @status "running")}}
+              <span class="alloc-health-indicator">
+                {{#if (eq @health "healthy")}}
+                  <FlightIcon @name="check" @color="white" />
+                {{else}}
+                  <FlightIcon @name="running" @color="white" />
+                {{/if}}
+              </span>
+            {{/if}}
+          {{/unless}}
         </span>
       {{/each}}
     </div>
@@ -22,18 +24,20 @@
   {{#if this.remaining}}
     <span class="represented-allocation rest {{@status}} {{@health}} {{@canary}}">
       {{#if this.countToShow}}+{{/if}}{{this.remaining}}
-      {{#if (eq @canary "canary")}}
-        <span class="alloc-canary-indicator" />
-      {{/if}}
-      {{#if (eq @status "running")}}
-        <span class="alloc-health-indicator">
-          {{#if (eq @health "healthy")}}
-            <FlightIcon @name="check" @color="#25ba81" />
-          {{else}}
-            <FlightIcon @name="running" @color="black" />
-          {{/if}}
-        </span>
-      {{/if}}
+      {{#unless @steady}}
+        {{#if (eq @canary "canary")}}
+          <span class="alloc-canary-indicator" />
+        {{/if}}
+        {{#if (eq @status "running")}}
+          <span class="alloc-health-indicator">
+            {{#if (eq @health "healthy")}}
+              <FlightIcon @name="check" @color="#25ba81" />
+            {{else}}
+              <FlightIcon @name="running" @color="black" />
+            {{/if}}
+          </span>
+        {{/if}}
+      {{/unless}}
     </span>
   {{/if}}
 </div>

--- a/ui/app/components/job-status/allocation-status-block.hbs
+++ b/ui/app/components/job-status/allocation-status-block.hbs
@@ -5,13 +5,32 @@
   {{#if this.countToShow}}
     <div class="ungrouped-allocs">
       {{#each (range 0 this.countToShow)}}
-        <span class="represented-allocation {{@status}}" />
+        <span class="represented-allocation {{@status}} {{@health}} {{@canary}}">
+          {{#if (eq @status "running")}}
+            <span class="alloc-health-indicator">
+              {{#if (eq @health "healthy")}}
+                <FlightIcon @name="check" @color="white" />
+              {{else}}
+                <FlightIcon @name="running" @color="black" />
+              {{/if}}
+            </span>
+          {{/if}}
+        </span>
       {{/each}}
     </div>
   {{/if}}
   {{#if this.remaining}}
-    <span class="represented-allocation rest {{@status}}">
+    <span class="represented-allocation rest {{@status}} {{@health}} {{@canary}}">
       {{#if this.countToShow}}+{{/if}}{{this.remaining}}
+      {{#if (eq @status "running")}}
+        <span class="alloc-health-indicator">
+          {{#if (eq @health "healthy")}}
+            <FlightIcon @name="check" @color="white" />
+          {{else}}
+            <FlightIcon @name="running" @color="black" />
+          {{/if}}
+        </span>
+      {{/if}}
     </span>
   {{/if}}
 </div>

--- a/ui/app/components/job-status/allocation-status-block.hbs
+++ b/ui/app/components/job-status/allocation-status-block.hbs
@@ -11,7 +11,7 @@
               {{#if (eq @health "healthy")}}
                 <FlightIcon @name="check" @color="white" />
               {{else}}
-                <FlightIcon @name="running" @color="black" />
+                <FlightIcon @name="running" @color="white" />
               {{/if}}
             </span>
           {{/if}}
@@ -25,7 +25,7 @@
       {{#if (eq @status "running")}}
         <span class="alloc-health-indicator">
           {{#if (eq @health "healthy")}}
-            <FlightIcon @name="check" @color="white" />
+            <FlightIcon @name="check" @color="#25ba81" />
           {{else}}
             <FlightIcon @name="running" @color="black" />
           {{/if}}

--- a/ui/app/components/job-status/allocation-status-block.hbs
+++ b/ui/app/components/job-status/allocation-status-block.hbs
@@ -22,6 +22,9 @@
   {{#if this.remaining}}
     <span class="represented-allocation rest {{@status}} {{@health}} {{@canary}}">
       {{#if this.countToShow}}+{{/if}}{{this.remaining}}
+      {{#if (eq @canary "canary")}}
+        <span class="alloc-canary-indicator" />
+      {{/if}}
       {{#if (eq @status "running")}}
         <span class="alloc-health-indicator">
           {{#if (eq @health "healthy")}}

--- a/ui/app/components/job-status/allocation-status-block.hbs
+++ b/ui/app/components/job-status/allocation-status-block.hbs
@@ -23,7 +23,7 @@
   {{/if}}
   {{#if this.remaining}}
     <span class="represented-allocation rest {{@status}} {{@health}} {{@canary}}">
-      {{#if this.countToShow}}+{{/if}}{{this.remaining}}
+      <span class="rest-count">{{#if this.countToShow}}+{{/if}}{{this.remaining}}</span>
       {{#unless @steady}}
         {{#if (eq @canary "canary")}}
           <span class="alloc-canary-indicator" />

--- a/ui/app/components/job-status/allocation-status-row.hbs
+++ b/ui/app/components/job-status/allocation-status-row.hbs
@@ -1,4 +1,4 @@
-<div class="allocation-status-row">
+{{!-- <div class="allocation-status-row">
   {{#if this.showSummaries}}
     <div class="alloc-status-summaries"
       {{did-insert this.captureElement}}
@@ -6,7 +6,7 @@
     >
       {{#each-in @allocBlocks as |status allocs|}}
         {{#if (gt allocs.length 0)}}
-          <JobStatus::AllocationStatusBlock @status={{status}} @count={{allocs.length}} @width={{compute (action this.calcPerc) allocs.length}} />
+          <JobStatus::AllocationStatusBlock @status={{status}} @count={{allocs.length}} @width={{compute (action this.calcPerc) allocs.length}} @allocs={{allocs}} />
         {{/if}}
       {{/each-in}}
     </div>
@@ -21,4 +21,44 @@
       {{/each-in}}
     </div>
   {{/if}}
+</div> --}}
+
+<div class="allocation-status-row">
+  {{#if this.showSummaries}}
+    <div class="alloc-status-summaries"
+      {{did-insert this.captureElement}}
+      {{window-resize this.reflow}}
+    >
+      {{#each-in @allocBlocks as |status allocsByStatus|}}
+        {{#each-in allocsByStatus as |health allocsByHealth|}}
+          {{#each-in allocsByHealth as |canary allocsByCanary|}}
+            {{#if (gt allocsByCanary.length 0)}}
+              <JobStatus::AllocationStatusBlock
+                @status={{status}}
+                @health={{health}}
+                @canary={{canary}}
+                @count={{allocsByCanary.length}}
+                @width={{compute (action this.calcPerc) allocsByCanary.length}}
+                @allocs={{allocsByCanary}} />
+            {{/if}}
+          {{/each-in}}
+        {{/each-in}}
+      {{/each-in}}
+    </div>
+  {{else}}
+    <div class="ungrouped-allocs">
+      {{#each-in @allocBlocks as |status allocsByStatus|}}
+        {{#each-in allocsByStatus as |health allocsByHealth|}}
+          {{#each-in allocsByHealth as |canary allocsByCanary|}}
+            {{#if (gt allocsByCanary.length 0)}}
+              {{#each (range 0 allocsByCanary.length)}}
+                <span class="represented-allocation {{status}} {{health}} {{canary}}"></span>
+              {{/each}}
+            {{/if}}
+          {{/each-in}}
+        {{/each-in}}
+      {{/each-in}}
+    </div>
+  {{/if}}
 </div>
+       

--- a/ui/app/components/job-status/allocation-status-row.hbs
+++ b/ui/app/components/job-status/allocation-status-row.hbs
@@ -37,6 +37,7 @@
                 @status={{status}}
                 @health={{health}}
                 @canary={{canary}}
+                @steady={{@steady}}
                 @count={{allocsByCanary.length}}
                 @width={{compute (action this.calcPerc) allocsByCanary.length}}
                 @allocs={{allocsByCanary}} />
@@ -52,7 +53,22 @@
           {{#each-in allocsByHealth as |canary allocsByCanary|}}
             {{#if (gt allocsByCanary.length 0)}}
               {{#each (range 0 allocsByCanary.length)}}
-                <span class="represented-allocation {{status}} {{health}} {{canary}}"></span>
+                <span class="represented-allocation {{status}} {{health}} {{canary}}">
+                  {{#unless @steady}}
+                    {{#if (eq canary "canary")}}
+                      <span class="alloc-canary-indicator" />
+                    {{/if}}
+                    {{#if (eq status "running")}}
+                      <span class="alloc-health-indicator">
+                        {{#if (eq health "healthy")}}
+                          <FlightIcon @name="check" @color="white" />
+                        {{else}}
+                          <FlightIcon @name="running" @color="white" />
+                        {{/if}}
+                      </span>
+                    {{/if}}
+                  {{/unless}}
+                </span>
               {{/each}}
             {{/if}}
           {{/each-in}}

--- a/ui/app/components/job-status/allocation-status-row.hbs
+++ b/ui/app/components/job-status/allocation-status-row.hbs
@@ -30,8 +30,14 @@
         {{#each-in allocsByStatus as |health allocsByHealth|}}
           {{#each-in allocsByHealth as |canary allocsByCanary|}}
             {{#if (gt allocsByCanary.length 0)}}
-              {{#each (range 0 allocsByCanary.length)}}
-                <span class="represented-allocation {{status}} {{health}} {{canary}}">
+              {{#each (range 0 allocsByCanary.length) as |i|}}
+                <ConditionalLinkTo
+                  @condition={{not (eq status "unplaced")}}
+                  @route="allocations.allocation"
+                  @model={{get allocsByCanary i}}
+                  @class="represented-allocation {{status}} {{health}} {{canary}}"
+                  @label="View allocation"
+                >
                   {{#unless @steady}}
                     {{#if (eq canary "canary")}}
                       <span class="alloc-canary-indicator" />
@@ -46,7 +52,7 @@
                       </span>
                     {{/if}}
                   {{/unless}}
-                </span>
+                </ConditionalLinkTo>
               {{/each}}
             {{/if}}
           {{/each-in}}

--- a/ui/app/components/job-status/allocation-status-row.hbs
+++ b/ui/app/components/job-status/allocation-status-row.hbs
@@ -22,7 +22,10 @@
       {{/each-in}}
     </div>
   {{else}}
-    <div class="ungrouped-allocs">
+    <div class="ungrouped-allocs"
+      {{did-insert this.captureElement}}
+      {{window-resize this.reflow}}
+    >
       {{#each-in @allocBlocks as |status allocsByStatus|}}
         {{#each-in allocsByStatus as |health allocsByHealth|}}
           {{#each-in allocsByHealth as |canary allocsByCanary|}}

--- a/ui/app/components/job-status/allocation-status-row.hbs
+++ b/ui/app/components/job-status/allocation-status-row.hbs
@@ -1,28 +1,3 @@
-{{!-- <div class="allocation-status-row">
-  {{#if this.showSummaries}}
-    <div class="alloc-status-summaries"
-      {{did-insert this.captureElement}}
-      {{window-resize this.reflow}}
-    >
-      {{#each-in @allocBlocks as |status allocs|}}
-        {{#if (gt allocs.length 0)}}
-          <JobStatus::AllocationStatusBlock @status={{status}} @count={{allocs.length}} @width={{compute (action this.calcPerc) allocs.length}} @allocs={{allocs}} />
-        {{/if}}
-      {{/each-in}}
-    </div>
-  {{else}}
-    <div class="ungrouped-allocs">
-      {{#each-in @allocBlocks as |status allocs|}}
-        {{#if (gt allocs.length 0)}}
-          {{#each (range 0 allocs.length)}}
-            <span class="represented-allocation {{status}}"></span>
-          {{/each}}
-        {{/if}}
-      {{/each-in}}
-    </div>
-  {{/if}}
-</div> --}}
-
 <div class="allocation-status-row">
   {{#if this.showSummaries}}
     <div class="alloc-status-summaries"

--- a/ui/app/components/job-status/allocation-status-row.js
+++ b/ui/app/components/job-status/allocation-status-row.js
@@ -1,3 +1,4 @@
+// @ts-check
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
@@ -7,11 +8,22 @@ const UNGROUPED_ALLOCS_THRESHOLD = 50;
 export default class JobStatusAllocationStatusRowComponent extends Component {
   @tracked width = 0;
 
+  // get allocBlockSlots() {
+  //   return Object.values(this.args.allocBlocks).reduce(
+  //     (m, n) => m + n.length,
+  //     0
+  //   );
+  // }
+
   get allocBlockSlots() {
-    return Object.values(this.args.allocBlocks).reduce(
-      (m, n) => m + n.length,
-      0
-    );
+    return Object.values(this.args.allocBlocks)
+      .flatMap((statusObj) => Object.values(statusObj))
+      .flatMap((healthObj) => Object.values(healthObj))
+      .reduce(
+        (totalSlots, allocsByCanary) =>
+          totalSlots + (allocsByCanary ? allocsByCanary.length : 0),
+        0
+      );
   }
 
   get showSummaries() {

--- a/ui/app/components/job-status/allocation-status-row.js
+++ b/ui/app/components/job-status/allocation-status-row.js
@@ -3,6 +3,9 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
+const ALLOC_BLOCK_WIDTH = 32;
+const ALLOC_BLOCK_GAP = 10;
+
 export default class JobStatusAllocationStatusRowComponent extends Component {
   @tracked width = 0;
 
@@ -18,7 +21,11 @@ export default class JobStatusAllocationStatusRowComponent extends Component {
   }
 
   get showSummaries() {
-    return this.allocBlockSlots * 42 - 10 > this.width;
+    return (
+      this.allocBlockSlots * (ALLOC_BLOCK_WIDTH + ALLOC_BLOCK_GAP) -
+        ALLOC_BLOCK_GAP >
+      this.width
+    );
   }
 
   calcPerc(count) {

--- a/ui/app/components/job-status/allocation-status-row.js
+++ b/ui/app/components/job-status/allocation-status-row.js
@@ -8,13 +8,6 @@ const UNGROUPED_ALLOCS_THRESHOLD = 50;
 export default class JobStatusAllocationStatusRowComponent extends Component {
   @tracked width = 0;
 
-  // get allocBlockSlots() {
-  //   return Object.values(this.args.allocBlocks).reduce(
-  //     (m, n) => m + n.length,
-  //     0
-  //   );
-  // }
-
   get allocBlockSlots() {
     return Object.values(this.args.allocBlocks)
       .flatMap((statusObj) => Object.values(statusObj))

--- a/ui/app/components/job-status/allocation-status-row.js
+++ b/ui/app/components/job-status/allocation-status-row.js
@@ -3,8 +3,6 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
-const UNGROUPED_ALLOCS_THRESHOLD = 50;
-
 export default class JobStatusAllocationStatusRowComponent extends Component {
   @tracked width = 0;
 
@@ -20,7 +18,7 @@ export default class JobStatusAllocationStatusRowComponent extends Component {
   }
 
   get showSummaries() {
-    return this.allocBlockSlots > UNGROUPED_ALLOCS_THRESHOLD;
+    return this.allocBlockSlots * 42 - 10 > this.width;
   }
 
   calcPerc(count) {

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -36,7 +36,7 @@
     <div class="boxed-section-body">
       <div class="deployment-allocations">
         {{#if this.oldVersionAllocBlockIDs.length}}
-          <h4 class="title is-5">Previous Allocations: {{#if this.oldVersionAllocBlocks.running}}{{this.oldVersionAllocBlocks.running.length}} running{{/if}}</h4>
+          <h4 class="title is-5">Previous Allocations: {{#if this.oldVersionAllocBlocks.running}}{{this.oldRunningHealthyAllocBlocks.length}} running{{/if}}</h4>
           <JobStatus::AllocationStatusRow @allocBlocks={{this.oldVersionAllocBlocks}} @steady={{true}} />
         {{/if}}
 
@@ -45,15 +45,6 @@
       </div>
 
       <div class="legend-and-summary">
-        {{!-- <legend>
-          {{#each this.allocTypes as |type|}}
-            <span class="legend-item {{if (eq (get (get this.newVersionAllocBlocks type.label) "length") 0) "faded"}}">
-              <span class="represented-allocation {{type.label}}"></span>
-              {{get (get this.newVersionAllocBlocks type.label) "length"}} {{capitalize type.label}}
-            </span>
-          {{/each}}
-        </legend> --}}
-
         <legend>
           {{#each this.allocTypes as |type|}}
             {{#each-in (get this.newVersionAllocBlocks type.label) as |health allocsByHealth|}}

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -38,6 +38,19 @@
         {{#if this.oldVersionAllocBlockIDs.length}}
           <h4 class="title is-5">Previous Allocations: {{#if this.oldVersionAllocBlocks.running}}{{this.oldRunningHealthyAllocBlocks.length}} running{{/if}}</h4>
           <JobStatus::AllocationStatusRow @allocBlocks={{this.oldVersionAllocBlocks}} @steady={{true}} />
+          <div class="legend-and-summary">
+            <legend>
+              <span class="legend-item {{if (eq (get this.oldRunningHealthyAllocBlocks "length") 0) "faded"}}">
+                <span class="represented-allocation running"></span>
+                {{get this.oldRunningHealthyAllocBlocks "length"}} Running
+              </span>
+              <span class="legend-item {{if (eq (get this.oldCompleteHealthyAllocBlocks "length") 0) "faded"}}">
+                <span class="represented-allocation complete"></span>
+                {{get this.oldCompleteHealthyAllocBlocks "length"}} Complete
+              </span>
+            </legend>
+          </div>
+
         {{/if}}
 
         <h4 class="title is-5">New allocations: {{this.newRunningHealthyAllocBlocks.length}}/{{this.totalAllocs}} running and healthy</h4>
@@ -57,7 +70,6 @@
             {{/each-in}}
           {{/each}}
         </legend>
-
       </div>
 
       <div class="history-and-params">

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -91,20 +91,6 @@
           </span>
 
         </legend>
-
-
-        {{!-- <legend>
-          {{#each this.allocTypes as |type|}}
-            {{#each-in (get this.newVersionAllocBlocks type.label) as |health allocsByHealth|}}
-              {{#each-in allocsByHealth as |canary allocsByCanary|}}
-                <span class="legend-item {{if (eq (get allocsByCanary "length") 0) "faded"}}">
-                  <span class="represented-allocation {{type.label}} {{health}} {{canary}}"></span>
-                  {{get allocsByCanary "length"}} {{capitalize type.label}} {{capitalize health}} {{capitalize canary}}
-                </span>
-              {{/each-in}}
-            {{/each-in}}
-          {{/each}}
-        </legend> --}}
       </div>
 
       <div class="history-and-params">

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -37,7 +37,7 @@
       <div class="deployment-allocations">
         {{#if this.oldVersionAllocBlockIDs.length}}
           <h4 class="title is-5">Previous Allocations: {{#if this.oldVersionAllocBlocks.running}}{{this.oldVersionAllocBlocks.running.length}} running{{/if}}</h4>
-          <JobStatus::AllocationStatusRow @allocBlocks={{this.oldVersionAllocBlocks}} />
+          <JobStatus::AllocationStatusRow @allocBlocks={{this.oldVersionAllocBlocks}} @steady={{true}} />
         {{/if}}
 
         <h4 class="title is-5">New allocations: {{this.newRunningHealthyAllocBlocks.length}}/{{this.totalAllocs}} running and healthy</h4>

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -40,19 +40,33 @@
           <JobStatus::AllocationStatusRow @allocBlocks={{this.oldVersionAllocBlocks}} />
         {{/if}}
 
-        <h4 class="title is-5">New allocations: {{this.newVersionAllocBlocks.running.length}}/{{this.totalAllocs}} running</h4>
+        <h4 class="title is-5">New allocations: {{this.newRunningHealthyAllocBlocks.length}}/{{this.totalAllocs}} running and healthy</h4>
         <JobStatus::AllocationStatusRow @allocBlocks={{this.newVersionAllocBlocks}} />
       </div>
 
       <div class="legend-and-summary">
-        <legend>
+        {{!-- <legend>
           {{#each this.allocTypes as |type|}}
             <span class="legend-item {{if (eq (get (get this.newVersionAllocBlocks type.label) "length") 0) "faded"}}">
               <span class="represented-allocation {{type.label}}"></span>
               {{get (get this.newVersionAllocBlocks type.label) "length"}} {{capitalize type.label}}
             </span>
           {{/each}}
+        </legend> --}}
+
+        <legend>
+          {{#each this.allocTypes as |type|}}
+            {{#each-in (get this.newVersionAllocBlocks type.label) as |health allocsByHealth|}}
+              {{#each-in allocsByHealth as |canary allocsByCanary|}}
+                <span class="legend-item {{if (eq (get allocsByCanary "length") 0) "faded"}}">
+                  <span class="represented-allocation {{type.label}} {{health}} {{canary}}"></span>
+                  {{get allocsByCanary "length"}} {{capitalize type.label}} {{capitalize health}} {{capitalize canary}}
+                </span>
+              {{/each-in}}
+            {{/each-in}}
+          {{/each}}
         </legend>
+
       </div>
 
       <div class="history-and-params">

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -62,10 +62,17 @@
         {{!-- Legend by Status, then by Health, then by Canary --}}
         <legend>
           {{#each-in this.newAllocsByStatus as |status count|}}
-            <span class="legend-item {{if (eq count 0) "faded"}}">
+            <ConditionalLinkTo
+              @condition={{not (eq status "unplaced")}}
+              @route="jobs.job.allocations"
+              @model={{@job}}
+              @query={{hash status=(concat '["' status '"]') version=(concat '[' this.job.latestDeployment.versionNumber ']')}}
+              @class="legend-item {{if (eq count 0) "faded"}}"
+              @label="View {{status}} allocations"
+            >
               <span class="represented-allocation {{status}}"></span>
-              {{count}} {{capitalize status}}
-            </span>
+                {{count}} {{capitalize status}}
+            </ConditionalLinkTo>
           {{/each-in}}
 
           {{#each-in this.newAllocsByHealth as |health count|}}
@@ -75,7 +82,7 @@
                   {{#if (eq health "healthy")}}
                     <FlightIcon @name="check" @color="#25ba81" />
                   {{else}}
-                    <FlightIcon @name="running" @color="black" />
+                    <FlightIcon @name="running" @color="black" class="not-animated" />
                   {{/if}}
                 </span>
               </span>

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -70,7 +70,7 @@
 
           {{#each-in this.newAllocsByHealth as |health count|}}
             <span class="legend-item {{if (eq count 0) "faded"}}">
-              <span class="represented-allocation unplaced">
+              <span class="represented-allocation legend-example">
                 <span class="alloc-health-indicator">
                   {{#if (eq health "healthy")}}
                     <FlightIcon @name="check" @color="#25ba81" />
@@ -84,7 +84,7 @@
           {{/each-in}}
 
           <span class="legend-item {{if (eq this.newAllocsByCanary.canary 0) "faded"}}">
-            <span class="represented-allocation pending canary">
+            <span class="represented-allocation legend-example canary">
               <span class="alloc-canary-indicator" />
             </span>
             {{this.newAllocsByCanary.canary}} Canary

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -58,7 +58,42 @@
       </div>
 
       <div class="legend-and-summary">
+
+        {{!-- Legend by Status, then by Health, then by Canary --}}
         <legend>
+          {{#each-in this.newAllocsByStatus as |status count|}}
+            <span class="legend-item {{if (eq count 0) "faded"}}">
+              <span class="represented-allocation {{status}}"></span>
+              {{count}} {{capitalize status}}
+            </span>
+          {{/each-in}}
+
+          {{#each-in this.newAllocsByHealth as |health count|}}
+            <span class="legend-item {{if (eq count 0) "faded"}}">
+              <span class="represented-allocation unplaced">
+                <span class="alloc-health-indicator">
+                  {{#if (eq health "healthy")}}
+                    <FlightIcon @name="check" @color="#25ba81" />
+                  {{else}}
+                    <FlightIcon @name="running" @color="black" />
+                  {{/if}}
+                </span>
+              </span>
+              {{count}} {{capitalize health}}
+            </span>
+          {{/each-in}}
+
+          <span class="legend-item {{if (eq this.newAllocsByCanary.canary 0) "faded"}}">
+            <span class="represented-allocation pending canary">
+              <span class="alloc-canary-indicator" />
+            </span>
+            {{this.newAllocsByCanary.canary}} Canary
+          </span>
+
+        </legend>
+
+
+        {{!-- <legend>
           {{#each this.allocTypes as |type|}}
             {{#each-in (get this.newVersionAllocBlocks type.label) as |health allocsByHealth|}}
               {{#each-in allocsByHealth as |canary allocsByCanary|}}
@@ -69,7 +104,7 @@
               {{/each-in}}
             {{/each-in}}
           {{/each}}
-        </legend>
+        </legend> --}}
       </div>
 
       <div class="history-and-params">

--- a/ui/app/components/job-status/panel/deploying.js
+++ b/ui/app/components/job-status/panel/deploying.js
@@ -21,9 +21,53 @@ export default class JobStatusPanelDeployingComponent extends Component {
   ].map((type) => {
     return {
       label: type,
-      property: `${type}Allocs`,
+      // property: `${type}Allocs`,
     };
   });
+
+  // clientStatuses = [
+  //   'running',
+  //   'pending',
+  //   'failed',
+  //   'unknown',
+  // ];
+
+  // propertyStatuses = [
+  //   'isCanary',
+  //   'isHealthy',
+  //   'isNotHealthy'
+  // ];
+
+  // // Make a matrix of clientStatuses and propertyStatuses
+  // allocTypes = this.clientStatuses.reduce((acc, clientStatus) => {
+  //   this.propertyStatuses.forEach(propertyStatus => {
+  //     acc.push({
+  //       label: `${clientStatus} ${propertyStatus}`,
+  //       clientStatus,
+  //       propertyStatus,
+  //     });
+  //   });
+  //   return acc;
+  // }, []);
+
+  // allocTypes = [
+  //   { clientStatus: 'running',  isCanary: true},
+  //   { clientStatus: 'running',  isCanary: false},
+  //   { clientStatus: 'pending',  isCanary: true},
+  //   { clientStatus: 'pending',  isCanary: false},
+  //   { clientStatus: 'failed',   isCanary: true},
+  //   { clientStatus: 'failed',   isCanary: false},
+  //   // 'unknown',
+  //   // 'lost',
+  //   // 'queued',
+  //   // 'complete',
+  //   'unplaced',
+  // ].map((type) => {
+  //   return {
+  //     label: type,
+  //     // property: `${type}Allocs`,
+  //   };
+  // });
 
   @tracked oldVersionAllocBlockIDs = [];
 
@@ -64,12 +108,39 @@ export default class JobStatusPanelDeployingComponent extends Component {
   @alias('job.latestDeployment') deployment;
   @alias('deployment.desiredTotal') desiredTotal;
 
+  // get oldVersionAllocBlocks() {
+  //   return this.job.allocations
+  //     .filter((allocation) => this.oldVersionAllocBlockIDs.includes(allocation))
+  //     .reduce((alloGroups, currentAlloc) => {
+  //       (alloGroups[currentAlloc.clientStatus] =
+  //         alloGroups[currentAlloc.clientStatus] || []).push(currentAlloc);
+  //       return alloGroups;
+  //     }, {});
+  // }
+  // get oldVersionAllocBlocks() {
+  //   return this.job.allocations
+  //     .filter((allocation) => this.oldVersionAllocBlockIDs.includes(allocation))
+  //     .reduce((alloGroups, currentAlloc) => {
+  //       const key = `${currentAlloc.clientStatus} old`;
+  //       (alloGroups[key] = alloGroups[key] || []).push(currentAlloc);
+  //       return alloGroups;
+  //     }, {});
+  // }
+
   get oldVersionAllocBlocks() {
     return this.job.allocations
       .filter((allocation) => this.oldVersionAllocBlockIDs.includes(allocation))
       .reduce((alloGroups, currentAlloc) => {
-        (alloGroups[currentAlloc.clientStatus] =
-          alloGroups[currentAlloc.clientStatus] || []).push(currentAlloc);
+        const status = currentAlloc.clientStatus;
+
+        if (!alloGroups[status]) {
+          alloGroups[status] = {
+            healthy: { nonCanary: [] },
+            unhealthy: { nonCanary: [] },
+          };
+        }
+        alloGroups[status].healthy.nonCanary.push(currentAlloc);
+
         return alloGroups;
       }, {});
   }
@@ -79,36 +150,54 @@ export default class JobStatusPanelDeployingComponent extends Component {
     let allocationsOfDeploymentVersion = this.job.allocations.filter(
       (a) => a.jobVersion === this.deployment.get('versionNumber')
     );
-    // Only fill up to 100% of desiredTotal. Once we've filled up, we can stop counting.
-    let allocationsOfShowableType = this.allocTypes.reduce((blocks, type) => {
-      const jobAllocsOfType = allocationsOfDeploymentVersion.filterBy(
-        'clientStatus',
-        type.label
-      );
-      if (availableSlotsToFill > 0) {
-        blocks[type.label] = Array(
-          Math.min(availableSlotsToFill, jobAllocsOfType.length)
-        )
-          .fill()
-          .map((_, i) => {
-            return jobAllocsOfType[i];
-          });
-        availableSlotsToFill -= blocks[type.label].length;
-      } else {
-        blocks[type.label] = [];
-      }
-      return blocks;
+
+    let allocationCategories = this.allocTypes.reduce((categories, type) => {
+      categories[type.label] = {
+        healthy: { canary: [], nonCanary: [] },
+        unhealthy: { canary: [], nonCanary: [] },
+      };
+      return categories;
     }, {});
+
+    for (let alloc of allocationsOfDeploymentVersion) {
+      if (availableSlotsToFill <= 0) {
+        break;
+      }
+      let status = alloc.clientStatus;
+      let health = alloc.isHealthy ? 'healthy' : 'unhealthy';
+      let canary = alloc.isCanary ? 'canary' : 'nonCanary';
+
+      if (allocationCategories[status]) {
+        allocationCategories[status][health][canary].push(alloc);
+        availableSlotsToFill--;
+      }
+    }
+
+    // Fill unplaced slots if availableSlotsToFill > 0
     if (availableSlotsToFill > 0) {
-      allocationsOfShowableType['unplaced'] = Array(availableSlotsToFill)
+      allocationCategories['unplaced'] = {
+        healthy: { canary: [], nonCanary: [] },
+        unhealthy: { canary: [], nonCanary: [] },
+      };
+      allocationCategories['unplaced']['healthy']['nonCanary'] = Array(
+        availableSlotsToFill
+      )
         .fill()
         .map(() => {
           return { clientStatus: 'unplaced' };
         });
     }
-    return allocationsOfShowableType;
+    console.log('allocationCategories', allocationCategories);
+
+    return allocationCategories;
   }
 
+  get newRunningHealthyAllocBlocks() {
+    return [
+      ...this.newVersionAllocBlocks['running']['healthy']['canary'],
+      ...this.newVersionAllocBlocks['running']['healthy']['nonCanary'],
+    ];
+  }
   // TODO: eventually we will want this from a new property on a job.
   // TODO: consolidate w/ the one in steady.js
   get totalAllocs() {

--- a/ui/app/components/job-status/panel/deploying.js
+++ b/ui/app/components/job-status/panel/deploying.js
@@ -21,7 +21,6 @@ export default class JobStatusPanelDeployingComponent extends Component {
   ].map((type) => {
     return {
       label: type,
-      // property: `${type}Allocs`,
     };
   });
 

--- a/ui/app/components/job-status/panel/deploying.js
+++ b/ui/app/components/job-status/panel/deploying.js
@@ -136,7 +136,10 @@ export default class JobStatusPanelDeployingComponent extends Component {
   }
 
   get oldRunningHealthyAllocBlocks() {
-    return this.oldVersionAllocBlocks['running']['healthy']['nonCanary'];
+    return this.oldVersionAllocBlocks.running?.healthy?.nonCanary || [];
+  }
+  get oldCompleteHealthyAllocBlocks() {
+    return this.oldVersionAllocBlocks.complete?.healthy?.nonCanary || [];
   }
 
   // TODO: eventually we will want this from a new property on a job.

--- a/ui/app/components/job-status/panel/deploying.js
+++ b/ui/app/components/job-status/panel/deploying.js
@@ -135,6 +135,38 @@ export default class JobStatusPanelDeployingComponent extends Component {
     ];
   }
 
+  // #region legend
+  get newAllocsByStatus() {
+    return Object.entries(this.newVersionAllocBlocks).reduce(
+      (counts, [status, healthStatusObj]) => {
+        counts[status] = Object.values(healthStatusObj)
+          .flatMap((canaryStatusObj) => Object.values(canaryStatusObj))
+          .flatMap((canaryStatusArray) => canaryStatusArray).length;
+        return counts;
+      },
+      {}
+    );
+  }
+
+  get newAllocsByCanary() {
+    return Object.values(this.newVersionAllocBlocks)
+      .flatMap((healthStatusObj) => Object.values(healthStatusObj))
+      .flatMap((canaryStatusObj) => Object.entries(canaryStatusObj))
+      .reduce((counts, [canaryStatus, items]) => {
+        counts[canaryStatus] = (counts[canaryStatus] || 0) + items.length;
+        return counts;
+      }, {});
+  }
+
+  get newAllocsByHealth() {
+    return {
+      healthy: this.newRunningHealthyAllocBlocks.length,
+      'health unknown':
+        this.totalAllocs - this.newRunningHealthyAllocBlocks.length,
+    };
+  }
+  // #endregion legend
+
   get oldRunningHealthyAllocBlocks() {
     return this.oldVersionAllocBlocks.running?.healthy?.nonCanary || [];
   }

--- a/ui/app/components/job-status/panel/deploying.js
+++ b/ui/app/components/job-status/panel/deploying.js
@@ -25,50 +25,6 @@ export default class JobStatusPanelDeployingComponent extends Component {
     };
   });
 
-  // clientStatuses = [
-  //   'running',
-  //   'pending',
-  //   'failed',
-  //   'unknown',
-  // ];
-
-  // propertyStatuses = [
-  //   'isCanary',
-  //   'isHealthy',
-  //   'isNotHealthy'
-  // ];
-
-  // // Make a matrix of clientStatuses and propertyStatuses
-  // allocTypes = this.clientStatuses.reduce((acc, clientStatus) => {
-  //   this.propertyStatuses.forEach(propertyStatus => {
-  //     acc.push({
-  //       label: `${clientStatus} ${propertyStatus}`,
-  //       clientStatus,
-  //       propertyStatus,
-  //     });
-  //   });
-  //   return acc;
-  // }, []);
-
-  // allocTypes = [
-  //   { clientStatus: 'running',  isCanary: true},
-  //   { clientStatus: 'running',  isCanary: false},
-  //   { clientStatus: 'pending',  isCanary: true},
-  //   { clientStatus: 'pending',  isCanary: false},
-  //   { clientStatus: 'failed',   isCanary: true},
-  //   { clientStatus: 'failed',   isCanary: false},
-  //   // 'unknown',
-  //   // 'lost',
-  //   // 'queued',
-  //   // 'complete',
-  //   'unplaced',
-  // ].map((type) => {
-  //   return {
-  //     label: type,
-  //     // property: `${type}Allocs`,
-  //   };
-  // });
-
   @tracked oldVersionAllocBlockIDs = [];
 
   // Called via did-insert; sets a static array of "outgoing"
@@ -107,25 +63,6 @@ export default class JobStatusPanelDeployingComponent extends Component {
 
   @alias('job.latestDeployment') deployment;
   @alias('deployment.desiredTotal') desiredTotal;
-
-  // get oldVersionAllocBlocks() {
-  //   return this.job.allocations
-  //     .filter((allocation) => this.oldVersionAllocBlockIDs.includes(allocation))
-  //     .reduce((alloGroups, currentAlloc) => {
-  //       (alloGroups[currentAlloc.clientStatus] =
-  //         alloGroups[currentAlloc.clientStatus] || []).push(currentAlloc);
-  //       return alloGroups;
-  //     }, {});
-  // }
-  // get oldVersionAllocBlocks() {
-  //   return this.job.allocations
-  //     .filter((allocation) => this.oldVersionAllocBlockIDs.includes(allocation))
-  //     .reduce((alloGroups, currentAlloc) => {
-  //       const key = `${currentAlloc.clientStatus} old`;
-  //       (alloGroups[key] = alloGroups[key] || []).push(currentAlloc);
-  //       return alloGroups;
-  //     }, {});
-  // }
 
   get oldVersionAllocBlocks() {
     return this.job.allocations
@@ -187,7 +124,6 @@ export default class JobStatusPanelDeployingComponent extends Component {
           return { clientStatus: 'unplaced' };
         });
     }
-    console.log('allocationCategories', allocationCategories);
 
     return allocationCategories;
   }
@@ -198,6 +134,11 @@ export default class JobStatusPanelDeployingComponent extends Component {
       ...this.newVersionAllocBlocks['running']['healthy']['nonCanary'],
     ];
   }
+
+  get oldRunningHealthyAllocBlocks() {
+    return this.oldVersionAllocBlocks['running']['healthy']['nonCanary'];
+  }
+
   // TODO: eventually we will want this from a new property on a job.
   // TODO: consolidate w/ the one in steady.js
   get totalAllocs() {

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -29,7 +29,7 @@
           {{#each this.allocTypes as |type|}}
             <span class="legend-item {{if (eq (get (get this.allocBlocks type.label) "length") 0) "faded"}}">
               <span class="represented-allocation {{type.label}}"></span>
-              {{get (get this.allocBlocks type.label) "length"}} {{capitalize type.label}}
+              {{get (get (get (get this.allocBlocks type.label) 'healthy') 'nonCanary') "length"}} {{capitalize type.label}}
             </span>
           {{/each}}
         </legend>

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -27,10 +27,17 @@
       <div class="legend-and-summary">
         <legend>
           {{#each this.allocTypes as |type|}}
-            <span class="legend-item {{if (eq (get (get this.allocBlocks type.label) "length") 0) "faded"}}">
+            <ConditionalLinkTo
+              @condition={{not (eq type.label "unplaced")}}
+              @route="jobs.job.allocations"
+              @model={{@job}}
+              @query={{hash status=(concat '["' type.label '"]') version=(concat '[' (keys this.versions) ']')}}
+              @class="legend-item {{if (eq (get (get (get (get this.allocBlocks type.label) 'healthy') 'nonCanary') "length") 0) "faded"}}"
+              @label="View {{type.label}} allocations"
+            >
               <span class="represented-allocation {{type.label}}"></span>
               {{get (get (get (get this.allocBlocks type.label) 'healthy') 'nonCanary') "length"}} {{capitalize type.label}}
-            </span>
+            </ConditionalLinkTo>
           {{/each}}
         </legend>
 
@@ -39,8 +46,10 @@
           <ul>
             {{#each-in this.versions as |version allocs|}}
               <li>
-                <Hds::Badge @text={{version}} />
-                <Hds::BadgeCount @text={{allocs.length}} @type="inverted" />
+                <LinkTo @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' version ']')    status=(concat '["running", "pending", "failed"]')         }}>
+                  <Hds::Badge @text={{concat "v" version}} />
+                  <Hds::BadgeCount @text={{allocs.length}} @type="inverted" />
+                </LinkTo>
               </li>
             {{/each-in}}
           </ul>

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -22,7 +22,7 @@
       <JobPage::Parts::SummaryChart @job={{@job}} />
     {{else}}
       <h3 class="title is-4 running-allocs-title"><strong>{{@job.runningAllocs}}/{{this.totalAllocs}}</strong> Allocations Running</h3>
-      <JobStatus::AllocationStatusRow @allocBlocks={{this.allocBlocks}} />
+      <JobStatus::AllocationStatusRow @allocBlocks={{this.allocBlocks}} @steady={{true}} />
 
       <div class="legend-and-summary">
         <legend>

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -18,7 +18,6 @@ export default class JobStatusPanelSteadyComponent extends Component {
   ].map((type) => {
     return {
       label: type,
-      // property: `${type}Allocs`,
     };
   });
 

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -42,7 +42,7 @@ export default class JobStatusPanelSteadyComponent extends Component {
               }),
           },
         };
-        availableSlotsToFill -= blocks[type.label].length;
+        availableSlotsToFill -= blocks[type.label].healthy.nonCanary.length;
       } else {
         blocks[type.label] = { healthy: { nonCanary: [] } };
       }

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -18,7 +18,7 @@ export default class JobStatusPanelSteadyComponent extends Component {
   ].map((type) => {
     return {
       label: type,
-      property: `${type}Allocs`,
+      // property: `${type}Allocs`,
     };
   });
 
@@ -44,7 +44,7 @@ export default class JobStatusPanelSteadyComponent extends Component {
         };
         availableSlotsToFill -= blocks[type.label].length;
       } else {
-        blocks[type.label] = [];
+        blocks[type.label] = {healthy: {nonCanary: []}};
       }
       return blocks;
     }, {});

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -75,7 +75,7 @@ export default class JobStatusPanelSteadyComponent extends Component {
       .flatMap((allocType) => Object.values(allocType))
       .flatMap((allocHealth) => Object.values(allocHealth))
       .flatMap((allocCanary) => Object.values(allocCanary))
-      .map((a) => (!isNaN(a?.jobVersion) ? `v${a.jobVersion}` : 'pending')) // "starting" allocs, and possibly others, do not yet have a jobVersion
+      .map((a) => (!isNaN(a?.jobVersion) ? a.jobVersion : 'pending')) // "starting" allocs, and possibly others, do not yet have a jobVersion
       .reduce(
         (result, item) => ({
           ...result,

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -44,7 +44,7 @@ export default class JobStatusPanelSteadyComponent extends Component {
         };
         availableSlotsToFill -= blocks[type.label].length;
       } else {
-        blocks[type.label] = {healthy: {nonCanary: []}};
+        blocks[type.label] = { healthy: { nonCanary: [] } };
       }
       return blocks;
     }, {});
@@ -73,7 +73,9 @@ export default class JobStatusPanelSteadyComponent extends Component {
 
   get versions() {
     return Object.values(this.allocBlocks)
-      .flat()
+      .flatMap((allocType) => Object.values(allocType))
+      .flatMap((allocHealth) => Object.values(allocHealth))
+      .flatMap((allocCanary) => Object.values(allocCanary))
       .map((a) => (!isNaN(a?.jobVersion) ? `v${a.jobVersion}` : 'pending')) // "starting" allocs, and possibly others, do not yet have a jobVersion
       .reduce(
         (result, item) => ({

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -31,13 +31,17 @@ export default class JobStatusPanelSteadyComponent extends Component {
         type.label
       );
       if (availableSlotsToFill > 0) {
-        blocks[type.label] = Array(
-          Math.min(availableSlotsToFill, jobAllocsOfType.length)
-        )
-          .fill()
-          .map((_, i) => {
-            return jobAllocsOfType[i];
-          });
+        blocks[type.label] = {
+          healthy: {
+            nonCanary: Array(
+              Math.min(availableSlotsToFill, jobAllocsOfType.length)
+            )
+              .fill()
+              .map((_, i) => {
+                return jobAllocsOfType[i];
+              }),
+          },
+        };
         availableSlotsToFill -= blocks[type.label].length;
       } else {
         blocks[type.label] = [];
@@ -45,11 +49,15 @@ export default class JobStatusPanelSteadyComponent extends Component {
       return blocks;
     }, {});
     if (availableSlotsToFill > 0) {
-      allocationsOfShowableType['unplaced'] = Array(availableSlotsToFill)
-        .fill()
-        .map(() => {
-          return { clientStatus: 'unplaced' };
-        });
+      allocationsOfShowableType['unplaced'] = {
+        healthy: {
+          nonCanary: Array(availableSlotsToFill)
+            .fill()
+            .map(() => {
+              return { clientStatus: 'unplaced' };
+            }),
+        },
+      };
     }
     return allocationsOfShowableType;
   }

--- a/ui/app/controllers/jobs/job/allocations.js
+++ b/ui/app/controllers/jobs/job/allocations.js
@@ -41,12 +41,16 @@ export default class AllocationsController extends Controller.extend(
     {
       qpTaskGroup: 'taskGroup',
     },
+    {
+      qpVersion: 'version',
+    },
     'activeTask',
   ];
 
   qpStatus = '';
   qpClient = '';
   qpTaskGroup = '';
+  qpVersion = '';
   currentPage = 1;
   pageSize = 25;
   activeTask = null;
@@ -70,10 +74,16 @@ export default class AllocationsController extends Controller.extend(
     'allocations.[]',
     'selectionStatus',
     'selectionClient',
-    'selectionTaskGroup'
+    'selectionTaskGroup',
+    'selectionVersion'
   )
   get filteredAllocations() {
-    const { selectionStatus, selectionClient, selectionTaskGroup } = this;
+    const {
+      selectionStatus,
+      selectionClient,
+      selectionTaskGroup,
+      selectionVersion,
+    } = this;
 
     return this.allocations.filter((alloc) => {
       if (
@@ -94,6 +104,12 @@ export default class AllocationsController extends Controller.extend(
       ) {
         return false;
       }
+      if (
+        selectionVersion.length &&
+        !selectionVersion.includes(alloc.jobVersion)
+      ) {
+        return false;
+      }
       return true;
     });
   }
@@ -105,6 +121,7 @@ export default class AllocationsController extends Controller.extend(
   @selection('qpStatus') selectionStatus;
   @selection('qpClient') selectionClient;
   @selection('qpTaskGroup') selectionTaskGroup;
+  @selection('qpVersion') selectionVersion;
 
   @action
   gotoAllocation(allocation) {
@@ -156,6 +173,24 @@ export default class AllocationsController extends Controller.extend(
     });
 
     return taskGroups.sort().map((tg) => ({ key: tg, label: tg }));
+  }
+
+  @computed('model.allocations.[]', 'selectionVersion')
+  get optionsVersions() {
+    const versions = Array.from(
+      new Set(this.model.allocations.mapBy('jobVersion'))
+    ).compact();
+
+    // Update query param when the list of versions changes.
+    scheduleOnce('actions', () => {
+      // eslint-disable-next-line ember/no-side-effects
+      this.set(
+        'qpVersion',
+        serialize(intersection(versions, this.selectionVersion))
+      );
+    });
+
+    return versions.sort((a, b) => a - b).map((v) => ({ key: v, label: v }));
   }
 
   setFacetQueryParam(queryParam, selection) {

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -41,6 +41,15 @@ export default class Allocation extends Model {
 
   @attr('string') clientStatus;
   @attr('string') desiredStatus;
+  @attr() deploymentStatus;
+
+  get isCanary() {
+    return this.deploymentStatus?.Canary;
+  }
+
+  get isHealthy() {
+    return this.deploymentStatus?.Healthy;
+  }
 
   @attr healthChecks;
 

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -267,9 +267,14 @@
     }
 
     // Canary Status
-    &.canary {
-      // border: 2px solid $orange;
+    &.canary > .alloc-canary-indicator {
       overflow: hidden;
+      width: 16px;
+      height: 16px;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+
       &:after {
         content: '';
         position: absolute;

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -162,6 +162,7 @@
     height: 32px;
     width: 32px;
     color: white;
+    position: relative;
 
     $queued: $grey;
     $pending: $grey-lighter;
@@ -201,7 +202,6 @@
 
     // Health Statuses
     &.running {
-      position: relative;
       // overflow: hidden;
       .alloc-health-indicator {
         position: absolute;

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -65,6 +65,9 @@
         gap: 0.5rem;
         & > li {
           white-space: nowrap;
+          & a {
+            text-decoration: none;
+          }
         }
       }
     }
@@ -300,6 +303,10 @@
         background-color: $orange;
       }
     }
+  }
+
+  .legend-item .represented-allocation .flight-icon {
+    animation: none;
   }
 
   & > .boxed-section-body > .deployment-allocations {

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -46,6 +46,7 @@
 
   .legend-and-summary {
     // grid-area: legend-and-summary;
+    // TODO: may revisit this grid-area later, but is currently used in 2 competing ways
     display: grid;
     gap: 0.5rem;
     grid-template-columns: 50% 50%;
@@ -107,7 +108,6 @@
     display: grid;
     gap: 10px;
     grid-auto-flow: column;
-    // grid-auto-columns: minmax(1px, 32px);
     grid-auto-columns: 32px;
 
     & > .represented-allocation {
@@ -140,6 +140,7 @@
       }
 
       .represented-allocation.rest {
+        // TODO: we eventually want to establish a minimum width here. However, we need to also include this in the allocation-status-block width computation.
         font-size: 0.8rem;
         text-align: center;
         display: grid;
@@ -147,7 +148,6 @@
         font-weight: bold;
         text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
         width: 100%;
-        // min-width: 32px; // TODO: fix
 
         &.unplaced {
           color: black;
@@ -202,7 +202,6 @@
 
     // Health Statuses
     &.running {
-      // overflow: hidden;
       .alloc-health-indicator {
         position: absolute;
         width: 100%;
@@ -210,7 +209,6 @@
         display: grid;
         align-content: center;
         justify-content: center;
-        // background-color: white;
       }
       &.rest .alloc-health-indicator {
         top: -7px;
@@ -223,47 +221,6 @@
         box-sizing: border-box;
         transform: scale(0.75);
       }
-      &.rest.healthy {
-        .alloc-health-indicator {
-          // background: $nomad-green-dark;
-          // border: 1px solid white;
-        }
-      }
-
-      // .alloc-health-indicator {
-      //   position: absolute;
-      //   // top: -6px;
-      //   // right: -6px;
-      //   // border-radius: 20px;
-      //   width: 100%;
-      //   height: 100%;
-      //   display: grid;
-      //   align-content: center;
-      //   justify-content: center;
-      // }
-
-      // &.healthy {
-      //   .alloc-health-indicator {
-      //     background: #16704d;
-      //   }
-      // }
-
-      // &:after {
-      //   content: "";
-      //   position:absolute;
-      //   right: -8px;
-      //   top: -8px;
-      //   width:16px;
-      //   height:16px;
-      //   transform:rotate(45deg);
-      //   background-color:#4A4A4A;
-      // }
-
-      // &.healthy {
-      //   &:after {
-      //     background-color: $nomad-green-darker;
-      //   }
-      // }
     }
 
     // Canary Status

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -142,12 +142,14 @@
       .represented-allocation.rest {
         // TODO: we eventually want to establish a minimum width here. However, we need to also include this in the allocation-status-block width computation.
         font-size: 0.8rem;
-        text-align: center;
-        display: grid;
-        align-content: center;
         font-weight: bold;
         text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
         width: 100%;
+
+        & > .rest-count {
+          position: relative;
+          z-index: 2;
+        }
 
         &.unplaced {
           color: black;
@@ -163,6 +165,9 @@
     width: 32px;
     color: white;
     position: relative;
+    display: grid;
+    align-content: center;
+    justify-content: center;
 
     $queued: $grey;
     $pending: $grey-lighter;
@@ -191,16 +196,67 @@
     &.pending {
       background: $pending;
       color: black;
+      position: relative;
+      overflow: hidden;
+
+      &:after {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: linear-gradient(-60deg, $pending, #eee, $pending);
+        animation: shimmer 2s ease-in-out infinite;
+      }
     }
     &.lost {
       background: $lost;
     }
+
     &.unplaced {
-      background: transparent;
-      border: 2px solid $grey-lighter;
+      background: $grey-lighter;
+      position: relative;
+      overflow: hidden;
+
+      &:before {
+        background: linear-gradient(-60deg, $pending, #eee, $pending);
+        animation: shimmer 2s ease-in-out infinite;
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+      &:after {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: calc(100% - 4px);
+        height: calc(100% - 4px);
+        margin: 2px;
+        background: white;
+        border-radius: 3px;
+      }
+    }
+
+    &.legend-example {
+      background: #eee;
     }
 
     // Health Statuses
+
+    .alloc-health-indicator {
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      display: grid;
+      align-content: center;
+      justify-content: center;
+    }
+
     &.running {
       .alloc-health-indicator {
         position: absolute;
@@ -262,6 +318,11 @@
     .represented-allocation {
       width: 20px;
       height: 20px;
+      animation: none;
+      &:before,
+      &:after {
+        animation: none;
+      }
     }
   }
 
@@ -358,5 +419,17 @@
   }
   to {
     box-shadow: inset 0 0 0 100px rgba(255, 200, 0, 0);
+  }
+}
+
+@keyframes shimmer {
+  0% {
+    transform: translate3d(-100%, 0, 0);
+  }
+  30% {
+    transform: translate3d(100%, 0, 0);
+  }
+  100% {
+    transform: translate3d(100%, 0, 0);
   }
 }

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -52,7 +52,7 @@
 
     legend {
       display: grid;
-      grid-template-columns: repeat(2, 1fr);
+      grid-template-columns: repeat(4, 1fr);
       gap: 0.5rem;
     }
     .versions {
@@ -274,6 +274,7 @@
       position: absolute;
       bottom: 0;
       left: 0;
+      border-radius: 4px;
 
       &:after {
         content: '';

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -210,15 +210,14 @@
         display: grid;
         align-content: center;
         justify-content: center;
-        background-color: unset;
+        // background-color: white;
       }
       &.rest .alloc-health-indicator {
         top: -7px;
         right: -7px;
         border-radius: 20px;
         background: white;
-        box-shadow: 0px 0px 3px 0px rgba(0, 0, 0, 0.3);
-        // border: 1px solid white;
+        box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, 0.5);
         width: 20px;
         height: 20px;
         box-sizing: border-box;
@@ -226,7 +225,7 @@
       }
       &.rest.healthy {
         .alloc-health-indicator {
-          background: $nomad-green-dark;
+          // background: $nomad-green-dark;
           // border: 1px solid white;
         }
       }

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -147,6 +147,7 @@
         font-weight: bold;
         text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
         width: 100%;
+        // min-width: 32px; // TODO: fix
 
         &.unplaced {
           color: black;
@@ -169,6 +170,7 @@
     $failed: $danger;
     $lost: $dark;
 
+    // Client Statuses
     &.running {
       background: $running;
     }
@@ -192,10 +194,93 @@
     &.lost {
       background: $lost;
     }
-
     &.unplaced {
       background: transparent;
       border: 2px solid $grey-lighter;
+    }
+
+    // Health Statuses
+    &.running {
+      position: relative;
+      // overflow: hidden;
+      .alloc-health-indicator {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        display: grid;
+        align-content: center;
+        justify-content: center;
+        background-color: unset;
+      }
+      &.rest .alloc-health-indicator {
+        top: -7px;
+        right: -7px;
+        border-radius: 20px;
+        background: white;
+        box-shadow: 0px 0px 3px 0px rgba(0, 0, 0, 0.3);
+        // border: 1px solid white;
+        width: 20px;
+        height: 20px;
+        box-sizing: border-box;
+        transform: scale(0.75);
+      }
+      &.rest.healthy {
+        .alloc-health-indicator {
+          background: $nomad-green-dark;
+          // border: 1px solid white;
+        }
+      }
+
+      // .alloc-health-indicator {
+      //   position: absolute;
+      //   // top: -6px;
+      //   // right: -6px;
+      //   // border-radius: 20px;
+      //   width: 100%;
+      //   height: 100%;
+      //   display: grid;
+      //   align-content: center;
+      //   justify-content: center;
+      // }
+
+      // &.healthy {
+      //   .alloc-health-indicator {
+      //     background: #16704d;
+      //   }
+      // }
+
+      // &:after {
+      //   content: "";
+      //   position:absolute;
+      //   right: -8px;
+      //   top: -8px;
+      //   width:16px;
+      //   height:16px;
+      //   transform:rotate(45deg);
+      //   background-color:#4A4A4A;
+      // }
+
+      // &.healthy {
+      //   &:after {
+      //     background-color: $nomad-green-darker;
+      //   }
+      // }
+    }
+
+    // Canary Status
+    &.canary {
+      // border: 2px solid $orange;
+      overflow: hidden;
+      &:after {
+        content: '';
+        position: absolute;
+        left: -8px;
+        bottom: -8px;
+        width: 16px;
+        height: 16px;
+        transform: rotate(45deg);
+        background-color: $orange;
+      }
     }
   }
 

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -44,8 +44,8 @@
     }
   }
 
-  .boxed-section-body > .legend-and-summary {
-    grid-area: legend-and-summary;
+  .legend-and-summary {
+    // grid-area: legend-and-summary;
     display: grid;
     gap: 0.5rem;
     grid-template-columns: 50% 50%;
@@ -107,11 +107,11 @@
     display: grid;
     gap: 10px;
     grid-auto-flow: column;
-    grid-auto-columns: minmax(1px, 32px);
-    margin-bottom: 1rem;
+    // grid-auto-columns: minmax(1px, 32px);
+    grid-auto-columns: 32px;
 
     & > .represented-allocation {
-      width: auto;
+      width: 32px;
     }
   }
 
@@ -288,20 +288,22 @@
     }
   }
 
-  & > .boxed-section-body > .legend-and-summary {
-    .legend-item {
-      display: grid;
-      gap: 0.5rem;
-      grid-template-columns: auto 1fr;
+  & > .boxed-section-body > .deployment-allocations {
+    margin-bottom: 1rem;
+  }
 
-      &.faded {
-        opacity: 0.5;
-      }
+  .legend-item {
+    display: grid;
+    gap: 0.5rem;
+    grid-template-columns: auto 1fr;
 
-      .represented-allocation {
-        width: 20px;
-        height: 20px;
-      }
+    &.faded {
+      opacity: 0.5;
+    }
+
+    .represented-allocation {
+      width: 20px;
+      height: 20px;
     }
   }
 

--- a/ui/app/templates/jobs/job/allocations.hbs
+++ b/ui/app/templates/jobs/job/allocations.hbs
@@ -33,6 +33,13 @@
             @selection={{this.selectionTaskGroup}}
             @onSelect={{action this.setFacetQueryParam "qpTaskGroup"}}
           />
+          <MultiSelectDropdown
+            data-test-allocation-version-facet
+            @label="Job Version"
+            @options={{this.optionsVersions}}
+            @selection={{this.selectionVersion}}
+            @onSelect={{action this.setFacetQueryParam "qpVersion"}}
+          />
         </div>
       </div>
     </div>

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -115,7 +115,7 @@ module('Acceptance | job status panel', function (hooks) {
         `All ${jobAllocCount} allocations are represented in the status panel`
       );
 
-    groupTaskCount = 40;
+    groupTaskCount = 20;
 
     job = server.create('job', {
       status: 'running',
@@ -130,6 +130,7 @@ module('Acceptance | job status panel', function (hooks) {
         lost: 0,
       },
       groupTaskCount,
+      noActiveDeployment: true,
       shallow: true,
     });
 
@@ -161,7 +162,7 @@ module('Acceptance | job status panel', function (hooks) {
       .dom('.ungrouped-allocs .represented-allocation.failed')
       .exists(
         { count: failedAllocCount },
-        `All ${failedAllocCount} running allocations are represented in the status panel`
+        `All ${failedAllocCount} failed allocations are represented in the status panel`
       );
     await percySnapshot(assert);
   });
@@ -171,7 +172,7 @@ module('Acceptance | job status panel', function (hooks) {
 
     faker.seed(1);
 
-    let groupTaskCount = 50;
+    let groupTaskCount = 20;
 
     let job = server.create('job', {
       status: 'running',
@@ -196,6 +197,7 @@ module('Acceptance | job status panel', function (hooks) {
       jobId: job.id,
     }).length;
 
+    await this.pauseTest();
     assert
       .dom('.ungrouped-allocs .represented-allocation.running')
       .exists(
@@ -203,7 +205,7 @@ module('Acceptance | job status panel', function (hooks) {
         `All ${jobAllocCount} allocations are represented in the status panel, ungrouped`
       );
 
-    groupTaskCount = 51;
+    groupTaskCount = 40;
 
     job = server.create('job', {
       status: 'running',
@@ -228,9 +230,8 @@ module('Acceptance | job status panel', function (hooks) {
       jobId: job.id,
     }).length;
 
-    // At standard test resolution, 51 allocations will attempt to display 20 ungrouped, and 31 grouped.
+    // At standard test resolution, 40 allocations will attempt to display 20 ungrouped, and 20 grouped.
     let desiredUngroupedAllocCount = 20;
-
     assert
       .dom('.ungrouped-allocs .represented-allocation.running')
       .exists(

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -197,7 +197,6 @@ module('Acceptance | job status panel', function (hooks) {
       jobId: job.id,
     }).length;
 
-    await this.pauseTest();
     assert
       .dom('.ungrouped-allocs .represented-allocation.running')
       .exists(


### PR DESCRIPTION
Instead of just splitting by `alloc.clientStatus`, we now split by multiple factors and give indicators/icons as such.

This splits `allocBlocks` objects in both the "steady" and "deploying" panels into an object format like this:

```
allocBlocks = {
  running: {
    healthy: {
      nonCanary: [Allocation, Allocation, Allocation],
      canary: [Allocation],
    },
    unhealthy: {
      nonCanary: [],
      canary: [],
    },
  },
  pending: {
    healthy: {
      nonCanary: [Allocation, Allocation, Allocation],
      canary: [],
    },
    unhealthy: {
      nonCanary: [],
      canary: [],
    },
  },
  failed: {
    healthy: {
      nonCanary: [],
      canary: [],
    },
    unhealthy: {
      nonCanary: [],
      canary: [],
    },
  },
  unplaced: {
    healthy: {
      nonCanary: [Allocation, Allocation, Allocation],
      canary: [],
    },
    unhealthy: {
      nonCanary: [],
      canary: [],
    },
  },
  complete: {
    healthy: {
      nonCanary: [],
      canary: [],
    },
    unhealthy: {
      nonCanary: [],
      canary: [],
    },
  },
}
```

Since we're also allowing for many more sub-categories when displaying these allocation blocks, we've also established a new rule with minimum block size. We'll no longer have an arbitrary threshold at which it splits into "aggregate/summary" view (was 50 blocks), now it will depend on a user's screen width.

![image](https://user-images.githubusercontent.com/713991/229534712-9d13a64a-95b1-4bce-bea2-a25c3f40d944.png)

Resolves https://github.com/hashicorp/nomad/issues/16724