### PR TITLE
Feat: add windows `os.build` attribute to host fingerprint

### DIFF
--- a/.changelog/17576.txt
+++ b/.changelog/17576.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runtime: Added 'os.build' attribute to node fingerprint on windows os
+```

--- a/client/fingerprint/host.go
+++ b/client/fingerprint/host.go
@@ -5,6 +5,7 @@ package fingerprint
 
 import (
 	"runtime"
+	"strings"
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/shirou/gopsutil/v3/host"
@@ -29,12 +30,21 @@ func (f *HostFingerprint) Fingerprint(req *FingerprintRequest, resp *Fingerprint
 		return err
 	}
 
+	if runtime.GOOS == "windows" {
+		platformVersion := strings.Split(hostInfo.PlatformVersion, "Build")
+		if len(platformVersion) == 2 {
+			resp.AddAttribute("os.version", strings.TrimSpace(platformVersion[0]))
+			resp.AddAttribute("os.build", strings.TrimSpace(platformVersion[1]))
+		} else {
+			f.logger.Warn("unable to retrieve 'os.build' attribute", "platform_version", hostInfo.PlatformVersion)
+		}
+	} else {
+		resp.AddAttribute("os.version", hostInfo.PlatformVersion)
+		resp.AddAttribute("kernel.version", hostInfo.KernelVersion)
+	}
 	resp.AddAttribute("os.name", hostInfo.Platform)
-	resp.AddAttribute("os.version", hostInfo.PlatformVersion)
-
 	resp.AddAttribute("kernel.name", runtime.GOOS)
 	resp.AddAttribute("kernel.arch", hostInfo.KernelArch)
-	resp.AddAttribute("kernel.version", hostInfo.KernelVersion)
 
 	resp.AddAttribute("unique.hostname", hostInfo.Hostname)
 	resp.Detected = true

--- a/client/fingerprint/host_test.go
+++ b/client/fingerprint/host_test.go
@@ -4,6 +4,7 @@
 package fingerprint
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
@@ -35,8 +36,17 @@ func TestHostFingerprint(t *testing.T) {
 		t.Fatalf("should generate a diff of node attributes")
 	}
 
+	commonAttributes := []string{"os.name", "os.version", "unique.hostname", "kernel.name"}
+	nonWindowsAttributes := append(commonAttributes, "kernel.version")
+	windowsAttributes := append(commonAttributes, "os.build")
+
+	expectedAttributes := nonWindowsAttributes
+	if runtime.GOOS == "windows" {
+		expectedAttributes = windowsAttributes
+	}
+
 	// Host info
-	for _, key := range []string{"os.name", "os.version", "unique.hostname", "kernel.name"} {
+	for _, key := range expectedAttributes {
 		assertNodeAttributeContains(t, response.Attributes, key)
 	}
 }

--- a/website/content/docs/runtime/interpolation.mdx
+++ b/website/content/docs/runtime/interpolation.mdx
@@ -122,6 +122,7 @@ Below is a table documenting common node properties.
 | `${attr.platform.aws.placement.availability-zone}` | Availability Zone of the client (if on AWS EC2)                                                                                                        |
 | `${attr.os.name}`                                  | Operating system of the client (e.g. `ubuntu`, `windows`, `darwin`)                                                                                    |
 | `${attr.os.version}`                               | Version of the client OS                                                                                                                               |
+| `${attr.os.build}`                                 | Build number (e.g `14393.5501`) of the client OS (if on Windows)                                                                                       |
 
 The full list of node attributes can be obtained by running `nomad node status -verbose [node]`.
 


### PR DESCRIPTION
fixes #16591