### PR TITLE
acl: refactor acl.UpsertTokens to avoid unnecessary RPC calls

### DIFF
--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -641,6 +641,18 @@ func (a *ACL) UpsertTokens(args *structs.ACLTokenUpsertRequest, reply *structs.A
 		return err
 	}
 
+	return a.upsertTokens(args, reply, stateSnapshot)
+}
+
+// upsertTokens is a method that contains common token upsertion logic without
+// the RPC authentication, metrics, etc. Used in other RPC calls that require to
+// upsert tokens.
+func (a *ACL) upsertTokens(
+	args *structs.ACLTokenUpsertRequest,
+	reply *structs.ACLTokenUpsertResponse,
+	stateSnapshot *state.StateSnapshot,
+) error {
+
 	// Validate each token
 	for idx, token := range args.Tokens {
 
@@ -2776,7 +2788,7 @@ func (a *ACL) OIDCCompleteAuth(
 
 	var tokenUpsertReply structs.ACLTokenUpsertResponse
 
-	if err := a.srv.RPC(structs.ACLUpsertTokensRPCMethod, &tokenUpsertRequest, &tokenUpsertReply); err != nil {
+	if err := a.upsertTokens(&tokenUpsertRequest, &tokenUpsertReply, stateSnapshot); err != nil {
 		return err
 	}
 
@@ -2924,7 +2936,7 @@ func (a *ACL) Login(args *structs.ACLLoginRequest, reply *structs.ACLLoginRespon
 
 	var tokenUpsertReply structs.ACLTokenUpsertResponse
 
-	if err := a.srv.RPC(structs.ACLUpsertTokensRPCMethod, &tokenUpsertRequest, &tokenUpsertReply); err != nil {
+	if err := a.upsertTokens(&tokenUpsertRequest, &tokenUpsertReply, stateSnapshot); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
New RPC endpoints introduced during OIDC and JWT auth perform unnecessary many RPC calls when they upsert generated ACL tokens, as [pointed out](https://github.com/hashicorp/nomad/pull/15918/files/223c764e82408f02c306d9ebf98477167a4c6a05#r1138684122) by @tgross. 

This PR moves the common logic from `acl.UpsertTokens` method into a helper method that contains common logic, and sidesteps authentication, metrics, etc. 