### PR TITLE
bug:  update `job.run` and `job.update` adapter methods

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -79,23 +79,51 @@ export default class JobAdapter extends WatchableNamespaceIDs {
   // Running a job doesn't follow REST create semantics so it's easier to
   // treat it as an action.
   run(job) {
+    let Submission;
+    try {
+      JSON.parse(job.get('_newDefinition'));
+      Submission = {
+        Source: job.get('_newDefinition'),
+        Format: 'json',
+      };
+    } catch {
+      Submission = {
+        Source: job.get('_newDefinition'),
+        Format: 'hcl2',
+        Variables: job.get('_newDefinitionVariables'),
+      };
+    }
+
     return this.ajax(this.urlForCreateRecord('job'), 'POST', {
       data: {
         Job: job.get('_newDefinitionJSON'),
+        Submission,
       },
     });
   }
 
-  update(job, format) {
+  update(job) {
     const jobId = job.get('id') || job.get('_idBeforeSaving');
+
+    let Submission;
+    try {
+      JSON.parse(job.get('_newDefinition'));
+      Submission = {
+        Source: job.get('_newDefinition'),
+        Format: 'json',
+      };
+    } catch {
+      Submission = {
+        Source: job.get('_newDefinition'),
+        Format: 'hcl2',
+        Variables: job.get('_newDefinitionVariables'),
+      };
+    }
+
     return this.ajax(this.urlForUpdateRecord(jobId, 'job'), 'POST', {
       data: {
         Job: job.get('_newDefinitionJSON'),
-        Submission: {
-          Source: job.get('_newDefinition'),
-          Format: format,
-          Variables: job.get('_newDefinitionVariables'),
-        },
+        Submission,
       },
     });
   }

--- a/ui/app/components/job-page/parts/title.js
+++ b/ui/app/components/job-page/parts/title.js
@@ -78,7 +78,7 @@ export default class Title extends Component {
 
     try {
       yield job.parse();
-      yield job.update('json');
+      yield job.update();
       // Eagerly update the job status to avoid flickering
       job.set('status', 'running');
       if (withNotifications) {

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -250,9 +250,10 @@ export default class Job extends Model {
     return this.store.adapterFor('job').run(this);
   }
 
-  update(format) {
+  update() {
     assert('A job must be parsed before updated', this._newDefinitionJSON);
-    return this.store.adapterFor('job').update(this, format);
+
+    return this.store.adapterFor('job').update(this);
   }
 
   parse() {


### PR DESCRIPTION
This PR updates the adapter method's (`run` and `update`) on the `Job` class to reflect the new request schema to include a `Submission` object to maintain a job version history.