### PR TITLE
allow periodic jobs to use workload identity ACL policies

### DIFF
--- a/.changelog/17018.txt
+++ b/.changelog/17018.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity: Fixed a bug where workload identities for periodic and dispatch jobs would not have access to their parent job's ACL policy
+```

--- a/nomad/acl.go
+++ b/nomad/acl.go
@@ -428,7 +428,11 @@ func (s *Server) resolvePoliciesForClaims(claims *structs.IdentityClaims) ([]*st
 	}
 
 	// Find any policies attached to the job
-	iter, err := snap.ACLPolicyByJob(nil, alloc.Namespace, alloc.Job.ID)
+	jobId := alloc.Job.ID
+	if alloc.Job.ParentID != "" {
+		jobId = alloc.Job.ParentID
+	}
+	iter, err := snap.ACLPolicyByJob(nil, alloc.Namespace, jobId)
 	if err != nil {
 		return nil, err
 	}

--- a/nomad/variables_endpoint_test.go
+++ b/nomad/variables_endpoint_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
@@ -50,7 +51,8 @@ func TestVariablesEndpoint_auth(t *testing.T) {
 	alloc3.ClientStatus = structs.AllocClientStatusRunning
 	alloc3.Job.Namespace = ns
 	alloc3.Namespace = ns
-	alloc3.Job.ParentID = jobID
+	parentID := uuid.Short()
+	alloc3.Job.ParentID = parentID
 
 	alloc4 := mock.Alloc()
 	alloc4.ClientStatus = structs.AllocClientStatusRunning
@@ -224,7 +226,7 @@ func TestVariablesEndpoint_auth(t *testing.T) {
 			name:        "WI for dispatch job can read parent secret",
 			token:       idDispatchToken,
 			cap:         acl.PolicyRead,
-			path:        fmt.Sprintf("nomad/jobs/%s", jobID),
+			path:        fmt.Sprintf("nomad/jobs/%s", parentID),
 			expectedErr: nil,
 		},
 


### PR DESCRIPTION
prevent all calls to the [Task API](https://developer.hashicorp.com/nomad/api-docs/task-api) from a periodically-dispatched job failing with `403`.

This happens because no policy for the job id (one with a `periodic-\d+` suffix) matches the generated token claims (that specifically use the [parent job id](https://github.com/hashicorp/nomad/blob/891999789689240006b2a6076b73ddc67249d48d/nomad/structs/structs.go#L10912C19-L10914)).

## steps to reproduce

Create a policy with

```sh
nomad acl policy apply -namespace default -job example example-job <(cat <<EOF
namespace "default" {
  policy = "write"
}
EOF
)
```

Create a job

```hcl
# example.nomad
job "example" {
  datacenters = ["casa"]
  type = "batch"
  priority = 10

  periodic {
    cron             = "*/15 * * * * *"
    prohibit_overlap = true
  }

  group "example" {
    task "example" {
      driver = "docker"

      config {
        image = "curlimages/curl:7.87.0"
        args = [
          "--unix-socket", "${NOMAD_SECRETS_DIR}/api.sock",
          "-H", "Authorization: Bearer ${NOMAD_TOKEN}",
          "--fail-with-body",
          "--verbose",
          "localhost/v1/client/metadata",
        ]
      }


      identity {
        env = true
        file = false
      }
    }
  }

}
```

Run and dispatch
```sh
nomad run example.nomad 
echo "{}" | nomad job dispatch example -
```

It'll fail with a 403, and upon inspecting the claims we find

```sh
echo "the second part of the JWT, possibly padded with equal signs" | base64 -d | jq
```

```json
{
  "nomad_namespace": "default",
  "nomad_job_id": "example",
  "nomad_allocation_id": "dcc6477e-1b20-afbd-b46a-d3810d198b53",
  "nomad_task": "example",
  "nbf": 1682647044,
  "iat": 1682647044
}
```

but current code searches for policies for job id `example/periodic-\d+`