### PR TITLE
ui:  explain why `alloc` is failing

### DIFF
--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -128,6 +128,10 @@ export default class Allocation extends Model {
 
   @belongsTo('evaluation') followUpEvaluation;
 
+  get followUpEvaluationId() {
+    return this.belongsTo('evaluation').id();
+  }
+
   @computed('clientStatus')
   get statusClass() {
     const classMap = {
@@ -199,6 +203,27 @@ export default class Allocation extends Model {
       !this.get('followUpEvaluation.content') &&
       this.clientStatus === 'failed'
     );
+  }
+
+  @computed(
+    'hasStoppedRescheduling',
+    'node.status',
+    'resources.length',
+    'task.{config.errors.length,code.errors.length}'
+  )
+  get failureReason() {
+    switch (this.hasStoppedRescheduling) {
+      case this.node.status === 'failed':
+        return 'the node that the allocation was scheduled on failed.';
+      case this.resources.length === 0:
+        return 'the resources that the allocation was scheduled on were not available.';
+      case this.task.config.errors.length > 0:
+        return "the task or service's configuration was incorrect.";
+      case this.task.code.errors.length > 0:
+        return "there was an error in the task or service's code.";
+      default:
+        return 'of an unknown failure reason.';
+    }
   }
 
   stop() {

--- a/ui/app/templates/components/reschedule-event-timeline.hbs
+++ b/ui/app/templates/components/reschedule-event-timeline.hbs
@@ -12,7 +12,7 @@
   {{/if}}
   {{#if @allocation.hasStoppedRescheduling}}
     <li class="timeline-note" data-test-stop-warning>
-      {{x-icon "alert-triangle" class="is-warning is-text"}} Nomad has stopped attempting to reschedule this allocation.
+      {{x-icon "alert-triangle" class="is-warning is-text"}} Nomad has stopped attempting to reschedule this allocation because {{@allocation.failureReason}}. To debug further try checking out the associated <LinkTo @route="evaluations.index" @query={{@allocation.followUpEvaluationId}}>evaluation</LinkTo>.
     </li>
   {{/if}}
   {{#if (and @allocation.followUpEvaluation.waitUntil (not @allocation.nextAllocation))}}


### PR DESCRIPTION
Resolves #16942 

This PR creates a new derived state property on the `Allocation` model to show why an allocation has stopped rescheduling and updates the template to provide a better reason about why the allocation has stopped rescheduling and links to the follow up evaluation to enable the user to debug what's happening.