### PR TITLE
cli: output errors when monitoring deployment

### DIFF
--- a/.changelog/17348.txt
+++ b/.changelog/17348.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Output error messages during deployment monitoring
+```

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -255,7 +255,7 @@ UPDATE:
 		deploy, meta, err = client.Deployments().Info(deployID, &q)
 		if err != nil {
 			d.Append(glint.Layout(glint.Style(
-				glint.Text(fmt.Sprintf("%s: Error fetching deployment", formatTime(time.Now()))),
+				glint.Text(fmt.Sprintf("%s: Error fetching deployment: %v", formatTime(time.Now()), err)),
 				glint.Color("red"),
 			)).MarginLeft(4), glint.Text(""))
 			d.RenderFrame()
@@ -281,7 +281,7 @@ UPDATE:
 				allocComponent = glint.Layout(
 					allocComponent,
 					glint.Style(
-						glint.Text("Error fetching allocations"),
+						glint.Text(fmt.Sprintf("Error fetching allocations: %v", err)),
 						glint.Color("red"),
 					),
 				)
@@ -324,7 +324,7 @@ UPDATE:
 
 				if err != nil {
 					d.Append(glint.Layout(glint.Style(
-						glint.Text(fmt.Sprintf("%s: Error fetching rollback deployment", formatTime(time.Now()))),
+						glint.Text(fmt.Sprintf("%s: Error fetching rollback deployment: %v", formatTime(time.Now()), err)),
 						glint.Color("red"),
 					)).MarginLeft(4), glint.Text(""))
 					d.RenderFrame()
@@ -393,7 +393,7 @@ func (c *DeploymentStatusCommand) defaultMonitor(client *api.Client, deployID st
 		var meta *api.QueryMeta
 		deploy, meta, err = client.Deployments().Info(deployID, &q)
 		if err != nil {
-			c.Ui.Error(c.Colorize().Color(fmt.Sprintf("%s: Error fetching deployment", formatTime(time.Now()))))
+			c.Ui.Error(c.Colorize().Color(fmt.Sprintf("%s: Error fetching deployment: %v", formatTime(time.Now()), err)))
 			return
 		}
 
@@ -405,7 +405,7 @@ func (c *DeploymentStatusCommand) defaultMonitor(client *api.Client, deployID st
 			info += "\n\n[bold]Allocations[reset]\n"
 			allocs, _, err := client.Deployments().Allocations(deployID, nil)
 			if err != nil {
-				info += "Error fetching allocations"
+				info += fmt.Sprintf("Error fetching allocations: %v", err)
 			} else {
 				info += formatAllocListStubs(allocs, verbose, length)
 			}
@@ -435,7 +435,7 @@ func (c *DeploymentStatusCommand) defaultMonitor(client *api.Client, deployID st
 				c.Ui.Output("")
 				if err != nil {
 					c.Ui.Error(c.Colorize().Color(
-						fmt.Sprintf("%s: Error fetching deployment of previous job version", formatTime(time.Now())),
+						fmt.Sprintf("%s: Error fetching deployment of previous job version: %v", formatTime(time.Now()), err),
 					))
 					return
 				}


### PR DESCRIPTION
A few errors during deployment monitoring were being ignored, preventing further investigation and understanding or problems such as #12062