### PR TITLE
refact:  update for `GET job/:jobId/submission` endpoint

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -14,6 +14,15 @@ export default class JobAdapter extends WatchableNamespaceIDs {
     return this.ajax(url, 'GET');
   }
 
+  fetchRawSpecification(job) {
+    const url = addToPath(
+      this.urlForFindRecord(job.get('id'), 'job', null, 'submission'),
+      '',
+      'version=' + job.get('version')
+    );
+    return this.ajax(url, 'GET');
+  }
+
   forcePeriodic(job) {
     if (job.get('periodic')) {
       const url = addToPath(

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -219,6 +219,10 @@ export default class Job extends Model {
     return this.store.adapterFor('job').fetchRawDefinition(this);
   }
 
+  fetchRawSpecification() {
+    return this.store.adapterFor('job').fetchRawSpecification(this);
+  }
+
   forcePeriodic() {
     return this.store.adapterFor('job').forcePeriodic(this);
   }

--- a/ui/app/routes/jobs/job/definition.js
+++ b/ui/app/routes/jobs/job/definition.js
@@ -7,11 +7,8 @@ export default class DefinitionRoute extends Route {
 
     const definition = await job.fetchRawDefinition();
 
-    const hasSpecification = !!definition?.Specification;
-
-    const specification = hasSpecification
-      ? await new Blob([definition?.Specification?.Definition]).text()
-      : null;
+    const specificationResponse = await job.fetchRawSpecification();
+    const specification = specificationResponse?.Source ?? null;
 
     return {
       job,

--- a/ui/app/utils/add-to-path.js
+++ b/ui/app/utils/add-to-path.js
@@ -1,10 +1,18 @@
 // Adds a string to the end of a URL path while being mindful of query params
-export default function addToPath(url, extension = '') {
+export default function addToPath(url, extension = '', additionalParams) {
   const [path, params] = url.split('?');
   let newUrl = `${path}${extension}`;
 
   if (params) {
     newUrl += `?${params}`;
+  }
+
+  if (additionalParams) {
+    if (params) {
+      newUrl += `&${additionalParams}`;
+    } else {
+      newUrl += `?${additionalParams}`;
+    }
   }
 
   return newUrl;

--- a/ui/tests/unit/adapters/job-test.js
+++ b/ui/tests/unit/adapters/job-test.js
@@ -7,6 +7,9 @@ import { startMirage } from 'nomad-ui/initializers/ember-cli-mirage';
 import { AbortController } from 'fetch';
 import { TextEncoderLite } from 'text-encoder-lite';
 import base64js from 'base64-js';
+import addToPath from 'nomad-ui/utils/add-to-path';
+import sinon from 'sinon';
+import { resolve } from 'rsvp';
 
 module('Unit | Adapter | Job', function (hooks) {
   setupTest(hooks);
@@ -604,6 +607,71 @@ module('Unit | Adapter | Job', function (hooks) {
       `/v1/job/${job.plainId}/dispatch?region=${region}`
     );
     assert.equal(request.method, 'POST');
+  });
+
+  module('#fetchRawSpecification', function () {
+    test('it makes a GET request to the correct URL', async function (assert) {
+      const adapter = this.owner.lookup('adapter:job');
+      const job = {
+        get: sinon.stub(),
+      };
+
+      job.get.withArgs('id').returns('["job-id"]');
+      job.get.withArgs('version').returns('job-version');
+
+      const expectedURL = addToPath(
+        adapter.urlForFindRecord('["job-id"]', 'job', null, 'submission'),
+        '',
+        'version=' + job.get('version')
+      );
+
+      // Stub the ajax method to avoid making real API calls
+      sinon.stub(adapter, 'ajax').callsFake(() => resolve({}));
+
+      await adapter.fetchRawSpecification(job);
+
+      assert.ok(adapter.ajax.calledOnce, 'The ajax method is called once');
+
+      assert.equal(
+        expectedURL,
+        '/v1/job/job-id/submission?version=job-version',
+        'it formats the URL correctly'
+      );
+    });
+
+    test('it formats namespaces correctly', async function (assert) {
+      const adapter = this.owner.lookup('adapter:job');
+      const job = {
+        get: sinon.stub(),
+      };
+
+      job.get.withArgs('id').returns('["job-id"]');
+      job.get.withArgs('version').returns('job-version');
+      job.get.withArgs('namespace').returns('zoey');
+
+      const expectedURL = addToPath(
+        adapter.urlForFindRecord(
+          '["job-id", "zoey"]',
+          'job',
+          null,
+          'submission'
+        ),
+        '',
+        'version=' + job.get('version')
+      );
+
+      // Stub the ajax method to avoid making real API calls
+      sinon.stub(adapter, 'ajax').callsFake(() => resolve({}));
+
+      await adapter.fetchRawSpecification(job);
+
+      assert.ok(adapter.ajax.calledOnce, 'The ajax method is called once');
+
+      assert.equal(
+        expectedURL,
+        '/v1/job/job-id/submission?namespace=zoey&version=job-version'
+      );
+    });
   });
 });
 


### PR DESCRIPTION
This PR creates a new adapter and model method for fetching a specification for a job and refactors the `jobs.job.definition` route's model to use the specification returned from this API response instead of trying to pull this off of the `GET /job/:jobId` endpoint.

This PR is part of a larger block of work that will update the UI in accordance with late API changes.

Loom Walk Through:  https://www.loom.com/share/6291a654c01f473a98edcae0b5fff0cd