### PR TITLE
[f-gh-17449] Add flag to modify the number of time the client attempts to call the locks endpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -584,6 +584,7 @@ func (c *Client) SetSecretID(secretID string) {
 }
 
 func (c *Client) configureRetries(ro *retryOptions) {
+
 	c.config.retryOptions = &retryOptions{
 		maxRetries:      defaultNumberOfRetries,
 		maxBackoffDelay: defaultMaxBackoffDelay,
@@ -594,7 +595,7 @@ func (c *Client) configureRetries(ro *retryOptions) {
 		c.config.retryOptions.delayBase = ro.delayBase
 	}
 
-	if ro.maxRetries != 0 {
+	if ro.maxRetries != defaultNumberOfRetries {
 		c.config.retryOptions.maxRetries = ro.maxRetries
 	}
 

--- a/api/locks.go
+++ b/api/locks.go
@@ -57,6 +57,7 @@ func (c *Client) Locks(wo WriteOptions, v Variable, opts ...LocksOption) (*Locks
 		ttl:          ttl,
 		ro: retryOptions{
 			maxToLastCall: ttl,
+			maxRetries:    defaultNumberOfRetries,
 		},
 	}
 

--- a/api/retry.go
+++ b/api/retry.go
@@ -45,7 +45,7 @@ func (c *Client) retryPut(ctx context.Context, endpoint string, in, out any, q *
 	t := time.NewTimer(attemptDelay)
 	defer t.Stop()
 
-	for attempt := int64(0); attempt < c.config.retryOptions.maxRetries; attempt++ {
+	for attempt := int64(0); attempt < c.config.retryOptions.maxRetries+1; attempt++ {
 		attemptDelay = c.calculateDelay(attempt)
 
 		t.Reset(attemptDelay)

--- a/api/retry_test.go
+++ b/api/retry_test.go
@@ -94,7 +94,7 @@ func Test_RetryPut_one_call(t *testing.T) {
 		must.Error(t, err)
 		must.Nil(t, md)
 
-		must.Len(t, 1, mh.callsCounter)
+		must.Len(t, 2, mh.callsCounter)
 	})
 }
 
@@ -120,7 +120,7 @@ func Test_RetryPut_capped_base_too_big(t *testing.T) {
 		md, err := cm.retryPut(context.TODO(), "/endpoint", nil, nil, &WriteOptions{})
 		must.Error(t, err)
 
-		must.Len(t, 3, mh.callsCounter)
+		must.Len(t, 4, mh.callsCounter)
 
 		must.Nil(t, md)
 		must.Greater(t, cm.config.retryOptions.maxBackoffDelay, mh.callsCounter[1].Sub(mh.callsCounter[0]))

--- a/command/var_lock.go
+++ b/command/var_lock.go
@@ -66,6 +66,7 @@ Var lock Options:
   -delay
 	Optional, time the variable is blocked from locking when a lease is not renewed.	
 	Defaults to 15s.
+
   -max-retry
 	Optional, max-retry up to this number of times if Nomad returns a 500 error
 	while monitoring the lock. This allows riding out brief periods of


### PR DESCRIPTION
Following the Consul lead, this PR introduces a flag to use on the CLI when using the var lock command that allows the user to modify the number of times the client retries a call in case of an unexpected response.