### PR TITLE
docs: add note to upgrade guide about yanked version

### DIFF
--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -42,6 +42,21 @@ registered before the upgrade would no longer collect allocation logs. The
 by a `logs.disabled` field that defaults to false. The `logs.enabled` field value
 will be ignored in 1.5.5 and will be removed in Nomad 1.6.0.
 
+## Nomad 1.5.4
+
+Nomad 1.5.4 included a bug where allocations that are rescheduled for jobs
+registered before the upgrade would no longer collect allocation logs. The
+client will emit debug-level logs like the following:
+
+```
+client.alloc_runner.task_runner.task_hook: log collection is disabled by task
+```
+
+You should avoid this version of Nomad and instead install the latest version of
+Nomad 1.5. If you have already upgraded to Nomad 1.5.4, upgrading to Nomad 1.5.5
+will restore logging collection when clients are restarted as part of the
+upgrade process.
+
 ## Nomad 1.5.1
 
 #### Artifact Download Regression Fix


### PR DESCRIPTION
Nomad 1.5.4 shipped with a logmon bug that we rolled out a fix for in Nomad 1.5.5. Unfortunately we can't yank the release but we should leave a note in the upgrade guide telling users to avoid it.

I'll backport this to `release/1.5.x` and the `stable-website` branch once merged.