### PR TITLE
refact:  update models for relationship

### DIFF
--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -28,7 +28,7 @@ export default class Job extends Model {
   @attr('number') createIndex;
   @attr('number') modifyIndex;
   @attr('date') submitTime;
-  @attr('string') nodePool; // Jobs are related to Node Pools via Allocations, but no relationship.
+  @attr('string') nodePool; // Jobs are related to Node Pools either directly or via its Namespace, but no relationship.
 
   @fragment('structured-attributes') meta;
 

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -28,6 +28,7 @@ export default class Job extends Model {
   @attr('number') createIndex;
   @attr('number') modifyIndex;
   @attr('date') submitTime;
+  @attr('string') nodePool; // Jobs are related to Node Pools via Allocations, but no relationship.
 
   @fragment('structured-attributes') meta;
 

--- a/ui/app/models/node-pool.js
+++ b/ui/app/models/node-pool.js
@@ -4,7 +4,7 @@
  */
 
 import Model from '@ember-data/model';
-import { attr } from '@ember-data/model';
+import { attr, hasMany } from '@ember-data/model';
 import { computed } from '@ember/object';
 import classic from 'ember-classic-decorator';
 
@@ -14,6 +14,7 @@ export default class NodePool extends Model {
   @attr('string') description;
   @attr() meta;
   @attr() schedulerConfiguration;
+  @hasMany('node') nodes;
 
   @computed('schedulerConfiguration.SchedulerAlgorithm')
   get schedulerAlgorithm() {

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -7,7 +7,7 @@ import { computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
 import Model from '@ember-data/model';
 import { attr } from '@ember-data/model';
-import { hasMany } from '@ember-data/model';
+import { belongsTo, hasMany } from '@ember-data/model';
 import { fragment, fragmentArray } from 'ember-data-model-fragments/attributes';
 import RSVP from 'rsvp';
 import shortUUIDProperty from '../utils/properties/short-uuid';
@@ -55,6 +55,7 @@ export default class Node extends Model {
   }
 
   @hasMany('allocations', { inverse: 'node' }) allocations;
+  @belongsTo('node-pool') nodePool;
 
   @computed('allocations.@each.clientStatus')
   get completeAllocations() {

--- a/ui/mirage/factories/job.js
+++ b/ui/mirage/factories/job.js
@@ -214,6 +214,15 @@ export default Factory.extend({
       });
     }
 
+    if (!job.nodePool) {
+      const nodePool = server.db.nodePools.length
+        ? pickOne(server.db.nodePools).name
+        : server.create('node-pool').name;
+      job.update({
+        nodePool,
+      });
+    }
+
     const groupProps = {
       job,
       createAllocations: job.createAllocations,
@@ -368,6 +377,7 @@ export default Factory.extend({
         datacenters: job.datacenters,
         createAllocations: job.createAllocations,
         shallow: job.shallow,
+        noActiveDeployment: job.noActiveDeployment,
       });
     }
   },

--- a/ui/mirage/factories/node-pool.js
+++ b/ui/mirage/factories/node-pool.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  name: (i) => `node-pool-${i}`,
+  description: (i) => `describe node-pool-${i}`,
+  meta: {},
+  schedulerConfiguration: {},
+});

--- a/ui/mirage/factories/node.js
+++ b/ui/mirage/factories/node.js
@@ -12,21 +12,26 @@ import moment from 'moment';
 const UUIDS = provide(100, faker.random.uuid.bind(faker.random));
 const NODE_STATUSES = ['initializing', 'ready', 'down'];
 const NODE_CLASSES = provide(7, faker.company.bsBuzz.bind(faker.company));
-const NODE_VERSIONS = ['1.1.0-beta', '1.0.2-alpha+ent', ...provide(5, faker.system.semver)];
+const NODE_VERSIONS = [
+  '1.1.0-beta',
+  '1.0.2-alpha+ent',
+  ...provide(5, faker.system.semver),
+];
 const REF_DATE = new Date();
 
 export default Factory.extend({
-  id: i => (i / 100 >= 1 ? `${UUIDS[i]}-${i}` : UUIDS[i]),
-  name: i => `nomad@${HOSTS[i % HOSTS.length]}`,
+  id: (i) => (i / 100 >= 1 ? `${UUIDS[i]}-${i}` : UUIDS[i]),
+  name: (i) => `nomad@${HOSTS[i % HOSTS.length]}`,
 
   datacenter: () => faker.helpers.randomize(DATACENTERS),
   nodeClass: () => faker.helpers.randomize(NODE_CLASSES),
   drain: faker.random.boolean,
   status: () => faker.helpers.randomize(NODE_STATUSES),
   tlsEnabled: faker.random.boolean,
-  schedulingEligibility: () => (faker.random.boolean() ? 'eligible' : 'ineligible'),
+  schedulingEligibility: () =>
+    faker.random.boolean() ? 'eligible' : 'ineligible',
 
-  createIndex: i => i,
+  createIndex: (i) => i,
   modifyIndex: () => faker.random.number({ min: 10, max: 2000 }),
   version: () => faker.helpers.randomize(NODE_VERSIONS),
 
@@ -35,8 +40,8 @@ export default Factory.extend({
   },
 
   forceIPv4: trait({
-    name: i => {
-      const ipv4Hosts = HOSTS.filter(h => !h.startsWith('['));
+    name: (i) => {
+      const ipv4Hosts = HOSTS.filter((h) => !h.startsWith('['));
       return `nomad@${ipv4Hosts[i % ipv4Hosts.length]}`;
     },
   }),
@@ -45,8 +50,13 @@ export default Factory.extend({
     drain: true,
     schedulingEligibility: 'ineligible',
     drainStrategy: {
-      Deadline: faker.random.number({ min: 30 * 1000, max: 5 * 60 * 60 * 1000 }) * 1000000,
-      ForceDeadline: moment(REF_DATE).add(faker.random.number({ min: 1, max: 5 }), 'd'),
+      Deadline:
+        faker.random.number({ min: 30 * 1000, max: 5 * 60 * 60 * 1000 }) *
+        1000000,
+      ForceDeadline: moment(REF_DATE).add(
+        faker.random.number({ min: 1, max: 5 }),
+        'd'
+      ),
       IgnoreSystemJobs: faker.random.boolean(),
     },
   }),
@@ -135,9 +145,13 @@ export default Factory.extend({
       id: node.httpAddr,
     });
 
-    const events = server.createList('node-event', faker.random.number({ min: 1, max: 10 }), {
-      nodeId: node.id,
-    });
+    const events = server.createList(
+      'node-event',
+      faker.random.number({ min: 1, max: 10 }),
+      {
+        nodeId: node.id,
+      }
+    );
 
     node.update({
       eventIds: events.mapBy('id'),
@@ -146,11 +160,17 @@ export default Factory.extend({
     server.create('client-stat', {
       id: node.id,
     });
+
+    if (!node.nodePool) {
+      node.update({
+        nodePool: server.create('node-pool', { nodes: [node] }),
+      });
+    }
   },
 });
 
 function makeDrivers() {
-  const generate = name => {
+  const generate = (name) => {
     const detected = faker.random.number(10) >= 3;
     const healthy = detected && faker.random.number(10) >= 3;
     const attributes = {

--- a/ui/mirage/models/node-pool.js
+++ b/ui/mirage/models/node-pool.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { Model, hasMany } from 'ember-cli-mirage';
+
+export default Model.extend({
+  nodes: hasMany('node'),
+});

--- a/ui/mirage/models/node.js
+++ b/ui/mirage/models/node.js
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { Model, hasMany } from 'ember-cli-mirage';
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
   events: hasMany('node-event'),
+  nodePool: belongsTo('node-pool'),
 });

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -225,6 +225,7 @@ moduleForJob('Acceptance | job detail (periodic child)', 'allocations', () => {
   const parent = server.create('job', 'periodic', {
     childrenCount: 1,
     shallow: true,
+    noActiveDeployment: true,
   });
   return server.db.jobs.where({ parentId: parent.id })[0];
 });

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -73,6 +73,7 @@ module('Acceptance | job status panel', function (hooks) {
       datacenters: ['*'],
       type: 'service',
       createAllocations: true,
+      noActiveDeployment: true,
     });
 
     await visit(`/jobs/${job.id}?statusMode=historical`);

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -641,22 +641,28 @@ module('Acceptance | tokens', function (hooks) {
 
   test('Tokens Deletion', async function (assert) {
     allScenarios.policiesTestCluster(server);
+    const testPolicy = server.db.policies[0];
+    const existingTokens = server.db.tokens.filter((t) =>
+      t.policyIds.includes(testPolicy.name)
+    );
     // Create an expired token
     server.create('token', {
       name: 'Doomed Token',
       id: 'enjoying-my-day-here',
-      policyIds: [server.db.policies[0].name],
+      policyIds: [testPolicy.name],
     });
 
     window.localStorage.nomadTokenSecret = server.db.tokens[0].secretId;
     await visit('/policies');
 
     await click('[data-test-policy-row]:first-child');
-    assert.equal(currentURL(), `/policies/${server.db.policies[0].name}`);
-
+    assert.equal(currentURL(), `/policies/${testPolicy.name}`);
     assert
       .dom('[data-test-policy-token-row]')
-      .exists({ count: 3 }, 'Expected number of tokens are shown');
+      .exists(
+        { count: existingTokens.length + 1 },
+        'Expected number of tokens are shown'
+      );
 
     const doomedTokenRow = [...findAll('[data-test-policy-token-row]')].find(
       (a) => a.textContent.includes('Doomed Token')
@@ -672,32 +678,45 @@ module('Acceptance | tokens', function (hooks) {
     assert.dom('.flash-message.alert-success').exists();
     assert
       .dom('[data-test-policy-token-row]')
-      .exists({ count: 2 }, 'One fewer token after deletion');
+      .exists(
+        { count: existingTokens.length },
+        'One fewer token after deletion'
+      );
     await percySnapshot(assert);
     window.localStorage.nomadTokenSecret = null;
   });
 
   test('Test Token Creation', async function (assert) {
     allScenarios.policiesTestCluster(server);
+    const testPolicy = server.db.policies[0];
+    const existingTokens = server.db.tokens.filter((t) =>
+      t.policyIds.includes(testPolicy.name)
+    );
 
     window.localStorage.nomadTokenSecret = server.db.tokens[0].secretId;
     await visit('/policies');
 
     await click('[data-test-policy-row]:first-child');
-    assert.equal(currentURL(), `/policies/${server.db.policies[0].name}`);
+    assert.equal(currentURL(), `/policies/${testPolicy.name}`);
 
     assert
       .dom('[data-test-policy-token-row]')
-      .exists({ count: 2 }, 'Expected number of tokens are shown');
+      .exists(
+        { count: existingTokens.length },
+        'Expected number of tokens are shown'
+      );
 
     await click('[data-test-create-test-token]');
     assert.dom('.flash-message.alert-success').exists();
     assert
       .dom('[data-test-policy-token-row]')
-      .exists({ count: 3 }, 'One more token after test token creation');
+      .exists(
+        { count: existingTokens.length + 1 },
+        'One more token after test token creation'
+      );
     assert
       .dom('[data-test-policy-token-row]:last-child [data-test-token-name]')
-      .hasText(`Example Token for ${server.db.policies[0].name}`);
+      .hasText(`Example Token for ${testPolicy.name}`);
     await percySnapshot(assert);
     window.localStorage.nomadTokenSecret = null;
   });

--- a/ui/tests/unit/models/node-test.js
+++ b/ui/tests/unit/models/node-test.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | NodePool', function (hooks) {
+  setupTest(hooks);
+
+  test('a node pool can be associated with multiples nodes', function (assert) {
+    const store = this.owner.lookup('service:store');
+    this.subject = () => store.createRecord('node-pool');
+    const nodePool = this.subject();
+    const node1 = store.createRecord('node', { name: 'Node 1' });
+    const node2 = store.createRecord('node', { name: 'Node 2' });
+
+    nodePool.get('nodes').pushObject(node1);
+    nodePool.get('nodes').pushObject(node2);
+
+    const nodes = nodePool.get('nodes');
+
+    assert.equal(nodes.length, 2);
+    assert.ok(nodes.includes(node1));
+    assert.ok(nodes.includes(node2));
+  });
+});


### PR DESCRIPTION
Resolves #17293 

This PR adds a relationship between the Node and NodePool models. In addition, The Job model now has an @attr('string') property called nodePool.

The nodePool property on the Node model is used to store the name of the NodePool that the job is associated with. The nodes property on the NodePool model is used to store a list of the Job models that are associated with the NodePool.

This change was made to allow users to easily associate jobs with node pools. For example, a user could create a job and specify the name of the node pool that the job should be run on.

**Testing**
The changes in this PR have been tested using the following tests:

`ui/tests/unit/models/node-pool-test.js`

The tests have been written to ensure that the Node and NodePool models can be associated with each other correctly.

**Impact**
This change will have a minor impact on the codebase. The Node and NodePool models will now have a relationship with each other.

**Next Steps**
The next steps for this change are to seed the Mirage environments such that `node pools` are reflected. Once that is ready, we'll be ready to visualize the changes in the UI against both a Mirage scenario so that design can sign off and against the real API changes to smoke test the changes.