### PR TITLE
ci: more self-hosted iops for checks workflow

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -20,8 +20,9 @@ on:
 
 jobs:
   checks:
-    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-22.04' }}
-    timeout-minutes: 10
+    # largest available self-hosted disk for extra iops because linting is io-intensive
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "disk_gb=255"]') || 'ubuntu-22.04' }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:


### PR DESCRIPTION
Avoid hitting the timeout on nomad-enterprise.
These values have worked consistently in my tests over yonder.