### PR TITLE
docs: ampersand and bash backgrounding problem

### DIFF
--- a/website/content/api-docs/agent.mdx
+++ b/website/content/api-docs/agent.mdx
@@ -129,7 +129,7 @@ The table below shows this endpoint's support for
 ```shell-session
 $ curl \
     --request POST \
-    https://localhost:4646/v1/agent/servers?address=1.2.3.4:4647&address=5.6.7.8:4647
+    "https://localhost:4646/v1/agent/servers?address=1.2.3.4:4647&address=5.6.7.8:4647"
 ```
 
 ## Query Self
@@ -408,7 +408,7 @@ The table below shows this endpoint's support for
 ```shell-session
 $ curl \
     --request POST \
-    https://localhost:4646/v1/agent/join?address=1.2.3.4&address=5.6.7.8
+    "https://localhost:4646/v1/agent/join?address=1.2.3.4&address=5.6.7.8"
 ```
 
 ### Sample Response
@@ -615,10 +615,10 @@ The table below shows this endpoint's support for
 
 ```shell-session
 $ curl \
-    https://localhost:4646/v1/agent/monitor?log_level=debug&server_id=leader
+    "https://localhost:4646/v1/agent/monitor?log_level=debug&server_id=leader"
 
 $ curl \
-    https://localhost:4646/v1/agent/monitor?log_level=debug&node_id=a57b2adb-1a30-2dda-8df0-25abb0881952
+    "https://localhost:4646/v1/agent/monitor?log_level=debug&node_id=a57b2adb-1a30-2dda-8df0-25abb0881952"
 ```
 
 ### Sample Response
@@ -705,19 +705,19 @@ The following table explains when each endpoint is available:
 ```shell-session
 $ curl -O -J \
     --header "X-Nomad-Token: 8176afd3-772d-0b71-8f85-7fa5d903e9d4" \
-    https://localhost:4646/v1/agent/pprof/goroutine?server_id=leader
+    "https://localhost:4646/v1/agent/pprof/goroutine?server_id=leader"
 
 $ go tool pprof goroutine
 
 $ curl -O -J \
     --header "X-Nomad-Token: 8176afd3-772d-0b71-8f85-7fa5d903e9d4" \
-    https://localhost:4646/v1/agent/pprof/profile?seconds=5&node_id=a57b2adb-1a30-2dda-8df0-25abb0881952
+    "https://localhost:4646/v1/agent/pprof/profile?seconds=5&node_id=a57b2adb-1a30-2dda-8df0-25abb0881952"
 
 $ go tool pprof profile
 
 $ curl -O -J \
     --header "X-Nomad-Token: 8176afd3-772d-0b71-8f85-7fa5d903e9d4" \
-    https://localhost:4646/v1/agent/pprof/trace?&seconds=5&server_id=server1.global
+    "https://localhost:4646/v1/agent/pprof/trace?&seconds=5&server_id=server1.global"
 
 go tool trace trace
 ```


### PR DESCRIPTION
the `&` symbol messes up the command when copying and pasting into a shell