### PR TITLE
ui: fix notification service in token controller

### DIFF
--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -23,7 +23,6 @@ export default class Tokens extends Controller {
   @service token;
   @service store;
   @service router;
-  @service notifications;
 
   queryParams = ['code', 'state', 'jwtAuthMethod'];
 


### PR DESCRIPTION
Remove unneeded service injection. This service is not being used in this controller and currently only exists in `main`, causing `release/1.5.x` to [break](https://app.circleci.com/pipelines/github/hashicorp/nomad-enterprise/4640/workflows/c21e8058-80dd-4f5b-8fb6-1217ced4241d/jobs/50445?invite=true#step-107-2759).