### PR TITLE
[ui] Fixed: Evaluations sidebar/response not scrollable

### DIFF
--- a/.changelog/16960.txt
+++ b/.changelog/16960.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix a visual bug where evaluation response wasn't scrollable in the Web UI.
+```

--- a/ui/app/components/evaluation-sidebar/detail.hbs
+++ b/ui/app/components/evaluation-sidebar/detail.hbs
@@ -11,7 +11,7 @@
     <div
       data-test-eval-detail
       data-test-eval-detail-is-open={{this.isSideBarOpen}}
-      class="sidebar {{if this.isSideBarOpen "open"}}"
+      class="sidebar {{if this.isSideBarOpen "open"}} evaluations-sidebar"
       {{on-click-outside
         this.closeSidebar
         capture=true
@@ -162,7 +162,7 @@
           </div>
         {{/if}}
         {{! Evaluation JSON Response}}
-        <div class="boxed-section">
+        <div class="boxed-section evaluation-response">
           <div class="boxed-section-head">
             Evaluation Response
           </div>

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -12,7 +12,7 @@ $subNavOffset: 49px;
   width: 750px;
   padding: 24px;
   right: 0%;
-  overflow: visible;
+  overflow: auto;
   bottom: 0;
   top: $topNavOffset;
   transform: translateX(100%);
@@ -40,6 +40,23 @@ $subNavOffset: 49px;
     left: -16px;
     box-shadow: -5px 0 10px -5px rgb(0 0 0 / 20%);
     border-radius: 16px;
+  }
+
+  &.evaluations-sidebar {
+    display: grid;
+    gap: 1rem;
+    grid-template-rows: auto auto auto auto minmax(200px, 1fr);
+    & > .evaluation-response {
+      display: grid;
+      grid-template-rows: auto 1fr;
+      overflow: hidden;
+      & > .boxed-section-body {
+        overflow: auto;
+      }
+    }
+    & > div {
+      margin: 0;
+    }
   }
 }
 

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -43,11 +43,13 @@ $subNavOffset: 49px;
   }
 
   &.evaluations-sidebar {
-    display: grid;
-    gap: 1rem;
-    grid-template-rows: auto auto auto auto minmax(200px, 1fr);
+    display: flex;
+    gap: 1.5rem;
+    flex-direction: column;
+
     & > .evaluation-response {
       display: grid;
+      min-height: 200px;
       grid-template-rows: auto 1fr;
       overflow: hidden;
       & > .boxed-section-body {

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -12,7 +12,7 @@ $subNavOffset: 49px;
   width: 750px;
   padding: 24px;
   right: 0%;
-  overflow: auto;
+  overflow: visible;
   bottom: 0;
   top: $topNavOffset;
   transform: translateX(100%);

--- a/ui/app/styles/components/sidebar.scss
+++ b/ui/app/styles/components/sidebar.scss
@@ -56,7 +56,8 @@ $subNavOffset: 49px;
         overflow: auto;
       }
     }
-    & > div {
+    & > div,
+    h1.title {
       margin: 0;
     }
   }


### PR DESCRIPTION
This PR establishes CSS flexbox regions in the Evaluations sidebar so both it, and the evaluation response, can be scrolled.