### PR TITLE
Observe newlines when displaying variables

### DIFF
--- a/.changelog/17343.txt
+++ b/.changelog/17343.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: preserve newlines when displaying shown variables in non-json mode
+```

--- a/ui/app/styles/components/variables.scss
+++ b/ui/app/styles/components/variables.scss
@@ -201,6 +201,9 @@ table.variable-items {
       display: grid;
       grid-template-columns: auto auto 1fr;
       gap: 0.5rem;
+      & > code {
+        white-space: pre-wrap;
+      }
     }
   }
 }


### PR DESCRIPTION
Resolves #17183 

pre-wrap-formatting will honour newline characters and still attempt to wrap at the appropriate point (in case of a particularly long variable with spaces, etc.)

![image](https://github.com/hashicorp/nomad/assets/713991/d9d642aa-2203-468c-b8cc-920892ed129b)
![image](https://github.com/hashicorp/nomad/assets/713991/f4c3a397-934d-42cf-9536-8b614d8d7d21)
