### PR TITLE
vault: add `use_identity` and `default_identity` agent configuration and implicit workload identity

### DIFF
--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -397,16 +397,16 @@ func parseVaults(c *Config, list *ast.ObjectList) error {
 
 		if o := listVal.Filter("default_identity"); len(o.Items) > 0 {
 			var m map[string]interface{}
-			defaultIdendityBlock := o.Items[0]
-			if err := hcl.DecodeObject(&m, defaultIdendityBlock.Val); err != nil {
+			defaultIdentityBlock := o.Items[0]
+			if err := hcl.DecodeObject(&m, defaultIdentityBlock.Val); err != nil {
 				return err
 			}
 
-			var defaultIdendity config.WorkloadIdentityConfig
-			if err := mapstructure.WeakDecode(m, &defaultIdendity); err != nil {
+			var defaultIdentity config.WorkloadIdentityConfig
+			if err := mapstructure.WeakDecode(m, &defaultIdentity); err != nil {
 				return err
 			}
-			c.Vaults[v.Name].DefaultIdentity = &defaultIdendity
+			c.Vaults[v.Name].DefaultIdentity = &defaultIdentity
 		}
 	}
 

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -199,6 +199,17 @@ func ParseConfigFile(path string) (*Config, error) {
 		}
 	}
 
+	for name, vaultConfig := range c.Vaults {
+		if vaultConfig.DefaultIdentity != nil {
+			tds = append(tds, durationConversionMap{
+				fmt.Sprintf("vaults.%s.default_identity.ttl", name), nil, &vaultConfig.DefaultIdentity.TTLHCL,
+				func(d *time.Duration) {
+					vaultConfig.DefaultIdentity.TTL = d
+				},
+			})
+		}
+	}
+
 	// Add enterprise audit sinks for time.Duration parsing
 	for i, sink := range c.Audit.Sinks {
 		tds = append(tds, durationConversionMap{

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -312,6 +312,8 @@ var basicConfig = &Config{
 			Audience: []string{"vault.io", "nomad.io"},
 			Env:      pointer.Of(false),
 			File:     pointer.Of(true),
+			TTL:      pointer.Of(3 * time.Hour),
+			TTLHCL:   "3h",
 		},
 	},
 	Vaults: map[string]*config.VaultConfig{
@@ -335,6 +337,8 @@ var basicConfig = &Config{
 				Audience: []string{"vault.io", "nomad.io"},
 				Env:      pointer.Of(false),
 				File:     pointer.Of(true),
+				TTL:      pointer.Of(3 * time.Hour),
+				TTLHCL:   "3h",
 			},
 		},
 	},

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -307,6 +307,7 @@ var basicConfig = &Config{
 		TLSSkipVerify:        &trueValue,
 		TaskTokenTTL:         "1s",
 		Token:                "12345",
+		UseIdentity:          pointer.Of(true),
 	},
 	Vaults: map[string]*config.VaultConfig{
 		"default": {
@@ -324,6 +325,7 @@ var basicConfig = &Config{
 			TLSSkipVerify:        &trueValue,
 			TaskTokenTTL:         "1s",
 			Token:                "12345",
+			UseIdentity:          pointer.Of(true),
 		},
 	},
 	TLSConfig: &config.TLSConfig{

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -308,6 +308,11 @@ var basicConfig = &Config{
 		TaskTokenTTL:         "1s",
 		Token:                "12345",
 		UseIdentity:          pointer.Of(true),
+		DefaultIdentity: &config.WorkloadIdentityConfig{
+			Audience: []string{"vault.io", "nomad.io"},
+			Env:      pointer.Of(false),
+			File:     pointer.Of(true),
+		},
 	},
 	Vaults: map[string]*config.VaultConfig{
 		"default": {
@@ -326,6 +331,11 @@ var basicConfig = &Config{
 			TaskTokenTTL:         "1s",
 			Token:                "12345",
 			UseIdentity:          pointer.Of(true),
+			DefaultIdentity: &config.WorkloadIdentityConfig{
+				Audience: []string{"vault.io", "nomad.io"},
+				Env:      pointer.Of(false),
+				File:     pointer.Of(true),
+			},
 		},
 	},
 	TLSConfig: &config.TLSConfig{

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -272,6 +272,12 @@ vault {
   tls_skip_verify       = true
   create_from_role      = "test_role"
   use_identity          = true
+
+  default_identity {
+    aud  = ["vault.io", "nomad.io"]
+    env  = false
+    file = true
+  }
 }
 
 tls {

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -271,6 +271,7 @@ vault {
   tls_server_name       = "foobar"
   tls_skip_verify       = true
   create_from_role      = "test_role"
+  use_identity          = true
 }
 
 tls {

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -277,6 +277,7 @@ vault {
     aud  = ["vault.io", "nomad.io"]
     env  = false
     file = true
+    ttl  = "3h"
   }
 }
 

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -392,7 +392,8 @@
       "default_identity": {
         "aud": ["vault.io", "nomad.io"],
         "env": false,
-        "file": true
+        "file": true,
+        "ttl": "3h"
       },
       "enabled": false,
       "key_file": "/path/to/key/file",

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -389,6 +389,11 @@
       "ca_path": "/path/to/ca",
       "cert_file": "/path/to/cert/file",
       "create_from_role": "test_role",
+      "default_identity": {
+        "aud": ["vault.io", "nomad.io"],
+        "env": false,
+        "file": true
+      },
       "enabled": false,
       "key_file": "/path/to/key/file",
       "task_token_ttl": "1s",

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -394,7 +394,8 @@
       "task_token_ttl": "1s",
       "tls_server_name": "foobar",
       "tls_skip_verify": true,
-      "token": "12345"
+      "token": "12345",
+      "use_identity": true
     }
   ]
 }

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -483,11 +483,28 @@ func (c *Config) ConsulTemplateIdentity() *structs.WorkloadIdentity {
 	return workloadIdentityFromConfig(c.ConsulConfig.TemplateIdentity)
 }
 
+// VaultDefaultIdentity returns the workload identity to be used for accessing
+// the Vault API.
+func (c *Config) VaultDefaultIdentity() *structs.WorkloadIdentity {
+	if c.VaultConfig == nil {
+		return nil
+	}
+
+	return workloadIdentityFromConfig(c.VaultConfig.DefaultIdentity)
+}
+
 // UseConsulIdentity returns true when Consul workload identity is enabled.
 func (c *Config) UseConsulIdentity() bool {
 	return c.ConsulConfig != nil &&
 		c.ConsulConfig.UseIdentity != nil &&
 		*c.ConsulConfig.UseIdentity
+}
+
+// UseVaultIdentity returns true when Vault workload identity is enabled.
+func (c *Config) UseVaultIdentity() bool {
+	return c.VaultConfig != nil &&
+		c.VaultConfig.UseIdentity != nil &&
+		*c.VaultConfig.UseIdentity
 }
 
 // workloadIdentityFromConfig returns a structs.WorkloadIdentity to be used in

--- a/nomad/job_endpoint_hook_implicit_identities.go
+++ b/nomad/job_endpoint_hook_implicit_identities.go
@@ -79,17 +79,13 @@ func (h jobImplicitIdentitiesHook) handleConsulService(s *structs.Service) {
 
 // handleVault injects a workload identity to the task if:
 //  1. The task has a Vault block.
-//  2. The server is configures with `vault.use_identity = true` and a
+//  2. The server is configured with `vault.use_identity = true` and a
 //     `vault.default_identity` is provided.
 //
 // If the task already has an identity named `vault` it sets the identity name
 // to the expected value.
 func (h jobImplicitIdentitiesHook) handleVault(t *structs.Task) {
-	if !h.srv.config.UseVaultIdentity() {
-		return
-	}
-
-	if t.Vault == nil {
+	if !h.srv.config.UseVaultIdentity() || t.Vault == nil {
 		return
 	}
 

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/pointer"
@@ -127,6 +128,7 @@ func Test_jobValidate_Validate_consul_service(t *testing.T) {
 				must.ErrorContains(t, err, tc.expectedErr)
 			}
 
+			must.Len(t, len(tc.expectedWarns), warns, must.Sprintf("got warnings: %v", warns))
 			for _, exp := range tc.expectedWarns {
 				hasWarn := false
 				for _, w := range warns {
@@ -170,6 +172,7 @@ func Test_jobValidate_Validate_vault(t *testing.T) {
 				UseIdentity: pointer.Of(true),
 				DefaultIdentity: &config.WorkloadIdentityConfig{
 					Audience: []string{"vault.io"},
+					TTL:      pointer.Of(time.Hour),
 				},
 			},
 		},
@@ -179,6 +182,7 @@ func Test_jobValidate_Validate_vault(t *testing.T) {
 			inputTaskIdentities: []*structs.WorkloadIdentity{{
 				Name:     vaultIdentityName,
 				Audience: []string{"vault.io"},
+				TTL:      time.Hour,
 			}},
 			inputConfig: &config.VaultConfig{
 				UseIdentity: pointer.Of(true),
@@ -212,6 +216,7 @@ func Test_jobValidate_Validate_vault(t *testing.T) {
 				UseIdentity: pointer.Of(true),
 				DefaultIdentity: &config.WorkloadIdentityConfig{
 					Audience: []string{"vault.io"},
+					TTL:      pointer.Of(time.Hour),
 				},
 			},
 			expectedWarns: []string{"policies will be ignored"},
@@ -224,6 +229,7 @@ func Test_jobValidate_Validate_vault(t *testing.T) {
 			inputTaskIdentities: []*structs.WorkloadIdentity{{
 				Name:     vaultIdentityName,
 				Audience: []string{"vault.io"},
+				TTL:      time.Hour,
 			}},
 			inputConfig: &config.VaultConfig{
 				UseIdentity: pointer.Of(false),
@@ -238,6 +244,7 @@ func Test_jobValidate_Validate_vault(t *testing.T) {
 			inputTaskIdentities: []*structs.WorkloadIdentity{{
 				Name:     vaultIdentityName,
 				Audience: []string{"vault.io"},
+				TTL:      time.Hour,
 			}},
 			inputConfig: &config.VaultConfig{
 				UseIdentity: pointer.Of(true),
@@ -275,7 +282,7 @@ func Test_jobValidate_Validate_vault(t *testing.T) {
 				must.ErrorContains(t, err, tc.expectedErr)
 			}
 
-			must.Len(t, len(tc.expectedWarns), warns)
+			must.Len(t, len(tc.expectedWarns), warns, must.Sprintf("got warnings: %v", warns))
 			for _, exp := range tc.expectedWarns {
 				hasWarn := false
 				for _, w := range warns {

--- a/nomad/structs/config/vault.go
+++ b/nomad/structs/config/vault.go
@@ -21,11 +21,11 @@ const (
 //   - Renew Vault tokens/leases.
 //   - Pass a token for the Nomad Server to derive sub-tokens.
 //   - Create child tokens with policy subsets of the Server's token.
-//   - Create Vault ACL tokens from workload identity JTWs.
+//   - Create Vault ACL tokens from workload identity JWTs.
 type VaultConfig struct {
 	// Servers and clients fields.
 
-	// Name is used to identity the Vault cluster related to this
+	// Name is used to identify the Vault cluster related to this
 	// configuration.
 	Name string `mapstructure:"name"`
 
@@ -39,12 +39,12 @@ type VaultConfig struct {
 	// config value is also unset, the default auth method or cluster global
 	// role is used.
 	//
-	// When not using workload identities, the Nomad servers will derive toknes
-	// using this role. The token given to Nomad does not have to be created
-	// from this role but must have "update" capability on
-	// "auth/token/create/<create_from_role>". If this value is unset and the
-	// token is created from a role, the value is defaulted to the role the
-	// token is from.
+	// When not using workload identities, the Nomad servers will derive tokens
+	// using this role. The Vault token provided to the Nomad server config
+	// does not have to be created from this role but must have "update"
+	// capability on "auth/token/create/<create_from_role>". If this value is
+	// unset and the token is created from a role, the value is defaulted to
+	// the role the token is from.
 	//
 	// This used to be a server-only field, but it's a client-only field when
 	// workload identities are used, so it should be set in both places during

--- a/nomad/structs/config/vault_test.go
+++ b/nomad/structs/config/vault_test.go
@@ -29,6 +29,7 @@ func TestVaultConfig_Merge(t *testing.T) {
 		TLSKeyFile:           "1",
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "1",
+		UseIdentity:          pointer.Of(false),
 	}
 
 	c2 := &VaultConfig{
@@ -44,6 +45,7 @@ func TestVaultConfig_Merge(t *testing.T) {
 		TLSKeyFile:           "2",
 		TLSSkipVerify:        nil,
 		TLSServerName:        "2",
+		UseIdentity:          pointer.Of(true),
 	}
 
 	e := &VaultConfig{
@@ -59,6 +61,7 @@ func TestVaultConfig_Merge(t *testing.T) {
 		TLSKeyFile:           "2",
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "2",
+		UseIdentity:          pointer.Of(true),
 	}
 
 	result := c1.Merge(c2)
@@ -85,6 +88,7 @@ func TestVaultConfig_Equals(t *testing.T) {
 		TLSKeyFile:           "1",
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "1",
+		UseIdentity:          pointer.Of(true),
 	}
 
 	c2 := &VaultConfig{
@@ -102,6 +106,7 @@ func TestVaultConfig_Equals(t *testing.T) {
 		TLSKeyFile:           "1",
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "1",
+		UseIdentity:          pointer.Of(true),
 	}
 
 	must.Equal(t, c1, c2)
@@ -121,6 +126,7 @@ func TestVaultConfig_Equals(t *testing.T) {
 		TLSKeyFile:           "1",
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "1",
+		UseIdentity:          pointer.Of(true),
 	}
 
 	c4 := &VaultConfig{
@@ -138,6 +144,7 @@ func TestVaultConfig_Equals(t *testing.T) {
 		TLSKeyFile:           "1",
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "1",
+		UseIdentity:          pointer.Of(false),
 	}
 
 	must.NotEqual(t, c3, c4)

--- a/nomad/structs/config/vault_test.go
+++ b/nomad/structs/config/vault_test.go
@@ -30,6 +30,7 @@ func TestVaultConfig_Merge(t *testing.T) {
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "1",
 		UseIdentity:          pointer.Of(false),
+		DefaultIdentity:      nil,
 	}
 
 	c2 := &VaultConfig{
@@ -46,6 +47,11 @@ func TestVaultConfig_Merge(t *testing.T) {
 		TLSSkipVerify:        nil,
 		TLSServerName:        "2",
 		UseIdentity:          pointer.Of(true),
+		DefaultIdentity: &WorkloadIdentityConfig{
+			Audience: []string{"vault.dev"},
+			Env:      pointer.Of(true),
+			File:     pointer.Of(false),
+		},
 	}
 
 	e := &VaultConfig{
@@ -62,6 +68,11 @@ func TestVaultConfig_Merge(t *testing.T) {
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "2",
 		UseIdentity:          pointer.Of(true),
+		DefaultIdentity: &WorkloadIdentityConfig{
+			Audience: []string{"vault.dev"},
+			Env:      pointer.Of(true),
+			File:     pointer.Of(false),
+		},
 	}
 
 	result := c1.Merge(c2)
@@ -89,6 +100,11 @@ func TestVaultConfig_Equals(t *testing.T) {
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "1",
 		UseIdentity:          pointer.Of(true),
+		DefaultIdentity: &WorkloadIdentityConfig{
+			Audience: []string{"vault.dev"},
+			Env:      pointer.Of(true),
+			File:     pointer.Of(false),
+		},
 	}
 
 	c2 := &VaultConfig{
@@ -107,6 +123,11 @@ func TestVaultConfig_Equals(t *testing.T) {
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "1",
 		UseIdentity:          pointer.Of(true),
+		DefaultIdentity: &WorkloadIdentityConfig{
+			Audience: []string{"vault.dev"},
+			Env:      pointer.Of(true),
+			File:     pointer.Of(false),
+		},
 	}
 
 	must.Equal(t, c1, c2)
@@ -127,6 +148,11 @@ func TestVaultConfig_Equals(t *testing.T) {
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "1",
 		UseIdentity:          pointer.Of(true),
+		DefaultIdentity: &WorkloadIdentityConfig{
+			Audience: []string{"vault.dev"},
+			Env:      pointer.Of(true),
+			File:     pointer.Of(false),
+		},
 	}
 
 	c4 := &VaultConfig{
@@ -145,6 +171,11 @@ func TestVaultConfig_Equals(t *testing.T) {
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "1",
 		UseIdentity:          pointer.Of(false),
+		DefaultIdentity: &WorkloadIdentityConfig{
+			Audience: []string{"vault.io"},
+			Env:      pointer.Of(false),
+			File:     pointer.Of(true),
+		},
 	}
 
 	must.NotEqual(t, c3, c4)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7645,6 +7645,15 @@ func (t *Task) IsPoststop() bool {
 		t.Lifecycle.Hook == TaskLifecycleHookPoststop
 }
 
+func (t *Task) GetIdentity(name string) *WorkloadIdentity {
+	for _, wid := range t.Identities {
+		if wid.Name == name {
+			return wid
+		}
+	}
+	return nil
+}
+
 func (t *Task) Copy() *Task {
 	if t == nil {
 		return nil
@@ -10004,10 +10013,6 @@ func (v *Vault) Validate() error {
 	}
 
 	var mErr multierror.Error
-	if len(v.Policies) == 0 {
-		_ = multierror.Append(&mErr, fmt.Errorf("Policy list cannot be empty"))
-	}
-
 	for _, p := range v.Policies {
 		if p == "root" {
 			_ = multierror.Append(&mErr, fmt.Errorf("Can not specify \"root\" policy"))

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -6191,15 +6191,9 @@ func TestVault_Validate(t *testing.T) {
 
 	v := &Vault{
 		Env:        true,
-		ChangeMode: VaultChangeModeNoop,
+		ChangeMode: VaultChangeModeSignal,
+		Policies:   []string{"foo", "root"},
 	}
-
-	if err := v.Validate(); err == nil || !strings.Contains(err.Error(), "Policy list") {
-		t.Fatalf("Expected policy list empty error")
-	}
-
-	v.Policies = []string{"foo", "root"}
-	v.ChangeMode = VaultChangeModeSignal
 
 	err := v.Validate()
 	if err == nil {


### PR DESCRIPTION
Add new agent configuration `use_identity` and `default_identity` to the `vault` block.

`use_identity` is a boolean value that determines if Vault tokens should be derived from workload identity JWTs instead of the traditional flow of relying on Nomad servers for token derivation. If `use_identity` is `true` jobs with a `vault` block receive an implicit `identity` called `vault` if one is not already present.

`default_identity` is the `identity` block injected to tasks that don't define an `identity` block named `vault`.

Job validation on register becomes a little more complicated because we now need to check three places:
1. `vault` block in job
2. `vault` block in server config
3. `identity` in task

```mermaid
flowchart TD
	Start[Job Registered] --> HasVault{Job has vault block?}

    HasVault -->|No| HasVaultIdentityNoVault{Job has vault identity?}
    HasVault -->|Yes| HasVaultIdentityWithVault{Job has vault identity?}

    HasVaultIdentityNoVault -->|Yes| VaultNoIdentityWarn[Warn\nVault identity without vault block]
    HasVaultIdentityNoVault --> |No| NoVault[No Vault]
    VaultNoIdentityWarn --> NoVault

    HasVaultIdentityWithVault -->|Yes| UseIdentityWithVaultIdentity{Server vault.use_identity}
    HasVaultIdentityWithVault -->|No| UseIdentityWithoutVaultIdentity{Server vault.use_identity}

    UseIdentityWithVaultIdentity -->|True| WIDHasPolicies{Vault block has policies?}
    UseIdentityWithVaultIdentity -->|False| NoVaultIdentityWarn[Warn\nVault identity without using identity]
    
    
    WIDHasPolicies -->|No| UseWID[Use workload identity]
    WIDHasPolicies -->|Yes| DeprecatePoliciesWarn[Warn\nUsing identity with policies]
    DeprecatePoliciesWarn --> UseWID
    
    NoVaultIdentityWarn --> LegacyHasPolicies{Vault block has policies?}
    LegacyHasPolicies -->|Yes| UseLegacy[Use legacy flow]
    LegacyHasPolicies -->|No| MissingPoliciesError[Error\nLegacy flow without policies]
    
    UseIdentityWithoutVaultIdentity -->|False| LegacyHasPolicies
    UseIdentityWithoutVaultIdentity -->|True| HasDefaultIdentity{Server has default_identity?}
    
    HasDefaultIdentity -->|No| NoIdentityError[Error\nUsing indentity without identity]
    HasDefaultIdentity -->|Yes| InjectDefaultIdentity[Inject default identity]
    InjectDefaultIdentity --> WIDHasPolicies
```

_Note to reviewers: https://github.com/hashicorp/nomad/pull/18343/commits/98c09961b33706b9f6817aca9d8360aa75f65034 causes some diffs that are not necessary to the core logic because it just re-order struct fields. You can review the PR by commit or look at the diff without this commit in https://github.com/hashicorp/nomad/pull/18343/files/19fd50976f1436818c4d16267269ccac00682617_