### PR TITLE
Moves to the current LTS release of Node for our build and release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Setup node and yarn
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: "14"
+          node-version: "18"
           cache-dependency-path: "ui/yarn.lock"
 
       - name: Install Yarn
@@ -151,7 +151,7 @@ jobs:
       - name: Setup node and yarn
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: "14"
+          node-version: "18"
           cache-dependency-path: "ui/yarn.lock"
 
       - name: Install Yarn
@@ -256,7 +256,7 @@ jobs:
       - name: Setup node and yarn
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: "14"
+          node-version: "18"
           cache-dependency-path: "ui/yarn.lock"
 
       - name: Install Yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Setup node and yarn
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: "14"
+          node-version: "18"
           cache-dependency-path: "ui/yarn.lock"
 
       - name: Install Yarn

--- a/scripts/vagrant-linux-unpriv-ui.sh
+++ b/scripts/vagrant-linux-unpriv-ui.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-export NODE_VERSION=14.19.2
+export NODE_VERSION=18.16.1
 
 # Install NVM for simple node.js version management
 curl -sSL --fail -o- https://raw.githubusercontent.com/creationix/nvm/v0.36.0/install.sh | bash

--- a/ui/README.md
+++ b/ui/README.md
@@ -6,7 +6,7 @@ The official Nomad UI.
 
 This is an [ember.js](https://emberjs.com/) project, and you will need the following tools installed on your computer.
 
-- [Node.js v10](https://nodejs.org/)
+- [The current Node.js LTS release](https://nodejs.org/)
 - [Yarn](https://yarnpkg.com)
 - [Ember CLI](https://ember-cli.com/)
 


### PR DESCRIPTION
Much like the ember-test-audit node version bumps from https://github.com/hashicorp/nomad/pull/17624, this upgrades Node to the current LTS version for our build workflows.

Without this, an older version of node would fail upon storybook installation, and possibly elsewhere.