### PR TITLE
[ui, deployments] Deployment history on steady state

### DIFF
--- a/ui/app/components/job-status/deployment-history.hbs
+++ b/ui/app/components/job-status/deployment-history.hbs
@@ -1,14 +1,18 @@
 <div class="deployment-history {{if this.isHidden "hidden"}}">
   <header>
     <h4 class="title is-5">
-      <Hds::Button
-        @text={{or @title "Deployment History"}}
+      <button
+        class="button"
         {{on "click" (action (mut this.isHidden) (if this.isHidden false true))}}
-        @color="tertiary"
-        @icon={{if this.isHidden "chevron-down" "chevron-up"}}
-        @iconPosition="trailing"
-        @isFullWidth={{true}}
-      />
+        type="button"
+      >
+        {{or @title "Deployment History"}}
+        {{#if this.isHidden}}
+          {{x-icon "chevron-down"}}
+        {{else}}
+          {{x-icon "chevron-up"}}
+        {{/if}}
+      </button>
     </h4>
     {{#unless this.isHidden}}
       <SearchBox

--- a/ui/app/components/job-status/deployment-history.hbs
+++ b/ui/app/components/job-status/deployment-history.hbs
@@ -1,53 +1,66 @@
-<div class="deployment-history">
+<div class="deployment-history {{if this.isHidden "hidden"}}">
   <header>
-    <h4 class="title is-5">Deployment History</h4>
-    <SearchBox
-      data-test-history-search
-      @searchTerm={{mut this.searchTerm}}
-      @placeholder="Search events..."
-    />
+    <h4 class="title is-5">
+      <Hds::Button
+        @text={{or @title "Deployment History"}}
+        {{on "click" (action (mut this.isHidden) (if this.isHidden false true))}}
+        @color="tertiary"
+        @icon={{if this.isHidden "chevron-down" "chevron-up"}}
+        @iconPosition="trailing"
+        @isFullWidth={{true}}
+      />
+    </h4>
+    {{#unless this.isHidden}}
+      <SearchBox
+        data-test-history-search
+        @searchTerm={{mut this.searchTerm}}
+        @placeholder="Search events..."
+      />
+    {{/unless}}
   </header>
-  <ol class="timeline">
-    {{#each this.history as |deployment-log|}}
-      <li class="timeline-object {{if (eq deployment-log.exitCode 1) "error"}}">
-        <div class="boxed-section-head is-light">
-          <LinkTo @route="allocations.allocation" @model={{deployment-log.state.allocation}} class="allocation-reference">{{deployment-log.state.allocation.shortId}}</LinkTo>
-          <span><strong>{{deployment-log.type}}:</strong> {{deployment-log.message}}</span>
-          <span class="pull-right">
-            {{format-ts deployment-log.time}}
-          </span>
-        </div>
-      </li>
-    {{else}}
-      {{#if this.errorState}}
-        <li class="timeline-object">
+  {{#unless this.isHidden}}
+    <ol class="timeline">
+      {{#each this.history as |deployment-log|}}
+        <li class="timeline-object {{if (eq deployment-log.exitCode 1) "error"}}">
           <div class="boxed-section-head is-light">
-            <span>Error loading deployment history</span>
+            <LinkTo @route="allocations.allocation" @model={{deployment-log.state.allocation}} class="allocation-reference">{{deployment-log.state.allocation.shortId}}</LinkTo>
+            <span><strong>{{deployment-log.type}}:</strong> {{deployment-log.message}}</span>
+            <span class="pull-right">
+              {{format-ts deployment-log.time}}
+            </span>
           </div>
         </li>
       {{else}}
-        {{#if this.deploymentAllocations.length}}
-          {{#if this.searchTerm}}
-            <li class="timeline-object" data-test-history-search-no-match>
-              <div class="boxed-section-head is-light">
-                <span>No events match {{this.searchTerm}}</span>
-              </div>
-            </li>
+        {{#if this.errorState}}
+          <li class="timeline-object">
+            <div class="boxed-section-head is-light">
+              <span>Error loading deployment history</span>
+            </div>
+          </li>
+        {{else}}
+          {{#if this.deploymentAllocations.length}}
+            {{#if this.searchTerm}}
+              <li class="timeline-object" data-test-history-search-no-match>
+                <div class="boxed-section-head is-light">
+                  <span>No events match {{this.searchTerm}}</span>
+                </div>
+              </li>
+            {{else}}
+              <li class="timeline-object">
+                <div class="boxed-section-head is-light">
+                  <span>No deployment events yet</span>
+                </div>
+              </li>
+            {{/if}}
           {{else}}
             <li class="timeline-object">
               <div class="boxed-section-head is-light">
-                <span>No deployment events yet</span>
+                <span>Loading deployment events</span>
               </div>
             </li>
           {{/if}}
-        {{else}}
-          <li class="timeline-object">
-            <div class="boxed-section-head is-light">
-              <span>Loading deployment events</span>
-            </div>
-          </li>
         {{/if}}
-      {{/if}}
-    {{/each}}
-  </ol>
+      {{/each}}
+    </ol>
+  {{/unless}}
 </div>

--- a/ui/app/components/job-status/deployment-history.js
+++ b/ui/app/components/job-status/deployment-history.js
@@ -5,8 +5,12 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 
+const MAX_NUMBER_OF_EVENTS = 500;
+
 export default class JobStatusDeploymentHistoryComponent extends Component {
   @service notifications;
+
+  @tracked isHidden = this.args.isHidden;
 
   /**
    * @type { Error }
@@ -36,8 +40,11 @@ export default class JobStatusDeploymentHistoryComponent extends Component {
    * @type { import('../../models/allocation').default[] }
    */
   get deploymentAllocations() {
-    return this.jobAllocations.filter(
-      (alloc) => alloc.jobVersion === this.deploymentVersion
+    return (
+      this.args.allocations ||
+      this.jobAllocations.filter(
+        (alloc) => alloc.jobVersion === this.deploymentVersion
+      )
     );
   }
 
@@ -57,7 +64,8 @@ export default class JobStatusDeploymentHistoryComponent extends Component {
         .flat()
         .filter((a) => this.containsSearchTerm(a))
         .sort((a, b) => a.get('time') - b.get('time'))
-        .reverse();
+        .reverse()
+        .slice(0, MAX_NUMBER_OF_EVENTS);
     } catch (e) {
       this.triggerError(e);
       return [];

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -93,6 +93,17 @@
         </section>
 
       </div>
+
+      <div class="history-and-params">
+        {{#if this.latestVersionAllocations.length}}
+          <JobStatus::DeploymentHistory
+            @title="Allocation History"
+            @allocations={{this.latestVersionAllocations}}
+            @isHidden={{true}}
+          />
+        {{/if}}
+      </div>
+
     {{/if}}
   </div>
 </div>

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -176,4 +176,8 @@ export default class JobStatusPanelSteadyComponent extends Component {
   get supportsRescheduling() {
     return this.job.type !== 'system';
   }
+
+  get latestVersionAllocations() {
+    return this.job.allocations.filter((a) => !a.isOld);
+  }
 }

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -368,14 +368,31 @@
       margin-bottom: 1rem;
       align-items: end;
       & > h4 {
-        margin: 0;
+        margin-bottom: 0;
+        height: 100%;
         & > button {
           justify-content: left;
+          font-size: 1.25rem;
+          width: 100%;
+          color: $blue;
           border: none;
+          box-shadow: none;
+          outline: none;
           padding: 0;
-          background: none;
-          &:hover {
+          font-weight: 600;
+          &:focus {
+            outline: none;
+            box-shadow: none;
+          }
+
+          &:hover,
+          &:focus {
             text-decoration: underline;
+          }
+          & > svg {
+            padding-left: 0.5rem;
+            height: 2rem;
+            width: 2rem;
           }
         }
       }

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -352,13 +352,33 @@
     margin-top: 1rem;
   }
 
+  &.steady-state .history-and-params {
+    grid-template-columns: auto;
+  }
+
   .deployment-history {
+    &.hidden > header {
+      margin-bottom: 0;
+    }
+
     & > header {
       display: grid;
       grid-template-columns: 1fr 2fr;
       gap: 1rem;
       margin-bottom: 1rem;
       align-items: end;
+      & > h4 {
+        margin: 0;
+        & > button {
+          justify-content: left;
+          border: none;
+          padding: 0;
+          background: none;
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+      }
       & > .search-box {
         max-width: unset;
       }


### PR DESCRIPTION
Adds a toggle to show/hide deployment history, and adds task event history to steady-state job status panels

Resolves #17159 

![image](https://github.com/hashicorp/nomad/assets/713991/20723c19-9da5-4141-8166-a0cf5a26c39a)
![image](https://github.com/hashicorp/nomad/assets/713991/28d37817-9f1a-4b3e-85b9-efe198678a5b)
