### PR TITLE
build: support s390x architecture for linux (ent)

### DIFF
--- a/.changelog/18069.txt
+++ b/.changelog/18069.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-build: Support building s390x binaries (Enterprise)
+build (Enterprise): Support building s390x binaries. 
 ```

--- a/.changelog/18069.txt
+++ b/.changelog/18069.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+build: Support building s390x binaries (Enterprise)
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -53,6 +53,7 @@ ALL_TARGETS = linux_386 \
 	linux_amd64 \
 	linux_arm \
 	linux_arm64 \
+	linux_s390x \
 	windows_386 \
 	windows_amd64
 endif


### PR DESCRIPTION
Makefile changes required for supporting s390x builds and a corresponding changelog entry. 

Enterprise PR: https://github.com/hashicorp/nomad-enterprise/pull/1202

Resolves #18068 