### PR TITLE
compliance: add headers with fixed copywrite tool

### DIFF
--- a/.github/secret-scanning.yml
+++ b/.github/secret-scanning.yml
@@ -1,2 +1,5 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 paths-ignore:
   - "website/content/*"

--- a/api/error_unexpected_response.go
+++ b/api/error_unexpected_response.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package api
 
 import (

--- a/api/error_unexpected_response_test.go
+++ b/api/error_unexpected_response_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package api_test
 
 import (

--- a/client/config/drain.go
+++ b/client/config/drain.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package config
 
 import (

--- a/client/drain.go
+++ b/client/drain.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package client
 
 import (

--- a/client/drain_test.go
+++ b/client/drain_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package client
 
 import (

--- a/command/ui/writer_ui_test.go
+++ b/command/ui/writer_ui_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package ui
 
 import (

--- a/demo/csi/nfs/agent.hcl
+++ b/demo/csi/nfs/agent.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 data_dir = "/tmp/nomad/data"
 
 server {

--- a/demo/csi/nfs/jobs/controller-plugin.nomad.hcl
+++ b/demo/csi/nfs/jobs/controller-plugin.nomad.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Controller plugins create and manage CSI volumes.
 # This one just creates folders within the NFS mount.
 job "controller" {

--- a/demo/csi/nfs/jobs/nfs.nomad.hcl
+++ b/demo/csi/nfs/jobs/nfs.nomad.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # A test NFS server that serves a host volume for persistent state.
 job "nfs" {
   group "nfs" {

--- a/demo/csi/nfs/jobs/node-plugin.nomad.hcl
+++ b/demo/csi/nfs/jobs/node-plugin.nomad.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Node plugins mount the volume on the host to present to other tasks.
 job "node" {
   # node plugins should run anywhere your task might be placed, i.e. ~everywhere

--- a/demo/csi/nfs/jobs/web.nomad.hcl
+++ b/demo/csi/nfs/jobs/web.nomad.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Serve the contents of our CSI volume with a little web server.
 job "web" {
   group "web" {

--- a/demo/csi/nfs/setup.sh
+++ b/demo/csi/nfs/setup.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 
 # Set up all the demo components.
 # This can be run repeatedly as it is fairly idempotent.

--- a/demo/csi/nfs/teardown.sh
+++ b/demo/csi/nfs/teardown.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 
 # Clean up all demo components.
 

--- a/demo/csi/nfs/volume.hcl
+++ b/demo/csi/nfs/volume.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 id        = "csi-nfs"
 name      = "csi-nfs"
 type      = "csi"

--- a/e2e/consul/consul_test.go
+++ b/e2e/consul/consul_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package consul
 
 import (

--- a/e2e/consul/input/alloc_restart.hcl
+++ b/e2e/consul/input/alloc_restart.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 job "alloc-restart" {
   constraint {
     attribute = "${attr.kernel.name}"

--- a/e2e/jobsubmissions/doc.go
+++ b/e2e/jobsubmissions/doc.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 // Package jobsubmissions contains e2e tests related to the /v1/job/<id>/submission
 // HTTP API endpoint and related components.
 package jobsubmissions

--- a/e2e/jobsubmissions/input/huge.hcl
+++ b/e2e/jobsubmissions/input/huge.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 job "huge" {
   type = "batch"
 

--- a/e2e/jobsubmissions/input/x.hcl
+++ b/e2e/jobsubmissions/input/x.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # This is an HCL comment
 
 X = "my var file x value"

--- a/e2e/jobsubmissions/input/xyz.hcl
+++ b/e2e/jobsubmissions/input/xyz.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 variable "X" {
   type = string
 }

--- a/e2e/jobsubmissions/input/y.hcl
+++ b/e2e/jobsubmissions/input/y.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 
 Y = 700
 

--- a/e2e/jobsubmissions/input/z.hcl
+++ b/e2e/jobsubmissions/input/z.hcl
@@ -1,2 +1,5 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 Z = true
 

--- a/e2e/jobsubmissions/jobsubapi_test.go
+++ b/e2e/jobsubmissions/jobsubapi_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package jobsubmissions
 
 import (

--- a/nomad/structs/config/drain.go
+++ b/nomad/structs/config/drain.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package config
 
 import "github.com/hashicorp/nomad/helper/pointer"

--- a/ui/app/components/conditional-link-to.hbs
+++ b/ui/app/components/conditional-link-to.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+~}}
+
 {{#if @condition}}
   <LinkTo @route={{@route}} @model={{@model}} @query={{this.query}} class={{@class}} aria-label={{@label}}>
     {{yield}}

--- a/ui/app/components/conditional-link-to.js
+++ b/ui/app/components/conditional-link-to.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import Component from '@glimmer/component';
 
 export default class ConditionalLinkToComponent extends Component {

--- a/ui/app/components/job-editor/alert.js
+++ b/ui/app/components/job-editor/alert.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';

--- a/ui/app/components/job-page/parts/summary-chart.js
+++ b/ui/app/components/job-page/parts/summary-chart.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 // @ts-check
 import Component from '@glimmer/component';
 import { action } from '@ember/object';

--- a/ui/app/components/job-status/allocation-status-block.hbs
+++ b/ui/app/components/job-status/allocation-status-block.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+~}}
+
 <div
   class="allocation-status-block {{unless this.countToShow "rest-only"}}"
   style={{html-safe (concat "width: " @width "px")}}

--- a/ui/app/components/job-status/allocation-status-block.js
+++ b/ui/app/components/job-status/allocation-status-block.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import Component from '@glimmer/component';
 
 export default class JobStatusAllocationStatusBlockComponent extends Component {

--- a/ui/app/components/job-status/allocation-status-row.hbs
+++ b/ui/app/components/job-status/allocation-status-row.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+~}}
+
 <div class="allocation-status-row">
   {{#if this.showSummaries}}
     <div class="alloc-status-summaries"

--- a/ui/app/components/job-status/allocation-status-row.js
+++ b/ui/app/components/job-status/allocation-status-row.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 // @ts-check
 import Component from '@glimmer/component';
 import { action } from '@ember/object';

--- a/ui/app/components/job-status/deployment-history.hbs
+++ b/ui/app/components/job-status/deployment-history.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+~}}
+
 <div class="deployment-history {{if this.isHidden "hidden"}}">
   <header>
     <h4 class="title is-5">

--- a/ui/app/components/job-status/deployment-history.js
+++ b/ui/app/components/job-status/deployment-history.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 // @ts-check
 import Component from '@glimmer/component';
 import { alias } from '@ember/object/computed';

--- a/ui/app/components/job-status/failed-or-lost.hbs
+++ b/ui/app/components/job-status/failed-or-lost.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+~}}
+
 <section class="failed-or-lost">
   <h4>Replaced Allocations</h4>
   <div class="failed-or-lost-links">

--- a/ui/app/components/job-status/latest-deployment.hbs
+++ b/ui/app/components/job-status/latest-deployment.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+~}}
+
 <section class="latest-deployment">
   <LinkTo @route="jobs.job.deployments" @model={{@job}}>
     <h4>

--- a/ui/app/components/job-status/latest-deployment.js
+++ b/ui/app/components/job-status/latest-deployment.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import Component from '@glimmer/component';
 import { alias } from '@ember/object/computed';
 

--- a/ui/app/components/job-status/panel.hbs
+++ b/ui/app/components/job-status/panel.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+~}}
+
 {{#if this.isActivelyDeploying}}
   <JobStatus::Panel::Deploying @job={{@job}} @handleError={{@handleError}} />
 {{else}}

--- a/ui/app/components/job-status/panel.js
+++ b/ui/app/components/job-status/panel.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 // @ts-check
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+~}}
+
 <div class="job-status-panel boxed-section active-deployment is-info" data-test-job-status-panel>
   <div class="boxed-section-head">
     <div class="boxed-section-row"

--- a/ui/app/components/job-status/panel/deploying.js
+++ b/ui/app/components/job-status/panel/deploying.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 // @ts-check
 import Component from '@glimmer/component';
 import { task } from 'ember-concurrency';

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+~}}
+
 <div class="job-status-panel boxed-section steady-state {{if (eq @statusMode "historical") "historical-state" "current-state"}}" data-test-job-status-panel data-test-status-mode={{@statusMode}}>
   <div class="boxed-section-head">
     <h2>Status</h2>

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 // @ts-check
 import Component from '@glimmer/component';
 import { alias } from '@ember/object/computed';

--- a/ui/app/components/job-status/update-params.hbs
+++ b/ui/app/components/job-status/update-params.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+~}}
+
 <Trigger @onError={{action this.onError}} @do={{this.fetchJobDefinition}} as |trigger|>
   {{did-insert trigger.fns.do}}
 

--- a/ui/app/components/job-status/update-params.js
+++ b/ui/app/components/job-status/update-params.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 // @ts-check
 import Component from '@glimmer/component';
 import { action } from '@ember/object';

--- a/ui/app/helpers/merge.js
+++ b/ui/app/helpers/merge.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import { helper } from '@ember/component/helper';
 
 function merge(positional) {

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 .job-status-panel {
   // #region layout
   &.steady-state.current-state .boxed-section-body {

--- a/ui/app/templates/components/job-editor/alert.hbs
+++ b/ui/app/templates/components/job-editor/alert.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+~}}
+
   <div class="job-editor-alerts">
     {{#if @data.error}}
       <Hds::Alert @type="inline" @color="critical" data-test-error={{@data.error.type}} as |A|>

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+~}}
+
 <div class="boxed-section">
   <div class="boxed-section-head">
     Job Definition

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+~}}
+
 <div class="boxed-section">
     <div class="boxed-section-head">
     Job Definition

--- a/ui/app/templates/components/job-editor/review.hbs
+++ b/ui/app/templates/components/job-editor/review.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+~}}
+
 <div class="boxed-section">
     <div class="boxed-section-head">Job Plan</div>
     <div class="boxed-section-body is-dark">

--- a/ui/app/templates/components/job-page/parts/summary-chart.hbs
+++ b/ui/app/templates/components/job-page/parts/summary-chart.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+~}}
+
 {{#if @job.hasChildren}}
   <ChildrenStatusBar
     @allocationContainer={{@job.summary}}

--- a/ui/app/utils/allocation-client-statuses.js
+++ b/ui/app/utils/allocation-client-statuses.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 // @ts-check
 
 /**

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 // @ts-check
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';

--- a/ui/tests/integration/components/job-status-panel-test.js
+++ b/ui/tests/integration/components/job-status-panel-test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, render } from '@ember/test-helpers';

--- a/ui/tests/integration/components/job-status/failed-or-lost-test.js
+++ b/ui/tests/integration/components/job-status/failed-or-lost-test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';

--- a/ui/tests/utils/generate-raw-json-job.js
+++ b/ui/tests/utils/generate-raw-json-job.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 export const JOB_JSON = {
   Shallow: false,
   CreateRecommendations: true,


### PR DESCRIPTION
Closes #17117


```
diablo nomad on main
➜ copywrite headers -s MPL-2.0
Using license identifier: MPL-2.0
Using copyright holder: HashiCorp, Inc.

Exempting the following search patterns:
command/asset/*.hcl
```