### PR TITLE
check in stderrFrame is nil before logging stderrFrame.Data

### DIFF
--- a/.changelog/17815.txt
+++ b/.changelog/17815.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+logs: check if incoming stderr or stdout struct is not null before logging its fields
+```

--- a/.changelog/17815.txt
+++ b/.changelog/17815.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-logs: check if incoming stderr or stdout struct is not null before logging its fields
+cli: Fix panic in `alloc logs` command when receiving empty stdout or stderr log frames
 ```

--- a/command/alloc_logs.go
+++ b/command/alloc_logs.go
@@ -401,7 +401,9 @@ func (l *AllocLogsCommand) tailMultipleFiles(client *api.Client, alloc *api.Allo
 		case stderrErr := <-stderrErrCh:
 			return fmt.Errorf("received an error from stderr log stream: %v", stderrErr)
 		case stderrFrame := <-stderrFrames:
-			logUI.Warn(string(stderrFrame.Data))
+			if stderrFrame != nil {
+				logUI.Warn(string(stderrFrame.Data))
+			}
 		}
 	}
 }

--- a/command/alloc_logs.go
+++ b/command/alloc_logs.go
@@ -397,7 +397,9 @@ func (l *AllocLogsCommand) tailMultipleFiles(client *api.Client, alloc *api.Allo
 		case stdoutErr := <-stdoutErrCh:
 			return fmt.Errorf("received an error from stdout log stream: %v", stdoutErr)
 		case stdoutFrame := <-stdoutFrames:
-			logUI.Output(string(stdoutFrame.Data))
+			if stdoutFrame != nil {
+				logUI.Output(string(stdoutFrame.Data))
+			}
 		case stderrErr := <-stderrErrCh:
 			return fmt.Errorf("received an error from stderr log stream: %v", stderrErr)
 		case stderrFrame := <-stderrFrames:


### PR DESCRIPTION
Prevent panic if stderrFrame is nil


```
debug logging:

logUI: &{reader:0xc000014010 writer:0xc000014018 errorWriter:0xc000014020 underlyingUI:0xc000a26750 isColor:true outputColor:{Code:0 Bold:false} infoColor:{Code:92 Bold:false} errorColor:{Code:91 Bold:false} warnColor:{Code:93 Bold:false}} 
stderrFrame: <nil> 



panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1fbf565]

goroutine 1 [running]:
github.com/hashicorp/nomad/command.(*AllocLogsCommand).tailMultipleFiles(0xc00040d7a0, 0xc000a2ae70, 0x24?)
	/home/kmulvey/src/go/src/github.com/hashicorp/nomad/command/alloc_logs.go:403 +0x645
github.com/hashicorp/nomad/command.(*AllocLogsCommand).Run(0xc00040d7a0, {0xc0000520c0, 0x3, 0x3})
	/home/kmulvey/src/go/src/github.com/hashicorp/nomad/command/alloc_logs.go:233 +0x967
github.com/mitchellh/cli.(*CLI).Run(0xc000a07cc0)
	/home/kmulvey/src/go/pkg/mod/github.com/mitchellh/cli@v1.1.5/cli.go:262 +0x5f8
main.Run({0xc0000520b0, 0x4, 0x4})
	/home/kmulvey/src/go/src/github.com/hashicorp/nomad/main.go:107 +0x28a
main.main()
	/home/kmulvey/src/go/src/github.com/hashicorp/nomad/main.go:77 +0x4e
```