### PR TITLE
e2e: use DNS instead of HTTP to get my_public_ipv4

### DIFF
--- a/e2e/terraform/network.tf
+++ b/e2e/terraform/network.tf
@@ -20,12 +20,18 @@ data "aws_subnet" "secondary" {
   }
 }
 
-data "http" "my_public_ipv4" {
-  url = "https://api.ipify.org"
+# using a dns lookup instead of http, because it's faster
+# and should be more reliable.
+data "external" "my_public_ipv4" {
+  program = ["/bin/sh", "-c", <<-EOT
+    ip="$(dig @resolver4.opendns.com myip.opendns.com +short -4)"
+    echo '{"ip": "'$ip'"}'
+    EOT
+  ]
 }
 
 locals {
-  ingress_cidr = var.restrict_ingress_cidrblock ? "${chomp(data.http.my_public_ipv4.body)}/32" : "0.0.0.0/0"
+  ingress_cidr = var.restrict_ingress_cidrblock ? "${chomp(data.external.my_public_ipv4.result["ip"])}/32" : "0.0.0.0/0"
 }
 
 resource "aws_security_group" "servers" {


### PR DESCRIPTION
`ipify.org` is frequently flakey, causing Terraform apply/destroy to errors in E2E tests, e.g.

```
│ Error: HTTP request error. Response code: 502
│ 
Terraform planned the following actions, but then encountered a problem:
│   with data.http.my_public_ipv4,
│   on network.tf line 23, in data "http" "my_public_ipv4":
│   23: data "http" "my_public_ipv4" {
```

This replaces the HTTP lookup with DNS, which is faster (not that speed matters a whole lot here), but more importantly, OpenDNS should (hopefully) be more reliable.