### PR TITLE
add copywrite headers commit to ignore-revs config file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # This commit just fixes some typos and isn't useful
 b0a20b4dc965a38b0c843f47c16685ccad7439da
+
+# giant copywrite headers commit
+f005448366ed3e796a2f22696d8c063dff4677f8


### PR DESCRIPTION
Update the configuration file that's handy for those of us with `blame.ignoreRevsFile` set