### PR TITLE
core: eliminate second index on job_submissions table

### DIFF
--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -283,7 +283,6 @@ func jobVersionSchema() *memdb.TableSchema {
 
 // jobSubmissionSchema returns the memdb table schema of job submissions
 // which contain the original source material of each job, per version.
-// Unique index by Namespace, JobID, and Version.
 func jobSubmissionSchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
 		Name: "job_submission",
@@ -291,34 +290,21 @@ func jobSubmissionSchema() *memdb.TableSchema {
 			"id": {
 				Name:         "id",
 				AllowMissing: false,
-				Unique:       true,
+				Unique:       true, // basically worthless
+				// index by (Namespace, JobID, Version) but uniqueness is DIY.
 				Indexer: &memdb.CompoundIndex{
 					Indexes: []memdb.Indexer{
 						&memdb.StringFieldIndex{
 							Field: "Namespace",
 						},
+
 						&memdb.StringFieldIndex{
 							Field:     "JobID",
 							Lowercase: true,
 						},
+
 						&memdb.UintFieldIndex{
 							Field: "Version",
-						},
-					},
-				},
-			},
-			"by_jobID": {
-				Name:         "by_jobID",
-				AllowMissing: false,
-				Unique:       false,
-				Indexer: &memdb.CompoundIndex{
-					Indexes: []memdb.Indexer{
-						&memdb.StringFieldIndex{
-							Field: "Namespace",
-						},
-						&memdb.StringFieldIndex{
-							Field:     "JobID",
-							Lowercase: true,
 						},
 					},
 				},

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -290,8 +290,11 @@ func jobSubmissionSchema() *memdb.TableSchema {
 			"id": {
 				Name:         "id",
 				AllowMissing: false,
-				Unique:       true, // basically worthless
-				// index by (Namespace, JobID, Version) but uniqueness is DIY.
+				Unique:       true,
+				// index by (Namespace, JobID, Version)
+				// note: uniqueness applies only at the moment of insertion,
+				// if anything modifies one of these fields (as the stored
+				// struct is a pointer, there is no consistency)
 				Indexer: &memdb.CompoundIndex{
 					Indexes: []memdb.Indexer{
 						&memdb.StringFieldIndex{

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1908,7 +1908,7 @@ func (s *StateStore) deleteJobScalingPolicies(index uint64, job *structs.Job, tx
 
 func (s *StateStore) deleteJobSubmission(job *structs.Job, txn *txn) error {
 	// find submissions associated with job
-	remove := *set.NewHashSet[*structs.JobSubmission, string](6)
+	remove := *set.NewHashSet[*structs.JobSubmission, string](structs.JobTrackedVersions)
 
 	iter, err := txn.Get("job_submission", "id_prefix", job.Namespace, job.ID)
 	if err != nil {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1907,8 +1907,36 @@ func (s *StateStore) deleteJobScalingPolicies(index uint64, job *structs.Job, tx
 }
 
 func (s *StateStore) deleteJobSubmission(job *structs.Job, txn *txn) error {
-	_, err := txn.DeleteAll("job_submission", "by_jobID", job.Namespace, job.ID)
-	return err
+	// find submissions associated with job
+	remove := *set.NewHashSet[*structs.JobSubmission, string](6)
+
+	iter, err := txn.Get("job_submission", "id_prefix", job.Namespace, job.ID)
+	if err != nil {
+		return err
+	}
+
+	for {
+		obj := iter.Next()
+		if obj == nil {
+			break
+		}
+		sub := obj.(*structs.JobSubmission)
+
+		// iterating by prefix; ensure we have an exact match
+		if sub.Namespace == job.Namespace && sub.JobID == job.ID {
+			remove.Insert(sub)
+		}
+	}
+
+	// now delete the submissions we found associated with the job
+	for _, sub := range remove.Slice() {
+		err := txn.Delete("job_submission", sub)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // deleteJobVersions deletes all versions of the given job.
@@ -5366,6 +5394,10 @@ func (s *StateStore) updateJobScalingPolicies(index uint64, job *structs.Job, tx
 // job structure originates from. It is up to the job submitter to include the source
 // material, and as such sub may be nil, in which case nothing is stored.
 func (s *StateStore) updateJobSubmission(index uint64, sub *structs.JobSubmission, namespace, jobID string, version uint64, txn *txn) error {
+	// critical that we operate on a copy; the original must not be modified
+	// e.g. in the case of job gc and its last second version bump
+	sub = sub.Copy()
+
 	switch {
 	case sub == nil:
 		return nil
@@ -5380,7 +5412,18 @@ func (s *StateStore) updateJobSubmission(index uint64, sub *structs.JobSubmissio
 		sub.Version = version
 	}
 
-	// insert the job submission
+	// check if we already have a submission for this (namespace, jobID, version)
+	obj, err := txn.First("job_submission", "id", namespace, jobID, version)
+	if err != nil {
+		return err
+	}
+	if obj != nil {
+		// if we already have a submission for this (namespace, jobID, version)
+		// then there is nothing to do; manually avoid potential for duplicates
+		return nil
+	}
+
+	// insert the job submission for this (namespace, jobID, version)
 	if err := txn.Insert("job_submission", sub); err != nil {
 		return err
 	}
@@ -5395,16 +5438,19 @@ func (s *StateStore) pruneJobSubmissions(namespace, jobID string, txn *txn) erro
 	// holes in the submissions (or none at all)
 	limit := structs.JobTrackedVersions
 
-	iter, err := txn.Get("job_submission", "by_jobID", namespace, jobID)
+	// iterate through all stored submissions
+	iter, err := txn.Get("job_submission", "id_prefix", namespace, jobID)
 	if err != nil {
 		return err
 	}
 
-	// lookup each stored submission's (modify index, version)
 	stored := make([]lang.Pair[uint64, uint64], 0, limit+1)
 	for next := iter.Next(); next != nil; next = iter.Next() {
 		sub := next.(*structs.JobSubmission)
-		stored = append(stored, lang.Pair[uint64, uint64]{First: sub.JobModifyIndex, Second: sub.Version})
+		// scanning by prefix; make sure we collect exact matches only
+		if sub.Namespace == namespace && sub.JobID == jobID {
+			stored = append(stored, lang.Pair[uint64, uint64]{First: sub.JobModifyIndex, Second: sub.Version})
+		}
 	}
 
 	// if we are still below the limit, nothing to do

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4307,6 +4307,29 @@ type JobSubmission struct {
 	JobModifyIndex uint64
 }
 
+// Hash returns a value representative of the intended uniquness of a
+// JobSubmission in the job_submission state store table (namespace, jobID, version).
+func (js *JobSubmission) Hash() string {
+	return fmt.Sprintf("%s \x00 %s \x00 %d", js.Namespace, js.JobID, js.Version)
+}
+
+// Copy creates a deep copy of js.
+func (js *JobSubmission) Copy() *JobSubmission {
+	if js == nil {
+		return nil
+	}
+	return &JobSubmission{
+		Source:         js.Source,
+		Format:         js.Format,
+		VariableFlags:  maps.Clone(js.VariableFlags),
+		Variables:      js.Variables,
+		Namespace:      js.Namespace,
+		JobID:          js.JobID,
+		Version:        js.Version,
+		JobModifyIndex: js.JobModifyIndex,
+	}
+}
+
 // Job is the scope of a scheduling request to Nomad. It is the largest
 // scoped object, and is a named collection of task groups. Each task group
 // is further composed of tasks. A task group (TG) is the unit of scheduling


### PR DESCRIPTION
This PR refactors the `job_submissions` state store code to eliminate the
use of a second index formerly used for purging all versions of a given
job. In practice we ended up with duplicate entries on the table. Instead,
use index prefix scanning on the primary index and also tidy up any potential
for creating (or removing) duplicates.

Currently on main attempting to GC a job results in, 
```
    2023-05-10T20:15:42.657Z [ERROR] nomad.fsm: deregistering job failed: job=http error="DeleteJob failed: deleting job submission failed: not found"
    2023-05-10T20:15:42.657Z [ERROR] nomad.job: batch deregister failed: error="DeleteJob failed: deleting job submission failed: not found"
    2023-05-10T20:15:42.657Z [ERROR] core.sched: batch job reap failed: error="DeleteJob failed: deleting job submission failed: not found"
```

The "not found" is a funny symptom - the problem is that we have 2 references to the same job submission, we apply the delete to the first one, and then we get an error trying to delete the second.