### PR TITLE
cli: fix panic on job plan when -diff=false

### DIFF
--- a/.changelog/16944.txt
+++ b/.changelog/16944.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix panic on job plan when -diff=false
+```

--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -237,9 +237,9 @@ func (c *JobPlanCommand) Run(args []string) int {
 	}
 
 	// Setup the options
-	opts := &api.PlanOptions{}
-	if diff {
-		opts.Diff = true
+	opts := &api.PlanOptions{
+		// Always request the diff so we can tell if there are changes.
+		Diff: true,
 	}
 	if policyOverride {
 		opts.PolicyOverride = true


### PR DESCRIPTION
PR #14492 introduced a new check to return 0 when the `nomad job plan` command returns a diff of type `None`.

But the `-diff` CLI flag was also being used to control whether the plan request should return the diff of not instead of just controlling if the diff was printed.

This means that when `-diff=false` is set the response does not include any diff information, and so the new check panics.

This commit fixes the problem by always requesting a diff and using the `-diff` only for controlling output, as it's currently documented.

Closes https://github.com/hashicorp/nomad/issues/16939