### PR TITLE
Add the ability to disable rescheduling of lost tasks. Implements issue #10366

### DIFF
--- a/.changelog/16867.txt
+++ b/.changelog/16867.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+**Reschedule on Lost**: Adds the ability to prevent tasks on down nodes from being rescheduled
+```

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -310,8 +310,9 @@ func TestJobs_Canonicalize(t *testing.T) {
 				},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:  pointerOf(""),
-						Count: pointerOf(1),
+						Name:             pointerOf(""),
+						Count:            pointerOf(1),
+						RescheduleOnLost: pointerOf(true),
 						EphemeralDisk: &EphemeralDisk{
 							Sticky:  pointerOf(false),
 							Migrate: pointerOf(false),
@@ -394,8 +395,9 @@ func TestJobs_Canonicalize(t *testing.T) {
 				JobModifyIndex:    pointerOf(uint64(0)),
 				TaskGroups: []*TaskGroup{
 					{
-						Name:  pointerOf(""),
-						Count: pointerOf(1),
+						Name:             pointerOf(""),
+						Count:            pointerOf(1),
+						RescheduleOnLost: pointerOf(true),
 						EphemeralDisk: &EphemeralDisk{
 							Sticky:  pointerOf(false),
 							Migrate: pointerOf(false),
@@ -545,8 +547,9 @@ func TestJobs_Canonicalize(t *testing.T) {
 				},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:  pointerOf("cache"),
-						Count: pointerOf(1),
+						Name:             pointerOf("cache"),
+						Count:            pointerOf(1),
+						RescheduleOnLost: pointerOf(true),
 						RestartPolicy: &RestartPolicy{
 							Interval: pointerOf(5 * time.Minute),
 							Attempts: pointerOf(10),
@@ -655,8 +658,9 @@ func TestJobs_Canonicalize(t *testing.T) {
 				},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:  pointerOf("cache"),
-						Count: pointerOf(1),
+						Name:             pointerOf("cache"),
+						Count:            pointerOf(1),
+						RescheduleOnLost: pointerOf(true),
 						RestartPolicy: &RestartPolicy{
 							Interval: pointerOf(5 * time.Minute),
 							Attempts: pointerOf(10),
@@ -913,8 +917,9 @@ func TestJobs_Canonicalize(t *testing.T) {
 				},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:  pointerOf("bar"),
-						Count: pointerOf(1),
+						Name:             pointerOf("bar"),
+						Count:            pointerOf(1),
+						RescheduleOnLost: pointerOf(true),
 						EphemeralDisk: &EphemeralDisk{
 							Sticky:  pointerOf(false),
 							Migrate: pointerOf(false),
@@ -1018,7 +1023,8 @@ func TestJobs_Canonicalize(t *testing.T) {
 				ParentID: pointerOf("lol"),
 				TaskGroups: []*TaskGroup{
 					{
-						Name: pointerOf("bar"),
+						Name:             pointerOf("bar"),
+						RescheduleOnLost: pointerOf(true),
 						RestartPolicy: &RestartPolicy{
 							Delay:    pointerOf(15 * time.Second),
 							Attempts: pointerOf(2),

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -455,6 +455,7 @@ type TaskGroup struct {
 	MaxClientDisconnect       *time.Duration            `mapstructure:"max_client_disconnect" hcl:"max_client_disconnect,optional"`
 	Scaling                   *ScalingPolicy            `hcl:"scaling,block"`
 	Consul                    *Consul                   `hcl:"consul,block"`
+	RescheduleOnLost          *bool                     `hcl:"reschedule_on_lost,optional"`
 }
 
 // NewTaskGroup creates a new TaskGroup.
@@ -573,7 +574,9 @@ func (g *TaskGroup) Canonicalize(job *Job) {
 	for _, s := range g.Services {
 		s.Canonicalize(nil, g, job)
 	}
-
+	if g.RescheduleOnLost == nil {
+		g.RescheduleOnLost = pointerOf(true)
+	}
 }
 
 // These needs to be in sync with DefaultServiceJobRestartPolicy in

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1062,6 +1062,12 @@ func ApiTgToStructsTG(job *structs.Job, taskGroup *api.TaskGroup, tg *structs.Ta
 		Mode:     *taskGroup.RestartPolicy.Mode,
 	}
 
+	if taskGroup.RescheduleOnLost == nil {
+		tg.RescheduleOnLost = true
+	} else {
+		tg.RescheduleOnLost = *taskGroup.RescheduleOnLost
+	}
+
 	if taskGroup.ShutdownDelay != nil {
 		tg.ShutdownDelay = taskGroup.ShutdownDelay
 	}

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -2916,6 +2916,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						Operand: "z",
 					},
 				},
+				RescheduleOnLost: true,
 				Affinities: []*structs.Affinity{
 					{
 						LTarget: "x",
@@ -3389,8 +3390,9 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 		},
 		TaskGroups: []*structs.TaskGroup{
 			{
-				Name:  "group1",
-				Count: 5,
+				Name:             "group1",
+				Count:            5,
+				RescheduleOnLost: true,
 				Constraints: []*structs.Constraint{
 					{
 						LTarget: "x",

--- a/nomad/mock/job.go
+++ b/nomad/mock/job.go
@@ -30,8 +30,9 @@ func Job() *structs.Job {
 		},
 		TaskGroups: []*structs.TaskGroup{
 			{
-				Name:  "web",
-				Count: 10,
+				Name:             "web",
+				Count:            10,
+				RescheduleOnLost: true,
 				Constraints: []*structs.Constraint{
 					{
 						LTarget: "${attr.consul.version}",

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -863,32 +863,38 @@ func TestJobDiff(t *testing.T) {
 			Old: &Job{
 				TaskGroups: []*TaskGroup{
 					{
-						Name:  "foo",
-						Count: 1,
+						Name:             "foo",
+						Count:            1,
+						RescheduleOnLost: true,
 					},
 					{
-						Name:  "bar",
-						Count: 1,
+						Name:             "bar",
+						Count:            1,
+						RescheduleOnLost: false,
 					},
 					{
-						Name:  "baz",
-						Count: 1,
+						Name:             "baz",
+						Count:            1,
+						RescheduleOnLost: true,
 					},
 				},
 			},
 			New: &Job{
 				TaskGroups: []*TaskGroup{
 					{
-						Name:  "bar",
-						Count: 1,
+						Name:             "bar",
+						Count:            1,
+						RescheduleOnLost: false,
 					},
 					{
-						Name:  "baz",
-						Count: 2,
+						Name:             "baz",
+						Count:            2,
+						RescheduleOnLost: true,
 					},
 					{
-						Name:  "bam",
-						Count: 1,
+						Name:             "bam",
+						Count:            1,
+						RescheduleOnLost: true,
 					},
 				},
 			},
@@ -904,6 +910,12 @@ func TestJobDiff(t *testing.T) {
 								Name: "Count",
 								Old:  "",
 								New:  "1",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "RescheduleOnLost",
+								Old:  "",
+								New:  "true",
 							},
 						},
 					},
@@ -931,6 +943,12 @@ func TestJobDiff(t *testing.T) {
 								Type: DiffTypeDeleted,
 								Name: "Count",
 								Old:  "1",
+								New:  "",
+							},
+							{
+								Type: DiffTypeDeleted,
+								Name: "RescheduleOnLost",
+								Old:  "true",
 								New:  "",
 							},
 						},
@@ -1447,6 +1465,31 @@ func TestTaskGroupDiff(t *testing.T) {
 						Name: "Meta[foo]",
 						Old:  "bar",
 						New:  "baz",
+					},
+				},
+			},
+		},
+		{
+			TestCase: "Reschedule on lost diff",
+			Old: &TaskGroup{
+				Name:             "foo",
+				Count:            100,
+				RescheduleOnLost: true,
+			},
+			New: &TaskGroup{
+				Name:             "foo",
+				Count:            100,
+				RescheduleOnLost: false,
+			},
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Name: "foo",
+				Fields: []*FieldDiff{
+					{
+						Type: DiffTypeEdited,
+						Name: "RescheduleOnLost",
+						Old:  "true",
+						New:  "false",
 					},
 				},
 			},

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6496,6 +6496,11 @@ type TaskGroup struct {
 	// MaxClientDisconnect, if set, configures the client to allow placed
 	// allocations for tasks in this group to attempt to resume running without a restart.
 	MaxClientDisconnect *time.Duration
+
+	// RescheduleOnLost is used to control how allocations on disconnected
+	// nodes are handled. For backwards compatibility, it defaults to true.
+	// When true, such jobs are rescheduled.
+	RescheduleOnLost bool
 }
 
 func (tg *TaskGroup) Copy() *TaskGroup {

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -535,7 +535,7 @@ func (a *allocReconciler) computeGroup(groupName string, all allocSet) bool {
 	// placements can be made without any other consideration.
 	deploymentPlaceReady := !a.deploymentPaused && !a.deploymentFailed && !isCanarying
 
-	underProvisionedBy = a.computeReplacements(deploymentPlaceReady, desiredChanges, place, rescheduleNow, lost, underProvisionedBy)
+	underProvisionedBy = a.computeReplacements(tg, deploymentPlaceReady, desiredChanges, place, rescheduleNow, lost, underProvisionedBy)
 
 	if deploymentPlaceReady {
 		a.computeDestructiveUpdates(destructive, underProvisionedBy, desiredChanges, tg)
@@ -753,25 +753,30 @@ func (a *allocReconciler) computePlacements(group *structs.TaskGroup,
 	// Add replacements for disconnected and lost allocs up to group.Count
 	existing := len(untainted) + len(migrate) + len(reschedule)
 
-	// Add replacements for lost
-	for _, alloc := range lost {
-		if existing >= group.Count {
-			// Reached desired count, do not replace remaining lost
-			// allocs
-			break
-		}
+	if group.RescheduleOnLost {
+		// Add replacements for lost
+		for _, alloc := range lost {
+			if existing >= group.Count {
+				// Reached desired count, do not replace remaining lost
+				// allocs
+				break
+			}
 
-		existing++
-		place = append(place, allocPlaceResult{
-			name:               alloc.Name,
-			taskGroup:          group,
-			previousAlloc:      alloc,
-			reschedule:         false,
-			canary:             alloc.DeploymentStatus.IsCanary(),
-			downgradeNonCanary: isCanarying && !alloc.DeploymentStatus.IsCanary(),
-			minJobVersion:      alloc.Job.Version,
-			lost:               true,
-		})
+			existing++
+			place = append(place, allocPlaceResult{
+				name:               alloc.Name,
+				taskGroup:          group,
+				previousAlloc:      alloc,
+				reschedule:         false,
+				canary:             alloc.DeploymentStatus.IsCanary(),
+				downgradeNonCanary: isCanarying && !alloc.DeploymentStatus.IsCanary(),
+				minJobVersion:      alloc.Job.Version,
+				lost:               true,
+			})
+		}
+	} else {
+		//Don't add placements for lost where RescheduleOnLost is not enabled
+		existing += len(lost)
 	}
 
 	// Add remaining placement results
@@ -793,7 +798,7 @@ func (a *allocReconciler) computePlacements(group *structs.TaskGroup,
 // and if the placement is already rescheduling or part of a failed deployment.
 // The input deploymentPlaceReady is calculated as the deployment is not paused, failed, or canarying.
 // It returns the number of allocs still needed.
-func (a *allocReconciler) computeReplacements(deploymentPlaceReady bool, desiredChanges *structs.DesiredUpdates,
+func (a *allocReconciler) computeReplacements(tg *structs.TaskGroup, deploymentPlaceReady bool, desiredChanges *structs.DesiredUpdates,
 	place []allocPlaceResult, rescheduleNow, lost allocSet, underProvisionedBy int) int {
 
 	// Disconnecting allocs are not failing, but are included in rescheduleNow.
@@ -827,7 +832,7 @@ func (a *allocReconciler) computeReplacements(deploymentPlaceReady bool, desired
 
 	// If allocs have been lost, determine the number of replacements that are needed
 	// and add placements to the result for the lost allocs.
-	if len(lost) != 0 {
+	if len(lost) != 0 && tg.RescheduleOnLost {
 		allowed := helper.Min(len(lost), len(place))
 		desiredChanges.Place += uint64(allowed)
 		a.result.place = append(a.result.place, place[:allowed]...)
@@ -966,7 +971,11 @@ func (a *allocReconciler) computeStop(group *structs.TaskGroup, nameIndex *alloc
 	// Mark all lost allocations for stop.
 	var stop allocSet
 	stop = stop.union(lost)
-	a.markDelayed(lost, structs.AllocClientStatusLost, allocLost, followupEvals)
+	if group.RescheduleOnLost {
+		a.markDelayed(lost, structs.AllocClientStatusLost, allocLost, followupEvals)
+	} else {
+		a.markStop(lost, structs.AllocClientStatusLost, allocLost)
+	}
 
 	// If we are still deploying or creating canaries, don't stop them
 	if isCanarying {

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -214,6 +214,11 @@ func tasksUpdated(jobA, jobB *structs.Job, taskGroup string) comparison {
 		return difference("number of tasks", lenA, lenB)
 	}
 
+	// Check for rescheduleOnLost changes
+	if a.RescheduleOnLost != b.RescheduleOnLost {
+		return difference("reschedule on lost", a.RescheduleOnLost, b.RescheduleOnLost)
+	}
+
 	// Check ephemeral disk
 	if !a.EphemeralDisk.Equal(b.EphemeralDisk) {
 		return difference("ephemeral disk", a.EphemeralDisk, b.EphemeralDisk)

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -508,7 +508,12 @@ func TestTasksUpdated(t *testing.T) {
 
 	// Compare changed Template ErrMissingKey
 	j30.TaskGroups[0].Tasks[0].Templates[0].ErrMissingKey = true
-	must.True(t, tasksUpdated(j29, j30, name).modified)
+	require.True(t, tasksUpdated(j29, j30, name).modified)
+
+	// Change rescheduleOnLost mode
+	j31 := mock.Job()
+	j31.TaskGroups[0].RescheduleOnLost = false
+	require.True(t, tasksUpdated(j1, j31, name).modified)
 }
 
 func TestTasksUpdated_connectServiceUpdated(t *testing.T) {

--- a/website/content/docs/job-specification/group.mdx
+++ b/website/content/docs/job-specification/group.mdx
@@ -62,6 +62,10 @@ job "docs" {
   rescheduling strategy. Nomad will then attempt to schedule the task on another
   node if any of the group allocation statuses become "failed".
 
+- `reschedule_on_lost` `(bool: true)` - Specifies if a groups tasks can be
+  rescheduled when their allocations become lost. If set to false, jobs with
+  lost tasks will be left in a running state until an operator intervenes.
+
 - `restart` <code>([Restart][]: nil)</code> - Specifies the restart policy for
   all tasks in this group. If omitted, a default policy exists for each job
   type, which can be found in the [restart block documentation][restart].


### PR DESCRIPTION
This adds the ability to prevent tasks being rescheduled when their allocations are lost as suggested in https://github.com/hashicorp/nomad/issues/10366

Jobs with lost allocations are left in the running state and require intervention. Currently, jobs can be stopped manually via the CLI or API. e.g. `nomad job stop`. A future improvement would be to implement `nomad alloc reschedule` as suggested in the issue.