### PR TITLE
fix 'default' alias not added to interface specified by `network_interface` 

### DIFF
--- a/.changelog/18096.txt
+++ b/.changelog/18096.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+fix: 'default' alias not added to interface specified by network_interface
+```

--- a/.changelog/18096.txt
+++ b/.changelog/18096.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-fingerprint: 'default' alias not added to interface specified by network_interface
+fingerprint: fix 'default' alias not being added to interface specified by network_interface
 ```

--- a/.changelog/18096.txt
+++ b/.changelog/18096.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-fix: 'default' alias not added to interface specified by network_interface
+fingerprint: 'default' alias not added to interface specified by network_interface
 ```

--- a/client/fingerprint/network.go
+++ b/client/fingerprint/network.go
@@ -247,18 +247,14 @@ func deriveAddressAliases(iface net.Interface, addr net.IP, config *config.Confi
 		}
 	}
 
-	if len(aliases) > 0 {
-		return
-	}
-
 	if config.NetworkInterface != "" {
 		if config.NetworkInterface == iface.Name {
-			return []string{"default"}
+			aliases = append(aliases, "default")
 		}
 	} else if ri, err := sockaddr.NewRouteInfo(); err == nil {
 		defaultIface, err := ri.GetDefaultInterfaceName()
 		if err == nil && iface.Name == defaultIface {
-			return []string{"default"}
+			aliases = append(aliases, "default")
 		}
 	}
 

--- a/client/fingerprint/network_test.go
+++ b/client/fingerprint/network_test.go
@@ -500,6 +500,9 @@ func TestNetworkFingerPrint_MultipleAliases(t *testing.T) {
 	for alias := range cfg.HostNetworks {
 		expected = append(expected, alias)
 	}
+	// eth3 matches the NetworkInterface and will then generate the 'default'
+	// alias
+	expected = append(expected, "default")
 	sort.Strings(expected)
 	sort.Strings(aliases)
 	require.Equal(t, expected, aliases, "host networks should match aliases")
@@ -537,7 +540,7 @@ func TestNetworkFingerPrint_HostNetworkReservedPorts(t *testing.T) {
 					CIDR:      "100.64.0.11/10",
 				},
 			},
-			expected: []string{"", "", ""},
+			expected: []string{"", "", "", ""},
 		},
 		{
 			name: "reserved ports in some aliases",
@@ -560,7 +563,7 @@ func TestNetworkFingerPrint_HostNetworkReservedPorts(t *testing.T) {
 					CIDR:      "100.64.0.11/10",
 				},
 			},
-			expected: []string{"22", "80,3000-4000", ""},
+			expected: []string{"22", "80,3000-4000", "", ""},
 		},
 	}
 


### PR DESCRIPTION
closes https://github.com/hashicorp/nomad/issues/18097

consider the following config.hcl
```hcl
# config.hcl
client {
  network_interface = "tailscale0"

  host_network "tailscale" {
    interface = "tailscale0"
  }

  host_network "public" {
    interface = "wlan0"
  }
}
```

whenever you would schedule the following job 

```hcl
# job.hcl
job "docs" {
  datacenters = ["dc1"]

  group "example" {
    network {
      port "http" {}
    }
    task "server" {
      driver = "docker"

      config {
        image = "hashicorp/http-echo"
        ports = ["http"]
        args = [
          "-listen",
          ":5678",
          "-text",
          "hello world",
        ]
      }
    }
  }
}
```

you would see `* Constraint "missing host network \"default\" for port \"http\"": 1 nodes excluded by filter` because the 'default' host_network alias is being replaces with 'tailscale'. The follow PR appends the 'default' alias regardless to the addresses specified by `network_interface`.