### PR TITLE
F UI node pool topoviz

### DIFF
--- a/ui/app/controllers/topology.js
+++ b/ui/app/controllers/topology.js
@@ -44,6 +44,9 @@ export default class TopologyControllers extends Controller.extend(Searchable) {
     {
       qpDatacenter: 'dc',
     },
+    {
+      qpNodePool: 'nodePool',
+    },
   ];
 
   @tracked searchTerm = '';
@@ -51,6 +54,7 @@ export default class TopologyControllers extends Controller.extend(Searchable) {
   qpVersion = '';
   qpClass = '';
   qpDatacenter = '';
+  qpNodePool = '';
 
   setFacetQueryParam(queryParam, selection) {
     this.set(queryParam, serialize(selection));
@@ -59,6 +63,7 @@ export default class TopologyControllers extends Controller.extend(Searchable) {
   @selection('qpState') selectionState;
   @selection('qpClass') selectionClass;
   @selection('qpDatacenter') selectionDatacenter;
+  @selection('qpNodePool') selectionNodePool;
   @selection('qpVersion') selectionVersion;
 
   @computed
@@ -109,6 +114,29 @@ export default class TopologyControllers extends Controller.extend(Searchable) {
     return datacenters.sort().map((dc) => ({ key: dc, label: dc }));
   }
 
+  @computed('model.nodePools.[]', 'selectionNodePool')
+  get optionsNodePool() {
+    const availableNodePools = this.model.nodePools;
+
+    scheduleOnce('actions', () => {
+      // eslint-disable-next-line ember/no-side-effects
+      this.set(
+        'qpNodePool',
+        serialize(
+          intersection(
+            availableNodePools.map(({ name }) => name),
+            this.selectionNodePool
+          )
+        )
+      );
+    });
+
+    return availableNodePools.sort().map((nodePool) => ({
+      key: nodePool.name,
+      label: nodePool.name,
+    }));
+  }
+
   @computed('model.nodes', 'nodes.[]', 'selectionVersion')
   get optionsVersion() {
     const versions = Array.from(
@@ -140,6 +168,7 @@ export default class TopologyControllers extends Controller.extend(Searchable) {
         selectionVersion,
         selectionDatacenter,
         selectionClass,
+        selectionNodePool,
       } = this;
       return (
         (selectionState.length ? selectionState.includes(node.status) : true) &&
@@ -151,6 +180,9 @@ export default class TopologyControllers extends Controller.extend(Searchable) {
           : true) &&
         (selectionClass.length
           ? selectionClass.includes(node.nodeClass)
+          : true) &&
+        (selectionNodePool.length
+          ? selectionNodePool.includes(node.nodePool)
           : true) &&
         (node.name.includes(searchTerm) ||
           node.datacenter.includes(searchTerm) ||

--- a/ui/app/routes/topology.js
+++ b/ui/app/routes/topology.js
@@ -23,7 +23,10 @@ export default class TopologyRoute extends Route.extend(WithForbiddenState) {
         namespace: '*',
       }),
       nodes: this.store.query('node', { resources: true }),
-      nodePools: this.store.findAll('node-pool'),
+      // Nodes are not allowed to be in the 'all' node pool, so filter it out.
+      nodePools: this.store
+        .findAll('node-pool')
+        .then((pools) => pools.filter((p) => p.name !== 'all')),
     }).catch(notifyForbidden(this));
   }
 

--- a/ui/app/styles/components/dashboard-metric.scss
+++ b/ui/app/styles/components/dashboard-metric.scss
@@ -17,7 +17,7 @@
     font-weight: $weight-bold;
     font-size: $size-3;
 
-    &.topo {
+    &.justify {
       display: flex;
       flex-direction: column;
       align-items: center;

--- a/ui/app/templates/components/topo-viz/datacenter.hbs
+++ b/ui/app/templates/components/topo-viz/datacenter.hbs
@@ -5,11 +5,15 @@
 
 <div data-test-topo-viz-datacenter class="boxed-section topo-viz-datacenter">
   <div data-test-topo-viz-datacenter-label class="boxed-section-head is-hollow">
-    <strong>{{@datacenter.name}}</strong>
-    <span class="bumper-left">{{this.scheduledAllocations.length}} Allocs</span>
-    <span class="bumper-left">{{@datacenter.nodes.length}} Nodes</span>
-    <span class="bumper-left is-faded">{{format-bytes this.aggregatedAllocationResources.memory start="MiB"}}/{{format-bytes this.aggregatedNodeResources.memory start="MiB"}},
-      {{format-hertz this.aggregatedAllocationResources.cpu}}/{{format-hertz this.aggregatedNodeResources.cpu}}</span>
+    <span class="tooltip" aria-label="Datacenter"><strong>{{@datacenter.name}}</strong></span>
+    <span class="bumper-left tooltip" aria-label="Number of Allocations">{{this.scheduledAllocations.length}} Allocs</span>
+    <span class="bumper-left tooltip" aria-label="Number of Nodes">{{@datacenter.nodes.length}} Nodes</span>
+    <span class="bumper-left is-faded">
+      <span class="tooltip" aria-label="Memory Allocated">{{format-bytes this.aggregatedAllocationResources.memory start="MiB"}}</span>/
+      <span class="tooltip" aria-label="Total Memory">{{format-bytes this.aggregatedNodeResources.memory start="MiB"}},</span>
+      <span class="tooltip" aria-label="CPU Allocated">{{format-hertz this.aggregatedAllocationResources.cpu}}/</span>
+      <span class="tooltip" aria-label="Total CPU">{{format-hertz this.aggregatedNodeResources.cpu}}</span>
+    </span>
   </div>
   <div class="boxed-section-body">
     <FlexMasonry @columns={{if @isSingleColumn 1 2}} @items={{@datacenter.nodes}} as |node|>

--- a/ui/app/templates/components/topo-viz/node.hbs
+++ b/ui/app/templates/components/topo-viz/node.hbs
@@ -11,11 +11,15 @@
       {{else if (not @node.node.isEligible)}}
         <span data-test-status-icon class="tooltip" aria-label="Client is ineligible">{{x-icon "lock-closed" class="is-warning"}}</span>
       {{/if}}
-      <strong><LinkTo @route="clients.client" @model={{@node.node.id}}>{{@node.node.name}}</LinkTo></strong>
-      <span class="bumper-left">{{this.count}} Allocs</span>
-      <span class="bumper-left is-faded">{{format-scheduled-bytes @node.memory start="MiB"}}, {{format-scheduled-hertz @node.cpu}}</span>
-      <span class="bumper-left is-faded">{{@node.node.status}}</span>
-      <span class="bumper-left is-faded">{{@node.node.version}}</span>
+      <span class="tooltip" aria-label="Node Name"><strong><LinkTo @route="clients.client" @model={{@node.node.id}}>{{@node.node.name}}</LinkTo></strong></span>
+      <span class="bumper-left tooltip" aria-label="Number of Allocations">{{this.count}} Allocs</span>
+      <span class="bumper-left is-faded tooltip" aria-label="Node Pool">{{@node.node.nodePool}}</span>
+      <span class="bumper-left is-faded">
+        <span class="tooltip" aria-label="Node Memory">{{format-scheduled-bytes @node.memory start="MiB"}}</span>,
+        <span class="tooltip" aria-label="Node CPU">{{format-scheduled-hertz @node.cpu}}</span>
+      </span>
+      <span class="bumper-left is-faded tooltip" aria-label="Node Status">{{@node.node.status}}</span>
+      <span class="bumper-left is-faded tooltip" aria-label="Nomad Version">{{@node.node.version}}</span>
     </p>
   {{/unless}}
   <svg

--- a/ui/app/templates/topology.hbs
+++ b/ui/app/templates/topology.hbs
@@ -370,7 +370,7 @@
               {{else}}
                 <div class="columns is-flush">
                   <div class="dashboard-metric column">
-                    <p data-test-node-count class="metric topo">
+                    <p data-test-node-count class="metric justify">
                       {{this.model.nodes.length}}
                       <span class="metric-label">
                         Clients
@@ -378,7 +378,7 @@
                     </p>
                   </div>
                   <div class="dashboard-metric column">
-                    <p data-test-alloc-count class="metric topo">
+                    <p data-test-alloc-count class="metric justify">
                       {{this.scheduledAllocations.length}}
                       <span class="metric-label">
                         Allocations
@@ -386,7 +386,7 @@
                     </p>
                   </div>
                   <div class="dashboard-metric column">
-                    <p data-test-node-pool-count class="metric topo">
+                    <p data-test-node-pool-count class="metric justify">
                       {{this.model.nodePools.length}}
                       <span class="metric-label">
                         Node Pools

--- a/ui/app/templates/topology.hbs
+++ b/ui/app/templates/topology.hbs
@@ -488,6 +488,13 @@
             <div class="toolbar-item is-right-aligned is-mobile-full-width">
               <div class="button-bar">
                 <MultiSelectDropdown
+                  data-test-node-pool-facet
+                  @label="Node Pool"
+                  @options={{this.optionsNodePool}}
+                  @selection={{this.selectionNodePool}}
+                  @onSelect={{action this.setFacetQueryParam "qpNodePool"}}
+                />
+                <MultiSelectDropdown
                   data-test-datacenter-facet
                   @label="Datacenter"
                   @options={{this.optionsDatacenter}}

--- a/ui/tests/acceptance/topology-test.js
+++ b/ui/tests/acceptance/topology-test.js
@@ -323,22 +323,41 @@ module('Acceptance | topology', function (hooks) {
     server.createList('node', 2, {
       nodeClass: 'foo-bar-baz',
     });
+
+    // Create node pool exclusive for these nodes.
+    server.create('node-pool', { name: 'test-node-pool' });
+    server.createList('node', 3, {
+      nodePool: 'test-node-pool',
+    });
+
     server.createList('allocation', 5);
 
     await Topology.visit();
-    assert.dom('[data-test-topo-viz-node]').exists({ count: 12 });
+    assert.dom('[data-test-topo-viz-node]').exists({ count: 15 });
 
     await typeIn('input.node-search', server.schema.nodes.first().name);
     assert.dom('[data-test-topo-viz-node]').exists({ count: 1 });
     await typeIn('input.node-search', server.schema.nodes.first().name);
     assert.dom('[data-test-topo-viz-node]').doesNotExist();
     await click('[title="Clear search"]');
-    assert.dom('[data-test-topo-viz-node]').exists({ count: 12 });
+    assert.dom('[data-test-topo-viz-node]').exists({ count: 15 });
 
     await Topology.facets.class.toggle();
     await Topology.facets.class.options
       .findOneBy('label', 'foo-bar-baz')
       .toggle();
     assert.dom('[data-test-topo-viz-node]').exists({ count: 2 });
+    await Topology.facets.class.options
+      .findOneBy('label', 'foo-bar-baz')
+      .toggle();
+
+    await Topology.facets.nodePool.toggle();
+    await Topology.facets.nodePool.options
+      .findOneBy('label', 'test-node-pool')
+      .toggle();
+    assert.dom('[data-test-topo-viz-node]').exists({ count: 3 });
+    await Topology.facets.nodePool.options
+      .findOneBy('label', 'test-node-pool')
+      .toggle();
   });
 });

--- a/ui/tests/acceptance/topology-test.js
+++ b/ui/tests/acceptance/topology-test.js
@@ -45,6 +45,7 @@ module('Acceptance | topology', function (hooks) {
 
   test('by default the info panel shows cluster aggregate stats', async function (assert) {
     faker.seed(1);
+    server.create('node-pool', { name: 'all' });
     server.createList('node', 3);
     server.createList('allocation', 5);
 
@@ -67,6 +68,15 @@ module('Acceptance | topology', function (hooks) {
     assert.equal(
       Topology.clusterInfoPanel.allocCount,
       `${scheduledAllocs.length} Allocations`
+    );
+
+    // Node pool count ignores 'all'.
+    const nodePools = server.schema.nodePools
+      .all()
+      .models.filter((p) => p.name !== 'all');
+    assert.equal(
+      Topology.clusterInfoPanel.nodePoolCount,
+      `${nodePools.length} Node Pools`
     );
 
     const nodeResources = server.schema.nodes

--- a/ui/tests/pages/topology.js
+++ b/ui/tests/pages/topology.js
@@ -37,6 +37,7 @@ export default create({
     scope: '[data-test-info-panel]',
     nodeCount: text('[data-test-node-count]'),
     allocCount: text('[data-test-alloc-count]'),
+    nodePoolCount: text('[data-test-node-pool-count]'),
 
     memoryProgressValue: attribute('value', '[data-test-memory-progress-bar]'),
     memoryAbsoluteValue: text('[data-test-memory-absolute-value]'),

--- a/ui/tests/pages/topology.js
+++ b/ui/tests/pages/topology.js
@@ -26,6 +26,7 @@ export default create({
   viz: TopoViz('[data-test-topo-viz]'),
 
   facets: {
+    nodePool: multiFacet('[data-test-node-pool-facet]'),
     datacenter: multiFacet('[data-test-datacenter-facet]'),
     class: multiFacet('[data-test-class-facet]'),
     state: multiFacet('[data-test-state-facet]'),


### PR DESCRIPTION
This PR adds some node pool information and interactions to the Topology page.

* Allow filtering nodes by node pool.
* Don't count the `all` node pool in the aggregate metric box.
* Add tooltips to the node and datacenter labels to clarify what they represent.

I know that there's a new tooltip component, but it's currently not available in this branch. I can updated it once everything is merged to `main`.

https://github.com/hashicorp/nomad/assets/775380/ee1b2fb5-4c71-4c3e-b203-1d12f980e53e

