### PR TITLE
ui:  node pools - add node pool to overview pages

### DIFF
--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -243,6 +243,14 @@
         </span>
         {{this.model.datacenter}}
       </span>
+      {{#if this.model.nodePool}}
+        <span class="pair" data-test-node-pool>
+          <span class="term">
+            Node Pool
+          </span>
+          {{this.model.nodePool}}
+        </span>
+      {{/if}}
       {{#if this.model.nodeClass}}
         <span class="pair" data-test-node-class>
           <span class="term">

--- a/ui/app/templates/components/job-page/parts/stats-box.hbs
+++ b/ui/app/templates/components/job-page/parts/stats-box.hbs
@@ -31,6 +31,12 @@
         {{@job.namespace.name}}
       </span>
     {{/if}}
+    {{#if @job.nodePool}}
+      <span class="pair" data-test-job-stat="nodePool">
+        <span class="term">Node Pool</span>
+        {{@job.nodePool}}
+      </span>
+    {{/if}}
     {{yield to="after-namespace"}}
   </div>
 


### PR DESCRIPTION
Resolves #17289 and #17291 

This PR adds the associated Node Pool name to the Job and Client Detail Overview pages.