### PR TITLE
Add missing consul grpc config

### DIFF
--- a/terraform/shared/config/consul.json
+++ b/terraform/shared/config/consul.json
@@ -10,5 +10,11 @@
   "service": {
     "name": "consul"
   },
-  "retry_join": ["RETRY_JOIN"]
+  "retry_join": ["RETRY_JOIN"],
+  "ports": {
+    "grpc": 8502
+  },
+  "connect": {
+    "enabled": true
+  }
 }

--- a/terraform/shared/config/consul_client.json
+++ b/terraform/shared/config/consul_client.json
@@ -5,5 +5,8 @@
   "bind_addr": "0.0.0.0",
   "client_addr": "0.0.0.0",
   "advertise_addr": "IP_ADDRESS",
-  "retry_join": ["RETRY_JOIN"]
+  "retry_join": ["RETRY_JOIN"],
+  "ports": {
+    "grpc": 8502
+  }
 }


### PR DESCRIPTION
This Terraform folder is for quickly building an integrated Nomad/Consul cluster on the cloud. To avoid Job submission failures with Consul as the provider, it requires to include grpc port `8502` and enable the `connect` option in the configuration.