### PR TITLE
client: fix panic on alloc stop in non-Linux environments

### DIFF
--- a/client/allocrunner/network_hook.go
+++ b/client/allocrunner/network_hook.go
@@ -186,6 +186,10 @@ func (h *networkHook) Postrun() error {
 		}
 	}
 
-	// issue driver destroy regardless if we have a spec (e.g. cleanup pause container)
-	return h.manager.DestroyNetwork(h.alloc.ID, h.spec)
+	// h.manager is only set on Linux.
+	if h.manager != nil {
+		// issue driver destroy regardless if we have a spec (e.g. cleanup pause container)
+		return h.manager.DestroyNetwork(h.alloc.ID, h.spec)
+	}
+	return nil
 }


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/17455 fixes an issue where the pause container was not being properly shutdown due to the `Postrun` hook not being executed. 

But trying to run `h.manager.DestroyNetwork()` in non-Linux environments results in a panic because `h.manager` is always `nil`.

https://github.com/hashicorp/nomad/blob/0aeeaf1083c21911c327916a3a830675d3623d4b/client/allocrunner/network_manager_nonlinux.go#L18-L20

```
    2023-06-13T15:02:00.623-0400 [INFO]  client.gc: marking allocation for GC: alloc_id=125fc2c9-a687-8fde-daa1-1cf998d26a33
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x20 pc=0x1019037b8]

goroutine 423 [running]:
github.com/hashicorp/nomad/client/allocrunner.(*networkHook).Postrun(0x14000f2dd40?)
        github.com/hashicorp/nomad/client/allocrunner/network_hook.go:190 +0x198
github.com/hashicorp/nomad/client/allocrunner.(*allocRunner).postrun(0x14000541d40)
        github.com/hashicorp/nomad/client/allocrunner/alloc_runner_hooks.go:253 +0x328
github.com/hashicorp/nomad/client/allocrunner.(*allocRunner).Run(0x14000541d40)
        github.com/hashicorp/nomad/client/allocrunner/alloc_runner.go:364 +0x218
created by github.com/hashicorp/nomad/client.(*Client).addAlloc
        github.com/hashicorp/nomad/client/client.go:2653 +0x9ac
```

This PR skips the call to `DestroyNetwork` if `h.manager` is `nil`.

No CHANGELOG since #17455 has not been released.