### PR TITLE
[ui] Parallelization down from 4 to 3 and circle workflow for test-ui removed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,37 +212,6 @@ jobs:
           path: c:\tmp\test-reports
       - store_artifacts:
           path: c:\tmp\test-reports
-  test-ui:
-    docker:
-      - image: docker.mirror.hashicorp.services/circleci/node:14-browsers
-        environment:
-          # See https://git.io/vdao3 for details.
-          JOBS: 2
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v3-deps-{{ checksum "ui/yarn.lock" }}
-      - run:
-          name: yarn install
-          command: cd ui && yarn install --frozen-lockfile
-      - save_cache:
-          key: v3-deps-{{ checksum "ui/yarn.lock" }}
-          paths:
-            - ./ui/node_modules
-      - run:
-          name: lint:js
-          command: cd ui && yarn run lint:js
-      - run:
-          name: lint:hbs
-          command: cd ui && yarn run lint:hbs
-      - run:
-          name: Ember tests
-          command: mkdir -p /tmp/test-reports && cd ui && yarn test
-      - store_test_results:
-          path: /tmp/test-reports
-      - store_artifacts:
-          path: /tmp/test-reports
   test-machine:
     executor: "<< parameters.executor >>"
     parameters:
@@ -511,15 +480,6 @@ workflows:
                 - /^docs-.*/
                 - /^backport/docs-.*/
                 - stable-website
-
-      - test-ui:
-          filters:
-            branches:
-              ignore:
-                - stable-website
-                - /^docs-.*/
-                - /^backport/docs-.*/
-                - /^e2e-.*/
 
         # Note: comment-out this job in ENT
       - test-windows:

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,7 @@
     "build-storybook": "STORYBOOK=true ember build && build-storybook -s dist",
     "storybook": "STORYBOOK=true start-storybook -p 6006 -s dist",
     "test": "npm-run-all lint test:*",
-    "exam": "ember exam --split=4 --parallel",
+    "exam": "ember exam --split=3 --parallel",
     "test:ember": "percy exec -- ember test",
     "local:qunitdom": "ember test --server --query=dockcontainer",
     "local:exam": "ember exam --server --load-balance --parallel=4",

--- a/ui/tests/test-helper.js
+++ b/ui/tests/test-helper.js
@@ -11,18 +11,15 @@ import { setApplication } from '@ember/test-helpers';
 import start from 'ember-exam/test-support/start';
 import { setup } from 'qunit-dom';
 import './helpers/flash-message';
-import Ember from 'ember';
+
+import { _backburner } from '@ember/runloop';
+import { RSVP } from '@ember/-internals/runtime';
+
+RSVP.configure('async', function (callback, promise) {
+  _backburner.schedule('actions', () => callback(promise));
+});
 
 setApplication(Application.create(config.APP));
-
-Ember.onerror = function (err) {
-  console.log('an onerror event has occurred and is being overridden');
-  console.error(err);
-  console.log('stringified', JSON.stringify(err));
-  console.log('end of onerror event');
-  QUnit.assert.ok(false, err);
-  return new Error(err);
-};
 
 setup(QUnit.assert);
 

--- a/ui/tests/test-helper.js
+++ b/ui/tests/test-helper.js
@@ -18,8 +18,10 @@ setApplication(Application.create(config.APP));
 Ember.onerror = function (err) {
   console.log('an onerror event has occurred and is being overridden');
   console.error(err);
+  console.log('stringified', JSON.stringify(err));
   console.log('end of onerror event');
   QUnit.assert.ok(false, err);
+  return err;
 };
 
 setup(QUnit.assert);

--- a/ui/tests/test-helper.js
+++ b/ui/tests/test-helper.js
@@ -11,8 +11,16 @@ import { setApplication } from '@ember/test-helpers';
 import start from 'ember-exam/test-support/start';
 import { setup } from 'qunit-dom';
 import './helpers/flash-message';
+import Ember from 'ember';
 
 setApplication(Application.create(config.APP));
+
+Ember.onerror = function (err) {
+  console.log('an onerror event has occurred and is being overridden');
+  console.error(err);
+  console.log('end of onerror event');
+  QUnit.assert.ok(false, err);
+};
 
 setup(QUnit.assert);
 

--- a/ui/tests/test-helper.js
+++ b/ui/tests/test-helper.js
@@ -21,7 +21,7 @@ Ember.onerror = function (err) {
   console.log('stringified', JSON.stringify(err));
   console.log('end of onerror event');
   QUnit.assert.ok(false, err);
-  return err;
+  return new Error(err);
 };
 
 setup(QUnit.assert);


### PR DESCRIPTION
Noticing a non-trivial % of test runs on main timing out / running for hours, so reducing the parallelization from 4 to 3 for Ember tests.

Removing Circle test-ui to remove the redundancy and for Percy-run related reasons