### PR TITLE
website: add Nomad Ops to Tools

### DIFF
--- a/website/content/tools/index.mdx
+++ b/website/content/tools/index.mdx
@@ -42,6 +42,7 @@ The following external tools are currently available for Nomad and maintained by
 - [Nomad Firehose](https://github.com/seatgeek/nomad-firehose) - A tool to enable teams to quickly build logic around nomad task events without hooking into Nomad API
 - [Nomad Helper](https://github.com/seatgeek/nomad-helper) - A Nomad helper binary. Reevaluate jobs, force garbage collection, drain nodes, export/import count information
 - [Nomad Monitoring](https://github.com/mr-karan/nomad-monitoring) -  Collection of jobspecs and Grafana dashboards for end to end monitoring of Nomad clusters
+- [Nomad Ops](https://nomad-ops.github.io/nomad-ops) - A simple operator for Nomad which reconciles the running jobs in comparison to git repos
 - [Nomad Pipeline](https://github.com/HyperBadger/nomad-pipeline) - A tool to make running pipeline-style workloads on Nomad
 - [Nomad Toast](https://github.com/jrasell/nomad-toast) - A tool for receiving notifications based on HashiCorp Nomad events
 - [Nomad Vector Logger](https://github.com/mr-karan/nomad-vector-logger) -  A daemon which continuously watches jobs running in a Nomad cluster and templates out a Vector configuration file which can be used to collect application logs enriched with Nomad metadata. 


### PR DESCRIPTION
Add https://github.com/nomad-ops/nomad-ops to our Tools page.