### PR TITLE
backport fix for PR #17996 to 1.4.x

### DIFF
--- a/nomad/client_csi_endpoint.go
+++ b/nomad/client_csi_endpoint.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 // ClientCSI is used to forward RPC requests to the targed Nomad client's

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -19,7 +19,6 @@ import (
 	cconfig "github.com/hashicorp/nomad/client/config"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/helper/uuid"
-	"github.com/hashicorp/nomad/lib/lang"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -1981,18 +1980,24 @@ func TestCSI_SerializedControllerRPC(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(3)
 
-	timeCh := make(chan lang.Pair[string, time.Duration])
+	timeCh := make(chan struct {
+		pluginID string
+		dur      time.Duration
+	})
 
 	testFn := func(pluginID string, dur time.Duration) {
 		defer wg.Done()
-		c := NewCSIVolumeEndpoint(srv, nil)
+		c := &CSIVolume{srv: srv, logger: nil}
 		now := time.Now()
 		err := c.serializedControllerRPC(pluginID, func() error {
 			time.Sleep(dur)
 			return nil
 		})
 		elapsed := time.Since(now)
-		timeCh <- lang.Pair[string, time.Duration]{pluginID, elapsed}
+		timeCh <- struct {
+			pluginID string
+			dur      time.Duration
+		}{pluginID, elapsed}
 		must.NoError(t, err)
 	}
 
@@ -2002,8 +2007,8 @@ func TestCSI_SerializedControllerRPC(t *testing.T) {
 
 	totals := map[string]time.Duration{}
 	for i := 0; i < 3; i++ {
-		pair := <-timeCh
-		totals[pair.First] += pair.Second
+		result := <-timeCh
+		totals[result.pluginID] += result.dur
 	}
 
 	wg.Wait()


### PR DESCRIPTION
The backport for #17996 was automatically merged by BPA but the build did not work due to missing imports and changes to the signatures of some our RPC structs. Fix the backport.