### PR TITLE
drivers/docker: fix a hostConfigMemorySwappiness panic

### DIFF
--- a/client/lib/cgroupslib/default.go
+++ b/client/lib/cgroupslib/default.go
@@ -11,6 +11,6 @@ func LinuxResourcesPath(string, string) string {
 }
 
 // MaybeDisableMemorySwappiness does nothing on non-Linux systems
-func MaybeDisableMemorySwappiness() *int {
+func MaybeDisableMemorySwappiness() *uint64 {
 	return nil
 }

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -23,9 +23,6 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/go-set"
-	"github.com/ryanuber/go-glob"
-	"golang.org/x/exp/slices"
-
 	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/client/lib/cpustats"
 	"github.com/hashicorp/nomad/client/lib/numalib"
@@ -41,6 +38,8 @@ import (
 	"github.com/hashicorp/nomad/plugins/base"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	pstructs "github.com/hashicorp/nomad/plugins/shared/structs"
+	"github.com/ryanuber/go-glob"
+	"golang.org/x/exp/slices"
 )
 
 var (


### PR DESCRIPTION
`cgroupslib.MaybeDisableMemorySwappiness` returned an incorrect type, and was
incorrectly typecast to `int64` causing a panic on non-linux and non-windows hosts. 