### PR TITLE
jobspec: support `cluster` field for Consul and Service blocks

### DIFF
--- a/api/consul.go
+++ b/api/consul.go
@@ -13,13 +13,18 @@ import (
 type Consul struct {
 	// (Enterprise-only) Namespace represents a Consul namespace.
 	Namespace string `mapstructure:"namespace" hcl:"namespace,optional"`
+
+	// (Enterprise-only) Cluster represents a specific Consul cluster.
+	Cluster string `mapstructure:"cluster" hcl:"cluster,optional"`
 }
 
 // Canonicalize Consul into a canonical form. The Canonicalize structs containing
 // a Consul should ensure it is not nil.
 func (c *Consul) Canonicalize() {
-	// Nothing to do here.
-	//
+	if c.Cluster == "" {
+		c.Cluster = "default"
+	}
+
 	// If Namespace is nil, that is a choice of the job submitter that
 	// we should inherit from higher up (i.e. job<-group). Likewise, if
 	// Namespace is set but empty, that is a choice to use the default consul
@@ -30,6 +35,7 @@ func (c *Consul) Canonicalize() {
 func (c *Consul) Copy() *Consul {
 	return &Consul{
 		Namespace: c.Namespace,
+		Cluster:   c.Cluster,
 	}
 }
 

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -336,6 +336,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 						},
 						Consul: &Consul{
 							Namespace: "",
+							Cluster:   "default",
 						},
 						Update: &UpdateStrategy{
 							Stagger:          pointerOf(30 * time.Second),
@@ -422,6 +423,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 						},
 						Consul: &Consul{
 							Namespace: "",
+							Cluster:   "default",
 						},
 						Tasks: []*Task{
 							{
@@ -513,6 +515,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 						},
 						Consul: &Consul{
 							Namespace: "",
+							Cluster:   "default",
 						},
 						Update: &UpdateStrategy{
 							Stagger:          pointerOf(30 * time.Second),
@@ -687,6 +690,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 						},
 						Consul: &Consul{
 							Namespace: "",
+							Cluster:   "default",
 						},
 						Update: &UpdateStrategy{
 							Stagger:          pointerOf(30 * time.Second),
@@ -741,6 +745,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 										AddressMode: "auto",
 										OnUpdate:    "require_healthy",
 										Provider:    "consul",
+										Cluster:     "default",
 										Checks: []ServiceCheck{
 											{
 												Name:     "alive",
@@ -949,6 +954,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 						},
 						Consul: &Consul{
 							Namespace: "",
+							Cluster:   "default",
 						},
 						Update: &UpdateStrategy{
 							Stagger:          pointerOf(2 * time.Second),
@@ -997,6 +1003,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 						},
 						Consul: &Consul{
 							Namespace: "",
+							Cluster:   "default",
 						},
 						Update: &UpdateStrategy{
 							Stagger:          pointerOf(1 * time.Second),
@@ -1128,6 +1135,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 						},
 						Consul: &Consul{
 							Namespace: "",
+							Cluster:   "default",
 						},
 						Update: &UpdateStrategy{
 							Stagger:          pointerOf(30 * time.Second),
@@ -1182,6 +1190,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 						},
 						Consul: &Consul{
 							Namespace: "",
+							Cluster:   "default",
 						},
 						Update: &UpdateStrategy{
 							Stagger:          pointerOf(30 * time.Second),

--- a/api/services.go
+++ b/api/services.go
@@ -248,6 +248,9 @@ type Service struct {
 	// Provider defines which backend system provides the service registration,
 	// either "consul" (default) or "nomad".
 	Provider string `hcl:"provider,optional"`
+
+	// Cluster is valid only for Nomad Enterprise with provider: consul
+	Cluster string `hcl:"cluster,optional`
 }
 
 const (
@@ -284,6 +287,9 @@ func (s *Service) Canonicalize(t *Task, tg *TaskGroup, job *Job) {
 	// Default the service provider.
 	if s.Provider == "" {
 		s.Provider = ServiceProviderConsul
+	}
+	if s.Cluster == "" {
+		s.Cluster = "default"
 	}
 
 	if len(s.Meta) == 0 {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1491,6 +1491,7 @@ func ApiServicesToStructs(in []*api.Service, group bool) []*structs.Service {
 			TaggedAddresses:   maps.Clone(s.TaggedAddresses),
 			OnUpdate:          s.OnUpdate,
 			Provider:          s.Provider,
+			Cluster:           s.Cluster,
 		}
 
 		if l := len(s.Checks); l != 0 {
@@ -1847,6 +1848,7 @@ func apiConsulToStructs(in *api.Consul) *structs.Consul {
 	}
 	return &structs.Consul{
 		Namespace: in.Namespace,
+		Cluster:   in.Cluster,
 	}
 }
 

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -2985,11 +2985,13 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 				},
 				Consul: &structs.Consul{
 					Namespace: "team-foo",
+					Cluster:   "default",
 				},
 				Services: []*structs.Service{
 					{
 						Name:              "groupserviceA",
 						Provider:          "consul",
+						Cluster:           "default",
 						Tags:              []string{"a", "b"},
 						CanaryTags:        []string{"d", "e"},
 						EnableTagOverride: true,
@@ -3091,6 +3093,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 							{
 								Name:              "serviceA",
 								Provider:          "consul",
+								Cluster:           "default",
 								Tags:              []string{"1", "2"},
 								CanaryTags:        []string{"3", "4"},
 								EnableTagOverride: true,
@@ -3429,6 +3432,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 				},
 				Consul: &structs.Consul{
 					Namespace: "foo",
+					Cluster:   "default",
 				},
 				Tasks: []*structs.Task{
 					{

--- a/nomad/structs/consul.go
+++ b/nomad/structs/consul.go
@@ -7,6 +7,9 @@ package structs
 type Consul struct {
 	// Namespace in which to operate in Consul.
 	Namespace string
+
+	// Cluster (by name) to send API requests to
+	Cluster string
 }
 
 // Copy the Consul block.
@@ -16,6 +19,7 @@ func (c *Consul) Copy() *Consul {
 	}
 	return &Consul{
 		Namespace: c.Namespace,
+		Cluster:   c.Cluster,
 	}
 }
 
@@ -24,7 +28,14 @@ func (c *Consul) Equal(o *Consul) bool {
 	if c == nil || o == nil {
 		return c == o
 	}
-	return c.Namespace == o.Namespace
+	if c.Namespace != o.Namespace {
+		return false
+	}
+	if c.Cluster != o.Cluster {
+		return false
+	}
+
+	return true
 }
 
 // Validate returns whether c is valid.

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -3097,6 +3097,7 @@ func TestTaskGroupDiff(t *testing.T) {
 					{
 						Name:              "foo",
 						Namespace:         "team1",
+						Cluster:           "default",
 						TaskName:          "task1",
 						EnableTagOverride: false,
 						Checks: []*ServiceCheck{
@@ -3179,6 +3180,7 @@ func TestTaskGroupDiff(t *testing.T) {
 					{
 						Name:              "foo",
 						Namespace:         "team1",
+						Cluster:           "default",
 						TaskName:          "task2",
 						EnableTagOverride: true,
 						Checks: []*ServiceCheck{
@@ -3287,6 +3289,12 @@ func TestTaskGroupDiff(t *testing.T) {
 								Name: "AddressMode",
 								Old:  "",
 								New:  "",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "Cluster",
+								Old:  "default",
+								New:  "default",
 							},
 							{
 								Type: DiffTypeEdited,
@@ -6353,6 +6361,12 @@ func TestTaskDiff(t *testing.T) {
 							},
 							{
 								Type: DiffTypeNone,
+								Name: "Cluster",
+								Old:  "",
+								New:  "",
+							},
+							{
+								Type: DiffTypeNone,
 								Name: "EnableTagOverride",
 								Old:  "false",
 								New:  "false",
@@ -6510,6 +6524,12 @@ func TestTaskDiff(t *testing.T) {
 							{
 								Type: DiffTypeNone,
 								Name: "AddressMode",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "Cluster",
+								Old:  "",
+								New:  "",
 							},
 							{
 								Type: DiffTypeNone,
@@ -6965,7 +6985,8 @@ func TestTaskDiff(t *testing.T) {
 			Old: &Task{
 				Services: []*Service{
 					{
-						Name: "foo",
+						Name:    "foo",
+						Cluster: "default",
 						Checks: []*ServiceCheck{
 							{
 								Name:          "foo",
@@ -6991,7 +7012,8 @@ func TestTaskDiff(t *testing.T) {
 			New: &Task{
 				Services: []*Service{
 					{
-						Name: "foo",
+						Name:    "foo",
+						Cluster: "default",
 						Checks: []*ServiceCheck{
 							{
 								Name:          "foo",
@@ -7033,6 +7055,12 @@ func TestTaskDiff(t *testing.T) {
 								Name: "AddressMode",
 								Old:  "",
 								New:  "",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "Cluster",
+								Old:  "default",
+								New:  "default",
 							},
 							{
 								Type: DiffTypeNone,
@@ -8664,6 +8692,12 @@ func TestServicesDiff(t *testing.T) {
 							New:  "alloc",
 						},
 						{
+							Type: DiffTypeNone,
+							Name: "Cluster",
+							Old:  "",
+							New:  "",
+						},
+						{
 							Type: DiffTypeEdited,
 							Name: "EnableTagOverride",
 							Old:  "true",
@@ -8760,6 +8794,12 @@ func TestServicesDiff(t *testing.T) {
 							Name: "AddressMode",
 						},
 						{
+							Type: DiffTypeNone,
+							Name: "Cluster",
+							Old:  "",
+							New:  "",
+						},
+						{
 							Type: DiffTypeAdded,
 							Name: "EnableTagOverride",
 							New:  "false",
@@ -8825,6 +8865,12 @@ func TestServicesDiff(t *testing.T) {
 						{
 							Type: DiffTypeNone,
 							Name: "AddressMode",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "Cluster",
+							Old:  "",
+							New:  "",
 						},
 						{
 							Type: DiffTypeAdded,
@@ -8896,6 +8942,12 @@ func TestServicesDiff(t *testing.T) {
 						{
 							Type: DiffTypeNone,
 							Name: "AddressMode",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "Cluster",
+							Old:  "",
+							New:  "",
 						},
 						{
 							Type: DiffTypeNone,
@@ -8976,6 +9028,12 @@ func TestServicesDiff(t *testing.T) {
 						},
 						{
 							Type: DiffTypeNone,
+							Name: "Cluster",
+							Old:  "",
+							New:  "",
+						},
+						{
+							Type: DiffTypeNone,
 							Name: "EnableTagOverride",
 							Old:  "false",
 							New:  "false",
@@ -9038,6 +9096,7 @@ func TestServicesDiff(t *testing.T) {
 				{
 					Name:      "webapp",
 					Provider:  "nomad",
+					Cluster:   "default",
 					PortLabel: "http",
 				},
 			},
@@ -9045,6 +9104,7 @@ func TestServicesDiff(t *testing.T) {
 				{
 					Name:      "webapp",
 					Provider:  "consul",
+					Cluster:   "default",
 					PortLabel: "http",
 				},
 			},
@@ -9060,6 +9120,12 @@ func TestServicesDiff(t *testing.T) {
 						{
 							Type: DiffTypeNone,
 							Name: "AddressMode",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "Cluster",
+							Old:  "default",
+							New:  "default",
 						},
 						{
 							Type: DiffTypeNone,

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -615,6 +615,9 @@ type Service struct {
 	// left empty by the operator.
 	Provider string
 
+	// Consul Cluster (by name) to send API requests to
+	Cluster string
+
 	// Identity is a field populated automatically by the job mutating hook.
 	// Its name will be `consul-service/${service_name}`, and its contents will
 	// match the server's `consul.service_identity` configuration block.
@@ -957,6 +960,10 @@ func (s *Service) Equal(o *Service) bool {
 	}
 
 	if s.Provider != o.Provider {
+		return false
+	}
+
+	if s.Cluster != o.Cluster {
 		return false
 	}
 


### PR DESCRIPTION
This field supports the upcoming ENT-only multiple Consul clusters feature. The job validation and mutation hooks will come in a separate PR.

Ref: https://github.com/hashicorp/team-nomad/issues/404