### PR TITLE
connect: set default envoy version domain

### DIFF
--- a/.changelog/17045.txt
+++ b/.changelog/17045.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: use full docker.io prefixed name for envoy image references
+```

--- a/client/allocrunner/taskrunner/envoy_version_hook.go
+++ b/client/allocrunner/taskrunner/envoy_version_hook.go
@@ -67,7 +67,7 @@ func (_ *envoyVersionHook) Name() string {
 
 func (h *envoyVersionHook) Prestart(_ context.Context, request *ifs.TaskPrestartRequest, _ *ifs.TaskPrestartResponse) error {
 	// First interpolation of the task image. Typically this turns the default
-	// ${meta.connect.sidecar_task} into envoyproxy/envoy:v${NOMAD_envoy_version}
+	// ${meta.connect.sidecar_task} into docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}
 	// but could be a no-op or some other value if so configured.
 	h.interpolateImage(request.Task, request.TaskEnv)
 

--- a/client/allocrunner/taskrunner/envoy_version_hook_test.go
+++ b/client/allocrunner/taskrunner/envoy_version_hook_test.go
@@ -96,7 +96,7 @@ func TestEnvoyVersionHook_tweakImage(t *testing.T) {
 			"envoy": {"1.15.0", "1.14.4", "1.13.4", "1.12.6"},
 		})
 		must.NoError(t, err)
-		must.Eq(t, "envoyproxy/envoy:v1.15.0", result)
+		must.Eq(t, "docker.io/envoyproxy/envoy:v1.15.0", result)
 	})
 
 	t.Run("custom image", func(t *testing.T) {
@@ -261,7 +261,7 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_standard(t *testing.T) {
 	must.NoError(t, h.Prestart(context.Background(), request, &response))
 
 	// Assert the Task.Config[image] is concrete
-	must.Eq(t, "envoyproxy/envoy:v1.15.0", request.Task.Config["image"])
+	must.Eq(t, "docker.io/envoyproxy/envoy:v1.15.0", request.Task.Config["image"])
 }
 
 func TestTaskRunner_EnvoyVersionHook_Prestart_custom(t *testing.T) {
@@ -459,7 +459,7 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_restart(t *testing.T) {
 
 	// Run the hook and ensure the tasks image has been modified.
 	must.NoError(t, h.Prestart(context.Background(), request, &response))
-	must.Eq(t, "envoyproxy/envoy:v1.15.0", request.Task.Config["image"])
+	must.Eq(t, "docker.io/envoyproxy/envoy:v1.15.0", request.Task.Config["image"])
 
 	// Overwrite the previously modified image. This is the same behaviour that
 	// occurs when the server sends a non-destructive allocation update.
@@ -467,10 +467,10 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_restart(t *testing.T) {
 
 	// Run the Prestart hook function again, and ensure the image is updated.
 	must.NoError(t, h.Prestart(context.Background(), request, &response))
-	must.Eq(t, "envoyproxy/envoy:v1.15.0", request.Task.Config["image"])
+	must.Eq(t, "docker.io/envoyproxy/envoy:v1.15.0", request.Task.Config["image"])
 
 	// Run the hook again, and ensure the config is still the same mimicking
 	// a non-user initiated restart.
 	must.NoError(t, h.Prestart(context.Background(), request, &response))
-	must.Eq(t, "envoyproxy/envoy:v1.15.0", request.Task.Config["image"])
+	must.Eq(t, "docker.io/envoyproxy/envoy:v1.15.0", request.Task.Config["image"])
 }

--- a/helper/envoy/envoy.go
+++ b/helper/envoy/envoy.go
@@ -42,7 +42,7 @@ const (
 	// Folks wanting to build and use custom images while still having Nomad refer
 	// to specific versions as preferred by Consul would set meta.connect.sidecar_image
 	// to something like: "custom/envoy:${NOMAD_envoy_version}".
-	ImageFormat = "envoyproxy/envoy:v" + VersionVar
+	ImageFormat = "docker.io/envoyproxy/envoy:v" + VersionVar
 
 	// VersionVar will be replaced with the Envoy version string when
 	// used in the meta.connect.sidecar_image variable.

--- a/website/content/api-docs/client.mdx
+++ b/website/content/api-docs/client.mdx
@@ -75,8 +75,8 @@ Formatted by appending `?pretty` above.
 {
     "Meta": {
         "connect.proxy_concurrency": "1",
-        "connect.sidecar_image": "envoyproxy/envoy:v${NOMAD_envoy_version}",
-        "connect.gateway_image": "envoyproxy/envoy:v${NOMAD_envoy_version}",
+        "connect.sidecar_image": "docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}",
+        "connect.gateway_image": "docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}",
         "connect.log_level": "debug",
         "foo": "bar"
     },
@@ -86,8 +86,8 @@ Formatted by appending `?pretty` above.
         "connect.log_level": "debug"
     },
     "Static": {
-        "connect.sidecar_image": "envoyproxy/envoy:v${NOMAD_envoy_version}",
-        "connect.gateway_image": "envoyproxy/envoy:v${NOMAD_envoy_version}",
+        "connect.sidecar_image": "docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}",
+        "connect.gateway_image": "docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}",
         "connect.log_level": "info",
         "connect.proxy_concurrency": "1"
     }
@@ -165,8 +165,8 @@ Formatted by appending `?pretty` above.
 {
     "Meta": {
         "connect.proxy_concurrency": "1",
-        "connect.sidecar_image": "envoyproxy/envoy:v${NOMAD_envoy_version}",
-        "connect.gateway_image": "envoyproxy/envoy:v${NOMAD_envoy_version}",
+        "connect.sidecar_image": "docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}",
+        "connect.gateway_image": "docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}",
         "connect.log_level": "debug",
         "foo": "bar"
     },
@@ -176,8 +176,8 @@ Formatted by appending `?pretty` above.
         "connect.log_level": "debug"
     },
     "Static": {
-        "connect.sidecar_image": "envoyproxy/envoy:v${NOMAD_envoy_version}",
-        "connect.gateway_image": "envoyproxy/envoy:v${NOMAD_envoy_version}",
+        "connect.sidecar_image": "docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}",
+        "connect.gateway_image": "docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}",
         "connect.log_level": "info",
         "connect.proxy_concurrency": "1"
     }

--- a/website/content/docs/commands/node/meta/read.mdx
+++ b/website/content/docs/commands/node/meta/read.mdx
@@ -43,20 +43,20 @@ nomad node meta read [-json] [-node-id ...]
 $ nomad node meta read -node-id 3b58b0a6
 
 All Meta
-connect.gateway_image     = envoyproxy/envoy:v${NOMAD_envoy_version}
+connect.gateway_image     = docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}
 connect.log_level         = info
 connect.proxy_concurrency = 1
-connect.sidecar_image     = envoyproxy/envoy:v${NOMAD_envoy_version}
+connect.sidecar_image     = docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}
 example                   = a
 
 Dynamic Meta
 example = a
 
 Static Meta
-connect.gateway_image     = envoyproxy/envoy:v${NOMAD_envoy_version}
+connect.gateway_image     = docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}
 connect.log_level         = info
 connect.proxy_concurrency = 1
-connect.sidecar_image     = envoyproxy/envoy:v${NOMAD_envoy_version}
+connect.sidecar_image     = docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}
 ```
 
 [api]: /nomad/api-docs/client#read-node-metadata

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -199,7 +199,7 @@ are enabled.
 ### Specify Envoy image
 
 The Docker image used for Connect gateway tasks defaults to the official [Envoy
-Docker] image, `envoyproxy/envoy:v${NOMAD_envoy_version}`, where `${NOMAD_envoy_version}`
+Docker] image, `docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}`, where `${NOMAD_envoy_version}`
 is resolved automatically by a query to Consul. The image to use can be configured
 by setting `meta.connect.gateway_image` in the Nomad job. Custom images can still
 make use of the envoy version interpolation, e.g.

--- a/website/content/docs/job-specification/sidecar_task.mdx
+++ b/website/content/docs/job-specification/sidecar_task.mdx
@@ -105,10 +105,10 @@ The `meta.connect.sidecar_image`, `meta.connect.gateway_image`, `meta.connect.lo
 and `meta.connect.proxy_concurrency` variables are [client configurable][nodemeta]
 variables with the following defaults:
 
-- `sidecar_image` - `(string: "envoyproxy/envoy:v${NOMAD_envoy_version}")` - The official
+- `sidecar_image` - `(string: "docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}")` - The official
   upstream Envoy Docker image, where `${NOMAD_envoy_version}` is resolved automatically
   by a query to Consul.
-- `gateway_image` - `(string: "envoyproxy/envoy:v${NOMAD_envoy_version}")` - The official
+- `gateway_image` - `(string: "docker.io/envoyproxy/envoy:v${NOMAD_envoy_version}")` - The official
   upstream Envoy Docker image, where `${NOMAD_envoy_version}` is resolved automatically
   by a query to Consul.
 - `log_level` - `(string: "info")` - Envoy sidecar log level. "`debug`" is useful for


### PR DESCRIPTION
This PR modifies references to the `envoyproxy/envoy` docker image to
explicitly include the `docker.io` prefix. This does not affect existing
[docker] users, but makes things easier for Podman users, who otherwise need to
specify the full name because Podman does not default to `docker.io`