### PR TITLE
Deployment Status Command Does Not Respect -namespace Wildcard

### DIFF
--- a/.changelog/16792.txt
+++ b/.changelog/16792.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: the deployment's list endpoint now supports look up by prefix using the wildcard for namespace
+```

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -454,7 +454,7 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 	if err != nil {
 		return err
 	}
-	
+
 	if aclObj != nil && !aclObj.AllowNsOp(namespace, acl.NamespaceCapabilityReadJob) {
 		return structs.ErrPermissionDenied
 	}
@@ -511,7 +511,7 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 			}
 
 			var deploys []*structs.Deployment
-			paginator, err := paginator.NewPaginator(iter, tokenizer, filters, args.QueryOptions,
+			pnator, err := paginator.NewPaginator(iter, tokenizer, filters, args.QueryOptions,
 				func(raw interface{}) error {
 					deploy := raw.(*structs.Deployment)
 					deploys = append(deploys, deploy)
@@ -522,7 +522,7 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 					http.StatusBadRequest, "failed to create result paginator: %v", err)
 			}
 
-			nextToken, err := paginator.Page()
+			nextToken, err := pnator.Page()
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to read result page: %v", err)

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -454,7 +454,8 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 	if err != nil {
 		return err
 	}
-	if !aclObj.AllowNsOp(namespace, acl.NamespaceCapabilityReadJob) {
+	
+	if aclObj != nil && !aclObj.AllowNsOp(namespace, acl.NamespaceCapabilityReadJob) {
 		return structs.ErrPermissionDenied
 	}
 

--- a/nomad/deployment_endpoint_test.go
+++ b/nomad/deployment_endpoint_test.go
@@ -982,7 +982,7 @@ func TestDeploymentEndpoint_List(t *testing.T) {
 	d.JobID = j.ID
 	state := s1.fsm.State()
 
-	must.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, j), must.Sprint("UpsertJob"))
+	must.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), must.Sprint("UpsertJob"))
 	must.Nil(t, state.UpsertDeployment(1000, d), must.Sprint("UpsertDeployment"))
 
 	// Lookup the deployments
@@ -1020,7 +1020,7 @@ func TestDeploymentEndpoint_List(t *testing.T) {
 	d2.Namespace = "prod"
 	d2.JobID = j2.ID
 	must.Nil(t, state.UpsertNamespaces(1001, []*structs.Namespace{{Name: "prod"}}))
-	must.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 1002, j2), must.Sprint("UpsertJob"))
+	must.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 1002, nil, j2), must.Sprint("UpsertJob"))
 	must.Nil(t, state.UpsertDeployment(1003, d2), must.Sprint("UpsertDeployment"))
 
 	// Lookup the deployments with wildcard namespace
@@ -1276,7 +1276,7 @@ func TestDeploymentEndpoint_List_Blocking(t *testing.T) {
 	d := mock.Deployment()
 	d.JobID = j.ID
 
-	must.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, j), must.Sprint("UpsertJob"))
+	must.Nil(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, j), must.Sprint("UpsertJob"))
 
 	// Upsert alloc triggers watches
 	time.AfterFunc(100*time.Millisecond, func() {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -681,7 +681,8 @@ func deploymentNamespaceFilter(namespace string) func(interface{}) bool {
 			return true
 		}
 
-		return d.Namespace != namespace
+		return namespace != structs.AllNamespacesSentinel &&
+			d.Namespace != namespace
 	}
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9858,6 +9858,14 @@ func (d *Deployment) GoString() string {
 	return base
 }
 
+// GetNamespace implements the NamespaceGetter interface, required for pagination.
+func (d *Deployment) GetNamespace() string {
+	if d == nil {
+		return ""
+	}
+	return d.Namespace
+}
+
 // DeploymentState tracks the state of a deployment for a given task group.
 type DeploymentState struct {
 	// AutoRevert marks whether the task group has indicated the job should be


### PR DESCRIPTION
This PR addresses the bug reported [here](https://github.com/hashicorp/nomad/issues/13660)

The deployments Namespace filter did not take into account the namespace wildcard, resulting on an empty response every time it was used in conjunction with a prefix.  This PR adds the missing wildcard check as well as filtering by the allowed namespaces according to the ACL token.