### PR TITLE
test-e2e: no need to run vaultcomat tests as root

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -49,10 +49,7 @@ jobs:
       - uses: hashicorp/setup-golang@v1
       - run: make deps
       - name: Vault Compatability
-        run: |
-          sudo sed -i 's!Defaults!#Defaults!g' /etc/sudoers
-          sudo -E env "PATH=$PATH" make integration-test
-          sudo -E env "PATH=$PATH" make clean
+        run: make integration-test
       - run: make e2e-test
 permissions:
   contents: read

--- a/e2e/vaultcompat/vaultcompat_test.go
+++ b/e2e/vaultcompat/vaultcompat_test.go
@@ -134,7 +134,8 @@ func startNomad(t *testing.T, vc *vaultapi.Client) (func(), *nomadapi.Client) {
 		}
 		c.DevMode = true
 		c.Client = &testutil.ClientConfig{
-			Enabled: true,
+			Enabled:      true,
+			TotalCompute: 1000,
 		}
 		c.LogLevel = testlog.HCLoggerTestLevel().String()
 	})

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -78,7 +78,8 @@ type ServerConfig struct {
 
 // ClientConfig is used to configure the client
 type ClientConfig struct {
-	Enabled bool `json:"enabled"`
+	Enabled      bool `json:"enabled"`
+	TotalCompute int  `json:"cpu_total_compute"`
 }
 
 // VaultConfig is used to configure Vault


### PR DESCRIPTION
6747ef8803 fixes the Nomad client to support using the raw_exec
driver while running as a non-root user. Remove the use of sudo
in the test-e2e workflow for running integration (vaultcompat)
tests.

Needed to plumb `cpu_total_compute` client config for the agent
runner, since Nomad cannot detect the cpu specs on the github public
runner without root.
