### PR TITLE
chore(lint): use Go stdlib variables for HTTP methods and status codes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -103,5 +103,6 @@ linters:
     # - errchkjson (todo)
     # - errorlint (todo)
     - exportloopref
+    - usestdlibvars
   fast: false
 

--- a/client/allocrunner/checks_hook_test.go
+++ b/client/allocrunner/checks_hook_test.go
@@ -130,13 +130,13 @@ func allocWithDifferentNomadChecks(id, addr, port string) *structs.Allocation {
 var checkHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
 	case "/fail":
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = io.WriteString(w, "500 problem")
 	case "/hang":
 		time.Sleep(2 * time.Second)
 		_, _ = io.WriteString(w, "too slow")
 	default:
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, "200 ok")
 	}
 })

--- a/client/fingerprint/env_azure.go
+++ b/client/fingerprint/env_azure.go
@@ -82,7 +82,7 @@ func (f *EnvAzureFingerprint) Get(attribute string, format string) (string, erro
 	}
 
 	req := &http.Request{
-		Method: "GET",
+		Method: http.MethodGet,
 		URL:    parsedURL,
 		Header: http.Header{
 			"Metadata":   []string{"true"},

--- a/client/fingerprint/env_azure_test.go
+++ b/client/fingerprint/env_azure_test.go
@@ -91,7 +91,7 @@ func testFingerprint_Azure(t *testing.T, withExternalIp bool) {
 		}
 
 		if !found {
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
 	defer ts.Close()

--- a/client/fingerprint/env_digitalocean_test.go
+++ b/client/fingerprint/env_digitalocean_test.go
@@ -77,7 +77,7 @@ func TestFingerprint_DigitalOcean(t *testing.T) {
 		}
 
 		if !found {
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
 	defer ts.Close()

--- a/client/fingerprint/env_gce.go
+++ b/client/fingerprint/env_gce.go
@@ -97,7 +97,7 @@ func (f *EnvGCEFingerprint) Get(attribute string, recursive bool) (string, error
 	}
 
 	req := &http.Request{
-		Method: "GET",
+		Method: http.MethodGet,
 		URL:    parsedUrl,
 		Header: http.Header{
 			"Metadata-Flavor": []string{"Google"},

--- a/client/fingerprint/env_gce_test.go
+++ b/client/fingerprint/env_gce_test.go
@@ -88,7 +88,7 @@ func testFingerprint_GCE(t *testing.T, withExternalIp bool) {
 		}
 
 		if !found {
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
 	defer ts.Close()

--- a/client/serviceregistration/checks/client.go
+++ b/client/serviceregistration/checks/client.go
@@ -196,11 +196,11 @@ func (c *checker) checkHTTP(ctx context.Context, qc *QueryContext, q *Query) *st
 	qr.StatusCode = result.StatusCode
 
 	switch {
-	case result.StatusCode == 200:
+	case result.StatusCode == http.StatusOK:
 		qr.Status = structs.CheckSuccess
 		qr.Output = "nomad: http ok"
 		return qr
-	case result.StatusCode < 400:
+	case result.StatusCode < http.StatusBadRequest:
 		qr.Status = structs.CheckSuccess
 	default:
 		qr.Status = structs.CheckFailure

--- a/client/serviceregistration/checks/client_test.go
+++ b/client/serviceregistration/checks/client_test.go
@@ -41,19 +41,19 @@ func TestChecker_Do_HTTP(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/fail":
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = io.WriteString(w, "500 problem")
 		case "/hang":
 			time.Sleep(1 * time.Second)
 			_, _ = io.WriteString(w, "too slow")
 		case "/long-fail":
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = io.WriteString(w, tooLong)
 		case "/long-not-fail":
-			w.WriteHeader(201)
+			w.WriteHeader(http.StatusCreated)
 			_, _ = io.WriteString(w, tooLong)
 		default:
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 			_, _ = io.WriteString(w, "200 ok")
 		}
 	}))

--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *HTTPServer) ACLPoliciesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
@@ -39,11 +39,11 @@ func (s *HTTPServer) ACLPolicySpecificRequest(resp http.ResponseWriter, req *htt
 		return nil, CodedError(400, "Missing Policy Name")
 	}
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		return s.aclPolicyQuery(resp, req, name)
-	case "PUT", "POST":
+	case http.MethodPut, http.MethodPost:
 		return s.aclPolicyUpdate(resp, req, name)
-	case "DELETE":
+	case http.MethodDelete:
 		return s.aclPolicyDelete(resp, req, name)
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)
@@ -115,7 +115,7 @@ func (s *HTTPServer) aclPolicyDelete(resp http.ResponseWriter, req *http.Request
 }
 
 func (s *HTTPServer) ACLTokensRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
@@ -187,11 +187,11 @@ func (s *HTTPServer) aclTokenCrud(resp http.ResponseWriter, req *http.Request,
 	}
 
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		return s.aclTokenQuery(resp, req, tokenAccessor)
-	case "PUT", "POST":
+	case http.MethodPut, http.MethodPost:
 		return s.aclTokenUpdate(resp, req, tokenAccessor)
-	case "DELETE":
+	case http.MethodDelete:
 		return s.aclTokenDelete(resp, req, tokenAccessor)
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)
@@ -220,7 +220,7 @@ func (s *HTTPServer) aclTokenQuery(resp http.ResponseWriter, req *http.Request,
 }
 
 func (s *HTTPServer) aclTokenSelf(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 	args := structs.ResolveACLTokenRequest{}

--- a/command/agent/acl_endpoint_test.go
+++ b/command/agent/acl_endpoint_test.go
@@ -42,7 +42,7 @@ func TestHTTP_ACLPolicyList(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/acl/policies", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/acl/policies", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -91,7 +91,7 @@ func TestHTTP_ACLPolicyQuery(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/acl/policy/"+p1.Name, nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/acl/policy/"+p1.Name, nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -129,7 +129,7 @@ func TestHTTP_ACLPolicyCreate(t *testing.T) {
 		// Make the HTTP request
 		p1 := mock.ACLPolicy()
 		buf := encodeReq(p1)
-		req, err := http.NewRequest("PUT", "/v1/acl/policy/"+p1.Name, buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/acl/policy/"+p1.Name, buf)
 		must.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -190,7 +190,7 @@ func TestHTTP_ACLPolicyDelete(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("DELETE", "/v1/acl/policy/"+p1.Name, nil)
+		req, err := http.NewRequest(http.MethodDelete, "/v1/acl/policy/"+p1.Name, nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -223,7 +223,7 @@ func TestHTTP_ACLTokenBootstrap(t *testing.T) {
 	}
 	httpTest(t, conf, func(s *TestAgent) {
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/acl/bootstrap", nil)
+		req, err := http.NewRequest(http.MethodPut, "/v1/acl/bootstrap", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -262,7 +262,7 @@ func TestHTTP_ACLTokenBootstrapOperator(t *testing.T) {
 		buf := encodeReq(args)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/acl/bootstrap", buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/acl/bootstrap", buf)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -312,7 +312,7 @@ func TestHTTP_ACLTokenList(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/acl/tokens", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/acl/tokens", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -363,7 +363,7 @@ func TestHTTP_ACLTokenQuery(t *testing.T) {
 		out := resp.Tokens[0]
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/acl/token/"+out.AccessorID, nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/acl/token/"+out.AccessorID, nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -412,7 +412,7 @@ func TestHTTP_ACLTokenSelf(t *testing.T) {
 		out := resp.Tokens[0]
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/acl/token/self", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/acl/token/self", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -449,7 +449,7 @@ func TestHTTP_ACLTokenCreate(t *testing.T) {
 		p1 := mock.ACLToken()
 		p1.AccessorID = ""
 		buf := encodeReq(p1)
-		req, err := http.NewRequest("PUT", "/v1/acl/token", buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/acl/token", buf)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -491,7 +491,7 @@ func TestHTTP_ACLTokenCreateExpirationTTL(t *testing.T) {
   "Global": false
 }`
 
-		req, err := http.NewRequest("PUT", "/v1/acl/token", bytes.NewReader([]byte(aclToken)))
+		req, err := http.NewRequest(http.MethodPut, "/v1/acl/token", bytes.NewReader([]byte(aclToken)))
 		must.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -537,7 +537,7 @@ func TestHTTP_ACLTokenDelete(t *testing.T) {
 		ID := resp.Tokens[0].AccessorID
 
 		// Make the HTTP request
-		req, err := http.NewRequest("DELETE", "/v1/acl/token/"+ID, nil)
+		req, err := http.NewRequest(http.MethodDelete, "/v1/acl/token/"+ID, nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -585,7 +585,7 @@ func TestHTTP_OneTimeToken(t *testing.T) {
 
 		// Make a HTTP request to get a one-time token
 
-		req, err := http.NewRequest("POST", "/v1/acl/token/onetime", nil)
+		req, err := http.NewRequest(http.MethodPost, "/v1/acl/token/onetime", nil)
 		require.NoError(t, err)
 		req.Header.Set("X-Nomad-Token", aclSecret)
 		respW := httptest.NewRecorder()
@@ -602,7 +602,7 @@ func TestHTTP_OneTimeToken(t *testing.T) {
 
 		buf := encodeReq(structs.OneTimeTokenExchangeRequest{
 			OneTimeSecretID: ott.OneTimeToken.OneTimeSecretID})
-		req, err = http.NewRequest("POST", "/v1/acl/token/onetime/exchange", buf)
+		req, err = http.NewRequest(http.MethodPost, "/v1/acl/token/onetime/exchange", buf)
 		require.NoError(t, err)
 		respW = httptest.NewRecorder()
 
@@ -618,7 +618,7 @@ func TestHTTP_OneTimeToken(t *testing.T) {
 
 		buf = encodeReq(structs.OneTimeTokenExchangeRequest{
 			OneTimeSecretID: ott.OneTimeToken.OneTimeSecretID})
-		req, err = http.NewRequest("POST", "/v1/acl/token/onetime/exchange", buf)
+		req, err = http.NewRequest(http.MethodPost, "/v1/acl/token/onetime/exchange", buf)
 		require.NoError(t, err)
 		respW = httptest.NewRecorder()
 

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -59,7 +59,7 @@ func nomadMember(m serf.Member) Member {
 }
 
 func (s *HTTPServer) AgentSelfRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
@@ -131,7 +131,7 @@ func (s *HTTPServer) AgentJoinRequest(resp http.ResponseWriter, req *http.Reques
 }
 
 func (s *HTTPServer) AgentMembersRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
@@ -418,9 +418,9 @@ func (s *HTTPServer) agentPprof(reqType pprof.ReqType, resp http.ResponseWriter,
 // servers for a given agent.
 func (s *HTTPServer) AgentServersRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	switch req.Method {
-	case "PUT", "POST":
+	case http.MethodPut, http.MethodPost:
 		return s.updateServers(resp, req)
-	case "GET":
+	case http.MethodGet:
 		return s.listServers(resp, req)
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)
@@ -552,7 +552,7 @@ type joinResult struct {
 }
 
 func (s *HTTPServer) HealthRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -41,7 +41,7 @@ func TestHTTP_AgentSelf(t *testing.T) {
 
 	httpTest(t, nil, func(s *TestAgent) {
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/agent/self", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/agent/self", nil)
 		require.NoError(err)
 		respW := httptest.NewRecorder()
 
@@ -106,7 +106,7 @@ func TestHTTP_AgentSelf_ACL(t *testing.T) {
 		state := s.Agent.server.State()
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/agent/self", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/agent/self", nil)
 		require.Nil(err)
 
 		// Try request without a token and expect failure
@@ -162,7 +162,7 @@ func TestHTTP_AgentJoin(t *testing.T) {
 		addr := net.JoinHostPort(member.Addr.String(), strconv.Itoa(int(member.Port)))
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT",
+		req, err := http.NewRequest(http.MethodPut,
 			fmt.Sprintf("/v1/agent/join?address=%s&address=%s", addr, addr), nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
@@ -190,7 +190,7 @@ func TestHTTP_AgentMembers(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/agent/members", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/agent/members", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -218,7 +218,7 @@ func TestHTTP_AgentMembers_ACL(t *testing.T) {
 		state := s.Agent.server.State()
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/agent/members", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/agent/members", nil)
 		require.Nil(err)
 
 		// Try request without a token and expect failure
@@ -269,7 +269,7 @@ func TestHTTP_AgentMonitor(t *testing.T) {
 
 	t.Run("invalid log_json parameter", func(t *testing.T) {
 		httpTest(t, nil, func(s *TestAgent) {
-			req, err := http.NewRequest("GET", "/v1/agent/monitor?log_json=no", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/agent/monitor?log_json=no", nil)
 			require.NoError(t, err)
 			resp := newClosableRecorder()
 
@@ -282,7 +282,7 @@ func TestHTTP_AgentMonitor(t *testing.T) {
 
 	t.Run("unknown log_level", func(t *testing.T) {
 		httpTest(t, nil, func(s *TestAgent) {
-			req, err := http.NewRequest("GET", "/v1/agent/monitor?log_level=unknown", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/agent/monitor?log_level=unknown", nil)
 			require.NoError(t, err)
 			resp := newClosableRecorder()
 
@@ -295,7 +295,7 @@ func TestHTTP_AgentMonitor(t *testing.T) {
 
 	t.Run("check for specific log level", func(t *testing.T) {
 		httpTest(t, nil, func(s *TestAgent) {
-			req, err := http.NewRequest("GET", "/v1/agent/monitor?log_level=warn", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/agent/monitor?log_level=warn", nil)
 			require.NoError(t, err)
 			resp := newClosableRecorder()
 			defer resp.Close()
@@ -329,7 +329,7 @@ func TestHTTP_AgentMonitor(t *testing.T) {
 
 	t.Run("plain output", func(t *testing.T) {
 		httpTest(t, nil, func(s *TestAgent) {
-			req, err := http.NewRequest("GET", "/v1/agent/monitor?log_level=debug&plain=true", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/agent/monitor?log_level=debug&plain=true", nil)
 			require.NoError(t, err)
 			resp := newClosableRecorder()
 			defer resp.Close()
@@ -363,7 +363,7 @@ func TestHTTP_AgentMonitor(t *testing.T) {
 
 	t.Run("logs for a specific node", func(t *testing.T) {
 		httpTest(t, nil, func(s *TestAgent) {
-			req, err := http.NewRequest("GET", "/v1/agent/monitor?log_level=warn&node_id="+s.client.NodeID(), nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/agent/monitor?log_level=warn&node_id="+s.client.NodeID(), nil)
 			require.NoError(t, err)
 			resp := newClosableRecorder()
 			defer resp.Close()
@@ -403,7 +403,7 @@ func TestHTTP_AgentMonitor(t *testing.T) {
 
 	t.Run("logs for a local client with no server running on agent", func(t *testing.T) {
 		httpTest(t, nil, func(s *TestAgent) {
-			req, err := http.NewRequest("GET", "/v1/agent/monitor?log_level=warn", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/agent/monitor?log_level=warn", nil)
 			require.NoError(t, err)
 			resp := newClosableRecorder()
 			defer resp.Close()
@@ -508,7 +508,7 @@ func TestAgent_PprofRequest_Permissions(t *testing.T) {
 				httpTest(t, cb, func(s *TestAgent) {
 					state := s.Agent.server.State()
 					url := "/v1/agent/pprof/cmdline"
-					req, err := http.NewRequest("GET", url, nil)
+					req, err := http.NewRequest(http.MethodGet, url, nil)
 					require.NoError(t, err)
 					respW := httptest.NewRecorder()
 
@@ -605,7 +605,7 @@ func TestAgent_PprofRequest(t *testing.T) {
 					s.Agent.server = nil
 				}
 
-				req, err := http.NewRequest("GET", url, nil)
+				req, err := http.NewRequest(http.MethodGet, url, nil)
 				require.NoError(t, err)
 				respW := httptest.NewRecorder()
 
@@ -646,7 +646,7 @@ func TestHTTP_AgentForceLeave(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/agent/force-leave?node=foo", nil)
+		req, err := http.NewRequest(http.MethodPut, "/v1/agent/force-leave?node=foo", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -668,7 +668,7 @@ func TestHTTP_AgentForceLeave_ACL(t *testing.T) {
 		state := s.Agent.server.State()
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/agent/force-leave?node=foo", nil)
+		req, err := http.NewRequest(http.MethodPut, "/v1/agent/force-leave?node=foo", nil)
 		require.Nil(err)
 
 		// Try request without a token and expect failure
@@ -737,7 +737,7 @@ func TestHTTP_AgentSetServers(t *testing.T) {
 		})
 
 		// Create the request
-		req, err := http.NewRequest("PUT", "/v1/agent/servers", nil)
+		req, err := http.NewRequest(http.MethodPut, "/v1/agent/servers", nil)
 		require.Nil(err)
 
 		// Send the request
@@ -747,7 +747,7 @@ func TestHTTP_AgentSetServers(t *testing.T) {
 		require.Contains(err.Error(), "missing server address")
 
 		// Create a valid request
-		req, err = http.NewRequest("PUT", "/v1/agent/servers?address=127.0.0.1%3A4647&address=127.0.0.2%3A4647&address=127.0.0.3%3A4647", nil)
+		req, err = http.NewRequest(http.MethodPut, "/v1/agent/servers?address=127.0.0.1%3A4647&address=127.0.0.2%3A4647&address=127.0.0.3%3A4647", nil)
 		require.Nil(err)
 
 		// Send the request which should fail
@@ -756,7 +756,7 @@ func TestHTTP_AgentSetServers(t *testing.T) {
 		require.NotNil(err)
 
 		// Retrieve the servers again
-		req, err = http.NewRequest("GET", "/v1/agent/servers", nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/agent/servers", nil)
 		require.Nil(err)
 		respW = httptest.NewRecorder()
 
@@ -802,7 +802,7 @@ func TestHTTP_AgentSetServers_ACL(t *testing.T) {
 
 		// Make the HTTP request
 		path := fmt.Sprintf("/v1/agent/servers?address=%s", url.QueryEscape(s.GetConfig().AdvertiseAddrs.RPC))
-		req, err := http.NewRequest("PUT", path, nil)
+		req, err := http.NewRequest(http.MethodPut, path, nil)
 		require.Nil(err)
 
 		// Try request without a token and expect failure
@@ -852,7 +852,7 @@ func TestHTTP_AgentListServers_ACL(t *testing.T) {
 		state := s.Agent.server.State()
 
 		// Create list request
-		req, err := http.NewRequest("GET", "/v1/agent/servers", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/agent/servers", nil)
 		require.Nil(err)
 
 		expected := []string{
@@ -917,7 +917,7 @@ func TestHTTP_AgentListKeys(t *testing.T) {
 	httpTest(t, func(c *Config) {
 		c.Server.EncryptKey = key1
 	}, func(s *TestAgent) {
-		req, err := http.NewRequest("GET", "/v1/agent/keyring/list", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/agent/keyring/list", nil)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -944,7 +944,7 @@ func TestHTTP_AgentListKeys_ACL(t *testing.T) {
 		state := s.Agent.server.State()
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/agent/keyring/list", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/agent/keyring/list", nil)
 		require.Nil(err)
 
 		// Try request without a token and expect failure
@@ -1003,7 +1003,7 @@ func TestHTTP_AgentInstallKey(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		req, err := http.NewRequest("GET", "/v1/agent/keyring/install", bytes.NewReader(b))
+		req, err := http.NewRequest(http.MethodGet, "/v1/agent/keyring/install", bytes.NewReader(b))
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -1013,7 +1013,7 @@ func TestHTTP_AgentInstallKey(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
-		req, err = http.NewRequest("GET", "/v1/agent/keyring/list", bytes.NewReader(b))
+		req, err = http.NewRequest(http.MethodGet, "/v1/agent/keyring/list", bytes.NewReader(b))
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -1044,7 +1044,7 @@ func TestHTTP_AgentRemoveKey(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
-		req, err := http.NewRequest("GET", "/v1/agent/keyring/install", bytes.NewReader(b))
+		req, err := http.NewRequest(http.MethodGet, "/v1/agent/keyring/install", bytes.NewReader(b))
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -1054,7 +1054,7 @@ func TestHTTP_AgentRemoveKey(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		req, err = http.NewRequest("GET", "/v1/agent/keyring/remove", bytes.NewReader(b))
+		req, err = http.NewRequest(http.MethodGet, "/v1/agent/keyring/remove", bytes.NewReader(b))
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -1063,7 +1063,7 @@ func TestHTTP_AgentRemoveKey(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		req, err = http.NewRequest("GET", "/v1/agent/keyring/list", nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/agent/keyring/list", nil)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -1087,7 +1087,7 @@ func TestHTTP_AgentHealth_Ok(t *testing.T) {
 	httpACLTest(t, nil, func(s *TestAgent) {
 		// No ?type=
 		{
-			req, err := http.NewRequest("GET", "/v1/agent/health", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/agent/health", nil)
 			require.Nil(err)
 
 			respW := httptest.NewRecorder()
@@ -1106,7 +1106,7 @@ func TestHTTP_AgentHealth_Ok(t *testing.T) {
 
 		// type=client
 		{
-			req, err := http.NewRequest("GET", "/v1/agent/health?type=client", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/agent/health?type=client", nil)
 			require.Nil(err)
 
 			respW := httptest.NewRecorder()
@@ -1123,7 +1123,7 @@ func TestHTTP_AgentHealth_Ok(t *testing.T) {
 
 		// type=server
 		{
-			req, err := http.NewRequest("GET", "/v1/agent/health?type=server", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/agent/health?type=server", nil)
 			require.Nil(err)
 
 			respW := httptest.NewRecorder()
@@ -1140,7 +1140,7 @@ func TestHTTP_AgentHealth_Ok(t *testing.T) {
 
 		// type=client&type=server
 		{
-			req, err := http.NewRequest("GET", "/v1/agent/health?type=client&type=server", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/agent/health?type=client&type=server", nil)
 			require.Nil(err)
 
 			respW := httptest.NewRecorder()
@@ -1175,7 +1175,7 @@ func TestHTTP_AgentHealth_BadServer(t *testing.T) {
 
 	// No ?type= means server is just skipped
 	{
-		req, err := http.NewRequest("GET", "/v1/agent/health", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/agent/health", nil)
 		require.Nil(err)
 
 		respW := httptest.NewRecorder()
@@ -1192,7 +1192,7 @@ func TestHTTP_AgentHealth_BadServer(t *testing.T) {
 
 	// type=server means server is considered unhealthy
 	{
-		req, err := http.NewRequest("GET", "/v1/agent/health?type=server", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/agent/health?type=server", nil)
 		require.Nil(err)
 
 		respW := httptest.NewRecorder()
@@ -1218,7 +1218,7 @@ func TestHTTP_AgentHealth_BadClient(t *testing.T) {
 	httpACLTest(t, cb, func(s *TestAgent) {
 		// No ?type= means client is just skipped
 		{
-			req, err := http.NewRequest("GET", "/v1/agent/health", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/agent/health", nil)
 			require.Nil(err)
 
 			respW := httptest.NewRecorder()
@@ -1235,7 +1235,7 @@ func TestHTTP_AgentHealth_BadClient(t *testing.T) {
 
 		// type=client means client is considered unhealthy
 		{
-			req, err := http.NewRequest("GET", "/v1/agent/health?type=client", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/agent/health?type=client", nil)
 			require.Nil(err)
 
 			respW := httptest.NewRecorder()
@@ -1396,7 +1396,7 @@ func TestHTTP_XSS_Monitor(t *testing.T) {
 			defer s.Shutdown()
 
 			path := fmt.Sprintf("%s/v1/agent/monitor?error_level=error&plain=%t", s.HTTPAddr(), !tc.JSON)
-			req, err := http.NewRequest("GET", path, nil)
+			req, err := http.NewRequest(http.MethodGet, path, nil)
 			require.NoError(t, err)
 			resp := NewFakeRW()
 			closedErr := errors.New("sentinel error")
@@ -1562,7 +1562,7 @@ func schedulerWorkerInfoTest_testCases() []schedulerWorkerAPITest_testCase {
 		{
 			name: "get without token",
 			request: schedulerWorkerAPITest_testRequest{
-				verb:        "GET",
+				verb:        http.MethodGet,
 				aclToken:    "",
 				requestBody: "",
 			},
@@ -1572,7 +1572,7 @@ func schedulerWorkerInfoTest_testCases() []schedulerWorkerAPITest_testCase {
 		{
 			name: "get with management token",
 			request: schedulerWorkerAPITest_testRequest{
-				verb:        "GET",
+				verb:        http.MethodGet,
 				aclToken:    "management",
 				requestBody: "",
 			},
@@ -1582,7 +1582,7 @@ func schedulerWorkerInfoTest_testCases() []schedulerWorkerAPITest_testCase {
 		{
 			name: "get with read token",
 			request: schedulerWorkerAPITest_testRequest{
-				verb:        "GET",
+				verb:        http.MethodGet,
 				aclToken:    "agent_read",
 				requestBody: "",
 			},
@@ -1592,7 +1592,7 @@ func schedulerWorkerInfoTest_testCases() []schedulerWorkerAPITest_testCase {
 		{
 			name: "get with invalid token",
 			request: schedulerWorkerAPITest_testRequest{
-				verb:        "GET",
+				verb:        http.MethodGet,
 				aclToken:    "node_write",
 				requestBody: "",
 			},
@@ -1736,7 +1736,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "get without token",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "GET",
+				verb:        http.MethodGet,
 				aclToken:    "",
 				requestBody: "",
 			},
@@ -1746,7 +1746,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "get with management token",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "GET",
+				verb:        http.MethodGet,
 				aclToken:    "management",
 				requestBody: "",
 			},
@@ -1756,7 +1756,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "get with read token",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "GET",
+				verb:        http.MethodGet,
 				aclToken:    "agent_read",
 				requestBody: "",
 			},
@@ -1766,7 +1766,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "get with write token",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "GET",
+				verb:        http.MethodGet,
 				aclToken:    "agent_write",
 				requestBody: "",
 			},
@@ -1776,7 +1776,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "post with no token",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "POST",
+				verb:        http.MethodPost,
 				aclToken:    "",
 				requestBody: `{"num_schedulers":9,"enabled_schedulers":["_core", "batch"]}`,
 			},
@@ -1786,7 +1786,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "put with no token",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "PUT",
+				verb:        http.MethodPut,
 				aclToken:    "",
 				requestBody: `{"num_schedulers":8,"enabled_schedulers":["_core", "batch"]}`,
 			},
@@ -1796,7 +1796,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "post with invalid token",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "POST",
+				verb:        http.MethodPost,
 				aclToken:    "node_write",
 				requestBody: `{"num_schedulers":9,"enabled_schedulers":["_core", "batch"]}`,
 			},
@@ -1806,7 +1806,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "put with invalid token",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "PUT",
+				verb:        http.MethodPut,
 				aclToken:    "node_write",
 				requestBody: `{"num_schedulers":8,"enabled_schedulers":["_core", "batch"]}`,
 			},
@@ -1816,7 +1816,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "post with valid token",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "POST",
+				verb:        http.MethodPost,
 				aclToken:    "agent_write",
 				requestBody: `{"num_schedulers":9,"enabled_schedulers":["_core", "batch"]}`,
 			},
@@ -1826,7 +1826,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "put with valid token",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "PUT",
+				verb:        http.MethodPut,
 				aclToken:    "agent_write",
 				requestBody: `{"num_schedulers":8,"enabled_schedulers":["_core", "batch"]}`,
 			},
@@ -1836,7 +1836,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "post with good token and bad value",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "POST",
+				verb:        http.MethodPost,
 				aclToken:    "agent_write",
 				requestBody: `{"num_schedulers":-1,"enabled_schedulers":["_core", "batch"]}`,
 			},
@@ -1846,7 +1846,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "post with bad token and bad value",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "POST",
+				verb:        http.MethodPost,
 				aclToken:    "node_write",
 				requestBody: `{"num_schedulers":-1,"enabled_schedulers":["_core", "batch"]}`,
 			},
@@ -1856,7 +1856,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "put with good token and bad value",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "PUT",
+				verb:        http.MethodPut,
 				aclToken:    "agent_write",
 				requestBody: `{"num_schedulers":-1,"enabled_schedulers":["_core", "batch"]}`,
 			},
@@ -1866,7 +1866,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "put with bad token and bad value",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "PUT",
+				verb:        http.MethodPut,
 				aclToken:    "node_write",
 				requestBody: `{"num_schedulers":-1,"enabled_schedulers":["_core", "batch"]}`,
 			},
@@ -1876,7 +1876,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "post with bad json",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "POST",
+				verb:        http.MethodPost,
 				aclToken:    "agent_write",
 				requestBody: `{num_schedulers:-1,"enabled_schedulers":["_core", "batch"]}`,
 			},
@@ -1886,7 +1886,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 		{
 			name: "put with bad json",
 			request: schedulerWorkerConfigTest_testRequest{
-				verb:        "PUT",
+				verb:        http.MethodPut,
 				aclToken:    "agent_write",
 				requestBody: `{num_schedulers:-1,"enabled_schedulers":["_core", "batch"]}`,
 			},
@@ -2019,7 +2019,7 @@ func schedulerWorkerTest_parseError(t *testing.T, isACLEnabled bool, tc schedule
 func TestHTTP_AgentSchedulerWorkerInfoRequest_Client(t *testing.T) {
 	ci.Parallel(t)
 
-	verbs := []string{"GET", "POST", "PUT"}
+	verbs := []string{http.MethodGet, http.MethodPost, http.MethodPut}
 	path := "schedulers"
 
 	for _, verb := range verbs {
@@ -2045,7 +2045,7 @@ func TestHTTP_AgentSchedulerWorkerInfoRequest_Client(t *testing.T) {
 func TestHTTP_AgentSchedulerWorkerConfigRequest_Client(t *testing.T) {
 	ci.Parallel(t)
 
-	verbs := []string{"GET", "POST", "PUT"}
+	verbs := []string{http.MethodGet, http.MethodPost, http.MethodPut}
 	path := "schedulers/config"
 
 	for _, verb := range verbs {

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -27,7 +27,7 @@ const (
 )
 
 func (s *HTTPServer) AllocsRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
@@ -99,7 +99,7 @@ func (s *HTTPServer) AllocSpecificRequest(resp http.ResponseWriter, req *http.Re
 }
 
 func (s *HTTPServer) allocGet(allocID string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -404,7 +404,7 @@ func TestHTTP_AllocStop(t *testing.T) {
 		// Test that the happy path works
 		{
 			// Make the HTTP request
-			req, err := http.NewRequest(http.MethodGet, "/v1/allocation/"+alloc.ID+"/stop", nil)
+			req, err := http.NewRequest(http.MethodPost, "/v1/allocation/"+alloc.ID+"/stop", nil)
 			require.NoError(err)
 			respW := httptest.NewRecorder()
 

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -52,7 +52,7 @@ func TestHTTP_AllocsList(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/allocations", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/allocations", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -119,7 +119,7 @@ func TestHTTP_AllocsPrefixList(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/allocations?prefix=aaab", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/allocations?prefix=aaab", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -170,7 +170,7 @@ func TestHTTP_AllocQuery(t *testing.T) {
 		require.NoError(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc}))
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/allocation/"+alloc.ID, nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/allocation/"+alloc.ID, nil)
 		require.NoError(err)
 		respW := httptest.NewRecorder()
 
@@ -221,7 +221,7 @@ func TestHTTP_AllocQuery_Payload(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/allocation/"+alloc.ID, nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/allocation/"+alloc.ID, nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -267,7 +267,7 @@ func TestHTTP_AllocRestart(t *testing.T) {
 		{
 			// Make the HTTP request
 			buf := encodeReq(map[string]string{})
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -285,7 +285,7 @@ func TestHTTP_AllocRestart(t *testing.T) {
 			s.server = nil
 
 			buf := encodeReq(map[string]string{})
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
 			require.Nil(err)
 
 			respW := httptest.NewRecorder()
@@ -312,7 +312,7 @@ func TestHTTP_AllocRestart(t *testing.T) {
 			})
 
 			buf := encodeReq(map[string]string{})
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
 			require.Nil(err)
 
 			respW := httptest.NewRecorder()
@@ -335,7 +335,7 @@ func TestHTTP_AllocRestart_ACL(t *testing.T) {
 		// If there's no token, we expect the request to fail.
 		{
 			buf := encodeReq(map[string]string{})
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
 			require.NoError(err)
 
 			respW := httptest.NewRecorder()
@@ -347,7 +347,7 @@ func TestHTTP_AllocRestart_ACL(t *testing.T) {
 		// Try request with an invalid token and expect it to fail
 		{
 			buf := encodeReq(map[string]string{})
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
 			require.NoError(err)
 
 			respW := httptest.NewRecorder()
@@ -362,7 +362,7 @@ func TestHTTP_AllocRestart_ACL(t *testing.T) {
 		// Still returns an error because the alloc does not exist
 		{
 			buf := encodeReq(map[string]string{})
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
 			require.NoError(err)
 
 			respW := httptest.NewRecorder()
@@ -378,7 +378,7 @@ func TestHTTP_AllocRestart_ACL(t *testing.T) {
 		// Still returns an error because the alloc does not exist
 		{
 			buf := encodeReq(map[string]string{})
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
 			require.NoError(err)
 
 			respW := httptest.NewRecorder()
@@ -404,7 +404,7 @@ func TestHTTP_AllocStop(t *testing.T) {
 		// Test that the happy path works
 		{
 			// Make the HTTP request
-			req, err := http.NewRequest("POST", "/v1/allocation/"+alloc.ID+"/stop", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/allocation/"+alloc.ID+"/stop", nil)
 			require.NoError(err)
 			respW := httptest.NewRecorder()
 
@@ -422,7 +422,7 @@ func TestHTTP_AllocStop(t *testing.T) {
 		// Test that we 404 when the allocid is invalid
 		{
 			// Make the HTTP request
-			req, err := http.NewRequest("POST", "/v1/allocation/"+uuid.Generate()+"/stop", nil)
+			req, err := http.NewRequest(http.MethodPost, "/v1/allocation/"+uuid.Generate()+"/stop", nil)
 			require.NoError(err)
 			respW := httptest.NewRecorder()
 
@@ -557,7 +557,7 @@ func TestHTTP_AllocStats(t *testing.T) {
 		// Local node, local resp
 		{
 			// Make the HTTP request
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/allocation/%s/stats", uuid.Generate()), nil)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/stats", uuid.Generate()), nil)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -574,7 +574,7 @@ func TestHTTP_AllocStats(t *testing.T) {
 			srv := s.server
 			s.server = nil
 
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/allocation/%s/stats", uuid.Generate()), nil)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/stats", uuid.Generate()), nil)
 			require.Nil(err)
 
 			respW := httptest.NewRecorder()
@@ -600,7 +600,7 @@ func TestHTTP_AllocStats(t *testing.T) {
 				t.Fatalf("should have client: %v", err)
 			})
 
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/allocation/%s/stats", uuid.Generate()), nil)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/stats", uuid.Generate()), nil)
 			require.Nil(err)
 
 			respW := httptest.NewRecorder()
@@ -621,7 +621,7 @@ func TestHTTP_AllocStats_ACL(t *testing.T) {
 		state := s.Agent.server.State()
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/allocation/%s/stats", uuid.Generate()), nil)
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/stats", uuid.Generate()), nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -672,7 +672,7 @@ func TestHTTP_AllocSnapshot(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/client/allocation/123/snapshot", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/client/allocation/123/snapshot", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -691,7 +691,7 @@ func TestHTTP_AllocSnapshot_WithMigrateToken(t *testing.T) {
 	require := require.New(t)
 	httpACLTest(t, nil, func(s *TestAgent) {
 		// Request without a token fails
-		req, err := http.NewRequest("GET", "/v1/client/allocation/123/snapshot", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/client/allocation/123/snapshot", nil)
 		require.Nil(err)
 
 		// Make the unauthorized request
@@ -708,7 +708,7 @@ func TestHTTP_AllocSnapshot_WithMigrateToken(t *testing.T) {
 
 		// Request with a token succeeds
 		url := fmt.Sprintf("/v1/client/allocation/%s/snapshot", alloc.ID)
-		req, err = http.NewRequest("GET", url, nil)
+		req, err = http.NewRequest(http.MethodGet, url, nil)
 		require.Nil(err)
 
 		req.Header.Set("X-Nomad-Token", validMigrateToken)
@@ -779,7 +779,7 @@ func TestHTTP_AllocSnapshot_Atomic(t *testing.T) {
 		// streamed over a 200 HTTP response the only way to signal an
 		// error is by writing a marker file.
 		respW := httptest.NewRecorder()
-		req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/allocation/%s/snapshot", alloc.ID), nil)
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/snapshot", alloc.ID), nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -838,7 +838,7 @@ func TestHTTP_AllocGC(t *testing.T) {
 	httpTest(t, nil, func(s *TestAgent) {
 		// Local node, local resp
 		{
-			req, err := http.NewRequest("GET", path, nil)
+			req, err := http.NewRequest(http.MethodGet, path, nil)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -855,7 +855,7 @@ func TestHTTP_AllocGC(t *testing.T) {
 			srv := s.server
 			s.server = nil
 
-			req, err := http.NewRequest("GET", path, nil)
+			req, err := http.NewRequest(http.MethodGet, path, nil)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -884,7 +884,7 @@ func TestHTTP_AllocGC(t *testing.T) {
 				t.Fatalf("should have client: %v", err)
 			})
 
-			req, err := http.NewRequest("GET", path, nil)
+			req, err := http.NewRequest(http.MethodGet, path, nil)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -910,7 +910,7 @@ func TestHTTP_AllocGC_ACL(t *testing.T) {
 		state := s.Agent.server.State()
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", path, nil)
+		req, err := http.NewRequest(http.MethodGet, path, nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -963,7 +963,7 @@ func TestHTTP_AllocAllGC(t *testing.T) {
 	httpTest(t, nil, func(s *TestAgent) {
 		// Local node, local resp
 		{
-			req, err := http.NewRequest("GET", "/v1/client/gc", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/client/gc", nil)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -980,7 +980,7 @@ func TestHTTP_AllocAllGC(t *testing.T) {
 			srv := s.server
 			s.server = nil
 
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/gc?node_id=%s", uuid.Generate()), nil)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/gc?node_id=%s", uuid.Generate()), nil)
 			require.Nil(err)
 
 			respW := httptest.NewRecorder()
@@ -1006,7 +1006,7 @@ func TestHTTP_AllocAllGC(t *testing.T) {
 				t.Fatalf("should have client: %v", err)
 			})
 
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/gc?node_id=%s", c.NodeID()), nil)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/gc?node_id=%s", c.NodeID()), nil)
 			require.Nil(err)
 
 			respW := httptest.NewRecorder()
@@ -1026,7 +1026,7 @@ func TestHTTP_AllocAllGC_ACL(t *testing.T) {
 		state := s.Agent.server.State()
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/client/gc", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/client/gc", nil)
 		require.Nil(err)
 
 		// Try request without a token and expect failure
@@ -1109,7 +1109,7 @@ func TestHTTP_ReadWsHandshake(t *testing.T) {
 				return nil
 			}
 
-			req := httptest.NewRequest("PUT", "/target", nil)
+			req := httptest.NewRequest(http.MethodPut, "/target", nil)
 			if c.handshake {
 				req.URL.RawQuery = "ws_handshake=true"
 			}

--- a/command/agent/csi_endpoint_test.go
+++ b/command/agent/csi_endpoint_test.go
@@ -24,7 +24,7 @@ func TestHTTP_CSIEndpointPlugin(t *testing.T) {
 		defer cleanup()
 
 		body := bytes.NewBuffer(nil)
-		req, err := http.NewRequest("GET", "/v1/plugin/csi/foo", body)
+		req, err := http.NewRequest(http.MethodGet, "/v1/plugin/csi/foo", body)
 		require.NoError(t, err)
 
 		resp := httptest.NewRecorder()
@@ -66,7 +66,7 @@ func TestHTTP_CSIParseSecrets(t *testing.T) {
 			structs.CSISecrets(map[string]string{"one": "value_one=two", "two": "value_two"})},
 	}
 	for _, tc := range testCases {
-		req, _ := http.NewRequest("GET", "/v1/plugin/csi/foo", nil)
+		req, _ := http.NewRequest(http.MethodGet, "/v1/plugin/csi/foo", nil)
 		req.Header.Add("X-Nomad-CSI-Secrets", tc.val)
 		require.Equal(t, tc.expect, parseCSISecrets(req), tc.val)
 	}
@@ -90,13 +90,13 @@ func TestHTTP_CSIEndpointRegisterVolume(t *testing.T) {
 			}},
 		}
 		body := encodeReq(args)
-		req, err := http.NewRequest("PUT", "/v1/volumes", body)
+		req, err := http.NewRequest(http.MethodPut, "/v1/volumes", body)
 		require.NoError(t, err)
 		resp := httptest.NewRecorder()
 		_, err = s.Server.CSIVolumesRequest(resp, req)
 		require.NoError(t, err, "put error")
 
-		req, err = http.NewRequest("GET", "/v1/volume/csi/bar", nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/volume/csi/bar", nil)
 		require.NoError(t, err)
 		resp = httptest.NewRecorder()
 		raw, err := s.Server.CSIVolumeSpecificRequest(resp, req)
@@ -106,7 +106,7 @@ func TestHTTP_CSIEndpointRegisterVolume(t *testing.T) {
 		require.Equal(t, 1, out.ControllersHealthy)
 		require.Equal(t, 2, out.NodesHealthy)
 
-		req, err = http.NewRequest("DELETE", "/v1/volume/csi/bar/detach", nil)
+		req, err = http.NewRequest(http.MethodDelete, "/v1/volume/csi/bar/detach", nil)
 		require.NoError(t, err)
 		resp = httptest.NewRecorder()
 		_, err = s.Server.CSIVolumeSpecificRequest(resp, req)
@@ -132,13 +132,13 @@ func TestHTTP_CSIEndpointCreateVolume(t *testing.T) {
 			}},
 		}
 		body := encodeReq(args)
-		req, err := http.NewRequest("PUT", "/v1/volumes/create", body)
+		req, err := http.NewRequest(http.MethodPut, "/v1/volumes/create", body)
 		require.NoError(t, err)
 		resp := httptest.NewRecorder()
 		_, err = s.Server.CSIVolumesRequest(resp, req)
 		require.Error(t, err, "controller validate volume: No path to node")
 
-		req, err = http.NewRequest("DELETE", "/v1/volume/csi/baz", nil)
+		req, err = http.NewRequest(http.MethodDelete, "/v1/volume/csi/baz", nil)
 		require.NoError(t, err)
 		resp = httptest.NewRecorder()
 		_, err = s.Server.CSIVolumeSpecificRequest(resp, req)
@@ -161,7 +161,7 @@ func TestHTTP_CSIEndpointSnapshot(t *testing.T) {
 			}},
 		}
 		body := encodeReq(args)
-		req, err := http.NewRequest("PUT", "/v1/volumes/snapshot", body)
+		req, err := http.NewRequest(http.MethodPut, "/v1/volumes/snapshot", body)
 		require.NoError(t, err)
 		resp := httptest.NewRecorder()
 		_, err = s.Server.CSISnapshotsRequest(resp, req)

--- a/command/agent/deployment_endpoint_test.go
+++ b/command/agent/deployment_endpoint_test.go
@@ -26,7 +26,7 @@ func TestHTTP_DeploymentList(t *testing.T) {
 		assert.Nil(state.UpsertDeployment(1000, d2), "UpsertDeployment")
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/deployments", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/deployments", nil)
 		assert.Nil(err, "HTTP Request")
 		respW := httptest.NewRecorder()
 
@@ -59,7 +59,7 @@ func TestHTTP_DeploymentPrefixList(t *testing.T) {
 		assert.Nil(state.UpsertDeployment(1000, d2), "UpsertDeployment")
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/deployments?prefix=aaab", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/deployments?prefix=aaab", nil)
 		assert.Nil(err, "HTTP Request")
 		respW := httptest.NewRecorder()
 
@@ -116,7 +116,7 @@ func TestHTTP_DeploymentAllocations(t *testing.T) {
 		assert.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{a1, a2}), "UpsertAllocs")
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/deployment/allocations/"+d.ID, nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/deployment/allocations/"+d.ID, nil)
 		assert.Nil(err, "HTTP Request")
 		respW := httptest.NewRecorder()
 
@@ -150,7 +150,7 @@ func TestHTTP_DeploymentQuery(t *testing.T) {
 		assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/deployment/"+d.ID, nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/deployment/"+d.ID, nil)
 		assert.Nil(err, "HTTP Request")
 		respW := httptest.NewRecorder()
 
@@ -193,7 +193,7 @@ func TestHTTP_DeploymentPause(t *testing.T) {
 		buf := encodeReq(args)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/deployment/pause/"+d.ID, buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/deployment/pause/"+d.ID, buf)
 		assert.Nil(err, "HTTP Request")
 		respW := httptest.NewRecorder()
 
@@ -234,7 +234,7 @@ func TestHTTP_DeploymentPromote(t *testing.T) {
 		buf := encodeReq(args)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/deployment/pause/"+d.ID, buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/deployment/pause/"+d.ID, buf)
 		assert.Nil(err, "HTTP Request")
 		respW := httptest.NewRecorder()
 
@@ -279,7 +279,7 @@ func TestHTTP_DeploymentAllocHealth(t *testing.T) {
 		buf := encodeReq(args)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/deployment/allocation-health/"+d.ID, buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/deployment/allocation-health/"+d.ID, buf)
 		assert.Nil(err, "HTTP Request")
 		respW := httptest.NewRecorder()
 
@@ -309,7 +309,7 @@ func TestHTTP_DeploymentFail(t *testing.T) {
 		assert.Nil(state.UpsertDeployment(999, d), "UpsertDeployment")
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/deployment/fail/"+d.ID, nil)
+		req, err := http.NewRequest(http.MethodPut, "/v1/deployment/fail/"+d.ID, nil)
 		assert.Nil(err, "HTTP Request")
 		respW := httptest.NewRecorder()
 

--- a/command/agent/eval_endpoint.go
+++ b/command/agent/eval_endpoint.go
@@ -99,7 +99,7 @@ func (s *HTTPServer) EvalSpecificRequest(resp http.ResponseWriter, req *http.Req
 }
 
 func (s *HTTPServer) evalAllocations(resp http.ResponseWriter, req *http.Request, evalID string) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
@@ -123,7 +123,7 @@ func (s *HTTPServer) evalAllocations(resp http.ResponseWriter, req *http.Request
 }
 
 func (s *HTTPServer) evalQuery(resp http.ResponseWriter, req *http.Request, evalID string) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 

--- a/command/agent/eval_endpoint_test.go
+++ b/command/agent/eval_endpoint_test.go
@@ -30,7 +30,7 @@ func TestHTTP_EvalList(t *testing.T) {
 		require.NoError(t, err)
 
 		// simple list request
-		req, err := http.NewRequest("GET", "/v1/evaluations", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/evaluations", nil)
 		require.NoError(t, err)
 		respW := httptest.NewRecorder()
 		obj, err := s.Server.EvalsRequest(respW, req)
@@ -43,7 +43,7 @@ func TestHTTP_EvalList(t *testing.T) {
 		require.Len(t, obj.([]*structs.Evaluation), 2, "expected 2 evals")
 
 		// paginated list request
-		req, err = http.NewRequest("GET", "/v1/evaluations?per_page=1", nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/evaluations?per_page=1", nil)
 		require.NoError(t, err)
 		respW = httptest.NewRecorder()
 		obj, err = s.Server.EvalsRequest(respW, req)
@@ -53,7 +53,7 @@ func TestHTTP_EvalList(t *testing.T) {
 		require.Len(t, obj.([]*structs.Evaluation), 1, "expected 1 eval")
 
 		// filtered list request
-		req, err = http.NewRequest("GET",
+		req, err = http.NewRequest(http.MethodGet,
 			fmt.Sprintf("/v1/evaluations?per_page=10&job=%s", eval2.JobID), nil)
 		require.NoError(t, err)
 		respW = httptest.NewRecorder()
@@ -81,7 +81,7 @@ func TestHTTP_EvalPrefixList(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/evaluations?prefix=aaab", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/evaluations?prefix=aaab", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -264,7 +264,7 @@ func TestHTTP_EvalAllocations(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET",
+		req, err := http.NewRequest(http.MethodGet,
 			"/v1/evaluation/"+alloc1.EvalID+"/allocations", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
@@ -308,7 +308,7 @@ func TestHTTP_EvalQuery(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/evaluation/"+eval.ID, nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/evaluation/"+eval.ID, nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -355,7 +355,7 @@ func TestHTTP_EvalQueryWithRelated(t *testing.T) {
 		require.NoError(t, err)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", fmt.Sprintf("/v1/evaluation/%s?related=true", eval1.ID), nil)
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/evaluation/%s?related=true", eval1.ID), nil)
 		require.NoError(t, err)
 		respW := httptest.NewRecorder()
 
@@ -391,7 +391,7 @@ func TestHTTP_EvalCount(t *testing.T) {
 		must.NoError(t, err)
 
 		// simple count request
-		req, err := http.NewRequest("GET", "/v1/evaluations/count", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/evaluations/count", nil)
 		must.NoError(t, err)
 		respW := httptest.NewRecorder()
 		obj, err := s.Server.EvalsCountRequest(respW, req)
@@ -411,7 +411,7 @@ func TestHTTP_EvalCount(t *testing.T) {
 		// filtered count request
 		v := url.Values{}
 		v.Add("filter", fmt.Sprintf("JobID==\"%s\"", eval2.JobID))
-		req, err = http.NewRequest("GET", "/v1/evaluations/count?"+v.Encode(), nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/evaluations/count?"+v.Encode(), nil)
 		must.NoError(t, err)
 		respW = httptest.NewRecorder()
 		obj, err = s.Server.EvalsCountRequest(respW, req)

--- a/command/agent/event_endpoint_test.go
+++ b/command/agent/event_endpoint_test.go
@@ -32,7 +32,7 @@ func TestEventStream(t *testing.T) {
 
 	httpTest(t, nil, func(s *TestAgent) {
 		ctx, cancel := context.WithCancel(context.Background())
-		req, err := http.NewRequestWithContext(ctx, "GET", "/v1/event/stream", nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/v1/event/stream", nil)
 		require.Nil(t, err)
 		resp := httptest.NewRecorder()
 
@@ -79,7 +79,7 @@ func TestEventStream_NamespaceQuery(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		req, err := http.NewRequestWithContext(ctx, "GET", "/v1/event/stream?namespace=foo", nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/v1/event/stream?namespace=foo", nil)
 		require.Nil(t, err)
 		resp := httptest.NewRecorder()
 

--- a/command/agent/fs_endpoint_test.go
+++ b/command/agent/fs_endpoint_test.go
@@ -121,7 +121,7 @@ func TestHTTP_FS_List_MissingParams(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 	httpTest(t, nil, func(s *TestAgent) {
-		req, err := http.NewRequest("GET", "/v1/client/fs/ls/", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/client/fs/ls/", nil)
 		require.Nil(err)
 		respW := httptest.NewRecorder()
 		_, err = s.Server.DirectoryListRequest(respW, req)
@@ -133,14 +133,14 @@ func TestHTTP_FS_Stat_MissingParams(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 	httpTest(t, nil, func(s *TestAgent) {
-		req, err := http.NewRequest("GET", "/v1/client/fs/stat/", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/client/fs/stat/", nil)
 		require.Nil(err)
 		respW := httptest.NewRecorder()
 
 		_, err = s.Server.FileStatRequest(respW, req)
 		require.EqualError(err, allocIDNotPresentErr.Error())
 
-		req, err = http.NewRequest("GET", "/v1/client/fs/stat/foo", nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/client/fs/stat/foo", nil)
 		require.Nil(err)
 		respW = httptest.NewRecorder()
 
@@ -153,19 +153,19 @@ func TestHTTP_FS_ReadAt_MissingParams(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 	httpTest(t, nil, func(s *TestAgent) {
-		req, err := http.NewRequest("GET", "/v1/client/fs/readat/", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/client/fs/readat/", nil)
 		require.NoError(err)
 
 		_, err = s.Server.FileReadAtRequest(httptest.NewRecorder(), req)
 		require.Error(err)
 
-		req, err = http.NewRequest("GET", "/v1/client/fs/readat/foo", nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/client/fs/readat/foo", nil)
 		require.NoError(err)
 
 		_, err = s.Server.FileReadAtRequest(httptest.NewRecorder(), req)
 		require.Error(err)
 
-		req, err = http.NewRequest("GET", "/v1/client/fs/readat/foo?path=/path/to/file", nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/client/fs/readat/foo?path=/path/to/file", nil)
 		require.NoError(err)
 
 		_, err = s.Server.FileReadAtRequest(httptest.NewRecorder(), req)
@@ -177,14 +177,14 @@ func TestHTTP_FS_Cat_MissingParams(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 	httpTest(t, nil, func(s *TestAgent) {
-		req, err := http.NewRequest("GET", "/v1/client/fs/cat/", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/client/fs/cat/", nil)
 		require.Nil(err)
 		respW := httptest.NewRecorder()
 
 		_, err = s.Server.FileCatRequest(respW, req)
 		require.EqualError(err, allocIDNotPresentErr.Error())
 
-		req, err = http.NewRequest("GET", "/v1/client/fs/stat/foo", nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/client/fs/stat/foo", nil)
 		require.Nil(err)
 		respW = httptest.NewRecorder()
 
@@ -197,21 +197,21 @@ func TestHTTP_FS_Stream_MissingParams(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 	httpTest(t, nil, func(s *TestAgent) {
-		req, err := http.NewRequest("GET", "/v1/client/fs/stream/", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/client/fs/stream/", nil)
 		require.NoError(err)
 		respW := httptest.NewRecorder()
 
 		_, err = s.Server.Stream(respW, req)
 		require.EqualError(err, allocIDNotPresentErr.Error())
 
-		req, err = http.NewRequest("GET", "/v1/client/fs/stream/foo", nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/client/fs/stream/foo", nil)
 		require.NoError(err)
 		respW = httptest.NewRecorder()
 
 		_, err = s.Server.Stream(respW, req)
 		require.EqualError(err, fileNameNotPresentErr.Error())
 
-		req, err = http.NewRequest("GET", "/v1/client/fs/stream/foo?path=/path/to/file", nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/client/fs/stream/foo?path=/path/to/file", nil)
 		require.NoError(err)
 		respW = httptest.NewRecorder()
 
@@ -228,7 +228,7 @@ func TestHTTP_FS_Logs_MissingParams(t *testing.T) {
 	require := require.New(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		// AllocID Not Present
-		req, err := http.NewRequest("GET", "/v1/client/fs/logs/", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/client/fs/logs/", nil)
 		require.NoError(err)
 		respW := httptest.NewRecorder()
 
@@ -237,7 +237,7 @@ func TestHTTP_FS_Logs_MissingParams(t *testing.T) {
 		require.Equal(400, respW.Code)
 
 		// Task Not Present
-		req, err = http.NewRequest("GET", "/v1/client/fs/logs/foo", nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/client/fs/logs/foo", nil)
 		require.NoError(err)
 		respW = httptest.NewRecorder()
 
@@ -246,7 +246,7 @@ func TestHTTP_FS_Logs_MissingParams(t *testing.T) {
 		require.Equal(400, respW.Code)
 
 		// Log Type Not Present
-		req, err = http.NewRequest("GET", "/v1/client/fs/logs/foo?task=foo", nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/client/fs/logs/foo?task=foo", nil)
 		require.NoError(err)
 		respW = httptest.NewRecorder()
 
@@ -255,7 +255,7 @@ func TestHTTP_FS_Logs_MissingParams(t *testing.T) {
 		require.Equal(400, respW.Code)
 
 		// case where all parameters are set but alloc isn't found
-		req, err = http.NewRequest("GET", "/v1/client/fs/logs/foo?task=foo&type=stdout", nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/client/fs/logs/foo?task=foo&type=stdout", nil)
 		require.NoError(err)
 		respW = httptest.NewRecorder()
 
@@ -272,7 +272,7 @@ func TestHTTP_FS_List(t *testing.T) {
 		a := mockFSAlloc(s.client.NodeID(), nil)
 		addAllocToClient(s, a, terminalClientAlloc)
 
-		req, err := http.NewRequest("GET", "/v1/client/fs/ls/"+a.ID, nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/client/fs/ls/"+a.ID, nil)
 		require.Nil(err)
 		respW := httptest.NewRecorder()
 		raw, err := s.Server.DirectoryListRequest(respW, req)
@@ -293,7 +293,7 @@ func TestHTTP_FS_Stat(t *testing.T) {
 		addAllocToClient(s, a, terminalClientAlloc)
 
 		path := fmt.Sprintf("/v1/client/fs/stat/%s?path=alloc/", a.ID)
-		req, err := http.NewRequest("GET", path, nil)
+		req, err := http.NewRequest(http.MethodGet, path, nil)
 		require.Nil(err)
 		respW := httptest.NewRecorder()
 		raw, err := s.Server.FileStatRequest(respW, req)
@@ -319,7 +319,7 @@ func TestHTTP_FS_ReadAt(t *testing.T) {
 		path := fmt.Sprintf("/v1/client/fs/readat/%s?path=alloc/logs/web.stdout.0&offset=%d&limit=%d",
 			a.ID, offset, limit)
 
-		req, err := http.NewRequest("GET", path, nil)
+		req, err := http.NewRequest(http.MethodGet, path, nil)
 		require.Nil(err)
 		respW := httptest.NewRecorder()
 		_, err = s.Server.FileReadAtRequest(respW, req)
@@ -365,7 +365,7 @@ func TestHTTP_FS_Cat(t *testing.T) {
 
 		path := fmt.Sprintf("/v1/client/fs/cat/%s?path=alloc/logs/web.stdout.0", a.ID)
 
-		req, err := http.NewRequest("GET", path, nil)
+		req, err := http.NewRequest(http.MethodGet, path, nil)
 		require.Nil(err)
 		respW := httptest.NewRecorder()
 		_, err = s.Server.FileCatRequest(respW, req)
@@ -414,7 +414,7 @@ func TestHTTP_FS_Stream_NoFollow(t *testing.T) {
 		path := fmt.Sprintf("/v1/client/fs/stream/%s?path=alloc/logs/web.stdout.0&offset=%d&origin=end&follow=false",
 			a.ID, offset)
 
-		req, err := http.NewRequest("GET", path, nil)
+		req, err := http.NewRequest(http.MethodGet, path, nil)
 		require.Nil(err)
 		respW := testutil.NewResponseRecorder()
 		doneCh := make(chan struct{})
@@ -478,7 +478,7 @@ func TestHTTP_FS_Stream_Follow(t *testing.T) {
 		path := fmt.Sprintf("/v1/client/fs/stream/%s?path=alloc/logs/web.stdout.0&offset=%d&origin=end",
 			a.ID, offset)
 
-		req, err := http.NewRequest("GET", path, nil)
+		req, err := http.NewRequest(http.MethodGet, path, nil)
 		require.Nil(err)
 		respW := httptest.NewRecorder()
 		doneCh := make(chan struct{})
@@ -521,7 +521,7 @@ func TestHTTP_FS_Logs(t *testing.T) {
 		path := fmt.Sprintf("/v1/client/fs/logs/%s?type=stdout&task=web&offset=%d&origin=end&plain=true",
 			a.ID, offset)
 
-		req, err := http.NewRequest("GET", path, nil)
+		req, err := http.NewRequest(http.MethodGet, path, nil)
 		require.Nil(err)
 		respW := testutil.NewResponseRecorder()
 		go func() {
@@ -580,7 +580,7 @@ func TestHTTP_FS_Logs_Follow(t *testing.T) {
 		path := fmt.Sprintf("/v1/client/fs/logs/%s?type=stdout&task=web&offset=%d&origin=end&plain=true&follow=true",
 			a.ID, offset)
 
-		req, err := http.NewRequest("GET", path, nil)
+		req, err := http.NewRequest(http.MethodGet, path, nil)
 		require.Nil(err)
 		respW := testutil.NewResponseRecorder()
 		errCh := make(chan error, 1)
@@ -616,7 +616,7 @@ func TestHTTP_FS_Logs_PropagatesErrors(t *testing.T) {
 		path := fmt.Sprintf("/v1/client/fs/logs/%s?type=stdout&task=web&offset=0&origin=end&plain=true",
 			uuid.Generate())
 
-		req, err := http.NewRequest("GET", path, nil)
+		req, err := http.NewRequest(http.MethodGet, path, nil)
 		require.NoError(t, err)
 		respW := testutil.NewResponseRecorder()
 

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -661,7 +661,7 @@ func (s *HTTPServer) handleRootFallthrough() http.Handler {
 			if req.URL.RawQuery != "" {
 				url = url + "?" + req.URL.RawQuery
 			}
-			http.Redirect(w, req, url, 307)
+			http.Redirect(w, req, url, http.StatusTemporaryRedirect)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -877,7 +877,7 @@ func parseWait(resp http.ResponseWriter, req *http.Request, b *structs.QueryOpti
 	if wait := query.Get("wait"); wait != "" {
 		dur, err := time.ParseDuration(wait)
 		if err != nil {
-			resp.WriteHeader(400)
+			resp.WriteHeader(http.StatusBadRequest)
 			resp.Write([]byte("Invalid wait time"))
 			return true
 		}
@@ -886,7 +886,7 @@ func parseWait(resp http.ResponseWriter, req *http.Request, b *structs.QueryOpti
 	if idx := query.Get("index"); idx != "" {
 		index, err := strconv.ParseUint(idx, 10, 64)
 		if err != nil {
-			resp.WriteHeader(400)
+			resp.WriteHeader(http.StatusBadRequest)
 			resp.Write([]byte("Invalid index"))
 			return true
 		}
@@ -905,7 +905,7 @@ func parseConsistency(resp http.ResponseWriter, req *http.Request, b *structs.Qu
 		}
 		staleQuery, err := strconv.ParseBool(staleVal[0])
 		if err != nil {
-			resp.WriteHeader(400)
+			resp.WriteHeader(http.StatusBadRequest)
 			_, _ = resp.Write([]byte(fmt.Sprintf("Expect `true` or `false` for `stale` query string parameter, got %s", staleVal[0])))
 			return
 		}
@@ -1163,7 +1163,7 @@ func (a *authMiddleware) ServeHTTP(resp http.ResponseWriter, req *http.Request) 
 		}
 
 		a.srv.logger.Error("error authenticating built API request", "error", err, "url", req.URL, "method", req.Method)
-		resp.WriteHeader(500)
+		resp.WriteHeader(http.StatusInternalServerError)
 		resp.Write([]byte("Server error authenticating request\n"))
 		return
 	}

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -67,7 +67,7 @@ func BenchmarkHTTPRequests(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			resp := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/v1/kv/key", nil)
+			req, _ := http.NewRequest(http.MethodGet, "/v1/kv/key", nil)
 			s.Server.wrap(handler)(resp, req)
 		}
 	})
@@ -228,7 +228,7 @@ func TestSetHeaders(t *testing.T) {
 		return &structs.Job{Name: "foo"}, nil
 	}
 
-	req, _ := http.NewRequest("GET", "/v1/kv/key", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/v1/kv/key", nil)
 	s.Server.wrap(handler)(resp, req)
 	header := resp.Header().Get("foo")
 
@@ -249,7 +249,7 @@ func TestContentTypeIsJSON(t *testing.T) {
 		return &structs.Job{Name: "foo"}, nil
 	}
 
-	req, _ := http.NewRequest("GET", "/v1/kv/key", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/v1/kv/key", nil)
 	s.Server.wrap(handler)(resp, req)
 
 	contentType := resp.Header().Get("Content-Type")
@@ -270,7 +270,7 @@ func TestWrapNonJSON(t *testing.T) {
 		return []byte("test response"), nil
 	}
 
-	req, _ := http.NewRequest("GET", "/v1/kv/key", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/v1/kv/key", nil)
 	s.Server.wrapNonJSON(handler)(resp, req)
 
 	respBody, _ := io.ReadAll(resp.Body)
@@ -294,7 +294,7 @@ func TestWrapNonJSON_Error(t *testing.T) {
 	// RPC coded error
 	{
 		resp := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/v1/kv/key", nil)
+		req, _ := http.NewRequest(http.MethodGet, "/v1/kv/key", nil)
 		s.Server.wrapNonJSON(handlerRPCErr)(resp, req)
 		respBody, _ := io.ReadAll(resp.Body)
 		require.Equal(t, []byte("not found"), respBody)
@@ -304,7 +304,7 @@ func TestWrapNonJSON_Error(t *testing.T) {
 	// CodedError
 	{
 		resp := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/v1/kv/key", nil)
+		req, _ := http.NewRequest(http.MethodGet, "/v1/kv/key", nil)
 		s.Server.wrapNonJSON(handlerCodedErr)(resp, req)
 		respBody, _ := io.ReadAll(resp.Body)
 		require.Equal(t, []byte("unprocessable"), respBody)
@@ -340,7 +340,7 @@ func testPrettyPrint(pretty string, prettyFmt bool, t *testing.T) {
 	}
 
 	urlStr := "/v1/job/foo?" + pretty
-	req, _ := http.NewRequest("GET", urlStr, nil)
+	req, _ := http.NewRequest(http.MethodGet, urlStr, nil)
 	s.Server.wrap(handler)(resp, req)
 
 	var expected bytes.Buffer
@@ -378,7 +378,7 @@ func TestPermissionDenied(t *testing.T) {
 			return nil, structs.ErrPermissionDenied
 		}
 
-		req, _ := http.NewRequest("GET", "/v1/job/foo", nil)
+		req, _ := http.NewRequest(http.MethodGet, "/v1/job/foo", nil)
 		s.Server.wrap(handler)(resp, req)
 		assert.Equal(t, resp.Code, 403)
 	}
@@ -390,7 +390,7 @@ func TestPermissionDenied(t *testing.T) {
 			return nil, fmt.Errorf("rpc error: %v", structs.ErrPermissionDenied)
 		}
 
-		req, _ := http.NewRequest("GET", "/v1/job/foo", nil)
+		req, _ := http.NewRequest(http.MethodGet, "/v1/job/foo", nil)
 		s.Server.wrap(handler)(resp, req)
 		assert.Equal(t, resp.Code, 403)
 	}
@@ -408,7 +408,7 @@ func TestTokenNotFound(t *testing.T) {
 	}
 
 	urlStr := "/v1/job/foo"
-	req, _ := http.NewRequest("GET", urlStr, nil)
+	req, _ := http.NewRequest(http.MethodGet, urlStr, nil)
 	s.Server.wrap(handler)(resp, req)
 	assert.Equal(t, resp.Code, 403)
 }
@@ -418,7 +418,7 @@ func TestParseWait(t *testing.T) {
 	resp := httptest.NewRecorder()
 	var b structs.QueryOptions
 
-	req, err := http.NewRequest("GET",
+	req, err := http.NewRequest(http.MethodGet,
 		"/v1/catalog/nodes?wait=60s&index=1000", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -441,7 +441,7 @@ func TestParseWait_InvalidTime(t *testing.T) {
 	resp := httptest.NewRecorder()
 	var b structs.QueryOptions
 
-	req, err := http.NewRequest("GET",
+	req, err := http.NewRequest(http.MethodGet,
 		"/v1/catalog/nodes?wait=60foo&index=1000", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -461,7 +461,7 @@ func TestParseWait_InvalidIndex(t *testing.T) {
 	resp := httptest.NewRecorder()
 	var b structs.QueryOptions
 
-	req, err := http.NewRequest("GET",
+	req, err := http.NewRequest(http.MethodGet,
 		"/v1/catalog/nodes?wait=60s&index=foo", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -483,20 +483,20 @@ func TestParseConsistency(t *testing.T) {
 
 	testCases := [2]string{"/v1/catalog/nodes?stale", "/v1/catalog/nodes?stale=true"}
 	for _, urlPath := range testCases {
-		req, err := http.NewRequest("GET", urlPath, nil)
+		req, err := http.NewRequest(http.MethodGet, urlPath, nil)
 		must.NoError(t, err)
 		resp = httptest.NewRecorder()
 		parseConsistency(resp, req, &b)
 		must.True(t, b.AllowStale)
 	}
 
-	req, err := http.NewRequest("GET", "/v1/catalog/nodes?stale=false", nil)
+	req, err := http.NewRequest(http.MethodGet, "/v1/catalog/nodes?stale=false", nil)
 	must.NoError(t, err)
 	resp = httptest.NewRecorder()
 	parseConsistency(resp, req, &b)
 	must.False(t, b.AllowStale)
 
-	req, err = http.NewRequest("GET", "/v1/catalog/nodes?stale=random", nil)
+	req, err = http.NewRequest(http.MethodGet, "/v1/catalog/nodes?stale=random", nil)
 	must.NoError(t, err)
 	resp = httptest.NewRecorder()
 	parseConsistency(resp, req, &b)
@@ -504,7 +504,7 @@ func TestParseConsistency(t *testing.T) {
 	must.EqOp(t, 400, resp.Code)
 
 	b = structs.QueryOptions{}
-	req, err = http.NewRequest("GET", "/v1/catalog/nodes?consistent", nil)
+	req, err = http.NewRequest(http.MethodGet, "/v1/catalog/nodes?consistent", nil)
 	must.NoError(t, err)
 
 	resp = httptest.NewRecorder()
@@ -517,7 +517,7 @@ func TestParseRegion(t *testing.T) {
 	s := makeHTTPServer(t, nil)
 	defer s.Shutdown()
 
-	req, err := http.NewRequest("GET",
+	req, err := http.NewRequest(http.MethodGet,
 		"/v1/jobs?region=foo", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -530,7 +530,7 @@ func TestParseRegion(t *testing.T) {
 	}
 
 	region = ""
-	req, err = http.NewRequest("GET", "/v1/jobs", nil)
+	req, err = http.NewRequest(http.MethodGet, "/v1/jobs", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -575,7 +575,7 @@ func TestParseToken(t *testing.T) {
 	for i := range cases {
 		tc := cases[i]
 		t.Run(tc.Name, func(t *testing.T) {
-			req, err := http.NewRequest("GET", "/v1/jobs", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/jobs", nil)
 			req.Header.Add(tc.HeaderKey, tc.HeaderValue)
 			if err != nil {
 				t.Fatalf("err: %v", err)
@@ -715,7 +715,7 @@ func TestParsePagination(t *testing.T) {
 		tc := cases[i]
 		t.Run("Input-"+tc.Input, func(t *testing.T) {
 
-			req, err := http.NewRequest("GET",
+			req, err := http.NewRequest(http.MethodGet,
 				"/v1/volumes/csi/external?"+tc.Input, nil)
 
 			require.NoError(t, err)
@@ -781,7 +781,7 @@ func TestParseNodeListStubFields(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			req, err := http.NewRequest("GET", tc.req, nil)
+			req, err := http.NewRequest(http.MethodGet, tc.req, nil)
 			must.NoError(t, err)
 
 			got, err := parseNodeListStubFields(req)
@@ -834,7 +834,7 @@ func TestHTTP_VerifyHTTPSClient(t *testing.T) {
 
 	reqURL := fmt.Sprintf("https://%s/v1/agent/self", s.Agent.config.AdvertiseAddrs.HTTP)
 
-	request, err := http.NewRequest("GET", reqURL, nil)
+	request, err := http.NewRequest(http.MethodGet, reqURL, nil)
 	must.NoError(t, err, must.Sprintf("error creating request: %v", err))
 
 	resp, err := clnt.Do(request)
@@ -867,7 +867,7 @@ func TestHTTP_VerifyHTTPSClient(t *testing.T) {
 	}
 	transport := &http.Transport{TLSClientConfig: tlsConf}
 	client := &http.Client{Transport: transport}
-	req, err := http.NewRequest("GET", reqURL, nil)
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
 	if err != nil {
 		t.Fatalf("error creating request: %v", err)
 	}
@@ -895,7 +895,7 @@ func TestHTTP_VerifyHTTPSClient(t *testing.T) {
 	}
 	tlsConf.RootCAs = x509.NewCertPool()
 	tlsConf.RootCAs.AppendCertsFromPEM(cacertBytes)
-	req, err = http.NewRequest("GET", reqURL, nil)
+	req, err = http.NewRequest(http.MethodGet, reqURL, nil)
 	if err != nil {
 		t.Fatalf("error creating request: %v", err)
 	}
@@ -930,7 +930,7 @@ func TestHTTP_VerifyHTTPSClient(t *testing.T) {
 	}
 	transport = &http.Transport{TLSClientConfig: tlsConf}
 	client = &http.Client{Transport: transport}
-	req, err = http.NewRequest("GET", reqURL, nil)
+	req, err = http.NewRequest(http.MethodGet, reqURL, nil)
 	if err != nil {
 		t.Fatalf("error creating request: %v", err)
 	}
@@ -939,7 +939,7 @@ func TestHTTP_VerifyHTTPSClient(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200 status code but got: %d", resp.StatusCode)
 	}
 }
@@ -1005,7 +1005,7 @@ func TestHTTP_VerifyHTTPSClient_AfterConfigReload(t *testing.T) {
 
 	transport := &http.Transport{TLSClientConfig: tlsConf}
 	client := &http.Client{Transport: transport}
-	req, err := http.NewRequest("GET", httpsReqURL, nil)
+	req, err := http.NewRequest(http.MethodGet, httpsReqURL, nil)
 	assert.Nil(err)
 
 	// Check that we get an error that the certificate isn't valid for the
@@ -1036,7 +1036,7 @@ func TestHTTP_VerifyHTTPSClient_AfterConfigReload(t *testing.T) {
 
 	transport = &http.Transport{TLSClientConfig: tlsConf}
 	client = &http.Client{Transport: transport}
-	req, err = http.NewRequest("GET", httpsReqURL, nil)
+	req, err = http.NewRequest(http.MethodGet, httpsReqURL, nil)
 	assert.Nil(err)
 
 	resp, err := client.Do(req)

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -25,9 +25,9 @@ const jobNotFoundErr = "job not found"
 
 func (s *HTTPServer) JobsRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		return s.jobListRequest(resp, req)
-	case "PUT", "POST":
+	case http.MethodPut, http.MethodPost:
 		return s.jobUpdate(resp, req, "")
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)
@@ -237,7 +237,7 @@ func (s *HTTPServer) periodicForceRequest(resp http.ResponseWriter, req *http.Re
 }
 
 func (s *HTTPServer) jobAllocations(resp http.ResponseWriter, req *http.Request, jobID string) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 	allAllocs, _ := strconv.ParseBool(req.URL.Query().Get("all"))
@@ -266,7 +266,7 @@ func (s *HTTPServer) jobAllocations(resp http.ResponseWriter, req *http.Request,
 }
 
 func (s *HTTPServer) jobEvaluations(resp http.ResponseWriter, req *http.Request, jobID string) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 	args := structs.JobSpecificRequest{
@@ -289,7 +289,7 @@ func (s *HTTPServer) jobEvaluations(resp http.ResponseWriter, req *http.Request,
 }
 
 func (s *HTTPServer) jobDeployments(resp http.ResponseWriter, req *http.Request, jobID string) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 	all, _ := strconv.ParseBool(req.URL.Query().Get("all"))
@@ -314,7 +314,7 @@ func (s *HTTPServer) jobDeployments(resp http.ResponseWriter, req *http.Request,
 }
 
 func (s *HTTPServer) jobLatestDeployment(resp http.ResponseWriter, req *http.Request, jobID string) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 	args := structs.JobSpecificRequest{
@@ -339,7 +339,7 @@ func (s *HTTPServer) jobSubmissionCRUD(resp http.ResponseWriter, req *http.Reque
 		return nil, CodedError(400, "Unable to parse job submission version parameter")
 	}
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		return s.jobSubmissionQuery(resp, req, jobID, version)
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)
@@ -371,11 +371,11 @@ func (s *HTTPServer) jobSubmissionQuery(resp http.ResponseWriter, req *http.Requ
 
 func (s *HTTPServer) jobCRUD(resp http.ResponseWriter, req *http.Request, jobID string) (interface{}, error) {
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		return s.jobQuery(resp, req, jobID)
-	case "PUT", "POST":
+	case http.MethodPut, http.MethodPost:
 		return s.jobUpdate(resp, req, jobID)
-	case "DELETE":
+	case http.MethodDelete:
 		return s.jobDelete(resp, req, jobID)
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)
@@ -545,9 +545,9 @@ func (s *HTTPServer) jobDelete(resp http.ResponseWriter, req *http.Request, jobI
 func (s *HTTPServer) jobScale(resp http.ResponseWriter, req *http.Request, jobID string) (interface{}, error) {
 
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		return s.jobScaleStatus(resp, req, jobID)
-	case "PUT", "POST":
+	case http.MethodPut, http.MethodPost:
 		return s.jobScaleAction(resp, req, jobID)
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -44,7 +44,7 @@ func TestHTTP_JobsList(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/jobs", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/jobs", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -103,7 +103,7 @@ func TestHTTP_PrefixJobsList(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/jobs?prefix=aabb", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/jobs?prefix=aabb", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -153,7 +153,7 @@ func TestHTTP_JobsList_AllNamespaces_OSS(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/jobs?namespace=*", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/jobs?namespace=*", nil)
 		require.NoError(t, err)
 		respW := httptest.NewRecorder()
 
@@ -186,7 +186,7 @@ func TestHTTP_JobsRegister(t *testing.T) {
 		buf := encodeReq(args)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/jobs", buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/jobs", buf)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -242,7 +242,7 @@ func TestHTTP_JobsRegister_IgnoresParentID(t *testing.T) {
 		buf := encodeReq(args)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/jobs", buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/jobs", buf)
 		require.NoError(t, err)
 		respW := httptest.NewRecorder()
 
@@ -305,7 +305,7 @@ func TestHTTP_JobsRegister_ACL(t *testing.T) {
 		buf := encodeReq(args)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/jobs", buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/jobs", buf)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -337,7 +337,7 @@ func TestHTTP_JobsRegister_Defaulting(t *testing.T) {
 		buf := encodeReq(args)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/jobs", buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/jobs", buf)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -386,7 +386,7 @@ func TestHTTP_JobsParse(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		buf := encodeReq(api.JobsParseRequest{JobHCL: mock.HCL()})
-		req, err := http.NewRequest("POST", "/v1/jobs/parse", buf)
+		req, err := http.NewRequest(http.MethodPost, "/v1/jobs/parse", buf)
 		must.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -410,7 +410,7 @@ func TestHTTP_JobsParse_HCLVar(t *testing.T) {
 			JobHCL:    hclJob,
 			Variables: hclVar,
 		})
-		req, err := http.NewRequest("POST", "/v1/jobs/parse", buf)
+		req, err := http.NewRequest(http.MethodPost, "/v1/jobs/parse", buf)
 		must.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -519,7 +519,7 @@ func TestHTTP_JobsParse_ACL(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				buf := encodeReq(api.JobsParseRequest{JobHCL: mock.HCL()})
-				req, err := http.NewRequest("POST", "/v1/jobs/parse", buf)
+				req, err := http.NewRequest(http.MethodPost, "/v1/jobs/parse", buf)
 				require.NoError(t, err)
 
 				if tc.namespace != "" {
@@ -568,7 +568,7 @@ func TestHTTP_JobQuery(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/job/"+job.ID, nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/job/"+job.ID, nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -617,7 +617,7 @@ func TestHTTP_JobQuery_Payload(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/job/"+job.ID, nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/job/"+job.ID, nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -670,7 +670,7 @@ func TestHTTP_jobUpdate_systemScaling(t *testing.T) {
 		buf := encodeReq(args)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/job/"+*job.ID, buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/job/"+*job.ID, buf)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -698,7 +698,7 @@ func TestHTTP_JobUpdate(t *testing.T) {
 		buf := encodeReq(args)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/job/"+*job.ID, buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/job/"+*job.ID, buf)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -786,7 +786,7 @@ func TestHTTP_JobUpdate_EvalPriority(t *testing.T) {
 				buf := encodeReq(args)
 
 				// Make the HTTP request
-				req, err := http.NewRequest("PUT", "/v1/job/"+*job.ID, buf)
+				req, err := http.NewRequest(http.MethodPut, "/v1/job/"+*job.ID, buf)
 				assert.Nil(t, err)
 				respW := httptest.NewRecorder()
 
@@ -817,7 +817,7 @@ func TestHTTP_JobUpdate_EvalPriority(t *testing.T) {
 				assert.NotNil(t, getResp.Job)
 
 				// Check the evaluation that resulted from the job register.
-				evalInfoReq, err := http.NewRequest("GET", "/v1/evaluation/"+regResp.EvalID, nil)
+				evalInfoReq, err := http.NewRequest(http.MethodGet, "/v1/evaluation/"+regResp.EvalID, nil)
 				assert.Nil(t, err)
 				respW.Flush()
 
@@ -901,7 +901,7 @@ func TestHTTP_JobUpdateRegion(t *testing.T) {
 				// Make the HTTP request
 				url := "/v1/job/" + *job.ID
 
-				req, err := http.NewRequest("PUT", url, buf)
+				req, err := http.NewRequest(http.MethodPut, url, buf)
 				require.NoError(t, err)
 				respW := httptest.NewRecorder()
 
@@ -952,7 +952,7 @@ func TestHTTP_JobDelete(t *testing.T) {
 		}
 
 		// Make the HTTP request to do a soft delete
-		req, err := http.NewRequest("DELETE", "/v1/job/"+job.ID, nil)
+		req, err := http.NewRequest(http.MethodDelete, "/v1/job/"+job.ID, nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -995,7 +995,7 @@ func TestHTTP_JobDelete(t *testing.T) {
 		}
 
 		// Make the HTTP request to do a purge delete
-		req2, err := http.NewRequest("DELETE", "/v1/job/"+job.ID+"?purge=true", nil)
+		req2, err := http.NewRequest(http.MethodDelete, "/v1/job/"+job.ID+"?purge=true", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1077,7 +1077,7 @@ func TestHTTP_JobDelete_EvalPriority(t *testing.T) {
 				buf := encodeReq(args)
 
 				// Make the HTTP request
-				regReq, err := http.NewRequest("PUT", "/v1/job/"+*job.ID, buf)
+				regReq, err := http.NewRequest(http.MethodPut, "/v1/job/"+*job.ID, buf)
 				assert.Nil(t, err)
 				respW := httptest.NewRecorder()
 
@@ -1103,7 +1103,7 @@ func TestHTTP_JobDelete_EvalPriority(t *testing.T) {
 				assert.NotNil(t, getResp.Job)
 
 				// Delete the job.
-				deleteReq, err := http.NewRequest("DELETE", "/v1/job/"+*job.ID+"?purge=true", nil)
+				deleteReq, err := http.NewRequest(http.MethodDelete, "/v1/job/"+*job.ID+"?purge=true", nil)
 				assert.Nil(t, err)
 				respW.Flush()
 
@@ -1129,7 +1129,7 @@ func TestHTTP_JobDelete_EvalPriority(t *testing.T) {
 				assert.NotEmpty(t, respW.Result().Header.Get("X-Nomad-Index"))
 
 				// Check the evaluation that resulted from the job register.
-				evalInfoReq, err := http.NewRequest("GET", "/v1/evaluation/"+dereg.EvalID, nil)
+				evalInfoReq, err := http.NewRequest(http.MethodGet, "/v1/evaluation/"+dereg.EvalID, nil)
 				assert.Nil(t, err)
 				respW.Flush()
 
@@ -1177,7 +1177,7 @@ func TestHTTP_Job_ScaleTaskGroup(t *testing.T) {
 		buf := encodeReq(scaleReq)
 
 		// Make the HTTP request to scale the job group
-		req, err := http.NewRequest("POST", "/v1/job/"+job.ID+"/scale", buf)
+		req, err := http.NewRequest(http.MethodPost, "/v1/job/"+job.ID+"/scale", buf)
 		require.NoError(err)
 		respW := httptest.NewRecorder()
 
@@ -1229,7 +1229,7 @@ func TestHTTP_Job_ScaleStatus(t *testing.T) {
 		}
 
 		// Make the HTTP request to scale the job group
-		req, err := http.NewRequest("GET", "/v1/job/"+job.ID+"/scale", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/job/"+job.ID+"/scale", nil)
 		require.NoError(err)
 		respW := httptest.NewRecorder()
 
@@ -1265,7 +1265,7 @@ func TestHTTP_JobForceEvaluate(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("POST", "/v1/job/"+job.ID+"/evaluate", nil)
+		req, err := http.NewRequest(http.MethodPost, "/v1/job/"+job.ID+"/evaluate", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1316,7 +1316,7 @@ func TestHTTP_JobEvaluate_ForceReschedule(t *testing.T) {
 		buf := encodeReq(jobEvalReq)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("POST", "/v1/job/"+job.ID+"/evaluate", buf)
+		req, err := http.NewRequest(http.MethodPost, "/v1/job/"+job.ID+"/evaluate", buf)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1359,7 +1359,7 @@ func TestHTTP_JobEvaluations(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/job/"+job.ID+"/evaluations", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/job/"+job.ID+"/evaluations", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1424,7 +1424,7 @@ func TestHTTP_JobAllocations(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/job/"+alloc1.Job.ID+"/allocations?all=true", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/job/"+alloc1.Job.ID+"/allocations?all=true", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1482,7 +1482,7 @@ func TestHTTP_JobDeployments(t *testing.T) {
 		assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/job/"+j.ID+"/deployments", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/job/"+j.ID+"/deployments", nil)
 		assert.Nil(err, "HTTP")
 		respW := httptest.NewRecorder()
 
@@ -1525,7 +1525,7 @@ func TestHTTP_JobDeployment(t *testing.T) {
 		assert.Nil(state.UpsertDeployment(1000, d), "UpsertDeployment")
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/job/"+j.ID+"/deployment", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/job/"+j.ID+"/deployment", nil)
 		assert.Nil(err, "HTTP")
 		respW := httptest.NewRecorder()
 
@@ -1578,7 +1578,7 @@ func TestHTTP_JobVersions(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/job/"+job.ID+"/versions?diffs=true", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/job/"+job.ID+"/versions?diffs=true", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1683,7 +1683,7 @@ func TestHTTP_PeriodicForce(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("POST", "/v1/job/"+job.ID+"/periodic/force", nil)
+		req, err := http.NewRequest(http.MethodPost, "/v1/job/"+job.ID+"/periodic/force", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1724,7 +1724,7 @@ func TestHTTP_JobPlan(t *testing.T) {
 		buf := encodeReq(args)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/job/"+*job.ID+"/plan", buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/job/"+*job.ID+"/plan", buf)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1806,7 +1806,7 @@ func TestHTTP_JobPlanRegion(t *testing.T) {
 				buf := encodeReq(args)
 
 				// Make the HTTP request
-				req, err := http.NewRequest("PUT", "/v1/job/"+*job.ID+"/plan", buf)
+				req, err := http.NewRequest(http.MethodPut, "/v1/job/"+*job.ID+"/plan", buf)
 				require.NoError(t, err)
 				respW := httptest.NewRecorder()
 
@@ -1854,7 +1854,7 @@ func TestHTTP_JobDispatch(t *testing.T) {
 		buf := encodeReq(args2)
 
 		// Make the HTTP request
-		req2, err := http.NewRequest("PUT", "/v1/job/"+job.ID+"/dispatch", buf)
+		req2, err := http.NewRequest(http.MethodPut, "/v1/job/"+job.ID+"/dispatch", buf)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1912,7 +1912,7 @@ func TestHTTP_JobRevert(t *testing.T) {
 		buf := encodeReq(args)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/job/"+job.ID+"/revert", buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/job/"+job.ID+"/revert", buf)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -1970,7 +1970,7 @@ func TestHTTP_JobStable(t *testing.T) {
 		buf := encodeReq(args)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/job/"+job.ID+"/stable", buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/job/"+job.ID+"/stable", buf)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -2107,7 +2107,7 @@ func TestJobs_ParsingWriteRequest(t *testing.T) {
 				Multiregion: tc.multiregion,
 			}
 
-			req, _ := http.NewRequest("POST", "/", nil)
+			req, _ := http.NewRequest(http.MethodPost, "/", nil)
 			if tc.queryToken != "" {
 				req.Header.Set("X-Nomad-Token", tc.queryToken)
 			}
@@ -2593,7 +2593,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								Args:          []string{"a", "b"},
 								Path:          "/check",
 								Protocol:      "http",
-								Method:        "POST",
+								Method:        http.MethodPost,
 								Body:          "{\"check\":\"mem\"}",
 								PortLabel:     "foo",
 								AddressMode:   "driver",
@@ -3005,7 +3005,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								Args:          []string{"a", "b"},
 								Path:          "/check",
 								Protocol:      "http",
-								Method:        "POST",
+								Method:        http.MethodPost,
 								Body:          "{\"check\":\"mem\"}",
 								PortLabel:     "foo",
 								AddressMode:   "driver",
@@ -3621,7 +3621,7 @@ func TestHTTP_JobValidate_SystemMigrate(t *testing.T) {
 		buf := encodeReq(args)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/validate/job", buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/validate/job", buf)
 		must.NoError(t, err)
 		respW := httptest.NewRecorder()
 

--- a/command/agent/metrics_endpoint.go
+++ b/command/agent/metrics_endpoint.go
@@ -20,7 +20,7 @@ var (
 // MetricsRequest returns metrics for the agent. Metrics are JSON by default
 // but Prometheus is an optional format.
 func (s *HTTPServer) MetricsRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 

--- a/command/agent/metrics_endpoint_test.go
+++ b/command/agent/metrics_endpoint_test.go
@@ -24,7 +24,7 @@ func TestHTTP_MetricsWithIllegalMethod(t *testing.T) {
 	assert := assert.New(t)
 
 	httpTest(t, nil, func(s *TestAgent) {
-		req, err := http.NewRequest("DELETE", "/v1/metrics", nil)
+		req, err := http.NewRequest(http.MethodDelete, "/v1/metrics", nil)
 		assert.Nil(err)
 		respW := httptest.NewRecorder()
 
@@ -38,7 +38,7 @@ func TestHTTP_MetricsPrometheusDisabled(t *testing.T) {
 	assert := assert.New(t)
 
 	httpTest(t, func(c *Config) { c.Telemetry.PrometheusMetrics = false }, func(s *TestAgent) {
-		req, err := http.NewRequest("GET", "/v1/metrics?format=prometheus", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/metrics?format=prometheus", nil)
 		assert.Nil(err)
 
 		resp, err := s.Server.MetricsRequest(nil, req)
@@ -52,7 +52,7 @@ func TestHTTP_MetricsPrometheusEnabled(t *testing.T) {
 	assert := assert.New(t)
 
 	httpTest(t, nil, func(s *TestAgent) {
-		req, err := http.NewRequest("GET", "/v1/metrics?format=prometheus", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/metrics?format=prometheus", nil)
 		assert.Nil(err)
 		respW := httptest.NewRecorder()
 
@@ -74,14 +74,14 @@ func TestHTTP_Metrics(t *testing.T) {
 	httpTest(t, nil, func(s *TestAgent) {
 		// make a separate HTTP request first, to ensure Nomad has written metrics
 		// and prevent a race condition
-		req, err := http.NewRequest("GET", "/v1/agent/self", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/agent/self", nil)
 		assert.Nil(err)
 		respW := httptest.NewRecorder()
 		s.Server.AgentSelfRequest(respW, req)
 
 		// now make a metrics endpoint request, which should be already initialized
 		// and written to
-		req, err = http.NewRequest("GET", "/v1/metrics", nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/metrics", nil)
 		assert.Nil(err)
 		respW = httptest.NewRecorder()
 
@@ -136,7 +136,7 @@ func TestHTTP_FreshClientAllocMetrics(t *testing.T) {
 		var pending, running, terminal float32 = -1.0, -1.0, -1.0
 		testutil.WaitForResultRetries(100, func() (bool, error) {
 			time.Sleep(100 * time.Millisecond)
-			req, err := http.NewRequest("GET", "/v1/metrics", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/metrics", nil)
 			require.NoError(err)
 			respW := httptest.NewRecorder()
 

--- a/command/agent/namespace_endpoint.go
+++ b/command/agent/namespace_endpoint.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *HTTPServer) NamespacesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
@@ -38,11 +38,11 @@ func (s *HTTPServer) NamespaceSpecificRequest(resp http.ResponseWriter, req *htt
 		return nil, CodedError(400, "Missing Namespace Name")
 	}
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		return s.namespaceQuery(resp, req, name)
-	case "PUT", "POST":
+	case http.MethodPut, http.MethodPost:
 		return s.namespaceUpdate(resp, req, name)
-	case "DELETE":
+	case http.MethodDelete:
 		return s.namespaceDelete(resp, req, name)
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)
@@ -50,7 +50,7 @@ func (s *HTTPServer) NamespaceSpecificRequest(resp http.ResponseWriter, req *htt
 }
 
 func (s *HTTPServer) NamespaceCreateRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "PUT" && req.Method != "POST" {
+	if req.Method != http.MethodPut && req.Method != http.MethodPost {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 

--- a/command/agent/namespace_endpoint_test.go
+++ b/command/agent/namespace_endpoint_test.go
@@ -29,7 +29,7 @@ func TestHTTP_NamespaceList(t *testing.T) {
 		assert.Nil(s.Agent.RPC("Namespace.UpsertNamespaces", &args, &resp))
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/namespaces", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/namespaces", nil)
 		assert.Nil(err)
 		respW := httptest.NewRecorder()
 
@@ -60,7 +60,7 @@ func TestHTTP_NamespaceQuery(t *testing.T) {
 		assert.Nil(s.Agent.RPC("Namespace.UpsertNamespaces", &args, &resp))
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/namespace/"+ns1.Name, nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/namespace/"+ns1.Name, nil)
 		assert.Nil(err)
 		respW := httptest.NewRecorder()
 
@@ -85,7 +85,7 @@ func TestHTTP_NamespaceCreate(t *testing.T) {
 		// Make the HTTP request
 		ns1 := mock.Namespace()
 		buf := encodeReq(ns1)
-		req, err := http.NewRequest("PUT", "/v1/namespace", buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/namespace", buf)
 		assert.Nil(err)
 		respW := httptest.NewRecorder()
 
@@ -116,7 +116,7 @@ func TestHTTP_NamespaceUpdate(t *testing.T) {
 		// Make the HTTP request
 		ns1 := mock.Namespace()
 		buf := encodeReq(ns1)
-		req, err := http.NewRequest("PUT", "/v1/namespace/"+ns1.Name, buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/namespace/"+ns1.Name, buf)
 		assert.Nil(err)
 		respW := httptest.NewRecorder()
 
@@ -153,7 +153,7 @@ func TestHTTP_NamespaceDelete(t *testing.T) {
 		assert.Nil(s.Agent.RPC("Namespace.UpsertNamespaces", &args, &resp))
 
 		// Make the HTTP request
-		req, err := http.NewRequest("DELETE", "/v1/namespace/"+ns1.Name, nil)
+		req, err := http.NewRequest(http.MethodDelete, "/v1/namespace/"+ns1.Name, nil)
 		assert.Nil(err)
 		respW := httptest.NewRecorder()
 

--- a/command/agent/node_endpoint.go
+++ b/command/agent/node_endpoint.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *HTTPServer) NodesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
@@ -67,7 +67,7 @@ func (s *HTTPServer) NodeSpecificRequest(resp http.ResponseWriter, req *http.Req
 
 func (s *HTTPServer) nodeForceEvaluate(resp http.ResponseWriter, req *http.Request,
 	nodeID string) (interface{}, error) {
-	if req.Method != "PUT" && req.Method != "POST" {
+	if req.Method != http.MethodPut && req.Method != http.MethodPost {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 	args := structs.NodeEvaluateRequest{
@@ -85,7 +85,7 @@ func (s *HTTPServer) nodeForceEvaluate(resp http.ResponseWriter, req *http.Reque
 
 func (s *HTTPServer) nodeAllocations(resp http.ResponseWriter, req *http.Request,
 	nodeID string) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 	args := structs.NodeSpecificRequest{
@@ -112,7 +112,7 @@ func (s *HTTPServer) nodeAllocations(resp http.ResponseWriter, req *http.Request
 
 func (s *HTTPServer) nodeToggleDrain(resp http.ResponseWriter, req *http.Request,
 	nodeID string) (interface{}, error) {
-	if req.Method != "PUT" && req.Method != "POST" {
+	if req.Method != http.MethodPut && req.Method != http.MethodPost {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
@@ -148,7 +148,7 @@ func (s *HTTPServer) nodeToggleDrain(resp http.ResponseWriter, req *http.Request
 
 func (s *HTTPServer) nodeToggleEligibility(resp http.ResponseWriter, req *http.Request,
 	nodeID string) (interface{}, error) {
-	if req.Method != "PUT" && req.Method != "POST" {
+	if req.Method != http.MethodPut && req.Method != http.MethodPost {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
@@ -172,7 +172,7 @@ func (s *HTTPServer) nodeToggleEligibility(resp http.ResponseWriter, req *http.R
 
 func (s *HTTPServer) nodeQuery(resp http.ResponseWriter, req *http.Request,
 	nodeID string) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 	args := structs.NodeSpecificRequest{
@@ -195,7 +195,7 @@ func (s *HTTPServer) nodeQuery(resp http.ResponseWriter, req *http.Request,
 }
 
 func (s *HTTPServer) nodePurge(resp http.ResponseWriter, req *http.Request, nodeID string) (interface{}, error) {
-	if req.Method != "PUT" && req.Method != "POST" {
+	if req.Method != http.MethodPut && req.Method != http.MethodPost {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 	args := structs.NodeDeregisterRequest{

--- a/command/agent/node_endpoint_test.go
+++ b/command/agent/node_endpoint_test.go
@@ -34,7 +34,7 @@ func TestHTTP_NodesList(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/nodes", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/nodes", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -91,7 +91,7 @@ func TestHTTP_NodesPrefixList(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/nodes?prefix=12345678", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/nodes?prefix=12345678", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -149,7 +149,7 @@ func TestHTTP_NodesOSList(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/nodes?prefix=123456&os=true", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/nodes?prefix=123456&os=true", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -213,7 +213,7 @@ func TestHTTP_NodeForceEval(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("POST", "/v1/node/"+node.ID+"/evaluate", nil)
+		req, err := http.NewRequest(http.MethodPost, "/v1/node/"+node.ID+"/evaluate", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -273,7 +273,7 @@ func TestHTTP_NodeAllocations(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/node/"+node.ID+"/allocations", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/node/"+node.ID+"/allocations", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -334,7 +334,7 @@ func TestHTTP_NodeDrain(t *testing.T) {
 
 		// Make the HTTP request
 		buf := encodeReq(drainReq)
-		req, err := http.NewRequest("POST", "/v1/node/"+node.ID+"/drain", buf)
+		req, err := http.NewRequest(http.MethodPost, "/v1/node/"+node.ID+"/drain", buf)
 		require.Nil(err)
 		respW := httptest.NewRecorder()
 
@@ -376,7 +376,7 @@ func TestHTTP_NodeDrain(t *testing.T) {
 			"cancel_reason": "changed my mind",
 		}
 		buf = encodeReq(drainReq)
-		req, err = http.NewRequest("POST", "/v1/node/"+node.ID+"/drain", buf)
+		req, err = http.NewRequest(http.MethodPost, "/v1/node/"+node.ID+"/drain", buf)
 		require.Nil(err)
 		respW = httptest.NewRecorder()
 
@@ -422,7 +422,7 @@ func TestHTTP_NodeEligible(t *testing.T) {
 
 		// Make the HTTP request
 		buf := encodeReq(eligibilityReq)
-		req, err := http.NewRequest("POST", "/v1/node/"+node.ID+"/eligibility", buf)
+		req, err := http.NewRequest(http.MethodPost, "/v1/node/"+node.ID+"/eligibility", buf)
 		require.Nil(err)
 		respW := httptest.NewRecorder()
 
@@ -446,7 +446,7 @@ func TestHTTP_NodeEligible(t *testing.T) {
 		// Make the HTTP request to set something invalid
 		eligibilityReq.Eligibility = "foo"
 		buf = encodeReq(eligibilityReq)
-		req, err = http.NewRequest("POST", "/v1/node/"+node.ID+"/eligibility", buf)
+		req, err = http.NewRequest(http.MethodPost, "/v1/node/"+node.ID+"/eligibility", buf)
 		require.Nil(err)
 		respW = httptest.NewRecorder()
 
@@ -484,7 +484,7 @@ func TestHTTP_NodePurge(t *testing.T) {
 		}
 
 		// Make the HTTP request to purge it
-		req, err := http.NewRequest("POST", "/v1/node/"+node.ID+"/purge", nil)
+		req, err := http.NewRequest(http.MethodPost, "/v1/node/"+node.ID+"/purge", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -537,7 +537,7 @@ func TestHTTP_NodeQuery(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/node/"+node.ID, nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/node/"+node.ID, nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/command/agent/node_pool_endpoint.go
+++ b/command/agent/node_pool_endpoint.go
@@ -13,9 +13,9 @@ import (
 
 func (s *HTTPServer) NodePoolsRequest(resp http.ResponseWriter, req *http.Request) (any, error) {
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		return s.nodePoolList(resp, req)
-	case "PUT", "POST":
+	case http.MethodPut, http.MethodPost:
 		return s.nodePoolUpsert(resp, req, "")
 	default:
 		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
@@ -38,11 +38,11 @@ func (s *HTTPServer) NodePoolSpecificRequest(resp http.ResponseWriter, req *http
 
 func (s *HTTPServer) nodePoolCRUD(resp http.ResponseWriter, req *http.Request, poolName string) (any, error) {
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		return s.nodePoolQuery(resp, req, poolName)
-	case "PUT", "POST":
+	case http.MethodPut, http.MethodPost:
 		return s.nodePoolUpsert(resp, req, poolName)
-	case "DELETE":
+	case http.MethodDelete:
 		return s.nodePoolDelete(resp, req, poolName)
 	default:
 		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)

--- a/command/agent/node_pool_endpoint.go
+++ b/command/agent/node_pool_endpoint.go
@@ -13,9 +13,9 @@ import (
 
 func (s *HTTPServer) NodePoolsRequest(resp http.ResponseWriter, req *http.Request) (any, error) {
 	switch req.Method {
-	case http.MethodGet:
+	case "GET":
 		return s.nodePoolList(resp, req)
-	case http.MethodPut, http.MethodPost:
+	case "PUT", "POST":
 		return s.nodePoolUpsert(resp, req, "")
 	default:
 		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
@@ -38,11 +38,11 @@ func (s *HTTPServer) NodePoolSpecificRequest(resp http.ResponseWriter, req *http
 
 func (s *HTTPServer) nodePoolCRUD(resp http.ResponseWriter, req *http.Request, poolName string) (any, error) {
 	switch req.Method {
-	case http.MethodGet:
+	case "GET":
 		return s.nodePoolQuery(resp, req, poolName)
-	case http.MethodPut, http.MethodPost:
+	case "PUT", "POST":
 		return s.nodePoolUpsert(resp, req, poolName)
-	case http.MethodDelete:
+	case "DELETE":
 		return s.nodePoolDelete(resp, req, poolName)
 	default:
 		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)

--- a/command/agent/node_pool_endpoint_test.go
+++ b/command/agent/node_pool_endpoint_test.go
@@ -32,7 +32,7 @@ func TestHTTP_NodePool_List(t *testing.T) {
 		must.NoError(t, err)
 
 		// Make HTTP request.
-		req, err := http.NewRequest("GET", "/v1/node/pools", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/node/pools", nil)
 		must.NoError(t, err)
 		respW := httptest.NewRecorder()
 
@@ -63,7 +63,7 @@ func TestHTTP_NodePool_Info(t *testing.T) {
 
 		t.Run("test pool", func(t *testing.T) {
 			// Make HTTP request for test pool.
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/node/pool/%s", pool.Name), nil)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/node/pool/%s", pool.Name), nil)
 			must.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -86,7 +86,7 @@ func TestHTTP_NodePool_Info(t *testing.T) {
 
 		t.Run("built-in pool", func(t *testing.T) {
 			// Make HTTP request for built-in pool.
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/node/pool/%s", structs.NodePoolAll), nil)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/node/pool/%s", structs.NodePoolAll), nil)
 			must.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -104,7 +104,7 @@ func TestHTTP_NodePool_Info(t *testing.T) {
 
 		t.Run("invalid pool", func(t *testing.T) {
 			// Make HTTP request for built-in pool.
-			req, err := http.NewRequest("GET", "/v1/node/pool/doesn-exist", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/node/pool/doesn-exist", nil)
 			must.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -126,7 +126,7 @@ func TestHTTP_NodePool_Create(t *testing.T) {
 		// Create test node pool.
 		pool := mock.NodePool()
 		buf := encodeReq(pool)
-		req, err := http.NewRequest("PUT", "/v1/node/pools", buf)
+		req, err := http.NewRequest(http.MethodPut, "/v1/node/pools", buf)
 		must.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -174,7 +174,7 @@ func TestHTTP_NodePool_Update(t *testing.T) {
 			}
 
 			buf := encodeReq(updated)
-			req, err := http.NewRequest("PUT", fmt.Sprintf("/v1/node/pool/%s", updated.Name), buf)
+			req, err := http.NewRequest(http.MethodPut, fmt.Sprintf("/v1/node/pool/%s", updated.Name), buf)
 			must.NoError(t, err)
 
 			respW := httptest.NewRecorder()
@@ -218,7 +218,7 @@ func TestHTTP_NodePool_Update(t *testing.T) {
 			}
 
 			buf := encodeReq(updated)
-			req, err := http.NewRequest("PUT", "/v1/node/pool/", buf)
+			req, err := http.NewRequest(http.MethodPut, "/v1/node/pool/", buf)
 			must.NoError(t, err)
 
 			respW := httptest.NewRecorder()
@@ -261,7 +261,7 @@ func TestHTTP_NodePool_Update(t *testing.T) {
 
 			// Make request with the wrong path.
 			buf := encodeReq(updated)
-			req, err := http.NewRequest("PUT", "/v1/node/pool/wrong", buf)
+			req, err := http.NewRequest(http.MethodPut, "/v1/node/pool/wrong", buf)
 			must.NoError(t, err)
 
 			respW := httptest.NewRecorder()
@@ -294,7 +294,7 @@ func TestHTTP_NodePool_Delete(t *testing.T) {
 		must.NoError(t, err)
 
 		// Delete test node pool.
-		req, err := http.NewRequest("DELETE", fmt.Sprintf("/v1/node/pool/%s", pool.Name), nil)
+		req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/node/pool/%s", pool.Name), nil)
 		must.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -383,7 +383,7 @@ func TestHTTP_NodePool_NodesList(t *testing.T) {
 				t.Run(tc.name, func(t *testing.T) {
 					// Make HTTP request.
 					path := fmt.Sprintf("/v1/node/pool/%s/nodes?%s", tc.pool, tc.args)
-					req, err := http.NewRequest("GET", path, nil)
+					req, err := http.NewRequest(http.MethodGet, path, nil)
 					must.NoError(t, err)
 					respW := httptest.NewRecorder()
 

--- a/command/agent/node_pool_endpoint_test.go
+++ b/command/agent/node_pool_endpoint_test.go
@@ -32,7 +32,7 @@ func TestHTTP_NodePool_List(t *testing.T) {
 		must.NoError(t, err)
 
 		// Make HTTP request.
-		req, err := http.NewRequest(http.MethodGet, "/v1/node/pools", nil)
+		req, err := http.NewRequest("GET", "/v1/node/pools", nil)
 		must.NoError(t, err)
 		respW := httptest.NewRecorder()
 
@@ -63,7 +63,7 @@ func TestHTTP_NodePool_Info(t *testing.T) {
 
 		t.Run("test pool", func(t *testing.T) {
 			// Make HTTP request for test pool.
-			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/node/pool/%s", pool.Name), nil)
+			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/node/pool/%s", pool.Name), nil)
 			must.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -86,7 +86,7 @@ func TestHTTP_NodePool_Info(t *testing.T) {
 
 		t.Run("built-in pool", func(t *testing.T) {
 			// Make HTTP request for built-in pool.
-			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/node/pool/%s", structs.NodePoolAll), nil)
+			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/node/pool/%s", structs.NodePoolAll), nil)
 			must.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -104,7 +104,7 @@ func TestHTTP_NodePool_Info(t *testing.T) {
 
 		t.Run("invalid pool", func(t *testing.T) {
 			// Make HTTP request for built-in pool.
-			req, err := http.NewRequest(http.MethodGet, "/v1/node/pool/doesn-exist", nil)
+			req, err := http.NewRequest("GET", "/v1/node/pool/doesn-exist", nil)
 			must.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -126,7 +126,7 @@ func TestHTTP_NodePool_Create(t *testing.T) {
 		// Create test node pool.
 		pool := mock.NodePool()
 		buf := encodeReq(pool)
-		req, err := http.NewRequest(http.MethodPut, "/v1/node/pools", buf)
+		req, err := http.NewRequest("PUT", "/v1/node/pools", buf)
 		must.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -174,7 +174,7 @@ func TestHTTP_NodePool_Update(t *testing.T) {
 			}
 
 			buf := encodeReq(updated)
-			req, err := http.NewRequest(http.MethodPut, fmt.Sprintf("/v1/node/pool/%s", updated.Name), buf)
+			req, err := http.NewRequest("PUT", fmt.Sprintf("/v1/node/pool/%s", updated.Name), buf)
 			must.NoError(t, err)
 
 			respW := httptest.NewRecorder()
@@ -218,7 +218,7 @@ func TestHTTP_NodePool_Update(t *testing.T) {
 			}
 
 			buf := encodeReq(updated)
-			req, err := http.NewRequest(http.MethodPut, "/v1/node/pool/", buf)
+			req, err := http.NewRequest("PUT", "/v1/node/pool/", buf)
 			must.NoError(t, err)
 
 			respW := httptest.NewRecorder()
@@ -261,7 +261,7 @@ func TestHTTP_NodePool_Update(t *testing.T) {
 
 			// Make request with the wrong path.
 			buf := encodeReq(updated)
-			req, err := http.NewRequest(http.MethodPut, "/v1/node/pool/wrong", buf)
+			req, err := http.NewRequest("PUT", "/v1/node/pool/wrong", buf)
 			must.NoError(t, err)
 
 			respW := httptest.NewRecorder()
@@ -294,7 +294,7 @@ func TestHTTP_NodePool_Delete(t *testing.T) {
 		must.NoError(t, err)
 
 		// Delete test node pool.
-		req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/node/pool/%s", pool.Name), nil)
+		req, err := http.NewRequest("DELETE", fmt.Sprintf("/v1/node/pool/%s", pool.Name), nil)
 		must.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -383,7 +383,7 @@ func TestHTTP_NodePool_NodesList(t *testing.T) {
 				t.Run(tc.name, func(t *testing.T) {
 					// Make HTTP request.
 					path := fmt.Sprintf("/v1/node/pool/%s/nodes?%s", tc.pool, tc.args)
-					req, err := http.NewRequest(http.MethodGet, path, nil)
+					req, err := http.NewRequest("GET", path, nil)
 					must.NoError(t, err)
 					respW := httptest.NewRecorder()
 

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -38,7 +38,7 @@ func (s *HTTPServer) OperatorRequest(resp http.ResponseWriter, req *http.Request
 // OperatorRaftConfiguration is used to inspect the current Raft configuration.
 // This supports the stale query mode in case the cluster doesn't have a leader.
 func (s *HTTPServer) OperatorRaftConfiguration(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		resp.WriteHeader(http.StatusMethodNotAllowed)
 		return nil, nil
 	}
@@ -59,7 +59,7 @@ func (s *HTTPServer) OperatorRaftConfiguration(resp http.ResponseWriter, req *ht
 // OperatorRaftPeer supports actions on Raft peers. Currently we only support
 // removing peers by address.
 func (s *HTTPServer) OperatorRaftPeer(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "DELETE" {
+	if req.Method != http.MethodDelete {
 		return nil, CodedError(404, ErrInvalidMethod)
 	}
 
@@ -102,7 +102,7 @@ func (s *HTTPServer) OperatorRaftPeer(resp http.ResponseWriter, req *http.Reques
 func (s *HTTPServer) OperatorAutopilotConfiguration(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Switch on the method
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		var args structs.GenericRequest
 		if done := s.parse(resp, req, &args.Region, &args.QueryOptions); done {
 			return nil, nil
@@ -128,7 +128,7 @@ func (s *HTTPServer) OperatorAutopilotConfiguration(resp http.ResponseWriter, re
 
 		return out, nil
 
-	case "PUT":
+	case http.MethodPut:
 		var args structs.AutopilotSetConfigRequest
 		s.parseWriteRequest(req, &args.WriteRequest)
 
@@ -177,7 +177,7 @@ func (s *HTTPServer) OperatorAutopilotConfiguration(resp http.ResponseWriter, re
 
 // OperatorServerHealth is used to get the health of the servers in the given Region.
 func (s *HTTPServer) OperatorServerHealth(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(404, ErrInvalidMethod)
 	}
 
@@ -225,10 +225,10 @@ func (s *HTTPServer) OperatorServerHealth(resp http.ResponseWriter, req *http.Re
 func (s *HTTPServer) OperatorSchedulerConfiguration(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Switch on the method
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		return s.schedulerGetConfig(resp, req)
 
-	case "PUT", "POST":
+	case http.MethodPut, http.MethodPost:
 		return s.schedulerUpdateConfig(resp, req)
 
 	default:
@@ -297,9 +297,9 @@ func (s *HTTPServer) schedulerUpdateConfig(resp http.ResponseWriter, req *http.R
 
 func (s *HTTPServer) SnapshotRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		return s.snapshotSaveRequest(resp, req)
-	case "PUT", "POST":
+	case http.MethodPut, http.MethodPost:
 		return s.snapshotRestoreRequest(resp, req)
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)

--- a/command/agent/operator_endpoint_oss.go
+++ b/command/agent/operator_endpoint_oss.go
@@ -12,10 +12,10 @@ import (
 
 func (s *HTTPServer) LicenseRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		resp.WriteHeader(http.StatusNoContent)
 		return nil, nil
-	case "PUT":
+	case http.MethodPut:
 		return nil, CodedError(501, ErrEntOnly)
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)

--- a/command/agent/operator_endpoint_test.go
+++ b/command/agent/operator_endpoint_test.go
@@ -32,7 +32,7 @@ func TestHTTP_OperatorRaftConfiguration(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		body := bytes.NewBuffer(nil)
-		req, err := http.NewRequest("GET", "/v1/operator/raft/configuration", body)
+		req, err := http.NewRequest(http.MethodGet, "/v1/operator/raft/configuration", body)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -62,7 +62,7 @@ func TestHTTP_OperatorRaftPeer(t *testing.T) {
 	assert := assert.New(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		body := bytes.NewBuffer(nil)
-		req, err := http.NewRequest("DELETE", "/v1/operator/raft/peer?address=nope", body)
+		req, err := http.NewRequest(http.MethodDelete, "/v1/operator/raft/peer?address=nope", body)
 		assert.Nil(err)
 
 		// If we get this error, it proves we sent the address all the
@@ -77,7 +77,7 @@ func TestHTTP_OperatorRaftPeer(t *testing.T) {
 
 	httpTest(t, nil, func(s *TestAgent) {
 		body := bytes.NewBuffer(nil)
-		req, err := http.NewRequest("DELETE", "/v1/operator/raft/peer?id=nope", body)
+		req, err := http.NewRequest(http.MethodDelete, "/v1/operator/raft/peer?id=nope", body)
 		assert.Nil(err)
 
 		// If we get this error, it proves we sent the address all the
@@ -95,13 +95,13 @@ func TestOperator_AutopilotGetConfiguration(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		body := bytes.NewBuffer(nil)
-		req, _ := http.NewRequest("GET", "/v1/operator/autopilot/configuration", body)
+		req, _ := http.NewRequest(http.MethodGet, "/v1/operator/autopilot/configuration", body)
 		resp := httptest.NewRecorder()
 		obj, err := s.Server.OperatorAutopilotConfiguration(resp, req)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		if resp.Code != 200 {
+		if resp.Code != http.StatusOK {
 			t.Fatalf("bad code: %d", resp.Code)
 		}
 		out, ok := obj.(api.AutopilotConfiguration)
@@ -118,7 +118,7 @@ func TestOperator_AutopilotSetConfiguration(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		body := bytes.NewBuffer([]byte(`{"CleanupDeadServers": false}`))
-		req, _ := http.NewRequest("PUT", "/v1/operator/autopilot/configuration", body)
+		req, _ := http.NewRequest(http.MethodPut, "/v1/operator/autopilot/configuration", body)
 		resp := httptest.NewRecorder()
 		if _, err := s.Server.OperatorAutopilotConfiguration(resp, req); err != nil {
 			t.Fatalf("err: %v", err)
@@ -147,7 +147,7 @@ func TestOperator_AutopilotCASConfiguration(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		body := bytes.NewBuffer([]byte(`{"CleanupDeadServers": false}`))
-		req, _ := http.NewRequest("PUT", "/v1/operator/autopilot/configuration", body)
+		req, _ := http.NewRequest(http.MethodPut, "/v1/operator/autopilot/configuration", body)
 		resp := httptest.NewRecorder()
 		if _, err := s.Server.OperatorAutopilotConfiguration(resp, req); err != nil {
 			t.Fatalf("err: %v", err)
@@ -174,7 +174,7 @@ func TestOperator_AutopilotCASConfiguration(t *testing.T) {
 		// Create a CAS request, bad index
 		{
 			buf := bytes.NewBuffer([]byte(`{"CleanupDeadServers": true}`))
-			req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/operator/autopilot/configuration?cas=%d", reply.ModifyIndex-1), buf)
+			req, _ := http.NewRequest(http.MethodPut, fmt.Sprintf("/v1/operator/autopilot/configuration?cas=%d", reply.ModifyIndex-1), buf)
 			resp := httptest.NewRecorder()
 			obj, err := s.Server.OperatorAutopilotConfiguration(resp, req)
 			if err != nil {
@@ -189,7 +189,7 @@ func TestOperator_AutopilotCASConfiguration(t *testing.T) {
 		// Create a CAS request, good index
 		{
 			buf := bytes.NewBuffer([]byte(`{"CleanupDeadServers": true}`))
-			req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/operator/autopilot/configuration?cas=%d", reply.ModifyIndex), buf)
+			req, _ := http.NewRequest(http.MethodPut, fmt.Sprintf("/v1/operator/autopilot/configuration?cas=%d", reply.ModifyIndex), buf)
 			resp := httptest.NewRecorder()
 			obj, err := s.Server.OperatorAutopilotConfiguration(resp, req)
 			if err != nil {
@@ -218,7 +218,7 @@ func TestOperator_ServerHealth(t *testing.T) {
 		c.Server.RaftProtocol = 3
 	}, func(s *TestAgent) {
 		body := bytes.NewBuffer(nil)
-		req, _ := http.NewRequest("GET", "/v1/operator/autopilot/health", body)
+		req, _ := http.NewRequest(http.MethodGet, "/v1/operator/autopilot/health", body)
 		f := func() error {
 			resp := httptest.NewRecorder()
 			obj, err := s.Server.OperatorServerHealth(resp, req)
@@ -259,7 +259,7 @@ func TestOperator_ServerHealth_Unhealthy(t *testing.T) {
 		c.Autopilot.LastContactThreshold = -1 * time.Second
 	}, func(s *TestAgent) {
 		body := bytes.NewBuffer(nil)
-		req, _ := http.NewRequest("GET", "/v1/operator/autopilot/health", body)
+		req, _ := http.NewRequest(http.MethodGet, "/v1/operator/autopilot/health", body)
 		f := func() error {
 			resp := httptest.NewRecorder()
 			obj, err := s.Server.OperatorServerHealth(resp, req)
@@ -294,7 +294,7 @@ func TestOperator_SchedulerGetConfiguration(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		body := bytes.NewBuffer(nil)
-		req, _ := http.NewRequest("GET", "/v1/operator/scheduler/configuration", body)
+		req, _ := http.NewRequest(http.MethodGet, "/v1/operator/scheduler/configuration", body)
 		resp := httptest.NewRecorder()
 		obj, err := s.Server.OperatorSchedulerConfiguration(resp, req)
 		require.Nil(t, err)
@@ -324,7 +324,7 @@ func TestOperator_SchedulerSetConfiguration(t *testing.T) {
     "ServiceSchedulerEnabled": true
   }
 }`))
-		req, _ := http.NewRequest("PUT", "/v1/operator/scheduler/configuration", body)
+		req, _ := http.NewRequest(http.MethodPut, "/v1/operator/scheduler/configuration", body)
 		resp := httptest.NewRecorder()
 		setResp, err := s.Server.OperatorSchedulerConfiguration(resp, req)
 		require.Nil(t, err)
@@ -360,7 +360,7 @@ func TestOperator_SchedulerCASConfiguration(t *testing.T) {
                      "SysBatchSchedulerEnabled":true,
                      "BatchSchedulerEnabled":true
         }}`))
-		req, _ := http.NewRequest("PUT", "/v1/operator/scheduler/configuration", body)
+		req, _ := http.NewRequest(http.MethodPut, "/v1/operator/scheduler/configuration", body)
 		resp := httptest.NewRecorder()
 		setResp, err := s.Server.OperatorSchedulerConfiguration(resp, req)
 		require.Nil(err)
@@ -390,7 +390,7 @@ func TestOperator_SchedulerCASConfiguration(t *testing.T) {
                      "SystemSchedulerEnabled": false,
                      "BatchSchedulerEnabled":true
         }}`))
-			req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/operator/scheduler/configuration?cas=%d", reply.QueryMeta.Index-1), buf)
+			req, _ := http.NewRequest(http.MethodPut, fmt.Sprintf("/v1/operator/scheduler/configuration?cas=%d", reply.QueryMeta.Index-1), buf)
 			resp := httptest.NewRecorder()
 			setResp, err := s.Server.OperatorSchedulerConfiguration(resp, req)
 			require.Nil(err)
@@ -407,7 +407,7 @@ func TestOperator_SchedulerCASConfiguration(t *testing.T) {
                      "SystemSchedulerEnabled": false,
                      "BatchSchedulerEnabled":false
         }}`))
-			req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/operator/scheduler/configuration?cas=%d", reply.QueryMeta.Index), buf)
+			req, _ := http.NewRequest(http.MethodPut, fmt.Sprintf("/v1/operator/scheduler/configuration?cas=%d", reply.QueryMeta.Index), buf)
 			resp := httptest.NewRecorder()
 			setResp, err := s.Server.OperatorSchedulerConfiguration(resp, req)
 			require.Nil(err)
@@ -462,7 +462,7 @@ func TestOperator_SnapshotRequests(t *testing.T) {
 		require.NoError(t, err)
 
 		// now actually snapshot
-		req, _ := http.NewRequest("GET", "/v1/operator/snapshot", nil)
+		req, _ := http.NewRequest(http.MethodGet, "/v1/operator/snapshot", nil)
 		resp := httptest.NewRecorder()
 		_, err = s.Server.SnapshotRequest(resp, req)
 		require.NoError(t, err)
@@ -498,7 +498,7 @@ func TestOperator_SnapshotRequests(t *testing.T) {
 	}, func(s *TestAgent) {
 		jobExists := func() bool {
 			// check job isn't present
-			req, _ := http.NewRequest("GET", "/v1/job/"+job.ID, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/v1/job/"+job.ID, nil)
 			resp := httptest.NewRecorder()
 			j, _ := s.Server.jobCRUD(resp, req, job.ID)
 			return j != nil
@@ -512,7 +512,7 @@ func TestOperator_SnapshotRequests(t *testing.T) {
 		require.NoError(t, err)
 		defer f.Close()
 
-		req, _ := http.NewRequest("PUT", "/v1/operator/snapshot", f)
+		req, _ := http.NewRequest(http.MethodPut, "/v1/operator/snapshot", f)
 		resp := httptest.NewRecorder()
 		_, err = s.Server.SnapshotRequest(resp, req)
 		require.NoError(t, err)

--- a/command/agent/region_endpoint.go
+++ b/command/agent/region_endpoint.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *HTTPServer) RegionListRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 

--- a/command/agent/region_endpoint_test.go
+++ b/command/agent/region_endpoint_test.go
@@ -15,7 +15,7 @@ func TestHTTP_RegionList(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/regions", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/regions", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/command/agent/scaling_endpoint.go
+++ b/command/agent/scaling_endpoint.go
@@ -13,7 +13,7 @@ import (
 
 func (s *HTTPServer) ScalingPoliciesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		return s.scalingPoliciesListRequest(resp, req)
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)
@@ -52,7 +52,7 @@ func (s *HTTPServer) ScalingPolicySpecificRequest(resp http.ResponseWriter, req 
 func (s *HTTPServer) scalingPolicyCRUD(resp http.ResponseWriter, req *http.Request,
 	policyID string) (interface{}, error) {
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		return s.scalingPolicyQuery(resp, req, policyID)
 	default:
 		return nil, CodedError(405, ErrInvalidMethod)

--- a/command/agent/scaling_endpoint_test.go
+++ b/command/agent/scaling_endpoint_test.go
@@ -34,7 +34,7 @@ func TestHTTP_ScalingPoliciesList(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/scaling/policies", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/scaling/policies", nil)
 		require.NoError(err)
 
 		respW := httptest.NewRecorder()
@@ -75,7 +75,7 @@ func TestHTTP_ScalingPoliciesList_Filter(t *testing.T) {
 		}
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/scaling/policies?job="+job.ID, nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/scaling/policies?job="+job.ID, nil)
 		require.NoError(err)
 		respW := httptest.NewRecorder()
 
@@ -88,7 +88,7 @@ func TestHTTP_ScalingPoliciesList_Filter(t *testing.T) {
 		require.Len(l, 1)
 
 		// Request again, with policy type filter
-		req, err = http.NewRequest("GET", "/v1/scaling/policies?type=cluster", nil)
+		req, err = http.NewRequest(http.MethodGet, "/v1/scaling/policies?type=cluster", nil)
 		require.NoError(err)
 		respW = httptest.NewRecorder()
 
@@ -120,7 +120,7 @@ func TestHTTP_ScalingPolicyGet(t *testing.T) {
 		require.NoError(err)
 
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/scaling/policy/"+p.ID, nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/scaling/policy/"+p.ID, nil)
 		require.NoError(err)
 		respW := httptest.NewRecorder()
 

--- a/command/agent/search_endpoint_test.go
+++ b/command/agent/search_endpoint_test.go
@@ -33,7 +33,7 @@ func TestHTTP_PrefixSearchWithIllegalMethod(t *testing.T) {
 	ci.Parallel(t)
 
 	httpTest(t, nil, func(s *TestAgent) {
-		req, err := http.NewRequest("DELETE", "/v1/search", nil)
+		req, err := http.NewRequest(http.MethodDelete, "/v1/search", nil)
 		require.NoError(t, err)
 		respW := httptest.NewRecorder()
 
@@ -46,7 +46,7 @@ func TestHTTP_FuzzySearchWithIllegalMethod(t *testing.T) {
 	ci.Parallel(t)
 
 	httpTest(t, nil, func(s *TestAgent) {
-		req, err := http.NewRequest("DELETE", "/v1/search/fuzzy", nil)
+		req, err := http.NewRequest(http.MethodDelete, "/v1/search/fuzzy", nil)
 		require.NoError(t, err)
 		respW := httptest.NewRecorder()
 
@@ -76,7 +76,7 @@ func TestHTTP_PrefixSearch_POST(t *testing.T) {
 		createJobForTest(testJob, s, t)
 
 		data := structs.SearchRequest{Prefix: testJobPrefix, Context: structs.Jobs}
-		req, err := http.NewRequest("POST", "/v1/search", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -104,7 +104,7 @@ func TestHTTP_FuzzySearch_POST(t *testing.T) {
 	httpTest(t, nil, func(s *TestAgent) {
 		createJobForTest(testJobID, s, t)
 		data := structs.FuzzySearchRequest{Text: "fau", Context: structs.Namespaces}
-		req, err := http.NewRequest("POST", "/v1/search/fuzzy", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search/fuzzy", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -136,7 +136,7 @@ func TestHTTP_PrefixSearch_PUT(t *testing.T) {
 		createJobForTest(testJob, s, t)
 
 		data := structs.SearchRequest{Prefix: testJobPrefix, Context: structs.Jobs}
-		req, err := http.NewRequest("PUT", "/v1/search", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPut, "/v1/search", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -164,7 +164,7 @@ func TestHTTP_FuzzySearch_PUT(t *testing.T) {
 	httpTest(t, nil, func(s *TestAgent) {
 		createJobForTest(testJobID, s, t)
 		data := structs.FuzzySearchRequest{Text: "fau", Context: structs.Namespaces}
-		req, err := http.NewRequest("PUT", "/v1/search/fuzzy", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPut, "/v1/search/fuzzy", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -200,7 +200,7 @@ func TestHTTP_PrefixSearch_MultipleJobs(t *testing.T) {
 		createJobForTest(testJobC, s, t)
 
 		data := structs.SearchRequest{Prefix: testJobPrefix, Context: structs.Jobs}
-		req, err := http.NewRequest("POST", "/v1/search", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -232,7 +232,7 @@ func TestHTTP_FuzzySearch_MultipleJobs(t *testing.T) {
 		job4ID := createCmdJobForTest("job4", "/sbin/ping", s, t).ID
 
 		data := structs.FuzzySearchRequest{Text: "bin", Context: structs.Jobs}
-		req, err := http.NewRequest("POST", "/v1/search/fuzzy", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search/fuzzy", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -277,7 +277,7 @@ func TestHTTP_PrefixSearch_Evaluation(t *testing.T) {
 
 		prefix := eval1.ID[:len(eval1.ID)-2]
 		data := structs.SearchRequest{Prefix: prefix, Context: structs.Evals}
-		req, err := http.NewRequest("POST", "/v1/search", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -310,7 +310,7 @@ func TestHTTP_FuzzySearch_Evaluation(t *testing.T) {
 		// fuzzy search does prefix search for evaluations
 		prefix := eval1.ID[:len(eval1.ID)-2]
 		data := structs.FuzzySearchRequest{Text: prefix, Context: structs.Evals}
-		req, err := http.NewRequest("POST", "/v1/search/fuzzy", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search/fuzzy", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -349,7 +349,7 @@ func TestHTTP_PrefixSearch_Allocations(t *testing.T) {
 
 		prefix := alloc.ID[:len(alloc.ID)-2]
 		data := structs.SearchRequest{Prefix: prefix, Context: structs.Allocs}
-		req, err := http.NewRequest("POST", "/v1/search", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -379,7 +379,7 @@ func TestHTTP_FuzzySearch_Allocations(t *testing.T) {
 		require.NoError(t, err)
 
 		data := structs.FuzzySearchRequest{Text: "-job", Context: structs.Allocs}
-		req, err := http.NewRequest("POST", "/v1/search/fuzzy", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search/fuzzy", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -410,7 +410,7 @@ func TestHTTP_PrefixSearch_Nodes(t *testing.T) {
 
 		prefix := node.ID[:len(node.ID)-2]
 		data := structs.SearchRequest{Prefix: prefix, Context: structs.Nodes}
-		req, err := http.NewRequest("POST", "/v1/search", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -440,7 +440,7 @@ func TestHTTP_FuzzySearch_Nodes(t *testing.T) {
 		require.NoError(t, err)
 
 		data := structs.FuzzySearchRequest{Text: "oo", Context: structs.Nodes}
-		req, err := http.NewRequest("POST", "/v1/search/fuzzy", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search/fuzzy", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -470,7 +470,7 @@ func TestHTTP_PrefixSearch_Deployments(t *testing.T) {
 
 		prefix := deployment.ID[:len(deployment.ID)-2]
 		data := structs.SearchRequest{Prefix: prefix, Context: structs.Deployments}
-		req, err := http.NewRequest("POST", "/v1/search", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -499,7 +499,7 @@ func TestHTTP_FuzzySearch_Deployments(t *testing.T) {
 		// fuzzy search of deployments are prefix searches
 		prefix := deployment.ID[:len(deployment.ID)-2]
 		data := structs.FuzzySearchRequest{Text: prefix, Context: structs.Deployments}
-		req, err := http.NewRequest("POST", "/v1/search/fuzzy", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search/fuzzy", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -522,7 +522,7 @@ func TestHTTP_PrefixSearch_NoJob(t *testing.T) {
 
 	httpTest(t, nil, func(s *TestAgent) {
 		data := structs.SearchRequest{Prefix: "12345", Context: structs.Jobs}
-		req, err := http.NewRequest("POST", "/v1/search", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -542,7 +542,7 @@ func TestHTTP_FuzzySearch_NoJob(t *testing.T) {
 
 	httpTest(t, nil, func(s *TestAgent) {
 		data := structs.FuzzySearchRequest{Text: "12345", Context: structs.Jobs}
-		req, err := http.NewRequest("POST", "/v1/search/fuzzy", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search/fuzzy", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -572,7 +572,7 @@ func TestHTTP_PrefixSearch_AllContext(t *testing.T) {
 		require.NoError(t, err)
 
 		data := structs.SearchRequest{Prefix: testJobPrefix, Context: structs.All}
-		req, err := http.NewRequest("POST", "/v1/search", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -604,7 +604,7 @@ func TestHTTP_FuzzySearch_AllContext(t *testing.T) {
 		require.NoError(t, err)
 
 		data := structs.FuzzySearchRequest{Text: "aa", Context: structs.All}
-		req, err := http.NewRequest("POST", "/v1/search/fuzzy", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search/fuzzy", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -644,7 +644,7 @@ func TestHTTP_PrefixSearch_Variables(t *testing.T) {
 		require.NoError(t, setResp.Error)
 
 		data := structs.SearchRequest{Prefix: testPathPrefix, Context: structs.Variables}
-		req, err := http.NewRequest("POST", "/v1/search", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -677,7 +677,7 @@ func TestHTTP_FuzzySearch_Variables(t *testing.T) {
 		require.NoError(t, setResp.Error)
 
 		data := structs.FuzzySearchRequest{Text: testPathText, Context: structs.Variables}
-		req, err := http.NewRequest("POST", "/v1/search/", encodeReq(data))
+		req, err := http.NewRequest(http.MethodPost, "/v1/search/", encodeReq(data))
 		require.NoError(t, err)
 
 		respW := httptest.NewRecorder()
@@ -786,7 +786,7 @@ func TestHTTP_PrefixSearch_Variables_ACL(t *testing.T) {
 					},
 				}
 
-				req, err := http.NewRequest("POST", "/v1/search", encodeReq(data))
+				req, err := http.NewRequest(http.MethodPost, "/v1/search", encodeReq(data))
 				require.NoError(t, err)
 
 				respW := httptest.NewRecorder()
@@ -910,7 +910,7 @@ func TestHTTP_FuzzySearch_Variables_ACL(t *testing.T) {
 						Namespace: tcNS(tC),
 					},
 				}
-				req, err := http.NewRequest("POST", "/v1/search/fuzzy", encodeReq(data))
+				req, err := http.NewRequest(http.MethodPost, "/v1/search/fuzzy", encodeReq(data))
 				require.NoError(t, err)
 
 				setToken(req, tC.token)

--- a/command/agent/stats_endpoint_test.go
+++ b/command/agent/stats_endpoint_test.go
@@ -26,7 +26,7 @@ func TestClientStatsRequest(t *testing.T) {
 
 		// Local node, local resp
 		{
-			req, err := http.NewRequest("GET", "/v1/client/stats/?since=foo", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/client/stats/?since=foo", nil)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -43,7 +43,7 @@ func TestClientStatsRequest(t *testing.T) {
 			srv := s.server
 			s.server = nil
 
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/stats?node_id=%s", uuid.Generate()), nil)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/stats?node_id=%s", uuid.Generate()), nil)
 			require.Nil(err)
 
 			respW := httptest.NewRecorder()
@@ -69,7 +69,7 @@ func TestClientStatsRequest(t *testing.T) {
 				t.Fatalf("should have client: %v", err)
 			})
 
-			req, err := http.NewRequest("GET", fmt.Sprintf("/v1/client/stats?node_id=%s", c.NodeID()), nil)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/stats?node_id=%s", c.NodeID()), nil)
 			require.Nil(err)
 
 			respW := httptest.NewRecorder()
@@ -85,7 +85,7 @@ func TestClientStatsRequest_ACL(t *testing.T) {
 	assert := assert.New(t)
 	httpACLTest(t, nil, func(s *TestAgent) {
 		state := s.Agent.server.State()
-		req, err := http.NewRequest("GET", "/v1/client/stats/", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/client/stats/", nil)
 		assert.Nil(err)
 
 		// Try request without a token and expect failure

--- a/command/agent/status_endpoint.go
+++ b/command/agent/status_endpoint.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *HTTPServer) StatusLeaderRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
@@ -27,7 +27,7 @@ func (s *HTTPServer) StatusLeaderRequest(resp http.ResponseWriter, req *http.Req
 }
 
 func (s *HTTPServer) StatusPeersRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 

--- a/command/agent/status_endpoint_test.go
+++ b/command/agent/status_endpoint_test.go
@@ -15,7 +15,7 @@ func TestHTTP_StatusLeader(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/status/leader", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/status/leader", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -38,7 +38,7 @@ func TestHTTP_StatusPeers(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		// Make the HTTP request
-		req, err := http.NewRequest("GET", "/v1/status/peers", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/status/peers", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/command/agent/system_endpoint.go
+++ b/command/agent/system_endpoint.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *HTTPServer) GarbageCollectRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "PUT" {
+	if req.Method != http.MethodPut {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
@@ -27,7 +27,7 @@ func (s *HTTPServer) GarbageCollectRequest(resp http.ResponseWriter, req *http.R
 }
 
 func (s *HTTPServer) ReconcileJobSummaries(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "PUT" {
+	if req.Method != http.MethodPut {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 

--- a/command/agent/system_endpoint_test.go
+++ b/command/agent/system_endpoint_test.go
@@ -15,7 +15,7 @@ func TestHTTP_SystemGarbageCollect(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/system/gc", nil)
+		req, err := http.NewRequest(http.MethodPut, "/v1/system/gc", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -32,7 +32,7 @@ func TestHTTP_ReconcileJobSummaries(t *testing.T) {
 	ci.Parallel(t)
 	httpTest(t, nil, func(s *TestAgent) {
 		// Make the HTTP request
-		req, err := http.NewRequest("PUT", "/v1/system/reconcile/summaries", nil)
+		req, err := http.NewRequest(http.MethodPut, "/v1/system/reconcile/summaries", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -203,7 +203,7 @@ RETRY:
 		})
 	} else {
 		testutil.WaitForResult(func() (bool, error) {
-			req, _ := http.NewRequest("GET", "/v1/agent/self", nil)
+			req, _ := http.NewRequest(http.MethodGet, "/v1/agent/self", nil)
 			resp := httptest.NewRecorder()
 			_, err := a.Server.AgentSelfRequest(resp, req)
 			return err == nil && resp.Code == 200, err

--- a/command/agent/variable_endpoint.go
+++ b/command/agent/variable_endpoint.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *HTTPServer) VariablesListRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != http.MethodGet {
+	if req.Method != "GET" {
 		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
 	}
 

--- a/command/agent/variable_endpoint.go
+++ b/command/agent/variable_endpoint.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *HTTPServer) VariablesListRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if req.Method != "GET" {
+	if req.Method != http.MethodGet {
 		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
 	}
 

--- a/command/agent/variable_endpoint_test.go
+++ b/command/agent/variable_endpoint_test.go
@@ -41,7 +41,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.EqualError(t, err, ErrInvalidMethod)
 		})
 		t.Run("error_parse_list", func(t *testing.T) {
-			req, err := http.NewRequest("GET", "/v1/vars?wait=99a", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/vars?wait=99a", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			_, _ = s.Server.VariablesListRequest(respW, req)
@@ -49,7 +49,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.Equal(t, "Invalid wait time", string(respW.Body.Bytes()))
 		})
 		t.Run("error_rpc_list", func(t *testing.T) {
-			req, err := http.NewRequest("GET", "/v1/vars?region=bad", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/vars?region=bad", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariablesListRequest(respW, req)
@@ -58,7 +58,7 @@ func TestHTTP_Variables(t *testing.T) {
 		})
 		t.Run("list", func(t *testing.T) {
 			// Test the empty list case
-			req, err := http.NewRequest("GET", "/v1/vars", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/vars", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -75,7 +75,7 @@ func TestHTTP_Variables(t *testing.T) {
 			}
 
 			// Make the HTTP request
-			req, err = http.NewRequest("GET", "/v1/vars", nil)
+			req, err = http.NewRequest(http.MethodGet, "/v1/vars", nil)
 			require.NoError(t, err)
 			respW = httptest.NewRecorder()
 
@@ -92,7 +92,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.Len(t, obj.([]*structs.VariableMetadata), 4)
 
 			// test prefix query
-			req, err = http.NewRequest("GET", "/v1/vars?prefix="+svs[0].Path, nil)
+			req, err = http.NewRequest(http.MethodGet, "/v1/vars?prefix="+svs[0].Path, nil)
 			require.NoError(t, err)
 			respW = httptest.NewRecorder()
 
@@ -112,7 +112,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.Nil(t, obj)
 		})
 		t.Run("error_parse_query", func(t *testing.T) {
-			req, err := http.NewRequest("GET", "/v1/var/does/not/exist?wait=99a", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/var/does/not/exist?wait=99a", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			_, _ = s.Server.VariableSpecificRequest(respW, req)
@@ -120,7 +120,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.Equal(t, "Invalid wait time", string(respW.Body.Bytes()))
 		})
 		t.Run("error_rpc_query", func(t *testing.T) {
-			req, err := http.NewRequest("GET", "/v1/var/does/not/exist?region=bad", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/var/does/not/exist?region=bad", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -129,7 +129,7 @@ func TestHTTP_Variables(t *testing.T) {
 		})
 		t.Run("query_unset_path", func(t *testing.T) {
 			// Make a request for a non-existing variable
-			req, err := http.NewRequest("GET", "/v1/var/", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/var/", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -138,7 +138,7 @@ func TestHTTP_Variables(t *testing.T) {
 		})
 		t.Run("query_unset_variable", func(t *testing.T) {
 			// Make a request for a non-existing variable
-			req, err := http.NewRequest("GET", "/v1/var/not/real", nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/var/not/real", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -152,7 +152,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.NoError(t, rpcWriteSV(s, sv1, out))
 
 			// Query a variable
-			req, err := http.NewRequest("GET", "/v1/var/"+sv1.Path, nil)
+			req, err := http.NewRequest(http.MethodGet, "/v1/var/"+sv1.Path, nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -171,7 +171,7 @@ func TestHTTP_Variables(t *testing.T) {
 		sv1 := mock.Variable()
 		t.Run("error_parse_create", func(t *testing.T) {
 			buf := encodeBrokenReq(&sv1)
-			req, err := http.NewRequest("PUT", "/v1/var/"+sv1.Path, buf)
+			req, err := http.NewRequest(http.MethodPut, "/v1/var/"+sv1.Path, buf)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -180,7 +180,7 @@ func TestHTTP_Variables(t *testing.T) {
 		})
 		t.Run("error_rpc_create", func(t *testing.T) {
 			buf := encodeReq(sv1)
-			req, err := http.NewRequest("PUT", "/v1/var/does/not/exist?region=bad", buf)
+			req, err := http.NewRequest(http.MethodPut, "/v1/var/does/not/exist?region=bad", buf)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -191,7 +191,7 @@ func TestHTTP_Variables(t *testing.T) {
 			sv2 := sv1.Copy()
 			sv2.Items = nil
 			buf := encodeReq(sv2)
-			req, err := http.NewRequest("PUT", "/v1/var/"+sv1.Path, buf)
+			req, err := http.NewRequest(http.MethodPut, "/v1/var/"+sv1.Path, buf)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -200,7 +200,7 @@ func TestHTTP_Variables(t *testing.T) {
 		})
 		t.Run("create", func(t *testing.T) {
 			buf := encodeReq(sv1)
-			req, err := http.NewRequest("PUT", "/v1/var/"+sv1.Path, buf)
+			req, err := http.NewRequest(http.MethodPut, "/v1/var/"+sv1.Path, buf)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -231,7 +231,7 @@ func TestHTTP_Variables(t *testing.T) {
 			// break the request body
 			badBuf := encodeBrokenReq(&sv1U)
 
-			req, err := http.NewRequest("PUT", "/v1/var/"+sv1.Path, badBuf)
+			req, err := http.NewRequest(http.MethodPut, "/v1/var/"+sv1.Path, badBuf)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -249,7 +249,7 @@ func TestHTTP_Variables(t *testing.T) {
 
 			// test broken rpc error
 			buf := encodeReq(&sv1U)
-			req, err := http.NewRequest("PUT", "/v1/var/"+sv1.Path+"?region=bad", buf)
+			req, err := http.NewRequest(http.MethodPut, "/v1/var/"+sv1.Path+"?region=bad", buf)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -266,7 +266,7 @@ func TestHTTP_Variables(t *testing.T) {
 			svU.Items["new"] = "new"
 			// Make the HTTP request
 			buf := encodeReq(&svU)
-			req, err := http.NewRequest("PUT", "/v1/var/"+sv.Path, buf)
+			req, err := http.NewRequest(http.MethodPut, "/v1/var/"+sv.Path, buf)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -304,7 +304,7 @@ func TestHTTP_Variables(t *testing.T) {
 			// Make the HTTP request
 			{
 				buf := encodeReq(&svU)
-				req, err := http.NewRequest("PUT", "/v1/var/"+svU.Path+"?cas=1", buf)
+				req, err := http.NewRequest(http.MethodPut, "/v1/var/"+svU.Path+"?cas=1", buf)
 				require.NoError(t, err)
 				respW := httptest.NewRecorder()
 
@@ -331,7 +331,7 @@ func TestHTTP_Variables(t *testing.T) {
 			// Make the HTTP request
 			{
 				buf := encodeReq(&svU)
-				req, err := http.NewRequest("PUT", "/v1/var/"+svU.Path+"?cas="+fmt.Sprint(sv.ModifyIndex), buf)
+				req, err := http.NewRequest(http.MethodPut, "/v1/var/"+svU.Path+"?cas="+fmt.Sprint(sv.ModifyIndex), buf)
 				require.NoError(t, err)
 				respW := httptest.NewRecorder()
 
@@ -382,7 +382,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.NoError(t, rpcWriteSV(s, sv1, nil))
 
 			// Make the HTTP request
-			req, err := http.NewRequest("DELETE", "/v1/var/"+sv1.Path+"?region=bad", nil)
+			req, err := http.NewRequest(http.MethodDelete, "/v1/var/"+sv1.Path+"?region=bad", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -399,7 +399,7 @@ func TestHTTP_Variables(t *testing.T) {
 
 			// Make the HTTP request
 			{
-				req, err := http.NewRequest("DELETE", "/v1/var/"+sv.Path+"?cas=1", nil)
+				req, err := http.NewRequest(http.MethodDelete, "/v1/var/"+sv.Path+"?cas=1", nil)
 				require.NoError(t, err)
 				respW := httptest.NewRecorder()
 
@@ -427,7 +427,7 @@ func TestHTTP_Variables(t *testing.T) {
 			}
 			// Make the HTTP request
 			{
-				req, err := http.NewRequest("DELETE", "/v1/var/"+sv.Path+"?cas="+fmt.Sprint(sv.ModifyIndex), nil)
+				req, err := http.NewRequest(http.MethodDelete, "/v1/var/"+sv.Path+"?cas="+fmt.Sprint(sv.ModifyIndex), nil)
 				require.NoError(t, err)
 				respW := httptest.NewRecorder()
 
@@ -448,7 +448,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.NoError(t, rpcWriteSV(s, sv1, nil))
 
 			// Make the HTTP request
-			req, err := http.NewRequest("DELETE", "/v1/var/"+sv1.Path, nil)
+			req, err := http.NewRequest(http.MethodDelete, "/v1/var/"+sv1.Path, nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 

--- a/command/agent/variable_endpoint_test.go
+++ b/command/agent/variable_endpoint_test.go
@@ -41,7 +41,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.EqualError(t, err, ErrInvalidMethod)
 		})
 		t.Run("error_parse_list", func(t *testing.T) {
-			req, err := http.NewRequest(http.MethodGet, "/v1/vars?wait=99a", nil)
+			req, err := http.NewRequest("GET", "/v1/vars?wait=99a", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			_, _ = s.Server.VariablesListRequest(respW, req)
@@ -49,7 +49,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.Equal(t, "Invalid wait time", string(respW.Body.Bytes()))
 		})
 		t.Run("error_rpc_list", func(t *testing.T) {
-			req, err := http.NewRequest(http.MethodGet, "/v1/vars?region=bad", nil)
+			req, err := http.NewRequest("GET", "/v1/vars?region=bad", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariablesListRequest(respW, req)
@@ -58,7 +58,7 @@ func TestHTTP_Variables(t *testing.T) {
 		})
 		t.Run("list", func(t *testing.T) {
 			// Test the empty list case
-			req, err := http.NewRequest(http.MethodGet, "/v1/vars", nil)
+			req, err := http.NewRequest("GET", "/v1/vars", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -75,7 +75,7 @@ func TestHTTP_Variables(t *testing.T) {
 			}
 
 			// Make the HTTP request
-			req, err = http.NewRequest(http.MethodGet, "/v1/vars", nil)
+			req, err = http.NewRequest("GET", "/v1/vars", nil)
 			require.NoError(t, err)
 			respW = httptest.NewRecorder()
 
@@ -92,7 +92,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.Len(t, obj.([]*structs.VariableMetadata), 4)
 
 			// test prefix query
-			req, err = http.NewRequest(http.MethodGet, "/v1/vars?prefix="+svs[0].Path, nil)
+			req, err = http.NewRequest("GET", "/v1/vars?prefix="+svs[0].Path, nil)
 			require.NoError(t, err)
 			respW = httptest.NewRecorder()
 
@@ -112,7 +112,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.Nil(t, obj)
 		})
 		t.Run("error_parse_query", func(t *testing.T) {
-			req, err := http.NewRequest(http.MethodGet, "/v1/var/does/not/exist?wait=99a", nil)
+			req, err := http.NewRequest("GET", "/v1/var/does/not/exist?wait=99a", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			_, _ = s.Server.VariableSpecificRequest(respW, req)
@@ -120,7 +120,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.Equal(t, "Invalid wait time", string(respW.Body.Bytes()))
 		})
 		t.Run("error_rpc_query", func(t *testing.T) {
-			req, err := http.NewRequest(http.MethodGet, "/v1/var/does/not/exist?region=bad", nil)
+			req, err := http.NewRequest("GET", "/v1/var/does/not/exist?region=bad", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -129,7 +129,7 @@ func TestHTTP_Variables(t *testing.T) {
 		})
 		t.Run("query_unset_path", func(t *testing.T) {
 			// Make a request for a non-existing variable
-			req, err := http.NewRequest(http.MethodGet, "/v1/var/", nil)
+			req, err := http.NewRequest("GET", "/v1/var/", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -138,7 +138,7 @@ func TestHTTP_Variables(t *testing.T) {
 		})
 		t.Run("query_unset_variable", func(t *testing.T) {
 			// Make a request for a non-existing variable
-			req, err := http.NewRequest(http.MethodGet, "/v1/var/not/real", nil)
+			req, err := http.NewRequest("GET", "/v1/var/not/real", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -152,7 +152,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.NoError(t, rpcWriteSV(s, sv1, out))
 
 			// Query a variable
-			req, err := http.NewRequest(http.MethodGet, "/v1/var/"+sv1.Path, nil)
+			req, err := http.NewRequest("GET", "/v1/var/"+sv1.Path, nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -171,7 +171,7 @@ func TestHTTP_Variables(t *testing.T) {
 		sv1 := mock.Variable()
 		t.Run("error_parse_create", func(t *testing.T) {
 			buf := encodeBrokenReq(&sv1)
-			req, err := http.NewRequest(http.MethodPut, "/v1/var/"+sv1.Path, buf)
+			req, err := http.NewRequest("PUT", "/v1/var/"+sv1.Path, buf)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -180,7 +180,7 @@ func TestHTTP_Variables(t *testing.T) {
 		})
 		t.Run("error_rpc_create", func(t *testing.T) {
 			buf := encodeReq(sv1)
-			req, err := http.NewRequest(http.MethodPut, "/v1/var/does/not/exist?region=bad", buf)
+			req, err := http.NewRequest("PUT", "/v1/var/does/not/exist?region=bad", buf)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -191,7 +191,7 @@ func TestHTTP_Variables(t *testing.T) {
 			sv2 := sv1.Copy()
 			sv2.Items = nil
 			buf := encodeReq(sv2)
-			req, err := http.NewRequest(http.MethodPut, "/v1/var/"+sv1.Path, buf)
+			req, err := http.NewRequest("PUT", "/v1/var/"+sv1.Path, buf)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -200,7 +200,7 @@ func TestHTTP_Variables(t *testing.T) {
 		})
 		t.Run("create", func(t *testing.T) {
 			buf := encodeReq(sv1)
-			req, err := http.NewRequest(http.MethodPut, "/v1/var/"+sv1.Path, buf)
+			req, err := http.NewRequest("PUT", "/v1/var/"+sv1.Path, buf)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 			obj, err := s.Server.VariableSpecificRequest(respW, req)
@@ -231,7 +231,7 @@ func TestHTTP_Variables(t *testing.T) {
 			// break the request body
 			badBuf := encodeBrokenReq(&sv1U)
 
-			req, err := http.NewRequest(http.MethodPut, "/v1/var/"+sv1.Path, badBuf)
+			req, err := http.NewRequest("PUT", "/v1/var/"+sv1.Path, badBuf)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -249,7 +249,7 @@ func TestHTTP_Variables(t *testing.T) {
 
 			// test broken rpc error
 			buf := encodeReq(&sv1U)
-			req, err := http.NewRequest(http.MethodPut, "/v1/var/"+sv1.Path+"?region=bad", buf)
+			req, err := http.NewRequest("PUT", "/v1/var/"+sv1.Path+"?region=bad", buf)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -266,7 +266,7 @@ func TestHTTP_Variables(t *testing.T) {
 			svU.Items["new"] = "new"
 			// Make the HTTP request
 			buf := encodeReq(&svU)
-			req, err := http.NewRequest(http.MethodPut, "/v1/var/"+sv.Path, buf)
+			req, err := http.NewRequest("PUT", "/v1/var/"+sv.Path, buf)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -304,7 +304,7 @@ func TestHTTP_Variables(t *testing.T) {
 			// Make the HTTP request
 			{
 				buf := encodeReq(&svU)
-				req, err := http.NewRequest(http.MethodPut, "/v1/var/"+svU.Path+"?cas=1", buf)
+				req, err := http.NewRequest("PUT", "/v1/var/"+svU.Path+"?cas=1", buf)
 				require.NoError(t, err)
 				respW := httptest.NewRecorder()
 
@@ -331,7 +331,7 @@ func TestHTTP_Variables(t *testing.T) {
 			// Make the HTTP request
 			{
 				buf := encodeReq(&svU)
-				req, err := http.NewRequest(http.MethodPut, "/v1/var/"+svU.Path+"?cas="+fmt.Sprint(sv.ModifyIndex), buf)
+				req, err := http.NewRequest("PUT", "/v1/var/"+svU.Path+"?cas="+fmt.Sprint(sv.ModifyIndex), buf)
 				require.NoError(t, err)
 				respW := httptest.NewRecorder()
 
@@ -382,7 +382,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.NoError(t, rpcWriteSV(s, sv1, nil))
 
 			// Make the HTTP request
-			req, err := http.NewRequest(http.MethodDelete, "/v1/var/"+sv1.Path+"?region=bad", nil)
+			req, err := http.NewRequest("DELETE", "/v1/var/"+sv1.Path+"?region=bad", nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 
@@ -399,7 +399,7 @@ func TestHTTP_Variables(t *testing.T) {
 
 			// Make the HTTP request
 			{
-				req, err := http.NewRequest(http.MethodDelete, "/v1/var/"+sv.Path+"?cas=1", nil)
+				req, err := http.NewRequest("DELETE", "/v1/var/"+sv.Path+"?cas=1", nil)
 				require.NoError(t, err)
 				respW := httptest.NewRecorder()
 
@@ -427,7 +427,7 @@ func TestHTTP_Variables(t *testing.T) {
 			}
 			// Make the HTTP request
 			{
-				req, err := http.NewRequest(http.MethodDelete, "/v1/var/"+sv.Path+"?cas="+fmt.Sprint(sv.ModifyIndex), nil)
+				req, err := http.NewRequest("DELETE", "/v1/var/"+sv.Path+"?cas="+fmt.Sprint(sv.ModifyIndex), nil)
 				require.NoError(t, err)
 				respW := httptest.NewRecorder()
 
@@ -448,7 +448,7 @@ func TestHTTP_Variables(t *testing.T) {
 			require.NoError(t, rpcWriteSV(s, sv1, nil))
 
 			// Make the HTTP request
-			req, err := http.NewRequest(http.MethodDelete, "/v1/var/"+sv1.Path, nil)
+			req, err := http.NewRequest("DELETE", "/v1/var/"+sv1.Path, nil)
 			require.NoError(t, err)
 			respW := httptest.NewRecorder()
 

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1219,7 +1219,7 @@ func (c *OperatorDebugCommand) collectConsulAPI(client *http.Client, urlPath str
 func (c *OperatorDebugCommand) collectConsulAPIRequest(client *http.Client, urlPath string, dir string, file string) error {
 	url := c.consul.addrVal + urlPath
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP request for Consul API URL=%q: %w", url, err)
 	}
@@ -1253,7 +1253,7 @@ func (c *OperatorDebugCommand) collectVault(dir, vault string) error {
 		}
 	}
 
-	req, err := http.NewRequest("GET", vaultAddr+"/v1/sys/health", nil)
+	req, err := http.NewRequest(http.MethodGet, vaultAddr+"/v1/sys/health", nil)
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP request for Vault API URL=%q: %w", vaultAddr, err)
 	}

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -833,7 +833,7 @@ func TestDebug_RedirectError(t *testing.T) {
 		}
 
 		w.Header().Set("Location", "/ui/")
-		w.WriteHeader(307)
+		w.WriteHeader(http.StatusTemporaryRedirect)
 		fmt.Fprintln(w, `<a href="/ui/">Temporary Redirect</a>.`)
 	}))
 	defer ts.Close()

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -360,7 +360,7 @@ func (s *TestServer) url(path string) string {
 
 // requireOK checks the HTTP response code and ensures it is acceptable.
 func (s *TestServer) requireOK(resp *http.Response) error {
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("Bad status code: %d", resp.StatusCode)
 	}
 	return nil
@@ -368,7 +368,7 @@ func (s *TestServer) requireOK(resp *http.Response) error {
 
 // put performs a new HTTP PUT request.
 func (s *TestServer) put(path string, body io.Reader) *http.Response {
-	req, err := http.NewRequest("PUT", s.url(path), body)
+	req, err := http.NewRequest(http.MethodPut, s.url(path), body)
 	if err != nil {
 		s.t.Fatalf("err: %s", err)
 	}


### PR DESCRIPTION
# What

- Modify `net/http` related calls to consistently use HTTP methods and response codes from variables/constants provided by the pkg.
- Add `usestdlibvars` to lint configuration.

See #18061 and #18062 for changes related to node pool and variable endpoints.

# Why

Some parts of the codebase already use these. With this PR, better code consistency and reliability.

