### PR TITLE
Update util_linux.go

### DIFF
--- a/.changelog/16900.txt
+++ b/.changelog/16900.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+fix: Added "/usr/libexec" to the landlocked directories the getter has access to
+```

--- a/client/allocrunner/taskrunner/getter/util_linux.go
+++ b/client/allocrunner/taskrunner/getter/util_linux.go
@@ -63,6 +63,7 @@ func lockdown(allocDir, taskDir string) error {
 		landlock.Dir("/bin", "rx"),
 		landlock.Dir("/usr/bin", "rx"),
 		landlock.Dir("/usr/local/bin", "rx"),
+		landlock.Dir("/usr/libexec", "rx"),
 		landlock.Dir(allocDir, "rwc"),
 		landlock.Dir(taskDir, "rwc"),
 	}


### PR DESCRIPTION
This PR "/usr/libexec" to the landlocked directories the getter has access to, to allow git to call executables in the git-core directories in RHEL style distros

Closes #16899 