### PR TITLE
docs: add missing API field JobACL and fix workload identity headers

### DIFF
--- a/website/content/api-docs/acl/policies.mdx
+++ b/website/content/api-docs/acl/policies.mdx
@@ -82,13 +82,32 @@ The table below shows this endpoint's support for
 
 - `Rules` `(string: <required>)` - Specifies the Policy rules in HCL or JSON format.
 
+- `JobACL` `(JobACL: <optional>)` - Associates the policy with a given
+  namespace, job, group, or task. Refer to [Workload Associated ACL
+  Policies][concepts_workload_identity_acl] for more information.
+
+  - `Namespace` `(string: <optional>)` - The namespace to attach the policy.
+    Required if `JobID` is set.
+
+  - `JobID` `(string: <optional>)` - The job to attach to the policy. Required
+    if `Group` is set.
+
+  - `Group` `(string: <optional>)` - The group to attach to the policy.
+    Required if `Task` is set.
+
+  - `Task` `(string: <optional>)` - The task to attach to the policy.
+
 ### Sample Payload
 
 ```json
 {
   "Name": "my-policy",
   "Description": "This is a great policy",
-  "Rules": ""
+  "Rules": "",
+  "JobACL": {
+    "Namespace": "default",
+    "JobID": "example"
+  }
 }
 ```
 
@@ -165,3 +184,5 @@ $ curl \
     --request DELETE \
     https://localhost:4646/v1/acl/policy/foo
 ```
+
+[concepts_workload_identity_acl]: /nomad/docs/concepts/workload-identity#workload-associated-acl-policies

--- a/website/content/docs/concepts/workload-identity.mdx
+++ b/website/content/docs/concepts/workload-identity.mdx
@@ -21,7 +21,7 @@ includes the following identity claims:
 }
 ```
 
-# Using Workload Identity
+## Using Workload Identity
 
 While Nomad always creates and uses workload identities internally, the JWT is
 not exposed to tasks by default.
@@ -43,7 +43,7 @@ task "example" {
 }
 ```
 
-# Workload Associated ACL Policies
+## Workload Associated ACL Policies
 
 You can associate additional ACL policies with workload identities by passing
 the `-job`, `-group`, and `-task` flags to `nomad acl policy apply`. When Nomad


### PR DESCRIPTION
For some reason the headers are not displayed if they're a level 1 header:
https://developer.hashicorp.com/nomad/docs/concepts/workload-identity