### PR TITLE
[ui] Job status panel legend should only show "health unknown" for running allocs

### DIFF
--- a/ui/app/components/job-status/panel/deploying.js
+++ b/ui/app/components/job-status/panel/deploying.js
@@ -187,6 +187,13 @@ export default class JobStatusPanelDeployingComponent extends Component {
     ];
   }
 
+  get newRunningHealthUnknownAllocBlocks() {
+    return [
+      ...this.newVersionAllocBlocks['running']['health_unknown']['canary'],
+      ...this.newVersionAllocBlocks['running']['health_unknown']['nonCanary'],
+    ];
+  }
+
   get rescheduledAllocs() {
     return this.job.allocations.filter((a) => !a.isOld && a.hasBeenRescheduled);
   }
@@ -222,10 +229,7 @@ export default class JobStatusPanelDeployingComponent extends Component {
     return {
       healthy: this.newRunningHealthyAllocBlocks.length,
       unhealthy: this.newRunningUnhealthyAllocBlocks.length,
-      health_unknown:
-        this.totalAllocs -
-        this.newRunningHealthyAllocBlocks.length -
-        this.newRunningUnhealthyAllocBlocks.length,
+      health_unknown: this.newRunningHealthUnknownAllocBlocks.length,
     };
   }
   // #endregion legend


### PR DESCRIPTION
"Health Unknown" no longer counts unplaced, failed, etc. allocations.

![image](https://github.com/hashicorp/nomad/assets/713991/0fb0fe4e-5b88-40dd-a3b2-1ab6aa8b7346)
