### PR TITLE
scale: fixed a bug where evals could be created with wrong type.

### DIFF
--- a/.changelog/17092.txt
+++ b/.changelog/17092.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scale: Fixed a bug where evals could be created with the wrong type
+```

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1152,7 +1152,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 				ID:             uuid.Generate(),
 				Namespace:      namespace,
 				Priority:       job.Priority, // Safe as nil check performed above.
-				Type:           structs.JobTypeService,
+				Type:           job.Type,
 				TriggeredBy:    structs.EvalTriggerScaling,
 				JobID:          args.JobID,
 				JobModifyIndex: reply.JobModifyIndex,


### PR DESCRIPTION
The job scale RPC endpoint hard-coded the eval creation to use the type of service. This meant scaling events triggered on jobs of type batch would create evaluations with the wrong type, which does not seem to cause any problems, just confusion when correlating the two.

closes #17091 