### PR TITLE
[ui, deployments] handle node read permissions for system job panel

### DIFF
--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -21,7 +21,14 @@
     {{#if (eq @statusMode "historical")}}
       <JobPage::Parts::SummaryChart @job={{@job}} />
     {{else}}
-      <h3 class="title is-4 running-allocs-title"><strong>{{@job.runningAllocs}}/{{this.totalAllocs}}</strong> Allocations Running</h3>
+      <h3 class="title is-4 running-allocs-title">
+        <strong>
+          {{@job.runningAllocs}}
+          {{#if this.totalAllocsCanBeKnown}}
+            /{{this.totalAllocs}}
+          {{/if}}
+        </strong>
+        Allocations Running</h3>
       <JobStatus::AllocationStatusRow @allocBlocks={{this.allocBlocks}} @steady={{true}} />
 
       <div class="legend-and-summary">

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -23,8 +23,8 @@
     {{else}}
       <h3 class="title is-4 running-allocs-title">
         <strong>
-          {{@job.runningAllocs}}
-          {{#if this.totalAllocsCanBeKnown}}
+          {{@job.runningAllocs ~}}
+          {{#if this.totalAllocsCanBeKnown ~}}
             /{{this.totalAllocs}}
           {{/if}}
         </strong>

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -24,11 +24,11 @@
       <h3 class="title is-4 running-allocs-title">
         <strong>
           {{@job.runningAllocs ~}}
-          {{#if this.totalAllocsCanBeKnown ~}}
+          {{#unless this.atMostOneAllocPerNode ~}}
             /{{this.totalAllocs}}
-          {{/if}}
+          {{/unless}}
         </strong>
-        Allocations Running</h3>
+        {{pluralize "Allocation" @job.runningAllocs}} Running</h3>
       <JobStatus::AllocationStatusRow @allocBlocks={{this.allocBlocks}} @steady={{true}} />
 
       <div class="legend-and-summary">

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -2,8 +2,10 @@
 import Component from '@glimmer/component';
 import { alias } from '@ember/object/computed';
 import matchGlob from 'nomad-ui/utils/match-glob';
+import { inject as service } from '@ember/service';
 
 export default class JobStatusPanelSteadyComponent extends Component {
+  @service can;
   @alias('args.job') job;
 
   // Build note: allocTypes order matters! We will fill up to 100% of totalAllocs in this order.
@@ -70,20 +72,31 @@ export default class JobStatusPanelSteadyComponent extends Component {
     if (this.args.job.type === 'service') {
       return this.args.job.taskGroups.reduce((sum, tg) => sum + tg.count, 0);
     } else if (this.args.job.type === 'system') {
-      // Filter nodes by the datacenters defined in the job.
-      const filteredNodes = this.nodes.filter((n) => {
-        return this.args.job.datacenters.find((dc) => {
-          return !!matchGlob(dc, n.datacenter);
+      if (this.totalAllocsCanBeKnown) {
+        // Filter nodes by the datacenters defined in the job.
+        const filteredNodes = this.nodes.filter((n) => {
+          return this.args.job.datacenters.find((dc) => {
+            return !!matchGlob(dc, n.datacenter);
+          });
         });
-      });
 
-      return filteredNodes.length;
-      // return this.args.job.allocations.uniqBy('node.id').length
-      // return this.args.job.allocations
-      //   .filter((a) => a.jobVersion === this.args.job.version)
-      //   .uniqBy('node.id').length;
+        return filteredNodes.length;
+      } else {
+        // You don't have node read access, so do the best you can: uniqBy node IDs on the allocs you can see.
+        return this.args.job.allocations.uniqBy('nodeID').length;
+      }
     } else {
       return this.args.job.count; // TODO: this is probably not the correct totalAllocs count for any type.
+    }
+  }
+
+  get totalAllocsCanBeKnown() {
+    // System jobs don't have a group.count, so we depend on reading the overal number of nodes.
+    // If the user lacks "read client" capabilities, this becomes impossible.
+    if (this.args.job.type === 'system') {
+      return this.can.can('read client');
+    } else {
+      return true;
     }
   }
 

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -32,6 +32,7 @@ export default class Allocation extends Model {
   @belongsTo('job') job;
   @belongsTo('node') node;
   @attr('string') namespace;
+  @attr('string') nodeID;
   @attr('string') name;
   @attr('string') taskGroupName;
   @fragment('resources') resources;


### PR DESCRIPTION
We depend on iterating over `nodes` to determine how many allocations should be running in a system job. So what happens when the user's ACL doesn't allow for `node-read` permissions?

An easy solution would be to just drop a "You require node-read" block over top of the panel, like we do for the `JobStatusInClient` panel.

But we _can_ know a bit about the nodes — their IDs, anyway — and we can know that for system jobs at most one alloc is supposed to run per node.

So in this way, we can do something, which is better than nothing: show them the actual state, if not the desired state, of their job allocations.

This drops the "/Y" part of "X/Y allocations running" for the steady state panel when you lack node-read permissions and are viewing a system job. It also can never show "Unplaced" allocs, as it has no idea about which nodes exist that lack them.

<img width="880" alt="image" src="https://user-images.githubusercontent.com/713991/236027472-9e181996-0b37-487b-a705-8cc543cce789.png">
