### PR TITLE
[ui] When a purged/404-ing job is detected, boot the user out of that job and back to the index

### DIFF
--- a/ui/app/controllers/jobs/job.js
+++ b/ui/app/controllers/jobs/job.js
@@ -22,15 +22,15 @@ export default class JobController extends Controller {
     return this.model;
   }
 
-  get jobHasBeenYoinked() {
+  get jobNotFoundFromServer() {
     return (
       this.watchers.job.isError &&
-      this.watchers.job.error.errors.some((e) => e.status === '404')
+      this.watchers.job.error.errors?.some((e) => e.status === '404')
     );
   }
 
-  @action yoinkedJobHandler() {
-    if (this.jobHasBeenYoinked) {
+  @action notFoundJobHandler() {
+    if (this.jobNotFoundFromServer) {
       this.notifications.add({
         title: `Job ${this.job.name} has been deleted`,
         message:

--- a/ui/app/controllers/jobs/job.js
+++ b/ui/app/controllers/jobs/job.js
@@ -22,21 +22,17 @@ export default class JobController extends Controller {
     return this.model;
   }
 
-  get jobNotFoundFromServer() {
-    return (
-      this.watchers.job.isError &&
-      this.watchers.job.error.errors?.some((e) => e.status === '404')
-    );
-  }
-
   @action notFoundJobHandler() {
-    if (this.jobNotFoundFromServer) {
+    if (
+      this.watchers.job.isError &&
+      this.watchers.job.error?.errors?.some((e) => e.status === '404')
+    ) {
       this.notifications.add({
-        title: `Job ${this.job.name} has been deleted`,
+        title: `Job "${this.job.name}" has been deleted`,
         message:
           'The job you were looking at has been deleted; this is usually because it was purged from elsewhere.',
         color: 'critical',
-        destroyOnClick: false,
+        sticky: true,
       });
       this.router.transitionTo('jobs');
     }

--- a/ui/app/controllers/jobs/job.js
+++ b/ui/app/controllers/jobs/job.js
@@ -3,9 +3,14 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+// @ts-check
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class JobController extends Controller {
+  @service router;
+  @service notifications;
   queryParams = [
     {
       jobNamespace: 'namespace',
@@ -15,5 +20,25 @@ export default class JobController extends Controller {
 
   get job() {
     return this.model;
+  }
+
+  get jobHasBeenYoinked() {
+    return (
+      this.watchers.job.isError &&
+      this.watchers.job.error.errors.some((e) => e.status === '404')
+    );
+  }
+
+  @action yoinkedJobHandler() {
+    if (this.jobHasBeenYoinked) {
+      this.notifications.add({
+        title: `Job ${this.job.name} has been deleted`,
+        message:
+          'The job you were looking at has been deleted; this is usually because it was purged from elsewhere.',
+        color: 'critical',
+        destroyOnClick: false,
+      });
+      this.router.transitionTo('jobs');
+    }
   }
 }

--- a/ui/app/controllers/jobs/job.js
+++ b/ui/app/controllers/jobs/job.js
@@ -11,6 +11,7 @@ import { inject as service } from '@ember/service';
 export default class JobController extends Controller {
   @service router;
   @service notifications;
+  @service store;
   queryParams = [
     {
       jobNamespace: 'namespace',
@@ -34,6 +35,7 @@ export default class JobController extends Controller {
         color: 'critical',
         sticky: true,
       });
+      this.store.unloadRecord(this.job);
       this.router.transitionTo('jobs');
     }
   }

--- a/ui/app/routes/jobs/job.js
+++ b/ui/app/routes/jobs/job.js
@@ -8,13 +8,16 @@ import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 import notifyError from 'nomad-ui/utils/notify-error';
 import classic from 'ember-classic-decorator';
+import { watchRecord } from 'nomad-ui/utils/properties/watch';
+import WithWatchers from 'nomad-ui/mixins/with-watchers';
 
 @classic
-export default class JobRoute extends Route {
+export default class JobRoute extends Route.extend(WithWatchers) {
   @service can;
   @service store;
   @service token;
   @service router;
+  @service notifications;
 
   serialize(model) {
     return { job_name: model.get('idWithNamespace') };
@@ -57,4 +60,15 @@ export default class JobRoute extends Route {
       })
       .catch(notifyError(this));
   }
+
+  startWatchers(controller, model) {
+    if (!model) {
+      return;
+    }
+    controller.set('watchers', {
+      job: this.watch.perform(model),
+    });
+  }
+
+  @watchRecord('job', { shouldSurfaceErrors: true }) watch;
 }

--- a/ui/app/routes/jobs/job.js
+++ b/ui/app/routes/jobs/job.js
@@ -9,6 +9,7 @@ import RSVP from 'rsvp';
 import notifyError from 'nomad-ui/utils/notify-error';
 import classic from 'ember-classic-decorator';
 import { watchRecord } from 'nomad-ui/utils/properties/watch';
+import { collect } from '@ember/object/computed';
 import WithWatchers from 'nomad-ui/mixins/with-watchers';
 
 @classic
@@ -71,4 +72,6 @@ export default class JobRoute extends Route.extend(WithWatchers) {
   }
 
   @watchRecord('job', { shouldSurfaceErrors: true }) watch;
+  @collect('watch')
+  watchers;
 }

--- a/ui/app/routes/jobs/job/index.js
+++ b/ui/app/routes/jobs/job/index.js
@@ -27,7 +27,6 @@ export default class IndexRoute extends Route.extend(WithWatchers) {
       return;
     }
     controller.set('watchers', {
-      // model: this.watch.perform(model),
       summary: this.watchSummary.perform(model.get('summary')),
       allocations: this.watchAllocations.perform(model),
       evaluations: this.watchEvaluations.perform(model),
@@ -59,7 +58,6 @@ export default class IndexRoute extends Route.extend(WithWatchers) {
     return super.setupController(...arguments);
   }
 
-  // @watchRecord('job') watch;
   @watchQuery('job') watchAllJobs;
   @watchAll('node') watchNodes;
   @watchRecord('job-summary') watchSummary;
@@ -68,7 +66,6 @@ export default class IndexRoute extends Route.extend(WithWatchers) {
   @watchRelationship('latestDeployment') watchLatestDeployment;
 
   @collect(
-    // 'watch',
     'watchAllJobs',
     'watchSummary',
     'watchAllocations',

--- a/ui/app/routes/jobs/job/index.js
+++ b/ui/app/routes/jobs/job/index.js
@@ -27,7 +27,7 @@ export default class IndexRoute extends Route.extend(WithWatchers) {
       return;
     }
     controller.set('watchers', {
-      model: this.watch.perform(model),
+      // model: this.watch.perform(model),
       summary: this.watchSummary.perform(model.get('summary')),
       allocations: this.watchAllocations.perform(model),
       evaluations: this.watchEvaluations.perform(model),
@@ -59,7 +59,7 @@ export default class IndexRoute extends Route.extend(WithWatchers) {
     return super.setupController(...arguments);
   }
 
-  @watchRecord('job') watch;
+  // @watchRecord('job') watch;
   @watchQuery('job') watchAllJobs;
   @watchAll('node') watchNodes;
   @watchRecord('job-summary') watchSummary;
@@ -68,7 +68,7 @@ export default class IndexRoute extends Route.extend(WithWatchers) {
   @watchRelationship('latestDeployment') watchLatestDeployment;
 
   @collect(
-    'watch',
+    // 'watch',
     'watchAllJobs',
     'watchSummary',
     'watchAllocations',

--- a/ui/app/templates/jobs/job.hbs
+++ b/ui/app/templates/jobs/job.hbs
@@ -3,5 +3,5 @@
   SPDX-License-Identifier: MPL-2.0
 ~}}
 
-{{did-update this.yoinkedJobHandler this.jobHasBeenYoinked}}
+{{did-update this.notFoundJobHandler this.jobNotFoundFromServer}}
 <Breadcrumb @crumb={{hash type="job" job=this.job}} />{{outlet}}

--- a/ui/app/templates/jobs/job.hbs
+++ b/ui/app/templates/jobs/job.hbs
@@ -3,5 +3,5 @@
   SPDX-License-Identifier: MPL-2.0
 ~}}
 
-{{did-update this.notFoundJobHandler this.jobNotFoundFromServer}}
+{{did-update this.notFoundJobHandler this.watchers.job.isError}}
 <Breadcrumb @crumb={{hash type="job" job=this.job}} />{{outlet}}

--- a/ui/app/templates/jobs/job.hbs
+++ b/ui/app/templates/jobs/job.hbs
@@ -3,4 +3,5 @@
   SPDX-License-Identifier: MPL-2.0
 ~}}
 
+{{did-update this.yoinkedJobHandler this.jobHasBeenYoinked}}
 <Breadcrumb @crumb={{hash type="job" job=this.job}} />{{outlet}}

--- a/ui/app/utils/properties/watch.js
+++ b/ui/app/utils/properties/watch.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+// @ts-check
+
 import Ember from 'ember';
 import { get } from '@ember/object';
 import { assert } from '@ember/debug';
@@ -15,7 +17,16 @@ import config from 'nomad-ui/config/environment';
 
 const isEnabled = config.APP.blockingQueries !== false;
 
-export function watchRecord(modelName) {
+/**
+ * @typedef watchRecordOptions
+ * @property {boolean} [shouldSurfaceErrors=false] - If true, the task will throw errors instead of yielding them.
+ */
+
+/**
+ * @param {string} modelName - The name of the model to watch.
+ * @param {watchRecordOptions} [options]
+ */
+export function watchRecord(modelName, { shouldSurfaceErrors = false } = {}) {
   return task(function* (id, throttle = 2000) {
     assert(
       'To watch a record, the record adapter MUST extend Watchable',
@@ -35,6 +46,9 @@ export function watchRecord(modelName) {
           wait(throttle),
         ]);
       } catch (e) {
+        if (shouldSurfaceErrors) {
+          throw e;
+        }
         yield e;
         break;
       } finally {

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -5,7 +5,7 @@
 
 /* eslint-disable ember/no-test-module-for */
 /* eslint-disable qunit/require-expect */
-import { currentURL } from '@ember/test-helpers';
+import { currentURL, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -15,6 +15,7 @@ import moduleForJob, {
   moduleForJobWithClientStatus,
 } from 'nomad-ui/tests/helpers/module-for-job';
 import JobDetail from 'nomad-ui/tests/pages/jobs/detail';
+import percySnapshot from '@percy/ember';
 
 moduleForJob('Acceptance | job detail (batch)', 'allocations', () =>
   server.create('job', {
@@ -614,5 +615,80 @@ module('Acceptance | job detail (with namespaces)', function (hooks) {
 
     await JobDetail.visit({ id: `${job2.id}@${secondNamespace.name}` });
     assert.ok(JobDetail.incrementButton.isDisabled);
+  });
+
+  test('handles when a job is remotely purged', async function (assert) {
+    const namespace = server.create('namespace');
+    const job = server.create('job', {
+      namespaceId: namespace.id,
+      status: 'running',
+      type: 'service',
+      shallow: true,
+      noActiveDeployment: true,
+      createAllocations: true,
+      groupsCount: 1,
+      groupTaskCount: 1,
+      allocStatusDistribution: {
+        running: 1,
+      },
+    });
+
+    await JobDetail.visit({ id: `${job.id}@${namespace.id}` });
+
+    assert.equal(currentURL(), `/jobs/${job.id}%40${namespace.id}`);
+
+    // Simulate a 404 error on the job watcher
+    const controller = this.owner.lookup('controller:jobs.job');
+    let jobWatcher = controller.watchers.job;
+    jobWatcher.isError = true;
+    jobWatcher.error = { errors: [{ status: '404' }] };
+    await settled();
+
+    // User should be booted off the page
+    assert.equal(currentURL(), '/jobs?namespace=*');
+
+    // A notification should be present
+    assert
+      .dom('.flash-message.alert-critical')
+      .exists('A toast error message pops up.');
+
+    await percySnapshot(assert);
+  });
+
+  test('handles when a job is remotely purged, from a job subnav page', async function (assert) {
+    const namespace = server.create('namespace');
+    const job = server.create('job', {
+      namespaceId: namespace.id,
+      status: 'running',
+      type: 'service',
+      shallow: true,
+      noActiveDeployment: true,
+      createAllocations: true,
+      groupsCount: 1,
+      groupTaskCount: 1,
+      allocStatusDistribution: {
+        running: 1,
+      },
+    });
+
+    await JobDetail.visit({ id: `${job.id}@${namespace.id}` });
+    await JobDetail.tabFor('allocations').visit();
+
+    assert.equal(currentURL(), `/jobs/${job.id}@${namespace.id}/allocations`);
+
+    // Simulate a 404 error on the job watcher
+    const controller = this.owner.lookup('controller:jobs.job');
+    let jobWatcher = controller.watchers.job;
+    jobWatcher.isError = true;
+    jobWatcher.error = { errors: [{ status: '404' }] };
+    await settled();
+
+    // User should be booted off the page
+    assert.equal(currentURL(), '/jobs?namespace=*');
+
+    // A notification should be present
+    assert
+      .dom('.flash-message.alert-critical')
+      .exists('A toast error message pops up.');
   });
 });


### PR DESCRIPTION
- In the event that a job is removed/purged/GC'd from elsewhere while the user is actively on a job page, this PR causes an event to fire that 1. boots the user back to the jobs index page, and 2. gives them a sticky notification about what happened.
- Moves the "job watcher" from jobs.job.index level to jobs.job level, so a "yoinked" job can be observed from anyplace within the job's subnav, not just the index page
- extends the `watchRecord` watcher util to accept a `shouldSurfaceErrors` param. This is experimental, but makes it so that elsewhere we can check `this.model.watchers.{}.isError`, where before it was being yielded but not set on the watcher itself.

<img width="872" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/ebc8b868-0a5d-4d6e-9511-e49aea6bf7dd">


Resolves #17757 