### PR TITLE
docs: support multiple Vault and Consul clusters (ENT-only)

### DIFF
--- a/website/content/docs/configuration/consul.mdx
+++ b/website/content/docs/configuration/consul.mdx
@@ -38,6 +38,10 @@ Consul servers. If you are observing flapping services, you may have
 multiple Nomad agents talking to the same Consul agent. As such avoid
 configuring Nomad to talk to Consul via DNS such as consul.service.consul
 
+In Nomad Enterprise, you may specify multiple `consul` blocks to configure
+access to multiple Consul clusters. Each Consul cluster must have a different
+value for the [`name`](#name) field.
+
 ## `consul` Parameters
 
 - `address` `(string: "127.0.0.1:8500")` - Specifies the address to the local
@@ -99,6 +103,12 @@ configuring Nomad to talk to Consul via DNS such as consul.service.consul
 
 - `key_file` `(string: "")` - Specifies the path to the private key used for
   Consul communication. If this is set then you need to also set `cert_file`.
+
+- `name` `(string: "default")` <EnterpriseAlert inline/> - Specifies a name for
+  the cluster so it can be referred to by job submitters in the job
+  specification's [`consul.cluster`][] or [`service.cluster`][] fields. In Nomad
+  Community Edition, only the `"default"` cluster will be used, so this field
+  should be omitted.
 
 - `namespace` `(string: "")` - Specifies the [Consul namespace](/consul/docs/enterprise/namespaces)
   used by the Consul integration. If non-empty, this namespace will be used on
@@ -234,3 +244,5 @@ namespace "nomad-ns" {
 [go-sockaddr/template]: https://pkg.go.dev/github.com/hashicorp/go-sockaddr/template
 [grpc_port]: /consul/docs/agent/config/config-files#grpc_port
 [grpctls_port]: /consul/docs/agent/config/config-files#grpc_tls_port
+[`consul.cluster`]: /nomad/docs/job-specification/group#cluster
+[`service.cluster`]: /nomad/docs/job-specification/service#cluster

--- a/website/content/docs/configuration/vault.mdx
+++ b/website/content/docs/configuration/vault.mdx
@@ -23,6 +23,10 @@ vault {
 }
 ```
 
+In Nomad Enterprise, you may specify multiple `vault` blocks to configure access
+to multiple Vault clusters. Each Vault cluster must have a different value for
+the [`name`](#name) field.
+
 ## `vault` Parameters
 
 - `address` - `(string: "https://vault.service.consul:8200")` - Specifies the
@@ -68,6 +72,11 @@ vault {
   `cert_file`. This must be set if
   [tls_require_and_verify_client_cert](/vault/docs/configuration/listener/tcp#tls_require_and_verify_client_cert)
   is enabled in Vault.
+
+- `name` `(string: "default")` <EnterpriseAlert inline/> - Specifies a name for
+  the cluster so it can be referred to by job submitters in the job
+  specification's [`vault.cluster`][] field. In Nomad Community Edition, only
+  the `"default"` cluster will be used, so this field should be omitted.
 
 - `namespace` `(string: "")` - Specifies the [Vault namespace](/vault/docs/enterprise/namespaces)
   used by the Vault integration. If non-empty, this namespace will be used on
@@ -150,3 +159,4 @@ can be accomplished by sending the process a `SIGHUP` signal.
 
 [vault]: https://www.vaultproject.io/ 'Vault by HashiCorp'
 [nomad-vault]: /nomad/docs/integrations/vault-integration 'Nomad Vault Integration'
+[`vault.cluster`]: /nomad/docs/job-specification/vault#cluster

--- a/website/content/docs/job-specification/group.mdx
+++ b/website/content/docs/job-specification/group.mdx
@@ -117,6 +117,11 @@ job "docs" {
 
 ### `consul` Parameters
 
+- `cluster` `(string: "default")` <EnterpriseAlert inline/> - Specifies the
+  Consul cluster to use. The Nomad client will retrieve a Consul token from the
+  cluster configured in the agent configuration with the same
+  [`consul.name`][]. In Nomad Community Edition, this field is ignored.
+
 - `namespace` `(string: "")` <EnterpriseAlert inline/> - The Consul namespace in which
   group and task-level services within the group will be registered. Use of
   `template` to access Consul KV will read from the specified Consul namespace.
@@ -358,3 +363,4 @@ flag will be _ignored_. Deploying a job with `max_client_disconnect` to a
 [update]: /nomad/docs/job-specification/update 'Nomad update Job Specification'
 [vault]: /nomad/docs/job-specification/vault 'Nomad vault Job Specification'
 [volume]: /nomad/docs/job-specification/volume 'Nomad volume Job Specification'
+[`consul.name`]: /nomad/docs/configuration/consul#name

--- a/website/content/docs/job-specification/service.mdx
+++ b/website/content/docs/job-specification/service.mdx
@@ -77,6 +77,12 @@ Connect][connect] integration.
   `nomad`. All services within a single task group must utilise the same
   provider value.
 
+- `cluster` `(string: "default")` <EnterpriseAlert inline/> - Specifies the
+  Consul cluster to use, when the `provider` is `"consul"`. The Nomad client
+  will retrieve a Consul token from the cluster configured in the agent
+  configuration with the same [`consul.name`][]. In Nomad Community Edition,
+  this field is ignored.
+
 - `check` <code>([Check][check]: nil)</code> - Specifies a health
   check associated with the service. This can be specified multiple times to
   define multiple checks for the service. At this time, a check using the Nomad
@@ -517,3 +523,4 @@ advertise and check directly since Nomad isn't managing any port assignments.
 [network_mode]: /nomad/docs/job-specification/network#mode
 [on_update]: /nomad/docs/job-specification/service#on_update
 [tagged_addresses]: /consul/docs/discovery/services#tagged-addresses
+[`consul.name`]: /nomad/docs/configuration/consul#name

--- a/website/content/docs/job-specification/vault.mdx
+++ b/website/content/docs/job-specification/vault.mdx
@@ -30,6 +30,7 @@ job "docs" {
   group "example" {
     task "server" {
       vault {
+        cluster  = "default"
         policies = ["cdn", "frontend"]
 
         change_mode   = "signal"
@@ -67,6 +68,11 @@ with Vault as well.
 - `change_signal` `(string: "")` - Specifies the signal to send to the task as a
   string like `"SIGUSR1"` or `"SIGINT"`. This option is required if the
   `change_mode` is `signal`.
+
+- `cluster` `(string: "default")` <EnterpriseAlert inline/> - Specifies the
+  Vault cluster to use. The Nomad client will retrieve a Vault token from the
+  cluster configured in the agent configuration with the same
+  [`vault.name`][]. In Nomad Community Edition, this field is ignored.
 
 - `env` `(bool: true)` - Specifies if the `VAULT_TOKEN` and `VAULT_NAMESPACE`
   environment variables should be set when starting the task.
@@ -199,3 +205,4 @@ vault {
 [restart]: /nomad/docs/job-specification/restart "Nomad restart Job Specification"
 [template]: /nomad/docs/job-specification/template "Nomad template Job Specification"
 [vault]: https://www.vaultproject.io/ "Vault by HashiCorp"
+[`vault.name`]: /nomad/docs/configuration/vault#name

--- a/website/content/docs/other-specifications/namespace.mdx
+++ b/website/content/docs/other-specifications/namespace.mdx
@@ -42,6 +42,18 @@ node_pool_config {
   default = "prod"
   allowed = ["all", "default"]
 }
+
+# Vault configuration is a Nomad Enterprise feature.
+vault {
+  default = "default"
+  allowed = ["default", "infra"]
+}
+
+# Consul configuration is a Nomad Enterprise feature.
+consul {
+  default = "default"
+  allowed = ["all", "default"]
+}
 ```
 
 ## Namespace Specification Parameters
@@ -65,6 +77,14 @@ node_pool_config {
 - `node_pool_config` <code>([NodePoolConfiguration](#node_pool_config-parameters): &lt;optional&gt;)</code> <EnterpriseAlert inline /> -
   Specifies node pool configurations. These values are checked at job
   submission.
+
+- `vault` <code>([Vault](#vault-parameters): &lt;optional&gt;)</code> <EnterpriseAlert inline /> -
+  Specifies which Vault clusters are allowed to be used from this
+  namespace. These values are checked at job submission.
+
+- `consul` <code>([Consul](#consul-parameters): &lt;optional&gt;)</code> <EnterpriseAlert inline /> -
+  Specifies which Consul clusters are allowed to be used from this
+  namespace. These values are checked at job submission.
 
 ### `capabilities` Parameters
 
@@ -90,6 +110,40 @@ node_pool_config {
   globbing through the use of `*` for multi-character matching. If specified,
   any node pool is allowed to be used, except for those that match any of these
   patterns. This field cannot be used with `allowed`.
+
+### `vault` Parameters <EnterpriseAlert inline />
+
+- `default` `(string: "default")` - Specifies the Vault cluster to use for jobs
+  in this namespace that don't define a Vault cluster in their specification.
+
+- `allowed` `(array<string>: nil)` - Specifies the Vault clusters that are
+  allowed to be used by jobs in this namespace. By default, all Vault clusters
+  are allowed.  If an empty list is provided only the namespace's default Vault
+  cluster is allowed. This field supports wildcard globbing through the use of
+  `*` for multi-character matching. This field cannot be used with `denied`.
+
+- `denied` `(array<string>: nil)` - Specifies the Vault clusters that are not
+  allowed to be used by jobs in this namespace. This field supports wildcard
+  globbing through the use of `*` for multi-character matching. If specified,
+  any Vault cluster is allowed to be used, except for those that match any of
+  these patterns. This field cannot be used with `allowed`.
+
+### `consul` Parameters <EnterpriseAlert inline />
+
+- `default` `(string: "default")` - Specifies the Consul cluster to use for jobs
+  in this namespace that don't define a Consul cluster in their specification.
+
+- `allowed` `(array<string>: nil)` - Specifies the Consul clusters that are
+  allowed to be used by jobs in this namespace. By default, all Consul clusters
+  are allowed.  If an empty list is provided only the namespace's default Consul
+  cluster is allowed. This field supports wildcard globbing through the use of
+  `*` for multi-character matching. This field cannot be used with `denied`.
+
+- `denied` `(array<string>: nil)` - Specifies the Consul clusters that are not
+  allowed to be used by jobs in this namespace. This field supports wildcard
+  globbing through the use of `*` for multi-character matching. If specified,
+  any Consul cluster is allowed to be used, except for those that match any of
+  these patterns. This field cannot be used with `allowed`.
 
 [cli_ns_apply]: /nomad/docs/commands/namespace/apply
 [hcl2]: /nomad/docs/job-specification/hcl2


### PR DESCRIPTION
This changeset is the documentation for supporting multiple Vault and Consul clusters in Nomad Enterprise. It includes documentation changes for the agent configuration (#18255), the namespace specification (#18425), and the vault, consul, and service blocks of the jobspec (#18409).

Preview links:
* https://nomad-asjneuto4-hashicorp.vercel.app/nomad/docs/configuration/consul
* https://nomad-asjneuto4-hashicorp.vercel.app/nomad/docs/configuration/vault
* https://nomad-asjneuto4-hashicorp.vercel.app/nomad/docs/other-specifications/namespace
* https://nomad-asjneuto4-hashicorp.vercel.app/nomad/docs/job-specification/group#cluster
* https://nomad-asjneuto4-hashicorp.vercel.app/nomad/docs/job-specification/service#cluster
* https://nomad-asjneuto4-hashicorp.vercel.app/nomad/docs/job-specification/vault#cluster