### PR TITLE
ui: update Topology page tooltips to Helios

### DIFF
--- a/ui/app/templates/components/topo-viz/datacenter.hbs
+++ b/ui/app/templates/components/topo-viz/datacenter.hbs
@@ -5,14 +5,32 @@
 
 <div data-test-topo-viz-datacenter class="boxed-section topo-viz-datacenter">
   <div data-test-topo-viz-datacenter-label class="boxed-section-head is-hollow">
-    <span class="tooltip" aria-label="Datacenter"><strong>{{@datacenter.name}}</strong></span>
-    <span class="bumper-left tooltip" aria-label="Number of Allocations">{{this.scheduledAllocations.length}} Allocs</span>
-    <span class="bumper-left tooltip" aria-label="Number of Nodes">{{@datacenter.nodes.length}} Nodes</span>
+    <Hds::TooltipButton @text="Datacenter" aria-label="Datacenter name">
+      <strong>{{@datacenter.name}}</strong>
+    </Hds::TooltipButton>
+    <span class="bumper-left">
+      <Hds::TooltipButton @text="Number of Allocations" aria-label="Number of allocations in datacenter {{@datacenter.name}}">
+        {{this.scheduledAllocations.length}} Allocs
+      </Hds::TooltipButton>
+    </span>
+    <span class="bumper-left">
+      <Hds::TooltipButton @text="Number of Nodes" aria-label="Number of nodes in datacenter {{@datacenter.name}}">
+        {{@datacenter.nodes.length}} Nodes
+      </Hds::TooltipButton>
+    </span>
     <span class="bumper-left is-faded">
-      <span class="tooltip" aria-label="Memory Allocated">{{format-bytes this.aggregatedAllocationResources.memory start="MiB"}}</span>/
-      <span class="tooltip" aria-label="Total Memory">{{format-bytes this.aggregatedNodeResources.memory start="MiB"}},</span>
-      <span class="tooltip" aria-label="CPU Allocated">{{format-hertz this.aggregatedAllocationResources.cpu}}/</span>
-      <span class="tooltip" aria-label="Total CPU">{{format-hertz this.aggregatedNodeResources.cpu}}</span>
+      <Hds::TooltipButton @text="Memory Allocated" aria-label="Sum of memory allocated in datacenter {{@datacenter.name}}">
+        {{format-bytes this.aggregatedAllocationResources.memory start="MiB"}}
+      </Hds::TooltipButton> /
+      <Hds::TooltipButton @text="Total Memory" aria-label="Sum of memory from all nodes in datacenter {{@datacenter.name}}">
+        {{format-bytes this.aggregatedNodeResources.memory start="MiB"}},
+      </Hds::TooltipButton>
+      <Hds::TooltipButton @text="CPU Allocated" aria-label="Sum of CPU allocated in datacenter {{@datacenter.name}}">
+        {{format-hertz this.aggregatedAllocationResources.cpu}} /
+      </Hds::TooltipButton>
+      <Hds::TooltipButton @text="Total CPU" aria-label="Sum of CPU from all nodes in datacenter {{@datacenter.name}}">
+        {{format-hertz this.aggregatedNodeResources.cpu}}
+      </Hds::TooltipButton>
     </span>
   </div>
   <div class="boxed-section-body">

--- a/ui/app/templates/components/topo-viz/node.hbs
+++ b/ui/app/templates/components/topo-viz/node.hbs
@@ -7,19 +7,47 @@
   {{#unless @isDense}}
     <p data-test-label class="label">
       {{#if @node.node.isDraining}}
-        <span data-test-status-icon class="tooltip" aria-label="Client is draining">{{x-icon "clock-outline" class="is-info"}}</span>
+        <Hds::TooltipButton data-test-status-icon @text="Node is draining" aria-label="Node {{@node.node.name}} is draining">
+          {{x-icon "clock-outline" class="is-info"}}
+        </Hds::TooltipButton>
       {{else if (not @node.node.isEligible)}}
-        <span data-test-status-icon class="tooltip" aria-label="Client is ineligible">{{x-icon "lock-closed" class="is-warning"}}</span>
+        <Hds::TooltipButton data-test-status-icon @text="Node is ineligible" aria-label="Node {{@node.node.name}} is ineligible">
+          {{x-icon "lock-closed" class="is-warning"}}
+        </Hds::TooltipButton>
       {{/if}}
-      <span class="tooltip" aria-label="Node Name"><strong><LinkTo @route="clients.client" @model={{@node.node.id}}>{{@node.node.name}}</LinkTo></strong></span>
-      <span class="bumper-left tooltip" aria-label="Number of Allocations">{{this.count}} Allocs</span>
-      <span class="bumper-left is-faded tooltip" aria-label="Node Pool">{{@node.node.nodePool}}</span>
-      <span class="bumper-left is-faded">
-        <span class="tooltip" aria-label="Node Memory">{{format-scheduled-bytes @node.memory start="MiB"}}</span>,
-        <span class="tooltip" aria-label="Node CPU">{{format-scheduled-hertz @node.cpu}}</span>
+      <strong>
+        <LinkTo {{hds-tooltip "Node Name"}}  @route="clients.client" @model={{@node.node.id}}>
+          {{@node.node.name}}
+        </LinkTo>
+      </strong>
+      <span class="bumper-left">
+        <Hds::TooltipButton @text="Number of Allocations" aria-label="Number of Allocations in node {{@node.node.name}}">
+          {{this.count}} Allocs
+        </Hds::TooltipButton>
       </span>
-      <span class="bumper-left is-faded tooltip" aria-label="Node Status">{{@node.node.status}}</span>
-      <span class="bumper-left is-faded tooltip" aria-label="Nomad Version">{{@node.node.version}}</span>
+      <span class="bumper-left is-faded">
+        <Hds::TooltipButton @text="Node Pool" aria-label="Node pool for node {{@node.node.name}}">
+          {{@node.node.nodePool}}
+        </Hds::TooltipButton>
+      </span>
+      <span class="bumper-left is-faded">
+        <Hds::TooltipButton @text="Node Memory" aria-label="Amount of memory in node {{@node.node.name}}">
+          {{format-scheduled-bytes @node.memory start="MiB"}}
+        </Hds::TooltipButton>,
+        <Hds::TooltipButton @text="Node CPU" aria-label="Amount of CPU in node {{@node.node.name}}">
+          {{format-scheduled-hertz @node.cpu}}
+        </Hds::TooltipButton>
+      </span>
+      <span class="bumper-left is-faded">
+        <Hds::TooltipButton @text="Node Status" aria-label="Status of node {{@node.node.name}}">
+          {{@node.node.status}}
+        </Hds::TooltipButton>
+      </span>
+      <span class="bumper-left is-faded">
+        <Hds::TooltipButton @text="Nomad Version" aria-label="Version of Nomad running in node {{@node.node.name}}">
+          {{@node.node.version}}
+        </Hds::TooltipButton>
+      </span>
     </p>
   {{/unless}}
   <svg

--- a/ui/tests/integration/components/topo-viz/datacenter-test.js
+++ b/ui/tests/integration/components/topo-viz/datacenter-test.js
@@ -119,7 +119,7 @@ module('Integration | Component | TopoViz::Datacenter', function (hooks) {
     assert.ok(TopoVizDatacenter.label.includes(`${allocs.length} Allocs`));
     assert.ok(
       TopoVizDatacenter.label.includes(
-        `${formatBytes(memoryReserved, 'MiB')}/${formatBytes(
+        `${formatBytes(memoryReserved, 'MiB')} / ${formatBytes(
           memoryTotal,
           'MiB'
         )}`
@@ -127,7 +127,7 @@ module('Integration | Component | TopoViz::Datacenter', function (hooks) {
     );
     assert.ok(
       TopoVizDatacenter.label.includes(
-        `${formatHertz(cpuReserved, 'MHz')}/${formatHertz(cpuTotal, 'MHz')}`
+        `${formatHertz(cpuReserved, 'MHz')} / ${formatHertz(cpuTotal, 'MHz')}`
       )
     );
   });

--- a/ui/tests/integration/components/topo-viz/node-test.js
+++ b/ui/tests/integration/components/topo-viz/node-test.js
@@ -149,7 +149,7 @@ module('Integration | Component | TopoViz::Node', function (hooks) {
     await render(commonTemplate);
 
     assert.ok(TopoVizNode.statusIcon.includes('icon-is-clock-outline'));
-    assert.equal(TopoVizNode.statusIconLabel, 'Client is draining');
+    assert.equal(TopoVizNode.statusIconLabel, 'Node Node One is draining');
   });
 
   test('the status icon indicates when the node is ineligible for scheduling', async function (assert) {
@@ -166,7 +166,7 @@ module('Integration | Component | TopoViz::Node', function (hooks) {
     await render(commonTemplate);
 
     assert.ok(TopoVizNode.statusIcon.includes('icon-is-lock-closed'));
-    assert.equal(TopoVizNode.statusIconLabel, 'Client is ineligible');
+    assert.equal(TopoVizNode.statusIconLabel, 'Node Node One is ineligible');
   });
 
   test('when isDense is false, clicking the node does nothing', async function (assert) {


### PR DESCRIPTION
Use new Helios tooltip component with more descriptive `aria-label` values. Wrap `Hds::TooltipButton` inside the `span` so the `bumber-left` offset is not included in the tooltip position.

Also make the use of the terms "node" and "client" more consistent, switching to "node" since it was used more often.