### PR TITLE
Ensure that the index processed by the client is at least as new as the last one processed.

### DIFF
--- a/.changelog/18269.txt
+++ b/.changelog/18269.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Ignore stale server updates to prevent GCing allocations that should be running
+```

--- a/client/client.go
+++ b/client/client.go
@@ -2368,7 +2368,7 @@ OUTER:
 		// For full context, please see https://github.com/hashicorp/nomad/issues/18267
 		if resp.Index <= req.MinQueryIndex {
 			c.logger.Debug("Received stale allocation information. Retrying.",
-				"received index", resp.Index, "requested min index", req.MinQueryIndex)
+				"index", resp.Index, "min_index", req.MinQueryIndex)
 			continue OUTER
 		}
 

--- a/client/client.go
+++ b/client/client.go
@@ -2366,7 +2366,7 @@ OUTER:
 		// after a prolonged downtime.
 		//
 		// For full context, please see https://github.com/hashicorp/nomad/issues/18267
-		if resp.Index < req.MinQueryIndex {
+		if resp.Index <= req.MinQueryIndex {
 			c.logger.Debug("Received stale allocation information. Retrying.",
 				"received index", resp.Index, "requested min index", req.MinQueryIndex)
 			continue OUTER

--- a/client/client.go
+++ b/client/client.go
@@ -2360,6 +2360,18 @@ OUTER:
 		default:
 		}
 
+		// We have not received any new data, or received stale data. This may happen in
+		// an array of situations, the worst of which seems to be a blocking request
+		// timeout when the scheduler which we are contacting is newly added or recovering
+		// after a prolonged downtime.
+		//
+		// For full context, please see https://github.com/hashicorp/nomad/issues/18267
+		if resp.Index < req.MinQueryIndex {
+			c.logger.Debug("Received stale allocation information. Retrying.",
+				"received index", resp.Index, "requested min index", req.MinQueryIndex)
+			continue OUTER
+		}
+
 		// Filter all allocations whose AllocModifyIndex was not incremented.
 		// These are the allocations who have either not been updated, or whose
 		// updates are a result of the client sending an update for the alloc.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -644,7 +644,9 @@ func TestClient_WatchAllocs(t *testing.T) {
 	failureSeen := false
 	testutil.WaitForResult(func() (bool, error) {
 		c1.allocLock.RLock()
-		if _, ok := c1.allocs[alloc3.ID]; ok {
+		_, ok := c1.allocs[alloc3.ID]
+		c1.allocLock.RUnlock()
+		if ok {
 			failureSeen = true
 			return true, fmt.Errorf("Unexpected allocation present in client state.")
 		}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -562,16 +562,10 @@ func TestClient_WatchAllocs(t *testing.T) {
 	alloc1.JobID = job.ID
 	alloc1.Job = job
 	alloc1.NodeID = c1.Node().ID
-
 	alloc2 := mock.Alloc()
 	alloc2.NodeID = c1.Node().ID
 	alloc2.JobID = job.ID
 	alloc2.Job = job
-
-	alloc3 := mock.Alloc()
-	alloc3.NodeID = c1.Node().ID
-	alloc3.JobID = job.ID
-	alloc3.Job = job
 
 	state := s1.State()
 	if err := state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job); err != nil {
@@ -605,7 +599,7 @@ func TestClient_WatchAllocs(t *testing.T) {
 	// alloc runner.
 	alloc2_2 := alloc2.Copy()
 	alloc2_2.DesiredStatus = structs.AllocDesiredStatusStop
-	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 105, []*structs.Allocation{alloc2_2}); err != nil {
+	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 104, []*structs.Allocation{alloc2_2}); err != nil {
 		t.Fatalf("err upserting stopped alloc: %v", err)
 	}
 
@@ -627,35 +621,6 @@ func TestClient_WatchAllocs(t *testing.T) {
 		return ar.Alloc().DesiredStatus == structs.AllocDesiredStatusStop, nil
 	}, func(err error) {
 		t.Fatalf("err: %v", err)
-	})
-
-	// Attempt to add an allocation with a RAFT index which predates the one currently
-	// known to the client. This is to ensure that the client monotonically increases the
-	// index it asks for and does not accept responses which have already been seen.
-	//
-	// Unfortunately, this requires us to depend on timeout for assertion. This isn't
-	// ideal, but barring changes to the state machine it is hard for us to assert that
-	// the client has made a query against the scheduler and received a stale answer.
-	alloc3.DesiredStatus = structs.AllocDesiredStatusStop
-	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 104, []*structs.Allocation{alloc3}); err != nil {
-		t.Fatalf("err upserting stopped alloc: %v", err)
-	}
-
-	failureSeen := false
-	testutil.WaitForResult(func() (bool, error) {
-		c1.allocLock.RLock()
-		_, ok := c1.allocs[alloc3.ID]
-		c1.allocLock.RUnlock()
-		if ok {
-			failureSeen = true
-			return true, fmt.Errorf("Unexpected allocation present in client state.")
-		}
-		return false, nil
-
-	}, func(err error) {
-		if failureSeen {
-			t.Fatalf("err: %v", err)
-		}
 	})
 }
 


### PR DESCRIPTION
A fix for https://github.com/hashicorp/nomad/issues/18267, ensuring that "time travel" of the client state is not possible.

I could not find tests which may exercise this logic meaningfully. Please point me the right direction and I'm happy to add them

Please note that this isn't an actual good fix to the underlying issue, but rather a stop-gap measure.