### PR TITLE
build: move GitHub actions to versions allowed by prodsec

### DIFF
--- a/.github/workflows/ember-assets.yml
+++ b/.github/workflows/ember-assets.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
           node-version: '14'
-      - uses: backspace/ember-asset-size-action@edit-comment # TSCCR: no entry for repository "backspace/ember-asset-size-action"
+      - uses: mainmatter/ember-asset-size-action@v3
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           working-directory: "ui"

--- a/.github/workflows/ember-assets.yml
+++ b/.github/workflows/ember-assets.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
           node-version: '14'
-      - uses: mainmatter/ember-asset-size-action@v3
+      - uses: mainmatter/ember-asset-size-action@255fe534db3d2f731e0d70ce9a5de74b0a6b140a # v3
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           working-directory: "ui"

--- a/.github/workflows/ember-test-audit.yml
+++ b/.github/workflows/ember-test-audit.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           ref: ${{ github.event.pull_request.base.sha }}
-      - uses: nanasess/setup-chromedriver@master # TSCCR: no entry for repository "nanasess/setup-chromedriver"
+      - uses: nanasess/setup-chromedriver@95301782a076fbe8c9ecf54395a4689f7b195285 # v2.0.0
       - name: Use Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: nanasess/setup-chromedriver@master # TSCCR: no entry for repository "nanasess/setup-chromedriver"
+      - uses: nanasess/setup-chromedriver@95301782a076fbe8c9ecf54395a4689f7b195285 # v2.0.0
       - name: Use Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: pr-audit
-      - uses: backspace/ember-test-audit-comparison-action@v2 # TSCCR: no entry for repository "backspace/ember-test-audit-comparison-action"
+      - uses: backspace/ember-test-audit-comparison-action@21e9492d0033bc7e84b6189ae94537a6ed045cfa # v2
         with:
           base-report-path: base-audit.json
           comparison-report-path: pr-audit.json
@@ -72,12 +72,12 @@ jobs:
           path: audit-diff.md
       - name: Check for existence of flakiness report
         id: check_file
-        uses: andstor/file-existence-action@v1 # TSCCR: no entry for repository "andstor/file-existence-action"
+        uses: andstor/file-existence-action@f02338908d150e00a4b8bebc2dad18bd9e5229b0 # v1.1.0
         with:
           files: "flakiness-report.md"
       - name: comment PR
         if: steps.check_file.outputs.files_exists == 'true'
-        uses: mshick/add-pr-comment@v2.8.1
+        uses: mshick/add-pr-comment@7c0890544fb33b0bdd2e59467fbacb62e028a096 # v2.8.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/ember-test-audit.yml
+++ b/.github/workflows/ember-test-audit.yml
@@ -77,8 +77,8 @@ jobs:
           files: "flakiness-report.md"
       - name: comment PR
         if: steps.check_file.outputs.files_exists == 'true'
-        uses: machine-learning-apps/pr-comment@1.0.0 # TSCCR: no entry for repository "machine-learning-apps/pr-comment"
+        uses: mshick/add-pr-comment@v2.8.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          path: flakiness-report.md
+          message_path: flakiness-report.md

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -15,4 +15,4 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: returntocorp/semgrep-action@v1 # TSCCR: no entry for repository "returntocorp/semgrep-action"
+      - uses: returntocorp/semgrep-action@v1  # TSCCR: no entry for repository "returntocorp/semgrep-action"


### PR DESCRIPTION
The `backspace/ember-asset-size` action we're using is unmaintained and has a bunch of vulns in it, so it won't pass security screening (this is a NodeJS action so it has piles of dependencies, 99% of which won't be in use but fails automated screening anyways). Move this to the upstream version.

The `machine-learning-apps/pr-comment` action also presents a problem for the ProdSec security screening because it's archived and also runs an external Docker image. Move this to a likely-ok maintained action for now, until we can spare some time to remove this in lieu of something more reasonable that isn't a GitHub action.

Once this is tested, I'll then have to follow up in https://github.com/hashicorp/security-tsccr/pull/428 to pin the SHA, and then I'll have to follow-up once that other PR is merged to pin the SHAs here.