### PR TITLE
cli: search all namespaces for node volumes

### DIFF
--- a/.changelog/17925.txt
+++ b/.changelog/17925.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a bug that prevented CSI volumes in namespaces other than `default` from being displayed in the `nomad node status -verbose` output
+```

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -702,15 +702,14 @@ func (c *NodeStatusCommand) outputNodeCSIVolumeInfo(client *api.Client, node *ap
 
 		// Output the volumes in name order
 		output := make([]string, 0, len(names)+1)
-		output = append(output, "ID|Name|Namespace|Plugin ID|Schedulable|Provider|Access Mode")
+		output = append(output, "ID|Name|Plugin ID|Schedulable|Provider|Access Mode")
 		for _, name := range names {
 			v, ok := volumes[name]
 			if ok {
 				output = append(output, fmt.Sprintf(
-					"%s|%s|%s|%s|%t|%s|%s",
+					"%s|%s|%s|%t|%s|%s",
 					v.ID,
 					name,
-					v.Namespace,
 					v.PluginID,
 					v.Schedulable,
 					v.Provider,

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -687,7 +687,9 @@ func (c *NodeStatusCommand) outputNodeCSIVolumeInfo(client *api.Client, node *ap
 	// Fetch the volume objects with current status
 	// Ignore an error, all we're going to do is omit the volumes
 	volumes := map[string]*api.CSIVolumeListStub{}
-	vs, _ := client.Nodes().CSIVolumes(node.ID, nil)
+	vs, _ := client.Nodes().CSIVolumes(node.ID, &api.QueryOptions{
+		Namespace: "*",
+	})
 	for _, v := range vs {
 		n, ok := requests[v.ID]
 		if ok {
@@ -700,14 +702,15 @@ func (c *NodeStatusCommand) outputNodeCSIVolumeInfo(client *api.Client, node *ap
 
 		// Output the volumes in name order
 		output := make([]string, 0, len(names)+1)
-		output = append(output, "ID|Name|Plugin ID|Schedulable|Provider|Access Mode")
+		output = append(output, "ID|Name|Namespace|Plugin ID|Schedulable|Provider|Access Mode")
 		for _, name := range names {
 			v, ok := volumes[name]
 			if ok {
 				output = append(output, fmt.Sprintf(
-					"%s|%s|%s|%t|%s|%s",
+					"%s|%s|%s|%s|%t|%s|%s",
 					v.ID,
 					name,
+					v.Namespace,
 					v.PluginID,
 					v.Schedulable,
 					v.Provider,

--- a/command/volume_status_csi.go
+++ b/command/volume_status_csi.go
@@ -187,12 +187,11 @@ func (c *VolumeStatusCommand) csiFormatVolumes(vols []*api.CSIVolumeListStub) (s
 // Format the volumes, assumes that we're already sorted by volume ID
 func csiFormatSortedVolumes(vols []*api.CSIVolumeListStub) (string, error) {
 	rows := make([]string, len(vols)+1)
-	rows[0] = "ID|Name|Namespace|Plugin ID|Schedulable|Access Mode"
+	rows[0] = "ID|Name|Plugin ID|Schedulable|Access Mode"
 	for i, v := range vols {
-		rows[i+1] = fmt.Sprintf("%s|%s|%s|%s|%t|%s",
+		rows[i+1] = fmt.Sprintf("%s|%s|%s|%t|%s",
 			v.ID,
 			v.Name,
-			v.Namespace,
 			v.PluginID,
 			v.Schedulable,
 			v.AccessMode,

--- a/command/volume_status_csi.go
+++ b/command/volume_status_csi.go
@@ -187,11 +187,12 @@ func (c *VolumeStatusCommand) csiFormatVolumes(vols []*api.CSIVolumeListStub) (s
 // Format the volumes, assumes that we're already sorted by volume ID
 func csiFormatSortedVolumes(vols []*api.CSIVolumeListStub) (string, error) {
 	rows := make([]string, len(vols)+1)
-	rows[0] = "ID|Name|Plugin ID|Schedulable|Access Mode"
+	rows[0] = "ID|Name|Namespace|Plugin ID|Schedulable|Access Mode"
 	for i, v := range vols {
-		rows[i+1] = fmt.Sprintf("%s|%s|%s|%t|%s",
+		rows[i+1] = fmt.Sprintf("%s|%s|%s|%s|%t|%s",
 			v.ID,
 			v.Name,
+			v.Namespace,
 			v.PluginID,
 			v.Schedulable,
 			v.AccessMode,


### PR DESCRIPTION
When looking for CSI volumes to display in the `node status` command the CLI needs to search all namespaces. ~It's also helpful to display the volume namespace in the command output.~ This has been handled by #17911.

Closes https://github.com/hashicorp/nomad/issues/17923