### PR TITLE
docker: add cgroupns task config

### DIFF
--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -342,6 +342,7 @@ var (
 		"auth_soft_fail": hclspec.NewAttr("auth_soft_fail", "bool", false),
 		"cap_add":        hclspec.NewAttr("cap_add", "list(string)", false),
 		"cap_drop":       hclspec.NewAttr("cap_drop", "list(string)", false),
+		"cgroupns":       hclspec.NewAttr("cgroupns", "string", false),
 		"command":        hclspec.NewAttr("command", "string", false),
 		"cpuset_cpus":    hclspec.NewAttr("cpuset_cpus", "string", false),
 		"cpu_hard_limit": hclspec.NewAttr("cpu_hard_limit", "bool", false),
@@ -433,6 +434,7 @@ type TaskConfig struct {
 	AuthSoftFail      bool               `codec:"auth_soft_fail"`
 	CapAdd            []string           `codec:"cap_add"`
 	CapDrop           []string           `codec:"cap_drop"`
+	CgroupnsMode      string             `codec:"cgroupns"`
 	Command           string             `codec:"command"`
 	CPUCFSPeriod      int64              `codec:"cpu_cfs_period"`
 	CPUHardLimit      bool               `codec:"cpu_hard_limit"`

--- a/drivers/docker/config_test.go
+++ b/drivers/docker/config_test.go
@@ -215,6 +215,7 @@ config {
   cap_add = ["CAP_SYS_NICE"]
   cap_drop = ["CAP_SYS_ADMIN", "CAP_SYS_TIME"]
   command = "/bin/bash"
+  cgroupns = "host"
   cpu_hard_limit = true
   cpu_cfs_period = 20
   devices = [
@@ -365,6 +366,7 @@ config {
 		CapAdd:       []string{"CAP_SYS_NICE"},
 		CapDrop:      []string{"CAP_SYS_ADMIN", "CAP_SYS_TIME"},
 		Command:      "/bin/bash",
+		CgroupnsMode: "host",
 		CPUHardLimit: true,
 		CPUCFSPeriod: 20,
 		Devices: []DockerDevice{

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -978,6 +978,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 	}
 
 	hostConfig := &docker.HostConfig{
+		CgroupnsMode: driverConfig.CgroupnsMode,
 		CgroupParent: cgroupParent(task.Resources), // if applicable
 
 		Memory:            memory,            // hard limit

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -84,6 +84,9 @@ The `docker` driver supports the following configuration in the job spec. Only
   }
   ```
 
+- `cgroupns` - (Optional) Cgroup namespace to use. Can be set to `host` or
+  `private`. If not specified Docker's default will be used.
+
 - `cpuset_cpus` <sup>Beta</sup> - (Optional) CPUs in which to allow execution
   (0-3, 0,1). Limit the specific CPUs or cores a container can use. A
   comma-separated list or hyphen-separated range of CPUs a container can use, if


### PR DESCRIPTION
Add support for Docker's [`--cgroupns`](https://docs.docker.com/engine/reference/commandline/run/) flag.

Some applications, like those requiring systemd in a cgroupv2 environment`, need to set this flag in order to run properly, but I'm not sure if this inverferes with the cgroup setup Nomad does, so opening up for discussion.