### PR TITLE
connect: envoy remove fallback

### DIFF
--- a/.changelog/17044.txt
+++ b/.changelog/17044.txt
@@ -1,0 +1,3 @@
+```release-note:deprecation
+envoy: remove support for envoy fallback image
+```

--- a/client/allocrunner/taskrunner/envoy_version_hook.go
+++ b/client/allocrunner/taskrunner/envoy_version_hook.go
@@ -5,6 +5,7 @@ package taskrunner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -38,9 +39,8 @@ func newEnvoyVersionHookConfig(alloc *structs.Allocation, proxiesClient consul.S
 
 // envoyVersionHook is used to determine and set the Docker image used for Consul
 // Connect sidecar proxy tasks. It will query Consul for a set of preferred Envoy
-// versions if the task image is unset or references ${NOMAD_envoy_version}. Nomad
-// will fallback the image to the previous default Envoy v1.11.2 if Consul is too old
-// to support the supported proxies API.
+// versions if the task image is unset or references ${NOMAD_envoy_version}. If
+// Consul does not report its supported envoy versions then the hood will fail.
 type envoyVersionHook struct {
 	// alloc is the allocation with the envoy task being rewritten.
 	alloc *structs.Allocation
@@ -165,12 +165,12 @@ func (h *envoyVersionHook) needsVersion(config map[string]interface{}) bool {
 	return strings.Contains(image, envoy.VersionVar)
 }
 
-// tweakImage determines the best Envoy version to use. If supported is nil or empty
-// Nomad will fallback to the legacy envoy image used before Nomad v1.0.
+// tweakImage determines the best Envoy version to use. If no supported versions were
+// detected from the Consul API just return an error.
 func (h *envoyVersionHook) tweakImage(configured string, supported map[string][]string) (string, error) {
 	versions := supported["envoy"]
 	if len(versions) == 0 {
-		return envoy.FallbackImage, nil
+		return "", errors.New("Consul did not report any supported envoy versions")
 	}
 
 	latest, err := semver(versions[0])

--- a/client/allocrunner/taskrunner/envoy_version_hook_test.go
+++ b/client/allocrunner/taskrunner/envoy_version_hook_test.go
@@ -79,9 +79,8 @@ func TestEnvoyVersionHook_tweakImage(t *testing.T) {
 	image := envoy.ImageFormat
 
 	t.Run("legacy", func(t *testing.T) {
-		result, err := (*envoyVersionHook)(nil).tweakImage(image, nil)
-		must.NoError(t, err)
-		must.Eq(t, envoy.FallbackImage, result)
+		_, err := (*envoyVersionHook)(nil).tweakImage(image, nil)
+		must.Error(t, err)
 	})
 
 	t.Run("unexpected", func(t *testing.T) {
@@ -350,7 +349,7 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_skip(t *testing.T) {
 	must.MapNotContainsKey(t, request.Task.Config, "image")
 }
 
-func TestTaskRunner_EnvoyVersionHook_Prestart_fallback(t *testing.T) {
+func TestTaskRunner_EnvoyVersionHook_Prestart_no_fallback(t *testing.T) {
 	ci.Parallel(t)
 
 	logger := testlog.HCLogger(t)
@@ -382,10 +381,7 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_fallback(t *testing.T) {
 	var response ifs.TaskPrestartResponse
 
 	// Run the hook
-	must.NoError(t, h.Prestart(context.Background(), request, &response))
-
-	// Assert the Task.Config[image] is the fallback image
-	must.Eq(t, "envoyproxy/envoy:v1.11.2@sha256:a7769160c9c1a55bb8d07a3b71ce5d64f72b1f665f10d81aa1581bc3cf850d09", request.Task.Config["image"])
+	must.Error(t, h.Prestart(context.Background(), request, &response))
 }
 
 func TestTaskRunner_EnvoyVersionHook_Prestart_error(t *testing.T) {

--- a/helper/envoy/envoy.go
+++ b/helper/envoy/envoy.go
@@ -47,12 +47,6 @@ const (
 	// VersionVar will be replaced with the Envoy version string when
 	// used in the meta.connect.sidecar_image variable.
 	VersionVar = "${NOMAD_envoy_version}"
-
-	// FallbackImage is the image set in the node meta by default
-	// to be used by Consul Connect sidecar tasks. As of Nomad 1.0, this value
-	// is only used as a fallback when the version of Consul does not yet support
-	// dynamic envoy versions.
-	FallbackImage = "envoyproxy/envoy:v1.11.2@sha256:a7769160c9c1a55bb8d07a3b71ce5d64f72b1f665f10d81aa1581bc3cf850d09"
 )
 
 // PortLabel creates a consistent port label using the inputs of a prefix,


### PR DESCRIPTION
This PR does some cleanup of an old code path for versions of Consul that
did not support reporting the supported versions of Envoy in its API. Those
versions are no longer supported for years at this point, and the fallback
version of envoy hasn't been supported by any version of Consul for almost
as long. Remove this code path that is no longer useful.