### PR TITLE
build: remove 386 builds for Nomad 1.6.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         goos: [windows]
-        goarch: ["386", "amd64"]
+        goarch: ["amd64"]
       fail-fast: true
 
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux]
-        goarch: ["arm", "arm64", "386", "amd64"]
+        goarch: ["arm", "arm64", "amd64"]
       fail-fast: true
 
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -166,12 +166,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y software-properties-common
-          sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt-get install -y \
-            libc6-dev-i386 \
-            libpcre3-dev \
-            linux-libc-dev:i386
           sudo apt-get install -y \
             binutils-aarch64-linux-gnu \
             binutils-arm-linux-gnueabihf \
@@ -297,7 +292,7 @@ jobs:
   #   runs-on: [ custom, linux, xxl, 20.04 ]
   #   strategy:
   #     matrix:
-  #       arch: ["arm", "arm64", "386", "amd64"]
+  #       arch: ["arm", "arm64", "amd64"]
   #   env:
   #     repo: ${{github.event.repository.name}}
   #     version: ${{needs.get-product-version.outputs.product-version}}

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -37,8 +37,21 @@ capability or the `read` policy must update their tokens to use the
 #### Command `nomad tls cert create` flag `-cluster-region` deprecated
 
 Nomad 1.6.0 will deprecate the command `nomad tls cert create` flag `-cluster-region`
-in favour of using the standard flag `-region`. The `-cluster-region` flag 
-will be removed in Nomad 1.7.0 
+in favour of using the standard flag `-region`. The `-cluster-region` flag
+will be removed in Nomad 1.7.0
+
+#### 32-bit Intel Builds Deprecated
+
+Starting with Nomad 1.6.0, HashiCorp will no longer release 32-bit Intel builds
+of Nomad and Nomad Enterprise (the builds named `windows_386` and
+`linux_386`). Bug fixes will continue to be backported to the 1.5.x and 1.4.x
+versions so long as those major versions are still supported.
+
+The 32-bit ARM build (`linux_arm` for the armhf architecture) is deprecated and
+may be removed in a future major version of Nomad. The 32-bit ARM build is not
+tested and may include bugs around platform-specific integer sizes. Using 64-bit
+builds for small form-factor hosts such as the RaspberryPi is strongly
+recommended.
 
 ## Nomad 1.5.5
 


### PR DESCRIPTION
The 32-bit Intel builds (aka "386") are not tested and likely have bugs involving platform-sized integers when operated at any non-trivial scale. Remove these builds from the upcoming Nomad 1.6.0 and provide recommendations in the upgrade notes for those users who might have hobbyist boards running 32-bit ARM (this will primarily be the RaspberryPi Zero or older spins of the RaspPi).

Ref https://github.com/hashicorp/nomad-enterprise/issues/1053
cc @davemay99 as a heads up and @mikenomitch and @mmcquillan for approvals

**DO NOT BACKPORT!** :grinning: 