### PR TITLE
ci: keep windows tests on public runners

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -43,7 +43,7 @@ env:
   VAULT_VERSION: 1.4.1
 jobs:
   test-windows:
-    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "windows", "type=c5.2xlarge"]') || 'windows-2019-16core' }}
+    runs-on: 'windows-2019-16core'
     env:
       GOTESTSUM_PATH: c:\tmp\test-reports
     steps:


### PR DESCRIPTION
After merging #17775 I discovered that our self-hosted windows runners lack `docker` currently, so for now just revert to public runners.

Will revisit later.