### PR TITLE
allocrunner: prevent panic on network manager

### DIFF
--- a/.changelog/16921.txt
+++ b/.changelog/16921.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-client: Prevent a panic when starting jobs without task group network
+client: Prevent a panic when an allocation has a legacy task-level bridge network and uses a driver that does not create a network namespace
 ```

--- a/.changelog/16921.txt
+++ b/.changelog/16921.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Prevent a panic when starting jobs without task group network
+```

--- a/client/allocrunner/network_manager_linux.go
+++ b/client/allocrunner/network_manager_linux.go
@@ -93,7 +93,7 @@ func newNetworkManager(alloc *structs.Allocation, driverManager drivermanager.Ma
 
 			nm = netManager
 			networkInitiator = task.Name
-		} else if tg.Networks[0].Hostname != "" {
+		} else if len(tg.Networks) > 0 && tg.Networks[0].Hostname != "" {
 			// TODO jrasell: remove once the default linux network manager
 			//  supports setting the hostname in bridged mode. This currently
 			//  indicates only Docker supports this, which is true unless a

--- a/client/allocrunner/network_manager_linux_test.go
+++ b/client/allocrunner/network_manager_linux_test.go
@@ -256,6 +256,32 @@ func TestNewNetworkManager(t *testing.T) {
 			err:         true,
 			errContains: "hostname is not currently supported on driver group1",
 		},
+		{
+			name: "legacy task network using exec and bridge",
+			alloc: &structs.Allocation{
+				TaskGroup: "group",
+				Job: &structs.Job{
+					TaskGroups: []*structs.TaskGroup{
+						{
+							Name: "group",
+							Tasks: []*structs.Task{
+								{
+									Name:   "task1",
+									Driver: "group1",
+									Resources: &structs.Resources{
+										Networks: []*structs.NetworkResource{
+											{Mode: "bridge"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			mustInit: false,
+			err:      false,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)


### PR DESCRIPTION
Check the task group network length before trying to access the first element.

I haven't been able to reproduce the problem but the fix seems clear enough.

Closes #16863 