### PR TITLE
[server] Directed leadership transfer CLI and API

### DIFF
--- a/.changelog/17383.txt
+++ b/.changelog/17383.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+server: Added transfer-leadership API and CLI
+```

--- a/api/operator.go
+++ b/api/operator.go
@@ -120,6 +120,46 @@ func (op *Operator) RaftRemovePeerByID(id string, q *WriteOptions) error {
 	return nil
 }
 
+// RaftTransferLeadershipByAddress is used to transfer leadership to a
+// different peer using its address in the form of "IP:port".
+func (op *Operator) RaftTransferLeadershipByAddress(address string, q *WriteOptions) error {
+	r, err := op.c.newRequest("PUT", "/v1/operator/raft/transfer-leadership")
+	if err != nil {
+		return err
+	}
+	r.setWriteOptions(q)
+
+	r.params.Set("address", address)
+
+	_, resp, err := requireOK(op.c.doRequest(r))
+	if err != nil {
+		return err
+	}
+
+	resp.Body.Close()
+	return nil
+}
+
+// RaftTransferLeadershipByID is used to transfer leadership to a
+// different peer using its Raft ID.
+func (op *Operator) RaftTransferLeadershipByID(id string, q *WriteOptions) error {
+	r, err := op.c.newRequest("PUT", "/v1/operator/raft/transfer-leadership")
+	if err != nil {
+		return err
+	}
+	r.setWriteOptions(q)
+
+	r.params.Set("id", id)
+
+	_, resp, err := requireOK(op.c.doRequest(r))
+	if err != nil {
+		return err
+	}
+
+	resp.Body.Close()
+	return nil
+}
+
 // SchedulerConfiguration is the config for controlling scheduler behavior
 type SchedulerConfiguration struct {
 	// SchedulerAlgorithm lets you select between available scheduling algorithms.
@@ -362,4 +402,13 @@ func (op *Operator) LicenseGet(q *QueryOptions) (*LicenseReply, *QueryMeta, erro
 	qm.RequestTime = rtt
 
 	return &reply, qm, nil
+}
+
+type LeadershipTransferResponse struct {
+	From RaftServer
+	To   RaftServer
+	Noop bool
+	Err  error
+
+	QueryMeta
 }

--- a/api/operator.go
+++ b/api/operator.go
@@ -410,5 +410,5 @@ type LeadershipTransferResponse struct {
 	Noop bool
 	Err  error
 
-	QueryMeta
+	WriteMeta
 }

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -112,22 +112,19 @@ func (s *HTTPServer) OperatorRaftTransferLeadership(resp http.ResponseWriter, re
 
 	// There are some items that we can parse for here that are more unwieldy in
 	// the Validate() func on the RPC request object, like repeated query params.
-	if hasID {
-		if len(id) > 1 {
-			return nil, CodedError(http.StatusBadRequest, "must specify only one id")
-		}
-		if id[0] == "" {
-			return nil, CodedError(http.StatusBadRequest, "id must be non-empty")
-		}
-	} else if hasAddress {
-		if len(addr) > 1 {
-			return nil, CodedError(http.StatusBadRequest, "must specify only one address")
-		}
-		if addr[0] == "" {
-			return nil, CodedError(http.StatusBadRequest, "address must be non-empty")
-		}
-	} else {
+	switch {
+	case !hasID && !hasAddress:
 		return nil, CodedError(http.StatusBadRequest, "must specify id or address")
+	case hasID && hasAddress:
+		return nil, CodedError(http.StatusBadRequest, "must specify either id or address")
+	case hasID && id[0] == "":
+		return nil, CodedError(http.StatusBadRequest, "id must be non-empty")
+	case hasID && len(id) > 1:
+		return nil, CodedError(http.StatusBadRequest, "must specify only one id")
+	case hasAddress && addr[0] == "":
+		return nil, CodedError(http.StatusBadRequest, "address must be non-empty")
+	case hasAddress && len(addr) > 1:
+		return nil, CodedError(http.StatusBadRequest, "must specify only one address")
 	}
 
 	var reply api.LeadershipTransferResponse

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -127,7 +127,7 @@ func (s *HTTPServer) OperatorRaftTransferLeadership(resp http.ResponseWriter, re
 		return nil, CodedError(http.StatusBadRequest, "must specify only one address")
 	}
 
-	var reply api.LeadershipTransferResponse
+	var out structs.LeadershipTransferResponse
 	args := &structs.RaftPeerRequest{}
 	s.parseWriteRequest(req, &args.WriteRequest)
 
@@ -141,8 +141,13 @@ func (s *HTTPServer) OperatorRaftTransferLeadership(resp http.ResponseWriter, re
 		return nil, CodedError(http.StatusBadRequest, err.Error())
 	}
 
-	err := s.agent.RPC("Operator.TransferLeadershipToPeer", &args, &reply)
-	return nil, err
+	err := s.agent.RPC("Operator.TransferLeadershipToPeer", &args, &out)
+	if err != nil {
+		return nil, err
+	}
+
+	setIndex(resp, out.Index)
+	return out, nil
 }
 
 // OperatorAutopilotConfiguration is used to inspect the current Autopilot configuration.

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/netip"
 	"strconv"
 	"strings"
 	"time"
@@ -139,12 +138,6 @@ func (s *HTTPServer) OperatorRaftTransferLeadership(resp http.ResponseWriter, re
 		args.ID = raft.ServerID(id[0])
 	} else {
 		args.Address = raft.ServerAddress(addr[0])
-		if args.Address == "" {
-			return nil, CodedError(http.StatusBadRequest, "address must be non-empty")
-		}
-		if _, err := netip.ParseAddrPort(string(args.Address)); err != nil {
-			return nil, CodedError(http.StatusBadRequest, fmt.Sprintf("address must be in IP:port format: %s", err.Error()))
-		}
 	}
 
 	if err := args.Validate(); err != nil {

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -146,7 +146,6 @@ func (s *HTTPServer) OperatorRaftTransferLeadership(resp http.ResponseWriter, re
 		return nil, err
 	}
 
-	setIndex(resp, out.Index)
 	return out, nil
 }
 

--- a/command/commands.go
+++ b/command/commands.go
@@ -749,6 +749,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"operator raft transfer-leadership": func() (cli.Command, error) {
+			return &OperatorRaftTransferLeadershipCommand{
+				Meta: meta,
+			}, nil
+		},
 		"operator raft info": func() (cli.Command, error) {
 			return &OperatorRaftInfoCommand{
 				Meta: meta,

--- a/command/operator_raft_leadership_transfer.go
+++ b/command/operator_raft_leadership_transfer.go
@@ -36,10 +36,10 @@ General Options:
 Remove Peer Options:
 
   -peer-address="IP:port"
-	Transfer leadership to the Nomad server with given Raft address.
+    Transfer leadership to the Nomad server with given Raft address.
 
   -peer-id="id"
-	Transfer leadership to the Nomad server with given Raft ID.
+    Transfer leadership to the Nomad server with given Raft ID.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/operator_raft_leadership_transfer.go
+++ b/command/operator_raft_leadership_transfer.go
@@ -21,11 +21,13 @@ Usage: nomad operator raft transfer-leadership [options]
 
   Transfer leadership to the Nomad server with given -peer-address or
   -peer-id in the Raft configuration. All server nodes in the cluster
-	must be running at least Raft protocol v3 in order to use this command.
+  must be running at least Raft protocol v3 in order to use this command.
 
   There are cases where you might desire transferring leadership from one
   cluster member to another, for example, during a rolling upgrade. This
   command allows you to designate a new server to be cluster leader.
+
+  Note: This command requires a currently established leader to function.
 
   If ACLs are enabled, this command requires a management token.
 
@@ -41,6 +43,7 @@ Remove Peer Options:
   -peer-id="id"
     Transfer leadership to the Nomad server with given Raft ID.
 `
+
 	return strings.TrimSpace(helpText)
 }
 

--- a/command/operator_raft_leadership_transfer.go
+++ b/command/operator_raft_leadership_transfer.go
@@ -1,0 +1,122 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/posener/complete"
+)
+
+type OperatorRaftTransferLeadershipCommand struct {
+	Meta
+}
+
+func (c *OperatorRaftTransferLeadershipCommand) Help() string {
+	helpText := `
+Usage: nomad operator raft transfer-leadership [options]
+
+  Transfer leadership to the Nomad server with given -peer-address or
+  -peer-id in the Raft configuration. All server nodes in the cluster
+	must be running at least Raft protocol v3 in order to use this command.
+
+  There are cases where you might desire transferring leadership from one
+	cluster member to another, for example, during a rolling upgrade. This
+	command allows you to designate a new server to be cluster leader.
+
+  If ACLs are enabled, this command requires a management token.
+
+General Options:
+
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
+
+Remove Peer Options:
+
+  -peer-address="IP:port"
+	Transfer leadership to the Nomad server with given Raft address.
+
+  -peer-id="id"
+	Transfer leadership to the Nomad server with given Raft ID.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *OperatorRaftTransferLeadershipCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-peer-address": complete.PredictAnything,
+			"-peer-id":      complete.PredictAnything,
+		})
+}
+
+func (c *OperatorRaftTransferLeadershipCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *OperatorRaftTransferLeadershipCommand) Synopsis() string {
+	return "Transfer leadership to a specified Nomad server"
+}
+
+func (c *OperatorRaftTransferLeadershipCommand) Name() string {
+	return "operator raft transfer-leadership"
+}
+
+func (c *OperatorRaftTransferLeadershipCommand) Run(args []string) int {
+	var peerAddress string
+	var peerID string
+
+	flags := c.Meta.FlagSet("raft", FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+
+	flags.StringVar(&peerAddress, "peer-address", "", "")
+	flags.StringVar(&peerID, "peer-id", "", "")
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to parse args: %v", err))
+		return 1
+	}
+
+	// Set up a client.
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+	operator := client.Operator()
+
+	if err := raftTransferLeadership(peerAddress, peerID, operator); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error transferring leadership to peer: %v", err))
+		return 1
+	}
+	if peerAddress != "" {
+		c.Ui.Output(fmt.Sprintf("Transferred leadership to peer with address %q", peerAddress))
+	} else {
+		c.Ui.Output(fmt.Sprintf("Transferred leadership to peer with id %q", peerID))
+	}
+
+	return 0
+}
+
+func raftTransferLeadership(address, id string, operator *api.Operator) error {
+	if len(address) == 0 && len(id) == 0 {
+		return fmt.Errorf("an address or id is required for the destination peer")
+	}
+	if len(address) > 0 && len(id) > 0 {
+		return fmt.Errorf("cannot give both an address and id")
+	}
+
+	// Try to kick the peer.
+	if len(address) > 0 {
+		if err := operator.RaftTransferLeadershipByAddress(address, nil); err != nil {
+			return err
+		}
+	} else {
+		if err := operator.RaftTransferLeadershipByID(id, nil); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/command/operator_raft_leadership_transfer.go
+++ b/command/operator_raft_leadership_transfer.go
@@ -24,8 +24,8 @@ Usage: nomad operator raft transfer-leadership [options]
 	must be running at least Raft protocol v3 in order to use this command.
 
   There are cases where you might desire transferring leadership from one
-	cluster member to another, for example, during a rolling upgrade. This
-	command allows you to designate a new server to be cluster leader.
+  cluster member to another, for example, during a rolling upgrade. This
+  command allows you to designate a new server to be cluster leader.
 
   If ACLs are enabled, this command requires a management token.
 
@@ -107,7 +107,7 @@ func raftTransferLeadership(address, id string, operator *api.Operator) error {
 		return fmt.Errorf("cannot give both an address and id")
 	}
 
-	// Try to kick the peer.
+	// Try to perform the leadership transfer.
 	if len(address) > 0 {
 		if err := operator.RaftTransferLeadershipByAddress(address, nil); err != nil {
 			return err

--- a/nomad/operator_endpoint.go
+++ b/nomad/operator_endpoint.go
@@ -124,7 +124,7 @@ func (op *Operator) RaftRemovePeerByAddress(args *structs.RaftPeerByAddressReque
 
 	// Since this is an operation designed for humans to use, we will return
 	// an error if the supplied address isn't among the peers since it's
-	// likely they screwed up.
+	// likely a mistake.
 	{
 		future := op.srv.raft.GetConfiguration()
 		if err := future.Error(); err != nil {
@@ -182,7 +182,7 @@ func (op *Operator) RaftRemovePeerByID(args *structs.RaftPeerByIDRequest, reply 
 
 	// Since this is an operation designed for humans to use, we will return
 	// an error if the supplied id isn't among the peers since it's
-	// likely they screwed up.
+	// likely a mistake.
 	var address raft.ServerAddress
 	{
 		future := op.srv.raft.GetConfiguration()
@@ -225,6 +225,134 @@ REMOVE:
 	}
 
 	op.logger.Warn("removed Raft peer", "peer_id", args.ID)
+	return nil
+}
+
+// TransferLeadershipToServerAddress is used to transfer leadership away from the
+// current leader to a specific target peer. This can help prevent leadership
+// flapping during a rolling upgrade by allowing the cluster operator to target
+// an already upgraded node before upgrading the remainder of the cluster.
+func (op *Operator) TransferLeadershipToServerAddress(args *structs.RaftPeerByAddressRequest, reply *struct{}) error {
+	authErr := op.srv.Authenticate(op.ctx, args)
+
+	if done, err := op.srv.forward("Operator.TransferLeadershipToServerAddress", args, args, reply); done {
+		return err
+	}
+	op.srv.MeasureRPCRate("operator", structs.RateMetricWrite, args)
+	if authErr != nil {
+		return structs.ErrPermissionDenied
+	}
+
+	// Check management permissions
+	if aclObj, err := op.srv.ResolveACL(args); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
+	return op.doTransfer(args)
+}
+
+// TransferLeadershipToServerID is used to transfer leadership away from the
+// current leader to a specific target peer. This can help prevent leadership
+// flapping during a rolling upgrade by allowing the cluster operator to target
+// an already upgraded node before upgrading the remainder of the cluster.
+func (op *Operator) TransferLeadershipToServerID(args *structs.RaftPeerByIDRequest, reply *struct{}) error {
+	authErr := op.srv.Authenticate(op.ctx, args)
+
+	if done, err := op.srv.forward("Operator.TransferLeadershipToServerID", args, args, reply); done {
+		return err
+	}
+	op.srv.MeasureRPCRate("operator", structs.RateMetricWrite, args)
+	if authErr != nil {
+		return structs.ErrPermissionDenied
+	}
+
+	// Check management permissions
+	if aclObj, err := op.srv.ResolveACL(args); err != nil {
+		return err
+	} else if aclObj != nil && !aclObj.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
+	return op.doTransfer(args)
+}
+
+func (op *Operator) doTransfer(args any) error {
+	var id raft.ServerID
+	var addr raft.ServerAddress
+	var kind, testedVal string // to be used in making error strings
+
+	if lAddr, lID := op.srv.raft.LeaderWithID(); id == lID && addr == lAddr {
+		op.logger.Debug("leadership transfer to current leader is a no-op")
+		return nil
+	}
+
+	minRaftProtocol, err := op.srv.MinRaftProtocol()
+	if err != nil {
+		return err
+	}
+
+	// TransferLeadership is not supported until Raft protocol v3 or greater.
+	if minRaftProtocol < 3 {
+		op.logger.Warn("unsupported minimum common raft protocol version", "required", "3", "current", minRaftProtocol)
+		return fmt.Errorf("unsupported minimum common raft protocol version")
+	}
+
+	// This is in a scope so that future will go out of scope once we're done
+	// checking the configuration, enabling us to reuse the name later.
+	{
+		// Get the raft configuration
+		future := op.srv.raft.GetConfiguration()
+		if err := future.Error(); err != nil {
+			return err
+		}
+
+		// Since this is an operation designed for humans to use, we will return
+		// an error if the supplied id isn't among the peers since it's
+		// likely a mistake.
+		switch tArg := args.(type) {
+		case *structs.RaftPeerByAddressRequest:
+			kind = "address"
+			testedVal = string(tArg.Address)
+			for _, s := range future.Configuration().Servers {
+				if s.Address == tArg.Address {
+					id = s.ID
+					addr = s.Address
+					goto TRANSFER
+				}
+			}
+		case *structs.RaftPeerByIDRequest:
+			kind = "id"
+			testedVal = string(tArg.ID)
+			for _, s := range future.Configuration().Servers {
+				if s.ID == tArg.ID {
+					id = s.ID
+					addr = s.Address
+					goto TRANSFER
+				}
+			}
+		default:
+			// This should never happen, since this function's callers ensure that the
+			// type is either a RaftPeerByAddressRequest or RaftPeerByIDRequest via
+			// their argument types; however, it can't hurt to be defensive for the
+			// future and it feels better to make an error than to panic for missing
+			// (but non-critical) functionality.
+			op.logger.Error("doTransfer: invalid argument", "type", fmt.Sprintf("%T", args))
+			return fmt.Errorf("doTransfer: invalid argument type (%T)", args)
+		}
+		return fmt.Errorf("%s %q was not found in the Raft configuration",
+			kind, testedVal)
+	}
+
+TRANSFER:
+	log := op.logger.With("peer_id", id, "peer_addr", addr)
+	if err = op.srv.leadershipTransferToServer(id, addr); err != nil {
+		log.Error("failed transferring leadership", "error", err)
+		return err
+	}
+
+	log.Info("transferred leadership")
 	return nil
 }
 

--- a/nomad/operator_endpoint.go
+++ b/nomad/operator_endpoint.go
@@ -229,14 +229,14 @@ REMOVE:
 	return nil
 }
 
-// TransferLeadershipToServerID is used to transfer leadership away from the
+// TransferLeadershipToPeer is used to transfer leadership away from the
 // current leader to a specific target peer. This can help prevent leadership
 // flapping during a rolling upgrade by allowing the cluster operator to target
 // an already upgraded node before upgrading the remainder of the cluster.
 func (op *Operator) TransferLeadershipToPeer(req *structs.RaftPeerRequest, reply *structs.LeadershipTransferResponse) error {
 	// Populate the reply's `To` with the arguments. Only one of them is likely
 	// to be filled. We don't get any additional information until after auth
-	// to prevent leaking cluster details vis the error response.
+	// to prevent leaking cluster details via the error response.
 	reply.To = structs.NewRaftIDAddress(req.Address, req.ID)
 
 	authErr := op.srv.Authenticate(op.ctx, req)

--- a/nomad/operator_endpoint.go
+++ b/nomad/operator_endpoint.go
@@ -258,7 +258,7 @@ func (op *Operator) TransferLeadershipToPeer(req *structs.RaftPeerRequest, reply
 		return structs.ErrPermissionDenied
 	}
 
-	// Technically, this code will be running on the leader becuase of the RPC
+	// Technically, this code will be running on the leader because of the RPC
 	// forwarding, but a leadership change could happen at any moment while we're
 	// running. We need the leader's raft info to populate the response struct
 	// anyway, so we have a chance to check again here
@@ -274,7 +274,7 @@ func (op *Operator) TransferLeadershipToPeer(req *structs.RaftPeerRequest, reply
 
 	// while this is a somewhat more expensive test than later ones, if this
 	// test fails, they will _never_ be able to do a transfer. We do this after
-	// ACL checks though, so as to not leak cluster info to unvalidated users.
+	// ACL checks though, so as to not leak cluster info to non-validated users.
 	minRaftProtocol, err := op.srv.MinRaftProtocol()
 	if err != nil {
 		reply.Err = err
@@ -412,7 +412,7 @@ func (op *Operator) AutopilotSetConfiguration(args *structs.AutopilotSetConfigRe
 		return structs.ErrPermissionDenied
 	}
 
-	// All servers should be at or above 0.8.0 to apply this operatation
+	// All servers should be at or above 0.8.0 to apply this operation
 	if !ServersMeetMinimumVersion(op.srv.Members(), op.srv.Region(), minAutopilotVersion, false) {
 		return fmt.Errorf("All servers should be running version %v to update autopilot config", minAutopilotVersion)
 	}

--- a/nomad/operator_endpoint_test.go
+++ b/nomad/operator_endpoint_test.go
@@ -488,8 +488,8 @@ func TestOperator_TransferLeadershipToServerAddress_ACL(t *testing.T) {
 	invalidToken := mock.CreatePolicyAndToken(t, state, 1001, "test-invalid", mock.NodePolicy(acl.PolicyWrite))
 
 	arg := structs.RaftPeerRequest{
-		Address:      addr,
-		WriteRequest: structs.WriteRequest{Region: s1.config.Region},
+		RaftIDAddress: structs.RaftIDAddress{Address: addr},
+		WriteRequest:  structs.WriteRequest{Region: s1.config.Region},
 	}
 
 	var reply struct{}
@@ -544,7 +544,9 @@ func TestOperator_TransferLeadershipToServerID_ACL(t *testing.T) {
 	invalidToken := mock.CreatePolicyAndToken(t, state, 1001, "test-invalid", mock.NodePolicy(acl.PolicyWrite))
 
 	arg := structs.RaftPeerRequest{
-		ID:           tgtID,
+		RaftIDAddress: structs.RaftIDAddress{
+			ID: tgtID,
+		},
 		WriteRequest: structs.WriteRequest{Region: s1.config.Region},
 	}
 

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -52,6 +52,8 @@ type RaftConfigurationResponse struct {
 
 // RaftPeerByAddressRequest is used by the Operator endpoint to apply a Raft
 // operation on a specific Raft peer by address in the form of "IP:port".
+//
+// Deprecated: Use RaftPeerRequest with an Address instead.
 type RaftPeerByAddressRequest struct {
 	// Address is the peer to remove, in the form "IP:port".
 	Address raft.ServerAddress
@@ -62,6 +64,8 @@ type RaftPeerByAddressRequest struct {
 
 // RaftPeerByIDRequest is used by the Operator endpoint to apply a Raft
 // operation on a specific Raft peer by ID.
+//
+// Deprecated: Use RaftPeerRequest with an ID instead.
 type RaftPeerByIDRequest struct {
 	// ID is the peer ID to remove.
 	ID raft.ServerID
@@ -106,6 +110,15 @@ func (r *RaftPeerRequest) validateAddress() error {
 		return fmt.Errorf("address must be in IP:port format: %w", err)
 	}
 	return nil
+}
+
+type LeadershipTransferResponse struct {
+	From RaftServer // Server yielding leadership
+	To   RaftServer // Server obtaining leadership
+	Noop bool       // Was the transfer a non-operation
+	Err  error      // Non-nil if there was an error while transferring leadership
+
+	WriteMeta
 }
 
 // AutopilotSetConfigRequest is used by the Operator endpoint to update the

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -4,9 +4,11 @@
 package structs
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/raft"
 )
 
@@ -81,8 +83,25 @@ type RaftPeerRequest struct {
 	WriteRequest
 }
 
-func (r *RaftPeerRequest) IsValid() bool {
-	return r.ID == "" || r.Address == ""
+func (r *RaftPeerRequest) Validate() error {
+	if (r.ID == "" && r.Address == "") || (r.ID != "" && r.Address == "") {
+		return errors.New("either ID or Address must be set")
+	}
+	if r.ID != "" {
+		return r.validateID()
+	}
+	return r.validateAddress()
+}
+
+func (r *RaftPeerRequest) validateID() error {
+	if _, err := uuid.ParseUUID(string(r.ID)); err != nil {
+		return fmt.Errorf("id must be a uuid: %w", err)
+	}
+	return nil
+}
+
+func (r *RaftPeerRequest) validateAddress() error {
+	return nil
 }
 
 // AutopilotSetConfigRequest is used by the Operator endpoint to update the

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -6,6 +6,7 @@ package structs
 import (
 	"errors"
 	"fmt"
+	"net/netip"
 	"time"
 
 	"github.com/hashicorp/go-uuid"
@@ -101,6 +102,9 @@ func (r *RaftPeerRequest) validateID() error {
 }
 
 func (r *RaftPeerRequest) validateAddress() error {
+	if _, err := netip.ParseAddrPort(string(r.Address)); err != nil {
+		return fmt.Errorf("address must be in IP:port format: %w", err)
+	}
 	return nil
 }
 

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -84,7 +84,7 @@ type RaftPeerRequest struct {
 }
 
 func (r *RaftPeerRequest) Validate() error {
-	if (r.ID == "" && r.Address == "") || (r.ID != "" && r.Address == "") {
+	if (r.ID == "" && r.Address == "") || (r.ID != "" && r.Address != "") {
 		return errors.New("either ID or Address must be set")
 	}
 	if r.ID != "" {

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -78,12 +78,8 @@ type RaftPeerByIDRequest struct {
 // operation on a specific Raft peer by its peer ID or address in the form of
 // "IP:port".
 type RaftPeerRequest struct {
-	// ID is the peer ID to remove
-	ID raft.ServerID
-
-	// Address is the peer to target, in the form "IP:port".
-	Address raft.ServerAddress
-
+	// RaftIDAddress contains an ID and Address field to identify the target
+	RaftIDAddress
 	// WriteRequest holds the Region for this request.
 	WriteRequest
 }
@@ -113,12 +109,21 @@ func (r *RaftPeerRequest) validateAddress() error {
 }
 
 type LeadershipTransferResponse struct {
-	From RaftServer // Server yielding leadership
-	To   RaftServer // Server obtaining leadership
-	Noop bool       // Was the transfer a non-operation
-	Err  error      // Non-nil if there was an error while transferring leadership
+	From RaftIDAddress // Server yielding leadership
+	To   RaftIDAddress // Server obtaining leadership
+	Noop bool          // Was the transfer a non-operation
+	Err  error         // Non-nil if there was an error while transferring leadership
+}
 
-	WriteMeta
+type RaftIDAddress struct {
+	Address raft.ServerAddress
+	ID      raft.ServerID
+}
+
+// NewRaftIDAddress takes parameters in the order provided by raft's
+// LeaderWithID func and returns a RaftIDAddress
+func NewRaftIDAddress(a raft.ServerAddress, id raft.ServerID) RaftIDAddress {
+	return RaftIDAddress{ID: id, Address: a}
 }
 
 // AutopilotSetConfigRequest is used by the Operator endpoint to update the

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -67,6 +67,24 @@ type RaftPeerByIDRequest struct {
 	WriteRequest
 }
 
+// RaftPeerRequest is used by the Operator endpoint to apply a Raft
+// operation on a specific Raft peer by its peer ID or address in the form of
+// "IP:port".
+type RaftPeerRequest struct {
+	// ID is the peer ID to remove
+	ID raft.ServerID
+
+	// Address is the peer to target, in the form "IP:port".
+	Address raft.ServerAddress
+
+	// WriteRequest holds the Region for this request.
+	WriteRequest
+}
+
+func (r *RaftPeerRequest) IsValid() bool {
+	return r.ID == "" || r.Address == ""
+}
+
 // AutopilotSetConfigRequest is used by the Operator endpoint to update the
 // current Autopilot configuration of the cluster.
 type AutopilotSetConfigRequest struct {

--- a/website/content/api-docs/operator/raft.mdx
+++ b/website/content/api-docs/operator/raft.mdx
@@ -196,11 +196,13 @@ The table below shows this endpoint's support for
   as provided in the output of `/v1/operator/raft/configuration` API endpoint or
   the `nomad operator raft list-peers` command.
 
-  <Note>
+<Note>
 
-  Either `address` or `id` must be provided, but not both.
+- The cluster must be running Raft protocol v3 or greater on all server members.
 
-  </Note>
+- Either `address` or `id` must be provided, but not both.
+
+</Note>
 
 ### Sample Requests
 

--- a/website/content/api-docs/operator/raft.mdx
+++ b/website/content/api-docs/operator/raft.mdx
@@ -2,7 +2,7 @@
 layout: api
 page_title: Raft - Operator - HTTP API
 description: |-
-  The /operator/raft endpoints provide tools for management of  the Raft subsystem.
+  The /operator/raft endpoints provide tools for management of the Raft subsystem.
 ---
 
 # Raft Operator HTTP API
@@ -34,26 +34,56 @@ The table below shows this endpoint's support for
 
 ### Sample Request
 
+<Tabs>
+<Tab heading="Nomad CLI">
+
+```shell-session
+$ nomad operator api /v1/operator/raft/configuration
+```
+
+</Tab>
+<Tab heading="curl">
+
 ```shell-session
 $ curl \
     https://localhost:4646/v1/operator/raft/configuration
 ```
 
+</Tab>
+</Tabs>
+
 ### Sample Response
 
 ```json
 {
-  "Index": 1,
-  "Servers": [
-    {
-      "Address": "127.0.0.1:4647",
-      "ID": "127.0.0.1:4647",
-      "Leader": true,
-      "Node": "bacon-mac.global",
-      "RaftProtocol": 2,
-      "Voter": true
-    }
-  ]
+    "Index": 0,
+    "Servers": [
+        {
+            "Address": "10.1.0.10:4647",
+            "ID": "c13f9998-a0f3-d765-0b52-55a0b3ce5f88",
+            "Leader": false,
+            "Node": "node1.global",
+            "RaftProtocol": "3",
+            "Voter": true
+        },
+        {
+            "Address": "10.1.0.20:4647",
+            "ID": "d7927f2b-067f-45a4-6266-af8bb84de082",
+            "Leader": true,
+            "Node": "node2.global",
+            "RaftProtocol": "3",
+            "Voter": true
+        },
+        {
+            "Address": "10.1.0.30:4647",
+            "ID": "00d56ef8-938e-abc3-6f8a-f8ac80a80fb9",
+            "Leader": false,
+            "Node": "node3.global",
+            "RaftProtocol": "3",
+            "Voter": true
+        }
+
+    ]
 }
 ```
 
@@ -66,8 +96,8 @@ $ curl \
 - `Servers` `(array: Server)` - The returned `Servers` array has information
   about the servers in the Raft peer configuration.
 
-  - `ID` `(string)` - The ID of the server. This is the same as the `Address`
-    but may be upgraded to a GUID in a future version of Nomad.
+  - `ID` `(string)` - The ID of the server. For Raft protocol v2, this is the
+    same as the `Address`. Raft protocol v3 uses GUIDs as the ID.
 
   - `Node` `(string)` - The node name of the server, as known to Nomad, or
     `"(unknown)"` if the node is stale and not known.
@@ -100,18 +130,98 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `address` `(string: <optional>)` - Specifies the server to remove as
-  `ip:port`. This cannot be provided along with the `id` parameter.
+- `address` `(string: <optional>)` - Specifies the Raft **Address** of the
+  server to remove as provided in the output of `/v1/operator/raft/configuration`
+  API endpoint or the `nomad operator raft list-peers` command.
 
-- `id` `(string: <optional>)` - Specifies the server to remove as
-  `id`. This cannot be provided along with the `address` parameter.
+- `id` `(string: <optional>)` - Specifies the Raft **ID** of the server to
+  remove as provided in the output of `/v1/operator/raft/configuration`
+  API endpoint or the `nomad operator raft list-peers` command.
+
+  <Note>
+
+  Either `address` or `id` must be provided, but not both.
+
+  </Note>
 
 ### Sample Request
+
+
+<Tabs>
+<Tab heading="Nomad CLI">
+
+```shell-session
+$ nomad operator api -X DELETE \
+   /v1/operator/raft/peer?address=1.2.3.4:4647
+```
+
+</Tab>
+<Tab heading="curl">
 
 ```shell-session
 $ curl \
     --request DELETE \
-    https://localhost:4646/v1/operator/raft/peer?address=1.2.3.4:4646
+    --header "X-Nomad-Token: ${NOMAD_TOKEN}"
+    https://127.0.0.1:4646/v1/operator/raft/peer?address=1.2.3.4:4647
 ```
+
+</Tab>
+</Tabs>
+
+## Transfer Leadership to another Raft Peer
+
+This endpoint tells the current cluster leader to transfer leadership
+to the Nomad server with given address or ID in the Raft
+configuration. The return code signifies success or failure.
+
+| Method              | Path                                    | Produces           |
+| ------------------- | --------------------------------------- | ------------------ |
+| `PUT` <br /> `POST` | `/v1/operator/raft/transfer-leadership` | `application/json` |
+
+The table below shows this endpoint's support for
+[blocking queries](/nomad/api-docs#blocking-queries) and
+[required ACLs](/nomad/api-docs#acls).
+
+| Blocking Queries | ACL Required |
+| ---------------- | ------------ |
+| `NO`             | `management` |
+
+### Parameters
+
+- `address` `(string: <optional>)` - Specifies the Raft **Address** of the
+  target server as provided in the output of `/v1/operator/raft/configuration`
+  API endpoint or the `nomad operator raft list-peers` command.
+
+- `id` `(string: <optional>)` - Specifies the Raft **ID** of the target server
+  as provided in the output of `/v1/operator/raft/configuration` API endpoint or
+  the `nomad operator raft list-peers` command.
+
+  <Note>
+
+  Either `address` or `id` must be provided, but not both.
+
+  </Note>
+
+### Sample Requests
+
+<Tabs>
+<Tab heading="Nomad CLI">
+
+```shell-session
+$ nomad operator api -X PUT \
+    "/v1/operator/raft/transfer-leadership?address=1.2.3.4:4647"
+```
+
+</Tab>
+<Tab heading="curl">
+
+```shell-session
+$ curl --request PUT \
+    --header "X-Nomad-Token: ${NOMAD_TOKEN}"
+    "https://127.0.0.1:4646/v1/operator/raft/transfer-leadership?address=1.2.3.4:4647"
+```
+
+</Tab>
+</Tabs>
 
 [consensus protocol guide]: /nomad/docs/concepts/consensus

--- a/website/content/docs/commands/operator/raft/transfer-leadership.mdx
+++ b/website/content/docs/commands/operator/raft/transfer-leadership.mdx
@@ -1,0 +1,57 @@
+---
+layout: docs
+page_title: 'Commands: operator raft transfer-leadership'
+description: |
+  Transfer leadership to a specific a Nomad server.
+---
+
+# Command: operator raft transfer-leadership
+
+Transfer leadership from the current leader to the given server member.
+
+While performing a [rolling upgrade][] of your Nomad cluster, it might be
+advisable to transfer leadership to a specific node in the cluster. For example,
+setting the leader to the first upgraded server in the cluster can prevent
+leadership churn as you upgrade the remaining server nodes.
+
+The target server's ID or address:port are required and can be obtained by
+running the [`nomad operator raft list-peers`][] command or by calling the
+[Read Raft Configuration][] API endpoint.
+
+For an API to perform these operations programmatically, please see the
+documentation for the [Operator][] endpoint.
+
+## Usage
+
+```plaintext
+nomad operator raft transfer-leadership [options]
+```
+
+<Tip title="Required Permissions">
+If ACLs are enabled, this command requires a management token.
+</Tip>
+
+## General Options
+
+@include 'general_options_no_namespace.mdx'
+
+## Transfer Leadership Options
+
+- `-peer-address`: Specifies the Raft **Address** of the target server as
+  provided in the output of the [`nomad operator raft list-peers`][] command or
+  the [Read Raft Configuration] API endpoint.
+
+- `-peer-id`: Specifies the Raft **ID** of the target server as provided in the
+  output of the [`nomad operator raft list-peers`][] command or the
+  [Read Raft Configuration] API endpoint.
+
+  <Note>
+
+  Either `-peer-address` or `-peer-id` must be provided, but not both.
+
+  </Note>
+
+[`nomad operator raft list-peers`]: /nomad/docs/commands/operator/raft/list-peers 'Nomad operator raft list-peers command'
+[operator]: /nomad/api-docs/operator 'Nomad Operator API'
+[rolling upgrade]: /nomad/docs/upgrade#upgrade-process
+[Read Raft Configuration]: /nomad/api-docs/operator/raft#read-raft-configuration

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -800,6 +800,10 @@
               {
                 "title": "state",
                 "path": "commands/operator/raft/state"
+              },
+              {
+                "title": "transfer-leadership",
+                "path": "commands/operator/raft/transfer-leadership"
               }
             ]
           },


### PR DESCRIPTION
This PR adds an API endpoint and a CLI command to allow cluster operators to move leadership from the current leader to a specified server node. This can reduce leadership churn during rolling updates by allowing the operator to migrate leadership to the first upgraded node.

**Commits**
- Add directed leadership transfer func
- Add leadership transfer RPC endpoint
- Add ACL tests for leadership-transfer endpoint
- Add HTTP API route and implementation
- Add to Go API client
- Implement CLI command
- Add documentation
    - [🔍 cli docs](https://nomad-qglbkcast-hashicorp.vercel.app/nomad/docs/commands/operator/raft/transfer-leadership)
    - [🔍 api docs](https://nomad-qglbkcast-hashicorp.vercel.app/nomad/api-docs/operator/raft#transfer-leadership-to-another-raft-peer)

Fixes: https://github.com/hashicorp/nomad/issues/7376