### PR TITLE
ui: handle errors from unimplemented services

### DIFF
--- a/.changelog/18020.txt
+++ b/.changelog/18020.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed error handling for cross-region requests when the receiving region does not implement the endpoint being requested
+```

--- a/ui/app/adapters/application.js
+++ b/ui/app/adapters/application.js
@@ -44,7 +44,9 @@ export default class ApplicationAdapter extends RESTAdapter {
     return super.findAll(...arguments).catch((error) => {
       const errorCodes = codesForError(error);
 
-      const isNotImplemented = errorCodes.includes('501');
+      const isNotImplemented =
+        errorCodes.includes('501') ||
+        error.message.includes("rpc: can't find service");
 
       if (isNotImplemented) {
         return [];


### PR DESCRIPTION
When a request is made to an RPC service that doesn't exist (for example, a cross-region request from a newer version of Nomad to an older version that doesn't implement the endpoint) the application should return an empty list as well.