### PR TITLE
docs: move CNI reference plugins installation to CNI overview page

### DIFF
--- a/website/content/docs/integrations/consul-connect.mdx
+++ b/website/content/docs/integrations/consul-connect.mdx
@@ -146,37 +146,9 @@ $ sudo nomad agent -dev-connect
 
 ### CNI Plugins
 
-Nomad uses CNI plugins to configure the network namespace used to secure the
+Nomad uses CNI reference plugins to configure the network namespace used to secure the
 Consul service mesh sidecar proxy. All Nomad client nodes using network namespaces
-must have CNI plugins installed.
-
-The following commands install CNI plugins:
-
-```shell-session
-curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/releases/download/v1.0.0/cni-plugins-linux-$( [ $(uname -m) = aarch64 ] && echo arm64 || echo amd64)"-v1.0.0.tgz
-sudo mkdir -p /opt/cni/bin
-sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
-```
-
-Ensure the your Linux operating system distribution has been configured to allow
-container traffic through the bridge network to be routed via iptables. These
-tunables can be set as follows:
-
-```shell-session
-echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-arptables
-echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-ip6tables
-echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables
-```
-
-To preserve these settings on startup of a client node, add a file including the
-following to `/etc/sysctl.d/` or remove the file your Linux distribution puts in
-that directory.
-
-```
-net.bridge.bridge-nf-call-arptables = 1
-net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-```
+must have these CNI plugins [installed][cni_install].
 
 ## Run the Service Mesh-enabled Services
 
@@ -404,3 +376,4 @@ filesystem.
 [anon_token]: /consul/docs/security/acl/acl-tokens#special-purpose-tokens
 [consul_ports]: /consul/docs/agent/config/config-files#ports
 [consul_grpc_tls]: /consul/docs/upgrading/upgrade-specific#changes-to-grpc-tls-configuration
+[cni_install]: /nomad/docs/install#post-installation-steps

--- a/website/content/docs/networking/cni.mdx
+++ b/website/content/docs/networking/cni.mdx
@@ -23,6 +23,14 @@ operating-system agnostic interface to configure workload networking.
 Custom networking in Nomad is accomplished with a combination of CNI plugin
 binaries and CNI configuration files.
 
+## CNI reference plugins
+
+The CNCF maintains a set of reference CNI plugins for basic network operations.
+These plugins are required for Nomad's `bridge` networking mode and for integrating
+with Consul service mesh.
+
+See the Linux [post-install steps][cni_install] for installing CNI reference plugins.
+
 ## CNI plugins
 
 Spec-compliant plugins should work with Nomad, however, it's possible a plugin
@@ -208,6 +216,7 @@ a unique value for your configuration.
 [`cni_path`]: /nomad/docs/configuration/client#cni_path
 [`mode`]: /nomad/docs/job-specification/network#mode
 [bridge]: https://www.cni.dev/plugins/current/main/bridge/
+[cni_install]: /nomad/docs/install#post-installation-steps
 [cni_ref]: https://github.com/containernetworking/plugins
 [cni_spec]: https://www.cni.dev/docs/spec/
 [cni_spec_net_config]: https://github.com/containernetworking/cni/blob/main/SPEC.md#configuration-format

--- a/website/content/docs/networking/index.mdx
+++ b/website/content/docs/networking/index.mdx
@@ -305,7 +305,7 @@ assigned random port numbers and so Nomad service discovery with DNS uses
 [allocation]: /nomad/docs/concepts/architecture#allocation
 [cni]: /nomad/docs/networking/cni
 [cni_bridge]: https://www.cni.dev/plugins/current/main/bridge/
-[cni_install]: /nomad/tutorials/get-started/get-started-install#post-installation-steps
+[cni_install]: /nomad/docs/install#post-installation-steps
 [consul_dns]: /consul/docs/discovery/dns
 [consul_dns_forwarding]: /consul/tutorials/networking/dns-forwarding
 [consul_service_mesh]: /nomad/docs/integrations/consul-connect


### PR DESCRIPTION
This PR moves the instruction steps for install the CNI reference plugins
from the Consul Mesh integration page to the general Networking CNI page.

These plugins are required for bridge networking, not just Consul Mesh,
so it makes sense to have them on the general CNI page.

Closes #17038
