### PR TITLE
cli: fix panic on job restart

### DIFF
--- a/.changelog/17346.txt
+++ b/.changelog/17346.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix a panic in the `nomad job restart` command when monitoring replacement allocations
+```

--- a/command/job_restart.go
+++ b/command/job_restart.go
@@ -1045,7 +1045,7 @@ func (c *JobRestartCommand) monitorReplacementAlloc(
 
 		alloc, qm, err := c.client.Allocations().Info(currentAllocID, q)
 		if err != nil {
-			errCh <- fmt.Errorf("Failed to retrieve allocation %q: %w", limit(alloc.ID, c.length), err)
+			errCh <- fmt.Errorf("Failed to retrieve allocation %q: %w", limit(currentAllocID, c.length), err)
 			return
 		}
 


### PR DESCRIPTION
When monitoring the replacement allocation, if the `Allocations().Info()` request fails, the `alloc` variable is `nil`, so it should not be read.

Only backport to 1.5.x because that's when the `nomad job restart` was added.

Fixes #17329