### PR TITLE
node pools: fix node upsert and state mutation tests

### DIFF
--- a/nomad/node_pool_endpoint_test.go
+++ b/nomad/node_pool_endpoint_test.go
@@ -440,7 +440,7 @@ func TestNodePoolEndpoint_GetNodePool(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Make node pool list request.
+			// Make node pool fetch request.
 			req := &structs.NodePoolSpecificRequest{
 				QueryOptions: structs.QueryOptions{
 					Region: "global",
@@ -536,7 +536,7 @@ func TestNodePoolEndpoint_GetNodePool_ACL(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Make node pool list request.
+			// Make node pool fetch request.
 			req := &structs.NodePoolSpecificRequest{
 				QueryOptions: structs.QueryOptions{
 					Region:    "global",
@@ -581,6 +581,7 @@ func TestNodePoolEndpoint_GetNodePool_BlockingQuery(t *testing.T) {
 	})
 
 	// Update first node pool to trigger watcher.
+	pool1 = pool1.Copy()
 	pool1.Meta["updated"] = "true"
 	time.AfterFunc(300*time.Millisecond, func() {
 		s.fsm.State().UpsertNodePools(structs.MsgTypeTestSetup, 1002, []*structs.NodePool{pool1})

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -1304,12 +1304,6 @@ func TestStateStore_UpsertNode_NodePool(t *testing.T) {
 			expectedNewPool: true,
 		},
 		{
-			name:         "register new node with empty pool in default",
-			nodeID:       "",
-			poolName:     "",
-			expectedPool: structs.NodePoolDefault,
-		},
-		{
 			name:         "update existing node in existing pool",
 			nodeID:       nodeWithPoolID,
 			poolName:     devPoolName,
@@ -1323,12 +1317,6 @@ func TestStateStore_UpsertNode_NodePool(t *testing.T) {
 			expectedNewPool: true,
 		},
 		{
-			name:         "update existing node with empty pool in default",
-			nodeID:       nodeWithPoolID,
-			poolName:     "",
-			expectedPool: devPoolName,
-		},
-		{
 			name:         "update legacy node with pool",
 			nodeID:       nodeWithoutPoolID,
 			poolName:     devPoolName,
@@ -1340,12 +1328,6 @@ func TestStateStore_UpsertNode_NodePool(t *testing.T) {
 			poolName:        "new",
 			expectedPool:    "new",
 			expectedNewPool: true,
-		},
-		{
-			name:         "update legacy node with empty pool places it in default",
-			nodeID:       nodeWithoutPoolID,
-			poolName:     "",
-			expectedPool: structs.NodePoolDefault,
 		},
 	}
 
@@ -1384,11 +1366,14 @@ func TestStateStore_UpsertNode_NodePool(t *testing.T) {
 			default:
 				node = mock.Node()
 			}
+			node.NodePool = tc.poolName
 			err = state.UpsertNode(structs.MsgTypeTestSetup, 1003, node)
 			must.NoError(t, err)
 
 			// Verify that node is part of the expected pool.
-			must.Eq(t, tc.expectedPool, node.NodePool)
+			got, err := state.NodeByID(nil, node.ID)
+			must.NoError(t, err)
+			must.Eq(t, tc.expectedPool, got.NodePool)
 
 			// Fech pool.
 			pool, err := state.NodePoolByName(nil, tc.expectedPool)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -1360,9 +1360,9 @@ func TestStateStore_UpsertNode_NodePool(t *testing.T) {
 			var node *structs.Node
 			switch tc.nodeID {
 			case nodeWithPoolID:
-				node = nodeWithPool
+				node = nodeWithPool.Copy()
 			case nodeWithoutPoolID:
-				node = nodeWithoutPool
+				node = nodeWithoutPool.Copy()
 			default:
 				node = mock.Node()
 			}


### PR DESCRIPTION
Move tests that assumed canonicalization was been done in the state store to the FSM, where it actually happens, and fix some state store pointer mutation.