### PR TITLE
docs: Update the order of docker auth method

### DIFF
--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -872,7 +872,7 @@ plugin "docker" {
 
 - `pull_activity_timeout` - Defaults to `2m`. If Nomad receives no communication
   from the Docker engine during an image pull within this timeframe, Nomad will
-  timeout the request that initiated the pull command. (Minimum of `1m`)
+  time out the request that initiated the pull command. (Minimum of `1m`)
 
 - `pids_limit` - Defaults to unlimited (`0`). An integer value that specifies
   the pid limit for all the Docker containers running on that Nomad client. You
@@ -908,7 +908,7 @@ host system.
   - `config`<a id="plugin_auth_file"></a> - Allows an operator to specify a
     JSON file which is in the dockercfg format containing authentication
     information for a private registry, from either (in order) `auths`,
-    `credHelpers` or `credsStore`.
+    `credsStore` or `credHelpers`.
 
   - `helper`<a id="plugin_auth_helper"></a> - Allows an operator to specify a
     [credsStore](https://docs.docker.com/engine/reference/commandline/login/#credential-helper-protocol)
@@ -1029,7 +1029,7 @@ options](/nomad/docs/configuration/client#options):
 - `docker.auth.config` <a id="auth_file"></a>- Allows an operator to specify a
   JSON file which is in the dockercfg format containing authentication
   information for a private registry, from either (in order) `auths`,
-  `credHelpers` or `credsStore`.
+  `credsStore` or `credHelpers`.
 
 - `docker.auth.helper` <a id="auth_helper"></a>- Allows an operator to specify a
   [credsStore](https://docs.docker.com/engine/reference/commandline/login/#credential-helper-protocol)


### PR DESCRIPTION
Hi team,

This PR fixes the order of docker auth method.

Fixes: https://github.com/hashicorp/nomad/issues/17760