### PR TITLE
node pools: replicate from authoritative region

### DIFF
--- a/command/agent/node_pool_endpoint_test.go
+++ b/command/agent/node_pool_endpoint_test.go
@@ -73,6 +73,7 @@ func TestHTTP_NodePool_Info(t *testing.T) {
 			// Verify expected pool is returned.
 			must.Eq(t, pool, obj.(*structs.NodePool), must.Cmp(cmpopts.IgnoreFields(
 				structs.NodePool{},
+				"Hash",
 				"CreateIndex",
 				"ModifyIndex",
 			)))
@@ -143,6 +144,7 @@ func TestHTTP_NodePool_Create(t *testing.T) {
 		must.NoError(t, err)
 		must.Eq(t, pool, got, must.Cmp(cmpopts.IgnoreFields(
 			structs.NodePool{},
+			"Hash",
 			"CreateIndex",
 			"ModifyIndex",
 		)))
@@ -193,6 +195,7 @@ func TestHTTP_NodePool_Update(t *testing.T) {
 			must.NoError(t, err)
 			must.Eq(t, updated, got, must.Cmp(cmpopts.IgnoreFields(
 				structs.NodePool{},
+				"Hash",
 				"CreateIndex",
 				"ModifyIndex",
 			)))
@@ -239,6 +242,7 @@ func TestHTTP_NodePool_Update(t *testing.T) {
 			must.NoError(t, err)
 			must.Eq(t, updated, got, must.Cmp(cmpopts.IgnoreFields(
 				structs.NodePool{},
+				"Hash",
 				"CreateIndex",
 				"ModifyIndex",
 			)))
@@ -278,6 +282,7 @@ func TestHTTP_NodePool_Update(t *testing.T) {
 			must.NoError(t, err)
 			must.Eq(t, pool, got, must.Cmp(cmpopts.IgnoreFields(
 				structs.NodePool{},
+				"Hash",
 				"CreateIndex",
 				"ModifyIndex",
 			)))

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-version"
+	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 	"github.com/shoenig/test/wait"
 	"github.com/stretchr/testify/assert"
@@ -1804,6 +1805,87 @@ func TestLeader_DiffNamespaces(t *testing.T) {
 
 	// ns2 is un-modified - ignore. ns3 modified, ns4 new.
 	assert.Equal(t, []string{ns3.Name, ns4.Name}, update)
+}
+
+func TestLeader_ReplicateNodePools(t *testing.T) {
+	ci.Parallel(t)
+
+	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
+		c.Region = "region1"
+		c.AuthoritativeRegion = "region1"
+		c.ACLEnabled = true
+	})
+	defer cleanupS1()
+	s2, _, cleanupS2 := TestACLServer(t, func(c *Config) {
+		c.Region = "region2"
+		c.AuthoritativeRegion = "region1"
+		c.ACLEnabled = true
+		c.ReplicationBackoff = 20 * time.Millisecond
+		c.ReplicationToken = root.SecretID
+	})
+	defer cleanupS2()
+	TestJoin(t, s1, s2)
+	testutil.WaitForLeader(t, s1.RPC)
+	testutil.WaitForLeader(t, s2.RPC)
+
+	// Write a node pool to the authoritative region
+	np1 := mock.NodePool()
+	must.NoError(t, s1.State().UpsertNodePools(
+		structs.MsgTypeTestSetup, 100, []*structs.NodePool{np1}))
+
+	// Wait for the node pool to replicate
+	testutil.WaitForResult(func() (bool, error) {
+		store := s2.State()
+		out, err := store.NodePoolByName(nil, np1.Name)
+		return out != nil, err
+	}, func(err error) {
+		t.Fatalf("should replicate node pool")
+	})
+
+	// Delete the node pool at the authoritative region
+	must.NoError(t, s1.State().DeleteNodePools(structs.MsgTypeTestSetup, 200, []string{np1.Name}))
+
+	// Wait for the namespace deletion to replicate
+	testutil.WaitForResult(func() (bool, error) {
+		store := s2.State()
+		out, err := store.NodePoolByName(nil, np1.Name)
+		return out == nil, err
+	}, func(err error) {
+		t.Fatalf("should replicate node pool deletion")
+	})
+}
+
+func TestLeader_DiffNodePools(t *testing.T) {
+	ci.Parallel(t)
+
+	state := state.TestStateStore(t)
+
+	// Populate the local state
+	np1, np2, np3 := mock.NodePool(), mock.NodePool(), mock.NodePool()
+	must.NoError(t, state.UpsertNodePools(
+		structs.MsgTypeTestSetup, 100, []*structs.NodePool{np1, np2, np3}))
+
+	// Simulate a remote list
+	rnp2 := np2.Copy()
+	rnp2.ModifyIndex = 50 // Ignored, same index
+	rnp3 := np3.Copy()
+	rnp3.ModifyIndex = 100 // Updated, higher index
+	rnp3.Description = "force a hash update"
+	rnp3.SetHash()
+	rnp4 := mock.NodePool()
+	remoteList := []*structs.NodePool{
+		rnp2,
+		rnp3,
+		rnp4,
+	}
+	delete, update := diffNodePools(state, 50, remoteList)
+	sort.Strings(delete)
+
+	// np1 does not exist on the remote side, should delete
+	test.Eq(t, []string{structs.NodePoolAll, structs.NodePoolDefault, np1.Name}, delete)
+
+	// np2 is un-modified - ignore. np3 modified, np4 new.
+	test.Eq(t, []*structs.NodePool{rnp3, rnp4}, update)
 }
 
 // waitForStableLeadership waits until a leader is elected and all servers

--- a/nomad/mock/mock.go
+++ b/nomad/mock/mock.go
@@ -252,7 +252,7 @@ func Namespace() *structs.Namespace {
 }
 
 func NodePool() *structs.NodePool {
-	return &structs.NodePool{
+	pool := &structs.NodePool{
 		Name:        fmt.Sprintf("pool-%s", uuid.Short()),
 		Description: "test node pool",
 		Meta:        map[string]string{"team": "test"},
@@ -260,6 +260,8 @@ func NodePool() *structs.NodePool {
 			SchedulerAlgorithm: structs.SchedulerAlgorithmSpread,
 		},
 	}
+	pool.SetHash()
+	return pool
 }
 
 // ServiceRegistrations generates an array containing two unique service

--- a/nomad/node_pool_endpoint.go
+++ b/nomad/node_pool_endpoint.go
@@ -203,6 +203,8 @@ func (n *NodePool) UpsertNodePools(args *structs.NodePoolUpsertRequest, reply *s
 		if pool.IsBuiltIn() {
 			return structs.NewErrRPCCodedf(http.StatusBadRequest, "modifying node pool %q is not allowed", pool.Name)
 		}
+
+		pool.SetHash()
 	}
 
 	// Update via Raft.

--- a/nomad/node_pool_endpoint_test.go
+++ b/nomad/node_pool_endpoint_test.go
@@ -730,6 +730,7 @@ func TestNodePoolEndpoint_UpsertNodePools(t *testing.T) {
 					must.NoError(t, err)
 					must.Eq(t, pool, got, must.Cmp(cmpopts.IgnoreFields(
 						structs.NodePool{},
+						"Hash",
 						"CreateIndex",
 						"ModifyIndex",
 					)))
@@ -865,6 +866,7 @@ func TestNodePoolEndpoint_UpsertNodePool_ACL(t *testing.T) {
 					must.NoError(t, err)
 					must.Eq(t, pool, got, must.Cmp(cmpopts.IgnoreFields(
 						structs.NodePool{},
+						"Hash",
 						"CreateIndex",
 						"ModifyIndex",
 					)))


### PR DESCRIPTION
Upserts and deletes of node pools are forwarded to the authoritative region, just like we do for namespaces, quotas, ACL policies, etc. Replicate node pools from the authoritative region.