### PR TITLE
cli: prevent panic if job node pool is nil

### DIFF
--- a/command/job_status.go
+++ b/command/job_status.go
@@ -167,6 +167,11 @@ func (c *JobStatusCommand) Run(args []string) int {
 	periodic := job.IsPeriodic()
 	parameterized := job.IsParameterized()
 
+	nodePool := ""
+	if job.NodePool != nil {
+		nodePool = *job.NodePool
+	}
+
 	// Format the job info
 	basic := []string{
 		fmt.Sprintf("ID|%s", *job.ID),
@@ -176,7 +181,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 		fmt.Sprintf("Priority|%d", *job.Priority),
 		fmt.Sprintf("Datacenters|%s", strings.Join(job.Datacenters, ",")),
 		fmt.Sprintf("Namespace|%s", *job.Namespace),
-		fmt.Sprintf("Node Pool|%s", *job.NodePool),
+		fmt.Sprintf("Node Pool|%s", nodePool),
 		fmt.Sprintf("Status|%s", getStatusString(*job.Status, job.Stop)),
 		fmt.Sprintf("Periodic|%v", periodic),
 		fmt.Sprintf("Parameterized|%v", parameterized),


### PR DESCRIPTION
If the `nomad` CLI is used to access a cluster running a version that does not include node pools the command will `nil` panic when trying to resolve the job's node pool.

Thanks @gulducat for the report!