### PR TITLE
ui: add node pool memory oversubscription config

### DIFF
--- a/ui/app/models/node-pool.js
+++ b/ui/app/models/node-pool.js
@@ -19,4 +19,9 @@ export default class NodePool extends Model {
   get schedulerAlgorithm() {
     return this.get('schedulerConfiguration.SchedulerAlgorithm');
   }
+
+  @computed('schedulerConfiguration.MemoryOversubscriptionEnabled')
+  get memoryOversubscriptionEnabled() {
+    return this.get('schedulerConfiguration.MemoryOversubscriptionEnabled');
+  }
 }

--- a/ui/tests/unit/serializers/node-pool-test.js
+++ b/ui/tests/unit/serializers/node-pool-test.js
@@ -15,32 +15,106 @@ module('Unit | Serializer | NodePool', function (hooks) {
   });
 
   test('should serialize a NodePool', function (assert) {
-    const nodePool = this.store.createRecord('node-pool', {
-      name: 'prod-eng',
-      description: 'Production workloads',
-      meta: {
-        env: 'production',
-        team: 'engineering',
+    const testCases = [
+      {
+        name: 'full node pool',
+        input: {
+          name: 'prod-eng',
+          description: 'Production workloads',
+          meta: {
+            env: 'production',
+            team: 'engineering',
+          },
+          schedulerConfiguration: {
+            SchedulerAlgorithm: 'spread',
+            MemoryOversubscriptionEnabled: true,
+          },
+        },
+        expected: {
+          Name: 'prod-eng',
+          Description: 'Production workloads',
+          Meta: {
+            env: 'production',
+            team: 'engineering',
+          },
+          SchedulerConfiguration: {
+            SchedulerAlgorithm: 'spread',
+            MemoryOversubscriptionEnabled: true,
+          },
+        },
       },
-      schedulerConfiguration: {
-        SchedulerAlgorithm: 'spread',
+      {
+        name: 'node pool without scheduler configuration',
+        input: {
+          name: 'prod-eng',
+          description: 'Production workloads',
+          meta: {
+            env: 'production',
+            team: 'engineering',
+          },
+        },
+        expected: {
+          Name: 'prod-eng',
+          Description: 'Production workloads',
+          Meta: {
+            env: 'production',
+            team: 'engineering',
+          },
+          SchedulerConfiguration: undefined,
+        },
       },
-    });
+      {
+        name: 'node pool with null scheduler configuration',
+        input: {
+          name: 'prod-eng',
+          description: 'Production workloads',
+          meta: {
+            env: 'production',
+            team: 'engineering',
+          },
+          schedulerConfiguration: null,
+        },
+        expected: {
+          Name: 'prod-eng',
+          Description: 'Production workloads',
+          Meta: {
+            env: 'production',
+            team: 'engineering',
+          },
+          SchedulerConfiguration: null,
+        },
+      },
+      {
+        name: 'node pool with empty scheduler configuration',
+        input: {
+          name: 'prod-eng',
+          description: 'Production workloads',
+          meta: {
+            env: 'production',
+            team: 'engineering',
+          },
+          schedulerConfiguration: {},
+        },
+        expected: {
+          Name: 'prod-eng',
+          Description: 'Production workloads',
+          Meta: {
+            env: 'production',
+            team: 'engineering',
+          },
+          SchedulerConfiguration: {},
+        },
+      },
+    ];
 
-    const serializedNodePool = this.subject().serialize(
-      nodePool._createSnapshot()
-    );
-
-    assert.deepEqual(serializedNodePool, {
-      Name: 'prod-eng',
-      Description: 'Production workloads',
-      Meta: {
-        env: 'production',
-        team: 'engineering',
-      },
-      SchedulerConfiguration: {
-        SchedulerAlgorithm: 'spread',
-      },
-    });
+    for (const tc of testCases) {
+      const nodePool = this.store.createRecord('node-pool', tc.input);
+      const got = this.subject().serialize(nodePool._createSnapshot());
+      assert.deepEqual(
+        got,
+        tc.expected,
+        `${tc.name} failed, got ${JSON.stringify(got)}`
+      );
+    }
   });
 });


### PR DESCRIPTION
Add new node pool scheduler configuration to `NodePool` model that was created in https://github.com/hashicorp/nomad/pull/17575 and update serializer test to cover more scenarios. Since `SchedulerConfiguration` is an Enterprise feature, it will be returned as `null` in OSS. It's also comprised of all optional fields, meaning that a node pool like this is valid:

```hcl
node_pool "test" {
  scheduler_configuration {}
}
```