### PR TITLE
ui: remove redundant children jobs table columns

### DIFF
--- a/ui/app/templates/components/job-page/parts/children.hbs
+++ b/ui/app/templates/components/job-page/parts/children.hbs
@@ -46,25 +46,11 @@
           <t.sort-by @prop="name">
             Name
           </t.sort-by>
-          {{#if this.system.shouldShowNamespaces}}
-            <t.sort-by @prop="namespace.name" data-test-jobs-namespace-header>
-              Namespace
-            </t.sort-by>
-          {{/if}}
-          <t.sort-by @prop="nodePool">
-            Node Pool
-          </t.sort-by>
           <t.sort-by @prop="submitTime" data-test-jobs-submit-time-header>
             Submitted At
           </t.sort-by>
           <t.sort-by @prop="status">
             Status
-          </t.sort-by>
-          <t.sort-by @prop="type">
-            Type
-          </t.sort-by>
-          <t.sort-by @prop="priority">
-            Priority
           </t.sort-by>
           <th>
             Groups

--- a/ui/app/templates/components/job-page/parts/stats-box.hbs
+++ b/ui/app/templates/components/job-page/parts/stats-box.hbs
@@ -32,7 +32,7 @@
       </span>
     {{/if}}
     {{#if @job.nodePool}}
-      <span class="pair" data-test-job-stat="nodePool">
+      <span class="pair" data-test-job-stat="node-pool">
         <span class="term">Node Pool</span>
         {{@job.nodePool}}
       </span>

--- a/ui/app/templates/components/job-row.hbs
+++ b/ui/app/templates/components/job-row.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <td data-test-job-name
-  {{keyboard-shortcut 
+  {{keyboard-shortcut
     enumerated=true
     action=(action "gotoJob" @job)
   }}
@@ -25,14 +25,16 @@
 
   </LinkTo>
 </td>
-{{#if this.system.shouldShowNamespaces}}
-  <td data-test-job-namespace>
-    {{this.job.namespace.name}}
+{{#if (not (eq @context "child"))}}
+  {{#if this.system.shouldShowNamespaces}}
+    <td data-test-job-namespace>
+      {{this.job.namespace.name}}
+    </td>
+  {{/if}}
+  <td data-test-job-node-pool>
+    {{this.job.nodePool}}
   </td>
 {{/if}}
-<td data-test-job-nodepool>
-  {{this.job.nodePool}}
-</td>
 {{#if (eq @context "child")}}
   <td data-test-job-submit-time>
     {{format-month-ts this.job.submitTime}}
@@ -43,12 +45,14 @@
     {{this.job.status}}
   </span>
 </td>
-<td data-test-job-type>
-  {{this.job.displayType.type}}
-</td>
-<td data-test-job-priority>
-  {{this.job.priority}}
-</td>
+{{#if (not (eq @context "child"))}}
+  <td data-test-job-type>
+    {{this.job.displayType.type}}
+  </td>
+  <td data-test-job-priority>
+    {{this.job.priority}}
+  </td>
+{{/if}}
 <td data-test-job-task-groups>
   {{#if this.job.taskGroupCount}}
     {{this.job.taskGroupCount}}

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -171,6 +171,14 @@ moduleForJob(
         )
       );
     },
+    "don't display redundant information in children table": async function (
+      job,
+      assert
+    ) {
+      assert.notOk(JobDetail.jobsHeader.hasNodePool);
+      assert.notOk(JobDetail.jobsHeader.hasPriority);
+      assert.notOk(JobDetail.jobsHeader.hasType);
+    },
   }
 );
 
@@ -186,9 +194,8 @@ moduleForJob(
     return parent;
   },
   {
-    'display namespace in children table': async function (job, assert) {
-      assert.ok(JobDetail.jobsHeader.hasNamespace);
-      assert.equal(JobDetail.jobs[0].namespace, job.namespace);
+    "don't display namespace in children table": async function (job, assert) {
+      assert.notOk(JobDetail.jobsHeader.hasNamespace);
     },
   }
 );
@@ -216,6 +223,14 @@ moduleForJob(
         )
       );
     },
+    "don't display redundant information in children table": async function (
+      job,
+      assert
+    ) {
+      assert.notOk(JobDetail.jobsHeader.hasNodePool);
+      assert.notOk(JobDetail.jobsHeader.hasPriority);
+      assert.notOk(JobDetail.jobsHeader.hasType);
+    },
   }
 );
 
@@ -231,9 +246,8 @@ moduleForJob(
     return parent;
   },
   {
-    'display namespace in children table': async function (job, assert) {
-      assert.ok(JobDetail.jobsHeader.hasNamespace);
-      assert.equal(JobDetail.jobs[0].namespace, job.namespace);
+    "don't display namespace in children table": async function (job, assert) {
+      assert.notOk(JobDetail.jobsHeader.hasNamespace);
     },
   }
 );

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -71,6 +71,7 @@ module('Acceptance | jobs list', function (hooks) {
 
     assert.equal(jobRow.name, job.name, 'Name');
     assert.notOk(jobRow.hasNamespace);
+    assert.equal(jobRow.nodePool, job.nodePool, 'Node Pool');
     assert.equal(jobRow.link, `/ui/jobs/${job.id}@default`, 'Detail Link');
     assert.equal(jobRow.status, job.status, 'Status');
     assert.equal(jobRow.type, typeForJob(job), 'Type');

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -104,6 +104,19 @@ export default function moduleForJob(
       }
     });
 
+    test('page header displays job information', async function (assert) {
+      assert.equal(JobDetail.statFor('type').text, `Type ${job.type}`);
+      assert.equal(
+        JobDetail.statFor('priority').text,
+        `Priority ${job.priority}`
+      );
+      assert.equal(JobDetail.statFor('version').text, `Version ${job.version}`);
+      assert.equal(
+        JobDetail.statFor('node-pool').text,
+        `Node Pool ${job.nodePool}`
+      );
+    });
+
     if (context === 'allocations') {
       test('allocations for the job are shown in the overview', async function (assert) {
         if (jobTypesWithStatusPanel.includes(job.type)) {

--- a/ui/tests/pages/jobs/detail.js
+++ b/ui/tests/pages/jobs/detail.js
@@ -108,13 +108,17 @@ export default create({
     scope: '[data-test-jobs-header]',
     hasSubmitTime: isPresent('[data-test-jobs-submit-time-header]'),
     hasNamespace: isPresent('[data-test-jobs-namespace-header]'),
+    hasNodePool: isPresent('[data-test-jobs-node-pool-header]'),
+    hasType: isPresent('[data-test-jobs-type-header]'),
+    hasPriority: isPresent('[data-test-jobs-priority-header]'),
   },
 
   jobs: collection('[data-test-job-row]', {
     id: attribute('data-test-job-row'),
     name: text('[data-test-job-name]'),
-    namespace: text('[data-test-job-namespace]'),
     link: attribute('href', '[data-test-job-name] a'),
+    namespace: text('[data-test-job-namespace]'),
+    nodePool: text('[data-test-job-node-pool]'),
     submitTime: text('[data-test-job-submit-time]'),
     status: text('[data-test-job-status]'),
     type: text('[data-test-job-type]'),

--- a/ui/tests/pages/jobs/list.js
+++ b/ui/tests/pages/jobs/list.js
@@ -36,8 +36,9 @@ export default create({
   jobs: collection('[data-test-job-row]', {
     id: attribute('data-test-job-row'),
     name: text('[data-test-job-name]'),
-    namespace: text('[data-test-job-namespace]'),
     link: attribute('href', '[data-test-job-name] a'),
+    namespace: text('[data-test-job-namespace]'),
+    nodePool: text('[data-test-job-node-pool]'),
     status: text('[data-test-job-status]'),
     type: text('[data-test-job-type]'),
     priority: text('[data-test-job-priority]'),


### PR DESCRIPTION
The namespace, node pool, type, and priority values were already displayed at the page header, so they made the children job table quite crowded.