### PR TITLE
client: include response body in output for successful HTTP checks

### DIFF
--- a/.changelog/18345.txt
+++ b/.changelog/18345.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+services: Include response body in output for successful HTTP checks when using Nomad native service discovery
+```

--- a/client/serviceregistration/checks/client.go
+++ b/client/serviceregistration/checks/client.go
@@ -205,16 +205,12 @@ func (c *checker) checkHTTP(ctx context.Context, qc *QueryContext, q *Query) *st
 	switch {
 	case result.StatusCode == http.StatusOK:
 		qr.Status = structs.CheckSuccess
-		qr.Output = "nomad: http ok"
-		return qr
 	case result.StatusCode < http.StatusBadRequest:
 		qr.Status = structs.CheckSuccess
 	default:
 		qr.Status = structs.CheckFailure
 	}
 
-	// status code was not 200; read the response body and set that as the
-	// check result output content
 	qr.Output = limitRead(result.Body)
 
 	return qr

--- a/client/serviceregistration/checks/client_test.go
+++ b/client/serviceregistration/checks/client_test.go
@@ -203,7 +203,7 @@ func TestChecker_Do_HTTP(t *testing.T) {
 			structs.Healthiness,
 			structs.CheckSuccess,
 			http.StatusOK,
-			"nomad: http ok",
+			"200 ok",
 		),
 	}}
 

--- a/client/serviceregistration/checks/client_test.go
+++ b/client/serviceregistration/checks/client_test.go
@@ -143,7 +143,7 @@ func TestChecker_Do_HTTP(t *testing.T) {
 			structs.Healthiness,
 			structs.CheckSuccess,
 			http.StatusOK,
-			"nomad: http ok",
+			"200 ok",
 		),
 	}, {
 		name: "200 readiness",
@@ -153,7 +153,7 @@ func TestChecker_Do_HTTP(t *testing.T) {
 			structs.Readiness,
 			structs.CheckSuccess,
 			http.StatusOK,
-			"nomad: http ok",
+			"200 ok",
 		),
 	}, {
 		name: "500 healthiness",


### PR DESCRIPTION
This brings Nomad's service checks closer in line with those of Consul. Specifically, Consul provides the HTTP response body in the "Output" field of health checks, even those that are passing. 

This is needed for services that query the Nomad alloc checks API for more detailed service health info (for example, we return player count for game servers in our health check and use this to stop jobs that have no players for extended periods of time.)

On a side note, I'd like to think through (and would contribute to) a solid way to query for all health checks for a given service ala Consul's "/health/checks/:service" endpoint. 

I'm learning this is may be a limitation because health checks are only stored on the Nomad client and not replicated. Even an endpoint to get all health checks for a Node would be useful!

Please let me know if I'm trending towards an antipattern with this and similar changes. I'm new to the Hashicorp ecosystem and not sure if we're using health checks in a good way or if there's a better tool. 
