### PR TITLE
cli: fix missing `-quiet` flag for `var init`

### DIFF
--- a/.changelog/17526.txt
+++ b/.changelog/17526.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Add `-quiet` flag to `nomad var init` command
+```

--- a/command/var_init.go
+++ b/command/var_init.go
@@ -44,6 +44,8 @@ Init Options:
   -out (hcl | json)
     Format of generated variable specification. Defaults to "hcl".
 
+  -quiet
+    Do not print success message.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/var_init.go
+++ b/command/var_init.go
@@ -54,7 +54,8 @@ func (c *VarInitCommand) Synopsis() string {
 
 func (c *VarInitCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
-		"-out": complete.PredictSet("hcl", "json"),
+		"-out":   complete.PredictSet("hcl", "json"),
+		"-quiet": complete.PredictNothing,
 	}
 }
 
@@ -71,6 +72,7 @@ func (c *VarInitCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.StringVar(&outFmt, "out", "hcl", "")
+	flags.BoolVar(&quiet, "quiet", false, "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1

--- a/website/content/docs/commands/var/init.mdx
+++ b/website/content/docs/commands/var/init.mdx
@@ -24,6 +24,8 @@ When no filename is supplied, a default filename of "spec.nv.hcl" or
 - `-out` `(enum: hcl | json)`: Format of generated variable
   specification. Defaults to `hcl`.
 
+- `-quiet`: Do not print success message.
+
 ## Examples
 
 Create an example variable specification:


### PR DESCRIPTION
The `var init` command was intended to have support for a `-quiet` flag but it was not documented and never parsed.