### PR TITLE
deps: update go-bexpr from 0.1.11 to 0.1.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/consul/api v1.18.0
 	github.com/hashicorp/consul/sdk v0.13.0
 	github.com/hashicorp/cronexpr v1.1.1
-	github.com/hashicorp/go-bexpr v0.1.11
+	github.com/hashicorp/go-bexpr v0.1.12
 	github.com/hashicorp/go-checkpoint v0.0.0-20171009173528-1545e56e46de
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-connlimit v0.3.0
@@ -110,7 +110,7 @@ require (
 	github.com/shoenig/go-m1cpu v0.1.5
 	github.com/shoenig/test v0.6.4
 	github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.2
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 	github.com/zclconf/go-cty v1.12.1
 	github.com/zclconf/go-cty-yaml v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -799,8 +799,8 @@ github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FK
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-bexpr v0.1.11 h1:6DqdA/KBjurGby9yTY0bmkathya0lfwF2SeuubCI7dY=
-github.com/hashicorp/go-bexpr v0.1.11/go.mod h1:f03lAo0duBlDIUMGCuad8oLcgejw4m7U+N8T+6Kz1AE=
+github.com/hashicorp/go-bexpr v0.1.12 h1:XrdVhmwu+9iYxIUWxsGVG7NQwrhzJZ0vR6nbN5bLgrA=
+github.com/hashicorp/go-bexpr v0.1.12/go.mod h1:ACktpcSySkFNpcxWSClFrut7wicd9WzisnvHuw+g9K8=
 github.com/hashicorp/go-checkpoint v0.0.0-20171009173528-1545e56e46de h1:XDCSythtg8aWSRSO29uwhgh7b127fWr+m5SemqjSUL8=
 github.com/hashicorp/go-checkpoint v0.0.0-20171009173528-1545e56e46de/go.mod h1:xIwEieBHERyEvaeKF/TcHh1Hu+lxPM+n2vT1+g9I4m4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -1345,8 +1345,9 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -4266,6 +4266,8 @@ func TestClientEndpoint_UpdateAlloc_Evals_ByTrigger(t *testing.T) {
 
 }
 
+// TestNode_List_PaginationFiltering asserts that API pagination and filtering
+// works against the Node.List RPC.
 func TestNode_List_PaginationFiltering(t *testing.T) {
 	ci.Parallel(t)
 
@@ -4280,21 +4282,25 @@ func TestNode_List_PaginationFiltering(t *testing.T) {
 		id     string
 		dc     string
 		status string
+		meta   map[string]string
 	}{
 		{
 			id:     "aaaa1111-3350-4b4b-d185-0e1992ed43e9",
 			dc:     "dc2",
 			status: structs.NodeStatusDisconnected,
+			meta:   map[string]string{"foo": "bar"},
 		},
 		{
 			id:     "aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
 			dc:     "dc1",
 			status: structs.NodeStatusReady,
+			meta:   map[string]string{"foo": "bar"},
 		},
 		{
 			id:     "aaaaaa33-3350-4b4b-d185-0e1992ed43e9",
 			dc:     "dc3",
 			status: structs.NodeStatusReady,
+			meta:   map[string]string{"foo": "something else"},
 		},
 		{
 			id:     "aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
@@ -4321,6 +4327,7 @@ func TestNode_List_PaginationFiltering(t *testing.T) {
 		mockNode.ID = m.id
 		mockNode.Datacenter = m.dc
 		mockNode.Status = m.status
+		mockNode.Meta = m.meta
 		mockNode.CreateIndex = index
 		require.NoError(t, testState.UpsertNode(structs.MsgTypeTestSetup, index, mockNode))
 	}
@@ -4384,6 +4391,14 @@ func TestNode_List_PaginationFiltering(t *testing.T) {
 			expectedIDs: []string{
 				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
 				"aaaaaaaa-3350-4b4b-d185-0e1992ed43e9",
+			},
+		},
+		{
+			name:   "filter on meta key",
+			filter: `Meta["foo"] == "bar"`,
+			expectedIDs: []string{
+				"aaaa1111-3350-4b4b-d185-0e1992ed43e9",
+				"aaaaaa22-3350-4b4b-d185-0e1992ed43e9",
 			},
 		},
 	}


### PR DESCRIPTION
Pulls in https://github.com/hashicorp/go-bexpr/pull/38

Fixes #16758