### PR TITLE
ci: clean GOCACHE before build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,7 @@ jobs:
           GO_TAGS: ${{ env.GO_TAGS }}
           CGO_ENABLED: 1
         run: |
+          go clean -cache
           make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
           mv pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
@@ -189,6 +190,7 @@ jobs:
           GO_TAGS: ${{ env.GO_TAGS }}
           CGO_ENABLED: 1
         run: |
+          go clean -cache
           make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
           mv pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
@@ -274,6 +276,7 @@ jobs:
           GO_TAGS: "${{ env.GO_TAGS }} netcgo"
           CGO_ENABLED: 1
         run: |
+          go clean -cache
           make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
           mv pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2


### PR DESCRIPTION
This is basically to avoid Fear/Uncertainty/Doubt.

The github action [actions/setup-go](https://github.com/actions/setup-go) (and, with a different chache key, [hashicorp/setup-golang](https://github.com/hashicorp/setup-golang)) caches both GOMODCACHE (go source files), which is good, and GOCACHE (build outputs), which *might* be bad, if the cache was built on an OS with an older glibc than we want to support. from `go help cache`:
> [...] the build cache does not detect changes to C libraries imported with cgo.

I think we've been okay so far, because the cache has always(~?) been built on 20.04 machines, but to be safe, this wipes the build cache (leaving the mod cache alone) before building.

related PR that checks the build after the fact: #17706