### PR TITLE
[hooks] Fix pre-push hook

### DIFF
--- a/dev/hooks/pre-push
+++ b/dev/hooks/pre-push
@@ -3,28 +3,31 @@
 set -euo pipefail
 
 fail () {
-    echo "pre-push hook: $@" >&2
-    echo "    --no-verify to bypass this hook" >&2
-    exit 1
+  echo "pre-push hook: $@" >&2
+  echo "    --no-verify to bypass this hook" >&2
+  exit 1
 }
 
-# only push to oss when the enterprise version is absent
+if ! git rev-parse --show-toplevel > /dev/null; then
+  fail "this hook must be run from a worktree."
+fi
+
+# only push to oss when the enterprise sentinel file is absent
 # ====================
-oss="git@github.com:hashicorp/nomad.git"
-ent="hashicorp/nomad-enterprise"
+if [ -f version/version_ent.go ]; then
 
-# isEnterprise exits with a 0 when the first parameter matches the
-# nomad-enterprise repo, regardless of additional optional and variable
-# components of the remote URL, like the terminal ".git" extension
-isEnterprise () {
-  local arg="${1}"
-  return (echo "${arg}" | grep -q -E "^(https://github.com/|git@github.com:)?${ent}(.git)?$")
-}
+  # isEnterprise exits with a 0 when its first parameter matches the
+  # nomad-enterprise repo, regardless of additional optional and variable
+  # components of the remote URL, like the terminal ".git" extension
+  isEnterprise () {
+    local ent="hashicorp/nomad-enterprise"
+    local remote_url="${1}"
+    echo "${remote_url}" | grep -q -E "^((https://|((ssh://)?git@))?(www\.)?github\.com[:/])?hashicorp/nomad-enterprise(.git)?$"
+  }
 
-isEnterprise "${2}"
-
-if [ $? -ne 0 -a -f version/version_ent.go ]; then
-    fail "found enterprise version file version/version_ent.go pushing to non-enterprise remote \"${2}\""
+  if ! isEnterprise "${2}"; then
+    fail "found version/version_ent.go pushing to non-enterprise remote \"${2}\""
+  fi
 fi
 
 # do not push directly to main, stable-*, release/*
@@ -43,3 +46,4 @@ do
         fail "refusing to push directly to a branch prefixed \`release/\`"
     fi
 done
+


### PR DESCRIPTION
In #17560 I broke the pre-push hook. This PR should fix it and adds some more possibilities to the mix.

Since we use the presence of the sentinel file to determine if we're pushing the enterprise version, rather than checking the remote every time the hook runs, I moved all of the enterprise checking into a conditional based on that test.

The regex is nasty, because there are a lot of optional components to legit remote URLs 😢 