### PR TITLE
node pool: add search support

### DIFF
--- a/acl/acl.go
+++ b/acl/acl.go
@@ -410,12 +410,12 @@ func (a *ACL) AllowNodePool(pool string) bool {
 	return !capabilities.Check(PolicyDeny)
 }
 
-// AllowAnyNodePool returns true if any operation is allowed in at least one
+// AllowNodePoolSearch returns true if any operation is allowed in at least one
 // node pool.
 //
 // This is a very loose check and is expected that callers perform more precise
 // verification later.
-func (a *ACL) AllowAnyNodePool() bool {
+func (a *ACL) AllowNodePoolSearch() bool {
 	// Hot path if ACL is not enabled or token is management.
 	if a == nil || a.management {
 		return true

--- a/acl/acl.go
+++ b/acl/acl.go
@@ -410,6 +410,35 @@ func (a *ACL) AllowNodePool(pool string) bool {
 	return !capabilities.Check(PolicyDeny)
 }
 
+// AllowAnyNodePool returns true if any operation is allowed in at least one
+// node pool.
+//
+// This is a very loose check and is expected that callers perform more precise
+// verification later.
+func (a *ACL) AllowAnyNodePool() bool {
+	// Hot path if ACL is not enabled or token is management.
+	if a == nil || a.management {
+		return true
+	}
+
+	// Check for any non-deny capabilities.
+	iter := a.nodePools.Root().Iterator()
+	for _, capability, ok := iter.Next(); ok; _, capability, ok = iter.Next() {
+		if !capability.Check(NodePoolCapabilityDeny) {
+			return true
+		}
+	}
+
+	iter = a.wildcardNodePools.Root().Iterator()
+	for _, capability, ok := iter.Next(); ok; _, capability, ok = iter.Next() {
+		if !capability.Check(NodePoolCapabilityDeny) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // AllowHostVolumeOperation checks if a given operation is allowed for a host volume
 func (a *ACL) AllowHostVolumeOperation(hv string, op string) bool {
 	// Hot path management tokens

--- a/nomad/search_endpoint.go
+++ b/nomad/search_endpoint.go
@@ -33,6 +33,7 @@ var (
 		structs.Allocs,
 		structs.Jobs,
 		structs.Nodes,
+		structs.NodePools,
 		structs.Evals,
 		structs.Deployments,
 		structs.Plugins,
@@ -75,6 +76,8 @@ func (s *Search) getPrefixMatches(iter memdb.ResultIterator, prefix string) ([]s
 			id = t.ID
 		case *structs.Node:
 			id = t.ID
+		case *structs.NodePool:
+			id = t.Name
 		case *structs.Deployment:
 			id = t.ID
 		case *structs.CSIPlugin:
@@ -216,6 +219,10 @@ func (s *Search) fuzzyMatchSingle(raw interface{}, text string) (structs.Context
 		name = t.Name
 		scope = []string{t.ID}
 		ctx = structs.Nodes
+	case *structs.NodePool:
+		name = t.Name
+		scope = []string{t.Name}
+		ctx = structs.NodePools
 	case *structs.Namespace:
 		name = t.Name
 		ctx = structs.Namespaces
@@ -381,6 +388,15 @@ func getResourceIter(context structs.Context, aclObj *acl.ACL, namespace, prefix
 		return store.AllocsByIDPrefix(ws, namespace, prefix, state.SortDefault)
 	case structs.Nodes:
 		return store.NodesByIDPrefix(ws, prefix)
+	case structs.NodePools:
+		iter, err := store.NodePoolsByNamePrefix(ws, prefix, state.SortDefault)
+		if err != nil {
+			return nil, err
+		}
+		if aclObj == nil || aclObj.IsManagement() {
+			return iter, nil
+		}
+		return memdb.NewFilterIterator(iter, nodePoolCapFilter(aclObj)), nil
 	case structs.Deployments:
 		return store.DeploymentsByIDPrefix(ws, namespace, prefix, state.SortDefault)
 	case structs.Plugins:
@@ -449,6 +465,17 @@ func getFuzzyResourceIterator(context structs.Context, aclObj *acl.ACL, namespac
 		}
 		return store.Nodes(ws)
 
+	case structs.NodePools:
+		iter, err := store.NodePools(ws, state.SortDefault)
+		if err != nil {
+			return nil, err
+		}
+
+		if aclObj == nil || aclObj.IsManagement() {
+			return iter, nil
+		}
+		return memdb.NewFilterIterator(iter, nodePoolCapFilter(aclObj)), nil
+
 	case structs.Plugins:
 		if wildcard(namespace) {
 			iter, err := store.CSIPlugins(ws)
@@ -504,6 +531,15 @@ func nsCapFilter(aclObj *acl.ACL) memdb.FilterFunc {
 		default:
 			return false
 		}
+	}
+}
+
+// nsCapFilter produces a memdb.FilterFunc for removing node pools not
+// accessible by aclObj during a table scan.
+func nodePoolCapFilter(aclObj *acl.ACL) memdb.FilterFunc {
+	return func(v interface{}) bool {
+		pool := v.(*structs.NodePool)
+		return !aclObj.AllowNodePoolOperation(pool.Name, acl.NodePoolCapabilityRead)
 	}
 }
 
@@ -633,11 +669,12 @@ func sufficientSearchPerms(aclObj *acl.ACL, namespace string, context structs.Co
 	}
 
 	nodeRead := aclObj.AllowNodeRead()
+	allowNodePool := aclObj.AllowAnyNodePool()
 	allowNS := aclObj.AllowNamespace(namespace)
 	jobRead := aclObj.AllowNsOp(namespace, acl.NamespaceCapabilityReadJob)
 	allowEnt := sufficientSearchPermsEnt(aclObj)
 
-	if !nodeRead && !allowNS && !allowEnt && !jobRead {
+	if !nodeRead && !allowNodePool && !allowNS && !allowEnt && !jobRead {
 		return false
 	}
 
@@ -647,6 +684,12 @@ func sufficientSearchPerms(aclObj *acl.ACL, namespace string, context structs.Co
 	switch context {
 	case structs.Nodes:
 		return nodeRead
+	case structs.NodePools:
+		// Just the search term is not enough to determine if the token is
+		// allowed to access node pools since the prefix may not patch the
+		// node pool label in the policy. Node pools will be filters when
+		// iterate over the results.
+		return true
 	case structs.Namespaces:
 		return allowNS
 	case structs.Allocs, structs.Deployments, structs.Evals, structs.Jobs:
@@ -673,7 +716,7 @@ func sufficientSearchPerms(aclObj *acl.ACL, namespace string, context structs.Co
 //
 // These types are available for fuzzy searching:
 //
-//	Nodes, Namespaces, Jobs, Allocs, Plugins
+//	Nodes, Node Pools, Namespaces, Jobs, Allocs, Plugins
 //
 // Jobs are a special case that expand into multiple types, and whose return
 // values include Scope which is a descending list of IDs of parent objects,
@@ -889,6 +932,10 @@ func filteredSearchContexts(aclObj *acl.ACL, namespace string, context structs.C
 			}
 		case structs.Nodes:
 			if aclObj.AllowNodeRead() {
+				available = append(available, c)
+			}
+		case structs.NodePools:
+			if aclObj.AllowAnyNodePool() {
 				available = append(available, c)
 			}
 		case structs.Volumes:

--- a/nomad/search_endpoint.go
+++ b/nomad/search_endpoint.go
@@ -534,7 +534,7 @@ func nsCapFilter(aclObj *acl.ACL) memdb.FilterFunc {
 	}
 }
 
-// nsCapFilter produces a memdb.FilterFunc for removing node pools not
+// nodePoolCapFilter produces a memdb.FilterFunc for removing node pools not
 // accessible by aclObj during a table scan.
 func nodePoolCapFilter(aclObj *acl.ACL) memdb.FilterFunc {
 	return func(v interface{}) bool {
@@ -669,7 +669,7 @@ func sufficientSearchPerms(aclObj *acl.ACL, namespace string, context structs.Co
 	}
 
 	nodeRead := aclObj.AllowNodeRead()
-	allowNodePool := aclObj.AllowAnyNodePool()
+	allowNodePool := aclObj.AllowNodePoolSearch()
 	allowNS := aclObj.AllowNamespace(namespace)
 	jobRead := aclObj.AllowNsOp(namespace, acl.NamespaceCapabilityReadJob)
 	allowEnt := sufficientSearchPermsEnt(aclObj)
@@ -685,10 +685,10 @@ func sufficientSearchPerms(aclObj *acl.ACL, namespace string, context structs.Co
 	case structs.Nodes:
 		return nodeRead
 	case structs.NodePools:
-		// Just the search term is not enough to determine if the token is
-		// allowed to access node pools since the prefix may not patch the
-		// node pool label in the policy. Node pools will be filters when
-		// iterate over the results.
+		// The search term alone is not enough to determine if the token is
+		// allowed to access the given prefix since it may not match node pool
+		// label in the policy. Node pools will be filtered when iterating over
+		// the results.
 		return true
 	case structs.Namespaces:
 		return allowNS
@@ -935,7 +935,7 @@ func filteredSearchContexts(aclObj *acl.ACL, namespace string, context structs.C
 				available = append(available, c)
 			}
 		case structs.NodePools:
-			if aclObj.AllowAnyNodePool() {
+			if aclObj.AllowNodePoolSearch() {
 				available = append(available, c)
 			}
 		case structs.Volumes:

--- a/nomad/structs/search.go
+++ b/nomad/structs/search.go
@@ -14,6 +14,7 @@ const (
 	Evals           Context = "evals"
 	Jobs            Context = "jobs"
 	Nodes           Context = "nodes"
+	NodePools       Context = "node_pools"
 	Namespaces      Context = "namespaces"
 	Quotas          Context = "quotas"
 	Recommendations Context = "recommendations"

--- a/website/content/api-docs/search.mdx
+++ b/website/content/api-docs/search.mdx
@@ -9,10 +9,10 @@ description: The /search endpoint is used to search for Nomad objects
 ## Prefix Searching
 
 The `/search` endpoint returns matches for a given prefix and context, where a
-context can be jobs, allocations, evaluations, nodes, deployments, plugins,
-namespaces, or volumes. When using Nomad Enterprise, the allowed contexts
-include quotas. Additionally, a prefix can be searched for within every
-context.
+context can be jobs, allocations, evaluations, nodes, node pools, deployments,
+plugins, namespaces, or volumes. When using Nomad Enterprise, the allowed
+contexts include quotas. Additionally, a prefix can be searched for within
+every context.
 
 | Method | Path         | Produces           |
 | ------ | ------------ | ------------------ |
@@ -22,14 +22,14 @@ The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
 [required ACLs](/nomad/api-docs#acls).
 
-| Blocking Queries | ACL Required                     |
-| ---------------- | -------------------------------- |
-| `NO`             | `node:read, namespace:read-jobs` |
+| Blocking Queries | ACL Required                                     |
+| ---------------- | ------------------------------------------------ |
+| `NO`             | `node:read, node_pool:read, namespace:read-jobs` |
 
-When ACLs are enabled, requests must have a token valid for `node:read` or
-`namespace:read-jobs` roles. If the token is only valid for `node:read`, then
-job related results will not be returned. If the token is only valid for
-`namespace:read-jobs`, then node results will not be returned.
+When ACLs are enabled, requests must have a token valid for `node:read`,
+`node_pool:read`, or `namespace:read-jobs` roles. If the token is only valid
+for a portion of these capabilities, then results will include results
+including only data readable with the given token.
 
 ### Parameters
 
@@ -38,8 +38,8 @@ job related results will not be returned. If the token is only valid for
   matches might be "abcd", or "aabb".
 - `Context` `(string: <required>)` - Defines the scope in which a search for a
   prefix operates. Contexts can be: "jobs", "evals", "allocs", "nodes",
-  "deployment", "plugins", "volumes" or "all", where "all" means every
-  context will be searched.
+  "node_pools", "deployment", "plugins", "volumes" or "all", where "all" means
+  every context will be searched.
 
 ### Sample Payload (for all contexts)
 
@@ -123,11 +123,12 @@ $ curl \
 
 ## Fuzzy Searching
 
-The `/search/fuzzy` endpoint returns partial substring matches for a given search
-term and context, where a context can be jobs, allocations, nodes, plugins, or namespaces.
-Additionally, fuzzy searching can be done across all contexts. For better control
-over the performance implications of fuzzy searching on Nomad servers, aspects of
-fuzzy searching can be tuned through the <code>[search]</code> block in Nomad agent config.
+The `/search/fuzzy` endpoint returns partial substring matches for a given
+search term and context, where a context can be jobs, allocations, nodes, node
+pools, plugins, or namespaces. Additionally, fuzzy searching can be done across
+all contexts. For better control over the performance implications of fuzzy
+searching on Nomad servers, aspects of fuzzy searching can be tuned through
+the <code>[search]</code> block in Nomad agent config.
 
 Fuzzy search results are ordered starting with closest matching terms. Items of
 a name that exactly matches the search term are listed first.
@@ -140,27 +141,28 @@ The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
 [required ACLs](/nomad/api-docs#acls).
 
-| Blocking Queries | ACL Required                                                |
-| ---------------- | ----------------------------------------------------------- |
-| `NO`             | `node:read, namespace:read-jobs, namespace:csi-list-plugin` |
+| Blocking Queries | ACL Required                                                                |
+| ---------------- | --------------------------------------------------------------------------- |
+| `NO`             | `node:read, node_pool:read, namespace:read-jobs, namespace:csi-list-plugin` |
 
-When ACLs are enabled, requests must have a token valid for `node:read`, `plugin:read` or
-`namespace:read-jobs` roles. If the token is only valid for a portion of these
-capabilities, then results will include results including only data readable with
-the given token.
+When ACLs are enabled, requests must have a token valid for `node:read`,
+`node_pool:read`, `plugin:read`, or `namespace:read-jobs` roles. If the token
+is only valid for a portion of these capabilities, then results will include
+results including only data readable with the given token.
 
 ### Parameters
 
 - `Text` `(string: <required>)` - Specifies the identifier against which
   matches will be found. For example, if the given text were "py", potential
   fuzzy matches might be "python", "spying", or "happy".
+
 - `Context` `(string: <required>)` - Defines the scope in which a search for a
-  prefix operates. Contexts can be: "jobs", "allocs", "nodes", "plugins", or
-  "all", where "all" means every context will be searched. When "all" is selected,
-  additional prefix matches will be included for the "deployments", "evals", and
-  "volumes" types. When searching in the "jobs" context, results that fuzzy match
-  "groups", "services", "tasks", "images", "commands", and "classes" are also
-  included in the results.
+  prefix operates. Contexts can be: "jobs", "allocs", "nodes", "node_pools",
+  "plugins", or "all", where "all" means every context will be searched. When
+  "all" is selected, additional prefix matches will be included for the
+  "deployments", "evals", and "volumes" types. When searching in the "jobs"
+  context, results that fuzzy match "groups", "services", "tasks", "images",
+  "commands", and "classes" are also included in the results.
 
 ### Scope
 
@@ -338,6 +340,51 @@ $ curl \
 ##### Scope (nodes)
 
 - `Scope[0]` : Node ID
+
+### Sample Payload (for node pools)
+
+```json
+{
+  "Text": "lab",
+  "Context": "node_pools"
+}
+```
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --request POST \
+    --data @payload.json \
+    https://localhost:4646/v1/search/fuzzy
+```
+
+### Sample Response
+
+```json
+{
+  "Index": 9,
+  "KnownLeader": true,
+  "LastContact": 0,
+  "Matches": {
+    "node_pools": [
+      {
+        "ID": "dev-lab1",
+        "Scope": [
+          "dev-lab1"
+        ]
+      }
+    ]
+  },
+  "Truncations": {
+    "nodes": false
+  }
+}
+```
+
+##### Scope (node pools)
+
+- `Scope[0]` : Node Pool Name
 
 ### Sample Payload (for allocs)
 


### PR DESCRIPTION
Add node pools support to the fuzzy and prefix search endpoints. 

These endpoints are used by the CLI for prefix match and shell tab-completion.

Doc preview:
https://nomad-git-f-node-pools-search-hashicorp.vercel.app/nomad/api-docs/search