### PR TITLE
[17070] Correct the status description and modify time of canceled evals.

### DIFF
--- a/.changelog/17071.txt
+++ b/.changelog/17071.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+bug: Corrected status description and modification time for canceled evaluations
+```

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3160,11 +3160,12 @@ func (s *StateStore) nestedUpsertEval(txn *txn, index uint64, eval *structs.Eval
 		}
 
 		// Go through and update the evals
-		for _, eval := range blocked {
-			newEval := eval.Copy()
+		for _, blockedEval := range blocked {
+			newEval := blockedEval.Copy()
 			newEval.Status = structs.EvalStatusCancelled
-			newEval.StatusDescription = fmt.Sprintf("evaluation %q successful", newEval.ID)
+			newEval.StatusDescription = fmt.Sprintf("evaluation %q successful", eval.ID)
 			newEval.ModifyIndex = index
+			newEval.ModifyTime = eval.CreateTime
 
 			if err := txn.Insert("evals", newEval); err != nil {
 				return fmt.Errorf("eval insert failed: %v", err)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -4176,6 +4176,14 @@ func TestStateStore_UpsertEvals_CancelBlocked(t *testing.T) {
 		t.Fatalf("bad: %#v %#v", out1, out2)
 	}
 
+	if !strings.Contains(out1.StatusDescription, eval.ID) || !strings.Contains(out2.StatusDescription, eval.ID) {
+		t.Fatalf("bad status description %#v %#v", out1, out2)
+	}
+
+	if out1.ModifyTime != eval.ModifyTime || out2.ModifyTime != eval.ModifyTime {
+		t.Fatalf("bad modify time %#v %#v", out1, out2)
+	}
+
 	if watchFired(ws) {
 		t.Fatalf("bad")
 	}


### PR DESCRIPTION
Fix for https://github.com/hashicorp/nomad/issues/17070. Corrected the status description and modify time of evals which are canceled due to another eval having completed in the meantime. 

Tests added. It seems that the testing has originally been written a rather long time before the new-style of testing started within the Nomad codebase. Please let me know if you'd rather I moved the entire test to the new style, or if added if clauses seem like a reasonable tradeoff given the size of the change.