### PR TITLE
client: send node secret with every client-to-server RPC

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1975,7 +1975,7 @@ func (c *Client) getRegistrationToken() string {
 
 	select {
 	case <-c.registeredCh:
-		return c.GetConfig().Node.SecretID
+		return c.secretNodeID()
 	default:
 		// If we haven't yet closed the registeredCh we're either starting for
 		// the 1st time or we've just restarted. Check the local state to see if
@@ -1987,7 +1987,7 @@ func (c *Client) getRegistrationToken() string {
 		}
 		if registration != nil && registration.HasRegistered {
 			c.registeredOnce.Do(func() { close(c.registeredCh) })
-			return c.GetConfig().Node.SecretID
+			return c.secretNodeID()
 		}
 	}
 	return ""

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -437,13 +437,14 @@ func resolveServer(s string) (net.Addr, error) {
 	return net.ResolveTCPAddr("tcp", net.JoinHostPort(host, port))
 }
 
-// Ping never mutates the request, so reuse a singleton to avoid the extra
-// malloc
-var pingRequest = &structs.GenericRequest{}
-
 // Ping is used to ping a particular server and returns whether it is healthy or
 // a potential error.
 func (c *Client) Ping(srv net.Addr) error {
+	pingRequest := &structs.GenericRequest{
+		QueryOptions: structs.QueryOptions{
+			AuthToken: c.secretNodeID(),
+		},
+	}
 	var reply struct{}
 	err := c.connPool.RPC(c.Region(), srv, "Status.Ping", pingRequest, &reply)
 	return err

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -460,7 +460,6 @@ func resolveServer(s string) (net.Addr, error) {
 // Ping is used to ping a particular server and returns whether it is healthy or
 // a potential error.
 func (c *Client) Ping(srv net.Addr) error {
-	c.logger.Error("Ping!!!!")
 	pingRequest := &structs.GenericRequest{
 		QueryOptions: structs.QueryOptions{
 			AuthToken: c.GetConfig().Node.SecretID,

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -462,7 +462,7 @@ func resolveServer(s string) (net.Addr, error) {
 func (c *Client) Ping(srv net.Addr) error {
 	pingRequest := &structs.GenericRequest{
 		QueryOptions: structs.QueryOptions{
-			AuthToken: c.GetConfig().Node.SecretID,
+			AuthToken: c.secretNodeID(),
 		},
 	}
 	var reply struct{}

--- a/client/state/db_error.go
+++ b/client/state/db_error.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/nomad/client/dynamicplugins"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
 	"github.com/hashicorp/nomad/client/serviceregistration/checks"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -126,6 +127,14 @@ func (m *ErrDB) PutNodeMeta(map[string]*string) error {
 }
 
 func (m *ErrDB) GetNodeMeta() (map[string]*string, error) {
+	return nil, fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) PutNodeRegistration(reg *cstructs.NodeRegistration) error {
+	return fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) GetNodeRegistration() (*cstructs.NodeRegistration, error) {
 	return nil, fmt.Errorf("Error!")
 }
 

--- a/client/state/db_mem.go
+++ b/client/state/db_mem.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/nomad/client/dynamicplugins"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
 	"github.com/hashicorp/nomad/client/serviceregistration/checks"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"golang.org/x/exp/maps"
 )
@@ -50,6 +51,8 @@ type MemDB struct {
 
 	// key -> value or nil
 	nodeMeta map[string]*string
+
+	nodeRegistration *cstructs.NodeRegistration
 
 	logger hclog.Logger
 
@@ -302,6 +305,19 @@ func (m *MemDB) GetNodeMeta() (map[string]*string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.nodeMeta, nil
+}
+
+func (m *MemDB) PutNodeRegistration(reg *cstructs.NodeRegistration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nodeRegistration = reg
+	return nil
+}
+
+func (m *MemDB) GetNodeRegistration() (*cstructs.NodeRegistration, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.nodeRegistration, nil
 }
 
 func (m *MemDB) Close() error {

--- a/client/state/db_noop.go
+++ b/client/state/db_noop.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/nomad/client/dynamicplugins"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
 	"github.com/hashicorp/nomad/client/serviceregistration/checks"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -119,6 +120,14 @@ func (n NoopDB) PutNodeMeta(map[string]*string) error {
 }
 
 func (n NoopDB) GetNodeMeta() (map[string]*string, error) {
+	return nil, nil
+}
+
+func (n NoopDB) PutNodeRegistration(reg *cstructs.NodeRegistration) error {
+	return nil
+}
+
+func (n NoopDB) GetNodeRegistration() (*cstructs.NodeRegistration, error) {
 	return nil, nil
 }
 

--- a/client/state/interface.go
+++ b/client/state/interface.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/nomad/client/dynamicplugins"
 	driverstate "github.com/hashicorp/nomad/client/pluginmanager/drivermanager/state"
 	"github.com/hashicorp/nomad/client/serviceregistration/checks"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -117,6 +118,9 @@ type StateDB interface {
 	// GetNodeMeta retrieves node metadata for merging with the copy from
 	// the Client's config.
 	GetNodeMeta() (map[string]*string, error)
+
+	PutNodeRegistration(*cstructs.NodeRegistration) error
+	GetNodeRegistration() (*cstructs.NodeRegistration, error)
 
 	// Close the database. Unsafe for further use after calling regardless
 	// of return value.

--- a/client/structs/structs.go
+++ b/client/structs/structs.go
@@ -362,3 +362,8 @@ const CheckBufSize = 4 * 1024
 // DriverStatsNotImplemented is the error to be returned if a driver doesn't
 // implement stats.
 var DriverStatsNotImplemented = errors.New("stats not implemented for driver")
+
+// NodeRegistration stores data about the client's registration with the server
+type NodeRegistration struct {
+	HasRegistered bool
+}

--- a/nomad/acl.go
+++ b/nomad/acl.go
@@ -105,13 +105,6 @@ func (s *Server) Authenticate(ctx *RPCContext, args structs.RequestWithIdentity)
 
 	// At this point we either have an anonymous token or an invalid one.
 
-	// TODO(tgross): remove this entirely in 1.6.0 and enforce that all RPCs
-	// driven by the clients have secret IDs set
-	if ctx.NodeID != "" && secretID != "" {
-		args.SetIdentity(&structs.AuthenticatedIdentity{ClientID: ctx.NodeID})
-		return nil
-	}
-
 	// Unlike clients that provide their Node ID on first connection, server
 	// RPCs don't include an ID for the server so we identify servers by cert
 	// and IP address.


### PR DESCRIPTION
In Nomad 1.5.3 we fixed a security bug that allowed bypass of ACL checks if the request came thru a client node first. But this fix broke (knowingly) the identification of many client-to-server RPCs. These will be now measured as if they were anonymous. The reason for this is that many client-to-server RPCs do not send the node secret and instead rely on the protection of mTLS.

This changeset ensures that the node secret is being sent with every client-to-server RPC request. In a future version of Nomad we can add enforcement on the server side, but this was left out of this changeset to reduce risks to the safe upgrade path.

Sending the node secret as an auth token introduces a new problem during initial introduction of a client. Clients send many RPCs concurrently with `Node.Register`, but until the node is registered the node secret is unknown to the server and will be rejected as invalid. This causes permission denied errors.

To fix that, this changeset introduces a gate on having successfully made a `Node.Register` RPC before any other RPCs can be sent (except for `Status.Ping`, which we need earlier but which also ignores the error because that handler doesn't do an authorization check). This ensures that we only send requests with a node secret already known to the server. This also makes client startup a little easier to reason about because we know `Node.Register` must succeed first, and it should make for a good place to hook in future plans for secure introduction of nodes. The tradeoff is that an existing client that has running allocs will take slightly longer (a second or two) to transition to ready after a restart, because the transition in `Node.UpdateStatus` is gated at the server by first submitting `Node.UpdateAlloc` with client alloc updates.

Fixes: https://github.com/hashicorp/nomad/issues/16798
Fixes: https://github.com/hashicorp/nomad-enterprise/issues/1069
