### PR TITLE
job_endpoint hooks: fix identity block mutator behavior

### DIFF
--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -394,10 +394,20 @@ func (jobIdentityCreator) Mutate(job *structs.Job) (*structs.Job, []error, error
 			if s.Provider != "consul" {
 				continue
 			}
-			s.Identity = &structs.WorkloadIdentity{
-				Name:        fmt.Sprintf("consul-service/%s", s.Name),
-				Audience:    []string{"consul.io"},
-				ServiceName: s.Name,
+
+			identityName := fmt.Sprintf("consul-service/%s", s.Name)
+
+			// if there's an identity block present, overwrite its name and ServiceName, but
+			// keep the rest
+			if s.Identity != nil {
+				s.Identity.Name = identityName
+				s.Identity.ServiceName = s.Name
+			} else {
+				s.Identity = &structs.WorkloadIdentity{
+					Name:        identityName,
+					Audience:    []string{"consul.io"},
+					ServiceName: s.Name,
+				}
 			}
 		}
 	}

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -398,7 +398,9 @@ func (jobIdentityCreator) Mutate(job *structs.Job) (*structs.Job, []error, error
 			identityName := fmt.Sprintf("consul-service/%s", s.Name)
 
 			// if there's an identity block present, overwrite its name and ServiceName, but
-			// keep the rest
+			// keep the rest. Users can set custom aud, file and env properties to account
+			// for the specifics of their environments, but Name and ServiceName must always
+			// conform to a convention.
 			if s.Identity != nil {
 				s.Identity.Name = identityName
 				s.Identity.ServiceName = s.Name

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -833,7 +833,7 @@ func Test_jobIdentityCreator_Mutate(t *testing.T) {
 			},
 		},
 		{
-			name: "custom set identity, mutate",
+			name: "custom set identity, merge",
 			inputJob: &structs.Job{
 				TaskGroups: []*structs.TaskGroup{{
 					Services: []*structs.Service{{
@@ -841,7 +841,9 @@ func Test_jobIdentityCreator_Mutate(t *testing.T) {
 						Name:     "web",
 						Identity: &structs.WorkloadIdentity{
 							Name:     "test",
-							Audience: []string{"consul.io"},
+							Audience: []string{"consul.io", "nomad.dev"},
+							File:     true,
+							Env:      false,
 						},
 					}},
 				}},
@@ -853,8 +855,10 @@ func Test_jobIdentityCreator_Mutate(t *testing.T) {
 						Name:     "web",
 						Identity: &structs.WorkloadIdentity{
 							Name:        "consul-service/web",
-							Audience:    []string{"consul.io"},
+							Audience:    []string{"consul.io", "nomad.dev"},
 							ServiceName: "web",
+							File:        true,
+							Env:         false,
 						},
 					}},
 				}},


### PR DESCRIPTION
If there's an `identity` block present in the config, do not overwrite it
completely. Only set the `Name` and `ServiceName` fields, and keep the rest. 
