### PR TITLE
backport changelog update for vendor label for linux packaging (#16071)

### DIFF
--- a/.changelog/16071.txt
+++ b/.changelog/16071.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+build: Linux packages now have vendor label and set the default label to HashiCorp. This fix is implemented for any future releases, but will not be updated for historical releases
+```


### PR DESCRIPTION
The backport bot missed https://github.com/hashicorp/nomad/pull/16071 so this changelog-only PR is not present in the release/1.5.x branch as we'd expect.