### PR TITLE
ui:  node pool filter on `jobs.index` page

### DIFF
--- a/ui/app/adapters/node-pool.js
+++ b/ui/app/adapters/node-pool.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import ApplicationAdapter from './application';
+import classic from 'ember-classic-decorator';
+import { pluralize } from 'ember-inflector';
+
+@classic
+export default class NodePoolAdapter extends ApplicationAdapter {
+  urlForFindAll(modelName) {
+    let [relationshipResource, resource] = modelName.split('-');
+    resource = pluralize(resource);
+    const baseUrl = `/v1/${relationshipResource}/${resource}`;
+
+    return baseUrl;
+  }
+}

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -57,6 +57,9 @@ export default class IndexController extends Controller.extend(
     {
       qpNamespace: 'namespace',
     },
+    {
+      qpNodePool: 'nodePool',
+    },
   ];
 
   currentPage = 1;
@@ -81,11 +84,13 @@ export default class IndexController extends Controller.extend(
   qpStatus = '';
   qpDatacenter = '';
   qpPrefix = '';
+  qpNodePool = '';
 
   @selection('qpType') selectionType;
   @selection('qpStatus') selectionStatus;
   @selection('qpDatacenter') selectionDatacenter;
   @selection('qpPrefix') selectionPrefix;
+  @selection('qpNodePool') selectionNodePools;
 
   @computed
   get optionsType() {
@@ -194,6 +199,29 @@ export default class IndexController extends Controller.extend(
     return availableNamespaces;
   }
 
+  @computed('selectionNodePools', 'model.nodePools.[]')
+  get optionsNodePools() {
+    const availableNodePools = this.model.nodePools;
+
+    scheduleOnce('actions', () => {
+      // eslint-disable-next-line ember/no-side-effects
+      this.set(
+        'qpNodePool',
+        serialize(
+          intersection(
+            availableNodePools.map(({ name }) => name),
+            this.selectionNodePools
+          )
+        )
+      );
+    });
+
+    return availableNodePools.map((nodePool) => ({
+      key: nodePool.name,
+      label: nodePool.name,
+    }));
+  }
+
   /**
     Visible jobs are those that match the selected namespace and aren't children
     of periodic or parameterized jobs.
@@ -212,6 +240,7 @@ export default class IndexController extends Controller.extend(
     'selectionType',
     'selectionStatus',
     'selectionDatacenter',
+    'selectionNodePools',
     'selectionPrefix'
   )
   get filteredJobs() {
@@ -220,6 +249,7 @@ export default class IndexController extends Controller.extend(
       selectionStatus: statuses,
       selectionDatacenter: datacenters,
       selectionPrefix: prefixes,
+      selectionNodePools: nodePools,
     } = this;
 
     // A job must match ALL filter facets, but it can match ANY selection within a facet
@@ -243,6 +273,10 @@ export default class IndexController extends Controller.extend(
         datacenters.length &&
         !job.get('datacenters').find((dc) => datacenters.includes(dc))
       ) {
+        return false;
+      }
+
+      if (nodePools.length && !nodePools.includes(job.get('nodePool'))) {
         return false;
       }
 

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -28,6 +28,7 @@ export default class Job extends Model {
   @attr('number') createIndex;
   @attr('number') modifyIndex;
   @attr('date') submitTime;
+  @attr('string') nodePool; // Jobs are related to Node Pools via Allocations, but no relationship.
 
   @fragment('structured-attributes') meta;
 

--- a/ui/app/models/node-pool.js
+++ b/ui/app/models/node-pool.js
@@ -4,7 +4,7 @@
  */
 
 import Model from '@ember-data/model';
-import { attr } from '@ember-data/model';
+import { attr, hasMany } from '@ember-data/model';
 import { computed } from '@ember/object';
 import classic from 'ember-classic-decorator';
 
@@ -14,6 +14,7 @@ export default class NodePool extends Model {
   @attr('string') description;
   @attr() meta;
   @attr() schedulerConfiguration;
+  @hasMany('node') nodes;
 
   @computed('schedulerConfiguration.SchedulerAlgorithm')
   get schedulerAlgorithm() {

--- a/ui/app/models/node.js
+++ b/ui/app/models/node.js
@@ -7,7 +7,7 @@ import { computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
 import Model from '@ember-data/model';
 import { attr } from '@ember-data/model';
-import { hasMany } from '@ember-data/model';
+import { belongsTo, hasMany } from '@ember-data/model';
 import { fragment, fragmentArray } from 'ember-data-model-fragments/attributes';
 import RSVP from 'rsvp';
 import shortUUIDProperty from '../utils/properties/short-uuid';
@@ -55,6 +55,7 @@ export default class Node extends Model {
   }
 
   @hasMany('allocations', { inverse: 'node' }) allocations;
+  @belongsTo('node-pool') nodePool;
 
   @computed('allocations.@each.clientStatus')
   get completeAllocations() {

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -30,6 +30,7 @@ export default class IndexRoute extends Route.extend(
         .query('job', { namespace: params.qpNamespace, meta: true })
         .catch(notifyForbidden(this)),
       namespaces: this.store.findAll('namespace'),
+      nodePools: this.store.findAll('node-pool'),
     });
   }
 

--- a/ui/app/routes/topology.js
+++ b/ui/app/routes/topology.js
@@ -23,6 +23,7 @@ export default class TopologyRoute extends Route.extend(WithForbiddenState) {
         namespace: '*',
       }),
       nodes: this.store.query('node', { resources: true }),
+      nodePools: this.store.findAll('node-pool'),
     }).catch(notifyForbidden(this));
   }
 
@@ -32,6 +33,7 @@ export default class TopologyRoute extends Route.extend(WithForbiddenState) {
       controller.model = {
         allocations: [],
         nodes: [],
+        nodePools: [],
       };
     }
 

--- a/ui/app/styles/components/dashboard-metric.scss
+++ b/ui/app/styles/components/dashboard-metric.scss
@@ -17,6 +17,12 @@
     font-weight: $weight-bold;
     font-size: $size-3;
 
+    &.topo {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
     .metric-units {
       font-size: $size-4;
     }

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -59,6 +59,13 @@
           @onSelect={{action this.setFacetQueryParam "qpType"}}
         />
         <MultiSelectDropdown
+          data-test-node-pool-facet
+          @label="Node Pool"
+          @options={{this.optionsNodePools}}
+          @selection={{this.selectionNodePools}}
+          @onSelect={{action this.setFacetQueryParam "qpNodePool"}}
+        />
+        <MultiSelectDropdown
           data-test-status-facet
           @label="Status"
           @options={{this.optionsStatus}}

--- a/ui/app/templates/topology.hbs
+++ b/ui/app/templates/topology.hbs
@@ -370,7 +370,7 @@
               {{else}}
                 <div class="columns is-flush">
                   <div class="dashboard-metric column">
-                    <p data-test-node-count class="metric">
+                    <p data-test-node-count class="metric topo">
                       {{this.model.nodes.length}}
                       <span class="metric-label">
                         Clients
@@ -378,10 +378,18 @@
                     </p>
                   </div>
                   <div class="dashboard-metric column">
-                    <p data-test-alloc-count class="metric">
+                    <p data-test-alloc-count class="metric topo">
                       {{this.scheduledAllocations.length}}
                       <span class="metric-label">
                         Allocations
+                      </span>
+                    </p>
+                  </div>
+                  <div class="dashboard-metric column">
+                    <p data-test-node-pool-count class="metric topo">
+                      {{this.model.nodePools.length}}
+                      <span class="metric-label">
+                        Node Pools
                       </span>
                     </p>
                   </div>

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -338,6 +338,10 @@ export default function () {
     return this.serialize(nodes.find(params.id));
   });
 
+  this.get('/node/pools', function ({ nodePools }) {
+    return this.serialize(nodePools.all());
+  });
+
   this.get('/allocations');
 
   this.get('/allocation/:id');

--- a/ui/mirage/factories/job.js
+++ b/ui/mirage/factories/job.js
@@ -214,6 +214,15 @@ export default Factory.extend({
       });
     }
 
+    if (!job.nodePool) {
+      const nodePool = server.db.nodePools.length
+        ? pickOne(server.db.nodePools).name
+        : server.create('node-pool').name;
+      job.update({
+        nodePool,
+      });
+    }
+
     const groupProps = {
       job,
       createAllocations: job.createAllocations,

--- a/ui/mirage/factories/node-pool.js
+++ b/ui/mirage/factories/node-pool.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  name: (i) => `node-pool-${i}`,
+  description: (i) => `describe node-pool-${i}`,
+  meta: {},
+  schedulerConfiguration: {},
+});

--- a/ui/mirage/factories/node.js
+++ b/ui/mirage/factories/node.js
@@ -12,21 +12,26 @@ import moment from 'moment';
 const UUIDS = provide(100, faker.random.uuid.bind(faker.random));
 const NODE_STATUSES = ['initializing', 'ready', 'down'];
 const NODE_CLASSES = provide(7, faker.company.bsBuzz.bind(faker.company));
-const NODE_VERSIONS = ['1.1.0-beta', '1.0.2-alpha+ent', ...provide(5, faker.system.semver)];
+const NODE_VERSIONS = [
+  '1.1.0-beta',
+  '1.0.2-alpha+ent',
+  ...provide(5, faker.system.semver),
+];
 const REF_DATE = new Date();
 
 export default Factory.extend({
-  id: i => (i / 100 >= 1 ? `${UUIDS[i]}-${i}` : UUIDS[i]),
-  name: i => `nomad@${HOSTS[i % HOSTS.length]}`,
+  id: (i) => (i / 100 >= 1 ? `${UUIDS[i]}-${i}` : UUIDS[i]),
+  name: (i) => `nomad@${HOSTS[i % HOSTS.length]}`,
 
   datacenter: () => faker.helpers.randomize(DATACENTERS),
   nodeClass: () => faker.helpers.randomize(NODE_CLASSES),
   drain: faker.random.boolean,
   status: () => faker.helpers.randomize(NODE_STATUSES),
   tlsEnabled: faker.random.boolean,
-  schedulingEligibility: () => (faker.random.boolean() ? 'eligible' : 'ineligible'),
+  schedulingEligibility: () =>
+    faker.random.boolean() ? 'eligible' : 'ineligible',
 
-  createIndex: i => i,
+  createIndex: (i) => i,
   modifyIndex: () => faker.random.number({ min: 10, max: 2000 }),
   version: () => faker.helpers.randomize(NODE_VERSIONS),
 
@@ -35,8 +40,8 @@ export default Factory.extend({
   },
 
   forceIPv4: trait({
-    name: i => {
-      const ipv4Hosts = HOSTS.filter(h => !h.startsWith('['));
+    name: (i) => {
+      const ipv4Hosts = HOSTS.filter((h) => !h.startsWith('['));
       return `nomad@${ipv4Hosts[i % ipv4Hosts.length]}`;
     },
   }),
@@ -45,8 +50,13 @@ export default Factory.extend({
     drain: true,
     schedulingEligibility: 'ineligible',
     drainStrategy: {
-      Deadline: faker.random.number({ min: 30 * 1000, max: 5 * 60 * 60 * 1000 }) * 1000000,
-      ForceDeadline: moment(REF_DATE).add(faker.random.number({ min: 1, max: 5 }), 'd'),
+      Deadline:
+        faker.random.number({ min: 30 * 1000, max: 5 * 60 * 60 * 1000 }) *
+        1000000,
+      ForceDeadline: moment(REF_DATE).add(
+        faker.random.number({ min: 1, max: 5 }),
+        'd'
+      ),
       IgnoreSystemJobs: faker.random.boolean(),
     },
   }),
@@ -135,9 +145,13 @@ export default Factory.extend({
       id: node.httpAddr,
     });
 
-    const events = server.createList('node-event', faker.random.number({ min: 1, max: 10 }), {
-      nodeId: node.id,
-    });
+    const events = server.createList(
+      'node-event',
+      faker.random.number({ min: 1, max: 10 }),
+      {
+        nodeId: node.id,
+      }
+    );
 
     node.update({
       eventIds: events.mapBy('id'),
@@ -146,11 +160,17 @@ export default Factory.extend({
     server.create('client-stat', {
       id: node.id,
     });
+
+    if (!node.nodePool) {
+      node.update({
+        nodePool: server.create('node-pool', { nodes: [node] }),
+      });
+    }
   },
 });
 
 function makeDrivers() {
-  const generate = name => {
+  const generate = (name) => {
     const detected = faker.random.number(10) >= 3;
     const healthy = detected && faker.random.number(10) >= 3;
     const attributes = {

--- a/ui/mirage/models/node-pool.js
+++ b/ui/mirage/models/node-pool.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { Model, hasMany } from 'ember-cli-mirage';
+
+export default Model.extend({
+  nodes: hasMany('node'),
+});

--- a/ui/mirage/models/node.js
+++ b/ui/mirage/models/node.js
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { Model, hasMany } from 'ember-cli-mirage';
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
   events: hasMany('node-event'),
+  nodePool: belongsTo('node-pool'),
 });

--- a/ui/tests/unit/models/node-test.js
+++ b/ui/tests/unit/models/node-test.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | NodePool', function (hooks) {
+  setupTest(hooks);
+
+  test('a node pool can be associated with multiples nodes', function (assert) {
+    const store = this.owner.lookup('service:store');
+    this.subject = () => store.createRecord('node-pool');
+    const nodePool = this.subject();
+    const node1 = store.createRecord('node', { name: 'Node 1' });
+    const node2 = store.createRecord('node', { name: 'Node 2' });
+
+    nodePool.get('nodes').pushObject(node1);
+    nodePool.get('nodes').pushObject(node2);
+
+    const nodes = nodePool.get('nodes');
+
+    assert.equal(nodes.length, 2);
+    assert.ok(nodes.includes(node1));
+    assert.ok(nodes.includes(node2));
+  });
+});


### PR DESCRIPTION
Resolves #17287 

This PR adds a filter to the `jobs.index` page to enable filtering jobs by node pool.