### PR TITLE
[ui] Node Pools moved to after Type in jobs index columns

### DIFF
--- a/ui/app/templates/clients/index.hbs
+++ b/ui/app/templates/clients/index.hbs
@@ -21,6 +21,13 @@
       <div class="toolbar-item is-right-aligned is-mobile-full-width">
         <div class="button-bar">
           <MultiSelectDropdown
+            data-test-state-facet
+            @label="State"
+            @options={{this.optionsState}}
+            @selection={{this.selectionState}}
+            @onSelect={{action this.setFacetQueryParam "qpState"}}
+          />
+          <MultiSelectDropdown
             data-test-node-pool-facet
             @label="Node Pool"
             @options={{this.optionsNodePool}}
@@ -33,13 +40,6 @@
             @options={{this.optionsClass}}
             @selection={{this.selectionClass}}
             @onSelect={{action this.setFacetQueryParam "qpClass"}}
-          />
-          <MultiSelectDropdown
-            data-test-state-facet
-            @label="State"
-            @options={{this.optionsState}}
-            @selection={{this.selectionState}}
-            @onSelect={{action this.setFacetQueryParam "qpState"}}
           />
           <MultiSelectDropdown
             data-test-datacenter-facet

--- a/ui/app/templates/components/job-row.hbs
+++ b/ui/app/templates/components/job-row.hbs
@@ -31,9 +31,6 @@
       {{this.job.namespace.name}}
     </td>
   {{/if}}
-  <td data-test-job-node-pool>
-    {{this.job.nodePool}}
-  </td>
 {{/if}}
 {{#if (eq @context "child")}}
   <td data-test-job-submit-time>
@@ -48,6 +45,9 @@
 {{#if (not (eq @context "child"))}}
   <td data-test-job-type>
     {{this.job.displayType.type}}
+  </td>
+  <td data-test-job-node-pool>
+    {{this.job.nodePool}}
   </td>
   <td data-test-job-priority>
     {{this.job.priority}}

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -143,14 +143,14 @@
               Namespace
             </t.sort-by>
           {{/if}}
-          <t.sort-by @prop="nodePool">
-              Node Pool
-          </t.sort-by>
           <t.sort-by @prop="status">
             Status
           </t.sort-by>
           <t.sort-by @prop="type">
             Type
+          </t.sort-by>
+          <t.sort-by @prop="nodePool">
+              Node Pool
           </t.sort-by>
           <t.sort-by @prop="priority">
             Priority


### PR DESCRIPTION
- moves the "state" filter box on the clients index page to be first
- moves the "Node Pool" column header to after Type on the jobs index page
![image](https://github.com/hashicorp/nomad/assets/713991/dc87fd2f-884b-452d-b264-186f1711da88)
