### PR TITLE
node pools: register a node in a node pool

### DIFF
--- a/api/nodes.go
+++ b/api/nodes.go
@@ -553,6 +553,7 @@ type Node struct {
 	Links                 map[string]string
 	Meta                  map[string]string
 	NodeClass             string
+	NodePool              string
 	CgroupParent          string
 	Drain                 bool
 	DrainStrategy         *DrainStrategy
@@ -914,6 +915,7 @@ type NodeListStub struct {
 	Datacenter            string
 	Name                  string
 	NodeClass             string
+	NodePool              string
 	Version               string
 	Drain                 bool
 	SchedulingEligibility string

--- a/api/nodes_test.go
+++ b/api/nodes_test.go
@@ -60,6 +60,7 @@ func TestNodes_List(t *testing.T) {
 
 	nodeListStub, queryMeta := queryNodeList(t, nodes)
 	must.Len(t, 1, nodeListStub)
+	must.Eq(t, NodePoolDefault, nodeListStub[0].NodePool)
 
 	// Check that we got valid QueryMeta.
 	assertQueryMeta(t, queryMeta)
@@ -140,6 +141,7 @@ func TestNodes_Info(t *testing.T) {
 	// Check that the result is what we expect
 	must.Eq(t, nodeID, result.ID)
 	must.Eq(t, dc, result.Datacenter)
+	must.Eq(t, NodePoolDefault, result.NodePool)
 
 	must.Eq(t, 20000, result.NodeResources.MinDynamicPort)
 	must.Eq(t, 32000, result.NodeResources.MaxDynamicPort)

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -750,6 +750,7 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	conf.Node.Name = agentConfig.NodeName
 	conf.Node.Meta = agentConfig.Client.Meta
 	conf.Node.NodeClass = agentConfig.Client.NodeClass
+	conf.Node.NodePool = agentConfig.Client.NodePool
 
 	// Set up the HTTP advertise address
 	conf.Node.HTTPAddr = agentConfig.AdvertiseAddrs.HTTP

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -25,7 +25,6 @@ import (
 	checkpoint "github.com/hashicorp/go-checkpoint"
 	discover "github.com/hashicorp/go-discover"
 	hclog "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-set"
 	gsyslog "github.com/hashicorp/go-syslog"
 	"github.com/hashicorp/logutils"
 	"github.com/hashicorp/nomad/helper"
@@ -384,11 +383,12 @@ func (c *Command) IsValidConfig(config, cmdConfig *Config) bool {
 	// Validate node pool name early to prevent agent from starting but the
 	// client failing to register.
 	if pool := config.Client.NodePool; pool != "" {
-		invalidNames := set.From([]string{
-			structs.NodePoolAll,
-		})
-		if err := structs.ValidateNodePoolName(pool, invalidNames); err != nil {
+		if err := structs.ValidateNodePoolName(pool); err != nil {
 			c.Ui.Error(fmt.Sprintf("Invalid node pool: %v", err))
+			return false
+		}
+		if pool == structs.NodePoolAll {
+			c.Ui.Error(fmt.Sprintf("Invalid node pool: node is not allowed to register in node pool %q", structs.NodePoolAll))
 			return false
 		}
 	}

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -25,6 +25,7 @@ import (
 	checkpoint "github.com/hashicorp/go-checkpoint"
 	discover "github.com/hashicorp/go-discover"
 	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-set"
 	gsyslog "github.com/hashicorp/go-syslog"
 	"github.com/hashicorp/logutils"
 	"github.com/hashicorp/nomad/helper"
@@ -106,6 +107,7 @@ func (c *Command) readConfig() *Config {
 	flags.StringVar(&cmdConfig.Client.StateDir, "state-dir", "", "")
 	flags.StringVar(&cmdConfig.Client.AllocDir, "alloc-dir", "", "")
 	flags.StringVar(&cmdConfig.Client.NodeClass, "node-class", "", "")
+	flags.StringVar(&cmdConfig.Client.NodePool, "node-pool", "", "")
 	flags.StringVar(&servers, "servers", "", "")
 	flags.Var((*flaghelper.StringFlag)(&meta), "meta", "")
 	flags.StringVar(&cmdConfig.Client.NetworkInterface, "network-interface", "", "")
@@ -379,6 +381,18 @@ func (c *Command) IsValidConfig(config, cmdConfig *Config) bool {
 		return false
 	}
 
+	// Validate node pool name early to prevent agent from starting but the
+	// client failing to register.
+	if pool := config.Client.NodePool; pool != "" {
+		invalidNames := set.From([]string{
+			structs.NodePoolAll,
+		})
+		if err := structs.ValidateNodePoolName(pool, invalidNames); err != nil {
+			c.Ui.Error(fmt.Sprintf("Invalid node pool: %v", err))
+			return false
+		}
+	}
+
 	if config.Client.MinDynamicPort < 0 || config.Client.MinDynamicPort > structs.MaxValidPort {
 		c.Ui.Error(fmt.Sprintf("Invalid dynamic port range: min_dynamic_port=%d", config.Client.MinDynamicPort))
 		return false
@@ -629,6 +643,7 @@ func (c *Command) AutocompleteFlags() complete.Flags {
 		"-state-dir":                     complete.PredictDirs("*"),
 		"-alloc-dir":                     complete.PredictDirs("*"),
 		"-node-class":                    complete.PredictAnything,
+		"-node-pool":                     complete.PredictAnything,
 		"-servers":                       complete.PredictAnything,
 		"-meta":                          complete.PredictAnything,
 		"-config":                        configFilePredictor,
@@ -1406,6 +1421,10 @@ Client Options:
   -node-class
     Mark this node as a member of a node-class. This can be used to label
     similar node types.
+
+  -node-pool
+    Register this node under this node pool. If the node pool does not exist it
+    will be created automatically when the node registers.
 
   -meta
     User specified metadata to associated with the node. Each instance of -meta

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -1423,7 +1423,7 @@ Client Options:
     similar node types.
 
   -node-pool
-    Register this node under this node pool. If the node pool does not exist it
+    Register this node in this node pool. If the node pool does not exist it
     will be created automatically when the node registers.
 
   -meta

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -71,6 +71,10 @@ func TestCommand_Args(t *testing.T) {
 			[]string{"-client", "-data-dir=" + tmpDir, "-meta=invalid.=inaccessible-value"},
 			"Invalid Client.Meta key: invalid.",
 		},
+		{
+			[]string{"-client", "-node-pool=not@valid"},
+			"Invalid node pool",
+		},
 	}
 	for _, tc := range tcases {
 		// Make a new command. We preemptively close the shutdownCh
@@ -304,6 +308,26 @@ func TestIsValidConfig(t *testing.T) {
 				DataDir: "foo/bar",
 			},
 			err: "must be given as an absolute",
+		},
+		{
+			name: "InvalidNodePoolChar",
+			conf: Config{
+				Client: &ClientConfig{
+					Enabled:  true,
+					NodePool: "not@valid",
+				},
+			},
+			err: "Invalid node pool",
+		},
+		{
+			name: "InvalidNodePoolName",
+			conf: Config{
+				Client: &ClientConfig{
+					Enabled:  true,
+					NodePool: structs.NodePoolAll,
+				},
+			},
+			err: "not allowed",
 		},
 		{
 			name: "NegativeMinDynamicPort",

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -204,6 +204,11 @@ type ClientConfig struct {
 	// NodeClass is used to group the node by class
 	NodeClass string `hcl:"node_class"`
 
+	// NodePool defines the node pool in which the client is registered. If the
+	// node pool does not exist it will be created automatically when the node
+	// registers.
+	NodePool string `hcl:"node_pool"`
+
 	// Options is used for configuration of nomad internals,
 	// like fingerprinters and drivers. The format is:
 	//
@@ -1269,6 +1274,7 @@ func DefaultConfig() *Config {
 		UI:             config.DefaultUIConfig(),
 		Client: &ClientConfig{
 			Enabled:               false,
+			NodePool:              structs.NodePoolDefault,
 			MaxKillTimeout:        "30s",
 			ClientMinPort:         14000,
 			ClientMaxPort:         14512,
@@ -2055,6 +2061,9 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	}
 	if b.NodeClass != "" {
 		result.NodeClass = b.NodeClass
+	}
+	if b.NodePool != "" {
+		result.NodePool = b.NodePool
 	}
 	if b.NetworkInterface != "" {
 		result.NetworkInterface = b.NetworkInterface

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -109,6 +109,7 @@ func TestConfig_Merge(t *testing.T) {
 			StateDir:  "/tmp/state1",
 			AllocDir:  "/tmp/alloc1",
 			NodeClass: "class1",
+			NodePool:  "dev",
 			Options: map[string]string{
 				"foo": "bar",
 			},
@@ -297,6 +298,7 @@ func TestConfig_Merge(t *testing.T) {
 			StateDir:  "/tmp/state2",
 			AllocDir:  "/tmp/alloc2",
 			NodeClass: "class2",
+			NodePool:  "dev",
 			Servers:   []string{"server2"},
 			Meta: map[string]string{
 				"baz": "zip",

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -250,7 +250,7 @@ func (c *NodeStatusCommand) Run(args []string) int {
 			return 0
 		}
 
-		out[0] = "ID|DC|Name|Class|"
+		out[0] = "ID|Node Pool|DC|Name|Class|"
 
 		if c.os {
 			out[0] += "OS|"
@@ -267,8 +267,9 @@ func (c *NodeStatusCommand) Run(args []string) int {
 		}
 
 		for i, node := range nodes {
-			out[i+1] = fmt.Sprintf("%s|%s|%s|%s",
+			out[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s",
 				limit(node.ID, c.length),
+				node.NodePool,
 				node.Datacenter,
 				node.Name,
 				node.NodeClass)
@@ -480,6 +481,7 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 	basic := []string{
 		fmt.Sprintf("ID|%s", node.ID),
 		fmt.Sprintf("Name|%s", node.Name),
+		fmt.Sprintf("Node Pool|%s", node.NodePool),
 		fmt.Sprintf("Class|%s", node.NodeClass),
 		fmt.Sprintf("DC|%s", node.Datacenter),
 		fmt.Sprintf("Drain|%v", formatDrain(node)),

--- a/nomad/mock/node.go
+++ b/nomad/mock/node.go
@@ -110,6 +110,7 @@ func Node() *structs.Node {
 			"version":  "5.6",
 		},
 		NodeClass:             "linux-medium-pci",
+		NodePool:              structs.NodePoolDefault,
 		Status:                structs.NodeStatusReady,
 		SchedulingEligibility: structs.NodeSchedulingEligible,
 	}

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set"
 	vapi "github.com/hashicorp/vault/api"
 	"golang.org/x/sync/errgroup"
 
@@ -139,12 +138,12 @@ func (n *Node) Register(args *structs.NodeRegisterRequest, reply *structs.NodeUp
 	// Validate node pool value if provided. The node is canonicalized in the
 	// FSM, where an empty node pool is set to "default".
 	if args.Node.NodePool != "" {
-		invalidNames := set.From([]string{
-			structs.NodePoolAll,
-		})
-		err := structs.ValidateNodePoolName(args.Node.NodePool, invalidNames)
+		err := structs.ValidateNodePoolName(args.Node.NodePool)
 		if err != nil {
 			return fmt.Errorf("invalid node pool: %v", err)
+		}
+		if args.Node.NodePool == structs.NodePoolAll {
+			return fmt.Errorf("node is not allowed to register in node pool %q", structs.NodePoolAll)
 		}
 	}
 

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -215,6 +215,91 @@ func TestClientEndpoint_Register_SecretMismatch(t *testing.T) {
 	}
 }
 
+func TestClientEndpoint_Register_NodePool(t *testing.T) {
+	ci.Parallel(t)
+
+	s, cleanupS := TestServer(t, nil)
+	defer cleanupS()
+	codec := rpcClient(t, s)
+	testutil.WaitForLeader(t, s.RPC)
+
+	testCases := []struct {
+		name        string
+		pool        string
+		expectedErr string
+		validateFn  func(*testing.T, *structs.Node)
+	}{
+		{
+			name:        "invalid node pool name",
+			pool:        "not@valid",
+			expectedErr: "invalid node pool: invalid name",
+		},
+		{
+			name:        "built-in pool all not allowed",
+			pool:        structs.NodePoolAll,
+			expectedErr: `invalid node pool: node pool name "all" is not allowed`,
+		},
+		{
+			name: "set default node pool when empty",
+			pool: "",
+			validateFn: func(t *testing.T, node *structs.Node) {
+				state := s.fsm.State()
+				ws := memdb.NewWatchSet()
+
+				// Verify node was registered with default node pool.
+				got, err := state.NodeByID(ws, node.ID)
+				must.NoError(t, err)
+				must.NotNil(t, got)
+				must.Eq(t, structs.NodePoolDefault, got.NodePool)
+			},
+		},
+		{
+			name: "set node pool requested",
+			pool: "my-pool",
+			validateFn: func(t *testing.T, node *structs.Node) {
+				state := s.fsm.State()
+				ws := memdb.NewWatchSet()
+
+				// Verify node was registered.
+				got, err := state.NodeByID(ws, node.ID)
+				must.NoError(t, err)
+				must.NotNil(t, got)
+
+				// Verify node pool was created.
+				pool, err := state.NodePoolByName(ws, "my-pool")
+				must.NoError(t, err)
+				must.NotNil(t, pool)
+
+				// Verify node was added to the pool.
+				must.Eq(t, "my-pool", got.NodePool)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := mock.Node()
+			node.NodePool = tc.pool
+
+			req := &structs.NodeRegisterRequest{
+				Node:         node,
+				WriteRequest: structs.WriteRequest{Region: "global"},
+			}
+			var resp structs.GenericResponse
+			err := msgpackrpc.CallWithCodec(codec, "Node.Register", req, &resp)
+
+			if tc.expectedErr != "" {
+				must.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				must.NoError(t, err)
+				if tc.validateFn != nil {
+					tc.validateFn(t, req.Node)
+				}
+			}
+		})
+	}
+}
+
 // Test the deprecated single node deregistration path
 func TestClientEndpoint_DeregisterOne(t *testing.T) {
 	ci.Parallel(t)

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -237,7 +237,7 @@ func TestClientEndpoint_Register_NodePool(t *testing.T) {
 		{
 			name:        "built-in pool all not allowed",
 			pool:        structs.NodePoolAll,
-			expectedErr: `invalid node pool: node pool name "all" is not allowed`,
+			expectedErr: `node is not allowed to register in node pool "all"`,
 		},
 		{
 			name: "set default node pool when empty",

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -900,6 +900,14 @@ func (s *StateStore) UpsertNode(msgType structs.MessageType, index uint64, node 
 	txn := s.db.WriteTxnMsgT(msgType, index)
 	defer txn.Abort()
 
+	// Create node pool if necessary.
+	if node.NodePool != "" {
+		_, err := s.fetchOrCreateNodePoolTxn(txn, index, node.NodePool)
+		if err != nil {
+			return err
+		}
+	}
+
 	err := upsertNodeTxn(txn, index, node)
 	if err != nil {
 		return nil

--- a/nomad/structs/node_class.go
+++ b/nomad/structs/node_class.go
@@ -45,7 +45,7 @@ func (n *Node) ComputeClass() error {
 // included in the computed node class.
 func (n Node) HashInclude(field string, v interface{}) (bool, error) {
 	switch field {
-	case "Datacenter", "Attributes", "Meta", "NodeClass", "NodeResources":
+	case "Datacenter", "Attributes", "Meta", "NodeClass", "NodePool", "NodeResources":
 		return true, nil
 	default:
 		return false, nil

--- a/nomad/structs/node_class_test.go
+++ b/nomad/structs/node_class_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/uuid"
 	psstructs "github.com/hashicorp/nomad/plugins/shared/structs"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,6 +52,7 @@ func testNode() *Node {
 			"pci-dss": "true",
 		},
 		NodeClass: "linux-medium-pci",
+		NodePool:  "dev",
 		Status:    NodeStatusReady,
 	}
 }
@@ -216,6 +218,25 @@ func TestNode_ComputedClass_Meta(t *testing.T) {
 	if old != n.ComputedClass {
 		t.Fatal("ComputeClass() didn't ignore unique meta key")
 	}
+}
+
+func TestNode_ComputedClass_NodePool(t *testing.T) {
+	ci.Parallel(t)
+
+	// Create a node and get its computed class.
+	n := testNode()
+	err := n.ComputeClass()
+	must.NoError(t, err)
+	must.NotEq(t, "", n.ComputedClass)
+	old := n.ComputedClass
+
+	// Modify node pool and expect computed class to change.
+	n.NodePool = "prod"
+	err = n.ComputeClass()
+	must.NoError(t, err)
+	must.NotEq(t, "", n.ComputedClass)
+	must.NotEq(t, old, n.ComputedClass)
+	old = n.ComputedClass
 }
 
 func TestNode_EscapedConstraints(t *testing.T) {

--- a/nomad/structs/node_pool.go
+++ b/nomad/structs/node_pool.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set"
 	"golang.org/x/exp/maps"
 )
 
@@ -34,13 +33,9 @@ var (
 )
 
 // ValidadeNodePoolName returns an error if a node pool name is invalid.
-func ValidateNodePoolName(pool string, invalidNames *set.Set[string]) error {
+func ValidateNodePoolName(pool string) error {
 	if !validNodePoolName.MatchString(pool) {
 		return fmt.Errorf("invalid name %q, must match regex %s", pool, validNodePoolName)
-	}
-
-	if invalidNames != nil && invalidNames.Contains(pool) {
-		return fmt.Errorf("node pool name %q is not allowed", pool)
 	}
 	return nil
 }
@@ -74,7 +69,7 @@ func (n *NodePool) GetID() string {
 func (n *NodePool) Validate() error {
 	var mErr *multierror.Error
 
-	mErr = multierror.Append(mErr, ValidateNodePoolName(n.Name, nil))
+	mErr = multierror.Append(mErr, ValidateNodePoolName(n.Name))
 
 	if len(n.Description) > maxNodePoolDescriptionLength {
 		mErr = multierror.Append(mErr, fmt.Errorf("description longer than %d", maxNodePoolDescriptionLength))

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2109,6 +2109,9 @@ type Node struct {
 	// together for the purpose of determining scheduling pressure.
 	NodeClass string
 
+	// NodePool is the node pool the node belongs to.
+	NodePool string
+
 	// ComputedClass is a unique id that identifies nodes with a common set of
 	// attributes and capabilities.
 	ComputedClass string
@@ -2196,6 +2199,10 @@ func (n *Node) Ready() bool {
 func (n *Node) Canonicalize() {
 	if n == nil {
 		return
+	}
+
+	if n.NodePool == "" {
+		n.NodePool = NodePoolDefault
 	}
 
 	// Ensure SchedulingEligibility is correctly set whenever draining so the plan applier and other scheduling logic
@@ -2356,6 +2363,7 @@ func (n *Node) Stub(fields *NodeStubFields) *NodeListStub {
 		Datacenter:            n.Datacenter,
 		Name:                  n.Name,
 		NodeClass:             n.NodeClass,
+		NodePool:              n.NodePool,
 		Version:               n.Attributes["nomad.version"],
 		Drain:                 n.DrainStrategy != nil,
 		SchedulingEligibility: n.SchedulingEligibility,
@@ -2393,6 +2401,7 @@ type NodeListStub struct {
 	Attributes            map[string]string `json:",omitempty"`
 	Datacenter            string
 	Name                  string
+	NodePool              string
 	NodeClass             string
 	Version               string
 	Drain                 bool

--- a/website/content/api-docs/nodes.mdx
+++ b/website/content/api-docs/nodes.mdx
@@ -141,6 +141,7 @@ $ curl \
     "ModifyIndex": 2526,
     "Name": "nomad-4",
     "NodeClass": "",
+    "NodePool": "default",
     "SchedulingEligibility": "eligible",
     "Status": "ready",
     "StatusDescription": "",
@@ -348,6 +349,7 @@ $ curl \
   "ModifyIndex": 14,
   "Name": "mew",
   "NodeClass": "",
+  "NodePool": "default",
   "NodeResources": {
     "Cpu": {
       "CpuShares": 32000

--- a/website/content/docs/commands/agent.mdx
+++ b/website/content/docs/commands/agent.mdx
@@ -121,6 +121,9 @@ via CLI arguments. The `agent` command accepts the following arguments:
 - `-node-class=<class>`: Equivalent to the Client [node_class]
   config option.
 
+- `-node-pool=<node-pool>`: Equivalent to the Client [node_pool]
+  config option.
+
 - `-plugin-dir=<path>`: Equivalent to the [plugin_dir] config option.
 
 - `-region=<region>`: Equivalent to the [region] config option.
@@ -205,6 +208,7 @@ via CLI arguments. The `agent` command accepts the following arguments:
 [name]: /nomad/docs/configuration#name
 [network_interface]: /nomad/docs/configuration/client#network_interface
 [node_class]: /nomad/docs/configuration/client#node_class
+[node_pool]: /nomad/docs/configuration/client#node_pool
 [nomad agent]: /nomad/docs/operations/nomad-agent
 [plugin_dir]: /nomad/docs/configuration#plugin_dir
 [region]: /nomad/docs/configuration#region

--- a/website/content/docs/commands/node/status.mdx
+++ b/website/content/docs/commands/node/status.mdx
@@ -67,18 +67,18 @@ List view:
 
 ```shell-session
 $ nomad node status
-ID        DC   Name   Class   Drain  Eligibility  Status
-a72dfba2  dc1  node1  <none>  false  eligible     ready
-1f3f03ea  dc1  node2  <none>  false  eligible     ready
+ID        Node Pool  DC   Name   Class   Drain  Eligibility  Status
+a72dfba2  default    dc1  node1  <none>  false  eligible     ready
+1f3f03ea  dev        dc1  node2  <none>  false  eligible     ready
 ```
 
 List view, with operating system name:
 
 ```shell-session
 $ nomad node status -os
-ID        DC   Name   Class   OS      Drain  Eligibility  Status
-a72dfba2  dc1  node1  <none>  ubuntu  false  eligible     ready
-f73e3993  dc1  node2  <none>  centos  false  eligible     ready
+ID        Node Pool  DC   Name   Class   OS      Drain  Eligibility  Status
+a72dfba2  default    dc1  node1  <none>  ubuntu  false  eligible     ready
+f73e3993  dev        dc1  node2  <none>  centos  false  eligible     ready
 ```
 
 List view, with quiet:
@@ -91,28 +91,29 @@ $ nomad node status -quiet
 f35be281-85a5-d1e6-d268-6e8a6f0684df
 ```
 
-**NOTE**: `-quiet` cannot be used in conjuction with `-verbose` or `-json`.
+**NOTE**: `-quiet` cannot be used in conjunction with `-verbose` or `-json`.
 
 List view, with running allocations:
 
 ```shell-session
 $ nomad node status -allocs
-ID        DC   Name   Class   Drain  Eligibility  Status  Running Allocs
-4d2ba53b  dc1  node1  <none>  false  eligible     ready   1
-34dfba32  dc1  node2  <none>  false  eligible     ready   3
+ID        Node Pool  DC   Name   Class   Drain  Eligibility  Status  Running Allocs
+4d2ba53b  default    dc1  node1  <none>  false  eligible     ready   1
+34dfba32  dev        dc1  node2  <none>  false  eligible     ready   3
 ```
 
 Single-node view in short mode:
 
 ```shell-session
 $ nomad node status -short 1f3f03ea
-ID     = c754da1f
-Name   = nomad
-Class  = <none>
-DC     = dc1
-Drain  = false
-Status = ready
-Uptime = 17h2m25s
+ID        = c754da1f
+Name      = nomad
+Node Pool = default
+Class     = <none>
+DC        = dc1
+Drain     = false
+Status    = ready
+Uptime    = 17h2m25s
 
 Allocations
 ID        Eval ID   Job ID   Task Group  Desired Status  Client Status
@@ -123,13 +124,14 @@ Full output for a single node:
 
 ```shell-session
 $ nomad node status 1f3f03ea
-ID     = c754da1f
-Name    = nomad-server01
-Class   = <none>
-DC      = dc1
-Drain   = false
-Status  = ready
-Uptime  = 17h42m50s
+ID        = c754da1f
+Name      = nomad-server01
+Node Pool = default
+Class     = <none>
+DC        = dc1
+Drain     = false
+Status    = ready
+Uptime    = 17h42m50s
 
 Drivers
 Driver    Detected  Healthy
@@ -166,13 +168,14 @@ Using `-self` when on a Nomad Client:
 
 ```shell-session
 $ nomad node status -self
-ID     = c754da1f
-Name   = nomad-client01
-Class  = <none>
-DC     = dc1
-Drain  = false
-Status = ready
-Uptime = 17h7m41s
+ID        = c754da1f
+Name      = nomad-client01
+Node Pool = default
+Class     = <none>
+DC        = dc1
+Drain     = false
+Status    = ready
+Uptime    = 17h7m41s
 
 Drivers
 Driver    Detected  Healthy
@@ -236,13 +239,14 @@ Using `-stats` to see detailed to resource usage information on the node:
 
 ```shell-session
 $ nomad node status -stats c754da1f
-ID     = c754da1f
-Name   = nomad-client01
-Class  = <none>
-DC     = dc1
-Drain  = false
-Status = ready
-Uptime = 17h7m41s
+ID        = c754da1f
+Name      = nomad-client01
+Node Pool = default
+Class     = <none>
+DC        = dc1
+Drain     = false
+Status    = ready
+Uptime    = 17h7m41s
 
 Drivers
 Driver    Detected  Healthy
@@ -317,13 +321,14 @@ To view verbose information about the node:
 
 ```shell-session
 $ nomad node status -verbose c754da1f
-ID     = c754da1f-6337-b86d-47dc-2ef4c71aca14
-Name   = nomad
-Class  = <none>
-DC     = dc1
-Drain  = false
-Status = ready
-Uptime = 17h7m41s
+ID        = c754da1f-6337-b86d-47dc-2ef4c71aca14
+Name      = nomad
+Node Pool = default
+Class     = <none>
+DC        = dc1
+Drain     = false
+Status    = ready
+Uptime    = 17h7m41s
 
 Host Volumes
 Name  ReadOnly  Source

--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -86,6 +86,11 @@ client {
   group client nodes by user-defined class. This can be used during job
   placement as a filter.
 
+- `node_pool` `(string: "default")` - Specifies the node pool in which the
+  client is registered. If the node pool does not exist yet, it will be created
+  automatically when the node registers with the cluster. If not specified the
+  `default` node pool is used.
+
 - `options` <code>([Options](#options-parameters): nil)</code> - Specifies a
   key-value mapping of internal configuration for clients, such as for driver
   configuration.


### PR DESCRIPTION
Add new client configuration `node_pool` to allow assigning a node to a pool. If the node pool does not exist yet, it will be created automatically when the node registers. The built-in `all` node pool is not allowed to be used.

Doc preview:
https://nomad-git-f-node-pools-register-node-hashicorp.vercel.app/nomad/docs/configuration/client#node_pool