### PR TITLE
[ui, deployments] Fix order in which allocations are ascribed to the status chart

### DIFF
--- a/ui/app/components/job-status/panel/deploying.js
+++ b/ui/app/components/job-status/panel/deploying.js
@@ -30,9 +30,7 @@ export default class JobStatusPanelDeployingComponent extends Component {
   // allocations we can track throughout a deployment
   establishOldAllocBlockIDs() {
     this.oldVersionAllocBlockIDs = this.job.allocations.filter(
-      (a) =>
-        a.clientStatus === 'running' &&
-        a.jobVersion !== this.deployment.get('versionNumber')
+      (a) => a.clientStatus === 'running' && a.isOld
     );
   }
 
@@ -84,7 +82,7 @@ export default class JobStatusPanelDeployingComponent extends Component {
   get newVersionAllocBlocks() {
     let availableSlotsToFill = this.desiredTotal;
     let allocationsOfDeploymentVersion = this.job.allocations.filter(
-      (a) => a.jobVersion === this.deployment.get('versionNumber')
+      (a) => !a.isOld
     );
 
     let allocationCategories = this.allocTypes.reduce((categories, type) => {
@@ -153,19 +151,11 @@ export default class JobStatusPanelDeployingComponent extends Component {
   }
 
   get rescheduledAllocs() {
-    return this.job.allocations.filter(
-      (a) =>
-        a.jobVersion === this.job.latestDeployment.get('versionNumber') &&
-        a.hasBeenRescheduled
-    );
+    return this.job.allocations.filter((a) => !a.isOld && a.hasBeenRescheduled);
   }
 
   get restartedAllocs() {
-    return this.job.allocations.filter(
-      (a) =>
-        a.jobVersion === this.job.latestDeployment.get('versionNumber') &&
-        a.hasBeenRestarted
-    );
+    return this.job.allocations.filter((a) => !a.isOld && a.hasBeenRestarted);
   }
 
   // #region legend

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -62,7 +62,7 @@
           <ul>
             {{#each-in this.versions as |version allocs|}}
               <li>
-                <LinkTo @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' version ']')    status=(concat '["running", "pending", "failed"]')         }}>
+                <LinkTo data-version={{version}} @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' version ']')    status=(concat '["running", "pending", "failed"]')         }}>
                   <Hds::Badge @text={{concat "v" version}} />
                   <Hds::BadgeCount @text={{allocs.length}} @type="inverted" />
                 </LinkTo>

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -103,15 +103,11 @@ export default class JobStatusPanelSteadyComponent extends Component {
   }
 
   get rescheduledAllocs() {
-    return this.job.allocations.filter(
-      (a) => a.jobVersion === this.job.version && a.hasBeenRescheduled
-    );
+    return this.job.allocations.filter((a) => !a.isOld && a.hasBeenRescheduled);
   }
 
   get restartedAllocs() {
-    return this.job.allocations.filter(
-      (a) => a.jobVersion === this.job.version && a.hasBeenRestarted
-    );
+    return this.job.allocations.filter((a) => !a.isOld && a.hasBeenRestarted);
   }
 
   get supportsRescheduling() {

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -3,47 +3,24 @@ import Component from '@glimmer/component';
 import { alias } from '@ember/object/computed';
 import matchGlob from 'nomad-ui/utils/match-glob';
 
-/**
- * @enum {string}
- */
-const ClientStatus = {
-  RUNNING: 'running',
-  PENDING: 'pending',
-  FAILED: 'failed',
-  LOST: 'lost',
-  UNPLACED: 'unplaced',
-};
-
 export default class JobStatusPanelSteadyComponent extends Component {
   @alias('args.job') job;
 
   // Build note: allocTypes order matters! We will fill up to 100% of totalAllocs in this order.
-
   allocTypes = [
-    ClientStatus.RUNNING,
-    ClientStatus.PENDING,
-    ClientStatus.FAILED,
-    ClientStatus.LOST,
-    // ClientStatus.UNPLACED,
+    'running',
+    'pending',
+    'failed',
+    // 'unknown',
+    'lost',
+    // 'queued',
+    // 'complete',
+    'unplaced',
   ].map((type) => {
     return {
       label: type,
     };
   });
-  // allocTypes = [
-  //   'running',
-  //   'pending',
-  //   'failed',
-  //   // 'unknown',
-  //   'lost',
-  //   // 'queued',
-  //   // 'complete',
-  //   'unplaced',
-  // ].map((type) => {
-  //   return {
-  //     label: type,
-  //   };
-  // });
 
   /**
    * @typedef {Object} HealthStatus
@@ -58,7 +35,12 @@ export default class JobStatusPanelSteadyComponent extends Component {
    */
 
   /**
-   * @typedef {Record<keyof typeof ClientStatus, AllocationStatus>} AllocationBlock
+   * @typedef {Object} AllocationBlock
+   * @property {AllocationStatus} [RUNNING]
+   * @property {AllocationStatus} [PENDING]
+   * @property {AllocationStatus} [FAILED]
+   * @property {AllocationStatus} [LOST]
+   * @property {AllocationStatus} [UNPLACED]
    */
 
   /**
@@ -86,9 +68,7 @@ export default class JobStatusPanelSteadyComponent extends Component {
 
     // First accumulate the Running/Pending allocations
     for (const alloc of this.job.allocations.filter(
-      (a) =>
-        a.clientStatus === ClientStatus.RUNNING ||
-        a.clientStatus === ClientStatus.PENDING
+      (a) => a.clientStatus === 'running' || a.clientStatus === 'pending'
     )) {
       if (availableSlotsToFill === 0) {
         break;
@@ -102,9 +82,7 @@ export default class JobStatusPanelSteadyComponent extends Component {
     // Sort all allocs by jobVersion in descending order
     const sortedAllocs = this.args.job.allocations
       .filter(
-        (a) =>
-          a.clientStatus !== ClientStatus.RUNNING &&
-          a.clientStatus !== ClientStatus.PENDING
+        (a) => a.clientStatus !== 'running' && a.clientStatus !== 'pending'
       )
       .sortBy('jobVersion')
       .reverse();
@@ -141,7 +119,6 @@ export default class JobStatusPanelSteadyComponent extends Component {
       };
     }
 
-    console.log('allocationsOfShowableType', allocationsOfShowableType);
     return allocationsOfShowableType;
   }
 

--- a/ui/app/utils/properties/job-client-status.js
+++ b/ui/app/utils/properties/job-client-status.js
@@ -56,9 +56,7 @@ export default function jobClientStatus(nodesKey, jobKey) {
         byStatus: {},
         totalNodes: filteredNodes.length,
       };
-      console.log('calc filgred nodes', filteredNodes);
       filteredNodes.forEach((n) => {
-        console.log('hm', allocsByNodeID[n.id], job.taskGroups.length);
         const status = jobStatus(allocsByNodeID[n.id], job.taskGroups.length);
         result.byNode[n.id] = status;
 
@@ -118,7 +116,6 @@ function jobStatus(allocs, expected) {
   const summary = allocs
     .filter((a) => !a.isOld)
     .reduce((acc, a) => {
-      console.log('---', a.get('node.id'), a.clientStatus);
       const status = a.clientStatus;
       if (!acc[status]) {
         acc[status] = 0;

--- a/ui/app/utils/properties/job-client-status.js
+++ b/ui/app/utils/properties/job-client-status.js
@@ -56,7 +56,9 @@ export default function jobClientStatus(nodesKey, jobKey) {
         byStatus: {},
         totalNodes: filteredNodes.length,
       };
+      console.log('calc filgred nodes', filteredNodes);
       filteredNodes.forEach((n) => {
+        console.log('hm', allocsByNodeID[n.id], job.taskGroups.length);
         const status = jobStatus(allocsByNodeID[n.id], job.taskGroups.length);
         result.byNode[n.id] = status;
 
@@ -116,6 +118,7 @@ function jobStatus(allocs, expected) {
   const summary = allocs
     .filter((a) => !a.isOld)
     .reduce((acc, a) => {
+      console.log('---', a.get('node.id'), a.clientStatus);
       const status = a.clientStatus;
       if (!acc[status]) {
         acc[status] = 0;

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -21,7 +21,11 @@ moduleForJob('Acceptance | job detail (batch)', 'allocations', () =>
 );
 
 moduleForJob('Acceptance | job detail (system)', 'allocations', () =>
-  server.create('job', { type: 'system', shallow: true })
+  server.create('job', {
+    type: 'system',
+    shallow: true,
+    noActiveDeployment: true,
+  })
 );
 
 moduleForJobWithClientStatus(

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -176,6 +176,84 @@ module('Acceptance | job status panel', function (hooks) {
     });
   });
 
+  test('After running/pending allocations are covered, fill in allocs by jobVersion, descending', async function (assert) {
+    assert.expect(9);
+    let job = server.create('job', {
+      status: 'running',
+      datacenters: ['*'],
+      type: 'service',
+      resourceSpec: ['M: 256, C: 500'], // a single group
+      createAllocations: false,
+      groupTaskCount: 4,
+      shallow: true,
+      version: 5,
+    });
+
+    server.create('allocation', {
+      jobId: job.id,
+      clientStatus: 'running',
+      jobVersion: 5,
+    });
+    server.create('allocation', {
+      jobId: job.id,
+      clientStatus: 'pending',
+      jobVersion: 5,
+    });
+    server.create('allocation', {
+      jobId: job.id,
+      clientStatus: 'running',
+      jobVersion: 3,
+    });
+    server.create('allocation', {
+      jobId: job.id,
+      clientStatus: 'failed',
+      jobVersion: 4,
+    });
+    server.create('allocation', {
+      jobId: job.id,
+      clientStatus: 'lost',
+      jobVersion: 5,
+    });
+
+    await visit(`/jobs/${job.id}`);
+    assert.dom('.job-status-panel').exists();
+
+    // We expect to see 4 represented-allocations, since that's the number in our groupTaskCount
+    assert
+      .dom('.ungrouped-allocs .represented-allocation')
+      .exists({ count: 4 });
+
+    // We expect 2 of them to be running, and one to be pending, since running/pending allocations superecede other clientStatuses
+    assert
+      .dom('.ungrouped-allocs .represented-allocation.running')
+      .exists({ count: 2 });
+    assert
+      .dom('.ungrouped-allocs .represented-allocation.pending')
+      .exists({ count: 1 });
+
+    // We expect the lone other allocation to be lost, since it has the highest jobVersion
+    assert
+      .dom('.ungrouped-allocs .represented-allocation.lost')
+      .exists({ count: 1 });
+
+    // We expect the job versions legend to show 3 at v5 (running, pending, and lost), and 1 at v3 (old running), and none at v4 (failed is not represented)
+    assert.dom('.job-status-panel .versions > ul > li').exists({ count: 2 });
+    assert
+      .dom('.job-status-panel .versions > ul > li > a[data-version="5"]')
+      .exists({ count: 1 });
+    assert
+      .dom('.job-status-panel .versions > ul > li > a[data-version="3"]')
+      .exists({ count: 1 });
+    assert
+      .dom('.job-status-panel .versions > ul > li > a[data-version="4"]')
+      .doesNotExist();
+    await percySnapshot(assert, {
+      percyCSS: `
+        .allocation-row td { display: none; }
+      `,
+    });
+  });
+
   test('Status Panel groups allocations when they get past a threshold', async function (assert) {
     assert.expect(6);
 

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -548,6 +548,7 @@ module('Acceptance | job status panel', function (hooks) {
       groupTaskCount,
       activeDeployment: true,
       shallow: true,
+      version: 0,
     });
 
     let state = server.create('task-state');

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -18,7 +18,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import JobDetail from 'nomad-ui/tests/pages/jobs/detail';
 import setPolicy from 'nomad-ui/tests/utils/set-policy';
 
-const jobTypesWithStatusPanel = ['service'];
+const jobTypesWithStatusPanel = ['service', 'system'];
 
 async function switchToHistorical() {
   await JobDetail.statusModes.historical.click();


### PR DESCRIPTION
The order in which we want to show allocations (that may have previously been relevant but perhaps no longer are?) in our new visualization has gone through a few changes.

First, we figured "Let's just show them in order of what the user cares about! Running first, then pending, then failed, then lost...." and so on.

Then, we realized that this would clump all the failed allocations from older versions together before we got to the lost allocations of the newest version.

Because the user would expect the "latest" allocs to exist there instead, we can walk backwards by job version instead.

Ah! But that's not *quite right*. Running/Pending still matter above all else. So the new, nuanced solution looks like this:
- Look at all job allocations and grab the running/pending ones first
- Then, sort reverse by jobVersion and walk backwards to fill up `totalAllocs` (the desired total)
- Any that are left over / would otherwise be taken up by now-GC'd allocs are set as `unplaced`

===

We can most easily see this error in the previous version with the following situation:
- job has a count of 2
- job v0 has an alloc placement that goes `failed`
- job v1 has an alloc placement that goes `lost`

Before this fix, the 2 allocations that would have been shown would be "running" and "failed", since failed was earlier in the allocTypes list.

Now, it will show "running" and "lost", which is closer to the user's expectations in reverse-job-version ordering.

![image](https://user-images.githubusercontent.com/713991/235995961-394f6129-e49f-4dff-a4f4-929aa72768f6.png)
![image](https://user-images.githubusercontent.com/713991/235995997-a2eda171-34fa-489b-8161-0e9a7ceb8490.png)
