### PR TITLE
styling:  UX requests

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -79,23 +79,51 @@ export default class JobAdapter extends WatchableNamespaceIDs {
   // Running a job doesn't follow REST create semantics so it's easier to
   // treat it as an action.
   run(job) {
+    let Submission;
+    try {
+      JSON.parse(job.get('_newDefinition'));
+      Submission = {
+        Source: job.get('_newDefinition'),
+        Format: 'json',
+      };
+    } catch {
+      Submission = {
+        Source: job.get('_newDefinition'),
+        Format: 'hcl2',
+        Variables: job.get('_newDefinitionVariables'),
+      };
+    }
+
     return this.ajax(this.urlForCreateRecord('job'), 'POST', {
       data: {
         Job: job.get('_newDefinitionJSON'),
+        Submission,
       },
     });
   }
 
-  update(job, format) {
+  update(job) {
     const jobId = job.get('id') || job.get('_idBeforeSaving');
+
+    let Submission;
+    try {
+      JSON.parse(job.get('_newDefinition'));
+      Submission = {
+        Source: job.get('_newDefinition'),
+        Format: 'json',
+      };
+    } catch {
+      Submission = {
+        Source: job.get('_newDefinition'),
+        Format: 'hcl2',
+        Variables: job.get('_newDefinitionVariables'),
+      };
+    }
+
     return this.ajax(this.urlForUpdateRecord(jobId, 'job'), 'POST', {
       data: {
         Job: job.get('_newDefinitionJSON'),
-        Submission: {
-          Source: job.get('_newDefinition'),
-          Format: format,
-          Variables: job.get('_newDefinitionVariables'),
-        },
+        Submission,
       },
     });
   }

--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -54,6 +54,11 @@ export default class JobEditor extends Component {
 
   @localStorageProperty('nomadMessageJobPlan', true) shouldShowPlanMessage;
 
+  @action
+  dismissPlanMessage() {
+    this.shouldShowPlanMessage = false;
+  }
+
   @(task(function* () {
     this.reset();
 
@@ -177,6 +182,7 @@ export default class JobEditor extends Component {
   get fns() {
     return {
       onCancel: this.onCancel,
+      onDismissPlanMessage: this.dismissPlanMessage,
       onEdit: this.edit,
       onPlan: this.plan,
       onReset: this.reset,

--- a/ui/app/components/job-page/parts/title.js
+++ b/ui/app/components/job-page/parts/title.js
@@ -78,7 +78,7 @@ export default class Title extends Component {
 
     try {
       yield job.parse();
-      yield job.update('json');
+      yield job.update();
       // Eagerly update the job status to avoid flickering
       job.set('status', 'running');
       if (withNotifications) {

--- a/ui/app/components/tooltip.js
+++ b/ui/app/components/tooltip.js
@@ -3,14 +3,43 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+// @ts-check
+import { assert } from '@ember/debug';
 import Component from '@glimmer/component';
 
+/**
+ * Tooltip component that conditionally displays a truncated text.
+ *
+ * @class Tooltip
+ * @extends Component
+ */
 export default class Tooltip extends Component {
+  /**
+   * Determines if the tooltip should be displayed.
+   * Defaults to `true` if the `condition` argument is not provided.
+   *
+   * @property condition
+   * @type {boolean}
+   * @readonly
+   */
   get condition() {
     if (this.args.condition === undefined) return true;
+
+    assert('Must pass a boolean.', typeof this.args.condition === 'boolean');
+
     return this.args.condition;
   }
 
+  /**
+   * Returns the truncated text to be displayed in the tooltip.
+   * If the input text length is less than 30 characters, the input text is returned as-is.
+   * Otherwise, the text is truncated to include the first 15 characters, followed by an ellipsis,
+   * and then the last 10 characters.
+   *
+   * @property text
+   * @type {string}
+   * @readonly
+   */
   get text() {
     const inputText = this.args.text?.toString();
     if (!inputText || inputText.length < 30) {

--- a/ui/app/components/tooltip.js
+++ b/ui/app/components/tooltip.js
@@ -6,6 +6,11 @@
 import Component from '@glimmer/component';
 
 export default class Tooltip extends Component {
+  get condition() {
+    if (this.args.condition === undefined) return true;
+    return this.args.condition;
+  }
+
   get text() {
     const inputText = this.args.text?.toString();
     if (!inputText || inputText.length < 30) {

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -250,9 +250,10 @@ export default class Job extends Model {
     return this.store.adapterFor('job').run(this);
   }
 
-  update(format) {
+  update() {
     assert('A job must be parsed before updated', this._newDefinitionJSON);
-    return this.store.adapterFor('job').update(this, format);
+
+    return this.store.adapterFor('job').update(this);
   }
 
   parse() {

--- a/ui/app/styles/components/codemirror.scss
+++ b/ui/app/styles/components/codemirror.scss
@@ -160,6 +160,13 @@ header.run-job-header {
 .buttonset {
   display: flex;
   justify-content: space-between;
+
+  &.sticky {
+    position: sticky;
+    bottom: 0;
+    background: white;
+    padding: 0.5rem 0;
+  }
 }
 
 .job-definition-select {
@@ -171,6 +178,11 @@ header.run-job-header {
   grid-template-columns: 1fr 1fr;
   padding: 0.25rem 0.5rem;
   margin: 0rem 1rem;
+
+  &.disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
 
   button {
     height: auto;
@@ -186,4 +198,11 @@ header.run-job-header {
       background: $white;
     }
   }
+}
+
+.job-editor-alerts {
+  display: grid;
+  grid-template-rows: repeat(minmax(200px, 1fr), auto-fit);
+  gap: 10px;
+  margin-bottom: 10px;
 }

--- a/ui/app/templates/components/job-editor.hbs
+++ b/ui/app/templates/components/job-editor.hbs
@@ -6,6 +6,7 @@
 <div>
   <JobEditor::Alert 
     @data={{merge (hash error=this.error stage=this.stage) this.data}}
+    @fns={{this.fns}}
   />
 
     {{#if (eq @context "new")}}

--- a/ui/app/templates/components/job-editor/alert.hbs
+++ b/ui/app/templates/components/job-editor/alert.hbs
@@ -1,4 +1,4 @@
-  <div style="margin-bottom: 10px">
+  <div class="job-editor-alerts">
     {{#if @data.error}}
       <Hds::Alert @type="inline" @color="critical" data-test-error={{@data.error.type}} as |A|>
           <A.Title data-test-error-title>{{conditionally-capitalize @data.error.type true}}</A.Title>
@@ -20,7 +20,7 @@
         </Hds::Alert>
     {{/if}}
     {{#if (and (eq @data.stage "review") @data.shouldShowPlanMessage)}}
-      <Hds::Alert @type="inline" @onDismiss={{fn (mut @data.showPlanMessage)}} as |A|>
+      <Hds::Alert @type="inline" @onDismiss={{@fns.onDismissPlanMessage}} as |A|>
           <A.Title data-test-plan-help-title>Job Plan</A.Title>
           <A.Description data-test-plan-help-message>This is the impact running this job will have on your cluster</A.Description>
       </Hds::Alert>

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -34,6 +34,7 @@
                 class="json-viewer is-variable-editor"
                 data-test-variable-editor
                 {{code-mirror
+                autofocus=false
                 screenReaderLabel="HLC Variables for Job Spec"
                 content=@data.variables
                 theme="hashi"
@@ -46,7 +47,7 @@
     </div>
     {{/if}}
 </div>
-<div class="is-associative buttonset">
+<div class="is-associative buttonset sticky">
     <Hds::Button
     {{on "click" (perform @fns.onPlan)}}
     disabled={{or @fns.onPlan.isRunning (not @data.job._newDefinition)}}

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -2,25 +2,25 @@
     <div class="boxed-section-head">
     Job Definition
     <div class="pull-right" style="display: flex">
-        {{#if @data.hasSpecification}}
-        <div class="job-definition-select" data-test-select={{@data.view}}>
-            <button 
-                class="button is-small is-borderless {{if (eq @data.view "job-spec") "is-active"}}"
-                type="button"
-                {{on "click" (fn @fns.onSelect "job-spec")}}
-            >
-                Job Spec
-            </button>
-            <button 
-                class="button is-small is-borderless {{if (eq @data.view "full-definition") "is-active"}}"
-                type="button"
-                {{on "click" (fn @fns.onSelect "full-definition")}}
-                data-test-select-full
-            >
-                Full Definition
-            </button>
-        </div>
-        {{/if}}
+        <Tooltip @condition={{unless @data.hasSpecification true false}} @isFullText={{true}} @text="A jobspec file was not submitted when this job was run. You can still view and edit the expanded JSON format.">
+            <div class="job-definition-select {{unless @data.hasSpecification " disabled"}}" data-test-select={{@data.view}}>
+                <button 
+                    class="button is-small is-borderless {{if (eq @data.view "job-spec") "is-active"}}"
+                    type="button"
+                    {{on "click" (fn @fns.onSelect "job-spec")}}
+                >
+                    Job Spec
+                </button>
+                <button 
+                    class="button is-small is-borderless {{if (eq @data.view "full-definition") "is-active"}}"
+                    type="button"
+                    {{on "click" (fn @fns.onSelect "full-definition")}}
+                    data-test-select-full
+                >
+                    Full Definition
+                </button>
+            </div>        
+        </Tooltip>
         <button
             class="button is-light is-compact"
             type="button"

--- a/ui/app/templates/components/tooltip.hbs
+++ b/ui/app/templates/components/tooltip.hbs
@@ -3,6 +3,10 @@
   SPDX-License-Identifier: MPL-2.0
 ~}}
 
-<span class="tooltip" aria-label="{{this.text}}">
+{{#if this.condition}}
+  <span class={{concat "tooltip" (if @isFullText " multiline")}} aria-label={{if @isFullText @text this.text}}>
+    {{yield}}
+  </span>
+{{else}}
   {{yield}}
-</span>
+{{/if}}


### PR DESCRIPTION
This PR tackles several styling requests:

- Disabling the toggle with tooltip messaging
- Spacing out alerts
- Dismissing the plan message
- Sticky job plan button
- Autofocusing the code mirror editor to prevent automatic scrolling when there's too much code in the editor or a second editor is present

Video Walk Through:  https://www.loom.com/share/74a9dc40dc2d4d5586b4e4f98f0538b6