### PR TITLE
state: remove vague scaling event schema todo item.

### DIFF
--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -1178,7 +1178,7 @@ func csiPluginTableSchema() *memdb.TableSchema {
 	}
 }
 
-// StringFieldIndex is used to extract a field from an object
+// ScalingPolicyTargetFieldIndex is used to extract a field from an object
 // using reflection and builds an index on that field.
 type ScalingPolicyTargetFieldIndex struct {
 	Field string
@@ -1333,16 +1333,6 @@ func scalingEventTableSchema() *memdb.TableSchema {
 					},
 				},
 			},
-
-			// TODO: need to figure out whether we want to index these or the jobs or ...
-			// "error": {
-			// 	Name:         "error",
-			// 	AllowMissing: false,
-			// 	Unique:       false,
-			// 	Indexer: &memdb.FieldSetIndex{
-			// 		Field: "Error",
-			// 	},
-			// },
 		},
 	}
 }


### PR DESCRIPTION
It's a vague, 3 year old todo. If we want more indexes, we can identify which when coming to design it.