### PR TITLE
e2e: do not set a user for raw_exec tasks

### DIFF
--- a/e2e/example/input/env.hcl
+++ b/e2e/example/input/env.hcl
@@ -23,7 +23,6 @@ job "env" {
     }
 
     task "task" {
-      user   = "nobody"
       driver = "raw_exec"
 
       config {

--- a/e2e/example/input/sleep.hcl
+++ b/e2e/example/input/sleep.hcl
@@ -28,7 +28,6 @@ job "sleep" {
     }
 
     task "task" {
-      user   = "nobody"
       driver = "raw_exec"
 
       config {

--- a/e2e/servicediscovery/input/checks_task_restart_main.nomad
+++ b/e2e/servicediscovery/input/checks_task_restart_main.nomad
@@ -35,7 +35,6 @@ job "checks_task_restart" {
 
     task "python" {
       driver = "raw_exec"
-      user   = "nobody"
       config {
         command = "python3"
         args    = ["-m", "http.server", "${NOMAD_PORT_http}", "--directory", "/tmp"]


### PR DESCRIPTION
Cannot set a user for raw_exec tasks, because doing so does not work
with the 0700 root owned client data directory that we setup in the e2e
cluster in accordance with the Nomad hardening guide.
