### PR TITLE
ui: handle node pool requests to older regions

### DIFF
--- a/.changelog/18021.txt
+++ b/.changelog/18021.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed a bug that could cause an error when accessing a region running versions of Nomad prior to 1.6.0
+```

--- a/ui/app/adapters/node-pool.js
+++ b/ui/app/adapters/node-pool.js
@@ -14,4 +14,21 @@ export default class NodePoolAdapter extends ApplicationAdapter {
     resource = pluralize(resource);
     return `/v1/${relationshipResource}/${resource}`;
   }
+
+  findAll() {
+    return super.findAll(...arguments).catch((error) => {
+      // Handle the case where the node pool request is sent to a region that
+      // doesn't have node pools and the request is handled by the nodes
+      // endpoint.
+      const isNodeRequest = error.message.includes(
+        'node lookup failed: index error: UUID must be 36 characters'
+      );
+      if (isNodeRequest) {
+        return [];
+      }
+
+      // Rethrow to be handled downstream.
+      throw error;
+    });
+  }
 }

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -247,7 +247,7 @@
         <span class="term">
           Node Pool
         </span>
-        {{this.model.nodePool}}
+        {{#if this.model.nodePool}}{{this.model.nodePool}}{{else}}-{{/if}}
       </span>
       {{#if this.model.nodeClass}}
         <span class="pair" data-test-node-class>

--- a/ui/app/templates/components/client-node-row.hbs
+++ b/ui/app/templates/components/client-node-row.hbs
@@ -18,7 +18,9 @@
   </span>
 </td>
 <td data-test-client-address class="is-200px is-truncatable">{{this.node.httpAddr}}</td>
-<td data-test-client-node-pool title="{{this.node.nodePool}}">{{this.node.nodePool}}</td>
+<td data-test-client-node-pool title="{{this.node.nodePool}}">
+  {{#if this.node.nodePool}}{{this.node.nodePool}}{{else}}-{{/if}}
+</td>
 <td data-test-client-datacenter>{{this.node.datacenter}}</td>
 <td data-test-client-version>{{this.node.version}}</td>
 <td data-test-client-volumes>{{if this.node.hostVolumes.length this.node.hostVolumes.length}}</td>

--- a/ui/app/templates/components/job-page/parts/stats-box.hbs
+++ b/ui/app/templates/components/job-page/parts/stats-box.hbs
@@ -33,7 +33,7 @@
     {{/if}}
     <span class="pair" data-test-job-stat="node-pool">
       <span class="term">Node Pool</span>
-      {{@job.nodePool}}
+      {{#if @job.nodePool}}{{@job.nodePool}}{{else}}-{{/if}}
     </span>
     {{yield to="after-namespace"}}
   </div>

--- a/ui/app/templates/components/job-row.hbs
+++ b/ui/app/templates/components/job-row.hbs
@@ -47,7 +47,7 @@
     {{this.job.displayType.type}}
   </td>
   <td data-test-job-node-pool>
-    {{this.job.nodePool}}
+    {{#if this.job.nodePool}}{{this.job.nodePool}}{{else}}-{{/if}}
   </td>
   <td data-test-job-priority>
     {{this.job.priority}}


### PR DESCRIPTION
When accessing a region running a version of Nomad without node pools an error was thrown because the request is handled by the nodes endpoint which fails because it assumes `pools` is the node ID.

Fixes #18007