### PR TITLE
[ui] Remove unnecessary subnav for parent jobs

### DIFF
--- a/ui/app/components/job-subnav.js
+++ b/ui/app/components/job-subnav.js
@@ -16,4 +16,11 @@ export default class JobSubnav extends Component {
       job?.hasClientStatus && !job?.hasChildren && this.can.can('read client')
     );
   }
+
+  // Periodic and Parameterized jobs "parents" are not jobs unto themselves, but more like summaries.
+  // They should not have tabs for allocations, evaluations, etc.
+  // but their child jobs, and other job types generally, should.
+  get shouldHideNonParentTabs() {
+    return this.args.job?.hasChildren;
+  }
 }

--- a/ui/app/templates/components/job-subnav.hbs
+++ b/ui/app/templates/components/job-subnav.hbs
@@ -44,43 +44,45 @@
         </LinkTo>
       </li>
     {{/if}}
-    <li data-test-tab="allocations">
-      <LinkTo
-        @route="jobs.job.allocations"
-        @model={{format-job-id @job.id}}
-        @activeClass="is-active"
-      >
-        Allocations
-      </LinkTo>
-    </li>
-    <li data-test-tab="evaluations">
-      <LinkTo
-        @route="jobs.job.evaluations"
-        @model={{@job}}
-        @activeClass="is-active"
-      >
-        Evaluations
-      </LinkTo>
-    </li>
-    {{#if this.shouldRenderClientsTab}}
-      <li data-test-tab="clients">
+    {{#unless this.shouldHideNonParentTabs}}
+      <li data-test-tab="allocations">
         <LinkTo
-          @route="jobs.job.clients"
+          @route="jobs.job.allocations"
+          @model={{format-job-id @job.id}}
+          @activeClass="is-active"
+        >
+          Allocations
+        </LinkTo>
+      </li>
+      <li data-test-tab="evaluations">
+        <LinkTo
+          @route="jobs.job.evaluations"
           @model={{@job}}
           @activeClass="is-active"
         >
-          Clients
+          Evaluations
         </LinkTo>
       </li>
-    {{/if}}
-    <li data-test-tab="services">
-      <LinkTo
-        @route="jobs.job.services"
-        @model={{@job}}
-        @activeClass="is-active"
-      >
-        Services
-      </LinkTo>
-    </li>
+      {{#if this.shouldRenderClientsTab}}
+        <li data-test-tab="clients">
+          <LinkTo
+            @route="jobs.job.clients"
+            @model={{@job}}
+            @activeClass="is-active"
+          >
+            Clients
+          </LinkTo>
+        </li>
+      {{/if}}
+      <li data-test-tab="services">
+        <LinkTo
+          @route="jobs.job.services"
+          @model={{@job}}
+          @activeClass="is-active"
+        >
+          Services
+        </LinkTo>
+      </li>
+    {{/unless}}
   </ul>
 </div>

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -101,16 +101,6 @@ export default function moduleForJob(
       assert.equal(decodeURIComponent(currentURL()), expectedURL);
     });
 
-    test('the subnav links to evaluations', async function (assert) {
-      await JobDetail.tabFor('evaluations').visit();
-
-      const expectedURL = job.namespace
-        ? `/jobs/${job.name}@${job.namespace}/evaluations`
-        : `/jobs/${job.name}/evaluations`;
-
-      assert.equal(decodeURIComponent(currentURL()), expectedURL);
-    });
-
     test('the title buttons are dependent on job status', async function (assert) {
       if (job.status === 'dead') {
         assert.ok(JobDetail.start.isPresent);
@@ -228,6 +218,16 @@ export default function moduleForJob(
           JobDetail.allocationsSummary.isHidden,
           'Allocations are not shown in the summary section'
         );
+      });
+    } else {
+      test('the subnav links to evaluations', async function (assert) {
+        await JobDetail.tabFor('evaluations').visit();
+
+        const expectedURL = job.namespace
+          ? `/jobs/${job.name}@${job.namespace}/evaluations`
+          : `/jobs/${job.name}/evaluations`;
+
+        assert.equal(decodeURIComponent(currentURL()), expectedURL);
       });
     }
 


### PR DESCRIPTION
Allocations, Evaluations, and Services don't exist for parents of child jobs, but we show their menu items anyway. This adds a check to see if the job has children, and if so, hides the relevant nav. "Clients" is also swept up on this, and is a redundant check, but that's fine.

Resolves #17189 