### PR TITLE
[ui] Job Status/Deployment Panel: legend items with a count of 0 no longer links

### DIFF
--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -96,7 +96,7 @@
         <legend>
           {{#each-in this.newAllocsByStatus as |status count|}}
             <ConditionalLinkTo
-              @condition={{not (eq status "unplaced")}}
+              @condition={{and (not (eq status "unplaced")) (gt count 0)}}
               @route="jobs.job.allocations"
               @model={{@job}}
               @query={{hash status=(concat '["' status '"]') version=(concat '[' this.job.latestDeployment.versionNumber ']')}}

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -51,7 +51,7 @@
         <legend>
           {{#each this.allocTypes as |type|}}
             <ConditionalLinkTo
-              @condition={{not (eq type.label "unplaced")}}
+              @condition={{and (not (eq type.label "unplaced")) (get (get (get (get this.allocBlocks type.label) 'healthy') 'nonCanary') "length")}}
               @route="jobs.job.allocations"
               @model={{@job}}
               @query={{hash status=(concat '["' type.label '"]') version=(concat '[' (map-by "version" this.versions) ']')}}


### PR DESCRIPTION
Previously, the "0 pending", "0 failed" here would have been links to otherwise empty list pages. Now we check for the existence of allocations in that class before making it a link, otherwise it's just a span.


![image](https://github.com/hashicorp/nomad/assets/713991/d9085e54-e759-4d96-8644-fcd239afad9a)
