### PR TITLE
ui:  create node pool model

### DIFF
--- a/ui/app/models/node-pool.js
+++ b/ui/app/models/node-pool.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Model from '@ember-data/model';
+import { attr } from '@ember-data/model';
+import { computed } from '@ember/object';
+import classic from 'ember-classic-decorator';
+
+@classic
+export default class NodePool extends Model {
+  @attr('string') name;
+  @attr('string') description;
+  @attr() meta;
+  @attr() schedulerConfiguration;
+
+  @computed('schedulerConfiguration.SchedulerAlgorithm')
+  get schedulerAlgorithm() {
+    return this.get('schedulerConfiguration.SchedulerAlgorithm');
+  }
+}

--- a/ui/app/serializers/node-pool.js
+++ b/ui/app/serializers/node-pool.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import ApplicationSerializer from './application';
+import classic from 'ember-classic-decorator';
+
+@classic
+export default class NodePool extends ApplicationSerializer {
+  primaryKey = 'Name';
+}

--- a/ui/tests/unit/serializers/node-pool-test.js
+++ b/ui/tests/unit/serializers/node-pool-test.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Serializer | NodePool', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.subject = () => this.store.serializerFor('node-pool');
+  });
+
+  test('should serialize a NodePool', function (assert) {
+    const nodePool = this.store.createRecord('node-pool', {
+      name: 'prod-eng',
+      description: 'Production workloads',
+      meta: {
+        env: 'production',
+        team: 'engineering',
+      },
+      schedulerConfiguration: {
+        SchedulerAlgorithm: 'spread',
+      },
+    });
+
+    const serializedNodePool = this.subject().serialize(
+      nodePool._createSnapshot()
+    );
+
+    assert.deepEqual(serializedNodePool, {
+      Name: 'prod-eng',
+      Description: 'Production workloads',
+      Meta: {
+        env: 'production',
+        team: 'engineering',
+      },
+      SchedulerConfiguration: {
+        SchedulerAlgorithm: 'spread',
+      },
+    });
+  });
+});


### PR DESCRIPTION
Resolves #17292 

This PR adds a new NodePool model and serializer. The NodePool model is used to represent a pool of nodes that can be used to run applications. The serializer is used to serialize the JSON response of a NodePool object to a JSON:API object.

The NodePool model has the following properties:

```
name: The name of the node pool
description: A description of the node pool
meta: A map of additional metadata about the node pool
schedulerConfiguration: The configuration of the scheduler for the node pool
```

The serializer serializes NodePool objects to JSON:API by converting the properties of the objects to strings. The following is an example of the serialized object that is generated for a NodePool object:


```
{
  "name": "prod-eng",
  "description": "Production workloads",
  "meta": {
    "env": "production",
    "team": "engineering"
  },
  "schedulerConfiguration": {
    "SchedulerAlgorithm": "spread" // pattern match:  We don't apply camelCasing for nested objects in other models
  }
}
```