### PR TITLE
e2e: packer windows from "ECS_Optimized" image

### DIFF
--- a/e2e/terraform/packer/windows-2016-amd64.pkr.hcl
+++ b/e2e/terraform/packer/windows-2016-amd64.pkr.hcl
@@ -22,7 +22,7 @@ source "amazon-ebs" "latest_windows_2016" {
 
   source_ami_filter {
     filters = {
-      name                = "Windows_Server-2016-English-Full-Containers-*"
+      name                = "Windows_Server-2016-English-Full-ECS_Optimized-*"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }


### PR DESCRIPTION
E2E tests have not been running due to Windows packer build failing with "No AMI was found matching filters"

Specifically the filter that this PR alters, because "Containers" AMIs evaporated at some point...
https://aws.amazon.com/marketplace/pp/prodview-yfve3zjgfjtug
> This version has been removed and is no longer available to new customers.

Related PR from not that long ago, which switched to "Containers" -- #17572 

I confirmed that "[ECS_Optimized](https://aws.amazon.com/marketplace/pp/prodview-i7fubrhchpwdi)" can run docker commands, and build scripts run clean, but I have not verified an actual E2E run against it manually.

I tried updating to 2019, but at least one build script failed (install-consul.ps1), and I don't want to hunt it down right now.  For posterity, the error was:

```
==> amazon-ebs.latest_windows_2016: Invoke-WebRequest : Win32 internal error "Access is denied" 0x5 occurred while reading the console output buffer.
==> amazon-ebs.latest_windows_2016: Contact Microsoft Customer Support Services.
==> amazon-ebs.latest_windows_2016: At C:\Windows\Temp\script-64ff3ce4-0a28-6829-4fda-2fdf97beef2f.ps1:22 char:5
==> amazon-ebs.latest_windows_2016: +     Invoke-WebRequest -Uri $url -Outfile consul.zip -ErrorAction Stop
==> amazon-ebs.latest_windows_2016: +     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
==> amazon-ebs.latest_windows_2016:     + CategoryInfo          : ReadError: (:) [Invoke-WebRequest], HostException
==> amazon-ebs.latest_windows_2016:     + FullyQualifiedErrorId : ReadConsoleOutput,Microsoft.PowerShell.Commands.InvokeWebRequestCommand
```