### PR TITLE
client: unveil /etc/ssh/ssh_known_hosts for artifact downloads

### DIFF
--- a/client/allocrunner/taskrunner/getter/util_linux_test.go
+++ b/client/allocrunner/taskrunner/getter/util_linux_test.go
@@ -32,8 +32,8 @@ func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
 	t.Setenv("HOME", fakeHome)
 
 	const (
-		ssh        = ".ssh"
-		knownHosts = ".ssh/known_hosts"
+		homeSSH        = ".ssh"
+		homeKnownHosts = ".ssh/known_hosts"
 	)
 
 	var (
@@ -41,8 +41,9 @@ func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
 		hgFile         = filepath.Join(fakeEtc, "hgrc")
 		hgDir          = filepath.Join(fakeEtc, "hgrc.d")
 		etcPasswd      = filepath.Join(fakeEtc, "passwd")
-		sshDir         = filepath.Join(fakeHome, ssh)
-		knownHostsFile = filepath.Join(fakeHome, knownHosts)
+		etcKnownHosts  = filepath.Join(fakeEtc, "ssh/ssh_known_hosts")
+		sshDir         = filepath.Join(fakeHome, homeSSH)
+		knownHostsFile = filepath.Join(fakeHome, homeKnownHosts)
 	)
 
 	err := os.WriteFile(gitConfig, []byte("git"), filePerm)
@@ -54,20 +55,35 @@ func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
 	err = os.Mkdir(hgDir, dirPerm)
 	must.NoError(t, err)
 
-	err = os.WriteFile(etcPasswd, []byte("x:y:z"), filePerm)
+	err = os.WriteFile(etcPasswd, []byte("etc passwd"), filePerm)
+	must.NoError(t, err)
+
+	err = os.Mkdir(filepath.Join(fakeEtc, "ssh"), dirPerm)
+	must.NoError(t, err)
+
+	err = os.WriteFile(etcKnownHosts, []byte("etc known hosts"), filePerm)
 	must.NoError(t, err)
 
 	err = os.Mkdir(sshDir, dirPerm)
 	must.NoError(t, err)
 
-	err = os.WriteFile(knownHostsFile, []byte("abc123"), filePerm)
+	err = os.WriteFile(knownHostsFile, []byte("home known hosts"), filePerm)
 	must.NoError(t, err)
 
-	paths := filesForVCS(ssh, knownHosts, etcPasswd, gitConfig, hgFile, hgDir)
+	paths := filesForVCS(
+		homeSSH,
+		homeKnownHosts,
+		etcPasswd,
+		etcKnownHosts,
+		gitConfig,
+		hgFile,
+		hgDir,
+	)
 	must.SliceEqual(t, []*landlock.Path{
 		landlock.Dir(sshDir, "r"),
 		landlock.File(knownHostsFile, "rw"),
 		landlock.File(etcPasswd, "r"),
+		landlock.File(etcKnownHosts, "r"),
 		landlock.File(gitConfig, "r"),
 		landlock.File(hgFile, "r"),
 		landlock.Dir(hgDir, "r"),


### PR DESCRIPTION
This PR fixes a bug where nodes configured with populated
`/etc/ssh/ssh_known_hosts` files would be unable to read them during
artifact downloading.

Fixes #17086
