### PR TITLE
Update linux package license to BUSL-1.1

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -7,6 +7,9 @@ project {
   header_ignore = [
     "command/asset/*.hcl",
     "command/agent/bindata_assetfs.go",
+    "api/**",
+    "drivers/shared/**",
+    "plugins/**",
     // Enterprise files do not fall under the open source licensing. OSS-ENT
     // merge conflicts might happen here, please be sure to put new OSS
     // exceptions above this comment.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,7 +207,7 @@ jobs:
           version: ${{ needs.get-product-version.outputs.product-version }}
           maintainer: "HashiCorp"
           homepage: "https://github.com/hashicorp/nomad"
-          license: "MPL-2.0"
+          license: "BUSL-1.1"
           binary: "pkg/${{ matrix.goos }}_${{ matrix.goarch }}/${{ env.PKG_NAME }}"
           deb_depends: "openssl"
           rpm_depends: "openssl"


### PR DESCRIPTION
This updates the linux package license to BUSL-1.1.
This PR should be merged to main so that the change is included in the next minor release that is cut from main.
License changes are not required on release branches (ongoing patch releases of current minor releases).

Also update copywrite.hcl to exclude MPL licensed subdirs.
