### PR TITLE
Versioned job summary (allocation clientStatuses by version and group)

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -1092,10 +1092,11 @@ func (j *Job) LookupTaskGroup(name string) *TaskGroup {
 
 // JobSummary summarizes the state of the allocations of a job
 type JobSummary struct {
-	JobID     string
-	Namespace string
-	Summary   map[string]TaskGroupSummary
-	Children  *JobChildrenSummary
+	JobID            string
+	Namespace        string
+	Summary          map[string]TaskGroupSummary
+	VersionedSummary map[string]VersionedTaskGroupSummary
+	Children         *JobChildrenSummary
 
 	// Raft Indexes
 	CreateIndex uint64
@@ -1127,6 +1128,17 @@ type TaskGroupSummary struct {
 	Starting int
 	Lost     int
 	Unknown  int
+}
+
+type VersionedTaskGroupSummary struct {
+	Queued            map[string]int
+	Complete          map[string]int
+	Failed            map[string]int
+	Running           map[string]int
+	Starting          map[string]int
+	Lost              map[string]int
+	Unknown           map[string]int
+	FailedButReplaced map[string]int
 }
 
 // JobListStub is used to return a subset of information about

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -1131,14 +1131,13 @@ type TaskGroupSummary struct {
 }
 
 type VersionedTaskGroupSummary struct {
-	Queued            map[string]int
-	Complete          map[string]int
-	Failed            map[string]int
-	Running           map[string]int
-	Starting          map[string]int
-	Lost              map[string]int
-	Unknown           map[string]int
-	FailedButReplaced map[string]int
+	Queued   map[string]int
+	Complete map[string]int
+	Failed   map[string]int
+	Running  map[string]int
+	Starting map[string]int
+	Lost     map[string]int
+	Unknown  map[string]int
 }
 
 // JobListStub is used to return a subset of information about

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -1095,7 +1095,7 @@ type JobSummary struct {
 	JobID            string
 	Namespace        string
 	Summary          map[string]TaskGroupSummary
-	VersionedSummary map[string]VersionedTaskGroupSummary
+	VersionedSummary map[uint64]VersionedSummary
 	Children         *JobChildrenSummary
 
 	// Raft Indexes
@@ -1130,14 +1130,9 @@ type TaskGroupSummary struct {
 	Unknown  int
 }
 
-type VersionedTaskGroupSummary struct {
-	Queued   map[string]int
-	Complete map[string]int
-	Failed   map[string]int
-	Running  map[string]int
-	Starting map[string]int
-	Lost     map[string]int
-	Unknown  map[string]int
+type VersionedSummary struct {
+	Version int
+	Groups  map[string]TaskGroupSummary
 }
 
 // JobListStub is used to return a subset of information about

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -2806,8 +2806,9 @@ func TestFSM_ReconcileSummaries(t *testing.T) {
 				Queued: 10,
 			},
 		},
-		CreateIndex: 1000,
-		ModifyIndex: out1.ModifyIndex,
+		VersionedSummary: map[uint64]structs.VersionedSummary{},
+		CreateIndex:      1000,
+		ModifyIndex:      out1.ModifyIndex,
 	}
 	if !reflect.DeepEqual(&expected, out1) {
 		t.Fatalf("expected: %#v, actual: %#v", &expected, out1)
@@ -2826,6 +2827,16 @@ func TestFSM_ReconcileSummaries(t *testing.T) {
 			"web": {
 				Queued:   9,
 				Starting: 1,
+			},
+		},
+		VersionedSummary: map[uint64]structs.VersionedSummary{
+			0: {
+				Version: 0,
+				Groups: map[string]structs.TaskGroupSummary{
+					"web": {
+						Starting: 1,
+					},
+				},
 			},
 		},
 		CreateIndex: 1010,
@@ -2896,11 +2907,12 @@ func TestFSM_ReconcileParentJobSummary(t *testing.T) {
 	ws := memdb.NewWatchSet()
 	out1, _ := state.JobSummaryByID(ws, job1.Namespace, job1.ID)
 	expected := structs.JobSummary{
-		JobID:       job1.ID,
-		Namespace:   job1.Namespace,
-		Summary:     make(map[string]structs.TaskGroupSummary),
-		CreateIndex: 1000,
-		ModifyIndex: out1.ModifyIndex,
+		JobID:            job1.ID,
+		Namespace:        job1.Namespace,
+		Summary:          make(map[string]structs.TaskGroupSummary),
+		VersionedSummary: make(map[uint64]structs.VersionedSummary),
+		CreateIndex:      1000,
+		ModifyIndex:      out1.ModifyIndex,
 		Children: &structs.JobChildrenSummary{
 			Running: 1,
 		},

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -4818,6 +4818,14 @@ func TestJobEndpoint_GetJobSummary(t *testing.T) {
 		Summary: map[string]structs.TaskGroupSummary{
 			"web": {},
 		},
+		VersionedSummary: map[uint64]structs.VersionedSummary{
+			0: {
+				Version: 0,
+				Groups: map[string]structs.TaskGroupSummary{
+					"web": {},
+				},
+			},
+		},
 		Children:    new(structs.JobChildrenSummary),
 		CreateIndex: job.CreateIndex,
 		ModifyIndex: job.CreateIndex,
@@ -4879,6 +4887,14 @@ func TestJobEndpoint_Summary_ACL(t *testing.T) {
 		Namespace: job.Namespace,
 		Summary: map[string]structs.TaskGroupSummary{
 			"web": {},
+		},
+		VersionedSummary: map[uint64]structs.VersionedSummary{
+			0: {
+				Version: 0,
+				Groups: map[string]structs.TaskGroupSummary{
+					"web": {},
+				},
+			},
 		},
 		Children:    new(structs.JobChildrenSummary),
 		CreateIndex: job.CreateIndex,

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -132,6 +132,14 @@ func JobSummary(jobID string) *structs.JobSummary {
 				Starting: 0,
 			},
 		},
+		VersionedSummary: map[uint64]structs.VersionedSummary{
+			0: {
+				Version: 0,
+				Groups: map[string]structs.TaskGroupSummary{
+					"web": {},
+				},
+			},
+		},
 	}
 }
 

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -1580,6 +1580,16 @@ func TestClientEndpoint_Drain_Down(t *testing.T) {
 					Lost:   1,
 				},
 			},
+			VersionedSummary: map[uint64]structs.VersionedSummary{
+				0: {
+					Version: 0,
+					Groups: map[string]structs.TaskGroupSummary{
+						"web": {
+							Lost: 1,
+						},
+					},
+				},
+			},
 			Children:    new(structs.JobChildrenSummary),
 			CreateIndex: jobResp.JobModifyIndex,
 			ModifyIndex: summary.ModifyIndex,
@@ -1598,6 +1608,16 @@ func TestClientEndpoint_Drain_Down(t *testing.T) {
 			Summary: map[string]structs.TaskGroupSummary{
 				"web": {
 					Lost: 1,
+				},
+			},
+			VersionedSummary: map[uint64]structs.VersionedSummary{
+				0: {
+					Version: 0,
+					Groups: map[string]structs.TaskGroupSummary{
+						"web": {
+							Lost: 1,
+						},
+					},
 				},
 			},
 			Children:    new(structs.JobChildrenSummary),

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -5793,21 +5793,29 @@ func (s *StateStore) updateSummaryWithAlloc(index uint64, alloc *structs.Allocat
 		case structs.AllocClientStatusRunning:
 			if tgSummary.Running > 0 {
 				tgSummary.Running -= 1
+			}
+			if vtgSummary.Running[fmt.Sprint(existingAlloc.Job.Version)] > 0 {
 				vtgSummary.Running[fmt.Sprint(existingAlloc.Job.Version)] -= 1
 			}
 		case structs.AllocClientStatusPending:
 			if tgSummary.Starting > 0 {
 				tgSummary.Starting -= 1
+			}
+			if vtgSummary.Starting[fmt.Sprint(existingAlloc.Job.Version)] > 0 {
 				vtgSummary.Starting[fmt.Sprint(existingAlloc.Job.Version)] -= 1
 			}
 		case structs.AllocClientStatusLost:
 			if tgSummary.Lost > 0 {
 				tgSummary.Lost -= 1
+			}
+			if vtgSummary.Lost[fmt.Sprint(existingAlloc.Job.Version)] > 0 {
 				vtgSummary.Lost[fmt.Sprint(existingAlloc.Job.Version)] -= 1
 			}
 		case structs.AllocClientStatusUnknown:
 			if tgSummary.Unknown > 0 {
 				tgSummary.Unknown -= 1
+			}
+			if vtgSummary.Unknown[fmt.Sprint(existingAlloc.Job.Version)] > 0 {
 				vtgSummary.Unknown[fmt.Sprint(existingAlloc.Job.Version)] -= 1
 			}
 		case structs.AllocClientStatusFailed, structs.AllocClientStatusComplete:

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5115,8 +5115,6 @@ type VersionedTaskGroupSummary struct {
 	Starting map[string]int
 	Lost     map[string]int
 	Unknown  map[string]int
-	// FailedWithoutReplacement map[string]int
-	FailedButReplaced map[string]int
 }
 
 const (

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5046,6 +5046,8 @@ type JobSummary struct {
 	// Summary contains the summary per task group for the Job
 	Summary map[string]TaskGroupSummary
 
+	VersionedSummary map[string]VersionedTaskGroupSummary
+
 	// Children contains a summary for the children of this job.
 	Children *JobChildrenSummary
 
@@ -5062,7 +5064,14 @@ func (js *JobSummary) Copy() *JobSummary {
 	for k, v := range js.Summary {
 		newTGSummary[k] = v
 	}
+	// TODO: (PHIL) figure out if I need to do this for VersionedSummary also
+	// Check out maps.clone!
+	newVTGSummary := make(map[string]VersionedTaskGroupSummary, len(js.VersionedSummary))
+	for k, v := range js.VersionedSummary {
+		newVTGSummary[k] = v
+	}
 	newJobSummary.Summary = newTGSummary
+	newJobSummary.VersionedSummary = newVTGSummary
 	newJobSummary.Children = newJobSummary.Children.Copy()
 	return newJobSummary
 }
@@ -5095,6 +5104,19 @@ type TaskGroupSummary struct {
 	Starting int
 	Lost     int
 	Unknown  int
+}
+
+// VersionedTaskGroupSummary roughly matches the format of TaskGroupSummary, but for each status type, provides an object with versions as keys and counts as values.
+type VersionedTaskGroupSummary struct {
+	Queued   map[string]int
+	Complete map[string]int
+	Failed   map[string]int
+	Running  map[string]int
+	Starting map[string]int
+	Lost     map[string]int
+	Unknown  map[string]int
+	// FailedWithoutReplacement map[string]int
+	FailedButReplaced map[string]int
 }
 
 const (

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5068,12 +5068,11 @@ func (js *JobSummary) Copy() *JobSummary {
 
 	newVTGSummary := make(map[uint64]VersionedSummary, len(js.VersionedSummary))
 	for k, v := range js.VersionedSummary {
-		uk := uint64(k)
 		newGroupSummary := make(map[string]TaskGroupSummary, len(v.Groups))
 		for groupKey, groupVal := range v.Groups {
 			newGroupSummary[groupKey] = groupVal
 		}
-		newVTGSummary[uk] = VersionedSummary{
+		newVTGSummary[k] = VersionedSummary{
 			Version: v.Version,
 			Groups:  newGroupSummary,
 		}

--- a/nomad/system_endpoint_test.go
+++ b/nomad/system_endpoint_test.go
@@ -165,8 +165,9 @@ func TestSystemEndpoint_ReconcileSummaries(t *testing.T) {
 					Queued: 10,
 				},
 			},
-			ModifyIndex: summary.ModifyIndex,
-			CreateIndex: summary.CreateIndex,
+			VersionedSummary: map[uint64]structs.VersionedSummary{},
+			ModifyIndex:      summary.ModifyIndex,
+			CreateIndex:      summary.CreateIndex,
 		}
 		if !reflect.DeepEqual(&expectedSummary, summary) {
 			return false, fmt.Errorf("expected: %v, actual: %v", expectedSummary, summary)


### PR DESCRIPTION
Gives me a "versioned" summary object to mirror the existing summary, so I can show, for example, only recent clientStatus aggregate info on the jobs index list page.

In practice, this'll give me output that looks like this on a JobSummary:

<img width="647" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/e4d3fabc-e6c3-4428-8ec5-b23daab891be">

---
Known edge cases and potential improvements:
- **Alloc version update timing**: An allocation that gets its version updated, but does not change clientStatus (such as being bumped from version 0 to 1 when a non-destructive update happens, such as getting a task service's tags array updated) does not trigger the state store. Reconcile Summaries does fix this, though.
- **Indicating "Failed, but replaced so it's fine" status to a user**: Inside a job page, we're able to read all allocs directly and ascertain their .Job.Version and .ClientStatus, and also reason about the job's DesiredStatus. We've waxed about having an easily-accessible [Job.DesiredAllocCount](https://github.com/hashicorp/nomad/issues/17099) before, but there are reasons why that might be tricky to implement as well. From the jobs index page and elsewhere, getting info about something like DesiredCount is not currently possible without making potentially a lot of separate requests.