### PR TITLE
[chore] Update pre-push hook to handle more remote URL shapes

### DIFF
--- a/dev/hooks/pre-push
+++ b/dev/hooks/pre-push
@@ -11,8 +11,10 @@ fail () {
 # only push to oss when the enterprise version is absent
 # ====================
 oss="git@github.com:hashicorp/nomad.git"
-ent="git@github.com:hashicorp/nomad-enterprise.git"
-if [ "$2" != "$ent" -a -f version/version_ent.go ]; then
+ent="hashicorp/nomad-enterprise"
+
+arg="${${${arg%.git}#git@github.com:}#https://github.com/}"
+if [ "${arg}" != "${ent}" -a -f version/version_ent.go ]; then
     fail "found enterprise version file version/version_ent.go while pushing to oss remote"
 fi
 


### PR DESCRIPTION
This change allows the pre-push hook to handle https-shaped URLs and URLs that don't end in `.git`