### PR TITLE
client: fix role permission issue with duplicate policies.

### DIFF
--- a/.changelog/18419.txt
+++ b/.changelog/18419.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+acl: Fixed a bug where ACL tokens linked to ACL roles containing duplicate policies would cause erronous permission denined responses
+```

--- a/client/acl_test.go
+++ b/client/acl_test.go
@@ -131,13 +131,13 @@ func TestClient_resolveTokenACLRoles(t *testing.T) {
 	defer cleanup()
 
 	// Create an ACL Role and a client token which is linked to this.
-	mockACLRole := mock.ACLRole()
+	mockACLRole1 := mock.ACLRole()
 
 	mockACLToken := mock.ACLToken()
 	mockACLToken.Policies = []string{}
-	mockACLToken.Roles = []*structs.ACLTokenRoleLink{{ID: mockACLRole.ID}}
+	mockACLToken.Roles = []*structs.ACLTokenRoleLink{{ID: mockACLRole1.ID}}
 
-	err := testServer.State().UpsertACLRoles(structs.MsgTypeTestSetup, 10, []*structs.ACLRole{mockACLRole}, true)
+	err := testServer.State().UpsertACLRoles(structs.MsgTypeTestSetup, 10, []*structs.ACLRole{mockACLRole1}, true)
 	must.NoError(t, err)
 	err = testServer.State().UpsertACLTokens(structs.MsgTypeTestSetup, 20, []*structs.ACLToken{mockACLToken})
 	must.NoError(t, err)
@@ -150,12 +150,32 @@ func TestClient_resolveTokenACLRoles(t *testing.T) {
 	// Test the cache directly and check that the ACL role previously queried
 	// is now cached.
 	must.Eq(t, 1, testClient.roleCache.Len())
-	must.True(t, testClient.roleCache.Contains(mockACLRole.ID))
+	must.True(t, testClient.roleCache.Contains(mockACLRole1.ID))
 
 	// Resolve the roles again to check we get the same results.
 	resolvedRoles2, err := testClient.resolveTokenACLRoles(rootACLToken.SecretID, mockACLToken.Roles)
 	must.NoError(t, err)
 	must.SliceContainsAll(t, resolvedRoles1, resolvedRoles2)
+
+	// Create another ACL role which will have the same ACL policy links as the
+	// previous
+	mockACLRole2 := mock.ACLRole()
+	must.NoError(t,
+		testServer.State().UpsertACLRoles(
+			structs.MsgTypeTestSetup, 30, []*structs.ACLRole{mockACLRole2}, true))
+
+	// Update the ACL token so that it links to two ACL roles, which include
+	// duplicate ACL policies.
+	mockACLToken.Roles = append(mockACLToken.Roles, &structs.ACLTokenRoleLink{ID: mockACLRole2.ID})
+	must.NoError(t,
+		testServer.State().UpsertACLTokens(
+			structs.MsgTypeTestSetup, 40, []*structs.ACLToken{mockACLToken}))
+
+	// Ensure when resolving the ACL token, we are returned a deduplicated list
+	// of ACL policy names.
+	resolvedRoles3, err := testClient.resolveTokenACLRoles(rootACLToken.SecretID, mockACLToken.Roles)
+	must.NoError(t, err)
+	must.SliceContainsAll(t, []string{"mocked-test-policy-1", "mocked-test-policy-2"}, resolvedRoles3)
 }
 
 func TestClient_ACL_ResolveToken_Disabled(t *testing.T) {


### PR DESCRIPTION
This change deduplicates the ACL policy list generated from ACL roles referenced within an ACL token on the client.

Previously the list could contain duplicates, which would cause erronous permission denied errors when calling client related RPC/ HTTP API endpoints. This is because the client calls the ACL get policies endpoint which subsequently ensures the caller has permission to view the ACL policies. This check is performed by comparing the requested list args with the policies referenced by the caller ACL token. When a duplicate is present, this check fails, as the check must ensure the slices match exactly.

The linked issue has details on how to reproduce the problem, if readers want to test this before and after the code changes.

Closes #17201 