### PR TITLE
Update node version to 16 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Setup node and yarn
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: "14"
+          node-version: "16"
           cache-dependency-path: "ui/yarn.lock"
 
       - name: Install Yarn


### PR DESCRIPTION
node 16 is required to run "generating static asset" part now