### PR TITLE
ui: remove redundant columns from child job table

### DIFF
--- a/.changelog/17645.txt
+++ b/.changelog/17645.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: remove namespace, type, and priority columns from child job table
+```

--- a/ui/app/templates/components/job-page/parts/children.hbs
+++ b/ui/app/templates/components/job-page/parts/children.hbs
@@ -46,22 +46,11 @@
           <t.sort-by @prop="name">
             Name
           </t.sort-by>
-          {{#if this.system.shouldShowNamespaces}}
-            <t.sort-by @prop="namespace.name" data-test-jobs-namespace-header>
-              Namespace
-            </t.sort-by>
-          {{/if}}
           <t.sort-by @prop="submitTime" data-test-jobs-submit-time-header>
             Submitted At
           </t.sort-by>
           <t.sort-by @prop="status">
             Status
-          </t.sort-by>
-          <t.sort-by @prop="type">
-            Type
-          </t.sort-by>
-          <t.sort-by @prop="priority">
-            Priority
           </t.sort-by>
           <th>
             Groups

--- a/ui/app/templates/components/job-row.hbs
+++ b/ui/app/templates/components/job-row.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <td data-test-job-name
-  {{keyboard-shortcut 
+  {{keyboard-shortcut
     enumerated=true
     action=(action "gotoJob" @job)
   }}
@@ -25,10 +25,12 @@
 
   </LinkTo>
 </td>
-{{#if this.system.shouldShowNamespaces}}
-  <td data-test-job-namespace>
-    {{this.job.namespace.name}}
-  </td>
+{{#if (not (eq @context "child"))}}
+  {{#if this.system.shouldShowNamespaces}}
+    <td data-test-job-namespace>
+      {{this.job.namespace.name}}
+    </td>
+  {{/if}}
 {{/if}}
 {{#if (eq @context "child")}}
   <td data-test-job-submit-time>
@@ -40,12 +42,14 @@
     {{this.job.status}}
   </span>
 </td>
-<td data-test-job-type>
-  {{this.job.displayType.type}}
-</td>
-<td data-test-job-priority>
-  {{this.job.priority}}
-</td>
+{{#if (not (eq @context "child"))}}
+  <td data-test-job-type>
+    {{this.job.displayType.type}}
+  </td>
+  <td data-test-job-priority>
+    {{this.job.priority}}
+  </td>
+{{/if}}
 <td data-test-job-task-groups>
   {{#if this.job.taskGroupCount}}
     {{this.job.taskGroupCount}}

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -171,6 +171,13 @@ moduleForJob(
         )
       );
     },
+    "don't display redundant information in children table": async function (
+      job,
+      assert
+    ) {
+      assert.notOk(JobDetail.jobsHeader.hasPriority);
+      assert.notOk(JobDetail.jobsHeader.hasType);
+    },
   }
 );
 
@@ -186,9 +193,8 @@ moduleForJob(
     return parent;
   },
   {
-    'display namespace in children table': async function (job, assert) {
-      assert.ok(JobDetail.jobsHeader.hasNamespace);
-      assert.equal(JobDetail.jobs[0].namespace, job.namespace);
+    "don't display namespace in children table": async function (job, assert) {
+      assert.notOk(JobDetail.jobsHeader.hasNamespace);
     },
   }
 );
@@ -216,6 +222,13 @@ moduleForJob(
         )
       );
     },
+    "don't display redundant information in children table": async function (
+      job,
+      assert
+    ) {
+      assert.notOk(JobDetail.jobsHeader.hasPriority);
+      assert.notOk(JobDetail.jobsHeader.hasType);
+    },
   }
 );
 
@@ -231,9 +244,8 @@ moduleForJob(
     return parent;
   },
   {
-    'display namespace in children table': async function (job, assert) {
-      assert.ok(JobDetail.jobsHeader.hasNamespace);
-      assert.equal(JobDetail.jobs[0].namespace, job.namespace);
+    "don't display namespace in children table": async function (job, assert) {
+      assert.notOk(JobDetail.jobsHeader.hasNamespace);
     },
   }
 );

--- a/ui/tests/pages/jobs/detail.js
+++ b/ui/tests/pages/jobs/detail.js
@@ -108,6 +108,8 @@ export default create({
     scope: '[data-test-jobs-header]',
     hasSubmitTime: isPresent('[data-test-jobs-submit-time-header]'),
     hasNamespace: isPresent('[data-test-jobs-namespace-header]'),
+    hasType: isPresent('[data-test-jobs-type-header]'),
+    hasPriority: isPresent('[data-test-jobs-priority-header]'),
   },
 
   jobs: collection('[data-test-job-row]', {


### PR DESCRIPTION
Namespace, job type, and priority are already available from the parent job header, so displaying them in the table caused it to be too crowded.

(Extracted from https://github.com/hashicorp/nomad/pull/17301 as a user-facing change)