### PR TITLE
[ui] Text type to password type input on profile sign-in page

### DIFF
--- a/.changelog/17345.txt
+++ b/.changelog/17345.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: change token input type from text to password
+```

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -112,7 +112,7 @@
             <Input
               id="token-input"
               class="input"
-              @type="text"
+              @type="password"
               placeholder="{{if this.hasJWTAuthMethods "36-character token secret or JWT" "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"}}"
               {{autofocus}}
               {{on "input" (action (mut this.secret) value="target.value")}}


### PR DESCRIPTION
Resolves #16901

Changes ACL Token/JWT input field to be of type "password", enabling password managers and triggering browsers to store it sensitively.

I considered adding a "show token" button but opted against it for keeping overhead low.