### PR TITLE
Add acquire and release lock functions on the state store

### DIFF
--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -2249,7 +2249,8 @@ func (f *FSMFilter) Include(item interface{}) bool {
 	return true
 }
 
-func (n *nomadFSM) applyVariableOperation(msgType structs.MessageType, buf []byte, index uint64) interface{} {
+func (n *nomadFSM) applyVariableOperation(msgType structs.MessageType, buf []byte,
+	index uint64) interface{} {
 	var req structs.VarApplyStateRequest
 	if err := structs.Decode(buf, &req); err != nil {
 		panic(fmt.Errorf("failed to decode request: %v", err))
@@ -2265,6 +2266,10 @@ func (n *nomadFSM) applyVariableOperation(msgType structs.MessageType, buf []byt
 		return n.state.VarDeleteCAS(index, &req)
 	case structs.VarOpCAS:
 		return n.state.VarSetCAS(index, &req)
+	case structs.VarOpLockAcquire:
+		return n.state.VarLockAcquire(index, &req)
+	case structs.VarOpLockRelease:
+		return n.state.VarLockRelease(index, &req)
 	default:
 		err := fmt.Errorf("Invalid variable operation '%s'", req.Op)
 		n.logger.Warn("Invalid variable operation", "operation", req.Op)

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -2250,7 +2250,7 @@ func (f *FSMFilter) Include(item interface{}) bool {
 }
 
 func (n *nomadFSM) applyVariableOperation(msgType structs.MessageType, buf []byte,
-	index uint64) interface{} {
+	index uint64) any {
 	var req structs.VarApplyStateRequest
 	if err := structs.Decode(buf, &req); err != nil {
 		panic(fmt.Errorf("failed to decode request: %v", err))

--- a/nomad/state/state_store_variables.go
+++ b/nomad/state/state_store_variables.go
@@ -185,20 +185,6 @@ func (s *StateStore) varSetCASTxn(tx WriteTxn, idx uint64, req *structs.VarApply
 	}
 
 	if ok {
-		// If the variable exists and is locked, it can only be updated by providing the correct
-		// lock ID.
-		// If the variable is locked, it can only be updated by providing the correct
-		// lock ID.
-		if isLocked(svEx.Lock, req) {
-			zeroVal := &structs.VariableEncrypted{
-				VariableMetadata: structs.VariableMetadata{
-					Namespace: svEx.Namespace,
-					Path:      svEx.Path,
-				},
-			}
-			return req.ConflictResponse(idx, zeroVal)
-		}
-
 		// If the existing index does not match the provided CAS index arg, then we
 		// shouldn't update anything and can safely return early here.
 		if sv.ModifyIndex != svEx.ModifyIndex {

--- a/nomad/state/state_store_variables.go
+++ b/nomad/state/state_store_variables.go
@@ -580,9 +580,9 @@ func (s *StateStore) VarLockAcquire(idx uint64,
 		return req.ErrorResponse(idx, fmt.Errorf("variable lookup failed: %v", err))
 	}
 
+	sv, ok := raw.(*structs.VariableEncrypted)
 	// If the variable exist, we must make sure it doesn't hold a lock already
-	if raw != nil {
-		sv := raw.(*structs.VariableEncrypted)
+	if ok {
 		if sv.VariableMetadata.Lock != nil {
 			return req.ErrorResponse(idx, errVarAlreadyLocked)
 		}

--- a/nomad/state/state_store_variables.go
+++ b/nomad/state/state_store_variables.go
@@ -609,7 +609,7 @@ func (s *StateStore) VarLockRelease(idx uint64,
 		return req.ErrorResponse(idx, errLockNotFound)
 	}
 
-	if sv.Lock.ID != req.Var.Lock.ID {
+	if req.Var.Lock != nil && sv.Lock.ID != req.Var.Lock.ID {
 		// Avoid showing the variable data on a failed lock release
 		zeroVal := &structs.VariableEncrypted{
 			VariableMetadata: structs.VariableMetadata{

--- a/nomad/state/state_store_variables.go
+++ b/nomad/state/state_store_variables.go
@@ -567,20 +567,20 @@ func (s *StateStore) VarLockRelease(idx uint64,
 	}
 
 	if raw == nil {
-		// Should this be a conflict?
 		return req.ErrorResponse(idx, errVarNotFound)
 	}
 
 	sv, _ := raw.(*structs.VariableEncrypted)
 
 	if sv.Lock == nil || sv.Lock.ID == "" {
-		// Should this be a conflict?
 		return req.ErrorResponse(idx, errLockNotFound)
 	}
 
 	if sv.Lock.ID != req.Var.Lock.ID {
-		// Should this be a conflict?
-		return req.ErrorResponse(idx, errLockNotFound)
+		// Avoid showing the variable data while doing a lock release
+		svCopy := sv.Copy()
+		svCopy.VariableData = structs.VariableData{}
+		return req.ConflictResponse(idx, &svCopy)
 	}
 
 	updated := sv.Copy()

--- a/nomad/state/state_store_variables.go
+++ b/nomad/state/state_store_variables.go
@@ -406,17 +406,6 @@ func (s *StateStore) svDeleteCASTxn(tx WriteTxn, idx uint64, req *structs.VarApp
 		return req.ConflictResponse(idx, svEx)
 	}
 
-	// If the variable is locked, it can only be deleted providing the correct lock ID
-	if ok && isLocked(sv.Lock, req) {
-		zeroVal := &structs.VariableEncrypted{
-			VariableMetadata: structs.VariableMetadata{
-				Namespace: sv.Namespace,
-				Path:      sv.Path,
-			},
-		}
-		return req.ConflictResponse(idx, zeroVal)
-	}
-
 	// If the existing index does not match the provided CAS index arg, then we
 	// shouldn't update anything and can safely return early here.
 	if !ok || sv.ModifyIndex != svEx.ModifyIndex {
@@ -441,6 +430,7 @@ func (s *StateStore) svDeleteTxn(tx WriteTxn, idx uint64, req *structs.VarApplyS
 	}
 
 	sv := existingRaw.(*structs.VariableEncrypted)
+
 	if isLocked(sv.Lock, req) {
 		zeroVal := &structs.VariableEncrypted{
 			VariableMetadata: structs.VariableMetadata{

--- a/nomad/state/state_store_variables.go
+++ b/nomad/state/state_store_variables.go
@@ -567,7 +567,7 @@ func (s *StateStore) VarLockRelease(idx uint64,
 
 	sv, _ := raw.(*structs.VariableEncrypted)
 
-	if sv.Lock.ID == "" || sv.Lock.ID != req.Var.Lock.ID {
+	if sv.Lock == nil || sv.Lock.ID == "" || sv.Lock.ID != req.Var.Lock.ID {
 		zeroVal := &structs.VariableEncrypted{
 			VariableMetadata: structs.VariableMetadata{
 				Namespace: sv.Namespace,

--- a/nomad/state/state_store_variables_test.go
+++ b/nomad/state/state_store_variables_test.go
@@ -766,7 +766,7 @@ func TestStateStore_AcquireAndReleaseLock(t *testing.T) {
 		})
 
 	must.ErrorIs(t, resp.Error, errVarAlreadyLocked)
-	// Ensure the create and modify where NOT modified
+	// Ensure the create and modify were NOT modified
 	must.Eq(t, 20, got[0].CreateIndex, must.Sprintf("%s: incorrect create index", got[0].Path))
 	must.Eq(t, 20, got[0].ModifyIndex, must.Sprintf("%s: incorrect modify index", got[0].Path))
 

--- a/nomad/state/state_store_variables_test.go
+++ b/nomad/state/state_store_variables_test.go
@@ -932,7 +932,8 @@ func TestStateStore_AcquireAndReleaseLock(t *testing.T) {
 				Var: allVars[0],
 			})
 
-		must.ErrorIs(t, resp.Error, errVarAlreadyLocked)
+		must.NoError(t, resp.Error)
+		must.Eq(t, structs.VarOpResultConflict, resp.Result)
 		// Ensure the create and modify were NOT modified
 		must.Eq(t, 20, allVars[0].CreateIndex, must.Sprintf("%s: incorrect create index", allVars[0].Path))
 		must.Eq(t, 20, allVars[0].ModifyIndex, must.Sprintf("%s: incorrect modify index", allVars[0].Path))

--- a/nomad/state/state_store_variables_test.go
+++ b/nomad/state/state_store_variables_test.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"encoding/json"
+	"errors"
 	"sort"
 	"strings"
 	"testing"
@@ -825,6 +826,103 @@ func TestStateStore_AcquireAndReleaseLock(t *testing.T) {
 
 	// Ensure the variable data didn't change
 	must.Eq(t, mv.Data, sve.Data)
+}
+
+func TestStateStore_Release(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	insertIndex := uint64(20)
+	resp := testState.VarSet(insertIndex, &structs.VarApplyStateRequest{
+		Op: structs.VarOpSet,
+		Var: &structs.VariableEncrypted{
+			VariableMetadata: structs.VariableMetadata{
+				Path:      "/non/lock/variable/path",
+				Namespace: "default",
+			},
+			VariableData: mock.VariableEncrypted().VariableData,
+		},
+	})
+	insertIndex++
+	must.NoError(t, resp.Error)
+
+	resp = testState.VarSet(insertIndex, &structs.VarApplyStateRequest{
+		Op: structs.VarOpSet,
+		Var: &structs.VariableEncrypted{
+			VariableMetadata: structs.VariableMetadata{
+				Path:      "lock/variable/path",
+				Namespace: "default",
+				Lock: &structs.VariableLock{
+					ID: "theLockID",
+				},
+			},
+			VariableData: mock.VariableEncrypted().VariableData,
+		},
+	})
+	must.NoError(t, resp.Error)
+
+	testCases := []struct {
+		name       string
+		lookUpPath string
+		lockID     string
+		expErr     error
+		expResult  structs.VarOpResult
+	}{
+		{
+			name:       "variable_not_found",
+			lookUpPath: "fake/path/",
+			expErr:     errVarNotFound,
+			expResult:  structs.VarOpResultError,
+		},
+		{
+			name:       "variable_has_no_lock",
+			lookUpPath: "/non/lock/variable/path",
+			expErr:     errLockNotFound,
+			expResult:  structs.VarOpResultError,
+		},
+		{
+			name:       "lock_id_doesn't_match",
+			lookUpPath: "lock/variable/path",
+			lockID:     "wrongLockID",
+			expErr:     errLockNotFound,
+			expResult:  structs.VarOpResultError,
+		},
+		{
+			name:       "lock_released",
+			lookUpPath: "lock/variable/path",
+			lockID:     "theLockID",
+			expErr:     nil,
+			expResult:  structs.VarOpResultOk,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			req := &structs.VarApplyStateRequest{
+				Op: structs.VarOpLockRelease,
+				Var: &structs.VariableEncrypted{
+					VariableMetadata: structs.VariableMetadata{
+						Path:      tc.lookUpPath,
+						Namespace: "default",
+					},
+				},
+			}
+
+			if tc.lockID != "" {
+				req.Var.VariableMetadata.Lock = &structs.VariableLock{
+					ID: tc.lockID,
+				}
+			}
+
+			resp = testState.VarLockRelease(insertIndex, req)
+
+			if !errors.Is(tc.expErr, resp.Error) {
+				t.Fatalf("expected error, got %s", resp.Error)
+			}
+
+			must.Eq(t, tc.expResult, resp.Result)
+		})
+	}
 }
 
 func getAllVariables(ss *StateStore, ws memdb.WatchSet) ([]*structs.VariableEncrypted, error) {

--- a/nomad/state/state_store_variables_test.go
+++ b/nomad/state/state_store_variables_test.go
@@ -884,8 +884,8 @@ func TestStateStore_Release(t *testing.T) {
 			name:       "lock_id_doesn't_match",
 			lookUpPath: "lock/variable/path",
 			lockID:     "wrongLockID",
-			expErr:     errLockNotFound,
-			expResult:  structs.VarOpResultError,
+			expErr:     nil,
+			expResult:  structs.VarOpResultConflict,
 		},
 		{
 			name:       "lock_released",

--- a/nomad/state/state_store_variables_test.go
+++ b/nomad/state/state_store_variables_test.go
@@ -847,6 +847,7 @@ func TestStateStore_Variables_DeleteCAS(t *testing.T) {
 			Op:  structs.VarOpDelete,
 			Var: sv,
 		}
+
 		resp = ts.VarDeleteCAS(15, req)
 		must.True(t, resp.IsConflict())
 
@@ -856,15 +857,6 @@ func TestStateStore_Variables_DeleteCAS(t *testing.T) {
 				Var: &svCopy,
 			})
 
-		must.True(t, resp.IsOk())
-
-		// A CAS delete with a correct index should succeed.
-		req = &structs.VarApplyStateRequest{
-			Op:  structs.VarOpDelete,
-			Var: sv,
-		}
-
-		resp = ts.VarDeleteCAS(20, req)
 		must.True(t, resp.IsOk())
 	})
 

--- a/nomad/state/state_store_variables_test.go
+++ b/nomad/state/state_store_variables_test.go
@@ -1009,7 +1009,7 @@ func TestStateStore_AcquireAndReleaseLock(t *testing.T) {
 	})
 }
 
-func TestStateStore_Release(t *testing.T) {
+func TestStateStore_ReleaseLock(t *testing.T) {
 	ci.Parallel(t)
 	testState := testStateStore(t)
 

--- a/nomad/state/state_store_variables_test.go
+++ b/nomad/state/state_store_variables_test.go
@@ -819,10 +819,10 @@ func TestStateStore_Variables_DeleteCAS(t *testing.T) {
 		must.Eq(t, sv.VariableMetadata, resp.Conflict.VariableMetadata)
 	})
 
-	t.Run("locked_var-cas_ok", func(t *testing.T) {
+	t.Run("real_locked_var-cas_0", func(t *testing.T) {
 		ci.Parallel(t)
 		sv := mock.VariableEncrypted()
-		sv.Path = "real_var/cas_ok"
+		sv.Path = "real_var/cas_0"
 		resp := ts.VarSet(10, &structs.VarApplyStateRequest{
 			Op:  structs.VarOpSet,
 			Var: sv,
@@ -847,7 +847,7 @@ func TestStateStore_Variables_DeleteCAS(t *testing.T) {
 			Op:  structs.VarOpDelete,
 			Var: sv,
 		}
-		resp = ts.VarDeleteCAS(0, req)
+		resp = ts.VarDeleteCAS(15, req)
 		must.True(t, resp.IsConflict())
 
 		resp = ts.VarLockRelease(20,
@@ -856,8 +856,15 @@ func TestStateStore_Variables_DeleteCAS(t *testing.T) {
 				Var: &svCopy,
 			})
 
-		svCopy.VariableMetadata.Lock = nil
+		must.True(t, resp.IsOk())
 
+		// A CAS delete with a correct index should succeed.
+		req = &structs.VarApplyStateRequest{
+			Op:  structs.VarOpDelete,
+			Var: sv,
+		}
+
+		resp = ts.VarDeleteCAS(20, req)
 		must.True(t, resp.IsOk())
 	})
 

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -627,11 +627,18 @@ func (sv *Variables) groupForAlloc(claims *structs.IdentityClaims) (string, erro
 // RenewLock is used to apply a SV renew lock operation on a variable to maintain the lease.
 func (sv *Variables) RenewLock(args *structs.VariablesRenewLockRequest, reply *structs.VariablesRenewLockResponse) error {
 	authErr := sv.srv.Authenticate(sv.ctx, args)
+<<<<<<< HEAD
+=======
+	sv.srv.MeasureRPCRate("variables", structs.RateMetricWrite, args)
+>>>>>>> 7d33a7c243 (fix: move the rpc metrics up on the renew lock to include auth errors)
 	if done, err := sv.srv.forward(structs.VariablesRenewLockRPCMethod, args, args, reply); done {
 		return err
 	}
 
+<<<<<<< HEAD
 	sv.srv.MeasureRPCRate("variables", structs.RateMetricWrite, args)
+=======
+>>>>>>> 7d33a7c243 (fix: move the rpc metrics up on the renew lock to include auth errors)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -627,18 +627,11 @@ func (sv *Variables) groupForAlloc(claims *structs.IdentityClaims) (string, erro
 // RenewLock is used to apply a SV renew lock operation on a variable to maintain the lease.
 func (sv *Variables) RenewLock(args *structs.VariablesRenewLockRequest, reply *structs.VariablesRenewLockResponse) error {
 	authErr := sv.srv.Authenticate(sv.ctx, args)
-<<<<<<< HEAD
-=======
-	sv.srv.MeasureRPCRate("variables", structs.RateMetricWrite, args)
->>>>>>> 7d33a7c243 (fix: move the rpc metrics up on the renew lock to include auth errors)
 	if done, err := sv.srv.forward(structs.VariablesRenewLockRPCMethod, args, args, reply); done {
 		return err
 	}
 
-<<<<<<< HEAD
 	sv.srv.MeasureRPCRate("variables", structs.RateMetricWrite, args)
-=======
->>>>>>> 7d33a7c243 (fix: move the rpc metrics up on the renew lock to include auth errors)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}


### PR DESCRIPTION
This PR adds the implementation of the acquire and release calls on the state store. If an acquire call is made on a variable that doesn't exist, it will be created. For the release, the lock ID is verified before proceeding with the release.

Related: https://github.com/hashicorp/nomad/issues/17449
Targets: feature branch