### PR TITLE
[ui] Affix the page header to the top of the page

### DIFF
--- a/.changelog/17783.txt
+++ b/.changelog/17783.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: affix page header to the top of the browser window to handle browser extension push-down gracefully
+```

--- a/ui/app/styles/components/page-layout.scss
+++ b/ui/app/styles/components/page-layout.scss
@@ -12,6 +12,7 @@
     position: fixed;
     width: 100%;
     z-index: $z-header;
+    top: 0;
 
     // Defensive styles in case header height goes over 100px, causing
     // the left gutter menu to be on top of the header.


### PR DESCRIPTION
A report shows a 3rd party browser extension puts a banner at the top of page and awkwardly shifts nav; this fixes that

<img width="1261" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/6ae6c252-2d30-4af8-9097-026a7a5ecb89">
