### PR TITLE
[api] Add NetworkStatus to allocation response

### DIFF
--- a/.changelog/17280.txt
+++ b/.changelog/17280.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: add missing field NetworkStatus for Allocation
+```

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -270,6 +270,7 @@ type Allocation struct {
 	PreviousAllocation    string
 	NextAllocation        string
 	RescheduleTracker     *RescheduleTracker
+	NetworkStatus         *AllocNetworkStatus
 	PreemptedAllocations  []string
 	PreemptedByAllocation string
 	CreateIndex           uint64
@@ -277,7 +278,6 @@ type Allocation struct {
 	AllocModifyIndex      uint64
 	CreateTime            int64
 	ModifyTime            int64
-	NetworkStatus         *AllocNetworkStatus
 }
 
 // AllocationMetric is used to deserialize allocation metrics.

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -277,6 +277,7 @@ type Allocation struct {
 	AllocModifyIndex      uint64
 	CreateTime            int64
 	ModifyTime            int64
+	NetworkStatus         *AllocNetworkStatus
 }
 
 // AllocationMetric is used to deserialize allocation metrics.
@@ -398,6 +399,15 @@ type AllocDeploymentStatus struct {
 	Timestamp   time.Time
 	Canary      bool
 	ModifyIndex uint64
+}
+
+// AllocNetworkStatus captures the status of an allocation's network during runtime.
+// Depending on the network mode, an allocation's address may need to be known to other
+// systems in Nomad such as service registration.
+type AllocNetworkStatus struct {
+	InterfaceName string
+	Address       string
+	DNS           *DNSConfig
 }
 
 type AllocatedResources struct {

--- a/api/allocations_test.go
+++ b/api/allocations_test.go
@@ -161,6 +161,46 @@ func TestAllocations_CreateIndexSort(t *testing.T) {
 	must.Eq(t, allocs, expect)
 }
 
+func TestAllocations_Info(t *testing.T) {
+	testutil.RequireRoot(t)
+	testutil.Parallel(t)
+
+	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
+		c.DevMode = true
+	})
+	defer s.Stop()
+	a := c.Allocations()
+
+	// wait for node
+	_ = oneNodeFromNodeList(t, c.Nodes())
+
+	// Create a job and attempt to register it
+	job := testJob()
+	resp, wm, err := c.Jobs().Register(job, nil)
+	must.NoError(t, err)
+	must.NotNil(t, resp)
+	must.UUIDv4(t, resp.EvalID)
+	assertWriteMeta(t, wm)
+
+	// List allocations.
+	qo := &QueryOptions{
+		WaitIndex: wm.LastIndex,
+	}
+	allocs, qm, err := a.List(qo)
+	must.NoError(t, err)
+	must.NonZero(t, qm.LastIndex)
+
+	// Check that we got one allocation.
+	must.Len(t, 1, allocs)
+	must.Eq(t, resp.EvalID, allocs[0].EvalID)
+
+	// Fetch alloc info.
+	qo.WaitIndex = qm.LastIndex
+	alloc, _, err := a.Info(allocs[0].ID, qo)
+
+	must.NotNil(t, alloc.NetworkStatus)
+}
+
 func TestAllocations_RescheduleInfo(t *testing.T) {
 	testutil.Parallel(t)
 


### PR DESCRIPTION
Service discovery or mesh network systems consuming the Nomad event stream or API need to know the CNI assigned IP for the allocation. This data is returned by the underlying Nomad API but isn't mapped in the response struct in the Go client.
