### PR TITLE
[ui] links to allocations explicitly go through their route model hook

### DIFF
--- a/ui/app/controllers/clients/client/index.js
+++ b/ui/app/controllers/clients/client/index.js
@@ -205,7 +205,7 @@ export default class ClientController extends Controller.extend(
 
   @action
   gotoAllocation(allocation) {
-    this.transitionToRoute('allocations.allocation', allocation);
+    this.transitionToRoute('allocations.allocation', allocation.id);
   }
 
   @action

--- a/ui/app/controllers/csi/plugins/plugin/allocations.js
+++ b/ui/app/controllers/csi/plugins/plugin/allocations.js
@@ -113,7 +113,7 @@ export default class AllocationsController extends Controller.extend(
   @action
   gotoAllocation(allocation, event) {
     lazyClick([
-      () => this.transitionToRoute('allocations.allocation', allocation),
+      () => this.transitionToRoute('allocations.allocation', allocation.id),
       event,
     ]);
   }

--- a/ui/app/controllers/csi/plugins/plugin/index.js
+++ b/ui/app/controllers/csi/plugins/plugin/index.js
@@ -19,6 +19,6 @@ export default class IndexController extends Controller {
 
   @action
   gotoAllocation(allocation) {
-    this.transitionToRoute('allocations.allocation', allocation);
+    this.transitionToRoute('allocations.allocation', allocation.id);
   }
 }

--- a/ui/app/controllers/csi/volumes/volume.js
+++ b/ui/app/controllers/csi/volumes/volume.js
@@ -60,6 +60,6 @@ export default class VolumeController extends Controller {
 
   @action
   gotoAllocation(allocation) {
-    this.transitionToRoute('allocations.allocation', allocation);
+    this.transitionToRoute('allocations.allocation', allocation.id);
   }
 }

--- a/ui/app/controllers/jobs/job/allocations.js
+++ b/ui/app/controllers/jobs/job/allocations.js
@@ -166,7 +166,7 @@ export default class AllocationsController extends Controller.extend(
 
   @action
   gotoAllocation(allocation) {
-    this.transitionToRoute('allocations.allocation', allocation);
+    this.transitionToRoute('allocations.allocation', allocation.id);
   }
 
   get optionsAllocationStatus() {

--- a/ui/app/controllers/jobs/job/task-group.js
+++ b/ui/app/controllers/jobs/job/task-group.js
@@ -140,7 +140,7 @@ export default class TaskGroupController extends Controller.extend(
 
   @action
   gotoAllocation(allocation) {
-    this.transitionToRoute('allocations.allocation', allocation);
+    this.transitionToRoute('allocations.allocation', allocation.id);
   }
 
   @action

--- a/ui/app/routes/allocations/allocation.js
+++ b/ui/app/routes/allocations/allocation.js
@@ -50,6 +50,9 @@ export default class AllocationRoute extends Route.extend(WithWatchers) {
         super.model(...arguments),
         this.store.findAll('namespace'),
       ]);
+      if (allocation.isPartial) {
+        await allocation.reload();
+      }
       const jobId = allocation.belongsTo('job').id();
       await this.store.findRecord('job', jobId);
       return allocation;

--- a/ui/tests/acceptance/job-allocations-test.js
+++ b/ui/tests/acceptance/job-allocations-test.js
@@ -4,7 +4,7 @@
  */
 
 /* eslint-disable qunit/require-expect */
-import { currentURL } from '@ember/test-helpers';
+import { currentURL, click, find } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -75,6 +75,33 @@ module('Acceptance | job allocations', function (hooks) {
     });
 
     assert.equal(document.title, `Job ${job.name} allocations - Nomad`);
+  });
+
+  test('clicking an allocation results in the correct endpoint being hit', async function (assert) {
+    server.createList('allocation', Allocations.pageSize - 1, {
+      shallow: true,
+    });
+    allocations = server.schema.allocations.where({ jobId: job.id }).models;
+
+    await Allocations.visit({ id: job.id });
+
+    const firstAllocation = find('[data-test-allocation]');
+    await click(firstAllocation);
+
+    const requestToAllocationEndpoint = server.pretender.handledRequests.find(
+      (request) =>
+        request.url.includes(
+          `/v1/allocation/${firstAllocation.dataset.testAllocation}`
+        )
+    );
+
+    assert.ok(requestToAllocationEndpoint, 'the correct endpoint is hit');
+
+    assert.equal(
+      currentURL(),
+      `/allocations/${firstAllocation.dataset.testAllocation}`,
+      'the URL is correct'
+    );
   });
 
   test('allocations table is sortable', async function (assert) {


### PR DESCRIPTION
Resolves #17521 

When loading an allocation from a parent page, like the allocations list of a job, there were circumstances where that allocation would load as `isPartial`, and be missing critical data, notably `taskGroup`. We have components like our `LifecycleChart` that make use of that data and throw a fatal exception if not found.

This ensures that the model, if partial, is fully loaded when /allocations/allocation/$id is hit. This further changes our links to allocation pages to pass in the ID of the allocation rather than a (potentially partial) model itself, in order to cause it to rerun the route model hook.

