### PR TITLE
connect: use heuristic to detect sidecar task driver

### DIFF
--- a/.changelog/17065.txt
+++ b/.changelog/17065.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Auto detect when to use podman for connect sidecar proxies
+```

--- a/nomad/job_endpoint_hook_connect_test.go
+++ b/nomad/job_endpoint_hook_connect_test.go
@@ -9,10 +9,12 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,6 +59,68 @@ func TestJobEndpointConnect_isSidecarForService(t *testing.T) {
 	}
 }
 
+func TestJobEndpointConnect_groupConnectGuessTaskDriver(t *testing.T) {
+	ci.Parallel(t)
+
+	cases := []struct {
+		name    string
+		drivers []string
+		exp     string
+	}{
+		{
+			name:    "none",
+			drivers: nil,
+			exp:     "docker",
+		},
+		{
+			name:    "neither",
+			drivers: []string{"exec", "raw_exec", "rkt"},
+			exp:     "docker",
+		},
+		{
+			name:    "docker only",
+			drivers: []string{"docker"},
+			exp:     "docker",
+		},
+		{
+			name:    "podman only",
+			drivers: []string{"podman"},
+			exp:     "podman",
+		},
+		{
+			name:    "mix with docker",
+			drivers: []string{"podman", "docker", "exec"},
+			exp:     "docker",
+		},
+		{
+			name:    "mix without docker",
+			drivers: []string{"exec", "podman", "raw_exec"},
+			exp:     "podman",
+		},
+	}
+
+	for _, tc := range cases {
+		tasks := helper.ConvertSlice(tc.drivers, func(driver string) *structs.Task {
+			return &structs.Task{Driver: driver}
+		})
+		tg := &structs.TaskGroup{Tasks: tasks}
+		result := groupConnectGuessTaskDriver(tg)
+		must.Eq(t, tc.exp, result)
+	}
+}
+
+func TestJobEndpointConnect_newConnectSidecarTask(t *testing.T) {
+	ci.Parallel(t)
+
+	task := newConnectSidecarTask("redis", "podman")
+	must.Eq(t, "connect-proxy-redis", task.Name)
+	must.Eq(t, "podman", task.Driver)
+
+	task2 := newConnectSidecarTask("db", "docker")
+	must.Eq(t, "connect-proxy-db", task2.Name)
+	must.Eq(t, "docker", task2.Driver)
+}
+
 func TestJobEndpointConnect_groupConnectHook(t *testing.T) {
 	ci.Parallel(t)
 
@@ -90,8 +154,8 @@ func TestJobEndpointConnect_groupConnectHook(t *testing.T) {
 	// Expected tasks
 	tgExp := job.TaskGroups[0].Copy()
 	tgExp.Tasks = []*structs.Task{
-		newConnectSidecarTask("backend"),
-		newConnectSidecarTask("admin"),
+		newConnectSidecarTask("backend", "docker"),
+		newConnectSidecarTask("admin", "docker"),
 	}
 	tgExp.Services[0].Name = "backend"
 	tgExp.Services[1].Name = "admin"


### PR DESCRIPTION
This PR adds a heuristic to detect whether to use the podman task driver
for the connect sidecar proxy. The podman driver will be selected if there
is at least one task in the task group configured to use podman, and there
are zero tasks in the group configured to use docker. In all other cases
the task driver defaults to docker.

After this change, we should be able to run typical Connect jobspecs
(e.g. nomad job init [-short] -connect) on Clusters configured with the
podman task driver, without modification to the job files.

Closes #17042
