### PR TITLE
docs: note windows requirement for workload identity

### DIFF
--- a/website/content/api-docs/task-api.mdx
+++ b/website/content/api-docs/task-api.mdx
@@ -92,6 +92,11 @@ the outcome by searching for the updated Node's metadata:
 $ nomad node status -filter 'Meta.example == "Hello World!"'
 ```
 
+## Limitations
+
+- Using the Task API Unix Domain Socket on Windows [requires][windows] Windows
+build 17063 or later.
+
 [acl]: /nomad/docs/concepts/acl
 [acl-tokens]: /nomad/docs/concepts/acl#token
 [alloc-exec]: /nomad/docs/commands/alloc/exec
@@ -100,3 +105,4 @@ $ nomad node status -filter 'Meta.example == "Hello World!"'
 [mTLS]: /nomad/tutorials/transport-security/security-enable-tls
 [task-user]: /nomad/docs/job-specification/task#user
 [workload-id]: /nomad/docs/concepts/workload-identity
+[windows]: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/

--- a/website/content/docs/concepts/workload-identity.mdx
+++ b/website/content/docs/concepts/workload-identity.mdx
@@ -98,6 +98,11 @@ nomad acl policy apply \
    redis-policy ./policy.hcl
 ```
 
+## Task API
+
+It can be convenient to combine workload identity with Nomad's [Task API]
+[taskapi] for  enabling tasks to access the Nomad API.
+
 [allocation]: /nomad/docs/concepts/architecture#allocation
 [identity-block]: /nomad/docs/job-specification/identity
 [plan applier]: /nomad/docs/concepts/scheduling/scheduling
@@ -105,3 +110,5 @@ nomad acl policy apply \
 [Task Access to Variables]: /nomad/docs/concepts/variables#task-access-to-variables
 [List Services API]: /nomad/api-docs/services#list-services
 [Read Service API]: /nomad/api-docs/services#read-service
+[windows]: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
+[taskapi]: /nomad/api-docs/task-api

--- a/website/content/docs/job-specification/identity.mdx
+++ b/website/content/docs/job-specification/identity.mdx
@@ -47,5 +47,12 @@ job "docs" {
   readable by that user. Otherwise the file is readable by everyone but is
   protected by parent directory permissions.
 
+## Task API
+
+It can be convenient to combine workload identity with Nomad's [Task API]
+[taskapi] for  enabling tasks to access the Nomad API.
+
 [taskuser]: /nomad/docs/job-specification/task#user "Nomad task Block"
 [Workload Identity]: /nomad/docs/concepts/workload-identity "Nomad Workload Identity"
+[windows]: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
+[taskapi]: /nomad/api-docs/task-api


### PR DESCRIPTION
Support for UDS sockets was added to Windows 10 (build 17063), make a note in the Task API docs. Also reference Task API from WI  pages since it's a common use case to combine the two features.

https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
