### PR TITLE
fix multiple overflow errors in exponential backoff

### DIFF
--- a/.changelog/18200.txt
+++ b/.changelog/18200.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fixed a bug where exponential backoff could result in excessive CPU usage
+```

--- a/client/allocrunner/taskrunner/vault_hook.go
+++ b/client/allocrunner/taskrunner/vault_hook.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	ti "github.com/hashicorp/nomad/client/allocrunner/taskrunner/interfaces"
 	"github.com/hashicorp/nomad/client/vaultclient"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -311,8 +312,8 @@ OUTER:
 // deriveVaultToken derives the Vault token using exponential backoffs. It
 // returns the Vault token and whether the manager should exit.
 func (h *vaultHook) deriveVaultToken() (token string, exit bool) {
-	attempts := 0
-	backoff := time.Duration(0)
+	var attempts uint64
+	var backoff time.Duration
 	for {
 		tokens, err := h.client.DeriveToken(h.alloc, []string{h.taskName})
 		if err == nil {
@@ -340,13 +341,9 @@ func (h *vaultHook) deriveVaultToken() (token string, exit bool) {
 		}
 
 		// Handle the retry case
-		if backoff < vaultBackoffLimit {
-			backoff = (1 << (2 * uint64(attempts))) * vaultBackoffBaseline
-			if backoff > vaultBackoffLimit {
-				backoff = vaultBackoffLimit
-			}
-			attempts++
-		}
+		backoff = helper.Backoff(vaultBackoffBaseline, vaultBackoffLimit, attempts)
+		attempts++
+
 		h.logger.Error("failed to derive Vault token", "error", err, "recoverable", true, "backoff", backoff)
 
 		// Wait till retrying

--- a/client/devicemanager/instance.go
+++ b/client/devicemanager/instance.go
@@ -510,9 +510,8 @@ START:
 			}
 		}
 
-		// Reset the backoff since we got statistics
+		// Reset the attempts since we got statistics
 		attempt = 0
-		backoff = 0
 
 		// Store the new stats
 		if sresp.Groups != nil {

--- a/client/pluginmanager/drivermanager/instance.go
+++ b/client/pluginmanager/drivermanager/instance.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pluginutils/loader"
 	"github.com/hashicorp/nomad/helper/pluginutils/singleton"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -290,7 +291,7 @@ func (i *instanceManager) fingerprint() {
 
 	// backoff and retry used if the RPC is closed by the other end
 	var backoff time.Duration
-	var retry int
+	var retry uint64
 	for {
 		if backoff > 0 {
 			select {
@@ -329,13 +330,8 @@ func (i *instanceManager) fingerprint() {
 				i.handleFingerprintError()
 
 				// Calculate the new backoff
-				if backoff < driverFPBackoffLimit {
-					backoff = (1 << (2 * uint64(retry))) * driverFPBackoffBaseline
-					if backoff > driverFPBackoffLimit {
-						backoff = driverFPBackoffLimit
-					}
-					retry++
-				}
+				backoff = helper.Backoff(driverFPBackoffBaseline, driverFPBackoffLimit, retry)
+				retry++
 				continue
 			}
 			cancel()

--- a/client/pluginmanager/drivermanager/instance.go
+++ b/client/pluginmanager/drivermanager/instance.go
@@ -329,12 +329,13 @@ func (i *instanceManager) fingerprint() {
 				i.handleFingerprintError()
 
 				// Calculate the new backoff
-				backoff = (1 << (2 * uint64(retry))) * driverFPBackoffBaseline
-				if backoff > driverFPBackoffLimit {
-					backoff = driverFPBackoffLimit
+				if backoff < driverFPBackoffLimit {
+					backoff = (1 << (2 * uint64(retry))) * driverFPBackoffBaseline
+					if backoff > driverFPBackoffLimit {
+						backoff = driverFPBackoffLimit
+					}
+					retry++
 				}
-				// Increment retry counter
-				retry++
 				continue
 			}
 			cancel()
@@ -453,11 +454,13 @@ func (i *instanceManager) handleEvents() {
 				i.logger.Warn("failed to receive task events, retrying", "error", err, "retry", retry)
 
 				// Calculate the new backoff
-				backoff = (1 << (2 * uint64(retry))) * driverFPBackoffBaseline
-				if backoff > driverFPBackoffLimit {
-					backoff = driverFPBackoffLimit
+				if backoff < driverFPBackoffLimit {
+					backoff = (1 << (2 * uint64(retry))) * driverFPBackoffBaseline
+					if backoff > driverFPBackoffLimit {
+						backoff = driverFPBackoffLimit
+					}
+					retry++
 				}
-				retry++
 				continue
 			}
 			cancel()

--- a/client/pluginmanager/drivermanager/instance.go
+++ b/client/pluginmanager/drivermanager/instance.go
@@ -423,7 +423,7 @@ func (i *instanceManager) handleEvents() {
 	}
 
 	var backoff time.Duration
-	var retry int
+	var retry uint64
 	for {
 		if backoff > 0 {
 			select {
@@ -450,13 +450,8 @@ func (i *instanceManager) handleEvents() {
 				i.logger.Warn("failed to receive task events, retrying", "error", err, "retry", retry)
 
 				// Calculate the new backoff
-				if backoff < driverFPBackoffLimit {
-					backoff = (1 << (2 * uint64(retry))) * driverFPBackoffBaseline
-					if backoff > driverFPBackoffLimit {
-						backoff = driverFPBackoffLimit
-					}
-					retry++
-				}
+				backoff = helper.Backoff(driverFPBackoffBaseline, driverFPBackoffLimit, retry)
+				retry++
 				continue
 			}
 			cancel()

--- a/command/agent/consul/version_checker.go
+++ b/command/agent/consul/version_checker.go
@@ -27,6 +27,7 @@ func checkConsulTLSSkipVerify(ctx context.Context, logger log.Logger, client Age
 
 	timer, stop := helper.NewSafeTimer(limit)
 	defer stop()
+	backoff := time.Duration(0)
 
 	for {
 		self, err := client.Self()
@@ -40,11 +41,13 @@ func checkConsulTLSSkipVerify(ctx context.Context, logger log.Logger, client Age
 			return
 		}
 
-		backoff := (1 << (2 * i)) * baseline
-		if backoff > limit {
-			backoff = limit
-		} else {
-			i++
+		if backoff < limit {
+			backoff = (1 << (2 * i)) * baseline
+			if backoff > limit {
+				backoff = limit
+			} else {
+				i++
+			}
 		}
 
 		timer.Reset(backoff)

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -527,8 +527,8 @@ CREATE:
 		}
 
 		if attempted < 5 {
-			backoff = helper.Backoff(50*time.Millisecond, time.Minute, attempted)
 			attempted++
+			backoff = helper.Backoff(50*time.Millisecond, time.Minute, attempted)
 			time.Sleep(backoff)
 			goto CREATE
 		}
@@ -539,6 +539,7 @@ CREATE:
 		return nil, nstructs.NewRecoverableError(createErr, true)
 	} else if isDockerTransientError(createErr) && attempted < 5 {
 		attempted++
+		backoff = helper.Backoff(50*time.Millisecond, time.Minute, attempted)
 		time.Sleep(backoff)
 		goto CREATE
 	}

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -533,9 +533,6 @@ CREATE:
 			goto CREATE
 		}
 
-		if attempted < 5 {
-			attempted++
-		}
 	} else if strings.Contains(strings.ToLower(createErr.Error()), "no such image") {
 		// There is still a very small chance this is possible even with the
 		// coordinator so retry.

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -572,7 +572,8 @@ START:
 	return recoverableErrTimeouts(startErr)
 }
 
-// nextBackoff returns appropriate docker backoff durations after attempted attempts.
+// nextBackoff returns appropriate docker backoff durations after attempted
+// attempts. Note that the caller must cap attempted so that it doesn't overflow
 func nextBackoff(attempted int) time.Duration {
 	// attempts in 200ms, 800ms, 3.2s, 12.8s, 51.2s
 	// TODO: add randomization factor and extract to a helper

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -476,7 +476,9 @@ type createContainerClient interface {
 func (d *Driver) createContainer(client createContainerClient, config docker.CreateContainerOptions,
 	image string) (*docker.Container, error) {
 	// Create a container
-	attempted := 0
+	var attempted uint64
+	var backoff time.Duration
+
 CREATE:
 	container, createErr := client.CreateContainer(config)
 	if createErr == nil {
@@ -525,9 +527,14 @@ CREATE:
 		}
 
 		if attempted < 5 {
+			backoff = helper.Backoff(50*time.Millisecond, time.Minute, attempted)
 			attempted++
-			time.Sleep(nextBackoff(attempted))
+			time.Sleep(backoff)
 			goto CREATE
+		}
+
+		if attempted < 5 {
+			attempted++
 		}
 	} else if strings.Contains(strings.ToLower(createErr.Error()), "no such image") {
 		// There is still a very small chance this is possible even with the
@@ -535,7 +542,7 @@ CREATE:
 		return nil, nstructs.NewRecoverableError(createErr, true)
 	} else if isDockerTransientError(createErr) && attempted < 5 {
 		attempted++
-		time.Sleep(nextBackoff(attempted))
+		time.Sleep(backoff)
 		goto CREATE
 	}
 
@@ -550,8 +557,9 @@ func (d *Driver) startContainer(c *docker.Container) error {
 		return err
 	}
 
-	// Start a container
-	attempted := 0
+	var attempted uint64
+	var backoff time.Duration
+
 START:
 	startErr := dockerClient.StartContainer(c.ID, c.HostConfig)
 	if startErr == nil || strings.Contains(startErr.Error(), "Container already running") {
@@ -563,21 +571,14 @@ START:
 	if isDockerTransientError(startErr) {
 		if attempted < 5 {
 			attempted++
-			time.Sleep(nextBackoff(attempted))
+			backoff = helper.Backoff(50*time.Millisecond, time.Minute, attempted)
+			time.Sleep(backoff)
 			goto START
 		}
 		return nstructs.NewRecoverableError(startErr, true)
 	}
 
 	return recoverableErrTimeouts(startErr)
-}
-
-// nextBackoff returns appropriate docker backoff durations after attempted
-// attempts. Note that the caller must cap attempted so that it doesn't overflow
-func nextBackoff(attempted int) time.Duration {
-	// attempts in 200ms, 800ms, 3.2s, 12.8s, 51.2s
-	// TODO: add randomization factor and extract to a helper
-	return 1 << (2 * uint64(attempted)) * 50 * time.Millisecond
 }
 
 // createImage creates a docker image either by pulling it from a registry or by

--- a/drivers/docker/stats.go
+++ b/drivers/docker/stats.go
@@ -137,12 +137,13 @@ func (h *taskHandle) collectStats(ctx context.Context, destCh *usageSender, inte
 			h.logger.Debug("error collecting stats from container", "error", err)
 
 			// Calculate the new backoff
-			backoff = (1 << (2 * uint64(retry))) * statsCollectorBackoffBaseline
-			if backoff > statsCollectorBackoffLimit {
-				backoff = statsCollectorBackoffLimit
+			if backoff < statsCollectorBackoffLimit {
+				backoff = (1 << (2 * uint64(retry))) * statsCollectorBackoffBaseline
+				if backoff > statsCollectorBackoffLimit {
+					backoff = statsCollectorBackoffLimit
+				}
+				retry++
 			}
-			// Increment retry counter
-			retry++
 			continue
 		}
 		// Stats finished either because context was canceled, doneCh was closed

--- a/helper/backoff.go
+++ b/helper/backoff.go
@@ -1,0 +1,31 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package helper
+
+import (
+	"time"
+)
+
+func Backoff(backoffBase time.Duration, backoffLimit time.Duration, attempt uint64) time.Duration {
+	const MaxUint = ^uint64(0)
+	const MaxInt = int64(MaxUint >> 1)
+
+	// Ensure lack of non-positive backoffs since these make no sense
+	if backoffBase.Nanoseconds() <= 0 {
+		return max(backoffBase, 0*time.Second)
+	}
+
+	// Ensure that a large attempt will not cause an overflow
+	if attempt > 62 || MaxInt/backoffBase.Nanoseconds() < (1<<attempt) {
+		return backoffLimit
+	}
+
+	// Compute deadline and clamp it to backoffLimit
+	deadline := 1 << attempt * backoffBase
+	if deadline > backoffLimit {
+		deadline = backoffLimit
+	}
+
+	return deadline
+}

--- a/helper/backoff_test.go
+++ b/helper/backoff_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package helper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shoenig/test/must"
+)
+
+func Test_Backoff(t *testing.T) {
+	const MaxUint = ^uint64(0)
+	const MaxInt = int64(MaxUint >> 1)
+
+	cases := []struct {
+		name           string
+		backoffBase    time.Duration
+		backoffLimit   time.Duration
+		attempt        uint64
+		expectedResult time.Duration
+	}{
+		{
+			name:           "backoff limit clamps for high base",
+			backoffBase:    time.Hour,
+			backoffLimit:   time.Minute,
+			attempt:        1,
+			expectedResult: time.Minute,
+		},
+		{
+			name:           "backoff limit clamps for boundary attempt",
+			backoffBase:    time.Hour,
+			backoffLimit:   time.Minute,
+			attempt:        63,
+			expectedResult: time.Minute,
+		},
+		{
+			name:           "small retry value",
+			backoffBase:    time.Minute,
+			backoffLimit:   time.Hour,
+			attempt:        0,
+			expectedResult: time.Minute,
+		},
+		{
+			name:           "first retry value",
+			backoffBase:    time.Minute,
+			backoffLimit:   time.Hour,
+			attempt:        1,
+			expectedResult: 2 * time.Minute,
+		},
+		{
+			name:           "fifth retry value",
+			backoffBase:    time.Minute,
+			backoffLimit:   time.Hour,
+			attempt:        5,
+			expectedResult: 32 * time.Minute,
+		},
+		{
+			name:           "sixth retry value",
+			backoffBase:    time.Minute,
+			backoffLimit:   time.Hour,
+			attempt:        6,
+			expectedResult: time.Hour,
+		},
+	}
+
+	for _, tc := range cases {
+		result := Backoff(tc.backoffBase, tc.backoffLimit, tc.attempt)
+		must.Eq(t, tc.expectedResult, result)
+	}
+}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -274,13 +274,13 @@ func (s *StateStore) SnapshotMinIndex(ctx context.Context, index uint64) (*State
 		}
 
 		// Exponential back off
-		retries++
 		if retryTimer == nil {
 			// First retry, start at baseline
 			retryTimer = time.NewTimer(backoffBase)
 		} else {
 			// Subsequent retry, reset timer
 			if deadline < backoffLimit {
+				retries++
 				deadline = 1 << (2 * retries) * backoffBase
 				if deadline > backoffLimit {
 					deadline = backoffLimit

--- a/nomad/worker.go
+++ b/nomad/worker.go
@@ -109,8 +109,9 @@ type Worker struct {
 
 	// failures is the count of errors encountered while dequeueing evaluations
 	// and is used to calculate backoff.
-	failures  uint
-	evalToken string
+	failures       uint
+	failureBackoff time.Duration
+	evalToken      string
 
 	// snapshotIndex is the index of the snapshot in which the scheduler was
 	// first invoked. It is used to mark the SnapshotIndex of evaluations
@@ -133,6 +134,7 @@ func newWorker(ctx context.Context, srv *Server, args SchedulerWorkerPoolArgs) *
 		start:             time.Now(),
 		status:            WorkerStarting,
 		enabledSchedulers: make([]string, len(args.EnabledSchedulers)),
+		failureBackoff:    time.Duration(0),
 	}
 	copy(w.enabledSchedulers, args.EnabledSchedulers)
 
@@ -874,12 +876,17 @@ func (w *Worker) shouldResubmit(err error) bool {
 // backoff if the server or the worker is shutdown.
 func (w *Worker) backoffErr(base, limit time.Duration) bool {
 	w.setWorkloadStatus(WorkloadBackoff)
-	backoff := (1 << (2 * w.failures)) * base
-	if backoff > limit {
-		backoff = limit
-	} else {
-		w.failures++
+
+	backoff := w.failureBackoff
+	if w.failureBackoff < limit {
+		backoff = (1 << (2 * w.failures)) * base
+		if backoff > limit {
+			backoff = limit
+		} else {
+			w.failures++
+		}
 	}
+
 	select {
 	case <-time.After(backoff):
 		return false

--- a/nomad/worker.go
+++ b/nomad/worker.go
@@ -884,6 +884,7 @@ func (w *Worker) backoffErr(base, limit time.Duration) bool {
 			backoff = limit
 		} else {
 			w.failures++
+			w.failureBackoff = backoff
 		}
 	}
 


### PR DESCRIPTION
We use capped exponential backoff in several places in the code when handling failures. The code we've copy-and-pasted all over has a check to see if the backoff is greater than the limit, but this check happens after the bitshift and we always increment the number of attempts. This causes an overflow with a fairly small number of failures (ex. at one place I tested it occurs after only 24 iterations), resulting in a negative backoff which then never recovers. The backoff becomes a tight loop consuming resources and/or DoS'ing a Nomad RPC handler or an external API such as Vault. Note this doesn't occur in places where we cap the number of iterations so the loop breaks (usually to return an error), so long as the number of iterations is reasonable.

Introduce a check on the cap before the bitshift to avoid overflow in all places this can occur.

Fixes: #18199