### PR TITLE
docs: describe the default Workload Identity ACL policy

### DIFF
--- a/website/content/docs/concepts/workload-identity.mdx
+++ b/website/content/docs/concepts/workload-identity.mdx
@@ -43,6 +43,14 @@ task "example" {
 }
 ```
 
+## Default Workload ACL Policy
+
+By default, a Workload Identity has access to a implicit ACL policy. This policy
+grants access to Nomad Variables associated with the job, group, and task, as
+described in [Task Access to Variables][]. The implicit policy also allows
+access to list or read any Nomad service registration as with the [List Services
+API][] or [Read Service API][].
+
 ## Workload Associated ACL Policies
 
 You can associate additional ACL policies with workload identities by passing
@@ -94,3 +102,6 @@ nomad acl policy apply \
 [identity-block]: /nomad/docs/job-specification/identity
 [plan applier]: /nomad/docs/concepts/scheduling/scheduling
 [JSON Web Token (JWT)]: https://datatracker.ietf.org/doc/html/rfc7519
+[Task Access to Variables]: /nomad/docs/concepts/variables#task-access-to-variables
+[List Services API]: /nomad/api-docs/services#list-services
+[Read Service API]: /nomad/api-docs/services#read-service


### PR DESCRIPTION
Workload Identities have an implicit default policy. This policy can't currently be described via HCL because it includes task interpolation for Variables and access to the Services API (which doesn't exist as its own ACL capbility). Describe this in our WI documentation.

Fixes: #16277