### PR TITLE
cli: fix broken `node pool jobs` test

### DIFF
--- a/command/agent/node_pool_endpoint_test.go
+++ b/command/agent/node_pool_endpoint_test.go
@@ -429,7 +429,7 @@ func TestHTTP_NodePool_JobsList(t *testing.T) {
 		err := s.Agent.RPC("NodePool.UpsertNodePools", &npUpReq, &npUpResp)
 		must.NoError(t, err)
 
-		for _, poolName := range []string{pool1.Name, "default"} {
+		for _, poolName := range []string{pool1.Name, "default", "all"} {
 			for i := 0; i < 2; i++ {
 				job := mock.MinJob()
 				job.NodePool = poolName
@@ -477,7 +477,7 @@ func TestHTTP_NodePool_JobsList(t *testing.T) {
 
 		obj, err = s.Server.NodePoolSpecificRequest(respW, req)
 		must.NoError(t, err)
-		must.SliceLen(t, 4, obj.([]*structs.JobListStub))
+		must.SliceLen(t, 2, obj.([]*structs.JobListStub))
 
 	})
 }

--- a/command/node_pool_jobs_test.go
+++ b/command/node_pool_jobs_test.go
@@ -52,6 +52,8 @@ func TestNodePoolJobsListCommand_Run(t *testing.T) {
 	registerJob("default", "default", "job3")
 	registerJob("default", "default", "job4")
 	registerJob("default", "system", "job5")
+	registerJob("all", "system", "job6")
+	registerJob("all", "default", "job7")
 
 	testCases := []struct {
 		name         string
@@ -79,9 +81,9 @@ func TestNodePoolJobsListCommand_Run(t *testing.T) {
 			expectedCode: 0,
 		},
 		{
-			name:         "list with specific namespaces in all pools",
+			name:         "list with specific namespace in the all pool",
 			args:         []string{"-namespace", "system", "all"},
-			expectedJobs: []string{"job2", "job5"},
+			expectedJobs: []string{"job6"},
 			expectedCode: 0,
 		},
 		{


### PR DESCRIPTION
In #17705 we fixed a bug in the treatment of the "all" node pool for the `node pool jobs` command but missed a test in the CLI and HTTP endpoint.