### PR TITLE
ci: fix missing import

### DIFF
--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	psstructs "github.com/hashicorp/nomad/plugins/shared/structs"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
Add missing import to fix https://github.com/hashicorp/nomad/actions/runs/4726130915/jobs/8385391229#step:4:3833

Targets `release/1.3.x` only.