### PR TITLE
ui:  add sign-in link on err page

### DIFF
--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -93,6 +93,11 @@
         data-test-error-clients-link
         class="button is-white"
       >Go to Clients</LinkTo>
+      <LinkTo
+        @route="settings.tokens"
+        data-test-error-signin-link
+        class="button is-white"
+      >Go to Sign In</LinkTo>
     </div>
   </div>
 {{else}}

--- a/ui/tests/acceptance/application-errors-test.js
+++ b/ui/tests/acceptance/application-errors-test.js
@@ -82,7 +82,7 @@ module('Acceptance | application errors ', function (hooks) {
     await percySnapshot(assert);
   });
 
-  test('error pages include links to the jobs and clients pages', async function (assert) {
+  test('error pages include links to the jobs, clients and auth pages', async function (assert) {
     await visit('/a/non-existent/page');
 
     assert.ok(JobsList.error.isPresent, 'An error is shown');
@@ -96,6 +96,13 @@ module('Acceptance | application errors ', function (hooks) {
 
     await JobsList.error.gotoClients();
     assert.equal(currentURL(), '/clients', 'Now on the clients page');
+    assert.notOk(JobsList.error.isPresent, 'The error is gone now');
+
+    await visit('/a/non-existent/page');
+    assert.ok(JobsList.error.isPresent, 'An error is shown');
+
+    await JobsList.error.gotoSignin();
+    assert.equal(currentURL(), '/settings/tokens', 'Now on the sign-in page');
     assert.notOk(JobsList.error.isPresent, 'The error is gone now');
   });
 });

--- a/ui/tests/pages/jobs/list.js
+++ b/ui/tests/pages/jobs/list.js
@@ -63,6 +63,7 @@ export default create({
     seekHelp: clickable('[data-test-error-message] a'),
     gotoJobs: clickable('[data-test-error-jobs-link]'),
     gotoClients: clickable('[data-test-error-clients-link]'),
+    gotoSignin: clickable('[data-test-error-signin-link]'),
   },
 
   pageSizeSelect: pageSizeSelect(),


### PR DESCRIPTION
![image](https://github.com/hashicorp/nomad/assets/41024828/9572daa3-44a4-4c94-be61-c048cc7544c3)

This PR adds a link to the Sign In page to the Nomad UI error page.