### PR TITLE
ci: fix test failures due to backport issues

### DIFF
--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -7645,7 +7645,7 @@ func TestJobEndpoint_Scale_SystemJob(t *testing.T) {
 	state := testServer.fsm.State()
 
 	mockSystemJob := mock.SystemJob()
-	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 10, nil, mockSystemJob))
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 10, mockSystemJob))
 
 	scaleReq := &structs.JobScaleRequest{
 		JobID: mockSystemJob.ID,


### PR DESCRIPTION
causing CI failures with the following error:
```
=== Errors
drivers\docker\driver_test.go:849:20: undefined: os
drivers\docker\driver_test.go:850:20: undefined: os
```

```
nomad/job_endpoint_test.go:7648:69: too many arguments in call to state.UpsertJob
	have ("github.com/hashicorp/nomad/nomad/structs".MessageType, number, nil, *"github.com/hashicorp/nomad/nomad/structs".Job)
	want ("github.com/hashicorp/nomad/nomad/structs".MessageType, uint64, *"github.com/hashicorp/nomad/nomad/structs".Job)
```