### PR TITLE
node pools: implement `node pool init` command

### DIFF
--- a/command/asset/asset.go
+++ b/command/asset/asset.go
@@ -16,3 +16,9 @@ var JobConnect []byte
 
 //go:embed connect-short.nomad.hcl
 var JobConnectShort []byte
+
+//go:embed pool.nomad.hcl
+var NodePoolSpec []byte
+
+//go:embed pool.nomad.json
+var NodePoolSpecJSON []byte

--- a/command/asset/pool.nomad.hcl
+++ b/command/asset/pool.nomad.hcl
@@ -1,0 +1,25 @@
+node_pool "example" {
+
+  description = "Example node pool"
+
+  # meta is optional metadata on the node pool, defined as key-value pairs.
+  # The scheduler does not use node pool metadata as part of scheduling.
+  meta {
+    environment = "prod"
+    owner       = "sre"
+  }
+
+  # The scheduler configuration options specific to this node pool. This block
+  # supports a subset of the fields supported in the global scheduler
+  # configuration as described at:
+  # https://developer.hashicorp.com/nomad/docs/commands/operator/scheduler/set-config
+  #
+  # * scheduler_algorithm is the scheduling algorithm to use for the pool.
+  #   If not defined, the global cluster scheduling algorithm is used.
+  #
+  # Available only in Nomad Enterprise.
+
+  # scheduler_configuration {
+  #   scheduler_algorithm = "spread"
+  # }
+}

--- a/command/asset/pool.nomad.json
+++ b/command/asset/pool.nomad.json
@@ -1,0 +1,11 @@
+{
+  "Name": "example",
+  "Description": "Example node pool",
+  "Meta": {
+    "environment": "prod",
+    "owner": "sre"
+  },
+  "SchedulerConfiguration": {
+    "SchedulerAlgorithm": "spread"
+  }
+}

--- a/command/commands.go
+++ b/command/commands.go
@@ -636,6 +636,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"node pool init": func() (cli.Command, error) {
+			return &NodePoolInitCommand{
+				Meta: meta,
+			}, nil
+		},
 		"node pool jobs": func() (cli.Command, error) {
 			return &NodePoolJobsCommand{
 				Meta: meta,

--- a/command/node_pool_init.go
+++ b/command/node_pool_init.go
@@ -56,7 +56,8 @@ func (c *NodePoolInitCommand) Synopsis() string {
 
 func (c *NodePoolInitCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
-		"-out": complete.PredictSet("hcl", "json"),
+		"-out":   complete.PredictSet("hcl", "json"),
+		"-quiet": complete.PredictNothing,
 	}
 }
 

--- a/command/node_pool_init.go
+++ b/command/node_pool_init.go
@@ -1,0 +1,162 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+
+	"github.com/posener/complete"
+)
+
+const (
+	// DefaultHclNodePoolInitName is the default name we use when initializing
+	// the example node pool spec file in HCL format
+	DefaultHclNodePoolInitName = "pool.np.hcl"
+
+	// DefaultJsonNodePoolInitName is the default name we use when initializing
+	// the example node pool spec in JSON format
+	DefaultJsonNodePoolInitName = "pool.np.json"
+)
+
+// NodePoolInitCommand generates a new variable specification
+type NodePoolInitCommand struct {
+	Meta
+}
+
+func (c *NodePoolInitCommand) Help() string {
+	helpText := `
+Usage: nomad node pool init <filename>
+
+  Creates an example node pool specification file that can be used as a starting
+  point to customize further. When no filename is supplied, a default filename
+  of "pool.np.hcl" or "pool.np.json" will be used depending on the output
+  format.
+
+Init Options:
+
+  -out (hcl | json)
+    Format of generated node pool specification. Defaults to "hcl".
+
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *NodePoolInitCommand) Synopsis() string {
+	return "Create an example node pool specification file"
+}
+
+func (c *NodePoolInitCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-out": complete.PredictSet("hcl", "json"),
+	}
+}
+
+func (c *NodePoolInitCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *NodePoolInitCommand) Name() string { return "node pool init" }
+
+func (c *NodePoolInitCommand) Run(args []string) int {
+	var outFmt string
+	var quiet bool
+
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.StringVar(&outFmt, "out", "hcl", "")
+
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	// Check that we get no arguments
+	args = flags.Args()
+	if l := len(args); l > 1 {
+		c.Ui.Error("This command takes no arguments or one: <filename>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+	var fileName, fileContent string
+	switch outFmt {
+	case "hcl":
+		fileName = DefaultHclNodePoolInitName
+		fileContent = defaultHclNodePoolSpec
+	case "json":
+		fileName = DefaultJsonNodePoolInitName
+		fileContent = defaultJsonNodePoolSpec
+	}
+
+	if len(args) == 1 {
+		fileName = args[0]
+	}
+
+	// Check if the file already exists
+	_, err := os.Stat(fileName)
+	if err == nil {
+		c.Ui.Error(fmt.Sprintf("File %q already exists", fileName))
+		return 1
+	}
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		c.Ui.Error(fmt.Sprintf("Failed to stat %q: %v", fileName, err))
+		return 1
+	}
+
+	// Write out the example
+	err = os.WriteFile(fileName, []byte(fileContent), 0660)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to write %q: %v", fileName, err))
+		return 1
+	}
+
+	// Success
+	if !quiet {
+		c.Ui.Output(fmt.Sprintf("Example node pool specification written to %s", fileName))
+	}
+	return 0
+}
+
+var defaultHclNodePoolSpec = strings.TrimSpace(`
+node_pool "example" {
+
+  description = "Example node pool"
+
+  # meta is optional metadata on the node pool, defined as key-value pairs.
+  # The scheduler does not use node pool metadata as part of scheduling.
+  meta {
+    environment = "prod"
+    owner       = "sre"
+  }
+
+  # The scheduler configuration options specific to this node pool. This block
+  # supports a subset of the fields supported in the global scheduler
+  # configuration as described at:
+  # https://developer.hashicorp.com/nomad/docs/commands/operator/scheduler/set-config
+  #
+  # Available only in Nomad Enterprise.
+  scheduler_configuration {
+
+    # scheduler_algorithm is the scheduling algorithm to use for the pool.
+    # If not defined, the global cluster scheduling algorithm is used.
+    scheduler_algorithm = "spread"
+  }
+}
+`) + "\n"
+
+var defaultJsonNodePoolSpec = strings.TrimSpace(`
+{
+  "Name": "example",
+  "Description": "Example node pool",
+  "Meta": {
+    "environment": "prod",
+    "owner": "sre"
+  },
+  "SchedulerConfiguration": {
+    "SchedulerAlgorithm": "spread"
+  }
+}
+`) + "\n"

--- a/command/node_pool_init_test.go
+++ b/command/node_pool_init_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/nomad/ci"
+)
+
+func TestNodePoolInitCommand_Implements(t *testing.T) {
+	ci.Parallel(t)
+	var _ cli.Command = &NodePoolInitCommand{}
+}
+
+func TestNodePoolInitCommand_Run(t *testing.T) {
+	ci.Parallel(t)
+	dir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	err = os.Chdir(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	t.Run("hcl", func(t *testing.T) {
+		ci.Parallel(t)
+		dir := dir
+		ui := cli.NewMockUi()
+		cmd := &NodePoolInitCommand{Meta: Meta{Ui: ui}}
+
+		// Fails on misuse
+		ec := cmd.Run([]string{"some", "bad", "args"})
+		require.Equal(t, 1, ec)
+		require.Contains(t, ui.ErrorWriter.String(), commandErrorText(cmd))
+		require.Empty(t, ui.OutputWriter.String())
+		reset(ui)
+
+		// Works if the file doesn't exist
+		ec = cmd.Run([]string{"-out", "hcl"})
+		require.Empty(t, ui.ErrorWriter.String())
+		require.Equal(t, "Example node pool specification written to pool.np.hcl\n", ui.OutputWriter.String())
+		require.Zero(t, ec)
+		reset(ui)
+		t.Cleanup(func() { os.Remove(path.Join(dir, "pool.np.hcl")) })
+
+		content, err := os.ReadFile(DefaultHclNodePoolInitName)
+		require.NoError(t, err)
+		require.Equal(t, defaultHclNodePoolSpec, string(content))
+
+		// Fails if the file exists
+		ec = cmd.Run([]string{"-out", "hcl"})
+		require.Contains(t, ui.ErrorWriter.String(), "exists")
+		require.Empty(t, ui.OutputWriter.String())
+		require.Equal(t, 1, ec)
+		reset(ui)
+
+		// Works if file is passed
+		ec = cmd.Run([]string{"-out", "hcl", "myTest.hcl"})
+		require.Empty(t, ui.ErrorWriter.String())
+		require.Equal(t, "Example node pool specification written to myTest.hcl\n", ui.OutputWriter.String())
+		require.Zero(t, ec)
+		reset(ui)
+
+		t.Cleanup(func() { os.Remove(path.Join(dir, "myTest.hcl")) })
+		content, err = os.ReadFile("myTest.hcl")
+		require.NoError(t, err)
+		require.Equal(t, defaultHclNodePoolSpec, string(content))
+	})
+
+	t.Run("json", func(t *testing.T) {
+		ci.Parallel(t)
+		dir := dir
+		ui := cli.NewMockUi()
+		cmd := &NodePoolInitCommand{Meta: Meta{Ui: ui}}
+
+		// Fails on misuse
+		code := cmd.Run([]string{"some", "bad", "args"})
+		require.Equal(t, 1, code)
+		require.Contains(t, ui.ErrorWriter.String(), "This command takes no arguments or one")
+		require.Empty(t, ui.OutputWriter.String())
+		reset(ui)
+
+		// Works if the file doesn't exist
+		code = cmd.Run([]string{"-out", "json"})
+		require.Contains(t, ui.OutputWriter.String(), "Example node pool specification written to pool.np.json\n")
+		require.Zero(t, code)
+		reset(ui)
+
+		t.Cleanup(func() { os.Remove(path.Join(dir, "pool.np.json")) })
+		content, err := os.ReadFile(DefaultJsonNodePoolInitName)
+		require.NoError(t, err)
+		require.Equal(t, defaultJsonNodePoolSpec, string(content))
+
+		// Fails if the file exists
+		code = cmd.Run([]string{"-out", "json"})
+		require.Contains(t, ui.ErrorWriter.String(), "exists")
+		require.Empty(t, ui.OutputWriter.String())
+		require.Equal(t, 1, code)
+		reset(ui)
+
+		// Works if file is passed
+		code = cmd.Run([]string{"-out", "json", "myTest.json"})
+		require.Contains(t, ui.OutputWriter.String(), "Example node pool specification written to myTest.json\n")
+		require.Zero(t, code)
+		reset(ui)
+
+		t.Cleanup(func() { os.Remove(path.Join(dir, "myTest.json")) })
+		content, err = os.ReadFile("myTest.json")
+		require.NoError(t, err)
+		require.Equal(t, defaultJsonNodePoolSpec, string(content))
+	})
+}

--- a/website/content/docs/commands/node-pool/init.mdx
+++ b/website/content/docs/commands/node-pool/init.mdx
@@ -16,13 +16,15 @@ used as a starting point to customize further.
 nomad node pool init <filename>
 ```
 
-When no filename is supplied, a default filename of "pool.np.hcl" or
-"pool.np.json" will be used depending on the output format.
+When no filename is supplied, a default filename of "pool.nomad.hcl" or
+"pool.nomad.json" will be used depending on the output format.
 
 ## Init Options
 
 - `-out` `(enum: hcl | json)`: Format of generated node pool
   specification. Defaults to `hcl`.
+
+- `-quiet`: Do not print success message.
 
 ## Examples
 
@@ -30,5 +32,5 @@ Create an example node pool specification:
 
 ```shell-session
 $ nomad node pool init
-Example node pool specification written to pool.np.hcl
+Example node pool specification written to pool.nomad.hcl
 ```

--- a/website/content/docs/commands/node-pool/init.mdx
+++ b/website/content/docs/commands/node-pool/init.mdx
@@ -1,0 +1,34 @@
+---
+layout: docs
+page_title: 'Commands: node pool init'
+description: |
+  Generate an example node pool specification.
+---
+
+# Command: node pool init
+
+The `node pool init` creates an example node pool specification file that can be
+used as a starting point to customize further.
+
+## Usage
+
+```plaintext
+nomad node pool init <filename>
+```
+
+When no filename is supplied, a default filename of "pool.np.hcl" or
+"pool.np.json" will be used depending on the output format.
+
+## Init Options
+
+- `-out` `(enum: hcl | json)`: Format of generated node pool
+  specification. Defaults to `hcl`.
+
+## Examples
+
+Create an example node pool specification:
+
+```shell-session
+$ nomad node pool init
+Example node pool specification written to pool.np.hcl
+```

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -692,6 +692,10 @@
             "path": "commands/node-pool/info"
           },
           {
+            "title": "init",
+            "path": "commands/node-pool/init"
+          },
+          {
             "title": "jobs",
             "path": "commands/node-pool/jobs"
           },


### PR DESCRIPTION
Implement a `nomad node pool init` command that generates an example spec file in either HCL or JSON format.