### PR TITLE
fix panic from zero JobTrackedVersions config

### DIFF
--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1513,10 +1513,11 @@ func (n *nomadFSM) restoreImpl(old io.ReadCloser, filter *FSMFilter) error {
 
 	// Create a new state store
 	config := &state.StateStoreConfig{
-		Logger:          n.config.Logger,
-		Region:          n.config.Region,
-		EnablePublisher: n.config.EnableEventBroker,
-		EventBufferSize: n.config.EventBufferSize,
+		Logger:             n.config.Logger,
+		Region:             n.config.Region,
+		EnablePublisher:    n.config.EnableEventBroker,
+		EventBufferSize:    n.config.EventBufferSize,
+		JobTrackedVersions: n.config.JobTrackedVersions,
 	}
 	newState, err := state.NewStateStore(config)
 	if err != nil {

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -29,6 +29,17 @@ func testStateStore(t *testing.T) *StateStore {
 	return TestStateStore(t)
 }
 
+func TestStateStore_InvalidConfig(t *testing.T) {
+	config := &StateStoreConfig{
+		// default zero value, but explicit because it causes validation failure
+		JobTrackedVersions: 0,
+	}
+	store, err := NewStateStore(config)
+	must.Nil(t, store)
+	must.Error(t, err)
+	must.ErrorContains(t, err, "JobTrackedVersions must be positive")
+}
+
 func TestStateStore_Blocking_Error(t *testing.T) {
 	ci.Parallel(t)
 

--- a/nomad/state/testing.go
+++ b/nomad/state/testing.go
@@ -32,11 +32,13 @@ func TestStateStore(t testing.TB) *StateStore {
 
 func TestStateStorePublisher(t testing.TB) *StateStoreConfig {
 	return &StateStoreConfig{
-		Logger:          testlog.HCLogger(t),
-		Region:          "global",
-		EnablePublisher: true,
+		Logger:             testlog.HCLogger(t),
+		Region:             "global",
+		EnablePublisher:    true,
+		JobTrackedVersions: structs.JobDefaultTrackedVersions,
 	}
 }
+
 func TestStateStoreCfg(t testing.TB, cfg *StateStoreConfig) *StateStore {
 	state, err := NewStateStore(cfg)
 	if err != nil {


### PR DESCRIPTION
that occurred during server fsm restore, which later produced a negative slice index when trying to upsertJobVersion.

The bug appears to have been introduced in #17939 where [the risk was identified](https://github.com/hashicorp/nomad/pull/17939#discussion_r1268092633) but not quite covered all the way.

Stack trace of the panic:

```
==> Starting Nomad agent...
panic: runtime error: index out of range [-1]

goroutine 115 [running]:
github.com/hashicorp/nomad/nomad/state.(*StateStore).upsertJobVersion(0xc000ecedb0, 0x21da, 0xc000c50b40, 0xc000d70100)
        github.com/hashicorp/nomad/nomad/state/state_store.go:2068 +0x370
github.com/hashicorp/nomad/nomad/state.(*StateStore).upsertJobImpl(0xc00146cd80?, 0x21da, 0x0, 0xc000c50b40, 0x0, 0xc000d70100)
        github.com/hashicorp/nomad/nomad/state/state_store.go:1772 +0x6f5
github.com/hashicorp/nomad/nomad/state.(*StateStore).UpsertJobTxn(...)
        github.com/hashicorp/nomad/nomad/state/state_store.go:1691
github.com/hashicorp/nomad/nomad.(*nomadFSM).handleJobDeregister(0xc000a80ee0, 0x21da, {0xc000eb1767, 0x3}, {0xc000eb1770, 0x7}, 0x0, 0x0, 0xc000d70100)
        github.com/hashicorp/nomad/nomad/fsm.go:843 +0x4bc
github.com/hashicorp/nomad/nomad.(*nomadFSM).applyDeregisterJob.func1(0xc000d67338?)
        github.com/hashicorp/nomad/nomad/fsm.go:729 +0x4d
github.com/hashicorp/nomad/nomad/state.(*StateStore).WithWriteTransaction(0xc0002514a1?, 0x5c?, 0x15c?, 0xc0012d5b88)
        github.com/hashicorp/nomad/nomad/state/state_store.go:6477 +0x6b
github.com/hashicorp/nomad/nomad.(*nomadFSM).applyDeregisterJob(0xc000a80ee0, 0xda?, {0xc0002514a1, 0x15c, 0x15c}, 0x21da)
        github.com/hashicorp/nomad/nomad/fsm.go:728 +0x152
github.com/hashicorp/nomad/nomad.(*nomadFSM).Apply(0xc000a80ee0, 0xc001226960)
        github.com/hashicorp/nomad/nomad/fsm.go:242 +0x295
github.com/hashicorp/raft.(*Raft).runFSM.func1(0xc0009e59f0)
        github.com/hashicorp/raft@v1.5.0/fsm.go:101 +0x224
github.com/hashicorp/raft.(*Raft).runFSM.func2({0xc000d6a600, 0x40, 0x4?})
        github.com/hashicorp/raft@v1.5.0/fsm.go:124 +0x462
github.com/hashicorp/raft.(*Raft).runFSM(0xc00050fb80)
        github.com/hashicorp/raft@v1.5.0/fsm.go:240 +0x3e8
github.com/hashicorp/raft.(*raftState).goFunc.func1()
        github.com/hashicorp/raft@v1.5.0/state.go:149 +0x53
created by github.com/hashicorp/raft.(*raftState).goFunc in goroutine 1
        github.com/hashicorp/raft@v1.5.0/state.go:147 +0x79
```