### PR TITLE
job_endpoint: jobIdentityCreator hook

### DIFF
--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -73,7 +73,7 @@ func NewJobEndpoints(s *Server, ctx *RPCContext) *Job {
 			jobExposeCheckHook{},
 			jobImpliedConstraints{},
 			jobNodePoolMutatingHook{srv: s},
-			jobIdentityCreator{},
+			jobIdentityCreator{srv: s},
 		},
 		validators: []jobValidator{
 			jobConnectHook{},

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -73,6 +73,7 @@ func NewJobEndpoints(s *Server, ctx *RPCContext) *Job {
 			jobExposeCheckHook{},
 			jobImpliedConstraints{},
 			jobNodePoolMutatingHook{srv: s},
+			jobIdentityCreator{},
 		},
 		validators: []jobValidator{
 			jobConnectHook{},

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -378,8 +378,7 @@ func (j *Job) submissionController(args *structs.JobRegisterRequest) error {
 	return nil
 }
 
-// jobIdentityCreator finds all `service` block with `provider = "consul"` and
-// creates new `identity` blocks for them.
+// jobIdentityCreator adds implicit `identity` blocks for external services, like Consul and Vault.
 type jobIdentityCreator struct {
 	srv *Server
 }

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -389,8 +389,6 @@ func (jobIdentityCreator) Name() string {
 }
 
 func (jobIdentityCreator) Mutate(job *structs.Job) (*structs.Job, []error, error) {
-	warnings := []error{}
-
 	for _, tg := range job.TaskGroups {
 		for _, s := range tg.Services {
 			if s.Provider != "consul" {
@@ -410,5 +408,5 @@ func (jobIdentityCreator) Mutate(job *structs.Job) (*structs.Job, []error, error
 		}
 	}
 
-	return job, warnings, nil
+	return job, nil, nil
 }

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -378,7 +378,8 @@ func (j *Job) submissionController(args *structs.JobRegisterRequest) error {
 	return nil
 }
 
-// jobIdentityCreator adds implicit `identity` blocks for external services, like Consul and Vault.
+// jobIdentityCreator adds implicit `identity` blocks for external services,
+// like Consul and Vault.
 type jobIdentityCreator struct {
 	srv *Server
 }
@@ -393,16 +394,10 @@ func (jobIdentityCreator) Mutate(job *structs.Job) (*structs.Job, []error, error
 			if s.Provider != "consul" {
 				continue
 			}
-			// users can override default settings by setting the identity values in the
-			// jobspec by hand
-			if s.Identity != nil {
-				continue
-			}
-
 			s.Identity = &structs.WorkloadIdentity{
 				Name:        fmt.Sprintf("consul-service/%s", s.Name),
 				Audience:    []string{"consul.io"},
-				ServiceName: fmt.Sprintf("consul-service/%s", s.Name),
+				ServiceName: s.Name,
 			}
 		}
 	}

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -818,91 +818,70 @@ func Test_jobIdentityCreator_Mutate(t *testing.T) {
 		{
 			name: "no mutation",
 			inputJob: &structs.Job{
-				TaskGroups: []*structs.TaskGroup{
-					&structs.TaskGroup{
-						Services: []*structs.Service{
-							&structs.Service{
-								Provider: "nomad",
-							},
-						},
-					},
-				},
+				TaskGroups: []*structs.TaskGroup{{
+					Services: []*structs.Service{{
+						Provider: "nomad",
+					}},
+				}},
 			},
 			expectedOutputJob: &structs.Job{
-				TaskGroups: []*structs.TaskGroup{
-					&structs.TaskGroup{
-						Services: []*structs.Service{
-							&structs.Service{
-								Provider: "nomad",
-							},
-						},
-					},
-				},
+				TaskGroups: []*structs.TaskGroup{{
+					Services: []*structs.Service{{
+						Provider: "nomad",
+					}},
+				}},
 			},
 		},
 		{
-			name: "custom set identity, no mutation",
+			name: "custom set identity, mutate",
 			inputJob: &structs.Job{
-				TaskGroups: []*structs.TaskGroup{
-					&structs.TaskGroup{
-						Services: []*structs.Service{
-							&structs.Service{
-								Provider: "consul",
-								Identity: &structs.WorkloadIdentity{
-									Name:     "test",
-									Audience: []string{"consul.io"},
-								},
-							},
+				TaskGroups: []*structs.TaskGroup{{
+					Services: []*structs.Service{{
+						Provider: "consul",
+						Name:     "web",
+						Identity: &structs.WorkloadIdentity{
+							Name:     "test",
+							Audience: []string{"consul.io"},
 						},
-					},
-				},
+					}},
+				}},
 			},
 			expectedOutputJob: &structs.Job{
-				TaskGroups: []*structs.TaskGroup{
-					&structs.TaskGroup{
-						Services: []*structs.Service{
-							&structs.Service{
-								Provider: "consul",
-								Identity: &structs.WorkloadIdentity{
-									Name:     "test",
-									Audience: []string{"consul.io"},
-								},
-							},
+				TaskGroups: []*structs.TaskGroup{{
+					Services: []*structs.Service{{
+						Provider: "consul",
+						Name:     "web",
+						Identity: &structs.WorkloadIdentity{
+							Name:        "consul-service/web",
+							Audience:    []string{"consul.io"},
+							ServiceName: "web",
 						},
-					},
-				},
+					}},
+				}},
 			},
 		},
 		{
 			name: "mutate",
 			inputJob: &structs.Job{
-				TaskGroups: []*structs.TaskGroup{
-					&structs.TaskGroup{
-						Services: []*structs.Service{
-							&structs.Service{
-								Provider: "consul",
-								Name:     "web",
-							},
-						},
-					},
-				},
+				TaskGroups: []*structs.TaskGroup{{
+					Services: []*structs.Service{{
+						Provider: "consul",
+						Name:     "web",
+					}},
+				}},
 			},
 			expectedOutputJob: &structs.Job{
-				TaskGroups: []*structs.TaskGroup{
-					&structs.TaskGroup{
-						Services: []*structs.Service{
-							&structs.Service{
-								Provider: "consul",
-								Name:     "web",
-								Identity: &structs.WorkloadIdentity{
-									Name:        "consul-service/web",
-									Audience:    []string{"consul.io"},
-									ServiceName: "consul-service/web",
-								},
-							},
+				TaskGroups: []*structs.TaskGroup{{
+					Services: []*structs.Service{{
+						Provider: "consul",
+						Name:     "web",
+						Identity: &structs.WorkloadIdentity{
+							Name:        "consul-service/web",
+							Audience:    []string{"consul.io"},
+							ServiceName: "web",
 						},
-					},
-				},
+					}},
+				}},
 			},
 		},
 	}


### PR DESCRIPTION
This PR introduces a job-mutating hook that inserts an `Identity` block for services that use the `consul` provider. 

Relates to https://github.com/hashicorp/team-nomad/issues/404