### PR TITLE
[ui, deployments] Fix a bug where watchers on a parent (periodic) job would continue on a child route

### DIFF
--- a/.changelog/17214.txt
+++ b/.changelog/17214.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes an issue where the allocations table on child (periodic, parameterized) job pages wouldn't update when accessed via their parent
+```

--- a/ui/app/mixins/with-watchers.js
+++ b/ui/app/mixins/with-watchers.js
@@ -41,13 +41,16 @@ export default Mixin.create(WithVisibilityDetection, {
   actions: {
     willTransition(transition) {
       // Don't cancel watchers if transitioning into a sub-route
+      // Make sure, if it starts with the route name, that it's not the same route
       if (
         !transition.intent.name ||
-        !transition.intent.name.startsWith(this.routeName)
+        !(
+          transition.intent.name.startsWith(this.routeName) &&
+          this.routeName !== transition.intent.name
+        )
       ) {
         this.cancelAllWatchers();
       }
-
       // Bubble the action up to the application route
       return true;
     },


### PR DESCRIPTION
On a parent/child Nomad job (periodic, parameterized), the Nomad UI shows a page at `jobs/:job` that aggregates information about its child jobs. For example, a periodic job that runs hourly, etc. would have all its hourly runs included in a "Child Jobs" table.

That parent job, though, does not have any allocations (or evaluations, or services) of its own. Despite this, we do consider it a job, if only of a different type (we might otherwise have considered it a "folder" or some other similar concept)

Because we consider it a job, we give it all the bells and whistles that nomad jobs have at the top level (we're pulling some of these back, though; see the removal of unnecessary subnav in https://github.com/hashicorp/nomad/pull/17190 for example).

While this is pretty innocuous most of the time (an empty list of allocations is always returned for a parent periodic job, causing no real harm), there is a problem with how these watchers interact with our concept of routes: because moving from a parent job to its child has the same Ember route location, not everything is torn down and brought back up again. Our relationship watchers need to be cancelled and restarted with the child job's model. This PR cancels existing watchers when doing a transition between two pages at the same route.

In plain terms, before this PR, the content of the "Task Groups" bar would update, but the content of the "Allocations" table never would — only when clicking into the child job from its parent. When loaded directly by URL, things would work fine. This is fixed with the exact-name check here.

Resolves #17193 