### PR TITLE
[ui, compliance] Remove the newline after .hbs copyright headers

### DIFF
--- a/ui/app/components/allocation-service-sidebar.hbs
+++ b/ui/app/components/allocation-service-sidebar.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div
   class="sidebar has-subnav service-sidebar {{if this.isSideBarOpen "open"}}"
   {{on-click-outside

--- a/ui/app/components/allocation-service-sidebar.hbs
+++ b/ui/app/components/allocation-service-sidebar.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div
   class="sidebar has-subnav service-sidebar {{if this.isSideBarOpen "open"}}"
   {{on-click-outside

--- a/ui/app/components/breadcrumbs.hbs
+++ b/ui/app/components/breadcrumbs.hbs
@@ -1,5 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{yield this.crumbs}}

--- a/ui/app/components/breadcrumbs.hbs
+++ b/ui/app/components/breadcrumbs.hbs
@@ -2,5 +2,4 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{yield this.crumbs}}

--- a/ui/app/components/breadcrumbs/default.hbs
+++ b/ui/app/components/breadcrumbs/default.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
 <li data-test-breadcrumb-default
   {{(modifier

--- a/ui/app/components/breadcrumbs/default.hbs
+++ b/ui/app/components/breadcrumbs/default.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
 <li data-test-breadcrumb-default
   {{(modifier

--- a/ui/app/components/breadcrumbs/job.hbs
+++ b/ui/app/components/breadcrumbs/job.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Trigger @onError={{action this.onError}} @do={{this.fetchParent}} as |trigger|>
   {{did-insert trigger.fns.do}}
   {{#if trigger.data.isBusy}}

--- a/ui/app/components/breadcrumbs/job.hbs
+++ b/ui/app/components/breadcrumbs/job.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Trigger @onError={{action this.onError}} @do={{this.fetchParent}} as |trigger|>
   {{did-insert trigger.fns.do}}
   {{#if trigger.data.isBusy}}

--- a/ui/app/components/chart-primitives/area.hbs
+++ b/ui/app/components/chart-primitives/area.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <defs>
   <linearGradient x1="0" x2="0" y1="0" y2="1" class="{{this.colorClass}}" id="{{this.fillId}}">
     <stop class="start" offset="0%" />

--- a/ui/app/components/chart-primitives/area.hbs
+++ b/ui/app/components/chart-primitives/area.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <defs>
   <linearGradient x1="0" x2="0" y1="0" y2="1" class="{{this.colorClass}}" id="{{this.fillId}}">
     <stop class="start" offset="0%" />

--- a/ui/app/components/chart-primitives/h-annotations.hbs
+++ b/ui/app/components/chart-primitives/h-annotations.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div data-test-annotations class="line-chart-annotations" style={{this.chartAnnotationsStyle}} ...attributes>
   {{#each this.processed key=@key as |annotation|}}
     <div data-test-annotation class="chart-horizontal-annotation" style={{annotation.style}}>

--- a/ui/app/components/chart-primitives/h-annotations.hbs
+++ b/ui/app/components/chart-primitives/h-annotations.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div data-test-annotations class="line-chart-annotations" style={{this.chartAnnotationsStyle}} ...attributes>
   {{#each this.processed key=@key as |annotation|}}
     <div data-test-annotation class="chart-horizontal-annotation" style={{annotation.style}}>

--- a/ui/app/components/chart-primitives/tooltip.hbs
+++ b/ui/app/components/chart-primitives/tooltip.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div data-test-chart-tooltip class="chart-tooltip {{if @active "active" "inactive"}}" style={{@style}} ...attributes>
   <ol>
     {{#each @data as |props|}}

--- a/ui/app/components/chart-primitives/tooltip.hbs
+++ b/ui/app/components/chart-primitives/tooltip.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div data-test-chart-tooltip class="chart-tooltip {{if @active "active" "inactive"}}" style={{@style}} ...attributes>
   <ol>
     {{#each @data as |props|}}

--- a/ui/app/components/chart-primitives/v-annotations.hbs
+++ b/ui/app/components/chart-primitives/v-annotations.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div data-test-annotations class="line-chart-annotations" style={{this.chartAnnotationsStyle}} ...attributes>
   {{#each this.processed key=@key as |annotation|}}
     <div data-test-annotation class="chart-vertical-annotation {{annotation.iconClass}} {{annotation.staggerClass}}" style={{annotation.style}}>

--- a/ui/app/components/chart-primitives/v-annotations.hbs
+++ b/ui/app/components/chart-primitives/v-annotations.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div data-test-annotations class="line-chart-annotations" style={{this.chartAnnotationsStyle}} ...attributes>
   {{#each this.processed key=@key as |annotation|}}
     <div data-test-annotation class="chart-vertical-annotation {{annotation.iconClass}} {{annotation.staggerClass}}" style={{annotation.style}}>

--- a/ui/app/components/das/accepted.hbs
+++ b/ui/app/components/das/accepted.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <section class="das-accepted">
   <main>
     <h3>Recommendation accepted</h3>

--- a/ui/app/components/das/accepted.hbs
+++ b/ui/app/components/das/accepted.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <section class="das-accepted">
   <main>
     <h3>Recommendation accepted</h3>

--- a/ui/app/components/das/diffs-table.hbs
+++ b/ui/app/components/das/diffs-table.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <table class='diffs-table' ...attributes>
   <tbody>
     <tr data-test-current>

--- a/ui/app/components/das/diffs-table.hbs
+++ b/ui/app/components/das/diffs-table.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <table class='diffs-table' ...attributes>
   <tbody>
     <tr data-test-current>

--- a/ui/app/components/das/dismissed.hbs
+++ b/ui/app/components/das/dismissed.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <section class="das-dismissed {{if this.explanationUnderstood 'understood'}}">
   {{#if this.explanationUnderstood}}
     <h3 {{did-insert this.proceedAutomatically}}>Recommendation dismissed</h3>

--- a/ui/app/components/das/dismissed.hbs
+++ b/ui/app/components/das/dismissed.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <section class="das-dismissed {{if this.explanationUnderstood 'understood'}}">
   {{#if this.explanationUnderstood}}
     <h3 {{did-insert this.proceedAutomatically}}>Recommendation dismissed</h3>

--- a/ui/app/components/das/error.hbs
+++ b/ui/app/components/das/error.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <section class="das-error" data-test-recommendation-error>
   <section>
     <h3 data-test-headline>Recommendation error</h3>

--- a/ui/app/components/das/error.hbs
+++ b/ui/app/components/das/error.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <section class="das-error" data-test-recommendation-error>
   <section>
     <h3 data-test-headline>Recommendation error</h3>

--- a/ui/app/components/das/recommendation-accordion.hbs
+++ b/ui/app/components/das/recommendation-accordion.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.show}}
   <ListAccordion
     data-test-recommendation-accordion

--- a/ui/app/components/das/recommendation-accordion.hbs
+++ b/ui/app/components/das/recommendation-accordion.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.show}}
   <ListAccordion
     data-test-recommendation-accordion

--- a/ui/app/components/das/recommendation-card.hbs
+++ b/ui/app/components/das/recommendation-card.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{! template-lint-disable no-duplicate-landmark-elements}}
 {{#if this.interstitialComponent}}
   <section class="das-interstitial" style={{this.interstitialStyle}}>

--- a/ui/app/components/das/recommendation-card.hbs
+++ b/ui/app/components/das/recommendation-card.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{! template-lint-disable no-duplicate-landmark-elements}}
 {{#if this.interstitialComponent}}
   <section class="das-interstitial" style={{this.interstitialStyle}}>

--- a/ui/app/components/das/recommendation-chart.hbs
+++ b/ui/app/components/das/recommendation-chart.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div
   ...attributes
   class="chart recommendation-chart {{this.directionClass}}"

--- a/ui/app/components/das/recommendation-chart.hbs
+++ b/ui/app/components/das/recommendation-chart.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div
   ...attributes
   class="chart recommendation-chart {{this.directionClass}}"

--- a/ui/app/components/das/recommendation-row.hbs
+++ b/ui/app/components/das/recommendation-row.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if @summary.taskGroup.allocations.length}}
   {{! Prevent storing aggregate diffs until allocation count is known }}
   <tr

--- a/ui/app/components/das/recommendation-row.hbs
+++ b/ui/app/components/das/recommendation-row.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if @summary.taskGroup.allocations.length}}
   {{! Prevent storing aggregate diffs until allocation count is known }}
   <tr

--- a/ui/app/components/das/task-row.hbs
+++ b/ui/app/components/das/task-row.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <tr
   class={{if @active 'active'}}
   {{on 'click' @onClick}}

--- a/ui/app/components/das/task-row.hbs
+++ b/ui/app/components/das/task-row.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <tr
   class={{if @active 'active'}}
   {{on 'click' @onClick}}

--- a/ui/app/components/evaluation-sidebar/detail.hbs
+++ b/ui/app/components/evaluation-sidebar/detail.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#let this.currentEvalDetail as |evaluation|}}
   {{#if this.isSideBarOpen}}
     {{keyboard-commands this.keyCommands}}

--- a/ui/app/components/evaluation-sidebar/detail.hbs
+++ b/ui/app/components/evaluation-sidebar/detail.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#let this.currentEvalDetail as |evaluation|}}
   {{#if this.isSideBarOpen}}
     {{keyboard-commands this.keyCommands}}

--- a/ui/app/components/evaluation-sidebar/related-evaluations.hbs
+++ b/ui/app/components/evaluation-sidebar/related-evaluations.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="boxed-section">
   <div class="boxed-section-head">
     Related Evaluations

--- a/ui/app/components/evaluation-sidebar/related-evaluations.hbs
+++ b/ui/app/components/evaluation-sidebar/related-evaluations.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="boxed-section">
   <div class="boxed-section-head">
     Related Evaluations

--- a/ui/app/components/keyboard-shortcuts-modal.hbs
+++ b/ui/app/components/keyboard-shortcuts-modal.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.keyboard.shortcutsVisible}}
   {{keyboard-commands (array this.escapeCommand)}}
   <div class="keyboard-shortcuts"

--- a/ui/app/components/keyboard-shortcuts-modal.hbs
+++ b/ui/app/components/keyboard-shortcuts-modal.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.keyboard.shortcutsVisible}}
   {{keyboard-commands (array this.escapeCommand)}}
   <div class="keyboard-shortcuts"

--- a/ui/app/components/metadata-editor.hbs
+++ b/ui/app/components/metadata-editor.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <form class="metadata-editor">
   <label>
     <strong>Key</strong>

--- a/ui/app/components/metadata-editor.hbs
+++ b/ui/app/components/metadata-editor.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <form class="metadata-editor">
   <label>
     <strong>Key</strong>

--- a/ui/app/components/metadata-kv.hbs
+++ b/ui/app/components/metadata-kv.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <tr data-test-attributes-section>
   {{#if this.editing}}
     <td colspan="2">

--- a/ui/app/components/metadata-kv.hbs
+++ b/ui/app/components/metadata-kv.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <tr data-test-attributes-section>
   {{#if this.editing}}
     <td colspan="2">

--- a/ui/app/components/policy-editor.hbs
+++ b/ui/app/components/policy-editor.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <form class="edit-policy" autocomplete="off" {{on "submit" this.save}}>
 	{{#if @policy.isNew }}
 		<label>

--- a/ui/app/components/policy-editor.hbs
+++ b/ui/app/components/policy-editor.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <form class="edit-policy" autocomplete="off" {{on "submit" this.save}}>
 	{{#if @policy.isNew }}
 		<label>

--- a/ui/app/components/primary-metric/allocation.hbs
+++ b/ui/app/components/primary-metric/allocation.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div data-test-primary-metric class="primary-metric" ...attributes
   {{did-insert this.start}}
   {{did-update this.start}}>

--- a/ui/app/components/primary-metric/allocation.hbs
+++ b/ui/app/components/primary-metric/allocation.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div data-test-primary-metric class="primary-metric" ...attributes
   {{did-insert this.start}}
   {{did-update this.start}}>

--- a/ui/app/components/primary-metric/current-value.hbs
+++ b/ui/app/components/primary-metric/current-value.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="columns secondary-graphic">
   <div class="column">
     <div class="inline-chart" data-test-percentage-bar>

--- a/ui/app/components/primary-metric/current-value.hbs
+++ b/ui/app/components/primary-metric/current-value.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="columns secondary-graphic">
   <div class="column">
     <div class="inline-chart" data-test-percentage-bar>

--- a/ui/app/components/primary-metric/node.hbs
+++ b/ui/app/components/primary-metric/node.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div data-test-primary-metric class="primary-metric" ...attributes
   {{did-insert this.start}}
   {{did-update this.start}}>

--- a/ui/app/components/primary-metric/node.hbs
+++ b/ui/app/components/primary-metric/node.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div data-test-primary-metric class="primary-metric" ...attributes
   {{did-insert this.start}}
   {{did-update this.start}}>

--- a/ui/app/components/primary-metric/task.hbs
+++ b/ui/app/components/primary-metric/task.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div data-test-primary-metric class="primary-metric" ...attributes
   {{did-insert this.start}}
   {{did-update this.start @taskState @metric}}>

--- a/ui/app/components/primary-metric/task.hbs
+++ b/ui/app/components/primary-metric/task.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div data-test-primary-metric class="primary-metric" ...attributes
   {{did-insert this.start}}
   {{did-update this.start @taskState @metric}}>

--- a/ui/app/components/profile-navbar-item.hbs
+++ b/ui/app/components/profile-navbar-item.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.token.selfToken}}
   <PowerSelect
   data-test-header-profile-dropdown

--- a/ui/app/components/profile-navbar-item.hbs
+++ b/ui/app/components/profile-navbar-item.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.token.selfToken}}
   <PowerSelect
   data-test-header-profile-dropdown

--- a/ui/app/components/providers/actors-relationships.hbs
+++ b/ui/app/components/providers/actors-relationships.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{yield
   (hash fns=this.actorsRelationships.fns data=this.actorsRelationships.data)
 }}

--- a/ui/app/components/providers/actors-relationships.hbs
+++ b/ui/app/components/providers/actors-relationships.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{yield
   (hash fns=this.actorsRelationships.fns data=this.actorsRelationships.data)
 }}

--- a/ui/app/components/service-status-indicator.hbs
+++ b/ui/app/components/service-status-indicator.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <span
   class="service-status-indicator status-{{@check.Status}} tooltip is-right-aligned"
   aria-label="{{@check.Status}} at {{format-ts @check.Timestamp}}"

--- a/ui/app/components/service-status-indicator.hbs
+++ b/ui/app/components/service-status-indicator.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <span
   class="service-status-indicator status-{{@check.Status}} tooltip is-right-aligned"
   aria-label="{{@check.Status}} at {{format-ts @check.Timestamp}}"

--- a/ui/app/components/single-select-dropdown/index.hbs
+++ b/ui/app/components/single-select-dropdown/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div data-test-single-select-dropdown class="dropdown" ...attributes>
   <PowerSelect
     @options={{@options}}

--- a/ui/app/components/single-select-dropdown/index.hbs
+++ b/ui/app/components/single-select-dropdown/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div data-test-single-select-dropdown class="dropdown" ...attributes>
   <PowerSelect
     @options={{@options}}

--- a/ui/app/components/status-cell.hbs
+++ b/ui/app/components/status-cell.hbs
@@ -1,5 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <span class="color-swatch {{@status}}"></span>{{@status}}

--- a/ui/app/components/status-cell.hbs
+++ b/ui/app/components/status-cell.hbs
@@ -2,5 +2,4 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <span class="color-swatch {{@status}}"></span>{{@status}}

--- a/ui/app/components/task-context-sidebar.hbs
+++ b/ui/app/components/task-context-sidebar.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Portal @target="log-sidebar-portal">
 	<div
 		class="sidebar task-context-sidebar has-subnav {{if this.wide "wide"}} {{if @task.events.length "has-events"}} {{if this.isSideBarOpen "open"}}"

--- a/ui/app/components/task-context-sidebar.hbs
+++ b/ui/app/components/task-context-sidebar.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Portal @target="log-sidebar-portal">
 	<div
 		class="sidebar task-context-sidebar has-subnav {{if this.wide "wide"}} {{if @task.events.length "has-events"}} {{if this.isSideBarOpen "open"}}"

--- a/ui/app/components/task-sub-row.hbs
+++ b/ui/app/components/task-sub-row.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <tr class="task-sub-row {{if @active "is-active"}}"
 	{{keyboard-shortcut
 		enumerated=true

--- a/ui/app/components/task-sub-row.hbs
+++ b/ui/app/components/task-sub-row.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <tr class="task-sub-row {{if @active "is-active"}}"
 	{{keyboard-shortcut
 		enumerated=true

--- a/ui/app/components/trigger.hbs
+++ b/ui/app/components/trigger.hbs
@@ -1,5 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{yield (hash data=this.data fns=this.fns)}}

--- a/ui/app/components/trigger.hbs
+++ b/ui/app/components/trigger.hbs
@@ -2,5 +2,4 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{yield (hash data=this.data fns=this.fns)}}

--- a/ui/app/components/variable-form.hbs
+++ b/ui/app/components/variable-form.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{did-update this.onViewChange @view}}
 {{did-insert this.establishKeyValues}}
 <form class="new-variables" autocomplete="off" {{on "submit" this.save}}>

--- a/ui/app/components/variable-form.hbs
+++ b/ui/app/components/variable-form.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{did-update this.onViewChange @view}}
 {{did-insert this.establishKeyValues}}
 <form class="new-variables" autocomplete="off" {{on "submit" this.save}}>

--- a/ui/app/components/variable-form/input-group.hbs
+++ b/ui/app/components/variable-form/input-group.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <label class="value-label">
   <span>
     Value

--- a/ui/app/components/variable-form/input-group.hbs
+++ b/ui/app/components/variable-form/input-group.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <label class="value-label">
   <span>
     Value

--- a/ui/app/components/variable-form/job-template-editor.hbs
+++ b/ui/app/components/variable-form/job-template-editor.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{did-insert this.establishKeyValues}}
 <div>
   <label>

--- a/ui/app/components/variable-form/job-template-editor.hbs
+++ b/ui/app/components/variable-form/job-template-editor.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{did-insert this.establishKeyValues}}
 <div>
   <label>

--- a/ui/app/components/variable-form/namespace-filter.hbs
+++ b/ui/app/components/variable-form/namespace-filter.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Trigger @do={{this.fetchNamespaces}} @onSuccess={{this.formatAndSetNamespaces}} as |trigger|>
   {{did-insert trigger.fns.do}}
   {{! No-op on Error}}

--- a/ui/app/components/variable-form/namespace-filter.hbs
+++ b/ui/app/components/variable-form/namespace-filter.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Trigger @do={{this.fetchNamespaces}} @onSuccess={{this.formatAndSetNamespaces}} as |trigger|>
   {{did-insert trigger.fns.do}}
   {{! No-op on Error}}

--- a/ui/app/components/variable-form/related-entities.hbs
+++ b/ui/app/components/variable-form/related-entities.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <p class="related-entities notification">
 <FlightIcon @name="info-fill" @color="var(--blue)" />
 <span>

--- a/ui/app/components/variable-form/related-entities.hbs
+++ b/ui/app/components/variable-form/related-entities.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <p class="related-entities notification">
 <FlightIcon @name="info-fill" @color="var(--blue)" />
 <span>

--- a/ui/app/components/variable-paths.hbs
+++ b/ui/app/components/variable-paths.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <ListTable class="path-tree" @source={{@branch}} as |t|>
   <t.head>
     <th>

--- a/ui/app/components/variable-paths.hbs
+++ b/ui/app/components/variable-paths.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <ListTable class="path-tree" @source={{@branch}} as |t|>
   <t.head>
     <th>

--- a/ui/app/templates/allocations.hbs
+++ b/ui/app/templates/allocations.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <PageLayout>
   {{outlet}}
 </PageLayout>

--- a/ui/app/templates/allocations.hbs
+++ b/ui/app/templates/allocations.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <PageLayout>
   {{outlet}}
 </PageLayout>

--- a/ui/app/templates/allocations/allocation.hbs
+++ b/ui/app/templates/allocations/allocation.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#each this.breadcrumbs as |crumb|}}
   <Breadcrumb @crumb={{crumb}} />
 {{/each}}

--- a/ui/app/templates/allocations/allocation.hbs
+++ b/ui/app/templates/allocations/allocation.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#each this.breadcrumbs as |crumb|}}
   <Breadcrumb @crumb={{crumb}} />
 {{/each}}

--- a/ui/app/templates/allocations/allocation/fs.hbs
+++ b/ui/app/templates/allocations/allocation/fs.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title this.pathWithLeadingSlash " -  Allocation " this.allocation.shortId " filesystem"}}
 <AllocationSubnav @allocation={{this.allocation}} />
 <Fs::Browser

--- a/ui/app/templates/allocations/allocation/fs.hbs
+++ b/ui/app/templates/allocations/allocation/fs.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title this.pathWithLeadingSlash " -  Allocation " this.allocation.shortId " filesystem"}}
 <AllocationSubnav @allocation={{this.allocation}} />
 <Fs::Browser

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Allocation " this.model.name}}
 <AllocationSubnav @allocation={{this.model}} />
 <section class="section">

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Allocation " this.model.name}}
 <AllocationSubnav @allocation={{this.model}} />
 <section class="section">

--- a/ui/app/templates/allocations/allocation/task.hbs
+++ b/ui/app/templates/allocations/allocation/task.hbs
@@ -2,5 +2,4 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{this.breadcrumb}} />{{outlet}}

--- a/ui/app/templates/allocations/allocation/task.hbs
+++ b/ui/app/templates/allocations/allocation/task.hbs
@@ -1,5 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{this.breadcrumb}} />{{outlet}}

--- a/ui/app/templates/allocations/allocation/task/fs.hbs
+++ b/ui/app/templates/allocations/allocation/task/fs.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title this.pathWithLeadingSlash " -  Task " this.taskState.name " filesystem"}}
 <TaskSubnav @task={{this.taskState}} />
 <Fs::Browser

--- a/ui/app/templates/allocations/allocation/task/fs.hbs
+++ b/ui/app/templates/allocations/allocation/task/fs.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title this.pathWithLeadingSlash " -  Task " this.taskState.name " filesystem"}}
 <TaskSubnav @task={{this.taskState}} />
 <Fs::Browser

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Task " this.model.name}}
 <TaskSubnav @task={{this.model}} />
 <section class="section">

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Task " this.model.name}}
 <TaskSubnav @task={{this.model}} />
 <section class="section">

--- a/ui/app/templates/allocations/allocation/task/logs.hbs
+++ b/ui/app/templates/allocations/allocation/task/logs.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Task " this.model.name " logs"}}
 <TaskSubnav @task={{this.model}} />
 <section class="section is-full-width">

--- a/ui/app/templates/allocations/allocation/task/logs.hbs
+++ b/ui/app/templates/allocations/allocation/task/logs.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Task " this.model.name " logs"}}
 <TaskSubnav @task={{this.model}} />
 <section class="section is-full-width">

--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title
   (if this.system.shouldShowRegions (concat this.system.activeRegion " - "))
   (if this.system.agent.config.UI.Label.Text (concat this.system.agent.config.UI.Label.Text " - "))

--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title
   (if this.system.shouldShowRegions (concat this.system.activeRegion " - "))
   (if this.system.agent.config.UI.Label.Text (concat this.system.agent.config.UI.Label.Text " - "))

--- a/ui/app/templates/clients.hbs
+++ b/ui/app/templates/clients.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{hash label="Clients" args=(array "clients.index")}} />
 <PageLayout>
   {{outlet}}

--- a/ui/app/templates/clients.hbs
+++ b/ui/app/templates/clients.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{hash label="Clients" args=(array "clients.index")}} />
 <PageLayout>
   {{outlet}}

--- a/ui/app/templates/clients/client.hbs
+++ b/ui/app/templates/clients/client.hbs
@@ -2,5 +2,4 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{this.breadcrumb}} />{{outlet}}

--- a/ui/app/templates/clients/client.hbs
+++ b/ui/app/templates/clients/client.hbs
@@ -1,5 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{this.breadcrumb}} />{{outlet}}

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Client " (or this.model.name this.model.shortId)}}
 <ClientSubnav @client={{this.model}} />
 <section class="section">

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Client " (or this.model.name this.model.shortId)}}
 <ClientSubnav @client={{this.model}} />
 <section class="section">

--- a/ui/app/templates/clients/client/monitor.hbs
+++ b/ui/app/templates/clients/client/monitor.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Client " (or this.model.name this.model.shortId)}}
 <ClientSubnav @client={{this.model}} />
 <section class="section is-full-width">

--- a/ui/app/templates/clients/client/monitor.hbs
+++ b/ui/app/templates/clients/client/monitor.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Client " (or this.model.name this.model.shortId)}}
 <ClientSubnav @client={{this.model}} />
 <section class="section is-full-width">

--- a/ui/app/templates/clients/index.hbs
+++ b/ui/app/templates/clients/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Clients"}}
 <section class="section">
   {{#if this.isForbidden}}

--- a/ui/app/templates/clients/index.hbs
+++ b/ui/app/templates/clients/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Clients"}}
 <section class="section">
   {{#if this.isForbidden}}

--- a/ui/app/templates/clients/loading.hbs
+++ b/ui/app/templates/clients/loading.hbs
@@ -1,5 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <section class="section has-text-centered"><LoadingSpinner /></section>

--- a/ui/app/templates/clients/loading.hbs
+++ b/ui/app/templates/clients/loading.hbs
@@ -2,5 +2,4 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <section class="section has-text-centered"><LoadingSpinner /></section>

--- a/ui/app/templates/components/agent-monitor.hbs
+++ b/ui/app/templates/components/agent-monitor.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="boxed-section">
   <div class="boxed-section-head" data-test-level-switcher-parent>
     <PowerSelect

--- a/ui/app/templates/components/agent-monitor.hbs
+++ b/ui/app/templates/components/agent-monitor.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="boxed-section">
   <div class="boxed-section-head" data-test-level-switcher-parent>
     <PowerSelect

--- a/ui/app/templates/components/allocation-row.hbs
+++ b/ui/app/templates/components/allocation-row.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <td data-test-indicators class="is-narrow">
   {{#if this.allocation.unhealthyDrivers.length}}
     <span

--- a/ui/app/templates/components/allocation-row.hbs
+++ b/ui/app/templates/components/allocation-row.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <td data-test-indicators class="is-narrow">
   {{#if this.allocation.unhealthyDrivers.length}}
     <span

--- a/ui/app/templates/components/allocation-stat.hbs
+++ b/ui/app/templates/components/allocation-stat.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.allocation.isRunning}}
   {{#if (and (not this.stat) this.isLoading)}}
     &hellip;

--- a/ui/app/templates/components/allocation-stat.hbs
+++ b/ui/app/templates/components/allocation-stat.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.allocation.isRunning}}
   {{#if (and (not this.stat) this.isLoading)}}
     &hellip;

--- a/ui/app/templates/components/allocation-subnav.hbs
+++ b/ui/app/templates/components/allocation-subnav.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="tabs is-subnav" {{did-insert this.keyboard.registerNav type="subnav"}} {{will-destroy this.keyboard.unregisterSubnav}}>
   <ul>
     <li><LinkTo @route="allocations.allocation.index" @model={{this.allocation}} @activeClass="is-active">Overview</LinkTo></li>

--- a/ui/app/templates/components/allocation-subnav.hbs
+++ b/ui/app/templates/components/allocation-subnav.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="tabs is-subnav" {{did-insert this.keyboard.registerNav type="subnav"}} {{will-destroy this.keyboard.unregisterSubnav}}>
   <ul>
     <li><LinkTo @route="allocations.allocation.index" @model={{this.allocation}} @activeClass="is-active">Overview</LinkTo></li>

--- a/ui/app/templates/components/app-breadcrumbs.hbs
+++ b/ui/app/templates/components/app-breadcrumbs.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumbs as |breadcrumbs|>
   {{#each breadcrumbs as |crumb iter|}}
     {{#let crumb.args.crumb as |c|}}

--- a/ui/app/templates/components/app-breadcrumbs.hbs
+++ b/ui/app/templates/components/app-breadcrumbs.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumbs as |breadcrumbs|>
   {{#each breadcrumbs as |crumb iter|}}
     {{#let crumb.args.crumb as |c|}}

--- a/ui/app/templates/components/attributes-section.hbs
+++ b/ui/app/templates/components/attributes-section.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#each-in this.attributes as |key value|}}
   {{#if (is-object value)}}
     <tr data-test-attributes-section>

--- a/ui/app/templates/components/attributes-section.hbs
+++ b/ui/app/templates/components/attributes-section.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#each-in this.attributes as |key value|}}
   {{#if (is-object value)}}
     <tr data-test-attributes-section>

--- a/ui/app/templates/components/attributes-table.hbs
+++ b/ui/app/templates/components/attributes-table.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <table class="table is-striped is-fixed is-compact is-darkened no-mobile-condense" ...attributes>
   <thead>
     <tr>

--- a/ui/app/templates/components/attributes-table.hbs
+++ b/ui/app/templates/components/attributes-table.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <table class="table is-striped is-fixed is-compact is-darkened no-mobile-condense" ...attributes>
   <thead>
     <tr>

--- a/ui/app/templates/components/client-node-row.hbs
+++ b/ui/app/templates/components/client-node-row.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <td data-test-icon class="is-narrow">
   {{#if this.node.unhealthyDrivers.length}}
     <span class="tooltip text-center" role="tooltip" aria-label="Client has unhealthy drivers">

--- a/ui/app/templates/components/client-node-row.hbs
+++ b/ui/app/templates/components/client-node-row.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <td data-test-icon class="is-narrow">
   {{#if this.node.unhealthyDrivers.length}}
     <span class="tooltip text-center" role="tooltip" aria-label="Client has unhealthy drivers">

--- a/ui/app/templates/components/client-subnav.hbs
+++ b/ui/app/templates/components/client-subnav.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="tabs is-subnav" {{did-insert this.keyboard.registerNav type="subnav"}} {{will-destroy this.keyboard.unregisterSubnav}}>
   <ul>
     <li><LinkTo @route="clients.client.index" @model={{this.client}} @activeClass="is-active">Overview</LinkTo></li>

--- a/ui/app/templates/components/client-subnav.hbs
+++ b/ui/app/templates/components/client-subnav.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="tabs is-subnav" {{did-insert this.keyboard.registerNav type="subnav"}} {{will-destroy this.keyboard.unregisterSubnav}}>
   <ul>
     <li><LinkTo @route="clients.client.index" @model={{this.client}} @activeClass="is-active">Overview</LinkTo></li>

--- a/ui/app/templates/components/copy-button.hbs
+++ b/ui/app/templates/components/copy-button.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if (eq this.state 'success')}}
   <div class='button is-small is-static {{if @compact "is-compact"}} {{unless @border "is-borderless"}}'>
     {{#if @inset}}

--- a/ui/app/templates/components/copy-button.hbs
+++ b/ui/app/templates/components/copy-button.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if (eq this.state 'success')}}
   <div class='button is-small is-static {{if @compact "is-compact"}} {{unless @border "is-borderless"}}'>
     {{#if @inset}}

--- a/ui/app/templates/components/distribution-bar.hbs
+++ b/ui/app/templates/components/distribution-bar.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <svg>
   <defs>
     <clipPath>

--- a/ui/app/templates/components/distribution-bar.hbs
+++ b/ui/app/templates/components/distribution-bar.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <svg>
   <defs>
     <clipPath>

--- a/ui/app/templates/components/drain-popover.hbs
+++ b/ui/app/templates/components/drain-popover.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{! template-lint-disable require-input-label }}
 <PopoverMenu
   data-test-drain-popover

--- a/ui/app/templates/components/drain-popover.hbs
+++ b/ui/app/templates/components/drain-popover.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{! template-lint-disable require-input-label }}
 <PopoverMenu
   data-test-drain-popover

--- a/ui/app/templates/components/evaluation-sidebar/evaluation-actor.hbs
+++ b/ui/app/templates/components/evaluation-sidebar/evaluation-actor.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Providers::ActorsRelationships as |actors|>
   <div
     class="related-evaluation

--- a/ui/app/templates/components/evaluation-sidebar/evaluation-actor.hbs
+++ b/ui/app/templates/components/evaluation-sidebar/evaluation-actor.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Providers::ActorsRelationships as |actors|>
   <div
     class="related-evaluation

--- a/ui/app/templates/components/exec-terminal.hbs
+++ b/ui/app/templates/components/exec-terminal.hbs
@@ -2,5 +2,4 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class='terminal'></div>

--- a/ui/app/templates/components/exec-terminal.hbs
+++ b/ui/app/templates/components/exec-terminal.hbs
@@ -1,5 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class='terminal'></div>

--- a/ui/app/templates/components/exec/open-button.hbs
+++ b/ui/app/templates/components/exec/open-button.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#let (cannot "exec allocation" namespace=this.job.namespace) as |cannotExec|}}
   <button
     data-test-exec-button

--- a/ui/app/templates/components/exec/open-button.hbs
+++ b/ui/app/templates/components/exec/open-button.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#let (cannot "exec allocation" namespace=this.job.namespace) as |cannotExec|}}
   <button
     data-test-exec-button

--- a/ui/app/templates/components/exec/task-contents.hbs
+++ b/ui/app/templates/components/exec/task-contents.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="border-and-label">
   <div class="border"></div>
   <div class="task-label">{{this.task.name}}</div>

--- a/ui/app/templates/components/exec/task-contents.hbs
+++ b/ui/app/templates/components/exec/task-contents.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="border-and-label">
   <div class="border"></div>
   <div class="task-label">{{this.task.name}}</div>

--- a/ui/app/templates/components/exec/task-group-parent.hbs
+++ b/ui/app/templates/components/exec/task-group-parent.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <button {{action "toggleOpen"}} class="toggle-button {{if this.hasPendingAllocations "is-loading"}}" data-test-task-group-name type="button">
   {{x-icon (if this.isOpen "chevron-down" "chevron-right")}}
   {{this.taskGroup.name}}

--- a/ui/app/templates/components/exec/task-group-parent.hbs
+++ b/ui/app/templates/components/exec/task-group-parent.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <button {{action "toggleOpen"}} class="toggle-button {{if this.hasPendingAllocations "is-loading"}}" data-test-task-group-name type="button">
   {{x-icon (if this.isOpen "chevron-down" "chevron-right")}}
   {{this.taskGroup.name}}

--- a/ui/app/templates/components/flex-masonry.hbs
+++ b/ui/app/templates/components/flex-masonry.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div
   data-test-flex-masonry
   class="flex-masonry {{if @withSpacing "with-spacing"}} flex-masonry-columns-{{@columns}}"

--- a/ui/app/templates/components/flex-masonry.hbs
+++ b/ui/app/templates/components/flex-masonry.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div
   data-test-flex-masonry
   class="flex-masonry {{if @withSpacing "with-spacing"}} flex-masonry-columns-{{@columns}}"

--- a/ui/app/templates/components/forbidden-message.hbs
+++ b/ui/app/templates/components/forbidden-message.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div data-test-error class="empty-message">
   <h3 data-test-error-title class="empty-message-headline">Not Authorized</h3>
   <p data-test-error-message class="empty-message-body">

--- a/ui/app/templates/components/forbidden-message.hbs
+++ b/ui/app/templates/components/forbidden-message.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div data-test-error class="empty-message">
   <h3 data-test-error-title class="empty-message-headline">Not Authorized</h3>
   <p data-test-error-message class="empty-message-body">

--- a/ui/app/templates/components/fs/breadcrumbs.hbs
+++ b/ui/app/templates/components/fs/breadcrumbs.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <ul>
   <li class={{if this.breadcrumbs "" "is-active"}}>
     <Fs::Link @allocation={{this.allocation}} @taskState={{this.taskState}}>

--- a/ui/app/templates/components/fs/breadcrumbs.hbs
+++ b/ui/app/templates/components/fs/breadcrumbs.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <ul>
   <li class={{if this.breadcrumbs "" "is-active"}}>
     <Fs::Link @allocation={{this.allocation}} @taskState={{this.taskState}}>

--- a/ui/app/templates/components/fs/browser.hbs
+++ b/ui/app/templates/components/fs/browser.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <section class="section is-closer {{if this.isFile "is-full-width"}}">
   {{#if this.isFile}}
     <Fs::File @allocation={{this.allocation}} @taskState={{this.taskState}} @file={{this.path}} @stat={{this.stat}} @class="fs-explorer">

--- a/ui/app/templates/components/fs/browser.hbs
+++ b/ui/app/templates/components/fs/browser.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <section class="section is-closer {{if this.isFile "is-full-width"}}">
   {{#if this.isFile}}
     <Fs::File @allocation={{this.allocation}} @taskState={{this.taskState}} @file={{this.path}} @stat={{this.stat}} @class="fs-explorer">

--- a/ui/app/templates/components/fs/directory-entry.hbs
+++ b/ui/app/templates/components/fs/directory-entry.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <tr data-test-entry>
   <td>
     <Fs::Link @allocation={{this.allocation}} @taskState={{this.taskState}} @path={{this.pathToEntry}}>

--- a/ui/app/templates/components/fs/directory-entry.hbs
+++ b/ui/app/templates/components/fs/directory-entry.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <tr data-test-entry>
   <td>
     <Fs::Link @allocation={{this.allocation}} @taskState={{this.taskState}} @path={{this.pathToEntry}}>

--- a/ui/app/templates/components/fs/file.hbs
+++ b/ui/app/templates/components/fs/file.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.noConnection}}
   <div data-test-connection-error class="notification is-error">
     <h3 class="title is-4">Cannot fetch file</h3>

--- a/ui/app/templates/components/fs/file.hbs
+++ b/ui/app/templates/components/fs/file.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.noConnection}}
   <div data-test-connection-error class="notification is-error">
     <h3 class="title is-4">Cannot fetch file</h3>

--- a/ui/app/templates/components/fs/link.hbs
+++ b/ui/app/templates/components/fs/link.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.taskState}}
   {{#if this.path}}
     <LinkTo @route="allocations.allocation.task.fs" @models={{array this.allocation this.taskState this.path}} @activeClass="is-active">

--- a/ui/app/templates/components/fs/link.hbs
+++ b/ui/app/templates/components/fs/link.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.taskState}}
   {{#if this.path}}
     <LinkTo @route="allocations.allocation.task.fs" @models={{array this.allocation this.taskState this.path}} @activeClass="is-active">

--- a/ui/app/templates/components/gauge-chart.hbs
+++ b/ui/app/templates/components/gauge-chart.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <svg data-test-gauge-svg role="img" height={{this.height}} title="gauge chart">
   <defs>
     <linearGradient x1="0" x2="1" y1="0" y2="0" class="{{this.chartClass}}" id="{{this.fillId}}">

--- a/ui/app/templates/components/gauge-chart.hbs
+++ b/ui/app/templates/components/gauge-chart.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <svg data-test-gauge-svg role="img" height={{this.height}} title="gauge chart">
   <defs>
     <linearGradient x1="0" x2="1" y1="0" y2="0" class="{{this.chartClass}}" id="{{this.fillId}}">

--- a/ui/app/templates/components/global-header.hbs
+++ b/ui/app/templates/components/global-header.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{! template-lint-disable no-duplicate-landmark-elements }}
 <nav class="navbar is-primary" title="navigation">
   <div class="navbar-brand">

--- a/ui/app/templates/components/global-header.hbs
+++ b/ui/app/templates/components/global-header.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{! template-lint-disable no-duplicate-landmark-elements }}
 <nav class="navbar is-primary" title="navigation">
   <div class="navbar-brand">

--- a/ui/app/templates/components/global-search/control.hbs
+++ b/ui/app/templates/components/global-search/control.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
   <PowerSelect
     @tagName="div"
     data-test-search

--- a/ui/app/templates/components/global-search/control.hbs
+++ b/ui/app/templates/components/global-search/control.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
   <PowerSelect
     @tagName="div"
     data-test-search

--- a/ui/app/templates/components/global-search/message.hbs
+++ b/ui/app/templates/components/global-search/message.hbs
@@ -1,4 +1,5 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+

--- a/ui/app/templates/components/global-search/message.hbs
+++ b/ui/app/templates/components/global-search/message.hbs
@@ -2,4 +2,3 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-

--- a/ui/app/templates/components/global-search/trigger.hbs
+++ b/ui/app/templates/components/global-search/trigger.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{x-icon "search" class="is-small"}}
 {{#unless this.select.isOpen}}
   <span class='placeholder'>Jump to</span>

--- a/ui/app/templates/components/global-search/trigger.hbs
+++ b/ui/app/templates/components/global-search/trigger.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{x-icon "search" class="is-small"}}
 {{#unless this.select.isOpen}}
   <span class='placeholder'>Jump to</span>

--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div
   data-test-gutter-menu
   class="page-column is-left {{if this.isOpen "is-open"}}"

--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div
   data-test-gutter-menu
   class="page-column is-left {{if this.isOpen "is-open"}}"

--- a/ui/app/templates/components/hamburger-menu.hbs
+++ b/ui/app/templates/components/hamburger-menu.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <svg class="hamburger-menu" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
   <rect x="0" y="0" width="100" height="16" />
   <rect x="0" y="42" width="100" height="16" />

--- a/ui/app/templates/components/hamburger-menu.hbs
+++ b/ui/app/templates/components/hamburger-menu.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <svg class="hamburger-menu" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
   <rect x="0" y="0" width="100" height="16" />
   <rect x="0" y="42" width="100" height="16" />

--- a/ui/app/templates/components/image-file.hbs
+++ b/ui/app/templates/components/image-file.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <a data-test-image-link href={{this.src}} target="_blank" rel="noopener noreferrer" class="image-file-image">
   <img data-test-image src={{this.src}} alt={{or this.alt this.fileName}} title={{this.fileName}} onload={{action this.updateImageMeta}} />
 </a>

--- a/ui/app/templates/components/image-file.hbs
+++ b/ui/app/templates/components/image-file.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <a data-test-image-link href={{this.src}} target="_blank" rel="noopener noreferrer" class="image-file-image">
   <img data-test-image src={{this.src}} alt={{or this.alt this.fileName}} title={{this.fileName}} onload={{action this.updateImageMeta}} />
 </a>

--- a/ui/app/templates/components/job-client-status-row.hbs
+++ b/ui/app/templates/components/job-client-status-row.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <tr data-test-client={{this.row.node.id}} class="job-client-status-row is-interactive" {{on "click" (fn @onClick this.row.node)}}>
   <td data-test-short-id>
     <LinkTo @route="allocations.allocation" @model={{this.allocation}} class="is-primary">

--- a/ui/app/templates/components/job-client-status-row.hbs
+++ b/ui/app/templates/components/job-client-status-row.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <tr data-test-client={{this.row.node.id}} class="job-client-status-row is-interactive" {{on "click" (fn @onClick this.row.node)}}>
   <td data-test-short-id>
     <LinkTo @route="allocations.allocation" @model={{this.allocation}} class="is-primary">

--- a/ui/app/templates/components/job-deployment-details.hbs
+++ b/ui/app/templates/components/job-deployment-details.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{yield (hash
   metrics=(component "job-deployment/deployment-metrics" deployment=@deployment)
   taskGroups=(component "job-deployment/task-groups" deployment=@deployment)

--- a/ui/app/templates/components/job-deployment-details.hbs
+++ b/ui/app/templates/components/job-deployment-details.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{yield (hash
   metrics=(component "job-deployment/deployment-metrics" deployment=@deployment)
   taskGroups=(component "job-deployment/task-groups" deployment=@deployment)

--- a/ui/app/templates/components/job-deployment.hbs
+++ b/ui/app/templates/components/job-deployment.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="boxed-section-head is-light inline-definitions">
   <span>{{this.deployment.shortId}}</span>
   <span class="bumper-left tag {{this.deployment.statusClass}}" data-test-deployment-status="{{this.deployment.statusClass}}">{{this.deployment.status}}</span>

--- a/ui/app/templates/components/job-deployment.hbs
+++ b/ui/app/templates/components/job-deployment.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="boxed-section-head is-light inline-definitions">
   <span>{{this.deployment.shortId}}</span>
   <span class="bumper-left tag {{this.deployment.statusClass}}" data-test-deployment-status="{{this.deployment.statusClass}}">{{this.deployment.status}}</span>

--- a/ui/app/templates/components/job-deployment/deployment-allocations.hbs
+++ b/ui/app/templates/components/job-deployment/deployment-allocations.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div data-test-deployment-allocations class="boxed-section">
   <div class="boxed-section-head">
     Allocations

--- a/ui/app/templates/components/job-deployment/deployment-allocations.hbs
+++ b/ui/app/templates/components/job-deployment/deployment-allocations.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div data-test-deployment-allocations class="boxed-section">
   <div class="boxed-section-head">
     Allocations

--- a/ui/app/templates/components/job-deployment/deployment-metrics.hbs
+++ b/ui/app/templates/components/job-deployment/deployment-metrics.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="columns deployment-metrics">
   <div class="column nowrap">
     <div class="metric-group">

--- a/ui/app/templates/components/job-deployment/deployment-metrics.hbs
+++ b/ui/app/templates/components/job-deployment/deployment-metrics.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="columns deployment-metrics">
   <div class="column nowrap">
     <div class="metric-group">

--- a/ui/app/templates/components/job-deployment/task-groups.hbs
+++ b/ui/app/templates/components/job-deployment/task-groups.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div data-test-deployment-task-groups class="boxed-section">
   <div class="boxed-section-head">
     Task Groups

--- a/ui/app/templates/components/job-deployment/task-groups.hbs
+++ b/ui/app/templates/components/job-deployment/task-groups.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div data-test-deployment-task-groups class="boxed-section">
   <div class="boxed-section-head">
     Task Groups

--- a/ui/app/templates/components/job-deployments-stream.hbs
+++ b/ui/app/templates/components/job-deployments-stream.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#each this.annotatedDeployments key="deployment.id" as |record|}}
   {{#if record.meta.showDate}}
     <li data-test-deployment-time class="timeline-note">

--- a/ui/app/templates/components/job-deployments-stream.hbs
+++ b/ui/app/templates/components/job-deployments-stream.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#each this.annotatedDeployments key="deployment.id" as |record|}}
   {{#if record.meta.showDate}}
     <li data-test-deployment-time class="timeline-note">

--- a/ui/app/templates/components/job-diff-fields-and-objects.hbs
+++ b/ui/app/templates/components/job-diff-fields-and-objects.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="diff-section-table">
   {{#each this.fields as |field|}}
     <div

--- a/ui/app/templates/components/job-diff-fields-and-objects.hbs
+++ b/ui/app/templates/components/job-diff-fields-and-objects.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="diff-section-table">
   {{#each this.fields as |field|}}
     <div

--- a/ui/app/templates/components/job-diff.hbs
+++ b/ui/app/templates/components/job-diff.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{! Job heading }}
 {{! template-lint-disable simple-unless }}
 <div

--- a/ui/app/templates/components/job-diff.hbs
+++ b/ui/app/templates/components/job-diff.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{! Job heading }}
 {{! template-lint-disable simple-unless }}
 <div

--- a/ui/app/templates/components/job-dispatch.hbs
+++ b/ui/app/templates/components/job-dispatch.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.errors}}
   <div data-test-dispatch-error class="notification is-danger">
     <h3 class="title is-4" data-test-parse-error-title>Dispatch Error</h3>

--- a/ui/app/templates/components/job-dispatch.hbs
+++ b/ui/app/templates/components/job-dispatch.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.errors}}
   <div data-test-dispatch-error class="notification is-danger">
     <h3 class="title is-4" data-test-parse-error-title>Dispatch Error</h3>

--- a/ui/app/templates/components/job-editor.hbs
+++ b/ui/app/templates/components/job-editor.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div>
   {{#if this.error}}
     <div data-test-error={{this.error.type}} class="notification is-danger">

--- a/ui/app/templates/components/job-editor.hbs
+++ b/ui/app/templates/components/job-editor.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div>
   {{#if this.error}}
     <div data-test-error={{this.error.type}} class="notification is-danger">

--- a/ui/app/templates/components/job-page.hbs
+++ b/ui/app/templates/components/job-page.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{yield
   (hash
     data=(hash)

--- a/ui/app/templates/components/job-page.hbs
+++ b/ui/app/templates/components/job-page.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{yield
   (hash
     data=(hash)

--- a/ui/app/templates/components/job-page/batch.hbs
+++ b/ui/app/templates/components/job-page/batch.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-page/batch.hbs
+++ b/ui/app/templates/components/job-page/batch.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-page/parameterized-child.hbs
+++ b/ui/app/templates/components/job-page/parameterized-child.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-page/parameterized-child.hbs
+++ b/ui/app/templates/components/job-page/parameterized-child.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-page/parameterized.hbs
+++ b/ui/app/templates/components/job-page/parameterized.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-page/parameterized.hbs
+++ b/ui/app/templates/components/job-page/parameterized.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-page/parts/body.hbs
+++ b/ui/app/templates/components/job-page/parts/body.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <JobSubnav @job={{@job}} />
 <section class="section">
   {{yield}}

--- a/ui/app/templates/components/job-page/parts/body.hbs
+++ b/ui/app/templates/components/job-page/parts/body.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <JobSubnav @job={{@job}} />
 <section class="section">
   {{yield}}

--- a/ui/app/templates/components/job-page/parts/children.hbs
+++ b/ui/app/templates/components/job-page/parts/children.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="boxed-section-head">
   Job Launches
   {{#if this.job.parameterized}}

--- a/ui/app/templates/components/job-page/parts/children.hbs
+++ b/ui/app/templates/components/job-page/parts/children.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="boxed-section-head">
   Job Launches
   {{#if this.job.parameterized}}

--- a/ui/app/templates/components/job-page/parts/das-recommendations.hbs
+++ b/ui/app/templates/components/job-page/parts/das-recommendations.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if (can "accept recommendations")}}
   {{#each @job.recommendationSummaries as |summary|}}
     <Das::RecommendationAccordion @summary={{summary}} />

--- a/ui/app/templates/components/job-page/parts/das-recommendations.hbs
+++ b/ui/app/templates/components/job-page/parts/das-recommendations.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if (can "accept recommendations")}}
   {{#each @job.recommendationSummaries as |summary|}}
     <Das::RecommendationAccordion @summary={{summary}} />

--- a/ui/app/templates/components/job-page/parts/error.hbs
+++ b/ui/app/templates/components/job-page/parts/error.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.errorMessage}}
   <div class="notification is-danger">
     <div class="columns">

--- a/ui/app/templates/components/job-page/parts/error.hbs
+++ b/ui/app/templates/components/job-page/parts/error.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.errorMessage}}
   <div class="notification is-danger">
     <div class="columns">

--- a/ui/app/templates/components/job-page/parts/job-client-status-summary.hbs
+++ b/ui/app/templates/components/job-page/parts/job-client-status-summary.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.job.hasClientStatus}}
   <ListAccordion
     data-test-job-client-summary

--- a/ui/app/templates/components/job-page/parts/job-client-status-summary.hbs
+++ b/ui/app/templates/components/job-page/parts/job-client-status-summary.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.job.hasClientStatus}}
   <ListAccordion
     data-test-job-client-summary

--- a/ui/app/templates/components/job-page/parts/latest-deployment.hbs
+++ b/ui/app/templates/components/job-page/parts/latest-deployment.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.job.latestDeployment}}
   <div class="boxed-section {{if this.job.latestDeployment.isRunning "is-info"}}" data-test-active-deployment>
     <div class="boxed-section-head">

--- a/ui/app/templates/components/job-page/parts/latest-deployment.hbs
+++ b/ui/app/templates/components/job-page/parts/latest-deployment.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.job.latestDeployment}}
   <div class="boxed-section {{if this.job.latestDeployment.isRunning "is-info"}}" data-test-active-deployment>
     <div class="boxed-section-head">

--- a/ui/app/templates/components/job-page/parts/meta.hbs
+++ b/ui/app/templates/components/job-page/parts/meta.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if @job.meta.structured}}
   <div class="boxed-section">
     <div class="boxed-section-head">

--- a/ui/app/templates/components/job-page/parts/meta.hbs
+++ b/ui/app/templates/components/job-page/parts/meta.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if @job.meta.structured}}
   <div class="boxed-section">
     <div class="boxed-section-head">

--- a/ui/app/templates/components/job-page/parts/placement-failures.hbs
+++ b/ui/app/templates/components/job-page/parts/placement-failures.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.job.hasPlacementFailures}}
   <div class="boxed-section is-danger" data-test-placement-failures>
     <div class="boxed-section-head">

--- a/ui/app/templates/components/job-page/parts/placement-failures.hbs
+++ b/ui/app/templates/components/job-page/parts/placement-failures.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.job.hasPlacementFailures}}
   <div class="boxed-section is-danger" data-test-placement-failures>
     <div class="boxed-section-head">

--- a/ui/app/templates/components/job-page/parts/recent-allocations.hbs
+++ b/ui/app/templates/components/job-page/parts/recent-allocations.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="boxed-section">
   <div class="boxed-section-head">
     Recent Allocations

--- a/ui/app/templates/components/job-page/parts/recent-allocations.hbs
+++ b/ui/app/templates/components/job-page/parts/recent-allocations.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="boxed-section">
   <div class="boxed-section-head">
     Recent Allocations

--- a/ui/app/templates/components/job-page/parts/stats-box.hbs
+++ b/ui/app/templates/components/job-page/parts/stats-box.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{! template-lint-disable no-inline-styles }}
 <div class="boxed-section is-small">
   <div class="boxed-section-body inline-definitions">

--- a/ui/app/templates/components/job-page/parts/stats-box.hbs
+++ b/ui/app/templates/components/job-page/parts/stats-box.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{! template-lint-disable no-inline-styles }}
 <div class="boxed-section is-small">
   <div class="boxed-section-body inline-definitions">

--- a/ui/app/templates/components/job-page/parts/summary-legend-item.hbs
+++ b/ui/app/templates/components/job-page/parts/summary-legend-item.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="legend-item">
   <span
     class="color-swatch {{if @datum.className @datum.className (concat "swatch-" @index)}}"

--- a/ui/app/templates/components/job-page/parts/summary-legend-item.hbs
+++ b/ui/app/templates/components/job-page/parts/summary-legend-item.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="legend-item">
   <span
     class="color-swatch {{if @datum.className @datum.className (concat "swatch-" @index)}}"

--- a/ui/app/templates/components/job-page/parts/summary.hbs
+++ b/ui/app/templates/components/job-page/parts/summary.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <ListAccordion
   data-test-job-summary
   @source={{array this.job}}

--- a/ui/app/templates/components/job-page/parts/summary.hbs
+++ b/ui/app/templates/components/job-page/parts/summary.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <ListAccordion
   data-test-job-summary
   @source={{array this.job}}

--- a/ui/app/templates/components/job-page/parts/task-groups.hbs
+++ b/ui/app/templates/components/job-page/parts/task-groups.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="boxed-section">
   <div class="boxed-section-head">
     Task Groups

--- a/ui/app/templates/components/job-page/parts/task-groups.hbs
+++ b/ui/app/templates/components/job-page/parts/task-groups.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="boxed-section">
   <div class="boxed-section-head">
     Task Groups

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <h1 class="title with-flex">
   <div data-test-job-name>
     {{or this.title this.job.name}}

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <h1 class="title with-flex">
   <div data-test-job-name>
     {{or this.title this.job.name}}

--- a/ui/app/templates/components/job-page/periodic-child.hbs
+++ b/ui/app/templates/components/job-page/periodic-child.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-page/periodic-child.hbs
+++ b/ui/app/templates/components/job-page/periodic-child.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-page/periodic.hbs
+++ b/ui/app/templates/components/job-page/periodic.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-page/periodic.hbs
+++ b/ui/app/templates/components/job-page/periodic.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-page/service.hbs
+++ b/ui/app/templates/components/job-page/service.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-page/service.hbs
+++ b/ui/app/templates/components/job-page/service.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-page/sysbatch.hbs
+++ b/ui/app/templates/components/job-page/sysbatch.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-page/sysbatch.hbs
+++ b/ui/app/templates/components/job-page/sysbatch.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-page/system.hbs
+++ b/ui/app/templates/components/job-page/system.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-page/system.hbs
+++ b/ui/app/templates/components/job-page/system.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <JobPage @job={{@job}} as |jobPage|>
   <jobPage.ui.Body>
     <jobPage.ui.Error />

--- a/ui/app/templates/components/job-row.hbs
+++ b/ui/app/templates/components/job-row.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <td data-test-job-name
   {{keyboard-shortcut 
     enumerated=true

--- a/ui/app/templates/components/job-row.hbs
+++ b/ui/app/templates/components/job-row.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <td data-test-job-name
   {{keyboard-shortcut 
     enumerated=true

--- a/ui/app/templates/components/job-service-row.hbs
+++ b/ui/app/templates/components/job-service-row.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <tr
   data-test-service-row
   data-test-service-name={{@service.name}}

--- a/ui/app/templates/components/job-service-row.hbs
+++ b/ui/app/templates/components/job-service-row.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <tr
   data-test-service-row
   data-test-service-name={{@service.name}}

--- a/ui/app/templates/components/job-subnav.hbs
+++ b/ui/app/templates/components/job-subnav.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div data-test-subnav="job" class="tabs is-subnav" {{did-insert this.keyboard.registerNav type="subnav"}} {{will-destroy this.keyboard.unregisterSubnav}}>
   <ul>
     <li data-test-tab="overview">

--- a/ui/app/templates/components/job-subnav.hbs
+++ b/ui/app/templates/components/job-subnav.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div data-test-subnav="job" class="tabs is-subnav" {{did-insert this.keyboard.registerNav type="subnav"}} {{will-destroy this.keyboard.unregisterSubnav}}>
   <ul>
     <li data-test-tab="overview">

--- a/ui/app/templates/components/job-version.hbs
+++ b/ui/app/templates/components/job-version.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="boxed-section-head is-light inline-definitions">
   Version #{{this.version.number}}
   <span class="bumper-left pair is-faded">

--- a/ui/app/templates/components/job-version.hbs
+++ b/ui/app/templates/components/job-version.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="boxed-section-head is-light inline-definitions">
   Version #{{this.version.number}}
   <span class="bumper-left pair is-faded">

--- a/ui/app/templates/components/job-versions-stream.hbs
+++ b/ui/app/templates/components/job-versions-stream.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#each this.annotatedVersions key="version.id" as |record|}}
   {{#if record.meta.showDate}}
     <li data-test-version-time class="timeline-note">

--- a/ui/app/templates/components/job-versions-stream.hbs
+++ b/ui/app/templates/components/job-versions-stream.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#each this.annotatedVersions key="version.id" as |record|}}
   {{#if record.meta.showDate}}
     <li data-test-version-time class="timeline-note">

--- a/ui/app/templates/components/json-viewer.hbs
+++ b/ui/app/templates/components/json-viewer.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div
   data-test-json-viewer
   {{code-mirror

--- a/ui/app/templates/components/json-viewer.hbs
+++ b/ui/app/templates/components/json-viewer.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div
   data-test-json-viewer
   {{code-mirror

--- a/ui/app/templates/components/lifecycle-chart-row.hbs
+++ b/ui/app/templates/components/lifecycle-chart-row.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div
   class="lifecycle-chart-row {{this.task.lifecycleName}} {{this.activeClass}} {{this.finishedClass}}"
   data-test-lifecycle-task>

--- a/ui/app/templates/components/lifecycle-chart-row.hbs
+++ b/ui/app/templates/components/lifecycle-chart-row.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div
   class="lifecycle-chart-row {{this.task.lifecycleName}} {{this.activeClass}} {{this.finishedClass}}"
   data-test-lifecycle-task>

--- a/ui/app/templates/components/lifecycle-chart.hbs
+++ b/ui/app/templates/components/lifecycle-chart.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
   {{#if (gt this.lifecyclePhases.length 1)}}
     <div class="boxed-section" data-test-lifecycle-chart>
       <div class="boxed-section-head">

--- a/ui/app/templates/components/lifecycle-chart.hbs
+++ b/ui/app/templates/components/lifecycle-chart.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
   {{#if (gt this.lifecyclePhases.length 1)}}
     <div class="boxed-section" data-test-lifecycle-chart>
       <div class="boxed-section-head">

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div
   class="chart line-chart"
   ...attributes

--- a/ui/app/templates/components/line-chart.hbs
+++ b/ui/app/templates/components/line-chart.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div
   class="chart line-chart"
   ...attributes

--- a/ui/app/templates/components/list-accordion.hbs
+++ b/ui/app/templates/components/list-accordion.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#each this.decoratedSource as |item|}}
 {{yield (hash
     head=(component "list-accordion/accordion-head"

--- a/ui/app/templates/components/list-accordion.hbs
+++ b/ui/app/templates/components/list-accordion.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#each this.decoratedSource as |item|}}
 {{yield (hash
     head=(component "list-accordion/accordion-head"

--- a/ui/app/templates/components/list-accordion/accordion-body.hbs
+++ b/ui/app/templates/components/list-accordion/accordion-body.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.isOpen}}
   <div data-test-accordion-body class="accordion-body {{if this.fullBleed "is-full-bleed"}}">
     {{yield}}

--- a/ui/app/templates/components/list-accordion/accordion-body.hbs
+++ b/ui/app/templates/components/list-accordion/accordion-body.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.isOpen}}
   <div data-test-accordion-body class="accordion-body {{if this.fullBleed "is-full-bleed"}}">
     {{yield}}

--- a/ui/app/templates/components/list-accordion/accordion-head.hbs
+++ b/ui/app/templates/components/list-accordion/accordion-head.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="accordion-head-content">
   {{yield}}
 </div>

--- a/ui/app/templates/components/list-accordion/accordion-head.hbs
+++ b/ui/app/templates/components/list-accordion/accordion-head.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="accordion-head-content">
   {{yield}}
 </div>

--- a/ui/app/templates/components/list-pagination.hbs
+++ b/ui/app/templates/components/list-pagination.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.source.length}}
   {{yield (hash
     first=(component "list-pagination/list-pager" test="first" label="First page" page=1 visible=(not (eq this.page 1)))

--- a/ui/app/templates/components/list-pagination.hbs
+++ b/ui/app/templates/components/list-pagination.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.source.length}}
   {{yield (hash
     first=(component "list-pagination/list-pager" test="first" label="First page" page=1 visible=(not (eq this.page 1)))

--- a/ui/app/templates/components/list-pagination/list-pager.hbs
+++ b/ui/app/templates/components/list-pagination/list-pager.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.visible}}
   <LinkTo
     @query={{hash currentPage=this.page}}

--- a/ui/app/templates/components/list-pagination/list-pager.hbs
+++ b/ui/app/templates/components/list-pagination/list-pager.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.visible}}
   <LinkTo
     @query={{hash currentPage=this.page}}

--- a/ui/app/templates/components/list-table.hbs
+++ b/ui/app/templates/components/list-table.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{yield (hash
   head=(component "list-table/table-head")
   body=(component "list-table/table-body" rows=this.decoratedSource)

--- a/ui/app/templates/components/list-table.hbs
+++ b/ui/app/templates/components/list-table.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{yield (hash
   head=(component "list-table/table-head")
   body=(component "list-table/table-body" rows=this.decoratedSource)

--- a/ui/app/templates/components/list-table/sort-by.hbs
+++ b/ui/app/templates/components/list-table/sort-by.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <SafeLinkTo
   @query={{hash sortProperty=this.prop sortDescending=this.shouldSortDescending}}
   data-test-sort-by={{this.prop}}>

--- a/ui/app/templates/components/list-table/sort-by.hbs
+++ b/ui/app/templates/components/list-table/sort-by.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <SafeLinkTo
   @query={{hash sortProperty=this.prop sortDescending=this.shouldSortDescending}}
   data-test-sort-by={{this.prop}}>

--- a/ui/app/templates/components/list-table/table-body.hbs
+++ b/ui/app/templates/components/list-table/table-body.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#each this.rows key=this.key as |row index|}}
   {{yield row index}}
 {{/each}}

--- a/ui/app/templates/components/list-table/table-body.hbs
+++ b/ui/app/templates/components/list-table/table-body.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#each this.rows key=this.key as |row index|}}
   {{yield row index}}
 {{/each}}

--- a/ui/app/templates/components/list-table/table-head.hbs
+++ b/ui/app/templates/components/list-table/table-head.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <tr>
   {{yield}}
 </tr>

--- a/ui/app/templates/components/list-table/table-head.hbs
+++ b/ui/app/templates/components/list-table/table-head.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <tr>
   {{yield}}
 </tr>

--- a/ui/app/templates/components/loading-spinner.hbs
+++ b/ui/app/templates/components/loading-spinner.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="loading-spinner {{if this.paused 'paused'}}" {{on "click" (toggle-action 'paused' this)}}>
   <div class="cube-and-logo">
     <div class="cube">

--- a/ui/app/templates/components/loading-spinner.hbs
+++ b/ui/app/templates/components/loading-spinner.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="loading-spinner {{if this.paused 'paused'}}" {{on "click" (toggle-action 'paused' this)}}>
   <div class="cube-and-logo">
     <div class="cube">

--- a/ui/app/templates/components/multi-select-dropdown.hbs
+++ b/ui/app/templates/components/multi-select-dropdown.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <BasicDropdown
   @horizontalPosition="left"
   @onOpen={{action

--- a/ui/app/templates/components/multi-select-dropdown.hbs
+++ b/ui/app/templates/components/multi-select-dropdown.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <BasicDropdown
   @horizontalPosition="left"
   @onOpen={{action

--- a/ui/app/templates/components/nomad-logo.hbs
+++ b/ui/app/templates/components/nomad-logo.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <svg class="nomad-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 206.31 60.07">
   <g>
     <g>

--- a/ui/app/templates/components/nomad-logo.hbs
+++ b/ui/app/templates/components/nomad-logo.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <svg class="nomad-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 206.31 60.07">
   <g>
     <g>

--- a/ui/app/templates/components/page-layout.hbs
+++ b/ui/app/templates/components/page-layout.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <GlobalHeader
   @class="page-header"
   @onHamburgerClick={{action (mut this.isGutterOpen) true}}>

--- a/ui/app/templates/components/page-layout.hbs
+++ b/ui/app/templates/components/page-layout.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <GlobalHeader
   @class="page-header"
   @onHamburgerClick={{action (mut this.isGutterOpen) true}}>

--- a/ui/app/templates/components/page-size-select.hbs
+++ b/ui/app/templates/components/page-size-select.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="field is-horizontal" data-test-page-size-select-parent ...attributes>
   <span class="field-label is-small">
     Per page

--- a/ui/app/templates/components/page-size-select.hbs
+++ b/ui/app/templates/components/page-size-select.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="field is-horizontal" data-test-page-size-select-parent ...attributes>
   <span class="field-label is-small">
     Per page

--- a/ui/app/templates/components/placement-failure.hbs
+++ b/ui/app/templates/components/placement-failure.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.placementFailures}}
   {{#with this.placementFailures as |failures|}}
     <h3 class="title is-5" data-test-placement-failure-task-group>

--- a/ui/app/templates/components/placement-failure.hbs
+++ b/ui/app/templates/components/placement-failure.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.placementFailures}}
   {{#with this.placementFailures as |failures|}}
     <h3 class="title is-5" data-test-placement-failure-task-group>

--- a/ui/app/templates/components/plugin-allocation-row.hbs
+++ b/ui/app/templates/components/plugin-allocation-row.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.allocation}}
   <td data-test-indicators class="is-narrow">
     {{#if this.allocation.unhealthyDrivers.length}}

--- a/ui/app/templates/components/plugin-allocation-row.hbs
+++ b/ui/app/templates/components/plugin-allocation-row.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.allocation}}
   <td data-test-indicators class="is-narrow">
     {{#if this.allocation.unhealthyDrivers.length}}

--- a/ui/app/templates/components/plugin-subnav.hbs
+++ b/ui/app/templates/components/plugin-subnav.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div data-test-subnav="plugins" class="tabs is-subnav" {{did-insert this.keyboard.registerNav type="subnav"}} {{will-destroy this.keyboard.unregisterSubnav}}>
   <ul>
     <li data-test-tab="overview"><LinkTo @route="csi.plugins.plugin.index" @model={{@plugin}} @activeClass="is-active">Overview</LinkTo></li>

--- a/ui/app/templates/components/plugin-subnav.hbs
+++ b/ui/app/templates/components/plugin-subnav.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div data-test-subnav="plugins" class="tabs is-subnav" {{did-insert this.keyboard.registerNav type="subnav"}} {{will-destroy this.keyboard.unregisterSubnav}}>
   <ul>
     <li data-test-tab="overview"><LinkTo @route="csi.plugins.plugin.index" @model={{@plugin}} @activeClass="is-active">Overview</LinkTo></li>

--- a/ui/app/templates/components/popover-menu.hbs
+++ b/ui/app/templates/components/popover-menu.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <BasicDropdown
   @horizontalPosition="right"
   @disabled={{this.isDisabled}}

--- a/ui/app/templates/components/popover-menu.hbs
+++ b/ui/app/templates/components/popover-menu.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <BasicDropdown
   @horizontalPosition="right"
   @disabled={{this.isDisabled}}

--- a/ui/app/templates/components/proxy-tag.hbs
+++ b/ui/app/templates/components/proxy-tag.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <span class="badge is-light tooltip" role="tooltip" aria-label="Consul Connect proxy task" data-test-proxy-tag>
   Proxy
 </span>

--- a/ui/app/templates/components/proxy-tag.hbs
+++ b/ui/app/templates/components/proxy-tag.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <span class="badge is-light tooltip" role="tooltip" aria-label="Consul Connect proxy task" data-test-proxy-tag>
   Proxy
 </span>

--- a/ui/app/templates/components/region-switcher.hbs
+++ b/ui/app/templates/components/region-switcher.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.system.shouldShowRegions}}
   <span data-test-region-switcher-parent>
     <PowerSelect

--- a/ui/app/templates/components/region-switcher.hbs
+++ b/ui/app/templates/components/region-switcher.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.system.shouldShowRegions}}
   <span data-test-region-switcher-parent>
     <PowerSelect

--- a/ui/app/templates/components/reschedule-event-row.hbs
+++ b/ui/app/templates/components/reschedule-event-row.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <li class="timeline-note">
   {{#if this.label}}
     <strong data-test-reschedule-label>{{this.label}}</strong>

--- a/ui/app/templates/components/reschedule-event-row.hbs
+++ b/ui/app/templates/components/reschedule-event-row.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <li class="timeline-note">
   {{#if this.label}}
     <strong data-test-reschedule-label>{{this.label}}</strong>

--- a/ui/app/templates/components/reschedule-event-timeline.hbs
+++ b/ui/app/templates/components/reschedule-event-timeline.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <ol class="timeline">
   {{#if @allocation.nextAllocation}}
     <RescheduleEventRow

--- a/ui/app/templates/components/reschedule-event-timeline.hbs
+++ b/ui/app/templates/components/reschedule-event-timeline.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <ol class="timeline">
   {{#if @allocation.nextAllocation}}
     <RescheduleEventRow

--- a/ui/app/templates/components/scale-events-accordion.hbs
+++ b/ui/app/templates/components/scale-events-accordion.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <ListAccordion data-test-scale-events @source={{@events}} @key="time" as |a|>
   <a.head
     @buttonLabel="details"

--- a/ui/app/templates/components/scale-events-accordion.hbs
+++ b/ui/app/templates/components/scale-events-accordion.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <ListAccordion data-test-scale-events @source={{@events}} @key="time" as |a|>
   <a.head
     @buttonLabel="details"

--- a/ui/app/templates/components/scale-events-chart.hbs
+++ b/ui/app/templates/components/scale-events-chart.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <LineChart
   @timeseries={{true}}
   @xProp="time"

--- a/ui/app/templates/components/scale-events-chart.hbs
+++ b/ui/app/templates/components/scale-events-chart.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <LineChart
   @timeseries={{true}}
   @xProp="time"

--- a/ui/app/templates/components/search-box.hbs
+++ b/ui/app/templates/components/search-box.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="control">
   <span class="prefix-icon">{{x-icon "search"}}</span>
   <input

--- a/ui/app/templates/components/search-box.hbs
+++ b/ui/app/templates/components/search-box.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="control">
   <span class="prefix-icon">{{x-icon "search"}}</span>
   <input

--- a/ui/app/templates/components/server-agent-row.hbs
+++ b/ui/app/templates/components/server-agent-row.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <td data-test-server-name
   {{keyboard-shortcut 
     enumerated=true

--- a/ui/app/templates/components/server-agent-row.hbs
+++ b/ui/app/templates/components/server-agent-row.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <td data-test-server-name
   {{keyboard-shortcut 
     enumerated=true

--- a/ui/app/templates/components/server-subnav.hbs
+++ b/ui/app/templates/components/server-subnav.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="tabs is-subnav" {{did-insert this.keyboard.registerNav type="subnav"}} {{will-destroy this.keyboard.unregisterSubnav}}>
   <ul>
     <li><LinkTo @route="servers.server.index" @model={{this.server}} @activeClass="is-active">Overview</LinkTo></li>

--- a/ui/app/templates/components/server-subnav.hbs
+++ b/ui/app/templates/components/server-subnav.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="tabs is-subnav" {{did-insert this.keyboard.registerNav type="subnav"}} {{will-destroy this.keyboard.unregisterSubnav}}>
   <ul>
     <li><LinkTo @route="servers.server.index" @model={{this.server}} @activeClass="is-active">Overview</LinkTo></li>

--- a/ui/app/templates/components/stats-time-series.hbs
+++ b/ui/app/templates/components/stats-time-series.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <LineChart
   @data={{@data}}
   @dataProp={{@dataProp}}

--- a/ui/app/templates/components/stats-time-series.hbs
+++ b/ui/app/templates/components/stats-time-series.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <LineChart
   @data={{@data}}
   @dataProp={{@dataProp}}

--- a/ui/app/templates/components/stepper-input.hbs
+++ b/ui/app/templates/components/stepper-input.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <label
   data-test-stepper-label
   for="stepper-input-{{this.elementId}}"

--- a/ui/app/templates/components/stepper-input.hbs
+++ b/ui/app/templates/components/stepper-input.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <label
   data-test-stepper-label
   for="stepper-input-{{this.elementId}}"

--- a/ui/app/templates/components/storage-subnav.hbs
+++ b/ui/app/templates/components/storage-subnav.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="tabs is-subnav" {{did-insert this.keyboard.registerNav type="subnav"}} {{will-destroy this.keyboard.unregisterSubnav}}>
   <ul>
     <li data-test-tab="volumes">

--- a/ui/app/templates/components/storage-subnav.hbs
+++ b/ui/app/templates/components/storage-subnav.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="tabs is-subnav" {{did-insert this.keyboard.registerNav type="subnav"}} {{will-destroy this.keyboard.unregisterSubnav}}>
   <ul>
     <li data-test-tab="volumes">

--- a/ui/app/templates/components/streaming-file.hbs
+++ b/ui/app/templates/components/streaming-file.hbs
@@ -1,5 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <code data-test-output>{{this.logger.output}}</code>

--- a/ui/app/templates/components/streaming-file.hbs
+++ b/ui/app/templates/components/streaming-file.hbs
@@ -2,5 +2,4 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <code data-test-output>{{this.logger.output}}</code>

--- a/ui/app/templates/components/svg-patterns.hbs
+++ b/ui/app/templates/components/svg-patterns.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <svg class="svg-pattern" height="0" width="0" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <defs>
 

--- a/ui/app/templates/components/svg-patterns.hbs
+++ b/ui/app/templates/components/svg-patterns.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <svg class="svg-pattern" height="0" width="0" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <defs>
 

--- a/ui/app/templates/components/task-group-row.hbs
+++ b/ui/app/templates/components/task-group-row.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <td data-test-task-group-name>
   <LinkTo @route="jobs.job.task-group" @models={{array this.taskGroup.job this.taskGroup}} class="is-primary">
     {{this.taskGroup.name}}

--- a/ui/app/templates/components/task-group-row.hbs
+++ b/ui/app/templates/components/task-group-row.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <td data-test-task-group-name>
   <LinkTo @route="jobs.job.task-group" @models={{array this.taskGroup.job this.taskGroup}} class="is-primary">
     {{this.taskGroup.name}}

--- a/ui/app/templates/components/task-log.hbs
+++ b/ui/app/templates/components/task-log.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.noConnection}}
   <div data-test-connection-error class="notification is-error">
     <div class="columns">

--- a/ui/app/templates/components/task-log.hbs
+++ b/ui/app/templates/components/task-log.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.noConnection}}
   <div data-test-connection-error class="notification is-error">
     <div class="columns">

--- a/ui/app/templates/components/task-row.hbs
+++ b/ui/app/templates/components/task-row.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <td class="is-narrow">
   {{#unless this.task.driverStatus.healthy}}
     <span

--- a/ui/app/templates/components/task-row.hbs
+++ b/ui/app/templates/components/task-row.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <td class="is-narrow">
   {{#unless this.task.driverStatus.healthy}}
     <span

--- a/ui/app/templates/components/task-subnav.hbs
+++ b/ui/app/templates/components/task-subnav.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div class="tabs is-subnav" {{did-insert this.keyboard.registerNav type="subnav"}} {{will-destroy this.keyboard.unregisterSubnav}}>
   <ul>
     <li><LinkTo @route="allocations.allocation.task.index" @models={{array this.task.allocation this.task}} @activeClass="is-active">Overview</LinkTo></li>

--- a/ui/app/templates/components/task-subnav.hbs
+++ b/ui/app/templates/components/task-subnav.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div class="tabs is-subnav" {{did-insert this.keyboard.registerNav type="subnav"}} {{will-destroy this.keyboard.unregisterSubnav}}>
   <ul>
     <li><LinkTo @route="allocations.allocation.task.index" @models={{array this.task.allocation this.task}} @activeClass="is-active">Overview</LinkTo></li>

--- a/ui/app/templates/components/toggle.hbs
+++ b/ui/app/templates/components/toggle.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{! template-lint-disable }}
 <input
   data-test-input

--- a/ui/app/templates/components/toggle.hbs
+++ b/ui/app/templates/components/toggle.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{! template-lint-disable }}
 <input
   data-test-input

--- a/ui/app/templates/components/tooltip.hbs
+++ b/ui/app/templates/components/tooltip.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <span class="tooltip" aria-label="{{this.text}}">
   {{yield}}
 </span>

--- a/ui/app/templates/components/tooltip.hbs
+++ b/ui/app/templates/components/tooltip.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <span class="tooltip" aria-label="{{this.text}}">
   {{yield}}
 </span>

--- a/ui/app/templates/components/topo-viz.hbs
+++ b/ui/app/templates/components/topo-viz.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div
   data-test-topo-viz
   class="topo-viz {{if this.isSingleColumn "is-single-column"}}"

--- a/ui/app/templates/components/topo-viz.hbs
+++ b/ui/app/templates/components/topo-viz.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div
   data-test-topo-viz
   class="topo-viz {{if this.isSingleColumn "is-single-column"}}"

--- a/ui/app/templates/components/topo-viz/datacenter.hbs
+++ b/ui/app/templates/components/topo-viz/datacenter.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div data-test-topo-viz-datacenter class="boxed-section topo-viz-datacenter">
   <div data-test-topo-viz-datacenter-label class="boxed-section-head is-hollow">
     <strong>{{@datacenter.name}}</strong>

--- a/ui/app/templates/components/topo-viz/datacenter.hbs
+++ b/ui/app/templates/components/topo-viz/datacenter.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div data-test-topo-viz-datacenter class="boxed-section topo-viz-datacenter">
   <div data-test-topo-viz-datacenter-label class="boxed-section-head is-hollow">
     <strong>{{@datacenter.name}}</strong>

--- a/ui/app/templates/components/topo-viz/node.hbs
+++ b/ui/app/templates/components/topo-viz/node.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <div data-test-topo-viz-node class="topo-viz-node {{unless this.allocations.length "is-empty"}}" {{did-insert this.reloadNode}}>
   {{#unless @isDense}}
     <p data-test-label class="label">

--- a/ui/app/templates/components/topo-viz/node.hbs
+++ b/ui/app/templates/components/topo-viz/node.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <div data-test-topo-viz-node class="topo-viz-node {{unless this.allocations.length "is-empty"}}" {{did-insert this.reloadNode}}>
   {{#unless @isDense}}
     <p data-test-label class="label">

--- a/ui/app/templates/components/two-step-button.hbs
+++ b/ui/app/templates/components/two-step-button.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#if this.isIdle}}
   <button
     data-test-idle-button

--- a/ui/app/templates/components/two-step-button.hbs
+++ b/ui/app/templates/components/two-step-button.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.isIdle}}
   <button
     data-test-idle-button

--- a/ui/app/templates/csi.hbs
+++ b/ui/app/templates/csi.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <PageLayout>
   {{outlet}}
 </PageLayout>

--- a/ui/app/templates/csi.hbs
+++ b/ui/app/templates/csi.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <PageLayout>
   {{outlet}}
 </PageLayout>

--- a/ui/app/templates/csi/plugins.hbs
+++ b/ui/app/templates/csi/plugins.hbs
@@ -1,5 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{hash label="Storage" args=(array "csi.index")}} />{{outlet}}

--- a/ui/app/templates/csi/plugins.hbs
+++ b/ui/app/templates/csi/plugins.hbs
@@ -2,5 +2,4 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{hash label="Storage" args=(array "csi.index")}} />{{outlet}}

--- a/ui/app/templates/csi/plugins/index.hbs
+++ b/ui/app/templates/csi/plugins/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "CSI Plugins"}}
 <StorageSubnav />
 <section class="section">

--- a/ui/app/templates/csi/plugins/index.hbs
+++ b/ui/app/templates/csi/plugins/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "CSI Plugins"}}
 <StorageSubnav />
 <section class="section">

--- a/ui/app/templates/csi/plugins/plugin.hbs
+++ b/ui/app/templates/csi/plugins/plugin.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#each this.breadcrumbs as |crumb|}}
   <Breadcrumb @crumb={{crumb}} />
 {{/each}}

--- a/ui/app/templates/csi/plugins/plugin.hbs
+++ b/ui/app/templates/csi/plugins/plugin.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#each this.breadcrumbs as |crumb|}}
   <Breadcrumb @crumb={{crumb}} />
 {{/each}}

--- a/ui/app/templates/csi/plugins/plugin/allocations.hbs
+++ b/ui/app/templates/csi/plugins/plugin/allocations.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "CSI Plugin " this.model.plainId " allocations"}}
 <PluginSubnav @plugin={{this.model}} />
 <section class="section">

--- a/ui/app/templates/csi/plugins/plugin/allocations.hbs
+++ b/ui/app/templates/csi/plugins/plugin/allocations.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "CSI Plugin " this.model.plainId " allocations"}}
 <PluginSubnav @plugin={{this.model}} />
 <section class="section">

--- a/ui/app/templates/csi/plugins/plugin/index.hbs
+++ b/ui/app/templates/csi/plugins/plugin/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "CSI Plugin " this.model.plainId}}
 <PluginSubnav @plugin={{this.model}} />
 <section class="section">

--- a/ui/app/templates/csi/plugins/plugin/index.hbs
+++ b/ui/app/templates/csi/plugins/plugin/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "CSI Plugin " this.model.plainId}}
 <PluginSubnav @plugin={{this.model}} />
 <section class="section">

--- a/ui/app/templates/csi/volumes.hbs
+++ b/ui/app/templates/csi/volumes.hbs
@@ -1,5 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{hash label="Storage" args=(array "csi.index")}} />{{outlet}}

--- a/ui/app/templates/csi/volumes.hbs
+++ b/ui/app/templates/csi/volumes.hbs
@@ -2,5 +2,4 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{hash label="Storage" args=(array "csi.index")}} />{{outlet}}

--- a/ui/app/templates/csi/volumes/index.hbs
+++ b/ui/app/templates/csi/volumes/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "CSI Volumes"}}
 <StorageSubnav />
 <section class="section">

--- a/ui/app/templates/csi/volumes/index.hbs
+++ b/ui/app/templates/csi/volumes/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "CSI Volumes"}}
 <StorageSubnav />
 <section class="section">

--- a/ui/app/templates/csi/volumes/volume.hbs
+++ b/ui/app/templates/csi/volumes/volume.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#each this.breadcrumbs as |crumb|}}
   <Breadcrumb @crumb={{crumb}} />
 {{/each}}

--- a/ui/app/templates/csi/volumes/volume.hbs
+++ b/ui/app/templates/csi/volumes/volume.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{#each this.breadcrumbs as |crumb|}}
   <Breadcrumb @crumb={{crumb}} />
 {{/each}}

--- a/ui/app/templates/evaluations.hbs
+++ b/ui/app/templates/evaluations.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{hash label="Evaluations" args=(array "evaluations.index")}} />
 <PageLayout>
   <PortalTarget @name="eval-detail-portal" />

--- a/ui/app/templates/evaluations.hbs
+++ b/ui/app/templates/evaluations.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{hash label="Evaluations" args=(array "evaluations.index")}} />
 <PageLayout>
   <PortalTarget @name="eval-detail-portal" />

--- a/ui/app/templates/evaluations/index.hbs
+++ b/ui/app/templates/evaluations/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Evaluations"}}
 {{did-update this.notifyEvalChange this.currentEval}}
 <section class="section">

--- a/ui/app/templates/evaluations/index.hbs
+++ b/ui/app/templates/evaluations/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Evaluations"}}
 {{did-update this.notifyEvalChange this.currentEval}}
 <section class="section">

--- a/ui/app/templates/exec-loading.hbs
+++ b/ui/app/templates/exec-loading.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Exec"}}
 <nav class="navbar is-popup">
   <div class="navbar-brand">

--- a/ui/app/templates/exec-loading.hbs
+++ b/ui/app/templates/exec-loading.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Exec"}}
 <nav class="navbar is-popup">
   <div class="navbar-brand">

--- a/ui/app/templates/exec.hbs
+++ b/ui/app/templates/exec.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Exec"}}
 <nav class="navbar is-popup">
   <div class="navbar-brand">

--- a/ui/app/templates/exec.hbs
+++ b/ui/app/templates/exec.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Exec"}}
 <nav class="navbar is-popup">
   <div class="navbar-brand">

--- a/ui/app/templates/index.hbs
+++ b/ui/app/templates/index.hbs
@@ -1,4 +1,5 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+

--- a/ui/app/templates/index.hbs
+++ b/ui/app/templates/index.hbs
@@ -2,4 +2,3 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-

--- a/ui/app/templates/jobs.hbs
+++ b/ui/app/templates/jobs.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{hash label="Jobs" args=(array "jobs.index")}} />
 <PageLayout>
   {{outlet}}

--- a/ui/app/templates/jobs.hbs
+++ b/ui/app/templates/jobs.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{hash label="Jobs" args=(array "jobs.index")}} />
 <PageLayout>
   {{outlet}}

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Jobs"}}
 <section class="section">
   <div class="toolbar">

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Jobs"}}
 <section class="section">
   <div class="toolbar">

--- a/ui/app/templates/jobs/job.hbs
+++ b/ui/app/templates/jobs/job.hbs
@@ -2,5 +2,4 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{hash type="job" job=this.job}} />{{outlet}}

--- a/ui/app/templates/jobs/job.hbs
+++ b/ui/app/templates/jobs/job.hbs
@@ -1,5 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{hash type="job" job=this.job}} />{{outlet}}

--- a/ui/app/templates/jobs/job/allocations.hbs
+++ b/ui/app/templates/jobs/job/allocations.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Job " this.job.name " allocations"}}
 <JobSubnav @job={{this.job}} />
 <section class="section">

--- a/ui/app/templates/jobs/job/allocations.hbs
+++ b/ui/app/templates/jobs/job/allocations.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Job " this.job.name " allocations"}}
 <JobSubnav @job={{this.job}} />
 <section class="section">

--- a/ui/app/templates/jobs/job/clients.hbs
+++ b/ui/app/templates/jobs/job/clients.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Job " this.job.name " clients"}}
 <JobSubnav @job={{this.job}} />
 <section class="section">

--- a/ui/app/templates/jobs/job/clients.hbs
+++ b/ui/app/templates/jobs/job/clients.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Job " this.job.name " clients"}}
 <JobSubnav @job={{this.job}} />
 <section class="section">

--- a/ui/app/templates/jobs/job/definition.hbs
+++ b/ui/app/templates/jobs/job/definition.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Job " this.job.name " definition"}}
 <JobSubnav @job={{this.job}} />
 <section class="section">

--- a/ui/app/templates/jobs/job/definition.hbs
+++ b/ui/app/templates/jobs/job/definition.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Job " this.job.name " definition"}}
 <JobSubnav @job={{this.job}} />
 <section class="section">

--- a/ui/app/templates/jobs/job/deployments.hbs
+++ b/ui/app/templates/jobs/job/deployments.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Job " this.job.name " deployments"}}
 <JobSubnav @job={{this.job}} />
 <section class="section">

--- a/ui/app/templates/jobs/job/deployments.hbs
+++ b/ui/app/templates/jobs/job/deployments.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Job " this.job.name " deployments"}}
 <JobSubnav @job={{this.job}} />
 <section class="section">

--- a/ui/app/templates/jobs/job/dispatch.hbs
+++ b/ui/app/templates/jobs/job/dispatch.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{hash label="Dispatch" args=(array "jobs.job.dispatch")}} />
 {{page-title "Dispatch new " this.model.name}}
 <JobSubnav @job={{this.model}} />

--- a/ui/app/templates/jobs/job/dispatch.hbs
+++ b/ui/app/templates/jobs/job/dispatch.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{hash label="Dispatch" args=(array "jobs.job.dispatch")}} />
 {{page-title "Dispatch new " this.model.name}}
 <JobSubnav @job={{this.model}} />

--- a/ui/app/templates/jobs/job/evaluations.hbs
+++ b/ui/app/templates/jobs/job/evaluations.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Job " this.job.name " evaluations"}}
 <JobSubnav @job={{this.job}} />
 <section class="section">

--- a/ui/app/templates/jobs/job/evaluations.hbs
+++ b/ui/app/templates/jobs/job/evaluations.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Job " this.job.name " evaluations"}}
 <JobSubnav @job={{this.job}} />
 <section class="section">

--- a/ui/app/templates/jobs/job/index.hbs
+++ b/ui/app/templates/jobs/job/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Job " this.model.name}}
 {{component
   (concat "job-page/" this.model.templateType)

--- a/ui/app/templates/jobs/job/index.hbs
+++ b/ui/app/templates/jobs/job/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Job " this.model.name}}
 {{component
   (concat "job-page/" this.model.templateType)

--- a/ui/app/templates/jobs/job/loading.hbs
+++ b/ui/app/templates/jobs/job/loading.hbs
@@ -2,6 +2,5 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <JobSubnav @job={{this.job}} />
 <section class="section has-text-centered"><LoadingSpinner /></section>

--- a/ui/app/templates/jobs/job/loading.hbs
+++ b/ui/app/templates/jobs/job/loading.hbs
@@ -1,6 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <JobSubnav @job={{this.job}} />
 <section class="section has-text-centered"><LoadingSpinner /></section>

--- a/ui/app/templates/jobs/job/services.hbs
+++ b/ui/app/templates/jobs/job/services.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Job " @model.name " services"}}
 <JobSubnav @job={{@model}} />
 {{outlet}}

--- a/ui/app/templates/jobs/job/services.hbs
+++ b/ui/app/templates/jobs/job/services.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Job " @model.name " services"}}
 <JobSubnav @job={{@model}} />
 {{outlet}}

--- a/ui/app/templates/jobs/job/services/index.hbs
+++ b/ui/app/templates/jobs/job/services/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <section class="section service-list">
 	{{#if this.sortedServices.length}}
 		<ListTable

--- a/ui/app/templates/jobs/job/services/index.hbs
+++ b/ui/app/templates/jobs/job/services/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <section class="section service-list">
 	{{#if this.sortedServices.length}}
 		<ListTable

--- a/ui/app/templates/jobs/job/services/service.hbs
+++ b/ui/app/templates/jobs/job/services/service.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <section class="section service-list">
   <h1 class="title">
     <LinkTo class="back-link" @route="jobs.job.services">

--- a/ui/app/templates/jobs/job/services/service.hbs
+++ b/ui/app/templates/jobs/job/services/service.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <section class="section service-list">
   <h1 class="title">
     <LinkTo class="back-link" @route="jobs.job.services">

--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{this.breadcrumb}} />
 {{page-title "Task group " this.model.name " - Job " this.model.job.name}}
 <div class="tabs is-subnav">

--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{this.breadcrumb}} />
 {{page-title "Task group " this.model.name " - Job " this.model.job.name}}
 <div class="tabs is-subnav">

--- a/ui/app/templates/jobs/job/versions.hbs
+++ b/ui/app/templates/jobs/job/versions.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Job " this.job.name " versions"}}
 <JobSubnav @job={{this.job}} />
 <section class="section">

--- a/ui/app/templates/jobs/job/versions.hbs
+++ b/ui/app/templates/jobs/job/versions.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Job " this.job.name " versions"}}
 <JobSubnav @job={{this.job}} />
 <section class="section">

--- a/ui/app/templates/jobs/loading.hbs
+++ b/ui/app/templates/jobs/loading.hbs
@@ -1,5 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <section class="section has-text-centered"><LoadingSpinner /></section>

--- a/ui/app/templates/jobs/loading.hbs
+++ b/ui/app/templates/jobs/loading.hbs
@@ -2,5 +2,4 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <section class="section has-text-centered"><LoadingSpinner /></section>

--- a/ui/app/templates/jobs/run/index.hbs
+++ b/ui/app/templates/jobs/run/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{hash label="Run" args=(array "jobs.run")}} />
 {{page-title "Run a job"}}
 <section class="section">

--- a/ui/app/templates/jobs/run/index.hbs
+++ b/ui/app/templates/jobs/run/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{hash label="Run" args=(array "jobs.run")}} />
 {{page-title "Run a job"}}
 <section class="section">

--- a/ui/app/templates/jobs/run/templates/index.hbs
+++ b/ui/app/templates/jobs/run/templates/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <section class="section">
     <header class="run-job-header">
         <h1 class="title is-3">Choose a template</h1>

--- a/ui/app/templates/jobs/run/templates/index.hbs
+++ b/ui/app/templates/jobs/run/templates/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <section class="section">
     <header class="run-job-header">
         <h1 class="title is-3">Choose a template</h1>

--- a/ui/app/templates/jobs/run/templates/manage.hbs
+++ b/ui/app/templates/jobs/run/templates/manage.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Manage templates"}}
 <section class="section">
     <header class="run-job-header">

--- a/ui/app/templates/jobs/run/templates/manage.hbs
+++ b/ui/app/templates/jobs/run/templates/manage.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Manage templates"}}
 <section class="section">
     <header class="run-job-header">

--- a/ui/app/templates/jobs/run/templates/new.hbs
+++ b/ui/app/templates/jobs/run/templates/new.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Create a custom template"}}
 <section class="section">
     <header class="run-job-header">

--- a/ui/app/templates/jobs/run/templates/new.hbs
+++ b/ui/app/templates/jobs/run/templates/new.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Create a custom template"}}
 <section class="section">
     <header class="run-job-header">

--- a/ui/app/templates/jobs/run/templates/template.hbs
+++ b/ui/app/templates/jobs/run/templates/template.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Edit template"}}
 <section class="section">
     <header class="run-job-header">

--- a/ui/app/templates/jobs/run/templates/template.hbs
+++ b/ui/app/templates/jobs/run/templates/template.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Edit template"}}
 <section class="section">
     <header class="run-job-header">

--- a/ui/app/templates/loading.hbs
+++ b/ui/app/templates/loading.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <PageLayout>
   <section class="section has-text-centered"><LoadingSpinner /></section>
 </PageLayout>

--- a/ui/app/templates/loading.hbs
+++ b/ui/app/templates/loading.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <PageLayout>
   <section class="section has-text-centered"><LoadingSpinner /></section>
 </PageLayout>

--- a/ui/app/templates/oidc-mock.hbs
+++ b/ui/app/templates/oidc-mock.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Mock OIDC Test Page"}}
 
 <section class="mock-sso-provider">

--- a/ui/app/templates/oidc-mock.hbs
+++ b/ui/app/templates/oidc-mock.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Mock OIDC Test Page"}}
 
 <section class="mock-sso-provider">

--- a/ui/app/templates/optimize.hbs
+++ b/ui/app/templates/optimize.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{hash label="Recommendations" args=(array "optimize")}} />
 <PageLayout>
   <section class="section">

--- a/ui/app/templates/optimize.hbs
+++ b/ui/app/templates/optimize.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{hash label="Recommendations" args=(array "optimize")}} />
 <PageLayout>
   <section class="section">

--- a/ui/app/templates/optimize/summary.hbs
+++ b/ui/app/templates/optimize/summary.hbs
@@ -2,6 +2,5 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{this.breadcrumb}} />
 <Das::RecommendationCard @summary={{@model}} @proceed={{this.optimizeController.proceed}} />

--- a/ui/app/templates/optimize/summary.hbs
+++ b/ui/app/templates/optimize/summary.hbs
@@ -1,6 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{this.breadcrumb}} />
 <Das::RecommendationCard @summary={{@model}} @proceed={{this.optimizeController.proceed}} />

--- a/ui/app/templates/policies.hbs
+++ b/ui/app/templates/policies.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{hash label="Policies" args=(array "policies.index")}} />
 <PageLayout>
   {{outlet}}

--- a/ui/app/templates/policies.hbs
+++ b/ui/app/templates/policies.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{hash label="Policies" args=(array "policies.index")}} />
 <PageLayout>
   {{outlet}}

--- a/ui/app/templates/policies/index.hbs
+++ b/ui/app/templates/policies/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Policies"}}
 <section class="section">
   <div class="toolbar">

--- a/ui/app/templates/policies/index.hbs
+++ b/ui/app/templates/policies/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Policies"}}
 <section class="section">
   <div class="toolbar">

--- a/ui/app/templates/policies/new.hbs
+++ b/ui/app/templates/policies/new.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{hash label="New" args=(array "policies.new")}} />
 {{page-title "Create Policy"}}
 <section class="section">

--- a/ui/app/templates/policies/new.hbs
+++ b/ui/app/templates/policies/new.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{hash label="New" args=(array "policies.new")}} />
 {{page-title "Create Policy"}}
 <section class="section">

--- a/ui/app/templates/policies/policy.hbs
+++ b/ui/app/templates/policies/policy.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{hash label=this.policy.name args=(array "policies.policy" this.policy.name)}} />
 {{page-title "Policy"}}
 <section class="section">

--- a/ui/app/templates/policies/policy.hbs
+++ b/ui/app/templates/policies/policy.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{hash label=this.policy.name args=(array "policies.policy" this.policy.name)}} />
 {{page-title "Policy"}}
 <section class="section">

--- a/ui/app/templates/servers.hbs
+++ b/ui/app/templates/servers.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{hash label="Servers" args=(array "servers.index")}} />
 <PageLayout>
   {{outlet}}

--- a/ui/app/templates/servers.hbs
+++ b/ui/app/templates/servers.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{hash label="Servers" args=(array "servers.index")}} />
 <PageLayout>
   {{outlet}}

--- a/ui/app/templates/servers/index.hbs
+++ b/ui/app/templates/servers/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Servers"}}
 <section class="section">
   {{#if this.isForbidden}}

--- a/ui/app/templates/servers/index.hbs
+++ b/ui/app/templates/servers/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Servers"}}
 <section class="section">
   {{#if this.isForbidden}}

--- a/ui/app/templates/servers/loading.hbs
+++ b/ui/app/templates/servers/loading.hbs
@@ -2,5 +2,4 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
   <section class="section has-text-centered"><LoadingSpinner /></section>

--- a/ui/app/templates/servers/loading.hbs
+++ b/ui/app/templates/servers/loading.hbs
@@ -1,5 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
   <section class="section has-text-centered"><LoadingSpinner /></section>

--- a/ui/app/templates/servers/server.hbs
+++ b/ui/app/templates/servers/server.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb
   @crumb={{hash title="Server" label=this.server.name args=(array "servers.server" this.server.id)}}
 />

--- a/ui/app/templates/servers/server.hbs
+++ b/ui/app/templates/servers/server.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb
   @crumb={{hash title="Server" label=this.server.name args=(array "servers.server" this.server.id)}}
 />

--- a/ui/app/templates/servers/server/index.hbs
+++ b/ui/app/templates/servers/server/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Server " this.model.name}}
 <ServerSubnav @server={{this.model}} />
 <section class="section">

--- a/ui/app/templates/servers/server/index.hbs
+++ b/ui/app/templates/servers/server/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Server " this.model.name}}
 <ServerSubnav @server={{this.model}} />
 <section class="section">

--- a/ui/app/templates/servers/server/monitor.hbs
+++ b/ui/app/templates/servers/server/monitor.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Server " this.model.name}}
 <ServerSubnav @server={{this.model}} />
 <section class="section is-full-width">

--- a/ui/app/templates/servers/server/monitor.hbs
+++ b/ui/app/templates/servers/server/monitor.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Server " this.model.name}}
 <ServerSubnav @server={{this.model}} />
 <section class="section is-full-width">

--- a/ui/app/templates/settings.hbs
+++ b/ui/app/templates/settings.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <PageLayout>
   {{outlet}}
 </PageLayout>

--- a/ui/app/templates/settings.hbs
+++ b/ui/app/templates/settings.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <PageLayout>
   {{outlet}}
 </PageLayout>

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Authorization"}}
 <section class="section authorization-page">
   {{#if this.isValidatingToken}}

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Authorization"}}
 <section class="section authorization-page">
   {{#if this.isValidatingToken}}

--- a/ui/app/templates/topology.hbs
+++ b/ui/app/templates/topology.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{hash label="Topology" args=(array "topology")}} />
 {{page-title "Cluster Topology"}}
 <PageLayout>

--- a/ui/app/templates/topology.hbs
+++ b/ui/app/templates/topology.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{hash label="Topology" args=(array "topology")}} />
 {{page-title "Cluster Topology"}}
 <PageLayout>

--- a/ui/app/templates/variables.hbs
+++ b/ui/app/templates/variables.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <Breadcrumb @crumb={{hash label="Variables" args=(array "variables.index")}} />
 <PageLayout>
   {{outlet}}

--- a/ui/app/templates/variables.hbs
+++ b/ui/app/templates/variables.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <Breadcrumb @crumb={{hash label="Variables" args=(array "variables.index")}} />
 <PageLayout>
   {{outlet}}

--- a/ui/app/templates/variables/index.hbs
+++ b/ui/app/templates/variables/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Variables"}}
 <section class="section">
   <div class="toolbar">

--- a/ui/app/templates/variables/index.hbs
+++ b/ui/app/templates/variables/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Variables"}}
 <section class="section">
   <div class="toolbar">

--- a/ui/app/templates/variables/new.hbs
+++ b/ui/app/templates/variables/new.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "New Variable"}}
 <Breadcrumb @crumb={{hash label="New" args=(array "variables.new")}} />
 

--- a/ui/app/templates/variables/new.hbs
+++ b/ui/app/templates/variables/new.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "New Variable"}}
 <Breadcrumb @crumb={{hash label="New" args=(array "variables.new")}} />
 

--- a/ui/app/templates/variables/path.hbs
+++ b/ui/app/templates/variables/path.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Variables: " this.absolutePath}}
 {{#each this.breadcrumbs as |crumb|}}
   <Breadcrumb @crumb={{crumb}} />

--- a/ui/app/templates/variables/path.hbs
+++ b/ui/app/templates/variables/path.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Variables: " this.absolutePath}}
 {{#each this.breadcrumbs as |crumb|}}
   <Breadcrumb @crumb={{crumb}} />

--- a/ui/app/templates/variables/variable.hbs
+++ b/ui/app/templates/variables/variable.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Variables: " this.model.path}}
 {{#each this.breadcrumbs as |crumb|}}
   <Breadcrumb @crumb={{crumb}} />

--- a/ui/app/templates/variables/variable.hbs
+++ b/ui/app/templates/variables/variable.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Variables: " this.model.path}}
 {{#each this.breadcrumbs as |crumb|}}
   <Breadcrumb @crumb={{crumb}} />

--- a/ui/app/templates/variables/variable/edit.hbs
+++ b/ui/app/templates/variables/variable/edit.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 {{page-title "Edit Variable"}}
 
 <h1 class="title variable-title">

--- a/ui/app/templates/variables/variable/edit.hbs
+++ b/ui/app/templates/variables/variable/edit.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{page-title "Edit Variable"}}
 
 <h1 class="title variable-title">

--- a/ui/app/templates/variables/variable/index.hbs
+++ b/ui/app/templates/variables/variable/index.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
-}}
+~}}
+
 <h1 class="variable-title title with-flex">
   <div>
     <FlightIcon @name="file-text" />

--- a/ui/app/templates/variables/variable/index.hbs
+++ b/ui/app/templates/variables/variable/index.hbs
@@ -2,7 +2,6 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 <h1 class="variable-title title with-flex">
   <div>
     <FlightIcon @name="file-text" />


### PR DESCRIPTION
We were seeing test failures in main related to log-content equivalence tests, as well as some flakey percy vertical spacing issues, that seem to point to the newline after copyright headers. This PR attempts to remove that newline across all our .hbs files in the ui, to see if those problems are resolved.

![image](https://user-images.githubusercontent.com/713991/231487271-1b8f1691-2d1d-48eb-8846-3e914f6737e1.png)
![image](https://user-images.githubusercontent.com/713991/231487293-3ec770ae-ec6b-4df9-9644-7f011ba5cb75.png)
