### PR TITLE
api: prevent panic on job plan

### DIFF
--- a/.changelog/17689.txt
+++ b/.changelog/17689.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fixed a bug that caused a panic when calling the `Jobs().Plan()` function with a job missing an ID
+```

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -447,6 +447,9 @@ func (j *Jobs) PlanOpts(job *Job, opts *PlanOptions, q *WriteOptions) (*JobPlanR
 	if job == nil {
 		return nil, nil, errors.New("must pass non-nil job")
 	}
+	if job.ID == nil {
+		return nil, nil, errors.New("job is missing ID")
+	}
 
 	// Setup the request
 	req := &JobPlanRequest{

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -2059,6 +2059,12 @@ func TestJobs_Plan(t *testing.T) {
 	_, _, err = jobs.Plan(nil, true, nil)
 	must.Error(t, err)
 
+	// Check that passing a nil job ID fails
+	invalidJob := testJob()
+	invalidJob.ID = nil
+	_, _, err = jobs.Plan(invalidJob, true, nil)
+	must.Error(t, err)
+
 	// Make a plan request
 	planResp, wm, err := jobs.Plan(job, true, nil)
 	must.NoError(t, err)


### PR DESCRIPTION
Check for a nil job ID to prevent a panic when calling Jobs().Plan().

Closes https://github.com/hashicorp/nomad/issues/17418