### PR TITLE
fingerprint: add support for fingerprinting multiple Consul clusters

### DIFF
--- a/client/fingerprint/consul.go
+++ b/client/fingerprint/consul.go
@@ -10,14 +10,12 @@ import (
 	"time"
 
 	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-hclog"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-version"
 	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
-)
-
-const (
-	consulAvailable   = "available"
-	consulUnavailable = "unavailable"
+	"github.com/hashicorp/nomad/nomad/structs/config"
 )
 
 var (
@@ -30,10 +28,14 @@ var (
 
 // ConsulFingerprint is used to fingerprint for Consul
 type ConsulFingerprint struct {
-	logger     log.Logger
-	client     *consulapi.Client
-	lastState  string
-	extractors map[string]consulExtractor
+	logger log.Logger
+	states map[string]*consulFingerprintState
+}
+
+type consulFingerprintState struct {
+	client      *consulapi.Client
+	isAvailable bool
+	extractors  map[string]consulExtractor
 }
 
 // consulExtractor is used to parse out one attribute from consulInfo. Returns
@@ -43,29 +45,48 @@ type consulExtractor func(agentconsul.Self) (string, bool)
 // NewConsulFingerprint is used to create a Consul fingerprint
 func NewConsulFingerprint(logger log.Logger) Fingerprint {
 	return &ConsulFingerprint{
-		logger:    logger.Named("consul"),
-		lastState: consulUnavailable,
+		logger: logger.Named("consul"),
+		states: map[string]*consulFingerprintState{},
 	}
 }
 
 func (f *ConsulFingerprint) Fingerprint(req *FingerprintRequest, resp *FingerprintResponse) error {
+	var mErr *multierror.Error
+	for _, cfg := range f.consulConfigs(req) {
+		err := f.fingerprintImpl(cfg, resp)
+		if err != nil {
+			mErr = multierror.Append(mErr, err)
+		}
+	}
 
-	// establish consul client if necessary
-	if err := f.initialize(req); err != nil {
+	return mErr.ErrorOrNil()
+}
+
+func (f *ConsulFingerprint) fingerprintImpl(cfg *config.ConsulConfig, resp *FingerprintResponse) error {
+
+	logger := f.logger.With("cluster", cfg.Name)
+
+	state, ok := f.states[cfg.Name]
+	if !ok {
+		state = &consulFingerprintState{}
+		f.states[cfg.Name] = state
+	}
+
+	if err := state.initialize(cfg, logger); err != nil {
 		return err
 	}
 
 	// query consul for agent self api
-	info := f.query(resp)
+	info := state.query(logger)
 	if len(info) == 0 {
 		// unable to reach consul, nothing to do this time
 		return nil
 	}
 
 	// apply the extractor for each attribute
-	for attr, extractor := range f.extractors {
+	for attr, extractor := range state.extractors {
 		if s, ok := extractor(info); !ok {
-			f.logger.Warn("unable to fingerprint consul", "attribute", attr)
+			logger.Warn("unable to fingerprint consul", "attribute", attr)
 		} else {
 			resp.AddAttribute(attr, s)
 		}
@@ -75,11 +96,11 @@ func (f *ConsulFingerprint) Fingerprint(req *FingerprintRequest, resp *Fingerpri
 	f.link(resp)
 
 	// indicate Consul is now available
-	if f.lastState == consulUnavailable {
-		f.logger.Info("consul agent is available")
+	if !state.isAvailable {
+		logger.Info("consul agent is available")
 	}
 
-	f.lastState = consulAvailable
+	state.isAvailable = true
 	resp.Detected = true
 	return nil
 }
@@ -88,46 +109,61 @@ func (f *ConsulFingerprint) Periodic() (bool, time.Duration) {
 	return true, 15 * time.Second
 }
 
-func (f *ConsulFingerprint) initialize(req *FingerprintRequest) error {
-	// Only create the Consul client once to avoid creating many connections
-	if f.client == nil {
-		consulConfig, err := req.Config.ConsulConfig.ApiConfig()
-		if err != nil {
-			return fmt.Errorf("failed to initialize Consul client config: %v", err)
-		}
+func (cfs *consulFingerprintState) initialize(cfg *config.ConsulConfig, logger hclog.Logger) error {
+	if cfs.client != nil {
+		return nil // already initialized!
+	}
 
-		f.client, err = consulapi.NewClient(consulConfig)
-		if err != nil {
-			return fmt.Errorf("failed to initialize Consul client: %s", err)
-		}
+	consulConfig, err := cfg.ApiConfig()
+	if err != nil {
+		return fmt.Errorf("failed to initialize Consul client config: %v", err)
+	}
 
-		f.extractors = map[string]consulExtractor{
-			"consul.server":        f.server,
-			"consul.version":       f.version,
-			"consul.sku":           f.sku,
-			"consul.revision":      f.revision,
-			"unique.consul.name":   f.name,
-			"consul.datacenter":    f.dc,
-			"consul.segment":       f.segment,
-			"consul.connect":       f.connect,
-			"consul.grpc":          f.grpc(consulConfig.Scheme),
-			"consul.ft.namespaces": f.namespaces,
+	cfs.client, err = consulapi.NewClient(consulConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize Consul client: %v", err)
+	}
+
+	if cfg.Name == "default" {
+		cfs.extractors = map[string]consulExtractor{
+			"consul.server":        cfs.server,
+			"consul.version":       cfs.version,
+			"consul.sku":           cfs.sku,
+			"consul.revision":      cfs.revision,
+			"unique.consul.name":   cfs.name, // note: won't have this for non-default clusters
+			"consul.datacenter":    cfs.dc,
+			"consul.segment":       cfs.segment,
+			"consul.connect":       cfs.connect,
+			"consul.grpc":          cfs.grpc(consulConfig.Scheme, logger),
+			"consul.ft.namespaces": cfs.namespaces,
+		}
+	} else {
+		cfs.extractors = map[string]consulExtractor{
+			fmt.Sprintf("consul.%s.server", cfg.Name):        cfs.server,
+			fmt.Sprintf("consul.%s.version", cfg.Name):       cfs.version,
+			fmt.Sprintf("consul.%s.sku", cfg.Name):           cfs.sku,
+			fmt.Sprintf("consul.%s.revision", cfg.Name):      cfs.revision,
+			fmt.Sprintf("consul.%s.datacenter", cfg.Name):    cfs.dc,
+			fmt.Sprintf("consul.%s.segment", cfg.Name):       cfs.segment,
+			fmt.Sprintf("consul.%s.connect", cfg.Name):       cfs.connect,
+			fmt.Sprintf("consul.%s.grpc", cfg.Name):          cfs.grpc(consulConfig.Scheme, logger),
+			fmt.Sprintf("consul.%s.ft.namespaces", cfg.Name): cfs.namespaces,
 		}
 	}
 
 	return nil
 }
 
-func (f *ConsulFingerprint) query(resp *FingerprintResponse) agentconsul.Self {
+func (cfs *consulFingerprintState) query(logger hclog.Logger) agentconsul.Self {
 	// We'll try to detect consul by making a query to to the agent's self API.
 	// If we can't hit this URL consul is probably not running on this machine.
-	info, err := f.client.Agent().Self()
+	info, err := cfs.client.Agent().Self()
 	if err != nil {
 		// indicate consul no longer available
-		if f.lastState == consulAvailable {
-			f.logger.Info("consul agent is unavailable")
+		if cfs.isAvailable {
+			logger.Info("consul agent is unavailable: %v", err)
 		}
-		f.lastState = consulUnavailable
+		cfs.isAvailable = false
 		return nil
 	}
 	return info
@@ -143,36 +179,36 @@ func (f *ConsulFingerprint) link(resp *FingerprintResponse) {
 	}
 }
 
-func (f *ConsulFingerprint) server(info agentconsul.Self) (string, bool) {
+func (cfs *consulFingerprintState) server(info agentconsul.Self) (string, bool) {
 	s, ok := info["Config"]["Server"].(bool)
 	return strconv.FormatBool(s), ok
 }
 
-func (f *ConsulFingerprint) version(info agentconsul.Self) (string, bool) {
+func (cfs *consulFingerprintState) version(info agentconsul.Self) (string, bool) {
 	v, ok := info["Config"]["Version"].(string)
 	return v, ok
 }
 
-func (f *ConsulFingerprint) sku(info agentconsul.Self) (string, bool) {
+func (cfs *consulFingerprintState) sku(info agentconsul.Self) (string, bool) {
 	return agentconsul.SKU(info)
 }
 
-func (f *ConsulFingerprint) revision(info agentconsul.Self) (string, bool) {
+func (cfs *consulFingerprintState) revision(info agentconsul.Self) (string, bool) {
 	r, ok := info["Config"]["Revision"].(string)
 	return r, ok
 }
 
-func (f *ConsulFingerprint) name(info agentconsul.Self) (string, bool) {
+func (cfs *consulFingerprintState) name(info agentconsul.Self) (string, bool) {
 	n, ok := info["Config"]["NodeName"].(string)
 	return n, ok
 }
 
-func (f *ConsulFingerprint) dc(info agentconsul.Self) (string, bool) {
+func (cfs *consulFingerprintState) dc(info agentconsul.Self) (string, bool) {
 	d, ok := info["Config"]["Datacenter"].(string)
 	return d, ok
 }
 
-func (f *ConsulFingerprint) segment(info agentconsul.Self) (string, bool) {
+func (cfs *consulFingerprintState) segment(info agentconsul.Self) (string, bool) {
 	tags, tagsOK := info["Member"]["Tags"].(map[string]interface{})
 	if !tagsOK {
 		return "", false
@@ -181,12 +217,12 @@ func (f *ConsulFingerprint) segment(info agentconsul.Self) (string, bool) {
 	return s, ok
 }
 
-func (f *ConsulFingerprint) connect(info agentconsul.Self) (string, bool) {
+func (cfs *consulFingerprintState) connect(info agentconsul.Self) (string, bool) {
 	c, ok := info["DebugConfig"]["ConnectEnabled"].(bool)
 	return strconv.FormatBool(c), ok
 }
 
-func (f *ConsulFingerprint) grpc(scheme string) func(info agentconsul.Self) (string, bool) {
+func (cfs *consulFingerprintState) grpc(scheme string, logger hclog.Logger) func(info agentconsul.Self) (string, bool) {
 	return func(info agentconsul.Self) (string, bool) {
 
 		// The version is needed in order to understand which config object to
@@ -199,14 +235,14 @@ func (f *ConsulFingerprint) grpc(scheme string) func(info agentconsul.Self) (str
 
 		consulVersion, err := version.NewVersion(strings.TrimSpace(v))
 		if err != nil {
-			f.logger.Warn("invalid Consul version", "version", v)
+			logger.Warn("invalid Consul version", "version", v)
 			return "", false
 		}
 
 		// If the Consul agent being fingerprinted is running a version less
 		// than 1.14.0 we use the original single gRPC port.
 		if consulVersion.Core().LessThan(consulGRPCPortChangeVersion.Core()) {
-			return f.grpcPort(info)
+			return cfs.grpcPort(info)
 		}
 
 		// Now that we know we are querying a Consul agent running v1.14.0 or
@@ -214,23 +250,23 @@ func (f *ConsulFingerprint) grpc(scheme string) func(info agentconsul.Self) (str
 		// config depending on whether we have been asked to speak TLS or not.
 		switch strings.ToLower(scheme) {
 		case "https":
-			return f.grpcTLSPort(info)
+			return cfs.grpcTLSPort(info)
 		default:
-			return f.grpcPort(info)
+			return cfs.grpcPort(info)
 		}
 	}
 }
 
-func (f *ConsulFingerprint) grpcPort(info agentconsul.Self) (string, bool) {
+func (cfs *consulFingerprintState) grpcPort(info agentconsul.Self) (string, bool) {
 	p, ok := info["DebugConfig"]["GRPCPort"].(float64)
 	return fmt.Sprintf("%d", int(p)), ok
 }
 
-func (f *ConsulFingerprint) grpcTLSPort(info agentconsul.Self) (string, bool) {
+func (cfs *consulFingerprintState) grpcTLSPort(info agentconsul.Self) (string, bool) {
 	p, ok := info["DebugConfig"]["GRPCTLSPort"].(float64)
 	return fmt.Sprintf("%d", int(p)), ok
 }
 
-func (f *ConsulFingerprint) namespaces(info agentconsul.Self) (string, bool) {
+func (cfs *consulFingerprintState) namespaces(info agentconsul.Self) (string, bool) {
 	return strconv.FormatBool(agentconsul.Namespaces(info)), true
 }

--- a/client/fingerprint/consul_ce.go
+++ b/client/fingerprint/consul_ce.go
@@ -1,0 +1,23 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !ent
+
+package fingerprint
+
+import "github.com/hashicorp/nomad/nomad/structs/config"
+
+// consulConfigs returns the set of Consul configurations the fingerprint needs
+// to check. In Nomad CE we only check the default Consul.
+func (f *ConsulFingerprint) consulConfigs(req *FingerprintRequest) map[string]*config.ConsulConfig {
+	agentCfg := req.Config
+	if agentCfg.ConsulConfig == nil {
+		return nil
+	}
+
+	if len(req.Config.ConsulConfigs) > 1 {
+		f.logger.Warn("multiple Consul configurations are only supported in Nomad Enterprise")
+	}
+
+	return map[string]*config.ConsulConfig{"default": agentCfg.ConsulConfig}
+}

--- a/client/fingerprint/consul_test.go
+++ b/client/fingerprint/consul_test.go
@@ -16,7 +16,7 @@ import (
 	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/stretchr/testify/require"
+	"github.com/shoenig/test/must"
 )
 
 // fakeConsul creates an HTTP server mimicking Consul /v1/agent/self endpoint on
@@ -42,7 +42,7 @@ func fakeConsul(payload string) (*httptest.Server, *config.Config) {
 
 func fakeConsulPayload(t *testing.T, filename string) string {
 	b, err := os.ReadFile(filename)
-	require.NoError(t, err)
+	must.NoError(t, err)
 	return string(b)
 }
 
@@ -53,394 +53,394 @@ func newConsulFingerPrint(t *testing.T) *ConsulFingerprint {
 func TestConsulFingerprint_server(t *testing.T) {
 	ci.Parallel(t)
 
-	fp := newConsulFingerPrint(t)
+	cfs := consulFingerprintState{}
 
 	t.Run("is server", func(t *testing.T) {
-		s, ok := fp.server(agentconsul.Self{
+		s, ok := cfs.server(agentconsul.Self{
 			"Config": {"Server": true},
 		})
-		require.True(t, ok)
-		require.Equal(t, "true", s)
+		must.True(t, ok)
+		must.Eq(t, "true", s)
 	})
 
 	t.Run("is not server", func(t *testing.T) {
-		s, ok := fp.server(agentconsul.Self{
+		s, ok := cfs.server(agentconsul.Self{
 			"Config": {"Server": false},
 		})
-		require.True(t, ok)
-		require.Equal(t, "false", s)
+		must.True(t, ok)
+		must.Eq(t, "false", s)
 	})
 
 	t.Run("missing", func(t *testing.T) {
-		_, ok := fp.server(agentconsul.Self{
+		_, ok := cfs.server(agentconsul.Self{
 			"Config": {},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 
 	t.Run("malformed", func(t *testing.T) {
-		_, ok := fp.server(agentconsul.Self{
+		_, ok := cfs.server(agentconsul.Self{
 			"Config": {"Server": 9000},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 }
 
 func TestConsulFingerprint_version(t *testing.T) {
 	ci.Parallel(t)
 
-	fp := newConsulFingerPrint(t)
+	cfs := consulFingerprintState{}
 
 	t.Run("oss", func(t *testing.T) {
-		v, ok := fp.version(agentconsul.Self{
+		v, ok := cfs.version(agentconsul.Self{
 			"Config": {"Version": "v1.9.5"},
 		})
-		require.True(t, ok)
-		require.Equal(t, "v1.9.5", v)
+		must.True(t, ok)
+		must.Eq(t, "v1.9.5", v)
 	})
 
 	t.Run("ent", func(t *testing.T) {
-		v, ok := fp.version(agentconsul.Self{
+		v, ok := cfs.version(agentconsul.Self{
 			"Config": {"Version": "v1.9.5+ent"},
 		})
-		require.True(t, ok)
-		require.Equal(t, "v1.9.5+ent", v)
+		must.True(t, ok)
+		must.Eq(t, "v1.9.5+ent", v)
 	})
 
 	t.Run("missing", func(t *testing.T) {
-		_, ok := fp.version(agentconsul.Self{
+		_, ok := cfs.version(agentconsul.Self{
 			"Config": {},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 
 	t.Run("malformed", func(t *testing.T) {
-		_, ok := fp.version(agentconsul.Self{
+		_, ok := cfs.version(agentconsul.Self{
 			"Config": {"Version": 9000},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 }
 
 func TestConsulFingerprint_sku(t *testing.T) {
 	ci.Parallel(t)
 
-	fp := newConsulFingerPrint(t)
+	cfs := consulFingerprintState{}
 
 	t.Run("oss", func(t *testing.T) {
-		s, ok := fp.sku(agentconsul.Self{
+		s, ok := cfs.sku(agentconsul.Self{
 			"Config": {"Version": "v1.9.5"},
 		})
-		require.True(t, ok)
-		require.Equal(t, "oss", s)
+		must.True(t, ok)
+		must.Eq(t, "oss", s)
 	})
 
 	t.Run("oss dev", func(t *testing.T) {
-		s, ok := fp.sku(agentconsul.Self{
+		s, ok := cfs.sku(agentconsul.Self{
 			"Config": {"Version": "v1.9.5-dev"},
 		})
-		require.True(t, ok)
-		require.Equal(t, "oss", s)
+		must.True(t, ok)
+		must.Eq(t, "oss", s)
 	})
 
 	t.Run("ent", func(t *testing.T) {
-		s, ok := fp.sku(agentconsul.Self{
+		s, ok := cfs.sku(agentconsul.Self{
 			"Config": {"Version": "v1.9.5+ent"},
 		})
-		require.True(t, ok)
-		require.Equal(t, "ent", s)
+		must.True(t, ok)
+		must.Eq(t, "ent", s)
 	})
 
 	t.Run("ent dev", func(t *testing.T) {
-		s, ok := fp.sku(agentconsul.Self{
+		s, ok := cfs.sku(agentconsul.Self{
 			"Config": {"Version": "v1.9.5+ent-dev"},
 		})
-		require.True(t, ok)
-		require.Equal(t, "ent", s)
+		must.True(t, ok)
+		must.Eq(t, "ent", s)
 	})
 
 	t.Run("extra spaces", func(t *testing.T) {
-		v, ok := fp.sku(agentconsul.Self{
+		v, ok := cfs.sku(agentconsul.Self{
 			"Config": {"Version": "   v1.9.5\n"},
 		})
-		require.True(t, ok)
-		require.Equal(t, "oss", v)
+		must.True(t, ok)
+		must.Eq(t, "oss", v)
 	})
 
 	t.Run("missing", func(t *testing.T) {
-		_, ok := fp.sku(agentconsul.Self{
+		_, ok := cfs.sku(agentconsul.Self{
 			"Config": {},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 
 	t.Run("malformed", func(t *testing.T) {
-		_, ok := fp.sku(agentconsul.Self{
+		_, ok := cfs.sku(agentconsul.Self{
 			"Config": {"Version": "***"},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 }
 
 func TestConsulFingerprint_revision(t *testing.T) {
 	ci.Parallel(t)
 
-	fp := newConsulFingerPrint(t)
+	cfs := consulFingerprintState{}
 
 	t.Run("ok", func(t *testing.T) {
-		r, ok := fp.revision(agentconsul.Self{
+		r, ok := cfs.revision(agentconsul.Self{
 			"Config": {"Revision": "3c1c22679"},
 		})
-		require.True(t, ok)
-		require.Equal(t, "3c1c22679", r)
+		must.True(t, ok)
+		must.Eq(t, "3c1c22679", r)
 	})
 
 	t.Run("malformed", func(t *testing.T) {
-		_, ok := fp.revision(agentconsul.Self{
+		_, ok := cfs.revision(agentconsul.Self{
 			"Config": {"Revision": 9000},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 
 	t.Run("missing", func(t *testing.T) {
-		_, ok := fp.revision(agentconsul.Self{
+		_, ok := cfs.revision(agentconsul.Self{
 			"Config": {},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 }
 
 func TestConsulFingerprint_dc(t *testing.T) {
 	ci.Parallel(t)
 
-	fp := newConsulFingerPrint(t)
+	cfs := consulFingerprintState{}
 
 	t.Run("ok", func(t *testing.T) {
-		dc, ok := fp.dc(agentconsul.Self{
+		dc, ok := cfs.dc(agentconsul.Self{
 			"Config": {"Datacenter": "dc1"},
 		})
-		require.True(t, ok)
-		require.Equal(t, "dc1", dc)
+		must.True(t, ok)
+		must.Eq(t, "dc1", dc)
 	})
 
 	t.Run("malformed", func(t *testing.T) {
-		_, ok := fp.dc(agentconsul.Self{
+		_, ok := cfs.dc(agentconsul.Self{
 			"Config": {"Datacenter": 9000},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 
 	t.Run("missing", func(t *testing.T) {
-		_, ok := fp.dc(agentconsul.Self{
+		_, ok := cfs.dc(agentconsul.Self{
 			"Config": {},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 }
 
 func TestConsulFingerprint_segment(t *testing.T) {
 	ci.Parallel(t)
 
-	fp := newConsulFingerPrint(t)
+	cfs := consulFingerprintState{}
 
 	t.Run("ok", func(t *testing.T) {
-		s, ok := fp.segment(agentconsul.Self{
+		s, ok := cfs.segment(agentconsul.Self{
 			"Member": {"Tags": map[string]interface{}{"segment": "seg1"}},
 		})
-		require.True(t, ok)
-		require.Equal(t, "seg1", s)
+		must.True(t, ok)
+		must.Eq(t, "seg1", s)
 	})
 
 	t.Run("segment missing", func(t *testing.T) {
-		_, ok := fp.segment(agentconsul.Self{
+		_, ok := cfs.segment(agentconsul.Self{
 			"Member": {"Tags": map[string]interface{}{}},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 
 	t.Run("tags missing", func(t *testing.T) {
-		_, ok := fp.segment(agentconsul.Self{
+		_, ok := cfs.segment(agentconsul.Self{
 			"Member": {},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 
 	t.Run("malformed", func(t *testing.T) {
-		_, ok := fp.segment(agentconsul.Self{
+		_, ok := cfs.segment(agentconsul.Self{
 			"Member": {"Tags": map[string]interface{}{"segment": 9000}},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 }
 
 func TestConsulFingerprint_connect(t *testing.T) {
 	ci.Parallel(t)
 
-	fp := newConsulFingerPrint(t)
+	cfs := consulFingerprintState{}
 
 	t.Run("connect enabled", func(t *testing.T) {
-		s, ok := fp.connect(agentconsul.Self{
+		s, ok := cfs.connect(agentconsul.Self{
 			"DebugConfig": {"ConnectEnabled": true},
 		})
-		require.True(t, ok)
-		require.Equal(t, "true", s)
+		must.True(t, ok)
+		must.Eq(t, "true", s)
 	})
 
 	t.Run("connect not enabled", func(t *testing.T) {
-		s, ok := fp.connect(agentconsul.Self{
+		s, ok := cfs.connect(agentconsul.Self{
 			"DebugConfig": {"ConnectEnabled": false},
 		})
-		require.True(t, ok)
-		require.Equal(t, "false", s)
+		must.True(t, ok)
+		must.Eq(t, "false", s)
 	})
 
 	t.Run("connect missing", func(t *testing.T) {
-		_, ok := fp.connect(agentconsul.Self{
+		_, ok := cfs.connect(agentconsul.Self{
 			"DebugConfig": {},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 }
 
 func TestConsulFingerprint_grpc(t *testing.T) {
 	ci.Parallel(t)
 
-	fp := newConsulFingerPrint(t)
+	cfs := consulFingerprintState{}
 
 	t.Run("grpc set pre-1.14 http", func(t *testing.T) {
-		s, ok := fp.grpc("http")(agentconsul.Self{
+		s, ok := cfs.grpc("http", testlog.HCLogger(t))(agentconsul.Self{
 			"Config":      {"Version": "1.13.3"},
 			"DebugConfig": {"GRPCPort": 8502.0}, // JSON numbers are floats
 		})
-		require.True(t, ok)
-		require.Equal(t, "8502", s)
+		must.True(t, ok)
+		must.Eq(t, "8502", s)
 	})
 
 	t.Run("grpc disabled pre-1.14 http", func(t *testing.T) {
-		s, ok := fp.grpc("http")(agentconsul.Self{
+		s, ok := cfs.grpc("http", testlog.HCLogger(t))(agentconsul.Self{
 			"Config":      {"Version": "1.13.3"},
 			"DebugConfig": {"GRPCPort": -1.0}, // JSON numbers are floats
 		})
-		require.True(t, ok)
-		require.Equal(t, "-1", s)
+		must.True(t, ok)
+		must.Eq(t, "-1", s)
 	})
 
 	t.Run("grpc set pre-1.14 https", func(t *testing.T) {
-		s, ok := fp.grpc("https")(agentconsul.Self{
+		s, ok := cfs.grpc("https", testlog.HCLogger(t))(agentconsul.Self{
 			"Config":      {"Version": "1.13.3"},
 			"DebugConfig": {"GRPCPort": 8502.0}, // JSON numbers are floats
 		})
-		require.True(t, ok)
-		require.Equal(t, "8502", s)
+		must.True(t, ok)
+		must.Eq(t, "8502", s)
 	})
 
 	t.Run("grpc disabled pre-1.14 https", func(t *testing.T) {
-		s, ok := fp.grpc("https")(agentconsul.Self{
+		s, ok := cfs.grpc("https", testlog.HCLogger(t))(agentconsul.Self{
 			"Config":      {"Version": "1.13.3"},
 			"DebugConfig": {"GRPCPort": -1.0}, // JSON numbers are floats
 		})
-		require.True(t, ok)
-		require.Equal(t, "-1", s)
+		must.True(t, ok)
+		must.Eq(t, "-1", s)
 	})
 
 	t.Run("grpc set post-1.14 http", func(t *testing.T) {
-		s, ok := fp.grpc("http")(agentconsul.Self{
+		s, ok := cfs.grpc("http", testlog.HCLogger(t))(agentconsul.Self{
 			"Config":      {"Version": "1.14.0"},
 			"DebugConfig": {"GRPCPort": 8502.0}, // JSON numbers are floats
 		})
-		require.True(t, ok)
-		require.Equal(t, "8502", s)
+		must.True(t, ok)
+		must.Eq(t, "8502", s)
 	})
 
 	t.Run("grpc disabled post-1.14 http", func(t *testing.T) {
-		s, ok := fp.grpc("http")(agentconsul.Self{
+		s, ok := cfs.grpc("http", testlog.HCLogger(t))(agentconsul.Self{
 			"Config":      {"Version": "1.14.0"},
 			"DebugConfig": {"GRPCPort": -1.0}, // JSON numbers are floats
 		})
-		require.True(t, ok)
-		require.Equal(t, "-1", s)
+		must.True(t, ok)
+		must.Eq(t, "-1", s)
 	})
 
 	t.Run("grpc disabled post-1.14 https", func(t *testing.T) {
-		s, ok := fp.grpc("https")(agentconsul.Self{
+		s, ok := cfs.grpc("https", testlog.HCLogger(t))(agentconsul.Self{
 			"Config":      {"Version": "1.14.0"},
 			"DebugConfig": {"GRPCTLSPort": -1.0}, // JSON numbers are floats
 		})
-		require.True(t, ok)
-		require.Equal(t, "-1", s)
+		must.True(t, ok)
+		must.Eq(t, "-1", s)
 	})
 
 	t.Run("grpc set post-1.14 https", func(t *testing.T) {
-		s, ok := fp.grpc("https")(agentconsul.Self{
+		s, ok := cfs.grpc("https", testlog.HCLogger(t))(agentconsul.Self{
 			"Config":      {"Version": "1.14.0"},
 			"DebugConfig": {"GRPCTLSPort": 8503.0}, // JSON numbers are floats
 		})
-		require.True(t, ok)
-		require.Equal(t, "8503", s)
+		must.True(t, ok)
+		must.Eq(t, "8503", s)
 	})
 
 	t.Run("version with extra spaces", func(t *testing.T) {
-		s, ok := fp.grpc("https")(agentconsul.Self{
+		s, ok := cfs.grpc("https", testlog.HCLogger(t))(agentconsul.Self{
 			"Config":      {"Version": "  1.14.0\n"},
 			"DebugConfig": {"GRPCTLSPort": 8503.0}, // JSON numbers are floats
 		})
-		require.True(t, ok)
-		require.Equal(t, "8503", s)
+		must.True(t, ok)
+		must.Eq(t, "8503", s)
 	})
 
 	t.Run("grpc missing http", func(t *testing.T) {
-		_, ok := fp.grpc("http")(agentconsul.Self{
+		_, ok := cfs.grpc("http", testlog.HCLogger(t))(agentconsul.Self{
 			"DebugConfig": {},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 
 	t.Run("grpc missing https", func(t *testing.T) {
-		_, ok := fp.grpc("https")(agentconsul.Self{
+		_, ok := cfs.grpc("https", testlog.HCLogger(t))(agentconsul.Self{
 			"DebugConfig": {},
 		})
-		require.False(t, ok)
+		must.False(t, ok)
 	})
 }
 
 func TestConsulFingerprint_namespaces(t *testing.T) {
 	ci.Parallel(t)
 
-	fp := newConsulFingerPrint(t)
+	cfs := consulFingerprintState{}
 
 	t.Run("supports namespaces", func(t *testing.T) {
-		value, ok := fp.namespaces(agentconsul.Self{
+		value, ok := cfs.namespaces(agentconsul.Self{
 			"Stats": {"license": map[string]interface{}{"features": "Automated Backups, Automated Upgrades, Enhanced Read Scalability, Network Segments, Redundancy Zone, Advanced Network Federation, Namespaces, SSO, Audit Logging"}},
 		})
-		require.True(t, ok)
-		require.Equal(t, "true", value)
+		must.True(t, ok)
+		must.Eq(t, "true", value)
 	})
 
 	t.Run("no namespaces", func(t *testing.T) {
-		value, ok := fp.namespaces(agentconsul.Self{
+		value, ok := cfs.namespaces(agentconsul.Self{
 			"Stats": {"license": map[string]interface{}{"features": "Automated Backups, Automated Upgrades, Enhanced Read Scalability, Network Segments, Redundancy Zone, Advanced Network Federation, SSO, Audit Logging"}},
 		})
-		require.True(t, ok)
-		require.Equal(t, "false", value)
+		must.True(t, ok)
+		must.Eq(t, "false", value)
 
 	})
 
 	t.Run("stats missing", func(t *testing.T) {
-		value, ok := fp.namespaces(agentconsul.Self{})
-		require.True(t, ok)
-		require.Equal(t, "false", value)
+		value, ok := cfs.namespaces(agentconsul.Self{})
+		must.True(t, ok)
+		must.Eq(t, "false", value)
 	})
 
 	t.Run("license missing", func(t *testing.T) {
-		value, ok := fp.namespaces(agentconsul.Self{"Stats": {}})
-		require.True(t, ok)
-		require.Equal(t, "false", value)
+		value, ok := cfs.namespaces(agentconsul.Self{"Stats": {}})
+		must.True(t, ok)
+		must.Eq(t, "false", value)
 	})
 
 	t.Run("features missing", func(t *testing.T) {
-		value, ok := fp.namespaces(agentconsul.Self{"Stats": {"license": map[string]interface{}{}}})
-		require.True(t, ok)
-		require.Equal(t, "false", value)
+		value, ok := cfs.namespaces(agentconsul.Self{"Stats": {"license": map[string]interface{}{}}})
+		must.True(t, ok)
+		must.Eq(t, "false", value)
 	})
 }
 
@@ -455,13 +455,13 @@ func TestConsulFingerprint_Fingerprint_oss(t *testing.T) {
 	node := &structs.Node{Attributes: make(map[string]string)}
 
 	// consul not available before first run
-	require.Equal(t, consulUnavailable, cf.lastState)
+	must.Nil(t, cf.states["default"])
 
 	// execute first query with good response
 	var resp FingerprintResponse
 	err := cf.Fingerprint(&FingerprintRequest{Config: cfg, Node: node}, &resp)
-	require.NoError(t, err)
-	require.Equal(t, map[string]string{
+	must.NoError(t, err)
+	must.Eq(t, map[string]string{
 		"consul.datacenter":    "dc1",
 		"consul.revision":      "3c1c22679",
 		"consul.segment":       "seg1",
@@ -473,10 +473,10 @@ func TestConsulFingerprint_Fingerprint_oss(t *testing.T) {
 		"consul.ft.namespaces": "false",
 		"unique.consul.name":   "HAL9000",
 	}, resp.Attributes)
-	require.True(t, resp.Detected)
+	must.True(t, resp.Detected)
 
 	// consul now available
-	require.Equal(t, consulAvailable, cf.lastState)
+	must.True(t, cf.states["default"].isAvailable)
 
 	var resp2 FingerprintResponse
 
@@ -493,18 +493,18 @@ func TestConsulFingerprint_Fingerprint_oss(t *testing.T) {
 
 	// execute second query with error
 	err2 := cf.Fingerprint(&FingerprintRequest{Config: cfg, Node: node}, &resp2)
-	require.NoError(t, err2)         // does not return error
-	require.Nil(t, resp2.Attributes) // attributes unset so they don't change
-	require.True(t, resp.Detected)   // never downgrade
+	must.NoError(t, err2)         // does not return error
+	must.Nil(t, resp2.Attributes) // attributes unset so they don't change
+	must.True(t, resp.Detected)   // never downgrade
 
 	// consul no longer available
-	require.Equal(t, consulUnavailable, cf.lastState)
+	must.False(t, cf.states["default"].isAvailable)
 
 	// execute third query no error
 	var resp3 FingerprintResponse
 	err3 := cf.Fingerprint(&FingerprintRequest{Config: cfg, Node: node}, &resp3)
-	require.NoError(t, err3)
-	require.Equal(t, map[string]string{
+	must.NoError(t, err3)
+	must.Eq(t, map[string]string{
 		"consul.datacenter":    "dc1",
 		"consul.revision":      "3c1c22679",
 		"consul.segment":       "seg1",
@@ -518,8 +518,8 @@ func TestConsulFingerprint_Fingerprint_oss(t *testing.T) {
 	}, resp3.Attributes)
 
 	// consul now available again
-	require.Equal(t, consulAvailable, cf.lastState)
-	require.True(t, resp.Detected)
+	must.True(t, cf.states["default"].isAvailable)
+	must.True(t, resp.Detected)
 }
 
 func TestConsulFingerprint_Fingerprint_ent(t *testing.T) {
@@ -533,13 +533,13 @@ func TestConsulFingerprint_Fingerprint_ent(t *testing.T) {
 	node := &structs.Node{Attributes: make(map[string]string)}
 
 	// consul not available before first run
-	require.Equal(t, consulUnavailable, cf.lastState)
+	must.Nil(t, cf.states["default"])
 
 	// execute first query with good response
 	var resp FingerprintResponse
 	err := cf.Fingerprint(&FingerprintRequest{Config: cfg, Node: node}, &resp)
-	require.NoError(t, err)
-	require.Equal(t, map[string]string{
+	must.NoError(t, err)
+	must.Eq(t, map[string]string{
 		"consul.datacenter":    "dc1",
 		"consul.revision":      "22ce6c6ad",
 		"consul.segment":       "seg1",
@@ -551,10 +551,10 @@ func TestConsulFingerprint_Fingerprint_ent(t *testing.T) {
 		"consul.grpc":          "8502",
 		"unique.consul.name":   "HAL9000",
 	}, resp.Attributes)
-	require.True(t, resp.Detected)
+	must.True(t, resp.Detected)
 
 	// consul now available
-	require.Equal(t, consulAvailable, cf.lastState)
+	must.True(t, cf.states["default"].isAvailable)
 
 	var resp2 FingerprintResponse
 
@@ -572,18 +572,18 @@ func TestConsulFingerprint_Fingerprint_ent(t *testing.T) {
 
 	// execute second query with error
 	err2 := cf.Fingerprint(&FingerprintRequest{Config: cfg, Node: node}, &resp2)
-	require.NoError(t, err2)         // does not return error
-	require.Nil(t, resp2.Attributes) // attributes unset so they don't change
-	require.True(t, resp.Detected)   // never downgrade
+	must.NoError(t, err2)         // does not return error
+	must.Nil(t, resp2.Attributes) // attributes unset so they don't change
+	must.True(t, resp.Detected)   // never downgrade
 
 	// consul no longer available
-	require.Equal(t, consulUnavailable, cf.lastState)
+	must.False(t, cf.states["default"].isAvailable)
 
 	// execute third query no error
 	var resp3 FingerprintResponse
 	err3 := cf.Fingerprint(&FingerprintRequest{Config: cfg, Node: node}, &resp3)
-	require.NoError(t, err3)
-	require.Equal(t, map[string]string{
+	must.NoError(t, err3)
+	must.Eq(t, map[string]string{
 		"consul.datacenter":    "dc1",
 		"consul.revision":      "22ce6c6ad",
 		"consul.segment":       "seg1",
@@ -597,6 +597,6 @@ func TestConsulFingerprint_Fingerprint_ent(t *testing.T) {
 	}, resp3.Attributes)
 
 	// consul now available again
-	require.Equal(t, consulAvailable, cf.lastState)
-	require.True(t, resp.Detected)
+	must.True(t, cf.states["default"].isAvailable)
+	must.True(t, resp.Detected)
 }

--- a/client/fingerprint/vault.go
+++ b/client/fingerprint/vault.go
@@ -17,20 +17,15 @@ import (
 	vapi "github.com/hashicorp/vault/api"
 )
 
-const (
-	vaultAvailable   = "available"
-	vaultUnavailable = "unavailable"
-)
-
 var vaultBaseFingerprintInterval = 15 * time.Second
 
 // VaultFingerprint is used to fingerprint for Vault
 type VaultFingerprint struct {
 	logger log.Logger
-	states map[string]*fingerprintState
+	states map[string]*vaultFingerprintState
 }
 
-type fingerprintState struct {
+type vaultFingerprintState struct {
 	client      *vapi.Client
 	isAvailable bool
 	nextCheck   time.Time
@@ -40,7 +35,7 @@ type fingerprintState struct {
 func NewVaultFingerprint(logger log.Logger) Fingerprint {
 	return &VaultFingerprint{
 		logger: logger.Named("vault"),
-		states: map[string]*fingerprintState{},
+		states: map[string]*vaultFingerprintState{},
 	}
 }
 
@@ -63,7 +58,7 @@ func (f *VaultFingerprint) fingerprintImpl(cfg *config.VaultConfig, resp *Finger
 
 	state, ok := f.states[cfg.Name]
 	if !ok {
-		state = &fingerprintState{}
+		state = &vaultFingerprintState{}
 		f.states[cfg.Name] = state
 	}
 	if state.nextCheck.After(time.Now()) {


### PR DESCRIPTION
Add fingerprinting we'll need to accept multiple Consul clusters in upcoming Nomad Enterprise features. The fingerprinter will create a map of Consul clients by cluster name. In Nomad CE, all but the default cluster will be ignored and there will be no visible behavior change.

Ref: https://github.com/hashicorp/team-nomad/issues/404
_Note: similar to https://github.com/hashicorp/nomad/pull/18253, I'll need to prep an ENT PR to go with this one_