### PR TITLE
Standardize on GitHub Actions for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,7 @@ jobs:
     executor: go-windows
 
     steps:
+      - run: docker version
       - run: git config --global core.autocrlf false
       - checkout
       - run:

--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,14 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+self-hosted-runner:
+  # Labels of self-hosted runner in array of string
+  labels:
+    - custom
+    - xl
+    - 22.04
+    - linux
+    - xxl
+    - 20.04
+    - custom-windows-medium
+    - windows-2019-16core

--- a/.github/actions/install-vault/action.yml
+++ b/.github/actions/install-vault/action.yml
@@ -1,0 +1,33 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+name: install-vault
+inputs:
+  version:
+    required: false
+    default: 1.2.4
+runs:
+  using: composite
+  steps:
+  - name: Install Vault
+    run: |-
+      set -x
+
+      case "${OSTYPE}" in
+        linux*)  os="linux" ;;
+        darwin*) os="darwin" ;;
+        msys*)   os="windows" ;;
+        *)       echo "unknown os: ${OSTYPE}"; exit 1 ;;
+      esac
+
+      curl -SL --fail -o /tmp/vault.zip https://releases.hashicorp.com/vault/"${{ inputs.version }}"/vault_"${{ inputs.version }}"_"${os}"_amd64.zip
+
+      if [[ "${os}" != "windows" ]]; then
+        sudo unzip -d /usr/local/bin /tmp/vault.zip
+        rm -rf /tmp/vault*
+      else
+        rm -rf c:\Windows\vault.exe
+        unzip /tmp/vault.zip -d "/c/Windows"
+        rm -rf /tmp/vault*
+      fi
+    shell: bash

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,15 @@
+# If the repository is public, be sure to change to GitHub hosted runners
+name: Lint GitHub Actions Workflows
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+permissions:
+  contents: read
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: "Check workflow files"
+        uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -71,3 +71,6 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.BACKPORT_ASSISTANT_FAILURE_SLACK }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+permissions:
+  contents: read
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,9 @@ jobs:
         id: get-go-version
         # We use .go-version as our source of truth for current Go
         # version, because "goenv" can react to it automatically.
-        run: |
+        run: |-
           echo "Building with Go $(cat .go-version)"
-          echo "go-version=$(cat .go-version)" >> $GITHUB_OUTPUT
+          echo "go-version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
   get-product-version:
     runs-on: ubuntu-20.04
     outputs:
@@ -48,9 +48,9 @@ jobs:
           ref: ${{ github.event.inputs.build-ref }}
       - name: get product version
         id: get-product-version
-        run: |
+        run: |-
           make version
-          echo "product-version=$(make version)" >> $GITHUB_OUTPUT
+          echo "product-version=$(make version)" >> "$GITHUB_OUTPUT"
   generate-metadata-file:
     needs: get-product-version
     runs-on: ubuntu-20.04
@@ -177,9 +177,9 @@ jobs:
       - name: Set gcc
         run: |
           if [ "${{ matrix.goarch }}" == "arm" ]; then
-            echo "CC=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
+            echo "CC=arm-linux-gnueabihf-gcc" >> "$GITHUB_ENV"
           elif [ "${{ matrix.goarch }}" == "arm64" ]; then
-            echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+            echo "CC=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
           fi
 
       - name: Build
@@ -216,8 +216,8 @@ jobs:
 
       - name: Set Package Names
         run: |
-          echo "RPM_PACKAGE=$(basename out/*.rpm)" >> $GITHUB_ENV
-          echo "DEB_PACKAGE=$(basename out/*.deb)" >> $GITHUB_ENV
+          echo "RPM_PACKAGE=$(basename out/*.rpm)" >> "$GITHUB_ENV"
+          echo "DEB_PACKAGE=$(basename out/*.deb)" >> "$GITHUB_ENV"
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
@@ -281,8 +281,10 @@ jobs:
           name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           path: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
 
-  # This placed here for when the Nomad team is ready to build docker images.
-  # Please reach out the RDX team for assistance or refer to the CRT Self-Serve Onboarding doc.
+permissions:
+  contents: read
+# This placed here for when the Nomad team is ready to build docker images.
+# Please reach out the RDX team for assistance or refer to the CRT Self-Serve Onboarding doc.
 
   # build-docker-default:
   #   name: Docker ${{ matrix.arch }} default release build

--- a/.github/workflows/ember-assets.yml
+++ b/.github/workflows/ember-assets.yml
@@ -22,3 +22,5 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           working-directory: "ui"
+permissions:
+  contents: read

--- a/.github/workflows/ember-test-audit.yml
+++ b/.github/workflows/ember-test-audit.yml
@@ -72,7 +72,7 @@ jobs:
           path: audit-diff.md
       - name: Check for existence of flakiness report
         id: check_file
-        uses: andstor/file-existence-action@f02338908d150e00a4b8bebc2dad18bd9e5229b0 # v1.1.0
+        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2.0.0
         with:
           files: "flakiness-report.md"
       - name: comment PR
@@ -82,3 +82,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           message_path: flakiness-report.md
+permissions:
+  contents: read
+

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -21,3 +21,6 @@ jobs:
 
             If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
           pr-lock-inactive-days: '120'
+permissions:
+  contents: read
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,35 +29,33 @@ jobs:
     steps:
       - name: Prevent running from main
         if: ${{ github.ref_name == 'main' }}
-        run: |
+        run: |-
           echo "::error::Workflow not allowed to run from ${{ github.ref_name }}"
           exit 1
 
       - name: Print release info
-        run: |
+        run: |-
           echo "::notice::Release v${{ github.event.inputs.version }} from branch ${{ github.ref_name }}"
 
       - name: Install semver CLI
-        run: |
+        run: |-
           local_bin="${HOME}/.local/bin"
           mkdir -p "${local_bin}"
           curl -L --output "${local_bin}/semver" \
             https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.3.0/src/semver
           chmod +x "${local_bin}/semver"
-          echo "${local_bin}" >> $GITHUB_PATH
+          echo "${local_bin}" >> "$GITHUB_PATH"
 
       - name: Validate release version
-        run: |
+        run: |-
           if [ "$(semver validate ${{ github.event.inputs.version }})" == "invalid" ]; then
             echo "::error::Version ${{ github.event.inputs.version }} is invalid"
             exit 1
           fi
-
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-
       - name: Setup Git
-        run: |
-          if [ "${{ secrets.ELEVATED_GITHUB_TOKEN }}" ]; then
+        run: |-
+          if [ -n "${{ secrets.ELEVATED_GITHUB_TOKEN }}" ]; then
             git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com/".insteadOf "https://github.com"
           fi
           git config --global user.email "github-team-nomad-core@hashicorp.com"
@@ -69,7 +67,7 @@ jobs:
         # version, because "goenv" can react to it automatically.
         run: |
           echo "Building with Go $(cat .go-version)"
-          echo "go-version=$(cat .go-version)" >> $GITHUB_OUTPUT
+          echo "go-version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
 
       - name: Setup go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
@@ -138,7 +136,7 @@ jobs:
           else
             echo "no files were updated"
           fi
-          echo "build-ref=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "build-ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Invoke build workflow
         uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1.2.2
@@ -146,7 +144,7 @@ jobs:
           workflow: build
           token: ${{ secrets.ELEVATED_GITHUB_TOKEN}}
           inputs: '{"build-ref": "${{ steps.commit-change-push.outputs.build-ref }}", "make-prerelease": "false"}'
-          ref: ${{ needs.prepare-release.outputs.build-ref }}
+          ref: ${{ steps.commit-change-push.outputs.build-ref }}
 
       - name: Revert notification channel
         if: ${{ github.event.inputs.notification-channel != '' }}
@@ -190,7 +188,7 @@ jobs:
         run: |
           # These generated files are only needed when building the final
           # binary and should be not be present in the repository afterwards.
-          find . -name '*.generated.go' | xargs git rm
+          find . -name '*.generated.go' -print0 | xargs -0 git rm
           git status
 
       - name: Commit post-release changes
@@ -205,3 +203,6 @@ jobs:
           else
             echo "no files were updated"
           fi
+permissions:
+  contents: read
+

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -15,4 +15,7 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: returntocorp/semgrep-action@245bf11ddb2f3d4e35f116608cf6e27ae0f9aa04 # v1
+      - uses: returntocorp/semgrep-action@8689a93eca50c91f8e8cfa61e3c4fb7e96d12bf2 # v1
+permissions:
+  contents: read
+

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -127,3 +127,6 @@ jobs:
           hc-install install -version ${{env.CONSUL_VERSION}} -path ${{env.GOBIN}} consul
           sudo sed -i 's!Defaults!#Defaults!g' /etc/sudoers
           sudo -E env "PATH=$PATH" make test-nomad
+permissions:
+  contents: read
+

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,0 +1,48 @@
+name: test-e2e
+on:
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.changelog/**'
+      - '.tours/**'
+      - 'contributing/**'
+      - 'demo/**'
+      - 'dev/**'
+      - 'integrations/**'
+      - 'pkg/**'
+      - 'scripts/**'
+      - 'terraform/**'
+      - 'ui/**'
+      - 'website/**'
+  push:
+    branches:
+      - main
+      - release/**
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.changelog/**'
+      - '.tours/**'
+      - 'contributing/**'
+      - 'demo/**'
+      - 'dev/**'
+      - 'integrations/**'
+      - 'pkg/**'
+      - 'scripts/**'
+      - 'terraform/**'
+      - 'ui/**'
+      - 'website/**'
+
+jobs:
+  test-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Setup go
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+      - run: make deps
+      - run: make integration-test
+      - run: make e2e-test
+permissions:
+  contents: read

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -1,0 +1,57 @@
+name: test-ui
+on:
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.changelog/**'
+      - '.tours/**'
+      - 'contributing/**'
+      - 'demo/**'
+      - 'dev/**'
+      - 'e2e/**'
+      - 'integrations/**'
+      - 'pkg/**'
+      - 'scripts/**'
+      - 'terraform/**'
+      - 'website/**'
+  push:
+    branches:
+      - main
+      - release/**
+      - test-ui
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.changelog/**'
+      - '.tours/**'
+      - 'contributing/**'
+      - 'demo/**'
+      - 'dev/**'
+      - 'e2e/**'
+      - 'integrations/**'
+      - 'pkg/**'
+      - 'scripts/**'
+      - 'terraform/**'
+      - 'website/**'
+
+jobs:
+  test-ui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: yarn install
+        run: cd ui && yarn install --frozen-lockfile
+      - name: lint:js
+        run: cd ui && yarn run lint:js
+      - name: lint:hbs
+        run: cd ui && yarn run lint:hbs
+      - name: Ember tests
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+        run: mkdir -p /tmp/test-reports && cd ui && yarn test
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          path: "/tmp/test-reports"
+permissions:
+  contents: read

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,0 +1,97 @@
+name: test-windows
+on:
+  pull_request:
+    branches:
+      - main
+      - release/**
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.changelog/**'
+      - '.tours/**'
+      - 'contributing/**'
+      - 'demo/**'
+      - 'dev/**'
+      - 'e2e/**'
+      - 'integrations/**'
+      - 'pkg/**'
+      - 'scripts/**'
+      - 'terraform/**'
+      - 'ui/**'
+      - 'website/**'
+  push:
+    branches:
+      - main
+      - release/**
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.changelog/**'
+      - '.tours/**'
+      - 'contributing/**'
+      - 'demo/**'
+      - 'dev/**'
+      - 'e2e/**'
+      - 'integrations/**'
+      - 'pkg/**'
+      - 'scripts/**'
+      - 'terraform/**'
+      - 'ui/**'
+      - 'website/**'
+
+env:
+  VAULT_VERSION: 1.4.1
+jobs:
+  test-windows:
+    runs-on: "windows-2019-16core"
+    env:
+      GOTESTSUM_PATH: c:\tmp\test-reports
+    steps:
+      - name: Docker Info
+        run: docker version
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Setup go
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version-file: ".go-version"
+      - name: Show installed Go version
+        shell: bash
+        run: |-
+          export PATH=/c/go/bin:/c/gopath/bin:$PATH
+          go version
+      - uses: "./.github/actions/install-vault"
+        with:
+          version: "$VAULT_VERSION"
+      - run: vault version
+      - run: choco install make
+      - name: Install golang dependencies
+        shell: bash
+        run: |-
+          make deps
+      - name: Pre-download docker test image
+        shell: bash
+        run: |-
+          docker pull docker.mirror.hashicorp.services/hashicorpdev/busybox-windows:ltsc2019
+      - name: Build nomad
+        shell: bash
+        run: |-
+          go install .
+      - name: Run tests with gotestsum
+        shell: bash
+        env:
+          BUSYBOX_IMAGE: docker.mirror.hashicorp.services/hashicorpdev/busybox-windows:ltsc2019
+        run: |-
+          # Only test docker driver tests for now
+          export PATH=/c/go/bin:/c/gopath/bin:$PATH
+          gotestsum --format=short-verbose \
+            --junitfile results.xml \
+            github.com/hashicorp/nomad/drivers/docker \
+            github.com/hashicorp/nomad/client/lib/fifo \
+            github.com/hashicorp/nomad/client/logmon
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: results.xml
+          path: results.xml
+permissions:
+  contents: read


### PR DESCRIPTION
The primary goal here is to migrate our remaining CI workflows from Circle CI to GitHub Actions, namely: test-e2e, test-ui, and test-windows.

Related test changes to enable that were split out to separate PRs: #17401 and #17399

Extra-curricularly, as part of the overall migration effort company-wide, this also includes some standardization such as:
 * explicit permissions:read on various workflows
 * pinned action version shas (per [hashicorp/security-public-tsccr](https://github.com/hashicorp/security-public-tsccr))
 * actionlint, which among other things runs shellcheck on GHA run steps