### PR TITLE
gracefully recover tasks that use csi node plugins

### DIFF
--- a/.changelog/16809.txt
+++ b/.changelog/16809.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: gracefully recover tasks that use csi node plugins
+```

--- a/client/allocrunner/csi_hook_test.go
+++ b/client/allocrunner/csi_hook_test.go
@@ -417,6 +417,10 @@ type mockPluginManager struct {
 	mounter mockVolumeMounter
 }
 
+func (mgr mockPluginManager) WaitForPlugin(ctx context.Context, pluginType, pluginID string) error {
+	return nil
+}
+
 func (mgr mockPluginManager) MounterForPlugin(ctx context.Context, pluginID string) (csimanager.VolumeMounter, error) {
 	return mgr.mounter, nil
 }

--- a/client/dynamicplugins/registry.go
+++ b/client/dynamicplugins/registry.go
@@ -317,6 +317,7 @@ func (d *dynamicRegistry) WaitForPlugin(ctx context.Context, ptype, name string)
 	ctx, cancel := context.WithTimeout(ctx, 24*time.Hour)
 	defer cancel()
 
+	timer := time.NewTimer(time.Duration(delay) * time.Millisecond)
 	for {
 		for _, p := range d.ListPlugins(ptype) {
 			if p.Name == name {
@@ -329,7 +330,7 @@ func (d *dynamicRegistry) WaitForPlugin(ctx context.Context, ptype, name string)
 		case <-ctx.Done():
 			// an externally-defined timeout wins the day
 			return nil, ctx.Err()
-		case <-time.After(time.Duration(delay) * time.Millisecond):
+		case <-timer.C:
 			// continue after our internal delay
 		}
 		if delay < maxDelay {
@@ -338,6 +339,7 @@ func (d *dynamicRegistry) WaitForPlugin(ctx context.Context, ptype, name string)
 		if delay > maxDelay {
 			delay = maxDelay
 		}
+		timer.Reset(time.Duration(delay) * time.Millisecond)
 	}
 }
 

--- a/client/pluginmanager/csimanager/interface.go
+++ b/client/pluginmanager/csimanager/interface.go
@@ -59,6 +59,10 @@ type Manager interface {
 	// PluginManager returns a PluginManager for use by the node fingerprinter.
 	PluginManager() pluginmanager.PluginManager
 
+	// WaitForPlugin waits for the plugin to become available,
+	// or until its context is canceled or times out.
+	WaitForPlugin(ctx context.Context, pluginType, pluginID string) error
+
 	// MounterForPlugin returns a VolumeMounter for the plugin ID associated
 	// with the volume.	Returns an error if this plugin isn't registered.
 	MounterForPlugin(ctx context.Context, pluginID string) (VolumeMounter, error)

--- a/client/pluginmanager/csimanager/manager.go
+++ b/client/pluginmanager/csimanager/manager.go
@@ -39,7 +39,7 @@ func New(config *Config) Manager {
 	}
 
 	return &csiManager{
-		logger:    config.Logger.Named("csiManager"),
+		logger:    config.Logger.Named("csi_manager"),
 		eventer:   config.TriggerNodeEvent,
 		registry:  config.DynamicRegistry,
 		instances: make(map[string]map[string]*instanceManager),
@@ -84,6 +84,8 @@ func (c *csiManager) WaitForPlugin(ctx context.Context, pType, pID string) error
 	if err != nil {
 		return fmt.Errorf("%s plugin '%s' did not become ready: %w", pType, pID, err)
 	}
+	c.instancesLock.Lock()
+	defer c.instancesLock.Unlock()
 	c.ensureInstance(p)
 	return nil
 }

--- a/client/pluginmanager/csimanager/manager.go
+++ b/client/pluginmanager/csimanager/manager.go
@@ -39,7 +39,7 @@ func New(config *Config) Manager {
 	}
 
 	return &csiManager{
-		logger:    config.Logger,
+		logger:    config.Logger.Named("csiManager"),
 		eventer:   config.TriggerNodeEvent,
 		registry:  config.DynamicRegistry,
 		instances: make(map[string]map[string]*instanceManager),
@@ -73,6 +73,19 @@ type csiManager struct {
 
 func (c *csiManager) PluginManager() pluginmanager.PluginManager {
 	return c
+}
+
+// WaitForPlugin waits for a specific plugin to be registered and available,
+// unless the context is canceled, or it takes longer than a minute.
+func (c *csiManager) WaitForPlugin(ctx context.Context, pType, pID string) error {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	p, err := c.registry.WaitForPlugin(ctx, pType, pID)
+	if err != nil {
+		return fmt.Errorf("%s plugin '%s' did not become ready: %w", pType, pID, err)
+	}
+	c.ensureInstance(p)
+	return nil
 }
 
 func (c *csiManager) MounterForPlugin(ctx context.Context, pluginID string) (VolumeMounter, error) {

--- a/client/pluginmanager/csimanager/manager_test.go
+++ b/client/pluginmanager/csimanager/manager_test.go
@@ -1,15 +1,18 @@
 package csimanager
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/dynamicplugins"
 	"github.com/hashicorp/nomad/client/pluginmanager"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
 
@@ -91,6 +94,41 @@ func TestManager_DeregisterPlugin(t *testing.T) {
 		im := instanceManagerByTypeAndName(pm, plugin.Type, plugin.Name)
 		return im == nil
 	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestManager_WaitForPlugin(t *testing.T) {
+	ci.Parallel(t)
+
+	registry := setupRegistry(nil)
+	t.Cleanup(registry.Shutdown)
+	pm := testManager(t, registry, 5*time.Second) // resync period can be long.
+	t.Cleanup(pm.Shutdown)
+	pm.Run()
+
+	t.Run("never happens", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		t.Cleanup(cancel)
+
+		err := pm.WaitForPlugin(ctx, "bad-type", "bad-name")
+		must.Error(t, err)
+		must.ErrorContains(t, err, "did not become ready: context deadline exceeded")
+	})
+
+	t.Run("ok after delay", func(t *testing.T) {
+		plugin := fakePlugin(0, dynamicplugins.PluginTypeCSIController)
+
+		// register the plugin in the near future
+		time.AfterFunc(100*time.Millisecond, func() {
+			err := registry.RegisterPlugin(plugin)
+			must.NoError(t, err)
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		t.Cleanup(cancel)
+
+		err := pm.WaitForPlugin(ctx, plugin.Type, plugin.Name)
+		must.NoError(t, err)
+	})
 }
 
 // TestManager_MultiplePlugins ensures that multiple plugins with the same


### PR DESCRIPTION
With happy running tasks that use a CSI volume, on client restart they may fail to be recovered and instead be killed and rescheduled, even though there is a healthy happy CSI plugin running right next to them.

The simplest version of the error condition I could replicate was using this repo's `demo/csi/hostpath` example.  With the tasks all set up, I stop the client and start it again:

```
2023-04-05T22:10:33.940Z [INFO]  client.alloc_runner.task_runner: Task event: alloc_id=0480ac51-dd38-49ec-8831-48fd3c674279 task=redis type=Received msg="Task received by client" failed=false
2023-04-05T22:10:33.948Z [INFO]  client.alloc_runner.task_runner: Task event: alloc_id=d013ee08-10fc-ff0e-ef5e-cc444048fbfd task=plugin type=Received msg="Task received by client" failed=false
2023-04-05T22:10:33.959Z [ERROR] client.alloc_runner: prerun failed: alloc_id=0480ac51-dd38-49ec-8831-48fd3c674279 error="pre-run hook \"csi_hook\" failed: plugin hostpath-plugin0 for type csi-node not found"
2023-04-05T22:10:33.964Z [INFO]  client.alloc_runner.task_runner: Task event: alloc_id=0480ac51-dd38-49ec-8831-48fd3c674279 task=redis type="Setup Failure" msg="failed to setup alloc: pre-run hook \"csi_hook\" failed: plugin hostpath-plugin0 for type csi-node not found" failed=true
2023-04-05T22:10:33.974Z [INFO]  client.alloc_runner.task_runner: Task event: alloc_id=d013ee08-10fc-ff0e-ef5e-cc444048fbfd task=plugin type="Plugin became healthy" msg="plugin: hostpath-plugin0" failed=false
2023-04-05T22:10:36.973Z [INFO]  client.gc: marking allocation for GC: alloc_id=0480ac51-dd38-49ec-8831-48fd3c674279
```

The client doesn't know yet that the CSI plugin task is healthy, because it happens to try to recover the task that needs it first.

After this change, which retries for some time (one minute (is that ok?)) to find the plugin that it expects to exist:

```
2023-04-05T22:18:03.805Z [INFO]  client.alloc_runner.task_runner: Task event: alloc_id=3f38e8b5-106b-87c7-9df4-b5815fa955d5 task=redis type=Received msg="Task received by client" failed=false
2023-04-05T22:18:03.819Z [INFO]  client.alloc_runner.task_runner: Task event: alloc_id=d6f262f3-b20d-89d2-1bdd-6f92a01c2003 task=plugin type=Received msg="Task received by client" failed=false
2023-04-05T22:18:04.116Z [INFO]  client.alloc_runner.task_runner: Task event: alloc_id=d6f262f3-b20d-89d2-1bdd-6f92a01c2003 task=plugin type="Plugin became healthy" msg="plugin: hostpath-plugin0" failed=false
2023-04-05T22:18:04.262Z [INFO]  client.alloc_runner.runner_hook.csi_hook: found CSI plugin: alloc_id=3f38e8b5-106b-87c7-9df4-b5815fa955d5 type=csi-node name=hostpath-plugin0
```

We may wish to test with a more complex CSI setup to make sure that this fully Fixes #13028