### PR TITLE
[ui] Adds a "Scheduling" filter to the job.allocations page

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -326,6 +326,7 @@ func (a *Allocation) Stub() *AllocationListStub {
 		TaskStates:            a.TaskStates,
 		DeploymentStatus:      a.DeploymentStatus,
 		FollowupEvalID:        a.FollowupEvalID,
+		NextAllocation:        a.JobID,
 		RescheduleTracker:     a.RescheduleTracker,
 		PreemptedAllocations:  a.PreemptedAllocations,
 		PreemptedByAllocation: a.PreemptedByAllocation,
@@ -379,6 +380,7 @@ type AllocationListStub struct {
 	TaskStates            map[string]*TaskState
 	DeploymentStatus      *AllocDeploymentStatus
 	FollowupEvalID        string
+	NextAllocation        string
 	RescheduleTracker     *RescheduleTracker
 	PreemptedAllocations  []string
 	PreemptedByAllocation string

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10896,6 +10896,7 @@ func (a *Allocation) Stub(fields *AllocStubFields) *AllocListStub {
 		TaskStates:            a.TaskStates,
 		DeploymentStatus:      a.DeploymentStatus,
 		FollowupEvalID:        a.FollowupEvalID,
+		NextAllocation:        a.NextAllocation,
 		RescheduleTracker:     a.RescheduleTracker,
 		PreemptedAllocations:  a.PreemptedAllocations,
 		PreemptedByAllocation: a.PreemptedByAllocation,
@@ -11058,6 +11059,7 @@ type AllocListStub struct {
 	TaskStates            map[string]*TaskState
 	DeploymentStatus      *AllocDeploymentStatus
 	FollowupEvalID        string
+	NextAllocation        string
 	RescheduleTracker     *RescheduleTracker
 	PreemptedAllocations  []string
 	PreemptedByAllocation string

--- a/ui/app/components/job-status/failed-or-lost.hbs
+++ b/ui/app/components/job-status/failed-or-lost.hbs
@@ -9,14 +9,28 @@
       <FlightIcon @name="info" />
     </span>
   </h4>
-  <ConditionalLinkTo
-    @condition={{this.shouldLinkToAllocations}}
-    @route="jobs.job.allocations"
-    @model={{@job}}
-    @query={{hash status=(concat '["failed", "lost", "unknown"]') version=(concat '[' @job.latestDeployment.versionNumber ']')}}
-    @label="View Allocations"
-    @class="failed-or-lost-link"
-  >
-    {{@allocs.length}}
-  </ConditionalLinkTo>
+  {{#if (eq @title "Rescheduled")}}
+    <ConditionalLinkTo
+      @condition={{this.shouldLinkToAllocations}}
+      @route="jobs.job.allocations"
+      @model={{@job}}
+      @query={{hash scheduling=(concat '["has-been-rescheduled"]') version=(concat '[' @job.latestDeployment.versionNumber ']')}}
+      @label="View Allocations"
+      @class="failed-or-lost-link"
+    >
+      {{@allocs.length}}
+    </ConditionalLinkTo>
+  {{/if}}
+  {{#if (eq @title "Restarted")}}
+    <ConditionalLinkTo
+      @condition={{this.shouldLinkToAllocations}}
+      @route="jobs.job.allocations"
+      @model={{@job}}
+      @query={{hash scheduling=(concat '["has-been-restarted"]') version=(concat '[' @job.latestDeployment.versionNumber ']')}}
+      @label="View Allocations"
+      @class="failed-or-lost-link"
+    >
+      {{@allocs.length}}
+    </ConditionalLinkTo>
+  {{/if}}
 </section>

--- a/ui/app/components/job-status/failed-or-lost.js
+++ b/ui/app/components/job-status/failed-or-lost.js
@@ -2,6 +2,6 @@ import Component from '@glimmer/component';
 
 export default class JobStatusFailedOrLostComponent extends Component {
   get shouldLinkToAllocations() {
-    return this.args.title !== 'Restarted' && this.args.allocs.length;
+    return this.args.allocs.length;
   }
 }

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -48,7 +48,7 @@
               @condition={{not (eq type.label "unplaced")}}
               @route="jobs.job.allocations"
               @model={{@job}}
-              @query={{hash status=(concat '["' type.label '"]') version=(concat '[' (keys this.versions) ']')}}
+              @query={{hash status=(concat '["' type.label '"]') version=(concat '[' (map-by "version" this.versions) ']')}}
               @class="legend-item {{if (eq (get (get (get (get this.allocBlocks type.label) 'healthy') 'nonCanary') "length") 0) "faded"}}"
               @label="View {{type.label}} allocations"
             >

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -156,7 +156,6 @@ export default class JobStatusPanelSteadyComponent extends Component {
         }
         return result;
       }, []);
-    console.log('uh versions', versions);
     return versions;
   }
 

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -156,6 +156,7 @@ export default class JobStatusPanelSteadyComponent extends Component {
         }
         return result;
       }, []);
+    console.log('uh versions', versions);
     return versions;
   }
 

--- a/ui/app/templates/components/multi-select-dropdown.hbs
+++ b/ui/app/templates/components/multi-select-dropdown.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <BasicDropdown
-  @horizontalPosition="left"
+  @horizontalPosition="auto"
   @onOpen={{action
     (queue (action (mut this.isOpen) true) (action this.capture))
   }}

--- a/ui/app/templates/jobs/job/allocations.hbs
+++ b/ui/app/templates/jobs/job/allocations.hbs
@@ -45,6 +45,12 @@
             @selection={{this.selectionVersion}}
             @onSelect={{action this.setFacetQueryParam "qpVersion"}}
           />
+          <MultiSelectDropdown
+            @label="Scheduling"
+            @options={{this.optionsScheduling}}
+            @selection={{this.selectionScheduling}}
+            @onSelect={{action this.setFacetQueryParam "qpScheduling"}}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Adds a new filter, "Scheduling", to the job allocations page. This helps facilitate Rescheduled/Restarted links from the upcoming [Job Status Panel](https://github.com/hashicorp/nomad/issues/16128) and gives us future options for letting users drill down on this list page.

Because of some seen inconsistencies in testing, this adds `NextAllocation` to Allocations in their list/stub form from our API, where before they only existed when an allocation was being fetched individually. This, combined with a check for FollowUpEvalID, gives us a better picture of "Is a terminal allocation never going to be rescheduled?", which the UI is seeking to show to users here.

![image](https://github.com/hashicorp/nomad/assets/713991/aa9b71d4-6c10-4af4-bfe6-b8171a0354de)

![image](https://github.com/hashicorp/nomad/assets/713991/c2b59246-fcfc-4c17-b6d5-a3cde7f5d395)


Resolves #17221 