### PR TITLE
[ui] Search results are overloading filter with sorted results

### DIFF
--- a/.changelog/18053.txt
+++ b/.changelog/18053.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: search results are no longer overridden by sorting preferences on the jobs index page
+```

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -19,7 +19,6 @@ import {
   deserializedQueryParam as selection,
 } from 'nomad-ui/utils/qp-serialize';
 import classic from 'ember-classic-decorator';
-import { tracked } from '@glimmer/tracking';
 
 const DEFAULT_SORT_PROPERTY = 'modifyIndex';
 const DEFAULT_SORT_DESCENDING = true;
@@ -72,7 +71,7 @@ export default class IndexController extends Controller.extend(
   @readOnly('userSettings.pageSize') pageSize;
 
   sortProperty = DEFAULT_SORT_PROPERTY;
-  sortDescending = true;
+  sortDescending = DEFAULT_SORT_DESCENDING;
 
   @computed
   get searchProps() {
@@ -298,6 +297,7 @@ export default class IndexController extends Controller.extend(
     });
   }
 
+  // eslint-disable-next-line ember/require-computed-property-dependencies
   @computed('searchTerm')
   get sortAtLastSearch() {
     return {
@@ -307,13 +307,26 @@ export default class IndexController extends Controller.extend(
     };
   }
 
-  @computed('sortAtLastSearch', 'searchTerm', 'sortDescending', 'sortProperty')
+  @computed(
+    'searchTerm',
+    'sortAtLastSearch.{sortDescending,sortProperty}',
+    'sortDescending',
+    'sortProperty'
+  )
   get prioritizeSearchOrder() {
-    return (
+    let shouldPrioritizeSearchOrder =
       !!this.searchTerm &&
       this.sortAtLastSearch.sortProperty === this.sortProperty &&
-      this.sortAtLastSearch.sortDescending === this.sortDescending
-    );
+      this.sortAtLastSearch.sortDescending === this.sortDescending;
+    if (shouldPrioritizeSearchOrder) {
+      /* eslint-disable ember/no-side-effects */
+      this.set('sortDescending', DEFAULT_SORT_DESCENDING);
+      this.set('sortProperty', DEFAULT_SORT_PROPERTY);
+      this.set('sortAtLastSearch.sortProperty', DEFAULT_SORT_PROPERTY);
+      this.set('sortAtLastSearch.sortDescending', DEFAULT_SORT_DESCENDING);
+    }
+    /* eslint-enable ember/no-side-effects */
+    return shouldPrioritizeSearchOrder;
   }
 
   @alias('filteredJobs') listToSearch;

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -18,6 +18,8 @@ import {
 } from 'nomad-ui/utils/qp-serialize';
 import classic from 'ember-classic-decorator';
 
+const DEFAULT_SORT_PROPERTY = 'modifyIndex';
+
 @classic
 export default class IndexController extends Controller.extend(
   Sortable,
@@ -65,7 +67,7 @@ export default class IndexController extends Controller.extend(
   currentPage = 1;
   @readOnly('userSettings.pageSize') pageSize;
 
-  sortProperty = 'modifyIndex';
+  sortProperty = DEFAULT_SORT_PROPERTY;
   sortDescending = true;
 
   @computed
@@ -292,9 +294,17 @@ export default class IndexController extends Controller.extend(
     });
   }
 
+  @computed('sortProperty', 'searchTerm')
+  get unsortedSearchState() {
+    return this.sortProperty === DEFAULT_SORT_PROPERTY && !!this.searchTerm;
+  }
+
   @alias('filteredJobs') listToSearch;
   @alias('listSearched') listToSort;
-  @alias('listSorted') sortedJobs;
+
+  get sortedJobs() {
+    return this.unsortedSearchState ? this.listSearched : this.listSorted;
+  }
 
   isShowingDeploymentDetails = false;
 

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -19,6 +19,7 @@ import {
 import classic from 'ember-classic-decorator';
 
 const DEFAULT_SORT_PROPERTY = 'modifyIndex';
+const DEFAULT_SORT_DESCENDING = true;
 
 @classic
 export default class IndexController extends Controller.extend(
@@ -296,12 +297,19 @@ export default class IndexController extends Controller.extend(
 
   @computed('sortProperty', 'searchTerm')
   get unsortedSearchState() {
-    return this.sortProperty === DEFAULT_SORT_PROPERTY && !!this.searchTerm;
+    return (
+      this.sortProperty === DEFAULT_SORT_PROPERTY &&
+      this.sortDescending === DEFAULT_SORT_DESCENDING &&
+      !!this.searchTerm
+    );
   }
 
   @alias('filteredJobs') listToSearch;
   @alias('listSearched') listToSort;
 
+  // sortedJobs is what we use to populate the table;
+  // If the user has searched but not sorted, we return the (fuzzy) searched list verbatim
+  // If the user has sorted, we allow the fuzzy search to filter down the list, but return it in a sorted order.
   get sortedJobs() {
     return this.unsortedSearchState ? this.listSearched : this.listSorted;
   }

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -295,7 +295,7 @@ export default class IndexController extends Controller.extend(
     });
   }
 
-  @computed('sortProperty', 'searchTerm')
+  @computed('searchTerm', 'sortDescending', 'sortProperty')
   get unsortedSearchState() {
     return (
       this.sortProperty === DEFAULT_SORT_PROPERTY &&


### PR DESCRIPTION
Bit of context here:
- Our Searchable mixin uses fuzzy-finding, so both my jobs "fakepy" and "fails_after_10" will show up when I type "fai" or "fak" into my search bar
![image](https://github.com/hashicorp/nomad/assets/713991/25c38122-eff8-4732-9ed0-0c0c3f9522e8)
- Last year, we addressed a [bug where sorting wouldn't apply at all if a search term was present](https://github.com/hashicorp/nomad/issues/14872) in PR #15432 
- More recently, we'd heard concerns that our search results appeared degraded from previous versions, see these screenshots showing 1.5.6 and 1.4.10 respectively: 
<img width="151" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/1c048b13-eea5-4153-afe8-fd6a84f30abe">
<img width="135" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/cad83dc8-cde8-4264-a2aa-5ceb5f58510c">


This PR attempts to both preserve the ability to sort after searching, and not overload results with searched-but-not-ordered filter results by creating a new getter() that checks to see if any sorting has been applied.