### PR TITLE
[ui] Keyboard shortcuts to switch regions

### DIFF
--- a/.changelog/17169.txt
+++ b/.changelog/17169.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: adds keyboard nav for switching between regions by pressing "r 1", "r 2", etc.
+```

--- a/ui/app/components/region-switcher.js
+++ b/ui/app/components/region-switcher.js
@@ -26,6 +26,9 @@ export default class RegionSwitcher extends Component {
   }
 
   get keyCommands() {
+    if (this.sortedRegions.length <= 1) {
+      return [];
+    }
     return this.sortedRegions.map((region, iter) => {
       return {
         label: `Switch to ${region} region`,

--- a/ui/app/components/region-switcher.js
+++ b/ui/app/components/region-switcher.js
@@ -24,4 +24,14 @@ export default class RegionSwitcher extends Component {
       queryParams: { region },
     });
   }
+
+  get keyCommands() {
+    return this.sortedRegions.map((region, iter) => {
+      return {
+        label: `Switch to ${region} region`,
+        pattern: ['r', `${iter + 1}`],
+        action: () => this.gotoRegion(region),
+      };
+    });
+  }
 }

--- a/ui/app/templates/components/region-switcher.hbs
+++ b/ui/app/templates/components/region-switcher.hbs
@@ -3,6 +3,8 @@
   SPDX-License-Identifier: MPL-2.0
 ~}}
 
+{{keyboard-commands this.keyCommands}}
+
 {{#if this.system.shouldShowRegions}}
   <span data-test-region-switcher-parent>
     <PowerSelect

--- a/ui/tests/acceptance/keyboard-test.js
+++ b/ui/tests/acceptance/keyboard-test.js
@@ -361,5 +361,41 @@ module('Acceptance | keyboard', function (hooks) {
         'Shift+ArrowRight takes you to the first tab in the loop'
       );
     });
+
+    test('Region switching', async function (assert) {
+      ['Detroit', 'Halifax', 'Phoenix', 'Toronto', 'Windsor'].forEach((id) => {
+        server.create('region', { id });
+      });
+
+      await visit('/jobs');
+
+      // Regions are in the keynav modal
+      await triggerEvent('.page-layout', 'keydown', { key: '?' });
+      await triggerEvent('.page-layout', 'keydown', { key: '?' });
+      assert.ok(Layout.keyboard.modalShown);
+      assert
+        .dom('[data-test-command-label="Switch to Detroit region"]')
+        .exists('First created region is in the modal');
+
+      assert
+        .dom('[data-test-command-label="Switch to Windsor region"]')
+        .exists('Last created region is in the modal');
+
+      // Triggers a region switch to Halifax
+      triggerEvent('.page-layout', 'keydown', { key: 'r' });
+      await triggerEvent('.page-layout', 'keydown', { key: '2' });
+      assert.ok(
+        currentURL().includes('region=Halifax'),
+        'r 2 command takes you to the second region'
+      );
+
+      // Triggers a region switch to Phoenix
+      triggerEvent('.page-layout', 'keydown', { key: 'r' });
+      await triggerEvent('.page-layout', 'keydown', { key: '3' });
+      assert.ok(
+        currentURL().includes('region=Halifax'),
+        'r 3 command takes you to the third region'
+      );
+    });
   });
 });

--- a/ui/tests/acceptance/keyboard-test.js
+++ b/ui/tests/acceptance/keyboard-test.js
@@ -393,7 +393,7 @@ module('Acceptance | keyboard', function (hooks) {
       triggerEvent('.page-layout', 'keydown', { key: 'r' });
       await triggerEvent('.page-layout', 'keydown', { key: '3' });
       assert.ok(
-        currentURL().includes('region=Halifax'),
+        currentURL().includes('region=Phoenix'),
         'r 3 command takes you to the third region'
       );
     });


### PR DESCRIPTION
Adds `r #` keyboard bindings to regions.

**Note**: I'm making an assumption here that users have few regions in general to save on keystrokes. If, however, we expect that users commonly have 10+ regions, then I should switch this to `r 0 1` instead of just `r 1`, lest you end up on the wrong region when you meant to go to region 10 or 11 etc. (we evaluate the buffer on keypress eagerly)

<img width="617" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/11a87605-345b-4b6f-b3df-668d8ecc5ca6">
