### PR TITLE
docs: disable secret scanning for documentation content

### DIFF
--- a/.github/secret-scanning.yml
+++ b/.github/secret-scanning.yml
@@ -1,0 +1,2 @@
+paths-ignore:
+  - "website/content/*"


### PR DESCRIPTION
Examples in the documentation frequently include tokens, including Vault tokens which end up triggering GitHub's secret scanner. Remove these from consideration so that we don't get false positive reports.