### PR TITLE
Update the revision used by the docker build action.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,7 +300,7 @@ jobs:
         run: |
           echo "revision=${{ github.event.inputs.build-ref }}" >> "$GITHUB_ENV"
       - name: Docker Build (Action)
-        uses: hashicorp/actions-docker-build@add-revision-input
+        uses: hashicorp/actions-docker-build@v1
         with:
           smoke_test: |
             TEST_VERSION="$(docker run "${IMAGE_NAME}" version | awk '/Nomad v/{print $2}')"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,10 +292,15 @@ jobs:
         arch: ["arm64", "amd64"]
     env:
       version: ${{needs.get-product-version.outputs.product-version}}
+      revision: ${{github.sha}}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Set revision
+        if: "${{ github.event.inputs.build-ref != '' }}"
+        run: |
+          echo "revision=${{ github.event.inputs.build-ref }}" >> "$GITHUB_ENV"
       - name: Docker Build (Action)
-        uses: hashicorp/actions-docker-build@v1
+        uses: hashicorp/actions-docker-build@add-revision-input
         with:
           smoke_test: |
             TEST_VERSION="$(docker run "${IMAGE_NAME}" version | awk '/Nomad v/{print $2}')"
@@ -305,13 +310,14 @@ jobs:
             fi
             echo "Test PASSED"
           version: ${{env.version}}
+          revision: ${{env.revision}}
           target: release
           arch: ${{matrix.arch}}
           tags: |
             docker.io/hashicorp/${{env.PKG_NAME}}:${{env.version}}
           dev_tags: |
             docker.io/hashicorppreview/${{ env.PKG_NAME }}:${{ env.version }}-dev
-            docker.io/hashicorppreview/${{ env.PKG_NAME }}:${{ env.version }}-${{ github.sha }}
+            docker.io/hashicorppreview/${{ env.PKG_NAME }}:${{ env.version }}-${{env.revision}}
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
         run: |
-          gh workflow run build.yml --field build-ref=${{ steps.commit-change-push.outputs.build-ref }} --field make-prerelease=false
+          gh workflow run build.yml --ref ${{ github.ref_name }} --field build-ref=${{ steps.commit-change-push.outputs.build-ref }} --field make-prerelease=false
 
       - name: Revert notification channel
         if: ${{ github.event.inputs.notification-channel != '' }}


### PR DESCRIPTION
This should always reflect the commit that's being built, as this may differ from the default `github.sha `that the workflow was invoked at.

Goes with https://github.com/hashicorp/actions-docker-build/pull/59 - and should not be merged until the PR is merged and a new version of the action is cut.