### PR TITLE
feat: improve policy documentation for "query_window" property

### DIFF
--- a/website/content/tools/autoscaling/plugins/apm/nomad.mdx
+++ b/website/content/tools/autoscaling/plugins/apm/nomad.mdx
@@ -8,8 +8,14 @@ description: The "nomad-apm" APM plugin queries the Nomad API for metrics.
 
 The Nomad APM plugin allows querying the Nomad API for metric data. This provides
 an immediate starting point without addition applications but comes at the price
-of efficiency. When using this APM, it is advised to monitor Nomad carefully
-ensuring it is not put under excessive load pressure.
+of efficiency and flexibility. When using this APM, it is advised to monitor
+Nomad carefully ensuring it is not put under excessive load pressure.
+
+Since Nomad does not store historical metric data and only reports instant
+metrics values, the Nomad APM plugin does not support the [`query_window`][]
+policy option and is not able to aggregate metrics over time, such as computing
+averages or percentiles. An external APM is required to support uses cases like
+these.
 
 ~> The Nomad APM plugin should only be used when scaling based on CPU and
 memory usage. For more advanced scenarios, such as scaling a cluster to
@@ -129,3 +135,4 @@ The metric value can be:
   allocated for the allocation.
 
 [nomad_telemetry_block]: /nomad/docs/configuration/telemetry#inlinecode-publish_allocation_metrics
+[`query_window`]: /nomad/tools/autoscaling/policy#query_window

--- a/website/content/tools/autoscaling/policy.mdx
+++ b/website/content/tools/autoscaling/policy.mdx
@@ -65,9 +65,9 @@ horizontal application scaling or horizontal cluster scaling.
   can be found on the [APM Plugins][apm_plugin_docs] page.
 
 - `query_window` - Defines how far back to query the APM for metrics. It should
-  be provided as a duration (e.g.: `"5s"`, `"1m"`). Defaults to `1m`.
-  This value is ignored when the Nomad APM plugin is used,
-  because that doesn't provide historical data.
+  be provided as a duration (e.g.: `"5s"`, `"1m"`). Defaults to `1m`. This
+  value may not be supported by all APM plugins. Refer to the documentation of
+  the specific APM plugin being used for more information.
 
 - `group` - Specifies which checks should treated as correlated when the policy
   is evaluated. Refer to [Check Grouping][concepts_grouping] for more

--- a/website/content/tools/autoscaling/policy.mdx
+++ b/website/content/tools/autoscaling/policy.mdx
@@ -66,6 +66,8 @@ horizontal application scaling or horizontal cluster scaling.
 
 - `query_window` - Defines how far back to query the APM for metrics. It should
   be provided as a duration (e.g.: `"5s"`, `"1m"`). Defaults to `1m`.
+  This value is ignored when the Nomad APM plugin is used,
+  because that doesn't provide historical data.
 
 - `group` - Specifies which checks should treated as correlated when the policy
   is evaluated. Refer to [Check Grouping][concepts_grouping] for more


### PR DESCRIPTION
Based on the [nomad-autoscaler source code](https://github.com/hashicorp/nomad-autoscaler/blob/954f26e8c56526d62f78d6991f5ff2a29dc6fa9f/plugins/builtin/apm/nomad/plugin/metrics.go#L37), the `query_window` property is ignored, if the Nomad APM plugin is in use, because that doesn't have memory.