### PR TITLE
[ui, deployments] Restarted and Rescheduled panel cells

### DIFF
--- a/ui/app/components/job-status/failed-or-lost.hbs
+++ b/ui/app/components/job-status/failed-or-lost.hbs
@@ -1,6 +1,6 @@
 <section class="failed-or-lost">
   <h4>
-    {{or @title "Failed or Lost"}}
+    {{@title}}
     <span
       class="tooltip multiline text-center"
       role="tooltip"

--- a/ui/app/components/job-status/failed-or-lost.hbs
+++ b/ui/app/components/job-status/failed-or-lost.hbs
@@ -1,0 +1,22 @@
+<section class="failed-or-lost">
+  <h4>
+    Failed or Lost
+    <span
+      class="tooltip multiline text-center"
+      role="tooltip"
+      aria-label="This number shows allocations that have failed or are lost for the most recent deployment. These allocations may have been restarted or rescheduled depending on your configuration. Permanent failures will be shown in the visual above."
+    >
+      <FlightIcon @name="info" />
+    </span>
+  </h4>
+  <ConditionalLinkTo
+    @condition={{@allocs.length}}
+    @route="jobs.job.allocations"
+    @model={{@job}}
+    @query={{hash status=(concat '["failed", "lost", "unknown"]') version=(concat '[' @job.latestDeployment.versionNumber ']')}}
+    @label="View Failed or Lost allocations"
+    @class="failed-or-lost-link"
+  >
+    <span class="failed-or-lost-link">{{@allocs.length}}</span>
+  </ConditionalLinkTo>
+</section>

--- a/ui/app/components/job-status/failed-or-lost.hbs
+++ b/ui/app/components/job-status/failed-or-lost.hbs
@@ -1,22 +1,22 @@
 <section class="failed-or-lost">
   <h4>
-    Failed or Lost
+    {{or @title "Failed or Lost"}}
     <span
       class="tooltip multiline text-center"
       role="tooltip"
-      aria-label="This number shows allocations that have failed or are lost for the most recent deployment. These allocations may have been restarted or rescheduled depending on your configuration. Permanent failures will be shown in the visual above."
+      aria-label={{@description}}
     >
       <FlightIcon @name="info" />
     </span>
   </h4>
   <ConditionalLinkTo
-    @condition={{@allocs.length}}
+    @condition={{this.shouldLinkToAllocations}}
     @route="jobs.job.allocations"
     @model={{@job}}
     @query={{hash status=(concat '["failed", "lost", "unknown"]') version=(concat '[' @job.latestDeployment.versionNumber ']')}}
-    @label="View Failed or Lost allocations"
+    @label="View Allocations"
     @class="failed-or-lost-link"
   >
-    <span class="failed-or-lost-link">{{@allocs.length}}</span>
+    {{@allocs.length}}
   </ConditionalLinkTo>
 </section>

--- a/ui/app/components/job-status/failed-or-lost.js
+++ b/ui/app/components/job-status/failed-or-lost.js
@@ -1,0 +1,4 @@
+import Component from '@glimmer/component';
+
+export default class JobStatusFailedOrLostComponent extends Component {
+}

--- a/ui/app/components/job-status/failed-or-lost.js
+++ b/ui/app/components/job-status/failed-or-lost.js
@@ -1,4 +1,7 @@
 import Component from '@glimmer/component';
 
 export default class JobStatusFailedOrLostComponent extends Component {
+  get shouldLinkToAllocations() {
+    return this.args.title !== 'Restarted' && this.args.allocs.length;
+  }
 }

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -102,6 +102,12 @@
           </span>
 
         </legend>
+
+        <JobStatus::FailedOrLost
+          @allocs={{this.failedOrLostAllocs}}
+          @job={{@job}}
+        />
+
       </div>
 
       <div class="history-and-params">

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -104,8 +104,17 @@
         </legend>
 
         <JobStatus::FailedOrLost
-          @allocs={{this.failedOrLostAllocs}}
+          @allocs={{this.rescheduledAllocs}}
           @job={{@job}}
+          @title="Rescheduled"
+          @description="Allocations that have been rescheduled, on another node if possible, due to failure during deployment"
+        />
+
+        <JobStatus::FailedOrLost
+          @allocs={{this.restartedAllocs}}
+          @job={{@job}}
+          @title="Restarted"
+          @description="Allocations that have been restarted in-place due to a task failure during deployment"
         />
 
       </div>

--- a/ui/app/components/job-status/panel/deploying.js
+++ b/ui/app/components/job-status/panel/deploying.js
@@ -144,6 +144,12 @@ export default class JobStatusPanelDeployingComponent extends Component {
     ];
   }
 
+  get failedOrLostAllocs() {
+    return this.job.allocations.filter(
+      (a) => a.jobVersion === this.deployment.get('versionNumber') && (a.clientStatus === 'failed' || a.clientStatus === 'lost' || a.clientStatus === 'unknown')
+    );
+  }
+
   // #region legend
   get newAllocsByStatus() {
     return Object.entries(this.newVersionAllocBlocks).reduce(

--- a/ui/app/components/job-status/panel/deploying.js
+++ b/ui/app/components/job-status/panel/deploying.js
@@ -153,21 +153,19 @@ export default class JobStatusPanelDeployingComponent extends Component {
   }
 
   get rescheduledAllocs() {
-    let allocs = this.job.allocations.filter(
+    return this.job.allocations.filter(
       (a) =>
         a.jobVersion === this.job.latestDeployment.get('versionNumber') &&
         a.hasBeenRescheduled
     );
-    return allocs;
   }
 
   get restartedAllocs() {
-    let allocs = this.job.allocations.filter(
+    return this.job.allocations.filter(
       (a) =>
         a.jobVersion === this.job.latestDeployment.get('versionNumber') &&
         a.hasBeenRestarted
     );
-    return allocs;
   }
 
   // #region legend

--- a/ui/app/components/job-status/panel/deploying.js
+++ b/ui/app/components/job-status/panel/deploying.js
@@ -61,7 +61,6 @@ export default class JobStatusPanelDeployingComponent extends Component {
   fail;
 
   @alias('job.latestDeployment') deployment;
-  // @alias('deployment.desiredTotal') desiredTotal;
   @alias('totalAllocs') desiredTotal;
 
   get oldVersionAllocBlocks() {

--- a/ui/app/components/job-status/panel/deploying.js
+++ b/ui/app/components/job-status/panel/deploying.js
@@ -61,7 +61,8 @@ export default class JobStatusPanelDeployingComponent extends Component {
   fail;
 
   @alias('job.latestDeployment') deployment;
-  @alias('deployment.desiredTotal') desiredTotal;
+  // @alias('deployment.desiredTotal') desiredTotal;
+  @alias('totalAllocs') desiredTotal;
 
   get oldVersionAllocBlocks() {
     return this.job.allocations

--- a/ui/app/components/job-status/panel/deploying.js
+++ b/ui/app/components/job-status/panel/deploying.js
@@ -82,7 +82,6 @@ export default class JobStatusPanelDeployingComponent extends Component {
   }
 
   get newVersionAllocBlocks() {
-    // console.log('============');
     let availableSlotsToFill = this.desiredTotal;
     let allocationsOfDeploymentVersion = this.job.allocations.filter(
       (a) => a.jobVersion === this.deployment.get('versionNumber')

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -41,6 +41,11 @@
           {{/each}}
         </legend>
 
+        <JobStatus::FailedOrLost
+          @allocs={{this.failedOrLostAllocs}}
+          @job={{@job}}
+        />
+
         <section class="versions">
           <h4>Versions</h4>
           <ul>

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -42,8 +42,17 @@
         </legend>
 
         <JobStatus::FailedOrLost
-          @allocs={{this.failedOrLostAllocs}}
+          @allocs={{this.rescheduledAllocs}}
           @job={{@job}}
+          @title="Rescheduled"
+          @description="Allocations that have been rescheduled, on another node if possible, due to failure"
+        />
+
+        <JobStatus::FailedOrLost
+          @allocs={{this.restartedAllocs}}
+          @job={{@job}}
+          @title="Restarted"
+          @description="Allocations that have been restarted in-place due to a task failure"
         />
 
         <section class="versions">

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -84,4 +84,25 @@ export default class JobStatusPanelSteadyComponent extends Component {
         []
       );
   }
+
+  get failedOrLostAllocs() {
+    let allocs = this.job.allocations.filter(
+      (a) =>
+        // a.jobVersion === this.job.latestDeployment.get('versionNumber')
+        true
+        && (a.clientStatus === 'failed' || a.clientStatus === 'lost' || a.clientStatus === 'unknown')
+    );
+    // console.log('before FUE check', allocs);
+    allocs = allocs.filter((a) => {
+      return !a.get('followUpEvaluation.content')
+      // console.log('RESC', a.desiredTransition.Reschedule, a.desiredTransition);
+      if (a.desiredTransition.Reschedule) {
+        console.log('failed alloc', a, 'has a desiredTransition.Reschedule', a.desiredTransition.Reschedule, a.desiredTransition)
+      }
+      return !a.desiredTransition.Reschedule
+    });
+    console.log('preret', allocs);
+    return allocs;
+  }
+
 }

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -11,7 +11,7 @@ export default class JobStatusPanelSteadyComponent extends Component {
     'pending',
     'failed',
     // 'unknown',
-    // 'lost',
+    'lost',
     // 'queued',
     // 'complete',
     'unplaced',

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -86,20 +86,18 @@ export default class JobStatusPanelSteadyComponent extends Component {
   }
 
   get rescheduledAllocs() {
-    let allocs = this.job.allocations.filter(
+    return this.job.allocations.filter(
       (a) =>
         a.jobVersion === this.job.latestDeployment.get('versionNumber') &&
         a.hasBeenRescheduled
     );
-    return allocs;
   }
 
   get restartedAllocs() {
-    let allocs = this.job.allocations.filter(
+    return this.job.allocations.filter(
       (a) =>
         a.jobVersion === this.job.latestDeployment.get('versionNumber') &&
         a.hasBeenRestarted
     );
-    return allocs;
   }
 }

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -70,14 +70,14 @@ export default class Allocation extends Model {
   }
 
   get hasBeenRescheduled() {
-    return this.desiredTransition?.Reschedule;
+    return this.get('followUpEvaluation.content');
   }
 
   get hasBeenRestarted() {
     return this.states
       .map((s) => s.events.content)
       .flat()
-      .find((e) => e.type === 'Terminated');
+      .find((e) => e.type === 'Restarting');
   }
 
   @attr healthChecks;

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -46,6 +46,7 @@ export default class Allocation extends Model {
 
   @attr('string') clientStatus;
   @attr('string') desiredStatus;
+  @attr() desiredTransition;
   @attr() deploymentStatus;
 
   get isCanary() {

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -57,6 +57,29 @@ export default class Allocation extends Model {
     return this.deploymentStatus?.Healthy;
   }
 
+  get willNotRestart() {
+    return this.clientStatus === 'failed' || this.clientStatus === 'lost';
+  }
+
+  get willNotReschedule() {
+    return (
+      this.willNotRestart &&
+      !this.get('nextAllocation.content') &&
+      !this.get('followUpEvaluation.content')
+    );
+  }
+
+  get hasBeenRescheduled() {
+    return this.desiredTransition?.Reschedule;
+  }
+
+  get hasBeenRestarted() {
+    return this.states
+      .map((s) => s.events.content)
+      .flat()
+      .find((e) => e.type === 'Terminated');
+  }
+
   @attr healthChecks;
 
   async getServiceHealth() {

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -49,9 +49,10 @@
     // TODO: may revisit this grid-area later, but is currently used in 2 competing ways
     display: grid;
     gap: 0.5rem;
-    grid-template-columns: 50% 25% 25%;
+    grid-template-columns: 55% 15% 15% 15%;
 
-    & > section > h4, & > legend > h4 {
+    & > section > h4,
+    & > legend > h4 {
       // font-size: 1.25rem;
       margin-bottom: 0.5rem;
     }

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -53,7 +53,6 @@
 
     & > section > h4,
     & > legend > h4 {
-      // font-size: 1.25rem;
       margin-bottom: 0.5rem;
     }
 

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -49,7 +49,12 @@
     // TODO: may revisit this grid-area later, but is currently used in 2 competing ways
     display: grid;
     gap: 0.5rem;
-    grid-template-columns: 50% 50%;
+    grid-template-columns: 50% 25% 25%;
+
+    & > section > h4, & > legend > h4 {
+      // font-size: 1.25rem;
+      margin-bottom: 0.5rem;
+    }
 
     legend {
       display: grid;
@@ -69,6 +74,14 @@
             text-decoration: none;
           }
         }
+      }
+    }
+
+    .failed-or-lost {
+      .failed-or-lost-link {
+        display: block;
+        font-size: 1.5rem;
+        font-weight: bold;
       }
     }
   }

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -277,7 +277,7 @@ module('Acceptance | job status panel', function (hooks) {
         running: 0.5,
         failed: 0.3,
         pending: 0.1,
-        lost: 0.1,
+        unknown: 0.1,
       },
       groupTaskCount,
       shallow: true,
@@ -291,7 +291,7 @@ module('Acceptance | job status panel', function (hooks) {
     // 25 running: 9 ungrouped, 17 grouped
     // 15 failed: 5 ungrouped, 10 grouped
     // 5 pending: 0 ungrouped, 5 grouped
-    // 5 lost: 0 ungrouped, 5 grouped. Represented as "Unplaced"
+    // 5 unknown: 0 ungrouped, 5 grouped. Represented as "Unplaced"
 
     assert
       .dom('.ungrouped-allocs .represented-allocation.running')

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -506,7 +506,7 @@ module('Acceptance | job status panel', function (hooks) {
       .dom(restartedCell.querySelector('.failed-or-lost-link'))
       .hasText('0', 'Restarted cell has zero value');
 
-    // A wild event appears! Change a recent task event to type "Terminated" in a task state:
+    // A wild event appears! Change a recent task event to type "Restarting" in a task state:
     this.store
       .peekAll('job')
       .objectAt(0)
@@ -516,7 +516,7 @@ module('Acceptance | job status panel', function (hooks) {
       .objectAt(0)
       .get('events')
       .objectAt(0)
-      .set('type', 'Terminated');
+      .set('type', 'Restarting');
 
     await settled();
 
@@ -524,7 +524,7 @@ module('Acceptance | job status panel', function (hooks) {
       .dom(restartedCell.querySelector('.failed-or-lost-link'))
       .hasText(
         '1',
-        'Restarted cell updates when a task event with type "Terminated" is added'
+        'Restarted cell updates when a task event with type "Restarting" is added'
       );
 
     this.store
@@ -536,7 +536,7 @@ module('Acceptance | job status panel', function (hooks) {
       .objectAt(0)
       .get('events')
       .objectAt(0)
-      .set('type', 'Terminated');
+      .set('type', 'Restarting');
 
     await settled();
 
@@ -545,7 +545,7 @@ module('Acceptance | job status panel', function (hooks) {
       .dom(restartedCell.querySelector('.failed-or-lost-link'))
       .hasText(
         '2',
-        'Restarted cell updates when a second task event with type "Terminated" is added'
+        'Restarted cell updates when a second task event with type "Restarting" is added'
       );
 
     this.store
@@ -553,9 +553,8 @@ module('Acceptance | job status panel', function (hooks) {
       .objectAt(0)
       .get('allocations')
       .objectAt(0)
-      .set('desiredTransition', {
-        Reschedule: true,
-      });
+      .get('followUpEvaluation')
+      .set('content', { 'test-key': 'not-empty' });
 
     await settled();
 

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -449,6 +449,90 @@ module('Acceptance | job status panel', function (hooks) {
       );
   });
 
+  test.only('Restarted/Rescheduled/Failed numbers reflected correctly', async function (assert) {
+    // assert.expect(6);
+
+    // faker.seed(1);
+
+    let groupTaskCount = 20;
+
+    let job = server.create('job', {
+      status: 'running',
+      datacenters: ['*'],
+      type: 'service',
+      resourceSpec: ['M: 256, C: 500'], // a single group
+      createAllocations: true,
+      allocStatusDistribution: {
+        running: 1,
+        failed: 0,
+        unknown: 0,
+        lost: 0,
+      },
+      groupTaskCount,
+      shallow: true,
+    });
+
+    await visit(`/jobs/${job.id}`);
+    assert.dom('.job-status-panel').exists();
+
+    let jobAllocCount = server.db.allocations.where({
+      jobId: job.id,
+    }).length;
+
+    assert
+      .dom('.ungrouped-allocs .represented-allocation.running')
+      .exists(
+        { count: jobAllocCount },
+        `All ${jobAllocCount} allocations are represented in the status panel, ungrouped`
+      );
+
+    groupTaskCount = 40;
+
+    job = server.create('job', {
+      status: 'running',
+      datacenters: ['*'],
+      type: 'service',
+      resourceSpec: ['M: 256, C: 500'], // a single group
+      createAllocations: true,
+      allocStatusDistribution: {
+        running: 1,
+        failed: 0,
+        unknown: 0,
+        lost: 0,
+      },
+      groupTaskCount,
+      shallow: true,
+    });
+
+    await visit(`/jobs/${job.id}`);
+    assert.dom('.job-status-panel').exists();
+
+    jobAllocCount = server.db.allocations.where({
+      jobId: job.id,
+    }).length;
+
+    // At standard test resolution, 40 allocations will attempt to display 20 ungrouped, and 20 grouped.
+    let desiredUngroupedAllocCount = 20;
+    assert
+      .dom('.ungrouped-allocs .represented-allocation.running')
+      .exists(
+        { count: desiredUngroupedAllocCount },
+        `${desiredUngroupedAllocCount} allocations are represented ungrouped`
+      );
+
+    assert
+      .dom('.represented-allocation.rest')
+      .exists('Allocations are numerous enough that a summary block exists');
+    assert
+      .dom('.represented-allocation.rest')
+      .hasText(
+        `+${groupTaskCount - desiredUngroupedAllocCount}`,
+        'Summary block has the correct number of grouped allocs'
+      );
+
+    await percySnapshot(assert);
+  });
+
   module('deployment history', function () {
     test('Deployment history can be searched', async function (assert) {
       faker.seed(1);

--- a/ui/tests/integration/components/job-status/failed-or-lost-test.js
+++ b/ui/tests/integration/components/job-status/failed-or-lost-test.js
@@ -2,25 +2,71 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { componentA11yAudit } from 'nomad-ui/tests/helpers/a11y-audit';
 
-module('Integration | Component | job-status/failed-or-lost', function(hooks) {
+module('Integration | Component | job-status/failed-or-lost', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+  test('it renders', async function (assert) {
+    let allocs = [
+      {
+        id: 1,
+        name: 'alloc1',
+      },
+      {
+        id: 2,
+        name: 'alloc2',
+      },
+    ];
 
-    await render(hbs`<JobStatus::FailedOrLost />`);
+    this.set('allocs', allocs);
 
-    assert.dom(this.element).hasText('');
+    await render(hbs`<JobStatus::FailedOrLost
+      @title="Rescheduled"
+      @description="Rescheduled Allocations"
+      @allocs={{this.allocs}}
+    />`);
 
-    // Template block usage:
-    await render(hbs`
-      <JobStatus::FailedOrLost>
-        template block text
-      </JobStatus::FailedOrLost>
-    `);
+    assert.dom('h4').hasText('Rescheduled');
+    assert.dom('.failed-or-lost-link').hasText('2');
 
-    assert.dom(this.element).hasText('template block text');
+    await this.pauseTest();
+    allocs.push({
+      id: 3,
+      name: 'alloc3',
+    });
+
+    this.set('allocs', allocs);
+    await this.pauseTest();
+
+    assert.dom('.failed-or-lost-link').hasText('3');
+
+    await componentA11yAudit(this.element, assert);
+  });
+
+  test('it links or does not link appropriately', async function (assert) {
+    let allocs = [
+      {
+        id: 1,
+        name: 'alloc1',
+      },
+      {
+        id: 2,
+        name: 'alloc2',
+      },
+    ];
+
+    this.set('allocs', allocs);
+
+    await render(hbs`<JobStatus::FailedOrLost
+      @title="Rescheduled"
+      @description="Rescheduled Allocations"
+      @allocs={{this.allocs}}
+    />`);
+
+    // Ensure it's of type a
+    assert.dom('.failed-or-lost-link').hasTagName('a');
+    this.set('allocs', []);
+    assert.dom('.failed-or-lost-link').doesNotHaveTagName('a');
   });
 });

--- a/ui/tests/integration/components/job-status/failed-or-lost-test.js
+++ b/ui/tests/integration/components/job-status/failed-or-lost-test.js
@@ -8,6 +8,7 @@ module('Integration | Component | job-status/failed-or-lost', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
+    assert.expect(3);
     let allocs = [
       {
         id: 1,
@@ -29,17 +30,6 @@ module('Integration | Component | job-status/failed-or-lost', function (hooks) {
 
     assert.dom('h4').hasText('Rescheduled');
     assert.dom('.failed-or-lost-link').hasText('2');
-
-    await this.pauseTest();
-    allocs.push({
-      id: 3,
-      name: 'alloc3',
-    });
-
-    this.set('allocs', allocs);
-    await this.pauseTest();
-
-    assert.dom('.failed-or-lost-link').hasText('3');
 
     await componentA11yAudit(this.element, assert);
   });

--- a/ui/tests/integration/components/job-status/failed-or-lost-test.js
+++ b/ui/tests/integration/components/job-status/failed-or-lost-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | job-status/failed-or-lost', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<JobStatus::FailedOrLost />`);
+
+    assert.dom(this.element).hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <JobStatus::FailedOrLost>
+        template block text
+      </JobStatus::FailedOrLost>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+});


### PR DESCRIPTION
Adds indicators and links for those allocations that have been restarted and rescheduled, either during a deployment or due to failures in an otherwise steady state.

![image](https://user-images.githubusercontent.com/713991/234369137-d242d3f2-820a-4fd6-ba9c-04cf1714804c.png)

Additionally, adds the concept of "permanent failure" to allocations we show in the main chart. For example, an allocation that has failed past its restart attempts will go into a "failed" clientStatus, but we don't want to show it in the main chart if there's a rescheduled allocation to take it over. The new `allocation.hasBeenRescheduled` computed property handles this.