### PR TITLE
draft-cpu-partitions

### DIFF
--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -121,6 +121,7 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 		newAllocDirHook(hookLogger, ar.allocDir),
 		newUpstreamAllocsHook(hookLogger, ar.prevAllocWatcher),
 		newDiskMigrationHook(hookLogger, ar.prevAllocMigrator, ar.allocDir),
+		newCPUPartsHook(hookLogger, ar.partitions, alloc),
 		newAllocHealthWatcherHook(hookLogger, alloc, newEnvBuilder, hs, ar.Listener(), ar.consulClient, ar.checkStore),
 		newNetworkHook(hookLogger, ns, alloc, nm, nc, ar, builtTaskEnv),
 		newGroupServiceHook(groupServiceHookConfig{

--- a/client/allocrunner/cpuparts_hook.go
+++ b/client/allocrunner/cpuparts_hook.go
@@ -1,0 +1,56 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package allocrunner
+
+import (
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/lib/cgroupslib"
+	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+const (
+	cpuPartsHookName = "cpuparts_hook"
+)
+
+// cpuPartsHooks is responsible for managing cpuset partitioning on Linux
+// nodes. This mechanism works by segregating tasks that make use of "cpu" vs.
+// "cores" resources. Tasks that make use of "cpu" resource actually make use
+// of shared cores that have not been reserved. The scheduler ensures enough
+// cores on a node are not reserved such that all tasks have the minimum amount
+// of cpu bandwidth they requested.
+type cpuPartsHook struct {
+	logger  hclog.Logger
+	allocID string
+
+	reservations *idset.Set[hw.CoreID]
+	partitions   cgroupslib.Partition
+}
+
+func newCPUPartsHook(
+	logger hclog.Logger,
+	partitions cgroupslib.Partition,
+	alloc *structs.Allocation,
+) *cpuPartsHook {
+
+	return &cpuPartsHook{
+		logger:       logger,
+		allocID:      alloc.ID,
+		partitions:   partitions,
+		reservations: alloc.ReservedCores(),
+	}
+}
+
+func (h *cpuPartsHook) Name() string {
+	return cpuPartsHookName
+}
+
+func (h *cpuPartsHook) Prerun() error {
+	return h.partitions.Reserve(h.reservations)
+}
+
+func (h *cpuPartsHook) Postrun() error {
+	return h.partitions.Release(h.reservations)
+}

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -848,7 +848,8 @@ func (tr *TaskRunner) shouldRestart() (bool, time.Duration) {
 }
 
 func (tr *TaskRunner) assignCgroup(taskConfig *drivers.TaskConfig) {
-	p := cgroupslib.LinuxResourcesPath(taskConfig.AllocID, taskConfig.Name)
+	reserveCores := len(tr.taskResources.Cpu.ReservedCores) > 0
+	p := cgroupslib.LinuxResourcesPath(taskConfig.AllocID, taskConfig.Name, reserveCores)
 	taskConfig.Resources.LinuxResources.CpusetCgroupPath = p
 }
 

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -72,7 +72,7 @@ func (tr *TaskRunner) initHooks() {
 		newStatsHook(tr, tr.clientConfig.StatsCollectionInterval, hookLogger),
 		newDeviceHook(tr.devicemanager, hookLogger),
 		newAPIHook(tr.shutdownCtx, tr.clientConfig.APIListenerRegistrar, hookLogger),
-		newWranglerHook(tr.wranglers, task.Name, alloc.ID, hookLogger),
+		newWranglerHook(tr.wranglers, task.Name, alloc.ID, task.UsesCores(), hookLogger),
 	}
 
 	// If the task has a CSI block, add the hook.

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -151,7 +151,7 @@ func testTaskRunnerConfig(t *testing.T, alloc *structs.Allocation, taskName stri
 		ShutdownDelayCancelFn: shutdownDelayCancelFn,
 		ServiceRegWrapper:     wrapperMock,
 		Getter:                getter.TestSandbox(t),
-		Wranglers:             proclib.New(&proclib.Configs{Logger: testlog.HCLogger(t)}),
+		Wranglers:             proclib.MockWranglers(t),
 		WIDMgr:                MockWIDMgr{},
 	}
 

--- a/client/allocrunner/taskrunner/wrangler_hook.go
+++ b/client/allocrunner/taskrunner/wrangler_hook.go
@@ -26,13 +26,19 @@ type wranglerHook struct {
 	log       hclog.Logger
 }
 
-func newWranglerHook(wranglers cifs.ProcessWranglers, task, allocID string, log hclog.Logger) *wranglerHook {
+func newWranglerHook(
+	wranglers cifs.ProcessWranglers,
+	task, allocID string,
+	cores bool,
+	log hclog.Logger,
+) *wranglerHook {
 	return &wranglerHook{
 		log:       log.Named(wranglerHookName),
 		wranglers: wranglers,
 		task: proclib.Task{
 			AllocID: allocID,
 			Task:    task,
+			Cores:   cores,
 		},
 	}
 }

--- a/client/allocrunner/testing.go
+++ b/client/allocrunner/testing.go
@@ -18,6 +18,7 @@ import (
 	clientconfig "github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/consul"
 	"github.com/hashicorp/nomad/client/devicemanager"
+	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/client/lib/proclib"
 	"github.com/hashicorp/nomad/client/pluginmanager/drivermanager"
 	"github.com/hashicorp/nomad/client/serviceregistration/checks/checkstore"
@@ -25,7 +26,6 @@ import (
 	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/client/vaultclient"
-	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
@@ -96,7 +96,8 @@ func testAllocRunnerConfig(t *testing.T, alloc *structs.Allocation) (*config.All
 		ServiceRegWrapper:  wrapper.NewHandlerWrapper(clientConf.Logger, consulRegMock, nomadRegMock),
 		CheckStore:         checkstore.NewStore(clientConf.Logger, stateDB),
 		Getter:             getter.TestSandbox(t),
-		Wranglers:          proclib.New(&proclib.Configs{Logger: testlog.HCLogger(t)}),
+		Wranglers:          proclib.MockWranglers(t),
+		Partitions:         cgroupslib.MockPartition(),
 	}
 
 	return conf, cleanup

--- a/client/client.go
+++ b/client/client.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/nomad/client/fingerprint"
 	"github.com/hashicorp/nomad/client/hoststats"
 	cinterfaces "github.com/hashicorp/nomad/client/interfaces"
+	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/client/lib/numalib"
 	"github.com/hashicorp/nomad/client/lib/proclib"
 	"github.com/hashicorp/nomad/client/pluginmanager"
@@ -331,6 +332,9 @@ type Client struct {
 	// fingerprinting
 	topology *numalib.Topology
 
+	// partitions is used for managing cpuset partitioning on linux systems
+	partitions cgroupslib.Partition
+
 	// widmgr retrieves workload identities
 	widmgr *widmgr.WIDMgr
 }
@@ -465,9 +469,15 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 		c.topology = numalib.NoImpl(ir.Topology)
 	}
 
+	// Create the cpu core partition manager
+	c.partitions = cgroupslib.GetPartition(
+		c.topology.UsableCores(),
+	)
+
 	// Create the process wranglers
 	wranglers := proclib.New(&proclib.Configs{
-		Logger: c.logger.Named("proclib"),
+		UsableCores: c.topology.UsableCores(),
+		Logger:      c.logger.Named("proclib"),
 	})
 	c.wranglers = wranglers
 
@@ -1258,6 +1268,7 @@ func (c *Client) restoreState() error {
 			RPCClient:           c,
 			Getter:              c.getter,
 			Wranglers:           c.wranglers,
+			Partitions:          c.partitions,
 		}
 
 		ar, err := c.allocrunnerFactory(arConf)
@@ -2748,6 +2759,7 @@ func (c *Client) addAlloc(alloc *structs.Allocation, migrateToken string) error 
 		RPCClient:           c,
 		Getter:              c.getter,
 		Wranglers:           c.wranglers,
+		Partitions:          c.partitions,
 		WIDMgr:              c.widmgr,
 	}
 

--- a/client/config/arconfig.go
+++ b/client/config/arconfig.go
@@ -110,6 +110,9 @@ type AllocRunnerConfig struct {
 	// Wranglers is an interface for managing unix/windows processes.
 	Wranglers interfaces.ProcessWranglers
 
+	// Partitions is an interface for managing cpuset partitions.
+	Partitions interfaces.CPUPartitions
+
 	// WIDMgr fetches workload identities
 	WIDMgr *widmgr.WIDMgr
 }

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/consul-template/config"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
-	"github.com/hashicorp/nomad/client/lib/numalib"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
 	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/command/agent/host"
 	"github.com/hashicorp/nomad/helper"
@@ -309,7 +309,7 @@ type Config struct {
 	CgroupParent string
 
 	// ReservableCores if set overrides the set of reservable cores reported in fingerprinting.
-	ReservableCores []numalib.CoreID
+	ReservableCores []hw.CoreID
 
 	// NomadServiceDiscovery determines whether the Nomad native service
 	// discovery client functionality is enabled.

--- a/client/fingerprint/cpu_default_test.go
+++ b/client/fingerprint/cpu_default_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/config"
-	"github.com/hashicorp/nomad/client/lib/numalib"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
 	"github.com/hashicorp/nomad/client/testutil"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -63,7 +63,7 @@ func TestCPUFingerprint_OverrideCompute(t *testing.T) {
 		Attributes: make(map[string]string),
 	}
 	cfg := &config.Config{
-		ReservableCores: []numalib.CoreID{0, 1, 2},
+		ReservableCores: []hw.CoreID{0, 1, 2},
 	}
 	var originalCPU int
 

--- a/client/interfaces/client.go
+++ b/client/interfaces/client.go
@@ -4,6 +4,8 @@
 package interfaces
 
 import (
+	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
 	"github.com/hashicorp/nomad/client/lib/proclib"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/device"
@@ -46,4 +48,11 @@ type ArtifactGetter interface {
 type ProcessWranglers interface {
 	Setup(proclib.Task) error
 	Destroy(proclib.Task) error
+}
+
+// CPUPartitions is an interface satisfied by the cgroupslib package.
+type CPUPartitions interface {
+	Restore(*idset.Set[hw.CoreID])
+	Reserve(*idset.Set[hw.CoreID]) error
+	Release(*idset.Set[hw.CoreID]) error
 }

--- a/client/lib/cgroupslib/default.go
+++ b/client/lib/cgroupslib/default.go
@@ -6,7 +6,7 @@
 package cgroupslib
 
 // LinuxResourcesPath does nothing on non-Linux systems
-func LinuxResourcesPath(string, string) string {
+func LinuxResourcesPath(string, string, bool) string {
 	return ""
 }
 

--- a/client/lib/cgroupslib/editor.go
+++ b/client/lib/cgroupslib/editor.go
@@ -32,16 +32,14 @@ func OpenPath(dir string) Interface {
 	}
 }
 
-// OpenFromCpusetCG1 creates a handle for modifying cgroup interface files of
-// the given interface, given a path to the cpuset interface.
-//
-// This is useful because a Nomad task resources struct only keeps track of
-// the cpuset cgroup directory in the cgroups v1 regime, but nowadays we want
-// to modify more than the cpuset in some cases.
-func OpenFromCpusetCG1(dir, iface string) Interface {
-	return &editor{
-		dpath: strings.Replace(dir, "cpuset", iface, 1),
+// OpenFromFreezerCG1 creates a handle for modifying cgroup interface files
+// of the given interface, given a path to the freezer cgroup.
+func OpenFromFreezerCG1(orig, iface string) Interface {
+	if iface == "cpuset" {
+		panic("cannot open cpuset")
 	}
+	p := strings.Replace(orig, "/freezer/", "/"+iface+"/", 1)
+	return OpenPath(p)
 }
 
 // An Interface can be used to read and write the interface files of a cgroup.
@@ -89,16 +87,17 @@ func (e *editor) Write(filename, content string) error {
 // A Factory creates a Lifecycle which is an abstraction over the setup and
 // teardown routines used for creating and destroying cgroups used for
 // constraining Nomad tasks.
-func Factory(allocID, task string) Lifecycle {
+func Factory(allocID, task string, cores bool) Lifecycle {
 	switch GetMode() {
 	case CG1:
 		return &lifeCG1{
 			allocID: allocID,
 			task:    task,
+			cores:   cores,
 		}
 	default:
 		return &lifeCG2{
-			dpath: pathCG2(allocID, task),
+			dpath: pathCG2(allocID, task, cores),
 		}
 	}
 }
@@ -118,6 +117,7 @@ type Lifecycle interface {
 type lifeCG1 struct {
 	allocID string
 	task    string
+	cores   bool // uses core reservation
 }
 
 func (l *lifeCG1) Setup() error {
@@ -127,13 +127,32 @@ func (l *lifeCG1) Setup() error {
 		if err != nil {
 			return err
 		}
+		if strings.Contains(p, "/reserve/") {
+			if err = l.inheritMems(p); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
+}
+
+func (l *lifeCG1) inheritMems(destination string) error {
+	parent := filepath.Join(filepath.Dir(destination), "cpuset.mems")
+	b, err := os.ReadFile(parent)
+	if err != nil {
+		return err
+	}
+	destination = filepath.Join(destination, "cpuset.mems")
+	return os.WriteFile(destination, b, 0644)
 }
 
 func (l *lifeCG1) Teardown() error {
 	paths := l.paths()
 	for _, p := range paths {
+		if filepath.Base(p) == "share" {
+			// avoid removing the share cgroup
+			continue
+		}
 		err := os.RemoveAll(p)
 		if err != nil {
 			return err
@@ -162,7 +181,7 @@ func (l *lifeCG1) Kill() error {
 }
 
 func (l *lifeCG1) edit(iface string) *editor {
-	scope := scopeCG1(l.allocID, l.task)
+	scope := ScopeCG1(l.allocID, l.task)
 	return &editor{
 		dpath: filepath.Join(root, iface, NomadCgroupParent, scope),
 	}
@@ -184,14 +203,22 @@ func (l *lifeCG1) thaw() error {
 }
 
 func (l *lifeCG1) paths() []string {
-	scope := scopeCG1(l.allocID, l.task)
-	ifaces := []string{"freezer", "cpu", "memory", "cpuset"}
-	paths := make([]string, 0, len(ifaces))
+	scope := ScopeCG1(l.allocID, l.task)
+	ifaces := []string{"freezer", "cpu", "memory"}
+	paths := make([]string, 0, len(ifaces)+1)
 	for _, iface := range ifaces {
 		paths = append(paths, filepath.Join(
 			root, iface, NomadCgroupParent, scope,
 		))
 	}
+
+	switch partition := GetPartitionFromBool(l.cores); partition {
+	case "reserve":
+		paths = append(paths, filepath.Join(root, "cpuset", NomadCgroupParent, partition, scope))
+	case "share":
+		paths = append(paths, filepath.Join(root, "cpuset", NomadCgroupParent, partition))
+	}
+
 	return paths
 }
 
@@ -235,7 +262,7 @@ func getPIDs(file string) (*set.Set[int], error) {
 	return result, nil
 }
 
-func scopeCG1(allocID, task string) string {
+func ScopeCG1(allocID, task string) string {
 	return fmt.Sprintf("%s.%s", allocID, task)
 }
 
@@ -243,6 +270,7 @@ func scopeCG2(allocID, task string) string {
 	return fmt.Sprintf("%s.%s.scope", allocID, task)
 }
 
-func pathCG2(allocID, task string) string {
-	return filepath.Join(root, NomadCgroupParent, scopeCG2(allocID, task))
+func pathCG2(allocID, task string, cores bool) string {
+	partition := GetPartitionFromBool(cores)
+	return filepath.Join(root, NomadCgroupParent, partition, scopeCG2(allocID, task))
 }

--- a/client/lib/cgroupslib/init_default.go
+++ b/client/lib/cgroupslib/init_default.go
@@ -1,0 +1,11 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !linux
+
+package cgroupslib
+
+// PathCG1 returns empty string on non-Linux systems
+func PathCG1(allocID, taskName, iface string) string {
+	return ""
+}

--- a/client/lib/cgroupslib/mount.go
+++ b/client/lib/cgroupslib/mount.go
@@ -15,6 +15,10 @@ import (
 )
 
 func detect() Mode {
+	if os.Geteuid() > 0 {
+		return OFF
+	}
+
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {
 		return OFF
@@ -22,6 +26,7 @@ func detect() Mode {
 	defer func() {
 		_ = f.Close()
 	}()
+
 	return scan(f)
 }
 

--- a/client/lib/cgroupslib/partition.go
+++ b/client/lib/cgroupslib/partition.go
@@ -1,0 +1,63 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package cgroupslib
+
+import (
+	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
+)
+
+// A Partition is used to track reserved vs. shared cpu cores.
+type Partition interface {
+	Restore(*idset.Set[hw.CoreID])
+	Reserve(*idset.Set[hw.CoreID]) error
+	Release(*idset.Set[hw.CoreID]) error
+}
+
+// SharePartition is the name of the cgroup containing cgroups for tasks
+// making use of the 'cpu' resource, which pools and shares cpu cores.
+func SharePartition() string {
+	switch GetMode() {
+	case CG1:
+		return "share"
+	case CG2:
+		return "share.slice"
+	default:
+		return ""
+	}
+}
+
+// ReservePartition is the name of the cgroup containing cgroups for tasks
+// making use of the 'cores' resource, which reserves specific cpu cores.
+func ReservePartition() string {
+	switch GetMode() {
+	case CG1:
+		return "reserve"
+	case CG2:
+		return "reserve.slice"
+	default:
+		return ""
+	}
+}
+
+// GetPartitionFromCores returns the name of the cgroup that should contain
+// the cgroup of the task, which is determined by inspecting the cores
+// parameter, which is a non-empty string if the task is using reserved
+// cores.
+func GetPartitionFromCores(cores string) string {
+	if cores == "" {
+		return SharePartition()
+	}
+	return ReservePartition()
+}
+
+// GetPartitionFromBool returns the name of the cgroup that should contain
+// the cgroup of the task, which is determined from the cores parameter,
+// which indicates whether the task is making use of reserved cores.
+func GetPartitionFromBool(cores bool) string {
+	if cores {
+		return ReservePartition()
+	}
+	return SharePartition()
+}

--- a/client/lib/cgroupslib/partition_default.go
+++ b/client/lib/cgroupslib/partition_default.go
@@ -1,0 +1,16 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !linux
+
+package cgroupslib
+
+import (
+	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
+)
+
+// GetPartition creates a no-op Partition that does not do anything.
+func GetPartition(*idset.Set[hw.CoreID]) Partition {
+	return NoopPartition()
+}

--- a/client/lib/cgroupslib/partition_linux.go
+++ b/client/lib/cgroupslib/partition_linux.go
@@ -1,0 +1,98 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build linux
+
+package cgroupslib
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
+)
+
+// GetPartition creates a Partition suitable for managing cores on this
+// Linux system.
+func GetPartition(cores *idset.Set[hw.CoreID]) Partition {
+	return NewPartition(cores)
+}
+
+// NewPartition creates a cpuset partition manager for managing the books
+// when allocations are created and destroyed. The initial set of cores is
+// the usable set of cores by Nomad.
+func NewPartition(cores *idset.Set[hw.CoreID]) Partition {
+	var (
+		sharePath   string
+		reservePath string
+	)
+
+	switch GetMode() {
+	case OFF:
+		return NoopPartition()
+	case CG1:
+		sharePath = filepath.Join(root, "cpuset", NomadCgroupParent, SharePartition(), "cpuset.cpus")
+		reservePath = filepath.Join(root, "cpuset", NomadCgroupParent, ReservePartition(), "cpuset.cpus")
+	case CG2:
+		sharePath = filepath.Join(root, NomadCgroupParent, SharePartition(), "cpuset.cpus")
+		reservePath = filepath.Join(root, NomadCgroupParent, ReservePartition(), "cpuset.cpus")
+	}
+
+	return &partition{
+		sharePath:   sharePath,
+		reservePath: reservePath,
+		share:       cores.Copy(),
+		reserve:     idset.Empty[hw.CoreID](),
+	}
+}
+
+type partition struct {
+	sharePath   string
+	reservePath string
+
+	lock    sync.Mutex
+	share   *idset.Set[hw.CoreID]
+	reserve *idset.Set[hw.CoreID]
+}
+
+func (p *partition) Restore(cores *idset.Set[hw.CoreID]) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.share.RemoveSet(cores)
+	p.reserve.InsertSet(cores)
+}
+
+func (p *partition) Reserve(cores *idset.Set[hw.CoreID]) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.share.RemoveSet(cores)
+	p.reserve.InsertSet(cores)
+
+	return p.write()
+}
+
+func (p *partition) Release(cores *idset.Set[hw.CoreID]) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.reserve.RemoveSet(cores)
+	p.share.InsertSet(cores)
+
+	return p.write()
+}
+
+func (p *partition) write() error {
+	shareStr := p.share.String()
+	if err := os.WriteFile(p.sharePath, []byte(shareStr), 0644); err != nil {
+		return err
+	}
+	reserveStr := p.reserve.String()
+	if err := os.WriteFile(p.reservePath, []byte(reserveStr), 0644); err != nil {
+		return err
+	}
+	return nil
+}

--- a/client/lib/cgroupslib/partition_noop.go
+++ b/client/lib/cgroupslib/partition_noop.go
@@ -1,0 +1,25 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package cgroupslib
+
+import (
+	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
+)
+
+func NoopPartition() Partition {
+	return new(noop)
+}
+
+type noop struct{}
+
+func (p *noop) Reserve(*idset.Set[hw.CoreID]) error {
+	return nil
+}
+
+func (p *noop) Release(*idset.Set[hw.CoreID]) error {
+	return nil
+}
+
+func (p *noop) Restore(*idset.Set[hw.CoreID]) {}

--- a/client/lib/cgroupslib/partition_test.go
+++ b/client/lib/cgroupslib/partition_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build linux
+
+package cgroupslib
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
+	"github.com/shoenig/test/must"
+)
+
+// testPartition creates a fresh partition configured with cores 10-20.
+func testPartition(t *testing.T) *partition {
+	dir := t.TempDir()
+	shareFile := filepath.Join(dir, "share.cpus")
+	reserveFile := filepath.Join(dir, "reserve.cpus")
+	return &partition{
+		sharePath:   shareFile,
+		reservePath: reserveFile,
+		share:       idset.From[hw.CoreID]([]hw.CoreID{10, 11, 12, 13, 14, 15, 16, 17, 18, 19}),
+		reserve:     idset.Empty[hw.CoreID](),
+	}
+}
+
+func coreset(ids ...hw.CoreID) *idset.Set[hw.CoreID] {
+	return idset.From[hw.CoreID](ids)
+}
+
+func TestPartition_Restore(t *testing.T) {
+	p := testPartition(t)
+
+	must.NotEmpty(t, p.share)
+	must.Empty(t, p.reserve)
+
+	p.Restore(coreset(11, 13))
+	p.Restore(coreset(15, 16, 17))
+	p.Restore(coreset(10, 19))
+
+	expShare := idset.From[hw.CoreID]([]hw.CoreID{12, 14, 18})
+	expReserve := idset.From[hw.CoreID]([]hw.CoreID{11, 13, 15, 16, 17, 10, 19})
+
+	must.Eq(t, expShare, p.share)
+	must.Eq(t, expReserve, p.reserve)
+
+	// restore does not write to the cgroup interface
+	must.FileNotExists(t, p.sharePath)
+	must.FileNotExists(t, p.reservePath)
+}
+
+func TestPartition_Reserve(t *testing.T) {
+	p := testPartition(t)
+
+	p.Reserve(coreset(10, 15, 19))
+	p.Reserve(coreset(12, 13))
+
+	expShare := idset.From[hw.CoreID]([]hw.CoreID{11, 14, 16, 17, 18})
+	expReserve := idset.From[hw.CoreID]([]hw.CoreID{10, 12, 13, 15, 19})
+
+	must.Eq(t, expShare, p.share)
+	must.Eq(t, expReserve, p.reserve)
+
+	must.FileContains(t, p.sharePath, "11,14,16-18")
+	must.FileContains(t, p.reservePath, "10,12-13,15,19")
+}
+
+func TestPartition_Release(t *testing.T) {
+	p := testPartition(t)
+
+	// some reservations
+	p.Reserve(coreset(10, 15, 19))
+	p.Reserve(coreset(12, 13))
+	p.Reserve(coreset(11, 18))
+
+	must.FileContains(t, p.sharePath, "14,16-17")
+	must.FileContains(t, p.reservePath, "10-13,15,18-19")
+
+	// release 1
+	p.Release(coreset(12, 13))
+	must.FileContains(t, p.sharePath, "12-14,16-17")
+	must.FileContains(t, p.reservePath, "10-11,15,18-19")
+
+	// release 2
+	p.Release(coreset(10, 15, 19))
+	must.FileContains(t, p.sharePath, "10,12-17,19")
+	must.FileContains(t, p.reservePath, "11,18")
+
+	// release 3
+	p.Release(coreset(11, 18))
+	must.FileContains(t, p.sharePath, "10-19")
+	must.FileContains(t, p.reservePath, "")
+}

--- a/client/lib/cgroupslib/testing.go
+++ b/client/lib/cgroupslib/testing.go
@@ -1,0 +1,53 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package cgroupslib
+
+import (
+	"sync"
+
+	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
+)
+
+// MockPartition creates an in-memory Partition manager backed by 8 fake cpu cores.
+func MockPartition() Partition {
+	return &mock{
+		share:   idset.From[hw.CoreID]([]hw.CoreID{0, 1, 2, 3, 4, 5, 6, 7}),
+		reserve: idset.Empty[hw.CoreID](),
+	}
+}
+
+type mock struct {
+	lock    sync.Mutex
+	share   *idset.Set[hw.CoreID]
+	reserve *idset.Set[hw.CoreID]
+}
+
+func (m *mock) Restore(cores *idset.Set[hw.CoreID]) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.share.RemoveSet(cores)
+	m.reserve.InsertSet(cores)
+}
+
+func (m *mock) Reserve(cores *idset.Set[hw.CoreID]) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.reserve.RemoveSet(cores)
+	m.share.InsertSet(cores)
+
+	return nil
+}
+
+func (m *mock) Release(cores *idset.Set[hw.CoreID]) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.reserve.RemoveSet(cores)
+	m.share.InsertSet(cores)
+
+	return nil
+}

--- a/client/lib/idset/idset.go
+++ b/client/lib/idset/idset.go
@@ -17,6 +17,8 @@ import (
 
 // An ID is representative of a non-negative identifier of something like
 // a CPU core ID, a NUMA node ID, etc.
+//
+// See the hwids package for typical use cases.
 type ID interface {
 	~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uint
 }
@@ -35,6 +37,11 @@ func Empty[T ID]() *Set[T] {
 	return &Set[T]{
 		items: set.New[T](0),
 	}
+}
+
+// Copy creates a deep copy of s.
+func (s *Set[T]) Copy() *Set[T] {
+	return &Set[T]{items: s.items.Copy()}
 }
 
 var (
@@ -108,10 +115,24 @@ func (s *Set[T]) Slice() []T {
 	return items
 }
 
+// InsertSet inserts all items of other into s.
+func (s *Set[T]) InsertSet(other *Set[T]) {
+	s.items.InsertSet(other.items)
+}
+
+// RemoveSet removes all items of other from s.
+func (s *Set[T]) RemoveSet(other *Set[T]) {
+	s.items.RemoveSet(other.items)
+}
+
 // String creates a well-formed cpuset string representation of the Set.
 func (s *Set[T]) String() string {
 	if s.items.Empty() {
-		return ""
+		// cgroups notation uses a space (or newline) to indicate
+		// "empty"; and this value is written to cgroups interface
+		// files
+		const empty = " "
+		return empty
 	}
 
 	var parts []string

--- a/client/lib/numalib/detect.go
+++ b/client/lib/numalib/detect.go
@@ -5,6 +5,7 @@ package numalib
 
 import (
 	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
 )
 
 // A SystemScanner represents one methodology of detecting CPU hardware on a
@@ -35,7 +36,7 @@ type ConfigScanner struct {
 	// Only meaningful on Linux, this value can be used to override the set of
 	// CPU core IDs we may make use of. Normally these are detected by reading
 	// Nomad parent cgroup cpuset interface file.
-	ReservableCores *idset.Set[CoreID]
+	ReservableCores *idset.Set[hw.CoreID]
 
 	// TotalCompute comes from client.cpu_total_compute.
 	//
@@ -49,7 +50,7 @@ type ConfigScanner struct {
 	// ReservedCores comes from client.reserved.cores.
 	//
 	// Used to withhold a set of cores from being used by Nomad for scheduling.
-	ReservedCores *idset.Set[CoreID]
+	ReservedCores *idset.Set[hw.CoreID]
 
 	// ReservedCompute comes from client.reserved.cpu.
 	//

--- a/client/lib/numalib/detect_darwin.go
+++ b/client/lib/numalib/detect_darwin.go
@@ -7,6 +7,7 @@ package numalib
 
 import (
 	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
 	"github.com/shoenig/go-m1cpu"
 	"golang.org/x/sys/unix"
 )
@@ -19,8 +20,8 @@ func PlatformScanners() []SystemScanner {
 }
 
 const (
-	nodeID   = NodeID(0)
-	socketID = SocketID(0)
+	nodeID   = hw.NodeID(0)
+	socketID = hw.SocketID(0)
 	maxSpeed = KHz(0)
 )
 
@@ -29,7 +30,7 @@ type MacOS struct{}
 
 func (m *MacOS) ScanSystem(top *Topology) {
 	// all apple hardware is non-numa; just assume as much
-	top.NodeIDs = idset.Empty[NodeID]()
+	top.NodeIDs = idset.Empty[hw.NodeID]()
 	top.NodeIDs.Insert(nodeID)
 
 	// arch specific detection
@@ -49,7 +50,7 @@ func (m *MacOS) scanAppleSilicon(top *Topology) {
 	eCoreSpeed := KHz(m1cpu.ECoreHz() / 1000)
 
 	top.Cores = make([]Core, pCoreCount+eCoreCount)
-	nthCore := CoreID(0)
+	nthCore := hw.CoreID(0)
 
 	for i := 0; i < pCoreCount; i++ {
 		top.insert(nodeID, socketID, nthCore, performance, maxSpeed, pCoreSpeed)
@@ -69,6 +70,6 @@ func (m *MacOS) scanLegacyX86(top *Topology) {
 
 	top.Cores = make([]Core, coreCount)
 	for i := 0; i < int(coreCount); i++ {
-		top.insert(nodeID, socketID, CoreID(i), performance, maxSpeed, coreSpeed)
+		top.insert(nodeID, socketID, hw.CoreID(i), performance, maxSpeed, coreSpeed)
 	}
 }

--- a/client/lib/numalib/detect_default.go
+++ b/client/lib/numalib/detect_default.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
 	"github.com/shirou/gopsutil/v3/cpu"
 )
 
@@ -22,8 +23,8 @@ func PlatformScanners() []SystemScanner {
 }
 
 const (
-	nodeID   = NodeID(0)
-	socketID = SocketID(0)
+	nodeID   = hw.NodeID(0)
+	socketID = hw.SocketID(0)
 	maxSpeed = KHz(0)
 )
 
@@ -34,7 +35,7 @@ type Generic struct{}
 func (g *Generic) ScanSystem(top *Topology) {
 	// hardware may or may not be NUMA, but for now we only
 	// detect such topology on linux systems
-	top.NodeIDs = idset.Empty[NodeID]()
+	top.NodeIDs = idset.Empty[hw.NodeID]()
 	top.NodeIDs.Insert(nodeID)
 
 	// cores
@@ -55,6 +56,6 @@ func (g *Generic) ScanSystem(top *Topology) {
 	for i := 0; i < count; i++ {
 		info := infos[0]
 		speed := KHz(MHz(info.Mhz) * 1000)
-		top.insert(nodeID, socketID, CoreID(i), performance, maxSpeed, speed)
+		top.insert(nodeID, socketID, hw.CoreID(i), performance, maxSpeed, speed)
 	}
 }

--- a/client/lib/numalib/detect_linux.go
+++ b/client/lib/numalib/detect_linux.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
 )
 
 // PlatformScanners returns the set of SystemScanner for Linux.
@@ -59,7 +60,7 @@ func (*Sysfs) available() bool {
 }
 
 func (*Sysfs) discoverOnline(st *Topology) {
-	ids, err := getIDSet[NodeID](nodeOnline)
+	ids, err := getIDSet[hw.NodeID](nodeOnline)
 	if err == nil {
 		st.NodeIDs = ids
 	}
@@ -72,7 +73,7 @@ func (*Sysfs) discoverCosts(st *Topology) {
 		st.Distances[i] = make([]Cost, dimension)
 	}
 
-	_ = st.NodeIDs.ForEach(func(id NodeID) error {
+	_ = st.NodeIDs.ForEach(func(id hw.NodeID) error {
 		s, err := getString(distanceFile, id)
 		if err != nil {
 			return err
@@ -87,25 +88,25 @@ func (*Sysfs) discoverCosts(st *Topology) {
 }
 
 func (*Sysfs) discoverCores(st *Topology) {
-	onlineCores, err := getIDSet[CoreID](cpuOnline)
+	onlineCores, err := getIDSet[hw.CoreID](cpuOnline)
 	if err != nil {
 		return
 	}
 	st.Cores = make([]Core, onlineCores.Size())
 
-	_ = st.NodeIDs.ForEach(func(node NodeID) error {
+	_ = st.NodeIDs.ForEach(func(node hw.NodeID) error {
 		s, err := os.ReadFile(fmt.Sprintf(cpulistFile, node))
 		if err != nil {
 			return err
 		}
 
-		cores := idset.Parse[CoreID](string(s))
-		_ = cores.ForEach(func(core CoreID) error {
+		cores := idset.Parse[hw.CoreID](string(s))
+		_ = cores.ForEach(func(core hw.CoreID) error {
 			// best effort, zero values are defaults
-			socket, _ := getNumeric[SocketID](cpuSocketFile, core)
+			socket, _ := getNumeric[hw.SocketID](cpuSocketFile, core)
 			max, _ := getNumeric[KHz](cpuMaxFile, core)
 			base, _ := getNumeric[KHz](cpuBaseFile, core)
-			siblings, _ := getIDSet[CoreID](cpuSiblingFile, core)
+			siblings, _ := getIDSet[hw.CoreID](cpuSiblingFile, core)
 			st.insert(node, socket, core, gradeOf(siblings), max, base)
 			return nil
 		})
@@ -182,7 +183,7 @@ func (s *Cgroups2) ScanSystem(top *Topology) {
 
 // combine scanCgroups
 func scanIDs(top *Topology, content string) {
-	ids := idset.Parse[CoreID](content)
+	ids := idset.Parse[hw.CoreID](content)
 	for _, cpu := range top.Cores {
 		if !ids.Contains(cpu.ID) {
 			cpu.Disable = true

--- a/client/lib/numalib/hw/ids.go
+++ b/client/lib/numalib/hw/ids.go
@@ -1,0 +1,20 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package hw provides types for identifying hardware.
+//
+// This is a separate "leaf" package that is easy to import from many other
+// packages without creating circular imports.
+package hw
+
+type (
+	// A NodeID represents a NUMA node. There could be more than
+	// one NUMA node per socket.
+	NodeID uint8
+
+	// A SocketID represents a physicsl CPU socket.
+	SocketID uint8
+
+	// A CoreID represents one logical (vCPU) core.
+	CoreID uint16
+)

--- a/client/lib/proclib/config.go
+++ b/client/lib/proclib/config.go
@@ -5,6 +5,8 @@ package proclib
 
 import (
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
 )
 
 // Configs is used to pass along values from client configuration that are
@@ -12,4 +14,8 @@ import (
 // was set in agent configuration.
 type Configs struct {
 	Logger hclog.Logger
+
+	// UsableCores is the actual set of cpu cores Nomad is able and
+	// allowed to use.
+	UsableCores *idset.Set[hw.CoreID]
 }

--- a/client/lib/proclib/testing.go
+++ b/client/lib/proclib/testing.go
@@ -1,0 +1,38 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package proclib
+
+import (
+	"github.com/hashicorp/nomad/helper/testlog"
+	testing "github.com/mitchellh/go-testing-interface"
+)
+
+func MockWranglers(t testing.T) *Wranglers {
+	return &Wranglers{
+		configs: &Configs{
+			Logger: testlog.HCLogger(t),
+		},
+		m:      make(map[Task]ProcessWrangler),
+		create: mocks,
+	}
+}
+
+func mocks(Task) ProcessWrangler {
+	return new(mock)
+}
+
+type mock struct {
+}
+
+func (m *mock) Initialize() error {
+	return nil
+}
+
+func (m *mock) Kill() error {
+	return nil
+}
+
+func (m *mock) Cleanup() error {
+	return nil
+}

--- a/client/lib/proclib/wrangler.go
+++ b/client/lib/proclib/wrangler.go
@@ -9,10 +9,12 @@ import (
 )
 
 // Task records the unique coordinates of a task from the perspective of a Nomad
-// client running the task, that is to say (alloc_id, task_name).
+// client running the task, that is to say (alloc_id, task_name). Also indicates
+// whether the task is making use of reserved cpu cores.
 type Task struct {
 	AllocID string
 	Task    string
+	Cores   bool
 }
 
 func (task Task) String() string {

--- a/client/lib/proclib/wrangler_cg1_linux.go
+++ b/client/lib/proclib/wrangler_cg1_linux.go
@@ -25,12 +25,12 @@ type LinuxWranglerCG1 struct {
 
 func newCG1(c *Configs) create {
 	logger := c.Logger.Named("cg1")
-	cgroupslib.Init(logger)
+	cgroupslib.Init(logger, c.UsableCores.String())
 	return func(task Task) ProcessWrangler {
 		return &LinuxWranglerCG1{
 			task: task,
 			log:  logger,
-			cg:   cgroupslib.Factory(task.AllocID, task.Task),
+			cg:   cgroupslib.Factory(task.AllocID, task.Task, task.Cores),
 		}
 	}
 }

--- a/client/lib/proclib/wrangler_cg2_linux.go
+++ b/client/lib/proclib/wrangler_cg2_linux.go
@@ -22,12 +22,12 @@ type LinuxWranglerCG2 struct {
 
 func newCG2(c *Configs) create {
 	logger := c.Logger.Named("cg2")
-	cgroupslib.Init(logger)
+	cgroupslib.Init(logger, c.UsableCores.String())
 	return func(task Task) ProcessWrangler {
 		return &LinuxWranglerCG2{
 			task: task,
 			log:  c.Logger,
-			cg:   cgroupslib.Factory(task.AllocID, task.Task),
+			cg:   cgroupslib.Factory(task.AllocID, task.Task, task.Cores),
 		}
 	}
 }

--- a/client/state/upgrade_int_test.go
+++ b/client/state/upgrade_int_test.go
@@ -20,6 +20,7 @@ import (
 	clientconfig "github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/devicemanager"
 	dmstate "github.com/hashicorp/nomad/client/devicemanager/state"
+	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/client/lib/proclib"
 	"github.com/hashicorp/nomad/client/pluginmanager/drivermanager"
 	regMock "github.com/hashicorp/nomad/client/serviceregistration/mock"
@@ -214,7 +215,8 @@ func checkUpgradedAlloc(t *testing.T, path string, db StateDB, alloc *structs.Al
 		PrevAllocMigrator: allocwatcher.NoopPrevAlloc{},
 		DeviceManager:     devicemanager.NoopMockManager(),
 		DriverManager:     drivermanager.TestDriverManager(t),
-		Wranglers:         proclib.New(&proclib.Configs{Logger: testlog.HCLogger(t)}),
+		Wranglers:         proclib.MockWranglers(t),
+		Partitions:        cgroupslib.MockPartition(),
 	}
 	ar, err := allocrunner.NewAllocRunner(conf)
 	require.NoError(t, err)

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -261,7 +261,7 @@ type ClientConfig struct {
 	DiskFreeMB int `hcl:"disk_free_mb"`
 
 	// ReservableCores is used to override detected reservable cpu cores.
-	ReserveableCores string `hcl:"reservable_cores"`
+	ReservableCores string `hcl:"reservable_cores"`
 
 	// MaxKillTimeout allows capping the user-specifiable KillTimeout.
 	MaxKillTimeout string `hcl:"max_kill_timeout"`
@@ -1271,10 +1271,10 @@ func DevConfig(mode *devModeConfig) *Config {
 	conf.Client.Options[fingerprint.TightenNetworkTimeoutsConfig] = "true"
 	conf.Client.BindWildcardDefaultHostNetwork = true
 	conf.Client.NomadServiceDiscovery = pointer.Of(true)
+	conf.Client.ReservableCores = "" // inherit all the cores
 	conf.Telemetry.PrometheusMetrics = true
 	conf.Telemetry.PublishAllocationMetrics = true
 	conf.Telemetry.PublishNodeMetrics = true
-
 	return conf
 }
 
@@ -2161,8 +2161,8 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	} else if b.Reserved != nil {
 		result.Reserved = result.Reserved.Merge(b.Reserved)
 	}
-	if b.ReserveableCores != "" {
-		result.ReserveableCores = b.ReserveableCores
+	if b.ReservableCores != "" {
+		result.ReservableCores = b.ReservableCores
 	}
 	if b.GCInterval != 0 {
 		result.GCInterval = b.GCInterval

--- a/command/agent/consul/int_test.go
+++ b/command/agent/consul/int_test.go
@@ -170,7 +170,7 @@ func TestConsul_Integration(t *testing.T) {
 		DriverManager:       drivermanager.TestDriverManager(t),
 		StartConditionMetCh: closedCh,
 		ServiceRegWrapper:   wrapper.NewHandlerWrapper(logger, serviceClient, regMock.NewServiceRegistrationHandler(logger)),
-		Wranglers:           proclib.New(&proclib.Configs{Logger: testlog.HCLogger(t)}),
+		Wranglers:           proclib.MockWranglers(t),
 	}
 
 	tr, err := taskrunner.NewTaskRunner(config)

--- a/drivers/docker/cpuset.go
+++ b/drivers/docker/cpuset.go
@@ -1,0 +1,76 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/hashicorp/nomad/helper"
+)
+
+const (
+	// cpusetSyncPeriod is how often we check to see if the cpuset of a task
+	// needs to be updated - if there is no work to do, no action is taken
+	cpusetSyncPeriod = 3 * time.Second
+)
+
+// cpuset is used to manage the cpuset.cpus interface file in the cgroup that
+// docker daemon creates for the container being run by the task driver. we
+// must do this hack because docker does not allow
+type cpuset struct {
+	doneCh      <-chan bool
+	source      string
+	destination string
+	previous    string
+	sync        func(string, string)
+}
+
+func (c *cpuset) watch() {
+	if c.sync == nil {
+		// use the real thing if we are not doing tests
+		c.sync = c.copyCpuset
+	}
+
+	ticks, cancel := helper.NewSafeTimer(cpusetSyncPeriod)
+	defer cancel()
+
+	for {
+		select {
+		case <-c.doneCh:
+			return
+		case <-ticks.C:
+			c.sync(c.source, c.destination)
+			ticks.Reset(cpusetSyncPeriod)
+		}
+	}
+}
+
+func (c *cpuset) copyCpuset(source, destination string) {
+	source = filepath.Join(source, "cpuset.cpus.effective")
+	destination = filepath.Join(destination, "cpuset.cpus")
+
+	// read the current value of usable cores
+	b, err := os.ReadFile(source)
+	if err != nil {
+		return
+	}
+
+	// if the current value is the same as the value we wrote last,
+	// there is nothing to do
+	current := string(b)
+	if current == c.previous {
+		return
+	}
+
+	// otherwise write the new value
+	err = os.WriteFile(destination, b, 0644)
+	if err != nil {
+		return
+	}
+
+	// we wrote a new value; store that value so we do not write it again
+	c.previous = current
+}

--- a/drivers/docker/cpuset_test.go
+++ b/drivers/docker/cpuset_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package docker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
+)
+
+func Test_cpuset_watch(t *testing.T) {
+	ci.Parallel(t)
+
+	doneCh := make(chan bool)
+
+	source := "/source"
+	destination := "/destination"
+	hits := 0
+
+	callback := func(s, d string) {
+		must.Eq(t, source, s)
+		must.Eq(t, destination, d)
+		hits++
+	}
+
+	c := &cpuset{
+		doneCh:      doneCh,
+		source:      "/source",
+		destination: "/destination",
+		previous:    "",
+		sync:        callback,
+	}
+	go c.watch()
+
+	time.Sleep(3*time.Second + 10*time.Millisecond)
+	doneCh <- true
+
+	must.Eq(t, 1, hits)
+}

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -1560,6 +1560,8 @@ func TestDockerDriver_Init(t *testing.T) {
 }
 
 func TestDockerDriver_CPUSetCPUs(t *testing.T) {
+	// The cpuset_cpus config option is ignored starting in Nomad 1.6
+
 	ci.Parallel(t)
 	testutil.DockerCompatible(t)
 	testutil.CgroupsCompatible(t)
@@ -1570,15 +1572,15 @@ func TestDockerDriver_CPUSetCPUs(t *testing.T) {
 	}{
 		{
 			Name:       "Single CPU",
-			CPUSetCPUs: "0",
+			CPUSetCPUs: "",
 		},
 		{
 			Name:       "Comma separated list of CPUs",
-			CPUSetCPUs: "0,1",
+			CPUSetCPUs: "",
 		},
 		{
 			Name:       "Range of CPUs",
-			CPUSetCPUs: "0-1",
+			CPUSetCPUs: "",
 		},
 	}
 
@@ -1587,16 +1589,16 @@ func TestDockerDriver_CPUSetCPUs(t *testing.T) {
 			task, cfg, _ := dockerTask(t)
 
 			cfg.CPUSetCPUs = testCase.CPUSetCPUs
-			require.NoError(t, task.EncodeConcreteDriverConfig(cfg))
+			must.NoError(t, task.EncodeConcreteDriverConfig(cfg))
 
 			client, d, handle, cleanup := dockerSetup(t, task, nil)
 			defer cleanup()
-			require.NoError(t, d.WaitUntilStarted(task.ID, 5*time.Second))
+			must.NoError(t, d.WaitUntilStarted(task.ID, 5*time.Second))
 
 			container, err := client.InspectContainer(handle.containerID)
-			require.NoError(t, err)
+			must.NoError(t, err)
 
-			require.Equal(t, cfg.CPUSetCPUs, container.HostConfig.CPUSetCPUs)
+			must.Eq(t, cfg.CPUSetCPUs, container.HostConfig.CPUSetCPUs)
 		})
 	}
 }

--- a/drivers/docker/handle.go
+++ b/drivers/docker/handle.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/consul-template/signals"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
-
+	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/drivers/docker/docklog"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	pstructs "github.com/hashicorp/nomad/plugins/shared/structs"
@@ -41,6 +41,7 @@ type taskHandle struct {
 	dloggerPluginClient   *plugin.Client
 	task                  *drivers.TaskConfig
 	containerID           string
+	containerCgroup       string
 	containerImage        string
 	doneCh                chan bool
 	waitCh                chan struct{}
@@ -243,8 +244,41 @@ func (h *taskHandle) shutdownLogger() {
 	h.dloggerPluginClient.Kill()
 }
 
+func (h *taskHandle) startCpusetFixer() {
+	if cgroupslib.GetMode() == cgroupslib.OFF {
+		return
+	}
+
+	if h.task.Resources.LinuxResources.CpusetCpus != "" {
+		// nothing to fixup if the task is given static cores
+		return
+	}
+
+	cgroup := h.containerCgroup
+	if cgroup == "" {
+		// The api does not actually set this value, so we are left to compute it ourselves.
+		// Luckily this is documented,
+		// https://docs.docker.com/config/containers/runmetrics/#find-the-cgroup-for-a-given-container
+		switch cgroupslib.GetMode() {
+		case cgroupslib.CG1:
+			cgroup = "/sys/fs/cgroup/cpuset/docker/" + h.containerID
+		default:
+			// systemd driver; not sure if we need to consider cgroupfs driver
+			cgroup = "/sys/fs/cgroup/system.slice/docker-" + h.containerID + ".scope"
+		}
+	}
+
+	go (&cpuset{
+		doneCh:      h.doneCh,
+		source:      h.task.Resources.LinuxResources.CpusetCgroupPath,
+		destination: cgroup,
+	}).watch()
+}
+
 func (h *taskHandle) run() {
 	defer h.shutdownLogger()
+
+	h.startCpusetFixer()
 
 	exitCode, werr := h.infinityClient.WaitContainer(h.containerID)
 	if werr != nil {

--- a/drivers/exec/driver_test.go
+++ b/drivers/exec/driver_test.go
@@ -57,7 +57,7 @@ func testResources(allocID, task string) *drivers.Resources {
 		LinuxResources: &drivers.LinuxResources{
 			MemoryLimitBytes: 134217728,
 			CPUShares:        100,
-			CpusetCgroupPath: cgroupslib.LinuxResourcesPath(allocID, task),
+			CpusetCgroupPath: cgroupslib.LinuxResourcesPath(allocID, task, false),
 		},
 	}
 

--- a/drivers/java/driver_test.go
+++ b/drivers/java/driver_test.go
@@ -299,7 +299,7 @@ func basicTask(t *testing.T, name string, taskConfig *TaskConfig) *drivers.TaskC
 			LinuxResources: &drivers.LinuxResources{
 				MemoryLimitBytes: 134217728,
 				CPUShares:        100,
-				CpusetCgroupPath: cgroupslib.LinuxResourcesPath(allocID, name),
+				CpusetCgroupPath: cgroupslib.LinuxResourcesPath(allocID, name, false),
 			},
 		},
 	}

--- a/drivers/rawexec/driver_test.go
+++ b/drivers/rawexec/driver_test.go
@@ -58,7 +58,7 @@ func testResources(allocID, task string) *drivers.Resources {
 		LinuxResources: &drivers.LinuxResources{
 			MemoryLimitBytes: 134217728,
 			CPUShares:        100,
-			CpusetCgroupPath: cgroupslib.LinuxResourcesPath(allocID, task),
+			CpusetCgroupPath: cgroupslib.LinuxResourcesPath(allocID, task, false),
 		},
 	}
 

--- a/drivers/shared/executor/executor.go
+++ b/drivers/shared/executor/executor.go
@@ -21,6 +21,7 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/client/allocdir"
+	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/client/lib/cpustats"
 	"github.com/hashicorp/nomad/client/lib/fifo"
 	"github.com/hashicorp/nomad/client/lib/numalib"
@@ -158,19 +159,42 @@ type ExecCommand struct {
 	Capabilities []string
 }
 
-// Cgroup returns the path to the cgroup the Nomad client is managing for the
-// task that is about to be run.
+// CpusetCgroup returns the path to the cgroup in which the Nomad client will
+// write the PID of the task process for managing cpu core usage.
 //
 // On cgroups v1 systems this returns the path to the cpuset cgroup specifically.
+// Critical: is "/reserve/<id>" or "/share"; do not try to parse this!
 //
-// On cgroups v2 systems this returns the patah to the task's scope.
+// On cgroups v2 systems this just returns the unified cgroup.
 //
 // On non-Linux systems this returns the empty string and has no meaning.
-func (c *ExecCommand) Cgroup() string {
+func (c *ExecCommand) CpusetCgroup() string {
 	if c == nil || c.Resources == nil || c.Resources.LinuxResources == nil {
 		return ""
 	}
 	return c.Resources.LinuxResources.CpusetCgroupPath
+}
+
+// StatsCgroup returns the path to the cgroup Nomad client will use to inspect
+// for spawned process IDs.
+//
+// On cgroups v1 systems this returns the path to the freezer cgroup.
+//
+// On cgroups v2 systems this just returns the unified cgroup.
+//
+// On non-Linux systems this returns the empty string and has no meaning.
+func (c *ExecCommand) StatsCgroup() string {
+	if c == nil || c.Resources == nil || c.Resources.LinuxResources == nil {
+		return ""
+	}
+	switch cgroupslib.GetMode() {
+	case cgroupslib.CG1:
+		taskName := filepath.Base(c.TaskDir)
+		allocID := filepath.Base(filepath.Dir(c.TaskDir))
+		return cgroupslib.PathCG1(allocID, taskName, "freezer")
+	default:
+		return c.CpusetCgroup()
+	}
 }
 
 // SetWriters sets the writer for the process stdout and stderr. This should
@@ -364,7 +388,7 @@ func (e *UniversalExecutor) Exec(deadline time.Time, name string, args []string)
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
 
-	if cleanup, err := e.setSubCmdCgroup(&e.childCmd, e.command.Cgroup()); err != nil {
+	if cleanup, err := e.setSubCmdCgroup(&e.childCmd, e.command.StatsCgroup()); err != nil {
 		return nil, 0, err
 	} else {
 		defer cleanup()
@@ -455,7 +479,7 @@ func (e *UniversalExecutor) ExecStreaming(ctx context.Context, command []string,
 					return err
 				}
 			}
-			cgroup := e.command.Cgroup()
+			cgroup := e.command.StatsCgroup()
 			if cleanup, err := e.setSubCmdCgroup(cmd, cgroup); err != nil {
 				return err
 			} else {

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -78,13 +78,18 @@ func testExecutorCommandWithChroot(t *testing.T) *testExecCmd {
 		t.Fatalf("allocDir.NewTaskDir(%q) failed: %v", task.Name, err)
 	}
 	td := allocDir.TaskDirs[task.Name]
+
 	cmd := &ExecCommand{
 		Env:     taskEnv.List(),
 		TaskDir: td.Dir,
 		Resources: &drivers.Resources{
 			NomadResources: alloc.AllocatedResources.Tasks[task.Name],
 			LinuxResources: &drivers.LinuxResources{
-				CpusetCgroupPath: cgroupslib.LinuxResourcesPath(alloc.ID, task.Name),
+				CpusetCgroupPath: cgroupslib.LinuxResourcesPath(
+					alloc.ID,
+					task.Name,
+					alloc.AllocatedResources.UsesCores(),
+				),
 			},
 		},
 	}

--- a/drivers/shared/executor/executor_test.go
+++ b/drivers/shared/executor/executor_test.go
@@ -91,13 +91,13 @@ func testExecutorCommand(t *testing.T) *testExecCmd {
 			LinuxResources: &drivers.LinuxResources{
 				CPUShares:        500,
 				MemoryLimitBytes: 256 * 1024 * 1024,
-				CpusetCgroupPath: cgroupslib.LinuxResourcesPath(alloc.ID, task.Name),
+				CpusetCgroupPath: cgroupslib.LinuxResourcesPath(alloc.ID, task.Name, false),
 			},
 		},
 	}
 
 	// create cgroup for our task (because we aren't using task runners)
-	f := cgroupslib.Factory(alloc.ID, task.Name)
+	f := cgroupslib.Factory(alloc.ID, task.Name, false)
 	must.NoError(t, f.Setup())
 
 	// cleanup cgroup once test is done (because no task runners)

--- a/drivers/shared/executor/executor_universal_linux.go
+++ b/drivers/shared/executor/executor_universal_linux.go
@@ -107,10 +107,10 @@ func (e *UniversalExecutor) statCG(cgroup string) (int, func(), error) {
 
 // configureResourceContainer on Linux configures the cgroups to be used to track
 // pids created by the executor
+//
+// pid: pid of the executor (i.e. ourself)
 func (e *UniversalExecutor) configureResourceContainer(command *ExecCommand, pid int) (func(), error) {
-
-	// get our cgroup reference (cpuset in v1)
-	cgroup := command.Cgroup()
+	cgroup := command.StatsCgroup()
 
 	// cgCleanup will be called after the task has been launched
 	// v1: remove the executor process from the task's cgroups
@@ -121,7 +121,7 @@ func (e *UniversalExecutor) configureResourceContainer(command *ExecCommand, pid
 	switch cgroupslib.GetMode() {
 	case cgroupslib.CG1:
 		e.configureCG1(cgroup, command)
-		cgCleanup = e.enterCG1(cgroup)
+		cgCleanup = e.enterCG1(cgroup, command.CpusetCgroup())
 	default:
 		e.configureCG2(cgroup, command)
 		// configure child process to spawn in the cgroup
@@ -144,17 +144,24 @@ func (e *UniversalExecutor) configureResourceContainer(command *ExecCommand, pid
 // created for the task - so that the task and its children will spawn in
 // those cgroups. The cleanup function moves the executor out of the task's
 // cgroups and into the nomad/ parent cgroups.
-func (e *UniversalExecutor) enterCG1(cgroup string) func() {
+func (e *UniversalExecutor) enterCG1(statsCgroup, cpusetCgroup string) func() {
 	pid := strconv.Itoa(unix.Getpid())
 
-	// write pid to all the groups
-	ifaces := []string{"freezer", "cpu", "memory"} // todo: cpuset
+	// write pid to all the normal interfaces
+	ifaces := []string{"freezer", "cpu", "memory"}
 	for _, iface := range ifaces {
-		ed := cgroupslib.OpenFromCpusetCG1(cgroup, iface)
+		ed := cgroupslib.OpenFromFreezerCG1(statsCgroup, iface)
 		err := ed.Write("cgroup.procs", pid)
 		if err != nil {
 			e.logger.Warn("failed to write cgroup", "interface", iface, "error", err)
 		}
+	}
+
+	// write pid to the cpuset interface, which varies between reserve/share
+	ed := cgroupslib.OpenPath(cpusetCgroup)
+	err := ed.Write("cgroup.procs", pid)
+	if err != nil {
+		e.logger.Warn("failed to write cpuset cgroup", "error", err)
 	}
 
 	// cleanup func that moves executor back up to nomad cgroup
@@ -169,29 +176,32 @@ func (e *UniversalExecutor) enterCG1(cgroup string) func() {
 }
 
 func (e *UniversalExecutor) configureCG1(cgroup string, command *ExecCommand) {
+	// write memory limits
 	memHard, memSoft := e.computeMemory(command)
-	ed := cgroupslib.OpenFromCpusetCG1(cgroup, "memory")
+	ed := cgroupslib.OpenFromFreezerCG1(cgroup, "memory")
 	_ = ed.Write("memory.limit_in_bytes", strconv.FormatInt(memHard, 10))
 	if memSoft > 0 {
-		ed = cgroupslib.OpenFromCpusetCG1(cgroup, "memory")
 		_ = ed.Write("memory.soft_limit_in_bytes", strconv.FormatInt(memSoft, 10))
 	}
 
-	// set memory swappiness
+	// write memory swappiness
 	swappiness := cgroupslib.MaybeDisableMemorySwappiness()
 	if swappiness != nil {
-		ed := cgroupslib.OpenFromCpusetCG1(cgroup, "memory")
 		value := int64(*swappiness)
 		_ = ed.Write("memory.swappiness", strconv.FormatInt(value, 10))
 	}
 
-	// write cpu shares file
+	// write cpu shares
 	cpuShares := strconv.FormatInt(command.Resources.LinuxResources.CPUShares, 10)
-	ed = cgroupslib.OpenFromCpusetCG1(cgroup, "cpu")
+	ed = cgroupslib.OpenFromFreezerCG1(cgroup, "cpu")
 	_ = ed.Write("cpu.shares", cpuShares)
 
-	// TODO(shoenig) manage cpuset
-	e.logger.Info("TODO CORES", "cpuset", command.Resources.LinuxResources.CpusetCpus)
+	// write cpuset, if set
+	if cpuSet := command.Resources.LinuxResources.CpusetCpus; cpuSet != "" {
+		cpusetPath := command.Resources.LinuxResources.CpusetCgroupPath
+		ed = cgroupslib.OpenPath(cpusetPath)
+		_ = ed.Write("cpuset.cpus", cpuSet)
+	}
 }
 
 func (e *UniversalExecutor) configureCG2(cgroup string, command *ExecCommand) {
@@ -212,13 +222,14 @@ func (e *UniversalExecutor) configureCG2(cgroup string, command *ExecCommand) {
 		_ = ed.Write("memory.swappiness", strconv.FormatInt(value, 10))
 	}
 
-	// write cpu cgroup files
+	// write cpu weight cgroup file
 	cpuWeight := e.computeCPU(command)
 	ed = cgroupslib.OpenPath(cgroup)
 	_ = ed.Write("cpu.weight", strconv.FormatUint(cpuWeight, 10))
 
-	// TODO(shoenig) manage cpuset
-	e.logger.Info("TODO CORES", "cpuset", command.Resources.LinuxResources.CpusetCpus)
+	// write cpuset cgroup file, if set
+	cpusetCpus := command.Resources.LinuxResources.CpusetCpus
+	_ = ed.Write("cpuset.cpus", cpusetCpus)
 }
 
 func (*UniversalExecutor) computeCPU(command *ExecCommand) uint64 {

--- a/drivers/shared/executor/procstats/list_linux.go
+++ b/drivers/shared/executor/procstats/list_linux.go
@@ -11,19 +11,12 @@ import (
 )
 
 type Cgrouper interface {
-	Cgroup() string
+	StatsCgroup() string
 }
 
 func List(cg Cgrouper) *set.Set[ProcessID] {
-	cgroup := cg.Cgroup()
-	var ed cgroupslib.Interface
-	switch cgroupslib.GetMode() {
-	case cgroupslib.CG1:
-		ed = cgroupslib.OpenFromCpusetCG1(cgroup, "freezer")
-	default:
-		ed = cgroupslib.OpenPath(cgroup)
-	}
-
+	cgroup := cg.StatsCgroup()
+	ed := cgroupslib.OpenPath(cgroup)
 	s, err := ed.PIDs()
 	if err != nil {
 		return set.New[ProcessID](0)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -36,6 +36,8 @@ import (
 	"github.com/hashicorp/go-set"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
 	"github.com/hashicorp/nomad/command/agent/host"
 	"github.com/hashicorp/nomad/command/agent/pprof"
 	"github.com/hashicorp/nomad/helper"
@@ -3780,6 +3782,17 @@ type AllocatedResources struct {
 
 	// Shared is the set of resource that are shared by all tasks in the group.
 	Shared AllocatedSharedResources
+}
+
+// UsesCores returns true if any of the tasks in the allocation make use
+// of reserved cpu cores.
+func (a *AllocatedResources) UsesCores() bool {
+	for _, taskRes := range a.Tasks {
+		if len(taskRes.Cpu.ReservedCores) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *AllocatedResources) Copy() *AllocatedResources {
@@ -7541,6 +7554,10 @@ type Task struct {
 	Identities []*WorkloadIdentity
 }
 
+func (t *Task) UsesCores() bool {
+	return t.Resources.Cores > 0
+}
+
 // UsesConnect is for conveniently detecting if the Task is able to make use
 // of Consul Connect features. This will be indicated in the TaskKind of the
 // Task, which exports known types of Tasks. UsesConnect will be true if the
@@ -10589,6 +10606,22 @@ func (a *Allocation) GetCreateIndex() uint64 {
 		return 0
 	}
 	return a.CreateIndex
+}
+
+// ReservedCores returns the union of reserved cores across tasks in this alloc.
+func (a *Allocation) ReservedCores() *idset.Set[hw.CoreID] {
+	s := idset.Empty[hw.CoreID]()
+	if a == nil || a.AllocatedResources == nil {
+		return s
+	}
+	for _, taskResources := range a.AllocatedResources.Tasks {
+		if len(taskResources.Cpu.ReservedCores) > 0 {
+			for _, core := range taskResources.Cpu.ReservedCores {
+				s.Insert(hw.CoreID(core))
+			}
+		}
+	}
+	return s
 }
 
 // ConsulNamespace returns the Consul namespace of the task group associated

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -4551,6 +4551,41 @@ func TestReschedulePolicy_Validate(t *testing.T) {
 	}
 }
 
+func TestAllocation_ReservedCores(t *testing.T) {
+	ci.Parallel(t)
+
+	a := &Allocation{
+		AllocatedResources: &AllocatedResources{
+			Tasks: map[string]*AllocatedTaskResources{
+				"nil": {
+					Cpu: AllocatedCpuResources{
+						ReservedCores: nil,
+					},
+				},
+				"empty": {
+					Cpu: AllocatedCpuResources{
+						ReservedCores: make([]uint16, 0),
+					},
+				},
+				"one": {
+					Cpu: AllocatedCpuResources{
+						ReservedCores: []uint16{7},
+					},
+				},
+				"three": {
+					Cpu: AllocatedCpuResources{
+						ReservedCores: []uint16{1, 3, 4},
+					},
+				},
+			},
+		},
+	}
+
+	result := a.ReservedCores()
+	must.Eq(t, "1,3-4,7", result.String())
+
+}
+
 func TestAllocation_Index(t *testing.T) {
 	ci.Parallel(t)
 

--- a/plugins/drivers/testutils/testing_linux.go
+++ b/plugins/drivers/testutils/testing_linux.go
@@ -14,7 +14,7 @@ import (
 // exists, since Nomad client creates them. Why do we write tests that directly
 // invoke task drivers without any context of the Nomad client? Who knows.
 func (h *DriverHarness) MakeTaskCgroup(allocID, taskName string) {
-	f := cgroupslib.Factory(allocID, taskName)
+	f := cgroupslib.Factory(allocID, taskName, false)
 	must.NoError(h.t, f.Setup())
 
 	// ensure child procs are dead and remove the cgroup when the test is done


### PR DESCRIPTION
- init cgroup tree and start on hook
- wip uh i dunno
- wip need to use not destroy
- wip: use postrun
- wip: able to write partitions
- wip: parts work for rawexec
- wip: works wth exec driver
- wip: start rename to use slice
- wip: fix partition name again
- wip stuff
- wip: seems alright
- wip: cleanup a bit
- wip: remove netlog
- wip: fixup dev mode
- wip: restore cpusets
- wip: hmm cg1 is broken
- wip: cg1 clone children and mems
- wip: cg1 rawexec works
- wip: cg1 exec cores works
- wip: rawexec cg1 works again
- wip: exec is broken
- wip: exec works again
- wip cg1 seems to work again
- wip cg2 works again
- wip: remove netlog
