### PR TITLE
node pools: support `node.pool` constraint in scheduler

### DIFF
--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -809,6 +809,9 @@ func resolveTarget(target string, node *structs.Node) (string, bool) {
 	case "${node.class}" == target:
 		return node.NodeClass, true
 
+	case "${node.pool}" == target:
+		return node.NodePool, true
+
 	case strings.HasPrefix(target, "${attr."):
 		attr := strings.TrimSuffix(strings.TrimPrefix(target, "${attr."), "}")
 		val, ok := node.Attributes[attr]

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -875,12 +875,14 @@ func TestConstraintChecker(t *testing.T) {
 		mock.Node(),
 		mock.Node(),
 		mock.Node(),
+		mock.Node(),
 	}
 
 	nodes[0].Attributes["kernel.name"] = "freebsd"
 	nodes[1].Datacenter = "dc2"
 	nodes[2].NodeClass = "large"
 	nodes[2].Attributes["foo"] = "bar"
+	nodes[3].NodePool = "prod"
 
 	constraints := []*structs.Constraint{
 		{
@@ -897,6 +899,11 @@ func TestConstraintChecker(t *testing.T) {
 			Operand: "!=",
 			LTarget: "${node.class}",
 			RTarget: "linux-medium-pci",
+		},
+		{
+			Operand: "!=",
+			LTarget: "${node.pool}",
+			RTarget: "prod",
 		},
 		{
 			Operand: "is_set",
@@ -919,6 +926,10 @@ func TestConstraintChecker(t *testing.T) {
 		{
 			Node:   nodes[2],
 			Result: true,
+		},
+		{
+			Node:   nodes[3],
+			Result: false,
 		},
 	}
 

--- a/website/content/docs/runtime/interpolation.mdx
+++ b/website/content/docs/runtime/interpolation.mdx
@@ -91,12 +91,13 @@ attributes are interpreted by **both** constraints and within the task and
 driver.
 
 | Variable              | Description                                 | Example Value                          |
-| ----------------------| ------------------------------------------- | -------------------------------------- |
+|-----------------------|---------------------------------------------|----------------------------------------|
 | `${node.unique.id}`   | 36 character unique client identifier       | `9afa5da1-8f39-25a2-48dc-ba31fd7c0023` |
 | `${node.region}`      | Client's region                             | `global`                               |
 | `${node.datacenter}`  | Client's datacenter                         | `dc1`                                  |
 | `${node.unique.name}` | Client's name                               | `nomad-client-10-1-2-4`                |
 | `${node.class}`       | Client's class                              | `linux-64bit`                          |
+| `${node.pool}`        | Client's node pool                          | `prod`                                 |
 | `${attr.<property>}`  | Property given by `property` on the client  | `${attr.cpu.arch} => amd64`            |
 | `${meta.<key>}`       | Metadata value given by `key` on the client | `${meta.foo} => bar`                   |
 


### PR DESCRIPTION
Although most of the time jobs will be assigned to a single node pool, users may want to set the node pool to "all" and then constraint to a subset of node pools. Add support for setting a contraint like `${node.pool}`.