### PR TITLE
release pipeline: fix ref arguments in invoking workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,12 +139,11 @@ jobs:
           echo "build-ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Invoke build workflow
-        uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1.2.2
-        with:
-          workflow: build
-          token: ${{ secrets.ELEVATED_GITHUB_TOKEN}}
-          inputs: '{"build-ref": "${{ steps.commit-change-push.outputs.build-ref }}", "make-prerelease": "false"}'
-          ref: ${{ steps.commit-change-push.outputs.build-ref }}
+        id: invoke-build
+        env:
+          GH_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yml --field build-ref=${{ steps.commit-change-push.outputs.build-ref }} --field make-prerelease=false
 
       - name: Revert notification channel
         if: ${{ github.event.inputs.notification-channel != '' }}


### PR DESCRIPTION
Although #17669 fixed the permissions of the release pipeline to push new commits, there was still an error when invoking the `build` workflow.

The format of the reference was changed in #17103 such that we're sending the git ref (a SHA) and not the "--ref" argument required by the GH actions workflow API, which in this case is apparently specially defined as "The branch or tag name which contains the version of the workflow file you'd like to run" and not what git calls a "ref".

This changeset:
* Removes the third-party action entirely so that we're using GitHub's own tooling. This removes one more thing from the supply chain to pin and ensures a 1:1 mapping of args to what's documented by GitHub.
* Removes the `--ref` argument entirely, which causes it to default to the current branch that the release workflow is running on (which is always what we want).

---

Tested out in https://github.com/hashicorp/nomad-enterprise/actions/runs/5349266786 (after many many iterations :grinning: )