### PR TITLE
Added config flag to disable frame-ancestor for the nomad UI

### DIFF
--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -649,7 +649,13 @@ func (e *codedError) Code() int {
 func (s *HTTPServer) handleUI(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		header := w.Header()
-		header.Add("Content-Security-Policy", "default-src 'none'; connect-src *; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'none'; frame-ancestors 'none'")
+		agentConfig := s.agent.GetConfig()
+		uiDisableFrameAncestorsEnabled := agentConfig.UI != nil && agentConfig.UI.DisableFrameAncestors
+		if uiDisableFrameAncestorsEnabled {
+			header.Add("Content-Security-Policy", "default-src 'none'; connect-src *; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'none'")
+		} else {
+			header.Add("Content-Security-Policy", "default-src 'none'; connect-src *; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'none'; frame-ancestors 'none'")
+		}
 		h.ServeHTTP(w, req)
 	})
 }

--- a/nomad/structs/config/ui.go
+++ b/nomad/structs/config/ui.go
@@ -11,6 +11,9 @@ type UIConfig struct {
 	// Enabled is used to enable the web UI
 	Enabled bool `hcl:"enabled"`
 
+	// Disable frame-ancestors CSP header
+	DisableFrameAncestors bool `hcl:"disable_frame_ancestors"`
+
 	// Consul configures deep links for Consul UI
 	Consul *ConsulUIConfig `hcl:"consul"`
 


### PR DESCRIPTION
In order to be able to embed the nomad UI in an iframe as requested under #7056 I made a test implementation to add a configuration variable that disables `frame-ancestors 'none' ` 
The configuration option goes under the UI config and it is a boolen flag called: `DisableFrameAncestors`