### PR TITLE
docs: remove unneeded brackets from job specification template docs

### DIFF
--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -430,7 +430,6 @@ template {
 {{ range nomadVarList }}
   {{ . }}
 {{ end }}
-}
 EOH
 }
 
@@ -439,7 +438,6 @@ template {
 {{ range nomadVarList }}
   {{ .Path }}
 {{ end }}
-}
 EOH
 }
 ```
@@ -453,7 +451,6 @@ template {
 {{ range nomadVarList "path/to/filter" }}
   {{ . }}
 {{ end }}
-}
 EOH
 }
 ```
@@ -468,7 +465,6 @@ template {
 {{ range nomadVarList "path/to/filter@example_namespace" }}
   {{ . }}
 {{ end }}
-}
 EOH
 }
 ```


### PR DESCRIPTION
Removes unnecessary curly brackets from the job specification template docs in the ["Nomad variables"](https://developer.hashicorp.com/nomad/docs/job-specification/template#nomad-variables) section.

```diff
template {
  data        = <<EOH
{{ range nomadVarList }}
  {{ . }}
{{ end }}
- }
EOH
}
```