### PR TITLE
docs: fix job dispatch documentation

### DIFF
--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -1762,9 +1762,12 @@ The table below shows this endpoint's support for
 - `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified
   in the job file during submission). This is specified as part of the path.
 
-- `idempotency_token` `(string: "")` - Optional identifier used to prevent more
+- `IdempotencyToken` `(string: "")` - Optional identifier used to prevent more
   than one instance of the job from being dispatched. This is specified as a
   URL query parameter.
+
+- `IdPrefixTemplate` `(string: "")` - Optional prefix added to dispatched job
+  IDs.
 
 - `Payload` `(string: "")` - Specifies a base64 encoded string containing the
   payload. This is limited to 65536 bytes (64KiB).

--- a/website/content/docs/commands/job/dispatch.mdx
+++ b/website/content/docs/commands/job/dispatch.mdx
@@ -72,8 +72,7 @@ dispatching parameterized jobs.
 - `-idempotency-token`: Optional identifier used to prevent more than one
   instance of the job from being dispatched.
 
-
-- `-id-prefix-template`: Optional prefix template for dispatched job IDs.
+- `-id-prefix-template`: Optional prefix added to dispatched job IDs.
 
 - `-verbose`: Show full information.
 


### PR DESCRIPTION
- Add missing `IdPrefixTemplate` to the API docs.
- Fix casing of `IdempotencyToken` in the API docs.
- Remove `template` from the `-id-prefix-template` flag description. I found it to be confusing as, as far as I can tell, the value isn't actually templated.

Closes #18173