### PR TITLE
state: canonicalize namespace on restore

### DIFF
--- a/.changelog/18017.txt
+++ b/.changelog/18017.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fixed a bug where namespace were not canonicalize on snapshot restore, resulting in potential nil access panic
+```

--- a/.changelog/18017.txt
+++ b/.changelog/18017.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-core: Fixed a bug where namespace were not canonicalize on snapshot restore, resulting in potential nil access panic
+core: Fixed a bug where namespaces were not canonicalized on snapshot restore, resulting in potential nil access panic
 ```

--- a/nomad/state/state_store_restore.go
+++ b/nomad/state/state_store_restore.go
@@ -205,6 +205,8 @@ func (r *StateRestore) ScalingEventsRestore(jobEvents *structs.JobScalingEvents)
 
 // NamespaceRestore is used to restore a namespace
 func (r *StateRestore) NamespaceRestore(ns *structs.Namespace) error {
+	// Handle upgrade path.
+	ns.Canonicalize()
 	if err := r.txn.Insert(TableNamespaces, ns); err != nil {
 		return fmt.Errorf("namespace insert failed: %v", err)
 	}


### PR DESCRIPTION
The upgrade path to Nomad 1.6.0 requires canonicalizing the namespace in order to set the default scheduler configuration values.

Previous implementation only canonicalized on namespace upsert operations, which works for recent namespaces as those Raft transactions are reapplied on upgrade.

But for older namespaces restore from a snapshot the code path did not canonicalize them, leaving the scheduler configuration set as `nil`.

Fixes #18007

_Note to reviewers: I was writing tests for this, but then I remembered that `Namespace.Canonicalize()` on OSS is no-op so I will add them to the Enterprise repo._
https://github.com/hashicorp/nomad/blob/f52912454dec9bc552b7e2b6f0e3160bd31c625e/nomad/structs/structs_oss.go#L16