### PR TITLE
Fix the logic for the display of a newly created lock

### DIFF
--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -262,7 +262,7 @@ func (sv *Variables) makeVariablesApplyResponse(
 			// Verify the caller is providing the correct lockID, meaning it is the
 			// lock holder and has access to the lock information or is a management call.
 			// If locked, remove the lock information from response.
-			if isCallerOwner(req, eResp.WrittenSVMeta) || !isManagement {
+			if !(isCallerOwner(req, eResp.WrittenSVMeta) || isManagement) {
 				out.Output.VariableMetadata.Lock = nil
 			}
 		}
@@ -321,7 +321,7 @@ func (sv *Variables) Read(args *structs.VariablesReadRequest, reply *structs.Var
 
 	defer metrics.MeasureSince([]string{"nomad", "variables", "read"}, time.Now())
 
-	aclObj, _, err := sv.handleMixedAuthEndpoint(args.QueryOptions,
+	aclObj, err := sv.handleMixedAuthEndpoint(args.QueryOptions,
 		acl.PolicyRead, args.Path)
 	if err != nil {
 		return err
@@ -591,7 +591,7 @@ func (sv *Variables) decrypt(v *structs.VariableEncrypted) (*structs.VariableDec
 
 // handleMixedAuthEndpoint is a helper to handle auth on RPC endpoints that can
 // either be called by external clients or by workload identity
-func (sv *Variables) handleMixedAuthEndpoint(args structs.QueryOptions, policy, pathOrPrefix string) (*acl.ACL, *structs.IdentityClaims, error) {
+func (sv *Variables) handleMixedAuthEndpoint(args structs.QueryOptions, policy, pathOrPrefix string) (*acl.ACL, error) {
 
 	var aclObj *acl.ACL
 	var err error
@@ -599,17 +599,17 @@ func (sv *Variables) handleMixedAuthEndpoint(args structs.QueryOptions, policy, 
 	if aclToken != nil {
 		aclObj, err = sv.srv.ResolveACLForToken(aclToken)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 	claims := args.GetIdentity().GetClaims()
 
 	err = sv.authorize(aclObj, claims, args.RequestNamespace(), policy, pathOrPrefix)
 	if err != nil {
-		return aclObj, claims, err
+		return aclObj, err
 	}
 
-	return aclObj, claims, nil
+	return aclObj, nil
 }
 
 func (sv *Variables) authorize(aclObj *acl.ACL, claims *structs.IdentityClaims, ns, policy, pathOrPrefix string) error {
@@ -749,5 +749,5 @@ func isCallerOwner(req *structs.VariablesApplyRequest, respVarMeta *structs.Vari
 
 	return reqLock != nil &&
 		savedLock != nil &&
-		reqLock.ID != savedLock.ID
+		reqLock.ID == savedLock.ID
 }

--- a/nomad/variables_endpoint_test.go
+++ b/nomad/variables_endpoint_test.go
@@ -1404,43 +1404,49 @@ func TestVariablesEndpoint_Read_Lock_ACL(t *testing.T) {
 	listPol := mock.NamespacePolicyWithVariables(
 		structs.DefaultNamespace, "", []string{"list-jobs"},
 		map[string][]string{
-			"dropbox/*": {"list", "read", "write"},
+			"dropbox/*": {"list", "read"},
 		})
 	listToken := mock.CreatePolicyAndToken(t, state, 1003, "test-write-invalid", listPol)
 
 	sv := mock.Variable()
 	sv.Path = "dropbox/a"
 
-	sv.VariableMetadata.Lock = &structs.VariableLock{
-		ID:        "theLockID",
-		TTL:       24 * time.Hour,
-		LockDelay: 15 * time.Second,
-	}
+	latest := sv.Copy()
+	t.Run("successfully acquire lock on new variable", func(t *testing.T) {
+		sv := sv.Copy()
+		sv.VariableMetadata.Lock = &structs.VariableLock{
+			TTL:       24 * time.Hour,
+			LockDelay: 15 * time.Second,
+		}
 
-	bPlain, err := json.Marshal(sv.Items)
-	must.NoError(t, err)
-	bEnc, kID, err := srv.encrypter.Encrypt(bPlain)
+		applyReq := structs.VariablesApplyRequest{
+			Op:  structs.VarOpLockAcquire,
+			Var: &sv,
+			WriteRequest: structs.WriteRequest{
+				Region:    "global",
+				AuthToken: rootToken.SecretID,
+			},
+		}
 
-	// Creating and locking the variable directly on the state store allows us to
-	// set up the lock ID and bypass the timers.
-	svEnc := structs.VariableEncrypted{
-		VariableMetadata: sv.VariableMetadata,
-		VariableData: structs.VariableData{
-			Data:  bEnc,
-			KeyID: kID,
-		},
-	}
+		runningTimers := srv.lockTTLTimer.TimerNum()
 
-	ssResp := state.VarLockAcquire(100, &structs.VarApplyStateRequest{
-		Op:  structs.VarOpLockAcquire,
-		Var: &svEnc,
+		applyResp := new(structs.VariablesApplyResponse)
+		err := msgpackrpc.CallWithCodec(codec, structs.VariablesApplyRPCMethod, &applyReq, applyResp)
+
+		must.NoError(t, err)
+		must.Eq(t, structs.VarOpResultOk, applyResp.Result)
+		must.NotNil(t, applyResp.Output.VariableMetadata.Lock)
+		must.Eq(t, sv.Items, applyResp.Output.Items)
+
+		must.NotNil(t, srv.lockTTLTimer.Get(applyResp.Output.VariableMetadata.Lock.ID))
+		must.Eq(t, runningTimers+1, srv.lockTTLTimer.TimerNum())
+		latest = *applyResp.Output
+
 	})
-
-	must.NoError(t, ssResp.Error)
 
 	t.Run("successfully read the lock information with a management call", func(t *testing.T) {
 		req := &structs.VariablesReadRequest{
-			Path: svEnc.Path,
+			Path: sv.Path,
 			QueryOptions: structs.QueryOptions{
 				Namespace: structs.DefaultNamespace,
 				AuthToken: rootToken.SecretID,
@@ -1451,12 +1457,12 @@ func TestVariablesEndpoint_Read_Lock_ACL(t *testing.T) {
 		readResp := new(structs.VariablesReadResponse)
 		must.NoError(t, msgpackrpc.CallWithCodec(codec, "Variables.Read", req, &readResp))
 		must.NotNil(t, readResp.Data.VariableMetadata.Lock)
-		must.Eq(t, "theLockID", readResp.Data.LockID())
+		must.Eq(t, latest.LockID(), readResp.Data.LockID())
 	})
 
-	t.Run("try to read the lock information without a list token", func(t *testing.T) {
+	t.Run("try to read the lock information with a list token", func(t *testing.T) {
 		req := &structs.VariablesReadRequest{
-			Path: svEnc.Path,
+			Path: sv.Path,
 			QueryOptions: structs.QueryOptions{
 				Namespace: structs.DefaultNamespace,
 				AuthToken: listToken.SecretID,

--- a/nomad/variables_endpoint_test.go
+++ b/nomad/variables_endpoint_test.go
@@ -385,7 +385,7 @@ func TestVariablesEndpoint_auth(t *testing.T) {
 		if err != nil {
 			return structs.ErrPermissionDenied
 		}
-		_, _, err = variablesRPC.handleMixedAuthEndpoint(
+		_, err = variablesRPC.handleMixedAuthEndpoint(
 			*args, cap, path)
 		return err
 	}


### PR DESCRIPTION
On top of fixing the lock owner check, this PR also introduces a change that allows for the ACL object that is created when the call is made using a workload identity token to be used outside of the `authorize` function.

This code will need to be revisited after the nil ACLs is removed