### PR TITLE
np: fix list of jobs for node pool `all`

### DIFF
--- a/nomad/node_pool_endpoint.go
+++ b/nomad/node_pool_endpoint.go
@@ -440,30 +440,21 @@ func (n *NodePool) ListJobs(args *structs.NodePoolJobsRequest, reply *structs.No
 					},
 				}
 
-				if args.Name == structs.NodePoolAll {
-					if namespace == structs.AllNamespacesSentinel {
-						iter, err = store.Jobs(ws)
-					} else {
-						iter, err = store.JobsByNamespace(ws, namespace)
-					}
+				if namespace == structs.AllNamespacesSentinel {
+					iter, err = store.JobsByPool(ws, args.Name)
 				} else {
-					if namespace == structs.AllNamespacesSentinel {
-						iter, err = store.JobsByPool(ws, args.Name)
-					} else {
-						iter, err = store.JobsByNamespace(ws, namespace)
-						filters = append(filters,
-							paginator.GenericFilter{
-								Allow: func(raw interface{}) (bool, error) {
-									job := raw.(*structs.Job)
-									if job == nil || job.NodePool != args.Name {
-										return false, nil
-									}
-									return true, nil
-								},
-							})
-					}
+					iter, err = store.JobsByNamespace(ws, namespace)
+					filters = append(filters,
+						paginator.GenericFilter{
+							Allow: func(raw interface{}) (bool, error) {
+								job := raw.(*structs.Job)
+								if job == nil || job.NodePool != args.Name {
+									return false, nil
+								}
+								return true, nil
+							},
+						})
 				}
-
 				if err != nil {
 					return err
 				}

--- a/nomad/node_pool_endpoint_test.go
+++ b/nomad/node_pool_endpoint_test.go
@@ -1454,6 +1454,9 @@ func TestNodePoolEndpoint_ListJobs_PaginationFiltering(t *testing.T) {
 		{name: "job-08", pool: "prod-1", namespace: "default", status: structs.JobStatusRunning},
 		{name: "job-09", pool: "prod-1", namespace: "non-default", status: structs.JobStatusPending},
 		{name: "job-10", pool: "dev-1", namespace: "default", status: structs.JobStatusPending},
+		{name: "job-11", pool: "all", namespace: "default", status: structs.JobStatusPending},
+		{name: "job-12", pool: "all", namespace: "default", status: structs.JobStatusPending},
+		{name: "job-13", pool: "all", namespace: "non-default", status: structs.JobStatusPending},
 	}
 	for _, m := range mocks {
 		job := mock.MinJob()
@@ -1583,22 +1586,19 @@ func TestNodePoolEndpoint_ListJobs_PaginationFiltering(t *testing.T) {
 			expectedError: "Permission denied",
 		},
 		{
-			name:      "test13 all pool wildcard NS",
-			pool:      "all",
-			namespace: "*",
-			aclToken:  root.SecretID,
-			expectedIDs: []string{ // note these are sorted namespace-then-job-ID
-				"job-00", "job-01", "job-02", "job-04", "job-05",
-				"job-08", "job-10", "job-06", "job-03", "job-09",
-			},
+			name:        "test13 all pool wildcard NS",
+			pool:        "all",
+			namespace:   "*",
+			aclToken:    root.SecretID,
+			expectedIDs: []string{"job-11", "job-12", "job-13"},
 		},
 		{
 			name:              "test14 all pool default NS",
 			pool:              "all",
-			pageSize:          4,
+			pageSize:          1,
 			aclToken:          root.SecretID,
-			expectedNextToken: "default.job-05",
-			expectedIDs:       []string{"job-00", "job-01", "job-02", "job-04"},
+			expectedNextToken: "default.job-12",
+			expectedIDs:       []string{"job-11"},
 		},
 	}
 


### PR DESCRIPTION
Unlike nodes, jobs are allowed to be registered in the node pool `all`, in which case all nodes are used for evaluating placements. When listing jobs for the `all` node pool only those that are explicitly in this node pool should be returned.