### PR TITLE
docs: fixup example of readiness check

### DIFF
--- a/website/content/docs/job-specification/check.mdx
+++ b/website/content/docs/job-specification/check.mdx
@@ -354,7 +354,7 @@ service {
     path      = "/leader"
     interval  = "10s"
     timeout   = "2s"
-    on_update = "ignore_warnings"
+    on_update = "ignore"
   }
 }
 ```


### PR DESCRIPTION
A "readiness" check implies a failing healthcheck will not cause the
deployment of a service to stop - i.e. it is only used as a liveness
probe in the context of service discoverability.

Fix our docs example to reflect that a readiness check is created by
setting on_update to "ignore" (as opposed to "ignore_warnings").
