### PR TITLE
ci: pull secrets from Vault in nomad-enterprise

### DIFF
--- a/.github/actions/vault-secrets/action.yml
+++ b/.github/actions/vault-secrets/action.yml
@@ -1,0 +1,23 @@
+name: vault-secrets
+description: 'pull secrets from CI Vault into environment vars'
+inputs:
+  paths:
+    description: 'vault-action secrets input'
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Authenticate to Vault
+      if: endsWith(github.repository, '-enterprise')
+      id: vault-auth
+      run: vault-auth
+      shell: bash
+    - name: Retrieve Vault-hosted Secrets
+      if: endsWith(github.repository, '-enterprise')
+      id: vault
+      uses: hashicorp/vault-action@v2.4.3
+      with:
+        url: ${{ steps.vault-auth.outputs.addr }}
+        caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+        token: ${{ steps.vault-auth.outputs.token }}
+        secrets: ${{ inputs.paths }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -38,6 +38,11 @@ jobs:
     if: always() && needs.backport.result == 'failure'
     runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-latest' }}
     steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: ./.github/actions/vault-secrets
+        with:
+          paths: |-
+            kv/data/teams/nomad/slack-webhooks feed-nomad | SLACK_FEED_NOMAD ;
       - name: Send slack notification on failure
         uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
         with:
@@ -70,8 +75,8 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.BACKPORT_ASSISTANT_FAILURE_SLACK }}
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_FEED_NOMAD || secrets.BACKPORT_ASSISTANT_FAILURE_SLACK }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 permissions:
   contents: read
-
+  id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,6 +247,14 @@ jobs:
         with:
           ref: ${{ github.event.inputs.build-ref }}
 
+      - uses: ./.github/actions/vault-secrets
+        with:
+          paths: |-
+            kv/data/github/hashicorp/nomad-enterprise/gha ELEVATED_GITHUB_TOKEN ;
+      - name: Git config token
+        if: endsWith(github.repository, '-enterprise')
+        run: git config --global url.'https://${{ env.ELEVATED_GITHUB_TOKEN }}@github.com'.insteadOf 'https://github.com'
+
       - name: Setup go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
@@ -324,3 +332,4 @@ jobs:
 
 permissions:
   contents: read
+  id-token: write

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -26,6 +26,13 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           fetch-depth: 0 # needs tags for checkproto
+      - uses: ./.github/actions/vault-secrets
+        with:
+          paths: |-
+            kv/data/github/hashicorp/nomad-enterprise/gha ELEVATED_GITHUB_TOKEN ;
+      - name: Git config token
+        if: endsWith(github.repository, '-enterprise')
+        run: git config --global url.'https://${{ env.ELEVATED_GITHUB_TOKEN }}@github.com'.insteadOf 'https://github.com'
       - uses: hashicorp/setup-golang@v1
       - name: Run make check
         run: |
@@ -34,3 +41,4 @@ jobs:
           make check
 permissions:
   contents: read
+  id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,15 @@ jobs:
             exit 1
           fi
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - name: Setup Git
+      - uses: ./.github/actions/vault-secrets
+        with:
+          paths: |-
+            kv/data/github/hashicorp/nomad-enterprise/gha ELEVATED_GITHUB_TOKEN ;
+      - name: Git config token
+        if: endsWith(github.repository, '-enterprise')
+        run: git config --global url.'https://${{ env.ELEVATED_GITHUB_TOKEN }}@github.com'.insteadOf 'https://github.com'
+      - name: Git config user/name
         run: |-
-          if [ -n "${{ secrets.ELEVATED_GITHUB_TOKEN }}" ]; then
-            git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN }}:@github.com/".insteadOf "https://github.com"
-          fi
           git config --global user.email "github-team-nomad-core@hashicorp.com"
           git config --global user.name "hc-github-team-nomad-core"
 
@@ -141,7 +145,7 @@ jobs:
       - name: Invoke build workflow
         id: invoke-build
         env:
-          GH_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ env.ELEVATED_GITHUB_TOKEN || secrets.ELEVATED_GITHUB_TOKEN }}
         run: |
           gh workflow run build.yml --ref ${{ github.ref_name }} --field build-ref=${{ steps.commit-change-push.outputs.build-ref }} --field make-prerelease=false
 
@@ -205,3 +209,4 @@ jobs:
 
 permissions:
   contents: write
+  id-token: write

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -53,6 +53,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: ./.github/actions/vault-secrets
+        with:
+          paths: |-
+            kv/data/github/hashicorp/nomad-enterprise/gha ELEVATED_GITHUB_TOKEN ;
+      - name: Git config token
+        if: endsWith(github.repository, '-enterprise')
+        run: git config --global url.'https://${{ env.ELEVATED_GITHUB_TOKEN }}@github.com'.insteadOf 'https://github.com'
       - uses: hashicorp/setup-golang@v1
       - name: Get Go modules
         run: |
@@ -120,3 +127,4 @@ jobs:
           sudo -E env "PATH=$PATH" make test-nomad
 permissions:
   contents: read
+  id-token: write

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -39,9 +39,17 @@ jobs:
     runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: ./.github/actions/vault-secrets
+        with:
+          paths: |-
+            kv/data/github/hashicorp/nomad-enterprise/gha ELEVATED_GITHUB_TOKEN ;
+      - name: Git config token
+        if: endsWith(github.repository, '-enterprise')
+        run: git config --global url.'https://${{ env.ELEVATED_GITHUB_TOKEN }}@github.com'.insteadOf 'https://github.com'
       - uses: hashicorp/setup-golang@v1
       - run: make deps
       - run: make integration-test
       - run: make e2e-test
 permissions:
   contents: read
+  id-token: write

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -72,9 +72,13 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: ./.github/actions/setup-js
       - uses: browser-actions/setup-chrome@c485fa3bab6be59dce18dbc18ef6ab7cbc8ff5f1 # v1.2.0
+      - uses: ./.github/actions/vault-secrets
+        with:
+          paths: |-
+            kv/data/teams/nomad/ui PERCY_TOKEN ;
       - name: ember exam
         env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PERCY_TOKEN: ${{ env.PERCY_TOKEN || secrets.PERCY_TOKEN }}
           PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
         run: yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }}
 
@@ -90,10 +94,15 @@ jobs:
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: ./.github/actions/setup-js
+      - uses: ./.github/actions/vault-secrets
+        with:
+          paths: |-
+            kv/data/teams/nomad/ui PERCY_TOKEN ;
       - name: finalize
         env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PERCY_TOKEN: ${{ env.PERCY_TOKEN || secrets.PERCY_TOKEN }}
           PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
         run: yarn percy build:finalize
 permissions:
   contents: read
+  id-token: write


### PR DESCRIPTION
Now that (most) secrets-requiring workflows run on self-hosted runners in nomad-enterprise (#17775), we're able to (conditionally) pull secrets from our internal CI Vault cluster.

The approach here uses a [composite action](https://docs.github.com/en/actions/creating-actions/about-custom-actions#composite-actions) to avoid repetitive boilerplate, which also means it needs* to set secrets as env vars (also the default behavior of hashicorp/vault-action, and common practice in other projects, sans the composite action).  Otherwise, it would require an odd maneuver, for GHA reasons, to have the composite output a dynamic map instead (*but it is possible, if we really want to. ask me how if you'd like).

As with the aforementioned PR, this is here in OSS Nomad repo to avoid merge conflicts with enterprise.  I've pre-tested the workflows there, so hopefully no runtime surprises when we go to merge oss->ent.