### PR TITLE
ci: add copywrite action to check file headers.

### DIFF
--- a/.github/workflows/copywrite.yml
+++ b/.github/workflows/copywrite.yml
@@ -10,6 +10,9 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e # v1.1.2
         name: Setup Copywrite
+        with:
+          version: v0.16.4
+          archive-checksum: c299f830e6eef7e126a3c6ef99ac6f43a3c132d830c769e0d36fa347fa1af254
       - name: Check Header Compliance
         run: copywrite headers --plan
 permissions:

--- a/.github/workflows/copywrite.yml
+++ b/.github/workflows/copywrite.yml
@@ -1,0 +1,16 @@
+name: Check Copywrite Headers
+
+on:
+  push: {}
+
+jobs:
+  copywrite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e # v1.1.2
+        name: Setup Copywrite
+      - name: Check Header Compliance
+        run: copywrite headers --plan
+permissions:
+  contents: read


### PR DESCRIPTION
This PR's copywrite CI run: https://github.com/hashicorp/nomad/actions/runs/5521733801/jobs/10070278831?pr=17889

closes #17887 