### PR TITLE
[ui, deployments] Job status for System Jobs

### DIFF
--- a/ui/app/components/job-status/panel.hbs
+++ b/ui/app/components/job-status/panel.hbs
@@ -1,5 +1,5 @@
 {{#if this.isActivelyDeploying}}
   <JobStatus::Panel::Deploying @job={{@job}} @handleError={{@handleError}} />
 {{else}}
-  <JobStatus::Panel::Steady @job={{@job}} @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} />
+  <JobStatus::Panel::Steady @job={{@job}} @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} @nodes={{this.nodes}} />
 {{/if}}

--- a/ui/app/components/job-status/panel.js
+++ b/ui/app/components/job-status/panel.js
@@ -1,8 +1,15 @@
 // @ts-check
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 
 export default class JobStatusPanelComponent extends Component {
+  @service store;
+
   get isActivelyDeploying() {
     return this.args.job.get('latestDeployment.isRunning');
+  }
+
+  get nodes() {
+    return this.store.peekAll('node');
   }
 }

--- a/ui/app/components/job-status/panel.js
+++ b/ui/app/components/job-status/panel.js
@@ -10,6 +10,9 @@ export default class JobStatusPanelComponent extends Component {
   }
 
   get nodes() {
+    if (!this.args.job.get('hasClientStatus')) {
+      return [];
+    }
     return this.store.peekAll('node');
   }
 }

--- a/ui/app/components/job-status/panel/deploying.js
+++ b/ui/app/components/job-status/panel/deploying.js
@@ -30,9 +30,7 @@ export default class JobStatusPanelDeployingComponent extends Component {
   // allocations we can track throughout a deployment
   establishOldAllocBlockIDs() {
     this.oldVersionAllocBlockIDs = this.job.allocations.filter(
-      (a) =>
-        a.clientStatus === 'running' &&
-        a.jobVersion !== this.deployment.get('versionNumber')
+      (a) => a.clientStatus === 'running' && a.isOld
     );
   }
 
@@ -84,7 +82,7 @@ export default class JobStatusPanelDeployingComponent extends Component {
   get newVersionAllocBlocks() {
     let availableSlotsToFill = this.desiredTotal;
     let allocationsOfDeploymentVersion = this.job.allocations.filter(
-      (a) => a.jobVersion === this.deployment.get('versionNumber')
+      (a) => !a.isOld
     );
 
     let allocationCategories = this.allocTypes.reduce((categories, type) => {
@@ -153,19 +151,11 @@ export default class JobStatusPanelDeployingComponent extends Component {
   }
 
   get rescheduledAllocs() {
-    return this.job.allocations.filter(
-      (a) =>
-        a.jobVersion === this.job.latestDeployment.get('versionNumber') &&
-        a.hasBeenRescheduled
-    );
+    return this.job.allocations.filter((a) => !a.isOld && a.hasBeenRescheduled);
   }
 
   get restartedAllocs() {
-    return this.job.allocations.filter(
-      (a) =>
-        a.jobVersion === this.job.latestDeployment.get('versionNumber') &&
-        a.hasBeenRestarted
-    );
+    return this.job.allocations.filter((a) => !a.isOld && a.hasBeenRestarted);
   }
 
   // #region legend

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -69,7 +69,7 @@
           <ul>
             {{#each-in this.versions as |version allocs|}}
               <li>
-                <LinkTo @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' version ']')    status=(concat '["running", "pending", "failed"]')         }}>
+                <LinkTo data-version={{version}} @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' version ']')    status=(concat '["running", "pending", "failed"]')         }}>
                   <Hds::Badge @text={{concat "v" version}} />
                   <Hds::BadgeCount @text={{allocs.length}} @type="inverted" />
                 </LinkTo>

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -21,7 +21,14 @@
     {{#if (eq @statusMode "historical")}}
       <JobPage::Parts::SummaryChart @job={{@job}} />
     {{else}}
-      <h3 class="title is-4 running-allocs-title"><strong>{{@job.runningAllocs}}/{{this.totalAllocs}}</strong> Allocations Running</h3>
+      <h3 class="title is-4 running-allocs-title">
+        <strong>
+          {{@job.runningAllocs ~}}
+          {{#unless this.atMostOneAllocPerNode ~}}
+            /{{this.totalAllocs}}
+          {{/unless}}
+        </strong>
+        {{pluralize "Allocation" @job.runningAllocs}} Running</h3>
       <JobStatus::AllocationStatusRow @allocBlocks={{this.allocBlocks}} @steady={{true}} />
 
       <div class="legend-and-summary">

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -41,12 +41,14 @@
           {{/each}}
         </legend>
 
-        <JobStatus::FailedOrLost
-          @allocs={{this.rescheduledAllocs}}
-          @job={{@job}}
-          @title="Rescheduled"
-          @description="Allocations that have been rescheduled, on another node if possible, due to failure"
-        />
+        {{#if this.supportsRescheduling}}
+          <JobStatus::FailedOrLost
+            @allocs={{this.rescheduledAllocs}}
+            @job={{@job}}
+            @title="Rescheduled"
+            @description="Allocations that have been rescheduled, on another node if possible, due to failure"
+          />
+        {{/if}}
 
         <JobStatus::FailedOrLost
           @allocs={{this.restartedAllocs}}

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -23,32 +23,91 @@ export default class JobStatusPanelSteadyComponent extends Component {
     };
   });
 
+  /**
+   * @typedef {Object} HealthStatus
+   * @property {Array} nonCanary
+   * @property {Array} canary
+   */
+
+  /**
+   * @typedef {Object} AllocationStatus
+   * @property {HealthStatus} healthy
+   * @property {HealthStatus} unhealthy
+   */
+
+  /**
+   * @typedef {Object} AllocationBlock
+   * @property {AllocationStatus} [RUNNING]
+   * @property {AllocationStatus} [PENDING]
+   * @property {AllocationStatus} [FAILED]
+   * @property {AllocationStatus} [LOST]
+   * @property {AllocationStatus} [UNPLACED]
+   */
+
+  /**
+   * Looks through running/pending allocations with the aim of filling up your desired number of allocations.
+   * If any desired remain, it will walk backwards through job versions and other allocation types to build
+   * a picture of the job's overall status.
+   *
+   * @returns {AllocationBlock} An object containing healthy non-canary allocations
+   *                            for each clientStatus.
+   */
   get allocBlocks() {
     let availableSlotsToFill = this.totalAllocs;
-    // Only fill up to 100% of totalAllocs. Once we've filled up, we can stop counting.
-    let allocationsOfShowableType = this.allocTypes.reduce((blocks, type) => {
-      const jobAllocsOfType = this.args.job.allocations
-        .sortBy('jobVersion') // Try counting from latest deployment's allocs and work backwards if needed
-        .reverse()
-        .filterBy('clientStatus', type.label);
-      if (availableSlotsToFill > 0) {
-        blocks[type.label] = {
-          healthy: {
-            nonCanary: Array(
-              Math.min(availableSlotsToFill, jobAllocsOfType.length)
-            )
-              .fill()
-              .map((_, i) => {
-                return jobAllocsOfType[i];
-              }),
-          },
-        };
-        availableSlotsToFill -= blocks[type.label].healthy.nonCanary.length;
-      } else {
-        blocks[type.label] = { healthy: { nonCanary: [] } };
+
+    // Initialize allocationsOfShowableType with empty arrays for each clientStatus
+    /**
+     * @type {AllocationBlock}
+     */
+    let allocationsOfShowableType = this.allocTypes.reduce(
+      (accumulator, type) => {
+        accumulator[type.label] = { healthy: { nonCanary: [] } };
+        return accumulator;
+      },
+      {}
+    );
+
+    // First accumulate the Running/Pending allocations
+    for (const alloc of this.job.allocations.filter(
+      (a) => a.clientStatus === 'running' || a.clientStatus === 'pending'
+    )) {
+      if (availableSlotsToFill === 0) {
+        break;
       }
-      return blocks;
-    }, {});
+
+      const status = alloc.clientStatus;
+      allocationsOfShowableType[status].healthy.nonCanary.push(alloc);
+      availableSlotsToFill--;
+    }
+
+    // Sort all allocs by jobVersion in descending order
+    const sortedAllocs = this.args.job.allocations
+      .filter(
+        (a) => a.clientStatus !== 'running' && a.clientStatus !== 'pending'
+      )
+      .sortBy('jobVersion')
+      .reverse();
+
+    // Iterate over the sorted allocs
+    for (const alloc of sortedAllocs) {
+      if (availableSlotsToFill === 0) {
+        break;
+      }
+
+      const status = alloc.clientStatus;
+      // If the alloc has another clientStatus, add it to the corresponding list
+      // as long as we haven't reached the totalAllocs limit for that clientStatus
+      if (
+        this.allocTypes.map(({ label }) => label).includes(status) &&
+        allocationsOfShowableType[status].healthy.nonCanary.length <
+          this.totalAllocs
+      ) {
+        allocationsOfShowableType[status].healthy.nonCanary.push(alloc);
+        availableSlotsToFill--;
+      }
+    }
+
+    // Handle unplaced allocs
     if (availableSlotsToFill > 0) {
       allocationsOfShowableType['unplaced'] = {
         healthy: {
@@ -60,6 +119,7 @@ export default class JobStatusPanelSteadyComponent extends Component {
         },
       };
     }
+
     return allocationsOfShowableType;
   }
 
@@ -97,15 +157,11 @@ export default class JobStatusPanelSteadyComponent extends Component {
   }
 
   get rescheduledAllocs() {
-    return this.job.allocations.filter(
-      (a) => a.jobVersion === this.job.version && a.hasBeenRescheduled
-    );
+    return this.job.allocations.filter((a) => !a.isOld && a.hasBeenRescheduled);
   }
 
   get restartedAllocs() {
-    return this.job.allocations.filter(
-      (a) => a.jobVersion === this.job.version && a.hasBeenRestarted
-    );
+    return this.job.allocations.filter((a) => !a.isOld && a.hasBeenRestarted);
   }
 
   get supportsRescheduling() {

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -82,6 +82,8 @@ export default class JobStatusPanelSteadyComponent extends Component {
       // return this.args.job.allocations
       //   .filter((a) => a.jobVersion === this.args.job.version)
       //   .uniqBy('node.id').length;
+    } else {
+      return this.args.job.count; // TODO: this is probably not the correct totalAllocs count for any type.
     }
   }
 
@@ -102,9 +104,7 @@ export default class JobStatusPanelSteadyComponent extends Component {
 
   get rescheduledAllocs() {
     return this.job.allocations.filter(
-      (a) =>
-        a.jobVersion === this.job.latestDeployment.get('versionNumber') &&
-        a.hasBeenRescheduled
+      (a) => a.jobVersion === this.job.version && a.hasBeenRescheduled
     );
   }
 

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -61,13 +61,15 @@ export default class JobStatusPanelSteadyComponent extends Component {
     return allocationsOfShowableType;
   }
 
-  // TODO: eventually we will want this from a new property on a job.
   get totalAllocs() {
-    // v----- Experimental method: Count all allocs. Good for testing but not a realistic representation of "Desired"
-    // return this.allocTypes.reduce((sum, type) => sum + this.args.job[type.property], 0);
-
-    // v----- Realistic method: Tally a job's task groups' "count" property
-    return this.args.job.taskGroups.reduce((sum, tg) => sum + tg.count, 0);
+    if (this.args.job.type === 'service') {
+      return this.args.job.taskGroups.reduce((sum, tg) => sum + tg.count, 0);
+    } else if (this.args.job.type === 'system') {
+      // return this.args.job.allocations.uniqBy('node.id').length
+      return this.args.job.allocations
+        .filter((a) => a.jobVersion === this.args.job.version)
+        .uniqBy('node.id').length;
+    }
   }
 
   get versions() {

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -1,10 +1,8 @@
 // @ts-check
 import Component from '@glimmer/component';
 import { alias } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
 
 export default class JobStatusPanelSteadyComponent extends Component {
-  @service can;
   @alias('args.job') job;
 
   // Build note: allocTypes order matters! We will fill up to 100% of totalAllocs in this order.

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -32,6 +32,7 @@ export default class Allocation extends Model {
   @belongsTo('job') job;
   @belongsTo('node') node;
   @attr('string') namespace;
+  @attr('string') nodeID;
   @attr('string') name;
   @attr('string') taskGroupName;
   @fragment('resources') resources;

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -159,7 +159,6 @@
         // TODO: we eventually want to establish a minimum width here. However, we need to also include this in the allocation-status-block width computation.
         font-size: 0.8rem;
         font-weight: bold;
-        text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
         width: 100%;
 
         & > .rest-count {

--- a/ui/app/templates/components/job-page/system.hbs
+++ b/ui/app/templates/components/job-page/system.hbs
@@ -9,8 +9,9 @@
     <jobPage.ui.Title />
     <jobPage.ui.StatsBox />
     <jobPage.ui.DasRecommendations />
+    <jobPage.ui.StatusPanel @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} />
     <jobPage.ui.JobClientStatusSummary />
-    <jobPage.ui.Summary @forceCollapsed="true" />
+    <jobPage.ui.Summary />
     <jobPage.ui.PlacementFailures />
     <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}} />
     <jobPage.ui.RecentAllocations @activeTask={{@activeTask}} @setActiveTaskQueryParam={{@setActiveTaskQueryParam}} />

--- a/ui/app/templates/components/job-page/system.hbs
+++ b/ui/app/templates/components/job-page/system.hbs
@@ -10,8 +10,6 @@
     <jobPage.ui.StatsBox />
     <jobPage.ui.DasRecommendations />
     <jobPage.ui.StatusPanel @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} />
-    <jobPage.ui.JobClientStatusSummary />
-    <jobPage.ui.Summary />
     <jobPage.ui.PlacementFailures />
     <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}} />
     <jobPage.ui.RecentAllocations @activeTask={{@activeTask}} @setActiveTaskQueryParam={{@setActiveTaskQueryParam}} />

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -225,7 +225,7 @@ moduleForJob(
 moduleForJob(
   'Acceptance | job detail (service)',
   'allocations',
-  () => server.create('job', { type: 'service' }),
+  () => server.create('job', { type: 'service', noActiveDeployment: true }),
   {
     'the subnav links to deployment': async (job, assert) => {
       await JobDetail.tabFor('deployments').visit();
@@ -266,6 +266,7 @@ module('Acceptance | job detail (with namespaces)', function (hooks) {
       type: 'service',
       status: 'running',
       namespaceId: server.db.namespaces[1].name,
+      noActiveDeployment: true,
     });
     server.createList('job', 3, {
       namespaceId: server.db.namespaces[0].name,
@@ -414,6 +415,7 @@ module('Acceptance | job detail (with namespaces)', function (hooks) {
       namespaceId: server.db.namespaces[1].name,
       groupsCount: 3,
       createRecommendations: true,
+      noActiveDeployment: true,
     });
 
     window.localStorage.nomadTokenSecret = managementToken.secretId;

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -21,7 +21,11 @@ moduleForJob('Acceptance | job detail (batch)', 'allocations', () =>
 );
 
 moduleForJob('Acceptance | job detail (system)', 'allocations', () =>
-  server.create('job', { type: 'system', shallow: true })
+  server.create('job', {
+    type: 'system',
+    shallow: true,
+    noActiveDeployment: true,
+  })
 );
 
 moduleForJob('Acceptance | job detail (sysbatch)', 'allocations', () =>

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -24,29 +24,6 @@ moduleForJob('Acceptance | job detail (system)', 'allocations', () =>
   server.create('job', { type: 'system', shallow: true })
 );
 
-moduleForJobWithClientStatus(
-  'Acceptance | job detail with client status (system)',
-  () =>
-    server.create('job', {
-      status: 'running',
-      datacenters: ['dc1'],
-      type: 'system',
-      createAllocations: false,
-    })
-);
-
-moduleForJobWithClientStatus(
-  'Acceptance | job detail with client status (system with wildcard dc)',
-  () =>
-    server.create('job', {
-      id: 'system-wildcard-dc',
-      status: 'running',
-      datacenters: ['canada-*-1'],
-      type: 'system',
-      createAllocations: false,
-    })
-);
-
 moduleForJob('Acceptance | job detail (sysbatch)', 'allocations', () =>
   server.create('job', { type: 'sysbatch', shallow: true })
 );

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -709,7 +709,6 @@ module('Acceptance | job status panel', function (hooks) {
   });
 
   module('System jobs', function () {
-    // TODO
     test('System jobs show restarted but not rescheduled allocs', async function (assert) {
       this.store = this.owner.lookup('service:store');
 
@@ -726,6 +725,7 @@ module('Acceptance | job status panel', function (hooks) {
         },
         noActiveDeployment: true,
         shallow: true,
+        version: 0,
       });
 
       let state = server.create('task-state');
@@ -737,96 +737,92 @@ module('Acceptance | job status panel', function (hooks) {
 
       await visit(`/jobs/${job.id}`);
       assert.dom('.job-status-panel').exists();
-      assert.ok(true);
-      // await this.pauseTest();
-      // assert
-      //   .dom('.failed-or-lost')
-      //   .exists({ count: 2 }, 'Restarted and Rescheduled cells are both present');
+      assert.dom('.failed-or-lost').exists({ count: 1 });
+      assert.dom('.failed-or-lost h4').hasText('Restarted');
+      assert
+        .dom('.failed-or-lost-link')
+        .hasText('0', 'Restarted cell at zero by default');
 
-      // let rescheduledCell = [...findAll('.failed-or-lost')][0];
-      // let restartedCell = [...findAll('.failed-or-lost')][1];
+      // A wild event appears! Change a recent task event to type "Restarting" in a task state:
+      this.store
+        .peekAll('job')
+        .objectAt(0)
+        .get('allocations')
+        .objectAt(0)
+        .get('states')
+        .objectAt(0)
+        .get('events')
+        .objectAt(0)
+        .set('type', 'Restarting');
 
-      // // Check that the title in each cell has the right text
-      // assert.dom(rescheduledCell.querySelector('h4')).hasText('Rescheduled');
-      // assert.dom(restartedCell.querySelector('h4')).hasText('Restarted');
+      await settled();
 
-      // // Check that both values are zero and non-links
-      // assert
-      //   .dom(rescheduledCell.querySelector('a'))
-      //   .doesNotExist('Rescheduled cell is not a link');
-      // assert
-      //   .dom(rescheduledCell.querySelector('.failed-or-lost-link'))
-      //   .hasText('0', 'Rescheduled cell has zero value');
-      // assert
-      //   .dom(restartedCell.querySelector('a'))
-      //   .doesNotExist('Restarted cell is not a link');
-      // assert
-      //   .dom(restartedCell.querySelector('.failed-or-lost-link'))
-      //   .hasText('0', 'Restarted cell has zero value');
-
-      // // A wild event appears! Change a recent task event to type "Restarting" in a task state:
-      // this.store
-      //   .peekAll('job')
-      //   .objectAt(0)
-      //   .get('allocations')
-      //   .objectAt(0)
-      //   .get('states')
-      //   .objectAt(0)
-      //   .get('events')
-      //   .objectAt(0)
-      //   .set('type', 'Restarting');
-
-      // await settled();
-
-      // assert
-      //   .dom(restartedCell.querySelector('.failed-or-lost-link'))
-      //   .hasText(
-      //     '1',
-      //     'Restarted cell updates when a task event with type "Restarting" is added'
-      //   );
-
-      // this.store
-      //   .peekAll('job')
-      //   .objectAt(0)
-      //   .get('allocations')
-      //   .objectAt(1)
-      //   .get('states')
-      //   .objectAt(0)
-      //   .get('events')
-      //   .objectAt(0)
-      //   .set('type', 'Restarting');
-
-      // await settled();
-
-      // // Trigger a reschedule! Set up a desiredTransition object with a Reschedule property on one of the allocations.
-      // assert
-      //   .dom(restartedCell.querySelector('.failed-or-lost-link'))
-      //   .hasText(
-      //     '2',
-      //     'Restarted cell updates when a second task event with type "Restarting" is added'
-      //   );
-
-      // this.store
-      //   .peekAll('job')
-      //   .objectAt(0)
-      //   .get('allocations')
-      //   .objectAt(0)
-      //   .get('followUpEvaluation')
-      //   .set('content', { 'test-key': 'not-empty' });
-
-      // await settled();
-
-      // assert
-      //   .dom(rescheduledCell.querySelector('.failed-or-lost-link'))
-      //   .hasText('1', 'Rescheduled cell updates when desiredTransition is set');
-      // assert
-      //   .dom(rescheduledCell.querySelector('a'))
-      //   .exists('Rescheduled cell with a non-zero number is now a link');
+      assert
+        .dom('.failed-or-lost-link')
+        .hasText(
+          '1',
+          'Restarted cell updates when a task event with type "Restarting" is added'
+        );
     });
 
-    // TODO
-    test("System jobs' totalAllocs count matches the number of nodes that exist", async function (assert) {
-      assert.ok(true);
+    test('System jobs do not have a sense of Desired/Total allocs', async function (assert) {
+      this.store = this.owner.lookup('service:store');
+
+      server.db.nodes.remove();
+
+      server.createList('node', 3, {
+        status: 'ready',
+        drain: false,
+        schedulingEligibility: 'eligible',
+      });
+
+      let job = server.create('job', {
+        status: 'running',
+        datacenters: ['*'],
+        type: 'system',
+        createAllocations: false,
+        noActiveDeployment: true,
+        shallow: true,
+        version: 0,
+      });
+
+      // Create an allocation on this job for each node
+      server.schema.nodes.all().models.forEach((node) => {
+        server.create('allocation', {
+          jobId: job.id,
+          jobVersion: 0,
+          clientStatus: 'running',
+          nodeId: node.id,
+        });
+      });
+
+      await visit(`/jobs/${job.id}`);
+      let storedJob = await this.store.find(
+        'job',
+        JSON.stringify([job.id, 'default'])
+      );
+      let summary = await storedJob.get('summary');
+      summary
+        .get('taskGroupSummaries')
+        .objectAt(0)
+        .set(
+          'runningAllocs',
+          server.schema.allocations.where({
+            jobId: job.id,
+            clientStatus: 'running',
+          }).length
+        );
+      await settled();
+
+      assert.dom('.job-status-panel').exists();
+      assert.dom('.running-allocs-title').hasText(
+        `${
+          server.schema.allocations.where({
+            jobId: job.id,
+            clientStatus: 'running',
+          }).length
+        } Allocations Running`
+      );
     });
 
     // TODO, post-https://github.com/hashicorp/nomad/pull/17073 merge

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -628,4 +628,131 @@ module('Acceptance | job status panel', function (hooks) {
         .exists('No match message is shown');
     });
   });
+
+  module('System jobs', function () {
+    // TODO
+    test('System jobs show restarted but not rescheduled allocs', async function (assert) {
+      this.store = this.owner.lookup('service:store');
+
+      let job = server.create('job', {
+        status: 'running',
+        datacenters: ['*'],
+        type: 'system',
+        createAllocations: true,
+        allocStatusDistribution: {
+          running: 0.5,
+          failed: 0.5,
+          unknown: 0,
+          lost: 0,
+        },
+        noActiveDeployment: true,
+        shallow: true,
+      });
+
+      let state = server.create('task-state');
+      state.events = server.schema.taskEvents.where({ taskStateId: state.id });
+      server.schema.allocations.where({ jobId: job.id }).update({
+        taskStateIds: [state.id],
+        jobVersion: 0,
+      });
+
+      await visit(`/jobs/${job.id}`);
+      assert.dom('.job-status-panel').exists();
+      assert.ok(true);
+      // await this.pauseTest();
+      // assert
+      //   .dom('.failed-or-lost')
+      //   .exists({ count: 2 }, 'Restarted and Rescheduled cells are both present');
+
+      // let rescheduledCell = [...findAll('.failed-or-lost')][0];
+      // let restartedCell = [...findAll('.failed-or-lost')][1];
+
+      // // Check that the title in each cell has the right text
+      // assert.dom(rescheduledCell.querySelector('h4')).hasText('Rescheduled');
+      // assert.dom(restartedCell.querySelector('h4')).hasText('Restarted');
+
+      // // Check that both values are zero and non-links
+      // assert
+      //   .dom(rescheduledCell.querySelector('a'))
+      //   .doesNotExist('Rescheduled cell is not a link');
+      // assert
+      //   .dom(rescheduledCell.querySelector('.failed-or-lost-link'))
+      //   .hasText('0', 'Rescheduled cell has zero value');
+      // assert
+      //   .dom(restartedCell.querySelector('a'))
+      //   .doesNotExist('Restarted cell is not a link');
+      // assert
+      //   .dom(restartedCell.querySelector('.failed-or-lost-link'))
+      //   .hasText('0', 'Restarted cell has zero value');
+
+      // // A wild event appears! Change a recent task event to type "Restarting" in a task state:
+      // this.store
+      //   .peekAll('job')
+      //   .objectAt(0)
+      //   .get('allocations')
+      //   .objectAt(0)
+      //   .get('states')
+      //   .objectAt(0)
+      //   .get('events')
+      //   .objectAt(0)
+      //   .set('type', 'Restarting');
+
+      // await settled();
+
+      // assert
+      //   .dom(restartedCell.querySelector('.failed-or-lost-link'))
+      //   .hasText(
+      //     '1',
+      //     'Restarted cell updates when a task event with type "Restarting" is added'
+      //   );
+
+      // this.store
+      //   .peekAll('job')
+      //   .objectAt(0)
+      //   .get('allocations')
+      //   .objectAt(1)
+      //   .get('states')
+      //   .objectAt(0)
+      //   .get('events')
+      //   .objectAt(0)
+      //   .set('type', 'Restarting');
+
+      // await settled();
+
+      // // Trigger a reschedule! Set up a desiredTransition object with a Reschedule property on one of the allocations.
+      // assert
+      //   .dom(restartedCell.querySelector('.failed-or-lost-link'))
+      //   .hasText(
+      //     '2',
+      //     'Restarted cell updates when a second task event with type "Restarting" is added'
+      //   );
+
+      // this.store
+      //   .peekAll('job')
+      //   .objectAt(0)
+      //   .get('allocations')
+      //   .objectAt(0)
+      //   .get('followUpEvaluation')
+      //   .set('content', { 'test-key': 'not-empty' });
+
+      // await settled();
+
+      // assert
+      //   .dom(rescheduledCell.querySelector('.failed-or-lost-link'))
+      //   .hasText('1', 'Rescheduled cell updates when desiredTransition is set');
+      // assert
+      //   .dom(rescheduledCell.querySelector('a'))
+      //   .exists('Rescheduled cell with a non-zero number is now a link');
+    });
+
+    // TODO
+    test("System jobs' totalAllocs count matches the number of nodes that exist", async function (assert) {
+      assert.ok(true);
+    });
+
+    // TODO, post-https://github.com/hashicorp/nomad/pull/17073 merge
+    test('System jobs handle node:read permissions', async function (assert) {
+      assert.ok(true);
+    });
+  });
 });

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -56,7 +56,7 @@ export default function moduleForJob(
         await JobDetail.visit({ id: `${job.id}@${job.namespace}` });
       }
 
-      const hasClientStatus = ['system', 'sysbatch'].includes(job.type);
+      const hasClientStatus = ['sysbatch'].includes(job.type);
       if (context === 'allocations' && hasClientStatus) {
         await click("[data-test-accordion-summary-chart='allocation-status']");
       }

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -18,7 +18,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import JobDetail from 'nomad-ui/tests/pages/jobs/detail';
 import setPolicy from 'nomad-ui/tests/utils/set-policy';
 
-const jobTypesWithStatusPanel = ['service'];
+const jobTypesWithStatusPanel = ['service', 'system'];
 
 async function switchToHistorical() {
   await JobDetail.statusModes.historical.click();


### PR DESCRIPTION
Extends the new Job Status panel to System type jobs.

<img width="894" alt="image" src="https://user-images.githubusercontent.com/713991/236549309-fe9b7f63-5200-41ef-a196-112b7831c158.png">

System jobs have a few nuances compared to Service jobs worth mentioning, and that generally drove this PR:
- They do not have the concept of allocation "Rescheduling", so the rescheduling cell has been omitted 
- They have no concept of deployments, so the panel only has a "steady" mode
- The desired allocation count **cannot be known**. This is currently the subject of [some discussion elsewhere](https://github.com/hashicorp/nomad/issues/17099) but for purposes of this PR has amounted to showing "3 allocations running" instead of "3/5 allocations running"

This PR deprecates the JobClientStatusSummary and Summary items for system jobs.