### PR TITLE
build: pin semgrep action

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -15,4 +15,4 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: returntocorp/semgrep-action@v1  # TSCCR: no entry for repository "returntocorp/semgrep-action"
+      - uses: returntocorp/semgrep-action@245bf11ddb2f3d4e35f116608cf6e27ae0f9aa04 # v1


### PR DESCRIPTION
The ref, sha, and URL in the TSCCR repo for the `returntocorp/semgrep-action` action was incorrect, so the pinning tool was not able to find the correct entry and it was not pinned in #17238.

The repository is fixed in https://github.com/hashicorp/security-tsccr/pull/431