### PR TITLE
config: parsing support for multiple Vault clusters in agent config

### DIFF
--- a/client/config/testing.go
+++ b/client/config/testing.go
@@ -69,6 +69,7 @@ func TestClientConfig(t testing.T) (*Config, func()) {
 	conf.CgroupParent = "testing.slice"
 
 	conf.VaultConfig.Enabled = pointer.Of(false)
+	conf.VaultConfigs["default"].Enabled = pointer.Of(false)
 	conf.DevMode = true
 
 	// Loosen GC threshold

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -507,7 +507,11 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 
 	// Add the Consul and Vault configs
 	conf.ConsulConfig = agentConfig.Consul
+
 	conf.VaultConfig = agentConfig.Vault
+	for _, vaultConfig := range agentConfig.Vaults {
+		conf.VaultConfigs[vaultConfig.Name] = vaultConfig
+	}
 
 	// Set the TLS config
 	conf.TLSConfig = agentConfig.TLSConfig
@@ -799,7 +803,11 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	}
 
 	conf.ConsulConfig = agentConfig.Consul
+
 	conf.VaultConfig = agentConfig.Vault
+	for _, vaultConfig := range agentConfig.Vaults {
+		conf.VaultConfigs[vaultConfig.Name] = vaultConfig
+	}
 
 	// Set up Telemetry configuration
 	conf.StatsCollectionInterval = agentConfig.Telemetry.collectionInterval

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -89,6 +89,11 @@ func (s *HTTPServer) AgentSelfRequest(resp http.ResponseWriter, req *http.Reques
 	if self.Config != nil && self.Config.Vault != nil && self.Config.Vault.Token != "" {
 		self.Config.Vault.Token = "<redacted>"
 	}
+	for _, vaultConfig := range self.Config.Vaults {
+		if vaultConfig.Token != "" {
+			vaultConfig.Token = "<redacted>"
+		}
+	}
 
 	if self.Config != nil && self.Config.ACL != nil && self.Config.ACL.ReplicationToken != "" {
 		self.Config.ACL.ReplicationToken = "<redacted>"

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -73,9 +73,10 @@ func (c *Command) readConfig() *Config {
 		Server: &ServerConfig{
 			ServerJoin: &ServerJoin{},
 		},
-		Vault: &config.VaultConfig{},
-		ACL:   &ACLConfig{},
-		Audit: &config.AuditConfig{},
+		Vault:  &config.VaultConfig{},
+		Vaults: map[string]*config.VaultConfig{},
+		ACL:    &ACLConfig{},
+		Audit:  &config.AuditConfig{},
 	}
 
 	flags := flag.NewFlagSet("agent", flag.ContinueOnError)

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -73,11 +73,11 @@ func (c *Command) readConfig() *Config {
 		Server: &ServerConfig{
 			ServerJoin: &ServerJoin{},
 		},
-		Vault:  &config.VaultConfig{},
-		Vaults: map[string]*config.VaultConfig{},
-		ACL:    &ACLConfig{},
-		Audit:  &config.AuditConfig{},
+		Vault: &config.VaultConfig{},
+		ACL:   &ACLConfig{},
+		Audit: &config.AuditConfig{},
 	}
+	cmdConfig.Vaults = map[string]*config.VaultConfig{"default": cmdConfig.Vault}
 
 	flags := flag.NewFlagSet("agent", flag.ContinueOnError)
 	flags.Usage = func() { c.Ui.Error(c.Help()) }

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -959,6 +959,7 @@ func TestConfig_MultipleVault(t *testing.T) {
 
 	must.MapLen(t, 1, cfg.Vaults)
 	must.Equal(t, cfg.Vault, cfg.Vaults["default"])
+	must.True(t, cfg.Vault == cfg.Vaults["default"]) // must be same pointer
 
 	// merge in the user's configuration
 	fc, err := LoadConfig("testdata/basic.hcl")

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -184,6 +184,7 @@ func TestConfig_Merge(t *testing.T) {
 			"Access-Control-Allow-Origin": "*",
 		},
 		Vault: &config.VaultConfig{
+			Name:                 "default",
 			Token:                "1",
 			AllowUnauthenticated: &falseValue,
 			TaskTokenTTL:         "1",
@@ -194,6 +195,21 @@ func TestConfig_Merge(t *testing.T) {
 			TLSKeyFile:           "1",
 			TLSSkipVerify:        &falseValue,
 			TLSServerName:        "1",
+		},
+		Vaults: map[string]*config.VaultConfig{
+			"default": {
+				Name:                 "default",
+				Token:                "1",
+				AllowUnauthenticated: &falseValue,
+				TaskTokenTTL:         "1",
+				Addr:                 "1",
+				TLSCaFile:            "1",
+				TLSCaPath:            "1",
+				TLSCertFile:          "1",
+				TLSKeyFile:           "1",
+				TLSSkipVerify:        &falseValue,
+				TLSServerName:        "1",
+			},
 		},
 		Consul: &config.ConsulConfig{
 			ServerServiceName:    "1",
@@ -393,6 +409,7 @@ func TestConfig_Merge(t *testing.T) {
 			"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
 		},
 		Vault: &config.VaultConfig{
+			Name:                 "default",
 			Token:                "2",
 			AllowUnauthenticated: &trueValue,
 			TaskTokenTTL:         "2",
@@ -403,6 +420,21 @@ func TestConfig_Merge(t *testing.T) {
 			TLSKeyFile:           "2",
 			TLSSkipVerify:        &trueValue,
 			TLSServerName:        "2",
+		},
+		Vaults: map[string]*config.VaultConfig{
+			"default": {
+				Name:                 "default",
+				Token:                "2",
+				AllowUnauthenticated: &trueValue,
+				TaskTokenTTL:         "2",
+				Addr:                 "2",
+				TLSCaFile:            "2",
+				TLSCaPath:            "2",
+				TLSCertFile:          "2",
+				TLSKeyFile:           "2",
+				TLSSkipVerify:        &trueValue,
+				TLSServerName:        "2",
+			},
 		},
 		Consul: &config.ConsulConfig{
 			ServerServiceName:    "2",

--- a/command/agent/testdata/extra-vault.hcl
+++ b/command/agent/testdata/extra-vault.hcl
@@ -1,0 +1,26 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+# this default config should merge cleanly onto the basic config
+vault {
+  name    = "default"
+  enabled = true
+  token   = "abracadabra"
+}
+
+# this alternate config should be added as an extra vault config
+vault {
+  name                  = "alternate"
+  address               = "127.0.0.1:9501"
+  allow_unauthenticated = true
+  task_token_ttl        = "5s"
+  enabled               = true
+  token                 = "xyzzy"
+  ca_file               = "/path/to/ca/file"
+  ca_path               = "/path/to/ca"
+  cert_file             = "/path/to/cert/file"
+  key_file              = "/path/to/key/file"
+  tls_server_name       = "barbaz"
+  tls_skip_verify       = true
+  create_from_role      = "test_role2"
+}

--- a/command/agent/testdata/extra-vault.hcl
+++ b/command/agent/testdata/extra-vault.hcl
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-# this default config should merge cleanly onto the basic config
+# this unnamed (default) config should merge cleanly onto the basic config
 vault {
-  name    = "default"
   enabled = true
   token   = "abracadabra"
 }

--- a/command/agent/testdata/sample0.json
+++ b/command/agent/testdata/sample0.json
@@ -82,6 +82,7 @@
     "verify_server_hostname": true
   },
   "vault": {
+    "name": "default",
     "address": "http://host.example.com:8200",
     "create_from_role": "nomad-cluster",
     "enabled": true

--- a/nomad/structs/config/vault.go
+++ b/nomad/structs/config/vault.go
@@ -25,21 +25,22 @@ const (
 //
 // - Create child tokens with policy subsets of the Server's token.
 type VaultConfig struct {
+	Name string `mapstructure:"name"`
 
 	// Enabled enables or disables Vault support.
-	Enabled *bool `hcl:"enabled"`
+	Enabled *bool `mapstructure:"enabled"`
 
 	// Token is the Vault token given to Nomad such that it can
 	// derive child tokens. Nomad will renew this token at half its lease
 	// lifetime.
-	Token string `hcl:"token"`
+	Token string `mapstructure:"token"`
 
 	// Role sets the role in which to create tokens from. The Token given to
 	// Nomad does not have to be created from this role but must have "update"
 	// capability on "auth/token/create/<create_from_role>". If this value is
 	// unset and the token is created from a role, the value is defaulted to the
 	// role the token is from.
-	Role string `hcl:"create_from_role"`
+	Role string `mapstructure:"create_from_role"`
 
 	// Namespace sets the Vault namespace used for all calls against the
 	// Vault API. If this is unset, then Nomad does not use Vault namespaces.
@@ -48,16 +49,16 @@ type VaultConfig struct {
 	// AllowUnauthenticated allows users to submit jobs requiring Vault tokens
 	// without providing a Vault token proving they have access to these
 	// policies.
-	AllowUnauthenticated *bool `hcl:"allow_unauthenticated"`
+	AllowUnauthenticated *bool `mapstructure:"allow_unauthenticated"`
 
 	// TaskTokenTTL is the TTL of the tokens created by Nomad Servers and used
 	// by the client.  There should be a minimum time value such that the client
 	// does not have to renew with Vault at a very high frequency
-	TaskTokenTTL string `hcl:"task_token_ttl"`
+	TaskTokenTTL string `mapstructure:"task_token_ttl"`
 
 	// Addr is the address of the local Vault agent. This should be a complete
 	// URL such as "http://vault.example.com"
-	Addr string `hcl:"address"`
+	Addr string `mapstructure:"address"`
 
 	// ConnectionRetryIntv is the interval to wait before re-attempting to
 	// connect to Vault.
@@ -65,29 +66,30 @@ type VaultConfig struct {
 
 	// TLSCaFile is the path to a PEM-encoded CA cert file to use to verify the
 	// Vault server SSL certificate.
-	TLSCaFile string `hcl:"ca_file"`
+	TLSCaFile string `mapstructure:"ca_file"`
 
 	// TLSCaFile is the path to a directory of PEM-encoded CA cert files to
 	// verify the Vault server SSL certificate.
-	TLSCaPath string `hcl:"ca_path"`
+	TLSCaPath string `mapstructure:"ca_path"`
 
 	// TLSCertFile is the path to the certificate for Vault communication
-	TLSCertFile string `hcl:"cert_file"`
+	TLSCertFile string `mapstructure:"cert_file"`
 
 	// TLSKeyFile is the path to the private key for Vault communication
-	TLSKeyFile string `hcl:"key_file"`
+	TLSKeyFile string `mapstructure:"key_file"`
 
 	// TLSSkipVerify enables or disables SSL verification
-	TLSSkipVerify *bool `hcl:"tls_skip_verify"`
+	TLSSkipVerify *bool `mapstructure:"tls_skip_verify"`
 
 	// TLSServerName, if set, is used to set the SNI host when connecting via TLS.
-	TLSServerName string `hcl:"tls_server_name"`
+	TLSServerName string `mapstructure:"tls_server_name"`
 }
 
 // DefaultVaultConfig returns the canonical defaults for the Nomad
 // `vault` configuration.
 func DefaultVaultConfig() *VaultConfig {
 	return &VaultConfig{
+		Name:                 "default",
 		Addr:                 "https://vault.service.consul:8200",
 		ConnectionRetryIntv:  DefaultVaultConnectRetryIntv,
 		AllowUnauthenticated: pointer.Of(true),
@@ -109,6 +111,9 @@ func (c *VaultConfig) AllowsUnauthenticated() bool {
 func (c *VaultConfig) Merge(b *VaultConfig) *VaultConfig {
 	result := *c
 
+	if b.Name != "" {
+		c.Name = b.Name
+	}
 	if b.Enabled != nil {
 		result.Enabled = b.Enabled
 	}


### PR DESCRIPTION
Add the plumbing we need to accept multiple Vault clusters in Nomad agent configuration, to support upcoming Nomad Enterprise features. The `vault` blocks are differentiated by a new `name` field, and if the `name` is omitted it becomes the "default" Vault configuration. All blocks with the same name are merged together, as with the existing behavior.

Unfortunately we're still using HCL1 for parsing configuration and the `Decode` method doesn't parse multiple blocks differentiated only by a field name without a label. So we've had to add an extra parsing pass, similar to what we've done for HCL1 jobspecs.

For now, all existing consumers will use the "default" Vault configuration, so there's no user-facing behavior change in this changeset other than the contents of the agent self API.

Ref: https://github.com/hashicorp/team-nomad/issues/404