### PR TITLE
release pipeline: release workflow needs write permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,6 @@ jobs:
           else
             echo "no files were updated"
           fi
-permissions:
-  contents: read
 
+permissions:
+  contents: write


### PR DESCRIPTION
In #17103 we set read-only permissions on all the workflows. Unfortunately we missed that the `release` workflow makes git commits and pushes them to the repository, so it needs to have write permissions.