### PR TITLE
core: use faster concatenation for alloc name generation.

### DIFF
--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -382,7 +382,7 @@ func DenormalizeAllocationJobs(job *Job, allocs []*Allocation) {
 
 // AllocName returns the name of the allocation given the input.
 func AllocName(job, group string, idx uint) string {
-	return fmt.Sprintf("%s.%s[%d]", job, group, idx)
+	return job + "." + group + "[" + strconv.FormatUint(uint64(idx), 10) + "]"
 }
 
 // AllocSuffix returns the alloc index suffix that was added by the AllocName


### PR DESCRIPTION
I was poking around in this code, so thought I would experiment quickly with an improvement to the name generation. I'm not strongly in favour of this, as it makes reading slightly more difficult, but thought I'd raise it to be opinions anyway.

benchmark:
```
goos: darwin
goarch: arm64
pkg: jrasell-experiments/benchmarks
BenchmarkAllocNameOriginal-12    	 9239590	       111.2 ns/op	      80 B/op	       3 allocs/op
BenchmarkAllocNameNew-12         	34172659	        35.10 ns/op	      48 B/op	       1 allocs/op
```