### PR TITLE
Deprecated, pending deletion: Roles' policies observered

### DIFF
--- a/ui/app/abilities/variable.js
+++ b/ui/app/abilities/variable.js
@@ -54,6 +54,7 @@ export default class Variable extends AbstractAbility {
 
   @computed('token.selfTokenPolicies')
   get policiesSupportVariableList() {
+    console.log('uhhhhhhhh', this.token.selfTokenPolicies);
     return this.policyNamespacesIncludeVariablesCapabilities(
       this.token.selfTokenPolicies,
       ['list', 'read', 'write', 'destroy']
@@ -85,6 +86,11 @@ export default class Variable extends AbstractAbility {
     capabilities = [],
     path
   ) {
+    console.log(
+      'checking on policyNamespacesIncludeVaraiblesCapabilities',
+      policies,
+      capabilities
+    );
     const namespacesWithVariableCapabilities = policies
       .toArray()
       .filter((policy) => get(policy, 'rulesJSON.Namespaces'))
@@ -107,6 +113,8 @@ export default class Variable extends AbstractAbility {
       })
       .flat()
       .compact();
+
+    console.log('flattified', namespacesWithVariableCapabilities, capabilities);
 
     // Check for requested permissions
     return namespacesWithVariableCapabilities.some((abilityList) => {

--- a/ui/app/adapters/role.js
+++ b/ui/app/adapters/role.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// @ts-check
+import { default as ApplicationAdapter, namespace } from './application';
+
+export default class RoleAdapter extends ApplicationAdapter {
+  namespace = namespace + '/acl';
+}

--- a/ui/app/adapters/role.js
+++ b/ui/app/adapters/role.js
@@ -5,7 +5,9 @@
 
 // @ts-check
 import { default as ApplicationAdapter, namespace } from './application';
+import classic from 'ember-classic-decorator';
 
+@classic
 export default class RoleAdapter extends ApplicationAdapter {
   namespace = namespace + '/acl';
 }

--- a/ui/app/controllers/policies/policy.js
+++ b/ui/app/controllers/policies/policy.js
@@ -61,18 +61,16 @@ export default class PoliciesPolicyController extends Controller {
   deletePolicy;
 
   async refreshTokens() {
-    this.tokens = this.store
-      .peekAll('token')
-      .filter((token) =>
-        token.policyNames?.includes(decodeURIComponent(this.policy.name))
-      );
+    this.tokens = this.store.peekAll('token').filter((token) => {
+      return token.policyNames?.includes(decodeURIComponent(this.policy.name));
+    });
   }
 
   @task(function* () {
     try {
       const newToken = this.store.createRecord('token', {
         name: `Example Token for ${this.policy.name}`,
-        policies: [this.policy],
+        tokenPolicies: [this.policy],
         // New date 10 minutes into the future
         expirationTime: new Date(Date.now() + 10 * 60 * 1000),
         type: 'client',

--- a/ui/app/models/role.js
+++ b/ui/app/models/role.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// @ts-check
+import Model from '@ember-data/model';
+import { attr, hasMany } from '@ember-data/model';
+
+export default class Role extends Model {
+  @attr('string') name;
+  @attr('string') description;
+  @hasMany('policy', { defaultValue: () => [] }) policies;
+}

--- a/ui/app/models/token.js
+++ b/ui/app/models/token.js
@@ -15,6 +15,7 @@ export default class Token extends Model {
   @attr('date') createTime;
   @attr('string') type;
   @hasMany('policy') policies;
+  @hasMany('role') roles;
   @attr() policyNames;
   @attr('date') expirationTime;
 

--- a/ui/app/models/token.js
+++ b/ui/app/models/token.js
@@ -26,6 +26,7 @@ export default class Token extends Model {
   }
 
   get policies() {
+    console.log('am i even getting hit');
     return [
       ...this.tokenPolicies.toArray(),
       ...this.roles.map((role) => role.policies.toArray()).flat(),

--- a/ui/app/models/token.js
+++ b/ui/app/models/token.js
@@ -14,7 +14,7 @@ export default class Token extends Model {
   @attr('boolean') global;
   @attr('date') createTime;
   @attr('string') type;
-  @hasMany('policy') policies;
+  @hasMany('policy') tokenPolicies;
   @hasMany('role') roles;
   @attr() policyNames;
   @attr('date') expirationTime;
@@ -23,5 +23,12 @@ export default class Token extends Model {
 
   get isExpired() {
     return this.expirationTime && this.expirationTime < new Date();
+  }
+
+  get policies() {
+    return [
+      ...this.tokenPolicies.toArray(),
+      ...this.roles.map((role) => role.policies.toArray()).flat(),
+    ].uniq();
   }
 }

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -56,7 +56,7 @@ export default class ApplicationRoute extends Route {
         this.controllerFor('application').set('error', e);
       }
 
-      const fetchSelfTokenAndPolicies = this.get(
+      const fetchSelfTokenAndPolicies = await this.get(
         'token.fetchSelfTokenAndPolicies'
       )
         .perform()

--- a/ui/app/serializers/role.js
+++ b/ui/app/serializers/role.js
@@ -7,12 +7,8 @@
 import ApplicationSerializer from './application';
 
 export default class RoleSerializer extends ApplicationSerializer {
-  // attrs = {
-  //   policies: { key: 'PolicyNames', serialize: false },
-  // };
-
   normalize(typeHash, hash) {
-    hash.Policies = hash.Policies || [];
+    hash.Policies = hash.Policies || []; // null guard
     hash.PolicyIDs = hash.Policies.map((policy) => policy.Name);
     return super.normalize(typeHash, hash);
   }

--- a/ui/app/serializers/role.js
+++ b/ui/app/serializers/role.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// @ts-check
+import ApplicationSerializer from './application';
+
+export default class RoleSerializer extends ApplicationSerializer {
+  // attrs = {
+  //   policies: { key: 'PolicyNames', serialize: false },
+  // };
+
+  normalize(typeHash, hash) {
+    hash.Policies = hash.Policies || [];
+    hash.PolicyIDs = hash.Policies.map((policy) => policy.Name);
+    return super.normalize(typeHash, hash);
+  }
+}

--- a/ui/app/serializers/token.js
+++ b/ui/app/serializers/token.js
@@ -18,6 +18,8 @@ export default class TokenSerializer extends ApplicationSerializer {
   normalize(typeHash, hash) {
     hash.PolicyIDs = hash.Policies;
     hash.PolicyNames = copy(hash.Policies);
+    hash.Roles = hash.Roles || [];
+    hash.RoleIDs = hash.Roles.map((role) => role.ID);
     return super.normalize(typeHash, hash);
   }
 }

--- a/ui/app/serializers/token.js
+++ b/ui/app/serializers/token.js
@@ -16,7 +16,7 @@ export default class TokenSerializer extends ApplicationSerializer {
   };
 
   normalize(typeHash, hash) {
-    hash.PolicyIDs = hash.Policies;
+    hash.TokenPolicyIDs = hash.Policies;
     hash.PolicyNames = copy(hash.Policies);
     hash.Roles = hash.Roles || [];
     hash.RoleIDs = hash.Roles.map((role) => role.ID);

--- a/ui/app/serializers/token.js
+++ b/ui/app/serializers/token.js
@@ -22,4 +22,11 @@ export default class TokenSerializer extends ApplicationSerializer {
     hash.RoleIDs = hash.Roles.map((role) => role.ID);
     return super.normalize(typeHash, hash);
   }
+
+  serialize(snapshot, options) {
+    const hash = super.serialize(snapshot, options);
+    hash.PolicyIDs = hash.TokenPolicyIDs;
+    delete hash.TokenPolicyIDs;
+    return hash;
+  }
 }

--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -144,7 +144,7 @@
               @activeClass="is-active"
               data-test-gutter-link="policies"
             >
-              Policies
+              Policies and Roles
             </LinkTo>
           </li>
         {{/if}}

--- a/ui/app/templates/policies.hbs
+++ b/ui/app/templates/policies.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 ~}}
 
-<Breadcrumb @crumb={{hash label="Policies" args=(array "policies.index")}} />
+<Breadcrumb @crumb={{hash label="Policies and Roles" args=(array "policies.index")}} />
 <PageLayout>
   {{outlet}}
 </PageLayout>

--- a/ui/app/templates/policies/index.hbs
+++ b/ui/app/templates/policies/index.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 ~}}
 
-{{page-title "Policies"}}
+{{page-title "Policies and Roles"}}
 <section class="section">
   <div class="toolbar">
     <div class="toolbar-item is-right-aligned is-mobile-full-width">

--- a/ui/app/templates/settings/tokens.hbs
+++ b/ui/app/templates/settings/tokens.hbs
@@ -159,6 +159,44 @@
                 <button data-test-token-clear class="button is-primary" {{action "clearTokenProperties"}} type="button">Sign Out</button>
               </div>
             </div>
+
+            {{#if this.tokenRecord.roles.length}}
+              <h3 class="title is-4">Roles</h3>
+                {{#each this.tokenRecord.roles as |role|}}
+                <div data-test-token-role class="boxed-section">
+                  <div data-test-role-name class="boxed-section-head">
+                    {{role.name}}
+                  </div>
+                  <div class="boxed-section-body">
+                      {{#if role.description}}
+                        <p class="content">
+                          {{role.description}}
+                        </p>
+                      {{/if}}
+                    <div data-test-role-policies>
+                      <h4 class="title is-5">Policies</h4>
+                      {{#each role.policies as |policy|}}
+                      <li><a href="#{{policy.name}}">{{policy.name}}</a></li>
+                        {{!-- <div data-test-role-policy class="boxed-section">
+                          <div data-test-policy-name class="boxed-section-head">
+                            {{policy.name}}
+                          </div>
+                          <div class="boxed-section-body">
+                            <p data-test-policy-description class="content">
+                              {{#if policy.description}}
+                                {{policy.description}}
+                              {{else}}
+                                <em>No description</em>
+                              {{/if}}
+                            </p>
+                          </div>
+                        </div> --}}
+                      {{/each}}
+                    </div>
+                  </div>
+                </div>
+                {{/each}}
+            {{/if}}
             <h3 class="title is-4">Policies</h3>
             {{#if (eq this.tokenRecord.type "management")}}
               <div data-test-token-management-message class="boxed-section">
@@ -168,7 +206,7 @@
               </div>
             {{else}}
               {{#each this.tokenRecord.policies as |policy|}}
-                <div data-test-token-policy class="boxed-section">
+                <div id="{{policy.name}}" data-test-token-policy class="boxed-section">
                   <div data-test-policy-name class="boxed-section-head">
                     {{policy.name}}
                   </div>

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -299,7 +299,8 @@ export default function () {
     });
 
     if (token) {
-      const { policyIds } = token;
+      const policyIds = token.tokenPolicyIds;
+
       const policies = server.db.policies.find(policyIds);
       const hasReadPolicy = policies.find(
         (p) =>
@@ -571,7 +572,7 @@ export default function () {
     // is of type management
     if (
       tokenForSecret &&
-      (tokenForSecret.policies.includes(policy) ||
+      (tokenForSecret.tokenPolicies.includes(policy) ||
         tokenForSecret.type === 'management')
     ) {
       return this.serialize(policy);
@@ -589,10 +590,10 @@ export default function () {
     const { id } = request.params;
     schema.tokens
       .all()
-      .models.filter((token) => token.policyIds.includes(id))
+      .models.filter((token) => token.tokenPolicyIds.includes(id))
       .forEach((token) => {
         token.update({
-          policyIds: token.policyIds.filter((pid) => pid !== id),
+          tokenPolicyIds: token.tokenPolicyIds.filter((pid) => pid !== id),
         });
       });
     server.db.policies.remove(id);

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -467,6 +467,7 @@ export default function () {
   });
 
   this.get('/acl/tokens', function ({ tokens }, req) {
+    console.log('uhhhhhh tokens', tokens);
     return this.serialize(tokens.all());
   });
 
@@ -489,7 +490,10 @@ export default function () {
 
   this.get('/acl/token/self', function ({ tokens }, req) {
     const secret = req.requestHeaders['X-Nomad-Token'];
+    console.log('incoming secret', secret);
+    console.log('and tokens', tokens);
     const tokenForSecret = tokens.findBy({ secretId: secret });
+    console.log('tokenfor', tokenForSecret);
 
     // Return the token if it exists
     if (tokenForSecret) {

--- a/ui/mirage/factories/token.js
+++ b/ui/mirage/factories/token.js
@@ -19,20 +19,20 @@ export default Factory.extend({
   oneTimeSecret: () => faker.random.uuid(),
 
   afterCreate(token, server) {
-    if (token.policyIds && token.policyIds.length) return;
-    const policyIds = Array(faker.random.number({ min: 1, max: 5 }))
+    if (token.tokenPolicyIds && token.tokenPolicyIds.length) return;
+    const tokenPolicyIds = Array(faker.random.number({ min: 1, max: 5 }))
       .fill(0)
       .map(() => faker.hacker.verb())
       .uniq();
 
-    policyIds.forEach((policy) => {
+    tokenPolicyIds.forEach((policy) => {
       const dbPolicy = server.db.policies.find(policy);
       if (!dbPolicy) {
         server.create('policy', { id: policy });
       }
     });
 
-    token.update({ policyIds });
+    token.update({ tokenPolicyIds });
 
     // Create a special policy with variables rules in place
     if (token.id === '53cur3-v4r14bl35') {
@@ -74,7 +74,7 @@ node {
         },
       };
       server.create('policy', variableMakerPolicy);
-      token.policyIds.push(variableMakerPolicy.id);
+      token.tokenPolicyIds.push(variableMakerPolicy.id);
     }
     if (token.id === 'f3w3r-53cur3-v4r14bl35') {
       const variableViewerPolicy = {
@@ -168,7 +168,7 @@ node {
         },
       };
       server.create('policy', variableViewerPolicy);
-      token.policyIds.push(variableViewerPolicy.id);
+      token.tokenPolicyIds.push(variableViewerPolicy.id);
     }
     if (token.id === '3XP1R35-1N-3L3V3N-M1NU735') {
       token.update({

--- a/ui/mirage/factories/token.js
+++ b/ui/mirage/factories/token.js
@@ -21,6 +21,11 @@ export default Factory.extend({
 
   afterCreate(token, server) {
     if (token.tokenPolicyIds && token.tokenPolicyIds.length) return;
+    // Manager creating a token applies policyIds directly, not tokenPolicyIds
+    if (token.policyIds && token.policyIds.length) {
+      token.update({ tokenPolicyIds: token.policyIds });
+      return;
+    }
     const tokenPolicyIds = Array(faker.random.number({ min: 1, max: 5 }))
       .fill(0)
       .map(() => faker.hacker.verb())
@@ -178,10 +183,10 @@ node {
     }
 
     // Mimic the ember model's policies getter
-    console.log('tokpolids', token.tokenPolicyIds);
+    console.log('tokpolids', token, token.tokenPolicyIds);
     token.update({
       policies: [
-        ...token.tokenPolicyIds.map((id) => server.db.policies.find(id)),
+        ...token.tokenPolicyIds.map((id) => server.schema.policies.find(id)),
         // ...token.policyIds.map((id) => server.db.policies.find(id)),
       ],
     });

--- a/ui/mirage/factories/token.js
+++ b/ui/mirage/factories/token.js
@@ -15,6 +15,7 @@ export default Factory.extend({
   name: (i) => `${i === 0 ? 'Manager ' : ''}${faker.name.findName()}`,
   global: () => faker.random.boolean(),
   type: (i) => (i === 0 ? 'management' : 'client'),
+  roles: () => [],
 
   oneTimeSecret: () => faker.random.uuid(),
 
@@ -175,5 +176,14 @@ node {
         expirationTime: new Date(new Date().getTime() + 11 * 60 * 1000),
       });
     }
+
+    // Mimic the ember model's policies getter
+    console.log('tokpolids', token.tokenPolicyIds);
+    token.update({
+      policies: [
+        ...token.tokenPolicyIds.map((id) => server.db.policies.find(id)),
+        // ...token.policyIds.map((id) => server.db.policies.find(id)),
+      ],
+    });
   },
 });

--- a/ui/mirage/models/token.js
+++ b/ui/mirage/models/token.js
@@ -7,4 +7,12 @@ import { Model, hasMany, belongsTo } from 'ember-cli-mirage';
 
 export default Model.extend({
   tokenPolicies: hasMany('policy'),
+  // policies: hasMany('policy'),
+  get policies() {
+    console.log('lol, lmao', this.tokenPolicies);
+    return this.tokenPolicies;
+    // return this.tokenPolicies;
+
+    // return this.tokenPolicies.models;
+  },
 });

--- a/ui/mirage/models/token.js
+++ b/ui/mirage/models/token.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { Model, hasMany, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  tokenPolicies: hasMany('policy'),
+});

--- a/ui/mirage/serializers/token.js
+++ b/ui/mirage/serializers/token.js
@@ -9,9 +9,12 @@ export default ApplicationSerializer.extend({
   serializeIds: 'always',
 
   keyForRelationshipIds(relationship) {
-    if (relationship === 'policies') {
+    if (relationship === 'tokenPolicies') {
       return 'Policies';
     }
-    return ApplicationSerializer.prototype.keyForRelationshipIds.apply(this, arguments);
+    return ApplicationSerializer.prototype.keyForRelationshipIds.apply(
+      this,
+      arguments
+    );
   },
 });

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -385,7 +385,7 @@ module('Acceptance | job detail (with namespaces)', function (hooks) {
       },
     });
 
-    clientToken.policyIds = [policy.id];
+    clientToken.tokenPolicyIds = [policy.id];
     clientToken.save();
 
     await JobDetail.visit({ id: job1.id });
@@ -605,7 +605,7 @@ module('Acceptance | job detail (with namespaces)', function (hooks) {
     });
     job.update({ taskGroupIds: [scalingGroup.id] });
 
-    clientToken.policyIds = [policy.id];
+    clientToken.tokenPolicyIds = [policy.id];
     clientToken.save();
     window.localStorage.nomadTokenSecret = clientToken.secretId;
 

--- a/ui/tests/acceptance/job-dispatch-test.js
+++ b/ui/tests/acceptance/job-dispatch-test.js
@@ -85,14 +85,14 @@ function moduleForJobDispatch(title, jobFactory) {
         },
       });
 
-      clientToken.policyIds = [policy.id];
+      clientToken.tokenPolicyIds = [policy.id];
       clientToken.save();
 
       await JobDetail.visit({ id: `${job.id}@${namespace.name}` });
       assert.notOk(JobDetail.dispatchButton.isDisabled);
 
       // Reset clientToken policies.
-      clientToken.policyIds = [];
+      clientToken.tokenPolicyIds = [];
       clientToken.save();
     });
 

--- a/ui/tests/acceptance/job-run-test.js
+++ b/ui/tests/acceptance/job-run-test.js
@@ -155,7 +155,7 @@ module('Acceptance | job run', function (hooks) {
       },
     });
 
-    clientTokenWithPolicy.policyIds = [policy.id];
+    clientTokenWithPolicy.tokenPolicyIds = [policy.id];
     clientTokenWithPolicy.save();
     window.localStorage.nomadTokenSecret = clientTokenWithPolicy.secretId;
 

--- a/ui/tests/acceptance/job-versions-test.js
+++ b/ui/tests/acceptance/job-versions-test.js
@@ -230,7 +230,7 @@ module('Acceptance | job versions (with client token)', function (hooks) {
       },
     });
 
-    clientToken.policyIds = [policy.id];
+    clientToken.tokenPolicyIds = [policy.id];
     clientToken.save();
 
     window.localStorage.nomadTokenSecret = clientToken.secretId;

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -457,7 +457,7 @@ module('Acceptance | jobs list', function (hooks) {
       },
     });
 
-    clientToken.policyIds = [policy.id];
+    clientToken.tokenPolicyIds = [policy.id];
     clientToken.save();
 
     window.localStorage.nomadTokenSecret = clientToken.secretId;
@@ -488,7 +488,7 @@ module('Acceptance | jobs list', function (hooks) {
       },
     });
 
-    clientToken.policyIds = [policy.id];
+    clientToken.tokenPolicyIds = [policy.id];
     clientToken.save();
 
     window.localStorage.nomadTokenSecret = clientToken.secretId;

--- a/ui/tests/acceptance/task-group-detail-test.js
+++ b/ui/tests/acceptance/task-group-detail-test.js
@@ -231,7 +231,7 @@ module('Acceptance | task group detail', function (hooks) {
       },
     });
 
-    clientToken.policyIds = [policy.id];
+    clientToken.tokenPolicyIds = [policy.id];
     clientToken.save();
 
     window.localStorage.nomadTokenSecret = clientToken.secretId;

--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -151,13 +151,14 @@ module('Acceptance | tokens', function (hooks) {
 
     await Tokens.visit();
     await Tokens.secret(secretId).submit();
-
     assert.ok(Tokens.successMessage, 'Token success message is shown');
     assert.notOk(Tokens.errorMessage, 'Token error message is not shown');
     assert.notOk(
       Tokens.managementMessage,
       'Token management message is not shown'
     );
+    // TODO: Pick up from here; missing a policy.
+
     assert.equal(
       Tokens.policies.length,
       clientToken.policies.length,

--- a/ui/tests/acceptance/variables-test.js
+++ b/ui/tests/acceptance/variables-test.js
@@ -57,6 +57,7 @@ module('Acceptance | variables', function (hooks) {
     assert.expect(2);
     allScenarios.variableTestCluster(server);
     const variablesToken = server.db.tokens.find(VARIABLE_TOKEN_ID);
+    console.log('VARIABLESTOKEN', variablesToken);
     window.localStorage.nomadTokenSecret = variablesToken.secretId;
 
     await Variables.visit();

--- a/ui/tests/utils/set-policy.js
+++ b/ui/tests/utils/set-policy.js
@@ -6,7 +6,7 @@
 export default function setPolicy(policy) {
   const { id: policyId } = server.create('policy', policy);
   const clientToken = server.create('token', { type: 'client' });
-  clientToken.policyIds = [policyId];
+  clientToken.tokenPolicyIds = [policyId];
   clientToken.save();
 
   window.localStorage.clear();


### PR DESCRIPTION
DEPRECATED in favour of https://github.com/hashicorp/nomad/pull/18346

When your token has a role, it finds out the associated policies, fetches them, and for purposes of what you're allowed to see in the UI, treats them just like any policy that your token has applied to it directly.

This also updates the Authentication ("sign in" / "profile") page with info about your role and its policies:

![image](https://github.com/hashicorp/nomad/assets/713991/f17c6664-25d6-4f67-8a28-3b44fd1b0523)
