### PR TITLE
Add Partition on ConsulUpstream, ConsulTerminatingConfigEntry, ConsulIngressConfigEntry and ConsulIngressService

### DIFF
--- a/.changelog/16768.txt
+++ b/.changelog/16768.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Added support for Partition field on ConsulUpstream, ConsulTerminatingConfigEntry, ConsulIngressConfigEntry and ConsulIngressService
+```

--- a/api/consul.go
+++ b/api/consul.go
@@ -207,6 +207,7 @@ func (c *ConsulMeshGateway) Copy() *ConsulMeshGateway {
 type ConsulUpstream struct {
 	DestinationName      string             `mapstructure:"destination_name" hcl:"destination_name,optional"`
 	DestinationNamespace string             `mapstructure:"destination_namespace" hcl:"destination_namespace,optional"`
+	DestinationPartition string             `mapstructure:"destination_partition" hcl:"destination_partition,optional"`
 	LocalBindPort        int                `mapstructure:"local_bind_port" hcl:"local_bind_port,optional"`
 	Datacenter           string             `mapstructure:"datacenter" hcl:"datacenter,optional"`
 	LocalBindAddress     string             `mapstructure:"local_bind_address" hcl:"local_bind_address,optional"`
@@ -221,6 +222,7 @@ func (cu *ConsulUpstream) Copy() *ConsulUpstream {
 	return &ConsulUpstream{
 		DestinationName:      cu.DestinationName,
 		DestinationNamespace: cu.DestinationNamespace,
+		DestinationPartition: cu.DestinationPartition,
 		LocalBindPort:        cu.LocalBindPort,
 		Datacenter:           cu.Datacenter,
 		LocalBindAddress:     cu.LocalBindAddress,
@@ -413,6 +415,8 @@ type ConsulIngressService struct {
 	Name string `hcl:"name,optional"`
 
 	Hosts []string `hcl:"hosts,optional"`
+
+	Partition string `mapstructure:"partition" hcl:"partition,optional"`
 }
 
 func (s *ConsulIngressService) Canonicalize() {
@@ -437,8 +441,9 @@ func (s *ConsulIngressService) Copy() *ConsulIngressService {
 	}
 
 	return &ConsulIngressService{
-		Name:  s.Name,
-		Hosts: hosts,
+		Name:      s.Name,
+		Hosts:     hosts,
+		Partition: s.Partition,
 	}
 }
 
@@ -499,6 +504,7 @@ type ConsulIngressConfigEntry struct {
 
 	TLS       *ConsulGatewayTLSConfig  `hcl:"tls,block"`
 	Listeners []*ConsulIngressListener `hcl:"listener,block"`
+	Partition string                   `mapstructure:"partition" hcl:"partition,optional"`
 }
 
 func (e *ConsulIngressConfigEntry) Canonicalize() {
@@ -533,6 +539,7 @@ func (e *ConsulIngressConfigEntry) Copy() *ConsulIngressConfigEntry {
 	return &ConsulIngressConfigEntry{
 		TLS:       e.TLS.Copy(),
 		Listeners: listeners,
+		Partition: e.Partition,
 	}
 }
 
@@ -570,7 +577,8 @@ type ConsulTerminatingConfigEntry struct {
 	// Namespace is not yet supported.
 	// Namespace string
 
-	Services []*ConsulLinkedService `hcl:"service,block"`
+	Partition string                 `hcl:"partition,optional" mapstructure:"partition"`
+	Services  []*ConsulLinkedService `hcl:"service,block"`
 }
 
 func (e *ConsulTerminatingConfigEntry) Canonicalize() {
@@ -601,7 +609,8 @@ func (e *ConsulTerminatingConfigEntry) Copy() *ConsulTerminatingConfigEntry {
 	}
 
 	return &ConsulTerminatingConfigEntry{
-		Services: services,
+		Partition: e.Partition,
+		Services:  services,
 	}
 }
 

--- a/api/consul_test.go
+++ b/api/consul_test.go
@@ -174,6 +174,7 @@ func TestConsulUpstream_Copy(t *testing.T) {
 		cu := &ConsulUpstream{
 			DestinationName:      "dest1",
 			DestinationNamespace: "ns2",
+			DestinationPartition: "partition-1",
 			Datacenter:           "dc2",
 			LocalBindPort:        2000,
 			LocalBindAddress:     "10.0.0.1",
@@ -198,6 +199,7 @@ func TestConsulUpstream_Canonicalize(t *testing.T) {
 		cu := &ConsulUpstream{
 			DestinationName:      "dest1",
 			DestinationNamespace: "ns2",
+			DestinationPartition: "partition-1",
 			Datacenter:           "dc2",
 			LocalBindPort:        2000,
 			LocalBindAddress:     "10.0.0.1",
@@ -208,6 +210,7 @@ func TestConsulUpstream_Canonicalize(t *testing.T) {
 		must.Eq(t, &ConsulUpstream{
 			DestinationName:      "dest1",
 			DestinationNamespace: "ns2",
+			DestinationPartition: "partition-1",
 			Datacenter:           "dc2",
 			LocalBindPort:        2000,
 			LocalBindAddress:     "10.0.0.1",
@@ -362,10 +365,12 @@ func TestConsulIngressConfigEntry_Canonicalize(t *testing.T) {
 				Port:     9090,
 				Protocol: "http",
 				Services: []*ConsulIngressService{{
-					Name:  "service1",
-					Hosts: []string{"1.1.1.1"},
+					Name:      "service1",
+					Hosts:     []string{"1.1.1.1"},
+					Partition: "partition-1",
 				}},
 			}},
+			Partition: "partition-1",
 		}
 		c.Canonicalize()
 		must.Eq(t, &ConsulIngressConfigEntry{
@@ -374,10 +379,12 @@ func TestConsulIngressConfigEntry_Canonicalize(t *testing.T) {
 				Port:     9090,
 				Protocol: "http",
 				Services: []*ConsulIngressService{{
-					Name:  "service1",
-					Hosts: []string{"1.1.1.1"},
+					Name:      "service1",
+					Hosts:     []string{"1.1.1.1"},
+					Partition: "partition-1",
 				}},
 			}},
+			Partition: "partition-1",
 		}, c)
 	})
 }
@@ -405,6 +412,7 @@ func TestConsulIngressConfigEntry_Copy(t *testing.T) {
 				Hosts: []string{"2.2.2.2"},
 			}},
 		}},
+		Partition: "partition-1",
 	}
 
 	t.Run("complete", func(t *testing.T) {
@@ -449,6 +457,7 @@ func TestConsulTerminatingConfigEntry_Copy(t *testing.T) {
 			KeyFile:  "key_file.pem",
 			SNI:      "sni.terminating.consul",
 		}},
+		Partition: "partition-1",
 	}
 
 	t.Run("complete", func(t *testing.T) {

--- a/command/agent/consul/connect.go
+++ b/command/agent/consul/connect.go
@@ -200,6 +200,7 @@ func connectUpstreams(in []structs.ConsulUpstream) []api.Upstream {
 		upstreams[i] = api.Upstream{
 			DestinationName:      upstream.DestinationName,
 			DestinationNamespace: upstream.DestinationNamespace,
+			DestinationPartition: upstream.DestinationPartition,
 			LocalBindPort:        upstream.LocalBindPort,
 			Datacenter:           upstream.Datacenter,
 			LocalBindAddress:     upstream.LocalBindAddress,

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1530,6 +1530,7 @@ func apiConnectIngressGatewayToStructs(in *api.ConsulIngressConfigEntry) *struct
 	return &structs.ConsulIngressConfigEntry{
 		TLS:       apiConnectGatewayTLSConfig(in.TLS),
 		Listeners: apiConnectIngressListenersToStructs(in.Listeners),
+		Partition: in.Partition,
 	}
 }
 
@@ -1588,8 +1589,9 @@ func apiConnectIngressServiceToStructs(in *api.ConsulIngressService) *structs.Co
 	}
 
 	return &structs.ConsulIngressService{
-		Name:  in.Name,
-		Hosts: slices.Clone(in.Hosts),
+		Name:      in.Name,
+		Hosts:     slices.Clone(in.Hosts),
+		Partition: in.Partition,
 	}
 }
 
@@ -1599,7 +1601,8 @@ func apiConnectTerminatingGatewayToStructs(in *api.ConsulTerminatingConfigEntry)
 	}
 
 	return &structs.ConsulTerminatingConfigEntry{
-		Services: apiConnectTerminatingServicesToStructs(in.Services),
+		Partition: in.Partition,
+		Services:  apiConnectTerminatingServicesToStructs(in.Services),
 	}
 }
 
@@ -1678,6 +1681,7 @@ func apiUpstreamsToStructs(in []*api.ConsulUpstream) []structs.ConsulUpstream {
 		upstreams[i] = structs.ConsulUpstream{
 			DestinationName:      upstream.DestinationName,
 			DestinationNamespace: upstream.DestinationNamespace,
+			DestinationPartition: upstream.DestinationPartition,
 			LocalBindPort:        upstream.LocalBindPort,
 			Datacenter:           upstream.Datacenter,
 			LocalBindAddress:     upstream.LocalBindAddress,

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -3713,6 +3713,7 @@ func TestConversion_apiUpstreamsToStructs(t *testing.T) {
 	require.Equal(t, []structs.ConsulUpstream{{
 		DestinationName:      "upstream",
 		DestinationNamespace: "ns2",
+		DestinationPartition: "partition-1",
 		LocalBindPort:        8000,
 		Datacenter:           "dc2",
 		LocalBindAddress:     "127.0.0.2",
@@ -3720,6 +3721,7 @@ func TestConversion_apiUpstreamsToStructs(t *testing.T) {
 	}}, apiUpstreamsToStructs([]*api.ConsulUpstream{{
 		DestinationName:      "upstream",
 		DestinationNamespace: "ns2",
+		DestinationPartition: "partition-1",
 		LocalBindPort:        8000,
 		Datacenter:           "dc2",
 		LocalBindAddress:     "127.0.0.2",
@@ -3859,10 +3861,12 @@ func TestConversion_ApiConsulConnectToStructs(t *testing.T) {
 						Port:     1111,
 						Protocol: "http",
 						Services: []*structs.ConsulIngressService{{
-							Name:  "ingress1",
-							Hosts: []string{"host1"},
+							Name:      "ingress1",
+							Hosts:     []string{"host1"},
+							Partition: "partition-1",
 						}},
 					}},
+					Partition: "partition-1",
 				},
 			},
 		}, ApiConsulConnectToStructs(
@@ -3879,10 +3883,12 @@ func TestConversion_ApiConsulConnectToStructs(t *testing.T) {
 							Port:     1111,
 							Protocol: "http",
 							Services: []*api.ConsulIngressService{{
-								Name:  "ingress1",
-								Hosts: []string{"host1"},
+								Name:      "ingress1",
+								Hosts:     []string{"host1"},
+								Partition: "partition-1",
 							}},
 						}},
+						Partition: "partition-1",
 					},
 				},
 			},
@@ -3893,6 +3899,7 @@ func TestConversion_ApiConsulConnectToStructs(t *testing.T) {
 		require.Equal(t, &structs.ConsulConnect{
 			Gateway: &structs.ConsulGateway{
 				Terminating: &structs.ConsulTerminatingConfigEntry{
+					Partition: "partition-1",
 					Services: []*structs.ConsulLinkedService{{
 						Name:     "linked-service",
 						CAFile:   "ca.pem",
@@ -3905,6 +3912,7 @@ func TestConversion_ApiConsulConnectToStructs(t *testing.T) {
 		}, ApiConsulConnectToStructs(&api.ConsulConnect{
 			Gateway: &api.ConsulGateway{
 				Terminating: &api.ConsulTerminatingConfigEntry{
+					Partition: "partition-1",
 					Services: []*api.ConsulLinkedService{{
 						Name:     "linked-service",
 						CAFile:   "ca.pem",

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -1176,10 +1176,11 @@ func TestParse(t *testing.T) {
 											LocalServicePort: 8080,
 											Upstreams: []*api.ConsulUpstream{
 												{
-													DestinationName:  "other-service",
-													LocalBindPort:    4567,
-													LocalBindAddress: "0.0.0.0",
-													Datacenter:       "dc1",
+													DestinationName:      "other-service",
+													DestinationPartition: "partition-1",
+													LocalBindPort:        4567,
+													LocalBindAddress:     "0.0.0.0",
+													Datacenter:           "dc1",
 
 													MeshGateway: &api.ConsulMeshGateway{
 														Mode: "local",
@@ -1632,11 +1633,13 @@ func TestParse(t *testing.T) {
 											Hosts: []string{
 												"127.0.0.1:8001",
 												"[::1]:8001",
-											}}, {
+											},
+											Partition: "partition-1"}, {
 											Name: "service2",
 											Hosts: []string{
 												"10.0.0.1:8001",
-											}},
+											},
+											Partition: "partition-1"},
 										}}, {
 										Port:     8080,
 										Protocol: "http",
@@ -1645,9 +1648,11 @@ func TestParse(t *testing.T) {
 											Hosts: []string{
 												"2.2.2.2:8080",
 											},
+											Partition: "partition-1",
 										}},
 									},
 									},
+									Partition: "partition-1",
 								},
 							},
 						},
@@ -1688,6 +1693,7 @@ func TestParse(t *testing.T) {
 										Name: "service2",
 										SNI:  "myhost",
 									}},
+									Partition: "partition-1",
 								},
 							},
 						},

--- a/jobspec/test-fixtures/tg-network.hcl
+++ b/jobspec/test-fixtures/tg-network.hcl
@@ -34,10 +34,11 @@ job "foo" {
             local_service_port = 8080
 
             upstreams {
-              destination_name   = "other-service"
-              local_bind_port    = 4567
-              local_bind_address = "0.0.0.0"
-              datacenter         = "dc1"
+              destination_name      = "other-service"
+              destination_partition = "partition-1"
+              local_bind_port       = 4567
+              local_bind_address    = "0.0.0.0"
+              datacenter            = "dc1"
 
               mesh_gateway {
                 mode = "local"

--- a/jobspec/test-fixtures/tg-service-connect-gateway-ingress.hcl
+++ b/jobspec/test-fixtures/tg-service-connect-gateway-ingress.hcl
@@ -22,6 +22,8 @@ job "connect_gateway_ingress" {
             }
           }
           ingress {
+            partition = "partition-1"
+
             tls {
               enabled         = true
               tls_min_version = "TLSv1_2"
@@ -32,12 +34,14 @@ job "connect_gateway_ingress" {
               port     = 8001
               protocol = "tcp"
               service {
-                name  = "service1"
-                hosts = ["127.0.0.1:8001", "[::1]:8001"]
+                name      = "service1"
+                hosts     = ["127.0.0.1:8001", "[::1]:8001"]
+                partition = "partition-1"
               }
               service {
-                name  = "service2"
-                hosts = ["10.0.0.1:8001"]
+                name      = "service2"
+                hosts     = ["10.0.0.1:8001"]
+                partition = "partition-1"
               }
             }
 
@@ -45,8 +49,9 @@ job "connect_gateway_ingress" {
               port     = 8080
               protocol = "http"
               service {
-                name  = "nginx"
-                hosts = ["2.2.2.2:8080"]
+                name      = "nginx"
+                hosts     = ["2.2.2.2:8080"]
+                partition = "partition-1"
               }
             }
           }

--- a/jobspec/test-fixtures/tg-service-connect-gateway-terminating.hcl
+++ b/jobspec/test-fixtures/tg-service-connect-gateway-terminating.hcl
@@ -28,6 +28,8 @@ job "connect_gateway_terminating" {
           }
 
           terminating {
+            partition = "partition-1"
+
             service {
               name      = "service1"
               ca_file   = "ca.pem"

--- a/nomad/consul.go
+++ b/nomad/consul.go
@@ -581,9 +581,16 @@ func convertIngressCE(namespace, service string, entry *structs.ConsulIngressCon
 	for _, listener := range entry.Listeners {
 		var services []api.IngressService = nil
 		for _, s := range listener.Services {
+			var partition string = ""
+			if s.Partition != "" {
+				partition = s.Partition
+			} else {
+				partition = entry.Partition
+			}
 			services = append(services, api.IngressService{
-				Name:  s.Name,
-				Hosts: slices.Clone(s.Hosts),
+				Name:      s.Name,
+				Hosts:     slices.Clone(s.Hosts),
+				Partition: partition,
 			})
 		}
 		listeners = append(listeners, api.IngressListener{
@@ -607,6 +614,7 @@ func convertIngressCE(namespace, service string, entry *structs.ConsulIngressCon
 		Name:      service,
 		TLS:       tls,
 		Listeners: listeners,
+		Partition: entry.Partition,
 	}
 }
 
@@ -625,6 +633,7 @@ func convertTerminatingCE(namespace, service string, entry *structs.ConsulTermin
 		Namespace: namespace,
 		Kind:      api.TerminatingGateway,
 		Name:      service,
+		Partition: entry.Partition,
 		Services:  linked,
 	}
 }

--- a/nomad/consul.go
+++ b/nomad/consul.go
@@ -578,10 +578,10 @@ func (c *consulConfigsAPI) setCE(ctx context.Context, entry api.ConfigEntry) err
 
 func convertIngressCE(namespace, service string, entry *structs.ConsulIngressConfigEntry) api.ConfigEntry {
 	var listeners []api.IngressListener = nil
+	var partition string
 	for _, listener := range entry.Listeners {
 		var services []api.IngressService = nil
 		for _, s := range listener.Services {
-			var partition string = ""
 			if s.Partition != "" {
 				partition = s.Partition
 			} else {

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -3123,6 +3123,12 @@ func TestTaskGroupDiff(t *testing.T) {
 																New:  "ns2",
 															},
 															{
+																Type: DiffTypeNone,
+																Name: "DestinationPartition",
+																Old:  "",
+																New:  "",
+															},
+															{
 																Type: DiffTypeAdded,
 																Name: "LocalBindAddress",
 																Old:  "",
@@ -3268,6 +3274,14 @@ func TestTaskGroupDiff(t *testing.T) {
 											{
 												Type: DiffTypeEdited,
 												Name: "Ingress",
+												Fields: []*FieldDiff{
+													{
+														Type: DiffTypeNone,
+														Name: "Partition",
+														Old:  "",
+														New:  "",
+													},
+												},
 												Objects: []*ObjectDiff{
 													{
 														Type: DiffTypeEdited,
@@ -3321,6 +3335,12 @@ func TestTaskGroupDiff(t *testing.T) {
 																		Old:  "",
 																		New:  "listener2",
 																	},
+																	{
+																		Type: DiffTypeNone,
+																		Name: "Partition",
+																		Old:  "",
+																		New:  "",
+																	},
 																},
 																Objects: []*ObjectDiff{
 																	{
@@ -3373,6 +3393,12 @@ func TestTaskGroupDiff(t *testing.T) {
 																		Old:  "listener1",
 																		New:  "",
 																	},
+																	{
+																		Type: DiffTypeNone,
+																		Name: "Partition",
+																		Old:  "",
+																		New:  "",
+																	},
 																},
 															},
 														},
@@ -3382,6 +3408,14 @@ func TestTaskGroupDiff(t *testing.T) {
 											{
 												Type: DiffTypeEdited,
 												Name: "Terminating",
+												Fields: []*FieldDiff{
+													{
+														Type: DiffTypeNone,
+														Name: "Partition",
+														Old:  "",
+														New:  "",
+													},
+												},
 												Objects: []*ObjectDiff{
 													{
 														Type: DiffTypeAdded,

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -745,9 +745,21 @@ func TestConsulUpstream_upstreamEqual(t *testing.T) {
 		must.False(t, upstreamsEquals(a, b))
 	})
 
+	t.Run("different dest partition", func(t *testing.T) {
+		a := []ConsulUpstream{up("foo", 8000)}
+		a[0].DestinationPartition = "partition-1"
+
+		b := []ConsulUpstream{up("foo", 8000)}
+		b[0].DestinationPartition = "partition-2"
+
+		must.False(t, upstreamsEquals(a, b))
+	})
+
 	t.Run("identical", func(t *testing.T) {
 		a := []ConsulUpstream{up("foo", 8000), up("bar", 9000)}
+		a[0].DestinationPartition = "partition-1"
 		b := []ConsulUpstream{up("foo", 8000), up("bar", 9000)}
+		b[0].DestinationPartition = "partition-1"
 		must.True(t, upstreamsEquals(a, b))
 	})
 
@@ -870,6 +882,7 @@ var (
 			},
 		},
 		Ingress: &ConsulIngressConfigEntry{
+			Partition: "partition-1",
 			TLS: &ConsulGatewayTLSConfig{
 				Enabled: true,
 			},
@@ -877,17 +890,20 @@ var (
 				Port:     3000,
 				Protocol: "http",
 				Services: []*ConsulIngressService{{
-					Name:  "service1",
-					Hosts: []string{"10.0.0.1", "10.0.0.1:3000"},
+					Name:      "service1",
+					Hosts:     []string{"10.0.0.1", "10.0.0.1:3000"},
+					Partition: "partition-1",
 				}, {
-					Name:  "service2",
-					Hosts: []string{"10.0.0.2", "10.0.0.2:3000"},
+					Name:      "service2",
+					Hosts:     []string{"10.0.0.2", "10.0.0.2:3000"},
+					Partition: "partition-1",
 				}},
 			}, {
 				Port:     3001,
 				Protocol: "tcp",
 				Services: []*ConsulIngressService{{
-					Name: "service3",
+					Name:      "service3",
+					Partition: "partition-1",
 				}},
 			}},
 		},
@@ -900,6 +916,7 @@ var (
 			EnvoyGatewayBindAddresses: nil,
 		},
 		Terminating: &ConsulTerminatingConfigEntry{
+			Partition: "partition-1",
 			Services: []*ConsulLinkedService{{
 				Name:     "linked-service1",
 				CAFile:   "ca.pem",
@@ -1139,11 +1156,13 @@ func TestConsulGateway_ingressServicesEqual(t *testing.T) {
 	ci.Parallel(t)
 
 	igs1 := []*ConsulIngressService{{
-		Name:  "service1",
-		Hosts: []string{"host1", "host2"},
+		Name:      "service1",
+		Hosts:     []string{"host1", "host2"},
+		Partition: "partition-1",
 	}, {
-		Name:  "service2",
-		Hosts: []string{"host3"},
+		Name:      "service2",
+		Hosts:     []string{"host3"},
+		Partition: "partition-1",
 	}}
 
 	require.False(t, ingressServicesEqual(igs1, nil))
@@ -1156,11 +1175,13 @@ func TestConsulGateway_ingressServicesEqual(t *testing.T) {
 	require.True(t, ingressServicesEqual(igs1, reversed))
 
 	hostOrder := []*ConsulIngressService{{
-		Name:  "service1",
-		Hosts: []string{"host2", "host1"}, // hosts reversed
+		Name:      "service1",
+		Hosts:     []string{"host2", "host1"}, // hosts reversed
+		Partition: "partition-1",
 	}, {
-		Name:  "service2",
-		Hosts: []string{"host3"},
+		Name:      "service2",
+		Hosts:     []string{"host3"},
+		Partition: "partition-1",
 	}}
 
 	require.True(t, ingressServicesEqual(igs1, hostOrder))
@@ -1173,14 +1194,16 @@ func TestConsulGateway_ingressListenersEqual(t *testing.T) {
 		Port:     2000,
 		Protocol: "http",
 		Services: []*ConsulIngressService{{
-			Name:  "service1",
-			Hosts: []string{"host1", "host2"},
+			Name:      "service1",
+			Hosts:     []string{"host1", "host2"},
+			Partition: "partition-1",
 		}},
 	}, {
 		Port:     2001,
 		Protocol: "tcp",
 		Services: []*ConsulIngressService{{
-			Name: "service2",
+			Name:      "service2",
+			Partition: "partition-1",
 		}},
 	}}
 

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -150,6 +150,8 @@ envoy_gateway_bind_addresses "<service>" {
   multiple hosts, but only in the leftmost DNS label. This ensures that all defined
   hosts are valid DNS records. For example, `*.example.com` is valid while `example.*`
   and `*-suffix.example.com` are not.
+- `partition` `(string: "")` - The admin partition from which to resolve the service 
+  if different than the existing partition. The current partition is used if unspecified.
 
 ### `terminating` Parameters
 

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -150,6 +150,10 @@ envoy_gateway_bind_addresses "<service>" {
 
 ### `terminating` Parameters
 
+- `partition` `(string: "default")` - Specifies the admin partition to which the configuration entry will apply. 
+  This must match the partition in which the gateway is registered. If omitted, the partition will be inherited 
+  from the request or will default to the default partition.
+
 - `service` <code>(array<[linked-service]>: required)</code> - One or more services to be
   linked with the gateway. The gateway will proxy traffic to these services. These
   linked services must be registered with Consul for the gateway to discover their

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -92,6 +92,9 @@ envoy_gateway_bind_addresses "<service>" {
 - `tls` <code>([tls]: nil)</code> - TLS configuration for this gateway.
 - `listener` <code>(array<[listener]> : required)</code> - One or more listeners that the
   ingress gateway should setup, uniquely identified by their port number.
+- `partition` `(string: "default")` - Specifies the admin partition in which the configuration 
+  will apply. The value must match the partition in which the gateway is registered.
+  If omitted, the partition will be inherited from the request.
 
 #### `tls` Parameters
 

--- a/website/content/docs/job-specification/upstreams.mdx
+++ b/website/content/docs/job-specification/upstreams.mdx
@@ -83,6 +83,8 @@ job "countdash" {
 
 - `destination_name` `(string: <required>)` - Name of the upstream service.
 - `destination_namespace` `(string: <required>)` - Name of the upstream Consul namespace.
+- `destination_partition` `(string: "default")` - String value that specifies the name of the admin partition containing the upstream service. 
+  If destination_peer is set, destination_partition refers to the local admin partition in which the peering was established.
 - `local_bind_port` - `(int: <required>)` - The port the proxy will receive
   connections for the upstream on.
 - `datacenter` `(string: "")` - The Consul datacenter in which to issue the


### PR DESCRIPTION
# Description

## Changes

- Updated ConsulUpstream, ConsulTerminatingConfigEntry, ConsulIngressConfigEntry and ConsulIngressService Structs adding the Partition field.
- Update related tests
- Update Nomad Documentation for ConsulUpstream, ConsulTerminatingConfigEntry, ConsulIngressConfigEntry and ConsulIngressService Structs.

## Progress
### Work completed: 
- Added partition fields at api/consul.go and nomad/structs/services.go, on the following structs:
  - ConsulUpstream
  - ConsulIngressService
  - ConsulTerminatingConfigEntry
  - ConsulIngressConfigEntry
- Update receiver functions at api/consul.go and nomad/structs/services.go:
  - Copy
  - Equal
- Update parse and apiConnect on jobspec/parse_service.go and command/agent/job_endpoint.go
- Update connect and conver functions on command/agent/consul/connect.go and nomad/consul.go
- Update mdx docs.
- Apply inherit behavior on partition field for ConsulIngressService:
  - When ConsulIngressService partition is empty, set value from ConsulIngressConfigEntry partition field.

### Pending work:
- We assumed that partition should only be inherited on ConsulIngressService, since is the only struct that have a partition defined in upper levels(ConsulIngressConfigEntry). Is pending if this assumption is correct, or if field value should be inherited in other cases too.
- Running end-to-end tests. Since partitions are Consul Enterprise fields, we couldn't tested end to end, as we test other values. 