### PR TITLE
ci: fix flaky UI test

### DIFF
--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -677,12 +677,12 @@ module('Acceptance | allocation detail (services)', function (hooks) {
       name: 'Service-haver',
       id: 'service-haver',
       namespaceId: 'default',
-      allocStatusDistribution: {
-        running: 1,
-      },
     });
 
-    const currentAlloc = server.db.allocations.findBy({ jobId: job.id });
+    const runningAlloc = server.create('allocation', {
+      jobId: job.id,
+      forceRunningClientStatus: true,
+    });
     const otherAlloc = server.db.allocations.reject((j) => j.jobId !== job.id);
 
     server.db.serviceFragments.update({
@@ -691,7 +691,7 @@ module('Acceptance | allocation detail (services)', function (hooks) {
           Status: 'success',
           Check: 'check1',
           Timestamp: 99,
-          Alloc: currentAlloc.id,
+          Alloc: runningAlloc.id,
         },
         {
           Status: 'failure',
@@ -700,21 +700,21 @@ module('Acceptance | allocation detail (services)', function (hooks) {
           propThatDoesntMatter:
             'this object will be ignored, since it shared a Check name with a later one.',
           Timestamp: 98,
-          Alloc: currentAlloc.id,
+          Alloc: runningAlloc.id,
         },
         {
           Status: 'success',
           Check: 'check2',
           Output: 'Two',
           Timestamp: 99,
-          Alloc: currentAlloc.id,
+          Alloc: runningAlloc.id,
         },
         {
           Status: 'failure',
           Check: 'check3',
           Output: 'Oh no!',
           Timestamp: 99,
-          Alloc: currentAlloc.id,
+          Alloc: runningAlloc.id,
         },
         {
           Status: 'success',


### PR DESCRIPTION
While backporting https://github.com/hashicorp/nomad/pull/17648 I noticed that this test can still be flaky because the service can be assigned to a non-running allocation.

I fixed this during the backports, so pulling it to `main` as here.