### PR TITLE
[ui, deployments] Denominator based on completed allocations for batch jobs

### DIFF
--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -22,13 +22,23 @@
       <JobPage::Parts::SummaryChart @job={{@job}} />
     {{else}}
       <h3 class="title is-4 running-allocs-title">
-        <strong>
-          {{@job.runningAllocs ~}}
-          {{#unless this.atMostOneAllocPerNode ~}}
-            /{{this.totalAllocs}}
-          {{/unless}}
-        </strong>
-        {{pluralize "Allocation" @job.runningAllocs}} Running</h3>
+        {{#if this.allAllocsComplete}}
+          All allocations have completed successfully
+        {{else}}
+          <strong>
+              {{@job.runningAllocs ~}}
+              {{#unless this.atMostOneAllocPerNode ~}}
+                {{#if (eq @job.type "batch") ~}}
+                  /{{this.totalNonCompletedAllocs}}
+                {{else ~}}
+                  /{{this.totalAllocs}}
+                {{/if}}
+              {{/unless}}
+          </strong>
+          {{#if (eq @job.type "batch") ~}}Remaining{{/if}}
+          {{pluralize "Allocation" @job.runningAllocs}} Running
+        {{/if}}
+      </h3>
       <JobStatus::AllocationStatusRow @allocBlocks={{this.allocBlocks}} @steady={{true}} />
 
       <div class="legend-and-summary">

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -121,8 +121,6 @@ export default class JobStatusPanelSteadyComponent extends Component {
   get totalAllocs() {
     if (this.args.job.type === 'service' || this.args.job.type === 'batch') {
       return this.args.job.taskGroups.reduce((sum, tg) => sum + tg.count, 0);
-      // } else if (this.args.job.type === 'batch') {
-      //   return this.args.job.taskGroups.reduce((sum, tg) => sum + tg.count, 0) - this.completedAllocs.length;
     } else if (this.atMostOneAllocPerNode) {
       return this.args.job.allocations.uniqBy('nodeID').length;
     } else {

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -121,11 +121,21 @@ export default class JobStatusPanelSteadyComponent extends Component {
   get totalAllocs() {
     if (this.args.job.type === 'service' || this.args.job.type === 'batch') {
       return this.args.job.taskGroups.reduce((sum, tg) => sum + tg.count, 0);
+      // } else if (this.args.job.type === 'batch') {
+      //   return this.args.job.taskGroups.reduce((sum, tg) => sum + tg.count, 0) - this.completedAllocs.length;
     } else if (this.atMostOneAllocPerNode) {
       return this.args.job.allocations.uniqBy('nodeID').length;
     } else {
       return this.args.job.count; // TODO: this is probably not the correct totalAllocs count for any type.
     }
+  }
+
+  get totalNonCompletedAllocs() {
+    return this.totalAllocs - this.completedAllocs.length;
+  }
+
+  get allAllocsComplete() {
+    return this.completedAllocs.length && this.totalNonCompletedAllocs === 0;
   }
 
   get atMostOneAllocPerNode() {
@@ -157,6 +167,12 @@ export default class JobStatusPanelSteadyComponent extends Component {
 
   get restartedAllocs() {
     return this.job.allocations.filter((a) => !a.isOld && a.hasBeenRestarted);
+  }
+
+  get completedAllocs() {
+    return this.job.allocations.filter(
+      (a) => !a.isOld && a.clientStatus === 'complete'
+    );
   }
 
   get supportsRescheduling() {

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -727,7 +727,7 @@ module('Acceptance | job status panel', function (hooks) {
         groupTaskCount: 10,
         noActiveDeployment: true,
         shallow: true,
-        version: 0,
+        version: 1,
       });
 
       let serviceJob = server.create('job', {
@@ -745,13 +745,18 @@ module('Acceptance | job status panel', function (hooks) {
         groupTaskCount: 10,
         noActiveDeployment: true,
         shallow: true,
-        version: 0,
+        version: 1,
       });
 
       // Batch job should have 5 running, 3 failed, 2 completed
       await visit(`/jobs/${batchJob.id}`);
       assert.dom('.job-status-panel').exists();
-      assert.dom('.running-allocs-title').hasText('5/10 Allocations Running');
+      assert
+        .dom('.running-allocs-title')
+        .hasText(
+          '5/8 Remaining Allocations Running',
+          'Completed allocations do not count toward the Remaining denominator'
+        );
       assert
         .dom('.ungrouped-allocs .represented-allocation.complete')
         .exists(


### PR DESCRIPTION
We shouldn't count "complete" allocations against the denominator in the "7/10 Allocations Running" heading, when the 3 non-running are of "complete" status. Instead, in this case, we would say "7/7 Remaining Allocations Running".

Resolves #17139 