### PR TITLE
Retain task states for post stop tasks at the time of node GC

### DIFF
--- a/.changelog/17971.txt
+++ b/.changelog/17971.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where the state of poststop tasks could be corrupted by client gc
+```

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -734,6 +734,19 @@ func (ar *allocRunner) killTasks() map[string]*structs.TaskState {
 	}
 	wg.Wait()
 
+	// Perform no action on post stop tasks, but retain their states if they exist. This
+	// commonly happens at the time of alloc GC from the client node.
+	for name, tr := range ar.tasks {
+		if !tr.IsPoststopTask() {
+			continue
+		}
+
+		state := tr.TaskState()
+		if state != nil {
+			states[name] = state
+		}
+	}
+
 	return states
 }
 


### PR DESCRIPTION
Persist the task states for post stop tasks at the time of killing to resolve https://github.com/hashicorp/nomad/issues/17971.

Please note that this is the safer of the two options discussed within the original issue description.