### PR TITLE
CI: Dynamic runs-on values for oss/ent

### DIFF
--- a/.github/actions/setup-js/action.yml
+++ b/.github/actions/setup-js/action.yml
@@ -1,0 +1,34 @@
+name: setup-js
+description: install node and yarn, and run yarn install
+inputs:
+  node-version:
+    description: 'node version'
+    # https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md
+    # package.json has ember-cli at version ~3.28.5 currently
+    default: '16'
+runs:
+  using: composite
+  steps:
+    - name: Install yarn
+      run: |-
+        # install yarn if not present
+        yarn --version && exit
+        # note: can't `npm install -g` on self-hosted runners
+        npm install yarn --no-package-lock --no-save
+        cd node_modules/.bin
+          ./yarn --version
+          echo "$PWD" >> "$GITHUB_PATH"
+      working-directory: /tmp
+      shell: bash
+    # enforce node version (self-hosted default is not necessarily what we want)
+    # after yarn, so we can use yarn for cache.
+    - name: Setup node
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: yarn
+        cache-dependency-path: ui/yarn.lock
+    - name: Yarn install
+      run: yarn install --frozen-lockfile
+      working-directory: ui
+      shell: bash

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -31,11 +31,12 @@ jobs:
           # Enabling this option increased the number of backport failures.
           BACKPORT_MERGE_COMMIT: false
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+
   handle-failure:
     needs:
       - backport
     if: always() && needs.backport.result == 'failure'
-    runs-on: ubuntu-latest
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-latest' }}
     steps:
       - name: Send slack notification on failure
         uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,7 +231,7 @@ jobs:
 
   build-darwin:
     needs: [get-go-version, get-product-version]
-    runs-on: macos-latest
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "macos"]') || 'macos-latest' }}
     strategy:
       matrix:
         goos: [darwin]

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   checks:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-22.04' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   prepare-release:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-20.04' }}
     outputs:
       build-ref: ${{ steps.commit-change-push.outputs.build-ref }}
     steps:

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -45,9 +45,11 @@ env:
   VAULT_VERSION: 1.12.2
   NOMAD_SLOW_TEST: 0
   NOMAD_TEST_LOG_LEVEL: OFF
+
 jobs:
+  # this caches dependencies for subsequent jobs, including private deps in enterprise
   mods:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-22.04' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -36,11 +36,10 @@ on:
 
 jobs:
   test-e2e:
-    runs-on: ubuntu-latest
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - name: Setup go
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+      - uses: hashicorp/setup-golang@v1
       - run: make deps
       - run: make integration-test
       - run: make e2e-test

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -46,8 +46,7 @@ jobs:
       nonce: ${{ steps.nonce.outputs.nonce }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - name: yarn install
-        run: yarn install --frozen-lockfile
+      - uses: ./.github/actions/setup-js
       - name: lint:js
         run: yarn run lint:js
       - name: lint:hbs
@@ -59,7 +58,7 @@ jobs:
   tests:
     needs:
       - pre-test
-    runs-on: ubuntu-latest
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-latest' }}
     timeout-minutes: 30
     continue-on-error: true
     defaults:
@@ -71,26 +70,26 @@ jobs:
         split: [4]
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - name: yarn install
-        run: yarn install --frozen-lockfile
+      - uses: ./.github/actions/setup-js
+      - uses: browser-actions/setup-chrome@c485fa3bab6be59dce18dbc18ef6ab7cbc8ff5f1 # v1.2.0
       - name: ember exam
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
         run: yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }}
+
   finalize:
-    runs-on: ubuntu-latest
+    needs:
+      - pre-test
+      - tests
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-latest' }}
     timeout-minutes: 30
     defaults:
       run:
         working-directory: ui
-    needs:
-      - pre-test
-      - tests
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - name: yarn install
-        run: yarn install --frozen-lockfile
+      - uses: ./.github/actions/setup-js
       - name: finalize
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -43,7 +43,7 @@ env:
   VAULT_VERSION: 1.4.1
 jobs:
   test-windows:
-    runs-on: "windows-2019-16core"
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "windows", "type=c5.2xlarge"]') || 'windows-2019-16core' }}
     env:
       GOTESTSUM_PATH: c:\tmp\test-reports
     steps:


### PR DESCRIPTION
In order to fetch secrets from Vault in our Enterprise repo, we need to use self-hosted runners, but here in this public repo, we may only use public runners.

To reduce merge conflicts between OSS and ENT (and backports..), this PR adds conditions that will result in public runners here in OSS, but self-hosted runners in ENT.  I have done a lot of trial-and-error to end up with what I hope is a nice middle-ground between complexity, explicitness, and non-mergeflictery.

A subsequent PR will add the steps to (again, conditionally) fetch secrets from Vault.