### PR TITLE
Add check for missing `path` in client `host_volume` config

### DIFF
--- a/.changelog/17393.txt
+++ b/.changelog/17393.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Add check for missing `path` in `nomad config validate` command
+```

--- a/.changelog/17393.txt
+++ b/.changelog/17393.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-cli: Add check for missing `path` in `nomad config validate` command
+cli: Add check for missing host volume `path` in `nomad config validate` command
 ```

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -393,6 +393,13 @@ func (c *Command) IsValidConfig(config, cmdConfig *Config) bool {
 		}
 	}
 
+	for _, volumeConfig := range config.Client.HostVolumes {
+		if volumeConfig.Path == "" {
+			c.Ui.Error("Missing path in host_volume config")
+			return false
+		}
+	}
+
 	if config.Client.MinDynamicPort < 0 || config.Client.MinDynamicPort > structs.MaxValidPort {
 		c.Ui.Error(fmt.Sprintf("Invalid dynamic port range: min_dynamic_port=%d", config.Client.MinDynamicPort))
 		return false

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -430,6 +430,48 @@ func TestIsValidConfig(t *testing.T) {
 			},
 			err: "client.artifact block invalid: http_read_timeout must be > 0",
 		},
+		{
+			name: "BadHostVolumeConfig",
+			conf: Config{
+				DataDir: "/tmp",
+				Client: &ClientConfig{
+					Enabled: true,
+					HostVolumes: []*structs.ClientHostVolumeConfig{
+						{
+							Name:     "test",
+							ReadOnly: true,
+						},
+						{
+							Name:     "test",
+							ReadOnly: true,
+							Path:     "/random/path",
+						},
+					},
+				},
+			},
+			err: "Missing path in host_volume config",
+		},
+		{
+			name: "ValidHostVolumeConfig",
+			conf: Config{
+				DataDir: "/tmp",
+				Client: &ClientConfig{
+					Enabled: true,
+					HostVolumes: []*structs.ClientHostVolumeConfig{
+						{
+							Name:     "test",
+							ReadOnly: true,
+							Path:     "/random/path1",
+						},
+						{
+							Name:     "test",
+							ReadOnly: true,
+							Path:     "/random/path2",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Hi team,

This PR aims to add additional check for missing `path` value in client `host_volume` config. I have added 2 more test cases to validate this change. Please let me know if I need to make any additional changes for this :pray: 

Fixes : https://github.com/hashicorp/nomad/issues/16968