### PR TITLE
[ui] alignment and spacing for job status panel

### DIFF
--- a/.changelog/16134.txt
+++ b/.changelog/16134.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Added a new Job Status Panel that helps show allocation status throughout a deployment and in steady state
+```

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -76,9 +76,9 @@
                   <li>
                     <LinkTo data-version={{versionObj.version}} @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' versionObj.version ']')    status=(concat '["running", "pending", "failed"]')         }}>
                       {{#if (eq versionObj.version "unknown")}}
-                        <Hds::Badge @text="unknown" class="version-label" />
+                        <Hds::Badge @text="unknown" class="version-label" @type="inverted" />
                       {{else}}
-                        <Hds::Badge @text={{concat "v" versionObj.version}} class="version-label" />
+                        <Hds::Badge @text={{concat "v" versionObj.version}} class="version-label" @type="inverted" />
                       {{/if}}
                       <Hds::Badge @text={{versionObj.allocations.length}} class="version-count" />
                     </LinkTo>
@@ -108,7 +108,7 @@
         <h4 class="title is-5" data-test-new-allocation-tally><span>New allocations: {{this.newRunningHealthyAllocBlocks.length}}/{{this.totalAllocs}} running and healthy</span>
           <span class="versions">
           <LinkTo data-version={{@job.version}} @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' @job.version ']')}}>
-            <Hds::Badge @text={{concat "v" @job.version}} class="version-label" />
+            <Hds::Badge @text={{concat "v" @job.version}} @type="inverted" class="version-label" />
           </LinkTo>
           </span>
         </h4>

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -94,11 +94,11 @@
             <legend>
               <span class="legend-item {{if (eq (get this.oldRunningHealthyAllocBlocks "length") 0) "faded"}}">
                 <span class="represented-allocation running"></span>
-                {{get this.oldRunningHealthyAllocBlocks "length"}} Running
+                <span class="count">{{get this.oldRunningHealthyAllocBlocks "length"}} Running</span>
               </span>
               <span class="legend-item {{if (eq (get this.oldCompleteHealthyAllocBlocks "length") 0) "faded"}}">
                 <span class="represented-allocation complete"></span>
-                {{get this.oldCompleteHealthyAllocBlocks "length"}} Complete
+                <span class="count">{{get this.oldCompleteHealthyAllocBlocks "length"}} Complete</span>
               </span>
             </legend>
           </div>
@@ -131,7 +131,7 @@
               @label="View {{status}} allocations"
             >
               <span class="represented-allocation {{status}}"></span>
-                {{count}} {{capitalize status}}
+              <span class="count">{{count}} {{capitalize status}}</span>
             </ConditionalLinkTo>
           {{/each-in}}
 
@@ -148,7 +148,7 @@
                   {{/if}}
                 </span>
               </span>
-              {{count}} {{humanize health}}
+              <span class="count">{{count}} {{humanize health}}</span>
             </span>
           {{/each-in}}
 
@@ -156,7 +156,7 @@
             <span class="represented-allocation legend-example canary">
               <span class="alloc-canary-indicator" />
             </span>
-            {{this.newAllocsByCanary.canary}} Canary
+            <span class="count">{{this.newAllocsByCanary.canary}} Canary</span>
           </span>
 
         </legend>

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -79,9 +79,9 @@
               <li>
                 <LinkTo data-version={{versionObj.version}} @route="jobs.job.allocations" @model={{@job}} @query={{hash version=(concat '[' versionObj.version ']')    status=(concat '["running", "pending", "failed"]')         }}>
                   {{#if (eq versionObj.version "unknown")}}
-                    <Hds::Badge @text="unknown" @type="filled" class="version-label" />
+                    <Hds::Badge @text="unknown" @type="inverted" class="version-label" />
                   {{else}}
-                    <Hds::Badge @text={{concat "v" versionObj.version}} @type="filled" class="version-label" />
+                    <Hds::Badge @text={{concat "v" versionObj.version}} @type="inverted" class="version-label" />
                   {{/if}}
                   <Hds::Badge @text={{versionObj.allocations.length}} @type="filled" class="version-count" />
                 </LinkTo>

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -59,7 +59,7 @@
               @label="View {{type.label}} allocations"
             >
               <span class="represented-allocation {{type.label}}"></span>
-              {{get (get (get (get this.allocBlocks type.label) 'healthy') 'nonCanary') "length"}} {{capitalize type.label}}
+              <span class="count">{{get (get (get (get this.allocBlocks type.label) 'healthy') 'nonCanary') "length"}} {{capitalize type.label}}</span>
             </ConditionalLinkTo>
           {{/each}}
         </legend>

--- a/ui/app/components/job-status/update-params.hbs
+++ b/ui/app/components/job-status/update-params.hbs
@@ -7,7 +7,7 @@
   {{did-insert trigger.fns.do}}
 
   <div class="update-parameters">
-    <h4 class="title is-5">Update Params</h4>
+    <h4 class="title is-4">Update Params</h4>
     <code>
 
       {{#if (and trigger.data.isSuccess (not trigger.data.isError))}}

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -413,7 +413,7 @@
     white-space: nowrap;
     flex: 1 0 auto;
 
-    &.faded {
+    &.faded .count {
       opacity: 0.5;
     }
 

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -111,6 +111,10 @@
       gap: 0.5rem;
       & > li {
         white-space: nowrap;
+        &:has(.version-count) .version-label {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+        }
       }
       a {
         text-decoration: none;
@@ -119,8 +123,6 @@
     .version-label {
       position: relative;
       z-index: 2;
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
       & > .hds-badge__text {
         font-weight: 700;
       }
@@ -131,7 +133,6 @@
       z-index: 1;
       left: -1rem;
       padding-left: 1rem;
-      // background-color: var(--token-color-surface-faint);
     }
   }
 

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -107,7 +107,7 @@
   .versions {
     & > ul {
       display: grid;
-      grid-template-columns: repeat(auto-fit, 100px);
+      grid-template-columns: repeat(auto-fit, 65px);
       gap: 0.5rem;
       & > li {
         white-space: nowrap;

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -89,6 +89,7 @@
         display: grid;
         grid-template-columns: auto 1fr;
         gap: 0.5rem;
+        margin-top: 1rem;
 
         & > .versions > ul {
           grid-template-columns: unset;
@@ -128,7 +129,7 @@
       z-index: 1;
       left: -1rem;
       padding-left: 1rem;
-      background-color: var(--token-color-surface-faint);
+      // background-color: var(--token-color-surface-faint);
     }
   }
 
@@ -150,9 +151,9 @@
 
     legend {
       display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      grid-auto-rows: max-content;
+      grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
       gap: 0.5rem;
+      grid-template-rows: min-content;
     }
     .latest-deployment {
       h4 svg {
@@ -405,14 +406,12 @@
     animation: none;
   }
 
-  & > .boxed-section-body > .deployment-allocations {
-    margin-bottom: 1rem;
-  }
-
   .legend-item {
     display: grid;
     gap: 0.5rem;
     grid-template-columns: auto 1fr;
+    white-space: nowrap;
+    flex: 1 0 auto;
 
     &.faded {
       opacity: 0.5;
@@ -433,7 +432,12 @@
     display: grid;
     grid-template-columns: 70% auto;
     gap: 1rem;
-    margin-top: 1rem;
+    margin-top: 2rem;
+    & > .deployment-history,
+    & > .update-parameters {
+      display: grid;
+      grid-template-rows: 50px auto;
+    }
   }
 
   &.steady-state .history-and-params {
@@ -520,6 +524,10 @@
       max-height: 300px;
       overflow-y: auto;
       display: block;
+    }
+    & > .title {
+      display: grid;
+      align-content: center;
     }
     ul,
     span.notification {

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -119,6 +119,8 @@
     .version-label {
       position: relative;
       z-index: 2;
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
       & > .hds-badge__text {
         font-weight: 700;
       }

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -16,6 +16,7 @@ import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import Allocation from 'nomad-ui/tests/pages/allocations/detail';
 import moment from 'moment';
 import formatHost from 'nomad-ui/utils/format-host';
+import faker from 'nomad-ui/mirage/faker';
 
 let job;
 let node;
@@ -735,6 +736,7 @@ module('Acceptance | allocation detail (services)', function (hooks) {
   });
 
   test('Allocation has a list of services with active checks', async function (assert) {
+    faker.seed(1);
     const runningAlloc = server.db.allocations.findBy({
       jobId: 'service-haver',
       clientStatus: 'running',

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -688,6 +688,7 @@ module('Acceptance | allocation detail (services)', function (hooks) {
     const runningAlloc = server.create('allocation', {
       jobId: job.id,
       forceRunningClientStatus: true,
+      clientStatus: 'running',
     });
     const otherAlloc = server.db.allocations.reject((j) => j.jobId !== job.id);
 
@@ -739,6 +740,7 @@ module('Acceptance | allocation detail (services)', function (hooks) {
     faker.seed(1);
     const runningAlloc = server.db.allocations.findBy({
       jobId: 'service-haver',
+      forceRunningClientStatus: true,
       clientStatus: 'running',
     });
     await Allocation.visit({ id: runningAlloc.id });

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -736,7 +736,7 @@ module('Acceptance | allocation detail (services)', function (hooks) {
     });
   });
 
-  test('Allocation has a list of services with active checks', async function (assert) {
+  test.only('Allocation has a list of services with active checks', async function (assert) {
     faker.seed(1);
     const runningAlloc = server.db.allocations.findBy({
       jobId: 'service-haver',
@@ -751,8 +751,40 @@ module('Acceptance | allocation detail (services)', function (hooks) {
       .dom('[data-test-service-status-bar]')
       .exists('At least one allocation has service health');
 
+    const nameOfFirstServiceWithHealth = document
+      .querySelector('[data-test-service-status-bar]')
+      .parentElement.parentElement.parentElement.children[1].textContent.replace(
+        /(\r\n|\n|\r)/gm,
+        ''
+      )
+      .trim();
+    console.log(
+      'Number of service rows',
+      document.querySelectorAll('[data-test-service]').length
+    );
+    console.log(
+      'Number of status-bars',
+      document.querySelectorAll('[data-test-service-status-bar]').length
+    );
+    console.log('Name of first service bar', nameOfFirstServiceWithHealth);
     await click('[data-test-service-status-bar]');
     assert.dom('.service-sidebar').hasClass('open');
+    console.log('Providing extra information for test failures');
+    console.log(
+      'total number of healh check TRs',
+      document.querySelectorAll('table.health-checks tr[data-service-health]')
+        .length
+    );
+    console.log(
+      'Map of statuses of those health checks',
+      [
+        ...document.querySelectorAll(
+          'table.health-checks tr[data-service-health]'
+        ),
+      ]
+        .map((tr) => tr.dataset.serviceHealth)
+        .toString()
+    );
     assert
       .dom('table.health-checks tr[data-service-health="success"]')
       .exists({ count: 2 }, 'Two successful health checks');

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -751,40 +751,8 @@ module('Acceptance | allocation detail (services)', function (hooks) {
       .dom('[data-test-service-status-bar]')
       .exists('At least one allocation has service health');
 
-    const nameOfFirstServiceWithHealth = document
-      .querySelector('[data-test-service-status-bar]')
-      .parentElement.parentElement.parentElement.children[1].textContent.replace(
-        /(\r\n|\n|\r)/gm,
-        ''
-      )
-      .trim();
-    console.log(
-      'Number of service rows',
-      document.querySelectorAll('[data-test-service]').length
-    );
-    console.log(
-      'Number of status-bars',
-      document.querySelectorAll('[data-test-service-status-bar]').length
-    );
-    console.log('Name of first service bar', nameOfFirstServiceWithHealth);
     await click('[data-test-service-status-bar]');
     assert.dom('.service-sidebar').hasClass('open');
-    console.log('Providing extra information for test failures');
-    console.log(
-      'total number of healh check TRs',
-      document.querySelectorAll('table.health-checks tr[data-service-health]')
-        .length
-    );
-    console.log(
-      'Map of statuses of those health checks',
-      [
-        ...document.querySelectorAll(
-          'table.health-checks tr[data-service-health]'
-        ),
-      ]
-        .map((tr) => tr.dataset.serviceHealth)
-        .toString()
-    );
     assert
       .dom('table.health-checks tr[data-service-health="success"]')
       .exists({ count: 2 }, 'Two successful health checks');

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -736,7 +736,7 @@ module('Acceptance | allocation detail (services)', function (hooks) {
     });
   });
 
-  test.only('Allocation has a list of services with active checks', async function (assert) {
+  test('Allocation has a list of services with active checks', async function (assert) {
     faker.seed(1);
     const runningAlloc = server.db.allocations.findBy({
       jobId: 'service-haver',


### PR DESCRIPTION
Cleans up and standardizes spacing across a handful of elements in the job status panel;
makes the version tabs stand out more;
fades only the text part of faded legend items

<img width="976" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/f62ce7c5-172d-46c3-afff-ffc686ac805d">
