### PR TITLE
followup to numa/cgroups refactor 

### DIFF
--- a/client/allocrunner/taskrunner/wrangler_hook.go
+++ b/client/allocrunner/taskrunner/wrangler_hook.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	wranglerHookName = "wrangler"
+	wranglerHookName = "procisolation"
 )
 
 // A wranglerHook provides a mechanism through which the Client can be sure any

--- a/client/lib/numalib/topology.go
+++ b/client/lib/numalib/topology.go
@@ -54,12 +54,12 @@ type (
 	Cost     uint8
 )
 
-func (hz KHz) MHz() MHz {
-	return MHz(hz / 1000)
+func (khz KHz) MHz() MHz {
+	return MHz(khz / 1000)
 }
 
-func (hz KHz) String() string {
-	return strconv.FormatUint(uint64(hz.MHz()), 10)
+func (khz KHz) String() string {
+	return strconv.FormatUint(uint64(khz.MHz()), 10)
 }
 
 // A Topology provides a bird-eye view of the system NUMA topology.

--- a/lib/lang/stack.go
+++ b/lib/lang/stack.go
@@ -4,6 +4,9 @@
 package lang
 
 // A Stack is a simple LIFO datastructure.
+//
+// This datastructure is not concurrency-safe; any locking
+// required should be done by the caller!
 type Stack[T any] struct {
 	top *object[T]
 }


### PR DESCRIPTION
- lang: note that Stack is not concurrency-safe
- client: use more descriptive name for wrangler hook in logs
- numalib: use correct name for receiver parameter
