### PR TITLE
leadership: add lock timer leadership transition functionality.

### DIFF
--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-version"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -440,6 +441,76 @@ func TestLeader_PeriodicDispatcher_Restore_NoEvals(t *testing.T) {
 	if last.Launch.Before(now) {
 		t.Fatalf("restorePeriodicDispatcher did not force launch: last %v; want after %v", last.Launch, now)
 	}
+}
+
+func TestServer_restoreLockTTLTimers(t *testing.T) {
+	ci.Parallel(t)
+
+	testServer, testServerCleanup := TestServer(t, nil)
+	defer testServerCleanup()
+	testutil.WaitForLeader(t, testServer.RPC)
+
+	// Generate two variables, one with and one without a lock and upsert these
+	// into state.
+	mockVar1 := mock.VariableEncrypted()
+
+	mockVar2 := mock.VariableEncrypted()
+	mockVar2.Lock = &structs.VariableLock{
+		ID:        uuid.Generate(),
+		TTL:       15 * time.Second,
+		LockDelay: 15 * time.Second,
+	}
+
+	upsertResp1 := testServer.fsm.State().VarSet(10, &structs.VarApplyStateRequest{Var: mockVar1, Op: structs.VarOpSet})
+	must.NoError(t, upsertResp1.Error)
+
+	upsertResp2 := testServer.fsm.State().VarSet(20, &structs.VarApplyStateRequest{Var: mockVar2, Op: structs.VarOpLockAcquire})
+	must.NoError(t, upsertResp2.Error)
+
+	// Call the server function that restores the lock TTL timers. This would
+	// usually happen on leadership transition.
+	must.NoError(t, testServer.restoreLockTTLTimers())
+
+	// Ensure the TTL timer tracking has the expected entries.
+	must.Nil(t, testServer.lockTTLTimer.Get(mockVar1.LockID()))
+	must.NotNil(t, testServer.lockTTLTimer.Get(mockVar2.LockID()))
+}
+
+func TestServer_invalidateVariableLock(t *testing.T) {
+	ci.Parallel(t)
+
+	testServer, testServerCleanup := TestServer(t, nil)
+	defer testServerCleanup()
+	testutil.WaitForLeader(t, testServer.RPC)
+
+	// Generate a variable that includes a lock entry and upsert this into our
+	// state.
+	mockVar1 := mock.VariableEncrypted()
+	mockVar1.Lock = &structs.VariableLock{
+		ID:        uuid.Generate(),
+		TTL:       15 * time.Second,
+		LockDelay: 15 * time.Second,
+	}
+
+	upsertResp1 := testServer.fsm.State().VarSet(10, &structs.VarApplyStateRequest{Var: mockVar1, Op: structs.VarOpLockAcquire})
+	must.NoError(t, upsertResp1.Error)
+
+	// Create the timer manually, so we can control the invalidation for
+	// testing.
+	testServer.lockTTLTimer.Create(mockVar1.LockID(), mockVar1.Lock.TTL, func() {})
+
+	// Perform the invalidation call.
+	testServer.invalidateVariableLock(mockVar1.LockID(), mockVar1)
+
+	// Ensure the TTL timer has been removed.
+	must.Nil(t, testServer.lockTTLTimer.Get(mockVar1.LockID()))
+
+	// Pull the variable out of state and check that the lock ID has been
+	// removed.
+	_, varGetResp, err := testServer.fsm.State().VarGet(nil, mockVar1.Namespace, mockVar1.Path)
+	must.NoError(t, err)
+	must.NotNil(t, varGetResp.Lock)
+	must.Eq(t, "", varGetResp.LockID())
 }
 
 type mockJobEvalDispatcher struct {

--- a/nomad/lock/delay.go
+++ b/nomad/lock/delay.go
@@ -58,6 +58,13 @@ func (d *DelayTimer) Set(id string, now time.Time, delay time.Duration) {
 	})
 }
 
+// RemoveAll removes all registered timers.
+func (d *DelayTimer) RemoveAll() {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.delayTimers = make(map[string]time.Time)
+}
+
 // EmitMetrics is a long-running routine used to emit periodic metrics about
 // the Delay.
 func (d *DelayTimer) EmitMetrics(period time.Duration, shutdownCh chan struct{}) {
@@ -75,7 +82,7 @@ func (d *DelayTimer) EmitMetrics(period time.Duration, shutdownCh chan struct{})
 	}
 }
 
-// len returns the number of registered delay timers.
+// timerNum returns the number of registered delay timers.
 func (d *DelayTimer) timerNum() int {
 	d.lock.RLock()
 	defer d.lock.RUnlock()

--- a/nomad/lock/delay_test.go
+++ b/nomad/lock/delay_test.go
@@ -30,4 +30,14 @@ func TestDelay(t *testing.T) {
 	time.Sleep(120 * time.Millisecond)
 	must.True(t, delay.Get("test-delay-1").Before(timeNow))
 	must.Eq(t, 0, delay.timerNum())
+
+	// Add a key and set a long expiration.
+	timeNow = time.Now()
+	delay.Set("test-delay-2", timeNow, 1000*time.Millisecond)
+	must.False(t, delay.Get("test-delay-2").Before(time.Now()))
+	must.Eq(t, 1, delay.timerNum())
+
+	// Perform the stop call which the leader will do when stepping down.
+	delay.RemoveAll()
+	must.Eq(t, 0, delay.timerNum())
 }

--- a/nomad/lock/ttl.go
+++ b/nomad/lock/ttl.go
@@ -98,7 +98,7 @@ func (t *TTLTimer) EmitMetrics(period time.Duration, shutdownCh chan struct{}) {
 	}
 }
 
-// len returns the number of registered timers.
+// timerNum returns the number of registered timers.
 func (t *TTLTimer) timerNum() int {
 	t.lock.RLock()
 	defer t.lock.RUnlock()

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/hashicorp/nomad/lib/auth/oidc"
 	"github.com/hashicorp/nomad/nomad/deploymentwatcher"
 	"github.com/hashicorp/nomad/nomad/drainer"
+	"github.com/hashicorp/nomad/nomad/lock"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
@@ -263,6 +264,12 @@ type Server struct {
 	// shutting down, the oidcProviderCache.Shutdown() function must be called.
 	oidcProviderCache *oidc.ProviderCache
 
+	// lockTTLTimer and lockDelayTimer are used to track variable lock timers.
+	// These are held in memory on the leader rather than in state to avoid
+	// large amount of Raft writes.
+	lockTTLTimer   *lock.TTLTimer
+	lockDelayTimer *lock.DelayTimer
+
 	// leaderAcl is the management ACL token that is valid when resolved by the
 	// current leader.
 	leaderAcl     string
@@ -376,6 +383,8 @@ func NewServer(config *Config, consulCatalog consul.CatalogAPI, consulConfigEntr
 		rpcTLS:                  incomingTLS,
 		aclCache:                aclCache,
 		workersEventCh:          make(chan interface{}, 1),
+		lockTTLTimer:            lock.NewTTLTimer(),
+		lockDelayTimer:          lock.NewDelayTimer(),
 	}
 
 	s.shutdownCtx, s.shutdownCancel = context.WithCancel(context.Background())

--- a/nomad/structs/variables.go
+++ b/nomad/structs/variables.go
@@ -324,6 +324,19 @@ func (sv VariableMetadata) GetCreateIndex() uint64 {
 	return sv.CreateIndex
 }
 
+// LockID returns the ID of the lock. In the event this is not held, or the
+// variable is not a lock, this string will be empty.
+func (sv *VariableMetadata) LockID() string {
+	if sv.Lock == nil {
+		return ""
+	}
+	return sv.Lock.ID
+}
+
+// IsLock is a helper to indicate whether the variable is being used for
+// locking.
+func (sv *VariableMetadata) IsLock() bool { return sv.Lock != nil }
+
 // VariablesQuota is used to track the total size of variables entries per
 // namespace. The total length of Variable.EncryptedData in bytes will be added
 // to the VariablesQuota table in the same transaction as a write, update, or

--- a/nomad/structs/variables_test.go
+++ b/nomad/structs/variables_test.go
@@ -189,6 +189,75 @@ func TestVariableMetadata_Copy(t *testing.T) {
 	}
 }
 
+func TestVariableMetadata_LockID(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name                  string
+		inputVariableMetadata *VariableMetadata
+		expectedOutput        string
+	}{
+		{
+			name: "nil lock",
+			inputVariableMetadata: &VariableMetadata{
+				Lock: nil,
+			},
+			expectedOutput: "",
+		},
+		{
+			name: "empty ID",
+			inputVariableMetadata: &VariableMetadata{
+				Lock: &VariableLock{ID: ""},
+			},
+			expectedOutput: "",
+		},
+		{
+			name: "populated ID",
+			inputVariableMetadata: &VariableMetadata{
+				Lock: &VariableLock{ID: "mylovelylovelyid"},
+			},
+			expectedOutput: "mylovelylovelyid",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			must.Eq(t, tc.expectedOutput, tc.inputVariableMetadata.LockID())
+		})
+	}
+}
+
+func TestVariableMetadata_IsLock(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name                  string
+		inputVariableMetadata *VariableMetadata
+		expectedOutput        bool
+	}{
+		{
+			name: "nil",
+			inputVariableMetadata: &VariableMetadata{
+				Lock: nil,
+			},
+			expectedOutput: false,
+		},
+		{
+			name: "not nil",
+			inputVariableMetadata: &VariableMetadata{
+				Lock: &VariableLock{},
+			},
+			expectedOutput: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			must.Eq(t, tc.expectedOutput, tc.inputVariableMetadata.IsLock())
+		})
+	}
+}
+
 func TestStructs_VariableDecrypted_Copy(t *testing.T) {
 	ci.Parallel(t)
 	n := time.Now()


### PR DESCRIPTION
Lock timers are tracked within memory, the TTLs are monitored from the leader only. This means leadership transition must start/stop certain background processes to track TTL timers, and emit metrics about the background processes.

Related: #17449 
Targets: feature branch