### PR TITLE
Revert "client: include response body in output for successful HTTP checks (#18345)"

### DIFF
--- a/.changelog/18345.txt
+++ b/.changelog/18345.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-services: Include response body in output for successful HTTP checks when using Nomad native service discovery
-```

--- a/client/serviceregistration/checks/client.go
+++ b/client/serviceregistration/checks/client.go
@@ -205,12 +205,16 @@ func (c *checker) checkHTTP(ctx context.Context, qc *QueryContext, q *Query) *st
 	switch {
 	case result.StatusCode == http.StatusOK:
 		qr.Status = structs.CheckSuccess
+		qr.Output = "nomad: http ok"
+		return qr
 	case result.StatusCode < http.StatusBadRequest:
 		qr.Status = structs.CheckSuccess
 	default:
 		qr.Status = structs.CheckFailure
 	}
 
+	// status code was not 200; read the response body and set that as the
+	// check result output content
 	qr.Output = limitRead(result.Body)
 
 	return qr

--- a/client/serviceregistration/checks/client.go
+++ b/client/serviceregistration/checks/client.go
@@ -205,6 +205,9 @@ func (c *checker) checkHTTP(ctx context.Context, qc *QueryContext, q *Query) *st
 	switch {
 	case result.StatusCode == http.StatusOK:
 		qr.Status = structs.CheckSuccess
+		// The check output is ignored on success to prevent users from relying
+		// on their content since querying service check results is an
+		// expensive operation.
 		qr.Output = "nomad: http ok"
 		return qr
 	case result.StatusCode < http.StatusBadRequest:

--- a/client/serviceregistration/checks/client_test.go
+++ b/client/serviceregistration/checks/client_test.go
@@ -143,7 +143,7 @@ func TestChecker_Do_HTTP(t *testing.T) {
 			structs.Healthiness,
 			structs.CheckSuccess,
 			http.StatusOK,
-			"200 ok",
+			"nomad: http ok",
 		),
 	}, {
 		name: "200 readiness",
@@ -153,7 +153,7 @@ func TestChecker_Do_HTTP(t *testing.T) {
 			structs.Readiness,
 			structs.CheckSuccess,
 			http.StatusOK,
-			"200 ok",
+			"nomad: http ok",
 		),
 	}, {
 		name: "500 healthiness",
@@ -203,7 +203,7 @@ func TestChecker_Do_HTTP(t *testing.T) {
 			structs.Healthiness,
 			structs.CheckSuccess,
 			http.StatusOK,
-			"200 ok",
+			"nomad: http ok",
 		),
 	}}
 


### PR DESCRIPTION
This reverts commit d0a93f12d1ec1e2b276f9958898c9a6fe4f6b077.
