### PR TITLE
[ui] Versions added to deploying status panel

### DIFF
--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -84,7 +84,7 @@
 
         {{/if}}
 
-        <h4 class="title is-5" data-test-new-allocation-tally>New allocations: {{this.newRunningHealthyAllocBlocks.length}}/{{this.totalAllocs}} running and healthy
+        <h4 class="title is-5" data-test-new-allocation-tally><span>New allocations: {{this.newRunningHealthyAllocBlocks.length}}/{{this.totalAllocs}} running and healthy</span>
           <LinkTo data-version={{@job.version}} @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' @job.version ']')}}>
             <Hds::Badge @text={{concat "v" @job.version}} />
           </LinkTo>

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -65,7 +65,28 @@
 
       <div class="deployment-allocations">
         {{#if this.oldVersionAllocBlockIDs.length}}
-          <h4 class="title is-5" data-test-old-allocation-tally>Previous allocations: {{#if this.oldVersionAllocBlocks.running}}{{this.oldRunningHealthyAllocBlocks.length}} running{{/if}}</h4>
+          <h4 class="title is-5 previous-allocations-heading" data-test-old-allocation-tally>
+            <span>
+              Previous allocations: {{#if this.oldVersionAllocBlocks.running}}{{this.oldRunningHealthyAllocBlocks.length}} running{{/if}}
+            </span>
+
+            <section class="versions">
+              <ul>
+                {{#each this.oldVersions as |versionObj|}}
+                  <li>
+                    <LinkTo data-version={{versionObj.version}} @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' versionObj.version ']')    status=(concat '["running", "pending", "failed"]')         }}>
+                      {{#if (eq versionObj.version "unknown")}}
+                        <Hds::Badge @text="unknown" />
+                      {{else}}
+                        <Hds::Badge @text={{concat "v" versionObj.version}} />
+                      {{/if}}
+                      <Hds::BadgeCount @text={{versionObj.allocations.length}} @type="inverted" />
+                    </LinkTo>
+                  </li>
+                {{/each}}
+              </ul>
+            </section>
+          </h4>
           <div class="previous-allocations">
             <JobStatus::AllocationStatusRow @allocBlocks={{this.oldVersionAllocBlocks}} @steady={{true}} />
           </div>
@@ -144,25 +165,6 @@
           @job={{@job}}
           @supportsRescheduling={{true}}
         />
-
-        <section class="versions">
-          <h4>Versions</h4>
-          <ul>
-            {{#each this.versions as |versionObj|}}
-              <li>
-                <LinkTo data-version={{versionObj.version}} @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' versionObj.version ']')    status=(concat '["running", "pending", "failed"]')         }}>
-                  {{#if (eq versionObj.version "unknown")}}
-                    <Hds::Badge @text="unknown" />
-                  {{else}}
-                    <Hds::Badge @text={{concat "v" versionObj.version}} />
-                  {{/if}}
-                  <Hds::BadgeCount @text={{versionObj.allocations.length}} @type="inverted" />
-                </LinkTo>
-              </li>
-            {{/each}}
-          </ul>
-        </section>
-
 
       </div>
 

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -76,11 +76,11 @@
                   <li>
                     <LinkTo data-version={{versionObj.version}} @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' versionObj.version ']')    status=(concat '["running", "pending", "failed"]')         }}>
                       {{#if (eq versionObj.version "unknown")}}
-                        <Hds::Badge @text="unknown" />
+                        <Hds::Badge @text="unknown" class="version-label" />
                       {{else}}
-                        <Hds::Badge @text={{concat "v" versionObj.version}} />
+                        <Hds::Badge @text={{concat "v" versionObj.version}} class="version-label" />
                       {{/if}}
-                      <Hds::BadgeCount @text={{versionObj.allocations.length}} @type="inverted" />
+                      <Hds::Badge @text={{versionObj.allocations.length}} class="version-count" />
                     </LinkTo>
                   </li>
                 {{/each}}
@@ -106,9 +106,11 @@
         {{/if}}
 
         <h4 class="title is-5" data-test-new-allocation-tally><span>New allocations: {{this.newRunningHealthyAllocBlocks.length}}/{{this.totalAllocs}} running and healthy</span>
+          <span class="versions">
           <LinkTo data-version={{@job.version}} @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' @job.version ']')}}>
-            <Hds::Badge @text={{concat "v" @job.version}} />
+            <Hds::Badge @text={{concat "v" @job.version}} class="version-label" />
           </LinkTo>
+          </span>
         </h4>
         <div class="new-allocations">
           <JobStatus::AllocationStatusRow @allocBlocks={{this.newVersionAllocBlocks}} />

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -84,7 +84,11 @@
 
         {{/if}}
 
-        <h4 class="title is-5" data-test-new-allocation-tally>New allocations: {{this.newRunningHealthyAllocBlocks.length}}/{{this.totalAllocs}} running and healthy</h4>
+        <h4 class="title is-5" data-test-new-allocation-tally>New allocations: {{this.newRunningHealthyAllocBlocks.length}}/{{this.totalAllocs}} running and healthy
+          <LinkTo data-version={{@job.version}} @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' @job.version ']')}}>
+            <Hds::Badge @text={{concat "v" @job.version}} />
+          </LinkTo>
+        </h4>
         <div class="new-allocations">
           <JobStatus::AllocationStatusRow @allocBlocks={{this.newVersionAllocBlocks}} />
         </div>
@@ -140,6 +144,25 @@
           @job={{@job}}
           @supportsRescheduling={{true}}
         />
+
+        <section class="versions">
+          <h4>Versions</h4>
+          <ul>
+            {{#each this.versions as |versionObj|}}
+              <li>
+                <LinkTo data-version={{versionObj.version}} @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' versionObj.version ']')    status=(concat '["running", "pending", "failed"]')         }}>
+                  {{#if (eq versionObj.version "unknown")}}
+                    <Hds::Badge @text="unknown" />
+                  {{else}}
+                    <Hds::Badge @text={{concat "v" versionObj.version}} />
+                  {{/if}}
+                  <Hds::BadgeCount @text={{versionObj.allocations.length}} @type="inverted" />
+                </LinkTo>
+              </li>
+            {{/each}}
+          </ul>
+        </section>
+
 
       </div>
 

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -79,11 +79,11 @@
               <li>
                 <LinkTo data-version={{versionObj.version}} @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' versionObj.version ']')    status=(concat '["running", "pending", "failed"]')         }}>
                   {{#if (eq versionObj.version "unknown")}}
-                    <Hds::Badge @text="unknown" />
+                    <Hds::Badge @text="unknown" @type="filled" class="version-label" />
                   {{else}}
-                    <Hds::Badge @text={{concat "v" versionObj.version}} />
+                    <Hds::Badge @text={{concat "v" versionObj.version}} @type="filled" class="version-label" />
                   {{/if}}
-                  <Hds::BadgeCount @text={{versionObj.allocations.length}} @type="inverted" />
+                  <Hds::Badge @text={{versionObj.allocations.length}} @type="filled" class="version-count" />
                 </LinkTo>
               </li>
             {{/each}}

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -110,10 +110,25 @@
       gap: 0.5rem;
       & > li {
         white-space: nowrap;
-        & a {
-          text-decoration: none;
-        }
       }
+      a {
+        text-decoration: none;
+      }
+    }
+    .version-label {
+      position: relative;
+      z-index: 2;
+      & > .hds-badge__text {
+        font-weight: 700;
+      }
+    }
+    .version-count {
+      color: $blue;
+      position: relative;
+      z-index: 1;
+      left: -1rem;
+      padding-left: 1rem;
+      background-color: var(--token-color-surface-faint);
     }
   }
 

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -86,11 +86,34 @@
 
       & > h4 {
         margin-bottom: -0.5rem;
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0.5rem;
+
+        & > .versions > ul {
+          grid-template-columns: unset;
+          grid-auto-columns: min-content;
+          grid-auto-flow: column;
+        }
       }
     }
 
     & > .history-and-params {
       grid-area: history-and-params;
+    }
+  }
+
+  .versions {
+    & > ul {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, 100px);
+      gap: 0.5rem;
+      & > li {
+        white-space: nowrap;
+        & a {
+          text-decoration: none;
+        }
+      }
     }
   }
 
@@ -115,19 +138,6 @@
       grid-template-columns: repeat(4, 1fr);
       grid-auto-rows: max-content;
       gap: 0.5rem;
-    }
-    .versions {
-      & > ul {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, 100px);
-        gap: 0.5rem;
-        & > li {
-          white-space: nowrap;
-          & a {
-            text-decoration: none;
-          }
-        }
-      }
     }
     .latest-deployment {
       h4 svg {

--- a/ui/tests/integration/components/job-status-panel-test.js
+++ b/ui/tests/integration/components/job-status-panel-test.js
@@ -200,7 +200,7 @@ module(
         );
 
       assert.equal(
-        find('[data-test-new-allocation-tally]').textContent.trim(),
+        find('[data-test-new-allocation-tally] > span').textContent.trim(),
         `New allocations: ${
           this.job.allocations.filter(
             (a) =>
@@ -291,7 +291,7 @@ module(
         );
 
       assert.equal(
-        find('[data-test-new-allocation-tally]').textContent.trim(),
+        find('[data-test-new-allocation-tally] > span').textContent.trim(),
         `New allocations: ${
           this.job.allocations.filter(
             (a) =>

--- a/ui/tests/integration/components/job-status-panel-test.js
+++ b/ui/tests/integration/components/job-status-panel-test.js
@@ -303,7 +303,7 @@ module(
       );
 
       assert.equal(
-        find('[data-test-old-allocation-tally]').textContent.trim(),
+        find('[data-test-old-allocation-tally] > span').textContent.trim(),
         `Previous allocations: ${
           this.job.allocations.filter(
             (a) =>
@@ -355,7 +355,7 @@ module(
         );
 
       assert.equal(
-        find('[data-test-old-allocation-tally]').textContent.trim(),
+        find('[data-test-old-allocation-tally] > span').textContent.trim(),
         `Previous allocations: ${
           this.job.allocations.filter(
             (a) =>


### PR DESCRIPTION
In two places:
- next to the "New allocations: x/y running and healthy" shows the latest version number
- in a "Versions" cell that matches the steady state format, which'll show counts for all allocations running between prev and new allocs of non-terminal status
![image](https://github.com/hashicorp/nomad/assets/713991/b2918c6c-1e28-477c-a9d8-af066a2107f3)
![image](https://github.com/hashicorp/nomad/assets/713991/ee849ec7-b460-4259-b132-8898bd60ac5a)
