### PR TITLE
nsd: retain query params in HTTP health checks

### DIFF
--- a/.changelog/17936.txt
+++ b/.changelog/17936.txt
@@ -1,3 +1,3 @@
-```release-note:improvement
-services: Allow passing query parameters in Nomad native service discovery HTTP health checks
+```release-note:bug
+services: Fixed a bug that prevented passing query parameters in Nomad native service discovery HTTP health check paths
 ```

--- a/.changelog/17936.txt
+++ b/.changelog/17936.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+services: Allow passing query parameters in Nomad native service discovery HTTP health checks
+```

--- a/client/serviceregistration/checks/client.go
+++ b/client/serviceregistration/checks/client.go
@@ -155,11 +155,18 @@ func (c *checker) checkHTTP(ctx context.Context, qc *QueryContext, q *Query) *st
 		return qr
 	}
 
-	u := (&url.URL{
+	relative, err := url.Parse(q.Path)
+	if err != nil {
+		qr.Output = err.Error()
+		qr.Status = structs.CheckFailure
+		return qr
+	}
+
+	base := url.URL{
 		Scheme: q.Protocol,
 		Host:   addr,
-		Path:   q.Path,
-	}).String()
+	}
+	u := base.ResolveReference(relative).String()
 
 	request, err := http.NewRequest(q.Method, u, nil)
 	if err != nil {

--- a/client/serviceregistration/checks/client_test.go
+++ b/client/serviceregistration/checks/client_test.go
@@ -39,6 +39,19 @@ func TestChecker_Do_HTTP(t *testing.T) {
 
 	// create an http server with various responses
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// handle query param requests with string match because we want to
+		// test the path is set correctly instead of with escaped query params.
+		if strings.Contains(r.URL.Path, "query-param") {
+			if r.URL.RawQuery == "" {
+				w.WriteHeader(400)
+				_, _ = io.WriteString(w, "400 bad request")
+			} else {
+				w.WriteHeader(200)
+				_, _ = io.WriteString(w, "200 ok")
+			}
+			return
+		}
+
 		switch r.URL.Path {
 		case "/fail":
 			w.WriteHeader(500)
@@ -181,6 +194,16 @@ func TestChecker_Do_HTTP(t *testing.T) {
 			structs.CheckSuccess,
 			http.StatusCreated,
 			truncate,
+		),
+	}, {
+		name: "query param",
+		qc:   makeQueryContext(),
+		q:    makeQuery(structs.Healthiness, "query-param?a=b"),
+		expResult: makeExpResult(
+			structs.Healthiness,
+			structs.CheckSuccess,
+			http.StatusOK,
+			"nomad: http ok",
 		),
 	}}
 


### PR DESCRIPTION
Apply the [same logic as Consul service health checks](https://github.com/hashicorp/nomad/blob/437941816c6b84f4b756f694fe42cb028ff50e65/command/agent/consul/service_client.go#L1658-L1667) when building the HTTP URL so that query params in `path` are preserved.

Closes https://github.com/hashicorp/nomad/issues/17790