### PR TITLE
[ui] Don't show a service as healthy when its parent alloc is not running

### DIFF
--- a/.changelog/17465.txt
+++ b/.changelog/17465.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: dont show a service as healthy when its parent allocation stops running
+```

--- a/ui/app/components/allocation-service-sidebar.hbs
+++ b/ui/app/components/allocation-service-sidebar.hbs
@@ -20,6 +20,11 @@
             {{#if (eq this.aggregateStatus 'Unhealthy')}}
               <FlightIcon @name="x-square-fill" @color="#c84034" />
               Unhealthy
+            {{else if (eq this.aggregateStatus 'Unknown')}}
+            <Tooltip @text="The parent allocation for this service is not running" @isFullText={{true}}>
+              <FlightIcon @name="help" @color="#999999" />
+              Health Unknown
+            </Tooltip>
             {{else}}
               <FlightIcon @name="check-square-fill" @color="#25ba81" />
               Healthy

--- a/ui/app/components/allocation-service-sidebar.js
+++ b/ui/app/components/allocation-service-sidebar.js
@@ -38,7 +38,7 @@ export default class AllocationServiceSidebarComponent extends Component {
   }
 
   get aggregateStatus() {
-    if (this.args.allocation?.clientStatus != -'running') return 'Unknown';
+    if (this.args.allocation?.clientStatus !== 'running') return 'Unknown';
     return this.checks.any((check) => check.Status === 'failure')
       ? 'Unhealthy'
       : 'Healthy';

--- a/ui/app/components/allocation-service-sidebar.js
+++ b/ui/app/components/allocation-service-sidebar.js
@@ -38,6 +38,7 @@ export default class AllocationServiceSidebarComponent extends Component {
   }
 
   get aggregateStatus() {
+    if (this.args.allocation?.clientStatus != -'running') return 'Unknown';
     return this.checks.any((check) => check.Status === 'failure')
       ? 'Unhealthy'
       : 'Healthy';

--- a/ui/tests/integration/components/allocation-service-sidebar-test.js
+++ b/ui/tests/integration/components/allocation-service-sidebar-test.js
@@ -76,7 +76,7 @@ module(
       };
 
       this.set('closeSidebar', () => this.set('service', null));
-      this.set('allocation', { id: 'myAlloc' });
+      this.set('allocation', { id: 'myAlloc', clientStatus: 'running' });
       this.set('service', healthyService);
       await render(
         hbs`<AllocationServiceSidebar @service={{this.service}} @allocation={{this.allocation}} @fns={{hash closeSidebar=this.closeSidebar}} />`
@@ -91,6 +91,13 @@ module(
         hbs`<AllocationServiceSidebar @service={{this.service}} @allocation={{this.allocation}} @fns={{hash closeSidebar=this.closeSidebar}} />`
       );
       assert.dom('h1 .aggregate-status').includesText('Unhealthy');
+
+      this.set('service', healthyService);
+      this.set('allocation', { id: 'myAlloc2', clientStatus: 'failed' });
+      await render(
+        hbs`<AllocationServiceSidebar @service={{this.service}} @allocation={{this.allocation}} @fns={{hash closeSidebar=this.closeSidebar}} />`
+      );
+      assert.dom('h1 .aggregate-status').includesText('Health Unknown');
     });
 
     test('it handles Consul services with reduced functionality', async function (assert) {


### PR DESCRIPTION
Adds a "Health Unknown" indicator and tooltip when the allocation a service is running on is not in a running state.

Previously, any /checks would return `null` and it would optimistically show Healthy for its aggregate status.

<img width="801" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/f365610d-1ae9-4aac-9f74-5617b266cbd1">
