### PR TITLE
UI-specific GHA test changes re-implemented

### DIFF
--- a/ui/mirage/factories/job.js
+++ b/ui/mirage/factories/job.js
@@ -368,6 +368,7 @@ export default Factory.extend({
         datacenters: job.datacenters,
         createAllocations: job.createAllocations,
         shallow: job.shallow,
+        noActiveDeployment: job.noActiveDeployment,
       });
     }
   },

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -21,6 +21,10 @@ moduleForJob('Acceptance | job detail (batch)', 'allocations', () =>
     type: 'batch',
     shallow: true,
     noActiveDeployment: true,
+    createAllocations: true,
+    allocStatusDistribution: {
+      running: 1,
+    },
   })
 );
 
@@ -29,6 +33,10 @@ moduleForJob('Acceptance | job detail (system)', 'allocations', () =>
     type: 'system',
     shallow: true,
     noActiveDeployment: true,
+    createAllocations: true,
+    allocStatusDistribution: {
+      running: 1,
+    },
   })
 );
 
@@ -37,6 +45,11 @@ moduleForJob('Acceptance | job detail (sysbatch)', 'allocations', () =>
     type: 'sysbatch',
     shallow: true,
     noActiveDeployment: true,
+    createAllocations: true,
+    allocStatusDistribution: {
+      running: 1,
+      failed: 1,
+    },
   })
 );
 
@@ -87,6 +100,10 @@ moduleForJob('Acceptance | job detail (sysbatch child)', 'allocations', () => {
     childrenCount: 1,
     shallow: true,
     datacenters: ['dc1'],
+    createAllocations: true,
+    allocStatusDistribution: {
+      running: 1,
+    },
     noActiveDeployment: true,
   });
   return server.db.jobs.where({ parentId: parent.id })[0];
@@ -225,6 +242,11 @@ moduleForJob('Acceptance | job detail (periodic child)', 'allocations', () => {
   const parent = server.create('job', 'periodic', {
     childrenCount: 1,
     shallow: true,
+    createAllocations: true,
+    allocStatusDistribution: {
+      running: 1,
+    },
+    noActiveDeployment: true,
   });
   return server.db.jobs.where({ parentId: parent.id })[0];
 });
@@ -237,6 +259,10 @@ moduleForJob(
       childrenCount: 1,
       shallow: true,
       noActiveDeployment: true,
+      createAllocations: true,
+      allocStatusDistribution: {
+        running: 1,
+      },
     });
     return server.db.jobs.where({ parentId: parent.id })[0];
   }

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -148,8 +148,17 @@ export default function moduleForJob(
         if (jobTypesWithStatusPanel.includes(job.type)) {
           await switchToHistorical(job);
         }
-        const legendItem = find('.legend li.is-clickable');
-        const status = legendItem.getAttribute('data-test-legend-label');
+
+        // explicitly setting allocationStatusDistribution when creating the job that gets passed here
+        // is the best way to ensure we don't end up with an unlinkable "queued" allocation status,
+        // but we can be redundant for the sake of future-proofing this here.
+        const legendItem = find(
+          '.legend li.is-clickable:not([data-test-legend-label="queued"]) a'
+        );
+
+        const status = legendItem.parentElement.getAttribute(
+          'data-test-legend-label'
+        );
         await legendItem.click();
 
         const encodedStatus = encodeURIComponent(JSON.stringify([status]));
@@ -259,7 +268,11 @@ export function moduleForJobWithClientStatus(
       );
       job = jobFactory();
       clients.forEach((c) => {
-        server.create('allocation', { jobId: job.id, nodeId: c.id });
+        server.create('allocation', {
+          jobId: job.id,
+          nodeId: c.id,
+          clientStatus: 'running',
+        });
       });
     });
 


### PR DESCRIPTION
UI-specific tests that were pulled from https://github.com/hashicorp/nomad/pull/17103 — they were necessitated because GHA appears to run our acceptance tests under a different order / set of circumstances than Circle.

This hardens the tests a bit and gives them some sensible defaults (like "Batch jobs do not have deployments", etc.)

