### PR TITLE
identity: add support for multiple identities + audiences

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -723,7 +723,13 @@ type Task struct {
 	KillSignal      string                 `mapstructure:"kill_signal" hcl:"kill_signal,optional"`
 	Kind            string                 `hcl:"kind,optional"`
 	ScalingPolicies []*ScalingPolicy       `hcl:"scaling,block"`
-	Identity        *WorkloadIdentity      `hcl:"identity,block"`
+
+	// Identity is the default Nomad Workload Identity and will be added to
+	// Identities with the name "default"
+	Identity *WorkloadIdentity
+
+	// Workload Identities
+	Identities []*WorkloadIdentity `hcl:"identity,block"`
 }
 
 func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {
@@ -1145,6 +1151,8 @@ func (t *TaskCSIPluginConfig) Canonicalize() {
 // WorkloadIdentity is the jobspec block which determines if and how a workload
 // identity is exposed to tasks.
 type WorkloadIdentity struct {
-	Env  bool `hcl:"env,optional"`
-	File bool `hcl:"file,optional"`
+	Name     string   `hcl:"name,optional"`
+	Audience []string `mapstructure:"aud" hcl:"aud,optional"`
+	Env      bool     `hcl:"env,optional"`
+	File     bool     `hcl:"file,optional"`
 }

--- a/ci/test-core.json
+++ b/ci/test-core.json
@@ -26,6 +26,7 @@
     "client/hoststats/...",
     "client/structs/...",
     "client/taskenv/...",
+    "client/widmgr/...",
     "command/agent/...",
     "command/raft_tools/...",
     "command/ui/...",

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -30,6 +30,7 @@ import (
 	cstate "github.com/hashicorp/nomad/client/state"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/vaultclient"
+	"github.com/hashicorp/nomad/client/widmgr"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/device"
@@ -199,6 +200,9 @@ type allocRunner struct {
 
 	// wranglers is an interface for managing unix/windows processes.
 	wranglers cinterfaces.ProcessWranglers
+
+	// widmgr fetches workload identities
+	widmgr *widmgr.WIDMgr
 }
 
 // NewAllocRunner returns a new allocation runner.
@@ -241,6 +245,7 @@ func NewAllocRunner(config *config.AllocRunnerConfig) (interfaces.AllocRunner, e
 		getter:                   config.Getter,
 		wranglers:                config.Wranglers,
 		hookResources:            cstructs.NewAllocHookResources(),
+		widmgr:                   config.WIDMgr,
 	}
 
 	// Create the logger based on the allocation ID
@@ -298,6 +303,7 @@ func (ar *allocRunner) initTaskRunners(tasks []*structs.Task) error {
 			Getter:              ar.getter,
 			Wranglers:           ar.wranglers,
 			AllocHookResources:  ar.hookResources,
+			WIDMgr:              ar.widmgr,
 		}
 
 		// Create, but do not Run, the task runner

--- a/client/allocrunner/taskrunner/identity_hook.go
+++ b/client/allocrunner/taskrunner/identity_hook.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"sync"
 
 	log "github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/helper/users"
+	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 // identityHook sets the task runner's Nomad workload identity token
@@ -24,20 +24,22 @@ const (
 	wiTokenFile = "nomad_token"
 )
 
+// IdentitySigner is the interface needed to retrieve signed identities for
+// workload identities. At runtime it is implemented by *widmgr.WIDMgr.
+type IdentitySigner interface {
+	SignIdentities(minIndex uint64, req []*structs.WorkloadIdentityRequest) ([]*structs.SignedWorkloadIdentity, error)
+}
+
 type identityHook struct {
 	tr       *TaskRunner
+	tokenDir string
 	logger   log.Logger
-	taskName string
-	lock     sync.Mutex
-
-	// tokenPath is the path in which to read and write the token
-	tokenPath string
 }
 
 func newIdentityHook(tr *TaskRunner, logger log.Logger) *identityHook {
 	h := &identityHook{
 		tr:       tr,
-		taskName: tr.taskName,
+		tokenDir: tr.taskDir.SecretsDir,
 	}
 	h.logger = logger.Named(h.Name())
 	return h
@@ -48,32 +50,26 @@ func (*identityHook) Name() string {
 }
 
 func (h *identityHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-	h.tokenPath = filepath.Join(req.TaskDir.SecretsDir, wiTokenFile)
 
-	return h.setToken()
-}
-
-func (h *identityHook) Update(_ context.Context, req *interfaces.TaskUpdateRequest, _ *interfaces.TaskUpdateResponse) error {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-
-	return h.setToken()
-}
-
-// setToken adds the Nomad token to the task's environment and writes it to a
-// file if requested by the jobsepc.
-func (h *identityHook) setToken() error {
-	token := h.tr.alloc.SignedIdentities[h.taskName]
-	if token == "" {
-		return nil
+	// Handle default workload identity
+	if err := h.setDefaultToken(); err != nil {
+		return err
 	}
 
-	h.tr.setNomadToken(token)
+	signedWIDs, err := h.getIdentities(req.Alloc, req.Task)
+	if err != nil {
+		return fmt.Errorf("error fetching alternate identities: %w", err)
+	}
 
-	if id := h.tr.task.Identity; id != nil && id.File {
-		if err := h.writeToken(token); err != nil {
+	for _, widspec := range req.Task.Identities {
+		signedWID := signedWIDs[widspec.Name]
+		if signedWID == nil {
+			// The only way to hit this should be a bug as it indicates the server
+			// did not sign an identity for a task on this alloc.
+			return fmt.Errorf("missing workload identity %q", widspec.Name)
+		}
+
+		if err := h.setAltToken(widspec, signedWID.JWT); err != nil {
 			return err
 		}
 	}
@@ -81,12 +77,77 @@ func (h *identityHook) setToken() error {
 	return nil
 }
 
-// writeToken writes the given token to disk
-func (h *identityHook) writeToken(token string) error {
-	// Write token as owner readable only
-	if err := users.WriteFileFor(h.tokenPath, []byte(token), h.tr.task.User); err != nil {
-		return fmt.Errorf("failed to write nomad token: %w", err)
+// setDefaultToken adds the Nomad token to the task's environment and writes it to a
+// file if requested by the jobsepc.
+func (h *identityHook) setDefaultToken() error {
+	token := h.tr.alloc.SignedIdentities[h.tr.taskName]
+	if token == "" {
+		return nil
+	}
+
+	// Handle internal use and env var
+	h.tr.setNomadToken(token)
+
+	task := h.tr.Task()
+
+	// Handle file writing
+	if id := task.Identity; id != nil && id.File {
+		// Write token as owner readable only
+		tokenPath := filepath.Join(h.tokenDir, wiTokenFile)
+		if err := users.WriteFileFor(tokenPath, []byte(token), task.User); err != nil {
+			return fmt.Errorf("failed to write nomad token: %w", err)
+		}
 	}
 
 	return nil
+}
+
+// setAltToken takes an alternate workload identity and sets the env var and/or
+// writes the token file as specified by the jobspec.
+func (h *identityHook) setAltToken(widspec *structs.WorkloadIdentity, rawJWT string) error {
+	if widspec.Env {
+		h.tr.envBuilder.SetWorkloadToken(widspec.Name, rawJWT)
+	}
+
+	if widspec.File {
+		tokenPath := filepath.Join(h.tokenDir, fmt.Sprintf("nomad_%s.jwt", widspec.Name))
+		if err := users.WriteFileFor(tokenPath, []byte(rawJWT), h.tr.Task().User); err != nil {
+			return fmt.Errorf("failed to write token for identity %q: %w", widspec.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// getIdentities calls Alloc.SignIdentities to get all of the identities for
+// this workload signed. If there are no identities to be signed then (nil,
+// nil) is returned.
+func (h *identityHook) getIdentities(alloc *structs.Allocation, task *structs.Task) (map[string]*structs.SignedWorkloadIdentity, error) {
+
+	if len(task.Identities) == 0 {
+		return nil, nil
+	}
+
+	req := make([]*structs.WorkloadIdentityRequest, len(task.Identities))
+	for i, widspec := range task.Identities {
+		req[i] = &structs.WorkloadIdentityRequest{
+			AllocID:      alloc.ID,
+			TaskName:     task.Name,
+			IdentityName: widspec.Name,
+		}
+	}
+
+	// Get signed workload identities
+	signedWIDs, err := h.tr.widmgr.SignIdentities(alloc.CreateIndex, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Index initial workload identities by name
+	widMap := make(map[string]*structs.SignedWorkloadIdentity, len(signedWIDs))
+	for _, wid := range signedWIDs {
+		widMap[wid.IdentityName] = wid
+	}
+
+	return widMap, nil
 }

--- a/client/allocrunner/taskrunner/identity_hook_test.go
+++ b/client/allocrunner/taskrunner/identity_hook_test.go
@@ -6,6 +6,5 @@ package taskrunner
 import "github.com/hashicorp/nomad/client/allocrunner/interfaces"
 
 var _ interfaces.TaskPrestartHook = (*identityHook)(nil)
-var _ interfaces.TaskUpdateHook = (*identityHook)(nil)
 
 // See task_runner_test.go:TestTaskRunner_IdentityHook

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -265,6 +265,9 @@ type TaskRunner struct {
 	// wranglers manage unix/windows processes leveraging operating
 	// system features like cgroups
 	wranglers cinterfaces.ProcessWranglers
+
+	// widmgr fetches workload identities
+	widmgr IdentitySigner
 }
 
 type Config struct {
@@ -337,6 +340,9 @@ type Config struct {
 	// AllocHookResources is how taskrunner hooks can get state written by
 	// allocrunner hooks
 	AllocHookResources *cstructs.AllocHookResources
+
+	// WIDMgr fetches workload identities
+	WIDMgr IdentitySigner
 }
 
 func NewTaskRunner(config *Config) (*TaskRunner, error) {
@@ -398,6 +404,7 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 		serviceRegWrapper:     config.ServiceRegWrapper,
 		getter:                config.Getter,
 		wranglers:             config.Wranglers,
+		widmgr:                config.WIDMgr,
 	}
 
 	// Create the logger based on the allocation ID

--- a/client/allocrunner/taskrunner/task_runner_getters.go
+++ b/client/allocrunner/taskrunner/task_runner_getters.go
@@ -90,12 +90,8 @@ func (tr *TaskRunner) setNomadToken(token string) {
 	defer tr.nomadTokenLock.Unlock()
 	tr.nomadToken = token
 
-	if id := tr.task.Identity; id != nil {
-		tr.envBuilder.SetWorkloadToken(token, id.Env)
-	} else {
-		// Default to *not* injecting the workload token into the task's
-		// environment.
-		tr.envBuilder.SetWorkloadToken(token, false)
+	if id := tr.Task().Identity; id != nil && id.Env {
+		tr.envBuilder.SetDefaultWorkloadToken(token)
 	}
 }
 

--- a/client/config/arconfig.go
+++ b/client/config/arconfig.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	cstate "github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/client/vaultclient"
+	"github.com/hashicorp/nomad/client/widmgr"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -108,6 +109,9 @@ type AllocRunnerConfig struct {
 
 	// Wranglers is an interface for managing unix/windows processes.
 	Wranglers interfaces.ProcessWranglers
+
+	// WIDMgr fetches workload identities
+	WIDMgr *widmgr.WIDMgr
 }
 
 // PrevAllocWatcher allows AllocRunners to wait for a previous allocation to

--- a/client/widmgr/widmgr.go
+++ b/client/widmgr/widmgr.go
@@ -1,0 +1,83 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package widmgr
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+type RPCer interface {
+	RPC(method string, args any, reply any) error
+}
+
+// Config wraps the configuration parameters the workload identity manager
+// needs.
+type Config struct {
+	// NodeSecret is the node's secret token
+	NodeSecret string
+
+	// Region of the node
+	Region string
+
+	RPC RPCer
+}
+
+// WIDMgr fetches and validates workload identities.
+type WIDMgr struct {
+	nodeSecret string
+	region     string
+	rpc        RPCer
+}
+
+// New workload identity manager.
+func New(c Config) *WIDMgr {
+	return &WIDMgr{
+		nodeSecret: c.NodeSecret,
+		region:     c.Region,
+		rpc:        c.RPC,
+	}
+}
+
+// SignIdentities wraps the Alloc.SignIdentities RPC and retrieves signed
+// workload identities. The minIndex should be set to the lowest allocation
+// CreateIndex to ensure that the server handling the request isn't so stale
+// that it doesn't know the allocation exist (and therefore rejects the signing
+// requests).
+//
+// Since a single rejection causes an error to be returned, SignIdentities
+// should currently only be used when requesting signed identities for a single
+// allocation.
+func (m *WIDMgr) SignIdentities(minIndex uint64, req []*structs.WorkloadIdentityRequest) ([]*structs.SignedWorkloadIdentity, error) {
+	args := structs.AllocIdentitiesRequest{
+		Identities: req,
+		QueryOptions: structs.QueryOptions{
+			Region:        m.region,
+			MinQueryIndex: minIndex - 1,
+			AllowStale:    true,
+			AuthToken:     m.nodeSecret,
+		},
+	}
+	reply := structs.AllocIdentitiesResponse{}
+	if err := m.rpc.RPC("Alloc.SignIdentities", &args, &reply); err != nil {
+		return nil, err
+	}
+
+	if n := len(reply.Rejections); n == 1 {
+		return nil, fmt.Errorf("%d/%d signing request was rejected", n, len(req))
+	} else if n > 1 {
+		return nil, fmt.Errorf("%d/%d signing requests were rejected", n, len(req))
+	}
+
+	if len(reply.SignedIdentities) == 0 {
+		return nil, fmt.Errorf("empty signed identity response")
+	}
+
+	if exp, act := len(reply.SignedIdentities), len(req); exp != act {
+		return nil, fmt.Errorf("expected %d signed identities but received %d", exp, act)
+	}
+
+	return reply.SignedIdentities, nil
+}

--- a/client/widmgr/widmgr_test.go
+++ b/client/widmgr/widmgr_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package widmgr_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/nomad/client/widmgr"
+	"github.com/hashicorp/nomad/command/agent"
+	"github.com/hashicorp/nomad/helper/pointer"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/shoenig/test/must"
+)
+
+func TestWIDMgr(t *testing.T) {
+	t.Parallel()
+
+	// Create a mixed ta
+	ta := agent.NewTestAgent(t, "widtest", func(c *agent.Config) {
+		c.Server.Enabled = true
+		c.Server.NumSchedulers = pointer.Of(1)
+		c.Client.Enabled = true
+	})
+	t.Cleanup(ta.Shutdown)
+
+	mgr := widmgr.New(widmgr.Config{
+		NodeSecret: uuid.Generate(), // not checked when ACLs disabled
+		Region:     "global",
+		RPC:        ta,
+	})
+
+	_, err := mgr.SignIdentities(1, nil)
+	must.ErrorContains(t, err, "no identities requested")
+
+	_, err = mgr.SignIdentities(1, []*structs.WorkloadIdentityRequest{
+		{
+			AllocID:      uuid.Generate(),
+			TaskName:     "web",
+			IdentityName: "foo",
+		},
+	})
+	must.ErrorContains(t, err, "rejected")
+
+	// Register a job with 3 identities (but only 2 that need signing)
+	job := mock.MinJob()
+	job.TaskGroups[0].Tasks[0].Identity = &structs.WorkloadIdentity{
+		Env: true,
+	}
+	job.TaskGroups[0].Tasks[0].Identities = []*structs.WorkloadIdentity{
+		{
+			Name:     "consul",
+			Audience: []string{"a", "b"},
+			Env:      true,
+		},
+		{
+			Name: "vault",
+			File: true,
+		},
+	}
+	job.Canonicalize()
+
+	testutil.RegisterJob(t, ta.RPC, job)
+
+	var allocs []*structs.AllocListStub
+	testutil.WaitForResult(func() (bool, error) {
+		args := &structs.JobSpecificRequest{}
+		args.JobID = job.ID
+		args.QueryOptions.Region = job.Region
+		args.Namespace = job.Namespace
+		var resp structs.JobAllocationsResponse
+		err := ta.RPC("Job.Allocations", args, &resp)
+		if err != nil {
+			return false, fmt.Errorf("Job.Allocations error: %v", err)
+		}
+
+		if len(resp.Allocations) == 0 {
+			return false, fmt.Errorf("no allocs")
+		}
+		allocs = resp.Allocations
+		return len(allocs) == 1, fmt.Errorf("unexpected number of allocs: %d", len(allocs))
+	}, func(err error) {
+		must.NoError(t, err)
+	})
+	must.Len(t, 1, allocs)
+
+	// Get signed identites for alloc
+	widreqs := []*structs.WorkloadIdentityRequest{
+		{
+			AllocID:      allocs[0].ID,
+			TaskName:     job.TaskGroups[0].Tasks[0].Name,
+			IdentityName: "consul",
+		},
+		{
+			AllocID:      allocs[0].ID,
+			TaskName:     job.TaskGroups[0].Tasks[0].Name,
+			IdentityName: "vault",
+		},
+	}
+
+	swids, err := mgr.SignIdentities(allocs[0].CreateIndex, widreqs)
+	must.NoError(t, err)
+	must.Len(t, 2, swids)
+	must.Eq(t, *widreqs[0], swids[0].WorkloadIdentityRequest)
+	must.StrContains(t, swids[0].JWT, ".")
+	must.Eq(t, *widreqs[1], swids[1].WorkloadIdentityRequest)
+	must.StrContains(t, swids[1].JWT, ".")
+}

--- a/helper/joseutil/joseutil.go
+++ b/helper/joseutil/joseutil.go
@@ -1,0 +1,23 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package joseutil
+
+import (
+	"errors"
+
+	"github.com/go-jose/go-jose/v3/jwt"
+)
+
+var ErrNoKeyID = errors.New("missing key ID header")
+
+// KeyID returns the KeyID header for a JWT or ErrNoKeyID if a key id could not
+// be found. No clue why jose makes this so awkward.
+func KeyID(token *jwt.JSONWebToken) (string, error) {
+	for _, h := range token.Headers {
+		if h.KeyID != "" {
+			return h.KeyID, nil
+		}
+	}
+	return "", ErrNoKeyID
+}

--- a/helper/joseutil/joseutil.go
+++ b/helper/joseutil/joseutil.go
@@ -1,5 +1,5 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
 
 package joseutil
 

--- a/jobspec2/parse_job.go
+++ b/jobspec2/parse_job.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/helper/pointer"
+	"golang.org/x/exp/slices"
 )
 
 func normalizeJob(jc *jobConfig) {
@@ -52,6 +53,23 @@ func normalizeJob(jc *jobConfig) {
 
 			if t.Vault == nil {
 				t.Vault = jc.Vault
+			}
+
+			//COMPAT To preserve compatibility with pre-1.7 agents, move the default
+			//       identity to Task.Identity.
+			defaultIdx := -1
+			for i, wid := range t.Identities {
+				if wid.Name == "" || wid.Name == "default" {
+					t.Identity = wid
+					defaultIdx = i
+					break
+				}
+			}
+
+			// If the default identity was found in Identities above, remove it from the
+			// slice.
+			if defaultIdx >= 0 {
+				t.Identities = slices.Delete(t.Identities, defaultIdx, defaultIdx+1)
 			}
 		}
 	}

--- a/jobspec2/test-fixtures/identity-compat.nomad.hcl
+++ b/jobspec2/test-fixtures/identity-compat.nomad.hcl
@@ -1,0 +1,42 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+job "identitycompat" {
+  group "cache" {
+    count = 1
+
+    network {
+      port "db" {
+        to = 6379
+      }
+    }
+
+    task "redis" {
+      driver = "docker"
+
+      config {
+        image          = "redis:7"
+        ports          = ["db"]
+        auth_soft_fail = true
+      }
+
+      identity {
+        env  = true
+        file = true
+      }
+
+      # This identity will only be supported by >=1.7 agents but is included to
+      # ensure parsing handles both the default and alternate identities
+      # properly.
+      identity {
+        name = "foo"
+        aud  = ["bar"]
+      }
+
+      resources {
+        cpu    = 400
+        memory = 256 # 256MB
+      }
+    }
+  }
+}

--- a/jobspec2/test-fixtures/identity-compat.nomad.hcl
+++ b/jobspec2/test-fixtures/identity-compat.nomad.hcl
@@ -1,5 +1,5 @@
 # Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: BUSL-1.1
 
 job "identitycompat" {
   group "cache" {

--- a/nomad/acl_test.go
+++ b/nomad/acl_test.go
@@ -129,11 +129,11 @@ func TestAuthenticate_mTLS(t *testing.T) {
 	alloc2.JobID = job.ID
 	alloc2.ClientStatus = structs.AllocClientStatusRunning
 
-	claims1 := alloc1.ToTaskIdentityClaims(nil, "web")
+	claims1 := structs.NewIdentityClaims(job, alloc1, "web", alloc1.LookupTask("web").Identity, time.Now())
 	claims1Token, _, err := leader.encrypter.SignClaims(claims1)
 	must.NoError(t, err, must.Sprint("could not sign claims"))
 
-	claims2 := alloc2.ToTaskIdentityClaims(nil, "web")
+	claims2 := structs.NewIdentityClaims(job, alloc2, "web", alloc2.LookupTask("web").Identity, time.Now())
 	claims2Token, _, err := leader.encrypter.SignClaims(claims2)
 	must.NoError(t, err, must.Sprint("could not sign claims"))
 

--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1671,5 +1672,183 @@ func TestAlloc_GetServiceRegistrations(t *testing.T) {
 			defer cleanup()
 			tc.testFn(t, server, aclToken)
 		})
+	}
+}
+
+func TestAlloc_SignIdentities_Bad(t *testing.T) {
+	t.Parallel()
+
+	// Use non-ACL server because auth should always be enforced on this endpoint
+	s1, cleanupS1 := TestServer(t, nil)
+	t.Cleanup(cleanupS1)
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	req := &structs.AllocIdentitiesRequest{
+		QueryOptions: structs.QueryOptions{
+			Region:     "global",
+			Namespace:  structs.DefaultNamespace,
+			AllowStale: true,
+		},
+	}
+	var resp structs.AllocIdentitiesResponse
+
+	// Not including identities results in an error to catch bad client
+	// implementations
+	must.EqError(t, msgpackrpc.CallWithCodec(codec, "Alloc.SignIdentities", &req, &resp), "no identities requested")
+
+	// Making up an alloc returns a rejection.
+	req.Identities = []*structs.WorkloadIdentityRequest{{
+		AllocID:      uuid.Generate(),
+		TaskName:     "foo",
+		IdentityName: "bar",
+	}}
+	must.NoError(t, msgpackrpc.CallWithCodec(codec, "Alloc.SignIdentities", &req, &resp))
+	must.Len(t, 1, resp.Rejections)
+	must.Eq(t, *req.Identities[0], resp.Rejections[0].WorkloadIdentityRequest)
+	must.Eq(t, structs.WIRejectionReasonMissingAlloc, resp.Rejections[0].Reason)
+
+	// Insert an alloc with an alternate identity
+	alloc := mock.Alloc()
+	alloc.Job.TaskGroups[0].Tasks[0].Identities = []*structs.WorkloadIdentity{
+		{
+			Name:     "alt",
+			Audience: []string{"test"},
+		},
+	}
+	summary := mock.JobSummary(alloc.JobID)
+	state := s1.fsm.State()
+	must.NoError(t, state.UpsertJobSummary(100, summary))
+	must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 101, []*structs.Allocation{alloc}))
+
+	// A valid alloc and invalid TaskName is an error
+	req.Identities[0].AllocID = alloc.ID
+	req.Identities[0].TaskName = "invalid"
+	must.NoError(t, msgpackrpc.CallWithCodec(codec, "Alloc.SignIdentities", &req, &resp))
+	must.Len(t, 1, resp.Rejections)
+	must.Eq(t, *req.Identities[0], resp.Rejections[0].WorkloadIdentityRequest)
+	must.Eq(t, structs.WIRejectionReasonMissingTask, resp.Rejections[0].Reason)
+
+	// A valid alloc+task name still errors if the identity doesn't exist
+	req.Identities[0].TaskName = "web"
+	req.Identities[0].IdentityName = "invalid"
+	must.NoError(t, msgpackrpc.CallWithCodec(codec, "Alloc.SignIdentities", &req, &resp))
+	must.Len(t, 1, resp.Rejections)
+	must.Eq(t, *req.Identities[0], resp.Rejections[0].WorkloadIdentityRequest)
+	must.Eq(t, structs.WIRejectionReasonMissingIdentity, resp.Rejections[0].Reason)
+
+	// I know the test is named "Bad" but let's make sure it does actually work
+	req.Identities[0].IdentityName = "alt"
+	must.NoError(t, msgpackrpc.CallWithCodec(codec, "Alloc.SignIdentities", &req, &resp))
+	must.Len(t, 0, resp.Rejections)
+	must.Len(t, 1, resp.SignedIdentities)
+
+	// Looking for a missing alloc should return a rejection and a signed id
+	req.Identities = append(req.Identities, &structs.WorkloadIdentityRequest{
+		AllocID:      uuid.Generate(),
+		TaskName:     "foo",
+		IdentityName: "bar",
+	})
+	must.NoError(t, msgpackrpc.CallWithCodec(codec, "Alloc.SignIdentities", &req, &resp))
+	must.Len(t, 1, resp.Rejections)
+	must.Eq(t, *req.Identities[1], resp.Rejections[0].WorkloadIdentityRequest)
+	must.Eq(t, structs.WIRejectionReasonMissingAlloc, resp.Rejections[0].Reason)
+	must.Len(t, 1, resp.SignedIdentities)
+}
+
+// TestAlloc_SignIdentities_Blocking asserts that if a server is behind the
+// desired index the signing request will block until the index is reached.
+func TestAlloc_SignIdentities_Blocking(t *testing.T) {
+	t.Parallel()
+
+	s1, cleanupS1 := TestServer(t, nil)
+	t.Cleanup(cleanupS1)
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+	state := s1.fsm.State()
+
+	// Create the alloc we're going to query for, but don't insert it yet. This
+	// simulates querying a slow follower or a restoring server.
+	alloc := mock.Alloc()
+	alloc.Job.TaskGroups[0].Tasks[0].Identities = []*structs.WorkloadIdentity{
+		{
+			Name:     "alt",
+			Audience: []string{"test"},
+		},
+	}
+	summary := mock.JobSummary(alloc.JobID)
+
+	// Write a different alloc so the index is known but won't match our request
+	otherAlloc := mock.Alloc()
+	otherSummary := mock.JobSummary(otherAlloc.JobID)
+	must.NoError(t, state.UpsertJobSummary(999, otherSummary))
+	must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{otherAlloc}))
+
+	type resultT struct {
+		Err   error
+		Reply structs.AllocIdentitiesResponse
+	}
+	resultCh := make(chan resultT, 1)
+
+	go func() {
+		req := &structs.AllocIdentitiesRequest{
+			Identities: []*structs.WorkloadIdentityRequest{
+				{
+					AllocID:      alloc.ID,
+					TaskName:     "web",
+					IdentityName: "alt",
+				},
+			},
+			QueryOptions: structs.QueryOptions{
+				Region:        "global",
+				Namespace:     structs.DefaultNamespace,
+				AllowStale:    true,
+				MinQueryIndex: 1999,
+				MaxQueryTime:  10 * time.Second,
+			},
+		}
+		var resp structs.AllocIdentitiesResponse
+
+		err := msgpackrpc.CallWithCodec(codec, "Alloc.SignIdentities", &req, &resp)
+		resultCh <- resultT{
+			Err:   err,
+			Reply: resp,
+		}
+	}()
+
+	select {
+	case result := <-resultCh:
+		t.Fatalf("1. result returned when RPC should have blocked.\n >> err=%s\n >> rejections=%v", result.Err, result.Reply.Rejections)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Add another alloc to bump the index but not to the MinQueryIndex
+	otherAlloc = mock.Alloc()
+	otherSummary = mock.JobSummary(otherAlloc.JobID)
+	must.NoError(t, state.UpsertJobSummary(1997, otherSummary))
+	must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1998, []*structs.Allocation{otherAlloc}))
+
+	select {
+	case result := <-resultCh:
+		t.Fatalf("2. result returned when RPC should have blocked.\n >> err=%s\n >> rejections=%v", result.Err, result.Reply.Rejections)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Finally add the alloc we're waiting for
+	must.NoError(t, state.UpsertJobSummary(1999, summary))
+	must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 2000, []*structs.Allocation{alloc}))
+
+	select {
+	case result := <-resultCh:
+		must.NoError(t, result.Err)
+		must.Eq(t, 2000, result.Reply.Index)
+		must.Len(t, 0, result.Reply.Rejections)
+		must.Len(t, 1, result.Reply.SignedIdentities)
+		sid := result.Reply.SignedIdentities[0]
+		must.Eq(t, alloc.ID, sid.AllocID)
+		must.Eq(t, "web", sid.TaskName)
+		must.Eq(t, "alt", sid.IdentityName)
+	case <-time.After(5 * time.Second):
+		t.Fatalf("result not returned when expected")
 	}
 }

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -17,7 +17,8 @@ import (
 	"sync"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
 	log "github.com/hashicorp/go-hclog"
 	kms "github.com/hashicorp/go-kms-wrapping/v2"
 	"github.com/hashicorp/go-kms-wrapping/v2/aead"
@@ -25,6 +26,7 @@ import (
 
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/crypto"
+	"github.com/hashicorp/nomad/helper/joseutil"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -179,48 +181,59 @@ func (e *Encrypter) SignClaims(claim *structs.IdentityClaims) (string, string, e
 		}
 	}
 
-	token := jwt.NewWithClaims(&jwt.SigningMethodEd25519{}, claim)
-	token.Header[keyIDHeader] = keyset.rootKey.Meta.KeyID
-
-	tokenString, err := token.SignedString(keyset.privateKey)
+	opts := (&jose.SignerOptions{}).WithHeader("kid", keyset.rootKey.Meta.KeyID).WithType("JWT")
+	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.EdDSA, Key: keyset.privateKey}, opts)
+	if err != nil {
+		return "", "", err
+	}
+	raw, err := jwt.Signed(sig).Claims(claim).CompactSerialize()
 	if err != nil {
 		return "", "", err
 	}
 
-	return tokenString, keyset.rootKey.Meta.KeyID, nil
+	return raw, keyset.rootKey.Meta.KeyID, nil
 }
 
 // VerifyClaim accepts a previously-signed encoded claim and validates
 // it before returning the claim
 func (e *Encrypter) VerifyClaim(tokenString string) (*structs.IdentityClaims, error) {
 
-	token, err := jwt.ParseWithClaims(tokenString, &structs.IdentityClaims{}, func(token *jwt.Token) (interface{}, error) {
-		if _, ok := token.Method.(*jwt.SigningMethodEd25519); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", token.Method.Alg())
-		}
-		raw := token.Header[keyIDHeader]
-		if raw == nil {
-			return nil, fmt.Errorf("missing key ID header")
-		}
-		keyID := raw.(string)
-
-		e.lock.RLock()
-		defer e.lock.RUnlock()
-		keyset, err := e.keysetByIDLocked(keyID)
-		if err != nil {
-			return nil, err
-		}
-		return keyset.privateKey.Public(), nil
-	})
-
+	token, err := jwt.ParseSigned(tokenString)
 	if err != nil {
-		return nil, fmt.Errorf("failed to verify token: %v", err)
+		return nil, fmt.Errorf("failed to parse signed token: %w", err)
 	}
 
-	claims, ok := token.Claims.(*structs.IdentityClaims)
-	if !ok || !token.Valid {
-		return nil, fmt.Errorf("failed to verify token: invalid token")
+	// Find the Key ID
+	keyID, err := joseutil.KeyID(token)
+	if err != nil {
+		return nil, err
 	}
+
+	// Find the Key
+	pubKey, err := e.GetPublicKey(keyID)
+	if err != nil {
+		return nil, err
+	}
+
+	typedPubKey, err := pubKey.GetPublicKey()
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate the claims.
+	claims := &structs.IdentityClaims{}
+	if err := token.Claims(typedPubKey, claims); err != nil {
+		return nil, fmt.Errorf("invalid signature: %w", err)
+	}
+
+	//COMPAT Until we can guarantee there are no pre-1.7 JWTs in use we can only
+	//       validate the signature and have no further expectations of the
+	//       claims.
+	expect := jwt.Expected{}
+	if err := claims.Validate(expect); err != nil {
+		return nil, fmt.Errorf("invalid claims: %w", err)
+	}
+
 	return claims, nil
 }
 

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -362,10 +362,10 @@ func TestEncrypter_SignVerify(t *testing.T) {
 	testutil.WaitForLeader(t, srv.RPC)
 
 	alloc := mock.Alloc()
-	claim := alloc.ToTaskIdentityClaims(nil, "web")
+	claims := structs.NewIdentityClaims(alloc.Job, alloc, "web", alloc.LookupTask("web").Identity, time.Now())
 	e := srv.encrypter
 
-	out, _, err := e.SignClaims(claim)
+	out, _, err := e.SignClaims(claims)
 	require.NoError(t, err)
 
 	got, err := e.VerifyClaim(out)

--- a/nomad/service_registration_endpoint_test.go
+++ b/nomad/service_registration_endpoint_test.go
@@ -6,6 +6,7 @@ package nomad
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-memdb"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
@@ -888,7 +889,7 @@ func TestServiceRegistration_List(t *testing.T) {
 				job.Namespace = "platform"
 				allocs[0].Namespace = "platform"
 				require.NoError(t, s.State().UpsertJob(structs.MsgTypeTestSetup, 10, nil, job))
-				s.signAllocIdentities(job, allocs)
+				s.signAllocIdentities(job, allocs, time.Now())
 				require.NoError(t, s.State().UpsertAllocs(structs.MsgTypeTestSetup, 15, allocs))
 
 				signedToken := allocs[0].SignedIdentities["web"]
@@ -1175,7 +1176,7 @@ func TestServiceRegistration_GetService(t *testing.T) {
 				allocs := []*structs.Allocation{mock.Alloc()}
 				job := allocs[0].Job
 				require.NoError(t, s.State().UpsertJob(structs.MsgTypeTestSetup, 10, nil, job))
-				s.signAllocIdentities(job, allocs)
+				s.signAllocIdentities(job, allocs, time.Now())
 				require.NoError(t, s.State().UpsertAllocs(structs.MsgTypeTestSetup, 15, allocs))
 
 				signedToken := allocs[0].SignedIdentities["web"]

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt/v5"
+	jwt "github.com/go-jose/go-jose/v3/jwt"
 	"github.com/hashicorp/cronexpr"
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/go-multierror"
@@ -1680,9 +1680,14 @@ type SingleAllocResponse struct {
 	QueryMeta
 }
 
-// AllocsGetResponse is used to return a set of allocations
+// AllocsGetResponse is used to return a set of allocations and their workload
+// identities.
 type AllocsGetResponse struct {
 	Allocs []*Allocation
+
+	// SignedIdentities are the alternate workload identities for the Allocs.
+	SignedIdentities []SignedWorkloadIdentity
+
 	QueryMeta
 }
 
@@ -7490,9 +7495,12 @@ type Task struct {
 	// CSIPluginConfig is used to configure the plugin supervisor for the task.
 	CSIPluginConfig *TaskCSIPluginConfig
 
-	// Identity controls if and how the workload identity is exposed to
-	// tasks similar to the Vault block.
+	// Identity is the default Nomad Workload Identity.
 	Identity *WorkloadIdentity
+
+	// Identities are the alternate workload identities for use with 3rd party
+	// endpoints.
+	Identities []*WorkloadIdentity
 }
 
 // UsesConnect is for conveniently detecting if the Task is able to make use
@@ -7554,6 +7562,7 @@ func (t *Task) Copy() *Task {
 	nt.DispatchPayload = nt.DispatchPayload.Copy()
 	nt.Lifecycle = nt.Lifecycle.Copy()
 	nt.Identity = nt.Identity.Copy()
+	nt.Identities = helper.CopySlice(nt.Identities)
 
 	if t.Artifacts != nil {
 		artifacts := make([]*TaskArtifact, 0, len(t.Artifacts))
@@ -7621,6 +7630,30 @@ func (t *Task) Canonicalize(job *Job, tg *TaskGroup) {
 	for _, template := range t.Templates {
 		template.Canonicalize()
 	}
+
+	// Initialize default Nomad workload identity
+	defaultIdx := -1
+	for i, wid := range t.Identities {
+		wid.Canonicalize()
+
+		// For backward compatibility put the default identity in Task.Identity.
+		if wid.Name == WorkloadIdentityDefaultName {
+			t.Identity = wid
+			defaultIdx = i
+		}
+	}
+
+	// If the default identity was found in Identities above, remove it from the
+	// slice.
+	if defaultIdx >= 0 {
+		t.Identities = slices.Delete(t.Identities, defaultIdx, defaultIdx+1)
+	}
+
+	// If there was no default identity, always create one.
+	if t.Identity == nil {
+		t.Identity = &WorkloadIdentity{}
+	}
+	t.Identity.Canonicalize()
 }
 
 func (t *Task) GoString() string {
@@ -7800,6 +7833,19 @@ func (t *Task) Validate(jobType string, tg *TaskGroup) error {
 		// TODO: Investigate validation of the PluginMountDir. Not much we can do apart from check IsAbs until after we understand its execution environment though :(
 	}
 
+	// Validate Identity/Identities
+	for _, wid := range t.Identities {
+		// Task.Canonicalize should move the default identity out of the Identities
+		// slice, so if one is found that means it is a duplicate.
+		if wid.Name == WorkloadIdentityDefaultName {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("Duplicate default identities found"))
+		}
+
+		if err := wid.Validate(); err != nil {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("Identity %q is invalid: %w", wid.Name, err))
+		}
+	}
+
 	return mErr.ErrorOrNil()
 }
 
@@ -7970,6 +8016,13 @@ func (t *Task) Warnings() error {
 	for idx, tmpl := range t.Templates {
 		if err := tmpl.Warnings(); err != nil {
 			err = multierror.Prefix(err, fmt.Sprintf("Template[%d]", idx))
+			mErr.Errors = append(mErr.Errors, err)
+		}
+	}
+
+	for _, wid := range t.Identities {
+		if err := wid.Warnings(); err != nil {
+			err = multierror.Prefix(err, fmt.Sprintf("Identity[%s]", wid.Name))
 			mErr.Errors = append(mErr.Errors, err)
 		}
 	}
@@ -11100,35 +11153,6 @@ func (a *Allocation) NeedsToReconnect() bool {
 	return disconnected
 }
 
-func (a *Allocation) ToIdentityClaims(job *Job) *IdentityClaims {
-	now := jwt.NewNumericDate(time.Now().UTC())
-	claims := &IdentityClaims{
-		Namespace:    a.Namespace,
-		JobID:        a.JobID,
-		AllocationID: a.ID,
-		RegisteredClaims: jwt.RegisteredClaims{
-			// TODO: implement a refresh loop to prevent allocation identities from
-			// expiring before the allocation is terminal. Once that's implemented,
-			// add an ExpiresAt here ExpiresAt: &jwt.NumericDate{}
-			// https://github.com/hashicorp/nomad/issues/16258
-			NotBefore: now,
-			IssuedAt:  now,
-		},
-	}
-	if job != nil && job.ParentID != "" {
-		claims.JobID = job.ParentID
-	}
-	return claims
-}
-
-func (a *Allocation) ToTaskIdentityClaims(job *Job, taskName string) *IdentityClaims {
-	claims := a.ToIdentityClaims(job)
-	if claims != nil {
-		claims.TaskName = taskName
-	}
-	return claims
-}
-
 // IdentityClaims are the input to a JWT identifying a workload. It
 // should never be serialized to msgpack unsigned.
 type IdentityClaims struct {
@@ -11137,7 +11161,56 @@ type IdentityClaims struct {
 	AllocationID string `json:"nomad_allocation_id"`
 	TaskName     string `json:"nomad_task"`
 
-	jwt.RegisteredClaims
+	jwt.Claims
+}
+
+// NewIdentityClaims returns new workload identity claims. Since it may be
+// called with a denormalized Allocation, the Job must be passed in distinctly.
+//
+// ID claim is random (nondeterministic) so multiple calls with the same values
+// will not return equal claims by design. JWT IDs should never collide.
+func NewIdentityClaims(job *Job, alloc *Allocation, taskName string, wid *WorkloadIdentity, now time.Time) *IdentityClaims {
+
+	tg := job.LookupTaskGroup(alloc.TaskGroup)
+	if tg == nil {
+		return nil
+	}
+
+	jwtnow := jwt.NewNumericDate(now.UTC())
+	claims := &IdentityClaims{
+		Namespace:    alloc.Namespace,
+		JobID:        alloc.JobID,
+		AllocationID: alloc.ID,
+		Claims: jwt.Claims{
+			NotBefore: jwtnow,
+			IssuedAt:  jwtnow,
+		},
+	}
+
+	// If this is a child job, use the parent's ID
+	if job.ParentID != "" {
+		claims.JobID = job.ParentID
+	}
+
+	claims.TaskName = taskName
+	claims.Audience = wid.Audience
+	claims.SetSubject(job, alloc.TaskGroup, taskName, wid.Name)
+
+	claims.ID = uuid.Generate()
+
+	return claims
+}
+
+// SetSubject creates the standard subject claim for workload identities.
+func (claims *IdentityClaims) SetSubject(job *Job, group, task, id string) {
+	claims.Subject = strings.Join([]string{
+		job.Region,
+		job.Namespace,
+		job.ID,
+		group,
+		task,
+		id,
+	}, ":")
 }
 
 // AllocationDiff is another named type for Allocation (to use the same fields),

--- a/nomad/structs/workload_id.go
+++ b/nomad/structs/workload_id.go
@@ -3,9 +3,52 @@
 
 package structs
 
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"golang.org/x/exp/slices"
+)
+
+const (
+	// WorkloadIdentityDefaultName is the name of the default (builtin) Workload
+	// Identity.
+	WorkloadIdentityDefaultName = "default"
+
+	// WorkloadIdentityDefaultAud is the audience of the default identity.
+	WorkloadIdentityDefaultAud = "nomadproject.io"
+
+	// WIRejectionReasonMissingAlloc is the WorkloadIdentityRejection.Reason
+	// returned when an allocation longer exists. This may be due to the alloc
+	// being GC'd or the job being updated.
+	WIRejectionReasonMissingAlloc = "allocation not found"
+
+	// WIRejectionReasonMissingTask is the WorkloadIdentityRejection.Reason
+	// returned when the requested task no longer exists on the allocation.
+	WIRejectionReasonMissingTask = "task not found"
+
+	// WIRejectionReasonMissingIdentity is the WorkloadIdentityRejection.Reason
+	// returned when the requested identity does not exist on the allocation.
+	WIRejectionReasonMissingIdentity = "identity not found"
+)
+
+var (
+	// validIdentityName is used to validate workload identity Name fields. Must
+	// be safe to use in filenames.
+	//
+	// Reuse validNamespaceName to save a bit of memory.
+	validIdentityName = validNamespaceName
+)
+
 // WorkloadIdentity is the jobspec block which determines if and how a workload
 // identity is exposed to tasks similar to the Vault block.
 type WorkloadIdentity struct {
+	Name string
+
+	// Audience is the valid recipients for this identity (the "aud" JWT claim)
+	// and defaults to the identity's name.
+	Audience []string
+
 	// Env injects the Workload Identity into the Task's environment if
 	// set.
 	Env bool
@@ -20,14 +63,24 @@ func (wi *WorkloadIdentity) Copy() *WorkloadIdentity {
 		return nil
 	}
 	return &WorkloadIdentity{
-		Env:  wi.Env,
-		File: wi.File,
+		Name:     wi.Name,
+		Audience: slices.Clone(wi.Audience),
+		Env:      wi.Env,
+		File:     wi.File,
 	}
 }
 
 func (wi *WorkloadIdentity) Equal(other *WorkloadIdentity) bool {
 	if wi == nil || other == nil {
 		return wi == other
+	}
+
+	if wi.Name != other.Name {
+		return false
+	}
+
+	if !slices.Equal(wi.Audience, other.Audience) {
+		return false
 	}
 
 	if wi.Env != other.Env {
@@ -39,4 +92,91 @@ func (wi *WorkloadIdentity) Equal(other *WorkloadIdentity) bool {
 	}
 
 	return true
+}
+
+func (wi *WorkloadIdentity) Canonicalize() {
+	if wi == nil {
+		return
+	}
+
+	if wi.Name == "" {
+		wi.Name = WorkloadIdentityDefaultName
+	}
+
+	// The default identity is only valid for use with Nomad itself.
+	if wi.Name == WorkloadIdentityDefaultName {
+		wi.Audience = []string{WorkloadIdentityDefaultAud}
+	}
+}
+
+func (wi *WorkloadIdentity) Validate() error {
+	if wi == nil {
+		return fmt.Errorf("must not be nil")
+	}
+
+	var mErr multierror.Error
+
+	if !validIdentityName.MatchString(wi.Name) {
+		err := fmt.Errorf("invalid name %q. Must match regex %s", wi.Name, validIdentityName)
+		mErr.Errors = append(mErr.Errors, err)
+	}
+
+	for i, aud := range wi.Audience {
+		if aud == "" {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("an empty string is an invalid audience (%d)", i+1))
+		}
+	}
+
+	return mErr.ErrorOrNil()
+}
+
+func (wi *WorkloadIdentity) Warnings() error {
+	if wi == nil {
+		return fmt.Errorf("must not be nil")
+	}
+
+	if n := len(wi.Audience); n == 0 {
+		return fmt.Errorf("identities without an audience are insecure")
+	} else if n > 1 {
+		return fmt.Errorf("while multiple audiences is allowed, it is more secure to use 1 audience per identity")
+	}
+
+	return nil
+}
+
+// WorkloadIdentityRequest encapsulates the 3 parameters used to generated a
+// signed workload identity: the alloc, task, and specific identity's name.
+type WorkloadIdentityRequest struct {
+	AllocID      string
+	TaskName     string
+	IdentityName string
+}
+
+// SignedWorkloadIdentity is the response to a WorkloadIdentityRequest and
+// includes the JWT for the requested workload identity.
+type SignedWorkloadIdentity struct {
+	WorkloadIdentityRequest
+	JWT string
+}
+
+// WorkloadIdentityRejection is the response to a WorkloadIdentityRequest that
+// is rejected and includes a reason.
+type WorkloadIdentityRejection struct {
+	WorkloadIdentityRequest
+	Reason string
+}
+
+// AllocIdentitiesRequest is the RPC arguments for requesting signed workload
+// identities.
+type AllocIdentitiesRequest struct {
+	Identities []*WorkloadIdentityRequest
+	QueryOptions
+}
+
+// AllocIdentitiesResponse is the RPC response for requested workload
+// identities including any rejections.
+type AllocIdentitiesResponse struct {
+	SignedIdentities []*SignedWorkloadIdentity
+	Rejections       []*WorkloadIdentityRejection
+	QueryMeta
 }

--- a/nomad/structs/workload_id_test.go
+++ b/nomad/structs/workload_id_test.go
@@ -4,6 +4,7 @@
 package structs
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
@@ -32,4 +33,157 @@ func TestWorkloadIdentity_Equal(t *testing.T) {
 
 	newWI.File = true
 	must.NotEqual(t, orig, newWI)
+
+	newWI.File = false
+	must.Equal(t, orig, newWI)
+
+	newWI.Name = "foo"
+	must.NotEqual(t, orig, newWI)
+
+	newWI.Name = ""
+	must.Equal(t, orig, newWI)
+
+	newWI.Audience = []string{"foo"}
+	must.NotEqual(t, orig, newWI)
+}
+
+// TestWorkloadIdentity_Validate asserts that canonicalized workload identities
+// validate and emit warnings as expected.
+func TestWorkloadIdentity_Validate(t *testing.T) {
+	ci.Parallel(t)
+
+	cases := []struct {
+		Desc string
+		In   WorkloadIdentity
+		Exp  WorkloadIdentity
+		Err  string
+		Warn string
+	}{
+		{
+			Desc: "Empty",
+			In:   WorkloadIdentity{},
+			Exp: WorkloadIdentity{
+				Name:     WorkloadIdentityDefaultName,
+				Audience: []string{WorkloadIdentityDefaultAud},
+			},
+		},
+		{
+			Desc: "Default audience",
+			In: WorkloadIdentity{
+				Name: WorkloadIdentityDefaultName,
+			},
+			Exp: WorkloadIdentity{
+				Name:     WorkloadIdentityDefaultName,
+				Audience: []string{WorkloadIdentityDefaultAud},
+			},
+		},
+		{
+			Desc: "Ok",
+			In: WorkloadIdentity{
+				Name:     "foo-id",
+				Audience: []string{"http://nomadproject.io/"},
+				Env:      true,
+				File:     true,
+			},
+			Exp: WorkloadIdentity{
+				Name:     "foo-id",
+				Audience: []string{"http://nomadproject.io/"},
+				Env:      true,
+				File:     true,
+			},
+		},
+		{
+			Desc: "Be reasonable",
+			In: WorkloadIdentity{
+				Name: strings.Repeat("x", 1025),
+			},
+			Err: "invalid name",
+		},
+		{
+			Desc: "No hacks",
+			In: WorkloadIdentity{
+				Name: "../etc/passwd",
+			},
+			Err: "invalid name",
+		},
+		{
+			Desc: "No Windows hacks",
+			In: WorkloadIdentity{
+				Name: `A:\hacks`,
+			},
+			Err: "invalid name",
+		},
+		{
+			Desc: "Empty audience",
+			In: WorkloadIdentity{
+				Name:     "foo",
+				Audience: []string{"ok", ""},
+			},
+			Err: "an empty string is an invalid audience (2)",
+		},
+		{
+			Desc: "Warn audience",
+			In: WorkloadIdentity{
+				Name: "foo",
+			},
+			Exp: WorkloadIdentity{
+				Name: "foo",
+			},
+			Warn: "identities without an audience are insecure",
+		},
+		{
+			Desc: "Warn too many audiences",
+			In: WorkloadIdentity{
+				Name:     "foo",
+				Audience: []string{"foo", "bar"},
+			},
+			Exp: WorkloadIdentity{
+				Name:     "foo",
+				Audience: []string{"foo", "bar"},
+			},
+			Warn: "while multiple audiences is allowed, it is more secure to use 1 audience per identity",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Desc, func(t *testing.T) {
+			tc.In.Canonicalize()
+
+			if err := tc.In.Validate(); err != nil {
+				if tc.Err == "" {
+					t.Fatalf("unexpected validation error: %s", err)
+				}
+				must.ErrorContains(t, err, tc.Err)
+				return
+			}
+
+			// Only compare valid structs
+			must.Eq(t, tc.Exp, tc.In)
+
+			if err := tc.In.Warnings(); err != nil {
+				if tc.Warn == "" {
+					t.Fatalf("unexpected warnings: %s", err)
+				}
+				must.ErrorContains(t, err, tc.Warn)
+				return
+			}
+		})
+	}
+}
+
+func TestWorkloadIdentity_Nil(t *testing.T) {
+	t.Parallel()
+
+	var nilWID *WorkloadIdentity
+
+	nilWID = nilWID.Copy()
+	must.Nil(t, nilWID)
+
+	must.True(t, nilWID.Equal(nil))
+
+	nilWID.Canonicalize()
+
+	must.Error(t, nilWID.Validate())
+
+	must.Error(t, nilWID.Warnings())
 }

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -112,6 +112,9 @@ func TestConfigForServer(t testing.T) *Config {
 	// max job submission source size
 	config.JobMaxSourceSize = 1e6
 
+	// Default to having concurrent schedulers
+	config.NumSchedulers = 2
+
 	return config
 }
 

--- a/nomad/variables_endpoint_test.go
+++ b/nomad/variables_endpoint_test.go
@@ -64,15 +64,15 @@ func TestVariablesEndpoint_auth(t *testing.T) {
 	must.NoError(t, store.UpsertAllocs(
 		structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc1, alloc2, alloc3, alloc4}))
 
-	claims1 := alloc1.ToTaskIdentityClaims(nil, "web")
+	claims1 := structs.NewIdentityClaims(alloc1.Job, alloc1, "web", alloc1.LookupTask("web").Identity, time.Now())
 	idToken, _, err := srv.encrypter.SignClaims(claims1)
 	must.NoError(t, err)
 
-	claims2 := alloc2.ToTaskIdentityClaims(nil, "web")
+	claims2 := structs.NewIdentityClaims(alloc2.Job, alloc2, "web", alloc2.LookupTask("web").Identity, time.Now())
 	noPermissionsToken, _, err := srv.encrypter.SignClaims(claims2)
 	must.NoError(t, err)
 
-	claims3 := alloc3.ToTaskIdentityClaims(alloc3.Job, "web")
+	claims3 := structs.NewIdentityClaims(alloc3.Job, alloc3, "web", alloc3.LookupTask("web").Identity, time.Now())
 	idDispatchToken, _, err := srv.encrypter.SignClaims(claims3)
 	must.NoError(t, err)
 
@@ -86,7 +86,7 @@ func TestVariablesEndpoint_auth(t *testing.T) {
 	idTokenParts[2] = strings.Join(sig, "")
 	invalidIDToken := strings.Join(idTokenParts, ".")
 
-	claims4 := alloc4.ToTaskIdentityClaims(alloc4.Job, "web")
+	claims4 := structs.NewIdentityClaims(alloc4.Job, alloc4, "web", alloc4.LookupTask("web").Identity, time.Now())
 	wiOnlyToken, _, err := srv.encrypter.SignClaims(claims4)
 	must.NoError(t, err)
 
@@ -605,7 +605,7 @@ func TestVariablesEndpoint_ListFiltering(t *testing.T) {
 	must.NoError(t, store.UpsertAllocs(
 		structs.MsgTypeTestSetup, idx, []*structs.Allocation{alloc}))
 
-	claims := alloc.ToTaskIdentityClaims(alloc.Job, "web")
+	claims := structs.NewIdentityClaims(alloc.Job, alloc, "web", alloc.LookupTask("web").Identity, time.Now())
 	token, _, err := srv.encrypter.SignClaims(claims)
 	must.NoError(t, err)
 

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -315,9 +315,13 @@ func tasksUpdated(jobA, jobB *structs.Job, taskGroup string) comparison {
 			return c
 		}
 
-		// Inspect Identity being exposed
+		// Inspect Identities being exposed
 		if !at.Identity.Equal(bt.Identity) {
 			return difference("task identity", at.Identity, bt.Identity)
+		}
+
+		if !slices.EqualFunc(at.Identities, bt.Identities, func(a, b *structs.WorkloadIdentity) bool { return a.Equal(b) }) {
+			return difference("task identity", at.Identities, bt.Identities)
 		}
 
 		// Most LogConfig updates are in-place but if we change Disabled we need


### PR DESCRIPTION
### The Good

Allow for multiple `identity{}` blocks on tasks with distinct names and identities. The existing identity is referred to internally as the `default Nomad identity` since it is intended for the workload to identify itself to Nomad's API. Other identities are referred to as `alternate identities` as they're optional and for use with 3rd party services (Consul, Vault, Traefik, user apps, etc).

Validation does not prevent creating "hidden" identities (identities with both env=false and file=false) because followup PRs are likely to make use of that (just like we already do for the default identity).

The `WIDMgr` (Workload ID Manager) is currently a light wrapper around the `Alloc.GetIdentities` RPC, but could someday implement optimizations such as batching requests. Since identity minting is purely CPU bound I'm not sure if that will ever be necessary, but encapsulation for encapsulation's sake is nice sometimes too.

I did choose to duplicate the token's expiration time within the `Alloc.GetIdentities` RPC's response instead of the approach in the PoC branch #17434 which actually validated the JWTs and plucked out the expirations. Making identity fetching depend on public key fetching seemed needlessly complex, so I chose to just duplicate/de-normalize the expiry.

The way `Alloc.GetIdentities` uses Stale+WaitIndex is a bit unique: since the JWTs themselves are stateless, the WaitIndex is only used to ensure the server serving the request knows the Alloc exists (otherwise races between Client's reading allocs and servers processing Raft logs could cause spurious failures; not to mention the problem of restoring servers being arbitrarily stale). As long as the RPC can tell the alloc existed, any server can sign a JWT. So despite using Stale+WaitIndex, we don't use a blocking query to wait for some state to change and impact identities. Even when I add expiration support the server can't use a blocking query to hold off clients until they really need a new identity because servers won't record the expiration of tokens.

### The Bad

This doesn't implement the `Alloc.GetAllocs`-includes-JWTs optimization of the proof of concept branch. I plan on moving that over, but the plumbing is ugly and felt like a distraction from these core bits. It is *only* an optimization and does not change functionality.

The current implementation of `Alloc.GetIdentities`/`WIDMgr` will block on contacting servers on agent restart or node reboot. This prevents using alternate identities on disconnected nodes. Using `PrivateDir` to store the JWTs across restarts seems necessary, but I don't have a tidy solution across reboots.

### The Ugly

The HCL/JSON story is a bit awkward:

1. jobspec2/parse.go has to pluck the default Identity out of the Identities slice to put it back on Identity in case a 1.7 CLI is posting to a 1.6 API.
2. WorkloadIdentity.Canonicalize has to do the same dance in case 1.6 JSON is sent to a 1.7 API.

But it seems to work! The default identity stays in place, and all of the new identities are in the slice.

#### Intentionally Delaying
- Docs
- Changelog
Without expiration there's still no way to use this securely, so I'm going to "soft launch" until then.