### PR TITLE
Fix terraform syntax in Azure example due to deprecated tf resource arguments

### DIFF
--- a/terraform/azure/modules/hashistack/hashistack.tf
+++ b/terraform/azure/modules/hashistack/hashistack.tf
@@ -38,7 +38,7 @@ resource "azurerm_subnet" "hashistack-sn" {
   name                 = "hashistack-sn"
   resource_group_name  = "${azurerm_resource_group.hashistack.name}"
   virtual_network_name = "${azurerm_virtual_network.hashistack-vn.name}"
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_security_group" "hashistack-sg" {
@@ -100,7 +100,7 @@ resource "azurerm_public_ip" "hashistack-server-public-ip" {
   name                         = "hashistack-server-ip-${count.index}"
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.hashistack.name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "static"
 }
 
 resource "azurerm_network_interface" "hashistack-server-ni" {
@@ -117,7 +117,7 @@ resource "azurerm_network_interface" "hashistack-server-ni" {
     public_ip_address_id          = "${element(azurerm_public_ip.hashistack-server-public-ip.*.id, count.index)}"
   }
 
-  tags {
+  tags = {
     ConsulAutoJoin = "auto-join"
   }
 }
@@ -166,8 +166,7 @@ resource "azurerm_virtual_machine" "server" {
 
 data "template_file" "user_data_server" {
   template = "${file("${path.root}/user-data-server.sh")}"
-
-  vars {
+  vars = {
     server_count = "${var.server_count}"
     retry_join   = "${var.retry_join}"
   }
@@ -178,7 +177,7 @@ resource "azurerm_public_ip" "hashistack-client-public-ip" {
   name                         = "hashistack-client-ip-${count.index}"
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.hashistack.name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "static"
 }
 
 resource "azurerm_network_interface" "hashistack-client-ni" {
@@ -195,7 +194,7 @@ resource "azurerm_network_interface" "hashistack-client-ni" {
     public_ip_address_id          = "${element(azurerm_public_ip.hashistack-client-public-ip.*.id, count.index)}"
   }
 
-  tags {
+  tags = {
     ConsulAutoJoin = "auto-join"
   }
 }
@@ -245,8 +244,7 @@ resource "azurerm_virtual_machine" "client" {
 
 data "template_file" "user_data_client" {
   template = "${file("${path.root}/user-data-client.sh")}"
-
-  vars {
+  vars = {
     retry_join = "${var.retry_join}"
   }
 }

--- a/terraform/azure/modules/hashistack/hashistack.tf
+++ b/terraform/azure/modules/hashistack/hashistack.tf
@@ -100,7 +100,7 @@ resource "azurerm_public_ip" "hashistack-server-public-ip" {
   name                         = "hashistack-server-ip-${count.index}"
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.hashistack.name}"
-  allocation_method            = "static"
+  allocation_method            = "Static"
 }
 
 resource "azurerm_network_interface" "hashistack-server-ni" {
@@ -177,7 +177,7 @@ resource "azurerm_public_ip" "hashistack-client-public-ip" {
   name                         = "hashistack-client-ip-${count.index}"
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.hashistack.name}"
-  allocation_method            = "static"
+  allocation_method            = "Static"
 }
 
 resource "azurerm_network_interface" "hashistack-client-ni" {


### PR DESCRIPTION
Hi team,

This PR is my attempt to fix the syntax error highlighted in issue https://github.com/hashicorp/nomad/issues/17464

- `address_prefixes` is the latest arg for `azurerm_subnet` resource ([link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet#address_prefixes)) . The last supported version for `address_prefix` was in [3.2.0](https://registry.terraform.io/providers/hashicorp/azurerm/3.2.0/docs/resources/subnet)
- `allocation_method` replaces `public_ip_address_allocation`. Sorry the version was too old I could not find any doc earlier than 2.0 that uses `public_ip_address_allocation`. The intial code commit was 6 years ago so I guess it goes further than that :smile: 
- A few smaller changes from HCL ( current format ) to HCL2.

There was no .terraform-version file to track but I guess its around 0.12 ish for terraform version. Let me know if you want to have an overhaul of this ( for other cloud providers too, if needed ). Also, please guide me on whether a changelog is needed :pray: 