### PR TITLE
Replace missing constructor in backported test

### DIFF
--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -4438,7 +4438,14 @@ func TestNode_constructNodeServerInfoResponse_MissingNode(t *testing.T) {
 	node := mock.Node()
 	var reply structs.NodeUpdateResponse
 
-	nE := NewNodeEndpoint(s, nil)
+	nE := &Node{
+		srv:     s,
+		ctx:     nil,
+		logger:  s.logger.Named("client"),
+		updates: []*structs.Allocation{},
+		evals:   []*structs.Evaluation{},
+	}
+
 	snap, err := s.State().Snapshot()
 	must.NoError(t, err)
 


### PR DESCRIPTION
PR 17322 introduced a test that depends on a constructor missing in 1.4.x. This converts the test to instantiate the struct directly.