### PR TITLE
[ui, deployments] Version sorting in the job status panel

### DIFF
--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -67,14 +67,18 @@
         <section class="versions">
           <h4>Versions</h4>
           <ul>
-            {{#each-in this.versions as |version allocs|}}
+            {{#each this.versions as |versionObj|}}
               <li>
-                <LinkTo data-version={{version}} @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' version ']')    status=(concat '["running", "pending", "failed"]')         }}>
-                  <Hds::Badge @text={{concat "v" version}} />
-                  <Hds::BadgeCount @text={{allocs.length}} @type="inverted" />
+                <LinkTo data-version={{versionObj.version}} @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' versionObj.version ']')    status=(concat '["running", "pending", "failed"]')         }}>
+                  {{#if (eq versionObj.version "unknown")}}
+                    <Hds::Badge @text="unknown" />
+                  {{else}}
+                    <Hds::Badge @text={{concat "v" versionObj.version}} />
+                  {{/if}}
+                  <Hds::BadgeCount @text={{versionObj.allocations.length}} @type="inverted" />
                 </LinkTo>
               </li>
-            {{/each-in}}
+            {{/each}}
           </ul>
         </section>
 


### PR DESCRIPTION
Resolves #17149

![image](https://github.com/hashicorp/nomad/assets/713991/1a6864af-4611-4a72-b726-3a0814b3c0a0)

- Sorts versions ascending
- changes "pending" to "unknown" and removes the "v" before it