### PR TITLE
CI: refer to repo secrets in an early secret step

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,10 +13,23 @@ jobs:
     runs-on: ubuntu-latest
     container: hashicorpdev/backport-assistant:0.2.3
     steps:
-      - name: Setup secrets
+      # retrieve secrets from Vault (ENT-only right now)
+      - name: Authenticate to Vault
+        if: endsWith(github.repository, '-enterprise')
+        id: vault-auth
+        run: vault-auth
+      - name: Fetch Secrets
+        if: endsWith(github.repository, '-enterprise')
         id: secrets
-        run: |-
-          echo "GITHUB_TOKEN=${{ secrets.ELEVATED_GITHUB_TOKEN }}" >> "$GITHUB_OUTPUT"
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          exportEnv: false
+          secrets: |
+            kv/data/github/hashicorp/${{ github.repository }}/gha ELEVATED_GITHUB_TOKEN ;
+
       - name: Backport changes to stable-website
         run: |
           backport-assistant backport -merge-method=squash -automerge
@@ -25,7 +38,7 @@ jobs:
           BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
           # Enabling this option increased the number of backport failures.
           BACKPORT_MERGE_COMMIT: false
-          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ endswith(github.repository, '-enterprise') && steps.secrets.outputs.ELEVATED_GITHUB_TOKEN || secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Backport changes to targeted release branch
         run: |
           backport-assistant backport -merge-method=squash -automerge
@@ -34,17 +47,30 @@ jobs:
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
           # Enabling this option increased the number of backport failures.
           BACKPORT_MERGE_COMMIT: false
-          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ endswith(github.repository, '-enterprise') && steps.secrets.outputs.ELEVATED_GITHUB_TOKEN || secrets.ELEVATED_GITHUB_TOKEN }}
   handle-failure:
     needs:
       - backport
     if: always() && needs.backport.result == 'failure'
     runs-on: ubuntu-latest
     steps:
-      - name: Setup secrets
+      # retrieve secrets from Vault (ENT-only right now)
+      - name: Authenticate to Vault
+        if: endsWith(github.repository, '-enterprise')
+        id: vault-auth
+        run: vault-auth
+      - name: Fetch Secrets
+        if: endsWith(github.repository, '-enterprise')
         id: secrets
-        run: |-
-          echo "SLACK_URL=${{ secrets.BACKPORT_ASSISTANT_FAILURE_SLACK }}" >> "$GITHUB_OUTPUT"
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          exportEnv: false
+          secrets: |
+            kv/data/teams/nomad/slack-webhooks feed-nomad | SLACK_FEED_NOMAD ;
+
       - name: Send slack notification on failure
         uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
         with:
@@ -77,7 +103,7 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_URL }}
+          SLACK_WEBHOOK_URL: ${{ endswith(github.repository, '-enterprise') && steps.secrets.outputs.SLACK_FEED_NOMAD || secrets.BACKPORT_ASSISTANT_FAILURE_SLACK }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 permissions:
   contents: read

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     container: hashicorpdev/backport-assistant:0.2.3
     steps:
+      - name: Setup secrets
+        id: secrets
+        run: |-
+          echo "GITHUB_TOKEN=${{ secrets.ELEVATED_GITHUB_TOKEN }}" >> "$GITHUB_OUTPUT"
       - name: Backport changes to stable-website
         run: |
           backport-assistant backport -merge-method=squash -automerge
@@ -21,7 +25,7 @@ jobs:
           BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
           # Enabling this option increased the number of backport failures.
           BACKPORT_MERGE_COMMIT: false
-          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_TOKEN }}
       - name: Backport changes to targeted release branch
         run: |
           backport-assistant backport -merge-method=squash -automerge
@@ -30,13 +34,17 @@ jobs:
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
           # Enabling this option increased the number of backport failures.
           BACKPORT_MERGE_COMMIT: false
-          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_TOKEN }}
   handle-failure:
     needs:
       - backport
     if: always() && needs.backport.result == 'failure'
     runs-on: ubuntu-latest
     steps:
+      - name: Setup secrets
+        id: secrets
+        run: |-
+          echo "SLACK_URL=${{ secrets.BACKPORT_ASSISTANT_FAILURE_SLACK }}" >> "$GITHUB_OUTPUT"
       - name: Send slack notification on failure
         uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
         with:
@@ -69,7 +77,7 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.BACKPORT_ASSISTANT_FAILURE_SLACK }}
+          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,11 @@ jobs:
           echo "::error::Workflow not allowed to run from ${{ github.ref_name }}"
           exit 1
 
+      - name: Setup secrets
+        id: secrets
+        run: |-
+          echo "GITHUB_TOKEN=${{ secrets.ELEVATED_GITHUB_TOKEN }}" >> "$GITHUB_OUTPUT"
+
       - name: Print release info
         run: |-
           echo "::notice::Release v${{ github.event.inputs.version }} from branch ${{ github.ref_name }}"
@@ -55,8 +60,8 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Setup Git
         run: |-
-          if [ -n "${{ secrets.ELEVATED_GITHUB_TOKEN }}" ]; then
-            git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com/".insteadOf "https://github.com"
+          if [ -n "${{ steps.secrets.outputs.GITHUB_TOKEN }}" ]; then
+            git config --global url."https://${{ steps.secrets.outputs.GITHUB_TOKEN }}:@github.com/".insteadOf "https://github.com"
           fi
           git config --global user.email "github-team-nomad-core@hashicorp.com"
           git config --global user.name "hc-github-team-nomad-core"
@@ -141,7 +146,7 @@ jobs:
       - name: Invoke build workflow
         id: invoke-build
         env:
-          GH_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.secrets.outputs.GITHUB_TOKEN }}
         run: |
           gh workflow run build.yml --field build-ref=${{ steps.commit-change-push.outputs.build-ref }} --field make-prerelease=false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,26 @@ jobs:
           echo "::error::Workflow not allowed to run from ${{ github.ref_name }}"
           exit 1
 
-      - name: Setup secrets
+      # retrieve secrets from Vault (ENT-only right now)
+      - name: Authenticate to Vault
+        if: endsWith(github.repository, '-enterprise')
+        id: vault-auth
+        run: vault-auth
+      - name: Fetch Secrets
+        if: endsWith(github.repository, '-enterprise')
         id: secrets
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          exportEnv: false
+          secrets: |
+            kv/data/github/hashicorp/${{ github.repository }}/gha ELEVATED_GITHUB_TOKEN ;
+      - name: Setup git (ent)
+        if: endsWith(github.repository, '-enterprise')
         run: |-
-          echo "GITHUB_TOKEN=${{ secrets.ELEVATED_GITHUB_TOKEN }}" >> "$GITHUB_OUTPUT"
+          git config --global url."https://${{ steps.secrets.outputs.ELEVATED_GITHUB_TOKEN }}:@github.com/".insteadOf "https://github.com"
 
       - name: Print release info
         run: |-
@@ -60,9 +76,6 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Setup Git
         run: |-
-          if [ -n "${{ steps.secrets.outputs.GITHUB_TOKEN }}" ]; then
-            git config --global url."https://${{ steps.secrets.outputs.GITHUB_TOKEN }}:@github.com/".insteadOf "https://github.com"
-          fi
           git config --global user.email "github-team-nomad-core@hashicorp.com"
           git config --global user.name "hc-github-team-nomad-core"
 
@@ -146,7 +159,7 @@ jobs:
       - name: Invoke build workflow
         id: invoke-build
         env:
-          GH_TOKEN: ${{ steps.secrets.outputs.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ endswith(github.repository, '-enterprise') && steps.secrets.outputs.ELEVATED_GITHUB_TOKEN || secrets.ELEVATED_GITHUB_TOKEN }}
         run: |
           gh workflow run build.yml --field build-ref=${{ steps.commit-change-push.outputs.build-ref }} --field make-prerelease=false
 

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -70,12 +70,16 @@ jobs:
         partition: [1, 2, 3, 4]
         split: [4]
     steps:
+      - name: Setup secrets
+        id: secrets
+        run: |-
+          echo "PERCY_TOKEN=${{ secrets.PERCY_TOKEN }}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: yarn install
         run: yarn install --frozen-lockfile
       - name: ember exam
         env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PERCY_TOKEN: ${{ steps.secrets.outputs.PERCY_TOKEN }}
           PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
         run: yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }}
   finalize:
@@ -88,12 +92,16 @@ jobs:
       - pre-test
       - tests
     steps:
+      - name: Setup secrets
+        id: secrets
+        run: |-
+          echo "PERCY_TOKEN=${{ secrets.PERCY_TOKEN }}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: yarn install
         run: yarn install --frozen-lockfile
       - name: finalize
         env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PERCY_TOKEN: ${{ steps.secrets.outputs.PERCY_TOKEN }}
           PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
         run: yarn percy build:finalize
 permissions:

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -70,16 +70,29 @@ jobs:
         partition: [1, 2, 3, 4]
         split: [4]
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - name: Setup secrets
+      # retrieve secrets from Vault (ENT-only right now)
+      - name: Authenticate to Vault
+        if: endsWith(github.repository, '-enterprise')
+        id: vault-auth
+        run: vault-auth
+      - name: Fetch Secrets
+        if: endsWith(github.repository, '-enterprise')
         id: secrets
-        run: |-
-          echo "PERCY_TOKEN=${{ secrets.PERCY_TOKEN }}" >> "$GITHUB_OUTPUT"
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          exportEnv: false
+          secrets: |
+            kv/data/teams/nomad/ui PERCY_TOKEN ;
+
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: yarn install
         run: yarn install --frozen-lockfile
       - name: ember exam
         env:
-          PERCY_TOKEN: ${{ steps.secrets.outputs.PERCY_TOKEN }}
+          PERCY_TOKEN: ${{ endswith(github.repository, '-enterprise') && steps.secrets.outputs.PERCY_TOKEN || secrets.PERCY_TOKEN }}
           PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
         run: yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }}
   finalize:
@@ -92,16 +105,29 @@ jobs:
       - pre-test
       - tests
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - name: Setup secrets
+      # retrieve secrets from Vault (ENT-only right now)
+      - name: Authenticate to Vault
+        if: endsWith(github.repository, '-enterprise')
+        id: vault-auth
+        run: vault-auth
+      - name: Fetch Secrets
+        if: endsWith(github.repository, '-enterprise')
         id: secrets
-        run: |-
-          echo "PERCY_TOKEN=${{ secrets.PERCY_TOKEN }}" >> "$GITHUB_OUTPUT"
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          exportEnv: false
+          secrets: |
+            kv/data/teams/nomad/ui PERCY_TOKEN ;
+
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: yarn install
         run: yarn install --frozen-lockfile
       - name: finalize
         env:
-          PERCY_TOKEN: ${{ steps.secrets.outputs.PERCY_TOKEN }}
+          PERCY_TOKEN: ${{ endswith(github.repository, '-enterprise') && steps.secrets.outputs.PERCY_TOKEN || secrets.PERCY_TOKEN }}
           PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
         run: yarn percy build:finalize
 permissions:

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -70,11 +70,11 @@ jobs:
         partition: [1, 2, 3, 4]
         split: [4]
     steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Setup secrets
         id: secrets
         run: |-
           echo "PERCY_TOKEN=${{ secrets.PERCY_TOKEN }}" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: yarn install
         run: yarn install --frozen-lockfile
       - name: ember exam
@@ -92,11 +92,11 @@ jobs:
       - pre-test
       - tests
     steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Setup secrets
         id: secrets
         run: |-
           echo "PERCY_TOKEN=${{ secrets.PERCY_TOKEN }}" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: yarn install
         run: yarn install --frozen-lockfile
       - name: finalize


### PR DESCRIPTION
The goal here is to minimize merge conflicts between OSS->ENT due to our using Vault only in private repos.

Let me know if this seems misguided, but my plan is to replace this new "Setup secrets" step in ENT with [hashicorp/vault-action](https://github.com/hashicorp/vault-action) in such a way that the steps that use the secrets can reference them the same way `${{ steps.secrets.outputs.SECRET }}` in both OSS and ENT.

Some changes to secrets themselves will still likely collide, but unrelated changes _around_ lines that happen to contain secrets should not.

I've heard other projects just copy the workflows and maintain a separate ENT copy, but I personally find that to be unappetizing.