### PR TITLE
Add the ability to customise the details of the CA

### DIFF
--- a/.changelog/17309.txt
+++ b/.changelog/17309.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-tls: Add the ability to customize the details of the CA
+cli: Add the ability to customize the details of the CA when running `nomad tls ca create`
 ```

--- a/.changelog/17309.txt
+++ b/.changelog/17309.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+tls: Add the ability to customize the details of the CA
+```

--- a/command/tls_ca_create.go
+++ b/command/tls_ca_create.go
@@ -34,6 +34,27 @@ type TLSCACreateCommand struct {
 	// additionalDomain provides a list of restricted domains to the CA which
 	// will then reject any domains other than these.
 	additionalDomain flags.StringFlag
+
+	// country is used to set a country code for the CA
+	country string
+
+	// postalCode is used to set a postal code for the CA
+	postalCode string
+
+	// province is used to set a province for the CA
+	province string
+
+	// locality is used to set a locality for the CA
+	locality string
+
+	// streetAddress is used to set a street address for the CA
+	streetAddress string
+
+	// organization is used to set an organization for the CA
+	organization string
+
+	// organizationalUnit is used to set an organizational unit for the CA
+	organizationalUnit string
 }
 
 func (c *TLSCACreateCommand) Help() string {
@@ -53,6 +74,9 @@ CA Create Options:
   -common-name
     Common Name of CA. Defaults to "Nomad Agent CA".
 
+  -country
+    Country of the CA. Defaults to "US".
+
   -days
     Provide number of days the CA is valid for from now on.
     Defaults to 5 years or 1825 days.
@@ -61,12 +85,31 @@ CA Create Options:
     Domain of Nomad cluster. Only used in combination with -name-constraint.
     Defaults to "nomad".
 
+  -locality
+    Locality of the CA. Defaults to "San Francisco".
+
   -name-constraint
     Enables the DNS name restriction functionality to the CA. Results in the CA
     rejecting certificates for any other DNS zone. If enabled, localhost and the
     value of -domain will be added to the allowed DNS zones field. If the UI is
     going to be served over HTTPS its hostname must be added with
     -additional-domain. Defaults to false.
+
+  -organization
+    Organization of the CA. Defaults to "HashiCorp Inc.".
+
+  -organizational-unit
+    Organizational Unit of the CA. Defaults to "Nomad".
+
+  -postal-code
+    Postal Code of the CA. Defaults to "94105".
+
+  -province
+    Province of the CA. Defaults to "CA".
+
+  -street-address
+    Street Address of the CA. Defaults to "101 Second Street".
+
 `
 	return strings.TrimSpace(helpText)
 }
@@ -74,11 +117,18 @@ CA Create Options:
 func (c *TLSCACreateCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
-			"-additional-domain": complete.PredictAnything,
-			"-common-name":       complete.PredictAnything,
-			"-days":              complete.PredictAnything,
-			"-domain":            complete.PredictAnything,
-			"-name-constraint":   complete.PredictAnything,
+			"-additional-domain":   complete.PredictAnything,
+			"-common-name":         complete.PredictAnything,
+			"-days":                complete.PredictAnything,
+			"-country":             complete.PredictAnything,
+			"-domain":              complete.PredictAnything,
+			"-locality":            complete.PredictAnything,
+			"-name-constraint":     complete.PredictAnything,
+			"-organization":        complete.PredictAnything,
+			"-organizational-unit": complete.PredictAnything,
+			"-postcode":            complete.PredictAnything,
+			"-province":            complete.PredictAnything,
+			"-street-address":      complete.PredictAnything,
 		})
 }
 
@@ -101,6 +151,13 @@ func (c *TLSCACreateCommand) Run(args []string) int {
 	flagSet.BoolVar(&c.constraint, "name-constraint", false, "")
 	flagSet.StringVar(&c.domain, "domain", "nomad", "")
 	flagSet.StringVar(&c.commonName, "common-name", "", "")
+	flagSet.StringVar(&c.country, "country", "", "")
+	flagSet.StringVar(&c.postalCode, "post-code", "", "")
+	flagSet.StringVar(&c.province, "province", "", "")
+	flagSet.StringVar(&c.locality, "locality", "", "")
+	flagSet.StringVar(&c.streetAddress, "street-address", "", "")
+	flagSet.StringVar(&c.organization, "organization", "", "")
+	flagSet.StringVar(&c.organizationalUnit, "organizational-unit", "", "")
 	if err := flagSet.Parse(args); err != nil {
 		return 1
 	}

--- a/command/tls_ca_create.go
+++ b/command/tls_ca_create.go
@@ -126,7 +126,7 @@ func (c *TLSCACreateCommand) AutocompleteFlags() complete.Flags {
 			"-name-constraint":     complete.PredictAnything,
 			"-organization":        complete.PredictAnything,
 			"-organizational-unit": complete.PredictAnything,
-			"-postcode":            complete.PredictAnything,
+			"-postal-code":         complete.PredictAnything,
 			"-province":            complete.PredictAnything,
 			"-street-address":      complete.PredictAnything,
 		})
@@ -147,12 +147,12 @@ func (c *TLSCACreateCommand) Run(args []string) int {
 	flagSet := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flagSet.Usage = func() { c.Ui.Output(c.Help()) }
 	flagSet.Var(&c.additionalDomain, "additional-domain", "")
-	flagSet.IntVar(&c.days, "days", 1825, "")
+	flagSet.IntVar(&c.days, "days", 0, "")
 	flagSet.BoolVar(&c.constraint, "name-constraint", false, "")
 	flagSet.StringVar(&c.domain, "domain", "nomad", "")
 	flagSet.StringVar(&c.commonName, "common-name", "", "")
 	flagSet.StringVar(&c.country, "country", "", "")
-	flagSet.StringVar(&c.postalCode, "post-code", "", "")
+	flagSet.StringVar(&c.postalCode, "postal-code", "", "")
 	flagSet.StringVar(&c.province, "province", "", "")
 	flagSet.StringVar(&c.locality, "locality", "", "")
 	flagSet.StringVar(&c.streetAddress, "street-address", "", "")
@@ -200,7 +200,19 @@ func (c *TLSCACreateCommand) Run(args []string) int {
 		constraints = append(constraints, c.additionalDomain...)
 	}
 
-	ca, pk, err := tlsutil.GenerateCA(tlsutil.CAOpts{Name: c.commonName, Days: c.days, Domain: c.domain, PermittedDNSDomains: constraints})
+	ca, pk, err := tlsutil.GenerateCA(tlsutil.CAOpts{
+		Name:                c.commonName,
+		Days:                c.days,
+		Domain:              c.domain,
+		PermittedDNSDomains: constraints,
+		Country:             c.country,
+		PostalCode:          c.postalCode,
+		Province:            c.province,
+		Locality:            c.locality,
+		StreetAddress:       c.streetAddress,
+		Organization:        c.organization,
+		OrganizationalUnit:  c.organizationalUnit,
+	})
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/command/tls_ca_create.go
+++ b/command/tls_ca_create.go
@@ -169,30 +169,28 @@ func (c *TLSCACreateCommand) Run(args []string) int {
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}
-	if c.IsEmpty() {
-		c.domain = "nomad"
-	} else if c.IsEmpty() && c.days != 0 {
+	if c.IsCustom() && c.days != 0 || c.IsCustom() {
 		c.domain = "nomad"
 	} else {
 		if c.commonName == "" {
-			c.Ui.Error("please provide the -common-name flag when customizing the CA")
+			c.Ui.Error("Please provide the -common-name flag when customizing the CA")
 			c.Ui.Error(commandErrorText(c))
 			return 1
 		}
 		if c.country == "" {
-			c.Ui.Error("please provide the -country flag when customizing the CA")
+			c.Ui.Error("Please provide the -country flag when customizing the CA")
 			c.Ui.Error(commandErrorText(c))
 			return 1
 		}
 
 		if c.organization == "" {
-			c.Ui.Error("please provide the -organization flag when customizing the CA")
+			c.Ui.Error("Please provide the -organization flag when customizing the CA")
 			c.Ui.Error(commandErrorText(c))
 			return 1
 		}
 
 		if c.organizationalUnit == "" {
-			c.Ui.Error("please provide the -organizational-unit flag when customizing the CA")
+			c.Ui.Error("Please provide the -organizational-unit flag when customizing the CA")
 			c.Ui.Error(commandErrorText(c))
 			return 1
 		}
@@ -260,9 +258,9 @@ func (c *TLSCACreateCommand) Run(args []string) int {
 	return 0
 }
 
-// IsEmpty checks whether any of TLSCACreateCommand parameters have been populated with
+// IsCustom checks whether any of TLSCACreateCommand parameters have been populated with
 // non-default values.
-func (c TLSCACreateCommand) IsEmpty() bool {
+func (c *TLSCACreateCommand) IsCustom() bool {
 	return c.commonName == "" &&
 		c.country == "" &&
 		c.postalCode == "" &&

--- a/command/tls_ca_create_test.go
+++ b/command/tls_ca_create_test.go
@@ -64,6 +64,16 @@ func TestCACreateCommand(t *testing.T) {
 				require.Contains(t, cert.Issuer.CommonName, "CustomCA")
 			},
 		},
+		{"ca custom date",
+			[]string{
+				"-days=365",
+			},
+			"nomad-agent-ca.pem",
+			"nomad-agent-ca-key.pem",
+			func(t *testing.T, cert *x509.Certificate) {
+				require.Equal(t, 365*24*time.Hour, time.Until(cert.NotAfter).Round(24*time.Hour))
+			},
+		},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/command/tls_ca_create_test.go
+++ b/command/tls_ca_create_test.go
@@ -46,6 +46,10 @@ func TestCACreateCommand(t *testing.T) {
 				"-name-constraint=true",
 				"-domain=foo",
 				"-additional-domain=bar",
+				"-common-name=CustomCA",
+				"-country=ZZ",
+				"-organization=CustOrg",
+				"-organizational-unit=CustOrgUnit",
 			},
 			"foo-agent-ca.pem",
 			"foo-agent-ca-key.pem",
@@ -54,6 +58,10 @@ func TestCACreateCommand(t *testing.T) {
 				require.True(t, cert.PermittedDNSDomainsCritical)
 				require.Len(t, cert.PermittedDNSDomains, 4)
 				require.ElementsMatch(t, cert.PermittedDNSDomains, []string{"nomad", "foo", "localhost", "bar"})
+				require.Equal(t, cert.Issuer.Organization, []string{"CustOrg"})
+				require.Equal(t, cert.Issuer.OrganizationalUnit, []string{"CustOrgUnit"})
+				require.Equal(t, cert.Issuer.Country, []string{"ZZ"})
+				require.Contains(t, cert.Issuer.CommonName, "CustomCA")
 			},
 		},
 	}

--- a/command/tls_ca_create_test.go
+++ b/command/tls_ca_create_test.go
@@ -6,7 +6,6 @@ package command
 import (
 	"crypto/x509"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -57,24 +56,6 @@ func TestCACreateCommand(t *testing.T) {
 				require.ElementsMatch(t, cert.PermittedDNSDomains, []string{"nomad", "foo", "localhost", "bar"})
 			},
 		},
-		{"with common-name",
-			[]string{
-				"-common-name=foo",
-			},
-			"nomad-agent-ca.pem",
-			"nomad-agent-ca-key.pem",
-			func(t *testing.T, cert *x509.Certificate) {
-				require.Equal(t, cert.Subject.CommonName, "foo")
-			},
-		},
-		{"without common-name",
-			[]string{},
-			"nomad-agent-ca.pem",
-			"nomad-agent-ca-key.pem",
-			func(t *testing.T, cert *x509.Certificate) {
-				require.True(t, strings.HasPrefix(cert.Subject.CommonName, "Nomad Agent CA"))
-			},
-		},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -97,5 +78,4 @@ func TestCACreateCommand(t *testing.T) {
 			require.NoError(t, os.Remove(tc.keyPath))
 		})
 	}
-
 }

--- a/helper/tlsutil/generate.go
+++ b/helper/tlsutil/generate.go
@@ -67,6 +67,13 @@ type CAOpts struct {
 	Days                int
 	PermittedDNSDomains []string
 	Domain              string
+	Country             string
+	PostalCode          string
+	Province            string
+	Locality            string
+	StreetAddress       string
+	Organization        string
+	OrganizationalUnit  string
 	Name                string
 }
 
@@ -106,6 +113,7 @@ func GenerateCA(opts CAOpts) (string, string, error) {
 			return "", "", err
 		}
 	}
+
 	name := opts.Name
 	if name == "" {
 		name = fmt.Sprintf("Nomad Agent CA %d", sn)
@@ -116,17 +124,53 @@ func GenerateCA(opts CAOpts) (string, string, error) {
 		days = 365
 	}
 
+	country := opts.Country
+	if country == "" {
+		country = ("US")
+	}
+
+	postalCode := opts.PostalCode
+	if postalCode == "" {
+		postalCode = ("94105")
+	}
+
+	province := opts.Province
+	if province == "" {
+		province = ("CA")
+	}
+
+	locality := opts.Locality
+	if locality == "" {
+		locality = ("San Francisco")
+	}
+
+	streetAddress := opts.StreetAddress
+	if streetAddress == "" {
+		streetAddress = ("101 Second Street")
+	}
+
+	organization := opts.Organization
+	if organization == "" {
+		organization = ("HashiCorp Inc.")
+	}
+
+	organizationalUnit := opts.OrganizationalUnit
+	if organizationalUnit == "" {
+		organizationalUnit = ("Nomad")
+	}
+
 	// Create the CA cert
 	template := x509.Certificate{
 		SerialNumber: sn,
 		Subject: pkix.Name{
-			Country:       []string{"US"},
-			PostalCode:    []string{"94105"},
-			Province:      []string{"CA"},
-			Locality:      []string{"San Francisco"},
-			StreetAddress: []string{"101 Second Street"},
-			Organization:  []string{"HashiCorp Inc."},
-			CommonName:    name,
+			Country:            []string{country},
+			PostalCode:         []string{postalCode},
+			Province:           []string{province},
+			Locality:           []string{locality},
+			StreetAddress:      []string{streetAddress},
+			Organization:       []string{organization},
+			OrganizationalUnit: []string{organizationalUnit},
+			CommonName:         name,
 		},
 		BasicConstraintsValid: true,
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,

--- a/helper/tlsutil/generate.go
+++ b/helper/tlsutil/generate.go
@@ -89,17 +89,18 @@ type CertOpts struct {
 	ExtKeyUsage []x509.ExtKeyUsage
 }
 
-// Check if any of CAOpts the variables are populated
-func AreCARequiredFieldsEmpty(caOpts CAOpts) bool {
-	return caOpts.Days == 0 &&
-		caOpts.Country == "" &&
-		caOpts.PostalCode == "" &&
-		caOpts.Province == "" &&
-		caOpts.Locality == "" &&
-		caOpts.StreetAddress == "" &&
-		caOpts.Organization == "" &&
-		caOpts.OrganizationalUnit == "" &&
-		caOpts.Name == ""
+// IsEmpty checks whether any of CAOpts parameters have been populated with
+// non-default values.
+func (c CAOpts) IsEmpty() bool {
+	return c.Days == 0 &&
+		c.Country == "" &&
+		c.PostalCode == "" &&
+		c.Province == "" &&
+		c.Locality == "" &&
+		c.StreetAddress == "" &&
+		c.Organization == "" &&
+		c.OrganizationalUnit == "" &&
+		c.Name == ""
 }
 
 // GenerateCA generates a new CA for agent TLS (not to be confused with Connect TLS)
@@ -112,9 +113,7 @@ func GenerateCA(opts CAOpts) (string, string, error) {
 		sn     = opts.Serial
 	)
 
-	// Check if opts required fields are empty
-	isEmpty := AreCARequiredFieldsEmpty(opts)
-	if isEmpty {
+	if opts.IsEmpty() {
 
 		if signer == nil {
 			var err error

--- a/helper/tlsutil/generate.go
+++ b/helper/tlsutil/generate.go
@@ -88,9 +88,9 @@ type CertOpts struct {
 	ExtKeyUsage []x509.ExtKeyUsage
 }
 
-// IsEmpty checks whether any of CAOpts parameters have been populated with
+// IsCustom checks whether any of CAOpts parameters have been populated with
 // non-default values.
-func (c CAOpts) IsEmpty() bool {
+func (c *CAOpts) IsCustom() bool {
 	return c.Country == "" &&
 		c.PostalCode == "" &&
 		c.Province == "" &&
@@ -131,18 +131,11 @@ func GenerateCA(opts CAOpts) (string, string, error) {
 		}
 	}
 
-	if opts.IsEmpty() && opts.Days == 0 {
+	if opts.IsCustom() {
 		opts.Name = fmt.Sprintf("Nomad Agent CA %d", sn)
-		opts.Days = 1825
-		opts.Country = "US"
-		opts.PostalCode = "94105"
-		opts.Province = "CA"
-		opts.Locality = "San Francisco"
-		opts.StreetAddress = "101 Second Street"
-		opts.Organization = "HashiCorp Inc."
-		opts.OrganizationalUnit = "Nomad"
-	} else if opts.IsEmpty() && opts.Days != 0 {
-		opts.Name = fmt.Sprintf("Nomad Agent CA %d", sn)
+		if opts.Days == 0 {
+			opts.Days = 1825
+		}
 		opts.Country = "US"
 		opts.PostalCode = "94105"
 		opts.Province = "CA"

--- a/helper/tlsutil/generate_test.go
+++ b/helper/tlsutil/generate_test.go
@@ -121,7 +121,6 @@ func TestGenerateCA(t *testing.T) {
 		ca, pk, err := GenerateCA(CAOpts{
 			Days:                6,
 			PermittedDNSDomains: []string{"domain1.com"},
-			Domain:              "custdomain.com",
 			Country:             "ZZ",
 			PostalCode:          "0000",
 			Province:            "CustProvince",
@@ -155,14 +154,25 @@ func TestGenerateCA(t *testing.T) {
 		require.Equal(t, x509.KeyUsageCertSign|x509.KeyUsageCRLSign|x509.KeyUsageDigitalSignature, cert.KeyUsage)
 	})
 
+	t.Run("Custom CA Custom Date", func(t *testing.T) {
+		ca, pk, err := GenerateCA(CAOpts{
+			Days: 365,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, ca)
+		require.NotEmpty(t, pk)
+
+		cert, err := parseCert(ca)
+		require.WithinDuration(t, cert.NotAfter, time.Now().AddDate(0, 0, 365), time.Minute)
+	})
+
 	t.Run("Custom CA No CN", func(t *testing.T) {
 		ca, pk, err := GenerateCA(CAOpts{
 			Days:                6,
 			PermittedDNSDomains: []string{"domain1.com"},
-			Domain:              "custdomain.com",
 			Locality:            "CustLocality",
 		})
-		require.ErrorContains(t, err, "-common-name")
+		require.ErrorContains(t, err, "common name value not provided")
 		require.Empty(t, ca)
 		require.Empty(t, pk)
 	})
@@ -171,11 +181,10 @@ func TestGenerateCA(t *testing.T) {
 		ca, pk, err := GenerateCA(CAOpts{
 			Days:                6,
 			PermittedDNSDomains: []string{"domain1.com"},
-			Domain:              "custdomain.com",
 			Name:                "Custom CA",
 			Locality:            "CustLocality",
 		})
-		require.ErrorContains(t, err, "-country")
+		require.ErrorContains(t, err, "country value not provided")
 		require.Empty(t, ca)
 		require.Empty(t, pk)
 	})
@@ -184,12 +193,11 @@ func TestGenerateCA(t *testing.T) {
 		ca, pk, err := GenerateCA(CAOpts{
 			Days:                6,
 			PermittedDNSDomains: []string{"domain1.com"},
-			Domain:              "custdomain.com",
 			Name:                "Custom CA",
 			Country:             "ZZ",
 			Locality:            "CustLocality",
 		})
-		require.ErrorContains(t, err, "-organization")
+		require.ErrorContains(t, err, "organization value not provided")
 		// require.NoError(t, err)
 		require.Empty(t, ca)
 		require.Empty(t, pk)
@@ -199,13 +207,12 @@ func TestGenerateCA(t *testing.T) {
 		ca, pk, err := GenerateCA(CAOpts{
 			Days:                6,
 			PermittedDNSDomains: []string{"domain1.com"},
-			Domain:              "custdomain.com",
 			Name:                "Custom CA",
 			Country:             "ZZ",
 			Locality:            "CustLocality",
 			Organization:        "CustOrg",
 		})
-		require.ErrorContains(t, err, "-organizational-unit")
+		require.ErrorContains(t, err, "organizational unit value not provided")
 		require.Empty(t, ca)
 		require.Empty(t, pk)
 	})

--- a/nomad/rpc_test.go
+++ b/nomad/rpc_test.go
@@ -1374,7 +1374,6 @@ func newTLSTestHelper(t *testing.T) tlsTestHelper {
 		Name:               "Nomad CA",
 		Country:            "ZZ",
 		Days:               5,
-		Domain:             "nomad",
 		Organization:       "CustOrgUnit",
 		OrganizationalUnit: "CustOrgUnit",
 	})

--- a/nomad/rpc_test.go
+++ b/nomad/rpc_test.go
@@ -1370,7 +1370,14 @@ func newTLSTestHelper(t *testing.T) tlsTestHelper {
 	}
 
 	// Generate CA certificate and write it to disk.
-	h.caPEM, h.pk, err = tlsutil.GenerateCA(tlsutil.CAOpts{Days: 5, Domain: "nomad"})
+	h.caPEM, h.pk, err = tlsutil.GenerateCA(tlsutil.CAOpts{
+		Name:               "Nomad CA",
+		Country:            "ZZ",
+		Days:               5,
+		Domain:             "nomad",
+		Organization:       "CustOrgUnit",
+		OrganizationalUnit: "CustOrgUnit",
+	})
 	must.NoError(t, err)
 
 	err = os.WriteFile(filepath.Join(h.dir, "ca.pem"), []byte(h.caPEM), 0600)

--- a/website/content/docs/commands/tls/ca-create.mdx
+++ b/website/content/docs/commands/tls/ca-create.mdx
@@ -24,13 +24,17 @@ nomad tls ca create [options]
   `-additional-domain`. Can be used multiple times. This option can only used in
   combination with `-domain` and `-name-constraint`.
 
-- `common-name`: Common Name of CA. Defaults to Nomad Agent CA.
+- `-common-name`: Common Name of CA. Defaults to Nomad Agent CA.
+
+- `-country`: Country of the CA. Defaults to "US".
 
 - `-days=<int>`: Provide number of days the CA is valid for from now on,
   defaults to 5 years.
 
 - `-domain=<string>`: Domain of nomad cluster. Only used in combination with
   `-name-constraint`. Defaults to `nomad`.
+
+- `-locality`: Locality of the CA. Defaults to "San Francisco".
 
 - `-name-constraint`: Add name constraints for the CA. Results in rejecting
   certificates for other DNS than specified. If set to true, "localhost" and
@@ -39,6 +43,16 @@ nomad tls ca create [options]
 ~> **Warning:** If `-name-constraint` is enabled and you intend to serve the
   Nomad web UI over HTTPS its DNS must be added with `additional-domain`. It is
   not possible to add that after the fact.
+
+- `-organization`: Organization of the CA. Defaults to "HashiCorp Inc.".
+
+- `-organizational-unit`: Organizational Unit of the CA. Defaults to "Nomad".
+
+- `-postal-code`: Postal Code of the CA. Defaults to "94105".
+
+- `-province`: Province of the CA. Defaults to "CA".
+
+- `-street-address`: Street Address of the CA. Defaults to "101 Second Street".
 
 ## Example
 


### PR DESCRIPTION
Allow operators to customise the CA created using `nomad tls ca create`