### PR TITLE
client: fix Consul version finterprint

### DIFF
--- a/.changelog/17349.txt
+++ b/.changelog/17349.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: fixed a bug that prevented Nomad from fingerprinting Consul 1.13.8 correctly
+```

--- a/client/fingerprint/consul.go
+++ b/client/fingerprint/consul.go
@@ -197,8 +197,9 @@ func (f *ConsulFingerprint) grpc(scheme string) func(info agentconsul.Self) (str
 			return "", false
 		}
 
-		consulVersion, err := version.NewVersion(v)
+		consulVersion, err := version.NewVersion(strings.TrimSpace(v))
 		if err != nil {
+			f.logger.Warn("invalid Consul version", "version", v)
 			return "", false
 		}
 

--- a/client/fingerprint/consul_test.go
+++ b/client/fingerprint/consul_test.go
@@ -159,6 +159,14 @@ func TestConsulFingerprint_sku(t *testing.T) {
 		require.Equal(t, "ent", s)
 	})
 
+	t.Run("extra spaces", func(t *testing.T) {
+		v, ok := fp.sku(agentconsul.Self{
+			"Config": {"Version": "   v1.9.5\n"},
+		})
+		require.True(t, ok)
+		require.Equal(t, "oss", v)
+	})
+
 	t.Run("missing", func(t *testing.T) {
 		_, ok := fp.sku(agentconsul.Self{
 			"Config": {},
@@ -365,6 +373,15 @@ func TestConsulFingerprint_grpc(t *testing.T) {
 	t.Run("grpc set post-1.14 https", func(t *testing.T) {
 		s, ok := fp.grpc("https")(agentconsul.Self{
 			"Config":      {"Version": "1.14.0"},
+			"DebugConfig": {"GRPCTLSPort": 8503.0}, // JSON numbers are floats
+		})
+		require.True(t, ok)
+		require.Equal(t, "8503", s)
+	})
+
+	t.Run("version with extra spaces", func(t *testing.T) {
+		s, ok := fp.grpc("https")(agentconsul.Self{
+			"Config":      {"Version": "  1.14.0\n"},
 			"DebugConfig": {"GRPCTLSPort": 8503.0}, // JSON numbers are floats
 		})
 		require.True(t, ok)

--- a/command/agent/consul/self.go
+++ b/command/agent/consul/self.go
@@ -20,7 +20,7 @@ func SKU(info Self) (string, bool) {
 		return "", ok
 	}
 
-	ver, vErr := version.NewVersion(v)
+	ver, vErr := version.NewVersion(strings.TrimSpace(v))
 	if vErr != nil {
 		return "", false
 	}


### PR DESCRIPTION
Consul v1.13.8 was released with a [breaking change](https://github.com/hashicorp/consul/issues/17503) in the /v1/agent/self endpoint version where a line break was being returned.

This caused the Nomad finterprint to fail because `NewVersion` errors on parse.

This commit removes any extra space from the Consul version returned by the API.

Closes https://github.com/hashicorp/nomad/issues/17302