### PR TITLE
check: Add support for Consul field tls_server_name

### DIFF
--- a/.changelog/17334.txt
+++ b/.changelog/17334.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+checks: Added support for Consul check field tls_server_name
+```

--- a/api/services.go
+++ b/api/services.go
@@ -212,6 +212,7 @@ type ServiceCheck struct {
 	Interval               time.Duration       `hcl:"interval,optional"`
 	Timeout                time.Duration       `hcl:"timeout,optional"`
 	InitialStatus          string              `mapstructure:"initial_status" hcl:"initial_status,optional"`
+	TLSServerName          string              `mapstructure:"tls_server_name" hcl:"tls_server_name,optional"`
 	TLSSkipVerify          bool                `mapstructure:"tls_skip_verify" hcl:"tls_skip_verify,optional"`
 	Header                 map[string][]string `hcl:"header,block"`
 	Method                 string              `hcl:"method,optional"`

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -1164,6 +1164,7 @@ func apiCheckRegistrationToCheck(r *api.AgentCheckRegistration) *api.AgentServic
 		Body:                   r.Body,
 		TCP:                    r.TCP,
 		Status:                 r.Status,
+		TLSServerName:          r.TLSServerName,
 		TLSSkipVerify:          r.TLSSkipVerify,
 		GRPC:                   r.GRPC,
 		GRPCUseTLS:             r.GRPCUseTLS,
@@ -1653,6 +1654,7 @@ func createCheckReg(serviceID, checkID string, check *structs.ServiceCheck, host
 		if check.TLSSkipVerify {
 			chkReg.TLSSkipVerify = true
 		}
+		chkReg.TLSServerName = check.TLSServerName
 		base := url.URL{
 			Scheme: proto,
 			Host:   net.JoinHostPort(host, strconv.Itoa(port)),
@@ -1681,6 +1683,7 @@ func createCheckReg(serviceID, checkID string, check *structs.ServiceCheck, host
 		if check.TLSSkipVerify {
 			chkReg.TLSSkipVerify = true
 		}
+		chkReg.TLSServerName = check.TLSServerName
 
 	default:
 		return nil, fmt.Errorf("check type %+q not valid", check.Type)

--- a/command/agent/consul/unit_test.go
+++ b/command/agent/consul/unit_test.go
@@ -972,6 +972,7 @@ func TestCreateCheckReg_GRPC(t *testing.T) {
 		PortLabel:     "label",
 		GRPCService:   "foo.Bar",
 		GRPCUseTLS:    true,
+		TLSServerName: "localhost",
 		TLSSkipVerify: true,
 		Timeout:       time.Second,
 		Interval:      time.Minute,
@@ -988,13 +989,14 @@ func TestCreateCheckReg_GRPC(t *testing.T) {
 		AgentServiceCheck: api.AgentServiceCheck{
 			Timeout:       "1s",
 			Interval:      "1m0s",
-			GRPC:          "localhost:8080/foo.Bar",
+			GRPC:          "127.0.0.1:8080/foo.Bar",
 			GRPCUseTLS:    true,
+			TLSServerName: "localhost",
 			TLSSkipVerify: true,
 		},
 	}
 
-	actual, err := createCheckReg(serviceID, checkID, check, "localhost", 8080, "default")
+	actual, err := createCheckReg(serviceID, checkID, check, "127.0.0.1", 8080, "default")
 	must.NoError(t, err)
 	must.Eq(t, expected, actual)
 }

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1482,6 +1482,7 @@ func ApiServicesToStructs(in []*api.Service, group bool) []*structs.Service {
 					Interval:               check.Interval,
 					Timeout:                check.Timeout,
 					InitialStatus:          check.InitialStatus,
+					TLSServerName:          check.TLSServerName,
 					TLSSkipVerify:          check.TLSSkipVerify,
 					Header:                 check.Header,
 					Method:                 check.Method,

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -3017,6 +3017,12 @@ func TestTaskGroupDiff(t *testing.T) {
 									},
 									{
 										Type: DiffTypeNone,
+										Name: "TLSServerName",
+										Old:  "",
+										New:  "",
+									},
+									{
+										Type: DiffTypeNone,
 										Name: "TLSSkipVerify",
 										Old:  "false",
 										New:  "false",
@@ -6554,6 +6560,12 @@ func TestTaskDiff(t *testing.T) {
 										Name: "SuccessBeforePassing",
 										Old:  "4",
 										New:  "4",
+									},
+									{
+										Type: DiffTypeNone,
+										Name: "TLSServerName",
+										Old:  "",
+										New:  "",
 									},
 									{
 										Type: DiffTypeNone,

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -383,6 +383,11 @@ func (sc *ServiceCheck) validateNomad() error {
 		return fmt.Errorf("failures_before_critical may only be set for Consul service checks")
 	}
 
+	// tls_server_name is consul only
+	if sc.TLSServerName != "" {
+		return fmt.Errorf("tls_server_name may only be set for Consul service checks")
+	}
+
 	return nil
 }
 
@@ -470,7 +475,7 @@ func (sc *ServiceCheck) Hash(serviceID string) string {
 	// use name "true" to maintain ID stability
 	hashBool(h, sc.TLSSkipVerify, "true")
 
-	// Only include TLSServerName if set.
+	// Only include TLSServerName if set to maintain ID stability with Nomad <1.6.0
 	hashStringIfNonEmpty(h, sc.TLSServerName)
 
 	// maintain artisanal map hashing to maintain ID stability

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -353,6 +353,17 @@ func TestServiceCheck_validateNomad(t *testing.T) {
 				Body:     "this is a request payload!",
 			},
 		},
+		{
+			name: "http with tls_server_name",
+			sc: &ServiceCheck{
+				Type:          ServiceCheckHTTP,
+				Interval:      3 * time.Second,
+				Timeout:       1 * time.Second,
+				Path:          "/health",
+				TLSServerName: "foo",
+			},
+			exp: `tls_server_name may only be set for Consul service checks`,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/ui/stories/components/diff-viewer.stories.js
+++ b/ui/stories/components/diff-viewer.stories.js
@@ -436,6 +436,13 @@ export let DiffViewerWithManyChanges = () => {
                           },
                           {
                             Annotations: null,
+                            Name: 'TLSServerName',
+                            New: '',
+                            Old: '',
+                            Type: 'None',
+                          },
+                          {
+                            Annotations: null,
                             Name: 'TLSSkipVerify',
                             New: 'false',
                             Old: 'false',

--- a/website/content/docs/job-specification/check.mdx
+++ b/website/content/docs/job-specification/check.mdx
@@ -157,8 +157,27 @@ job "example" {
   Nomad. For Consul service checks, valid options are `grpc`, `http`, `script`,
   and `tcp`. For Nomad service checks, valid options are `http` and `tcp`.
 
-- `tls_skip_verify` `(bool: false)` - Skip verifying TLS certificates for HTTPS
-  checks. Only supported in the Consul service provider.
+- `tls_server_name` `(string: "")` - Indicates the ServerName to use for SNI and
+  validation of the certificate presented by the server being checked, when
+  performing TLS enabled checks (`https`, `grpc` + `grpc_use_tls`). If left
+  unspecified, the ServerName will be inferred from the address of the server
+  being checked unless the address is an IP address. There are two common cases
+  where this is beneficial:
+
+    - When the check address is an IP, `tls_server_name` can be specified for
+      SNI. Note: setting tls_server_name will also override the hostname used to
+      verify the certificate presented by the server being checked.
+
+    - When the a hostname in the check address won't be present in the SAN
+      (Subject Alternative Name) field of the certificate presented by the
+      server being checked. Note: setting `tls_server_name` will also override
+      the hostname used for SNI.
+
+  This field is only supported in the Consul service provider. 
+
+- `tls_skip_verify` `(bool: false)` - Skip verification of certificates for
+  `https` and `grpc` + `grpc_use_tls` checks . Only supported in the Consul
+  service provider.
 
 - `on_update` `(string: "require_healthy")` - Specifies how checks should be
   evaluated when determining deployment health (including a job's initial

--- a/website/content/docs/job-specification/check.mdx
+++ b/website/content/docs/job-specification/check.mdx
@@ -81,6 +81,8 @@ job "example" {
 
 - `grpc_use_tls` `(bool: false)` - Use TLS to perform a gRPC health check. May
   be used with `tls_skip_verify` to use TLS but skip certificate verification.
+  May be used with `tls_server_name` to specify the ServerName to use for SNI
+  and validation of the certificate presented by the server being checked.
 
 - `initial_status` `(string: <enum>)` - Specifies the starting status of the
   service. Valid options are `passing`, `warning`, and `critical`. Omitting
@@ -159,24 +161,24 @@ job "example" {
 
 - `tls_server_name` `(string: "")` - Indicates the ServerName to use for SNI and
   validation of the certificate presented by the server being checked, when
-  performing TLS enabled checks (`https`, `grpc`, and `grpc_use_tls`). If left
+  performing TLS enabled checks (`https` and `grpc` with `grpc_use_tls`). If left
   unspecified, the ServerName will be inferred from the address of the server
   being checked unless the address is an IP address. There are two common cases
   where this is beneficial:
 
-    - When the check address is an IP, `tls_server_name` can be specified for
-      SNI. Note: setting `tls_server_name` will also override the hostname used to
-      verify the certificate presented by the server being checked.
+    - When the check address contains an IP, `tls_server_name` can be specified
+      for SNI. Note: setting `tls_server_name` will also override the hostname
+      used to verify the certificate presented by the server being checked.
 
-    - When the hostname in the check address won't be present in the SAN
-      (Subject Alternative Name) field of the certificate presented by the
+    - When the check address contains a hostname which isn't be present in the
+      SAN (Subject Alternative Name) field of the certificate presented by the
       server being checked. Note: setting `tls_server_name` will also override
       the hostname used for SNI.
 
   This field is only supported in the Consul service provider. 
 
 - `tls_skip_verify` `(bool: false)` - Skip verification of certificates for
-  `https` and `grpc` + `grpc_use_tls` checks . Only supported in the Consul
+  `https` and `grpc` with `grpc_use_tls` checks . Only supported in the Consul
   service provider.
 
 - `on_update` `(string: "require_healthy")` - Specifies how checks should be

--- a/website/content/docs/job-specification/check.mdx
+++ b/website/content/docs/job-specification/check.mdx
@@ -159,16 +159,16 @@ job "example" {
 
 - `tls_server_name` `(string: "")` - Indicates the ServerName to use for SNI and
   validation of the certificate presented by the server being checked, when
-  performing TLS enabled checks (`https`, `grpc` + `grpc_use_tls`). If left
+  performing TLS enabled checks (`https`, `grpc`, and `grpc_use_tls`). If left
   unspecified, the ServerName will be inferred from the address of the server
   being checked unless the address is an IP address. There are two common cases
   where this is beneficial:
 
     - When the check address is an IP, `tls_server_name` can be specified for
-      SNI. Note: setting tls_server_name will also override the hostname used to
+      SNI. Note: setting `tls_server_name` will also override the hostname used to
       verify the certificate presented by the server being checked.
 
-    - When the a hostname in the check address won't be present in the SAN
+    - When the hostname in the check address won't be present in the SAN
       (Subject Alternative Name) field of the certificate presented by the
       server being checked. Note: setting `tls_server_name` will also override
       the hostname used for SNI.


### PR DESCRIPTION
### Description

The `tls_server_name` field was added to Consul in hashicorp/consul#9475. This PR adds support for the same field in Nomad `service -> check` stanzas.

### Motivation

There are two common situations where specifying this field can be beneficial:

1. When the check address is an IP, `tls_server_name` can be specified for SNI. Note: setting `tls_server_name` will also override the hostname used to verify the certificate presented by the server being checked.

2. When the hostname in the check address won't be present in the SAN (Subject Alternative Name) field of the certificate presented by the server being checked. Note: setting `tls_server_name` will also override the hostname used for SNI.

The latter of these is especially important given that today you would have to specify `tls_skip_verify` which omits TLS verification altogether, a choice which is generally unsuitable for production.

### Changes

- Add support for Consul health check field `tls_server_name` to `service -> check` stanzas.
- Add documentation to support this field.
- Fix up documentation for:
  - `tls_skip_verify` to indicate support for `https` and `grpc` with `grpc_use_tls` checks and
  - `grpc_use_tls` to indicate that `tls_server_name` can be combined with this field.

### Links

- [Related Consul PR](https://github.com/hashicorp/consul/pull/17481): includes an explanation of how this field is implemented inside of Consul, offers a slight tweak to what Consul should do when it's left unspecified, and updates their documentation similar to the docs updates in this PR.

Fixes #2166