### PR TITLE
[ui] General status for steady-state jobs

### DIFF
--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -9,7 +9,7 @@
       {{did-insert (action this.establishOldAllocBlockIDs)}}
       >
         <h2>Status:
-          <Hds::Badge @text="Deploying {{@job.latestDeployment.shortId}}" @color="highlight" @type="outlined" @size="small" />
+          <Hds::Badge @text="Deploying {{@job.latestDeployment.shortId}}" @color="highlight" @type="filled" />
         </h2>
         <div class="pull-right">
           {{#if @job.latestDeployment.isRunning}}
@@ -50,7 +50,7 @@
                 <A.Description>Your canary allocations have failed their health checks. Please have a look at the error logs and task events for the allocations in question.</A.Description>
               </Hds::Alert>
             {{else}}
-              <Hds::Alert @type="inline" @color="highlight" as |A|>
+              <Hds::Alert @type="inline" @color="neutral" as |A|>
                 <A.Title>Checking Canary health</A.Title>
                 {{#if this.deploymentIsAutoPromoted}}
                   <A.Description>Your canary allocations are being placed and health-checked. If they pass, they will be automatically promoted and your deployment will continue.</A.Description>

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -3,34 +3,29 @@
   SPDX-License-Identifier: MPL-2.0
 ~}}
 
-<div class="job-status-panel boxed-section active-deployment is-info" data-test-job-status-panel>
-  <div class="boxed-section-head">
+<div class="job-status-panel boxed-section active-deployment" data-test-job-status-panel>
+  <div class="boxed-section-head hds-foreground-primary">
     <div class="boxed-section-row"
       {{did-insert (action this.establishOldAllocBlockIDs)}}
       >
-        Deployment Status
-        <span class="badge is-white bumper-left" data-test-active-deployment-stat="id">{{@job.latestDeployment.shortId}}</span>
+        <h2>Status:
+          <Hds::Badge @text="Deploying {{@job.latestDeployment.shortId}}" @color="highlight" @type="outlined" @size="small" />
+        </h2>
+        {{!-- <span class="badge is-white bumper-left" data-test-active-deployment-stat="id">{{@job.latestDeployment.shortId}}</span> --}}
         <div class="pull-right">
           {{#if @job.latestDeployment.isRunning}}
-            <TwoStepButton
+            <Hds::Button
+              data-test-fail
+              {{on "click" (perform this.fail)}}
+              disabled={{this.fail.isRunning}}
+              @color="critical"
+              @text="Fail Deployment"
               {{keyboard-shortcut
                 label="Fail Deployment"
                 pattern=(array "f" "a" "i" "l")
                 action=(perform this.fail)
               }}
-              data-test-fail
-              @classes={{hash
-                idleButton="is-danger"
-                confirmationMessage="inherit-color"
-                confirmButton="is-danger"}}
-              @idleText="Fail Deployment"
-              @cancelText="Cancel"
-              @confirmText="Yes, Fail Deployment"
-              @confirmationMessage="Are you sure?"
-              @inlineText={{true}}
-              @awaitingConfirmation={{this.fail.isRunning}}
-              @disabled={{this.fail.isRunning}}
-              @onConfirm={{perform this.fail}} />
+            />
           {{/if}}
         </div>
       </div>

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -11,7 +11,6 @@
         <h2>Status:
           <Hds::Badge @text="Deploying {{@job.latestDeployment.shortId}}" @color="highlight" @type="outlined" @size="small" />
         </h2>
-        {{!-- <span class="badge is-white bumper-left" data-test-active-deployment-stat="id">{{@job.latestDeployment.shortId}}</span> --}}
         <div class="pull-right">
           {{#if @job.latestDeployment.isRunning}}
             <Hds::Button

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -5,7 +5,7 @@
 
 <div class="job-status-panel boxed-section steady-state {{if (eq @statusMode "historical") "historical-state" "current-state"}}" data-test-job-status-panel data-test-status-mode={{@statusMode}}>
   <div class="boxed-section-head">
-    <h2>Status: <Hds::Badge @text={{this.currentStatus.label}} @color={{this.currentStatus.state}} @type="filled" @size="small" /></h2>
+    <h2>Status: <Hds::Badge @text={{this.currentStatus.label}} @color={{this.currentStatus.state}} @type="filled" /></h2>
     
     <div class="select-mode">
       <button type="button"

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -5,7 +5,14 @@
 
 <div class="job-status-panel boxed-section steady-state {{if (eq @statusMode "historical") "historical-state" "current-state"}}" data-test-job-status-panel data-test-status-mode={{@statusMode}}>
   <div class="boxed-section-head">
-    <h2>Status</h2>
+    <h2>Status:
+
+{{!-- <Hds::Badge @text="Highlight badge" @color="highlight" /> --}}
+<Hds::Badge @text={{this.currentStatus.label}} @color={{this.currentStatus.state}} @type="outlined" @size="small" />
+{{!-- <Hds::Badge @text="Warning badge" @color="warning" />
+<Hds::Badge @text="Critical badge" @color="critical" /> --}}
+    </h2>
+    
     <div class="select-mode">
       <button type="button"
         data-test-status-mode-current

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -5,7 +5,7 @@
 
 <div class="job-status-panel boxed-section steady-state {{if (eq @statusMode "historical") "historical-state" "current-state"}}" data-test-job-status-panel data-test-status-mode={{@statusMode}}>
   <div class="boxed-section-head">
-    <h2>Status: <Hds::Badge @text={{this.currentStatus.label}} @color={{this.currentStatus.state}} @type="outlined" @size="small" /></h2>
+    <h2>Status: <Hds::Badge @text={{this.currentStatus.label}} @color={{this.currentStatus.state}} @type="filled" @size="small" /></h2>
     
     <div class="select-mode">
       <button type="button"

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -5,13 +5,7 @@
 
 <div class="job-status-panel boxed-section steady-state {{if (eq @statusMode "historical") "historical-state" "current-state"}}" data-test-job-status-panel data-test-status-mode={{@statusMode}}>
   <div class="boxed-section-head">
-    <h2>Status:
-
-{{!-- <Hds::Badge @text="Highlight badge" @color="highlight" /> --}}
-<Hds::Badge @text={{this.currentStatus.label}} @color={{this.currentStatus.state}} @type="outlined" @size="small" />
-{{!-- <Hds::Badge @text="Warning badge" @color="warning" />
-<Hds::Badge @text="Critical badge" @color="critical" /> --}}
-    </h2>
+    <h2>Status: <Hds::Badge @text={{this.currentStatus.label}} @color={{this.currentStatus.state}} @type="outlined" @size="small" /></h2>
     
     <div class="select-mode">
       <button type="button"

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -2,6 +2,7 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
+@import '~@hashicorp/design-system-tokens/dist/products/css/helpers/colors.css';
 
 .job-status-panel {
   // #region layout
@@ -21,6 +22,22 @@
 
     & > .allocation-status-row {
       grid-area: allocation-status-row;
+    }
+  }
+
+  .boxed-section-head h2 .hds-badge {
+    margin-left: 5px;
+    margin-top: -2px;
+  }
+
+  &.active-deployment {
+    & > .boxed-section-head {
+      background: var(--token-color-surface-highlight);
+    }
+    & > .boxed-section-head,
+    & > .boxed-section-body,
+    & > .boxed-section-foot {
+      border-color: var(--token-color-border-highlight);
     }
   }
 

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -33,6 +33,12 @@
   &.active-deployment {
     & > .boxed-section-head {
       background: var(--token-color-surface-highlight);
+
+      h2 .hds-badge {
+        background-color: var(--token-color-border-highlight);
+        border-color: var(--token-color-border-highlight);
+        color: var(--token-color-foreground-highlight-high-contrast);
+      }
     }
     & > .boxed-section-head,
     & > .boxed-section-body,

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -132,7 +132,7 @@
     gap: 0.5rem;
     grid-template-columns: 1fr 1fr;
     padding: 0.25rem 0.5rem;
-    margin-left: 1rem;
+    margin-left: auto;
 
     button {
       height: auto;

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -12,7 +12,6 @@
         <span>Pack</span>
       </span>
     {{/if}}
-    <span class="bumper-left tag {{this.job.statusClass}}" data-test-job-status>{{this.job.status}}</span>
     {{yield}}
   </div>
   <div>

--- a/ui/tests/integration/components/job-page/service-test.js
+++ b/ui/tests/integration/components/job-page/service-test.js
@@ -303,8 +303,7 @@ module('Integration | Component | job-page/service', function (hooks) {
     this.setProperties(commonProperties(job));
     await render(commonTemplate);
 
-    await click('.active-deployment [data-test-idle-button]');
-    await click('.active-deployment [data-test-confirm-button]');
+    await click('.active-deployment [data-test-fail]');
 
     const requests = this.server.pretender.handledRequests;
 
@@ -331,8 +330,7 @@ module('Integration | Component | job-page/service', function (hooks) {
     this.setProperties(commonProperties(job));
     await render(commonTemplate);
 
-    await click('.active-deployment [data-test-idle-button]');
-    await click('.active-deployment [data-test-confirm-button]');
+    await click('.active-deployment [data-test-fail]');
 
     assert.equal(
       find('[data-test-job-error-title]').textContent,

--- a/ui/tests/integration/components/job-status-panel-test.js
+++ b/ui/tests/integration/components/job-status-panel-test.js
@@ -48,7 +48,7 @@ module(
     });
 
     test('the latest deployment section shows up for the currently running deployment: Ungrouped Allocations (small cluster)', async function (assert) {
-      assert.expect(25);
+      assert.expect(24);
 
       this.server.create('node');
 
@@ -114,11 +114,6 @@ module(
       assert.ok(
         find('.active-deployment'),
         'Shows an active deployment if latest status is Running'
-      );
-
-      assert.ok(
-        find('.active-deployment').classList.contains('is-info'),
-        'Running deployment gets the is-info class'
       );
 
       // Half the shown allocations are running, 1 is pending, 1 is failed; none are canaries or healthy.


### PR DESCRIPTION
An abstracted status to indicate how a job is doing, based on its allocations' clientStatus, compared to what is expected/desired.

Possible states:
Batch/Sysbatch jobs:
- Complete if all are complete
- Running if any are running
- Degraded if any are failed/lost
- Failed if all are failed/lost

Service and System jobs:
- Healthy if all are running
- Recovering if any are "pending" (Note: pending in a non-deploying state means a reschedule has taken place, etc.)
- Degraded if some are failed/lost/unplaced
- Failed if all are failed/lost/unplaced

![image](https://github.com/hashicorp/nomad/assets/713991/b8fa7888-af6a-49b9-a3ad-d1b2670950de)
![image](https://github.com/hashicorp/nomad/assets/713991/8516300f-3ad3-4606-b230-2611edea6644)
![image](https://github.com/hashicorp/nomad/assets/713991/74649403-fedc-4913-a338-ac469b484a97)
![image](https://github.com/hashicorp/nomad/assets/713991/39533433-f7a8-4c05-8636-79fe7d94885b)
<img width="997" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/37abf348-2341-4edf-a7d5-a85a8fa05111">

