### PR TITLE
changelog entry for Vault SDK update

### DIFF
--- a/.changelog/17281.txt
+++ b/.changelog/17281.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+deps: Updated Vault SDK to 0.9.0
+```


### PR DESCRIPTION
The Vault SDK was updated by dependabot but I forgot to add a changelog entry for it. I'll cherry-pick this commit onto a backport PR as well.