### PR TITLE
docs: fix typo in regex_replace.mdx

### DIFF
--- a/website/content/docs/job-specification/hcl2/functions/string/regex_replace.mdx
+++ b/website/content/docs/job-specification/hcl2/functions/string/regex_replace.mdx
@@ -32,7 +32,7 @@ hello everybody
 > regex_replace("hello world", "w.*d", "everybody")
 hello everybody
 
-> regex_replace("-ab-axxb-", "a(x*)b", "$1W)
+> regex_replace("-ab-axxb-", "a(x*)b", "$1W")
 ---
 
 > regex_replace("-ab-axxb-", "a(x*)b", "${1}W")


### PR DESCRIPTION
Fix a missing quote in the code sample for `regex_replace()`.