### PR TITLE
node pools: implement HTTP API to list jobs in pool

### DIFF
--- a/api/node_pools.go
+++ b/api/node_pools.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 )
 
@@ -86,6 +87,18 @@ func (n *NodePools) Delete(name string, w *WriteOptions) (*WriteMeta, error) {
 		return nil, err
 	}
 	return wm, nil
+}
+
+// ListJobs is used to list all the jobs in a node pool.
+func (n *NodePools) ListJobs(poolName string, q *QueryOptions) ([]*JobListStub, *QueryMeta, error) {
+	var resp []*JobListStub
+	qm, err := n.client.query(
+		fmt.Sprintf("/v1/node/pool/%s/jobs", url.PathEscape(poolName)),
+		&resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resp, qm, nil
 }
 
 // NodePool is used to serialize a node pool.

--- a/command/agent/node_pool_endpoint.go
+++ b/command/agent/node_pool_endpoint.go
@@ -28,6 +28,9 @@ func (s *HTTPServer) NodePoolSpecificRequest(resp http.ResponseWriter, req *http
 	case strings.HasSuffix(path, "/nodes"):
 		poolName := strings.TrimSuffix(path, "/nodes")
 		return s.nodePoolNodesList(resp, req, poolName)
+	case strings.HasSuffix(path, "/jobs"):
+		poolName := strings.TrimSuffix(path, "/jobs")
+		return s.nodePoolJobList(resp, req, poolName)
 	default:
 		return s.nodePoolCRUD(resp, req, path)
 	}
@@ -125,6 +128,10 @@ func (s *HTTPServer) nodePoolDelete(resp http.ResponseWriter, req *http.Request,
 }
 
 func (s *HTTPServer) nodePoolNodesList(resp http.ResponseWriter, req *http.Request, poolName string) (interface{}, error) {
+	if req.Method != http.MethodGet {
+		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
+	}
+
 	args := structs.NodePoolNodesRequest{
 		Name: poolName,
 	}
@@ -156,4 +163,45 @@ func (s *HTTPServer) nodePoolNodesList(resp http.ResponseWriter, req *http.Reque
 		out.Nodes = make([]*structs.NodeListStub, 0)
 	}
 	return out.Nodes, nil
+}
+
+func (s *HTTPServer) nodePoolJobList(resp http.ResponseWriter, req *http.Request, poolName string) (any, error) {
+	if req.Method != http.MethodGet {
+		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
+	}
+
+	args := structs.NodePoolJobsRequest{
+		Name: poolName,
+	}
+	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
+		return nil, nil
+	}
+
+	if args.Prefix != "" {
+		// the prefix argument is ambiguous for this endpoint (does it refer to
+		// the node pool name or the job names like /v1/jobs?) so the RPC
+		// handler ignores it
+		return nil, CodedError(http.StatusBadRequest, "prefix argument not allowed")
+	}
+
+	// Parse meta query param
+	args.Fields = &structs.JobStubFields{}
+	jobMeta, err := parseBool(req, "meta")
+	if err != nil {
+		return nil, err
+	}
+	if jobMeta != nil {
+		args.Fields.Meta = *jobMeta
+	}
+
+	var out structs.NodePoolJobsResponse
+	if err := s.agent.RPC("NodePool.ListJobs", &args, &out); err != nil {
+		return nil, err
+	}
+
+	setMeta(resp, &out.QueryMeta)
+	if out.Jobs == nil {
+		out.Jobs = make([]*structs.JobListStub, 0)
+	}
+	return out.Jobs, nil
 }

--- a/nomad/node_pool_endpoint.go
+++ b/nomad/node_pool_endpoint.go
@@ -312,21 +312,30 @@ func (n *NodePool) ListJobs(args *structs.NodePoolJobsRequest, reply *structs.No
 					},
 				}
 
-				if namespace == structs.AllNamespacesSentinel {
-					iter, err = store.JobsByPool(ws, args.Name)
+				if args.Name == structs.NodePoolAll {
+					if namespace == structs.AllNamespacesSentinel {
+						iter, err = store.Jobs(ws)
+					} else {
+						iter, err = store.JobsByNamespace(ws, namespace)
+					}
 				} else {
-					iter, err = store.JobsByNamespace(ws, namespace)
-					filters = append(filters,
-						paginator.GenericFilter{
-							Allow: func(raw interface{}) (bool, error) {
-								job := raw.(*structs.Job)
-								if job == nil || job.NodePool != args.Name {
-									return false, nil
-								}
-								return true, nil
-							},
-						})
+					if namespace == structs.AllNamespacesSentinel {
+						iter, err = store.JobsByPool(ws, args.Name)
+					} else {
+						iter, err = store.JobsByNamespace(ws, namespace)
+						filters = append(filters,
+							paginator.GenericFilter{
+								Allow: func(raw interface{}) (bool, error) {
+									job := raw.(*structs.Job)
+									if job == nil || job.NodePool != args.Name {
+										return false, nil
+									}
+									return true, nil
+								},
+							})
+					}
 				}
+
 				if err != nil {
 					return err
 				}

--- a/website/content/api-docs/node-pools.mdx
+++ b/website/content/api-docs/node-pools.mdx
@@ -342,4 +342,96 @@ $ nomad operator api /v1/node/pool/prod-eng/nodes?os=true
 ]
 ```
 
+
+# List Node Pool Jobs
+
+This endpoint lists the jobs in a node pool.
+
+| Method | Path                             | Produces           |
+| ------ | -------------------------------- | ------------------ |
+| `GET`  | `/v1/node/pool/:node_pool/jobs` | `application/json` |
+
+The table below shows this endpoint's support for
+[blocking queries](/nomad/api-docs#blocking-queries) and
+[required ACLs](/nomad/api-docs#acls).
+
+| Blocking Queries | ACL Required                        |
+| ---------------- | ----------------------------------- |
+| `YES`            | `namespace:read` <br /> `node_pool:read` |
+
+### Parameters
+
+- `:node_pool` `(string: <required>)`- Specifies the node pool to list jobs.
+
+- `filter` `(string: "")` - Specifies the [expression](/nomad/api-docs#filtering)
+  used to filter the results. Consider using pagination to reduce resource used
+  to serve the request.
+
+- `meta` `(bool: false)` - If set, jobs returned will include a
+  [meta](/nomad/docs/job-specification/meta) field containing key-value pairs
+  provided in the job specification's `meta` block.
+
+- `namespace` `(string: "default")` - Specifies the target namespace. Specifying
+  `*` will return all jobs across all the authorized namespaces.
+
+- `next_token` `(string: "")` - This endpoint supports paging. The `next_token`
+  parameter accepts a string which identifies the next expected job. This value
+  can be obtained from the `X-Nomad-NextToken` header from the previous
+  response.
+
+- `per_page` `(int: 0)` - Specifies a maximum number of jobs to return for this
+  request. If omitted, the response is not paginated. The value of the
+  `X-Nomad-NextToken` header of the last response can be used as the
+  `next_token` of the next request to fetch additional pages.
+
+### Sample Request
+
+```shell-session
+$ nomad operator api /v1/node/pool/prod-eng/jobs
+```
+
+```shell-session
+$ nomad operator api /v1/node/pool/prod-eng/jobs?namespace=prod
+```
+
+### Sample Response
+
+```json
+[
+  {
+    "ID": "example",
+    "ParentID": "",
+    "Name": "example",
+    "Type": "service",
+    "Priority": 50,
+    "Status": "pending",
+    "StatusDescription": "",
+    "JobSummary": {
+      "JobID": "example",
+      "Namespace": "default",
+      "Summary": {
+        "cache": {
+          "Queued": 1,
+          "Complete": 1,
+          "Failed": 0,
+          "Running": 0,
+          "Starting": 0,
+          "Lost": 0
+        }
+      },
+      "Children": {
+        "Pending": 0,
+        "Running": 0,
+        "Dead": 0
+      },
+      "CreateIndex": 52,
+      "ModifyIndex": 96
+    },
+    "CreateIndex": 52,
+    "ModifyIndex": 93,
+    "JobModifyIndex": 52
+  }
+]
+```
+
 [api_scheduler_alog]: /nomad/api-docs/operator/scheduler#scheduleralgorithm


### PR DESCRIPTION
Implements the HTTP API associated with the `NodePool.ListJobs` RPC, including the `api` package for the public API. Also fixes a bug in the RPC handler where we were missing handling of the special `all` node pool.