### PR TITLE
fingerprint: add support for fingerprinting multiple Vault clusters

### DIFF
--- a/client/fingerprint/vault.go
+++ b/client/fingerprint/vault.go
@@ -88,7 +88,7 @@ func (f *VaultFingerprint) fingerprintImpl(cfg *config.VaultConfig, resp *Finger
 	if err != nil {
 		// Print a message indicating that Vault is not available anymore
 		if state.isAvailable {
-			logger.Info("Vault is unavailable", "cluster", cfg.Name)
+			logger.Info("Vault is unavailable")
 		}
 		state.isAvailable = false
 		state.nextCheck = time.Time{} // always check on next interval
@@ -110,14 +110,14 @@ func (f *VaultFingerprint) fingerprintImpl(cfg *config.VaultConfig, resp *Finger
 	// If Vault was previously unavailable print a message to indicate the Agent
 	// is available now
 	if !state.isAvailable {
-		logger.Info("Vault is available", "cluster", cfg.Name)
+		logger.Info("Vault is available")
 	}
 
 	// Widen the minimum window to the next check so that if one out of a set of
 	// Vaults is unhealthy we don't greatly increase requests to the healthy
 	// ones. This is less than the minimum window if all Vaults are healthy so
 	// that we don't desync from the larger window provided by Periodic
-	state.nextCheck = time.Now().Add(30 * time.Second)
+	state.nextCheck = time.Now().Add(29 * time.Second)
 	state.isAvailable = true
 
 	resp.Detected = true

--- a/client/fingerprint/vault.go
+++ b/client/fingerprint/vault.go
@@ -22,7 +22,7 @@ const (
 	vaultUnavailable = "unavailable"
 )
 
-var vaultBaseFingerprintInterval = time.Duration(15 * time.Second)
+var vaultBaseFingerprintInterval = 15 * time.Second
 
 // VaultFingerprint is used to fingerprint for Vault
 type VaultFingerprint struct {

--- a/client/fingerprint/vault_ce.go
+++ b/client/fingerprint/vault_ce.go
@@ -1,0 +1,19 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !ent
+
+package fingerprint
+
+import "github.com/hashicorp/nomad/nomad/structs/config"
+
+// vaultConfigs returns the set of Vault configurations the fingerprint needs to
+// check. In Nomad CE we only check the default Vault.
+func (f *VaultFingerprint) vaultConfigs(req *FingerprintRequest) map[string]*config.VaultConfig {
+	agentCfg := req.Config
+	if agentCfg.VaultConfig == nil || !agentCfg.VaultConfig.IsEnabled() {
+		return nil
+	}
+
+	return map[string]*config.VaultConfig{"default": agentCfg.VaultConfig}
+}

--- a/client/fingerprint/vault_test.go
+++ b/client/fingerprint/vault_test.go
@@ -64,6 +64,11 @@ func TestVaultFingerprint(t *testing.T) {
 	// Stop Vault to simulate it being unavailable
 	tv.Stop()
 
+	// Reset the nextCheck time for testing purposes, or we won't pick up the
+	// change until the next period, up to 2min from now
+	vfp := fp.(*VaultFingerprint)
+	vfp.states["default"].nextCheck = time.Now()
+
 	err = fp.Fingerprint(request, &response)
 	if err != nil {
 		t.Fatalf("Failed to fingerprint: %s", err)

--- a/testutil/vault.go
+++ b/testutil/vault.go
@@ -72,6 +72,7 @@ func NewTestVaultFromPath(t testing.T, binary string) *TestVault {
 		RootToken: token,
 		Client:    client,
 		Config: &config.VaultConfig{
+			Name:    "default",
 			Enabled: &enable,
 			Token:   token,
 			Addr:    http,


### PR DESCRIPTION
Add fingerprinting we'll need to accept multiple Vault clusters in upcoming Nomad Enterprise features. The fingerprinter will create a map of Vault clients by cluster name. In Nomad CE, all but the default cluster will be ignored and there will be no visible behavior change.

Ref: https://github.com/hashicorp/team-nomad/issues/404
_Don't merge until we've got a ENT repo PR ready for the `vault_ent.go` file._