### PR TITLE
fix: allowed metric values documentation for the Nomad APM plugin

### DIFF
--- a/website/content/tools/autoscaling/plugins/apm/nomad.mdx
+++ b/website/content/tools/autoscaling/plugins/apm/nomad.mdx
@@ -78,8 +78,14 @@ The metric value can be:
 - `cpu` - CPU usage as reported by the `nomad.client.allocs.cpu.total_percent`
   metric.
 
+- `cpu-allocated` - the percentage of CPU used out of the total CPU allocated
+for the allocation.
+
 - `memory` - Memory usage as reported by the `nomad.client.allocs.memory.usage`
   metric.
+
+- `memory-allocated` - the percentage of memory used out of the total memory
+allocated for the allocation.
 
 ## Policy Configuration Options - Client Nodes
 
@@ -119,13 +125,7 @@ The metric value can be:
 - `cpu` - allocated CPU as reported by calculating total allocatable against the
   total allocated by the scheduler.
 
-- `cpu-allocated` - the percentage of CPU used out of the total CPU allocated
-  for the allocation.
-
 - `memory` - allocated memory as reported by calculating total allocatable against
   the total allocated by the scheduler.
-
-- `memory-allocated` - the percentage of memory used out of the total memory
-  allocated for the allocation.
 
 [nomad_telemetry_block]: /nomad/docs/configuration/telemetry#inlinecode-publish_allocation_metrics


### PR DESCRIPTION
Based on the [nomad-autoscaler](https://github.com/hashicorp/nomad-autoscaler) codebase and on the [validateMetricTaskGroupQuery](https://github.com/hashicorp/nomad-autoscaler/blob/954f26e8c56526d62f78d6991f5ff2a29dc6fa9f/plugins/builtin/apm/nomad/plugin/job.go#L273) vs [validateMetricNodeQuery](https://github.com/hashicorp/nomad-autoscaler/blob/954f26e8c56526d62f78d6991f5ff2a29dc6fa9f/plugins/builtin/apm/nomad/plugin/node.go#L197), this is how the documentation should look like.