### PR TITLE
Smoke test binaries for EL7/glibc-2.17 compatiblity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,5 +313,43 @@ jobs:
             docker.io/hashicorppreview/${{ env.PKG_NAME }}:${{ env.version }}-dev
             docker.io/hashicorppreview/${{ env.PKG_NAME }}:${{ env.version }}-${{ github.sha }}
 
+  minimum-os:
+    name: OS Compatibility
+    # A quick smoke test of our binaries on our minimum target OS (RHEL 7). Why RHEL 7? Because the glibc version is that old (2.17).
+    needs:
+      - get-go-version
+      - get-product-version
+      - build-linux
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      # Note: Ideally we'd test all our target archs, unfortunately availability of containers of these OS's vary.
+      # For instance there is no ubi7 image for arm64 (there is on ubi8), RHBZ#1728771. And none at all for arm.
+      # So we have to settle for only being able to validate where we can, which is just amd64.
+      matrix:
+        goos: [linux]
+        goarch: [amd64]
+    steps:
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version: ${{needs.get-go-version.outputs.go-version}}
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+      - name: Test binary
+        env:
+          artifact_name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+        run: |
+          echo "::group::Unpack and Prep"
+          docker pull registry.access.redhat.com/ubi7/ubi-minimal:7.9-1057
+          unzip "$artifact_name"
+          echo "::group::Diagnostics"
+          echo "CGO related build information:"
+          go version -m ./nomad | grep CGO
+          echo "GLIBC links:"
+          go tool nm ./nomad | grep -i glibc | cut -d @ -f 2-3 | sort --version-sort | uniq
+          echo "::group::Smoke test binary"
+          docker run --rm -v "$PWD:/src" registry.access.redhat.com/ubi7/ubi-minimal:7.9-1057 /src/nomad version
+
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

This adds a quick smoke test of our binaries to verify we haven't exceeded the maximum glibc (2.17) version supported on older OSes (EL7). Which would break our ability to execute on older OSes.

## Why

This is related to our recent efforts to upgrade our GH build environment. When CGO enabled builds are built on Ubuntu-22 they include symbols to glibc versions (2.32+) that exceed our desired minimum OS version (EL7). To mitigate we are instead building on Ubuntu-20. However, Ubuntu-20 itself also includes a newer glibc version. So we need to make sure we check the binaries to prevent us from unintentionally dropping support by adding explicit smoke testing of the binary.

For clarity, here's a breakdown of distribution and glibc versions to provide a bit more context to why we should test on EL7:

| Distro          | glibc version | [EOL](https://endoflife.date)              |
|-----------------|---------------|------------------|
| Debian Jessie   | 2.19          | June 2025        |
| Debian Stretch  | 2.24          | June 2027        |
| CentOS 7        | 2.17          | June 2024        |
| CentOS 8        | 2.28          | December 2021        |
| CentOS 8 Stream       | 2.28          | May 2024        |
| CentOS 9 Stream       | 2.34          | May 2027        |
| RedHat 7        | 2.17          | June 2024        |
| RedHat 8        | 2.28          | May 2031        |
| RedHat 9        | 2.34          | June 2034        |
| Ubuntu 20.04    | 2.31          | May 2030         |
| Ubuntu 22.04    | 2.35          | May 2033         |

## Notes

This only affects CGO_ENABLED=1 binaries (like nomad).

This smoke test is only verifying `amd64` binaries because RH doesn't have an `arm64` container image for EL7 even though it ships the OS (this is fixed as of ubi8). However, no version releases an `arm` image.

## Related

(cross-liking for HC reference)
  - [Findings in hashicorp/nomad-enterprise#951](https://github.com/hashicorp/nomad-enterprise/issues/951#issuecomment-1553338889)
  - [Fixes added to hashicorp/vault-enterprise#4242](https://github.com/hashicorp/vault-enterprise/pull/4242)