### PR TITLE
refact:  API refactoring

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -53,7 +53,7 @@ export default class JobAdapter extends WatchableNamespaceIDs {
     return this.ajax(url, 'POST', {
       data: {
         JobHCL: spec,
-        JobVariables: jobVars,
+        Variables: jobVars,
         Canonicalize: true,
       },
     });

--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -148,20 +148,22 @@ export default class JobEditor extends Component {
     }
   }
 
-  get variables() {
-    function jsonToHcl(obj) {
-      const hclLines = [];
+  jsonToHcl(obj) {
+    const hclLines = [];
 
-      for (const key in obj) {
-        const value = obj[key];
-        const hclValue = typeof value === 'string' ? `"${value}"` : value;
-        hclLines.push(`${key}=${hclValue}`);
-      }
-
-      return hclLines.join('\n');
+    for (const key in obj) {
+      const value = obj[key];
+      const hclValue = typeof value === 'string' ? `"${value}"` : value;
+      hclLines.push(`${key}=${hclValue}\n`);
     }
 
-    return jsonToHcl(this.args.variables);
+    return hclLines.join('\n');
+  }
+
+  get variables() {
+    return this.jsonToHcl(this.args.variables.flags).concat(
+      this.args.variables.literal
+    );
   }
 
   get data() {

--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -24,6 +24,15 @@ export default class JobEditor extends Component {
     if (this.definition) {
       this.setDefinitionOnModel();
     }
+
+    if (this.args.variables) {
+      this.args.job.set(
+        '_newDefinitionVariables',
+        this.jsonToHcl(this.args.variables.flags).concat(
+          this.args.variables.literal
+        )
+      );
+    }
   }
 
   get isEditing() {

--- a/ui/app/controllers/jobs/job/definition.js
+++ b/ui/app/controllers/jobs/job/definition.js
@@ -19,7 +19,8 @@ export default class DefinitionController extends Controller.extend(
   @alias('model.format') format;
   @alias('model.job') job;
   @alias('model.specification') specification;
-  @alias('model.variables') variables;
+  @alias('model.variableFlags') variableFlags;
+  @alias('model.variableLiteral') variableLiteral;
 
   @tracked view;
   @tracked isEditing = false;

--- a/ui/app/routes/jobs/job/definition.js
+++ b/ui/app/routes/jobs/job/definition.js
@@ -14,11 +14,13 @@ export default class DefinitionRoute extends Route {
 
     let format = 'json'; // default to json in network request errors
     let specification;
-    let variables;
+    let variableFlags;
+    let variableLiteral;
     try {
       const specificationResponse = await job.fetchRawSpecification();
       specification = specificationResponse?.Source ?? null;
-      variables = specificationResponse?.VariableFlags ?? null;
+      variableFlags = specificationResponse?.VariableFlags ?? null;
+      variableLiteral = specificationResponse?.Variables ?? null;
       format = specificationResponse?.Format ?? 'json';
     } catch (e) {
       // Swallow the error because Nomad job pre-1.6 will not have a specification
@@ -29,7 +31,8 @@ export default class DefinitionRoute extends Route {
       format,
       job,
       specification,
-      variables,
+      variableFlags,
+      variableLiteral,
     };
   }
 

--- a/ui/app/templates/components/job-editor/alert.hbs
+++ b/ui/app/templates/components/job-editor/alert.hbs
@@ -8,8 +8,8 @@
     {{#if (and (eq @data.stage "read") @data.hasVariables (eq @data.view "job-spec"))}}
       {{#if this.shouldShowAlert}}
         <Hds::Alert @type="inline" @onDismiss={{this.dismissAlert}} data-test-variable-notification as |A|>
-          <A.Title>All Job Variable Values Not Shown</A.Title>
-          <A.Description>Please refer to Nomad CLI to see the current value of all variables.</A.Description>
+          <A.Title>All HCL variable values Not Shown</A.Title>
+          <A.Description>All HCL variable values provided to this job version may not be shown. Ensure HCL variable values are properly set when submitting the job.</A.Description>
         </Hds::Alert>
       {{/if}}
     {{/if}}

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -27,7 +27,7 @@
     {{#if (eq @data.view "job-spec")}}
     <div class="boxed-section" style="margin-top: 10px">
         <div class="boxed-section-head">
-            Edit HCL Variables
+            Edit HCL Variable Values
         </div>
         <div class="boxed-section-body is-full-bleed">
             <div
@@ -36,7 +36,7 @@
                 {{code-mirror
                 autofocus=false
                 screenReaderLabel="HLC Variables for Job Spec"
-                content=@data.variables
+                content=@data.job._newDefinitionVariables
                 theme="hashi"
                 onUpdate=@fns.onUpdate
                 type="hclVariables"

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -58,7 +58,7 @@
     {{#if (and (eq @data.view "job-spec") @data.hasVariables)}}
     <div class="boxed-section" style="margin-top: 10px">
         <div class="boxed-section-head">
-            HCL Variables
+            HCL Variable Values
         </div>
         <div class="boxed-section-body is-full-bleed">
             <div

--- a/ui/app/templates/jobs/job/definition.hbs
+++ b/ui/app/templates/jobs/job/definition.hbs
@@ -13,7 +13,7 @@
     @format={{this.format}}
     @job={{this.job}}
     @specification={{this.specification}}
-    @variables={{this.variables}}
+    @variables={{hash flags=this.variableFlags literal=this.variableLiteral}}
     @view={{this.view}}
     @onSubmit={{action this.onSubmit}}
     @onSelect={{this.selectView}}


### PR DESCRIPTION
Closes #16981 

This PR:

- Updates the request schema formatted by the `parse` method on the `Job` adapter.
- Updates some copy.
- Visualizes Variable Flags and Variable Literal into one field and allows users to edit them, as well.

Loom Walk Through:  https://www.loom.com/share/6b1164793c0e4e0288aee4aa0aca0669