### PR TITLE
docs: fix broken link to Consul DNS overview page

### DIFF
--- a/website/content/docs/networking/index.mdx
+++ b/website/content/docs/networking/index.mdx
@@ -282,7 +282,7 @@ the same port number.
 
 In Nomad, allocations use the IP address of the client they are running and are
 assigned random port numbers and so Nomad service discovery with DNS uses
-[`SRV` records][dns_srv] instead of `A` or `AAA` records.
+[`SRV` records][dns_srv] instead of `A` or `AAAA` records.
 
 ## Next topics
 
@@ -306,7 +306,7 @@ assigned random port numbers and so Nomad service discovery with DNS uses
 [cni]: /nomad/docs/networking/cni
 [cni_bridge]: https://www.cni.dev/plugins/current/main/bridge/
 [cni_install]: /nomad/docs/install#post-installation-steps
-[consul_dns]: /consul/docs/discovery/dns
+[consul_dns]: /consul/docs/services/discovery/dns-overview
 [consul_dns_forwarding]: /consul/tutorials/networking/dns-forwarding
 [consul_service_mesh]: /nomad/docs/integrations/consul-connect
 [dns_srv]: https://en.wikipedia.org/wiki/SRV_record

--- a/website/content/docs/networking/service-discovery.mdx
+++ b/website/content/docs/networking/service-discovery.mdx
@@ -134,7 +134,7 @@ rules to preview canaries.
 [`service`]: /nomad/docs/job-specification/service
 [`tags`]: /nomad/docs/job-specification/service#tags
 [`template`]: /nomad/docs/job-specification/template#template-examples
-[consul_dns]: /consul/docs/discovery/dns
+[consul_dns]: /consul/docs/services/discovery/dns-overview
 [consul_sd]: /consul/docs/concepts/service-discovery
 [ct_nomad_service_fn]: https://github.com/hashicorp/consul-template/blob/main/docs/templating-language.md#nomadservice
 [ct_service_fn]: https://github.com/hashicorp/consul-template/blob/main/docs/templating-language.md#service


### PR DESCRIPTION
closes #18405 