### PR TITLE
ui: visualize variables

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -19,6 +19,15 @@ export default class JobAdapter extends WatchableNamespaceIDs {
     return this.ajax(url, 'GET');
   }
 
+  fetchRawSpecification(job) {
+    const url = addToPath(
+      this.urlForFindRecord(job.get('id'), 'job', null, 'submission'),
+      '',
+      'version=' + job.get('version')
+    );
+    return this.ajax(url, 'GET');
+  }
+
   forcePeriodic(job) {
     if (job.get('periodic')) {
       const url = addToPath(

--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -144,6 +144,22 @@ export default class JobEditor extends Component {
     }
   }
 
+  get variables() {
+    function jsonToHcl(obj) {
+      const hclLines = [];
+
+      for (const key in obj) {
+        const value = obj[key];
+        const hclValue = typeof value === 'string' ? `"${value}"` : value;
+        hclLines.push(`${key}=${hclValue}`);
+      }
+
+      return hclLines.join('\n');
+    }
+
+    return jsonToHcl(this.args.variables);
+  }
+
   get data() {
     return {
       cancelable: this.args.cancelable,
@@ -153,6 +169,7 @@ export default class JobEditor extends Component {
       job: this.args.job,
       planOutput: this.planOutput,
       shouldShowPlanMessage: this.shouldShowPlanMessage,
+      variables: this.variables,
       view: this.args.view,
     };
   }

--- a/ui/app/controllers/jobs/job/definition.js
+++ b/ui/app/controllers/jobs/job/definition.js
@@ -18,6 +18,7 @@ export default class DefinitionController extends Controller.extend(
   @alias('model.definition') definition;
   @alias('model.job') job;
   @alias('model.specification') specification;
+  @alias('model.variables') variables;
 
   @tracked view;
   @tracked isEditing = false;

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -224,6 +224,10 @@ export default class Job extends Model {
     return this.store.adapterFor('job').fetchRawDefinition(this);
   }
 
+  fetchRawSpecification() {
+    return this.store.adapterFor('job').fetchRawSpecification(this);
+  }
+
   forcePeriodic() {
     return this.store.adapterFor('job').forcePeriodic(this);
   }

--- a/ui/app/routes/jobs/job/definition.js
+++ b/ui/app/routes/jobs/job/definition.js
@@ -14,11 +14,13 @@ export default class DefinitionRoute extends Route {
 
     const specificationResponse = await job.fetchRawSpecification();
     const specification = specificationResponse?.Source ?? null;
+    const variables = specificationResponse?.VariableFlags ?? null;
 
     return {
       job,
       definition,
       specification,
+      variables,
     };
   }
 

--- a/ui/app/routes/jobs/job/definition.js
+++ b/ui/app/routes/jobs/job/definition.js
@@ -12,11 +12,8 @@ export default class DefinitionRoute extends Route {
 
     const definition = await job.fetchRawDefinition();
 
-    const hasSpecification = !!definition?.Specification;
-
-    const specification = hasSpecification
-      ? await new Blob([definition?.Specification?.Definition]).text()
-      : null;
+    const specificationResponse = await job.fetchRawSpecification();
+    const specification = specificationResponse?.Source ?? null;
 
     return {
       job,

--- a/ui/app/styles/components/json-viewer.scss
+++ b/ui/app/styles/components/json-viewer.scss
@@ -7,4 +7,10 @@
   &.has-fluid-height .CodeMirror-scroll {
     min-height: 0;
   }
+
+  &.is-variable-editor .CodeMirror-scroll {
+    box-sizing: inherit;
+    height: 200px;
+    min-height: 0;
+  }
 }

--- a/ui/app/templates/components/job-editor.hbs
+++ b/ui/app/templates/components/job-editor.hbs
@@ -8,12 +8,14 @@
     @data={{merge (hash error=this.error stage=this.stage) this.data}}
   />
 
-    <header class="run-job-header">
-      <h1 class="title is-3">Run a job</h1>
-      <p>
-        Paste or author HCL or JSON to submit to your cluster, or select from a list of templates. A plan will be requested before the job is submitted. You can also attach a job spec by uploading a job file or dragging &amp; dropping a file to the editor.
-      </p>
-    </header>
+    {{#if (eq @context "new")}}
+      <header class="run-job-header">
+        <h1 class="title is-3">Run a job</h1>
+        <p>
+          Paste or author HCL or JSON to submit to your cluster, or select from a list of templates. A plan will be requested before the job is submitted. You can also attach a job spec by uploading a job file or dragging &amp; dropping a file to the editor.
+        </p>
+      </header>
+    {{/if}}
     {{did-update this.setDefinitionOnModel this.definition}}
     {{component (concat 'job-editor/' this.stage) data=this.data fns=this.fns}}
 </div>

--- a/ui/app/templates/components/job-editor/alert.hbs
+++ b/ui/app/templates/components/job-editor/alert.hbs
@@ -1,27 +1,29 @@
-  {{#if @data.error}}
-    <Hds::Alert @type="inline" @color="critical" data-test-error={{@data.error.type}} as |A|>
-        <A.Title data-test-error-title>{{conditionally-capitalize @data.error.type true}}</A.Title>
-        <A.Description data-test-error-message>{{@data.error.message}}</A.Description>
-    </Hds::Alert>
-  {{/if}}
-  {{#if (and (eq @data.stage "read") @data.hasVariables (eq @data.view "job-spec"))}}
-    {{#if this.shouldShowAlert}}
-      <Hds::Alert @type="inline" @onDismiss={{this.dismissAlert}} data-test-variable-notification as |A|>
-        <A.Title>Job Variable Values Not Shown</A.Title>
-        <A.Description>Please refer to Nomad CLI to see the current value of variables.</A.Description>
+  <div style="margin-bottom: 10px">
+    {{#if @data.error}}
+      <Hds::Alert @type="inline" @color="critical" data-test-error={{@data.error.type}} as |A|>
+          <A.Title data-test-error-title>{{conditionally-capitalize @data.error.type true}}</A.Title>
+          <A.Description data-test-error-message>{{@data.error.message}}</A.Description>
       </Hds::Alert>
     {{/if}}
-  {{/if}}
-  {{#if (and (eq @data.stage "edit") (eq @data.view "full-definition"))}}
-      <Hds::Alert @type="inline" @color="warning" data-test-json-warning as |A|>
-        <A.Title>Edit JSON</A.Title>
-        <A.Description>If you edit the JSON formation in the full definition, you will no longer be able to see job spec in HCL.</A.Description>
+    {{#if (and (eq @data.stage "read") @data.hasVariables (eq @data.view "job-spec"))}}
+      {{#if this.shouldShowAlert}}
+        <Hds::Alert @type="inline" @onDismiss={{this.dismissAlert}} data-test-variable-notification as |A|>
+          <A.Title>All Job Variable Values Not Shown</A.Title>
+          <A.Description>Please refer to Nomad CLI to see the current value of all variables.</A.Description>
+        </Hds::Alert>
+      {{/if}}
+    {{/if}}
+    {{#if (and (eq @data.stage "edit") (eq @data.view "full-definition"))}}
+        <Hds::Alert @type="inline" @color="warning" data-test-json-warning as |A|>
+          <A.Title>Edit JSON</A.Title>
+          <A.Description>If you edit the JSON formation in the full definition, you will no longer be able to see job spec in HCL.</A.Description>
+        </Hds::Alert>
+    {{/if}}
+    {{#if (and (eq @data.stage "review") @data.shouldShowPlanMessage)}}
+      <Hds::Alert @type="inline" @onDismiss={{fn (mut @data.showPlanMessage)}} as |A|>
+          <A.Title data-test-plan-help-title>Job Plan</A.Title>
+          <A.Description data-test-plan-help-message>This is the impact running this job will have on your cluster</A.Description>
       </Hds::Alert>
-  {{/if}}
-  {{#if (and (eq @data.stage "review") @data.shouldShowPlanMessage)}}
-    <Hds::Alert @type="inline" @onDismiss={{fn (mut @data.showPlanMessage)}} as |A|>
-        <A.Title data-test-plan-help-title>Job Plan</A.Title>
-        <A.Description data-test-plan-help-message>This is the impact running this job will have on your cluster</A.Description>
-    </Hds::Alert>
-  {{/if}}
+    {{/if}}
+  </div>
   

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -25,19 +25,24 @@
         />
     </div>
     {{#if (eq @data.view "job-spec")}}
-    <div>
-        <h1 style="font-size: 2rem; font-weight: 600">Edit HCL Variables</h1>
-        <div
-            data-test-variable-editor
-            {{code-mirror
-            screenReaderLabel="HLC Variables for Job Spec"
-            content=""
-            theme="hashi"
-            onUpdate=@fns.onUpdate
-            type="hclVariables"
-            mode="ruby"
-            }}
-        />
+    <div class="boxed-section" style="margin-top: 10px">
+        <div class="boxed-section-head">
+            Edit HCL Variables
+        </div>
+        <div class="boxed-section-body is-full-bleed">
+            <div
+                class="json-viewer is-variable-editor"
+                data-test-variable-editor
+                {{code-mirror
+                screenReaderLabel="HLC Variables for Job Spec"
+                content=@data.variables
+                theme="hashi"
+                onUpdate=@fns.onUpdate
+                type="hclVariables"
+                mode="ruby"
+                }}
+            />
+        </div>
     </div>
     {{/if}}
 </div>

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -55,4 +55,24 @@
         />
     {{/if}}
     </div>
+    {{#if (eq @data.view "job-spec")}}
+    <div class="boxed-section" style="margin-top: 10px">
+        <div class="boxed-section-head">
+            HCL Variables
+        </div>
+        <div class="boxed-section-body is-full-bleed">
+            <div
+                class="json-viewer is-variable-editor"
+                data-test-variable-editor
+                {{code-mirror
+                    screenReaderLabel="HLC Variables for Job Spec"
+                    content=@data.variables
+                    mode="ruby"
+                    theme="hashi-read-only"
+                    readOnly=true
+                }}
+            />
+        </div>
+    </div>
+    {{/if}}
 </div>

--- a/ui/app/templates/jobs/job/definition.hbs
+++ b/ui/app/templates/jobs/job/definition.hbs
@@ -12,6 +12,7 @@
     @definition={{this.definition}}
     @job={{this.job}}
     @specification={{this.specification}}
+    @variables={{this.variables}}
     @view={{this.view}}
     @onSubmit={{action this.onSubmit}}
     @onSelect={{this.selectView}}

--- a/ui/app/utils/add-to-path.js
+++ b/ui/app/utils/add-to-path.js
@@ -4,12 +4,20 @@
  */
 
 // Adds a string to the end of a URL path while being mindful of query params
-export default function addToPath(url, extension = '') {
+export default function addToPath(url, extension = '', additionalParams) {
   const [path, params] = url.split('?');
   let newUrl = `${path}${extension}`;
 
   if (params) {
     newUrl += `?${params}`;
+  }
+
+  if (additionalParams) {
+    if (params) {
+      newUrl += `&${additionalParams}`;
+    } else {
+      newUrl += `?${additionalParams}`;
+    }
   }
 
   return newUrl;

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -112,6 +112,10 @@ export default function () {
     return new Response(200, {}, this.serialize(job));
   });
 
+  this.get('/job/:id/submission', function (schema, req) {
+    return new Response(200, {}, JSON.stringify({}));
+  });
+
   this.post('/job/:id/plan', function (schema, req) {
     const body = JSON.parse(req.requestBody);
 

--- a/ui/tests/acceptance/job-definition-test.js
+++ b/ui/tests/acceptance/job-definition-test.js
@@ -145,7 +145,19 @@ module('display and edit using full specification', function (hooks) {
 
   test('it allows users to select between full specification and JSON definition', async function (assert) {
     assert.expect(3);
+    const specification_response = {
+      Format: 'hcl2',
+      JobID: 'example',
+      JobIndex: 223,
+      Namespace: 'default',
+      Source:
+        'variable "datacenter" {\n  description = "The datacenter to run the job in"\n  type        = string\n  default     = "dc1"\n}\n\njob "example" {\n  datacenters = [var.datacenter]\n\n  group "example-group" {\n    task "example-task" {\n      driver = "docker"\n\n      config {\n        image = "redis:3.2"\n      }\n\n      resources {\n        cpu    = 500\n        memory = 256\n      }\n    }\n  }\n}\n',
+      VariableFlags: { datacenter: 'dc2' },
+      Variables: '',
+      Version: 0,
+    };
     server.get('/job/:id', () => JOB_JSON);
+    server.get('/job/:id/submission', () => specification_response);
 
     await Definition.visit({ id: job.id });
 
@@ -155,7 +167,7 @@ module('display and edit using full specification', function (hooks) {
     let codeMirror = getCodeMirrorInstance('[data-test-editor]');
     assert.equal(
       codeMirror.getValue(),
-      JOB_JSON.Specification.Definition,
+      specification_response.Source,
       'Shows the full definition as written by the user'
     );
 

--- a/ui/tests/unit/adapters/job-test.js
+++ b/ui/tests/unit/adapters/job-test.js
@@ -12,6 +12,9 @@ import { startMirage } from 'nomad-ui/initializers/ember-cli-mirage';
 import { AbortController } from 'fetch';
 import { TextEncoderLite } from 'text-encoder-lite';
 import base64js from 'base64-js';
+import addToPath from 'nomad-ui/utils/add-to-path';
+import sinon from 'sinon';
+import { resolve } from 'rsvp';
 
 module('Unit | Adapter | Job', function (hooks) {
   setupTest(hooks);
@@ -609,6 +612,71 @@ module('Unit | Adapter | Job', function (hooks) {
       `/v1/job/${job.plainId}/dispatch?region=${region}`
     );
     assert.equal(request.method, 'POST');
+  });
+
+  module('#fetchRawSpecification', function () {
+    test('it makes a GET request to the correct URL', async function (assert) {
+      const adapter = this.owner.lookup('adapter:job');
+      const job = {
+        get: sinon.stub(),
+      };
+
+      job.get.withArgs('id').returns('["job-id"]');
+      job.get.withArgs('version').returns('job-version');
+
+      const expectedURL = addToPath(
+        adapter.urlForFindRecord('["job-id"]', 'job', null, 'submission'),
+        '',
+        'version=' + job.get('version')
+      );
+
+      // Stub the ajax method to avoid making real API calls
+      sinon.stub(adapter, 'ajax').callsFake(() => resolve({}));
+
+      await adapter.fetchRawSpecification(job);
+
+      assert.ok(adapter.ajax.calledOnce, 'The ajax method is called once');
+
+      assert.equal(
+        expectedURL,
+        '/v1/job/job-id/submission?version=job-version',
+        'it formats the URL correctly'
+      );
+    });
+
+    test('it formats namespaces correctly', async function (assert) {
+      const adapter = this.owner.lookup('adapter:job');
+      const job = {
+        get: sinon.stub(),
+      };
+
+      job.get.withArgs('id').returns('["job-id"]');
+      job.get.withArgs('version').returns('job-version');
+      job.get.withArgs('namespace').returns('zoey');
+
+      const expectedURL = addToPath(
+        adapter.urlForFindRecord(
+          '["job-id", "zoey"]',
+          'job',
+          null,
+          'submission'
+        ),
+        '',
+        'version=' + job.get('version')
+      );
+
+      // Stub the ajax method to avoid making real API calls
+      sinon.stub(adapter, 'ajax').callsFake(() => resolve({}));
+
+      await adapter.fetchRawSpecification(job);
+
+      assert.ok(adapter.ajax.calledOnce, 'The ajax method is called once');
+
+      assert.equal(
+        expectedURL,
+        '/v1/job/job-id/submission?namespace=zoey&version=job-version'
+      );
+    });
   });
 });
 


### PR DESCRIPTION
In this PR, we introduce a feature to display specification literals via variable flags from the API response in the read-only and edit views. The PR also adds styling and spacing adjustments to ensure that the displayed literals look visually appealing and that code mirror doesn't take up too much space. Additionally, the PR includes logic to manually convert JSON objects to HCL format using loose logic, focusing on variable flags. 

Side Effect: Note that the text displayed in the Job Editor header is now only conditionally rendered to show on the job run page, which utilizes the same editor component.

Loom Walk Through:  https://www.loom.com/share/07a0d2cde466416890d3aaa3988e5559