### PR TITLE
docs: add more notes about artifact breaking changes in 1.5.0

### DIFF
--- a/.changelog/15514.txt
+++ b/.changelog/15514.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+artifact: environment variables no longer inherited by default from Nomad client
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ BREAKING CHANGES:
 * config: the `datacenter` field for agent configuration no longer accepts the `*` character as part of the datacenter name [[GH-11170](https://github.com/hashicorp/nomad/issues/11170)]
 * core: Ensure no leakage of evaluations for batch jobs. Prior to this change allocations and evaluations for batch jobs were never garbage collected until the batch job was explicitly stopped. The new `batch_eval_gc_threshold` server configuration controls how often they are collected. The default threshold is `24h`. [[GH-15097](https://github.com/hashicorp/nomad/issues/15097)]
 * metrics: The metric `nomad.nomad.broker.total_blocked` has been renamed to `nomad.nomad.broker.total_pending` to reduce confusion with the `nomad.blocked_eval.total_blocked` metric. [[GH-15835](https://github.com/hashicorp/nomad/issues/15835)]
+* artifact: Environment variables are no longer inherited by default from the Nomad client [[GH-15514](https://github.com/hashicorp/nomad/issues/15514)]
+* artifact: File size and count limits are now applied by default to artifact downloads [[GH-16151](https://github.com/hashicorp/nomad/issues/16151)]
 
 SECURITY:
 

--- a/website/content/docs/job-specification/artifact.mdx
+++ b/website/content/docs/job-specification/artifact.mdx
@@ -246,7 +246,7 @@ artifact {
 
 ## Environment
 
-Starting with Nomad 1.5.0, the `artifact` downloader by default does not have access to the environment variables
+The `artifact` downloader by default does not have access to the environment variables
 set for the Nomad client. Inheritence of environment variables can be managed through the [`artifact.set_environment_variables`][client_artifact]
 client configuration.
 

--- a/website/content/docs/job-specification/artifact.mdx
+++ b/website/content/docs/job-specification/artifact.mdx
@@ -244,6 +244,12 @@ artifact {
 }
 ```
 
+## Environment
+
+Starting with Nomad 1.5.0, the `artifact` downloader by default does not have access to the environment variables
+set for the Nomad client. Inheritence of environment variables can be managed through the [`artifact.set_environment_variables`][client_artifact]
+client configuration.
+
 [client_artifact]: /nomad/docs/configuration/client#artifact-parameters
 [go-getter]: https://github.com/hashicorp/go-getter 'HashiCorp go-getter Library'
 [go-getter-headers]: https://github.com/hashicorp/go-getter#headers 'HashiCorp go-getter Headers'


### PR DESCRIPTION
- changelog: note artifact breaking changes for 1.5.0
- docs: add note about environment variables to artifact job spec docs

Closes #17000

I didn't add a .changelog file for the compression limits entry because there already is one (originally got sorted under improvements, now calling it out as a breaking change) 