### PR TITLE
Use wait client for stopping docker tasks

### DIFF
--- a/drivers/docker/handle.go
+++ b/drivers/docker/handle.go
@@ -159,7 +159,7 @@ func (h *taskHandle) Kill(killTimeout time.Duration, signal string) error {
 	// Signal is used to kill the container with the desired signal before
 	// calling StopContainer
 	if signal == "" {
-		err = h.client.StopContainer(h.containerID, uint(killTimeout.Seconds()))
+		err = h.waitClient.StopContainer(h.containerID, uint(killTimeout.Seconds()))
 	} else {
 		ctx, cancel := context.WithTimeout(context.Background(), killTimeout)
 		defer cancel()

--- a/drivers/docker/handle.go
+++ b/drivers/docker/handle.go
@@ -192,7 +192,7 @@ func (h *taskHandle) Kill(killTimeout time.Duration, signal string) error {
 		}
 
 		// Stop the container
-		err = h.client.StopContainer(h.containerID, 0)
+		err = h.waitClient.StopContainer(h.containerID, 0)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/17023

The [docker client timeout value](https://github.com/hashicorp/nomad/blob/84e7cf39f6c7b0aee49d174ba03bd95824c83c59/drivers/docker/config.go#LL41C6-L41C6) was causing a SIGTERM to be sent to the process 5 minutes after an initial kill signal was sent. This was confirmed by changing this value to various other values, recompiling, and then watching the timestamps of various SIGTERM's sent to the task.

By using the waitClient, which does not use a timeout, instead of the standard client, we can get around the additional SIGTERM being sent. In this case, there is no timeout and we wait until the client's max_kill_timeout value or job's kill_timeout value.

Note: I have not tested this with alternative signals yet, just the default. There is a different codepath for that. 

Also, this could totally be the wrong direction and have implications I don't understand, but I figured it's at least a start of the convo :)