### PR TITLE
node pools: add event stream support

### DIFF
--- a/api/event_stream.go
+++ b/api/event_stream.go
@@ -19,6 +19,7 @@ const (
 	TopicAllocation Topic = "Allocation"
 	TopicJob        Topic = "Job"
 	TopicNode       Topic = "Node"
+	TopicNodePool   Topic = "NodePool"
 	TopicService    Topic = "Service"
 	TopicAll        Topic = "*"
 )
@@ -99,6 +100,16 @@ func (e *Event) Node() (*Node, error) {
 	return out.Node, nil
 }
 
+// NodePool returns a NodePool struct from a given event payload. If the Event
+// Topic is NodePool this will return a valid NodePool.
+func (e *Event) NodePool() (*NodePool, error) {
+	out, err := e.decodePayload()
+	if err != nil {
+		return nil, err
+	}
+	return out.NodePool, nil
+}
+
 // Service returns a ServiceRegistration struct from a given event payload. If
 // the Event Topic is Service this will return a valid ServiceRegistration.
 func (e *Event) Service() (*ServiceRegistration, error) {
@@ -115,6 +126,7 @@ type eventPayload struct {
 	Evaluation *Evaluation          `mapstructure:"Evaluation"`
 	Job        *Job                 `mapstructure:"Job"`
 	Node       *Node                `mapstructure:"Node"`
+	NodePool   *NodePool            `mapstructure:"NodePool"`
 	Service    *ServiceRegistration `mapstructure:"Service"`
 }
 

--- a/api/event_stream_test.go
+++ b/api/event_stream_test.go
@@ -42,6 +42,10 @@ func TestTopic_String(t *testing.T) {
 			expectedOutput: "Node",
 		},
 		{
+			inputTopic:     TopicNodePool,
+			expectedOutput: "NodePool",
+		},
+		{
 			inputTopic:     TopicService,
 			expectedOutput: "Service",
 		},
@@ -299,6 +303,19 @@ func TestEventStream_PayloadValueHelpers(t *testing.T) {
 				must.Eq(t, &Node{
 					ID:         "some-id",
 					Datacenter: "some-dc-id",
+				}, n)
+			},
+		},
+		{
+			desc:  "node_pool",
+			input: []byte(`{"Topic":"NodePool","Payload":{"NodePool":{"Description":"prod pool","Name":"prod"}}}`),
+			expectFn: func(t *testing.T, event Event) {
+				must.Eq(t, TopicNodePool, event.Topic)
+				n, err := event.NodePool()
+				must.NoError(t, err)
+				must.Eq(t, &NodePool{
+					Name:        "prod",
+					Description: "prod pool",
 				}, n)
 			},
 		},

--- a/nomad/state/events.go
+++ b/nomad/state/events.go
@@ -12,6 +12,8 @@ var MsgTypeEvents = map[structs.MessageType]string{
 	structs.NodeRegisterRequestType:                      structs.TypeNodeRegistration,
 	structs.NodeDeregisterRequestType:                    structs.TypeNodeDeregistration,
 	structs.UpsertNodeEventsType:                         structs.TypeNodeEvent,
+	structs.NodePoolUpsertRequestType:                    structs.TypeNodePoolUpserted,
+	structs.NodePoolDeleteRequestType:                    structs.TypeNodePoolDeleted,
 	structs.EvalUpdateRequestType:                        structs.TypeEvalUpdated,
 	structs.AllocClientUpdateRequestType:                 structs.TypeAllocationUpdated,
 	structs.JobRegisterRequestType:                       structs.TypeJobRegistered,
@@ -135,6 +137,18 @@ func eventFromChange(change memdb.Change) (structs.Event, bool) {
 				Key:   before.ID,
 				Payload: &structs.NodeStreamEvent{
 					Node: before,
+				},
+			}, true
+		case TableNodePools:
+			before, ok := change.Before.(*structs.NodePool)
+			if !ok {
+				return structs.Event{}, false
+			}
+			return structs.Event{
+				Topic: structs.TopicNodePool,
+				Key:   before.Name,
+				Payload: &structs.NodePoolEvent{
+					NodePool: before,
 				},
 			}, true
 		case TableServiceRegistrations:
@@ -286,6 +300,18 @@ func eventFromChange(change memdb.Change) (structs.Event, bool) {
 			Key:   after.ID,
 			Payload: &structs.NodeStreamEvent{
 				Node: after,
+			},
+		}, true
+	case TableNodePools:
+		after, ok := change.After.(*structs.NodePool)
+		if !ok {
+			return structs.Event{}, false
+		}
+		return structs.Event{
+			Topic: structs.TopicNodePool,
+			Key:   after.Name,
+			Payload: &structs.NodePoolEvent{
+				NodePool: after,
 			},
 		}, true
 	case "deployment":

--- a/nomad/state/state_store_node_pools.go
+++ b/nomad/state/state_store_node_pools.go
@@ -24,7 +24,7 @@ func (s *StateStore) nodePoolInit() error {
 	}
 
 	return s.UpsertNodePools(
-		structs.NodePoolUpsertRequestType,
+		structs.SystemInitializationType,
 		1,
 		[]*structs.NodePool{allNodePool, defaultNodePool},
 	)

--- a/nomad/stream/event_broker.go
+++ b/nomad/stream/event_broker.go
@@ -367,6 +367,12 @@ func aclAllowsSubscription(aclObj *acl.ACL, subReq *SubscribeRequest) bool {
 			if ok := aclObj.AllowNodeRead(); !ok {
 				return false
 			}
+		case structs.TopicNodePool:
+			// Require management token for node pools since we can't filter
+			// out node pools the token doesn't have access to.
+			if ok := aclObj.IsManagement(); !ok {
+				return false
+			}
 		default:
 			if ok := aclObj.IsManagement(); !ok {
 				return false

--- a/nomad/stream/event_broker_test.go
+++ b/nomad/stream/event_broker_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
 
 	"github.com/stretchr/testify/require"
 )
@@ -987,6 +988,88 @@ func TestEventBroker_handleACLUpdates_tokenExpiry(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEventBroker_NodePool_ACL(t *testing.T) {
+	ci.Parallel(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	testCases := []struct {
+		name        string
+		token       *structs.ACLToken
+		policy      *structs.ACLPolicy
+		expectedErr string
+	}{
+		{
+			name: "management token",
+			token: &structs.ACLToken{
+				AccessorID: uuid.Generate(),
+				SecretID:   uuid.Generate(),
+				Type:       structs.ACLManagementToken,
+			},
+		},
+		{
+			name: "client token",
+			token: &structs.ACLToken{
+				AccessorID: uuid.Generate(),
+				SecretID:   uuid.Generate(),
+				Type:       structs.ACLClientToken,
+			},
+			expectedErr: structs.ErrPermissionDenied.Error(),
+		},
+		{
+			name: "node pool read",
+			token: &structs.ACLToken{
+				AccessorID: uuid.Generate(),
+				SecretID:   uuid.Generate(),
+				Type:       structs.ACLClientToken,
+				Policies:   []string{"node-pool-read"},
+			},
+			policy: &structs.ACLPolicy{
+				Name:  "node-pool-read",
+				Rules: `node_pool "*" { policy = "read" }`,
+			},
+			expectedErr: structs.ErrPermissionDenied.Error(),
+		},
+		{
+			name: "node pool write",
+			token: &structs.ACLToken{
+				AccessorID: uuid.Generate(),
+				SecretID:   uuid.Generate(),
+				Type:       structs.ACLClientToken,
+				Policies:   []string{"node-pool-write"},
+			},
+			policy: &structs.ACLPolicy{
+				Name:  "node-pool-write",
+				Rules: `node_pool "*" { policy = "write" }`,
+			},
+			expectedErr: structs.ErrPermissionDenied.Error(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tokenProvider := &fakeACLTokenProvider{token: tc.token, policy: tc.policy}
+			aclDelegate := &fakeACLDelegate{tokenProvider: tokenProvider}
+
+			publisher, err := NewEventBroker(ctx, aclDelegate, EventBrokerCfg{})
+			must.NoError(t, err)
+
+			_, _, err = publisher.SubscribeWithACLCheck(&SubscribeRequest{
+				Topics: map[structs.Topic][]string{structs.TopicNodePool: {"*"}},
+				Token:  tc.token.SecretID,
+			})
+
+			if tc.expectedErr != "" {
+				must.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				must.NoError(t, err)
+			}
+		})
+	}
+
 }
 
 func consumeSubscription(ctx context.Context, sub *Subscription) <-chan subNextResult {

--- a/nomad/structs/event.go
+++ b/nomad/structs/event.go
@@ -24,6 +24,7 @@ const (
 	TopicAllocation     Topic = "Allocation"
 	TopicJob            Topic = "Job"
 	TopicNode           Topic = "Node"
+	TopicNodePool       Topic = "NodePool"
 	TopicACLPolicy      Topic = "ACLPolicy"
 	TopicACLToken       Topic = "ACLToken"
 	TopicACLRole        Topic = "ACLRole"
@@ -37,6 +38,8 @@ const (
 	TypeNodeEligibilityUpdate         = "NodeEligibility"
 	TypeNodeDrain                     = "NodeDrain"
 	TypeNodeEvent                     = "NodeStreamEvent"
+	TypeNodePoolUpserted              = "NodePoolUpserted"
+	TypeNodePoolDeleted               = "NodePoolDeleted"
 	TypeDeploymentUpdate              = "DeploymentStatusUpdate"
 	TypeDeploymentPromotion           = "DeploymentPromotion"
 	TypeDeploymentAllocHealth         = "DeploymentAllocHealth"
@@ -131,6 +134,11 @@ type DeploymentEvent struct {
 // NodeStreamEvent holds a newly updated Node
 type NodeStreamEvent struct {
 	Node *Node
+}
+
+// NodePoolEvent holds a newly updated NodePool.
+type NodePoolEvent struct {
+	NodePool *NodePool
 }
 
 type ACLTokenEvent struct {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -134,6 +134,11 @@ const (
 )
 
 const (
+	// SystemInitializationType is used for messages that initialize parts of
+	// the system, such as the state store. These messages are not included in
+	// the event stream.
+	SystemInitializationType MessageType = 127
+
 	// IgnoreUnknownTypeFlag is set along with a MessageType
 	// to indicate that the message type can be safely ignored
 	// if it is not recognized. This is for future proofing, so

--- a/website/content/api-docs/events.mdx
+++ b/website/content/api-docs/events.mdx
@@ -39,6 +39,7 @@ by default, requiring a management token.
 | `Deployment` | `namespace:read-job` |
 | `Evaluation` | `namespace:read-job` |
 | `Node`       | `node:read`          |
+| `NodePool`   | `management`         |
 | `Service`    | `namespace:read-job` |
 
 ### Parameters
@@ -75,6 +76,7 @@ by default, requiring a management token.
 | Deployment | Deployment                      |
 | Node       | Node                            |
 | NodeDrain  | Node                            |
+| NodePool   | NodePool                        |
 | Service    | Service Registrations           |
 
 ### Event Types
@@ -102,6 +104,8 @@ by default, requiring a management token.
 | NodeEligibility               |
 | NodeDrain                     |
 | NodeEvent                     |
+| NodePoolUpserted              |
+| NodePoolDeleted               |
 | PlanResult                    |
 | ServiceRegistration           |
 | ServiceDeregistration         |


### PR DESCRIPTION
Add event stream support for node pools. Upsert and delete actions are 

Doc preview:
https://nomad-git-f-node-pools-event-stream-hashicorp.vercel.app/nomad/api-docs/events