### PR TITLE
Added accessor info to Tuples in template.mdx

### DIFF
--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -508,7 +508,7 @@ link to the parent variable:
 
 - `Values`: produces a key-sorted list.
 
-- `Tuples`: produces a key-sorted list of K,V tuple structs.
+- `Tuples`: produces a key-sorted list of K,V tuple structs, with accessors `.K` and `.V` for the key and value respectively.
 
 - `Metadata`: returns this collection's parent metadata as a `NomadVarMeta`
 


### PR DESCRIPTION
I had to dig deep in google to find the accessor function for a tuple struct. Technically it is kinda there with K,V tuple struct. However, it was not clear to me and possibly others. Added the info.