### PR TITLE
bubble up the error message from go-getter

### DIFF
--- a/.changelog/18444.txt
+++ b/.changelog/18444.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+status: go-getter failure reason now shown in `alloc status`
+```

--- a/client/allocrunner/taskrunner/getter/util.go
+++ b/client/allocrunner/taskrunner/getter/util.go
@@ -143,10 +143,11 @@ func (s *Sandbox) runCmd(env *parameters) error {
 
 	// start & wait for the subprocess to terminate
 	if err := cmd.Run(); err != nil {
-		subproc.Log(output, s.logger.Error)
+		msg := subproc.Log(output, s.logger.Error)
+
 		return &Error{
 			URL:         env.Source,
-			Err:         fmt.Errorf("getter subprocess failed: %v", err),
+			Err:         fmt.Errorf("getter subprocess failed: %v [%v]", err, msg),
 			Recoverable: true,
 		}
 	}

--- a/client/allocrunner/taskrunner/getter/util.go
+++ b/client/allocrunner/taskrunner/getter/util.go
@@ -147,7 +147,7 @@ func (s *Sandbox) runCmd(env *parameters) error {
 
 		return &Error{
 			URL:         env.Source,
-			Err:         fmt.Errorf("getter subprocess failed: %v [%v]", err, msg),
+			Err:         fmt.Errorf("getter subprocess failed: %v: %v", err, msg),
 			Recoverable: true,
 		}
 	}

--- a/helper/subproc/subproc.go
+++ b/helper/subproc/subproc.go
@@ -45,12 +45,14 @@ func Print(format string, args ...any) {
 //
 // r should be a buffer containing output (typically combined stdin + stdout)
 // f should be an HCLogger Print method (e.g. log.Debug)
-func Log(r io.Reader, f func(msg string, args ...any)) {
+func Log(r io.Reader, f func(msg string, args ...any)) string {
 	scanner := bufio.NewScanner(r)
+	line := "unknown error"
 	for scanner.Scan() {
-		line := scanner.Text()
+		line = scanner.Text()
 		f("sub-process", "OUTPUT", line)
 	}
+	return line
 }
 
 // Context creates a context setup with the given timeout.

--- a/helper/subproc/subproc.go
+++ b/helper/subproc/subproc.go
@@ -54,7 +54,7 @@ func Log(r io.Reader, f func(msg string, args ...any)) string {
 		lines += line + "\n"
 		f("sub-process", "OUTPUT", line)
 	}
-	return strings.TrimSuffix(lines, "\n")
+	return strings.TrimSpace(lines)
 }
 
 // Context creates a context setup with the given timeout.

--- a/helper/subproc/subproc.go
+++ b/helper/subproc/subproc.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"time"
+	"strings"
 )
 
 const (
@@ -47,12 +48,13 @@ func Print(format string, args ...any) {
 // f should be an HCLogger Print method (e.g. log.Debug)
 func Log(r io.Reader, f func(msg string, args ...any)) string {
 	scanner := bufio.NewScanner(r)
-	line := "unknown error"
+	lines := ""
 	for scanner.Scan() {
-		line = scanner.Text()
+		line := scanner.Text()
+		lines += line + "\n"
 		f("sub-process", "OUTPUT", line)
 	}
-	return line
+	return strings.TrimSuffix(lines, "\n")
 }
 
 // Context creates a context setup with the given timeout.


### PR DESCRIPTION
possible fix for https://github.com/hashicorp/nomad/issues/18442

EDIT:

Tested the locally built Nomad agent binary using `nomad agent -dev` with:

```bash
mkdir large_tar
cd large_tar/
mkdir data
for i in {1..5000} ; do echo "" > data/$i.txt; done
tar czvf data.tar.gz data/
python3 -m http.server 9000
```


```hcl
job "tar_fail" {

  group "cache" {
    network {
      port "db" {
        to = 6379
      }
    }

    task "redis" {
      artifact {
        source      = "http://127.0.0.1:9000/data.tar.gz"
        destination = "local/some-directory"
      }

      driver = "docker"

      config {
        image          = "redis:7"
        ports          = ["db"]
        auth_soft_fail = true
      }

      identity {
        env  = true
        file = true
      }

      resources {
        cpu    = 500
        memory = 256
      }
    }
  }
}
```
