### PR TITLE
scheduler: prevent -Inf in job anti affinity scoring

### DIFF
--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -619,7 +619,7 @@ func (iter *JobAntiAffinityIterator) Next() *RankedNode {
 
 		// Calculate the penalty based on number of collisions
 		// TODO(preetha): Figure out if batch jobs need a different scoring penalty where collisions matter less
-		if collisions > 0 {
+		if collisions > 0 && iter.desiredCount > 0 {
 			scorePenalty := -1 * float64(collisions+1) / float64(iter.desiredCount)
 			option.Scores = append(option.Scores, scorePenalty)
 			iter.ctx.Metrics().ScoreNode(option.Node, "job-anti-affinity", scorePenalty)


### PR DESCRIPTION
Similar to https://github.com/hashicorp/nomad/pull/17198, we are seeing 

```
job-anti-affinity": -Inf,
```

I am yet able to replicate the issue. My understanding is that with desiredCount of `0`, there should be no allocation placement, hence no ranking/feasibility code should run. 

https://github.com/hashicorp/nomad/blob/13ee343853431cf3f424a7dfd605632f0950c7ee/scheduler/generic_sched.go#L454-L469

That being said, it is happening and I believe the fix is straightforward.

I'll update the PR with more unit tests if possible once we understood the root cause.