### PR TITLE
ui:  add option to filter for jobs that are packs

### DIFF
--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -91,6 +91,7 @@ export default class IndexController extends Controller.extend(
   get optionsType() {
     return [
       { key: 'batch', label: 'Batch' },
+      { key: 'pack', label: 'Pack' },
       { key: 'parameterized', label: 'Parameterized' },
       { key: 'periodic', label: 'Periodic' },
       { key: 'service', label: 'Service' },
@@ -224,7 +225,13 @@ export default class IndexController extends Controller.extend(
     // A job must match ALL filter facets, but it can match ANY selection within a facet
     // Always return early to prevent unnecessary facet predicates.
     return this.visibleJobs.filter((job) => {
-      if (types.length && !types.includes(job.get('displayType'))) {
+      const shouldShowPack = types.includes('pack') && job.displayType.isPack;
+
+      if (types.length && shouldShowPack) {
+        return true;
+      }
+
+      if (types.length && !types.includes(job.get('displayType.type'))) {
         return false;
       }
 

--- a/ui/app/controllers/optimize.js
+++ b/ui/app/controllers/optimize.js
@@ -192,7 +192,7 @@ export default class OptimizeController extends Controller {
         return false;
       }
 
-      if (types.length && !types.includes(job.get('displayType'))) {
+      if (types.length && !types.includes(job.get('displayType.type'))) {
         return false;
       }
 

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -31,6 +31,10 @@ export default class Job extends Model {
 
   @fragment('structured-attributes') meta;
 
+  get isPack() {
+    return !!this.meta?.structured?.pack;
+  }
+
   // True when the job is the parent periodic or parameterized jobs
   // Instances of periodic or parameterized jobs are false for both properties
   @attr('boolean') periodic;
@@ -69,14 +73,14 @@ export default class Job extends Model {
   // A composite of type and other job attributes to determine
   // a better type descriptor for human interpretation rather
   // than for scheduling.
-  @computed('type', 'periodic', 'parameterized')
+  @computed('isPack', 'type', 'periodic', 'parameterized')
   get displayType() {
     if (this.periodic) {
-      return 'periodic';
+      return { type: 'periodic', isPack: this.isPack };
     } else if (this.parameterized) {
-      return 'parameterized';
+      return { type: 'parameterized', isPack: this.isPack };
     }
-    return this.type;
+    return { type: this.type, isPack: this.isPack };
   }
 
   // A composite of type and other job attributes to determine

--- a/ui/app/templates/components/job-row.hbs
+++ b/ui/app/templates/components/job-row.hbs
@@ -41,7 +41,7 @@
   </span>
 </td>
 <td data-test-job-type>
-  {{this.job.displayType}}
+  {{this.job.displayType.type}}
 </td>
 <td data-test-job-priority>
   {{this.job.priority}}

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -270,6 +270,7 @@ module('Acceptance | jobs list', function (hooks) {
     paramName: 'type',
     expectedOptions: [
       'Batch',
+      'Pack',
       'Parameterized',
       'Periodic',
       'Service',


### PR DESCRIPTION
Resolves #15736 

This PR adds a UI filter to the `jobs.index` view to enable filtering for jobs that are packs.