### PR TITLE
Add retry mechanism for put call

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -200,6 +200,10 @@ type Config struct {
 	TLSConfig *TLSConfig
 
 	Headers http.Header
+
+	// retryOptions holds the configuration necessary to perform retries
+	// on put calls.
+	retryOptions *retryOptions
 }
 
 // ClientConfig copies the configuration with a new client address, region, and

--- a/api/retry.go
+++ b/api/retry.go
@@ -6,7 +6,6 @@ package api
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 )
@@ -70,7 +69,7 @@ func (rc *retryClient) retryPut(ctx context.Context, endpoint string, in, out an
 
 	for attempt := uint64(0); attempt < rc.MaxRetries; attempt++ {
 		iDelay = rc.calculateDelay(attempt)
-		fmt.Println(iDelay.String())
+
 		t := time.NewTimer(iDelay)
 		select {
 		case <-ctx.Done():

--- a/api/retry.go
+++ b/api/retry.go
@@ -1,0 +1,137 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type client interface {
+	put(endpoint string, in, out any, q *WriteOptions) (*WriteMeta, error)
+}
+
+type retryClient struct {
+	c client
+	retryOptions
+}
+
+// LockOptions is used to parameterize the Lock behavior.
+type retryOptions struct {
+	MaxRetries      uint64        // Optional, defaults to 3
+	MaxBetweenCalls time.Duration // Optional, defaults to 0, meaning no time cap
+	MaxToLastCall   time.Duration // Optional, defaults to 0, meaning no time cap
+	FixedDelay      time.Duration // Optional, defaults to 0, meaning Delay is exponential, starting at 1sec
+	DelayBase       time.Duration // Optional, defaults to 1sec
+}
+
+func newRetryClient(c client, opts retryOptions) *retryClient {
+	rc := &retryClient{
+		c: c,
+		retryOptions: retryOptions{
+			MaxRetries: 3,
+			DelayBase:  time.Second,
+		},
+	}
+
+	if opts.DelayBase != 0 {
+		rc.DelayBase = opts.DelayBase
+	}
+
+	if opts.MaxRetries != 0 {
+		rc.MaxRetries = opts.MaxRetries
+	}
+
+	if opts.MaxBetweenCalls != 0 {
+		rc.MaxBetweenCalls = opts.MaxBetweenCalls
+	}
+
+	if opts.MaxToLastCall != 0 {
+		rc.MaxToLastCall = opts.MaxToLastCall
+	}
+
+	if opts.FixedDelay != 0 {
+		rc.FixedDelay = opts.FixedDelay
+	}
+
+	return rc
+}
+
+func (rc *retryClient) retryPut(ctx context.Context, endpoint string, in, out any, q *WriteOptions) (*WriteMeta, error) {
+	var err error
+	var wm *WriteMeta
+
+	iDelay := time.Duration(0)
+	startTime := time.Now()
+
+	for attempt := uint64(0); attempt < rc.MaxRetries; attempt++ {
+		iDelay = rc.calculateDelay(attempt)
+		fmt.Println(iDelay.String())
+		t := time.NewTimer(iDelay)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-t.C:
+		}
+
+		wm, err = rc.c.put(endpoint, in, out, q)
+
+		// Maximum retry period is up, don't retry
+		if rc.MaxToLastCall != 0 && time.Now().Sub(startTime) > rc.MaxToLastCall {
+			break
+		}
+
+		// The put function only returns WriteMetadata if the call was successful
+		// don't retry
+		if wm != nil {
+			break
+		}
+
+		// If WriteMetadata is nil, we need to process the error to decide if a retry is
+		// necessary or not
+		var callErr *UnexpectedResponseError
+		ok := errors.As(err, &callErr)
+
+		// If is not UnexpectedResponseError, it is an error while performing the call
+		// don't retry
+		if !ok {
+			break
+		}
+
+		// Only 500+ or 429 status calls may be retried, otherwise
+		// don't retry
+		if !isCallRetriable(callErr.StatusCode()) {
+			break
+		}
+	}
+
+	return wm, err
+}
+
+func isCallRetriable(statusCode int) bool {
+	return statusCode > http.StatusInternalServerError &&
+		statusCode < http.StatusNetworkAuthenticationRequired ||
+		statusCode == http.StatusTooManyRequests
+}
+
+func (rc *retryClient) calculateDelay(attempt uint64) time.Duration {
+	if rc.FixedDelay != 0 {
+		return rc.FixedDelay
+	}
+
+	if attempt == 0 {
+		return 0
+	}
+
+	new := rc.DelayBase << (attempt - 1)
+
+	if rc.MaxBetweenCalls != 0 && new > rc.MaxBetweenCalls {
+		return rc.MaxBetweenCalls
+	}
+
+	return new
+}

--- a/api/retry_test.go
+++ b/api/retry_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,29 +12,37 @@ import (
 	"github.com/shoenig/test/must"
 )
 
+type mockHandler struct {
+	callsCounter []time.Time
+}
+
+func (mh *mockHandler) Handle(rw http.ResponseWriter, req *http.Request) {
+	mh.callsCounter = append(mh.callsCounter, time.Now())
+
+	// return a populated meta after 7 tries to test he retries stops after a
+	// successful call
+	if len(mh.callsCounter) < 7 {
+		http.Error(rw, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
+		return
+	}
+
+	rw.WriteHeader(http.StatusOK)
+	rw.Header().Set("Content-Type", "application/json")
+
+	resp := &WriteMeta{}
+	jsonResp, _ := json.Marshal(resp)
+
+	rw.Write(jsonResp)
+	return
+}
+
 func Test_RetryPut_multiple_calls(t *testing.T) {
 	t.Run("successfully retries until no error, delayed capped to 100ms", func(t *testing.T) {
-		callsCounter := []time.Time{}
+		mh := mockHandler{
+			callsCounter: []time.Time{},
+		}
 
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			callsCounter = append(callsCounter, time.Now())
-
-			// return a populated meta after 7 tries to test he retries stops after a
-			// successful call
-			if len(callsCounter) < 7 {
-				http.Error(rw, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
-				return
-			}
-
-			rw.WriteHeader(http.StatusOK)
-			rw.Header().Set("Content-Type", "application/json")
-
-			resp := &WriteMeta{}
-			jsonResp, _ := json.Marshal(resp)
-
-			rw.Write(jsonResp)
-			return
-		}))
+		server := httptest.NewServer(http.HandlerFunc(mh.Handle))
 
 		cm := &Client{
 			httpClient: server.Client(),
@@ -42,7 +51,7 @@ func Test_RetryPut_multiple_calls(t *testing.T) {
 				retryOptions: &retryOptions{
 					delayBase:       10 * time.Millisecond,
 					maxRetries:      10,
-					maxBetweenCalls: 100 * time.Millisecond,
+					maxBackoffDelay: 100 * time.Millisecond,
 				},
 			},
 		}
@@ -50,41 +59,25 @@ func Test_RetryPut_multiple_calls(t *testing.T) {
 		md, err := cm.retryPut(context.TODO(), "/endpoint", nil, nil, &WriteOptions{})
 		must.NoError(t, err)
 
-		must.Len(t, 7, callsCounter)
+		must.Len(t, 7, mh.callsCounter)
 
 		must.NotNil(t, md)
-		must.Greater(t, 10*time.Millisecond, callsCounter[1].Sub(callsCounter[0]))
-		must.Greater(t, 20*time.Millisecond, callsCounter[2].Sub(callsCounter[1]))
-		must.Greater(t, 40*time.Millisecond, callsCounter[3].Sub(callsCounter[2]))
-		must.Greater(t, 80*time.Millisecond, callsCounter[4].Sub(callsCounter[3]))
-		must.Greater(t, 100*time.Millisecond, callsCounter[5].Sub(callsCounter[4]))
-		must.Greater(t, 100*time.Millisecond, callsCounter[6].Sub(callsCounter[5]))
+		must.Greater(t, 10*time.Millisecond, mh.callsCounter[1].Sub(mh.callsCounter[0]))
+		must.Greater(t, 20*time.Millisecond, mh.callsCounter[2].Sub(mh.callsCounter[1]))
+		must.Greater(t, 40*time.Millisecond, mh.callsCounter[3].Sub(mh.callsCounter[2]))
+		must.Greater(t, 80*time.Millisecond, mh.callsCounter[4].Sub(mh.callsCounter[3]))
+		must.Greater(t, 100*time.Millisecond, mh.callsCounter[5].Sub(mh.callsCounter[4]))
+		must.Greater(t, 100*time.Millisecond, mh.callsCounter[6].Sub(mh.callsCounter[5]))
 	})
 }
 
 func Test_RetryPut_one_call(t *testing.T) {
 	t.Run("successfully retries until no error, delayed capped to 100ms", func(t *testing.T) {
-		callsCounter := []time.Time{}
+		mh := mockHandler{
+			callsCounter: []time.Time{},
+		}
 
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			callsCounter = append(callsCounter, time.Now())
-
-			// return a populated meta after 7 tries to test he retries stops after a
-			// successful call
-			if len(callsCounter) < 7 {
-				http.Error(rw, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
-				return
-			}
-
-			rw.WriteHeader(http.StatusOK)
-			rw.Header().Set("Content-Type", "application/json")
-
-			resp := &WriteMeta{}
-			jsonResp, _ := json.Marshal(resp)
-
-			rw.Write(jsonResp)
-			return
-		}))
+		server := httptest.NewServer(http.HandlerFunc(mh.Handle))
 
 		cm := &Client{
 			httpClient: server.Client(),
@@ -101,6 +94,37 @@ func Test_RetryPut_one_call(t *testing.T) {
 		must.Error(t, err)
 		must.Nil(t, md)
 
-		must.Len(t, 1, callsCounter)
+		must.Len(t, 1, mh.callsCounter)
+	})
+}
+
+func Test_RetryPut_capped_base_too_big(t *testing.T) {
+	t.Run("successfully retries until no error, delayed capped to 100ms", func(t *testing.T) {
+		mh := mockHandler{
+			callsCounter: []time.Time{},
+		}
+
+		defaultMaxBackoffDelay = 200 * time.Millisecond
+
+		server := httptest.NewServer(http.HandlerFunc(mh.Handle))
+		cm := &Client{
+			httpClient: server.Client(),
+			config: Config{
+				Address: server.URL,
+				retryOptions: &retryOptions{
+					delayBase:  math.MaxInt64 * time.Nanosecond,
+					maxRetries: 3,
+				},
+			},
+		}
+
+		md, err := cm.retryPut(context.TODO(), "/endpoint", nil, nil, &WriteOptions{})
+		must.Error(t, err)
+
+		must.Len(t, 3, mh.callsCounter)
+
+		must.Nil(t, md)
+		must.Greater(t, defaultMaxBackoffDelay, mh.callsCounter[1].Sub(mh.callsCounter[0]))
+		must.Greater(t, defaultMaxBackoffDelay, mh.callsCounter[2].Sub(mh.callsCounter[1]))
 	})
 }

--- a/api/retry_test.go
+++ b/api/retry_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/shoenig/test/must"
+)
+
+type mockClient struct {
+	callsCounter []time.Time
+}
+
+func (mc *mockClient) put(_ string, _, _ any, _ *WriteOptions) (*WriteMeta, error) {
+	mc.callsCounter = append(mc.callsCounter, time.Now())
+
+	// return a populated meta after 7 tries to test he retries stops after a
+	// successful call
+	if len(mc.callsCounter) < 7 {
+		return nil, &UnexpectedResponseError{
+			statusCode: http.StatusBadGateway,
+		}
+	}
+	return &WriteMeta{}, nil
+}
+
+func Test_RetryPut(t *testing.T) {
+	t.Run("successfully retries until no error, delayed capped to 100ms", func(t *testing.T) {
+
+		mc := &mockClient{}
+		rc := newRetryClient(mc, retryOptions{
+			DelayBase:       10 * time.Millisecond,
+			MaxRetries:      10,
+			MaxBetweenCalls: 100 * time.Millisecond,
+		})
+
+		_, err := rc.retryPut(context.TODO(), "/endpoint/", nil, nil, &WriteOptions{})
+		must.NoError(t, err)
+
+		must.Len(t, 7, mc.callsCounter)
+
+		must.Greater(t, 10*time.Millisecond, mc.callsCounter[1].Sub(mc.callsCounter[0]))
+		must.Greater(t, 20*time.Millisecond, mc.callsCounter[2].Sub(mc.callsCounter[1]))
+		must.Greater(t, 40*time.Millisecond, mc.callsCounter[3].Sub(mc.callsCounter[2]))
+		must.Greater(t, 80*time.Millisecond, mc.callsCounter[4].Sub(mc.callsCounter[3]))
+		must.Greater(t, 100*time.Millisecond, mc.callsCounter[5].Sub(mc.callsCounter[4]))
+		must.Greater(t, 100*time.Millisecond, mc.callsCounter[6].Sub(mc.callsCounter[5]))
+	})
+	t.Run("successfully calls 1 time", func(t *testing.T) {
+		mc := &mockClient{}
+		rc := newRetryClient(mc, retryOptions{
+			MaxRetries: 1,
+		})
+
+		_, err := rc.retryPut(context.TODO(), "/endpoint/", nil, nil, &WriteOptions{})
+		must.Error(t, err)
+
+		must.Len(t, 1, mc.callsCounter)
+	})
+}

--- a/api/retry_test.go
+++ b/api/retry_test.go
@@ -2,61 +2,105 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/shoenig/test/must"
 )
 
-type mockClient struct {
-	callsCounter []time.Time
-}
-
-func (mc *mockClient) put(_ string, _, _ any, _ *WriteOptions) (*WriteMeta, error) {
-	mc.callsCounter = append(mc.callsCounter, time.Now())
-
-	// return a populated meta after 7 tries to test he retries stops after a
-	// successful call
-	if len(mc.callsCounter) < 7 {
-		return nil, &UnexpectedResponseError{
-			statusCode: http.StatusBadGateway,
-		}
-	}
-	return &WriteMeta{}, nil
-}
-
-func Test_RetryPut(t *testing.T) {
+func Test_RetryPut_multiple_calls(t *testing.T) {
 	t.Run("successfully retries until no error, delayed capped to 100ms", func(t *testing.T) {
+		callsCounter := []time.Time{}
 
-		mc := &mockClient{}
-		rc := newRetryClient(mc, retryOptions{
-			DelayBase:       10 * time.Millisecond,
-			MaxRetries:      10,
-			MaxBetweenCalls: 100 * time.Millisecond,
-		})
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			callsCounter = append(callsCounter, time.Now())
 
-		_, err := rc.retryPut(context.TODO(), "/endpoint/", nil, nil, &WriteOptions{})
+			// return a populated meta after 7 tries to test he retries stops after a
+			// successful call
+			if len(callsCounter) < 7 {
+				http.Error(rw, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
+				return
+			}
+
+			rw.WriteHeader(http.StatusOK)
+			rw.Header().Set("Content-Type", "application/json")
+
+			resp := &WriteMeta{}
+			jsonResp, _ := json.Marshal(resp)
+
+			rw.Write(jsonResp)
+			return
+		}))
+
+		cm := &Client{
+			httpClient: server.Client(),
+			config: Config{
+				Address: server.URL,
+				retryOptions: &retryOptions{
+					delayBase:       10 * time.Millisecond,
+					maxRetries:      10,
+					maxBetweenCalls: 100 * time.Millisecond,
+				},
+			},
+		}
+
+		md, err := cm.retryPut(context.TODO(), "/endpoint", nil, nil, &WriteOptions{})
 		must.NoError(t, err)
 
-		must.Len(t, 7, mc.callsCounter)
+		must.Len(t, 7, callsCounter)
 
-		must.Greater(t, 10*time.Millisecond, mc.callsCounter[1].Sub(mc.callsCounter[0]))
-		must.Greater(t, 20*time.Millisecond, mc.callsCounter[2].Sub(mc.callsCounter[1]))
-		must.Greater(t, 40*time.Millisecond, mc.callsCounter[3].Sub(mc.callsCounter[2]))
-		must.Greater(t, 80*time.Millisecond, mc.callsCounter[4].Sub(mc.callsCounter[3]))
-		must.Greater(t, 100*time.Millisecond, mc.callsCounter[5].Sub(mc.callsCounter[4]))
-		must.Greater(t, 100*time.Millisecond, mc.callsCounter[6].Sub(mc.callsCounter[5]))
+		must.NotNil(t, md)
+		must.Greater(t, 10*time.Millisecond, callsCounter[1].Sub(callsCounter[0]))
+		must.Greater(t, 20*time.Millisecond, callsCounter[2].Sub(callsCounter[1]))
+		must.Greater(t, 40*time.Millisecond, callsCounter[3].Sub(callsCounter[2]))
+		must.Greater(t, 80*time.Millisecond, callsCounter[4].Sub(callsCounter[3]))
+		must.Greater(t, 100*time.Millisecond, callsCounter[5].Sub(callsCounter[4]))
+		must.Greater(t, 100*time.Millisecond, callsCounter[6].Sub(callsCounter[5]))
 	})
-	t.Run("successfully calls 1 time", func(t *testing.T) {
-		mc := &mockClient{}
-		rc := newRetryClient(mc, retryOptions{
-			MaxRetries: 1,
-		})
+}
 
-		_, err := rc.retryPut(context.TODO(), "/endpoint/", nil, nil, &WriteOptions{})
+func Test_RetryPut_one_call(t *testing.T) {
+	t.Run("successfully retries until no error, delayed capped to 100ms", func(t *testing.T) {
+		callsCounter := []time.Time{}
+
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			callsCounter = append(callsCounter, time.Now())
+
+			// return a populated meta after 7 tries to test he retries stops after a
+			// successful call
+			if len(callsCounter) < 7 {
+				http.Error(rw, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
+				return
+			}
+
+			rw.WriteHeader(http.StatusOK)
+			rw.Header().Set("Content-Type", "application/json")
+
+			resp := &WriteMeta{}
+			jsonResp, _ := json.Marshal(resp)
+
+			rw.Write(jsonResp)
+			return
+		}))
+
+		cm := &Client{
+			httpClient: server.Client(),
+			config: Config{
+				Address: server.URL,
+				retryOptions: &retryOptions{
+					delayBase:  10 * time.Millisecond,
+					maxRetries: 1,
+				},
+			},
+		}
+
+		md, err := cm.retryPut(context.TODO(), "/endpoint/", nil, nil, &WriteOptions{})
 		must.Error(t, err)
+		must.Nil(t, md)
 
-		must.Len(t, 1, mc.callsCounter)
+		must.Len(t, 1, callsCounter)
 	})
 }

--- a/api/retry_test.go
+++ b/api/retry_test.go
@@ -104,16 +104,15 @@ func Test_RetryPut_capped_base_too_big(t *testing.T) {
 			callsCounter: []time.Time{},
 		}
 
-		defaultMaxBackoffDelay = 200 * time.Millisecond
-
 		server := httptest.NewServer(http.HandlerFunc(mh.Handle))
 		cm := &Client{
 			httpClient: server.Client(),
 			config: Config{
 				Address: server.URL,
 				retryOptions: &retryOptions{
-					delayBase:  math.MaxInt64 * time.Nanosecond,
-					maxRetries: 3,
+					delayBase:       math.MaxInt64 * time.Nanosecond,
+					maxRetries:      3,
+					maxBackoffDelay: 200 * time.Millisecond,
 				},
 			},
 		}
@@ -124,7 +123,7 @@ func Test_RetryPut_capped_base_too_big(t *testing.T) {
 		must.Len(t, 3, mh.callsCounter)
 
 		must.Nil(t, md)
-		must.Greater(t, defaultMaxBackoffDelay, mh.callsCounter[1].Sub(mh.callsCounter[0]))
-		must.Greater(t, defaultMaxBackoffDelay, mh.callsCounter[2].Sub(mh.callsCounter[1]))
+		must.Greater(t, cm.config.retryOptions.maxBackoffDelay, mh.callsCounter[1].Sub(mh.callsCounter[0]))
+		must.Greater(t, cm.config.retryOptions.maxBackoffDelay, mh.callsCounter[2].Sub(mh.callsCounter[1]))
 	})
 }


### PR DESCRIPTION
The SDK for the locking could benefit from a retry mechanism for calls made to the nomad server, this PR introduces this mechanism on top of the put call already present on the api.