### PR TITLE
test: fix quota command autocomplete

### DIFF
--- a/command/quota_inspect_test.go
+++ b/command/quota_inspect_test.go
@@ -98,7 +98,7 @@ func TestQuotaInspectCommand_AutocompleteArgs(t *testing.T) {
 	_, err := client.Quotas().Register(qs, nil)
 	must.NoError(t, err)
 
-	args := complete.Args{Last: "t"}
+	args := complete.Args{Last: "q"}
 	predictor := cmd.AutocompleteArgs()
 
 	res := predictor.Predict(args)


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/16781 modified `testQuotaSpec` to start with a `q` instead of `t`.