### PR TITLE
build: add Docker image

### DIFF
--- a/.changelog/17017.txt
+++ b/.changelog/17017.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+build: Publish official Docker images with the Nomad CLI
+```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,41 +281,38 @@ jobs:
           name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           path: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
 
+  build-docker-default:
+    name: Docker ${{ matrix.arch }} default release build
+    needs:
+      - get-product-version
+      - build-linux
+    runs-on: [ custom, linux, xxl, 20.04 ]
+    strategy:
+      matrix:
+        arch: ["arm", "arm64", "386", "amd64"]
+    env:
+      version: ${{needs.get-product-version.outputs.product-version}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Build (Action)
+        uses: hashicorp/actions-docker-build@v1
+        with:
+          smoke_test: |
+            TEST_VERSION="$(docker run "${IMAGE_NAME}" version | awk '/Nomad v/{print $2}')"
+            if [ "${TEST_VERSION}" != "v${version}" ]; then
+              echo "Test FAILED"
+              exit 1
+            fi
+            echo "Test PASSED"
+          version: ${{env.version}}
+          target: release
+          arch: ${{matrix.arch}}
+          tags: |
+            docker.io/hashicorp/${{env.PKG_NAME}}:${{env.version}}
+            986891699432.dkr.ecr.us-east-1.amazonaws.com/hashicorp/${{env.PKG_NAME}}:${{env.version}}
+          dev_tags: |
+            docker.io/hashicorppreview/${{ env.PKG_NAME }}:${{ env.version }}-dev
+            docker.io/hashicorppreview/${{ env.PKG_NAME }}:${{ env.version }}-${{ github.sha }}
+
 permissions:
   contents: read
-# This placed here for when the Nomad team is ready to build docker images.
-# Please reach out the RDX team for assistance or refer to the CRT Self-Serve Onboarding doc.
-
-  # build-docker-default:
-  #   name: Docker ${{ matrix.arch }} default release build
-  #   needs:
-  #     - get-product-version
-  #     - build
-  #   runs-on: [ custom, linux, xxl, 20.04 ]
-  #   strategy:
-  #     matrix:
-  #       arch: ["arm", "arm64", "amd64"]
-  #   env:
-  #     repo: ${{github.event.repository.name}}
-  #     version: ${{needs.get-product-version.outputs.product-version}}
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Docker Build (Action)
-  #       uses: hashicorp/actions-docker-build@v1
-  #       with:
-  #         # Add smoke test here. Below is a sample smoke test that runs the built image
-  #         # and validates the version.
-  #         smoke_test: |
-  #           TEST_VERSION="$(docker run "${IMAGE_NAME}" | awk '/CLI version/{print $3}')"
-  #           if [ "${TEST_VERSION}" != "${version}" ]; then
-  #             echo "Test FAILED"
-  #             exit 1
-  #           fi
-  #           echo "Test PASSED"
-  #         version: ${{env.version}}
-  #         target: release-default
-  #         arch: ${{matrix.arch}}
-  #         tags: |
-  #           docker.io/hashicorp/${{env.repo}}:${{env.version}}
-  #           986891699432.dkr.ecr.us-east-1.amazonaws.com/hashicorp/${{env.repo}}:${{env.version}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,8 +281,8 @@ jobs:
           name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           path: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
 
-  build-docker-default:
-    name: Docker ${{ matrix.arch }} default release build
+  build-docker:
+    name: Docker ${{ matrix.arch }} build
     needs:
       - get-product-version
       - build-linux
@@ -293,7 +293,7 @@ jobs:
     env:
       version: ${{needs.get-product-version.outputs.product-version}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1
         with:
@@ -309,7 +309,6 @@ jobs:
           arch: ${{matrix.arch}}
           tags: |
             docker.io/hashicorp/${{env.PKG_NAME}}:${{env.version}}
-            986891699432.dkr.ecr.us-east-1.amazonaws.com/hashicorp/${{env.PKG_NAME}}:${{env.version}}
           dev_tags: |
             docker.io/hashicorppreview/${{ env.PKG_NAME }}:${{ env.version }}-dev
             docker.io/hashicorppreview/${{ env.PKG_NAME }}:${{ env.version }}-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: [ custom, linux, xxl, 20.04 ]
     strategy:
       matrix:
-        arch: ["arm", "arm64", "386", "amd64"]
+        arch: ["arm64", "amd64"]
     env:
       version: ${{needs.get-product-version.outputs.product-version}}
     steps:

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -66,6 +66,20 @@ event "promote-staging" {
   }
 }
 
+event "promote-staging-docker" {
+  depends = ["promote-staging"]
+
+  action "promote-staging-docker" {
+    organization = "hashicorp"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-staging-docker"
+  }
+
+  notification {
+    on = "always"
+  }
+}
+
 event "trigger-production" {
   // This event is dispatched by the bob trigger-promotion command  // and is required - do not delete.
 }
@@ -84,8 +98,22 @@ event "promote-production" {
   }
 }
 
-event "promote-production-packaging" {
+event "promote-production-docker" {
   depends = ["promote-production"]
+
+  action "promote-production-docker" {
+    organization = "hashicorp"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-production-docker"
+  }
+
+  notification {
+    on = "always"
+  }
+}
+
+event "promote-production-packaging" {
+  depends = ["promote-production-docker"]
 
   action "promote-production-packaging" {
     organization = "hashicorp"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-FROM busybox:1.36.0 as release
+# busybox:v1.36.0
+FROM busybox@sha256:acaddd9ed544f7baf3373064064a51250b14cfe3ec604d65765a53da5958e5f5 as release
 
 ARG PRODUCT_NAME=nomad
 ARG PRODUCT_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+FROM busybox:1.36.0 as release
+
+ARG PRODUCT_NAME=nomad
+ARG PRODUCT_VERSION
+ARG PRODUCT_REVISION
+# TARGETARCH and TARGETOS are set automatically when --platform is provided.
+ARG TARGETOS TARGETARCH
+
+LABEL maintainer="Nomad Team <nomad@hashicorp.com>"
+LABEL version=${PRODUCT_VERSION}
+LABEL revision=${PRODUCT_REVISION}
+
+COPY dist/$TARGETOS/$TARGETARCH/nomad /bin/
+COPY ./scripts/docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-# busybox:v1.36.0
-FROM busybox@sha256:acaddd9ed544f7baf3373064064a51250b14cfe3ec604d65765a53da5958e5f5 as release
+# docker.io/library/busybox:1.36.0
+# When pinning use the multi-arch manifest list, `docker buildx imagetools inspect ...`
+FROM docker.io/library/busybox@sha256:9e2bbca079387d7965c3a9cee6d0c53f4f4e63ff7637877a83c4c05f2a666112 as release
 
 ARG PRODUCT_NAME=nomad
 ARG PRODUCT_VERSION

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env ash
+
+case "$1" in
+  "agent" )
+    if [[ -z "${NOMAD_SKIP_DOCKER_IMAGE_WARN}" ]]
+    then
+      echo "====================================================================================="
+      echo "!! Running Nomad clients inside Docker containers is not supported.                !!"
+      echo "!! Refer to https://www.nomadproject.io/s/nomad-in-docker for more information.    !!"
+      echo "!! Set the NOMAD_SKIP_DOCKER_IMAGE_WARN environment variable to skip this warning. !!"
+      echo "====================================================================================="
+      echo ""
+      sleep 2
+    fi
+esac
+
+exec nomad "$@"

--- a/website/content/docs/install/production/requirements.mdx
+++ b/website/content/docs/install/production/requirements.mdx
@@ -203,6 +203,8 @@ The [`hashicorp/nomad`][nomad_docker_hub] Docker image is intended to be used
 in automated pipelines for [CLI operations][docs_cli], such as
 [`nomad job plan`][], [`nomad fmt`][], and others.
 
+~> **Note:** The Nomad Docker image is not tested when running as an agent.
+
 [Security Model]: /nomad/docs/concepts/security
 [production deployment guide]: /nomad/tutorials/enterprise/production-deployment-guide-vm-with-consul#configure-systemd
 [linux capabilities]: #linux-capabilities

--- a/website/content/docs/install/production/requirements.mdx
+++ b/website/content/docs/install/production/requirements.mdx
@@ -189,9 +189,28 @@ This is not a supported or well-tested configuration. See [GH-13669][] for a
 further discussion and to provide feedback on your experiences trying to run
 rootless Nomad clients.
 
+## Running Nomad in Docker
+
+Running systems as Docker containers has become a common practice. While it's
+possible to run Nomad servers inside containers, Nomad clients require
+extensive access to the underlying host machine, as described in
+[Rootless Nomad Clients][]. Docker containers introduce a non-trivial
+abstraction layer that makes it hard to properly configure clients and task
+drivers therefore **running Nomad clients in Docker containers is not
+officially supported**.
+
+The [`hashicorp/nomad`][nomad_docker_hub] Docker image is intended to be used
+in automated pipelines for [CLI operations][docs_cli], such as
+[`nomad job plan`][], [`nomad fmt`][], and others.
+
 [Security Model]: /nomad/docs/concepts/security
 [production deployment guide]: /nomad/tutorials/enterprise/production-deployment-guide-vm-with-consul#configure-systemd
 [linux capabilities]: #linux-capabilities
 [`capabilities(7)`]: https://man7.org/linux/man-pages/man7/capabilities.7.html
 [overlay filesystem]: https://www.kernel.org/doc/html/latest/filesystems/overlayfs.html
 [GH-13669]: https://github.com/hashicorp/nomad/issues/13669
+[Rootless Nomad Clients]: #hardening-nomad
+[nomad_docker_hub]: https://hub.docker.com/r/hashicorp/nomad
+[docs_cli]: /nomad/docs/commands
+[`nomad job plan`]: /nomad/docs/commands/job/plan
+[`nomad fmt`]: /nomad/docs/commands/fmt

--- a/website/content/docs/install/production/requirements.mdx
+++ b/website/content/docs/install/production/requirements.mdx
@@ -209,7 +209,7 @@ in automated pipelines for [CLI operations][docs_cli], such as
 [`capabilities(7)`]: https://man7.org/linux/man-pages/man7/capabilities.7.html
 [overlay filesystem]: https://www.kernel.org/doc/html/latest/filesystems/overlayfs.html
 [GH-13669]: https://github.com/hashicorp/nomad/issues/13669
-[Rootless Nomad Clients]: #hardening-nomad
+[Rootless Nomad Clients]: #rootless-nomad-clients
 [nomad_docker_hub]: https://hub.docker.com/r/hashicorp/nomad
 [docs_cli]: /nomad/docs/commands
 [`nomad job plan`]: /nomad/docs/commands/job/plan


### PR DESCRIPTION
Update release process to produce a [Docker image](https://hub.docker.com/r/hashicorp/nomad). 

This image is intended for CI usage and running clients as Docker containers is not supported for the reasons described in https://github.com/hashicorp/nomad/issues/6487#issuecomment-542484234 and https://github.com/hashicorp/nomad/issues/6487#issuecomment-1473795286.

Closes https://github.com/hashicorp/nomad/issues/6487