### PR TITLE
ci: set `continue-on-error: true` on `test-ui`

### DIFF
--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -61,6 +61,7 @@ jobs:
       - pre-test
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    continue-on-error: true
     defaults:
       run:
         working-directory: ui


### PR DESCRIPTION
Since the matrix exercises different test cases, it's better to allow all partitions to completely run, even if one of them fails, so it's easier to catch multiple test failures.