### PR TITLE
np: update docs and add test for nil lists

### DIFF
--- a/command/namespace_apply_test.go
+++ b/command/namespace_apply_test.go
@@ -120,6 +120,24 @@ meta {
 			input:    "",
 			expected: &api.Namespace{},
 		},
+		{
+			name: "lists in node pool config are nil if not provided",
+			input: `
+name = "nil-lists"
+
+node_pool_config {
+  default = "default"
+}
+`,
+			expected: &api.Namespace{
+				Name: "nil-lists",
+				NodePoolConfiguration: &api.NamespaceNodePoolConfiguration{
+					Default: "default",
+					Allowed: nil,
+					Denied:  nil,
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5396,10 +5396,10 @@ type NamespaceNodePoolConfiguration struct {
 	Default string
 
 	// Allowed specifies the node pools that are allowed to be used by jobs in
-	// this namespace. This field supports wildcard globbing through the use
-	// of `*` for multi-character matching. If specified, only the node pools
-	// that match these patterns are allowed. This field cannot be used
-	// with Denied.
+	// this namespace. By default, all node pools are allowed. If an empty list
+	// is provided only the namespace's default node pool is allowed. This field
+	// supports wildcard globbing through the use of `*` for multi-character
+	// matching. This field cannot be used with Denied.
 	Allowed []string
 
 	// Denied specifies the node pools that are not allowed to be used by jobs

--- a/website/content/docs/other-specifications/namespace.mdx
+++ b/website/content/docs/other-specifications/namespace.mdx
@@ -79,13 +79,13 @@ node_pool_config {
 - `default` `(string: "default")` - Specifies the node pool to use for jobs in
   this namespace that don't define a node pool in their specification.
 
-- `allowed` `(array<string>: [])` - Specifies the node pools that are allowed
-  to be used by jobs in this namespace. This field supports wildcard globbing
-  through the use of `*` for multi-character matching. If specified, only the
-  node pools that match these patterns are allowed. This field cannot be used
-  with `denied`.
+- `allowed` `(array<string>: nil)` - Specifies the node pools that are allowed
+  to be used by jobs in this namespace. By default, all node pools are allowed.
+  If an empty list is provided only the namespace's default node pool is
+  allowed. This field supports wildcard globbing through the use of `*` for
+  multi-character matching. This field cannot be used with `denied`.
 
-- `denied` `(array<string>: [])` - Specifies the node pools that are not
+- `denied` `(array<string>: nil)` - Specifies the node pools that are not
   allowed to be used by jobs in this namespace. This field supports wildcard
   globbing through the use of `*` for multi-character matching. If specified,
   any node pool is allowed to be used, except for those that match any of these


### PR DESCRIPTION
Document and test that if a namespace does not provide an `allow` or `deny` list than those are treated as `nil` and have a different behaviour from an empty list (`[]string{}`).