### PR TITLE
[ui] Use ]] and [[ to paginate index pages

### DIFF
--- a/.changelog/18210.txt
+++ b/.changelog/18210.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: adds keyboard commands for pagination on lists using [[ and ]]
+```

--- a/ui/.template-lintrc.js
+++ b/ui/.template-lintrc.js
@@ -19,5 +19,6 @@ module.exports = {
   },
   ignore: [
     'app/components/breadcrumbs/*', // using {{(modifier)}} syntax
+    'app/templates/components/list-pagination/list-pager', // using {{(modifier)}} syntax
   ],
 };

--- a/ui/app/components/list-pagination/list-pager.js
+++ b/ui/app/components/list-pagination/list-pager.js
@@ -6,7 +6,17 @@
 import Component from '@ember/component';
 import { tagName } from '@ember-decorators/component';
 import classic from 'ember-classic-decorator';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 @classic
 @tagName('')
-export default class ListPager extends Component {}
+export default class ListPager extends Component {
+  @service router;
+  @action
+  gotoRoute() {
+    this.router.transitionTo(this.router.currentRouteName, {
+      queryParams: { page: this.page },
+    });
+  }
+}

--- a/ui/app/components/list-pagination/list-pager.js
+++ b/ui/app/components/list-pagination/list-pager.js
@@ -8,11 +8,23 @@ import { tagName } from '@ember-decorators/component';
 import classic from 'ember-classic-decorator';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import KeyboardShortcutModifier from 'nomad-ui/modifiers/keyboard-shortcut';
 
 @classic
 @tagName('')
 export default class ListPager extends Component {
   @service router;
+
+  // Even though we don't currently use "first" / "last" pagination in the app,
+  // the option is there at a component level, so let's make sure that we
+  // only append keyNav to the "next" and "prev" links.
+  // We use this to make the modifier conditional, per https://v5.chriskrycho.com/journal/conditional-modifiers-and-helpers-in-emberjs/
+  get includeKeyboardNav() {
+    return this.label === 'Next page' || this.label === 'Previous page'
+      ? KeyboardShortcutModifier
+      : null;
+  }
+
   @action
   gotoRoute() {
     this.router.transitionTo(this.router.currentRouteName, {

--- a/ui/app/templates/components/list-pagination/list-pager.hbs
+++ b/ui/app/templates/components/list-pagination/list-pager.hbs
@@ -3,6 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
+{{! template-lint-disable no-unknown-arguments-for-builtin-components }}
 {{#if this.visible}}
   <LinkTo
     @query={{hash currentPage=this.page}}

--- a/ui/app/templates/components/list-pagination/list-pager.hbs
+++ b/ui/app/templates/components/list-pagination/list-pager.hbs
@@ -9,11 +9,12 @@
     class={{this.class}}
     data-test-pager={{this.test}}
     aria-label={{this.label}}
-    {{keyboard-shortcut
+    {{(modifier
+      this.includeKeyboardNav
       label=(if (eq this.label 'Next page') 'Next Page' 'Previous Page')
       action=(action "gotoRoute")
       pattern=(if (eq this.label 'Next page') (array "]" "]") (array "[" "["))
-    }}
+    )}}
   >
     {{yield}}
   </LinkTo>

--- a/ui/app/templates/components/list-pagination/list-pager.hbs
+++ b/ui/app/templates/components/list-pagination/list-pager.hbs
@@ -9,6 +9,11 @@
     class={{this.class}}
     data-test-pager={{this.test}}
     aria-label={{this.label}}
+    {{keyboard-shortcut
+      label=(if (eq this.label 'Next page') 'Next Page' 'Previous Page')
+      action=(action "gotoRoute")
+      pattern=(if (eq this.label 'Next page') (array "]" "]") (array "[" "["))
+    }}
   >
     {{yield}}
   </LinkTo>

--- a/ui/app/templates/components/list-pagination/list-pager.hbs
+++ b/ui/app/templates/components/list-pagination/list-pager.hbs
@@ -3,7 +3,6 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-{{! template-lint-disable no-unknown-arguments-for-builtin-components }}
 {{#if this.visible}}
   <LinkTo
     @query={{hash currentPage=this.page}}

--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -36,7 +36,7 @@ module.exports = function (environment) {
 
     APP: {
       blockingQueries: true,
-      mirageScenario: 'mediumCluster',
+      mirageScenario: 'smallCluster',
       mirageWithNamespaces: true,
       mirageWithTokens: true,
       mirageWithRegions: true,

--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -36,7 +36,7 @@ module.exports = function (environment) {
 
     APP: {
       blockingQueries: true,
-      mirageScenario: 'smallCluster',
+      mirageScenario: 'mediumCluster',
       mirageWithNamespaces: true,
       mirageWithTokens: true,
       mirageWithRegions: true,


### PR DESCRIPTION
Adds a `[[` and `]]` key command to the `list-pager` prev/next page elements. These are included on, for example, the Jobs index page, clients index page, jobs.job.allocatinos page, etc.

