### PR TITLE
client: avoid trying to remove unreadable cgroup

### DIFF
--- a/.changelog/17450.txt
+++ b/.changelog/17450.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where agent would panic during drain incurred by shutdown
+```

--- a/client/lib/cgutil/cpuset_manager_v2.go
+++ b/client/lib/cgutil/cpuset_manager_v2.go
@@ -247,6 +247,11 @@ func (c *cpusetManagerV2) cleanup() {
 	}
 
 	if err := filepath.WalkDir(c.parentAbs, func(path string, entry os.DirEntry, err error) error {
+		// skip anything we cannot read
+		if err != nil {
+			return nil
+		}
+
 		// a cgroup is a directory
 		if !entry.IsDir() {
 			return nil


### PR DESCRIPTION
During shutdown of a client with drain_on_shutdown there is a race between
the Client ending the cgroup and the task's cpuset manager cleaning up
the cgroup. During the path traversal, skip anything we cannot read, which
avoids the nil DirEntry we try to dereference now.

Fixes #17439
