### PR TITLE
core: fix kill_timeout validation when progress_deadline is 0

### DIFF
--- a/.changelog/17342.txt
+++ b/.changelog/17342.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: fixed a bug that caused job validation to fail when a task with `kill_timeout` was placed inside a group with `update.progress_deadline` set to 0
+```

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6831,7 +6831,7 @@ func (tg *TaskGroup) Validate(j *Job) error {
 
 		// Validate the group's Update Strategy does not conflict with the Task's kill_timeout for service type jobs
 		if isTypeService && tg.Update != nil {
-			// progress_deadline = 0 has a special meaning show it should not
+			// progress_deadline = 0 has a special meaning so it should not be
 			// validated against the task's kill_timeout.
 			if tg.Update.ProgressDeadline > 0 && task.KillTimeout > tg.Update.ProgressDeadline {
 				mErr.Errors = append(mErr.Errors, fmt.Errorf("Task %s has a kill timout (%s) longer than the group's progress deadline (%s)",

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6831,12 +6831,13 @@ func (tg *TaskGroup) Validate(j *Job) error {
 
 		// Validate the group's Update Strategy does not conflict with the Task's kill_timeout for service type jobs
 		if isTypeService && tg.Update != nil {
-			if task.KillTimeout > tg.Update.ProgressDeadline {
+			// progress_deadline = 0 has a special meaning show it should not
+			// validated against the task's kill_timeout.
+			if tg.Update.ProgressDeadline > 0 && task.KillTimeout > tg.Update.ProgressDeadline {
 				mErr.Errors = append(mErr.Errors, fmt.Errorf("Task %s has a kill timout (%s) longer than the group's progress deadline (%s)",
 					task.Name, task.KillTimeout.String(), tg.Update.ProgressDeadline.String()))
 			}
 		}
-
 	}
 
 	return mErr.ErrorOrNil()

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1426,6 +1426,39 @@ func TestTaskGroup_Validate(t *testing.T) {
 			jobType: JobTypeService,
 		},
 		{
+			name: "progress_deadline 0 does not conflict with kill_timeout",
+			tg: &TaskGroup{
+				Name:  "web",
+				Count: 1,
+				Tasks: []*Task{
+					{
+						Name:        "web",
+						Driver:      "mock_driver",
+						Leader:      true,
+						KillTimeout: DefaultUpdateStrategy.ProgressDeadline + 25*time.Minute,
+						Resources:   DefaultResources(),
+						LogConfig:   DefaultLogConfig(),
+					},
+				},
+				Update: &UpdateStrategy{
+					Stagger:          30 * time.Second,
+					MaxParallel:      1,
+					HealthCheck:      UpdateStrategyHealthCheck_Checks,
+					MinHealthyTime:   10 * time.Second,
+					HealthyDeadline:  5 * time.Minute,
+					ProgressDeadline: 0,
+					AutoRevert:       false,
+					AutoPromote:      false,
+					Canary:           0,
+				},
+				RestartPolicy:    NewRestartPolicy(JobTypeService),
+				ReschedulePolicy: NewReschedulePolicy(JobTypeService),
+				Migrate:          DefaultMigrateStrategy(),
+				EphemeralDisk:    DefaultEphemeralDisk(),
+			},
+			jobType: JobTypeService,
+		},
+		{
 			name: "service and task using different provider",
 			tg: &TaskGroup{
 				Name: "group-a",
@@ -1460,7 +1493,11 @@ func TestTaskGroup_Validate(t *testing.T) {
 			j.Type = tc.jobType
 
 			err := tc.tg.Validate(j)
-			requireErrors(t, err, tc.expErr...)
+			if len(tc.expErr) > 0 {
+				requireErrors(t, err, tc.expErr...)
+			} else {
+				must.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes the validation for `kill_timeout` when `progress_deadline` is set to 0, which is a special case that should not be validated.

Closes #17335