### PR TITLE
backport docker build to 1.3.x

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -1,13 +1,19 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 schema = "1"
 
 project "nomad" {
   team = "nomad"
+
   slack {
     notification_channel = "C03B5EWFW01"
   }
+
   github {
     organization = "hashicorp"
     repository   = "nomad"
+
     release_branches = [
       "main",
       "release/**",
@@ -42,12 +48,12 @@ event "prepare" {
 ## they should be added to the end of the file after the prepare event stanza.
 
 event "trigger-staging" {
-  // This event is dispatched by the bob trigger-promotion command
-  // and is required - do not delete.
+  // This event is dispatched by the bob trigger-promotion command  // and is required - do not delete.
 }
 
 event "promote-staging" {
   depends = ["trigger-staging"]
+
   action "promote-staging" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
@@ -60,13 +66,27 @@ event "promote-staging" {
   }
 }
 
+event "promote-staging-docker" {
+  depends = ["promote-staging"]
+
+  action "promote-staging-docker" {
+    organization = "hashicorp"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-staging-docker"
+  }
+
+  notification {
+    on = "always"
+  }
+}
+
 event "trigger-production" {
-  // This event is dispatched by the bob trigger-promotion command
-  // and is required - do not delete.
+  // This event is dispatched by the bob trigger-promotion command  // and is required - do not delete.
 }
 
 event "promote-production" {
   depends = ["trigger-production"]
+
   action "promote-production" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
@@ -78,8 +98,23 @@ event "promote-production" {
   }
 }
 
-event "promote-production-packaging" {
+event "promote-production-docker" {
   depends = ["promote-production"]
+
+  action "promote-production-docker" {
+    organization = "hashicorp"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-production-docker"
+  }
+
+  notification {
+    on = "always"
+  }
+}
+
+event "promote-production-packaging" {
+  depends = ["promote-production-docker"]
+
   action "promote-production-packaging" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# docker.io/library/busybox:1.36.0
+# When pinning use the multi-arch manifest list, `docker buildx imagetools inspect ...`
+FROM docker.io/library/busybox@sha256:9e2bbca079387d7965c3a9cee6d0c53f4f4e63ff7637877a83c4c05f2a666112 as release
+
+ARG PRODUCT_NAME=nomad
+ARG PRODUCT_VERSION
+ARG PRODUCT_REVISION
+# TARGETARCH and TARGETOS are set automatically when --platform is provided.
+ARG TARGETOS TARGETARCH
+
+LABEL maintainer="Nomad Team <nomad@hashicorp.com>"
+LABEL version=${PRODUCT_VERSION}
+LABEL revision=${PRODUCT_REVISION}
+
+COPY dist/$TARGETOS/$TARGETARCH/nomad /bin/
+COPY ./scripts/docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["help"]

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env ash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+
+case "$1" in
+  "agent" )
+    if [[ -z "${NOMAD_SKIP_DOCKER_IMAGE_WARN}" ]]
+    then
+      echo "====================================================================================="
+      echo "!! Running Nomad clients inside Docker containers is not supported.                !!"
+      echo "!! Refer to https://www.nomadproject.io/s/nomad-in-docker for more information.    !!"
+      echo "!! Set the NOMAD_SKIP_DOCKER_IMAGE_WARN environment variable to skip this warning. !!"
+      echo "====================================================================================="
+      echo ""
+      sleep 2
+    fi
+esac
+
+exec nomad "$@"

--- a/website/content/docs/install/production/requirements.mdx
+++ b/website/content/docs/install/production/requirements.mdx
@@ -189,9 +189,30 @@ This is not a supported or well-tested configuration. See [GH-13669][] for a
 further discussion and to provide feedback on your experiences trying to run
 rootless Nomad clients.
 
+## Running Nomad in Docker
+
+Running systems as Docker containers has become a common practice. While it's
+possible to run Nomad servers inside containers, Nomad clients require
+extensive access to the underlying host machine, as described in
+[Rootless Nomad Clients][]. Docker containers introduce a non-trivial
+abstraction layer that makes it hard to properly configure clients and task
+drivers therefore **running Nomad clients in Docker containers is not
+officially supported**.
+
+The [`hashicorp/nomad`][nomad_docker_hub] Docker image is intended to be used
+in automated pipelines for [CLI operations][docs_cli], such as
+[`nomad job plan`][], [`nomad fmt`][], and others.
+
+~> **Note:** The Nomad Docker image is not tested when running as an agent.
+
 [Security Model]: /nomad/docs/concepts/security
 [production deployment guide]: /nomad/tutorials/enterprise/production-deployment-guide-vm-with-consul#configure-systemd
 [linux capabilities]: #linux-capabilities
 [`capabilities(7)`]: https://man7.org/linux/man-pages/man7/capabilities.7.html
 [overlay filesystem]: https://www.kernel.org/doc/html/latest/filesystems/overlayfs.html
 [GH-13669]: https://github.com/hashicorp/nomad/issues/13669
+[Rootless Nomad Clients]: #rootless-nomad-clients
+[nomad_docker_hub]: https://hub.docker.com/r/hashicorp/nomad
+[docs_cli]: /nomad/docs/commands
+[`nomad job plan`]: /nomad/docs/commands/job/plan
+[`nomad fmt`]: /nomad/docs/commands/fmt


### PR DESCRIPTION
In https://github.com/hashicorp/nomad/pull/17767 we backported the build pipeline to be current with `main` but missed the Dockerfile, related scripts, and docs. (Note this is unlikely to ever be released unless we ship a patch for 1.3.x before 1.6.0 GA, but better to have it and not need it.)