### PR TITLE
ci: remove backport automerge

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Backport changes to stable-website
         run: |
-          backport-assistant backport -merge-method=squash -automerge
+          backport-assistant backport -merge-method=squash
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
           BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
@@ -24,7 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Backport changes to targeted release branch
         run: |
-          backport-assistant backport -merge-method=squash -automerge
+          backport-assistant backport -merge-method=squash
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.[+\\w]+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"


### PR DESCRIPTION
Backport assistant has been failing and generating wrong PRs and merges sometimes. Removing the `-automerge` flag allows us to review and fix backports before they are silently merged.

Examples of incorrect backporting:

https://github.com/hashicorp/nomad/pull/17925/files 
https://github.com/hashicorp/nomad/commit/950235df48869e0f3f1dc8950dc430394ababa85

https://github.com/hashicorp/nomad/pull/18234/files 
https://github.com/hashicorp/nomad/commit/52e2ad7807884aa385183c68d7bf653c49e4881d