### PR TITLE
deploymentwatcher: fail early whenever possible

### DIFF
--- a/.changelog/17341.txt
+++ b/.changelog/17341.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+deploymentwatcher: Allow deployments to fail early when running out of reschedule attempts
+```

--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -702,7 +702,7 @@ func (w *deploymentWatcher) shouldFailEarly(deployment *structs.Deployment, allo
 
 	// Fail on the first unhealthy allocation if no progress deadline is specified.
 	if dstate.ProgressDeadline == 0 {
-		w.logger.Debug("failing deployment because an allocation failed and the deployment is not progress based", alloc.ID)
+		w.logger.Debug("failing deployment because an allocation failed and the deployment is not progress based", "alloc", alloc.ID)
 		return true
 	}
 
@@ -712,7 +712,7 @@ func (w *deploymentWatcher) shouldFailEarly(deployment *structs.Deployment, allo
 		if !isRescheduleEligible {
 			// We have run out of reschedule attempts: do not wait for the progress deadline to expire because
 			// we know that we will not be able to try to get another allocation healthy
-			w.logger.Debug("failing deployment because an allocation has failed and the task group has run out of reschedule attempts", alloc.ID)
+			w.logger.Debug("failing deployment because an allocation has failed and the task group has run out of reschedule attempts", "alloc", alloc.ID)
 			return true
 		}
 	}

--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -700,10 +700,8 @@ func (w *deploymentWatcher) shouldFailEarly(deployment *structs.Deployment, allo
 		return false
 	}
 
-	hasProgressDeadline := dstate.ProgressDeadline != 0
-
 	// Fail on the first unhealthy allocation if no progress deadline is specified.
-	if !hasProgressDeadline {
+	if dstate.ProgressDeadline == 0 {
 		w.logger.Debug("failing deployment because an allocation failed and the deployment is not progress based", alloc.ID)
 		return true
 	}

--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -615,30 +615,12 @@ func (w *deploymentWatcher) handleAllocUpdate(allocs []*structs.AllocListStub) (
 			continue
 		}
 
-		hasProgressDeadline := dstate.ProgressDeadline != 0
-		failDeployment := false
-
-		// Fail on the first unhealthy allocation if no progress deadline is specified.
-		if !hasProgressDeadline && alloc.DeploymentStatus.IsUnhealthy() {
-			w.logger.Debug("failing deployment because an allocation failed and the deployment is not progress based", alloc.ID)
-			failDeployment = true
-		}
-
-		if hasProgressDeadline && alloc.DeploymentStatus.IsUnhealthy() &&
-			deployment.Active() {
-			reschedulePolicy := w.j.LookupTaskGroup(alloc.TaskGroup).ReschedulePolicy
-			isRescheduleEligible := alloc.RescheduleEligible(reschedulePolicy, time.Unix(alloc.ModifyTime, 0))
-			if !isRescheduleEligible {
-				// We have run out of reschedule attempts: do not wait for the progress deadline to expire because
-				// we can fail early
-				w.logger.Debug("failing deployment because an allocation has failed and the task group has run out of reschedule attempts", alloc.ID)
-				failDeployment = true
-			}
-		}
+		// Check if we can already fail the deployment
+		failDeployment := w.shouldFailEarly(deployment, alloc, dstate)
 
 		// Check if the allocation has failed and we need to mark it for allow
 		// replacements
-		if !failDeployment && alloc.DeploymentStatus.IsUnhealthy() &&
+		if alloc.DeploymentStatus.IsUnhealthy() && !failDeployment &&
 			deployment.Active() && !alloc.DesiredTransition.ShouldReschedule() {
 			res.allowReplacements = append(res.allowReplacements, alloc.ID)
 			continue
@@ -711,6 +693,33 @@ func (w *deploymentWatcher) shouldFail() (fail, rollback bool, err error) {
 	}
 
 	return fail, false, nil
+}
+
+func (w *deploymentWatcher) shouldFailEarly(deployment *structs.Deployment, alloc *structs.AllocListStub, dstate *structs.DeploymentState) bool {
+	if !alloc.DeploymentStatus.IsUnhealthy() {
+		return false
+	}
+
+	hasProgressDeadline := dstate.ProgressDeadline != 0
+
+	// Fail on the first unhealthy allocation if no progress deadline is specified.
+	if !hasProgressDeadline {
+		w.logger.Debug("failing deployment because an allocation failed and the deployment is not progress based", alloc.ID)
+		return true
+	}
+
+	if deployment.Active() {
+		reschedulePolicy := w.j.LookupTaskGroup(alloc.TaskGroup).ReschedulePolicy
+		isRescheduleEligible := alloc.RescheduleEligible(reschedulePolicy, time.Now())
+		if !isRescheduleEligible {
+			// We have run out of reschedule attempts: do not wait for the progress deadline to expire because
+			// we know that we will not be able to try to get another allocation healthy
+			w.logger.Debug("failing deployment because an allocation has failed and the task group has run out of reschedule attempts", alloc.ID)
+			return true
+		}
+	}
+
+	return false
 }
 
 // getDeploymentProgressCutoff returns the progress cutoff for the given

--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
 	mocker "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -1787,86 +1788,85 @@ func TestDeploymentWatcher_Watch_StartWithoutProgressDeadline(t *testing.T) {
 // Test that we exit before hitting the Progress Deadline when we run out of reschedule attempts
 // for a failing deployment
 func TestDeploymentWatcher_Watch_FailEarly(t *testing.T) {
-       ci.Parallel(t)
-       require := require.New(t)
-       w, m := testDeploymentWatcher(t, 1000.0, 1*time.Millisecond)
+	ci.Parallel(t)
+	w, m := testDeploymentWatcher(t, 1000.0, 1*time.Millisecond)
 
-       // Create a job, alloc, and a deployment
-       j := mock.Job()
-       j.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
-       j.TaskGroups[0].Update.MaxParallel = 2
-       j.TaskGroups[0].Update.ProgressDeadline = 500 * time.Millisecond
-       // Allow only 1 allocation for that deployment
-        j.TaskGroups[0].ReschedulePolicy.Attempts = 0
-        j.TaskGroups[0].ReschedulePolicy.Unlimited = false
-       j.Stable = true
-       d := mock.Deployment()
-       d.JobID = j.ID
-       d.TaskGroups["web"].ProgressDeadline = 500 * time.Millisecond
-       d.TaskGroups["web"].RequireProgressBy = time.Now().Add(d.TaskGroups["web"].ProgressDeadline)
-       a := mock.Alloc()
-       now := time.Now()
-       a.CreateTime = now.UnixNano()
-       a.ModifyTime = now.UnixNano()
-       a.DeploymentID = d.ID
-       require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
-       require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
-       require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
+	// Create a job, alloc, and a deployment
+	j := mock.Job()
+	j.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
+	j.TaskGroups[0].Update.MaxParallel = 2
+	j.TaskGroups[0].Update.ProgressDeadline = 500 * time.Millisecond
+	// Allow only 1 allocation for that deployment
+	j.TaskGroups[0].ReschedulePolicy.Attempts = 0
+	j.TaskGroups[0].ReschedulePolicy.Unlimited = false
+	j.Stable = true
+	d := mock.Deployment()
+	d.JobID = j.ID
+	d.TaskGroups["web"].ProgressDeadline = 500 * time.Millisecond
+	d.TaskGroups["web"].RequireProgressBy = time.Now().Add(d.TaskGroups["web"].ProgressDeadline)
+	a := mock.Alloc()
+	now := time.Now()
+	a.CreateTime = now.UnixNano()
+	a.ModifyTime = now.UnixNano()
+	a.DeploymentID = d.ID
+	must.Nil(t, m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), must.Sprint("UpsertJob"))
+	must.Nil(t, m.state.UpsertDeployment(m.nextIndex(), d), must.Sprint("UpsertDeployment"))
+	must.Nil(t, m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), must.Sprint("UpsertAllocs"))
 
-       // require that we get a call to UpsertDeploymentStatusUpdate
-       c := &matchDeploymentStatusUpdateConfig{
-               DeploymentID:      d.ID,
-               Status:            structs.DeploymentStatusFailed,
-               StatusDescription: structs.DeploymentStatusDescriptionFailedAllocations,
-               Eval:              true,
-       }
-       m2 := matchDeploymentStatusUpdateRequest(c)
-       m.On("UpdateDeploymentStatus", mocker.MatchedBy(m2)).Return(nil)
+	// require that we get a call to UpsertDeploymentStatusUpdate
+	c := &matchDeploymentStatusUpdateConfig{
+		DeploymentID:      d.ID,
+		Status:            structs.DeploymentStatusFailed,
+		StatusDescription: structs.DeploymentStatusDescriptionFailedAllocations,
+		Eval:              true,
+	}
+	m2 := matchDeploymentStatusUpdateRequest(c)
+	m.On("UpdateDeploymentStatus", mocker.MatchedBy(m2)).Return(nil)
 
-       w.SetEnabled(true, m.state)
-       testutil.WaitForResult(func() (bool, error) { return 1 == watchersCount(w), nil },
-               func(err error) { require.Equal(1, watchersCount(w), "Should have 1 deployment") })
+	w.SetEnabled(true, m.state)
+	testutil.WaitForResult(func() (bool, error) { return 1 == watchersCount(w), nil },
+		func(err error) { must.Eq(t, 1, watchersCount(w), must.Sprint("Should have 1 deployment")) })
 
-       // Update the alloc to be unhealthy
-       a2 := a.Copy()
-       a2.DeploymentStatus = &structs.AllocDeploymentStatus{
-               Healthy:   pointer.Of(false),
-               Timestamp: now,
-       }
-       require.Nil(m.state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a2}))
+	// Update the alloc to be unhealthy
+	a2 := a.Copy()
+	a2.DeploymentStatus = &structs.AllocDeploymentStatus{
+		Healthy:   pointer.Of(false),
+		Timestamp: now,
+	}
+	must.Nil(t, m.state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a2}))
 
-       // Wait for the deployment to be failed
-       testutil.WaitForResult(func() (bool, error) {
-               d, err := m.state.DeploymentByID(nil, d.ID)
-               if err != nil {
-                       return false, err
-               }
+	// Wait for the deployment to be failed
+	testutil.WaitForResult(func() (bool, error) {
+		d, err := m.state.DeploymentByID(nil, d.ID)
+		if err != nil {
+			return false, err
+		}
 
-               if d.Status != structs.DeploymentStatusFailed {
-                       return false, fmt.Errorf("bad status %q", d.Status)
-               }
+		if d.Status != structs.DeploymentStatusFailed {
+			return false, fmt.Errorf("bad status %q", d.Status)
+		}
 
-               return d.StatusDescription == structs.DeploymentStatusDescriptionFailedAllocations, fmt.Errorf("bad status description %q", d.StatusDescription)
-       }, func(err error) {
-               t.Fatal(err)
-       })
+		return d.StatusDescription == structs.DeploymentStatusDescriptionFailedAllocations, fmt.Errorf("bad status description %q", d.StatusDescription)
+	}, func(err error) {
+		t.Fatal(err)
+	})
 
-       // require there are is only one evaluation
-       testutil.WaitForResult(func() (bool, error) {
-               ws := memdb.NewWatchSet()
-               evals, err := m.state.EvalsByJob(ws, j.Namespace, j.ID)
-               if err != nil {
-                       return false, err
-               }
+	// require there are is only one evaluation
+	testutil.WaitForResult(func() (bool, error) {
+		ws := memdb.NewWatchSet()
+		evals, err := m.state.EvalsByJob(ws, j.Namespace, j.ID)
+		if err != nil {
+			return false, err
+		}
 
-               if l := len(evals); l != 1 {
-                       return false, fmt.Errorf("Got %d evals; want 1", l)
-               }
+		if l := len(evals); l != 1 {
+			return false, fmt.Errorf("Got %d evals; want 1", l)
+		}
 
-               return true, nil
-       }, func(err error) {
-               t.Fatal(err)
-       })
+		return true, nil
+	}, func(err error) {
+		t.Fatal(err)
+	})
 }
 
 // Tests that the watcher fails rollback when the spec hasn't changed

--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -1784,6 +1784,91 @@ func TestDeploymentWatcher_Watch_StartWithoutProgressDeadline(t *testing.T) {
 	})
 }
 
+// Test that we exit before hitting the Progress Deadline when we run out of reschedule attempts
+// for a failing deployment
+func TestDeploymentWatcher_Watch_FailEarly(t *testing.T) {
+       ci.Parallel(t)
+       require := require.New(t)
+       w, m := testDeploymentWatcher(t, 1000.0, 1*time.Millisecond)
+
+       // Create a job, alloc, and a deployment
+       j := mock.Job()
+       j.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
+       j.TaskGroups[0].Update.MaxParallel = 2
+       j.TaskGroups[0].Update.ProgressDeadline = 500 * time.Millisecond
+       // Allow only 1 allocation for that deployment
+        j.TaskGroups[0].ReschedulePolicy.Attempts = 0
+        j.TaskGroups[0].ReschedulePolicy.Unlimited = false
+       j.Stable = true
+       d := mock.Deployment()
+       d.JobID = j.ID
+       d.TaskGroups["web"].ProgressDeadline = 500 * time.Millisecond
+       d.TaskGroups["web"].RequireProgressBy = time.Now().Add(d.TaskGroups["web"].ProgressDeadline)
+       a := mock.Alloc()
+       now := time.Now()
+       a.CreateTime = now.UnixNano()
+       a.ModifyTime = now.UnixNano()
+       a.DeploymentID = d.ID
+       require.Nil(m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j), "UpsertJob")
+       require.Nil(m.state.UpsertDeployment(m.nextIndex(), d), "UpsertDeployment")
+       require.Nil(m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}), "UpsertAllocs")
+
+       // require that we get a call to UpsertDeploymentStatusUpdate
+       c := &matchDeploymentStatusUpdateConfig{
+               DeploymentID:      d.ID,
+               Status:            structs.DeploymentStatusFailed,
+               StatusDescription: structs.DeploymentStatusDescriptionFailedAllocations,
+               Eval:              true,
+       }
+       m2 := matchDeploymentStatusUpdateRequest(c)
+       m.On("UpdateDeploymentStatus", mocker.MatchedBy(m2)).Return(nil)
+
+       w.SetEnabled(true, m.state)
+       testutil.WaitForResult(func() (bool, error) { return 1 == watchersCount(w), nil },
+               func(err error) { require.Equal(1, watchersCount(w), "Should have 1 deployment") })
+
+       // Update the alloc to be unhealthy
+       a2 := a.Copy()
+       a2.DeploymentStatus = &structs.AllocDeploymentStatus{
+               Healthy:   pointer.Of(false),
+               Timestamp: now,
+       }
+       require.Nil(m.state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a2}))
+
+       // Wait for the deployment to be failed
+       testutil.WaitForResult(func() (bool, error) {
+               d, err := m.state.DeploymentByID(nil, d.ID)
+               if err != nil {
+                       return false, err
+               }
+
+               if d.Status != structs.DeploymentStatusFailed {
+                       return false, fmt.Errorf("bad status %q", d.Status)
+               }
+
+               return d.StatusDescription == structs.DeploymentStatusDescriptionFailedAllocations, fmt.Errorf("bad status description %q", d.StatusDescription)
+       }, func(err error) {
+               t.Fatal(err)
+       })
+
+       // require there are is only one evaluation
+       testutil.WaitForResult(func() (bool, error) {
+               ws := memdb.NewWatchSet()
+               evals, err := m.state.EvalsByJob(ws, j.Namespace, j.ID)
+               if err != nil {
+                       return false, err
+               }
+
+               if l := len(evals); l != 1 {
+                       return false, fmt.Errorf("Got %d evals; want 1", l)
+               }
+
+               return true, nil
+       }, func(err error) {
+               t.Fatal(err)
+       })
+}
+
 // Tests that the watcher fails rollback when the spec hasn't changed
 func TestDeploymentWatcher_RollbackFailed(t *testing.T) {
 	ci.Parallel(t)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10090,8 +10090,6 @@ func (rt *RescheduleTracker) Copy() *RescheduleTracker {
 	return nt
 }
 
-// RescheduleEligible returns if an allocation is eligible to be rescheduled according
-// to its ReschedulePolicy and the current state of its reschedule trackers
 func (rt *RescheduleTracker) RescheduleEligible(reschedulePolicy *ReschedulePolicy, failTime time.Time) bool {
 	if reschedulePolicy == nil {
 		return false
@@ -10105,7 +10103,7 @@ func (rt *RescheduleTracker) RescheduleEligible(reschedulePolicy *ReschedulePoli
 		return true
 	}
 	// Early return true if there are no attempts yet and the number of allowed attempts is > 0
-	if len(rt.Events) == 0 && attempts > 0 {
+	if (rt == nil || len(rt.Events) == 0) && attempts > 0 {
 		return true
 	}
 	attempted, _ := rt.rescheduleInfo(reschedulePolicy, failTime)
@@ -10120,7 +10118,7 @@ func (rt *RescheduleTracker) rescheduleInfo(reschedulePolicy *ReschedulePolicy, 
 	interval := reschedulePolicy.Interval
 
 	attempted := 0
-	if attempts > 0 {
+	if rt != nil && attempts > 0 {
 		for j := len(rt.Events) - 1; j >= 0; j-- {
 			lastAttempt := rt.Events[j].RescheduleTime
 			timeDiff := failTime.UTC().UnixNano() - lastAttempt
@@ -10566,42 +10564,10 @@ func (a *Allocation) ShouldReschedule(reschedulePolicy *ReschedulePolicy, failTi
 // RescheduleEligible returns if the allocation is eligible to be rescheduled according
 // to its ReschedulePolicy and the current state of its reschedule trackers
 func (a *Allocation) RescheduleEligible(reschedulePolicy *ReschedulePolicy, failTime time.Time) bool {
-	if reschedulePolicy == nil {
-		return false
-	}
-
-	if a.RescheduleTracker == nil {
-		return reschedulePolicy.Attempts > 0
-	}
-
 	return a.RescheduleTracker.RescheduleEligible(reschedulePolicy, failTime)
 }
 
-func (a *Allocation) rescheduleInfo(reschedulePolicy *ReschedulePolicy, failTime time.Time) (int, int) {
-	if reschedulePolicy == nil {
-		return 0, 0
-	}
-	attempts := reschedulePolicy.Attempts
-	interval := reschedulePolicy.Interval
-
-	attempted := 0
-	if a.RescheduleTracker != nil && attempts > 0 {
-		for j := len(a.RescheduleTracker.Events) - 1; j >= 0; j-- {
-			lastAttempt := a.RescheduleTracker.Events[j].RescheduleTime
-			timeDiff := failTime.UTC().UnixNano() - lastAttempt
-			if timeDiff < interval.Nanoseconds() {
-				attempted += 1
-			}
-		}
-	}
-	return attempted, attempts
-}
-
 func (a *Allocation) RescheduleInfo() (int, int) {
-	if a.RescheduleTracker == nil {
-		return 0, 0
-	}
-
 	return a.RescheduleTracker.rescheduleInfo(a.ReschedulePolicy(), a.LastEventTime())
 }
 
@@ -10660,7 +10626,7 @@ func (a *Allocation) nextRescheduleTime(failTime time.Time, reschedulePolicy *Re
 	rescheduleEligible := reschedulePolicy.Unlimited || (reschedulePolicy.Attempts > 0 && a.RescheduleTracker == nil)
 	if reschedulePolicy.Attempts > 0 && a.RescheduleTracker != nil && a.RescheduleTracker.Events != nil {
 		// Check for eligibility based on the interval if max attempts is set
-		attempted, attempts := a.rescheduleInfo(reschedulePolicy, failTime)
+		attempted, attempts := a.RescheduleTracker.rescheduleInfo(reschedulePolicy, failTime)
 		rescheduleEligible = attempted < attempts && nextDelay < reschedulePolicy.Interval
 	}
 	return nextRescheduleTime, rescheduleEligible
@@ -11131,25 +11097,17 @@ type AllocListStub struct {
 	ModifyTime            int64
 }
 
-// RescheduleEligible returns if the allocation is eligible to be rescheduled according
-// to its ReschedulePolicy and the current state of its reschedule trackers
-func (a *AllocListStub) RescheduleEligible(reschedulePolicy *ReschedulePolicy, failTime time.Time) bool {
-	if reschedulePolicy == nil {
-		return false
-	}
-
-	if a.RescheduleTracker == nil {
-		return reschedulePolicy.Attempts > 0
-	}
-
-	return a.RescheduleTracker.RescheduleEligible(reschedulePolicy, failTime)
-}
-
 // SetEventDisplayMessages populates the display message if its not already
 // set, a temporary fix to handle old allocations that don't have it. This
 // method will be removed in a future release.
 func (a *AllocListStub) SetEventDisplayMessages() {
 	setDisplayMsg(a.TaskStates)
+}
+
+// RescheduleEligible returns if the allocation is eligible to be rescheduled according
+// to its ReschedulePolicy and the current state of its reschedule trackers
+func (a *AllocListStub) RescheduleEligible(reschedulePolicy *ReschedulePolicy, failTime time.Time) bool {
+	return a.RescheduleTracker.RescheduleEligible(reschedulePolicy, failTime)
 }
 
 func setDisplayMsg(taskStates map[string]*TaskState) {


### PR DESCRIPTION
Given a deployment that has a progress_deadline, if a task group runs out of reschedule attempts, allow it to fail at this time instead of waiting until the progress_deadline is reached.

See #17260