### PR TITLE
Create a lint workflow for copyright checking

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -4,6 +4,7 @@
 schema_version = 1
 
 project {
+  license = "MPL-2.0"
   header_ignore = [
     "command/asset/*.hcl",
   ]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,5 +15,7 @@ jobs:
     steps:
       - name: Setup Copywrite
         uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e # v1.1.2
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Check Header Compliance
         run: copywrite headers --plan

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+on:
+  push:
+    branches:
+      - main
+      - release/*
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  copyright:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Copywrite
+        uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e # v1.1.2
+      - name: Check Header Compliance
+        run: copywrite headers --plan

--- a/client/structs/enum.go
+++ b/client/structs/enum.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package structs
 
 // AllocUpdatePriority indicates the urgency of an allocation update so that the


### PR DESCRIPTION
This change introduces a lint workflow that verifies files have the required copyright headers. This allows us to be more proactive regarding copyright changes _before_ the bot comes around and asks for changes.

I've created this as a generic workflow "Lint" so that we have a place to possibly surface `make check` tests to our contributors.

Discovered during #17103 

Since we are adding a lint to an existing repository, I've gone ahead and applied the fix to failing files. Attached is an example of the copyright lint action failing:
![image](https://github.com/hashicorp/nomad/assets/90741/d88f0523-a6d6-4fb9-a473-2766d208a22d)
