### PR TITLE
test: add MultiregionMinJob mock

### DIFF
--- a/nomad/mock/job.go
+++ b/nomad/mock/job.go
@@ -322,6 +322,26 @@ func MultiregionJob() *structs.Job {
 	return job
 }
 
+func MultiregionMinJob() *structs.Job {
+	job := MinJob()
+	update := *structs.DefaultUpdateStrategy
+	job.Update = update
+	job.TaskGroups[0].Update = &update
+	job.Multiregion = &structs.Multiregion{
+		Regions: []*structs.MultiregionRegion{
+			{
+				Name:  "west",
+				Count: 1,
+			},
+			{
+				Name:  "east",
+				Count: 1,
+			},
+		},
+	}
+	return job
+}
+
 func BatchJob() *structs.Job {
 	job := &structs.Job{
 		Region:      "global",


### PR DESCRIPTION
Add `MultiregionMinJob()` mock to be used in Enterprise tests. Backporting in case it becomes useful to test bug fixes.