### PR TITLE
[ui] Link to allocations.allocation by ID reference, not by model

### DIFF
--- a/ui/app/components/job-status/deployment-history.hbs
+++ b/ui/app/components/job-status/deployment-history.hbs
@@ -33,7 +33,7 @@
       {{#each this.history as |deployment-log|}}
         <li class="timeline-object {{if (eq deployment-log.exitCode 1) "error"}}">
           <div class="boxed-section-head is-light">
-            <LinkTo @route="allocations.allocation" @model={{deployment-log.state.allocation}} class="allocation-reference">{{deployment-log.state.allocation.shortId}}</LinkTo>
+            <LinkTo @route="allocations.allocation" @model={{deployment-log.state.allocation.id}} class="allocation-reference">{{deployment-log.state.allocation.shortId}}</LinkTo>
             <span><strong>{{deployment-log.type}}:</strong> {{deployment-log.message}}</span>
             <span class="pull-right">
               {{format-ts deployment-log.time}}

--- a/ui/app/components/job-status/individual-allocation.hbs
+++ b/ui/app/components/job-status/individual-allocation.hbs
@@ -7,7 +7,7 @@
   <ConditionalLinkTo
     @condition={{not (eq @status "unplaced")}}
     @route="allocations.allocation"
-    @model={{@allocation}}
+    @model={{@allocation.id}}
     @class="represented-allocation {{@status}} {{@health}} {{@canary}}"
     @label="View allocation"
   >


### PR DESCRIPTION
Follows up on the work done in #17737 — missed two template-driven (LinkTo) spots that are covered here: the individual allocation blocks (green/red/etc. squares in the status panel), and the left-side links in Deployment History.