### PR TITLE
[f-gh-17449-lease] Add lease mechanism to SDK

### DIFF
--- a/api/locks.go
+++ b/api/locks.go
@@ -26,11 +26,15 @@ var (
 
 	//LockNoPathErr is returned when no path is provided in the variable to be
 	// used for the lease mechanism
-	LockNoPathErr = errors.New("the path for the lock provided")
+	LockNoPathErr = errors.New("variable's path can't be empty")
 )
 
 // Locks returns a new handle on a lock for the given variable.
 func (c *Client) Locks(wo WriteOptions, v Variable) (*Locks, error) {
+
+	if v.Path == "" {
+		return nil, LockNoPathErr
+	}
 
 	ttl, err := time.ParseDuration(v.Lock.TTL)
 	if err != nil {

--- a/api/locks.go
+++ b/api/locks.go
@@ -135,7 +135,7 @@ func (l *Locks) Renew(ctx context.Context) error {
 	return nil
 }
 
-func (l *Locks) TTL() time.Duration {
+func (l *Locks) LockTTL() time.Duration {
 	return l.ttl
 }
 

--- a/api/locks.go
+++ b/api/locks.go
@@ -51,6 +51,8 @@ func (c *Client) Locks(wo WriteOptions, v *Variable, lease time.Duration) *Locks
 }
 
 // Locks is used to maintain all the resources necessary to operate over a lock.
+// It makes the calls to the http using an exponential retry mechanism that will
+// try until it either reaches 5 attempts or the ttl of the lock expires.
 type Locks struct {
 	c *Client
 	Variable
@@ -117,7 +119,8 @@ type locker interface {
 // LockLeaser is a helper used to run a protected function that should only be
 // active if the instance that runs it is currently holding the lock.
 // It includes the lease renewal mechanism and tracking in case the protected
-// function returns an error.
+// function returns an error. Internally it uses an exponential retry mechanism
+// for the api calls.
 type LockLeaser struct {
 	ID            string
 	lease         time.Duration

--- a/api/locks.go
+++ b/api/locks.go
@@ -118,6 +118,8 @@ type locker interface {
 
 // LockLeaser is a helper used to run a protected function that should only be
 // active if the instance that runs it is currently holding the lock.
+// Can be used to provide synchrony among multiple independent instances.
+//
 // It includes the lease renewal mechanism and tracking in case the protected
 // function returns an error. Internally it uses an exponential retry mechanism
 // for the api calls.

--- a/api/locks.go
+++ b/api/locks.go
@@ -124,6 +124,7 @@ type LockLeaser struct {
 	locker
 }
 
+// Should we add the possibility to pass a variable?
 func (c *Client) NewLockLeaser(lease time.Duration, wo WriteOptions) *LockLeaser {
 	ID := uuid.Generate()
 

--- a/api/locks.go
+++ b/api/locks.go
@@ -155,7 +155,7 @@ type Locker interface {
 	// mechanism among multiple instances looking to acquire the same lock.
 	Renew(ctx context.Context) error
 
-	// LockTTL() returns the expiration time of the underlying lock.
+	// LockTTL returns the expiration time of the underlying lock.
 	LockTTL() time.Duration
 }
 

--- a/api/locks.go
+++ b/api/locks.go
@@ -1,0 +1,229 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+//
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/hashicorp/nomad/helper/uuid"
+)
+
+const (
+	leaseRenewalFactor = 0.7
+	retryBackoffFactor = 1.1
+)
+
+var (
+	// ErrLockHeld is returned if we attempt to double lock
+	ErrLockHeld = fmt.Errorf("Lock already held")
+
+	// ErrLockNotHeld is returned if we attempt to unlock a lock
+	// that we do not hold.
+	ErrLockNotHeld = fmt.Errorf("Lock not held")
+
+	// ErrLockInUse is returned if we attempt to destroy a lock
+	// that is in use.
+	ErrLockInUse = fmt.Errorf("Lock in use")
+
+	// ErrLockConflict is returned if the flags on a key
+	// used for a lock do not match expectation
+	ErrLockConflict = fmt.Errorf("Existing key does not match lock holder")
+)
+
+type puter interface {
+	retryPut(ctx context.Context, endpoint string, in, out any, q *WriteOptions) (*WriteMeta, error)
+}
+
+// Variables returns a new handle on the variables.
+func (c *Client) Locks(v *Variable, wo WriteOptions) *Locks {
+
+	l := &Locks{
+		p:            c,
+		WriteOptions: wo,
+	}
+	// Fill var if empty
+	if v != nil {
+		l.Variable = *v
+	}
+
+	return l
+}
+
+type Locks struct {
+	p puter
+	Variable
+
+	WriteOptions
+}
+
+func (l *Locks) Acquire(ctx context.Context, callerID string) (string, error) {
+	var out Variable
+
+	_, err := l.p.retryPut(ctx, "/v1/var/"+l.Path+"?lock-acquire", l.Variable, &out, &l.WriteOptions)
+	if err != nil {
+		return "", err
+	}
+
+	l.Variable = out
+
+	return out.Lock.ID, nil
+}
+
+func (l *Locks) Release(ctx context.Context) error {
+	var out Variable
+
+	_, err := l.p.retryPut(ctx, "/v1/var/"+l.Path+"?lock-release", l.Variable, &out, &l.WriteOptions)
+	if err != nil {
+		return err
+	}
+
+	l.Variable = out
+	return nil
+}
+
+func (l *Locks) Renew(ctx context.Context) error {
+	var out VariableMetadata
+
+	_, err := l.p.retryPut(ctx, "/v1/var/"+l.Path+"?lock-renew", l.Variable, &out, &l.WriteOptions)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type locker interface {
+	Acquire(ctx context.Context, callerID string) (string, error)
+	Release(ctx context.Context) error
+	Renew(ctx context.Context) error
+}
+
+type LockLeaser struct {
+	ID            string
+	renewalPeriod time.Duration
+	waitPeriod    time.Duration
+	randomDelay   time.Duration
+
+	logger log.Logger
+	locker
+}
+
+func (c *Client) NewLockLeaser(lease time.Duration, wo WriteOptions) *LockLeaser {
+	ID := uuid.Generate()
+
+	rn := rand.New(rand.NewSource(time.Now().Unix())).Intn(100)
+
+	v := &Variable{
+		Namespace: wo.Namespace,
+		Path:      "", // TO BE DETERMINED, any ideas?
+		Lock: &VariableLock{
+			TTL: lease.String(),
+		},
+	}
+
+	ll := LockLeaser{
+		renewalPeriod: time.Duration(float64(lease) * leaseRenewalFactor),
+		waitPeriod:    time.Duration(float64(lease) * retryBackoffFactor),
+		ID:            ID,
+		randomDelay:   time.Duration(rn) * time.Millisecond,
+		locker:        c.Locks(v, wo),
+	}
+
+	return &ll
+}
+
+func (ll *LockLeaser) Start(ctx context.Context, protectedFunc func(ctx context.Context) error) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer func() {
+		ll.locker.Release(ctx)
+		cancel()
+	}()
+
+	errChannel := make(chan error)
+
+	// To avoid collisions if all the instances start at the same time, wait
+	// a random time before making the first call.
+	ll.wait(ctx)
+
+	waitTicker := time.NewTicker(ll.waitPeriod)
+	defer waitTicker.Stop()
+
+	for {
+
+		lockID, err := ll.locker.Acquire(ctx, ll.ID)
+		if err != nil {
+			return err
+		}
+
+		if lockID != "" {
+
+			funcCtx, funcCancel := context.WithCancel(ctx)
+			defer funcCancel()
+
+			// Start running the lock protected function
+			go func() {
+				err := protectedFunc(funcCtx)
+				if err != nil {
+					errChannel <- err
+				}
+			}()
+
+			// Maintain lease is a blocking function, will only return in case
+			// the lock is lost or the context is canceled.
+			err := ll.maintainLease(ctx)
+			if err != nil {
+
+				funcCancel()
+				// Give the protected function some time to return before potentially
+				// running it again.
+				ll.wait(ctx)
+			}
+
+		}
+
+		waitTicker.Stop()
+		waitTicker = time.NewTicker(ll.waitPeriod)
+
+		select {
+		case err := <-errChannel:
+			return err
+
+		case <-ctx.Done():
+			return nil
+
+		case <-waitTicker.C:
+		}
+	}
+}
+
+func (ll *LockLeaser) maintainLease(ctx context.Context) error {
+	renewTicker := time.NewTicker(ll.renewalPeriod)
+	defer renewTicker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case <-renewTicker.C:
+			err := ll.locker.Renew(ctx)
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (ll *LockLeaser) wait(ctx context.Context) {
+	t := time.NewTimer(ll.randomDelay)
+	defer t.Stop()
+
+	select {
+	case <-ctx.Done():
+	case <-t.C:
+	}
+}

--- a/api/locks.go
+++ b/api/locks.go
@@ -3,7 +3,6 @@
 
 package api
 
-//
 import (
 	"context"
 	"fmt"

--- a/api/locks.go
+++ b/api/locks.go
@@ -252,7 +252,7 @@ func (ll *LockLeaser) start(ctx context.Context, protectedFuncs ...func(ctx cont
 						errChannel <- fmt.Errorf("error executing protected function %w", err)
 						return
 					}
-					// cancel will signal teh start function to return without errors
+					// cancel will signal the start function to return without errors
 					cancel()
 				}
 			}()

--- a/api/locks.go
+++ b/api/locks.go
@@ -204,7 +204,7 @@ func (ll *LockLeaser) Start(ctx context.Context, protectedFuncs ...func(ctx cont
 
 	err = ll.locker.Release(ctx)
 	if err != nil {
-		mErr.Errors = append(mErr.Errors, fmt.Errorf("release: %w", err))
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("lock release: %w", err))
 	}
 
 	return mErr.ErrorOrNil()
@@ -232,7 +232,7 @@ func (ll *LockLeaser) start(ctx context.Context, protectedFuncs ...func(ctx cont
 	for {
 		lockID, err := ll.locker.Acquire(ctx)
 		if err != nil && !errors.Is(err, ErrLockConflict) {
-			errChannel <- fmt.Errorf("error acquiring the lock: %w", err)
+			errChannel <- err
 		}
 
 		if lockID != "" {

--- a/api/locks_test.go
+++ b/api/locks_test.go
@@ -90,7 +90,7 @@ type mockService struct {
 	starterID     string
 }
 
-func (ms *mockService) Run(callerID string, ctx context.Context) func(ctx context.Context) error {
+func (ms *mockService) Run(callerID string, _ context.Context) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		ms.mu.Lock()
 		ms.startsCounter += 1

--- a/api/locks_test.go
+++ b/api/locks_test.go
@@ -1,0 +1,400 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/shoenig/test/must"
+)
+
+var testLease = 10 * time.Millisecond
+
+type mockLock struct {
+	locked        bool
+	acquireCalls  map[string]int
+	renewsCounter int
+	mu            sync.Mutex
+
+	leaseStartTime time.Time
+}
+
+func (ml *mockLock) Acquire(_ context.Context, callerID string) (string, error) {
+	ml.mu.Lock()
+	defer ml.mu.Unlock()
+
+	ml.acquireCalls[callerID] += 1
+	if ml.locked {
+		return "", nil
+	}
+
+	ml.locked = true
+	ml.leaseStartTime = time.Now()
+	ml.renewsCounter = 0
+	return "lockID", nil
+}
+
+func (ml *mockLock) Release(_ context.Context) error {
+	ml.mu.Lock()
+	defer ml.mu.Unlock()
+
+	if !ml.locked {
+		return errors.New("lock not locked")
+	}
+
+	ml.locked = false
+	ml.renewsCounter = 0
+	return nil
+}
+
+// The behavior of renew is not an exact replication of
+// the lock work, its intended to test the behavior of the
+// multiple instances running.
+func (ml *mockLock) Renew(_ context.Context) error {
+	ml.mu.Lock()
+	defer ml.mu.Unlock()
+
+	if !ml.locked {
+		return errors.New("error")
+	}
+
+	if time.Since(ml.leaseStartTime) > testLease {
+		ml.locked = false
+		return errors.New("lease lost")
+	}
+
+	ml.leaseStartTime = time.Now()
+	ml.renewsCounter += 1
+	return nil
+}
+
+func (ml *mockLock) getLockState() mockLock {
+	ml.mu.Lock()
+	defer ml.mu.Unlock()
+
+	return mockLock{
+		locked:        ml.locked,
+		acquireCalls:  copyMap(ml.acquireCalls),
+		renewsCounter: ml.renewsCounter,
+	}
+}
+
+type mockService struct {
+	mu            sync.Mutex
+	startsCounter int
+	starterID     string
+}
+
+func (ms *mockService) Run(callerID string, ctx context.Context) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		ms.mu.Lock()
+		ms.startsCounter += 1
+		ms.starterID = callerID
+		ms.mu.Unlock()
+
+		<-ctx.Done()
+
+		ms.mu.Lock()
+		ms.starterID = ""
+		ms.mu.Unlock()
+
+		return nil
+	}
+}
+
+func (ms *mockService) getServiceState() mockService {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+
+	return mockService{
+		startsCounter: ms.startsCounter,
+		starterID:     ms.starterID,
+	}
+}
+
+func TestAcquireLock_MultipleInstances(t *testing.T) {
+	l := mockLock{
+		acquireCalls: map[string]int{},
+	}
+
+	s := mockService{}
+
+	testCtx, testCancel := context.WithCancel(context.Background())
+	defer testCancel()
+
+	// Set up independent contexts to test the switch when one controller stops
+	hac1Ctx, hac1Cancel := context.WithCancel(testCtx)
+	defer hac1Cancel()
+
+	// Wait time on hac1 is 0, it should always get the lock.
+	hac1 := LockLeaser{
+		ID:            "hac1",
+		locker:        &l,
+		renewalPeriod: time.Duration(float64(testLease) * leaseRenewalFactor),
+		waitPeriod:    time.Duration(float64(testLease) * retryBackoffFactor),
+		randomDelay:   0,
+	}
+
+	hac2 := LockLeaser{
+		ID:            "hac2",
+		locker:        &l,
+		renewalPeriod: time.Duration(float64(testLease) * leaseRenewalFactor),
+		waitPeriod:    time.Duration(float64(testLease) * retryBackoffFactor),
+		randomDelay:   6 * time.Millisecond,
+	}
+
+	lock := l.getLockState()
+	must.False(t, lock.locked)
+
+	go hac1.Start(hac1Ctx, s.Run(hac1.ID, hac1Ctx))
+	go hac2.Start(testCtx, s.Run(hac2.ID, testCtx))
+
+	time.Sleep(4 * time.Millisecond)
+	/*
+		After 4 ms more (4 ms total):
+		* hac2 should  not have tried to acquire the lock because it has an initial delay of 6ms.
+		* hac1 should have the lock and the service should be running.
+		* The first lease is not over yet, no calls to renew should have been made.
+	*/
+
+	lock = l.getLockState()
+	service := s.getServiceState()
+
+	must.True(t, lock.locked)
+	must.Eq(t, 1, lock.acquireCalls[hac1.ID])
+	must.Eq(t, 0, lock.acquireCalls[hac2.ID])
+
+	must.Eq(t, 0, lock.renewsCounter)
+
+	must.Eq(t, 1, service.startsCounter)
+	must.StrContains(t, hac1.ID, service.starterID)
+
+	time.Sleep(6 * time.Millisecond)
+	/*
+		After 6 ms more (10 ms total):
+		* hac2 should have tried to acquire the lock at least once, after the 6ms
+			initial delay has passed.
+		* hc1 should have renewed once the lease and still hold the lock.
+	*/
+	lock = l.getLockState()
+	service = s.getServiceState()
+	must.True(t, lock.locked)
+	must.Eq(t, 1, lock.acquireCalls[hac1.ID])
+	must.Eq(t, 1, lock.acquireCalls[hac2.ID])
+
+	must.One(t, lock.renewsCounter)
+
+	must.One(t, service.startsCounter)
+	must.StrContains(t, hac1.ID, service.starterID)
+
+	time.Sleep(5 * time.Millisecond)
+
+	/*
+		After 5 ms more (15 ms total):
+		* hac2 should have tried to acquire the lock still just once:
+				initialDelay(6) + waitTime(11) = 18.
+		* hac1 should have renewed the lease 2 times and still hold the lock:
+				initialDelay(0) + renewals(2) * renewalPeriod(7) = 14.
+	*/
+
+	lock = l.getLockState()
+	service = s.getServiceState()
+	must.Eq(t, 1, lock.acquireCalls[hac1.ID])
+	must.Eq(t, 1, lock.acquireCalls[hac2.ID])
+
+	must.True(t, lock.locked)
+
+	must.Eq(t, 2, lock.renewsCounter)
+	must.Eq(t, 1, service.startsCounter)
+	must.StrContains(t, hac1.ID, service.starterID)
+
+	time.Sleep(15 * time.Millisecond)
+
+	/*
+		After 15 ms more (30 ms total):
+		* hac2 should have tried to acquire the lock 3 times:
+				initialDelay(6) + calls(2)* waitTime(11) = 28.
+		* hac1 should have renewed the lease 4 times and still hold the lock:
+				initialDelay(0) + renewals(4) * renewalPeriod(7) = 28.
+	*/
+
+	lock = l.getLockState()
+	service = s.getServiceState()
+	must.Eq(t, 1, lock.acquireCalls[hac1.ID])
+	must.Eq(t, 3, lock.acquireCalls[hac2.ID])
+
+	must.True(t, lock.locked)
+
+	must.Eq(t, 4, lock.renewsCounter)
+	must.Eq(t, 1, service.startsCounter)
+	must.StrContains(t, hac1.ID, service.starterID)
+
+	// Start a new instance of the service with ha running, initial delay of 1ms
+	hac3 := LockLeaser{
+		ID:            "hac3",
+		locker:        &l,
+		renewalPeriod: time.Duration(float64(testLease) * leaseRenewalFactor),
+		waitPeriod:    time.Duration(float64(testLease) * retryBackoffFactor),
+		randomDelay:   1 * time.Millisecond,
+	}
+
+	go hac3.Start(testCtx, s.Run(hac3.ID, testCtx))
+	time.Sleep(15 * time.Millisecond)
+
+	/*
+		After 15 ms more (45 ms total):
+		* hac3 should have tried to acquire the lock twice, once on start and
+			once after waitTime(11).
+		* hac2 should have tried to acquire the lock 4 times:
+				initialDelay(6) + calls(3) * waitTime(11) = 39.
+		* hac1 should have renewed the lease 4 times and still hold the lock:
+				initialDelay(0) + renewals(6) * renewalPeriod(7) = 42.
+	*/
+
+	lock = l.getLockState()
+	service = s.getServiceState()
+	must.Eq(t, 1, lock.acquireCalls[hac1.ID])
+	must.Eq(t, 4, lock.acquireCalls[hac2.ID])
+	must.Eq(t, 2, lock.acquireCalls[hac3.ID])
+
+	must.True(t, lock.locked)
+
+	must.Eq(t, 6, lock.renewsCounter)
+	must.Eq(t, 1, service.startsCounter)
+	must.StrContains(t, hac1.ID, service.starterID)
+
+	// Stop hac1 and release the lock
+	hac1Cancel()
+
+	err := l.Release(testCtx)
+	must.NoError(t, err)
+
+	time.Sleep(10 * time.Millisecond)
+
+	/*
+		After 10 ms more (55 ms total):
+		* hac3 should have tried to acquire the lock 3 times.
+		* hac2 should have tried to acquire the lock 5 times and succeeded on the
+		 the fifth, is currently holding the lock and Run the service, no renewals.
+		* hc1 is stopped.
+	*/
+
+	lock = l.getLockState()
+	service = s.getServiceState()
+	must.Eq(t, 1, lock.acquireCalls[hac1.ID])
+	must.Eq(t, 5, lock.acquireCalls[hac2.ID])
+	must.Eq(t, 3, lock.acquireCalls[hac3.ID])
+
+	must.True(t, lock.locked)
+
+	must.Eq(t, 0, lock.renewsCounter)
+	must.Eq(t, 2, service.startsCounter)
+	must.StrContains(t, hac2.ID, service.starterID)
+
+	time.Sleep(5 * time.Millisecond)
+
+	/*
+		After 5 ms more (60 ms total):
+		* hac3 should have tried to acquire the lock 3 times.
+		* hac2 should have renewed the lock once.
+		* hc1 is stopped.
+	*/
+
+	lock = l.getLockState()
+	service = s.getServiceState()
+	must.Eq(t, 1, lock.acquireCalls[hac1.ID])
+	must.Eq(t, 5, lock.acquireCalls[hac2.ID])
+	must.Eq(t, 3, lock.acquireCalls[hac3.ID])
+
+	must.True(t, lock.locked)
+
+	must.Eq(t, 1, lock.renewsCounter)
+	must.Eq(t, 2, service.startsCounter)
+	must.StrContains(t, hac2.ID, service.starterID)
+}
+
+func TestFailedRenewal(t *testing.T) {
+	l := mockLock{
+		acquireCalls: map[string]int{},
+	}
+
+	s := mockService{}
+
+	testCtx, testCancel := context.WithCancel(context.Background())
+	defer testCancel()
+
+	// Set the renewal period to 1.5  * testLease (15 ms) to force and error.
+	hac := LockLeaser{
+		ID:            "hac1",
+		locker:        &l,
+		renewalPeriod: time.Duration(float64(testLease) * 1.5),
+		waitPeriod:    time.Duration(float64(testLease) * retryBackoffFactor),
+		randomDelay:   0,
+	}
+
+	lock := l.getLockState()
+	must.False(t, lock.locked)
+
+	go hac.Start(testCtx, s.Run(hac.ID, testCtx))
+
+	time.Sleep(5 * time.Millisecond)
+	/*
+		After 5ms, the service should be running and the lock held,
+		no renewals needed or performed yet.
+	*/
+
+	lock = l.getLockState()
+	service := s.getServiceState()
+	must.Eq(t, 1, lock.acquireCalls[hac.ID])
+	must.True(t, lock.locked)
+
+	must.Eq(t, 0, lock.renewsCounter)
+	must.Eq(t, 1, service.startsCounter)
+	must.StrContains(t, hac.ID, service.starterID)
+
+	time.Sleep(15 * time.Millisecond)
+
+	/*
+		After 15ms (20ms total) hac should have tried and failed at renewing the
+		lock, causing the service to return, no new calls to acquire the lock yet
+		either.
+	*/
+
+	lock = l.getLockState()
+	service = s.getServiceState()
+	must.Eq(t, 1, lock.acquireCalls[hac.ID])
+	must.False(t, lock.locked)
+
+	must.Eq(t, 0, lock.renewsCounter)
+	must.Eq(t, 1, service.startsCounter)
+	must.StrContains(t, hac.ID, "")
+
+	time.Sleep(10 * time.Millisecond)
+
+	/*
+		After 10ms (30ms total) hac should have tried and succeeded at getting
+		the lock and the service should be running again.
+	*/
+
+	lock = l.getLockState()
+	service = s.getServiceState()
+	must.Eq(t, 2, lock.acquireCalls[hac.ID])
+	must.True(t, lock.locked)
+
+	must.Eq(t, 0, lock.renewsCounter)
+	must.Eq(t, 2, service.startsCounter)
+	must.StrContains(t, hac.ID, service.starterID)
+}
+
+func copyMap(originalMap map[string]int) map[string]int {
+	newMap := map[string]int{}
+	for k, v := range originalMap {
+		newMap[k] = v
+	}
+	return newMap
+}

--- a/api/locks_test.go
+++ b/api/locks_test.go
@@ -19,9 +19,14 @@ type mockLock struct {
 	locked        bool
 	acquireCalls  map[string]int
 	renewsCounter int
+	ownerID       string
 	mu            sync.Mutex
 
 	leaseStartTime time.Time
+}
+
+func (ml *mockLock) LockTTL() time.Duration {
+	return testLease
 }
 
 func (ml *mockLock) Acquire(_ context.Context, callerID string) (string, error) {
@@ -36,7 +41,7 @@ func (ml *mockLock) Acquire(_ context.Context, callerID string) (string, error) 
 	ml.locked = true
 	ml.leaseStartTime = time.Now()
 	ml.renewsCounter = 0
-	return "lockID", nil
+	return "lockPath", nil
 }
 
 func (ml *mockLock) Release(_ context.Context) error {
@@ -85,6 +90,8 @@ func (ml *mockLock) getLockState() mockLock {
 }
 
 type mockService struct {
+	mockLock
+
 	mu            sync.Mutex
 	startsCounter int
 	starterID     string

--- a/api/locks_test.go
+++ b/api/locks_test.go
@@ -65,7 +65,7 @@ func (ml *mockLock) Renew(_ context.Context) error {
 
 	if time.Since(ml.leaseStartTime) > testLease {
 		ml.locked = false
-		return errLockConflict
+		return ErrLockConflict
 	}
 
 	ml.leaseStartTime = time.Now()

--- a/api/locks_test.go
+++ b/api/locks_test.go
@@ -151,7 +151,7 @@ func TestAcquireLock_MultipleInstances(t *testing.T) {
 	must.False(t, lock.locked)
 
 	go func() {
-		err := hac1.Start(hac1Ctx, s.Run(hac1.ID, hac1Ctx))
+		err := hac1.Start(hac1Ctx, s.Run(hac1.ID, testCtx))
 		must.NoError(t, err)
 	}()
 
@@ -280,9 +280,6 @@ func TestAcquireLock_MultipleInstances(t *testing.T) {
 
 	// Stop hac1 and release the lock
 	hac1Cancel()
-
-	err := l.Release(testCtx)
-	must.NoError(t, err)
 
 	time.Sleep(10 * time.Millisecond)
 

--- a/api/locks_test.go
+++ b/api/locks_test.go
@@ -65,7 +65,7 @@ func (ml *mockLock) Renew(_ context.Context) error {
 
 	if time.Since(ml.leaseStartTime) > testLease {
 		ml.locked = false
-		return errors.New("lease lost")
+		return errLockConflict
 	}
 
 	ml.leaseStartTime = time.Now()
@@ -417,6 +417,7 @@ func TestStart_ProtectedFunctionError(t *testing.T) {
 	err := hac.Start(testCtx, func(ctx context.Context) error {
 		return errors.New("error")
 	})
+
 	must.Error(t, err)
 
 	lock = l.getLockState()

--- a/api/retry.go
+++ b/api/retry.go
@@ -6,7 +6,6 @@ package api
 import (
 	"context"
 	"errors"
-	"math"
 	"net/http"
 	"time"
 )
@@ -17,28 +16,23 @@ const (
 	defaultMaxBackoffDelay = 5 * time.Minute
 )
 
-type client interface {
-	put(endpoint string, in, out any, q *WriteOptions) (*WriteMeta, error)
-}
-
-type retryClient struct {
-	c client
-	retryOptions
-}
-
-// LockOptions is used to parameterize the Lock behavior.
 type retryOptions struct {
 	maxRetries int64 // Optional, defaults to 5
 	// maxBackoffDelay  sets a capping value for the delay between calls, to avoid it growing infinitely
 	maxBackoffDelay time.Duration // Optional, defaults to 5 min
 	// maxToLastCall sets a capping value for all the retry process, in case there is a deadline to make the call.
-	maxToLastCall time.Duration // Optional, defaults to 5min, meaning no time cap
+	maxToLastCall time.Duration // Optional, defaults to 0, meaning no time cap
 	// fixedDelay is used in case an uniform distribution of the calls is preferred.
 	fixedDelay time.Duration // Optional, defaults to 0, meaning Delay is exponential, starting at 1sec
 	// delayBase is used to calculate the starting value at which the delay starts to grow,
 	// When left empty, a value of 1 sec will be used as base and then the delays will
 	// grow exponentially with every attempt: starting at 1s, then 2s, 4s, 8s...
 	delayBase time.Duration // Optional, defaults to 1sec
+
+	// maxValidAttempt is used to ensure that a big attempts number or a big delayBase number will not cause
+	// a negative delay by overflowing the delay increase. Every attempt after the
+	// maxValid will use the maxBackoffDelay if configured, or the defaultMaxBackoffDelay if not.
+	maxValidAttempt int64
 }
 
 func (c *Client) retryPut(ctx context.Context, endpoint string, in, out any, q *WriteOptions) (*WriteMeta, error) {
@@ -116,14 +110,7 @@ func (c *Client) calculateDelay(attempt int64) time.Duration {
 		return 0
 	}
 
-	// Ensure that a big attempt number or a big delayBase number will not cause
-	// a negative delay by overflowing the delay increase.
-	// TODO: This value should be calculated on configuration and set the
-	// to default if not provided.
-	maxValidAttempt := int64(math.Log2(float64(math.MaxInt64 /
-		c.config.retryOptions.delayBase.Nanoseconds())))
-
-	if attempt > maxValidAttempt {
+	if attempt > c.config.retryOptions.maxValidAttempt {
 		return c.config.retryOptions.maxBackoffDelay
 	}
 

--- a/api/variables.go
+++ b/api/variables.go
@@ -398,7 +398,7 @@ type Variable struct {
 	Items VariableItems `hcl:"items"`
 
 	// Lock holds the information about the variable lock if its being used.
-	Lock *VariableLock `hcl:",lock,optional" json:",omitempty"`
+	Lock VariableLock `hcl:",lock,optional" json:",omitempty"`
 }
 
 // VariableMetadata specifies the metadata for a variable and

--- a/api/variables.go
+++ b/api/variables.go
@@ -398,7 +398,7 @@ type Variable struct {
 	Items VariableItems `hcl:"items"`
 
 	// Lock holds the information about the variable lock if its being used.
-	Lock VariableLock `hcl:",lock,optional" json:",omitempty"`
+	Lock *VariableLock `hcl:",lock,optional" json:",omitempty"`
 }
 
 // VariableMetadata specifies the metadata for a variable and

--- a/nomad/locks.go
+++ b/nomad/locks.go
@@ -60,7 +60,7 @@ func (s *Server) CreateVariableLockTTLTimer(variable structs.VariableEncrypted) 
 
 	s.lockTTLTimer.Create(lockID, lockTTL, func() {
 		s.logger.Debug("locks: lock TTL expired, starting delay",
-			"namespace", variable.Namespace, "path", variable.Path)
+			"namespace", variable.Namespace, "path", variable.Path, "ttl", variable.Lock.TTL)
 		s.lockTTLTimer.StopAndRemove(lockID)
 
 		_ = time.AfterFunc(variable.Lock.LockDelay, func() {
@@ -112,7 +112,7 @@ func (s *Server) RenewTTLTimer(variable structs.VariableEncrypted) error {
 	lockID := variable.LockID()
 
 	s.logger.Debug("locks: renewing the lock",
-		"namespace", variable.Namespace, "path", variable.Path)
+		"namespace", variable.Namespace, "path", variable.Path, "ttl", variable.Lock.TTL)
 
 	lock := s.lockTTLTimer.Get(lockID)
 	if lock == nil {

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -25,11 +25,11 @@ const (
 )
 
 var (
-	errVarAlreadyLocked = structs.NewErrRPCCoded(400, "variable already holds a lock")
-	errVarNotFound      = structs.NewErrRPCCoded(404, "variable doesn't exist")
-	errLockNotFound     = structs.NewErrRPCCoded(409, "variable doesn't hold a lock")
-	errVarIsLocked      = structs.NewErrRPCCoded(409, "attempting to modify locked variable")
-	errMissingLockInfo  = structs.NewErrRPCCoded(400, "missing lock information")
+	errVarAlreadyLocked = structs.NewErrRPCCoded(http.StatusBadRequest, "variable already holds a lock")
+	errVarNotFound      = structs.NewErrRPCCoded(http.StatusNotFound, "variable doesn't exist")
+	errLockNotFound     = structs.NewErrRPCCoded(http.StatusConflict, "variable doesn't hold a lock")
+	errVarIsLocked      = structs.NewErrRPCCoded(http.StatusConflict, "attempting to modify locked variable")
+	errMissingLockInfo  = structs.NewErrRPCCoded(http.StatusBadRequest, "missing lock information")
 )
 
 type variableTimers interface {

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -103,7 +103,7 @@ func (sv *Variables) Apply(args *structs.VariablesApplyRequest, reply *structs.V
 
 	err = canonicalizeAndValidate(args)
 	if err != nil {
-		return err
+		return structs.NewErrRPCCoded(http.StatusBadRequest, err.Error())
 	}
 
 	var ev *structs.VariableEncrypted
@@ -209,7 +209,11 @@ func canonicalizeAndValidate(args *structs.VariablesApplyRequest) error {
 	case structs.VarOpSet, structs.VarOpCAS:
 		args.Var.Canonicalize()
 
-		return args.Var.Validate()
+		err := args.Var.Validate()
+		if err != nil {
+			return structs.NewErrRPCCoded(http.StatusBadRequest, err.Error())
+		}
+		return nil
 
 	case structs.VarOpDelete, structs.VarOpDeleteCAS:
 		if args.Var == nil || args.Var.Path == "" {

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -26,10 +26,10 @@ const (
 )
 
 var (
-	errVarAlreadyLocked = errors.New("variable already holds a lock")
-	errVarNotFound      = errors.New("variable doesn't exist")
-	errLockNotFound     = errors.New("variable doesn't hold a lock")
-	errVarIsLocked      = errors.New("attempting to modify locked variable")
+	errVarAlreadyLocked = structs.NewErrRPCCoded(400, "variable already holds a lock")
+	errVarNotFound      = structs.NewErrRPCCoded(404, "variable doesn't exist")
+	errLockNotFound     = structs.NewErrRPCCoded(409, "variable doesn't hold a lock")
+	errVarIsLocked      = structs.NewErrRPCCoded(409, "attempting to modify locked variable")
 )
 
 type variableTimers interface {

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -29,7 +29,7 @@ var (
 	errVarNotFound      = structs.NewErrRPCCoded(404, "variable doesn't exist")
 	errLockNotFound     = structs.NewErrRPCCoded(409, "variable doesn't hold a lock")
 	errVarIsLocked      = structs.NewErrRPCCoded(409, "attempting to modify locked variable")
-	errMissingLockInfo  = structs.NewErrRPCCoded(400, "release requires all lock information")
+	errMissingLockInfo  = structs.NewErrRPCCoded(400, "missing lock information")
 )
 
 type variableTimers interface {


### PR DESCRIPTION
Add mechanism to run on high availability by using a lock to maintain the synchrony among instances, to ensure only one is running at all times, keeping others on stand by in case of failure.

For more information, refer to the RFC: [[NMD-179] Leader election using locking mechanism for the Autoscaler](https://go.hashi.co/rfc/nmd-179)