### PR TITLE
cni: fix plugin fingerprinting versions

### DIFF
--- a/.changelog/16776.txt
+++ b/.changelog/16776.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fix CNI plugin version fingerprint when output includes protocol version
+```

--- a/client/fingerprint/plugins_cni.go
+++ b/client/fingerprint/plugins_cni.go
@@ -110,8 +110,7 @@ func (f *PluginsCNIFingerprint) detectOnePlugin(pluginPath string, entry os.DirE
 	//  CNI bridge plugin v1.0.0
 	//  (and optionally another line that contains the supported CNI protocol versions)
 	tokens := strings.Fields(string(output))
-	for i := 0; i < len(tokens); i++ {
-		token := tokens[i]
+	for _, token := range tokens {
 		if _, parseErr := version.NewSemver(token); parseErr == nil {
 			return token, true
 		}

--- a/client/fingerprint/plugins_cni.go
+++ b/client/fingerprint/plugins_cni.go
@@ -108,8 +108,9 @@ func (f *PluginsCNIFingerprint) detectOnePlugin(pluginPath string, entry os.DirE
 	// e.g.
 	//  /opt/cni/bin/bridge <no args>
 	//  CNI bridge plugin v1.0.0
+	//  (and optionally another line that contains the supported CNI protocol versions)
 	tokens := strings.Fields(string(output))
-	for i := len(tokens) - 1; i >= 0; i-- {
+	for i := 0; i < len(tokens); i++ {
 		token := tokens[i]
 		if _, parseErr := version.NewSemver(token); parseErr == nil {
 			return token, true

--- a/client/fingerprint/plugins_cni_test.go
+++ b/client/fingerprint/plugins_cni_test.go
@@ -29,8 +29,10 @@ func TestPluginsCNIFingerprint_Fingerprint_present(t *testing.T) {
 	must.True(t, response.Detected)
 	attrCustom := f.(*PluginsCNIFingerprint).attribute("custom")
 	attrBridge := f.(*PluginsCNIFingerprint).attribute("bridge")
+	attrVlan := f.(*PluginsCNIFingerprint).attribute("vlan")
 	must.Eq(t, "v1.2.3", response.Attributes[attrCustom])
 	must.Eq(t, "v1.0.2", response.Attributes[attrBridge])
+	must.Eq(t, "v1.2.0", response.Attributes[attrVlan])
 }
 
 func TestPluginsCNIFingerprint_Fingerprint_multi(t *testing.T) {
@@ -49,10 +51,12 @@ func TestPluginsCNIFingerprint_Fingerprint_multi(t *testing.T) {
 	must.True(t, response.Detected)
 	attrCustom := f.(*PluginsCNIFingerprint).attribute("custom")
 	attrBridge := f.(*PluginsCNIFingerprint).attribute("bridge")
+	attrVlan := f.(*PluginsCNIFingerprint).attribute("vlan")
 	attrCustom2 := f.(*PluginsCNIFingerprint).attribute("custom2")
 	must.Eq(t, "v1.2.3", response.Attributes[attrCustom])
 	must.Eq(t, "v1.0.2", response.Attributes[attrBridge])
 	must.Eq(t, "v9.9.9", response.Attributes[attrCustom2])
+	must.Eq(t, "v1.2.0", response.Attributes[attrVlan])
 }
 
 func TestPluginsCNIFingerprint_Fingerprint_absent(t *testing.T) {

--- a/client/fingerprint/test_fixtures/cni/bridge
+++ b/client/fingerprint/test_fixtures/cni/bridge
@@ -1,3 +1,4 @@
 #!/bin/sh
 
+# This fixture uses the old version output, without the supported CNI protocol versions.
 echo "CNI bridge plugin v1.0.2"

--- a/client/fingerprint/test_fixtures/cni/vlan
+++ b/client/fingerprint/test_fixtures/cni/vlan
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# This fixture uses the new version output, including the supported CNI protocol versions.
+echo "CNI vlan plugin v1.2.0"
+echo "CNI protocol versions supported: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 1.0.0"


### PR DESCRIPTION
CNI plugins v1.2.0 and above output a second line, containing supported protocol versions. Nomad tests should support this.