### PR TITLE
fingerprint: backoff on Consul fingerprint after initial success

### DIFF
--- a/.changelog/18426.txt
+++ b/.changelog/18426.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+fingerprint: clients now backoff after successfully fingerprinting Consul
+```

--- a/client/fingerprint/consul_test.go
+++ b/client/fingerprint/consul_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/config"
@@ -491,6 +492,10 @@ func TestConsulFingerprint_Fingerprint_oss(t *testing.T) {
 	node.Attributes["connect.grpc"] = "foo"
 	node.Attributes["unique.consul.name"] = "foo"
 
+	// Reset the nextCheck time for testing purposes, or we won't pick up the
+	// change until the next period, up to 2min from now
+	cf.states["default"].nextCheck = time.Now()
+
 	// execute second query with error
 	err2 := cf.Fingerprint(&FingerprintRequest{Config: cfg, Node: node}, &resp2)
 	must.NoError(t, err2)         // does not return error
@@ -569,6 +574,10 @@ func TestConsulFingerprint_Fingerprint_ent(t *testing.T) {
 	node.Attributes["consul.connect"] = "foo"
 	node.Attributes["connect.grpc"] = "foo"
 	node.Attributes["unique.consul.name"] = "foo"
+
+	// Reset the nextCheck time for testing purposes, or we won't pick up the
+	// change until the next period, up to 2min from now
+	cf.states["default"].nextCheck = time.Now()
 
 	// execute second query with error
 	err2 := cf.Fingerprint(&FingerprintRequest{Config: cfg, Node: node}, &resp2)


### PR DESCRIPTION
In the original design of Consul fingerprinting, we would poll every period so that we could change the client's fingerprint if Consul became unavailable. As of 1.4.0 (ref #14673) we no longer update the fingerprint in order to avoid excessive `Node.Register` RPCs when someone's Consul cluster is flapping.

This allows us to safely backoff Consul fingerprinting on success, just as we have with Vault.

Ref: https://github.com/hashicorp/nomad/pull/18392#discussion_r1318549264