### PR TITLE
[UI, CI] Bump the ember-test-audit workflow to node 18

### DIFF
--- a/.github/workflows/ember-test-audit.yml
+++ b/.github/workflows/ember-test-audit.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: '14'
+          node-version: '18'
       - run: yarn --frozen-lockfile
       - run: mkdir -p /tmp/test-reports
       - run: npx ember-test-audit 1 --json --output ../base-audit.json
@@ -39,7 +39,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: '14'
+          node-version: '18'
       - run: yarn --frozen-lockfile
       - run: mkdir -p /tmp/test-reports
       - run: npx ember-test-audit 1 --json --output ../pr-audit.json


### PR DESCRIPTION
After upgrading Storybook, the `ember-test-audit` workflow started insta-failing due to an incompatible node version for a Storybook related dependency:

```
error @storybook/ember-cli-storybook@0.6.0: The engine "node" is incompatible with this module. Expected version ">= 16". Got "14.21.3"
```

Node 14 is past EOL, so it makes sense to upgrade it in the workflow.