### PR TITLE
docs: fix keyring path in install docs

### DIFF
--- a/website/content/docs/install/index.mdx
+++ b/website/content/docs/install/index.mdx
@@ -84,7 +84,7 @@ $ sudo apt-get update && \
 Add the HashiCorp [GPG key][gpg-key].
 
 ```shell-session
-$ wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /keyrings/hashicorp-archive-keyring.gpg
+$ wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
 ```
 
 Add the official HashiCorp Linux repository.


### PR DESCRIPTION
As noted in https://github.com/hashicorp/nomad/pull/16767#discussion_r1172756817, our fix for adding the keyring had a typo on the path. I checked the equivalent tutorials repo PR and it was correct there.