### PR TITLE
[ui] Text wrap long lines of code and logs

### DIFF
--- a/.changelog/17754.txt
+++ b/.changelog/17754.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: adds a toggle and localStorage property to Word Wrap logs and job definitions
+```

--- a/ui/app/components/job-editor.js
+++ b/ui/app/components/job-editor.js
@@ -85,6 +85,7 @@ export default class JobEditor extends Component {
   }
 
   @localStorageProperty('nomadMessageJobPlan', true) shouldShowPlanMessage;
+  @localStorageProperty('nomadShouldWrapCode', false) shouldWrapCode;
 
   @action
   dismissPlanMessage() {
@@ -184,6 +185,14 @@ export default class JobEditor extends Component {
   }
 
   /**
+   * Toggle the wrapping of the job's definition or definition variables.
+   */
+  @action
+  toggleWrap() {
+    this.shouldWrapCode = !this.shouldWrapCode;
+  }
+
+  /**
    * Read the content of an uploaded job specification file and update the job's definition.
    *
    * @param {Event} event - The input change event containing the selected file.
@@ -242,6 +251,7 @@ export default class JobEditor extends Component {
       planOutput: this.planOutput,
       shouldShowPlanMessage: this.shouldShowPlanMessage,
       view: this.args.view,
+      shouldWrap: this.shouldWrapCode,
     };
   }
 
@@ -257,6 +267,7 @@ export default class JobEditor extends Component {
       onSelect: this.args.onSelect,
       onUpdate: this.updateCode,
       onUpload: this.uploadJobSpec,
+      onToggleWrap: this.toggleWrap,
     };
   }
 }

--- a/ui/app/components/task-log.js
+++ b/ui/app/components/task-log.js
@@ -12,6 +12,7 @@ import { logger } from 'nomad-ui/utils/classes/log';
 import timeout from 'nomad-ui/utils/timeout';
 import { classNames } from '@ember-decorators/component';
 import classic from 'ember-classic-decorator';
+import localStorageProperty from 'nomad-ui/utils/properties/local-storage';
 
 class MockAbortController {
   abort() {
@@ -42,7 +43,7 @@ export default class TaskLog extends Component {
 
   shouldFillHeight = true;
 
-  wrapped = false;
+  @localStorageProperty('nomadShouldWrapCode', false) wrapped;
 
   @alias('userSettings.logMode') mode;
 

--- a/ui/app/components/task-log.js
+++ b/ui/app/components/task-log.js
@@ -42,6 +42,8 @@ export default class TaskLog extends Component {
 
   shouldFillHeight = true;
 
+  wrapped = false;
+
   @alias('userSettings.logMode') mode;
 
   @computed('allocation.{id,node.httpAddr}', 'useServer')
@@ -122,5 +124,10 @@ export default class TaskLog extends Component {
   @action
   failoverToServer() {
     this.set('useServer', true);
+  }
+
+  @action toggleWrap() {
+    this.toggleProperty('wrapped');
+    return false;
   }
 }

--- a/ui/app/modifiers/code-mirror.js
+++ b/ui/app/modifiers/code-mirror.js
@@ -30,6 +30,7 @@ export default class CodeMirrorModifier extends Modifier {
   }
 
   didUpdateArguments() {
+    this._editor.setOption('lineWrapping', this.args.named.lineWrapping);
     this._editor.setOption('readOnly', this.args.named.readOnly);
     if (!this.args.named.content) {
       return;
@@ -66,6 +67,7 @@ export default class CodeMirrorModifier extends Modifier {
         value: this.args.named.content || '',
         viewportMargin: this.args.named.viewportMargin || '',
         screenReaderLabel: this.args.named.screenReaderLabel || '',
+        lineWrapping: this.args.named.lineWrapping || false,
       });
 
       if (this.autofocus) {

--- a/ui/app/styles/components/boxed-section.scss
+++ b/ui/app/styles/components/boxed-section.scss
@@ -78,8 +78,13 @@
     .header-toggle {
       display: inline-block;
       position: relative;
-      top: $control-padding-vertical;
+      top: 0.2em;
       margin-left: $control-padding-horizontal;
+      margin-right: $control-padding-horizontal;
+    }
+
+    &.task-log-head .header-toggle {
+      top: 0.5em;
     }
   }
 

--- a/ui/app/styles/components/boxed-section.scss
+++ b/ui/app/styles/components/boxed-section.scss
@@ -70,8 +70,16 @@
       border-top-right-radius: 0;
     }
 
-    .button {
+    .button,
+    .is-inline-block {
       display: inline-block;
+    }
+
+    .header-toggle {
+      display: inline-block;
+      position: relative;
+      top: $control-padding-vertical;
+      margin-left: $control-padding-horizontal;
     }
   }
 

--- a/ui/app/styles/components/cli-window.scss
+++ b/ui/app/styles/components/cli-window.scss
@@ -12,6 +12,10 @@
 
   code {
     height: 100%;
+
+    &.wrapped {
+      white-space: pre-wrap;
+    }
   }
 
   .is-light {

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -37,6 +37,18 @@
           </button>
         </div>
       </Tooltip>
+        <button class="button is-light is-compact"
+          type="button"
+          {{on "click" @fns.onToggleWrap}}
+          {{keyboard-shortcut action=(action @fns.onToggleWrap) pattern=(array "w" "w") }}
+        >
+          {{#if @data.shouldWrap}}
+            Unwrap
+          {{else}}
+            Wrap
+          {{/if}}
+        </button>
+
         <button
           class="button is-light is-compact pull-right"
           onclick={{@fns.onCancel}}
@@ -57,6 +69,7 @@
         theme="hashi"
         onUpdate=@fns.onUpdate
         mode=(if (eq @data.format "json") "javascript" "ruby")
+        lineWrapping=@data.shouldWrap
       }}
     ></div>
   </div>
@@ -77,6 +90,7 @@
             onUpdate=@fns.onUpdate
             type="hclVariables"
             mode="ruby"
+            lineWrapping=@data.shouldWrap
           }}
         ></div>
       </div>

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -40,7 +40,7 @@
         <button class="button is-light is-compact"
           type="button"
           {{on "click" @fns.onToggleWrap}}
-          {{keyboard-shortcut action=(action @fns.onToggleWrap) pattern=(array "w" "w") }}
+          {{keyboard-shortcut label="Toggle word wrap" action=(action @fns.onToggleWrap) pattern=(array "w" "w") }}
         >
           {{#if @data.shouldWrap}}
             Unwrap

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -8,6 +8,15 @@
     Job Definition
     {{#if @data.cancelable}}
     <div class="pull-right" style="display: flex">
+      <span class="header-toggle">
+        <Hds::Form::Toggle::Field
+          {{keyboard-shortcut label="Toggle word wrap" action=(action @fns.onToggleWrap) pattern=(array "w" "w") menuLevel=true }}
+          checked={{@data.shouldWrap}}
+          {{on "change" @fns.onToggleWrap}}
+        as |F|>
+          <F.Label>Word Wrap</F.Label>
+        </Hds::Form::Toggle::Field>
+      </span>
       <Tooltip
         @condition={{unless @data.hasSpecification true false}}
         @isFullText={{true}}
@@ -37,18 +46,6 @@
           </button>
         </div>
       </Tooltip>
-        <button class="button is-light is-compact"
-          type="button"
-          {{on "click" @fns.onToggleWrap}}
-          {{keyboard-shortcut label="Toggle word wrap" action=(action @fns.onToggleWrap) pattern=(array "w" "w") }}
-        >
-          {{#if @data.shouldWrap}}
-            Unwrap
-          {{else}}
-            Wrap
-          {{/if}}
-        </button>
-
         <button
           class="button is-light is-compact pull-right"
           onclick={{@fns.onCancel}}

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -30,7 +30,7 @@
         <button class="button is-light is-compact"
           type="button"
           {{on "click" @fns.onToggleWrap}}
-          {{keyboard-shortcut action=(action @fns.onToggleWrap) pattern=(array "w" "w") }}
+          {{keyboard-shortcut label="Toggle word wrap" action=(action @fns.onToggleWrap) pattern=(array "w" "w") }}
         >
           {{#if @data.shouldWrap}}
             Unwrap

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -7,6 +7,16 @@
     <div class="boxed-section-head">
     Job Definition
     <div class="pull-right" style="display: flex">
+        <span class="header-toggle">
+          <Hds::Form::Toggle::Field
+            {{keyboard-shortcut label="Toggle word wrap" action=(action @fns.onToggleWrap) pattern=(array "w" "w") menuLevel=true }}
+            checked={{@data.shouldWrap}}
+            {{on "change" @fns.onToggleWrap}}
+          as |F|>
+            <F.Label>Word Wrap</F.Label>
+          </Hds::Form::Toggle::Field>
+        </span>
+
         <Tooltip @condition={{unless @data.hasSpecification true false}} @isFullText={{true}} @text="A jobspec file was not submitted when this job was run. You can still view and edit the expanded JSON format.">
             <div class="job-definition-select {{unless @data.hasSpecification " disabled"}}" data-test-select={{@data.view}}>
                 <button 
@@ -27,18 +37,6 @@
             </div>        
         </Tooltip>
 
-        <button class="button is-light is-compact"
-          type="button"
-          {{on "click" @fns.onToggleWrap}}
-          {{keyboard-shortcut label="Toggle word wrap" action=(action @fns.onToggleWrap) pattern=(array "w" "w") }}
-        >
-          {{#if @data.shouldWrap}}
-            Unwrap
-          {{else}}
-            Wrap
-          {{/if}}
-        </button>
-
         <button
             class="button is-light is-compact"
             type="button"
@@ -47,6 +45,7 @@
         >
             Edit
         </button>
+
       </div>
     </div>
     <div class="boxed-section-body is-full-bleed">

--- a/ui/app/templates/components/job-editor/read.hbs
+++ b/ui/app/templates/components/job-editor/read.hbs
@@ -26,6 +26,19 @@
                 </button>
             </div>        
         </Tooltip>
+
+        <button class="button is-light is-compact"
+          type="button"
+          {{on "click" @fns.onToggleWrap}}
+          {{keyboard-shortcut action=(action @fns.onToggleWrap) pattern=(array "w" "w") }}
+        >
+          {{#if @data.shouldWrap}}
+            Unwrap
+          {{else}}
+            Wrap
+          {{/if}}
+        </button>
+
         <button
             class="button is-light is-compact"
             type="button"
@@ -34,7 +47,7 @@
         >
             Edit
         </button>
-        </div>
+      </div>
     </div>
     <div class="boxed-section-body is-full-bleed">
     {{#if (eq @data.view "job-spec")}}
@@ -46,6 +59,7 @@
             readOnly=true
             screenReaderLabel="Job specification"          
             theme="hashi-read-only"
+            lineWrapping=@data.shouldWrap
             }} 
         />
     {{else}}
@@ -56,6 +70,7 @@
             theme="hashi-read-only"
             readOnly=true
             screenReaderLabel="JSON Viewer"
+            lineWrapping=@data.shouldWrap
             }}
         />
     {{/if}}
@@ -75,6 +90,7 @@
                     mode="ruby"
                     theme="hashi-read-only"
                     readOnly=true
+                    lineWrapping=@data.shouldWrap
                 }}
             />
         </div>

--- a/ui/app/templates/components/streaming-file.hbs
+++ b/ui/app/templates/components/streaming-file.hbs
@@ -3,4 +3,4 @@
   SPDX-License-Identifier: MPL-2.0
 ~}}
 
-<code data-test-output>{{this.logger.output}}</code>
+<code data-test-output class={{if @wrapped "wrapped"}}>{{this.logger.output}} </code>

--- a/ui/app/templates/components/streaming-file.hbs
+++ b/ui/app/templates/components/streaming-file.hbs
@@ -3,4 +3,4 @@
   SPDX-License-Identifier: MPL-2.0
 ~}}
 
-<code data-test-output class={{if @wrapped "wrapped"}}>{{this.logger.output}} </code>
+<code data-test-output class={{if @wrapped "wrapped"}}>{{this.logger.output}}</code>

--- a/ui/app/templates/components/task-log.hbs
+++ b/ui/app/templates/components/task-log.hbs
@@ -27,6 +27,7 @@
         {{keyboard-shortcut label="Toggle word wrap" action=(action "toggleWrap") pattern=(array "w" "w") menuLevel=true }}
         checked={{this.wrapped}}
         {{on "change" this.toggleWrap}}
+        data-test-word-wrap-toggle
       as |F|>
         <F.Label>Word Wrap</F.Label>
       </Hds::Form::Toggle::Field>

--- a/ui/app/templates/components/task-log.hbs
+++ b/ui/app/templates/components/task-log.hbs
@@ -27,14 +27,15 @@
     <button data-test-log-action="toggle-stream" class="button is-white" onclick={{action "toggleStream"}} type="button" title="{{if this.logger.isStreaming "Stop" "Start"}} log streaming">
       {{x-icon (if this.logger.isStreaming "media-pause" "media-play") class="is-text"}}
     </button>
-    <button
-      {{keyboard-shortcut label="Toggle word wrap" action=(action "toggleWrap") pattern=(array "w" "w") menuLevel=true }}
-      class="button is-white"
-      onclick={{action "toggleWrap"}}
-      type="button"
-    >
-      {{#if this.wrapped}}Unwrap text{{else}}Wrap text{{/if}}
-    </button>
+    <span class="header-toggle">
+      <Hds::Form::Toggle::Field
+        {{keyboard-shortcut label="Toggle word wrap" action=(action "toggleWrap") pattern=(array "w" "w") menuLevel=true }}
+        checked={{this.wrapped}}
+        {{on "change" this.toggleWrap}}
+      as |F|>
+        <F.Label>Word Wrap</F.Label>
+      </Hds::Form::Toggle::Field>
+    </span>
   </span>
 </div>
 <div data-test-log-box class="boxed-section-body is-dark is-full-bleed">

--- a/ui/app/templates/components/task-log.hbs
+++ b/ui/app/templates/components/task-log.hbs
@@ -16,17 +16,12 @@
     </div>
   </div>
 {{/if}}
-<div class="boxed-section-head">
+<div class="boxed-section-head task-log-head">
   <span>
     <button data-test-log-action="stdout" class="button {{if (eq this.mode "stdout") "is-info"}}" {{action "setMode" "stdout"}} type="button">stdout</button>
     <button data-test-log-action="stderr" class="button {{if (eq this.mode "stderr") "is-danger"}}" {{action "setMode" "stderr"}} type="button">stderr</button>
   </span>
   <span class="pull-right">
-    <button data-test-log-action="head" class="button is-white" onclick={{action "gotoHead"}} type="button">Head</button>
-    <button data-test-log-action="tail" class="button is-white" onclick={{action "gotoTail"}} type="button">Tail</button>
-    <button data-test-log-action="toggle-stream" class="button is-white" onclick={{action "toggleStream"}} type="button" title="{{if this.logger.isStreaming "Stop" "Start"}} log streaming">
-      {{x-icon (if this.logger.isStreaming "media-pause" "media-play") class="is-text"}}
-    </button>
     <span class="header-toggle">
       <Hds::Form::Toggle::Field
         {{keyboard-shortcut label="Toggle word wrap" action=(action "toggleWrap") pattern=(array "w" "w") menuLevel=true }}
@@ -36,6 +31,11 @@
         <F.Label>Word Wrap</F.Label>
       </Hds::Form::Toggle::Field>
     </span>
+    <button data-test-log-action="head" class="button is-white" onclick={{action "gotoHead"}} type="button">Head</button>
+    <button data-test-log-action="tail" class="button is-white" onclick={{action "gotoTail"}} type="button">Tail</button>
+    <button data-test-log-action="toggle-stream" class="button is-white" onclick={{action "toggleStream"}} type="button" title="{{if this.logger.isStreaming "Stop" "Start"}} log streaming">
+      {{x-icon (if this.logger.isStreaming "media-pause" "media-play") class="is-text"}}
+    </button>
   </span>
 </div>
 <div data-test-log-box class="boxed-section-body is-dark is-full-bleed">

--- a/ui/app/templates/components/task-log.hbs
+++ b/ui/app/templates/components/task-log.hbs
@@ -27,7 +27,14 @@
     <button data-test-log-action="toggle-stream" class="button is-white" onclick={{action "toggleStream"}} type="button" title="{{if this.logger.isStreaming "Stop" "Start"}} log streaming">
       {{x-icon (if this.logger.isStreaming "media-pause" "media-play") class="is-text"}}
     </button>
-    <button class="button is-white" onclick={{action "toggleWrap"}} type="button">{{#if this.wrapped}}Unwrap text{{else}}Wrap text{{/if}}</button>
+    <button
+      {{keyboard-shortcut action=(action "toggleWrap") pattern=(array "w" "w") menuLevel=true }}
+      class="button is-white"
+      onclick={{action "toggleWrap"}}
+      type="button"
+    >
+      {{#if this.wrapped}}Unwrap text{{else}}Wrap text{{/if}}
+    </button>
   </span>
 </div>
 <div data-test-log-box class="boxed-section-body is-dark is-full-bleed">

--- a/ui/app/templates/components/task-log.hbs
+++ b/ui/app/templates/components/task-log.hbs
@@ -27,8 +27,9 @@
     <button data-test-log-action="toggle-stream" class="button is-white" onclick={{action "toggleStream"}} type="button" title="{{if this.logger.isStreaming "Stop" "Start"}} log streaming">
       {{x-icon (if this.logger.isStreaming "media-pause" "media-play") class="is-text"}}
     </button>
+    <button class="button is-white" onclick={{action "toggleWrap"}} type="button">{{#if this.wrapped}}Unwrap text{{else}}Wrap text{{/if}}</button>
   </span>
 </div>
 <div data-test-log-box class="boxed-section-body is-dark is-full-bleed">
-  <StreamingFile @logger={{this.logger}} @mode={{this.streamMode}} @isStreaming={{this.isStreaming}} @shouldFillHeight={{this.shouldFillHeight}} />
+  <StreamingFile @logger={{this.logger}} @mode={{this.streamMode}} @isStreaming={{this.isStreaming}} @shouldFillHeight={{this.shouldFillHeight}} @wrapped={{this.wrapped}} />
 </div>

--- a/ui/app/templates/components/task-log.hbs
+++ b/ui/app/templates/components/task-log.hbs
@@ -28,7 +28,7 @@
       {{x-icon (if this.logger.isStreaming "media-pause" "media-play") class="is-text"}}
     </button>
     <button
-      {{keyboard-shortcut action=(action "toggleWrap") pattern=(array "w" "w") menuLevel=true }}
+      {{keyboard-shortcut label="Toggle word wrap" action=(action "toggleWrap") pattern=(array "w" "w") menuLevel=true }}
       class="button is-white"
       onclick={{action "toggleWrap"}}
       type="button"


### PR DESCRIPTION
Lets a user wrap text in their logs and job definitions.

- Adds a "Wrap" button to job definitions and logs in the UI
- Preference saved to localStorage, so persists across refresh
- Adds a keyboard shortcut (`ww`) to toggle

![image](https://github.com/hashicorp/nomad/assets/713991/80f59f57-1d73-4714-85cd-e38070211119)
![image](https://github.com/hashicorp/nomad/assets/713991/30f61044-2b53-4f37-860a-2fef3238ae13)



TODO: tests

Resolves #17749 