### PR TITLE
[f-gh-17449] Docs: Add website documentation for the var lock command and HTTP lock operations

### DIFF
--- a/website/content/api-docs/variables/index.mdx
+++ b/website/content/api-docs/variables/index.mdx
@@ -9,7 +9,7 @@ description: |-
 # Vars HTTP API
 
 The `/var` and `/vars` endpoints are used to query for and interact with
-variables and for set up locks and leases over the variables.
+variables, and set up locks and leases over them.
 
 See the [Variables] documentation for information how these capabilities are
 used. For a CLI to perform these operations manually, please see the

--- a/website/content/api-docs/variables/index.mdx
+++ b/website/content/api-docs/variables/index.mdx
@@ -1,0 +1,18 @@
+---
+layout: api
+page_title: Variables - HTTP API
+description: |-
+  The /var endpoints are used to query for and interact with variables and variable
+  locking.
+---
+
+# Vars HTTP API
+
+The `/var` and `/vars` endpoints are used to query for and interact with
+variables and for set up locks and leases over the variables.
+
+See the [Variables] documentation for information how these capabilities are
+used. For a CLI to perform these operations manually, please see the
+documentation for the [`nomad var`] commands.
+
+Please choose a sub-section in the navigation for more information

--- a/website/content/api-docs/variables/locks.mdx
+++ b/website/content/api-docs/variables/locks.mdx
@@ -160,7 +160,7 @@ $ curl \
 
 #### Sample Response
 
-The response body returns released variable along with metadata
+The response body returns the released variable along with metadata
 created by the server:
 
 ```json

--- a/website/content/api-docs/variables/locks.mdx
+++ b/website/content/api-docs/variables/locks.mdx
@@ -199,7 +199,7 @@ will include only metadata and not the `Items` field:
 
 When creating a new variable using the lock-acquire operation, all the known 
 [restrictions][] regarding the path and size of the content apply, but unlike 
-regular variables, locked variables can be created with or without any itmes.
+regular variables, locked variables can be created with or without any items.
 
 The lock TTL and Delay must be values between 10 seconds and 24 hours.
 

--- a/website/content/api-docs/variables/locks.mdx
+++ b/website/content/api-docs/variables/locks.mdx
@@ -24,7 +24,7 @@ The lock operation parameter can be:
 - `lock-acquire`: When used, the call will introduce a lock over the variable if 
 it exists, or create a new one if it doesn't. The lock ID will be returned in the 
 response and it must be provided to perform any other operation over the lock. 
-The variable items can be udpated at any time using the lock ID, but the lock
+The variable items can be updated at any time using the lock ID, but the lock
 parametes are unmmutable, attempting to modify them while a lock is present will
 generate an error. 
 

--- a/website/content/api-docs/variables/locks.mdx
+++ b/website/content/api-docs/variables/locks.mdx
@@ -23,12 +23,17 @@ The lock operation parameter can be:
 
 - `lock-acquire`: When used, the call will introduce a lock over the variable if 
 it exists, or create a new one if it doesn't. The lock ID will be returned in the 
-response and it must be provided to perform any other operation over the lock. In
-the case of attempting to acquire a variable that is already locked, a conflict
+response and it must be provided to perform any other operation over the lock. 
+The variable items can be udpated at any time using the lock ID, but the lock
+parametes are unmmutable, attempting to modify them while a lock is present will
+generate an error. 
+
+In the case of attempting to acquire a variable that is already locked, a conflict
 response will be returned. 
 
 The lock-acquire operation will override the variable items if new values are 
 present.
+
 
 #### Sample Request
 
@@ -130,8 +135,8 @@ parameters:
 inmediatly remove the lock over the variable, making it modifiable without 
 restrictions again. 
 
-The lock-release operation will not override the variable items, if new values 
-are present, they will be silently discarded.
+The lock-release operation will not override the variable items, if the request
+body contains any item, it will generate a bad request response.
 
 #### Sample Request
 
@@ -162,11 +167,6 @@ created by the server:
 {
   "CreateIndex": 11,
   "CreateTime": 1694555280887153000,
-  "Items": {
-    "user": "me",
-    "password": "passw0rd1"
-  },
-  "Lock": null,
   "ModifyIndex": 66,
   "ModifyTime": 1694556922600469000,
   "Namespace": "prod",

--- a/website/content/api-docs/variables/locks.mdx
+++ b/website/content/api-docs/variables/locks.mdx
@@ -25,7 +25,7 @@ The lock operation parameter can be:
 it exists, or create a new one if it doesn't. The lock ID will be returned in the 
 response and it must be provided to perform any other operation over the lock. 
 The variable items can be updated at any time using the lock ID, but the lock
-parametes are unmmutable, attempting to modify them while a lock is present will
+parameters are unmmutable, attempting to modify them while a lock is present will
 generate an error. 
 
 In the case of attempting to acquire a variable that is already locked, a conflict

--- a/website/content/api-docs/variables/locks.mdx
+++ b/website/content/api-docs/variables/locks.mdx
@@ -11,7 +11,7 @@ The `/var` endpoint is used to hold, renew and release a lock over a variable.
 ## Lock Variable
 
 The endpoint to create a variable can also be used to hold a lock and interact with
-it throught the use of a parameter defining the operation to be performed.
+it through the use of a parameter defining the operation to be performed.
 
 | Method | Path                                 | Produces           |
 |--------|--------------------------------------|--------------------|

--- a/website/content/api-docs/variables/locks.mdx
+++ b/website/content/api-docs/variables/locks.mdx
@@ -20,13 +20,15 @@ it throught the use of a parameter defining the operation to be performed.
 ### Parameters
 
 The lock operation parameter can be:
+
 - `lock-acquire`: When used, the call will introduce a lock over the variable if 
 it exists, or create a new one if it doesn't. The lock ID will be returned in the 
 response and it must be provided to perform any other operation over the lock. In
 the case of attempting to acquire a variable that is already locked, a conflict
-response will be returned. When creating a new variable, all the known 
-[restrictions][] regarding the path and size of the content apply, but unlike 
-regular variables, locked variables can be created with or without any itmes.
+response will be returned. 
+
+The lock-acquire operation will override the variable items if new values are 
+present.
 
 #### Sample Request
 
@@ -48,80 +50,158 @@ $ curl \
   },
   "Lock": {
     "TTL": "15s",
-    "LockDelay"
+    "LockDelay": "1m"
   }
+}
+```
+
+#### Sample Response
+
+The response body returns the created or updated variable including the lock 
+parameters and ID, along with metadata created by the server:
+
+```json
+{
+  "CreateIndex": 15,
+  "CreateTime": 1694552155379696000,
+  "Items": {
+    "user": "me",
+    "password": "passw0rd1"
+  },
+  "Lock": {
+    "TTL": "15s",
+    "LockDelay": "15s",
+    "ID": "670c7248-e2ef-f982-e4c5-f4437f75f1e4"
+  },
+  "ModifyIndex": 16,
+  "ModifyTime": 1694552206138804000,
+  "Namespace": "prod",
+  "Path": "example/first"
 }
 ```
 
 - `lock-renew`: A valid call to lock renew needs to be placed before the lock's
-TTL is up in order to mantain the variable locked. A valid 
+TTL is up in order to mantain the variable locked. A valid call must include the
+lock ID as part of the request body. If the lock TTL is up without a renewal or
+release calls, the variable will remain unlockable for at least the lock dealy. 
 
-- `lock-release`
-
-
-
-### Sample Request
+#### Sample Request
 
 ```shell-session
 $ curl \
     -XPUT -d@spec.nsv.json \
-    https://localhost:4646/v1/var/example/first
+    https://localhost:4646/v1/var/example/first?lock-renew
 ```
 
-### Sample Payload
+#### Sample Payload
 
 ```json
 {
-  "Namespace": "prod",
   "Path": "example/first",
-  "Items": {
-    "user": "me",
-    "password": "passw0rd1"
+  "Namespace": "prod",
+  "Lock": {
+    "ID": "670c7248-e2ef-f982-e4c5-f4437f75f1e4"
   }
 }
 ```
 
-### Sample Response
+#### Sample Response
 
-The response body returns the created or updated variable along with metadata
+The response body only returns metadata created by the server and the lock
+parameters:
+
+```json
+{
+  "CreateIndex": 11,
+  "CreateTime": 1694555280887153000,
+  "Lock": {
+    "TTL": "15s",
+    "LockDelay": "15s",
+    "ID": "670c7248-e2ef-f982-e4c5-f4437f75f1e4"
+  },
+  "ModifyIndex": 43,
+  "ModifyTime": 1694556175092779000,
+  "Namespace": "prod",
+  "Path": "example/first"
+}
+```
+
+- `lock-release`: A call to the endpoint with the `lock-release` operation will
+inmediatly remove the lock over the variable, making it modifiable without 
+restrictions again. 
+
+The lock-release operation will override the variable items if new values are 
+present.
+
+#### Sample Request
+
+```shell-session
+$ curl \
+    -XPUT -d@spec.nsv.json \
+    https://localhost:4646/v1/var/example/first?lock-release
+```
+
+#### Sample Payload
+
+```json
+{
+  "Path": "example/first",
+  "Namespace": "prod",
+  "Lock": {
+    "ID": "670c7248-e2ef-f982-e4c5-f4437f75f1e4"
+  }
+}
+```
+
+#### Sample Response
+
+The response body returns released variable along with metadata
 created by the server:
 
 ```json
 {
-  "Namespace": "prod",
-  "Path": "example/first",
-  "CreateIndex": 1457,
-  "ModifyIndex": 1457,
-  "CreateTime": 1662061225600373000,
-  "ModifyTime": 1662061225600373000,
+  "CreateIndex": 11,
+  "CreateTime": 1694555280887153000,
   "Items": {
     "user": "me",
     "password": "passw0rd1"
-  }
+  },
+  "Lock": null,
+  "ModifyIndex": 66,
+  "ModifyTime": 1694556922600469000,
+  "Namespace": "prod",
+  "Path": "example/first"
 }
 ```
 
 ### Sample Response for Conflict
 
-In the case of a compare-and-set conflict, the API will return HTTP error code
+In the case of an attempt to lock, renew or modify a locked variable
+without the correct ID, the API will return HTTP error code
 409 and a response body showing the conflicting variable. If the provided ACL
 token does not also have `read` permissions to the variable path, the response
 will include only metadata and not the `Items` field:
 
 ```json
 {
-  "Namespace": "prod",
-  "Path": "example/first",
-  "CreateIndex": 1457,
-  "ModifyIndex": 1457,
-  "CreateTime": 1662061225600373000,
-  "ModifyTime": 1662061225600373000,
-  "Items": {
-    "user": "me",
-    "password": "passw0rd1"
-  }
+  "CreateIndex": 0,
+  "CreateTime": 0,
+  "Items": null,
+  "Lock": null,
+  "ModifyIndex": 0,
+  "ModifyTime": 0,
+  "Namespace": "default",
+  "Path": "example/first"
 }
 ```
+
+## Restrictions
+
+When creating a new variable using the lock-acquire operation, all the known 
+[restrictions][] regarding the path and size of the content apply, but unlike 
+regular variables, locked variables can be created with or without any itmes.
+
+The lock TTL and Delay must be values between 10 seconds and 24 hours.
 
 [Variables]: /nomad/docs/concepts/variables
 [`nomad var`]: /nomad/docs/commands/var

--- a/website/content/api-docs/variables/locks.mdx
+++ b/website/content/api-docs/variables/locks.mdx
@@ -1,0 +1,130 @@
+---
+layout: api
+page_title: Variable Locks - HTTP API
+description: The /var endpoints are used to query for and interact with variables and locks.
+---
+
+# Locks HTTP API
+
+The `/var` endpoint is used hold, renew and release a lock over a variable.
+
+## Lock Variable
+
+The endpoint to create a variable can also be used to hold a lock and interact with
+it throught the use of a parameter defining the operation to be performed.
+
+| Method | Path                                 | Produces           |
+|--------|--------------------------------------|--------------------|
+| `PUT`  | `/v1/var/:var_path?<lock-operation>` | `application/json` |
+
+### Parameters
+
+The lock operation parameter can be:
+- `lock-acquire`: When used, the call will introduce a lock over the variable if 
+it exists, or create a new one if it doesn't. The lock ID will be returned in the 
+response and it must be provided to perform any other operation over the lock. In
+the case of attempting to acquire a variable that is already locked, a conflict
+response will be returned. When creating a new variable, all the known 
+[restrictions][] regarding the path and size of the content apply, but unlike 
+regular variables, locked variables can be created with or without any itmes.
+
+#### Sample Request
+
+```shell-session
+$ curl \
+    -XPUT -d@spec.nsv.json \
+    https://localhost:4646/v1/var/example/first?lock-acquire
+```
+
+#### Sample Payload
+
+```json
+{
+  "Namespace": "prod",
+  "Path": "example/first",
+  "Items": {
+    "user": "me",
+    "password": "passw0rd1"
+  },
+  "Lock": {
+    "TTL": "15s",
+    "LockDelay"
+  }
+}
+```
+
+- `lock-renew`: A valid call to lock renew needs to be placed before the lock's
+TTL is up in order to mantain the variable locked. A valid 
+
+- `lock-release`
+
+
+
+### Sample Request
+
+```shell-session
+$ curl \
+    -XPUT -d@spec.nsv.json \
+    https://localhost:4646/v1/var/example/first
+```
+
+### Sample Payload
+
+```json
+{
+  "Namespace": "prod",
+  "Path": "example/first",
+  "Items": {
+    "user": "me",
+    "password": "passw0rd1"
+  }
+}
+```
+
+### Sample Response
+
+The response body returns the created or updated variable along with metadata
+created by the server:
+
+```json
+{
+  "Namespace": "prod",
+  "Path": "example/first",
+  "CreateIndex": 1457,
+  "ModifyIndex": 1457,
+  "CreateTime": 1662061225600373000,
+  "ModifyTime": 1662061225600373000,
+  "Items": {
+    "user": "me",
+    "password": "passw0rd1"
+  }
+}
+```
+
+### Sample Response for Conflict
+
+In the case of a compare-and-set conflict, the API will return HTTP error code
+409 and a response body showing the conflicting variable. If the provided ACL
+token does not also have `read` permissions to the variable path, the response
+will include only metadata and not the `Items` field:
+
+```json
+{
+  "Namespace": "prod",
+  "Path": "example/first",
+  "CreateIndex": 1457,
+  "ModifyIndex": 1457,
+  "CreateTime": 1662061225600373000,
+  "ModifyTime": 1662061225600373000,
+  "Items": {
+    "user": "me",
+    "password": "passw0rd1"
+  }
+}
+```
+
+[Variables]: /nomad/docs/concepts/variables
+[`nomad var`]: /nomad/docs/commands/var
+[blocking queries]: /nomad/api-docs#blocking-queries
+[required ACLs]: /nomad/api-docs#acls
+[RFC3986]: https://www.rfc-editor.org/rfc/rfc3986#section-2

--- a/website/content/api-docs/variables/locks.mdx
+++ b/website/content/api-docs/variables/locks.mdx
@@ -130,8 +130,8 @@ parameters:
 inmediatly remove the lock over the variable, making it modifiable without 
 restrictions again. 
 
-The lock-release operation will override the variable items if new values are 
-present.
+The lock-release operation will not override the variable items, if new values 
+are present, they will be silently discarded.
 
 #### Sample Request
 

--- a/website/content/api-docs/variables/locks.mdx
+++ b/website/content/api-docs/variables/locks.mdx
@@ -132,7 +132,7 @@ parameters:
 ```
 
 - `lock-release`: A call to the endpoint with the `lock-release` operation will
-inmediatly remove the lock over the variable, making it modifiable without 
+immediately remove the lock over the variable, making it modifiable without 
 restrictions again. 
 
 The lock-release operation will not override the variable items, if the request

--- a/website/content/api-docs/variables/locks.mdx
+++ b/website/content/api-docs/variables/locks.mdx
@@ -6,7 +6,7 @@ description: The /var endpoints are used to query for and interact with variable
 
 # Locks HTTP API
 
-The `/var` endpoint is used hold, renew and release a lock over a variable.
+The `/var` endpoint is used to hold, renew and release a lock over a variable.
 
 ## Lock Variable
 

--- a/website/content/api-docs/variables/locks.mdx
+++ b/website/content/api-docs/variables/locks.mdx
@@ -88,7 +88,7 @@ parameters and ID, along with metadata created by the server:
 - `lock-renew`: A valid call to lock renew needs to be placed before the lock's
 TTL is up in order to mantain the variable locked. A valid call must include the
 lock ID as part of the request body. If the lock TTL is up without a renewal or
-release calls, the variable will remain unlockable for at least the lock dealy. 
+release calls, the variable will remain unlockable for at least the lock delay. 
 
 #### Sample Request
 

--- a/website/content/api-docs/variables/variables.mdx
+++ b/website/content/api-docs/variables/variables.mdx
@@ -151,8 +151,8 @@ The table below shows this endpoint's support for [blocking queries] and
   allows check-and-set style updates.
 
 - `lock-operation` `(string: <unset>)` - This endpoint can also be used to create 
-and hold a lock over a variable, refer to the locks section for more 
-[information][].
+and hold a lock over a variable, refer to the [locks section][] for more
+information.
 
 ## Restrictions
 
@@ -296,7 +296,7 @@ the response will include only metadata and not the `Items` field:
 
 
 [Variables]: /nomad/docs/concepts/variables
-[Locks]:
+[locks section]: /nomad/docs/commands/var/lock
 [`nomad var`]: /nomad/docs/commands/var
 [blocking queries]: /nomad/api-docs#blocking-queries
 [required ACLs]: /nomad/api-docs#acls

--- a/website/content/api-docs/variables/variables.mdx
+++ b/website/content/api-docs/variables/variables.mdx
@@ -150,6 +150,10 @@ The table below shows this endpoint's support for [blocking queries] and
   0, the variable is only created if it does not already exist. This paradigm
   allows check-and-set style updates.
 
+- `lock-operation` `(string: <unset>)` - This endpoint can also be used to create 
+and hold a lock over a variable, refer to the locks section for more 
+[information][].
+
 ## Restrictions
 
 Variable paths are restricted to [RFC3986][] URL-safe characters that don't
@@ -292,6 +296,7 @@ the response will include only metadata and not the `Items` field:
 
 
 [Variables]: /nomad/docs/concepts/variables
+[Locks]:
 [`nomad var`]: /nomad/docs/commands/var
 [blocking queries]: /nomad/api-docs#blocking-queries
 [required ACLs]: /nomad/api-docs#acls

--- a/website/content/docs/commands/var/lock.mdx
+++ b/website/content/docs/commands/var/lock.mdx
@@ -1,0 +1,109 @@
+---
+layout: docs
+page_title: "Command: var lock"
+description: |-
+  The "var lock" command locks a variable, only allowing the lock owner to modify it.
+---
+
+# Command: var lock
+
+The `var lock` command holds a lock on a [variable][].
+
+## Usage
+
+```plaintext
+nomad var lock [options] <lock spec file reference> child...
+nomad var lock [options] <path to store variable> [<variable spec file reference>] child
+```
+
+The lock command provides a mechanism for simple distributed locking. A lock
+is created in the given variable, and only when held, is a child process invoked.
+
+The lock command can be called on an existing variable or an entire new variable
+specification can be provided to the command from a file by using an
+@-prefixed path to a variable specification file. Items to be stored in the 
+variable can be supplied using the specification file as well. 
+
+Nomad lock launches its children in a shell. By default, Nomad will use the
+shell defined in the environment variable SHELL. If SHELL is not defined, 
+it will default to /bin/sh. It should be noted that not all shells terminate
+child processes when they receive SIGTERM. Under Ubuntu, /bin/sh is linked 
+to dash, which does not terminate its children. In order to ensure that 
+child processes are killed when the lock is lost, be sure to set the SHELL
+environment variable appropriately, or run without a shell by setting -shell=false. 
+ 
+If ACLs are enabled, this command requires the 'variables:write' capability
+for the destination namespace and path.
+
+## Restrictions
+
+Variable paths are restricted to [RFC3986][] URL-safe characters that don't
+conflict with the use of the characters `@` and `.` in template blocks. This
+includes alphanumeric characters and the special characters `-`, `_`, `~`, and
+`/`. Paths may be up to 128 bytes long. The following regex matches the allowed
+paths: `^[a-zA-Z0-9-_~/]{1,128}$`
+
+The keys for the items in a variable may contain any character, but keys
+containing characters outside the set of Unicode letters, Unicode digits, and
+the underscore (`_`) can not be read directly using dotted references in Nomad's
+template engine. Instead, they require the use of the `index` template function
+to directly access their values. This does not impact cases where the keys and
+values are read using the `range` function.
+
+Variable items are restricted to 64KiB in size. This limit is calculated by
+taking the sum of the length in bytes of all of the unencrypted keys and values.
+
+## General Options
+
+@include 'general_options.mdx'
+
+## Lock Options
+- `-verbose`: Provides additional information via standard error to preserve
+  standard output (stdout) for redirected output.
+
+- `ttl`: Optional, TTL for the lock, time the variable will be locked. Defaults to 15s.
+
+- `delay`: Optional, time the variable is blocked from locking when a lease is not renewed.	
+	Defaults to 15s.
+
+- `max-retry`:Optional, max-retry up to this number of times if Nomad returns a 500 error
+	while monitoring the lock. This allows riding out brief periods of
+	unavailability without causing leader elections, but increases the amount of
+	time required to detect a lost lock in some cases. Defaults to 5. Set to 0 to
+	disable.
+
+- `shell`: Optional, use a shell to run the command (can set a custom shell via		
+	the SHELL environment variable). The default value is true.
+
+## Examples
+
+Attempst to acquire a lock over the variable at path "secret/creds" for a time of 
+15s and executes  `nomad job run webapp.nomad.hcl` if it succeds:
+
+```shell-session
+$ nomad var lock -ttl=15s secret/creds "nomad job run webapp.nomad.hcl"
+```
+
+The data can also be consumed from a file on disk by prefixing with the "@"
+symbol. For example, you can store a variable using a specification created with
+the `nomad var init` command.
+
+```shell-session
+$ nomad var lock secret/foo @spec.nv.json `nomad job run webapp.nomad.hcl`
+```
+
+## SHELL
+
+Consul lock launches its children in a shell. By default, Consul will use the shell
+defined in the environment variable `SHELL`. If `SHELL` is not defined, it will
+default to `/bin/sh`. It should be noted that not all shells terminate child
+processes when they receive `SIGTERM`. Under Ubuntu, `/bin/sh` is linked to `dash`,
+which does **not** terminate its children. In order to ensure that child processes
+are killed when the lock is lost, be sure to set the `SHELL` environment variable
+appropriately, or run without a shell by setting `-shell=false`.
+
+[variable]: /nomad/docs/concepts/variables
+[varspec]: /nomad/docs/other-specifications/variables
+[ACL Policy]: /nomad/docs/other-specifications/acl-policy#variables
+[RFC3986]: https://www.rfc-editor.org/rfc/rfc3986#section-2
+

--- a/website/content/docs/commands/var/lock.mdx
+++ b/website/content/docs/commands/var/lock.mdx
@@ -78,7 +78,7 @@ taking the sum of the length in bytes of all of the unencrypted keys and values.
 ## Examples
 
 Attempts to acquire a lock over the variable at path "secret/creds" for a time of 
-15s and executes  `nomad job run webapp.nomad.hcl` if it succeds:
+15s and executes  `nomad job run webapp.nomad.hcl` if it succeeds:
 
 ```shell-session
 $ nomad var lock -ttl=15s secret/creds "nomad job run webapp.nomad.hcl"

--- a/website/content/docs/commands/var/lock.mdx
+++ b/website/content/docs/commands/var/lock.mdx
@@ -77,7 +77,7 @@ taking the sum of the length in bytes of all of the unencrypted keys and values.
 
 ## Examples
 
-Attempst to acquire a lock over the variable at path "secret/creds" for a time of 
+Attempts to acquire a lock over the variable at path "secret/creds" for a time of 
 15s and executes  `nomad job run webapp.nomad.hcl` if it succeds:
 
 ```shell-session

--- a/website/content/docs/commands/var/lock.mdx
+++ b/website/content/docs/commands/var/lock.mdx
@@ -32,7 +32,7 @@ to dash, which does not terminate its children. In order to ensure that
 child processes are killed when the lock is lost, be sure to set the SHELL
 environment variable appropriately, or run without a shell by setting -shell=false. 
  
-If ACLs are enabled, this command requires the 'variables:write' capability
+If [ACLs][] are enabled, this command requires the 'variables:write' capability
 for the destination namespace and path.
 
 ## Restrictions
@@ -92,18 +92,9 @@ the `nomad var init` command.
 $ nomad var lock secret/foo @spec.nv.json `nomad job run webapp.nomad.hcl`
 ```
 
-## SHELL
-
-Consul lock launches its children in a shell. By default, Consul will use the shell
-defined in the environment variable `SHELL`. If `SHELL` is not defined, it will
-default to `/bin/sh`. It should be noted that not all shells terminate child
-processes when they receive `SIGTERM`. Under Ubuntu, `/bin/sh` is linked to `dash`,
-which does **not** terminate its children. In order to ensure that child processes
-are killed when the lock is lost, be sure to set the `SHELL` environment variable
-appropriately, or run without a shell by setting `-shell=false`.
-
 [variable]: /nomad/docs/concepts/variables
-[varspec]: /nomad/docs/other-specifications/variables
+[varspec]:  /nomad/docs/other-specifications/variables
 [ACL Policy]: /nomad/docs/other-specifications/acl-policy#variables
 [RFC3986]: https://www.rfc-editor.org/rfc/rfc3986#section-2
+[ACL]: /nomad/docs/other-specifications/acl-policy#variables
 

--- a/website/data/api-docs-nav-data.json
+++ b/website/data/api-docs-nav-data.json
@@ -185,7 +185,20 @@
   },
   {
     "title": "Variables",
-    "path": "variables"
+    "routes": [
+      {
+        "title": "Overview",
+        "path": "variables"
+      },
+      {
+        "title": "Variables",
+        "path": "variables/variables"
+      },
+      {
+        "title": "Locks",
+        "path": "variables/locks"
+      }
+    ]
   },
   {
     "title": "Volumes",

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1089,6 +1089,10 @@
             "path": "commands/var/put"
           },
           {
+            "title": "lock",
+            "path": "commands/var/lock"
+          },
+          {
             "title": "purge",
             "path": "commands/var/purge"
           }


### PR DESCRIPTION
Related: https://github.com/hashicorp/nomad/issues/17449