### PR TITLE
[ui] A few variables-ui-related bugfixes

### DIFF
--- a/.changelog/17319.txt
+++ b/.changelog/17319.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixed a handful of UX-related bugs during variable editing
+```

--- a/ui/app/components/variable-form.hbs
+++ b/ui/app/components/variable-form.hbs
@@ -148,6 +148,7 @@
             class="delete-row button is-danger is-inverted"
             type="button"
             {{on "click" (action this.deleteRow entry)}}
+            disabled={{eq this.keyValues.length 1}}
           >
             Delete
           </button>

--- a/ui/app/components/variable-form.hbs
+++ b/ui/app/components/variable-form.hbs
@@ -14,6 +14,17 @@
         Format: <code>nomad/jobs/&lt;jobname&gt;</code>, <code>nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;</code>, <code>nomad/jobs/&lt;jobname&gt;/&lt;groupname&gt;/&lt;taskname&gt;</code></p>
       </div>
     {{/unless}}
+
+    {{#if this.shouldShowLinkedEntities}}
+      <VariableForm::RelatedEntities
+        @new={{true}}
+        @job={{@model.pathLinkedEntities.job}}
+        @group={{@model.pathLinkedEntities.group}}
+        @task={{@model.pathLinkedEntities.task}}
+        @namespace={{this.variableNamespace}}
+      />
+    {{/if}}
+
   {{/if}}
 
   {{#if this.hasConflict}}
@@ -148,16 +159,6 @@
         </div>
       {{/each}}
     {{/if}}
-  {{/if}}
-
-  {{#if (and this.shouldShowLinkedEntities @model.isNew)}}
-    <VariableForm::RelatedEntities
-      @new={{true}}
-      @job={{@model.pathLinkedEntities.job}}
-      @group={{@model.pathLinkedEntities.group}}
-      @task={{@model.pathLinkedEntities.task}}
-      @namespace={{this.variableNamespace}}
-    />
   {{/if}}
 
   <footer>

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -140,7 +140,9 @@ export default class VariableFormComponent extends Component {
     let existingVariable = existingVariables
       .without(this.args.model)
       .find(
-        (v) => v.path === pathValue && v.namespace === this.variableNamespace
+        (v) =>
+          v.path === pathValue &&
+          (v.namespace === this.variableNamespace || !this.variableNamespace)
       );
     if (existingVariable) {
       return {
@@ -372,7 +374,8 @@ export default class VariableFormComponent extends Component {
     return (
       this.args.model.pathLinkedEntities?.job ||
       this.args.model.pathLinkedEntities?.group ||
-      this.args.model.pathLinkedEntities?.task
+      this.args.model.pathLinkedEntities?.task ||
+      trimPath([this.path]) === 'nomad/jobs'
     );
   }
 

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -182,7 +182,10 @@ export default class VariableFormComponent extends Component {
   }
 
   @action appendRow() {
-    this.keyValues.pushObject(copy(EMPTY_KV));
+    // Clear our any entity errors
+    let newRow = copy(EMPTY_KV);
+    newRow.warnings = EmberObject.create();
+    this.keyValues.pushObject(newRow);
   }
 
   @action deleteRow(row) {

--- a/ui/app/components/variable-form/related-entities.hbs
+++ b/ui/app/components/variable-form/related-entities.hbs
@@ -14,7 +14,7 @@
     {{else if @job}}
     job <LinkTo @route="jobs.job" @model={{concat @job "@" @namespace}}>{{@job}} <FlightIcon @name="external-link" /></LinkTo>
     {{else}}
-    all nomad jobs
+    all nomad jobs in this namespace
     {{/if}}
 </span>
 </p>

--- a/ui/app/components/variable-form/related-entities.hbs
+++ b/ui/app/components/variable-form/related-entities.hbs
@@ -12,7 +12,9 @@
     {{else if @group}}
     group <LinkTo @route="jobs.job.task-group" @models={{array (concat @job "@" @namespace) @group}}>{{@group}} <FlightIcon @name="external-link" /></LinkTo>
     {{else if @job}}
-    job <LinkTo @route="jobs.job" @model={{concat @job "@" @namespace}}>{{@job}} <FlightIcon @name="external-link" /></LinkTo><
+    job <LinkTo @route="jobs.job" @model={{concat @job "@" @namespace}}>{{@job}} <FlightIcon @name="external-link" /></LinkTo>
+    {{else}}
+    all nomad jobs
     {{/if}}
 </span>
 </p>

--- a/ui/app/controllers/variables/variable/index.js
+++ b/ui/app/controllers/variables/variable/index.js
@@ -82,7 +82,8 @@ export default class VariablesVariableIndexController extends Controller {
     return (
       this.model.pathLinkedEntities?.job ||
       this.model.pathLinkedEntities?.group ||
-      this.model.pathLinkedEntities?.task
+      this.model.pathLinkedEntities?.task ||
+      this.model.path === 'nomad/jobs'
     );
   }
 


### PR DESCRIPTION
- Adds a "this variable will be accessible by all jobs" notification if saving to exactly `nomad/jobs`
- moves said notification, on new variables, to the top of the form because otherwise it separated the "Add More" button and made it non-obviously connected
- fixed a bug where a no-namespaces cluster would result in no duplicate path warnings firing
- delete button is disabled for the only remaining KV in a variable when editing
- fixed a bug where you would add an illegal character, delete the KV row, add a new blank one, and the illegal character warning was still present.