### PR TITLE
CSI: persist previous mounts on client to restore during restart

### DIFF
--- a/.changelog/17840.txt
+++ b/.changelog/17840.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where CSI volumes would fail to restore during client restarts
+```

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -1460,3 +1460,20 @@ func (ar *allocRunner) GetUpdatePriority(a *structs.Allocation) cstructs.AllocUp
 
 	return cstructs.AllocUpdatePriorityNone
 }
+
+func (ar *allocRunner) SetCSIVolumes(vols map[string]*state.CSIVolumeStub) error {
+	return ar.stateDB.PutAllocVolumes(ar.id, &state.AllocVolumes{
+		CSIVolumes: vols,
+	})
+}
+
+func (ar *allocRunner) GetCSIVolumes() (map[string]*state.CSIVolumeStub, error) {
+	allocVols, err := ar.stateDB.GetAllocVolumes(ar.id)
+	if err != nil {
+		return nil, err
+	}
+	if allocVols == nil {
+		return nil, nil
+	}
+	return allocVols.CSIVolumes, nil
+}

--- a/client/allocrunner/csi_hook_test.go
+++ b/client/allocrunner/csi_hook_test.go
@@ -8,11 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/client/allocrunner/state"
 	"github.com/hashicorp/nomad/client/pluginmanager"
 	"github.com/hashicorp/nomad/client/pluginmanager/csimanager"
 	cstructs "github.com/hashicorp/nomad/client/structs"
@@ -21,7 +23,9 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
 )
 
 var _ interfaces.RunnerPrerunHook = (*csiHook)(nil)
@@ -31,19 +35,21 @@ func TestCSIHook(t *testing.T) {
 	ci.Parallel(t)
 
 	alloc := mock.Alloc()
+	testMountSrc := fmt.Sprintf(
+		"test-alloc-dir/%s/testvolume0/ro-file-system-single-node-reader-only", alloc.ID)
 	logger := testlog.HCLogger(t)
 
 	testcases := []struct {
-		name                   string
-		volumeRequests         map[string]*structs.VolumeRequest
-		startsUnschedulable    bool
-		startsWithClaims       bool
-		expectedClaimErr       error
-		expectedMounts         map[string]*csimanager.MountInfo
-		expectedMountCalls     int
-		expectedUnmountCalls   int
-		expectedClaimCalls     int
-		expectedUnpublishCalls int
+		name                  string
+		volumeRequests        map[string]*structs.VolumeRequest
+		startsUnschedulable   bool
+		startsWithClaims      bool
+		startsWithStubs       map[string]*state.CSIVolumeStub
+		startsWithValidMounts bool
+		failsFirstUnmount     bool
+		expectedClaimErr      error
+		expectedMounts        map[string]*csimanager.MountInfo
+		expectedCalls         map[string]int
 	}{
 
 		{
@@ -61,13 +67,10 @@ func TestCSIHook(t *testing.T) {
 				},
 			},
 			expectedMounts: map[string]*csimanager.MountInfo{
-				"vol0": &csimanager.MountInfo{Source: fmt.Sprintf(
-					"test-alloc-dir/%s/testvolume0/ro-file-system-single-node-reader-only", alloc.ID)},
+				"vol0": &csimanager.MountInfo{Source: testMountSrc},
 			},
-			expectedMountCalls:     1,
-			expectedUnmountCalls:   1,
-			expectedClaimCalls:     1,
-			expectedUnpublishCalls: 1,
+			expectedCalls: map[string]int{
+				"claim": 1, "mount": 1, "unmount": 1, "unpublish": 1},
 		},
 
 		{
@@ -85,13 +88,10 @@ func TestCSIHook(t *testing.T) {
 				},
 			},
 			expectedMounts: map[string]*csimanager.MountInfo{
-				"vol0": &csimanager.MountInfo{Source: fmt.Sprintf(
-					"test-alloc-dir/%s/testvolume0/ro-file-system-single-node-reader-only", alloc.ID)},
+				"vol0": &csimanager.MountInfo{Source: testMountSrc},
 			},
-			expectedMountCalls:     1,
-			expectedUnmountCalls:   1,
-			expectedClaimCalls:     1,
-			expectedUnpublishCalls: 1,
+			expectedCalls: map[string]int{
+				"claim": 1, "mount": 1, "unmount": 1, "unpublish": 1},
 		},
 
 		{
@@ -110,15 +110,11 @@ func TestCSIHook(t *testing.T) {
 			},
 			startsUnschedulable: true,
 			expectedMounts: map[string]*csimanager.MountInfo{
-				"vol0": &csimanager.MountInfo{Source: fmt.Sprintf(
-					"test-alloc-dir/%s/testvolume0/ro-file-system-single-node-reader-only", alloc.ID)},
+				"vol0": &csimanager.MountInfo{Source: testMountSrc},
 			},
-			expectedMountCalls:     0,
-			expectedUnmountCalls:   0,
-			expectedClaimCalls:     1,
-			expectedUnpublishCalls: 0,
+			expectedCalls: map[string]int{"claim": 1},
 			expectedClaimErr: errors.New(
-				"claim volumes: could not claim volume testvolume0: volume is currently unschedulable"),
+				"claiming volumes: could not claim volume testvolume0: volume is currently unschedulable"),
 		},
 
 		{
@@ -137,62 +133,105 @@ func TestCSIHook(t *testing.T) {
 			},
 			startsWithClaims: true,
 			expectedMounts: map[string]*csimanager.MountInfo{
-				"vol0": &csimanager.MountInfo{Source: fmt.Sprintf(
-					"test-alloc-dir/%s/testvolume0/ro-file-system-single-node-reader-only", alloc.ID)},
+				"vol0": &csimanager.MountInfo{Source: testMountSrc},
 			},
-			expectedMountCalls:     1,
-			expectedUnmountCalls:   1,
-			expectedClaimCalls:     2,
-			expectedUnpublishCalls: 1,
+			expectedCalls: map[string]int{
+				"claim": 2, "mount": 1, "unmount": 1, "unpublish": 1},
+		},
+		{
+			name: "already mounted",
+			volumeRequests: map[string]*structs.VolumeRequest{
+				"vol0": {
+					Name:           "vol0",
+					Type:           structs.VolumeTypeCSI,
+					Source:         "testvolume0",
+					ReadOnly:       true,
+					AccessMode:     structs.CSIVolumeAccessModeSingleNodeReader,
+					AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
+					MountOptions:   &structs.CSIMountOptions{},
+					PerAlloc:       false,
+				},
+			},
+			startsWithStubs: map[string]*state.CSIVolumeStub{"vol0": {
+				VolumeID:       "vol0",
+				PluginID:       "vol0-plugin",
+				ExternalNodeID: "i-example",
+				MountInfo:      &csimanager.MountInfo{Source: testMountSrc},
+			}},
+			startsWithValidMounts: true,
+			expectedMounts: map[string]*csimanager.MountInfo{
+				"vol0": &csimanager.MountInfo{Source: testMountSrc},
+			},
+			expectedCalls: map[string]int{"hasMount": 1, "unmount": 1, "unpublish": 1},
+		},
+		{
+			name: "existing but invalid mounts",
+			volumeRequests: map[string]*structs.VolumeRequest{
+				"vol0": {
+					Name:           "vol0",
+					Type:           structs.VolumeTypeCSI,
+					Source:         "testvolume0",
+					ReadOnly:       true,
+					AccessMode:     structs.CSIVolumeAccessModeSingleNodeReader,
+					AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
+					MountOptions:   &structs.CSIMountOptions{},
+					PerAlloc:       false,
+				},
+			},
+			startsWithStubs: map[string]*state.CSIVolumeStub{"vol0": {
+				VolumeID:       "testvolume0",
+				PluginID:       "vol0-plugin",
+				ExternalNodeID: "i-example",
+				MountInfo:      &csimanager.MountInfo{Source: testMountSrc},
+			}},
+			startsWithValidMounts: false,
+			expectedMounts: map[string]*csimanager.MountInfo{
+				"vol0": &csimanager.MountInfo{Source: testMountSrc},
+			},
+			expectedCalls: map[string]int{
+				"hasMount": 1, "claim": 1, "mount": 1, "unmount": 1, "unpublish": 1},
 		},
 
-		// TODO: this won't actually work on the client.
-		// https://github.com/hashicorp/nomad/issues/11798
-		//
-		// {
-		// 	name: "one source volume mounted read-only twice",
-		// 	volumeRequests: map[string]*structs.VolumeRequest{
-		// 		"vol0": {
-		// 			Name:           "vol0",
-		// 			Type:           structs.VolumeTypeCSI,
-		// 			Source:         "testvolume0",
-		// 			ReadOnly:       true,
-		// 			AccessMode:     structs.CSIVolumeAccessModeMultiNodeReader,
-		// 			AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
-		// 			MountOptions:   &structs.CSIMountOptions{},
-		// 			PerAlloc:       false,
-		// 		},
-		// 		"vol1": {
-		// 			Name:           "vol1",
-		// 			Type:           structs.VolumeTypeCSI,
-		// 			Source:         "testvolume0",
-		// 			ReadOnly:       false,
-		// 			AccessMode:     structs.CSIVolumeAccessModeMultiNodeReader,
-		// 			AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
-		// 			MountOptions:   &structs.CSIMountOptions{},
-		// 			PerAlloc:       false,
-		// 		},
-		// 	},
-		// 	expectedMounts: map[string]*csimanager.MountInfo{
-		// 		"vol0": &csimanager.MountInfo{Source: fmt.Sprintf(
-		// 			"test-alloc-dir/%s/testvolume0/ro-file-system-multi-node-reader-only", alloc.ID)},
-		// 		"vol1": &csimanager.MountInfo{Source: fmt.Sprintf(
-		// 			"test-alloc-dir/%s/testvolume0/ro-file-system-multi-node-reader-only", alloc.ID)},
-		// 	},
-		// 	expectedMountCalls:     1,
-		// 	expectedUnmountCalls:   1,
-		// 	expectedClaimCalls:     1,
-		// 	expectedUnpublishCalls: 1,
-		// },
+		{
+			name: "retry on failed unmount",
+			volumeRequests: map[string]*structs.VolumeRequest{
+				"vol0": {
+					Name:           "vol0",
+					Type:           structs.VolumeTypeCSI,
+					Source:         "testvolume0",
+					ReadOnly:       true,
+					AccessMode:     structs.CSIVolumeAccessModeSingleNodeReader,
+					AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
+					MountOptions:   &structs.CSIMountOptions{},
+					PerAlloc:       false,
+				},
+			},
+			failsFirstUnmount: true,
+			expectedMounts: map[string]*csimanager.MountInfo{
+				"vol0": &csimanager.MountInfo{Source: testMountSrc},
+			},
+			expectedCalls: map[string]int{
+				"claim": 1, "mount": 1, "unmount": 2, "unpublish": 2},
+		},
+
+		{
+			name:           "should not run",
+			volumeRequests: map[string]*structs.VolumeRequest{},
+		},
 	}
 
 	for i := range testcases {
 		tc := testcases[i]
 		t.Run(tc.name, func(t *testing.T) {
+
 			alloc.Job.TaskGroups[0].Volumes = tc.volumeRequests
 
-			callCounts := map[string]int{}
-			mgr := mockPluginManager{mounter: mockVolumeMounter{callCounts: callCounts}}
+			callCounts := &callCounter{counts: map[string]int{}}
+			mgr := mockPluginManager{mounter: mockVolumeMounter{
+				hasMounts:         tc.startsWithValidMounts,
+				callCounts:        callCounts,
+				failsFirstUnmount: pointer.Of(tc.failsFirstUnmount),
+			}}
 			rpcer := mockRPCer{
 				alloc:            alloc,
 				callCounts:       callCounts,
@@ -205,39 +244,47 @@ func TestCSIHook(t *testing.T) {
 					FSIsolation:  drivers.FSIsolationChroot,
 					MountConfigs: drivers.MountConfigSupportAll,
 				},
+				stubs: tc.startsWithStubs,
 			}
+
 			hook := newCSIHook(alloc, logger, mgr, rpcer, ar, ar.res, "secret")
 			hook.minBackoffInterval = 1 * time.Millisecond
 			hook.maxBackoffInterval = 10 * time.Millisecond
 			hook.maxBackoffDuration = 500 * time.Millisecond
 
-			require.NotNil(t, hook)
+			must.NotNil(t, hook)
 
 			if tc.expectedClaimErr != nil {
-				require.EqualError(t, hook.Prerun(), tc.expectedClaimErr.Error())
+				must.EqError(t, hook.Prerun(), tc.expectedClaimErr.Error())
 				mounts := ar.res.GetCSIMounts()
-				require.Nil(t, mounts)
+				must.Nil(t, mounts)
 			} else {
-				require.NoError(t, hook.Prerun())
+				must.NoError(t, hook.Prerun())
 				mounts := ar.res.GetCSIMounts()
-				require.NotNil(t, mounts)
-				require.Equal(t, tc.expectedMounts, mounts)
-				require.NoError(t, hook.Postrun())
+				must.MapEq(t, tc.expectedMounts, mounts,
+					must.Sprintf("got mounts: %v", mounts))
+				must.NoError(t, hook.Postrun())
 			}
 
-			require.Equal(t, tc.expectedMountCalls, callCounts["mount"])
-			require.Equal(t, tc.expectedUnmountCalls, callCounts["unmount"])
-			require.Equal(t, tc.expectedClaimCalls, callCounts["claim"])
-			require.Equal(t, tc.expectedUnpublishCalls, callCounts["unpublish"])
+			if tc.failsFirstUnmount {
+				// retrying the unmount doesn't block Postrun, so give it time
+				// to run once more before checking the call counts to ensure
+				// this doesn't flake between 1 and 2 unmount/unpublish calls
+				time.Sleep(100 * time.Millisecond)
+			}
+
+			counts := callCounts.get()
+			must.MapEq(t, tc.expectedCalls, counts,
+				must.Sprintf("got calls: %v", counts))
 
 		})
 	}
 
 }
 
-// TestCSIHook_claimVolumesFromAlloc_Validation tests that the validation of task
-// capabilities in claimVolumesFromAlloc ensures at least one task supports CSI.
-func TestCSIHook_claimVolumesFromAlloc_Validation(t *testing.T) {
+// TestCSIHook_Prerun_Validation tests that the validation of task capabilities
+// in Prerun ensures at least one task supports CSI.
+func TestCSIHook_Prerun_Validation(t *testing.T) {
 	ci.Parallel(t)
 
 	alloc := mock.Alloc()
@@ -256,10 +303,10 @@ func TestCSIHook_claimVolumesFromAlloc_Validation(t *testing.T) {
 	}
 
 	type testCase struct {
-		name             string
-		caps             *drivers.Capabilities
-		capFunc          func() (*drivers.Capabilities, error)
-		expectedClaimErr error
+		name        string
+		caps        *drivers.Capabilities
+		capFunc     func() (*drivers.Capabilities, error)
+		expectedErr string
 	}
 
 	testcases := []testCase{
@@ -268,8 +315,8 @@ func TestCSIHook_claimVolumesFromAlloc_Validation(t *testing.T) {
 			caps: &drivers.Capabilities{
 				MountConfigs: drivers.MountConfigSupportNone,
 			},
-			capFunc:          nil,
-			expectedClaimErr: errors.New("claim volumes: no task supports CSI"),
+			capFunc:     nil,
+			expectedErr: "no task supports CSI",
 		},
 
 		{
@@ -278,7 +325,7 @@ func TestCSIHook_claimVolumesFromAlloc_Validation(t *testing.T) {
 			capFunc: func() (*drivers.Capabilities, error) {
 				return nil, errors.New("error thrown by driver")
 			},
-			expectedClaimErr: errors.New("claim volumes: could not validate task driver capabilities: error thrown by driver"),
+			expectedErr: "could not validate task driver capabilities: error thrown by driver",
 		},
 
 		{
@@ -286,8 +333,7 @@ func TestCSIHook_claimVolumesFromAlloc_Validation(t *testing.T) {
 			caps: &drivers.Capabilities{
 				MountConfigs: drivers.MountConfigSupportAll,
 			},
-			capFunc:          nil,
-			expectedClaimErr: nil,
+			capFunc: nil,
 		},
 	}
 
@@ -295,9 +341,11 @@ func TestCSIHook_claimVolumesFromAlloc_Validation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			alloc.Job.TaskGroups[0].Volumes = volumeRequests
 
-			callCounts := map[string]int{}
-			mgr := mockPluginManager{mounter: mockVolumeMounter{callCounts: callCounts}}
-
+			callCounts := &callCounter{counts: map[string]int{}}
+			mgr := mockPluginManager{mounter: mockVolumeMounter{
+				callCounts:        callCounts,
+				failsFirstUnmount: pointer.Of(false),
+			}}
 			rpcer := mockRPCer{
 				alloc:            alloc,
 				callCounts:       callCounts,
@@ -314,8 +362,8 @@ func TestCSIHook_claimVolumesFromAlloc_Validation(t *testing.T) {
 			hook := newCSIHook(alloc, logger, mgr, rpcer, ar, ar.res, "secret")
 			require.NotNil(t, hook)
 
-			if tc.expectedClaimErr != nil {
-				require.EqualError(t, hook.Prerun(), tc.expectedClaimErr.Error())
+			if tc.expectedErr != "" {
+				require.EqualError(t, hook.Prerun(), tc.expectedErr)
 				mounts := ar.res.GetCSIMounts()
 				require.Nil(t, mounts)
 			} else {
@@ -330,21 +378,44 @@ func TestCSIHook_claimVolumesFromAlloc_Validation(t *testing.T) {
 
 // HELPERS AND MOCKS
 
+type callCounter struct {
+	lock   sync.Mutex
+	counts map[string]int
+}
+
+func (c *callCounter) inc(name string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.counts[name]++
+}
+
+func (c *callCounter) get() map[string]int {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return maps.Clone(c.counts)
+}
+
 type mockRPCer struct {
 	alloc            *structs.Allocation
-	callCounts       map[string]int
+	callCounts       *callCounter
 	hasExistingClaim *bool
 	schedulable      *bool
 }
 
 // RPC mocks the server RPCs, acting as though any request succeeds
-func (r mockRPCer) RPC(method string, args interface{}, reply interface{}) error {
+func (r mockRPCer) RPC(method string, args any, reply any) error {
 	switch method {
 	case "CSIVolume.Claim":
-		r.callCounts["claim"]++
+		r.callCounts.inc("claim")
 		req := args.(*structs.CSIVolumeClaimRequest)
 		vol := r.testVolume(req.VolumeID)
 		err := vol.Claim(req.ToClaim(), r.alloc)
+
+		// after the first claim attempt is made, reset the volume's claims as
+		// though it's been released from another node
+		*r.hasExistingClaim = false
+		*r.schedulable = true
+
 		if err != nil {
 			return err
 		}
@@ -353,22 +424,24 @@ func (r mockRPCer) RPC(method string, args interface{}, reply interface{}) error
 		resp.PublishContext = map[string]string{}
 		resp.Volume = vol
 		resp.QueryMeta = structs.QueryMeta{}
+
 	case "CSIVolume.Unpublish":
-		r.callCounts["unpublish"]++
+		r.callCounts.inc("unpublish")
 		resp := reply.(*structs.CSIVolumeUnpublishResponse)
 		resp.QueryMeta = structs.QueryMeta{}
+
 	default:
 		return fmt.Errorf("unexpected method")
 	}
 	return nil
 }
 
-// testVolume is a helper that optionally starts as unschedulable /
-// claimed until after the first claim RPC is made, so that we can
-// test retryable vs non-retryable failures
+// testVolume is a helper that optionally starts as unschedulable / claimed, so
+// that we can test retryable vs non-retryable failures
 func (r mockRPCer) testVolume(id string) *structs.CSIVolume {
 	vol := structs.NewCSIVolume(id, 0)
 	vol.Schedulable = *r.schedulable
+	vol.PluginID = "plugin-" + id
 	vol.RequestedCapabilities = []*structs.CSIVolumeCapability{
 		{
 			AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
@@ -393,27 +466,40 @@ func (r mockRPCer) testVolume(id string) *structs.CSIVolume {
 		}
 	}
 
-	if r.callCounts["claim"] >= 0 {
-		*r.hasExistingClaim = false
-		*r.schedulable = true
-	}
-
 	return vol
 }
 
 type mockVolumeMounter struct {
-	callCounts map[string]int
+	hasMounts         bool
+	failsFirstUnmount *bool
+	callCounts        *callCounter
 }
 
 func (vm mockVolumeMounter) MountVolume(ctx context.Context, vol *structs.CSIVolume, alloc *structs.Allocation, usageOpts *csimanager.UsageOptions, publishContext map[string]string) (*csimanager.MountInfo, error) {
-	vm.callCounts["mount"]++
+	vm.callCounts.inc("mount")
 	return &csimanager.MountInfo{
 		Source: filepath.Join("test-alloc-dir", alloc.ID, vol.ID, usageOpts.ToFS()),
 	}, nil
 }
+
 func (vm mockVolumeMounter) UnmountVolume(ctx context.Context, volID, remoteID, allocID string, usageOpts *csimanager.UsageOptions) error {
-	vm.callCounts["unmount"]++
+	vm.callCounts.inc("unmount")
+
+	if *vm.failsFirstUnmount {
+		*vm.failsFirstUnmount = false
+		return fmt.Errorf("could not unmount")
+	}
+
 	return nil
+}
+
+func (vm mockVolumeMounter) HasMount(_ context.Context, mountInfo *csimanager.MountInfo) (bool, error) {
+	vm.callCounts.inc("hasMount")
+	return mountInfo != nil && vm.hasMounts, nil
+}
+
+func (vm mockVolumeMounter) ExternalID() string {
+	return "i-example"
 }
 
 type mockPluginManager struct {
@@ -436,6 +522,9 @@ type mockAllocRunner struct {
 	res     *cstructs.AllocHookResources
 	caps    *drivers.Capabilities
 	capFunc func() (*drivers.Capabilities, error)
+
+	stubs    map[string]*state.CSIVolumeStub
+	stubFunc func() (map[string]*state.CSIVolumeStub, error)
 }
 
 func (ar mockAllocRunner) GetTaskDriverCapabilities(taskName string) (*drivers.Capabilities, error) {
@@ -443,4 +532,16 @@ func (ar mockAllocRunner) GetTaskDriverCapabilities(taskName string) (*drivers.C
 		return ar.capFunc()
 	}
 	return ar.caps, nil
+}
+
+func (ar mockAllocRunner) SetCSIVolumes(stubs map[string]*state.CSIVolumeStub) error {
+	ar.stubs = stubs
+	return nil
+}
+
+func (ar mockAllocRunner) GetCSIVolumes() (map[string]*state.CSIVolumeStub, error) {
+	if ar.stubFunc != nil {
+		return ar.stubFunc()
+	}
+	return ar.stubs, nil
 }

--- a/client/allocrunner/state/state.go
+++ b/client/allocrunner/state/state.go
@@ -6,6 +6,7 @@ package state
 import (
 	"time"
 
+	"github.com/hashicorp/nomad/client/pluginmanager/csimanager"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -75,4 +76,18 @@ func (s *State) ClientTerminalStatus() bool {
 	default:
 		return false
 	}
+}
+
+type AllocVolumes struct {
+	CSIVolumes map[string]*CSIVolumeStub // volume request name -> CSIVolumeStub
+}
+
+// CSIVolumeStub is a stripped-down version of the CSIVolume with just the
+// relevant data that we need to persist about the volume.
+type CSIVolumeStub struct {
+	VolumeID         string
+	VolumeExternalID string
+	PluginID         string
+	ExternalNodeID   string
+	MountInfo        *csimanager.MountInfo
 }

--- a/client/pluginmanager/csimanager/instance.go
+++ b/client/pluginmanager/csimanager/instance.go
@@ -94,7 +94,13 @@ func (i *instanceManager) setupVolumeManager() {
 	case <-i.shutdownCtx.Done():
 		return
 	case <-i.fp.hadFirstSuccessfulFingerprintCh:
-		i.volumeManager = newVolumeManager(i.logger, i.eventer, i.client, i.mountPoint, i.containerMountPoint, i.fp.requiresStaging)
+
+		var externalID string
+		if i.fp.basicInfo != nil && i.fp.basicInfo.NodeInfo != nil {
+			externalID = i.fp.basicInfo.NodeInfo.ID
+		}
+
+		i.volumeManager = newVolumeManager(i.logger, i.eventer, i.client, i.mountPoint, i.containerMountPoint, i.fp.requiresStaging, externalID)
 		i.logger.Debug("volume manager setup complete")
 		close(i.volumeManagerSetupCh)
 		return

--- a/client/pluginmanager/csimanager/interface.go
+++ b/client/pluginmanager/csimanager/interface.go
@@ -56,6 +56,8 @@ func (u *UsageOptions) ToFS() string {
 type VolumeMounter interface {
 	MountVolume(ctx context.Context, vol *structs.CSIVolume, alloc *structs.Allocation, usageOpts *UsageOptions, publishContext map[string]string) (*MountInfo, error)
 	UnmountVolume(ctx context.Context, volID, remoteID, allocID string, usageOpts *UsageOptions) error
+	HasMount(ctx context.Context, mountInfo *MountInfo) (bool, error)
+	ExternalID() string
 }
 
 type Manager interface {

--- a/client/pluginmanager/csimanager/volume.go
+++ b/client/pluginmanager/csimanager/volume.go
@@ -53,9 +53,14 @@ type volumeManager struct {
 	// requiresStaging shows whether the plugin requires that the volume manager
 	// calls NodeStageVolume and NodeUnstageVolume RPCs during setup and teardown
 	requiresStaging bool
+
+	// externalNodeID is the identity of a given nomad client as observed by the
+	// storage provider (ex. a hostname, VM instance ID, etc.)
+	externalNodeID string
 }
 
-func newVolumeManager(logger hclog.Logger, eventer TriggerNodeEvent, plugin csi.CSIPlugin, rootDir, containerRootDir string, requiresStaging bool) *volumeManager {
+func newVolumeManager(logger hclog.Logger, eventer TriggerNodeEvent, plugin csi.CSIPlugin, rootDir, containerRootDir string, requiresStaging bool, externalID string) *volumeManager {
+
 	return &volumeManager{
 		logger:              logger.Named("volume_manager"),
 		eventer:             eventer,
@@ -64,6 +69,7 @@ func newVolumeManager(logger hclog.Logger, eventer TriggerNodeEvent, plugin csi.
 		containerMountPoint: containerRootDir,
 		requiresStaging:     requiresStaging,
 		usageTracker:        newVolumeUsageTracker(),
+		externalNodeID:      externalID,
 	}
 }
 
@@ -375,4 +381,14 @@ func (v *volumeManager) UnmountVolume(ctx context.Context, volID, remoteID, allo
 	v.eventer(event)
 
 	return err
+}
+
+func (v *volumeManager) ExternalID() string {
+	return v.externalNodeID
+}
+
+func (v *volumeManager) HasMount(_ context.Context, mountInfo *MountInfo) (bool, error) {
+	m := mount.New()
+	isNotMount, err := m.IsNotAMountPoint(mountInfo.Source)
+	return !isNotMount, err
 }

--- a/client/pluginmanager/csimanager/volume_test.go
+++ b/client/pluginmanager/csimanager/volume_test.go
@@ -92,7 +92,8 @@ func TestVolumeManager_ensureStagingDir(t *testing.T) {
 
 			csiFake := &csifake.Client{}
 			eventer := func(e *structs.NodeEvent) {}
-			manager := newVolumeManager(testlog.HCLogger(t), eventer, csiFake, tmpPath, tmpPath, true)
+			manager := newVolumeManager(testlog.HCLogger(t), eventer, csiFake,
+				tmpPath, tmpPath, true, "i-example")
 			expectedStagingPath := manager.stagingDirForVolume(tmpPath, tc.Volume.ID, tc.UsageOptions)
 
 			if tc.CreateDirAheadOfTime {
@@ -193,7 +194,8 @@ func TestVolumeManager_stageVolume(t *testing.T) {
 			csiFake.NextNodeStageVolumeErr = tc.PluginErr
 
 			eventer := func(e *structs.NodeEvent) {}
-			manager := newVolumeManager(testlog.HCLogger(t), eventer, csiFake, tmpPath, tmpPath, true)
+			manager := newVolumeManager(testlog.HCLogger(t), eventer, csiFake,
+				tmpPath, tmpPath, true, "i-example")
 			ctx := context.Background()
 
 			err := manager.stageVolume(ctx, tc.Volume, tc.UsageOptions, nil)
@@ -251,7 +253,8 @@ func TestVolumeManager_unstageVolume(t *testing.T) {
 			csiFake.NextNodeUnstageVolumeErr = tc.PluginErr
 
 			eventer := func(e *structs.NodeEvent) {}
-			manager := newVolumeManager(testlog.HCLogger(t), eventer, csiFake, tmpPath, tmpPath, true)
+			manager := newVolumeManager(testlog.HCLogger(t), eventer, csiFake,
+				tmpPath, tmpPath, true, "i-example")
 			ctx := context.Background()
 
 			err := manager.unstageVolume(ctx,
@@ -374,7 +377,8 @@ func TestVolumeManager_publishVolume(t *testing.T) {
 			csiFake.NextNodePublishVolumeErr = tc.PluginErr
 
 			eventer := func(e *structs.NodeEvent) {}
-			manager := newVolumeManager(testlog.HCLogger(t), eventer, csiFake, tmpPath, tmpPath, true)
+			manager := newVolumeManager(testlog.HCLogger(t), eventer, csiFake,
+				tmpPath, tmpPath, true, "i-example")
 			ctx := context.Background()
 
 			_, err := manager.publishVolume(ctx, tc.Volume, tc.Allocation, tc.UsageOptions, nil)
@@ -441,7 +445,8 @@ func TestVolumeManager_unpublishVolume(t *testing.T) {
 			csiFake.NextNodeUnpublishVolumeErr = tc.PluginErr
 
 			eventer := func(e *structs.NodeEvent) {}
-			manager := newVolumeManager(testlog.HCLogger(t), eventer, csiFake, tmpPath, tmpPath, true)
+			manager := newVolumeManager(testlog.HCLogger(t), eventer, csiFake,
+				tmpPath, tmpPath, true, "i-example")
 			ctx := context.Background()
 
 			err := manager.unpublishVolume(ctx,
@@ -473,7 +478,8 @@ func TestVolumeManager_MountVolumeEvents(t *testing.T) {
 		events = append(events, e)
 	}
 
-	manager := newVolumeManager(testlog.HCLogger(t), eventer, csiFake, tmpPath, tmpPath, true)
+	manager := newVolumeManager(testlog.HCLogger(t), eventer, csiFake,
+		tmpPath, tmpPath, true, "i-example")
 	ctx := context.Background()
 	vol := &structs.CSIVolume{
 		ID:        "vol",

--- a/client/state/db_error.go
+++ b/client/state/db_error.go
@@ -62,6 +62,14 @@ func (m *ErrDB) GetAcknowledgedState(allocID string) (*arstate.State, error) {
 	return nil, fmt.Errorf("Error!")
 }
 
+func (m *ErrDB) PutAllocVolumes(allocID string, state *arstate.AllocVolumes, opts ...WriteOption) error {
+	return fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) GetAllocVolumes(allocID string) (*arstate.AllocVolumes, error) {
+	return nil, fmt.Errorf("Error!")
+}
+
 func (m *ErrDB) GetTaskRunnerState(allocID string, taskName string) (*state.LocalState, *structs.TaskState, error) {
 	return nil, nil, fmt.Errorf("Error!")
 }

--- a/client/state/db_mem.go
+++ b/client/state/db_mem.go
@@ -33,6 +33,9 @@ type MemDB struct {
 	// alloc_id -> value
 	acknowledgedState map[string]*arstate.State
 
+	// alloc_id -> value
+	allocVolumeStates map[string]*arstate.AllocVolumes
+
 	// alloc_id -> task_name -> value
 	localTaskState map[string]map[string]*state.LocalState
 	taskState      map[string]map[string]*structs.TaskState
@@ -137,6 +140,19 @@ func (m *MemDB) GetAcknowledgedState(allocID string) (*arstate.State, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.acknowledgedState[allocID], nil
+}
+
+func (m *MemDB) PutAllocVolumes(allocID string, state *arstate.AllocVolumes, opts ...WriteOption) error {
+	m.mu.Lock()
+	m.allocVolumeStates[allocID] = state
+	defer m.mu.Unlock()
+	return nil
+}
+
+func (m *MemDB) GetAllocVolumes(allocID string) (*arstate.AllocVolumes, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.allocVolumeStates[allocID], nil
 }
 
 func (m *MemDB) GetTaskRunnerState(allocID string, taskName string) (*state.LocalState, *structs.TaskState, error) {

--- a/client/state/db_noop.go
+++ b/client/state/db_noop.go
@@ -55,6 +55,12 @@ func (n NoopDB) PutAcknowledgedState(allocID string, state *arstate.State, opts 
 
 func (n NoopDB) GetAcknowledgedState(allocID string) (*arstate.State, error) { return nil, nil }
 
+func (n NoopDB) PutAllocVolumes(allocID string, state *arstate.AllocVolumes, opts ...WriteOption) error {
+	return nil
+}
+
+func (n NoopDB) GetAllocVolumes(allocID string) (*arstate.AllocVolumes, error) { return nil, nil }
+
 func (n NoopDB) GetTaskRunnerState(allocID string, taskName string) (*state.LocalState, *structs.TaskState, error) {
 	return nil, nil, nil
 }

--- a/client/state/interface.go
+++ b/client/state/interface.go
@@ -54,6 +54,14 @@ type StateDB interface {
 	// state. It may be nil even if there's no error
 	GetAcknowledgedState(string) (*arstate.State, error)
 
+	// PutAllocVolumes stores stubs of an allocation's dynamic volume mounts so
+	// they can be restored.
+	PutAllocVolumes(allocID string, state *arstate.AllocVolumes, opts ...WriteOption) error
+
+	// GetAllocVolumes retrieves stubs of an allocation's dynamic volume mounts
+	// so they can be restored.
+	GetAllocVolumes(allocID string) (*arstate.AllocVolumes, error)
+
 	// GetTaskRunnerState returns the LocalState and TaskState for a
 	// TaskRunner. Either state may be nil if it is not found, but if an
 	// error is encountered only the error will be non-nil.

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -412,6 +412,17 @@ func ConvertSlice[A, B any](original []A, conversion func(a A) B) []B {
 	return result
 }
 
+// ConvertMap takes the input map and generates a new one using the supplied
+// conversion function to convert the values. This is useful when converting one
+// map to another using the same keys.
+func ConvertMap[K comparable, A, B any](original map[K]A, conversion func(a A) B) map[K]B {
+	result := make(map[K]B, len(original))
+	for k, a := range original {
+		result[k] = conversion(a)
+	}
+	return result
+}
+
 // IsMethodHTTP returns whether s is a known HTTP method, ignoring case.
 func IsMethodHTTP(s string) bool {
 	switch strings.ToUpper(s) {

--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -222,6 +222,14 @@ func (v *VolumeRequest) Copy() *VolumeRequest {
 	return nv
 }
 
+func (v *VolumeRequest) VolumeID(tgName string) string {
+	source := v.Source
+	if v.PerAlloc {
+		source = source + AllocSuffix(tgName)
+	}
+	return source
+}
+
 func CopyMapVolumeRequest(s map[string]*VolumeRequest) map[string]*VolumeRequest {
 	if s == nil {
 		return nil


### PR DESCRIPTION
When claiming a CSI volume, we need to ensure the CSI node plugin is running before we send any CSI RPCs. This extends even to the controller publish RPC because it requires the storage provider's "external node ID" for the client. This primarily impacts client restarts because the client's initial fingerprint won't include restored plugins.

Unfortunately there's no mapping of volume to plugin ID available in the jobspec, so we don't have enough information to wait on plugins until we either get the volume from the server or retrieve the plugin ID from data we've persisted on the client.

If we always require getting the volume from the server before making the claim, a client restart for disconnected clients will cause all the allocations that need CSI volumes to fail. Even while connected, checking in with the server to verify the volume's plugin before trying to make a claim RPC is inherently racy, so we'll leave that case as-is and it will fail the claim if the node plugin needed to support a newly-placed allocation is flapping such that the node fingerprint is changing.

So instead of blocking for information from the server, this changeset persists a minimum subset of data about the volume and its plugin in the client state DB, and retrieves that data during the CSI hook's prerun to avoid re-claiming and remounting the volume unnecessarily. This fixes the client restart bug but also reduces Nomad RPC and CSI RPC traffic during client restarts.

This changeset also updates the RPC handler to use the external node ID from the claim whenever it is available.

Fixes: #13028

---

Note for reviewers: this looks like a bit of a monster of a PR because of all the plumbing required for adding a new client state DB object. The bulk of the non-plumbing changes are in `client/allocrunner/csi_hook.go`, which GitHub is helpfully folding. :grinning:  An unfortunate amount of the churn in that file is having to break up the `claimVolume` function a bit, but I think the top-level flow in `Prerun` is a lot more legible as a result. In addition to expanding the test coverage in the unit test, I've also end-to-end tested this with the AWS EBS plugin and restarting the client in various configurations. (Also note this will not do anything for #15415)