### PR TITLE
[ui] Flaky test fix: expiring token notification

### DIFF
--- a/ui/tests/acceptance/token-test.js
+++ b/ui/tests/acceptance/token-test.js
@@ -312,7 +312,7 @@ module('Acceptance | tokens', function (hooks) {
     assert.timeout(6000);
     const nearlyExpiringToken = server.create('token', {
       name: 'Not quite dead yet',
-      expirationTime: moment().add(10, 'm').add(5, 's').toDate(),
+      expirationTime: moment().add(10, 'm').add(3, 's').toDate(),
     });
 
     await Tokens.visit();


### PR DESCRIPTION
We've got this acceptance test in the UI that checks to make sure that, when the "10 minutes until your ACL token expires" point hits, you get a notification.

We would create a token with an expiry 10m5s out, wait 0.5s for initialization, and then wait 5s to make sure the notification is there.

With recent test runner changes (Circle -> GHA), we're noticing this fail more often. This may be because the JS runtime is different or slightly slower.

Because the user-facing notification is persistent (doesn't go away on its own), we're safe to wait a little longer before checking if the notification is present. And in order not to take any longer on our already-kind-of-long test runs, I've opted to shorten the token TTL rather than extending the setTimeout() length.