### PR TITLE
ci: fix some flaky UI tests

### DIFF
--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -7,13 +7,7 @@
 /* Mirage fixtures are random so we can't expect a set number of assertions */
 import AdapterError from '@ember-data/adapter/error';
 import { run } from '@ember/runloop';
-import {
-  currentURL,
-  click,
-  visit,
-  triggerEvent,
-  waitFor,
-} from '@ember/test-helpers';
+import { currentURL, click, triggerEvent, waitFor } from '@ember/test-helpers';
 import { assign } from '@ember/polyfills';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
@@ -686,6 +680,9 @@ module('Acceptance | allocation detail (services)', function (hooks) {
       name: 'Service-haver',
       id: 'service-haver',
       namespaceId: 'default',
+      allocStatusDistribution: {
+        running: 1,
+      },
     });
 
     const currentAlloc = server.db.allocations.findBy({ jobId: job.id });
@@ -736,14 +733,18 @@ module('Acceptance | allocation detail (services)', function (hooks) {
   });
 
   test('Allocation has a list of services with active checks', async function (assert) {
-    await visit('jobs/service-haver@default');
-    await click('.allocation-row');
+    const runningAlloc = server.db.allocations.findBy({
+      jobId: 'service-haver',
+      clientStatus: 'running',
+    });
+    await Allocation.visit({ id: runningAlloc.id });
     assert.dom('[data-test-service]').exists();
     assert.dom('.service-sidebar').exists();
     assert.dom('.service-sidebar').doesNotHaveClass('open');
     assert
       .dom('[data-test-service-status-bar]')
       .exists('At least one allocation has service health');
+
     await click('[data-test-service-status-bar]');
     assert.dom('.service-sidebar').hasClass('open');
     assert

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -73,6 +73,7 @@ module('Acceptance | job status panel', function (hooks) {
       datacenters: ['*'],
       type: 'service',
       createAllocations: true,
+      noActiveDeployment: true,
     });
 
     await visit(`/jobs/${job.id}?statusMode=historical`);
@@ -819,6 +820,7 @@ module('Acceptance | job status panel', function (hooks) {
           lost: 0,
           complete: 0.2,
         },
+        groupsCount: 1,
         groupTaskCount: 10,
         noActiveDeployment: true,
         shallow: true,
@@ -837,6 +839,7 @@ module('Acceptance | job status panel', function (hooks) {
           lost: 0,
           complete: 0.2,
         },
+        groupsCount: 1,
         groupTaskCount: 10,
         noActiveDeployment: true,
         shallow: true,

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -641,22 +641,28 @@ module('Acceptance | tokens', function (hooks) {
 
   test('Tokens Deletion', async function (assert) {
     allScenarios.policiesTestCluster(server);
+    const testPolicy = server.db.policies[0];
+    const existingTokens = server.db.tokens.filter((t) =>
+      t.policyIds.includes(testPolicy.name)
+    );
     // Create an expired token
     server.create('token', {
       name: 'Doomed Token',
       id: 'enjoying-my-day-here',
-      policyIds: [server.db.policies[0].name],
+      policyIds: [testPolicy.name],
     });
 
     window.localStorage.nomadTokenSecret = server.db.tokens[0].secretId;
     await visit('/policies');
 
     await click('[data-test-policy-row]:first-child');
-    assert.equal(currentURL(), `/policies/${server.db.policies[0].name}`);
-
+    assert.equal(currentURL(), `/policies/${testPolicy.name}`);
     assert
       .dom('[data-test-policy-token-row]')
-      .exists({ count: 3 }, 'Expected number of tokens are shown');
+      .exists(
+        { count: existingTokens.length + 1 },
+        'Expected number of tokens are shown'
+      );
 
     const doomedTokenRow = [...findAll('[data-test-policy-token-row]')].find(
       (a) => a.textContent.includes('Doomed Token')
@@ -672,32 +678,45 @@ module('Acceptance | tokens', function (hooks) {
     assert.dom('.flash-message.alert-success').exists();
     assert
       .dom('[data-test-policy-token-row]')
-      .exists({ count: 2 }, 'One fewer token after deletion');
+      .exists(
+        { count: existingTokens.length },
+        'One fewer token after deletion'
+      );
     await percySnapshot(assert);
     window.localStorage.nomadTokenSecret = null;
   });
 
   test('Test Token Creation', async function (assert) {
     allScenarios.policiesTestCluster(server);
+    const testPolicy = server.db.policies[0];
+    const existingTokens = server.db.tokens.filter((t) =>
+      t.policyIds.includes(testPolicy.name)
+    );
 
     window.localStorage.nomadTokenSecret = server.db.tokens[0].secretId;
     await visit('/policies');
 
     await click('[data-test-policy-row]:first-child');
-    assert.equal(currentURL(), `/policies/${server.db.policies[0].name}`);
+    assert.equal(currentURL(), `/policies/${testPolicy.name}`);
 
     assert
       .dom('[data-test-policy-token-row]')
-      .exists({ count: 2 }, 'Expected number of tokens are shown');
+      .exists(
+        { count: existingTokens.length },
+        'Expected number of tokens are shown'
+      );
 
     await click('[data-test-create-test-token]');
     assert.dom('.flash-message.alert-success').exists();
     assert
       .dom('[data-test-policy-token-row]')
-      .exists({ count: 3 }, 'One more token after test token creation');
+      .exists(
+        { count: existingTokens.length + 1 },
+        'One more token after test token creation'
+      );
     assert
       .dom('[data-test-policy-token-row]:last-child [data-test-token-name]')
-      .hasText(`Example Token for ${server.db.policies[0].name}`);
+      .hasText(`Example Token for ${testPolicy.name}`);
     await percySnapshot(assert);
     window.localStorage.nomadTokenSecret = null;
   });


### PR DESCRIPTION
These tests would fail depending on the value of the seed used.

(Extracted from https://github.com/hashicorp/nomad/pull/17301 so they can be backported)