### PR TITLE
fingerprint: add warning in CE when there are multiple vaults

### DIFF
--- a/client/fingerprint/vault_ce.go
+++ b/client/fingerprint/vault_ce.go
@@ -15,5 +15,9 @@ func (f *VaultFingerprint) vaultConfigs(req *FingerprintRequest) map[string]*con
 		return nil
 	}
 
+	if len(req.Config.VaultConfigs) > 1 {
+		f.logger.Warn("multiple Vault configurations are only supported in Nomad Enterprise")
+	}
+
 	return map[string]*config.VaultConfig{"default": agentCfg.VaultConfig}
 }


### PR DESCRIPTION
Nomad CE only supports a single (default) Vault cluster, so log a warning if the user has configured multiple Vaults. Matches the logging done in https://github.com/hashicorp/nomad/pull/18392