### PR TITLE
[ui] HCL-in-UI: Re-arrange buttons, add save-as-file

### DIFF
--- a/.changelog/17752.txt
+++ b/.changelog/17752.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Adds a Download as .nomad.hcl button to jobspec editing in the UI
+```

--- a/ui/app/styles/components/codemirror.scss
+++ b/ui/app/styles/components/codemirror.scss
@@ -140,6 +140,7 @@ header.run-job-header {
   grid-template-columns: 1fr auto;
   margin-bottom: 2rem;
   gap: 0 1rem;
+  align-items: end;
   & > h1 {
     grid-column: -1 / 1;
   }
@@ -166,6 +167,10 @@ header.run-job-header {
     bottom: 0;
     background: white;
     padding: 0.5rem 0;
+
+    &.pull-left {
+      justify-content: flex-start;
+    }
   }
 }
 

--- a/ui/app/templates/components/job-editor.hbs
+++ b/ui/app/templates/components/job-editor.hbs
@@ -15,6 +15,28 @@
         <p>
           Paste or author HCL or JSON to submit to your cluster, or select from a list of templates. A plan will be requested before the job is submitted. You can also attach a job spec by uploading a job file or dragging &amp; dropping a file to the editor.
         </p>
+
+        {{#if (can "write variable" path="*" namespace="*")}}
+          <Hds::ButtonSet>
+            <label
+              class="job-spec-upload hds-button hds-button--color-secondary hds-button--size-medium"
+            >
+              <div class="hds-button__text">Upload file</div>
+              <input
+                type="file"
+                onchange={{action this.uploadJobSpec}}
+                accept=".hcl,.json,.nomad"
+              />
+            </label>
+            <Hds::Button
+              @text="Choose from template"
+              @color="secondary"
+              @route="jobs.run.templates"
+              data-test-choose-template
+            />
+          </Hds::ButtonSet>
+        {{/if}}
+
       </header>
     {{/if}}
     {{did-update this.setDefinitionOnModel this.definition}}

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -99,4 +99,10 @@
       data-test-save-as-template
     />
   {{/if}}
+  <Hds::Button
+    @text="Save as .nomad.hcl"
+    @color="secondary"
+    {{on "click" @fns.onSaveFile}}
+
+  />
 </Hds::ButtonSet>

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -83,7 +83,7 @@
     </div>
   {{/if}}
 </div>
-<div class="is-associative buttonset sticky">
+<Hds::ButtonSet class="is-associative buttonset sticky pull-left">
   <Hds::Button
     {{on "click" (perform @fns.onPlan)}}
     disabled={{or @fns.onPlan.isRunning (not @data.job._newDefinition)}}
@@ -91,34 +91,12 @@
     @text="Plan"
   />
   {{#if @data.job.isNew}}
-    <Hds::ButtonSet>
-      <label
-        class="job-spec-upload hds-button hds-button--color-secondary hds-button--size-medium"
-      >
-        <div class="hds-button__text">Upload file</div>
-        <input
-          type="file"
-          onchange={{action @fns.onUpload}}
-          accept=".hcl,.json,.nomad"
-        />
-      </label>
-      {{#if (can "write variable" path="*" namespace="*")}}
-        <Hds::Button
-          @icon="file-plus"
-          @text="Save as template"
-          @color="tertiary"
-          @route="jobs.run.templates.new"
-          {{on "click" @fns.onSaveAs}}
-          data-test-save-as-template
-        />
-        <Hds::Button
-          @icon="file-text"
-          @text="Choose from a template"
-          @color="tertiary"
-          @route="jobs.run.templates"
-          data-test-choose-template
-        />
-      {{/if}}
-    </Hds::ButtonSet>
+    <Hds::Button
+      @text="Save as template"
+      @color="secondary"
+      @route="jobs.run.templates.new"
+      {{on "click" @fns.onSaveAs}}
+      data-test-save-as-template
+    />
   {{/if}}
-</div>
+</Hds::ButtonSet>

--- a/ui/tests/integration/components/job-editor-test.js
+++ b/ui/tests/integration/components/job-editor-test.js
@@ -85,6 +85,7 @@ module('Integration | Component | job-editor', function (hooks) {
       @job={{job}}
       @context={{context}}
       @onSubmit={{onSubmit}}
+      @handleSaveAsTemplate={{handleSaveAsTemplate}}
     />
   `;
 
@@ -92,6 +93,7 @@ module('Integration | Component | job-editor', function (hooks) {
     component.setProperties({
       job,
       onSubmit: sinon.spy(),
+      handleSaveAsTemplate: sinon.spy(),
       context: 'new',
     });
     await component.render(commonTemplate);


### PR DESCRIPTION
- Rearranges buttons when adding a jobspec, or editing an existing jobspec, to be more intuitive
- Adds a "Download as .nomad.hcl" button when editing, to let users practice good infra-as-code
![image](https://github.com/hashicorp/nomad/assets/713991/6bc6af39-fe33-4e95-a97e-3d9943e83824)


Resolves #17327 