### PR TITLE
ci: hclfmt files

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,36 @@
+# Run 'make check' on paths ignored by test-core.yaml.
+name: Run checks
+on:
+  pull_request:
+    paths:
+      - 'demo/**'
+      - 'e2e/terraform/**'
+      - 'terraform/**'
+      - 'website/**'
+  push:
+    branches:
+      - 'main'
+      - 'release/**'
+    paths:
+      - 'demo/**'
+      - 'e2e/terraform/**'
+      - 'terraform/**'
+      - 'website/**'
+  workflow_call:
+
+jobs:
+  checks:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          fetch-depth: 0 # needs tags for checkproto
+      - uses: hashicorp/setup-golang@v1
+      - name: Run make check
+        run: |
+          make missing
+          make bootstrap
+          make check
+permissions:
+  contents: read

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -57,19 +57,8 @@ jobs:
           make tidy
           make bootstrap
   checks:
+    uses: ./.github/workflows/checks.yaml
     needs: [mods]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          fetch-depth: 0 # needs tags for checkproto
-      - uses: hashicorp/setup-golang@v1
-      - name: Run make check
-        run: |
-          make missing
-          make bootstrap
-          make check
   compile:
     needs: [mods, checks]
     strategy:
@@ -129,4 +118,3 @@ jobs:
           sudo -E env "PATH=$PATH" make test-nomad
 permissions:
   contents: read
-

--- a/terraform/azure/modules/hashistack/hashistack.tf
+++ b/terraform/azure/modules/hashistack/hashistack.tf
@@ -96,11 +96,11 @@ resource "azurerm_network_security_rule" "hashistack-sgr-8500" {
 }
 
 resource "azurerm_public_ip" "hashistack-server-public-ip" {
-  count                        = "${var.server_count}"
-  name                         = "hashistack-server-ip-${count.index}"
-  location                     = "${var.location}"
-  resource_group_name          = "${azurerm_resource_group.hashistack.name}"
-  allocation_method            = "Static"
+  count               = "${var.server_count}"
+  name                = "hashistack-server-ip-${count.index}"
+  location            = "${var.location}"
+  resource_group_name = "${azurerm_resource_group.hashistack.name}"
+  allocation_method   = "Static"
 }
 
 resource "azurerm_network_interface" "hashistack-server-ni" {
@@ -173,11 +173,11 @@ data "template_file" "user_data_server" {
 }
 
 resource "azurerm_public_ip" "hashistack-client-public-ip" {
-  count                        = "${var.client_count}"
-  name                         = "hashistack-client-ip-${count.index}"
-  location                     = "${var.location}"
-  resource_group_name          = "${azurerm_resource_group.hashistack.name}"
-  allocation_method            = "Static"
+  count               = "${var.client_count}"
+  name                = "hashistack-client-ip-${count.index}"
+  location            = "${var.location}"
+  resource_group_name = "${azurerm_resource_group.hashistack.name}"
+  allocation_method   = "Static"
 }
 
 resource "azurerm_network_interface" "hashistack-client-ni" {


### PR DESCRIPTION
Apply `hclfmt` on files in the `terraform` directory and also add a new workflow to run `make check` on paths that are ignored by [`test-core.yaml`](https://github.com/hashicorp/nomad/blob/main/.github/workflows/test-core.yaml) but have content verified by `make check`.

https://github.com/hashicorp/nomad/pull/17601 shows an example where code is changed. Only one instance of `checks.yaml` runs.

https://github.com/hashicorp/nomad/pull/17604 shows an example where only HCL files are changed. Again, only one isntance of `checks.yaml` runs.

I think we may ended up with duplicate runs if a PR changes files in and out of the ignore list, but I think that's relative rare? Except maybe for `website/**` so we could remove it from `checks.yaml`.