### PR TITLE
cli: add help message for `-consul-namespace`

### DIFF
--- a/.changelog/18081.txt
+++ b/.changelog/18081.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Add missing help message for the `-consul-namespace` flag in the `nomad job run` command
+```

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -121,6 +121,14 @@ Run Options:
     the job file. This overrides the token found in $CONSUL_HTTP_TOKEN environment
     variable and that found in the job.
 
+  -consul-namespace
+    (Enterprise only) If set, any services in the job will be registered into
+    the specified Consul namespace. Any template block reading from Consul KV
+    will be scoped to the specified Consul namespace. If Consul ACLs are
+    enabled and the "consul" block "allow_unauthenticated" is disabled in the
+    Nomad server configuration, then a Consul token must be supplied with
+    appropriate service and KV Consul ACL policy permissions.
+
   -vault-token
     Used to validate if the user submitting the job has permission to run the job
     according to its Vault policies. A Vault token must be supplied if the vault
@@ -156,21 +164,22 @@ func (c *JobRunCommand) Synopsis() string {
 func (c *JobRunCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
-			"-check-index":     complete.PredictNothing,
-			"-detach":          complete.PredictNothing,
-			"-verbose":         complete.PredictNothing,
-			"-consul-token":    complete.PredictNothing,
-			"-vault-token":     complete.PredictAnything,
-			"-vault-namespace": complete.PredictAnything,
-			"-output":          complete.PredictNothing,
-			"-policy-override": complete.PredictNothing,
-			"-preserve-counts": complete.PredictNothing,
-			"-json":            complete.PredictNothing,
-			"-hcl1":            complete.PredictNothing,
-			"-hcl2-strict":     complete.PredictNothing,
-			"-var":             complete.PredictAnything,
-			"-var-file":        complete.PredictFiles("*.var"),
-			"-eval-priority":   complete.PredictNothing,
+			"-check-index":      complete.PredictNothing,
+			"-detach":           complete.PredictNothing,
+			"-verbose":          complete.PredictNothing,
+			"-consul-token":     complete.PredictNothing,
+			"-consul-namespace": complete.PredictAnything,
+			"-vault-token":      complete.PredictAnything,
+			"-vault-namespace":  complete.PredictAnything,
+			"-output":           complete.PredictNothing,
+			"-policy-override":  complete.PredictNothing,
+			"-preserve-counts":  complete.PredictNothing,
+			"-json":             complete.PredictNothing,
+			"-hcl1":             complete.PredictNothing,
+			"-hcl2-strict":      complete.PredictNothing,
+			"-var":              complete.PredictAnything,
+			"-var-file":         complete.PredictFiles("*.var"),
+			"-eval-priority":    complete.PredictNothing,
 		})
 }
 

--- a/website/content/docs/commands/job/run.mdx
+++ b/website/content/docs/commands/job/run.mdx
@@ -101,9 +101,9 @@ that volume.
 
 - `-consul-namespace`: <EnterpriseAlert inline/> If set, any services in the job will be registered into the
   specified Consul namespace. Any `template` block reading from Consul KV will
-  scoped to the specified Consul namespace. If Consul ACLs are enabled and the
+  be scoped to the specified Consul namespace. If Consul ACLs are enabled and the
   [`consul` block `allow_unauthenticated`] is disabled in the Nomad server configuration, then
-  a Consul token must be supplied with appropriate service and kv Consul ACL policy
+  a Consul token must be supplied with appropriate service and KV Consul ACL policy
   permissions.
 
 - `-vault-token`: Used to validate if the user submitting the job has


### PR DESCRIPTION
Add missing help entry for the `-consul-namespace` flag in `nomad job run`.