### PR TITLE
[ui] Sort variables ascending by key at serialization time

### DIFF
--- a/.changelog/18051.txt
+++ b/.changelog/18051.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: sort variable key/values alphabetically by key when editing
+```

--- a/ui/app/serializers/variable.js
+++ b/ui/app/serializers/variable.js
@@ -21,12 +21,14 @@ export default class VariableSerializer extends ApplicationSerializer {
     if (!hash.Items) {
       hash.Items = { '': '' };
     }
-    hash.KeyValues = Object.entries(hash.Items).map(([key, value]) => {
-      return {
-        key,
-        value,
-      };
-    });
+    hash.KeyValues = Object.entries(hash.Items)
+      .map(([key, value]) => {
+        return {
+          key,
+          value,
+        };
+      })
+      .sort((a, b) => a.key.localeCompare(b.key));
     delete hash.Items;
     return super.normalizeFindRecordResponse(
       store,


### PR DESCRIPTION
Doesn't impact the variable view page, as it's already using a table that sorts ascending on key by default, but on the edit page, which iterates over and creates a form label for each, they'll now appear ascending on key alpha.