### PR TITLE
ui: remove node pool `all` from client list filter

### DIFF
--- a/ui/app/controllers/clients/index.js
+++ b/ui/app/controllers/clients/index.js
@@ -171,7 +171,9 @@ export default class IndexController extends Controller.extend(
 
   @computed('selectionNodePools', 'model.nodePools.[]')
   get optionsNodePools() {
-    const availableNodePools = this.model.nodePools;
+    const availableNodePools = this.model.nodePools.filter(
+      (p) => p.name !== 'all'
+    );
 
     scheduleOnce('actions', () => {
       // eslint-disable-next-line ember/no-side-effects

--- a/ui/app/templates/components/client-node-row.hbs
+++ b/ui/app/templates/components/client-node-row.hbs
@@ -12,7 +12,7 @@
 </td>
 <td data-test-client-id><LinkTo @route="clients.client" @model={{this.node.id}} class="is-primary">{{this.node.shortId}}</LinkTo></td>
 <td data-test-client-name class="is-200px is-truncatable" title="{{this.node.name}}">{{this.node.name}}</td>
-<td data-test-client-nodepool title="{{this.node.nodePool}}">{{this.node.nodePool}}</td>
+<td data-test-client-node-pool title="{{this.node.nodePool}}">{{this.node.nodePool}}</td>
 <td data-test-client-composite-status>
   <span class="tooltip" aria-label="{{this.node.status}} / {{if this.node.isDraining "draining" "not draining"}} / {{if this.node.isEligible "eligible" "not eligible"}}">
     <span class="{{this.compositeStatusClass}}">{{this.node.compositeStatus}}</span>

--- a/ui/tests/acceptance/clients-list-test.js
+++ b/ui/tests/acceptance/clients-list-test.js
@@ -74,6 +74,7 @@ module('Acceptance | clients list', function (hooks) {
 
     assert.equal(nodeRow.id, node.id.split('-')[0], 'ID');
     assert.equal(nodeRow.name, node.name, 'Name');
+    assert.equal(nodeRow.nodePool, node.nodePool, 'Node Pool');
     assert.equal(
       nodeRow.compositeStatus.text,
       'draining',
@@ -323,6 +324,29 @@ module('Acceptance | clients list', function (hooks) {
 
       return selection.includes(node.status);
     },
+  });
+
+  testFacet('Node Pools', {
+    facet: ClientsList.facets.nodePools,
+    paramName: 'nodePool',
+    expectedOptions() {
+      return server.db.nodePools
+        .filter((p) => p.name !== 'all') // The node pool 'all' should not be a filter.
+        .map((p) => p.name);
+    },
+    async beforeEach() {
+      server.create('agent');
+      server.create('node-pool', { name: 'all' });
+      server.create('node-pool', { name: 'default' });
+      server.createList('node-pool', 10);
+
+      // Make sure each node pool has at least one node.
+      server.db.nodePools.forEach((p) => {
+        server.createList('node', 2, { nodePool: p.name });
+      });
+      await ClientsList.visit();
+    },
+    filter: (node, selection) => selection.includes(node.nodePool),
   });
 
   testFacet('Datacenters', {

--- a/ui/tests/pages/clients/list.js
+++ b/ui/tests/pages/clients/list.js
@@ -50,6 +50,7 @@ export default create({
     },
 
     address: text('[data-test-client-address]'),
+    nodePool: text('[data-test-client-node-pool]'),
     datacenter: text('[data-test-client-datacenter]'),
     version: text('[data-test-client-version]'),
     allocations: text('[data-test-client-allocations]'),
@@ -75,6 +76,7 @@ export default create({
   },
 
   facets: {
+    nodePools: multiFacet('[data-test-node-pool-facet]'),
     class: multiFacet('[data-test-class-facet]'),
     state: multiFacet('[data-test-state-facet]'),
     datacenter: multiFacet('[data-test-datacenter-facet]'),


### PR DESCRIPTION
The built-in node pool `all` should not be a client filter because nodes are not allowed to register there.

![image](https://github.com/hashicorp/nomad/assets/775380/2ad9dc89-4d42-423f-bbae-df9d3abe1f58)
