### PR TITLE
rpc: use "+" concatenations in hot path RPC rate limit metrics.

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -515,15 +515,15 @@ func (ai *AuthenticatedIdentity) String() string {
 		return "unauthenticated"
 	}
 	if ai.ACLToken != nil {
-		return fmt.Sprintf("token:%s", ai.ACLToken.AccessorID)
+		return "token:" + ai.ACLToken.AccessorID
 	}
 	if ai.Claims != nil {
-		return fmt.Sprintf("alloc:%s", ai.Claims.AllocationID)
+		return "alloc:" + ai.Claims.AllocationID
 	}
 	if ai.ClientID != "" {
-		return fmt.Sprintf("client:%s", ai.ClientID)
+		return "client:" + ai.ClientID
 	}
-	return fmt.Sprintf("%s:%s", ai.TLSName, ai.RemoteIP.String())
+	return ai.TLSName + ":" + ai.RemoteIP.String()
 }
 
 func (ai *AuthenticatedIdentity) IsExpired(now time.Time) bool {

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -5,6 +5,7 @@ package structs
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"reflect"
 	"strings"
@@ -21,6 +22,62 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAuthenticatedIdentity_String(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name                       string
+		inputAuthenticatedIdentity *AuthenticatedIdentity
+		expectedOutput             string
+	}{
+		{
+			name:                       "nil",
+			inputAuthenticatedIdentity: nil,
+			expectedOutput:             "unauthenticated",
+		},
+		{
+			name: "ACL token",
+			inputAuthenticatedIdentity: &AuthenticatedIdentity{
+				ACLToken: &ACLToken{
+					AccessorID: "my-testing-accessor-id",
+				},
+			},
+			expectedOutput: "token:my-testing-accessor-id",
+		},
+		{
+			name: "alloc claim",
+			inputAuthenticatedIdentity: &AuthenticatedIdentity{
+				Claims: &IdentityClaims{
+					AllocationID: "my-testing-alloc-id",
+				},
+			},
+			expectedOutput: "alloc:my-testing-alloc-id",
+		},
+		{
+			name: "client",
+			inputAuthenticatedIdentity: &AuthenticatedIdentity{
+				ClientID: "my-testing-client-id",
+			},
+			expectedOutput: "client:my-testing-client-id",
+		},
+		{
+			name: "tls remote IP",
+			inputAuthenticatedIdentity: &AuthenticatedIdentity{
+				TLSName:  "my-testing-tls-name",
+				RemoteIP: net.IPv4(192, 168, 135, 232),
+			},
+			expectedOutput: "my-testing-tls-name:192.168.135.232",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := tc.inputAuthenticatedIdentity.String()
+			must.Eq(t, tc.expectedOutput, actualOutput)
+		})
+	}
+}
 
 func TestJob_Validate(t *testing.T) {
 	ci.Parallel(t)


### PR DESCRIPTION
Using the "+" operator is faster than the `fmt` package functions which I think makes sense to use here as they are simple concatenations and in a hot-path. I added some simple tests to ensure the change doesn't alter the behaviour.