### PR TITLE
Do not set attributes when spawning the getter child

### DIFF
--- a/.changelog/16791.txt
+++ b/.changelog/16791.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Remove setting attributes when spawning the getter child
+```

--- a/client/allocrunner/taskrunner/getter/testing.go
+++ b/client/allocrunner/taskrunner/getter/testing.go
@@ -28,20 +28,15 @@ func TestSandbox(t *testing.T) *Sandbox {
 //
 // returns alloc_dir, task_dir
 func SetupDir(t *testing.T) (string, string) {
-	uid, gid := credentials()
-
 	allocDir := t.TempDir()
 	taskDir := filepath.Join(allocDir, "local")
 	topDir := filepath.Dir(allocDir)
 
-	must.NoError(t, os.Chown(topDir, int(uid), int(gid)))
 	must.NoError(t, os.Chmod(topDir, 0o755))
 
-	must.NoError(t, os.Chown(allocDir, int(uid), int(gid)))
 	must.NoError(t, os.Chmod(allocDir, 0o755))
 
 	must.NoError(t, os.Mkdir(taskDir, 0o755))
-	must.NoError(t, os.Chown(taskDir, int(uid), int(gid)))
 	must.NoError(t, os.Chmod(taskDir, 0o755))
 	return allocDir, taskDir
 }

--- a/client/allocrunner/taskrunner/getter/testing.go
+++ b/client/allocrunner/taskrunner/getter/testing.go
@@ -24,7 +24,7 @@ func TestSandbox(t *testing.T) *Sandbox {
 }
 
 // SetupDir creates a directory suitable for testing artifact - i.e. it is
-// owned by the nobody user as would be the case in a normal client operation.
+// owned by the user under which nomad runs.
 //
 // returns alloc_dir, task_dir
 func SetupDir(t *testing.T) (string, string) {

--- a/client/allocrunner/taskrunner/getter/util.go
+++ b/client/allocrunner/taskrunner/getter/util.go
@@ -137,7 +137,6 @@ func (s *Sandbox) runCmd(env *parameters) error {
 	cmd.Stdin = env.reader()
 	cmd.Stdout = output
 	cmd.Stderr = output
-	cmd.SysProcAttr = attributes()
 
 	// start & wait for the subprocess to terminate
 	if err := cmd.Run(); err != nil {

--- a/client/allocrunner/taskrunner/getter/util_default.go
+++ b/client/allocrunner/taskrunner/getter/util_default.go
@@ -6,11 +6,6 @@ import (
 	"path/filepath"
 )
 
-// credentials is not implemented by default
-func credentials() (uint32, uint32) {
-	return 0, 0
-}
-
 // lockdown is not implemented by default
 func lockdown(string, string) error {
 	return nil

--- a/client/allocrunner/taskrunner/getter/util_default.go
+++ b/client/allocrunner/taskrunner/getter/util_default.go
@@ -4,13 +4,7 @@ package getter
 
 import (
 	"path/filepath"
-	"syscall"
 )
-
-// attributes is not implemented by default
-func attributes() *syscall.SysProcAttr {
-	return nil
-}
 
 // credentials is not implemented by default
 func credentials() (uint32, uint32) {

--- a/client/allocrunner/taskrunner/getter/util_linux.go
+++ b/client/allocrunner/taskrunner/getter/util_linux.go
@@ -25,18 +25,6 @@ func init() {
 	userGID = uint32(syscall.Getgid())
 }
 
-// attributes returns the system process attributes to run
-// the sandbox process with
-func attributes() *syscall.SysProcAttr {
-	uid, gid := credentials()
-	return &syscall.SysProcAttr{
-		Credential: &syscall.Credential{
-			Uid: uid,
-			Gid: gid,
-		},
-	}
-}
-
 // credentials returns the UID and GID of the user the child process
 // will run as - for now this is always the same user the Nomad agent is
 // running as.

--- a/client/allocrunner/taskrunner/getter/util_linux.go
+++ b/client/allocrunner/taskrunner/getter/util_linux.go
@@ -5,32 +5,11 @@ package getter
 import (
 	"os"
 	"path/filepath"
-	"syscall"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/shoenig/go-landlock"
 	"golang.org/x/sys/unix"
 )
-
-var (
-	// userUID is the current user's uid
-	userUID uint32
-
-	// userGID is the current user's gid
-	userGID uint32
-)
-
-func init() {
-	userUID = uint32(syscall.Getuid())
-	userGID = uint32(syscall.Getgid())
-}
-
-// credentials returns the UID and GID of the user the child process
-// will run as - for now this is always the same user the Nomad agent is
-// running as.
-func credentials() (uint32, uint32) {
-	return userUID, userGID
-}
 
 // findHomeDir returns the home directory as provided by os.UserHomeDir. In case
 // os.UserHomeDir returns an error, we return /root if the current process is being

--- a/client/allocrunner/taskrunner/getter/util_windows.go
+++ b/client/allocrunner/taskrunner/getter/util_windows.go
@@ -5,7 +5,6 @@ package getter
 import (
 	"os"
 	"path/filepath"
-	"syscall"
 )
 
 // credentials is not implemented on Windows

--- a/client/allocrunner/taskrunner/getter/util_windows.go
+++ b/client/allocrunner/taskrunner/getter/util_windows.go
@@ -8,11 +8,6 @@ import (
 	"syscall"
 )
 
-// attributes is not implemented on Windows
-func attributes() *syscall.SysProcAttr {
-	return nil
-}
-
 // credentials is not implemented on Windows
 func credentials() (uint32, uint32) {
 	return 0, 0

--- a/client/allocrunner/taskrunner/getter/util_windows.go
+++ b/client/allocrunner/taskrunner/getter/util_windows.go
@@ -7,11 +7,6 @@ import (
 	"path/filepath"
 )
 
-// credentials is not implemented on Windows
-func credentials() (uint32, uint32) {
-	return 0, 0
-}
-
 // lockdown is not implemented on Windows
 func lockdown(string, string) error {
 	return nil


### PR DESCRIPTION
https://github.com/hashicorp/nomad/commit/95359b8c4cc9afbfe4db9b612d07f5116bad1066 disabled running the artifact downloader on Linux as the user `nobody` but left behind the code to set UID / GID, which are currently set as the same ones the user Nomad runs under. The current implementation however doesn't work, as described in https://github.com/hashicorp/nomad/issues/16789.

This PR removes setting attributes altogether as they are technically non required and they'll be inherited from the parent.

Fixes https://github.com/hashicorp/nomad/issues/16789