### PR TITLE
ci: migrate semgrep action from deprecated wrapper

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,13 +9,14 @@ jobs:
   semgrep:
     name: Semgrep Scan
     runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep:1.36.0
     env:
       SEMGREP_SEND_METRICS: 0
     # Skip any PR created by dependabot to avoid permission issues
     if: (github.actor != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: returntocorp/semgrep-action@245bf11ddb2f3d4e35f116608cf6e27ae0f9aa04 # v1
+      - run: semgrep ci --config=.semgrep/
 permissions:
   contents: read
-


### PR DESCRIPTION
closes #18312 
related https://github.com/hashicorp/nomad/issues/18325