### PR TITLE
ui: setup mirage and tests for node pools

### DIFF
--- a/ui/mirage/factories/job.js
+++ b/ui/mirage/factories/job.js
@@ -200,6 +200,11 @@ export default Factory.extend({
   shallow: false,
 
   afterCreate(job, server) {
+    Ember.assert(
+      '[Mirage] No node pools! make sure node pools are created before jobs',
+      server.db.nodePools.length
+    );
+
     if (!job.namespaceId) {
       const namespace = server.db.namespaces.length
         ? pickOne(server.db.namespaces).id
@@ -215,11 +220,8 @@ export default Factory.extend({
     }
 
     if (!job.nodePool) {
-      const nodePool = server.db.nodePools.length
-        ? pickOne(server.db.nodePools).name
-        : server.create('node-pool').name;
       job.update({
-        nodePool,
+        nodePool: pickOne(server.db.nodePools).name,
       });
     }
 

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -609,7 +609,7 @@ function allNodeTypes(server) {
 
 function everyFeature(server) {
   server.createList('agent', 3, 'withConsulLink', 'withVaultLink');
-  server.createList('node-pool', count);
+  server.createList('node-pool', 3);
 
   server.create('node', 'forceIPv4');
   server.create('node', 'draining');

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -44,9 +44,12 @@ export default function (server) {
     );
   }
 
+  // Make sure built-in node pools exist.
+  createBuiltInNodePools(server);
   if (withNamespaces) createNamespaces(server);
   if (withTokens) createTokens(server);
   if (withRegions) createRegions(server);
+
   activeScenario(server);
 }
 
@@ -56,6 +59,7 @@ function smallCluster(server) {
   faker.seed(1);
   server.create('feature', { name: 'Dynamic Application Sizing' });
   server.createList('agent', 3, 'withConsulLink', 'withVaultLink');
+  server.createList('node-pool', 2);
   server.createList('node', 5);
   server.create(
     'node',
@@ -347,6 +351,7 @@ function smallCluster(server) {
 
 function mediumCluster(server) {
   server.createList('agent', 3, 'withConsulLink', 'withVaultLink');
+  server.createList('node-pool', 5);
   server.createList('node', 50);
   server.createList('job', 25);
 }
@@ -563,12 +568,14 @@ function servicesTestCluster(server) {
 // Due to Mirage performance, large cluster scenarios will be slow
 function largeCluster(server) {
   server.createList('agent', 5);
+  server.createList('node-pool', 10);
   server.createList('node', 1000);
   server.createList('job', 100);
 }
 
 function massiveCluster(server) {
   server.createList('agent', 7);
+  server.createList('node-pool', 100);
   server.createList('node', 5000);
   server.createList('job', 2000);
 }
@@ -602,6 +609,7 @@ function allNodeTypes(server) {
 
 function everyFeature(server) {
   server.createList('agent', 3, 'withConsulLink', 'withVaultLink');
+  server.createList('node-pool', count);
 
   server.create('node', 'forceIPv4');
   server.create('node', 'draining');
@@ -635,6 +643,11 @@ function emptyCluster(server) {
 }
 
 // Behaviors
+
+function createBuiltInNodePools(server) {
+  server.create('node-pool', { name: 'default' });
+  server.create('node-pool', { name: 'all' });
+}
 
 function createTokens(server) {
   server.createList('token', 3);

--- a/ui/mirage/scenarios/topo.js
+++ b/ui/mirage/scenarios/topo.js
@@ -16,6 +16,7 @@ const genResources = (CPU, Memory) => ({
 
 export function topoSmall(server) {
   server.createList('agent', 3, 'withConsulLink', 'withVaultLink');
+  server.createList('node-pool', 4);
   server.createList('node', 12, {
     datacenter: 'dc1',
     status: 'ready',
@@ -35,7 +36,7 @@ export function topoSmall(server) {
     ['M: 512, C: 250', 'M: 600, C: 200'],
   ];
 
-  jobResources.forEach(spec => {
+  jobResources.forEach((spec) => {
     server.create('job', {
       status: 'running',
       datacenters: ['dc1'],
@@ -98,7 +99,7 @@ export function topoMedium(server) {
     ['M: 512, C: 250', 'M: 600, C: 200'],
   ];
 
-  jobResources.forEach(spec => {
+  jobResources.forEach((spec) => {
     server.create('job', {
       status: 'running',
       datacenters: ['dc1'],

--- a/ui/mirage/utils.js
+++ b/ui/mirage/utils.js
@@ -16,8 +16,13 @@ export function provider() {
   return () => provide(...arguments);
 }
 
-export function pickOne(list) {
-  return list[faker.random.number(list.length - 1)];
+export function pickOne(list, filterFn) {
+  let candidates = list;
+  if (filterFn) {
+    candidates = list.filter(filterFn);
+  }
+
+  return candidates[faker.random.number(candidates.length - 1)];
 }
 
 export function arrToObj(prop, alias = '') {
@@ -31,7 +36,6 @@ export function arrToObj(prop, alias = '') {
 }
 
 export const generateAcceptanceTestEvalMock = (id) => {
-
   return {
     CreateIndex: 20,
     CreateTime: 1647899150314738000,

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -34,6 +34,7 @@ module('Acceptance | allocation detail', function (hooks) {
   hooks.beforeEach(async function () {
     server.create('agent');
 
+    server.create('node-pool');
     node = server.create('node');
     job = server.create('job', {
       groupsCount: 1,
@@ -488,6 +489,7 @@ module('Acceptance | allocation detail (rescheduled)', function (hooks) {
   hooks.beforeEach(async function () {
     server.create('agent');
 
+    server.create('node-pool');
     node = server.create('node');
     job = server.create('job', { createAllocations: false });
     allocation = server.create('allocation', 'rescheduled');
@@ -510,6 +512,7 @@ module('Acceptance | allocation detail (not running)', function (hooks) {
   hooks.beforeEach(async function () {
     server.create('agent');
 
+    server.create('node-pool');
     node = server.create('node');
     job = server.create('job', { createAllocations: false });
     allocation = server.create('allocation', { clientStatus: 'pending' });
@@ -540,6 +543,7 @@ module('Acceptance | allocation detail (preemptions)', function (hooks) {
 
   hooks.beforeEach(async function () {
     server.create('agent');
+    server.create('node-pool');
     node = server.create('node');
     job = server.create('job', { createAllocations: false });
   });
@@ -678,6 +682,7 @@ module('Acceptance | allocation detail (services)', function (hooks) {
   hooks.beforeEach(async function () {
     server.create('feature', { name: 'Dynamic Application Sizing' });
     server.createList('agent', 3, 'withConsulLink', 'withVaultLink');
+    server.createList('node-pool', 3);
     server.createList('node', 5);
     server.createList('job', 1, { createRecommendations: true });
     const job = server.create('job', {

--- a/ui/tests/acceptance/allocation-fs-test.js
+++ b/ui/tests/acceptance/allocation-fs-test.js
@@ -20,6 +20,7 @@ module('Acceptance | allocation fs', function (hooks) {
 
   hooks.beforeEach(async function () {
     server.create('agent');
+    server.create('node-pool');
     server.create('node', 'forceIPv4');
     const job = server.create('job', { createAllocations: false });
 

--- a/ui/tests/acceptance/client-detail-test.js
+++ b/ui/tests/acceptance/client-detail-test.js
@@ -46,6 +46,7 @@ module('Acceptance | client detail', function (hooks) {
   hooks.beforeEach(function () {
     window.localStorage.clear();
 
+    server.create('node-pool');
     server.create('node', 'forceIPv4', { schedulingEligibility: 'eligible' });
     node = server.db.nodes[0];
 
@@ -1257,6 +1258,7 @@ module('Acceptance | client detail', function (hooks) {
       return Array.from(new Set(allocs.mapBy('jobId'))).sort();
     },
     async beforeEach() {
+      server.create('node-pool');
       server.createList('job', 5);
       await ClientDetail.visit({ id: node.id });
     },
@@ -1275,6 +1277,7 @@ module('Acceptance | client detail', function (hooks) {
       'Unknown',
     ],
     async beforeEach() {
+      server.create('node-pool');
       server.createList('job', 5, { createAllocations: false });
       ['pending', 'running', 'complete', 'failed', 'lost', 'unknown'].forEach(
         (s) => {
@@ -1306,6 +1309,7 @@ module('Acceptance | client detail (multi-namespace)', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
+    server.create('node-pool');
     server.create('node', 'forceIPv4', { schedulingEligibility: 'eligible' });
     node = server.db.nodes[0];
 

--- a/ui/tests/acceptance/clients-list-test.js
+++ b/ui/tests/acceptance/clients-list-test.js
@@ -20,6 +20,7 @@ module('Acceptance | clients list', function (hooks) {
 
   hooks.beforeEach(function () {
     window.localStorage.clear();
+    server.createList('node-pool', 3);
   });
 
   test('it passes an accessibility audit', async function (assert) {

--- a/ui/tests/acceptance/evaluations-test.js
+++ b/ui/tests/acceptance/evaluations-test.js
@@ -643,6 +643,7 @@ module('Acceptance | evaluations list', function (hooks) {
 
   module('resource linking', function () {
     test('it should generate a link to the job resource', async function (assert) {
+      server.create('node-pool');
       server.create('node');
       const job = server.create('job', { id: 'example', shallow: true });
       server.create('evaluation', { jobId: job.id });
@@ -662,6 +663,7 @@ module('Acceptance | evaluations list', function (hooks) {
     });
 
     test('it should generate a link to the node resource', async function (assert) {
+      server.create('node-pool');
       const node = server.create('node');
       server.create('evaluation', { nodeId: node.id });
       await visit('/evaluations');

--- a/ui/tests/acceptance/exec-test.js
+++ b/ui/tests/acceptance/exec-test.js
@@ -26,6 +26,7 @@ module('Acceptance | exec', function (hooks) {
     faker.seed(1);
 
     server.create('agent');
+    server.create('node-pool');
     server.create('node');
 
     this.job = server.create('job', {

--- a/ui/tests/acceptance/job-allocations-test.js
+++ b/ui/tests/acceptance/job-allocations-test.js
@@ -30,6 +30,7 @@ module('Acceptance | job allocations', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
+    server.create('node-pool');
     server.create('node');
 
     job = server.create('job', {
@@ -211,6 +212,7 @@ module('Acceptance | job allocations', function (hooks) {
       ).sort();
     },
     async beforeEach() {
+      server.create('node-pool');
       job = server.create('job', {
         type: 'service',
         status: 'running',

--- a/ui/tests/acceptance/job-clients-test.js
+++ b/ui/tests/acceptance/job-clients-test.js
@@ -43,6 +43,7 @@ module('Acceptance | job clients', function (hooks) {
       },
     });
 
+    server.createList('node-pool', 5);
     clients = server.createList('node', 12, {
       datacenter: 'dc1',
       status: 'ready',

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -282,6 +282,7 @@ module('Acceptance | job detail (with namespaces)', function (hooks) {
 
   hooks.beforeEach(function () {
     server.createList('namespace', 2);
+    server.create('node-pool');
     server.create('node');
     job = server.create('job', {
       type: 'service',

--- a/ui/tests/acceptance/job-dispatch-test.js
+++ b/ui/tests/acceptance/job-dispatch-test.js
@@ -47,6 +47,7 @@ function moduleForJobDispatch(title, jobFactory) {
 
     hooks.beforeEach(function () {
       // Required for placing allocations (a result of dispatching jobs)
+      server.create('node-pool');
       server.create('node');
 
       job = jobFactory();

--- a/ui/tests/acceptance/job-evaluations-test.js
+++ b/ui/tests/acceptance/job-evaluations-test.js
@@ -19,6 +19,7 @@ module('Acceptance | job evaluations', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
+    server.create('node-pool');
     job = server.create('job', {
       noFailedPlacements: true,
       createAllocations: false,

--- a/ui/tests/acceptance/job-run-test.js
+++ b/ui/tests/acceptance/job-run-test.js
@@ -66,6 +66,7 @@ module('Acceptance | job run', function (hooks) {
 
   hooks.beforeEach(function () {
     // Required for placing allocations (a result of creating jobs)
+    server.create('node-pool');
     server.create('node');
 
     managementToken = server.create('token');

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -28,6 +28,7 @@ module('Acceptance | job status panel', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
+    server.create('node-pool');
     server.create('node');
   });
 

--- a/ui/tests/acceptance/job-versions-test.js
+++ b/ui/tests/acceptance/job-versions-test.js
@@ -23,6 +23,7 @@ module('Acceptance | job versions', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
+    server.create('node-pool');
     server.create('namespace');
     namespace = server.create('namespace');
 
@@ -176,6 +177,7 @@ module('Acceptance | job versions (with client token)', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
+    server.create('node-pool');
     job = server.create('job', { createAllocations: false });
     versions = server.db.jobVersions.where({ jobId: job.id });
 

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -22,6 +22,7 @@ module('Acceptance | jobs list', function (hooks) {
 
   hooks.beforeEach(function () {
     // Required for placing allocations (a result of creating jobs)
+    server.create('node-pool');
     server.create('node');
 
     managementToken = server.create('token');

--- a/ui/tests/acceptance/keyboard-test.js
+++ b/ui/tests/acceptance/keyboard-test.js
@@ -248,6 +248,7 @@ module('Acceptance | keyboard', function (hooks) {
 
   module('Dynamic Nav', function (dynamicHooks) {
     dynamicHooks.beforeEach(async function () {
+      server.create('node-pool');
       server.create('node');
     });
     test('Dynamic Table Nav', async function (assert) {

--- a/ui/tests/acceptance/optimize-test.js
+++ b/ui/tests/acceptance/optimize-test.js
@@ -40,6 +40,7 @@ module('Acceptance | optimize', function (hooks) {
   hooks.beforeEach(async function () {
     server.create('feature', { name: 'Dynamic Application Sizing' });
 
+    server.create('node-pool');
     server.create('node');
 
     server.createList('namespace', 2);
@@ -440,6 +441,7 @@ module('Acceptance | optimize search and facets', function (hooks) {
   hooks.beforeEach(async function () {
     server.create('feature', { name: 'Dynamic Application Sizing' });
 
+    server.create('node-pool');
     server.create('node');
 
     server.createList('namespace', 2);

--- a/ui/tests/acceptance/regions-test.js
+++ b/ui/tests/acceptance/regions-test.js
@@ -22,6 +22,7 @@ module('Acceptance | regions (only one)', function (hooks) {
 
   hooks.beforeEach(function () {
     server.create('agent');
+    server.create('node-pool');
     server.create('node');
     server.createList('job', 2, {
       createAllocations: false,
@@ -88,6 +89,7 @@ module('Acceptance | regions (many)', function (hooks) {
 
   hooks.beforeEach(function () {
     server.create('agent');
+    server.create('node-pool');
     server.create('node');
     server.createList('job', 2, {
       createAllocations: false,

--- a/ui/tests/acceptance/search-test.js
+++ b/ui/tests/acceptance/search-test.js
@@ -19,6 +19,7 @@ module('Acceptance | search', function (hooks) {
   setupMirage(hooks);
 
   test('search exposes and navigates to results from the fuzzy search endpoint', async function (assert) {
+    server.create('node-pool');
     server.create('node', { name: 'xyz' });
     const otherNode = server.create('node', { name: 'ghi' });
 
@@ -184,6 +185,7 @@ module('Acceptance | search', function (hooks) {
   });
 
   test('results are truncated at 10 per group', async function (assert) {
+    server.create('node-pool');
     server.create('node', { name: 'xyz' });
 
     for (let i = 0; i < 11; i++) {
@@ -203,6 +205,7 @@ module('Acceptance | search', function (hooks) {
   });
 
   test('server-side truncation is indicated in the group label', async function (assert) {
+    server.create('node-pool');
     server.create('node', { name: 'xyz' });
 
     for (let i = 0; i < 21; i++) {
@@ -241,6 +244,7 @@ module('Acceptance | search', function (hooks) {
   });
 
   test('pressing slash when an input element is focused does not start a search', async function (assert) {
+    server.create('node-pool');
     server.create('node');
     server.create('job');
 

--- a/ui/tests/acceptance/task-detail-test.js
+++ b/ui/tests/acceptance/task-detail-test.js
@@ -22,6 +22,7 @@ module('Acceptance | task detail', function (hooks) {
 
   hooks.beforeEach(async function () {
     server.create('agent');
+    server.create('node-pool');
     server.create('node');
     server.create('job', { createAllocations: false });
     allocation = server.create('allocation', 'withTaskWithPorts', {
@@ -337,6 +338,7 @@ module('Acceptance | task detail (no addresses)', function (hooks) {
 
   hooks.beforeEach(async function () {
     server.create('agent');
+    server.create('node-pool');
     server.create('node');
     server.create('job');
     allocation = server.create('allocation', 'withoutTaskWithPorts', {
@@ -354,6 +356,7 @@ module('Acceptance | task detail (different namespace)', function (hooks) {
 
   hooks.beforeEach(async function () {
     server.create('agent');
+    server.create('node-pool');
     server.create('node');
     server.create('namespace');
     server.create('namespace', { id: 'other-namespace' });
@@ -412,6 +415,7 @@ module('Acceptance | task detail (not running)', function (hooks) {
 
   hooks.beforeEach(async function () {
     server.create('agent');
+    server.create('node-pool');
     server.create('node');
     server.create('namespace');
     server.create('namespace', { id: 'other-namespace' });
@@ -447,6 +451,7 @@ module('Acceptance | proxy task detail', function (hooks) {
 
   hooks.beforeEach(async function () {
     server.create('agent');
+    server.create('node-pool');
     server.create('node');
     server.create('job', { createAllocations: false });
     allocation = server.create('allocation', 'withTaskWithPorts', {

--- a/ui/tests/acceptance/task-fs-test.js
+++ b/ui/tests/acceptance/task-fs-test.js
@@ -21,6 +21,7 @@ module('Acceptance | task fs', function (hooks) {
 
   hooks.beforeEach(async function () {
     server.create('agent');
+    server.create('node-pool');
     server.create('node', 'forceIPv4');
     const job = server.create('job', { createAllocations: false });
 

--- a/ui/tests/acceptance/task-group-detail-test.js
+++ b/ui/tests/acceptance/task-group-detail-test.js
@@ -35,6 +35,7 @@ module('Acceptance | task group detail', function (hooks) {
 
   hooks.beforeEach(async function () {
     server.create('agent');
+    server.create('node-pool');
     server.create('node', 'forceIPv4');
 
     job = server.create('job', {

--- a/ui/tests/acceptance/task-logs-test.js
+++ b/ui/tests/acceptance/task-logs-test.js
@@ -25,6 +25,7 @@ module('Acceptance | task logs', function (hooks) {
   hooks.beforeEach(async function () {
     faker.seed(1);
     server.create('agent');
+    server.create('node-pool');
     server.create('node', 'forceIPv4');
     job = server.create('job', { createAllocations: false });
 

--- a/ui/tests/acceptance/topology-test.js
+++ b/ui/tests/acceptance/topology-test.js
@@ -29,6 +29,7 @@ module('Acceptance | topology', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
+    server.createList('node-pool', 5);
     server.create('job', { createAllocations: false });
   });
 

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -41,6 +41,7 @@ export default function moduleForJob(
     });
 
     hooks.beforeEach(async function () {
+      server.create('node-pool');
       server.create('node');
       job = jobFactory();
       if (!job.namespace || job.namespace === 'default') {
@@ -243,6 +244,7 @@ export function moduleForJobWithClientStatus(
     setupMirage(hooks);
 
     hooks.beforeEach(async function () {
+      server.createList('node-pool', 3);
       const clients = server.createList('node', 3, {
         datacenter: 'dc1',
         status: 'ready',

--- a/ui/tests/integration/components/allocation-row-test.js
+++ b/ui/tests/integration/components/allocation-row-test.js
@@ -21,6 +21,7 @@ module('Integration | Component | allocation row', function (hooks) {
     this.store = this.owner.lookup('service:store');
     this.server = startMirage();
     this.server.create('namespace');
+    this.server.create('node-pool');
     this.server.create('node');
     this.server.create('job', { createAllocations: false });
   });

--- a/ui/tests/integration/components/job-page/parts/children-test.js
+++ b/ui/tests/integration/components/job-page/parts/children-test.js
@@ -19,6 +19,7 @@ module('Integration | Component | job-page/parts/children', function (hooks) {
     this.store = this.owner.lookup('service:store');
     this.server = startMirage();
     this.server.create('namespace');
+    this.server.create('node-pool');
   });
 
   hooks.afterEach(function () {

--- a/ui/tests/integration/components/job-page/parts/placement-failures-test.js
+++ b/ui/tests/integration/components/job-page/parts/placement-failures-test.js
@@ -24,6 +24,7 @@ module(
       this.store = this.owner.lookup('service:store');
       this.server = startMirage();
       this.server.create('namespace');
+      this.server.create('node-pool');
     });
 
     hooks.afterEach(function () {

--- a/ui/tests/integration/components/job-page/parts/summary-test.js
+++ b/ui/tests/integration/components/job-page/parts/summary-test.js
@@ -20,6 +20,7 @@ module('Integration | Component | job-page/parts/summary', function (hooks) {
     this.store = this.owner.lookup('service:store');
     this.server = startMirage();
     this.server.create('namespace');
+    this.server.create('node-pool');
   });
 
   hooks.afterEach(function () {

--- a/ui/tests/integration/components/job-page/parts/task-groups-test.js
+++ b/ui/tests/integration/components/job-page/parts/task-groups-test.js
@@ -25,6 +25,7 @@ module(
       this.store = this.owner.lookup('service:store');
       this.server = startMirage();
       this.server.create('namespace');
+      this.server.create('node-pool');
     });
 
     hooks.afterEach(function () {

--- a/ui/tests/integration/components/job-page/periodic-test.js
+++ b/ui/tests/integration/components/job-page/periodic-test.js
@@ -39,6 +39,7 @@ module('Integration | Component | job-page/periodic', function (hooks) {
     this.store = this.owner.lookup('service:store');
     this.server = startMirage();
     this.server.create('namespace');
+    this.server.create('node-pool');
   });
 
   hooks.afterEach(function () {

--- a/ui/tests/integration/components/job-status-panel-test.js
+++ b/ui/tests/integration/components/job-status-panel-test.js
@@ -22,6 +22,7 @@ module(
       window.localStorage.clear();
       this.store = this.owner.lookup('service:store');
       this.server = startMirage();
+      this.server.create('node-pool');
       this.server.create('namespace');
     });
 

--- a/ui/tests/integration/components/primary-metric/allocation-test.js
+++ b/ui/tests/integration/components/primary-metric/allocation-test.js
@@ -27,6 +27,7 @@ module('Integration | Component | PrimaryMetric::Allocation', function (hooks) {
     this.store = this.owner.lookup('service:store');
     this.server = startMirage();
     this.server.create('namespace');
+    this.server.create('node-pool');
     this.server.create('node');
     this.server.create('job', {
       groupsCount: 1,

--- a/ui/tests/integration/components/primary-metric/task-test.js
+++ b/ui/tests/integration/components/primary-metric/task-test.js
@@ -27,6 +27,7 @@ module('Integration | Component | PrimaryMetric::Task', function (hooks) {
     this.store = this.owner.lookup('service:store');
     this.server = startMirage();
     this.server.create('namespace');
+    this.server.create('node-pool');
     this.server.create('node');
     const job = this.server.create('job', {
       groupsCount: 1,

--- a/ui/tests/integration/components/reschedule-event-timeline-test.js
+++ b/ui/tests/integration/components/reschedule-event-timeline-test.js
@@ -18,6 +18,7 @@ module('Integration | Component | reschedule event timeline', function (hooks) {
     this.store = this.owner.lookup('service:store');
     this.server = startMirage();
     this.server.create('namespace');
+    this.server.create('node-pool');
     this.server.create('node');
     this.server.create('job', { createAllocations: false });
   });

--- a/ui/tests/integration/components/scale-events-accordion-test.js
+++ b/ui/tests/integration/components/scale-events-accordion-test.js
@@ -20,6 +20,7 @@ module('Integration | Component | scale-events-accordion', function (hooks) {
     fragmentSerializerInitializer(this.owner);
     this.store = this.owner.lookup('service:store');
     this.server = startMirage();
+    this.server.create('node-pool');
     this.server.create('node');
     this.taskGroupWithEvents = async function (events) {
       const job = this.server.create('job', { createAllocations: false });

--- a/ui/tests/integration/components/task-group-row-test.js
+++ b/ui/tests/integration/components/task-group-row-test.js
@@ -58,6 +58,7 @@ module('Integration | Component | task group row', function (hooks) {
     this.store = this.owner.lookup('service:store');
     this.token = this.owner.lookup('service:token');
     this.server = startMirage();
+    this.server.create('node-pool');
     this.server.create('node');
 
     managementToken = this.server.create('token');

--- a/ui/tests/unit/adapters/allocation-test.js
+++ b/ui/tests/unit/adapters/allocation-test.js
@@ -25,6 +25,7 @@ module('Unit | Adapter | Allocation', function (hooks) {
       this.server.create('region', { id: 'region-1' });
       this.server.create('region', { id: 'region-2' });
 
+      this.server.create('node-pool');
       this.server.create('node');
       this.server.create('job', { createAllocations: false });
       this.server.create('allocation', { id: 'alloc-1' });

--- a/ui/tests/unit/adapters/deployment-test.js
+++ b/ui/tests/unit/adapters/deployment-test.js
@@ -25,6 +25,7 @@ module('Unit | Adapter | Deployment', function (hooks) {
       this.server.create('region', { id: 'region-1' });
       this.server.create('region', { id: 'region-2' });
 
+      this.server.create('node-pool');
       this.server.create('node');
       const job = this.server.create('job', { createAllocations: false });
       const deploymentRecord = server.schema.deployments.where({

--- a/ui/tests/unit/adapters/job-test.js
+++ b/ui/tests/unit/adapters/job-test.js
@@ -34,6 +34,7 @@ module('Unit | Adapter | Job', function (hooks) {
 
       this.server.create('namespace');
       this.server.create('namespace', { id: 'some-namespace' });
+      this.server.create('node-pool');
       this.server.create('node');
       this.server.create('job', { id: 'job-1', namespaceId: 'default' });
       this.server.create('job', { id: 'job-2', namespaceId: 'some-namespace' });

--- a/ui/tests/unit/adapters/node-test.js
+++ b/ui/tests/unit/adapters/node-test.js
@@ -23,6 +23,7 @@ module('Unit | Adapter | Node', function (hooks) {
     this.server.create('region', { id: 'region-1' });
     this.server.create('region', { id: 'region-2' });
 
+    this.server.create('node-pool');
     this.server.create('node', { id: 'node-1' });
     this.server.create('node', { id: 'node-2' });
     this.server.create('job', { id: 'job-1', createAllocations: false });

--- a/ui/tests/unit/adapters/volume-test.js
+++ b/ui/tests/unit/adapters/volume-test.js
@@ -25,6 +25,7 @@ module('Unit | Adapter | Volume', function (hooks) {
     this.initializeUI = async () => {
       this.server.create('namespace');
       this.server.create('namespace', { id: 'some-namespace' });
+      this.server.create('node-pool');
       this.server.create('node');
       this.server.create('job', { id: 'job-1', namespaceId: 'default' });
       this.server.create('csi-plugin', 2);


### PR DESCRIPTION
Require node pools to be created before nodes and jobs to force correct environment setup and improve test repeatability.

This approach touches several files, but it makes tests more predictable than creating node pools with jobs and nodes. It also follows the approach taken for namespaces.