### PR TITLE
Fix the underlying problem that is preventing Storybook deploys

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -163,7 +163,7 @@
     "ember-cli-string-utils": "^1.1.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "12.* || 14.* || 16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
We're at a crossroads.

Storybook builds with `webpack@4`, but `webpack@4` is incompatible with Node v18 ([see comically long issue](https://github.com/webpack/webpack/issues/14532)).

Storybook@6 (what we're using) in theory supports `webpack@5` or maybe even an esbuild or vite builder, which would be compatible with Node v18, but this would require a more extensive upgrade that potentially runs into dead ends with the Ember integration.

So for the time being, forcing Vercel to use v16 (which is EOL in September) is the faster solution, as stop-gappy as it may be.