### PR TITLE
Add preemption_config to the server extra HCL keys to remove from config

### DIFF
--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -252,6 +252,10 @@ func extraKeys(c *Config) error {
 		helper.RemoveEqualFold(&c.ExtraKeysHCL, "server")
 	}
 
+	for _, k := range []string{"preemption_config"} {
+		helper.RemoveEqualFold(&c.Server.ExtraKeysHCL, k)
+	}
+
 	for _, k := range []string{"datadog_tags"} {
 		helper.RemoveEqualFold(&c.ExtraKeysHCL, k)
 		helper.RemoveEqualFold(&c.ExtraKeysHCL, "telemetry")


### PR DESCRIPTION
Add `preemption_config` to the set of keys which should be pruned from the server config as described in https://github.com/hashicorp/nomad/issues/17480. Please note that I do not know of any existing unit tests for this behavior, but I have tested this manually:

```
make bootstrap
make dev

$ cat ../nomad_sandbox/server.config 
{                                                                                                                                                                                                                                                                                      
  "data_dir": "/tmp/nomad/server",
  "log_level": "TRACE",
  "advertise": {                                                                                                                                                                                                                                                                       
    "http": "127.0.0.1",                                                                                                                                                                                                                                                               
    "rpc": "127.0.0.1",                                                                                                                                                                                                                                                                
    "serf": "127.0.0.1"                                                                                                                                                                                                                                                                
  },                                                                                                                                                                                                                                                                                   
  "server": {                                                                                                                                                                                                                                                                          
    "enabled": true,                                                                                                                                                                                                                                                                   
    "bootstrap_expect": 1,                                                                                                                                                                                                                                                             
    "default_scheduler_config": {                                                                                                                                                                                                                                                      
      "preemption_config": {
        "system_scheduler_enabled": true,                                                                                                                                                                                                                                              
        "sysbatch_scheduler_enabled": false,                                                                                                                                                                                                                                           
        "batch_scheduler_enabled": true,                                                                                                                                                                                                                                               
        "service_scheduler_enabled": false                                                                                                                                                                                                                                             
      }
    }                                                                                                                                                                                                                                                                                  
  }     
}
$ ./bin/nomad agent -config ../nomad_sandbox/server.config 
[...]

$ ./bin/nomad operator scheduler get-config                                                            
Scheduler Algorithm           = binpack                                                                                                            
Memory Oversubscription       = false                                                                                                              
Reject Job Registration       = false                                                                                                              
Pause Eval Broker             = false                                                                                                              
Preemption System Scheduler   = true                                                                                                               
Preemption Service Scheduler  = false                                   
Preemption Batch Scheduler    = true                                                                                                               
Preemption SysBatch Scheduler = false                                                                                                              
Modify Index                  = 5   ```