### PR TITLE
metrics: report task memory_max value

### DIFF
--- a/.changelog/17938.txt
+++ b/.changelog/17938.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+metrics: Add `allocs.memory.max_allocated` to report the value of tasks' `memory_max` resource value
+```

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -1482,9 +1482,11 @@ func (tr *TaskRunner) UpdateStats(ru *cstructs.TaskResourceUsage) {
 func (tr *TaskRunner) setGaugeForMemory(ru *cstructs.TaskResourceUsage) {
 	alloc := tr.Alloc()
 	var allocatedMem float32
+	var allocatedMemMax float32
 	if taskRes := alloc.AllocatedResources.Tasks[tr.taskName]; taskRes != nil {
 		// Convert to bytes to match other memory metrics
 		allocatedMem = float32(taskRes.Memory.MemoryMB) * 1024 * 1024
+		allocatedMemMax = float32(taskRes.Memory.MemoryMaxMB) * 1024 * 1024
 	}
 
 	ms := ru.ResourceUsage.MemoryStats
@@ -1507,6 +1509,10 @@ func (tr *TaskRunner) setGaugeForMemory(ru *cstructs.TaskResourceUsage) {
 	if allocatedMem > 0 {
 		metrics.SetGaugeWithLabels([]string{"client", "allocs", "memory", "allocated"},
 			allocatedMem, tr.baseLabels)
+	}
+	if allocatedMemMax > 0 {
+		metrics.SetGaugeWithLabels([]string{"client", "allocs", "memory", "max_allocated"},
+			allocatedMemMax, tr.baseLabels)
 	}
 }
 

--- a/website/content/docs/operations/metrics-reference.mdx
+++ b/website/content/docs/operations/metrics-reference.mdx
@@ -202,10 +202,10 @@ task driver; not all task drivers can provide all metrics.
 | `nomad.client.allocs.cpu.user`                | Total CPU resources consumed by the task in the user space        | Percentage  | Gauge   | alloc_id, host, job, namespace, task, task_group |
 | `nomad.client.allocs.failed`                  | Number of failed allocations                                      | Integer     | Counter | alloc_id, host, job, namespace, task, task_group |
 | `nomad.client.allocs.memory.allocated`        | Amount of memory allocated by the task                            | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.memory.max_allocated`    | Maximum amount of oversubscription memory allocated by the task   | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
 | `nomad.client.allocs.memory.cache`            | Amount of memory cached by the task                               | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
 | `nomad.client.allocs.memory.kernel_max_usage` | Maximum amount of memory ever used by the kernel for this task    | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
 | `nomad.client.allocs.memory.kernel_usage`     | Amount of memory used by the kernel for this task                 | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.memory.max_allocated`    | Maximum amount of oversubscription memory allocated by the task   | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
 | `nomad.client.allocs.memory.max_usage`        | Maximum amount of memory ever used by the task                    | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
 | `nomad.client.allocs.memory.rss`              | Amount of RSS memory consumed by the task                         | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
 | `nomad.client.allocs.memory.swap`             | Amount of memory swapped by the task                              | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |

--- a/website/content/docs/operations/metrics-reference.mdx
+++ b/website/content/docs/operations/metrics-reference.mdx
@@ -202,6 +202,7 @@ task driver; not all task drivers can provide all metrics.
 | `nomad.client.allocs.cpu.user`                | Total CPU resources consumed by the task in the user space        | Percentage  | Gauge   | alloc_id, host, job, namespace, task, task_group |
 | `nomad.client.allocs.failed`                  | Number of failed allocations                                      | Integer     | Counter | alloc_id, host, job, namespace, task, task_group |
 | `nomad.client.allocs.memory.allocated`        | Amount of memory allocated by the task                            | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.memory.max_allocated`    | Maximum amount of oversubscription memory allocated by the task   | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
 | `nomad.client.allocs.memory.cache`            | Amount of memory cached by the task                               | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
 | `nomad.client.allocs.memory.kernel_max_usage` | Maximum amount of memory ever used by the kernel for this task    | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
 | `nomad.client.allocs.memory.kernel_usage`     | Amount of memory used by the kernel for this task                 | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |


### PR DESCRIPTION
Add new `nomad.client.allocs.memory.max_allocated` metric to report the value of the task `memory_max` resource value.

Closes https://github.com/hashicorp/nomad/issues/17716